### PR TITLE
kbnm: Write whitelist path relative to overlay if set

### DIFF
--- a/go/kbnm/main.go
+++ b/go/kbnm/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 // internalVersion is the logical version of this code (rather than build).
-const internalVersion = "1.4"
+const internalVersion = "1.4.1"
 
 // Version is the build version of kbnm, overwritten during build with metadata.
 var Version = "dev"


### PR DESCRIPTION
Maybe there's a more straight-forward way of checking the relative path?

```
 ~/local/go/src/github.com/keybase/client/go/kbnm/foo/bin $ echo "$layout_dir"
/Users/shazow/local/go/src/github.com/keybase/client/go/kbnm/foo
 ~/local/go/src/github.com/keybase/client/go/kbnm/foo/bin $ ls
kbnm
 ~/local/go/src/github.com/keybase/client/go/kbnm/foo/bin $ KBNM_INSTALL_ROOT=1 KBNM_INSTALL_OVERLAY="$layout_dir" ./kbnm install
2017/07/28 12:12:17 installing: /Users/shazow/local/go/src/github.com/keybase/client/go/kbnm/foo/bin/kbnm
Installed NativeMessaging whitelists.
shazow@shazowic-lemur ~/local/go/src/github.com/keybase/client/go/kbnm/foo/bin $ cat ../Library/Google/Chrome/NativeMessagingHosts/io.keybase.kbnm.json
{
    "name": "io.keybase.kbnm",
    "description": "Keybase Native Messaging API",
    "path": "/bin/kbnm",
    "type": "stdio",
    "allowed_origins": [
        "chrome-extension://ognfafcpbkogffpmmdglhbjboeojlefj/",
        "chrome-extension://kockbbfoibcdfibclaojljblnhpnjndg/",
        "chrome-extension://gnjkbjlgkpiaehpibpdefaieklbfljjm/"
    ]
}
```