### PR TITLE
add local RPC to inject gregor ibm CORE-5975

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1487,9 +1487,9 @@ func (g *gregorHandler) DismissItem(id gregor.MsgID) error {
 	return err
 }
 
-func (g *gregorHandler) InjectItem(cat string, body []byte) (gregor.MsgID, error) {
+func (g *gregorHandler) InjectItem(ctx context.Context, cat string, body []byte, dtime gregor1.TimeOrOffset) (gregor1.MsgID, error) {
 	var err error
-	defer g.G().Trace(fmt.Sprintf("gregorHandler.InjectItem(%s)", cat),
+	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.InjectItem(%s)", cat),
 		func() error { return err },
 	)()
 
@@ -1500,11 +1500,11 @@ func (g *gregorHandler) InjectItem(cat string, body []byte) (gregor.MsgID, error
 	creation.Ibm_.StateUpdate_.Creation_ = &gregor1.Item{
 		Category_: gregor1.Category(cat),
 		Body_:     gregor1.Body(body),
+		Dtime_:    dtime,
 	}
 
 	incomingClient := gregor1.IncomingClient{Cli: g.cli}
-	// TODO: Should the interface take a context from the caller?
-	err = incomingClient.ConsumeMessage(context.TODO(), *creation)
+	err = incomingClient.ConsumeMessage(ctx, *creation)
 	return creation.Ibm_.StateUpdate_.Md_.MsgID_, err
 }
 
@@ -1581,6 +1581,10 @@ func (g *gregorHandler) getState(ctx context.Context) (res gregor1.State, err er
 
 func (g *gregorRPCHandler) GetState(ctx context.Context) (res gregor1.State, err error) {
 	return g.gh.getState(ctx)
+}
+
+func (g *gregorRPCHandler) InjectItem(ctx context.Context, arg keybase1.InjectItemArg) (gregor1.MsgID, error) {
+	return g.gh.InjectItem(ctx, arg.Cat, []byte(arg.Body), arg.Dtime)
 }
 
 func WrapGenericClientWithTimeout(client rpc.GenericClient, timeout time.Duration, timeoutErr error) rpc.GenericClient {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
+	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/pvlsource"
 	"github.com/keybase/client/go/teams"
@@ -841,7 +842,7 @@ func (d *Service) GregorInject(cat string, body []byte) (gregor.MsgID, error) {
 	if d.gregor == nil {
 		return nil, errors.New("can't gregor inject without a gregor")
 	}
-	return d.gregor.InjectItem(cat, body)
+	return d.gregor.InjectItem(context.TODO(), cat, body, gregor1.TimeOrOffset{})
 }
 
 func (d *Service) GregorInjectOutOfBandMessage(sys string, body []byte) error {

--- a/protocol/avdl/keybase1/gregor.avdl
+++ b/protocol/avdl/keybase1/gregor.avdl
@@ -3,4 +3,5 @@
 protocol gregor {
   import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
   gregor1.State getState();
+  gregor1.MsgID injectItem(string cat, string body, gregor1.TimeOrOffset dtime);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1439,6 +1439,14 @@ export function gregorGetStateRpcPromise (request: ?(requestCommon & {callback?:
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.getState', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function gregorInjectItemRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: gregorInjectItemResult) => void} & {param: gregorInjectItemRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.injectItem', request)
+}
+
+export function gregorInjectItemRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: gregorInjectItemResult) => void} & {param: gregorInjectItemRpcParam})): Promise<gregorInjectItemResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.injectItem', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function identifyIdentify2RpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyIdentify2Result) => void} & {param: identifyIdentify2RpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.identify2', request)
 }
@@ -5281,6 +5289,12 @@ export type gpgUiSignRpcParam = Exact<{
   fingerprint: bytes
 }>
 
+export type gregorInjectItemRpcParam = Exact<{
+  cat: string,
+  body: string,
+  dtime: gregor1.TimeOrOffset
+}>
+
 export type gregorUIPushOutOfBandMessagesRpcParam = Exact<{
   oobm?: ?Array<gregor1.OutOfBandMessage>
 }>
@@ -6226,6 +6240,7 @@ type gpgUiSelectKeyResult = string
 type gpgUiSignResult = string
 type gpgUiWantToAddGPGKeyResult = boolean
 type gregorGetStateResult = gregor1.State
+type gregorInjectItemResult = gregor1.MsgID
 type identifyIdentify2Result = Identify2Res
 type identifyIdentifyLiteResult = IdentifyLiteRes
 type identifyResolve3Result = UserOrTeamLite

--- a/protocol/json/keybase1/gregor.json
+++ b/protocol/json/keybase1/gregor.json
@@ -12,6 +12,23 @@
     "getState": {
       "request": [],
       "response": "gregor1.State"
+    },
+    "injectItem": {
+      "request": [
+        {
+          "name": "cat",
+          "type": "string"
+        },
+        {
+          "name": "body",
+          "type": "string"
+        },
+        {
+          "name": "dtime",
+          "type": "gregor1.TimeOrOffset"
+        }
+      ],
+      "response": "gregor1.MsgID"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1439,6 +1439,14 @@ export function gregorGetStateRpcPromise (request: ?(requestCommon & {callback?:
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.getState', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function gregorInjectItemRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: gregorInjectItemResult) => void} & {param: gregorInjectItemRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.injectItem', request)
+}
+
+export function gregorInjectItemRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: gregorInjectItemResult) => void} & {param: gregorInjectItemRpcParam})): Promise<gregorInjectItemResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.injectItem', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function identifyIdentify2RpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: identifyIdentify2Result) => void} & {param: identifyIdentify2RpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.identify2', request)
 }
@@ -5281,6 +5289,12 @@ export type gpgUiSignRpcParam = Exact<{
   fingerprint: bytes
 }>
 
+export type gregorInjectItemRpcParam = Exact<{
+  cat: string,
+  body: string,
+  dtime: gregor1.TimeOrOffset
+}>
+
 export type gregorUIPushOutOfBandMessagesRpcParam = Exact<{
   oobm?: ?Array<gregor1.OutOfBandMessage>
 }>
@@ -6226,6 +6240,7 @@ type gpgUiSelectKeyResult = string
 type gpgUiSignResult = string
 type gpgUiWantToAddGPGKeyResult = boolean
 type gregorGetStateResult = gregor1.State
+type gregorInjectItemResult = gregor1.MsgID
 type identifyIdentify2Result = Identify2Res
 type identifyIdentifyLiteResult = IdentifyLiteRes
 type identifyResolve3Result = UserOrTeamLite


### PR DESCRIPTION
Patch does the following:

1.) Add new RPC `InjectItem`, which will allow the frontend to add items to the Gregor state.
2.) Add a `dtime` parameter to the internal `InjectItem` so that these items can come with a pre-computed dismiss time.

cc @chrisnojima 