### PR TITLE
Fix pgp squish

### DIFF
--- a/shared/profile/pgp/finished-generating-pgp.desktop.js
+++ b/shared/profile/pgp/finished-generating-pgp.desktop.js
@@ -84,6 +84,7 @@ const stylePgpKeyString = {
 
 const styleUploadContainer = {
   ...globalStyles.flexBoxColumn,
+  flexShrink: 0,
   textAlign: 'left',
   marginTop: globalMargins.small,
 }


### PR DESCRIPTION
Was:
![image](https://user-images.githubusercontent.com/705646/29233382-8b7b204e-7ebe-11e7-8668-565e31f02a7f.png)

Now:
![image](https://user-images.githubusercontent.com/705646/29233372-82226d22-7ebe-11e7-81c9-da8534bc83d9.png)

The container with the top line of text was `flex` for its children to go left-to-right. But that was causing it to participate in the flexing of its parent and squish down to 0 height.

The dumb sheets don't show it because they don't have limit the max height of the screen.

This screen is disabled on mobile so I didn't touch it.