### PR TITLE
remove aux info and replace with creator info, and beef up list channels CLI CORE-5894

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -255,14 +255,13 @@ func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
 
 func GetTLFConversations(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
 	ri func() chat1.RemoteInterface, uid gregor1.UID, tlfID chat1.TLFID, topicType chat1.TopicType,
-	membersType chat1.ConversationMembersType, includeAuxiliaryInfo bool) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
+	membersType chat1.ConversationMembersType) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
 
 	tlfRes, err := ri().GetTLFConversations(ctx, chat1.GetTLFConversationsArg{
-		TlfID:                tlfID,
-		TopicType:            topicType,
-		MembersType:          membersType,
-		SummarizeMaxMsgs:     false,
-		IncludeAuxiliaryInfo: includeAuxiliaryInfo,
+		TlfID:            tlfID,
+		TopicType:        topicType,
+		MembersType:      membersType,
+		SummarizeMaxMsgs: false,
 	})
 	if err != nil {
 		return res, rl, err
@@ -357,7 +356,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 			return res, rl, err
 		}
 		tlfConvs, irl, err := GetTLFConversations(ctx, g, debugger, ri,
-			uid, nameInfo.ID, topicType, membersType, false)
+			uid, nameInfo.ID, topicType, membersType)
 		if err != nil {
 			debugger.Debug(ctx, "FindConversations: failed to list TLF conversations: %s", err.Error())
 			return res, rl, err

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -331,7 +331,7 @@ func (s *BlockingSender) checkTopicNameAndGetState(ctx context.Context, msg chat
 		topicType := msg.ClientHeader.Conv.TopicType
 		newTopicName := msg.MessageBody.Metadata().ConversationTitle
 		convs, _, err := GetTLFConversations(ctx, s.G(), s.DebugLabeler, s.getRi,
-			msg.ClientHeader.Sender, tlfID, topicType, membersType, false)
+			msg.ClientHeader.Sender, tlfID, topicType, membersType)
 		if err != nil {
 			return topicNameState, err
 		}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2032,11 +2032,10 @@ func (h *Server) JoinConversationLocal(ctx context.Context, arg chat1.JoinConver
 
 	// List all the conversations on the team
 	teamConvs, err := h.remoteClient().GetTLFConversations(ctx, chat1.GetTLFConversationsArg{
-		TlfID:                nameInfo.ID,
-		MembersType:          chat1.ConversationMembersType_TEAM,
-		TopicType:            arg.TopicType,
-		SummarizeMaxMsgs:     false, // tough call here, depends on if we are in most of convos on the team
-		IncludeAuxiliaryInfo: false,
+		TlfID:            nameInfo.ID,
+		MembersType:      chat1.ConversationMembersType_TEAM,
+		TopicType:        arg.TopicType,
+		SummarizeMaxMsgs: false, // tough call here, depends on if we are in most of convos on the team
 	})
 	if err != nil {
 		h.Debug(ctx, "JoinConversationLocal: failed to list team conversations: %s", err.Error())
@@ -2127,7 +2126,7 @@ func (h *Server) GetTLFConversationsLocal(ctx context.Context, arg chat1.GetTLFC
 
 	var convs []chat1.ConversationLocal
 	convs, res.RateLimits, err = GetTLFConversations(ctx, h.G(), h.DebugLabeler,
-		h.remoteClient, uid, nameInfo.ID, arg.TopicType, arg.MembersType, arg.IncludeAuxiliaryInfo)
+		h.remoteClient, uid, nameInfo.ID, arg.TopicType, arg.MembersType)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2125,11 +2125,13 @@ func (h *Server) GetTLFConversationsLocal(ctx context.Context, arg chat1.GetTLFC
 		return res, err
 	}
 
-	res.Convs, res.RateLimits, err = GetTLFConversations(ctx, h.G(), h.DebugLabeler,
+	var convs []chat1.ConversationLocal
+	convs, res.RateLimits, err = GetTLFConversations(ctx, h.G(), h.DebugLabeler,
 		h.remoteClient, uid, nameInfo.ID, arg.TopicType, arg.MembersType, arg.IncludeAuxiliaryInfo)
 	if err != nil {
 		return res, err
 	}
+	res.Convs = utils.PresentConversationLocals(convs)
 	res.Offline = h.G().InboxSource.IsOffline(ctx)
 	return res, nil
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2085,20 +2085,17 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		consumeNewMsg(listener0, chat1.MessageType_JOIN)
 		getTLFRes, err := ctc.as(t, users[1]).chatLocalHandler().GetTLFConversationsLocal(ctx1,
 			chat1.GetTLFConversationsLocalArg{
-				TlfName:              conv.TlfName,
-				TopicType:            chat1.TopicType_CHAT,
-				MembersType:          chat1.ConversationMembersType_TEAM,
-				IncludeAuxiliaryInfo: true,
+				TlfName:     conv.TlfName,
+				TopicType:   chat1.TopicType_CHAT,
+				MembersType: chat1.ConversationMembersType_TEAM,
 			})
 		require.NoError(t, err)
 		require.Equal(t, 3, len(getTLFRes.Convs))
-		require.Equal(t, DefaultTeamTopic, utils.GetTopicName(getTLFRes.Convs[0]))
-		require.Equal(t, topicName, utils.GetTopicName(getTLFRes.Convs[1]))
-		aux := getTLFRes.Convs[2].AuxiliaryInfo
-		require.True(t, aux != nil)
-		require.Equal(t, aux.ReaderCount, 2)
-		require.Equal(t, aux.ConversationCreator, gregor1.UID(users[0].User.GetUID().ToBytes()))
-		require.Equal(t, *aux.HeadlineModifier, gregor1.UID(users[1].User.GetUID().ToBytes()))
+		require.Equal(t, DefaultTeamTopic, getTLFRes.Convs[0].Channel)
+		require.Equal(t, topicName, getTLFRes.Convs[1].Channel)
+		creatorInfo := getTLFRes.Convs[2].CreatorInfo
+		require.NotNil(t, creatorInfo)
+		require.Equal(t, creatorInfo.Username, users[0].Username)
 		tvres, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
 			ConversationID: getTLFRes.Convs[2].GetConvID(),
 		})

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -584,6 +584,7 @@ func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxU
 	res.Name = rawConv.Info.TlfName
 	res.Snippet = GetConvSnippet(rawConv)
 	res.Channel = GetTopicName(rawConv)
+	res.Headline = GetHeadline(rawConv)
 	res.Participants = rawConv.Info.WriterNames
 	res.Status = rawConv.Info.Status
 	res.MembersType = rawConv.GetMembersType()
@@ -594,6 +595,13 @@ func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxU
 	res.Supersedes = rawConv.Supersedes
 	res.IsEmpty = rawConv.IsEmpty
 	res.Notifications = rawConv.Notifications
+	return res
+}
+
+func PresentConversationLocals(convs []chat1.ConversationLocal) (res []chat1.InboxUIItem) {
+	for _, conv := range convs {
+		res = append(res, PresentConversationLocal(conv))
+	}
 	return res
 }
 
@@ -734,6 +742,17 @@ func GetTopicName(conv chat1.ConversationLocal) string {
 		return ""
 	}
 	return maxTopicMsg.Valid().MessageBody.Metadata().ConversationTitle
+}
+
+func GetHeadline(conv chat1.ConversationLocal) string {
+	maxTopicMsg, err := conv.GetMaxMessage(chat1.MessageType_HEADLINE)
+	if err != nil {
+		return ""
+	}
+	if !maxTopicMsg.IsValid() {
+		return ""
+	}
+	return maxTopicMsg.Valid().MessageBody.Headline().Headline
 }
 
 func NotificationInfoSet(settings *chat1.ConversationNotificationInfo,

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -595,6 +595,7 @@ func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxU
 	res.Supersedes = rawConv.Supersedes
 	res.IsEmpty = rawConv.IsEmpty
 	res.Notifications = rawConv.Notifications
+	res.CreatorInfo = rawConv.CreatorInfo
 	return res
 }
 

--- a/go/client/cmd_chat_listchannels.go
+++ b/go/client/cmd_chat_listchannels.go
@@ -54,7 +54,15 @@ func (c *CmdChatListChannels) Run() error {
 
 	ui.Printf("Listing channels on %s:\n\n", c.tlfName)
 	for _, c := range listRes.Convs {
-		ui.Printf("#%s [%s]\n", c.Channel, c.Headline)
+		convLine := fmt.Sprintf("#%s", c.Channel)
+		if c.Headline != "" {
+			convLine += fmt.Sprintf(" [%s]", c.Headline)
+		}
+		if c.CreatorInfo != nil {
+			convLine += fmt.Sprintf(" (created by: %s on: %s)", c.CreatorInfo.Username,
+				c.CreatorInfo.Ctime.Time().Format("2006-01-02"))
+		}
+		ui.Printf(convLine + "\n")
 	}
 
 	return nil

--- a/go/client/cmd_chat_listchannels.go
+++ b/go/client/cmd_chat_listchannels.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/keybase/cli"
-	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -55,7 +54,7 @@ func (c *CmdChatListChannels) Run() error {
 
 	ui.Printf("Listing channels on %s:\n\n", c.tlfName)
 	for _, c := range listRes.Convs {
-		ui.Printf("#%s\n", utils.GetTopicName(c))
+		ui.Printf("#%s [%s]\n", c.Channel, c.Headline)
 	}
 
 	return nil
@@ -64,7 +63,7 @@ func (c *CmdChatListChannels) Run() error {
 func (c *CmdChatListChannels) ParseArgv(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) != 1 {
 		cli.ShowCommandHelp(ctx, "list-channels")
-		return fmt.Errorf("Incorrect usage.")
+		return fmt.Errorf("incorrect usage")
 	}
 
 	c.tlfName = ctx.Args().Get(0)

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -87,6 +87,7 @@ type InboxUIItem struct {
 	Name          string                        `codec:"name" json:"name"`
 	Snippet       string                        `codec:"snippet" json:"snippet"`
 	Channel       string                        `codec:"channel" json:"channel"`
+	Headline      string                        `codec:"headline" json:"headline"`
 	Visibility    TLFVisibility                 `codec:"visibility" json:"visibility"`
 	Participants  []string                      `codec:"participants" json:"participants"`
 	Status        ConversationStatus            `codec:"status" json:"status"`
@@ -105,6 +106,7 @@ func (o InboxUIItem) DeepCopy() InboxUIItem {
 		Name:       o.Name,
 		Snippet:    o.Snippet,
 		Channel:    o.Channel,
+		Headline:   o.Headline,
 		Visibility: o.Visibility.DeepCopy(),
 		Participants: (func(x []string) []string {
 			var ret []string

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -92,8 +92,9 @@ type InboxUIItem struct {
 	Participants  []string                      `codec:"participants" json:"participants"`
 	Status        ConversationStatus            `codec:"status" json:"status"`
 	MembersType   ConversationMembersType       `codec:"membersType" json:"membersType"`
-	Notifications *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
 	Time          gregor1.Time                  `codec:"time" json:"time"`
+	Notifications *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
+	CreatorInfo   *ConversationCreatorInfoLocal `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
 	FinalizeInfo  *ConversationFinalizeInfo     `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
 	Supersedes    []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
 	SupersededBy  []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
@@ -118,6 +119,7 @@ func (o InboxUIItem) DeepCopy() InboxUIItem {
 		})(o.Participants),
 		Status:      o.Status.DeepCopy(),
 		MembersType: o.MembersType.DeepCopy(),
+		Time:        o.Time.DeepCopy(),
 		Notifications: (func(x *ConversationNotificationInfo) *ConversationNotificationInfo {
 			if x == nil {
 				return nil
@@ -125,7 +127,13 @@ func (o InboxUIItem) DeepCopy() InboxUIItem {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Notifications),
-		Time: o.Time.DeepCopy(),
+		CreatorInfo: (func(x *ConversationCreatorInfoLocal) *ConversationCreatorInfoLocal {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.CreatorInfo),
 		FinalizeInfo: (func(x *ConversationFinalizeInfo) *ConversationFinalizeInfo {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -687,40 +687,16 @@ func (o ConversationReaderInfo) DeepCopy() ConversationReaderInfo {
 }
 
 type ConversationAuxiliaryInfo struct {
-	ConversationCtime   gregor1.Time  `codec:"conversationCtime" json:"conversationCtime"`
-	ConversationCreator gregor1.UID   `codec:"conversationCreator" json:"conversationCreator"`
-	HeadlineMtime       *gregor1.Time `codec:"headlineMtime,omitempty" json:"headlineMtime,omitempty"`
-	HeadlineModifier    *gregor1.UID  `codec:"headlineModifier,omitempty" json:"headlineModifier,omitempty"`
-	HeadlineMessageID   *MessageID    `codec:"headlineMessageID,omitempty" json:"headlineMessageID,omitempty"`
-	ReaderCount         int           `codec:"readerCount" json:"readerCount"`
+	ConversationCtime   gregor1.Time `codec:"conversationCtime" json:"conversationCtime"`
+	ConversationCreator gregor1.UID  `codec:"conversationCreator" json:"conversationCreator"`
+	ReaderCount         int          `codec:"readerCount" json:"readerCount"`
 }
 
 func (o ConversationAuxiliaryInfo) DeepCopy() ConversationAuxiliaryInfo {
 	return ConversationAuxiliaryInfo{
 		ConversationCtime:   o.ConversationCtime.DeepCopy(),
 		ConversationCreator: o.ConversationCreator.DeepCopy(),
-		HeadlineMtime: (func(x *gregor1.Time) *gregor1.Time {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.HeadlineMtime),
-		HeadlineModifier: (func(x *gregor1.UID) *gregor1.UID {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.HeadlineModifier),
-		HeadlineMessageID: (func(x *MessageID) *MessageID {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.HeadlineMessageID),
-		ReaderCount: o.ReaderCount,
+		ReaderCount:         o.ReaderCount,
 	}
 }
 

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -686,17 +686,27 @@ func (o ConversationReaderInfo) DeepCopy() ConversationReaderInfo {
 	}
 }
 
-type ConversationAuxiliaryInfo struct {
-	ConversationCtime   gregor1.Time `codec:"conversationCtime" json:"conversationCtime"`
-	ConversationCreator gregor1.UID  `codec:"conversationCreator" json:"conversationCreator"`
-	ReaderCount         int          `codec:"readerCount" json:"readerCount"`
+type ConversationCreatorInfo struct {
+	Ctime gregor1.Time `codec:"ctime" json:"ctime"`
+	Uid   gregor1.UID  `codec:"uid" json:"uid"`
 }
 
-func (o ConversationAuxiliaryInfo) DeepCopy() ConversationAuxiliaryInfo {
-	return ConversationAuxiliaryInfo{
-		ConversationCtime:   o.ConversationCtime.DeepCopy(),
-		ConversationCreator: o.ConversationCreator.DeepCopy(),
-		ReaderCount:         o.ReaderCount,
+func (o ConversationCreatorInfo) DeepCopy() ConversationCreatorInfo {
+	return ConversationCreatorInfo{
+		Ctime: o.Ctime.DeepCopy(),
+		Uid:   o.Uid.DeepCopy(),
+	}
+}
+
+type ConversationCreatorInfoLocal struct {
+	Ctime    gregor1.Time `codec:"ctime" json:"ctime"`
+	Username string       `codec:"username" json:"username"`
+}
+
+func (o ConversationCreatorInfoLocal) DeepCopy() ConversationCreatorInfoLocal {
+	return ConversationCreatorInfoLocal{
+		Ctime:    o.Ctime.DeepCopy(),
+		Username: o.Username,
 	}
 }
 
@@ -706,7 +716,7 @@ type Conversation struct {
 	Notifications   *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
 	MaxMsgs         []MessageBoxed                `codec:"maxMsgs" json:"maxMsgs"`
 	MaxMsgSummaries []MessageSummary              `codec:"maxMsgSummaries" json:"maxMsgSummaries"`
-	AuxiliaryInfo   *ConversationAuxiliaryInfo    `codec:"auxiliaryInfo,omitempty" json:"auxiliaryInfo,omitempty"`
+	CreatorInfo     *ConversationCreatorInfo      `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
 }
 
 func (o Conversation) DeepCopy() Conversation {
@@ -742,13 +752,13 @@ func (o Conversation) DeepCopy() Conversation {
 			}
 			return ret
 		})(o.MaxMsgSummaries),
-		AuxiliaryInfo: (func(x *ConversationAuxiliaryInfo) *ConversationAuxiliaryInfo {
+		CreatorInfo: (func(x *ConversationCreatorInfo) *ConversationCreatorInfo {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
-		})(o.AuxiliaryInfo),
+		})(o.CreatorInfo),
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2958,15 +2958,15 @@ func (o JoinLeaveConversationLocalRes) DeepCopy() JoinLeaveConversationLocalRes 
 }
 
 type GetTLFConversationsLocalRes struct {
-	Convs      []ConversationLocal `codec:"convs" json:"convs"`
-	Offline    bool                `codec:"offline" json:"offline"`
-	RateLimits []RateLimit         `codec:"rateLimits" json:"rateLimits"`
+	Convs      []InboxUIItem `codec:"convs" json:"convs"`
+	Offline    bool          `codec:"offline" json:"offline"`
+	RateLimits []RateLimit   `codec:"rateLimits" json:"rateLimits"`
 }
 
 func (o GetTLFConversationsLocalRes) DeepCopy() GetTLFConversationsLocalRes {
 	return GetTLFConversationsLocalRes{
-		Convs: (func(x []ConversationLocal) []ConversationLocal {
-			var ret []ConversationLocal
+		Convs: (func(x []InboxUIItem) []InboxUIItem {
+			var ret []InboxUIItem
 			for _, v := range x {
 				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2149,7 +2149,7 @@ type ConversationLocal struct {
 	Error            *ConversationErrorLocal       `codec:"error,omitempty" json:"error,omitempty"`
 	Info             ConversationInfoLocal         `codec:"info" json:"info"`
 	ReaderInfo       ConversationReaderInfo        `codec:"readerInfo" json:"readerInfo"`
-	AuxiliaryInfo    *ConversationAuxiliaryInfo    `codec:"auxiliaryInfo,omitempty" json:"auxiliaryInfo,omitempty"`
+	CreatorInfo      *ConversationCreatorInfoLocal `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
 	Notifications    *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
 	Supersedes       []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
 	SupersededBy     []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
@@ -2169,13 +2169,13 @@ func (o ConversationLocal) DeepCopy() ConversationLocal {
 		})(o.Error),
 		Info:       o.Info.DeepCopy(),
 		ReaderInfo: o.ReaderInfo.DeepCopy(),
-		AuxiliaryInfo: (func(x *ConversationAuxiliaryInfo) *ConversationAuxiliaryInfo {
+		CreatorInfo: (func(x *ConversationCreatorInfoLocal) *ConversationCreatorInfoLocal {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
-		})(o.AuxiliaryInfo),
+		})(o.CreatorInfo),
 		Notifications: (func(x *ConversationNotificationInfo) *ConversationNotificationInfo {
 			if x == nil {
 				return nil
@@ -3605,18 +3605,16 @@ func (o LeaveConversationLocalArg) DeepCopy() LeaveConversationLocalArg {
 }
 
 type GetTLFConversationsLocalArg struct {
-	TlfName              string                  `codec:"tlfName" json:"tlfName"`
-	TopicType            TopicType               `codec:"topicType" json:"topicType"`
-	MembersType          ConversationMembersType `codec:"membersType" json:"membersType"`
-	IncludeAuxiliaryInfo bool                    `codec:"includeAuxiliaryInfo" json:"includeAuxiliaryInfo"`
+	TlfName     string                  `codec:"tlfName" json:"tlfName"`
+	TopicType   TopicType               `codec:"topicType" json:"topicType"`
+	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
 }
 
 func (o GetTLFConversationsLocalArg) DeepCopy() GetTLFConversationsLocalArg {
 	return GetTLFConversationsLocalArg{
-		TlfName:              o.TlfName,
-		TopicType:            o.TopicType.DeepCopy(),
-		MembersType:          o.MembersType.DeepCopy(),
-		IncludeAuxiliaryInfo: o.IncludeAuxiliaryInfo,
+		TlfName:     o.TlfName,
+		TopicType:   o.TopicType.DeepCopy(),
+		MembersType: o.MembersType.DeepCopy(),
 	}
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -1041,20 +1041,18 @@ func (o LeaveConversationArg) DeepCopy() LeaveConversationArg {
 }
 
 type GetTLFConversationsArg struct {
-	TlfID                TLFID                   `codec:"tlfID" json:"tlfID"`
-	TopicType            TopicType               `codec:"topicType" json:"topicType"`
-	MembersType          ConversationMembersType `codec:"membersType" json:"membersType"`
-	SummarizeMaxMsgs     bool                    `codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
-	IncludeAuxiliaryInfo bool                    `codec:"includeAuxiliaryInfo" json:"includeAuxiliaryInfo"`
+	TlfID            TLFID                   `codec:"tlfID" json:"tlfID"`
+	TopicType        TopicType               `codec:"topicType" json:"topicType"`
+	MembersType      ConversationMembersType `codec:"membersType" json:"membersType"`
+	SummarizeMaxMsgs bool                    `codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
 }
 
 func (o GetTLFConversationsArg) DeepCopy() GetTLFConversationsArg {
 	return GetTLFConversationsArg{
-		TlfID:                o.TlfID.DeepCopy(),
-		TopicType:            o.TopicType.DeepCopy(),
-		MembersType:          o.MembersType.DeepCopy(),
-		SummarizeMaxMsgs:     o.SummarizeMaxMsgs,
-		IncludeAuxiliaryInfo: o.IncludeAuxiliaryInfo,
+		TlfID:            o.TlfID.DeepCopy(),
+		TopicType:        o.TopicType.DeepCopy(),
+		MembersType:      o.MembersType.DeepCopy(),
+		SummarizeMaxMsgs: o.SummarizeMaxMsgs,
 	}
 }
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -38,11 +38,12 @@ protocol chatUi {
     array<string> participants;
     ConversationStatus status;
     ConversationMembersType membersType;
-    union{ null, ConversationNotificationInfo } notifications;
     gregor1.Time time;
+    union { null, ConversationNotificationInfo } notifications;
+    union { null, ConversationCreatorInfoLocal } creatorInfo;
 
     // Finalized convo stuff
-    union{ null, ConversationFinalizeInfo } finalizeInfo;
+    union { null, ConversationFinalizeInfo } finalizeInfo;
     array<ConversationMetadata> supersedes;
     array<ConversationMetadata> supersededBy;
   }

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -33,6 +33,7 @@ protocol chatUi {
     string name;
     string snippet;
     string channel;
+    string headline;
     TLFVisibility visibility;
     array<string> participants;
     ConversationStatus status;

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -205,9 +205,6 @@ protocol common {
   record ConversationAuxiliaryInfo {
     gregor1.Time conversationCtime;
     gregor1.UID conversationCreator;
-    union { null, gregor1.Time } headlineMtime;
-    union { null, gregor1.UID } headlineModifier;
-    union { null, MessageID } headlineMessageID;
     int readerCount;
   }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -202,10 +202,14 @@ protocol common {
     ConversationMemberStatus status; // The status of the membership to the convo
   }
 
-  record ConversationAuxiliaryInfo {
-    gregor1.Time conversationCtime;
-    gregor1.UID conversationCreator;
-    int readerCount;
+  record ConversationCreatorInfo {
+    gregor1.Time ctime;
+    gregor1.UID uid;
+  }
+
+  record ConversationCreatorInfoLocal {
+    gregor1.Time ctime;
+    string username;
   }
 
   record Conversation {
@@ -220,8 +224,8 @@ protocol common {
     // each messageType in the conversation
     array<MessageSummary> maxMsgSummaries;
 
-    // miscellaneous metadata about the conversation
-    union { null, ConversationAuxiliaryInfo } auxiliaryInfo;
+    // creator info for the conversation
+    union { null, ConversationCreatorInfo } creatorInfo;
   }
 
   record MessageSummary {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -657,7 +657,7 @@ protocol local {
   JoinLeaveConversationLocalRes leaveConversationLocal(ConversationID convID);
 
   record GetTLFConversationsLocalRes {
-    array<ConversationLocal> convs;
+    array<InboxUIItem> convs;
     boolean offline;
     array<RateLimit> rateLimits;
   }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -395,7 +395,7 @@ protocol local {
     union { null, ConversationErrorLocal } error;
     ConversationInfoLocal info;
     ConversationReaderInfo readerInfo;
-    union { null, ConversationAuxiliaryInfo } auxiliaryInfo;
+    union { null, ConversationCreatorInfoLocal } creatorInfo;
     union { null, ConversationNotificationInfo } notifications;
     array<ConversationMetadata> supersedes;
     array<ConversationMetadata> supersededBy;
@@ -661,7 +661,7 @@ protocol local {
     boolean offline;
     array<RateLimit> rateLimits;
   }
-  GetTLFConversationsLocalRes getTLFConversationsLocal(string tlfName, TopicType topicType, ConversationMembersType membersType, boolean includeAuxiliaryInfo);
+  GetTLFConversationsLocalRes getTLFConversationsLocal(string tlfName, TopicType topicType, ConversationMembersType membersType);
 
   // Chat notification configuration endpoint. Does not need to be complete, just a delta on the
   // currently configured settings.

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -230,7 +230,7 @@ protocol remote {
     array<Conversation> conversations;
     union { null, RateLimit } rateLimit;
   }
-  GetTLFConversationsRes getTLFConversations(TLFID tlfID, TopicType topicType, ConversationMembersType membersType, boolean summarizeMaxMsgs, boolean includeAuxiliaryInfo);
+  GetTLFConversationsRes getTLFConversations(TLFID tlfID, TopicType topicType, ConversationMembersType membersType, boolean summarizeMaxMsgs);
 
   // Chat notification configuration endpoint. Does not need to be complete, just a delta on the
   // currently configured settings.

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -845,13 +845,17 @@ export type Conversation = {
   notifications?: ?ConversationNotificationInfo,
   maxMsgs?: ?Array<MessageBoxed>,
   maxMsgSummaries?: ?Array<MessageSummary>,
-  auxiliaryInfo?: ?ConversationAuxiliaryInfo,
+  creatorInfo?: ?ConversationCreatorInfo,
 }
 
-export type ConversationAuxiliaryInfo = {
-  conversationCtime: gregor1.Time,
-  conversationCreator: gregor1.UID,
-  readerCount: int,
+export type ConversationCreatorInfo = {
+  ctime: gregor1.Time,
+  uid: gregor1.UID,
+}
+
+export type ConversationCreatorInfoLocal = {
+  ctime: gregor1.Time,
+  username: string,
 }
 
 export type ConversationErrorLocal = {
@@ -920,7 +924,7 @@ export type ConversationLocal = {
   error?: ?ConversationErrorLocal,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
-  auxiliaryInfo?: ?ConversationAuxiliaryInfo,
+  creatorInfo?: ?ConversationCreatorInfoLocal,
   notifications?: ?ConversationNotificationInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -1238,8 +1242,9 @@ export type InboxUIItem = {
   participants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
-  notifications?: ?ConversationNotificationInfo,
   time: gregor1.Time,
+  notifications?: ?ConversationNotificationInfo,
+  creatorInfo?: ?ConversationCreatorInfoLocal,
   finalizeInfo?: ?ConversationFinalizeInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -2028,8 +2033,7 @@ export type localGetMessagesLocalRpcParam = Exact<{
 export type localGetTLFConversationsLocalRpcParam = Exact<{
   tlfName: string,
   topicType: TopicType,
-  membersType: ConversationMembersType,
-  includeAuxiliaryInfo: boolean
+  membersType: ConversationMembersType
 }>
 
 export type localGetThreadLocalRpcParam = Exact<{
@@ -2207,8 +2211,7 @@ export type remoteGetTLFConversationsRpcParam = Exact<{
   tlfID: TLFID,
   topicType: TopicType,
   membersType: ConversationMembersType,
-  summarizeMaxMsgs: boolean,
-  includeAuxiliaryInfo: boolean
+  summarizeMaxMsgs: boolean
 }>
 
 export type remoteGetThreadRemoteRpcParam = Exact<{

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -851,9 +851,6 @@ export type Conversation = {
 export type ConversationAuxiliaryInfo = {
   conversationCtime: gregor1.Time,
   conversationCreator: gregor1.UID,
-  headlineMtime?: ?gregor1.Time,
-  headlineModifier?: ?gregor1.UID,
-  headlineMessageID?: ?MessageID,
   readerCount: int,
 }
 
@@ -1131,7 +1128,7 @@ export type GetPublicConversationsRes = {
 }
 
 export type GetTLFConversationsLocalRes = {
-  convs?: ?Array<ConversationLocal>,
+  convs?: ?Array<InboxUIItem>,
   offline: boolean,
   rateLimits?: ?Array<RateLimit>,
 }
@@ -1236,6 +1233,7 @@ export type InboxUIItem = {
   name: string,
   snippet: string,
   channel: string,
+  headline: string,
   visibility: TLFVisibility,
   participants?: ?Array<string>,
   status: ConversationStatus,

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -116,6 +116,10 @@
           "name": "channel"
         },
         {
+          "type": "string",
+          "name": "headline"
+        },
+        {
           "type": "TLFVisibility",
           "name": "visibility"
         },

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -139,6 +139,10 @@
           "name": "membersType"
         },
         {
+          "type": "gregor1.Time",
+          "name": "time"
+        },
+        {
           "type": [
             null,
             "ConversationNotificationInfo"
@@ -146,8 +150,11 @@
           "name": "notifications"
         },
         {
-          "type": "gregor1.Time",
-          "name": "time"
+          "type": [
+            null,
+            "ConversationCreatorInfoLocal"
+          ],
+          "name": "creatorInfo"
         },
         {
           "type": [

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -504,19 +504,29 @@
     },
     {
       "type": "record",
-      "name": "ConversationAuxiliaryInfo",
+      "name": "ConversationCreatorInfo",
       "fields": [
         {
           "type": "gregor1.Time",
-          "name": "conversationCtime"
+          "name": "ctime"
         },
         {
           "type": "gregor1.UID",
-          "name": "conversationCreator"
+          "name": "uid"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "ConversationCreatorInfoLocal",
+      "fields": [
+        {
+          "type": "gregor1.Time",
+          "name": "ctime"
         },
         {
-          "type": "int",
-          "name": "readerCount"
+          "type": "string",
+          "name": "username"
         }
       ]
     },
@@ -559,9 +569,9 @@
         {
           "type": [
             null,
-            "ConversationAuxiliaryInfo"
+            "ConversationCreatorInfo"
           ],
-          "name": "auxiliaryInfo"
+          "name": "creatorInfo"
         }
       ]
     },

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -515,27 +515,6 @@
           "name": "conversationCreator"
         },
         {
-          "type": [
-            null,
-            "gregor1.Time"
-          ],
-          "name": "headlineMtime"
-        },
-        {
-          "type": [
-            null,
-            "gregor1.UID"
-          ],
-          "name": "headlineModifier"
-        },
-        {
-          "type": [
-            null,
-            "MessageID"
-          ],
-          "name": "headlineMessageID"
-        },
-        {
           "type": "int",
           "name": "readerCount"
         }

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1130,9 +1130,9 @@
         {
           "type": [
             null,
-            "ConversationAuxiliaryInfo"
+            "ConversationCreatorInfoLocal"
           ],
-          "name": "auxiliaryInfo"
+          "name": "creatorInfo"
         },
         {
           "type": [
@@ -2594,10 +2594,6 @@
         {
           "name": "membersType",
           "type": "ConversationMembersType"
-        },
-        {
-          "name": "includeAuxiliaryInfo",
-          "type": "boolean"
         }
       ],
       "response": "GetTLFConversationsLocalRes"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1859,7 +1859,7 @@
         {
           "type": {
             "type": "array",
-            "items": "ConversationLocal"
+            "items": "InboxUIItem"
           },
           "name": "convs"
         },

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -893,10 +893,6 @@
         {
           "name": "summarizeMaxMsgs",
           "type": "boolean"
-        },
-        {
-          "name": "includeAuxiliaryInfo",
-          "type": "boolean"
         }
       ],
       "response": "GetTLFConversationsRes"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -845,13 +845,17 @@ export type Conversation = {
   notifications?: ?ConversationNotificationInfo,
   maxMsgs?: ?Array<MessageBoxed>,
   maxMsgSummaries?: ?Array<MessageSummary>,
-  auxiliaryInfo?: ?ConversationAuxiliaryInfo,
+  creatorInfo?: ?ConversationCreatorInfo,
 }
 
-export type ConversationAuxiliaryInfo = {
-  conversationCtime: gregor1.Time,
-  conversationCreator: gregor1.UID,
-  readerCount: int,
+export type ConversationCreatorInfo = {
+  ctime: gregor1.Time,
+  uid: gregor1.UID,
+}
+
+export type ConversationCreatorInfoLocal = {
+  ctime: gregor1.Time,
+  username: string,
 }
 
 export type ConversationErrorLocal = {
@@ -920,7 +924,7 @@ export type ConversationLocal = {
   error?: ?ConversationErrorLocal,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
-  auxiliaryInfo?: ?ConversationAuxiliaryInfo,
+  creatorInfo?: ?ConversationCreatorInfoLocal,
   notifications?: ?ConversationNotificationInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -1238,8 +1242,9 @@ export type InboxUIItem = {
   participants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
-  notifications?: ?ConversationNotificationInfo,
   time: gregor1.Time,
+  notifications?: ?ConversationNotificationInfo,
+  creatorInfo?: ?ConversationCreatorInfoLocal,
   finalizeInfo?: ?ConversationFinalizeInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -2028,8 +2033,7 @@ export type localGetMessagesLocalRpcParam = Exact<{
 export type localGetTLFConversationsLocalRpcParam = Exact<{
   tlfName: string,
   topicType: TopicType,
-  membersType: ConversationMembersType,
-  includeAuxiliaryInfo: boolean
+  membersType: ConversationMembersType
 }>
 
 export type localGetThreadLocalRpcParam = Exact<{
@@ -2207,8 +2211,7 @@ export type remoteGetTLFConversationsRpcParam = Exact<{
   tlfID: TLFID,
   topicType: TopicType,
   membersType: ConversationMembersType,
-  summarizeMaxMsgs: boolean,
-  includeAuxiliaryInfo: boolean
+  summarizeMaxMsgs: boolean
 }>
 
 export type remoteGetThreadRemoteRpcParam = Exact<{

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -851,9 +851,6 @@ export type Conversation = {
 export type ConversationAuxiliaryInfo = {
   conversationCtime: gregor1.Time,
   conversationCreator: gregor1.UID,
-  headlineMtime?: ?gregor1.Time,
-  headlineModifier?: ?gregor1.UID,
-  headlineMessageID?: ?MessageID,
   readerCount: int,
 }
 
@@ -1131,7 +1128,7 @@ export type GetPublicConversationsRes = {
 }
 
 export type GetTLFConversationsLocalRes = {
-  convs?: ?Array<ConversationLocal>,
+  convs?: ?Array<InboxUIItem>,
   offline: boolean,
   rateLimits?: ?Array<RateLimit>,
 }
@@ -1236,6 +1233,7 @@ export type InboxUIItem = {
   name: string,
   snippet: string,
   channel: string,
+  headline: string,
   visibility: TLFVisibility,
   participants?: ?Array<string>,
   status: ConversationStatus,


### PR DESCRIPTION
Patch does the following:

1.) Removes `ConversationAuxiliaryInfo` and replaces with `ConversationCreatorInfo` and `ConversationCreatorInfoLocal`. 
2.) Lookup username of creator during localization process.
3.) Add `Headline` and creator info to `InboxUIItem` for frontend to render.
4.) Change return type of `GetTLFConversations` to be `InboxUIItems` for easier processing.
5.) Change `keybase chat list-channels` to output headline and created by info.