### PR TITLE
avoid cross-arch compilation in the keybase-git AUR package

### DIFF
--- a/packaging/linux/arch/PKGBUILD.git.in
+++ b/packaging/linux/arch/PKGBUILD.git.in
@@ -32,8 +32,10 @@ build() {
 package() {
   if [ "$CARCH" = "i686" ] ; then
     deb_arch="i386"
+    export KEYBASE_SKIP_64_BIT=1
   elif [ "$CARCH" = "x86_64" ] ; then
     deb_arch="amd64"
+    export KEYBASE_SKIP_32_BIT=1
   else
     echo "Unknown arch: $CARCH"
     exit 1

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -153,12 +153,20 @@ build_one_architecture() {
 # resinit_nix.go and fail the i386 build
 export CGO_ENABLED=1
 
-export GOARCH=amd64
-export debian_arch=amd64
-export electron_arch=x64
-build_one_architecture
+if [ -z "${KEYBASE_SKIP_64_BIT:-}" ] ; then
+  export GOARCH=amd64
+  export debian_arch=amd64
+  export electron_arch=x64
+  build_one_architecture
+else
+  echo SKIPPING 64-bit build
+fi
 
-export GOARCH=386
-export debian_arch=i386
-export electron_arch=ia32
-build_one_architecture
+if [ -z "${KEYBASE_SKIP_32_BIT:-}" ] ; then
+  export GOARCH=386
+  export debian_arch=i386
+  export electron_arch=ia32
+  build_one_architecture
+else
+  echo SKIPPING 32-bit build
+fi


### PR DESCRIPTION
The 32-bit build used to just waste time (which was still bad!), but now
that we've introduced CGO it requires extra build dependencies. Skip it
entirely.

r? @cjb 