### PR TITLE
Require a flag to revoke the last device in an account

### DIFF
--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -113,7 +113,7 @@ func getActiveDevicesAndKeys(tc *kbtest.ChatTestContext, u *kbtest.FakeUser) ([]
 }
 
 func doRevokeDevice(tc *kbtest.ChatTestContext, u *kbtest.FakeUser, id keybase1.DeviceID, force bool) error {
-	revokeEngine := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{ID: id, Force: force}, tc.G)
+	revokeEngine := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{ID: id, ForceSelf: force}, tc.G)
 	ctx := &engine.Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: u.NewSecretUI(),

--- a/go/client/cmd_device_remove.go
+++ b/go/client/cmd_device_remove.go
@@ -6,6 +6,7 @@ package client
 import (
 	"errors"
 	"fmt"
+
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
@@ -17,6 +18,7 @@ import (
 type CmdDeviceRemove struct {
 	idOrName string
 	force    bool
+	last     bool
 	libkb.Contextified
 }
 
@@ -30,6 +32,7 @@ func (c *CmdDeviceRemove) ParseArgv(ctx *cli.Context) error {
 	}
 	c.idOrName = ctx.Args()[0]
 	c.force = ctx.Bool("force")
+	c.last = ctx.Bool("last")
 	return nil
 }
 
@@ -103,8 +106,9 @@ func (c *CmdDeviceRemove) Run() (err error) {
 	}
 
 	return cli.RevokeDevice(context.TODO(), keybase1.RevokeDeviceArg{
-		Force:    c.force,
-		DeviceID: id,
+		Force:     c.force,
+		ForceLast: c.last,
+		DeviceID:  id,
 	})
 }
 
@@ -134,7 +138,11 @@ func NewCmdDeviceRemove(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  "f, force",
-				Usage: "Override warning about removing the current device.",
+				Usage: "Force removal of the current device.",
+			},
+			cli.BoolFlag{
+				Name:  "last",
+				Usage: "Force removal of the last device in your account.",
 			},
 		},
 		Action: func(c *cli.Context) {

--- a/go/client/cmd_device_remove.go
+++ b/go/client/cmd_device_remove.go
@@ -159,11 +159,11 @@ func NewCmdDeviceRemove(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 		Usage:        "Remove a device",
 		Flags: []cli.Flag{
 			cli.BoolFlag{
-				Name:  "f, force",
+				Name:  "force",
 				Usage: "Force removal of the current device.",
 			},
 			cli.BoolFlag{
-				Name:  "last",
+				Name:  "force-last",
 				Usage: "Force removal of the last device in your account.",
 			},
 		},

--- a/go/engine/deprovision.go
+++ b/go/engine/deprovision.go
@@ -73,8 +73,8 @@ func (e *DeprovisionEngine) attemptLoggedInRevoke(ctx *Context) error {
 	} else {
 		// Do the revoke. We expect this to succeed.
 		revokeArg := RevokeDeviceEngineArgs{
-			ID:    e.G().Env.GetDeviceIDForUsername(nun),
-			Force: true,
+			ID:        e.G().Env.GetDeviceIDForUsername(nun),
+			ForceSelf: true,
 		}
 		revokeEng := NewRevokeDeviceEngine(revokeArg, e.G())
 		err = revokeEng.Run(ctx)

--- a/go/engine/deprovision.go
+++ b/go/engine/deprovision.go
@@ -75,6 +75,7 @@ func (e *DeprovisionEngine) attemptLoggedInRevoke(ctx *Context) error {
 		revokeArg := RevokeDeviceEngineArgs{
 			ID:        e.G().Env.GetDeviceIDForUsername(nun),
 			ForceSelf: true,
+			ForceLast: true,
 		}
 		revokeEng := NewRevokeDeviceEngine(revokeArg, e.G())
 		err = revokeEng.Run(ctx)

--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -361,7 +361,7 @@ func assertCurrentDeviceRevoked(tc libkb.TestContext) {
 
 	// Revoke the current device! This will cause an error when deprovision
 	// tries to revoke the device again, but deprovision should carry on.
-	err = doRevokeDevice(tc, fu, tc.G.Env.GetDeviceID(), true /* force */)
+	err = doRevokeDevice(tc, fu, tc.G.Env.GetDeviceID(), true /* force */, false /* forceLast */)
 	if err != nil {
 		tc.T.Fatal(err)
 	}

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2808,8 +2808,8 @@ func testProvisionEnsureNoPaperKey(t *testing.T, upgradePerUserKey bool) {
 			SecretUI: &libkb.TestSecretUI{},
 		}
 		eng := NewRevokeDeviceEngine(RevokeDeviceEngineArgs{
-			ID:    originalPaperKey,
-			Force: false,
+			ID:        originalPaperKey,
+			ForceSelf: false,
 		}, tcX.G)
 		err := RunEngine(eng, ctx)
 		require.NoError(t, err, "revoke original paper key")
@@ -3005,8 +3005,8 @@ func TestProvisionAndRevoke(t *testing.T) {
 			SecretUI: &libkb.TestSecretUI{},
 		}
 		eng := NewRevokeDeviceEngine(RevokeDeviceEngineArgs{
-			ID:    tcX.G.ActiveDevice.DeviceID(),
-			Force: false,
+			ID:        tcX.G.ActiveDevice.DeviceID(),
+			ForceSelf: false,
 		}, tcY.G)
 		err := RunEngine(eng, ctx)
 		require.NoError(t, err, "revoke original paper key")

--- a/go/engine/paperkey_test.go
+++ b/go/engine/paperkey_test.go
@@ -213,7 +213,7 @@ func TestPaperKeyAfterRevokePUK(t *testing.T) {
 	}
 
 	revoke := func(devid keybase1.DeviceID) {
-		err := doRevokeDevice(tc, fu, devid, false)
+		err := doRevokeDevice(tc, fu, devid, false /* force */, false /* forceLast */)
 		require.NoError(t, err)
 	}
 

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -27,8 +27,9 @@ type RevokeEngine struct {
 }
 
 type RevokeDeviceEngineArgs struct {
-	ID    keybase1.DeviceID
-	Force bool
+	ID        keybase1.DeviceID
+	Force     bool
+	ForceLast bool
 }
 
 func NewRevokeDeviceEngine(args RevokeDeviceEngineArgs, g *libkb.GlobalContext) *RevokeEngine {

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -117,13 +117,15 @@ func (e *RevokeEngine) Run(ctx *Context) error {
 	var deviceID keybase1.DeviceID
 	if e.mode == RevokeDevice {
 		deviceID = e.deviceID
-		if e.deviceID == currentDevice && !e.force {
-			return errors.New("Can't revoke the current device.")
-		}
 
 		if len(me.GetComputedKeyFamily().GetAllActiveDevices()) == 1 && !e.forceLast {
-			return errors.New("Can't revoke the last device.")
+			return libkb.RevokeLastDeviceError{}
 		}
+
+		if e.deviceID == currentDevice && !(e.force || e.forceLast) {
+			return libkb.RevokeCurrentDeviceError{}
+		}
+
 	}
 
 	kidsToRevoke, err := e.getKIDsToRevoke(me)

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -23,13 +23,13 @@ type RevokeEngine struct {
 	deviceID  keybase1.DeviceID
 	kid       keybase1.KID
 	mode      RevokeMode
-	force     bool
+	forceSelf bool
 	forceLast bool
 }
 
 type RevokeDeviceEngineArgs struct {
 	ID        keybase1.DeviceID
-	Force     bool
+	ForceSelf bool
 	ForceLast bool
 }
 
@@ -37,7 +37,7 @@ func NewRevokeDeviceEngine(args RevokeDeviceEngineArgs, g *libkb.GlobalContext) 
 	return &RevokeEngine{
 		deviceID:     args.ID,
 		mode:         RevokeDevice,
-		force:        args.Force,
+		forceSelf:    args.ForceSelf,
 		forceLast:    args.ForceLast,
 		Contextified: libkb.NewContextified(g),
 	}
@@ -122,7 +122,7 @@ func (e *RevokeEngine) Run(ctx *Context) error {
 			return libkb.RevokeLastDeviceError{}
 		}
 
-		if e.deviceID == currentDevice && !(e.force || e.forceLast) {
+		if e.deviceID == currentDevice && !(e.forceSelf || e.forceLast) {
 			return libkb.RevokeCurrentDeviceError{}
 		}
 

--- a/go/engine/revoke_sigs.go
+++ b/go/engine/revoke_sigs.go
@@ -83,6 +83,9 @@ func (e *RevokeSigsEngine) Run(ctx *Context) error {
 		KeyType: libkb.DeviceSigningKeyType,
 	}
 	sigKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "to revoke a signature"))
+	if err != nil {
+		return err
+	}
 	if sigKey == nil {
 		return fmt.Errorf("Revocation signing key is nil.")
 	}

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -41,8 +41,8 @@ func doRevokeKey(tc libkb.TestContext, u *FakeUser, kid keybase1.KID) error {
 	return err
 }
 
-func doRevokeDevice(tc libkb.TestContext, u *FakeUser, id keybase1.DeviceID, force, forceLast bool) error {
-	revokeEngine := NewRevokeDeviceEngine(RevokeDeviceEngineArgs{ID: id, Force: force, ForceLast: forceLast}, tc.G)
+func doRevokeDevice(tc libkb.TestContext, u *FakeUser, id keybase1.DeviceID, forceSelf, forceLast bool) error {
+	revokeEngine := NewRevokeDeviceEngine(RevokeDeviceEngineArgs{ID: id, ForceSelf: forceSelf, ForceLast: forceLast}, tc.G)
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: u.NewSecretUI(),

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -41,8 +41,8 @@ func doRevokeKey(tc libkb.TestContext, u *FakeUser, kid keybase1.KID) error {
 	return err
 }
 
-func doRevokeDevice(tc libkb.TestContext, u *FakeUser, id keybase1.DeviceID, force bool) error {
-	revokeEngine := NewRevokeDeviceEngine(RevokeDeviceEngineArgs{ID: id, Force: force}, tc.G)
+func doRevokeDevice(tc libkb.TestContext, u *FakeUser, id keybase1.DeviceID, force, forceLast bool) error {
+	revokeEngine := NewRevokeDeviceEngine(RevokeDeviceEngineArgs{ID: id, Force: force, ForceLast: forceLast}, tc.G)
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: u.NewSecretUI(),
@@ -93,7 +93,7 @@ func testRevokeDevice(t *testing.T, upgradePerUserKey bool) {
 	}
 
 	// Revoking the current device should fail.
-	err := doRevokeDevice(tc, u, thisDevice.ID, false)
+	err := doRevokeDevice(tc, u, thisDevice.ID, false, false)
 	if err == nil {
 		tc.T.Fatal("Expected revoking the current device to fail.")
 	}
@@ -101,7 +101,7 @@ func testRevokeDevice(t *testing.T, upgradePerUserKey bool) {
 	assertNumDevicesAndKeys(tc, u, 2, 4)
 
 	// But it should succeed with the --force flag.
-	err = doRevokeDevice(tc, u, thisDevice.ID, true)
+	err = doRevokeDevice(tc, u, thisDevice.ID, true, false)
 	if err != nil {
 		tc.T.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestTrackAfterRevoke(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("tc2 revokes tc1 device:")
-	err = doRevokeDevice(tc2, u, tc1.G.Env.GetDeviceID(), false)
+	err = doRevokeDevice(tc2, u, tc1.G.Env.GetDeviceID(), false, false)
 	require.NoError(t, err)
 
 	// Still logged in on tc1.  Try to use it to track someone.  It should fail
@@ -334,7 +334,7 @@ func TestSignAfterRevoke(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("tc2 revokes tc1 device:")
-	err = doRevokeDevice(tc2, u, tc1.G.Env.GetDeviceID(), false)
+	err = doRevokeDevice(tc2, u, tc1.G.Env.GetDeviceID(), false, false)
 	require.NoError(t, err)
 
 	// Still logged in on tc1, a revoked device.
@@ -418,7 +418,43 @@ func revokeAnyPaperKey(tc libkb.TestContext, fu *FakeUser) *libkb.Device {
 	}
 	require.NotNil(t, revokeDevice, "no paper key found to revoke")
 	t.Logf("revoke %s", revokeDevice.ID)
-	err := doRevokeDevice(tc, fu, revokeDevice.ID, false)
+	err := doRevokeDevice(tc, fu, revokeDevice.ID, false, false)
 	require.NoError(t, err)
 	return revokeDevice
+}
+
+func TestRevokeLastDevice(t *testing.T) {
+	tc := SetupEngineTest(t, "rev")
+	defer tc.Cleanup()
+
+	u := CreateAndSignupFakeUser(tc, "rev")
+
+	assertNumDevicesAndKeys(tc, u, 1, 2)
+
+	devices, _ := getActiveDevicesAndKeys(tc, u)
+	thisDevice := devices[0]
+
+	// Revoking the current device should fail.
+	err := doRevokeDevice(tc, u, thisDevice.ID, false, false)
+	if err == nil {
+		t.Fatal("Expected revoking the current device to fail.")
+	}
+
+	assertNumDevicesAndKeys(tc, u, 1, 2)
+
+	// Since this is the last device, it should fail with `force` too:
+	err = doRevokeDevice(tc, u, thisDevice.ID, true, false)
+	if err == nil {
+		t.Fatal("Expected revoking the current last device to fail.")
+	}
+
+	assertNumDevicesAndKeys(tc, u, 1, 2)
+
+	// With `force` and `forceLast`, the revoke should succeed
+	err = doRevokeDevice(tc, u, thisDevice.ID, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertNumDevicesAndKeys(tc, u, 0, 0)
 }

--- a/go/engine/saltpack_sign_test.go
+++ b/go/engine/saltpack_sign_test.go
@@ -364,12 +364,12 @@ func TestSaltpackVerifyRevoked(t *testing.T) {
 	}
 
 	// Revoke the current device.
-	err := doRevokeDevice(tc, fu, currentDevice.ID, false)
+	err := doRevokeDevice(tc, fu, currentDevice.ID, false, false)
 	if err == nil {
 		tc.T.Fatal("Expected revoking the current device to fail.")
 	}
 	// force=true is required for the current device
-	err = doRevokeDevice(tc, fu, currentDevice.ID, true)
+	err = doRevokeDevice(tc, fu, currentDevice.ID, true, false)
 	if err != nil {
 		tc.T.Fatal(err)
 	}

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -154,7 +154,7 @@ func TestLoadDeviceKeyRevoked(t *testing.T) {
 	}
 
 	// Revoke the current device with --force
-	err = doRevokeDevice(tc, fu, thisDevice.ID, true)
+	err = doRevokeDevice(tc, fu, thisDevice.ID, true, false)
 	if err != nil {
 		tc.T.Fatal(err)
 	}

--- a/go/engine/user_test.go
+++ b/go/engine/user_test.go
@@ -4,12 +4,13 @@
 package engine
 
 import (
+	"testing"
+	"time"
+
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestLoadUserPlusKeysHasKeys(t *testing.T) {
@@ -62,7 +63,7 @@ func TestLoadUserPlusKeysRevoked(t *testing.T) {
 		}
 	}
 
-	if err := doRevokeDevice(tc, fu, paper.ID, false); err != nil {
+	if err := doRevokeDevice(tc, fu, paper.ID, false, false); err != nil {
 		t.Fatal(err)
 	}
 	fakeClock.Advance(libkb.CachedUserTimeout + 2*time.Second)

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -260,6 +260,8 @@ const (
 	SCTeamTarNotFound          = int(keybase1.StatusCode_SCTeamTarNotFound)
 	SCTeamMemberExists         = int(keybase1.StatusCode_SCTeamMemberExists)
 	SCLoginStateTimeout        = int(keybase1.StatusCode_SCLoginStateTimeout)
+	SCRevokeCurrentDevice      = int(keybase1.StatusCode_SCRevokeCurrentDevice)
+	SCRevokeLastDevice         = int(keybase1.StatusCode_SCRevokeLastDevice)
 )
 
 const (

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2053,3 +2053,15 @@ func (e KBFSNotRunning) Error() string {
 		return err
 	}
 }
+
+type RevokeCurrentDeviceError struct{}
+
+func (e RevokeCurrentDeviceError) Error() string {
+	return "cannot revoke the current device without confirmation"
+}
+
+type RevokeLastDeviceError struct{}
+
+func (e RevokeLastDeviceError) Error() string {
+	return "cannot revoke the last device in your account without confirmation"
+}

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -580,6 +580,10 @@ func ImportStatusAsError(s *keybase1.Status) error {
 			}
 		}
 		return e
+	case SCRevokeCurrentDevice:
+		return RevokeCurrentDeviceError{}
+	case SCRevokeLastDevice:
+		return RevokeLastDeviceError{}
 
 	default:
 		ase := AppStatusError{
@@ -2000,5 +2004,21 @@ func (e LoginStateTimeoutError) ToStatus() keybase1.Status {
 			{Key: "AttemptedRequest", Value: e.AttemptedRequest},
 			{Key: "Duration", Value: e.Duration.String()},
 		},
+	}
+}
+
+func (e RevokeCurrentDeviceError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCRevokeCurrentDevice,
+		Name: "SC_DEVICE_REVOKE_CURRENT",
+		Desc: e.Error(),
+	}
+}
+
+func (e RevokeLastDeviceError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCRevokeLastDevice,
+		Name: "SC_DEVICE_REVOKE_LAST",
+		Desc: e.Error(),
 	}
 }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -66,6 +66,8 @@ const (
 	StatusCode_SCDevicePrevProvisioned    StatusCode = 1413
 	StatusCode_SCDeviceNoProvision        StatusCode = 1414
 	StatusCode_SCDeviceProvisionViaDevice StatusCode = 1415
+	StatusCode_SCRevokeCurrentDevice      StatusCode = 1416
+	StatusCode_SCRevokeLastDevice         StatusCode = 1417
 	StatusCode_SCStreamExists             StatusCode = 1501
 	StatusCode_SCStreamNotFound           StatusCode = 1502
 	StatusCode_SCStreamWrongKind          StatusCode = 1503
@@ -173,6 +175,8 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCDevicePrevProvisioned":    1413,
 	"SCDeviceNoProvision":        1414,
 	"SCDeviceProvisionViaDevice": 1415,
+	"SCRevokeCurrentDevice":      1416,
+	"SCRevokeLastDevice":         1417,
 	"SCStreamExists":             1501,
 	"SCStreamNotFound":           1502,
 	"SCStreamWrongKind":          1503,
@@ -278,6 +282,8 @@ var StatusCodeRevMap = map[StatusCode]string{
 	1413: "SCDevicePrevProvisioned",
 	1414: "SCDeviceNoProvision",
 	1415: "SCDeviceProvisionViaDevice",
+	1416: "SCRevokeCurrentDevice",
+	1417: "SCRevokeLastDevice",
 	1501: "SCStreamExists",
 	1502: "SCStreamNotFound",
 	1503: "SCStreamWrongKind",

--- a/go/protocol/keybase1/revoke.go
+++ b/go/protocol/keybase1/revoke.go
@@ -24,6 +24,7 @@ type RevokeDeviceArg struct {
 	SessionID int      `codec:"sessionID" json:"sessionID"`
 	DeviceID  DeviceID `codec:"deviceID" json:"deviceID"`
 	Force     bool     `codec:"force" json:"force"`
+	ForceLast bool     `codec:"forceLast" json:"forceLast"`
 }
 
 func (o RevokeDeviceArg) DeepCopy() RevokeDeviceArg {
@@ -31,6 +32,7 @@ func (o RevokeDeviceArg) DeepCopy() RevokeDeviceArg {
 		SessionID: o.SessionID,
 		DeviceID:  o.DeviceID.DeepCopy(),
 		Force:     o.Force,
+		ForceLast: o.ForceLast,
 	}
 }
 

--- a/go/protocol/keybase1/revoke.go
+++ b/go/protocol/keybase1/revoke.go
@@ -23,7 +23,7 @@ func (o RevokeKeyArg) DeepCopy() RevokeKeyArg {
 type RevokeDeviceArg struct {
 	SessionID int      `codec:"sessionID" json:"sessionID"`
 	DeviceID  DeviceID `codec:"deviceID" json:"deviceID"`
-	Force     bool     `codec:"force" json:"force"`
+	ForceSelf bool     `codec:"forceSelf" json:"forceSelf"`
 	ForceLast bool     `codec:"forceLast" json:"forceLast"`
 }
 
@@ -31,7 +31,7 @@ func (o RevokeDeviceArg) DeepCopy() RevokeDeviceArg {
 	return RevokeDeviceArg{
 		SessionID: o.SessionID,
 		DeviceID:  o.DeviceID.DeepCopy(),
-		Force:     o.Force,
+		ForceSelf: o.ForceSelf,
 		ForceLast: o.ForceLast,
 	}
 }

--- a/go/service/revoke.go
+++ b/go/service/revoke.go
@@ -41,7 +41,7 @@ func (h *RevokeHandler) RevokeDevice(_ context.Context, arg keybase1.RevokeDevic
 		SecretUI:  h.getSecretUI(sessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
-	eng := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{ID: arg.DeviceID, Force: arg.Force, ForceLast: arg.ForceLast}, h.G())
+	eng := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{ID: arg.DeviceID, ForceSelf: arg.ForceSelf, ForceLast: arg.ForceLast}, h.G())
 	return engine.RunEngine(eng, &ctx)
 }
 

--- a/go/service/revoke.go
+++ b/go/service/revoke.go
@@ -41,7 +41,7 @@ func (h *RevokeHandler) RevokeDevice(_ context.Context, arg keybase1.RevokeDevic
 		SecretUI:  h.getSecretUI(sessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
-	eng := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{ID: arg.DeviceID, Force: arg.Force}, h.G())
+	eng := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{ID: arg.DeviceID, Force: arg.Force, ForceLast: arg.ForceLast}, h.G())
 	return engine.RunEngine(eng, &ctx)
 }
 

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -58,6 +58,8 @@ protocol constants {
     SCDevicePrevProvisioned_1413,
     SCDeviceNoProvision_1414,
     SCDeviceProvisionViaDevice_1415,
+    SCRevokeCurrentDevice_1416,
+    SCRevokeLastDevice_1417,
     SCStreamExists_1501,
     SCStreamNotFound_1502,
     SCStreamWrongKind_1503,

--- a/protocol/avdl/keybase1/revoke.avdl
+++ b/protocol/avdl/keybase1/revoke.avdl
@@ -4,6 +4,6 @@ protocol revoke {
   import idl "common.avdl";
 
   void revokeKey(int sessionID, KID keyID);
-  void revokeDevice(int sessionID, DeviceID deviceID, boolean force);
+  void revokeDevice(int sessionID, DeviceID deviceID, boolean force, boolean forceLast);
   void revokeSigs(int sessionID, array<string> sigIDQueries);
 }

--- a/protocol/avdl/keybase1/revoke.avdl
+++ b/protocol/avdl/keybase1/revoke.avdl
@@ -4,6 +4,6 @@ protocol revoke {
   import idl "common.avdl";
 
   void revokeKey(int sessionID, KID keyID);
-  void revokeDevice(int sessionID, DeviceID deviceID, boolean force, boolean forceLast);
+  void revokeDevice(int sessionID, DeviceID deviceID, boolean forceSelf, boolean forceLast);
   void revokeSigs(int sessionID, array<string> sigIDQueries);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -173,6 +173,8 @@ export const ConstantsStatusCode = {
   scdeviceprevprovisioned: 1413,
   scdevicenoprovision: 1414,
   scdeviceprovisionviadevice: 1415,
+  screvokecurrentdevice: 1416,
+  screvokelastdevice: 1417,
   scstreamexists: 1501,
   scstreamnotfound: 1502,
   scstreamwrongkind: 1503,
@@ -5251,6 +5253,8 @@ export type StatusCode =
   | 1413 // SCDevicePrevProvisioned_1413
   | 1414 // SCDeviceNoProvision_1414
   | 1415 // SCDeviceProvisionViaDevice_1415
+  | 1416 // SCRevokeCurrentDevice_1416
+  | 1417 // SCRevokeLastDevice_1417
   | 1501 // SCStreamExists_1501
   | 1502 // SCStreamNotFound_1502
   | 1503 // SCStreamWrongKind_1503

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6542,7 +6542,8 @@ export type rekeyUIRekeySendEventRpcParam = Exact<{
 
 export type revokeRevokeDeviceRpcParam = Exact<{
   deviceID: DeviceID,
-  force: boolean
+  force: boolean,
+  forceLast: boolean
 }>
 
 export type revokeRevokeKeyRpcParam = Exact<{

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6546,7 +6546,7 @@ export type rekeyUIRekeySendEventRpcParam = Exact<{
 
 export type revokeRevokeDeviceRpcParam = Exact<{
   deviceID: DeviceID,
-  force: boolean,
+  forceSelf: boolean,
   forceLast: boolean
 }>
 

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -62,6 +62,8 @@
         "SCDevicePrevProvisioned_1413",
         "SCDeviceNoProvision_1414",
         "SCDeviceProvisionViaDevice_1415",
+        "SCRevokeCurrentDevice_1416",
+        "SCRevokeLastDevice_1417",
         "SCStreamExists_1501",
         "SCStreamNotFound_1502",
         "SCStreamWrongKind_1503",

--- a/protocol/json/keybase1/revoke.json
+++ b/protocol/json/keybase1/revoke.json
@@ -34,6 +34,10 @@
         {
           "name": "force",
           "type": "boolean"
+        },
+        {
+          "name": "forceLast",
+          "type": "boolean"
         }
       ],
       "response": null

--- a/protocol/json/keybase1/revoke.json
+++ b/protocol/json/keybase1/revoke.json
@@ -32,7 +32,7 @@
           "type": "DeviceID"
         },
         {
-          "name": "force",
+          "name": "forceSelf",
           "type": "boolean"
         },
         {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -173,6 +173,8 @@ export const ConstantsStatusCode = {
   scdeviceprevprovisioned: 1413,
   scdevicenoprovision: 1414,
   scdeviceprovisionviadevice: 1415,
+  screvokecurrentdevice: 1416,
+  screvokelastdevice: 1417,
   scstreamexists: 1501,
   scstreamnotfound: 1502,
   scstreamwrongkind: 1503,
@@ -5251,6 +5253,8 @@ export type StatusCode =
   | 1413 // SCDevicePrevProvisioned_1413
   | 1414 // SCDeviceNoProvision_1414
   | 1415 // SCDeviceProvisionViaDevice_1415
+  | 1416 // SCRevokeCurrentDevice_1416
+  | 1417 // SCRevokeLastDevice_1417
   | 1501 // SCStreamExists_1501
   | 1502 // SCStreamNotFound_1502
   | 1503 // SCStreamWrongKind_1503

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6542,7 +6542,8 @@ export type rekeyUIRekeySendEventRpcParam = Exact<{
 
 export type revokeRevokeDeviceRpcParam = Exact<{
   deviceID: DeviceID,
-  force: boolean
+  force: boolean,
+  forceLast: boolean
 }>
 
 export type revokeRevokeKeyRpcParam = Exact<{

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6546,7 +6546,7 @@ export type rekeyUIRekeySendEventRpcParam = Exact<{
 
 export type revokeRevokeDeviceRpcParam = Exact<{
   deviceID: DeviceID,
-  force: boolean,
+  forceSelf: boolean,
   forceLast: boolean
 }>
 


### PR DESCRIPTION
This patch adds a flag to `device remove` for forcing removal of the last device in an account.

To revoke the last device in your account, you need to do 

    keybase device remove --force --last <device id>

Note that the revoke plumbing uses a bit of an "old" style where we copied args all over the place into different structures instead of passing keybase1 protocol structs around.  I didn't change any of that in favor of changing the least amount of code as possible.