### PR TITLE
Improve `device add` UX, login state logging, timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To enable use of these pre-commit hooks:
 
 Then proceed as normal.
 
+
 ### Cryptography Notice
 
 This distribution includes cryptographic software. The country in which you currently reside may have restrictions on the import, possession, use, and/or re-export to another country, of encryption software. BEFORE using any encryption software, please check your country's laws, regulations and policies concerning the import, possession, or use, and re-export of encryption software, to see if this is permitted. See http://www.wassenaar.org/ for more information.

--- a/go/client/cmd_device_add.go
+++ b/go/client/cmd_device_add.go
@@ -65,7 +65,7 @@ func (c *CmdDeviceAdd) Run() error {
 			dui.Printf("We only run one at a time to ensure the device is provisioned correctly.\n\n")
 			dui.Printf("(Note that this often happens when you run `device add` on a new\n")
 			dui.Printf("computer while it is being provisioned. You need to run it on an\n")
-			dui.Printf("existing computer that is already reqistered with Keybase.)\n")
+			dui.Printf("existing computer that is already registered with Keybase.)\n")
 			return nil
 		}
 		return err

--- a/go/client/cmd_device_add.go
+++ b/go/client/cmd_device_add.go
@@ -38,7 +38,11 @@ func NewCmdDeviceAdd(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 
 // RunClient runs the command in client/server mode.
 func (c *CmdDeviceAdd) Run() error {
-	var err error
+	dui := c.G().UI.GetDumbOutputUI()
+	dui.Printf("Starting `device add`...\n\n")
+	dui.Printf("(Please note that you should run `device add` on a computer that is\n")
+	dui.Printf("already registered with Keybase)\n")
+
 	cli, err := GetDeviceClient(c.G())
 	if err != nil {
 		return err
@@ -51,7 +55,23 @@ func (c *CmdDeviceAdd) Run() error {
 		return err
 	}
 
-	return cli.DeviceAdd(context.TODO(), 0)
+	if err := cli.DeviceAdd(context.TODO(), 0); err != nil {
+		if lsErr, ok := err.(libkb.LoginStateTimeoutError); ok {
+			c.G().Log.Debug("caught a LoginStateTimeoutError in `device add` command: %s", lsErr)
+			c.G().Log.Debug("providing hopefully helpful terminal output...")
+
+			dui.Printf("\n\nSorry, but it looks like there is another login or device provisioning\n")
+			dui.Printf("task currently running.\n\n")
+			dui.Printf("We only run one at a time to ensure the device is provisioned correctly.\n\n")
+			dui.Printf("(Note that this often happens when you run `device add` on a new\n")
+			dui.Printf("computer while it is being provisioned. You need to run it on an\n")
+			dui.Printf("existing computer that is already reqistered with Keybase.)\n")
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 // ParseArgv gets the secret phrase from the command args.

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -257,6 +257,7 @@ const (
 	SCTeamTarDuplicate         = int(keybase1.StatusCode_SCTeamTarDuplicate)
 	SCTeamTarNotFound          = int(keybase1.StatusCode_SCTeamTarNotFound)
 	SCTeamMemberExists         = int(keybase1.StatusCode_SCTeamMemberExists)
+	SCLoginStateTimeout        = int(keybase1.StatusCode_SCLoginStateTimeout)
 )
 
 const (

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -2012,4 +2013,14 @@ type BadSessionError struct {
 
 func (e BadSessionError) Error() string {
 	return fmt.Sprintf("bad session: %s", e.Desc)
+}
+
+type LoginStateTimeoutError struct {
+	ActiveRequest    string
+	AttemptedRequest string
+	Duration         time.Duration
+}
+
+func (e LoginStateTimeoutError) Error() string {
+	return fmt.Sprintf("LoginState request timeout - attempted: %s, active request: %s, duration: %s", e.ActiveRequest, e.AttemptedRequest, e.Duration)
 }

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
@@ -561,6 +562,22 @@ func ImportStatusAsError(s *keybase1.Status) error {
 			}
 		}
 		return ret
+	case SCLoginStateTimeout:
+		var e LoginStateTimeoutError
+		for _, field := range s.Fields {
+			switch field.Key {
+			case "ActiveRequest":
+				e.ActiveRequest = field.Value
+			case "AttemptedRequest":
+				e.AttemptedRequest = field.Value
+			case "Duration":
+				dur, err := time.ParseDuration(field.Value)
+				if err == nil {
+					e.Duration = dur
+				}
+			}
+		}
+		return e
 
 	default:
 		ase := AppStatusError{
@@ -1959,6 +1976,19 @@ func (e AccountResetError) ToStatus() keybase1.Status {
 			{Key: "e_uid", Value: string(e.expected.Uid)},
 			{Key: "e_version", Value: fmt.Sprintf("%d", e.expected.EldestSeqno)},
 			{Key: "r_version", Value: fmt.Sprintf("%d", e.received)},
+		},
+	}
+}
+
+func (e LoginStateTimeoutError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCLoginStateTimeout,
+		Name: "LOGIN_STATE_TIMEOUT",
+		Desc: e.Error(),
+		Fields: []keybase1.StringKVPair{
+			{Key: "ActiveRequest", Value: e.ActiveRequest},
+			{Key: "AttemptedRequest", Value: e.AttemptedRequest},
+			{Key: "Duration", Value: e.Duration.String()},
 		},
 	}
 }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -85,6 +85,7 @@ const (
 	StatusCode_SCInvalidLocationError     StatusCode = 1802
 	StatusCode_SCServiceStatusError       StatusCode = 1803
 	StatusCode_SCInstallError             StatusCode = 1804
+	StatusCode_SCLoginStateTimeout        StatusCode = 2400
 	StatusCode_SCChatInternal             StatusCode = 2500
 	StatusCode_SCChatRateLimit            StatusCode = 2501
 	StatusCode_SCChatConvExists           StatusCode = 2502
@@ -187,6 +188,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCInvalidLocationError":     1802,
 	"SCServiceStatusError":       1803,
 	"SCInstallError":             1804,
+	"SCLoginStateTimeout":        2400,
 	"SCChatInternal":             2500,
 	"SCChatRateLimit":            2501,
 	"SCChatConvExists":           2502,
@@ -287,6 +289,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	1802: "SCInvalidLocationError",
 	1803: "SCServiceStatusError",
 	1804: "SCInstallError",
+	2400: "SCLoginStateTimeout",
 	2500: "SCChatInternal",
 	2501: "SCChatRateLimit",
 	2502: "SCChatConvExists",

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -77,6 +77,7 @@ protocol constants {
     SCInvalidLocationError_1802,
     SCServiceStatusError_1803,
     SCInstallError_1804,
+    SCLoginStateTimeout_2400,
     SCChatInternal_2500,
     SCChatRateLimit_2501,
     SCChatConvExists_2502,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -187,6 +187,7 @@ export const ConstantsStatusCode = {
   scinvalidlocationerror: 1802,
   scservicestatuserror: 1803,
   scinstallerror: 1804,
+  scloginstatetimeout: 2400,
   scchatinternal: 2500,
   scchatratelimit: 2501,
   scchatconvexists: 2502,
@@ -5945,6 +5946,7 @@ export type StatusCode =
   | 1802 // SCInvalidLocationError_1802
   | 1803 // SCServiceStatusError_1803
   | 1804 // SCInstallError_1804
+  | 2400 // SCLoginStateTimeout_2400
   | 2500 // SCChatInternal_2500
   | 2501 // SCChatRateLimit_2501
   | 2502 // SCChatConvExists_2502

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -81,6 +81,7 @@
         "SCInvalidLocationError_1802",
         "SCServiceStatusError_1803",
         "SCInstallError_1804",
+        "SCLoginStateTimeout_2400",
         "SCChatInternal_2500",
         "SCChatRateLimit_2501",
         "SCChatConvExists_2502",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -187,6 +187,7 @@ export const ConstantsStatusCode = {
   scinvalidlocationerror: 1802,
   scservicestatuserror: 1803,
   scinstallerror: 1804,
+  scloginstatetimeout: 2400,
   scchatinternal: 2500,
   scchatratelimit: 2501,
   scchatconvexists: 2502,
@@ -5945,6 +5946,7 @@ export type StatusCode =
   | 1802 // SCInvalidLocationError_1802
   | 1803 // SCServiceStatusError_1803
   | 1804 // SCInstallError_1804
+  | 2400 // SCLoginStateTimeout_2400
   | 2500 // SCChatInternal_2500
   | 2501 // SCChatRateLimit_2501
   | 2502 // SCChatConvExists_2502


### PR DESCRIPTION
This patch should help clear up confusion when people run `device add` on a yet-to-be-provisioned device.  It displays some text before doing anything explaining that `device add` should only be run on existing devices.

    Starting `device add`...
    
    (Please note that you should run `device add` on a computer that is
    already registered with Keybase)

Then there is a new special error for LoginState timeouts, and when that happens the user will see:

    Sorry, but it looks like there is another login or device provisioning
    task currently running.
    
    We only run one at a time to ensure the device is provisioned correctly.
    
    (Note that this often happens when you run `device add` on a new
    computer while it is being provisioned. You need to run it on an
    existing computer that is already reqistered with Keybase.)

In addition to this, I improved the LoginState request logging so that the logs should be easier to parse when these issues come up.