### PR TITLE
Don't bail out when GetForTeamManagementByStringName fails

### DIFF
--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -95,7 +95,8 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 		if ok {
 			t, err := GetForTeamManagementByStringName(ctx, g, teamName, true)
 			if err != nil {
-				return nil, err
+				g.Log.Warning("Error while getting team (%s): %v", teamName, err)
+				continue
 			}
 			teamAnnotatedInvites, err := AnnotateInvites(ctx, g, t.chain().inner.ActiveInvites, teamName)
 			if err != nil {


### PR DESCRIPTION
Since a while ago `team list-memberships` started failing for me on one of my test account. This account is in a number of teams they are not keyed in, because these teams were created by a script etc. This PR changes list-membership not to fail entirely when some membership is in bad state.

Instead of
```
» kbs team list-memberships
Running `go install github.com/keybase/client/go/keybase`...Done.
▶ WARNING Running in devel mode
▶ WARNING not exportable error: loading team secrets: no key box from server (*errors.errorString)
▶ ERROR loading team secrets: no key box from server
```

it is now

```
» kbs team list-memberships
Running `go install github.com/keybase/client/go/keybase`...Done.
▶ WARNING Running in devel mode
▶ WARNING Error while getting team (t_a3fb5fe8.be): loading team secrets: no key box from server
▶ WARNING Error while getting team (t_4c7e3067.be): loading team secrets: no key box from server
▶ WARNING Error while getting team (t_4c7e3067.ae): loading team secrets: no key box from server
▶ WARNING Error while getting team (t_0da2ebe4.be): loading team secrets: no key box from server
▶ WARNING Error while getting team (t_0da2ebe4.ae): loading team secrets: no key box from server
▶ WARNING Error while getting team (t_a3fb5fe8.ae): loading team secrets: no key box from server
Team             Role             Username       Full name
t_4c7e3067       owner            teamtester2    
t_4c7e3067.be    implied admin    teamtester2    
t_4c7e3067.ae    implied admin    teamtester2 
....
```

no idea if it has any practical use. Feel free delete this PR if current behavior is desired. Thanks!