### PR TITLE
Fix updateTyping not being throttled

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -8,7 +8,7 @@ import NoConversation from './no-conversation'
 import Rekey from './rekey/container'
 import pausableConnect from '../../util/pausable-connect'
 import {getProfile} from '../../actions/tracker'
-import {withState, withHandlers, compose, branch, renderNothing, renderComponent, lifecycle} from 'recompose'
+import {withState, withHandlers, compose, branch, renderNothing, renderComponent} from 'recompose'
 import {selectedSearchIdHoc} from '../../search/helpers'
 import {chatSearchResultArray} from '../../constants/selectors'
 import ConversationError from './error/conversation-error'
@@ -158,7 +158,6 @@ export default compose(
   withState('listScrollDownCounter', 'setListScrollDownCounter', 0),
   withState('searchText', 'onChangeSearchText', ''),
   withState('addNewParticipant', 'onAddNewParticipant', false),
-  withState('chatText', 'setChatText', props => props.defaultChatText || ''),
   selectedSearchIdHoc,
   withHandlers({
     onAddNewParticipant: props => () => props.onAddNewParticipant(true),
@@ -172,21 +171,6 @@ export default compose(
     },
     onMouseOverSearchResult: props => id => {
       props.onUpdateSelectedSearchResult(id)
-    },
-  }),
-  lifecycle({
-    componentWillUnmount: function() {
-      this.props.onStoreInputText(this.props.chatText)
-    },
-    componentWillReceiveProps: function(nextProps) {
-      if (
-        this.props.selectedConversationIDKey &&
-        this.props.selectedConversationIDKey !== nextProps.selectedConversationIDKey
-      ) {
-        this.props.onStoreInputText(this.props.chatText)
-        // withState won't get called again if props changes!
-        this.props.setChatText(nextProps.defaultChatText)
-      }
     },
   })
 )(Conversation)

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -155,8 +155,6 @@ class Conversation extends Component<void, Props, State> {
                   {this.props.finalizeInfo
                     ? <OldProfileResetNotice />
                     : <Input
-                        text={this.props.chatText}
-                        setText={this.props.setChatText}
                         focusInputCounter={this.props.focusInputCounter}
                         onEditLastMessage={this.props.onEditLastMessage}
                         onScrollDown={this.props.onScrollDown}

--- a/shared/chat/conversation/index.native.js
+++ b/shared/chat/conversation/index.native.js
@@ -77,8 +77,6 @@ const Conversation = (props: Props) => (
               {props.finalizeInfo
                 ? <OldProfileResetNotice />
                 : <Input
-                    text={props.chatText}
-                    setText={props.setChatText}
                     focusInputCounter={props.focusInputCounter}
                     onEditLastMessage={props.onEditLastMessage}
                     onScrollDown={props.onScrollDown}


### PR DESCRIPTION
@keybase/react-hackers this moves the chat text to inside the input container which avoids calling mergeprops all the time which subverted the throttle