### PR TITLE
Remove badges on folders when you click into them

### DIFF
--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -15,7 +15,6 @@ import {
   NotifyFSRequestFSSyncStatusRequestRpcPromise,
 } from '../constants/types/flow-types'
 import {badgeApp} from './notifications'
-import {navigateUp} from '../actions/route-tree'
 import {call, put, select} from 'redux-saga/effects'
 import {safeTakeLatest, safeTakeEvery} from '../util/saga'
 import {isMobile} from '../constants/platform'
@@ -220,10 +219,8 @@ function* _addSaga(action: FavoriteAdd): SagaGenerator<any, any> {
       const action: FavoriteAdded = {type: Constants.favoriteAdded, payload: undefined}
       yield put(action)
       yield put(favoriteList())
-      yield put(navigateUp())
     } catch (error) {
       console.warn('Err in favorite.favoriteAdd', error)
-      yield put(navigateUp())
     }
   }
 }
@@ -243,10 +240,8 @@ function* _ignoreSaga(action: FavoriteAdd): SagaGenerator<any, any> {
       const action: FavoriteIgnored = {type: Constants.favoriteIgnored, payload: undefined}
       yield put(action)
       yield put(favoriteList())
-      yield put(navigateUp())
     } catch (error) {
       console.warn('Err in favorite.favoriteIgnore', error)
-      yield put(navigateUp())
     }
   }
 }

--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -55,7 +55,7 @@ class Files extends Component<void, Props, State> {
   }
 
   componentDidMount() {
-    if (this.props.folder && !this.props.folder.ignored) {
+    if (this.props.folder && !this.props.folder.ignored && this.props.folder.meta === 'new') {
       this.props.favoriteFolder(this.props.path)
     }
   }

--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -54,6 +54,12 @@ class Files extends Component<void, Props, State> {
     this._checkFolderExistence(nextProps)
   }
 
+  componentDidMount() {
+    if (this.props.folder && !this.props.folder.ignored) {
+      this.props.favoriteFolder(this.props.path)
+    }
+  }
+
   render() {
     const {folder, username} = this.props
     if (!folder) return null // Protect from state where the folder to be displayed was removed

--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -66,9 +66,11 @@ class Files extends Component<void, Props, State> {
     }
     const ignoreCurrentFolder = () => {
       this.props.ignoreFolder(this.props.path)
+      this.props.navigateUp()
     }
     const unIgnoreCurrentFolder = () => {
       this.props.favoriteFolder(this.props.path)
+      this.props.navigateUp()
     }
     const allowIgnore = folder.users.some(f => !f.you)
 


### PR DESCRIPTION
@keybase/react-hackers 

1) Adding or deleting a KBFS favorite was causing a navigateUp() in those sagas.  I moved the navigation outside of the sagas so that we can use them here without navigating.

2) We want to remove the "new" badge on a KBFS folder when you click on it in Folders, but!  Turns out that the way to remove the "new" badge is to add the folder as a favorite, *and* our concept of "Unignore folder" is a mapping onto adding it as a favorite -- that's how you unignore a folder.

So if we added a favorite every time we clicked on a folder, we'd keep unignoring that folder every time we clicked.  So we have to check that it's unignored, and that's it's "new" (to avoid unnecessary server round trips while you're clicking around) before favoriting it.