### PR TITLE
Update the inbox snippet after deleting a message

### DIFF
--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -700,9 +700,10 @@ function updateSnippet(
 }
 
 function unboxConversations(
-  conversationIDKeys: Array<Constants.ConversationIDKey>
+  conversationIDKeys: Array<Constants.ConversationIDKey>,
+  force: boolean,
 ): Constants.UnboxConversations {
-  return {payload: {conversationIDKeys}, type: 'chat:unboxConversations'}
+  return {payload: {conversationIDKeys, force}, type: 'chat:unboxConversations'}
 }
 
 export {

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -701,7 +701,7 @@ function updateSnippet(
 
 function unboxConversations(
   conversationIDKeys: Array<Constants.ConversationIDKey>,
-  force: boolean,
+  force: boolean
 ): Constants.UnboxConversations {
   return {payload: {conversationIDKeys, force}, type: 'chat:unboxConversations'}
 }

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -701,7 +701,7 @@ function updateSnippet(
 
 function unboxConversations(
   conversationIDKeys: Array<Constants.ConversationIDKey>,
-  force: boolean
+  force?: boolean = false
 ): Constants.UnboxConversations {
   return {payload: {conversationIDKeys, force}, type: 'chat:unboxConversations'}
 }

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -69,7 +69,7 @@ const _backgroundUnboxLoop = function*() {
         .toArray()
 
       if (conversationIDKeys.length) {
-        yield put(Creators.unboxConversations(conversationIDKeys))
+        yield put(Creators.unboxConversations(conversationIDKeys, false))
       } else {
         break
       }
@@ -160,7 +160,7 @@ function* onInboxStale(): SagaGenerator<any, any> {
       .take(20)
       .concat(conversations.filter(c => c.teamname))
 
-    yield put(Creators.unboxConversations(toUnbox.map(c => c.conversationIDKey).toArray()))
+    yield put(Creators.unboxConversations(toUnbox.map(c => c.conversationIDKey).toArray(), false))
 
     const {
       initialConversation,
@@ -186,7 +186,7 @@ function* onInboxStale(): SagaGenerator<any, any> {
 function* onGetInboxAndUnbox({
   payload: {conversationIDKeys},
 }: Constants.GetInboxAndUnbox): SagaGenerator<any, any> {
-  yield put(Creators.unboxConversations(conversationIDKeys))
+  yield put(Creators.unboxConversations(conversationIDKeys, false))
 }
 
 function _toSupersedeInfo(
@@ -270,7 +270,7 @@ function* untrustedInboxVisible(action: Constants.UntrustedInboxVisible): SagaGe
     .toArray()
 
   if (conversationIDKeys.length) {
-    yield put(Creators.unboxConversations(conversationIDKeys))
+    yield put(Creators.unboxConversations(conversationIDKeys, false))
   }
 }
 
@@ -357,7 +357,7 @@ const unboxConversationsSagaMap = {
 
 // Loads the trusted inbox segments
 function* unboxConversations(action: Constants.UnboxConversations): SagaGenerator<any, any> {
-  let {conversationIDKeys} = action.payload
+  let {conversationIDKeys, force} = action.payload
   conversationIDKeys = yield select(
     (state: TypedState, conversationIDKeys: Array<Constants.ConversationIDKey>) => {
       const inbox = state.chat.get('inbox')
@@ -368,7 +368,7 @@ function* unboxConversations(action: Constants.UnboxConversations): SagaGenerato
         }
 
         const state = inbox.find(i => i.get('conversationIDKey') === c)
-        return !state || state.state === 'untrusted'
+        return force || !state || state.state === 'untrusted'
       })
     },
     conversationIDKeys

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -69,7 +69,7 @@ const _backgroundUnboxLoop = function*() {
         .toArray()
 
       if (conversationIDKeys.length) {
-        yield put(Creators.unboxConversations(conversationIDKeys, false))
+        yield put(Creators.unboxConversations(conversationIDKeys))
       } else {
         break
       }
@@ -160,7 +160,7 @@ function* onInboxStale(): SagaGenerator<any, any> {
       .take(20)
       .concat(conversations.filter(c => c.teamname))
 
-    yield put(Creators.unboxConversations(toUnbox.map(c => c.conversationIDKey).toArray(), false))
+    yield put(Creators.unboxConversations(toUnbox.map(c => c.conversationIDKey).toArray()))
 
     const {
       initialConversation,
@@ -186,7 +186,7 @@ function* onInboxStale(): SagaGenerator<any, any> {
 function* onGetInboxAndUnbox({
   payload: {conversationIDKeys},
 }: Constants.GetInboxAndUnbox): SagaGenerator<any, any> {
-  yield put(Creators.unboxConversations(conversationIDKeys, false))
+  yield put(Creators.unboxConversations(conversationIDKeys))
 }
 
 function _toSupersedeInfo(
@@ -270,7 +270,7 @@ function* untrustedInboxVisible(action: Constants.UntrustedInboxVisible): SagaGe
     .toArray()
 
   if (conversationIDKeys.length) {
-    yield put(Creators.unboxConversations(conversationIDKeys, false))
+    yield put(Creators.unboxConversations(conversationIDKeys))
   }
 }
 
@@ -360,6 +360,7 @@ function* unboxConversations(action: Constants.UnboxConversations): SagaGenerato
   let {conversationIDKeys, force} = action.payload
   conversationIDKeys = yield select(
     (state: TypedState, conversationIDKeys: Array<Constants.ConversationIDKey>) => {
+      console.warn('in unbox, force', force)
       const inbox = state.chat.get('inbox')
 
       return conversationIDKeys.filter(c => {

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -360,7 +360,6 @@ function* unboxConversations(action: Constants.UnboxConversations): SagaGenerato
   let {conversationIDKeys, force} = action.payload
   conversationIDKeys = yield select(
     (state: TypedState, conversationIDKeys: Array<Constants.ConversationIDKey>) => {
-      console.warn('in unbox, force', force)
       const inbox = state.chat.get('inbox')
 
       return conversationIDKeys.filter(c => {

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -1152,7 +1152,7 @@ function* _markThreadsStale(action: Constants.MarkThreadsStale): SagaGenerator<a
   // Load inbox items of any stale items so we get update on rekeyInfos, etc
   const {updates} = action.payload
   const convIDs = updates.map(u => Constants.conversationIDToKey(u.convID))
-  yield put(Creators.unboxConversations(convIDs, false))
+  yield put(Creators.unboxConversations(convIDs))
 
   // Selected is stale?
   const selectedConversation = yield select(Constants.getSelectedConversation)

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -113,7 +113,7 @@ function* startNewConversation(
     yield put(selectConversation(newConversationIDKey, false))
   }
   // Load the inbox so we can post, we wait till this is done
-  yield call(unboxConversations, [newConversationIDKey])
+  yield call(unboxConversations, [newConversationIDKey], false)
   return [newConversationIDKey, tlfName]
 }
 

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -113,7 +113,7 @@ function* startNewConversation(
     yield put(selectConversation(newConversationIDKey, false))
   }
   // Load the inbox so we can post, we wait till this is done
-  yield call(unboxConversations, [newConversationIDKey], false)
+  yield call(unboxConversations, [newConversationIDKey])
   return [newConversationIDKey, tlfName]
 }
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -419,7 +419,7 @@ export const blankChat = 'chat:blankChat'
 
 export type UnboxConversations = NoErrorTypedAction<
   'chat:unboxConversations',
-  {conversationIDKeys: Array<ConversationIDKey>}
+  {conversationIDKeys: Array<ConversationIDKey>, force: boolean}
 >
 
 export type AddPendingConversation = NoErrorTypedAction<


### PR DESCRIPTION
@keybase/react-hackers CC @mmaxim 

Sometimes when we delete a message we get an `incomingMessage.conv` object on the delete action that we can use to update our inbox, and sometimes we don't.

This PR checks to see whether we got a `conv` -- if we didn't, it calls `unboxConversations([conversationID])` (which calls `getInboxNonblockLocalRpc([conversationID])`) to get an up to date snippet for that conversation after the delete.

`unboxConversations()` was previously refusing to ask for an update on an inbox item that was already unboxed, so this PR also extends that action with a `force` parameter to make that possible.