### PR TITLE
Chat inbox perf fixes

### DIFF
--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -706,6 +706,10 @@ function unboxConversations(
   return {payload: {conversationIDKeys, force}, type: 'chat:unboxConversations'}
 }
 
+function unboxMore(): Constants.UnboxMore {
+  return {type: 'chat:unboxMore', payload: undefined}
+}
+
 export {
   addPending,
   appendMessages,
@@ -770,6 +774,7 @@ export {
   threadLoadedOffline,
   toggleChannelWideNotifications,
   unboxConversations,
+  unboxMore,
   unstageUserForSearch,
   untrustedInboxVisible,
   updateBadging,

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -16,7 +16,6 @@ import {delay} from 'redux-saga'
 import {globalError} from '../../constants/config'
 import {navigateTo} from '../route-tree'
 import {parseFolderNameToUsers} from '../../util/kbfs'
-import {onIdlePromise} from '../../util/idle-callback'
 import {unsafeUnwrap} from '../../constants/types/more'
 import {usernameSelector} from '../../constants/selectors'
 import {isMobile} from '../../constants/platform'
@@ -287,6 +286,8 @@ function* unboxMore(): SagaGenerator<any, any> {
     return
   }
 
+  // the most recent thing you asked for is likely what you want
+  // (aka scrolling)
   const conv = _chatInboxToProcess.pop()
   yield spawn(processConversation, conv)
 

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -1397,6 +1397,7 @@ function* chatSaga(): SagaGenerator<any, any> {
   yield Saga.safeTakeLatest('chat:setNotifications', _setNotifications)
   yield Saga.safeTakeLatest('chat:toggleChannelWideNotifications', _setNotifications)
   yield Saga.safeTakeSerially('chat:unboxConversations', Inbox.unboxConversations)
+  yield Saga.safeTakeLatest('chat:unboxMore', Inbox.unboxMore)
 }
 
 export default chatSaga

--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -47,6 +47,10 @@ const getSimpleRows = createSelector(
 
         return !isEmpty && !isSuperseded && !isFilteredOut
       })
+      .map(i => ({
+        conversationIDKey: i.conversationIDKey,
+        time: i.time,
+      }))
       .sort((a, b) => {
         if (a.time === b.time) {
           return a.conversationIDKey.localeCompare(b.conversationIDKey)

--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -34,31 +34,34 @@ const passesParticipantFilter = (participants: I.List<string>, filter: string, y
 const getSimpleRows = createSelector(
   [getInbox, getAlwaysShow, getFilter, getSupersededByState, Constants.getYou],
   (inbox, alwaysShow, filter, supersededByState, you) => {
-    return inbox
-      .filter(i => {
-        if (i.teamType === ChatTypes.CommonTeamType.complex) {
-          return false
-        }
+    return (
+      inbox
+        .filter(i => {
+          if (i.teamType === ChatTypes.CommonTeamType.complex) {
+            return false
+          }
 
-        const id = i.conversationIDKey
-        const isEmpty = i.isEmpty && !alwaysShow.has(id)
-        const isSuperseded = !!supersededByState.get(id)
-        const isFilteredOut = !!(filter && !passesParticipantFilter(i.get('participants'), filter, you))
+          const id = i.conversationIDKey
+          const isEmpty = i.isEmpty && !alwaysShow.has(id)
+          const isSuperseded = !!supersededByState.get(id)
+          const isFilteredOut = !!(filter && !passesParticipantFilter(i.get('participants'), filter, you))
 
-        return !isEmpty && !isSuperseded && !isFilteredOut
-      })
-      .map(i => ({
-        conversationIDKey: i.conversationIDKey,
-        time: i.time,
-      }))
-      .sort((a, b) => {
-        if (a.time === b.time) {
-          return a.conversationIDKey.localeCompare(b.conversationIDKey)
-        }
+          return !isEmpty && !isSuperseded && !isFilteredOut
+        })
+        // this is done for perf reasons and that sorting immutable lists is slow
+        .map(i => ({
+          conversationIDKey: i.conversationIDKey,
+          time: i.time,
+        }))
+        .sort((a, b) => {
+          if (a.time === b.time) {
+            return a.conversationIDKey.localeCompare(b.conversationIDKey)
+          }
 
-        return b.time - a.time
-      })
-      .map(i => i.conversationIDKey)
+          return b.time - a.time
+        })
+        .map(i => i.conversationIDKey)
+    )
   }
 )
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -424,6 +424,7 @@ export const maxMessagesToLoadAtATime = 50
 export const nothingSelected = 'chat:noneSelected'
 export const blankChat = 'chat:blankChat'
 
+export type UnboxMore = NoErrorTypedAction<'chat:unboxMore', void>
 export type UnboxConversations = NoErrorTypedAction<
   'chat:unboxConversations',
   {conversationIDKeys: Array<ConversationIDKey>, force: boolean}


### PR DESCRIPTION
@keybase/react-hackers This is based on my user timings stuff.

1. Sort was being called a lot and its very slow due to immutable-js records. its actually faster to convert the whole thing into simple objects then sorting :(
1. The request to delay handing unboxing due to idle timing with a 100ms timeout actually resolves the timeout waaaay later (like 1 s) due to all the work we're doing in parallel. Instead of having all these unbox calls fighting each other we just have a single simple queue
