### PR TITLE
don't modify messages with @ mentions anymore, instead just let clients know what users are mentioned CORE-5908

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -454,7 +454,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				}
 				desktopNotification := g.shouldDisplayDesktopNotification(ctx, uid, conv, decmsg)
 				activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-					Message: utils.PresentMessageUnboxed(decmsg),
+					Message: utils.PresentMessageUnboxed(ctx, g.G().GetUPAKLoader(), decmsg),
 					ConvID:  nm.ConvID,
 					Conv:    g.presentUIItem(conv),
 					DisplayDesktopNotification: desktopNotification,

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -345,14 +345,13 @@ func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 		kind := chat1.NotificationKind_GENERIC
 		switch typ {
 		case chat1.MessageType_TEXT:
-			atMentions, chanMention := utils.ParseAtMentionedUIDs(ctx,
-				msg.Valid().MessageBody.Text().Body, g.G().GetUPAKLoader(), &g.DebugLabeler)
-			for _, at := range atMentions {
+			for _, at := range msg.Valid().AtMentions {
 				if at.Eq(uid) {
 					kind = chat1.NotificationKind_ATMENTION
 					break
 				}
 			}
+			chanMention := msg.Valid().ChannelMention
 			notifyFromChanMention := false
 			if chanMention == chat1.ChannelMention_HERE || chanMention == chat1.ChannelMention_ALL {
 				notifyFromChanMention = conv.Notifications.ChannelWide
@@ -454,7 +453,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				}
 				desktopNotification := g.shouldDisplayDesktopNotification(ctx, uid, conv, decmsg)
 				activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-					Message: utils.PresentMessageUnboxed(ctx, g.G().GetUPAKLoader(), decmsg),
+					Message: utils.PresentMessageUnboxed(decmsg),
 					ConvID:  nm.ConvID,
 					Conv:    g.presentUIItem(conv),
 					DisplayDesktopNotification: desktopNotification,

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -403,20 +403,11 @@ func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePla
 	chanMention := chat1.ChannelMention_NONE
 	switch plaintext.ClientHeader.MessageType {
 	case chat1.MessageType_TEXT:
-		var newBody string
-		newBody, atMentions, chanMention = utils.ParseAndDecorateAtMentionedUIDs(ctx,
+		atMentions, chanMention = utils.ParseAtMentionedUIDs(ctx,
 			plaintext.MessageBody.Text().Body, s.G().GetUPAKLoader(), &s.DebugLabeler)
-		msg.MessageBody = chat1.NewMessageBodyWithText(chat1.MessageText{
-			Body: newBody,
-		})
 	case chat1.MessageType_EDIT:
-		var newBody string
-		newBody, atMentions, chanMention = utils.ParseAndDecorateAtMentionedUIDs(ctx,
+		atMentions, chanMention = utils.ParseAtMentionedUIDs(ctx,
 			plaintext.MessageBody.Edit().Body, s.G().GetUPAKLoader(), &s.DebugLabeler)
-		msg.MessageBody = chat1.NewMessageBodyWithEdit(chat1.MessageEdit{
-			MessageID: plaintext.MessageBody.Edit().MessageID,
-			Body:      newBody,
-		})
 	}
 
 	if len(atMentions) > 0 {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -413,10 +413,10 @@ func (h *Server) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg
 	}, nil
 }
 
-func (h *Server) presentThreadView(tv chat1.ThreadView) (res chat1.UIMessages) {
+func (h *Server) presentThreadView(ctx context.Context, tv chat1.ThreadView) (res chat1.UIMessages) {
 	res.Pagination = utils.PresentPagination(tv.Pagination)
 	for _, msg := range tv.Messages {
-		res.Messages = append(res.Messages, utils.PresentMessageUnboxed(msg))
+		res.Messages = append(res.Messages, utils.PresentMessageUnboxed(ctx, h.G().GetUPAKLoader(), msg))
 	}
 	return res
 }
@@ -508,7 +508,7 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 			h.Debug(ctx, "GetThreadNonblock: sending cached response: %d messages", len(resThread.Messages))
 			var jsonPt []byte
 			var err error
-			pt := h.presentThreadView(*resThread)
+			pt := h.presentThreadView(ctx, *resThread)
 			if jsonPt, err = json.Marshal(pt); err != nil {
 				h.Debug(ctx, "GetThreadNonblock: failed to JSON cached response: %s", err)
 				return
@@ -543,7 +543,7 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 		h.Debug(ctx, "GetThreadNonblock: sending full response: %d messages", len(remoteThread.Messages))
 		uilock.Lock()
 		defer uilock.Unlock()
-		uires := h.presentThreadView(remoteThread)
+		uires := h.presentThreadView(bctx, remoteThread)
 		var jsonUIRes []byte
 		if jsonUIRes, fullErr = json.Marshal(uires); fullErr != nil {
 			h.Debug(ctx, "GetThreadNonblock: failed to JSON full result: %s", fullErr)

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -416,7 +416,7 @@ func (h *Server) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg
 func (h *Server) presentThreadView(ctx context.Context, tv chat1.ThreadView) (res chat1.UIMessages) {
 	res.Pagination = utils.PresentPagination(tv.Pagination)
 	for _, msg := range tv.Messages {
-		res.Messages = append(res.Messages, utils.PresentMessageUnboxed(ctx, h.G().GetUPAKLoader(), msg))
+		res.Messages = append(res.Messages, utils.PresentMessageUnboxed(msg))
 	}
 	return res
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -843,6 +843,18 @@ func TestChatSrvPostLocalAtMention(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no new message")
 		}
+
+		mustPostLocalForTest(t, ctc, users[0], created,
+			chat1.NewMessageBodyWithText(chat1.MessageText{Body: "@channel"}))
+		select {
+		case info := <-listener.newMessage:
+			require.True(t, info.Message.IsValid())
+			require.Equal(t, chat1.MessageType_TEXT, info.Message.GetMessageType())
+			require.Zero(t, len(info.Message.Valid().AtMentions))
+			require.True(t, info.DisplayDesktopNotification)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no new message")
+		}
 	})
 }
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -851,6 +851,7 @@ func TestChatSrvPostLocalAtMention(t *testing.T) {
 			require.True(t, info.Message.IsValid())
 			require.Equal(t, chat1.MessageType_TEXT, info.Message.GetMessageType())
 			require.Zero(t, len(info.Message.Valid().AtMentions))
+			require.Equal(t, chat1.ChannelMention_ALL, info.Message.Valid().ChannelMention)
 			require.True(t, info.DisplayDesktopNotification)
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no new message")

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -639,6 +639,7 @@ func PresentMessageUnboxed(rawMsg chat1.MessageUnboxed) (res chat1.UIMessage) {
 			SenderDeviceRevokedAt: rawMsg.Valid().SenderDeviceRevokedAt,
 			Superseded:            rawMsg.Valid().ServerHeader.SupersededBy != 0,
 			AtMentions:            rawMsg.Valid().AtMentionUsernames,
+			ChannelMention:        rawMsg.Valid().ChannelMention,
 		})
 	case chat1.MessageUnboxedState_OUTBOX:
 		var body string

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -611,35 +611,7 @@ func PresentConversationLocals(convs []chat1.ConversationLocal) (res []chat1.Inb
 	return res
 }
 
-func getAtMentionUsernames(ctx context.Context, upak libkb.UPAKLoader, body chat1.MessageBody) (res []string) {
-	typ, err := body.MessageType()
-	if err != nil {
-		return nil
-	}
-
-	var atMentions []gregor1.UID
-	switch typ {
-	case chat1.MessageType_TEXT:
-		atMentions, _ = ParseAtMentionedUIDs(ctx, body.Text().Body, upak, nil)
-	case chat1.MessageType_EDIT:
-		atMentions, _ = ParseAtMentionedUIDs(ctx, body.Edit().Body, upak, nil)
-	}
-
-	usernames := make(map[string]bool)
-	for _, uid := range atMentions {
-		name, err := upak.LookupUsername(ctx, keybase1.UID(uid.String()))
-		if err != nil {
-			continue
-		}
-		usernames[name.String()] = true
-	}
-	for u := range usernames {
-		res = append(res, u)
-	}
-	return res
-}
-
-func PresentMessageUnboxed(ctx context.Context, upak libkb.UPAKLoader, rawMsg chat1.MessageUnboxed) (res chat1.UIMessage) {
+func PresentMessageUnboxed(rawMsg chat1.MessageUnboxed) (res chat1.UIMessage) {
 	state, err := rawMsg.State()
 	if err != nil {
 		res = chat1.NewUIMessageWithError(chat1.MessageUnboxedError{
@@ -666,7 +638,7 @@ func PresentMessageUnboxed(ctx context.Context, upak libkb.UPAKLoader, rawMsg ch
 			SenderDeviceType:      rawMsg.Valid().SenderDeviceType,
 			SenderDeviceRevokedAt: rawMsg.Valid().SenderDeviceRevokedAt,
 			Superseded:            rawMsg.Valid().ServerHeader.SupersededBy != 0,
-			AtMentions:            getAtMentionUsernames(ctx, upak, rawMsg.Valid().MessageBody),
+			AtMentions:            rawMsg.Valid().AtMentionUsernames,
 		})
 	case chat1.MessageUnboxedState_OUTBOX:
 		var body string

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -486,11 +486,13 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 	// hit notify router with new message
 	if m.world.TcsByID[uid.String()].G.NotifyRouter != nil {
 		activity := chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-			Message: utils.PresentMessageUnboxed(chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
-				ClientHeader: m.headerToVerifiedForTesting(inserted.ClientHeader),
-				ServerHeader: *inserted.ServerHeader,
-				MessageBody:  m.createBogusBody(inserted.GetMessageType()),
-			})),
+			Message: utils.PresentMessageUnboxed(ctx,
+				m.world.TcsByID[uid.String()].G.GetUPAKLoader(),
+				chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
+					ClientHeader: m.headerToVerifiedForTesting(inserted.ClientHeader),
+					ServerHeader: *inserted.ServerHeader,
+					MessageBody:  m.createBogusBody(inserted.GetMessageType()),
+				})),
 		})
 		m.world.TcsByID[uid.String()].G.NotifyRouter.HandleNewChatActivity(context.Background(),
 			keybase1.UID(uid.String()), &activity)

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -486,8 +486,7 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 	// hit notify router with new message
 	if m.world.TcsByID[uid.String()].G.NotifyRouter != nil {
 		activity := chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-			Message: utils.PresentMessageUnboxed(ctx,
-				m.world.TcsByID[uid.String()].G.GetUPAKLoader(),
+			Message: utils.PresentMessageUnboxed(
 				chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
 					ClientHeader: m.headerToVerifiedForTesting(inserted.ClientHeader),
 					ServerHeader: *inserted.ServerHeader,

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -188,6 +188,18 @@ func (o InboxUIItems) DeepCopy() InboxUIItems {
 	}
 }
 
+type UIAtMention struct {
+	Username string `codec:"username" json:"username"`
+	Position int    `codec:"position" json:"position"`
+}
+
+func (o UIAtMention) DeepCopy() UIAtMention {
+	return UIAtMention{
+		Username: o.Username,
+		Position: o.Position,
+	}
+}
+
 type UIMessageValid struct {
 	MessageID             MessageID     `codec:"messageID" json:"messageID"`
 	Ctime                 gregor1.Time  `codec:"ctime" json:"ctime"`
@@ -198,6 +210,7 @@ type UIMessageValid struct {
 	SenderDeviceType      string        `codec:"senderDeviceType" json:"senderDeviceType"`
 	Superseded            bool          `codec:"superseded" json:"superseded"`
 	SenderDeviceRevokedAt *gregor1.Time `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
+	AtMentions            []UIAtMention `codec:"atMentions" json:"atMentions"`
 }
 
 func (o UIMessageValid) DeepCopy() UIMessageValid {
@@ -223,6 +236,14 @@ func (o UIMessageValid) DeepCopy() UIMessageValid {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.SenderDeviceRevokedAt),
+		AtMentions: (func(x []UIAtMention) []UIAtMention {
+			var ret []UIAtMention
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.AtMentions),
 	}
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -188,18 +188,6 @@ func (o InboxUIItems) DeepCopy() InboxUIItems {
 	}
 }
 
-type UIAtMention struct {
-	Username string `codec:"username" json:"username"`
-	Position int    `codec:"position" json:"position"`
-}
-
-func (o UIAtMention) DeepCopy() UIAtMention {
-	return UIAtMention{
-		Username: o.Username,
-		Position: o.Position,
-	}
-}
-
 type UIMessageValid struct {
 	MessageID             MessageID     `codec:"messageID" json:"messageID"`
 	Ctime                 gregor1.Time  `codec:"ctime" json:"ctime"`
@@ -210,7 +198,7 @@ type UIMessageValid struct {
 	SenderDeviceType      string        `codec:"senderDeviceType" json:"senderDeviceType"`
 	Superseded            bool          `codec:"superseded" json:"superseded"`
 	SenderDeviceRevokedAt *gregor1.Time `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
-	AtMentions            []UIAtMention `codec:"atMentions" json:"atMentions"`
+	AtMentions            []string      `codec:"atMentions" json:"atMentions"`
 }
 
 func (o UIMessageValid) DeepCopy() UIMessageValid {
@@ -236,10 +224,10 @@ func (o UIMessageValid) DeepCopy() UIMessageValid {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.SenderDeviceRevokedAt),
-		AtMentions: (func(x []UIAtMention) []UIAtMention {
-			var ret []UIAtMention
+		AtMentions: (func(x []string) []string {
+			var ret []string
 			for _, v := range x {
-				vCopy := v.DeepCopy()
+				vCopy := v
 				ret = append(ret, vCopy)
 			}
 			return ret

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -189,16 +189,17 @@ func (o InboxUIItems) DeepCopy() InboxUIItems {
 }
 
 type UIMessageValid struct {
-	MessageID             MessageID     `codec:"messageID" json:"messageID"`
-	Ctime                 gregor1.Time  `codec:"ctime" json:"ctime"`
-	OutboxID              *string       `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
-	MessageBody           MessageBody   `codec:"messageBody" json:"messageBody"`
-	SenderUsername        string        `codec:"senderUsername" json:"senderUsername"`
-	SenderDeviceName      string        `codec:"senderDeviceName" json:"senderDeviceName"`
-	SenderDeviceType      string        `codec:"senderDeviceType" json:"senderDeviceType"`
-	Superseded            bool          `codec:"superseded" json:"superseded"`
-	SenderDeviceRevokedAt *gregor1.Time `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
-	AtMentions            []string      `codec:"atMentions" json:"atMentions"`
+	MessageID             MessageID      `codec:"messageID" json:"messageID"`
+	Ctime                 gregor1.Time   `codec:"ctime" json:"ctime"`
+	OutboxID              *string        `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	MessageBody           MessageBody    `codec:"messageBody" json:"messageBody"`
+	SenderUsername        string         `codec:"senderUsername" json:"senderUsername"`
+	SenderDeviceName      string         `codec:"senderDeviceName" json:"senderDeviceName"`
+	SenderDeviceType      string         `codec:"senderDeviceType" json:"senderDeviceType"`
+	Superseded            bool           `codec:"superseded" json:"superseded"`
+	SenderDeviceRevokedAt *gregor1.Time  `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
+	AtMentions            []string       `codec:"atMentions" json:"atMentions"`
+	ChannelMention        ChannelMention `codec:"channelMention" json:"channelMention"`
 }
 
 func (o UIMessageValid) DeepCopy() UIMessageValid {
@@ -232,6 +233,7 @@ func (o UIMessageValid) DeepCopy() UIMessageValid {
 			}
 			return ret
 		})(o.AtMentions),
+		ChannelMention: o.ChannelMention.DeepCopy(),
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1742,6 +1742,9 @@ type MessageUnboxedValid struct {
 	HeaderSignature       *SignatureInfo              `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
 	VerificationKey       *[]byte                     `codec:"verificationKey,omitempty" json:"verificationKey,omitempty"`
 	SenderDeviceRevokedAt *gregor1.Time               `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
+	AtMentionUsernames    []string                    `codec:"atMentionUsernames" json:"atMentionUsernames"`
+	AtMentions            []gregor1.UID               `codec:"atMentions" json:"atMentions"`
+	ChannelMention        ChannelMention              `codec:"channelMention" json:"channelMention"`
 }
 
 func (o MessageUnboxedValid) DeepCopy() MessageUnboxedValid {
@@ -1780,6 +1783,23 @@ func (o MessageUnboxedValid) DeepCopy() MessageUnboxedValid {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.SenderDeviceRevokedAt),
+		AtMentionUsernames: (func(x []string) []string {
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.AtMentionUsernames),
+		AtMentions: (func(x []gregor1.UID) []gregor1.UID {
+			var ret []gregor1.UID
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.AtMentions),
+		ChannelMention: o.ChannelMention.DeepCopy(),
 	}
 }
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -66,6 +66,7 @@ protocol chatUi {
     boolean superseded;
     union {null, gregor1.Time} senderDeviceRevokedAt;
     array<string> atMentions;
+    ChannelMention channelMention;
   }
 
   record UIMessageOutbox {

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -55,6 +55,11 @@ protocol chatUi {
     boolean offline;
   }
 
+  record UIAtMention {
+    string username;
+    int position;
+  }
+
   record UIMessageValid {
     MessageID messageID;
     gregor1.Time ctime;
@@ -65,6 +70,7 @@ protocol chatUi {
     string senderDeviceType;
     boolean superseded;
     union {null, gregor1.Time} senderDeviceRevokedAt;
+    array<UIAtMention> atMentions;
   }
 
   record UIMessageOutbox {

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -55,11 +55,6 @@ protocol chatUi {
     boolean offline;
   }
 
-  record UIAtMention {
-    string username;
-    int position;
-  }
-
   record UIMessageValid {
     MessageID messageID;
     gregor1.Time ctime;
@@ -70,7 +65,7 @@ protocol chatUi {
     string senderDeviceType;
     boolean superseded;
     union {null, gregor1.Time} senderDeviceRevokedAt;
-    array<UIAtMention> atMentions;
+    array<string> atMentions;
   }
 
   record UIMessageOutbox {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -295,6 +295,10 @@ protocol local {
     // We aren't sure whether the device was revoked when the message was sent.
     // Re-evaluated when unboxed or pulled from the cache.
     union {null, gregor1.Time} senderDeviceRevokedAt;
+
+    array<string> atMentionUsernames;
+    array<gregor1.UID> atMentions;
+    ChannelMention channelMention;
   }
 
   enum MessageUnboxedErrorType {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1882,6 +1882,7 @@ export type UIMessageValid = {
   superseded: boolean,
   senderDeviceRevokedAt?: ?gregor1.Time,
   atMentions?: ?Array<string>,
+  channelMention: ChannelMention,
 }
 
 export type UIMessages = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1854,6 +1854,11 @@ export type TyperInfo = {
   deviceType: string,
 }
 
+export type UIAtMention = {
+  username: string,
+  position: int,
+}
+
 export type UIMessage =
     { state: 1, valid: ?UIMessageValid }
   | { state: 2, error: ?MessageUnboxedError }
@@ -1878,6 +1883,7 @@ export type UIMessageValid = {
   senderDeviceType: string,
   superseded: boolean,
   senderDeviceRevokedAt?: ?gregor1.Time,
+  atMentions?: ?Array<UIAtMention>,
 }
 
 export type UIMessages = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1514,6 +1514,9 @@ export type MessageUnboxedValid = {
   headerSignature?: ?SignatureInfo,
   verificationKey?: ?bytes,
   senderDeviceRevokedAt?: ?gregor1.Time,
+  atMentionUsernames?: ?Array<string>,
+  atMentions?: ?Array<gregor1.UID>,
+  channelMention: ChannelMention,
 }
 
 export type NameQuery = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1854,11 +1854,6 @@ export type TyperInfo = {
   deviceType: string,
 }
 
-export type UIAtMention = {
-  username: string,
-  position: int,
-}
-
 export type UIMessage =
     { state: 1, valid: ?UIMessageValid }
   | { state: 2, error: ?MessageUnboxedError }
@@ -1883,7 +1878,7 @@ export type UIMessageValid = {
   senderDeviceType: string,
   superseded: boolean,
   senderDeviceRevokedAt?: ?gregor1.Time,
-  atMentions?: ?Array<UIAtMention>,
+  atMentions?: ?Array<string>,
 }
 
 export type UIMessages = {

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -210,20 +210,6 @@
     },
     {
       "type": "record",
-      "name": "UIAtMention",
-      "fields": [
-        {
-          "type": "string",
-          "name": "username"
-        },
-        {
-          "type": "int",
-          "name": "position"
-        }
-      ]
-    },
-    {
-      "type": "record",
       "name": "UIMessageValid",
       "fields": [
         {
@@ -271,7 +257,7 @@
         {
           "type": {
             "type": "array",
-            "items": "UIAtMention"
+            "items": "string"
           },
           "name": "atMentions"
         }

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -260,6 +260,10 @@
             "items": "string"
           },
           "name": "atMentions"
+        },
+        {
+          "type": "ChannelMention",
+          "name": "channelMention"
         }
       ]
     },

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -210,6 +210,20 @@
     },
     {
       "type": "record",
+      "name": "UIAtMention",
+      "fields": [
+        {
+          "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "int",
+          "name": "position"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "UIMessageValid",
       "fields": [
         {
@@ -253,6 +267,13 @@
             "gregor1.Time"
           ],
           "name": "senderDeviceRevokedAt"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "UIAtMention"
+          },
+          "name": "atMentions"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -868,6 +868,24 @@
             "gregor1.Time"
           ],
           "name": "senderDeviceRevokedAt"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "atMentionUsernames"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "gregor1.UID"
+          },
+          "name": "atMentions"
+        },
+        {
+          "type": "ChannelMention",
+          "name": "channelMention"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1882,6 +1882,7 @@ export type UIMessageValid = {
   superseded: boolean,
   senderDeviceRevokedAt?: ?gregor1.Time,
   atMentions?: ?Array<string>,
+  channelMention: ChannelMention,
 }
 
 export type UIMessages = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1854,6 +1854,11 @@ export type TyperInfo = {
   deviceType: string,
 }
 
+export type UIAtMention = {
+  username: string,
+  position: int,
+}
+
 export type UIMessage =
     { state: 1, valid: ?UIMessageValid }
   | { state: 2, error: ?MessageUnboxedError }
@@ -1878,6 +1883,7 @@ export type UIMessageValid = {
   senderDeviceType: string,
   superseded: boolean,
   senderDeviceRevokedAt?: ?gregor1.Time,
+  atMentions?: ?Array<UIAtMention>,
 }
 
 export type UIMessages = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1514,6 +1514,9 @@ export type MessageUnboxedValid = {
   headerSignature?: ?SignatureInfo,
   verificationKey?: ?bytes,
   senderDeviceRevokedAt?: ?gregor1.Time,
+  atMentionUsernames?: ?Array<string>,
+  atMentions?: ?Array<gregor1.UID>,
+  channelMention: ChannelMention,
 }
 
 export type NameQuery = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1854,11 +1854,6 @@ export type TyperInfo = {
   deviceType: string,
 }
 
-export type UIAtMention = {
-  username: string,
-  position: int,
-}
-
 export type UIMessage =
     { state: 1, valid: ?UIMessageValid }
   | { state: 2, error: ?MessageUnboxedError }
@@ -1883,7 +1878,7 @@ export type UIMessageValid = {
   senderDeviceType: string,
   superseded: boolean,
   senderDeviceRevokedAt?: ?gregor1.Time,
-  atMentions?: ?Array<UIAtMention>,
+  atMentions?: ?Array<string>,
 }
 
 export type UIMessages = {


### PR DESCRIPTION
Patch does the following:

1.) Stops adding backticks to @mentioned usernames on the sender side.
2.) Add fields in both `MessageUnboxed` and `UIMessage` for information about @mentions on the receive side from `UnboxMessage`.
3.) Change `shouldDisplayDesktopNotification` to use this info instead of parsing info itself.

cc @MarcoPolo @chrisnojima 