### PR TITLE
Skip inactive/obsolete invitations in AnnotateInvites

### DIFF
--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -146,11 +146,14 @@ func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, invites map[ke
 			if err != nil {
 				return nil, err
 			}
-			normalized, err := upakLoader.LookupUsername(context.Background(), uv.Uid)
+			up, err := upakLoader.LoadUserPlusKeys(context.Background(), uv.Uid, "")
 			if err != nil {
 				return nil, err
 			}
-			name = keybase1.TeamInviteName(normalized.String())
+			if uv.EldestSeqno != up.EldestSeqno {
+				continue
+			}
+			name = keybase1.TeamInviteName(up.Username)
 		}
 		annotatedInvites[id] = keybase1.AnnotatedTeamInvite{
 			Role:            invite.Role,


### PR DESCRIPTION
Before:
```
» kb team list-members tests3
tests3  owner    t63s
tests3  admin    teemo132
tests3  writer   teemo555
tests3  writer*  teemo555  (* invited by t63s; awaiting acceptance)
tests3  writer*  teemo555  (* invited by t63s; awaiting acceptance)
```
(`teemo555` reset multiple times, the invitations there are for previous eldestseqnos)

After:
```
» kbs team list-members tests3
tests3  owner   t63s
tests3  admin   teemo132
tests3  writer  teemo555
```

This is the most straightforward way, but there are other ways to solve this issue:
1) Have an `Inactive` field in `AnnotatedTeamInvite` and set it if the EldestSeqno do not match with user's. Then UI can filter inactive/obsolete invitations.
2) Be smarter about deciding what's "inactive". E.g. only skip if there are more than one invitation for an uid, leave only the most recent (sorted by EldestSeqno), also when listing them mark if it's inactive - so team admins will know that the person might need re-invite.

CC @patrickxb @maxtaco 