### PR TITLE
Don't crash in AccountDelete

### DIFF
--- a/go/engine/account_delete_test.go
+++ b/go/engine/account_delete_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccountDelete(t *testing.T) {
@@ -33,6 +34,31 @@ func TestAccountDelete(t *testing.T) {
 	if _, ok := err.(libkb.DeletedError); !ok {
 		t.Errorf("loading deleted user error type: %T, expected libkb.DeletedError", err)
 	}
+}
+
+func TestAccountDeleteAfterRestart(t *testing.T) {
+	tc := SetupEngineTest(t, "acct")
+	defer tc.Cleanup()
+
+	fu := SignupFakeUserStoreSecret(tc, "acct")
+
+	simulateServiceRestart(t, tc, fu)
+
+	ctx := &Context{}
+	eng := NewAccountDelete(tc.G)
+	err := RunEngine(eng, ctx)
+	if err == nil {
+		t.Fatalf("AccountDelete after restart was broken but it looks like you've fixed it. Please make this test expect nil error here and uncomment the rest.")
+	}
+	require.Equal(t, "LoginSession is nil", err.Error())
+
+	// _, err = libkb.LoadUser(libkb.NewLoadUserByNameArg(tc.G, fu.Username))
+	// if err == nil {
+	// 	t.Fatal("no error loading deleted user")
+	// }
+	// if _, ok := err.(libkb.DeletedError); !ok {
+	// 	t.Errorf("loading deleted user error type: %T, expected libkb.DeletedError", err)
+	// }
 }
 
 func TestAccountDeleteIdentify(t *testing.T) {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -1009,6 +1009,7 @@ func simulateServiceRestart(t *testing.T, tc libkb.TestContext, fu *FakeUser) {
 	tc.G.LoginState().Account(func(a *libkb.Account) {
 		a.ClearStreamCache()
 		a.ClearCachedSecretKeys()
+		a.ClearLoginSession()
 	}, "account - clear")
 
 	// now assert we can login without a passphrase

--- a/go/libkb/login_session.go
+++ b/go/libkb/login_session.go
@@ -147,6 +147,9 @@ func (s *LoginSession) Dump() {
 }
 
 func (s *LoginSession) Load() error {
+	if s == nil {
+		return fmt.Errorf("LoginSession is nil")
+	}
 	if s.loaded && !s.cleared {
 		return fmt.Errorf("LoginSession already loaded for %s", s.sessionFor)
 	}


### PR DESCRIPTION
This makes `keybase acctdelete` and the analog from the GUI not panic the service. It does not make them work.