### PR TITLE
add support for channel-wide notifications and take into account for desktop notifications CORE-5650

### DIFF
--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -25,7 +25,7 @@ func setupLoaderTest(t *testing.T) (*kbtest.ChatTestContext, *kbtest.ChatMockWor
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -32,7 +32,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -369,7 +369,7 @@ func TestGetThreadCaching(t *testing.T) {
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -482,7 +482,7 @@ func TestGetThreadHoleResolution(t *testing.T) {
 		pt.MessageBody = chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: fmt.Sprintf("MIKE: %d", i),
 		})
-		msg, _, _, err = sender.Prepare(ctx, pt, chat1.ConversationMembersType_KBFS, &conv)
+		msg, _, _, _, err = sender.Prepare(ctx, pt, chat1.ConversationMembersType_KBFS, &conv)
 		require.NoError(t, err)
 		require.NotNil(t, msg)
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -139,7 +139,7 @@ func (s *sendHelper) newConversation(ctx context.Context) error {
 
 	boxer := NewBoxer(s.G())
 	sender := NewBlockingSender(s.G(), boxer, nil, s.remoteInterface)
-	mbox, _, _, err := sender.Prepare(ctx, first, s.membersType, nil)
+	mbox, _, _, _, err := sender.Prepare(ctx, first, s.membersType, nil)
 	if err != nil {
 		return err
 	}

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -104,7 +104,7 @@ func TestInboxSourceSkipAhead(t *testing.T) {
 
 	t.Logf("add message but drop oobm")
 
-	boxed, _, _, err := sender.Prepare(ctx, chat1.MessagePlaintext{
+	boxed, _, _, _, err := sender.Prepare(ctx, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        conv.Metadata.IdTriple,
 			Sender:      u.User.GetUID().ToBytes(),

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -345,15 +345,19 @@ func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 		kind := chat1.NotificationKind_GENERIC
 		switch typ {
 		case chat1.MessageType_TEXT:
-			atMentions := utils.ParseAtMentionedUIDs(ctx, msg.Valid().MessageBody.Text().Body,
-				g.G().GetUPAKLoader(), &g.DebugLabeler)
+			atMentions, chanMention := utils.ParseAtMentionedUIDs(ctx,
+				msg.Valid().MessageBody.Text().Body, g.G().GetUPAKLoader(), &g.DebugLabeler)
 			for _, at := range atMentions {
 				if at.Eq(uid) {
 					kind = chat1.NotificationKind_ATMENTION
 					break
 				}
 			}
-			return conv.Notifications.Settings[apptype][kind]
+			notifyFromChanMention := false
+			if chanMention == chat1.ChannelMention_HERE || chanMention == chat1.ChannelMention_ALL {
+				notifyFromChanMention = conv.Notifications.ChannelWide
+			}
+			return conv.Notifications.Settings[apptype][kind] || notifyFromChanMention
 		case chat1.MessageType_ATTACHMENT:
 			return conv.Notifications.Settings[apptype][kind]
 		default:

--- a/go/chat/push_test.go
+++ b/go/chat/push_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func sendSimple(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, ph *PushHandler,
-	sender Sender, conv chat1.Conversation, user *kbtest.FakeUser,
+	sender types.Sender, conv chat1.Conversation, user *kbtest.FakeUser,
 	iboxXform func(chat1.InboxVers) chat1.InboxVers) {
 	uid := gregor1.UID(user.User.GetUID().ToBytes())
 	convID := conv.GetConvID()

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -637,7 +637,7 @@ func (h *Server) makeFirstMessage(ctx context.Context, triple chat1.Conversation
 	}
 
 	sender := NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient)
-	mbox, _, _, err := sender.Prepare(ctx, msg, membersType, nil)
+	mbox, _, _, _, err := sender.Prepare(ctx, msg, membersType, nil)
 	return mbox, err
 }
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2066,15 +2066,22 @@ func TestChatSrvSetAppNotificationSettings(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no new message event")
 		}
-		text := fmt.Sprintf("@%s", users[0].Username)
-		mustPostLocalForTest(t, ctc, users[1], conv,
-			chat1.NewMessageBodyWithText(chat1.MessageText{Body: text}))
-		select {
-		case info := <-listener0.newMessage:
-			require.True(t, info.DisplayDesktopNotification)
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "no new message event")
+
+		validateDisplayAtMention := func(name string) {
+			text := fmt.Sprintf("@%s", name)
+			mustPostLocalForTest(t, ctc, users[1], conv,
+				chat1.NewMessageBodyWithText(chat1.MessageText{Body: text}))
+			select {
+			case info := <-listener0.newMessage:
+				require.True(t, info.DisplayDesktopNotification)
+			case <-time.After(20 * time.Second):
+				require.Fail(t, "no new message event")
+			}
 		}
+		validateDisplayAtMention(users[0].Username)
+		validateDisplayAtMention("channel")
+		validateDisplayAtMention("everyone")
+		validateDisplayAtMention("here")
 	})
 
 }

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func newBlankConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, uid gregor1.UID,
-	ri chat1.RemoteInterface, sender Sender, tlfName string) chat1.Conversation {
+	ri chat1.RemoteInterface, sender types.Sender, tlfName string) chat1.Conversation {
 	trip := newConvTriple(ctx, t, tc, tlfName)
 	firstMessagePlaintext := chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
@@ -26,7 +26,7 @@ func newBlankConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext,
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -51,7 +51,7 @@ func newBlankConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext,
 }
 
 func newConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, uid gregor1.UID,
-	ri chat1.RemoteInterface, sender Sender, tlfName string) chat1.Conversation {
+	ri chat1.RemoteInterface, sender types.Sender, tlfName string) chat1.Conversation {
 	conv := newBlankConv(ctx, t, tc, uid, ri, sender, tlfName)
 	_, _, _, err := sender.Send(ctx, conv.GetConvID(), chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -56,6 +56,12 @@ type MessageDeliverer interface {
 	ForceDeliverLoop(ctx context.Context)
 }
 
+type Sender interface {
+	Send(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext, clientPrev chat1.MessageID) (chat1.OutboxID, *chat1.MessageBoxed, *chat1.RateLimit, error)
+	Prepare(ctx context.Context, msg chat1.MessagePlaintext, membersType chat1.ConversationMembersType,
+		conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, chat1.ChannelMention, error)
+}
+
 type ChatLocalizer interface {
 	Localize(ctx context.Context, uid gregor1.UID, inbox chat1.Inbox) ([]chat1.ConversationLocal, error)
 	Name() string

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -402,9 +402,23 @@ func ParseAtMentionsNames(ctx context.Context, body string) (res []string) {
 	return res
 }
 
-func ParseAtMentionedUIDs(ctx context.Context, body string, upak libkb.UPAKLoader, debug *DebugLabeler) (res []gregor1.UID) {
+func ParseAtMentionedUIDs(ctx context.Context, body string, upak libkb.UPAKLoader, debug *DebugLabeler) (atRes []gregor1.UID, chanRes chat1.ChannelMention) {
 	names := ParseAtMentionsNames(ctx, body)
+	chanRes = chat1.ChannelMention_NONE
 	for _, name := range names {
+
+		switch name {
+		case "channel", "everyone":
+			chanRes = chat1.ChannelMention_ALL
+			continue
+		case "here":
+			if chanRes != chat1.ChannelMention_ALL {
+				chanRes = chat1.ChannelMention_HERE
+			}
+			continue
+		default:
+		}
+
 		kuid, err := upak.LookupUID(ctx, libkb.NewNormalizedUsername(name))
 		if err != nil {
 			if debug != nil {
@@ -413,9 +427,33 @@ func ParseAtMentionedUIDs(ctx context.Context, body string, upak libkb.UPAKLoade
 			}
 			continue
 		}
-		res = append(res, kuid.ToBytes())
+		atRes = append(atRes, kuid.ToBytes())
 	}
-	return res
+	return atRes, chanRes
+}
+
+func ParseAndDecorateAtMentionedUIDs(ctx context.Context, body string, upak libkb.UPAKLoader, debug *DebugLabeler) (newBody string, atRes []gregor1.UID, chanRes chat1.ChannelMention) {
+	atRes, chanRes = ParseAtMentionedUIDs(ctx, body, upak, debug)
+	newBody = atMentionRegExp.ReplaceAllStringFunc(body, func(m string) string {
+		replace := false
+		switch m {
+		case "@channel", "@here", "@everyone":
+			replace = true
+		default:
+			toks := strings.Split(m, "@")
+			if len(toks) == 2 {
+				_, err := upak.LookupUID(ctx, libkb.NewNormalizedUsername(toks[1]))
+				if err == nil {
+					replace = true
+				}
+			}
+		}
+		if replace {
+			return fmt.Sprintf("`%s`", m)
+		}
+		return m
+	})
+	return newBody, atRes, chanRes
 }
 
 func PluckMessageIDs(msgs []chat1.MessageSummary) []chat1.MessageID {

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -27,4 +27,8 @@ func TestParseAtMentionsNames(t *testing.T) {
 	matches := ParseAtMentionsNames(context.TODO(), text)
 	expected := []string{"chat_1e2263952c", "mike", "chat_5511c5e0ce", "ksjdskj", "k1"}
 	require.Equal(t, expected, matches)
+	text = "@mike@jim"
+	matches = ParseAtMentionsNames(context.TODO(), text)
+	expected = []string{"mike"}
+	require.Equal(t, expected, matches)
 }

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -294,6 +294,35 @@ func (o GetPublicConversationsRes) DeepCopy() GetPublicConversationsRes {
 	}
 }
 
+type ChannelMention int
+
+const (
+	ChannelMention_NONE ChannelMention = 0
+	ChannelMention_ALL  ChannelMention = 1
+	ChannelMention_HERE ChannelMention = 2
+)
+
+func (o ChannelMention) DeepCopy() ChannelMention { return o }
+
+var ChannelMentionMap = map[string]ChannelMention{
+	"NONE": 0,
+	"ALL":  1,
+	"HERE": 2,
+}
+
+var ChannelMentionRevMap = map[ChannelMention]string{
+	0: "NONE",
+	1: "ALL",
+	2: "HERE",
+}
+
+func (e ChannelMention) String() string {
+	if v, ok := ChannelMentionRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type UnreadUpdateFull struct {
 	Ignore    bool           `codec:"ignore" json:"ignore"`
 	InboxVers InboxVers      `codec:"inboxVers" json:"inboxVers"`
@@ -712,6 +741,7 @@ type PostRemoteArg struct {
 	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
 	MessageBoxed   MessageBoxed   `codec:"messageBoxed" json:"messageBoxed"`
 	AtMentions     []gregor1.UID  `codec:"atMentions" json:"atMentions"`
+	ChannelMention ChannelMention `codec:"channelMention" json:"channelMention"`
 }
 
 func (o PostRemoteArg) DeepCopy() PostRemoteArg {
@@ -726,6 +756,7 @@ func (o PostRemoteArg) DeepCopy() PostRemoteArg {
 			}
 			return ret
 		})(o.AtMentions),
+		ChannelMention: o.ChannelMention.DeepCopy(),
 	}
 }
 

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -104,7 +104,13 @@ protocol remote {
   GetThreadRemoteRes getThreadRemote(ConversationID conversationID, union { null, GetThreadQuery } query, union { null, Pagination } pagination);
   GetPublicConversationsRes getPublicConversations(TLFID tlfID, TopicType topicType, boolean summarizeMaxMsgs);
 
-  PostRemoteRes postRemote(ConversationID conversationID, MessageBoxed messageBoxed, array<gregor1.UID> atMentions);
+  enum ChannelMention {
+    NONE_0,
+    ALL_1,
+    HERE_2
+  }
+
+  PostRemoteRes postRemote(ConversationID conversationID, MessageBoxed messageBoxed, array<gregor1.UID> atMentions, ChannelMention channelMention);
   NewConversationRemoteRes newConversationRemote(ConversationIDTriple idTriple);
 
   // on duplication of idTriple, and error is returned and the conversation ID of the existing conversation is returned.

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -195,6 +195,12 @@ export const NotifyChatChatActivityType = {
   setAppNotificationSettings: 7,
 }
 
+export const RemoteChannelMention = {
+  none: 0,
+  all: 1,
+  here: 2,
+}
+
 export const RemoteMessageBoxedVersion = {
   vnone: 0,
   v1: 1,
@@ -1118,6 +1124,11 @@ export type BodyPlaintextVersion =
   | 8 // V8_8
   | 9 // V9_9
   | 10 // V10_10
+
+export type ChannelMention =
+    0 // NONE_0
+  | 1 // ALL_1
+  | 2 // HERE_2
 
 export type ChatActivity =
     { activityType: 1, incomingMessage: ?IncomingMessage }
@@ -2410,7 +2421,8 @@ export type remoteNewConversationRemoteRpcParam = Exact<{
 export type remotePostRemoteRpcParam = Exact<{
   conversationID: ConversationID,
   messageBoxed: MessageBoxed,
-  atMentions?: ?Array<gregor1.UID>
+  atMentions?: ?Array<gregor1.UID>,
+  channelMention: ChannelMention
 }>
 
 export type remotePublishReadMessageRpcParam = Exact<{

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -246,6 +246,15 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "ChannelMention",
+      "symbols": [
+        "NONE_0",
+        "ALL_1",
+        "HERE_2"
+      ]
+    },
+    {
       "type": "record",
       "name": "UnreadUpdateFull",
       "fields": [
@@ -566,6 +575,10 @@
             "type": "array",
             "items": "gregor1.UID"
           }
+        },
+        {
+          "name": "channelMention",
+          "type": "ChannelMention"
         }
       ],
       "response": "PostRemoteRes"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -195,6 +195,12 @@ export const NotifyChatChatActivityType = {
   setAppNotificationSettings: 7,
 }
 
+export const RemoteChannelMention = {
+  none: 0,
+  all: 1,
+  here: 2,
+}
+
 export const RemoteMessageBoxedVersion = {
   vnone: 0,
   v1: 1,
@@ -1118,6 +1124,11 @@ export type BodyPlaintextVersion =
   | 8 // V8_8
   | 9 // V9_9
   | 10 // V10_10
+
+export type ChannelMention =
+    0 // NONE_0
+  | 1 // ALL_1
+  | 2 // HERE_2
 
 export type ChatActivity =
     { activityType: 1, incomingMessage: ?IncomingMessage }
@@ -2410,7 +2421,8 @@ export type remoteNewConversationRemoteRpcParam = Exact<{
 export type remotePostRemoteRpcParam = Exact<{
   conversationID: ConversationID,
   messageBoxed: MessageBoxed,
-  atMentions?: ?Array<gregor1.UID>
+  atMentions?: ?Array<gregor1.UID>,
+  channelMention: ChannelMention
 }>
 
 export type remotePublishReadMessageRpcParam = Exact<{


### PR DESCRIPTION
Patch does the following:

1.) Parse out channel-wide notifications (@channel, @here, @everyone), and send them along on `PostRemote`.
2.) Upon receiving a text message, parse out channel mentions and set desktop notification bit with respect to channel wide notification config.