### PR TITLE
remove setTimeout which caused our session handling to be incorrect

### DIFF
--- a/shared/engine/transport-shared.js
+++ b/shared/engine/transport-shared.js
@@ -123,10 +123,7 @@ class TransportShared extends RobustTransport {
       // delay the call back to us
       const handler = payload => {
         this._injectInstrumentedResponse(payload)
-        // Defer a frame since decoding can take awhile, using setTimeout and not setImmediate on purpose
-        setTimeout(() => {
-          incomingRPCCallback(payload)
-        }, 0)
+        incomingRPCCallback(payload)
       }
 
       this.set_generic_handler(


### PR DESCRIPTION
I noticed getting yellowboxes on messages to dead sessions. This is a timing issue where we get incoming rpc closing events and handle those immediately , yet can handle messages in a delayed fashion. Instead of making that work (which seems racy anyways) i just removed the setTimeout I added. We can hopefully fix this in another way, this is simple for now
@keybase/react-hackers 