### PR TITLE
Add proof set reducers

### DIFF
--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -261,7 +261,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 		readSubteamID = *arg.readSubteamID
 	}
 
-	proofSet := newProofSet()
+	proofSet := newProofSet(l.G())
 	var parentChildOperations []*parentChildOperation
 
 	// Backfill stubbed links that need to be filled now.

--- a/go/teams/proofs.go
+++ b/go/teams/proofs.go
@@ -1,9 +1,10 @@
 package teams
 
 import (
-	"context"
 	"fmt"
 	"sort"
+
+	"golang.org/x/net/context"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/client/go/libkb"
@@ -20,6 +21,11 @@ type proofTerm struct {
 	linkMap map[keybase1.Seqno]keybase1.LinkID
 }
 
+func (t *proofTerm) shortForm() string {
+	return fmt.Sprintf("%v@%v", t.sigMeta.SigChainLocation.Seqno, t.leafID)
+
+}
+
 type proofTermBookends struct {
 	left  proofTerm
 	right *proofTerm
@@ -31,6 +37,10 @@ type proof struct {
 	reason string
 }
 
+func (p *proof) shortForm() string {
+	return fmt.Sprintf("%v --> %v '%v'", p.a.shortForm(), p.b.shortForm(), p.reason)
+}
+
 type proofIndex struct {
 	a keybase1.UserOrTeamID
 	b keybase1.UserOrTeamID
@@ -38,10 +48,17 @@ type proofIndex struct {
 
 func (t proofTerm) seqno() keybase1.Seqno { return t.sigMeta.SigChainLocation.Seqno }
 
+// comparison method only valid if `t` and `u` are known to be on the same chain
 func (t proofTerm) lessThanOrEqual(u proofTerm) bool {
 	return t.seqno() <= u.seqno()
 }
 
+// comparison method only valid if `t` and `u` are known to be on the same chain
+func (t proofTerm) equal(u proofTerm) bool {
+	return t.seqno() == u.seqno()
+}
+
+// comparison method only valid if `t` and `u` are known to be on the same chain
 func (t proofTerm) max(u proofTerm) proofTerm {
 	if t.lessThanOrEqual(u) {
 		return u
@@ -49,6 +66,7 @@ func (t proofTerm) max(u proofTerm) proofTerm {
 	return t
 }
 
+// comparison method only valid if `t` and `u` are known to be on the same chain
 func (t proofTerm) min(u proofTerm) proofTerm {
 	if t.lessThanOrEqual(u) {
 		return t
@@ -61,15 +79,19 @@ func newProofIndex(a keybase1.UserOrTeamID, b keybase1.UserOrTeamID) proofIndex 
 }
 
 type proofSetT struct {
+	libkb.Contextified
 	proofs map[proofIndex][]proof
 }
 
-func newProofSet() *proofSetT {
-	return &proofSetT{make(map[proofIndex][]proof)}
+func newProofSet(g *libkb.GlobalContext) *proofSetT {
+	return &proofSetT{
+		Contextified: libkb.NewContextified(g),
+		proofs:       make(map[proofIndex][]proof),
+	}
 }
 
 // AddNeededHappensBeforeProof adds a new needed proof to the proof set. The
-// proof is that a happened before b.  If there are other proofs in the proof set
+// proof is that `a` happened before `b`.  If there are other proofs in the proof set
 // that prove the same thing, then we can tighten those proofs with a and b if
 // it makes sense.  For instance, if there is an existing proof that c<d,
 // but we know that c<a and b<d, then it suffices to replace c<d with a<b as
@@ -77,18 +99,50 @@ func newProofSet() *proofSetT {
 // to a merkle tree lookup, so it makes sense to be stingy. Return the modified
 // proof set with the new proofs needed, but the original arugment p will
 // be mutated.
-func (p *proofSetT) AddNeededHappensBeforeProof(a proofTerm, b proofTerm, reason string) *proofSetT {
+func (p *proofSetT) AddNeededHappensBeforeProof(ctx context.Context, a proofTerm, b proofTerm, reason string) *proofSetT {
+
+	var action string
+	defer func() {
+		p.G().Log.CDebugf(ctx, "proofSet add(%v --> %v) [%v] '%v'", a.shortForm(), b.shortForm(), action, reason)
+	}()
+
 	idx := newProofIndex(a.leafID, b.leafID)
+
+	if idx.a.Equal(idx.b) {
+		// If both terms are on the same chain
+		if a.lessThanOrEqual(b) {
+			// The proof is self-evident.
+			// Discard it.
+			action = "discard-easy"
+			return p
+		}
+		// The proof is self-evident FALSE.
+		// Add it and return immediately so the rest of this function doesn't have to trip over it.
+		// It should be failed later by the checker.
+		action = "added-easy-false"
+		p.proofs[idx] = append(p.proofs[idx], proof{a, b, reason})
+		return p
+	}
+
 	set := p.proofs[idx]
 	for i := len(set) - 1; i >= 0; i-- {
-		proof := set[i]
-		if proof.a.lessThanOrEqual(a) && b.lessThanOrEqual(proof.b) {
-			proof.a = proof.a.max(a)
-			proof.b = proof.b.min(b)
-			set[i] = proof
+		existing := set[i]
+		if existing.a.lessThanOrEqual(a) && b.lessThanOrEqual(existing.b) {
+			// If the new proof is surrounded by the old proof.
+			existing.a = existing.a.max(a)
+			existing.b = existing.b.min(b)
+			set[i] = existing
+			action = "collapsed"
+			return p
+		}
+		if existing.a.equal(a) && existing.b.lessThanOrEqual(b) {
+			// If the new proof is the same on the left and weaker on the right.
+			// Discard the new proof, as it is implied by the existing one.
+			action = "discard-weak"
 			return p
 		}
 	}
+	action = "added"
 	p.proofs[idx] = append(p.proofs[idx], proof{a, b, reason})
 	return p
 }
@@ -137,7 +191,11 @@ func (p proof) lookupMerkleTreeChain(ctx context.Context, world LoaderContext) (
 
 // check a single proof. Call to the merkle API enddpoint, and then ensure that the
 // data that comes back fits the proof and previously checked sighcain links.
-func (p proof) check(ctx context.Context, g *libkb.GlobalContext, world LoaderContext) error {
+func (p proof) check(ctx context.Context, g *libkb.GlobalContext, world LoaderContext) (err error) {
+	defer func() {
+		g.Log.CDebugf(ctx, "TeamLoader proofSet check1(%v) -> %v", p.shortForm(), err)
+	}()
+
 	triple, err := p.lookupMerkleTreeChain(ctx, world)
 	if err != nil {
 		return err
@@ -182,8 +240,8 @@ func (p proof) check(ctx context.Context, g *libkb.GlobalContext, world LoaderCo
 }
 
 // check the entire proof set, failing if any one proof fails.
-func (p *proofSetT) check(ctx context.Context, g *libkb.GlobalContext, world LoaderContext) (err error) {
-	defer g.CTrace(ctx, "TeamLoader proofSet check", func() error { return err })()
+func (p *proofSetT) check(ctx context.Context, world LoaderContext) (err error) {
+	defer p.G().CTrace(ctx, "TeamLoader proofSet check", func() error { return err })()
 
 	var total int
 	for _, v := range p.proofs {
@@ -194,9 +252,9 @@ func (p *proofSetT) check(ctx context.Context, g *libkb.GlobalContext, world Loa
 	for _, v := range p.proofs {
 		for _, proof := range v {
 			if i%100 == 0 {
-				g.Log.CDebugf(ctx, "TeamLoader proofSet check [%v / %v]", i, total)
+				p.G().Log.CDebugf(ctx, "TeamLoader proofSet check [%v / %v]", i, total)
 			}
-			err = proof.check(ctx, g, world)
+			err = proof.check(ctx, p.G(), world)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Improve `AddNeededHappensBeforeProof` so that it skips more roundtrip merkle checks because of stuff we know about ordering locally. This improves the speed of cold-loading a team. This does not improve the speed of loading a team that is cached, which should be a more common case.

Before on `keybase`
```
TeamLoader proofSet check [0 / 93] [tags:LT=g7g5FjftPz-K]
TeamLoader#load2(05327b776e5fbf5ee3d7a5905bff2624) -> <nil> [time=4.052269823s] [tags:LT=g7g5FjftPz-K]
```

After on `keybase`
```
TeamLoader proofSet check [0 / 7] [tags:LT=cQTgE00No7bL]
TeamLoader#load2(05327b776e5fbf5ee3d7a5905bff2624) -> <nil> [time=1.236651143s] [tags:LT=cQTgE00No7bL]
```

I've got a pathological test team locally that is 790 links of one user adding and removing another user.
Before on `longteam1`
```
TeamLoader proofSet check [0 / 1579] [tags:LT=SdlRiTNw41DL]
TeamLoader#load2(a4b542076492750b07826fb4ce8a9924) -> <nil> [time=16.673533014s] [tags:LT=SdlRiTNw41DL]
```

After on `longteam1`
```
TeamLoader proofSet check [0 / 1] [tags:LT=usUmS892ZtmQ]
TeamLoader#load2(a4b542076492750b07826fb4ce8a9924) -> <nil> [time=927.037914ms] [tags:LT=usUmS892ZtmQ]
```