### PR TITLE
Fix possible extra navigateUp to login screen when saving profile

### DIFF
--- a/shared/actions/profile/index.js
+++ b/shared/actions/profile/index.js
@@ -13,7 +13,7 @@ import {
 } from './proofs'
 import {call, put, select, fork} from 'redux-saga/effects'
 import {getMyProfile} from '.././tracker'
-import {navigateAppend, navigateTo, navigateUp, switchTo} from '../../actions/route-tree'
+import {navigateAppend, navigateTo, navigateUp, switchTo, putActionIfOnPath} from '../../actions/route-tree'
 import {pgpSaga, dropPgp, generatePgp, updatePgpInfo} from './pgp'
 import {profileTab} from '../../constants/tabs'
 import {revokeRevokeSigsRpcPromise, userProfileEditRpcPromise} from '../../constants/types/flow-types'
@@ -34,7 +34,8 @@ function* _editProfile(action: Constants.EditProfile): SagaGenerator<any, any> {
   yield call(userProfileEditRpcPromise, {
     param: {bio, fullName, location},
   })
-  yield put(navigateUp())
+  // If the profile tab remained on the edit profile screen, navigate back to the top level.
+  yield put(putActionIfOnPath([profileTab, 'editProfile'], navigateTo([], [profileTab]), [profileTab]))
 }
 
 function updateUsername(username: string): Constants.UpdateUsername {

--- a/shared/actions/route-tree.js
+++ b/shared/actions/route-tree.js
@@ -32,8 +32,8 @@ const pathActionTransformer = (action, oldState) => {
   }
 }
 
-export function pathSelector(state: TypedState): I.List<string> {
-  return getPath(state.routeTree.routeState)
+export function pathSelector(state: TypedState, parentPath?: Path): I.List<string> {
+  return getPath(state.routeTree.routeState, parentPath)
 }
 
 // Set (or update) the tree of route definitions. Dispatched at initialization
@@ -107,11 +107,12 @@ export function navigateUp(): NavigateUp {
 // Do a navigate action if the path is still what is expected
 export function putActionIfOnPath<T: TypedAction<*, *, *>>(
   expectedPath: Path,
-  otherAction: T
+  otherAction: T,
+  parentPath?: Path
 ): Constants.PutActionIfOnPath<T> {
   return {
     type: Constants.putActionIfOnPath,
-    payload: {expectedPath, otherAction},
+    payload: {expectedPath, otherAction, parentPath},
   }
 }
 
@@ -133,9 +134,11 @@ export function resetRoute(path: Path): ResetRoute {
   }
 }
 
-function* _putActionIfOnPath({payload: {otherAction, expectedPath}}: Constants.PutActionIfOnPath<*>) {
-  const currentPath = yield select(pathSelector)
-  if (I.is(expectedPath, currentPath)) {
+function* _putActionIfOnPath({
+  payload: {otherAction, expectedPath, parentPath},
+}: Constants.PutActionIfOnPath<*>) {
+  const currentPath = yield select(pathSelector, parentPath)
+  if (I.is(I.List(expectedPath), currentPath)) {
     yield put(otherAction)
   }
 }

--- a/shared/constants/route-tree.js
+++ b/shared/constants/route-tree.js
@@ -25,7 +25,7 @@ export type NavigateUp = NoErrorTypedAction<'routeTree:navigateUp', null>
 export const putActionIfOnPath = 'routeTree:putActionIfOnPath'
 export type PutActionIfOnPath<T: TypedAction<*, *, *>> = NoErrorTypedAction<
   'routeTree:putActionIfOnPath',
-  {expectedPath: Path, otherAction: T}
+  {expectedPath: Path, parentPath?: Path, otherAction: T}
 >
 
 export const setRouteState = 'routeTree:setRouteState'


### PR DESCRIPTION
If the user pressed the back button while the editProfile saga was
working, the saga could trigger a navigateUp() from the profile screen,
causing the app to appear to log out.

@keybase/react-hackers 