### PR TITLE
Chat: Avoid outboxID races using new RPC

### DIFF
--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -207,15 +207,14 @@ function* _appendAttachmentPlaceholder(
   uploadPath: string
 ) {
   const author = yield select(usernameSelector)
-  const hasPendingFailure = yield select(Shared.pendingFailureSelector, outboxIDKey)
   const message: Constants.AttachmentMessage = {
     author,
     conversationIDKey,
     deviceName: '',
     deviceType: isMobile ? 'mobile' : 'desktop',
-    failureDescription: hasPendingFailure,
+    failureDescription: '',
     key: Constants.messageKey(conversationIDKey, 'outboxIDAttachment', outboxIDKey),
-    messageState: hasPendingFailure ? 'failed' : 'pending',
+    messageState: 'pending',
     outboxID: outboxIDKey,
     senderDeviceRevokedAt: null,
     timestamp: Date.now(),
@@ -239,10 +238,6 @@ function* _appendAttachmentPlaceholder(
     )
   )
   yield put(Creators.attachmentLoaded(message.key, preview.filename, true))
-  if (hasPendingFailure) {
-    yield put(Creators.removePendingFailure(outboxIDKey))
-  }
-
   return message
 }
 

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -296,16 +296,6 @@ function updateInbox(conversation: Constants.InboxState): Constants.UpdateInbox 
   return {payload: {conversation}, type: 'chat:updateInbox'}
 }
 
-function createPendingFailure(
-  failureDescription: string,
-  outboxID: Constants.OutboxIDKey
-): Constants.CreatePendingFailure {
-  return {
-    payload: {failureDescription, outboxID},
-    type: 'chat:createPendingFailure',
-  }
-}
-
 function updatePaginationNext(
   conversationIDKey: Constants.ConversationIDKey,
   paginationNext: Buffer
@@ -607,10 +597,6 @@ function removeOutboxMessage(
   }
 }
 
-function removePendingFailure(outboxID: Constants.OutboxIDKey): Constants.RemovePendingFailure {
-  return {payload: {outboxID}, type: 'chat:removePendingFailure'}
-}
-
 function openConversation(conversationIDKey: Constants.ConversationIDKey): Constants.OpenConversation {
   return {payload: {conversationIDKey}, type: 'chat:openConversation'}
 }
@@ -706,7 +692,6 @@ export {
   clearMessages,
   clearSearchResults,
   clearRekey,
-  createPendingFailure,
   deleteMessage,
   downloadProgress,
   editMessage,
@@ -734,7 +719,6 @@ export {
   postMessage,
   prependMessages,
   removeOutboxMessage,
-  removePendingFailure,
   removeTempPendingConversations,
   replaceConversation,
   retryAttachment,

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -61,16 +61,6 @@ function* _incomingMessage(action: Constants.IncomingMessage): SagaGenerator<any
           // $FlowIssue
           const errTyp = outboxRecord.state.error.typ
           const failureDescription = _decodeFailureDescription(errTyp)
-          // There's an RPC race condition here.  Two possibilities:
-          //
-          // Either we've already finished in _postMessage() and have recorded
-          // the outboxID pending message in the store, or we haven't.  If we
-          // have, just set it to failed.  If we haven't, record this as a
-          // pending failure, and pick up the pending failure at the bottom of
-          // _postMessage() instead.
-          //
-          // Do we have this conversation loaded?  If not, don't do anything -
-          // we'll pick up the failure when we load that thread.
           const isConversationLoaded = yield select(Shared.conversationStateSelector, conversationIDKey)
           if (!isConversationLoaded) return
 
@@ -88,7 +78,7 @@ function* _incomingMessage(action: Constants.IncomingMessage): SagaGenerator<any
               )
             )
           } else {
-            yield put(Creators.createPendingFailure(failureDescription, outboxID))
+            throw new Error("Pending message wasn't found!")
           }
         }
       }

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -101,9 +101,43 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
     }
   }
 
-  const sent = yield call(ChatTypes.localPostLocalNonblockRpcPromise, {
+  const outboxID = yield call(ChatTypes.localGenerateOutboxIDRpcPromise)
+  const author = yield select(usernameSelector)
+
+  const message: Constants.Message = {
+    author,
+    conversationIDKey: action.payload.conversationIDKey,
+    deviceName: '',
+    deviceType: isMobile ? 'mobile' : 'desktop',
+    editedCount: 0,
+    failureDescription: '',
+    key: Constants.messageKey(action.payload.conversationIDKey, 'outboxIDText', outboxID),
+    message: new HiddenString(action.payload.text.stringValue()),
+    messageState: 'pending',
+    outboxID: Constants.outboxIDToKey(outboxID),
+    senderDeviceRevokedAt: null,
+    timestamp: Date.now(),
+    type: 'Text',
+    you: author,
+  }
+
+  const selectedConversation = yield select(Constants.getSelectedConversation)
+  const appFocused = yield select(Shared.focusedSelector)
+
+  yield put(
+    Creators.appendMessages(
+      conversationIDKey,
+      conversationIDKey === selectedConversation,
+      appFocused,
+      [message],
+      false
+    )
+  )
+
+  yield call(ChatTypes.localPostLocalNonblockRpcPromise, {
     param: {
       conversationID: Constants.keyToConversationID(conversationIDKey),
+      outboxID,
       identifyBehavior: yield call(Shared.getPostingIdentifyBehavior, conversationIDKey),
       clientPrev: lastMessageID,
       msg: {
@@ -117,40 +151,6 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
       },
     },
   })
-
-  const author = yield select(usernameSelector)
-  if (sent && author) {
-    const outboxID = Constants.outboxIDToKey(sent.outboxID)
-    const message: Constants.Message = {
-      author,
-      conversationIDKey: action.payload.conversationIDKey,
-      deviceName: '',
-      deviceType: isMobile ? 'mobile' : 'desktop',
-      editedCount: 0,
-      failureDescription: '',
-      key: Constants.messageKey(action.payload.conversationIDKey, 'outboxIDText', outboxID),
-      message: new HiddenString(action.payload.text.stringValue()),
-      messageState: 'pending',
-      outboxID,
-      senderDeviceRevokedAt: null,
-      timestamp: Date.now(),
-      type: 'Text',
-      you: author,
-    }
-
-    const selectedConversation = yield select(Constants.getSelectedConversation)
-    const appFocused = yield select(Shared.focusedSelector)
-
-    yield put(
-      Creators.appendMessages(
-        conversationIDKey,
-        conversationIDKey === selectedConversation,
-        appFocused,
-        [message],
-        false
-      )
-    )
-  }
 }
 
 function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -121,17 +121,16 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
   const author = yield select(usernameSelector)
   if (sent && author) {
     const outboxID = Constants.outboxIDToKey(sent.outboxID)
-    const hasPendingFailure = yield select(Shared.pendingFailureSelector, outboxID)
     const message: Constants.Message = {
       author,
       conversationIDKey: action.payload.conversationIDKey,
       deviceName: '',
       deviceType: isMobile ? 'mobile' : 'desktop',
       editedCount: 0,
-      failureDescription: hasPendingFailure,
+      failureDescription: '',
       key: Constants.messageKey(action.payload.conversationIDKey, 'outboxIDText', outboxID),
       message: new HiddenString(action.payload.text.stringValue()),
-      messageState: hasPendingFailure ? 'failed' : 'pending',
+      messageState: 'pending',
       outboxID,
       senderDeviceRevokedAt: null,
       timestamp: Date.now(),
@@ -151,9 +150,6 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
         false
       )
     )
-    if (hasPendingFailure) {
-      yield put(Creators.removePendingFailure(outboxID))
-    }
   }
 }
 

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -25,10 +25,6 @@ function routeSelector(state: TypedState) {
 function focusedSelector(state: TypedState) {
   return state.config.appFocused
 }
-function pendingFailureSelector(state: TypedState, outboxID: Constants.OutboxIDKey) {
-  return state.chat.get('pendingFailures').get(outboxID)
-}
-
 function conversationStateSelector(state: TypedState, conversationIDKey: Constants.ConversationIDKey) {
   return state.chat.get('conversationStates', Map()).get(conversationIDKey)
 }
@@ -192,7 +188,6 @@ export {
   messageOutboxIDSelector,
   messageSelector,
   metaDataSelector,
-  pendingFailureSelector,
   routeSelector,
   selectedInboxSelector,
   startNewConversation,

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -370,7 +370,6 @@ export const StateRecord: KBRecord<T> = Record({
   finalizedState: Map(),
   supersedesState: Map(),
   supersededByState: Map(),
-  pendingFailures: Map(),
   conversationUnreadCounts: Map(),
   rekeyInfos: Map(),
   alwaysShow: Set(),
@@ -403,7 +402,6 @@ export type State = KBRecord<{
   supersedesState: SupersedesState,
   supersededByState: SupersededByState,
   metaData: MetaDataMap,
-  pendingFailures: Map<OutboxIDKey, ?string>,
   conversationUnreadCounts: Map<ConversationIDKey, number>,
   rekeyInfos: Map<ConversationIDKey, RekeyInfo>,
   alwaysShow: Set<ConversationIDKey>,
@@ -457,10 +455,6 @@ export type BlockConversation = NoErrorTypedAction<
 export type ClearMessages = NoErrorTypedAction<'chat:clearMessages', {conversationIDKey: ConversationIDKey}>
 export type ClearSearchResults = NoErrorTypedAction<'chat:clearSearchResults', {}>
 export type ClearRekey = NoErrorTypedAction<'chat:clearRekey', {conversationIDKey: ConversationIDKey}>
-export type CreatePendingFailure = NoErrorTypedAction<
-  'chat:createPendingFailure',
-  {failureDescription: string, outboxID: OutboxIDKey}
->
 export type DeleteMessage = NoErrorTypedAction<'chat:deleteMessage', {message: Message}>
 export type EditMessage = NoErrorTypedAction<'chat:editMessage', {message: Message, text: HiddenString}>
 export type ExitSearch = NoErrorTypedAction<'chat:exitSearch', {}>
@@ -521,7 +515,6 @@ export type RemoveOutboxMessage = NoErrorTypedAction<
   'chat:removeOutboxMessage',
   {conversationIDKey: ConversationIDKey, outboxID: OutboxIDKey}
 >
-export type RemovePendingFailure = NoErrorTypedAction<'chat:removePendingFailure', {outboxID: OutboxIDKey}>
 export type ReplaceConversation = NoErrorTypedAction<
   'chat:replaceConversation',
   {oldKey: ConversationIDKey, newKey: ConversationIDKey}

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -371,14 +371,6 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
         )
       )
     }
-    case 'chat:createPendingFailure': {
-      const {failureDescription, outboxID} = action.payload
-      return state.set('pendingFailures', state.get('pendingFailures').set(outboxID, failureDescription))
-    }
-    case 'chat:removePendingFailure': {
-      const {outboxID} = action.payload
-      return state.set('pendingFailures', state.get('pendingFailures').delete(outboxID))
-    }
     case 'chat:attachmentLoaded': {
       const {messageKey, path, isPreview} = action.payload
       let toMerge


### PR DESCRIPTION
@keybase/react-hackers CC @mmaxim 

Before this PR, we would:

* send a message
* (failure path 1) maybe get a failure notification for it, store it away
* get the newly-sent message's outboxID back from the service
* put it in the store
* after putting the pending message in the store, see if we stored away a failure for it and apply it
* (failure path 2) maybe get a failure notification for it, apply it

After this PR, we have only one path for errors, and we get to completely remove the "PendingFailure" concept from the code:

* get an outboxID for the message we're about to send, without sending it yet
* put it in the store
* send it
* if we get a failure notification, apply it

There might also be a bit of a perceived performance gain on sending, since the service no longer accepts and queues the message before we display it on-screen.