### PR TITLE
Reason is an IdentifyReason

### DIFF
--- a/go/protocol/keybase1/identify.go
+++ b/go/protocol/keybase1/identify.go
@@ -204,7 +204,7 @@ type ResolveIdentifyImplicitTeamArg struct {
 	IsPublic         bool                `codec:"isPublic" json:"isPublic"`
 	DoIdentifies     bool                `codec:"doIdentifies" json:"doIdentifies"`
 	Create           bool                `codec:"create" json:"create"`
-	Reason           string              `codec:"reason" json:"reason"`
+	Reason           IdentifyReason      `codec:"reason" json:"reason"`
 	IdentifyBehavior TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
@@ -216,7 +216,7 @@ func (o ResolveIdentifyImplicitTeamArg) DeepCopy() ResolveIdentifyImplicitTeamAr
 		IsPublic:         o.IsPublic,
 		DoIdentifies:     o.DoIdentifies,
 		Create:           o.Create,
-		Reason:           o.Reason,
+		Reason:           o.Reason.DeepCopy(),
 		IdentifyBehavior: o.IdentifyBehavior.DeepCopy(),
 	}
 }

--- a/protocol/avdl/keybase1/identify.avdl
+++ b/protocol/avdl/keybase1/identify.avdl
@@ -78,13 +78,14 @@ protocol identify {
     string assertions,
     string suffix,
     boolean isPublic,
-    boolean doIdentifies, // Whether core runs identifies on all the people or assertions
-    boolean create,       // Whether to create the team if none exists
-    string reason,     // Displayed in the header of the tracker popup
+    boolean doIdentifies,  // Whether core runs identifies on all the people or assertions
+    boolean create,        // Whether to create the team if none exists
+    IdentifyReason reason, // Displayed in the header of the tracker popup
     TLFIdentifyBehavior identifyBehavior
   );
   record ResolveIdentifyImplicitTeamRes {
-    // Display name possibly updated by resolutions and conflicts. With the logged-in user first (so not a canonical CORE display name).
+    // Display name possibly updated by resolutions and conflicts.
+    // With the logged-in user first (so not a canonical CORE display name).
     string displayName; // example: "alice,bob,zed#bot (conflicted copy 2017-05-08 #3)"
     TeamID teamID;
     array<UserVersion> writers; // Members of the team that can write. The team OWNERs.

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5223,7 +5223,7 @@ export type identifyResolveIdentifyImplicitTeamRpcParam = Exact<{
   isPublic: boolean,
   doIdentifies: boolean,
   create: boolean,
-  reason: string,
+  reason: IdentifyReason,
   identifyBehavior: TLFIdentifyBehavior
 }>
 

--- a/protocol/json/keybase1/identify.json
+++ b/protocol/json/keybase1/identify.json
@@ -295,7 +295,7 @@
         },
         {
           "name": "reason",
-          "type": "string"
+          "type": "IdentifyReason"
         },
         {
           "name": "identifyBehavior",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5223,7 +5223,7 @@ export type identifyResolveIdentifyImplicitTeamRpcParam = Exact<{
   isPublic: boolean,
   doIdentifies: boolean,
   create: boolean,
-  reason: string,
+  reason: IdentifyReason,
   identifyBehavior: TLFIdentifyBehavior
 }>
 


### PR DESCRIPTION
We already have a type for `IdentifyReason`, so use it instead of string.