### PR TITLE
fix classname

### DIFF
--- a/shared/common-adapters/user-proofs.desktop.js
+++ b/shared/common-adapters/user-proofs.desktop.js
@@ -95,7 +95,7 @@ class ProofRow extends React.PureComponent<ProofRowProps, ProofRowState> {
               <Text
                 inline={true}
                 type="Body"
-                className="underline"
+                className="hover-underline"
                 style={{
                   ...shared.proofNameStyle(proof),
                   ...globalStyles.selectable,


### PR DESCRIPTION
Not sure how this happened but this should be hover underline
@keybase/react-hackers 