### PR TITLE
Speed up tests

### DIFF
--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -466,7 +466,7 @@ func TestChatMessageRevokedKeyThenSent(t *testing.T) {
 		defer tc.Cleanup()
 
 		// need a real user
-		u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
+		u, err := kbtest.CreateAndSignupFakeUserPaper("unbox", tc.G)
 		require.NoError(t, err)
 		t.Logf("using username:%+v uid: %+v", u.Username, u.User.GetUID())
 
@@ -532,7 +532,7 @@ func TestChatMessageSentThenRevokedSenderKey(t *testing.T) {
 		defer tc.Cleanup()
 
 		// need a real user
-		u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
+		u, err := kbtest.CreateAndSignupFakeUserPaper("unbox", tc.G)
 		require.NoError(t, err)
 		t.Logf("using username:%+v uid: %+v", u.Username, u.User.GetUID())
 

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -13,19 +13,11 @@ import (
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	insecureTriplesec "github.com/keybase/go-triplesec-insecure"
 	"github.com/stretchr/testify/require"
 )
 
 func SetupEngineTest(tb testing.TB, name string) libkb.TestContext {
 	tc := externals.SetupTest(tb, name, 2)
-	tc.G.NewTriplesec = func(passphrase []byte, salt []byte) (libkb.Triplesec, error) {
-		warner := func() { tc.G.Log.Warning("Installing insecure Triplesec with weak stretch parameters") }
-		isProduction := func() bool {
-			return tc.G.Env.GetRunMode() == libkb.ProductionRunMode
-		}
-		return insecureTriplesec.NewCipher(passphrase, salt, warner, isProduction)
-	}
 	return tc
 }
 

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -68,6 +68,14 @@ func (fu *FakeUser) Login(g *libkb.GlobalContext) error {
 }
 
 func CreateAndSignupFakeUser(prefix string, g *libkb.GlobalContext) (*FakeUser, error) {
+	return createAndSignupFakeUser(prefix, g, true)
+}
+
+func CreateAndSignupFakeUserPaper(prefix string, g *libkb.GlobalContext) (*FakeUser, error) {
+	return createAndSignupFakeUser(prefix, g, false)
+}
+
+func createAndSignupFakeUser(prefix string, g *libkb.GlobalContext, skipPaper bool) (*FakeUser, error) {
 	fu, err := NewFakeUser(prefix)
 	if err != nil {
 		return nil, err
@@ -80,6 +88,7 @@ func CreateAndSignupFakeUser(prefix string, g *libkb.GlobalContext) (*FakeUser, 
 		DeviceName: "my device",
 		SkipGPG:    true,
 		SkipMail:   true,
+		SkipPaper:  skipPaper,
 	}
 	ctx := &engine.Context{
 		LogUI:    g.UI.GetLogUI(),

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	insecureTriplesec "github.com/keybase/go-triplesec-insecure"
 )
 
 // TestConfig tracks libkb config during a test
@@ -267,6 +268,15 @@ func setupTestContext(tb testing.TB, name string, tcPrev *TestContext) (tc TestC
 
 	if G.SecretStoreAll == nil {
 		G.SecretStoreAll = &SecretStoreLocked{SecretStoreAll: NewTestSecretStoreAll(G, G)}
+	}
+
+	// use an insecure triplesec in tests
+	tc.G.NewTriplesec = func(passphrase []byte, salt []byte) (Triplesec, error) {
+		warner := func() { tc.G.Log.Warning("Installing insecure Triplesec with weak stretch parameters") }
+		isProduction := func() bool {
+			return tc.G.Env.GetRunMode() == ProductionRunMode
+		}
+		return insecureTriplesec.NewCipher(passphrase, salt, warner, isProduction)
 	}
 
 	return


### PR DESCRIPTION
Use insecure 3sec for all tests, skip paper key on signup.

Local speed ups:

teams:  126s => 73s
chat: 186s => 112s

(engine already had both of these optimizations)