### PR TITLE
change encryptedb to grab the right LevelDB from a function provided by its creator

### DIFF
--- a/go/chat/storage/basebox.go
+++ b/go/chat/storage/basebox.go
@@ -28,10 +28,12 @@ func newBaseBox(g *globals.Context) *baseBox {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
 		return getSecretBoxKey(ctx, g.ExternalG(), DefaultSecretUI)
 	}
-
+	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
+		return g.LocalChatDb
+	}
 	return &baseBox{
 		Contextified: globals.NewContextified(g),
-		encryptedDB:  encrypteddb.New(g.ExternalG(), g.LocalChatDb, keyFn),
+		encryptedDB:  encrypteddb.New(g.ExternalG(), dbFn, keyFn),
 	}
 }
 

--- a/go/teams/storage.go
+++ b/go/teams/storage.go
@@ -91,9 +91,12 @@ func NewDiskStorage(g *libkb.GlobalContext) *DiskStorage {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
 		return getLocalStorageSecretBoxKey(ctx, g)
 	}
+	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
+		return g.LocalDb
+	}
 	return &DiskStorage{
 		Contextified: libkb.NewContextified(g),
-		encryptedDB:  encrypteddb.New(g, g.LocalDb, keyFn),
+		encryptedDB:  encrypteddb.New(g, dbFn, keyFn),
 	}
 }
 


### PR DESCRIPTION
Otherwise if the database is nuked and replaced on `G`, then this guy will always be trying to use the old one.

cc @maxtaco 