### PR TITLE
Add team access request support

### DIFF
--- a/go/client/cmd_team.go
+++ b/go/client/cmd_team.go
@@ -24,6 +24,9 @@ func NewCmdTeam(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 			newCmdTeamLeave(cl, g),
 			newCmdTeamRename(cl, g),
 			newCmdTeamAcceptInvite(cl, g),
+			newCmdTeamRequestAccess(cl, g),
+			newCmdTeamIgnoreRequest(cl, g),
+			newCmdTeamListRequests(cl, g),
 		},
 	}
 }

--- a/go/client/cmd_team_ignore_request.go
+++ b/go/client/cmd_team_ignore_request.go
@@ -4,6 +4,8 @@ import (
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
 )
 
 type CmdTeamIgnoreRequest struct {
@@ -20,6 +22,12 @@ func newCmdTeamIgnoreRequest(cl *libcmdline.CommandLine, g *libkb.GlobalContext)
 		Action: func(c *cli.Context) {
 			cmd := NewCmdTeamIgnoreRequestRunner(g)
 			cl.ChooseCommand(cmd, "ignore-request", c)
+		},
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "u, user",
+				Usage: "username",
+			},
 		},
 	}
 }
@@ -49,10 +57,18 @@ func (c *CmdTeamIgnoreRequest) Run() error {
 		return err
 	}
 
-	_ = cli
+	arg := keybase1.TeamIgnoreRequestArg{
+		Name:     c.Team,
+		Username: c.Username,
+	}
+
+	err = cli.TeamIgnoreRequest(context.Background(), arg)
+	if err != nil {
+		return err
+	}
 
 	dui := c.G().UI.GetDumbOutputUI()
-	dui.Printf("done")
+	dui.Printf("Success! %s's request will be ignored.\n", c.Username)
 
 	return nil
 }

--- a/go/client/cmd_team_ignore_request.go
+++ b/go/client/cmd_team_ignore_request.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+type CmdTeamIgnoreRequest struct {
+	libkb.Contextified
+	Team     string
+	Username string
+}
+
+func newCmdTeamIgnoreRequest(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "ignore-request",
+		ArgumentHelp: "<team name> --user=<username>",
+		Usage:        "ignore request to join a team",
+		Action: func(c *cli.Context) {
+			cmd := NewCmdTeamIgnoreRequestRunner(g)
+			cl.ChooseCommand(cmd, "ignore-request", c)
+		},
+	}
+}
+
+func NewCmdTeamIgnoreRequestRunner(g *libkb.GlobalContext) *CmdTeamIgnoreRequest {
+	return &CmdTeamIgnoreRequest{Contextified: libkb.NewContextified(g)}
+}
+
+func (c *CmdTeamIgnoreRequest) ParseArgv(ctx *cli.Context) error {
+	var err error
+	c.Team, err = ParseOneTeamName(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.Username, err = ParseUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CmdTeamIgnoreRequest) Run() error {
+	cli, err := GetTeamsClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	_ = cli
+
+	dui := c.G().UI.GetDumbOutputUI()
+	dui.Printf("done")
+
+	return nil
+}
+
+func (c *CmdTeamIgnoreRequest) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/client/cmd_team_list_requests.go
+++ b/go/client/cmd_team_list_requests.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+type CmdTeamListRequests struct {
+	libkb.Contextified
+}
+
+func newCmdTeamListRequests(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "list-requests",
+		Usage: "list requests to join teams",
+		Action: func(c *cli.Context) {
+			cmd := NewCmdTeamListRequestsRunner(g)
+			cl.ChooseCommand(cmd, "list-requests", c)
+		},
+	}
+}
+
+func NewCmdTeamListRequestsRunner(g *libkb.GlobalContext) *CmdTeamListRequests {
+	return &CmdTeamListRequests{Contextified: libkb.NewContextified(g)}
+}
+
+func (c *CmdTeamListRequests) ParseArgv(ctx *cli.Context) error {
+	return nil
+}
+
+func (c *CmdTeamListRequests) Run() error {
+	cli, err := GetTeamsClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	_ = cli
+
+	dui := c.G().UI.GetDumbOutputUI()
+	dui.Printf("done")
+
+	return nil
+}
+
+func (c *CmdTeamListRequests) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/client/cmd_team_list_requests.go
+++ b/go/client/cmd_team_list_requests.go
@@ -1,9 +1,14 @@
 package client
 
 import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
+	"golang.org/x/net/context"
 )
 
 type CmdTeamListRequests struct {
@@ -35,10 +40,25 @@ func (c *CmdTeamListRequests) Run() error {
 		return err
 	}
 
-	_ = cli
+	reqs, err := cli.TeamListRequests(context.Background(), 0)
+	if err != nil {
+		return err
+	}
 
-	dui := c.G().UI.GetDumbOutputUI()
-	dui.Printf("done")
+	dui := c.G().UI.GetTerminalUI()
+	if len(reqs) == 0 {
+		dui.Printf("No requests at this time.\n")
+		return nil
+	}
+
+	tabw := new(tabwriter.Writer)
+	tabw.Init(dui.OutputWriter(), 0, 8, 2, ' ', 0)
+	for _, req := range reqs {
+		fmt.Fprintf(tabw, "%s\t%s wants to join\n", req.Name, req.Username)
+	}
+	tabw.Flush()
+	dui.Printf("%s\n", strings.Repeat("-", 70))
+	dui.Printf("To handle requests, use `keybase team add-member` or `keybase team ignore-request`.\n")
 
 	return nil
 }

--- a/go/client/cmd_team_request_access.go
+++ b/go/client/cmd_team_request_access.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+type CmdTeamRequestAccess struct {
+	libkb.Contextified
+	Team string
+}
+
+func newCmdTeamRequestAccess(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "request-access",
+		ArgumentHelp: "<team name>",
+		Usage:        "request access to a team",
+		Action: func(c *cli.Context) {
+			cmd := NewCmdTeamRequestAccessRunner(g)
+			cl.ChooseCommand(cmd, "request-access", c)
+		},
+	}
+}
+
+func NewCmdTeamRequestAccessRunner(g *libkb.GlobalContext) *CmdTeamRequestAccess {
+	return &CmdTeamRequestAccess{Contextified: libkb.NewContextified(g)}
+}
+
+func (c *CmdTeamRequestAccess) ParseArgv(ctx *cli.Context) error {
+	var err error
+	c.Team, err = ParseOneTeamName(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CmdTeamRequestAccess) Run() error {
+	cli, err := GetTeamsClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	_ = cli
+
+	dui := c.G().UI.GetDumbOutputUI()
+	dui.Printf("done")
+
+	return nil
+}
+
+func (c *CmdTeamRequestAccess) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/client/cmd_team_request_access.go
+++ b/go/client/cmd_team_request_access.go
@@ -4,6 +4,8 @@ import (
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
 )
 
 type CmdTeamRequestAccess struct {
@@ -43,10 +45,17 @@ func (c *CmdTeamRequestAccess) Run() error {
 		return err
 	}
 
-	_ = cli
+	arg := keybase1.TeamRequestAccessArg{
+		Name: c.Team,
+	}
+
+	err = cli.TeamRequestAccess(context.Background(), arg)
+	if err != nil {
+		return err
+	}
 
 	dui := c.G().UI.GetDumbOutputUI()
-	dui.Printf("done")
+	dui.Printf("An email has been sent to the admins of %s.\n", c.Team)
 
 	return nil
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -251,6 +251,9 @@ const (
 	SCChatClientError          = int(keybase1.StatusCode_SCChatClientError)
 	SCAccountReset             = int(keybase1.StatusCode_SCAccountReset)
 	SCTeamReadError            = int(keybase1.StatusCode_SCTeamReadError)
+	SCTeamTarDuplicate         = int(keybase1.StatusCode_SCTeamTarDuplicate)
+	SCTeamTarNotFound          = int(keybase1.StatusCode_SCTeamTarNotFound)
+	SCTeamMemberExists         = int(keybase1.StatusCode_SCTeamMemberExists)
 )
 
 const (

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -104,6 +104,9 @@ const (
 	StatusCode_SCChatClientError          StatusCode = 2516
 	StatusCode_SCChatNotInTeam            StatusCode = 2517
 	StatusCode_SCTeamReadError            StatusCode = 2623
+	StatusCode_SCTeamTarDuplicate         StatusCode = 2663
+	StatusCode_SCTeamTarNotFound          StatusCode = 2664
+	StatusCode_SCTeamMemberExists         StatusCode = 2665
 )
 
 func (o StatusCode) DeepCopy() StatusCode { return o }
@@ -203,6 +206,9 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCChatClientError":          2516,
 	"SCChatNotInTeam":            2517,
 	"SCTeamReadError":            2623,
+	"SCTeamTarDuplicate":         2663,
+	"SCTeamTarNotFound":          2664,
+	"SCTeamMemberExists":         2665,
 }
 
 var StatusCodeRevMap = map[StatusCode]string{
@@ -300,6 +306,9 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2516: "SCChatClientError",
 	2517: "SCChatNotInTeam",
 	2623: "SCTeamReadError",
+	2663: "SCTeamTarDuplicate",
+	2664: "SCTeamTarNotFound",
+	2665: "SCTeamMemberExists",
 }
 
 func (e StatusCode) String() string {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -116,15 +116,15 @@ func (h *TeamsHandler) TeamAcceptInvite(ctx context.Context, arg keybase1.TeamAc
 }
 
 func (h *TeamsHandler) TeamRequestAccess(ctx context.Context, arg keybase1.TeamRequestAccessArg) error {
-	return nil
+	return teams.RequestAccess(ctx, h.G().ExternalG(), arg.Name)
 }
 
 func (h *TeamsHandler) TeamListRequests(ctx context.Context, sessionID int) ([]keybase1.TeamJoinRequest, error) {
-	return nil, nil
+	return teams.ListRequests(ctx, h.G().ExternalG())
 }
 
 func (h *TeamsHandler) TeamIgnoreRequest(ctx context.Context, arg keybase1.TeamIgnoreRequestArg) error {
-	return nil
+	return teams.IgnoreRequest(ctx, h.G().ExternalG(), arg.Name, arg.Username)
 }
 
 func (h *TeamsHandler) LoadTeamPlusApplicationKeys(netCtx context.Context, arg keybase1.LoadTeamPlusApplicationKeysArg) (keybase1.TeamPlusApplicationKeys, error) {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -115,6 +115,18 @@ func (h *TeamsHandler) TeamAcceptInvite(ctx context.Context, arg keybase1.TeamAc
 	return teams.AcceptInvite(ctx, h.G().ExternalG(), arg.Token)
 }
 
+func (h *TeamsHandler) TeamRequestAccess(ctx context.Context, arg keybase1.TeamRequestAccessArg) error {
+	return nil
+}
+
+func (h *TeamsHandler) TeamListRequests(ctx context.Context, sessionID int) ([]keybase1.TeamJoinRequest, error) {
+	return nil, nil
+}
+
+func (h *TeamsHandler) TeamIgnoreRequest(ctx context.Context, arg keybase1.TeamIgnoreRequestArg) error {
+	return nil
+}
+
 func (h *TeamsHandler) LoadTeamPlusApplicationKeys(netCtx context.Context, arg keybase1.LoadTeamPlusApplicationKeysArg) (keybase1.TeamPlusApplicationKeys, error) {
 	netCtx = libkb.WithLogTag(netCtx, "LTPAK")
 	h.G().Log.CDebugf(netCtx, "+ TeamHandler#LoadTeamPlusApplicationKeys(%+v)", arg)

--- a/go/teams/request_test.go
+++ b/go/teams/request_test.go
@@ -1,0 +1,154 @@
+package teams
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+
+	"golang.org/x/net/context"
+)
+
+func TestAccessRequestAccept(t *testing.T) {
+	tc, owner, u1, _, teamName := memberSetupMultiple(t)
+	defer tc.Cleanup()
+
+	// owner is logged in and created teamName
+	tc.G.Logout()
+
+	// u1 requests access to the team
+	if err := u1.Login(tc.G); err != nil {
+		t.Fatal(err)
+	}
+	if err := RequestAccess(context.Background(), tc.G, teamName); err != nil {
+		t.Fatal(err)
+	}
+
+	// owner lists requests, sees u1 request
+	tc.G.Logout()
+	if err := owner.Login(tc.G); err != nil {
+		t.Fatal(err)
+	}
+	reqs, err := ListRequests(context.Background(), tc.G)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 1 {
+		t.Fatalf("num requests: %d, expected 1", len(reqs))
+	}
+	if reqs[0].Name != teamName {
+		t.Errorf("request team name: %q, expected %q", reqs[0].Name, teamName)
+	}
+	if reqs[0].Username != u1.Username {
+		t.Errorf("request username: %q, expected %q", reqs[0].Username, u1.Username)
+	}
+
+	// owner add u1 to team
+	if _, err := AddMember(context.Background(), tc.G, teamName, u1.Username, keybase1.TeamRole_WRITER); err != nil {
+		t.Fatal(err)
+	}
+
+	// owner lists requests, sees no requests
+	assertNoRequests(tc)
+
+	// u1 requests access to the team again
+	tc.G.Logout()
+	if err := u1.Login(tc.G); err != nil {
+		t.Fatal(err)
+	}
+	err = RequestAccess(context.Background(), tc.G, teamName)
+	if err == nil {
+		t.Fatal("second RequestAccess success, expected error")
+	}
+	aerr, ok := err.(libkb.AppStatusError)
+	if !ok {
+		t.Fatalf("error %s (%T), expected libkb.AppStatusError", err, err)
+	}
+	if aerr.Code != libkb.SCTeamMemberExists {
+		t.Errorf("status code: %d, expected %d", aerr.Code, libkb.SCTeamMemberExists)
+	}
+	tc.G.Logout()
+
+	// owner lists requests, sees no requests
+	if err := owner.Login(tc.G); err != nil {
+		t.Fatal(err)
+	}
+	assertNoRequests(tc)
+}
+
+func TestAccessRequestIgnore(t *testing.T) {
+	tc, owner, u1, _, teamName := memberSetupMultiple(t)
+	defer tc.Cleanup()
+
+	// owner is logged in and created teamName
+	tc.G.Logout()
+
+	// u1 requests access to the team
+	if err := u1.Login(tc.G); err != nil {
+		t.Fatal(err)
+	}
+	if err := RequestAccess(context.Background(), tc.G, teamName); err != nil {
+		t.Fatal(err)
+	}
+
+	// owner lists requests, sees u1 request
+	tc.G.Logout()
+	if err := owner.Login(tc.G); err != nil {
+		t.Fatal(err)
+	}
+	reqs, err := ListRequests(context.Background(), tc.G)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 1 {
+		t.Fatalf("num requests: %d, expected 1", len(reqs))
+	}
+	if reqs[0].Name != teamName {
+		t.Errorf("request team name: %q, expected %q", reqs[0].Name, teamName)
+	}
+	if reqs[0].Username != u1.Username {
+		t.Errorf("request username: %q, expected %q", reqs[0].Username, u1.Username)
+	}
+
+	// owner ignores u1 request
+	if err := IgnoreRequest(context.Background(), tc.G, reqs[0].Name, reqs[0].Username); err != nil {
+		t.Fatal(err)
+	}
+
+	// owner lists requests, sees no requests
+	assertNoRequests(tc)
+
+	// u1 requests access to the team again
+	tc.G.Logout()
+	if err := u1.Login(tc.G); err != nil {
+		t.Fatal(err)
+	}
+	err = RequestAccess(context.Background(), tc.G, teamName)
+	if err == nil {
+		t.Fatal("second RequestAccess success, expected error")
+	}
+	aerr, ok := err.(libkb.AppStatusError)
+	if !ok {
+		t.Fatalf("error %s (%T), expected libkb.AppStatusError", err, err)
+	}
+	if aerr.Code != libkb.SCTeamTarDuplicate {
+		t.Errorf("status code: %d, expected %d", aerr.Code, libkb.SCTeamTarDuplicate)
+	}
+	tc.G.Logout()
+
+	// owner lists requests, sees no requests
+	if err := owner.Login(tc.G); err != nil {
+		t.Fatal(err)
+	}
+	assertNoRequests(tc)
+}
+
+func assertNoRequests(tc libkb.TestContext) {
+	reqs, err := ListRequests(context.Background(), tc.G)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	if len(reqs) != 0 {
+		tc.T.Fatalf("num requests: %d, expected 0", len(reqs))
+	}
+}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -227,10 +227,8 @@ func Leave(ctx context.Context, g *libkb.GlobalContext, teamname string, permane
 }
 
 func AcceptInvite(ctx context.Context, g *libkb.GlobalContext, token string) error {
-	arg := libkb.NewAPIArg("team/token")
-	arg.Args = libkb.NewHTTPArgs()
+	arg := apiArg(ctx, "team/token")
 	arg.Args.Add("token", libkb.S{Val: token})
-	arg.SessionType = libkb.APISessionTypeREQUIRED
 	_, err := g.API.Post(arg)
 	return err
 }
@@ -383,13 +381,79 @@ func MemberInvite(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 }
 
 func RequestAccess(ctx context.Context, g *libkb.GlobalContext, teamname string) error {
-	return nil
+	arg := apiArg(ctx, "team/request_access")
+	arg.Args.Add("team", libkb.S{Val: teamname})
+	_, err := g.API.Post(arg)
+	return err
+}
+
+/*
+ "requests": [
+		        {
+		            "fq_name": "b6649e87",
+		            "team_id": "24d1a710564a4b8df341ce2b89a3c024",
+		            "uid": "7043f764ebac3571d30bafc3cc7f1d19",
+		            "username": "team_403bf36fda"
+		        }
+		    ],
+*/
+
+type accessRequest struct {
+	FQName   string          `json:"fq_name"`
+	TeamID   keybase1.TeamID `json:"team_id"`
+	UID      keybase1.UID    `json:"uid"`
+	Username string          `json:"username"`
+}
+
+type accessRequestList struct {
+	Requests []accessRequest `json:"requests"`
+	Status   libkb.AppStatus `json:"status"`
+}
+
+func (r *accessRequestList) GetAppStatus() *libkb.AppStatus {
+	return &r.Status
 }
 
 func ListRequests(ctx context.Context, g *libkb.GlobalContext) ([]keybase1.TeamJoinRequest, error) {
-	return nil, nil
+	// team/laar GET
+	arg := apiArg(ctx, "team/laar")
+
+	var arList accessRequestList
+	if err := g.API.GetDecode(arg, &arList); err != nil {
+		return nil, err
+	}
+
+	joinRequests := make([]keybase1.TeamJoinRequest, len(arList.Requests))
+	for i, ar := range arList.Requests {
+		joinRequests[i] = keybase1.TeamJoinRequest{
+			Name:     ar.FQName,
+			Username: ar.Username,
+		}
+	}
+
+	return joinRequests, nil
 }
 
 func IgnoreRequest(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	return nil
+	uv, err := loadUserVersionByUsername(ctx, g, username)
+	if err != nil {
+		if err == errInviteRequired {
+			return libkb.NotFoundError{
+				Msg: fmt.Sprintf("No keybase user found (%s)", username),
+			}
+		}
+		return err
+	}
+	arg := apiArg(ctx, "team/deny_access")
+	arg.Args.Add("team", libkb.S{Val: teamname})
+	arg.Args.Add("uid", libkb.S{Val: uv.Uid.String()})
+	_, err = g.API.Post(arg)
+	return err
+}
+
+func apiArg(ctx context.Context, endpoint string) libkb.APIArg {
+	arg := libkb.NewAPIArgWithNetContext(ctx, endpoint)
+	arg.Args = libkb.NewHTTPArgs()
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	return arg
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -381,3 +381,15 @@ func MemberInvite(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 	}
 	return t.chain().FindActiveInvite(username, typ)
 }
+
+func RequestAccess(ctx context.Context, g *libkb.GlobalContext, teamname string) error {
+	return nil
+}
+
+func ListRequests(ctx context.Context, g *libkb.GlobalContext) ([]keybase1.TeamJoinRequest, error) {
+	return nil, nil
+}
+
+func IgnoreRequest(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
+	return nil
+}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -387,17 +387,6 @@ func RequestAccess(ctx context.Context, g *libkb.GlobalContext, teamname string)
 	return err
 }
 
-/*
- "requests": [
-		        {
-		            "fq_name": "b6649e87",
-		            "team_id": "24d1a710564a4b8df341ce2b89a3c024",
-		            "uid": "7043f764ebac3571d30bafc3cc7f1d19",
-		            "username": "team_403bf36fda"
-		        }
-		    ],
-*/
-
 type accessRequest struct {
 	FQName   string          `json:"fq_name"`
 	TeamID   keybase1.TeamID `json:"team_id"`
@@ -415,7 +404,6 @@ func (r *accessRequestList) GetAppStatus() *libkb.AppStatus {
 }
 
 func ListRequests(ctx context.Context, g *libkb.GlobalContext) ([]keybase1.TeamJoinRequest, error) {
-	// team/laar GET
 	arg := apiArg(ctx, "team/laar")
 
 	var arList accessRequestList

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -95,7 +95,10 @@ protocol constants {
     SCChatDuplicateMessage_2515,
     SCChatClientError_2516,
     SCChatNotInTeam_2517,
-    SCTeamReadError_2623
+    SCTeamReadError_2623,
+    SCTeamTarDuplicate_2663,
+    SCTeamTarNotFound_2664,
+    SCTeamMemberExists_2665
   }
 
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -330,6 +330,11 @@ protocol teams {
     boolean chatSent;
   }
 
+  record TeamJoinRequest {
+    string name;
+    string username;
+  }
+
   void teamCreate(int sessionID, TeamName name);
   void teamCreateSubteam(int sessionID, TeamName name);
   TeamDetails teamGet(int sessionID, string name, boolean forceRepoll);
@@ -341,6 +346,9 @@ protocol teams {
   void teamEditMember(int sessionID, string name, string username, TeamRole role);
   void teamRename(int sessionID, TeamName prevName, TeamName newName);
   void teamAcceptInvite(int sessionID, string token);
+  void teamRequestAccess(int sessionID, string name); 
+  array<TeamJoinRequest> teamListRequests(int sessionID);
+  void teamIgnoreRequest(int sessionID, string name, string username);
 
   /**
    * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3644,6 +3644,21 @@ export function teamsTeamGetRpcPromise (request: $Exact<requestCommon & {callbac
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamGet', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamIgnoreRequestRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamIgnoreRequestRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.teamIgnoreRequest', request)
+}
+
+export function teamsTeamIgnoreRequestRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamIgnoreRequestRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamIgnoreRequest', request)
+}
+export function teamsTeamIgnoreRequestRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamIgnoreRequestRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamIgnoreRequest', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamIgnoreRequestRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamIgnoreRequestRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamIgnoreRequest', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamLeaveRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamLeaveRpcParam}>) {
   engineRpcOutgoing('keybase.1.teams.teamLeave', request)
 }
@@ -3657,6 +3672,21 @@ export function teamsTeamLeaveRpcChannelMapOld (channelConfig: ChannelConfig<*>,
 
 export function teamsTeamLeaveRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamLeaveRpcParam}>): Promise<void> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamLeave', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function teamsTeamListRequestsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamListRequestsResult) => void}>) {
+  engineRpcOutgoing('keybase.1.teams.teamListRequests', request)
+}
+
+export function teamsTeamListRequestsRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamListRequestsResult) => void}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListRequests', request)
+}
+export function teamsTeamListRequestsRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamListRequestsResult) => void}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamListRequests', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamListRequestsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamListRequestsResult) => void}>): Promise<teamsTeamListRequestsResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamListRequests', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function teamsTeamListRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamListResult) => void} & {param: teamsTeamListRpcParam}>) {
@@ -3702,6 +3732,21 @@ export function teamsTeamRenameRpcChannelMapOld (channelConfig: ChannelConfig<*>
 
 export function teamsTeamRenameRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRenameRpcParam}>): Promise<void> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRename', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function teamsTeamRequestAccessRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.teamRequestAccess', request)
+}
+
+export function teamsTeamRequestAccessRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamRequestAccess', request)
+}
+export function teamsTeamRequestAccessRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamRequestAccess', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamRequestAccessRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRequestAccess', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function testPanicRpc (request: Exact<requestCommon & requestErrorCallback & {param: testPanicRpcParam}>) {
@@ -6043,6 +6088,11 @@ export type TeamInvitee = {
   role: TeamRole,
 }
 
+export type TeamJoinRequest = {
+  name: string,
+  username: string,
+}
+
 export type TeamList = {
   uid: UID,
   username: string,
@@ -7271,6 +7321,11 @@ export type teamsTeamGetRpcParam = Exact<{
   forceRepoll: boolean
 }>
 
+export type teamsTeamIgnoreRequestRpcParam = Exact<{
+  name: string,
+  username: string
+}>
+
 export type teamsTeamLeaveRpcParam = Exact<{
   name: string,
   permanent: boolean
@@ -7288,6 +7343,10 @@ export type teamsTeamRemoveMemberRpcParam = Exact<{
 export type teamsTeamRenameRpcParam = Exact<{
   prevName: TeamName,
   newName: TeamName
+}>
+
+export type teamsTeamRequestAccessRpcParam = Exact<{
+  name: string
 }>
 
 export type testPanicRpcParam = Exact<{
@@ -7534,6 +7593,7 @@ type streamUiWriteResult = int
 type teamsLoadTeamPlusApplicationKeysResult = TeamPlusApplicationKeys
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamGetResult = TeamDetails
+type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = TeamList
 type testTestCallbackResult = string
 type testTestResult = Test
@@ -7767,10 +7827,13 @@ export type rpc =
   | teamsTeamCreateSubteamRpc
   | teamsTeamEditMemberRpc
   | teamsTeamGetRpc
+  | teamsTeamIgnoreRequestRpc
   | teamsTeamLeaveRpc
+  | teamsTeamListRequestsRpc
   | teamsTeamListRpc
   | teamsTeamRemoveMemberRpc
   | teamsTeamRenameRpc
+  | teamsTeamRequestAccessRpc
   | testPanicRpc
   | testTestCallbackRpc
   | testTestRpc

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -206,6 +206,9 @@ export const ConstantsStatusCode = {
   scchatclienterror: 2516,
   scchatnotinteam: 2517,
   scteamreaderror: 2623,
+  scteamtarduplicate: 2663,
+  scteamtarnotfound: 2664,
+  scteammemberexists: 2665,
 }
 
 export const CtlDbType = {
@@ -5946,6 +5949,9 @@ export type StatusCode =
   | 2516 // SCChatClientError_2516
   | 2517 // SCChatNotInTeam_2517
   | 2623 // SCTeamReadError_2623
+  | 2663 // SCTeamTarDuplicate_2663
+  | 2664 // SCTeamTarNotFound_2664
+  | 2665 // SCTeamMemberExists_2665
 
 export type Stream = {
   fd: int,

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -99,7 +99,10 @@
         "SCChatDuplicateMessage_2515",
         "SCChatClientError_2516",
         "SCChatNotInTeam_2517",
-        "SCTeamReadError_2623"
+        "SCTeamReadError_2623",
+        "SCTeamTarDuplicate_2663",
+        "SCTeamTarNotFound_2664",
+        "SCTeamMemberExists_2665"
       ]
     }
   ],

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -832,6 +832,20 @@
           "name": "chatSent"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "TeamJoinRequest",
+      "fields": [
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "string",
+          "name": "username"
+        }
+      ]
     }
   ],
   "messages": {
@@ -1017,6 +1031,48 @@
         },
         {
           "name": "token",
+          "type": "string"
+        }
+      ],
+      "response": null
+    },
+    "teamRequestAccess": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        }
+      ],
+      "response": null
+    },
+    "teamListRequests": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": {
+        "type": "array",
+        "items": "TeamJoinRequest"
+      }
+    },
+    "teamIgnoreRequest": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "username",
           "type": "string"
         }
       ],

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3644,6 +3644,21 @@ export function teamsTeamGetRpcPromise (request: $Exact<requestCommon & {callbac
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamGet', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamIgnoreRequestRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamIgnoreRequestRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.teamIgnoreRequest', request)
+}
+
+export function teamsTeamIgnoreRequestRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamIgnoreRequestRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamIgnoreRequest', request)
+}
+export function teamsTeamIgnoreRequestRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamIgnoreRequestRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamIgnoreRequest', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamIgnoreRequestRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamIgnoreRequestRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamIgnoreRequest', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamLeaveRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamLeaveRpcParam}>) {
   engineRpcOutgoing('keybase.1.teams.teamLeave', request)
 }
@@ -3657,6 +3672,21 @@ export function teamsTeamLeaveRpcChannelMapOld (channelConfig: ChannelConfig<*>,
 
 export function teamsTeamLeaveRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamLeaveRpcParam}>): Promise<void> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamLeave', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function teamsTeamListRequestsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamListRequestsResult) => void}>) {
+  engineRpcOutgoing('keybase.1.teams.teamListRequests', request)
+}
+
+export function teamsTeamListRequestsRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamListRequestsResult) => void}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListRequests', request)
+}
+export function teamsTeamListRequestsRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamListRequestsResult) => void}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamListRequests', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamListRequestsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamListRequestsResult) => void}>): Promise<teamsTeamListRequestsResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamListRequests', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function teamsTeamListRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: teamsTeamListResult) => void} & {param: teamsTeamListRpcParam}>) {
@@ -3702,6 +3732,21 @@ export function teamsTeamRenameRpcChannelMapOld (channelConfig: ChannelConfig<*>
 
 export function teamsTeamRenameRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRenameRpcParam}>): Promise<void> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRename', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function teamsTeamRequestAccessRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.teamRequestAccess', request)
+}
+
+export function teamsTeamRequestAccessRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamRequestAccess', request)
+}
+export function teamsTeamRequestAccessRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.teamRequestAccess', request, callback, incomingCallMap) })
+}
+
+export function teamsTeamRequestAccessRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRequestAccess', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function testPanicRpc (request: Exact<requestCommon & requestErrorCallback & {param: testPanicRpcParam}>) {
@@ -6043,6 +6088,11 @@ export type TeamInvitee = {
   role: TeamRole,
 }
 
+export type TeamJoinRequest = {
+  name: string,
+  username: string,
+}
+
 export type TeamList = {
   uid: UID,
   username: string,
@@ -7271,6 +7321,11 @@ export type teamsTeamGetRpcParam = Exact<{
   forceRepoll: boolean
 }>
 
+export type teamsTeamIgnoreRequestRpcParam = Exact<{
+  name: string,
+  username: string
+}>
+
 export type teamsTeamLeaveRpcParam = Exact<{
   name: string,
   permanent: boolean
@@ -7288,6 +7343,10 @@ export type teamsTeamRemoveMemberRpcParam = Exact<{
 export type teamsTeamRenameRpcParam = Exact<{
   prevName: TeamName,
   newName: TeamName
+}>
+
+export type teamsTeamRequestAccessRpcParam = Exact<{
+  name: string
 }>
 
 export type testPanicRpcParam = Exact<{
@@ -7534,6 +7593,7 @@ type streamUiWriteResult = int
 type teamsLoadTeamPlusApplicationKeysResult = TeamPlusApplicationKeys
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamGetResult = TeamDetails
+type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = TeamList
 type testTestCallbackResult = string
 type testTestResult = Test
@@ -7767,10 +7827,13 @@ export type rpc =
   | teamsTeamCreateSubteamRpc
   | teamsTeamEditMemberRpc
   | teamsTeamGetRpc
+  | teamsTeamIgnoreRequestRpc
   | teamsTeamLeaveRpc
+  | teamsTeamListRequestsRpc
   | teamsTeamListRpc
   | teamsTeamRemoveMemberRpc
   | teamsTeamRenameRpc
+  | teamsTeamRequestAccessRpc
   | testPanicRpc
   | testTestCallbackRpc
   | testTestRpc

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -206,6 +206,9 @@ export const ConstantsStatusCode = {
   scchatclienterror: 2516,
   scchatnotinteam: 2517,
   scteamreaderror: 2623,
+  scteamtarduplicate: 2663,
+  scteamtarnotfound: 2664,
+  scteammemberexists: 2665,
 }
 
 export const CtlDbType = {
@@ -5946,6 +5949,9 @@ export type StatusCode =
   | 2516 // SCChatClientError_2516
   | 2517 // SCChatNotInTeam_2517
   | 2623 // SCTeamReadError_2623
+  | 2663 // SCTeamTarDuplicate_2663
+  | 2664 // SCTeamTarNotFound_2664
+  | 2665 // SCTeamMemberExists_2665
 
 export type Stream = {
   fd: int,


### PR DESCRIPTION
This adds all the client support for team access requests, including three commands

1. `keybase team request-access`
1. `keybase team list-requests`
1. `keybase team ignore-request`

