### PR TITLE
send notifyrouter message for team delete CORE-5976

### DIFF
--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -54,6 +54,7 @@ func (n *chatListener) BadgeState(badgeState keybase1.BadgeState)               
 func (n *chatListener) ReachabilityChanged(r keybase1.Reachability)                         {}
 func (n *chatListener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
+func (n *chatListener) TeamDeleted(teamID keybase1.TeamID) {}
 func (n *chatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {
 	n.identifyUpdate <- update
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1516,6 +1516,7 @@ func (n *serverChatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFName
 }
 func (n *serverChatListener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
+func (n *serverChatListener) TeamDeleted(teamID keybase1.TeamID)
 func (n *serverChatListener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
 }
 func (n *serverChatListener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1516,7 +1516,7 @@ func (n *serverChatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFName
 }
 func (n *serverChatListener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
-func (n *serverChatListener) TeamDeleted(teamID keybase1.TeamID)
+func (n *serverChatListener) TeamDeleted(teamID keybase1.TeamID) {}
 func (n *serverChatListener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
 }
 func (n *serverChatListener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -117,3 +117,4 @@ func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUII
 func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)      {}
 func (n *nlistener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
+func (n *nlistener) TeamDeleted(teamID keybase1.TeamID) {}

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -116,6 +116,7 @@ func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.Conversa
 func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                    {}
 func (n *nlistener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
+func (n *nlistener) TeamDeleted(teamID keybase1.TeamID) {}
 func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationStaleUpdate) {
 	select {
 	case n.threadStale <- cids:

--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -40,6 +40,8 @@ func (r *teamHandler) Create(ctx context.Context, cli gregor1.IncomingInterface,
 		return true, r.changeTeam(ctx, item, keybase1.TeamChangeSet{})
 	case "team.rename":
 		return true, r.changeTeam(ctx, item, keybase1.TeamChangeSet{Renamed: true})
+	case "team.delete":
+		return true, r.deleteTeam(ctx, item)
 	default:
 		return false, fmt.Errorf("unknown teamHandler category: %q", category)
 	}
@@ -71,6 +73,16 @@ func (r *teamHandler) changeTeam(ctx context.Context, item gregor.Item, changes 
 	r.G().Log.Debug("team.(change|rename) unmarshaled: %+v", rows)
 
 	return teams.HandleChangeNotification(ctx, r.G(), rows, changes)
+}
+
+func (r *teamHandler) deleteTeam(ctx context.Context, item gregor.Item) error {
+	var rows []keybase1.TeamChangeRow
+	if err := json.Unmarshal(item.Body().Bytes(), &rows); err != nil {
+		r.G().Log.Debug("error unmarshaling team.(change|rename) item: %s", err)
+		return err
+	}
+	r.G().Log.Debug("team.delete unmarshaled: %+v", rows)
+	return teams.HandleDeleteNotification(ctx, r.G(), rows)
 }
 
 func (r *teamHandler) sharingBeforeSignup(ctx context.Context, item gregor.Item) error {

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -399,6 +399,10 @@ func (n *teamNotifyHandler) TeamChanged(ctx context.Context, arg keybase1.TeamCh
 	return nil
 }
 
+func (n *teamNotifyHandler) TeamDeleted(ctx context.Context, teamID keybase1.TeamID) error {
+	return nil
+}
+
 func TestGetTeamRootID(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -74,6 +74,13 @@ func HandleChangeNotification(ctx context.Context, g *libkb.GlobalContext, rows 
 	return nil
 }
 
+func HandleDeleteNotification(ctx context.Context, g *libkb.GlobalContext, rows []keybase1.TeamChangeRow) error {
+	for _, row := range rows {
+		g.NotifyRouter.HandleTeamDeleted(ctx, row.Id)
+	}
+	return nil
+}
+
 func HandleSBSRequest(ctx context.Context, g *libkb.GlobalContext, msg keybase1.TeamSBSMsg) (err error) {
 	ctx = libkb.WithLogTag(ctx, "CLKR")
 	defer g.CTrace(ctx, "HandleSBSRequest", func() error { return err })()

--- a/protocol/avdl/keybase1/notify_team.avdl
+++ b/protocol/avdl/keybase1/notify_team.avdl
@@ -15,4 +15,5 @@ protocol NotifyTeam {
   }
 
   void teamChanged(TeamID teamID, string teamName, Seqno latestSeqno, TeamChangeSet changes) oneway;
+  void teamDeleted(TeamID teamID) oneway;
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3688,6 +3688,10 @@ export type NotifyTeamTeamChangedRpcParam = Exact<{
   changes: TeamChangeSet
 }>
 
+export type NotifyTeamTeamDeletedRpcParam = Exact<{
+  teamID: TeamID
+}>
+
 export type NotifyTrackingTrackingChangedRpcParam = Exact<{
   uid: UID,
   username: string,
@@ -6691,6 +6695,12 @@ export type incomingCallMapType = Exact<{
       teamName: string,
       latestSeqno: Seqno,
       changes: TeamChangeSet
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.NotifyTeam.teamDeleted'?: (
+    params: Exact<{
+      teamID: TeamID
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/json/keybase1/notify_team.json
+++ b/protocol/json/keybase1/notify_team.json
@@ -48,6 +48,16 @@
       ],
       "response": null,
       "oneway": true
+    },
+    "teamDeleted": {
+      "request": [
+        {
+          "name": "teamID",
+          "type": "TeamID"
+        }
+      ],
+      "response": null,
+      "oneway": true
     }
   },
   "namespace": "keybase.1"

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -208,6 +208,9 @@ function* _setupTeamHandlers(): SagaGenerator<any, any> {
     engine().setIncomingHandler('keybase.1.NotifyTeam.teamChanged', () => {
       dispatch(Creators.getTeams())
     })
+    engine().setIncomingHandler('keybase.1.NotifyTeam.teamDeleted', () => {
+      dispatch(Creators.getTeams())
+    })
   })
 }
 

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3688,6 +3688,10 @@ export type NotifyTeamTeamChangedRpcParam = Exact<{
   changes: TeamChangeSet
 }>
 
+export type NotifyTeamTeamDeletedRpcParam = Exact<{
+  teamID: TeamID
+}>
+
 export type NotifyTrackingTrackingChangedRpcParam = Exact<{
   uid: UID,
   username: string,
@@ -6691,6 +6695,12 @@ export type incomingCallMapType = Exact<{
       teamName: string,
       latestSeqno: Seqno,
       changes: TeamChangeSet
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.NotifyTeam.teamDeleted'?: (
+    params: Exact<{
+      teamID: TeamID
     }>,
     response: CommonResponseHandler
   ) => void,


### PR DESCRIPTION
Patch adds a simple handler for `team.delete` Gregor messages by just converting them into a new `NotifyRouter` call that the frontend can listen for.

cc @chrisnojima 