### PR TITLE
Teams: do not post sigs that will result in multiple UVs

### DIFF
--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -355,7 +355,7 @@ func (u *smuUser) pollForMembershipUpdate(team smuTeam, kg keybase1.PerTeamKeyGe
 			u.ctx.t.Fatal(err)
 		}
 		if details.KeyGeneration == kg {
-			u.ctx.log.Debug("found key generation 2")
+			u.ctx.log.Debug("found key generation %d", kg)
 			return details
 		}
 		if i == 9 {

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -485,6 +485,8 @@ func TestTeamRemoveAfterReset(t *testing.T) {
 	bob.loginAfterReset(10)
 	divDebug(ctx, "Bob logged in after reset")
 
+	ann.pollForMembershipUpdate(team, keybase1.PerTeamKeyGeneration(2))
+
 	cli := ann.getTeamsClient()
 	err := cli.TeamRemoveMember(context.TODO(), keybase1.TeamRemoveMemberArg{
 		Name:     team.name,
@@ -521,6 +523,8 @@ func TestTeamReAddAfterReset(t *testing.T) {
 
 	bob.loginAfterReset(10)
 	divDebug(ctx, "Bob logged in after reset")
+
+	ann.pollForMembershipUpdate(team, keybase1.PerTeamKeyGeneration(2))
 
 	cli := ann.getTeamsClient()
 	_, err := cli.TeamAddMember(context.TODO(), keybase1.TeamAddMemberArg{

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -171,7 +171,6 @@ func TestTeamReset(t *testing.T) {
 // add bob (a user who has reset his account) to a team
 // that he was never a member of
 func TestTeamResetAdd(t *testing.T) {
-	t.Skip("this is flaky as of 2017-09-05")
 	ctx := newSMUContext(t)
 	defer ctx.cleanup()
 

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -31,11 +32,19 @@ func divDebug(ctx *smuContext, fmt string, arg ...interface{}) {
 	ctx.log.Debug(div+" "+fmt+" "+div, arg...)
 }
 
-func readChatsWithError(team smuTeam, u *smuUser) ([]chat1.MessageUnboxed, error) {
+func readChatsWithError(team smuTeam, u *smuUser) (messages []chat1.MessageUnboxed, err error) {
 	tctx := u.primaryDevice().popClone()
-	runner := client.NewCmdChatReadRunner(tctx.G)
-	runner.SetTeamChatForTest(team.name)
-	_, messages, err := runner.Fetch()
+	for i := 0; i < 5; i++ {
+		runner := client.NewCmdChatReadRunner(tctx.G)
+		runner.SetTeamChatForTest(team.name)
+		_, messages, err = runner.Fetch()
+		if err == nil {
+			return messages, err
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+
 	return messages, err
 }
 

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -56,7 +56,6 @@ func readChatsWithError(team smuTeam, u *smuUser) (messages []chat1.MessageUnbox
 
 		time.Sleep(wait)
 		totalWait += wait
-		wait = wait * 2
 	}
 
 	u.ctx.t.Logf("Failed to readChatsWithError after polling for %s", totalWait)

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -37,7 +37,7 @@ func readChatsWithError(team smuTeam, u *smuUser) (messages []chat1.MessageUnbox
 
 	wait := 100 * time.Millisecond
 	var totalWait time.Duration
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 10; i++ {
 		runner := client.NewCmdChatReadRunner(tctx.G)
 		runner.SetTeamChatForTest(team.name)
 		_, messages, err = runner.Fetch()
@@ -56,6 +56,7 @@ func readChatsWithError(team smuTeam, u *smuUser) (messages []chat1.MessageUnbox
 
 		time.Sleep(wait)
 		totalWait += wait
+		wait = wait * 2
 	}
 
 	u.ctx.t.Logf("Failed to readChatsWithError after polling for %s", totalWait)

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -504,11 +504,11 @@ func ReAddMemberAfterReset(ctx context.Context, g *libkb.GlobalContext, teamID k
 
 	existingUV, err := t.UserVersionByUID(ctx, uv.Uid)
 	if err != nil {
-		return fmt.Errorf("User %s has never been a member of this team.", username)
+		return libkb.NotFoundError{Msg: fmt.Sprintf("user %s has never been a member of this team.", username)}
 	}
 
 	if existingUV.EldestSeqno == uv.EldestSeqno {
-		return fmt.Errorf("No need to re-add member, user has not reset")
+		return libkb.ExistsError{Msg: fmt.Sprintf("user %s has not reset, not need to re-add", username)}
 	} else if existingUV.EldestSeqno > uv.EldestSeqno {
 		return fmt.Errorf("EldestSeqno going backwards")
 	}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -151,7 +151,7 @@ func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username s
 		// member in the team to automatically remove them (so AddMember
 		// can function as a Re-Add).
 		if existingUV.EldestSeqno > uv.EldestSeqno {
-			return keybase1.TeamAddMemberResult{}, fmt.Errorf("EldestSeqno is going backwards")
+			return keybase1.TeamAddMemberResult{}, fmt.Errorf("newer version of user %q already exists in team %q (%v > %v)", resolvedUsername, teamname, existingUV.EldestSeqno, uv.EldestSeqno)
 		}
 		req.None = []keybase1.UserVersion{existingUV}
 	}
@@ -504,13 +504,13 @@ func ReAddMemberAfterReset(ctx context.Context, g *libkb.GlobalContext, teamID k
 
 	existingUV, err := t.UserVersionByUID(ctx, uv.Uid)
 	if err != nil {
-		return libkb.NotFoundError{Msg: fmt.Sprintf("user %s has never been a member of this team.", username)}
+		return libkb.NotFoundError{Msg: fmt.Sprintf("user %q has never been a member of this team.", username)}
 	}
 
 	if existingUV.EldestSeqno == uv.EldestSeqno {
-		return libkb.ExistsError{Msg: fmt.Sprintf("user %s has not reset, not need to re-add", username)}
+		return libkb.ExistsError{Msg: fmt.Sprintf("user %q has not reset, no need to re-add", username)}
 	} else if existingUV.EldestSeqno > uv.EldestSeqno {
-		return fmt.Errorf("EldestSeqno going backwards")
+		return fmt.Errorf("newer version of user %q already exists in team %q (%v > %v)", username, teamID, existingUV.EldestSeqno, uv.EldestSeqno)
 	}
 
 	existingRole, err := t.MemberRole(ctx, existingUV)


### PR DESCRIPTION
When doing AddMember and there already is a member with same uid but different EldestSeqno, remove the old member (in the same sig).

When doing RemoveMember on a reset member, use proper UV instead of posting remove with user's current EldestSeqno (might also be 0 when they haven't reprovisioned yet?).