### PR TITLE
dont take up full width for big team row

### DIFF
--- a/shared/chat/inbox/row/big-team-rows.js
+++ b/shared/chat/inbox/row/big-team-rows.js
@@ -187,7 +187,7 @@ const channelBackgroundStyle = {
   marginLeft: globalMargins.medium,
   paddingLeft: globalMargins.tiny,
   paddingRight: globalMargins.tiny,
-  width: '100%',
+  width: '95%',
 }
 
 const mutedStyle = {


### PR DESCRIPTION
@keybase/react-hackers 

Not sure if this is a legit way to do this, but it fixes the problem of the orange dot not being shown on mobile.