### PR TITLE
Handle 'can't load inbox' error

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -105,6 +105,15 @@ function* onInboxStale(): SagaGenerator<any, any> {
     )
 
     const incoming = yield loadInboxChanMap.race()
+
+    if (incoming.finished) {
+      yield put(Creators.setInboxUntrustedState('loaded'))
+      if (incoming.finished.error) {
+        throw new Error(`Can't load inbox ${incoming.finished.error}`)
+      }
+      return
+    }
+
     if (
       !incoming['chat.1.chatUi.chatInboxUnverified'] ||
       !incoming['chat.1.chatUi.chatInboxUnverified'].response


### PR DESCRIPTION
This was because we assume the backend would give us the unverified inbox first, but there are cases where this doesn't happen. I think thats a different bug i'm trying to repro but for now this fixes out side

@keybase/react-hackers 