### PR TITLE
Attempt to fix "message stuck in pending state" bugs

### DIFF
--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -49,6 +49,16 @@ function messageOutboxIDSelector(
     .find(m => m.outboxID === outboxID)
 }
 
+function pendingMessageOutboxIDSelector(
+  state: TypedState,
+  conversationIDKey: Constants.ConversationIDKey,
+  outboxID: Constants.OutboxIDKey
+) {
+  return conversationStateSelector(state, conversationIDKey)
+    .get('messages')
+    .find(m => m.outboxID === outboxID && m.state === 'pending')
+}
+
 function devicenameSelector(state: TypedState) {
   return state.config && state.config.deviceName
 }
@@ -188,6 +198,7 @@ export {
   messageOutboxIDSelector,
   messageSelector,
   metaDataSelector,
+  pendingMessageOutboxIDSelector,
   routeSelector,
   selectedInboxSelector,
   startNewConversation,


### PR DESCRIPTION
@keybase/react-hackers CC @mmaxim 

I'm still testing this PR, putting it up for discussion.

In the olden days, pending messages worked like this:

* we send a message

* when it succeeds or fails, we get an incoming new chat activity message that tells us what happens

* we update the pending message in our store to match the new state

Now, though, something else can happen:

* we send a message

* we're offline for a bit

* we come back online

* the service tells us that our understanding of the thread is stale and we should get newer messages

* we do so

* the new thread includes the sent version of our previously pending message

In this version, we still have our pending message in our store, because nothing updated it when the new message came in.

This PR performs that update by deleting a pending message if we receive a message thread containing a message that matches its outboxID, and then pushing the new sent message in its place.

I had to switch away from using a map() over newMessages because you can't yield() inside a map().