### PR TITLE
Add # prefix to channel name for big teams

### DIFF
--- a/shared/chat/inbox/row/big-team-rows.js
+++ b/shared/chat/inbox/row/big-team-rows.js
@@ -67,7 +67,7 @@ class BigTeamChannelRow extends PureComponent<ChannelProps> {
                 color: this.props.isSelected ? globalColors.white : globalColors.black_75,
               }}
             >
-              {this.props.channelname}
+              #{this.props.channelname}
             </Text>
             {this.props.isMuted && <MutedIcon isSelected={this.props.isSelected} />}
             {this.props.hasUnread && <UnreadIcon />}


### PR DESCRIPTION
Filtered rows already have the # prefix.