### PR TITLE
try to make the KEX2 work even if the provisioner dies

### DIFF
--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keybase/client/go/kex2"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	jsonw "github.com/keybase/go-jsonw"
@@ -79,6 +80,18 @@ func (e *Kex2Provisionee) SubConsumers() []libkb.UIConsumer {
 	return nil
 }
 
+type kex2LogContext struct {
+	log logger.Logger
+}
+
+func (k kex2LogContext) Debug(format string, args ...interface{}) {
+	k.log.Debug(format, args...)
+}
+
+func newKex2LogContext(g *libkb.GlobalContext) kex2LogContext {
+	return kex2LogContext{g.Log}
+}
+
 // Run starts the engine.
 func (e *Kex2Provisionee) Run(ctx *Context) error {
 	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "Kex2Provisionee")
@@ -109,7 +122,7 @@ func (e *Kex2Provisionee) Run(ctx *Context) error {
 
 	karg := kex2.KexBaseArg{
 		Ctx:           nctx,
-		ProvisionCtx:  e.G(),
+		LogCtx:        newKex2LogContext(e.G()),
 		Mr:            libkb.NewKexRouter(e.G()),
 		DeviceID:      e.device.ID,
 		Secret:        e.secret,
@@ -214,8 +227,8 @@ func (e *Kex2Provisionee) HandleHello2(harg keybase1.Hello2Arg) (res keybase1.He
 }
 
 func (e *Kex2Provisionee) HandleDidCounterSign2(arg keybase1.DidCounterSign2Arg) (err error) {
-	e.G().Log.Debug("+ HandleDidCounterSign()")
-	defer func() { e.G().Log.Debug("- HandleDidCounterSign() -> %s", libkb.ErrToOk(err)) }()
+	e.G().Log.Debug("+ Kex2Provisionee#HandleDidCounterSign2()")
+	defer func() { e.G().Log.Debug("- Kex2Provisionee#HandleDidCounterSign2() -> %s", libkb.ErrToOk(err)) }()
 	var ppsBytes []byte
 	ppsBytes, _, err = e.dh.DecryptFromString(arg.PpsEncrypted)
 	if err != nil {
@@ -237,8 +250,8 @@ func (e *Kex2Provisionee) HandleDidCounterSign(sig []byte) (err error) {
 }
 
 func (e *Kex2Provisionee) handleDidCounterSign(sig []byte, perUserKeyBox *keybase1.PerUserKeyBox) (err error) {
-	e.G().Log.Debug("+ HandleDidCounterSign()")
-	defer func() { e.G().Log.Debug("- HandleDidCounterSign() -> %s", libkb.ErrToOk(err)) }()
+	e.G().Log.Debug("+ Kex2Provisionee#handleDidCounterSign()")
+	defer func() { e.G().Log.Debug("- Kex2Provisionee#handleDidCounterSign() -> %s", libkb.ErrToOk(err)) }()
 
 	// load self user (to load merkle root)
 	e.G().Log.Debug("| running for username %s", e.username)

--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -107,7 +107,7 @@ func (e *Kex2Provisioner) Run(ctx *Context) error {
 	// all set:  start provisioner
 	karg := kex2.KexBaseArg{
 		Ctx:           nctx,
-		ProvisionCtx:  e.G(),
+		LogCtx:        newKex2LogContext(e.G()),
 		Mr:            libkb.NewKexRouter(e.G()),
 		DeviceID:      deviceID,
 		Secret:        e.secret,

--- a/go/kex2/base.go
+++ b/go/kex2/base.go
@@ -8,14 +8,13 @@ import (
 	"net"
 	"time"
 
-	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"golang.org/x/net/context"
 )
 
-type ProvisionContext interface {
-	GetLog() logger.Logger
+type LogContext interface {
+	Debug(format string, args ...interface{})
 }
 
 type baseDevice struct {
@@ -29,7 +28,7 @@ type baseDevice struct {
 // KexBaseArg are arguments common to both Provisioner and Provisionee
 type KexBaseArg struct {
 	Ctx           context.Context
-	ProvisionCtx  ProvisionContext
+	LogCtx        LogContext
 	Mr            MessageRouter
 	Secret        Secret
 	DeviceID      keybase1.DeviceID // For now, this deviceID is different from the one in the transport

--- a/go/kex2/provisionee.go
+++ b/go/kex2/provisionee.go
@@ -4,6 +4,7 @@
 package kex2
 
 import (
+	"io"
 	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -13,8 +14,9 @@ import (
 
 type provisionee struct {
 	baseDevice
-	arg  ProvisioneeArg
-	done chan error
+	arg                ProvisioneeArg
+	done               chan error
+	startedCounterSign chan struct{}
 
 	server       *rpc.Server
 	serverDoneCh <-chan struct{}
@@ -42,8 +44,9 @@ func newProvisionee(arg ProvisioneeArg) *provisionee {
 		baseDevice: baseDevice{
 			start: make(chan struct{}),
 		},
-		arg:  arg,
-		done: make(chan error),
+		arg:                arg,
+		done:               make(chan error),
+		startedCounterSign: make(chan struct{}),
 	}
 	return ret
 }
@@ -82,6 +85,7 @@ func (p *provisionee) Hello2(_ context.Context, arg keybase1.Hello2Arg) (res key
 // It in turn delegates the work to the passed in Provisionee interface,
 // calling HandleDidCounterSign()
 func (p *provisionee) DidCounterSign(_ context.Context, sig []byte) (err error) {
+	p.startedCounterSign <- struct{}{}
 	err = p.arg.Provisionee.HandleDidCounterSign(sig)
 	p.done <- err
 	return err
@@ -91,6 +95,7 @@ func (p *provisionee) DidCounterSign(_ context.Context, sig []byte) (err error) 
 // It in turn delegates the work to the passed in Provisionee interface,
 // calling HandleDidCounterSign()
 func (p *provisionee) DidCounterSign2(_ context.Context, arg keybase1.DidCounterSign2Arg) (err error) {
+	p.startedCounterSign <- struct{}{}
 	err = p.arg.Provisionee.HandleDidCounterSign2(arg)
 	p.done <- err
 	return err
@@ -110,24 +115,40 @@ func (p *provisionee) run() (err error) {
 		return err
 	}
 
+	// If we hit a done or a server EOF before we started doing the
+	// countersign operation, then we have to bail out.
 	select {
 	case err := <-p.done:
 		return err
 	case <-p.serverDoneCh:
 		return p.server.Err()
+	case <-p.startedCounterSign:
 	}
+
+	// After we've started the counter sign operation, we don't care if the
+	// provisioner explodes. It makes sense to try to finish, however we can.
+	// Thus, we wait for EOF from the server in a Go routine.
+	go func() {
+		<-p.serverDoneCh
+		tmp := p.server.Err()
+		if tmp != nil && tmp != io.EOF {
+			p.debug("provisionee#run: RPC server died with an error: %s", tmp.Error())
+		}
+	}()
+
+	// Since we've already started the countersign operation, just wait around all
+	// day until it's done.
+	return <-p.done
 }
 
 func (p *provisionee) debug(fmtString string, args ...interface{}) {
-	if p.arg.ProvisionCtx != nil {
-		if log := p.arg.ProvisionCtx.GetLog(); log != nil {
-			log.Debug(fmtString, args...)
-		}
+	if p.arg.LogCtx != nil {
+		p.arg.LogCtx.Debug(fmtString, args...)
 	}
 }
 
 func (p *provisionee) startServer(s Secret) (err error) {
-	if p.conn, err = NewConn(p.arg.Ctx, p.arg.Mr, s, p.deviceID, p.arg.Timeout); err != nil {
+	if p.conn, err = NewConn(p.arg.Ctx, p.arg.LogCtx, p.arg.Mr, s, p.deviceID, p.arg.Timeout); err != nil {
 		return err
 	}
 	prots := []rpc.Protocol{

--- a/go/kex2/provisioner.go
+++ b/go/kex2/provisioner.go
@@ -52,10 +52,8 @@ func newProvisioner(arg ProvisionerArg) *provisioner {
 }
 
 func (p *provisioner) debug(fmtString string, args ...interface{}) {
-	if p.arg.ProvisionCtx != nil {
-		if log := p.arg.ProvisionCtx.GetLog(); log != nil {
-			log.Debug(fmtString, args...)
-		}
+	if p.arg.LogCtx != nil {
+		p.arg.LogCtx.Debug(fmtString, args...)
 	}
 }
 
@@ -120,7 +118,7 @@ func (p *provisioner) pickFirstConnection() (err error) {
 	// If not, we'll just have to wait for a message on p.arg.SecretChannel
 	// and use the provisionee's channel.
 	if len(p.arg.Secret) != 0 {
-		if conn, err = NewConn(p.arg.Ctx, p.arg.Mr, p.arg.Secret, p.deviceID, p.arg.Timeout); err != nil {
+		if conn, err = NewConn(p.arg.Ctx, p.arg.LogCtx, p.arg.Mr, p.arg.Secret, p.deviceID, p.arg.Timeout); err != nil {
 			return err
 		}
 		prot := keybase1.Kex2ProvisionerProtocol(p)
@@ -143,7 +141,7 @@ func (p *provisioner) pickFirstConnection() (err error) {
 		if len(sec) != SecretLen {
 			return ErrBadSecret
 		}
-		if p.conn, err = NewConn(p.arg.Ctx, p.arg.Mr, sec, p.deviceID, p.arg.Timeout); err != nil {
+		if p.conn, err = NewConn(p.arg.Ctx, p.arg.LogCtx, p.arg.Mr, sec, p.deviceID, p.arg.Timeout); err != nil {
 			return err
 		}
 		p.xp = rpc.NewTransport(p.conn, p.arg.Provisioner.GetLogFactory(), nil)

--- a/go/kex2/rpc_test.go
+++ b/go/kex2/rpc_test.go
@@ -161,6 +161,7 @@ func testProtocolXWithBehavior(t *testing.T, provisioneeBehavior int) (results [
 		err := RunProvisioner(ProvisionerArg{
 			KexBaseArg: KexBaseArg{
 				Ctx:           ctx,
+				LogCtx:        testLogCtx{t},
 				Mr:            router,
 				Secret:        genSecret(t),
 				DeviceID:      genKeybase1DeviceID(t),
@@ -177,6 +178,7 @@ func testProtocolXWithBehavior(t *testing.T, provisioneeBehavior int) (results [
 		err := RunProvisionee(ProvisioneeArg{
 			KexBaseArg: KexBaseArg{
 				Ctx:           context.Background(),
+				LogCtx:        testLogCtx{t},
 				Mr:            router,
 				Secret:        s2,
 				DeviceID:      genKeybase1DeviceID(t),
@@ -261,15 +263,6 @@ func TestFullProtocolXProvisioneeSlowHelloWithCancel(t *testing.T) {
 	}
 }
 
-func TestFullProtocolXProvisioneeSlowDidCounterSign(t *testing.T) {
-	results := testProtocolXWithBehavior(t, BadProvisioneeSlowDidCounterSign)
-	for i, e := range results {
-		if !eeq(e, ErrTimedOut) && !eeq(e, io.EOF) {
-			t.Fatalf("Bad error %d: %v", i, e)
-		}
-	}
-}
-
 func TestFullProtocolY(t *testing.T) {
 
 	timeout := time.Duration(60) * time.Second
@@ -286,6 +279,7 @@ func TestFullProtocolY(t *testing.T) {
 		err := RunProvisioner(ProvisionerArg{
 			KexBaseArg: KexBaseArg{
 				Ctx:           context.TODO(),
+				LogCtx:        testLogCtx{t},
 				Mr:            router,
 				Secret:        s1,
 				DeviceID:      genKeybase1DeviceID(t),
@@ -302,6 +296,7 @@ func TestFullProtocolY(t *testing.T) {
 		err := RunProvisionee(ProvisioneeArg{
 			KexBaseArg: KexBaseArg{
 				Ctx:           context.TODO(),
+				LogCtx:        testLogCtx{t},
 				Mr:            router,
 				Secret:        genSecret(t),
 				DeviceID:      genKeybase1DeviceID(t),

--- a/go/kex2/transport_test.go
+++ b/go/kex2/transport_test.go
@@ -211,8 +211,17 @@ func genDeviceID(t *testing.T) (ret DeviceID) {
 	return ret
 }
 
+type testLogCtx struct {
+	t *testing.T
+}
+
+func (t testLogCtx) Debug(format string, args ...interface{}) {
+	t.t.Logf(format, args...)
+}
+
 func genNewConn(t *testing.T, mr MessageRouter, s Secret, d DeviceID, rt time.Duration) net.Conn {
-	ret, err := NewConn(context.TODO(), mr, s, d, rt)
+	logCtx := testLogCtx{t}
+	ret, err := NewConn(context.TODO(), logCtx, mr, s, d, rt)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- We've seen some cases where a KEX2 provisioning was *So* close to working, but we think the provisioner died at the last second
- But there was no reason to kill it, since everything could have worked.
- So change the exit discipline of Kex2Provisionee
- Delete a test that now failed, since it relied on the old behavior
- Add some more debugging as to why we see EOFs in the logs