### PR TITLE
Finish pukless iteam test

### DIFF
--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -81,10 +81,13 @@ func TestImplicitPukless(t *testing.T) {
 	teamID, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
 	require.NoError(t, err)
 
-	// TODO enable this after fixing lookup
-	// teamID2, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
-	// require.NoError(t, err)
-	// require.Equal(t, teamID, teamID2)
+	teamID2, _, err := LookupImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
+	require.NoError(t, err)
+	require.Equal(t, teamID, teamID2)
+
+	teamID2, _, err = LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
+	require.NoError(t, err)
+	require.Equal(t, teamID, teamID2)
 
 	t.Logf("U0 loads the team")
 	team, err := Load(context.Background(), tcs[0].G, keybase1.LoadTeamArg{ID: teamID})


### PR DESCRIPTION
This needs a server fix to work. The problem is that the server creates the team with the wrong display name. It creates it as `6c861b46abef6784f8370e5901683019@keybase,team_66602e8e2a` in other words `<uid>@keybase,username`. But it should be `team_66602e8e2a,team_ae7f2e0b2a`.
