### PR TITLE
Fix devices row height

### DIFF
--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -141,7 +141,7 @@ const stylesCommonCore = {
 const stylesCommonRow = {
   ...globalStyles.flexBoxRow,
   ...stylesCommonCore,
-  minHeight: 64,
+  minHeight: isMobile ? 64 : 48,
   padding: 8,
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

Zeplin has the mobile devices row height as 64 and the desktop devices row height as 48, but the refactor left us leaving 64 for both.

The JIRA only mentions an ugly spinner when loading devices on desktop -- spinner looks okay to me now on macOS, maybe that was fixed in the meantime?  CC @cecileboucheron.