### PR TITLE
Fix for js reload being funky 

### DIFF
--- a/shared/engine/index.platform.native.js
+++ b/shared/engine/index.platform.native.js
@@ -4,6 +4,7 @@ import {TransportShared, sharedCreateClient, rpcLog} from './transport-shared'
 import {pack} from 'purepack'
 import {toByteArray, fromByteArray} from 'base64-js'
 import toBuffer from 'typedarray-to-buffer'
+import {printBridgeB64} from '../local-debug'
 
 import type {createClientType, incomingRPCCallbackType, connectDisconnectCB} from './index.platform'
 
@@ -18,7 +19,12 @@ class NativeTransport extends TransportShared {
       disconnectCallback,
       incomingRPCCallback,
       // We pass data over to the native side to be handled
-      data => nativeBridge.runWithData(data)
+      data => {
+        if (printBridgeB64) {
+          console.log(`PRINTBridge JS sending data ${data}`)
+        }
+        nativeBridge.runWithData(data)
+      }
     )
 
     // We're connected locally so we never get disconnected
@@ -68,6 +74,9 @@ function createClient(
 
   // This is how the RN side writes back to us
   RNEmitter.addListener(nativeBridge.eventName, payload => {
+    if (printBridgeB64) {
+      console.log(`PRINTBridge: JS got payload ${payload}`)
+    }
     return client.transport.packetize_data(toBuffer(toByteArray(payload)))
   })
 

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -33,6 +33,7 @@ let config: {[key: string]: any} = {
   overrideLoggedInTab: null,
   printOutstandingRPCs: false,
   printRPC: false,
+  printBridgeB64: false, // raw b64 going over the wire
   printRoutes: false,
   reactPerf: false,
   reduxSagaLogger: false,
@@ -89,6 +90,7 @@ if (PERF) {
     overrideLoggedInTab: null,
     printOutstandingRPCs: false,
     printRPC: false,
+    printBridgeB64: true,
     printRoutes: false,
     reactPerf: false,
     reduxSagaLogger: false,
@@ -116,6 +118,7 @@ export const {
   overrideLoggedInTab,
   printOutstandingRPCs,
   printRPC,
+  printBridgeB64,
   printRoutes,
   reactPerf,
   reduxDevToolsSelect,

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -90,7 +90,7 @@ if (PERF) {
     overrideLoggedInTab: null,
     printOutstandingRPCs: false,
     printRPC: false,
-    printBridgeB64: true,
+    printBridgeB64: false,
     printRoutes: false,
     reactPerf: false,
     reduxSagaLogger: false,


### PR DESCRIPTION
Spent a ton of time trying to debug what was happening. I still think there's some weird stuff going on but, after registering to be notified about reload and reseting the engine it seems to fix the problems i was seeing.

Before this fix
1. Type in a chat
1. We send a 'i am typing' notification to the daemon
1. We'd get a gregor oobm back
if you reload then you would get multiples of the gregor oobm messages back

After this fix you only get one response back correctly. But...
the daemon will spit out an error (maybe the root cause)
> PushHandler: BroadcastMessage: error handling oobm: unhandled system: chat.typing

I don't know if its worth diving into this further. At least not today

@keybase/react-hackers 
cc: @mmaxim 