### PR TITLE
Add join/leave messages

### DIFF
--- a/go/chat/msgchecker/boxed_checker.go
+++ b/go/chat/msgchecker/boxed_checker.go
@@ -35,8 +35,10 @@ func checkMessageBoxedLength(msg chat1.MessageBoxed) error {
 		return boxedFieldLengthChecker("HEADLINE message", len(msg.BodyCiphertext.E), BoxedHeadlineMessageBodyMaxLength)
 	case chat1.MessageType_METADATA:
 		return boxedFieldLengthChecker("METADATA message", len(msg.BodyCiphertext.E), BoxedMetadataMessageBodyMaxLength)
-	case chat1.MessageType_JOINLEAVE:
-		return boxedFieldLengthChecker("JOINLEAVE message", len(msg.BodyCiphertext.E), BoxedJoinLeaveMessageBodyMaxLength)
+	case chat1.MessageType_JOIN:
+		return boxedFieldLengthChecker("JOIN message", len(msg.BodyCiphertext.E), BoxedJoinMessageBodyMaxLength)
+	case chat1.MessageType_LEAVE:
+		return boxedFieldLengthChecker("LEAVE message", len(msg.BodyCiphertext.E), BoxedLeaveMessageBodyMaxLength)
 	default:
 		return fmt.Errorf("unknown message type: %v", msg.GetMessageType())
 	}

--- a/go/chat/msgchecker/boxed_checker.go
+++ b/go/chat/msgchecker/boxed_checker.go
@@ -1,7 +1,6 @@
 package msgchecker
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/keybase/client/go/protocol/chat1"
@@ -36,8 +35,10 @@ func checkMessageBoxedLength(msg chat1.MessageBoxed) error {
 		return boxedFieldLengthChecker("HEADLINE message", len(msg.BodyCiphertext.E), BoxedHeadlineMessageBodyMaxLength)
 	case chat1.MessageType_METADATA:
 		return boxedFieldLengthChecker("METADATA message", len(msg.BodyCiphertext.E), BoxedMetadataMessageBodyMaxLength)
+	case chat1.MessageType_JOINLEAVE:
+		return boxedFieldLengthChecker("JOINLEAVE message", len(msg.BodyCiphertext.E), BoxedJoinLeaveMessageBodyMaxLength)
 	default:
-		return errors.New("unknown message type")
+		return fmt.Errorf("unknown message type: %v", msg.GetMessageType())
 	}
 }
 

--- a/go/chat/msgchecker/constants.go
+++ b/go/chat/msgchecker/constants.go
@@ -7,8 +7,9 @@ const (
 )
 
 const (
-	BoxedTextMessageBodyMaxLength     = 5000
-	BoxedEditMessageBodyMaxLength     = 5000
-	BoxedHeadlineMessageBodyMaxLength = 380
-	BoxedMetadataMessageBodyMaxLength = 200
+	BoxedTextMessageBodyMaxLength      = 5000
+	BoxedEditMessageBodyMaxLength      = 5000
+	BoxedHeadlineMessageBodyMaxLength  = 380
+	BoxedMetadataMessageBodyMaxLength  = 200
+	BoxedJoinLeaveMessageBodyMaxLength = 200
 )

--- a/go/chat/msgchecker/constants.go
+++ b/go/chat/msgchecker/constants.go
@@ -7,9 +7,10 @@ const (
 )
 
 const (
-	BoxedTextMessageBodyMaxLength      = 5000
-	BoxedEditMessageBodyMaxLength      = 5000
-	BoxedHeadlineMessageBodyMaxLength  = 380
-	BoxedMetadataMessageBodyMaxLength  = 200
-	BoxedJoinLeaveMessageBodyMaxLength = 200
+	BoxedTextMessageBodyMaxLength     = 5000
+	BoxedEditMessageBodyMaxLength     = 5000
+	BoxedHeadlineMessageBodyMaxLength = 380
+	BoxedMetadataMessageBodyMaxLength = 200
+	BoxedJoinMessageBodyMaxLength     = 200
+	BoxedLeaveMessageBodyMaxLength    = 200
 )

--- a/go/chat/msgchecker/plaintext_checker.go
+++ b/go/chat/msgchecker/plaintext_checker.go
@@ -1,7 +1,6 @@
 package msgchecker
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -69,7 +68,7 @@ func checkMessagePlaintextLength(msg chat1.MessagePlaintext) error {
 		return err
 	}
 	switch mtype {
-	case chat1.MessageType_ATTACHMENT, chat1.MessageType_DELETE, chat1.MessageType_NONE, chat1.MessageType_TLFNAME, chat1.MessageType_ATTACHMENTUPLOADED:
+	case chat1.MessageType_ATTACHMENT, chat1.MessageType_DELETE, chat1.MessageType_NONE, chat1.MessageType_TLFNAME, chat1.MessageType_ATTACHMENTUPLOADED, chat1.MessageType_JOINLEAVE:
 		return nil
 	case chat1.MessageType_TEXT:
 		return plaintextFieldLengthChecker("message", len(msg.MessageBody.Text().Body), TextMessageMaxLength)
@@ -84,7 +83,11 @@ func checkMessagePlaintextLength(msg chat1.MessagePlaintext) error {
 		}
 		return nil
 	default:
-		return errors.New("unknown message type")
+		typ, err := msg.MessageBody.MessageType()
+		if err != nil {
+			return fmt.Errorf("unknown message type: %v", err)
+		}
+		return fmt.Errorf("unknown message type: %v", typ)
 	}
 }
 

--- a/go/chat/msgchecker/plaintext_checker.go
+++ b/go/chat/msgchecker/plaintext_checker.go
@@ -1,6 +1,7 @@
 package msgchecker
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 

--- a/go/chat/msgchecker/plaintext_checker.go
+++ b/go/chat/msgchecker/plaintext_checker.go
@@ -68,7 +68,7 @@ func checkMessagePlaintextLength(msg chat1.MessagePlaintext) error {
 		return err
 	}
 	switch mtype {
-	case chat1.MessageType_ATTACHMENT, chat1.MessageType_DELETE, chat1.MessageType_NONE, chat1.MessageType_TLFNAME, chat1.MessageType_ATTACHMENTUPLOADED, chat1.MessageType_JOINLEAVE:
+	case chat1.MessageType_ATTACHMENT, chat1.MessageType_DELETE, chat1.MessageType_NONE, chat1.MessageType_TLFNAME, chat1.MessageType_ATTACHMENTUPLOADED, chat1.MessageType_JOIN, chat1.MessageType_LEAVE:
 		return nil
 	case chat1.MessageType_TEXT:
 		return plaintextFieldLengthChecker("message", len(msg.MessageBody.Text().Body), TextMessageMaxLength)

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -482,8 +482,13 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	// If we are in preview mode, then just join the conversation right now.
 	switch conv.ReaderInfo.Status {
 	case chat1.ConversationMemberStatus_PREVIEW:
-		if _, err = ri.JoinConversation(ctx, convID); err != nil {
-			return chat1.OutboxID{}, nil, nil, err
+		switch msg.ClientHeader.MessageType {
+		case chat1.MessageType_JOIN, chat1.MessageType_LEAVE:
+			// pass so we don't loop between Send and Join/Leave.
+		default:
+			if _, err = ri.JoinConversation(ctx, convID); err != nil {
+				return chat1.OutboxID{}, nil, nil, err
+			}
 		}
 	default:
 		// do nothing

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2100,6 +2100,9 @@ func (h *Server) UpdateTyping(ctx context.Context, arg chat1.UpdateTypingArg) (e
 // Post a join or leave. Must be called when the user is in the conv.
 // Uses a blocking sender.
 func (h *Server) postJoinLeave(ctx context.Context, convID chat1.ConversationID, body chat1.MessageJoinLeave) (rl *chat1.RateLimit, err error) {
+	h.Debug(ctx, "+ postJoinLeave(%v)", convID)
+	defer func() { h.Debug(ctx, "- postJoinLeave -> %v", err) }()
+
 	uid := h.G().Env.GetUID()
 	if uid.IsNil() {
 		return rl, libkb.LoginRequiredError{}
@@ -2136,6 +2139,7 @@ func (h *Server) postJoinLeave(ctx context.Context, convID chat1.ConversationID,
 
 	// Send with a blocking sender
 	sender := NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient)
+	h.Debug(ctx, "postJoinLeave sending")
 	_, _, rl, err = sender.Send(ctx, convID, plaintext, 0)
 	return rl, err
 }

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -552,7 +552,7 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 				// Note that from this point on, TopicID is entirely the wrong value.
 				convID = cerr.ConvID
 			case libkb.ChatCollisionError:
-				// The triple did not exist, but a collision occurred on convID. Retry with a different topic ID.N
+				// The triple did not exist, but a collision occurred on convID. Retry with a different topic ID.
 				h.Debug(ctx, "NewConversationLocal: collision: %v", reserr)
 				continue
 			default:

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const inboxVersion = 11
+const inboxVersion = 12
 
 type queryHash []byte
 

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const blockIndexVersion = 7
+const blockIndexVersion = 8
 const blockSize = 100
 
 type blockEngine struct {

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -174,6 +174,7 @@ func makeChatCLIConversationFetcher(ctx *cli.Context, tlfName string, markAsRead
 	fetcher.query.MessageTypes = []chat1.MessageType{
 		chat1.MessageType_TEXT,
 		chat1.MessageType_ATTACHMENT,
+		chat1.MessageType_JOINLEAVE,
 	}
 	fetcher.query.Limit = chat1.UnreadFirstNumLimit{
 		NumRead: 2,

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -174,7 +174,8 @@ func makeChatCLIConversationFetcher(ctx *cli.Context, tlfName string, markAsRead
 	fetcher.query.MessageTypes = []chat1.MessageType{
 		chat1.MessageType_TEXT,
 		chat1.MessageType_ATTACHMENT,
-		chat1.MessageType_JOINLEAVE,
+		chat1.MessageType_JOIN,
+		chat1.MessageType_LEAVE,
 	}
 	fetcher.query.Limit = chat1.UnreadFirstNumLimit{
 		NumRead: 2,

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -475,6 +475,13 @@ func newMessageViewValid(g *libkb.GlobalContext, conversationID chat1.Conversati
 		mv.Renderable = false
 	case chat1.MessageType_ATTACHMENTUPLOADED:
 		mv.Renderable = false
+	case chat1.MessageType_JOINLEAVE:
+		mv.Renderable = true
+		if body.Joinleave().Join {
+			mv.Body = "Joined this channel"
+		} else {
+			mv.Body = "Left this channel"
+		}
 	default:
 		return mv, fmt.Errorf(fmt.Sprintf("unsupported MessageType: %s", typ.String()))
 	}

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -475,13 +475,12 @@ func newMessageViewValid(g *libkb.GlobalContext, conversationID chat1.Conversati
 		mv.Renderable = false
 	case chat1.MessageType_ATTACHMENTUPLOADED:
 		mv.Renderable = false
-	case chat1.MessageType_JOINLEAVE:
+	case chat1.MessageType_JOIN:
 		mv.Renderable = true
-		if body.Joinleave().Join {
-			mv.Body = "Joined this channel"
-		} else {
-			mv.Body = "Left this channel"
-		}
+		mv.Body = "<joined the channel>"
+	case chat1.MessageType_LEAVE:
+		mv.Renderable = true
+		mv.Body = "<left the channel>"
 	default:
 		return mv, fmt.Errorf(fmt.Sprintf("unsupported MessageType: %s", typ.String()))
 	}

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -135,7 +135,8 @@ const (
 	MessageType_TLFNAME            MessageType = 6
 	MessageType_HEADLINE           MessageType = 7
 	MessageType_ATTACHMENTUPLOADED MessageType = 8
-	MessageType_JOINLEAVE          MessageType = 9
+	MessageType_JOIN               MessageType = 9
+	MessageType_LEAVE              MessageType = 10
 )
 
 func (o MessageType) DeepCopy() MessageType { return o }
@@ -150,20 +151,22 @@ var MessageTypeMap = map[string]MessageType{
 	"TLFNAME":            6,
 	"HEADLINE":           7,
 	"ATTACHMENTUPLOADED": 8,
-	"JOINLEAVE":          9,
+	"JOIN":               9,
+	"LEAVE":              10,
 }
 
 var MessageTypeRevMap = map[MessageType]string{
-	0: "NONE",
-	1: "TEXT",
-	2: "ATTACHMENT",
-	3: "EDIT",
-	4: "DELETE",
-	5: "METADATA",
-	6: "TLFNAME",
-	7: "HEADLINE",
-	8: "ATTACHMENTUPLOADED",
-	9: "JOINLEAVE",
+	0:  "NONE",
+	1:  "TEXT",
+	2:  "ATTACHMENT",
+	3:  "EDIT",
+	4:  "DELETE",
+	5:  "METADATA",
+	6:  "TLFNAME",
+	7:  "HEADLINE",
+	8:  "ATTACHMENTUPLOADED",
+	9:  "JOIN",
+	10: "LEAVE",
 }
 
 type TopicType int

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -135,6 +135,7 @@ const (
 	MessageType_TLFNAME            MessageType = 6
 	MessageType_HEADLINE           MessageType = 7
 	MessageType_ATTACHMENTUPLOADED MessageType = 8
+	MessageType_JOINLEAVE          MessageType = 9
 )
 
 func (o MessageType) DeepCopy() MessageType { return o }
@@ -149,6 +150,7 @@ var MessageTypeMap = map[string]MessageType{
 	"TLFNAME":            6,
 	"HEADLINE":           7,
 	"ATTACHMENTUPLOADED": 8,
+	"JOINLEAVE":          9,
 }
 
 var MessageTypeRevMap = map[MessageType]string{
@@ -161,6 +163,7 @@ var MessageTypeRevMap = map[MessageType]string{
 	6: "TLFNAME",
 	7: "HEADLINE",
 	8: "ATTACHMENTUPLOADED",
+	9: "JOINLEAVE",
 }
 
 type TopicType int

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -102,6 +102,10 @@ func (t MessageType) String() string {
 		return "TLFNAME"
 	case MessageType_ATTACHMENTUPLOADED:
 		return "ATTACHMENTUPLOADED"
+	case MessageType_JOIN:
+		return "JOIN"
+	case MessageType_LEAVE:
+		return "LEAVE"
 	default:
 		return "UNKNOWN"
 	}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -368,6 +368,16 @@ func (o MessageAttachmentUploaded) DeepCopy() MessageAttachmentUploaded {
 	}
 }
 
+type MessageJoinLeave struct {
+	Join bool `codec:"join" json:"join"`
+}
+
+func (o MessageJoinLeave) DeepCopy() MessageJoinLeave {
+	return MessageJoinLeave{
+		Join: o.Join,
+	}
+}
+
 type MessageBody struct {
 	MessageType__        MessageType                  `codec:"messageType" json:"messageType"`
 	Text__               *MessageText                 `codec:"text,omitempty" json:"text,omitempty"`
@@ -377,6 +387,7 @@ type MessageBody struct {
 	Metadata__           *MessageConversationMetadata `codec:"metadata,omitempty" json:"metadata,omitempty"`
 	Headline__           *MessageHeadline             `codec:"headline,omitempty" json:"headline,omitempty"`
 	Attachmentuploaded__ *MessageAttachmentUploaded   `codec:"attachmentuploaded,omitempty" json:"attachmentuploaded,omitempty"`
+	Joinleave__          *MessageJoinLeave            `codec:"joinleave,omitempty" json:"joinleave,omitempty"`
 }
 
 func (o *MessageBody) MessageType() (ret MessageType, err error) {
@@ -414,6 +425,11 @@ func (o *MessageBody) MessageType() (ret MessageType, err error) {
 	case MessageType_ATTACHMENTUPLOADED:
 		if o.Attachmentuploaded__ == nil {
 			err = errors.New("unexpected nil value for Attachmentuploaded__")
+			return ret, err
+		}
+	case MessageType_JOINLEAVE:
+		if o.Joinleave__ == nil {
+			err = errors.New("unexpected nil value for Joinleave__")
 			return ret, err
 		}
 	}
@@ -490,6 +506,16 @@ func (o MessageBody) Attachmentuploaded() (res MessageAttachmentUploaded) {
 	return *o.Attachmentuploaded__
 }
 
+func (o MessageBody) Joinleave() (res MessageJoinLeave) {
+	if o.MessageType__ != MessageType_JOINLEAVE {
+		panic("wrong case accessed")
+	}
+	if o.Joinleave__ == nil {
+		return
+	}
+	return *o.Joinleave__
+}
+
 func NewMessageBodyWithText(v MessageText) MessageBody {
 	return MessageBody{
 		MessageType__: MessageType_TEXT,
@@ -536,6 +562,13 @@ func NewMessageBodyWithAttachmentuploaded(v MessageAttachmentUploaded) MessageBo
 	return MessageBody{
 		MessageType__:        MessageType_ATTACHMENTUPLOADED,
 		Attachmentuploaded__: &v,
+	}
+}
+
+func NewMessageBodyWithJoinleave(v MessageJoinLeave) MessageBody {
+	return MessageBody{
+		MessageType__: MessageType_JOINLEAVE,
+		Joinleave__:   &v,
 	}
 }
 
@@ -591,6 +624,13 @@ func (o MessageBody) DeepCopy() MessageBody {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Attachmentuploaded__),
+		Joinleave__: (func(x *MessageJoinLeave) *MessageJoinLeave {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Joinleave__),
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -368,14 +368,18 @@ func (o MessageAttachmentUploaded) DeepCopy() MessageAttachmentUploaded {
 	}
 }
 
-type MessageJoinLeave struct {
-	Join bool `codec:"join" json:"join"`
+type MessageJoin struct {
 }
 
-func (o MessageJoinLeave) DeepCopy() MessageJoinLeave {
-	return MessageJoinLeave{
-		Join: o.Join,
-	}
+func (o MessageJoin) DeepCopy() MessageJoin {
+	return MessageJoin{}
+}
+
+type MessageLeave struct {
+}
+
+func (o MessageLeave) DeepCopy() MessageLeave {
+	return MessageLeave{}
 }
 
 type MessageBody struct {
@@ -387,7 +391,8 @@ type MessageBody struct {
 	Metadata__           *MessageConversationMetadata `codec:"metadata,omitempty" json:"metadata,omitempty"`
 	Headline__           *MessageHeadline             `codec:"headline,omitempty" json:"headline,omitempty"`
 	Attachmentuploaded__ *MessageAttachmentUploaded   `codec:"attachmentuploaded,omitempty" json:"attachmentuploaded,omitempty"`
-	Joinleave__          *MessageJoinLeave            `codec:"joinleave,omitempty" json:"joinleave,omitempty"`
+	Join__               *MessageJoin                 `codec:"join,omitempty" json:"join,omitempty"`
+	Leave__              *MessageLeave                `codec:"leave,omitempty" json:"leave,omitempty"`
 }
 
 func (o *MessageBody) MessageType() (ret MessageType, err error) {
@@ -427,9 +432,14 @@ func (o *MessageBody) MessageType() (ret MessageType, err error) {
 			err = errors.New("unexpected nil value for Attachmentuploaded__")
 			return ret, err
 		}
-	case MessageType_JOINLEAVE:
-		if o.Joinleave__ == nil {
-			err = errors.New("unexpected nil value for Joinleave__")
+	case MessageType_JOIN:
+		if o.Join__ == nil {
+			err = errors.New("unexpected nil value for Join__")
+			return ret, err
+		}
+	case MessageType_LEAVE:
+		if o.Leave__ == nil {
+			err = errors.New("unexpected nil value for Leave__")
 			return ret, err
 		}
 	}
@@ -506,14 +516,24 @@ func (o MessageBody) Attachmentuploaded() (res MessageAttachmentUploaded) {
 	return *o.Attachmentuploaded__
 }
 
-func (o MessageBody) Joinleave() (res MessageJoinLeave) {
-	if o.MessageType__ != MessageType_JOINLEAVE {
+func (o MessageBody) Join() (res MessageJoin) {
+	if o.MessageType__ != MessageType_JOIN {
 		panic("wrong case accessed")
 	}
-	if o.Joinleave__ == nil {
+	if o.Join__ == nil {
 		return
 	}
-	return *o.Joinleave__
+	return *o.Join__
+}
+
+func (o MessageBody) Leave() (res MessageLeave) {
+	if o.MessageType__ != MessageType_LEAVE {
+		panic("wrong case accessed")
+	}
+	if o.Leave__ == nil {
+		return
+	}
+	return *o.Leave__
 }
 
 func NewMessageBodyWithText(v MessageText) MessageBody {
@@ -565,10 +585,17 @@ func NewMessageBodyWithAttachmentuploaded(v MessageAttachmentUploaded) MessageBo
 	}
 }
 
-func NewMessageBodyWithJoinleave(v MessageJoinLeave) MessageBody {
+func NewMessageBodyWithJoin(v MessageJoin) MessageBody {
 	return MessageBody{
-		MessageType__: MessageType_JOINLEAVE,
-		Joinleave__:   &v,
+		MessageType__: MessageType_JOIN,
+		Join__:        &v,
+	}
+}
+
+func NewMessageBodyWithLeave(v MessageLeave) MessageBody {
+	return MessageBody{
+		MessageType__: MessageType_LEAVE,
+		Leave__:       &v,
 	}
 }
 
@@ -624,13 +651,20 @@ func (o MessageBody) DeepCopy() MessageBody {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Attachmentuploaded__),
-		Joinleave__: (func(x *MessageJoinLeave) *MessageJoinLeave {
+		Join__: (func(x *MessageJoin) *MessageJoin {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
-		})(o.Joinleave__),
+		})(o.Join__),
+		Leave__: (func(x *MessageLeave) *MessageLeave {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Leave__),
 	}
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -31,7 +31,8 @@ protocol common {
     TLFNAME_6, // Only used as the very first message in conversations whose topic name is not set when created
     HEADLINE_7,
     ATTACHMENTUPLOADED_8,  // sent after upload completes to modify ATTACHMENT message
-    JOINLEAVE_9 // sent when joining or leaving a channel
+    JOIN_9, // sent when joining a channel
+    LEAVE_10
   }
 
   @go("nostring")

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -30,7 +30,8 @@ protocol common {
     METADATA_5,
     TLFNAME_6, // Only used as the very first message in conversations whose topic name is not set when created
     HEADLINE_7,
-    ATTACHMENTUPLOADED_8  // sent after upload completes to modify ATTACHMENT message
+    ATTACHMENTUPLOADED_8,  // sent after upload completes to modify ATTACHMENT message
+    JOINLEAVE_9 // sent when joining or leaving a channel
   }
 
   @go("nostring")

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -92,9 +92,9 @@ protocol local {
     bytes metadata;              // generic metadata (msgpack)
   }
 
-  record MessageJoinLeave {
-    boolean join; // whether this is a join or a leave
-  }
+  record MessageJoin {}
+
+  record MessageLeave {}
 
   variant MessageBody switch (MessageType messageType) {
     case TEXT: MessageText;
@@ -104,7 +104,8 @@ protocol local {
     case METADATA: MessageConversationMetadata;
     case HEADLINE: MessageHeadline;
     case ATTACHMENTUPLOADED: MessageAttachmentUploaded;
-    case JOINLEAVE: MessageJoinLeave;
+    case JOIN: MessageJoin;
+    case LEAVE: MessageLeave;
   }
 
   enum OutboxStateType {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -92,6 +92,10 @@ protocol local {
     bytes metadata;              // generic metadata (msgpack)
   }
 
+  record MessageJoinLeave {
+    boolean join; // whether this is a join or a leave
+  }
+
   variant MessageBody switch (MessageType messageType) {
     case TEXT: MessageText;
     case ATTACHMENT: MessageAttachment;
@@ -100,6 +104,7 @@ protocol local {
     case METADATA: MessageConversationMetadata;
     case HEADLINE: MessageHeadline;
     case ATTACHMENTUPLOADED: MessageAttachmentUploaded;
+    case JOINLEAVE: MessageJoinLeave;
   }
 
   enum OutboxStateType {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -92,7 +92,8 @@ export const CommonMessageType = {
   tlfname: 6,
   headline: 7,
   attachmentuploaded: 8,
-  joinleave: 9,
+  join: 9,
+  leave: 10,
 }
 
 export const CommonNotificationKind = {
@@ -1612,7 +1613,8 @@ export type MessageBody =
   | { messageType: 5, metadata: ?MessageConversationMetadata }
   | { messageType: 7, headline: ?MessageHeadline }
   | { messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded }
-  | { messageType: 9, joinleave: ?MessageJoinLeave }
+  | { messageType: 9, join: ?MessageJoin }
+  | { messageType: 10, leave: ?MessageLeave }
 
 export type MessageBoxed = {
   version: MessageBoxedVersion,
@@ -1676,9 +1678,9 @@ export type MessageHeadline = {
 
 export type MessageID = uint
 
-export type MessageJoinLeave = {
-  join: boolean,
-}
+export type MessageJoin = {}
+
+export type MessageLeave = {}
 
 export type MessagePlaintext = {
   clientHeader: MessageClientHeader,
@@ -1718,7 +1720,8 @@ export type MessageType =
   | 6 // TLFNAME_6
   | 7 // HEADLINE_7
   | 8 // ATTACHMENTUPLOADED_8
-  | 9 // JOINLEAVE_9
+  | 9 // JOIN_9
+  | 10 // LEAVE_10
 
 export type MessageUnboxed =
     { state: 1, valid: ?MessageUnboxedValid }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -92,6 +92,7 @@ export const CommonMessageType = {
   tlfname: 6,
   headline: 7,
   attachmentuploaded: 8,
+  joinleave: 9,
 }
 
 export const CommonNotificationKind = {
@@ -1611,6 +1612,7 @@ export type MessageBody =
   | { messageType: 5, metadata: ?MessageConversationMetadata }
   | { messageType: 7, headline: ?MessageHeadline }
   | { messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded }
+  | { messageType: 9, joinleave: ?MessageJoinLeave }
 
 export type MessageBoxed = {
   version: MessageBoxedVersion,
@@ -1674,6 +1676,10 @@ export type MessageHeadline = {
 
 export type MessageID = uint
 
+export type MessageJoinLeave = {
+  join: boolean,
+}
+
 export type MessagePlaintext = {
   clientHeader: MessageClientHeader,
   messageBody: MessageBody,
@@ -1712,6 +1718,7 @@ export type MessageType =
   | 6 // TLFNAME_6
   | 7 // HEADLINE_7
   | 8 // ATTACHMENTUPLOADED_8
+  | 9 // JOINLEAVE_9
 
 export type MessageUnboxed =
     { state: 1, valid: ?MessageUnboxedValid }

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -91,7 +91,8 @@
         "METADATA_5",
         "TLFNAME_6",
         "HEADLINE_7",
-        "ATTACHMENTUPLOADED_8"
+        "ATTACHMENTUPLOADED_8",
+        "JOINLEAVE_9"
       ],
       "go": "nostring"
     },

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -92,7 +92,8 @@
         "TLFNAME_6",
         "HEADLINE_7",
         "ATTACHMENTUPLOADED_8",
-        "JOINLEAVE_9"
+        "JOIN_9",
+        "LEAVE_10"
       ],
       "go": "nostring"
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -287,13 +287,13 @@
     },
     {
       "type": "record",
-      "name": "MessageJoinLeave",
-      "fields": [
-        {
-          "type": "boolean",
-          "name": "join"
-        }
-      ]
+      "name": "MessageJoin",
+      "fields": []
+    },
+    {
+      "type": "record",
+      "name": "MessageLeave",
+      "fields": []
     },
     {
       "type": "variant",
@@ -354,10 +354,17 @@
         },
         {
           "label": {
-            "name": "JOINLEAVE",
+            "name": "JOIN",
             "def": false
           },
-          "body": "MessageJoinLeave"
+          "body": "MessageJoin"
+        },
+        {
+          "label": {
+            "name": "LEAVE",
+            "def": false
+          },
+          "body": "MessageLeave"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -286,6 +286,16 @@
       ]
     },
     {
+      "type": "record",
+      "name": "MessageJoinLeave",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "join"
+        }
+      ]
+    },
+    {
       "type": "variant",
       "name": "MessageBody",
       "switch": {
@@ -341,6 +351,13 @@
             "def": false
           },
           "body": "MessageAttachmentUploaded"
+        },
+        {
+          "label": {
+            "name": "JOINLEAVE",
+            "def": false
+          },
+          "body": "MessageJoinLeave"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -92,7 +92,8 @@ export const CommonMessageType = {
   tlfname: 6,
   headline: 7,
   attachmentuploaded: 8,
-  joinleave: 9,
+  join: 9,
+  leave: 10,
 }
 
 export const CommonNotificationKind = {
@@ -1612,7 +1613,8 @@ export type MessageBody =
   | { messageType: 5, metadata: ?MessageConversationMetadata }
   | { messageType: 7, headline: ?MessageHeadline }
   | { messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded }
-  | { messageType: 9, joinleave: ?MessageJoinLeave }
+  | { messageType: 9, join: ?MessageJoin }
+  | { messageType: 10, leave: ?MessageLeave }
 
 export type MessageBoxed = {
   version: MessageBoxedVersion,
@@ -1676,9 +1678,9 @@ export type MessageHeadline = {
 
 export type MessageID = uint
 
-export type MessageJoinLeave = {
-  join: boolean,
-}
+export type MessageJoin = {}
+
+export type MessageLeave = {}
 
 export type MessagePlaintext = {
   clientHeader: MessageClientHeader,
@@ -1718,7 +1720,8 @@ export type MessageType =
   | 6 // TLFNAME_6
   | 7 // HEADLINE_7
   | 8 // ATTACHMENTUPLOADED_8
-  | 9 // JOINLEAVE_9
+  | 9 // JOIN_9
+  | 10 // LEAVE_10
 
 export type MessageUnboxed =
     { state: 1, valid: ?MessageUnboxedValid }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -92,6 +92,7 @@ export const CommonMessageType = {
   tlfname: 6,
   headline: 7,
   attachmentuploaded: 8,
+  joinleave: 9,
 }
 
 export const CommonNotificationKind = {
@@ -1611,6 +1612,7 @@ export type MessageBody =
   | { messageType: 5, metadata: ?MessageConversationMetadata }
   | { messageType: 7, headline: ?MessageHeadline }
   | { messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded }
+  | { messageType: 9, joinleave: ?MessageJoinLeave }
 
 export type MessageBoxed = {
   version: MessageBoxedVersion,
@@ -1674,6 +1676,10 @@ export type MessageHeadline = {
 
 export type MessageID = uint
 
+export type MessageJoinLeave = {
+  join: boolean,
+}
+
 export type MessagePlaintext = {
   clientHeader: MessageClientHeader,
   messageBody: MessageBody,
@@ -1712,6 +1718,7 @@ export type MessageType =
   | 6 // TLFNAME_6
   | 7 // HEADLINE_7
   | 8 // ATTACHMENTUPLOADED_8
+  | 9 // JOINLEAVE_9
 
 export type MessageUnboxed =
     { state: 1, valid: ?MessageUnboxedValid }


### PR DESCRIPTION
Adds two message types Join and Leave. The client sends one when you join or leave a channel. This is not guaranteed to happen if failures occur.

The CLI shows them like this. The GUI seems to ignore them, so that's up to them to ask for them in their get thread query.
```
$ kbu chat read --topic-name '#aaa' --team jlteam1
[1]  [jl2 54s] <left the channel>
[2]  [jl1 48s] hey you join this channel!
[3]  [jl2 43s] <joined the channel>
[4]  [jl2 35s] k, bye
[5]  [jl2 32s] <left the channel>
```

Old clients ignore these. The message caches are busted in this PR so that we don't pull incompletely decoded messages out of the cache.

Todo
- [x] tests
- [x] when you implicitly join/create by sending a message