### PR TITLE
Chat: Avoid unclickable badged convos by marking them as read

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -275,6 +275,19 @@ function* _chatInboxFailedSubSaga(params) {
   })
 
   yield put(Creators.updateInbox(conversation))
+
+  // Mark the conversation as read, to avoid a state where there's a
+  // badged conversation that can't be unbadged by clicking on it.
+  const {maxMsgid} = error.remoteConv.readerInfo
+  if (maxMsgid) {
+    yield call(ChatTypes.localMarkAsReadLocalRpcPromise, {
+      param: {
+        conversationID: convID,
+        msgID: maxMsgid,
+      },
+    })
+  }
+
   switch (error.typ) {
     case ChatTypes.LocalConversationErrorType.selfrekeyneeded: {
       yield put(Creators.updateInboxRekeySelf(conversationIDKey))

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -279,7 +279,8 @@ function* _chatInboxFailedSubSaga(params) {
   // Mark the conversation as read, to avoid a state where there's a
   // badged conversation that can't be unbadged by clicking on it.
   const {maxMsgid} = error.remoteConv.readerInfo
-  if (maxMsgid) {
+  const selectedConversation = yield select(Constants.getSelectedConversation)
+  if (maxMsgid && selectedConversation === conversationIDKey) {
     yield call(ChatTypes.localMarkAsReadLocalRpcPromise, {
       param: {
         conversationID: convID,


### PR DESCRIPTION
@keybase/react-hackers 

Mark the conversation as read in the path where we're failing to unbox a conversation, to avoid a state where there's a badged conversation that you can't remove the badge on.