### PR TITLE
don't show fuse install banner on linux

### DIFF
--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -9,7 +9,7 @@ import {connect} from 'react-redux'
 import {fuseStatus} from '../actions/kbfs'
 import Banner from './install/banner'
 import InstallSecurityPrefs from './install/security-prefs'
-
+import {isLinux} from '../constants/platform'
 import type {TypedState} from '../constants/reducer'
 
 class FoldersRender extends Component<Props> {
@@ -63,7 +63,7 @@ class FoldersRender extends Component<Props> {
           minHeight: 32,
         }}
       >
-        {!this.props.smallMode && <Banner />}
+        {!this.props.smallMode && !isLinux && <Banner />}
         <TabBar
           styleTabBar={{
             ...tabBarStyle,


### PR DESCRIPTION
Not sure if we want to expose the fuse removal on Linux, but for now this makes the folders page appear pre-installer-split on linux
@keybase/react-hackers 
@strib 