### PR TITLE
only load more messages if we have already loaded some messages

### DIFF
--- a/shared/chat/conversation/list/index.native.js
+++ b/shared/chat/conversation/list/index.native.js
@@ -44,8 +44,11 @@ class ConversationList extends Component<void, Props, void> {
 
   _keyExtractor = messageKey => messageKey
 
+  // Don't load if we have no messages in there. This happens a lot when we're dealing with stale messages
   _onEndReached = () => {
-    this.props.onLoadMoreMessages()
+    if (this.props.messageKeys.count() > 1) {
+      this.props.onLoadMoreMessages()
+    }
   }
 
   componentDidUpdate(prevProps: Props) {


### PR DESCRIPTION
@keybase/react-hackers this stops some extra loading that happens when we're coming in from a push notification