### PR TITLE
add restrictions to channel names formatting CORE-5678

### DIFF
--- a/go/chat/msgchecker/constants.go
+++ b/go/chat/msgchecker/constants.go
@@ -3,7 +3,7 @@ package msgchecker
 const (
 	TextMessageMaxLength = 4000
 	HeadlineMaxLength    = 280
-	TopicMaxLength       = 100
+	TopicMaxLength       = 20
 )
 
 const (

--- a/go/chat/msgchecker/plaintext_checker.go
+++ b/go/chat/msgchecker/plaintext_checker.go
@@ -21,9 +21,9 @@ const (
 func (r validateTopicNameRes) String() string {
 	switch r {
 	case validateTopicNameResInvalidChar:
-		return "invalid characters in topic name, please use alphanumeric plus _ and -"
+		return "invalid characters in channel name, please use alphanumeric plus _ and -"
 	case validateTopicNameResInvalidLength:
-		return "invalid topic name length. Must be greater than 0 and <= 20"
+		return "invalid channel name length. Must be greater than 0 and <= 20"
 	case validateTopicNameResOK:
 		return "OK"
 	}

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -325,6 +325,7 @@ func (s *BlockingSender) assetsForMessage(ctx context.Context, msgBody chat1.Mes
 // Returns (boxedMessage, pendingAssetDeletes, error)
 func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePlaintext,
 	membersType chat1.ConversationMembersType, conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, chat1.ChannelMention, error) {
+
 	// Make sure it is a proper length
 	if err := msgchecker.CheckMessagePlaintext(plaintext); err != nil {
 		return nil, nil, nil, chat1.ChannelMention_NONE, err

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -608,7 +608,6 @@ func (h *Server) makeFirstMessage(ctx context.Context, triple chat1.Conversation
 	topicName *string) (*chat1.MessageBoxed, error) {
 	var msg chat1.MessagePlaintext
 	if topicName != nil {
-		fmt.Printf("TOPIC NAME: FIRST: %s\n", *topicName)
 		msg = chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:        triple,

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -461,37 +461,6 @@ func TestChatSrvNewConversationLocal(t *testing.T) {
 	})
 }
 
-func TestChatSrvNewConversationLocalTopicNames(t *testing.T) {
-	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
-		ctc := makeChatTestContext(t, "NewConversationLocal", 2)
-		defer ctc.cleanup()
-		users := ctc.users()
-
-		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
-			ctc.as(t, users[1]).user())
-
-		tc := ctc.world.Tcs[users[0].Username]
-		ctx := ctc.as(t, users[0]).startCtx
-		uid := users[0].User.GetUID().ToBytes()
-		conv, _, err := GetUnverifiedConv(ctx, tc.Context(), uid, created.Id, false)
-		require.NoError(t, err)
-		if len(conv.MaxMsgSummaries) == 0 {
-			t.Fatalf("created conversation does not have a message")
-		}
-
-		switch mt {
-		case chat1.ConversationMembersType_KBFS:
-			if conv.MaxMsgSummaries[0].TlfName !=
-				string(kbtest.CanonicalTlfNameForTest(ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username)) {
-				t.Fatalf("unexpected TLF name in created conversation. expected %s, got %s", ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username, conv.MaxMsgs[0].ClientHeader.TlfName)
-			}
-		case chat1.ConversationMembersType_TEAM:
-			teamName := ctc.teamCache[teamKey(ctc.users())]
-			require.Equal(t, teamName, conv.MaxMsgSummaries[0].TlfName)
-		}
-	})
-}
-
 func TestChatSrvNewChatConversationLocalTwice(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "NewConversationLocal", 2)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -535,7 +535,12 @@ func TestChatSrvNewConversationMultiTeam(t *testing.T) {
 		require.Error(t, err)
 		topicName = ""
 		_, err = tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
-		require.Error(t, err)
+		switch mt {
+		case chat1.ConversationMembersType_KBFS:
+			require.NoError(t, err)
+		case chat1.ConversationMembersType_TEAM:
+			require.Error(t, err)
+		}
 		topicName = "dskjdskdjskdjskdjskdjskdjskdjskjdskjdskdskdjksdjks"
 		_, err = tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
 		require.Error(t, err)
@@ -785,33 +790,25 @@ func TestChatSrvPostLocalLengthLimit(t *testing.T) {
 
 		maxTextBody := strings.Repeat(".", msgchecker.TextMessageMaxLength)
 		_, err := postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: maxTextBody}))
-		if err != nil {
-			t.Fatalf("trying to post a text message with body length equal to the maximum failed")
-		}
+		require.NoError(t, err)
 		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: maxTextBody + "!"}))
-		if err == nil {
-			t.Fatalf("trying to post a text message with body length greater than the maximum did not fail")
-		}
+		require.Error(t, err)
 
 		maxHeadlineBody := strings.Repeat(".", msgchecker.HeadlineMaxLength)
 		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: maxHeadlineBody}))
-		if err != nil {
-			t.Fatalf("trying to post a headline message with headline length equal to the maximum failed")
-		}
+		require.NoError(t, err)
 		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: maxHeadlineBody + "!"}))
-		if err == nil {
-			t.Fatalf("trying to post a headline message with headline length greater than the maximum did not fail")
-		}
+		require.Error(t, err)
 
-		maxTopicBody := strings.Repeat(".", msgchecker.TopicMaxLength)
+		maxTopicBody := strings.Repeat("a", msgchecker.TopicMaxLength)
 		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: maxTopicBody}))
-		if err != nil {
-			t.Fatalf("trying to post a ConversationMetadata message with ConversationTitle length equal to the maximum failed")
-		}
-		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: maxTopicBody + "!"}))
-		if err == nil {
-			t.Fatalf("trying to post a ConversationMetadata message with ConversationTitle length greater than the maximum did not fail")
-		}
+		require.NoError(t, err)
+		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: maxTopicBody + "a"}))
+		require.Error(t, err)
+		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: "#mike"}))
+		require.Error(t, err)
+		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: "mii.ke"}))
+		require.Error(t, err)
 	})
 }
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -461,6 +461,37 @@ func TestChatSrvNewConversationLocal(t *testing.T) {
 	})
 }
 
+func TestChatSrvNewConversationLocalTopicNames(t *testing.T) {
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "NewConversationLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
+
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
+			ctc.as(t, users[1]).user())
+
+		tc := ctc.world.Tcs[users[0].Username]
+		ctx := ctc.as(t, users[0]).startCtx
+		uid := users[0].User.GetUID().ToBytes()
+		conv, _, err := GetUnverifiedConv(ctx, tc.Context(), uid, created.Id, false)
+		require.NoError(t, err)
+		if len(conv.MaxMsgSummaries) == 0 {
+			t.Fatalf("created conversation does not have a message")
+		}
+
+		switch mt {
+		case chat1.ConversationMembersType_KBFS:
+			if conv.MaxMsgSummaries[0].TlfName !=
+				string(kbtest.CanonicalTlfNameForTest(ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username)) {
+				t.Fatalf("unexpected TLF name in created conversation. expected %s, got %s", ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username, conv.MaxMsgs[0].ClientHeader.TlfName)
+			}
+		case chat1.ConversationMembersType_TEAM:
+			teamName := ctc.teamCache[teamKey(ctc.users())]
+			require.Equal(t, teamName, conv.MaxMsgSummaries[0].TlfName)
+		}
+	})
+}
+
 func TestChatSrvNewChatConversationLocalTwice(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "NewConversationLocal", 2)
@@ -503,14 +534,14 @@ func TestChatSrvNewConversationMultiTeam(t *testing.T) {
 
 		tc := ctc.as(t, users[0])
 		topicName := "MIKETIME"
-		ncres, err := tc.chatLocalHandler().NewConversationLocal(tc.startCtx,
-			chat1.NewConversationLocalArg{
-				TlfName:       conv.TlfName,
-				TopicName:     &topicName,
-				TopicType:     chat1.TopicType_CHAT,
-				TlfVisibility: chat1.TLFVisibility_PRIVATE,
-				MembersType:   mt,
-			})
+		arg := chat1.NewConversationLocalArg{
+			TlfName:       conv.TlfName,
+			TopicName:     &topicName,
+			TopicType:     chat1.TopicType_CHAT,
+			TlfVisibility: chat1.TLFVisibility_PRIVATE,
+			MembersType:   mt,
+		}
+		ncres, err := tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
 		switch mt {
 		case chat1.ConversationMembersType_TEAM:
 			require.NoError(t, err)
@@ -522,6 +553,23 @@ func TestChatSrvNewConversationMultiTeam(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewConversationLocal error: %v\n", err)
 		}
+
+		// Try some invalid names
+		topicName = "#mike"
+		_, err = tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
+		require.Error(t, err)
+		topicName = "/mike"
+		_, err = tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
+		require.Error(t, err)
+		topicName = "mi.ke"
+		_, err = tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
+		require.Error(t, err)
+		topicName = ""
+		_, err = tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
+		require.Error(t, err)
+		topicName = "dskjdskdjskdjskdjskdjskdjskdjskjdskjdskdskdjksdjks"
+		_, err = tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
+		require.Error(t, err)
 	})
 }
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1924,7 +1924,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		}))
 		require.NoError(t, err)
 
-		topicName := "MIKETIME"
+		topicName := "miketime"
 		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
 			chat1.NewConversationLocalArg{
 				TlfName:       conv.TlfName,

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -720,10 +720,14 @@ func (c *chatServiceHandler) makePostHeader(ctx context.Context, arg sendArgV1, 
 			return nil, err
 		}
 
+		var topicName *string
+		if arg.channel.TopicName != "" {
+			topicName = &arg.channel.TopicName
+		}
 		ncres, err := client.NewConversationLocal(ctx, chat1.NewConversationLocalArg{
 			TlfName:          arg.channel.Name,
 			TlfVisibility:    visibility,
-			TopicName:        &arg.channel.TopicName,
+			TopicName:        topicName,
 			TopicType:        tt,
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 			MembersType:      arg.channel.GetMembersType(),

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -106,8 +106,9 @@ func (c *CmdChatSend) Run() (err error) {
 	// Do one of set topic name, set headline, or send message
 	switch {
 	case c.setTopicName != "":
-		if conversationInfo.Triple.TopicType == chat1.TopicType_CHAT {
-			c.G().UI.GetTerminalUI().Printf("We are not supporting setting topic name for chat conversations yet. Ignoring --set-topic-name >.<\n")
+		if conversationInfo.Triple.TopicType == chat1.TopicType_CHAT &&
+			conversation.GetMembersType() != chat1.ConversationMembersType_TEAM {
+			c.G().UI.GetTerminalUI().Printf("We are not supporting setting topic name for chat conversations yet (except on team chats). Ignoring --set-topic-name >.<\n")
 			return nil
 		}
 		msg.ClientHeader.MessageType = chat1.MessageType_METADATA

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -829,7 +829,7 @@ function makeTeamTitle(messageBody: ?MessageBody): ?string {
   }
   switch (messageBody.messageType) {
     case ChatTypes.CommonMessageType.metadata:
-      return messageBody.metadata ? messageBody.metadata.conversationTitle : '<none>'
+      return messageBody.metadata ? `#${messageBody.metadata.conversationTitle}` : '<none>'
     default:
       return null
   }


### PR DESCRIPTION
Patch does the following:

1.) Adds restrictions when creating or renaming a topic name to only allow for alphanumeric plus + and _ and a nonzero length.
2.) Remove # from default team channel name.