### PR TITLE
Remove save button from notifications settings

### DIFF
--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -30,7 +30,6 @@ import type {
   InvitesSent,
   LoadSettings,
   NotificationsRefresh,
-  NotificationsSave,
   NotificationsToggle,
   OnChangeNewEmail,
   OnChangeNewPassphrase,
@@ -91,10 +90,6 @@ function invitesSend(email: string, message: ?string): InvitesSend {
 
 function notificationsRefresh(): NotificationsRefresh {
   return {type: Constants.notificationsRefresh, payload: undefined}
-}
-
-function notificationsSave(): NotificationsSave {
-  return {type: Constants.notificationsSave, payload: undefined}
 }
 
 function notificationsToggle(group: string, name?: string): NotificationsToggle {
@@ -167,7 +162,7 @@ function* _onSubmitNewPassphrase(): SagaGenerator<any, any> {
   }
 }
 
-function* saveNotificationsSaga(): SagaGenerator<any, any> {
+function* toggleNotificationsSaga(): SagaGenerator<any, any> {
   try {
     yield put(Constants.waiting(true))
     const current = yield select(state => state.settings.notifications)
@@ -471,7 +466,7 @@ function* settingsSaga(): SagaGenerator<any, any> {
   yield safeTakeLatest(Constants.invitesRefresh, refreshInvitesSaga)
   yield safeTakeEvery(Constants.invitesSend, sendInviteSaga)
   yield safeTakeLatest(Constants.notificationsRefresh, refreshNotificationsSaga)
-  yield safeTakeLatest(Constants.notificationsSave, saveNotificationsSaga)
+  yield safeTakeLatest(Constants.notificationsToggle, toggleNotificationsSaga)
   yield safeTakeLatest(Constants.deleteAccountForever, deleteAccountForeverSaga)
   yield safeTakeLatest(Constants.loadSettings, loadSettingsSaga)
   yield safeTakeEvery(Constants.onSubmitNewEmail, _onSubmitNewEmail)
@@ -485,7 +480,6 @@ export {
   invitesRefresh,
   invitesSend,
   notificationsRefresh,
-  notificationsSave,
   notificationsToggle,
   onChangeNewEmail,
   onChangeNewPassphrase,

--- a/shared/constants/settings.js
+++ b/shared/constants/settings.js
@@ -32,7 +32,6 @@ export type NotificationsGroupState = {
 }
 
 export type NotificationsState = {
-  allowSave: boolean,
   allowEdit: boolean,
   groups: {
     email?: NotificationsGroupState,
@@ -93,8 +92,6 @@ export type NotificationsRefresh = NoErrorTypedAction<'settings:notificationsRef
 export const notificationsRefreshed = 'settings:notificationsRefreshed'
 export type NotificationsRefreshed = NoErrorTypedAction<'settings:notificationsRefreshed', NotificationsState>
 
-export const notificationsSave = 'settings:notificationsSave'
-export type NotificationsSave = NoErrorTypedAction<'settings:notificationsSave', void>
 export const notificationsSaved = 'settings:notificationsSaved'
 export type NotificationsSaved = NoErrorTypedAction<'settings:notificationsSaved', void>
 
@@ -193,7 +190,6 @@ export type Actions =
   | InvitesRefresh
   | NotificationsRefresh
   | NotificationsRefreshed
-  | NotificationsSave
   | NotificationsSaved
   | NotificationsToggle
   | SetAllowDeleteAccount

--- a/shared/reducers/settings.js
+++ b/shared/reducers/settings.js
@@ -19,7 +19,6 @@ const initialState: State = {
   },
   notifications: {
     allowEdit: false,
-    allowSave: false,
     groups: {
       email: {
         settings: null,
@@ -92,19 +91,11 @@ function reducer(state: State = initialState, action: Actions): State {
         ...state,
         notifications: {
           ...state.notifications,
-          allowSave: true,
+          allowEdit: false,
           groups: {
             ...state.notifications.groups,
             ...changed,
           },
-        },
-      }
-    case Constants.notificationsSave:
-      return {
-        ...state,
-        notifications: {
-          ...state.notifications,
-          allowEdit: false,
         },
       }
     case Constants.notificationsSaved:
@@ -113,7 +104,6 @@ function reducer(state: State = initialState, action: Actions): State {
         notifications: {
           ...state.notifications,
           allowEdit: true,
-          allowSave: false,
         },
       }
     case Constants.notificationsRefreshed:
@@ -121,7 +111,6 @@ function reducer(state: State = initialState, action: Actions): State {
         ...state,
         notifications: {
           allowEdit: true,
-          allowSave: false,
           groups: {
             ...action.payload,
           },

--- a/shared/settings/dumb.desktop.js
+++ b/shared/settings/dumb.desktop.js
@@ -313,7 +313,6 @@ const commonSettings = {
       unsubscribedFromAll: false,
     },
   },
-  allowSave: true,
   allowEdit: true,
   waitingForResponse: false,
   onRefresh: () => console.log('onRefresh'),

--- a/shared/settings/notifications/container.js
+++ b/shared/settings/notifications/container.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import Notifications from './index'
 import {navigateUp} from '../../actions/route-tree'
-import {notificationsRefresh, notificationsSave, notificationsToggle} from '../../actions/settings'
+import {notificationsRefresh, notificationsToggle} from '../../actions/settings'
 
 import type {TypedState} from '../../constants/reducer'
 
@@ -24,7 +24,6 @@ export default connect(
   }),
   (dispatch: any, ownProps: {}) => ({
     onBack: () => dispatch(navigateUp()),
-    onSave: () => dispatch(notificationsSave()),
     onToggle: (group: string, name?: string) => dispatch(notificationsToggle(group, name)),
     onToggleUnsubscribeAll: (group: string) => dispatch(notificationsToggle(group)),
     onRefresh: () => dispatch(notificationsRefresh()),

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {Box, Button, Checkbox, ProgressIndicator, Text} from '../../common-adapters'
+import {Box, Checkbox, ProgressIndicator, Text} from '../../common-adapters'
 import {globalStyles, globalMargins} from '../../styles'
 
 import type {NotificationsSettingsState} from '../../constants/settings'
@@ -104,15 +104,6 @@ const Notifications = (props: Props) =>
             settings={props.groups.security.settings}
             unsubscribedFromAll={false}
           />}
-
-        <Button
-          style={{alignSelf: 'center', marginTop: globalMargins.small}}
-          type="Primary"
-          label="Save"
-          disabled={!props.allowSave || !props.allowEdit}
-          onClick={props.onSave}
-          waiting={props.waitingForResponse}
-        />
       </Box>
 
 export default Notifications

--- a/shared/settings/notifications/index.js.flow
+++ b/shared/settings/notifications/index.js.flow
@@ -14,7 +14,6 @@ export type Settings = Array<{
 
 export type Props = {
   allowEdit: boolean,
-  allowSave: boolean,
   groups: {
     app_push?: Group,
     email?: Group,
@@ -22,7 +21,6 @@ export type Props = {
     security?: Group,
   },
   onRefresh: () => void,
-  onSave: () => void,
   onToggle: (groupName: string, name: string) => void,
   onToggleUnsubscribeAll: (group: string) => void,
   waitingForResponse: boolean,


### PR DESCRIPTION
Saves on every toggle.

Note that Marco helped me hook up flashScrollIndicators(), but it didn't work on iOS and isn't available on Android, so it's not included here.

@keybase/react-hackers 