### PR TITLE
don't render the inbox at all when not active

### DIFF
--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -5,7 +5,7 @@ import Inbox from './index'
 import pausableConnect from '../../util/pausable-connect'
 import {createSelectorCreator, defaultMemoize} from 'reselect'
 import {loadInbox, newChat, untrustedInboxVisible} from '../../actions/chat/creators'
-import {compose, lifecycle} from 'recompose'
+import {compose, lifecycle, branch, renderNothing} from 'recompose'
 import throttle from 'lodash/throttle'
 
 import type {TypedState} from '../../constants/reducer'
@@ -43,10 +43,11 @@ const getRows = createImmutableEqualSelector([filteredInbox, getPending], (inbox
   return I.List(pending.keys()).concat(inbox)
 })
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = (state: TypedState, {isActiveRoute}) => ({
   isLoading: state.chat.get('inboxUntrustedState') === 'loading',
   showNewConversation: state.chat.inSearch && state.chat.inboxSearch.isEmpty(),
   rows: getRows(state),
+  isActiveRoute,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -62,6 +63,7 @@ const throttleHelper = throttle(cb => cb(), 60 * 1000)
 
 export default compose(
   pausableConnect(mapStateToProps, mapDispatchToProps),
+  branch(props => !props.isActiveRoute, renderNothing),
   lifecycle({
     componentDidMount: function() {
       throttleHelper(() => {


### PR DESCRIPTION
@chromakode I was playing around with your branch, trying my main use case which is ensuring no inbox stuff is going while i'm in a thread. 

Since the isRouteActive is only plumbed through automatically by the routing mechanism I decided to see what it looked like when the inbox view didn't render at all if its not the active route.
It actually seems ok (it disappears as soon as you nav into a convo, and doesn't appear until late when you swipe back), but its workable.

I'll make another branch where i plumb the isRouteActive flag further down into the connected rows and see what thats like. It might be challenging if we have further nested connectors multiple layers deep