### PR TITLE
handle team type changes properly CORE-6001

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -669,6 +669,22 @@ func (s *HybridInboxSource) SetAppNotificationSettings(ctx context.Context, uid 
 	return conv, nil
 }
 
+func (s *HybridInboxSource) TeamTypeChanged(ctx context.Context, uid gregor1.UID,
+	vers chat1.InboxVers, convID chat1.ConversationID, teamType chat1.TeamType) (conv *chat1.ConversationLocal, err error) {
+	defer s.Trace(ctx, func() error { return err }, "TeamTypeChanged")()
+	ib := storage.NewInbox(s.G(), uid)
+	if cerr := ib.TeamTypeChanged(ctx, vers, convID, teamType); cerr != nil {
+		err = s.handleInboxError(ctx, cerr, uid)
+		return nil, err
+	}
+	if conv, err = s.getConvLocal(ctx, uid, convID); err != nil {
+		s.Debug(ctx, "TeamTypeChanged: unable to load conversation: convID: %s err: %s",
+			convID, err.Error())
+		return nil, nil
+	}
+	return conv, nil
+}
+
 func (s *HybridInboxSource) TlfFinalize(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) (convs []chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "TlfFinalize")()

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -586,6 +586,30 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			if g.badger != nil && nm.UnreadUpdate != nil {
 				g.badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
 			}
+
+		case types.ActionTeamType:
+			var nm chat1.TeamTypePayload
+			err = dec.Decode(&nm)
+			if err != nil {
+				g.Debug(ctx, "chat activity: error decoding: %s", err.Error())
+				return
+			}
+			g.Debug(ctx, "chat activity: team type: convID: %s ", nm.ConvID)
+
+			uid := m.UID().Bytes()
+			if conv, err = g.G().InboxSource.TeamTypeChanged(ctx, uid, nm.InboxVers, nm.ConvID, nm.TeamType); err != nil {
+				g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
+			}
+
+			activity = chat1.NewChatActivityWithTeamtype(chat1.TeamTypeInfo{
+				ConvID:   nm.ConvID,
+				TeamType: nm.TeamType,
+				Conv:     g.presentUIItem(conv),
+			})
+
+			if g.badger != nil && nm.UnreadUpdate != nil {
+				g.badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
+			}
 		default:
 			g.Debug(ctx, "unhandled chat.activity action %q", action)
 		}

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -600,7 +600,6 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			if conv, err = g.G().InboxSource.TeamTypeChanged(ctx, uid, nm.InboxVers, nm.ConvID, nm.TeamType); err != nil {
 				g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
 			}
-
 			activity = chat1.NewChatActivityWithTeamtype(chat1.TeamTypeInfo{
 				ConvID:   nm.ConvID,
 				TeamType: nm.TeamType,

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1493,6 +1493,7 @@ type serverChatListener struct {
 	membersUpdate           chan chat1.MembersUpdateInfo
 	appNotificationSettings chan chat1.SetAppNotificationSettingsInfo
 	identifyUpdate          chan keybase1.CanonicalTLFNameAndIDWithBreaks
+	teamType                chan chat1.TeamTypeInfo
 }
 
 func (n *serverChatListener) Logout()                                                             {}
@@ -1536,6 +1537,8 @@ func (n *serverChatListener) NewChatActivity(uid keybase1.UID, activity chat1.Ch
 		n.membersUpdate <- activity.MembersUpdate()
 	case chat1.ChatActivityType_SET_APP_NOTIFICATION_SETTINGS:
 		n.appNotificationSettings <- activity.SetAppNotificationSettings()
+	case chat1.ChatActivityType_TEAMTYPE:
+		n.teamType <- activity.Teamtype()
 	}
 }
 func (n *serverChatListener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate) {
@@ -1557,6 +1560,7 @@ func newServerChatListener() *serverChatListener {
 		membersUpdate:           make(chan chat1.MembersUpdateInfo, 100),
 		appNotificationSettings: make(chan chat1.SetAppNotificationSettingsInfo, 100),
 		identifyUpdate:          make(chan keybase1.CanonicalTLFNameAndIDWithBreaks, 100),
+		teamType:                make(chan chat1.TeamTypeInfo, 100),
 	}
 }
 
@@ -2782,7 +2786,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 	require.Equal(t, 1, len(res.Conversations), "no convs found")
 }
 
-func TestImpTeamExistingKBFS(t *testing.T) {
+func TestChatSrvImpTeamExistingKBFS(t *testing.T) {
 	os.Setenv("KEYBASE_CHAT_MEMBER_TYPE", "impteam")
 	defer os.Setenv("KEYBASE_CHAT_MEMBER_TYPE", "")
 	ctc := makeChatTestContext(t, "NewConversationLocal", 2)
@@ -2796,4 +2800,46 @@ func TestImpTeamExistingKBFS(t *testing.T) {
 	if !c2.Id.Eq(c1.Id) {
 		t.Fatalf("2nd call to NewConversationLocal as IMPTEAM for a KBFS conversation did not return the same conversation ID")
 	}
+}
+
+func TestChatSrvTeamTypeChanged(t *testing.T) {
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "TestChatSrvTeamTypeChanged", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
+
+		// Only run this test for teams
+		switch mt {
+		case chat1.ConversationMembersType_TEAM:
+		default:
+			return
+		}
+
+		ctx := ctc.as(t, users[0]).startCtx
+		listener := newServerChatListener()
+		ctc.as(t, users[1]).h.G().SetService()
+		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener)
+		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
+			ctc.as(t, users[1]).user())
+		consumeNewMsg(t, listener, chat1.MessageType_JOIN)
+
+		topicName := "zjoinonsend"
+		channel, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
+			chat1.NewConversationLocalArg{
+				TlfName:       conv.TlfName,
+				TopicName:     &topicName,
+				TopicType:     chat1.TopicType_CHAT,
+				TlfVisibility: keybase1.TLFVisibility_PRIVATE,
+				MembersType:   chat1.ConversationMembersType_TEAM,
+			})
+		t.Logf("conv: %s chan: %s", conv.Id, channel.Conv.GetConvID())
+		require.NoError(t, err)
+		select {
+		case info := <-listener.teamType:
+			require.Equal(t, conv.Id, info.ConvID)
+			require.Equal(t, chat1.TeamType_COMPLEX, info.TeamType)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no team type")
+		}
+	})
 }

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -669,7 +669,8 @@ func TestInboxSync(t *testing.T) {
 
 	vers, err := inbox.Version(context.TODO())
 	require.NoError(t, err)
-	require.NoError(t, inbox.Sync(context.TODO(), vers+1, syncConvs))
+	syncRes, err := inbox.Sync(context.TODO(), vers+1, syncConvs)
+	require.NoError(t, err)
 	newVers, newRes, _, err := inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, vers+1, newVers)
@@ -678,7 +679,19 @@ func TestInboxSync(t *testing.T) {
 	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[1].Metadata.Status)
 	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[7].Metadata.Status)
 	require.Equal(t, chat1.ConversationStatus_UNFILED, newRes[4].Metadata.Status)
+	require.False(t, syncRes.TeamTypeChanged)
 
+	syncConvs = nil
+	vers, err = inbox.Version(context.TODO())
+	require.NoError(t, err)
+	convs[8].Metadata.TeamType = chat1.TeamType_COMPLEX
+	syncConvs = append(syncConvs, convs[8])
+	syncRes, err = inbox.Sync(context.TODO(), vers+1, syncConvs)
+	newVers, newRes, _, err = inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, vers+1, newVers)
+	require.Equal(t, chat1.TeamType_COMPLEX, newRes[9].Metadata.TeamType)
+	require.True(t, syncRes.TeamTypeChanged)
 }
 
 func TestInboxServerVersion(t *testing.T) {

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -225,10 +225,16 @@ func (s *Syncer) Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 	return s.sync(ctx, cli, uid, syncRes)
 }
 
-func (s *Syncer) shouldDoFullReloadFromIncremental(convs []chat1.Conversation) bool {
+func (s *Syncer) shouldDoFullReloadFromIncremental(ctx context.Context, syncRes storage.InboxSyncRes,
+	convs []chat1.Conversation) bool {
+	if syncRes.TeamTypeChanged {
+		s.Debug(ctx, "shouldDoFullReloadFromIncremental: team type changed")
+		return true
+	}
 	for _, conv := range convs {
 		switch conv.ReaderInfo.Status {
 		case chat1.ConversationMemberStatus_LEFT, chat1.ConversationMemberStatus_REMOVED:
+			s.Debug(ctx, "shouldDoFullReloadFromIncremental: join or leave conv")
 			return true
 		}
 	}
@@ -298,13 +304,14 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		s.Debug(ctx, "Sync: version out of date, but can incrementally sync: old vers: %v vers: %v convs: %d",
 			vers, incr.Vers, len(incr.Convs))
 
-		if err = ibox.Sync(ctx, incr.Vers, incr.Convs); err != nil {
+		var iboxSyncRes storage.InboxSyncRes
+		if iboxSyncRes, err = ibox.Sync(ctx, incr.Vers, incr.Convs); err != nil {
 			s.Debug(ctx, "Sync: failed to sync conversations to inbox: %s", err.Error())
 
 			// Send notifications for a full clear
 			s.SendChatStaleNotifications(ctx, uid, nil, true)
 		} else {
-			if s.shouldDoFullReloadFromIncremental(incr.Convs) {
+			if s.shouldDoFullReloadFromIncremental(ctx, iboxSyncRes, incr.Convs) {
 				// If we get word we shoudl full clear the inbox (like if the user left a conversation),
 				// then just reload everything
 				s.SendChatStaleNotifications(ctx, uid, nil, true)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -92,6 +92,8 @@ type InboxSource interface {
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
 	MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		joined []chat1.ConversationMember, removed []chat1.ConversationMember) (MembershipUpdateRes, error)
+	TeamTypeChanged(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
+		teamType chat1.TeamType) (*chat1.ConversationLocal, error)
 
 	GetInboxQueryLocalToRemote(ctx context.Context,
 		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, NameInfo, error)

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -10,6 +10,7 @@ var ActionNewMessage = "newMessage"
 var ActionReadMessage = "readMessage"
 var ActionSetStatus = "setStatus"
 var ActionSetAppNotificationSettings = "setAppNotificationSettings"
+var ActionTeamType = "teamType"
 
 var PushActivity = "chat.activity"
 var PushTyping = "chat.typing"

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -117,6 +117,30 @@ func (o SetStatusPayload) DeepCopy() SetStatusPayload {
 	}
 }
 
+type TeamTypePayload struct {
+	Action       string         `codec:"Action" json:"Action"`
+	ConvID       ConversationID `codec:"convID" json:"convID"`
+	TeamType     TeamType       `codec:"teamType" json:"teamType"`
+	InboxVers    InboxVers      `codec:"inboxVers" json:"inboxVers"`
+	UnreadUpdate *UnreadUpdate  `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
+}
+
+func (o TeamTypePayload) DeepCopy() TeamTypePayload {
+	return TeamTypePayload{
+		Action:    o.Action,
+		ConvID:    o.ConvID.DeepCopy(),
+		TeamType:  o.TeamType.DeepCopy(),
+		InboxVers: o.InboxVers.DeepCopy(),
+		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.UnreadUpdate),
+	}
+}
+
 type SetAppNotificationSettingsPayload struct {
 	Action    string                       `codec:"Action" json:"Action"`
 	ConvID    ConversationID               `codec:"convID" json:"convID"`

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -21,6 +21,7 @@ const (
 	ChatActivityType_FAILED_MESSAGE                ChatActivityType = 5
 	ChatActivityType_MEMBERS_UPDATE                ChatActivityType = 6
 	ChatActivityType_SET_APP_NOTIFICATION_SETTINGS ChatActivityType = 7
+	ChatActivityType_TEAMTYPE                      ChatActivityType = 8
 )
 
 func (o ChatActivityType) DeepCopy() ChatActivityType { return o }
@@ -34,6 +35,7 @@ var ChatActivityTypeMap = map[string]ChatActivityType{
 	"FAILED_MESSAGE":                5,
 	"MEMBERS_UPDATE":                6,
 	"SET_APP_NOTIFICATION_SETTINGS": 7,
+	"TEAMTYPE":                      8,
 }
 
 var ChatActivityTypeRevMap = map[ChatActivityType]string{
@@ -45,6 +47,7 @@ var ChatActivityTypeRevMap = map[ChatActivityType]string{
 	5: "FAILED_MESSAGE",
 	6: "MEMBERS_UPDATE",
 	7: "SET_APP_NOTIFICATION_SETTINGS",
+	8: "TEAMTYPE",
 }
 
 func (e ChatActivityType) String() string {
@@ -177,6 +180,18 @@ func (o MembersUpdateInfo) DeepCopy() MembersUpdateInfo {
 	}
 }
 
+type TeamTypeInfo struct {
+	ConvID   ConversationID `codec:"convID" json:"convID"`
+	TeamType TeamType       `codec:"teamType" json:"teamType"`
+}
+
+func (o TeamTypeInfo) DeepCopy() TeamTypeInfo {
+	return TeamTypeInfo{
+		ConvID:   o.ConvID.DeepCopy(),
+		TeamType: o.TeamType.DeepCopy(),
+	}
+}
+
 type ChatActivity struct {
 	ActivityType__               ChatActivityType                `codec:"activityType" json:"activityType"`
 	IncomingMessage__            *IncomingMessage                `codec:"incomingMessage,omitempty" json:"incomingMessage,omitempty"`
@@ -186,6 +201,7 @@ type ChatActivity struct {
 	FailedMessage__              *FailedMessageInfo              `codec:"failedMessage,omitempty" json:"failedMessage,omitempty"`
 	MembersUpdate__              *MembersUpdateInfo              `codec:"membersUpdate,omitempty" json:"membersUpdate,omitempty"`
 	SetAppNotificationSettings__ *SetAppNotificationSettingsInfo `codec:"setAppNotificationSettings,omitempty" json:"setAppNotificationSettings,omitempty"`
+	Teamtype__                   *TeamTypeInfo                   `codec:"teamtype,omitempty" json:"teamtype,omitempty"`
 }
 
 func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
@@ -223,6 +239,11 @@ func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
 	case ChatActivityType_SET_APP_NOTIFICATION_SETTINGS:
 		if o.SetAppNotificationSettings__ == nil {
 			err = errors.New("unexpected nil value for SetAppNotificationSettings__")
+			return ret, err
+		}
+	case ChatActivityType_TEAMTYPE:
+		if o.Teamtype__ == nil {
+			err = errors.New("unexpected nil value for Teamtype__")
 			return ret, err
 		}
 	}
@@ -299,6 +320,16 @@ func (o ChatActivity) SetAppNotificationSettings() (res SetAppNotificationSettin
 	return *o.SetAppNotificationSettings__
 }
 
+func (o ChatActivity) Teamtype() (res TeamTypeInfo) {
+	if o.ActivityType__ != ChatActivityType_TEAMTYPE {
+		panic("wrong case accessed")
+	}
+	if o.Teamtype__ == nil {
+		return
+	}
+	return *o.Teamtype__
+}
+
 func NewChatActivityWithIncomingMessage(v IncomingMessage) ChatActivity {
 	return ChatActivity{
 		ActivityType__:    ChatActivityType_INCOMING_MESSAGE,
@@ -345,6 +376,13 @@ func NewChatActivityWithSetAppNotificationSettings(v SetAppNotificationSettingsI
 	return ChatActivity{
 		ActivityType__:               ChatActivityType_SET_APP_NOTIFICATION_SETTINGS,
 		SetAppNotificationSettings__: &v,
+	}
+}
+
+func NewChatActivityWithTeamtype(v TeamTypeInfo) ChatActivity {
+	return ChatActivity{
+		ActivityType__: ChatActivityType_TEAMTYPE,
+		Teamtype__:     &v,
 	}
 }
 
@@ -400,6 +438,13 @@ func (o ChatActivity) DeepCopy() ChatActivity {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.SetAppNotificationSettings__),
+		Teamtype__: (func(x *TeamTypeInfo) *TeamTypeInfo {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Teamtype__),
 	}
 }
 

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -183,12 +183,20 @@ func (o MembersUpdateInfo) DeepCopy() MembersUpdateInfo {
 type TeamTypeInfo struct {
 	ConvID   ConversationID `codec:"convID" json:"convID"`
 	TeamType TeamType       `codec:"teamType" json:"teamType"`
+	Conv     *InboxUIItem   `codec:"conv,omitempty" json:"conv,omitempty"`
 }
 
 func (o TeamTypeInfo) DeepCopy() TeamTypeInfo {
 	return TeamTypeInfo{
 		ConvID:   o.ConvID.DeepCopy(),
 		TeamType: o.TeamType.DeepCopy(),
+		Conv: (func(x *InboxUIItem) *InboxUIItem {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Conv),
 	}
 }
 

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -46,6 +46,15 @@ protocol gregor {
         union { null, UnreadUpdate } unreadUpdate;
     }
 
+    record TeamTypePayload {
+        @lint("ignore")
+        string Action;
+        ConversationID convID;
+        TeamType teamType;
+        InboxVers inboxVers;
+        union { null, UnreadUpdate } unreadUpdate;
+    }
+
     record SetAppNotificationSettingsPayload {
         @lint("ignore")
         string Action;
@@ -53,7 +62,7 @@ protocol gregor {
         InboxVers inboxVers;
         ConversationNotificationInfo settings;
     }
-    
+
     record UnreadUpdate {
         ConversationID convID;
         // The count of unread messages to display
@@ -77,7 +86,7 @@ protocol gregor {
         gregor1.UID uid;
         gregor1.DeviceID deviceID;
         ConversationID convID;
-        boolean typing; 
+        boolean typing;
     }
 
     record UpdateConversationMembership {

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -58,6 +58,7 @@ protocol NotifyChat {
   record TeamTypeInfo {
     ConversationID convID;
     TeamType teamType;
+    union { null, InboxUIItem } conv;
   }
 
   variant ChatActivity switch (ChatActivityType activityType) {

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -12,7 +12,8 @@ protocol NotifyChat {
     SET_STATUS_4,
     FAILED_MESSAGE_5,
     MEMBERS_UPDATE_6,
-    SET_APP_NOTIFICATION_SETTINGS_7
+    SET_APP_NOTIFICATION_SETTINGS_7,
+    TEAMTYPE_8
   }
 
   record IncomingMessage {
@@ -54,6 +55,11 @@ protocol NotifyChat {
     boolean joined;
   }
 
+  record TeamTypeInfo {
+    ConversationID convID;
+    TeamType teamType;
+  }
+
   variant ChatActivity switch (ChatActivityType activityType) {
     case INCOMING_MESSAGE: IncomingMessage;
     case READ_MESSAGE: ReadMessageInfo;
@@ -62,6 +68,7 @@ protocol NotifyChat {
     case FAILED_MESSAGE: FailedMessageInfo;
     case MEMBERS_UPDATE: MembersUpdateInfo;
     case SET_APP_NOTIFICATION_SETTINGS: SetAppNotificationSettingsInfo;
+    case TEAMTYPE: TeamTypeInfo;
   }
 
   record TyperInfo {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -202,6 +202,7 @@ export const NotifyChatChatActivityType = {
   failedMessage: 5,
   membersUpdate: 6,
   setAppNotificationSettings: 7,
+  teamtype: 8,
 }
 
 export const NotifyChatStaleUpdateType = {
@@ -845,6 +846,7 @@ export type ChatActivity =
   | { activityType: 5, failedMessage: ?FailedMessageInfo }
   | { activityType: 6, membersUpdate: ?MembersUpdateInfo }
   | { activityType: 7, setAppNotificationSettings: ?SetAppNotificationSettingsInfo }
+  | { activityType: 8, teamtype: ?TeamTypeInfo }
 
 export type ChatActivityType =
     0 // RESERVED_0
@@ -855,6 +857,7 @@ export type ChatActivityType =
   | 5 // FAILED_MESSAGE_5
   | 6 // MEMBERS_UPDATE_6
   | 7 // SET_APP_NOTIFICATION_SETTINGS_7
+  | 8 // TEAMTYPE_8
 
 export type ConvTypingUpdate = {
   convID: ConversationID,
@@ -1841,6 +1844,19 @@ export type TeamType =
     0 // NONE_0
   | 1 // SIMPLE_1
   | 2 // COMPLEX_2
+
+export type TeamTypeInfo = {
+  convID: ConversationID,
+  teamType: TeamType,
+}
+
+export type TeamTypePayload = {
+  Action: string,
+  convID: ConversationID,
+  teamType: TeamType,
+  inboxVers: InboxVers,
+  unreadUpdate?: ?UnreadUpdate,
+}
 
 export type ThreadID = bytes
 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1848,6 +1848,7 @@ export type TeamType =
 export type TeamTypeInfo = {
   convID: ConversationID,
   teamType: TeamType,
+  conv?: ?InboxUIItem,
 }
 
 export type TeamTypePayload = {

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -150,6 +150,36 @@
     },
     {
       "type": "record",
+      "name": "TeamTypePayload",
+      "fields": [
+        {
+          "type": "string",
+          "name": "Action",
+          "lint": "ignore"
+        },
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        },
+        {
+          "type": "TeamType",
+          "name": "teamType"
+        },
+        {
+          "type": "InboxVers",
+          "name": "inboxVers"
+        },
+        {
+          "type": [
+            null,
+            "UnreadUpdate"
+          ],
+          "name": "unreadUpdate"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "SetAppNotificationSettingsPayload",
       "fields": [
         {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -19,7 +19,8 @@
         "SET_STATUS_4",
         "FAILED_MESSAGE_5",
         "MEMBERS_UPDATE_6",
-        "SET_APP_NOTIFICATION_SETTINGS_7"
+        "SET_APP_NOTIFICATION_SETTINGS_7",
+        "TEAMTYPE_8"
       ]
     },
     {
@@ -152,6 +153,20 @@
       ]
     },
     {
+      "type": "record",
+      "name": "TeamTypeInfo",
+      "fields": [
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        },
+        {
+          "type": "TeamType",
+          "name": "teamType"
+        }
+      ]
+    },
+    {
       "type": "variant",
       "name": "ChatActivity",
       "switch": {
@@ -207,6 +222,13 @@
             "def": false
           },
           "body": "SetAppNotificationSettingsInfo"
+        },
+        {
+          "label": {
+            "name": "TEAMTYPE",
+            "def": false
+          },
+          "body": "TeamTypeInfo"
         }
       ]
     },

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -163,6 +163,13 @@
         {
           "type": "TeamType",
           "name": "teamType"
+        },
+        {
+          "type": [
+            null,
+            "InboxUIItem"
+          ],
+          "name": "conv"
         }
       ]
     },

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -216,6 +216,10 @@ function* _incomingMessage(action: Constants.IncomingMessage): SagaGenerator<any
         }
       }
       break
+    case ChatTypes.NotifyChatChatActivityType.teamtype:
+      // Just reload everything if we get one of these
+      yield put(Creators.inboxStale())
+      break
     default:
       console.warn(
         'Unsupported incoming message type for Chat of type:',

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -202,6 +202,7 @@ export const NotifyChatChatActivityType = {
   failedMessage: 5,
   membersUpdate: 6,
   setAppNotificationSettings: 7,
+  teamtype: 8,
 }
 
 export const NotifyChatStaleUpdateType = {
@@ -845,6 +846,7 @@ export type ChatActivity =
   | { activityType: 5, failedMessage: ?FailedMessageInfo }
   | { activityType: 6, membersUpdate: ?MembersUpdateInfo }
   | { activityType: 7, setAppNotificationSettings: ?SetAppNotificationSettingsInfo }
+  | { activityType: 8, teamtype: ?TeamTypeInfo }
 
 export type ChatActivityType =
     0 // RESERVED_0
@@ -855,6 +857,7 @@ export type ChatActivityType =
   | 5 // FAILED_MESSAGE_5
   | 6 // MEMBERS_UPDATE_6
   | 7 // SET_APP_NOTIFICATION_SETTINGS_7
+  | 8 // TEAMTYPE_8
 
 export type ConvTypingUpdate = {
   convID: ConversationID,
@@ -1841,6 +1844,19 @@ export type TeamType =
     0 // NONE_0
   | 1 // SIMPLE_1
   | 2 // COMPLEX_2
+
+export type TeamTypeInfo = {
+  convID: ConversationID,
+  teamType: TeamType,
+}
+
+export type TeamTypePayload = {
+  Action: string,
+  convID: ConversationID,
+  teamType: TeamType,
+  inboxVers: InboxVers,
+  unreadUpdate?: ?UnreadUpdate,
+}
 
 export type ThreadID = bytes
 

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1848,6 +1848,7 @@ export type TeamType =
 export type TeamTypeInfo = {
   convID: ConversationID,
   teamType: TeamType,
+  conv?: ?InboxUIItem,
 }
 
 export type TeamTypePayload = {

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -151,7 +151,7 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
       const newInbox = action.payload.inbox.map(newRow => {
         const id = newRow.get('conversationIDKey')
         const existingRow = existingRows.find(existingRow => existingRow.get('conversationIDKey') === id)
-        return existingRow || newRow
+        return existingRow ? (existingRow.teamType !== newRow.teamType ? newRow : existingRow) : newRow
       })
 
       return state.set('inbox', newInbox).set('rekeyInfos', Map())


### PR DESCRIPTION
Patch does the following:

1.) Handles the new chat activity action `TeamType`, which indicates the team type of a conversation has changed.
2.) For Gregor messages received, we simply generate a message to the frontend telling it about the team type change. The frontend kicks off a full inbox reload as a result.
3.) For a synced team change, we detect this now in  `Inbox.Sync`, and set a special value on the return type from this function. This then indicates to the sync routine we should do a full inbox reload. It is too complicated to fit this in JS (probably where it actually belongs), so we just do it like this.

(also this won't pass CI until I land https://github.com/keybase/keybase/pull/1690)