### PR TITLE
Fix double-layer overlay on create channel on iOS

### DIFF
--- a/shared/teams/routes.js
+++ b/shared/teams/routes.js
@@ -17,7 +17,7 @@ const makeManageChannels = () => ({
   createChannel: {
     children: {},
     component: CreateChannel,
-    tags: {layerOnTop: true},
+    tags: {layerOnTop: !isMobile},
   },
 })
 


### PR DESCRIPTION
@keybase/react-hackers 

Before this PR, teams/create-channel looks like this on iOS:

<img width="625" alt="screen shot 2017-09-12 at 10 25 32 am" src="https://user-images.githubusercontent.com/21217/30339719-c419e74c-97a4-11e7-9ebb-8d75ccaeae1e.png">

I don't understand why layerOnTop does the wrong thing for this path, since CreateChannel's a path sibling to ManageChannels, rather than a child, but it's a blocker and this fixes it without breaking anything, so my confusion should probably get handled independently to the fix.