### PR TITLE
Fix white screen crash accessing tlfName on an inbox entry that hasn't been loaded yet

### DIFF
--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -306,10 +306,11 @@ const postAttachmentSagaMap = (
 function* onSelectAttachment({payload: {input}}: Constants.SelectAttachment): Generator<any, any, any> {
   const {title, filename} = input
   let {conversationIDKey} = input
+  let newConvoTlfName
 
   if (Constants.isPendingConversationIDKey(conversationIDKey)) {
     // Get a real conversationIDKey
-    conversationIDKey = yield call(Shared.startNewConversation, conversationIDKey)
+    [conversationIDKey, newConvoTlfName] = yield call(Shared.startNewConversation, conversationIDKey)
     if (!conversationIDKey) {
       return
     }
@@ -325,7 +326,7 @@ function* onSelectAttachment({payload: {input}}: Constants.SelectAttachment): Ge
   const inboxConvo = yield select(Shared.selectedInboxSelector, conversationIDKey)
   const param = {
     conversationID: Constants.keyToConversationID(conversationIDKey),
-    tlfName: inboxConvo.name,
+    tlfName: inboxConvo ? inboxConvo.name : newConvoTlfName,
     visibility: inboxConvo.visibility,
     attachment: {filename},
     preview,

--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -310,7 +310,7 @@ function* onSelectAttachment({payload: {input}}: Constants.SelectAttachment): Ge
 
   if (Constants.isPendingConversationIDKey(conversationIDKey)) {
     // Get a real conversationIDKey
-    [conversationIDKey, newConvoTlfName] = yield call(Shared.startNewConversation, conversationIDKey)
+    ;[conversationIDKey, newConvoTlfName] = yield call(Shared.startNewConversation, conversationIDKey)
     if (!conversationIDKey) {
       return
     }

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -69,7 +69,7 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
 
   if (Constants.isPendingConversationIDKey(conversationIDKey)) {
     // Get a real conversationIDKey
-    [conversationIDKey, newConvoTlfName] = yield call(Shared.startNewConversation, conversationIDKey)
+    ;[conversationIDKey, newConvoTlfName] = yield call(Shared.startNewConversation, conversationIDKey)
     if (!conversationIDKey) {
       return
     }

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -65,18 +65,22 @@ function* deleteMessage(action: Constants.DeleteMessage): SagaGenerator<any, any
 
 function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
   let {conversationIDKey} = action.payload
-
-  const inSearch = yield select((state: TypedState) => state.chat.get('inSearch'))
-  if (inSearch) {
-    yield put(Creators.exitSearch())
-  }
+  let newConvoTlfName
 
   if (Constants.isPendingConversationIDKey(conversationIDKey)) {
     // Get a real conversationIDKey
-    conversationIDKey = yield call(Shared.startNewConversation, conversationIDKey)
+    [conversationIDKey, newConvoTlfName] = yield call(Shared.startNewConversation, conversationIDKey)
     if (!conversationIDKey) {
       return
     }
+  }
+
+  // Note: This should happen *after* startNewConversation, because
+  // startNewConversation() uses the presence of a pendingConversation
+  // that is deleted by exitSearch().
+  const inSearch = yield select((state: TypedState) => state.chat.get('inSearch'))
+  if (inSearch) {
+    yield put(Creators.exitSearch())
   }
 
   const [inboxConvo, lastMessageID]: [Constants.InboxState, ?Constants.MessageID] = yield all([
@@ -121,7 +125,7 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
   yield call(ChatTypes.localPostTextNonblockRpcPromise, {
     param: {
       conversationID: Constants.keyToConversationID(conversationIDKey),
-      tlfName: inboxConvo.name,
+      tlfName: inboxConvo ? inboxConvo.name : newConvoTlfName,
       tlfPublic: false,
       outboxID,
       body: action.payload.text.stringValue(),

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -67,7 +67,7 @@ function tmpFileName(
 // Actually start a new conversation. conversationIDKey can be a pending one or a replacement
 function* startNewConversation(
   oldConversationIDKey: Constants.ConversationIDKey
-): Generator<any, ?Constants.ConversationIDKey, any> {
+): Generator<any, [?Constants.ConversationIDKey, ?string], any> {
   // Find the participants
   const pendingTlfName = Constants.pendingConversationIDKeyToTlfName(oldConversationIDKey)
   let tlfName
@@ -114,7 +114,7 @@ function* startNewConversation(
   }
   // Load the inbox so we can post, we wait till this is done
   yield call(unboxConversations, [newConversationIDKey])
-  return newConversationIDKey
+  return [newConversationIDKey, tlfName]
 }
 
 // If we're showing a banner we send chatGui, if we're not we send chatGuiStrict

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -82,7 +82,7 @@ function* startNewConversation(
 
   if (!tlfName) {
     console.warn("Shouldn't happen in practice")
-    return null
+    return [null, null]
   }
 
   const result = yield call(ChatTypes.localNewConversationLocalRpcPromise, {
@@ -97,7 +97,7 @@ function* startNewConversation(
   const newConversationIDKey = result ? Constants.conversationIDToKey(result.conv.info.id) : null
   if (!newConversationIDKey) {
     console.warn('No convoid from newConvoRPC')
-    return null
+    return [null, null]
   }
 
   // Replace any existing convo


### PR DESCRIPTION
@keybase/react-hackers 

postMessage passes a tlfName to the service.  We get the tlfName from the inbox entry associated with the conversation.  But there are races -- inbox entries appear because we're passed them from the service, and we add and unbox them asynchronously when we're idle.

If we try to post to a convo straight away after creating it, we can win or lose that race.  If we lose, inboxConvo will come up undefined because we haven't spawned this task yet:
```js
function* _chatInboxConversationSubSaga({conv}) {
  // Wait for an idle
  yield call(onIdlePromise, 100)
  // TODO might be better to make this a put with an associated takeEvery
  yield spawn(processConversation, conv)
  return EngineRpc.rpcResult()
}
```

When we're starting a conversation, we know what the new tlfName is -- we originally calculate it ourselves.  So this PR fixes the dependency on an inboxConvo existing already for a new conversation by passing the newly-created tlfName back to postMessage directly, instead of going through the roundtrip to the service's inbox.

Also, we were failing to upgrade a pending conversation because it was being deleted by an exitSearch() just before we tried to look it up.  That's fixed by moving the exitSearch() below the startNewConversation().

(Thanks @MarcoPolo for helping figure this out!)