### PR TITLE
make onChangeSearchText optional

### DIFF
--- a/shared/search/helpers.js
+++ b/shared/search/helpers.js
@@ -7,7 +7,7 @@ import debounce from 'lodash/debounce'
 const debounceTimeout = 1e3
 
 type OwnProps = {
-  onChangeSearchText: (s: string) => void,
+  onChangeSearchText: ?(s: string) => void,
   search: (term: string, service: Constants.Service) => void,
   selectedService: Constants.Service,
   searchResultIds: Array<Constants.SearchResultId>,
@@ -80,14 +80,14 @@ const onChangeSelectedSearchResultHoc = compose(
         // See whether the current search result term matches the last one submitted
         if (lastSearchTerm === props.searchResultTerm) {
           props.selectedSearchId && props.onAddSelectedUser(props.selectedSearchId)
-          props.onChangeSearchText('')
+          props.onChangeSearchText && props.onChangeSearchText('')
         }
       },
       onMoveSelectUp: ({onMove}) => () => onMove('up'),
       onMoveSelectDown: ({onMove}) => () => onMove('down'),
       onChangeText: (props: OwnPropsWithSearchDebounced) => nextText => {
         lastSearchTerm = nextText
-        props.onChangeSearchText(nextText)
+        props.onChangeSearchText && props.onChangeSearchText(nextText)
         if (nextText === '') {
           // In case we have a search that would fire after our other search
           props._searchDebounced.cancel()


### PR DESCRIPTION
@keybase/react-hackers this fixes the crash in profile if you hit next.
This is another reason to fixup this searchhoc thing. Chat has this as an ownProp but profile does not, and this helper code doesn't make that assumption so it crashes out