### PR TITLE
Standalone mode tests for teams

### DIFF
--- a/go/client/cmd_team_remove_member.go
+++ b/go/client/cmd_team_remove_member.go
@@ -15,10 +15,13 @@ import (
 
 type CmdTeamRemoveMember struct {
 	libkb.Contextified
-	team     string
-	username string
-	role     keybase1.TeamRole
-	force    bool
+	Team     string
+	Username string
+	Force    bool
+}
+
+func NewCmdTeamRemoveMemberRunner(g *libkb.GlobalContext) *CmdTeamRemoveMember {
+	return &CmdTeamRemoveMember{Contextified: libkb.NewContextified(g)}
 }
 
 func newCmdTeamRemoveMember(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -45,17 +48,17 @@ func newCmdTeamRemoveMember(cl *libcmdline.CommandLine, g *libkb.GlobalContext) 
 
 func (c *CmdTeamRemoveMember) ParseArgv(ctx *cli.Context) error {
 	var err error
-	c.team, err = ParseOneTeamName(ctx)
+	c.Team, err = ParseOneTeamName(ctx)
 	if err != nil {
 		return err
 	}
 
-	c.username, err = ParseUser(ctx)
+	c.Username, err = ParseUser(ctx)
 	if err != nil {
 		return err
 	}
 
-	c.force = ctx.Bool("force")
+	c.Force = ctx.Bool("force")
 
 	return nil
 }
@@ -63,7 +66,7 @@ func (c *CmdTeamRemoveMember) ParseArgv(ctx *cli.Context) error {
 func (c *CmdTeamRemoveMember) Run() error {
 	ui := c.G().UI.GetTerminalUI()
 
-	if !c.force {
+	if !c.Force {
 		configCLI, err := GetConfigClient(c.G())
 		if err != nil {
 			return err
@@ -74,8 +77,8 @@ func (c *CmdTeamRemoveMember) Run() error {
 		}
 
 		var prompt string
-		if curStatus.User != nil && libkb.NewNormalizedUsername(c.username).Eq(libkb.NewNormalizedUsername(curStatus.User.Username)) {
-			prompt = fmt.Sprintf("Are you sure you want to remove yourself from team %s?", c.team)
+		if curStatus.User != nil && libkb.NewNormalizedUsername(c.Username).Eq(libkb.NewNormalizedUsername(curStatus.User.Username)) {
+			prompt = fmt.Sprintf("Are you sure you want to remove yourself from team %s?", c.Team)
 		} else {
 			prompt = fmt.Sprint("Are you sure?")
 		}
@@ -94,15 +97,15 @@ func (c *CmdTeamRemoveMember) Run() error {
 	}
 
 	arg := keybase1.TeamRemoveMemberArg{
-		Name:     c.team,
-		Username: c.username,
+		Name:     c.Team,
+		Username: c.Username,
 	}
 
 	if err = cli.TeamRemoveMember(context.Background(), arg); err != nil {
 		return err
 	}
 
-	ui.Printf("Success! %s removed from team %s.\n", c.username, c.team)
+	ui.Printf("Success! %s removed from team %s.\n", c.Username, c.Team)
 
 	return nil
 }

--- a/go/systests/standalone_test.go
+++ b/go/systests/standalone_test.go
@@ -1,0 +1,95 @@
+package systests
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/client"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/service"
+	"github.com/stretchr/testify/require"
+)
+
+func makeUserStandalone(t *testing.T, pre string) *userPlusDevice {
+	tctx := setupTest(t, pre)
+	var u userPlusDevice
+
+	g := tctx.G
+
+	u.device = &deviceWrapper{tctx: tctx}
+
+	// Mimic what keybase/main.go does for Standalone.
+	var err error
+	svc := service.NewService(tctx.G, false)
+	err = svc.SetupCriticalSubServices()
+	require.NoError(t, err)
+	err = svc.StartLoopbackServer()
+	require.NoError(t, err)
+
+	g.StandaloneChatConnector = svc
+	g.Standalone = true
+
+	userInfo := randomUser(pre)
+
+	signupUI := signupUI{
+		info:         userInfo,
+		Contextified: libkb.NewContextified(g),
+	}
+	g.SetUI(&signupUI)
+	signup := client.NewCmdSignupRunner(g)
+	signup.SetTest()
+	if err := signup.Run(); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("signed up %s", userInfo.username)
+
+	u.username = userInfo.username
+	u.uid = libkb.UsernameToUID(u.username)
+	u.tc = tctx
+
+	cli, _, err := client.GetRPCClientWithContext(g)
+	require.NoError(t, err)
+
+	u.deviceClient = keybase1.DeviceClient{Cli: cli}
+
+	return &u
+}
+
+func TestStandaloneTeamMemberOps(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	tt.users = append(tt.users, makeUserStandalone(t, "user1"))
+	tt.addUser("user2")
+
+	team := tt.users[0].createTeam()
+
+	g := tt.users[0].tc.G
+
+	add := client.NewCmdTeamAddMemberRunner(g)
+	add.Team = team
+	add.Username = tt.users[1].username
+	add.Role = keybase1.TeamRole_WRITER
+	add.SkipChatNotification = false
+
+	err := add.Run()
+	require.NoError(t, err)
+
+	listmem := client.NewCmdTeamListMembershipsRunner(g)
+	listmem.SetJSON(true)
+	err = listmem.Run()
+	require.NoError(t, err)
+
+	listmem = client.NewCmdTeamListMembershipsRunner(g)
+	listmem.SetJSON(true)
+	listmem.SetTeam(team)
+	err = listmem.Run()
+	require.NoError(t, err)
+
+	remove := client.NewCmdTeamRemoveMemberRunner(g)
+	remove.Team = team
+	remove.Username = tt.users[1].username
+	remove.Force = true // avoid Yes/No prompt
+	err = remove.Run()
+	require.NoError(t, err)
+}

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -199,7 +199,6 @@ func (u *userPlusDevice) addTeamMember(team, username string, role keybase1.Team
 	add.Team = team
 	add.Username = username
 	add.Role = role
-	add.SkipChatNotification = true // kbfs client currently required to do this...
 	if err := add.Run(); err != nil {
 		u.tc.T.Fatal(err)
 	}
@@ -210,7 +209,6 @@ func (u *userPlusDevice) addTeamMemberEmail(team, email string, role keybase1.Te
 	add.Team = team
 	add.Email = email
 	add.Role = role
-	add.SkipChatNotification = true // kbfs client currently required to do this...
 	if err := add.Run(); err != nil {
 		u.tc.T.Fatal(err)
 	}


### PR DESCRIPTION
Add test setup that mimic standalone mode. `makeUserStandalone` returns `userPlusDevice` with service setup similar to one created in `keybase/main.go` standalone code path.

Removed `add.SkipChatNotification = true` from teams_test because it does not need KBFS anymore and works fine in regular test context.