### PR TITLE
clear any non-plaintext notifications in the notification center if they exist when plaintext is shown

### DIFF
--- a/shared/actions/platform-specific.native.js
+++ b/shared/actions/platform-specific.native.js
@@ -56,7 +56,22 @@ function saveAttachmentDialog(filePath: string): Promise<NextURI> {
   return Promise.resolve(filePath)
 }
 
-function displayNewMessageNotification(text: string, convID: string, badgeCount: number) {
+function displayNewMessageNotification(text: string, convID: string, badgeCount: number, myMsgID: number) {
+  PushNotificationIOS.getDeliveredNotifications(param => {
+    let idents = []
+    for (const n of param) {
+      if (n.userInfo && n.userInfo.msgID) {
+        const ident = n.identifier
+        const msgID = n.userInfo.msgID
+        if (msgID === myMsgID) {
+          idents.push(ident)
+          console.warn(`removing notification: ${ident} msgID: ${msgID}`)
+        }
+      }
+    }
+    PushNotificationIOS.removeDeliveredNotifications(idents)
+  })
+
   PushNotifications.localNotification({
     message: text,
     soundName: 'keybasemessage.wav',

--- a/shared/actions/platform-specific.native.js
+++ b/shared/actions/platform-specific.native.js
@@ -60,18 +60,9 @@ function displayNewMessageNotification(text: string, convID: string, badgeCount:
   // Dismiss any non-plaintext notifications for the same message ID
   if (isIOS) {
     PushNotificationIOS.getDeliveredNotifications(param => {
-      let idents = []
-      for (const n of param) {
-        if (n.userInfo && n.userInfo.msgID) {
-          const ident = n.identifier
-          const msgID = n.userInfo.msgID
-          if (msgID === myMsgID) {
-            idents.push(ident)
-            console.warn(`removing notification: ${ident} msgID: ${msgID}`)
-          }
-        }
-      }
-      PushNotificationIOS.removeDeliveredNotifications(idents)
+      PushNotificationIOS.removeDeliveredNotifications(
+        param.filter(p => p.userInfo && p.userInfo.msgID === myMsgID).map(p => p.identifier)
+      )
     })
   }
 

--- a/shared/actions/platform-specific.native.js
+++ b/shared/actions/platform-specific.native.js
@@ -57,20 +57,23 @@ function saveAttachmentDialog(filePath: string): Promise<NextURI> {
 }
 
 function displayNewMessageNotification(text: string, convID: string, badgeCount: number, myMsgID: number) {
-  PushNotificationIOS.getDeliveredNotifications(param => {
-    let idents = []
-    for (const n of param) {
-      if (n.userInfo && n.userInfo.msgID) {
-        const ident = n.identifier
-        const msgID = n.userInfo.msgID
-        if (msgID === myMsgID) {
-          idents.push(ident)
-          console.warn(`removing notification: ${ident} msgID: ${msgID}`)
+  // Dismiss any non-plaintext notifications for the same message ID
+  if (isIOS) {
+    PushNotificationIOS.getDeliveredNotifications(param => {
+      let idents = []
+      for (const n of param) {
+        if (n.userInfo && n.userInfo.msgID) {
+          const ident = n.identifier
+          const msgID = n.userInfo.msgID
+          if (msgID === myMsgID) {
+            idents.push(ident)
+            console.warn(`removing notification: ${ident} msgID: ${msgID}`)
+          }
         }
       }
-    }
-    PushNotificationIOS.removeDeliveredNotifications(idents)
-  })
+      PushNotificationIOS.removeDeliveredNotifications(idents)
+    })
+  }
 
   PushNotifications.localNotification({
     message: text,

--- a/shared/actions/push/index.js
+++ b/shared/actions/push/index.js
@@ -60,7 +60,7 @@ function* pushNotificationSaga(notification: Constants.PushNotification): SagaGe
             pushIDs: payload.p,
           },
         })
-        yield call(displayNewMessageNotification, unboxRes, payload.c, payload.b)
+        yield call(displayNewMessageNotification, unboxRes, payload.c, payload.b, payload.d)
       } catch (err) {
         console.info('failed to unbox silent notification', err)
       }

--- a/shared/constants/push.js
+++ b/shared/constants/push.js
@@ -17,6 +17,7 @@ export type PushNotification = {
     m?: string,
     p?: Array<string>,
     t?: number,
+    d?: number,
     type?: string,
     userInteraction: boolean,
     username?: string,


### PR DESCRIPTION
Point of this is to clear any notifications that come from APNS directly that concern the same message ID. This can happen if APNS decides to deliver the silent notification at the same time as the backup normal notification (this happens a lot). This way, the person will just have one item in the notification center for that message ID.