### PR TITLE
use FindConversation for SendTextByName so we can do the right thing with topic names CORE-5733

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -386,7 +386,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 		debugger.Debug(ctx, "FindConversation: no conversations found in inbox, trying public chats")
 
 		// Check for offline and return an error
-		if !g.Syncer.IsConnected(ctx) {
+		if g.InboxSource.IsOffline() {
 			return res, rl, OfflineError{}
 		}
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -53,7 +53,7 @@ func newSendHelper(g *globals.Context, name string, topicName string,
 	membersType chat1.ConversationMembersType, ident keybase1.TLFIdentifyBehavior, ri chat1.RemoteInterface) *sendHelper {
 	return &sendHelper{
 		Contextified: globals.NewContextified(g),
-		DebugLabeler: utils.NewDebugLabeler(g, "sendHelper", false),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "sendHelper", false),
 		name:         name,
 		topicName:    topicName,
 		membersType:  membersType,

--- a/go/chat/helper_test.go
+++ b/go/chat/helper_test.go
@@ -101,6 +101,9 @@ func TestSendTextByName(t *testing.T) {
 		switch mt {
 		case chat1.ConversationMembersType_TEAM:
 			require.NoError(t, err)
+			inbox, _, err = tc.Context().InboxSource.Read(ctx, uid, nil, true, nil, nil)
+			require.NoError(t, err)
+			require.Equal(t, 2, len(inbox.Convs))
 		default:
 			// No second topic name on KBFS chats
 			require.Error(t, err)

--- a/go/chat/helper_test.go
+++ b/go/chat/helper_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,4 +62,48 @@ func TestRecentConversationParticipants(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, maxUsers-1, len(res))
 	require.Equal(t, refList, res)
+}
+
+func TestSendTextByName(t *testing.T) {
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctx, world, ri2, _, _, _ := setupTest(t, 1)
+		defer world.Cleanup()
+
+		u := world.GetUsers()[0]
+		tc := world.Tcs[u.Username]
+		uid := u.User.GetUID().ToBytes()
+		var name string
+		switch mt {
+		case chat1.ConversationMembersType_TEAM:
+			name = createTeam(tc.TestContext)
+		default:
+			name = u.Username
+		}
+
+		require.NoError(t, SendTextByName(ctx, tc.Context(), name, "",
+			mt, keybase1.TLFIdentifyBehavior_CHAT_CLI, "HI", ri2))
+		inbox, _, err := tc.Context().InboxSource.Read(ctx, uid, nil, true, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(inbox.Convs))
+		require.NoError(t, SendTextByName(ctx, tc.Context(), name, "",
+			mt, keybase1.TLFIdentifyBehavior_CHAT_CLI, "HI", ri2))
+		inbox, _, err = tc.Context().InboxSource.Read(ctx, uid, nil, true, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(inbox.Convs))
+		tv, _, err := tc.Context().ConvSource.Pull(ctx, inbox.Convs[0].GetConvID(), uid, &chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}, nil)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(tv.Messages))
+
+		err = SendTextByName(ctx, tc.Context(), name, "MIKE",
+			mt, keybase1.TLFIdentifyBehavior_CHAT_CLI, "HI", ri2)
+		switch mt {
+		case chat1.ConversationMembersType_TEAM:
+			require.NoError(t, err)
+		default:
+			// No second topic name on KBFS chats
+			require.Error(t, err)
+		}
+	})
 }

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -779,11 +779,6 @@ func (s *Deliverer) doNotRetryFailure(ctx context.Context, obr chat1.OutboxRecor
 		return chat1.OutboxErrorType_DUPLICATE, true
 	}
 
-	// Check for duplicate connection error
-	if err == ErrDuplicateConnection {
-		return chat1.OutboxErrorType_DUPECONN, false
-	}
-
 	// Check attempts otherwise
 	if obr.State.Sending() >= deliverMaxAttempts {
 		return chat1.OutboxErrorType_MISC, true
@@ -802,7 +797,7 @@ func (s *Deliverer) failMessage(ctx context.Context, obr chat1.OutboxRecord,
 	}
 
 	switch oserr.Typ {
-	case chat1.OutboxErrorType_DUPLICATE, chat1.OutboxErrorType_DUPECONN:
+	case chat1.OutboxErrorType_DUPLICATE:
 		// Only send notification to frontend if it is not a duplicate, we just want these to go away
 	default:
 		obr.State = chat1.NewOutboxStateWithError(oserr)

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -779,6 +779,11 @@ func (s *Deliverer) doNotRetryFailure(ctx context.Context, obr chat1.OutboxRecor
 		return chat1.OutboxErrorType_DUPLICATE, true
 	}
 
+	// Check for duplicate connection error
+	if err == ErrDuplicateConnection {
+		return chat1.OutboxErrorType_DUPECONN, false
+	}
+
 	// Check attempts otherwise
 	if obr.State.Sending() >= deliverMaxAttempts {
 		return chat1.OutboxErrorType_MISC, true
@@ -797,7 +802,7 @@ func (s *Deliverer) failMessage(ctx context.Context, obr chat1.OutboxRecord,
 	}
 
 	switch oserr.Typ {
-	case chat1.OutboxErrorType_DUPLICATE:
+	case chat1.OutboxErrorType_DUPLICATE, chat1.OutboxErrorType_DUPECONN:
 		// Only send notification to frontend if it is not a duplicate, we just want these to go away
 	default:
 		obr.State = chat1.NewOutboxStateWithError(oserr)

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -112,7 +112,7 @@ func (h *TeamsHandler) sendTeamChatWelcomeMessage(ctx context.Context, team, use
 	body := fmt.Sprintf("Hello @channel! I've just added @%s to this team. Current team membership: \n\n%s\n\nKeybase teams are in very early alpha, and more info is available here: https://keybase.io/docs/command_line/teams_alpha.",
 		user, memberBody)
 	gregorCli := h.gregor.GetClient()
-	if err = chat.SendTextByName(ctx, h.G(), team, chat1.ConversationMembersType_TEAM,
+	if err = chat.SendTextByName(ctx, h.G(), team, chat.DefaultTeamTopic, chat1.ConversationMembersType_TEAM,
 		keybase1.TLFIdentifyBehavior_CHAT_CLI, body, gregorCli); err != nil {
 		return false
 	}


### PR DESCRIPTION
Patch does the following:

1.) Factor out the code for `FindConversations` from `FindConversationsLocal` and into helpers.go so we can use it outside of the RPC call.
2.) Change `SendTextByName` to use `FindConversations` so that it does the right thing with respect to topic names. It also simplifies the code.
3.) Change around `setupTest` so that it can work with Gregor and team tests.