### PR TITLE
use JSON encoding for payloads from GetThreadNonblock CORE-5855

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -454,7 +454,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				}
 				desktopNotification := g.shouldDisplayDesktopNotification(ctx, uid, conv, decmsg)
 				activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-					Message: decmsg,
+					Message: utils.PresentMessageUnboxed(decmsg),
 					ConvID:  nm.ConvID,
 					Conv:    g.presentUIItem(conv),
 					DisplayDesktopNotification: desktopNotification,

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -91,9 +91,10 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 	typ, err := activity.ActivityType()
 	if err == nil {
 		if typ == chat1.ChatActivityType_INCOMING_MESSAGE && activity.IncomingMessage().Message.IsValid() {
-			header := activity.IncomingMessage().Message.Valid().ClientHeader
-			if header.OutboxID != nil {
-				n.obids = append(n.obids, *activity.IncomingMessage().Message.Valid().ClientHeader.OutboxID)
+			strOutboxID := activity.IncomingMessage().Message.Valid().OutboxID
+			if strOutboxID != nil {
+				outboxID, _ := hex.DecodeString(*strOutboxID)
+				n.obids = append(n.obids, chat1.OutboxID(outboxID))
 				select {
 				case n.incoming <- len(n.obids):
 				case <-time.After(5 * time.Second):

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -479,7 +479,6 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 			return
 		default:
 		}
-		start := time.Now()
 		var pthread *string
 		if resThread != nil {
 			h.Debug(ctx, "GetThreadNonblock: sending cached response: %d messages", len(resThread.Messages))
@@ -499,7 +498,6 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 			SessionID: arg.SessionID,
 			Thread:    pthread,
 		})
-		h.Debug(ctx, "GetThreadNonblock: cached thread sent: %v", time.Now().Sub(start))
 	}()
 
 	wg.Add(1)
@@ -518,7 +516,6 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 		res.RateLimits = utils.AggRateLimitsP(rl)
 
 		// Acquire lock and send up actual response
-		start := time.Now()
 		h.Debug(ctx, "GetThreadNonblock: sending full response: %d messages", len(remoteThread.Messages))
 		uilock.Lock()
 		defer uilock.Unlock()
@@ -532,7 +529,6 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 			SessionID: arg.SessionID,
 			Thread:    string(jsonUIRes),
 		})
-		h.Debug(ctx, "GetThreadNonblock: full thread sent: %v", time.Now().Sub(start))
 
 		// This means we transmitted with success, so cancel local thread
 		cancel()

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1483,7 +1483,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			unboxed = info.Message
 			require.True(t, unboxed.IsValid(), "invalid message")
 			require.NotNil(t, unboxed.Valid().OutboxID, "no outbox ID")
-			require.Equal(t, res.OutboxID, *unboxed.Valid().OutboxID, "mismatch outbox ID")
+			require.Equal(t, res.OutboxID.String(), *unboxed.Valid().OutboxID, "mismatch outbox ID")
 			require.Equal(t, chat1.MessageType_TEXT, unboxed.GetMessageType(), "invalid type")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
@@ -1507,8 +1507,8 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			unboxed = info.Message
 			require.True(t, unboxed.IsValid(), "invalid message")
 			require.NotNil(t, unboxed.Valid().OutboxID, "no outbox ID")
-			require.Equal(t, genOutboxID, *unboxed.Valid().OutboxID, "mismatch outbox ID")
-			require.Equal(t, res.OutboxID, *unboxed.Valid().OutboxID, "mismatch outbox ID")
+			require.Equal(t, genOutboxID.String(), *unboxed.Valid().OutboxID, "mismatch outbox ID")
+			require.Equal(t, res.OutboxID.String(), *unboxed.Valid().OutboxID, "mismatch outbox ID")
 			require.Equal(t, chat1.MessageType_TEXT, unboxed.GetMessageType(), "invalid type")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
@@ -1530,7 +1530,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			unboxed = info.Message
 			require.True(t, unboxed.IsValid(), "invalid message")
 			require.NotNil(t, unboxed.Valid().OutboxID, "no outbox ID")
-			require.Equal(t, res.OutboxID, *unboxed.Valid().OutboxID, "mismatch outbox ID")
+			require.Equal(t, res.OutboxID.String(), *unboxed.Valid().OutboxID, "mismatch outbox ID")
 			require.Equal(t, chat1.MessageType_EDIT, unboxed.GetMessageType(), "invalid type")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
@@ -1551,7 +1551,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			unboxed = info.Message
 			require.True(t, unboxed.IsValid(), "invalid message")
 			require.NotNil(t, unboxed.Valid().OutboxID, "no outbox ID")
-			require.Equal(t, res.OutboxID, *unboxed.Valid().OutboxID, "mismatch outbox ID")
+			require.Equal(t, res.OutboxID.String(), *unboxed.Valid().OutboxID, "mismatch outbox ID")
 			require.Equal(t, chat1.MessageType_DELETE, unboxed.GetMessageType(), "invalid type")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1449,7 +1449,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		tc := ctc.as(t, users[0])
 		res, err := ctc.as(t, users[0]).chatLocalHandler().PostTextNonblock(tc.startCtx, arg)
 		require.NoError(t, err)
-		var unboxed chat1.MessageUnboxed
+		var unboxed chat1.UIMessage
 		switch mt {
 		case chat1.ConversationMembersType_KBFS:
 			// pass
@@ -1471,7 +1471,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 					require.Equal(t, chat1.MessageType_JOIN, unboxed.GetMessageType(), "unexpected type")
 				}
 				require.Equal(t, chat1.MessageType_JOIN, unboxed.GetMessageType(), "unexpected type")
-				require.Nil(t, unboxed.Valid().ClientHeader.OutboxID, "surprise outbox ID on JOIN")
+				require.Nil(t, unboxed.Valid().OutboxID, "surprise outbox ID on JOIN")
 			case <-time.After(20 * time.Second):
 				require.Fail(t, "no event received")
 			}
@@ -1482,8 +1482,8 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		case info := <-listener.newMessage:
 			unboxed = info.Message
 			require.True(t, unboxed.IsValid(), "invalid message")
-			require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
-			require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
+			require.NotNil(t, unboxed.Valid().OutboxID, "no outbox ID")
+			require.Equal(t, res.OutboxID, *unboxed.Valid().OutboxID, "mismatch outbox ID")
 			require.Equal(t, chat1.MessageType_TEXT, unboxed.GetMessageType(), "invalid type")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
@@ -1506,9 +1506,9 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		case info := <-listener.newMessage:
 			unboxed = info.Message
 			require.True(t, unboxed.IsValid(), "invalid message")
-			require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
-			require.Equal(t, genOutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
-			require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
+			require.NotNil(t, unboxed.Valid().OutboxID, "no outbox ID")
+			require.Equal(t, genOutboxID, *unboxed.Valid().OutboxID, "mismatch outbox ID")
+			require.Equal(t, res.OutboxID, *unboxed.Valid().OutboxID, "mismatch outbox ID")
 			require.Equal(t, chat1.MessageType_TEXT, unboxed.GetMessageType(), "invalid type")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
@@ -1529,8 +1529,8 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		case info := <-listener.newMessage:
 			unboxed = info.Message
 			require.True(t, unboxed.IsValid(), "invalid message")
-			require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
-			require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
+			require.NotNil(t, unboxed.Valid().OutboxID, "no outbox ID")
+			require.Equal(t, res.OutboxID, *unboxed.Valid().OutboxID, "mismatch outbox ID")
 			require.Equal(t, chat1.MessageType_EDIT, unboxed.GetMessageType(), "invalid type")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
@@ -1550,8 +1550,8 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		case info := <-listener.newMessage:
 			unboxed = info.Message
 			require.True(t, unboxed.IsValid(), "invalid message")
-			require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
-			require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
+			require.NotNil(t, unboxed.Valid().OutboxID, "no outbox ID")
+			require.Equal(t, res.OutboxID, *unboxed.Valid().OutboxID, "mismatch outbox ID")
 			require.Equal(t, chat1.MessageType_DELETE, unboxed.GetMessageType(), "invalid type")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
@@ -1665,7 +1665,7 @@ func TestChatSrvFindConversations(t *testing.T) {
 	})
 }
 
-func receiveThreadResult(t *testing.T, cb chan kbtest.NonblockThreadResult) (res *chat1.ThreadView) {
+func receiveThreadResult(t *testing.T, cb chan kbtest.NonblockThreadResult) (res *chat1.UIMessages) {
 	var tres kbtest.NonblockThreadResult
 	select {
 	case tres = <-cb:

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -611,14 +611,15 @@ func PresentMessageUnboxed(rawMsg chat1.MessageUnboxed) (res chat1.UIMessage) {
 			strOutboxID = &so
 		}
 		res = chat1.NewUIMessageWithValid(chat1.UIMessageValid{
-			MessageID:        rawMsg.GetMessageID(),
-			MessageType:      rawMsg.GetMessageType(),
-			Ctime:            rawMsg.Valid().ServerHeader.Ctime,
-			OutboxID:         strOutboxID,
-			MessageBody:      rawMsg.Valid().MessageBody,
-			SenderUsername:   rawMsg.Valid().SenderUsername,
-			SenderDeviceName: rawMsg.Valid().SenderDeviceName,
-			SenderDeviceType: rawMsg.Valid().SenderDeviceType,
+			MessageID:             rawMsg.GetMessageID(),
+			Ctime:                 rawMsg.Valid().ServerHeader.Ctime,
+			OutboxID:              strOutboxID,
+			MessageBody:           rawMsg.Valid().MessageBody,
+			SenderUsername:        rawMsg.Valid().SenderUsername,
+			SenderDeviceName:      rawMsg.Valid().SenderDeviceName,
+			SenderDeviceType:      rawMsg.Valid().SenderDeviceType,
+			SenderDeviceRevokedAt: rawMsg.Valid().SenderDeviceRevokedAt,
+			Superseded:            rawMsg.Valid().ServerHeader.SupersededBy != 0,
 		})
 	case chat1.MessageUnboxedState_OUTBOX:
 		var body string

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -450,6 +450,19 @@ func (m *ChatRemoteMock) promoteWriter(ctx context.Context, sender gregor1.UID, 
 	return res
 }
 
+func (m *ChatRemoteMock) createBogusBody(typ chat1.MessageType) chat1.MessageBody {
+	return chat1.MessageBody{
+		MessageType__:        typ,
+		Text__:               &chat1.MessageText{},
+		Edit__:               &chat1.MessageEdit{},
+		Attachment__:         &chat1.MessageAttachment{},
+		Delete__:             &chat1.MessageDelete{},
+		Attachmentuploaded__: &chat1.MessageAttachmentUploaded{},
+		Join__:               &chat1.MessageJoin{},
+		Leave__:              &chat1.MessageLeave{},
+	}
+}
+
 func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg) (res chat1.PostRemoteRes, err error) {
 	uid := arg.MessageBoxed.ClientHeader.Sender
 	conv := m.world.GetConversationByID(arg.ConversationID)
@@ -475,6 +488,7 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 			Message: utils.PresentMessageUnboxed(chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
 				ClientHeader: m.headerToVerifiedForTesting(inserted.ClientHeader),
 				ServerHeader: *inserted.ServerHeader,
+				MessageBody:  m.createBogusBody(inserted.GetMessageType()),
 			})),
 		})
 		m.world.TcsByID[uid.String()].G.NotifyRouter.HandleNewChatActivity(context.Background(),

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -471,10 +472,10 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 	// hit notify router with new message
 	if m.world.TcsByID[uid.String()].G.NotifyRouter != nil {
 		activity := chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-			Message: chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
+			Message: utils.PresentMessageUnboxed(chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
 				ClientHeader: m.headerToVerifiedForTesting(inserted.ClientHeader),
 				ServerHeader: *inserted.ServerHeader,
-			}),
+			})),
 		})
 		m.world.TcsByID[uid.String()].G.NotifyRouter.HandleNewChatActivity(context.Background(),
 			keybase1.UID(uid.String()), &activity)
@@ -728,7 +729,7 @@ type NonblockInboxResult struct {
 }
 
 type NonblockThreadResult struct {
-	Thread *chat1.ThreadView
+	Thread *chat1.UIMessages
 	Full   bool
 }
 
@@ -807,16 +808,31 @@ func (c *ChatUI) ChatInboxUnverified(ctx context.Context, arg chat1.ChatInboxUnv
 }
 
 func (c *ChatUI) ChatThreadCached(ctx context.Context, arg chat1.ChatThreadCachedArg) error {
-	c.threadCb <- NonblockThreadResult{
-		Thread: arg.Thread,
-		Full:   false,
+	var thread chat1.UIMessages
+	if arg.Thread == nil {
+		c.threadCb <- NonblockThreadResult{
+			Thread: nil,
+			Full:   false,
+		}
+	} else {
+		if err := json.Unmarshal([]byte(*arg.Thread), &thread); err != nil {
+			return err
+		}
+		c.threadCb <- NonblockThreadResult{
+			Thread: &thread,
+			Full:   false,
+		}
 	}
 	return nil
 }
 
 func (c *ChatUI) ChatThreadFull(ctx context.Context, arg chat1.ChatThreadFullArg) error {
+	var thread chat1.UIMessages
+	if err := json.Unmarshal([]byte(arg.Thread), &thread); err != nil {
+		return err
+	}
 	c.threadCb <- NonblockThreadResult{
-		Thread: &arg.Thread,
+		Thread: &thread,
 		Full:   true,
 	}
 	return nil

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -146,21 +146,21 @@ func (o InboxUIItems) DeepCopy() InboxUIItems {
 }
 
 type UIMessageValid struct {
-	MessageID        MessageID    `codec:"messageID" json:"messageID"`
-	MessageType      MessageType  `codec:"messageType" json:"messageType"`
-	Ctime            gregor1.Time `codec:"ctime" json:"ctime"`
-	OutboxID         *string      `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
-	MessageBody      MessageBody  `codec:"messageBody" json:"messageBody"`
-	SenderUsername   string       `codec:"senderUsername" json:"senderUsername"`
-	SenderDeviceName string       `codec:"senderDeviceName" json:"senderDeviceName"`
-	SenderDeviceType string       `codec:"senderDeviceType" json:"senderDeviceType"`
+	MessageID             MessageID     `codec:"messageID" json:"messageID"`
+	Ctime                 gregor1.Time  `codec:"ctime" json:"ctime"`
+	OutboxID              *string       `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	MessageBody           MessageBody   `codec:"messageBody" json:"messageBody"`
+	SenderUsername        string        `codec:"senderUsername" json:"senderUsername"`
+	SenderDeviceName      string        `codec:"senderDeviceName" json:"senderDeviceName"`
+	SenderDeviceType      string        `codec:"senderDeviceType" json:"senderDeviceType"`
+	Superseded            bool          `codec:"superseded" json:"superseded"`
+	SenderDeviceRevokedAt *gregor1.Time `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
 }
 
 func (o UIMessageValid) DeepCopy() UIMessageValid {
 	return UIMessageValid{
-		MessageID:   o.MessageID.DeepCopy(),
-		MessageType: o.MessageType.DeepCopy(),
-		Ctime:       o.Ctime.DeepCopy(),
+		MessageID: o.MessageID.DeepCopy(),
+		Ctime:     o.Ctime.DeepCopy(),
 		OutboxID: (func(x *string) *string {
 			if x == nil {
 				return nil
@@ -172,6 +172,14 @@ func (o UIMessageValid) DeepCopy() UIMessageValid {
 		SenderUsername:   o.SenderUsername,
 		SenderDeviceName: o.SenderDeviceName,
 		SenderDeviceType: o.SenderDeviceType,
+		Superseded:       o.Superseded,
+		SenderDeviceRevokedAt: (func(x *gregor1.Time) *gregor1.Time {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.SenderDeviceRevokedAt),
 	}
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -4,6 +4,7 @@
 package chat1
 
 import (
+	"errors"
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
@@ -141,6 +142,225 @@ func (o InboxUIItems) DeepCopy() InboxUIItems {
 			return &tmp
 		})(o.Pagination),
 		Offline: o.Offline,
+	}
+}
+
+type UIMessageValid struct {
+	MessageID        MessageID   `codec:"messageID" json:"messageID"`
+	OutboxID         *OutboxID   `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	MessageBody      MessageBody `codec:"messageBody" json:"messageBody"`
+	SenderUsername   string      `codec:"senderUsername" json:"senderUsername"`
+	SenderDeviceName string      `codec:"senderDeviceName" json:"senderDeviceName"`
+	SenderDeviceType string      `codec:"senderDeviceType" json:"senderDeviceType"`
+}
+
+func (o UIMessageValid) DeepCopy() UIMessageValid {
+	return UIMessageValid{
+		MessageID: o.MessageID.DeepCopy(),
+		OutboxID: (func(x *OutboxID) *OutboxID {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.OutboxID),
+		MessageBody:      o.MessageBody.DeepCopy(),
+		SenderUsername:   o.SenderUsername,
+		SenderDeviceName: o.SenderDeviceName,
+		SenderDeviceType: o.SenderDeviceType,
+	}
+}
+
+type MessageUnboxedState int
+
+const (
+	MessageUnboxedState_VALID       MessageUnboxedState = 1
+	MessageUnboxedState_ERROR       MessageUnboxedState = 2
+	MessageUnboxedState_OUTBOX      MessageUnboxedState = 3
+	MessageUnboxedState_PLACEHOLDER MessageUnboxedState = 4
+)
+
+func (o MessageUnboxedState) DeepCopy() MessageUnboxedState { return o }
+
+var MessageUnboxedStateMap = map[string]MessageUnboxedState{
+	"VALID":       1,
+	"ERROR":       2,
+	"OUTBOX":      3,
+	"PLACEHOLDER": 4,
+}
+
+var MessageUnboxedStateRevMap = map[MessageUnboxedState]string{
+	1: "VALID",
+	2: "ERROR",
+	3: "OUTBOX",
+	4: "PLACEHOLDER",
+}
+
+func (e MessageUnboxedState) String() string {
+	if v, ok := MessageUnboxedStateRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type UIMessage struct {
+	State__       MessageUnboxedState        `codec:"state" json:"state"`
+	Valid__       *UIMessageValid            `codec:"valid,omitempty" json:"valid,omitempty"`
+	Error__       *MessageUnboxedError       `codec:"error,omitempty" json:"error,omitempty"`
+	Outbox__      *OutboxRecord              `codec:"outbox,omitempty" json:"outbox,omitempty"`
+	Placeholder__ *MessageUnboxedPlaceholder `codec:"placeholder,omitempty" json:"placeholder,omitempty"`
+}
+
+func (o *UIMessage) State() (ret MessageUnboxedState, err error) {
+	switch o.State__ {
+	case MessageUnboxedState_VALID:
+		if o.Valid__ == nil {
+			err = errors.New("unexpected nil value for Valid__")
+			return ret, err
+		}
+	case MessageUnboxedState_ERROR:
+		if o.Error__ == nil {
+			err = errors.New("unexpected nil value for Error__")
+			return ret, err
+		}
+	case MessageUnboxedState_OUTBOX:
+		if o.Outbox__ == nil {
+			err = errors.New("unexpected nil value for Outbox__")
+			return ret, err
+		}
+	case MessageUnboxedState_PLACEHOLDER:
+		if o.Placeholder__ == nil {
+			err = errors.New("unexpected nil value for Placeholder__")
+			return ret, err
+		}
+	}
+	return o.State__, nil
+}
+
+func (o UIMessage) Valid() (res UIMessageValid) {
+	if o.State__ != MessageUnboxedState_VALID {
+		panic("wrong case accessed")
+	}
+	if o.Valid__ == nil {
+		return
+	}
+	return *o.Valid__
+}
+
+func (o UIMessage) Error() (res MessageUnboxedError) {
+	if o.State__ != MessageUnboxedState_ERROR {
+		panic("wrong case accessed")
+	}
+	if o.Error__ == nil {
+		return
+	}
+	return *o.Error__
+}
+
+func (o UIMessage) Outbox() (res OutboxRecord) {
+	if o.State__ != MessageUnboxedState_OUTBOX {
+		panic("wrong case accessed")
+	}
+	if o.Outbox__ == nil {
+		return
+	}
+	return *o.Outbox__
+}
+
+func (o UIMessage) Placeholder() (res MessageUnboxedPlaceholder) {
+	if o.State__ != MessageUnboxedState_PLACEHOLDER {
+		panic("wrong case accessed")
+	}
+	if o.Placeholder__ == nil {
+		return
+	}
+	return *o.Placeholder__
+}
+
+func NewUIMessageWithValid(v UIMessageValid) UIMessage {
+	return UIMessage{
+		State__: MessageUnboxedState_VALID,
+		Valid__: &v,
+	}
+}
+
+func NewUIMessageWithError(v MessageUnboxedError) UIMessage {
+	return UIMessage{
+		State__: MessageUnboxedState_ERROR,
+		Error__: &v,
+	}
+}
+
+func NewUIMessageWithOutbox(v OutboxRecord) UIMessage {
+	return UIMessage{
+		State__:  MessageUnboxedState_OUTBOX,
+		Outbox__: &v,
+	}
+}
+
+func NewUIMessageWithPlaceholder(v MessageUnboxedPlaceholder) UIMessage {
+	return UIMessage{
+		State__:       MessageUnboxedState_PLACEHOLDER,
+		Placeholder__: &v,
+	}
+}
+
+func (o UIMessage) DeepCopy() UIMessage {
+	return UIMessage{
+		State__: o.State__.DeepCopy(),
+		Valid__: (func(x *UIMessageValid) *UIMessageValid {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Valid__),
+		Error__: (func(x *MessageUnboxedError) *MessageUnboxedError {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Error__),
+		Outbox__: (func(x *OutboxRecord) *OutboxRecord {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Outbox__),
+		Placeholder__: (func(x *MessageUnboxedPlaceholder) *MessageUnboxedPlaceholder {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Placeholder__),
+	}
+}
+
+type UIMessages struct {
+	Messages   []UIMessage `codec:"messages" json:"messages"`
+	Pagination *Pagination `codec:"pagination,omitempty" json:"pagination,omitempty"`
+}
+
+func (o UIMessages) DeepCopy() UIMessages {
+	return UIMessages{
+		Messages: (func(x []UIMessage) []UIMessage {
+			var ret []UIMessage
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Messages),
+		Pagination: (func(x *Pagination) *Pagination {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Pagination),
 	}
 }
 
@@ -290,13 +510,13 @@ func (o ChatInboxFailedArg) DeepCopy() ChatInboxFailedArg {
 
 type ChatThreadCachedArg struct {
 	SessionID int         `codec:"sessionID" json:"sessionID"`
-	Thread    *ThreadView `codec:"thread,omitempty" json:"thread,omitempty"`
+	Thread    *UIMessages `codec:"thread,omitempty" json:"thread,omitempty"`
 }
 
 func (o ChatThreadCachedArg) DeepCopy() ChatThreadCachedArg {
 	return ChatThreadCachedArg{
 		SessionID: o.SessionID,
-		Thread: (func(x *ThreadView) *ThreadView {
+		Thread: (func(x *UIMessages) *UIMessages {
 			if x == nil {
 				return nil
 			}
@@ -308,7 +528,7 @@ func (o ChatThreadCachedArg) DeepCopy() ChatThreadCachedArg {
 
 type ChatThreadFullArg struct {
 	SessionID int        `codec:"sessionID" json:"sessionID"`
-	Thread    ThreadView `codec:"thread" json:"thread"`
+	Thread    UIMessages `codec:"thread" json:"thread"`
 }
 
 func (o ChatThreadFullArg) DeepCopy() ChatThreadFullArg {

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -147,8 +147,9 @@ func (o InboxUIItems) DeepCopy() InboxUIItems {
 
 type UIMessageValid struct {
 	MessageID        MessageID    `codec:"messageID" json:"messageID"`
+	MessageType      MessageType  `codec:"messageType" json:"messageType"`
 	Ctime            gregor1.Time `codec:"ctime" json:"ctime"`
-	OutboxID         *OutboxID    `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	OutboxID         *string      `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	MessageBody      MessageBody  `codec:"messageBody" json:"messageBody"`
 	SenderUsername   string       `codec:"senderUsername" json:"senderUsername"`
 	SenderDeviceName string       `codec:"senderDeviceName" json:"senderDeviceName"`
@@ -157,19 +158,38 @@ type UIMessageValid struct {
 
 func (o UIMessageValid) DeepCopy() UIMessageValid {
 	return UIMessageValid{
-		MessageID: o.MessageID.DeepCopy(),
-		Ctime:     o.Ctime.DeepCopy(),
-		OutboxID: (func(x *OutboxID) *OutboxID {
+		MessageID:   o.MessageID.DeepCopy(),
+		MessageType: o.MessageType.DeepCopy(),
+		Ctime:       o.Ctime.DeepCopy(),
+		OutboxID: (func(x *string) *string {
 			if x == nil {
 				return nil
 			}
-			tmp := (*x).DeepCopy()
+			tmp := (*x)
 			return &tmp
 		})(o.OutboxID),
 		MessageBody:      o.MessageBody.DeepCopy(),
 		SenderUsername:   o.SenderUsername,
 		SenderDeviceName: o.SenderDeviceName,
 		SenderDeviceType: o.SenderDeviceType,
+	}
+}
+
+type UIMessageOutbox struct {
+	State       OutboxState  `codec:"state" json:"state"`
+	OutboxID    string       `codec:"outboxID" json:"outboxID"`
+	MessageType MessageType  `codec:"messageType" json:"messageType"`
+	Body        string       `codec:"body" json:"body"`
+	Ctime       gregor1.Time `codec:"ctime" json:"ctime"`
+}
+
+func (o UIMessageOutbox) DeepCopy() UIMessageOutbox {
+	return UIMessageOutbox{
+		State:       o.State.DeepCopy(),
+		OutboxID:    o.OutboxID,
+		MessageType: o.MessageType.DeepCopy(),
+		Body:        o.Body,
+		Ctime:       o.Ctime.DeepCopy(),
 	}
 }
 
@@ -209,7 +229,7 @@ type UIMessage struct {
 	State__       MessageUnboxedState        `codec:"state" json:"state"`
 	Valid__       *UIMessageValid            `codec:"valid,omitempty" json:"valid,omitempty"`
 	Error__       *MessageUnboxedError       `codec:"error,omitempty" json:"error,omitempty"`
-	Outbox__      *OutboxRecord              `codec:"outbox,omitempty" json:"outbox,omitempty"`
+	Outbox__      *UIMessageOutbox           `codec:"outbox,omitempty" json:"outbox,omitempty"`
 	Placeholder__ *MessageUnboxedPlaceholder `codec:"placeholder,omitempty" json:"placeholder,omitempty"`
 }
 
@@ -259,7 +279,7 @@ func (o UIMessage) Error() (res MessageUnboxedError) {
 	return *o.Error__
 }
 
-func (o UIMessage) Outbox() (res OutboxRecord) {
+func (o UIMessage) Outbox() (res UIMessageOutbox) {
 	if o.State__ != MessageUnboxedState_OUTBOX {
 		panic("wrong case accessed")
 	}
@@ -293,7 +313,7 @@ func NewUIMessageWithError(v MessageUnboxedError) UIMessage {
 	}
 }
 
-func NewUIMessageWithOutbox(v OutboxRecord) UIMessage {
+func NewUIMessageWithOutbox(v UIMessageOutbox) UIMessage {
 	return UIMessage{
 		State__:  MessageUnboxedState_OUTBOX,
 		Outbox__: &v,
@@ -324,7 +344,7 @@ func (o UIMessage) DeepCopy() UIMessage {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Error__),
-		Outbox__: (func(x *OutboxRecord) *OutboxRecord {
+		Outbox__: (func(x *UIMessageOutbox) *UIMessageOutbox {
 			if x == nil {
 				return nil
 			}

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -539,32 +539,32 @@ func (o ChatInboxFailedArg) DeepCopy() ChatInboxFailedArg {
 }
 
 type ChatThreadCachedArg struct {
-	SessionID int         `codec:"sessionID" json:"sessionID"`
-	Thread    *UIMessages `codec:"thread,omitempty" json:"thread,omitempty"`
+	SessionID int     `codec:"sessionID" json:"sessionID"`
+	Thread    *string `codec:"thread,omitempty" json:"thread,omitempty"`
 }
 
 func (o ChatThreadCachedArg) DeepCopy() ChatThreadCachedArg {
 	return ChatThreadCachedArg{
 		SessionID: o.SessionID,
-		Thread: (func(x *UIMessages) *UIMessages {
+		Thread: (func(x *string) *string {
 			if x == nil {
 				return nil
 			}
-			tmp := (*x).DeepCopy()
+			tmp := (*x)
 			return &tmp
 		})(o.Thread),
 	}
 }
 
 type ChatThreadFullArg struct {
-	SessionID int        `codec:"sessionID" json:"sessionID"`
-	Thread    UIMessages `codec:"thread" json:"thread"`
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Thread    string `codec:"thread" json:"thread"`
 }
 
 func (o ChatThreadFullArg) DeepCopy() ChatThreadFullArg {
 	return ChatThreadFullArg{
 		SessionID: o.SessionID,
-		Thread:    o.Thread.DeepCopy(),
+		Thread:    o.Thread,
 	}
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -146,17 +146,19 @@ func (o InboxUIItems) DeepCopy() InboxUIItems {
 }
 
 type UIMessageValid struct {
-	MessageID        MessageID   `codec:"messageID" json:"messageID"`
-	OutboxID         *OutboxID   `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
-	MessageBody      MessageBody `codec:"messageBody" json:"messageBody"`
-	SenderUsername   string      `codec:"senderUsername" json:"senderUsername"`
-	SenderDeviceName string      `codec:"senderDeviceName" json:"senderDeviceName"`
-	SenderDeviceType string      `codec:"senderDeviceType" json:"senderDeviceType"`
+	MessageID        MessageID    `codec:"messageID" json:"messageID"`
+	Ctime            gregor1.Time `codec:"ctime" json:"ctime"`
+	OutboxID         *OutboxID    `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	MessageBody      MessageBody  `codec:"messageBody" json:"messageBody"`
+	SenderUsername   string       `codec:"senderUsername" json:"senderUsername"`
+	SenderDeviceName string       `codec:"senderDeviceName" json:"senderDeviceName"`
+	SenderDeviceType string       `codec:"senderDeviceType" json:"senderDeviceType"`
 }
 
 func (o UIMessageValid) DeepCopy() UIMessageValid {
 	return UIMessageValid{
 		MessageID: o.MessageID.DeepCopy(),
+		Ctime:     o.Ctime.DeepCopy(),
 		OutboxID: (func(x *OutboxID) *OutboxID {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -184,6 +184,53 @@ func (m MessageUnboxed) IsValid() bool {
 	return false
 }
 
+func (m UIMessage) IsValid() bool {
+	if state, err := m.State(); err == nil {
+		return state == MessageUnboxedState_VALID
+	}
+	return false
+}
+
+func (m UIMessage) GetMessageID() MessageID {
+	if state, err := m.State(); err == nil {
+		if state == MessageUnboxedState_VALID {
+			return m.Valid().MessageID
+		}
+		if state == MessageUnboxedState_ERROR {
+			return m.Error().MessageID
+		}
+		if state == MessageUnboxedState_PLACEHOLDER {
+			return m.Placeholder().MessageID
+		}
+	}
+	return 0
+}
+
+func (m UIMessage) GetMessageType() MessageType {
+	if state, err := m.State(); err == nil {
+		if state == MessageUnboxedState_VALID {
+			body := m.Valid().MessageBody
+			typ, err := body.MessageType()
+			if err != nil {
+				return MessageType_NONE
+			}
+			return typ
+		}
+		if state == MessageUnboxedState_ERROR {
+			return m.Error().MessageType
+		}
+		if state == MessageUnboxedState_OUTBOX {
+			return m.Outbox().MessageType
+		}
+		if state == MessageUnboxedState_PLACEHOLDER {
+			// All we know about a place holder is the ID, so just
+			// call it type NONE
+			return MessageType_NONE
+		}
+	}
+	return MessageType_NONE
+}
+
 func (m MessageBoxed) GetMessageID() MessageID {
 	return m.ServerHeader.MessageID
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1730,38 +1730,6 @@ func (o MessagePlaintext) DeepCopy() MessagePlaintext {
 	}
 }
 
-type MessageUnboxedState int
-
-const (
-	MessageUnboxedState_VALID       MessageUnboxedState = 1
-	MessageUnboxedState_ERROR       MessageUnboxedState = 2
-	MessageUnboxedState_OUTBOX      MessageUnboxedState = 3
-	MessageUnboxedState_PLACEHOLDER MessageUnboxedState = 4
-)
-
-func (o MessageUnboxedState) DeepCopy() MessageUnboxedState { return o }
-
-var MessageUnboxedStateMap = map[string]MessageUnboxedState{
-	"VALID":       1,
-	"ERROR":       2,
-	"OUTBOX":      3,
-	"PLACEHOLDER": 4,
-}
-
-var MessageUnboxedStateRevMap = map[MessageUnboxedState]string{
-	1: "VALID",
-	2: "ERROR",
-	3: "OUTBOX",
-	4: "PLACEHOLDER",
-}
-
-func (e MessageUnboxedState) String() string {
-	if v, ok := MessageUnboxedStateRevMap[e]; ok {
-		return v
-	}
-	return ""
-}
-
 type MessageUnboxedValid struct {
 	ClientHeader          MessageClientHeaderVerified `codec:"clientHeader" json:"clientHeader"`
 	ServerHeader          MessageServerHeader         `codec:"serverHeader" json:"serverHeader"`

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -55,7 +55,7 @@ func (e ChatActivityType) String() string {
 }
 
 type IncomingMessage struct {
-	Message                    MessageUnboxed `codec:"message" json:"message"`
+	Message                    UIMessage      `codec:"message" json:"message"`
 	ConvID                     ConversationID `codec:"convID" json:"convID"`
 	DisplayDesktopNotification bool           `codec:"displayDesktopNotification" json:"displayDesktopNotification"`
 	Conv                       *InboxUIItem   `codec:"conv,omitempty" json:"conv,omitempty"`

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -98,6 +98,6 @@ protocol chatUi {
   void chatInboxConversation(int sessionID, InboxUIItem conv);
   void chatInboxFailed(int sessionID, ConversationID convID, ConversationErrorLocal error);
 
-  void chatThreadCached(int sessionID, union { null, UIMessages } thread) oneway;
-  void chatThreadFull(int sessionID, UIMessages thread) oneway;
+  void chatThreadCached(int sessionID, union { null, string } thread) oneway;
+  void chatThreadFull(int sessionID, string thread) oneway;
 }

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -45,6 +45,7 @@ protocol chatUi {
 
   record UIMessageValid {
     MessageID messageID;
+    gregor1.Time ctime;
     union { null, OutboxID } outboxID;
     MessageBody messageBody;
     string senderUsername;

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -43,6 +43,34 @@ protocol chatUi {
     boolean offline;
   }
 
+  record UIMessageValid {
+    MessageID messageID;
+    union { null, OutboxID } outboxID;
+    MessageBody messageBody;
+    string senderUsername;
+    string senderDeviceName;
+    string senderDeviceType;
+  }
+
+  enum MessageUnboxedState {
+    VALID_1,
+    ERROR_2,
+    OUTBOX_3,
+    PLACEHOLDER_4
+  }
+
+  variant UIMessage switch (MessageUnboxedState state) {
+    case VALID: UIMessageValid;
+    case ERROR: MessageUnboxedError;
+    case OUTBOX: OutboxRecord;
+    case PLACEHOLDER: MessageUnboxedPlaceholder;
+  }
+
+  record UIMessages {
+    array<UIMessage> messages;
+    union { null, Pagination } pagination;
+  }
+
   void chatAttachmentUploadOutboxID(int sessionID, OutboxID outboxID);
   void chatAttachmentUploadStart(int sessionID, AssetMetadata metadata, MessageID placeholderMsgID) oneway;
   void chatAttachmentUploadProgress(int sessionID, long bytesComplete, long bytesTotal) oneway;
@@ -59,6 +87,6 @@ protocol chatUi {
   void chatInboxConversation(int sessionID, InboxUIItem conv);
   void chatInboxFailed(int sessionID, ConversationID convID, ConversationErrorLocal error);
 
-  void chatThreadCached(int sessionID, union { null, ThreadView } thread) oneway;
-  void chatThreadFull(int sessionID, ThreadView thread) oneway;
+  void chatThreadCached(int sessionID, union { null, UIMessages } thread) oneway;
+  void chatThreadFull(int sessionID, UIMessages thread) oneway;
 }

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -45,12 +45,21 @@ protocol chatUi {
 
   record UIMessageValid {
     MessageID messageID;
+    MessageType messageType;
     gregor1.Time ctime;
-    union { null, OutboxID } outboxID;
+    union { null, string } outboxID;
     MessageBody messageBody;
     string senderUsername;
     string senderDeviceName;
     string senderDeviceType;
+  }
+
+  record UIMessageOutbox {
+    OutboxState state;
+    string outboxID;
+    MessageType messageType;
+    string body;
+    gregor1.Time ctime;
   }
 
   enum MessageUnboxedState {
@@ -63,7 +72,7 @@ protocol chatUi {
   variant UIMessage switch (MessageUnboxedState state) {
     case VALID: UIMessageValid;
     case ERROR: MessageUnboxedError;
-    case OUTBOX: OutboxRecord;
+    case OUTBOX: UIMessageOutbox;
     case PLACEHOLDER: MessageUnboxedPlaceholder;
   }
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -45,13 +45,14 @@ protocol chatUi {
 
   record UIMessageValid {
     MessageID messageID;
-    MessageType messageType;
     gregor1.Time ctime;
     union { null, string } outboxID;
     MessageBody messageBody;
     string senderUsername;
     string senderDeviceName;
     string senderDeviceType;
+    boolean superseded;
+    union {null, gregor1.Time} senderDeviceRevokedAt;
   }
 
   record UIMessageOutbox {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -265,13 +265,6 @@ protocol local {
     MessageBody messageBody;
   }
 
-  enum MessageUnboxedState {
-    VALID_1,
-    ERROR_2,
-    OUTBOX_3,
-    PLACEHOLDER_4
-  }
-
   record MessageUnboxedValid {
     MessageClientHeaderVerified clientHeader;
     MessageServerHeader serverHeader;
@@ -323,6 +316,7 @@ protocol local {
     MessageID messageID;
   }
 
+  // If a new case is needed here, make sure to update UIMessage in chat_ui.avdl as well.
   variant MessageUnboxed switch (MessageUnboxedState state) {
     case VALID: MessageUnboxedValid;
     case ERROR: MessageUnboxedError;

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -16,7 +16,7 @@ protocol NotifyChat {
   }
 
   record IncomingMessage {
-    MessageUnboxed message;
+    UIMessage message;
     ConversationID convID;
     boolean displayDesktopNotification;
     union { null, InboxUIItem } conv;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1854,13 +1854,14 @@ export type UIMessageOutbox = {
 
 export type UIMessageValid = {
   messageID: MessageID,
-  messageType: MessageType,
   ctime: gregor1.Time,
   outboxID?: ?string,
   messageBody: MessageBody,
   senderUsername: string,
   senderDeviceName: string,
   senderDeviceType: string,
+  superseded: boolean,
+  senderDeviceRevokedAt?: ?gregor1.Time,
 }
 
 export type UIMessages = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1265,7 +1265,7 @@ export type InboxViewFull = {
 }
 
 export type IncomingMessage = {
-  message: MessageUnboxed,
+  message: UIMessage,
   convID: ConversationID,
   displayDesktopNotification: boolean,
   conv?: ?InboxUIItem,
@@ -1841,13 +1841,22 @@ export type TyperInfo = {
 export type UIMessage =
     { state: 1, valid: ?UIMessageValid }
   | { state: 2, error: ?MessageUnboxedError }
-  | { state: 3, outbox: ?OutboxRecord }
+  | { state: 3, outbox: ?UIMessageOutbox }
   | { state: 4, placeholder: ?MessageUnboxedPlaceholder }
+
+export type UIMessageOutbox = {
+  state: OutboxState,
+  outboxID: string,
+  messageType: MessageType,
+  body: string,
+  ctime: gregor1.Time,
+}
 
 export type UIMessageValid = {
   messageID: MessageID,
+  messageType: MessageType,
   ctime: gregor1.Time,
-  outboxID?: ?OutboxID,
+  outboxID?: ?string,
   messageBody: MessageBody,
   senderUsername: string,
   senderDeviceName: string,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -55,6 +55,13 @@ function _channelMapRpcHelper(channelConfig: ChannelConfig<*>, partialRpcCall: (
 }
 
 
+export const ChatUiMessageUnboxedState = {
+  valid: 1,
+  error: 2,
+  outbox: 3,
+  placeholder: 4,
+}
+
 export const CommonConversationMemberStatus = {
   active: 0,
   removed: 1,
@@ -171,13 +178,6 @@ export const LocalMessageUnboxedErrorType = {
   badversionCritical: 1,
   badversion: 2,
   identify: 3,
-}
-
-export const LocalMessageUnboxedState = {
-  valid: 1,
-  error: 2,
-  outbox: 3,
-  placeholder: 4,
 }
 
 export const LocalOutboxErrorType = {
@@ -1838,6 +1838,26 @@ export type TyperInfo = {
   deviceType: string,
 }
 
+export type UIMessage =
+    { state: 1, valid: ?UIMessageValid }
+  | { state: 2, error: ?MessageUnboxedError }
+  | { state: 3, outbox: ?OutboxRecord }
+  | { state: 4, placeholder: ?MessageUnboxedPlaceholder }
+
+export type UIMessageValid = {
+  messageID: MessageID,
+  outboxID?: ?OutboxID,
+  messageBody: MessageBody,
+  senderUsername: string,
+  senderDeviceName: string,
+  senderDeviceType: string,
+}
+
+export type UIMessages = {
+  messages?: ?Array<UIMessage>,
+  pagination?: ?Pagination,
+}
+
 export type UnreadFirstNumLimit = {
   NumRead: int,
   AtLeast: int,
@@ -1915,11 +1935,11 @@ export type chatUiChatInboxUnverifiedRpcParam = Exact<{
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
-  thread?: ?ThreadView
+  thread?: ?UIMessages
 }>
 
 export type chatUiChatThreadFullRpcParam = Exact<{
-  thread: ThreadView
+  thread: UIMessages
 }>
 
 export type localCancelPostRpcParam = Exact<{
@@ -2428,14 +2448,14 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatThreadCached'?: (
     params: Exact<{
       sessionID: int,
-      thread?: ?ThreadView
+      thread?: ?UIMessages
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatThreadFull'?: (
     params: Exact<{
       sessionID: int,
-      thread: ThreadView
+      thread: UIMessages
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1846,6 +1846,7 @@ export type UIMessage =
 
 export type UIMessageValid = {
   messageID: MessageID,
+  ctime: gregor1.Time,
   outboxID?: ?OutboxID,
   messageBody: MessageBody,
   senderUsername: string,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1946,11 +1946,11 @@ export type chatUiChatInboxUnverifiedRpcParam = Exact<{
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
-  thread?: ?UIMessages
+  thread?: ?string
 }>
 
 export type chatUiChatThreadFullRpcParam = Exact<{
-  thread: UIMessages
+  thread: string
 }>
 
 export type localCancelPostRpcParam = Exact<{
@@ -2459,14 +2459,14 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatThreadCached'?: (
     params: Exact<{
       sessionID: int,
-      thread?: ?UIMessages
+      thread?: ?string
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatThreadFull'?: (
     params: Exact<{
       sessionID: int,
-      thread: UIMessages
+      thread: string
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -165,13 +165,17 @@
           "name": "messageID"
         },
         {
+          "type": "MessageType",
+          "name": "messageType"
+        },
+        {
           "type": "gregor1.Time",
           "name": "ctime"
         },
         {
           "type": [
             null,
-            "OutboxID"
+            "string"
           ],
           "name": "outboxID"
         },
@@ -190,6 +194,32 @@
         {
           "type": "string",
           "name": "senderDeviceType"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "UIMessageOutbox",
+      "fields": [
+        {
+          "type": "OutboxState",
+          "name": "state"
+        },
+        {
+          "type": "string",
+          "name": "outboxID"
+        },
+        {
+          "type": "MessageType",
+          "name": "messageType"
+        },
+        {
+          "type": "string",
+          "name": "body"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "ctime"
         }
       ]
     },
@@ -230,7 +260,7 @@
             "name": "OUTBOX",
             "def": false
           },
-          "body": "OutboxRecord"
+          "body": "UIMessageOutbox"
         },
         {
           "label": {

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -155,6 +155,107 @@
           "name": "offline"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "UIMessageValid",
+      "fields": [
+        {
+          "type": "MessageID",
+          "name": "messageID"
+        },
+        {
+          "type": [
+            null,
+            "OutboxID"
+          ],
+          "name": "outboxID"
+        },
+        {
+          "type": "MessageBody",
+          "name": "messageBody"
+        },
+        {
+          "type": "string",
+          "name": "senderUsername"
+        },
+        {
+          "type": "string",
+          "name": "senderDeviceName"
+        },
+        {
+          "type": "string",
+          "name": "senderDeviceType"
+        }
+      ]
+    },
+    {
+      "type": "enum",
+      "name": "MessageUnboxedState",
+      "symbols": [
+        "VALID_1",
+        "ERROR_2",
+        "OUTBOX_3",
+        "PLACEHOLDER_4"
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "UIMessage",
+      "switch": {
+        "type": "MessageUnboxedState",
+        "name": "state"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "VALID",
+            "def": false
+          },
+          "body": "UIMessageValid"
+        },
+        {
+          "label": {
+            "name": "ERROR",
+            "def": false
+          },
+          "body": "MessageUnboxedError"
+        },
+        {
+          "label": {
+            "name": "OUTBOX",
+            "def": false
+          },
+          "body": "OutboxRecord"
+        },
+        {
+          "label": {
+            "name": "PLACEHOLDER",
+            "def": false
+          },
+          "body": "MessageUnboxedPlaceholder"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "UIMessages",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "UIMessage"
+          },
+          "name": "messages"
+        },
+        {
+          "type": [
+            null,
+            "Pagination"
+          ],
+          "name": "pagination"
+        }
+      ]
     }
   ],
   "messages": {
@@ -328,7 +429,7 @@
           "name": "thread",
           "type": [
             null,
-            "ThreadView"
+            "UIMessages"
           ]
         }
       ],
@@ -343,7 +444,7 @@
         },
         {
           "name": "thread",
-          "type": "ThreadView"
+          "type": "UIMessages"
         }
       ],
       "response": null,

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -470,7 +470,7 @@
           "name": "thread",
           "type": [
             null,
-            "UIMessages"
+            "string"
           ]
         }
       ],
@@ -485,7 +485,7 @@
         },
         {
           "name": "thread",
-          "type": "UIMessages"
+          "type": "string"
         }
       ],
       "response": null,

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -165,6 +165,10 @@
           "name": "messageID"
         },
         {
+          "type": "gregor1.Time",
+          "name": "ctime"
+        },
+        {
           "type": [
             null,
             "OutboxID"

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -165,10 +165,6 @@
           "name": "messageID"
         },
         {
-          "type": "MessageType",
-          "name": "messageType"
-        },
-        {
           "type": "gregor1.Time",
           "name": "ctime"
         },
@@ -194,6 +190,17 @@
         {
           "type": "string",
           "name": "senderDeviceType"
+        },
+        {
+          "type": "boolean",
+          "name": "superseded"
+        },
+        {
+          "type": [
+            null,
+            "gregor1.Time"
+          ],
+          "name": "senderDeviceRevokedAt"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -813,16 +813,6 @@
       ]
     },
     {
-      "type": "enum",
-      "name": "MessageUnboxedState",
-      "symbols": [
-        "VALID_1",
-        "ERROR_2",
-        "OUTBOX_3",
-        "PLACEHOLDER_4"
-      ]
-    },
-    {
       "type": "record",
       "name": "MessageUnboxedValid",
       "fields": [

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -27,7 +27,7 @@
       "name": "IncomingMessage",
       "fields": [
         {
-          "type": "MessageUnboxed",
+          "type": "UIMessage",
           "name": "message"
         },
         {

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -669,7 +669,7 @@ function unstageUserForSearch(user: SearchConstants.SearchResultId): Constants.U
 }
 
 function updateThread(
-  thread: ChatTypes.ThreadView,
+  thread: ChatTypes.UIMessages,
   yourName: string,
   yourDeviceName: string,
   conversationIDKey: string

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -288,7 +288,10 @@ function* _updateThread({
 
 function subSagaUpdateThread(yourName, yourDeviceName, conversationIDKey) {
   return function*({thread}) {
-    yield put(Creators.updateThread(thread, yourName, yourDeviceName, conversationIDKey))
+    if (thread) {
+      const decThread: ChatTypes.UIMessages = JSON.parse(thread)
+      yield put(Creators.updateThread(decThread, yourName, yourDeviceName, conversationIDKey))
+    }
     return EngineRpc.rpcResult()
   }
 }

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -96,8 +96,7 @@ function* _incomingMessage(action: Constants.IncomingMessage): SagaGenerator<any
         // private one, which is what we were doing before this change.
         if (
           incomingMessage.conv &&
-          incomingMessage.conv.info &&
-          incomingMessage.conv.info.visibility !== ChatTypes.CommonTLFVisibility.private
+          incomingMessage.conv.visibility !== ChatTypes.CommonTLFVisibility.private
         ) {
           return
         }
@@ -106,7 +105,7 @@ function* _incomingMessage(action: Constants.IncomingMessage): SagaGenerator<any
           yield call(Inbox.processConversation, incomingMessage.conv)
         }
 
-        const messageUnboxed: ChatTypes.MessageUnboxed = incomingMessage.message
+        const messageUnboxed: ChatTypes.UIMessage = incomingMessage.message
         const yourName = yield select(usernameSelector)
         const yourDeviceName = yield select(Shared.devicenameSelector)
         const conversationIDKey = Constants.conversationIDToKey(incomingMessage.convID)
@@ -444,26 +443,25 @@ function _decodeFailureDescription(typ: ChatTypes.OutboxErrorType): string {
 }
 
 function _unboxedToMessage(
-  message: ChatTypes.MessageUnboxed,
+  message: ChatTypes.UIMessage,
   yourName,
   yourDeviceName,
   conversationIDKey: Constants.ConversationIDKey
 ): Constants.Message {
-  if (message && message.state === ChatTypes.LocalMessageUnboxedState.outbox && message.outbox) {
+  if (message && message.state === ChatTypes.ChatUiMessageUnboxedState.outbox && message.outbox) {
     // Outbox messages are always text, not attachments.
-    const payload: ChatTypes.OutboxRecord = message.outbox
+    const payload: ChatTypes.UIMessageOutbox = message.outbox
     const messageState: Constants.MessageState = payload &&
       payload.state &&
       payload.state.state === ChatTypes.LocalOutboxStateType.error
       ? 'failed'
       : 'pending'
-    const messageBody: ChatTypes.MessageBody = payload.Msg.messageBody
     const failureDescription = messageState === 'failed' // prettier-ignore $FlowIssue
       ? _decodeFailureDescription(payload.state.error.typ)
       : null
     // $FlowIssue
-    const messageText: ChatTypes.MessageText = messageBody.text
-    const outboxIDKey = Constants.outboxIDToKey(payload.outboxID)
+    const messageText: ChatTypes.MessageText = message.outbox.body
+    const outboxIDKey = payload.outboxID
 
     return {
       author: yourName,
@@ -483,7 +481,7 @@ function _unboxedToMessage(
     }
   }
 
-  if (message.state === ChatTypes.LocalMessageUnboxedState.valid) {
+  if (message.state === ChatTypes.ChatUiMessageUnboxedState.valid) {
     const payload = message.valid
     if (payload) {
       const common = {
@@ -492,16 +490,15 @@ function _unboxedToMessage(
         deviceName: payload.senderDeviceName,
         deviceType: toDeviceType(payload.senderDeviceType),
         failureDescription: null,
-        messageID: payload.serverHeader.messageID,
+        messageID: payload.messageID,
         senderDeviceRevokedAt: payload.senderDeviceRevokedAt,
-        timestamp: payload.serverHeader.ctime,
+        timestamp: payload.ctime,
         you: yourName,
       }
 
       switch (payload.messageBody.messageType) {
         case ChatTypes.CommonMessageType.text:
-          const outboxID =
-            payload.clientHeader.outboxID && Constants.outboxIDToKey(payload.clientHeader.outboxID)
+          const outboxID = payload.outboxID
           const p: any = payload
           const message = new HiddenString(
             (p.messageBody && p.messageBody.text && p.messageBody.text.body) || ''
@@ -510,15 +507,14 @@ function _unboxedToMessage(
           return {
             type: 'Text',
             ...common,
-            editedCount: payload.serverHeader.supersededBy ? 1 : 0, // mark it as edited if it's been superseded
+            editedCount: payload.superseded ? 1 : 0, // mark it as edited if it's been superseded
             message,
             messageState: 'sent', // TODO, distinguish sent/pending once CORE sends it.
             outboxID,
             key: Constants.messageKey(common.conversationIDKey, 'messageIDText', common.messageID),
           }
         case ChatTypes.CommonMessageType.attachment: {
-          const outboxID =
-            payload.clientHeader.outboxID && Constants.outboxIDToKey(payload.clientHeader.outboxID)
+          const outboxID = payload.outboxID
           if (!payload.messageBody.attachment) {
             throw new Error('empty attachment body')
           }
@@ -576,8 +572,8 @@ function _unboxedToMessage(
           const deletedIDs = (payload.messageBody.delete && payload.messageBody.delete.messageIDs) || []
           return {
             type: 'Deleted',
-            timestamp: payload.serverHeader.ctime,
-            messageID: payload.serverHeader.messageID,
+            timestamp: payload.ctime,
+            messageID: payload.messageID,
             key: Constants.messageKey(common.conversationIDKey, 'messageIDDeleted', common.messageID),
             deletedIDs,
           }
@@ -585,8 +581,7 @@ function _unboxedToMessage(
           const message = new HiddenString(
             (payload.messageBody && payload.messageBody.edit && payload.messageBody.edit.body) || ''
           )
-          const outboxID =
-            payload.clientHeader.outboxID && Constants.outboxIDToKey(payload.clientHeader.outboxID)
+          const outboxID = payload.outboxID
           const targetMessageID = payload.messageBody.edit ? payload.messageBody.edit.messageID : 0
           return {
             key: Constants.messageKey(common.conversationIDKey, 'messageIDEdit', common.messageID),
@@ -631,7 +626,7 @@ function _unboxedToMessage(
     }
   }
 
-  if (message.state === ChatTypes.LocalMessageUnboxedState.error) {
+  if (message.state === ChatTypes.ChatUiMessageUnboxedState.error) {
     const error = message.error
     if (error) {
       switch (error.errType) {

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -747,7 +747,7 @@ export type ShareAttachment = NoErrorTypedAction<
 export type UpdateThread = NoErrorTypedAction<
   'chat:updateThread',
   {
-    thread: ChatTypes.ThreadView,
+    thread: ChatTypes.UIMessages,
     yourName: string,
     yourDeviceName: string,
     conversationIDKey: string,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1854,13 +1854,14 @@ export type UIMessageOutbox = {
 
 export type UIMessageValid = {
   messageID: MessageID,
-  messageType: MessageType,
   ctime: gregor1.Time,
   outboxID?: ?string,
   messageBody: MessageBody,
   senderUsername: string,
   senderDeviceName: string,
   senderDeviceType: string,
+  superseded: boolean,
+  senderDeviceRevokedAt?: ?gregor1.Time,
 }
 
 export type UIMessages = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1265,7 +1265,7 @@ export type InboxViewFull = {
 }
 
 export type IncomingMessage = {
-  message: MessageUnboxed,
+  message: UIMessage,
   convID: ConversationID,
   displayDesktopNotification: boolean,
   conv?: ?InboxUIItem,
@@ -1841,13 +1841,22 @@ export type TyperInfo = {
 export type UIMessage =
     { state: 1, valid: ?UIMessageValid }
   | { state: 2, error: ?MessageUnboxedError }
-  | { state: 3, outbox: ?OutboxRecord }
+  | { state: 3, outbox: ?UIMessageOutbox }
   | { state: 4, placeholder: ?MessageUnboxedPlaceholder }
+
+export type UIMessageOutbox = {
+  state: OutboxState,
+  outboxID: string,
+  messageType: MessageType,
+  body: string,
+  ctime: gregor1.Time,
+}
 
 export type UIMessageValid = {
   messageID: MessageID,
+  messageType: MessageType,
   ctime: gregor1.Time,
-  outboxID?: ?OutboxID,
+  outboxID?: ?string,
   messageBody: MessageBody,
   senderUsername: string,
   senderDeviceName: string,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -55,6 +55,13 @@ function _channelMapRpcHelper(channelConfig: ChannelConfig<*>, partialRpcCall: (
 }
 
 
+export const ChatUiMessageUnboxedState = {
+  valid: 1,
+  error: 2,
+  outbox: 3,
+  placeholder: 4,
+}
+
 export const CommonConversationMemberStatus = {
   active: 0,
   removed: 1,
@@ -171,13 +178,6 @@ export const LocalMessageUnboxedErrorType = {
   badversionCritical: 1,
   badversion: 2,
   identify: 3,
-}
-
-export const LocalMessageUnboxedState = {
-  valid: 1,
-  error: 2,
-  outbox: 3,
-  placeholder: 4,
 }
 
 export const LocalOutboxErrorType = {
@@ -1838,6 +1838,26 @@ export type TyperInfo = {
   deviceType: string,
 }
 
+export type UIMessage =
+    { state: 1, valid: ?UIMessageValid }
+  | { state: 2, error: ?MessageUnboxedError }
+  | { state: 3, outbox: ?OutboxRecord }
+  | { state: 4, placeholder: ?MessageUnboxedPlaceholder }
+
+export type UIMessageValid = {
+  messageID: MessageID,
+  outboxID?: ?OutboxID,
+  messageBody: MessageBody,
+  senderUsername: string,
+  senderDeviceName: string,
+  senderDeviceType: string,
+}
+
+export type UIMessages = {
+  messages?: ?Array<UIMessage>,
+  pagination?: ?Pagination,
+}
+
 export type UnreadFirstNumLimit = {
   NumRead: int,
   AtLeast: int,
@@ -1915,11 +1935,11 @@ export type chatUiChatInboxUnverifiedRpcParam = Exact<{
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
-  thread?: ?ThreadView
+  thread?: ?UIMessages
 }>
 
 export type chatUiChatThreadFullRpcParam = Exact<{
-  thread: ThreadView
+  thread: UIMessages
 }>
 
 export type localCancelPostRpcParam = Exact<{
@@ -2428,14 +2448,14 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatThreadCached'?: (
     params: Exact<{
       sessionID: int,
-      thread?: ?ThreadView
+      thread?: ?UIMessages
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatThreadFull'?: (
     params: Exact<{
       sessionID: int,
-      thread: ThreadView
+      thread: UIMessages
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1846,6 +1846,7 @@ export type UIMessage =
 
 export type UIMessageValid = {
   messageID: MessageID,
+  ctime: gregor1.Time,
   outboxID?: ?OutboxID,
   messageBody: MessageBody,
   senderUsername: string,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1946,11 +1946,11 @@ export type chatUiChatInboxUnverifiedRpcParam = Exact<{
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
-  thread?: ?UIMessages
+  thread?: ?string
 }>
 
 export type chatUiChatThreadFullRpcParam = Exact<{
-  thread: UIMessages
+  thread: string
 }>
 
 export type localCancelPostRpcParam = Exact<{
@@ -2459,14 +2459,14 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatThreadCached'?: (
     params: Exact<{
       sessionID: int,
-      thread?: ?UIMessages
+      thread?: ?string
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatThreadFull'?: (
     params: Exact<{
       sessionID: int,
-      thread: UIMessages
+      thread: string
     }>,
     response: CommonResponseHandler
   ) => void,


### PR DESCRIPTION
Patch does the following:

1.) Adds new types for the results of `GetThreadNonblock`: `UIMessage` and `UIMessages`. These types contain the minimal amount of information from `MessageUnboxed` that the frontend should need to consume. They also use `string` AVDL types for things that are normally `[]byte`, like `OutboxID`.
2.) JSON encode the payloads that get sent from the `GetThreadNonblock` callbacks. 
3.) Change around frontend to process the new protocol. 
4.) Fixup tests.