### PR TITLE
Fix iteam readers

### DIFF
--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -612,7 +612,7 @@ func parseImplicitTeamPart(ctx AssertionContext, s string) (typ string, name str
 			return "keybase", strings.ToLower(s), nil
 		}
 
-		return "", "", fmt.Errorf("Parsed part as keybase username, but invalid username")
+		return "", "", fmt.Errorf("Parsed part as keybase username, but invalid username: %s", s)
 	}
 	assertion, err := ParseAssertionURL(ctx, s, true)
 	if err != nil {

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -310,6 +310,7 @@ func testIdentifyLite(t *testing.T) {
 	t.Logf("make an implicit team")
 	iTeamCreateName := strings.Join([]string{tt.users[0].username, "bob@github"}, ",")
 	iTeamID, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamCreateName, false /*isPublic*/)
+	require.NoError(t, err)
 	iTeamImpName := getTeamName(iTeamID)
 	require.True(t, iTeamImpName.IsImplicit())
 	require.NoError(t, err)

--- a/go/teams/common_test.go
+++ b/go/teams/common_test.go
@@ -6,6 +6,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
@@ -34,4 +35,38 @@ func createTeamName(t *testing.T, root string, parts ...string) keybase1.TeamNam
 		require.NoError(t, err)
 	}
 	return name
+}
+
+// Create n TestContexts with logged in users
+// Returns (FakeUsers, TestContexts, CleanupFunction)
+func setupNTests(t *testing.T, n int) ([]*kbtest.FakeUser, []*libkb.TestContext, func()) {
+	return setupNTestsWithPukless(t, n, 0)
+}
+
+// nPukless is how many users start out with no PUK.
+// Those users appear at the end of the list
+func setupNTestsWithPukless(t *testing.T, n, nPukless int) ([]*kbtest.FakeUser, []*libkb.TestContext, func()) {
+	require.True(t, n > 0, "must create at least 1 tc")
+	require.True(t, n >= nPukless, "more pukless users than total users requested")
+	var fus []*kbtest.FakeUser
+	var tcs []*libkb.TestContext
+	for i := 0; i < n; i++ {
+		tc := SetupTest(t, "team", 1)
+		tcs = append(tcs, &tc)
+		if i >= n-nPukless {
+			tc.Tp.DisableUpgradePerUserKey = true
+		}
+		fu, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+		require.NoError(t, err)
+		fus = append(fus, fu)
+	}
+	cleanup := func() {
+		for _, tc := range tcs {
+			tc.Cleanup()
+		}
+	}
+	for i, fu := range fus {
+		t.Logf("U%d: %v %v", i, fu.Username, fu.GetUserVersion())
+	}
+	return fus, tcs, cleanup
 }

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -13,10 +13,6 @@ import (
 func CreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, impTeam keybase1.ImplicitTeamDisplayName) (res keybase1.TeamID, err error) {
 	defer g.CTrace(ctx, "CreateImplicitTeam", func() error { return err })()
 
-	// TODO Creating an implicit team doesn't yet support readers.
-	//      They are ignored.
-	//      Coming up in CORE-5877
-
 	name, err := NewImplicitTeamName()
 	if err != nil {
 		return res, err
@@ -48,9 +44,17 @@ func CreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, impTeam key
 	if err != nil {
 		return res, err
 	}
+	readerUPAKs, err := loadUsernameList(impTeam.Readers.KeybaseUsers)
+	if err != nil {
+		return res, err
+	}
 
 	var owners []SCTeamMember
+	var readers []SCTeamMember
 	var ownerInvites []SCTeamInvite
+	var readerInvites []SCTeamInvite
+
+	// Form secret boxes and make invites for KB users with no PUKs
 	secretboxRecipients := make(map[keybase1.UserVersion]keybase1.PerUserKey)
 
 	// Form secret boxes for KB users with PUKs, and invites for those without
@@ -69,6 +73,34 @@ func CreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, impTeam key
 			owners = append(owners, SCTeamMember(uv))
 		}
 	}
+	for _, upak := range readerUPAKs {
+		uv := upak.ToUserVersion()
+		puk := upak.GetLatestPerUserKey()
+		if puk == nil {
+			// Add this person as an invite if they do not have a puk
+			readerInvites = append(readerInvites, SCTeamInvite{
+				Type: "keybase",
+				Name: uv.PercentForm(),
+				ID:   NewInviteID(),
+			})
+		} else {
+			secretboxRecipients[uv] = *puk
+			readers = append(readers, SCTeamMember(uv))
+		}
+	}
+
+	members := SCTeamMembers{
+		Owners:  &[]SCTeamMember{},
+		Admins:  &[]SCTeamMember{},
+		Writers: &[]SCTeamMember{},
+		Readers: &[]SCTeamMember{},
+	}
+	if len(owners) > 0 {
+		members.Owners = &owners
+	}
+	if len(readers) > 0 {
+		members.Readers = &readers
+	}
 
 	// Add invites for assertions
 	for _, assertion := range impTeam.Writers.UnresolvedUsers {
@@ -78,22 +110,33 @@ func CreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, impTeam key
 			ID:   NewInviteID(),
 		})
 	}
-	var teamInvites *SCTeamInvites
+	for _, assertion := range impTeam.Readers.UnresolvedUsers {
+		readerInvites = append(readerInvites, SCTeamInvite{
+			Type: string(assertion.Service),
+			Name: assertion.User,
+			ID:   NewInviteID(),
+		})
+	}
+
+	invites := &SCTeamInvites{
+		Owners:  nil,
+		Admins:  nil,
+		Writers: nil,
+		Readers: nil,
+	}
 	if len(ownerInvites) > 0 {
-		teamInvites = &SCTeamInvites{
-			Owners:  &ownerInvites,
-			Admins:  &[]SCTeamInvite{},
-			Writers: &[]SCTeamInvite{},
-			Readers: &[]SCTeamInvite{},
-		}
+		invites.Owners = &ownerInvites
+	}
+	if len(readerInvites) > 0 {
+		invites.Readers = &readerInvites
 	}
 
 	// Post the team
-	return teamID, makeSigAndPostRootTeam(ctx, g, me, owners, teamInvites, secretboxRecipients, name.String(),
+	return teamID, makeSigAndPostRootTeam(ctx, g, me, members, invites, secretboxRecipients, name.String(),
 		teamID, impTeam.IsPublic, true)
 }
 
-func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me *libkb.User, users []SCTeamMember,
+func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me *libkb.User, members SCTeamMembers,
 	invites *SCTeamInvites, secretboxRecipients map[keybase1.UserVersion]keybase1.PerUserKey, name string,
 	teamID keybase1.TeamID, public, implicit bool) error {
 
@@ -127,7 +170,7 @@ func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me *lib
 	}
 
 	g.Log.CDebugf(ctx, "makeSigAndPostRootTeam make sigs")
-	teamSection, err := makeRootTeamSection(name, teamID, users, invites, perTeamSigningKey.GetKID(),
+	teamSection, err := makeRootTeamSection(name, teamID, members, invites, perTeamSigningKey.GetKID(),
 		perTeamEncryptionKey.GetKID(), public, implicit)
 	if err != nil {
 		return err
@@ -218,7 +261,14 @@ func CreateRootTeam(ctx context.Context, g *libkb.GlobalContext, name string) (e
 		me.ToUserVersion(): *ownerLatest,
 	}
 
-	return makeSigAndPostRootTeam(ctx, g, me, []SCTeamMember{SCTeamMember(me.ToUserVersion())}, nil,
+	members := SCTeamMembers{
+		Owners:  &[]SCTeamMember{SCTeamMember(me.ToUserVersion())},
+		Admins:  &[]SCTeamMember{},
+		Writers: &[]SCTeamMember{},
+		Readers: &[]SCTeamMember{},
+	}
+
+	return makeSigAndPostRootTeam(ctx, g, me, members, nil,
 		secretboxRecipients, name, RootTeamIDFromNameString(name), false, false)
 }
 
@@ -295,7 +345,7 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 	return &subteamID, nil
 }
 
-func makeRootTeamSection(teamName string, teamID keybase1.TeamID, owners []SCTeamMember, invites *SCTeamInvites,
+func makeRootTeamSection(teamName string, teamID keybase1.TeamID, members SCTeamMembers, invites *SCTeamInvites,
 	perTeamSigningKID keybase1.KID, perTeamEncryptionKID keybase1.KID, public bool, implicit bool) (SCTeamSection, error) {
 	teamSection := SCTeamSection{
 		Name:     (*SCTeamName)(&teamName),
@@ -307,12 +357,7 @@ func makeRootTeamSection(teamName string, teamID keybase1.TeamID, owners []SCTea
 			SigKID:     perTeamSigningKID,
 			EncKID:     perTeamEncryptionKID,
 		},
-		Members: &SCTeamMembers{
-			Owners:  &owners,
-			Admins:  &[]SCTeamMember{},
-			Writers: &[]SCTeamMember{},
-			Readers: &[]SCTeamMember{},
-		},
+		Members: &members,
 		Invites: invites,
 	}
 

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -28,8 +28,8 @@ func (i *implicitTeam) GetAppStatus() *libkb.AppStatus {
 	return &i.Status
 }
 
-func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, name string, public bool) (res keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
-	impTeamName, err = libkb.ParseImplicitTeamDisplayName(g.MakeAssertionContext(), name, public /*isPublic*/)
+func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (res keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
+	impTeamName, err = libkb.ParseImplicitTeamDisplayName(g.MakeAssertionContext(), displayName, public /*isPublic*/)
 	if err != nil {
 		return res, impTeamName, err
 	}
@@ -42,14 +42,14 @@ func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, name string
 	arg.NetContext = ctx
 	arg.SessionType = libkb.APISessionTypeREQUIRED
 	arg.Args = libkb.HTTPArgs{
-		"display_name": libkb.S{Val: name},
+		"display_name": libkb.S{Val: displayName},
 		"public":       libkb.B{Val: public},
 	}
 	var imp implicitTeam
 	if err = g.API.GetDecode(arg, &imp); err != nil {
 		if aerr, ok := err.(libkb.AppStatusError); ok &&
 			keybase1.StatusCode(aerr.Code) == keybase1.StatusCode_SCTeamReadError {
-			return res, impTeamName, NewTeamDoesNotExistError(name)
+			return res, impTeamName, NewTeamDoesNotExistError(displayName)
 		}
 		return res, impTeamName, err
 	}
@@ -77,12 +77,12 @@ func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, name string
 	return imp.TeamID, impTeamName, nil
 }
 
-func LookupOrCreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, name string, public bool) (res keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
-	res, impTeamName, err = LookupImplicitTeam(ctx, g, name, public)
+func LookupOrCreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (res keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
+	res, impTeamName, err = LookupImplicitTeam(ctx, g, displayName, public)
 	if err != nil {
 		if _, ok := err.(TeamDoesNotExistError); ok {
 			// If the team does not exist, then let's create it
-			impTeamName, err = libkb.ParseImplicitTeamDisplayName(g.MakeAssertionContext(), name, public /*isPublic*/)
+			impTeamName, err = libkb.ParseImplicitTeamDisplayName(g.MakeAssertionContext(), displayName, public /*isPublic*/)
 			if err != nil {
 				return res, impTeamName, err
 			}

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -102,30 +102,6 @@ func TestImplicitPukless(t *testing.T) {
 	require.Len(t, team.chain().inner.ActiveInvites, 1, "number of invites")
 }
 
-func TestImplicitTeamTmp(t *testing.T) {
-	fus, tcs, cleanup := setupNTests(t, 2)
-	defer cleanup()
-
-	displayName := "" + fus[0].Username + "#" + fus[1].Username
-	t.Logf("U0 creates an implicit team: %v", displayName)
-	teamID, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*public*/)
-	require.NoError(t, err)
-
-	t.Logf("U1 looks up the team (softly)")
-	teamID2, _, err := LookupImplicitTeam(context.Background(), tcs[0].G, displayName, false /*public*/)
-	require.NoError(t, err)
-	require.Equal(t, teamID, teamID2, "users should lookup the same team ID")
-
-	t.Logf("U1 looks up the team")
-	teamID2, _, err = LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*public*/)
-	require.NoError(t, err)
-	require.Equal(t, teamID, teamID2, "users should lookup the same team ID")
-
-	t.Logf("U1 loads the team")
-	_, err = Load(context.Background(), tcs[1].G, keybase1.LoadTeamArg{ID: teamID2})
-	require.NoError(t, err)
-}
-
 // Test loading an implicit team as a #reader.
 func TestImplicitTeamReader(t *testing.T) {
 	fus, tcs, cleanup := setupNTests(t, 2)

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -13,40 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Create n TestContexts with logged in users
-// Returns (FakeUsers, TestContexts, CleanupFunction)
-func setupNTests(t *testing.T, n int) ([]*kbtest.FakeUser, []*libkb.TestContext, func()) {
-	return setupNTestsWithPukless(t, n, 0)
-}
-
-// nPukless is how many users start out with no PUK.
-// Those users appear at the end of the list
-func setupNTestsWithPukless(t *testing.T, n, nPukless int) ([]*kbtest.FakeUser, []*libkb.TestContext, func()) {
-	require.True(t, n > 0, "must create at least 1 tc")
-	require.True(t, n >= nPukless, "more pukless users than total users requested")
-	var fus []*kbtest.FakeUser
-	var tcs []*libkb.TestContext
-	for i := 0; i < n; i++ {
-		tc := SetupTest(t, "team", 1)
-		tcs = append(tcs, &tc)
-		if i >= n-nPukless {
-			tc.Tp.DisableUpgradePerUserKey = true
-		}
-		fu, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
-		require.NoError(t, err)
-		fus = append(fus, fu)
-	}
-	cleanup := func() {
-		for _, tc := range tcs {
-			tc.Cleanup()
-		}
-	}
-	for i, fu := range fus {
-		t.Logf("U%d: %v %v", i, fu.Username, fu.GetUserVersion())
-	}
-	return fus, tcs, cleanup
-}
-
 func TestLoaderBasic(t *testing.T) {
 	tc := SetupTest(t, "team", 1)
 	defer tc.Cleanup()


### PR DESCRIPTION
The team root sig maker now includes readers. It had been dropping them.