### PR TITLE
Load iteams

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1521,8 +1521,8 @@ var namePartRxx = regexp.MustCompile(`([a-zA-Z0-9][a-zA-Z0-9_]?)+`)
 var implicitRxxString = fmt.Sprintf("^%s[0-9a-f]{%d}$", implicitTeamPrefix, implicitSuffixLengthBytes*2)
 var implicitNameRxx = regexp.MustCompile(implicitRxxString)
 
-var implicitTeamPrefix = "__keybase_implicit_team__"
-var implicitSuffixLengthBytes = 16
+const implicitTeamPrefix = "__keybase_implicit_team__"
+const implicitSuffixLengthBytes = 16
 
 func TeamNameFromString(s string) (TeamName, error) {
 	ret := TeamName{}

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -5,6 +5,7 @@ package keybase1
 
 import (
 	"errors"
+
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -5,7 +5,6 @@ package keybase1
 
 import (
 	"errors"
-
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -378,6 +378,7 @@ func (o UserVersion) DeepCopy() UserVersion {
 type TeamPlusApplicationKeys struct {
 	Id              TeamID               `codec:"id" json:"id"`
 	Name            string               `codec:"name" json:"name"`
+	Implicit        bool                 `codec:"implicit" json:"implicit"`
 	Application     TeamApplication      `codec:"application" json:"application"`
 	Writers         []UserVersion        `codec:"writers" json:"writers"`
 	OnlyReaders     []UserVersion        `codec:"onlyReaders" json:"onlyReaders"`
@@ -388,6 +389,7 @@ func (o TeamPlusApplicationKeys) DeepCopy() TeamPlusApplicationKeys {
 	return TeamPlusApplicationKeys{
 		Id:          o.Id.DeepCopy(),
 		Name:        o.Name,
+		Implicit:    o.Implicit,
 		Application: o.Application.DeepCopy(),
 		Writers: (func(x []UserVersion) []UserVersion {
 			var ret []UserVersion
@@ -632,6 +634,7 @@ func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
 type TeamSigChainState struct {
 	Reader        UserVersion                         `codec:"reader" json:"reader"`
 	Id            TeamID                              `codec:"id" json:"id"`
+	Implicit      bool                                `codec:"implicit" json:"implicit"`
 	RootAncestor  TeamName                            `codec:"rootAncestor" json:"rootAncestor"`
 	NameDepth     int                                 `codec:"nameDepth" json:"nameDepth"`
 	NameLog       []TeamNameLogPoint                  `codec:"nameLog" json:"nameLog"`
@@ -650,6 +653,7 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 	return TeamSigChainState{
 		Reader:       o.Reader.DeepCopy(),
 		Id:           o.Id.DeepCopy(),
+		Implicit:     o.Implicit,
 		RootAncestor: o.RootAncestor.DeepCopy(),
 		NameDepth:    o.NameDepth,
 		NameLog: (func(x []TeamNameLogPoint) []TeamNameLogPoint {

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -40,6 +40,7 @@ type SCTeamMembers struct {
 }
 
 type SCTeamInvites struct {
+	Owners  *[]SCTeamInvite   `json:"owner,omitempty"`
 	Admins  *[]SCTeamInvite   `json:"admin,omitempty"`
 	Writers *[]SCTeamInvite   `json:"writer,omitempty"`
 	Readers *[]SCTeamInvite   `json:"reader,omitempty"`

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -193,6 +193,18 @@ func NewTeamDoesNotExistError(descriptor string) error {
 	return TeamDoesNotExistError{descriptor}
 }
 
+type ImplicitTeamOperationError struct {
+	msg string
+}
+
+func (e ImplicitTeamOperationError) Error() string {
+	return fmt.Sprintf("Implicit team operation not allowed: %v", e.msg)
+}
+
+func NewImplicitTeamOperationError(format string, args ...interface{}) error {
+	return &ImplicitTeamOperationError{msg: fmt.Sprintf(format, args...)}
+}
+
 func fixupTeamGetError(ctx context.Context, g *libkb.GlobalContext, e error, n string) error {
 	if e == nil {
 		return nil

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -562,22 +562,3 @@ func TestHiddenSubteam(t *testing.T) {
 	t.Logf(spew.Sdump(team.chain().inner.SubteamLog))
 	require.Len(t, team.chain().inner.SubteamLog, 0, "subteam log should be empty because all subteam links were stubbed for this user")
 }
-
-func TestParseImplicitTeamBackingName(t *testing.T) {
-	tc := SetupTest(t, "team", 1)
-	defer tc.Cleanup()
-
-	badNames := []string{
-		"__keybase_implicit_team__",
-		"__keybase_implicit_team__12345678901234567801234567890q",
-		"__keybase_implicit_team__12345678901234567801234567890",
-	}
-	for _, badName := range badNames {
-		_, err := keybase1.TeamNameFromString(badName)
-		require.Error(t, err)
-	}
-	goodName := "__keybase_implicit_team__0123456789abcdef0123456789abcdef"
-	name, err := keybase1.TeamNameFromString(goodName)
-	require.NoError(t, err)
-	require.Equal(t, string(name.Parts[0]), "__keybase_implicit_team__0123456789abcdef0123456789abcdef")
-}

--- a/go/teams/name_test.go
+++ b/go/teams/name_test.go
@@ -48,3 +48,22 @@ func TestTeamNameFromString(t *testing.T) {
 		require.Equal(t, c.implicit, name.IsImplicit())
 	}
 }
+
+func TestParseImplicitTeamBackingName(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	defer tc.Cleanup()
+
+	badNames := []string{
+		"__keybase_implicit_team__",
+		"__keybase_implicit_team__12345678901234567801234567890q",
+		"__keybase_implicit_team__12345678901234567801234567890",
+	}
+	for _, badName := range badNames {
+		_, err := keybase1.TeamNameFromString(badName)
+		require.Error(t, err)
+	}
+	goodName := "__keybase_implicit_team__0123456789abcdef0123456789abcdef"
+	name, err := keybase1.TeamNameFromString(goodName)
+	require.NoError(t, err)
+	require.Equal(t, string(name.Parts[0]), "__keybase_implicit_team__0123456789abcdef0123456789abcdef")
+}

--- a/go/teams/name_test.go
+++ b/go/teams/name_test.go
@@ -1,0 +1,50 @@
+package teams
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTeamNameFromString(t *testing.T) {
+	cases := []struct {
+		str      string
+		ok       bool
+		implicit bool
+	}{
+		{"", false, false},
+		{"a", false, false},
+		{"a.", false, false},
+		{"aaaa.", false, false},
+		{"aaaa.bbbbb.", false, false},
+		{".aaaa", false, false},
+		{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false, false},
+
+		{"aaa.bbb.ccc", true, false},
+		{"aaa.ccc", true, false},
+		{"__keybase_implicit_team__", false, false},
+		{"__keybase_implicit_team__.x", false, false},
+		{"__keybase_implicit_team__9f6d31062cf8efbca45f9b193b24d724", true, true},
+		{"__keybase_implicit_team__bbbb26367512347c55154f14d436fb8b", true, true},
+		{"__keybase_implicit_team_", false, true},
+		{"__keybase_implicit_team__", false, true},
+		{"__keybase_implicit_team___", false, true},
+		{"__keybase_implicit_team__bbbb26367512347c55154f14d436fb8", false, true},  // too short
+		{"__keybase_implicit_team__bbbb26367512347c55154f14d436fb8z", false, true}, // non-hex
+	}
+
+	for i, c := range cases {
+		t.Logf("--> [%v] %+v", i, c)
+		name, err := keybase1.TeamNameFromString(c.str)
+		if c.ok {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err)
+			continue
+		}
+		require.True(t, len(name.Parts) > 0)
+		require.Equal(t, c.str, name.String())
+		require.Equal(t, c.implicit, name.IsImplicit())
+	}
+}

--- a/go/teams/rpc_exim.go
+++ b/go/teams/rpc_exim.go
@@ -33,6 +33,7 @@ func (t *Team) ExportToTeamPlusApplicationKeys(ctx context.Context, idTime keyba
 	ret = keybase1.TeamPlusApplicationKeys{
 		Id:              t.chain().GetID(),
 		Name:            t.Name().String(),
+		Implicit:        t.chain().IsImplicit(),
 		Application:     application,
 		Writers:         writers,
 		OnlyReaders:     onlyReaders,

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -182,7 +182,6 @@ protocol teams {
     TeamID id;
 
     // Whether this is an implicit team.
-    // Implicits teams are more restricted.
     boolean implicit;
 
     // Name of the root ancestor. For A.B.C this is 'A'.

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -106,6 +106,7 @@ protocol teams {
   record TeamPlusApplicationKeys {
       TeamID id;
       string name;
+      boolean implicit;
       TeamApplication application;
 
       array<UserVersion> writers;
@@ -179,6 +180,10 @@ protocol teams {
     UserVersion reader;
 
     TeamID id;
+
+    // Whether this is an implicit team.
+    // Implicits teams are more restricted.
+    boolean implicit;
 
     // Name of the root ancestor. For A.B.C this is 'A'.
     TeamName rootAncestor;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4520,6 +4520,7 @@ export type TeamNamePart = string
 export type TeamPlusApplicationKeys = {
   id: TeamID,
   name: string,
+  implicit: boolean,
   application: TeamApplication,
   writers?: ?Array<UserVersion>,
   onlyReaders?: ?Array<UserVersion>,
@@ -4548,6 +4549,7 @@ export type TeamSBSMsg = {
 export type TeamSigChainState = {
   reader: UserVersion,
   id: TeamID,
+  implicit: boolean,
   rootAncestor: TeamName,
   nameDepth: int,
   nameLog?: ?Array<TeamNameLogPoint>,

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -324,6 +324,10 @@
           "name": "name"
         },
         {
+          "type": "boolean",
+          "name": "implicit"
+        },
+        {
           "type": "TeamApplication",
           "name": "application"
         },
@@ -516,6 +520,10 @@
         {
           "type": "TeamID",
           "name": "id"
+        },
+        {
+          "type": "boolean",
+          "name": "implicit"
         },
         {
           "type": "TeamName",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4520,6 +4520,7 @@ export type TeamNamePart = string
 export type TeamPlusApplicationKeys = {
   id: TeamID,
   name: string,
+  implicit: boolean,
   application: TeamApplication,
   writers?: ?Array<UserVersion>,
   onlyReaders?: ?Array<UserVersion>,
@@ -4548,6 +4549,7 @@ export type TeamSBSMsg = {
 export type TeamSigChainState = {
   reader: UserVersion,
   id: TeamID,
+  implicit: boolean,
   rootAncestor: TeamName,
   nameDepth: int,
   nameLog?: ?Array<TeamNameLogPoint>,


### PR DESCRIPTION
TeamLoader now understands implicit teams and places lots of restrictions on them. I tested merging this into mike/CORE-5841 and `TestCreateImplicitTeam` still passes.