### PR TITLE
Fix error message when team doesn't exist

### DIFF
--- a/go/teams/delete_test.go
+++ b/go/teams/delete_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeleteRoot(t *testing.T) {
@@ -20,16 +21,8 @@ func TestDeleteRoot(t *testing.T) {
 	}
 
 	_, err := GetForTeamManagementByStringName(context.Background(), tc.G, teamname, false)
-	if err == nil {
-		t.Fatal("no error getting deleted team")
-	}
-	aerr, ok := err.(libkb.AppStatusError)
-	if !ok {
-		t.Fatalf("error type: %T (%s), expected libkb.AppStatusError", err, err)
-	}
-	if aerr.Code != int(keybase1.StatusCode_SCTeamNotFound) {
-		t.Errorf("error status code: %d, expected %d", aerr.Code, keybase1.StatusCode_SCTeamNotFound)
-	}
+	require.Error(t, err, "no error getting deleted team")
+	require.IsType(t, TeamDoesNotExistError{}, err)
 }
 
 func TestDeleteSubteamAdmin(t *testing.T) {

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -3,6 +3,8 @@ package teams
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -167,20 +169,38 @@ func NewResolveError(name keybase1.TeamName, id keybase1.TeamID) ResolveError {
 	return ResolveError{name, id}
 }
 
-func fixupTeamGetError(e error, n string) error {
+type TeamDoesNotExistError struct {
+	descriptor string
+}
+
+func (e TeamDoesNotExistError) Error() string {
+	return fmt.Sprintf("Team %q does not exist", e.descriptor)
+}
+
+func NewTeamDoesNotExistError(descriptor string) error {
+	return TeamDoesNotExistError{descriptor}
+}
+
+func fixupTeamGetError(ctx context.Context, g *libkb.GlobalContext, e error, n string) error {
 	if e == nil {
 		return nil
 	}
-	ase, ok := e.(libkb.AppStatusError)
-	if !ok {
-		return e
+	switch e := e.(type) {
+	case libkb.AppStatusError:
+		switch keybase1.StatusCode(e.Code) {
+		case keybase1.StatusCode_SCTeamReadError:
+			e.Desc = fmt.Sprintf("You are not a member of team %q; try `keybase team request-access %s` for access", n, n)
+		case keybase1.StatusCode_SCTeamNotFound:
+			return NewTeamDoesNotExistError(n)
+		default:
+		}
+	case TeamDoesNotExistError:
+		// Replace the not found error so that it has a name instead of team ID.
+		// If subteams are involved the name might not correspond to the ID
+		// but it's better to have this undertandable error message that's accurate
+		// most of the time than one with an ID that's always accurate.
+		g.Log.CDebugf(ctx, "replacing error: %v", e)
+		return NewTeamDoesNotExistError(n)
 	}
-	switch keybase1.StatusCode(ase.Code) {
-	case keybase1.StatusCode_SCTeamReadError:
-		ase.Desc = fmt.Sprintf("You are not a member of team %q; try `keybase team request-access %s` for access", n, n)
-	case keybase1.StatusCode_SCTeamNotFound:
-		ase.Desc = fmt.Sprintf("Team %q does not exist", n)
-	default:
-	}
-	return ase
+	return e
 }

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -45,7 +45,7 @@ func GetForTeamManagementByStringName(ctx context.Context, g *libkb.GlobalContex
 		ForceRepoll: true,
 		NeedAdmin:   needAdmin,
 	})
-	return team, fixupTeamGetError(err, name)
+	return team, fixupTeamGetError(ctx, g, err, name)
 }
 
 // Get a team with no stubbed links if we are an admin. Use this instead of NeedAdmin when you don't

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -185,7 +185,8 @@ func (l *LoaderContextG) MerkleLookup(ctx context.Context, teamID keybase1.TeamI
 		return r1, r2, fmt.Errorf("merkle returned wrong leaf: %v != %v", leaf.TeamID.String(), teamID.String())
 	}
 	if leaf.Private == nil {
-		return r1, r2, fmt.Errorf("merkle returned nil leaf")
+		l.G().Log.CDebugf(ctx, "TeamLoader hidden error: merkle returned nil leaf")
+		return r1, r2, NewTeamDoesNotExistError(teamID.String())
 	}
 	return leaf.Private.Seqno, leaf.Private.LinkID.Export(), nil
 }


### PR DESCRIPTION
@zapu good catch, and thanks for the bisect which made it easy to figure out! This brings those errors back to how to they were before.

The behavior changed because that commit introduced this forgotten error check, so the not found error occurred higher up.
https://github.com/keybase/client/commit/3d20ae30c0f5c710898368a9f9ca40e5ca7b40c5#diff-4f4e4469548562dee434def94bc09a41R249