### PR TITLE
Fix ordering of branch() for rekey vs error

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -134,8 +134,9 @@ export default compose(
     (props: Props) => props.selectedConversationIDKey === Constants.nothingSelected && !props.inSearch,
     renderComponent(NoConversation)
   ),
-  branch((props: Props) => props.conversationIsError, renderComponent(ConversationError)),
+  // Ordering of branch() is important here -- rekey should come before error.
   branch((props: Props) => !props.finalizeInfo && props.rekeyInfo, renderComponent(Rekey)),
+  branch((props: Props) => props.conversationIsError, renderComponent(ConversationError)),
   withState('focusInputCounter', 'setFocusInputCounter', 0),
   withState('editLastMessageCounter', 'setEditLastMessageCounter', 0),
   withState('listScrollDownCounter', 'setListScrollDownCounter', 0),


### PR DESCRIPTION
@keybase/react-hackers

The error branch() was capturing rekeys, so we weren't rendering the Rekey component.  Fix the ordering to test for rekey first.