### PR TITLE
Allow deleting pending messages (e.g. when offline)

### DIFF
--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -64,7 +64,6 @@ function* deleteMessage(action: Constants.DeleteMessage): SagaGenerator<any, any
     })
   } else {
     // Deleting a local outbox message.
-    if (message.messageState !== 'failed') throw new Error('Tried to delete a non-failed message')
     const outboxID = message.outboxID
     if (!outboxID) throw new Error('No outboxID for pending message delete')
 


### PR DESCRIPTION
@keybase/react-hackers CC @mmaxim 

Tested this for allowing deletion of pending messages, works great.  Not sure why this check was present.

Perhaps it was there as a sanity check to make sure we only got to this branch for outbox messages, not server messages.  But there's more than one state of outbox message: pending as well as failed, so the test isn't correct.