### PR TITLE
Get per-user-key on provision

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -599,21 +599,11 @@ func (e *loginProvision) route(ctx *Context) error {
 	}
 
 	if e.hasDevice {
-		err := e.chooseDevice(ctx, e.hasPGP)
-		if err != nil {
-			return err
-		}
-		e.perUserKeyUpgradeSoft(ctx)
-		return nil
+		return e.chooseDevice(ctx, e.hasPGP)
 	}
 
 	if e.hasPGP {
-		err := e.tryPGP(ctx)
-		if err != nil {
-			return err
-		}
-		e.perUserKeyUpgradeSoft(ctx)
-		return nil
+		return e.tryPGP(ctx)
 	}
 
 	if !e.arg.User.GetEldestKID().IsNil() {
@@ -1070,17 +1060,6 @@ func (e *loginProvision) cleanup() {
 	// the best way to cleanup is to logout...
 	e.G().Log.Debug("an error occurred during provisioning, logging out")
 	e.G().Logout()
-}
-
-// Get a per-user key.
-// Wait for attempt but only warn on error.
-func (e *loginProvision) perUserKeyUpgradeSoft(ctx *Context) error {
-	eng := NewPerUserKeyUpgrade(e.G(), &PerUserKeyUpgradeArgs{})
-	err := RunEngine(eng, ctx)
-	if err != nil {
-		e.G().Log.CWarningf(ctx.GetNetContext(), "loginProvision PerUserKeyUpgrade failed: %v", err)
-	}
-	return err
 }
 
 var devtypeSortOrder = map[string]int{libkb.DeviceTypeMobile: 0, libkb.DeviceTypeDesktop: 1, libkb.DeviceTypePaper: 2}

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -1256,6 +1256,8 @@ func TestProvisionGPGSign(t *testing.T) {
 		// after provisioning, the secret should be stored
 		assertSecretStored(tc2, u1.Username)
 
+		checkPerUserKeyCount(&tc2, 1)
+
 		// since they *did not* import a pgp key, they should *not* be able to pgp sign something:
 		if err := signString(tc2, "sign me", u1.NewSecretUI()); err == nil {
 			t.Error("pgp sign worked after gpg provision w/o import")

--- a/go/engine/pgpprovision.go
+++ b/go/engine/pgpprovision.go
@@ -111,7 +111,18 @@ func (e *PGPProvision) provision(ctx *Context) error {
 	}
 
 	// need a session to try to get synced private key
-	return e.G().LoginState().LoginWithPassphrase(e.user.GetName(), e.passphrase, false, afterLogin)
+	err := e.G().LoginState().LoginWithPassphrase(e.user.GetName(), e.passphrase, false, afterLogin)
+	if err != nil {
+		return err
+	}
+
+	// Get a per-user key
+	eng := NewPerUserKeyUpgrade(e.G(), &PerUserKeyUpgradeArgs{})
+	err = RunEngine(eng, ctx)
+	if err != nil {
+		e.G().Log.CWarningf(ctx.GetNetContext(), "PGPProvision PerUserKeyUpgrade failed: %v", err)
+	}
+	return nil
 }
 
 // syncedPGPKey looks for a synced pgp key for e.user.  If found,

--- a/go/engine/pgpprovision.go
+++ b/go/engine/pgpprovision.go
@@ -116,7 +116,8 @@ func (e *PGPProvision) provision(ctx *Context) error {
 		return err
 	}
 
-	// Get a per-user key
+	// Get a per-user key.
+	// Wait for attempt but only warn on error.
 	eng := NewPerUserKeyUpgrade(e.G(), &PerUserKeyUpgradeArgs{})
 	err = RunEngine(eng, ctx)
 	if err != nil {

--- a/go/engine/pgpprovision_test.go
+++ b/go/engine/pgpprovision_test.go
@@ -39,4 +39,6 @@ func TestPGPProvision(t *testing.T) {
 	if err := AssertProvisioned(tc2); err != nil {
 		t.Fatal(err)
 	}
+
+	checkPerUserKeyCount(&tc, 1)
 }

--- a/go/engine/puk_upgrade.go
+++ b/go/engine/puk_upgrade.go
@@ -74,14 +74,14 @@ func (e *PerUserKeyUpgrade) inner(ctx *Context) error {
 		WithUID(uid).
 		WithSelf(true).
 		WithPublicKeyOptional()
-	upak, me, err := e.G().GetUPAKLoader().Load(*loadArg)
+	upak, me, err := e.G().GetUPAKLoader().LoadV2(*loadArg)
 	if err != nil {
 		return err
 	}
-	// `me` could be nil. Use the upak for quick checks and then fill `me`.
+	// `me` could be nil. Use the upak for quick checks and then pass maybe-nil `me` to the next engine.
 
 	e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyUpgrade check for key")
-	if len(upak.Base.PerUserKeys) > 0 {
+	if len(upak.Current.PerUserKeys) > 0 {
 		e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyUpgrade already has per-user-key")
 		e.DidNewKey = false
 		return nil


### PR DESCRIPTION
The problem: Bob signed up on the site and got a pgp key but no devices. (Because they reset, but that doesn't matter). Alice tried to invite Bob to a team but it said he needs to provision a device (needs a PUK). Bob provisioned a device, PerUserKeyUpgradeBackground ran, then he logged in. In 1 hour the background would go again, but in the meantime Alice and Bob and Chris got confused.

The fix: Try to upgrade to a PUK whenever you provision a device. I made it a warning if it fails just to not make provisioning riskier, but I don't expect it to fail.

All the details: Provisioning a device that is the first _key_ has first-class PUK support for adding the first PUK. Provisioning a device when you already have a PUK has first-class support for rolling the PUK. This PR addresses straggler cases: provisioning a first device when you have a pgp key, and provisioning a non-first device when you don't have a PUK. Those now attempt to get a first PUK but in a separate subsequent transaction from the main provisioning sig posts. The background task takes care of the case where an already-provisioned device upgrades its software.

`loginProvision` is the real engine and `TestProvisionGPGSign` is the real test.
`PGPProvision` is a dev-only engine and `TestPGPProvision` is its test.