### PR TITLE
Alias list-members to list-memberships

### DIFF
--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -49,7 +49,8 @@ func newCmdTeamListMemberships(cl *libcmdline.CommandLine, g *libkb.GlobalContex
 	return cli.Command{
 		Name:         "list-memberships",
 		ArgumentHelp: "[team name] [--user=username]",
-		Usage:        "List team memberships.",
+		Aliases:      []string{"list-members"},
+		Usage:        "List your teams, or people on a team.",
 		Action: func(c *cli.Context) {
 			cmd := NewCmdTeamListMembershipsRunner(g)
 			cl.ChooseCommand(cmd, "list-memberships", c)

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -57,7 +57,7 @@ func GetMaybeAdminByStringName(ctx context.Context, g *libkb.GlobalContext, name
 		ForceRepoll: true,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fixupTeamGetError(ctx, g, err, name)
 	}
 	me, err := loadUserVersionByUID(ctx, g, g.Env.GetUID())
 	if err != nil {


### PR DESCRIPTION
```
$ kbu team list-members sijfdjf
sijfdjf  owner    cn1
sijfdjf  writer*  alice                (* invited by cn1; awaiting acceptance)
sijfdjf  writer*  laskdjf@example.com  (* invited by cn1; awaiting acceptance)
```

```
$ kbu team help
...
COMMANDS:
...
   list-memberships, list-members       List your teams, or people on a team.
...
```

```
$ kbu team list-members notateam
▶ ERROR Team "notateam" does not exist
```