### PR TITLE
Encrypted PGP export

### DIFF
--- a/go/client/cmd_pgp_export.go
+++ b/go/client/cmd_pgp_export.go
@@ -39,13 +39,14 @@ func NewCmdPGPExport(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 			},
 			cli.BoolFlag{
 				Name:  "unencrypted",
-				Usage: "When exporting secret key, do not protect key with a passphrase.",
+				Usage: "When exporting private keys, do not protect with a passphrase.",
 			},
 		},
 		Description: `"keybase pgp export" exports public (and optionally private) 
    PGP keys from Keybase, and into a file or to standard output.
-   It doesn't access the GnuPG keychain at all. By default, when exporting secret
-   key, you will be asked for passphrase to protect exported key.`,
+   It doesn't access the GnuPG keychain at all. By default, when
+   exporting private keys, you will be asked for passphrase to encrypt
+   the exported keys.`,
 	}
 }
 

--- a/go/client/cmd_pgp_export.go
+++ b/go/client/cmd_pgp_export.go
@@ -37,10 +37,16 @@ func NewCmdPGPExport(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 				Name:  "q, query",
 				Usage: "Only export keys matching that query.",
 			},
+			cli.BoolFlag{
+				Name:  "unencrypted",
+				Usage: "When exporting secret key, do not protect key with Keybase passphrase.",
+			},
 		},
-		Description: `"keybase pgp export" exports public (and optionally private) PGP keys
-   from Keybase, and into a file or to standard output. It doesn't access
-   the GnuPG keychain at all.`,
+		Description: `"keybase pgp export" exports public (and optionally private) 
+   PGP keys from Keybase, and into a file or to standard output.
+   It doesn't access the GnuPG keychain at all. When exporting
+   secret key, by default the key will be protected by Keybase
+   passphrase.`,
 	}
 }
 
@@ -57,6 +63,7 @@ func (s *CmdPGPExport) ParseArgv(ctx *cli.Context) error {
 
 	s.arg.Options.Secret = ctx.Bool("secret")
 	s.arg.Options.Query = ctx.String("query")
+	s.arg.Unencrypted = ctx.Bool("unencrypted")
 	s.outfile = ctx.String("outfile")
 
 	if nargs > 0 {

--- a/go/client/cmd_pgp_export.go
+++ b/go/client/cmd_pgp_export.go
@@ -39,14 +39,13 @@ func NewCmdPGPExport(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 			},
 			cli.BoolFlag{
 				Name:  "unencrypted",
-				Usage: "When exporting secret key, do not protect key with Keybase passphrase.",
+				Usage: "When exporting secret key, do not protect key with a passphrase.",
 			},
 		},
 		Description: `"keybase pgp export" exports public (and optionally private) 
    PGP keys from Keybase, and into a file or to standard output.
-   It doesn't access the GnuPG keychain at all. When exporting
-   secret key, by default the key will be protected by Keybase
-   passphrase.`,
+   It doesn't access the GnuPG keychain at all. By default, when exporting secret
+   key, you will be asked for passphrase to protect exported key.`,
 	}
 }
 

--- a/go/client/cmd_pgp_export.go
+++ b/go/client/cmd_pgp_export.go
@@ -63,7 +63,7 @@ func (s *CmdPGPExport) ParseArgv(ctx *cli.Context) error {
 
 	s.arg.Options.Secret = ctx.Bool("secret")
 	s.arg.Options.Query = ctx.String("query")
-	s.arg.Unencrypted = ctx.Bool("unencrypted")
+	s.arg.Encrypted = !ctx.Bool("unencrypted")
 	s.outfile = ctx.String("outfile")
 
 	if nargs > 0 {

--- a/go/client/cmd_pgp_gen.go
+++ b/go/client/cmd_pgp_gen.go
@@ -30,7 +30,6 @@ func (v *CmdPGPGen) ParseArgv(ctx *cli.Context) (err error) {
 		g := libkb.PGPGenArg{}
 		g.PGPUids = ctx.StringSlice("pgp-uid")
 		v.arg.DoExport = !ctx.Bool("no-export")
-		v.arg.ExportEncrypted = !ctx.Bool("unencrypted")
 		v.arg.AllowMulti = ctx.Bool("multi")
 		if ctx.Bool("debug") {
 			g.PrimaryBits = SmallKey
@@ -65,6 +64,12 @@ func (v *CmdPGPGen) Run() (err error) {
 	v.arg.PushSecret, err = v.G().UI.GetTerminalUI().PromptYesNo(PromptDescriptorPGPGenPushSecret, "Push an encrypted copy of your new secret key to the Keybase.io server?", libkb.PromptDefaultYes)
 	if err != nil {
 		return err
+	}
+	if v.arg.DoExport {
+		v.arg.ExportEncrypted, err = v.G().UI.GetTerminalUI().PromptYesNo(PromptDescriptorPGPGenEncryptSecret, "When exporting to the GnuPG keychain, encrypt private keys with a passphrase?", libkb.PromptDefaultYes)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = cli.PGPKeyGen(context.TODO(), v.arg.Export())
@@ -169,10 +174,6 @@ func NewCmdPGPGen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
 			cli.BoolFlag{
 				Name:  "no-export",
 				Usage: "Disable exporting of new keys to GPG keychain.",
-			},
-			cli.BoolFlag{
-				Name:  "unencrypted",
-				Usage: "When exporting to GPG keychain, do not encrypt keys.",
 			},
 		},
 		Description: `"keybase pgp gen" generates a new PGP key for this account.

--- a/go/client/cmd_pgp_gen.go
+++ b/go/client/cmd_pgp_gen.go
@@ -172,7 +172,7 @@ func NewCmdPGPGen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
 			},
 			cli.BoolFlag{
 				Name:  "unencrypted",
-				Usage: "When exporting to GPG keychain, do not encrypt key.",
+				Usage: "When exporting to GPG keychain, do not encrypt keys.",
 			},
 		},
 		Description: `"keybase pgp gen" generates a new PGP key for this account.
@@ -185,10 +185,11 @@ func NewCmdPGPGen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
    (LKS) protocol. (For more information, try 'keybase help keyring').
 
    Also, by default, the public **and secret** halves of the new PGP key
-   are exported to the local GnuPG keyring, if one is found. Unless
-   "--unencrypted" argument is provided, you will be asked to provide a
-   passphrase to encrypt key in GnuPG keyring. You can specify "--no-export"
-   to stop the export of the newly generated key to the GnuPG keyring.
+   are exported to the local GnuPG keyring, if one is found. Unless the
+   "--unencrypted" flag is provided, you will be asked to provide a
+   passphrase to encrypt the key in the GnuPG keyring. You can specify
+   "--no-export" to stop the export of the newly generated key to the
+   GnuPG keyring.
 
    On subsequent secret key accesses --- say for PGP decryption or
    for signing --- access to the local GnuPG keyring is not required.

--- a/go/client/cmd_pgp_gen.go
+++ b/go/client/cmd_pgp_gen.go
@@ -30,6 +30,7 @@ func (v *CmdPGPGen) ParseArgv(ctx *cli.Context) (err error) {
 		g := libkb.PGPGenArg{}
 		g.PGPUids = ctx.StringSlice("pgp-uid")
 		v.arg.DoExport = !ctx.Bool("no-export")
+		v.arg.ExportEncrypted = !ctx.Bool("unencrypted")
 		v.arg.AllowMulti = ctx.Bool("multi")
 		if ctx.Bool("debug") {
 			g.PrimaryBits = SmallKey
@@ -169,6 +170,10 @@ func NewCmdPGPGen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
 				Name:  "no-export",
 				Usage: "Disable exporting of new keys to GPG keychain.",
 			},
+			cli.BoolFlag{
+				Name:  "unencrypted",
+				Usage: "When exporting to GPG keychain, do not encrypt key.",
+			},
 		},
 		Description: `"keybase pgp gen" generates a new PGP key for this account.
    In all cases, it signs the public key with an exising device key,
@@ -180,11 +185,10 @@ func NewCmdPGPGen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
    (LKS) protocol. (For more information, try 'keybase help keyring').
 
    Also, by default, the public **and secret** halves of the new PGP key
-   are exported to the local GnuPG keyring, if one is found. The key
-   will not have a passphrase protecting it. If having a passphrase
-   on this key is important to you, run 'gpg edit-key' to supply one.
-   You can specify "--no-export" to stop the export of the newly generated
-   key to the GnuPG keyring.
+   are exported to the local GnuPG keyring, if one is found. Unless
+   "--unencrypted" argument is provided, you will be asked to provide a
+   passphrase to encrypt key in GnuPG keyring. You can specify "--no-export"
+   to stop the export of the newly generated key to the GnuPG keyring.
 
    On subsequent secret key accesses --- say for PGP decryption or
    for signing --- access to the local GnuPG keyring is not required.

--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -13,6 +13,7 @@ const (
 	PromptDescriptorReregister
 	PromptDescriptorInviteOK
 	PromptDescriptorPGPGenPushSecret
+	PromptDescriptorPGPGenEncryptSecret
 	PromptDescriptorDoctorWhichAccount
 	PromptDescriptorDoctorSignOK
 	PromptDescriptorGPGOKToAdd

--- a/go/engine/errors.go
+++ b/go/engine/errors.go
@@ -26,7 +26,7 @@ type GPGExportingError struct {
 
 func (e GPGExportingError) Error() string {
 	if e.inPGPGen {
-		const msg string = "PGP key has been generated and added to your account, but exporting to GPG keychain has failed. You can export again using `keybase pgp export -s`."
+		const msg string = "A PGP key has been generated and added to your account, but exporting to the GPG keychain has failed. You can try to export again using `keybase pgp export -s`."
 		return fmt.Sprintf("%s Error during GPG exporting: %s", msg, e.err.Error())
 	}
 	return e.err.Error()

--- a/go/engine/errors.go
+++ b/go/engine/errors.go
@@ -18,3 +18,16 @@ func (e CheckError) Error() string {
 }
 
 //=============================================================================
+
+type GPGExportingError struct {
+	err      error
+	inPGPGen bool // did this error happen during pgp generation?
+}
+
+func (e GPGExportingError) Error() string {
+	if e.inPGPGen {
+		const msg string = "PGP key has been generated and added to your account, but exporting to GPG keychain has failed. You can export again using `keybase pgp export -s`."
+		return fmt.Sprintf("%s Error during GPG exporting: %s", msg, e.err.Error())
+	}
+	return e.err.Error()
+}

--- a/go/engine/pgp_export_key.go
+++ b/go/engine/pgp_export_key.go
@@ -181,8 +181,8 @@ func (e *PGPKeyExportEngine) exportSecret(ctx *Context) error {
 	return nil
 }
 
-func getPGPPassphrase(g *libkb.GlobalContext, ui libkb.SecretUI) (keybase1.GetPassphraseRes, error) {
-	desc := "Enter passphrase to protect your PGP key. Secure passphrase should have at least 8 characters."
+func GetPGPPassphrase(g *libkb.GlobalContext, ui libkb.SecretUI) (keybase1.GetPassphraseRes, error) {
+	desc := "Enter passphrase to protect your PGP key. Secure passphrases have at least 8 characters."
 	pRes, err := libkb.GetSecret(g, ui, "PGP key passphrase", desc, "", false)
 	if err != nil {
 		return keybase1.GetPassphraseRes{}, err
@@ -207,12 +207,12 @@ func (e *PGPKeyExportEngine) encryptKey(ctx *Context, raw []byte) ([]byte, error
 		return nil, libkb.BadKeyError{Msg: "No secret part in PGP key."}
 	}
 
-	pRes, err := getPGPPassphrase(e.G(), ctx.SecretUI)
+	pRes, err := GetPGPPassphrase(e.G(), ctx.SecretUI)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = entity.PrivateKey.Encrypt([]byte(pRes.Passphrase), nil); err != nil {
+	if err = libkb.EncryptPGPKey(entity.Entity, pRes.Passphrase); err != nil {
 		return nil, err
 	}
 

--- a/go/engine/pgp_export_key.go
+++ b/go/engine/pgp_export_key.go
@@ -181,7 +181,7 @@ func (e *PGPKeyExportEngine) exportSecret(ctx *Context) error {
 	return nil
 }
 
-func GetPGPPassphrase(g *libkb.GlobalContext, ui libkb.SecretUI) (keybase1.GetPassphraseRes, error) {
+func GetPGPExportPassphrase(g *libkb.GlobalContext, ui libkb.SecretUI) (keybase1.GetPassphraseRes, error) {
 	desc := "Enter passphrase to protect your PGP key. Secure passphrases have at least 8 characters."
 	pRes, err := libkb.GetSecret(g, ui, "PGP key passphrase", desc, "", false)
 	if err != nil {
@@ -207,7 +207,7 @@ func (e *PGPKeyExportEngine) encryptKey(ctx *Context, raw []byte) ([]byte, error
 		return nil, libkb.BadKeyError{Msg: "No secret part in PGP key."}
 	}
 
-	pRes, err := GetPGPPassphrase(e.G(), ctx.SecretUI)
+	pRes, err := GetPGPExportPassphrase(e.G(), ctx.SecretUI)
 	if err != nil {
 		return nil, err
 	}

--- a/go/engine/pgp_export_key.go
+++ b/go/engine/pgp_export_key.go
@@ -27,11 +27,11 @@ const (
 
 type PGPKeyExportEngine struct {
 	libkb.Contextified
-	arg         keybase1.PGPQuery
-	unencrypted bool
-	qtype       queryType
-	res         []keybase1.KeyInfo
-	me          *libkb.User
+	arg       keybase1.PGPQuery
+	encrypted bool
+	qtype     queryType
+	res       []keybase1.KeyInfo
+	me        *libkb.User
 }
 
 func (e *PGPKeyExportEngine) Prereqs() Prereqs {
@@ -62,7 +62,7 @@ func NewPGPKeyExportEngine(arg keybase1.PGPExportArg, g *libkb.GlobalContext) *P
 	return &PGPKeyExportEngine{
 		arg:          arg.Options,
 		qtype:        either,
-		unencrypted:  arg.Unencrypted,
+		encrypted:    arg.Encrypted,
 		Contextified: libkb.NewContextified(g),
 	}
 }
@@ -71,7 +71,7 @@ func NewPGPKeyExportByKIDEngine(arg keybase1.PGPExportByKIDArg, g *libkb.GlobalC
 	return &PGPKeyExportEngine{
 		arg:          arg.Options,
 		qtype:        kid,
-		unencrypted:  arg.Unencrypted,
+		encrypted:    arg.Encrypted,
 		Contextified: libkb.NewContextified(g),
 	}
 }
@@ -80,7 +80,7 @@ func NewPGPKeyExportByFingerprintEngine(arg keybase1.PGPExportByFingerprintArg, 
 	return &PGPKeyExportEngine{
 		arg:          arg.Options,
 		qtype:        fingerprint,
-		unencrypted:  arg.Unencrypted,
+		encrypted:    arg.Encrypted,
 		Contextified: libkb.NewContextified(g),
 	}
 }
@@ -155,7 +155,7 @@ func (e *PGPKeyExportEngine) exportSecret(ctx *Context) error {
 		if storeSecret {
 			secretStorer = secretStore
 		}
-		if !e.unencrypted {
+		if e.encrypted {
 			// save passphrase to encrypt key later
 			passphrase = pw
 		}
@@ -166,7 +166,7 @@ func (e *PGPKeyExportEngine) exportSecret(ctx *Context) error {
 	}
 
 	reason := "key unlock for export "
-	if e.unencrypted {
+	if !e.encrypted {
 		reason += "(not encrypted)"
 	} else {
 		reason += "(encrypted with passphrase)"
@@ -194,7 +194,7 @@ func (e *PGPKeyExportEngine) exportSecret(ctx *Context) error {
 
 	var raw []byte
 
-	if e.unencrypted {
+	if !e.encrypted {
 		// User wanted un-encrypted key. Just pass raw bytes
 		raw = skb.RawUnlockedKey()
 

--- a/go/engine/pgp_export_key.go
+++ b/go/engine/pgp_export_key.go
@@ -181,8 +181,7 @@ func (e *PGPKeyExportEngine) exportSecret(ctx *Context) error {
 	return nil
 }
 
-func GetPGPExportPassphrase(g *libkb.GlobalContext, ui libkb.SecretUI) (keybase1.GetPassphraseRes, error) {
-	desc := "Enter passphrase to protect your PGP key. Secure passphrases have at least 8 characters."
+func GetPGPExportPassphrase(g *libkb.GlobalContext, ui libkb.SecretUI, desc string) (keybase1.GetPassphraseRes, error) {
 	pRes, err := libkb.GetSecret(g, ui, "PGP key passphrase", desc, "", false)
 	if err != nil {
 		return keybase1.GetPassphraseRes{}, err
@@ -207,7 +206,8 @@ func (e *PGPKeyExportEngine) encryptKey(ctx *Context, raw []byte) ([]byte, error
 		return nil, libkb.BadKeyError{Msg: "No secret part in PGP key."}
 	}
 
-	pRes, err := GetPGPExportPassphrase(e.G(), ctx.SecretUI)
+	desc := "Enter passphrase to protect your PGP key. Secure passphrases have at least 8 characters."
+	pRes, err := GetPGPExportPassphrase(e.G(), ctx.SecretUI, desc)
 	if err != nil {
 		return nil, err
 	}

--- a/go/engine/pgp_export_key_test.go
+++ b/go/engine/pgp_export_key_test.go
@@ -202,6 +202,12 @@ func TestPGPExportEncryption(t *testing.T) {
 		t.Fatal("Key is not encrypted")
 	}
 
+	for _, subkey := range entity.Subkeys {
+		if !subkey.PrivateKey.Encrypted {
+			t.Fatal("Subkey is not encrypted")
+		}
+	}
+
 	if err := entity.PrivateKey.Decrypt([]byte(pgpPassphrase)); err != nil {
 		t.Fatal("Decryption with passphrase failed")
 	}
@@ -232,5 +238,11 @@ func TestPGPExportEncryption(t *testing.T) {
 
 	if entity.PrivateKey.Encrypted {
 		t.Fatal("Key is encrypted")
+	}
+
+	for _, subkey := range entity.Subkeys {
+		if subkey.PrivateKey.Encrypted {
+			t.Fatal("Subkey is encrypted")
+		}
 	}
 }

--- a/go/engine/pgp_export_key_test.go
+++ b/go/engine/pgp_export_key_test.go
@@ -156,11 +156,11 @@ func TestPGPExportEncryption(t *testing.T) {
 		ExactMatch: true,
 	}
 
-	// Run export with Unencrypted: false
+	// Run export with Encrypted: true
 
 	arg := keybase1.PGPExportArg{
-		Options:     opts,
-		Unencrypted: false,
+		Options:   opts,
+		Encrypted: true,
 	}
 	xe := NewPGPKeyExportEngine(arg, tc.G)
 	if err := RunEngine(xe, ctx); err != nil {
@@ -184,11 +184,11 @@ func TestPGPExportEncryption(t *testing.T) {
 		t.Fatal("Decryption with passphrase failed")
 	}
 
-	// Run export with Unencrypted: true
+	// Run export with Encrypted: false
 
 	arg = keybase1.PGPExportArg{
-		Options:     opts,
-		Unencrypted: true,
+		Options:   opts,
+		Encrypted: false,
 	}
 	xe = NewPGPKeyExportEngine(arg, tc.G)
 	if err := RunEngine(xe, ctx); err != nil {

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -261,7 +261,7 @@ func (e *PGPKeyImportEngine) exportToGPG(ctx *Context) (err error) {
 
 	if e.arg.ExportEncrypted {
 		e.G().Log.Debug("Encrypting key with passphrase before exporting")
-		pRes, err := GetPGPPassphrase(e.G(), ctx.SecretUI)
+		pRes, err := GetPGPExportPassphrase(e.G(), ctx.SecretUI)
 		if err != nil {
 			return err
 		}

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -214,7 +214,7 @@ func (e *PGPKeyImportEngine) Run(ctx *Context) error {
 		}
 
 		if err := e.exportToGPG(ctx); err != nil {
-			return err
+			return GPGExportingError{err, true /* inPGPGen */}
 		}
 	}
 
@@ -261,7 +261,8 @@ func (e *PGPKeyImportEngine) exportToGPG(ctx *Context) (err error) {
 
 	if e.arg.ExportEncrypted {
 		e.G().Log.Debug("Encrypting key with passphrase before exporting")
-		pRes, err := GetPGPExportPassphrase(e.G(), ctx.SecretUI)
+		desc := "Exporting key to GPG keychain. Enter passphrase to protect the key. Secure passphrases have at least 8 characters."
+		pRes, err := GetPGPExportPassphrase(e.G(), ctx.SecretUI, desc)
 		if err != nil {
 			return err
 		}

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -9,6 +9,7 @@ package engine
 //
 
 import (
+	"bytes"
 	"errors"
 	"strings"
 
@@ -36,7 +37,8 @@ type PGPKeyImportEngineArg struct {
 	PushSecret       bool
 	OnlySave         bool
 	AllowMulti       bool
-	DoExport         bool
+	DoExport         bool // export to GPG keychain?
+	ExportEncrypted  bool // encrypt secret key before exporting to GPG?
 	DoUnlock         bool
 	GPGFallback      bool
 	PreloadTsec      libkb.Triplesec
@@ -219,6 +221,22 @@ func (e *PGPKeyImportEngine) Run(ctx *Context) error {
 	return nil
 }
 
+// clonePGPKeyBundle returns an approximate deep copy of PGPKeyBundle
+// by exporting and re-importing PGPKeyBundle. If PGP key contains
+// something that is not supported by either go-crypto exporter or
+// importer, that information will be lost.
+func clonePGPKeyBundle(bundle *libkb.PGPKeyBundle) (*libkb.PGPKeyBundle, error) {
+	var buf bytes.Buffer
+	if err := bundle.SerializePrivate(&buf); err != nil {
+		return nil, err
+	}
+	res, _, err := libkb.ReadOneKeyFromBytes(buf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 func (e *PGPKeyImportEngine) exportToGPG(ctx *Context) (err error) {
 	if !e.arg.DoExport || e.arg.Pregen != nil {
 		e.G().Log.Debug("| Skipping export to GPG")
@@ -239,7 +257,26 @@ func (e *PGPKeyImportEngine) exportToGPG(ctx *Context) (err error) {
 		return nil
 	}
 
-	err = gpg.ExportKey(*e.bundle, true /* export private key */)
+	exportedBundle := e.bundle
+
+	if e.arg.ExportEncrypted {
+		e.G().Log.Debug("Encrypting key with passphrase before exporting")
+		pRes, err := GetPGPPassphrase(e.G(), ctx.SecretUI)
+		if err != nil {
+			return err
+		}
+		// Avoid mutating e.bundle.
+		if exportedBundle, err = clonePGPKeyBundle(e.bundle); err != nil {
+			return err
+		}
+		if err = libkb.EncryptPGPKey(exportedBundle.Entity, pRes.Passphrase); err != nil {
+			return err
+		}
+	}
+
+	// If key is encrypted, use batch mode in gpg so it does not ask
+	// for passphrase to re-encrypt to its internal representation.
+	err = gpg.ExportKey(*exportedBundle, true /* private */, e.arg.ExportEncrypted /* batch */)
 	if err == nil {
 		ctx.LogUI.Info("Exported new key to the local GPG keychain")
 	}

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -241,7 +241,7 @@ func (e *PGPPullEngine) exportKeysToGPG(ctx *Context, user *libkb.User, tfp map[
 			continue
 		}
 
-		if err := e.gpgClient.ExportKey(*bundle, false /* export public key only */, false /* batch */); err != nil {
+		if err := e.gpgClient.ExportKey(*bundle, false /* export public key only */, false /* no batch */); err != nil {
 			return err
 		}
 

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -241,7 +241,7 @@ func (e *PGPPullEngine) exportKeysToGPG(ctx *Context, user *libkb.User, tfp map[
 			continue
 		}
 
-		if err := e.gpgClient.ExportKey(*bundle, false /* export public key only */); err != nil {
+		if err := e.gpgClient.ExportKey(*bundle, false /* export public key only */, false /* batch */); err != nil {
 			return err
 		}
 

--- a/go/engine/pgp_update_test.go
+++ b/go/engine/pgp_update_test.go
@@ -68,7 +68,7 @@ func TestPGPUpdate(t *testing.T) {
 	}
 
 	// Add the modified key to the gpg keyring
-	if err := gpgCLI.ExportKey(*bundle, false /* export public key only */); err != nil {
+	if err := gpgCLI.ExportKey(*bundle, false /* export public key only */, false /* no batch mode */); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/engine/rpc_exim.go
+++ b/go/engine/rpc_exim.go
@@ -11,6 +11,7 @@ import (
 func (a *PGPKeyImportEngineArg) Export() (ret keybase1.PGPKeyGenArg) {
 	ret.AllowMulti = a.AllowMulti
 	ret.DoExport = a.DoExport
+	ret.ExportEncrypted = a.ExportEncrypted
 	ret.PushSecret = a.PushSecret
 	a.Gen.ExportTo(&ret)
 	return
@@ -19,10 +20,11 @@ func (a *PGPKeyImportEngineArg) Export() (ret keybase1.PGPKeyGenArg) {
 func ImportPGPKeyImportEngineArg(a keybase1.PGPKeyGenArg) (ret PGPKeyImportEngineArg) {
 	ga := libkb.ImportKeyGenArg(a)
 	ret = PGPKeyImportEngineArg{
-		AllowMulti: a.AllowMulti,
-		DoExport:   a.DoExport,
-		PushSecret: a.PushSecret,
-		Gen:        &ga,
+		AllowMulti:      a.AllowMulti,
+		DoExport:        a.DoExport,
+		ExportEncrypted: a.ExportEncrypted,
+		PushSecret:      a.PushSecret,
+		Gen:             &ga,
 	}
 	return ret
 }

--- a/go/libkb/gpg_cli.go
+++ b/go/libkb/gpg_cli.go
@@ -154,11 +154,15 @@ func (g *GpgCLI) ImportKey(secret bool, fp PGPFingerprint, tty string) (*PGPKeyB
 	return bundle, nil
 }
 
-func (g *GpgCLI) ExportKey(k PGPKeyBundle, private bool) (err error) {
+func (g *GpgCLI) ExportKey(k PGPKeyBundle, private bool, batch bool) (err error) {
 	g.outputVersion()
 	arg := RunGpg2Arg{
 		Arguments: []string{"--import"},
 		Stdin:     true,
+	}
+
+	if batch {
+		arg.Arguments = append(arg.Arguments, "--batch")
 	}
 
 	res := g.Run2(arg)

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -872,3 +872,23 @@ func (p PGPFingerprint) GetProofType() keybase1.ProofType {
 }
 
 //===================================================
+
+func EncryptPGPKey(bundle *openpgp.Entity, passphrase string) error {
+	passBytes := []byte(passphrase)
+
+	if err := bundle.PrivateKey.Encrypt(passBytes, nil); err != nil {
+		return err
+	}
+
+	for _, subkey := range bundle.Subkeys {
+		if subkey.PrivateKey == nil {
+			continue
+		}
+
+		if err := subkey.PrivateKey.Encrypt(passBytes, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -263,9 +263,6 @@ func (s *SKB) unverifiedPassphraseStream(lctx LoginContext, passphrase string) (
 }
 
 func (s *SKB) UnlockSecretKey(lctx LoginContext, passphrase string, tsec Triplesec, pps *PassphraseStream, secretStorer SecretStorer) (key GenericKey, err error) {
-	if key = s.decryptedSecret; key != nil {
-		return
-	}
 	var unlocked []byte
 
 	switch s.Priv.Encryption {
@@ -306,6 +303,12 @@ func (s *SKB) UnlockSecretKey(lctx LoginContext, passphrase string, tsec Triples
 	default:
 		err = BadKeyError{fmt.Sprintf("Can't unlock secret with protection type %d", int(s.Priv.Encryption))}
 	}
+
+	if key = s.decryptedSecret; key != nil {
+		// Key is already unlocked and unpacked, do not parse again.
+		return
+	}
+
 	if err == nil {
 		key, err = s.parseUnlocked(unlocked)
 	}

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -263,6 +263,9 @@ func (s *SKB) unverifiedPassphraseStream(lctx LoginContext, passphrase string) (
 }
 
 func (s *SKB) UnlockSecretKey(lctx LoginContext, passphrase string, tsec Triplesec, pps *PassphraseStream, secretStorer SecretStorer) (key GenericKey, err error) {
+	if key = s.decryptedSecret; key != nil {
+		return
+	}
 	var unlocked []byte
 
 	switch s.Priv.Encryption {
@@ -303,12 +306,6 @@ func (s *SKB) UnlockSecretKey(lctx LoginContext, passphrase string, tsec Triples
 	default:
 		err = BadKeyError{fmt.Sprintf("Can't unlock secret with protection type %d", int(s.Priv.Encryption))}
 	}
-
-	if key = s.decryptedSecret; key != nil {
-		// Key is already unlocked and unpacked, do not parse again.
-		return
-	}
-
 	if err == nil {
 		key, err = s.parseUnlocked(unlocked)
 	}

--- a/go/protocol/keybase1/pgp.go
+++ b/go/protocol/keybase1/pgp.go
@@ -292,38 +292,44 @@ func (o PGPImportArg) DeepCopy() PGPImportArg {
 }
 
 type PGPExportArg struct {
-	SessionID int      `codec:"sessionID" json:"sessionID"`
-	Options   PGPQuery `codec:"options" json:"options"`
+	SessionID   int      `codec:"sessionID" json:"sessionID"`
+	Options     PGPQuery `codec:"options" json:"options"`
+	Unencrypted bool     `codec:"unencrypted" json:"unencrypted"`
 }
 
 func (o PGPExportArg) DeepCopy() PGPExportArg {
 	return PGPExportArg{
-		SessionID: o.SessionID,
-		Options:   o.Options.DeepCopy(),
+		SessionID:   o.SessionID,
+		Options:     o.Options.DeepCopy(),
+		Unencrypted: o.Unencrypted,
 	}
 }
 
 type PGPExportByFingerprintArg struct {
-	SessionID int      `codec:"sessionID" json:"sessionID"`
-	Options   PGPQuery `codec:"options" json:"options"`
+	SessionID   int      `codec:"sessionID" json:"sessionID"`
+	Options     PGPQuery `codec:"options" json:"options"`
+	Unencrypted bool     `codec:"unencrypted" json:"unencrypted"`
 }
 
 func (o PGPExportByFingerprintArg) DeepCopy() PGPExportByFingerprintArg {
 	return PGPExportByFingerprintArg{
-		SessionID: o.SessionID,
-		Options:   o.Options.DeepCopy(),
+		SessionID:   o.SessionID,
+		Options:     o.Options.DeepCopy(),
+		Unencrypted: o.Unencrypted,
 	}
 }
 
 type PGPExportByKIDArg struct {
-	SessionID int      `codec:"sessionID" json:"sessionID"`
-	Options   PGPQuery `codec:"options" json:"options"`
+	SessionID   int      `codec:"sessionID" json:"sessionID"`
+	Options     PGPQuery `codec:"options" json:"options"`
+	Unencrypted bool     `codec:"unencrypted" json:"unencrypted"`
 }
 
 func (o PGPExportByKIDArg) DeepCopy() PGPExportByKIDArg {
 	return PGPExportByKIDArg{
-		SessionID: o.SessionID,
-		Options:   o.Options.DeepCopy(),
+		SessionID:   o.SessionID,
+		Options:     o.Options.DeepCopy(),
+		Unencrypted: o.Unencrypted,
 	}
 }
 

--- a/go/protocol/keybase1/pgp.go
+++ b/go/protocol/keybase1/pgp.go
@@ -334,24 +334,26 @@ func (o PGPExportByKIDArg) DeepCopy() PGPExportByKIDArg {
 }
 
 type PGPKeyGenArg struct {
-	SessionID   int           `codec:"sessionID" json:"sessionID"`
-	PrimaryBits int           `codec:"primaryBits" json:"primaryBits"`
-	SubkeyBits  int           `codec:"subkeyBits" json:"subkeyBits"`
-	CreateUids  PGPCreateUids `codec:"createUids" json:"createUids"`
-	AllowMulti  bool          `codec:"allowMulti" json:"allowMulti"`
-	DoExport    bool          `codec:"doExport" json:"doExport"`
-	PushSecret  bool          `codec:"pushSecret" json:"pushSecret"`
+	SessionID       int           `codec:"sessionID" json:"sessionID"`
+	PrimaryBits     int           `codec:"primaryBits" json:"primaryBits"`
+	SubkeyBits      int           `codec:"subkeyBits" json:"subkeyBits"`
+	CreateUids      PGPCreateUids `codec:"createUids" json:"createUids"`
+	AllowMulti      bool          `codec:"allowMulti" json:"allowMulti"`
+	DoExport        bool          `codec:"doExport" json:"doExport"`
+	ExportEncrypted bool          `codec:"exportEncrypted" json:"exportEncrypted"`
+	PushSecret      bool          `codec:"pushSecret" json:"pushSecret"`
 }
 
 func (o PGPKeyGenArg) DeepCopy() PGPKeyGenArg {
 	return PGPKeyGenArg{
-		SessionID:   o.SessionID,
-		PrimaryBits: o.PrimaryBits,
-		SubkeyBits:  o.SubkeyBits,
-		CreateUids:  o.CreateUids.DeepCopy(),
-		AllowMulti:  o.AllowMulti,
-		DoExport:    o.DoExport,
-		PushSecret:  o.PushSecret,
+		SessionID:       o.SessionID,
+		PrimaryBits:     o.PrimaryBits,
+		SubkeyBits:      o.SubkeyBits,
+		CreateUids:      o.CreateUids.DeepCopy(),
+		AllowMulti:      o.AllowMulti,
+		DoExport:        o.DoExport,
+		ExportEncrypted: o.ExportEncrypted,
+		PushSecret:      o.PushSecret,
 	}
 }
 

--- a/go/protocol/keybase1/pgp.go
+++ b/go/protocol/keybase1/pgp.go
@@ -292,44 +292,44 @@ func (o PGPImportArg) DeepCopy() PGPImportArg {
 }
 
 type PGPExportArg struct {
-	SessionID   int      `codec:"sessionID" json:"sessionID"`
-	Options     PGPQuery `codec:"options" json:"options"`
-	Unencrypted bool     `codec:"unencrypted" json:"unencrypted"`
+	SessionID int      `codec:"sessionID" json:"sessionID"`
+	Options   PGPQuery `codec:"options" json:"options"`
+	Encrypted bool     `codec:"encrypted" json:"encrypted"`
 }
 
 func (o PGPExportArg) DeepCopy() PGPExportArg {
 	return PGPExportArg{
-		SessionID:   o.SessionID,
-		Options:     o.Options.DeepCopy(),
-		Unencrypted: o.Unencrypted,
+		SessionID: o.SessionID,
+		Options:   o.Options.DeepCopy(),
+		Encrypted: o.Encrypted,
 	}
 }
 
 type PGPExportByFingerprintArg struct {
-	SessionID   int      `codec:"sessionID" json:"sessionID"`
-	Options     PGPQuery `codec:"options" json:"options"`
-	Unencrypted bool     `codec:"unencrypted" json:"unencrypted"`
+	SessionID int      `codec:"sessionID" json:"sessionID"`
+	Options   PGPQuery `codec:"options" json:"options"`
+	Encrypted bool     `codec:"encrypted" json:"encrypted"`
 }
 
 func (o PGPExportByFingerprintArg) DeepCopy() PGPExportByFingerprintArg {
 	return PGPExportByFingerprintArg{
-		SessionID:   o.SessionID,
-		Options:     o.Options.DeepCopy(),
-		Unencrypted: o.Unencrypted,
+		SessionID: o.SessionID,
+		Options:   o.Options.DeepCopy(),
+		Encrypted: o.Encrypted,
 	}
 }
 
 type PGPExportByKIDArg struct {
-	SessionID   int      `codec:"sessionID" json:"sessionID"`
-	Options     PGPQuery `codec:"options" json:"options"`
-	Unencrypted bool     `codec:"unencrypted" json:"unencrypted"`
+	SessionID int      `codec:"sessionID" json:"sessionID"`
+	Options   PGPQuery `codec:"options" json:"options"`
+	Encrypted bool     `codec:"encrypted" json:"encrypted"`
 }
 
 func (o PGPExportByKIDArg) DeepCopy() PGPExportByKIDArg {
 	return PGPExportByKIDArg{
-		SessionID:   o.SessionID,
-		Options:     o.Options.DeepCopy(),
-		Unencrypted: o.Unencrypted,
+		SessionID: o.SessionID,
+		Options:   o.Options.DeepCopy(),
+		Encrypted: o.Encrypted,
 	}
 }
 

--- a/protocol/avdl/keybase1/pgp.avdl
+++ b/protocol/avdl/keybase1/pgp.avdl
@@ -91,7 +91,8 @@ protocol pgp {
   }
 
   @lint("ignore")
-  void pgpKeyGen(int sessionID, int primaryBits, int subkeyBits, PGPCreateUids createUids, boolean allowMulti, boolean doExport, boolean pushSecret);
+  void pgpKeyGen(int sessionID, int primaryBits, int subkeyBits, PGPCreateUids createUids, boolean allowMulti, boolean doExport, 
+  boolean exportEncrypted, boolean pushSecret);
 
   @lint("ignore")
   void pgpKeyGenDefault(int sessionID, PGPCreateUids createUids);

--- a/protocol/avdl/keybase1/pgp.avdl
+++ b/protocol/avdl/keybase1/pgp.avdl
@@ -80,9 +80,9 @@ protocol pgp {
   /**
     Exports active PGP keys. Only allows armored export.
     */
-  array<KeyInfo> pgpExport(int sessionID, PGPQuery options);
-  array<KeyInfo> pgpExportByFingerprint(int sessionID, PGPQuery options);
-  array<KeyInfo> pgpExportByKID(int sessionID, PGPQuery options);
+  array<KeyInfo> pgpExport(int sessionID, PGPQuery options, boolean unencrypted);
+  array<KeyInfo> pgpExportByFingerprint(int sessionID, PGPQuery options, boolean unencrypted);
+  array<KeyInfo> pgpExportByKID(int sessionID, PGPQuery options, boolean unencrypted);
 
   @lint("ignore")
   record PGPCreateUids {

--- a/protocol/avdl/keybase1/pgp.avdl
+++ b/protocol/avdl/keybase1/pgp.avdl
@@ -80,9 +80,9 @@ protocol pgp {
   /**
     Exports active PGP keys. Only allows armored export.
     */
-  array<KeyInfo> pgpExport(int sessionID, PGPQuery options, boolean unencrypted);
-  array<KeyInfo> pgpExportByFingerprint(int sessionID, PGPQuery options, boolean unencrypted);
-  array<KeyInfo> pgpExportByKID(int sessionID, PGPQuery options, boolean unencrypted);
+  array<KeyInfo> pgpExport(int sessionID, PGPQuery options, boolean encrypted);
+  array<KeyInfo> pgpExportByFingerprint(int sessionID, PGPQuery options, boolean encrypted);
+  array<KeyInfo> pgpExportByKID(int sessionID, PGPQuery options, boolean encrypted);
 
   @lint("ignore")
   record PGPCreateUids {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6383,6 +6383,7 @@ export type pgpPgpKeyGenRpcParam = Exact<{
   createUids: PGPCreateUids,
   allowMulti: boolean,
   doExport: boolean,
+  exportEncrypted: boolean,
   pushSecret: boolean
 }>
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6355,17 +6355,17 @@ export type pgpPgpEncryptRpcParam = Exact<{
 
 export type pgpPgpExportByFingerprintRpcParam = Exact<{
   options: PGPQuery,
-  unencrypted: boolean
+  encrypted: boolean
 }>
 
 export type pgpPgpExportByKIDRpcParam = Exact<{
   options: PGPQuery,
-  unencrypted: boolean
+  encrypted: boolean
 }>
 
 export type pgpPgpExportRpcParam = Exact<{
   options: PGPQuery,
-  unencrypted: boolean
+  encrypted: boolean
 }>
 
 export type pgpPgpImportRpcParam = Exact<{

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6354,15 +6354,18 @@ export type pgpPgpEncryptRpcParam = Exact<{
 }>
 
 export type pgpPgpExportByFingerprintRpcParam = Exact<{
-  options: PGPQuery
+  options: PGPQuery,
+  unencrypted: boolean
 }>
 
 export type pgpPgpExportByKIDRpcParam = Exact<{
-  options: PGPQuery
+  options: PGPQuery,
+  unencrypted: boolean
 }>
 
 export type pgpPgpExportRpcParam = Exact<{
-  options: PGPQuery
+  options: PGPQuery,
+  unencrypted: boolean
 }>
 
 export type pgpPgpImportRpcParam = Exact<{

--- a/protocol/json/keybase1/pgp.json
+++ b/protocol/json/keybase1/pgp.json
@@ -394,6 +394,10 @@
           "type": "boolean"
         },
         {
+          "name": "exportEncrypted",
+          "type": "boolean"
+        },
+        {
           "name": "pushSecret",
           "type": "boolean"
         }

--- a/protocol/json/keybase1/pgp.json
+++ b/protocol/json/keybase1/pgp.json
@@ -315,6 +315,10 @@
         {
           "name": "options",
           "type": "PGPQuery"
+        },
+        {
+          "name": "unencrypted",
+          "type": "boolean"
         }
       ],
       "response": {
@@ -332,6 +336,10 @@
         {
           "name": "options",
           "type": "PGPQuery"
+        },
+        {
+          "name": "unencrypted",
+          "type": "boolean"
         }
       ],
       "response": {
@@ -348,6 +356,10 @@
         {
           "name": "options",
           "type": "PGPQuery"
+        },
+        {
+          "name": "unencrypted",
+          "type": "boolean"
         }
       ],
       "response": {

--- a/protocol/json/keybase1/pgp.json
+++ b/protocol/json/keybase1/pgp.json
@@ -317,7 +317,7 @@
           "type": "PGPQuery"
         },
         {
-          "name": "unencrypted",
+          "name": "encrypted",
           "type": "boolean"
         }
       ],
@@ -338,7 +338,7 @@
           "type": "PGPQuery"
         },
         {
-          "name": "unencrypted",
+          "name": "encrypted",
           "type": "boolean"
         }
       ],
@@ -358,7 +358,7 @@
           "type": "PGPQuery"
         },
         {
-          "name": "unencrypted",
+          "name": "encrypted",
           "type": "boolean"
         }
       ],

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6383,6 +6383,7 @@ export type pgpPgpKeyGenRpcParam = Exact<{
   createUids: PGPCreateUids,
   allowMulti: boolean,
   doExport: boolean,
+  exportEncrypted: boolean,
   pushSecret: boolean
 }>
 

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6355,17 +6355,17 @@ export type pgpPgpEncryptRpcParam = Exact<{
 
 export type pgpPgpExportByFingerprintRpcParam = Exact<{
   options: PGPQuery,
-  unencrypted: boolean
+  encrypted: boolean
 }>
 
 export type pgpPgpExportByKIDRpcParam = Exact<{
   options: PGPQuery,
-  unencrypted: boolean
+  encrypted: boolean
 }>
 
 export type pgpPgpExportRpcParam = Exact<{
   options: PGPQuery,
-  unencrypted: boolean
+  encrypted: boolean
 }>
 
 export type pgpPgpImportRpcParam = Exact<{

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6354,15 +6354,18 @@ export type pgpPgpEncryptRpcParam = Exact<{
 }>
 
 export type pgpPgpExportByFingerprintRpcParam = Exact<{
-  options: PGPQuery
+  options: PGPQuery,
+  unencrypted: boolean
 }>
 
 export type pgpPgpExportByKIDRpcParam = Exact<{
-  options: PGPQuery
+  options: PGPQuery,
+  unencrypted: boolean
 }>
 
 export type pgpPgpExportRpcParam = Exact<{
-  options: PGPQuery
+  options: PGPQuery,
+  unencrypted: boolean
 }>
 
 export type pgpPgpImportRpcParam = Exact<{


### PR DESCRIPTION
This PR introduces passphrase protected PGP key secret exports. The default behavior is to protect secret key with user's passphrase, similar to what the website does. There is a flag `--unencrypted` to export keys without protection.

Because of how we ask for passphrases when fetching keys from Keyrings, `PGPKeyExportEngine.exportSecret` suffered quite a bit in terms of complexity, because all the machinery to fetch and unlock key (potentially asking for passphrase if the key in memory is locked) had to be collapsed and put into `PGPKeyExportEngine`.

The side effect of this change is that now we _always_ ask for passphrase when exporting PGP key, even if key is already unlocked in Keyrings.

Also important change is in `SKB.UnlockSecretKey` - it would exit early when key was unlocked without attempting the decryption, so in context of PGPExportEngine, we could grab unlocked key with wrong passphrase and then encrypt it using the same wrong passphrase. I changed `UnlockSecretKey`, but that change can also be reverted and additional check added to PGPExportEngine.