### PR TITLE
Fix chat identify skip

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -321,7 +321,7 @@ func (e *Identify2WithUID) Run(ctx *Context) (err error) {
 	}
 
 	// Only the first send matters, but we don't want to block the subsequent no-op
-	// sends. This code will break when we have more than 100 unblocking opporttunities.
+	// sends. This code will break when we have more than 100 unblocking opportunities.
 	ch := make(chan error, 100)
 
 	e.resultCh = ch

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1387,13 +1387,11 @@ func (e IdentifySummaryError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
 
 func IsIdentifyProofError(err error) bool {
 	switch err.(type) {
-	case ProofError:
-	case IdentifySummaryError:
+	case ProofError, IdentifySummaryError:
 		return true
 	default:
 		return false
 	}
-	return false
 }
 
 //=============================================================================


### PR DESCRIPTION
This looks like it did not do what was intended. Hopefully changing it to what was intended still makes it do the right thing.

Used here https://github.com/keybase/client/blob/8a073ff0ccda515dc0a4a55a9f25e5c48dcd3138/go/engine/identify2_with_uid.go#L298
and here
https://github.com/keybase/client/blob/8a073ff0ccda515dc0a4a55a9f25e5c48dcd3138/go/chat/tlf.go#L327