### PR TITLE
add a 'no thanks' button for push. write to local storage if they said no

### DIFF
--- a/shared/actions/platform-specific.desktop.js
+++ b/shared/actions/platform-specific.desktop.js
@@ -23,6 +23,10 @@ function configurePush() {
   throw new Error('Configure Push not needed on this platform')
 }
 
+function setNoPushPermissions(): Promise<*> {
+  throw new Error('Push permissions unsupported on this platform')
+}
+
 function showMainWindow(): AsyncAction {
   return () => {
     ipcRenderer && ipcRenderer.send('showMain')
@@ -39,5 +43,6 @@ export {
   configurePush,
   saveAttachmentDialog,
   showShareActionSheet,
+  setNoPushPermissions,
   displayNewMessageNotification,
 }

--- a/shared/actions/platform-specific.js.flow
+++ b/shared/actions/platform-specific.js.flow
@@ -1,6 +1,7 @@
 // @flow
 import type {AsyncAction} from '../constants/types/flux'
 
+declare function setNoPushPermissions(): Promise<*>
 declare function requestPushPermissions(): Promise<*>
 declare function configurePush(): void
 declare function showMainWindow(): AsyncAction
@@ -19,5 +20,6 @@ export {
   configurePush,
   saveAttachmentDialog,
   showShareActionSheet,
+  setNoPushPermissions,
   displayNewMessageNotification,
 }

--- a/shared/actions/platform-specific.native.js
+++ b/shared/actions/platform-specific.native.js
@@ -16,6 +16,14 @@ function requestPushPermissions(): Promise<*> {
   return PushNotifications.requestPermissions()
 }
 
+function setNoPushPermissions(): Promise<*> {
+  return new Promise((resolve, reject) => {
+    AsyncStorage.setItem('allowPush', 'false', e => {
+      resolve()
+    })
+  })
+}
+
 function showMainWindow() {
   return () => {
     // nothing
@@ -127,31 +135,35 @@ function configurePush() {
 
     console.log('Check push permissions')
     if (isIOS) {
-      PushNotifications.checkPermissions(permissions => {
-        console.log('Push checked permissions:', permissions)
-        if (!permissions.alert) {
-          // TODO(gabriel): Detect if we already showed permissions prompt and were denied,
-          // in which case we should not show prompt or show different prompt about enabling
-          // in Settings (for iOS)
-          emitter(
-            ({
-              payload: true,
-              type: 'push:permissionsPrompt',
-              logTransformer: action => ({
-                payload: action.payload,
-                type: action.type,
-              }),
-            }: PushConstants.PushPermissionsPrompt)
-          )
-        } else {
-          // We have permissions, this triggers a token registration in
-          // case it changed.
-          emitter(
-            ({
-              payload: undefined,
-              type: 'push:permissionsRequest',
-            }: PushConstants.PushPermissionsRequest)
-          )
+      AsyncStorage.getItem('allowPush', (error, result) => {
+        if (error || result !== 'false') {
+          PushNotifications.checkPermissions(permissions => {
+            console.log('Push checked permissions:', permissions)
+            if (!permissions.alert) {
+              // TODO(gabriel): Detect if we already showed permissions prompt and were denied,
+              // in which case we should not show prompt or show different prompt about enabling
+              // in Settings (for iOS)
+              emitter(
+                ({
+                  payload: true,
+                  type: 'push:permissionsPrompt',
+                  logTransformer: action => ({
+                    payload: action.payload,
+                    type: action.type,
+                  }),
+                }: PushConstants.PushPermissionsPrompt)
+              )
+            } else {
+              // We have permissions, this triggers a token registration in
+              // case it changed.
+              emitter(
+                ({
+                  payload: undefined,
+                  type: 'push:permissionsRequest',
+                }: PushConstants.PushPermissionsRequest)
+              )
+            }
+          })
         }
       })
     }
@@ -231,5 +243,6 @@ export {
   showMainWindow,
   configurePush,
   saveAttachmentDialog,
+  setNoPushPermissions,
   showShareActionSheet,
 }

--- a/shared/actions/push/creators.js
+++ b/shared/actions/push/creators.js
@@ -9,6 +9,10 @@ function permissionsRequest(): Constants.PushPermissionsRequest {
   return {type: Constants.permissionsRequest, payload: undefined}
 }
 
+function permissionsNo(): Constants.PushPermissionsNo {
+  return {type: Constants.permissionsNo, payload: undefined}
+}
+
 function permissionsRequesting(enabled: boolean): Constants.PushPermissionsRequesting {
   return {type: Constants.permissionsRequesting, payload: enabled}
 }
@@ -35,6 +39,7 @@ function updatePushToken(token: string, tokenType: Constants.TokenType): Constan
 
 export {
   configurePush,
+  permissionsNo,
   permissionsRequest,
   permissionsRequesting,
   permissionsPrompt,

--- a/shared/actions/push/index.js
+++ b/shared/actions/push/index.js
@@ -14,11 +14,22 @@ import type {SagaGenerator} from '../../constants/types/saga'
 import type {TypedState} from '../../constants/reducer'
 
 import {showUserProfile} from '../profile'
-import {requestPushPermissions, configurePush, displayNewMessageNotification} from '../platform-specific'
+import {
+  requestPushPermissions,
+  configurePush,
+  displayNewMessageNotification,
+  setNoPushPermissions,
+} from '../platform-specific'
 
 const pushSelector = ({push: {token, tokenType}}: TypedState) => ({token, tokenType})
 
 const deviceIDSelector = ({config: {deviceID}}: TypedState) => deviceID
+
+function* permissionsNoSaga(): SagaGenerator<any, any> {
+  yield call(setNoPushPermissions)
+  yield put({type: Constants.permissionsRequesting, payload: false})
+  yield put({type: Constants.permissionsPrompt, payload: false})
+}
 
 function* permissionsRequestSaga(): SagaGenerator<any, any> {
   try {
@@ -157,6 +168,7 @@ export function* deletePushTokenSaga(): SagaGenerator<any, any> {
 
 function* pushSaga(): SagaGenerator<any, any> {
   yield safeTakeLatest(Constants.permissionsRequest, permissionsRequestSaga)
+  yield safeTakeLatest(Constants.permissionsNo, permissionsNoSaga)
   yield safeTakeLatest(Constants.pushToken, pushTokenSaga)
   yield safeTakeLatest(Constants.savePushToken, savePushTokenSaga)
   yield safeTakeLatest(Constants.configurePush, configurePushSaga)

--- a/shared/app/push/push.native.js
+++ b/shared/app/push/push.native.js
@@ -3,13 +3,14 @@ import React from 'react'
 import {connect} from 'react-redux'
 import {Box, Button, Text, NativeScrollView, NativeImage} from '../../common-adapters/index.native'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
-import {permissionsRequest} from '../../actions/push/creators'
+import {permissionsRequest, permissionsNo} from '../../actions/push/creators'
 
 import type {TypedState} from '../../constants/reducer'
 
 type Props = {
   permissionsRequesting: boolean,
   onRequestPermissions: () => void,
+  onNoPermissions: () => void,
 }
 
 const Push = (props: Props) => (
@@ -20,9 +21,10 @@ const Push = (props: Props) => (
         alignItems: 'center',
         backgroundColor: globalColors.white,
         justifyContent: 'center',
+        width: '100%',
       }}
     >
-      <Box style={{margin: globalMargins.small}}>
+      <Box style={{padding: globalMargins.small, width: '100%'}}>
         <Text
           type="Header"
           style={{
@@ -60,10 +62,17 @@ const Push = (props: Props) => (
         <Button
           type="Primary"
           fullWidth={true}
-          style={{marginBottom: 0}}
-          onClick={() => props.onRequestPermissions()}
+          style={{marginBottom: 10}}
+          onClick={props.onRequestPermissions}
           label="Got it"
           waiting={props.permissionsRequesting}
+        />
+        <Button
+          type="Secondary"
+          fullWidth={true}
+          style={{marginBottom: 10}}
+          onClick={props.onNoPermissions}
+          label="No thanks"
         />
       </Box>
     </Box>
@@ -79,9 +88,8 @@ export default connect(
   },
   (dispatch: any) => {
     return {
-      onRequestPermissions: () => {
-        dispatch(permissionsRequest())
-      },
+      onRequestPermissions: () => dispatch(permissionsRequest()),
+      onNoPermissions: () => dispatch(permissionsNo()),
     }
   }
 )(Push)

--- a/shared/constants/push.js
+++ b/shared/constants/push.js
@@ -34,6 +34,9 @@ export const androidSenderID = '9603251415'
 export const configurePush = 'push:configurePush'
 export type ConfigurePush = NoErrorTypedAction<'push:configurePush', void>
 
+export const permissionsNo = 'push:permissionsNo'
+export type PushPermissionsNo = NoErrorTypedAction<'push:permissionsNo', void>
+
 export const permissionsRequest = 'push:permissionsRequest'
 export type PushPermissionsRequest = NoErrorTypedAction<'push:permissionsRequest', void>
 


### PR DESCRIPTION
@keybase/react-hackers this should hopefully fix the app store rejection

- [x] Fix layout of the push screen
- [x] Add a 'No thank' button
- [x] If you click no thanks we write to local storage that we don't want push

This means if you say no, you can no longer go back and change your mind (by going to the system settings). Longer term we could add a settings screen to wipe this setting so you can actually turn it back on (ticketed)