### PR TITLE
Add team tree, fix TeamLoader bugs

### DIFF
--- a/go/client/cmd_team.go
+++ b/go/client/cmd_team.go
@@ -23,6 +23,7 @@ func NewCmdTeam(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 			newCmdTeamEditMember(cl, g),
 			newCmdTeamLeave(cl, g),
 			newCmdTeamRename(cl, g),
+			newCmdTeamShowTree(cl, g),
 			newCmdTeamAcceptInvite(cl, g),
 			newCmdTeamRequestAccess(cl, g),
 			newCmdTeamIgnoreRequest(cl, g),

--- a/go/client/cmd_team_rename.go
+++ b/go/client/cmd_team_rename.go
@@ -11,7 +11,6 @@ import (
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"golang.org/x/net/context"
 )
 
@@ -71,13 +70,6 @@ func (v *CmdTeamRename) helpRenameWrongLevel() (err error) {
 func (v *CmdTeamRename) Run() (err error) {
 	cli, err := GetTeamsClient(v.G())
 	if err != nil {
-		return err
-	}
-
-	protocols := []rpc.Protocol{
-		NewSecretUIProtocol(v.G()),
-	}
-	if err = RegisterProtocolsWithContext(protocols, v.G()); err != nil {
 		return err
 	}
 

--- a/go/client/cmd_team_show_tree.go
+++ b/go/client/cmd_team_show_tree.go
@@ -11,7 +11,6 @@ import (
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"golang.org/x/net/context"
 )
 
@@ -23,9 +22,6 @@ type CmdTeamShowTree struct {
 
 func (v *CmdTeamShowTree) ParseArgv(ctx *cli.Context) (err error) {
 	v.TeamName, err = ParseOneTeamNameK1(ctx)
-	if err != nil {
-		return err
-	}
 	return err
 }
 
@@ -35,15 +31,7 @@ func (v *CmdTeamShowTree) Run() (err error) {
 		return err
 	}
 
-	protocols := []rpc.Protocol{
-		NewSecretUIProtocol(v.G()),
-	}
-	if err = RegisterProtocolsWithContext(protocols, v.G()); err != nil {
-		return err
-	}
-
 	// Get the tree from the root.
-
 	treeRes, err := cli.TeamTree(context.TODO(), keybase1.TeamTreeArg{
 		Name:      v.TeamName.RootAncestorName(),
 		SessionID: v.SessionID,

--- a/go/client/cmd_team_show_tree.go
+++ b/go/client/cmd_team_show_tree.go
@@ -1,0 +1,96 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"golang.org/x/net/context"
+)
+
+type CmdTeamShowTree struct {
+	TeamName  keybase1.TeamName
+	SessionID int
+	libkb.Contextified
+}
+
+func (v *CmdTeamShowTree) ParseArgv(ctx *cli.Context) (err error) {
+	v.TeamName, err = ParseOneTeamNameK1(ctx)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (v *CmdTeamShowTree) Run() (err error) {
+	cli, err := GetTeamsClient(v.G())
+	if err != nil {
+		return err
+	}
+
+	protocols := []rpc.Protocol{
+		NewSecretUIProtocol(v.G()),
+	}
+	if err = RegisterProtocolsWithContext(protocols, v.G()); err != nil {
+		return err
+	}
+
+	// Get the tree from the root.
+
+	treeRes, err := cli.TeamTree(context.TODO(), keybase1.TeamTreeArg{
+		Name:      v.TeamName.RootAncestorName(),
+		SessionID: v.SessionID,
+	})
+	if err != nil {
+		return err
+	}
+
+	var report []string
+	var hasStar bool
+	for _, row := range treeRes.Entries {
+		spaces := strings.Repeat("  ", row.Name.Depth()-1)
+		var star string
+		if !row.Admin {
+			star = " *"
+			hasStar = true
+		}
+		report = append(report, fmt.Sprintf("%s- %s%s", spaces, row.Name.String(), star))
+	}
+	if hasStar {
+		report = append(report, "* Subteams of teams you are not an admin of may be hidden.")
+	}
+	fmt.Printf("%s\n", strings.Join(report, "\n"))
+	return nil
+}
+
+func newCmdTeamShowTree(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "show-tree",
+		ArgumentHelp: "<team name>",
+		Usage:        "Show a team's subteams.",
+		Flags:        []cli.Flag{},
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdTeamShowTreeRunner(g), "teamshowtree", c)
+		},
+		Description: "Show all the subteams of a team.",
+	}
+}
+
+func NewCmdTeamShowTreeRunner(g *libkb.GlobalContext) *CmdTeamShowTree {
+	return &CmdTeamShowTree{Contextified: libkb.NewContextified(g)}
+}
+
+func (v *CmdTeamShowTree) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1707,3 +1707,7 @@ func (t TeamInviteType) String() (string, error) {
 
 	return "", nil
 }
+
+func (m MemberInfo) TeamName() (TeamName, error) {
+	return TeamNameFromString(m.FqName)
+}

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -945,6 +945,35 @@ func (o TeamJoinRequest) DeepCopy() TeamJoinRequest {
 	}
 }
 
+type TeamTreeResult struct {
+	Entries []TeamTreeEntry `codec:"entries" json:"entries"`
+}
+
+func (o TeamTreeResult) DeepCopy() TeamTreeResult {
+	return TeamTreeResult{
+		Entries: (func(x []TeamTreeEntry) []TeamTreeEntry {
+			var ret []TeamTreeEntry
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Entries),
+	}
+}
+
+type TeamTreeEntry struct {
+	Name  TeamName `codec:"name" json:"name"`
+	Admin bool     `codec:"admin" json:"admin"`
+}
+
+func (o TeamTreeEntry) DeepCopy() TeamTreeEntry {
+	return TeamTreeEntry{
+		Name:  o.Name.DeepCopy(),
+		Admin: o.Admin,
+	}
+}
+
 type TeamCreateArg struct {
 	SessionID int      `codec:"sessionID" json:"sessionID"`
 	Name      TeamName `codec:"name" json:"name"`
@@ -1135,6 +1164,18 @@ func (o TeamIgnoreRequestArg) DeepCopy() TeamIgnoreRequestArg {
 	}
 }
 
+type TeamTreeArg struct {
+	SessionID int      `codec:"sessionID" json:"sessionID"`
+	Name      TeamName `codec:"name" json:"name"`
+}
+
+func (o TeamTreeArg) DeepCopy() TeamTreeArg {
+	return TeamTreeArg{
+		SessionID: o.SessionID,
+		Name:      o.Name.DeepCopy(),
+	}
+}
+
 type LoadTeamPlusApplicationKeysArg struct {
 	SessionID   int             `codec:"sessionID" json:"sessionID"`
 	Id          TeamID          `codec:"id" json:"id"`
@@ -1166,6 +1207,7 @@ type TeamsInterface interface {
 	TeamRequestAccess(context.Context, TeamRequestAccessArg) error
 	TeamListRequests(context.Context, int) ([]TeamJoinRequest, error)
 	TeamIgnoreRequest(context.Context, TeamIgnoreRequestArg) error
+	TeamTree(context.Context, TeamTreeArg) (TeamTreeResult, error)
 	// * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.
 	// * If refreshers are non-empty, then force a refresh of the cache if the requirements
 	// * of the refreshers aren't met.
@@ -1400,6 +1442,22 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"teamTree": {
+				MakeArg: func() interface{} {
+					ret := make([]TeamTreeArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]TeamTreeArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]TeamTreeArg)(nil), args)
+						return
+					}
+					ret, err = i.TeamTree(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"loadTeamPlusApplicationKeys": {
 				MakeArg: func() interface{} {
 					ret := make([]LoadTeamPlusApplicationKeysArg, 1)
@@ -1492,6 +1550,11 @@ func (c TeamsClient) TeamListRequests(ctx context.Context, sessionID int) (res [
 
 func (c TeamsClient) TeamIgnoreRequest(ctx context.Context, __arg TeamIgnoreRequestArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamIgnoreRequest", []interface{}{__arg}, nil)
+	return
+}
+
+func (c TeamsClient) TeamTree(ctx context.Context, __arg TeamTreeArg) (res TeamTreeResult, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamTree", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -408,6 +408,7 @@ func (o TeamPlusApplicationKeys) DeepCopy() TeamPlusApplicationKeys {
 
 type TeamData struct {
 	Secretless      bool                                                 `codec:"secretless" json:"secretless"`
+	Name            TeamName                                             `codec:"name" json:"name"`
 	Chain           TeamSigChainState                                    `codec:"chain" json:"chain"`
 	PerTeamKeySeeds map[PerTeamKeyGeneration]PerTeamKeySeedItem          `codec:"perTeamKeySeeds" json:"perTeamKeySeeds"`
 	ReaderKeyMasks  map[TeamApplication]map[PerTeamKeyGeneration]MaskB64 `codec:"readerKeyMasks" json:"readerKeyMasks"`
@@ -417,6 +418,7 @@ type TeamData struct {
 func (o TeamData) DeepCopy() TeamData {
 	return TeamData{
 		Secretless: o.Secretless,
+		Name:       o.Name.DeepCopy(),
 		Chain:      o.Chain.DeepCopy(),
 		PerTeamKeySeeds: (func(x map[PerTeamKeyGeneration]PerTeamKeySeedItem) map[PerTeamKeyGeneration]PerTeamKeySeedItem {
 			ret := make(map[PerTeamKeyGeneration]PerTeamKeySeedItem)
@@ -596,7 +598,9 @@ func (o TeamInvite) DeepCopy() TeamInvite {
 type TeamSigChainState struct {
 	Reader        UserVersion                         `codec:"reader" json:"reader"`
 	Id            TeamID                              `codec:"id" json:"id"`
-	Name          TeamName                            `codec:"name" json:"name"`
+	RootAncestor  TeamName                            `codec:"rootAncestor" json:"rootAncestor"`
+	NameDepth     int                                 `codec:"nameDepth" json:"nameDepth"`
+	NameLog       []TeamNameLogPoint                  `codec:"nameLog" json:"nameLog"`
 	LastSeqno     Seqno                               `codec:"lastSeqno" json:"lastSeqno"`
 	LastLinkID    LinkID                              `codec:"lastLinkID" json:"lastLinkID"`
 	ParentID      *TeamID                             `codec:"parentID,omitempty" json:"parentID,omitempty"`
@@ -610,9 +614,18 @@ type TeamSigChainState struct {
 
 func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 	return TeamSigChainState{
-		Reader:     o.Reader.DeepCopy(),
-		Id:         o.Id.DeepCopy(),
-		Name:       o.Name.DeepCopy(),
+		Reader:       o.Reader.DeepCopy(),
+		Id:           o.Id.DeepCopy(),
+		RootAncestor: o.RootAncestor.DeepCopy(),
+		NameDepth:    o.NameDepth,
+		NameLog: (func(x []TeamNameLogPoint) []TeamNameLogPoint {
+			var ret []TeamNameLogPoint
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.NameLog),
 		LastSeqno:  o.LastSeqno.DeepCopy(),
 		LastLinkID: o.LastLinkID.DeepCopy(),
 		ParentID: (func(x *TeamID) *TeamID {
@@ -690,6 +703,18 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 			}
 			return ret
 		})(o.ActiveInvites),
+	}
+}
+
+type TeamNameLogPoint struct {
+	LastPart TeamNamePart `codec:"lastPart" json:"lastPart"`
+	Seqno    Seqno        `codec:"seqno" json:"seqno"`
+}
+
+func (o TeamNameLogPoint) DeepCopy() TeamNameLogPoint {
+	return TeamNameLogPoint{
+		LastPart: o.LastPart.DeepCopy(),
+		Seqno:    o.Seqno.DeepCopy(),
 	}
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -23,6 +23,8 @@ type TeamsHandler struct {
 	connID libkb.ConnectionID
 }
 
+var _ keybase1.TeamsInterface = (*TeamsHandler)(nil)
+
 func NewTeamsHandler(xp rpc.Transporter, id libkb.ConnectionID, g *globals.Context, gregor *gregorHandler) *TeamsHandler {
 	return &TeamsHandler{
 		BaseHandler:  NewBaseHandler(xp),
@@ -125,6 +127,10 @@ func (h *TeamsHandler) TeamListRequests(ctx context.Context, sessionID int) ([]k
 
 func (h *TeamsHandler) TeamIgnoreRequest(ctx context.Context, arg keybase1.TeamIgnoreRequestArg) error {
 	return teams.IgnoreRequest(ctx, h.G().ExternalG(), arg.Name, arg.Username)
+}
+
+func (h *TeamsHandler) TeamTree(ctx context.Context, arg keybase1.TeamTreeArg) (res keybase1.TeamTreeResult, err error) {
+	return teams.TeamTree(ctx, h.G().ExternalG(), arg)
 }
 
 func (h *TeamsHandler) LoadTeamPlusApplicationKeys(netCtx context.Context, arg keybase1.LoadTeamPlusApplicationKeysArg) (keybase1.TeamPlusApplicationKeys, error) {

--- a/go/teams/chain_test.go
+++ b/go/teams/chain_test.go
@@ -104,7 +104,7 @@ func TestTeamSigChainPlay1(t *testing.T) {
 			t.Logf("testing serde")
 		}
 
-		require.Equal(t, "t_9d6d1e37", state.GetName().String())
+		require.Equal(t, "t_9d6d1e37", string(state.LatestLastNamePart()))
 		require.False(t, state.IsSubteam())
 		ptk, err := state.GetLatestPerTeamKey()
 		require.NoError(t, err)
@@ -182,7 +182,7 @@ func TestTeamSigChainPlay2(t *testing.T) {
 	state, err := player.GetState()
 	require.NoError(t, err)
 	for i := 0; i < 2; i++ {
-		require.Equal(t, "t_bfaadb41", state.GetName().String())
+		require.Equal(t, "t_bfaadb41", string(state.LatestLastNamePart()))
 		require.False(t, state.IsSubteam())
 		ptk, err := state.GetLatestPerTeamKey()
 		require.NoError(t, err)

--- a/go/teams/common_test.go
+++ b/go/teams/common_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
 )
 
 func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
@@ -20,4 +21,15 @@ func GetForTestByStringName(ctx context.Context, g *libkb.GlobalContext, name st
 		Name:        name,
 		ForceRepoll: true,
 	})
+}
+
+func createTeamName(t *testing.T, root string, parts ...string) keybase1.TeamName {
+	name, err := keybase1.TeamNameFromString(root)
+	require.NoError(t, err)
+	require.True(t, name.IsRootTeam(), "team name must be root %v", root)
+	for _, part := range parts {
+		name, err = name.Append(part)
+		require.NoError(t, err)
+	}
+	return name
 }

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -48,7 +48,7 @@ func GetForTeamManagementByStringName(ctx context.Context, g *libkb.GlobalContex
 }
 
 // Get a team with no stubbed links if we are an admin. Use this instead of NeedAdmin when you don't
-// know whether you are an admin. This always causes roundtrips.
+// know whether you are an admin. This always causes roundtrips. Doesn't work for implicit admins.
 func GetMaybeAdminByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*Team, error) {
 	// Find out our up-to-date role.
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -1,6 +1,9 @@
 package teams
 
 import (
+	"fmt"
+	"sort"
+
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/engine"
@@ -17,6 +20,22 @@ func (r *statusList) GetAppStatus() *libkb.AppStatus {
 	return &r.Status
 }
 
+func getTeamsListFromServer(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID) ([]keybase1.MemberInfo, error) {
+	a := libkb.NewAPIArg("team/for_user")
+	a.NetContext = ctx
+	a.SessionType = libkb.APISessionTypeREQUIRED
+	if uid.Exists() {
+		a.Args = libkb.HTTPArgs{
+			"uid": libkb.S{Val: uid.String()},
+		}
+	}
+	var list statusList
+	if err := g.API.GetDecode(a, &list); err != nil {
+		return nil, err
+	}
+	return list.Teams, nil
+}
+
 func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg) (*keybase1.TeamList, error) {
 	var uid keybase1.UID
 	if arg.UserAssertion != "" {
@@ -27,17 +46,8 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 		uid = res.GetUID()
 	}
 
-	a := libkb.NewAPIArg("team/for_user")
-	a.NetContext = ctx
-	a.SessionType = libkb.APISessionTypeREQUIRED
-	if uid.Exists() {
-		a.Args = libkb.HTTPArgs{
-			"uid": libkb.S{Val: uid.String()},
-		}
-	}
-
-	var list statusList
-	if err := g.API.GetDecode(a, &list); err != nil {
+	list, err := getTeamsListFromServer(ctx, g, uid)
+	if err != nil {
 		return nil, err
 	}
 
@@ -61,7 +71,90 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 		Uid:      uid,
 		Username: username.String(),
 		FullName: fullName,
-		Teams:    list.Teams,
+		Teams:    list,
 	}
 	return &tl, nil
+}
+
+func TeamTree(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamTreeArg) (res keybase1.TeamTreeResult, err error) {
+	if !arg.Name.IsRootTeam() {
+		return res, fmt.Errorf("cannot get tree of non-root team")
+	}
+
+	serverList, err := getTeamsListFromServer(ctx, g, "")
+	if err != nil {
+		return res, err
+	}
+
+	// Map from team name (string) to entry
+	entryMap := make(map[string]keybase1.TeamTreeEntry)
+
+	// The server might have omitted some teams, oh well.
+	// Trusts the server for role.
+	// Load the teams by ID to make sure they are valid and get the validated names.
+	for _, info := range serverList {
+		serverName, err := info.TeamName()
+		if err != nil {
+			return res, err
+		}
+		if !serverName.RootAncestorName().Eq(arg.Name) {
+			// Skip those not in this tree.
+			continue
+		}
+		team, err := Load(ctx, g, keybase1.LoadTeamArg{
+			ID:          info.TeamID,
+			ForceRepoll: true,
+		})
+		if err != nil {
+			return res, err
+		}
+		var admin bool // true if an admin or implicit admin
+		if info.Role.IsAdminOrAbove() {
+			admin = true
+		}
+		if info.Implicit != nil && info.Implicit.Role.IsAdminOrAbove() {
+			admin = true
+		}
+		entryMap[team.Name().String()] = keybase1.TeamTreeEntry{
+			Name:  team.Name(),
+			Admin: admin,
+		}
+	}
+
+	// Add all parent names (recursively)
+	// So that if only A.B.C is in the list, we add A.B and A as well.
+	// Adding map entries while iterating is safe.
+	// "If map entries are created during iteration, that entry may be produced during the iteration or may be skipped."
+	for _, entry := range entryMap {
+		name := entry.Name.DeepCopy()
+		for name.Depth() > 0 {
+			_, ok := entryMap[name.String()]
+			if !ok {
+				entryMap[name.String()] = keybase1.TeamTreeEntry{
+					Name:  name,
+					Admin: false,
+				}
+			}
+			name, err = name.Parent()
+			if err != nil {
+				break
+			}
+		}
+	}
+
+	for _, entry := range entryMap {
+		res.Entries = append(res.Entries, entry)
+	}
+
+	if len(res.Entries) == 0 {
+		return res, fmt.Errorf("team not found: %v", arg.Name)
+	}
+
+	// Order into a tree order. Which happens to be alphabetical ordering.
+	// Example: [a, a.b, a.b.c, a.b.d, a.e.f, a.e.g]
+	sort.Slice(res.Entries, func(i, j int) bool {
+		return res.Entries[i].Name.String() < res.Entries[j].Name.String()
+	})
+
+	return res, nil
 }

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -330,7 +330,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 		}
 
 		var signer *keybase1.UserVersion
-		signer, proofSet, err = l.verifyLink(ctx, arg.teamID, ret, link, readSubteamID, proofSet)
+		signer, proofSet, err = l.verifyLink(ctx, arg.teamID, ret, arg.me, link, readSubteamID, proofSet)
 		if err != nil {
 			return nil, err
 		}
@@ -394,10 +394,14 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 
 	// Recalculate the team name. This is only dealing with ancestor renames, chain.go has already
 	// handled on-chain renames
-	newName, err := l.recalculateName(ctx, ret, arg.me, arg.staleOK)
+	newName, err := l.recalculateName(ctx, ret, arg.me, readSubteamID, arg.staleOK)
+	if err != nil {
+		return nil, fmt.Errorf("error recalculating name for %v: %v", ret.Chain.Name, err)
+	}
 	if !ret.Chain.Name.Eq(newName) {
 		// This deep copy is an absurd price to pay, but these mid-team renames should be quite rare.
-		ret := ret.DeepCopy()
+		copy := ret.DeepCopy()
+		ret = &copy
 		ret.Chain.Name = newName
 	}
 	// Check that the name matches the subteam-ness

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -393,7 +393,9 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 	}
 
 	// Recalculate the team name. This is only dealing with ancestor renames, chain.go has already
-	// handled on-chain renames
+	// handled on-chain renames.
+	// It is probably critical that this is always run. Without this a subteam could claim any parent
+	// team name and we woudln't notice.
 	newName, err := l.recalculateName(ctx, ret, arg.me, readSubteamID, arg.staleOK)
 	if err != nil {
 		return nil, fmt.Errorf("error recalculating name for %v: %v", ret.Chain.Name, err)

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -50,7 +50,7 @@ func TestLoaderBasic(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, teamID, team.Chain.Id)
-	require.True(t, teamName.Eq(team.Chain.Name))
+	require.True(t, teamName.Eq(team.Name))
 
 	t.Logf("load the team again")
 	team, err = tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
@@ -58,7 +58,7 @@ func TestLoaderBasic(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, teamID, team.Chain.Id)
-	require.True(t, teamName.Eq(team.Chain.Name))
+	require.True(t, teamName.Eq(team.Name))
 }
 
 // Test that the loader works after the cache turns stale
@@ -80,7 +80,7 @@ func TestLoaderStaleNoUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, teamID, team.Chain.Id)
-	require.True(t, teamName.Eq(team.Chain.Name))
+	require.True(t, teamName.Eq(team.Name))
 
 	t.Logf("make the cache look old")
 	st := getStorageFromG(tc.G)
@@ -97,7 +97,7 @@ func TestLoaderStaleNoUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, teamID, team.Chain.Id)
-	require.True(t, teamName.Eq(team.Chain.Name))
+	require.True(t, teamName.Eq(team.Name))
 }
 
 // Test loading a root team by name.
@@ -117,7 +117,7 @@ func TestLoaderByName(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, teamID, team.Chain.Id)
-	require.True(t, teamName.Eq(team.Chain.Name))
+	require.True(t, teamName.Eq(team.Name))
 }
 
 // Test loading a team with NeedKeyGeneration set.
@@ -312,7 +312,7 @@ func TestLoaderSubteamEasy(t *testing.T) {
 	require.Equal(t, team.Chain.Id, *subteamID)
 	expectedSubteamName, err := parentName.Append("mysubteam")
 	require.NoError(t, err)
-	require.Equal(t, expectedSubteamName, TeamSigChainState{inner: team.Chain}.GetName())
+	require.Equal(t, expectedSubteamName, team.Name)
 	require.Equal(t, parentID, *team.Chain.ParentID)
 }
 
@@ -426,7 +426,7 @@ func TestLoaderMultilevel(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, *subsubteamID, team.Chain.Id)
-	require.Equal(t, expectedSubsubTeamName, TeamSigChainState{inner: team.Chain}.GetName())
+	require.Equal(t, expectedSubsubTeamName, team.Name)
 }
 
 // Test that loading with wantmembers which have eldestseqno=0 works.

--- a/go/teams/rename_test.go
+++ b/go/teams/rename_test.go
@@ -60,7 +60,7 @@ func TestRenameSimple(t *testing.T) {
 // - Create team A.B1
 // - Create team A.B1.C <new_subteam>
 // - Rename A.B1 -> A.B2 (implicitly renaming A.B1.C -> A.B2.C)
-// - Someone else (U1) loads A.B1 with <new_subteam> stubbed
+// - Someone else (U1) loads A.B2 with <new_subteam> stubbed
 // - Add U1 as an admin of A.B2 or as a member of A.B2's subtree.
 // - U1 loads and inflates <new_subteam>.
 // The last step failed because the new_subteam link says A.B1.C

--- a/go/teams/rename_test.go
+++ b/go/teams/rename_test.go
@@ -54,3 +54,59 @@ func TestRenameSimple(t *testing.T) {
 	require.Len(t, parent.chain().inner.SubteamLog, 1, "subteam log has 1 series")
 	require.Len(t, parent.chain().inner.SubteamLog[*subteamID], 2, "subteam log has 2 entries")
 }
+
+// This was a bug that once caused the loader to get stuck.
+// - Create team A
+// - Create team A.B1
+// - Create team A.B1.C <new_subteam>
+// - Rename A.B1 -> A.B2 (implicitly renaming A.B1.C -> A.B2.C)
+// - Someone else (U1) loads A.B1 with <new_subteam> stubbed
+// - Add U1 as an admin of A.B2 or as a member of A.B2's subtree.
+// - U1 loads and inflates <new_subteam>.
+// The last step failed because the new_subteam link says A.B1.C
+// but that doesn't look like a valid subteam name of A.B2.
+func TestRenameInflateSubteamAfterRenameParent(t *testing.T) {
+	fus, tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	t.Logf("U0 creates A")
+	parentName, _ := createTeam2(*tcs[0])
+
+	subteamName1 := createTeamName(t, parentName.String(), "bb1")
+	subteamName2 := createTeamName(t, parentName.String(), "bb2")
+	subsubteamName2 := createTeamName(t, parentName.String(), "bb2", "cc")
+
+	t.Logf("U0 creates A.B1")
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "bb1", parentName)
+	require.NoError(t, err)
+
+	t.Logf("U0 creates A.B1.C")
+	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "cc", subteamName1)
+	require.NoError(t, err)
+
+	t.Logf("U0 adds U1 to A.B1 as a writer")
+	_, err = AddMember(context.TODO(), tcs[0].G, subteamName1.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+
+	t.Logf("U0 renames A.B1 -> A.B2")
+	err = RenameSubteam(context.TODO(), tcs[0].G, subteamName1, subteamName2)
+	require.NoError(t, err)
+
+	t.Logf("U1 loads A.B1 (will have stubbed link and new name)")
+	_, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+		ID:          *subteamID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err, "load subsubteam")
+
+	t.Logf("U0 adds U1 to A.B2.C as a writer")
+	_, err = AddMember(context.TODO(), tcs[0].G, subsubteamName2.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+
+	t.Logf("U1 loads A.B2.C which will cause it to inflate the new_subteam link in A.B2")
+	_, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+		ID:          *subsubteamID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err, "load subsubteam")
+}

--- a/go/teams/rpc_exim.go
+++ b/go/teams/rpc_exim.go
@@ -40,7 +40,7 @@ func (t *Team) ExportToTeamPlusApplicationKeys(ctx context.Context, idTime keyba
 
 	ret = keybase1.TeamPlusApplicationKeys{
 		Id:              t.chain().GetID(),
-		Name:            t.chain().GetName().String(),
+		Name:            t.Name().String(),
 		Application:     application,
 		Writers:         writers,
 		OnlyReaders:     onlyReaders,

--- a/go/teams/storage.go
+++ b/go/teams/storage.go
@@ -80,7 +80,7 @@ type DiskStorage struct {
 }
 
 // Increment to invalidate the disk cache.
-const diskStorageVersion = 1
+const diskStorageVersion = 2
 
 type DiskStorageItem struct {
 	Version int                `codec:"V"`

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -39,7 +39,7 @@ func (t *Team) chain() *TeamSigChainState {
 }
 
 func (t *Team) Name() keybase1.TeamName {
-	return t.chain().GetName()
+	return t.Data.Name
 }
 
 func (t *Team) Generation() keybase1.PerTeamKeyGeneration {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -165,7 +165,7 @@ protocol teams {
     // Latest name of the team
     // The last part of this name tracks LatestSeqno.
     // But the middle parts (b in a.b.c) do not track.
-    // They are kept up fairly up to date, but the guarantees are fuzzy.
+    // They are kept fairly up to date by TeamLoader, but the guarantees are fuzzy.
     TeamName name;
     // The last link procesed
     Seqno lastSeqno;
@@ -173,6 +173,11 @@ protocol teams {
 
     // Present if a subteam
     union { null, TeamID } parentID;
+
+	/* // Log of the names this team has gone through.  */
+	/* // The last part of the last entry in this log is the same as Name.  */
+	/* // However the rest of that entry may not be the same because of mid-team-renames.  */
+	/* array<NameLogPoint> nameLog;  */
 
     // For each user; the timeline of their role status.
     // The role checkpoints are always ordered by seqno.
@@ -198,6 +203,16 @@ protocol teams {
     // All invitations that are currently active.
     map<TeamInviteID,TeamInvite> activeInvites;
   }
+
+  /* // The team got this name at this point in time.  */
+  /* record NameLogPoint {  */
+  /* 	// The root ancestor and depth are always correct. */
+  /* 	// For the first entry in the log: the last 2 parts of the name are race-free correct. */
+  /* 	// For other entries: only the the last part is race-free correct. */
+  /* 	TeamName name;  */
+  /* 	// The seqno at which the team got this nam.e  */
+  /* 	Seqno seqno;  */
+  /* }  */
 
   // A user became this role at a point in time
   record UserLogPoint {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -118,6 +118,11 @@ protocol teams {
     // Whether this snapshot is entirely missing secrets.
     boolean secretless;
 
+    // Name of the team. This is tricky.
+    // The root ancestor and the depth are always correct.
+    // But the middle parts (b in a.b.c) do not track the sigchain.
+    // They are kept fairly up to date by TeamLoader, but the guarantees are fuzzy.
+    TeamName name;
     TeamSigChainState chain;
     // generation -> seed
     map<PerTeamKeyGeneration,PerTeamKeySeedItem> perTeamKeySeeds;
@@ -162,22 +167,21 @@ protocol teams {
     UserVersion reader;
 
     TeamID id;
-    // Latest name of the team
-    // The last part of this name tracks LatestSeqno.
-    // But the middle parts (b in a.b.c) do not track.
-    // They are kept fairly up to date by TeamLoader, but the guarantees are fuzzy.
-    TeamName name;
+
+    // Name of the root ancestor. For A.B.C this is 'A'.
+    TeamName rootAncestor;
+    // Depth of the name.
+    int nameDepth;
+
+    // Log of the last part of the team name.
+    array<TeamNameLogPoint> nameLog;
+
     // The last link procesed
     Seqno lastSeqno;
     LinkID lastLinkID;
 
     // Present if a subteam
     union { null, TeamID } parentID;
-
-	/* // Log of the names this team has gone through.  */
-	/* // The last part of the last entry in this log is the same as Name.  */
-	/* // However the rest of that entry may not be the same because of mid-team-renames.  */
-	/* array<NameLogPoint> nameLog;  */
 
     // For each user; the timeline of their role status.
     // The role checkpoints are always ordered by seqno.
@@ -204,15 +208,12 @@ protocol teams {
     map<TeamInviteID,TeamInvite> activeInvites;
   }
 
-  /* // The team got this name at this point in time.  */
-  /* record NameLogPoint {  */
-  /* 	// The root ancestor and depth are always correct. */
-  /* 	// For the first entry in the log: the last 2 parts of the name are race-free correct. */
-  /* 	// For other entries: only the the last part is race-free correct. */
-  /* 	TeamName name;  */
-  /* 	// The seqno at which the team got this nam.e  */
-  /* 	Seqno seqno;  */
-  /* }  */
+  // The team got this name at this point in time.
+  record TeamNameLogPoint {
+    TeamNamePart lastPart;
+    // The seqno at which the team got this name.
+    Seqno seqno;
+  }
 
   // A user became this role at a point in time
   record UserLogPoint {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -335,6 +335,15 @@ protocol teams {
     string username;
   }
 
+  record TeamTreeResult {
+    array<TeamTreeEntry> entries;
+  }
+
+  record TeamTreeEntry {
+    TeamName name;
+    boolean admin; // Whether the user is an admin, explicit or implicit.
+  }
+
   void teamCreate(int sessionID, TeamName name);
   void teamCreateSubteam(int sessionID, TeamName name);
   TeamDetails teamGet(int sessionID, string name, boolean forceRepoll);
@@ -349,6 +358,10 @@ protocol teams {
   void teamRequestAccess(int sessionID, string name); 
   array<TeamJoinRequest> teamListRequests(int sessionID);
   void teamIgnoreRequest(int sessionID, string name, string username);
+  // Get a list of all recursive subteams recursively. Sorted alphabetically like a tree.
+  // Team must be a root team.
+  // Example: a -> [a, a.b, a.b.c, a.b.d, a.e.f, a.e.g]
+  TeamTreeResult teamTree(int sessionID, TeamName name);
 
   /**
    * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6064,6 +6064,7 @@ export type TeamChangeSet = {
 
 export type TeamData = {
   secretless: boolean,
+  name: TeamName,
   chain: TeamSigChainState,
   perTeamKeySeeds: {[key: string]: PerTeamKeySeedItem},
   readerKeyMasks: {[key: string]: {[key: string]: MaskB64}},
@@ -6151,6 +6152,11 @@ export type TeamName = {
   parts?: ?Array<TeamNamePart>,
 }
 
+export type TeamNameLogPoint = {
+  lastPart: TeamNamePart,
+  seqno: Seqno,
+}
+
 export type TeamNamePart = string
 
 export type TeamPlusApplicationKeys = {
@@ -6184,7 +6190,9 @@ export type TeamSBSMsg = {
 export type TeamSigChainState = {
   reader: UserVersion,
   id: TeamID,
-  name: TeamName,
+  rootAncestor: TeamName,
+  nameDepth: int,
+  nameLog?: ?Array<TeamNameLogPoint>,
   lastSeqno: Seqno,
   lastLinkID: LinkID,
   parentID?: ?TeamID,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3752,6 +3752,21 @@ export function teamsTeamRequestAccessRpcPromise (request: $Exact<requestCommon 
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRequestAccess', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamTreeRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamTreeResult) => void} & {param: teamsTeamTreeRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.teamTree', request)
+}
+
+export function teamsTeamTreeRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamTreeResult) => void} & {param: teamsTeamTreeRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamTree', request)
+}
+export function teamsTeamTreeRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamTreeResult) => void} & {param: teamsTeamTreeRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamTree', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamTreeRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamTreeResult) => void} & {param: teamsTeamTreeRpcParam}>): Promise<teamsTeamTreeResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamTree', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function testPanicRpc (request: Exact<requestCommon & requestErrorCallback & {param: testPanicRpcParam}>) {
   engineRpcOutgoing('keybase.1.test.panic', request)
 }
@@ -6181,6 +6196,15 @@ export type TeamSigChainState = {
   activeInvites: {[key: string]: TeamInvite},
 }
 
+export type TeamTreeEntry = {
+  name: TeamName,
+  admin: boolean,
+}
+
+export type TeamTreeResult = {
+  entries?: ?Array<TeamTreeEntry>,
+}
+
 export type Test = {
   reply: string,
 }
@@ -7355,6 +7379,10 @@ export type teamsTeamRequestAccessRpcParam = Exact<{
   name: string
 }>
 
+export type teamsTeamTreeRpcParam = Exact<{
+  name: TeamName
+}>
+
 export type testPanicRpcParam = Exact<{
   message: string
 }>
@@ -7601,6 +7629,7 @@ type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = TeamList
+type teamsTeamTreeResult = TeamTreeResult
 type testTestCallbackResult = string
 type testTestResult = Test
 type tlfCompleteAndCanonicalizePrivateTlfNameResult = CanonicalTLFNameAndIDWithBreaks
@@ -7840,6 +7869,7 @@ export type rpc =
   | teamsTeamRemoveMemberRpc
   | teamsTeamRenameRpc
   | teamsTeamRequestAccessRpc
+  | teamsTeamTreeRpc
   | testPanicRpc
   | testTestCallbackRpc
   | testTestRpc

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -351,6 +351,10 @@
           "name": "secretless"
         },
         {
+          "type": "TeamName",
+          "name": "name"
+        },
+        {
           "type": "TeamSigChainState",
           "name": "chain"
         },
@@ -469,7 +473,18 @@
         },
         {
           "type": "TeamName",
-          "name": "name"
+          "name": "rootAncestor"
+        },
+        {
+          "type": "int",
+          "name": "nameDepth"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "TeamNameLogPoint"
+          },
+          "name": "nameLog"
         },
         {
           "type": "Seqno",
@@ -539,6 +554,20 @@
             "keys": "TeamInviteID"
           },
           "name": "activeInvites"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "TeamNameLogPoint",
+      "fields": [
+        {
+          "type": "TeamNamePart",
+          "name": "lastPart"
+        },
+        {
+          "type": "Seqno",
+          "name": "seqno"
         }
       ]
     },

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -846,6 +846,33 @@
           "name": "username"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "TeamTreeResult",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "TeamTreeEntry"
+          },
+          "name": "entries"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "TeamTreeEntry",
+      "fields": [
+        {
+          "type": "TeamName",
+          "name": "name"
+        },
+        {
+          "type": "boolean",
+          "name": "admin"
+        }
+      ]
     }
   ],
   "messages": {
@@ -1077,6 +1104,19 @@
         }
       ],
       "response": null
+    },
+    "teamTree": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "name",
+          "type": "TeamName"
+        }
+      ],
+      "response": "TeamTreeResult"
     },
     "loadTeamPlusApplicationKeys": {
       "request": [

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6064,6 +6064,7 @@ export type TeamChangeSet = {
 
 export type TeamData = {
   secretless: boolean,
+  name: TeamName,
   chain: TeamSigChainState,
   perTeamKeySeeds: {[key: string]: PerTeamKeySeedItem},
   readerKeyMasks: {[key: string]: {[key: string]: MaskB64}},
@@ -6151,6 +6152,11 @@ export type TeamName = {
   parts?: ?Array<TeamNamePart>,
 }
 
+export type TeamNameLogPoint = {
+  lastPart: TeamNamePart,
+  seqno: Seqno,
+}
+
 export type TeamNamePart = string
 
 export type TeamPlusApplicationKeys = {
@@ -6184,7 +6190,9 @@ export type TeamSBSMsg = {
 export type TeamSigChainState = {
   reader: UserVersion,
   id: TeamID,
-  name: TeamName,
+  rootAncestor: TeamName,
+  nameDepth: int,
+  nameLog?: ?Array<TeamNameLogPoint>,
   lastSeqno: Seqno,
   lastLinkID: LinkID,
   parentID?: ?TeamID,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3752,6 +3752,21 @@ export function teamsTeamRequestAccessRpcPromise (request: $Exact<requestCommon 
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRequestAccess', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamTreeRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamTreeResult) => void} & {param: teamsTeamTreeRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.teamTree', request)
+}
+
+export function teamsTeamTreeRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamTreeResult) => void} & {param: teamsTeamTreeRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamTree', request)
+}
+export function teamsTeamTreeRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamTreeResult) => void} & {param: teamsTeamTreeRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamTree', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamTreeRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamTreeResult) => void} & {param: teamsTeamTreeRpcParam}>): Promise<teamsTeamTreeResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamTree', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function testPanicRpc (request: Exact<requestCommon & requestErrorCallback & {param: testPanicRpcParam}>) {
   engineRpcOutgoing('keybase.1.test.panic', request)
 }
@@ -6181,6 +6196,15 @@ export type TeamSigChainState = {
   activeInvites: {[key: string]: TeamInvite},
 }
 
+export type TeamTreeEntry = {
+  name: TeamName,
+  admin: boolean,
+}
+
+export type TeamTreeResult = {
+  entries?: ?Array<TeamTreeEntry>,
+}
+
 export type Test = {
   reply: string,
 }
@@ -7355,6 +7379,10 @@ export type teamsTeamRequestAccessRpcParam = Exact<{
   name: string
 }>
 
+export type teamsTeamTreeRpcParam = Exact<{
+  name: TeamName
+}>
+
 export type testPanicRpcParam = Exact<{
   message: string
 }>
@@ -7601,6 +7629,7 @@ type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = TeamList
+type teamsTeamTreeResult = TeamTreeResult
 type testTestCallbackResult = string
 type testTestResult = Test
 type tlfCompleteAndCanonicalizePrivateTlfNameResult = CanonicalTLFNameAndIDWithBreaks
@@ -7840,6 +7869,7 @@ export type rpc =
   | teamsTeamRemoveMemberRpc
   | teamsTeamRenameRpc
   | teamsTeamRequestAccessRpc
+  | teamsTeamTreeRpc
   | testPanicRpc
   | testTestCallbackRpc
   | testTestRpc


### PR DESCRIPTION
Adds `keybase team show-tree`. Also fix two `TeamLoader` bugs.

`keybase team show-tree teamname` will show the tree from the root ancestor of teamname.
If you are the admin of the root, it looks like this
```
$ kbu team show-tree jazafraz
- jazafraz
  - jazafraz.aa3
  - jazafraz.aa4
    - jazafraz.aa4.bb1
    - jazafraz.aa4.bb2
```

If you are not the admin of the root, it looks like this:
```
$ kbu team show-tree jazafraz
- jazafraz *
  - jazafraz.aa4 *
    - jazafraz.aa4.bb2
* Subteams of teams you are not an admin of may be hidden.
```
Where that user is a writer of `aa4`, and an admin of `bb2`.

TeamLoader bug 1 was that `me` and `subteamReader` were not plumbed through, so some loads failed.

TeamLoader bug 2 was trickier and has to do with mid-team renaming. I ran in to it while testing `show-tree`. Say there is a parent team X.P1 which spawned a subteam S and then got renamed to X.P2. If you are added to P1 and load it then you will have the `new_subteam` link for S stubbed out. Then if you are added to S and try to inflate that link on the P2 chain, it will fail because "X.P1.S" is not a good name for a subteam of "X.P2".

The fix in this PR is to remember previous names for the subteam. It was getting confusing to remember which parts of team names were verified. So I split up the storage. `TeamSigChainState` now only stores the stuff we know for sure. And `TeamData.Name` stores the latest full name garnered by loading the whole ancestor chain. Hopefully the avdl is clear. I believe if there are no bugs that this should provide the same guarantees for team names except without that bug.

The team cache got invalidated (`diskStorageVersion++`) as a result of this change.