### PR TITLE
allow callers of PostLocalNonblock to specify the outbox ID CORE-5723

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -53,7 +53,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: "HIHI",
 		}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	msgID := msgBoxed.GetMessageID()
 	thread, _, err := tc.ChatG.ConvSource.Pull(ctx, res.ConvID, u.User.GetUID().ToBytes(),
@@ -77,7 +77,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 			MessageID: msgID,
 			Body:      "EDITED",
 		}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	editMsgID := editMsgBoxed.GetMessageID()
 
@@ -105,7 +105,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{
 			MessageIDs: []chat1.MessageID{msgID, editMsgID},
 		}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	deleteMsgID := deleteMsgBoxed.GetMessageID()
 	thread, _, err = tc.ChatG.ConvSource.Pull(ctx, res.ConvID, u.User.GetUID().ToBytes(),
@@ -389,7 +389,7 @@ func TestGetThreadCaching(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: "HIHI",
 		}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	msgID := msgBoxed.GetMessageID()
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -174,7 +174,7 @@ func (s *sendHelper) deliver(ctx context.Context, body chat1.MessageBody, mtype 
 		},
 		MessageBody: body,
 	}
-	_, _, _, err := sender.Send(ctx, s.convID, msg, 0)
+	_, _, _, err := sender.Send(ctx, s.convID, msg, 0, nil)
 	return err
 }
 

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -33,7 +33,7 @@ func TestInboxSourceUpdateRace(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: "HIHI",
 		}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 
 	ib, _, err := tc.ChatG.InboxSource.Read(ctx, u.User.GetUID().ToBytes(), nil, true, nil, nil)

--- a/go/chat/push_test.go
+++ b/go/chat/push_test.go
@@ -37,7 +37,7 @@ func sendSimple(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, p
 			Body: "hi",
 		}),
 	}
-	_, boxed, _, err := sender.Send(ctx, convID, pt, 0)
+	_, boxed, _, err := sender.Send(ctx, convID, pt, 0, nil)
 	require.NoError(t, err)
 
 	ibox := storage.NewInbox(tc.Context(), uid)

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -219,7 +219,7 @@ func TestNonblockChannel(t *testing.T) {
 			TlfName:   u.Username,
 			TlfPublic: false,
 		},
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 
 	select {
@@ -299,7 +299,7 @@ func TestNonblockTimer(t *testing.T) {
 			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
 				Body: "hi",
 			}),
-		}, 0)
+		}, 0, nil)
 		require.NoError(t, err)
 		msgID := msgBoxed.GetMessageID()
 		t.Logf("generated msgID: %d", msgID)
@@ -320,7 +320,7 @@ func TestNonblockTimer(t *testing.T) {
 					Prev: msgID,
 				},
 			},
-		}, keybase1.TLFIdentifyBehavior_CHAT_CLI)
+		}, nil, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 		obid := obr.OutboxID
 		t.Logf("generated obid: %s prev: %d", hex.EncodeToString(obid), msgID)
 		require.NoError(t, err)
@@ -348,7 +348,7 @@ func TestNonblockTimer(t *testing.T) {
 			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
 				Body: "hi",
 			}),
-		}, 0)
+		}, 0, nil)
 		require.NoError(t, err)
 		msgID := msgBoxed.GetMessageID()
 		t.Logf("generated msgID: %d", msgID)
@@ -394,7 +394,7 @@ type FailingSender struct {
 var _ types.Sender = (*FailingSender)(nil)
 
 func (f FailingSender) Send(ctx context.Context, convID chat1.ConversationID,
-	msg chat1.MessagePlaintext, clientPrev chat1.MessageID) (chat1.OutboxID, *chat1.MessageBoxed, *chat1.RateLimit, error) {
+	msg chat1.MessagePlaintext, clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (chat1.OutboxID, *chat1.MessageBoxed, *chat1.RateLimit, error) {
 	return chat1.OutboxID{}, nil, nil, fmt.Errorf("I always fail!!!!")
 }
 
@@ -443,7 +443,7 @@ func TestFailingSender(t *testing.T) {
 				TlfName:   u.Username,
 				TlfPublic: false,
 			},
-		}, 0)
+		}, 0, nil)
 		require.NoError(t, err)
 		obids = append(obids, obid)
 	}
@@ -493,7 +493,7 @@ func TestDisconnectedFailure(t *testing.T) {
 			TlfName:   u.Username,
 			TlfPublic: false,
 		},
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	cl.Advance(time.Millisecond)
 	select {
@@ -525,7 +525,7 @@ func TestDisconnectedFailure(t *testing.T) {
 				TlfName:   u.Username,
 				TlfPublic: false,
 			},
-		}, 0)
+		}, 0, nil)
 		require.NoError(t, err)
 		obids = append(obids, obid)
 		cl.Advance(time.Millisecond)
@@ -612,7 +612,7 @@ func TestDeletionHeaders(t *testing.T) {
 			MessageType: chat1.MessageType_TEXT,
 		},
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	firstMessageID := firstMessageBoxed.GetMessageID()
 	_, editBoxed, _, err := blockingSender.Send(ctx, conv.GetConvID(), chat1.MessagePlaintext{
@@ -624,7 +624,7 @@ func TestDeletionHeaders(t *testing.T) {
 			Supersedes:  firstMessageID,
 		},
 		MessageBody: chat1.NewMessageBodyWithEdit(chat1.MessageEdit{MessageID: firstMessageID, Body: "bar"}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	editID := editBoxed.GetMessageID()
 	_, editBoxed2, _, err := blockingSender.Send(ctx, conv.GetConvID(), chat1.MessagePlaintext{
@@ -636,7 +636,7 @@ func TestDeletionHeaders(t *testing.T) {
 			Supersedes:  firstMessageID,
 		},
 		MessageBody: chat1.NewMessageBodyWithEdit(chat1.MessageEdit{MessageID: firstMessageID, Body: "baz"}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	editID2 := editBoxed2.GetMessageID()
 
@@ -746,7 +746,7 @@ func TestAtMentionsEdit(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: text,
 		}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 
 	// edit that message and add atMentions
@@ -808,7 +808,7 @@ func TestPrevPointerAddition(t *testing.T) {
 				MessageType: chat1.MessageType_TEXT,
 			},
 			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
-		}, 0)
+		}, 0, nil)
 		require.NoError(t, err)
 	}
 
@@ -873,7 +873,7 @@ func TestDeletionAssets(t *testing.T) {
 			Preview:  &tmp1,
 			Previews: []chat1.Asset{mkAsset(), mkAsset()},
 		}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	firstMessageID := firstMessageBoxed.GetMessageID()
 
@@ -891,7 +891,7 @@ func TestDeletionAssets(t *testing.T) {
 			Object:    mkAsset(),
 			Previews:  []chat1.Asset{mkAsset(), mkAsset()},
 		}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	edit1ID := edit1Boxed.GetMessageID()
 	_, edit2Boxed, _, err := blockingSender.Send(ctx, conv.GetConvID(), chat1.MessagePlaintext{
@@ -901,7 +901,7 @@ func TestDeletionAssets(t *testing.T) {
 			Object:    mkAsset(),
 			Previews:  []chat1.Asset{mkAsset(), mkAsset()},
 		}),
-	}, 0)
+	}, 0, nil)
 	edit2ID := edit2Boxed.GetMessageID()
 	_, edit3Boxed, _, err := blockingSender.Send(ctx, conv.GetConvID(), chat1.MessagePlaintext{
 		ClientHeader: editHeader,
@@ -910,7 +910,7 @@ func TestDeletionAssets(t *testing.T) {
 			Object:    chat1.Asset{},
 			Previews:  nil,
 		}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	edit3ID := edit3Boxed.GetMessageID()
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1248,7 +1248,7 @@ func TestChatSrvGetOutbox(t *testing.T) {
 					Prev: 10,
 				},
 			},
-		}, keybase1.TLFIdentifyBehavior_CHAT_CLI)
+		}, nil, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 		require.NoError(t, err)
 
 		thread, err := h.GetThreadLocal(ctx, chat1.GetThreadLocalArg{

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -121,9 +121,9 @@ func (o *Outbox) PushMessage(ctx context.Context, convID chat1.ConversationID,
 	}
 
 	// Generate new outbox ID (unless the caller supplied it for us already)
-	var ierr error
 	var outboxID chat1.OutboxID
 	if suppliedOutboxID == nil {
+		var ierr error
 		outboxID, ierr = NewOutboxID()
 		if ierr != nil {
 			return rec, o.maybeNuke(NewInternalError(ctx, o.DebugLabeler,

--- a/go/chat/storage/outbox_test.go
+++ b/go/chat/storage/outbox_test.go
@@ -50,7 +50,7 @@ func TestChatOutbox(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		obr, err := ob.PushMessage(context.TODO(), conv.GetConvID(), makeMsgPlaintext("hi", uid),
-			keybase1.TLFIdentifyBehavior_CHAT_CLI)
+			nil, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 		require.NoError(t, err)
 		obrs = append(obrs, obr)
 		cl.Advance(time.Millisecond)

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -61,7 +61,7 @@ func newConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, uid 
 			MessageType: chat1.MessageType_TEXT,
 		},
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
-	}, 0)
+	}, 0, nil)
 	require.NoError(t, err)
 	convID := conv.GetConvID()
 	ires, err := ri.GetInboxRemote(ctx, chat1.GetInboxRemoteArg{

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -52,12 +52,13 @@ type MessageDeliverer interface {
 	Resumable
 
 	Queue(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext,
-		identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.OutboxRecord, error)
+		outboxID *chat1.OutboxID, identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.OutboxRecord, error)
 	ForceDeliverLoop(ctx context.Context)
 }
 
 type Sender interface {
-	Send(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext, clientPrev chat1.MessageID) (chat1.OutboxID, *chat1.MessageBoxed, *chat1.RateLimit, error)
+	Send(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext,
+		clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (chat1.OutboxID, *chat1.MessageBoxed, *chat1.RateLimit, error)
 	Prepare(ctx context.Context, msg chat1.MessagePlaintext, membersType chat1.ConversationMembersType,
 		conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, chat1.ChannelMention, *chat1.TopicNameState, error)
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3190,18 +3190,33 @@ func (o PostLocalArg) DeepCopy() PostLocalArg {
 	}
 }
 
+type GenerateOutboxIDArg struct {
+}
+
+func (o GenerateOutboxIDArg) DeepCopy() GenerateOutboxIDArg {
+	return GenerateOutboxIDArg{}
+}
+
 type PostLocalNonblockArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
 	Msg              MessagePlaintext             `codec:"msg" json:"msg"`
 	ClientPrev       MessageID                    `codec:"clientPrev" json:"clientPrev"`
+	OutboxID         *OutboxID                    `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 func (o PostLocalNonblockArg) DeepCopy() PostLocalNonblockArg {
 	return PostLocalNonblockArg{
-		ConversationID:   o.ConversationID.DeepCopy(),
-		Msg:              o.Msg.DeepCopy(),
-		ClientPrev:       o.ClientPrev.DeepCopy(),
+		ConversationID: o.ConversationID.DeepCopy(),
+		Msg:            o.Msg.DeepCopy(),
+		ClientPrev:     o.ClientPrev.DeepCopy(),
+		OutboxID: (func(x *OutboxID) *OutboxID {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.OutboxID),
 		IdentifyBehavior: o.IdentifyBehavior.DeepCopy(),
 	}
 }
@@ -3213,17 +3228,25 @@ type PostTextNonblockArg struct {
 	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
 	Body             string                       `codec:"body" json:"body"`
 	ClientPrev       MessageID                    `codec:"clientPrev" json:"clientPrev"`
+	OutboxID         *OutboxID                    `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 func (o PostTextNonblockArg) DeepCopy() PostTextNonblockArg {
 	return PostTextNonblockArg{
-		ConversationID:   o.ConversationID.DeepCopy(),
-		Conv:             o.Conv.DeepCopy(),
-		TlfName:          o.TlfName,
-		TlfPublic:        o.TlfPublic,
-		Body:             o.Body,
-		ClientPrev:       o.ClientPrev.DeepCopy(),
+		ConversationID: o.ConversationID.DeepCopy(),
+		Conv:           o.Conv.DeepCopy(),
+		TlfName:        o.TlfName,
+		TlfPublic:      o.TlfPublic,
+		Body:           o.Body,
+		ClientPrev:     o.ClientPrev.DeepCopy(),
+		OutboxID: (func(x *OutboxID) *OutboxID {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.OutboxID),
 		IdentifyBehavior: o.IdentifyBehavior.DeepCopy(),
 	}
 }
@@ -3235,17 +3258,25 @@ type PostDeleteNonblockArg struct {
 	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
 	Supersedes       MessageID                    `codec:"supersedes" json:"supersedes"`
 	ClientPrev       MessageID                    `codec:"clientPrev" json:"clientPrev"`
+	OutboxID         *OutboxID                    `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 func (o PostDeleteNonblockArg) DeepCopy() PostDeleteNonblockArg {
 	return PostDeleteNonblockArg{
-		ConversationID:   o.ConversationID.DeepCopy(),
-		Conv:             o.Conv.DeepCopy(),
-		TlfName:          o.TlfName,
-		TlfPublic:        o.TlfPublic,
-		Supersedes:       o.Supersedes.DeepCopy(),
-		ClientPrev:       o.ClientPrev.DeepCopy(),
+		ConversationID: o.ConversationID.DeepCopy(),
+		Conv:           o.Conv.DeepCopy(),
+		TlfName:        o.TlfName,
+		TlfPublic:      o.TlfPublic,
+		Supersedes:     o.Supersedes.DeepCopy(),
+		ClientPrev:     o.ClientPrev.DeepCopy(),
+		OutboxID: (func(x *OutboxID) *OutboxID {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.OutboxID),
 		IdentifyBehavior: o.IdentifyBehavior.DeepCopy(),
 	}
 }
@@ -3257,18 +3288,26 @@ type PostEditNonblockArg struct {
 	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
 	Supersedes       MessageID                    `codec:"supersedes" json:"supersedes"`
 	Body             string                       `codec:"body" json:"body"`
+	OutboxID         *OutboxID                    `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	ClientPrev       MessageID                    `codec:"clientPrev" json:"clientPrev"`
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 func (o PostEditNonblockArg) DeepCopy() PostEditNonblockArg {
 	return PostEditNonblockArg{
-		ConversationID:   o.ConversationID.DeepCopy(),
-		Conv:             o.Conv.DeepCopy(),
-		TlfName:          o.TlfName,
-		TlfPublic:        o.TlfPublic,
-		Supersedes:       o.Supersedes.DeepCopy(),
-		Body:             o.Body,
+		ConversationID: o.ConversationID.DeepCopy(),
+		Conv:           o.Conv.DeepCopy(),
+		TlfName:        o.TlfName,
+		TlfPublic:      o.TlfPublic,
+		Supersedes:     o.Supersedes.DeepCopy(),
+		Body:           o.Body,
+		OutboxID: (func(x *OutboxID) *OutboxID {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.OutboxID),
 		ClientPrev:       o.ClientPrev.DeepCopy(),
 		IdentifyBehavior: o.IdentifyBehavior.DeepCopy(),
 	}
@@ -3624,6 +3663,7 @@ type LocalInterface interface {
 	GetInboxAndUnboxLocal(context.Context, GetInboxAndUnboxLocalArg) (GetInboxAndUnboxLocalRes, error)
 	GetInboxNonblockLocal(context.Context, GetInboxNonblockLocalArg) (NonblockFetchRes, error)
 	PostLocal(context.Context, PostLocalArg) (PostLocalRes, error)
+	GenerateOutboxID(context.Context) (OutboxID, error)
 	PostLocalNonblock(context.Context, PostLocalNonblockArg) (PostLocalNonblockRes, error)
 	PostTextNonblock(context.Context, PostTextNonblockArg) (PostLocalNonblockRes, error)
 	PostDeleteNonblock(context.Context, PostDeleteNonblockArg) (PostLocalNonblockRes, error)
@@ -3746,6 +3786,17 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.PostLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"generateOutboxID": {
+				MakeArg: func() interface{} {
+					ret := make([]GenerateOutboxIDArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.GenerateOutboxID(ctx)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -4169,6 +4220,11 @@ func (c LocalClient) GetInboxNonblockLocal(ctx context.Context, __arg GetInboxNo
 
 func (c LocalClient) PostLocal(ctx context.Context, __arg PostLocalArg) (res PostLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.postLocal", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) GenerateOutboxID(ctx context.Context) (res OutboxID, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.generateOutboxID", []interface{}{GenerateOutboxIDArg{}}, &res)
 	return
 }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -504,16 +504,17 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  PostLocalNonblockRes postLocalNonblock(ConversationID conversationID, MessagePlaintext msg, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
+  OutboxID generateOutboxID();
+  PostLocalNonblockRes postLocalNonblock(ConversationID conversationID, MessagePlaintext msg, MessageID clientPrev, union { null, OutboxID } outboxID, keybase1.TLFIdentifyBehavior identifyBehavior);
   record PostLocalNonblockRes {
     array<RateLimit> rateLimits;
     OutboxID outboxID;
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  PostLocalNonblockRes postTextNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, string body, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
-  PostLocalNonblockRes postDeleteNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, MessageID supersedes,MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
-  PostLocalNonblockRes postEditNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, MessageID supersedes, string body, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalNonblockRes postTextNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, string body, MessageID clientPrev, union { null, OutboxID } outboxID,  keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalNonblockRes postDeleteNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, MessageID supersedes,MessageID clientPrev, union { null, OutboxID } outboxID,  keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalNonblockRes postEditNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, MessageID supersedes, string body, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
 
 
   @lint("ignore")

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -274,6 +274,18 @@ export function localFindConversationsLocalRpcPromise (request: $Exact<requestCo
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.findConversationsLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localGenerateOutboxIDRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGenerateOutboxIDResult) => void}>) {
+  engineRpcOutgoing('chat.1.local.generateOutboxID', request)
+}
+
+export function localGenerateOutboxIDRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGenerateOutboxIDResult) => void}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.generateOutboxID', request)
+}
+
+export function localGenerateOutboxIDRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGenerateOutboxIDResult) => void}>): Promise<localGenerateOutboxIDResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.generateOutboxID', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localGetCachedThreadRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getCachedThread', request)
 }
@@ -2159,6 +2171,7 @@ export type localPostDeleteNonblockRpcParam = Exact<{
   tlfPublic: boolean,
   supersedes: MessageID,
   clientPrev: MessageID,
+  outboxID?: ?OutboxID,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
@@ -2169,6 +2182,7 @@ export type localPostEditNonblockRpcParam = Exact<{
   tlfPublic: boolean,
   supersedes: MessageID,
   body: string,
+  outboxID?: ?OutboxID,
   clientPrev: MessageID,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
@@ -2187,6 +2201,7 @@ export type localPostLocalNonblockRpcParam = Exact<{
   conversationID: ConversationID,
   msg: MessagePlaintext,
   clientPrev: MessageID,
+  outboxID?: ?OutboxID,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
@@ -2203,6 +2218,7 @@ export type localPostTextNonblockRpcParam = Exact<{
   tlfPublic: boolean,
   body: string,
   clientPrev: MessageID,
+  outboxID?: ?OutboxID,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
@@ -2367,6 +2383,7 @@ export type remoteUpdateTypingRemoteRpcParam = Exact<{
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
 type localFindConversationsLocalResult = FindConversationsLocalRes
+type localGenerateOutboxIDResult = OutboxID
 type localGetCachedThreadResult = GetThreadLocalRes
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
@@ -2417,6 +2434,7 @@ export type rpc =
   | localDownloadAttachmentLocalRpc
   | localDownloadFileAttachmentLocalRpc
   | localFindConversationsLocalRpc
+  | localGenerateOutboxIDRpc
   | localGetCachedThreadRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2057,6 +2057,10 @@
       ],
       "response": "PostLocalRes"
     },
+    "generateOutboxID": {
+      "request": [],
+      "response": "OutboxID"
+    },
     "postLocalNonblock": {
       "request": [
         {
@@ -2070,6 +2074,13 @@
         {
           "name": "clientPrev",
           "type": "MessageID"
+        },
+        {
+          "name": "outboxID",
+          "type": [
+            null,
+            "OutboxID"
+          ]
         },
         {
           "name": "identifyBehavior",
@@ -2105,6 +2116,13 @@
           "type": "MessageID"
         },
         {
+          "name": "outboxID",
+          "type": [
+            null,
+            "OutboxID"
+          ]
+        },
+        {
           "name": "identifyBehavior",
           "type": "keybase1.TLFIdentifyBehavior"
         }
@@ -2138,6 +2156,13 @@
           "type": "MessageID"
         },
         {
+          "name": "outboxID",
+          "type": [
+            null,
+            "OutboxID"
+          ]
+        },
+        {
           "name": "identifyBehavior",
           "type": "keybase1.TLFIdentifyBehavior"
         }
@@ -2169,6 +2194,13 @@
         {
           "name": "body",
           "type": "string"
+        },
+        {
+          "name": "outboxID",
+          "type": [
+            null,
+            "OutboxID"
+          ]
         },
         {
           "name": "clientPrev",

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -274,6 +274,18 @@ export function localFindConversationsLocalRpcPromise (request: $Exact<requestCo
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.findConversationsLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localGenerateOutboxIDRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGenerateOutboxIDResult) => void}>) {
+  engineRpcOutgoing('chat.1.local.generateOutboxID', request)
+}
+
+export function localGenerateOutboxIDRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGenerateOutboxIDResult) => void}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.generateOutboxID', request)
+}
+
+export function localGenerateOutboxIDRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGenerateOutboxIDResult) => void}>): Promise<localGenerateOutboxIDResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.generateOutboxID', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localGetCachedThreadRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getCachedThread', request)
 }
@@ -2159,6 +2171,7 @@ export type localPostDeleteNonblockRpcParam = Exact<{
   tlfPublic: boolean,
   supersedes: MessageID,
   clientPrev: MessageID,
+  outboxID?: ?OutboxID,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
@@ -2169,6 +2182,7 @@ export type localPostEditNonblockRpcParam = Exact<{
   tlfPublic: boolean,
   supersedes: MessageID,
   body: string,
+  outboxID?: ?OutboxID,
   clientPrev: MessageID,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
@@ -2187,6 +2201,7 @@ export type localPostLocalNonblockRpcParam = Exact<{
   conversationID: ConversationID,
   msg: MessagePlaintext,
   clientPrev: MessageID,
+  outboxID?: ?OutboxID,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
@@ -2203,6 +2218,7 @@ export type localPostTextNonblockRpcParam = Exact<{
   tlfPublic: boolean,
   body: string,
   clientPrev: MessageID,
+  outboxID?: ?OutboxID,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
@@ -2367,6 +2383,7 @@ export type remoteUpdateTypingRemoteRpcParam = Exact<{
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
 type localFindConversationsLocalResult = FindConversationsLocalRes
+type localGenerateOutboxIDResult = OutboxID
 type localGetCachedThreadResult = GetThreadLocalRes
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
@@ -2417,6 +2434,7 @@ export type rpc =
   | localDownloadAttachmentLocalRpc
   | localDownloadFileAttachmentLocalRpc
   | localFindConversationsLocalRpc
+  | localGenerateOutboxIDRpc
   | localGetCachedThreadRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc


### PR DESCRIPTION
The point of this is to try and reduce the chance of race conditions on the frontend. They get into a situation where they make a nonblocking call to `PostLocalNonblock`, and don't get the outboxID until the callback for that call fires. In the meantime, they might be getting notifications about Gregor messages concerning that outbox ID, for which they don't know anything about. This patch introduces the following flow:

1.) Invoke `GenerateOutboxID` on the service to get a new outbox ID.
2.) Pass that parameter to `PostLocalNonblock` (and variants), to make sure the outbox ID on the new message is set to what was generating in step 1.

cc @cjb.