### PR TITLE
add topic name state to metadata messages and check for duplicate topic name CORE-5665

### DIFF
--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -25,7 +25,7 @@ func setupLoaderTest(t *testing.T) (*kbtest.ChatTestContext, *kbtest.ChatMockWor
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, _, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, _, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -32,7 +32,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -369,7 +369,7 @@ func TestGetThreadCaching(t *testing.T) {
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -482,7 +482,7 @@ func TestGetThreadHoleResolution(t *testing.T) {
 		pt.MessageBody = chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: fmt.Sprintf("MIKE: %d", i),
 		})
-		msg, _, _, _, err = sender.Prepare(ctx, pt, chat1.ConversationMembersType_KBFS, &conv)
+		msg, _, _, _, _, err = sender.Prepare(ctx, pt, chat1.ConversationMembersType_KBFS, &conv)
 		require.NoError(t, err)
 		require.NotNil(t, msg)
 

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -236,3 +236,13 @@ func (e OfflineClient) Call(ctx context.Context, method string, arg interface{},
 func (e OfflineClient) Notify(ctx context.Context, method string, arg interface{}) error {
 	return OfflineError{}
 }
+
+//=============================================================================
+
+type DuplicateTopicNameError struct {
+	TopicName string
+}
+
+func (e DuplicateTopicNameError) Error() string {
+	return fmt.Sprintf("channel name %s is already in use", e.TopicName)
+}

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -2,7 +2,6 @@ package chat
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -17,7 +16,6 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/go-codec/codec"
 )
 
 func SendTextByName(ctx context.Context, g *globals.Context, name string, membersType chat1.ConversationMembersType, ident keybase1.TLFIdentifyBehavior, text string, ri chat1.RemoteInterface) error {
@@ -324,18 +322,10 @@ func GetTopicNameState(ctx context.Context, g *globals.Context, debugger utils.D
 		})
 	}
 
-	mh := codec.MsgpackHandle{WriteExt: true}
-	var data []byte
-	enc := codec.NewEncoderBytes(&data, &mh)
-	if err := enc.Encode(pairs); err != nil {
+	if res, err = utils.CreateTopicNameState(pairs); err != nil {
+		debugger.Debug(ctx, "GetTopicNameState: failed to create topic name state: %s", err.Error())
 		return res, rl, err
 	}
 
-	h := sha256.New()
-	if _, err = h.Write(data); err != nil {
-		debugger.Debug(ctx, "GetTopicNameState: failed to hash topic name state: %s", err.Error())
-		return res, rl, err
-	}
-
-	return h.Sum(nil), rl, nil
+	return res, rl, nil
 }

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -291,19 +291,12 @@ func GetTLFConversations(ctx context.Context, g *globals.Context, debugger utils
 }
 
 func GetTopicNameState(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
-	ri func() chat1.RemoteInterface,
+	convs []chat1.ConversationLocal,
 	uid gregor1.UID, tlfID chat1.TLFID, topicType chat1.TopicType,
-	membersType chat1.ConversationMembersType) (res chat1.TopicNameState, rl []chat1.RateLimit, err error) {
-
-	var convs []chat1.ConversationLocal
-	convs, rl, err = GetTLFConversations(ctx, g, debugger, ri, uid, tlfID, topicType, membersType)
-	if err != nil {
-		debugger.Debug(ctx, "GetTopicNameState: failed to get TLF conversations: %s", err.Error())
-		return res, rl, err
-	}
-	sort.Sort(utils.ConvLocalByConvID(convs))
+	membersType chat1.ConversationMembersType) (res chat1.TopicNameState, err error) {
 
 	var pairs chat1.ConversationIDMessageIDPairs
+	sort.Sort(utils.ConvLocalByConvID(convs))
 	for _, conv := range convs {
 		msg, err := conv.GetMaxMessage(chat1.MessageType_METADATA)
 		if err != nil {
@@ -324,8 +317,8 @@ func GetTopicNameState(ctx context.Context, g *globals.Context, debugger utils.D
 
 	if res, err = utils.CreateTopicNameState(pairs); err != nil {
 		debugger.Debug(ctx, "GetTopicNameState: failed to create topic name state: %s", err.Error())
-		return res, rl, err
+		return res, err
 	}
 
-	return res, rl, nil
+	return res, nil
 }

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -104,7 +104,7 @@ func TestInboxSourceSkipAhead(t *testing.T) {
 
 	t.Logf("add message but drop oobm")
 
-	boxed, _, _, _, err := sender.Prepare(ctx, chat1.MessagePlaintext{
+	boxed, _, _, _, _, err := sender.Prepare(ctx, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        conv.Metadata.IdTriple,
 			Sender:      u.User.GetUID().ToBytes(),

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -321,11 +321,10 @@ func (s *BlockingSender) assetsForMessage(ctx context.Context, msgBody chat1.Mes
 	return assets, nil
 }
 
-func (s *BlockingSender) getTopicNameState(ctx context.Context, msg chat1.MessagePlaintext,
+func (s *BlockingSender) checkTopicNameAndGetState(ctx context.Context, msg chat1.MessagePlaintext,
 	conv *chat1.Conversation) (topicNameState *chat1.TopicNameState, err error) {
 	if conv != nil {
 		if msg.ClientHeader.MessageType == chat1.MessageType_METADATA {
-
 			newTopicName := msg.MessageBody.Metadata().ConversationTitle
 			convs, _, err := GetTLFConversations(ctx, s.G(), s.DebugLabeler, s.getRi,
 				msg.ClientHeader.Sender, conv.Metadata.IdTriple.Tlfid, conv.GetTopicType(),
@@ -386,7 +385,7 @@ func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePla
 
 	// Get topic name state if this is a METADATA message, so that we avoid any races to the
 	// server
-	topicNameState, err := s.getTopicNameState(ctx, msg, conv)
+	topicNameState, err := s.checkTopicNameAndGetState(ctx, msg, conv)
 	if err != nil {
 		return nil, nil, nil, chat1.ChannelMention_NONE, nil, err
 	}

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -426,7 +426,7 @@ func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePla
 	// it a bit to do it here.
 	boxed, err := s.boxer.BoxMessage(ctx, msg, membersType, skp)
 	if err != nil {
-		return nil, nil, nil, chanMention, topicNameState, err
+		return nil, nil, nil, chanMention, nil, err
 	}
 
 	return boxed, pendingAssetDeletes, atMentions, chanMention, topicNameState, nil
@@ -544,7 +544,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	}
 
 	var plres chat1.PostRemoteRes
-	// Try this up to 5 times in case we ar trying to set the topic name, and the topic name
+	// Try this up to 5 times in case we are trying to set the topic name, and the topic name
 	// state is moving around underneath us.
 	for i := 0; i < 5; i++ {
 		// Add a bunch of stuff to the message (like prev pointers, sender info, ...)

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -276,7 +276,7 @@ func TestNonblockTimer(t *testing.T) {
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, _, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, _, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -399,8 +399,8 @@ func (f FailingSender) Send(ctx context.Context, convID chat1.ConversationID,
 }
 
 func (f FailingSender) Prepare(ctx context.Context, msg chat1.MessagePlaintext,
-	membersType chat1.ConversationMembersType, convID *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, chat1.ChannelMention, error) {
-	return nil, nil, nil, chat1.ChannelMention_NONE, nil
+	membersType chat1.ConversationMembersType, convID *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, chat1.ChannelMention, *chat1.TopicNameState, error) {
+	return nil, nil, nil, chat1.ChannelMention_NONE, nil, nil
 }
 
 func recordCompare(t *testing.T, obids []chat1.OutboxID, obrs []chat1.OutboxRecord) {
@@ -651,7 +651,7 @@ func TestDeletionHeaders(t *testing.T) {
 		},
 		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: []chat1.MessageID{firstMessageID}}),
 	}
-	preparedDeletion, _, _, _, err := blockingSender.Prepare(ctx, deletion,
+	preparedDeletion, _, _, _, _, err := blockingSender.Prepare(ctx, deletion,
 		chat1.ConversationMembersType_KBFS, &conv)
 	require.NoError(t, err)
 
@@ -689,7 +689,7 @@ func TestAtMentionsText(t *testing.T) {
 
 	text := fmt.Sprintf("@%s hello! From @%s. @ksjdskj", u1.Username, u2.Username)
 	t.Logf("text: %s", text)
-	_, _, atMentions, chanMention, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
+	_, _, atMentions, chanMention, _, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        conv.Metadata.IdTriple,
 			Sender:      uid,
@@ -705,7 +705,7 @@ func TestAtMentionsText(t *testing.T) {
 	require.Equal(t, chat1.ChannelMention_NONE, chanMention)
 
 	text = "Hello @channel!"
-	_, _, atMentions, chanMention, err = blockingSender.Prepare(ctx, chat1.MessagePlaintext{
+	_, _, atMentions, chanMention, _, err = blockingSender.Prepare(ctx, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        conv.Metadata.IdTriple,
 			Sender:      uid,
@@ -752,7 +752,7 @@ func TestAtMentionsEdit(t *testing.T) {
 	// edit that message and add atMentions
 	text = fmt.Sprintf("@%s hello! From @%s. @ksjdskj", u1.Username, u2.Username)
 	firstMessageID := firstMessageBoxed.GetMessageID()
-	_, _, atMentions, chanMention, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
+	_, _, atMentions, chanMention, _, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        conv.Metadata.IdTriple,
 			Sender:      u.User.GetUID().ToBytes(),
@@ -771,7 +771,7 @@ func TestAtMentionsEdit(t *testing.T) {
 
 	// edit the message and add channel mention
 	text = "Hello @channel!"
-	_, _, atMentions, chanMention, err = blockingSender.Prepare(ctx, chat1.MessagePlaintext{
+	_, _, atMentions, chanMention, _, err = blockingSender.Prepare(ctx, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        conv.Metadata.IdTriple,
 			Sender:      uid,
@@ -822,7 +822,7 @@ func TestPrevPointerAddition(t *testing.T) {
 	require.NoError(t, err)
 
 	// Prepare a message and make sure it gets prev pointers
-	boxed, pendingAssetDeletes, _, _, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
+	boxed, pendingAssetDeletes, _, _, _, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        conv.Metadata.IdTriple,
 			Sender:      uid,
@@ -927,7 +927,7 @@ func TestDeletionAssets(t *testing.T) {
 		},
 		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: []chat1.MessageID{firstMessageID}}),
 	}
-	preparedDeletion, pendingAssetDeletes, _, _, err := blockingSender.Prepare(ctx, deletion,
+	preparedDeletion, pendingAssetDeletes, _, _, _, err := blockingSender.Prepare(ctx, deletion,
 		chat1.ConversationMembersType_KBFS, &conv)
 	require.NoError(t, err)
 

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -965,7 +965,8 @@ func (h *Server) PostLocal(ctx context.Context, arg chat1.PostLocalArg) (res cha
 
 	_, msgBoxed, rl, err := sender.Send(ctx, arg.ConversationID, arg.Msg, 0)
 	if err != nil {
-		return chat1.PostLocalRes{}, fmt.Errorf("PostLocal: unable to send message: %s", err.Error())
+		h.Debug(ctx, "PostLocal: unable to send message: %s", err.Error())
+		return chat1.PostLocalRes{}, err
 	}
 
 	return chat1.PostLocalRes{

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -520,7 +520,7 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 		if err != nil {
 			return chat1.NewConversationLocalRes{}, fmt.Errorf("error creating topic ID: %s", err)
 		}
-		firstMessageBoxed, err := h.makeFirstMessage(ctx, triple, info.CanonicalName,
+		firstMessageBoxed, topicNameState, err := h.makeFirstMessage(ctx, triple, info.CanonicalName,
 			arg.MembersType, arg.TlfVisibility, arg.TopicName)
 		if err != nil {
 			return chat1.NewConversationLocalRes{}, fmt.Errorf("error preparing message: %s", err)
@@ -528,9 +528,10 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 
 		var ncrres chat1.NewConversationRemoteRes
 		ncrres, reserr = h.remoteClient().NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
-			IdTriple:    triple,
-			TLFMessage:  *firstMessageBoxed,
-			MembersType: arg.MembersType,
+			IdTriple:       triple,
+			TLFMessage:     *firstMessageBoxed,
+			MembersType:    arg.MembersType,
+			TopicNameState: topicNameState,
 		})
 		if ncrres.RateLimit != nil {
 			res.RateLimits = append(res.RateLimits, *ncrres.RateLimit)
@@ -621,7 +622,7 @@ var DefaultTeamTopic = "general"
 
 func (h *Server) makeFirstMessage(ctx context.Context, triple chat1.ConversationIDTriple,
 	tlfName string, membersType chat1.ConversationMembersType, tlfVisibility chat1.TLFVisibility,
-	topicName *string) (*chat1.MessageBoxed, error) {
+	topicName *string) (*chat1.MessageBoxed, *chat1.TopicNameState, error) {
 	var msg chat1.MessagePlaintext
 	if topicName != nil {
 		msg = chat1.MessagePlaintext{
@@ -652,8 +653,8 @@ func (h *Server) makeFirstMessage(ctx context.Context, triple chat1.Conversation
 	}
 
 	sender := NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient)
-	mbox, _, _, _, err := sender.Prepare(ctx, msg, membersType, nil)
-	return mbox, err
+	mbox, _, _, _, topicNameState, err := sender.Prepare(ctx, msg, membersType, nil)
+	return mbox, topicNameState, err
 }
 
 func (h *Server) GetInboxSummaryForCLILocal(ctx context.Context, arg chat1.GetInboxSummaryForCLILocalQuery) (res chat1.GetInboxSummaryForCLILocalRes, err error) {
@@ -2368,8 +2369,13 @@ func (h *Server) GetTLFConversationsLocal(ctx context.Context, arg chat1.GetTLFC
 		return res, err
 	}
 
+<<<<<<< HEAD
 	res.Convs, res.RateLimits, err = GetTLFConversations(ctx, h.G(), h.DebugLabeler,
 		h.remoteClient, uid, nameInfo.ID, arg.TopicType, arg.MembersType)
+=======
+	res.Convs, res.RateLimits, err = GetTLFConversations(ctx, h.G(), h.DebugLabeler, h.remoteClient,
+		uid, nameInfo.ID, arg.TopicType, arg.MembersType)
+>>>>>>> wip
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2369,13 +2369,8 @@ func (h *Server) GetTLFConversationsLocal(ctx context.Context, arg chat1.GetTLFC
 		return res, err
 	}
 
-<<<<<<< HEAD
 	res.Convs, res.RateLimits, err = GetTLFConversations(ctx, h.G(), h.DebugLabeler,
 		h.remoteClient, uid, nameInfo.ID, arg.TopicType, arg.MembersType)
-=======
-	res.Convs, res.RateLimits, err = GetTLFConversations(ctx, h.G(), h.DebugLabeler, h.remoteClient,
-		uid, nameInfo.ID, arg.TopicType, arg.MembersType)
->>>>>>> wip
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -514,7 +514,7 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 		TopicID:   make(chat1.TopicID, 16),
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		h.Debug(ctx, "NewConversationLocal: attempt: %v", i)
 		triple.TopicID, err = utils.NewChatTopicID()
 		if err != nil {
@@ -525,7 +525,6 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 		if err != nil {
 			return chat1.NewConversationLocalRes{}, fmt.Errorf("error preparing message: %s", err)
 		}
-
 		var ncrres chat1.NewConversationRemoteRes
 		ncrres, reserr = h.remoteClient().NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
 			IdTriple:       triple,
@@ -539,6 +538,9 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 		convID := ncrres.ConvID
 		if reserr != nil {
 			switch cerr := reserr.(type) {
+			case libkb.ChatStalePreviousStateError:
+				h.Debug(ctx, "NewConversationLocal: stale topic name state, trying again")
+				continue
 			case libkb.ChatConvExistsError:
 				// This triple already exists.
 				h.Debug(ctx, "NewConversationLocal: conv exists: %v", cerr.ConvID)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2313,12 +2313,12 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, ts1.Eq(*ts2))
 
-		_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
+		/*_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
 			ConversationID: conv.Id,
 			MessageBoxed:   *msg1,
 		})
 		require.Error(t, err)
-		require.IsType(t, libkb.ChatClientError{}, err)
+		require.IsType(t, libkb.ChatClientError{}, err)*/
 		_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
 			ConversationID: conv.Id,
 			MessageBoxed:   *msg1,

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -26,7 +26,7 @@ func newBlankConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext,
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -59,7 +59,7 @@ type MessageDeliverer interface {
 type Sender interface {
 	Send(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext, clientPrev chat1.MessageID) (chat1.OutboxID, *chat1.MessageBoxed, *chat1.RateLimit, error)
 	Prepare(ctx context.Context, msg chat1.MessagePlaintext, membersType chat1.ConversationMembersType,
-		conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, chat1.ChannelMention, error)
+		conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, chat1.ChannelMention, *chat1.TopicNameState, error)
 }
 
 type ChatLocalizer interface {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -496,18 +496,19 @@ func SanitizeTopicName(topicName string) string {
 func CreateTopicNameState(cmp chat1.ConversationIDMessageIDPairs) chat1.TopicNameState {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	var data []byte
+	var err error
+	mh := codec.MsgpackHandle{WriteExt: true}
 	enc := codec.NewEncoderBytes(&data, &mh)
-	if err := enc.Encode(pairs); err != nil {
-		return res, rl, err
+	if err = enc.Encode(cmp); err != nil {
+		return chat1.TopicNameState{}, err
 	}
 
 	h := sha256.New()
 	if _, err = h.Write(data); err != nil {
-		debugger.Debug(ctx, "GetTopicNameState: failed to hash topic name state: %s", err.Error())
-		return res, rl, err
+		return chat1.TopicNameState{}, err
 	}
 
-	return h.Sum(nil)
+	return h.Sum(nil), nil
 }
 
 type ConvLocalByConvID []chat1.ConversationLocal

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"sort"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
 	context "golang.org/x/net/context"
 )
 
@@ -489,6 +491,23 @@ func PluckConvIDs(convs []chat1.Conversation) (res []chat1.ConversationID) {
 
 func SanitizeTopicName(topicName string) string {
 	return strings.TrimPrefix(topicName, "#")
+}
+
+func CreateTopicNameState(cmp chat1.ConversationIDMessageIDPairs) chat1.TopicNameState {
+	mh := codec.MsgpackHandle{WriteExt: true}
+	var data []byte
+	enc := codec.NewEncoderBytes(&data, &mh)
+	if err := enc.Encode(pairs); err != nil {
+		return res, rl, err
+	}
+
+	h := sha256.New()
+	if _, err = h.Write(data); err != nil {
+		debugger.Debug(ctx, "GetTopicNameState: failed to hash topic name state: %s", err.Error())
+		return res, rl, err
+	}
+
+	return h.Sum(nil)
 }
 
 type ConvLocalByConvID []chat1.ConversationLocal

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -493,8 +493,7 @@ func SanitizeTopicName(topicName string) string {
 	return strings.TrimPrefix(topicName, "#")
 }
 
-func CreateTopicNameState(cmp chat1.ConversationIDMessageIDPairs) chat1.TopicNameState {
-	mh := codec.MsgpackHandle{WriteExt: true}
+func CreateTopicNameState(cmp chat1.ConversationIDMessageIDPairs) (chat1.TopicNameState, error) {
 	var data []byte
 	var err error
 	mh := codec.MsgpackHandle{WriteExt: true}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -245,6 +245,7 @@ const (
 	SCChatAlreadyDeleted       = int(keybase1.StatusCode_SCChatAlreadyDeleted)
 	SCChatTLFFinalized         = int(keybase1.StatusCode_SCChatTLFFinalized)
 	SCChatCollision            = int(keybase1.StatusCode_SCChatCollision)
+	SCChatStalePreviousState   = int(keybase1.StatusCode_SCChatStalePreviousState)
 	SCBadEmail                 = int(keybase1.StatusCode_SCBadEmail)
 	SCIdentifySummaryError     = int(keybase1.StatusCode_SCIdentifySummaryError)
 	SCNeedSelfRekey            = int(keybase1.StatusCode_SCNeedSelfRekey)

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1859,6 +1859,14 @@ func (e ChatClientError) Error() string {
 
 //=============================================================================
 
+type ChatStalePreviousStateError struct{}
+
+func (e ChatStalePreviousStateError) Error() string {
+	return "stale previous state error"
+}
+
+//=============================================================================
+
 type InvalidAddressError struct {
 	Msg string
 }

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -409,6 +409,8 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		}
 	case SCChatInternal:
 		return ChatInternalError{}
+	case SCChatStalePreviousState:
+		return ChatStalePreviousStateError{}
 	case SCChatConvExists:
 		var convID chat1.ConversationID
 		for _, field := range s.Fields {
@@ -1763,6 +1765,14 @@ func (e ChatInternalError) ToStatus() keybase1.Status {
 	return keybase1.Status{
 		Code: SCChatInternal,
 		Name: "SC_CHAT_INTERNAL",
+		Desc: e.Error(),
+	}
+}
+
+func (e ChatStalePreviousStateError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCChatStalePreviousState,
+		Name: "SC_CHAT_STALE_PREVIOUS_STATE",
 		Desc: e.Error(),
 	}
 }

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -94,6 +94,17 @@ func (o OutboxID) DeepCopy() OutboxID {
 	})(o)
 }
 
+type TopicNameState []byte
+
+func (o TopicNameState) DeepCopy() TopicNameState {
+	return (func(x []byte) []byte {
+		if x == nil {
+			return nil
+		}
+		return append([]byte(nil), x...)
+	})(o)
+}
+
 type ConversationMembersType int
 
 const (
@@ -257,6 +268,35 @@ func (o ConversationMember) DeepCopy() ConversationMember {
 	return ConversationMember{
 		Uid:    o.Uid.DeepCopy(),
 		ConvID: o.ConvID.DeepCopy(),
+	}
+}
+
+type ConversationIDMessageIDPair struct {
+	ConvID ConversationID `codec:"convID" json:"convID"`
+	MsgID  MessageID      `codec:"msgID" json:"msgID"`
+}
+
+func (o ConversationIDMessageIDPair) DeepCopy() ConversationIDMessageIDPair {
+	return ConversationIDMessageIDPair{
+		ConvID: o.ConvID.DeepCopy(),
+		MsgID:  o.MsgID.DeepCopy(),
+	}
+}
+
+type ConversationIDMessageIDPairs struct {
+	Pairs []ConversationIDMessageIDPair `codec:"pairs" json:"pairs"`
+}
+
+func (o ConversationIDMessageIDPairs) DeepCopy() ConversationIDMessageIDPairs {
+	return ConversationIDMessageIDPairs{
+		Pairs: (func(x []ConversationIDMessageIDPair) []ConversationIDMessageIDPair {
+			var ret []ConversationIDMessageIDPair
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Pairs),
 	}
 }
 

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -616,4 +617,12 @@ func MakeEmptyUnreadUpdate(convID ConversationID) UnreadUpdate {
 		UnreadMessages:          0,
 		UnreadNotifyingMessages: counts,
 	}
+}
+
+func (s TopicNameState) Bytes() []byte {
+	return []byte(s)
+}
+
+func (s TopicNameState) Eq(o chat1.TopicNameState) bool {
+	return bytes.Equal(s.Bytes(), o.Bytes())
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -623,6 +622,6 @@ func (s TopicNameState) Bytes() []byte {
 	return []byte(s)
 }
 
-func (s TopicNameState) Eq(o chat1.TopicNameState) bool {
+func (s TopicNameState) Eq(o TopicNameState) bool {
 	return bytes.Equal(s.Bytes(), o.Bytes())
 }

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -738,10 +738,11 @@ func (o GetPublicConversationsArg) DeepCopy() GetPublicConversationsArg {
 }
 
 type PostRemoteArg struct {
-	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
-	MessageBoxed   MessageBoxed   `codec:"messageBoxed" json:"messageBoxed"`
-	AtMentions     []gregor1.UID  `codec:"atMentions" json:"atMentions"`
-	ChannelMention ChannelMention `codec:"channelMention" json:"channelMention"`
+	ConversationID ConversationID  `codec:"conversationID" json:"conversationID"`
+	MessageBoxed   MessageBoxed    `codec:"messageBoxed" json:"messageBoxed"`
+	AtMentions     []gregor1.UID   `codec:"atMentions" json:"atMentions"`
+	ChannelMention ChannelMention  `codec:"channelMention" json:"channelMention"`
+	TopicNameState *TopicNameState `codec:"topicNameState,omitempty" json:"topicNameState,omitempty"`
 }
 
 func (o PostRemoteArg) DeepCopy() PostRemoteArg {
@@ -757,6 +758,13 @@ func (o PostRemoteArg) DeepCopy() PostRemoteArg {
 			return ret
 		})(o.AtMentions),
 		ChannelMention: o.ChannelMention.DeepCopy(),
+		TopicNameState: (func(x *TopicNameState) *TopicNameState {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.TopicNameState),
 	}
 }
 
@@ -771,9 +779,10 @@ func (o NewConversationRemoteArg) DeepCopy() NewConversationRemoteArg {
 }
 
 type NewConversationRemote2Arg struct {
-	IdTriple    ConversationIDTriple    `codec:"idTriple" json:"idTriple"`
-	TLFMessage  MessageBoxed            `codec:"TLFMessage" json:"TLFMessage"`
-	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
+	IdTriple       ConversationIDTriple    `codec:"idTriple" json:"idTriple"`
+	TLFMessage     MessageBoxed            `codec:"TLFMessage" json:"TLFMessage"`
+	MembersType    ConversationMembersType `codec:"membersType" json:"membersType"`
+	TopicNameState *TopicNameState         `codec:"topicNameState,omitempty" json:"topicNameState,omitempty"`
 }
 
 func (o NewConversationRemote2Arg) DeepCopy() NewConversationRemote2Arg {
@@ -781,6 +790,13 @@ func (o NewConversationRemote2Arg) DeepCopy() NewConversationRemote2Arg {
 		IdTriple:    o.IdTriple.DeepCopy(),
 		TLFMessage:  o.TLFMessage.DeepCopy(),
 		MembersType: o.MembersType.DeepCopy(),
+		TopicNameState: (func(x *TopicNameState) *TopicNameState {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.TopicNameState),
 	}
 }
 

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -104,6 +104,7 @@ const (
 	StatusCode_SCChatDuplicateMessage     StatusCode = 2515
 	StatusCode_SCChatClientError          StatusCode = 2516
 	StatusCode_SCChatNotInTeam            StatusCode = 2517
+	StatusCode_SCChatStalePreviousState   StatusCode = 2518
 	StatusCode_SCTeamNotFound             StatusCode = 2614
 	StatusCode_SCTeamExists               StatusCode = 2619
 	StatusCode_SCTeamReadError            StatusCode = 2623
@@ -209,6 +210,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCChatDuplicateMessage":     2515,
 	"SCChatClientError":          2516,
 	"SCChatNotInTeam":            2517,
+	"SCChatStalePreviousState":   2518,
 	"SCTeamNotFound":             2614,
 	"SCTeamExists":               2619,
 	"SCTeamReadError":            2623,
@@ -312,6 +314,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2515: "SCChatDuplicateMessage",
 	2516: "SCChatClientError",
 	2517: "SCChatNotInTeam",
+	2518: "SCChatStalePreviousState",
 	2614: "SCTeamNotFound",
 	2619: "SCTeamExists",
 	2623: "SCTeamReadError",

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -13,6 +13,7 @@ protocol common {
   @typedef("bytes")  record Hash {}
   @typedef("uint64") @lint("ignore") record InboxVers {}
   @typedef("bytes")  record OutboxID {}
+  @typedef("bytes")  record TopicNameState {}
 
   enum ConversationMembersType {
     KBFS_0,
@@ -82,6 +83,14 @@ protocol common {
     ConversationID convID;
   }
 
+  record ConversationIDMessageIDPair {
+    ConversationID convID;
+    MessageID msgID;
+  }
+  record ConversationIDMessageIDPairs {
+    array<ConversationIDMessageIDPair> pairs;
+  }
+
   enum ConversationMemberStatus {
     ACTIVE_0,  // in the channel
     REMOVED_1, // removed from channel forcibly
@@ -121,7 +130,7 @@ protocol common {
     // If left empty, default is to show unfiled and favorite
     array<ConversationStatus> status;
 
-    // Extended list of conversation IDs to fetch (don't need to set convID, if convID is set then 
+    // Extended list of conversation IDs to fetch (don't need to set convID, if convID is set then
     // this it will be like appending it to this list)
     array<ConversationID> convIDs;
 
@@ -185,7 +194,7 @@ protocol common {
 
   record Conversation {
     ConversationMetadata metadata;
-    union { null, ConversationReaderInfo } readerInfo; // information about the convo from a user perspective 
+    union { null, ConversationReaderInfo } readerInfo; // information about the convo from a user perspective
     union { null, ConversationNotificationInfo } notifications; // user notification settings for the convo, will be null if it is just the default. Otherwise contains entries to modify default setting.
 
     // maxMsgs is the maximum message for each messageType in the conversation

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -96,7 +96,7 @@ protocol remote {
   }
 
   record GetPublicConversationsRes {
-    array<Conversation> conversations; 
+    array<Conversation> conversations;
     union { null, RateLimit } rateLimit;
   }
 
@@ -110,12 +110,12 @@ protocol remote {
     HERE_2
   }
 
-  PostRemoteRes postRemote(ConversationID conversationID, MessageBoxed messageBoxed, array<gregor1.UID> atMentions, ChannelMention channelMention);
+  PostRemoteRes postRemote(ConversationID conversationID, MessageBoxed messageBoxed, array<gregor1.UID> atMentions, ChannelMention channelMention, union { null, TopicNameState } topicNameState);
   NewConversationRemoteRes newConversationRemote(ConversationIDTriple idTriple);
 
   // on duplication of idTriple, and error is returned and the conversation ID of the existing conversation is returned.
   @lint("ignore")
-  NewConversationRemoteRes newConversationRemote2(ConversationIDTriple idTriple, MessageBoxed TLFMessage, ConversationMembersType membersType);
+  NewConversationRemoteRes newConversationRemote2(ConversationIDTriple idTriple, MessageBoxed TLFMessage, ConversationMembersType membersType, union { null, TopicNameState } topicNameState);
   GetMessagesRemoteRes getMessagesRemote(ConversationID conversationID, array<MessageID> messageIDs);
 
   MarkAsReadRes markAsRead(ConversationID conversationID, MessageID msgID);
@@ -152,18 +152,18 @@ protocol remote {
   bytes s3Sign(int version, bytes payload);
 
   // Get the inbox version for a user
-  InboxVers getInboxVersion(gregor1.UID uid); 
+  InboxVers getInboxVersion(gregor1.UID uid);
 
   enum SyncInboxResType {
     CURRENT_0,
     INCREMENTAL_1,
     CLEAR_2
   }
-  
+
   record SyncIncrementalRes {
     InboxVers vers;
     array<Conversation> convs;
-  } 
+  }
 
   record ServerCacheVers {
     int inboxVers;
@@ -197,7 +197,7 @@ protocol remote {
   }
 
   record SyncAllResult {
-    gregor1.AuthResult auth; 
+    gregor1.AuthResult auth;
     SyncChatRes chat;
     SyncAllNotificationRes notification;
     UnreadUpdateFull badge;
@@ -221,21 +221,21 @@ protocol remote {
 
   // Channel endpoints
   record JoinLeaveConversationRemoteRes {
-    union { null, RateLimit } rateLimit; 
+    union { null, RateLimit } rateLimit;
   }
   JoinLeaveConversationRemoteRes joinConversation(ConversationID convID);
   JoinLeaveConversationRemoteRes leaveConversation(ConversationID convID);
 
   record GetTLFConversationsRes {
-    array<Conversation> conversations; 
+    array<Conversation> conversations;
     union { null, RateLimit } rateLimit;
   }
   GetTLFConversationsRes getTLFConversations(TLFID tlfID, TopicType topicType, ConversationMembersType membersType, boolean summarizeMaxMsgs);
 
-  // Chat notification configuration endpoint. Does not need to be complete, just a delta on the 
+  // Chat notification configuration endpoint. Does not need to be complete, just a delta on the
   // currently configured settings.
   record SetAppNotificationSettingsRes {
-    union { null, RateLimit } rateLimit; 
+    union { null, RateLimit } rateLimit;
   }
   SetAppNotificationSettingsRes setAppNotificationSettings(ConversationID convID, ConversationNotificationInfo settings);
 

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -96,6 +96,7 @@ protocol constants {
     SCChatDuplicateMessage_2515,
     SCChatClientError_2516,
     SCChatNotInTeam_2517,
+    SCChatStalePreviousState_2518,
     SCTeamNotFound_2614,
     SCTeamExists_2619,
     SCTeamReadError_2623,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1039,6 +1039,15 @@ export type ConversationFinalizeInfo = {
 
 export type ConversationID = bytes
 
+export type ConversationIDMessageIDPair = {
+  convID: ConversationID,
+  msgID: MessageID,
+}
+
+export type ConversationIDMessageIDPairs = {
+  pairs?: ?Array<ConversationIDMessageIDPair>,
+}
+
 export type ConversationIDTriple = {
   tlfid: TLFID,
   topicType: TopicType,
@@ -1930,6 +1939,8 @@ export type ThreadViewBoxed = {
 
 export type TopicID = bytes
 
+export type TopicNameState = bytes
+
 export type TopicType =
     0 // NONE_0
   | 1 // CHAT_1
@@ -2273,7 +2284,8 @@ export type remoteMarkAsReadRpcParam = Exact<{
 export type remoteNewConversationRemote2RpcParam = Exact<{
   idTriple: ConversationIDTriple,
   TLFMessage: MessageBoxed,
-  membersType: ConversationMembersType
+  membersType: ConversationMembersType,
+  topicNameState?: ?TopicNameState
 }>
 
 export type remoteNewConversationRemoteRpcParam = Exact<{
@@ -2284,7 +2296,8 @@ export type remotePostRemoteRpcParam = Exact<{
   conversationID: ConversationID,
   messageBoxed: MessageBoxed,
   atMentions?: ?Array<gregor1.UID>,
-  channelMention: ChannelMention
+  channelMention: ChannelMention,
+  topicNameState?: ?TopicNameState
 }>
 
 export type remotePublishReadMessageRpcParam = Exact<{

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -206,6 +206,7 @@ export const ConstantsStatusCode = {
   scchatduplicatemessage: 2515,
   scchatclienterror: 2516,
   scchatnotinteam: 2517,
+  scchatstalepreviousstate: 2518,
   scteamnotfound: 2614,
   scteamexists: 2619,
   scteamreaderror: 2623,
@@ -5258,6 +5259,7 @@ export type StatusCode =
   | 2515 // SCChatDuplicateMessage_2515
   | 2516 // SCChatClientError_2516
   | 2517 // SCChatNotInTeam_2517
+  | 2518 // SCChatStalePreviousState_2518
   | 2614 // SCTeamNotFound_2614
   | 2619 // SCTeamExists_2619
   | 2623 // SCTeamReadError_2623

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -71,6 +71,12 @@
       "typedef": "bytes"
     },
     {
+      "type": "record",
+      "name": "TopicNameState",
+      "fields": [],
+      "typedef": "bytes"
+    },
+    {
       "type": "enum",
       "name": "ConversationMembersType",
       "symbols": [
@@ -139,6 +145,33 @@
         {
           "type": "ConversationID",
           "name": "convID"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "ConversationIDMessageIDPair",
+      "fields": [
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        },
+        {
+          "type": "MessageID",
+          "name": "msgID"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "ConversationIDMessageIDPairs",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationIDMessageIDPair"
+          },
+          "name": "pairs"
         }
       ]
     },

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -579,6 +579,13 @@
         {
           "name": "channelMention",
           "type": "ChannelMention"
+        },
+        {
+          "name": "topicNameState",
+          "type": [
+            null,
+            "TopicNameState"
+          ]
         }
       ],
       "response": "PostRemoteRes"
@@ -605,6 +612,13 @@
         {
           "name": "membersType",
           "type": "ConversationMembersType"
+        },
+        {
+          "name": "topicNameState",
+          "type": [
+            null,
+            "TopicNameState"
+          ]
         }
       ],
       "response": "NewConversationRemoteRes",

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -100,6 +100,7 @@
         "SCChatDuplicateMessage_2515",
         "SCChatClientError_2516",
         "SCChatNotInTeam_2517",
+        "SCChatStalePreviousState_2518",
         "SCTeamNotFound_2614",
         "SCTeamExists_2619",
         "SCTeamReadError_2623",

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1039,6 +1039,15 @@ export type ConversationFinalizeInfo = {
 
 export type ConversationID = bytes
 
+export type ConversationIDMessageIDPair = {
+  convID: ConversationID,
+  msgID: MessageID,
+}
+
+export type ConversationIDMessageIDPairs = {
+  pairs?: ?Array<ConversationIDMessageIDPair>,
+}
+
 export type ConversationIDTriple = {
   tlfid: TLFID,
   topicType: TopicType,
@@ -1930,6 +1939,8 @@ export type ThreadViewBoxed = {
 
 export type TopicID = bytes
 
+export type TopicNameState = bytes
+
 export type TopicType =
     0 // NONE_0
   | 1 // CHAT_1
@@ -2273,7 +2284,8 @@ export type remoteMarkAsReadRpcParam = Exact<{
 export type remoteNewConversationRemote2RpcParam = Exact<{
   idTriple: ConversationIDTriple,
   TLFMessage: MessageBoxed,
-  membersType: ConversationMembersType
+  membersType: ConversationMembersType,
+  topicNameState?: ?TopicNameState
 }>
 
 export type remoteNewConversationRemoteRpcParam = Exact<{
@@ -2284,7 +2296,8 @@ export type remotePostRemoteRpcParam = Exact<{
   conversationID: ConversationID,
   messageBoxed: MessageBoxed,
   atMentions?: ?Array<gregor1.UID>,
-  channelMention: ChannelMention
+  channelMention: ChannelMention,
+  topicNameState?: ?TopicNameState
 }>
 
 export type remotePublishReadMessageRpcParam = Exact<{

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -206,6 +206,7 @@ export const ConstantsStatusCode = {
   scchatduplicatemessage: 2515,
   scchatclienterror: 2516,
   scchatnotinteam: 2517,
+  scchatstalepreviousstate: 2518,
   scteamnotfound: 2614,
   scteamexists: 2619,
   scteamreaderror: 2623,
@@ -5258,6 +5259,7 @@ export type StatusCode =
   | 2515 // SCChatDuplicateMessage_2515
   | 2516 // SCChatClientError_2516
   | 2517 // SCChatNotInTeam_2517
+  | 2518 // SCChatStalePreviousState_2518
   | 2614 // SCTeamNotFound_2614
   | 2619 // SCTeamExists_2619
   | 2623 // SCTeamReadError_2623


### PR DESCRIPTION
Patch does the following:

1.) Check for duplicate topic names in `BlockingSender.Prepare`, as well as computes the `TopicNameState` as the time we do the duplicate check.
2.) Adds the `TopicNameState` parameter to `NewConversationRemote` and `PostRemote` to cover cases of topic name changes.
3.) Add retry loop to `BlockingSender.Send` in case we get an stale topic name state error back from the server. We can retry up to 5 times to see if we can get our change into play.

Companion of (and won't pass CI until merged): https://github.com/keybase/keybase/pull/1552