### PR TITLE
Return ProvisionFailedOfflineError instead of APINetError

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -116,6 +116,13 @@ func (e *loginProvision) Run(ctx *Context) error {
 	if err := e.route(ctx); err != nil {
 		// cleanup state because there was an error:
 		e.cleanup()
+
+		switch err.(type) {
+		case libkb.APINetError:
+			e.G().Log.Debug("provision failed with an APINetError: %s, returning ProvisionFailedOfflineError", err)
+			return libkb.ProvisionFailedOfflineError{}
+		}
+
 		return err
 	}
 

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -213,6 +213,7 @@ const (
 	SCDevicePrevProvisioned    = int(keybase1.StatusCode_SCDevicePrevProvisioned)
 	SCDeviceProvisionViaDevice = int(keybase1.StatusCode_SCDeviceProvisionViaDevice)
 	SCDeviceNoProvision        = int(keybase1.StatusCode_SCDeviceNoProvision)
+	SCDeviceProvisionOffline   = int(keybase1.StatusCode_SCDeviceProvisionOffline)
 	SCStreamExists             = int(keybase1.StatusCode_SCStreamExists)
 	SCStreamNotFound           = int(keybase1.StatusCode_SCStreamNotFound)
 	SCStreamWrongKind          = int(keybase1.StatusCode_SCStreamWrongKind)

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2117,3 +2117,9 @@ func (e KeyMaskNotFoundError) Error() string {
 	}
 	return msg
 }
+
+type ProvisionFailedOfflineError struct{}
+
+func (e ProvisionFailedOfflineError) Error() string {
+	return "Device provisioning failed because the device is offline"
+}

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -597,6 +597,8 @@ func ImportStatusAsError(s *keybase1.Status) error {
 			}
 		}
 		return e
+	case SCDeviceProvisionOffline:
+		return ProvisionFailedOfflineError{}
 
 	default:
 		ase := AppStatusError{
@@ -2053,5 +2055,13 @@ func (e KeyMaskNotFoundError) ToStatus() keybase1.Status {
 			{Key: "App", Value: strconv.Itoa(int(e.App))},
 			{Key: "Gen", Value: strconv.Itoa(int(e.Gen))},
 		},
+	}
+}
+
+func (e ProvisionFailedOfflineError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCDeviceProvisionOffline,
+		Name: "SC_DEVICE_PROVISION_OFFLINE",
+		Desc: e.Error(),
 	}
 }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -69,6 +69,7 @@ const (
 	StatusCode_SCDeviceProvisionViaDevice  StatusCode = 1415
 	StatusCode_SCRevokeCurrentDevice       StatusCode = 1416
 	StatusCode_SCRevokeLastDevice          StatusCode = 1417
+	StatusCode_SCDeviceProvisionOffline    StatusCode = 1418
 	StatusCode_SCStreamExists              StatusCode = 1501
 	StatusCode_SCStreamNotFound            StatusCode = 1502
 	StatusCode_SCStreamWrongKind           StatusCode = 1503
@@ -203,6 +204,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCDeviceProvisionViaDevice":  1415,
 	"SCRevokeCurrentDevice":       1416,
 	"SCRevokeLastDevice":          1417,
+	"SCDeviceProvisionOffline":    1418,
 	"SCStreamExists":              1501,
 	"SCStreamNotFound":            1502,
 	"SCStreamWrongKind":           1503,
@@ -335,6 +337,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	1415: "SCDeviceProvisionViaDevice",
 	1416: "SCRevokeCurrentDevice",
 	1417: "SCRevokeLastDevice",
+	1418: "SCDeviceProvisionOffline",
 	1501: "SCStreamExists",
 	1502: "SCStreamNotFound",
 	1503: "SCStreamWrongKind",

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -61,6 +61,7 @@ protocol constants {
     SCDeviceProvisionViaDevice_1415,
     SCRevokeCurrentDevice_1416,
     SCRevokeLastDevice_1417,
+    SCDeviceProvisionOffline_1418,
     SCStreamExists_1501,
     SCStreamNotFound_1502,
     SCStreamWrongKind_1503,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -189,6 +189,7 @@ export const ConstantsStatusCode = {
   scdeviceprovisionviadevice: 1415,
   screvokecurrentdevice: 1416,
   screvokelastdevice: 1417,
+  scdeviceprovisionoffline: 1418,
   scstreamexists: 1501,
   scstreamnotfound: 1502,
   scstreamwrongkind: 1503,
@@ -4533,6 +4534,7 @@ export type StatusCode =
   | 1415 // SCDeviceProvisionViaDevice_1415
   | 1416 // SCRevokeCurrentDevice_1416
   | 1417 // SCRevokeLastDevice_1417
+  | 1418 // SCDeviceProvisionOffline_1418
   | 1501 // SCStreamExists_1501
   | 1502 // SCStreamNotFound_1502
   | 1503 // SCStreamWrongKind_1503

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -65,6 +65,7 @@
         "SCDeviceProvisionViaDevice_1415",
         "SCRevokeCurrentDevice_1416",
         "SCRevokeLastDevice_1417",
+        "SCDeviceProvisionOffline_1418",
         "SCStreamExists_1501",
         "SCStreamNotFound_1502",
         "SCStreamWrongKind_1503",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -189,6 +189,7 @@ export const ConstantsStatusCode = {
   scdeviceprovisionviadevice: 1415,
   screvokecurrentdevice: 1416,
   screvokelastdevice: 1417,
+  scdeviceprovisionoffline: 1418,
   scstreamexists: 1501,
   scstreamnotfound: 1502,
   scstreamwrongkind: 1503,
@@ -4533,6 +4534,7 @@ export type StatusCode =
   | 1415 // SCDeviceProvisionViaDevice_1415
   | 1416 // SCRevokeCurrentDevice_1416
   | 1417 // SCRevokeLastDevice_1417
+  | 1418 // SCDeviceProvisionOffline_1418
   | 1501 // SCStreamExists_1501
   | 1502 // SCStreamNotFound_1502
   | 1503 // SCStreamWrongKind_1503


### PR DESCRIPTION
I tested this with real devices and in all offline cases, the error that came back from LoginProvision was an APINetError.  So this transforms that error to a new one, ProvisionFailedOffline, which is properly exported across RPC calls.  

Frontend could handle it and show a nice error screen.  At the very least, the user will now see "Device provisioning failed because the device is offline" instead of the current mess.

cc @chrisnojima @keybase/react-hackers 
