### PR TITLE
Use implicit teams for chat conversations

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/teams"
 	context "golang.org/x/net/context"
 )
 
@@ -394,18 +393,20 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.C
 			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(conv.Metadata.FinalizeInfo)
 
 			// XXX not necessary?
-			if conv.GetMembersType() == chat1.ConversationMembersType_IMPTEAM {
-				s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
+			/*
+				if conv.GetMembersType() == chat1.ConversationMembersType_IMPTEAM {
+					s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
 
-				team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{Name: tlfName})
-				if err != nil {
-					return err
+					team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{Name: tlfName})
+					if err != nil {
+						return err
+					}
+					tlfName, err = team.ImplicitTeamDisplayName(ctx)
+					if err != nil {
+						return err
+					}
 				}
-				tlfName, err = team.ImplicitTeamDisplayName(ctx)
-				if err != nil {
-					return err
-				}
-			}
+			*/
 
 			s.Debug(ctx, "identifyTLF: identifying from msg ID: %d name: %s convID: %s",
 				msg.GetMessageID(), tlfName, conv.GetConvID())

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -384,16 +384,13 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.C
 				return nil
 			}
 
+			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(conv.Metadata.FinalizeInfo)
+
 			switch conv.GetMembersType() {
 			case chat1.ConversationMembersType_TEAM:
 				// early out of team convs
 				return nil
-			default:
-			}
-
-			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(conv.Metadata.FinalizeInfo)
-
-			if conv.GetMembersType() == chat1.ConversationMembersType_IMPTEAM {
+			case chat1.ConversationMembersType_IMPTEAM:
 				s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
 
 				team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{Name: tlfName})

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -393,7 +393,9 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.C
 			case chat1.ConversationMembersType_IMPTEAM:
 				s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
 
-				team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{Name: tlfName})
+				tlfID := msg.Valid().ClientHeader.Conv.Tlfid
+				teamID := keybase1.TeamID(tlfID)
+				team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{ID: teamID})
 				if err != nil {
 					return err
 				}

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -394,7 +394,10 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.C
 				s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
 
 				tlfID := msg.Valid().ClientHeader.Conv.Tlfid
-				teamID := keybase1.TeamID(tlfID)
+				teamID, err := keybase1.TeamIDFromString(tlfID.String())
+				if err != nil {
+					return err
+				}
 				team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{ID: teamID})
 				if err != nil {
 					return err

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
 	context "golang.org/x/net/context"
 )
 
@@ -391,6 +392,21 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.C
 			}
 
 			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(conv.Metadata.FinalizeInfo)
+
+			// XXX not necessary?
+			if conv.GetMembersType() == chat1.ConversationMembersType_IMPTEAM {
+				s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
+
+				team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{Name: tlfName})
+				if err != nil {
+					return err
+				}
+				tlfName, err = team.ImplicitTeamDisplayName(ctx)
+				if err != nil {
+					return err
+				}
+			}
+
 			s.Debug(ctx, "identifyTLF: identifying from msg ID: %d name: %s convID: %s",
 				msg.GetMessageID(), tlfName, conv.GetConvID())
 

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
 	context "golang.org/x/net/context"
 )
 
@@ -392,21 +393,19 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.C
 
 			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(conv.Metadata.FinalizeInfo)
 
-			// XXX not necessary?
-			/*
-				if conv.GetMembersType() == chat1.ConversationMembersType_IMPTEAM {
-					s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
+			if conv.GetMembersType() == chat1.ConversationMembersType_IMPTEAM {
+				s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
 
-					team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{Name: tlfName})
-					if err != nil {
-						return err
-					}
-					tlfName, err = team.ImplicitTeamDisplayName(ctx)
-					if err != nil {
-						return err
-					}
+				team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{Name: tlfName})
+				if err != nil {
+					return err
 				}
-			*/
+				display, err := team.ImplicitTeamDisplayName(ctx)
+				if err != nil {
+					return err
+				}
+				tlfName = display.String()
+			}
 
 			s.Debug(ctx, "identifyTLF: identifying from msg ID: %d name: %s convID: %s",
 				msg.GetMessageID(), tlfName, conv.GetConvID())

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -648,8 +648,6 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 		case chat1.ConversationMembersType_TEAM:
 			n.topicName = &DefaultTeamTopic
 		}
-	} else if n.membersType == chat1.ConversationMembersType_IMPTEAM {
-		return res, rl, errors.New("no topic name allowed for implicit teams")
 	}
 
 	var findConvsTopicName string
@@ -674,12 +672,14 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 		return convs[0], rl, err
 	}
 
-	// if KBFS, return an error. Need to use IMPTEAM now.
-	if n.membersType == chat1.ConversationMembersType_KBFS {
-		// let it slide in devel for tests
-		if n.G().ExternalG().Env.GetRunMode() != libkb.DevelRunMode {
-			n.Debug(ctx, "KBFS conversations deprecated; switching membersType from KBFS to IMPTEAM")
-			n.membersType = chat1.ConversationMembersType_IMPTEAM
+	if n.G().ExternalG().Env.GetChatMemberType() == "impteam" {
+		// if KBFS, return an error. Need to use IMPTEAM now.
+		if n.membersType == chat1.ConversationMembersType_KBFS {
+			// let it slide in devel for tests
+			if n.G().ExternalG().Env.GetRunMode() != libkb.DevelRunMode {
+				n.Debug(ctx, "KBFS conversations deprecated; switching membersType from KBFS to IMPTEAM")
+				n.membersType = chat1.ConversationMembersType_IMPTEAM
+			}
 		}
 	}
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -789,8 +789,6 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 
 		// Send a message to the channel after joining.
 		switch n.membersType {
-		// XXX should this happen for IMPTEAM too?
-		// case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
 		case chat1.ConversationMembersType_TEAM:
 			joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
 			irl, err := postJoinLeave(ctx, n.G(), n.ri, n.uid, convID, joinMessageBody)

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -668,7 +668,13 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 		return convs[0], rl, err
 	}
 
-	// XXX if KBFS, return an error...need to use IMPTEAM now
+	// if KBFS, return an error. Need to use IMPTEAM now.
+	if n.membersType == chat1.ConversationMembersType_KBFS {
+		// let it slide in devel for tests
+		if n.G().ExternalG().Env.GetRunMode() != libkb.DevelRunMode {
+			return res, rl, errors.New("new KBFS conversations no longer allowed, use IMPTEAM")
+		}
+	}
 
 	n.Debug(ctx, "no matching previous conversation, proceeding to create new conv")
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -596,6 +596,11 @@ type newConversationHelper struct {
 func newNewConversationHelper(g *globals.Context, uid gregor1.UID, tlfName string, topicName *string,
 	topicType chat1.TopicType, membersType chat1.ConversationMembersType, vis chat1.TLFVisibility,
 	ri func() chat1.RemoteInterface) *newConversationHelper {
+
+	if membersType == chat1.ConversationMembersType_IMPTEAM && g.ExternalG().Env.GetChatMemberType() != "impteam" {
+		membersType = chat1.ConversationMembersType_KBFS
+	}
+
 	return &newConversationHelper{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "newConversationHelper", false),

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -350,6 +350,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 		debugger.Debug(ctx, "FindConversations: found conversations in inbox: tlfName: %s num: %d",
 			tlfName, len(inbox.Convs))
 		res = inbox.Convs
+		// } else if membersType == chat1.ConversationMembersType_TEAM || membersType == chat1.ConversationMembersType_IMPTEAM {
 	} else if membersType == chat1.ConversationMembersType_TEAM {
 		// If this is a team chat that we are looking for, then let's try searching all
 		// chats on the team to see if any match the arguments before giving up.
@@ -378,8 +379,6 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 		if len(res) > 0 {
 			debugger.Debug(ctx, "FindConversations: found team channels: num: %d", len(res))
 		}
-	} else if membersType == chat1.ConversationMembersType_IMPTEAM {
-		// XXX look here
 	} else if vis == chat1.TLFVisibility_PUBLIC {
 		debugger.Debug(ctx, "FindConversation: no conversations found in inbox, trying public chats")
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -360,7 +360,6 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 		debugger.Debug(ctx, "FindConversations: found conversations in inbox: tlfName: %s num: %d",
 			tlfName, len(inbox.Convs))
 		res = inbox.Convs
-		// } else if membersType == chat1.ConversationMembersType_TEAM || membersType == chat1.ConversationMembersType_IMPTEAM {
 	} else if membersType == chat1.ConversationMembersType_TEAM || membersType == chat1.ConversationMembersType_IMPTEAM {
 		// If this is a team chat that we are looking for, then let's try searching all
 		// chats on the team to see if any match the arguments before giving up.
@@ -709,13 +708,6 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 		}
 
 		n.Debug(ctx, "established conv: %v", convID)
-
-		// XXX made it here so far
-		/*
-			if n.membersType == chat1.ConversationMembersType_IMPTEAM {
-				panic("here x")
-			}
-		*/
 
 		// create succeeded; grabbing the conversation and returning
 		ib, irl, err := n.G().InboxSource.Read(ctx, n.uid, nil, false,

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -740,7 +740,9 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 
 		// Send a message to the channel after joining.
 		switch n.membersType {
-		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
+		// XXX should this happen for IMPTEAM too?
+		// case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
+		case chat1.ConversationMembersType_TEAM:
 			joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
 			irl, err := postJoinLeave(ctx, n.G(), n.ri, n.uid, convID, joinMessageBody)
 			if err != nil {

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -1052,12 +1052,13 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 			conversationLocal.Error = chat1.NewConversationErrorLocal(errMsg, conversationRemote, unverifiedTLFName, chat1.ConversationErrorType_TRANSIENT, nil)
 			return conversationLocal
 		}
-		conversationLocal.Info.TlfName, err = team.ImplicitTeamDisplayName(ctx)
+		display, err := team.ImplicitTeamDisplayName(ctx)
 		if err != nil {
 			errMsg := fmt.Sprintf("implicit team display name error for %q: %s", conversationLocal.Info.TlfName, err)
 			conversationLocal.Error = chat1.NewConversationErrorLocal(errMsg, conversationRemote, unverifiedTLFName, chat1.ConversationErrorType_TRANSIENT, nil)
 			return conversationLocal
 		}
+		conversationLocal.Info.TlfName = display.String()
 	}
 
 	// Only do this check if there is a chance the TLF name might be an SBS name. Only attempt

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/teams"
 	context "golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
@@ -484,11 +483,6 @@ func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	// Read unverified inbox
 	rquery, tlfInfo, err := s.GetInboxQueryLocalToRemote(ctx, query)
 	if err != nil {
-		if query != nil && query.Name != nil && query.Name.MembersType == chat1.ConversationMembersType_IMPTEAM {
-			if _, ok := err.(teams.TeamDoesNotExistError); ok {
-				return inbox, rl, nil
-			}
-		}
 		return inbox, rl, err
 	}
 	inbox, rl, err = s.ReadUnverified(ctx, uid, useLocalData, rquery, p)

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -1046,7 +1046,13 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 	// if this is an implicit team conversation, then the TLF name is the internal team name.
 	// Lookup the display name and use it instead.
 	if conversationLocal.GetMembersType() == chat1.ConversationMembersType_IMPTEAM {
-		team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{Name: conversationLocal.Info.TlfName})
+		teamID, err := keybase1.TeamIDFromString(conversationLocal.Info.Triple.Tlfid.String())
+		if err != nil {
+			errMsg := fmt.Sprintf("teams.Load failed for implicit team %q: %s", conversationLocal.Info.TlfName, err)
+			conversationLocal.Error = chat1.NewConversationErrorLocal(errMsg, conversationRemote, unverifiedTLFName, chat1.ConversationErrorType_TRANSIENT, nil)
+			return conversationLocal
+		}
+		team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{ID: teamID})
 		if err != nil {
 			errMsg := fmt.Sprintf("teams.Load failed for implicit team %q: %s", conversationLocal.Info.TlfName, err)
 			conversationLocal.Error = chat1.NewConversationErrorLocal(errMsg, conversationRemote, unverifiedTLFName, chat1.ConversationErrorType_TRANSIENT, nil)

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -56,6 +56,8 @@ func (k *KeyFinderImpl) createNameInfoSource(ctx context.Context,
 		return NewKBFSNameInfoSource(k.G())
 	case chat1.ConversationMembersType_TEAM:
 		return NewTeamsNameInfoSource(k.G())
+	case chat1.ConversationMembersType_IMPTEAM:
+		return NewImplicitTeamsNameInfoSource(k.G())
 	}
 	k.Debug(ctx, "createNameInfoSource: unknown members type, using KBFS: %v", membersType)
 	return NewKBFSNameInfoSource(k.G())

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -168,7 +168,7 @@ func (s *BlockingSender) checkConvID(ctx context.Context, conv chat1.Conversatio
 		}
 		if !namesEq {
 			s.Debug(ctx, "checkConvID: TlfName %s != %s", headerQ.TlfName, headerRef.TlfName)
-			return fmt.Errorf("TlfName does not match reference message")
+			return fmt.Errorf("TlfName does not match reference message [%q vs ref %q]", headerQ.TlfName, headerRef.TlfName)
 		}
 	}
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -201,35 +201,6 @@ func runWithMemberTypes(t *testing.T, f func(membersType chat1.ConversationMembe
 	start = time.Now()
 	f(chat1.ConversationMembersType_TEAM)
 	t.Logf("Team Stage End: %v", time.Now().Sub(start))
-
-	/*
-		t.Logf("Implicit Team Stage Begin")
-		start = time.Now()
-		f(chat1.ConversationMembersType_IMPTEAM)
-		t.Logf("Implicit Team Stage End: %v", time.Now().Sub(start))
-	*/
-
-	useRemoteMock = true
-}
-
-func runWithMemberTypesImplicit(t *testing.T, f func(membersType chat1.ConversationMembersType)) {
-	useRemoteMock = true
-	start := time.Now()
-	t.Logf("KBFS Stage Begin")
-	f(chat1.ConversationMembersType_KBFS)
-	t.Logf("KBFS Stage End: %v", time.Now().Sub(start))
-
-	useRemoteMock = false
-	t.Logf("Team Stage Begin")
-	start = time.Now()
-	f(chat1.ConversationMembersType_TEAM)
-	t.Logf("Team Stage End: %v", time.Now().Sub(start))
-
-	t.Logf("Implicit Team Stage Begin")
-	start = time.Now()
-	f(chat1.ConversationMembersType_IMPTEAM)
-	t.Logf("Implicit Team Stage End: %v", time.Now().Sub(start))
-
 	useRemoteMock = true
 }
 
@@ -466,7 +437,7 @@ func mustPostLocalForTest(t *testing.T, ctc *chatTestContext, asUser *kbtest.Fak
 	ctc.advanceFakeClock(time.Second)
 }
 
-func TestChatSrvNewConversationLocalX(t *testing.T) {
+func TestChatSrvNewConversationLocal(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "NewConversationLocal", 2)
 		defer ctc.cleanup()

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2491,6 +2491,8 @@ func TestChatSrvUnboxMobilePushNotification(t *testing.T) {
 }
 
 func TestChatSrvImplicitConversation(t *testing.T) {
+	os.Setenv("KEYBASE_CHAT_MEMBER_TYPE", "impteam")
+	defer os.Setenv("KEYBASE_CHAT_MEMBER_TYPE", "")
 	useRemoteMock = false
 	defer func() {
 		useRemoteMock = true
@@ -2592,6 +2594,8 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 }
 
 func TestImpTeamExistingKBFS(t *testing.T) {
+	os.Setenv("KEYBASE_CHAT_MEMBER_TYPE", "impteam")
+	defer os.Setenv("KEYBASE_CHAT_MEMBER_TYPE", "")
 	ctc := makeChatTestContext(t, "NewConversationLocal", 2)
 	defer ctc.cleanup()
 	users := ctc.users()

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2514,8 +2514,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 	require.Equal(t, 0, len(res.Conversations), "conv found")
 
 	// make the implicit team
-	implicitTeamDesc := keybase1.ImplicitTeamName{
-		IsPrivate: true,
+	implicitTeamDesc := keybase1.ImplicitTeamDisplayName{
 		Writers: keybase1.ImplicitTeamUserSet{
 			KeybaseUsers: []string{users[0].Username, users[1].Username},
 		},

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2571,6 +2571,8 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 	require.NotEmpty(t, conv.MaxMsgSummaries, "created conversation does not have a message")
 	require.Equal(t, ncres.Conv.Info.MembersType, chat1.ConversationMembersType_IMPTEAM, "implicit team")
 
+	t.Logf("ncres tlf name: %s", ncres.Conv.Info.TlfName)
+
 	// user 0 sends a message to conv
 	_, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, chat1.PostLocalArg{
 		ConversationID: ncres.Conv.Info.Id,
@@ -2588,6 +2590,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 	require.NoError(t, err)
 
 	// user 1 sends a message to conv
+	ctx = ctc.as(t, users[1]).startCtx
 	_, err = ctc.as(t, users[1]).chatLocalHandler().PostLocal(ctx, chat1.PostLocalArg{
 		ConversationID: ncres.Conv.Info.Id,
 		Msg: chat1.MessagePlaintext{
@@ -2602,4 +2605,18 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	// user 1 finds the conversation
+	tc = ctc.world.Tcs[users[1].Username]
+	ctx = ctc.as(t, users[1]).startCtx
+	res, err = ctc.as(t, users[1]).chatLocalHandler().FindConversationsLocal(ctx,
+		chat1.FindConversationsLocalArg{
+			TlfName:          displayName,
+			MembersType:      chat1.ConversationMembersType_IMPTEAM,
+			Visibility:       chat1.TLFVisibility_PRIVATE,
+			TopicType:        chat1.TopicType_CHAT,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res.Conversations), "no convs found")
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2590,3 +2590,17 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(res.Conversations), "no convs found")
 }
+
+func TestImpTeamExistingKBFS(t *testing.T) {
+	ctc := makeChatTestContext(t, "NewConversationLocal", 2)
+	defer ctc.cleanup()
+	users := ctc.users()
+
+	c1 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, chat1.ConversationMembersType_KBFS, ctc.as(t, users[1]).user())
+	c2 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, chat1.ConversationMembersType_IMPTEAM, ctc.as(t, users[1]).user())
+
+	t.Logf("c1: %v c2: %v", c1, c2)
+	if !c2.Id.Eq(c1.Id) {
+		t.Fatalf("2nd call to NewConversationLocal as IMPTEAM for a KBFS conversation did not return the same conversation ID")
+	}
+}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2570,4 +2570,36 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, conv.MaxMsgSummaries, "created conversation does not have a message")
 	require.Equal(t, ncres.Conv.Info.MembersType, chat1.ConversationMembersType_IMPTEAM, "implicit team")
+
+	// user 0 sends a message to conv
+	_, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, chat1.PostLocalArg{
+		ConversationID: ncres.Conv.Info.Id,
+		Msg: chat1.MessagePlaintext{
+			ClientHeader: chat1.MessageClientHeader{
+				Conv:        ncres.Conv.Info.Triple,
+				MessageType: chat1.MessageType_TEXT,
+				TlfName:     ncres.Conv.Info.TlfName,
+			},
+			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+				Body: "HI",
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	// user 1 sends a message to conv
+	_, err = ctc.as(t, users[1]).chatLocalHandler().PostLocal(ctx, chat1.PostLocalArg{
+		ConversationID: ncres.Conv.Info.Id,
+		Msg: chat1.MessagePlaintext{
+			ClientHeader: chat1.MessageClientHeader{
+				Conv:        ncres.Conv.Info.Triple,
+				MessageType: chat1.MessageType_TEXT,
+				TlfName:     ncres.Conv.Info.TlfName,
+			},
+			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+				Body: "Hello",
+			}),
+		},
+	})
+	require.NoError(t, err)
 }

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -80,7 +80,7 @@ func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, v
 		if err != nil {
 			return res, err
 		}
-		res.CanonicalName = name
+		res.CanonicalName, err = team.ImplicitTeamDisplayName(ctx)
 		if vis == chat1.TLFVisibility_PRIVATE {
 			chatKeys, err := team.AllApplicationKeys(ctx, keybase1.TeamApplication_CHAT)
 			if err != nil {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -117,7 +117,11 @@ func (t *ImplicitTeamsNameInfoSource) lookupInternalName(ctx context.Context, na
 	if err != nil {
 		return res, err
 	}
-	res.CanonicalName, err = team.ImplicitTeamDisplayName(ctx)
+	display, err := team.ImplicitTeamDisplayName(ctx)
+	if err != nil {
+		return res, err
+	}
+	res.CanonicalName = display.String()
 	if vis == chat1.TLFVisibility_PRIVATE {
 		chatKeys, err := team.AllApplicationKeys(ctx, keybase1.TeamApplication_CHAT)
 		if err != nil {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/types"
@@ -53,5 +54,74 @@ func teamToNameInfo(ctx context.Context, team *teams.Team, vis chat1.TLFVisibili
 			res.CryptKeys = append(res.CryptKeys, key)
 		}
 	}
+	return res, nil
+}
+
+type ImplicitTeamsNameInfoSource struct {
+	globals.Contextified
+	utils.DebugLabeler
+}
+
+func NewImplicitTeamsNameInfoSource(g *globals.Context) *ImplicitTeamsNameInfoSource {
+	return &ImplicitTeamsNameInfoSource{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "ImplicitTeamsNameInfoSource", false),
+	}
+}
+
+func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, vis chat1.TLFVisibility) (res types.NameInfo, err error) {
+	// XXX check if name is prefixed
+	if strings.HasPrefix(name, keybase1.ImplicitTeamPrefix) {
+		team, err := teams.Load(ctx, t.G().ExternalG(), keybase1.LoadTeamArg{Name: name})
+		if err != nil {
+			return res, err
+		}
+		res.ID, err = teamIDToTLFID(team.ID)
+		if err != nil {
+			return res, err
+		}
+		res.CanonicalName = name
+		if vis == chat1.TLFVisibility_PRIVATE {
+			chatKeys, err := team.AllApplicationKeys(ctx, keybase1.TeamApplication_CHAT)
+			if err != nil {
+				return res, err
+			}
+			for _, key := range chatKeys {
+				res.CryptKeys = append(res.CryptKeys, key)
+			}
+		}
+		return res, nil
+	}
+
+	teamID, teamName, err := teams.LookupImplicitTeam(ctx, t.G().ExternalG(), name, vis == chat1.TLFVisibility_PUBLIC)
+	if err != nil {
+		return res, err
+	}
+
+	if !teamID.IsRootTeam() {
+		panic(fmt.Sprintf("implicit team found via LookupImplicitTeam not root team: %s", teamID))
+	}
+
+	res.ID, err = teamIDToTLFID(teamID)
+	if err != nil {
+		return res, err
+	}
+
+	res.CanonicalName = teamName.String()
+
+	if vis == chat1.TLFVisibility_PRIVATE {
+		team, err := teams.Load(ctx, t.G().ExternalG(), keybase1.LoadTeamArg{ID: teamID})
+		if err != nil {
+			return res, err
+		}
+		chatKeys, err := team.AllApplicationKeys(ctx, keybase1.TeamApplication_CHAT)
+		if err != nil {
+			return res, err
+		}
+		for _, key := range chatKeys {
+			res.CryptKeys = append(res.CryptKeys, key)
+		}
+	}
+
 	return res, nil
 }

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -129,7 +129,7 @@ func (c ChatChannel) GetMembersType() chat1.ConversationMembersType {
 	if typ, ok := chat1.ConversationMembersTypeMap[strings.ToUpper(c.MembersType)]; ok {
 		return typ
 	}
-	return chat1.ConversationMembersType_KBFS
+	return chat1.ConversationMembersType_IMPTEAM
 }
 
 // ChatMessage represents a text message to be sent.

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -129,7 +129,7 @@ func (c ChatChannel) GetMembersType() chat1.ConversationMembersType {
 	if typ, ok := chat1.ConversationMembersTypeMap[strings.ToUpper(c.MembersType)]; ok {
 		return typ
 	}
-	return chat1.ConversationMembersType_IMPTEAM
+	return chat1.ConversationMembersType_KBFS
 }
 
 // ChatMessage represents a text message to be sent.

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -164,7 +164,7 @@ func annotateResolvingRequest(g *libkb.GlobalContext, req *chatConversationResol
 	}
 	switch *userOrTeamResult {
 	case keybase1.UserOrTeamResult_USER:
-		req.MembersType = chat1.ConversationMembersType_KBFS
+		req.MembersType = chat1.ConversationMembersType_IMPTEAM
 	case keybase1.UserOrTeamResult_TEAM:
 		req.MembersType = chat1.ConversationMembersType_TEAM
 	}

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -164,7 +164,11 @@ func annotateResolvingRequest(g *libkb.GlobalContext, req *chatConversationResol
 	}
 	switch *userOrTeamResult {
 	case keybase1.UserOrTeamResult_USER:
-		req.MembersType = chat1.ConversationMembersType_IMPTEAM
+		if g.Env.GetChatMemberType() == "impteam" {
+			req.MembersType = chat1.ConversationMembersType_IMPTEAM
+		} else {
+			req.MembersType = chat1.ConversationMembersType_KBFS
+		}
 	case keybase1.UserOrTeamResult_TEAM:
 		req.MembersType = chat1.ConversationMembersType_TEAM
 	}

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -102,7 +102,7 @@ func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.Conver
 	switch conv.GetMembersType() {
 	case chat1.ConversationMembersType_TEAM:
 		return v.convNameTeam(g, conv)
-	case chat1.ConversationMembersType_KBFS:
+	case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAM:
 		return v.convNameKBFS(g, conv, myUsername)
 	}
 	return ""

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -83,7 +83,7 @@ func (c *CmdChatSend) Run() (err error) {
 	// in finding existing conversations.
 	if c.G().Standalone {
 		switch c.resolvingRequest.MembersType {
-		case chat1.ConversationMembersType_TEAM:
+		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
 			c.G().StartStandaloneChat()
 		default:
 			err = CantRunInStandaloneError{}

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -612,7 +612,7 @@ func parseImplicitTeamPart(ctx AssertionContext, s string) (typ string, name str
 			return "keybase", strings.ToLower(s), nil
 		}
 
-		return "", "", fmt.Errorf("Parsed part as keybase username, but invalid username: %s", s)
+		return "", "", fmt.Errorf("Parsed part as keybase username, but invalid username (%q)", s)
 	}
 	assertion, err := ParseAssertionURL(ctx, s, true)
 	if err != nil {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -987,6 +987,15 @@ func (e *Env) GetInboxSourceType() string {
 	)
 }
 
+// GetChatMemberType returns the default member type for new conversations.
+// Currently defaults to `kbfs`, but `impteam` will be default in future.
+func (e *Env) GetChatMemberType() string {
+	return e.GetString(
+		func() string { return os.Getenv("KEYBASE_CHAT_MEMBER_TYPE") },
+		func() string { return "kbfs" },
+	)
+}
+
 func (e *Env) GetDeviceID() keybase1.DeviceID {
 	return e.config.GetDeviceID()
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1795,7 +1795,7 @@ func (i ImplicitTeamUserSet) List() string {
 	return strings.Join(names, ",")
 }
 
-func (n ImplicitTeamName) String() string {
+func (n ImplicitTeamDisplayName) String() string {
 	name := n.Writers.List()
 
 	if n.Readers.NumTotalUsers() > 0 {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1792,6 +1792,7 @@ func (i ImplicitTeamUserSet) List() string {
 	for _, u := range i.UnresolvedUsers {
 		names = append(names, u.String())
 	}
+	sort.Strings(names)
 	return strings.Join(names, ",")
 }
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -443,6 +443,11 @@ func (t TeamID) IsSubTeam() bool {
 	return suffix == SUB_TEAMID_SUFFIX_HEX
 }
 
+func (t TeamID) IsRootTeam() bool {
+	suffix := t[len(t)-2:]
+	return suffix == TEAMID_SUFFIX_HEX
+}
+
 func (t TeamID) String() string {
 	return string(t)
 }
@@ -1779,6 +1784,25 @@ func (m MemberInfo) TeamName() (TeamName, error) {
 
 func (i ImplicitTeamUserSet) NumTotalUsers() int {
 	return len(i.KeybaseUsers) + len(i.UnresolvedUsers)
+}
+
+func (i ImplicitTeamUserSet) List() string {
+	var names []string
+	names = append(names, i.KeybaseUsers...)
+	for _, u := range i.UnresolvedUsers {
+		names = append(names, u.String())
+	}
+	return strings.Join(names, ",")
+}
+
+func (n ImplicitTeamName) String() string {
+	name := n.Writers.List()
+
+	if n.Readers.NumTotalUsers() > 0 {
+		name += "#" + n.Readers.List()
+	}
+
+	return name
 }
 
 // LockIDFromBytes takes the first 8 bytes of the sha512 over data, interprets


### PR DESCRIPTION
This patch creates new conversations using implicit teams.

It's a bit tricky because of the internal implicit name (that no one sees) and the display name.

Tested manually with CLI `chat send` to new conversation and it created implicit team conversation:


    {"result":{"conversations":[{"id":"0000a25b61fb227b186c0f2d5dd66b5fe7e3b6530e52abb61e39f22183672454","channel":{"name":"wool","public":false,"members_type":"impteam","topic_type":"chat"},"unread":false,"active_at":1503690594,"active_at_ms":1503690594294}],"offline":false,"ratelimits":[{"tank":"chat","capacity":900,"reset":863,"gas":894}]}}

