### PR TITLE
yarn cache clean

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,9 +232,11 @@ helpers.rootLinuxNode(env, {
                                         wrap([$class: 'Xvfb']) {
                                             println "Test Windows JS"
                                             dir("visdiff") {
+                                                bat "yarn cache clean"
                                                 bat "yarn install --pure-lockfile"
                                             }
                                             dir("desktop") {
+                                                bat "yarn cache clean"
                                                 bat "yarn install --pure-lockfile"
                                                 withCredentials([[$class: 'UsernamePasswordMultiBinding',
                                                         credentialsId: 'visdiff-aws-creds',

--- a/circle.yml
+++ b/circle.yml
@@ -49,6 +49,7 @@ dependencies:
     #    background: true
     #    parallel: true
     # Maybe we dont need this with yarn - rm -rf $HOME/client/react-native/node_modules # Clear node_modules cache, it appears to be getting out of sync
+    - yarn cache clean
     - yarn install --pure-lockfile --ignore-engines
     - yarn global add react-native-cli
     - mkdir -p $GOPATH/src/github.com/keybase

--- a/shared/jenkins_test.sh
+++ b/shared/jenkins_test.sh
@@ -47,6 +47,7 @@ js_tests() {
     has_js_files
 
     echo 'yarn install'
+    yarn cache clean
     yarn install --pure-lockfile --prefer-offline --no-emoji --no-progress
     check_rc $? 'yarn install fail' 1
     echo 'yarn run flow'
@@ -79,6 +80,7 @@ visdiff_install() {
         echo 'No $change_target, skipping visdiff'
     else
         cd ../visdiff
+        yarn cache clean
         yarn install --pure-lockfile
         cd ../shared
         check_rc $? 'visdiff fail' 1


### PR DESCRIPTION
I had to force push a repo we forked and this causes yarn caches to be unhappy. this makes jenkins clear its yarn cache before installing

@keybase/react-hackers 