### PR TITLE
implementations for git repo metadata Get and Put

### DIFF
--- a/go/client/cmd_favorite.go
+++ b/go/client/cmd_favorite.go
@@ -30,6 +30,7 @@ func NewCmdFavorite(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 //
 //     /keybase/public/patrick,chris
 //     /keybase/private/patrick,maxtaco@twitter
+//     /keybase/team/bostonredsox
 //     public/patrick,jack
 //     /public/patrick,chris,sam
 //
@@ -45,10 +46,15 @@ func ParseTLF(path string) (keybase1.Folder, error) {
 	switch acc {
 	case "public":
 		f.Private = false
+		f.FolderType = keybase1.FolderType_PUBLIC
 	case "private":
 		f.Private = true
+		f.FolderType = keybase1.FolderType_PRIVATE
+	case "team":
+		f.Private = true
+		f.FolderType = keybase1.FolderType_TEAM
 	default:
-		return f, fmt.Errorf("folder path needs to contain public or private subdirectory")
+		return f, fmt.Errorf("folder path needs to contain a public, private, or team subdirectory")
 	}
 
 	f.Name = name

--- a/go/client/cmd_git.go
+++ b/go/client/cmd_git.go
@@ -1,0 +1,22 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+func NewCmdGit(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "git",
+		Usage:        "[devel only] Manage git repo metadata",
+		ArgumentHelp: "[arguments...]",
+		Subcommands: []cli.Command{
+			NewCmdGitMdput(cl, g),
+			NewCmdGitMdget(cl, g),
+		},
+	}
+}

--- a/go/client/cmd_git_mdget.go
+++ b/go/client/cmd_git_mdget.go
@@ -1,0 +1,84 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type CmdGitMdget struct {
+	libkb.Contextified
+	folder string
+}
+
+// NewCmdGitMdget creates a new cli.Command.
+func NewCmdGitMdget(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "mdget",
+		Usage:        "Fetch and decrypt repo metadata, printing the result as JSON",
+		ArgumentHelp: "[<folder>]",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdGitMdget{Contextified: libkb.NewContextified(g)}, "mdget", c)
+		},
+	}
+}
+
+// RunClient runs the command in client/server mode.
+func (c *CmdGitMdget) Run() error {
+	cli, err := GetGitClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	var res []keybase1.GitRepoResult
+	if len(c.folder) > 0 {
+		folder, err := ParseTLF(c.folder)
+		if err != nil {
+			return err
+		}
+		res, err = cli.GetGitMetadata(c.G().GetNetContext(), folder)
+		if err != nil {
+			return err
+		}
+	} else {
+		res, err = cli.GetAllGitMetadata(c.G().GetNetContext())
+		if err != nil {
+			return err
+		}
+	}
+
+	jsonStr, err := json.MarshalIndent(res, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonStr))
+	return nil
+}
+
+// ParseArgv gets the secret phrase from the command args.
+func (c *CmdGitMdget) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) > 1 {
+		return fmt.Errorf("mdget takes one optional argument")
+	}
+	if len(ctx.Args()) == 1 {
+		c.folder = ctx.Args()[0]
+	}
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdGitMdget) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/cmd_git_mdput.go
+++ b/go/client/cmd_git_mdput.go
@@ -1,0 +1,73 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type CmdGitMdput struct {
+	libkb.Contextified
+	folder   string
+	repoID   string
+	repoName string
+}
+
+// NewCmdGitMdput creates a new cli.Command.
+func NewCmdGitMdput(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "mdput",
+		Usage:        "Encrypt and upload new repo metadata",
+		ArgumentHelp: "<folder> <repoid> <reponame>",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdGitMdput{Contextified: libkb.NewContextified(g)}, "mdput", c)
+		},
+	}
+}
+
+// RunClient runs the command in client/server mode.
+func (c *CmdGitMdput) Run() error {
+	cli, err := GetGitClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	folder, err := ParseTLF(c.folder)
+	if err != nil {
+		return err
+	}
+
+	return cli.PutGitMetadata(c.G().GetNetContext(), keybase1.PutGitMetadataArg{
+		Folder: folder,
+		RepoID: keybase1.RepoID(c.repoID),
+		Metadata: keybase1.GitLocalMetadata{
+			RepoName: keybase1.GitRepoName(c.repoName),
+		},
+	})
+}
+
+// ParseArgv gets the secret phrase from the command args.
+func (c *CmdGitMdput) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 3 {
+		return fmt.Errorf("mdput takes three arguments")
+	}
+	c.folder = ctx.Args()[0]
+	c.repoID = ctx.Args()[1]
+	c.repoName = ctx.Args()[2]
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdGitMdput) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -30,6 +30,7 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 		NewCmdTestFSNotify(cl, g),
 		newCmdTlf(cl, g),
 		NewCmdScanProofs(cl, g),
+		NewCmdGit(cl, g),
 	}
 }
 

--- a/go/client/rpc.go
+++ b/go/client/rpc.go
@@ -361,3 +361,12 @@ func GetMerkleClient(g *libkb.GlobalContext) (cli keybase1.MerkleClient, err err
 	cli = keybase1.MerkleClient{Cli: rcli}
 	return cli, nil
 }
+
+func GetGitClient(g *libkb.GlobalContext) (cli keybase1.GitClient, err error) {
+	rcli, _, err := GetRPCClientWithContext(g)
+	if err != nil {
+		return cli, err
+	}
+	cli = keybase1.GitClient{Cli: rcli}
+	return cli, nil
+}

--- a/go/git/crypto.go
+++ b/go/git/crypto.go
@@ -49,7 +49,7 @@ func (c *Crypto) Box(ctx context.Context, plaintext []byte, teamSpec keybase1.Te
 	sealed := secretbox.Seal(nil, plaintext, &naclNonce, &encKey)
 
 	return &keybase1.EncryptedGitMetadata{
-		V:   1,
+		V:   libkb.CurrentGitMetadataEncryptionVersion,
 		E:   sealed,
 		N:   nonce,
 		Gen: key.KeyGeneration,

--- a/go/git/get.go
+++ b/go/git/get.go
@@ -1,0 +1,203 @@
+package git
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
+	"github.com/keybase/go-codec/codec"
+)
+
+type ServerResponseRepo struct {
+	TeamID                keybase1.TeamID               `json:"team_id"`
+	RepoID                keybase1.RepoID               `json:"repo_id"`
+	CTime                 time.Time                     `json:"ctime"`
+	MTime                 time.Time                     `json:"mtime"`
+	EncryptedMetadata     string                        `json:"encrypted_metadata"`
+	EncryptionVersion     int                           `json:"encryption_version"`
+	Nonce                 string                        `json:"nonce"`
+	KeyGeneration         keybase1.PerTeamKeyGeneration `json:"key_generation"`
+	LastModifyingUsername string                        `json:"last_writer_username"`
+	LastModifyingDeviceID keybase1.DeviceID             `json:"last_writer_device_id"`
+}
+
+type ServerResponse struct {
+	Repos  []ServerResponseRepo `json:"repos"`
+	Status libkb.AppStatus      `json:"status"`
+}
+
+var _ libkb.APIResponseWrapper = (*ServerResponse)(nil)
+
+// For GetDecode.
+func (r *ServerResponse) GetAppStatus() *libkb.AppStatus {
+	return &r.Status
+}
+
+// Implicit teams need to be converted back into the folder that matches their
+// display name. Regular teams become a regular team folder.
+func folderFromTeamID(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) (keybase1.Folder, error) {
+	team, err := teams.Load(ctx, g, keybase1.LoadTeamArg{
+		ID: teamID,
+	})
+	if err != nil {
+		return keybase1.Folder{}, err
+	}
+	if team.IsImplicit() {
+		// TODO: This function doesn't currently support conflict info.
+		name, err := team.ImplicitTeamDisplayNameString(ctx)
+		if err != nil {
+			return keybase1.Folder{}, err
+		}
+		var folderType keybase1.FolderType
+		if team.IsPublic() {
+			folderType = keybase1.FolderType_PUBLIC
+		} else {
+			folderType = keybase1.FolderType_PRIVATE
+		}
+		return keybase1.Folder{
+			Name:       name,
+			FolderType: folderType,
+			Private:    !team.IsPublic(),
+		}, nil
+	} else {
+		return keybase1.Folder{
+			Name:       team.Name().String(),
+			FolderType: keybase1.FolderType_TEAM,
+			Private:    !team.IsPublic(),
+		}, nil
+	}
+}
+
+func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keybase1.Folder) ([]keybase1.GitRepoResult, error) {
+	teamer := NewTeamer(g)
+	cryptoer := NewCrypto(g)
+
+	apiArg := libkb.APIArg{
+		Endpoint:    "kbfs/git/team/get",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		NetContext:  ctx,
+		Args:        libkb.HTTPArgs{
+		// a limit parameter exists, default 100, and we don't currently set it
+		},
+	}
+
+	// The team_id parameter is optional. Add it in if the caller supplied it.
+	if folder != nil {
+		if folder.FolderType != keybase1.FolderType_TEAM {
+			return nil, errors.New("git repo folders must be team folders")
+		}
+		teamIDVis, err := teamer.LookupOrCreate(ctx, *folder)
+		if err != nil {
+			return nil, err
+		}
+		apiArg.Args["team_id"] = libkb.S{Val: string(teamIDVis.TeamID)}
+	}
+	var serverResponse ServerResponse
+	err := g.GetAPI().GetDecode(apiArg, &serverResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initializing the results list to non-nil means that we end up seeing
+	// "[]" instead of "null" in the final JSON output on the CLI, which is
+	// preferable.
+	resultList := []keybase1.GitRepoResult{}
+	for _, responseRepo := range serverResponse.Repos {
+		// If the folder was passed in, use it. Otherwise, load the team to
+		// figure it out.
+		var repoFolder keybase1.Folder
+		if folder != nil {
+			repoFolder = *folder
+		} else {
+			repoFolder, err = folderFromTeamID(ctx, g, responseRepo.TeamID)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		teamIDVis := keybase1.TeamIDWithVisibility{
+			TeamID: responseRepo.TeamID,
+		}
+		if repoFolder.Private {
+			teamIDVis.Visibility = keybase1.TLFVisibility_PRIVATE
+		} else {
+			teamIDVis.Visibility = keybase1.TLFVisibility_PUBLIC
+		}
+
+		ciphertext, err := base64.StdEncoding.DecodeString(responseRepo.EncryptedMetadata)
+		if err != nil {
+			return nil, err
+		}
+
+		nonceSlice, err := base64.StdEncoding.DecodeString(responseRepo.Nonce)
+		if err != nil {
+			return nil, err
+		}
+		if len(nonceSlice) != len(keybase1.BoxNonce{}) {
+			return nil, fmt.Errorf("expected a nonce of length %d, found %d", len(keybase1.BoxNonce{}), len(nonceSlice))
+		}
+		var nonce keybase1.BoxNonce
+		copy(nonce[:], nonceSlice)
+
+		encryptedMetadata := keybase1.EncryptedGitMetadata{
+			V:   responseRepo.EncryptionVersion,
+			E:   ciphertext,
+			N:   nonce,
+			Gen: responseRepo.KeyGeneration,
+		}
+		msgpackPlaintext, err := cryptoer.Unbox(ctx, teamIDVis, &encryptedMetadata)
+		if err != nil {
+			return nil, err
+		}
+
+		var localMetadataVersioned keybase1.GitLocalMetadataVersioned
+		mh := codec.MsgpackHandle{WriteExt: true}
+		dec := codec.NewDecoderBytes(msgpackPlaintext, &mh)
+		err = dec.Decode(&localMetadataVersioned)
+		if err != nil {
+			return nil, err
+		}
+
+		// Translate back from GitLocalMetadataVersioned to the decoupled type
+		// that we use for local RPC.
+		version, err := localMetadataVersioned.Version()
+		if err != nil {
+			return nil, err
+		}
+		var localMetadata keybase1.GitLocalMetadata
+		switch version {
+		case keybase1.GitLocalMetadataVersion_V1:
+			localMetadata = keybase1.GitLocalMetadata{
+				RepoName: localMetadataVersioned.V1().RepoName,
+			}
+		default:
+			return nil, fmt.Errorf("unrecognized variant of GitLocalMetadataVersioned: %#v", version)
+		}
+
+		resultList = append(resultList, keybase1.GitRepoResult{
+			Folder:        repoFolder,
+			RepoID:        responseRepo.RepoID,
+			LocalMetadata: localMetadata,
+			ServerMetadata: keybase1.GitServerMetadata{
+				Ctime: keybase1.ToTime(responseRepo.CTime),
+				Mtime: keybase1.ToTime(responseRepo.MTime),
+				LastModifyingUsername: responseRepo.LastModifyingUsername,
+				LastModifyingDeviceID: responseRepo.LastModifyingDeviceID,
+			},
+		})
+	}
+	return resultList, nil
+}
+
+func GetMetadata(ctx context.Context, g *libkb.GlobalContext, folder keybase1.Folder) ([]keybase1.GitRepoResult, error) {
+	return getMetadataInner(ctx, g, &folder)
+}
+
+func GetAllMetadata(ctx context.Context, g *libkb.GlobalContext) ([]keybase1.GitRepoResult, error) {
+	return getMetadataInner(ctx, g, nil)
+}

--- a/go/git/put.go
+++ b/go/git/put.go
@@ -1,0 +1,57 @@
+package git
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
+)
+
+func PutMetadata(ctx context.Context, g *libkb.GlobalContext, arg keybase1.PutGitMetadataArg) error {
+	teamer := NewTeamer(g)
+	cryptoer := NewCrypto(g)
+
+	teamIDVis, err := teamer.LookupOrCreate(ctx, arg.Folder)
+	if err != nil {
+		return err
+	}
+
+	// Translate the GitLocalMetadata struct into GitLocalMetadataVersioned,
+	// for versioned storage.
+	localMetadataVersioned := keybase1.NewGitLocalMetadataVersionedWithV1(
+		keybase1.GitLocalMetadataV1{
+			RepoName: arg.Metadata.RepoName})
+
+	mh := codec.MsgpackHandle{WriteExt: true}
+	var msgpackLocalMetadata []byte
+	enc := codec.NewEncoderBytes(&msgpackLocalMetadata, &mh)
+	err = enc.Encode(localMetadataVersioned)
+	if err != nil {
+		return err
+	}
+	encryptedMetadata, err := cryptoer.Box(ctx, msgpackLocalMetadata, teamIDVis)
+	if err != nil {
+		return err
+	}
+	base64Ciphertext := base64.StdEncoding.EncodeToString(encryptedMetadata.E)
+	base64Nonce := base64.StdEncoding.EncodeToString(encryptedMetadata.N[:])
+
+	apiArg := libkb.APIArg{
+		Endpoint:    "kbfs/git/team/put",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		NetContext:  ctx,
+		Args: libkb.HTTPArgs{
+			"team_id":            libkb.S{Val: string(teamIDVis.TeamID)},
+			"repo_id":            libkb.S{Val: string(arg.RepoID)},
+			"encrypted_metadata": libkb.S{Val: base64Ciphertext},
+			"nonce":              libkb.S{Val: base64Nonce},
+			"key_generation":     libkb.I{Val: int(encryptedMetadata.Gen)},
+			"device_id":          libkb.S{Val: string(g.Env.GetDeviceID())},
+			"encryption_version": libkb.I{Val: encryptedMetadata.V},
+		},
+	}
+	_, err = g.GetAPI().Post(apiArg)
+	return err
+}

--- a/go/git/put_get_test.go
+++ b/go/git/put_get_test.go
@@ -1,0 +1,121 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package git
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
+	"github.com/stretchr/testify/require"
+)
+
+// Copied from the teams tests.
+func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
+	tc = libkb.SetupTest(tb, name, depth+1)
+	tc.G.SetServices(externals.GetServices())
+	teams.NewTeamLoaderAndInstall(tc.G)
+	return tc
+}
+
+func doPut(t *testing.T, g *libkb.GlobalContext, teamName string, repoID string, repoName string) {
+	err := PutMetadata(context.TODO(), g, keybase1.PutGitMetadataArg{
+		Folder: keybase1.Folder{
+			Name:       teamName,
+			Private:    true,
+			FolderType: keybase1.FolderType_TEAM,
+		},
+		RepoID: keybase1.RepoID(repoID),
+		Metadata: keybase1.GitLocalMetadata{
+			RepoName: keybase1.GitRepoName(repoName),
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestPutAndGet(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	defer tc.Cleanup()
+
+	// Note that the length limit for a team name, with the additional suffix
+	// below, is 16 characters. We have 5 to play with, including the implicit
+	// underscore after the prefix.
+	u, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
+	require.NoError(t, err)
+
+	// Create two teams, so that we can test filtering by TeamID.
+	teamName1 := u.Username + "t1"
+	err = teams.CreateRootTeam(context.TODO(), tc.G, teamName1)
+	require.NoError(t, err)
+
+	teamName2 := u.Username + "t2"
+	err = teams.CreateRootTeam(context.TODO(), tc.G, teamName2)
+	require.NoError(t, err)
+
+	// Create two git repos, one in each team. Remember that all we're
+	// "creating" here is metadata.
+	doPut(t, tc.G, teamName1, "abc123", "repoNameFirst")
+	doPut(t, tc.G, teamName2, "def456", "repoNameSecond")
+	expectedIDNames := map[string]string{
+		"abc123": "repoNameFirst",
+		"def456": "repoNameSecond",
+	}
+
+	// Get all repos, and make sure both come back.
+	allRepos, err := GetAllMetadata(context.Background(), tc.G)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(allRepos), "expected to get both repos back, found: %d", len(allRepos))
+	for _, repo := range allRepos {
+		require.Equal(t, expectedIDNames[string(repo.RepoID)], string(repo.LocalMetadata.RepoName))
+		require.Equal(t, repo.Folder.FolderType, keybase1.FolderType_TEAM)
+		require.Equal(t, repo.Folder.Private, true)
+		require.Equal(t, repo.ServerMetadata.LastModifyingUsername, u.Username)
+	}
+
+	// Now get the repos for just one team. Should be only one of the two we just created.
+	oneRepo, err := GetMetadata(context.Background(), tc.G, keybase1.Folder{
+		Name:       teamName1,
+		Private:    true,
+		FolderType: keybase1.FolderType_TEAM,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(oneRepo), "expected to get only one repo back, found: %d", len(oneRepo))
+	require.Equal(t, "repoNameFirst", string(oneRepo[0].LocalMetadata.RepoName))
+}
+
+func TestPutAndGetImplicitTeam(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	defer tc.Cleanup()
+
+	u1, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
+	require.NoError(t, err)
+	u2, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
+	require.NoError(t, err)
+
+	repoName := "implicit repo foo bar"
+	err = PutMetadata(context.TODO(), tc.G, keybase1.PutGitMetadataArg{
+		Folder: keybase1.Folder{
+			Name:       u1.Username + "," + u2.Username,
+			Private:    true,
+			FolderType: keybase1.FolderType_PRIVATE,
+		},
+		RepoID: keybase1.RepoID("abc123"),
+		Metadata: keybase1.GitLocalMetadata{
+			RepoName: keybase1.GitRepoName(repoName),
+		},
+	})
+	require.NoError(t, err)
+
+	allRepos, err := GetAllMetadata(context.Background(), tc.G)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(allRepos))
+	repo := allRepos[0]
+	require.Equal(t, repoName, string(repo.LocalMetadata.RepoName))
+	require.Equal(t, keybase1.FolderType_PRIVATE, repo.Folder.FolderType)
+	require.Equal(t, true, repo.Folder.Private)
+}

--- a/go/git/teamer.go
+++ b/go/git/teamer.go
@@ -48,12 +48,11 @@ func (t *TeamerImpl) lookupTeam(ctx context.Context, folder keybase1.Folder) (re
 	if !folder.Private {
 		return res, fmt.Errorf("public team git repos not supported")
 	}
-	teamName, err := libkb.ParseTeamPrivateKBFSPath(folder.Name)
 	if err != nil {
 		return res, err
 	}
 	team, err := teams.Load(ctx, t.G(), keybase1.LoadTeamArg{
-		Name:        teamName.String(),
+		Name:        folder.Name,
 		ForceRepoll: false, // if subteams get renamed in a racy way, just let this fail
 	})
 	if err != nil {
@@ -78,7 +77,7 @@ func (t *TeamerImpl) lookupOrCreateImplicitTeam(ctx context.Context, folder keyb
 		visibility = keybase1.TLFVisibility_PUBLIC
 	}
 
-	impName, err := libkb.ParseImplicitTeamTLFName(t.G().MakeAssertionContext(), folder.Name)
+	impName, err := libkb.ParseImplicitTeamTLFName(t.G().MakeAssertionContext(), "/keybase/"+folder.ToString())
 	if err != nil {
 		return res, err
 	}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -627,3 +627,5 @@ const (
 	SubteamIDTag       = 0x25
 	InviteIDTag        = 0x27
 )
+
+const CurrentGitMetadataEncryptionVersion = 1

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -711,11 +711,16 @@ func (s *SigID) MarshalJSON() ([]byte, error) {
 }
 
 func (f Folder) ToString() string {
-	prefix := "public/"
-	if f.Private {
-		prefix = "private/"
+	prefix := "<unrecognized>"
+	switch f.FolderType {
+	case FolderType_PRIVATE:
+		prefix = "private"
+	case FolderType_PUBLIC:
+		prefix = "public"
+	case FolderType_TEAM:
+		prefix = "team"
 	}
-	return prefix + f.Name
+	return prefix + "/" + f.Name
 }
 
 func (t TrackToken) String() string {

--- a/go/protocol/keybase1/git.go
+++ b/go/protocol/keybase1/git.go
@@ -4,6 +4,7 @@
 package keybase1
 
 import (
+	"errors"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )
@@ -33,6 +34,85 @@ type RepoID string
 
 func (o RepoID) DeepCopy() RepoID {
 	return o
+}
+
+type GitLocalMetadataVersion int
+
+const (
+	GitLocalMetadataVersion_V1 GitLocalMetadataVersion = 1
+)
+
+func (o GitLocalMetadataVersion) DeepCopy() GitLocalMetadataVersion { return o }
+
+var GitLocalMetadataVersionMap = map[string]GitLocalMetadataVersion{
+	"V1": 1,
+}
+
+var GitLocalMetadataVersionRevMap = map[GitLocalMetadataVersion]string{
+	1: "V1",
+}
+
+func (e GitLocalMetadataVersion) String() string {
+	if v, ok := GitLocalMetadataVersionRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type GitLocalMetadataV1 struct {
+	RepoName GitRepoName `codec:"repoName" json:"repoName"`
+}
+
+func (o GitLocalMetadataV1) DeepCopy() GitLocalMetadataV1 {
+	return GitLocalMetadataV1{
+		RepoName: o.RepoName.DeepCopy(),
+	}
+}
+
+type GitLocalMetadataVersioned struct {
+	Version__ GitLocalMetadataVersion `codec:"version" json:"version"`
+	V1__      *GitLocalMetadataV1     `codec:"v1,omitempty" json:"v1,omitempty"`
+}
+
+func (o *GitLocalMetadataVersioned) Version() (ret GitLocalMetadataVersion, err error) {
+	switch o.Version__ {
+	case GitLocalMetadataVersion_V1:
+		if o.V1__ == nil {
+			err = errors.New("unexpected nil value for V1__")
+			return ret, err
+		}
+	}
+	return o.Version__, nil
+}
+
+func (o GitLocalMetadataVersioned) V1() (res GitLocalMetadataV1) {
+	if o.Version__ != GitLocalMetadataVersion_V1 {
+		panic("wrong case accessed")
+	}
+	if o.V1__ == nil {
+		return
+	}
+	return *o.V1__
+}
+
+func NewGitLocalMetadataVersionedWithV1(v GitLocalMetadataV1) GitLocalMetadataVersioned {
+	return GitLocalMetadataVersioned{
+		Version__: GitLocalMetadataVersion_V1,
+		V1__:      &v,
+	}
+}
+
+func (o GitLocalMetadataVersioned) DeepCopy() GitLocalMetadataVersioned {
+	return GitLocalMetadataVersioned{
+		Version__: o.Version__.DeepCopy(),
+		V1__: (func(x *GitLocalMetadataV1) *GitLocalMetadataV1 {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.V1__),
+	}
 }
 
 type GitLocalMetadata struct {

--- a/go/service/git.go
+++ b/go/service/git.go
@@ -1,0 +1,38 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package service
+
+import (
+	"github.com/keybase/client/go/git"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"golang.org/x/net/context"
+)
+
+type GitHandler struct {
+	*BaseHandler
+	libkb.Contextified
+}
+
+var _ keybase1.GitInterface = (*GitHandler)(nil)
+
+func NewGitHandler(xp rpc.Transporter, g *libkb.GlobalContext) *GitHandler {
+	return &GitHandler{
+		BaseHandler:  NewBaseHandler(xp),
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func (h *GitHandler) PutGitMetadata(ctx context.Context, arg keybase1.PutGitMetadataArg) error {
+	return git.PutMetadata(ctx, h.G(), arg)
+}
+
+func (h *GitHandler) GetGitMetadata(ctx context.Context, folder keybase1.Folder) ([]keybase1.GitRepoResult, error) {
+	return git.GetMetadata(ctx, h.G(), folder)
+}
+
+func (h *GitHandler) GetAllGitMetadata(ctx context.Context) ([]keybase1.GitRepoResult, error) {
+	return git.GetAllMetadata(ctx, h.G())
+}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -124,6 +124,7 @@ func (d *Service) RegisterProtocols(srv *rpc.Server, xp rpc.Transporter, connID 
 		keybase1.TeamsProtocol(NewTeamsHandler(xp, connID, cg, d.gregor)),
 		keybase1.BadgerProtocol(newBadgerHandler(xp, g, d.badger)),
 		keybase1.MerkleProtocol(newMerkleHandler(xp, g)),
+		keybase1.GitProtocol(NewGitHandler(xp, g)),
 	}
 	for _, proto := range protocols {
 		if err = srv.Register(proto); err != nil {

--- a/go/systests/git_test.go
+++ b/go/systests/git_test.go
@@ -27,7 +27,7 @@ func TestGitTeamer(t *testing.T) {
 
 	t.Logf("team that doesn't exist")
 	res, err := teamer.LookupOrCreate(context.Background(), keybase1.Folder{
-		Name:       "/keybase/team/notateamxxx",
+		Name:       "notateamxxx",
 		Private:    true,
 		FolderType: keybase1.FolderType_TEAM,
 	})
@@ -37,7 +37,7 @@ func TestGitTeamer(t *testing.T) {
 	t.Logf("team that exists")
 	teamID, teamName := tt.users[0].createTeam2()
 	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
-		Name:       "/keybase/team/" + teamName.String(),
+		Name:       teamName.String(),
 		Private:    true,
 		FolderType: keybase1.FolderType_TEAM,
 	})
@@ -48,7 +48,7 @@ func TestGitTeamer(t *testing.T) {
 	t.Logf("public team")
 	teamID, teamName = tt.users[0].createTeam2()
 	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
-		Name:       "/keybase/team/" + teamName.String(),
+		Name:       teamName.String(),
 		Private:    false,
 		FolderType: keybase1.FolderType_TEAM,
 	})
@@ -60,7 +60,7 @@ func TestGitTeamer(t *testing.T) {
 	gil := tt.addUser("gil")
 	frag := fmt.Sprintf("%v,%v#%v", alice.username, bob.username, gil.username)
 	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
-		Name:       "/keybase/private/" + frag,
+		Name:       frag,
 		Private:    true,
 		FolderType: keybase1.FolderType_PRIVATE,
 	})
@@ -76,7 +76,7 @@ func TestGitTeamer(t *testing.T) {
 	frag = fmt.Sprintf("%v,%v#%v", alice.username, bob.username, gil.username)
 	teamID, _, err = teams.LookupOrCreateImplicitTeam(context.Background(), g, frag, false /*isPublic*/)
 	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
-		Name:       "/keybase/private/" + frag,
+		Name:       frag,
 		Private:    true,
 		FolderType: keybase1.FolderType_PRIVATE,
 	})
@@ -90,7 +90,7 @@ func TestGitTeamer(t *testing.T) {
 	frag = fmt.Sprintf("%v,%v#%v", alice.username, bob.username, gil.username)
 	teamID, _, err = teams.LookupOrCreateImplicitTeam(context.Background(), g, frag, true /*isPublic*/)
 	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
-		Name:       "/keybase/private/" + frag,
+		Name:       frag,
 		Private:    false,
 		FolderType: keybase1.FolderType_PUBLIC,
 	})
@@ -116,20 +116,11 @@ func TestGitTeamer(t *testing.T) {
 	require.Len(t, conflicts, 1)
 	t.Logf("check")
 	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
-		Name:       "/keybase/private/" + iTeamNameCreate1 + " " + libkb.FormatImplicitTeamDisplayNameSuffix(conflicts[0]),
+		Name:       iTeamNameCreate1 + " " + libkb.FormatImplicitTeamDisplayNameSuffix(conflicts[0]),
 		Private:    true,
 		FolderType: keybase1.FolderType_PRIVATE,
 	})
 	require.NoError(t, err)
 	require.Equal(t, res.TeamID, iTeamID2, "teamer should return the old conflicted team")
 	require.Equal(t, res.Visibility, keybase1.TLFVisibility_PRIVATE)
-
-	t.Logf("invalid tlf name")
-	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
-		Name:       "notapathxxx",
-		Private:    true,
-		FolderType: keybase1.FolderType_TEAM,
-	})
-	require.Error(t, err)
-	require.Regexp(t, `(?i)invalid.*name`, err.Error())
 }

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -50,6 +50,10 @@ func (t *Team) IsPublic() bool {
 	return t.chain().IsPublic()
 }
 
+func (t *Team) IsImplicit() bool {
+	return t.chain().IsImplicit()
+}
+
 func (t *Team) SharedSecret(ctx context.Context) (ret keybase1.PerTeamKeySeed, err error) {
 	defer t.G().CTrace(ctx, "Team#SharedSecret", func() error { return err })()
 	gen := t.chain().GetLatestGeneration()

--- a/protocol/avdl/keybase1/git.avdl
+++ b/protocol/avdl/keybase1/git.avdl
@@ -16,10 +16,25 @@ protocol git {
   @typedef("string")
   record RepoID {}
 
-  // Right now, the only metadata in our locally-encrypted-then-server-stored
-  // blob is the name of the repo. Everything else (mtime, last editing user)
-  // is inferred by the server based on who's doing the push, and stored in the
-  // clear.
+  enum GitLocalMetadataVersion {
+    V1_1
+  }
+
+  record GitLocalMetadataV1 {
+    GitRepoName repoName;
+  }
+
+  // GitLocalMetadataVersioned is a variant container for all the
+  // versions of GitLocalMetadata.
+  variant GitLocalMetadataVersioned switch (GitLocalMetadataVersion version) {
+    case V1 : GitLocalMetadataV1;
+  }
+
+  // GitLocalMetadata is the struct that local RPCs use to read and write repo
+  // metadata. It's decoupled from GitLocalMetadataVersioned, which is the
+  // format that we serialize and encrypt, in case we ever need to support
+  // multiple versions. Right now, however, its fields are exactly the same as
+  // the only current variant, GitLocalMetadataV1.
   record GitLocalMetadata {
     GitRepoName repoName;
   }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -278,6 +278,10 @@ export const FavoriteFolderType = {
   team: 3,
 }
 
+export const GitGitLocalMetadataVersion = {
+  v1: 1,
+}
+
 export const GregorUIPushReason = {
   none: 0,
   reconnected: 1,
@@ -3270,6 +3274,16 @@ export type GetTLFCryptKeysRes = {
 export type GitLocalMetadata = {
   repoName: GitRepoName,
 }
+
+export type GitLocalMetadataV1 = {
+  repoName: GitRepoName,
+}
+
+export type GitLocalMetadataVersion =
+    1 // V1_1
+
+export type GitLocalMetadataVersioned =
+    { version: 1, v1: ?GitLocalMetadataV1 }
 
 export type GitRepoName = string
 

--- a/protocol/json/keybase1/git.json
+++ b/protocol/json/keybase1/git.json
@@ -40,6 +40,40 @@
       "typedef": "string"
     },
     {
+      "type": "enum",
+      "name": "GitLocalMetadataVersion",
+      "symbols": [
+        "V1_1"
+      ]
+    },
+    {
+      "type": "record",
+      "name": "GitLocalMetadataV1",
+      "fields": [
+        {
+          "type": "GitRepoName",
+          "name": "repoName"
+        }
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "GitLocalMetadataVersioned",
+      "switch": {
+        "type": "GitLocalMetadataVersion",
+        "name": "version"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "V1",
+            "def": false
+          },
+          "body": "GitLocalMetadataV1"
+        }
+      ]
+    },
+    {
       "type": "record",
       "name": "GitLocalMetadata",
       "fields": [

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -278,6 +278,10 @@ export const FavoriteFolderType = {
   team: 3,
 }
 
+export const GitGitLocalMetadataVersion = {
+  v1: 1,
+}
+
 export const GregorUIPushReason = {
   none: 0,
   reconnected: 1,
@@ -3270,6 +3274,16 @@ export type GetTLFCryptKeysRes = {
 export type GitLocalMetadata = {
   repoName: GitRepoName,
 }
+
+export type GitLocalMetadataV1 = {
+  repoName: GitRepoName,
+}
+
+export type GitLocalMetadataVersion =
+    1 // V1_1
+
+export type GitLocalMetadataVersioned =
+    { version: 1, v1: ?GitLocalMetadataV1 }
 
 export type GitRepoName = string
 


### PR DESCRIPTION
We currently use nil implementations of Cryptoer (@patrickxb https://github.com/keybase/client/pull/8340) and Teamer (@mlsteele  https://github.com/keybase/client/pull/8345), because this is being written in parallel with those, so currently the code will not run. But it's intended to be easy to plug in the implementations once they're ready.

I will update this PR once its dependencies are in. One question for @mlsteele in the meantime, in a comment below.