### PR TITLE
Dont render unhandled messages, fixes initial timestamp

### DIFF
--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -114,6 +114,9 @@ function* _incomingMessage(action: Constants.IncomingMessage): SagaGenerator<any
         const yourDeviceName = yield select(Shared.devicenameSelector)
         const conversationIDKey = Constants.conversationIDToKey(incomingMessage.convID)
         const message = _unboxedToMessage(messageUnboxed, yourName, yourDeviceName, conversationIDKey)
+        if (message.type === 'Unhandled') {
+          return
+        }
         const svcShouldDisplayNotification = incomingMessage.displayDesktopNotification
 
         const pagination = incomingMessage.pagination
@@ -328,7 +331,10 @@ function* _updateThread({
       // about to add a newly received version of the same message.
       yield put(Creators.removeOutboxMessage(conversationIDKey, message.outboxID))
     }
-    newMessages.push(message)
+
+    if (message.type !== 'Unhandled') {
+      newMessages.push(message)
+    }
   }
 
   newMessages = newMessages.reverse()

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -61,7 +61,7 @@ const factory = (
     case 'timestamp':
       return <Timestamp messageKey={messageKey} />
     case 'messageIDUnhandled':
-      return <Box data-unhandled={true} data-messageKey={messageKey} />
+      return null
   }
 
   return <Box data-messageKey={messageKey} />


### PR DESCRIPTION
I was looking into the timestamp ticket and it seems to be rendering the dates correctly.
I did notice the initial timestamp was missing, this is cause while rendering it looks to see if the previous message exists to determine if its the first message and draws the timestamp. Often this first message is actually unhandled so it doesn't go through the wrapper code path. this easiest way to deal with this is to filter out those (they don't actually render anything anyways)
@keybase/react-hackers 