### PR TITLE
better error message when trying to load inner links when not admin

### DIFF
--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -26,8 +26,8 @@ func (e StubbedError) Error() string {
 	if e.note == nil {
 		return fmt.Sprintf("stubbed link when not expected (seqno %d)", int(e.l.outerLink.Seqno))
 	}
-	return fmt.Sprintf("stubbed link when not expected (seqno %d) (%s)",
-		int(e.l.outerLink.Seqno), *e.note)
+	return fmt.Sprintf("%s (stubbed link when not expected; at seqno %d)",
+		*e.note, int(e.l.outerLink.Seqno))
 }
 
 type InvalidLink struct {

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -100,11 +100,8 @@ func (l *TeamLoader) checkStubbed(ctx context.Context, arg load2ArgT, link *chai
 	if l.seqnosContains(arg.needSeqnos, link.Seqno()) {
 		return NewStubbedErrorWithNote(link, "Need seqno")
 	}
-	if arg.needAdmin {
+	if arg.needAdmin || !link.outerLink.LinkType.TeamAllowStubWithAdminFlag(arg.needAdmin) {
 		return NewStubbedErrorWithNote(link, "Need admin privilege for this action")
-	}
-	if !link.outerLink.LinkType.TeamAllowStubWithAdminFlag(arg.needAdmin) {
-		return NewStubbedErrorWithNote(link, "This action is disallowed")
 	}
 	return nil
 }

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -98,13 +98,13 @@ func (l *TeamLoader) checkStubbed(ctx context.Context, arg load2ArgT, link *chai
 		return nil
 	}
 	if l.seqnosContains(arg.needSeqnos, link.Seqno()) {
-		return NewStubbedErrorWithNote(link, "need seqno")
+		return NewStubbedErrorWithNote(link, "Need seqno")
 	}
 	if arg.needAdmin {
-		return NewStubbedErrorWithNote(link, "need admin")
+		return NewStubbedErrorWithNote(link, "Need admin privilege for this action")
 	}
 	if !link.outerLink.LinkType.TeamAllowStubWithAdminFlag(arg.needAdmin) {
-		return NewStubbedErrorWithNote(link, "disallowed")
+		return NewStubbedErrorWithNote(link, "This action is disallowed")
 	}
 	return nil
 }


### PR DESCRIPTION
When a user tries to do an admin action, the user tries to load the sigchain with `arg.needAdmin=true`.

If there are no stubbed links in the chain, the load succeeds and fails on an explicit check for the user to be an admin of the team.

Otherwise, the load fails when trying to load a stubbed link, since there's no `inner`. This PR makes the error message better.

RFC @zapu, @mlsteele, @patrickxb for a more appropriate message/different way of handling this scenario

```
# second case
~/kbgo/client (surya/CORE-5740/edit-member-stub) kbprod team edit-member keybase -u modalduality -r reader
▶ ERROR Need admin privilege for this action (stubbed link when not expected; at seqno 11)

# first case
~/kbgo/client (surya/CORE-5740/edit-member-stub) kbdev team edit-member alpha -u bob -r reader            
▶ ERROR user 81b637d8fcd2c6da6359e6963113a119%1 is not an admin of the team
```