### PR TITLE
get inbox version inside of this lock, so we don't race to get on waiter list and get stuck

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -117,25 +117,16 @@ func (g *gregorMessageOrderer) cleanupAfterTimeoutLocked(uid gregor1.UID, vers c
 func (g *gregorMessageOrderer) WaitForTurn(ctx context.Context, uid gregor1.UID,
 	newVers chat1.InboxVers) (res chan struct{}) {
 	res = make(chan struct{})
-	// Grab latest inbox version if we can
-	vers, err := g.latestInboxVersion(ctx, uid)
-	if err != nil {
-		g.Debug(ctx, "WaitForTurn: failed to get current inbox version: %s", err.Error())
-		close(res)
-		return res
-	}
-
-	// Check for an in-order update
-	if newVers <= vers+1 {
-		close(res)
-		return
-	}
-
 	// Out of order update, we are going to wait a fixed amount of time for the correctly
 	// ordered update
 	deadline := g.clock.Now().Add(time.Second)
 	go func() {
 		g.Lock()
+		vers, err := g.latestInboxVersion(ctx, uid)
+		if err != nil {
+			g.Debug(ctx, "WaitForTurn: failed to get current inbox version: %s", err.Error())
+			vers = newVers - 1
+		}
 		waiters := g.addToWaitersLocked(ctx, uid, vers, newVers)
 		g.Unlock()
 		g.Debug(ctx, "WaitForTurn: out of order update received, waiting on %d updates: vers: %d newVers: %d", len(waiters), vers, newVers)


### PR DESCRIPTION
This is a little tricky here, so let me know if you want to chat about it. This code is the client trying to re-order any out of order Gregor updates with respect to the inbox version. It was possible that when we fetched the latest inbox version, it could change before we added ourselves into the waiter queue for any messages with inbox versions between the current one and the one just received. 