### PR TITLE
Make PGP commands run identify without tracking

### DIFF
--- a/go/client/cmd_pgp_encrypt.go
+++ b/go/client/cmd_pgp_encrypt.go
@@ -77,7 +77,7 @@ func (c *CmdPGPEncrypt) Run() error {
 	protocols := []rpc.Protocol{
 		NewStreamUIProtocol(c.G()),
 		NewSecretUIProtocol(c.G()),
-		NewIdentifyMaybeTrackUIProtocol(c.G()),
+		NewIdentifyTrackUIProtocol(c.G()),
 	}
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
 		return err

--- a/go/client/cmd_pgp_encrypt.go
+++ b/go/client/cmd_pgp_encrypt.go
@@ -77,7 +77,7 @@ func (c *CmdPGPEncrypt) Run() error {
 	protocols := []rpc.Protocol{
 		NewStreamUIProtocol(c.G()),
 		NewSecretUIProtocol(c.G()),
-		NewIdentifyTrackUIProtocol(c.G()),
+		NewIdentifyUIProtocol(c.G()),
 	}
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
 		return err

--- a/go/client/cmd_pgp_pull.go
+++ b/go/client/cmd_pgp_pull.go
@@ -28,7 +28,7 @@ func (v *CmdPGPPull) Run() (err error) {
 		return err
 	}
 	protocols := []rpc.Protocol{
-		NewIdentifyMaybeTrackUIProtocol(v.G()),
+		NewIdentifyTrackUIProtocol(v.G()),
 	}
 	if err = RegisterProtocolsWithContext(protocols, v.G()); err != nil {
 		return err

--- a/go/client/cmd_pgp_verify.go
+++ b/go/client/cmd_pgp_verify.go
@@ -59,7 +59,7 @@ func (c *CmdPGPVerify) Run() error {
 	protocols := []rpc.Protocol{
 		NewStreamUIProtocol(c.G()),
 		NewSecretUIProtocol(c.G()),
-		NewIdentifyMaybeTrackUIProtocol(c.G()),
+		NewIdentifyTrackUIProtocol(c.G()),
 		NewPgpUIProtocol(c.G()),
 	}
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {

--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -23,30 +23,6 @@ func NewIdentifyTrackUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
 	return keybase1.IdentifyUiProtocol(&IdentifyUIServer{ui})
 }
 
-func cliIsLoggedIn(g *libkb.GlobalContext) bool {
-	configCli, err := GetConfigClient(g)
-	if err != nil {
-		return false
-	}
-
-	currentStatus, err := configCli.GetCurrentStatus(context.TODO(), 0)
-	if err != nil {
-		return false
-	}
-
-	return currentStatus.LoggedIn
-}
-
-// NewIdentifyMaybeTrackUIProtocol returns either IdentifyUiProtocol with
-// IdentifyTrackUI or IdentifyUI depending if user is logged in or not.
-func NewIdentifyMaybeTrackUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
-	if !cliIsLoggedIn(g) {
-		return NewIdentifyUIProtocol(g)
-	}
-
-	return NewIdentifyTrackUIProtocol(g)
-}
-
 func (i *IdentifyUIServer) DelegateIdentifyUI(_ context.Context) (int, error) {
 	return 0, libkb.UIDelegationUnavailableError{}
 }

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -199,10 +199,7 @@ func (e *PGPEncrypt) verifyUsers(ctx *Context, assertions []string, loggedIn boo
 			},
 			AlwaysBlock: true,
 		}
-		to := keybase1.TrackOptions{
-			LocalOnly: true,
-		}
-		eng := NewResolveThenIdentify2WithTrack(e.G(), &arg, to)
+		eng := NewResolveThenIdentify2(e.G(), &arg)
 		if err := RunEngine(eng, ctx); err != nil {
 			return nil, libkb.IdentifyFailedError{Assertion: userAssert, Reason: err.Error()}
 		}

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -199,7 +199,10 @@ func (e *PGPEncrypt) verifyUsers(ctx *Context, assertions []string, loggedIn boo
 			},
 			AlwaysBlock: true,
 		}
-		eng := NewResolveThenIdentify2(e.G(), &arg)
+		to := keybase1.TrackOptions{
+			LocalOnly: true,
+		}
+		eng := NewResolveThenIdentify2WithTrack(e.G(), &arg, to)
 		if err := RunEngine(eng, ctx); err != nil {
 			return nil, libkb.IdentifyFailedError{Assertion: userAssert, Reason: err.Error()}
 		}

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -147,9 +147,11 @@ func (e *PGPPullEngine) processUserWhenLoggedOut(ctx *Context, u string) error {
 	iarg := keybase1.Identify2Arg{
 		UserAssertion:    u,
 		ForceRemoteCheck: true,
+		AlwaysBlock:      true,
 	}
 	topts := keybase1.TrackOptions{
-		LocalOnly: true,
+		LocalOnly:  true,
+		ForPGPPull: true,
 	}
 	ieng := NewResolveThenIdentify2WithTrack(e.G(), &iarg, topts)
 	if err := RunEngine(ieng, ctx); err != nil {


### PR DESCRIPTION
We do not post tracking tokens anyway, so make the cli less-wrong by setting `LocalOnly` to true. ~~This will make Identify2 engine not ask "publicly follow?", only "Is this zzz you wanted?" or "Some proofs
failed; still follow?". The "still follow" here might be confusing because it's about local tracking. There is still an issue where we don't check for confirmation result there (e.g. pressing "NO" will still encrypt and return armored message), but it is a cache related defect in Identify2 engine which we decided not to fix right now.~~ Using just `NewIdentifyUIProtocol` makes the Identify go through but not ask for confirmation under any circumstance, which is exactly what we need right now. When there is more time, we can re-introduce tracking after pgp commands and make it work properly.

I'm abandoning https://github.com/keybase/client/pull/7704 for now in favor of this PR, as discussed previously.