### PR TITLE
Login locking fallout

### DIFF
--- a/go/engine/background_task.go
+++ b/go/engine/background_task.go
@@ -144,6 +144,7 @@ func (e *BackgroundTask) loop(ectx *Context) error {
 	var i int
 	for {
 		i++
+		e.log(ectx.GetNetContext(), "round(%v) start", i)
 		err := e.round(ectx)
 		if err != nil {
 			e.log(ectx.GetNetContext(), "round(%v) error: %s", i, err)
@@ -185,6 +186,6 @@ func (e *BackgroundTask) meta(s string) {
 }
 
 func (e *BackgroundTask) log(ctx context.Context, format string, args ...interface{}) {
-	content := fmt.Sprintf(format, args)
+	content := fmt.Sprintf(format, args...)
 	e.G().Log.CDebugf(ctx, "%s %s", e.Name(), content)
 }

--- a/go/engine/puk_upgrade_background.go
+++ b/go/engine/puk_upgrade_background.go
@@ -92,25 +92,29 @@ func (e *PerUserKeyUpgradeBackground) Shutdown() {
 
 func PerUserKeyUpgradeBackgroundRound(g *libkb.GlobalContext, ectx *Context) error {
 	if !g.Env.GetUpgradePerUserKey() {
-		g.Log.CDebugf(ectx.GetNetContext(), "CheckUpgradePerUserKey disabled")
+		g.Log.CDebugf(ectx.GetNetContext(), "PerUserKeyUpgradeBackground disabled")
 		return nil
 	}
 
 	if !g.LocalSigchainGuard().IsAvailable(ectx.GetNetContext(), "PerUserKeyUpgradeBackgroundRound") {
-		g.Log.CDebugf(ectx.GetNetContext(), "CheckUpgradePerUserKey yielding to guard")
+		g.Log.CDebugf(ectx.GetNetContext(), "PerUserKeyUpgradeBackground yielding to guard")
 		return nil
 	}
 
 	if g.ConnectivityMonitor.IsConnected(ectx.GetNetContext()) == libkb.ConnectivityMonitorNo {
-		g.Log.CDebugf(ectx.GetNetContext(), "CheckUpgradePerUserKey giving up offline")
+		g.Log.CDebugf(ectx.GetNetContext(), "PerUserKeyUpgradeBackground giving up offline")
 		return nil
 	}
 
 	// Do a fast local check to see if our work is done.
 	pukring, err := g.GetPerUserKeyring()
+	if err != nil {
+		g.Log.CDebugf(ectx.GetNetContext(), "PerUserKeyUpgradeBackground error getting keyring: %v", err)
+		// ignore error
+	}
 	if err == nil {
 		if pukring.HasAnyKeys() {
-			g.Log.CDebugf(ectx.GetNetContext(), "CheckUpgradePerUserKey already has keys")
+			g.Log.CDebugf(ectx.GetNetContext(), "PerUserKeyUpgradeBackground already has keys")
 			return nil
 		}
 	}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -115,6 +115,8 @@ type GlobalContext struct {
 	// Options specified for testing only
 	TestOptions GlobalTestOptions
 
+	// It is threadsafe to call methods on ActiveDevice which will always be non-nil.
+	// But don't access its members directly.
 	ActiveDevice *ActiveDevice
 
 	NetContext context.Context
@@ -226,7 +228,7 @@ func (g *GlobalContext) createLoginStateLocked() {
 		g.loginState.Shutdown()
 	}
 	g.loginState = NewLoginState(g)
-	g.ActiveDevice = new(ActiveDevice)
+	g.ActiveDevice.clear(g.loginState.account)
 }
 
 func (g *GlobalContext) createLoginState() {
@@ -240,11 +242,6 @@ func (g *GlobalContext) LoginState() *LoginState {
 	defer g.loginStateMu.RUnlock()
 
 	return g.loginState
-}
-
-// ResetLoginState is mainly used for testing...
-func (g *GlobalContext) ResetLoginState() {
-	g.createLoginStateLocked()
 }
 
 func (g *GlobalContext) Logout() error {
@@ -972,12 +969,10 @@ func (g *GlobalContext) UserChanged(u keybase1.UID) {
 }
 
 // GetPerUserKeyring recreates PerUserKeyring if the uid changes or this is none installed.
-// Using this during provisioning is nigh impossible because GetMyUID
-// routes through LoginSession and deadlocks.
 func (g *GlobalContext) GetPerUserKeyring() (ret *PerUserKeyring, err error) {
 	defer g.Trace("G#GetPerUserKeyring", func() error { return err })()
 
-	myUID := g.GetMyUID()
+	myUID := g.ActiveDevice.UID()
 	if myUID.IsNil() {
 		return nil, errors.New("PerUserKeyring unavailable with no UID")
 	}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -228,7 +228,9 @@ func (g *GlobalContext) createLoginStateLocked() {
 		g.loginState.Shutdown()
 	}
 	g.loginState = NewLoginState(g)
-	g.ActiveDevice.clear(g.loginState.account)
+	g.loginState.Account(func(a *Account) {
+		g.ActiveDevice.clear(a)
+	}, "ActiveDevice.clear")
 }
 
 func (g *GlobalContext) createLoginState() {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -441,3 +441,9 @@ func (f *FakeGregorDismisser) DismissItem(id gregor.MsgID) error {
 	f.dismissedIDs = append(f.dismissedIDs, id)
 	return nil
 }
+
+// ResetLoginState is only used for testing...
+// Bypasses locks.
+func (g *GlobalContext) ResetLoginState() {
+	g.createLoginStateLocked()
+}


### PR DESCRIPTION
- Add a little more logging to background tasks
- Make GetPerUserKeyring use ActiveDevice
- Make ActiveDevice safe by not reassigning it