### PR TITLE
[Experiment] Plumb isActive down chat view hierarchy

### DIFF
--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -142,6 +142,7 @@ class Conversation extends Component<void, Props, State> {
                 />
               : <div style={{...globalStyles.flexBoxColumn, flex: 1}}>
                   <List
+                    isActive={this.props.isActive}
                     focusInputCounter={this.props.focusInputCounter}
                     listScrollDownCounter={this.props.listScrollDownCounter}
                     onEditLastMessage={this.props.onEditLastMessage}

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -35,6 +35,7 @@ export type Props = {|
   onUpdateSelectedSearchResult: (id: ?SearchConstants.SearchResultId) => void,
   onAddNewParticipant: (clicked: boolean) => void,
   addNewParticipant: boolean,
+  isActive: boolean,
 |}
 
 export default class Conversation extends Component<void, Props, void> {}

--- a/shared/chat/conversation/index.native.js
+++ b/shared/chat/conversation/index.native.js
@@ -57,6 +57,7 @@ const Conversation = (props: Props) => (
             />
           : <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
               <List
+                isActive={props.isActive}
                 focusInputCounter={props.focusInputCounter}
                 listScrollDownCounter={props.listScrollDownCounter}
                 onEditLastMessage={props.onEditLastMessage}

--- a/shared/chat/conversation/list/container.js
+++ b/shared/chat/conversation/list/container.js
@@ -5,7 +5,7 @@ import HiddenString from '../../../util/hidden-string'
 import ListComponent from '.'
 import {List} from 'immutable'
 import {compose} from 'recompose'
-import {connect} from 'react-redux'
+import pausableConnect from '../../../util/pausable-connect'
 import {createSelector} from 'reselect'
 import {navigateAppend} from '../../../actions/route-tree'
 
@@ -141,4 +141,4 @@ const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps): Props
   }
 }
 
-export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps))(ListComponent)
+export default compose(pausableConnect(mapStateToProps, mapDispatchToProps, mergeProps))(ListComponent)

--- a/shared/chat/conversation/list/container.js.flow
+++ b/shared/chat/conversation/list/container.js.flow
@@ -26,6 +26,7 @@ export type DispatchProps = {|
 |}
 
 export type OwnProps = {|
+  isActive: boolean,
   focusInputCounter: number,
   listScrollDownCounter: number,
   onEditLastMessage: () => void,

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -131,7 +131,8 @@ class BaseList extends Component<void, Props, State> {
             this._onAction,
             this._onShowEditor,
             isSelected,
-            measure
+            measure,
+            this.props.isActive,
           )
           return (
             <div style={style}>

--- a/shared/chat/conversation/list/index.js.flow
+++ b/shared/chat/conversation/list/index.js.flow
@@ -4,6 +4,7 @@ import {List} from 'immutable'
 import * as Constants from '../../../constants/chat'
 
 export type Props = {|
+  isActive: boolean,
   messageKeys: List<string>,
   editLastMessageCounter: number,
   listScrollDownCounter: number,

--- a/shared/chat/conversation/list/index.native.js
+++ b/shared/chat/conversation/list/index.native.js
@@ -36,7 +36,8 @@ class ConversationList extends Component<void, Props, void> {
             this._onAction,
             this._onShowEditor,
             isSelected,
-            this._measure
+            this._measure,
+            this.props.isActive,
           )}
         </Box>
       )
@@ -72,6 +73,7 @@ class ConversationList extends Component<void, Props, void> {
     return (
       <FlatList
         data={this.props.messageKeys.toArray()}
+        extraData={this.props.isActive}
         renderItem={this._renderItem}
         renderScrollComponent={this._renderScrollComponent}
         onEndReached={this._onEndReached}

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -16,7 +16,8 @@ const factory = (
   onAction: (message: Constants.ServerMessage, event: any) => void,
   onShowEditor: (message: Constants.ServerMessage, event: any) => void,
   isSelected: boolean,
-  measure: () => void
+  measure: () => void,
+  isActive: boolean,
 ) => {
   const kind = Constants.messageKeyKind(messageKey)
   switch (kind) {
@@ -27,6 +28,7 @@ const factory = (
       return (
         <Wrapper
           innerClass={Attachment}
+          isActive={isActive}
           isSelected={isSelected}
           measure={measure}
           messageKey={messageKey}
@@ -44,6 +46,7 @@ const factory = (
       return (
         <Wrapper
           innerClass={TextMessage}
+          isActive={isActive}
           isSelected={isSelected}
           measure={measure}
           messageKey={messageKey}

--- a/shared/chat/conversation/messages/index.js.flow
+++ b/shared/chat/conversation/messages/index.js.flow
@@ -7,6 +7,7 @@ declare function factory(
   onAction: (message: Constants.ServerMessage, event: any) => void,
   onShowEditor: (message: Constants.ServerMessage, event: any) => void,
   isSelectd: boolean,
-  measure: () => void
+  measure: () => void,
+  isActive: boolean,
 ): React$Element<*>
 export default factory

--- a/shared/chat/conversation/messages/text/container.js
+++ b/shared/chat/conversation/messages/text/container.js
@@ -3,7 +3,7 @@ import * as Constants from '../../../../constants/chat'
 import TextMessage from '.'
 import createCachedSelector from 're-reselect'
 import {compose, lifecycle} from 'recompose'
-import {connect} from 'react-redux'
+import pausableConnect from '../../../../util/pausable-connect'
 
 import type {Props} from '.'
 import type {TypedState} from '../../../../constants/reducer'
@@ -29,7 +29,7 @@ const mergeProps = (stateProps, dispatchProps, {measure}: OwnProps) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, () => ({}), mergeProps),
+  pausableConnect(mapStateToProps, () => ({}), mergeProps),
   lifecycle({
     componentWillReceiveProps: function(nextProps: Props) {
       if (this.props.measure && this.props.type !== nextProps.type) {

--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -3,7 +3,7 @@ import * as Constants from '../../../../constants/chat'
 import * as Creators from '../../../../actions/chat/creators'
 import Wrapper from '.'
 import {compose, withHandlers, lifecycle} from 'recompose'
-import {connect} from 'react-redux'
+import pausableConnect from '../../../../util/pausable-connect'
 import {Map} from 'immutable'
 import {formatTimeForMessages} from '../../../../util/timestamp'
 import {lookupMessageProps} from '../../../shared'
@@ -106,7 +106,7 @@ const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownPro
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  pausableConnect(mapStateToProps, mapDispatchToProps, mergeProps),
   withHandlers({
     onAction: props => event => props._onAction(props._message, props._localMessageState, event),
     onShowEditor: props => event => props._onShowEditor(props._message, event),

--- a/shared/chat/conversation/messages/wrapper/shared.js
+++ b/shared/chat/conversation/messages/wrapper/shared.js
@@ -80,6 +80,7 @@ const MessageWrapper = (props: Props) => (
           <Box style={_textContainerStyle} className="message" data-message-key={props.messageKey}>
             <Box style={_flexOneColumn}>
               <props.innerClass
+                isActive={props.isActive}
                 messageKey={props.messageKey}
                 measure={props.measure}
                 onAction={props.onAction}

--- a/shared/util/pausable-connect.js
+++ b/shared/util/pausable-connect.js
@@ -10,6 +10,9 @@ function selectorFactory(dispatch, factoryOptions) {
   const pausableSelector = function(state, ownProps) {
     if (ownProps.isActive || cachedResult === undefined) {
       cachedResult = selector(state, ownProps)
+      cachedResult.isActive = ownProps.isActive
+    } else if (cachedResult.isActive !== ownProps.isActive) {
+      cachedResult = {...cachedResult, isActive: ownProps.isActive}
     }
     return cachedResult
   }


### PR DESCRIPTION
This is an unfinished experiment in passing `isActive` down through the chat list / message wrappers / message components. Wanted to share what this looks like while so we can determine whether it makes an appreciable positive or negative perf difference.
