### PR TITLE
move subteam create logic into service, and fix frontend create team from conv

### DIFF
--- a/go/client/cmd_team_create.go
+++ b/go/client/cmd_team_create.go
@@ -51,8 +51,10 @@ func (v *CmdTeamCreate) Run() (err error) {
 		return err
 	}
 	dui.Printf("Success!\n\n")
-	dui.Printf("NOTE: you can administer %s, but you won't see its files or chats\n", v.TeamName)
-	dui.Printf("unless you add yourself explicitly with `keybase team add-member`.\n\n")
+	if !v.TeamName.IsRootTeam() {
+		dui.Printf("NOTE: you can administer %s, but you won't see its files or chats\n", v.TeamName)
+		dui.Printf("unless you add yourself explicitly with `keybase team add-member`.\n\n")
+	}
 
 	return nil
 }

--- a/go/client/cmd_team_create.go
+++ b/go/client/cmd_team_create.go
@@ -42,7 +42,7 @@ func (v *CmdTeamCreate) Run() (err error) {
 		return err
 	}
 
-	_, err = cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{
+	createRes, err := cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{
 		Name:                 v.TeamName,
 		SessionID:            v.SessionID,
 		SendChatNotification: true,
@@ -50,9 +50,9 @@ func (v *CmdTeamCreate) Run() (err error) {
 	if err != nil {
 		return err
 	}
-	dui.Printf("Success!\n\n")
-	if !v.TeamName.IsRootTeam() {
-		dui.Printf("NOTE: you can administer %s, but you won't see its files or chats\n", v.TeamName)
+	dui.Printf("Success!\n")
+	if !createRes.CreatorAdded {
+		dui.Printf("\nNOTE: you can administer %s, but you won't see its files or chats\n", v.TeamName)
 		dui.Printf("unless you add yourself explicitly with `keybase team add-member`.\n\n")
 	}
 

--- a/go/client/cmd_team_create.go
+++ b/go/client/cmd_team_create.go
@@ -43,7 +43,7 @@ func (v *CmdTeamCreate) Run() (err error) {
 	}
 
 	createRes, err := cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{
-		Name:                 v.TeamName,
+		Name:                 v.TeamName.String(),
 		SessionID:            v.SessionID,
 		SendChatNotification: true,
 	})

--- a/go/client/cmd_team_create.go
+++ b/go/client/cmd_team_create.go
@@ -42,20 +42,7 @@ func (v *CmdTeamCreate) Run() (err error) {
 		return err
 	}
 
-	if v.TeamName.IsRootTeam() {
-		_, err = cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{
-			Name:                 v.TeamName,
-			SessionID:            v.SessionID,
-			SendChatNotification: true,
-		})
-		if err != nil {
-			return err
-		}
-		dui.Printf("Success!\n")
-		return nil
-	}
-
-	_, err = cli.TeamCreateSubteam(context.TODO(), keybase1.TeamCreateSubteamArg{
+	_, err = cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{
 		Name:                 v.TeamName,
 		SessionID:            v.SessionID,
 		SendChatNotification: true,

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1186,20 +1186,6 @@ func (o TeamCreateArg) DeepCopy() TeamCreateArg {
 	}
 }
 
-type TeamCreateSubteamArg struct {
-	SessionID            int      `codec:"sessionID" json:"sessionID"`
-	Name                 TeamName `codec:"name" json:"name"`
-	SendChatNotification bool     `codec:"sendChatNotification" json:"sendChatNotification"`
-}
-
-func (o TeamCreateSubteamArg) DeepCopy() TeamCreateSubteamArg {
-	return TeamCreateSubteamArg{
-		SessionID:            o.SessionID,
-		Name:                 o.Name.DeepCopy(),
-		SendChatNotification: o.SendChatNotification,
-	}
-}
-
 type TeamGetArg struct {
 	SessionID   int    `codec:"sessionID" json:"sessionID"`
 	Name        string `codec:"name" json:"name"`
@@ -1470,7 +1456,6 @@ func (o GetTeamRootIDArg) DeepCopy() GetTeamRootIDArg {
 
 type TeamsInterface interface {
 	TeamCreate(context.Context, TeamCreateArg) (TeamCreateResult, error)
-	TeamCreateSubteam(context.Context, TeamCreateSubteamArg) (TeamCreateResult, error)
 	TeamGet(context.Context, TeamGetArg) (TeamDetails, error)
 	TeamList(context.Context, TeamListArg) (AnnotatedTeamList, error)
 	TeamChangeMembership(context.Context, TeamChangeMembershipArg) error
@@ -1512,22 +1497,6 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.TeamCreate(ctx, (*typedArgs)[0])
-					return
-				},
-				MethodType: rpc.MethodCall,
-			},
-			"teamCreateSubteam": {
-				MakeArg: func() interface{} {
-					ret := make([]TeamCreateSubteamArg, 1)
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]TeamCreateSubteamArg)
-					if !ok {
-						err = rpc.NewTypeError((*[]TeamCreateSubteamArg)(nil), args)
-						return
-					}
-					ret, err = i.TeamCreateSubteam(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1862,11 +1831,6 @@ type TeamsClient struct {
 
 func (c TeamsClient) TeamCreate(ctx context.Context, __arg TeamCreateArg) (res TeamCreateResult, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreate", []interface{}{__arg}, &res)
-	return
-}
-
-func (c TeamsClient) TeamCreateSubteam(ctx context.Context, __arg TeamCreateSubteamArg) (res TeamCreateResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateSubteam", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1175,27 +1175,13 @@ func (o ImplicitTeamConflictInfo) DeepCopy() ImplicitTeamConflictInfo {
 }
 
 type TeamCreateArg struct {
-	SessionID            int      `codec:"sessionID" json:"sessionID"`
-	Name                 TeamName `codec:"name" json:"name"`
-	SendChatNotification bool     `codec:"sendChatNotification" json:"sendChatNotification"`
-}
-
-func (o TeamCreateArg) DeepCopy() TeamCreateArg {
-	return TeamCreateArg{
-		SessionID:            o.SessionID,
-		Name:                 o.Name.DeepCopy(),
-		SendChatNotification: o.SendChatNotification,
-	}
-}
-
-type TeamCreateWithStringArg struct {
 	SessionID            int    `codec:"sessionID" json:"sessionID"`
 	Name                 string `codec:"name" json:"name"`
 	SendChatNotification bool   `codec:"sendChatNotification" json:"sendChatNotification"`
 }
 
-func (o TeamCreateWithStringArg) DeepCopy() TeamCreateWithStringArg {
-	return TeamCreateWithStringArg{
+func (o TeamCreateArg) DeepCopy() TeamCreateArg {
+	return TeamCreateArg{
 		SessionID:            o.SessionID,
 		Name:                 o.Name,
 		SendChatNotification: o.SendChatNotification,
@@ -1472,7 +1458,6 @@ func (o GetTeamRootIDArg) DeepCopy() GetTeamRootIDArg {
 
 type TeamsInterface interface {
 	TeamCreate(context.Context, TeamCreateArg) (TeamCreateResult, error)
-	TeamCreateWithString(context.Context, TeamCreateWithStringArg) (TeamCreateResult, error)
 	TeamGet(context.Context, TeamGetArg) (TeamDetails, error)
 	TeamList(context.Context, TeamListArg) (AnnotatedTeamList, error)
 	TeamChangeMembership(context.Context, TeamChangeMembershipArg) error
@@ -1514,22 +1499,6 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.TeamCreate(ctx, (*typedArgs)[0])
-					return
-				},
-				MethodType: rpc.MethodCall,
-			},
-			"teamCreateWithString": {
-				MakeArg: func() interface{} {
-					ret := make([]TeamCreateWithStringArg, 1)
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]TeamCreateWithStringArg)
-					if !ok {
-						err = rpc.NewTypeError((*[]TeamCreateWithStringArg)(nil), args)
-						return
-					}
-					ret, err = i.TeamCreateWithString(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1864,11 +1833,6 @@ type TeamsClient struct {
 
 func (c TeamsClient) TeamCreate(ctx context.Context, __arg TeamCreateArg) (res TeamCreateResult, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreate", []interface{}{__arg}, &res)
-	return
-}
-
-func (c TeamsClient) TeamCreateWithString(ctx context.Context, __arg TeamCreateWithStringArg) (res TeamCreateResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateWithString", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -378,7 +378,7 @@ func (u *smuUser) createTeam(writers []*smuUser) smuTeam {
 		u.ctx.t.Fatal(err)
 	}
 	cli := u.getTeamsClient()
-	_, err = cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{Name: nameK1})
+	_, err = cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{Name: nameK1.String()})
 	if err != nil {
 		u.ctx.t.Fatal(err)
 	}

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -407,8 +407,7 @@ protocol teams {
     boolean creatorAdded;
   }
 
-  TeamCreateResult teamCreate(int sessionID, TeamName name, boolean sendChatNotification);
-  TeamCreateResult teamCreateWithString(int sessionID, string name, boolean sendChatNotification);
+  TeamCreateResult teamCreate(int sessionID, string name, boolean sendChatNotification);
   TeamDetails teamGet(int sessionID, string name, boolean forceRepoll);
   AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean all);
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -404,9 +404,11 @@ protocol teams {
 
   record TeamCreateResult {
     boolean chatSent;
+    boolean creatorAdded;
   }
 
   TeamCreateResult teamCreate(int sessionID, TeamName name, boolean sendChatNotification);
+  TeamCreateResult teamCreateWithString(int sessionID, string name, boolean sendChatNotification);
   TeamDetails teamGet(int sessionID, string name, boolean forceRepoll);
   AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean all);
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -97,7 +97,7 @@ protocol teams {
 
   @typedef("string")
   record UserVersionPercentForm {}
-  
+
 
   record TeamChangeReq {
     array<UserVersion> owners;
@@ -407,7 +407,6 @@ protocol teams {
   }
 
   TeamCreateResult teamCreate(int sessionID, TeamName name, boolean sendChatNotification);
-  TeamCreateResult teamCreateSubteam(int sessionID, TeamName name, boolean sendChatNotification);
   TeamDetails teamGet(int sessionID, string name, boolean forceRepoll);
   AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean all);
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2355,14 +2355,6 @@ export function teamsTeamCreateRpcPromise (request: (requestCommon & {callback?:
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreate', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function teamsTeamCreateSubteamRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateSubteamResult) => void} & {param: teamsTeamCreateSubteamRpcParam}): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamCreateSubteam', request)
-}
-
-export function teamsTeamCreateSubteamRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateSubteamResult) => void} & {param: teamsTeamCreateSubteamRpcParam})): Promise<teamsTeamCreateSubteamResult> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreateSubteam', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
 export function teamsTeamDeleteRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamDeleteRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamDelete', request)
 }
@@ -6030,11 +6022,6 @@ export type teamsTeamCreateRpcParam = Exact<{
   sendChatNotification: boolean
 }>
 
-export type teamsTeamCreateSubteamRpcParam = Exact<{
-  name: TeamName,
-  sendChatNotification: boolean
-}>
-
 export type teamsTeamDeleteRpcParam = Exact<{
   name: string
 }>
@@ -6346,7 +6333,6 @@ type teamsLookupImplicitTeamResult = TeamID
 type teamsLookupOrCreateImplicitTeamResult = TeamID
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamCreateResult = TeamCreateResult
-type teamsTeamCreateSubteamResult = TeamCreateResult
 type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2355,6 +2355,14 @@ export function teamsTeamCreateRpcPromise (request: (requestCommon & {callback?:
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreate', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamCreateWithStringRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateWithStringResult) => void} & {param: teamsTeamCreateWithStringRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamCreateWithString', request)
+}
+
+export function teamsTeamCreateWithStringRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateWithStringResult) => void} & {param: teamsTeamCreateWithStringRpcParam})): Promise<teamsTeamCreateWithStringResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreateWithString', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamDeleteRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamDeleteRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamDelete', request)
 }
@@ -4667,6 +4675,7 @@ export type TeamChangeSet = {
 
 export type TeamCreateResult = {
   chatSent: boolean,
+  creatorAdded: boolean,
 }
 
 export type TeamData = {
@@ -6022,6 +6031,11 @@ export type teamsTeamCreateRpcParam = Exact<{
   sendChatNotification: boolean
 }>
 
+export type teamsTeamCreateWithStringRpcParam = Exact<{
+  name: string,
+  sendChatNotification: boolean
+}>
+
 export type teamsTeamDeleteRpcParam = Exact<{
   name: string
 }>
@@ -6333,6 +6347,7 @@ type teamsLookupImplicitTeamResult = TeamID
 type teamsLookupOrCreateImplicitTeamResult = TeamID
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamCreateResult = TeamCreateResult
+type teamsTeamCreateWithStringResult = TeamCreateResult
 type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2355,14 +2355,6 @@ export function teamsTeamCreateRpcPromise (request: (requestCommon & {callback?:
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreate', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function teamsTeamCreateWithStringRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateWithStringResult) => void} & {param: teamsTeamCreateWithStringRpcParam}): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamCreateWithString', request)
-}
-
-export function teamsTeamCreateWithStringRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateWithStringResult) => void} & {param: teamsTeamCreateWithStringRpcParam})): Promise<teamsTeamCreateWithStringResult> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreateWithString', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
 export function teamsTeamDeleteRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamDeleteRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamDelete', request)
 }
@@ -6027,11 +6019,6 @@ export type teamsTeamChangeMembershipRpcParam = Exact<{
 }>
 
 export type teamsTeamCreateRpcParam = Exact<{
-  name: TeamName,
-  sendChatNotification: boolean
-}>
-
-export type teamsTeamCreateWithStringRpcParam = Exact<{
   name: string,
   sendChatNotification: boolean
 }>
@@ -6347,7 +6334,6 @@ type teamsLookupImplicitTeamResult = TeamID
 type teamsLookupOrCreateImplicitTeamResult = TeamID
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamCreateResult = TeamCreateResult
-type teamsTeamCreateWithStringResult = TeamCreateResult
 type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1034,6 +1034,10 @@
         {
           "type": "boolean",
           "name": "chatSent"
+        },
+        {
+          "type": "boolean",
+          "name": "creatorAdded"
         }
       ]
     },
@@ -1108,6 +1112,23 @@
         {
           "name": "name",
           "type": "TeamName"
+        },
+        {
+          "name": "sendChatNotification",
+          "type": "boolean"
+        }
+      ],
+      "response": "TeamCreateResult"
+    },
+    "teamCreateWithString": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "name",
+          "type": "string"
         },
         {
           "name": "sendChatNotification",

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1111,23 +1111,6 @@
         },
         {
           "name": "name",
-          "type": "TeamName"
-        },
-        {
-          "name": "sendChatNotification",
-          "type": "boolean"
-        }
-      ],
-      "response": "TeamCreateResult"
-    },
-    "teamCreateWithString": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        },
-        {
-          "name": "name",
           "type": "string"
         },
         {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1116,23 +1116,6 @@
       ],
       "response": "TeamCreateResult"
     },
-    "teamCreateSubteam": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        },
-        {
-          "name": "name",
-          "type": "TeamName"
-        },
-        {
-          "name": "sendChatNotification",
-          "type": "boolean"
-        }
-      ],
-      "response": "TeamCreateResult"
-    },
     "teamGet": {
       "request": [
         {

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -19,7 +19,7 @@ import type {TypedState} from '../../constants/reducer'
 
 const _createNewTeam = function(action: Constants.CreateNewTeam) {
   const {payload: {name}} = action
-  return call(RpcTypes.teamsTeamCreateWithStringRpcPromise, {
+  return call(RpcTypes.teamsTeamCreateRpcPromise, {
     param: {name, sendChatNotification: true},
   })
 }
@@ -38,7 +38,7 @@ const _createNewTeamFromConversation = function*(
   const me = yield select(usernameSelector)
   const inbox = yield select(selectedInboxSelector, conversationIDKey)
   if (inbox) {
-    const createRes = yield call(RpcTypes.teamsTeamCreateWithStringRpcPromise, {
+    const createRes = yield call(RpcTypes.teamsTeamCreateRpcPromise, {
       param: {name, sendChatNotification: true},
     })
     const participants = inbox.get('participants').toArray()

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -19,8 +19,8 @@ import type {TypedState} from '../../constants/reducer'
 
 const _createNewTeam = function(action: Constants.CreateNewTeam) {
   const {payload: {name}} = action
-  return call(RpcTypes.teamsTeamCreateRpcPromise, {
-    param: {name: {parts: [name]}, sendChatNotification: true},
+  return call(RpcTypes.teamsTeamCreateWithStringRpcPromise, {
+    param: {name, sendChatNotification: true},
   })
 }
 
@@ -38,17 +38,17 @@ const _createNewTeamFromConversation = function*(
   const me = yield select(usernameSelector)
   const inbox = yield select(selectedInboxSelector, conversationIDKey)
   if (inbox) {
-    yield call(RpcTypes.teamsTeamCreateRpcPromise, {
-      param: {name: {parts: [name]}, sendChatNotification: true},
+    const createRes = yield call(RpcTypes.teamsTeamCreateWithStringRpcPromise, {
+      param: {name, sendChatNotification: true},
     })
     const participants = inbox.get('participants').toArray()
     for (const username of participants) {
-      if (username !== me) {
+      if (!createRes.creatorAdded || username !== me) {
         yield call(RpcTypes.teamsTeamAddMemberRpcPromise, {
           param: {
             email: '',
             name,
-            role: RpcTypes.TeamsTeamRole.writer,
+            role: username === me ? RpcTypes.TeamsTeamRole.admin : RpcTypes.TeamsTeamRole.writer,
             sendChatNotification: true,
             username,
           },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2355,14 +2355,6 @@ export function teamsTeamCreateRpcPromise (request: (requestCommon & {callback?:
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreate', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function teamsTeamCreateSubteamRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateSubteamResult) => void} & {param: teamsTeamCreateSubteamRpcParam}): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamCreateSubteam', request)
-}
-
-export function teamsTeamCreateSubteamRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateSubteamResult) => void} & {param: teamsTeamCreateSubteamRpcParam})): Promise<teamsTeamCreateSubteamResult> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreateSubteam', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
 export function teamsTeamDeleteRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamDeleteRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamDelete', request)
 }
@@ -6030,11 +6022,6 @@ export type teamsTeamCreateRpcParam = Exact<{
   sendChatNotification: boolean
 }>
 
-export type teamsTeamCreateSubteamRpcParam = Exact<{
-  name: TeamName,
-  sendChatNotification: boolean
-}>
-
 export type teamsTeamDeleteRpcParam = Exact<{
   name: string
 }>
@@ -6346,7 +6333,6 @@ type teamsLookupImplicitTeamResult = TeamID
 type teamsLookupOrCreateImplicitTeamResult = TeamID
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamCreateResult = TeamCreateResult
-type teamsTeamCreateSubteamResult = TeamCreateResult
 type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2355,6 +2355,14 @@ export function teamsTeamCreateRpcPromise (request: (requestCommon & {callback?:
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreate', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamCreateWithStringRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateWithStringResult) => void} & {param: teamsTeamCreateWithStringRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamCreateWithString', request)
+}
+
+export function teamsTeamCreateWithStringRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateWithStringResult) => void} & {param: teamsTeamCreateWithStringRpcParam})): Promise<teamsTeamCreateWithStringResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreateWithString', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamDeleteRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamDeleteRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamDelete', request)
 }
@@ -4667,6 +4675,7 @@ export type TeamChangeSet = {
 
 export type TeamCreateResult = {
   chatSent: boolean,
+  creatorAdded: boolean,
 }
 
 export type TeamData = {
@@ -6022,6 +6031,11 @@ export type teamsTeamCreateRpcParam = Exact<{
   sendChatNotification: boolean
 }>
 
+export type teamsTeamCreateWithStringRpcParam = Exact<{
+  name: string,
+  sendChatNotification: boolean
+}>
+
 export type teamsTeamDeleteRpcParam = Exact<{
   name: string
 }>
@@ -6333,6 +6347,7 @@ type teamsLookupImplicitTeamResult = TeamID
 type teamsLookupOrCreateImplicitTeamResult = TeamID
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamCreateResult = TeamCreateResult
+type teamsTeamCreateWithStringResult = TeamCreateResult
 type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2355,14 +2355,6 @@ export function teamsTeamCreateRpcPromise (request: (requestCommon & {callback?:
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreate', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function teamsTeamCreateWithStringRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateWithStringResult) => void} & {param: teamsTeamCreateWithStringRpcParam}): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamCreateWithString', request)
-}
-
-export function teamsTeamCreateWithStringRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamCreateWithStringResult) => void} & {param: teamsTeamCreateWithStringRpcParam})): Promise<teamsTeamCreateWithStringResult> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamCreateWithString', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
 export function teamsTeamDeleteRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamDeleteRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamDelete', request)
 }
@@ -6027,11 +6019,6 @@ export type teamsTeamChangeMembershipRpcParam = Exact<{
 }>
 
 export type teamsTeamCreateRpcParam = Exact<{
-  name: TeamName,
-  sendChatNotification: boolean
-}>
-
-export type teamsTeamCreateWithStringRpcParam = Exact<{
   name: string,
   sendChatNotification: boolean
 }>
@@ -6347,7 +6334,6 @@ type teamsLookupImplicitTeamResult = TeamID
 type teamsLookupOrCreateImplicitTeamResult = TeamID
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamCreateResult = TeamCreateResult
-type teamsTeamCreateWithStringResult = TeamCreateResult
 type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList


### PR DESCRIPTION
Patch does the following:

1.) Moves all logic for determining which team create function to call into the service.
2.) Add new `TeamCreateWithString` so frontend doesn't need to pass in parts (which it was messing up).
3.) Change frontend to consume new `CreatorAdded` part of result, to determine if we should add team creator to team (relevant when creating subteam from conv that the creator should get auto added to).
