### PR TITLE
TeamList with All is fast

### DIFF
--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -242,10 +242,11 @@ func (l *TeamLoader) walkUpToAdmin(
 		if target.Eq(*parent) {
 			arg.needSeqnos = []keybase1.Seqno{admin.Seqno}
 		}
-		team, err = l.load2(ctx, arg)
+		load2Res, err := l.load2(ctx, arg)
 		if err != nil {
 			return nil, err
 		}
+		team = &load2Res.team
 	}
 	if team == nil {
 		return nil, fmt.Errorf("teamloader fault: nil team after admin walk")
@@ -476,7 +477,7 @@ func (l *TeamLoader) checkParentChildOperations(ctx context.Context,
 	}
 
 	for _, pco := range parentChildOperations {
-		parentChain := TeamSigChainState{inner: parent.Chain}
+		parentChain := TeamSigChainState{inner: parent.team.Chain}
 		err = l.checkOneParentChildOperation(ctx, pco, loadingTeamID, &parentChain)
 		if err != nil {
 			return err
@@ -802,7 +803,7 @@ func (l *TeamLoader) calculateName(ctx context.Context,
 	// Swap out the parent name as the base of this name.
 	// Check that the root ancestor name and depth still match the subteam chain.
 
-	newName, err = parent.Name.Append(string(chain.LatestLastNamePart()))
+	newName, err = parent.team.Name.Append(string(chain.LatestLastNamePart()))
 	if err != nil {
 		return newName, fmt.Errorf("invalid new subteam name: %v", err)
 	}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -234,6 +234,7 @@ func (l *TeamLoader) walkUpToAdmin(
 		}
 		arg := load2ArgT{
 			teamID:        *parent,
+			reason:        "walkUpToAdmin",
 			me:            me,
 			staleOK:       true,
 			readSubteamID: &readSubteamID,
@@ -454,6 +455,8 @@ func (l *TeamLoader) checkParentChildOperations(ctx context.Context,
 
 	parent, err := l.load2(ctx, load2ArgT{
 		teamID: *parentID,
+
+		reason: "checkParentChildOperations-parent",
 
 		needAdmin:         false,
 		needKeyGeneration: 0,
@@ -787,6 +790,7 @@ func (l *TeamLoader) calculateName(ctx context.Context,
 	// so this name recalculation is recursive.
 	parent, err := l.load2(ctx, load2ArgT{
 		teamID:        *chain.GetParentID(),
+		reason:        "calculateName",
 		staleOK:       staleOK,
 		readSubteamID: &readSubteamID,
 		me:            me,


### PR DESCRIPTION
This makes `TeamList` when `all` is set take 100ms instead of seconds with my test user that has ~50 teams.

The problems were:
- TeamLoader was doing 2 rpcs per call in a specific case. Reduced those to 1 every hour. The case was when using NeedAdmin and you were an implicit admin and an admin in the team.
- List was using load by name which always takes 1 rpc, now uses ID.

Comes with some logging stuff that helped me figure what the problem was and might come in handy later.