### PR TITLE
add the --include-implicit-teams flag to list-memberships

### DIFF
--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -154,7 +154,12 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 	c.tabw = new(tabwriter.Writer)
 	c.tabw.Init(dui.OutputWriter(), 0, 8, 4, ' ', 0)
 
-	fmt.Fprintf(c.tabw, "Team\tRole\tUsername\tFull name\n")
+	// Only print the username and full name columns when we're showing other users.
+	if c.showAll {
+		fmt.Fprintf(c.tabw, "Team\tRole\tUsername\tFull name\n")
+	} else {
+		fmt.Fprintf(c.tabw, "Team\tRole\n")
+	}
 	for _, t := range list.Teams {
 		var role string
 		if t.Implicit != nil {
@@ -166,7 +171,11 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 			}
 			role += strings.ToLower(t.Role.String())
 		}
-		fmt.Fprintf(c.tabw, "%s\t%s\t%s\t%s\n", t.FqName, role, t.Username, t.FullName)
+		if c.showAll {
+			fmt.Fprintf(c.tabw, "%s\t%s\t%s\t%s\n", t.FqName, role, t.Username, t.FullName)
+		} else {
+			fmt.Fprintf(c.tabw, "%s\t%s\n", t.FqName, role)
+		}
 	}
 	if c.showAll {
 		c.outputInvites(list.AnnotatedActiveInvites)

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -943,19 +943,21 @@ func (o ImplicitRole) DeepCopy() ImplicitRole {
 }
 
 type MemberInfo struct {
-	UserID   UID           `codec:"userID" json:"uid"`
-	TeamID   TeamID        `codec:"teamID" json:"team_id"`
-	FqName   string        `codec:"fqName" json:"fq_name"`
-	Role     TeamRole      `codec:"role" json:"role"`
-	Implicit *ImplicitRole `codec:"implicit,omitempty" json:"implicit,omitempty"`
+	UserID         UID           `codec:"userID" json:"uid"`
+	TeamID         TeamID        `codec:"teamID" json:"team_id"`
+	FqName         string        `codec:"fqName" json:"fq_name"`
+	IsImplicitTeam bool          `codec:"isImplicitTeam" json:"is_implicit_team"`
+	Role           TeamRole      `codec:"role" json:"role"`
+	Implicit       *ImplicitRole `codec:"implicit,omitempty" json:"implicit,omitempty"`
 }
 
 func (o MemberInfo) DeepCopy() MemberInfo {
 	return MemberInfo{
-		UserID: o.UserID.DeepCopy(),
-		TeamID: o.TeamID.DeepCopy(),
-		FqName: o.FqName,
-		Role:   o.Role.DeepCopy(),
+		UserID:         o.UserID.DeepCopy(),
+		TeamID:         o.TeamID.DeepCopy(),
+		FqName:         o.FqName,
+		IsImplicitTeam: o.IsImplicitTeam,
+		Role:           o.Role.DeepCopy(),
 		Implicit: (func(x *ImplicitRole) *ImplicitRole {
 			if x == nil {
 				return nil
@@ -984,23 +986,25 @@ func (o TeamList) DeepCopy() TeamList {
 }
 
 type AnnotatedMemberInfo struct {
-	UserID   UID           `codec:"userID" json:"uid"`
-	TeamID   TeamID        `codec:"teamID" json:"team_id"`
-	Username string        `codec:"username" json:"username"`
-	FullName string        `codec:"fullName" json:"full_name"`
-	FqName   string        `codec:"fqName" json:"fq_name"`
-	Role     TeamRole      `codec:"role" json:"role"`
-	Implicit *ImplicitRole `codec:"implicit,omitempty" json:"implicit,omitempty"`
+	UserID         UID           `codec:"userID" json:"uid"`
+	TeamID         TeamID        `codec:"teamID" json:"team_id"`
+	Username       string        `codec:"username" json:"username"`
+	FullName       string        `codec:"fullName" json:"full_name"`
+	FqName         string        `codec:"fqName" json:"fq_name"`
+	IsImplicitTeam bool          `codec:"isImplicitTeam" json:"is_implicit_team"`
+	Role           TeamRole      `codec:"role" json:"role"`
+	Implicit       *ImplicitRole `codec:"implicit,omitempty" json:"implicit,omitempty"`
 }
 
 func (o AnnotatedMemberInfo) DeepCopy() AnnotatedMemberInfo {
 	return AnnotatedMemberInfo{
-		UserID:   o.UserID.DeepCopy(),
-		TeamID:   o.TeamID.DeepCopy(),
-		Username: o.Username,
-		FullName: o.FullName,
-		FqName:   o.FqName,
-		Role:     o.Role.DeepCopy(),
+		UserID:         o.UserID.DeepCopy(),
+		TeamID:         o.TeamID.DeepCopy(),
+		Username:       o.Username,
+		FullName:       o.FullName,
+		FqName:         o.FqName,
+		IsImplicitTeam: o.IsImplicitTeam,
+		Role:           o.Role.DeepCopy(),
 		Implicit: (func(x *ImplicitRole) *ImplicitRole {
 			if x == nil {
 				return nil
@@ -1203,16 +1207,18 @@ func (o TeamGetArg) DeepCopy() TeamGetArg {
 }
 
 type TeamListArg struct {
-	SessionID     int    `codec:"sessionID" json:"sessionID"`
-	UserAssertion string `codec:"userAssertion" json:"userAssertion"`
-	All           bool   `codec:"all" json:"all"`
+	SessionID            int    `codec:"sessionID" json:"sessionID"`
+	UserAssertion        string `codec:"userAssertion" json:"userAssertion"`
+	All                  bool   `codec:"all" json:"all"`
+	IncludeImplicitTeams bool   `codec:"includeImplicitTeams" json:"includeImplicitTeams"`
 }
 
 func (o TeamListArg) DeepCopy() TeamListArg {
 	return TeamListArg{
-		SessionID:     o.SessionID,
-		UserAssertion: o.UserAssertion,
-		All:           o.All,
+		SessionID:            o.SessionID,
+		UserAssertion:        o.UserAssertion,
+		All:                  o.All,
+		IncludeImplicitTeams: o.IncludeImplicitTeams,
 	}
 }
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -354,6 +354,8 @@ protocol teams {
     TeamID teamID;
     @jsonkey("fq_name")
     string fqName;
+    @jsonkey("is_implicit_team")
+    boolean isImplicitTeam;
     TeamRole role;
     union{null, ImplicitRole} implicit;
   }
@@ -372,6 +374,8 @@ protocol teams {
     string fullName;
     @jsonkey("fq_name")
     string fqName;
+    @jsonkey("is_implicit_team")
+    boolean isImplicitTeam;
     TeamRole role;
     union{null, ImplicitRole} implicit;
   }
@@ -409,7 +413,7 @@ protocol teams {
 
   TeamCreateResult teamCreate(int sessionID, string name, boolean sendChatNotification);
   TeamDetails teamGet(int sessionID, string name, boolean forceRepoll);
-  AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean all);
+  AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean all, boolean includeImplicitTeams);
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);
   TeamAddMemberResult teamAddMember(int sessionID, string name, string email, string username, TeamRole role, boolean sendChatNotification);
   void teamRemoveMember(int sessionID, string name, string username);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2736,6 +2736,7 @@ export type AnnotatedMemberInfo = {
   username: string,
   fullName: string,
   fqName: string,
+  isImplicitTeam: boolean,
   role: TeamRole,
   implicit?: ?ImplicitRole,
 }
@@ -3581,6 +3582,7 @@ export type MemberInfo = {
   userID: UID,
   teamID: TeamID,
   fqName: string,
+  isImplicitTeam: boolean,
   role: TeamRole,
   implicit?: ?ImplicitRole,
 }
@@ -6075,7 +6077,8 @@ export type teamsTeamLeaveRpcParam = Exact<{
 
 export type teamsTeamListRpcParam = Exact<{
   userAssertion: string,
-  all: boolean
+  all: boolean,
+  includeImplicitTeams: boolean
 }>
 
 export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -874,6 +874,11 @@
           "jsonkey": "fq_name"
         },
         {
+          "type": "boolean",
+          "name": "isImplicitTeam",
+          "jsonkey": "is_implicit_team"
+        },
+        {
           "type": "TeamRole",
           "name": "role"
         },
@@ -926,6 +931,11 @@
           "type": "string",
           "name": "fqName",
           "jsonkey": "fq_name"
+        },
+        {
+          "type": "boolean",
+          "name": "isImplicitTeam",
+          "jsonkey": "is_implicit_team"
         },
         {
           "type": "TeamRole",
@@ -1149,6 +1159,10 @@
         },
         {
           "name": "all",
+          "type": "boolean"
+        },
+        {
+          "name": "includeImplicitTeams",
           "type": "boolean"
         }
       ],

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2736,6 +2736,7 @@ export type AnnotatedMemberInfo = {
   username: string,
   fullName: string,
   fqName: string,
+  isImplicitTeam: boolean,
   role: TeamRole,
   implicit?: ?ImplicitRole,
 }
@@ -3581,6 +3582,7 @@ export type MemberInfo = {
   userID: UID,
   teamID: TeamID,
   fqName: string,
+  isImplicitTeam: boolean,
   role: TeamRole,
   implicit?: ?ImplicitRole,
 }
@@ -6075,7 +6077,8 @@ export type teamsTeamLeaveRpcParam = Exact<{
 
 export type teamsTeamListRpcParam = Exact<{
   userAssertion: string,
-  all: boolean
+  all: boolean,
+  includeImplicitTeams: boolean
 }>
 
 export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{


### PR DESCRIPTION
r? @mlsteele 

Using the extra column from https://github.com/keybase/keybase/pull/1697, filter out implicit teams from the team list results by default, and add a flag (that maybe no one will ever use) to bring them back. Also clean up the formatting a little bit in the non-all case, where printing the username is redundant.