### PR TITLE
fix the linux i386 build

### DIFF
--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -149,6 +149,10 @@ build_one_architecture() {
   fi
 }
 
+# required for cross-compiling, or else the Go compiler will skip over
+# resinit_nix.go and fail the i386 build
+export CGO_ENABLED=1
+
 export GOARCH=amd64
 export debian_arch=amd64
 export electron_arch=x64


### PR DESCRIPTION
The recent res_init changes introduced cgo to the Linux build, which
broke things on i386, because Go disables cgo by default when
cross-compiling.

r? @mmaxim @cjb 