### PR TITLE
Fix issues with trying to get convID in the midst of leaving a conv

### DIFF
--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -901,7 +901,7 @@ function* _selectConversation(action: Constants.SelectConversation): SagaGenerat
     yield put(Creators.loadMoreMessages(conversationIDKey, true, fromUser))
     yield put(navigateTo([conversationIDKey], [chatTab]))
   } else {
-    yield put(navigateTo([], [chatTab]))
+    yield put(navigateTo([chatTab]))
   }
 
   // Do this here because it's possible loadMoreMessages bails early

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -35,7 +35,7 @@ function* deleteMessage(action: Constants.DeleteMessage): SagaGenerator<any, any
       select(Shared.selectedInboxSelector, conversationIDKey),
       select(Constants.lastMessageID, conversationIDKey),
     ])
-    yield put(navigateTo([conversationIDKey], [chatTab]))
+    yield put(navigateTo([], [chatTab, conversationIDKey]))
 
     const outboxID = yield call(ChatTypes.localGenerateOutboxIDRpcPromise)
     yield call(ChatTypes.localPostDeleteNonblockRpcPromise, {

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -35,7 +35,7 @@ function* deleteMessage(action: Constants.DeleteMessage): SagaGenerator<any, any
       select(Shared.selectedInboxSelector, conversationIDKey),
       select(Constants.lastMessageID, conversationIDKey),
     ])
-    yield put(navigateTo([], [chatTab, conversationIDKey]))
+    yield put(navigateTo([conversationIDKey], [chatTab]))
 
     const outboxID = yield call(ChatTypes.localGenerateOutboxIDRpcPromise)
     yield call(ChatTypes.localPostDeleteNonblockRpcPromise, {

--- a/shared/chat/conversation/block-conversation-warning/container.js
+++ b/shared/chat/conversation/block-conversation-warning/container.js
@@ -34,7 +34,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       }: BlockConversation)
     ),
   onBack: () => dispatch(navigateUp()),
-  navToRootChat: () => dispatch(navigateTo([], [chatTab])),
+  navToRootChat: () => dispatch(navigateTo([chatTab])),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -3,7 +3,7 @@ import * as Constants from '../../../constants/chat'
 import * as Creators from '../../../actions/chat/creators'
 import {SmallTeamInfoPanel, BigTeamInfoPanel} from '.'
 import {Map} from 'immutable'
-import {compose, renderComponent, branch} from 'recompose'
+import {compose, renderComponent, renderNothing, branch} from 'recompose'
 import {connect} from 'react-redux'
 import {createSelector} from 'reselect'
 import {navigateAppend, navigateTo} from '../../../actions/route-tree'
@@ -37,6 +37,9 @@ const getParticipants = createSelector(
 
 const mapStateToProps = (state: TypedState) => {
   const selectedConversationIDKey = Constants.getSelectedConversation(state)
+  if (!selectedConversationIDKey) {
+    return {}
+  }
   const inbox = Constants.getSelectedInbox(state)
   const channelname = inbox.get('channelname')
   const teamname = inbox.get('teamname')
@@ -53,7 +56,7 @@ const mapStateToProps = (state: TypedState) => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
-  _navToRootChat: () => dispatch(navigateTo([], [chatTab])),
+  _navToRootChat: () => dispatch(navigateTo([chatTab])),
   _onAddParticipant: (participants: Array<string>) => dispatch(Creators.newChat(participants)),
   _onLeaveConversation: (conversationIDKey: Constants.ConversationIDKey) => {
     dispatch(Creators.leaveConversation(conversationIDKey))
@@ -92,8 +95,8 @@ const mergeProps = (stateProps, dispatchProps) => ({
   onAddParticipant: () => dispatchProps._onAddParticipant(stateProps.participants.map(p => p.username)),
   onLeaveConversation: () => {
     if (stateProps.selectedConversationIDKey) {
-      dispatchProps._onLeaveConversation(stateProps.selectedConversationIDKey)
       dispatchProps._navToRootChat()
+      dispatchProps._onLeaveConversation(stateProps.selectedConversationIDKey)
     }
   },
   onMuteConversation: stateProps.selectedConversationIDKey &&
@@ -115,6 +118,7 @@ const mergeProps = (stateProps, dispatchProps) => ({
 
 const ConnectedInfoPanel = compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  branch(props => !props.selectedConversationIDKey, renderNothing),
   branch(props => props.channelname, renderComponent(BigTeamInfoPanel))
 )(SmallTeamInfoPanel)
 

--- a/shared/chat/conversation/info-panel/notifications/container.js.flow
+++ b/shared/chat/conversation/info-panel/notifications/container.js.flow
@@ -9,7 +9,7 @@ export type StateProps = {|
   conversationIDKey: string,
   desktop: NotifyType,
   mobile: NotifyType,
-|}
+|} | {||}
 
 export type DispatchProps = {|
   onSetNotification: (


### PR DESCRIPTION
Components in the info panel were trying to get the conversationIDKey as
we were leaving the conversation. We'd run into errors since there isn't
a selectedConversationIDKey.

@keybase/react-hackers 