### PR TITLE
Inject dependencies in teamloader

### DIFF
--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -31,6 +31,7 @@ func Load(ctx context.Context, g *libkb.GlobalContext, lArg keybase1.LoadTeamArg
 // Threadsafe.
 type TeamLoader struct {
 	libkb.Contextified
+	world   LoaderContext
 	storage *Storage
 	// Single-flight locks per team ID.
 	locktab libkb.LockTable
@@ -38,40 +39,29 @@ type TeamLoader struct {
 
 var _ libkb.TeamLoader = (*TeamLoader)(nil)
 
-func NewTeamLoader(g *libkb.GlobalContext, storage *Storage) *TeamLoader {
+func NewTeamLoader(g *libkb.GlobalContext, world LoaderContext, storage *Storage) *TeamLoader {
 	return &TeamLoader{
 		Contextified: libkb.NewContextified(g),
+		world:        world,
 		storage:      storage,
 	}
 }
 
 // NewTeamLoaderAndInstall creates a new loader and installs it into G.
 func NewTeamLoaderAndInstall(g *libkb.GlobalContext) *TeamLoader {
+	world := NewLoaderContextFromG(g)
 	st := NewStorage(g)
-	l := NewTeamLoader(g, st)
+	l := NewTeamLoader(g, world, st)
 	g.SetTeamLoader(l)
 	return l
 }
 
 func (l *TeamLoader) Load(ctx context.Context, lArg keybase1.LoadTeamArg) (res *keybase1.TeamData, err error) {
-	me, err := l.getMe(ctx)
+	me, err := l.world.GetMe(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return l.load1(ctx, me, lArg)
-}
-
-func (l *TeamLoader) getMe(ctx context.Context) (res keybase1.UserVersion, err error) {
-	loadMeArg := libkb.NewLoadUserArgBase(l.G()).
-		WithNetContext(ctx).
-		WithUID(l.G().Env.GetUID()).
-		WithSelf(true).
-		WithPublicKeyOptional()
-	upak, _, err := l.G().GetUPAKLoader().LoadV2(*loadMeArg)
-	if err != nil {
-		return keybase1.UserVersion{}, err
-	}
-	return NewUserVersion(upak.Current.Uid, upak.Current.EldestSeqno), nil
 }
 
 // Load1 unpacks the loadArg, calls load2, and does some final checks.
@@ -96,7 +86,7 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 	// It is safe for the answer to be wrong because the name is checked on the way out,
 	// and the merkle tree check guarantees one sigchain per team id.
 	if !teamID.Exists() {
-		teamID, err = l.resolveNameToIDUntrusted(ctx, *teamName)
+		teamID, err = l.world.ResolveNameToIDUntrusted(ctx, *teamName)
 		if err != nil {
 			l.G().Log.CDebugf(ctx, "TeamLoader looking up team by name failed: %v -> %v", *teamName, err)
 			return nil, err
@@ -169,33 +159,6 @@ func (l *TeamLoader) checkArg(ctx context.Context, lArg keybase1.LoadTeamArg) er
 		return fmt.Errorf("team load arg must have either ID or Name")
 	}
 	return nil
-}
-
-// Resolve a team name to a team ID.
-// Will always hit the server for subteams. The server can lie in this return value.
-func (l *TeamLoader) resolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName) (id keybase1.TeamID, err error) {
-	// For root team names, just hash.
-	if teamName.IsRootTeam() {
-		return teamName.ToTeamID(), nil
-	}
-
-	arg := libkb.NewRetryAPIArg("team/get")
-	arg.NetContext = ctx
-	arg.SessionType = libkb.APISessionTypeREQUIRED
-	arg.Args = libkb.HTTPArgs{
-		"name":        libkb.S{Val: teamName.String()},
-		"lookup_only": libkb.B{Val: true},
-	}
-
-	var rt rawTeam
-	if err := l.G().API.GetDecode(arg, &rt); err != nil {
-		return id, err
-	}
-	id = rt.ID
-	if !id.Exists() {
-		return id, fmt.Errorf("could not resolve team name: %v", teamName.String())
-	}
-	return id, nil
 }
 
 // Mostly the same as the public keybase.LoadTeamArg
@@ -282,7 +245,10 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 	if (ret == nil) || repoll {
 		l.G().Log.CDebugf(ctx, "TeamLoader looking up merkle leaf (force:%v)", arg.forceRepoll)
 		// Reference the merkle tree to fetch the sigchain tail leaf for the team.
-		lastSeqno, lastLinkID, err = l.lookupMerkle(ctx, arg.teamID)
+		lastSeqno, lastLinkID, err = l.world.MerkleLookup(ctx, arg.teamID)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		lastSeqno = ret.Chain.LastSeqno
 		lastLinkID = ret.Chain.LastLinkID
@@ -312,7 +278,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 	if ret == nil || ret.Chain.LastSeqno < lastSeqno {
 		lows := l.lows(ctx, ret)
 		l.G().Log.CDebugf(ctx, "TeamLoader getting links from server (%+v)", lows)
-		teamUpdate, err = l.getNewLinksFromServer(ctx, arg.teamID, lows, arg.readSubteamID)
+		teamUpdate, err = l.world.GetNewLinksFromServer(ctx, arg.teamID, lows, arg.readSubteamID)
 		if err != nil {
 			return nil, err
 		}
@@ -628,31 +594,16 @@ func (l *TeamLoader) satisfiesWantMembers(ctx context.Context,
 	return nil
 }
 
-func (l *TeamLoader) lookupMerkle(ctx context.Context, teamID keybase1.TeamID) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error) {
-	leaf, err := l.G().GetMerkleClient().LookupTeam(ctx, teamID)
-	if err != nil {
-		return r1, r2, err
-	}
-	if !leaf.TeamID.Eq(teamID) {
-		return r1, r2, fmt.Errorf("merkle returned wrong leaf: %v != %v", leaf.TeamID.String(), teamID.String())
-	}
-	if leaf.Private == nil {
-		return r1, r2, fmt.Errorf("merkle returned nil leaf")
-	}
-	return leaf.Private.Seqno, leaf.Private.LinkID.Export(), nil
-}
-
 func (l *TeamLoader) mungeWantMembers(ctx context.Context, wantMembers []keybase1.UserVersion) (res []keybase1.UserVersion, err error) {
 	for _, uv1 := range wantMembers {
 		uv2 := uv1
 		if uv2.EldestSeqno == 0 {
 			// Lookup the latest eldest seqno for that uid.
 			// This value may come from a cache.
-			upak, err := loadUPAK2(ctx, l.G(), uv2.Uid, false /*forcePoll */)
+			uv2.EldestSeqno, err = l.world.LookupEldestSeqno(ctx, uv2.Uid)
 			if err != nil {
 				return res, err
 			}
-			uv2.EldestSeqno = upak.Current.EldestSeqno
 			l.G().Log.CDebugf(ctx, "TeamLoader resolved wantMember %v -> %v", uv2.Uid, uv2.EldestSeqno)
 		}
 		res = append(res, uv2)
@@ -739,7 +690,7 @@ func (l *TeamLoader) VerifyTeamName(ctx context.Context, id keybase1.TeamID, nam
 // The specified team must be a subteam, or an error is returned.
 // Always sends a flurry of RPCs to get the most up to date info.
 func (l *TeamLoader) ImplicitAdmins(ctx context.Context, teamID keybase1.TeamID) (impAdmins []keybase1.UserVersion, err error) {
-	me, err := l.getMe(ctx)
+	me, err := l.world.GetMe(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -761,7 +712,7 @@ func (l *TeamLoader) ImplicitAdmins(ctx context.Context, teamID keybase1.TeamID)
 }
 
 func (l *TeamLoader) implicitAdminsAncestor(ctx context.Context, teamID keybase1.TeamID, ancestorID *keybase1.TeamID) ([]keybase1.UserVersion, error) {
-	me, err := l.getMe(ctx)
+	me, err := l.world.GetMe(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -831,7 +782,7 @@ func (l *TeamLoader) NotifyTeamRename(ctx context.Context, id keybase1.TeamID, n
 
 	var ancestorIDs []keybase1.TeamID
 
-	me, err := l.getMe(ctx)
+	me, err := l.world.GetMe(ctx)
 	if err != nil {
 		return err
 	}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -3,7 +3,6 @@ package teams
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -41,7 +40,7 @@ func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
 		return state, proofSet, parentChildOperations, nil
 	}
 
-	teamUpdate, err := l.getLinksFromServer(ctx, state.Chain.Id, requestSeqnos, &readSubteamID)
+	teamUpdate, err := l.world.GetLinksFromServer(ctx, state.Chain.Id, requestSeqnos, &readSubteamID)
 	if err != nil {
 		return state, proofSet, parentChildOperations, err
 	}
@@ -93,70 +92,6 @@ type getLinksLows struct {
 	ReaderKeyMask keybase1.PerTeamKeyGeneration
 }
 
-// Get new links from the server.
-func (l *TeamLoader) getNewLinksFromServer(ctx context.Context,
-	teamID keybase1.TeamID, lows getLinksLows,
-	readSubteamID *keybase1.TeamID) (*rawTeam, error) {
-
-	arg := libkb.NewRetryAPIArg("team/get")
-	arg.NetContext = ctx
-	arg.SessionType = libkb.APISessionTypeREQUIRED
-	arg.Args = libkb.HTTPArgs{
-		"id":  libkb.S{Val: teamID.String()},
-		"low": libkb.I{Val: int(lows.Seqno)},
-		// These don't really work yet on the client or server.
-		// "per_team_key_low":    libkb.I{Val: int(lows.PerTeamKey)},
-		// "reader_key_mask_low": libkb.I{Val: int(lows.PerTeamKey)},
-	}
-	if readSubteamID != nil {
-		arg.Args["read_subteam_id"] = libkb.S{Val: readSubteamID.String()}
-	}
-
-	var rt rawTeam
-	if err := l.G().API.GetDecode(arg, &rt); err != nil {
-		return nil, err
-	}
-	if !rt.ID.Eq(teamID) {
-		return nil, fmt.Errorf("server returned wrong team ID: %v != %v", rt.ID, teamID)
-	}
-	return &rt, nil
-}
-
-// Get full links from the server.
-// Does not guarantee that the server returned the correct links, nor that they are unstubbed.
-func (l *TeamLoader) getLinksFromServer(ctx context.Context,
-	teamID keybase1.TeamID, requestSeqnos []keybase1.Seqno, readSubteamID *keybase1.TeamID) (*rawTeam, error) {
-
-	var seqnoStrs []string
-	for _, seqno := range requestSeqnos {
-		seqnoStrs = append(seqnoStrs, fmt.Sprintf("%d", int(seqno)))
-	}
-	seqnoCommas := strings.Join(seqnoStrs, ",")
-
-	arg := libkb.NewRetryAPIArg("team/get")
-	arg.NetContext = ctx
-	arg.SessionType = libkb.APISessionTypeREQUIRED
-	arg.Args = libkb.HTTPArgs{
-		"id":     libkb.S{Val: teamID.String()},
-		"seqnos": libkb.S{Val: seqnoCommas},
-		// These don't really work yet on the client or server.
-		// "per_team_key_low":    libkb.I{Val: int(lows.PerTeamKey)},
-		// "reader_key_mask_low": libkb.I{Val: int(lows.PerTeamKey)},
-	}
-	if readSubteamID != nil {
-		arg.Args["read_subteam_id"] = libkb.S{Val: readSubteamID.String()}
-	}
-
-	var rt rawTeam
-	if err := l.G().API.GetDecode(arg, &rt); err != nil {
-		return nil, err
-	}
-	if !rt.ID.Eq(teamID) {
-		return nil, fmt.Errorf("server returned wrong team ID: %v != %v", rt.ID, teamID)
-	}
-	return &rt, nil
-}
-
 // checkStubbed checks if it's OK that a link is stubbed.
 func (l *TeamLoader) checkStubbed(ctx context.Context, arg load2ArgT, link *chainLinkUnpacked) error {
 	if !link.isStubbed() {
@@ -174,28 +109,22 @@ func (l *TeamLoader) checkStubbed(ctx context.Context, arg load2ArgT, link *chai
 	return nil
 }
 
-func (l *TeamLoader) loadUserAndKeyFromLinkInner(ctx context.Context, inner SCChainLinkPayload) (user *keybase1.UserPlusKeysV2, key *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
+func (l *TeamLoader) loadUserAndKeyFromLinkInner(ctx context.Context,
+	inner SCChainLinkPayload) (
+	signerUV keybase1.UserVersion, key *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
+
 	defer l.G().CTrace(ctx, fmt.Sprintf("TeamLoader#loadUserForSigVerification(%d)", int(inner.Seqno)), func() error { return err })()
 	keySection := inner.Body.Key
 	if keySection == nil {
-		return nil, nil, nil, libkb.NoUIDError{}
+		return signerUV, nil, nil, libkb.NoUIDError{}
 	}
 	uid := keySection.UID
 	kid := keySection.KID
-	user, key, linkMap, err = l.G().GetUPAKLoader().LoadKeyV2(ctx, uid, kid)
+	signerUV, key, linkMap, err = l.world.LoadKeyV2(ctx, uid, kid)
 	if err != nil {
-		return nil, nil, nil, err
+		return signerUV, nil, nil, err
 	}
-	return user, key, linkMap, nil
-}
-
-func forceLinkMapRefreshForUser(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID) (linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
-	arg := libkb.NewLoadUserArgBase(g).WithNetContext(ctx).WithUID(uid).WithForcePoll()
-	upak, _, err := g.GetUPAKLoader().LoadV2(*arg)
-	if err != nil {
-		return nil, err
-	}
-	return upak.SeqnoLinkIDs, nil
+	return signerUV, key, linkMap, nil
 }
 
 func (l *TeamLoader) verifySignatureAndExtractKID(ctx context.Context, outer libkb.OuterLinkV2WithMetadata) (keybase1.KID, error) {
@@ -246,7 +175,7 @@ func (l *TeamLoader) verifyLink(ctx context.Context,
 		return nil, proofSet, err
 	}
 
-	user, key, linkMap, err := l.loadUserAndKeyFromLinkInner(ctx, *link.inner)
+	signerUV, key, linkMap, err := l.loadUserAndKeyFromLinkInner(ctx, *link.inner)
 	if err != nil {
 		return nil, proofSet, err
 	}
@@ -260,9 +189,9 @@ func (l *TeamLoader) verifyLink(ctx context.Context,
 		teamLinkMap = state.Chain.LinkIDs
 	}
 
-	proofSet = addProofsForKeyInUserSigchain(teamID, teamLinkMap, link, user.Uid, key, linkMap, proofSet)
+	proofSet = addProofsForKeyInUserSigchain(teamID, teamLinkMap, link, signerUV.Uid, key, linkMap, proofSet)
 
-	signer := signerX{signer: user.ToUserVersion()}
+	signer := signerX{signer: signerUV}
 
 	// For a root team link, or a subteam_head, there is no reason to check adminship
 	// or writership (or readership) for the team.
@@ -272,14 +201,14 @@ func (l *TeamLoader) verifyLink(ctx context.Context,
 
 	var isReaderOrAbove bool
 	if !link.outerLink.LinkType.RequiresAdminPermission() {
-		err = l.verifyWriterOrReaderPermissions(ctx, state, link, user.ToUserVersion())
+		err = l.verifyWriterOrReaderPermissions(ctx, state, link, signerUV)
 		isReaderOrAbove = (err == nil)
 	}
 	if link.outerLink.LinkType.RequiresAdminPermission() || !isReaderOrAbove {
 		// Check for admin permissions if they are not an on-chain reader/writer
 		// because they might be an implicit admin.
 		// Reassigns signer, might set implicitAdmin.
-		proofSet, signer, err = l.verifyAdminPermissions(ctx, state, me, link, readSubteamID, user.ToUserVersion(), proofSet)
+		proofSet, signer, err = l.verifyAdminPermissions(ctx, state, me, link, readSubteamID, signerUV, proofSet)
 	}
 	return &signer, proofSet, err
 }
@@ -573,7 +502,7 @@ func (l *TeamLoader) checkOneParentChildOperation(ctx context.Context,
 func (l *TeamLoader) checkProofs(ctx context.Context,
 	state *keybase1.TeamData, proofSet *proofSetT) error {
 
-	return proofSet.check(ctx, l.G())
+	return proofSet.check(ctx, l.G(), l.world)
 }
 
 // Add data to the state that is not included in the sigchain:
@@ -793,20 +722,7 @@ func (l *TeamLoader) unboxPerTeamSecrets(ctx context.Context,
 }
 
 func (l *TeamLoader) perUserEncryptionKey(ctx context.Context, userSeqno keybase1.Seqno) (*libkb.NaclDHKeyPair, error) {
-	kr, err := l.G().GetPerUserKeyring()
-	if err != nil {
-		return nil, err
-	}
-	// Try to get it locally, if that fails try again after syncing.
-	encKey, err := kr.GetEncryptionKeyBySeqno(ctx, userSeqno)
-	if err == nil {
-		return encKey, err
-	}
-	if err := kr.Sync(ctx); err != nil {
-		return nil, err
-	}
-	encKey, err = kr.GetEncryptionKeyBySeqno(ctx, userSeqno)
-	return encKey, err
+	return l.world.PerUserEncryptionKey(ctx, userSeqno)
 }
 
 func (l *TeamLoader) unpackLinks(ctx context.Context, teamUpdate *rawTeam) ([]*chainLinkUnpacked, error) {

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -1,0 +1,224 @@
+package teams
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// Things TeamLoader uses that are mocked out for tests.
+type LoaderContext interface {
+	// Get new links from the server.
+	GetNewLinksFromServer(ctx context.Context,
+		teamID keybase1.TeamID, lows getLinksLows,
+		readSubteamID *keybase1.TeamID) (*rawTeam, error)
+	// Get full links from the server.
+	// Does not guarantee that the server returned the correct links, nor that they are unstubbed.
+	GetLinksFromServer(ctx context.Context,
+		teamID keybase1.TeamID, requestSeqnos []keybase1.Seqno,
+		readSubteamID *keybase1.TeamID) (*rawTeam, error)
+	GetMe(context.Context) (keybase1.UserVersion, error)
+	// Lookup the eldest seqno of a user. Can use the cache.
+	LookupEldestSeqno(context.Context, keybase1.UID) (keybase1.Seqno, error)
+	ResolveNameToIDUntrusted(context.Context, keybase1.TeamName) (keybase1.TeamID, error)
+	// Get the current user's per-user-key's derived encryption key (full).
+	PerUserEncryptionKey(ctx context.Context, userSeqno keybase1.Seqno) (*libkb.NaclDHKeyPair, error)
+	MerkleLookup(ctx context.Context, teamID keybase1.TeamID) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error)
+	MerkleLookupTripleAtHashMeta(ctx context.Context, leafID keybase1.UserOrTeamID, hm keybase1.HashMeta) (triple *libkb.MerkleTriple, err error)
+	ForceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap map[keybase1.Seqno]keybase1.LinkID, err error)
+	LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (keybase1.UserVersion, *keybase1.PublicKeyV2NaCl, map[keybase1.Seqno]keybase1.LinkID, error)
+}
+
+// The main LoaderContext is G.
+type LoaderContextG struct {
+	libkb.Contextified
+}
+
+var _ LoaderContext = (*LoaderContextG)(nil)
+
+func NewLoaderContextFromG(g *libkb.GlobalContext) LoaderContext {
+	return &LoaderContextG{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+// Get new links from the server.
+func (l *LoaderContextG) GetNewLinksFromServer(ctx context.Context,
+	teamID keybase1.TeamID, lows getLinksLows,
+	readSubteamID *keybase1.TeamID) (*rawTeam, error) {
+
+	arg := libkb.NewRetryAPIArg("team/get")
+	arg.NetContext = ctx
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	arg.Args = libkb.HTTPArgs{
+		"id":  libkb.S{Val: teamID.String()},
+		"low": libkb.I{Val: int(lows.Seqno)},
+		// These don't really work yet on the client or server.
+		// "per_team_key_low":    libkb.I{Val: int(lows.PerTeamKey)},
+		// "reader_key_mask_low": libkb.I{Val: int(lows.PerTeamKey)},
+	}
+	if readSubteamID != nil {
+		arg.Args["read_subteam_id"] = libkb.S{Val: readSubteamID.String()}
+	}
+
+	var rt rawTeam
+	if err := l.G().API.GetDecode(arg, &rt); err != nil {
+		return nil, err
+	}
+	if !rt.ID.Eq(teamID) {
+		return nil, fmt.Errorf("server returned wrong team ID: %v != %v", rt.ID, teamID)
+	}
+	return &rt, nil
+}
+
+// Get full links from the server.
+// Does not guarantee that the server returned the correct links, nor that they are unstubbed.
+func (l *LoaderContextG) GetLinksFromServer(ctx context.Context,
+	teamID keybase1.TeamID, requestSeqnos []keybase1.Seqno, readSubteamID *keybase1.TeamID) (*rawTeam, error) {
+
+	var seqnoStrs []string
+	for _, seqno := range requestSeqnos {
+		seqnoStrs = append(seqnoStrs, fmt.Sprintf("%d", int(seqno)))
+	}
+	seqnoCommas := strings.Join(seqnoStrs, ",")
+
+	arg := libkb.NewRetryAPIArg("team/get")
+	arg.NetContext = ctx
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	arg.Args = libkb.HTTPArgs{
+		"id":     libkb.S{Val: teamID.String()},
+		"seqnos": libkb.S{Val: seqnoCommas},
+		// These don't really work yet on the client or server.
+		// "per_team_key_low":    libkb.I{Val: int(lows.PerTeamKey)},
+		// "reader_key_mask_low": libkb.I{Val: int(lows.PerTeamKey)},
+	}
+	if readSubteamID != nil {
+		arg.Args["read_subteam_id"] = libkb.S{Val: readSubteamID.String()}
+	}
+
+	var rt rawTeam
+	if err := l.G().API.GetDecode(arg, &rt); err != nil {
+		return nil, err
+	}
+	if !rt.ID.Eq(teamID) {
+		return nil, fmt.Errorf("server returned wrong team ID: %v != %v", rt.ID, teamID)
+	}
+	return &rt, nil
+}
+
+func (l *LoaderContextG) GetMe(ctx context.Context) (res keybase1.UserVersion, err error) {
+	loadMeArg := libkb.NewLoadUserArgBase(l.G()).
+		WithNetContext(ctx).
+		WithUID(l.G().Env.GetUID()).
+		WithSelf(true).
+		WithPublicKeyOptional()
+	upak, _, err := l.G().GetUPAKLoader().LoadV2(*loadMeArg)
+	if err != nil {
+		return keybase1.UserVersion{}, err
+	}
+	return NewUserVersion(upak.Current.Uid, upak.Current.EldestSeqno), nil
+}
+
+func (l *LoaderContextG) LookupEldestSeqno(ctx context.Context, uid keybase1.UID) (keybase1.Seqno, error) {
+	// Lookup the latest eldest seqno for that uid.
+	// This value may come from a cache.
+	upak, err := loadUPAK2(ctx, l.G(), uid, false /*forcePoll */)
+	if err != nil {
+		return keybase1.Seqno(1), err
+	}
+	return upak.Current.EldestSeqno, nil
+}
+
+// Resolve a team name to a team ID.
+// Will always hit the server for subteams. The server can lie in this return value.
+func (l *LoaderContextG) ResolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName) (id keybase1.TeamID, err error) {
+	// For root team names, just hash.
+	if teamName.IsRootTeam() {
+		return teamName.ToTeamID(), nil
+	}
+
+	arg := libkb.NewRetryAPIArg("team/get")
+	arg.NetContext = ctx
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	arg.Args = libkb.HTTPArgs{
+		"name":        libkb.S{Val: teamName.String()},
+		"lookup_only": libkb.B{Val: true},
+	}
+
+	var rt rawTeam
+	if err := l.G().API.GetDecode(arg, &rt); err != nil {
+		return id, err
+	}
+	id = rt.ID
+	if !id.Exists() {
+		return id, fmt.Errorf("could not resolve team name: %v", teamName.String())
+	}
+	return id, nil
+}
+
+func (l *LoaderContextG) PerUserEncryptionKey(ctx context.Context, userSeqno keybase1.Seqno) (*libkb.NaclDHKeyPair, error) {
+	kr, err := l.G().GetPerUserKeyring()
+	if err != nil {
+		return nil, err
+	}
+	// Try to get it locally, if that fails try again after syncing.
+	encKey, err := kr.GetEncryptionKeyBySeqno(ctx, userSeqno)
+	if err == nil {
+		return encKey, err
+	}
+	if err := kr.Sync(ctx); err != nil {
+		return nil, err
+	}
+	encKey, err = kr.GetEncryptionKeyBySeqno(ctx, userSeqno)
+	return encKey, err
+}
+
+func (l *LoaderContextG) MerkleLookup(ctx context.Context, teamID keybase1.TeamID) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error) {
+	leaf, err := l.G().GetMerkleClient().LookupTeam(ctx, teamID)
+	if err != nil {
+		return r1, r2, err
+	}
+	if !leaf.TeamID.Eq(teamID) {
+		return r1, r2, fmt.Errorf("merkle returned wrong leaf: %v != %v", leaf.TeamID.String(), teamID.String())
+	}
+	if leaf.Private == nil {
+		return r1, r2, fmt.Errorf("merkle returned nil leaf")
+	}
+	return leaf.Private.Seqno, leaf.Private.LinkID.Export(), nil
+}
+
+func (l *LoaderContextG) MerkleLookupTripleAtHashMeta(ctx context.Context, leafID keybase1.UserOrTeamID, hm keybase1.HashMeta) (triple *libkb.MerkleTriple, err error) {
+	leaf, err := l.G().MerkleClient.LookupLeafAtHashMeta(ctx, leafID, hm)
+	if err != nil {
+		return nil, err
+	}
+	if leafID.IsUser() {
+		triple = leaf.Public
+	} else {
+		triple = leaf.Private
+	}
+	return triple, nil
+}
+
+func (l *LoaderContextG) ForceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
+	arg := libkb.NewLoadUserArgBase(l.G()).WithNetContext(ctx).WithUID(uid).WithForcePoll()
+	upak, _, err := l.G().GetUPAKLoader().LoadV2(*arg)
+	if err != nil {
+		return nil, err
+	}
+	return upak.SeqnoLinkIDs, nil
+}
+
+func (l *LoaderContextG) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (
+	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID,
+	err error) {
+
+	user, pubKey, linkMap, err := l.G().GetUPAKLoader().LoadKeyV2(ctx, uid, kid)
+	if err != nil {
+		return
+	}
+	return user.ToUserVersion(), pubKey, linkMap, nil
+}

--- a/go/teams/proofs.go
+++ b/go/teams/proofs.go
@@ -131,23 +131,14 @@ func (p *proofSetT) AllProofs() []proof {
 
 // lookupMerkleTreeChain loads the path up to the merkle tree and back down that corresponds
 // to this proof. It will contact the API server.  Returns the sigchain tail on success.
-func (p proof) lookupMerkleTreeChain(ctx context.Context, g *libkb.GlobalContext) (ret *libkb.MerkleTriple, err error) {
-	leaf, err := g.MerkleClient.LookupLeafAtHashMeta(ctx, p.a.leafID, p.b.sigMeta.PrevMerkleRootSigned.HashMeta)
-	if err != nil {
-		return nil, err
-	}
-	if p.a.leafID.IsUser() {
-		ret = leaf.Public
-	} else {
-		ret = leaf.Private
-	}
-	return ret, nil
+func (p proof) lookupMerkleTreeChain(ctx context.Context, world LoaderContext) (ret *libkb.MerkleTriple, err error) {
+	return world.MerkleLookupTripleAtHashMeta(ctx, p.a.leafID, p.b.sigMeta.PrevMerkleRootSigned.HashMeta)
 }
 
 // check a single proof. Call to the merkle API enddpoint, and then ensure that the
 // data that comes back fits the proof and previously checked sighcain links.
-func (p proof) check(ctx context.Context, g *libkb.GlobalContext) error {
-	triple, err := p.lookupMerkleTreeChain(ctx, g)
+func (p proof) check(ctx context.Context, g *libkb.GlobalContext, world LoaderContext) error {
+	triple, err := p.lookupMerkleTreeChain(ctx, world)
 	if err != nil {
 		return err
 	}
@@ -172,7 +163,7 @@ func (p proof) check(ctx context.Context, g *libkb.GlobalContext) error {
 	// we're toast.
 	if !ok && p.a.leafID.IsUser() {
 		g.Log.CDebugf(ctx, "proof#check: missed load for %s at %d; trying a force repoll", p.a.leafID.String(), laterSeqno)
-		lm, err := forceLinkMapRefreshForUser(ctx, g, p.a.leafID.AsUserOrBust())
+		lm, err := world.ForceLinkMapRefreshForUser(ctx, p.a.leafID.AsUserOrBust())
 		if err != nil {
 			return err
 		}
@@ -190,7 +181,7 @@ func (p proof) check(ctx context.Context, g *libkb.GlobalContext) error {
 }
 
 // check the entire proof set, failing if any one proof fails.
-func (p *proofSetT) check(ctx context.Context, g *libkb.GlobalContext) (err error) {
+func (p *proofSetT) check(ctx context.Context, g *libkb.GlobalContext, world LoaderContext) (err error) {
 	defer g.CTrace(ctx, "TeamLoader proofSet check", func() error { return err })()
 
 	var total int
@@ -204,7 +195,7 @@ func (p *proofSetT) check(ctx context.Context, g *libkb.GlobalContext) (err erro
 			if i%100 == 0 {
 				g.Log.CDebugf(ctx, "TeamLoader proofSet check [%v / %v]", i, total)
 			}
-			err = proof.check(ctx, g)
+			err = proof.check(ctx, g, world)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Move all the parts of team loader that talk to the outside world into `LoaderContext`. This shouldn't change any behavior, but makes it possible to mock that stuff for tests. Tests are not in this branch, that's still underway.