### PR TITLE
Add chat to rn storybook

### DIFF
--- a/shared/chat/conversation/list/index.stories.js
+++ b/shared/chat/conversation/list/index.stories.js
@@ -1,0 +1,172 @@
+// @flow
+import React from 'react'
+import * as I from 'immutable'
+import * as Constants from '../../../constants/chat'
+import {Box} from '../../../common-adapters'
+import {dataToRouteState} from '../../../route-tree'
+import {storiesOf, action} from '../../../stories/storybook'
+import {Provider} from 'react-redux'
+import {createStore} from 'redux'
+import List from './index'
+import {range} from 'lodash'
+import HiddenString from '../../../util/hidden-string'
+import {globalStyles} from '../../../styles'
+
+const you = 'trex'
+const conversationIDKey = 'mock'
+
+const users = ['trex', 'xert']
+const corpus = [
+  `Sorry, other word classes!  I have a NEW girlfriend now!`,
+  `Nope. He'd have to earn it! We'd do sports or something to see.`,
+  `What?! Seriously?`,
+  `Well, maybe the magazine will pique my interest!`,
+  `Insurance motivators? Uh, building complicaters? Domino frustraters? Wobbley Times U.S.A.? Um. . . Shakey Shakes Central? `,
+  `I'm going for STUNT immortality. I'll just keep kicking that kangaroo until even if somebody wanted to catch up, they'd look at my record and say "Well, THAT'S totally not worth doing".`,
+  `FINE. NO I DON'T.`,
+  ` Comedy relies on surprise, I think!  There's a twist that makes a joke funny, and I haven't figured out a generative algorithm yet.`,
+  `I - I think it's weird. `,
+  `Or perhaps like this!`,
+  `It occurs to me: every time I do something private, I'm REALLY just betting that technology to look into the arbitrary past won't ever be developed.  Because if it is ever invented, game over, man, game over!  People will be able to look at any moment in history!`,
+  `Companies don't want their most popular characters dying of old age!`,
+  `The creativity that was required to create hoverbikes has been erased!  Who had the insight now?`,
+  `UTAHRAPTOR. His speaking voice sounds like a text-to-speech synthesizer. That is awesome! That is objectively awesome.`,
+  `Oh wow! Really?`,
+  `Earlier today my nose was like, "Hey, T-Rex! I'm gonna leak blood for no reason!" and I was all "...Awesome?"`,
+  `*cough*`,
+  `But have you examined Appendix A of my resume, in whice there is an amazingly sweet HOLOGRAPHIC Batman sicker?`,
+  `LAH LAH LAH LAH LAH I can't hear you LAH LAH LAH what does God need with erotica anyway LAH LAH LAH LAH don't answer that LAH LAH LAH`,
+  ` Oooh, what's this, a sheep?  What are you going to do, PUNCH ME?`,
+  `*sigh*`,
+  `Dromiceiomimus, I'll give you the punchline and you'll supply the identifiable social group to be mocked, okay? The puchline is: "Just one: they hold the lightbulb still while the world revolves around them."`,
+  `Bananas is spelt, "b-a-n-a-n-a-s".`,
+  `Baloney! You don't even have a console that can run it.`,
+  `I will take what I can get!!`,
+  `This has got to stop!`,
+  `It turns out you can't make a law saying "dudes nobody say this guy's name anymore okay" without saying his name SOMEWHERE? But, I mean, I understand why they were upset. Kind of a dick move, Herostratus. I want to go down in history, but not for being the world's Suckiest Greek.`,
+  `What, you were The Mighty Thor?`,
+  `Nothing!!`,
+  `Pretty certain it does, Dromiceiomimus!`,
+]
+
+function makeMessage(messageID: string, you: string, author: string, timestamp: number, message: string) {
+  const key = Constants.messageKey(conversationIDKey, 'messageIDText', messageID)
+  return {
+    type: 'Text',
+    message: new HiddenString(message),
+    author,
+    deviceName: `${author}-phone`,
+    deviceType: 'mobile',
+    timestamp,
+    conversationIDKey,
+    messageID,
+    you,
+    messageState: 'sent',
+    failureDescription: null,
+    senderDeviceRevokedAt: null,
+    key,
+    editedCount: 0,
+  }
+}
+
+const messageCount = 100
+const messageMap = range(messageCount).reduce((acc, i) => {
+  const m = makeMessage(i, you, users[i % users.length], 1, corpus[i % corpus.length])
+  acc[m.key] = m
+  return acc
+}, {})
+
+const propCommon = {
+  messageKeys: I.List(),
+  editLastMessageCounter: 0,
+  listScrollDownCounter: 0,
+  onDeleteMessage: action('onDeleteMessage'),
+  onEditMessage: action('onEditMessage'),
+  onFocusInput: action('onFocusInput'),
+  onDownloadAttachment: action('onDownloadAttachment'),
+  onLoadMoreMessages: action('onLoadMoreMessages'),
+  onMessageAction: action('onMessageAction'),
+  onOpenInFileUI: action('onOpenInFileUI'),
+  getMessageFromMessageKey: (messageKey: Constants.MessageKey) => messageMap[messageKey],
+  selectedConversation: conversationIDKey,
+  validated: true,
+  you: 'trex',
+}
+
+const mock = {
+  default: {
+    ...propCommon,
+    messageKeys: I.List(Object.keys(messageMap)),
+  },
+}
+
+const load = () => {
+  storiesOf('Chat - List', module).add('Results List', () => {
+    const store = {
+      config: {
+        following: {},
+        username: 'tester',
+      },
+      chat: new Constants.StateRecord({
+        // $FlowIssue
+        messageMap: new I.Map(messageMap),
+        localMessageStates: I.Map(),
+        inbox: I.List(),
+        inboxFilter: I.List(),
+        inboxSearch: I.List(),
+        conversationStates: I.Map(),
+        metaData: I.Map(),
+        finalizedState: I.Map(),
+        supersedesState: I.Map(),
+        supersededByState: I.Map(),
+        pendingFailures: I.Map(),
+        conversationUnreadCounts: I.Map(),
+        rekeyInfos: I.Map(),
+        alwaysShow: I.Set(),
+        pendingConversations: I.Map(),
+        nowOverride: null,
+        editingMessage: null,
+        initialConversation: null,
+        inboxUntrustedState: 'unloaded',
+        previousConversation: null,
+        searchPending: false,
+        searchResults: null,
+        searchShowingSuggestions: false,
+        selectedUsersInSearch: I.List(),
+        inSearch: false,
+        tempPendingConversations: I.Map(),
+        searchResultTerm: '',
+      }),
+      routeTree: dataToRouteState({
+        selected: 'tabs:chatTab',
+        props: {},
+        state: {},
+        children: {
+          'tabs:chatTab': {
+            selected: 'mock',
+            props: {},
+            state: {},
+            children: {
+              mock: {
+                selected: null,
+                props: {},
+                state: {},
+                children: {},
+              },
+            },
+          },
+        },
+      }),
+    }
+
+    return (
+      <Box style={globalStyles.fillAbsolute}>
+        <Provider store={createStore(ignore => store, store)}>
+          <List {...mock.default} />
+        </Provider>
+      </Box>
+    )
+  })
+}
+
+export default load

--- a/shared/chat/shared.js
+++ b/shared/chat/shared.js
@@ -8,6 +8,6 @@ const lookupMessageProps = createCachedSelector(
     message,
     localMessageState,
   })
-)((state, messageKey) => messageKey)
+)((state, messageKey) => messageKey || 'null')
 
 export {lookupMessageProps}

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -124,6 +124,14 @@ export class RouteStateNode extends _RouteStateNode {
   }
 }
 
+// Converts plain old objects into route state nodes. Useful for testing
+export function dataToRouteState(data: Object) {
+  const {children, ...params} = data
+  const root = new RouteStateNode(params)
+  const parsedChildren = Object.keys(children).map(k => ({name: k, op: () => dataToRouteState(children[k])}))
+  return parsedChildren.reduce((acc, {name, op}) => acc.updateChild(name, op), root)
+}
+
 export class InvalidRouteError extends Error {}
 
 // Explicit list of iterable types to accept. We don't want to allow strings

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -125,11 +125,14 @@ export class RouteStateNode extends _RouteStateNode {
 }
 
 // Converts plain old objects into route state nodes. Useful for testing
-export function dataToRouteState(data: Object) {
+export function dataToRouteState(data: Object): RouteStateNode {
   const {children, ...params} = data
-  const root = new RouteStateNode(params)
+  const root: RouteStateNode = new RouteStateNode(params)
   const parsedChildren = Object.keys(children).map(k => ({name: k, op: () => dataToRouteState(children[k])}))
-  return parsedChildren.reduce((acc, {name, op}) => acc.updateChild(name, op), root)
+  return parsedChildren.reduce(
+    (acc: RouteStateNode, {name, op}): RouteStateNode => acc.updateChild(name, op),
+    root
+  )
 }
 
 export class InvalidRouteError extends Error {}

--- a/shared/stories/index.native.js
+++ b/shared/stories/index.native.js
@@ -7,19 +7,23 @@ import loadBox from '../common-adapters/box.stories'
 import loadIcon from '../common-adapters/icon.stories'
 import loadCheckbox from '../common-adapters/checkbox.stories'
 import loadText from '../common-adapters/text.stories'
+import loadChatList from '../chat/conversation/list/index.stories'
 import {StatusBar} from 'react-native'
 import {configure, addDecorator} from '@storybook/react-native'
 
+const scrollViewDecorator = story => [
+  <StatusBar key="statusbar" hidden={true} />,
+  <ScrollView key="scrollview" style={{flex: 1}}>
+    {story()}
+  </ScrollView>,
+]
+
 // Load common-adapter stories
 const load = () => {
-  addDecorator(story => [
-    <StatusBar key="statusbar" hidden={true} />,
-    <ScrollView key="scrollview" style={{flex: 1}}>
-      {story()}
-    </ScrollView>,
-  ])
-
   configure(() => {
+    loadChatList()
+    // If you want a scroll view, but the load fn after this decorator. Otherewise before
+    addDecorator(scrollViewDecorator)
     loadAvatar()
     loadBox()
     loadCheckbox()


### PR DESCRIPTION
@keybase/react-hackers 

Just the conversation list into rn story book. Really useful for debugging the chat list perf on android.

After doing this exercise I think it's also useful to have more of these for bigger screens. It makes it much easier to:

1. Test the state -> ui mapping is what you expect
1. When changes to the store happen you have screens that prove the state -> ui mapping still works
1. Test the perf of just the ui.
1. Be able to work and optimize the ui without internet! (and w/o even using the go code on android)

In a future PR I think I'll change the apk uploader pr thing to use storybook instead so it will be much more useful.