### PR TITLE
Fix config issue with SMU tests, add impteam SBS test

### DIFF
--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -411,7 +411,7 @@ func (u *smuUser) createTeam(writers []*smuUser) smuTeam {
 	return smuTeam{name: name}
 }
 
-func (u *smuUser) lookupImplicitTeamError(create bool, displayName string, public bool) (smuImplicitTeam, error) {
+func (u *smuUser) lookupImplicitTeam(create bool, displayName string, public bool) smuImplicitTeam {
 	cli := u.getTeamsClient()
 	var err error
 	var teamID keybase1.TeamID
@@ -420,19 +420,10 @@ func (u *smuUser) lookupImplicitTeamError(create bool, displayName string, publi
 	} else {
 		teamID, err = cli.LookupImplicitTeam(context.TODO(), keybase1.LookupImplicitTeamArg{Name: displayName, Public: public})
 	}
-
-	if err != nil {
-		return smuImplicitTeam{}, err
-	}
-	return smuImplicitTeam{ID: teamID}, nil
-}
-
-func (u *smuUser) lookupImplicitTeam(create bool, displayName string, public bool) smuImplicitTeam {
-	team, err := u.lookupImplicitTeamError(create, displayName, public)
 	if err != nil {
 		u.ctx.t.Fatal(err)
 	}
-	return team
+	return smuImplicitTeam{ID: teamID}
 }
 
 func (u *smuUser) addWriter(team smuTeam, w *smuUser) {

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -203,7 +203,7 @@ func TestTeamInviteResetNoKeys(t *testing.T) {
 	tt.users[0].waitForTeamChangedGregor(team, keybase1.Seqno(3))
 }
 
-func TestImpTeamInvite(t *testing.T) {
+func TestImpTeamWithRooter(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
@@ -238,7 +238,7 @@ func TestImpTeamInvite(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestImpTeamInviteWithConflicts(t *testing.T) {
+func TestImpTeamWithRooterConflict(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
@@ -279,7 +279,7 @@ func TestImpTeamInviteWithConflicts(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestImpTeamInviteWithConflicts2(t *testing.T) {
+func TestImpTeamWithMultipleRooters(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -159,6 +159,8 @@ func (tt *teamTester) addUser(pre string) *userPlusDevice {
 		tt.t.Fatal(err)
 	}
 
+	u.teamsClient = keybase1.TeamsClient{Cli: cli}
+
 	tt.users = append(tt.users, &u)
 	return &u
 }
@@ -175,6 +177,7 @@ type userPlusDevice struct {
 	device        *deviceWrapper
 	tc            *libkb.TestContext
 	deviceClient  keybase1.DeviceClient
+	teamsClient   keybase1.TeamsClient
 	notifications *teamNotifyHandler
 }
 
@@ -408,6 +411,19 @@ func (u *userPlusDevice) getTeamSeqno(teamID keybase1.TeamID) keybase1.Seqno {
 
 func (u *userPlusDevice) kickTeamRekeyd() {
 	kickTeamRekeyd(u.tc.G, u.tc.T)
+}
+
+func (u *userPlusDevice) lookupImplicitTeam(create bool, displayName string, public bool) (keybase1.TeamID, error) {
+	cli := u.teamsClient
+	var err error
+	var teamID keybase1.TeamID
+	if create {
+		teamID, err = cli.LookupOrCreateImplicitTeam(context.TODO(), keybase1.LookupOrCreateImplicitTeamArg{Name: displayName, Public: public})
+	} else {
+		teamID, err = cli.LookupImplicitTeam(context.TODO(), keybase1.LookupImplicitTeamArg{Name: displayName, Public: public})
+	}
+
+	return teamID, err
 }
 
 func kickTeamRekeyd(g *libkb.GlobalContext, t testing.TB) {

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -161,6 +161,8 @@ func (tt *teamTester) addUser(pre string) *userPlusDevice {
 
 	u.teamsClient = keybase1.TeamsClient{Cli: cli}
 
+	g.ConfigureConfig()
+
 	tt.users = append(tt.users, &u)
 	return &u
 }


### PR DESCRIPTION
Not calling `tctx.G.ConfigureConfig()` after signup was rendering config reader unusable, which then made session.go nuke its session in `nukeSessionFileIfOutOfSync` (`s.G().Env.GetConfig().GetUsername()` returned `""`). Somehow it didn't do much harm in other tests, but in SMU it was hitting the `nukeSession` branch and throwing the session out, so all the server could respond with afterwards was "not logged in".