### PR TITLE
Remove ineffectual keep-paper-key option

### DIFF
--- a/go/client/cmd_paperprovision.go
+++ b/go/client/cmd_paperprovision.go
@@ -23,23 +23,16 @@ func NewCmdPaperProvision(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cl
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdPaperProvisionRunner(g), "paperprovision", c)
 		},
-		Flags: []cli.Flag{
-			cli.BoolFlag{
-				Name:  "keep-paper-key, k",
-				Usage: "Keep paper key.",
-			},
-		},
 	}
 	return cmd
 }
 
 type CmdPaperProvision struct {
 	libkb.Contextified
-	username     string
-	deviceName   string
-	paperKey     string
-	SessionID    int
-	keepPaperKey bool
+	username   string
+	deviceName string
+	paperKey   string
+	SessionID  int
 }
 
 func NewCmdPaperProvisionRunner(g *libkb.GlobalContext) *CmdPaperProvision {
@@ -65,10 +58,6 @@ func (c *CmdPaperProvision) Run() (err error) {
 		return err
 	}
 
-	if c.keepPaperKey {
-		c.G().Log.Warning("'--keep-paper-key' has no effect")
-	}
-
 	err = client.PaperProvision(context.TODO(),
 		keybase1.PaperProvisionArg{
 			Username:   c.username,
@@ -81,7 +70,6 @@ func (c *CmdPaperProvision) Run() (err error) {
 }
 
 func (c *CmdPaperProvision) ParseArgv(ctx *cli.Context) error {
-	c.keepPaperKey = ctx.Bool("keep-paper-key")
 	nargs := len(ctx.Args())
 	if nargs != 3 {
 		return errors.New("Username, devicename and paperkey arguments required")

--- a/go/engine/paperprovision.go
+++ b/go/engine/paperprovision.go
@@ -16,7 +16,6 @@ type PaperProvisionEngine struct {
 	Username       string
 	DeviceName     string
 	PaperKey       string
-	keepPaperKey   bool
 	result         error
 	lks            *libkb.LKSec
 	User           *libkb.User


### PR DESCRIPTION
Get rid of `paperprovision --keep-paper-key`.  The final part of this trilogy:
- https://github.com/keybase/client/pull/7251
- https://github.com/keybase/kbfs-server/pull/305