### PR TITLE
Hide status bar on team manage/create on mobile

### DIFF
--- a/shared/chat/routes.native.js
+++ b/shared/chat/routes.native.js
@@ -63,12 +63,12 @@ const conversationRoute = new RouteDefNode({
 const manageChannelsRoute = new RouteDefNode({
   component: ManageChannels,
   children: {},
-  tags: {hideStatusBar: true, underStatusBar: true},
+  tags: {hideStatusBar: true},
 })
 
 const createChannelRoute = new RouteDefNode({
   component: CreateChannel,
-  tags: {hideStatusBar: true, underStatusBar: true},
+  tags: {hideStatusBar: true},
   children: {},
 })
 

--- a/shared/teams/routes.js
+++ b/shared/teams/routes.js
@@ -12,12 +12,12 @@ const makeManageChannels = () => ({
   manageChannels: {
     children: {},
     component: ManageChannels,
-    tags: {hideStatusBar: true, layerOnTop: !isMobile, underStatusBar: true},
+    tags: {hideStatusBar: true, layerOnTop: !isMobile},
   },
   createChannel: {
     children: {},
     component: CreateChannel,
-    tags: {hideStatusBar: true, layerOnTop: !isMobile, underStatusBar: true},
+    tags: {hideStatusBar: true, layerOnTop: !isMobile},
   },
 })
 

--- a/shared/teams/routes.js
+++ b/shared/teams/routes.js
@@ -12,12 +12,12 @@ const makeManageChannels = () => ({
   manageChannels: {
     children: {},
     component: ManageChannels,
-    tags: {layerOnTop: true},
+    tags: {hideStatusBar: true, layerOnTop: !isMobile, underStatusBar: true},
   },
   createChannel: {
     children: {},
     component: CreateChannel,
-    tags: {layerOnTop: !isMobile},
+    tags: {hideStatusBar: true, layerOnTop: !isMobile, underStatusBar: true},
   },
 })
 


### PR DESCRIPTION
@keybase/react-hackers 

The manage/create channels components draw inside the headerhoc area using a custom component, which only works if you hide the native top status bar, since otherwise you'll draw right on top of it.

These same components hide that bar when they're rendered through a Chat route, so this PR hides them when you get here from a Teams route, too.

(And if layerOnTop isn't disabled, the status bar comes through from below.)