### PR TITLE
Remove unused rpcs

### DIFF
--- a/go/client/cmd_stress.go
+++ b/go/client/cmd_stress.go
@@ -163,7 +163,7 @@ func (c *CmdStress) idSelf() {
 		return
 	}
 	icli := keybase1.IdentifyClient{Cli: cli}
-	_, err = icli.Identify(context.TODO(), keybase1.IdentifyArg{})
+	_, err = icli.Identify2(context.TODO(), keybase1.Identify2Arg{})
 	if err != nil {
 		G.Log.Warning("id self error: %s", err)
 	}
@@ -176,7 +176,7 @@ func (c *CmdStress) idAlice() {
 		return
 	}
 	icli := keybase1.IdentifyClient{Cli: cli}
-	_, err = icli.Identify(context.TODO(), keybase1.IdentifyArg{UserAssertion: "t_alice"})
+	_, err = icli.Identify2(context.TODO(), keybase1.Identify2Arg{UserAssertion: "t_alice"})
 	if err != nil {
 		G.Log.Warning("id t_alice error: %s", err)
 	}

--- a/go/protocol/keybase1/identify.go
+++ b/go/protocol/keybase1/identify.go
@@ -84,26 +84,6 @@ func (o IdentifyLiteRes) DeepCopy() IdentifyLiteRes {
 	}
 }
 
-type ResolveArg struct {
-	Assertion string `codec:"assertion" json:"assertion"`
-}
-
-func (o ResolveArg) DeepCopy() ResolveArg {
-	return ResolveArg{
-		Assertion: o.Assertion,
-	}
-}
-
-type Resolve2Arg struct {
-	Assertion string `codec:"assertion" json:"assertion"`
-}
-
-func (o Resolve2Arg) DeepCopy() Resolve2Arg {
-	return Resolve2Arg{
-		Assertion: o.Assertion,
-	}
-}
-
 type Resolve3Arg struct {
 	Assertion string `codec:"assertion" json:"assertion"`
 }
@@ -207,11 +187,6 @@ func (o IdentifyLiteArg) DeepCopy() IdentifyLiteArg {
 }
 
 type IdentifyInterface interface {
-	// Resolve an assertion to a UID. On failure, resolves to an empty UID and returns
-	// an error.
-	Resolve(context.Context, string) (UID, error)
-	// Resolve an assertion to a (UID,username). On failure, returns an error. Doesn't work for teams.
-	Resolve2(context.Context, string) (User, error)
 	// Resolve an assertion to a (UID,username) or (TeamID,teamname). On failure, returns an error.
 	Resolve3(context.Context, string) (UserOrTeamLite, error)
 	// DEPRECATED:  use identify2
@@ -227,38 +202,6 @@ func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
 	return rpc.Protocol{
 		Name: "keybase.1.identify",
 		Methods: map[string]rpc.ServeHandlerDescription{
-			"Resolve": {
-				MakeArg: func() interface{} {
-					ret := make([]ResolveArg, 1)
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]ResolveArg)
-					if !ok {
-						err = rpc.NewTypeError((*[]ResolveArg)(nil), args)
-						return
-					}
-					ret, err = i.Resolve(ctx, (*typedArgs)[0].Assertion)
-					return
-				},
-				MethodType: rpc.MethodCall,
-			},
-			"Resolve2": {
-				MakeArg: func() interface{} {
-					ret := make([]Resolve2Arg, 1)
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]Resolve2Arg)
-					if !ok {
-						err = rpc.NewTypeError((*[]Resolve2Arg)(nil), args)
-						return
-					}
-					ret, err = i.Resolve2(ctx, (*typedArgs)[0].Assertion)
-					return
-				},
-				MethodType: rpc.MethodCall,
-			},
 			"Resolve3": {
 				MakeArg: func() interface{} {
 					ret := make([]Resolve3Arg, 1)
@@ -329,21 +272,6 @@ func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
 
 type IdentifyClient struct {
 	Cli rpc.GenericClient
-}
-
-// Resolve an assertion to a UID. On failure, resolves to an empty UID and returns
-// an error.
-func (c IdentifyClient) Resolve(ctx context.Context, assertion string) (res UID, err error) {
-	__arg := ResolveArg{Assertion: assertion}
-	err = c.Cli.Call(ctx, "keybase.1.identify.Resolve", []interface{}{__arg}, &res)
-	return
-}
-
-// Resolve an assertion to a (UID,username). On failure, returns an error. Doesn't work for teams.
-func (c IdentifyClient) Resolve2(ctx context.Context, assertion string) (res User, err error) {
-	__arg := Resolve2Arg{Assertion: assertion}
-	err = c.Cli.Call(ctx, "keybase.1.identify.Resolve2", []interface{}{__arg}, &res)
-	return
 }
 
 // Resolve an assertion to a (UID,username) or (TeamID,teamname). On failure, returns an error.

--- a/go/protocol/keybase1/identify_common.go
+++ b/go/protocol/keybase1/identify_common.go
@@ -281,35 +281,6 @@ func (o IdentifyOutcome) DeepCopy() IdentifyOutcome {
 	}
 }
 
-type IdentifyRes struct {
-	User       *User           `codec:"user,omitempty" json:"user,omitempty"`
-	PublicKeys []PublicKey     `codec:"publicKeys" json:"publicKeys"`
-	Outcome    IdentifyOutcome `codec:"outcome" json:"outcome"`
-	TrackToken TrackToken      `codec:"trackToken" json:"trackToken"`
-}
-
-func (o IdentifyRes) DeepCopy() IdentifyRes {
-	return IdentifyRes{
-		User: (func(x *User) *User {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.User),
-		PublicKeys: (func(x []PublicKey) []PublicKey {
-			var ret []PublicKey
-			for _, v := range x {
-				vCopy := v.DeepCopy()
-				ret = append(ret, vCopy)
-			}
-			return ret
-		})(o.PublicKeys),
-		Outcome:    o.Outcome.DeepCopy(),
-		TrackToken: o.TrackToken.DeepCopy(),
-	}
-}
-
 type RemoteProof struct {
 	ProofType     ProofType `codec:"proofType" json:"proofType"`
 	Key           string    `codec:"key" json:"key"`

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -132,28 +132,6 @@ func (h *IdentifyHandler) identifyLiteUser(netCtx context.Context, arg keybase1.
 	return res, err
 }
 
-func (h *IdentifyHandler) Resolve(ctx context.Context, arg string) (uid keybase1.UID, err error) {
-	ctx = libkb.WithLogTag(ctx, "RSLV")
-	defer h.G().CTrace(ctx, fmt.Sprintf("IdentifyHandler#Resolve(%s)", arg), func() error { return err })()
-	rres := h.G().Resolver.ResolveFullExpression(ctx, arg)
-	return rres.GetUID(), rres.GetError()
-}
-
-func (h *IdentifyHandler) Resolve2(ctx context.Context, arg string) (u keybase1.User, err error) {
-	ctx = libkb.WithLogTag(ctx, "RSLV")
-	defer h.G().CTrace(ctx, fmt.Sprintf("IdentifyHandler#Resolve2(%s)", arg), func() error { return err })()
-	res := h.G().Resolver.ResolveFullExpressionNeedUsername(ctx, arg)
-	err = res.GetError()
-	if err != nil {
-		return keybase1.User{}, err
-	}
-	ret := res.User()
-	if ret.Uid.IsNil() {
-		return keybase1.User{}, libkb.UserNotFoundError{Msg: "resolve2 does not work with teams"}
-	}
-	return res.User(), nil
-}
-
 func (h *IdentifyHandler) Resolve3(ctx context.Context, arg string) (u keybase1.UserOrTeamLite, err error) {
 	ctx = libkb.WithLogTag(ctx, "RSLV")
 	defer h.G().CTrace(ctx, fmt.Sprintf("IdentifyHandler#Resolve3(%s)", arg), func() error { return err })()

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -4,7 +4,6 @@
 package service
 
 import (
-	"errors"
 	"fmt"
 
 	"golang.org/x/net/context"
@@ -146,11 +145,6 @@ func (h *IdentifyHandler) resolveUserOrTeam(ctx context.Context, arg string) (u 
 		return u, err
 	}
 	return res.UserOrTeam(), nil
-}
-
-func (h *IdentifyHandler) Identify(_ context.Context, arg keybase1.IdentifyArg) (res keybase1.IdentifyRes, err error) {
-	h.G().Log.Info("deprecated keybase1.Identify v1 called")
-	return res, errors.New("keybase1.Identify no longer supported")
 }
 
 func (u *RemoteIdentifyUI) newContext() (context.Context, func()) {

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestRPCs(t *testing.T) {
-	tc := setupTest(t, "resolve2")
+	tc := setupTest(t, "rpcs")
 	tc2 := cloneContext(tc)
 
 	libkb.G.LocalDb = nil
@@ -41,7 +41,6 @@ func TestRPCs(t *testing.T) {
 	<-startCh
 
 	// Add test RPC methods here.
-	testIdentifyResolve2(t, tc2.G)
 	testIdentifyResolve3(t, tc2.G)
 	testCheckInvitationCode(t, tc2.G)
 	testLoadAllPublicKeysUnverified(t, tc2.G)
@@ -61,58 +60,11 @@ func TestRPCs(t *testing.T) {
 	}
 }
 
-func testIdentifyResolve2(t *testing.T, g *libkb.GlobalContext) {
-
-	cli, err := client.GetIdentifyClient(g)
-	if err != nil {
-		t.Fatalf("failed to get new identifyclient: %v", err)
-	}
-
-	if _, err := cli.Resolve(context.TODO(), "uid:eb72f49f2dde6429e5d78003dae0c919"); err != nil {
-		t.Fatalf("Resolve failed: %v\n", err)
-	}
-
-	// We don't want to hit the cache, since the previous lookup never hit the
-	// server.  For Resolve2, we have to, since we need a username.  So test that
-	// here.
-	if res, err := cli.Resolve2(context.TODO(), "uid:eb72f49f2dde6429e5d78003dae0c919"); err != nil {
-		t.Fatalf("Resolve failed: %v\n", err)
-	} else if res.Username != "t_tracy" {
-		t.Fatalf("Wrong username: %s != 't_tracy", res.Username)
-	}
-
-	if res, err := cli.Resolve2(context.TODO(), "t_tracy@rooter"); err != nil {
-		t.Fatalf("Resolve2 failed: %v\n", err)
-	} else if res.Username != "t_tracy" {
-		t.Fatalf("Wrong name: %s != 't_tracy", res.Username)
-	} else if !res.Uid.Equal(keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")) {
-		t.Fatalf("Wrong uid for tracy: %s\n", res.Uid)
-	}
-
-	if _, err := cli.Resolve2(context.TODO(), "foobag@rooter"); err == nil {
-		t.Fatalf("expected an error on a bad resolve, but got none")
-	} else if _, ok := err.(libkb.ResolutionError); !ok {
-		t.Fatalf("Wrong error: wanted type %T but got (%v, %T)", libkb.ResolutionError{}, err, err)
-	}
-
-	if res, err := cli.Resolve2(context.TODO(), "t_tracy"); err != nil {
-		t.Fatalf("Resolve2 failed: %v\n", err)
-	} else if res.Username != "t_tracy" {
-		t.Fatalf("Wrong name: %s != 't_tracy", res.Username)
-	} else if !res.Uid.Equal(keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")) {
-		t.Fatalf("Wrong uid for tracy: %s\n", res.Uid)
-	}
-}
-
 func testIdentifyResolve3(t *testing.T, g *libkb.GlobalContext) {
 
 	cli, err := client.GetIdentifyClient(g)
 	if err != nil {
 		t.Fatalf("failed to get new identifyclient: %v", err)
-	}
-
-	if _, err := cli.Resolve(context.TODO(), "uid:eb72f49f2dde6429e5d78003dae0c919"); err != nil {
-		t.Fatalf("Resolve failed: %v\n", err)
 	}
 
 	// We don't want to hit the cache, since the previous lookup never hit the

--- a/protocol/avdl/keybase1/identify.avdl
+++ b/protocol/avdl/keybase1/identify.avdl
@@ -6,19 +6,6 @@ protocol identify {
 
 
   /**
-    Resolve an assertion to a UID. On failure, resolves to an empty UID and returns
-    an error.
-   */
-  @lint("ignore")
-  UID Resolve(string assertion);
-
-  /**
-    Resolve an assertion to a (UID,username). On failure, returns an error. Doesn't work for teams.
-   */
-  @lint("ignore")
-  User Resolve2(string assertion);
-
-  /**
     Resolve an assertion to a (UID,username) or (TeamID,teamname). On failure, returns an error.
    */
   @lint("ignore")

--- a/protocol/avdl/keybase1/identify.avdl
+++ b/protocol/avdl/keybase1/identify.avdl
@@ -11,14 +11,6 @@ protocol identify {
   @lint("ignore")
   UserOrTeamLite Resolve3(string assertion);
 
-  /**
-    DEPRECATED:  use identify2
-
-    Identify a user from a username or assertion (e.g. kbuser, twuser@twitter).
-    If forceRemoteCheck is true, we force all remote proofs to be checked (otherwise a cache is used).
-    */
-  IdentifyRes identify(int sessionID, string userAssertion, boolean forceRemoteCheck=false, boolean useDelegateUI=false, IdentifyReason reason, ClientType source);
-
   record IdentifyProofBreak {
     RemoteProof remoteProof;
     LinkCheckResult lcr;

--- a/protocol/avdl/keybase1/identify_common.avdl
+++ b/protocol/avdl/keybase1/identify_common.avdl
@@ -96,13 +96,6 @@ protocol identifyCommon {
     IdentifyReason reason;
   }
 
-  record IdentifyRes {
-    union { null, User } user;
-    array<PublicKey> publicKeys;
-    IdentifyOutcome outcome;
-    TrackToken trackToken;
-  }
-
   record RemoteProof {
     ProofType proofType;
     string key;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1387,14 +1387,6 @@ export function identifyIdentifyLiteRpcPromise (request: (requestCommon & {callb
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.identifyLite', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function identifyIdentifyRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyResult) => void} & {param: identifyIdentifyRpcParam}): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.identify', request)
-}
-
-export function identifyIdentifyRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyResult) => void} & {param: identifyIdentifyRpcParam})): Promise<identifyIdentifyResult> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.identify', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
 export function identifyResolve3RpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyResolve3Result) => void} & {param: identifyResolve3RpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.Resolve3', request)
 }
@@ -3231,13 +3223,6 @@ export type IdentifyReasonType =
   | 5 // VERIFY_5
   | 6 // RESOURCE_6
   | 7 // BACKGROUND_7
-
-export type IdentifyRes = {
-  user?: ?User,
-  publicKeys?: ?Array<PublicKey>,
-  outcome: IdentifyOutcome,
-  trackToken: TrackToken,
-}
 
 export type IdentifyRow = {
   rowId: int,
@@ -5153,14 +5138,6 @@ export type identifyIdentifyLiteRpcParam = Exact<{
   forceDisplay?: boolean
 }>
 
-export type identifyIdentifyRpcParam = Exact<{
-  userAssertion: string,
-  forceRemoteCheck?: boolean,
-  useDelegateUI?: boolean,
-  reason: IdentifyReason,
-  source: ClientType
-}>
-
 export type identifyResolve3RpcParam = Exact<{
   assertion: string
 }>
@@ -6046,7 +6023,6 @@ type gpgUiWantToAddGPGKeyResult = boolean
 type gregorGetStateResult = gregor1.State
 type identifyIdentify2Result = Identify2Res
 type identifyIdentifyLiteResult = IdentifyLiteRes
-type identifyIdentifyResult = IdentifyRes
 type identifyResolve3Result = UserOrTeamLite
 type identifyUiConfirmResult = ConfirmResult
 type identifyUiDelegateIdentifyUIResult = int

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1395,28 +1395,12 @@ export function identifyIdentifyRpcPromise (request: (requestCommon & {callback?
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.identify', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function identifyResolve2RpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyResolve2Result) => void} & {param: identifyResolve2RpcParam}): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.Resolve2', request)
-}
-
-export function identifyResolve2RpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: identifyResolve2Result) => void} & {param: identifyResolve2RpcParam})): Promise<identifyResolve2Result> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.Resolve2', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
 export function identifyResolve3RpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyResolve3Result) => void} & {param: identifyResolve3RpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.Resolve3', request)
 }
 
 export function identifyResolve3RpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: identifyResolve3Result) => void} & {param: identifyResolve3RpcParam})): Promise<identifyResolve3Result> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.Resolve3', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
-export function identifyResolveRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyResolveResult) => void} & {param: identifyResolveRpcParam}): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.Resolve', request)
-}
-
-export function identifyResolveRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: identifyResolveResult) => void} & {param: identifyResolveRpcParam})): Promise<identifyResolveResult> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.Resolve', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function installFuseStatusRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: installFuseStatusResult) => void} & {param: installFuseStatusRpcParam}): EngineChannel {
@@ -5177,15 +5161,7 @@ export type identifyIdentifyRpcParam = Exact<{
   source: ClientType
 }>
 
-export type identifyResolve2RpcParam = Exact<{
-  assertion: string
-}>
-
 export type identifyResolve3RpcParam = Exact<{
-  assertion: string
-}>
-
-export type identifyResolveRpcParam = Exact<{
   assertion: string
 }>
 
@@ -6071,9 +6047,7 @@ type gregorGetStateResult = gregor1.State
 type identifyIdentify2Result = Identify2Res
 type identifyIdentifyLiteResult = IdentifyLiteRes
 type identifyIdentifyResult = IdentifyRes
-type identifyResolve2Result = User
 type identifyResolve3Result = UserOrTeamLite
-type identifyResolveResult = UID
 type identifyUiConfirmResult = ConfirmResult
 type identifyUiDelegateIdentifyUIResult = int
 type installFuseStatusResult = FuseStatus

--- a/protocol/json/keybase1/identify.json
+++ b/protocol/json/keybase1/identify.json
@@ -96,38 +96,6 @@
       "doc": "Resolve an assertion to a (UID,username) or (TeamID,teamname). On failure, returns an error.",
       "lint": "ignore"
     },
-    "identify": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        },
-        {
-          "name": "userAssertion",
-          "type": "string"
-        },
-        {
-          "name": "forceRemoteCheck",
-          "type": "boolean",
-          "default": false
-        },
-        {
-          "name": "useDelegateUI",
-          "type": "boolean",
-          "default": false
-        },
-        {
-          "name": "reason",
-          "type": "IdentifyReason"
-        },
-        {
-          "name": "source",
-          "type": "ClientType"
-        }
-      ],
-      "response": "IdentifyRes",
-      "doc": "DEPRECATED:  use identify2\n\n    Identify a user from a username or assertion (e.g. kbuser, twuser@twitter).\n    If forceRemoteCheck is true, we force all remote proofs to be checked (otherwise a cache is used)."
-    },
     "identify2": {
       "request": [
         {

--- a/protocol/json/keybase1/identify.json
+++ b/protocol/json/keybase1/identify.json
@@ -85,28 +85,6 @@
     }
   ],
   "messages": {
-    "Resolve": {
-      "request": [
-        {
-          "name": "assertion",
-          "type": "string"
-        }
-      ],
-      "response": "UID",
-      "doc": "Resolve an assertion to a UID. On failure, resolves to an empty UID and returns\n    an error.",
-      "lint": "ignore"
-    },
-    "Resolve2": {
-      "request": [
-        {
-          "name": "assertion",
-          "type": "string"
-        }
-      ],
-      "response": "User",
-      "doc": "Resolve an assertion to a (UID,username). On failure, returns an error. Doesn't work for teams.",
-      "lint": "ignore"
-    },
     "Resolve3": {
       "request": [
         {

--- a/protocol/json/keybase1/identify_common.json
+++ b/protocol/json/keybase1/identify_common.json
@@ -214,34 +214,6 @@
     },
     {
       "type": "record",
-      "name": "IdentifyRes",
-      "fields": [
-        {
-          "type": [
-            null,
-            "User"
-          ],
-          "name": "user"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "PublicKey"
-          },
-          "name": "publicKeys"
-        },
-        {
-          "type": "IdentifyOutcome",
-          "name": "outcome"
-        },
-        {
-          "type": "TrackToken",
-          "name": "trackToken"
-        }
-      ]
-    },
-    {
-      "type": "record",
       "name": "RemoteProof",
       "fields": [
         {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1387,14 +1387,6 @@ export function identifyIdentifyLiteRpcPromise (request: (requestCommon & {callb
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.identifyLite', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function identifyIdentifyRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyResult) => void} & {param: identifyIdentifyRpcParam}): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.identify', request)
-}
-
-export function identifyIdentifyRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyResult) => void} & {param: identifyIdentifyRpcParam})): Promise<identifyIdentifyResult> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.identify', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
 export function identifyResolve3RpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyResolve3Result) => void} & {param: identifyResolve3RpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.Resolve3', request)
 }
@@ -3231,13 +3223,6 @@ export type IdentifyReasonType =
   | 5 // VERIFY_5
   | 6 // RESOURCE_6
   | 7 // BACKGROUND_7
-
-export type IdentifyRes = {
-  user?: ?User,
-  publicKeys?: ?Array<PublicKey>,
-  outcome: IdentifyOutcome,
-  trackToken: TrackToken,
-}
 
 export type IdentifyRow = {
   rowId: int,
@@ -5153,14 +5138,6 @@ export type identifyIdentifyLiteRpcParam = Exact<{
   forceDisplay?: boolean
 }>
 
-export type identifyIdentifyRpcParam = Exact<{
-  userAssertion: string,
-  forceRemoteCheck?: boolean,
-  useDelegateUI?: boolean,
-  reason: IdentifyReason,
-  source: ClientType
-}>
-
 export type identifyResolve3RpcParam = Exact<{
   assertion: string
 }>
@@ -6046,7 +6023,6 @@ type gpgUiWantToAddGPGKeyResult = boolean
 type gregorGetStateResult = gregor1.State
 type identifyIdentify2Result = Identify2Res
 type identifyIdentifyLiteResult = IdentifyLiteRes
-type identifyIdentifyResult = IdentifyRes
 type identifyResolve3Result = UserOrTeamLite
 type identifyUiConfirmResult = ConfirmResult
 type identifyUiDelegateIdentifyUIResult = int

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1395,28 +1395,12 @@ export function identifyIdentifyRpcPromise (request: (requestCommon & {callback?
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.identify', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function identifyResolve2RpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyResolve2Result) => void} & {param: identifyResolve2RpcParam}): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.Resolve2', request)
-}
-
-export function identifyResolve2RpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: identifyResolve2Result) => void} & {param: identifyResolve2RpcParam})): Promise<identifyResolve2Result> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.Resolve2', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
 export function identifyResolve3RpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyResolve3Result) => void} & {param: identifyResolve3RpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.Resolve3', request)
 }
 
 export function identifyResolve3RpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: identifyResolve3Result) => void} & {param: identifyResolve3RpcParam})): Promise<identifyResolve3Result> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.Resolve3', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
-export function identifyResolveRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyResolveResult) => void} & {param: identifyResolveRpcParam}): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.Resolve', request)
-}
-
-export function identifyResolveRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: identifyResolveResult) => void} & {param: identifyResolveRpcParam})): Promise<identifyResolveResult> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.Resolve', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function installFuseStatusRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: installFuseStatusResult) => void} & {param: installFuseStatusRpcParam}): EngineChannel {
@@ -5177,15 +5161,7 @@ export type identifyIdentifyRpcParam = Exact<{
   source: ClientType
 }>
 
-export type identifyResolve2RpcParam = Exact<{
-  assertion: string
-}>
-
 export type identifyResolve3RpcParam = Exact<{
-  assertion: string
-}>
-
-export type identifyResolveRpcParam = Exact<{
   assertion: string
 }>
 
@@ -6071,9 +6047,7 @@ type gregorGetStateResult = gregor1.State
 type identifyIdentify2Result = Identify2Res
 type identifyIdentifyLiteResult = IdentifyLiteRes
 type identifyIdentifyResult = IdentifyRes
-type identifyResolve2Result = User
 type identifyResolve3Result = UserOrTeamLite
-type identifyResolveResult = UID
 type identifyUiConfirmResult = ConfirmResult
 type identifyUiDelegateIdentifyUIResult = int
 type installFuseStatusResult = FuseStatus


### PR DESCRIPTION
Delete Resolve(1), Resolve2, and Identify(1). Identify2 is also not used by kbfs, but we use its argument internally a lot, so I left its service handler in.

I was motivated to do this by trying to understand resolve/identify and finding that a lot of it was dead. I'm not too familiar with this so if there's a reason not to do this lmk. Tested vendoring into kbfs and compiling kbfsfuse. I didn't do any runtime testing.

cc @strib 