### PR TITLE
Fix pukless implicit team invites

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1664,6 +1664,7 @@ func (u UserPlusKeysV2) ToUserVersion() UserVersion {
 	}
 }
 
+// Can return nil.
 func (u UserPlusKeysV2) GetLatestPerUserKey() *PerUserKey {
 	if len(u.PerUserKeys) > 0 {
 		return &u.PerUserKeys[len(u.PerUserKeys)-1]

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -309,7 +309,7 @@ func testIdentifyLite(t *testing.T) {
 
 	t.Logf("make an implicit team")
 	iTeamCreateName := strings.Join([]string{tt.users[0].username, "bob@github"}, ",")
-	iTeamID, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamCreateName, false /*public*/)
+	iTeamID, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamCreateName, false /*isPublic*/)
 	iTeamImpName := getTeamName(iTeamID)
 	require.True(t, iTeamImpName.IsImplicit())
 	require.NoError(t, err)

--- a/go/teams/common_test.go
+++ b/go/teams/common_test.go
@@ -5,15 +5,17 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
 
 func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
-	ret := libkb.SetupTest(tb, name, depth+1)
-	NewTeamLoaderAndInstall(ret.G)
-	return ret
+	tc = libkb.SetupTest(tb, name, depth+1)
+	tc.G.SetServices(externals.GetServices())
+	NewTeamLoaderAndInstall(tc.G)
+	return tc
 }
 
 func GetForTestByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*Team, error) {

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -16,12 +16,22 @@ import (
 // Create n TestContexts with logged in users
 // Returns (FakeUsers, TestContexts, CleanupFunction)
 func setupNTests(t *testing.T, n int) ([]*kbtest.FakeUser, []*libkb.TestContext, func()) {
+	return setupNTestsWithPukless(t, n, 0)
+}
+
+// nPukless is how many users start out with no PUK.
+// Those users appear at the end of the list
+func setupNTestsWithPukless(t *testing.T, n, nPukless int) ([]*kbtest.FakeUser, []*libkb.TestContext, func()) {
 	require.True(t, n > 0, "must create at least 1 tc")
+	require.True(t, n >= nPukless, "more pukless users than total users requested")
 	var fus []*kbtest.FakeUser
 	var tcs []*libkb.TestContext
 	for i := 0; i < n; i++ {
 		tc := SetupTest(t, "team", 1)
 		tcs = append(tcs, &tc)
+		if i < nPukless {
+			tc.Tp.DisableUpgradePerUserKey = true
+		}
 		fu, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
 		require.NoError(t, err)
 		fus = append(fus, fu)

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -29,7 +29,7 @@ func setupNTestsWithPukless(t *testing.T, n, nPukless int) ([]*kbtest.FakeUser, 
 	for i := 0; i < n; i++ {
 		tc := SetupTest(t, "team", 1)
 		tcs = append(tcs, &tc)
-		if i < nPukless {
+		if i >= n-nPukless {
 			tc.Tp.DisableUpgradePerUserKey = true
 		}
 		fu, err := kbtest.CreateAndSignupFakeUser("team", tc.G)


### PR DESCRIPTION
Creating an implicit team with a pukless user had a bug. In addition to inviting them, it tried to put them in the team, resulting in `team member missing a per-user key (error 284)` from the server. This PR fixes that problem.