### PR TITLE
deliver simple team information to frontend CORE-5973

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -901,6 +901,7 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		Triple:      conversationRemote.Metadata.IdTriple,
 		Status:      conversationRemote.Metadata.Status,
 		MembersType: conversationRemote.Metadata.MembersType,
+		TeamType:    conversationRemote.Metadata.TeamType,
 	}
 	conversationLocal.Info.FinalizeInfo = conversationRemote.Metadata.FinalizeInfo
 	for _, super := range conversationRemote.Metadata.Supersedes {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -156,6 +156,7 @@ func (h *Server) presentUnverifiedInbox(ctx context.Context, vres chat1.GetInbox
 		conv.Visibility = rawConv.Metadata.Visibility
 		conv.Notifications = rawConv.Notifications
 		conv.MembersType = rawConv.GetMembersType()
+		conv.TeamType = rawConv.Metadata.TeamType
 		res.Items = append(res.Items, conv)
 	}
 	res.Pagination = utils.PresentPagination(vres.Pagination)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -601,6 +601,7 @@ func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxU
 	res.IsEmpty = rawConv.IsEmpty
 	res.Notifications = rawConv.Notifications
 	res.CreatorInfo = rawConv.CreatorInfo
+	res.TeamType = rawConv.Info.TeamType
 	return res
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -33,6 +33,7 @@ type UnverifiedInboxUIItem struct {
 	Visibility    keybase1.TLFVisibility        `codec:"visibility" json:"visibility"`
 	Status        ConversationStatus            `codec:"status" json:"status"`
 	MembersType   ConversationMembersType       `codec:"membersType" json:"membersType"`
+	TeamType      TeamType                      `codec:"teamType" json:"teamType"`
 	Notifications *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
 	Time          gregor1.Time                  `codec:"time" json:"time"`
 }
@@ -44,6 +45,7 @@ func (o UnverifiedInboxUIItem) DeepCopy() UnverifiedInboxUIItem {
 		Visibility:  o.Visibility.DeepCopy(),
 		Status:      o.Status.DeepCopy(),
 		MembersType: o.MembersType.DeepCopy(),
+		TeamType:    o.TeamType.DeepCopy(),
 		Notifications: (func(x *ConversationNotificationInfo) *ConversationNotificationInfo {
 			if x == nil {
 				return nil
@@ -93,6 +95,7 @@ type InboxUIItem struct {
 	Participants  []string                      `codec:"participants" json:"participants"`
 	Status        ConversationStatus            `codec:"status" json:"status"`
 	MembersType   ConversationMembersType       `codec:"membersType" json:"membersType"`
+	TeamType      TeamType                      `codec:"teamType" json:"teamType"`
 	Time          gregor1.Time                  `codec:"time" json:"time"`
 	Notifications *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
 	CreatorInfo   *ConversationCreatorInfoLocal `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
@@ -120,6 +123,7 @@ func (o InboxUIItem) DeepCopy() InboxUIItem {
 		})(o.Participants),
 		Status:      o.Status.DeepCopy(),
 		MembersType: o.MembersType.DeepCopy(),
+		TeamType:    o.TeamType.DeepCopy(),
 		Time:        o.Time.DeepCopy(),
 		Notifications: (func(x *ConversationNotificationInfo) *ConversationNotificationInfo {
 			if x == nil {

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -202,6 +202,35 @@ var TopicTypeRevMap = map[TopicType]string{
 	2: "DEV",
 }
 
+type TeamType int
+
+const (
+	TeamType_NONE    TeamType = 0
+	TeamType_SIMPLE  TeamType = 1
+	TeamType_COMPLEX TeamType = 2
+)
+
+func (o TeamType) DeepCopy() TeamType { return o }
+
+var TeamTypeMap = map[string]TeamType{
+	"NONE":    0,
+	"SIMPLE":  1,
+	"COMPLEX": 2,
+}
+
+var TeamTypeRevMap = map[TeamType]string{
+	0: "NONE",
+	1: "SIMPLE",
+	2: "COMPLEX",
+}
+
+func (e TeamType) String() string {
+	if v, ok := TeamTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type NotificationKind int
 
 const (
@@ -566,6 +595,7 @@ type ConversationMetadata struct {
 	Visibility     keybase1.TLFVisibility    `codec:"visibility" json:"visibility"`
 	Status         ConversationStatus        `codec:"status" json:"status"`
 	MembersType    ConversationMembersType   `codec:"membersType" json:"membersType"`
+	TeamType       TeamType                  `codec:"teamType" json:"teamType"`
 	FinalizeInfo   *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
 	Supersedes     []ConversationMetadata    `codec:"supersedes" json:"supersedes"`
 	SupersededBy   []ConversationMetadata    `codec:"supersededBy" json:"supersededBy"`
@@ -580,6 +610,7 @@ func (o ConversationMetadata) DeepCopy() ConversationMetadata {
 		Visibility:     o.Visibility.DeepCopy(),
 		Status:         o.Status.DeepCopy(),
 		MembersType:    o.MembersType.DeepCopy(),
+		TeamType:       o.TeamType.DeepCopy(),
 		FinalizeInfo: (func(x *ConversationFinalizeInfo) *ConversationFinalizeInfo {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2021,6 +2021,7 @@ type ConversationInfoLocal struct {
 	Visibility   keybase1.TLFVisibility    `codec:"visibility" json:"visibility"`
 	Status       ConversationStatus        `codec:"status" json:"status"`
 	MembersType  ConversationMembersType   `codec:"membersType" json:"membersType"`
+	TeamType     TeamType                  `codec:"teamType" json:"teamType"`
 	WriterNames  []string                  `codec:"writerNames" json:"writerNames"`
 	ReaderNames  []string                  `codec:"readerNames" json:"readerNames"`
 	FinalizeInfo *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
@@ -2035,6 +2036,7 @@ func (o ConversationInfoLocal) DeepCopy() ConversationInfoLocal {
 		Visibility:  o.Visibility.DeepCopy(),
 		Status:      o.Status.DeepCopy(),
 		MembersType: o.MembersType.DeepCopy(),
+		TeamType:    o.TeamType.DeepCopy(),
 		WriterNames: (func(x []string) []string {
 			var ret []string
 			for _, v := range x {

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -18,6 +18,7 @@ protocol chatUi {
     keybase1.TLFVisibility visibility;
     ConversationStatus status;
     ConversationMembersType membersType;
+    TeamType teamType;
     union{ null, ConversationNotificationInfo } notifications;
     gregor1.Time time;
   }
@@ -39,6 +40,7 @@ protocol chatUi {
     array<string> participants;
     ConversationStatus status;
     ConversationMembersType membersType;
+    TeamType teamType;
     gregor1.Time time;
     union { null, ConversationNotificationInfo } notifications;
     union { null, ConversationCreatorInfoLocal } creatorInfo;

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -43,6 +43,12 @@ protocol common {
     DEV_2
   }
 
+  enum TeamType {
+    NONE_0,
+    SIMPLE_1,
+    COMPLEX_2
+  }
+
   @go("nostring")
   enum NotificationKind {
     GENERIC_0,
@@ -170,6 +176,7 @@ protocol common {
     keybase1.TLFVisibility visibility;
     ConversationStatus status;
     ConversationMembersType membersType;
+    TeamType teamType;
 
     // Finalize info for underlying TLF
     union { null, ConversationFinalizeInfo } finalizeInfo;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -354,6 +354,7 @@ protocol local {
     keybase1.TLFVisibility visibility;
     ConversationStatus status;
     ConversationMembersType membersType;
+    TeamType teamType;
 
     // Lists of usernames, always complete, optionally sorted by activity.
     array<string> writerNames;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -114,6 +114,12 @@ export const CommonNotificationKind = {
   atmention: 1,
 }
 
+export const CommonTeamType = {
+  none: 0,
+  simple: 1,
+  complex: 2,
+}
+
 export const CommonTopicType = {
   none: 0,
   chat: 1,
@@ -931,6 +937,7 @@ export type ConversationInfoLocal = {
   visibility: keybase1.TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  teamType: TeamType,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
   finalizeInfo?: ?ConversationFinalizeInfo,
@@ -971,6 +978,7 @@ export type ConversationMetadata = {
   visibility: keybase1.TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  teamType: TeamType,
   finalizeInfo?: ?ConversationFinalizeInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -1259,6 +1267,7 @@ export type InboxUIItem = {
   participants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  teamType: TeamType,
   time: gregor1.Time,
   notifications?: ?ConversationNotificationInfo,
   creatorInfo?: ?ConversationCreatorInfoLocal,
@@ -1828,6 +1837,11 @@ export type TLFResolveUpdate = {
   inboxVers: InboxVers,
 }
 
+export type TeamType =
+    0 // NONE_0
+  | 1 // SIMPLE_1
+  | 2 // COMPLEX_2
+
 export type ThreadID = bytes
 
 export type ThreadView = {
@@ -1921,6 +1935,7 @@ export type UnverifiedInboxUIItem = {
   visibility: keybase1.TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  teamType: TeamType,
   notifications?: ?ConversationNotificationInfo,
   time: gregor1.Time,
 }

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -60,6 +60,10 @@
           "name": "membersType"
         },
         {
+          "type": "TeamType",
+          "name": "teamType"
+        },
+        {
           "type": [
             null,
             "ConversationNotificationInfo"
@@ -142,6 +146,10 @@
         {
           "type": "ConversationMembersType",
           "name": "membersType"
+        },
+        {
+          "type": "TeamType",
+          "name": "teamType"
         },
         {
           "type": "gregor1.Time",

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -115,6 +115,15 @@
     },
     {
       "type": "enum",
+      "name": "TeamType",
+      "symbols": [
+        "NONE_0",
+        "SIMPLE_1",
+        "COMPLEX_2"
+      ]
+    },
+    {
+      "type": "enum",
       "name": "NotificationKind",
       "symbols": [
         "GENERIC_0",
@@ -418,6 +427,10 @@
         {
           "type": "ConversationMembersType",
           "name": "membersType"
+        },
+        {
+          "type": "TeamType",
+          "name": "teamType"
         },
         {
           "type": [

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1027,6 +1027,10 @@
           "name": "membersType"
         },
         {
+          "type": "TeamType",
+          "name": "teamType"
+        },
+        {
           "type": {
             "type": "array",
             "items": "string"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -114,6 +114,12 @@ export const CommonNotificationKind = {
   atmention: 1,
 }
 
+export const CommonTeamType = {
+  none: 0,
+  simple: 1,
+  complex: 2,
+}
+
 export const CommonTopicType = {
   none: 0,
   chat: 1,
@@ -931,6 +937,7 @@ export type ConversationInfoLocal = {
   visibility: keybase1.TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  teamType: TeamType,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
   finalizeInfo?: ?ConversationFinalizeInfo,
@@ -971,6 +978,7 @@ export type ConversationMetadata = {
   visibility: keybase1.TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  teamType: TeamType,
   finalizeInfo?: ?ConversationFinalizeInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -1259,6 +1267,7 @@ export type InboxUIItem = {
   participants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  teamType: TeamType,
   time: gregor1.Time,
   notifications?: ?ConversationNotificationInfo,
   creatorInfo?: ?ConversationCreatorInfoLocal,
@@ -1828,6 +1837,11 @@ export type TLFResolveUpdate = {
   inboxVers: InboxVers,
 }
 
+export type TeamType =
+    0 // NONE_0
+  | 1 // SIMPLE_1
+  | 2 // COMPLEX_2
+
 export type ThreadID = bytes
 
 export type ThreadView = {
@@ -1921,6 +1935,7 @@ export type UnverifiedInboxUIItem = {
   visibility: keybase1.TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  teamType: TeamType,
   notifications?: ?ConversationNotificationInfo,
   time: gregor1.Time,
 }


### PR DESCRIPTION
Patch does the following:

1.) Adds `TeamType` to all conversation types so that the frontend doesn't need to compute that themselves.
2.) Changes protocol for server side.

cc @chrisnojima 