### PR TITLE
Add test for MS driver signing to Jenkins windows installer build

### DIFF
--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -47,10 +47,10 @@ def doBuild() {
             // Note this depends on the build taking place on Windows 10 for the msi
             // extraction to yield the drivers we want to test.
             bat '''
-                "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat"
-                signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
-                signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"                
-                msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi" /qb TARGETDIR=temp
+                call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" &&
+                signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher" &&
+                signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher" &&
+                msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi" /qb TARGETDIR=temp &&
                 signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
             '''
         } else {

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -46,12 +46,10 @@ def doBuild() {
             // Check both the built .sys files and the msi package.
             // Note this depends on the build taking place on Windows 10 for the msi
             // extraction to yield the drivers we want to test.
-            bat '''
-                call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
-                call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
-                call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi" /qb TARGETDIR=temp
-                call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
-            '''
+            bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"'
+            bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"'
+            bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi" /qb TARGETDIR=temp'
+            bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"'
         } else {
             echo "Skipping signed driver checking"
         }

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -46,9 +46,9 @@ def doBuild() {
             // Check both the built .sys files and the msi package.
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\Win32\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
-            bat "%ProgramFiles%\\7=Zip\7z e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi Win10_Sys"
+            bat "\"%ProgramFiles%\\7=Zip\7z\" e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi Win10_Sys"
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v Win10_Sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
-            bat "%ProgramFiles%\\7=Zip\7z e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x86.msi Win10_Sys"
+            bat "\"%ProgramFiles%\\7=Zip\7z\" e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x86.msi Win10_Sys"
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v Win10_Sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
         } else {
             echo "Skipping signed driver checking"

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -46,10 +46,10 @@ def doBuild() {
             // Check both the built .sys files and the msi package.
             // Note this depends on the build taking place on Windows 10 for the msi
             // extraction to yield the drivers we want to test.
-            bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"'
-            bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"'
-            bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi" /qb TARGETDIR=temp'
-            bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"'
+            bat "call '%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat' && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find 'Issued to: Microsoft Windows Hardware Compatibility Publisher"
+            bat "call '%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat' && signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find 'Issued to: Microsoft Windows Hardware Compatibility Publisher"
+            bat "call '%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat' && msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi /qb TARGETDIR=temp"
+            bat "call '%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat' && signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find 'Issued to: Microsoft Windows Hardware Compatibility Publisher"
         } else {
             echo "Skipping signed driver checking"
         }

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -46,10 +46,10 @@ def doBuild() {
             // Check both the built .sys files and the msi package.
             // Note this depends on the build taking place on Windows 10 for the msi
             // extraction to yield the drivers we want to test.
-            bat "call '%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat' && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find 'Issued to: Microsoft Windows Hardware Compatibility Publisher"
-            bat "call '%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat' && signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find 'Issued to: Microsoft Windows Hardware Compatibility Publisher"
-            bat "call '%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat' && msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi /qb TARGETDIR=temp"
-            bat "call '%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat' && signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find 'Issued to: Microsoft Windows Hardware Compatibility Publisher"
+            bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
+            bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
+            bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi /qb TARGETDIR=temp"
+            bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
         } else {
             echo "Skipping signed driver checking"
         }

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -47,11 +47,10 @@ def doBuild() {
             // Note this depends on the build taking place on Windows 10 for the msi
             // extraction to yield the drivers we want to test.
             bat '''
-                call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" &&
-                signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher" &&
-                signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher" &&
-                msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi" /qb TARGETDIR=temp &&
-                signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
+                call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
+                call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
+                call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi" /qb TARGETDIR=temp
+                call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
             '''
         } else {
             echo "Skipping signed driver checking"

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -41,6 +41,22 @@ def publish(bucket, excluded, source) {
 }
 
 def doBuild() {
+    stage('Check Driver Signing') {
+        if (UpdateChannel != "None"){
+            // Check both the built .sys files and the msi package.
+            // Note this depends on the build taking place on Windows 10 for the msi
+            // extraction to yield the drivers we want to test.
+            bat '''
+                "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat"
+                signtool verify /all /kp /v ${DOKAN_PATH}\x64\Win10Release\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
+                signtool verify /all /kp /v ${DOKAN_PATH}\x86\Win10Release\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"                
+                msiexec /a ${DOKAN_PATH}\dokan_wix\bin\x64\release\Dokan_x64.msi" /qb TARGETDIR=temp
+                signtool verify /all /kp /v temp\Dokan\DokanLibrary-1.0.1\driver\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
+            '''
+        } else {
+            echo "Skipping signed driver checking"
+        }
+    }
     stage('Checkout Client') {
         // Reset symlink due to node/git/windows problems
         retry(3) {

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -48,10 +48,10 @@ def doBuild() {
             // extraction to yield the drivers we want to test.
             bat '''
                 "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat"
-                signtool verify /all /kp /v ${DOKAN_PATH}\x64\Win10Release\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
-                signtool verify /all /kp /v ${DOKAN_PATH}\x86\Win10Release\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"                
-                msiexec /a ${DOKAN_PATH}\dokan_wix\bin\x64\release\Dokan_x64.msi" /qb TARGETDIR=temp
-                signtool verify /all /kp /v temp\Dokan\DokanLibrary-1.0.1\driver\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
+                signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
+                signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"                
+                msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi" /qb TARGETDIR=temp
+                signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find "Issued to: Microsoft Windows Hardware Compatibility Publisher"
             '''
         } else {
             echo "Skipping signed driver checking"

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -48,7 +48,7 @@ def doBuild() {
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\Win32\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
             bat "\"%ProgramFiles%\\7-Zip\\7z\" e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi Win10_Sys"
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v Win10_Sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
-            bat "\"%ProgramFiles%\\7-Zip\\7z\" e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x86.msi Win10_Sys"
+            bat "\"%ProgramFiles%\\7-Zip\\7z\" e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x86\\release\\Dokan_x86.msi Win10_Sys"
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v Win10_Sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
         } else {
             echo "Skipping signed driver checking"

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -44,12 +44,12 @@ def doBuild() {
     stage('Check Driver Signing') {
         if (UpdateChannel != "None"){
             // Check both the built .sys files and the msi package.
-            // Note this depends on the build taking place on Windows 10 for the msi
-            // extraction to yield the drivers we want to test.
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\Win32\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
-            bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi /qb TARGETDIR=temp"
-            bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
+            bat "%ProgramFiles%\\7=Zip\7z e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi Win10_Sys"
+            bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v Win10_Sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
+            bat "%ProgramFiles%\\7=Zip\7z e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x86.msi Win10_Sys"
+            bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v Win10_Sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
         } else {
             echo "Skipping signed driver checking"
         }

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -47,7 +47,7 @@ def doBuild() {
             // Note this depends on the build taking place on Windows 10 for the msi
             // extraction to yield the drivers we want to test.
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
-            bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\x86\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
+            bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\Win32\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && msiexec /a ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi /qb TARGETDIR=temp"
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v temp\\Dokan\\DokanLibrary-1.0.1\\driver\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
         } else {

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -46,9 +46,9 @@ def doBuild() {
             // Check both the built .sys files and the msi package.
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\x64\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v ${DOKAN_PATH}\\Win32\\Win10Release\\dokan1.sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
-            bat "\"%ProgramFiles%\\7=Zip\7z\" e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi Win10_Sys"
+            bat "\"%ProgramFiles%\\7-Zip\\7z\" e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x64.msi Win10_Sys"
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v Win10_Sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
-            bat "\"%ProgramFiles%\\7=Zip\7z\" e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x86.msi Win10_Sys"
+            bat "\"%ProgramFiles%\\7-Zip\\7z\" e -y ${DOKAN_PATH}\\dokan_wix\\bin\\x64\\release\\Dokan_x86.msi Win10_Sys"
             bat "call \"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat\" && signtool verify /all /kp /v Win10_Sys | find \"Issued to: Microsoft Windows Hardware Compatibility Publisher\""
         } else {
             echo "Skipping signed driver checking"


### PR DESCRIPTION
Tested it, all the configurations except "None" will not be built if the signing is not present.
Note that the driver signing is complete and ready; this part just adds the test.
@keybase/react-hackers 