### PR TITLE
add a Debian dependency on libgconf-2-4

### DIFF
--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -30,7 +30,7 @@ if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/deb/repo"
 elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/deb"
-  dependencies="Depends: libappindicator1, fuse"
+  dependencies="Depends: libappindicator1, fuse, libgconf-2-4"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean repo


### PR DESCRIPTION
Fixes https://github.com/keybase/client/issues/7866. Will need manual
testing across Debian 8/9/Ubuntu, and i386/amd64.

r? @cjb 