### PR TITLE
add support for enabling/disabling plaintext mobile notifications CORE-5805

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -267,6 +267,16 @@ func (f failingRemote) RemoteNotificationSuccessful(ctx context.Context,
 	return nil
 }
 
+func (f failingRemote) SetGlobalAppNotificationSettings(ctx context.Context, arg chat1.GlobalAppNotificationSettings) error {
+	require.Fail(f.t, "SetGlobalAppNotificationSettings")
+	return nil
+}
+
+func (f failingRemote) GetGlobalAppNotificationSettings(ctx context.Context) (chat1.GlobalAppNotificationSettings, error) {
+	require.Fail(f.t, "GetGlobalAppNotificationSettings")
+	return chat1.GlobalAppNotificationSettings{}, nil
+}
+
 type failingTlf struct {
 	t *testing.T
 }

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2358,3 +2358,13 @@ func (h *Server) UnboxMobilePushNotification(ctx context.Context, arg chat1.Unbo
 		msgUnboxed.GetMessageType())
 	return "", errors.New("invalid message")
 }
+
+func (h *Server) SetGlobalAppNotificationSettingsLocal(ctx context.Context,
+	settings chat1.GlobalAppNotificationSettings) (err error) {
+	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, nil, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, "SetGlobalAppNotificationSettings")()
+	if err = h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
+	return h.remoteClient().SetGlobalAppNotificationSettings(ctx, settings)
+}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2368,3 +2368,12 @@ func (h *Server) SetGlobalAppNotificationSettingsLocal(ctx context.Context,
 	}
 	return h.remoteClient().SetGlobalAppNotificationSettings(ctx, settings)
 }
+
+func (h *Server) GetGlobalAppNotificationSettingsLocal(ctx context.Context) (res chat1.GlobalAppNotificationSettings, err error) {
+	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, nil, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, "GetGlobalAppNotificationSettings")()
+	if err = h.assertLoggedIn(ctx); err != nil {
+		return res, err
+	}
+	return h.remoteClient().GetGlobalAppNotificationSettings(ctx)
+}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2375,8 +2375,10 @@ func (h *Server) SetGlobalAppNotificationSettingsLocal(ctx context.Context,
 			h.Debug(ctx, "SetGlobalAppNotificationSettings: failed to convert key: %s", err.Error())
 			continue
 		}
-		h.Debug(ctx, "SetGlobalAppNotificationSettings: setting typ: %s enabled: %v", k, v)
-		settings.Settings[chat1.GlobalAppNotificationSetting(key)] = v
+		gkey := chat1.GlobalAppNotificationSetting(key)
+		h.Debug(ctx, "SetGlobalAppNotificationSettings: setting typ: %s enabled: %v",
+			chat1.GlobalAppNotificationSettingRevMap[gkey], v)
+		settings.Settings[gkey] = v
 	}
 
 	return h.remoteClient().SetGlobalAppNotificationSettings(ctx, settings)

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -572,6 +572,15 @@ func (m *ChatRemoteMock) SetAppNotificationSettings(ctx context.Context,
 	return res, errors.New("not implemented")
 }
 
+func (m *ChatRemoteMock) SetGlobalAppNotificationSettings(ctx context.Context,
+	arg chat1.GlobalAppNotificationSettings) error {
+	return errors.New("not implemented")
+}
+
+func (m *ChatRemoteMock) GetGlobalAppNotificationSettings(ctx context.Context) (chat1.GlobalAppNotificationSettings, error) {
+	return chat1.GlobalAppNotificationSettings{}, errors.New("not implemented")
+}
+
 func (m *ChatRemoteMock) TlfFinalize(ctx context.Context, arg chat1.TlfFinalizeArg) error {
 	return nil
 }

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -221,6 +221,53 @@ var NotificationKindRevMap = map[NotificationKind]string{
 	1: "ATMENTION",
 }
 
+type GlobalAppNotificationSetting int
+
+const (
+	GlobalAppNotificationSetting_NEWMESSAGES      GlobalAppNotificationSetting = 0
+	GlobalAppNotificationSetting_PLAINTEXTMOBILE  GlobalAppNotificationSetting = 1
+	GlobalAppNotificationSetting_PLAINTEXTDESKTOP GlobalAppNotificationSetting = 2
+)
+
+func (o GlobalAppNotificationSetting) DeepCopy() GlobalAppNotificationSetting { return o }
+
+var GlobalAppNotificationSettingMap = map[string]GlobalAppNotificationSetting{
+	"NEWMESSAGES":      0,
+	"PLAINTEXTMOBILE":  1,
+	"PLAINTEXTDESKTOP": 2,
+}
+
+var GlobalAppNotificationSettingRevMap = map[GlobalAppNotificationSetting]string{
+	0: "NEWMESSAGES",
+	1: "PLAINTEXTMOBILE",
+	2: "PLAINTEXTDESKTOP",
+}
+
+func (e GlobalAppNotificationSetting) String() string {
+	if v, ok := GlobalAppNotificationSettingRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type GlobalAppNotificationSettings struct {
+	Settings map[GlobalAppNotificationSetting]bool `codec:"settings" json:"settings"`
+}
+
+func (o GlobalAppNotificationSettings) DeepCopy() GlobalAppNotificationSettings {
+	return GlobalAppNotificationSettings{
+		Settings: (func(x map[GlobalAppNotificationSetting]bool) map[GlobalAppNotificationSetting]bool {
+			ret := make(map[GlobalAppNotificationSetting]bool)
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := v
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.Settings),
+	}
+}
+
 type ConversationStatus int
 
 const (

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3667,12 +3667,20 @@ func (o SetAppNotificationSettingsLocalArg) DeepCopy() SetAppNotificationSetting
 }
 
 type SetGlobalAppNotificationSettingsLocalArg struct {
-	Settings GlobalAppNotificationSettings `codec:"settings" json:"settings"`
+	Settings map[string]bool `codec:"settings" json:"settings"`
 }
 
 func (o SetGlobalAppNotificationSettingsLocalArg) DeepCopy() SetGlobalAppNotificationSettingsLocalArg {
 	return SetGlobalAppNotificationSettingsLocalArg{
-		Settings: o.Settings.DeepCopy(),
+		Settings: (func(x map[string]bool) map[string]bool {
+			ret := make(map[string]bool)
+			for k, v := range x {
+				kCopy := k
+				vCopy := v
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.Settings),
 	}
 }
 
@@ -3738,7 +3746,7 @@ type LocalInterface interface {
 	LeaveConversationLocal(context.Context, ConversationID) (JoinLeaveConversationLocalRes, error)
 	GetTLFConversationsLocal(context.Context, GetTLFConversationsLocalArg) (GetTLFConversationsLocalRes, error)
 	SetAppNotificationSettingsLocal(context.Context, SetAppNotificationSettingsLocalArg) (SetAppNotificationSettingsLocalRes, error)
-	SetGlobalAppNotificationSettingsLocal(context.Context, GlobalAppNotificationSettings) error
+	SetGlobalAppNotificationSettingsLocal(context.Context, map[string]bool) error
 	GetGlobalAppNotificationSettingsLocal(context.Context) (GlobalAppNotificationSettings, error)
 	UnboxMobilePushNotification(context.Context, UnboxMobilePushNotificationArg) (string, error)
 }
@@ -4450,7 +4458,7 @@ func (c LocalClient) SetAppNotificationSettingsLocal(ctx context.Context, __arg 
 	return
 }
 
-func (c LocalClient) SetGlobalAppNotificationSettingsLocal(ctx context.Context, settings GlobalAppNotificationSettings) (err error) {
+func (c LocalClient) SetGlobalAppNotificationSettingsLocal(ctx context.Context, settings map[string]bool) (err error) {
 	__arg := SetGlobalAppNotificationSettingsLocalArg{Settings: settings}
 	err = c.Cli.Call(ctx, "chat.1.local.setGlobalAppNotificationSettingsLocal", []interface{}{__arg}, nil)
 	return

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3666,6 +3666,16 @@ func (o SetAppNotificationSettingsLocalArg) DeepCopy() SetAppNotificationSetting
 	}
 }
 
+type SetGlobalAppNotificationSettingsLocalArg struct {
+	Settings GlobalAppNotificationSettings `codec:"settings" json:"settings"`
+}
+
+func (o SetGlobalAppNotificationSettingsLocalArg) DeepCopy() SetGlobalAppNotificationSettingsLocalArg {
+	return SetGlobalAppNotificationSettingsLocalArg{
+		Settings: o.Settings.DeepCopy(),
+	}
+}
+
 type UnboxMobilePushNotificationArg struct {
 	Payload     string                  `codec:"payload" json:"payload"`
 	ConvID      string                  `codec:"convID" json:"convID"`
@@ -3721,6 +3731,7 @@ type LocalInterface interface {
 	LeaveConversationLocal(context.Context, ConversationID) (JoinLeaveConversationLocalRes, error)
 	GetTLFConversationsLocal(context.Context, GetTLFConversationsLocalArg) (GetTLFConversationsLocalRes, error)
 	SetAppNotificationSettingsLocal(context.Context, SetAppNotificationSettingsLocalArg) (SetAppNotificationSettingsLocalRes, error)
+	SetGlobalAppNotificationSettingsLocal(context.Context, GlobalAppNotificationSettings) error
 	UnboxMobilePushNotification(context.Context, UnboxMobilePushNotificationArg) (string, error)
 }
 
@@ -4219,6 +4230,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"setGlobalAppNotificationSettingsLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]SetGlobalAppNotificationSettingsLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SetGlobalAppNotificationSettingsLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SetGlobalAppNotificationSettingsLocalArg)(nil), args)
+						return
+					}
+					err = i.SetGlobalAppNotificationSettingsLocal(ctx, (*typedArgs)[0].Settings)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"unboxMobilePushNotification": {
 				MakeArg: func() interface{} {
 					ret := make([]UnboxMobilePushNotificationArg, 1)
@@ -4401,6 +4428,12 @@ func (c LocalClient) GetTLFConversationsLocal(ctx context.Context, __arg GetTLFC
 
 func (c LocalClient) SetAppNotificationSettingsLocal(ctx context.Context, __arg SetAppNotificationSettingsLocalArg) (res SetAppNotificationSettingsLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.setAppNotificationSettingsLocal", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) SetGlobalAppNotificationSettingsLocal(ctx context.Context, settings GlobalAppNotificationSettings) (err error) {
+	__arg := SetGlobalAppNotificationSettingsLocalArg{Settings: settings}
+	err = c.Cli.Call(ctx, "chat.1.local.setGlobalAppNotificationSettingsLocal", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3676,6 +3676,13 @@ func (o SetGlobalAppNotificationSettingsLocalArg) DeepCopy() SetGlobalAppNotific
 	}
 }
 
+type GetGlobalAppNotificationSettingsLocalArg struct {
+}
+
+func (o GetGlobalAppNotificationSettingsLocalArg) DeepCopy() GetGlobalAppNotificationSettingsLocalArg {
+	return GetGlobalAppNotificationSettingsLocalArg{}
+}
+
 type UnboxMobilePushNotificationArg struct {
 	Payload     string                  `codec:"payload" json:"payload"`
 	ConvID      string                  `codec:"convID" json:"convID"`
@@ -3732,6 +3739,7 @@ type LocalInterface interface {
 	GetTLFConversationsLocal(context.Context, GetTLFConversationsLocalArg) (GetTLFConversationsLocalRes, error)
 	SetAppNotificationSettingsLocal(context.Context, SetAppNotificationSettingsLocalArg) (SetAppNotificationSettingsLocalRes, error)
 	SetGlobalAppNotificationSettingsLocal(context.Context, GlobalAppNotificationSettings) error
+	GetGlobalAppNotificationSettingsLocal(context.Context) (GlobalAppNotificationSettings, error)
 	UnboxMobilePushNotification(context.Context, UnboxMobilePushNotificationArg) (string, error)
 }
 
@@ -4246,6 +4254,17 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"getGlobalAppNotificationSettingsLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]GetGlobalAppNotificationSettingsLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.GetGlobalAppNotificationSettingsLocal(ctx)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"unboxMobilePushNotification": {
 				MakeArg: func() interface{} {
 					ret := make([]UnboxMobilePushNotificationArg, 1)
@@ -4434,6 +4453,11 @@ func (c LocalClient) SetAppNotificationSettingsLocal(ctx context.Context, __arg 
 func (c LocalClient) SetGlobalAppNotificationSettingsLocal(ctx context.Context, settings GlobalAppNotificationSettings) (err error) {
 	__arg := SetGlobalAppNotificationSettingsLocalArg{Settings: settings}
 	err = c.Cli.Call(ctx, "chat.1.local.setGlobalAppNotificationSettingsLocal", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) GetGlobalAppNotificationSettingsLocal(ctx context.Context) (res GlobalAppNotificationSettings, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.getGlobalAppNotificationSettingsLocal", []interface{}{GetGlobalAppNotificationSettingsLocalArg{}}, &res)
 	return
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -4,65 +4,64 @@
 package chat1
 
 import (
-	"errors"
-	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
+	gregor1 "github.com/keybase/client/go/protocol/gregor1"
+	"errors"
 )
 
+
 type MessageBoxed struct {
-	Version          MessageBoxedVersion  `codec:"version" json:"version"`
-	ServerHeader     *MessageServerHeader `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
-	ClientHeader     MessageClientHeader  `codec:"clientHeader" json:"clientHeader"`
-	HeaderCiphertext SealedData           `codec:"headerCiphertext" json:"headerCiphertext"`
-	BodyCiphertext   EncryptedData        `codec:"bodyCiphertext" json:"bodyCiphertext"`
-	VerifyKey        []byte               `codec:"verifyKey" json:"verifyKey"`
-	KeyGeneration    int                  `codec:"keyGeneration" json:"keyGeneration"`
+	Version	MessageBoxedVersion	`codec:"version" json:"version"`
+	ServerHeader	*MessageServerHeader	`codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
+	ClientHeader	MessageClientHeader	`codec:"clientHeader" json:"clientHeader"`
+	HeaderCiphertext	SealedData	`codec:"headerCiphertext" json:"headerCiphertext"`
+	BodyCiphertext	EncryptedData	`codec:"bodyCiphertext" json:"bodyCiphertext"`
+	VerifyKey	[]byte	`codec:"verifyKey" json:"verifyKey"`
+	KeyGeneration	int	`codec:"keyGeneration" json:"keyGeneration"`
 }
 
 func (o MessageBoxed) DeepCopy() MessageBoxed {
 	return MessageBoxed{
-		Version: o.Version.DeepCopy(),
-		ServerHeader: (func(x *MessageServerHeader) *MessageServerHeader {
+		Version : o.Version.DeepCopy(),
+		ServerHeader : (func (x *MessageServerHeader) *MessageServerHeader {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.ServerHeader),
-		ClientHeader:     o.ClientHeader.DeepCopy(),
-		HeaderCiphertext: o.HeaderCiphertext.DeepCopy(),
-		BodyCiphertext:   o.BodyCiphertext.DeepCopy(),
-		VerifyKey: (func(x []byte) []byte {
+		ClientHeader : o.ClientHeader.DeepCopy(),
+		HeaderCiphertext : o.HeaderCiphertext.DeepCopy(),
+		BodyCiphertext : o.BodyCiphertext.DeepCopy(),
+		VerifyKey : (func (x []byte) []byte {
 			if x == nil {
 				return nil
 			}
 			return append([]byte(nil), x...)
 		})(o.VerifyKey),
-		KeyGeneration: o.KeyGeneration,
+		KeyGeneration : o.KeyGeneration,
 	}
 }
 
 type MessageBoxedVersion int
-
 const (
 	MessageBoxedVersion_VNONE MessageBoxedVersion = 0
-	MessageBoxedVersion_V1    MessageBoxedVersion = 1
-	MessageBoxedVersion_V2    MessageBoxedVersion = 2
+	MessageBoxedVersion_V1 MessageBoxedVersion = 1
+	MessageBoxedVersion_V2 MessageBoxedVersion = 2
 )
 
 func (o MessageBoxedVersion) DeepCopy() MessageBoxedVersion { return o }
-
 var MessageBoxedVersionMap = map[string]MessageBoxedVersion{
-	"VNONE": 0,
-	"V1":    1,
-	"V2":    2,
+	"VNONE" : 0,
+	"V1" : 1,
+	"V2" : 2,
 }
 
 var MessageBoxedVersionRevMap = map[MessageBoxedVersion]string{
-	0: "VNONE",
-	1: "V1",
-	2: "V2",
+	0 : "VNONE",
+	1 : "V1",
+	2 : "V2",
 }
 
 func (e MessageBoxedVersion) String() string {
@@ -73,13 +72,13 @@ func (e MessageBoxedVersion) String() string {
 }
 
 type ThreadViewBoxed struct {
-	Messages   []MessageBoxed `codec:"messages" json:"messages"`
-	Pagination *Pagination    `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	Messages	[]MessageBoxed	`codec:"messages" json:"messages"`
+	Pagination	*Pagination	`codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 func (o ThreadViewBoxed) DeepCopy() ThreadViewBoxed {
 	return ThreadViewBoxed{
-		Messages: (func(x []MessageBoxed) []MessageBoxed {
+		Messages : (func (x []MessageBoxed) []MessageBoxed {
 			var ret []MessageBoxed
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -87,7 +86,7 @@ func (o ThreadViewBoxed) DeepCopy() ThreadViewBoxed {
 			}
 			return ret
 		})(o.Messages),
-		Pagination: (func(x *Pagination) *Pagination {
+		Pagination : (func (x *Pagination) *Pagination {
 			if x == nil {
 				return nil
 			}
@@ -98,14 +97,14 @@ func (o ThreadViewBoxed) DeepCopy() ThreadViewBoxed {
 }
 
 type GetInboxRemoteRes struct {
-	Inbox     InboxView  `codec:"inbox" json:"inbox"`
-	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Inbox	InboxView	`codec:"inbox" json:"inbox"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetInboxRemoteRes) DeepCopy() GetInboxRemoteRes {
 	return GetInboxRemoteRes{
-		Inbox: o.Inbox.DeepCopy(),
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		Inbox : o.Inbox.DeepCopy(),
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -116,13 +115,13 @@ func (o GetInboxRemoteRes) DeepCopy() GetInboxRemoteRes {
 }
 
 type GetInboxByTLFIDRemoteRes struct {
-	Convs     []Conversation `codec:"convs" json:"convs"`
-	RateLimit *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Convs	[]Conversation	`codec:"convs" json:"convs"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetInboxByTLFIDRemoteRes) DeepCopy() GetInboxByTLFIDRemoteRes {
 	return GetInboxByTLFIDRemoteRes{
-		Convs: (func(x []Conversation) []Conversation {
+		Convs : (func (x []Conversation) []Conversation {
 			var ret []Conversation
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -130,7 +129,7 @@ func (o GetInboxByTLFIDRemoteRes) DeepCopy() GetInboxByTLFIDRemoteRes {
 			}
 			return ret
 		})(o.Convs),
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -141,14 +140,14 @@ func (o GetInboxByTLFIDRemoteRes) DeepCopy() GetInboxByTLFIDRemoteRes {
 }
 
 type GetThreadRemoteRes struct {
-	Thread    ThreadViewBoxed `codec:"thread" json:"thread"`
-	RateLimit *RateLimit      `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Thread	ThreadViewBoxed	`codec:"thread" json:"thread"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetThreadRemoteRes) DeepCopy() GetThreadRemoteRes {
 	return GetThreadRemoteRes{
-		Thread: o.Thread.DeepCopy(),
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		Thread : o.Thread.DeepCopy(),
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -159,14 +158,14 @@ func (o GetThreadRemoteRes) DeepCopy() GetThreadRemoteRes {
 }
 
 type GetConversationMetadataRemoteRes struct {
-	Conv      Conversation `codec:"conv" json:"conv"`
-	RateLimit *RateLimit   `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Conv	Conversation	`codec:"conv" json:"conv"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetConversationMetadataRemoteRes) DeepCopy() GetConversationMetadataRemoteRes {
 	return GetConversationMetadataRemoteRes{
-		Conv: o.Conv.DeepCopy(),
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		Conv : o.Conv.DeepCopy(),
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -177,14 +176,14 @@ func (o GetConversationMetadataRemoteRes) DeepCopy() GetConversationMetadataRemo
 }
 
 type PostRemoteRes struct {
-	MsgHeader MessageServerHeader `codec:"msgHeader" json:"msgHeader"`
-	RateLimit *RateLimit          `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	MsgHeader	MessageServerHeader	`codec:"msgHeader" json:"msgHeader"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o PostRemoteRes) DeepCopy() PostRemoteRes {
 	return PostRemoteRes{
-		MsgHeader: o.MsgHeader.DeepCopy(),
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		MsgHeader : o.MsgHeader.DeepCopy(),
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -195,14 +194,14 @@ func (o PostRemoteRes) DeepCopy() PostRemoteRes {
 }
 
 type NewConversationRemoteRes struct {
-	ConvID    ConversationID `codec:"convID" json:"convID"`
-	RateLimit *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	ConvID	ConversationID	`codec:"convID" json:"convID"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o NewConversationRemoteRes) DeepCopy() NewConversationRemoteRes {
 	return NewConversationRemoteRes{
-		ConvID: o.ConvID.DeepCopy(),
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		ConvID : o.ConvID.DeepCopy(),
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -213,13 +212,13 @@ func (o NewConversationRemoteRes) DeepCopy() NewConversationRemoteRes {
 }
 
 type GetMessagesRemoteRes struct {
-	Msgs      []MessageBoxed `codec:"msgs" json:"msgs"`
-	RateLimit *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Msgs	[]MessageBoxed	`codec:"msgs" json:"msgs"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetMessagesRemoteRes) DeepCopy() GetMessagesRemoteRes {
 	return GetMessagesRemoteRes{
-		Msgs: (func(x []MessageBoxed) []MessageBoxed {
+		Msgs : (func (x []MessageBoxed) []MessageBoxed {
 			var ret []MessageBoxed
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -227,7 +226,7 @@ func (o GetMessagesRemoteRes) DeepCopy() GetMessagesRemoteRes {
 			}
 			return ret
 		})(o.Msgs),
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -238,12 +237,12 @@ func (o GetMessagesRemoteRes) DeepCopy() GetMessagesRemoteRes {
 }
 
 type MarkAsReadRes struct {
-	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o MarkAsReadRes) DeepCopy() MarkAsReadRes {
 	return MarkAsReadRes{
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -254,12 +253,12 @@ func (o MarkAsReadRes) DeepCopy() MarkAsReadRes {
 }
 
 type SetConversationStatusRes struct {
-	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o SetConversationStatusRes) DeepCopy() SetConversationStatusRes {
 	return SetConversationStatusRes{
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -270,13 +269,13 @@ func (o SetConversationStatusRes) DeepCopy() SetConversationStatusRes {
 }
 
 type GetPublicConversationsRes struct {
-	Conversations []Conversation `codec:"conversations" json:"conversations"`
-	RateLimit     *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Conversations	[]Conversation	`codec:"conversations" json:"conversations"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetPublicConversationsRes) DeepCopy() GetPublicConversationsRes {
 	return GetPublicConversationsRes{
-		Conversations: (func(x []Conversation) []Conversation {
+		Conversations : (func (x []Conversation) []Conversation {
 			var ret []Conversation
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -284,7 +283,7 @@ func (o GetPublicConversationsRes) DeepCopy() GetPublicConversationsRes {
 			}
 			return ret
 		})(o.Conversations),
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -295,25 +294,23 @@ func (o GetPublicConversationsRes) DeepCopy() GetPublicConversationsRes {
 }
 
 type ChannelMention int
-
 const (
 	ChannelMention_NONE ChannelMention = 0
-	ChannelMention_ALL  ChannelMention = 1
+	ChannelMention_ALL ChannelMention = 1
 	ChannelMention_HERE ChannelMention = 2
 )
 
 func (o ChannelMention) DeepCopy() ChannelMention { return o }
-
 var ChannelMentionMap = map[string]ChannelMention{
-	"NONE": 0,
-	"ALL":  1,
-	"HERE": 2,
+	"NONE" : 0,
+	"ALL" : 1,
+	"HERE" : 2,
 }
 
 var ChannelMentionRevMap = map[ChannelMention]string{
-	0: "NONE",
-	1: "ALL",
-	2: "HERE",
+	0 : "NONE",
+	1 : "ALL",
+	2 : "HERE",
 }
 
 func (e ChannelMention) String() string {
@@ -324,16 +321,16 @@ func (e ChannelMention) String() string {
 }
 
 type UnreadUpdateFull struct {
-	Ignore    bool           `codec:"ignore" json:"ignore"`
-	InboxVers InboxVers      `codec:"inboxVers" json:"inboxVers"`
-	Updates   []UnreadUpdate `codec:"updates" json:"updates"`
+	Ignore	bool	`codec:"ignore" json:"ignore"`
+	InboxVers	InboxVers	`codec:"inboxVers" json:"inboxVers"`
+	Updates	[]UnreadUpdate	`codec:"updates" json:"updates"`
 }
 
 func (o UnreadUpdateFull) DeepCopy() UnreadUpdateFull {
 	return UnreadUpdateFull{
-		Ignore:    o.Ignore,
-		InboxVers: o.InboxVers.DeepCopy(),
-		Updates: (func(x []UnreadUpdate) []UnreadUpdate {
+		Ignore : o.Ignore,
+		InboxVers : o.InboxVers.DeepCopy(),
+		Updates : (func (x []UnreadUpdate) []UnreadUpdate {
 			var ret []UnreadUpdate
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -345,47 +342,45 @@ func (o UnreadUpdateFull) DeepCopy() UnreadUpdateFull {
 }
 
 type S3Params struct {
-	Bucket               string `codec:"bucket" json:"bucket"`
-	ObjectKey            string `codec:"objectKey" json:"objectKey"`
-	AccessKey            string `codec:"accessKey" json:"accessKey"`
-	Acl                  string `codec:"acl" json:"acl"`
-	RegionName           string `codec:"regionName" json:"regionName"`
-	RegionEndpoint       string `codec:"regionEndpoint" json:"regionEndpoint"`
-	RegionBucketEndpoint string `codec:"regionBucketEndpoint" json:"regionBucketEndpoint"`
+	Bucket	string	`codec:"bucket" json:"bucket"`
+	ObjectKey	string	`codec:"objectKey" json:"objectKey"`
+	AccessKey	string	`codec:"accessKey" json:"accessKey"`
+	Acl	string	`codec:"acl" json:"acl"`
+	RegionName	string	`codec:"regionName" json:"regionName"`
+	RegionEndpoint	string	`codec:"regionEndpoint" json:"regionEndpoint"`
+	RegionBucketEndpoint	string	`codec:"regionBucketEndpoint" json:"regionBucketEndpoint"`
 }
 
 func (o S3Params) DeepCopy() S3Params {
 	return S3Params{
-		Bucket:               o.Bucket,
-		ObjectKey:            o.ObjectKey,
-		AccessKey:            o.AccessKey,
-		Acl:                  o.Acl,
-		RegionName:           o.RegionName,
-		RegionEndpoint:       o.RegionEndpoint,
-		RegionBucketEndpoint: o.RegionBucketEndpoint,
+		Bucket : o.Bucket,
+		ObjectKey : o.ObjectKey,
+		AccessKey : o.AccessKey,
+		Acl : o.Acl,
+		RegionName : o.RegionName,
+		RegionEndpoint : o.RegionEndpoint,
+		RegionBucketEndpoint : o.RegionBucketEndpoint,
 	}
 }
 
 type SyncInboxResType int
-
 const (
-	SyncInboxResType_CURRENT     SyncInboxResType = 0
+	SyncInboxResType_CURRENT SyncInboxResType = 0
 	SyncInboxResType_INCREMENTAL SyncInboxResType = 1
-	SyncInboxResType_CLEAR       SyncInboxResType = 2
+	SyncInboxResType_CLEAR SyncInboxResType = 2
 )
 
 func (o SyncInboxResType) DeepCopy() SyncInboxResType { return o }
-
 var SyncInboxResTypeMap = map[string]SyncInboxResType{
-	"CURRENT":     0,
-	"INCREMENTAL": 1,
-	"CLEAR":       2,
+	"CURRENT" : 0,
+	"INCREMENTAL" : 1,
+	"CLEAR" : 2,
 }
 
 var SyncInboxResTypeRevMap = map[SyncInboxResType]string{
-	0: "CURRENT",
-	1: "INCREMENTAL",
-	2: "CLEAR",
+	0 : "CURRENT",
+	1 : "INCREMENTAL",
+	2 : "CLEAR",
 }
 
 func (e SyncInboxResType) String() string {
@@ -396,14 +391,14 @@ func (e SyncInboxResType) String() string {
 }
 
 type SyncIncrementalRes struct {
-	Vers  InboxVers      `codec:"vers" json:"vers"`
-	Convs []Conversation `codec:"convs" json:"convs"`
+	Vers	InboxVers	`codec:"vers" json:"vers"`
+	Convs	[]Conversation	`codec:"convs" json:"convs"`
 }
 
 func (o SyncIncrementalRes) DeepCopy() SyncIncrementalRes {
 	return SyncIncrementalRes{
-		Vers: o.Vers.DeepCopy(),
-		Convs: (func(x []Conversation) []Conversation {
+		Vers : o.Vers.DeepCopy(),
+		Convs : (func (x []Conversation) []Conversation {
 			var ret []Conversation
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -415,29 +410,29 @@ func (o SyncIncrementalRes) DeepCopy() SyncIncrementalRes {
 }
 
 type ServerCacheVers struct {
-	InboxVers  int `codec:"inboxVers" json:"inboxVers"`
-	BodiesVers int `codec:"bodiesVers" json:"bodiesVers"`
+	InboxVers	int	`codec:"inboxVers" json:"inboxVers"`
+	BodiesVers	int	`codec:"bodiesVers" json:"bodiesVers"`
 }
 
 func (o ServerCacheVers) DeepCopy() ServerCacheVers {
 	return ServerCacheVers{
-		InboxVers:  o.InboxVers,
-		BodiesVers: o.BodiesVers,
+		InboxVers : o.InboxVers,
+		BodiesVers : o.BodiesVers,
 	}
 }
 
 type SyncInboxRes struct {
-	Typ__         SyncInboxResType    `codec:"typ" json:"typ"`
-	Incremental__ *SyncIncrementalRes `codec:"incremental,omitempty" json:"incremental,omitempty"`
+	Typ__	SyncInboxResType	`codec:"typ" json:"typ"`
+	Incremental__	*SyncIncrementalRes	`codec:"incremental,omitempty" json:"incremental,omitempty"`
 }
 
 func (o *SyncInboxRes) Typ() (ret SyncInboxResType, err error) {
-	switch o.Typ__ {
-	case SyncInboxResType_INCREMENTAL:
-		if o.Incremental__ == nil {
-			err = errors.New("unexpected nil value for Incremental__")
-			return ret, err
-		}
+	switch (o.Typ__) {
+		case SyncInboxResType_INCREMENTAL:
+			if o.Incremental__ == nil {
+				err = errors.New("unexpected nil value for Incremental__")
+				return ret, err
+			}
 	}
 	return o.Typ__, nil
 }
@@ -454,27 +449,27 @@ func (o SyncInboxRes) Incremental() (res SyncIncrementalRes) {
 
 func NewSyncInboxResWithCurrent() SyncInboxRes {
 	return SyncInboxRes{
-		Typ__: SyncInboxResType_CURRENT,
+		Typ__ : SyncInboxResType_CURRENT,
 	}
 }
 
 func NewSyncInboxResWithIncremental(v SyncIncrementalRes) SyncInboxRes {
 	return SyncInboxRes{
-		Typ__:         SyncInboxResType_INCREMENTAL,
-		Incremental__: &v,
+		Typ__ : SyncInboxResType_INCREMENTAL,
+		Incremental__ : &v,
 	}
 }
 
 func NewSyncInboxResWithClear() SyncInboxRes {
 	return SyncInboxRes{
-		Typ__: SyncInboxResType_CLEAR,
+		Typ__ : SyncInboxResType_CLEAR,
 	}
 }
 
 func (o SyncInboxRes) DeepCopy() SyncInboxRes {
-	return SyncInboxRes{
-		Typ__: o.Typ__.DeepCopy(),
-		Incremental__: (func(x *SyncIncrementalRes) *SyncIncrementalRes {
+	return SyncInboxRes {
+		Typ__ : o.Typ__.DeepCopy(),
+		Incremental__ : (func (x *SyncIncrementalRes) *SyncIncrementalRes {
 			if x == nil {
 				return nil
 			}
@@ -485,34 +480,32 @@ func (o SyncInboxRes) DeepCopy() SyncInboxRes {
 }
 
 type SyncChatRes struct {
-	CacheVers ServerCacheVers `codec:"cacheVers" json:"cacheVers"`
-	InboxRes  SyncInboxRes    `codec:"inboxRes" json:"inboxRes"`
+	CacheVers	ServerCacheVers	`codec:"cacheVers" json:"cacheVers"`
+	InboxRes	SyncInboxRes	`codec:"inboxRes" json:"inboxRes"`
 }
 
 func (o SyncChatRes) DeepCopy() SyncChatRes {
 	return SyncChatRes{
-		CacheVers: o.CacheVers.DeepCopy(),
-		InboxRes:  o.InboxRes.DeepCopy(),
+		CacheVers : o.CacheVers.DeepCopy(),
+		InboxRes : o.InboxRes.DeepCopy(),
 	}
 }
 
 type SyncAllNotificationType int
-
 const (
-	SyncAllNotificationType_STATE       SyncAllNotificationType = 0
+	SyncAllNotificationType_STATE SyncAllNotificationType = 0
 	SyncAllNotificationType_INCREMENTAL SyncAllNotificationType = 1
 )
 
 func (o SyncAllNotificationType) DeepCopy() SyncAllNotificationType { return o }
-
 var SyncAllNotificationTypeMap = map[string]SyncAllNotificationType{
-	"STATE":       0,
-	"INCREMENTAL": 1,
+	"STATE" : 0,
+	"INCREMENTAL" : 1,
 }
 
 var SyncAllNotificationTypeRevMap = map[SyncAllNotificationType]string{
-	0: "STATE",
-	1: "INCREMENTAL",
+	0 : "STATE",
+	1 : "INCREMENTAL",
 }
 
 func (e SyncAllNotificationType) String() string {
@@ -523,23 +516,23 @@ func (e SyncAllNotificationType) String() string {
 }
 
 type SyncAllNotificationRes struct {
-	Typ__         SyncAllNotificationType `codec:"typ" json:"typ"`
-	State__       *gregor1.State          `codec:"state,omitempty" json:"state,omitempty"`
-	Incremental__ *gregor1.SyncResult     `codec:"incremental,omitempty" json:"incremental,omitempty"`
+	Typ__	SyncAllNotificationType	`codec:"typ" json:"typ"`
+	State__	*gregor1.State	`codec:"state,omitempty" json:"state,omitempty"`
+	Incremental__	*gregor1.SyncResult	`codec:"incremental,omitempty" json:"incremental,omitempty"`
 }
 
 func (o *SyncAllNotificationRes) Typ() (ret SyncAllNotificationType, err error) {
-	switch o.Typ__ {
-	case SyncAllNotificationType_STATE:
-		if o.State__ == nil {
-			err = errors.New("unexpected nil value for State__")
-			return ret, err
-		}
-	case SyncAllNotificationType_INCREMENTAL:
-		if o.Incremental__ == nil {
-			err = errors.New("unexpected nil value for Incremental__")
-			return ret, err
-		}
+	switch (o.Typ__) {
+		case SyncAllNotificationType_STATE:
+			if o.State__ == nil {
+				err = errors.New("unexpected nil value for State__")
+				return ret, err
+			}
+		case SyncAllNotificationType_INCREMENTAL:
+			if o.Incremental__ == nil {
+				err = errors.New("unexpected nil value for Incremental__")
+				return ret, err
+			}
 	}
 	return o.Typ__, nil
 }
@@ -566,29 +559,29 @@ func (o SyncAllNotificationRes) Incremental() (res gregor1.SyncResult) {
 
 func NewSyncAllNotificationResWithState(v gregor1.State) SyncAllNotificationRes {
 	return SyncAllNotificationRes{
-		Typ__:   SyncAllNotificationType_STATE,
-		State__: &v,
+		Typ__ : SyncAllNotificationType_STATE,
+		State__ : &v,
 	}
 }
 
 func NewSyncAllNotificationResWithIncremental(v gregor1.SyncResult) SyncAllNotificationRes {
 	return SyncAllNotificationRes{
-		Typ__:         SyncAllNotificationType_INCREMENTAL,
-		Incremental__: &v,
+		Typ__ : SyncAllNotificationType_INCREMENTAL,
+		Incremental__ : &v,
 	}
 }
 
 func (o SyncAllNotificationRes) DeepCopy() SyncAllNotificationRes {
-	return SyncAllNotificationRes{
-		Typ__: o.Typ__.DeepCopy(),
-		State__: (func(x *gregor1.State) *gregor1.State {
+	return SyncAllNotificationRes {
+		Typ__ : o.Typ__.DeepCopy(),
+		State__ : (func (x *gregor1.State) *gregor1.State {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.State__),
-		Incremental__: (func(x *gregor1.SyncResult) *gregor1.SyncResult {
+		Incremental__ : (func (x *gregor1.SyncResult) *gregor1.SyncResult {
 			if x == nil {
 				return nil
 			}
@@ -599,28 +592,28 @@ func (o SyncAllNotificationRes) DeepCopy() SyncAllNotificationRes {
 }
 
 type SyncAllResult struct {
-	Auth         gregor1.AuthResult     `codec:"auth" json:"auth"`
-	Chat         SyncChatRes            `codec:"chat" json:"chat"`
-	Notification SyncAllNotificationRes `codec:"notification" json:"notification"`
-	Badge        UnreadUpdateFull       `codec:"badge" json:"badge"`
+	Auth	gregor1.AuthResult	`codec:"auth" json:"auth"`
+	Chat	SyncChatRes	`codec:"chat" json:"chat"`
+	Notification	SyncAllNotificationRes	`codec:"notification" json:"notification"`
+	Badge	UnreadUpdateFull	`codec:"badge" json:"badge"`
 }
 
 func (o SyncAllResult) DeepCopy() SyncAllResult {
 	return SyncAllResult{
-		Auth:         o.Auth.DeepCopy(),
-		Chat:         o.Chat.DeepCopy(),
-		Notification: o.Notification.DeepCopy(),
-		Badge:        o.Badge.DeepCopy(),
+		Auth : o.Auth.DeepCopy(),
+		Chat : o.Chat.DeepCopy(),
+		Notification : o.Notification.DeepCopy(),
+		Badge : o.Badge.DeepCopy(),
 	}
 }
 
 type JoinLeaveConversationRemoteRes struct {
-	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o JoinLeaveConversationRemoteRes) DeepCopy() JoinLeaveConversationRemoteRes {
 	return JoinLeaveConversationRemoteRes{
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -631,13 +624,13 @@ func (o JoinLeaveConversationRemoteRes) DeepCopy() JoinLeaveConversationRemoteRe
 }
 
 type GetTLFConversationsRes struct {
-	Conversations []Conversation `codec:"conversations" json:"conversations"`
-	RateLimit     *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Conversations	[]Conversation	`codec:"conversations" json:"conversations"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetTLFConversationsRes) DeepCopy() GetTLFConversationsRes {
 	return GetTLFConversationsRes{
-		Conversations: (func(x []Conversation) []Conversation {
+		Conversations : (func (x []Conversation) []Conversation {
 			var ret []Conversation
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -645,7 +638,7 @@ func (o GetTLFConversationsRes) DeepCopy() GetTLFConversationsRes {
 			}
 			return ret
 		})(o.Conversations),
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -656,12 +649,12 @@ func (o GetTLFConversationsRes) DeepCopy() GetTLFConversationsRes {
 }
 
 type SetAppNotificationSettingsRes struct {
-	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o SetAppNotificationSettingsRes) DeepCopy() SetAppNotificationSettingsRes {
 	return SetAppNotificationSettingsRes{
-		RateLimit: (func(x *RateLimit) *RateLimit {
+		RateLimit : (func (x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -671,23 +664,55 @@ func (o SetAppNotificationSettingsRes) DeepCopy() SetAppNotificationSettingsRes 
 	}
 }
 
+type GlobalAppNotificationSetting int
+const (
+	GlobalAppNotificationSetting_NEWMESSAGES GlobalAppNotificationSetting = 0
+	GlobalAppNotificationSetting_PLAINTEXTMOBILE GlobalAppNotificationSetting = 1
+	GlobalAppNotificationSetting_PLAINTEXTDESKTOP GlobalAppNotificationSetting = 2
+)
+
+func (o GlobalAppNotificationSetting) DeepCopy() GlobalAppNotificationSetting { return o }
+var GlobalAppNotificationSettingMap = map[string]GlobalAppNotificationSetting{
+	"NEWMESSAGES" : 0,
+	"PLAINTEXTMOBILE" : 1,
+	"PLAINTEXTDESKTOP" : 2,
+}
+
+var GlobalAppNotificationSettingRevMap = map[GlobalAppNotificationSetting]string{
+	0 : "NEWMESSAGES",
+	1 : "PLAINTEXTMOBILE",
+	2 : "PLAINTEXTDESKTOP",
+}
+
+func (e GlobalAppNotificationSetting) String() string {
+	if v, ok := GlobalAppNotificationSettingRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type GlobalAppNotificationSettings map<GlobalAppNotificationSetting, bool>
+func (o GlobalAppNotificationSettings) DeepCopy() GlobalAppNotificationSettings {
+	return o.DeepCopy()
+}
+
 type GetInboxRemoteArg struct {
-	Vers       InboxVers      `codec:"vers" json:"vers"`
-	Query      *GetInboxQuery `codec:"query,omitempty" json:"query,omitempty"`
-	Pagination *Pagination    `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	Vers	InboxVers	`codec:"vers" json:"vers"`
+	Query	*GetInboxQuery	`codec:"query,omitempty" json:"query,omitempty"`
+	Pagination	*Pagination	`codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 func (o GetInboxRemoteArg) DeepCopy() GetInboxRemoteArg {
 	return GetInboxRemoteArg{
-		Vers: o.Vers.DeepCopy(),
-		Query: (func(x *GetInboxQuery) *GetInboxQuery {
+		Vers : o.Vers.DeepCopy(),
+		Query : (func (x *GetInboxQuery) *GetInboxQuery {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Query),
-		Pagination: (func(x *Pagination) *Pagination {
+		Pagination : (func (x *Pagination) *Pagination {
 			if x == nil {
 				return nil
 			}
@@ -698,22 +723,22 @@ func (o GetInboxRemoteArg) DeepCopy() GetInboxRemoteArg {
 }
 
 type GetThreadRemoteArg struct {
-	ConversationID ConversationID  `codec:"conversationID" json:"conversationID"`
-	Query          *GetThreadQuery `codec:"query,omitempty" json:"query,omitempty"`
-	Pagination     *Pagination     `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
+	Query	*GetThreadQuery	`codec:"query,omitempty" json:"query,omitempty"`
+	Pagination	*Pagination	`codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 func (o GetThreadRemoteArg) DeepCopy() GetThreadRemoteArg {
 	return GetThreadRemoteArg{
-		ConversationID: o.ConversationID.DeepCopy(),
-		Query: (func(x *GetThreadQuery) *GetThreadQuery {
+		ConversationID : o.ConversationID.DeepCopy(),
+		Query : (func (x *GetThreadQuery) *GetThreadQuery {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Query),
-		Pagination: (func(x *Pagination) *Pagination {
+		Pagination : (func (x *Pagination) *Pagination {
 			if x == nil {
 				return nil
 			}
@@ -724,32 +749,32 @@ func (o GetThreadRemoteArg) DeepCopy() GetThreadRemoteArg {
 }
 
 type GetPublicConversationsArg struct {
-	TlfID            TLFID     `codec:"tlfID" json:"tlfID"`
-	TopicType        TopicType `codec:"topicType" json:"topicType"`
-	SummarizeMaxMsgs bool      `codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
+	TlfID	TLFID	`codec:"tlfID" json:"tlfID"`
+	TopicType	TopicType	`codec:"topicType" json:"topicType"`
+	SummarizeMaxMsgs	bool	`codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
 }
 
 func (o GetPublicConversationsArg) DeepCopy() GetPublicConversationsArg {
 	return GetPublicConversationsArg{
-		TlfID:            o.TlfID.DeepCopy(),
-		TopicType:        o.TopicType.DeepCopy(),
-		SummarizeMaxMsgs: o.SummarizeMaxMsgs,
+		TlfID : o.TlfID.DeepCopy(),
+		TopicType : o.TopicType.DeepCopy(),
+		SummarizeMaxMsgs : o.SummarizeMaxMsgs,
 	}
 }
 
 type PostRemoteArg struct {
-	ConversationID ConversationID  `codec:"conversationID" json:"conversationID"`
-	MessageBoxed   MessageBoxed    `codec:"messageBoxed" json:"messageBoxed"`
-	AtMentions     []gregor1.UID   `codec:"atMentions" json:"atMentions"`
-	ChannelMention ChannelMention  `codec:"channelMention" json:"channelMention"`
-	TopicNameState *TopicNameState `codec:"topicNameState,omitempty" json:"topicNameState,omitempty"`
+	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
+	MessageBoxed	MessageBoxed	`codec:"messageBoxed" json:"messageBoxed"`
+	AtMentions	[]gregor1.UID	`codec:"atMentions" json:"atMentions"`
+	ChannelMention	ChannelMention	`codec:"channelMention" json:"channelMention"`
+	TopicNameState	*TopicNameState	`codec:"topicNameState,omitempty" json:"topicNameState,omitempty"`
 }
 
 func (o PostRemoteArg) DeepCopy() PostRemoteArg {
 	return PostRemoteArg{
-		ConversationID: o.ConversationID.DeepCopy(),
-		MessageBoxed:   o.MessageBoxed.DeepCopy(),
-		AtMentions: (func(x []gregor1.UID) []gregor1.UID {
+		ConversationID : o.ConversationID.DeepCopy(),
+		MessageBoxed : o.MessageBoxed.DeepCopy(),
+		AtMentions : (func (x []gregor1.UID) []gregor1.UID {
 			var ret []gregor1.UID
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -757,8 +782,8 @@ func (o PostRemoteArg) DeepCopy() PostRemoteArg {
 			}
 			return ret
 		})(o.AtMentions),
-		ChannelMention: o.ChannelMention.DeepCopy(),
-		TopicNameState: (func(x *TopicNameState) *TopicNameState {
+		ChannelMention : o.ChannelMention.DeepCopy(),
+		TopicNameState : (func (x *TopicNameState) *TopicNameState {
 			if x == nil {
 				return nil
 			}
@@ -769,28 +794,28 @@ func (o PostRemoteArg) DeepCopy() PostRemoteArg {
 }
 
 type NewConversationRemoteArg struct {
-	IdTriple ConversationIDTriple `codec:"idTriple" json:"idTriple"`
+	IdTriple	ConversationIDTriple	`codec:"idTriple" json:"idTriple"`
 }
 
 func (o NewConversationRemoteArg) DeepCopy() NewConversationRemoteArg {
 	return NewConversationRemoteArg{
-		IdTriple: o.IdTriple.DeepCopy(),
+		IdTriple : o.IdTriple.DeepCopy(),
 	}
 }
 
 type NewConversationRemote2Arg struct {
-	IdTriple       ConversationIDTriple    `codec:"idTriple" json:"idTriple"`
-	TLFMessage     MessageBoxed            `codec:"TLFMessage" json:"TLFMessage"`
-	MembersType    ConversationMembersType `codec:"membersType" json:"membersType"`
-	TopicNameState *TopicNameState         `codec:"topicNameState,omitempty" json:"topicNameState,omitempty"`
+	IdTriple	ConversationIDTriple	`codec:"idTriple" json:"idTriple"`
+	TLFMessage	MessageBoxed	`codec:"TLFMessage" json:"TLFMessage"`
+	MembersType	ConversationMembersType	`codec:"membersType" json:"membersType"`
+	TopicNameState	*TopicNameState	`codec:"topicNameState,omitempty" json:"topicNameState,omitempty"`
 }
 
 func (o NewConversationRemote2Arg) DeepCopy() NewConversationRemote2Arg {
 	return NewConversationRemote2Arg{
-		IdTriple:    o.IdTriple.DeepCopy(),
-		TLFMessage:  o.TLFMessage.DeepCopy(),
-		MembersType: o.MembersType.DeepCopy(),
-		TopicNameState: (func(x *TopicNameState) *TopicNameState {
+		IdTriple : o.IdTriple.DeepCopy(),
+		TLFMessage : o.TLFMessage.DeepCopy(),
+		MembersType : o.MembersType.DeepCopy(),
+		TopicNameState : (func (x *TopicNameState) *TopicNameState {
 			if x == nil {
 				return nil
 			}
@@ -801,14 +826,14 @@ func (o NewConversationRemote2Arg) DeepCopy() NewConversationRemote2Arg {
 }
 
 type GetMessagesRemoteArg struct {
-	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
-	MessageIDs     []MessageID    `codec:"messageIDs" json:"messageIDs"`
+	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
+	MessageIDs	[]MessageID	`codec:"messageIDs" json:"messageIDs"`
 }
 
 func (o GetMessagesRemoteArg) DeepCopy() GetMessagesRemoteArg {
 	return GetMessagesRemoteArg{
-		ConversationID: o.ConversationID.DeepCopy(),
-		MessageIDs: (func(x []MessageID) []MessageID {
+		ConversationID : o.ConversationID.DeepCopy(),
+		MessageIDs : (func (x []MessageID) []MessageID {
 			var ret []MessageID
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -820,58 +845,58 @@ func (o GetMessagesRemoteArg) DeepCopy() GetMessagesRemoteArg {
 }
 
 type MarkAsReadArg struct {
-	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
-	MsgID          MessageID      `codec:"msgID" json:"msgID"`
+	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
+	MsgID	MessageID	`codec:"msgID" json:"msgID"`
 }
 
 func (o MarkAsReadArg) DeepCopy() MarkAsReadArg {
 	return MarkAsReadArg{
-		ConversationID: o.ConversationID.DeepCopy(),
-		MsgID:          o.MsgID.DeepCopy(),
+		ConversationID : o.ConversationID.DeepCopy(),
+		MsgID : o.MsgID.DeepCopy(),
 	}
 }
 
 type SetConversationStatusArg struct {
-	ConversationID ConversationID     `codec:"conversationID" json:"conversationID"`
-	Status         ConversationStatus `codec:"status" json:"status"`
+	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
+	Status	ConversationStatus	`codec:"status" json:"status"`
 }
 
 func (o SetConversationStatusArg) DeepCopy() SetConversationStatusArg {
 	return SetConversationStatusArg{
-		ConversationID: o.ConversationID.DeepCopy(),
-		Status:         o.Status.DeepCopy(),
+		ConversationID : o.ConversationID.DeepCopy(),
+		Status : o.Status.DeepCopy(),
 	}
 }
 
 type GetUnreadUpdateFullArg struct {
-	InboxVers InboxVers `codec:"inboxVers" json:"inboxVers"`
+	InboxVers	InboxVers	`codec:"inboxVers" json:"inboxVers"`
 }
 
 func (o GetUnreadUpdateFullArg) DeepCopy() GetUnreadUpdateFullArg {
 	return GetUnreadUpdateFullArg{
-		InboxVers: o.InboxVers.DeepCopy(),
+		InboxVers : o.InboxVers.DeepCopy(),
 	}
 }
 
 type GetS3ParamsArg struct {
-	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
+	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
 }
 
 func (o GetS3ParamsArg) DeepCopy() GetS3ParamsArg {
 	return GetS3ParamsArg{
-		ConversationID: o.ConversationID.DeepCopy(),
+		ConversationID : o.ConversationID.DeepCopy(),
 	}
 }
 
 type S3SignArg struct {
-	Version int    `codec:"version" json:"version"`
-	Payload []byte `codec:"payload" json:"payload"`
+	Version	int	`codec:"version" json:"version"`
+	Payload	[]byte	`codec:"payload" json:"payload"`
 }
 
 func (o S3SignArg) DeepCopy() S3SignArg {
 	return S3SignArg{
-		Version: o.Version,
-		Payload: (func(x []byte) []byte {
+		Version : o.Version,
+		Payload : (func (x []byte) []byte {
 			if x == nil {
 				return nil
 			}
@@ -881,83 +906,83 @@ func (o S3SignArg) DeepCopy() S3SignArg {
 }
 
 type GetInboxVersionArg struct {
-	Uid gregor1.UID `codec:"uid" json:"uid"`
+	Uid	gregor1.UID	`codec:"uid" json:"uid"`
 }
 
 func (o GetInboxVersionArg) DeepCopy() GetInboxVersionArg {
 	return GetInboxVersionArg{
-		Uid: o.Uid.DeepCopy(),
+		Uid : o.Uid.DeepCopy(),
 	}
 }
 
 type SyncInboxArg struct {
-	Vers InboxVers `codec:"vers" json:"vers"`
+	Vers	InboxVers	`codec:"vers" json:"vers"`
 }
 
 func (o SyncInboxArg) DeepCopy() SyncInboxArg {
 	return SyncInboxArg{
-		Vers: o.Vers.DeepCopy(),
+		Vers : o.Vers.DeepCopy(),
 	}
 }
 
 type SyncChatArg struct {
-	Vers InboxVers `codec:"vers" json:"vers"`
+	Vers	InboxVers	`codec:"vers" json:"vers"`
 }
 
 func (o SyncChatArg) DeepCopy() SyncChatArg {
 	return SyncChatArg{
-		Vers: o.Vers.DeepCopy(),
+		Vers : o.Vers.DeepCopy(),
 	}
 }
 
 type SyncAllArg struct {
-	Uid       gregor1.UID          `codec:"uid" json:"uid"`
-	DeviceID  gregor1.DeviceID     `codec:"deviceID" json:"deviceID"`
-	Session   gregor1.SessionToken `codec:"session" json:"session"`
-	InboxVers InboxVers            `codec:"inboxVers" json:"inboxVers"`
-	Ctime     gregor1.Time         `codec:"ctime" json:"ctime"`
-	Fresh     bool                 `codec:"fresh" json:"fresh"`
+	Uid	gregor1.UID	`codec:"uid" json:"uid"`
+	DeviceID	gregor1.DeviceID	`codec:"deviceID" json:"deviceID"`
+	Session	gregor1.SessionToken	`codec:"session" json:"session"`
+	InboxVers	InboxVers	`codec:"inboxVers" json:"inboxVers"`
+	Ctime	gregor1.Time	`codec:"ctime" json:"ctime"`
+	Fresh	bool	`codec:"fresh" json:"fresh"`
 }
 
 func (o SyncAllArg) DeepCopy() SyncAllArg {
 	return SyncAllArg{
-		Uid:       o.Uid.DeepCopy(),
-		DeviceID:  o.DeviceID.DeepCopy(),
-		Session:   o.Session.DeepCopy(),
-		InboxVers: o.InboxVers.DeepCopy(),
-		Ctime:     o.Ctime.DeepCopy(),
-		Fresh:     o.Fresh,
+		Uid : o.Uid.DeepCopy(),
+		DeviceID : o.DeviceID.DeepCopy(),
+		Session : o.Session.DeepCopy(),
+		InboxVers : o.InboxVers.DeepCopy(),
+		Ctime : o.Ctime.DeepCopy(),
+		Fresh : o.Fresh,
 	}
 }
 
 type TlfFinalizeArg struct {
-	TlfID          TLFID        `codec:"tlfID" json:"tlfID"`
-	ResetUser      string       `codec:"resetUser" json:"resetUser"`
-	ResetDate      string       `codec:"resetDate" json:"resetDate"`
-	ResetTimestamp gregor1.Time `codec:"resetTimestamp" json:"resetTimestamp"`
-	ResetFull      string       `codec:"resetFull" json:"resetFull"`
+	TlfID	TLFID	`codec:"tlfID" json:"tlfID"`
+	ResetUser	string	`codec:"resetUser" json:"resetUser"`
+	ResetDate	string	`codec:"resetDate" json:"resetDate"`
+	ResetTimestamp	gregor1.Time	`codec:"resetTimestamp" json:"resetTimestamp"`
+	ResetFull	string	`codec:"resetFull" json:"resetFull"`
 }
 
 func (o TlfFinalizeArg) DeepCopy() TlfFinalizeArg {
 	return TlfFinalizeArg{
-		TlfID:          o.TlfID.DeepCopy(),
-		ResetUser:      o.ResetUser,
-		ResetDate:      o.ResetDate,
-		ResetTimestamp: o.ResetTimestamp.DeepCopy(),
-		ResetFull:      o.ResetFull,
+		TlfID : o.TlfID.DeepCopy(),
+		ResetUser : o.ResetUser,
+		ResetDate : o.ResetDate,
+		ResetTimestamp : o.ResetTimestamp.DeepCopy(),
+		ResetFull : o.ResetFull,
 	}
 }
 
 type TlfResolveArg struct {
-	TlfID           TLFID         `codec:"tlfID" json:"tlfID"`
-	ResolvedWriters []gregor1.UID `codec:"resolvedWriters" json:"resolvedWriters"`
-	ResolvedReaders []gregor1.UID `codec:"resolvedReaders" json:"resolvedReaders"`
+	TlfID	TLFID	`codec:"tlfID" json:"tlfID"`
+	ResolvedWriters	[]gregor1.UID	`codec:"resolvedWriters" json:"resolvedWriters"`
+	ResolvedReaders	[]gregor1.UID	`codec:"resolvedReaders" json:"resolvedReaders"`
 }
 
 func (o TlfResolveArg) DeepCopy() TlfResolveArg {
 	return TlfResolveArg{
-		TlfID: o.TlfID.DeepCopy(),
-		ResolvedWriters: (func(x []gregor1.UID) []gregor1.UID {
+		TlfID : o.TlfID.DeepCopy(),
+		ResolvedWriters : (func (x []gregor1.UID) []gregor1.UID {
 			var ret []gregor1.UID
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -965,7 +990,7 @@ func (o TlfResolveArg) DeepCopy() TlfResolveArg {
 			}
 			return ret
 		})(o.ResolvedWriters),
-		ResolvedReaders: (func(x []gregor1.UID) []gregor1.UID {
+		ResolvedReaders : (func (x []gregor1.UID) []gregor1.UID {
 			var ret []gregor1.UID
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -977,108 +1002,126 @@ func (o TlfResolveArg) DeepCopy() TlfResolveArg {
 }
 
 type PublishReadMessageArg struct {
-	Uid    gregor1.UID    `codec:"uid" json:"uid"`
-	ConvID ConversationID `codec:"convID" json:"convID"`
-	MsgID  MessageID      `codec:"msgID" json:"msgID"`
+	Uid	gregor1.UID	`codec:"uid" json:"uid"`
+	ConvID	ConversationID	`codec:"convID" json:"convID"`
+	MsgID	MessageID	`codec:"msgID" json:"msgID"`
 }
 
 func (o PublishReadMessageArg) DeepCopy() PublishReadMessageArg {
 	return PublishReadMessageArg{
-		Uid:    o.Uid.DeepCopy(),
-		ConvID: o.ConvID.DeepCopy(),
-		MsgID:  o.MsgID.DeepCopy(),
+		Uid : o.Uid.DeepCopy(),
+		ConvID : o.ConvID.DeepCopy(),
+		MsgID : o.MsgID.DeepCopy(),
 	}
 }
 
 type PublishSetConversationStatusArg struct {
-	Uid    gregor1.UID        `codec:"uid" json:"uid"`
-	ConvID ConversationID     `codec:"convID" json:"convID"`
-	Status ConversationStatus `codec:"status" json:"status"`
+	Uid	gregor1.UID	`codec:"uid" json:"uid"`
+	ConvID	ConversationID	`codec:"convID" json:"convID"`
+	Status	ConversationStatus	`codec:"status" json:"status"`
 }
 
 func (o PublishSetConversationStatusArg) DeepCopy() PublishSetConversationStatusArg {
 	return PublishSetConversationStatusArg{
-		Uid:    o.Uid.DeepCopy(),
-		ConvID: o.ConvID.DeepCopy(),
-		Status: o.Status.DeepCopy(),
+		Uid : o.Uid.DeepCopy(),
+		ConvID : o.ConvID.DeepCopy(),
+		Status : o.Status.DeepCopy(),
 	}
 }
 
 type UpdateTypingRemoteArg struct {
-	Uid      gregor1.UID      `codec:"uid" json:"uid"`
-	DeviceID gregor1.DeviceID `codec:"deviceID" json:"deviceID"`
-	ConvID   ConversationID   `codec:"convID" json:"convID"`
-	Typing   bool             `codec:"typing" json:"typing"`
+	Uid	gregor1.UID	`codec:"uid" json:"uid"`
+	DeviceID	gregor1.DeviceID	`codec:"deviceID" json:"deviceID"`
+	ConvID	ConversationID	`codec:"convID" json:"convID"`
+	Typing	bool	`codec:"typing" json:"typing"`
 }
 
 func (o UpdateTypingRemoteArg) DeepCopy() UpdateTypingRemoteArg {
 	return UpdateTypingRemoteArg{
-		Uid:      o.Uid.DeepCopy(),
-		DeviceID: o.DeviceID.DeepCopy(),
-		ConvID:   o.ConvID.DeepCopy(),
-		Typing:   o.Typing,
+		Uid : o.Uid.DeepCopy(),
+		DeviceID : o.DeviceID.DeepCopy(),
+		ConvID : o.ConvID.DeepCopy(),
+		Typing : o.Typing,
 	}
 }
 
 type JoinConversationArg struct {
-	ConvID ConversationID `codec:"convID" json:"convID"`
+	ConvID	ConversationID	`codec:"convID" json:"convID"`
 }
 
 func (o JoinConversationArg) DeepCopy() JoinConversationArg {
 	return JoinConversationArg{
-		ConvID: o.ConvID.DeepCopy(),
+		ConvID : o.ConvID.DeepCopy(),
 	}
 }
 
 type LeaveConversationArg struct {
-	ConvID ConversationID `codec:"convID" json:"convID"`
+	ConvID	ConversationID	`codec:"convID" json:"convID"`
 }
 
 func (o LeaveConversationArg) DeepCopy() LeaveConversationArg {
 	return LeaveConversationArg{
-		ConvID: o.ConvID.DeepCopy(),
+		ConvID : o.ConvID.DeepCopy(),
 	}
 }
 
 type GetTLFConversationsArg struct {
-	TlfID                TLFID                   `codec:"tlfID" json:"tlfID"`
-	TopicType            TopicType               `codec:"topicType" json:"topicType"`
-	MembersType          ConversationMembersType `codec:"membersType" json:"membersType"`
-	SummarizeMaxMsgs     bool                    `codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
-	IncludeAuxiliaryInfo bool                    `codec:"includeAuxiliaryInfo" json:"includeAuxiliaryInfo"`
+	TlfID	TLFID	`codec:"tlfID" json:"tlfID"`
+	TopicType	TopicType	`codec:"topicType" json:"topicType"`
+	MembersType	ConversationMembersType	`codec:"membersType" json:"membersType"`
+	SummarizeMaxMsgs	bool	`codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
+	IncludeAuxiliaryInfo	bool	`codec:"includeAuxiliaryInfo" json:"includeAuxiliaryInfo"`
 }
 
 func (o GetTLFConversationsArg) DeepCopy() GetTLFConversationsArg {
 	return GetTLFConversationsArg{
-		TlfID:                o.TlfID.DeepCopy(),
-		TopicType:            o.TopicType.DeepCopy(),
-		MembersType:          o.MembersType.DeepCopy(),
-		SummarizeMaxMsgs:     o.SummarizeMaxMsgs,
-		IncludeAuxiliaryInfo: o.IncludeAuxiliaryInfo,
+		TlfID : o.TlfID.DeepCopy(),
+		TopicType : o.TopicType.DeepCopy(),
+		MembersType : o.MembersType.DeepCopy(),
+		SummarizeMaxMsgs : o.SummarizeMaxMsgs,
+		IncludeAuxiliaryInfo : o.IncludeAuxiliaryInfo,
 	}
 }
 
 type SetAppNotificationSettingsArg struct {
-	ConvID   ConversationID               `codec:"convID" json:"convID"`
-	Settings ConversationNotificationInfo `codec:"settings" json:"settings"`
+	ConvID	ConversationID	`codec:"convID" json:"convID"`
+	Settings	ConversationNotificationInfo	`codec:"settings" json:"settings"`
 }
 
 func (o SetAppNotificationSettingsArg) DeepCopy() SetAppNotificationSettingsArg {
 	return SetAppNotificationSettingsArg{
-		ConvID:   o.ConvID.DeepCopy(),
-		Settings: o.Settings.DeepCopy(),
+		ConvID : o.ConvID.DeepCopy(),
+		Settings : o.Settings.DeepCopy(),
+	}
+}
+
+type SetGlobalAppNotificationSettingsArg struct {
+	Settings	GlobalAppNotificationSettings	`codec:"settings" json:"settings"`
+}
+
+func (o SetGlobalAppNotificationSettingsArg) DeepCopy() SetGlobalAppNotificationSettingsArg {
+	return SetGlobalAppNotificationSettingsArg{
+		Settings : o.Settings.DeepCopy(),
+	}
+}
+
+type GetGlobalNotificationSettingsArg struct {
+}
+
+func (o GetGlobalNotificationSettingsArg) DeepCopy() GetGlobalNotificationSettingsArg {
+	return GetGlobalNotificationSettingsArg{
 	}
 }
 
 type RemoteNotificationSuccessfulArg struct {
-	AuthToken        gregor1.SessionToken `codec:"authToken" json:"authToken"`
-	CompanionPushIDs []string             `codec:"companionPushIDs" json:"companionPushIDs"`
+	AuthToken	gregor1.SessionToken	`codec:"authToken" json:"authToken"`
+	CompanionPushIDs	[]string	`codec:"companionPushIDs" json:"companionPushIDs"`
 }
 
 func (o RemoteNotificationSuccessfulArg) DeepCopy() RemoteNotificationSuccessfulArg {
 	return RemoteNotificationSuccessfulArg{
-		AuthToken: o.AuthToken.DeepCopy(),
-		CompanionPushIDs: (func(x []string) []string {
+		AuthToken : o.AuthToken.DeepCopy(),
+		CompanionPushIDs : (func (x []string) []string {
 			var ret []string
 			for _, v := range x {
 				vCopy := v
@@ -1090,36 +1133,38 @@ func (o RemoteNotificationSuccessfulArg) DeepCopy() RemoteNotificationSuccessful
 }
 
 type RemoteInterface interface {
-	GetInboxRemote(context.Context, GetInboxRemoteArg) (GetInboxRemoteRes, error)
-	GetThreadRemote(context.Context, GetThreadRemoteArg) (GetThreadRemoteRes, error)
-	GetPublicConversations(context.Context, GetPublicConversationsArg) (GetPublicConversationsRes, error)
-	PostRemote(context.Context, PostRemoteArg) (PostRemoteRes, error)
-	NewConversationRemote(context.Context, ConversationIDTriple) (NewConversationRemoteRes, error)
-	NewConversationRemote2(context.Context, NewConversationRemote2Arg) (NewConversationRemoteRes, error)
-	GetMessagesRemote(context.Context, GetMessagesRemoteArg) (GetMessagesRemoteRes, error)
-	MarkAsRead(context.Context, MarkAsReadArg) (MarkAsReadRes, error)
-	SetConversationStatus(context.Context, SetConversationStatusArg) (SetConversationStatusRes, error)
-	GetUnreadUpdateFull(context.Context, InboxVers) (UnreadUpdateFull, error)
-	GetS3Params(context.Context, ConversationID) (S3Params, error)
-	S3Sign(context.Context, S3SignArg) ([]byte, error)
-	GetInboxVersion(context.Context, gregor1.UID) (InboxVers, error)
-	SyncInbox(context.Context, InboxVers) (SyncInboxRes, error)
-	SyncChat(context.Context, InboxVers) (SyncChatRes, error)
-	SyncAll(context.Context, SyncAllArg) (SyncAllResult, error)
-	TlfFinalize(context.Context, TlfFinalizeArg) error
-	TlfResolve(context.Context, TlfResolveArg) error
-	PublishReadMessage(context.Context, PublishReadMessageArg) error
-	PublishSetConversationStatus(context.Context, PublishSetConversationStatusArg) error
-	UpdateTypingRemote(context.Context, UpdateTypingRemoteArg) error
-	JoinConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes, error)
-	LeaveConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes, error)
-	GetTLFConversations(context.Context, GetTLFConversationsArg) (GetTLFConversationsRes, error)
-	SetAppNotificationSettings(context.Context, SetAppNotificationSettingsArg) (SetAppNotificationSettingsRes, error)
-	RemoteNotificationSuccessful(context.Context, RemoteNotificationSuccessfulArg) error
+	GetInboxRemote(context.Context, GetInboxRemoteArg) (GetInboxRemoteRes,error)
+	GetThreadRemote(context.Context, GetThreadRemoteArg) (GetThreadRemoteRes,error)
+	GetPublicConversations(context.Context, GetPublicConversationsArg) (GetPublicConversationsRes,error)
+	PostRemote(context.Context, PostRemoteArg) (PostRemoteRes,error)
+	NewConversationRemote(context.Context, ConversationIDTriple) (NewConversationRemoteRes,error)
+	NewConversationRemote2(context.Context, NewConversationRemote2Arg) (NewConversationRemoteRes,error)
+	GetMessagesRemote(context.Context, GetMessagesRemoteArg) (GetMessagesRemoteRes,error)
+	MarkAsRead(context.Context, MarkAsReadArg) (MarkAsReadRes,error)
+	SetConversationStatus(context.Context, SetConversationStatusArg) (SetConversationStatusRes,error)
+	GetUnreadUpdateFull(context.Context, InboxVers) (UnreadUpdateFull,error)
+	GetS3Params(context.Context, ConversationID) (S3Params,error)
+	S3Sign(context.Context, S3SignArg) ([]byte,error)
+	GetInboxVersion(context.Context, gregor1.UID) (InboxVers,error)
+	SyncInbox(context.Context, InboxVers) (SyncInboxRes,error)
+	SyncChat(context.Context, InboxVers) (SyncChatRes,error)
+	SyncAll(context.Context, SyncAllArg) (SyncAllResult,error)
+	TlfFinalize(context.Context, TlfFinalizeArg) (error)
+	TlfResolve(context.Context, TlfResolveArg) (error)
+	PublishReadMessage(context.Context, PublishReadMessageArg) (error)
+	PublishSetConversationStatus(context.Context, PublishSetConversationStatusArg) (error)
+	UpdateTypingRemote(context.Context, UpdateTypingRemoteArg) (error)
+	JoinConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes,error)
+	LeaveConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes,error)
+	GetTLFConversations(context.Context, GetTLFConversationsArg) (GetTLFConversationsRes,error)
+	SetAppNotificationSettings(context.Context, SetAppNotificationSettingsArg) (SetAppNotificationSettingsRes,error)
+	SetGlobalAppNotificationSettings(context.Context, GlobalAppNotificationSettings) (error)
+	GetGlobalNotificationSettings(context.Context, ) (GlobalAppNotificationSettings,error)
+	RemoteNotificationSuccessful(context.Context, RemoteNotificationSuccessfulArg) (error)
 }
 
 func RemoteProtocol(i RemoteInterface) rpc.Protocol {
-	return rpc.Protocol{
+	return rpc.Protocol {
 		Name: "chat.1.remote",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getInboxRemote": {
@@ -1522,6 +1567,33 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"setGlobalAppNotificationSettings": {
+				MakeArg: func() interface{} {
+					ret := make([]SetGlobalAppNotificationSettingsArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SetGlobalAppNotificationSettingsArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SetGlobalAppNotificationSettingsArg)(nil), args)
+						return
+					}
+					err = i.SetGlobalAppNotificationSettings(ctx, (*typedArgs)[0].Settings)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"getGlobalNotificationSettings": {
+				MakeArg: func() interface{} {
+					ret := make([]GetGlobalNotificationSettingsArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.GetGlobalNotificationSettings(ctx, )
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"remoteNotificationSuccessful": {
 				MakeArg: func() interface{} {
 					ret := make([]RemoteNotificationSuccessfulArg, 1)
@@ -1546,88 +1618,88 @@ type RemoteClient struct {
 	Cli rpc.GenericClient
 }
 
-func (c RemoteClient) GetInboxRemote(ctx context.Context, __arg GetInboxRemoteArg) (res GetInboxRemoteRes, err error) {
+func (c RemoteClient) GetInboxRemote(ctx context.Context, __arg GetInboxRemoteArg) (res GetInboxRemoteRes,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getInboxRemote", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetThreadRemote(ctx context.Context, __arg GetThreadRemoteArg) (res GetThreadRemoteRes, err error) {
+func (c RemoteClient) GetThreadRemote(ctx context.Context, __arg GetThreadRemoteArg) (res GetThreadRemoteRes,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getThreadRemote", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetPublicConversations(ctx context.Context, __arg GetPublicConversationsArg) (res GetPublicConversationsRes, err error) {
+func (c RemoteClient) GetPublicConversations(ctx context.Context, __arg GetPublicConversationsArg) (res GetPublicConversationsRes,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getPublicConversations", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) PostRemote(ctx context.Context, __arg PostRemoteArg) (res PostRemoteRes, err error) {
+func (c RemoteClient) PostRemote(ctx context.Context, __arg PostRemoteArg) (res PostRemoteRes,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.postRemote", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) NewConversationRemote(ctx context.Context, idTriple ConversationIDTriple) (res NewConversationRemoteRes, err error) {
-	__arg := NewConversationRemoteArg{IdTriple: idTriple}
+func (c RemoteClient) NewConversationRemote(ctx context.Context, idTriple ConversationIDTriple) (res NewConversationRemoteRes,err error) {
+	__arg := NewConversationRemoteArg{ IdTriple : idTriple }
 	err = c.Cli.Call(ctx, "chat.1.remote.newConversationRemote", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) NewConversationRemote2(ctx context.Context, __arg NewConversationRemote2Arg) (res NewConversationRemoteRes, err error) {
+func (c RemoteClient) NewConversationRemote2(ctx context.Context, __arg NewConversationRemote2Arg) (res NewConversationRemoteRes,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.newConversationRemote2", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetMessagesRemote(ctx context.Context, __arg GetMessagesRemoteArg) (res GetMessagesRemoteRes, err error) {
+func (c RemoteClient) GetMessagesRemote(ctx context.Context, __arg GetMessagesRemoteArg) (res GetMessagesRemoteRes,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getMessagesRemote", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) MarkAsRead(ctx context.Context, __arg MarkAsReadArg) (res MarkAsReadRes, err error) {
+func (c RemoteClient) MarkAsRead(ctx context.Context, __arg MarkAsReadArg) (res MarkAsReadRes,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.markAsRead", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) SetConversationStatus(ctx context.Context, __arg SetConversationStatusArg) (res SetConversationStatusRes, err error) {
+func (c RemoteClient) SetConversationStatus(ctx context.Context, __arg SetConversationStatusArg) (res SetConversationStatusRes,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.SetConversationStatus", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetUnreadUpdateFull(ctx context.Context, inboxVers InboxVers) (res UnreadUpdateFull, err error) {
-	__arg := GetUnreadUpdateFullArg{InboxVers: inboxVers}
+func (c RemoteClient) GetUnreadUpdateFull(ctx context.Context, inboxVers InboxVers) (res UnreadUpdateFull,err error) {
+	__arg := GetUnreadUpdateFullArg{ InboxVers : inboxVers }
 	err = c.Cli.Call(ctx, "chat.1.remote.GetUnreadUpdateFull", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetS3Params(ctx context.Context, conversationID ConversationID) (res S3Params, err error) {
-	__arg := GetS3ParamsArg{ConversationID: conversationID}
+func (c RemoteClient) GetS3Params(ctx context.Context, conversationID ConversationID) (res S3Params,err error) {
+	__arg := GetS3ParamsArg{ ConversationID : conversationID }
 	err = c.Cli.Call(ctx, "chat.1.remote.getS3Params", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) S3Sign(ctx context.Context, __arg S3SignArg) (res []byte, err error) {
+func (c RemoteClient) S3Sign(ctx context.Context, __arg S3SignArg) (res []byte,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.s3Sign", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetInboxVersion(ctx context.Context, uid gregor1.UID) (res InboxVers, err error) {
-	__arg := GetInboxVersionArg{Uid: uid}
+func (c RemoteClient) GetInboxVersion(ctx context.Context, uid gregor1.UID) (res InboxVers,err error) {
+	__arg := GetInboxVersionArg{ Uid : uid }
 	err = c.Cli.Call(ctx, "chat.1.remote.getInboxVersion", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) SyncInbox(ctx context.Context, vers InboxVers) (res SyncInboxRes, err error) {
-	__arg := SyncInboxArg{Vers: vers}
+func (c RemoteClient) SyncInbox(ctx context.Context, vers InboxVers) (res SyncInboxRes,err error) {
+	__arg := SyncInboxArg{ Vers : vers }
 	err = c.Cli.Call(ctx, "chat.1.remote.syncInbox", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) SyncChat(ctx context.Context, vers InboxVers) (res SyncChatRes, err error) {
-	__arg := SyncChatArg{Vers: vers}
+func (c RemoteClient) SyncChat(ctx context.Context, vers InboxVers) (res SyncChatRes,err error) {
+	__arg := SyncChatArg{ Vers : vers }
 	err = c.Cli.Call(ctx, "chat.1.remote.syncChat", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) SyncAll(ctx context.Context, __arg SyncAllArg) (res SyncAllResult, err error) {
+func (c RemoteClient) SyncAll(ctx context.Context, __arg SyncAllArg) (res SyncAllResult,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.syncAll", []interface{}{__arg}, &res)
 	return
 }
@@ -1657,25 +1729,36 @@ func (c RemoteClient) UpdateTypingRemote(ctx context.Context, __arg UpdateTyping
 	return
 }
 
-func (c RemoteClient) JoinConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes, err error) {
-	__arg := JoinConversationArg{ConvID: convID}
+func (c RemoteClient) JoinConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes,err error) {
+	__arg := JoinConversationArg{ ConvID : convID }
 	err = c.Cli.Call(ctx, "chat.1.remote.joinConversation", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) LeaveConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes, err error) {
-	__arg := LeaveConversationArg{ConvID: convID}
+func (c RemoteClient) LeaveConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes,err error) {
+	__arg := LeaveConversationArg{ ConvID : convID }
 	err = c.Cli.Call(ctx, "chat.1.remote.leaveConversation", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetTLFConversations(ctx context.Context, __arg GetTLFConversationsArg) (res GetTLFConversationsRes, err error) {
+func (c RemoteClient) GetTLFConversations(ctx context.Context, __arg GetTLFConversationsArg) (res GetTLFConversationsRes,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getTLFConversations", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) SetAppNotificationSettings(ctx context.Context, __arg SetAppNotificationSettingsArg) (res SetAppNotificationSettingsRes, err error) {
+func (c RemoteClient) SetAppNotificationSettings(ctx context.Context, __arg SetAppNotificationSettingsArg) (res SetAppNotificationSettingsRes,err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.setAppNotificationSettings", []interface{}{__arg}, &res)
+	return
+}
+
+func (c RemoteClient) SetGlobalAppNotificationSettings(ctx context.Context, settings GlobalAppNotificationSettings) (err error) {
+	__arg := SetGlobalAppNotificationSettingsArg{ Settings : settings }
+	err = c.Cli.Call(ctx, "chat.1.remote.setGlobalAppNotificationSettings", []interface{}{__arg}, nil)
+	return
+}
+
+func (c RemoteClient) GetGlobalNotificationSettings(ctx context.Context, ) (res GlobalAppNotificationSettings,err error) {
+	err = c.Cli.Call(ctx, "chat.1.remote.getGlobalNotificationSettings", []interface{}{GetGlobalNotificationSettingsArg{}}, &res)
 	return
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -4,64 +4,65 @@
 package chat1
 
 import (
+	"errors"
+	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
-	gregor1 "github.com/keybase/client/go/protocol/gregor1"
-	"errors"
 )
 
-
 type MessageBoxed struct {
-	Version	MessageBoxedVersion	`codec:"version" json:"version"`
-	ServerHeader	*MessageServerHeader	`codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
-	ClientHeader	MessageClientHeader	`codec:"clientHeader" json:"clientHeader"`
-	HeaderCiphertext	SealedData	`codec:"headerCiphertext" json:"headerCiphertext"`
-	BodyCiphertext	EncryptedData	`codec:"bodyCiphertext" json:"bodyCiphertext"`
-	VerifyKey	[]byte	`codec:"verifyKey" json:"verifyKey"`
-	KeyGeneration	int	`codec:"keyGeneration" json:"keyGeneration"`
+	Version          MessageBoxedVersion  `codec:"version" json:"version"`
+	ServerHeader     *MessageServerHeader `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
+	ClientHeader     MessageClientHeader  `codec:"clientHeader" json:"clientHeader"`
+	HeaderCiphertext SealedData           `codec:"headerCiphertext" json:"headerCiphertext"`
+	BodyCiphertext   EncryptedData        `codec:"bodyCiphertext" json:"bodyCiphertext"`
+	VerifyKey        []byte               `codec:"verifyKey" json:"verifyKey"`
+	KeyGeneration    int                  `codec:"keyGeneration" json:"keyGeneration"`
 }
 
 func (o MessageBoxed) DeepCopy() MessageBoxed {
 	return MessageBoxed{
-		Version : o.Version.DeepCopy(),
-		ServerHeader : (func (x *MessageServerHeader) *MessageServerHeader {
+		Version: o.Version.DeepCopy(),
+		ServerHeader: (func(x *MessageServerHeader) *MessageServerHeader {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.ServerHeader),
-		ClientHeader : o.ClientHeader.DeepCopy(),
-		HeaderCiphertext : o.HeaderCiphertext.DeepCopy(),
-		BodyCiphertext : o.BodyCiphertext.DeepCopy(),
-		VerifyKey : (func (x []byte) []byte {
+		ClientHeader:     o.ClientHeader.DeepCopy(),
+		HeaderCiphertext: o.HeaderCiphertext.DeepCopy(),
+		BodyCiphertext:   o.BodyCiphertext.DeepCopy(),
+		VerifyKey: (func(x []byte) []byte {
 			if x == nil {
 				return nil
 			}
 			return append([]byte(nil), x...)
 		})(o.VerifyKey),
-		KeyGeneration : o.KeyGeneration,
+		KeyGeneration: o.KeyGeneration,
 	}
 }
 
 type MessageBoxedVersion int
+
 const (
 	MessageBoxedVersion_VNONE MessageBoxedVersion = 0
-	MessageBoxedVersion_V1 MessageBoxedVersion = 1
-	MessageBoxedVersion_V2 MessageBoxedVersion = 2
+	MessageBoxedVersion_V1    MessageBoxedVersion = 1
+	MessageBoxedVersion_V2    MessageBoxedVersion = 2
 )
 
 func (o MessageBoxedVersion) DeepCopy() MessageBoxedVersion { return o }
+
 var MessageBoxedVersionMap = map[string]MessageBoxedVersion{
-	"VNONE" : 0,
-	"V1" : 1,
-	"V2" : 2,
+	"VNONE": 0,
+	"V1":    1,
+	"V2":    2,
 }
 
 var MessageBoxedVersionRevMap = map[MessageBoxedVersion]string{
-	0 : "VNONE",
-	1 : "V1",
-	2 : "V2",
+	0: "VNONE",
+	1: "V1",
+	2: "V2",
 }
 
 func (e MessageBoxedVersion) String() string {
@@ -72,13 +73,13 @@ func (e MessageBoxedVersion) String() string {
 }
 
 type ThreadViewBoxed struct {
-	Messages	[]MessageBoxed	`codec:"messages" json:"messages"`
-	Pagination	*Pagination	`codec:"pagination,omitempty" json:"pagination,omitempty"`
+	Messages   []MessageBoxed `codec:"messages" json:"messages"`
+	Pagination *Pagination    `codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 func (o ThreadViewBoxed) DeepCopy() ThreadViewBoxed {
 	return ThreadViewBoxed{
-		Messages : (func (x []MessageBoxed) []MessageBoxed {
+		Messages: (func(x []MessageBoxed) []MessageBoxed {
 			var ret []MessageBoxed
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -86,7 +87,7 @@ func (o ThreadViewBoxed) DeepCopy() ThreadViewBoxed {
 			}
 			return ret
 		})(o.Messages),
-		Pagination : (func (x *Pagination) *Pagination {
+		Pagination: (func(x *Pagination) *Pagination {
 			if x == nil {
 				return nil
 			}
@@ -97,14 +98,14 @@ func (o ThreadViewBoxed) DeepCopy() ThreadViewBoxed {
 }
 
 type GetInboxRemoteRes struct {
-	Inbox	InboxView	`codec:"inbox" json:"inbox"`
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Inbox     InboxView  `codec:"inbox" json:"inbox"`
+	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetInboxRemoteRes) DeepCopy() GetInboxRemoteRes {
 	return GetInboxRemoteRes{
-		Inbox : o.Inbox.DeepCopy(),
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		Inbox: o.Inbox.DeepCopy(),
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -115,13 +116,13 @@ func (o GetInboxRemoteRes) DeepCopy() GetInboxRemoteRes {
 }
 
 type GetInboxByTLFIDRemoteRes struct {
-	Convs	[]Conversation	`codec:"convs" json:"convs"`
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Convs     []Conversation `codec:"convs" json:"convs"`
+	RateLimit *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetInboxByTLFIDRemoteRes) DeepCopy() GetInboxByTLFIDRemoteRes {
 	return GetInboxByTLFIDRemoteRes{
-		Convs : (func (x []Conversation) []Conversation {
+		Convs: (func(x []Conversation) []Conversation {
 			var ret []Conversation
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -129,7 +130,7 @@ func (o GetInboxByTLFIDRemoteRes) DeepCopy() GetInboxByTLFIDRemoteRes {
 			}
 			return ret
 		})(o.Convs),
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -140,14 +141,14 @@ func (o GetInboxByTLFIDRemoteRes) DeepCopy() GetInboxByTLFIDRemoteRes {
 }
 
 type GetThreadRemoteRes struct {
-	Thread	ThreadViewBoxed	`codec:"thread" json:"thread"`
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Thread    ThreadViewBoxed `codec:"thread" json:"thread"`
+	RateLimit *RateLimit      `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetThreadRemoteRes) DeepCopy() GetThreadRemoteRes {
 	return GetThreadRemoteRes{
-		Thread : o.Thread.DeepCopy(),
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		Thread: o.Thread.DeepCopy(),
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -158,14 +159,14 @@ func (o GetThreadRemoteRes) DeepCopy() GetThreadRemoteRes {
 }
 
 type GetConversationMetadataRemoteRes struct {
-	Conv	Conversation	`codec:"conv" json:"conv"`
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Conv      Conversation `codec:"conv" json:"conv"`
+	RateLimit *RateLimit   `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetConversationMetadataRemoteRes) DeepCopy() GetConversationMetadataRemoteRes {
 	return GetConversationMetadataRemoteRes{
-		Conv : o.Conv.DeepCopy(),
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		Conv: o.Conv.DeepCopy(),
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -176,14 +177,14 @@ func (o GetConversationMetadataRemoteRes) DeepCopy() GetConversationMetadataRemo
 }
 
 type PostRemoteRes struct {
-	MsgHeader	MessageServerHeader	`codec:"msgHeader" json:"msgHeader"`
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	MsgHeader MessageServerHeader `codec:"msgHeader" json:"msgHeader"`
+	RateLimit *RateLimit          `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o PostRemoteRes) DeepCopy() PostRemoteRes {
 	return PostRemoteRes{
-		MsgHeader : o.MsgHeader.DeepCopy(),
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		MsgHeader: o.MsgHeader.DeepCopy(),
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -194,14 +195,14 @@ func (o PostRemoteRes) DeepCopy() PostRemoteRes {
 }
 
 type NewConversationRemoteRes struct {
-	ConvID	ConversationID	`codec:"convID" json:"convID"`
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	ConvID    ConversationID `codec:"convID" json:"convID"`
+	RateLimit *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o NewConversationRemoteRes) DeepCopy() NewConversationRemoteRes {
 	return NewConversationRemoteRes{
-		ConvID : o.ConvID.DeepCopy(),
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		ConvID: o.ConvID.DeepCopy(),
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -212,13 +213,13 @@ func (o NewConversationRemoteRes) DeepCopy() NewConversationRemoteRes {
 }
 
 type GetMessagesRemoteRes struct {
-	Msgs	[]MessageBoxed	`codec:"msgs" json:"msgs"`
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Msgs      []MessageBoxed `codec:"msgs" json:"msgs"`
+	RateLimit *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetMessagesRemoteRes) DeepCopy() GetMessagesRemoteRes {
 	return GetMessagesRemoteRes{
-		Msgs : (func (x []MessageBoxed) []MessageBoxed {
+		Msgs: (func(x []MessageBoxed) []MessageBoxed {
 			var ret []MessageBoxed
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -226,7 +227,7 @@ func (o GetMessagesRemoteRes) DeepCopy() GetMessagesRemoteRes {
 			}
 			return ret
 		})(o.Msgs),
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -237,12 +238,12 @@ func (o GetMessagesRemoteRes) DeepCopy() GetMessagesRemoteRes {
 }
 
 type MarkAsReadRes struct {
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o MarkAsReadRes) DeepCopy() MarkAsReadRes {
 	return MarkAsReadRes{
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -253,12 +254,12 @@ func (o MarkAsReadRes) DeepCopy() MarkAsReadRes {
 }
 
 type SetConversationStatusRes struct {
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o SetConversationStatusRes) DeepCopy() SetConversationStatusRes {
 	return SetConversationStatusRes{
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -269,13 +270,13 @@ func (o SetConversationStatusRes) DeepCopy() SetConversationStatusRes {
 }
 
 type GetPublicConversationsRes struct {
-	Conversations	[]Conversation	`codec:"conversations" json:"conversations"`
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Conversations []Conversation `codec:"conversations" json:"conversations"`
+	RateLimit     *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetPublicConversationsRes) DeepCopy() GetPublicConversationsRes {
 	return GetPublicConversationsRes{
-		Conversations : (func (x []Conversation) []Conversation {
+		Conversations: (func(x []Conversation) []Conversation {
 			var ret []Conversation
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -283,7 +284,7 @@ func (o GetPublicConversationsRes) DeepCopy() GetPublicConversationsRes {
 			}
 			return ret
 		})(o.Conversations),
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -294,23 +295,25 @@ func (o GetPublicConversationsRes) DeepCopy() GetPublicConversationsRes {
 }
 
 type ChannelMention int
+
 const (
 	ChannelMention_NONE ChannelMention = 0
-	ChannelMention_ALL ChannelMention = 1
+	ChannelMention_ALL  ChannelMention = 1
 	ChannelMention_HERE ChannelMention = 2
 )
 
 func (o ChannelMention) DeepCopy() ChannelMention { return o }
+
 var ChannelMentionMap = map[string]ChannelMention{
-	"NONE" : 0,
-	"ALL" : 1,
-	"HERE" : 2,
+	"NONE": 0,
+	"ALL":  1,
+	"HERE": 2,
 }
 
 var ChannelMentionRevMap = map[ChannelMention]string{
-	0 : "NONE",
-	1 : "ALL",
-	2 : "HERE",
+	0: "NONE",
+	1: "ALL",
+	2: "HERE",
 }
 
 func (e ChannelMention) String() string {
@@ -321,16 +324,16 @@ func (e ChannelMention) String() string {
 }
 
 type UnreadUpdateFull struct {
-	Ignore	bool	`codec:"ignore" json:"ignore"`
-	InboxVers	InboxVers	`codec:"inboxVers" json:"inboxVers"`
-	Updates	[]UnreadUpdate	`codec:"updates" json:"updates"`
+	Ignore    bool           `codec:"ignore" json:"ignore"`
+	InboxVers InboxVers      `codec:"inboxVers" json:"inboxVers"`
+	Updates   []UnreadUpdate `codec:"updates" json:"updates"`
 }
 
 func (o UnreadUpdateFull) DeepCopy() UnreadUpdateFull {
 	return UnreadUpdateFull{
-		Ignore : o.Ignore,
-		InboxVers : o.InboxVers.DeepCopy(),
-		Updates : (func (x []UnreadUpdate) []UnreadUpdate {
+		Ignore:    o.Ignore,
+		InboxVers: o.InboxVers.DeepCopy(),
+		Updates: (func(x []UnreadUpdate) []UnreadUpdate {
 			var ret []UnreadUpdate
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -342,45 +345,47 @@ func (o UnreadUpdateFull) DeepCopy() UnreadUpdateFull {
 }
 
 type S3Params struct {
-	Bucket	string	`codec:"bucket" json:"bucket"`
-	ObjectKey	string	`codec:"objectKey" json:"objectKey"`
-	AccessKey	string	`codec:"accessKey" json:"accessKey"`
-	Acl	string	`codec:"acl" json:"acl"`
-	RegionName	string	`codec:"regionName" json:"regionName"`
-	RegionEndpoint	string	`codec:"regionEndpoint" json:"regionEndpoint"`
-	RegionBucketEndpoint	string	`codec:"regionBucketEndpoint" json:"regionBucketEndpoint"`
+	Bucket               string `codec:"bucket" json:"bucket"`
+	ObjectKey            string `codec:"objectKey" json:"objectKey"`
+	AccessKey            string `codec:"accessKey" json:"accessKey"`
+	Acl                  string `codec:"acl" json:"acl"`
+	RegionName           string `codec:"regionName" json:"regionName"`
+	RegionEndpoint       string `codec:"regionEndpoint" json:"regionEndpoint"`
+	RegionBucketEndpoint string `codec:"regionBucketEndpoint" json:"regionBucketEndpoint"`
 }
 
 func (o S3Params) DeepCopy() S3Params {
 	return S3Params{
-		Bucket : o.Bucket,
-		ObjectKey : o.ObjectKey,
-		AccessKey : o.AccessKey,
-		Acl : o.Acl,
-		RegionName : o.RegionName,
-		RegionEndpoint : o.RegionEndpoint,
-		RegionBucketEndpoint : o.RegionBucketEndpoint,
+		Bucket:               o.Bucket,
+		ObjectKey:            o.ObjectKey,
+		AccessKey:            o.AccessKey,
+		Acl:                  o.Acl,
+		RegionName:           o.RegionName,
+		RegionEndpoint:       o.RegionEndpoint,
+		RegionBucketEndpoint: o.RegionBucketEndpoint,
 	}
 }
 
 type SyncInboxResType int
+
 const (
-	SyncInboxResType_CURRENT SyncInboxResType = 0
+	SyncInboxResType_CURRENT     SyncInboxResType = 0
 	SyncInboxResType_INCREMENTAL SyncInboxResType = 1
-	SyncInboxResType_CLEAR SyncInboxResType = 2
+	SyncInboxResType_CLEAR       SyncInboxResType = 2
 )
 
 func (o SyncInboxResType) DeepCopy() SyncInboxResType { return o }
+
 var SyncInboxResTypeMap = map[string]SyncInboxResType{
-	"CURRENT" : 0,
-	"INCREMENTAL" : 1,
-	"CLEAR" : 2,
+	"CURRENT":     0,
+	"INCREMENTAL": 1,
+	"CLEAR":       2,
 }
 
 var SyncInboxResTypeRevMap = map[SyncInboxResType]string{
-	0 : "CURRENT",
-	1 : "INCREMENTAL",
-	2 : "CLEAR",
+	0: "CURRENT",
+	1: "INCREMENTAL",
+	2: "CLEAR",
 }
 
 func (e SyncInboxResType) String() string {
@@ -391,14 +396,14 @@ func (e SyncInboxResType) String() string {
 }
 
 type SyncIncrementalRes struct {
-	Vers	InboxVers	`codec:"vers" json:"vers"`
-	Convs	[]Conversation	`codec:"convs" json:"convs"`
+	Vers  InboxVers      `codec:"vers" json:"vers"`
+	Convs []Conversation `codec:"convs" json:"convs"`
 }
 
 func (o SyncIncrementalRes) DeepCopy() SyncIncrementalRes {
 	return SyncIncrementalRes{
-		Vers : o.Vers.DeepCopy(),
-		Convs : (func (x []Conversation) []Conversation {
+		Vers: o.Vers.DeepCopy(),
+		Convs: (func(x []Conversation) []Conversation {
 			var ret []Conversation
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -410,29 +415,29 @@ func (o SyncIncrementalRes) DeepCopy() SyncIncrementalRes {
 }
 
 type ServerCacheVers struct {
-	InboxVers	int	`codec:"inboxVers" json:"inboxVers"`
-	BodiesVers	int	`codec:"bodiesVers" json:"bodiesVers"`
+	InboxVers  int `codec:"inboxVers" json:"inboxVers"`
+	BodiesVers int `codec:"bodiesVers" json:"bodiesVers"`
 }
 
 func (o ServerCacheVers) DeepCopy() ServerCacheVers {
 	return ServerCacheVers{
-		InboxVers : o.InboxVers,
-		BodiesVers : o.BodiesVers,
+		InboxVers:  o.InboxVers,
+		BodiesVers: o.BodiesVers,
 	}
 }
 
 type SyncInboxRes struct {
-	Typ__	SyncInboxResType	`codec:"typ" json:"typ"`
-	Incremental__	*SyncIncrementalRes	`codec:"incremental,omitempty" json:"incremental,omitempty"`
+	Typ__         SyncInboxResType    `codec:"typ" json:"typ"`
+	Incremental__ *SyncIncrementalRes `codec:"incremental,omitempty" json:"incremental,omitempty"`
 }
 
 func (o *SyncInboxRes) Typ() (ret SyncInboxResType, err error) {
-	switch (o.Typ__) {
-		case SyncInboxResType_INCREMENTAL:
-			if o.Incremental__ == nil {
-				err = errors.New("unexpected nil value for Incremental__")
-				return ret, err
-			}
+	switch o.Typ__ {
+	case SyncInboxResType_INCREMENTAL:
+		if o.Incremental__ == nil {
+			err = errors.New("unexpected nil value for Incremental__")
+			return ret, err
+		}
 	}
 	return o.Typ__, nil
 }
@@ -449,27 +454,27 @@ func (o SyncInboxRes) Incremental() (res SyncIncrementalRes) {
 
 func NewSyncInboxResWithCurrent() SyncInboxRes {
 	return SyncInboxRes{
-		Typ__ : SyncInboxResType_CURRENT,
+		Typ__: SyncInboxResType_CURRENT,
 	}
 }
 
 func NewSyncInboxResWithIncremental(v SyncIncrementalRes) SyncInboxRes {
 	return SyncInboxRes{
-		Typ__ : SyncInboxResType_INCREMENTAL,
-		Incremental__ : &v,
+		Typ__:         SyncInboxResType_INCREMENTAL,
+		Incremental__: &v,
 	}
 }
 
 func NewSyncInboxResWithClear() SyncInboxRes {
 	return SyncInboxRes{
-		Typ__ : SyncInboxResType_CLEAR,
+		Typ__: SyncInboxResType_CLEAR,
 	}
 }
 
 func (o SyncInboxRes) DeepCopy() SyncInboxRes {
-	return SyncInboxRes {
-		Typ__ : o.Typ__.DeepCopy(),
-		Incremental__ : (func (x *SyncIncrementalRes) *SyncIncrementalRes {
+	return SyncInboxRes{
+		Typ__: o.Typ__.DeepCopy(),
+		Incremental__: (func(x *SyncIncrementalRes) *SyncIncrementalRes {
 			if x == nil {
 				return nil
 			}
@@ -480,32 +485,34 @@ func (o SyncInboxRes) DeepCopy() SyncInboxRes {
 }
 
 type SyncChatRes struct {
-	CacheVers	ServerCacheVers	`codec:"cacheVers" json:"cacheVers"`
-	InboxRes	SyncInboxRes	`codec:"inboxRes" json:"inboxRes"`
+	CacheVers ServerCacheVers `codec:"cacheVers" json:"cacheVers"`
+	InboxRes  SyncInboxRes    `codec:"inboxRes" json:"inboxRes"`
 }
 
 func (o SyncChatRes) DeepCopy() SyncChatRes {
 	return SyncChatRes{
-		CacheVers : o.CacheVers.DeepCopy(),
-		InboxRes : o.InboxRes.DeepCopy(),
+		CacheVers: o.CacheVers.DeepCopy(),
+		InboxRes:  o.InboxRes.DeepCopy(),
 	}
 }
 
 type SyncAllNotificationType int
+
 const (
-	SyncAllNotificationType_STATE SyncAllNotificationType = 0
+	SyncAllNotificationType_STATE       SyncAllNotificationType = 0
 	SyncAllNotificationType_INCREMENTAL SyncAllNotificationType = 1
 )
 
 func (o SyncAllNotificationType) DeepCopy() SyncAllNotificationType { return o }
+
 var SyncAllNotificationTypeMap = map[string]SyncAllNotificationType{
-	"STATE" : 0,
-	"INCREMENTAL" : 1,
+	"STATE":       0,
+	"INCREMENTAL": 1,
 }
 
 var SyncAllNotificationTypeRevMap = map[SyncAllNotificationType]string{
-	0 : "STATE",
-	1 : "INCREMENTAL",
+	0: "STATE",
+	1: "INCREMENTAL",
 }
 
 func (e SyncAllNotificationType) String() string {
@@ -516,23 +523,23 @@ func (e SyncAllNotificationType) String() string {
 }
 
 type SyncAllNotificationRes struct {
-	Typ__	SyncAllNotificationType	`codec:"typ" json:"typ"`
-	State__	*gregor1.State	`codec:"state,omitempty" json:"state,omitempty"`
-	Incremental__	*gregor1.SyncResult	`codec:"incremental,omitempty" json:"incremental,omitempty"`
+	Typ__         SyncAllNotificationType `codec:"typ" json:"typ"`
+	State__       *gregor1.State          `codec:"state,omitempty" json:"state,omitempty"`
+	Incremental__ *gregor1.SyncResult     `codec:"incremental,omitempty" json:"incremental,omitempty"`
 }
 
 func (o *SyncAllNotificationRes) Typ() (ret SyncAllNotificationType, err error) {
-	switch (o.Typ__) {
-		case SyncAllNotificationType_STATE:
-			if o.State__ == nil {
-				err = errors.New("unexpected nil value for State__")
-				return ret, err
-			}
-		case SyncAllNotificationType_INCREMENTAL:
-			if o.Incremental__ == nil {
-				err = errors.New("unexpected nil value for Incremental__")
-				return ret, err
-			}
+	switch o.Typ__ {
+	case SyncAllNotificationType_STATE:
+		if o.State__ == nil {
+			err = errors.New("unexpected nil value for State__")
+			return ret, err
+		}
+	case SyncAllNotificationType_INCREMENTAL:
+		if o.Incremental__ == nil {
+			err = errors.New("unexpected nil value for Incremental__")
+			return ret, err
+		}
 	}
 	return o.Typ__, nil
 }
@@ -559,29 +566,29 @@ func (o SyncAllNotificationRes) Incremental() (res gregor1.SyncResult) {
 
 func NewSyncAllNotificationResWithState(v gregor1.State) SyncAllNotificationRes {
 	return SyncAllNotificationRes{
-		Typ__ : SyncAllNotificationType_STATE,
-		State__ : &v,
+		Typ__:   SyncAllNotificationType_STATE,
+		State__: &v,
 	}
 }
 
 func NewSyncAllNotificationResWithIncremental(v gregor1.SyncResult) SyncAllNotificationRes {
 	return SyncAllNotificationRes{
-		Typ__ : SyncAllNotificationType_INCREMENTAL,
-		Incremental__ : &v,
+		Typ__:         SyncAllNotificationType_INCREMENTAL,
+		Incremental__: &v,
 	}
 }
 
 func (o SyncAllNotificationRes) DeepCopy() SyncAllNotificationRes {
-	return SyncAllNotificationRes {
-		Typ__ : o.Typ__.DeepCopy(),
-		State__ : (func (x *gregor1.State) *gregor1.State {
+	return SyncAllNotificationRes{
+		Typ__: o.Typ__.DeepCopy(),
+		State__: (func(x *gregor1.State) *gregor1.State {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.State__),
-		Incremental__ : (func (x *gregor1.SyncResult) *gregor1.SyncResult {
+		Incremental__: (func(x *gregor1.SyncResult) *gregor1.SyncResult {
 			if x == nil {
 				return nil
 			}
@@ -592,28 +599,28 @@ func (o SyncAllNotificationRes) DeepCopy() SyncAllNotificationRes {
 }
 
 type SyncAllResult struct {
-	Auth	gregor1.AuthResult	`codec:"auth" json:"auth"`
-	Chat	SyncChatRes	`codec:"chat" json:"chat"`
-	Notification	SyncAllNotificationRes	`codec:"notification" json:"notification"`
-	Badge	UnreadUpdateFull	`codec:"badge" json:"badge"`
+	Auth         gregor1.AuthResult     `codec:"auth" json:"auth"`
+	Chat         SyncChatRes            `codec:"chat" json:"chat"`
+	Notification SyncAllNotificationRes `codec:"notification" json:"notification"`
+	Badge        UnreadUpdateFull       `codec:"badge" json:"badge"`
 }
 
 func (o SyncAllResult) DeepCopy() SyncAllResult {
 	return SyncAllResult{
-		Auth : o.Auth.DeepCopy(),
-		Chat : o.Chat.DeepCopy(),
-		Notification : o.Notification.DeepCopy(),
-		Badge : o.Badge.DeepCopy(),
+		Auth:         o.Auth.DeepCopy(),
+		Chat:         o.Chat.DeepCopy(),
+		Notification: o.Notification.DeepCopy(),
+		Badge:        o.Badge.DeepCopy(),
 	}
 }
 
 type JoinLeaveConversationRemoteRes struct {
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o JoinLeaveConversationRemoteRes) DeepCopy() JoinLeaveConversationRemoteRes {
 	return JoinLeaveConversationRemoteRes{
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -624,13 +631,13 @@ func (o JoinLeaveConversationRemoteRes) DeepCopy() JoinLeaveConversationRemoteRe
 }
 
 type GetTLFConversationsRes struct {
-	Conversations	[]Conversation	`codec:"conversations" json:"conversations"`
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Conversations []Conversation `codec:"conversations" json:"conversations"`
+	RateLimit     *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetTLFConversationsRes) DeepCopy() GetTLFConversationsRes {
 	return GetTLFConversationsRes{
-		Conversations : (func (x []Conversation) []Conversation {
+		Conversations: (func(x []Conversation) []Conversation {
 			var ret []Conversation
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -638,7 +645,7 @@ func (o GetTLFConversationsRes) DeepCopy() GetTLFConversationsRes {
 			}
 			return ret
 		})(o.Conversations),
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -649,12 +656,12 @@ func (o GetTLFConversationsRes) DeepCopy() GetTLFConversationsRes {
 }
 
 type SetAppNotificationSettingsRes struct {
-	RateLimit	*RateLimit	`codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o SetAppNotificationSettingsRes) DeepCopy() SetAppNotificationSettingsRes {
 	return SetAppNotificationSettingsRes{
-		RateLimit : (func (x *RateLimit) *RateLimit {
+		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil
 			}
@@ -664,55 +671,23 @@ func (o SetAppNotificationSettingsRes) DeepCopy() SetAppNotificationSettingsRes 
 	}
 }
 
-type GlobalAppNotificationSetting int
-const (
-	GlobalAppNotificationSetting_NEWMESSAGES GlobalAppNotificationSetting = 0
-	GlobalAppNotificationSetting_PLAINTEXTMOBILE GlobalAppNotificationSetting = 1
-	GlobalAppNotificationSetting_PLAINTEXTDESKTOP GlobalAppNotificationSetting = 2
-)
-
-func (o GlobalAppNotificationSetting) DeepCopy() GlobalAppNotificationSetting { return o }
-var GlobalAppNotificationSettingMap = map[string]GlobalAppNotificationSetting{
-	"NEWMESSAGES" : 0,
-	"PLAINTEXTMOBILE" : 1,
-	"PLAINTEXTDESKTOP" : 2,
-}
-
-var GlobalAppNotificationSettingRevMap = map[GlobalAppNotificationSetting]string{
-	0 : "NEWMESSAGES",
-	1 : "PLAINTEXTMOBILE",
-	2 : "PLAINTEXTDESKTOP",
-}
-
-func (e GlobalAppNotificationSetting) String() string {
-	if v, ok := GlobalAppNotificationSettingRevMap[e]; ok {
-		return v
-	}
-	return ""
-}
-
-type GlobalAppNotificationSettings map<GlobalAppNotificationSetting, bool>
-func (o GlobalAppNotificationSettings) DeepCopy() GlobalAppNotificationSettings {
-	return o.DeepCopy()
-}
-
 type GetInboxRemoteArg struct {
-	Vers	InboxVers	`codec:"vers" json:"vers"`
-	Query	*GetInboxQuery	`codec:"query,omitempty" json:"query,omitempty"`
-	Pagination	*Pagination	`codec:"pagination,omitempty" json:"pagination,omitempty"`
+	Vers       InboxVers      `codec:"vers" json:"vers"`
+	Query      *GetInboxQuery `codec:"query,omitempty" json:"query,omitempty"`
+	Pagination *Pagination    `codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 func (o GetInboxRemoteArg) DeepCopy() GetInboxRemoteArg {
 	return GetInboxRemoteArg{
-		Vers : o.Vers.DeepCopy(),
-		Query : (func (x *GetInboxQuery) *GetInboxQuery {
+		Vers: o.Vers.DeepCopy(),
+		Query: (func(x *GetInboxQuery) *GetInboxQuery {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Query),
-		Pagination : (func (x *Pagination) *Pagination {
+		Pagination: (func(x *Pagination) *Pagination {
 			if x == nil {
 				return nil
 			}
@@ -723,22 +698,22 @@ func (o GetInboxRemoteArg) DeepCopy() GetInboxRemoteArg {
 }
 
 type GetThreadRemoteArg struct {
-	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
-	Query	*GetThreadQuery	`codec:"query,omitempty" json:"query,omitempty"`
-	Pagination	*Pagination	`codec:"pagination,omitempty" json:"pagination,omitempty"`
+	ConversationID ConversationID  `codec:"conversationID" json:"conversationID"`
+	Query          *GetThreadQuery `codec:"query,omitempty" json:"query,omitempty"`
+	Pagination     *Pagination     `codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 func (o GetThreadRemoteArg) DeepCopy() GetThreadRemoteArg {
 	return GetThreadRemoteArg{
-		ConversationID : o.ConversationID.DeepCopy(),
-		Query : (func (x *GetThreadQuery) *GetThreadQuery {
+		ConversationID: o.ConversationID.DeepCopy(),
+		Query: (func(x *GetThreadQuery) *GetThreadQuery {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Query),
-		Pagination : (func (x *Pagination) *Pagination {
+		Pagination: (func(x *Pagination) *Pagination {
 			if x == nil {
 				return nil
 			}
@@ -749,32 +724,32 @@ func (o GetThreadRemoteArg) DeepCopy() GetThreadRemoteArg {
 }
 
 type GetPublicConversationsArg struct {
-	TlfID	TLFID	`codec:"tlfID" json:"tlfID"`
-	TopicType	TopicType	`codec:"topicType" json:"topicType"`
-	SummarizeMaxMsgs	bool	`codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
+	TlfID            TLFID     `codec:"tlfID" json:"tlfID"`
+	TopicType        TopicType `codec:"topicType" json:"topicType"`
+	SummarizeMaxMsgs bool      `codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
 }
 
 func (o GetPublicConversationsArg) DeepCopy() GetPublicConversationsArg {
 	return GetPublicConversationsArg{
-		TlfID : o.TlfID.DeepCopy(),
-		TopicType : o.TopicType.DeepCopy(),
-		SummarizeMaxMsgs : o.SummarizeMaxMsgs,
+		TlfID:            o.TlfID.DeepCopy(),
+		TopicType:        o.TopicType.DeepCopy(),
+		SummarizeMaxMsgs: o.SummarizeMaxMsgs,
 	}
 }
 
 type PostRemoteArg struct {
-	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
-	MessageBoxed	MessageBoxed	`codec:"messageBoxed" json:"messageBoxed"`
-	AtMentions	[]gregor1.UID	`codec:"atMentions" json:"atMentions"`
-	ChannelMention	ChannelMention	`codec:"channelMention" json:"channelMention"`
-	TopicNameState	*TopicNameState	`codec:"topicNameState,omitempty" json:"topicNameState,omitempty"`
+	ConversationID ConversationID  `codec:"conversationID" json:"conversationID"`
+	MessageBoxed   MessageBoxed    `codec:"messageBoxed" json:"messageBoxed"`
+	AtMentions     []gregor1.UID   `codec:"atMentions" json:"atMentions"`
+	ChannelMention ChannelMention  `codec:"channelMention" json:"channelMention"`
+	TopicNameState *TopicNameState `codec:"topicNameState,omitempty" json:"topicNameState,omitempty"`
 }
 
 func (o PostRemoteArg) DeepCopy() PostRemoteArg {
 	return PostRemoteArg{
-		ConversationID : o.ConversationID.DeepCopy(),
-		MessageBoxed : o.MessageBoxed.DeepCopy(),
-		AtMentions : (func (x []gregor1.UID) []gregor1.UID {
+		ConversationID: o.ConversationID.DeepCopy(),
+		MessageBoxed:   o.MessageBoxed.DeepCopy(),
+		AtMentions: (func(x []gregor1.UID) []gregor1.UID {
 			var ret []gregor1.UID
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -782,8 +757,8 @@ func (o PostRemoteArg) DeepCopy() PostRemoteArg {
 			}
 			return ret
 		})(o.AtMentions),
-		ChannelMention : o.ChannelMention.DeepCopy(),
-		TopicNameState : (func (x *TopicNameState) *TopicNameState {
+		ChannelMention: o.ChannelMention.DeepCopy(),
+		TopicNameState: (func(x *TopicNameState) *TopicNameState {
 			if x == nil {
 				return nil
 			}
@@ -794,28 +769,28 @@ func (o PostRemoteArg) DeepCopy() PostRemoteArg {
 }
 
 type NewConversationRemoteArg struct {
-	IdTriple	ConversationIDTriple	`codec:"idTriple" json:"idTriple"`
+	IdTriple ConversationIDTriple `codec:"idTriple" json:"idTriple"`
 }
 
 func (o NewConversationRemoteArg) DeepCopy() NewConversationRemoteArg {
 	return NewConversationRemoteArg{
-		IdTriple : o.IdTriple.DeepCopy(),
+		IdTriple: o.IdTriple.DeepCopy(),
 	}
 }
 
 type NewConversationRemote2Arg struct {
-	IdTriple	ConversationIDTriple	`codec:"idTriple" json:"idTriple"`
-	TLFMessage	MessageBoxed	`codec:"TLFMessage" json:"TLFMessage"`
-	MembersType	ConversationMembersType	`codec:"membersType" json:"membersType"`
-	TopicNameState	*TopicNameState	`codec:"topicNameState,omitempty" json:"topicNameState,omitempty"`
+	IdTriple       ConversationIDTriple    `codec:"idTriple" json:"idTriple"`
+	TLFMessage     MessageBoxed            `codec:"TLFMessage" json:"TLFMessage"`
+	MembersType    ConversationMembersType `codec:"membersType" json:"membersType"`
+	TopicNameState *TopicNameState         `codec:"topicNameState,omitempty" json:"topicNameState,omitempty"`
 }
 
 func (o NewConversationRemote2Arg) DeepCopy() NewConversationRemote2Arg {
 	return NewConversationRemote2Arg{
-		IdTriple : o.IdTriple.DeepCopy(),
-		TLFMessage : o.TLFMessage.DeepCopy(),
-		MembersType : o.MembersType.DeepCopy(),
-		TopicNameState : (func (x *TopicNameState) *TopicNameState {
+		IdTriple:    o.IdTriple.DeepCopy(),
+		TLFMessage:  o.TLFMessage.DeepCopy(),
+		MembersType: o.MembersType.DeepCopy(),
+		TopicNameState: (func(x *TopicNameState) *TopicNameState {
 			if x == nil {
 				return nil
 			}
@@ -826,14 +801,14 @@ func (o NewConversationRemote2Arg) DeepCopy() NewConversationRemote2Arg {
 }
 
 type GetMessagesRemoteArg struct {
-	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
-	MessageIDs	[]MessageID	`codec:"messageIDs" json:"messageIDs"`
+	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
+	MessageIDs     []MessageID    `codec:"messageIDs" json:"messageIDs"`
 }
 
 func (o GetMessagesRemoteArg) DeepCopy() GetMessagesRemoteArg {
 	return GetMessagesRemoteArg{
-		ConversationID : o.ConversationID.DeepCopy(),
-		MessageIDs : (func (x []MessageID) []MessageID {
+		ConversationID: o.ConversationID.DeepCopy(),
+		MessageIDs: (func(x []MessageID) []MessageID {
 			var ret []MessageID
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -845,58 +820,58 @@ func (o GetMessagesRemoteArg) DeepCopy() GetMessagesRemoteArg {
 }
 
 type MarkAsReadArg struct {
-	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
-	MsgID	MessageID	`codec:"msgID" json:"msgID"`
+	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
+	MsgID          MessageID      `codec:"msgID" json:"msgID"`
 }
 
 func (o MarkAsReadArg) DeepCopy() MarkAsReadArg {
 	return MarkAsReadArg{
-		ConversationID : o.ConversationID.DeepCopy(),
-		MsgID : o.MsgID.DeepCopy(),
+		ConversationID: o.ConversationID.DeepCopy(),
+		MsgID:          o.MsgID.DeepCopy(),
 	}
 }
 
 type SetConversationStatusArg struct {
-	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
-	Status	ConversationStatus	`codec:"status" json:"status"`
+	ConversationID ConversationID     `codec:"conversationID" json:"conversationID"`
+	Status         ConversationStatus `codec:"status" json:"status"`
 }
 
 func (o SetConversationStatusArg) DeepCopy() SetConversationStatusArg {
 	return SetConversationStatusArg{
-		ConversationID : o.ConversationID.DeepCopy(),
-		Status : o.Status.DeepCopy(),
+		ConversationID: o.ConversationID.DeepCopy(),
+		Status:         o.Status.DeepCopy(),
 	}
 }
 
 type GetUnreadUpdateFullArg struct {
-	InboxVers	InboxVers	`codec:"inboxVers" json:"inboxVers"`
+	InboxVers InboxVers `codec:"inboxVers" json:"inboxVers"`
 }
 
 func (o GetUnreadUpdateFullArg) DeepCopy() GetUnreadUpdateFullArg {
 	return GetUnreadUpdateFullArg{
-		InboxVers : o.InboxVers.DeepCopy(),
+		InboxVers: o.InboxVers.DeepCopy(),
 	}
 }
 
 type GetS3ParamsArg struct {
-	ConversationID	ConversationID	`codec:"conversationID" json:"conversationID"`
+	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
 }
 
 func (o GetS3ParamsArg) DeepCopy() GetS3ParamsArg {
 	return GetS3ParamsArg{
-		ConversationID : o.ConversationID.DeepCopy(),
+		ConversationID: o.ConversationID.DeepCopy(),
 	}
 }
 
 type S3SignArg struct {
-	Version	int	`codec:"version" json:"version"`
-	Payload	[]byte	`codec:"payload" json:"payload"`
+	Version int    `codec:"version" json:"version"`
+	Payload []byte `codec:"payload" json:"payload"`
 }
 
 func (o S3SignArg) DeepCopy() S3SignArg {
 	return S3SignArg{
-		Version : o.Version,
-		Payload : (func (x []byte) []byte {
+		Version: o.Version,
+		Payload: (func(x []byte) []byte {
 			if x == nil {
 				return nil
 			}
@@ -906,83 +881,83 @@ func (o S3SignArg) DeepCopy() S3SignArg {
 }
 
 type GetInboxVersionArg struct {
-	Uid	gregor1.UID	`codec:"uid" json:"uid"`
+	Uid gregor1.UID `codec:"uid" json:"uid"`
 }
 
 func (o GetInboxVersionArg) DeepCopy() GetInboxVersionArg {
 	return GetInboxVersionArg{
-		Uid : o.Uid.DeepCopy(),
+		Uid: o.Uid.DeepCopy(),
 	}
 }
 
 type SyncInboxArg struct {
-	Vers	InboxVers	`codec:"vers" json:"vers"`
+	Vers InboxVers `codec:"vers" json:"vers"`
 }
 
 func (o SyncInboxArg) DeepCopy() SyncInboxArg {
 	return SyncInboxArg{
-		Vers : o.Vers.DeepCopy(),
+		Vers: o.Vers.DeepCopy(),
 	}
 }
 
 type SyncChatArg struct {
-	Vers	InboxVers	`codec:"vers" json:"vers"`
+	Vers InboxVers `codec:"vers" json:"vers"`
 }
 
 func (o SyncChatArg) DeepCopy() SyncChatArg {
 	return SyncChatArg{
-		Vers : o.Vers.DeepCopy(),
+		Vers: o.Vers.DeepCopy(),
 	}
 }
 
 type SyncAllArg struct {
-	Uid	gregor1.UID	`codec:"uid" json:"uid"`
-	DeviceID	gregor1.DeviceID	`codec:"deviceID" json:"deviceID"`
-	Session	gregor1.SessionToken	`codec:"session" json:"session"`
-	InboxVers	InboxVers	`codec:"inboxVers" json:"inboxVers"`
-	Ctime	gregor1.Time	`codec:"ctime" json:"ctime"`
-	Fresh	bool	`codec:"fresh" json:"fresh"`
+	Uid       gregor1.UID          `codec:"uid" json:"uid"`
+	DeviceID  gregor1.DeviceID     `codec:"deviceID" json:"deviceID"`
+	Session   gregor1.SessionToken `codec:"session" json:"session"`
+	InboxVers InboxVers            `codec:"inboxVers" json:"inboxVers"`
+	Ctime     gregor1.Time         `codec:"ctime" json:"ctime"`
+	Fresh     bool                 `codec:"fresh" json:"fresh"`
 }
 
 func (o SyncAllArg) DeepCopy() SyncAllArg {
 	return SyncAllArg{
-		Uid : o.Uid.DeepCopy(),
-		DeviceID : o.DeviceID.DeepCopy(),
-		Session : o.Session.DeepCopy(),
-		InboxVers : o.InboxVers.DeepCopy(),
-		Ctime : o.Ctime.DeepCopy(),
-		Fresh : o.Fresh,
+		Uid:       o.Uid.DeepCopy(),
+		DeviceID:  o.DeviceID.DeepCopy(),
+		Session:   o.Session.DeepCopy(),
+		InboxVers: o.InboxVers.DeepCopy(),
+		Ctime:     o.Ctime.DeepCopy(),
+		Fresh:     o.Fresh,
 	}
 }
 
 type TlfFinalizeArg struct {
-	TlfID	TLFID	`codec:"tlfID" json:"tlfID"`
-	ResetUser	string	`codec:"resetUser" json:"resetUser"`
-	ResetDate	string	`codec:"resetDate" json:"resetDate"`
-	ResetTimestamp	gregor1.Time	`codec:"resetTimestamp" json:"resetTimestamp"`
-	ResetFull	string	`codec:"resetFull" json:"resetFull"`
+	TlfID          TLFID        `codec:"tlfID" json:"tlfID"`
+	ResetUser      string       `codec:"resetUser" json:"resetUser"`
+	ResetDate      string       `codec:"resetDate" json:"resetDate"`
+	ResetTimestamp gregor1.Time `codec:"resetTimestamp" json:"resetTimestamp"`
+	ResetFull      string       `codec:"resetFull" json:"resetFull"`
 }
 
 func (o TlfFinalizeArg) DeepCopy() TlfFinalizeArg {
 	return TlfFinalizeArg{
-		TlfID : o.TlfID.DeepCopy(),
-		ResetUser : o.ResetUser,
-		ResetDate : o.ResetDate,
-		ResetTimestamp : o.ResetTimestamp.DeepCopy(),
-		ResetFull : o.ResetFull,
+		TlfID:          o.TlfID.DeepCopy(),
+		ResetUser:      o.ResetUser,
+		ResetDate:      o.ResetDate,
+		ResetTimestamp: o.ResetTimestamp.DeepCopy(),
+		ResetFull:      o.ResetFull,
 	}
 }
 
 type TlfResolveArg struct {
-	TlfID	TLFID	`codec:"tlfID" json:"tlfID"`
-	ResolvedWriters	[]gregor1.UID	`codec:"resolvedWriters" json:"resolvedWriters"`
-	ResolvedReaders	[]gregor1.UID	`codec:"resolvedReaders" json:"resolvedReaders"`
+	TlfID           TLFID         `codec:"tlfID" json:"tlfID"`
+	ResolvedWriters []gregor1.UID `codec:"resolvedWriters" json:"resolvedWriters"`
+	ResolvedReaders []gregor1.UID `codec:"resolvedReaders" json:"resolvedReaders"`
 }
 
 func (o TlfResolveArg) DeepCopy() TlfResolveArg {
 	return TlfResolveArg{
-		TlfID : o.TlfID.DeepCopy(),
-		ResolvedWriters : (func (x []gregor1.UID) []gregor1.UID {
+		TlfID: o.TlfID.DeepCopy(),
+		ResolvedWriters: (func(x []gregor1.UID) []gregor1.UID {
 			var ret []gregor1.UID
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -990,7 +965,7 @@ func (o TlfResolveArg) DeepCopy() TlfResolveArg {
 			}
 			return ret
 		})(o.ResolvedWriters),
-		ResolvedReaders : (func (x []gregor1.UID) []gregor1.UID {
+		ResolvedReaders: (func(x []gregor1.UID) []gregor1.UID {
 			var ret []gregor1.UID
 			for _, v := range x {
 				vCopy := v.DeepCopy()
@@ -1002,126 +977,125 @@ func (o TlfResolveArg) DeepCopy() TlfResolveArg {
 }
 
 type PublishReadMessageArg struct {
-	Uid	gregor1.UID	`codec:"uid" json:"uid"`
-	ConvID	ConversationID	`codec:"convID" json:"convID"`
-	MsgID	MessageID	`codec:"msgID" json:"msgID"`
+	Uid    gregor1.UID    `codec:"uid" json:"uid"`
+	ConvID ConversationID `codec:"convID" json:"convID"`
+	MsgID  MessageID      `codec:"msgID" json:"msgID"`
 }
 
 func (o PublishReadMessageArg) DeepCopy() PublishReadMessageArg {
 	return PublishReadMessageArg{
-		Uid : o.Uid.DeepCopy(),
-		ConvID : o.ConvID.DeepCopy(),
-		MsgID : o.MsgID.DeepCopy(),
+		Uid:    o.Uid.DeepCopy(),
+		ConvID: o.ConvID.DeepCopy(),
+		MsgID:  o.MsgID.DeepCopy(),
 	}
 }
 
 type PublishSetConversationStatusArg struct {
-	Uid	gregor1.UID	`codec:"uid" json:"uid"`
-	ConvID	ConversationID	`codec:"convID" json:"convID"`
-	Status	ConversationStatus	`codec:"status" json:"status"`
+	Uid    gregor1.UID        `codec:"uid" json:"uid"`
+	ConvID ConversationID     `codec:"convID" json:"convID"`
+	Status ConversationStatus `codec:"status" json:"status"`
 }
 
 func (o PublishSetConversationStatusArg) DeepCopy() PublishSetConversationStatusArg {
 	return PublishSetConversationStatusArg{
-		Uid : o.Uid.DeepCopy(),
-		ConvID : o.ConvID.DeepCopy(),
-		Status : o.Status.DeepCopy(),
+		Uid:    o.Uid.DeepCopy(),
+		ConvID: o.ConvID.DeepCopy(),
+		Status: o.Status.DeepCopy(),
 	}
 }
 
 type UpdateTypingRemoteArg struct {
-	Uid	gregor1.UID	`codec:"uid" json:"uid"`
-	DeviceID	gregor1.DeviceID	`codec:"deviceID" json:"deviceID"`
-	ConvID	ConversationID	`codec:"convID" json:"convID"`
-	Typing	bool	`codec:"typing" json:"typing"`
+	Uid      gregor1.UID      `codec:"uid" json:"uid"`
+	DeviceID gregor1.DeviceID `codec:"deviceID" json:"deviceID"`
+	ConvID   ConversationID   `codec:"convID" json:"convID"`
+	Typing   bool             `codec:"typing" json:"typing"`
 }
 
 func (o UpdateTypingRemoteArg) DeepCopy() UpdateTypingRemoteArg {
 	return UpdateTypingRemoteArg{
-		Uid : o.Uid.DeepCopy(),
-		DeviceID : o.DeviceID.DeepCopy(),
-		ConvID : o.ConvID.DeepCopy(),
-		Typing : o.Typing,
+		Uid:      o.Uid.DeepCopy(),
+		DeviceID: o.DeviceID.DeepCopy(),
+		ConvID:   o.ConvID.DeepCopy(),
+		Typing:   o.Typing,
 	}
 }
 
 type JoinConversationArg struct {
-	ConvID	ConversationID	`codec:"convID" json:"convID"`
+	ConvID ConversationID `codec:"convID" json:"convID"`
 }
 
 func (o JoinConversationArg) DeepCopy() JoinConversationArg {
 	return JoinConversationArg{
-		ConvID : o.ConvID.DeepCopy(),
+		ConvID: o.ConvID.DeepCopy(),
 	}
 }
 
 type LeaveConversationArg struct {
-	ConvID	ConversationID	`codec:"convID" json:"convID"`
+	ConvID ConversationID `codec:"convID" json:"convID"`
 }
 
 func (o LeaveConversationArg) DeepCopy() LeaveConversationArg {
 	return LeaveConversationArg{
-		ConvID : o.ConvID.DeepCopy(),
+		ConvID: o.ConvID.DeepCopy(),
 	}
 }
 
 type GetTLFConversationsArg struct {
-	TlfID	TLFID	`codec:"tlfID" json:"tlfID"`
-	TopicType	TopicType	`codec:"topicType" json:"topicType"`
-	MembersType	ConversationMembersType	`codec:"membersType" json:"membersType"`
-	SummarizeMaxMsgs	bool	`codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
-	IncludeAuxiliaryInfo	bool	`codec:"includeAuxiliaryInfo" json:"includeAuxiliaryInfo"`
+	TlfID                TLFID                   `codec:"tlfID" json:"tlfID"`
+	TopicType            TopicType               `codec:"topicType" json:"topicType"`
+	MembersType          ConversationMembersType `codec:"membersType" json:"membersType"`
+	SummarizeMaxMsgs     bool                    `codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
+	IncludeAuxiliaryInfo bool                    `codec:"includeAuxiliaryInfo" json:"includeAuxiliaryInfo"`
 }
 
 func (o GetTLFConversationsArg) DeepCopy() GetTLFConversationsArg {
 	return GetTLFConversationsArg{
-		TlfID : o.TlfID.DeepCopy(),
-		TopicType : o.TopicType.DeepCopy(),
-		MembersType : o.MembersType.DeepCopy(),
-		SummarizeMaxMsgs : o.SummarizeMaxMsgs,
-		IncludeAuxiliaryInfo : o.IncludeAuxiliaryInfo,
+		TlfID:                o.TlfID.DeepCopy(),
+		TopicType:            o.TopicType.DeepCopy(),
+		MembersType:          o.MembersType.DeepCopy(),
+		SummarizeMaxMsgs:     o.SummarizeMaxMsgs,
+		IncludeAuxiliaryInfo: o.IncludeAuxiliaryInfo,
 	}
 }
 
 type SetAppNotificationSettingsArg struct {
-	ConvID	ConversationID	`codec:"convID" json:"convID"`
-	Settings	ConversationNotificationInfo	`codec:"settings" json:"settings"`
+	ConvID   ConversationID               `codec:"convID" json:"convID"`
+	Settings ConversationNotificationInfo `codec:"settings" json:"settings"`
 }
 
 func (o SetAppNotificationSettingsArg) DeepCopy() SetAppNotificationSettingsArg {
 	return SetAppNotificationSettingsArg{
-		ConvID : o.ConvID.DeepCopy(),
-		Settings : o.Settings.DeepCopy(),
+		ConvID:   o.ConvID.DeepCopy(),
+		Settings: o.Settings.DeepCopy(),
 	}
 }
 
 type SetGlobalAppNotificationSettingsArg struct {
-	Settings	GlobalAppNotificationSettings	`codec:"settings" json:"settings"`
+	Settings GlobalAppNotificationSettings `codec:"settings" json:"settings"`
 }
 
 func (o SetGlobalAppNotificationSettingsArg) DeepCopy() SetGlobalAppNotificationSettingsArg {
 	return SetGlobalAppNotificationSettingsArg{
-		Settings : o.Settings.DeepCopy(),
+		Settings: o.Settings.DeepCopy(),
 	}
 }
 
-type GetGlobalNotificationSettingsArg struct {
+type GetGlobalAppNotificationSettingsArg struct {
 }
 
-func (o GetGlobalNotificationSettingsArg) DeepCopy() GetGlobalNotificationSettingsArg {
-	return GetGlobalNotificationSettingsArg{
-	}
+func (o GetGlobalAppNotificationSettingsArg) DeepCopy() GetGlobalAppNotificationSettingsArg {
+	return GetGlobalAppNotificationSettingsArg{}
 }
 
 type RemoteNotificationSuccessfulArg struct {
-	AuthToken	gregor1.SessionToken	`codec:"authToken" json:"authToken"`
-	CompanionPushIDs	[]string	`codec:"companionPushIDs" json:"companionPushIDs"`
+	AuthToken        gregor1.SessionToken `codec:"authToken" json:"authToken"`
+	CompanionPushIDs []string             `codec:"companionPushIDs" json:"companionPushIDs"`
 }
 
 func (o RemoteNotificationSuccessfulArg) DeepCopy() RemoteNotificationSuccessfulArg {
 	return RemoteNotificationSuccessfulArg{
-		AuthToken : o.AuthToken.DeepCopy(),
-		CompanionPushIDs : (func (x []string) []string {
+		AuthToken: o.AuthToken.DeepCopy(),
+		CompanionPushIDs: (func(x []string) []string {
 			var ret []string
 			for _, v := range x {
 				vCopy := v
@@ -1133,38 +1107,38 @@ func (o RemoteNotificationSuccessfulArg) DeepCopy() RemoteNotificationSuccessful
 }
 
 type RemoteInterface interface {
-	GetInboxRemote(context.Context, GetInboxRemoteArg) (GetInboxRemoteRes,error)
-	GetThreadRemote(context.Context, GetThreadRemoteArg) (GetThreadRemoteRes,error)
-	GetPublicConversations(context.Context, GetPublicConversationsArg) (GetPublicConversationsRes,error)
-	PostRemote(context.Context, PostRemoteArg) (PostRemoteRes,error)
-	NewConversationRemote(context.Context, ConversationIDTriple) (NewConversationRemoteRes,error)
-	NewConversationRemote2(context.Context, NewConversationRemote2Arg) (NewConversationRemoteRes,error)
-	GetMessagesRemote(context.Context, GetMessagesRemoteArg) (GetMessagesRemoteRes,error)
-	MarkAsRead(context.Context, MarkAsReadArg) (MarkAsReadRes,error)
-	SetConversationStatus(context.Context, SetConversationStatusArg) (SetConversationStatusRes,error)
-	GetUnreadUpdateFull(context.Context, InboxVers) (UnreadUpdateFull,error)
-	GetS3Params(context.Context, ConversationID) (S3Params,error)
-	S3Sign(context.Context, S3SignArg) ([]byte,error)
-	GetInboxVersion(context.Context, gregor1.UID) (InboxVers,error)
-	SyncInbox(context.Context, InboxVers) (SyncInboxRes,error)
-	SyncChat(context.Context, InboxVers) (SyncChatRes,error)
-	SyncAll(context.Context, SyncAllArg) (SyncAllResult,error)
-	TlfFinalize(context.Context, TlfFinalizeArg) (error)
-	TlfResolve(context.Context, TlfResolveArg) (error)
-	PublishReadMessage(context.Context, PublishReadMessageArg) (error)
-	PublishSetConversationStatus(context.Context, PublishSetConversationStatusArg) (error)
-	UpdateTypingRemote(context.Context, UpdateTypingRemoteArg) (error)
-	JoinConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes,error)
-	LeaveConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes,error)
-	GetTLFConversations(context.Context, GetTLFConversationsArg) (GetTLFConversationsRes,error)
-	SetAppNotificationSettings(context.Context, SetAppNotificationSettingsArg) (SetAppNotificationSettingsRes,error)
-	SetGlobalAppNotificationSettings(context.Context, GlobalAppNotificationSettings) (error)
-	GetGlobalNotificationSettings(context.Context, ) (GlobalAppNotificationSettings,error)
-	RemoteNotificationSuccessful(context.Context, RemoteNotificationSuccessfulArg) (error)
+	GetInboxRemote(context.Context, GetInboxRemoteArg) (GetInboxRemoteRes, error)
+	GetThreadRemote(context.Context, GetThreadRemoteArg) (GetThreadRemoteRes, error)
+	GetPublicConversations(context.Context, GetPublicConversationsArg) (GetPublicConversationsRes, error)
+	PostRemote(context.Context, PostRemoteArg) (PostRemoteRes, error)
+	NewConversationRemote(context.Context, ConversationIDTriple) (NewConversationRemoteRes, error)
+	NewConversationRemote2(context.Context, NewConversationRemote2Arg) (NewConversationRemoteRes, error)
+	GetMessagesRemote(context.Context, GetMessagesRemoteArg) (GetMessagesRemoteRes, error)
+	MarkAsRead(context.Context, MarkAsReadArg) (MarkAsReadRes, error)
+	SetConversationStatus(context.Context, SetConversationStatusArg) (SetConversationStatusRes, error)
+	GetUnreadUpdateFull(context.Context, InboxVers) (UnreadUpdateFull, error)
+	GetS3Params(context.Context, ConversationID) (S3Params, error)
+	S3Sign(context.Context, S3SignArg) ([]byte, error)
+	GetInboxVersion(context.Context, gregor1.UID) (InboxVers, error)
+	SyncInbox(context.Context, InboxVers) (SyncInboxRes, error)
+	SyncChat(context.Context, InboxVers) (SyncChatRes, error)
+	SyncAll(context.Context, SyncAllArg) (SyncAllResult, error)
+	TlfFinalize(context.Context, TlfFinalizeArg) error
+	TlfResolve(context.Context, TlfResolveArg) error
+	PublishReadMessage(context.Context, PublishReadMessageArg) error
+	PublishSetConversationStatus(context.Context, PublishSetConversationStatusArg) error
+	UpdateTypingRemote(context.Context, UpdateTypingRemoteArg) error
+	JoinConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes, error)
+	LeaveConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes, error)
+	GetTLFConversations(context.Context, GetTLFConversationsArg) (GetTLFConversationsRes, error)
+	SetAppNotificationSettings(context.Context, SetAppNotificationSettingsArg) (SetAppNotificationSettingsRes, error)
+	SetGlobalAppNotificationSettings(context.Context, GlobalAppNotificationSettings) error
+	GetGlobalAppNotificationSettings(context.Context) (GlobalAppNotificationSettings, error)
+	RemoteNotificationSuccessful(context.Context, RemoteNotificationSuccessfulArg) error
 }
 
 func RemoteProtocol(i RemoteInterface) rpc.Protocol {
-	return rpc.Protocol {
+	return rpc.Protocol{
 		Name: "chat.1.remote",
 		Methods: map[string]rpc.ServeHandlerDescription{
 			"getInboxRemote": {
@@ -1583,13 +1557,13 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"getGlobalNotificationSettings": {
+			"getGlobalAppNotificationSettings": {
 				MakeArg: func() interface{} {
-					ret := make([]GetGlobalNotificationSettingsArg, 1)
+					ret := make([]GetGlobalAppNotificationSettingsArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					ret, err = i.GetGlobalNotificationSettings(ctx, )
+					ret, err = i.GetGlobalAppNotificationSettings(ctx)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1618,88 +1592,88 @@ type RemoteClient struct {
 	Cli rpc.GenericClient
 }
 
-func (c RemoteClient) GetInboxRemote(ctx context.Context, __arg GetInboxRemoteArg) (res GetInboxRemoteRes,err error) {
+func (c RemoteClient) GetInboxRemote(ctx context.Context, __arg GetInboxRemoteArg) (res GetInboxRemoteRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getInboxRemote", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetThreadRemote(ctx context.Context, __arg GetThreadRemoteArg) (res GetThreadRemoteRes,err error) {
+func (c RemoteClient) GetThreadRemote(ctx context.Context, __arg GetThreadRemoteArg) (res GetThreadRemoteRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getThreadRemote", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetPublicConversations(ctx context.Context, __arg GetPublicConversationsArg) (res GetPublicConversationsRes,err error) {
+func (c RemoteClient) GetPublicConversations(ctx context.Context, __arg GetPublicConversationsArg) (res GetPublicConversationsRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getPublicConversations", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) PostRemote(ctx context.Context, __arg PostRemoteArg) (res PostRemoteRes,err error) {
+func (c RemoteClient) PostRemote(ctx context.Context, __arg PostRemoteArg) (res PostRemoteRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.postRemote", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) NewConversationRemote(ctx context.Context, idTriple ConversationIDTriple) (res NewConversationRemoteRes,err error) {
-	__arg := NewConversationRemoteArg{ IdTriple : idTriple }
+func (c RemoteClient) NewConversationRemote(ctx context.Context, idTriple ConversationIDTriple) (res NewConversationRemoteRes, err error) {
+	__arg := NewConversationRemoteArg{IdTriple: idTriple}
 	err = c.Cli.Call(ctx, "chat.1.remote.newConversationRemote", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) NewConversationRemote2(ctx context.Context, __arg NewConversationRemote2Arg) (res NewConversationRemoteRes,err error) {
+func (c RemoteClient) NewConversationRemote2(ctx context.Context, __arg NewConversationRemote2Arg) (res NewConversationRemoteRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.newConversationRemote2", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetMessagesRemote(ctx context.Context, __arg GetMessagesRemoteArg) (res GetMessagesRemoteRes,err error) {
+func (c RemoteClient) GetMessagesRemote(ctx context.Context, __arg GetMessagesRemoteArg) (res GetMessagesRemoteRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getMessagesRemote", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) MarkAsRead(ctx context.Context, __arg MarkAsReadArg) (res MarkAsReadRes,err error) {
+func (c RemoteClient) MarkAsRead(ctx context.Context, __arg MarkAsReadArg) (res MarkAsReadRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.markAsRead", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) SetConversationStatus(ctx context.Context, __arg SetConversationStatusArg) (res SetConversationStatusRes,err error) {
+func (c RemoteClient) SetConversationStatus(ctx context.Context, __arg SetConversationStatusArg) (res SetConversationStatusRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.SetConversationStatus", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetUnreadUpdateFull(ctx context.Context, inboxVers InboxVers) (res UnreadUpdateFull,err error) {
-	__arg := GetUnreadUpdateFullArg{ InboxVers : inboxVers }
+func (c RemoteClient) GetUnreadUpdateFull(ctx context.Context, inboxVers InboxVers) (res UnreadUpdateFull, err error) {
+	__arg := GetUnreadUpdateFullArg{InboxVers: inboxVers}
 	err = c.Cli.Call(ctx, "chat.1.remote.GetUnreadUpdateFull", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetS3Params(ctx context.Context, conversationID ConversationID) (res S3Params,err error) {
-	__arg := GetS3ParamsArg{ ConversationID : conversationID }
+func (c RemoteClient) GetS3Params(ctx context.Context, conversationID ConversationID) (res S3Params, err error) {
+	__arg := GetS3ParamsArg{ConversationID: conversationID}
 	err = c.Cli.Call(ctx, "chat.1.remote.getS3Params", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) S3Sign(ctx context.Context, __arg S3SignArg) (res []byte,err error) {
+func (c RemoteClient) S3Sign(ctx context.Context, __arg S3SignArg) (res []byte, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.s3Sign", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetInboxVersion(ctx context.Context, uid gregor1.UID) (res InboxVers,err error) {
-	__arg := GetInboxVersionArg{ Uid : uid }
+func (c RemoteClient) GetInboxVersion(ctx context.Context, uid gregor1.UID) (res InboxVers, err error) {
+	__arg := GetInboxVersionArg{Uid: uid}
 	err = c.Cli.Call(ctx, "chat.1.remote.getInboxVersion", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) SyncInbox(ctx context.Context, vers InboxVers) (res SyncInboxRes,err error) {
-	__arg := SyncInboxArg{ Vers : vers }
+func (c RemoteClient) SyncInbox(ctx context.Context, vers InboxVers) (res SyncInboxRes, err error) {
+	__arg := SyncInboxArg{Vers: vers}
 	err = c.Cli.Call(ctx, "chat.1.remote.syncInbox", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) SyncChat(ctx context.Context, vers InboxVers) (res SyncChatRes,err error) {
-	__arg := SyncChatArg{ Vers : vers }
+func (c RemoteClient) SyncChat(ctx context.Context, vers InboxVers) (res SyncChatRes, err error) {
+	__arg := SyncChatArg{Vers: vers}
 	err = c.Cli.Call(ctx, "chat.1.remote.syncChat", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) SyncAll(ctx context.Context, __arg SyncAllArg) (res SyncAllResult,err error) {
+func (c RemoteClient) SyncAll(ctx context.Context, __arg SyncAllArg) (res SyncAllResult, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.syncAll", []interface{}{__arg}, &res)
 	return
 }
@@ -1729,36 +1703,36 @@ func (c RemoteClient) UpdateTypingRemote(ctx context.Context, __arg UpdateTyping
 	return
 }
 
-func (c RemoteClient) JoinConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes,err error) {
-	__arg := JoinConversationArg{ ConvID : convID }
+func (c RemoteClient) JoinConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes, err error) {
+	__arg := JoinConversationArg{ConvID: convID}
 	err = c.Cli.Call(ctx, "chat.1.remote.joinConversation", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) LeaveConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes,err error) {
-	__arg := LeaveConversationArg{ ConvID : convID }
+func (c RemoteClient) LeaveConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes, err error) {
+	__arg := LeaveConversationArg{ConvID: convID}
 	err = c.Cli.Call(ctx, "chat.1.remote.leaveConversation", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) GetTLFConversations(ctx context.Context, __arg GetTLFConversationsArg) (res GetTLFConversationsRes,err error) {
+func (c RemoteClient) GetTLFConversations(ctx context.Context, __arg GetTLFConversationsArg) (res GetTLFConversationsRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getTLFConversations", []interface{}{__arg}, &res)
 	return
 }
 
-func (c RemoteClient) SetAppNotificationSettings(ctx context.Context, __arg SetAppNotificationSettingsArg) (res SetAppNotificationSettingsRes,err error) {
+func (c RemoteClient) SetAppNotificationSettings(ctx context.Context, __arg SetAppNotificationSettingsArg) (res SetAppNotificationSettingsRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.setAppNotificationSettings", []interface{}{__arg}, &res)
 	return
 }
 
 func (c RemoteClient) SetGlobalAppNotificationSettings(ctx context.Context, settings GlobalAppNotificationSettings) (err error) {
-	__arg := SetGlobalAppNotificationSettingsArg{ Settings : settings }
+	__arg := SetGlobalAppNotificationSettingsArg{Settings: settings}
 	err = c.Cli.Call(ctx, "chat.1.remote.setGlobalAppNotificationSettings", []interface{}{__arg}, nil)
 	return
 }
 
-func (c RemoteClient) GetGlobalNotificationSettings(ctx context.Context, ) (res GlobalAppNotificationSettings,err error) {
-	err = c.Cli.Call(ctx, "chat.1.remote.getGlobalNotificationSettings", []interface{}{GetGlobalNotificationSettingsArg{}}, &res)
+func (c RemoteClient) GetGlobalAppNotificationSettings(ctx context.Context) (res GlobalAppNotificationSettings, err error) {
+	err = c.Cli.Call(ctx, "chat.1.remote.getGlobalAppNotificationSettings", []interface{}{GetGlobalAppNotificationSettingsArg{}}, &res)
 	return
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -49,6 +49,16 @@ protocol common {
     ATMENTION_1
   }
 
+  // Global notification settings (on by default)
+  enum GlobalAppNotificationSetting {
+    NEWMESSAGES_0,
+    PLAINTEXTMOBILE_1,
+    PLAINTEXTDESKTOP_2
+  }
+  record GlobalAppNotificationSettings {
+    map<GlobalAppNotificationSetting, bool> settings;
+  }
+
   enum ConversationStatus {
     // Default status of the conversation
     UNFILED_0,

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -676,6 +676,7 @@ protocol local {
     array<RateLimit> rateLimits;
   }
   SetAppNotificationSettingsLocalRes setAppNotificationSettingsLocal(ConversationID convID, ConversationNotificationInfo settings);
+  void setGlobalAppNotificationSettingsLocal(GlobalAppNotificationSettings settings);
 
   // Unpack message from a push notification
   string unboxMobilePushNotification(string payload, string convID, ConversationMembersType membersType, array<string> pushIDs);

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -676,7 +676,7 @@ protocol local {
     array<RateLimit> rateLimits;
   }
   SetAppNotificationSettingsLocalRes setAppNotificationSettingsLocal(ConversationID convID, ConversationNotificationInfo settings);
-  void setGlobalAppNotificationSettingsLocal(GlobalAppNotificationSettings settings);
+  void setGlobalAppNotificationSettingsLocal(map<string, bool> settings);
   GlobalAppNotificationSettings getGlobalAppNotificationSettingsLocal();
 
   // Unpack message from a push notification

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -677,6 +677,7 @@ protocol local {
   }
   SetAppNotificationSettingsLocalRes setAppNotificationSettingsLocal(ConversationID convID, ConversationNotificationInfo settings);
   void setGlobalAppNotificationSettingsLocal(GlobalAppNotificationSettings settings);
+  GlobalAppNotificationSettings getGlobalAppNotificationSettingsLocal();
 
   // Unpack message from a push notification
   string unboxMobilePushNotification(string payload, string convID, ConversationMembersType membersType, array<string> pushIDs);

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -238,7 +238,16 @@ protocol remote {
     union { null, RateLimit } rateLimit;
   }
   SetAppNotificationSettingsRes setAppNotificationSettings(ConversationID convID, ConversationNotificationInfo settings);
+  // Global notification settings (on by default)
+  enum GlobalAppNotificationSetting {
+    NEWMESSAGES_0,
+    PLAINTEXTMOBILE_1,
+    PLAINTEXTDESKTOP_2
+  }
+  @typedef("map<GlobalAppNotificationSetting, bool>") record GlobalAppNotificationSettings {}
+  void setGlobalAppNotificationSettings(GlobalAppNotificationSettings settings);
+  GlobalAppNotificationSettings getGlobalNotificationSettings();
 
   // Endpoint to indicate a high priority push notification has been processed
- void remoteNotificationSuccessful(gregor1.SessionToken authToken, array<string> companionPushIDs);
+  void remoteNotificationSuccessful(gregor1.SessionToken authToken, array<string> companionPushIDs);
 }

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -238,15 +238,8 @@ protocol remote {
     union { null, RateLimit } rateLimit;
   }
   SetAppNotificationSettingsRes setAppNotificationSettings(ConversationID convID, ConversationNotificationInfo settings);
-  // Global notification settings (on by default)
-  enum GlobalAppNotificationSetting {
-    NEWMESSAGES_0,
-    PLAINTEXTMOBILE_1,
-    PLAINTEXTDESKTOP_2
-  }
-  @typedef("map<GlobalAppNotificationSetting, bool>") record GlobalAppNotificationSettings {}
   void setGlobalAppNotificationSettings(GlobalAppNotificationSettings settings);
-  GlobalAppNotificationSettings getGlobalNotificationSettings();
+  GlobalAppNotificationSettings getGlobalAppNotificationSettings();
 
   // Endpoint to indicate a high priority push notification has been processed
   void remoteNotificationSuccessful(gregor1.SessionToken authToken, array<string> companionPushIDs);

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -77,6 +77,12 @@ export const CommonConversationStatus = {
   reported: 5,
 }
 
+export const CommonGlobalAppNotificationSetting = {
+  newmessages: 0,
+  plaintextmobile: 1,
+  plaintextdesktop: 2,
+}
+
 export const CommonInboxResType = {
   versionhit: 0,
   full: 1,
@@ -586,6 +592,18 @@ export function localSetConversationStatusLocalRpcPromise (request: $Exact<reque
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localSetGlobalAppNotificationSettingsLocalRpc (request: Exact<requestCommon & requestErrorCallback & {param: localSetGlobalAppNotificationSettingsLocalRpcParam}>) {
+  engineRpcOutgoing('chat.1.local.setGlobalAppNotificationSettingsLocal', request)
+}
+
+export function localSetGlobalAppNotificationSettingsLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localSetGlobalAppNotificationSettingsLocalRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.setGlobalAppNotificationSettingsLocal', request)
+}
+
+export function localSetGlobalAppNotificationSettingsLocalRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localSetGlobalAppNotificationSettingsLocalRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.setGlobalAppNotificationSettingsLocal', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localUnboxMobilePushNotificationRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localUnboxMobilePushNotificationResult) => void} & {param: localUnboxMobilePushNotificationRpcParam}>) {
   engineRpcOutgoing('chat.1.local.unboxMobilePushNotification', request)
 }
@@ -608,6 +626,18 @@ export function localUpdateTypingRpcChannelMap (configKeys: Array<string>, reque
 
 export function localUpdateTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): Promise<void> {
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.updateTyping', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function remoteGetGlobalAppNotificationSettingsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetGlobalAppNotificationSettingsResult) => void}>) {
+  engineRpcOutgoing('chat.1.remote.getGlobalAppNotificationSettings', request)
+}
+
+export function remoteGetGlobalAppNotificationSettingsRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetGlobalAppNotificationSettingsResult) => void}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getGlobalAppNotificationSettings', request)
+}
+
+export function remoteGetGlobalAppNotificationSettingsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetGlobalAppNotificationSettingsResult) => void}>): Promise<remoteGetGlobalAppNotificationSettingsResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.getGlobalAppNotificationSettings', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function remoteGetInboxRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {param: remoteGetInboxRemoteRpcParam}>) {
@@ -848,6 +878,18 @@ export function remoteSetConversationStatusRpcChannelMap (configKeys: Array<stri
 
 export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {param: remoteSetConversationStatusRpcParam}>): Promise<remoteSetConversationStatusResult> {
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function remoteSetGlobalAppNotificationSettingsRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteSetGlobalAppNotificationSettingsRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.setGlobalAppNotificationSettings', request)
+}
+
+export function remoteSetGlobalAppNotificationSettingsRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteSetGlobalAppNotificationSettingsRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.setGlobalAppNotificationSettings', request)
+}
+
+export function remoteSetGlobalAppNotificationSettingsRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteSetGlobalAppNotificationSettingsRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.setGlobalAppNotificationSettings', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function remoteSyncAllRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>) {
@@ -1353,6 +1395,15 @@ export type GetThreadQuery = {
 export type GetThreadRemoteRes = {
   thread: ThreadViewBoxed,
   rateLimit?: ?RateLimit,
+}
+
+export type GlobalAppNotificationSetting =
+    0 // NEWMESSAGES_0
+  | 1 // PLAINTEXTMOBILE_1
+  | 2 // PLAINTEXTDESKTOP_2
+
+export type GlobalAppNotificationSettings = {
+  settings: {[key: string]: bool},
 }
 
 export type Hash = bytes
@@ -2273,6 +2324,10 @@ export type localSetConversationStatusLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
+export type localSetGlobalAppNotificationSettingsLocalRpcParam = Exact<{
+  settings: GlobalAppNotificationSettings
+}>
+
 export type localUnboxMobilePushNotificationRpcParam = Exact<{
   payload: string,
   convID: string,
@@ -2392,6 +2447,10 @@ export type remoteSetConversationStatusRpcParam = Exact<{
   status: ConversationStatus
 }>
 
+export type remoteSetGlobalAppNotificationSettingsRpcParam = Exact<{
+  settings: GlobalAppNotificationSettings
+}>
+
 export type remoteSyncAllRpcParam = Exact<{
   uid: gregor1.UID,
   deviceID: gregor1.DeviceID,
@@ -2458,6 +2517,7 @@ type localPostTextNonblockResult = PostLocalNonblockRes
 type localSetAppNotificationSettingsLocalResult = SetAppNotificationSettingsLocalRes
 type localSetConversationStatusLocalResult = SetConversationStatusLocalRes
 type localUnboxMobilePushNotificationResult = string
+type remoteGetGlobalAppNotificationSettingsResult = GlobalAppNotificationSettings
 type remoteGetInboxRemoteResult = GetInboxRemoteRes
 type remoteGetInboxVersionResult = InboxVers
 type remoteGetMessagesRemoteResult = GetMessagesRemoteRes
@@ -2510,8 +2570,10 @@ export type rpc =
   | localRetryPostRpc
   | localSetAppNotificationSettingsLocalRpc
   | localSetConversationStatusLocalRpc
+  | localSetGlobalAppNotificationSettingsLocalRpc
   | localUnboxMobilePushNotificationRpc
   | localUpdateTypingRpc
+  | remoteGetGlobalAppNotificationSettingsRpc
   | remoteGetInboxRemoteRpc
   | remoteGetInboxVersionRpc
   | remoteGetMessagesRemoteRpc
@@ -2532,6 +2594,7 @@ export type rpc =
   | remoteS3SignRpc
   | remoteSetAppNotificationSettingsRpc
   | remoteSetConversationStatusRpc
+  | remoteSetGlobalAppNotificationSettingsRpc
   | remoteSyncAllRpc
   | remoteSyncChatRpc
   | remoteSyncInboxRpc

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2337,7 +2337,7 @@ export type localSetConversationStatusLocalRpcParam = Exact<{
 }>
 
 export type localSetGlobalAppNotificationSettingsLocalRpcParam = Exact<{
-  settings: GlobalAppNotificationSettings
+  settings: {[key: string]: bool}
 }>
 
 export type localUnboxMobilePushNotificationRpcParam = Exact<{

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -316,6 +316,18 @@ export function localGetConversationForCLILocalRpcPromise (request: $Exact<reque
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getConversationForCLILocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localGetGlobalAppNotificationSettingsLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetGlobalAppNotificationSettingsLocalResult) => void}>) {
+  engineRpcOutgoing('chat.1.local.getGlobalAppNotificationSettingsLocal', request)
+}
+
+export function localGetGlobalAppNotificationSettingsLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetGlobalAppNotificationSettingsLocalResult) => void}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getGlobalAppNotificationSettingsLocal', request)
+}
+
+export function localGetGlobalAppNotificationSettingsLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetGlobalAppNotificationSettingsLocalResult) => void}>): Promise<localGetGlobalAppNotificationSettingsLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getGlobalAppNotificationSettingsLocal', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localGetInboxAndUnboxLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxAndUnboxLocalResult) => void} & {param: localGetInboxAndUnboxLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getInboxAndUnboxLocal', request)
 }
@@ -2494,6 +2506,7 @@ type localFindConversationsLocalResult = FindConversationsLocalRes
 type localGenerateOutboxIDResult = OutboxID
 type localGetCachedThreadResult = GetThreadLocalRes
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
+type localGetGlobalAppNotificationSettingsLocalResult = GlobalAppNotificationSettings
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
 type localGetInboxNonblockLocalResult = NonblockFetchRes
 type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
@@ -2547,6 +2560,7 @@ export type rpc =
   | localGenerateOutboxIDRpc
   | localGetCachedThreadRpc
   | localGetConversationForCLILocalRpc
+  | localGetGlobalAppNotificationSettingsLocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxNonblockLocalRpc
   | localGetInboxSummaryForCLILocalRpc

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -124,6 +124,29 @@
     },
     {
       "type": "enum",
+      "name": "GlobalAppNotificationSetting",
+      "symbols": [
+        "NEWMESSAGES_0",
+        "PLAINTEXTMOBILE_1",
+        "PLAINTEXTDESKTOP_2"
+      ]
+    },
+    {
+      "type": "record",
+      "name": "GlobalAppNotificationSettings",
+      "fields": [
+        {
+          "type": {
+            "type": "map",
+            "values": "bool",
+            "keys": "GlobalAppNotificationSetting"
+          },
+          "name": "settings"
+        }
+      ]
+    },
+    {
+      "type": "enum",
       "name": "ConversationStatus",
       "symbols": [
         "UNFILED_0",

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2633,7 +2633,11 @@
       "request": [
         {
           "name": "settings",
-          "type": "GlobalAppNotificationSettings"
+          "type": {
+            "type": "map",
+            "values": "bool",
+            "keys": "string"
+          }
         }
       ],
       "response": null

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2629,6 +2629,15 @@
       ],
       "response": "SetAppNotificationSettingsLocalRes"
     },
+    "setGlobalAppNotificationSettingsLocal": {
+      "request": [
+        {
+          "name": "settings",
+          "type": "GlobalAppNotificationSettings"
+        }
+      ],
+      "response": null
+    },
     "unboxMobilePushNotification": {
       "request": [
         {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2638,6 +2638,10 @@
       ],
       "response": null
     },
+    "getGlobalAppNotificationSettingsLocal": {
+      "request": [],
+      "response": "GlobalAppNotificationSettings"
+    },
     "unboxMobilePushNotification": {
       "request": [
         {

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -493,21 +493,6 @@
           "name": "rateLimit"
         }
       ]
-    },
-    {
-      "type": "enum",
-      "name": "GlobalAppNotificationSetting",
-      "symbols": [
-        "NEWMESSAGES_0",
-        "PLAINTEXTMOBILE_1",
-        "PLAINTEXTDESKTOP_2"
-      ]
-    },
-    {
-      "type": "record",
-      "name": "GlobalAppNotificationSettings",
-      "fields": [],
-      "typedef": "map<GlobalAppNotificationSetting, bool>"
     }
   ],
   "messages": {
@@ -938,7 +923,7 @@
       ],
       "response": null
     },
-    "getGlobalNotificationSettings": {
+    "getGlobalAppNotificationSettings": {
       "request": [],
       "response": "GlobalAppNotificationSettings"
     },

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -493,6 +493,21 @@
           "name": "rateLimit"
         }
       ]
+    },
+    {
+      "type": "enum",
+      "name": "GlobalAppNotificationSetting",
+      "symbols": [
+        "NEWMESSAGES_0",
+        "PLAINTEXTMOBILE_1",
+        "PLAINTEXTDESKTOP_2"
+      ]
+    },
+    {
+      "type": "record",
+      "name": "GlobalAppNotificationSettings",
+      "fields": [],
+      "typedef": "map<GlobalAppNotificationSetting, bool>"
     }
   ],
   "messages": {
@@ -913,6 +928,19 @@
         }
       ],
       "response": "SetAppNotificationSettingsRes"
+    },
+    "setGlobalAppNotificationSettings": {
+      "request": [
+        {
+          "name": "settings",
+          "type": "GlobalAppNotificationSettings"
+        }
+      ],
+      "response": null
+    },
+    "getGlobalNotificationSettings": {
+      "request": [],
+      "response": "GlobalAppNotificationSettings"
     },
     "remoteNotificationSuccessful": {
       "request": [

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -392,7 +392,7 @@ function* refreshNotificationsSaga(): SagaGenerator<any, any> {
   ])
   yield cancel(delayThenEmptyTask)
 
-  let results: {
+  const results: {
     notifications: {
       email: {
         settings: Array<{

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -201,7 +201,7 @@ function* saveNotificationsSaga(): SagaGenerator<any, any> {
       }
     }
 
-    const result = yield all([
+    const [result] = yield all([
       call(apiserverPostJSONRpcPromise, {
         param: {
           endpoint: 'account/subscribe',

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Constants from '../constants/settings'
+import * as ChatTypes from '../constants/types/flow-types-chat'
 import HiddenString from '../util/hidden-string'
 import {
   apiserverGetWithSessionRpcPromise,
@@ -369,10 +370,14 @@ function* refreshNotificationsSaga(): SagaGenerator<any, any> {
       args: [],
     },
   })
+  const chatGlobalSettings: ChatTypes.GlobalAppNotificationSettings = yield call(
+    ChatTypes.localGetGlobalAppNotificationSettingsLocalRpcPromise,
+    {}
+  )
 
   yield cancel(delayThenEmptyTask)
 
-  const results: {
+  let results: {
     notifications: {
       email: {
         settings: Array<{
@@ -382,8 +387,28 @@ function* refreshNotificationsSaga(): SagaGenerator<any, any> {
         }>,
         unsub: boolean,
       },
+      security: {
+        settings: Array<{
+          name: string,
+          description: string,
+          subscribed: boolean,
+        }>,
+        unsub: boolean,
+      },
     },
   } = JSON.parse((json && json.body) || '')
+  results.notifications['security'] = {
+    settings: [
+      {
+        name: 'mobileplaintext',
+        description: 'Display mobile plaintext notifications',
+        subscribed: chatGlobalSettings.settings[
+          `${ChatTypes.CommonGlobalAppNotificationSetting.plaintextmobile}`
+        ],
+      },
+    ],
+    unsub: false,
+  }
 
   const settingsToPayload = s =>
     ({

--- a/shared/constants/settings.js
+++ b/shared/constants/settings.js
@@ -205,3 +205,5 @@ export function waiting(waiting: boolean): TypedAction<'settings:waitingForRespo
     payload: waiting,
   }
 }
+
+export const securityGroup = 'security'

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -77,6 +77,12 @@ export const CommonConversationStatus = {
   reported: 5,
 }
 
+export const CommonGlobalAppNotificationSetting = {
+  newmessages: 0,
+  plaintextmobile: 1,
+  plaintextdesktop: 2,
+}
+
 export const CommonInboxResType = {
   versionhit: 0,
   full: 1,
@@ -586,6 +592,18 @@ export function localSetConversationStatusLocalRpcPromise (request: $Exact<reque
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localSetGlobalAppNotificationSettingsLocalRpc (request: Exact<requestCommon & requestErrorCallback & {param: localSetGlobalAppNotificationSettingsLocalRpcParam}>) {
+  engineRpcOutgoing('chat.1.local.setGlobalAppNotificationSettingsLocal', request)
+}
+
+export function localSetGlobalAppNotificationSettingsLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localSetGlobalAppNotificationSettingsLocalRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.setGlobalAppNotificationSettingsLocal', request)
+}
+
+export function localSetGlobalAppNotificationSettingsLocalRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localSetGlobalAppNotificationSettingsLocalRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.setGlobalAppNotificationSettingsLocal', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localUnboxMobilePushNotificationRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localUnboxMobilePushNotificationResult) => void} & {param: localUnboxMobilePushNotificationRpcParam}>) {
   engineRpcOutgoing('chat.1.local.unboxMobilePushNotification', request)
 }
@@ -608,6 +626,18 @@ export function localUpdateTypingRpcChannelMap (configKeys: Array<string>, reque
 
 export function localUpdateTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): Promise<void> {
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.updateTyping', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function remoteGetGlobalAppNotificationSettingsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetGlobalAppNotificationSettingsResult) => void}>) {
+  engineRpcOutgoing('chat.1.remote.getGlobalAppNotificationSettings', request)
+}
+
+export function remoteGetGlobalAppNotificationSettingsRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetGlobalAppNotificationSettingsResult) => void}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getGlobalAppNotificationSettings', request)
+}
+
+export function remoteGetGlobalAppNotificationSettingsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetGlobalAppNotificationSettingsResult) => void}>): Promise<remoteGetGlobalAppNotificationSettingsResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.getGlobalAppNotificationSettings', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function remoteGetInboxRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {param: remoteGetInboxRemoteRpcParam}>) {
@@ -848,6 +878,18 @@ export function remoteSetConversationStatusRpcChannelMap (configKeys: Array<stri
 
 export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {param: remoteSetConversationStatusRpcParam}>): Promise<remoteSetConversationStatusResult> {
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function remoteSetGlobalAppNotificationSettingsRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteSetGlobalAppNotificationSettingsRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.setGlobalAppNotificationSettings', request)
+}
+
+export function remoteSetGlobalAppNotificationSettingsRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteSetGlobalAppNotificationSettingsRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.setGlobalAppNotificationSettings', request)
+}
+
+export function remoteSetGlobalAppNotificationSettingsRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteSetGlobalAppNotificationSettingsRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.setGlobalAppNotificationSettings', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function remoteSyncAllRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>) {
@@ -1353,6 +1395,15 @@ export type GetThreadQuery = {
 export type GetThreadRemoteRes = {
   thread: ThreadViewBoxed,
   rateLimit?: ?RateLimit,
+}
+
+export type GlobalAppNotificationSetting =
+    0 // NEWMESSAGES_0
+  | 1 // PLAINTEXTMOBILE_1
+  | 2 // PLAINTEXTDESKTOP_2
+
+export type GlobalAppNotificationSettings = {
+  settings: {[key: string]: bool},
 }
 
 export type Hash = bytes
@@ -2273,6 +2324,10 @@ export type localSetConversationStatusLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
+export type localSetGlobalAppNotificationSettingsLocalRpcParam = Exact<{
+  settings: GlobalAppNotificationSettings
+}>
+
 export type localUnboxMobilePushNotificationRpcParam = Exact<{
   payload: string,
   convID: string,
@@ -2392,6 +2447,10 @@ export type remoteSetConversationStatusRpcParam = Exact<{
   status: ConversationStatus
 }>
 
+export type remoteSetGlobalAppNotificationSettingsRpcParam = Exact<{
+  settings: GlobalAppNotificationSettings
+}>
+
 export type remoteSyncAllRpcParam = Exact<{
   uid: gregor1.UID,
   deviceID: gregor1.DeviceID,
@@ -2458,6 +2517,7 @@ type localPostTextNonblockResult = PostLocalNonblockRes
 type localSetAppNotificationSettingsLocalResult = SetAppNotificationSettingsLocalRes
 type localSetConversationStatusLocalResult = SetConversationStatusLocalRes
 type localUnboxMobilePushNotificationResult = string
+type remoteGetGlobalAppNotificationSettingsResult = GlobalAppNotificationSettings
 type remoteGetInboxRemoteResult = GetInboxRemoteRes
 type remoteGetInboxVersionResult = InboxVers
 type remoteGetMessagesRemoteResult = GetMessagesRemoteRes
@@ -2510,8 +2570,10 @@ export type rpc =
   | localRetryPostRpc
   | localSetAppNotificationSettingsLocalRpc
   | localSetConversationStatusLocalRpc
+  | localSetGlobalAppNotificationSettingsLocalRpc
   | localUnboxMobilePushNotificationRpc
   | localUpdateTypingRpc
+  | remoteGetGlobalAppNotificationSettingsRpc
   | remoteGetInboxRemoteRpc
   | remoteGetInboxVersionRpc
   | remoteGetMessagesRemoteRpc
@@ -2532,6 +2594,7 @@ export type rpc =
   | remoteS3SignRpc
   | remoteSetAppNotificationSettingsRpc
   | remoteSetConversationStatusRpc
+  | remoteSetGlobalAppNotificationSettingsRpc
   | remoteSyncAllRpc
   | remoteSyncChatRpc
   | remoteSyncInboxRpc

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2337,7 +2337,7 @@ export type localSetConversationStatusLocalRpcParam = Exact<{
 }>
 
 export type localSetGlobalAppNotificationSettingsLocalRpcParam = Exact<{
-  settings: GlobalAppNotificationSettings
+  settings: {[key: string]: bool}
 }>
 
 export type localUnboxMobilePushNotificationRpcParam = Exact<{

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -316,6 +316,18 @@ export function localGetConversationForCLILocalRpcPromise (request: $Exact<reque
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getConversationForCLILocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localGetGlobalAppNotificationSettingsLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetGlobalAppNotificationSettingsLocalResult) => void}>) {
+  engineRpcOutgoing('chat.1.local.getGlobalAppNotificationSettingsLocal', request)
+}
+
+export function localGetGlobalAppNotificationSettingsLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetGlobalAppNotificationSettingsLocalResult) => void}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getGlobalAppNotificationSettingsLocal', request)
+}
+
+export function localGetGlobalAppNotificationSettingsLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetGlobalAppNotificationSettingsLocalResult) => void}>): Promise<localGetGlobalAppNotificationSettingsLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getGlobalAppNotificationSettingsLocal', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localGetInboxAndUnboxLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxAndUnboxLocalResult) => void} & {param: localGetInboxAndUnboxLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getInboxAndUnboxLocal', request)
 }
@@ -2494,6 +2506,7 @@ type localFindConversationsLocalResult = FindConversationsLocalRes
 type localGenerateOutboxIDResult = OutboxID
 type localGetCachedThreadResult = GetThreadLocalRes
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
+type localGetGlobalAppNotificationSettingsLocalResult = GlobalAppNotificationSettings
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
 type localGetInboxNonblockLocalResult = NonblockFetchRes
 type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
@@ -2547,6 +2560,7 @@ export type rpc =
   | localGenerateOutboxIDRpc
   | localGetCachedThreadRpc
   | localGetConversationForCLILocalRpc
+  | localGetGlobalAppNotificationSettingsLocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxNonblockLocalRpc
   | localGetInboxSummaryForCLILocalRpc

--- a/shared/reducers/settings.js
+++ b/shared/reducers/settings.js
@@ -63,7 +63,6 @@ function reducer(state: State = initialState, action: Actions): State {
       }
 
       const {group, name} = action.payload
-
       const updateSubscribe = (setting, storeGroup) => {
         let subscribed = setting.subscribed
 
@@ -89,7 +88,6 @@ function reducer(state: State = initialState, action: Actions): State {
           unsubscribedFromAll: !name && !unsubscribedFromAll,
         },
       }
-
       return {
         ...state,
         notifications: {

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -28,10 +28,10 @@ const Group = (props: {
   allowEdit: boolean,
   groupName: string,
   onToggle: (groupName: string, name: string) => void,
-  onToggleUnsubscribeAll: () => void,
+  onToggleUnsubscribeAll?: () => void,
   settings: ?Array<NotificationsSettingsState>,
   title: string,
-  unsub: string,
+  unsub?: string,
   unsubscribedFromAll: boolean,
 }) => (
   <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.medium}}>
@@ -50,7 +50,7 @@ const Group = (props: {
           />
         ))}
     </Box>
-    {props.unsub.length > 0 &&
+    {props.unsub &&
       <Box style={{...globalStyles.flexBoxColumn}}>
         <Text type="BodyBig">Or:</Text>
         <Checkbox
@@ -100,10 +100,8 @@ const Notifications = (props: Props) =>
             allowEdit={props.allowEdit}
             groupName="security"
             onToggle={props.onToggle}
-            onToggleUnsubscribeAll={() => {}}
             title="Security"
             settings={props.groups.security.settings}
-            unsub=""
             unsubscribedFromAll={false}
           />}
 

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -51,7 +51,7 @@ const Group = (props: {
         ))}
     </Box>
     {props.unsub.length > 0 &&
-      <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.small}}>
+      <Box style={{...globalStyles.flexBoxColumn}}>
         <Text type="BodyBig">Or:</Text>
         <Checkbox
           style={{marginTop: globalMargins.small}}

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -95,7 +95,7 @@ const Notifications = (props: Props) =>
           />}
 
         {props.groups.security &&
-          props.groups.security &&
+          props.groups.security.settings &&
           <Group
             allowEdit={props.allowEdit}
             groupName="security"

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -50,14 +50,17 @@ const Group = (props: {
           />
         ))}
     </Box>
-    <Text type="BodyBig">Or:</Text>
-    <Checkbox
-      style={{marginTop: globalMargins.small}}
-      onCheck={props.onToggleUnsubscribeAll}
-      disabled={!props.allowEdit}
-      checked={!!props.unsubscribedFromAll}
-      label={`Unsubscribe me from all ${props.unsub} notifications.`}
-    />
+    {props.unsub.length > 0 &&
+      <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.small}}>
+        <Text type="BodyBig">Or:</Text>
+        <Checkbox
+          style={{marginTop: globalMargins.small}}
+          onCheck={props.onToggleUnsubscribeAll}
+          disabled={!props.allowEdit}
+          checked={!!props.unsubscribedFromAll}
+          label={`Unsubscribe me from all ${props.unsub} notifications.`}
+        />
+      </Box>}
   </Box>
 )
 
@@ -89,6 +92,19 @@ const Notifications = (props: Props) =>
             unsub="push"
             settings={props.groups.app_push.settings}
             unsubscribedFromAll={props.groups.app_push.unsubscribedFromAll}
+          />}
+
+        {props.groups.security &&
+          props.groups.security &&
+          <Group
+            allowEdit={props.allowEdit}
+            groupName="security"
+            onToggle={props.onToggle}
+            onToggleUnsubscribeAll={() => {}}
+            title="Security"
+            settings={props.groups.security.settings}
+            unsub=""
+            unsubscribedFromAll={false}
           />}
 
         <Button

--- a/shared/settings/notifications/index.js.flow
+++ b/shared/settings/notifications/index.js.flow
@@ -19,6 +19,7 @@ export type Props = {
     app_push?: Group,
     email?: Group,
     sms?: Group,
+    security?: Group,
   },
   onRefresh: () => void,
   onSave: () => void,


### PR DESCRIPTION
Patch does the following:

1.) Adds local RPC endpoints for setting/getting global notifications settings from the chat system.
2.) Add a new option on the Notifications screen in Settings for toggling that option. Here is what it looks like on desktop:

![image](https://user-images.githubusercontent.com/1250314/29151471-6136619c-7d4f-11e7-9863-a5343e106ef4.png)


cc @malgorithms let me know if looks ok.