### PR TITLE
don't allow multiple channels to exist from client, and make CLI agnostic to # 

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -246,6 +247,8 @@ func RecentConversationParticipants(ctx context.Context, g *globals.Context, myU
 	return newRecentConversationParticipants(g).get(ctx, myUID)
 }
 
+var errGetUnverifiedConvNotFound = errors.New("GetUnverifiedConv: conversation not found")
+
 func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
 	convID chat1.ConversationID, useLocalData bool) (chat1.Conversation, *chat1.RateLimit, error) {
 
@@ -256,7 +259,7 @@ func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
 		return chat1.Conversation{}, ratelim, fmt.Errorf("GetUnverifiedConv: %s", err.Error())
 	}
 	if len(inbox.ConvsUnverified) == 0 {
-		return chat1.Conversation{}, ratelim, fmt.Errorf("GetUnverifiedConv: conversation not found: %s", convID)
+		return chat1.Conversation{}, ratelim, errGetUnverifiedConvNotFound
 	}
 	return inbox.ConvsUnverified[0], ratelim, nil
 }

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -1175,18 +1175,3 @@ func NewInboxSource(g *globals.Context, typ string, ri func() chat1.RemoteInterf
 		return remoteInbox
 	}
 }
-
-func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
-	convID chat1.ConversationID, useLocalData bool) (chat1.Conversation, *chat1.RateLimit, error) {
-
-	inbox, ratelim, err := g.InboxSource.ReadUnverified(ctx, uid, useLocalData, &chat1.GetInboxQuery{
-		ConvIDs: []chat1.ConversationID{convID},
-	}, nil)
-	if err != nil {
-		return chat1.Conversation{}, ratelim, fmt.Errorf("GetUnverifiedConv: %s", err.Error())
-	}
-	if len(inbox.ConvsUnverified) == 0 {
-		return chat1.Conversation{}, ratelim, fmt.Errorf("GetUnverifiedConv: conversation not found: %s", convID)
-	}
-	return inbox.ConvsUnverified[0], ratelim, nil
-}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -487,6 +487,10 @@ func PluckConvIDs(convs []chat1.Conversation) (res []chat1.ConversationID) {
 	return res
 }
 
+func SanitizeTopicName(topicName string) string {
+	return strings.TrimPrefix(topicName, "#")
+}
+
 type ConvLocalByConvID []chat1.ConversationLocal
 
 func (c ConvLocalByConvID) Len() int      { return len(c) }

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -141,7 +141,7 @@ func parseConversationTopicType(ctx *cli.Context) (topicType chat1.TopicType, er
 }
 
 func parseConversationResolvingRequest(ctx *cli.Context, tlfName string) (req chatConversationResolvingRequest, err error) {
-	req.TopicName = ctx.String("topic-name")
+	req.TopicName = utils.SanitizeTopicName(ctx.String("topic-name"))
 	req.TlfName = tlfName
 	if req.TopicType, err = parseConversationTopicType(ctx); err != nil {
 		return chatConversationResolvingRequest{}, err

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -72,7 +72,7 @@ func (v conversationInfoListView) show(g *libkb.GlobalContext) error {
 type conversationListView []chat1.ConversationLocal
 
 func (v conversationListView) convNameTeam(g *libkb.GlobalContext, conv chat1.ConversationLocal) string {
-	return fmt.Sprintf("%s [%s]", conv.Info.TlfName, conv.Info.TopicName)
+	return fmt.Sprintf("%s [#%s]", conv.Info.TlfName, conv.Info.TopicName)
 }
 
 func (v conversationListView) convNameKBFS(g *libkb.GlobalContext, conv chat1.ConversationLocal, myUsername string) string {

--- a/go/client/cmd_chat_joinchannel.go
+++ b/go/client/cmd_chat_joinchannel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/keybase/cli"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -66,7 +67,7 @@ func (c *CmdChatJoinChannel) ParseArgv(ctx *cli.Context) (err error) {
 	}
 
 	c.teamName = ctx.Args().Get(0)
-	c.topicName = ctx.Args().Get(1)
+	c.topicName = utils.SanitizeTopicName(ctx.Args().Get(1))
 	return nil
 }
 

--- a/go/client/cmd_chat_leavechannel.go
+++ b/go/client/cmd_chat_leavechannel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/keybase/cli"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -75,7 +76,7 @@ func (c *CmdChatLeaveChannel) ParseArgv(ctx *cli.Context) (err error) {
 	// Force team for now
 	c.resolvingRequest.MembersType = chat1.ConversationMembersType_TEAM
 	c.resolvingRequest.Visibility = chat1.TLFVisibility_PRIVATE
-	c.resolvingRequest.TopicName = topicName
+	c.resolvingRequest.TopicName = utils.SanitizeTopicName(topicName)
 
 	return nil
 }

--- a/go/client/cmd_chat_listchannels.go
+++ b/go/client/cmd_chat_listchannels.go
@@ -55,7 +55,7 @@ func (c *CmdChatListChannels) Run() error {
 
 	ui.Printf("Listing channels on %s:\n\n", c.tlfName)
 	for _, c := range listRes.Convs {
-		ui.Printf("%s\n", utils.GetTopicName(c))
+		ui.Printf("#%s\n", utils.GetTopicName(c))
 	}
 
 	return nil

--- a/go/client/cmd_chat_listmembers.go
+++ b/go/client/cmd_chat_listmembers.go
@@ -44,15 +44,12 @@ func (c *CmdChatListMembers) Run() error {
 	}
 
 	ctx := context.Background()
-	inboxRes, err := chatClient.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
-		Query: &chat1.GetInboxLocalQuery{
-			Name: &chat1.NameQuery{
-				Name:        c.tlfName,
-				MembersType: chat1.ConversationMembersType_TEAM,
-			},
-			TopicName: &c.topicName,
-			TopicType: &c.topicType,
-		},
+	inboxRes, err := chatClient.FindConversationsLocal(ctx, chat1.FindConversationsLocalArg{
+		TlfName:          c.tlfName,
+		MembersType:      chat1.ConversationMembersType_TEAM,
+		TopicName:        c.topicName,
+		TopicType:        c.topicType,
+		Visibility:       chat1.TLFVisibility_PRIVATE,
 		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	})
 	if err != nil {
@@ -65,7 +62,7 @@ func (c *CmdChatListMembers) Run() error {
 		return fmt.Errorf("ambiguous channel description, more than one conversation matches")
 	}
 
-	ui.Printf("Listing members in %s [%s]:\n\n", c.tlfName, c.topicName)
+	ui.Printf("Listing members in %s [#%s]:\n\n", c.tlfName, c.topicName)
 	for _, memb := range inboxRes.Conversations[0].Info.WriterNames {
 		ui.Printf("%s\n", memb)
 	}

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/msgchecker"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -166,7 +167,7 @@ func (c *CmdChatSend) Run() (err error) {
 }
 
 func (c *CmdChatSend) ParseArgv(ctx *cli.Context) (err error) {
-	c.setTopicName = ctx.String("set-topic-name")
+	c.setTopicName = utils.SanitizeTopicName(ctx.String("set-topic-name"))
 	c.setHeadline = ctx.String("set-headline")
 	c.clearHeadline = ctx.Bool("clear-headline")
 	c.hasTTY = isatty.IsTerminal(os.Stdin.Fd())


### PR DESCRIPTION
Patch does the following:

1.) Makes it so that # can be present in CLI chat commands, it will just get stripped off.
2.) Change `FindConversationsLocal` to try all channels on a team if we don't hit anything in the inbox. This will prevent a client from creating a channel of the same name from the CLI. It isn't the full solution to this problem, but it gets us like 99% of the way there for a desktop release. 

One downside is every `NewConversationLocal` for teams will need to grab every single channel from the team every time, but I think the answer here is a caching story for channels the user is not a member of. 

cc @malgorithms with this in play, I think releasing publicly would be fine on desktop.