### PR TITLE
Redirect folder accesses to Folders tab when KBFS isn't enabled

### DIFF
--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -155,10 +155,19 @@ const commonFolders = {
   onChat: tlf => console.log(`open chat with tlf ${tlf}`),
   onToggleShowIgnored,
   username: 'cecileb',
-  private: {tlfs, ignored, isPublic: false, parentProps, onToggleShowIgnored, showIgnored: true},
+  private: {
+    tlfs,
+    ignored,
+    installed: true,
+    isPublic: false,
+    parentProps,
+    onToggleShowIgnored,
+    showIgnored: true,
+  },
   public: {
     tlfs: [f2, f3, f4, f5],
     ignored,
+    installed: true,
     isPublic: true,
     privateBadge: 1,
     publicBadge: 222,
@@ -305,6 +314,7 @@ const filesMenuItems = [
 const commonFiles = (isPrivate): FilesProps => ({
   theme: isPrivate ? 'private' : 'public',
   ignored: false,
+  installed: true,
   allowIgnore: true,
   hasReadOnlyUsers: false,
   visiblePopupMenu: false,

--- a/shared/folders/index.desktop.js
+++ b/shared/folders/index.desktop.js
@@ -53,6 +53,7 @@ class FoldersRender extends Component<Props> {
       onOpen: this.props.onOpen,
       onChat: this.props.onChat,
       onClick: this.props.onClick,
+      installed: this.props.installed,
     }
 
     return (
@@ -68,7 +69,9 @@ class FoldersRender extends Component<Props> {
         <TabBar
           styleTabBar={{
             ...tabBarStyle,
-            backgroundColor: globalColors.white,
+            backgroundColor: !this.props.smallMode && !this.props.installed
+              ? globalColors.grey
+              : globalColors.white,
             minHeight: this.props.smallMode ? 32 : 48,
           }}
         >

--- a/shared/folders/index.js.flow
+++ b/shared/folders/index.js.flow
@@ -19,6 +19,7 @@ export type Props = {
   onRekey: (path: string) => void,
   onToggleShowIgnored: () => void,
   showSecurityPrefs?: boolean,
+  installed: boolean,
 }
 
 export default class Render extends React.Component<Props> {}

--- a/shared/folders/install/banner-install.js
+++ b/shared/folders/install/banner-install.js
@@ -47,7 +47,7 @@ class InstallBanner extends Component<Props, void> {
 const stylesContainer = {
   ...globalStyles.flexBoxRow,
   alignItems: 'center',
-  backgroundColor: globalColors.blue,
+  backgroundColor: globalColors.red,
   height: 56,
   justifyContent: 'center',
   minHeight: 56,

--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -36,6 +36,7 @@ const Ignored = ({rows, showIgnored, styles, onToggle, isPublic, onClick}) => {
 
 const Rows = ({
   tlfs = [],
+  installed,
   isIgnored,
   isPublic,
   onOpen,
@@ -53,6 +54,7 @@ const Rows = ({
           isPublic={isPublic}
           hasReadOnlyUsers={tlf.users && some(tlf.users, 'readOnly')}
           ignored={isIgnored}
+          installed={installed}
           onChat={onChat}
           onClick={onClick}
           onRekey={onRekey}

--- a/shared/folders/list.js.flow
+++ b/shared/folders/list.js.flow
@@ -7,6 +7,7 @@ export type Folder = ConstantsFolder
 export type Props = {
   tlfs?: Array<Folder>,
   ignored?: Array<Folder>,
+  installed: boolean,
   isPublic: boolean,
   style?: any,
   smallMode?: boolean,

--- a/shared/folders/row.desktop.js
+++ b/shared/folders/row.desktop.js
@@ -82,6 +82,7 @@ const RowMeta = ({ignored, meta, styles}) => {
 
 type RowType = {
   hasReadOnlyUsers: boolean,
+  installed: boolean,
   smallMode: boolean,
   sortName: string,
   onOpen: (path: string) => void,
@@ -95,6 +96,7 @@ const Row = ({
   isPublic,
   hasReadOnlyUsers,
   ignored,
+  installed,
   meta,
   modified,
   smallMode,
@@ -131,7 +133,7 @@ const Row = ({
   const containerStyle = {
     ...styles.rowContainer,
     minHeight: smallMode ? 40 : 48,
-    backgroundColor: globalColors.white,
+    backgroundColor: !smallMode && !installed ? globalColors.grey : globalColors.white,
   }
 
   return (


### PR DESCRIPTION
@keybase/react-hackers 

* If someone clicks on a "Show in Finder" link and KBFS isn't enabled, send them to the root of the Folders tab

* In the Folders tab, if KBFS isn't enabled, show the banner with a red background instead of blue, and grey out the folders list.