### PR TITLE
Allow stub delete, add tests

### DIFF
--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -100,7 +100,7 @@ func (t SigchainV2Type) TeamAllowStub(role keybase1.TeamRole) bool {
 		return false
 	case keybase1.TeamRole_NONE, keybase1.TeamRole_READER, keybase1.TeamRole_WRITER:
 		switch t {
-		case SigchainV2TypeTeamNewSubteam, SigchainV2TypeTeamRenameSubteam, SigchainV2TypeTeamInvite:
+		case SigchainV2TypeTeamNewSubteam, SigchainV2TypeTeamRenameSubteam, SigchainV2TypeTeamDeleteSubteam, SigchainV2TypeTeamInvite:
 			return true
 		default:
 			// disallow stubbing of other including unknown links

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -520,3 +520,45 @@ func TestLoaderGetImplicitAdminsList(t *testing.T) {
 	t.Logf("U0 sees the 3 implicit admins")
 	assertImpAdmins(tcs[0].G, *subteamID, []keybase1.UserVersion{fus[0].GetUserVersion(), fus[1].GetUserVersion(), fus[2].GetUserVersion()})
 }
+
+// Subteams should be invisible to writers.
+// U0 creates a subteam
+// U0 adds U1 to the root team
+// U1 should not see any subteams
+func TestHiddenSubteam(t *testing.T) {
+	fus, tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	t.Logf("U0 creates A")
+	parentName, parentID := createTeam2(*tcs[0])
+
+	subteamName1 := createTeamName(t, parentName.String(), "bbb")
+
+	t.Logf("U0 creates A.B")
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName)
+	require.NoError(t, err)
+
+	t.Logf("U0 adds U1 to A as a WRITER")
+	_, err = AddMember(context.TODO(), tcs[0].G, parentName.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+
+	t.Logf("U0 loads A")
+	team, err := Load(context.TODO(), tcs[0].G, keybase1.LoadTeamArg{
+		ID:          parentID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err, "load team")
+	t.Logf(spew.Sdump(team.chain().inner.SubteamLog))
+	require.Len(t, team.chain().ListSubteams(), 1, "subteam list")
+	require.Equal(t, *subteamID, team.chain().ListSubteams()[0].ID, "subteam ID")
+	require.Equal(t, subteamName1.String(), team.chain().ListSubteams()[0].Name.String(), "subteam name")
+
+	t.Logf("U1 loads A")
+	team, err = Load(context.TODO(), tcs[1].G, keybase1.LoadTeamArg{
+		ID:          parentID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err, "load team")
+	t.Logf(spew.Sdump(team.chain().inner.SubteamLog))
+	require.Len(t, team.chain().inner.SubteamLog, 0, "subteam log should be empty because all subteam links were stubbed for this user")
+}


### PR DESCRIPTION
Allow `subteam_delete` links to be stubbed. Add the tests that discovered these weren't stubbed.

This is not the main event of CORE-5738.