### PR TITLE
use JSON to transmit untrusted inbox CORE-5806

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -248,7 +248,7 @@ func (g *PushHandler) TlfFinalize(ctx context.Context, m gregor.OutOfBandMessage
 			if conv.GetTopicType() == chat1.TopicType_CHAT {
 				if g.shouldSendNotifications() {
 					g.G().NotifyRouter.HandleChatTLFFinalize(ctx, keybase1.UID(uid.String()),
-						convID, update.FinalizeInfo, conv)
+						convID, update.FinalizeInfo, g.presentUIItem(conv))
 				} else {
 					supdate := []chat1.ConversationStaleUpdate{chat1.ConversationStaleUpdate{
 						ConvID:     convID,
@@ -367,6 +367,14 @@ func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 	return false
 }
 
+func (g *PushHandler) presentUIItem(conv *chat1.ConversationLocal) (res *chat1.InboxUIItem) {
+	if conv != nil {
+		pc := utils.PresentConversationLocal(*conv)
+		res = &pc
+	}
+	return res
+}
+
 func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
@@ -448,7 +456,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
 					Message: decmsg,
 					ConvID:  nm.ConvID,
-					Conv:    conv,
+					Conv:    g.presentUIItem(conv),
 					DisplayDesktopNotification: desktopNotification,
 					Pagination:                 page,
 				})
@@ -494,7 +502,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			activity = chat1.NewChatActivityWithReadMessage(chat1.ReadMessageInfo{
 				MsgID:  nm.MsgID,
 				ConvID: nm.ConvID,
-				Conv:   conv,
+				Conv:   g.presentUIItem(conv),
 			})
 
 			if g.badger != nil && nm.UnreadUpdate != nil {
@@ -517,7 +525,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			activity = chat1.NewChatActivityWithSetStatus(chat1.SetStatusInfo{
 				ConvID: nm.ConvID,
 				Status: nm.Status,
-				Conv:   conv,
+				Conv:   g.presentUIItem(conv),
 			})
 
 			if g.badger != nil && nm.UnreadUpdate != nil {
@@ -573,7 +581,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			conv = &inbox.Convs[0]
 
 			activity = chat1.NewChatActivityWithNewConversation(chat1.NewConversationInfo{
-				Conv: *conv,
+				Conv: *g.presentUIItem(conv),
 			})
 
 			if g.badger != nil && nm.UnreadUpdate != nil {
@@ -617,7 +625,7 @@ func (g *PushHandler) notifyJoinChannel(ctx context.Context, uid gregor1.UID,
 
 	kuid := keybase1.UID(uid.String())
 	if g.shouldSendNotifications() {
-		g.G().NotifyRouter.HandleChatJoinedConversation(ctx, kuid, conv)
+		g.G().NotifyRouter.HandleChatJoinedConversation(ctx, kuid, *g.presentUIItem(&conv))
 	} else {
 		supdate := []chat1.ConversationStaleUpdate{chat1.ConversationStaleUpdate{
 			ConvID:     conv.GetConvID(),

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -368,6 +368,7 @@ func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePla
 
 	// convID will be nil in makeFirstMessage
 	if conv != nil {
+		msg.ClientHeader.Conv = conv.Metadata.IdTriple
 		msg, err = s.addPrevPointersAndCheckConvID(ctx, msg, *conv)
 		if err != nil {
 			return nil, nil, nil, chat1.ChannelMention_NONE, nil, err

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -114,13 +114,8 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 	}
 }
 
-func (n *chatListener) ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal) {
-
-}
-
-func (n *chatListener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID) {
-
-}
+func (n *chatListener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)    {}
+func (n *chatListener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID) {}
 
 func newConvTriple(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, username string) chat1.ConversationIDTriple {
 	nameInfo, err := CtxKeyFinder(ctx, tc.Context()).Find(ctx, username,

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -172,7 +172,8 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 		if lres.InboxRes == nil {
 			return res, fmt.Errorf("invalid conversation localize callback received")
 		}
-		h.Debug(ctx, "GetInboxNonblockLocal: unverified inbox sent: %d convs",
+		start := time.Now()
+		h.Debug(ctx, "GetInboxNonblockLocal: sending unverified inbox: %d convs",
 			len(lres.InboxRes.ConvsUnverified))
 		chatUI.ChatInboxUnverified(ctx, chat1.ChatInboxUnverifiedArg{
 			SessionID: arg.SessionID,
@@ -183,6 +184,7 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 				RateLimits:              res.RateLimits,
 			},
 		})
+		h.Debug(ctx, "GetInboxNonblockLocal: sent unverified inbox successfully: %v", time.Now().Sub(start))
 	case <-time.After(15 * time.Second):
 		return res, fmt.Errorf("timeout waiting for inbox result")
 	case <-ctx.Done():

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1004,7 +1004,8 @@ func (h *Server) PostAttachmentLocal(ctx context.Context, arg chat1.PostAttachme
 	parg := postAttachmentArg{
 		SessionID:        arg.SessionID,
 		ConversationID:   arg.ConversationID,
-		ClientHeader:     arg.ClientHeader,
+		TlfName:          arg.TlfName,
+		Visibility:       arg.Visibility,
 		Attachment:       newStreamSource(arg.Attachment),
 		Title:            arg.Title,
 		Metadata:         arg.Metadata,
@@ -1043,7 +1044,8 @@ func (h *Server) PostFileAttachmentLocal(ctx context.Context, arg chat1.PostFile
 	parg := postAttachmentArg{
 		SessionID:        arg.SessionID,
 		ConversationID:   arg.ConversationID,
-		ClientHeader:     arg.ClientHeader,
+		TlfName:          arg.TlfName,
+		Visibility:       arg.Visibility,
 		Title:            arg.Title,
 		Metadata:         arg.Metadata,
 		IdentifyBehavior: arg.IdentifyBehavior,
@@ -1089,7 +1091,8 @@ type attachmentPreview struct {
 type postAttachmentArg struct {
 	SessionID        int
 	ConversationID   chat1.ConversationID
-	ClientHeader     chat1.MessageClientHeader
+	TlfName          string
+	Visibility       chat1.TLFVisibility
 	Attachment       assetSource
 	Preview          *attachmentPreview
 	Title            string
@@ -1218,10 +1221,9 @@ func (h *Server) postAttachmentLocal(ctx context.Context, arg postAttachmentArg)
 	}
 
 	// set msg client header explicitly
-	postArg.Msg.ClientHeader.Conv = arg.ClientHeader.Conv
 	postArg.Msg.ClientHeader.MessageType = chat1.MessageType_ATTACHMENT
-	postArg.Msg.ClientHeader.TlfName = arg.ClientHeader.TlfName
-	postArg.Msg.ClientHeader.TlfPublic = arg.ClientHeader.TlfPublic
+	postArg.Msg.ClientHeader.TlfName = arg.TlfName
+	postArg.Msg.ClientHeader.TlfPublic = arg.Visibility == chat1.TLFVisibility_PUBLIC
 
 	h.Debug(ctx, "postAttachmentLocal: attachment assets uploaded, posting attachment message")
 	plres, err := h.PostLocal(ctx, postArg)
@@ -1286,8 +1288,8 @@ func (h *Server) postAttachmentLocalInOrder(ctx context.Context, arg postAttachm
 			ConversationID:   arg.ConversationID,
 			IdentifyBehavior: arg.IdentifyBehavior,
 			Supersedes:       placeholder.MessageID,
-			TlfName:          arg.ClientHeader.TlfName,
-			TlfPublic:        arg.ClientHeader.TlfPublic,
+			TlfName:          arg.TlfName,
+			TlfPublic:        arg.Visibility == chat1.TLFVisibility_PUBLIC,
 		}
 		_, derr := h.PostDeleteNonblock(ctx, deleteArg)
 		if derr != nil {
@@ -1377,11 +1379,10 @@ func (h *Server) postAttachmentLocalInOrder(ctx context.Context, arg postAttachm
 	}
 
 	// set msg client header explicitly
-	postArg.Msg.ClientHeader.Conv = arg.ClientHeader.Conv
 	postArg.Msg.ClientHeader.MessageType = chat1.MessageType_ATTACHMENTUPLOADED
 	postArg.Msg.ClientHeader.Supersedes = placeholder.MessageID
-	postArg.Msg.ClientHeader.TlfName = arg.ClientHeader.TlfName
-	postArg.Msg.ClientHeader.TlfPublic = arg.ClientHeader.TlfPublic
+	postArg.Msg.ClientHeader.TlfName = arg.TlfName
+	postArg.Msg.ClientHeader.TlfPublic = arg.Visibility == chat1.TLFVisibility_PUBLIC
 
 	h.Debug(ctx, "postAttachmentLocalInOrder: attachment assets uploaded, posting attachment message")
 	plres, err := h.PostLocal(ctx, postArg)
@@ -1580,7 +1581,6 @@ func (h *Server) postAttachmentPlaceholder(ctx context.Context, arg postAttachme
 		return chat1.PostLocalRes{}, err
 	}
 	obid := chat1.OutboxID(rbs)
-	arg.ClientHeader.OutboxID = &obid
 	chatUI := h.getChatUI(arg.SessionID)
 	chatUI.ChatAttachmentUploadOutboxID(ctx, chat1.ChatAttachmentUploadOutboxIDArg{SessionID: arg.SessionID, OutboxID: obid})
 
@@ -1602,8 +1602,13 @@ func (h *Server) postAttachmentPlaceholder(ctx context.Context, arg postAttachme
 	postArg := chat1.PostLocalArg{
 		ConversationID: arg.ConversationID,
 		Msg: chat1.MessagePlaintext{
-			ClientHeader: arg.ClientHeader,
-			MessageBody:  chat1.NewMessageBodyWithAttachment(attachment),
+			ClientHeader: chat1.MessageClientHeader{
+				TlfName:     arg.TlfName,
+				TlfPublic:   arg.Visibility == chat1.TLFVisibility_PUBLIC,
+				MessageType: chat1.MessageType_ATTACHMENT,
+				OutboxID:    &obid,
+			},
+			MessageBody: chat1.NewMessageBodyWithAttachment(attachment),
 		},
 		IdentifyBehavior: arg.IdentifyBehavior,
 	}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -201,12 +201,17 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 			h.Debug(ctx, "GetInboxNonblockLocal: failed to present untrusted inbox, failing: %s", err.Error())
 			return res, err
 		}
+		jbody, err := json.Marshal(uires)
+		if err != nil {
+			h.Debug(ctx, "GetInboxNonblockLocal: failed to JSON up unverified inbox: %s", err.Error())
+			return res, err
+		}
 		start := time.Now()
 		h.Debug(ctx, "GetInboxNonblockLocal: sending unverified inbox: %d convs",
 			len(lres.InboxRes.ConvsUnverified))
 		chatUI.ChatInboxUnverified(ctx, chat1.ChatInboxUnverifiedArg{
 			SessionID: arg.SessionID,
-			Inbox:     uires,
+			Inbox:     string(jbody),
 		})
 		h.Debug(ctx, "GetInboxNonblockLocal: sent unverified inbox successfully: %v", time.Now().Sub(start))
 	case <-time.After(15 * time.Second):

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -140,6 +140,7 @@ func (h *Server) presentUnverifiedInbox(ctx context.Context, vres chat1.GetInbox
 		conv.Name = rawConv.MaxMsgSummaries[0].TlfName
 		conv.Status = rawConv.Metadata.Status
 		conv.Time = utils.GetConvMtime(rawConv)
+		conv.Visibility = rawConv.Metadata.Visibility
 		res.Items = append(res.Items, conv)
 	}
 	res.Pagination = vres.Pagination
@@ -832,7 +833,6 @@ func (h *Server) PostDeleteNonblock(ctx context.Context, arg chat1.PostDeleteNon
 	parg.ConversationID = arg.ConversationID
 	parg.IdentifyBehavior = arg.IdentifyBehavior
 	parg.OutboxID = arg.OutboxID
-	parg.Msg.ClientHeader.Conv = arg.Conv
 	parg.Msg.ClientHeader.MessageType = chat1.MessageType_DELETE
 	parg.Msg.ClientHeader.Supersedes = arg.Supersedes
 	parg.Msg.ClientHeader.TlfName = arg.TlfName
@@ -848,7 +848,6 @@ func (h *Server) PostEditNonblock(ctx context.Context, arg chat1.PostEditNonbloc
 	parg.ConversationID = arg.ConversationID
 	parg.IdentifyBehavior = arg.IdentifyBehavior
 	parg.OutboxID = arg.OutboxID
-	parg.Msg.ClientHeader.Conv = arg.Conv
 	parg.Msg.ClientHeader.MessageType = chat1.MessageType_EDIT
 	parg.Msg.ClientHeader.Supersedes = arg.Supersedes
 	parg.Msg.ClientHeader.TlfName = arg.TlfName
@@ -868,7 +867,6 @@ func (h *Server) PostTextNonblock(ctx context.Context, arg chat1.PostTextNonbloc
 	parg.ConversationID = arg.ConversationID
 	parg.IdentifyBehavior = arg.IdentifyBehavior
 	parg.OutboxID = arg.OutboxID
-	parg.Msg.ClientHeader.Conv = arg.Conv
 	parg.Msg.ClientHeader.MessageType = chat1.MessageType_TEXT
 	parg.Msg.ClientHeader.TlfName = arg.TlfName
 	parg.Msg.ClientHeader.TlfPublic = arg.TlfPublic
@@ -1287,7 +1285,6 @@ func (h *Server) postAttachmentLocalInOrder(ctx context.Context, arg postAttachm
 		deleteArg := chat1.PostDeleteNonblockArg{
 			ConversationID:   arg.ConversationID,
 			IdentifyBehavior: arg.IdentifyBehavior,
-			Conv:             arg.ClientHeader.Conv,
 			Supersedes:       placeholder.MessageID,
 			TlfName:          arg.ClientHeader.TlfName,
 			TlfPublic:        arg.ClientHeader.TlfPublic,

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -622,7 +622,7 @@ func TestChatSrvGetInboxNonblock(t *testing.T) {
 		select {
 		case ibox := <-inboxCb:
 			require.NotNil(t, ibox.InboxRes, "nil inbox")
-			require.Zero(t, len(ibox.InboxRes.ConversationsUnverified), "wrong size inbox")
+			require.Zero(t, len(ibox.InboxRes.Items), "wrong size inbox")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no inbox received")
 		}
@@ -672,7 +672,7 @@ func TestChatSrvGetInboxNonblock(t *testing.T) {
 		select {
 		case ibox := <-inboxCb:
 			require.NotNil(t, ibox.InboxRes, "nil inbox")
-			require.Equal(t, len(convs), len(ibox.InboxRes.ConversationsUnverified), "wrong size inbox")
+			require.Equal(t, len(convs), len(ibox.InboxRes.Items), "wrong size inbox")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no inbox received")
 		}
@@ -1357,7 +1357,7 @@ type serverChatListener struct {
 	newMessage              chan chat1.IncomingMessage
 	threadsStale            chan []chat1.ConversationStaleUpdate
 	inboxStale              chan struct{}
-	joinedConv              chan chat1.ConversationLocal
+	joinedConv              chan chat1.InboxUIItem
 	leftConv                chan chat1.ConversationID
 	membersUpdate           chan chat1.MembersUpdateInfo
 	appNotificationSettings chan chat1.SetAppNotificationSettingsInfo
@@ -1405,7 +1405,7 @@ func (n *serverChatListener) NewChatActivity(uid keybase1.UID, activity chat1.Ch
 }
 func (n *serverChatListener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate) {
 }
-func (n *serverChatListener) ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal) {
+func (n *serverChatListener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem) {
 	n.joinedConv <- conv
 }
 func (n *serverChatListener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID) {
@@ -1417,7 +1417,7 @@ func newServerChatListener() *serverChatListener {
 		newMessage:              make(chan chat1.IncomingMessage, 100),
 		threadsStale:            make(chan []chat1.ConversationStaleUpdate, 100),
 		inboxStale:              make(chan struct{}, 100),
-		joinedConv:              make(chan chat1.ConversationLocal, 100),
+		joinedConv:              make(chan chat1.InboxUIItem, 100),
 		leftConv:                make(chan chat1.ConversationID, 100),
 		membersUpdate:           make(chan chat1.MembersUpdateInfo, 100),
 		appNotificationSettings: make(chan chat1.SetAppNotificationSettingsInfo, 100),
@@ -1441,7 +1441,6 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		t.Logf("send a text message")
 		arg := chat1.PostTextNonblockArg{
 			ConversationID:   created.Id,
-			Conv:             created.Triple,
 			TlfName:          created.TlfName,
 			TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
 			Body:             "hi",
@@ -1495,7 +1494,6 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		require.NoError(t, err)
 		arg = chat1.PostTextNonblockArg{
 			ConversationID:   created.Id,
-			Conv:             created.Triple,
 			TlfName:          created.TlfName,
 			TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
 			Body:             "hi",
@@ -1519,7 +1517,6 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		t.Logf("edit the message")
 		earg := chat1.PostEditNonblockArg{
 			ConversationID:   created.Id,
-			Conv:             created.Triple,
 			TlfName:          created.TlfName,
 			TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
 			Supersedes:       unboxed.GetMessageID(),
@@ -1542,7 +1539,6 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		t.Logf("delete the message")
 		darg := chat1.PostDeleteNonblockArg{
 			ConversationID:   created.Id,
-			Conv:             created.Triple,
 			TlfName:          created.TlfName,
 			TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
 			Supersedes:       unboxed.GetMessageID(),
@@ -2055,7 +2051,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		select {
 		case conv := <-listener1.joinedConv:
 			require.Equal(t, conv.GetConvID(), ncres.Conv.GetConvID())
-			require.Equal(t, topicName, utils.GetTopicName(conv))
+			require.Equal(t, topicName, conv.Channel)
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "failed to get joined notification")
 		}
@@ -2122,7 +2118,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		select {
 		case conv := <-listener1.joinedConv:
 			require.Equal(t, conv.GetConvID(), getTLFRes.Convs[1].GetConvID())
-			require.Equal(t, topicName, utils.GetTopicName(conv))
+			require.Equal(t, topicName, conv.Channel)
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "failed to get joined notification")
 		}
@@ -2174,7 +2170,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		select {
 		case conv := <-listener2.joinedConv:
 			require.Equal(t, conv.GetConvID(), getTLFRes.Convs[1].GetConvID())
-			require.Equal(t, topicName, utils.GetTopicName(conv))
+			require.Equal(t, topicName, conv.Channel)
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "failed to get joined notification")
 		}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -543,6 +543,14 @@ func (c ByConvID) Less(i, j int) bool {
 	return c[i].Less(c[j])
 }
 
+type ByMsgSummaryCtime []chat1.MessageSummary
+
+func (c ByMsgSummaryCtime) Len() int      { return len(c) }
+func (c ByMsgSummaryCtime) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c ByMsgSummaryCtime) Less(i, j int) bool {
+	return c[i].Ctime.Before(c[j].Ctime)
+}
+
 func GetTopicName(conv chat1.ConversationLocal) string {
 	maxTopicMsg, err := conv.GetMaxMessage(chat1.MessageType_METADATA)
 	if err != nil {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -525,7 +525,7 @@ func GetConvMtime(conv chat1.Conversation) gregor1.Time {
 		}
 	}
 	if len(summaries) == 0 {
-		return gregor1.Time(0)
+		return conv.ReaderInfo.Mtime
 	}
 	sort.Sort(ByMsgSummaryCtime(summaries))
 	return summaries[len(summaries)-1].Ctime
@@ -553,7 +553,7 @@ func GetConvMtimeLocal(conv chat1.ConversationLocal) gregor1.Time {
 	}
 	msg, err := PickLatestMessageUnboxed(conv, timeTyps)
 	if err != nil {
-		return gregor1.Time(0)
+		return conv.ReaderInfo.Mtime
 	}
 	return msg.Valid().ServerHeader.Ctime
 }
@@ -584,7 +584,12 @@ func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxU
 	res.Participants = rawConv.Info.WriterNames
 	res.Status = rawConv.Info.Status
 	res.MembersType = rawConv.GetMembersType()
+	res.Visibility = rawConv.Info.Visibility
 	res.Time = GetConvMtimeLocal(rawConv)
+	res.FinalizeInfo = rawConv.GetFinalizeInfo()
+	res.SupersededBy = rawConv.SupersededBy
+	res.Supersedes = rawConv.Supersedes
+	res.IsEmpty = rawConv.IsEmpty
 	return res
 }
 

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -94,10 +94,6 @@ var chatFlags = map[string]cli.Flag{
 		Name:  "u, unmute",
 		Usage: "Unmute the conversation",
 	},
-	"async": cli.BoolFlag{
-		Name:  "async",
-		Usage: "Fetch inbox and unbox asynchronously",
-	},
 }
 
 func mustGetChatFlags(keys ...string) (flags []cli.Flag) {
@@ -124,7 +120,7 @@ func getInboxFetcherUnreadFirstFlags() []cli.Flag {
 }
 
 func getInboxFetcherActivitySortedFlags() []cli.Flag {
-	return append(mustGetChatFlags("number", "since", "include-hidden", "async"), getConversationResolverFlags()...)
+	return append(mustGetChatFlags("number", "since", "include-hidden"), getConversationResolverFlags()...)
 }
 
 func parseConversationTopicType(ctx *cli.Context) (topicType chat1.TopicType, err error) {
@@ -231,8 +227,6 @@ func makeChatCLIInboxFetcherActivitySorted(ctx *cli.Context) (fetcher chatCLIInb
 	if !ctx.Bool("include-hidden") {
 		fetcher.query.Status = utils.VisibleChatConversationStatuses()
 	}
-
-	fetcher.async = ctx.Bool("async")
 
 	return fetcher, err
 }

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -326,9 +326,14 @@ func (c *chatServiceHandler) AttachV1(ctx context.Context, opts attachOptionsV1)
 	defer fsource.Close()
 	src := c.G().XStreams.ExportReader(fsource)
 
+	vis := chat1.TLFVisibility_PRIVATE
+	if header.clientHeader.TlfPublic {
+		vis = chat1.TLFVisibility_PUBLIC
+	}
 	arg := chat1.PostAttachmentLocalArg{
 		ConversationID: header.conversationID,
-		ClientHeader:   header.clientHeader,
+		TlfName:        header.clientHeader.TlfName,
+		Visibility:     vis,
 		Attachment: chat1.LocalSource{
 			Filename: info.Name(),
 			Size:     int(info.Size()),
@@ -400,9 +405,14 @@ func (c *chatServiceHandler) attachV1NoStream(ctx context.Context, opts attachOp
 	}
 	rl = append(rl, header.rateLimits...)
 
+	vis := chat1.TLFVisibility_PRIVATE
+	if header.clientHeader.TlfPublic {
+		vis = chat1.TLFVisibility_PUBLIC
+	}
 	arg := chat1.PostFileAttachmentLocalArg{
 		ConversationID: header.conversationID,
-		ClientHeader:   header.clientHeader,
+		TlfName:        header.clientHeader.TlfName,
+		Visibility:     vis,
 		Attachment: chat1.LocalFileSource{
 			Filename: opts.Filename,
 		},

--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -8,7 +8,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 )
@@ -105,125 +104,14 @@ func (c *ChatUI) ChatAttachmentDownloadDone(context.Context, int) error {
 }
 
 func (c *ChatUI) ChatInboxConversation(ctx context.Context, arg chat1.ChatInboxConversationArg) error {
-	if c.noOutput {
-		return nil
-	}
-	w := c.terminal.ErrorWriter()
-	sender := "<unknown>"
-	snippet := "<blank>"
-	tlf := arg.Conv.Info.TlfName + " (unverified)"
-	for _, msg := range arg.Conv.MaxMessages {
-		if msg.IsValid() {
-			body := msg.Valid().MessageBody
-			typ, err := (&body).MessageType()
-			if err != nil {
-				continue
-			}
-			if typ != chat1.MessageType_TEXT {
-				continue
-			}
-			sender = msg.Valid().SenderUsername
-			snippet = msg.Valid().MessageBody.Text().Body
-			tlf = msg.Valid().ClientHeader.TlfName
-			break
-		}
-	}
-	fmt.Fprintf(w, "conversation unboxed: tlf: %s sender: %s snippet: %s\n", tlf, sender, snippet)
 	return nil
 }
 
 func (c *ChatUI) ChatInboxFailed(ctx context.Context, arg chat1.ChatInboxFailedArg) error {
-	if c.noOutput {
-		return nil
-	}
-	w := c.terminal.ErrorWriter()
-	switch arg.Error.Typ {
-	case chat1.ConversationErrorType_SELFREKEYNEEDED, chat1.ConversationErrorType_OTHERREKEYNEEDED:
-		fmt.Fprintf(w, "conversation unbox failure: convID: %s err: [%s] %+v\n", arg.ConvID, arg.Error.Typ, arg.Error.RekeyInfo)
-	default:
-		fmt.Fprintf(w, "conversation unbox failure: convID: %s err: %s\n", arg.ConvID, arg.Error.Message)
-	}
 	return nil
 }
 
-func (c *ChatUI) getUnverifiedConvo(ctx context.Context, conv chat1.Conversation) (chat1.ConversationLocal, error) {
-	if len(conv.MaxMsgSummaries) == 0 {
-		return chat1.ConversationLocal{}, fmt.Errorf("no max messages")
-	}
-
-	// Get max text message
-	var txtMsg *chat1.MessageSummary
-	for _, msg := range conv.MaxMsgSummaries {
-		if msg.GetMessageType() == chat1.MessageType_TEXT {
-			txtMsg = &msg
-			break
-		}
-	}
-	if txtMsg == nil {
-		return chat1.ConversationLocal{}, fmt.Errorf("no text message found")
-	}
-
-	// Don't bother with activelist, to avoid loading users from the client.
-	wnames, rnames, err := utils.ReorderParticipants(ctx, c.G().GetUPAKLoader(),
-		txtMsg.TlfName, nil)
-	if err != nil {
-		return chat1.ConversationLocal{}, err
-	}
-	convLocal := chat1.ConversationLocal{
-		ReaderInfo: *conv.ReaderInfo,
-		MaxMessages: []chat1.MessageUnboxed{
-			// This is a fake unboxing, only used for `keybase chat ls --async`
-			// The contents have not been verified at all. Don't be fooled.
-			chat1.MessageUnboxed{
-				State__: chat1.MessageUnboxedState_VALID,
-				Valid__: &chat1.MessageUnboxedValid{
-					MessageBody: chat1.MessageBody{
-						MessageType__: chat1.MessageType_TEXT,
-						Text__: &chat1.MessageText{
-							Body: "<pending>",
-						},
-					},
-					ClientHeader: chat1.MessageClientHeaderVerified{
-						// Conv:         txtMsg.ClientHeader.Conv,
-						Conv:        conv.Metadata.IdTriple,
-						TlfName:     txtMsg.TlfName,
-						TlfPublic:   txtMsg.TlfPublic,
-						MessageType: chat1.MessageType_TEXT,
-						// Sender:       txtMsg.ClientHeader.Sender,
-						// SenderDevice: txtMsg.ClientHeader.SenderDevice,
-					},
-					// ServerHeader:   *txtMsg.ServerHeader,
-					SenderUsername: "???",
-				},
-			},
-		},
-		Info: chat1.ConversationInfoLocal{
-			Id:          conv.Metadata.ConversationID,
-			TlfName:     "<pending>",
-			WriterNames: wnames,
-			ReaderNames: rnames,
-		},
-	}
-
-	return convLocal, nil
-}
-
 func (c *ChatUI) ChatInboxUnverified(ctx context.Context, arg chat1.ChatInboxUnverifiedArg) error {
-
-	var convs []chat1.ConversationLocal
-	for _, conv := range arg.Inbox.ConversationsUnverified {
-		convLocal, err := c.getUnverifiedConvo(ctx, conv)
-		if err != nil {
-			c.G().Log.Error("unable to convert unverified conv: %s", err.Error())
-			continue
-		}
-		convs = append(convs, convLocal)
-	}
-
-	if err := conversationListView(convs).show(c.G(), string(c.G().Env.GetUsername()), false); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/go/client/cmd_chat_list.go
+++ b/go/client/cmd_chat_list.go
@@ -39,10 +39,8 @@ func (c *cmdChatList) Run() error {
 		return err
 	}
 
-	if !c.fetcher.async {
-		if err = conversationListView(conversations).show(c.G(), string(c.G().Env.GetUsername()), c.showDeviceName); err != nil {
-			return err
-		}
+	if err = conversationListView(conversations).show(c.G(), string(c.G().Env.GetUsername()), c.showDeviceName); err != nil {
+		return err
 	}
 
 	// TODO: print summary of inbox. e.g.

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -113,7 +113,7 @@ func (n *nlistener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID
 func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                         {}
 func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationStaleUpdate) {}
 func (n *nlistener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate)                       {}
-func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal)   {}
+func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)         {}
 func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)      {}
 func (n *nlistener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -722,8 +722,8 @@ func (m *ChatRemoteMock) S3Sign(context.Context, chat1.S3SignArg) ([]byte, error
 type NonblockInboxResult struct {
 	ConvID   chat1.ConversationID
 	Err      error
-	ConvRes  *chat1.ConversationLocal
-	InboxRes *chat1.GetInboxLocalRes
+	ConvRes  *chat1.InboxUIItem
+	InboxRes *chat1.UnverifiedInboxUIItems
 }
 
 type NonblockThreadResult struct {
@@ -782,7 +782,7 @@ func (c *ChatUI) ChatAttachmentDownloadDone(context.Context) error {
 func (c *ChatUI) ChatInboxConversation(ctx context.Context, arg chat1.ChatInboxConversationArg) error {
 	c.inboxCb <- NonblockInboxResult{
 		ConvRes: &arg.Conv,
-		ConvID:  arg.Conv.Info.Id,
+		ConvID:  arg.Conv.GetConvID(),
 	}
 	return nil
 }

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -49,7 +49,7 @@ type NotifyListener interface {
 	ChatInboxStale(uid keybase1.UID)
 	ChatThreadsStale(uid keybase1.UID, updates []chat1.ConversationStaleUpdate)
 	ChatTypingUpdate([]chat1.ConvTypingUpdate)
-	ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal)
+	ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)
 	ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)
 	PGPKeyInSecretStoreFile()
 	BadgeState(badgeState keybase1.BadgeState)
@@ -534,7 +534,7 @@ func (n *NotifyRouter) HandleChatIdentifyUpdate(ctx context.Context, update keyb
 	n.G().Log.CDebugf(ctx, "- Sent ChatIdentifyUpdate notification")
 }
 
-func (n *NotifyRouter) HandleChatTLFFinalize(ctx context.Context, uid keybase1.UID, convID chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo, conv *chat1.ConversationLocal) {
+func (n *NotifyRouter) HandleChatTLFFinalize(ctx context.Context, uid keybase1.UID, convID chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo, conv *chat1.InboxUIItem) {
 	if n == nil {
 		return
 	}
@@ -673,7 +673,7 @@ func (n *NotifyRouter) HandleChatTypingUpdate(ctx context.Context, updates []cha
 }
 
 func (n *NotifyRouter) HandleChatJoinedConversation(ctx context.Context, uid keybase1.UID,
-	conv chat1.ConversationLocal) {
+	conv chat1.InboxUIItem) {
 	if n == nil {
 		return
 	}

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -12,6 +12,7 @@ import (
 type UnverifiedInboxUIItem struct {
 	ConvID      string                  `codec:"convID" json:"convID"`
 	Name        string                  `codec:"name" json:"name"`
+	Visibility  TLFVisibility           `codec:"visibility" json:"visibility"`
 	Status      ConversationStatus      `codec:"status" json:"status"`
 	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
 	Time        gregor1.Time            `codec:"time" json:"time"`
@@ -21,6 +22,7 @@ func (o UnverifiedInboxUIItem) DeepCopy() UnverifiedInboxUIItem {
 	return UnverifiedInboxUIItem{
 		ConvID:      o.ConvID,
 		Name:        o.Name,
+		Visibility:  o.Visibility.DeepCopy(),
 		Status:      o.Status.DeepCopy(),
 		MembersType: o.MembersType.DeepCopy(),
 		Time:        o.Time.DeepCopy(),
@@ -55,22 +57,29 @@ func (o UnverifiedInboxUIItems) DeepCopy() UnverifiedInboxUIItems {
 }
 
 type InboxUIItem struct {
-	ConvID       string                  `codec:"convID" json:"convID"`
-	Name         string                  `codec:"name" json:"name"`
-	Snippet      string                  `codec:"snippet" json:"snippet"`
-	Channel      string                  `codec:"channel" json:"channel"`
-	Participants []string                `codec:"participants" json:"participants"`
-	Status       ConversationStatus      `codec:"status" json:"status"`
-	MembersType  ConversationMembersType `codec:"membersType" json:"membersType"`
-	Time         gregor1.Time            `codec:"time" json:"time"`
+	ConvID       string                    `codec:"convID" json:"convID"`
+	IsEmpty      bool                      `codec:"isEmpty" json:"isEmpty"`
+	Name         string                    `codec:"name" json:"name"`
+	Snippet      string                    `codec:"snippet" json:"snippet"`
+	Channel      string                    `codec:"channel" json:"channel"`
+	Visibility   TLFVisibility             `codec:"visibility" json:"visibility"`
+	Participants []string                  `codec:"participants" json:"participants"`
+	Status       ConversationStatus        `codec:"status" json:"status"`
+	MembersType  ConversationMembersType   `codec:"membersType" json:"membersType"`
+	Time         gregor1.Time              `codec:"time" json:"time"`
+	FinalizeInfo *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
+	Supersedes   []ConversationMetadata    `codec:"supersedes" json:"supersedes"`
+	SupersededBy []ConversationMetadata    `codec:"supersededBy" json:"supersededBy"`
 }
 
 func (o InboxUIItem) DeepCopy() InboxUIItem {
 	return InboxUIItem{
-		ConvID:  o.ConvID,
-		Name:    o.Name,
-		Snippet: o.Snippet,
-		Channel: o.Channel,
+		ConvID:     o.ConvID,
+		IsEmpty:    o.IsEmpty,
+		Name:       o.Name,
+		Snippet:    o.Snippet,
+		Channel:    o.Channel,
+		Visibility: o.Visibility.DeepCopy(),
 		Participants: (func(x []string) []string {
 			var ret []string
 			for _, v := range x {
@@ -82,6 +91,29 @@ func (o InboxUIItem) DeepCopy() InboxUIItem {
 		Status:      o.Status.DeepCopy(),
 		MembersType: o.MembersType.DeepCopy(),
 		Time:        o.Time.DeepCopy(),
+		FinalizeInfo: (func(x *ConversationFinalizeInfo) *ConversationFinalizeInfo {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.FinalizeInfo),
+		Supersedes: (func(x []ConversationMetadata) []ConversationMetadata {
+			var ret []ConversationMetadata
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Supersedes),
+		SupersededBy: (func(x []ConversationMetadata) []ConversationMetadata {
+			var ret []ConversationMetadata
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.SupersededBy),
 	}
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -4,6 +4,7 @@
 package chat1
 
 import (
+	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )
@@ -21,6 +22,33 @@ func (o UnverifiedInboxUIItem) DeepCopy() UnverifiedInboxUIItem {
 		Name:   o.Name,
 		Status: o.Status.DeepCopy(),
 		Time:   o.Time.DeepCopy(),
+	}
+}
+
+type UnverifiedInboxUIItems struct {
+	Items      []UnverifiedInboxUIItem `codec:"items" json:"items"`
+	Pagination *Pagination             `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	Offline    bool                    `codec:"offline" json:"offline"`
+}
+
+func (o UnverifiedInboxUIItems) DeepCopy() UnverifiedInboxUIItems {
+	return UnverifiedInboxUIItems{
+		Items: (func(x []UnverifiedInboxUIItem) []UnverifiedInboxUIItem {
+			var ret []UnverifiedInboxUIItem
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Items),
+		Pagination: (func(x *Pagination) *Pagination {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Pagination),
+		Offline: o.Offline,
 	}
 }
 
@@ -131,21 +159,14 @@ func (o ChatAttachmentDownloadDoneArg) DeepCopy() ChatAttachmentDownloadDoneArg 
 }
 
 type ChatInboxUnverifiedArg struct {
-	SessionID int                     `codec:"sessionID" json:"sessionID"`
-	Inbox     []UnverifiedInboxUIItem `codec:"inbox" json:"inbox"`
+	SessionID int                    `codec:"sessionID" json:"sessionID"`
+	Inbox     UnverifiedInboxUIItems `codec:"inbox" json:"inbox"`
 }
 
 func (o ChatInboxUnverifiedArg) DeepCopy() ChatInboxUnverifiedArg {
 	return ChatInboxUnverifiedArg{
 		SessionID: o.SessionID,
-		Inbox: (func(x []UnverifiedInboxUIItem) []UnverifiedInboxUIItem {
-			var ret []UnverifiedInboxUIItem
-			for _, v := range x {
-				vCopy := v.DeepCopy()
-				ret = append(ret, vCopy)
-			}
-			return ret
-		})(o.Inbox),
+		Inbox:     o.Inbox.DeepCopy(),
 	}
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -251,14 +251,14 @@ func (o ChatAttachmentDownloadDoneArg) DeepCopy() ChatAttachmentDownloadDoneArg 
 }
 
 type ChatInboxUnverifiedArg struct {
-	SessionID int                    `codec:"sessionID" json:"sessionID"`
-	Inbox     UnverifiedInboxUIItems `codec:"inbox" json:"inbox"`
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Inbox     string `codec:"inbox" json:"inbox"`
 }
 
 func (o ChatInboxUnverifiedArg) DeepCopy() ChatInboxUnverifiedArg {
 	return ChatInboxUnverifiedArg{
 		SessionID: o.SessionID,
-		Inbox:     o.Inbox.DeepCopy(),
+		Inbox:     o.Inbox,
 	}
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -10,18 +10,20 @@ import (
 )
 
 type UnverifiedInboxUIItem struct {
-	ConvID string             `codec:"convID" json:"convID"`
-	Name   string             `codec:"name" json:"name"`
-	Status ConversationStatus `codec:"status" json:"status"`
-	Time   gregor1.Time       `codec:"time" json:"time"`
+	ConvID      string                  `codec:"convID" json:"convID"`
+	Name        string                  `codec:"name" json:"name"`
+	Status      ConversationStatus      `codec:"status" json:"status"`
+	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
+	Time        gregor1.Time            `codec:"time" json:"time"`
 }
 
 func (o UnverifiedInboxUIItem) DeepCopy() UnverifiedInboxUIItem {
 	return UnverifiedInboxUIItem{
-		ConvID: o.ConvID,
-		Name:   o.Name,
-		Status: o.Status.DeepCopy(),
-		Time:   o.Time.DeepCopy(),
+		ConvID:      o.ConvID,
+		Name:        o.Name,
+		Status:      o.Status.DeepCopy(),
+		MembersType: o.MembersType.DeepCopy(),
+		Time:        o.Time.DeepCopy(),
 	}
 }
 
@@ -35,6 +37,64 @@ func (o UnverifiedInboxUIItems) DeepCopy() UnverifiedInboxUIItems {
 	return UnverifiedInboxUIItems{
 		Items: (func(x []UnverifiedInboxUIItem) []UnverifiedInboxUIItem {
 			var ret []UnverifiedInboxUIItem
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Items),
+		Pagination: (func(x *Pagination) *Pagination {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Pagination),
+		Offline: o.Offline,
+	}
+}
+
+type InboxUIItem struct {
+	ConvID       string                  `codec:"convID" json:"convID"`
+	Name         string                  `codec:"name" json:"name"`
+	Snippet      string                  `codec:"snippet" json:"snippet"`
+	Channel      string                  `codec:"channel" json:"channel"`
+	Participants []string                `codec:"participants" json:"participants"`
+	Status       ConversationStatus      `codec:"status" json:"status"`
+	MembersType  ConversationMembersType `codec:"membersType" json:"membersType"`
+	Time         gregor1.Time            `codec:"time" json:"time"`
+}
+
+func (o InboxUIItem) DeepCopy() InboxUIItem {
+	return InboxUIItem{
+		ConvID:  o.ConvID,
+		Name:    o.Name,
+		Snippet: o.Snippet,
+		Channel: o.Channel,
+		Participants: (func(x []string) []string {
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Participants),
+		Status:      o.Status.DeepCopy(),
+		MembersType: o.MembersType.DeepCopy(),
+		Time:        o.Time.DeepCopy(),
+	}
+}
+
+type InboxUIItems struct {
+	Items      []InboxUIItem `codec:"items" json:"items"`
+	Pagination *Pagination   `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	Offline    bool          `codec:"offline" json:"offline"`
+}
+
+func (o InboxUIItems) DeepCopy() InboxUIItems {
+	return InboxUIItems{
+		Items: (func(x []InboxUIItem) []InboxUIItem {
+			var ret []InboxUIItem
 			for _, v := range x {
 				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
@@ -171,8 +231,8 @@ func (o ChatInboxUnverifiedArg) DeepCopy() ChatInboxUnverifiedArg {
 }
 
 type ChatInboxConversationArg struct {
-	SessionID int               `codec:"sessionID" json:"sessionID"`
-	Conv      ConversationLocal `codec:"conv" json:"conv"`
+	SessionID int         `codec:"sessionID" json:"sessionID"`
+	Conv      InboxUIItem `codec:"conv" json:"conv"`
 }
 
 func (o ChatInboxConversationArg) DeepCopy() ChatInboxConversationArg {

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -8,6 +8,22 @@ import (
 	context "golang.org/x/net/context"
 )
 
+type UnverifiedInboxUIItem struct {
+	ConvID string             `codec:"convID" json:"convID"`
+	Name   string             `codec:"name" json:"name"`
+	Status ConversationStatus `codec:"status" json:"status"`
+	Time   gregor1.Time       `codec:"time" json:"time"`
+}
+
+func (o UnverifiedInboxUIItem) DeepCopy() UnverifiedInboxUIItem {
+	return UnverifiedInboxUIItem{
+		ConvID: o.ConvID,
+		Name:   o.Name,
+		Status: o.Status.DeepCopy(),
+		Time:   o.Time.DeepCopy(),
+	}
+}
+
 type ChatAttachmentUploadOutboxIDArg struct {
 	SessionID int      `codec:"sessionID" json:"sessionID"`
 	OutboxID  OutboxID `codec:"outboxID" json:"outboxID"`
@@ -115,14 +131,21 @@ func (o ChatAttachmentDownloadDoneArg) DeepCopy() ChatAttachmentDownloadDoneArg 
 }
 
 type ChatInboxUnverifiedArg struct {
-	SessionID int              `codec:"sessionID" json:"sessionID"`
-	Inbox     GetInboxLocalRes `codec:"inbox" json:"inbox"`
+	SessionID int                     `codec:"sessionID" json:"sessionID"`
+	Inbox     []UnverifiedInboxUIItem `codec:"inbox" json:"inbox"`
 }
 
 func (o ChatInboxUnverifiedArg) DeepCopy() ChatInboxUnverifiedArg {
 	return ChatInboxUnverifiedArg{
 		SessionID: o.SessionID,
-		Inbox:     o.Inbox.DeepCopy(),
+		Inbox: (func(x []UnverifiedInboxUIItem) []UnverifiedInboxUIItem {
+			var ret []UnverifiedInboxUIItem
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Inbox),
 	}
 }
 

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -625,3 +625,8 @@ func (s TopicNameState) Bytes() []byte {
 func (s TopicNameState) Eq(o TopicNameState) bool {
 	return bytes.Equal(s.Bytes(), o.Bytes())
 }
+
+func (i InboxUIItem) GetConvID() ConversationID {
+	bConvID, _ := hex.DecodeString(i.ConvID)
+	return ConversationID(bConvID)
+}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3401,7 +3401,8 @@ func (o GetMessagesLocalArg) DeepCopy() GetMessagesLocalArg {
 type PostAttachmentLocalArg struct {
 	SessionID        int                          `codec:"sessionID" json:"sessionID"`
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
-	ClientHeader     MessageClientHeader          `codec:"clientHeader" json:"clientHeader"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	Visibility       TLFVisibility                `codec:"visibility" json:"visibility"`
 	Attachment       LocalSource                  `codec:"attachment" json:"attachment"`
 	Preview          *MakePreviewRes              `codec:"preview,omitempty" json:"preview,omitempty"`
 	Title            string                       `codec:"title" json:"title"`
@@ -3413,7 +3414,8 @@ func (o PostAttachmentLocalArg) DeepCopy() PostAttachmentLocalArg {
 	return PostAttachmentLocalArg{
 		SessionID:      o.SessionID,
 		ConversationID: o.ConversationID.DeepCopy(),
-		ClientHeader:   o.ClientHeader.DeepCopy(),
+		TlfName:        o.TlfName,
+		Visibility:     o.Visibility.DeepCopy(),
 		Attachment:     o.Attachment.DeepCopy(),
 		Preview: (func(x *MakePreviewRes) *MakePreviewRes {
 			if x == nil {
@@ -3436,7 +3438,8 @@ func (o PostAttachmentLocalArg) DeepCopy() PostAttachmentLocalArg {
 type PostFileAttachmentLocalArg struct {
 	SessionID        int                          `codec:"sessionID" json:"sessionID"`
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
-	ClientHeader     MessageClientHeader          `codec:"clientHeader" json:"clientHeader"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	Visibility       TLFVisibility                `codec:"visibility" json:"visibility"`
 	Attachment       LocalFileSource              `codec:"attachment" json:"attachment"`
 	Preview          *MakePreviewRes              `codec:"preview,omitempty" json:"preview,omitempty"`
 	Title            string                       `codec:"title" json:"title"`
@@ -3448,7 +3451,8 @@ func (o PostFileAttachmentLocalArg) DeepCopy() PostFileAttachmentLocalArg {
 	return PostFileAttachmentLocalArg{
 		SessionID:      o.SessionID,
 		ConversationID: o.ConversationID.DeepCopy(),
-		ClientHeader:   o.ClientHeader.DeepCopy(),
+		TlfName:        o.TlfName,
+		Visibility:     o.Visibility.DeepCopy(),
 		Attachment:     o.Attachment.DeepCopy(),
 		Preview: (func(x *MakePreviewRes) *MakePreviewRes {
 			if x == nil {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3231,7 +3231,6 @@ func (o PostLocalNonblockArg) DeepCopy() PostLocalNonblockArg {
 
 type PostTextNonblockArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
-	Conv             ConversationIDTriple         `codec:"conv" json:"conv"`
 	TlfName          string                       `codec:"tlfName" json:"tlfName"`
 	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
 	Body             string                       `codec:"body" json:"body"`
@@ -3243,7 +3242,6 @@ type PostTextNonblockArg struct {
 func (o PostTextNonblockArg) DeepCopy() PostTextNonblockArg {
 	return PostTextNonblockArg{
 		ConversationID: o.ConversationID.DeepCopy(),
-		Conv:           o.Conv.DeepCopy(),
 		TlfName:        o.TlfName,
 		TlfPublic:      o.TlfPublic,
 		Body:           o.Body,
@@ -3261,7 +3259,6 @@ func (o PostTextNonblockArg) DeepCopy() PostTextNonblockArg {
 
 type PostDeleteNonblockArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
-	Conv             ConversationIDTriple         `codec:"conv" json:"conv"`
 	TlfName          string                       `codec:"tlfName" json:"tlfName"`
 	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
 	Supersedes       MessageID                    `codec:"supersedes" json:"supersedes"`
@@ -3273,7 +3270,6 @@ type PostDeleteNonblockArg struct {
 func (o PostDeleteNonblockArg) DeepCopy() PostDeleteNonblockArg {
 	return PostDeleteNonblockArg{
 		ConversationID: o.ConversationID.DeepCopy(),
-		Conv:           o.Conv.DeepCopy(),
 		TlfName:        o.TlfName,
 		TlfPublic:      o.TlfPublic,
 		Supersedes:     o.Supersedes.DeepCopy(),
@@ -3291,7 +3287,6 @@ func (o PostDeleteNonblockArg) DeepCopy() PostDeleteNonblockArg {
 
 type PostEditNonblockArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
-	Conv             ConversationIDTriple         `codec:"conv" json:"conv"`
 	TlfName          string                       `codec:"tlfName" json:"tlfName"`
 	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
 	Supersedes       MessageID                    `codec:"supersedes" json:"supersedes"`
@@ -3304,7 +3299,6 @@ type PostEditNonblockArg struct {
 func (o PostEditNonblockArg) DeepCopy() PostEditNonblockArg {
 	return PostEditNonblockArg{
 		ConversationID: o.ConversationID.DeepCopy(),
-		Conv:           o.Conv.DeepCopy(),
 		TlfName:        o.TlfName,
 		TlfPublic:      o.TlfPublic,
 		Supersedes:     o.Supersedes.DeepCopy(),

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -55,11 +55,11 @@ func (e ChatActivityType) String() string {
 }
 
 type IncomingMessage struct {
-	Message                    MessageUnboxed     `codec:"message" json:"message"`
-	ConvID                     ConversationID     `codec:"convID" json:"convID"`
-	DisplayDesktopNotification bool               `codec:"displayDesktopNotification" json:"displayDesktopNotification"`
-	Conv                       *ConversationLocal `codec:"conv,omitempty" json:"conv,omitempty"`
-	Pagination                 *Pagination        `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	Message                    MessageUnboxed `codec:"message" json:"message"`
+	ConvID                     ConversationID `codec:"convID" json:"convID"`
+	DisplayDesktopNotification bool           `codec:"displayDesktopNotification" json:"displayDesktopNotification"`
+	Conv                       *InboxUIItem   `codec:"conv,omitempty" json:"conv,omitempty"`
+	Pagination                 *Pagination    `codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 func (o IncomingMessage) DeepCopy() IncomingMessage {
@@ -67,7 +67,7 @@ func (o IncomingMessage) DeepCopy() IncomingMessage {
 		Message: o.Message.DeepCopy(),
 		ConvID:  o.ConvID.DeepCopy(),
 		DisplayDesktopNotification: o.DisplayDesktopNotification,
-		Conv: (func(x *ConversationLocal) *ConversationLocal {
+		Conv: (func(x *InboxUIItem) *InboxUIItem {
 			if x == nil {
 				return nil
 			}
@@ -85,16 +85,16 @@ func (o IncomingMessage) DeepCopy() IncomingMessage {
 }
 
 type ReadMessageInfo struct {
-	ConvID ConversationID     `codec:"convID" json:"convID"`
-	MsgID  MessageID          `codec:"msgID" json:"msgID"`
-	Conv   *ConversationLocal `codec:"conv,omitempty" json:"conv,omitempty"`
+	ConvID ConversationID `codec:"convID" json:"convID"`
+	MsgID  MessageID      `codec:"msgID" json:"msgID"`
+	Conv   *InboxUIItem   `codec:"conv,omitempty" json:"conv,omitempty"`
 }
 
 func (o ReadMessageInfo) DeepCopy() ReadMessageInfo {
 	return ReadMessageInfo{
 		ConvID: o.ConvID.DeepCopy(),
 		MsgID:  o.MsgID.DeepCopy(),
-		Conv: (func(x *ConversationLocal) *ConversationLocal {
+		Conv: (func(x *InboxUIItem) *InboxUIItem {
 			if x == nil {
 				return nil
 			}
@@ -105,7 +105,7 @@ func (o ReadMessageInfo) DeepCopy() ReadMessageInfo {
 }
 
 type NewConversationInfo struct {
-	Conv ConversationLocal `codec:"conv" json:"conv"`
+	Conv InboxUIItem `codec:"conv" json:"conv"`
 }
 
 func (o NewConversationInfo) DeepCopy() NewConversationInfo {
@@ -117,14 +117,14 @@ func (o NewConversationInfo) DeepCopy() NewConversationInfo {
 type SetStatusInfo struct {
 	ConvID ConversationID     `codec:"convID" json:"convID"`
 	Status ConversationStatus `codec:"status" json:"status"`
-	Conv   *ConversationLocal `codec:"conv,omitempty" json:"conv,omitempty"`
+	Conv   *InboxUIItem       `codec:"conv,omitempty" json:"conv,omitempty"`
 }
 
 func (o SetStatusInfo) DeepCopy() SetStatusInfo {
 	return SetStatusInfo{
 		ConvID: o.ConvID.DeepCopy(),
 		Status: o.Status.DeepCopy(),
-		Conv: (func(x *ConversationLocal) *ConversationLocal {
+		Conv: (func(x *InboxUIItem) *InboxUIItem {
 			if x == nil {
 				return nil
 			}
@@ -504,7 +504,7 @@ type ChatTLFFinalizeArg struct {
 	Uid          keybase1.UID             `codec:"uid" json:"uid"`
 	ConvID       ConversationID           `codec:"convID" json:"convID"`
 	FinalizeInfo ConversationFinalizeInfo `codec:"finalizeInfo" json:"finalizeInfo"`
-	Conv         *ConversationLocal       `codec:"conv,omitempty" json:"conv,omitempty"`
+	Conv         *InboxUIItem             `codec:"conv,omitempty" json:"conv,omitempty"`
 }
 
 func (o ChatTLFFinalizeArg) DeepCopy() ChatTLFFinalizeArg {
@@ -512,7 +512,7 @@ func (o ChatTLFFinalizeArg) DeepCopy() ChatTLFFinalizeArg {
 		Uid:          o.Uid.DeepCopy(),
 		ConvID:       o.ConvID.DeepCopy(),
 		FinalizeInfo: o.FinalizeInfo.DeepCopy(),
-		Conv: (func(x *ConversationLocal) *ConversationLocal {
+		Conv: (func(x *InboxUIItem) *InboxUIItem {
 			if x == nil {
 				return nil
 			}
@@ -583,8 +583,8 @@ func (o ChatTypingUpdateArg) DeepCopy() ChatTypingUpdateArg {
 }
 
 type ChatJoinedConversationArg struct {
-	Uid  keybase1.UID      `codec:"uid" json:"uid"`
-	Conv ConversationLocal `codec:"conv" json:"conv"`
+	Uid  keybase1.UID `codec:"uid" json:"uid"`
+	Conv InboxUIItem  `codec:"conv" json:"conv"`
 }
 
 func (o ChatJoinedConversationArg) DeepCopy() ChatJoinedConversationArg {

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -111,9 +111,9 @@ func (n *nlistener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationI
 }
 func (n *nlistener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {
 }
-func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal) {}
-func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)    {}
-func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                       {}
+func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)    {}
+func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID) {}
+func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                    {}
 func (n *nlistener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
 func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationStaleUpdate) {

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -1,19 +1,27 @@
 @namespace("chat.1")
 
 protocol chatUi {
-  void chatAttachmentUploadOutboxID(int sessionID, OutboxID outboxID); 
-  void chatAttachmentUploadStart(int sessionID, AssetMetadata metadata, MessageID placeholderMsgID) oneway; 
-  void chatAttachmentUploadProgress(int sessionID, long bytesComplete, long bytesTotal) oneway;     
-  void chatAttachmentUploadDone(int sessionID); 
 
-  void chatAttachmentPreviewUploadStart(int sessionID, AssetMetadata metadata) oneway;  
-  void chatAttachmentPreviewUploadDone(int sessionID);  
+  record UnverifiedInboxUIItem {
+    string convID;
+    string name;
+    ConversationStatus status;
+    gregor1.Time time;
+  }
 
-  void chatAttachmentDownloadStart(int sessionID); 
-  void chatAttachmentDownloadProgress(int sessionID, long bytesComplete, long bytesTotal) oneway;     
-  void chatAttachmentDownloadDone(int sessionID);  
+  void chatAttachmentUploadOutboxID(int sessionID, OutboxID outboxID);
+  void chatAttachmentUploadStart(int sessionID, AssetMetadata metadata, MessageID placeholderMsgID) oneway;
+  void chatAttachmentUploadProgress(int sessionID, long bytesComplete, long bytesTotal) oneway;
+  void chatAttachmentUploadDone(int sessionID);
 
-  void chatInboxUnverified(int sessionID, GetInboxLocalRes inbox); 
+  void chatAttachmentPreviewUploadStart(int sessionID, AssetMetadata metadata) oneway;
+  void chatAttachmentPreviewUploadDone(int sessionID);
+
+  void chatAttachmentDownloadStart(int sessionID);
+  void chatAttachmentDownloadProgress(int sessionID, long bytesComplete, long bytesTotal) oneway;
+  void chatAttachmentDownloadDone(int sessionID);
+
+  void chatInboxUnverified(int sessionID, array<UnverifiedInboxUIItem> inbox);
   void chatInboxConversation(int sessionID, ConversationLocal conv);
   void chatInboxFailed(int sessionID, ConversationID convID, ConversationErrorLocal error);
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -8,11 +8,29 @@ protocol chatUi {
     string convID;
     string name;
     ConversationStatus status;
+    ConversationMembersType membersType;
     gregor1.Time time;
   }
 
   record UnverifiedInboxUIItems {
     array<UnverifiedInboxUIItem> items;
+    union { null, Pagination } pagination;
+    boolean offline;
+  }
+
+  record InboxUIItem {
+    string convID;
+    string name;
+    string snippet;
+    string channel;
+    array<string> participants;
+    ConversationStatus status;
+    ConversationMembersType membersType;
+    gregor1.Time time;
+  }
+
+  record InboxUIItems {
+    array<InboxUIItem> items;
     union { null, Pagination } pagination;
     boolean offline;
   }
@@ -30,7 +48,7 @@ protocol chatUi {
   void chatAttachmentDownloadDone(int sessionID);
 
   void chatInboxUnverified(int sessionID, UnverifiedInboxUIItems inbox);
-  void chatInboxConversation(int sessionID, ConversationLocal conv);
+  void chatInboxConversation(int sessionID, InboxUIItem conv);
   void chatInboxFailed(int sessionID, ConversationID convID, ConversationErrorLocal error);
 
   void chatThreadCached(int sessionID, union { null, ThreadView } thread) oneway;

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -55,7 +55,7 @@ protocol chatUi {
   void chatAttachmentDownloadProgress(int sessionID, long bytesComplete, long bytesTotal) oneway;
   void chatAttachmentDownloadDone(int sessionID);
 
-  void chatInboxUnverified(int sessionID, UnverifiedInboxUIItems inbox);
+  void chatInboxUnverified(int sessionID, string inbox);
   void chatInboxConversation(int sessionID, InboxUIItem conv);
   void chatInboxFailed(int sessionID, ConversationID convID, ConversationErrorLocal error);
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -2,11 +2,19 @@
 
 protocol chatUi {
 
+  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
+
   record UnverifiedInboxUIItem {
     string convID;
     string name;
     ConversationStatus status;
     gregor1.Time time;
+  }
+
+  record UnverifiedInboxUIItems {
+    array<UnverifiedInboxUIItem> items;
+    union { null, Pagination } pagination;
+    boolean offline;
   }
 
   void chatAttachmentUploadOutboxID(int sessionID, OutboxID outboxID);
@@ -21,7 +29,7 @@ protocol chatUi {
   void chatAttachmentDownloadProgress(int sessionID, long bytesComplete, long bytesTotal) oneway;
   void chatAttachmentDownloadDone(int sessionID);
 
-  void chatInboxUnverified(int sessionID, array<UnverifiedInboxUIItem> inbox);
+  void chatInboxUnverified(int sessionID, UnverifiedInboxUIItems inbox);
   void chatInboxConversation(int sessionID, ConversationLocal conv);
   void chatInboxFailed(int sessionID, ConversationID convID, ConversationErrorLocal error);
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -7,6 +7,7 @@ protocol chatUi {
   record UnverifiedInboxUIItem {
     string convID;
     string name;
+    TLFVisibility visibility;
     ConversationStatus status;
     ConversationMembersType membersType;
     gregor1.Time time;
@@ -20,13 +21,20 @@ protocol chatUi {
 
   record InboxUIItem {
     string convID;
+   boolean isEmpty;
     string name;
     string snippet;
     string channel;
+    TLFVisibility visibility;
     array<string> participants;
     ConversationStatus status;
     ConversationMembersType membersType;
     gregor1.Time time;
+
+    // Finalized convo stuff
+    union{ null, ConversationFinalizeInfo } finalizeInfo;
+    array<ConversationMetadata> supersedes;
+    array<ConversationMetadata> supersededBy;
   }
 
   record InboxUIItems {

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -21,7 +21,7 @@ protocol chatUi {
 
   record InboxUIItem {
     string convID;
-   boolean isEmpty;
+    boolean isEmpty;
     string name;
     string snippet;
     string channel;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -513,9 +513,9 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  PostLocalNonblockRes postTextNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, string body, MessageID clientPrev, union { null, OutboxID } outboxID,  keybase1.TLFIdentifyBehavior identifyBehavior);
-  PostLocalNonblockRes postDeleteNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, MessageID supersedes,MessageID clientPrev, union { null, OutboxID } outboxID,  keybase1.TLFIdentifyBehavior identifyBehavior);
-  PostLocalNonblockRes postEditNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, MessageID supersedes, string body, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalNonblockRes postTextNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, string body, MessageID clientPrev, union { null, OutboxID } outboxID,  keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalNonblockRes postDeleteNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, MessageID supersedes,MessageID clientPrev, union { null, OutboxID } outboxID,  keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalNonblockRes postEditNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, MessageID supersedes, string body, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
 
 
   @lint("ignore")

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -595,7 +595,7 @@ protocol local {
   }
 
   // Post an attachment from stream source to conversationID.
-  PostLocalRes postAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalSource attachment, union { null, MakePreviewRes} preview, string title, bytes metadata, keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalRes postAttachmentLocal(int sessionID, ConversationID conversationID, string tlfName, TLFVisibility visibility, LocalSource attachment, union { null, MakePreviewRes} preview, string title, bytes metadata, keybase1.TLFIdentifyBehavior identifyBehavior);
 
   // LocalFileSource is a file attachment source.  Filename must be readable
   // by the service for the duration of the attachment upload.
@@ -604,7 +604,7 @@ protocol local {
   }
 
   // Post an attachment from file source to conversationID.
-  PostLocalRes postFileAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalFileSource attachment, union { null, MakePreviewRes } preview, string title, bytes metadata, keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalRes postFileAttachmentLocal(int sessionID, ConversationID conversationID, string tlfName, TLFVisibility visibility, LocalFileSource attachment, union { null, MakePreviewRes } preview, string title, bytes metadata, keybase1.TLFIdentifyBehavior identifyBehavior);
 
   record DownloadAttachmentLocalRes {
     boolean offline;

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -13,30 +13,30 @@ protocol NotifyChat {
     FAILED_MESSAGE_5,
     MEMBERS_UPDATE_6,
     SET_APP_NOTIFICATION_SETTINGS_7
-  } 
+  }
 
   record IncomingMessage {
     MessageUnboxed message;
     ConversationID convID;
     boolean displayDesktopNotification;
-    union { null, ConversationLocal } conv;
+    union { null, InboxUIItem } conv;
     union { null, Pagination } pagination;
   }
 
   record ReadMessageInfo {
     ConversationID convID;
     MessageID msgID;
-    union { null, ConversationLocal } conv;
+    union { null, InboxUIItem } conv;
   }
 
   record NewConversationInfo {
-    ConversationLocal conv;
+    InboxUIItem conv;
   }
 
   record SetStatusInfo {
     ConversationID convID;
     ConversationStatus status;
-    union { null, ConversationLocal } conv;
+    union { null, InboxUIItem } conv;
   }
 
   record SetAppNotificationSettingsInfo {
@@ -98,14 +98,14 @@ protocol NotifyChat {
   @notify("")
   @lint("ignore")
   void ChatTLFFinalize(keybase1.UID uid, ConversationID convID, ConversationFinalizeInfo finalizeInfo,
-    union { null, ConversationLocal } conv);
+    union { null, InboxUIItem } conv);
 
   @notify("")
   @lint("ignore")
   void ChatTLFResolve(keybase1.UID uid, ConversationID convID, ConversationResolveInfo resolveInfo);
 
   @notify("")
-  @lint("ignore") 
+  @lint("ignore")
   void ChatInboxStale(keybase1.UID uid);
 
   @notify("")
@@ -118,10 +118,10 @@ protocol NotifyChat {
 
   @notify("")
   @lint("ignore")
-  void ChatJoinedConversation(keybase1.UID uid, ConversationLocal conv);
+  void ChatJoinedConversation(keybase1.UID uid, InboxUIItem conv);
 
   @notify("")
   @lint("ignore")
-  void ChatLeftConversation(keybase1.UID uid, ConversationID convID); 
+  void ChatLeftConversation(keybase1.UID uid, ConversationID convID);
 
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1480,13 +1480,18 @@ export type InboxResType =
 
 export type InboxUIItem = {
   convID: string,
+  isEmpty: boolean,
   name: string,
   snippet: string,
   channel: string,
+  visibility: TLFVisibility,
   participants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
   time: gregor1.Time,
+  finalizeInfo?: ?ConversationFinalizeInfo,
+  supersedes?: ?Array<ConversationMetadata>,
+  supersededBy?: ?Array<ConversationMetadata>,
 }
 
 export type InboxUIItems = {
@@ -2102,6 +2107,7 @@ export type UnreadUpdateFull = {
 export type UnverifiedInboxUIItem = {
   convID: string,
   name: string,
+  visibility: TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
   time: gregor1.Time,
@@ -2296,7 +2302,6 @@ export type localPostAttachmentLocalRpcParam = Exact<{
 
 export type localPostDeleteNonblockRpcParam = Exact<{
   conversationID: ConversationID,
-  conv: ConversationIDTriple,
   tlfName: string,
   tlfPublic: boolean,
   supersedes: MessageID,
@@ -2307,7 +2312,6 @@ export type localPostDeleteNonblockRpcParam = Exact<{
 
 export type localPostEditNonblockRpcParam = Exact<{
   conversationID: ConversationID,
-  conv: ConversationIDTriple,
   tlfName: string,
   tlfPublic: boolean,
   supersedes: MessageID,
@@ -2343,7 +2347,6 @@ export type localPostLocalRpcParam = Exact<{
 
 export type localPostTextNonblockRpcParam = Exact<{
   conversationID: ConversationID,
-  conv: ConversationIDTriple,
   tlfName: string,
   tlfPublic: boolean,
   body: string,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2159,7 +2159,7 @@ export type chatUiChatInboxFailedRpcParam = Exact<{
 }>
 
 export type chatUiChatInboxUnverifiedRpcParam = Exact<{
-  inbox: UnverifiedInboxUIItems
+  inbox: string
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
@@ -2718,7 +2718,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatInboxUnverified'?: (
     params: Exact<{
       sessionID: int,
-      inbox: UnverifiedInboxUIItems
+      inbox: string
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2089,6 +2089,12 @@ export type UnverifiedInboxUIItem = {
   time: gregor1.Time,
 }
 
+export type UnverifiedInboxUIItems = {
+  items?: ?Array<UnverifiedInboxUIItem>,
+  pagination?: ?Pagination,
+  offline: boolean,
+}
+
 export type UpdateConversationMembership = {
   inboxVers: InboxVers,
   joined?: ?Array<ConversationMember>,
@@ -2129,7 +2135,7 @@ export type chatUiChatInboxFailedRpcParam = Exact<{
 }>
 
 export type chatUiChatInboxUnverifiedRpcParam = Exact<{
-  inbox?: ?Array<UnverifiedInboxUIItem>
+  inbox: UnverifiedInboxUIItems
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
@@ -2689,7 +2695,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatInboxUnverified'?: (
     params: Exact<{
       sessionID: int,
-      inbox?: ?Array<UnverifiedInboxUIItem>
+      inbox: UnverifiedInboxUIItems
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1478,6 +1478,23 @@ export type InboxResType =
     0 // VERSIONHIT_0
   | 1 // FULL_1
 
+export type InboxUIItem = {
+  convID: string,
+  name: string,
+  snippet: string,
+  channel: string,
+  participants?: ?Array<string>,
+  status: ConversationStatus,
+  membersType: ConversationMembersType,
+  time: gregor1.Time,
+}
+
+export type InboxUIItems = {
+  items?: ?Array<InboxUIItem>,
+  pagination?: ?Pagination,
+  offline: boolean,
+}
+
 export type InboxVers = uint64
 
 export type InboxView =
@@ -1494,7 +1511,7 @@ export type IncomingMessage = {
   message: MessageUnboxed,
   convID: ConversationID,
   displayDesktopNotification: boolean,
-  conv?: ?ConversationLocal,
+  conv?: ?InboxUIItem,
   pagination?: ?Pagination,
 }
 
@@ -1727,7 +1744,7 @@ export type NameQuery = {
 }
 
 export type NewConversationInfo = {
-  conv: ConversationLocal,
+  conv: InboxUIItem,
 }
 
 export type NewConversationLocalRes = {
@@ -1776,7 +1793,7 @@ export type NotifyChatChatInboxStaleRpcParam = Exact<{
 
 export type NotifyChatChatJoinedConversationRpcParam = Exact<{
   uid: keybase1.UID,
-  conv: ConversationLocal
+  conv: InboxUIItem
 }>
 
 export type NotifyChatChatLeftConversationRpcParam = Exact<{
@@ -1788,7 +1805,7 @@ export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
   uid: keybase1.UID,
   convID: ConversationID,
   finalizeInfo: ConversationFinalizeInfo,
-  conv?: ?ConversationLocal
+  conv?: ?InboxUIItem
 }>
 
 export type NotifyChatChatTLFResolveRpcParam = Exact<{
@@ -1881,7 +1898,7 @@ export type RateLimit = {
 export type ReadMessageInfo = {
   convID: ConversationID,
   msgID: MessageID,
-  conv?: ?ConversationLocal,
+  conv?: ?InboxUIItem,
 }
 
 export type ReadMessagePayload = {
@@ -1953,7 +1970,7 @@ export type SetConversationStatusRes = {
 export type SetStatusInfo = {
   convID: ConversationID,
   status: ConversationStatus,
-  conv?: ?ConversationLocal,
+  conv?: ?InboxUIItem,
 }
 
 export type SetStatusPayload = {
@@ -2086,6 +2103,7 @@ export type UnverifiedInboxUIItem = {
   convID: string,
   name: string,
   status: ConversationStatus,
+  membersType: ConversationMembersType,
   time: gregor1.Time,
 }
 
@@ -2126,7 +2144,7 @@ export type chatUiChatAttachmentUploadStartRpcParam = Exact<{
 }>
 
 export type chatUiChatInboxConversationRpcParam = Exact<{
-  conv: ConversationLocal
+  conv: InboxUIItem
 }>
 
 export type chatUiChatInboxFailedRpcParam = Exact<{
@@ -2702,7 +2720,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatInboxConversation'?: (
     params: Exact<{
       sessionID: int,
-      conv: ConversationLocal
+      conv: InboxUIItem
     }>,
     response: CommonResponseHandler
   ) => void,
@@ -2748,7 +2766,7 @@ export type incomingCallMapType = Exact<{
       uid: keybase1.UID,
       convID: ConversationID,
       finalizeInfo: ConversationFinalizeInfo,
-      conv?: ?ConversationLocal
+      conv?: ?InboxUIItem
     }> /* ,
     response: {} // Notify call
     */
@@ -2787,7 +2805,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatJoinedConversation'?: (
     params: Exact<{
       uid: keybase1.UID,
-      conv: ConversationLocal
+      conv: InboxUIItem
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2292,7 +2292,8 @@ export type localNewConversationLocalRpcParam = Exact<{
 
 export type localPostAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  clientHeader: MessageClientHeader,
+  tlfName: string,
+  visibility: TLFVisibility,
   attachment: LocalSource,
   preview?: ?MakePreviewRes,
   title: string,
@@ -2323,7 +2324,8 @@ export type localPostEditNonblockRpcParam = Exact<{
 
 export type localPostFileAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  clientHeader: MessageClientHeader,
+  tlfName: string,
+  visibility: TLFVisibility,
   attachment: LocalFileSource,
   preview?: ?MakePreviewRes,
   title: string,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2082,6 +2082,13 @@ export type UnreadUpdateFull = {
   updates?: ?Array<UnreadUpdate>,
 }
 
+export type UnverifiedInboxUIItem = {
+  convID: string,
+  name: string,
+  status: ConversationStatus,
+  time: gregor1.Time,
+}
+
 export type UpdateConversationMembership = {
   inboxVers: InboxVers,
   joined?: ?Array<ConversationMember>,
@@ -2122,7 +2129,7 @@ export type chatUiChatInboxFailedRpcParam = Exact<{
 }>
 
 export type chatUiChatInboxUnverifiedRpcParam = Exact<{
-  inbox: GetInboxLocalRes
+  inbox?: ?Array<UnverifiedInboxUIItem>
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
@@ -2682,7 +2689,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatInboxUnverified'?: (
     params: Exact<{
       sessionID: int,
-      inbox: GetInboxLocalRes
+      inbox?: ?Array<UnverifiedInboxUIItem>
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -25,6 +25,10 @@
           "name": "status"
         },
         {
+          "type": "ConversationMembersType",
+          "name": "membersType"
+        },
+        {
           "type": "gregor1.Time",
           "name": "time"
         }
@@ -38,6 +42,71 @@
           "type": {
             "type": "array",
             "items": "UnverifiedInboxUIItem"
+          },
+          "name": "items"
+        },
+        {
+          "type": [
+            null,
+            "Pagination"
+          ],
+          "name": "pagination"
+        },
+        {
+          "type": "boolean",
+          "name": "offline"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "InboxUIItem",
+      "fields": [
+        {
+          "type": "string",
+          "name": "convID"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "string",
+          "name": "snippet"
+        },
+        {
+          "type": "string",
+          "name": "channel"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "participants"
+        },
+        {
+          "type": "ConversationStatus",
+          "name": "status"
+        },
+        {
+          "type": "ConversationMembersType",
+          "name": "membersType"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "time"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "InboxUIItems",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "InboxUIItem"
           },
           "name": "items"
         },
@@ -194,7 +263,7 @@
         },
         {
           "name": "conv",
-          "type": "ConversationLocal"
+          "type": "InboxUIItem"
         }
       ],
       "response": null

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -21,6 +21,10 @@
           "name": "name"
         },
         {
+          "type": "TLFVisibility",
+          "name": "visibility"
+        },
+        {
           "type": "ConversationStatus",
           "name": "status"
         },
@@ -67,6 +71,10 @@
           "name": "convID"
         },
         {
+          "type": "boolean",
+          "name": "isEmpty"
+        },
+        {
           "type": "string",
           "name": "name"
         },
@@ -77,6 +85,10 @@
         {
           "type": "string",
           "name": "channel"
+        },
+        {
+          "type": "TLFVisibility",
+          "name": "visibility"
         },
         {
           "type": {
@@ -96,6 +108,27 @@
         {
           "type": "gregor1.Time",
           "name": "time"
+        },
+        {
+          "type": [
+            null,
+            "ConversationFinalizeInfo"
+          ],
+          "name": "finalizeInfo"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationMetadata"
+          },
+          "name": "supersedes"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationMetadata"
+          },
+          "name": "supersededBy"
         }
       ]
     },

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -283,7 +283,7 @@
         },
         {
           "name": "inbox",
-          "type": "UnverifiedInboxUIItems"
+          "type": "string"
         }
       ],
       "response": null

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -1,6 +1,12 @@
 {
   "protocol": "chatUi",
-  "imports": [],
+  "imports": [
+    {
+      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "type": "idl",
+      "import_as": "gregor1"
+    }
+  ],
   "types": [
     {
       "type": "record",
@@ -21,6 +27,30 @@
         {
           "type": "gregor1.Time",
           "name": "time"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "UnverifiedInboxUIItems",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "UnverifiedInboxUIItem"
+          },
+          "name": "items"
+        },
+        {
+          "type": [
+            null,
+            "Pagination"
+          ],
+          "name": "pagination"
+        },
+        {
+          "type": "boolean",
+          "name": "offline"
         }
       ]
     }
@@ -151,10 +181,7 @@
         },
         {
           "name": "inbox",
-          "type": {
-            "type": "array",
-            "items": "UnverifiedInboxUIItem"
-          }
+          "type": "UnverifiedInboxUIItems"
         }
       ],
       "response": null

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -1,7 +1,30 @@
 {
   "protocol": "chatUi",
   "imports": [],
-  "types": [],
+  "types": [
+    {
+      "type": "record",
+      "name": "UnverifiedInboxUIItem",
+      "fields": [
+        {
+          "type": "string",
+          "name": "convID"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "ConversationStatus",
+          "name": "status"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "time"
+        }
+      ]
+    }
+  ],
   "messages": {
     "chatAttachmentUploadOutboxID": {
       "request": [
@@ -128,7 +151,10 @@
         },
         {
           "name": "inbox",
-          "type": "GetInboxLocalRes"
+          "type": {
+            "type": "array",
+            "items": "UnverifiedInboxUIItem"
+          }
         }
       ],
       "response": null

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2103,10 +2103,6 @@
           "type": "ConversationID"
         },
         {
-          "name": "conv",
-          "type": "ConversationIDTriple"
-        },
-        {
           "name": "tlfName",
           "type": "string"
         },
@@ -2143,10 +2139,6 @@
           "type": "ConversationID"
         },
         {
-          "name": "conv",
-          "type": "ConversationIDTriple"
-        },
-        {
           "name": "tlfName",
           "type": "string"
         },
@@ -2181,10 +2173,6 @@
         {
           "name": "conversationID",
           "type": "ConversationID"
-        },
-        {
-          "name": "conv",
-          "type": "ConversationIDTriple"
         },
         {
           "name": "tlfName",

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2312,8 +2312,12 @@
           "type": "ConversationID"
         },
         {
-          "name": "clientHeader",
-          "type": "MessageClientHeader"
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "visibility",
+          "type": "TLFVisibility"
         },
         {
           "name": "attachment",
@@ -2352,8 +2356,12 @@
           "type": "ConversationID"
         },
         {
-          "name": "clientHeader",
-          "type": "MessageClientHeader"
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "visibility",
+          "type": "TLFVisibility"
         },
         {
           "name": "attachment",

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -41,7 +41,7 @@
         {
           "type": [
             null,
-            "ConversationLocal"
+            "InboxUIItem"
           ],
           "name": "conv"
         },
@@ -69,7 +69,7 @@
         {
           "type": [
             null,
-            "ConversationLocal"
+            "InboxUIItem"
           ],
           "name": "conv"
         }
@@ -80,7 +80,7 @@
       "name": "NewConversationInfo",
       "fields": [
         {
-          "type": "ConversationLocal",
+          "type": "InboxUIItem",
           "name": "conv"
         }
       ]
@@ -100,7 +100,7 @@
         {
           "type": [
             null,
-            "ConversationLocal"
+            "InboxUIItem"
           ],
           "name": "conv"
         }
@@ -321,7 +321,7 @@
           "name": "conv",
           "type": [
             null,
-            "ConversationLocal"
+            "InboxUIItem"
           ]
         }
       ],
@@ -399,7 +399,7 @@
         },
         {
           "name": "conv",
-          "type": "ConversationLocal"
+          "type": "InboxUIItem"
         }
       ],
       "response": null,

--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -319,10 +319,11 @@ function* onSelectAttachment({payload: {input}}: Constants.SelectAttachment): Ge
     },
   })
 
-  const header = yield call(Shared.clientHeader, ChatTypes.CommonMessageType.attachment, conversationIDKey)
+  const inboxConvo = yield select(Shared.selectedInboxSelector, conversationIDKey)
   const param = {
     conversationID: Constants.keyToConversationID(conversationIDKey),
-    clientHeader: header,
+    tlfName: inboxConvo.name,
+    visibility: inboxConvo.visibility,
     attachment: {filename},
     preview,
     title,

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -122,7 +122,8 @@ function* onInboxStale(): SagaGenerator<any, any> {
     }
     incoming['chat.1.chatUi.chatInboxUnverified'].response.result()
 
-    const inbox: ChatTypes.UnverifiedInboxUIItems = incoming['chat.1.chatUi.chatInboxUnverified'].params.inbox
+    const jsonInbox: string = incoming['chat.1.chatUi.chatInboxUnverified'].params.inbox
+    const inbox: ChatTypes.UnverifiedInboxUIItems = JSON.parse(jsonInbox)
     yield call(_updateFinalized, inbox)
 
     const author = yield select(usernameSelector)

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -910,7 +910,7 @@ function* _sendNotifications(action: Constants.AppendMessages): SagaGenerator<an
     if (convo && convo.get('status') !== 'muted') {
       if (message && message.type === 'Text') {
         console.log('Sending Chat notification')
-        const snippet = Constants.makeSnippet(Constants.serverMessageToMessageBody(message))
+        const snippet = Constants.makeSnippet(Constants.serverMessageToMessageText(message))
         yield put((dispatch: Dispatch) => {
           NotifyPopup(message.author, {body: snippet}, -1, message.author, () => {
             dispatch(Creators.selectConversation(action.payload.conversationIDKey, false))

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -5,7 +5,7 @@ import * as Creators from './creators'
 import * as Shared from './shared'
 import HiddenString from '../../util/hidden-string'
 import {TlfKeysTLFIdentifyBehavior} from '../../constants/types/flow-types'
-import {call, put, select} from 'redux-saga/effects'
+import {all, call, put, select} from 'redux-saga/effects'
 import {isMobile} from '../../constants/platform'
 import {usernameSelector} from '../../constants/selectors'
 import {navigateTo} from '../../actions/route-tree'
@@ -33,12 +33,10 @@ function* deleteMessage(action: Constants.DeleteMessage): SagaGenerator<any, any
 
   if (messageID) {
     // Deleting a server message.
-    const clientHeader = yield call(
-      Shared.clientHeader,
-      ChatTypes.CommonMessageType.delete,
-      conversationIDKey
-    )
-    const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
+    const [inboxConvo, conversationState] = yield all([
+      select(Shared.selectedInboxSelector, conversationIDKey),
+      select(Shared.conversationStateSelector, conversationIDKey),
+    ])
     let lastMessageID
     if (conversationState) {
       const message = conversationState.messages.findLast(m => !!m.messageID)
@@ -53,13 +51,12 @@ function* deleteMessage(action: Constants.DeleteMessage): SagaGenerator<any, any
     yield call(ChatTypes.localPostDeleteNonblockRpcPromise, {
       param: {
         clientPrev: lastMessageID,
-        conv: clientHeader.conv,
         conversationID: Constants.keyToConversationID(conversationIDKey),
         identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
         outboxID,
         supersedes: messageID,
-        tlfName: clientHeader.tlfName,
-        tlfPublic: clientHeader.tlfPublic,
+        tlfName: inboxConvo.name,
+        tlfPublic: false,
       },
     })
   } else {
@@ -92,8 +89,10 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
     }
   }
 
-  const inboxConvo = yield select(Shared.selectedInboxSelector, conversationIDKey)
-  const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
+  const [inboxConvo, conversationState] = yield all([
+    select(Shared.selectedInboxSelector, conversationIDKey),
+    select(Shared.conversationStateSelector, conversationIDKey),
+  ])
   let lastMessageID
   if (conversationState) {
     const message = conversationState.messages.findLast(m => !!m.messageID)
@@ -165,8 +164,10 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
     return
   }
 
-  const clientHeader = yield call(Shared.clientHeader, ChatTypes.CommonMessageType.edit, conversationIDKey)
-  const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
+  const [inboxConvo, conversationState] = yield all([
+    select(Shared.selectedInboxSelector, conversationIDKey),
+    select(Shared.conversationStateSelector, conversationIDKey),
+  ])
   let lastMessageID
   if (conversationState) {
     const message = conversationState.messages.findLast(m => !!m.messageID)
@@ -183,13 +184,12 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
     param: {
       body: action.payload.text.stringValue(),
       clientPrev: lastMessageID,
-      conv: clientHeader.conv,
       conversationID: Constants.keyToConversationID(conversationIDKey),
       identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
       outboxID,
       supersedes: messageID,
-      tlfName: clientHeader.tlfName,
-      tlfPublic: clientHeader.tlfPublic,
+      tlfName: inboxConvo.name,
+      tlfPublic: false,
     },
   })
 }

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -92,7 +92,7 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
     }
   }
 
-  const clientHeader = yield call(Shared.clientHeader, ChatTypes.CommonMessageType.text, conversationIDKey)
+  const inboxConvo = yield select(Shared.selectedInboxSelector, conversationIDKey)
   const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
   let lastMessageID
   if (conversationState) {
@@ -135,21 +135,15 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
     )
   )
 
-  yield call(ChatTypes.localPostLocalNonblockRpcPromise, {
+  yield call(ChatTypes.localPostTextNonblockRpcPromise, {
     param: {
       conversationID: Constants.keyToConversationID(conversationIDKey),
+      tlfName: inboxConvo.name,
+      tlfPublic: false,
       outboxID,
+      body: action.payload.text.stringValue(),
       identifyBehavior: yield call(Shared.getPostingIdentifyBehavior, conversationIDKey),
       clientPrev: lastMessageID,
-      msg: {
-        clientHeader,
-        messageBody: {
-          messageType: ChatTypes.CommonMessageType.text,
-          text: {
-            body: action.payload.text.stringValue(),
-          },
-        },
-      },
     },
   })
 }

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -78,11 +78,7 @@ function* clientHeader(
   conversationIDKey: Constants.ConversationIDKey
 ): Generator<any, ?ChatTypes.MessageClientHeader, any> {
   const infoSelector = (state: TypedState) => {
-    const convo = state.chat.get('inbox').find(convo => convo.get('conversationIDKey') === conversationIDKey)
-    if (convo) {
-      return convo.get('info')
-    }
-    return null
+    return state.chat.get('inbox').find(convo => convo.get('conversationIDKey') === conversationIDKey)
   }
 
   const info = yield select(infoSelector)
@@ -93,8 +89,7 @@ function* clientHeader(
   }
 
   return {
-    conv: info.triple,
-    tlfName: info.tlfName,
+    tlfName: info.name,
     tlfPublic: info.visibility === ChatTypes.CommonTLFVisibility.public,
     messageType,
     supersedes: 0,

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -73,31 +73,6 @@ function tmpFileName(
   return `kbchat-${conversationID}-${messageID}.${isPreview ? 'preview' : 'download'}`
 }
 
-function* clientHeader(
-  messageType: ChatTypes.MessageType,
-  conversationIDKey: Constants.ConversationIDKey
-): Generator<any, ?ChatTypes.MessageClientHeader, any> {
-  const infoSelector = (state: TypedState) => {
-    return state.chat.get('inbox').find(convo => convo.get('conversationIDKey') === conversationIDKey)
-  }
-
-  const info = yield select(infoSelector)
-
-  if (!info) {
-    console.warn('No info to postmessage!')
-    return
-  }
-
-  return {
-    tlfName: info.name,
-    tlfPublic: info.visibility === ChatTypes.CommonTLFVisibility.public,
-    messageType,
-    supersedes: 0,
-    sender: null,
-    senderDevice: null,
-  }
-}
-
 // Actually start a new conversation. conversationIDKey can be a pending one or a replacement
 function* startNewConversation(
   oldConversationIDKey: Constants.ConversationIDKey
@@ -173,7 +148,6 @@ function* getPostingIdentifyBehavior(
 
 export {
   alwaysShowSelector,
-  clientHeader,
   conversationStateSelector,
   devicenameSelector,
   focusedSelector,

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -283,6 +283,8 @@ export const InboxStateRecord = Record({
   state: 'untrusted',
   status: 'unfiled',
   time: 0,
+  name: '',
+  visibility: ChatTypes.CommonTLFVisibility.private,
 })
 
 export type InboxState = KBRecord<{

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -802,18 +802,8 @@ function keyToOutboxID(key: OutboxIDKey): OutboxID {
   return Buffer.from(key, 'hex')
 }
 
-function makeSnippet(messageBody: ?MessageBody): ?string {
-  if (!messageBody) {
-    return null
-  }
-  switch (messageBody.messageType) {
-    case ChatTypes.CommonMessageType.text:
-      return textSnippet(messageBody.text && messageBody.text.body, 100)
-    case ChatTypes.CommonMessageType.attachment:
-      return messageBody.attachment ? textSnippet(messageBody.attachment.object.title, 100) : 'Attachment'
-    default:
-      return null
-  }
+function makeSnippet(messageBody: ?string): ?string {
+  return textSnippet(messageBody || '', 100)
 }
 
 function makeTeamTitle(messageBody: ?MessageBody): ?string {
@@ -843,15 +833,10 @@ function participantFilter(participants: List<string>, you: string): List<string
   return withoutYou
 }
 
-function serverMessageToMessageBody(message: ServerMessage): ?MessageBody {
+function serverMessageToMessageText(message: ServerMessage): ?string {
   switch (message.type) {
     case 'Text':
-      return {
-        messageType: ChatTypes.CommonMessageType.text,
-        text: {
-          body: message.message.stringValue(),
-        },
-      }
+      return message.message.stringValue()
     default:
       return null
   }
@@ -1142,7 +1127,7 @@ export {
   splitMessageIDKey,
   outboxIDToKey,
   participantFilter,
-  serverMessageToMessageBody,
+  serverMessageToMessageText,
   usernamesToUserListItem,
   clampAttachmentPreviewSize,
   newestConversationIDKey,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1480,13 +1480,18 @@ export type InboxResType =
 
 export type InboxUIItem = {
   convID: string,
+  isEmpty: boolean,
   name: string,
   snippet: string,
   channel: string,
+  visibility: TLFVisibility,
   participants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
   time: gregor1.Time,
+  finalizeInfo?: ?ConversationFinalizeInfo,
+  supersedes?: ?Array<ConversationMetadata>,
+  supersededBy?: ?Array<ConversationMetadata>,
 }
 
 export type InboxUIItems = {
@@ -2102,6 +2107,7 @@ export type UnreadUpdateFull = {
 export type UnverifiedInboxUIItem = {
   convID: string,
   name: string,
+  visibility: TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
   time: gregor1.Time,
@@ -2296,7 +2302,6 @@ export type localPostAttachmentLocalRpcParam = Exact<{
 
 export type localPostDeleteNonblockRpcParam = Exact<{
   conversationID: ConversationID,
-  conv: ConversationIDTriple,
   tlfName: string,
   tlfPublic: boolean,
   supersedes: MessageID,
@@ -2307,7 +2312,6 @@ export type localPostDeleteNonblockRpcParam = Exact<{
 
 export type localPostEditNonblockRpcParam = Exact<{
   conversationID: ConversationID,
-  conv: ConversationIDTriple,
   tlfName: string,
   tlfPublic: boolean,
   supersedes: MessageID,
@@ -2343,7 +2347,6 @@ export type localPostLocalRpcParam = Exact<{
 
 export type localPostTextNonblockRpcParam = Exact<{
   conversationID: ConversationID,
-  conv: ConversationIDTriple,
   tlfName: string,
   tlfPublic: boolean,
   body: string,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2159,7 +2159,7 @@ export type chatUiChatInboxFailedRpcParam = Exact<{
 }>
 
 export type chatUiChatInboxUnverifiedRpcParam = Exact<{
-  inbox: UnverifiedInboxUIItems
+  inbox: string
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
@@ -2718,7 +2718,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatInboxUnverified'?: (
     params: Exact<{
       sessionID: int,
-      inbox: UnverifiedInboxUIItems
+      inbox: string
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2089,6 +2089,12 @@ export type UnverifiedInboxUIItem = {
   time: gregor1.Time,
 }
 
+export type UnverifiedInboxUIItems = {
+  items?: ?Array<UnverifiedInboxUIItem>,
+  pagination?: ?Pagination,
+  offline: boolean,
+}
+
 export type UpdateConversationMembership = {
   inboxVers: InboxVers,
   joined?: ?Array<ConversationMember>,
@@ -2129,7 +2135,7 @@ export type chatUiChatInboxFailedRpcParam = Exact<{
 }>
 
 export type chatUiChatInboxUnverifiedRpcParam = Exact<{
-  inbox?: ?Array<UnverifiedInboxUIItem>
+  inbox: UnverifiedInboxUIItems
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
@@ -2689,7 +2695,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatInboxUnverified'?: (
     params: Exact<{
       sessionID: int,
-      inbox?: ?Array<UnverifiedInboxUIItem>
+      inbox: UnverifiedInboxUIItems
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1478,6 +1478,23 @@ export type InboxResType =
     0 // VERSIONHIT_0
   | 1 // FULL_1
 
+export type InboxUIItem = {
+  convID: string,
+  name: string,
+  snippet: string,
+  channel: string,
+  participants?: ?Array<string>,
+  status: ConversationStatus,
+  membersType: ConversationMembersType,
+  time: gregor1.Time,
+}
+
+export type InboxUIItems = {
+  items?: ?Array<InboxUIItem>,
+  pagination?: ?Pagination,
+  offline: boolean,
+}
+
 export type InboxVers = uint64
 
 export type InboxView =
@@ -1494,7 +1511,7 @@ export type IncomingMessage = {
   message: MessageUnboxed,
   convID: ConversationID,
   displayDesktopNotification: boolean,
-  conv?: ?ConversationLocal,
+  conv?: ?InboxUIItem,
   pagination?: ?Pagination,
 }
 
@@ -1727,7 +1744,7 @@ export type NameQuery = {
 }
 
 export type NewConversationInfo = {
-  conv: ConversationLocal,
+  conv: InboxUIItem,
 }
 
 export type NewConversationLocalRes = {
@@ -1776,7 +1793,7 @@ export type NotifyChatChatInboxStaleRpcParam = Exact<{
 
 export type NotifyChatChatJoinedConversationRpcParam = Exact<{
   uid: keybase1.UID,
-  conv: ConversationLocal
+  conv: InboxUIItem
 }>
 
 export type NotifyChatChatLeftConversationRpcParam = Exact<{
@@ -1788,7 +1805,7 @@ export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
   uid: keybase1.UID,
   convID: ConversationID,
   finalizeInfo: ConversationFinalizeInfo,
-  conv?: ?ConversationLocal
+  conv?: ?InboxUIItem
 }>
 
 export type NotifyChatChatTLFResolveRpcParam = Exact<{
@@ -1881,7 +1898,7 @@ export type RateLimit = {
 export type ReadMessageInfo = {
   convID: ConversationID,
   msgID: MessageID,
-  conv?: ?ConversationLocal,
+  conv?: ?InboxUIItem,
 }
 
 export type ReadMessagePayload = {
@@ -1953,7 +1970,7 @@ export type SetConversationStatusRes = {
 export type SetStatusInfo = {
   convID: ConversationID,
   status: ConversationStatus,
-  conv?: ?ConversationLocal,
+  conv?: ?InboxUIItem,
 }
 
 export type SetStatusPayload = {
@@ -2086,6 +2103,7 @@ export type UnverifiedInboxUIItem = {
   convID: string,
   name: string,
   status: ConversationStatus,
+  membersType: ConversationMembersType,
   time: gregor1.Time,
 }
 
@@ -2126,7 +2144,7 @@ export type chatUiChatAttachmentUploadStartRpcParam = Exact<{
 }>
 
 export type chatUiChatInboxConversationRpcParam = Exact<{
-  conv: ConversationLocal
+  conv: InboxUIItem
 }>
 
 export type chatUiChatInboxFailedRpcParam = Exact<{
@@ -2702,7 +2720,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatInboxConversation'?: (
     params: Exact<{
       sessionID: int,
-      conv: ConversationLocal
+      conv: InboxUIItem
     }>,
     response: CommonResponseHandler
   ) => void,
@@ -2748,7 +2766,7 @@ export type incomingCallMapType = Exact<{
       uid: keybase1.UID,
       convID: ConversationID,
       finalizeInfo: ConversationFinalizeInfo,
-      conv?: ?ConversationLocal
+      conv?: ?InboxUIItem
     }> /* ,
     response: {} // Notify call
     */
@@ -2787,7 +2805,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatJoinedConversation'?: (
     params: Exact<{
       uid: keybase1.UID,
-      conv: ConversationLocal
+      conv: InboxUIItem
     }> /* ,
     response: {} // Notify call
     */

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2292,7 +2292,8 @@ export type localNewConversationLocalRpcParam = Exact<{
 
 export type localPostAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  clientHeader: MessageClientHeader,
+  tlfName: string,
+  visibility: TLFVisibility,
   attachment: LocalSource,
   preview?: ?MakePreviewRes,
   title: string,
@@ -2323,7 +2324,8 @@ export type localPostEditNonblockRpcParam = Exact<{
 
 export type localPostFileAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  clientHeader: MessageClientHeader,
+  tlfName: string,
+  visibility: TLFVisibility,
   attachment: LocalFileSource,
   preview?: ?MakePreviewRes,
   title: string,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2082,6 +2082,13 @@ export type UnreadUpdateFull = {
   updates?: ?Array<UnreadUpdate>,
 }
 
+export type UnverifiedInboxUIItem = {
+  convID: string,
+  name: string,
+  status: ConversationStatus,
+  time: gregor1.Time,
+}
+
 export type UpdateConversationMembership = {
   inboxVers: InboxVers,
   joined?: ?Array<ConversationMember>,
@@ -2122,7 +2129,7 @@ export type chatUiChatInboxFailedRpcParam = Exact<{
 }>
 
 export type chatUiChatInboxUnverifiedRpcParam = Exact<{
-  inbox: GetInboxLocalRes
+  inbox?: ?Array<UnverifiedInboxUIItem>
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
@@ -2682,7 +2689,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatInboxUnverified'?: (
     params: Exact<{
       sessionID: int,
-      inbox: GetInboxLocalRes
+      inbox?: ?Array<UnverifiedInboxUIItem>
     }>,
     response: CommonResponseHandler
   ) => void,


### PR DESCRIPTION
This changes the unverified inbox delivery to use a JSON encoding inside of a slim msgpack envelope. It turns out this is a significant speed up to decoding, so let's get it in play. 

At some point in the future, it would probably be a good idea to figure out some way to get JSON RPC enabled on an opt-in basis for RPC calls to the frontend. It is pretty clear that JSON decoding is significantly faster than msgpack, and so we would stand to get a fairly legitimate perf gain, especially on phones.