### PR TITLE
Add 'team rename' cli command

### DIFF
--- a/go/client/cmd_team.go
+++ b/go/client/cmd_team.go
@@ -22,6 +22,7 @@ func NewCmdTeam(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 			newCmdTeamRemoveMember(cl, g),
 			newCmdTeamEditMember(cl, g),
 			newCmdTeamLeave(cl, g),
+			newCmdTeamRename(cl, g),
 			newCmdTeamAcceptInvite(cl, g),
 		},
 	}

--- a/go/client/cmd_team_create.go
+++ b/go/client/cmd_team_create.go
@@ -13,14 +13,14 @@ import (
 )
 
 type CmdTeamCreate struct {
-	TeamName  string
+	TeamName  keybase1.TeamName
 	SessionID int
 	libkb.Contextified
 }
 
 func (v *CmdTeamCreate) ParseArgv(ctx *cli.Context) error {
 	var err error
-	v.TeamName, err = ParseOneTeamName(ctx)
+	v.TeamName, err = ParseOneTeamNameK1(ctx)
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,13 @@ func (v *CmdTeamCreate) Run() (err error) {
 		return err
 	}
 
-	return cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{
+	if v.TeamName.IsRootTeam() {
+		return cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{
+			Name:      v.TeamName,
+			SessionID: v.SessionID,
+		})
+	}
+	return cli.TeamCreateSubteam(context.TODO(), keybase1.TeamCreateSubteamArg{
 		Name:      v.TeamName,
 		SessionID: v.SessionID,
 	})

--- a/go/client/cmd_team_edit_member.go
+++ b/go/client/cmd_team_edit_member.go
@@ -73,7 +73,7 @@ func (c *CmdTeamEditMember) Run() error {
 	}
 
 	dui := c.G().UI.GetDumbOutputUI()
-	dui.Printf("Success! %s's role in %s is now %s.", c.username, c.team, c.role)
+	dui.Printf("Success! %s's role in %s is now %s.\n", c.username, c.team, c.role)
 
 	return nil
 }

--- a/go/client/cmd_team_rename.go
+++ b/go/client/cmd_team_rename.go
@@ -1,0 +1,119 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"golang.org/x/net/context"
+)
+
+type CmdTeamRename struct {
+	PrevName  keybase1.TeamName
+	NewName   keybase1.TeamName
+	SessionID int
+	libkb.Contextified
+}
+
+func (v *CmdTeamRename) ParseArgv(ctx *cli.Context) (err error) {
+	if len(ctx.Args()) != 2 {
+		return errors.New("two team names required")
+	}
+
+	v.PrevName, err = keybase1.TeamNameFromString(ctx.Args()[0])
+	if err != nil {
+		return fmt.Errorf("invalid old team name: %v", err)
+	}
+
+	v.NewName, err = keybase1.TeamNameFromString(ctx.Args()[1])
+	if err != nil {
+		return fmt.Errorf("invalid new team name: %v", err)
+	}
+
+	return nil
+}
+
+// Most of the checks are in the teams package.
+// This just covers this one presentation thing:
+//
+// > keybase team change-name aviato.usa.marketing aviato.america.sales
+// Error! You must first rename `aviato.usa` to `aviato.america`.
+func (v *CmdTeamRename) helpRenameWrongLevel() (err error) {
+	if v.PrevName.Depth() != v.NewName.Depth() {
+		return nil
+	}
+	if v.PrevName.Depth() < 3 {
+		return nil
+	}
+	// Scan the parts of both names looking for the first difference.
+	// Skip the root and the end. Because the root is not this case,
+	// and the end is not a problem.
+	// If it is in the middle then tell the user what to do.
+	for i := 1; i < len(v.PrevName.Parts)-1; i++ {
+		prevPart := v.PrevName.Parts[i]
+		newPart := v.NewName.Parts[i]
+		if !prevPart.Eq(newPart) {
+			a1 := keybase1.TeamName{Parts: v.PrevName.Parts[:i+1]}
+			a2 := keybase1.TeamName{Parts: v.NewName.Parts[:i+1]}
+			return fmt.Errorf("You must first rename `%v` to `%v`", a1, a2)
+		}
+	}
+	return nil
+}
+
+func (v *CmdTeamRename) Run() (err error) {
+	cli, err := GetTeamsClient(v.G())
+	if err != nil {
+		return err
+	}
+
+	protocols := []rpc.Protocol{
+		NewSecretUIProtocol(v.G()),
+	}
+	if err = RegisterProtocolsWithContext(protocols, v.G()); err != nil {
+		return err
+	}
+
+	err = v.helpRenameWrongLevel()
+	if err != nil {
+		return err
+	}
+
+	return cli.TeamRename(context.TODO(), keybase1.TeamRenameArg{
+		PrevName:  v.PrevName,
+		NewName:   v.NewName,
+		SessionID: v.SessionID,
+	})
+}
+
+func newCmdTeamRename(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "rename",
+		ArgumentHelp: "<team name> <new name>",
+		Usage:        "Change the name of a subteam.",
+		Flags:        []cli.Flag{},
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdTeamRenameRunner(g), "teamrename", c)
+		},
+		Description: "Rename a subteam.",
+	}
+}
+
+func NewCmdTeamRenameRunner(g *libkb.GlobalContext) *CmdTeamRename {
+	return &CmdTeamRename{Contextified: libkb.NewContextified(g)}
+}
+
+func (v *CmdTeamRename) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/client/team_helper.go
+++ b/go/client/team_helper.go
@@ -18,6 +18,14 @@ func ParseOneTeamName(ctx *cli.Context) (string, error) {
 	return ctx.Args()[0], nil
 }
 
+func ParseOneTeamNameK1(ctx *cli.Context) (res keybase1.TeamName, err error) {
+	teamNameStr, err := ParseOneTeamName(ctx)
+	if err != nil {
+		return res, err
+	}
+	return keybase1.TeamNameFromString(teamNameStr)
+}
+
 func ParseUser(ctx *cli.Context) (string, error) {
 	username := ctx.String("user")
 	if len(username) == 0 {

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -150,7 +150,9 @@ func (a *ActiveDevice) SigningKey() (GenericKey, error) {
 	a.RLock()
 	defer a.RUnlock()
 	if a.signingKey == nil {
-		return nil, NotFoundError{}
+		return nil, NotFoundError{
+			Msg: "Not found: device signing key",
+		}
 	}
 	return a.signingKey, nil
 }
@@ -161,7 +163,9 @@ func (a *ActiveDevice) EncryptionKey() (GenericKey, error) {
 	a.RLock()
 	defer a.RUnlock()
 	if a.encryptionKey == nil {
-		return nil, NotFoundError{}
+		return nil, NotFoundError{
+			Msg: "Not found: device encryption key",
+		}
 	}
 	return a.encryptionKey, nil
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -33,7 +33,22 @@ func NewTeamsHandler(xp rpc.Transporter, id libkb.ConnectionID, g *globals.Conte
 }
 
 func (h *TeamsHandler) TeamCreate(ctx context.Context, arg keybase1.TeamCreateArg) (err error) {
-	return teams.CreateRootTeam(ctx, h.G().ExternalG(), arg.Name)
+	return teams.CreateRootTeam(ctx, h.G().ExternalG(), arg.Name.String())
+}
+
+func (h *TeamsHandler) TeamCreateSubteam(ctx context.Context, arg keybase1.TeamCreateSubteamArg) (err error) {
+	if arg.Name.Depth() == 0 {
+		return fmt.Errorf("empty team name")
+	}
+	if arg.Name.IsRootTeam() {
+		return fmt.Errorf("cannot create subteam with root team name")
+	}
+	parentName, err := arg.Name.Parent()
+	if err != nil {
+		return err
+	}
+	_, err = teams.CreateSubteam(ctx, h.G().ExternalG(), string(arg.Name.LastPart()), parentName)
+	return err
 }
 
 func (h *TeamsHandler) TeamGet(ctx context.Context, arg keybase1.TeamGetArg) (keybase1.TeamDetails, error) {
@@ -90,6 +105,10 @@ func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEdit
 
 func (h *TeamsHandler) TeamLeave(ctx context.Context, arg keybase1.TeamLeaveArg) error {
 	return teams.Leave(ctx, h.G().ExternalG(), arg.Name, arg.Permanent)
+}
+
+func (h *TeamsHandler) TeamRename(ctx context.Context, arg keybase1.TeamRenameArg) error {
+	return teams.RenameSubteam(ctx, h.G().ExternalG(), arg.PrevName, arg.NewName)
 }
 
 func (h *TeamsHandler) TeamAcceptInvite(ctx context.Context, arg keybase1.TeamAcceptInviteArg) error {

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -306,8 +306,12 @@ func (u *smuUser) pollForMembershipUpdate(team smuTeam, kg keybase1.PerTeamKeyGe
 
 func (u *smuUser) createTeam(writers []*smuUser) smuTeam {
 	name := u.username + "t"
+	nameK1, err := keybase1.TeamNameFromString(name)
+	if err != nil {
+		u.ctx.t.Fatal(err)
+	}
 	cli := u.getTeamsClient()
-	err := cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{Name: name})
+	err = cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{Name: nameK1})
 	if err != nil {
 		u.ctx.t.Fatal(err)
 	}

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -179,15 +179,19 @@ type userPlusDevice struct {
 
 func (u *userPlusDevice) createTeam() string {
 	create := client.NewCmdTeamCreateRunner(u.tc.G)
-	name, err := libkb.RandString("tt", 5)
+	nameStr, err := libkb.RandString("tt", 5)
 	if err != nil {
 		u.tc.T.Fatal(err)
 	}
-	create.TeamName = strings.ToLower(name)
+	name, err := keybase1.TeamNameFromString(strings.ToLower(nameStr))
+	if err != nil {
+		u.tc.T.Fatal(err)
+	}
+	create.TeamName = name
 	if err := create.Run(); err != nil {
 		u.tc.T.Fatal(err)
 	}
-	return create.TeamName
+	return create.TeamName.String()
 }
 
 func (u *userPlusDevice) addTeamMember(team, username string, role keybase1.TeamRole) {

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -13,11 +13,13 @@ import (
 func CreateRootTeam(ctx context.Context, g *libkb.GlobalContext, name string) (err error) {
 	defer g.CTrace(ctx, "CreateRootTeam", func() error { return err })()
 
+	g.Log.CDebugf(ctx, "CreateRootTeam load me")
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(g))
 	if err != nil {
 		return err
 	}
 
+	g.Log.CDebugf(ctx, "CreateRootTeam get device keys")
 	deviceSigningKey, err := g.ActiveDevice.SigningKey()
 	if err != nil {
 		return err
@@ -54,6 +56,7 @@ func CreateRootTeam(ctx context.Context, g *libkb.GlobalContext, name string) (e
 		return err
 	}
 
+	g.Log.CDebugf(ctx, "CreateRootTeam make sigs")
 	teamSection, err := makeRootTeamSection(name, me, perTeamSigningKey.GetKID(), perTeamEncryptionKey.GetKID())
 	if err != nil {
 		return err
@@ -111,6 +114,7 @@ func CreateRootTeam(ctx context.Context, g *libkb.GlobalContext, name string) (e
 		},
 	}
 
+	g.Log.CDebugf(ctx, "CreateRootTeam post sigs")
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = []interface{}{sigMultiItem}
 	payload["per_team_key"] = secretboxes

--- a/go/teams/rename_test.go
+++ b/go/teams/rename_test.go
@@ -26,8 +26,10 @@ func TestRenameSimple(t *testing.T) {
 	require.NoError(t, err)
 	subteamName, err := parentTeamName.Append(subteamBasename)
 	require.NoError(t, err)
+	desiredName, err := parentTeamName.Append("bb2")
+	require.NoError(t, err)
 
-	err = RenameSubteam(context.TODO(), tc.G, subteamName, "bb2")
+	err = RenameSubteam(context.TODO(), tc.G, subteamName, desiredName)
 	require.NoError(t, err)
 
 	t.Logf("load the renamed team")

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -123,6 +123,11 @@ func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username s
 		if err == errInviteRequired {
 			return t.InviteMember(ctx, username, role, resolvedUsername, uv)
 		}
+		if _, ok := err.(libkb.NotFoundError); ok {
+			return keybase1.TeamAddMemberResult{}, libkb.NotFoundError{
+				Msg: fmt.Sprintf("Not found: user %v", username),
+			}
+		}
 		return keybase1.TeamAddMemberResult{}, err
 	}
 	if t.IsMember(ctx, uv) {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -330,7 +330,8 @@ protocol teams {
     boolean chatSent;
   }
 
-  void teamCreate(int sessionID, string name);
+  void teamCreate(int sessionID, TeamName name);
+  void teamCreateSubteam(int sessionID, TeamName name);
   TeamDetails teamGet(int sessionID, string name, boolean forceRepoll);
   TeamList teamList(int sessionID, string userAssertion);
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);
@@ -338,6 +339,7 @@ protocol teams {
   void teamRemoveMember(int sessionID, string name, string username);
   void teamLeave(int sessionID, string name, boolean permanent);
   void teamEditMember(int sessionID, string name, string username, TeamRole role);
+  void teamRename(int sessionID, TeamName prevName, TeamName newName);
   void teamAcceptInvite(int sessionID, string token);
 
   /**

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3599,6 +3599,21 @@ export function teamsTeamCreateRpcPromise (request: $Exact<requestCommon & reque
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreate', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamCreateSubteamRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamCreateSubteamRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.teamCreateSubteam', request)
+}
+
+export function teamsTeamCreateSubteamRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamCreateSubteamRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamCreateSubteam', request)
+}
+export function teamsTeamCreateSubteamRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamCreateSubteamRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamCreateSubteam', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamCreateSubteamRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamCreateSubteamRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreateSubteam', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamEditMemberRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamEditMemberRpcParam}>) {
   engineRpcOutgoing('keybase.1.teams.teamEditMember', request)
 }
@@ -3672,6 +3687,21 @@ export function teamsTeamRemoveMemberRpcChannelMapOld (channelConfig: ChannelCon
 
 export function teamsTeamRemoveMemberRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRemoveMemberRpcParam}>): Promise<void> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRemoveMember', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function teamsTeamRenameRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamRenameRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.teamRename', request)
+}
+
+export function teamsTeamRenameRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRenameRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamRename', request)
+}
+export function teamsTeamRenameRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRenameRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamRename', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamRenameRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRenameRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRename', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function testPanicRpc (request: Exact<requestCommon & requestErrorCallback & {param: testPanicRpcParam}>) {
@@ -7222,7 +7252,11 @@ export type teamsTeamChangeMembershipRpcParam = Exact<{
 }>
 
 export type teamsTeamCreateRpcParam = Exact<{
-  name: string
+  name: TeamName
+}>
+
+export type teamsTeamCreateSubteamRpcParam = Exact<{
+  name: TeamName
 }>
 
 export type teamsTeamEditMemberRpcParam = Exact<{
@@ -7248,6 +7282,11 @@ export type teamsTeamListRpcParam = Exact<{
 export type teamsTeamRemoveMemberRpcParam = Exact<{
   name: string,
   username: string
+}>
+
+export type teamsTeamRenameRpcParam = Exact<{
+  prevName: TeamName,
+  newName: TeamName
 }>
 
 export type testPanicRpcParam = Exact<{
@@ -7724,11 +7763,13 @@ export type rpc =
   | teamsTeamAddMemberRpc
   | teamsTeamChangeMembershipRpc
   | teamsTeamCreateRpc
+  | teamsTeamCreateSubteamRpc
   | teamsTeamEditMemberRpc
   | teamsTeamGetRpc
   | teamsTeamLeaveRpc
   | teamsTeamListRpc
   | teamsTeamRemoveMemberRpc
+  | teamsTeamRenameRpc
   | testPanicRpc
   | testTestCallbackRpc
   | testTestRpc

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -843,7 +843,20 @@
         },
         {
           "name": "name",
-          "type": "string"
+          "type": "TeamName"
+        }
+      ],
+      "response": null
+    },
+    "teamCreateSubteam": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "name",
+          "type": "TeamName"
         }
       ],
       "response": null
@@ -975,6 +988,23 @@
         {
           "name": "role",
           "type": "TeamRole"
+        }
+      ],
+      "response": null
+    },
+    "teamRename": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "prevName",
+          "type": "TeamName"
+        },
+        {
+          "name": "newName",
+          "type": "TeamName"
         }
       ],
       "response": null

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3599,6 +3599,21 @@ export function teamsTeamCreateRpcPromise (request: $Exact<requestCommon & reque
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreate', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamCreateSubteamRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamCreateSubteamRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.teamCreateSubteam', request)
+}
+
+export function teamsTeamCreateSubteamRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamCreateSubteamRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamCreateSubteam', request)
+}
+export function teamsTeamCreateSubteamRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamCreateSubteamRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamCreateSubteam', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamCreateSubteamRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamCreateSubteamRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreateSubteam', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamEditMemberRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamEditMemberRpcParam}>) {
   engineRpcOutgoing('keybase.1.teams.teamEditMember', request)
 }
@@ -3672,6 +3687,21 @@ export function teamsTeamRemoveMemberRpcChannelMapOld (channelConfig: ChannelCon
 
 export function teamsTeamRemoveMemberRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRemoveMemberRpcParam}>): Promise<void> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRemoveMember', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function teamsTeamRenameRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamRenameRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.teamRename', request)
+}
+
+export function teamsTeamRenameRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRenameRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamRename', request)
+}
+export function teamsTeamRenameRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRenameRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamRename', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamRenameRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRenameRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRename', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function testPanicRpc (request: Exact<requestCommon & requestErrorCallback & {param: testPanicRpcParam}>) {
@@ -7222,7 +7252,11 @@ export type teamsTeamChangeMembershipRpcParam = Exact<{
 }>
 
 export type teamsTeamCreateRpcParam = Exact<{
-  name: string
+  name: TeamName
+}>
+
+export type teamsTeamCreateSubteamRpcParam = Exact<{
+  name: TeamName
 }>
 
 export type teamsTeamEditMemberRpcParam = Exact<{
@@ -7248,6 +7282,11 @@ export type teamsTeamListRpcParam = Exact<{
 export type teamsTeamRemoveMemberRpcParam = Exact<{
   name: string,
   username: string
+}>
+
+export type teamsTeamRenameRpcParam = Exact<{
+  prevName: TeamName,
+  newName: TeamName
 }>
 
 export type testPanicRpcParam = Exact<{
@@ -7724,11 +7763,13 @@ export type rpc =
   | teamsTeamAddMemberRpc
   | teamsTeamChangeMembershipRpc
   | teamsTeamCreateRpc
+  | teamsTeamCreateSubteamRpc
   | teamsTeamEditMemberRpc
   | teamsTeamGetRpc
   | teamsTeamLeaveRpc
   | teamsTeamListRpc
   | teamsTeamRemoveMemberRpc
+  | teamsTeamRenameRpc
   | testPanicRpc
   | testTestCallbackRpc
   | testTestRpc


### PR DESCRIPTION
Adds `CmdTeamRename`. Adds subteam support to `CmdTeamCreate` by having it choose based on the name between `cli.TeamCreate` and `cli.TeamCreateSubteam`.

Changes a couple team RPCs to pass `keybase1.TeamName` instead of strings. Which breaks compatibility between a client and service that skew across this version. Which I hope we don't care about now.