### PR TITLE
make sure eldest key info is populated the same way as sibkey info

### DIFF
--- a/go/engine/upak2_test.go
+++ b/go/engine/upak2_test.go
@@ -86,4 +86,19 @@ func TestExportAllIncarnationsAfterReset(t *testing.T) {
 			t.Fatalf("found empty LinkID at seqno %d, that's pretty weird", seqno)
 		}
 	}
+
+	// Make sure the eldest key has delegation info populated correctly.
+	foundEldest := false
+	for _, key := range exported.Current.DeviceKeys {
+		if !key.Base.IsEldest {
+			continue
+		}
+		if foundEldest {
+			t.Fatal("found a second eldest key?!")
+		}
+		foundEldest = true
+		if key.Base.Provisioning.Time.IsZero() {
+			t.Fatal("eldest key provisioning info appears uninitialized")
+		}
+	}
 }

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -104,7 +104,7 @@ func (sc *SigChain) LocalDelegate(kf *KeyFamily, key GenericKey, sigID keybase1.
 
 	if len(sigID) > 0 {
 		var zeroTime time.Time
-		err = cki.Delegate(key.GetKID(), NowAsKeybaseTime(0), sigID, signingKid, signingKid, "" /* pgpHash */, isSibkey, time.Unix(0, 0), zeroTime, mhm, fau, keybase1.SigChainLocation{})
+		err = cki.Delegate(key.GetKID(), NowAsKeybaseTime(0), sigID, signingKid, signingKid, "" /* pgpHash */, isSibkey, false /* isEldest */, time.Unix(0, 0), zeroTime, mhm, fau, keybase1.SigChainLocation{})
 	}
 
 	return


### PR DESCRIPTION
Previously eldest keys were going around the Delegate function, which
meant that several fields in their ComputedKeyInfo were uninitialized.
Rather than duplicate the code for initializing them, we can use
Delegate there as well. Also add a test that these fields make it out
through export (fails prior to this PR).

r? @maxtaco 