### PR TITLE
Add local sigchain guard

### DIFF
--- a/go/engine/cryptocurrency.go
+++ b/go/engine/cryptocurrency.go
@@ -45,6 +45,9 @@ func (e *CryptocurrencyEngine) SubConsumers() []libkb.UIConsumer {
 }
 
 func (e *CryptocurrencyEngine) Run(ctx *Context) (err error) {
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "CryptocurrencyEngine")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "CryptocurrencyEngine")
+
 	defer e.G().Trace("CryptocurrencyEngine", func() error { return err })()
 
 	var typ libkb.CryptocurrencyType

--- a/go/engine/deprovision.go
+++ b/go/engine/deprovision.go
@@ -50,6 +50,9 @@ func (e *DeprovisionEngine) SubConsumers() []libkb.UIConsumer {
 // be already revoked), but it will still return an error if something
 // unexpected goes wrong.
 func (e *DeprovisionEngine) attemptLoggedInRevoke(ctx *Context) error {
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "DeprovisionEngine")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "DeprovisionEngine")
+
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
 	if err != nil {
 		e.G().Log.Debug("DeprovisionEngine error loading current user: %s", err)

--- a/go/engine/device_add.go
+++ b/go/engine/device_add.go
@@ -50,6 +50,9 @@ func (e *DeviceAdd) Run(ctx *Context) (err error) {
 	e.G().Log.Debug("+ DeviceAdd.Run()")
 	defer func() { e.G().Log.Debug("- DeviceAdd.Run() -> %s", libkb.ErrToOk(err)) }()
 
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "DeviceAdd")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "DeviceAdd")
+
 	arg := keybase1.ChooseDeviceTypeArg{Kind: keybase1.ChooseType_NEW_DEVICE}
 	provisioneeType, err := ctx.ProvisionUI.ChooseDeviceType(context.TODO(), arg)
 	if err != nil {

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -81,6 +81,9 @@ func (e *Kex2Provisionee) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *Kex2Provisionee) Run(ctx *Context) error {
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "Kex2Provisionee")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "Kex2Provisionee")
+
 	// check device struct:
 	if len(e.device.Type) == 0 {
 		return errors.New("provisionee device requires Type to be set")

--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -71,6 +71,10 @@ func (e *Kex2Provisioner) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the provisioner engine.
 func (e *Kex2Provisioner) Run(ctx *Context) error {
+
+	// The guard is acquired later, after the potentially long pause by the user.
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "Kex2Provisioner")
+
 	// before starting provisioning, need to load some information:
 	if err := e.loadMe(); err != nil {
 		return err
@@ -118,6 +122,7 @@ func (e *Kex2Provisioner) Run(ctx *Context) error {
 	if err := kex2.RunProvisioner(parg); err != nil {
 		return err
 	}
+	e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "Kex2Provisioner")
 
 	// successfully provisioned the other device
 	sarg := keybase1.ProvisionerSuccessArg{
@@ -300,6 +305,12 @@ func (e *Kex2Provisioner) sessionForY() (token, csrf string, err error) {
 // skeletonProof generates a partial key proof structure that
 // device Y can fill in.
 func (e *Kex2Provisioner) skeletonProof() (string, error) {
+
+	// Set the local sigchain guard to tell background tasks
+	// to stay off the sigchain while we do this.
+	// This is released at the end of Kex2Provisioner#Run
+	e.G().LocalSigchainGuard().Set(context.TODO(), "Kex2Provisioner")
+
 	// reload the self user to make sure it is fresh
 	// (this fixes TestProvisionWithRevoke [CORE-5631, CORE-5636])
 	if err := e.loadMe(); err != nil {

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -83,6 +83,9 @@ func (e *loginProvision) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *loginProvision) Run(ctx *Context) error {
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "loginProvision")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "loginProvision")
+
 	if err := e.checkArg(); err != nil {
 		return err
 	}

--- a/go/engine/paperkey.go
+++ b/go/engine/paperkey.go
@@ -60,6 +60,9 @@ func (e *PaperKey) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *PaperKey) Run(ctx *Context) error {
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "PaperKey")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "PaperKey")
+
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
 	if err != nil {
 		return err

--- a/go/engine/pgpprovision.go
+++ b/go/engine/pgpprovision.go
@@ -51,6 +51,9 @@ func (e *PGPProvision) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *PGPProvision) Run(ctx *Context) error {
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "PGPProvision")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "PGPProvision")
+
 	// clear out any existing session:
 	e.G().Logout()
 

--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -347,6 +347,8 @@ func (p *Prove) Run(ctx *Context) (err error) {
 	if err = p.doWarnings(ctx); err != nil {
 		return
 	}
+	p.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "Prove")
+	defer p.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "Prove")
 	stage("GenerateProof")
 	if err = p.generateProof(ctx); err != nil {
 		return
@@ -355,6 +357,7 @@ func (p *Prove) Run(ctx *Context) (err error) {
 	if err = p.postProofToServer(); err != nil {
 		return
 	}
+	p.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "Prove")
 	stage("CheckProofText")
 	if err = p.checkProofText(); err != nil {
 		return

--- a/go/engine/puk_upgrade_background.go
+++ b/go/engine/puk_upgrade_background.go
@@ -96,6 +96,11 @@ func PerUserKeyUpgradeBackgroundRound(g *libkb.GlobalContext, ectx *Context) err
 		return nil
 	}
 
+	if !g.LocalSigchainGuard().IsAvailable(ectx.GetNetContext(), "PerUserKeyUpgradeBackgroundRound") {
+		g.Log.CDebugf(ectx.GetNetContext(), "CheckUpgradePerUserKey yielding to guard")
+		return nil
+	}
+
 	if g.ConnectivityMonitor.IsConnected(ectx.GetNetContext()) == libkb.ConnectivityMonitorNo {
 		g.Log.CDebugf(ectx.GetNetContext(), "CheckUpgradePerUserKey giving up offline")
 		return nil

--- a/go/engine/puk_upkeep_background.go
+++ b/go/engine/puk_upkeep_background.go
@@ -95,6 +95,11 @@ func PerUserKeyUpkeepBackgroundRound(g *libkb.GlobalContext, ectx *Context) erro
 		return nil
 	}
 
+	if !g.LocalSigchainGuard().IsAvailable(ectx.GetNetContext(), "PerUserKeyUpkeepBackgroundRound") {
+		g.Log.CDebugf(ectx.GetNetContext(), "PerUserKeyUpkeepBackgroundRound yielding to guard")
+		return nil
+	}
+
 	arg := &PerUserKeyUpkeepArgs{}
 	eng := NewPerUserKeyUpkeep(g, arg)
 	err := RunEngine(eng, ectx)

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -102,6 +102,9 @@ func (e *RevokeEngine) getKIDsToRevoke(me *libkb.User) ([]keybase1.KID, error) {
 func (e *RevokeEngine) Run(ctx *Context) error {
 	e.G().Log.CDebugf(ctx.NetContext, "RevokeEngine#Run (mode:%v)", e.mode)
 
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "RevokeEngine")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "RevokeEngine")
+
 	currentDevice := e.G().Env.GetDeviceID()
 	var deviceID keybase1.DeviceID
 	if e.mode == RevokeDevice {

--- a/go/engine/revoke_sigs.go
+++ b/go/engine/revoke_sigs.go
@@ -60,6 +60,9 @@ func (e *RevokeSigsEngine) getSigIDsToRevoke(me *libkb.User) ([]keybase1.SigID, 
 }
 
 func (e *RevokeSigsEngine) Run(ctx *Context) error {
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "RevokeSigsEngine")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "RevokeSigsEngine")
+
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
 	if err != nil {
 		return err

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -57,6 +57,9 @@ func (e *TrackEngine) SubConsumers() []libkb.UIConsumer {
 }
 
 func (e *TrackEngine) Run(ctx *Context) error {
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "TrackEngine")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "TrackEngine")
+
 	arg := &keybase1.Identify2Arg{
 		UserAssertion:         e.arg.UserAssertion,
 		ForceRemoteCheck:      e.arg.ForceRemoteCheck,

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -49,6 +49,9 @@ func (e *UntrackEngine) SubConsumers() []libkb.UIConsumer {
 }
 
 func (e *UntrackEngine) Run(ctx *Context) (err error) {
+	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "UntrackEngine")
+	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "UntrackEngine")
+
 	e.arg.Me, err = e.loadMe()
 	if err != nil {
 		return

--- a/go/libkb/sigchain_guard.go
+++ b/go/libkb/sigchain_guard.go
@@ -1,0 +1,51 @@
+package libkb
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+)
+
+// A guard used to tell background tasks to stay off the sigchain
+// while the user is changing their sigchain on purpose.
+// Don't treat this as a lock, it's very sloppy.
+// The guard exists to avoid races where an intentional action like provisioning
+// loads the sigchain, but then it gets changed by a background task,
+// so the intentional action would fail.
+// This is just an atomic bool. Intentional actions can acquire it
+// multiple times, release it even when others have it,
+// so it's sloppy, but you'll never deadlock.
+type LocalSigchainGuard struct {
+	Contextified
+	mu       sync.Mutex
+	acquired bool
+}
+
+func NewLocalSigchainGuard(g *GlobalContext) *LocalSigchainGuard {
+	return &LocalSigchainGuard{
+		Contextified: NewContextified(g),
+		acquired:     false,
+	}
+}
+
+func (l *LocalSigchainGuard) Set(ctx context.Context, reason string) {
+	l.G().Log.CDebugf(ctx, "LocalSigchainGuard#Set(%v)", reason)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.acquired = true
+}
+
+func (l *LocalSigchainGuard) Clear(ctx context.Context, reason string) {
+	l.G().Log.CDebugf(ctx, "LocalSigchainGuard#Clear(%v)", reason)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.acquired = false
+}
+
+func (l *LocalSigchainGuard) IsAvailable(ctx context.Context, reason string) bool {
+	l.mu.Lock()
+	acquired := l.acquired
+	l.mu.Unlock()
+	l.G().Log.CDebugf(ctx, "LocalSigchainGuard#IsAvailable(%v) -> %v", reason, !acquired)
+	return !acquired
+}


### PR DESCRIPTION
The point of this is to further minimize races where the background tasks modify the sigchain while a user-driven action is concocting a sigchain link. I'm sure your change of making kex reload will already have gotten the major window for that race.

Add a locked bool to guard the sigchain while doing actions the user requested. The 2 puk background tasks will lay off the sigchain while it is set. It's a locked bool instead of a lock so that there is no chance it will deadlock. So it's plenty possible for it to be unlocked when it shouldn't be (if one engine Clear's after another Set's), but all that will do is infinitesimally increase the chance of a background task racing in. I made a handful of engines acquire it.