### PR TITLE
GetClient wait for connection to happen before returning OfflineClient

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -117,7 +117,7 @@ func (h *Server) handleOfflineError(ctx context.Context, err error,
 		h.Debug(ctx, "handleOfflineError: setting offline: err: %s", err.Error())
 		res.SetOffline()
 
-		// Reconnect Gregor if we think we are online
+		// Reconnect Gregor if we think we are offline
 		if _, err := h.serverConn.Reconnect(ctx); err != nil {
 			h.Debug(ctx, "handleOfflineError: error reconnecting: %s", err.Error())
 		}
@@ -133,6 +133,11 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, &breaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetInboxNonblockLocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
+	defer func() {
+		if res.Offline {
+			h.Debug(ctx, "GetInboxNonblockLocal: res.Offline")
+		}
+	}()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}
@@ -365,6 +370,11 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 				NewConversationRetry(h.G(), arg.ConversationID, ThreadLoad))
 		}
 	}()
+	defer func() {
+		if res.Offline {
+			h.Debug(ctx, "GetThreadNonblock: res.Offline")
+		}
+	}()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}
@@ -489,6 +499,11 @@ func (h *Server) GetInboxSummaryForCLILocal(ctx context.Context, arg chat1.GetIn
 		h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetInboxSummaryForCLILocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
+	defer func() {
+		if res.Offline {
+			h.Debug(ctx, "GetInboxSummaryForCLILocal: res.Offline")
+		}
+	}()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return chat1.GetInboxSummaryForCLILocalRes{}, err
 	}
@@ -1878,6 +1893,11 @@ func (h *Server) JoinConversationByIDLocal(ctx context.Context, convID chat1.Con
 		&identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("JoinConversationByID(%s)", convID))()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
+	defer func() {
+		if res.Offline {
+			h.Debug(ctx, "JoinConversationByIDLocal: res.Offline")
+		}
+	}()
 
 	uid, err := h.assertLoggedInUID(ctx)
 	if err != nil {
@@ -1900,6 +1920,11 @@ func (h *Server) JoinConversationLocal(ctx context.Context, arg chat1.JoinConver
 	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("JoinConversation(%s)",
 		arg.TopicName))()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
+	defer func() {
+		if res.Offline {
+			h.Debug(ctx, "JoinConversationLocal: res.Offline")
+		}
+	}()
 	uid, err := h.assertLoggedInUID(ctx)
 	if err != nil {
 		return res, err
@@ -1964,6 +1989,11 @@ func (h *Server) LeaveConversationLocal(ctx context.Context, convID chat1.Conver
 		&identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("LeaveConversation(%s)", convID))()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
+	defer func() {
+		if res.Offline {
+			h.Debug(ctx, "LeaveConversationLocal: res.Offline")
+		}
+	}()
 	uid, err := h.assertLoggedInUID(ctx)
 	if err != nil {
 		return res, err
@@ -1986,6 +2016,11 @@ func (h *Server) GetTLFConversationsLocal(ctx context.Context, arg chat1.GetTLFC
 	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("GetTLFConversations(%s)",
 		arg.TlfName))()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
+	defer func() {
+		if res.Offline {
+			h.Debug(ctx, "GetTLFConversationsLocal: res.Offline")
+		}
+	}()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}
@@ -2015,6 +2050,11 @@ func (h *Server) SetAppNotificationSettingsLocal(ctx context.Context,
 	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("SetAppNotificationSettings(%s)",
 		arg.ConvID))()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
+	defer func() {
+		if res.Offline {
+			h.Debug(ctx, "SetAppNotificationSettingsLocal: res.Offline")
+		}
+	}()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -114,12 +114,15 @@ func (h *Server) handleOfflineError(ctx context.Context, err error,
 	res chat1.OfflinableResult) error {
 
 	if h.isOfflineError(err) {
-		h.Debug(ctx, "handleOfflineError: setting offline: err: %s", err.Error())
+		h.Debug(ctx, "handleOfflineError: setting offline: err: %s", err)
 		res.SetOffline()
 
 		// Reconnect Gregor if we think we are offline
+		h.Debug(ctx, "handleOfflineError: reconnecting to gregor")
 		if _, err := h.serverConn.Reconnect(ctx); err != nil {
-			h.Debug(ctx, "handleOfflineError: error reconnecting: %s", err.Error())
+			h.Debug(ctx, "handleOfflineError: error reconnecting: %s", err)
+		} else {
+			h.Debug(ctx, "handleOfflineError: success reconnecting")
 		}
 
 		return nil
@@ -135,7 +138,7 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	defer func() {
 		if res.Offline {
-			h.Debug(ctx, "GetInboxNonblockLocal: res.Offline")
+			h.Debug(ctx, "GetInboxNonblockLocal: result obtained offline")
 		}
 	}()
 	if err = h.assertLoggedIn(ctx); err != nil {
@@ -372,7 +375,7 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 	}()
 	defer func() {
 		if res.Offline {
-			h.Debug(ctx, "GetThreadNonblock: res.Offline")
+			h.Debug(ctx, "GetThreadNonblock: result obtained offline")
 		}
 	}()
 	if err := h.assertLoggedIn(ctx); err != nil {
@@ -499,11 +502,6 @@ func (h *Server) GetInboxSummaryForCLILocal(ctx context.Context, arg chat1.GetIn
 		h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetInboxSummaryForCLILocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
-	defer func() {
-		if res.Offline {
-			h.Debug(ctx, "GetInboxSummaryForCLILocal: res.Offline")
-		}
-	}()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return chat1.GetInboxSummaryForCLILocalRes{}, err
 	}
@@ -1895,7 +1893,7 @@ func (h *Server) JoinConversationByIDLocal(ctx context.Context, convID chat1.Con
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	defer func() {
 		if res.Offline {
-			h.Debug(ctx, "JoinConversationByIDLocal: res.Offline")
+			h.Debug(ctx, "JoinConversationByIDLocal: result obtained offline")
 		}
 	}()
 
@@ -1922,7 +1920,7 @@ func (h *Server) JoinConversationLocal(ctx context.Context, arg chat1.JoinConver
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	defer func() {
 		if res.Offline {
-			h.Debug(ctx, "JoinConversationLocal: res.Offline")
+			h.Debug(ctx, "JoinConversationLocal: result obtained offline")
 		}
 	}()
 	uid, err := h.assertLoggedInUID(ctx)
@@ -1991,7 +1989,7 @@ func (h *Server) LeaveConversationLocal(ctx context.Context, convID chat1.Conver
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	defer func() {
 		if res.Offline {
-			h.Debug(ctx, "LeaveConversationLocal: res.Offline")
+			h.Debug(ctx, "LeaveConversationLocal: result obtained offline")
 		}
 	}()
 	uid, err := h.assertLoggedInUID(ctx)
@@ -2018,7 +2016,7 @@ func (h *Server) GetTLFConversationsLocal(ctx context.Context, arg chat1.GetTLFC
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	defer func() {
 		if res.Offline {
-			h.Debug(ctx, "GetTLFConversationsLocal: res.Offline")
+			h.Debug(ctx, "GetTLFConversationsLocal: result obtained offline")
 		}
 	}()
 	if err = h.assertLoggedIn(ctx); err != nil {
@@ -2052,7 +2050,7 @@ func (h *Server) SetAppNotificationSettingsLocal(ctx context.Context,
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	defer func() {
 		if res.Offline {
-			h.Debug(ctx, "SetAppNotificationSettingsLocal: res.Offline")
+			h.Debug(ctx, "SetAppNotificationSettingsLocal: result obtained offline")
 		}
 	}()
 	if err = h.assertLoggedIn(ctx); err != nil {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -353,10 +353,6 @@ func (g *gregorHandler) Connect(uri *rpc.FMPURI) (err error) {
 	g.connectHappened = make(chan struct{})
 	defer close(g.connectHappened)
 
-	g.G().Log.Debug("artificial sleep 1s")
-	time.Sleep(1 * time.Second)
-	g.G().Log.Debug("artificial sleep done")
-
 	// Create client interface to gregord; the user needs to be logged in for this
 	// to work
 	if err = g.resetGregorClient(); err != nil {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -143,6 +143,9 @@ type gregorHandler struct {
 	conn      *rpc.Connection
 	uri       *rpc.FMPURI
 
+	// connectHappened will be closed after gregor connection established
+	connectHappened chan struct{}
+
 	cli               rpc.GenericClient
 	pingCli           rpc.GenericClient
 	sessionID         gregor1.SessionID
@@ -243,9 +246,22 @@ func (g *gregorHandler) GetURI() *rpc.FMPURI {
 
 func (g *gregorHandler) GetClient() chat1.RemoteInterface {
 	if g.IsShutdown() || g.cli == nil {
-		g.chatLog.Debug(context.Background(), "GetClient: shutdown, using errorClient for chat1.RemoteClient")
-		return chat1.RemoteClient{Cli: chat.OfflineClient{}}
+		select {
+		case <-g.connectHappened:
+			if g.IsShutdown() || g.cli == nil {
+				g.chatLog.Debug(context.Background(), "GetClient: connectHappened, but still shutdown, using OfflineClient for chat1.RemoteClient")
+				return chat1.RemoteClient{Cli: chat.OfflineClient{}}
+
+			}
+			g.chatLog.Debug(context.Background(), "GetClient: successfully waited for connection")
+			return chat1.RemoteClient{Cli: chat.NewRemoteClient(g.G(), g.cli)}
+		case <-time.After(2 * time.Second):
+			g.chatLog.Debug(context.Background(), "GetClient: shutdown, using OfflineClient for chat1.RemoteClient (waited 2s for connectHappened)")
+			return chat1.RemoteClient{Cli: chat.OfflineClient{}}
+		}
 	}
+
+	g.chatLog.Debug(context.Background(), "GetClient: not shutdown, making new remote client")
 	return chat1.RemoteClient{Cli: chat.NewRemoteClient(g.G(), g.cli)}
 }
 
@@ -333,6 +349,13 @@ func (g *gregorHandler) setReachability(r *reachability) {
 func (g *gregorHandler) Connect(uri *rpc.FMPURI) (err error) {
 
 	defer g.G().Trace("gregorHandler#Connect", func() error { return err })()
+
+	g.connectHappened = make(chan struct{})
+	defer close(g.connectHappened)
+
+	g.G().Log.Debug("artificial sleep 1s")
+	time.Sleep(1 * time.Second)
+	g.G().Log.Debug("artificial sleep done")
 
 	// Create client interface to gregord; the user needs to be logged in for this
 	// to work

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -13,7 +13,7 @@ const nativeBridge = NativeModules.KeybaseEngine || {test: 'fallback'}
 // console.disableYellowBox = true
 
 // Set this to true if you want to turn off most console logging so you can profile easier
-const PERF = true
+const PERF = false
 
 let config: {[key: string]: any} = {
   actionStatFrequency: 0,

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -13,7 +13,7 @@ const nativeBridge = NativeModules.KeybaseEngine || {test: 'fallback'}
 // console.disableYellowBox = true
 
 // Set this to true if you want to turn off most console logging so you can profile easier
-const PERF = false
+const PERF = true
 
 let config: {[key: string]: any} = {
   actionStatFrequency: 0,


### PR DESCRIPTION
This changes GetClient to wait for up to 2s for any in progress connections to gregor to happen.  If none do, then it returns an OfflineClient.  Previously, an OfflineClient was returned immediately.

Note that it is still possible for calls like GetInboxNonblockLocal to have Offline set in the result if the results were obtained offline while a connection was in progress, there is no change here to affect that (although there is more logging).