### PR TITLE
Implicit team re-add member after reset

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1393,6 +1393,20 @@ func (o LookupOrCreateImplicitTeamArg) DeepCopy() LookupOrCreateImplicitTeamArg 
 	}
 }
 
+type TeamReAddMemberAfterResetArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Name      string `codec:"name" json:"name"`
+	Username  string `codec:"username" json:"username"`
+}
+
+func (o TeamReAddMemberAfterResetArg) DeepCopy() TeamReAddMemberAfterResetArg {
+	return TeamReAddMemberAfterResetArg{
+		SessionID: o.SessionID,
+		Name:      o.Name,
+		Username:  o.Username,
+	}
+}
+
 type LoadTeamPlusApplicationKeysArg struct {
 	SessionID   int             `codec:"sessionID" json:"sessionID"`
 	Id          TeamID          `codec:"id" json:"id"`
@@ -1438,6 +1452,7 @@ type TeamsInterface interface {
 	TeamDelete(context.Context, TeamDeleteArg) error
 	LookupImplicitTeam(context.Context, LookupImplicitTeamArg) (TeamID, error)
 	LookupOrCreateImplicitTeam(context.Context, LookupOrCreateImplicitTeamArg) (TeamID, error)
+	TeamReAddMemberAfterReset(context.Context, TeamReAddMemberAfterResetArg) error
 	// * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.
 	// * If refreshers are non-empty, then force a refresh of the cache if the requirements
 	// * of the refreshers aren't met.
@@ -1737,6 +1752,22 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"teamReAddMemberAfterReset": {
+				MakeArg: func() interface{} {
+					ret := make([]TeamReAddMemberAfterResetArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]TeamReAddMemberAfterResetArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]TeamReAddMemberAfterResetArg)(nil), args)
+						return
+					}
+					err = i.TeamReAddMemberAfterReset(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"loadTeamPlusApplicationKeys": {
 				MakeArg: func() interface{} {
 					ret := make([]LoadTeamPlusApplicationKeysArg, 1)
@@ -1865,6 +1896,11 @@ func (c TeamsClient) LookupImplicitTeam(ctx context.Context, __arg LookupImplici
 
 func (c TeamsClient) LookupOrCreateImplicitTeam(ctx context.Context, __arg LookupOrCreateImplicitTeamArg) (res TeamID, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.lookupOrCreateImplicitTeam", []interface{}{__arg}, &res)
+	return
+}
+
+func (c TeamsClient) TeamReAddMemberAfterReset(ctx context.Context, __arg TeamReAddMemberAfterResetArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamReAddMemberAfterReset", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1395,14 +1395,14 @@ func (o LookupOrCreateImplicitTeamArg) DeepCopy() LookupOrCreateImplicitTeamArg 
 
 type TeamReAddMemberAfterResetArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
-	Name      string `codec:"name" json:"name"`
+	Id        TeamID `codec:"id" json:"id"`
 	Username  string `codec:"username" json:"username"`
 }
 
 func (o TeamReAddMemberAfterResetArg) DeepCopy() TeamReAddMemberAfterResetArg {
 	return TeamReAddMemberAfterResetArg{
 		SessionID: o.SessionID,
-		Name:      o.Name,
+		Id:        o.Id.DeepCopy(),
 		Username:  o.Username,
 	}
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -208,3 +208,7 @@ func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keyba
 	teamID, _, err := teams.LookupOrCreateImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public)
 	return teamID, err
 }
+
+func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybase1.TeamReAddMemberAfterResetArg) error {
+	return teams.ReAddMemberAfterReset(ctx, h.G().ExternalG(), arg.Name, arg.Username)
+}

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -210,5 +210,5 @@ func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keyba
 }
 
 func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybase1.TeamReAddMemberAfterResetArg) error {
-	return teams.ReAddMemberAfterReset(ctx, h.G().ExternalG(), arg.Name, arg.Username)
+	return teams.ReAddMemberAfterReset(ctx, h.G().ExternalG(), arg.Id, arg.Username)
 }

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -446,6 +446,17 @@ func (u *smuUser) addOwner(team smuTeam, w *smuUser) {
 	}
 }
 
+func (u *smuUser) reAddUserAfterReset(team smuTeam, w *smuUser) {
+	cli := u.getTeamsClient()
+	err := cli.TeamReAddMemberAfterReset(context.TODO(), keybase1.TeamReAddMemberAfterResetArg{
+		Name:     team.name,
+		Username: w.username,
+	})
+	if err != nil {
+		u.ctx.t.Fatal(err)
+	}
+}
+
 func (u *smuUser) reset() {
 	err := u.primaryDevice().userClient().ResetUser(context.TODO(), 0)
 	if err != nil {

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -446,10 +446,10 @@ func (u *smuUser) addOwner(team smuTeam, w *smuUser) {
 	}
 }
 
-func (u *smuUser) reAddUserAfterReset(team smuTeam, w *smuUser) {
+func (u *smuUser) reAddUserAfterReset(id keybase1.TeamID, w *smuUser) {
 	cli := u.getTeamsClient()
 	err := cli.TeamReAddMemberAfterReset(context.TODO(), keybase1.TeamReAddMemberAfterResetArg{
-		Name:     team.name,
+		Id:       id,
 		Username: w.username,
 	})
 	if err != nil {

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -446,10 +446,10 @@ func (u *smuUser) addOwner(team smuTeam, w *smuUser) {
 	}
 }
 
-func (u *smuUser) reAddUserAfterReset(id keybase1.TeamID, w *smuUser) {
+func (u *smuUser) reAddUserAfterReset(team smuImplicitTeam, w *smuUser) {
 	cli := u.getTeamsClient()
 	err := cli.TeamReAddMemberAfterReset(context.TODO(), keybase1.TeamReAddMemberAfterResetArg{
-		Id:       id,
+		Id:       team.ID,
 		Username: w.username,
 	})
 	if err != nil {

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -325,6 +325,7 @@ func TestTeamResetNoKeysAdmin(t *testing.T) {
 	ann.addAdmin(team, bob)
 	divDebug(ctx, "Added bob as an admin")
 }
+
 // bob resets, implicit team lookup should still work for ann
 func TestImplicitTeamReset(t *testing.T) {
 	ctx := newSMUContext(t)
@@ -352,7 +353,6 @@ func TestImplicitTeamReset(t *testing.T) {
 	require.Equal(t, iteam.ID, iteam3.ID, "lookup after reset should return same team")
 	divDebug(ctx, "team looked up before reset")
 }
-
 
 func TestImplicitTeamUserReset(t *testing.T) {
 	ctx := newSMUContext(t)

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -389,14 +389,32 @@ func TestImplicitTeamUserReset(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	divDebug(ctx, "Implicit team name is %s\n", team.Name().String())
+	teamName := team.Name().String()
+	divDebug(ctx, "Implicit team name is %s\n", teamName)
 
-	alice.addOwner(smuTeam{name: team.Name().String()}, bob)
+	alice.reAddUserAfterReset(smuTeam{name: teamName}, bob)
 	divDebug(ctx, "Re-Added bob as an owner")
 
-	_, err = teams.Load(context.TODO(), G, keybase1.LoadTeamArg{
-		ID:          teamID,
-		ForceRepoll: true,
-	})
-	require.NoError(t, err)
+	tryLoad := func() {
+		_, err := teams.Load(context.TODO(), G, keybase1.LoadTeamArg{
+			ID:          teamID,
+			ForceRepoll: true,
+		})
+		require.NoError(t, err)
+	}
+
+	tryLoad()
+
+	bob.reset()
+	divDebug(ctx, "Reset bob again (%s) (poor bob)", bob.username)
+
+	bob.loginAfterReset(10)
+	divDebug(ctx, "Bob logged in after reset")
+
+	tryLoad()
+
+	alice.reAddUserAfterReset(smuTeam{name: teamName}, bob)
+	divDebug(ctx, "Re-Added bob as an owner again")
+
+	tryLoad()
 }

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -5,10 +5,13 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	client "github.com/keybase/client/go/client"
 	libkb "github.com/keybase/client/go/libkb"
 	chat1 "github.com/keybase/client/go/protocol/chat1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	teams "github.com/keybase/client/go/teams"
 	"github.com/stretchr/testify/require"
 )
 
@@ -322,7 +325,6 @@ func TestTeamResetNoKeysAdmin(t *testing.T) {
 	ann.addAdmin(team, bob)
 	divDebug(ctx, "Added bob as an admin")
 }
-
 // bob resets, implicit team lookup should still work for ann
 func TestImplicitTeamReset(t *testing.T) {
 	ctx := newSMUContext(t)
@@ -349,4 +351,45 @@ func TestImplicitTeamReset(t *testing.T) {
 	iteam3 := ann.lookupImplicitTeam(false /*create*/, displayName, false /*isPublic*/)
 	require.Equal(t, iteam.ID, iteam3.ID, "lookup after reset should return same team")
 	divDebug(ctx, "team looked up before reset")
+}
+
+
+func TestImplicitTeamUserReset(t *testing.T) {
+	ctx := newSMUContext(t)
+	defer ctx.cleanup()
+
+	alice := ctx.installKeybaseForUser("alice", 10)
+	alice.signup()
+	divDebug(ctx, "Signed up alice (%s)", alice.username)
+	bob := ctx.installKeybaseForUser("bob", 10)
+	bob.signup()
+	divDebug(ctx, "Signed up bob (%s)", bob.username)
+
+	cli := alice.getTeamsClient()
+	arg := keybase1.LookupOrCreateImplicitTeamArg{
+		Name:   fmt.Sprintf("%s,%s", alice.username, bob.username),
+		Public: false,
+	}
+	teamID, err := cli.LookupOrCreateImplicitTeam(context.TODO(), arg)
+	require.NoError(t, err)
+
+	divDebug(ctx, "Created implicit team %s\n", teamID)
+
+	bob.reset()
+	divDebug(ctx, "Reset bob (%s)", bob.username)
+
+	bob.loginAfterReset(10)
+	divDebug(ctx, "Bob logged in after reset")
+
+	G := alice.getPrimaryGlobalContext()
+	teams.NewTeamLoaderAndInstall(G)
+	team, err := teams.Load(context.TODO(), G, keybase1.LoadTeamArg{
+		ID: teamID,
+	})
+	require.NoError(t, err)
+
+	divDebug(ctx, "Implicit team name is %s\n", team.Name().String())
+
+	alice.addOwner(smuTeam{name: team.Name().String()}, bob)
+	divDebug(ctx, "Re-Added bob as an owner")
 }

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -384,7 +384,8 @@ func TestImplicitTeamUserReset(t *testing.T) {
 	G := alice.getPrimaryGlobalContext()
 	teams.NewTeamLoaderAndInstall(G)
 	team, err := teams.Load(context.TODO(), G, keybase1.LoadTeamArg{
-		ID: teamID,
+		ID:          teamID,
+		ForceRepoll: true,
 	})
 	require.NoError(t, err)
 
@@ -392,4 +393,10 @@ func TestImplicitTeamUserReset(t *testing.T) {
 
 	alice.addOwner(smuTeam{name: team.Name().String()}, bob)
 	divDebug(ctx, "Re-Added bob as an owner")
+
+	_, err = teams.Load(context.TODO(), G, keybase1.LoadTeamArg{
+		ID:          teamID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err)
 }

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -410,7 +410,7 @@ func TestImplicitTeamUserReset(t *testing.T) {
 	require.Equal(t, role, keybase1.TeamRole_NONE)
 
 	// Alice re-adds bob.
-	alice.reAddUserAfterReset(smuTeam{name: teamName}, bob)
+	alice.reAddUserAfterReset(teamID, bob)
 	divDebug(ctx, "Re-Added bob as an owner")
 
 	// Check if sigchain still plays back correctly
@@ -436,7 +436,7 @@ func TestImplicitTeamUserReset(t *testing.T) {
 	require.Equal(t, role, keybase1.TeamRole_NONE)
 
 	// Alice re-adds bob, again.
-	alice.reAddUserAfterReset(smuTeam{name: teamName}, bob)
+	alice.reAddUserAfterReset(teamID, bob)
 	divDebug(ctx, "Re-Added bob as an owner again")
 
 	// Check if sigchain plays correctly, at this point there are two

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -249,6 +249,21 @@ func (t TeamSigChainState) GetUsersWithRole(role keybase1.TeamRole) (res []keyba
 	return res, nil
 }
 
+func (t TeamSigChainState) GetLatestUVWithUID(uid keybase1.UID) (res keybase1.UserVersion, err error) {
+	found := false
+	for uv := range t.inner.UserLog {
+		if uv.Uid == uid && (!found || res.EldestSeqno < uv.EldestSeqno) {
+			res = uv
+			found = true
+		}
+	}
+
+	if !found {
+		return keybase1.UserVersion{}, errors.New("did not find user with given uid")
+	}
+	return res.DeepCopy(), nil
+}
+
 func (t TeamSigChainState) GetLatestPerTeamKey() (keybase1.PerTeamKey, error) {
 	res, ok := t.inner.PerTeamKeys[keybase1.PerTeamKeyGeneration(len(t.inner.PerTeamKeys))]
 	if !ok {

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -252,7 +252,7 @@ func (t TeamSigChainState) GetUsersWithRole(role keybase1.TeamRole) (res []keyba
 func (t TeamSigChainState) GetLatestUVWithUID(uid keybase1.UID) (res keybase1.UserVersion, err error) {
 	found := false
 	for uv := range t.inner.UserLog {
-		if uv.Uid == uid && (!found || res.EldestSeqno < uv.EldestSeqno) {
+		if uv.Uid == uid && t.getUserRole(uv) != keybase1.TeamRole_NONE && (!found || res.EldestSeqno < uv.EldestSeqno) {
 			res = uv
 			found = true
 		}

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -48,6 +48,14 @@ func GetForTeamManagementByStringName(ctx context.Context, g *libkb.GlobalContex
 	return team, fixupTeamGetError(ctx, g, err, name)
 }
 
+func GetForTeamManagementByTeamID(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID, needAdmin bool) (*Team, error) {
+	return Load(ctx, g, keybase1.LoadTeamArg{
+		ID:          id,
+		ForceRepoll: true,
+		NeedAdmin:   needAdmin,
+	})
+}
+
 // Get a team with no stubbed links if we are an admin. Use this instead of NeedAdmin when you don't
 // know whether you are an admin. This always causes roundtrips. Doesn't work for implicit admins.
 func GetMaybeAdminByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*Team, error) {

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -77,7 +77,7 @@ func (m *memberSet) loadMembers(ctx context.Context, g *libkb.GlobalContext, req
 }
 
 func (m *memberSet) loadGroup(ctx context.Context, g *libkb.GlobalContext, group []keybase1.UserVersion, storeRecipient, force bool) ([]member, error) {
-	members := []member{}
+	var members []member
 	for _, uv := range group {
 		mem, err := m.loadMember(ctx, g, uv, storeRecipient, force)
 		if _, reset := err.(libkb.AccountResetError); reset {

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -77,20 +77,16 @@ func (m *memberSet) loadMembers(ctx context.Context, g *libkb.GlobalContext, req
 }
 
 func (m *memberSet) loadGroup(ctx context.Context, g *libkb.GlobalContext, group []keybase1.UserVersion, storeRecipient, force bool) ([]member, error) {
-	members := make([]member, len(group))
-	var err error
-	for i, uv := range group {
-		members[i], err = m.loadMember(ctx, g, uv, storeRecipient, force)
+	members := []member{}
+	for _, uv := range group {
+		mem, err := m.loadMember(ctx, g, uv, storeRecipient, force)
 		if _, reset := err.(libkb.AccountResetError); reset {
 			if !storeRecipient {
 				// If caller doesn't care about keys, it probably expects
 				// reset users to be passed through as well. This is used
 				// in readding reset users in impteams.
-				members[i] = member{version: uv}
+				members = append(members, member{version: uv})
 			} else {
-				// TODO: This has a bug where it will leave empty member{}
-				// in the member list. If we are on our way of creating
-				// JSON payload, it will contain { Uid: "", EldestSeqno: 0 }.
 				g.Log.CDebugf(ctx, "Skipping reset account %s in team load", uv.String())
 			}
 			continue
@@ -98,6 +94,7 @@ func (m *memberSet) loadGroup(ctx context.Context, g *libkb.GlobalContext, group
 		if err != nil {
 			return nil, err
 		}
+		members = append(members, mem)
 	}
 	return members, nil
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -479,8 +479,8 @@ func GetRootID(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) 
 	return team.Name.RootAncestorName().ToTeamID(), nil
 }
 
-func ReAddMemberAfterReset(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
+func ReAddMemberAfterReset(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, username string) error {
+	t, err := GetForTeamManagementByTeamID(ctx, g, teamID, true)
 	if err != nil {
 		return err
 	}
@@ -495,7 +495,7 @@ func ReAddMemberAfterReset(ctx context.Context, g *libkb.GlobalContext, teamname
 	}
 
 	if existingUV.EldestSeqno == uv.EldestSeqno {
-		return fmt.Errorf("No need to ReAdd member, user has not reset")
+		return fmt.Errorf("No need to re-add member, user has not reset")
 	} else if existingUV.EldestSeqno > uv.EldestSeqno {
 		return fmt.Errorf("EldestSeqno going backwards?")
 	}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -365,7 +365,7 @@ func (t *Team) getDowngradedUsers(ms *memberSet) (uids []keybase1.UID, err error
 	for _, member := range ms.None {
 		// It's not a downgrade if we are removing a reset user.
 		role, err := t.chain().GetUserRole(member.version)
-		if err != nil && role != keybase1.TeamRole_NONE {
+		if err == nil && role != keybase1.TeamRole_NONE {
 			uids = append(uids, member.version.Uid)
 		}
 	}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -779,7 +779,7 @@ func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamCha
 	section.PerTeamKey = perTeamKeySection
 
 	section.CompletedInvites = req.CompletedInvites
-
+	section.Implicit = t.chain().IsImplicit()
 	return section, secretBoxes, implicitAdminBoxes, memSet, nil
 }
 

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -364,7 +364,8 @@ func (t *Team) getDowngradedUsers(ms *memberSet) (uids []keybase1.UID, err error
 
 	for _, member := range ms.None {
 		// It's not a downgrade if we are removing a reset user.
-		if role, err := t.chain().GetUserRole(member.version); err != nil && role != keybase1.TeamRole_NONE {
+		role, err := t.chain().GetUserRole(member.version)
+		if err != nil && role != keybase1.TeamRole_NONE {
 			uids = append(uids, member.version.Uid)
 		}
 	}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -366,9 +366,15 @@ func (t *Team) getDowngradedUsers(ctx context.Context, ms *memberSet) (uids []ke
 		// Load member first to check if their eldest_seqno has not changed.
 		// If it did, the member was nuked and we do not need to lease.
 		_, _, err := loadMember(ctx, t.G(), member.version, true)
-		if err == nil {
-			uids = append(uids, member.version.Uid)
+		if err != nil {
+			if _, reset := err.(libkb.AccountResetError); reset {
+				continue
+			} else {
+				return nil, err
+			}
 		}
+
+		uids = append(uids, member.version.Uid)
 	}
 
 	for _, member := range ms.nonAdmins() {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -440,6 +440,8 @@ protocol teams {
   TeamID lookupImplicitTeam(string name, boolean public);
   TeamID lookupOrCreateImplicitTeam(string name, boolean public);
 
+  void teamReAddMemberAfterReset(int sessionID, string name, string username);
+
   /**
    * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.
    * If refreshers are non-empty, then force a refresh of the cache if the requirements

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -440,7 +440,7 @@ protocol teams {
   TeamID lookupImplicitTeam(string name, boolean public);
   TeamID lookupOrCreateImplicitTeam(string name, boolean public);
 
-  void teamReAddMemberAfterReset(int sessionID, string name, string username);
+  void teamReAddMemberAfterReset(int sessionID, TeamID id, string username);
 
   /**
    * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5834,7 +5834,7 @@ export type teamsTeamListRpcParam = Exact<{
 }>
 
 export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
-  name: string,
+  id: TeamID,
   username: string
 }>
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2323,6 +2323,14 @@ export function teamsTeamListRpcPromise (request: (requestCommon & {callback?: ?
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamList', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamReAddMemberAfterResetRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamReAddMemberAfterResetRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamReAddMemberAfterReset', request)
+}
+
+export function teamsTeamReAddMemberAfterResetRpcPromise (request: (requestCommon & requestErrorCallback & {param: teamsTeamReAddMemberAfterResetRpcParam})): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamReAddMemberAfterReset', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamRemoveMemberRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamRemoveMemberRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamRemoveMember', request)
 }
@@ -5823,6 +5831,11 @@ export type teamsTeamLeaveRpcParam = Exact<{
 export type teamsTeamListRpcParam = Exact<{
   userAssertion: string,
   all: boolean
+}>
+
+export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
+  name: string,
+  username: string
 }>
 
 export type teamsTeamRemoveMemberRpcParam = Exact<{

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1367,6 +1367,23 @@
       ],
       "response": "TeamID"
     },
+    "teamReAddMemberAfterReset": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        }
+      ],
+      "response": null
+    },
     "loadTeamPlusApplicationKeys": {
       "request": [
         {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1374,8 +1374,8 @@
           "type": "int"
         },
         {
-          "name": "name",
-          "type": "string"
+          "name": "id",
+          "type": "TeamID"
         },
         {
           "name": "username",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5834,7 +5834,7 @@ export type teamsTeamListRpcParam = Exact<{
 }>
 
 export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
-  name: string,
+  id: TeamID,
   username: string
 }>
 

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2323,6 +2323,14 @@ export function teamsTeamListRpcPromise (request: (requestCommon & {callback?: ?
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamList', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamReAddMemberAfterResetRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamReAddMemberAfterResetRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamReAddMemberAfterReset', request)
+}
+
+export function teamsTeamReAddMemberAfterResetRpcPromise (request: (requestCommon & requestErrorCallback & {param: teamsTeamReAddMemberAfterResetRpcParam})): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamReAddMemberAfterReset', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamRemoveMemberRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamRemoveMemberRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamRemoveMember', request)
 }
@@ -5823,6 +5831,11 @@ export type teamsTeamLeaveRpcParam = Exact<{
 export type teamsTeamListRpcParam = Exact<{
   userAssertion: string,
   all: boolean
+}>
+
+export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
+  name: string,
+  username: string
 }>
 
 export type teamsTeamRemoveMemberRpcParam = Exact<{


### PR DESCRIPTION
Added a test and changed change membership sig generation to include `is_implicit` for implicit teams.