### PR TITLE
Skip track ask on pgp verify

### DIFF
--- a/go/client/cmd_pgp_verify.go
+++ b/go/client/cmd_pgp_verify.go
@@ -59,7 +59,7 @@ func (c *CmdPGPVerify) Run() error {
 	protocols := []rpc.Protocol{
 		NewStreamUIProtocol(c.G()),
 		NewSecretUIProtocol(c.G()),
-		NewIdentifyTrackUIProtocol(c.G()),
+		NewIdentifyUIProtocol(c.G()),
 		NewPgpUIProtocol(c.G()),
 	}
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {


### PR DESCRIPTION
Running `pgp verify` on a messages signed by myself was asking annoying questions. Now it succeeds with no interaction. `pgp decrypt` never had the issue, which I don't understand, but ok.

My main qualm is I'm not sure whether this bypasses the critical check that the key actually belongs to the right person. If you're not sure either I'll look into it.

Now it does this
```
$ kbu pgp verify < /tmp/sig.pgp
Signature verified. Signed by cn1 1 hour ago (2017-08-28 15:14:30 -0400 EDT).
PGP Fingerprint: df404d875c1600c485b9355520c60f59a57bff92.
```

Before this change these could happen:
```
$ kbu pgp verify < /tmp/sig.pgp
▶ INFO Identifying cn1
✔ public key fingerprint: DF40 4D87 5C16 00C4 85B9 3555 20C6 0F59 A57B FF92
✔ "cn1" on rooter: http://localhost:3000/_/api/1.0/rooter/cn1/899df6c3c6c7c904633fd3490e3c5903.json [cached 2017-08-28 16:18:22 EDT]
Is this the cn1 you wanted? [Y/n]
```

```
$ kbu pgp verify < /tmp/sig.pgp
▶ INFO Identifying cn1
✔ public key fingerprint: DF40 4D87 5C16 00C4 85B9 3555 20C6 0F59 A57B FF92
We found an account for cn1, but they haven't proven their identity. Still follow them? [y/N] ▶ ERROR input canceled
```

```
$ kbu pgp verify < /tmp/sig.pgp
▶ INFO Identifying cn1
✔ public key fingerprint: DF40 4D87 5C16 00C4 85B9 3555 20C6 0F59 A57B FF92
✔ "asdf" on github failed: No server-given hint for sig=cf9ff3ffcca2d402581efcf95752098a8b6bfad80a0261084fd750598e1a74050f (code=306)
✔ "cn1" on rooter: http://localhost:3000/_/api/1.0/rooter/cn1/7ef7b274ba0bb880644d13bb054c7303.json [cached 2017-08-28 16:15:58 EDT]
Some proofs failed; still follow cn1? [y/N] ▶ ERROR input canceled
```