### PR TITLE
Add test for re-inviting PUK-less user

### DIFF
--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	client "github.com/keybase/client/go/client"
+	engine "github.com/keybase/client/go/engine"
 	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -346,6 +347,17 @@ func (u *smuUser) signupNoPUK() {
 	for _, clone := range dw.clones {
 		clone.G.ConfigureConfig()
 	}
+}
+
+func (u *smuUser) perUserKeyUpgrade() error {
+	g := u.getPrimaryGlobalContext()
+	arg := &engine.PerUserKeyUpgradeArgs{}
+	eng := engine.NewPerUserKeyUpgrade(g, arg)
+	ctx := &engine.Context{
+		LogUI: g.UI.GetLogUI(),
+	}
+	err := engine.RunEngine(eng, ctx)
+	return err
 }
 
 type smuTeam struct {

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -203,6 +203,58 @@ func TestTeamInviteResetNoKeys(t *testing.T) {
 	tt.users[0].waitForTeamChangedGregor(team, keybase1.Seqno(3))
 }
 
+// See if we can re-invite user after they reset and thus make their
+// first invitation obsolete.
+func TestTeamReInviteAfterReset(t *testing.T) {
+	ctx := newSMUContext(t)
+	defer ctx.cleanup()
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	ann := tt.addUser("ann")
+
+	// Ann creates a team.
+	team := ann.createTeam()
+	t.Logf("Created team %q", team)
+
+	ann.waitForTeamChangedAndRotated(team, keybase1.Seqno(1))
+
+	bob := ctx.installKeybaseForUserNoPUK("bob", 10)
+	bob.signupNoPUK()
+	divDebug(ctx, "Signed up bob (%s)", bob.username)
+
+	// Try to add bob to team, should add an invitation because bob is PUK-less.
+	ann.addTeamMember(team, bob.username, keybase1.TeamRole_WRITER) // Invitation 1
+
+	// Reset, invalidates invitation 1.
+	bob.reset()
+	bob.loginAfterResetNoPUK(10)
+
+	// Try to add again (bob still doesn't have a PUK).
+	ann.addTeamMember(team, bob.username, keybase1.TeamRole_ADMIN) // Invitation 2
+
+	t.Logf("Trying to get a PUK")
+
+	libkb.G = bob.getPrimaryGlobalContext()
+	bob.primaryDevice().tctx.Tp.DisableUpgradePerUserKey = false
+
+	err := bob.perUserKeyUpgrade()
+	require.NoError(t, err)
+
+	t.Logf("Bob got a PUK, now let's see if Ann's client adds him to team")
+
+	ann.kickTeamRekeyd()
+	ann.waitForTeamChangedGregor(team, keybase1.Seqno(4))
+
+	details, err := ann.teamsClient.TeamGet(context.TODO(), keybase1.TeamGetArg{Name: team, ForceRepoll: true})
+	require.NoError(t, err)
+
+	// Bob should have became an admin, because the second invitations
+	// should have been used, not the first one.
+	require.Equal(t, len(details.Members.Admins), 1)
+	require.Equal(t, details.Members.Admins[0].Username, bob.username)
+}
+
 func TestImpTeamWithRooter(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()


### PR DESCRIPTION
This is a test for a story we've heard from a user, that they were unable to re-invite.
See https://keybase.atlassian.net/browse/CORE-5963

> It sounds like step 4 is the more serious bug. It sounds like we're not letting someone invite someone in after an account reset if there was a pending one from before the reset.
