### PR TITLE
make big team rows bold if they have unread messages

### DIFF
--- a/shared/chat/inbox/row/big-team-rows.js
+++ b/shared/chat/inbox/row/big-team-rows.js
@@ -48,6 +48,7 @@ type ChannelProps = {
 
 class BigTeamChannelRow extends PureComponent<ChannelProps> {
   render() {
+    const boldOverride = this.props.hasUnread ? globalStyles.fontBold : null
     return (
       <ClickableBox onClick={this.props.onSelectConversation}>
         <Box style={channelRowContainerStyle}>
@@ -59,7 +60,10 @@ class BigTeamChannelRow extends PureComponent<ChannelProps> {
           >
             <Text
               type={this.props.isSelected ? 'BodySemibold' : 'Body'}
-              style={{color: this.props.isSelected ? globalColors.white : globalColors.black_75}}
+              style={{
+                ...boldOverride,
+                color: this.props.isSelected ? globalColors.white : globalColors.black_75,
+              }}
             >
               {this.props.channelname}
             </Text>


### PR DESCRIPTION
I think this looks more clear on both desktop and mobile, otherwise it is just way too subtle to find an unread big team row. This might not be the final design, but I think it would be nice to get in to make team chat a little easier to use in the interim. Looks like this:

![image](https://user-images.githubusercontent.com/1250314/29852365-b51c92f0-8d07-11e7-96b8-8b4a44e51145.png)

cc @cecileboucheron @malgorithms 