### PR TITLE
Prompt for device name before starting kex

### DIFF
--- a/go/client/provision_ui.go
+++ b/go/client/provision_ui.go
@@ -241,7 +241,7 @@ func (p ProvisionUI) DisplayAndPromptSecret(ctx context.Context, arg keybase1.Di
 		// this is the provisionee device (device Y)
 		// For command line app, the provisionee displays secrets only
 
-		p.parent.Output("Type this verification code into your other device:\n\n")
+		p.parent.Output("\n\nType this verification code into your other device:\n\n")
 		p.parent.Output("\t" + arg.Phrase + "\n\n")
 		p.parent.Output("If you are using the command line client on your other device, run this command:\n\n")
 		p.parent.Output("\tkeybase device add\n\n")
@@ -269,9 +269,9 @@ func (p ProvisionUI) DisplayAndPromptSecret(ctx context.Context, arg keybase1.Di
 }
 
 func (p ProvisionUI) PromptNewDeviceName(ctx context.Context, arg keybase1.PromptNewDeviceNameArg) (string, error) {
-	p.parent.Output("\n\n\n")
+	p.parent.Output("\n\n")
 	p.parent.Printf(ColorString("magenta", "************************************************************\n"))
-	p.parent.Printf(ColorString("magenta", "* Final step: name your new device!                        *\n"))
+	p.parent.Printf(ColorString("magenta", "* Name your new device!                                    *\n"))
 	p.parent.Printf(ColorString("magenta", "************************************************************\n"))
 	p.parent.Output("\n\n\n")
 
@@ -302,15 +302,6 @@ func (p ProvisionUI) PromptNewDeviceName(ctx context.Context, arg keybase1.Promp
 
 func (p ProvisionUI) DisplaySecretExchanged(ctx context.Context, sessionID int) error {
 	p.parent.Printf("\n\n" + CHECK + " " + ColorString("bold", "Verification code received") + ".\n\n")
-	p.parent.Printf(ColorString("magenta", "************************************************************\n"))
-	p.parent.Printf(ColorString("magenta", "* On your new device, choose and save a public name for it *\n"))
-	p.parent.Printf(ColorString("magenta", "************************************************************\n"))
-	p.parent.Output("\n\nAfter you enter a device name on your new device, this command will finish\n")
-	p.parent.Output("provisioning your new device and you'll be all set.\n")
-	p.parent.Output("\n\nNote: if you do not see a prompt on your new device for a device name\n")
-	p.parent.Output("in a few seconds then the verification code entered above does not match the\n")
-	p.parent.Output("verification code provided on your new device. If that happens, quit\n")
-	p.parent.Output("this (ctrl-c) and try again.\n")
 	return nil
 }
 

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -414,6 +414,14 @@ func (e *Kex2Provisionee) Device() *libkb.Device {
 
 func (e *Kex2Provisionee) addDeviceSibkey(jw *jsonw.Wrapper) error {
 	if e.device.Description == nil {
+		// should not get in here with change to login_provision.go
+		// deviceWithType that is prompting for device name before
+		// starting this engine, but leaving the code here just
+		// as a safety measure.
+
+		e.G().Log.Debug("kex2 provisionee: device name (e.device.Description) is nil. It should be set by caller.")
+		e.G().Log.Debug("kex2 provisionee: proceeding to prompt user for device name, but figure out how this happened...")
+
 		// need user to get existing device names
 		loadArg := libkb.NewLoadUserByNameArg(e.G(), e.username)
 		loadArg.LoginContext = e.ctx.LoginContext
@@ -426,7 +434,7 @@ func (e *Kex2Provisionee) addDeviceSibkey(jw *jsonw.Wrapper) error {
 			e.G().Log.Debug("proceeding despite error getting existing device names: %s", err)
 		}
 
-		e.G().Log.Debug("prompting for device name")
+		e.G().Log.Debug("kex2 provisionee: prompting for device name")
 		arg := keybase1.PromptNewDeviceNameArg{
 			ExistingDevices: existingDevices,
 		}
@@ -435,7 +443,7 @@ func (e *Kex2Provisionee) addDeviceSibkey(jw *jsonw.Wrapper) error {
 			return err
 		}
 		e.device.Description = &name
-		e.G().Log.Debug("got device name: %q", name)
+		e.G().Log.Debug("kex2 provisionee: got device name: %q", name)
 	}
 
 	s := libkb.DeviceStatusActive

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -164,6 +164,16 @@ func (e *loginProvision) deviceWithType(ctx *Context, provisionerType keybase1.D
 		Type: e.arg.DeviceType,
 	}
 
+	// prompt for the device name here so there's no delay during kex:
+	e.G().Log.Debug("deviceWithType: prompting for device name")
+	name, err := e.deviceName(ctx)
+	if err != nil {
+		e.G().Log.Debug("deviceWithType: error getting device name from user: %s", err)
+		return err
+	}
+	device.Description = &name
+	e.G().Log.Debug("deviceWithType: got device name: %q", name)
+
 	// make a new secret:
 	secret, err := libkb.NewKex2Secret(e.arg.DeviceType == libkb.DeviceTypeMobile)
 	if err != nil {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -1658,10 +1658,6 @@ func TestProvisionDupDevice(t *testing.T) {
 
 	// provisioner needs to be logged in
 	userX := CreateAndSignupFakeUser(tcX, "login")
-	var secretX kex2.Secret
-	if _, err := rand.Read(secretX[:]); err != nil {
-		t.Fatal(err)
-	}
 
 	secretCh := make(chan kex2.Secret)
 
@@ -1677,38 +1673,17 @@ func TestProvisionDupDevice(t *testing.T) {
 	}
 	eng := NewLogin(tcY.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 
-	var wg sync.WaitGroup
-
 	// start provisionee
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := RunEngine(eng, ctx); err == nil {
-			t.Errorf("login ran without error")
-			return
-		}
-	}()
+	if err := RunEngine(eng, ctx); err == nil {
+		t.Errorf("login ran without error")
+		return
+	}
 
-	// start provisioner
-	provisioner := NewKex2Provisioner(tcX.G, secretX, nil)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	// Note: there is no need to start the provisioner as the provisionee will
+	// fail because of the duplicate device name before the provisioner
+	// is needed.
 
-		ctx := &Context{
-			SecretUI:    userX.NewSecretUI(),
-			ProvisionUI: newTestProvisionUI(),
-		}
-		if err := RunEngine(provisioner, ctx); err == nil {
-			t.Errorf("provisioner ran without error")
-			return
-		}
-	}()
-	secretFromY := <-secretCh
-	provisioner.AddSecret(secretFromY)
-
-	wg.Wait()
-
+	// double-check that provisioning failed
 	if err := AssertProvisioned(tcY); err == nil {
 		t.Fatal("device provisioned using existing name")
 	}


### PR DESCRIPTION
In the existing kex2 device provisioning, the user does:

1. new device: login
2. new device: choose an existing device
3. new device: told a secret to input into existing device 
4. existing device: device add
5. existing device: enter secret
6. new device: handle hello, **enter a new device name**
7. existing device: countersign
8. new device: post sigs

A problem that has been showing up in the logs is that in step 6, the user takes a while to enter a device name and the existing device either times out, or they stop the app.  So when 6 is finally complete, there is no device to countersign.

In this flow, kex starts on the new device at step 3.  It starts on the existing device at step 4.  There is a delay at step 6 while the user enters a device name.

In the CLI UX we added all these magenta banners to try to alert the user about this flow and keep them interacting on the correct device and not shutting down the existing device.

But, I think a better flow is:

1. new device: login
2. new device: choose an existing device
3. **new device: enter a new device name**
4. new device: told a secret to input into existing device 
5. existing device: device add
6. existing device: enter secret
7. new device: handle hello
8. existing device: countersign
9. new device: post sigs

Kex starts running on the new device at step 4 in the new flow.  It starts running on the existing device after step 6.  After step 6, there is no user interaction needed, so the whole exchange should be very quick with less chance of failure.

An added benefit of this change is that the prompt for the device name at step 3 in the new flow now retries 10 times with helpful prompts on what is wrong with the name.  The current flow this replaces has no such check and relies on the server to reject bad/existing names.

cc: @chrisnojima @malgorithms 