### PR TITLE
Call CheckReachability if unreachable before unlockDeviceKeys

### DIFF
--- a/go/engine/bootstrap_test.go
+++ b/go/engine/bootstrap_test.go
@@ -129,4 +129,8 @@ func (s OfflineConnectivityMonitor) IsConnected(ctx context.Context) libkb.Conne
 	return libkb.ConnectivityMonitorNo
 }
 
+func (s OfflineConnectivityMonitor) CheckReachability(ctx context.Context) error {
+	return nil
+}
+
 var _ libkb.ConnectivityMonitor = OfflineConnectivityMonitor{}

--- a/go/engine/login_provisioned_device.go
+++ b/go/engine/login_provisioned_device.go
@@ -173,6 +173,16 @@ func (e *LoginProvisionedDevice) run(ctx *Context) error {
 
 func (e *LoginProvisionedDevice) unlockDeviceKeys(ctx *Context, me *libkb.User) error {
 
+	// CORE-5876 idea that lksec will be unusable if reachablity state is NO
+	// and the user changed passphrase with a different device since it won't
+	// be able to sync the new server half.
+	if e.G().ConnectivityMonitor.IsConnected(ctx.NetContext) != libkb.ConnectivityMonitorYes {
+		e.G().Log.Debug("LoginProvisionedDevice: in unlockDeviceKeys, ConnectivityMonitor says not reachable, check to make sure")
+		if err := e.G().ConnectivityMonitor.CheckReachability(ctx.NetContext); err != nil {
+			e.G().Log.Debug("error checking reachability: %s", err)
+		}
+	}
+
 	ska := libkb.SecretKeyArg{
 		Me:      me,
 		KeyType: libkb.DeviceSigningKeyType,

--- a/go/engine/login_provisioned_device.go
+++ b/go/engine/login_provisioned_device.go
@@ -180,6 +180,9 @@ func (e *LoginProvisionedDevice) unlockDeviceKeys(ctx *Context, me *libkb.User) 
 		e.G().Log.Debug("LoginProvisionedDevice: in unlockDeviceKeys, ConnectivityMonitor says not reachable, check to make sure")
 		if err := e.G().ConnectivityMonitor.CheckReachability(ctx.NetContext); err != nil {
 			e.G().Log.Debug("error checking reachability: %s", err)
+		} else {
+			connected := e.G().ConnectivityMonitor.IsConnected(ctx.NetContext)
+			e.G().Log.Debug("after CheckReachability(), IsConnected() => %v (connected? %v)", connected, connected == libkb.ConnectivityMonitorYes)
 		}
 	}
 

--- a/go/libkb/connectivity_monitor.go
+++ b/go/libkb/connectivity_monitor.go
@@ -11,4 +11,8 @@ func (s NullConnectivityMonitor) IsConnected(ctx context.Context) ConnectivityMo
 	return ConnectivityMonitorYes
 }
 
+func (s NullConnectivityMonitor) CheckReachability(ctx context.Context) error {
+	return nil
+}
+
 var _ ConnectivityMonitor = NullConnectivityMonitor{}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -577,6 +577,7 @@ const (
 
 type ConnectivityMonitor interface {
 	IsConnected(ctx context.Context) ConnectivityMonitorResult
+	CheckReachability(ctx context.Context) error
 }
 
 type TeamLoader interface {

--- a/go/service/reachability.go
+++ b/go/service/reachability.go
@@ -91,3 +91,8 @@ func (h *reachability) IsConnected(ctx context.Context) libkb.ConnectivityMonito
 		return libkb.ConnectivityMonitorUnknown
 	}
 }
+
+func (h *reachability) CheckReachability(ctx context.Context) error {
+	h.check()
+	return nil
+}


### PR DESCRIPTION
Scenario:

1. device A in unreachable state (reachability set to No) and logged out
2. user changes passphrase on device B
3. login on device A.  syncer doesn't attempt to get server half for lksec because it thinks it is unreachable, so doesn't get new server half and cannot unlock device keys.

    2017-08-20T17:41:02.680636-05:00 ▶ [DEBU keybase syncer.go:32] 5e53f + Syncer.Load(8d4f86139289c98d7d19155f3c962819)
    2017-08-20T17:41:02.682178-05:00 ▶ [DEBU keybase sync_secret.go:97] 5e540 | loadFromStorage -> found=true, err=ok
    2017-08-20T17:41:02.682269-05:00 ▶ [DEBU keybase sync_secret.go:116] 5e541 | Loaded version 5
    2017-08-20T17:41:02.682319-05:00 ▶ [DEBU keybase syncer.go:42] 5e542 | **not connected, won't sync with server**
    2017-08-20T17:41:02.682369-05:00 ▶ [DEBU keybase syncer.go:34] 5e543 - Syncer.Load(8d4f86139289c98d7d19155f3c962819) -> ok

a little later:

    2017-08-20T17:41:02.684243-05:00 ▶ [DEBU keybase util.go:424] 5e55d - LKSec#Decrypt() -> ERROR: Bad passphrase: failed to open secretbox.
    2017-08-20T17:41:02.684342-05:00 ▶ [DEBU keybase skb.go:356] 5e55e - SKB:lksUnlock -> ERROR: Bad passphrase: failed to open secretbox.

The log doesn't contain a mention of when/how the reachability changed.

This patch checks reachability before device key unlock if currently unreachable.