### PR TITLE
Add implicit team lookup test for resolved assertions

### DIFF
--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -133,3 +133,37 @@ func TestImplicitTeamReader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, keybase1.TeamRole_READER, u1Role)
 }
+
+// Test the looking up an implicit team involving a resolved assertion gives the resolved iteam.
+func TestLookupImplicitTeamResolvedSocialAssertion(t *testing.T) {
+	fus, tcs, cleanup := setupNTests(t, 1)
+	defer cleanup()
+
+	// assumption: t_tracy@rooter resolves to t_tracy
+
+	displayName1 := fus[0].Username + ",t_tracy@rooter"
+	displayName2 := fus[0].Username + ",t_tracy"
+
+	teamID1, impTeamName1, err := LookupOrCreateImplicitTeam(context.TODO(), tcs[0].G, displayName1, false /*isPublic*/)
+	require.NoError(t, err)
+	teamID2, _, err := LookupOrCreateImplicitTeam(context.TODO(), tcs[0].G, displayName2, false /*isPublic*/)
+	require.NoError(t, err)
+
+	require.Equal(t, teamID1, teamID2, "implicit team ID should be the same for %v and %v", displayName1, displayName2)
+
+	team, err := Load(context.TODO(), tcs[0].G, keybase1.LoadTeamArg{
+		ID: teamID1,
+	})
+	require.NoError(t, err)
+	owners, err := team.UsersWithRole(keybase1.TeamRole_OWNER)
+	require.NoError(t, err)
+	require.Len(t, owners, 2)
+	require.Len(t, team.chain().inner.ActiveInvites, 0, "number of invites")
+
+	teamDisplay, err := team.ImplicitTeamDisplayNameString(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, displayName1, teamDisplay)
+	formatName, err := FormatImplicitTeamDisplayName(context.TODO(), tcs[0].G, impTeamName1)
+	require.NoError(t, err)
+	require.Equal(t, displayName1, formatName)
+}


### PR DESCRIPTION
This test failed. Do you think it should pass? If so I'll make a server ticket.

With this test failing it seems like these commands could cause an unnecessary SBS conflict. Depending on how the client is implemented.
```
keybase chat send t_tracy hello1
keybase chat send t_tracy@rooter hello2
```

```
mkdir /keybase/private/me,t_tracy
mkdir /keybase/private/me,t_tracy@rooter
```