### PR TITLE
add a stale update descriptor to give more information about the status of the thread CORE-5098

### DIFF
--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -57,7 +57,7 @@ func (c *ConversationRetry) String() string {
 func (c *ConversationRetry) SendStale(ctx context.Context, uid gregor1.UID) {
 	supdates := []chat1.ConversationStaleUpdate{chat1.ConversationStaleUpdate{
 		ConvID:     c.convID,
-		UpdateType: chat1.StaleUpdateType_CLEAR,
+		UpdateType: chat1.StaleUpdateType_NEWACTIVITY,
 	}}
 	c.G().Syncer.SendChatStaleNotifications(ctx, uid, supdates, false)
 }

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -55,7 +55,11 @@ func (c *ConversationRetry) String() string {
 }
 
 func (c *ConversationRetry) SendStale(ctx context.Context, uid gregor1.UID) {
-	c.G().Syncer.SendChatStaleNotifications(ctx, uid, []chat1.ConversationID{c.convID}, false)
+	supdates := []chat1.ConversationStaleUpdate{chat1.ConversationStaleUpdate{
+		ConvID:     c.convID,
+		UpdateType: chat1.StaleUpdateType_CLEAR,
+	}}
+	c.G().Syncer.SendChatStaleNotifications(ctx, uid, supdates, false)
 }
 
 func (c *ConversationRetry) Fix(ctx context.Context, uid gregor1.UID) error {

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -67,7 +67,7 @@ func TestFetchRetry(t *testing.T) {
 	select {
 	case updates := <-list.threadsStale:
 		require.Equal(t, 1, len(updates))
-		require.Equal(t, chat1.StaleUpdateType_CLEAR, updates[0].UpdateType)
+		require.Equal(t, chat1.StaleUpdateType_NEWACTIVITY, updates[0].UpdateType)
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "timeout on inbox stale")
 	}

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -65,8 +65,9 @@ func TestFetchRetry(t *testing.T) {
 	tc.ChatG.ConvSource.SetRemoteInterface(rifunc)
 	world.Fc.Advance(time.Hour)
 	select {
-	case cids := <-list.threadsStale:
-		require.Equal(t, 1, len(cids))
+	case updates := <-list.threadsStale:
+		require.Equal(t, 1, len(updates))
+		require.Equal(t, chat1.StaleUpdateType_CLEAR, updates[0].UpdateType)
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "timeout on inbox stale")
 	}

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -29,7 +29,7 @@ type chatListener struct {
 	failing        chan []chat1.OutboxRecord
 	identifyUpdate chan keybase1.CanonicalTLFNameAndIDWithBreaks
 	inboxStale     chan struct{}
-	threadsStale   chan []chat1.ConversationID
+	threadsStale   chan []chat1.ConversationStaleUpdate
 	bgConvLoads    chan chat1.ConversationID
 	typingUpdate   chan []chat1.ConvTypingUpdate
 }
@@ -69,9 +69,9 @@ func (n *chatListener) ChatInboxStale(uid keybase1.UID) {
 	}
 }
 
-func (n *chatListener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {
+func (n *chatListener) ChatThreadsStale(uid keybase1.UID, updates []chat1.ConversationStaleUpdate) {
 	select {
-	case n.threadsStale <- cids:
+	case n.threadsStale <- updates:
 	case <-time.After(5 * time.Second):
 		panic("timeout on the threads stale channel")
 	}
@@ -171,7 +171,7 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 		failing:        make(chan []chat1.OutboxRecord),
 		identifyUpdate: make(chan keybase1.CanonicalTLFNameAndIDWithBreaks),
 		inboxStale:     make(chan struct{}, 1),
-		threadsStale:   make(chan []chat1.ConversationID, 1),
+		threadsStale:   make(chan []chat1.ConversationStaleUpdate, 1),
 		bgConvLoads:    make(chan chat1.ConversationID, 10),
 		typingUpdate:   make(chan []chat1.ConvTypingUpdate, 10),
 	}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1698,8 +1698,9 @@ func TestChatSrvGetThreadNonblockError(t *testing.T) {
 		ctc.world.Fc.Advance(time.Hour)
 
 		select {
-		case cids := <-listener.threadsStale:
-			require.Equal(t, 1, len(cids))
+		case updates := <-listener.threadsStale:
+			require.Equal(t, 1, len(updates))
+			require.Equal(t, chat1.StaleUpdateType_NEWACTIVITY, updates[0].UpdateType)
 		case <-time.After(2 * time.Second):
 			require.Fail(t, "no threads stale message received")
 		}
@@ -1766,8 +1767,9 @@ func TestChatSrvGetInboxNonblockError(t *testing.T) {
 		ctc.world.Fc.Advance(time.Hour)
 
 		select {
-		case cids := <-listener.threadsStale:
-			require.Equal(t, 1, len(cids))
+		case updates := <-listener.threadsStale:
+			require.Equal(t, 1, len(updates))
+			require.Equal(t, chat1.StaleUpdateType_CLEAR, updates[0].UpdateType)
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no threads stale message received")
 		}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1769,7 +1769,7 @@ func TestChatSrvGetInboxNonblockError(t *testing.T) {
 		select {
 		case updates := <-listener.threadsStale:
 			require.Equal(t, 1, len(updates))
-			require.Equal(t, chat1.StaleUpdateType_CLEAR, updates[0].UpdateType)
+			require.Equal(t, chat1.StaleUpdateType_NEWACTIVITY, updates[0].UpdateType)
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no threads stale message received")
 		}

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -150,9 +150,10 @@ func TestSyncerConnected(t *testing.T) {
 	default:
 	}
 	select {
-	case cids := <-list.threadsStale:
-		require.Equal(t, 1, len(cids))
-		require.Equal(t, convs[1].GetConvID(), cids[0])
+	case updates := <-list.threadsStale:
+		require.Equal(t, 1, len(updates))
+		require.Equal(t, convs[1].GetConvID(), updates[0].ConvID)
+		require.Equal(t, chat1.StaleUpdateType_NEWACTIVITY, updates[0].UpdateType)
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no threads stale received")
 	}

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -243,8 +243,9 @@ func TestSyncerAppState(t *testing.T) {
 
 	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
 	select {
-	case cids := <-list.threadsStale:
-		require.Equal(t, 1, len(cids))
+	case updates := <-list.threadsStale:
+		require.Equal(t, 1, len(updates))
+		require.Equal(t, chat1.StaleUpdateType_NEWACTIVITY, updates[0].UpdateType)
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no stale messages")
 	}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -112,8 +112,8 @@ type Syncer interface {
 	Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
 		syncRes *chat1.SyncChatRes) error
 	RegisterOfflinable(offlinable Offlinable)
-	SendChatStaleNotifications(ctx context.Context, uid gregor1.UID, convIDs []chat1.ConversationID,
-		immediate bool)
+	SendChatStaleNotifications(ctx context.Context, uid gregor1.UID,
+		updates []chat1.ConversationStaleUpdate, immediate bool)
 	Shutdown()
 }
 

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -110,10 +110,10 @@ func (n *nlistener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationI
 }
 func (n *nlistener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {
 }
-func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                       {}
-func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID)        {}
-func (n *nlistener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate)                     {}
-func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal) {}
-func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)    {}
+func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                         {}
+func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationStaleUpdate) {}
+func (n *nlistener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate)                       {}
+func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal)   {}
+func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)      {}
 func (n *nlistener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -47,7 +47,7 @@ type NotifyListener interface {
 	ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID,
 		resolveInfo chat1.ConversationResolveInfo)
 	ChatInboxStale(uid keybase1.UID)
-	ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID)
+	ChatThreadsStale(uid keybase1.UID, updates []chat1.ConversationStaleUpdate)
 	ChatTypingUpdate([]chat1.ConvTypingUpdate)
 	ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal)
 	ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)
@@ -619,7 +619,7 @@ func (n *NotifyRouter) HandleChatInboxStale(ctx context.Context, uid keybase1.UI
 }
 
 func (n *NotifyRouter) HandleChatThreadsStale(ctx context.Context, uid keybase1.UID,
-	threads []chat1.ConversationID) {
+	updates []chat1.ConversationStaleUpdate) {
 	if n == nil {
 		return
 	}
@@ -633,7 +633,7 @@ func (n *NotifyRouter) HandleChatThreadsStale(ctx context.Context, uid keybase1.
 					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).ChatThreadsStale(context.Background(), chat1.ChatThreadsStaleArg{
 					Uid:     uid,
-					ConvIDs: threads,
+					Updates: updates,
 				})
 				wg.Done()
 			}()
@@ -642,7 +642,7 @@ func (n *NotifyRouter) HandleChatThreadsStale(ctx context.Context, uid keybase1.
 	})
 	wg.Wait()
 	if n.listener != nil {
-		n.listener.ChatThreadsStale(uid, threads)
+		n.listener.ChatThreadsStale(uid, updates)
 	}
 	n.G().Log.CDebugf(ctx, "- Sent ChatThreadsStale notification")
 }

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -440,6 +440,44 @@ func (o ConvTypingUpdate) DeepCopy() ConvTypingUpdate {
 	}
 }
 
+type StaleUpdateType int
+
+const (
+	StaleUpdateType_CLEAR       StaleUpdateType = 0
+	StaleUpdateType_NEWACTIVITY StaleUpdateType = 1
+)
+
+func (o StaleUpdateType) DeepCopy() StaleUpdateType { return o }
+
+var StaleUpdateTypeMap = map[string]StaleUpdateType{
+	"CLEAR":       0,
+	"NEWACTIVITY": 1,
+}
+
+var StaleUpdateTypeRevMap = map[StaleUpdateType]string{
+	0: "CLEAR",
+	1: "NEWACTIVITY",
+}
+
+func (e StaleUpdateType) String() string {
+	if v, ok := StaleUpdateTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type ConversationStaleUpdate struct {
+	ConvID     ConversationID  `codec:"convID" json:"convID"`
+	UpdateType StaleUpdateType `codec:"updateType" json:"updateType"`
+}
+
+func (o ConversationStaleUpdate) DeepCopy() ConversationStaleUpdate {
+	return ConversationStaleUpdate{
+		ConvID:     o.ConvID.DeepCopy(),
+		UpdateType: o.UpdateType.DeepCopy(),
+	}
+}
+
 type NewChatActivityArg struct {
 	Uid      keybase1.UID `codec:"uid" json:"uid"`
 	Activity ChatActivity `codec:"activity" json:"activity"`
@@ -509,21 +547,21 @@ func (o ChatInboxStaleArg) DeepCopy() ChatInboxStaleArg {
 }
 
 type ChatThreadsStaleArg struct {
-	Uid     keybase1.UID     `codec:"uid" json:"uid"`
-	ConvIDs []ConversationID `codec:"convIDs" json:"convIDs"`
+	Uid     keybase1.UID              `codec:"uid" json:"uid"`
+	Updates []ConversationStaleUpdate `codec:"updates" json:"updates"`
 }
 
 func (o ChatThreadsStaleArg) DeepCopy() ChatThreadsStaleArg {
 	return ChatThreadsStaleArg{
 		Uid: o.Uid.DeepCopy(),
-		ConvIDs: (func(x []ConversationID) []ConversationID {
-			var ret []ConversationID
+		Updates: (func(x []ConversationStaleUpdate) []ConversationStaleUpdate {
+			var ret []ConversationStaleUpdate
 			for _, v := range x {
 				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
-		})(o.ConvIDs),
+		})(o.Updates),
 	}
 }
 

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -73,7 +73,7 @@ type nlistener struct {
 	t                *testing.T
 	favoritesChanged []keybase1.UID
 	badgeState       chan keybase1.BadgeState
-	threadStale      chan []chat1.ConversationID
+	threadStale      chan []chat1.ConversationStaleUpdate
 	testChanTimeout  time.Duration
 }
 
@@ -83,7 +83,7 @@ func newNlistener(t *testing.T) *nlistener {
 	return &nlistener{
 		t:               t,
 		badgeState:      make(chan keybase1.BadgeState, 1),
-		threadStale:     make(chan []chat1.ConversationID, 1),
+		threadStale:     make(chan []chat1.ConversationStaleUpdate, 1),
 		testChanTimeout: 20 * time.Second,
 	}
 }
@@ -116,7 +116,7 @@ func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.Conversa
 func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                       {}
 func (n *nlistener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
-func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {
+func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationStaleUpdate) {
 	select {
 	case n.threadStale <- cids:
 	case <-time.After(n.testChanTimeout):

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -110,7 +110,14 @@ func (h *KBFSHandler) notifyConversation(uid keybase1.UID, filename string) {
 	}
 
 	h.G().Log.Debug("sending ChatThreadsStale notification (conversations: %d)", len(convIDs))
-	h.ChatG().Syncer.SendChatStaleNotifications(context.Background(), uid.ToBytes(), convIDs, false)
+	var updates []chat1.ConversationStaleUpdate
+	for _, convID := range convIDs {
+		updates = append(updates, chat1.ConversationStaleUpdate{
+			ConvID:     convID,
+			UpdateType: chat1.StaleUpdateType_CLEAR,
+		})
+	}
+	h.ChatG().Syncer.SendChatStaleNotifications(context.Background(), uid.ToBytes(), updates, false)
 }
 
 func (h *KBFSHandler) conversationIDs(uid keybase1.UID, tlf string, public bool) ([]chat1.ConversationID, error) {

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -77,6 +77,16 @@ protocol NotifyChat {
     array<TyperInfo> typers;
   }
 
+  enum StaleUpdateType {
+    CLEAR_0,
+    NEWACTIVITY_1
+  }
+
+  record ConversationStaleUpdate {
+    ConversationID convID;
+    StaleUpdateType updateType;
+  }
+
   @notify("")
   @lint("ignore")
   void NewChatActivity(keybase1.UID uid, ChatActivity activity);
@@ -100,7 +110,7 @@ protocol NotifyChat {
 
   @notify("")
   @lint("ignore")
-  void ChatThreadsStale(keybase1.UID uid, array<ConversationID> convIDs);
+  void ChatThreadsStale(keybase1.UID uid, array<ConversationStaleUpdate> updates);
 
   @notify("")
   @lint("ignore")

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -195,6 +195,11 @@ export const NotifyChatChatActivityType = {
   setAppNotificationSettings: 7,
 }
 
+export const NotifyChatStaleUpdateType = {
+  clear: 0,
+  newactivity: 1,
+}
+
 export const RemoteChannelMention = {
   none: 0,
   all: 1,
@@ -1270,6 +1275,11 @@ export type ConversationResolveInfo = {
   newTLFName: string,
 }
 
+export type ConversationStaleUpdate = {
+  convID: ConversationID,
+  updateType: StaleUpdateType,
+}
+
 export type ConversationStatus =
     0 // UNFILED_0
   | 1 // FAVORITE_1
@@ -1822,7 +1832,7 @@ export type NotifyChatChatTLFResolveRpcParam = Exact<{
 
 export type NotifyChatChatThreadsStaleRpcParam = Exact<{
   uid: keybase1.UID,
-  convIDs?: ?Array<ConversationID>
+  updates?: ?Array<ConversationStaleUpdate>
 }>
 
 export type NotifyChatChatTypingUpdateRpcParam = Exact<{
@@ -1998,6 +2008,10 @@ export type SignatureInfo = {
   s: bytes,
   k: bytes,
 }
+
+export type StaleUpdateType =
+    0 // CLEAR_0
+  | 1 // NEWACTIVITY_1
 
 export type SyncAllNotificationRes =
     { typ: 0, state: ?gregor1.State }
@@ -2737,7 +2751,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatThreadsStale'?: (
     params: Exact<{
       uid: keybase1.UID,
-      convIDs?: ?Array<ConversationID>
+      updates?: ?Array<ConversationStaleUpdate>
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -252,6 +252,28 @@
           "name": "typers"
         }
       ]
+    },
+    {
+      "type": "enum",
+      "name": "StaleUpdateType",
+      "symbols": [
+        "CLEAR_0",
+        "NEWACTIVITY_1"
+      ]
+    },
+    {
+      "type": "record",
+      "name": "ConversationStaleUpdate",
+      "fields": [
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        },
+        {
+          "type": "StaleUpdateType",
+          "name": "updateType"
+        }
+      ]
     }
   ],
   "messages": {
@@ -344,10 +366,10 @@
           "type": "keybase1.UID"
         },
         {
-          "name": "convIDs",
+          "name": "updates",
           "type": {
             "type": "array",
-            "items": "ConversationID"
+            "items": "ConversationStaleUpdate"
           }
         }
       ],

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -421,8 +421,8 @@ function inboxStale(): Constants.InboxStale {
   return {payload: undefined, type: 'chat:inboxStale'}
 }
 
-function markThreadsStale(convIDs: Array<Constants.ConversationIDKey>): Constants.MarkThreadsStale {
-  return {payload: {convIDs}, type: 'chat:markThreadsStale'}
+function markThreadsStale(updates: Array<ChatTypes.ConversationStaleUpdate>): Constants.MarkThreadsStale {
+  return {payload: {updates}, type: 'chat:markThreadsStale'}
 }
 
 function loadingMessages(

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -247,9 +247,9 @@ function* _setupChatHandlers(): SagaGenerator<any, any> {
       dispatch(Creators.inboxStale())
     })
 
-    engine().setIncomingHandler('chat.1.NotifyChat.ChatThreadsStale', ({convIDs}) => {
-      if (convIDs) {
-        dispatch(Creators.markThreadsStale(convIDs.map(Constants.conversationIDToKey)))
+    engine().setIncomingHandler('chat.1.NotifyChat.ChatThreadsStale', ({updates}) => {
+      if (updates) {
+        dispatch(Creators.markThreadsStale(updates))
       }
     })
   })
@@ -943,7 +943,8 @@ function* _sendNotifications(action: Constants.AppendMessages): SagaGenerator<an
 
 function* _markThreadsStale(action: Constants.MarkThreadsStale): SagaGenerator<any, any> {
   // Load inbox items of any stale items so we get update on rekeyInfos, etc
-  const {convIDs} = action.payload
+  const {updates} = action.payload
+  const convIDs = updates.map(u => Constants.conversationIDToKey(u.convID))
   yield call(Inbox.unboxConversations, convIDs)
 
   // Selected is stale?

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -26,6 +26,7 @@ import type {
   OutboxID as RPCOutboxID,
   ConversationID as RPCConversationID,
   TyperInfo,
+  ConversationStaleUpdate,
 } from './types/flow-types-chat'
 import type {DeviceType, KBRecord} from './types/more'
 import type {TypedState} from './reducer'
@@ -482,7 +483,7 @@ export type LoadingMessages = NoErrorTypedAction<
 >
 export type MarkThreadsStale = NoErrorTypedAction<
   'chat:markThreadsStale',
-  {convIDs: Array<ConversationIDKey>}
+  {updates: Array<ConversationStaleUpdate>}
 >
 export type MuteConversation = NoErrorTypedAction<
   'chat:muteConversation',

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -195,6 +195,11 @@ export const NotifyChatChatActivityType = {
   setAppNotificationSettings: 7,
 }
 
+export const NotifyChatStaleUpdateType = {
+  clear: 0,
+  newactivity: 1,
+}
+
 export const RemoteChannelMention = {
   none: 0,
   all: 1,
@@ -1270,6 +1275,11 @@ export type ConversationResolveInfo = {
   newTLFName: string,
 }
 
+export type ConversationStaleUpdate = {
+  convID: ConversationID,
+  updateType: StaleUpdateType,
+}
+
 export type ConversationStatus =
     0 // UNFILED_0
   | 1 // FAVORITE_1
@@ -1822,7 +1832,7 @@ export type NotifyChatChatTLFResolveRpcParam = Exact<{
 
 export type NotifyChatChatThreadsStaleRpcParam = Exact<{
   uid: keybase1.UID,
-  convIDs?: ?Array<ConversationID>
+  updates?: ?Array<ConversationStaleUpdate>
 }>
 
 export type NotifyChatChatTypingUpdateRpcParam = Exact<{
@@ -1998,6 +2008,10 @@ export type SignatureInfo = {
   s: bytes,
   k: bytes,
 }
+
+export type StaleUpdateType =
+    0 // CLEAR_0
+  | 1 // NEWACTIVITY_1
 
 export type SyncAllNotificationRes =
     { typ: 0, state: ?gregor1.State }
@@ -2737,7 +2751,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatThreadsStale'?: (
     params: Exact<{
       uid: keybase1.UID,
-      convIDs?: ?Array<ConversationID>
+      updates?: ?Array<ConversationStaleUpdate>
     }> /* ,
     response: {} // Notify call
     */

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -423,7 +423,8 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
         .setIn(['localMessageStates', newMessageKey], localMessageState)
     }
     case 'chat:markThreadsStale': {
-      const {convIDs} = action.payload
+      const {updates} = action.payload
+      const convIDs = updates.map(u => Constants.conversationIDToKey(u.convID))
       return state.update('conversationStates', conversationStates =>
         conversationStates.map((conversationState, conversationIDKey) => {
           if (convIDs.length === 0 || convIDs.includes(conversationIDKey)) {


### PR DESCRIPTION
Patch does the following:

1.) Adds a new type `ConversationStaleUpdate` which will contain a new field of type `StateUpdateType`, which will describe the seriousness of the stale situation.
2.) `CLEAR` updates come from weird situations, like Gregor updates from the future, TLF finalize messages, KBFS rekey notifications, and maybe some others.
3.) Most updates are `NEWACTIVITY` and should let the frontend know that they don't need to drop everything they currently have, and should just merge the results of their next `GetThreadLocal` call with what is currently being displayed.
4.) Batching makes it so that `CLEAR` always wins in case a conversation is marked twice in the batching window.
5.) Changed frontend code to just treat everything like a `CLEAR` for the time-being, just to not break everything. cc @chrisnojima 