### PR TITLE
Implicit admin keying on subteam create and rotate

### DIFF
--- a/go/teams/chain_test.go
+++ b/go/teams/chain_test.go
@@ -90,7 +90,7 @@ func TestTeamSigChainPlay1(t *testing.T) {
 				EldestSeqno: keybase1.Seqno(1),
 			}
 		}
-		err = player.AppendChainLink(context.TODO(), link, signer)
+		err = player.AppendChainLink(context.TODO(), link, signerToX(signer))
 		require.NoError(t, err)
 	}
 
@@ -173,7 +173,7 @@ func TestTeamSigChainPlay2(t *testing.T) {
 				EldestSeqno: keybase1.Seqno(1),
 			}
 		}
-		err = player.AppendChainLink(context.TODO(), link, signer)
+		err = player.AppendChainLink(context.TODO(), link, signerToX(signer))
 		require.NoError(t, err)
 	}
 	require.NoError(t, err)
@@ -269,7 +269,7 @@ func TestTeamSigChainWithInvites(t *testing.T) {
 				EldestSeqno: keybase1.Seqno(1),
 			}
 		}
-		err = player.AppendChainLink(context.TODO(), link, signer)
+		err = player.AppendChainLink(context.TODO(), link, signerToX(signer))
 		require.NoError(t, err)
 	}
 	require.NoError(t, err)
@@ -307,4 +307,11 @@ func TestTeamSigChainWithInvites(t *testing.T) {
 		require.Equal(t, i.Type.Sbs(), keybase1.TeamInviteSocialNetwork("twitter"))
 		require.Equal(t, i.Name, keybase1.TeamInviteName("u_8114060fcef4"))
 	})
+}
+
+func signerToX(uv *keybase1.UserVersion) *signerX {
+	if uv == nil {
+		return nil
+	}
+	return &signerX{signer: *uv}
 }

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -311,25 +311,11 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 		return
 	}
 
-	/*
-		ownerLatest := me.GetComputedKeyFamily().GetLatestPerUserKey()
-		if ownerLatest == nil {
-			err = errors.New("can't create a new team without having provisioned a per-user key")
-			return
-		}
-	*/
-
 	memSet := newMemberSet()
 	_, err = memSet.loadGroup(ctx, g, allParentAdmins, true, true)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	/*
-		secretboxRecipients := map[keybase1.UserVersion]keybase1.PerUserKey{
-			me.ToUserVersion(): *ownerLatest,
-		}
-	*/
 
 	// These boxes will get posted along with the sig below.
 	m, err := NewTeamKeyManager(g)

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -312,7 +312,7 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 	}
 
 	memSet := newMemberSet()
-	_, err = memSet.loadGroup(ctx, g, allParentAdmins, true, true)
+	_, err = memSet.loadGroup(ctx, g, allParentAdmins, true /* store recipients */, true /* force poll */)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -410,7 +410,6 @@ func makeSubteamTeamSection(subteamName keybase1.TeamName, subteamID keybase1.Te
 		},
 		Members: &SCTeamMembers{
 			// Only root teams can have owners. Do not make the current user an admin by default.
-			// TODO: Plumb through more control over the initial set of admins.
 			Owners:  &[]SCTeamMember{},
 			Admins:  &[]SCTeamMember{},
 			Writers: &[]SCTeamMember{},

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -389,7 +389,6 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 }
 
 func makeSubteamTeamSection(subteamName keybase1.TeamName, subteamID keybase1.TeamID, parentTeam *TeamSigChainState, owner *libkb.User, perTeamSigningKID keybase1.KID, perTeamEncryptionKID keybase1.KID, admin *SCTeamAdmin) (SCTeamSection, error) {
-	ownerUserVersion := owner.ToUserVersion()
 
 	subteamName2 := subteamName.String()
 	teamSection := SCTeamSection{
@@ -406,10 +405,10 @@ func makeSubteamTeamSection(subteamName keybase1.TeamName, subteamID keybase1.Te
 			EncKID:     perTeamEncryptionKID,
 		},
 		Members: &SCTeamMembers{
-			// Only root teams can have owners. Make the current user an admin by default.
+			// Only root teams can have owners. Do not make the current user an admin by default.
 			// TODO: Plumb through more control over the initial set of admins.
 			Owners:  &[]SCTeamMember{},
-			Admins:  &[]SCTeamMember{SCTeamMember(ownerUserVersion)},
+			Admins:  &[]SCTeamMember{},
 			Writers: &[]SCTeamMember{},
 			Readers: &[]SCTeamMember{},
 		},

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -91,6 +91,8 @@ func TestCreateSubteam(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, subteamFQName, subteam.Name())
 	require.Equal(t, keybase1.Seqno(1), subteam.chain().GetLatestSeqno())
+
+	assertRole(tc, subteamFQName.String(), u.Username, keybase1.TeamRole_OWNER)
 }
 
 func TestCreateSubSubteam(t *testing.T) {

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -92,7 +92,9 @@ func TestCreateSubteam(t *testing.T) {
 	require.Equal(t, subteamFQName, subteam.Name())
 	require.Equal(t, keybase1.Seqno(1), subteam.chain().GetLatestSeqno())
 
-	assertRole(tc, subteamFQName.String(), u.Username, keybase1.TeamRole_OWNER)
+	// current behavior of this package is to make the creator the admin, so
+	// make sure that is the case until we change it
+	assertRole(tc, subteamFQName.String(), u.Username, keybase1.TeamRole_ADMIN)
 }
 
 func TestCreateSubSubteam(t *testing.T) {
@@ -113,7 +115,18 @@ func TestCreateSubSubteam(t *testing.T) {
 	subteamName, err := parentTeamName.Append(subteamBasename)
 	require.NoError(t, err)
 
+	// current behavior of this package is to make the creator the admin, so
+	// make sure that is the case until we change it
+	assertRole(tc, subteamName.String(), u.Username, keybase1.TeamRole_ADMIN)
+
 	subsubteamBasename := "ccc"
 	_, err = CreateSubteam(context.TODO(), tc.G, subsubteamBasename, subteamName)
 	require.NoError(t, err)
+
+	subsubteamName, err := parentTeamName.Append(subteamBasename)
+	require.NoError(t, err)
+
+	// current behavior of this package is to make the creator the admin, so
+	// make sure that is the case until we change it
+	assertRole(tc, subsubteamName.String(), u.Username, keybase1.TeamRole_ADMIN)
 }

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -92,9 +92,9 @@ func TestCreateSubteam(t *testing.T) {
 	require.Equal(t, subteamFQName, subteam.Name())
 	require.Equal(t, keybase1.Seqno(1), subteam.chain().GetLatestSeqno())
 
-	// current behavior of this package is to make the creator the admin, so
-	// make sure that is the case until we change it
-	assertRole(tc, subteamFQName.String(), u.Username, keybase1.TeamRole_ADMIN)
+	// creator of subteam should *not* be a member of the subteam, they
+	// need to explicitly join it.
+	assertRole(tc, subteamFQName.String(), u.Username, keybase1.TeamRole_NONE)
 }
 
 func TestCreateSubSubteam(t *testing.T) {
@@ -115,9 +115,7 @@ func TestCreateSubSubteam(t *testing.T) {
 	subteamName, err := parentTeamName.Append(subteamBasename)
 	require.NoError(t, err)
 
-	// current behavior of this package is to make the creator the admin, so
-	// make sure that is the case until we change it
-	assertRole(tc, subteamName.String(), u.Username, keybase1.TeamRole_ADMIN)
+	assertRole(tc, subteamName.String(), u.Username, keybase1.TeamRole_NONE)
 
 	subsubteamBasename := "ccc"
 	_, err = CreateSubteam(context.TODO(), tc.G, subsubteamBasename, subteamName)
@@ -126,7 +124,5 @@ func TestCreateSubSubteam(t *testing.T) {
 	subsubteamName, err := parentTeamName.Append(subteamBasename)
 	require.NoError(t, err)
 
-	// current behavior of this package is to make the creator the admin, so
-	// make sure that is the case until we change it
-	assertRole(tc, subsubteamName.String(), u.Username, keybase1.TeamRole_ADMIN)
+	assertRole(tc, subsubteamName.String(), u.Username, keybase1.TeamRole_NONE)
 }

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -332,7 +332,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 			return nil, fmt.Errorf("team replay failed: prev chain broken at link %d", i)
 		}
 
-		var signer *keybase1.UserVersion
+		var signer *signerX
 		signer, proofSet, err = l.verifyLink(ctx, arg.teamID, ret, arg.me, link, readSubteamID, proofSet)
 		if err != nil {
 			return nil, err

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -666,17 +666,14 @@ func (l *TeamLoader) addSecrets(ctx context.Context,
 func (l *TeamLoader) checkReaderKeyMaskCoverage(ctx context.Context,
 	state *keybase1.TeamData, gen keybase1.PerTeamKeyGeneration) error {
 
-	// doesn't work for implied admins
-	/*
-		for _, app := range keybase1.TeamApplicationMap {
-			if _, ok := state.ReaderKeyMasks[app]; !ok {
-				return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
-			}
-			if _, ok := state.ReaderKeyMasks[app][gen]; !ok {
-				return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
-			}
+	for _, app := range keybase1.TeamApplicationMap {
+		if _, ok := state.ReaderKeyMasks[app]; !ok {
+			return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
 		}
-	*/
+		if _, ok := state.ReaderKeyMasks[app][gen]; !ok {
+			return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
+		}
+	}
 
 	return nil
 }

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -666,14 +666,17 @@ func (l *TeamLoader) addSecrets(ctx context.Context,
 func (l *TeamLoader) checkReaderKeyMaskCoverage(ctx context.Context,
 	state *keybase1.TeamData, gen keybase1.PerTeamKeyGeneration) error {
 
-	for _, app := range keybase1.TeamApplicationMap {
-		if _, ok := state.ReaderKeyMasks[app]; !ok {
-			return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
+	// doesn't work for implied admins
+	/*
+		for _, app := range keybase1.TeamApplicationMap {
+			if _, ok := state.ReaderKeyMasks[app]; !ok {
+				return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
+			}
+			if _, ok := state.ReaderKeyMasks[app][gen]; !ok {
+				return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
+			}
 		}
-		if _, ok := state.ReaderKeyMasks[app][gen]; !ok {
-			return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
-		}
-	}
+	*/
 
 	return nil
 }

--- a/go/teams/loader_types.go
+++ b/go/teams/loader_types.go
@@ -23,6 +23,14 @@ type parentChildOperation struct {
 
 // --------------------------------------------------
 
+type signerX struct {
+	signer keybase1.UserVersion
+	// Whether the user is definitely an implicit admin
+	implicitAdmin bool
+}
+
+// --------------------------------------------------
+
 type chainLinkUnpacked struct {
 	source    *SCChainLink
 	outerLink *libkb.OuterLinkV2WithMetadata

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -435,38 +435,11 @@ func TestMemberAddEmail(t *testing.T) {
 }
 
 func TestMemberAddAsImplicitAdmin(t *testing.T) {
-	tc, owner, otherA, otherB, rootName := memberSetupMultiple(t)
+	tc, owner, otherA, otherB, _, subteamName := memberSetupSubteam(t)
 	defer tc.Cleanup()
 
-	// add otherA and otherB as admins to rootName
-	_, err := AddMember(context.TODO(), tc.G, rootName, otherA.Username, keybase1.TeamRole_ADMIN)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = AddMember(context.TODO(), tc.G, rootName, otherB.Username, keybase1.TeamRole_ADMIN)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assertRole(tc, rootName, owner.Username, keybase1.TeamRole_OWNER)
-	assertRole(tc, rootName, otherA.Username, keybase1.TeamRole_ADMIN)
-	assertRole(tc, rootName, otherB.Username, keybase1.TeamRole_ADMIN)
-
-	// create a subteam
-	rootTeamName, err := keybase1.TeamNameFromString(rootName)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sub := "sub"
-	_, err = CreateSubteam(context.TODO(), tc.G, sub, rootTeamName)
-	if err != nil {
-		t.Fatal(err)
-	}
-	subteamName := rootName + "." + sub
-
-	// make sure owner, otherA, otherB are not members
-	assertRole(tc, subteamName, owner.Username, keybase1.TeamRole_NONE)
-	assertRole(tc, subteamName, otherA.Username, keybase1.TeamRole_NONE)
-	assertRole(tc, subteamName, otherB.Username, keybase1.TeamRole_NONE)
+	// owner created a subteam, otherA is implicit admin, otherB is nobody
+	// (all of that tested in memberSetupSubteam)
 
 	// switch to `otherA` user
 	tc.G.Logout()

--- a/go/teams/rotate_test.go
+++ b/go/teams/rotate_test.go
@@ -156,14 +156,21 @@ func TestImplicitAdminAfterRotateRequest(t *testing.T) {
 	}
 	secretBefore := team.Data.PerTeamKeySeeds[team.Generation()].Seed.ToBytes()
 
+	t.Logf("ttt rotate subteam")
+
 	if err := HandleRotateRequest(context.TODO(), tc.G, team.ID, team.Generation()); err != nil {
 		t.Fatal(err)
 	}
+
+	t.Logf("ttt rotate complete")
 
 	after, err := GetForTestByStringName(context.TODO(), tc.G, sub)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	t.Logf("ttt get complete")
+
 	if after.Generation() != 2 {
 		t.Fatalf("rotated subteam generation: %d, expected 2", after.Generation())
 	}
@@ -173,6 +180,7 @@ func TestImplicitAdminAfterRotateRequest(t *testing.T) {
 	}
 
 	// make sure the roles are ok after rotate
+	t.Logf("ttt checking roles")
 	assertRole(tc, root, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, root, otherA.Username, keybase1.TeamRole_ADMIN)
 	assertRole(tc, root, otherB.Username, keybase1.TeamRole_NONE)

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -742,6 +742,19 @@ func (t *Team) rotateBoxes(ctx context.Context, memSet *memberSet) (*PerTeamShar
 	if err := memSet.AddRemainingRecipients(ctx, t.G(), existing); err != nil {
 		return nil, nil, err
 	}
+
+	if t.chain().IsSubteam() {
+		// rotate needs to be keyed for all admins above it
+		allParentAdmins, err := t.G().GetTeamLoader().ImplicitAdmins(ctx, *t.chain().GetParentID())
+		if err != nil {
+			return nil, nil, err
+		}
+		_, err = memSet.loadGroup(ctx, t.G(), allParentAdmins, true, true)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	t.rotated = true
 
 	return t.keyManager.RotateSharedSecretBoxes(ctx, deviceEncryptionKey, memSet.recipients)

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -745,7 +745,7 @@ func (t *Team) rotateBoxes(ctx context.Context, memSet *memberSet) (*PerTeamShar
 
 	if t.chain().IsSubteam() {
 		// rotate needs to be keyed for all admins above it
-		allParentAdmins, err := t.G().GetTeamLoader().ImplicitAdmins(ctx, *t.chain().GetParentID())
+		allParentAdmins, err := t.G().GetTeamLoader().ImplicitAdmins(ctx, t.ID)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -789,6 +789,42 @@ func (t *Team) ForceMerkleRootUpdate(ctx context.Context) error {
 	return err
 }
 
+func (t *Team) AllAdmins(ctx context.Context) ([]keybase1.UserVersion, error) {
+	set := make(map[keybase1.UserVersion]bool)
+
+	owners, err := t.UsersWithRole(keybase1.TeamRole_OWNER)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range owners {
+		set[m] = true
+	}
+
+	admins, err := t.UsersWithRole(keybase1.TeamRole_ADMIN)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range admins {
+		set[m] = true
+	}
+
+	if t.chain().IsSubteam() {
+		imp, err := t.G().GetTeamLoader().ImplicitAdmins(ctx, t.ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range imp {
+			set[m] = true
+		}
+	}
+
+	var all []keybase1.UserVersion
+	for uv := range set {
+		all = append(all, uv)
+	}
+	return all, nil
+}
+
 func LoadTeamPlusApplicationKeys(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID,
 	application keybase1.TeamApplication, refreshers keybase1.TeamRefreshers) (res keybase1.TeamPlusApplicationKeys, err error) {
 


### PR DESCRIPTION
1. don't add any default members to a subteam when creating (cc @malgorithms)
2. when creating a subteam, key for all the implicit admins too
3. when rotating a subteam, key for all the implicit admins too
4. test that implicit admins can operate on subteams (before and after rotate)

Thanks to @mlsteele for his player/loader fixes to make all this work.