### PR TITLE
Run the updater command in `keybase update check`

### DIFF
--- a/go/client/cmd_update.go
+++ b/go/client/cmd_update.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/install"
@@ -44,7 +45,11 @@ func newCmdUpdateCheck(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.C
 				g.Log.Errorf("Error finding updater path: %s", err)
 				return
 			}
-			g.Log.Errorf("\nTo update, you can run:\n\n\t%s check", updaterPath)
+
+			cmd := exec.Command(updaterPath, "check")
+			if err := cmd.Run(); err != nil {
+				g.Log.Errorf("Error running %q: %s", updaterPath, err)
+			}
 		},
 	}
 }


### PR DESCRIPTION
Always bugged me that `keybase update check` didn't just run the update command instead of telling the user the command to run.