### PR TITLE
Chat: Handle the new "duplicate" message error type, by not displaying it

### DIFF
--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -298,10 +298,11 @@ function updateInbox(conversation: Constants.InboxState): Constants.UpdateInbox 
 
 function createPendingFailure(
   failureDescription: string,
+  failureType: ChatTypes.OutboxErrorType,
   outboxID: Constants.OutboxIDKey
 ): Constants.CreatePendingFailure {
   return {
-    payload: {failureDescription, outboxID},
+    payload: {failureDescription, failureType, outboxID},
     type: 'chat:createPendingFailure',
   }
 }

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -122,13 +122,14 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
   if (sent && author) {
     const outboxID = Constants.outboxIDToKey(sent.outboxID)
     const hasPendingFailure = yield select(Shared.pendingFailureSelector, outboxID)
+    const failureDescription = hasPendingFailure && hasPendingFailure.failureDescription
     const message: Constants.Message = {
       author,
       conversationIDKey: action.payload.conversationIDKey,
       deviceName: '',
       deviceType: isMobile ? 'mobile' : 'desktop',
       editedCount: 0,
-      failureDescription: hasPendingFailure,
+      failureDescription,
       key: Constants.messageKey(action.payload.conversationIDKey, 'outboxIDText', outboxID),
       message: new HiddenString(action.payload.text.stringValue()),
       messageState: hasPendingFailure ? 'failed' : 'pending',

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -143,15 +143,23 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
     const selectedConversation = yield select(Constants.getSelectedConversation)
     const appFocused = yield select(Shared.focusedSelector)
 
-    yield put(
-      Creators.appendMessages(
-        conversationIDKey,
-        conversationIDKey === selectedConversation,
-        appFocused,
-        [message],
-        false
+    // We go ahead and add the message we just sent to our messages store for
+    // display locally, *unless* we've already been told that this message
+    // failed as a duplicate send, in which case we ignore adding it.
+    const failureIsDuplicate =
+      hasPendingFailure && hasPendingFailure.failureType === ChatTypes.LocalOutboxErrorType.duplicate
+    if (!failureIsDuplicate) {
+      yield put(
+        Creators.appendMessages(
+          conversationIDKey,
+          conversationIDKey === selectedConversation,
+          appFocused,
+          [message],
+          false
+        )
       )
-    )
+    }
+
     if (hasPendingFailure) {
       yield put(Creators.removePendingFailure(outboxID))
     }

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -180,10 +180,27 @@ function* getPostingIdentifyBehavior(
   return TlfKeysTLFIdentifyBehavior.chatGuiStrict
 }
 
+function decodeFailureDescription(typ: ChatTypes.OutboxErrorType): string {
+  switch (typ) {
+    case ChatTypes.LocalOutboxErrorType.misc:
+      return 'unknown error'
+    case ChatTypes.LocalOutboxErrorType.offline:
+      return 'disconnected from chat server'
+    case ChatTypes.LocalOutboxErrorType.identify:
+      return 'proofs failed for recipient user'
+    case ChatTypes.LocalOutboxErrorType.toolong:
+      return 'message is too long'
+    case ChatTypes.LocalOutboxErrorType.duplicate:
+      return 'message is a duplicate'
+  }
+  return `unknown error type ${typ}`
+}
+
 export {
   alwaysShowSelector,
   clientHeader,
   conversationStateSelector,
+  decodeFailureDescription,
   devicenameSelector,
   focusedSelector,
   followingSelector,

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -35,8 +35,9 @@ const factory = (
           prevMessageKey={prevMessageKey}
         />
       )
+    case 'errorInvisible':
+      return <Box data-unhandled={true} data-messageKey={messageKey} />
     case 'error': // fallthrough
-    case 'errorInvisible': // fallthrough
     case 'messageIDError':
       return <ErrorMessage messageKey={messageKey} />
     case 'outboxIDText': // fallthrough

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -353,6 +353,11 @@ const LocalMessageState: (
   savedPath: null,
 })
 
+export type PendingFailureState = {
+  failureDescription: string,
+  failureType: ChatTypes.OutboxErrorType,
+}
+
 const defaultLocalMessageState = new LocalMessageState({})
 
 const getLocalMessageStateFromMessageKey = (state: TypedState, messageKey: MessageKey): ?Message =>
@@ -403,7 +408,7 @@ export type State = KBRecord<{
   supersedesState: SupersedesState,
   supersededByState: SupersededByState,
   metaData: MetaDataMap,
-  pendingFailures: Map<OutboxIDKey, ?string>,
+  pendingFailures: Map<OutboxIDKey, PendingFailureState>,
   conversationUnreadCounts: Map<ConversationIDKey, number>,
   rekeyInfos: Map<ConversationIDKey, RekeyInfo>,
   alwaysShow: Set<ConversationIDKey>,
@@ -459,7 +464,7 @@ export type ClearSearchResults = NoErrorTypedAction<'chat:clearSearchResults', {
 export type ClearRekey = NoErrorTypedAction<'chat:clearRekey', {conversationIDKey: ConversationIDKey}>
 export type CreatePendingFailure = NoErrorTypedAction<
   'chat:createPendingFailure',
-  {failureDescription: string, outboxID: OutboxIDKey}
+  {failureDescription: string, failureType: ChatTypes.OutboxErrorType, outboxID: OutboxIDKey}
 >
 export type DeleteMessage = NoErrorTypedAction<'chat:deleteMessage', {message: Message}>
 export type EditMessage = NoErrorTypedAction<'chat:editMessage', {message: Message, text: HiddenString}>

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -373,8 +373,11 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
       )
     }
     case 'chat:createPendingFailure': {
-      const {failureDescription, outboxID} = action.payload
-      return state.set('pendingFailures', state.get('pendingFailures').set(outboxID, failureDescription))
+      const {failureDescription, failureType, outboxID} = action.payload
+      return state.set(
+        'pendingFailures',
+        state.get('pendingFailures').set(outboxID, {failureDescription, failureType})
+      )
     }
     case 'chat:removePendingFailure': {
       const {outboxID} = action.payload


### PR DESCRIPTION
@keybase/react-hackers CC @chrisnojima @mmaxim 

If we get a message with error type "duplicate". it means it was rejected by Gregor as a duplicate attempted send.  Normally we display errors for failed messages and offer to retry them, but that's not appropriate here -- we don't want to display anything at all.

This PR seems to work, but I don't much like the way it turned out.  We can learn of "duplicate" error messages in three different ways:

1. They can be relayed to us from the outbox as part of a GetThread call, in which case we need to not render them at all.

2. Race outcome 1: we can send a message, display it in pending state in the GUI, and then get an IncomingMessage notification telling us about the duplicate failure, in which case we need to delete it from the GUI after it's already been rendered.

3. Race outcome 2: we can send a message, but due to a race between sagas and RPCs that RPCs win, we learn of the message's duplicate failure before we finish thinking we've sent a message.  In this case we need to store away the fact that we've been told of a failure, and the fact that it's this special kind of failure, and then when we would normally render the message as pending in the GUI we decide not to.

To achieve this, I went with:

1. When we unbox a message with this duplicate error, we store it as a messageKind of 'errorInvisible' instead of  'outboxText'.  We have to store some kind of message, because it's an invariant in all of our code that an _unboxedToMessage() call produces a Message object for the store in every case.

2. When we're rendering a thread, we now render these 'errorInvisible' messages an an empty `<Box />`.

3. When we get an IncomingMessage telling us about a failure (Race outcome 1), we update the Message object in the store to have the messageKind updated to `errorInvisible` at that point, and it's rendered away as it would be in the first case.

4. When we get an IncomingMessage telling us about a failure we haven't rendered yet (Race outcome 2), we just don't add anything at all in the store.

This is complicated enough that I'm not confident the code's going to be correct, and in general debugging these errors and races in transitioning messages from pending -> sent -> deleted is causing us a lot of hassle, so I don't feel good about merging this PR yet.  We might be better just asking for CORE help to take care of this case.  Or, we could try to refactor our code to eliminate this RPC<->sagas race, which I think would make us feel happier about adding new edge cases to this code.

What do you think?