### PR TITLE
Split info panel for small and big teams

### DIFF
--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Constants from '../../../constants/chat'
 import * as Creators from '../../../actions/chat/creators'
-import {InfoPanel, BigTeamInfoPanel} from '.'
+import {SmallTeamInfoPanel, BigTeamInfoPanel} from '.'
 import {Map} from 'immutable'
 import {compose, renderComponent, branch} from 'recompose'
 import {connect} from 'react-redux'
@@ -85,6 +85,6 @@ const mergeProps = (stateProps, dispatchProps) => ({
 const ConnectedInfoPanel = compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
   branch(props => props.channelname, renderComponent(BigTeamInfoPanel))
-)(InfoPanel)
+)(SmallTeamInfoPanel)
 
 export default ConnectedInfoPanel

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -32,11 +32,21 @@ const getParticipants = createSelector(
   }
 )
 
-const mapStateToProps = (state: TypedState) => ({
-  muted: Constants.getMuted(state),
-  participants: getParticipants(state),
-  selectedConversationIDKey: Constants.getSelectedConversation(state),
-})
+const mapStateToProps = (state: TypedState) => {
+  const selectedConversationIDKey = Constants.getSelectedConversation(state)
+  const conversation = state.chat
+    .get('inbox')
+    .find(i => i.get('conversationIDKey') === selectedConversationIDKey)
+  const channelname = conversation.get('channelname')
+  const teamname = conversation.get('teamname')
+  return {
+    channelname,
+    muted: Constants.getMuted(state),
+    participants: getParticipants(state),
+    selectedConversationIDKey,
+    teamname,
+  }
+}
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
   onAddParticipant: (participants: Array<string>) => dispatch(Creators.newChat(participants)),

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -34,11 +34,9 @@ const getParticipants = createSelector(
 
 const mapStateToProps = (state: TypedState) => {
   const selectedConversationIDKey = Constants.getSelectedConversation(state)
-  const conversation = state.chat
-    .get('inbox')
-    .find(i => i.get('conversationIDKey') === selectedConversationIDKey)
-  const channelname = conversation.get('channelname')
-  const teamname = conversation.get('teamname')
+  const inbox = Constants.getSelectedInbox(state)
+  const channelname = inbox.get('channelname')
+  const teamname = inbox.get('teamname')
   return {
     channelname,
     muted: Constants.getMuted(state),

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -1,9 +1,9 @@
 // @flow
 import * as Constants from '../../../constants/chat'
 import * as Creators from '../../../actions/chat/creators'
-import InfoPanel from '.'
+import {InfoPanel, ChannelInfoPanel} from '.'
 import {Map} from 'immutable'
-import {compose} from 'recompose'
+import {compose, renderComponent, branch} from 'recompose'
 import {connect} from 'react-redux'
 import {createSelector} from 'reselect'
 import {navigateAppend} from '../../../actions/route-tree'
@@ -84,4 +84,9 @@ const mergeProps = (stateProps, dispatchProps) => ({
     ),
 })
 
-export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps))(InfoPanel)
+const ConnectedInfoPanel = compose(
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  branch(props => props.channelname, renderComponent(ChannelInfoPanel))
+)(InfoPanel)
+
+export default ConnectedInfoPanel

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Constants from '../../../constants/chat'
 import * as Creators from '../../../actions/chat/creators'
-import {InfoPanel, ChannelInfoPanel} from '.'
+import {InfoPanel, BigTeamInfoPanel} from '.'
 import {Map} from 'immutable'
 import {compose, renderComponent, branch} from 'recompose'
 import {connect} from 'react-redux'
@@ -84,7 +84,7 @@ const mergeProps = (stateProps, dispatchProps) => ({
 
 const ConnectedInfoPanel = compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
-  branch(props => props.channelname, renderComponent(ChannelInfoPanel))
+  branch(props => props.channelname, renderComponent(BigTeamInfoPanel))
 )(InfoPanel)
 
 export default ConnectedInfoPanel

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -40,6 +40,7 @@ const mapStateToProps = (state: TypedState) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
   onAddParticipant: (participants: Array<string>) => dispatch(Creators.newChat(participants)),
+  onBack: () => dispatch(navigateUp()),
   onMuteConversation: (conversationIDKey: Constants.ConversationIDKey, muted: boolean) => {
     dispatch(Creators.muteConversation(conversationIDKey, muted))
   },
@@ -54,7 +55,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
     )
   },
   onShowProfile: (username: string) => dispatch(showUserProfile(username)),
-  onBack: () => dispatch(navigateUp()),
 })
 
 const mergeProps = (stateProps, dispatchProps) => ({

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -106,7 +106,8 @@ const _BigTeamInfoPanel = (props: BigTeamInfoPanelProps) => (
   </ScrollView>
 )
 
-const SmallTeamInfoPanel = branch(() => isMobile, HeaderHoc)(_SmallTeamInfoPanel)
-const BigTeamInfoPanel = branch(() => isMobile, HeaderHoc)(_BigTeamInfoPanel)
+const wrap = branch(() => isMobile, HeaderHoc)
+const SmallTeamInfoPanel = wrap(_SmallTeamInfoPanel)
+const BigTeamInfoPanel = wrap(_BigTeamInfoPanel)
 
 export {SmallTeamInfoPanel, BigTeamInfoPanel}

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -104,9 +104,9 @@ const _BigTeamInfoPanel = (props: BigTeamInfoPanelProps) => (
 
     <Divider style={{marginBottom: 20, marginTop: 20}} />
 
-      <Text style={{paddingLeft: globalMargins.small}} type="BodySmall">
-        Members
-      </Text>
+    <Text style={{paddingLeft: globalMargins.small}} type="BodySmall">
+      Members
+    </Text>
 
     <Participants
       participants={props.participants}

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -24,12 +24,16 @@ const _InfoPanel = (props: Props) => (
     }}
     contentContainerStyle={{...globalStyles.flexBoxColumn, alignItems: 'stretch', paddingBottom: 20}}
   >
-    <Text style={{alignSelf: 'center'}} type="BodySemibold">
-      #{props.channelname}
-    </Text>
-    <Text style={{alignSelf: 'center'}} type="BodySmall">
-      {props.teamname}
-    </Text>
+    {props.channelname
+      ? <Text style={{alignSelf: 'center'}} type="BodySemibold">
+          #{props.channelname}
+        </Text>
+      : null}
+    {props.channelname
+      ? <Text style={{alignSelf: 'center'}} type="BodySmall">
+          {props.teamname}
+        </Text>
+      : null}
 
     <Participants
       participants={props.participants}

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -62,18 +62,12 @@ const _ChannelInfoPanel = (props: ChannelInfoPanelProps) => (
     style={scrollViewStyle}
     contentContainerStyle={{...globalStyles.flexBoxColumn, alignItems: 'stretch', paddingBottom: 20}}
   >
-    <Text style={{alignSelf: 'center'}} type="BodySemibold">
+    <Text style={{alignSelf: 'center', marginTop: 20}} type="BodySemibold">
       #{props.channelname}
     </Text>
     <Text style={{alignSelf: 'center'}} type="BodySmall">
       {props.teamname}
     </Text>
-
-    <Participants
-      participants={props.participants}
-      onAddParticipant={props.onAddParticipant}
-      onShowProfile={props.onShowProfile}
-    />
 
     <Divider style={{marginBottom: 20, marginTop: 20}} />
 
@@ -82,7 +76,7 @@ const _ChannelInfoPanel = (props: ChannelInfoPanelProps) => (
         checked={props.muted}
         disabled={props.onMuteConversation == null}
         onCheck={checked => props.onMuteConversation(checked)}
-        label="Mute notifications"
+        label="Mute channel"
       />
       <Icon
         type="iconfont-shh"
@@ -96,7 +90,11 @@ const _ChannelInfoPanel = (props: ChannelInfoPanelProps) => (
 
     <Divider style={{marginBottom: 20, marginTop: 20}} />
 
-    <Button type="Danger" label="Block this conversation" onClick={props.onShowBlockConversationDialog} />
+    <Participants
+      participants={props.participants}
+      onAddParticipant={props.onAddParticipant}
+      onShowProfile={props.onShowProfile}
+    />
   </ScrollView>
 )
 

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -31,6 +31,31 @@ const scrollViewStyle = {
       }),
 }
 
+type muteRowProps = {
+  muted: boolean,
+  onMute: (muted: boolean) => void,
+  label: string,
+}
+
+const MuteRow = (props: muteRowProps) => (
+  <Box style={{...globalStyles.flexBoxRow, alignSelf: 'center'}}>
+    <Checkbox
+      checked={props.muted}
+      disabled={props.onMute == null}
+      onCheck={props.onMute}
+      label={props.label}
+    />
+    <Icon
+      type="iconfont-shh"
+      style={{
+        color: globalColors.black_20,
+        marginLeft: globalMargins.tiny,
+        ...(isMobile ? {fontSize: 24} : {}),
+      }}
+    />
+  </Box>
+)
+
 const _SmallTeamInfoPanel = (props: SmallTeamInfoPanelProps) => (
   <ScrollView
     style={scrollViewStyle}
@@ -44,22 +69,7 @@ const _SmallTeamInfoPanel = (props: SmallTeamInfoPanelProps) => (
 
     <Divider style={{marginBottom: 20, marginTop: 20}} />
 
-    <Box style={{...globalStyles.flexBoxRow, alignSelf: 'center'}}>
-      <Checkbox
-        checked={props.muted}
-        disabled={props.onMuteConversation == null}
-        onCheck={checked => props.onMuteConversation(checked)}
-        label="Mute notifications"
-      />
-      <Icon
-        type="iconfont-shh"
-        style={{
-          color: globalColors.black_20,
-          marginLeft: globalMargins.tiny,
-          ...(isMobile ? {fontSize: 24} : {}),
-        }}
-      />
-    </Box>
+    <MuteRow muted={props.muted} onMute={props.onMuteConversation} label="Mute notifications" />
 
     <Divider style={{marginBottom: 20, marginTop: 20}} />
 
@@ -85,22 +95,7 @@ const _BigTeamInfoPanel = (props: BigTeamInfoPanelProps) => (
 
     <Divider style={{marginBottom: 20, marginTop: 20}} />
 
-    <Box style={{...globalStyles.flexBoxRow, alignSelf: 'center'}}>
-      <Checkbox
-        checked={props.muted}
-        disabled={props.onMuteConversation == null}
-        onCheck={checked => props.onMuteConversation(checked)}
-        label="Mute channel"
-      />
-      <Icon
-        type="iconfont-shh"
-        style={{
-          color: globalColors.black_20,
-          marginLeft: globalMargins.tiny,
-          ...(isMobile ? {fontSize: 24} : {}),
-        }}
-      />
-    </Box>
+    <MuteRow muted={props.muted} onMute={props.onMuteConversation} label="Mute channel" />
 
     <Divider style={{marginBottom: 20, marginTop: 20}} />
 

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -1,6 +1,16 @@
 // @flow
 import * as React from 'react'
-import {Box, Button, Checkbox, Divider, HeaderHoc, Icon, ScrollView, Text} from '../../../common-adapters'
+import {
+  Avatar,
+  Box,
+  Button,
+  Checkbox,
+  Divider,
+  HeaderHoc,
+  Icon,
+  ScrollView,
+  Text,
+} from '../../../common-adapters'
 import {globalColors, globalMargins, globalStyles} from '../../../styles'
 import {isMobile} from '../../../constants/platform'
 import {branch} from 'recompose'
@@ -65,9 +75,13 @@ const _ChannelInfoPanel = (props: ChannelInfoPanelProps) => (
     <Text style={{alignSelf: 'center', marginTop: 20}} type="BodySemibold">
       #{props.channelname}
     </Text>
-    <Text style={{alignSelf: 'center'}} type="BodySmall">
-      {props.teamname}
-    </Text>
+
+    <Box style={{...globalStyles.flexBoxRow, alignSelf: 'center'}}>
+      <Avatar teamname={props.teamname} size={16} />
+      <Text style={{marginLeft: globalMargins.xtiny}} type="BodySmall">
+        {props.teamname}
+      </Text>
+    </Box>
 
     <Divider style={{marginBottom: 20, marginTop: 20}} />
 

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {Box, Button, Checkbox, Divider, HeaderHoc, Icon, ScrollView} from '../../../common-adapters'
+import {Box, Button, Checkbox, Divider, HeaderHoc, Icon, ScrollView, Text} from '../../../common-adapters'
 import {globalColors, globalMargins, globalStyles} from '../../../styles'
 import {isMobile} from '../../../constants/platform'
 import {branch} from 'recompose'
@@ -24,6 +24,13 @@ const _InfoPanel = (props: Props) => (
     }}
     contentContainerStyle={{...globalStyles.flexBoxColumn, alignItems: 'stretch', paddingBottom: 20}}
   >
+    <Text style={{alignSelf: 'center'}} type="BodySemibold">
+      #{props.channelname}
+    </Text>
+    <Text style={{alignSelf: 'center'}} type="BodySmall">
+      {props.teamname}
+    </Text>
+
     <Participants
       participants={props.participants}
       onAddParticipant={props.onAddParticipant}

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -17,7 +17,7 @@ import {branch} from 'recompose'
 
 import Participants from './participants'
 
-import type {InfoPanelProps, ChannelInfoPanelProps} from '.'
+import type {InfoPanelProps, BigTeamInfoPanelProps} from '.'
 
 const border = `1px solid ${globalColors.black_05}`
 const scrollViewStyle = {
@@ -67,7 +67,7 @@ const _InfoPanel = (props: InfoPanelProps) => (
   </ScrollView>
 )
 
-const _ChannelInfoPanel = (props: ChannelInfoPanelProps) => (
+const _BigTeamInfoPanel = (props: BigTeamInfoPanelProps) => (
   <ScrollView
     style={scrollViewStyle}
     contentContainerStyle={{...globalStyles.flexBoxColumn, alignItems: 'stretch', paddingBottom: 20}}
@@ -117,6 +117,6 @@ const _ChannelInfoPanel = (props: ChannelInfoPanelProps) => (
 )
 
 const InfoPanel = branch(() => isMobile, HeaderHoc)(_InfoPanel)
-const ChannelInfoPanel = branch(() => isMobile, HeaderHoc)(_ChannelInfoPanel)
+const BigTeamInfoPanel = branch(() => isMobile, HeaderHoc)(_BigTeamInfoPanel)
 
-export {InfoPanel, ChannelInfoPanel}
+export {InfoPanel, BigTeamInfoPanel}

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -7,33 +7,67 @@ import {branch} from 'recompose'
 
 import Participants from './participants'
 
-import type {Props} from '.'
+import type {InfoPanelProps, ChannelInfoPanelProps} from '.'
 
 const border = `1px solid ${globalColors.black_05}`
-const _InfoPanel = (props: Props) => (
+const scrollViewStyle = {
+  flex: 1,
+  ...(isMobile
+    ? {}
+    : {
+        backgroundColor: globalColors.white,
+        borderLeft: border,
+        borderRight: border,
+      }),
+}
+
+const _InfoPanel = (props: InfoPanelProps) => (
   <ScrollView
-    style={{
-      flex: 1,
-      ...(isMobile
-        ? {}
-        : {
-            backgroundColor: globalColors.white,
-            borderLeft: border,
-            borderRight: border,
-          }),
-    }}
+    style={scrollViewStyle}
     contentContainerStyle={{...globalStyles.flexBoxColumn, alignItems: 'stretch', paddingBottom: 20}}
   >
-    {props.channelname
-      ? <Text style={{alignSelf: 'center'}} type="BodySemibold">
-          #{props.channelname}
-        </Text>
-      : null}
-    {props.channelname
-      ? <Text style={{alignSelf: 'center'}} type="BodySmall">
-          {props.teamname}
-        </Text>
-      : null}
+    <Participants
+      participants={props.participants}
+      onAddParticipant={props.onAddParticipant}
+      onShowProfile={props.onShowProfile}
+    />
+
+    <Divider style={{marginBottom: 20, marginTop: 20}} />
+
+    <Box style={{...globalStyles.flexBoxRow, alignSelf: 'center'}}>
+      <Checkbox
+        checked={props.muted}
+        disabled={props.onMuteConversation == null}
+        onCheck={checked => props.onMuteConversation(checked)}
+        label="Mute notifications"
+      />
+      <Icon
+        type="iconfont-shh"
+        style={{
+          color: globalColors.black_20,
+          marginLeft: globalMargins.tiny,
+          ...(isMobile ? {fontSize: 24} : {}),
+        }}
+      />
+    </Box>
+
+    <Divider style={{marginBottom: 20, marginTop: 20}} />
+
+    <Button type="Danger" label="Block this conversation" onClick={props.onShowBlockConversationDialog} />
+  </ScrollView>
+)
+
+const _ChannelInfoPanel = (props: ChannelInfoPanelProps) => (
+  <ScrollView
+    style={scrollViewStyle}
+    contentContainerStyle={{...globalStyles.flexBoxColumn, alignItems: 'stretch', paddingBottom: 20}}
+  >
+    <Text style={{alignSelf: 'center'}} type="BodySemibold">
+      #{props.channelname}
+    </Text>
+    <Text style={{alignSelf: 'center'}} type="BodySmall">
+      {props.teamname}
+    </Text>
 
     <Participants
       participants={props.participants}
@@ -67,5 +101,6 @@ const _InfoPanel = (props: Props) => (
 )
 
 const InfoPanel = branch(() => isMobile, HeaderHoc)(_InfoPanel)
+const ChannelInfoPanel = branch(() => isMobile, HeaderHoc)(_ChannelInfoPanel)
 
-export default InfoPanel
+export {InfoPanel, ChannelInfoPanel}

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -30,6 +30,7 @@ const scrollViewStyle = {
         borderRight: border,
       }),
 }
+const contentContainerStyle = {...globalStyles.flexBoxColumn, alignItems: 'stretch', paddingBottom: 20}
 
 type muteRowProps = {
   muted: boolean,
@@ -57,10 +58,7 @@ const MuteRow = (props: muteRowProps) => (
 )
 
 const _SmallTeamInfoPanel = (props: SmallTeamInfoPanelProps) => (
-  <ScrollView
-    style={scrollViewStyle}
-    contentContainerStyle={{...globalStyles.flexBoxColumn, alignItems: 'stretch', paddingBottom: 20}}
-  >
+  <ScrollView style={scrollViewStyle} contentContainerStyle={contentContainerStyle}>
     <Participants
       participants={props.participants}
       onAddParticipant={props.onAddParticipant}
@@ -78,10 +76,7 @@ const _SmallTeamInfoPanel = (props: SmallTeamInfoPanelProps) => (
 )
 
 const _BigTeamInfoPanel = (props: BigTeamInfoPanelProps) => (
-  <ScrollView
-    style={scrollViewStyle}
-    contentContainerStyle={{...globalStyles.flexBoxColumn, alignItems: 'stretch', paddingBottom: 20}}
-  >
+  <ScrollView style={scrollViewStyle} contentContainerStyle={contentContainerStyle}>
     <Text style={{alignSelf: 'center', marginTop: 20}} type="BodySemibold">
       #{props.channelname}
     </Text>

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -17,7 +17,7 @@ import {branch} from 'recompose'
 
 import Participants from './participants'
 
-import type {InfoPanelProps, BigTeamInfoPanelProps} from '.'
+import type {SmallTeamInfoPanelProps, BigTeamInfoPanelProps} from '.'
 
 const border = `1px solid ${globalColors.black_05}`
 const scrollViewStyle = {
@@ -31,7 +31,7 @@ const scrollViewStyle = {
       }),
 }
 
-const _InfoPanel = (props: InfoPanelProps) => (
+const _SmallTeamInfoPanel = (props: SmallTeamInfoPanelProps) => (
   <ScrollView
     style={scrollViewStyle}
     contentContainerStyle={{...globalStyles.flexBoxColumn, alignItems: 'stretch', paddingBottom: 20}}
@@ -116,7 +116,7 @@ const _BigTeamInfoPanel = (props: BigTeamInfoPanelProps) => (
   </ScrollView>
 )
 
-const InfoPanel = branch(() => isMobile, HeaderHoc)(_InfoPanel)
+const SmallTeamInfoPanel = branch(() => isMobile, HeaderHoc)(_SmallTeamInfoPanel)
 const BigTeamInfoPanel = branch(() => isMobile, HeaderHoc)(_BigTeamInfoPanel)
 
-export {InfoPanel, BigTeamInfoPanel}
+export {SmallTeamInfoPanel, BigTeamInfoPanel}

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -104,6 +104,10 @@ const _ChannelInfoPanel = (props: ChannelInfoPanelProps) => (
 
     <Divider style={{marginBottom: 20, marginTop: 20}} />
 
+    <Text type="BodySmall">
+      Members
+    </Text>
+
     <Participants
       participants={props.participants}
       onAddParticipant={props.onAddParticipant}

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -104,9 +104,9 @@ const _ChannelInfoPanel = (props: ChannelInfoPanelProps) => (
 
     <Divider style={{marginBottom: 20, marginTop: 20}} />
 
-    <Text type="BodySmall">
-      Members
-    </Text>
+      <Text style={{paddingLeft: globalMargins.small}} type="BodySmall">
+        Members
+      </Text>
 
     <Participants
       participants={props.participants}

--- a/shared/chat/conversation/info-panel/index.js.flow
+++ b/shared/chat/conversation/info-panel/index.js.flow
@@ -2,7 +2,7 @@
 import {Component} from 'react'
 import {List} from 'immutable'
 
-export type InfoPanelProps = {
+export type SmallTeamInfoPanelProps = {
   muted: boolean,
   onAddParticipant: () => void,
   onMuteConversation: (muted: boolean) => void,
@@ -18,14 +18,13 @@ export type InfoPanelProps = {
   }>,
 }
 
-export class InfoPanel extends Component<InfoPanelProps> {}
+export class SmallTeamInfoPanel extends Component<SmallTeamInfoPanelProps> {}
 
 export type BigTeamInfoPanelProps = {
   channelname: string,
   muted: boolean,
   onAddParticipant: () => void,
   onMuteConversation: (muted: boolean) => void,
-  onShowBlockConversationDialog: () => void,
   onShowProfile: (username: string) => void,
   onToggleInfoPanel: () => void,
   participants: List<{

--- a/shared/chat/conversation/info-panel/index.js.flow
+++ b/shared/chat/conversation/info-panel/index.js.flow
@@ -3,6 +3,7 @@ import {Component} from 'react'
 import {List} from 'immutable'
 
 export type Props = {
+  channelname: ?string,
   muted: boolean,
   onAddParticipant: () => void,
   onMuteConversation: (muted: boolean) => void,
@@ -16,6 +17,7 @@ export type Props = {
     broken: boolean,
     isYou: boolean,
   }>,
+  teamname: ?string,
 }
 
 export default class InfoPanel extends Component<Props> {}

--- a/shared/chat/conversation/info-panel/index.js.flow
+++ b/shared/chat/conversation/info-panel/index.js.flow
@@ -2,11 +2,10 @@
 import {Component} from 'react'
 import {List} from 'immutable'
 
-export type SmallTeamInfoPanelProps = {
+type infoPanelProps = {
   muted: boolean,
   onAddParticipant: () => void,
   onMuteConversation: (muted: boolean) => void,
-  onShowBlockConversationDialog: () => void,
   onShowProfile: (username: string) => void,
   onToggleInfoPanel: () => void,
   participants: List<{
@@ -18,22 +17,16 @@ export type SmallTeamInfoPanelProps = {
   }>,
 }
 
+export type SmallTeamInfoPanelProps = {
+  ...$Exact<infoPanelProps>,
+  onShowBlockConversationDialog: () => void,
+}
+
 export class SmallTeamInfoPanel extends Component<SmallTeamInfoPanelProps> {}
 
 export type BigTeamInfoPanelProps = {
+  ...$Exact<infoPanelProps>,
   channelname: string,
-  muted: boolean,
-  onAddParticipant: () => void,
-  onMuteConversation: (muted: boolean) => void,
-  onShowProfile: (username: string) => void,
-  onToggleInfoPanel: () => void,
-  participants: List<{
-    username: string,
-    following: boolean,
-    fullname: string,
-    broken: boolean,
-    isYou: boolean,
-  }>,
   teamname: string,
 }
 

--- a/shared/chat/conversation/info-panel/index.js.flow
+++ b/shared/chat/conversation/info-panel/index.js.flow
@@ -20,7 +20,7 @@ export type InfoPanelProps = {
 
 export class InfoPanel extends Component<InfoPanelProps> {}
 
-export type ChannelInfoPanelProps = {
+export type BigTeamInfoPanelProps = {
   channelname: string,
   muted: boolean,
   onAddParticipant: () => void,
@@ -38,4 +38,4 @@ export type ChannelInfoPanelProps = {
   teamname: string,
 }
 
-export class ChannelInfoPanel extends Component<ChannelInfoPanelProps> {}
+export class BigTeamInfoPanel extends Component<BigTeamInfoPanelProps> {}

--- a/shared/chat/conversation/info-panel/index.js.flow
+++ b/shared/chat/conversation/info-panel/index.js.flow
@@ -17,15 +17,13 @@ type infoPanelProps = {
   }>,
 }
 
-export type SmallTeamInfoPanelProps = {
-  ...$Exact<infoPanelProps>,
+export type SmallTeamInfoPanelProps = infoPanelProps & {
   onShowBlockConversationDialog: () => void,
 }
 
 export class SmallTeamInfoPanel extends Component<SmallTeamInfoPanelProps> {}
 
-export type BigTeamInfoPanelProps = {
-  ...$Exact<infoPanelProps>,
+export type BigTeamInfoPanelProps = infoPanelProps & {
   channelname: string,
   teamname: string,
 }

--- a/shared/chat/conversation/info-panel/index.js.flow
+++ b/shared/chat/conversation/info-panel/index.js.flow
@@ -2,8 +2,7 @@
 import {Component} from 'react'
 import {List} from 'immutable'
 
-export type Props = {
-  channelname: ?string,
+export type InfoPanelProps = {
   muted: boolean,
   onAddParticipant: () => void,
   onMuteConversation: (muted: boolean) => void,
@@ -17,7 +16,26 @@ export type Props = {
     broken: boolean,
     isYou: boolean,
   }>,
-  teamname: ?string,
 }
 
-export default class InfoPanel extends Component<Props> {}
+export class InfoPanel extends Component<InfoPanelProps> {}
+
+export type ChannelInfoPanelProps = {
+  channelname: string,
+  muted: boolean,
+  onAddParticipant: () => void,
+  onMuteConversation: (muted: boolean) => void,
+  onShowBlockConversationDialog: () => void,
+  onShowProfile: (username: string) => void,
+  onToggleInfoPanel: () => void,
+  participants: List<{
+    username: string,
+    following: boolean,
+    fullname: string,
+    broken: boolean,
+    isYou: boolean,
+  }>,
+  teamname: string,
+}
+
+export class ChannelInfoPanel extends Component<ChannelInfoPanelProps> {}

--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -4,7 +4,7 @@ import ConversationHeader from './conversation/header'
 import ConversationInput from './conversation/input'
 import ConversationList from './conversation/list'
 import NoConversation from './conversation/no-conversation'
-import ConversationInfoPanel from './conversation/info-panel'
+import {InfoPanel} from './conversation/info-panel'
 import HiddenString from '../util/hidden-string'
 import Inbox from './inbox/container'
 import ParticipantRekey from './conversation/rekey/participant-rekey'
@@ -352,7 +352,7 @@ const commonInfoPanel = {
 }
 
 const infoPanel = {
-  component: ConversationInfoPanel,
+  component: InfoPanel,
   mocks: {
     Normal: {
       ...commonInfoPanel,

--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -4,7 +4,7 @@ import ConversationHeader from './conversation/header'
 import ConversationInput from './conversation/input'
 import ConversationList from './conversation/list'
 import NoConversation from './conversation/no-conversation'
-import {InfoPanel} from './conversation/info-panel'
+import {SmallTeamInfoPanel} from './conversation/info-panel'
 import HiddenString from '../util/hidden-string'
 import Inbox from './inbox/container'
 import ParticipantRekey from './conversation/rekey/participant-rekey'
@@ -352,7 +352,7 @@ const commonInfoPanel = {
 }
 
 const infoPanel = {
-  component: InfoPanel,
+  component: SmallTeamInfoPanel,
   mocks: {
     Normal: {
       ...commonInfoPanel,

--- a/shared/common-adapters/choice-list.desktop.js
+++ b/shared/common-adapters/choice-list.desktop.js
@@ -80,7 +80,7 @@ const styleInfoContainer = {
   ...globalStyles.flexBoxColumn,
   flex: 1,
   justifyContent: 'center',
-  alignItems: 'left', // TODO (AW): invalid prop value
+  alignItems: 'flex-start',
   textAlign: 'left',
   marginLeft: globalMargins.small,
 }


### PR DESCRIPTION
For big teams, display the channel and team name in
the info panel. Also change the wording and ordering of buttons slightly.