### PR TITLE
Fix new conv not posted

### DIFF
--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -38,19 +38,17 @@ function* deleteMessage(action: Constants.DeleteMessage): SagaGenerator<any, any
     yield put(navigateTo([], [chatTab, conversationIDKey]))
 
     const outboxID = yield call(ChatTypes.localGenerateOutboxIDRpcPromise)
-    if (lastMessageID) {
-      yield call(ChatTypes.localPostDeleteNonblockRpcPromise, {
-        param: {
-          clientPrev: Constants.parseMessageID(lastMessageID).msgID,
-          conversationID: Constants.keyToConversationID(conversationIDKey),
-          identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
-          outboxID,
-          supersedes: messageID,
-          tlfName: inboxConvo.name,
-          tlfPublic: false,
-        },
-      })
-    }
+    yield call(ChatTypes.localPostDeleteNonblockRpcPromise, {
+      param: {
+        clientPrev: lastMessageID ? Constants.parseMessageID(lastMessageID).msgID : 0,
+        conversationID: Constants.keyToConversationID(conversationIDKey),
+        identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
+        outboxID,
+        supersedes: messageID,
+        tlfName: inboxConvo.name,
+        tlfPublic: false,
+      },
+    })
   } else {
     // Deleting a local outbox message.
     const outboxID = message.outboxID
@@ -160,20 +158,18 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
   yield put(Creators.showEditor(null))
 
   const outboxID = yield call(ChatTypes.localGenerateOutboxIDRpcPromise)
-  if (lastMessageID) {
-    yield call(ChatTypes.localPostEditNonblockRpcPromise, {
-      param: {
-        body: action.payload.text.stringValue(),
-        clientPrev: Constants.parseMessageID(lastMessageID).msgID,
-        conversationID: Constants.keyToConversationID(conversationIDKey),
-        identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
-        outboxID,
-        supersedes: messageID,
-        tlfName: inboxConvo.name,
-        tlfPublic: false,
-      },
-    })
-  }
+  yield call(ChatTypes.localPostEditNonblockRpcPromise, {
+    param: {
+      body: action.payload.text.stringValue(),
+      clientPrev: lastMessageID ? Constants.parseMessageID(lastMessageID).msgID : 0,
+      conversationID: Constants.keyToConversationID(conversationIDKey),
+      identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
+      outboxID,
+      supersedes: messageID,
+      tlfName: inboxConvo.name,
+      tlfPublic: false,
+    },
+  })
 }
 
 function* retryMessage(action: Constants.RetryMessage): SagaGenerator<any, any> {

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -92,12 +92,12 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
 
   const message: Constants.Message = {
     author,
-    conversationIDKey: action.payload.conversationIDKey,
+    conversationIDKey: conversationIDKey,
     deviceName: '',
     deviceType: isMobile ? 'mobile' : 'desktop',
     editedCount: 0,
     failureDescription: '',
-    key: Constants.messageKey(action.payload.conversationIDKey, 'outboxIDText', outboxIDKey),
+    key: Constants.messageKey(conversationIDKey, 'outboxIDText', outboxIDKey),
     message: new HiddenString(action.payload.text.stringValue()),
     messageState: 'pending',
     outboxID: outboxIDKey,

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -120,19 +120,17 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
     )
   )
 
-  if (lastMessageID) {
-    yield call(ChatTypes.localPostTextNonblockRpcPromise, {
-      param: {
-        conversationID: Constants.keyToConversationID(conversationIDKey),
-        tlfName: inboxConvo.name,
-        tlfPublic: false,
-        outboxID,
-        body: action.payload.text.stringValue(),
-        identifyBehavior: yield call(Shared.getPostingIdentifyBehavior, conversationIDKey),
-        clientPrev: Constants.parseMessageID(lastMessageID).msgID,
-      },
-    })
-  }
+  yield call(ChatTypes.localPostTextNonblockRpcPromise, {
+    param: {
+      conversationID: Constants.keyToConversationID(conversationIDKey),
+      tlfName: inboxConvo.name,
+      tlfPublic: false,
+      outboxID,
+      body: action.payload.text.stringValue(),
+      identifyBehavior: yield call(Shared.getPostingIdentifyBehavior, conversationIDKey),
+      clientPrev: lastMessageID ? Constants.parseMessageID(lastMessageID).msgID : 0,
+    },
+  })
 }
 
 function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {


### PR DESCRIPTION
Basically we no longer had a lastMessageID since we were more aggressively filtering out messages in this PR (https://github.com/keybase/client/pull/8313).

clientPrev aka lastMessageID isn't super necessary so we should set it to 0 when not found instead of not making the call at all