### PR TITLE
Disallow team admins messing with owners

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -786,16 +786,24 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		if err != nil {
 			return res, err
 		}
-		switch signerRole {
-		case keybase1.TeamRole_ADMIN, keybase1.TeamRole_OWNER:
-			// ok
-		default:
-			return res, fmt.Errorf("link signer does not have permission to change membership: %v is a %v", signer, signerRole)
+		if !signerRole.IsAdminOrAbove() {
+			return res, fmt.Errorf("link signer does not have permission to change membership: %v is a %v",
+				signer, signerRole)
 		}
 
 		roleUpdates, err := t.sanityCheckMembers(*team.Members, false, true)
 		if err != nil {
 			return res, err
+		}
+
+		// Only owners can add more owners.
+		if (len(roleUpdates[keybase1.TeamRole_OWNER]) > 0) && (signerRole != keybase1.TeamRole_OWNER) {
+			return res, fmt.Errorf("non-owner cannot add owners")
+		}
+
+		// Only owners can remove owners.
+		if t.roleUpdatesDemoteOwners(prevState, roleUpdates) && (signerRole != keybase1.TeamRole_OWNER) {
+			return res, fmt.Errorf("non-owner cannot demote owners")
 		}
 
 		res.newState = prevState.DeepCopy()
@@ -1275,6 +1283,11 @@ func (t *TeamSigChainPlayer) sanityCheckInvites(invites SCTeamInvites) (addition
 	return additions, cancelations, nil
 }
 
+// A map describing an intent to change users's roles.
+// Each item means: change that user to that role.
+// To be clear: An omission does NOT mean to remove the existing role.
+type chainRoleUpdates map[keybase1.TeamRole][]keybase1.UserVersion
+
 // Check that all the users are formatted correctly.
 // Check that there are no duplicate members.
 // Do not check that all removals are members. That should be true, but not strictly enforced when reading.
@@ -1282,8 +1295,8 @@ func (t *TeamSigChainPlayer) sanityCheckInvites(invites SCTeamInvites) (addition
 // `allowRemovals` is whether removals are allowed.
 // `firstLink` is whether this is seqno=1. In which case owners must exist (for root team). And removals must not exist.
 // Rotates to a map which has entries for the roles that actually appeared in the input, even if they are empty lists.
-// In other words, if the input has only `admin -> []` then the output will have only `admin` in the map.
-func (t *TeamSigChainPlayer) sanityCheckMembers(members SCTeamMembers, requireOwners bool, allowRemovals bool) (map[keybase1.TeamRole][]keybase1.UserVersion, error) {
+// In other words, if the input has only `admin -> [...]` then the output will have only `admin` in the map.
+func (t *TeamSigChainPlayer) sanityCheckMembers(members SCTeamMembers, requireOwners bool, allowRemovals bool) (chainRoleUpdates, error) {
 	type assignment struct {
 		m    SCTeamMember
 		role keybase1.TeamRole
@@ -1356,6 +1369,26 @@ func (t *TeamSigChainPlayer) sanityCheckMembers(members SCTeamMembers, requireOw
 	return res, nil
 }
 
+// Whether the roleUpdates would demote any current owner to a lesser role.
+func (t *TeamSigChainPlayer) roleUpdatesDemoteOwners(prev *TeamSigChainState, roleUpdates map[keybase1.TeamRole][]keybase1.UserVersion) bool {
+	for toRole, uvs := range roleUpdates {
+		if toRole == keybase1.TeamRole_OWNER {
+			continue
+		}
+		for _, uv := range uvs {
+			fromRole, err := prev.GetUserRole(uv)
+			if err != nil {
+				continue // ignore error, user not in team
+			}
+			if fromRole == keybase1.TeamRole_OWNER {
+				// This is an intent to demote an owner.
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (t *TeamSigChainPlayer) checkPerTeamKey(link SCChainLink, perTeamKey SCPerTeamKey, expectedGeneration keybase1.PerTeamKeyGeneration) (res keybase1.PerTeamKey, err error) {
 	// check the per-team-key
 	if perTeamKey.Generation != expectedGeneration {
@@ -1396,7 +1429,7 @@ func (t *TeamSigChainPlayer) checkPerTeamKey(link SCChainLink, perTeamKey SCPerT
 // Update `userLog` with the membership in roleUpdates.
 // The `NONE` list removes users.
 // The other lists add users.
-func (t *TeamSigChainPlayer) updateMembership(stateToUpdate *TeamSigChainState, roleUpdates map[keybase1.TeamRole][]keybase1.UserVersion, sigMeta keybase1.SignatureMetadata) {
+func (t *TeamSigChainPlayer) updateMembership(stateToUpdate *TeamSigChainState, roleUpdates chainRoleUpdates, sigMeta keybase1.SignatureMetadata) {
 	for role, uvs := range roleUpdates {
 		for _, uv := range uvs {
 			stateToUpdate.inform(uv, role, sigMeta)

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -146,9 +146,14 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 }
 
 func (l *TeamLoader) checkArg(ctx context.Context, lArg keybase1.LoadTeamArg) error {
-	// TODO: stricter check on team ID format.
 	hasID := lArg.ID.Exists()
 	hasName := len(lArg.Name) > 0
+	if hasID {
+		_, err := keybase1.TeamIDFromString(lArg.ID.String())
+		if err != nil {
+			return fmt.Errorf("team load arg has invalid ID: %v", lArg.ID)
+		}
+	}
 	if !hasID && !hasName {
 		return fmt.Errorf("team load arg must have either ID or Name")
 	}

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -99,6 +99,7 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 		l.G().Log.CDebugf(ctx, "TeamLoader munge failed: %v", err)
 		// drop the error and just force a repoll.
 		mungedForceRepoll = true
+		mungedWantMembers = nil
 	}
 
 	var ret *keybase1.TeamData


### PR DESCRIPTION
- Disallow an admin self-promote themself to an owner
- Disallow an admin demoting any owner
- Disallow any mention of owners in subteams

I tested this manually by hacking the server and then making sigchain links that do these things, and then changing the client to reject them. There are no regression tests as that would require canned or invalid sigchains.

Luckily implicit admins have nothing to do with this because owners only exist on root teams.