### PR TITLE
Wrap zcash address

### DIFF
--- a/shared/profile/confirm-or-pending.desktop.js
+++ b/shared/profile/confirm-or-pending.desktop.js
@@ -29,7 +29,7 @@ const Render = (props: Props) => {
           overlay={platformIconOverlay}
           overlayColor={platformIconOverlayColor}
         />
-        <Text type="Header" style={{color: globalColors.blue}}>{username}</Text>
+        <Text type="Header" style={stylePlatformUsername}>{username}</Text>
         {!!usernameSubtitle &&
           <Text type="Body" style={{color: globalColors.black_20}}>{usernameSubtitle}</Text>}
         <Text type="Body" style={{marginTop: globalMargins.large, textAlign: 'center', maxWidth: 560}}>
@@ -45,6 +45,12 @@ const Render = (props: Props) => {
       </Box>
     </Box>
   )
+}
+
+const stylePlatformUsername = {
+  color: globalColors.blue,
+  maxWidth: 400,
+  overflowWrap: 'break-word',
 }
 
 export default Render

--- a/shared/profile/revoke/index.js
+++ b/shared/profile/revoke/index.js
@@ -90,7 +90,13 @@ const styleContentContainer = {
 
 const stylePlatformUsername = {
   ...globalStyles.textDecoration('line-through'),
-  ...(isMobile ? {} : {textAlign: 'center'}),
+  ...(isMobile
+    ? {}
+    : {
+        textAlign: 'center',
+        overflowWrap: 'break-word',
+        maxWidth: 400,
+      }),
   color: globalColors.red,
 }
 


### PR DESCRIPTION
Wrap zcash addresses on desktop. Used to be really long and go off screen. Mobile was already fine, so don't touch its styles.

Now looks like this:

![image](https://user-images.githubusercontent.com/705646/29231266-92634954-7eb4-11e7-9b77-e08e7c56dfb6.png)

![image](https://user-images.githubusercontent.com/705646/29231278-9e3bfc12-7eb4-11e7-9e6a-01f45d25e99c.png)
