### PR TITLE
Fix HoC to not cache props other than messageKeys

### DIFF
--- a/shared/chat/conversation/list/index.native.js
+++ b/shared/chat/conversation/list/index.native.js
@@ -90,9 +90,8 @@ const verticallyInvertedStyle = {
 }
 
 // Reverse the order of messageKeys to compensate for vertically reversed display
-const withReversedMessageKeys = withPropsOnChange(['messageKeys'], ({messageKeys, ...rest}) => ({
+const withReversedMessageKeys = withPropsOnChange(['messageKeys'], ({messageKeys}) => ({
   messageKeys: messageKeys.reverse(),
-  ...rest,
 }))
 
 export default withReversedMessageKeys(ConversationList)


### PR DESCRIPTION
Found this while tinkering on `isActive` / pausable connect. This HoC was preventing all props from updating until `messageKeys` changed.