### PR TITLE
fix for screen being white if you collapse 

### DIFF
--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -87,7 +87,7 @@ class Inbox extends React.PureComponent<Props, State> {
 
   componentWillReceiveProps(nextProps: Props) {
     if (this.props.smallTeamsHiddenRowCount === 0 && nextProps.smallTeamsHiddenRowCount > 0) {
-      this._list && this._list.scrollToOffset({animated: true, offset: 0})
+      this._list && this._list.scrollToOffset({animated: false, offset: 0})
     }
   }
 


### PR DESCRIPTION
if we pass animated as a flag RN does the wrong thing. turn it off and it works fine
@keybase/react-hackers 