### PR TITLE
LookupOrCreateImplicitTeam now resolves components

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -310,7 +310,7 @@ func (e *Identify2WithUID) resetError(err error) error {
 	}
 
 	if e.arg.IdentifyBehavior.WarningInsteadOfErrorOnBrokenTracks() {
-		e.G().Log.Debug("| Reset err from %v -> nil since caller is 'CHAT_GUI'", err)
+		e.G().Log.Debug("| Reset err from %v -> nil since caller is '%s' %d", err, e.arg.IdentifyBehavior, e.arg.IdentifyBehavior)
 		return nil
 	}
 

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -810,6 +810,7 @@ func ParseTeamPrivateKBFSPath(s string) (ret keybase1.TeamName, err error) {
 }
 
 type ResolvedAssertion struct {
-	Assertion AssertionExpression
-	UID       keybase1.UID
+	UID           keybase1.UID
+	Assertion     AssertionExpression
+	ResolveResult ResolveResult
 }

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -808,3 +808,8 @@ func ParseTeamPrivateKBFSPath(s string) (ret keybase1.TeamName, err error) {
 	}
 	return keybase1.TeamNameFromString(parts[3])
 }
+
+type ResolvedAssertion struct {
+	Assertion AssertionExpression
+	UID       keybase1.UID
+}

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -129,17 +129,17 @@ func (r *Resolver) ResolveFullExpressionWithBody(ctx context.Context, input stri
 	return r.resolveFullExpression(ctx, input, true, false)
 }
 
-func (r *Resolver) ResolveUser(ctx context.Context, assertion string) (u keybase1.User, err error) {
-	res := r.ResolveFullExpressionNeedUsername(ctx, assertion)
+func (r *Resolver) ResolveUser(ctx context.Context, assertion string) (u keybase1.User, res ResolveResult, err error) {
+	res = r.ResolveFullExpressionNeedUsername(ctx, assertion)
 	err = res.GetError()
 	if err != nil {
-		return u, err
+		return u, res, err
 	}
 	u = res.User()
 	if !u.Uid.Exists() {
-		return u, fmt.Errorf("no resolution for: %v", assertion)
+		return u, res, fmt.Errorf("no resolution for: %v", assertion)
 	}
-	return u, nil
+	return u, res, nil
 }
 
 func (r *Resolver) resolveFullExpression(ctx context.Context, input string, withBody bool, needUsername bool) (res ResolveResult) {

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -129,6 +129,19 @@ func (r *Resolver) ResolveFullExpressionWithBody(ctx context.Context, input stri
 	return r.resolveFullExpression(ctx, input, true, false)
 }
 
+func (r *Resolver) ResolveUser(ctx context.Context, assertion string) (u keybase1.User, err error) {
+	res := r.ResolveFullExpressionNeedUsername(ctx, assertion)
+	err = res.GetError()
+	if err != nil {
+		return u, err
+	}
+	u = res.User()
+	if !u.Uid.Exists() {
+		return u, fmt.Errorf("no resolution for: %v", assertion)
+	}
+	return u, nil
+}
+
 func (r *Resolver) resolveFullExpression(ctx context.Context, input string, withBody bool, needUsername bool) (res ResolveResult) {
 	defer r.G().CVTrace(ctx, VLog1, fmt.Sprintf("Resolver#resolveFullExpression(%q)", input), func() error { return res.err })()
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -997,13 +997,20 @@ func (t TLFID) ToBytes() []byte {
 }
 
 func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
-	return b == TLFIdentifyBehavior_CHAT_GUI || b == TLFIdentifyBehavior_CHAT_CLI ||
-		b == TLFIdentifyBehavior_CHAT_GUI_STRICT
+	switch b {
+	case TLFIdentifyBehavior_CHAT_CLI,
+		TLFIdentifyBehavior_CHAT_GUI,
+		TLFIdentifyBehavior_CHAT_GUI_STRICT:
+		return true
+	default:
+		return false
+	}
 }
 
 func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 	switch b {
-	case TLFIdentifyBehavior_CHAT_GUI, TLFIdentifyBehavior_CHAT_GUI_STRICT:
+	case TLFIdentifyBehavior_CHAT_GUI,
+		TLFIdentifyBehavior_CHAT_GUI_STRICT:
 		return true
 	default:
 		// TLFIdentifyBehavior_DEFAULT_KBFS, for filesystem activity that
@@ -1013,10 +1020,15 @@ func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 }
 
 func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
-	// The chat GUI (in non-strict mode) is specifically exempted from broken
-	// track errors, because people need to be able to use it to ask each other
-	// about the fact that proofs are broken.
-	return b == TLFIdentifyBehavior_CHAT_GUI
+	switch b {
+	case TLFIdentifyBehavior_CHAT_GUI:
+		// The chat GUI (in non-strict mode) is specifically exempted from broken
+		// track errors, because people need to be able to use it to ask each other
+		// about the fact that proofs are broken.
+		return true
+	default:
+		return false
+	}
 }
 
 // All of the chat modes want to prevent tracker popups.

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -500,8 +500,8 @@ func TestResolveIdentifyImplicitTeamWithDuplicates(t *testing.T) {
 	cli, err := client.GetIdentifyClient(g)
 	require.NoError(t, err, "failed to get new identifyclient")
 
-	for _, lookup := range []string{iTeamNameLookup1, iTeamNameLookup2, iTeamNameLookup3} {
-		t.Logf("checking: %v", lookup)
+	for i, lookup := range []string{iTeamNameLookup1, iTeamNameLookup2, iTeamNameLookup3} {
+		t.Logf("checking %v: %v", i, lookup)
 		res, err := cli.ResolveIdentifyImplicitTeam(context.Background(), keybase1.ResolveIdentifyImplicitTeamArg{
 			Assertions:       lookup,
 			Suffix:           "",

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -283,11 +283,12 @@ func TestImpTeamWithRooter(t *testing.T) {
 
 	team2, err := alice.lookupImplicitTeam(false /*create*/, newDisplayName, false /*isPublic*/)
 	require.NoError(t, err)
-	require.Equal(t, team2, team)
+	require.Equal(t, team, team2)
 
-	// Lookup by old name should fail
-	_, err = alice.lookupImplicitTeam(false /*create*/, displayName, false /*isPublic*/)
-	require.Error(t, err)
+	// Lookup by old name should get the same result
+	team2, err = alice.lookupImplicitTeam(false /*create*/, displayName, false /*isPublic*/)
+	require.NoError(t, err)
+	require.Equal(t, team, team2)
 }
 
 func TestImpTeamWithRooterConflict(t *testing.T) {
@@ -318,15 +319,17 @@ func TestImpTeamWithRooterConflict(t *testing.T) {
 
 	alice.waitForTeamIDChangedGregor(team, keybase1.Seqno(2))
 
-	// Display name with rooter name is no longer usable.
-	_, err = alice.lookupImplicitTeam(false /*create*/, displayNameRooter, false /*isPublic*/)
-	require.Error(t, err)
+	// Display name with rooter name now points to the conflict winner.
+	team3, err := alice.lookupImplicitTeam(false /*create*/, displayNameRooter, false /*isPublic*/)
+	require.NoError(t, err)
+	require.Equal(t, team2, team3)
 
-	// "LookupOrCreate" rooter name should fail as well.
-	_, err = alice.lookupImplicitTeam(true /*create*/, displayNameRooter, false /*isPublic*/)
-	require.Error(t, err)
+	// "LookupOrCreate" rooter name should work as well.
+	team3, err = alice.lookupImplicitTeam(true /*create*/, displayNameRooter, false /*isPublic*/)
+	require.NoError(t, err)
+	require.Equal(t, team2, team3)
 
-	// Clients should refer to this team using comma-separated usernames.
+	// The original name works as well.
 	_, err = alice.lookupImplicitTeam(false /*create*/, displayNameKeybase, false /*isPublic*/)
 	require.NoError(t, err)
 }

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -58,6 +58,7 @@ func readChatsWithErrorAndDevice(team smuTeam, u *smuUser, dev *smuDeviceWrapper
 			return messages, err
 		}
 
+		u.ctx.t.Logf("readChatsWithError polling for KBFS")
 		time.Sleep(wait)
 		totalWait += wait
 	}
@@ -73,9 +74,7 @@ func readChats(team smuTeam, u *smuUser, nMessages int) {
 func readChatsWithDevice(team smuTeam, u *smuUser, dev *smuDeviceWrapper, nMessages int) {
 	messages, err := readChatsWithErrorAndDevice(team, u, dev)
 	t := u.ctx.t
-	if err != nil {
-		u.ctx.t.Fatal(err)
-	}
+	require.NoError(t, err)
 	require.Equal(t, nMessages, len(messages))
 	for i, msg := range messages {
 		require.Equal(t, msg.Valid().MessageBody.Text().Body, fmt.Sprintf("%d", len(messages)-i-1))

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -56,6 +56,8 @@ func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	preResolveDisplayName string, impTeamNameInput keybase1.ImplicitTeamDisplayName) (
 	teamID keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, conflicts []keybase1.ImplicitTeamConflictInfo, err error) {
 
+	defer g.CTraceTimed(ctx, fmt.Sprintf("lookupImplicitTeamAndConflicts(%v)", preResolveDisplayName), func() error { return err })()
+
 	impTeamName = impTeamNameInput
 
 	// Use a copy without the conflict info to hit the api endpoint

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -33,6 +33,7 @@ func (i *implicitTeam) GetAppStatus() *libkb.AppStatus {
 	return &i.Status
 }
 
+// does resolve
 func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (
 	teamID keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
 
@@ -40,13 +41,22 @@ func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName
 	return teamID, impTeamName, err
 }
 
+// does resolve
 func LookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (
 	teamID keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, conflicts []keybase1.ImplicitTeamConflictInfo, err error) {
-
-	impTeamName, err = libkb.ParseImplicitTeamDisplayName(g.MakeAssertionContext(), displayName, public /*isPublic*/)
+	impName, err := ResolveImplicitTeamDisplayName(ctx, g, displayName, public)
 	if err != nil {
 		return teamID, impTeamName, conflicts, err
 	}
+	return lookupImplicitTeamAndConflicts(ctx, g, displayName, impName)
+}
+
+// does not resolve
+func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
+	preResolveDisplayName string, impTeamNameInput keybase1.ImplicitTeamDisplayName) (
+	teamID keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, conflicts []keybase1.ImplicitTeamConflictInfo, err error) {
+
+	impTeamName = impTeamNameInput
 
 	// Use a copy without the conflict info to hit the api endpoint
 	var impTeamNameWithoutConflict keybase1.ImplicitTeamDisplayName
@@ -62,13 +72,13 @@ func LookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	arg.SessionType = libkb.APISessionTypeREQUIRED
 	arg.Args = libkb.HTTPArgs{
 		"display_name": libkb.S{Val: lookupNameWithoutConflict},
-		"public":       libkb.B{Val: public},
+		"public":       libkb.B{Val: impTeamName.IsPublic},
 	}
 	var imp implicitTeam
 	if err = g.API.GetDecode(arg, &imp); err != nil {
 		if aerr, ok := err.(libkb.AppStatusError); ok &&
 			keybase1.StatusCode(aerr.Code) == keybase1.StatusCode_SCTeamReadError {
-			return teamID, impTeamName, conflicts, NewTeamDoesNotExistError(displayName)
+			return teamID, impTeamName, conflicts, NewTeamDoesNotExistError(preResolveDisplayName)
 		}
 		return teamID, impTeamName, conflicts, err
 	}
@@ -96,7 +106,7 @@ func LookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	}
 	if impTeamName.ConflictInfo != nil && !foundSelectedConflict {
 		// We got the team but didn't find the specific conflict requested.
-		return teamID, impTeamName, conflicts, NewTeamDoesNotExistError("could not find team with suffix: %v", displayName)
+		return teamID, impTeamName, conflicts, NewTeamDoesNotExistError("could not find team with suffix: %v", preResolveDisplayName)
 	}
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
 		ID:          imp.TeamID,
@@ -119,20 +129,21 @@ func LookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 		return teamID, impTeamName, conflicts, fmt.Errorf("implicit team name mismatch: %s != %s",
 			teamDisplayName, referenceImpName)
 	}
-	if team.IsPublic() != public {
-		return teamID, impTeamName, conflicts, fmt.Errorf("implicit team public-ness mismatch: %v != %v", team.IsPublic(), public)
+	if team.IsPublic() != impTeamName.IsPublic {
+		return teamID, impTeamName, conflicts, fmt.Errorf("implicit team public-ness mismatch: %v != %v", team.IsPublic(), impTeamName.IsPublic)
 	}
 
 	return teamID, impTeamName, conflicts, nil
 }
 
+// does resolve
 func LookupOrCreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (res keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
-	lookupName, err := libkb.ParseImplicitTeamDisplayName(g.MakeAssertionContext(), displayName, public)
+	lookupName, err := ResolveImplicitTeamDisplayName(ctx, g, displayName, public)
 	if err != nil {
 		return res, impTeamName, err
 	}
 
-	res, impTeamName, err = LookupImplicitTeam(ctx, g, displayName, public)
+	res, impTeamName, _, err = lookupImplicitTeamAndConflicts(ctx, g, displayName, lookupName)
 	if err != nil {
 		if _, ok := err.(TeamDoesNotExistError); ok {
 			if lookupName.ConflictInfo != nil {

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -33,7 +33,8 @@ func (i *implicitTeam) GetAppStatus() *libkb.AppStatus {
 	return &i.Status
 }
 
-// does resolve
+// Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted 2017-03-04 #1)"
+// Resolves social assertions.
 func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (
 	teamID keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
 
@@ -41,7 +42,8 @@ func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName
 	return teamID, impTeamName, err
 }
 
-// does resolve
+// Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted 2017-03-04 #1)"
+// Resolves social assertions.
 func LookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (
 	teamID keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, conflicts []keybase1.ImplicitTeamConflictInfo, err error) {
 	impName, err := ResolveImplicitTeamDisplayName(ctx, g, displayName, public)
@@ -51,7 +53,9 @@ func LookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	return lookupImplicitTeamAndConflicts(ctx, g, displayName, impName)
 }
 
-// does not resolve
+// Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted 2017-03-04 #1)"
+// Does not resolve social assertions.
+// preResolveDisplayName is used for logging and errors
 func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	preResolveDisplayName string, impTeamNameInput keybase1.ImplicitTeamDisplayName) (
 	teamID keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, conflicts []keybase1.ImplicitTeamConflictInfo, err error) {
@@ -138,7 +142,8 @@ func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	return teamID, impTeamName, conflicts, nil
 }
 
-// does resolve
+// Lookup or create an implicit team by name like "alice,bob+bob@twitter (conflicted 2017-03-04 #1)"
+// Resolves social assertions.
 func LookupOrCreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (res keybase1.TeamID, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
 	lookupName, err := ResolveImplicitTeamDisplayName(ctx, g, displayName, public)
 	if err != nil {

--- a/go/teams/resolve.go
+++ b/go/teams/resolve.go
@@ -3,7 +3,12 @@ package teams
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"golang.org/x/sync/errgroup"
+
+	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
@@ -39,4 +44,124 @@ func ResolveNameToID(ctx context.Context, g *libkb.GlobalContext, name keybase1.
 	}
 
 	return id, nil
+}
+
+// Resolve assertions in an implicit team display name and verify the result.
+// Resolve an implicit team name with assertions like "alice,bob+bob@twitter#char (conflicted 2017-03-04 #1)"
+// Into "alice,bob#char (conflicted 2017-03-04 #1)"
+// The input can contain compound assertions, but if compound assertions are left unresolved, an error will be returned.
+func ResolveImplicitTeamDisplayName(ctx context.Context, g *libkb.GlobalContext,
+	name string, public bool) (res keybase1.ImplicitTeamDisplayName, err error) {
+
+	defer g.CTrace(ctx, "resolvedAndCheckImplicitTeamDisplayName", func() error { return err })()
+
+	split1 := strings.SplitN(name, " ", 2) // split1: [assertions, ?conflict]
+	assertions := split1[0]
+	var suffix string
+	if len(split1) > 1 {
+		suffix = split1[1]
+	}
+
+	writerAssertions, readerAssertions, err := externals.ParseAssertionsWithReaders(assertions)
+	if err != nil {
+		return res, err
+	}
+
+	res = keybase1.ImplicitTeamDisplayName{
+		IsPublic: public,
+	}
+	if len(suffix) > 0 {
+		res.ConflictInfo, err = libkb.ParseImplicitTeamDisplayNameSuffix(suffix)
+		if err != nil {
+			return res, err
+		}
+	}
+
+	var resolvedAssertions []libkb.ResolvedAssertion
+
+	err = ResolveImplicitTeamSetUntrusted(ctx, g, writerAssertions, &res.Writers, &resolvedAssertions)
+	if err != nil {
+		return res, err
+	}
+	err = ResolveImplicitTeamSetUntrusted(ctx, g, readerAssertions, &res.Readers, &resolvedAssertions)
+	if err != nil {
+		return res, err
+	}
+
+	// errgroup collects errors and returns the first non-nil.
+	// subctx is canceled when the group finishes.
+	group, subctx := errgroup.WithContext(ctx)
+
+	// Identify everyone who resolved in parallel, checking that they match their resolved UID and original assertions.
+	for _, resolvedAssertion := range resolvedAssertions {
+		resolvedAssertion := resolvedAssertion // https://golang.org/doc/faq#closures_and_goroutines
+		group.Go(func() error {
+			return verifyResolveResult(subctx, g, resolvedAssertion)
+		})
+	}
+
+	err = group.Wait()
+	return res, err
+}
+
+// Try to resolve implicit team members.
+// Modifies the arguments `resSet` and appends to `resolvedAssertions`.
+// For each assertion in `sourceAssertions`, try to resolve them.
+//   If they resolve, add the username to `resSet` and the assertion to `resolvedAssertions`.
+//   If they don't resolve, add the SocialAssertion to `resSet`, but nothing to `resolvedAssertions`.
+func ResolveImplicitTeamSetUntrusted(ctx context.Context, g *libkb.GlobalContext,
+	sourceAssertions []libkb.AssertionExpression, resSet *keybase1.ImplicitTeamUserSet, resolvedAssertions *[]libkb.ResolvedAssertion) error {
+
+	for _, expr := range sourceAssertions {
+		u, err := g.Resolver.ResolveUser(ctx, expr.String())
+		if err != nil {
+			// Resolution failed. Could still be an SBS assertion.
+			sa, err := expr.ToSocialAssertion()
+			if err != nil {
+				// Could not convert to a social assertion.
+				// This could be because it is a compound assertion, which we do not support when SBS.
+				// Or it could be because it's a team assertion or something weird like that.
+				return err
+			}
+			resSet.UnresolvedUsers = append(resSet.UnresolvedUsers, sa)
+		} else {
+			// Resolution succeeded
+			resSet.KeybaseUsers = append(resSet.KeybaseUsers, u.Username)
+			// Append the resolvee and assertion to resolvedAssertions, in case we identify later.
+			*resolvedAssertions = append(*resolvedAssertions, libkb.ResolvedAssertion{
+				UID:       u.Uid,
+				Assertion: expr,
+			})
+		}
+	}
+	return nil
+}
+
+// Verify using Identify that a UID matches an assertion.
+func verifyResolveResult(ctx context.Context, g *libkb.GlobalContext, resolvedAssertion libkb.ResolvedAssertion) (err error) {
+
+	defer g.CTrace(ctx, fmt.Sprintf("verifyResolveResult ID user [%s] %s", resolvedAssertion.UID, resolvedAssertion.Assertion.String()),
+		func() error { return err })()
+
+	id2arg := keybase1.Identify2Arg{
+		Uid:           resolvedAssertion.UID,
+		UserAssertion: resolvedAssertion.Assertion.String(),
+		CanSuppressUI: true,
+		// Use CHAT_CLI to avoid tracker popups but DO externals checks.
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	}
+
+	engCtx := engine.Context{
+		// Send a nil IdentifyUI, this IdentifyBehavior should not use it anyway.
+		IdentifyUI: nil,
+		NetContext: ctx,
+	}
+
+	eng := engine.NewIdentify2WithUID(g, &id2arg)
+	err = engine.RunEngine(eng, &engCtx)
+	if err != nil {
+		idRes := eng.Result()
+		g.Log.CDebugf(ctx, "identify failed (IDres %v, TrackBreaks %v): %v", idRes != nil, idRes != nil && idRes.TrackBreaks != nil, err)
+	}
+	return err
 }

--- a/go/teams/resolve.go
+++ b/go/teams/resolve.go
@@ -143,6 +143,9 @@ func verifyResolveResult(ctx context.Context, g *libkb.GlobalContext, resolvedAs
 	defer g.CTrace(ctx, fmt.Sprintf("verifyResolveResult ID user [%s] %s", resolvedAssertion.UID, resolvedAssertion.Assertion.String()),
 		func() error { return err })()
 
+	// TODO it might be worth short-circuiting on local assertions. Because Identify might try and go do a bunch of remote proofs
+	// that aren't relevant.
+
 	id2arg := keybase1.Identify2Arg{
 		Uid:           resolvedAssertion.UID,
 		UserAssertion: resolvedAssertion.Assertion.String(),


### PR DESCRIPTION
`LookupOrCreateImplicitTeam` now resolves all components, and also can now handle compound assertions (like `alice@twitter+alice@github`). But it's a bit more complicated, and possibly slower, though hopefully not much and not in the common case where everyone is resolved.

This should solve the problem (that I haven't seen, just predict) where if someone does something like this they'll get an unnecessary conflicted implicit team.
```
keybase git create t_tracy repo1
keybase git create t_tracy@rooter repo2
```