### PR TITLE
Add back onBack handler

### DIFF
--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -76,6 +76,8 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
       ])
     )
   },
+  // Used by HeaderHoc.
+  onBack: () => dispatch(navigateUp()),
   onShowProfile: (username: string) => dispatch(showUserProfile(username)),
 })
 


### PR DESCRIPTION
Accidentally removed it, which makes HeaderHoc on mobile not display
the back button.