### PR TITLE
Try out GitHub's code owners feature

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+shared/*            @keybase/react-hackers


### PR DESCRIPTION
According to https://github.com/blog/2392-introducing-code-owners, this will automatically ask @keybase/react-hackers for a review (not sure how asking a group for a review actually works) each time a PR touches a file inside shared/.

We might want to use this format:
```
*         @keybase/core-hackers
shared/*  @keybase/react-hackers
```

Which says to tag core-hackers *unless* there's a JS change, and if so then only tag react-hackers.

.. ah, we don't actually have a core-hackers group yet though.  Would have to get one of those.