### PR TITLE
Remove prefix

### DIFF
--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2082,6 +2082,6 @@ func (e ImplicitTeamDisplayNameError) Error() string {
 	return fmt.Sprintf("Error parsing implicit team name: %s", e.msg)
 }
 
-func NewImplicitTeamDisplayNameError(s string) ImplicitTeamDisplayNameError {
-	return ImplicitTeamDisplayNameError{s}
+func NewImplicitTeamDisplayNameError(format string, args ...interface{}) ImplicitTeamDisplayNameError {
+	return ImplicitTeamDisplayNameError{fmt.Sprintf(format, args...)}
 }

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -73,6 +73,9 @@ func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName
 		return res, impTeamName, fmt.Errorf("implicit team name mismatch: %s != %s", teamDisplayName,
 			formatImpName)
 	}
+	if team.IsPublic() != public {
+		return res, impTeamName, fmt.Errorf("implicit team public-ness mismatch: %v != %v", team.IsPublic(), public)
+	}
 
 	return imp.TeamID, impTeamName, nil
 }
@@ -120,13 +123,9 @@ func FormatImplicitTeamDisplayName(ctx context.Context, g *libkb.GlobalContext, 
 			impTeamName.ConflictInfo.Generation)
 	}
 
-	normalized, err := kbfs.NormalizeNamesInTLF(writerNames, readerNames, suffix)
-	if err != nil {
-		return "", err
+	if len(writerNames) == 0 {
+		return "", fmt.Errorf("invalid implicit team name: no writers")
 	}
-	prefix := "private/"
-	if impTeamName.IsPublic {
-		prefix = "public/"
-	}
-	return prefix + normalized, nil
+
+	return kbfs.NormalizeNamesInTLF(writerNames, readerNames, suffix)
 }


### PR DESCRIPTION
Remove the `"public/private"` prefix from `FormatImplicitTeamDisplayName`. It's weird that the display name doesn't include all the info in the `keybase1.ImplicitTeamDisplayName` struct. But it's worse for `FormatImplicitDisplayName` and `ParseImplicitTeamDisplayName` to disagree. And the server interface is this way. Hopefully we always remember when comparing display names to also check public-ness.

Also add parsing of conflict suffixes to `ParseImplicitTeamDisplayName`.

And test that `FormatImplicitTeamDisplayName` and `ParseImplicitTeamDisplayName` get along.