### PR TITLE
TeamList is fast

### DIFF
--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -36,7 +36,7 @@ func NewTeamsHandler(xp rpc.Transporter, id libkb.ConnectionID, g *globals.Conte
 }
 
 func (h *TeamsHandler) TeamCreate(ctx context.Context, arg keybase1.TeamCreateArg) (res keybase1.TeamCreateResult, err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("TeamCreate(%s)", arg.Name), func() error { return err })()
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamCreate(%s)", arg.Name), func() error { return err })()
 	teamName, err := keybase1.TeamNameFromString(arg.Name)
 	if err != nil {
 		return res, err
@@ -67,12 +67,12 @@ func (h *TeamsHandler) TeamCreate(ctx context.Context, arg keybase1.TeamCreateAr
 }
 
 func (h *TeamsHandler) TeamGet(ctx context.Context, arg keybase1.TeamGetArg) (res keybase1.TeamDetails, err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("TeamGet(%s)", arg.Name), func() error { return err })()
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamGet(%s)", arg.Name), func() error { return err })()
 	return teams.Details(ctx, h.G().ExternalG(), arg.Name, arg.ForceRepoll)
 }
 
 func (h *TeamsHandler) TeamList(ctx context.Context, arg keybase1.TeamListArg) (res keybase1.AnnotatedTeamList, err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("TeamList(%s)", arg.UserAssertion), func() error { return err })()
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamList(%s)", arg.UserAssertion), func() error { return err })()
 	x, err := teams.List(ctx, h.G().ExternalG(), arg)
 	if err != nil {
 		return keybase1.AnnotatedTeamList{}, err
@@ -139,7 +139,7 @@ func (h *TeamsHandler) sendTeamChatWelcomeMessage(ctx context.Context, team, use
 }
 
 func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMemberArg) (res keybase1.TeamAddMemberResult, err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("TeamAddMember(%s,%s)", arg.Name, arg.Username),
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamAddMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
 	if arg.Email != "" {
 		if err := teams.InviteEmailMember(ctx, h.G().ExternalG(), arg.Name, arg.Email, arg.Role); err != nil {
@@ -164,59 +164,59 @@ func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMe
 }
 
 func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRemoveMemberArg) (err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("TeamRemoveMember(%s,%s)", arg.Name, arg.Username),
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRemoveMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
 	return teams.RemoveMember(ctx, h.G().ExternalG(), arg.Name, arg.Username)
 }
 
 func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEditMemberArg) (err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("TeamEditMember(%s,%s)", arg.Name, arg.Username),
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamEditMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
 	return teams.EditMember(ctx, h.G().ExternalG(), arg.Name, arg.Username, arg.Role)
 }
 
 func (h *TeamsHandler) TeamLeave(ctx context.Context, arg keybase1.TeamLeaveArg) (err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("TeamLeave(%s)", arg.Name), func() error { return err })()
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamLeave(%s)", arg.Name), func() error { return err })()
 	return teams.Leave(ctx, h.G().ExternalG(), arg.Name, arg.Permanent)
 }
 
 func (h *TeamsHandler) TeamRename(ctx context.Context, arg keybase1.TeamRenameArg) (err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("TeamRename(%s)", arg.PrevName), func() error { return err })()
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRename(%s)", arg.PrevName), func() error { return err })()
 	return teams.RenameSubteam(ctx, h.G().ExternalG(), arg.PrevName, arg.NewName)
 }
 
 func (h *TeamsHandler) TeamAcceptInvite(ctx context.Context, arg keybase1.TeamAcceptInviteArg) (err error) {
-	defer h.G().CTrace(ctx, "TeamAcceptInvite", func() error { return err })()
+	defer h.G().CTraceTimed(ctx, "TeamAcceptInvite", func() error { return err })()
 	return teams.AcceptInvite(ctx, h.G().ExternalG(), arg.Token)
 }
 
 func (h *TeamsHandler) TeamRequestAccess(ctx context.Context, arg keybase1.TeamRequestAccessArg) (err error) {
-	h.G().CTrace(ctx, "TeamRequestAccess", func() error { return err })()
+	h.G().CTraceTimed(ctx, "TeamRequestAccess", func() error { return err })()
 	return teams.RequestAccess(ctx, h.G().ExternalG(), arg.Name)
 }
 
 func (h *TeamsHandler) TeamAcceptInviteOrRequestAccess(ctx context.Context, arg keybase1.TeamAcceptInviteOrRequestAccessArg) (err error) {
-	defer h.G().CTrace(ctx, "TeamAcceptInviteOrRequestAccess", func() error { return err })()
+	defer h.G().CTraceTimed(ctx, "TeamAcceptInviteOrRequestAccess", func() error { return err })()
 	return teams.TeamAcceptInviteOrRequestAccess(ctx, h.G().ExternalG(), arg.TokenOrName)
 }
 
 func (h *TeamsHandler) TeamListRequests(ctx context.Context, sessionID int) (res []keybase1.TeamJoinRequest, err error) {
-	defer h.G().CTrace(ctx, "TeamListRequests", func() error { return err })()
+	defer h.G().CTraceTimed(ctx, "TeamListRequests", func() error { return err })()
 	return teams.ListRequests(ctx, h.G().ExternalG())
 }
 
 func (h *TeamsHandler) TeamIgnoreRequest(ctx context.Context, arg keybase1.TeamIgnoreRequestArg) (err error) {
-	defer h.G().CTrace(ctx, "TeamIgnoreRequest", func() error { return err })()
+	defer h.G().CTraceTimed(ctx, "TeamIgnoreRequest", func() error { return err })()
 	return teams.IgnoreRequest(ctx, h.G().ExternalG(), arg.Name, arg.Username)
 }
 
 func (h *TeamsHandler) TeamTree(ctx context.Context, arg keybase1.TeamTreeArg) (res keybase1.TeamTreeResult, err error) {
-	defer h.G().CTrace(ctx, "TeamTree", func() error { return err })()
+	defer h.G().CTraceTimed(ctx, "TeamTree", func() error { return err })()
 	return teams.TeamTree(ctx, h.G().ExternalG(), arg)
 }
 
 func (h *TeamsHandler) TeamDelete(ctx context.Context, arg keybase1.TeamDeleteArg) (err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("TeamDelete(%s)", arg.Name), func() error { return err })()
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamDelete(%s)", arg.Name), func() error { return err })()
 	ui := h.getTeamsUI(arg.SessionID)
 	return teams.Delete(ctx, h.G().ExternalG(), ui, arg.Name)
 }
@@ -232,13 +232,13 @@ func (h *TeamsHandler) GetTeamRootID(ctx context.Context, id keybase1.TeamID) (k
 }
 
 func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.LookupImplicitTeamArg) (res keybase1.TeamID, err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("LookupImplicitTeam(%s)", arg.Name), func() error { return err })()
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupImplicitTeam(%s)", arg.Name), func() error { return err })()
 	teamID, _, err := teams.LookupImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public)
 	return teamID, err
 }
 
 func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keybase1.LookupOrCreateImplicitTeamArg) (res keybase1.TeamID, err error) {
-	defer h.G().CTrace(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%s)", arg.Name),
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%s)", arg.Name),
 		func() error { return err })()
 	teamID, _, err := teams.LookupOrCreateImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public)
 	return teamID, err

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -93,7 +93,10 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 	for teamName := range teamNames {
 		_, ok := administeredTeams[teamName]
 		if ok {
-			t, err := GetForTeamManagementByStringName(ctx, g, teamName, true)
+			t, err := Load(ctx, g, keybase1.LoadTeamArg{
+				Name:      teamName,
+				NeedAdmin: true,
+			})
 			if err != nil {
 				g.Log.Warning("Error while getting team (%s): %v", teamName, err)
 				continue

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -451,6 +451,13 @@ func TestMemberListInviteUsername(t *testing.T) {
 		t.Errorf("AddMember result username %q does not match arg username %q", res.User.Username, username)
 	}
 
+	// List can return stale results for invites, so do a force load of the team to refresh the cache.
+	// In the real world, hopefully gregor would cause this.
+	Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
+		Name:        name,
+		ForceRepoll: true,
+	})
+
 	annotatedTeamList, err := List(context.TODO(), tc.G, keybase1.TeamListArg{UserAssertion: "", All: true})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
TeamList on an account with 58 teams (18 subteams) on prod used to take a couple seconds now takes 60ms. With `--all` it's still slow.

Just flipped `ForceRepoll` to false in `TeamList`. So now those results could be stale for up to 1 hour if you miss or race with the gregor team changed message. That's probably ok?

I'll try some more things, this is part 1.