### PR TITLE
Use sourceOfflinable in inbox, conv sources to wait for connections in IsOffline

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -376,7 +376,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 		debugger.Debug(ctx, "FindConversation: no conversations found in inbox, trying public chats")
 
 		// Check for offline and return an error
-		if g.InboxSource.IsOffline() {
+		if g.InboxSource.IsOffline(ctx) {
 			return res, rl, OfflineError{}
 		}
 

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -336,7 +336,7 @@ func (f *FetchRetrier) Disconnected(ctx context.Context) {
 }
 
 // IsOffline returns if the module thinks we are connected to the chat server.
-func (f *FetchRetrier) IsOffline() bool {
+func (f *FetchRetrier) IsOffline(ctx context.Context) bool {
 	f.Lock()
 	defer f.Unlock()
 	return f.offline

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -736,7 +736,7 @@ func (s *Deliverer) disconnectedTime() time.Duration {
 	return s.clock.Now().Sub(s.disconnTime)
 }
 
-func (s *Deliverer) IsOffline() bool {
+func (s *Deliverer) IsOffline(ctx context.Context) bool {
 	return !s.connected
 }
 

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -213,7 +213,7 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 		uires, err := h.presentUnverifiedInbox(ctx, chat1.GetInboxLocalRes{
 			ConversationsUnverified: lres.InboxRes.ConvsUnverified,
 			Pagination:              lres.InboxRes.Pagination,
-			Offline:                 h.G().InboxSource.IsOffline(),
+			Offline:                 h.G().InboxSource.IsOffline(ctx),
 		})
 		if err != nil {
 			h.Debug(ctx, "GetInboxNonblockLocal: failed to present untrusted inbox, failing: %s", err.Error())

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -274,7 +274,7 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 	}
 	wg.Wait()
 
-	res.Offline = h.G().InboxSource.IsOffline()
+	res.Offline = h.G().InboxSource.IsOffline(ctx)
 	res.IdentifyFailures = breaks
 	return res, nil
 }
@@ -337,7 +337,7 @@ func (h *Server) GetInboxAndUnboxLocal(ctx context.Context, arg chat1.GetInboxAn
 	res = chat1.GetInboxAndUnboxLocalRes{
 		Conversations:    ib.Convs,
 		Pagination:       ib.Pagination,
-		Offline:          h.G().InboxSource.IsOffline(),
+		Offline:          h.G().InboxSource.IsOffline(ctx),
 		RateLimits:       utils.AggRateLimitsP([]*chat1.RateLimit{rl}),
 		IdentifyFailures: identBreaks,
 	}
@@ -364,7 +364,7 @@ func (h *Server) GetCachedThread(ctx context.Context, arg chat1.GetCachedThreadA
 
 	return chat1.GetThreadLocalRes{
 		Thread:           thread,
-		Offline:          h.G().ConvSource.IsOffline(),
+		Offline:          h.G().ConvSource.IsOffline(ctx),
 		IdentifyFailures: identBreaks,
 	}, nil
 }
@@ -389,7 +389,7 @@ func (h *Server) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg
 
 	return chat1.GetThreadLocalRes{
 		Thread:           thread,
-		Offline:          h.G().ConvSource.IsOffline(),
+		Offline:          h.G().ConvSource.IsOffline(ctx),
 		RateLimits:       utils.AggRateLimitsP(rl),
 		IdentifyFailures: identBreaks,
 	}, nil
@@ -510,7 +510,7 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 	// Clean up context
 	cancel()
 
-	res.Offline = h.G().ConvSource.IsOffline()
+	res.Offline = h.G().ConvSource.IsOffline(ctx)
 	return res, fullErr
 }
 
@@ -747,7 +747,7 @@ func (h *Server) GetMessagesLocal(ctx context.Context, arg chat1.GetMessagesLoca
 
 	return chat1.GetMessagesLocalRes{
 		Messages:         messages,
-		Offline:          h.G().ConvSource.IsOffline(),
+		Offline:          h.G().ConvSource.IsOffline(ctx),
 		RateLimits:       utils.AggRateLimits(rlimits),
 		IdentifyFailures: identBreaks,
 	}, nil

--- a/go/chat/sourceofflinable.go
+++ b/go/chat/sourceofflinable.go
@@ -66,7 +66,7 @@ func (s *sourceOfflinable) IsOffline(ctx context.Context) bool {
 			return s.offline
 		case <-time.After(4 * time.Second):
 			s.Debug(ctx, "IsOffline: timed out")
-			return false
+			return true
 		}
 	}
 

--- a/go/chat/sourceofflinable.go
+++ b/go/chat/sourceofflinable.go
@@ -1,0 +1,85 @@
+package chat
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/chat/utils"
+	"golang.org/x/net/context"
+)
+
+// sourceOfflinable implements the chat/types.Offlinable interface.
+// It is meant to be embedded in inbox and conversation sources.
+// It's main purpose is that IsOffline() will wait for 4s to see if any
+// in progress connections succeed before returning.
+type sourceOfflinable struct {
+	utils.DebugLabeler
+	offline   bool
+	connected chan bool
+	sync.Mutex
+}
+
+var _ types.Offlinable = (*sourceOfflinable)(nil)
+
+func newSourceOfflinable(labeler utils.DebugLabeler) *sourceOfflinable {
+	return &sourceOfflinable{
+		DebugLabeler: labeler,
+		connected:    makeConnectedChan(),
+	}
+}
+
+func (s *sourceOfflinable) Connected(ctx context.Context) {
+	s.Debug(ctx, "connected")
+	s.Lock()
+	defer s.Unlock()
+
+	s.Debug(ctx, "connected: offline to false")
+	s.offline = false
+	s.connected <- true
+}
+
+func (s *sourceOfflinable) Disconnected(ctx context.Context) {
+	s.Debug(ctx, "disconnected")
+	s.Lock()
+	defer s.Unlock()
+
+	s.Debug(ctx, "disconnected: offline to true")
+
+	s.offline = true
+	close(s.connected)
+	s.connected = makeConnectedChan()
+}
+
+func (s *sourceOfflinable) IsOffline(ctx context.Context) bool {
+	s.Lock()
+	offline := s.offline
+	connected := s.connected
+	s.Unlock()
+
+	if offline {
+		select {
+		case <-connected:
+			s.Lock()
+			defer s.Unlock()
+			s.Debug(ctx, "IsOffline: waited and got %v", s.offline)
+			return s.offline
+		case <-time.After(4 * time.Second):
+			s.Debug(ctx, "IsOffline: timed out")
+			return false
+		}
+	}
+
+	return offline
+}
+
+func makeConnectedChan() chan bool {
+	// connectedBuffer is the sourceOfflinable connected channel buffer size.
+	// It is 10 just to be extra-safe that sends to the channel in
+	// Connected will not block in the case of more than one Connect call
+	// happening during the lifetime of the connected channel (which shouldn't
+	// happen).
+	const connectedBuffer = 10
+	return make(chan bool, 10)
+
+}

--- a/go/chat/sourceofflinable.go
+++ b/go/chat/sourceofflinable.go
@@ -73,13 +73,11 @@ func (s *sourceOfflinable) IsOffline(ctx context.Context) bool {
 	return offline
 }
 
+// makeConnectedChan creates a buffered channel for Connected to signal that
+// a connection happened.  The buffer size is 10 just to be extra-safe that
+// a send on the channel won't block during its lifetime (a buffer size of
+// 1 should be all that is required).
 func makeConnectedChan() chan bool {
-	// connectedBuffer is the sourceOfflinable connected channel buffer size.
-	// It is 10 just to be extra-safe that sends to the channel in
-	// Connected will not block in the case of more than one Connect call
-	// happening during the lifetime of the connected channel (which shouldn't
-	// happen).
-	const connectedBuffer = 10
 	return make(chan bool, 10)
 
 }

--- a/go/chat/sourceofflinable.go
+++ b/go/chat/sourceofflinable.go
@@ -30,7 +30,7 @@ func newSourceOfflinable(labeler utils.DebugLabeler) *sourceOfflinable {
 }
 
 func (s *sourceOfflinable) Connected(ctx context.Context) {
-	s.Debug(ctx, "connected")
+	defer s.Trace(ctx, func() error { return nil }, "Connected")()
 	s.Lock()
 	defer s.Unlock()
 
@@ -40,7 +40,7 @@ func (s *sourceOfflinable) Connected(ctx context.Context) {
 }
 
 func (s *sourceOfflinable) Disconnected(ctx context.Context) {
-	s.Debug(ctx, "disconnected")
+	defer s.Trace(ctx, func() error { return nil }, "Disconnected")()
 	s.Lock()
 	defer s.Unlock()
 
@@ -65,8 +65,10 @@ func (s *sourceOfflinable) IsOffline(ctx context.Context) bool {
 			s.Debug(ctx, "IsOffline: waited and got %v", s.offline)
 			return s.offline
 		case <-time.After(4 * time.Second):
+			s.Lock()
+			defer s.Unlock()
 			s.Debug(ctx, "IsOffline: timed out")
-			return true
+			return s.offline
 		}
 	}
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Offlinable interface {
-	IsOffline() bool
+	IsOffline(ctx context.Context) bool
 	Connected(ctx context.Context)
 	Disconnected(ctx context.Context)
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -34,6 +34,7 @@ import (
 
 const GregorRequestTimeout time.Duration = 30 * time.Second
 const GregorConnectionRetryInterval time.Duration = 2 * time.Second
+const GregorGetClientTimeout time.Duration = 4 * time.Second
 
 type IdentifyUIHandler struct {
 	libkb.Contextified
@@ -256,8 +257,8 @@ func (g *gregorHandler) GetClient() chat1.RemoteInterface {
 			}
 			g.chatLog.Debug(context.Background(), "GetClient: successfully waited for connection")
 			return chat1.RemoteClient{Cli: chat.NewRemoteClient(g.G(), g.cli)}
-		case <-time.After(2 * time.Second):
-			g.chatLog.Debug(context.Background(), "GetClient: shutdown, using OfflineClient for chat1.RemoteClient (waited 2s for connectHappened)")
+		case <-time.After(GregorGetClientTimeout):
+			g.chatLog.Debug(context.Background(), "GetClient: shutdown, using OfflineClient for chat1.RemoteClient (waited %s for connectHappened)", GregorGetClientTimeout)
 			return chat1.RemoteClient{Cli: chat.OfflineClient{}}
 		}
 	}

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -13,7 +13,7 @@ const nativeBridge = NativeModules.KeybaseEngine || {test: 'fallback'}
 // console.disableYellowBox = true
 
 // Set this to true if you want to turn off most console logging so you can profile easier
-const PERF = true
+const PERF = false
 
 let config: {[key: string]: any} = {
   actionStatFrequency: 0,

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -13,7 +13,7 @@ const nativeBridge = NativeModules.KeybaseEngine || {test: 'fallback'}
 // console.disableYellowBox = true
 
 // Set this to true if you want to turn off most console logging so you can profile easier
-const PERF = false
+const PERF = true
 
 let config: {[key: string]: any} = {
   actionStatFrequency: 0,


### PR DESCRIPTION
This patch introduces a new type, sourceOfflinable that implements the Offlinable interface.  The inbox and conversation sources embed it.  

It changes IsOffline to wait for 4s for a connection before returning true (offline).

The effect of this is that when the mobile app is foregrounded and the user interacts with chat during the period where the gregor connection is still being established, the user will not see a grey bar that says the app is offline unless the connection takes over 4s to finish.

The 4s value can be tweaked if needed.