### PR TITLE
Expand logging, checks on provisioning, safe file writes, fsync, extra for android

### DIFF
--- a/go/auth/credential_authority.go
+++ b/go/auth/credential_authority.go
@@ -416,8 +416,6 @@ func (u *user) check(ca checkArg) {
 			return
 		}
 	}
-
-	return
 }
 
 // getUserFromServer runs the UserKeyAPIer GetUser() API call while paying

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 
 	"golang.org/x/net/context"
@@ -132,6 +133,9 @@ func (e *loginProvision) Run(ctx *Context) error {
 	}
 
 	e.G().KeyfamilyChanged(e.arg.User.GetUID())
+
+	// check to make sure local files stored correctly
+	e.verifyLocalStorage()
 
 	return nil
 }
@@ -1060,6 +1064,50 @@ func (e *loginProvision) cleanup() {
 	// the best way to cleanup is to logout...
 	e.G().Log.Debug("an error occurred during provisioning, logging out")
 	e.G().Logout()
+}
+
+func (e *loginProvision) verifyLocalStorage() {
+	e.G().Log.Debug("loginProvision: verifying local storage")
+	defer e.G().Log.Debug("loginProvision: done verifying local storage")
+	normUsername := libkb.NewNormalizedUsername(e.username)
+
+	// check config.json looks ok
+	e.verifyRegularFile("config", e.G().Env.GetConfigFilename())
+	cr := e.G().Env.GetConfig()
+	if cr.GetUsername() != normUsername {
+		e.G().Log.Debug("loginProvision(verify): config username %q doesn't match engine username %q", cr.GetUsername(), normUsername)
+	}
+	if cr.GetUID().NotEqual(e.arg.User.GetUID()) {
+		e.G().Log.Debug("loginProvision(verify): config uid %q doesn't match engine uid %q", cr.GetUID(), e.arg.User.GetUID())
+	}
+
+	// check session.json is valid
+	e.verifyRegularFile("session", e.G().Env.GetSessionFilename())
+
+	// check keys in secretkeys.mpack
+	e.verifyRegularFile("secretkeys", e.G().SKBFilenameForUser(normUsername))
+
+	// check secret stored
+	secret, err := e.G().SecretStoreAll.RetrieveSecret(normUsername)
+	if err != nil {
+		e.G().Log.Debug("loginProvision(verify): failed to retrieve secret for %s: %s", e.username, err)
+	}
+	if secret.IsNil() || len(secret.Bytes()) == 0 {
+		e.G().Log.Debug("loginProvision(verify): retrieved nil/empty secret for %s", e.username)
+	}
+}
+
+func (e *loginProvision) verifyRegularFile(name, filename string) {
+	info, err := os.Stat(filename)
+	if err != nil {
+		e.G().Log.Debug("loginProvision(verify): stat %s file %q error: %s", name, filename, err)
+		return
+	}
+
+	e.G().Log.Debug("loginProvision(verify): %s file %q size: %d", name, filename, info.Size())
+	if !info.Mode().IsRegular() {
+		e.G().Log.Debug("loginProvision(verify): %s file %q not regular: %s", name, filename, info.Mode())
+	}
 }
 
 var devtypeSortOrder = map[string]int{libkb.DeviceTypeMobile: 0, libkb.DeviceTypeDesktop: 1, libkb.DeviceTypePaper: 2}

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -76,6 +76,9 @@ func NewAPIEngines(g *GlobalContext) (*InternalAPIEngine, *ExternalAPIEngine, er
 		return nil, nil, err
 	}
 	scraperConfig, err := g.Env.GenClientConfigForScrapers()
+	if err != nil {
+		return nil, nil, err
+	}
 	x := &ExternalAPIEngine{
 		BaseAPIEngine{
 			config:       scraperConfig,

--- a/go/libkb/file.go
+++ b/go/libkb/file.go
@@ -30,10 +30,6 @@ func (f File) GetFilename() string {
 	return f.filename
 }
 
-func (f File) DataLen() int64 {
-	return int64(len(f.data))
-}
-
 // WriteTo is for SafeWriter
 func (f File) WriteTo(w io.Writer) (int64, error) {
 	n, err := w.Write(f.data)

--- a/go/libkb/file.go
+++ b/go/libkb/file.go
@@ -30,8 +30,22 @@ func (f File) GetFilename() string {
 	return f.filename
 }
 
+func (f File) DataLen() int64 {
+	return int64(len(f.data))
+}
+
 // WriteTo is for SafeWriter
 func (f File) WriteTo(w io.Writer) (int64, error) {
 	n, err := w.Write(f.data)
+	if err == nil {
+		if n != len(f.data) {
+			// this shouldn't happen
+			//
+			//    Write must return a non-nil error if it returns n < len(p)
+			//
+			// but check just in case
+			return int64(n), io.ErrShortWrite
+		}
+	}
 	return int64(n), err
 }

--- a/go/libkb/file_test.go
+++ b/go/libkb/file_test.go
@@ -5,6 +5,7 @@ package libkb
 
 import (
 	"os"
+	"runtime"
 	"sync"
 	"testing"
 )
@@ -22,6 +23,9 @@ func TestFileSave(t *testing.T) {
 }
 
 func TestFileSaveConcurrent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip this on windows")
+	}
 	filename := "file_test.tmp"
 	defer os.Remove(filename)
 

--- a/go/libkb/file_test.go
+++ b/go/libkb/file_test.go
@@ -5,12 +5,12 @@ package libkb
 
 import (
 	"os"
+	"sync"
 	"testing"
 )
 
 func TestFileSave(t *testing.T) {
 	filename := "file_test.tmp"
-
 	defer os.Remove(filename)
 
 	file := NewFile(filename, []byte("test data"), 0644)
@@ -19,4 +19,38 @@ func TestFileSave(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestFileSaveConcurrent(t *testing.T) {
+	filename := "file_test.tmp"
+	defer os.Remove(filename)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			file := NewFile(filename, []byte("test data"), 0644)
+			t.Logf("Saving")
+			err := file.Save(G.Log)
+			if err != nil {
+				t.Errorf("save err: %s", err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	var wg2 sync.WaitGroup
+	file := NewFile(filename, []byte("test data"), 0644)
+	for i := 0; i < 20; i++ {
+		wg2.Add(1)
+		go func() {
+			err := file.Save(G.Log)
+			if err != nil {
+				t.Errorf("save err: %s", err)
+			}
+			wg2.Done()
+		}()
+	}
+	wg2.Wait()
 }

--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"sync"
 
 	jsonw "github.com/keybase/go-jsonw"
@@ -58,12 +59,14 @@ func (f *JSONFile) Load(warnOnNotFound bool) error {
 				f.G().Log.Debug(msg)
 			}
 			return nil
-		} else if os.IsPermission(err) {
+		}
+
+		if os.IsPermission(err) {
 			f.G().Log.Warning("Permission denied opening %s file %s", f.which, f.filename)
 			return nil
-		} else {
-			return err
 		}
+
+		return err
 	}
 	f.exists = true
 	defer file.Close()
@@ -210,42 +213,75 @@ func (f *JSONFile) save() (err error) {
 	defer writer.Close()
 
 	encoded, err := json.MarshalIndent(dat, "", "    ")
-	if err == nil {
-		_, err = writer.Write(encoded)
+	if err != nil {
+		f.G().Log.Errorf("Error marshaling data to %s file %s: %s", f.which, filename, err)
+		return err
 	}
 
+	n, err := writer.Write(encoded)
 	if err != nil {
-		f.G().Log.Errorf("Error encoding data to %s file %s: %s",
-			f.which, filename, err)
+		f.G().Log.Errorf("Error writing encoded data to %s file %s: %s", f.which, filename, err)
+		return err
+	}
+	if n != len(encoded) {
+		f.G().Log.Errorf("Error writing encoded data to %s file %s: wrote %d bytes, expected %d", f.which, filename, n, len(encoded))
+		return io.ErrShortWrite
+	}
+
+	err = writer.Sync()
+	if err != nil {
+		f.G().Log.Errorf("Error syncing %s file %s: %s", f.which, filename, err)
 		return err
 	}
 
 	err = writer.Close()
 	if err != nil {
-		f.G().Log.Errorf("Error flushing %s file %s: %s", f.which, filename, err)
+		f.G().Log.Errorf("Error closing %s file %s: %s", f.which, filename, err)
 		return err
 	}
+
 	f.G().Log.Debug("- saved %s file %s", f.which, filename)
-	return
+
+	if runtime.GOOS == "android" {
+		f.G().Log.Debug("| Android extra-checking in JSONFile.save")
+		info, err := os.Stat(filename)
+		if err != nil {
+			f.G().Log.Errorf("| Error os.Stat(%s): %s", filename, err)
+			return err
+		}
+		f.G().Log.Debug("| File info: name = %s", info.Name())
+		f.G().Log.Debug("| File info: size = %d", info.Size())
+		f.G().Log.Debug("| File info: mode = %s", info.Mode())
+		f.G().Log.Debug("| File info: mod time = %s", info.ModTime())
+
+		f.G().Log.Debug("| Android extra-checking done")
+	}
+
+	return nil
 }
 
 func (f *jsonFileTransaction) Abort() error {
-	f.f.G().Log.Debug("+ Aborting config rewrite %s", f.tmpname)
+	f.f.G().Log.Debug("+ Aborting %s rewrite %s", f.f.which, f.tmpname)
 	err := os.Remove(f.tmpname)
 	f.f.setTx(nil)
-	f.f.G().Log.Debug("- Abort -> %v\n", err)
+	f.f.G().Log.Debug("- Abort -> %s\n", ErrToOk(err))
 	return err
 }
 
 func (f *jsonFileTransaction) Commit() (err error) {
-	f.f.G().Log.Debug("+ Commit config rewrite %s", f.tmpname)
-	defer func() { f.f.G().Log.Debug("- Commit config rewrite %s", ErrToOk(err)) }()
+	f.f.G().Log.Debug("+ Commit %s rewrite %s", f.f.which, f.tmpname)
+	defer func() { f.f.G().Log.Debug("- Commit %s rewrite %s", f.f.which, ErrToOk(err)) }()
+
 	f.f.G().Log.Debug("| Commit: making parent directories for %q", f.f.filename)
 	if err = MakeParentDirs(f.f.filename); err != nil {
 		return err
 	}
 	f.f.G().Log.Debug("| Commit : renaming %q => %q", f.tmpname, f.f.filename)
 	err = renameFile(f.f.G(), f.tmpname, f.f.filename)
+	if err != nil {
+		f.f.G().Log.Debug("| Commit: rename %q => %q error: %s", f.tmpname, f.f.filename, err)
+	}
 	f.f.setTx(nil)
+
 	return err
 }

--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -254,6 +254,11 @@ func (f *JSONFile) save() (err error) {
 		f.G().Log.Debug("| File info: mode = %s", info.Mode())
 		f.G().Log.Debug("| File info: mod time = %s", info.ModTime())
 
+		if info.Size() != int64(len(encoded)) {
+			f.G().Log.Errorf("| File info size (%d) does not match encoded len (%d)", info.Size(), len(encoded))
+			return fmt.Errorf("file info size (%d) does not match encoded len (%d)", info.Size(), len(encoded))
+		}
+
 		f.G().Log.Debug("| Android extra-checking done")
 	}
 

--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -243,7 +243,7 @@ func (f *JSONFile) save() (err error) {
 	f.G().Log.Debug("- saved %s file %s", f.which, filename)
 
 	if runtime.GOOS == "android" {
-		f.G().Log.Debug("| Android extra-checking in JSONFile.save")
+		f.G().Log.Debug("| Android extra checks in JSONFile.save")
 		info, err := os.Stat(filename)
 		if err != nil {
 			f.G().Log.Errorf("| Error os.Stat(%s): %s", filename, err)
@@ -259,7 +259,7 @@ func (f *JSONFile) save() (err error) {
 			return fmt.Errorf("file info size (%d) does not match encoded len (%d)", info.Size(), len(encoded))
 		}
 
-		f.G().Log.Debug("| Android extra-checking done")
+		f.G().Log.Debug("| Android extra checks done")
 	}
 
 	return nil

--- a/go/libkb/json_test.go
+++ b/go/libkb/json_test.go
@@ -1,0 +1,34 @@
+package libkb
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestJsonTransaction(t *testing.T) {
+	tc := SetupTest(t, "json", 1)
+	defer tc.Cleanup()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			tx, err := tc.G.Env.GetConfigWriter().BeginTransaction()
+			if err == nil {
+				tx.Abort()
+			}
+			wg.Done()
+		}()
+	}
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			tx, err := tc.G.Env.GetConfigWriter().BeginTransaction()
+			if err == nil {
+				tx.Commit()
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}

--- a/go/libkb/key_lookup.go
+++ b/go/libkb/key_lookup.go
@@ -78,5 +78,8 @@ func keyLookup(g *GlobalContext, arg keyLookupArg) (username string, uid keybase
 	}
 
 	uid, err = keybase1.UIDFromString(data.UID)
+	if err != nil {
+		return username, uid, err
+	}
 	return data.Username, uid, nil
 }

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -29,7 +29,7 @@ type levelDBOps interface {
 
 func levelDbPut(ops levelDBOps, id DbKey, aliases []DbKey, value []byte) error {
 	idb := id.ToBytes(levelDbTableKv)
-	if aliases == nil || len(aliases) == 0 {
+	if len(aliases) == 0 {
 		// if no aliases, just do a put
 		return ops.Put(idb, value, nil)
 	}

--- a/go/libkb/skb_keyring.go
+++ b/go/libkb/skb_keyring.go
@@ -315,11 +315,13 @@ func (k *SKBKeyringFile) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	b64 := base64.NewEncoder(base64.StdEncoding, w)
+	defer b64.Close()
+
 	if err = packets.EncodeTo(b64); err != nil {
 		k.G().Log.Warning("Encoding problem: %s", err)
 		return 0, err
 	}
-	b64.Close()
+
 	return 0, nil
 }
 

--- a/go/libkb/skb_keyring.go
+++ b/go/libkb/skb_keyring.go
@@ -308,8 +308,8 @@ func (k *SKBKeyringFile) GetFilename() string { return k.filename }
 // WriteTo is similar to GetFilename described just above in terms of
 // locking discipline.
 func (k *SKBKeyringFile) WriteTo(w io.Writer) (int64, error) {
-	k.G().Log.Debug("+ WriteTo")
-	defer k.G().Log.Debug("- WriteTo")
+	k.G().Log.Debug("+ SKBKeyringFile WriteTo")
+	defer k.G().Log.Debug("- SKBKeyringFile WriteTo")
 	packets := make(KeybasePackets, len(k.Blocks))
 	var err error
 	for i, b := range k.Blocks {
@@ -324,6 +324,13 @@ func (k *SKBKeyringFile) WriteTo(w io.Writer) (int64, error) {
 		k.G().Log.Warning("Encoding problem: %s", err)
 		return 0, err
 	}
+
+	// explicitly check for error on Close:
+	if err := b64.Close(); err != nil {
+		k.G().Log.Warning("SKBKeyringFile: WriteTo b64.Close() error: %s", err)
+		return 0, err
+	}
+	k.G().Log.Debug("SKBKeyringFile: b64 stream closed successfully")
 
 	return 0, nil
 }

--- a/go/libkb/skb_keyring.go
+++ b/go/libkb/skb_keyring.go
@@ -240,13 +240,16 @@ func (k *SKBKeyringFile) Save() error {
 
 func (k *SKBKeyringFile) saveLocked() error {
 	if !k.dirty {
+		k.G().Log.Debug("SKBKeyringFile: saveLocked %s: not dirty, so skipping save", k.filename)
 		return nil
 	}
+	k.G().Log.Debug("SKBKeyringFile: saveLocked %s: dirty, safe saving", k.filename)
 	if err := SafeWriteToFile(k.G().Log, k, 0); err != nil {
+		k.G().Log.Debug("SKBKeyringFile: saveLocked %s: SafeWriteToFile error: %s", k.filename, err)
 		return err
 	}
 	k.dirty = false
-	k.G().Log.Debug("Updated keyring %s", k.filename)
+	k.G().Log.Debug("SKBKeyringFile: saveLocked success for %s", k.filename)
 	return nil
 }
 

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -20,6 +20,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 	"unicode"
@@ -176,35 +177,63 @@ type SafeWriteLogger interface {
 }
 
 // SafeWriteToFile to safely write to a file. Use mode=0 for default permissions.
-func safeWriteToFileOnce(g SafeWriteLogger, t SafeWriter, mode os.FileMode) error {
+func safeWriteToFileOnce(g SafeWriteLogger, t SafeWriter, mode os.FileMode) (err error) {
 	fn := t.GetFilename()
-	g.Debug(fmt.Sprintf("+ Writing to %s", fn))
+	g.Debug("+ SafeWriteToFile(%q)", fn)
+	defer g.Debug("- SafeWriteToFile(%q) -> %s", fn, ErrToOk(err))
+
 	tmpfn, tmp, err := OpenTempFile(fn, "", mode)
-	g.Debug(fmt.Sprintf("| Temporary file generated: %s", tmpfn))
 	if err != nil {
 		return err
 	}
+	g.Debug("| Temporary file generated: %s", tmpfn)
 
+	g.Debug("| WriteTo %s", tmpfn)
 	_, err = t.WriteTo(tmp)
-	if err == nil {
-		err = tmp.Close()
-		if err == nil {
-			err = os.Rename(tmpfn, fn)
-			if err != nil {
-				g.Errorf(fmt.Sprintf("Error renaming file %s: %s", tmpfn, err))
-				os.Remove(tmpfn)
-			}
-		} else {
-			g.Errorf(fmt.Sprintf("Error closing temporary file %s: %s", tmpfn, err))
-			os.Remove(tmpfn)
-		}
-	} else {
-		g.Errorf(fmt.Sprintf("Error writing temporary file %s: %s", tmpfn, err))
+	if err != nil {
+		g.Errorf("| Error writing temporary file %s: %s", tmpfn, err)
 		tmp.Close()
 		os.Remove(tmpfn)
+		return err
 	}
-	g.Debug(fmt.Sprintf("- Wrote to %s -> %s", fn, ErrToOk(err)))
-	return err
+
+	if err := tmp.Sync(); err != nil {
+		g.Errorf("| Error syncing temporary file %s: %s", tmpfn, err)
+		os.Remove(tmpfn)
+		return err
+	}
+
+	if err := tmp.Close(); err != nil {
+		g.Errorf("| Error closing temporary file %s: %s", tmpfn, err)
+		os.Remove(tmpfn)
+		return err
+	}
+
+	g.Debug("| Renaming temporary file %s -> permanent file %s", tmpfn, fn)
+	if err := os.Rename(tmpfn, fn); err != nil {
+		g.Errorf("| Error renaming temporary file %s -> permanent file %s: %s", tmpfn, fn, err)
+		os.Remove(tmpfn)
+		return err
+	}
+
+	if runtime.GOOS == "android" {
+		g.Debug("| Android extra-checking in safeWriteToFile")
+		info, err := os.Stat(fn)
+		if err != nil {
+			g.Errorf("| Error os.Stat(%s): %s", fn, err)
+			return err
+		}
+		g.Debug("| File info: name = %s", info.Name())
+		g.Debug("| File info: size = %d", info.Size())
+		g.Debug("| File info: mode = %s", info.Mode())
+		g.Debug("| File info: mod time = %s", info.ModTime())
+
+		g.Debug("| Android extra-checking done")
+	}
+
+	g.Debug("| Done writing to file %s", fn)
+
+	return nil
 }
 
 // Pluralize returns pluralized string with value.


### PR DESCRIPTION
This PR has a lot of small tweaks to help figure out android provisioning issues.

The logging and error checking throughout has been expanded.  Android gets some extra logging and checks.

In the two "safe" write functions we have, I added a call to Sync() to try to be extra careful about getting this data to the disk.

At the end of provisioning, some new checks are performed on the files that should be there: config.json, session.json, and the secret keys file.