### PR TITLE
Bring back prompts when doing chat read/send without argument

### DIFF
--- a/go/client/cmd_chat_read.go
+++ b/go/client/cmd_chat_read.go
@@ -65,10 +65,13 @@ func (c *CmdChatRead) SetTeamChatForTest(n string) {
 func (c *CmdChatRead) Run() error {
 	ui := c.G().UI.GetTerminalUI()
 
-	err := annotateResolvingRequest(c.G(), &c.fetcher.resolvingRequest)
-	if err != nil {
-		return err
+	if c.fetcher.resolvingRequest.TlfName != "" {
+		err := annotateResolvingRequest(c.G(), &c.fetcher.resolvingRequest)
+		if err != nil {
+			return err
+		}
 	}
+
 	convLocal, messages, err := c.Fetch()
 	if err != nil {
 		return err

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -70,9 +70,11 @@ func newCmdChatSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 }
 
 func (c *CmdChatSend) Run() (err error) {
-	err = annotateResolvingRequest(c.G(), &c.resolvingRequest)
-	if err != nil {
-		return err
+	if c.resolvingRequest.TlfName != "" {
+		err = annotateResolvingRequest(c.G(), &c.resolvingRequest)
+		if err != nil {
+			return err
+		}
 	}
 	// TLFVisibility_ANY doesn't make any sense for send, so switch that to PRIVATE:
 	if c.resolvingRequest.Visibility == keybase1.TLFVisibility_ANY {


### PR DESCRIPTION
Before:
```
~ » kb chat send
▶ ERROR Unable to find conversation.
When considering  as a username or a list of usernames, received error: TLF name  is in an incorrect format.
When considering  as a team name, received error: team load arg must have either ID or Name.
```

After:
```
~ » kb chat send
There are 2 conversations. Please choose one:
[1] private deckard,zapu                                                                                                                    
[2] private deckard,space_outlaw                                                                                                            
Please enter a number [1-2]: ▶ ERROR input canceled
```

PS. Should we also list teams there?