### PR TITLE
change supersede calculator to properly set at mentions for edits

### DIFF
--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -57,6 +57,8 @@ func (t *basicSupersedesTransform) transformEdit(msg chat1.MessageUnboxed, super
 		HeaderHash:            msg.Valid().HeaderHash,
 		HeaderSignature:       msg.Valid().HeaderSignature,
 		SenderDeviceRevokedAt: msg.Valid().SenderDeviceRevokedAt,
+		AtMentions:            superMsg.Valid().AtMentions,
+		AtMentionUsernames:    superMsg.Valid().AtMentionUsernames,
 	})
 	return &newMsg
 }


### PR DESCRIPTION
cc @MarcoPolo 

This fixes the problem of @ mentions not being set properly in `GetThreadLocal` because the supersede transform just dropped them.