### PR TITLE
generate join messages for all paths, fix inbox removals, and display join/leave message CORE-5788

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -433,3 +433,128 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 	}
 	return res, rl, nil
 }
+
+// Post a join or leave message. Must be called when the user is in the conv.
+// Uses a blocking sender.
+func postJoinLeave(ctx context.Context, g *globals.Context, ri func() chat1.RemoteInterface, uid gregor1.UID,
+	convID chat1.ConversationID, body chat1.MessageBody) (rl []chat1.RateLimit, err error) {
+	typ, err := body.MessageType()
+	if err != nil {
+		return nil, fmt.Errorf("message type for postJoinLeave: %v", err)
+	}
+	switch typ {
+	case chat1.MessageType_JOIN, chat1.MessageType_LEAVE:
+	// good
+	default:
+		return nil, fmt.Errorf("invalid message type for postJoinLeave: %v", typ)
+	}
+
+	// Get the conversation from the inbox.
+	query := chat1.GetInboxLocalQuery{
+		ConvIDs: []chat1.ConversationID{convID},
+	}
+	ib, irl, err := g.InboxSource.Read(ctx, uid, nil, true, &query, nil)
+	if len(ib.Convs) != 1 {
+		return rl, fmt.Errorf("post join/leave: found %d conversations", len(ib.Convs))
+	}
+	if irl != nil {
+		rl = append(rl, *irl)
+	}
+	conv := ib.Convs[0]
+
+	plaintext := chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:         conv.Info.Triple,
+			TlfName:      conv.Info.TlfName,
+			TlfPublic:    conv.Info.Visibility == chat1.TLFVisibility_PUBLIC,
+			MessageType:  typ,
+			Supersedes:   chat1.MessageID(0),
+			Deletes:      nil,
+			Prev:         nil, // Filled by Sender
+			Sender:       nil, // Filled by Sender
+			SenderDevice: nil, // Filled by Sender
+			MerkleRoot:   nil, // Filled by Boxer
+			OutboxID:     nil,
+			OutboxInfo:   nil,
+		},
+		MessageBody: body,
+	}
+
+	// Send with a blocking sender
+	sender := NewBlockingSender(g, NewBoxer(g), nil, ri)
+	_, _, irl, err = sender.Send(ctx, convID, plaintext, 0, nil)
+	if irl != nil {
+		rl = append(rl, *irl)
+	}
+	return rl, err
+}
+
+func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
+	ri func() chat1.RemoteInterface, uid gregor1.UID, convID chat1.ConversationID) (rl []chat1.RateLimit, err error) {
+	alreadyIn, irl, err := g.InboxSource.IsMember(ctx, uid, convID)
+	if err != nil {
+		debugger.Debug(ctx, "JoinConversation: IsMember err: %s", err.Error())
+		// Assume we're not in.
+		alreadyIn = false
+	}
+	if irl != nil {
+		rl = append(rl, *irl)
+	}
+
+	// Send the join command even if we're in.
+	joinRes, err := ri().JoinConversation(ctx, convID)
+	if err != nil {
+		debugger.Debug(ctx, "JoinConversation: failed to join conversation: %s", err.Error())
+		return rl, err
+	}
+	if joinRes.RateLimit != nil {
+		rl = append(rl, *joinRes.RateLimit)
+	}
+
+	if !alreadyIn {
+		// Send a message to the channel after joining.
+		joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
+		irl, err := postJoinLeave(ctx, g, ri, uid, convID, joinMessageBody)
+		if err != nil {
+			debugger.Debug(ctx, "JoinConversation: posting join-conv message failed: %v", err)
+			// ignore the error
+		}
+		rl = append(rl, irl...)
+	}
+	return rl, nil
+}
+
+func LeaveConversation(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
+	ri func() chat1.RemoteInterface, uid gregor1.UID, convID chat1.ConversationID) (rl []chat1.RateLimit, err error) {
+	alreadyIn, irl, err := g.InboxSource.IsMember(ctx, uid, convID)
+	if err != nil {
+		debugger.Debug(ctx, "LeaveConversation: IsMember err: %s", err.Error())
+		// Pretend we're in.
+		alreadyIn = true
+	}
+	if irl != nil {
+		rl = append(rl, *irl)
+	}
+
+	// Send a message to the channel before leaving
+	if alreadyIn {
+		leaveMessageBody := chat1.NewMessageBodyWithLeave(chat1.MessageLeave{})
+		irl, err := postJoinLeave(ctx, g, ri, uid, convID, leaveMessageBody)
+		if err != nil {
+			debugger.Debug(ctx, "LeaveConversation: posting leave-conv message failed: %v", err)
+			// ignore the error
+		}
+		rl = append(rl, irl...)
+	}
+
+	leaveRes, err := ri().LeaveConversation(ctx, convID)
+	if err != nil {
+		debugger.Debug(ctx, "LeaveConversation: failed to leave conversation: %s", err.Error())
+		return rl, err
+	}
+	if leaveRes.RateLimit != nil {
+		rl = append(rl, *leaveRes.RateLimit)
+	}
+
+	return rl, nil
+}

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -510,6 +510,14 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 	if joinRes.RateLimit != nil {
 		rl = append(rl, *joinRes.RateLimit)
 	}
+	if _, err = g.InboxSource.MembershipUpdate(ctx, uid, 0, []chat1.ConversationMember{
+		chat1.ConversationMember{
+			Uid:    uid,
+			ConvID: convID,
+		},
+	}, nil); err != nil {
+		debugger.Debug(ctx, "JoinConversation: failed to apply membership update: %s", err.Error())
+	}
 
 	if !alreadyIn {
 		// Send a message to the channel after joining.

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -194,14 +194,17 @@ func filterConvLocals(convLocals []chat1.ConversationLocal, rquery *chat1.GetInb
 type baseInboxSource struct {
 	globals.Contextified
 	utils.DebugLabeler
+	types.InboxSource
 
 	getChatInterface func() chat1.RemoteInterface
 	offline          bool
 }
 
-func newBaseInboxSource(g *globals.Context, getChatInterface func() chat1.RemoteInterface) *baseInboxSource {
+func newBaseInboxSource(g *globals.Context, ibs types.InboxSource,
+	getChatInterface func() chat1.RemoteInterface) *baseInboxSource {
 	return &baseInboxSource{
 		Contextified:     globals.NewContextified(g),
+		InboxSource:      ibs,
 		DebugLabeler:     utils.NewDebugLabeler(g.GetLog(), "baseInboxSource", false),
 		getChatInterface: getChatInterface,
 	}
@@ -273,6 +276,25 @@ func (b *baseInboxSource) GetInboxQueryLocalToRemote(ctx context.Context,
 	return rquery, info, nil
 }
 
+func (s *baseInboxSource) IsMember(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (bool, *chat1.RateLimit, error) {
+	ib, rl, err := s.ReadUnverified(ctx, uid, true, &chat1.GetInboxQuery{
+		ConvID: &convID,
+	}, nil)
+	if err != nil {
+		return false, rl, err
+	}
+	if len(ib.ConvsUnverified) == 0 {
+		return false, rl, fmt.Errorf("conversation not found: %s", convID)
+	}
+	conv := ib.ConvsUnverified[0]
+	switch conv.ReaderInfo.Status {
+	case chat1.ConversationMemberStatus_ACTIVE:
+		return true, rl, nil
+	default:
+		return false, rl, nil
+	}
+}
+
 func GetInboxQueryNameInfo(ctx context.Context, g *globals.Context,
 	lquery *chat1.GetInboxLocalQuery) (types.NameInfo, error) {
 	if lquery.Name == nil || len(lquery.Name.Name) == 0 {
@@ -291,11 +313,12 @@ type RemoteInboxSource struct {
 var _ types.InboxSource = (*RemoteInboxSource)(nil)
 
 func NewRemoteInboxSource(g *globals.Context, ri func() chat1.RemoteInterface) *RemoteInboxSource {
-	return &RemoteInboxSource{
-		Contextified:    globals.NewContextified(g),
-		DebugLabeler:    utils.NewDebugLabeler(g.GetLog(), "RemoteInboxSource", false),
-		baseInboxSource: newBaseInboxSource(g, ri),
+	s := &RemoteInboxSource{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "RemoteInboxSource", false),
 	}
+	s.baseInboxSource = newBaseInboxSource(g, s, ri)
+	return s
 }
 
 func (s *RemoteInboxSource) Read(ctx context.Context, uid gregor1.UID,
@@ -406,11 +429,12 @@ var _ types.InboxSource = (*HybridInboxSource)(nil)
 
 func NewHybridInboxSource(g *globals.Context,
 	getChatInterface func() chat1.RemoteInterface) *HybridInboxSource {
-	return &HybridInboxSource{
-		Contextified:    globals.NewContextified(g),
-		DebugLabeler:    utils.NewDebugLabeler(g.GetLog(), "HybridInboxSource", false),
-		baseInboxSource: newBaseInboxSource(g, getChatInterface),
+	s := &HybridInboxSource{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "HybridInboxSource", false),
 	}
+	s.baseInboxSource = newBaseInboxSource(g, s, getChatInterface)
+	return s
 }
 
 func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, query *chat1.GetInboxQuery,

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -418,7 +418,6 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				g.Debug(ctx, "chat activity: error decoding newMessage: %s", err.Error())
 				return
 			}
-
 			g.Debug(ctx, "chat activity: newMessage: convID: %s sender: %s",
 				nm.ConvID, nm.Message.ClientHeader.Sender)
 			if nm.Message.ClientHeader.OutboxID != nil {
@@ -426,11 +425,6 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 					hex.EncodeToString(*nm.Message.ClientHeader.OutboxID))
 			} else {
 				g.Debug(ctx, "chat activity: newMessage: outboxID is empty")
-			}
-			if nm.Message.ClientHeader.Sender.Eq(uid) &&
-				nm.Message.GetMessageType() == chat1.MessageType_LEAVE {
-				g.Debug(ctx, "chat activity: ignoring our own leave message")
-				return
 			}
 
 			// Update typing status to stopped

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -427,6 +427,11 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			} else {
 				g.Debug(ctx, "chat activity: newMessage: outboxID is empty")
 			}
+			if nm.Message.ClientHeader.Sender.Eq(uid) &&
+				nm.Message.GetMessageType() == chat1.MessageType_LEAVE {
+				g.Debug(ctx, "chat activity: ignoring our own leave message")
+				return
+			}
 
 			// Update typing status to stopped
 			g.typingMonitor.Update(ctx, chat1.TyperInfo{

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -595,25 +595,8 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 			return chat1.NewConversationLocalRes{}, errors.New(res.Conv.Error.Message)
 		}
 
-		// Send a message to the channel after joining.
-		switch arg.MembersType {
-		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
-			joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
-			rl, err = h.postJoinLeave(ctx, uid.ToBytes(), convID, joinMessageBody)
-			if err != nil {
-				h.Debug(ctx, "posting join-conv message failed: %v", err)
-				// ignore the error
-			}
-			if err == nil && rl != nil {
-				res.RateLimits = append(res.RateLimits, *rl)
-			}
-		default:
-			// pass
-		}
-
 		res.RateLimits = utils.AggRateLimits(res.RateLimits)
 		res.IdentifyFailures = identBreaks
-
 		return res, nil
 	}
 
@@ -2048,113 +2031,7 @@ func (h *Server) UpdateTyping(ctx context.Context, arg chat1.UpdateTypingArg) (e
 	return nil
 }
 
-// Check whether the active user is in a conv.
-func (h *Server) checkInConv(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (in bool, err error) {
-	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("checkInConv(%v)", convID))()
-
-	conv, _, err := GetUnverifiedConv(ctx, h.G(), uid, convID, true)
-	if err != nil {
-		return false, err
-	}
-	switch conv.ReaderInfo.Status {
-	case chat1.ConversationMemberStatus_ACTIVE:
-		return true, nil
-	default:
-		// including PREVIEW
-		return false, nil
-	}
-}
-
-// Post a join or leave message. Must be called when the user is in the conv.
-// Uses a blocking sender.
-func (h *Server) postJoinLeave(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, body chat1.MessageBody) (rl *chat1.RateLimit, err error) {
-	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("postJoinLeave(%v)", convID))()
-
-	typ, err := body.MessageType()
-	if err != nil {
-		return nil, fmt.Errorf("message type for postJoinLeave: %v", err)
-	}
-	switch typ {
-	case chat1.MessageType_JOIN, chat1.MessageType_LEAVE:
-	// good
-	default:
-		return nil, fmt.Errorf("invalid message type for postJoinLeave: %v", typ)
-	}
-
-	// Get the conversation from the inbox.
-	query := chat1.GetInboxLocalQuery{
-		ConvIDs: []chat1.ConversationID{convID},
-	}
-	ib, _, err := h.G().InboxSource.Read(ctx, uid, nil, true, &query, nil)
-	if len(ib.Convs) != 1 {
-		return rl, fmt.Errorf("post join/leave: found %d conversations", len(ib.Convs))
-	}
-	conv := ib.Convs[0]
-
-	plaintext := chat1.MessagePlaintext{
-		ClientHeader: chat1.MessageClientHeader{
-			Conv:         conv.Info.Triple,
-			TlfName:      conv.Info.TlfName,
-			TlfPublic:    conv.Info.Visibility == chat1.TLFVisibility_PUBLIC,
-			MessageType:  typ,
-			Supersedes:   chat1.MessageID(0),
-			Deletes:      nil,
-			Prev:         nil, // Filled by Sender
-			Sender:       nil, // Filled by Sender
-			SenderDevice: nil, // Filled by Sender
-			MerkleRoot:   nil, // Filled by Boxer
-			OutboxID:     nil,
-			OutboxInfo:   nil,
-		},
-		MessageBody: body,
-	}
-
-	// Send with a blocking sender
-	sender := NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient)
-	h.Debug(ctx, "postJoinLeave sending")
-	_, _, rl, err = sender.Send(ctx, convID, plaintext, 0, nil)
-	return rl, err
-}
-
-func (h *Server) doJoinConversation(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (res chat1.JoinLeaveConversationLocalRes, err error) {
-	alreadyIn, err := h.checkInConv(ctx, uid, convID)
-	if err != nil {
-		h.Debug(ctx, "doJoinConversation checkInConv err: %v", err)
-		// Assume we're not in.
-		alreadyIn = false
-	}
-
-	// Send the join command even if we're in.
-	joinRes, err := h.remoteClient().JoinConversation(ctx, convID)
-	if err != nil {
-		h.Debug(ctx, "doJoinConversation: failed to join conversation: %s", err.Error())
-		return res, err
-	}
-	if joinRes.RateLimit != nil {
-		res.RateLimits = append(res.RateLimits, *joinRes.RateLimit)
-	}
-
-	if !alreadyIn {
-		// Send a message to the channel after joining.
-		joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
-		rl, err := h.postJoinLeave(ctx, uid, convID, joinMessageBody)
-		if err != nil {
-			h.Debug(ctx, "posting join-conv message failed: %v", err)
-			// ignore the error
-		}
-		if err == nil && rl != nil {
-			res.RateLimits = append(res.RateLimits, *rl)
-		}
-	}
-
-	res.RateLimits = utils.AggRateLimits(res.RateLimits)
-	res.Offline = h.G().Syncer.IsConnected(ctx)
-
-	return res, nil
-}
-
 func (h *Server) JoinConversationByIDLocal(ctx context.Context, convID chat1.ConversationID) (res chat1.JoinLeaveConversationLocalRes, err error) {
-
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
 		&identBreaks, h.identNotifier)
@@ -2166,7 +2043,13 @@ func (h *Server) JoinConversationByIDLocal(ctx context.Context, convID chat1.Con
 		return res, err
 	}
 
-	return h.doJoinConversation(ctx, uid, convID)
+	rl, err := JoinConversation(ctx, h.G(), h.DebugLabeler, h.remoteClient, uid, convID)
+	if err != nil {
+		return res, err
+	}
+	res.RateLimits = utils.AggRateLimits(rl)
+	res.Offline = h.G().Syncer.IsConnected(ctx)
+	return res, nil
 }
 
 func (h *Server) JoinConversationLocal(ctx context.Context, arg chat1.JoinConversationLocalArg) (res chat1.JoinLeaveConversationLocalRes, err error) {
@@ -2225,7 +2108,13 @@ func (h *Server) JoinConversationLocal(ctx context.Context, arg chat1.JoinConver
 		return res, fmt.Errorf("no topic name %s exists on specified team", arg.TopicName)
 	}
 
-	return h.doJoinConversation(ctx, uid, convID)
+	rl, err := JoinConversation(ctx, h.G(), h.DebugLabeler, h.remoteClient, uid, convID)
+	if err != nil {
+		return res, err
+	}
+	res.RateLimits = utils.AggRateLimits(rl)
+	res.Offline = h.G().Syncer.IsConnected(ctx)
+	return res, nil
 }
 
 func (h *Server) LeaveConversationLocal(ctx context.Context, convID chat1.ConversationID) (res chat1.JoinLeaveConversationLocalRes, err error) {
@@ -2239,36 +2128,12 @@ func (h *Server) LeaveConversationLocal(ctx context.Context, convID chat1.Conver
 		return res, err
 	}
 
-	alreadyIn, err := h.checkInConv(ctx, uid, convID)
+	rl, err := LeaveConversation(ctx, h.G(), h.DebugLabeler, h.remoteClient, uid, convID)
 	if err != nil {
-		h.Debug(ctx, "doJoinConversation checkInConv err: %v", err)
-		// Pretend we're in.
-		alreadyIn = true
-	}
-
-	// Send a message to the channel before leaving
-	if alreadyIn {
-		leaveMessageBody := chat1.NewMessageBodyWithLeave(chat1.MessageLeave{})
-		rl, err := h.postJoinLeave(ctx, uid, convID, leaveMessageBody)
-		if err != nil {
-			h.Debug(ctx, "posting leave-conv message failed: %v", err)
-			// ignore the error
-		}
-		if err == nil && rl != nil {
-			res.RateLimits = append(res.RateLimits, *rl)
-		}
-	}
-
-	leaveRes, err := h.remoteClient().LeaveConversation(ctx, convID)
-	if err != nil {
-		h.Debug(ctx, "LeaveConversationLocal: failed to leave conversation: %s", err.Error())
 		return res, err
 	}
-	if leaveRes.RateLimit != nil {
-		res.RateLimits = append(res.RateLimits, *leaveRes.RateLimit)
-	}
 
-	res.RateLimits = utils.AggRateLimits(res.RateLimits)
+	res.RateLimits = utils.AggRateLimits(rl)
 	res.Offline = h.G().Syncer.IsConnected(ctx)
 	return res, nil
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1987,6 +1987,15 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			return
 		}
 
+		consumeNewMsg := func(listener *serverChatListener, typ chat1.MessageType) {
+			select {
+			case msg := <-listener.newMessage:
+				require.Equal(t, typ, msg.Message.GetMessageType())
+			case <-time.After(20 * time.Second):
+				require.Fail(t, "failed to get new message notification")
+			}
+		}
+
 		ctx := ctc.as(t, users[0]).startCtx
 		ctx1 := ctc.as(t, users[1]).startCtx
 
@@ -2004,11 +2013,11 @@ func TestChatSrvTeamChannels(t *testing.T) {
 
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
 			mt, ctc.as(t, users[1]).user(), ctc.as(t, users[2]).user())
-		_, err := postLocalForTest(t, ctc, users[1], conv, chat1.NewMessageBodyWithText(chat1.MessageText{
-			Body: "FAIL",
-		}))
-		require.NoError(t, err)
+		consumeNewMsg(listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(listener1, chat1.MessageType_JOIN)
+		t.Logf("first conv: %s", conv.Id)
 
+		t.Logf("create a conversation, and join user 1 into by sending a message")
 		topicName := "zjoinonsend"
 		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
 			chat1.NewConversationLocalArg{
@@ -2019,14 +2028,26 @@ func TestChatSrvTeamChannels(t *testing.T) {
 				MembersType:   chat1.ConversationMembersType_TEAM,
 			})
 		require.NoError(t, err)
+		consumeNewMsg(listener0, chat1.MessageType_JOIN)
 		_, err = postLocalForTest(t, ctc, users[1], ncres.Conv.Info, chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: fmt.Sprintf("JOINME"),
 		}))
-		require.NoError(t, err)
-
-		headline := "The headline is foobar!"
-		_, err = postLocalForTest(t, ctc, users[1], ncres.Conv.Info, chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: headline}))
-		require.NoError(t, err)
+		consumeAllMsgJoins := func(listener *serverChatListener) {
+			msgMap := make(map[chat1.MessageType]bool)
+			for i := 0; i < 2; i++ {
+				select {
+				case msg := <-listener.newMessage:
+					t.Logf("recvd: %v convID: %s", msg.Message.GetMessageType(), msg.ConvID)
+					msgMap[msg.Message.GetMessageType()] = true
+				case <-time.After(20 * time.Second):
+					require.Fail(t, "missing incoming")
+				}
+			}
+			require.True(t, msgMap[chat1.MessageType_TEXT])
+			require.True(t, msgMap[chat1.MessageType_JOIN])
+		}
+		consumeAllMsgJoins(listener0)
+		consumeAllMsgJoins(listener1)
 		select {
 		case conv := <-listener1.joinedConv:
 			require.Equal(t, conv.GetConvID(), ncres.Conv.GetConvID())
@@ -2043,6 +2064,14 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			require.Fail(t, "failed to get members update")
 		}
 
+		t.Logf("send headline on first convo")
+		headline := "The headline is foobar!"
+		_, err = postLocalForTest(t, ctc, users[1], ncres.Conv.Info, chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: headline}))
+		require.NoError(t, err)
+		consumeNewMsg(listener0, chat1.MessageType_HEADLINE)
+		consumeNewMsg(listener1, chat1.MessageType_HEADLINE)
+
+		t.Logf("create a new channel, and check GetTLFConversation result")
 		topicName = "miketime"
 		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
 			chat1.NewConversationLocalArg{
@@ -2053,7 +2082,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 				MembersType:   chat1.ConversationMembersType_TEAM,
 			})
 		require.NoError(t, err)
-
+		consumeNewMsg(listener0, chat1.MessageType_JOIN)
 		getTLFRes, err := ctc.as(t, users[1]).chatLocalHandler().GetTLFConversationsLocal(ctx1,
 			chat1.GetTLFConversationsLocalArg{
 				TlfName:              conv.TlfName,
@@ -2065,24 +2094,18 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		require.Equal(t, 3, len(getTLFRes.Convs))
 		require.Equal(t, DefaultTeamTopic, utils.GetTopicName(getTLFRes.Convs[0]))
 		require.Equal(t, topicName, utils.GetTopicName(getTLFRes.Convs[1]))
-
 		aux := getTLFRes.Convs[2].AuxiliaryInfo
 		require.True(t, aux != nil)
 		require.Equal(t, aux.ReaderCount, 2)
 		require.Equal(t, aux.ConversationCreator, gregor1.UID(users[0].User.GetUID().ToBytes()))
 		require.Equal(t, *aux.HeadlineModifier, gregor1.UID(users[1].User.GetUID().ToBytes()))
-
 		tvres, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
 			ConversationID: getTLFRes.Convs[2].GetConvID(),
 		})
-		if err != nil {
-			t.Fatalf("GetThreadLocal error: %v", err)
-		}
-		tv := tvres.Thread
-		if tv.Messages[0].Valid().MessageBody.Headline().Headline != headline {
-			t.Fatalf("unexpected response from GetThreadLocal . expected '%s' got %#+v\n", headline, tv.Messages[0])
-		}
+		require.NoError(t, err)
+		require.Equal(t, headline, tvres.Thread.Messages[0].Valid().MessageBody.Headline().Headline)
 
+		t.Logf("join user 1 into new convo manually")
 		_, err = ctc.as(t, users[1]).chatLocalHandler().JoinConversationLocal(ctx1, chat1.JoinConversationLocalArg{
 			TlfName:    conv.TlfName,
 			TopicType:  chat1.TopicType_CHAT,
@@ -2090,7 +2113,8 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			TopicName:  topicName,
 		})
 		require.NoError(t, err)
-
+		consumeNewMsg(listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(listener1, chat1.MessageType_JOIN)
 		select {
 		case conv := <-listener1.joinedConv:
 			require.Equal(t, conv.GetConvID(), getTLFRes.Convs[1].GetConvID())
@@ -2112,11 +2136,14 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			Body: fmt.Sprintf("FAIL: @%s", users[2].Username),
 		}))
 		require.NoError(t, err)
+		consumeNewMsg(listener0, chat1.MessageType_TEXT)
+		consumeNewMsg(listener1, chat1.MessageType_TEXT)
 
 		_, err = ctc.as(t, users[1]).chatLocalHandler().LeaveConversationLocal(ctx1,
 			ncres.Conv.GetConvID())
 		require.NoError(t, err)
-
+		consumeNewMsg(listener0, chat1.MessageType_LEAVE)
+		consumeNewMsg(listener1, chat1.MessageType_LEAVE)
 		select {
 		case convID := <-listener1.leftConv:
 			require.Equal(t, convID, getTLFRes.Convs[1].GetConvID())
@@ -2136,6 +2163,23 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			Body: "FAIL",
 		}))
 		require.NoError(t, err)
+		consumeAllMsgJoins(listener0)
+		consumeAllMsgJoins(listener2)
+		select {
+		case conv := <-listener2.joinedConv:
+			require.Equal(t, conv.GetConvID(), getTLFRes.Convs[1].GetConvID())
+			require.Equal(t, topicName, utils.GetTopicName(conv))
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "failed to get joined notification")
+		}
+		select {
+		case act := <-listener0.membersUpdate:
+			require.Equal(t, act.ConvID, getTLFRes.Convs[1].GetConvID())
+			require.True(t, act.Joined)
+			require.Equal(t, users[2].Username, act.Member)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "failed to get members update")
+		}
 
 		switch mt {
 		case chat1.ConversationMembersType_KBFS:
@@ -2151,22 +2195,6 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			require.Len(t, tvres.Thread.Messages, 1, "expected number of LEAVE messages")
 		default:
 			t.Fatalf("unknown members type: %v", mt)
-		}
-
-		select {
-		case conv := <-listener2.joinedConv:
-			require.Equal(t, conv.GetConvID(), getTLFRes.Convs[1].GetConvID())
-			require.Equal(t, topicName, utils.GetTopicName(conv))
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "failed to get joined notification")
-		}
-		select {
-		case act := <-listener0.membersUpdate:
-			require.Equal(t, act.ConvID, getTLFRes.Convs[1].GetConvID())
-			require.True(t, act.Joined)
-			require.Equal(t, users[2].Username, act.Member)
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "failed to get members update")
 		}
 	})
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2015,6 +2015,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			mt, ctc.as(t, users[1]).user(), ctc.as(t, users[2]).user())
 		consumeNewMsg(listener0, chat1.MessageType_JOIN)
 		consumeNewMsg(listener1, chat1.MessageType_JOIN)
+		consumeNewMsg(listener2, chat1.MessageType_JOIN)
 		t.Logf("first conv: %s", conv.Id)
 
 		t.Logf("create a conversation, and join user 1 into by sending a message")
@@ -2138,12 +2139,14 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		require.NoError(t, err)
 		consumeNewMsg(listener0, chat1.MessageType_TEXT)
 		consumeNewMsg(listener1, chat1.MessageType_TEXT)
+		consumeNewMsg(listener2, chat1.MessageType_TEXT)
 
 		_, err = ctc.as(t, users[1]).chatLocalHandler().LeaveConversationLocal(ctx1,
 			ncres.Conv.GetConvID())
 		require.NoError(t, err)
 		consumeNewMsg(listener0, chat1.MessageType_LEAVE)
 		consumeNewMsg(listener1, chat1.MessageType_LEAVE)
+		consumeNewMsg(listener2, chat1.MessageType_LEAVE)
 		select {
 		case convID := <-listener1.leftConv:
 			require.Equal(t, convID, getTLFRes.Convs[1].GetConvID())
@@ -2180,6 +2183,17 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "failed to get members update")
 		}
+
+		_, err = ctc.as(t, users[1]).chatLocalHandler().JoinConversationLocal(ctx1, chat1.JoinConversationLocalArg{
+			TlfName:    conv.TlfName,
+			TopicType:  chat1.TopicType_CHAT,
+			Visibility: chat1.TLFVisibility_PRIVATE,
+			TopicName:  topicName,
+		})
+		require.NoError(t, err)
+		consumeNewMsg(listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(listener1, chat1.MessageType_JOIN)
+		consumeNewMsg(listener2, chat1.MessageType_JOIN)
 
 		switch mt {
 		case chat1.ConversationMembersType_KBFS:

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -1019,6 +1019,7 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers,
 	convs := i.mergeConvs(ibox.Conversations, userJoined)
 	removedMap := make(map[string]bool)
 	for _, r := range userRemoved {
+		i.Debug(ctx, "MembershipUpdate: removing user from: %s", r)
 		removedMap[r.String()] = true
 	}
 	ibox.Conversations = nil

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -760,10 +760,11 @@ func TestMembershipUpdate(t *testing.T) {
 	require.Equal(t, chat1.InboxVers(2), vers)
 	for _, c := range res {
 		if c.GetConvID().Eq(convs[5].GetConvID()) {
-			require.Fail(t, "removed conv returned")
+			require.Equal(t, chat1.ConversationMemberStatus_LEFT, c.ReaderInfo.Status)
+			convs[5].ReaderInfo.Status = chat1.ConversationMemberStatus_LEFT
 		}
 	}
-	expected := append(convs[:5], append(convs[6:], joinedConvs...)...)
+	expected := append(convs, joinedConvs...)
 	sort.Sort(utils.ConvByConvID(expected))
 	sort.Sort(utils.ConvByConvID(res))
 	require.Equal(t, len(expected), len(res))

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -76,6 +76,7 @@ type InboxSource interface {
 		query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (chat1.Inbox, *chat1.RateLimit, error)
 	ReadUnverified(ctx context.Context, uid gregor1.UID, useLocalData bool,
 		query *chat1.GetInboxQuery, p *chat1.Pagination) (chat1.Inbox, *chat1.RateLimit, error)
+	IsMember(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (bool, *chat1.RateLimit, error)
 
 	NewConversation(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		conv chat1.Conversation) error

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -606,7 +606,6 @@ function _unboxedToMessage(
             editedCount: 0,
             message,
             messageState: 'sent', // TODO, distinguish sent/pending once CORE sends it.
-            outboxID: null,
             key: Constants.messageKey(common.conversationIDKey, 'messageIDText', common.messageID),
           }
         }
@@ -618,7 +617,6 @@ function _unboxedToMessage(
             editedCount: 0,
             message,
             messageState: 'sent', // TODO, distinguish sent/pending once CORE sends it.
-            outboxID: null,
             key: Constants.messageKey(common.conversationIDKey, 'messageIDText', common.messageID),
           }
         }

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -598,6 +598,30 @@ function _unboxedToMessage(
             type: 'Edit',
           }
         }
+        case ChatTypes.CommonMessageType.join: {
+          const message = new HiddenString('_*has joined the channel*_')
+          return {
+            type: 'Text',
+            ...common,
+            editedCount: 0,
+            message,
+            messageState: 'sent', // TODO, distinguish sent/pending once CORE sends it.
+            outboxID: null,
+            key: Constants.messageKey(common.conversationIDKey, 'messageIDText', common.messageID),
+          }
+        }
+        case ChatTypes.CommonMessageType.leave: {
+          const message = new HiddenString('_*has left the channel*_')
+          return {
+            type: 'Text',
+            ...common,
+            editedCount: 0,
+            message,
+            messageState: 'sent', // TODO, distinguish sent/pending once CORE sends it.
+            outboxID: null,
+            key: Constants.messageKey(common.conversationIDKey, 'messageIDText', common.messageID),
+          }
+        }
         default:
           const unhandled: Constants.UnhandledMessage = {
             ...common,


### PR DESCRIPTION
Patch does the following:

1.) Moves join/leave code into helper.go so we can access it easier. Invoke that code when auto joining a conversation by sending a message.
2.) Change how we store left conversations in local inbox to keep the record, just just set reader status to `LEFT` and filter them out in `applyQuery`.
3.) Render join/leave messages in thread view in GUI.
4.) Use correct userid when doing auto join code in `BlockingSender.Send`.