### PR TITLE
bump version to 1.0.28

### DIFF
--- a/go/libkb/version.go
+++ b/go/libkb/version.go
@@ -4,4 +4,4 @@
 package libkb
 
 // Version is the current version (should be MAJOR.MINOR.PATCH)
-const Version = "1.0.27"
+const Version = "1.0.28"


### PR DESCRIPTION
I'm going to tag the repo to prompt some downstream builds (Arch, BSD),
and it would be nice to do it with a fresh version number. We should
probably figure out a more automated strategy for this.

r? @cjb 