### PR TITLE
Better handling of error creating channel as implied admin

### DIFF
--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -213,8 +213,6 @@ func (r *chatConversationResolver) create(ctx context.Context, req chatConversat
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		r.G.UI.GetTerminalUI().Printf(newConversation+": %s.\n", req.ctx.canonicalizedTlfName)
 	}
 
 	var tnp *string
@@ -229,9 +227,9 @@ func (r *chatConversationResolver) create(ctx context.Context, req chatConversat
 		MembersType:   req.MembersType,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("creating conversation error: %v\n", err)
+		return nil, err
 	}
-	return &ncres.Conv, err
+	return &ncres.Conv, nil
 }
 
 func (r *chatConversationResolver) Resolve(ctx context.Context, req chatConversationResolvingRequest, behavior chatConversationResolvingBehavior) (

--- a/go/client/cmd_chat_createchannel.go
+++ b/go/client/cmd_chat_createchannel.go
@@ -1,8 +1,9 @@
 package client
 
 import (
-	"context"
-	"fmt"
+	"errors"
+
+	"golang.org/x/net/context"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
@@ -12,15 +13,14 @@ import (
 )
 
 type CmdChatCreateChannel struct {
-	g *libkb.GlobalContext
-
-	resolvingRequest chatConversationResolvingRequest
+	libkb.Contextified
+	teamName    string
+	channelName string
+	topicType   chat1.TopicType
 }
 
 func NewCmdChatCreateChannelRunner(g *libkb.GlobalContext) *CmdChatCreateChannel {
-	return &CmdChatCreateChannel{
-		g: g,
-	}
+	return &CmdChatCreateChannel{Contextified: libkb.NewContextified(g)}
 }
 
 func newCmdChatCreateChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -36,47 +36,49 @@ func newCmdChatCreateChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext)
 }
 
 func (c *CmdChatCreateChannel) Run() error {
-	c.g.StartStandaloneChat()
-	return chatSend(context.TODO(), c.g, ChatSendArg{
-		resolvingRequest: c.resolvingRequest,
-		nonBlock:         false,
-		team:             true,
-		message:          fmt.Sprintf("Welcome to #%s!", c.resolvingRequest.TopicName),
-		setHeadline:      "",
-		clearHeadline:    false,
-		hasTTY:           true,
-		setTopicName:     "",
-		mustNotExist:     true,
-	})
-}
-
-func (c *CmdChatCreateChannel) ParseArgv(ctx *cli.Context) (err error) {
-
-	var tlfName, topicName string
-	var topicType chat1.TopicType
-
-	if len(ctx.Args()) == 2 {
-		tlfName = ctx.Args().Get(0)
-		topicName = ctx.Args().Get(1)
-	} else {
-		return fmt.Errorf("create channel takes two arguments.")
-	}
-	if topicType, err = parseConversationTopicType(ctx); err != nil {
+	c.G().StartStandaloneChat()
+	chatClient, err := GetChatLocalClient(c.G())
+	if err != nil {
 		return err
 	}
+	resolver := &chatConversationResolver{G: c.G(), ChatClient: chatClient}
 
-	c.resolvingRequest.TlfName = tlfName
-	c.resolvingRequest.TopicType = topicType
-	c.resolvingRequest.TopicName = topicName
-	c.resolvingRequest.MembersType = chat1.ConversationMembersType_TEAM
-	c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
+	req := chatConversationResolvingRequest{
+		TlfName:     c.teamName,
+		TopicName:   c.channelName,
+		TopicType:   c.topicType,
+		MembersType: chat1.ConversationMembersType_TEAM,
+		Visibility:  keybase1.TLFVisibility_PRIVATE,
+		ctx: &chatConversationResolvingRequestContext{
+			canonicalizedTlfName: c.teamName,
+		},
+	}
+
+	_, err = resolver.create(context.Background(), req)
+	return err
+}
+
+func (c *CmdChatCreateChannel) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 2 {
+		return errors.New("create channel takes two arguments.")
+	}
+
+	c.teamName = ctx.Args().Get(0)
+	c.channelName = ctx.Args().Get(1)
+
+	var err error
+	c.topicType, err = parseConversationTopicType(ctx)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
 
 func (c *CmdChatCreateChannel) GetUsage() libkb.Usage {
 	return libkb.Usage{
-		Config: true,
-		API:    true,
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
 	}
 }

--- a/go/client/cmd_chat_createchannel.go
+++ b/go/client/cmd_chat_createchannel.go
@@ -55,6 +55,22 @@ func (c *CmdChatCreateChannel) Run() error {
 	}
 
 	_, err = resolver.create(context.Background(), req)
+
+	dui := c.G().UI.GetDumbOutputUI()
+	if err == nil {
+		dui.Printf("Success!\n")
+		return nil
+	}
+
+	switch err.(type) {
+	case libkb.KeyMaskNotFoundError:
+		// implied admin tried to create a channel
+		dui.Printf("Failed to create the channel %q\n\n", c.channelName)
+		dui.Printf("To edit %s's channels, you must join the team.\n", c.teamName)
+		dui.Printf("Try `keybase team add-member %s --user=%s --role=admin`\n\n", c.teamName, c.G().Env.GetUsername())
+		return nil
+	}
+
 	return err
 }
 

--- a/go/client/cmd_chat_renamechannel.go
+++ b/go/client/cmd_chat_renamechannel.go
@@ -13,7 +13,7 @@ import (
 )
 
 type CmdChatRenameChannel struct {
-	g *libkb.GlobalContext
+	libkb.Contextified
 
 	resolvingRequest chatConversationResolvingRequest
 	setTopicName     string
@@ -22,9 +22,7 @@ type CmdChatRenameChannel struct {
 }
 
 func NewCmdChatRenameChannelRunner(g *libkb.GlobalContext) *CmdChatRenameChannel {
-	return &CmdChatRenameChannel{
-		g: g,
-	}
+	return &CmdChatRenameChannel{Contextified: libkb.NewContextified(g)}
 }
 
 func newCmdChatRenameChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -41,8 +39,8 @@ func newCmdChatRenameChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext)
 }
 
 func (c *CmdChatRenameChannel) Run() error {
-	c.g.StartStandaloneChat()
-	return chatSend(context.TODO(), c.g, ChatSendArg{
+	c.G().StartStandaloneChat()
+	return chatSend(context.TODO(), c.G(), ChatSendArg{
 		resolvingRequest: c.resolvingRequest,
 		setTopicName:     c.setTopicName,
 		nonBlock:         c.nonBlock,

--- a/go/client/cmd_team_create.go
+++ b/go/client/cmd_team_create.go
@@ -42,10 +42,15 @@ func (v *CmdTeamCreate) Run() (err error) {
 		return err
 	}
 
+	// only send a chat notification if creating a root team.
+	// (if creating a sub team, the creator is not a member of the team
+	// and thus can't send a chat message)
+	sendChatNotification := v.TeamName.IsRootTeam()
+
 	createRes, err := cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{
 		Name:                 v.TeamName.String(),
 		SessionID:            v.SessionID,
-		SendChatNotification: true,
+		SendChatNotification: sendChatNotification,
 	})
 	if err != nil {
 		return err

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -263,6 +263,7 @@ const (
 	SCLoginStateTimeout        = int(keybase1.StatusCode_SCLoginStateTimeout)
 	SCRevokeCurrentDevice      = int(keybase1.StatusCode_SCRevokeCurrentDevice)
 	SCRevokeLastDevice         = int(keybase1.StatusCode_SCRevokeLastDevice)
+	SCTeamKeyMaskNotFound      = int(keybase1.StatusCode_SCTeamKeyMaskNotFound)
 )
 
 const (

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2104,3 +2104,16 @@ type TeamVisibilityError struct{}
 func (e TeamVisibilityError) Error() string {
 	return "loaded team doesn't match specified visibility"
 }
+
+type KeyMaskNotFoundError struct {
+	App keybase1.TeamApplication
+	Gen keybase1.PerTeamKeyGeneration
+}
+
+func (e KeyMaskNotFoundError) Error() string {
+	msg := fmt.Sprintf("You don't have access to %s for this team", e.App)
+	if e.Gen != keybase1.PerTeamKeyGeneration(0) {
+		msg += fmt.Sprintf(" (at generation %d)", int(e.Gen))
+	}
+	return msg
+}

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -586,6 +586,17 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		return RevokeCurrentDeviceError{}
 	case SCRevokeLastDevice:
 		return RevokeLastDeviceError{}
+	case SCTeamKeyMaskNotFound:
+		e := KeyMaskNotFoundError{}
+		for _, field := range s.Fields {
+			switch field.Key {
+			case "App":
+				e.App = keybase1.TeamApplication(field.IntValue())
+			case "Gen":
+				e.Gen = keybase1.PerTeamKeyGeneration(field.IntValue())
+			}
+		}
+		return e
 
 	default:
 		ase := AppStatusError{
@@ -2030,5 +2041,17 @@ func (e RevokeLastDeviceError) ToStatus() keybase1.Status {
 		Code: SCRevokeLastDevice,
 		Name: "SC_DEVICE_REVOKE_LAST",
 		Desc: e.Error(),
+	}
+}
+
+func (e KeyMaskNotFoundError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCTeamKeyMaskNotFound,
+		Name: "TEAM_KEY_MASK_NOT_FOUND",
+		Desc: e.Error(),
+		Fields: []keybase1.StringKVPair{
+			{Key: "App", Value: strconv.Itoa(int(e.App))},
+			{Key: "Gen", Value: strconv.Itoa(int(e.Gen))},
+		},
 	}
 }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -138,6 +138,7 @@ const (
 	StatusCode_SCTeamBadAdminSeqnoType     StatusCode = 2684
 	StatusCode_SCTeamImplicitBadAdd        StatusCode = 2685
 	StatusCode_SCTeamImplicitBadRemove     StatusCode = 2686
+	StatusCode_SCTeamKeyMaskNotFound       StatusCode = 2697
 )
 
 func (o StatusCode) DeepCopy() StatusCode { return o }
@@ -271,6 +272,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamBadAdminSeqnoType":     2684,
 	"SCTeamImplicitBadAdd":        2685,
 	"SCTeamImplicitBadRemove":     2686,
+	"SCTeamKeyMaskNotFound":       2697,
 }
 
 var StatusCodeRevMap = map[StatusCode]string{
@@ -402,6 +404,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2684: "SCTeamBadAdminSeqnoType",
 	2685: "SCTeamImplicitBadAdd",
 	2686: "SCTeamImplicitBadRemove",
+	2697: "SCTeamKeyMaskNotFound",
 }
 
 func (e StatusCode) String() string {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1914,3 +1914,11 @@ func ParseUserVersion(s UserVersionPercentForm) (res UserVersion, err error) {
 		EldestSeqno: Seqno(eldestSeqno),
 	}, nil
 }
+
+func (p StringKVPair) IntValue() int {
+	i, err := strconv.Atoi(p.Value)
+	if err != nil {
+		return 0
+	}
+	return i
+}

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -229,23 +229,10 @@ func fixupTeamGetError(ctx context.Context, g *libkb.GlobalContext, e error, n s
 	return e
 }
 
-type KeyMaskNotFoundError struct {
-	app keybase1.TeamApplication
-	gen keybase1.PerTeamKeyGeneration
+func NewKeyMaskNotFoundErrorForApplication(a keybase1.TeamApplication) libkb.KeyMaskNotFoundError {
+	return libkb.KeyMaskNotFoundError{App: a}
 }
 
-func (e KeyMaskNotFoundError) Error() string {
-	msg := fmt.Sprintf("You don't have access to %s for this team", e.app)
-	if e.gen != keybase1.PerTeamKeyGeneration(0) {
-		msg += fmt.Sprintf(" (at generation %d)", int(e.gen))
-	}
-	return msg
-}
-
-func NewKeyMaskNotFoundErrorForApplication(a keybase1.TeamApplication) KeyMaskNotFoundError {
-	return KeyMaskNotFoundError{app: a}
-}
-
-func NewKeyMaskNotFoundErrorForApplicationAndGeneration(a keybase1.TeamApplication, g keybase1.PerTeamKeyGeneration) KeyMaskNotFoundError {
-	return KeyMaskNotFoundError{app: a, gen: g}
+func NewKeyMaskNotFoundErrorForApplicationAndGeneration(a keybase1.TeamApplication, g keybase1.PerTeamKeyGeneration) libkb.KeyMaskNotFoundError {
+	return libkb.KeyMaskNotFoundError{App: a, Gen: g}
 }

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -129,6 +129,7 @@ protocol constants {
     SCTeamImplicitNotFound_2683,
     SCTeamBadAdminSeqnoType_2684,
     SCTeamImplicitBadAdd_2685,
-    SCTeamImplicitBadRemove_2686
+    SCTeamImplicitBadRemove_2686,
+    SCTeamKeyMaskNotFound_2697
   }
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -258,6 +258,7 @@ export const ConstantsStatusCode = {
   scteambadadminseqnotype: 2684,
   scteamimplicitbadadd: 2685,
   scteamimplicitbadremove: 2686,
+  scteamkeymasknotfound: 2697,
 }
 
 export const CtlDbType = {
@@ -4582,6 +4583,7 @@ export type StatusCode =
   | 2684 // SCTeamBadAdminSeqnoType_2684
   | 2685 // SCTeamImplicitBadAdd_2685
   | 2686 // SCTeamImplicitBadRemove_2686
+  | 2697 // SCTeamKeyMaskNotFound_2697
 
 export type Stream = {
   fd: int,

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -133,7 +133,8 @@
         "SCTeamImplicitNotFound_2683",
         "SCTeamBadAdminSeqnoType_2684",
         "SCTeamImplicitBadAdd_2685",
-        "SCTeamImplicitBadRemove_2686"
+        "SCTeamImplicitBadRemove_2686",
+        "SCTeamKeyMaskNotFound_2697"
       ]
     }
   ],

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -258,6 +258,7 @@ export const ConstantsStatusCode = {
   scteambadadminseqnotype: 2684,
   scteamimplicitbadadd: 2685,
   scteamimplicitbadremove: 2686,
+  scteamkeymasknotfound: 2697,
 }
 
 export const CtlDbType = {
@@ -4582,6 +4583,7 @@ export type StatusCode =
   | 2684 // SCTeamBadAdminSeqnoType_2684
   | 2685 // SCTeamImplicitBadAdd_2685
   | 2686 // SCTeamImplicitBadRemove_2686
+  | 2697 // SCTeamKeyMaskNotFound_2697
 
 export type Stream = {
   fd: int,


### PR DESCRIPTION
With this patch, implied admin trying to create a channel gets this:

```
> kbcl -d=0 chat create-channel haaa.sub hhoohh
Failed to create the channel "hhoohh"

To edit haaa.sub's channels, you must join the team.
Try `keybase team add-member haaa.sub --user=wool --role=admin`

```

Also, this fixes bug where creator of subteam tries (and fails) to send a chat notification after the team is created.

And some general cleanup of this command...