### PR TITLE
turn warnings on in flow

### DIFF
--- a/shared/.flowconfig
+++ b/shared/.flowconfig
@@ -35,7 +35,7 @@
 ./flow-typed
 
 [options]
-include_warnings=true
+include_warnings=false
 munge_underscores=true
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
@@ -58,6 +58,10 @@ suppress_comment=\\(.\\|\n\\)*\\$ForceType
 
 [lints]
 all=warn
+sketchy-null-bool=off
+sketchy-null-string=off
+sketchy-null-mixed=off
+sketchy-null-number=off
 
 [version]
 0.53.1

--- a/shared/.flowconfig
+++ b/shared/.flowconfig
@@ -35,6 +35,7 @@
 ./flow-typed
 
 [options]
+include_warnings=true
 munge_underscores=true
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
@@ -54,6 +55,9 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(1[0-7]\\|[0-9]\\).[0-9
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 suppress_comment=\\(.\\|\n\\)*\\$ForceType
+
+[lints]
+all=warn
 
 [version]
 0.53.1

--- a/shared/.flowconfig
+++ b/shared/.flowconfig
@@ -35,7 +35,7 @@
 ./flow-typed
 
 [options]
-include_warnings=false
+include_warnings=true
 munge_underscores=true
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable


### PR DESCRIPTION
This turns on flow lint warnings and shows those on the CLI by default now. I turned off the sketchy-null-* ones as they want you to be much stricter and not use truthy/falsey values. I don't think this would make our code simpler or safer in practice so i'm just disabling them. In practice we disallow 0 number (usually) and we'll likely make mistakes if we're doing more typeof checks