### PR TITLE
Inbox perf fixes

### DIFF
--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -699,18 +699,24 @@ function updateSnippet(
   return {payload: {conversationIDKey, snippet}, type: 'chat:updateSnippet'}
 }
 
+function unboxConversations(
+  conversationIDKeys: Array<Constants.ConversationIDKey>
+): Constants.UnboxConversations {
+  return {payload: {conversationIDKeys}, type: 'chat:unboxConversations'}
+}
+
 export {
   addPending,
   appendMessages,
   attachmentLoaded,
-  attachmentSaved,
-  attachmentSaveStart,
   attachmentSaveFailed,
+  attachmentSaveStart,
+  attachmentSaved,
   badgeAppForChat,
   blockConversation,
   clearMessages,
-  clearSearchResults,
   clearRekey,
+  clearSearchResults,
   deleteMessage,
   downloadProgress,
   editMessage,
@@ -762,6 +768,7 @@ export {
   startConversation,
   threadLoadedOffline,
   toggleChannelWideNotifications,
+  unboxConversations,
   unstageUserForSearch,
   untrustedInboxVisible,
   updateBadging,
@@ -775,6 +782,7 @@ export {
   updateLatestMessage,
   updateMetadata,
   updatePaginationNext,
+  updateSnippet,
   updateSupersededByState,
   updateSupersedesState,
   updateTempMessage,
@@ -783,5 +791,4 @@ export {
   updatedMetadata,
   updatedNotifications,
   uploadProgress,
-  updateSnippet,
 }

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -354,7 +354,6 @@ const unboxConversationsSagaMap = {
   'chat.1.chatUi.chatInboxUnverified': EngineRpc.passthroughResponseSaga,
 }
 
-const _TEMP = {}
 // Loads the trusted inbox segments
 function* unboxConversations(action: Constants.UnboxConversations): SagaGenerator<any, any> {
   let {conversationIDKeys} = action.payload
@@ -377,14 +376,6 @@ function* unboxConversations(action: Constants.UnboxConversations): SagaGenerato
   if (!conversationIDKeys.length) {
     return
   }
-  // TEMP
-  const TEMP = yield select()
-  conversationIDKeys.forEach(k => {
-    if (_TEMP[k]) {
-      debugger
-    }
-    _TEMP[k] = true
-  })
 
   yield put.resolve(Creators.setUnboxing(conversationIDKeys, false))
 

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -144,6 +144,7 @@ function* onInboxStale(): SagaGenerator<any, any> {
             participants: List(parseFolderNameToUsers(author, c.name).map(ul => ul.username)),
             status: Constants.ConversationStatusByEnum[c.status || 0],
             teamname: c.membersType === ChatTypes.CommonConversationMembersType.team ? c.name : undefined,
+            teamType: c.teamType,
             time: c.time,
           })
         })
@@ -259,8 +260,8 @@ function* untrustedInboxVisible(action: Constants.UntrustedInboxVisible): SagaGe
     return
   }
 
-  // Collect items to unbox
-  const total = rowsVisible * 2
+  // Collect items to unbox, sanity max at 40
+  const total = Math.max(rowsVisible + 2, 40)
   const conversationIDKeys = inboxes
     .slice(idx, idx + total)
     .map(i => (i.state === 'untrusted' ? i.conversationIDKey : null))
@@ -442,7 +443,7 @@ const parseNotifications = (
   }
 }
 
-// Convert server to our data type. Make timestamps and snippets
+// Convert server to our data type
 function _conversationLocalToInboxState(c: ?ChatTypes.InboxUIItem): ?Constants.InboxState {
   if (
     !c ||
@@ -476,6 +477,7 @@ function _conversationLocalToInboxState(c: ?ChatTypes.InboxUIItem): ?Constants.I
     state: 'unboxed',
     status: Constants.ConversationStatusByEnum[c.status],
     teamname,
+    teamType: c.teamType,
     time: c.time,
     visibility: c.visibility,
   })

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -154,12 +154,13 @@ function* onInboxStale(): SagaGenerator<any, any> {
     yield put(Creators.setInboxUntrustedState('loaded'))
     yield put(Creators.loadedInbox(conversations))
 
-    // Unbox teams so we can get their names
-    yield put(
-      Creators.unboxConversations(
-        conversations.filter(c => c.teamname).map(c => c.conversationIDKey).toArray()
-      )
-    )
+    // Load the first visible simple and teams so we can get the channel names
+    const toUnbox = conversations
+      .filter(c => !c.teamname)
+      .take(20)
+      .concat(conversations.filter(c => c.teamname))
+
+    yield put(Creators.unboxConversations(toUnbox.map(c => c.conversationIDKey).toArray()))
 
     const {
       initialConversation,

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -1147,7 +1147,7 @@ function* _markThreadsStale(action: Constants.MarkThreadsStale): SagaGenerator<a
   // Load inbox items of any stale items so we get update on rekeyInfos, etc
   const {updates} = action.payload
   const convIDs = updates.map(u => Constants.conversationIDToKey(u.convID))
-  yield call(Inbox.unboxConversations, convIDs)
+  yield put(Creators.unboxConversations(convIDs))
 
   // Selected is stale?
   const selectedConversation = yield select(Constants.getSelectedConversation)
@@ -1392,6 +1392,7 @@ function* chatSaga(): SagaGenerator<any, any> {
   yield Saga.safeTakeLatest('chat:exitSearch', _exitSearch)
   yield Saga.safeTakeLatest('chat:setNotifications', _setNotifications)
   yield Saga.safeTakeLatest('chat:toggleChannelWideNotifications', _setNotifications)
+  yield Saga.safeTakeSerially('chat:unboxConversations', Inbox.unboxConversations)
 }
 
 export default chatSaga

--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -15,7 +15,7 @@ import {globalStyles} from '../styles'
 import {RouteStateNode} from '../route-tree'
 import {isMobile} from '../constants/platform'
 import * as EntityConstants from '../constants/entities'
-
+import * as ChatTypes from '../constants/types/flow-types-chat'
 import type {ConversationIDKey} from '../constants/chat'
 
 const now = new Date(2016, 4, 20, 4, 20)
@@ -122,6 +122,7 @@ const inbox = [
     participants: List(participants),
     conversationIDKey: 'convo1',
     status: 'unfiled',
+    teamType: ChatTypes.CommonTeamType.none,
     time: now,
     snippet: 'fiveTEMPTEMP',
     unreadCount: 3,
@@ -131,6 +132,7 @@ const inbox = [
     participants: List(participants.slice(0, 2)),
     conversationIDKey: 'convo2',
     status: 'unfiled',
+    teamType: ChatTypes.CommonTeamType.none,
     time: now - 1000 * 60 * 60 * 3,
     snippet: '3 hours ago',
     unreadCount: 0,
@@ -140,6 +142,7 @@ const inbox = [
     participants: List(participants.slice(0, 3)),
     conversationIDKey: 'convo3',
     status: 'muted',
+    teamType: ChatTypes.CommonTeamType.none,
     time: now - 1000 * 60 * 60 * 24 * 3,
     snippet: '3 days ago',
     unreadCount: 0,
@@ -149,6 +152,7 @@ const inbox = [
     participants: List(participants.slice(0, 4)),
     conversationIDKey: 'convo5',
     status: 'unfiled',
+    teamType: ChatTypes.CommonTeamType.none,
     time: now - 1000 * 60 * 60 * 24 * 30,
     snippet: 'long ago',
     unreadCount: 0,
@@ -158,6 +162,7 @@ const inbox = [
     participants: List(participants.slice(0, 2)),
     conversationIDKey: 'convo6',
     status: 'unfiled',
+    teamType: ChatTypes.CommonTeamType.none,
     time: now - 1000 * 60 * 60 * 3,
     snippet: '3 hours ago',
     unreadCount: 1,
@@ -167,6 +172,7 @@ const inbox = [
     participants: List(participants.slice(0, 1)),
     conversationIDKey: 'convo7',
     status: 'muted',
+    teamType: ChatTypes.CommonTeamType.none,
     time: now - 1000 * 60 * 60 * 5,
     snippet: '3 hours ago',
     unreadCount: 1,

--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -49,7 +49,7 @@ const getSimpleRows = createSelector(
       })
       .sort((a, b) => {
         if (a.time === b.time) {
-          return a.id.localeCompare(b.id)
+          return a.conversationIDKey.localeCompare(b.conversationIDKey)
         }
 
         return b.time - a.time

--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -1,9 +1,10 @@
 // @flow
 import * as I from 'immutable'
 import * as Constants from '../../constants/chat'
+import * as ChatTypes from '../../constants/types/flow-types-chat'
 import Inbox from './index'
 import pausableConnect from '../../util/pausable-connect'
-import {createSelectorCreator, defaultMemoize} from 'reselect'
+import {createSelector} from 'reselect'
 import {loadInbox, newChat, untrustedInboxVisible, setInboxFilter} from '../../actions/chat/creators'
 import {compose, lifecycle, withState, withHandlers} from 'recompose'
 import throttle from 'lodash/throttle'
@@ -17,82 +18,35 @@ const getSupersededByState = (state: TypedState) => state.chat.get('supersededBy
 const getAlwaysShow = (state: TypedState) => state.chat.get('alwaysShow')
 const getPending = (state: TypedState) => state.chat.get('pendingConversations')
 const getFilter = (state: TypedState) => state.chat.get('inboxFilter')
-
-const createImmutableEqualSelector = createSelectorCreator(defaultMemoize, I.is)
+const getUnreadCounts = (state: TypedState) => state.chat.get('conversationUnreadCounts')
 
 const passesStringFilter = (filter: string, toCheck: string): boolean => {
   return toCheck.toLowerCase().indexOf(filter.toLowerCase()) >= 0
 }
 
 const passesParticipantFilter = (participants: I.List<string>, filter: string, you: ?string): boolean => {
-  if (!filter) {
-    return true
-  }
   const names = participants.filter(p => p !== you).toArray()
   // No need to worry about Unicode issues with toLowerCase(), since
   // names can only be ASCII.
   return names.some(n => passesStringFilter(filter, n))
 }
 
-const filteredInbox = createImmutableEqualSelector(
-  [getInbox, getSupersededByState, getAlwaysShow, getFilter, Constants.getYou],
-  (inbox, supersededByState, alwaysShow, filter, you) => {
-    const smallIds = []
-    const bigTeamToChannels = {}
-
-    // Partition small and big. Some big will turn into small later if they only have one channel
-    // Filter out any small teams that don't match
-    inbox.forEach(i => {
-      const id = i.conversationIDKey
-      if ((!i.isEmpty || alwaysShow.has(id)) && !supersededByState.get(id)) {
-        // Keep time cause we sort later
-        const value = {id, time: i.time}
-        if (!i.teamname && passesParticipantFilter(i.get('participants'), filter, you)) {
-          smallIds.push(value)
-        } else {
-          if (!bigTeamToChannels[i.teamname]) {
-            bigTeamToChannels[i.teamname] = {}
-          }
-          // Do we have the real name yet?
-          const channel = i.channelname === '-' ? id : i.channelname
-          bigTeamToChannels[i.teamname][channel] = value
+const getSimpleRows = createSelector(
+  [getInbox, getAlwaysShow, getFilter, getSupersededByState, Constants.getYou],
+  (inbox, alwaysShow, filter, supersededByState, you) => {
+    return inbox
+      .filter(i => {
+        if (i.teamType === ChatTypes.CommonTeamType.complex) {
+          return false
         }
-      }
-    })
 
-    // convert any small teams into smallids
-    Object.keys(bigTeamToChannels).forEach(team => {
-      // only one channel
-      const channels = Object.keys(bigTeamToChannels[team])
-      if (channels.length === 1) {
-        if (passesParticipantFilter(I.List.of(team), filter, you)) {
-          smallIds.push(bigTeamToChannels[team][channels[0]])
-        }
-        delete bigTeamToChannels[team]
-      }
-    })
+        const id = i.conversationIDKey
+        const isEmpty = i.isEmpty && !alwaysShow.has(id)
+        const isSuperseded = !!supersededByState.get(id)
+        const isFilteredOut = !!(filter && !passesParticipantFilter(i.get('participants'), filter, you))
 
-    // Filter out big teams
-    if (filter) {
-      Object.keys(bigTeamToChannels).forEach(team => {
-        // teamname doesn't pass
-        if (!passesStringFilter(filter, team)) {
-          const channels = Object.keys(bigTeamToChannels[team])
-          channels.forEach(c => {
-            if (!passesStringFilter(filter, c)) {
-              delete bigTeamToChannels[team][c]
-            }
-          })
-
-          const filteredChannels = Object.keys(bigTeamToChannels[team])
-          if (!filteredChannels.length) {
-            delete bigTeamToChannels[team]
-          }
-        }
+        return !isEmpty && !isSuperseded && !isFilteredOut
       })
-    }
-
-    const sortedSmallIds = smallIds
       .sort((a, b) => {
         if (a.time === b.time) {
           return a.id.localeCompare(b.id)
@@ -100,16 +54,57 @@ const filteredInbox = createImmutableEqualSelector(
 
         return b.time - a.time
       })
-      .map(v => v.id)
-
-    return [sortedSmallIds, bigTeamToChannels]
+      .map(i => i.conversationIDKey)
   }
 )
-const getRows = createImmutableEqualSelector(
-  [filteredInbox, getPending, getFilter],
-  (inbox, pending, filter) => {
-    const [smallIds, bigTeamToChannels] = inbox
 
+const getBigRows = createSelector([getInbox, getFilter], (inbox, filter) => {
+  const bigTeamToChannels = inbox
+    .filter(i => i.teamType === ChatTypes.CommonTeamType.complex)
+    .reduce((map, i) => {
+      if (!map[i.teamname]) {
+        map[i.teamname] = {}
+      }
+      const id = i.conversationIDKey
+      // Do we have the real name yet?
+      const channel = i.channelname === '-' ? id : i.channelname
+      map[i.teamname][channel] = id
+      return map
+    }, {})
+
+  // Filter out big teams
+  if (filter) {
+    Object.keys(bigTeamToChannels).forEach(team => {
+      // teamname doesn't pass
+      if (filter && !passesStringFilter(filter, team)) {
+        const channels = Object.keys(bigTeamToChannels[team])
+        channels.forEach(c => {
+          if (filter && !passesStringFilter(filter, c)) {
+            delete bigTeamToChannels[team][c]
+          }
+        })
+
+        const filteredChannels = Object.keys(bigTeamToChannels[team])
+        if (!filteredChannels.length) {
+          delete bigTeamToChannels[team]
+        }
+      }
+    })
+  }
+
+  return bigTeamToChannels
+})
+
+const getRows = createSelector(
+  [
+    getSimpleRows,
+    getBigRows,
+    getPending,
+    getFilter,
+    getUnreadCounts,
+    (_, smallTeamsExpanded) => smallTeamsExpanded,
+  ],
+  (smallIds, bigTeamToChannels, pending, filter, badgeCountMap, smallTeamsExpanded) => {
     const pids = I.List(pending.keySeq().map(k => ({conversationIDKey: k, type: 'small'})))
     const sids = I.List(smallIds.map(s => ({conversationIDKey: s, type: 'small'})))
 
@@ -129,7 +124,7 @@ const getRows = createImmutableEqualSelector(
           ].concat(
             Object.keys(channels).sort().map(channel => ({
               channelname: channel,
-              conversationIDKey: channels[channel].id,
+              conversationIDKey: channels[channel],
               teamname: team,
               type: 'big',
             }))
@@ -138,40 +133,42 @@ const getRows = createImmutableEqualSelector(
       )
     )
 
-    const allSmallTeams = pids.concat(sids)
-    return [allSmallTeams, bigTeams]
+    let smallTeams = pids.concat(sids)
+    let showSmallTeamsExpandDivider = false
+
+    if (!filter && bigTeams.count() && smallTeams.count() > smallteamsCollapsedMaxShown) {
+      showSmallTeamsExpandDivider = true
+      if (!smallTeamsExpanded) {
+        smallTeams = smallTeams.slice(0, smallteamsCollapsedMaxShown)
+      }
+    }
+
+    const bigTeamsBadgeCount = bigTeams.reduce((total, team) => {
+      if (team.type === 'big') {
+        return total + badgeCountMap.get(team.conversationIDKey, 0)
+      }
+      return total
+    }, 0)
+
+    const divider = {isBadged: bigTeamsBadgeCount > 0, type: 'divider'}
+    const bigTeamsLabel = {isFiltered: !!filter, type: 'bigTeamsLabel'}
+    const showBuildATeam = bigTeams.count() === 0
+
+    const rows = smallTeams
+      .concat(I.List(showSmallTeamsExpandDivider ? [divider] : []))
+      .concat(I.List(bigTeams.count() ? [bigTeamsLabel] : []))
+      .concat(bigTeams)
+
+    return {bigTeamsBadgeCount, rows, showBuildATeam, showSmallTeamsExpandDivider}
   }
 )
 
 const mapStateToProps = (state: TypedState, {isActiveRoute, smallTeamsExpanded}) => {
-  const [allSmallTeams, bigTeams] = getRows(state, smallTeamsExpanded)
+  const {rows, showBuildATeam, showSmallTeamsExpandDivider, bigTeamsBadgeCount} = getRows(
+    state,
+    smallTeamsExpanded
+  )
   const filter = getFilter(state)
-
-  let smallTeams = allSmallTeams
-  let showSmallTeamsExpandDivider = false
-
-  if (!filter && bigTeams.count() && allSmallTeams.count() > smallteamsCollapsedMaxShown) {
-    showSmallTeamsExpandDivider = true
-    if (!smallTeamsExpanded) {
-      smallTeams = allSmallTeams.slice(0, smallteamsCollapsedMaxShown)
-    }
-  }
-
-  const badgeCountMap = state.chat.get('conversationUnreadCounts')
-  const bigTeamsBadgeCount = bigTeams.reduce((total, team) => {
-    if (team.type === 'big') {
-      return total + badgeCountMap.get(team.conversationIDKey, 0)
-    }
-    return total
-  }, 0)
-  const divider = {isBadged: bigTeamsBadgeCount > 0, type: 'divider'}
-  const bigTeamsLabel = {isFiltered: !!filter, type: 'bigTeamsLabel'}
-  const showBuildATeam = bigTeams.count() === 0
-
-  const rows = smallTeams
-    .concat(I.List(showSmallTeamsExpandDivider ? [divider] : []))
-    .concat(I.List(bigTeams.count() ? [bigTeamsLabel] : []))
-    .concat(bigTeams)
 
   return {
     bigTeamsBadgeCount,

--- a/shared/chat/inbox/index.desktop.js
+++ b/shared/chat/inbox/index.desktop.js
@@ -68,12 +68,6 @@ class Inbox extends PureComponent<Props, State> {
 
   _list: any
 
-  componentWillReceiveProps(nextProps: Props) {
-    if (this.props.rows !== nextProps.rows && nextProps.rows.count()) {
-      this._onScrollUnbox()
-    }
-  }
-
   componentDidUpdate(prevProps: Props) {
     if (
       (this.props.rows !== prevProps.rows && prevProps.rows.count()) ||

--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -85,15 +85,6 @@ class Inbox extends React.PureComponent<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    if (this.props.rows !== nextProps.rows) {
-      if (nextProps.rows.count()) {
-        const row = nextProps.rows.get(0)
-        if (row.type === 'small' && row.conversationIDKey) {
-          this.props.onUntrustedInboxVisible(row.conversationIDKey, 20)
-        }
-      }
-    }
-
     if (this.props.smallTeamsExpanded !== nextProps.smallTeamsExpanded && !nextProps.smallTeamsExpanded) {
       this._list && this._list.scrollToOffset({animated: true, offset: 0})
     }

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -15,19 +15,21 @@ import {parseUserId, serviceIdToIcon} from '../util/platforms'
 import type {UserListItem} from '../common-adapters/usernames'
 import type {Path} from '../route-tree'
 import type {NoErrorTypedAction, TypedAction} from './types/flux'
-import type {
-  Asset,
-  AssetMetadata,
-  ChatActivity,
-  ConversationInfoLocal,
-  ConversationMembersType,
-  ConversationFinalizeInfo,
-  MessageBody,
-  MessageID as RPCMessageID,
-  OutboxID as RPCOutboxID,
-  ConversationID as RPCConversationID,
-  TyperInfo,
-  ConversationStaleUpdate,
+import {
+  CommonTeamType,
+  type Asset,
+  type AssetMetadata,
+  type ChatActivity,
+  type ConversationInfoLocal,
+  type ConversationMembersType,
+  type ConversationFinalizeInfo,
+  type MessageBody,
+  type MessageID as RPCMessageID,
+  type OutboxID as RPCOutboxID,
+  type ConversationID as RPCConversationID,
+  type TeamType,
+  type TyperInfo,
+  type ConversationStaleUpdate,
 } from './types/flow-types-chat'
 import {CommonTLFVisibility} from './types/flow-types'
 import type {DeviceType, KBRecord, KBOrderedSet} from './types/more'
@@ -297,6 +299,7 @@ export const InboxStateRecord = Record({
   time: 0,
   name: '',
   visibility: CommonTLFVisibility.private,
+  teamType: CommonTeamType.none,
 })
 
 export type InboxState = KBRecord<{
@@ -312,6 +315,7 @@ export type InboxState = KBRecord<{
   state: 'untrusted' | 'unboxed' | 'error' | 'unboxing',
   status: ConversationStateEnum,
   time: number,
+  teamType: TeamType,
 }>
 
 export type SupersedeInfo = {

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -1,12 +1,12 @@
 // @flow
 import * as SearchConstants from './search'
+import * as ChatTypes from './types/flow-types-chat'
 import {createShallowEqualSelector} from './selectors'
 import HiddenString from '../util/hidden-string'
 import {Buffer} from 'buffer'
 import {Set, List, Map, OrderedSet, Record} from 'immutable'
 import clamp from 'lodash/clamp'
 import invert from 'lodash/invert'
-import * as ChatTypes from './types/flow-types-chat'
 import {getPath, getPathState} from '../route-tree'
 import {chatTab} from './tabs'
 import {createSelector} from 'reselect'
@@ -15,22 +15,6 @@ import {parseUserId, serviceIdToIcon} from '../util/platforms'
 import type {UserListItem} from '../common-adapters/usernames'
 import type {Path} from '../route-tree'
 import type {NoErrorTypedAction, TypedAction} from './types/flux'
-import {
-  CommonTeamType,
-  type Asset,
-  type AssetMetadata,
-  type ChatActivity,
-  type ConversationInfoLocal,
-  type ConversationMembersType,
-  type ConversationFinalizeInfo,
-  type MessageBody,
-  type MessageID as RPCMessageID,
-  type OutboxID as RPCOutboxID,
-  type ConversationID as RPCConversationID,
-  type TeamType,
-  type TyperInfo,
-  type ConversationStaleUpdate,
-} from './types/flow-types-chat'
 import {CommonTLFVisibility} from './types/flow-types'
 import type {DeviceType, KBRecord, KBOrderedSet} from './types/more'
 import type {TypedState} from './reducer'
@@ -63,10 +47,10 @@ export const messageStates: Array<MessageState> = ['pending', 'failed', 'sent']
 export type AttachmentMessageState = MessageState | 'placeholder' | 'uploading'
 export type AttachmentType = 'Image' | 'Video' | 'Other'
 
-export type ConversationID = RPCConversationID
+export type ConversationID = ChatTypes.ConversationID
 export type ConversationIDKey = string
 
-export type OutboxID = RPCOutboxID
+export type OutboxID = ChatTypes.OutboxID
 export type OutboxIDKey = string
 
 export type MessageID = string
@@ -299,33 +283,33 @@ export const InboxStateRecord = Record({
   time: 0,
   name: '',
   visibility: CommonTLFVisibility.private,
-  teamType: CommonTeamType.none,
+  teamType: ChatTypes.CommonTeamType.none,
 })
 
 export type InboxState = KBRecord<{
   conversationIDKey: ConversationIDKey,
-  info: ConversationInfoLocal,
+  info: ChatTypes.ConversationInfoLocal,
   isEmpty: boolean,
   teamname: ?string,
   channelname: ?string,
   name: ?string,
-  membersType: ConversationMembersType,
+  membersType: ChatTypes.ConversationMembersType,
   notifications: NotificationsState,
   participants: List<string>,
   state: 'untrusted' | 'unboxed' | 'error' | 'unboxing',
   status: ConversationStateEnum,
   time: number,
-  teamType: TeamType,
+  teamType: ChatTypes.TeamType,
 }>
 
 export type SupersedeInfo = {
   conversationIDKey: ConversationID,
-  finalizeInfo: ConversationFinalizeInfo,
+  finalizeInfo: ChatTypes.ConversationFinalizeInfo,
 }
 
-export type FinalizeInfo = ConversationFinalizeInfo
+export type FinalizeInfo = ChatTypes.ConversationFinalizeInfo
 
-export type FinalizedState = Map<ConversationIDKey, ConversationFinalizeInfo>
+export type FinalizedState = Map<ConversationIDKey, ChatTypes.ConversationFinalizeInfo>
 
 export type SupersedesState = Map<ConversationIDKey, SupersedeInfo>
 export type SupersededByState = Map<ConversationIDKey, SupersedeInfo>
@@ -473,8 +457,8 @@ export type GetInboxAndUnbox = NoErrorTypedAction<
   {conversationIDKeys: Array<ConversationIDKey>}
 >
 export type InboxStale = NoErrorTypedAction<'chat:inboxStale', void>
-export type IncomingMessage = NoErrorTypedAction<'chat:incomingMessage', {activity: ChatActivity}>
-export type IncomingTyping = NoErrorTypedAction<'chat:incomingTyping', {activity: TyperInfo}>
+export type IncomingMessage = NoErrorTypedAction<'chat:incomingMessage', {activity: ChatTypes.ChatActivity}>
+export type IncomingTyping = NoErrorTypedAction<'chat:incomingTyping', {activity: ChatTypes.TyperInfo}>
 export type LeaveConversation = NoErrorTypedAction<
   'chat:leaveConversation',
   {conversationIDKey: ConversationIDKey}
@@ -491,7 +475,7 @@ export type LoadingMessages = NoErrorTypedAction<
 >
 export type MarkThreadsStale = NoErrorTypedAction<
   'chat:markThreadsStale',
-  {updates: Array<ConversationStaleUpdate>}
+  {updates: Array<ChatTypes.ConversationStaleUpdate>}
 >
 export type MuteConversation = NoErrorTypedAction<
   'chat:muteConversation',
@@ -834,11 +818,11 @@ function keyToOutboxID(key: OutboxIDKey): OutboxID {
 
 const _messageIDPrefix = 'MSGID-'
 const _messageIDPrefixReg = new RegExp('^' + _messageIDPrefix)
-function rpcMessageIDToMessageID(rpcMessageID: RPCMessageID): MessageID {
+function rpcMessageIDToMessageID(rpcMessageID: ChatTypes.MessageID): MessageID {
   return `${_messageIDPrefix}${rpcMessageID.toString(16)}`
 }
 
-function messageIDToRpcMessageID(msgID: MessageID): RPCMessageID {
+function messageIDToRpcMessageID(msgID: MessageID): ChatTypes.MessageID {
   return parseInt(msgID.substring(_messageIDPrefix.length), 16)
 }
 
@@ -855,7 +839,7 @@ function messageIDToSelfInventedID(msgID: MessageID) {
 type ParsedMessageID =
   | {
       type: 'rpcMessageID',
-      msgID: RPCMessageID,
+      msgID: ChatTypes.MessageID,
     }
   | {
       type: 'outboxID',
@@ -899,7 +883,7 @@ function makeSnippet(messageBody: ?string): ?string {
   return textSnippet(messageBody || '', 100)
 }
 
-function makeTeamTitle(messageBody: ?MessageBody): ?string {
+function makeTeamTitle(messageBody: ?ChatTypes.MessageBody): ?string {
   if (!messageBody) {
     return null
   }
@@ -967,7 +951,7 @@ function clampAttachmentPreviewSize({width, height}: AttachmentSize) {
   }
 }
 
-function parseMetadataPreviewSize(metadata: AssetMetadata): ?AttachmentSize {
+function parseMetadataPreviewSize(metadata: ChatTypes.AssetMetadata): ?AttachmentSize {
   if (metadata.assetType === ChatTypes.LocalAssetMetadataType.image && metadata.image) {
     return clampAttachmentPreviewSize(metadata.image)
   } else if (metadata.assetType === ChatTypes.LocalAssetMetadataType.video && metadata.video) {
@@ -975,7 +959,7 @@ function parseMetadataPreviewSize(metadata: AssetMetadata): ?AttachmentSize {
   }
 }
 
-function getAssetDuration(assetMetadata: ?AssetMetadata): ?number {
+function getAssetDuration(assetMetadata: ?ChatTypes.AssetMetadata): ?number {
   const assetIsVideo = assetMetadata && assetMetadata.assetType === ChatTypes.LocalAssetMetadataType.video
   if (assetIsVideo) {
     const assetVideoMetadata =
@@ -987,7 +971,7 @@ function getAssetDuration(assetMetadata: ?AssetMetadata): ?number {
   return null
 }
 
-function getAttachmentInfo(preview: ?(Asset | ChatTypes.MakePreviewRes), object: ?Asset) {
+function getAttachmentInfo(preview: ?(ChatTypes.Asset | ChatTypes.MakePreviewRes), object: ?ChatTypes.Asset) {
   const filename = object && object.filename
   const title = object && object.title
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -429,6 +429,11 @@ export const maxMessagesToLoadAtATime = 50
 export const nothingSelected = 'chat:noneSelected'
 export const blankChat = 'chat:blankChat'
 
+export type UnboxConversations = NoErrorTypedAction<
+  'chat:unboxConversations',
+  {conversationIDKeys: Array<ConversationIDKey>}
+>
+
 export type AddPendingConversation = NoErrorTypedAction<
   'chat:addPendingConversation',
   {participants: Array<string>, temporary: boolean}

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -49,9 +49,9 @@ if (__DEV__ && true) {
   config.dumbChatOnly = false
   config.dumbSheetOnly = false
   config.enableActionLogging = false
-  config.enableStoreLogging = true
-  config.forwardLogs = true
-  config.immediateStateLogging = true
+  config.enableStoreLogging = false
+  config.forwardLogs = false
+  config.immediateStateLogging = false
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.printRoutes = true


### PR DESCRIPTION
Coyne was seeing large perf issues w/ his inbox. The root cause was

- [x] Props generated by the inbox connector would mutate all the time causing the pureComponent checks to fail (fixed by making reselect better)
- [x] unboxConversations was yielded, which meant we could have arbitrary amounts of those in flight. I put in a pr yesterday to filter out to only unbox untrusted items but the mark as 'loading' state would race. Instead we take these serially so they can be filtered correctly
- [x] Untrusted visible wasn't really sanitychecked at all, and was *2 the rows visible. Now its +2 and maxes at 40
- [x] I needed the change this a bunch so i incorporated the new teamType flag so we don't have to do all this work ourselves