### PR TITLE
add delete conversation local RPC and CLI command CORE-5962

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -261,6 +261,12 @@ func (f failingRemote) LeaveConversation(ctx context.Context, convID chat1.Conve
 	require.Fail(f.t, "LeaveConversation")
 	return chat1.JoinLeaveConversationRemoteRes{}, nil
 }
+
+func (f failingRemote) DeleteConversation(ctx context.Context, convID chat1.ConversationID) (chat1.DeleteConversationRemoteRes, error) {
+	require.Fail(f.t, "DeleteConversation")
+	return chat1.DeleteConversationRemoteRes{}, nil
+}
+
 func (f failingRemote) RemoteNotificationSuccessful(ctx context.Context,
 	arg chat1.RemoteNotificationSuccessfulArg) error {
 	require.Fail(f.t, "RemoteNotificationSuccessful")

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2127,6 +2127,33 @@ func (h *Server) LeaveConversationLocal(ctx context.Context, convID chat1.Conver
 	return res, nil
 }
 
+func (h *Server) DeleteConversationLocal(ctx context.Context, convID chat1.ConversationID) (res chat1.DeleteConversationLocalRes, err error) {
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
+		&identBreaks, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("DeleteConversation(%s)", convID))()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
+	defer func() {
+		if res.Offline {
+			h.Debug(ctx, "DeleteConversationLocal: result obtained offline")
+		}
+	}()
+	_, err = h.assertLoggedInUID(ctx)
+	if err != nil {
+		return res, err
+	}
+
+	delRes, err := h.remoteClient().DeleteConversation(ctx, convID)
+	if err != nil {
+		return res, err
+	}
+	if delRes.RateLimit != nil {
+		res.RateLimits = []chat1.RateLimit{*delRes.RateLimit}
+	}
+	res.Offline = h.G().InboxSource.IsOffline(ctx)
+	return res, nil
+}
+
 func (h *Server) GetTLFConversationsLocal(ctx context.Context, arg chat1.GetTLFConversationsLocalArg) (res chat1.GetTLFConversationsLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI,

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2149,7 +2149,7 @@ func (h *Server) DeleteConversationLocal(ctx context.Context, arg chat1.DeleteCo
 		Channel:   arg.ChannelName,
 	})
 	if err != nil {
-		return res, nil
+		return res, err
 	}
 	if !confirmed {
 		return res, errors.New("channel delete unconfirmed")

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2980,5 +2980,10 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 		consumeTeamType(t, listener0)
 		consumeTeamType(t, listener1)
 
+		iboxRes, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxAndUnboxLocal(ctx,
+			chat1.GetInboxAndUnboxLocalArg{})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(iboxRes.Conversations))
+		require.Equal(t, conv.Id, iboxRes.Conversations[0].GetConvID())
 	})
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2065,12 +2065,6 @@ func TestChatSrvGetInboxNonblockError(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no threads stale message received")
 		}
-		select {
-		case cids := <-listener.threadsStale:
-			require.Zero(t, len(cids))
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "no thread stale msg")
-		}
 
 		rquery, _, err := g.InboxSource.GetInboxQueryLocalToRemote(context.TODO(), query)
 		require.NoError(t, err)

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -305,6 +305,11 @@ func (i *Inbox) applyQuery(ctx context.Context, query *chat1.GetInboxQuery, conv
 	for _, conv := range convs {
 		ok := true
 
+		// Existence check
+		if conv.Metadata.Existence != chat1.ConversationExistence_ACTIVE {
+			ok = false
+		}
+
 		// Member status check
 		switch conv.ReaderInfo.Status {
 		case chat1.ConversationMemberStatus_ACTIVE, chat1.ConversationMemberStatus_PREVIEW:

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -232,6 +232,12 @@ func (s *Syncer) shouldDoFullReloadFromIncremental(ctx context.Context, syncRes 
 		return true
 	}
 	for _, conv := range convs {
+		switch conv.Metadata.Existence {
+		case chat1.ConversationExistence_ACTIVE:
+		default:
+			s.Debug(ctx, "shouldDoFullReloadFromIncremental: deleted conversation: %s", conv.GetConvID())
+			return true
+		}
 		switch conv.ReaderInfo.Status {
 		case chat1.ConversationMemberStatus_LEFT, chat1.ConversationMemberStatus_REMOVED:
 			s.Debug(ctx, "shouldDoFullReloadFromIncremental: join or leave conv")

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -92,7 +92,6 @@ func (s *Syncer) sendNotificationsOnce() {
 		for uid := range s.fullReload {
 			s.Debug(context.Background(), "flushing full reload: uid: %s", uid)
 			s.G().NotifyRouter.HandleChatInboxStale(context.Background(), keybase1.UID(uid))
-			s.G().NotifyRouter.HandleChatThreadsStale(context.Background(), keybase1.UID(uid), nil)
 		}
 		s.fullReload = make(map[string]bool)
 

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -117,12 +117,6 @@ func TestSyncerConnected(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no inbox stale received")
 	}
-	select {
-	case cids := <-list.threadsStale:
-		require.Zero(t, len(cids))
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no threads stale received")
-	}
 	_, _, err := ibox.ReadAll(ctx)
 	require.Error(t, err)
 	require.IsType(t, storage.MissError{}, err)
@@ -192,12 +186,6 @@ func TestSyncerConnected(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no inbox stale received")
 	}
-	select {
-	case cids := <-list.threadsStale:
-		require.Zero(t, len(cids))
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no threads stale received")
-	}
 	_, _, err = ibox.ReadAll(ctx)
 	require.Error(t, err)
 	require.IsType(t, storage.MissError{}, err)
@@ -214,7 +202,7 @@ func TestSyncerConnected(t *testing.T) {
 	require.Equal(t, 5, srvVers)
 }
 
-func TestSyncerLeaveConversation(t *testing.T) {
+func TestSyncerAdHocFullReload(t *testing.T) {
 	ctx, world, ri2, _, sender, list := setupTest(t, 1)
 	defer world.Cleanup()
 
@@ -226,6 +214,7 @@ func TestSyncerLeaveConversation(t *testing.T) {
 	syncer.isConnected = true
 
 	conv := newConv(ctx, t, tc, uid, ri, sender, u.Username)
+	t.Logf("convID: %s", conv.GetConvID())
 	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
 		conv.ReaderInfo.Status = chat1.ConversationMemberStatus_LEFT
 		return chat1.NewSyncInboxResWithIncremental(chat1.SyncIncrementalRes{
@@ -239,24 +228,25 @@ func TestSyncerLeaveConversation(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no inbox stale")
 	}
-}
 
-func TestSyncerTeamType(t *testing.T) {
-	ctx, world, ri2, _, sender, list := setupTest(t, 1)
-	defer world.Cleanup()
-
-	ri := ri2.(*kbtest.ChatRemoteMock)
-	u := world.GetUsers()[0]
-	uid := u.User.GetUID().ToBytes()
-	tc := world.Tcs[u.Username]
-	syncer := NewSyncer(tc.Context())
-	syncer.isConnected = true
-
-	conv := newConv(ctx, t, tc, uid, ri, sender, u.Username)
 	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
 		conv.Metadata.TeamType = chat1.TeamType_COMPLEX
 		return chat1.NewSyncInboxResWithIncremental(chat1.SyncIncrementalRes{
-			Vers:  100,
+			Vers:  101,
+			Convs: []chat1.Conversation{conv},
+		}), nil
+	}
+	doSync(t, syncer, ri, uid)
+	select {
+	case <-list.inboxStale:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no inbox stale")
+	}
+
+	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
+		conv.Metadata.Existence = chat1.ConversationExistence_DELETED
+		return chat1.NewSyncInboxResWithIncremental(chat1.SyncIncrementalRes{
+			Vers:  102,
 			Convs: []chat1.Conversation{conv},
 		}), nil
 	}
@@ -316,12 +306,6 @@ func TestSyncerAppState(t *testing.T) {
 	}
 
 	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
-	select {
-	case cids := <-list.threadsStale:
-		require.Zero(t, len(cids))
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no stale messages")
-	}
 	select {
 	case <-list.inboxStale:
 	case <-time.After(20 * time.Second):

--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	"golang.org/x/net/context"
 
@@ -121,4 +122,16 @@ func (c *ChatUI) ChatThreadCached(ctx context.Context, arg chat1.ChatThreadCache
 
 func (c *ChatUI) ChatThreadFull(ctx context.Context, arg chat1.ChatThreadFullArg) error {
 	return nil
+}
+
+func (c *ChatUI) ChatConfirmChannelDelete(ctx context.Context, arg chat1.ChatConfirmChannelDeleteArg) (bool, error) {
+	term := c.G().UI.GetTerminalUI()
+	term.Printf("WARNING: This will destroy this chat channel and remove it from all members' inbox\n\n")
+	confirm := fmt.Sprintf("nuke %s", arg.Channel)
+	response, err := term.Prompt(PromptDescriptorDeleteRootTeam,
+		fmt.Sprintf("** if you are sure, please type: %q > ", confirm))
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(response) == confirm, nil
 }

--- a/go/client/cmd_chat.go
+++ b/go/client/cmd_chat.go
@@ -16,6 +16,7 @@ func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 		ArgumentHelp: "[arguments...]",
 		Subcommands: []cli.Command{
 			newCmdChatAPI(cl, g),
+			newCmdChatDeleteChannel(cl, g),
 			newCmdChatDownload(cl, g),
 			newCmdChatHide(cl, g),
 			newCmdChatJoinChannel(cl, g),

--- a/go/client/cmd_chat_delete_channel.go
+++ b/go/client/cmd_chat_delete_channel.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type CmdChatDeleteChannel struct {
+	libkb.Contextified
+
+	resolvingRequest chatConversationResolvingRequest
+}
+
+func NewCmdChatDeleteChannelRunner(g *libkb.GlobalContext) *CmdChatDeleteChannel {
+	return &CmdChatDeleteChannel{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatDeleteChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "delete-channel",
+		Usage:        "Delete a conversation channel",
+		ArgumentHelp: "[conversation [channel name]]",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatDeleteChannelRunner(g), "delete-channel", c)
+		},
+		Flags: mustGetChatFlags("topic-type"),
+	}
+}
+
+func (c *CmdChatDeleteChannel) Run() error {
+	chatClient, err := GetChatLocalClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	resolver := &chatConversationResolver{G: c.G(), ChatClient: chatClient}
+	conv, _, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
+		CreateIfNotExists: false,
+		MustNotExist:      false,
+		Interactive:       false,
+		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = chatClient.DeleteConversationLocal(ctx, conv.GetConvID())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CmdChatDeleteChannel) ParseArgv(ctx *cli.Context) (err error) {
+	if len(ctx.Args()) != 2 {
+		cli.ShowCommandHelp(ctx, "delete-channel")
+		return fmt.Errorf("Incorrect usage.")
+	}
+	teamName := ctx.Args().Get(0)
+	topicName := ctx.Args().Get(1)
+
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, teamName); err != nil {
+		return err
+	}
+
+	// Force team for now
+	c.resolvingRequest.MembersType = chat1.ConversationMembersType_TEAM
+	c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
+	c.resolvingRequest.TopicName = utils.SanitizeTopicName(topicName)
+
+	return nil
+}
+
+func (c *CmdChatDeleteChannel) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -857,3 +857,7 @@ func (c *ChatUI) ChatThreadFull(ctx context.Context, arg chat1.ChatThreadFullArg
 	}
 	return nil
 }
+
+func (c *ChatUI) ChatConfirmChannelDelete(ctx context.Context, arg chat1.ChatConfirmChannelDeleteArg) (bool, error) {
+	return true, nil
+}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -668,6 +668,10 @@ func (m *ChatRemoteMock) LeaveConversation(ctx context.Context, convID chat1.Con
 	return chat1.JoinLeaveConversationRemoteRes{}, nil
 }
 
+func (m *ChatRemoteMock) DeleteConversation(ctx context.Context, convID chat1.ConversationID) (chat1.DeleteConversationRemoteRes, error) {
+	return chat1.DeleteConversationRemoteRes{}, nil
+}
+
 type convByNewlyUpdated struct {
 	mock *ChatRemoteMock
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -355,6 +355,7 @@ type ChatUI interface {
 	ChatInboxFailed(context.Context, chat1.ChatInboxFailedArg) error
 	ChatThreadCached(context.Context, chat1.ChatThreadCachedArg) error
 	ChatThreadFull(context.Context, chat1.ChatThreadFullArg) error
+	ChatConfirmChannelDelete(context.Context, chat1.ChatConfirmChannelDeleteArg) (bool, error)
 }
 
 type PromptDefault int

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -626,6 +626,18 @@ func (o ChatThreadFullArg) DeepCopy() ChatThreadFullArg {
 	}
 }
 
+type ChatConfirmChannelDeleteArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Channel   string `codec:"channel" json:"channel"`
+}
+
+func (o ChatConfirmChannelDeleteArg) DeepCopy() ChatConfirmChannelDeleteArg {
+	return ChatConfirmChannelDeleteArg{
+		SessionID: o.SessionID,
+		Channel:   o.Channel,
+	}
+}
+
 type ChatUiInterface interface {
 	ChatAttachmentUploadOutboxID(context.Context, ChatAttachmentUploadOutboxIDArg) error
 	ChatAttachmentUploadStart(context.Context, ChatAttachmentUploadStartArg) error
@@ -641,6 +653,7 @@ type ChatUiInterface interface {
 	ChatInboxFailed(context.Context, ChatInboxFailedArg) error
 	ChatThreadCached(context.Context, ChatThreadCachedArg) error
 	ChatThreadFull(context.Context, ChatThreadFullArg) error
+	ChatConfirmChannelDelete(context.Context, ChatConfirmChannelDeleteArg) (bool, error)
 }
 
 func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
@@ -871,6 +884,22 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodNotify,
 			},
+			"chatConfirmChannelDelete": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatConfirmChannelDeleteArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatConfirmChannelDeleteArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatConfirmChannelDeleteArg)(nil), args)
+						return
+					}
+					ret, err = i.ChatConfirmChannelDelete(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -950,5 +979,10 @@ func (c ChatUiClient) ChatThreadCached(ctx context.Context, __arg ChatThreadCach
 
 func (c ChatUiClient) ChatThreadFull(ctx context.Context, __arg ChatThreadFullArg) (err error) {
 	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatThreadFull", []interface{}{__arg})
+	return
+}
+
+func (c ChatUiClient) ChatConfirmChannelDelete(ctx context.Context, __arg ChatConfirmChannelDeleteArg) (res bool, err error) {
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatConfirmChannelDelete", []interface{}{__arg}, &res)
 	return
 }

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -105,6 +105,35 @@ func (o TopicNameState) DeepCopy() TopicNameState {
 	})(o)
 }
 
+type ConversationExistence int
+
+const (
+	ConversationExistence_ACTIVE   ConversationExistence = 0
+	ConversationExistence_ARCHIVED ConversationExistence = 1
+	ConversationExistence_DELETED  ConversationExistence = 2
+)
+
+func (o ConversationExistence) DeepCopy() ConversationExistence { return o }
+
+var ConversationExistenceMap = map[string]ConversationExistence{
+	"ACTIVE":   0,
+	"ARCHIVED": 1,
+	"DELETED":  2,
+}
+
+var ConversationExistenceRevMap = map[ConversationExistence]string{
+	0: "ACTIVE",
+	1: "ARCHIVED",
+	2: "DELETED",
+}
+
+func (e ConversationExistence) String() string {
+	if v, ok := ConversationExistenceRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type ConversationMembersType int
 
 const (
@@ -460,6 +489,7 @@ type GetInboxQuery struct {
 	OneChatTypePerTLF *bool                      `codec:"oneChatTypePerTLF,omitempty" json:"oneChatTypePerTLF,omitempty"`
 	Status            []ConversationStatus       `codec:"status" json:"status"`
 	MemberStatus      []ConversationMemberStatus `codec:"memberStatus" json:"memberStatus"`
+	Existences        []ConversationExistence    `codec:"existences" json:"existences"`
 	ConvIDs           []ConversationID           `codec:"convIDs" json:"convIDs"`
 	UnreadOnly        bool                       `codec:"unreadOnly" json:"unreadOnly"`
 	ReadOnly          bool                       `codec:"readOnly" json:"readOnly"`
@@ -534,6 +564,14 @@ func (o GetInboxQuery) DeepCopy() GetInboxQuery {
 			}
 			return ret
 		})(o.MemberStatus),
+		Existences: (func(x []ConversationExistence) []ConversationExistence {
+			var ret []ConversationExistence
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Existences),
 		ConvIDs: (func(x []ConversationID) []ConversationID {
 			var ret []ConversationID
 			for _, v := range x {
@@ -596,6 +634,7 @@ type ConversationMetadata struct {
 	Status         ConversationStatus        `codec:"status" json:"status"`
 	MembersType    ConversationMembersType   `codec:"membersType" json:"membersType"`
 	TeamType       TeamType                  `codec:"teamType" json:"teamType"`
+	Existence      ConversationExistence     `codec:"existence" json:"existence"`
 	FinalizeInfo   *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
 	Supersedes     []ConversationMetadata    `codec:"supersedes" json:"supersedes"`
 	SupersededBy   []ConversationMetadata    `codec:"supersededBy" json:"supersededBy"`
@@ -611,6 +650,7 @@ func (o ConversationMetadata) DeepCopy() ConversationMetadata {
 		Status:         o.Status.DeepCopy(),
 		MembersType:    o.MembersType.DeepCopy(),
 		TeamType:       o.TeamType.DeepCopy(),
+		Existence:      o.Existence.DeepCopy(),
 		FinalizeInfo: (func(x *ConversationFinalizeInfo) *ConversationFinalizeInfo {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -680,3 +680,10 @@ func AllConversationMemberStatuses() (res []ConversationMemberStatus) {
 	}
 	return res
 }
+
+func AllConversationExistences() (res []ConversationExistence) {
+	for existence := range ConversationExistenceRevMap {
+		res = append(res, existence)
+	}
+	return res
+}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -638,6 +638,10 @@ func (r *SetAppNotificationSettingsLocalRes) SetOffline() {
 	r.Offline = true
 }
 
+func (r *DeleteConversationLocalRes) SetOffline() {
+	r.Offline = true
+}
+
 func (t TyperInfo) String() string {
 	return fmt.Sprintf("typer(u:%s d:%s)", t.Username, t.DeviceName)
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2022,6 +2022,7 @@ type ConversationInfoLocal struct {
 	Status       ConversationStatus        `codec:"status" json:"status"`
 	MembersType  ConversationMembersType   `codec:"membersType" json:"membersType"`
 	TeamType     TeamType                  `codec:"teamType" json:"teamType"`
+	Existence    ConversationExistence     `codec:"existence" json:"existence"`
 	WriterNames  []string                  `codec:"writerNames" json:"writerNames"`
 	ReaderNames  []string                  `codec:"readerNames" json:"readerNames"`
 	FinalizeInfo *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
@@ -2037,6 +2038,7 @@ func (o ConversationInfoLocal) DeepCopy() ConversationInfoLocal {
 		Status:      o.Status.DeepCopy(),
 		MembersType: o.MembersType.DeepCopy(),
 		TeamType:    o.TeamType.DeepCopy(),
+		Existence:   o.Existence.DeepCopy(),
 		WriterNames: (func(x []string) []string {
 			var ret []string
 			for _, v := range x {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3708,12 +3708,16 @@ func (o LeaveConversationLocalArg) DeepCopy() LeaveConversationLocalArg {
 }
 
 type DeleteConversationLocalArg struct {
-	ConvID ConversationID `codec:"convID" json:"convID"`
+	SessionID   int            `codec:"sessionID" json:"sessionID"`
+	ConvID      ConversationID `codec:"convID" json:"convID"`
+	ChannelName string         `codec:"channelName" json:"channelName"`
 }
 
 func (o DeleteConversationLocalArg) DeepCopy() DeleteConversationLocalArg {
 	return DeleteConversationLocalArg{
-		ConvID: o.ConvID.DeepCopy(),
+		SessionID:   o.SessionID,
+		ConvID:      o.ConvID.DeepCopy(),
+		ChannelName: o.ChannelName,
 	}
 }
 
@@ -3832,7 +3836,7 @@ type LocalInterface interface {
 	JoinConversationLocal(context.Context, JoinConversationLocalArg) (JoinLeaveConversationLocalRes, error)
 	JoinConversationByIDLocal(context.Context, ConversationID) (JoinLeaveConversationLocalRes, error)
 	LeaveConversationLocal(context.Context, ConversationID) (JoinLeaveConversationLocalRes, error)
-	DeleteConversationLocal(context.Context, ConversationID) (DeleteConversationLocalRes, error)
+	DeleteConversationLocal(context.Context, DeleteConversationLocalArg) (DeleteConversationLocalRes, error)
 	GetTLFConversationsLocal(context.Context, GetTLFConversationsLocalArg) (GetTLFConversationsLocalRes, error)
 	SetAppNotificationSettingsLocal(context.Context, SetAppNotificationSettingsLocalArg) (SetAppNotificationSettingsLocalRes, error)
 	SetGlobalAppNotificationSettingsLocal(context.Context, map[string]bool) error
@@ -4346,7 +4350,7 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]DeleteConversationLocalArg)(nil), args)
 						return
 					}
-					ret, err = i.DeleteConversationLocal(ctx, (*typedArgs)[0].ConvID)
+					ret, err = i.DeleteConversationLocal(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -4595,8 +4599,7 @@ func (c LocalClient) LeaveConversationLocal(ctx context.Context, convID Conversa
 	return
 }
 
-func (c LocalClient) DeleteConversationLocal(ctx context.Context, convID ConversationID) (res DeleteConversationLocalRes, err error) {
-	__arg := DeleteConversationLocalArg{ConvID: convID}
+func (c LocalClient) DeleteConversationLocal(ctx context.Context, __arg DeleteConversationLocalArg) (res DeleteConversationLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.deleteConversationLocal", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/remote_chat_ui.go
+++ b/go/service/remote_chat_ui.go
@@ -86,3 +86,7 @@ func (r *RemoteChatUI) ChatThreadCached(ctx context.Context, arg chat1.ChatThrea
 func (r *RemoteChatUI) ChatThreadFull(ctx context.Context, arg chat1.ChatThreadFullArg) error {
 	return r.cli.ChatThreadFull(ctx, arg)
 }
+
+func (r *RemoteChatUI) ChatConfirmChannelDelete(ctx context.Context, arg chat1.ChatConfirmChannelDeleteArg) (bool, error) {
+	return r.cli.ChatConfirmChannelDelete(ctx, arg)
+}

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -116,4 +116,6 @@ protocol chatUi {
 
   void chatThreadCached(int sessionID, union { null, string } thread) oneway;
   void chatThreadFull(int sessionID, string thread) oneway;
+
+  boolean chatConfirmChannelDelete(int sessionID, string channel);
 }

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -15,6 +15,12 @@ protocol common {
   @typedef("bytes")  record OutboxID {}
   @typedef("bytes")  record TopicNameState {}
 
+  enum ConversationExistence {
+    ACTIVE_0,
+    ARCHIVED_1,
+    DELETED_2
+  }
+
   enum ConversationMembersType {
     KBFS_0,
     TEAM_1,
@@ -141,6 +147,8 @@ protocol common {
     array<ConversationStatus> status;
     // If left empty, default is to return active and preview status
     array<ConversationMemberStatus> memberStatus;
+    // If left empty, default is active
+    array<ConversationExistence> existences;
 
     // Extended list of conversation IDs to fetch (don't need to set convID, if convID is set then
     // this it will be like appending it to this list)
@@ -177,6 +185,7 @@ protocol common {
     ConversationStatus status;
     ConversationMembersType membersType;
     TeamType teamType;
+    ConversationExistence existence;
 
     // Finalize info for underlying TLF
     union { null, ConversationFinalizeInfo } finalizeInfo;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -355,6 +355,7 @@ protocol local {
     ConversationStatus status;
     ConversationMembersType membersType;
     TeamType teamType;
+    ConversationExistence existence;
 
     // Lists of usernames, always complete, optionally sorted by activity.
     array<string> writerNames;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -663,6 +663,11 @@ protocol local {
   JoinLeaveConversationLocalRes joinConversationLocal(string tlfName, TopicType topicType, keybase1.TLFVisibility visibility, string topicName);
   JoinLeaveConversationLocalRes joinConversationByIDLocal(ConversationID convID);
   JoinLeaveConversationLocalRes leaveConversationLocal(ConversationID convID);
+  record DeleteConversationLocalRes {
+    boolean offline;
+    array<RateLimit> rateLimits;
+  }
+  DeleteConversationLocalRes deleteConversationLocal(ConversationID convID);
 
   record GetTLFConversationsLocalRes {
     array<InboxUIItem> convs;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -667,7 +667,7 @@ protocol local {
     boolean offline;
     array<RateLimit> rateLimits;
   }
-  DeleteConversationLocalRes deleteConversationLocal(ConversationID convID);
+  DeleteConversationLocalRes deleteConversationLocal(int sessionID, ConversationID convID, string channelName);
 
   record GetTLFConversationsLocalRes {
     array<InboxUIItem> convs;

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -226,6 +226,10 @@ protocol remote {
   }
   JoinLeaveConversationRemoteRes joinConversation(ConversationID convID);
   JoinLeaveConversationRemoteRes leaveConversation(ConversationID convID);
+  record DeleteConversationRemoteRes {
+    union { null, RateLimit } rateLimit;
+  }
+  DeleteConversationRemoteRes deleteConversation(ConversationID convID);
 
   record GetTLFConversationsRes {
     array<Conversation> conversations;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2033,6 +2033,10 @@ export type chatUiChatAttachmentUploadStartRpcParam = Exact<{
   placeholderMsgID: MessageID
 }>
 
+export type chatUiChatConfirmChannelDeleteRpcParam = Exact<{
+  channel: string
+}>
+
 export type chatUiChatInboxConversationRpcParam = Exact<{
   conv: InboxUIItem
 }>
@@ -2059,7 +2063,8 @@ export type localCancelPostRpcParam = Exact<{
 }>
 
 export type localDeleteConversationLocalRpcParam = Exact<{
-  convID: ConversationID
+  convID: ConversationID,
+  channelName: string
 }>
 
 export type localDownloadAttachmentLocalRpcParam = Exact<{
@@ -2445,6 +2450,7 @@ export type remoteUpdateTypingRemoteRpcParam = Exact<{
   convID: ConversationID,
   typing: boolean
 }>
+type chatUiChatConfirmChannelDeleteResult = boolean
 type localDeleteConversationLocalResult = DeleteConversationLocalRes
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
@@ -2599,6 +2605,16 @@ export type incomingCallMapType = Exact<{
       thread: string
     }>,
     response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatConfirmChannelDelete'?: (
+    params: Exact<{
+      sessionID: int,
+      channel: string
+    }>,
+    response: {
+      error: RPCErrorHandler,
+      result: (result: chatUiChatConfirmChannelDeleteResult) => void,
+    }
   ) => void,
   'keybase.1.NotifyChat.NewChatActivity'?: (
     params: Exact<{

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -62,6 +62,12 @@ export const ChatUiMessageUnboxedState = {
   placeholder: 4,
 }
 
+export const CommonConversationExistence = {
+  active: 0,
+  archived: 1,
+  deleted: 2,
+}
+
 export const CommonConversationMemberStatus = {
   active: 0,
   removed: 1,
@@ -521,6 +527,14 @@ export function localUpdateTypingRpcPromise (request: (requestCommon & requestEr
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.updateTyping', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function remoteDeleteConversationRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: remoteDeleteConversationResult) => void} & {param: remoteDeleteConversationRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.deleteConversation', request)
+}
+
+export function remoteDeleteConversationRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: remoteDeleteConversationResult) => void} & {param: remoteDeleteConversationRpcParam})): Promise<remoteDeleteConversationResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.deleteConversation', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function remoteGetGlobalAppNotificationSettingsRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: remoteGetGlobalAppNotificationSettingsResult) => void}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getGlobalAppNotificationSettings', request)
 }
@@ -908,6 +922,11 @@ export type ConversationErrorType =
   | 5 // TRANSIENT_5
   | 6 // NONE_6
 
+export type ConversationExistence =
+    0 // ACTIVE_0
+  | 1 // ARCHIVED_1
+  | 2 // DELETED_2
+
 export type ConversationFinalizeInfo = {
   resetUser: string,
   resetDate: string,
@@ -941,6 +960,7 @@ export type ConversationInfoLocal = {
   status: ConversationStatus,
   membersType: ConversationMembersType,
   teamType: TeamType,
+  existence: ConversationExistence,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
   finalizeInfo?: ?ConversationFinalizeInfo,
@@ -982,6 +1002,7 @@ export type ConversationMetadata = {
   status: ConversationStatus,
   membersType: ConversationMembersType,
   teamType: TeamType,
+  existence: ConversationExistence,
   finalizeInfo?: ?ConversationFinalizeInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -1017,6 +1038,10 @@ export type ConversationStatus =
   | 3 // BLOCKED_3
   | 4 // MUTED_4
   | 5 // REPORTED_5
+
+export type DeleteConversationRemoteRes = {
+  rateLimit?: ?RateLimit,
+}
 
 export type DownloadAttachmentLocalRes = {
   offline: boolean,
@@ -1113,6 +1138,7 @@ export type GetInboxQuery = {
   oneChatTypePerTLF?: ?boolean,
   status?: ?Array<ConversationStatus>,
   memberStatus?: ?Array<ConversationMemberStatus>,
+  existences?: ?Array<ConversationExistence>,
   convIDs?: ?Array<ConversationID>,
   unreadOnly: boolean,
   readOnly: boolean,
@@ -2251,6 +2277,10 @@ export type localUpdateTypingRpcParam = Exact<{
   typing: boolean
 }>
 
+export type remoteDeleteConversationRpcParam = Exact<{
+  convID: ConversationID
+}>
+
 export type remoteGetInboxRemoteRpcParam = Exact<{
   vers: InboxVers,
   query?: ?GetInboxQuery,
@@ -2430,6 +2460,7 @@ type localPostTextNonblockResult = PostLocalNonblockRes
 type localSetAppNotificationSettingsLocalResult = SetAppNotificationSettingsLocalRes
 type localSetConversationStatusLocalResult = SetConversationStatusLocalRes
 type localUnboxMobilePushNotificationResult = string
+type remoteDeleteConversationResult = DeleteConversationRemoteRes
 type remoteGetGlobalAppNotificationSettingsResult = GlobalAppNotificationSettings
 type remoteGetInboxRemoteResult = GetInboxRemoteRes
 type remoteGetInboxVersionResult = InboxVers

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -247,6 +247,14 @@ export function localCancelPostRpcPromise (request: (requestCommon & requestErro
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.CancelPost', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localDeleteConversationLocalRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: localDeleteConversationLocalResult) => void} & {param: localDeleteConversationLocalRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.deleteConversationLocal', request)
+}
+
+export function localDeleteConversationLocalRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: localDeleteConversationLocalResult) => void} & {param: localDeleteConversationLocalRpcParam})): Promise<localDeleteConversationLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.deleteConversationLocal', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localDownloadAttachmentLocalRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.DownloadAttachmentLocal', request)
 }
@@ -1038,6 +1046,11 @@ export type ConversationStatus =
   | 3 // BLOCKED_3
   | 4 // MUTED_4
   | 5 // REPORTED_5
+
+export type DeleteConversationLocalRes = {
+  offline: boolean,
+  rateLimits?: ?Array<RateLimit>,
+}
 
 export type DeleteConversationRemoteRes = {
   rateLimit?: ?RateLimit,
@@ -2045,6 +2058,10 @@ export type localCancelPostRpcParam = Exact<{
   outboxID: OutboxID
 }>
 
+export type localDeleteConversationLocalRpcParam = Exact<{
+  convID: ConversationID
+}>
+
 export type localDownloadAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
   messageID: MessageID,
@@ -2428,6 +2445,7 @@ export type remoteUpdateTypingRemoteRpcParam = Exact<{
   convID: ConversationID,
   typing: boolean
 }>
+type localDeleteConversationLocalResult = DeleteConversationLocalRes
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
 type localFindConversationsLocalResult = FindConversationsLocalRes

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -561,6 +561,19 @@
       ],
       "response": null,
       "oneway": true
+    },
+    "chatConfirmChannelDelete": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "channel",
+          "type": "string"
+        }
+      ],
+      "response": "boolean"
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -78,6 +78,15 @@
     },
     {
       "type": "enum",
+      "name": "ConversationExistence",
+      "symbols": [
+        "ACTIVE_0",
+        "ARCHIVED_1",
+        "DELETED_2"
+      ]
+    },
+    {
+      "type": "enum",
       "name": "ConversationMembersType",
       "symbols": [
         "KBFS_0",
@@ -331,6 +340,13 @@
         {
           "type": {
             "type": "array",
+            "items": "ConversationExistence"
+          },
+          "name": "existences"
+        },
+        {
+          "type": {
+            "type": "array",
             "items": "ConversationID"
           },
           "name": "convIDs"
@@ -431,6 +447,10 @@
         {
           "type": "TeamType",
           "name": "teamType"
+        },
+        {
+          "type": "ConversationExistence",
+          "name": "existence"
         },
         {
           "type": [

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1031,6 +1031,10 @@
           "name": "teamType"
         },
         {
+          "type": "ConversationExistence",
+          "name": "existence"
+        },
+        {
           "type": {
             "type": "array",
             "items": "string"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2706,8 +2706,16 @@
     "deleteConversationLocal": {
       "request": [
         {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
           "name": "convID",
           "type": "ConversationID"
+        },
+        {
+          "name": "channelName",
+          "type": "string"
         }
       ],
       "response": "DeleteConversationLocalRes"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1880,6 +1880,23 @@
     },
     {
       "type": "record",
+      "name": "DeleteConversationLocalRes",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "offline"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "GetTLFConversationsLocalRes",
       "fields": [
         {
@@ -2685,6 +2702,15 @@
         }
       ],
       "response": "JoinLeaveConversationLocalRes"
+    },
+    "deleteConversationLocal": {
+      "request": [
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": "DeleteConversationLocalRes"
     },
     "getTLFConversationsLocal": {
       "request": [

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -467,6 +467,19 @@
     },
     {
       "type": "record",
+      "name": "DeleteConversationRemoteRes",
+      "fields": [
+        {
+          "type": [
+            null,
+            "RateLimit"
+          ],
+          "name": "rateLimit"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "GetTLFConversationsRes",
       "fields": [
         {
@@ -879,6 +892,15 @@
         }
       ],
       "response": "JoinLeaveConversationRemoteRes"
+    },
+    "deleteConversation": {
+      "request": [
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": "DeleteConversationRemoteRes"
     },
     "getTLFConversations": {
       "request": [

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2033,6 +2033,10 @@ export type chatUiChatAttachmentUploadStartRpcParam = Exact<{
   placeholderMsgID: MessageID
 }>
 
+export type chatUiChatConfirmChannelDeleteRpcParam = Exact<{
+  channel: string
+}>
+
 export type chatUiChatInboxConversationRpcParam = Exact<{
   conv: InboxUIItem
 }>
@@ -2059,7 +2063,8 @@ export type localCancelPostRpcParam = Exact<{
 }>
 
 export type localDeleteConversationLocalRpcParam = Exact<{
-  convID: ConversationID
+  convID: ConversationID,
+  channelName: string
 }>
 
 export type localDownloadAttachmentLocalRpcParam = Exact<{
@@ -2445,6 +2450,7 @@ export type remoteUpdateTypingRemoteRpcParam = Exact<{
   convID: ConversationID,
   typing: boolean
 }>
+type chatUiChatConfirmChannelDeleteResult = boolean
 type localDeleteConversationLocalResult = DeleteConversationLocalRes
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
@@ -2599,6 +2605,16 @@ export type incomingCallMapType = Exact<{
       thread: string
     }>,
     response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatConfirmChannelDelete'?: (
+    params: Exact<{
+      sessionID: int,
+      channel: string
+    }>,
+    response: {
+      error: RPCErrorHandler,
+      result: (result: chatUiChatConfirmChannelDeleteResult) => void,
+    }
   ) => void,
   'keybase.1.NotifyChat.NewChatActivity'?: (
     params: Exact<{

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -62,6 +62,12 @@ export const ChatUiMessageUnboxedState = {
   placeholder: 4,
 }
 
+export const CommonConversationExistence = {
+  active: 0,
+  archived: 1,
+  deleted: 2,
+}
+
 export const CommonConversationMemberStatus = {
   active: 0,
   removed: 1,
@@ -521,6 +527,14 @@ export function localUpdateTypingRpcPromise (request: (requestCommon & requestEr
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.updateTyping', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function remoteDeleteConversationRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: remoteDeleteConversationResult) => void} & {param: remoteDeleteConversationRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.deleteConversation', request)
+}
+
+export function remoteDeleteConversationRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: remoteDeleteConversationResult) => void} & {param: remoteDeleteConversationRpcParam})): Promise<remoteDeleteConversationResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.deleteConversation', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function remoteGetGlobalAppNotificationSettingsRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: remoteGetGlobalAppNotificationSettingsResult) => void}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getGlobalAppNotificationSettings', request)
 }
@@ -908,6 +922,11 @@ export type ConversationErrorType =
   | 5 // TRANSIENT_5
   | 6 // NONE_6
 
+export type ConversationExistence =
+    0 // ACTIVE_0
+  | 1 // ARCHIVED_1
+  | 2 // DELETED_2
+
 export type ConversationFinalizeInfo = {
   resetUser: string,
   resetDate: string,
@@ -941,6 +960,7 @@ export type ConversationInfoLocal = {
   status: ConversationStatus,
   membersType: ConversationMembersType,
   teamType: TeamType,
+  existence: ConversationExistence,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
   finalizeInfo?: ?ConversationFinalizeInfo,
@@ -982,6 +1002,7 @@ export type ConversationMetadata = {
   status: ConversationStatus,
   membersType: ConversationMembersType,
   teamType: TeamType,
+  existence: ConversationExistence,
   finalizeInfo?: ?ConversationFinalizeInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -1017,6 +1038,10 @@ export type ConversationStatus =
   | 3 // BLOCKED_3
   | 4 // MUTED_4
   | 5 // REPORTED_5
+
+export type DeleteConversationRemoteRes = {
+  rateLimit?: ?RateLimit,
+}
 
 export type DownloadAttachmentLocalRes = {
   offline: boolean,
@@ -1113,6 +1138,7 @@ export type GetInboxQuery = {
   oneChatTypePerTLF?: ?boolean,
   status?: ?Array<ConversationStatus>,
   memberStatus?: ?Array<ConversationMemberStatus>,
+  existences?: ?Array<ConversationExistence>,
   convIDs?: ?Array<ConversationID>,
   unreadOnly: boolean,
   readOnly: boolean,
@@ -2251,6 +2277,10 @@ export type localUpdateTypingRpcParam = Exact<{
   typing: boolean
 }>
 
+export type remoteDeleteConversationRpcParam = Exact<{
+  convID: ConversationID
+}>
+
 export type remoteGetInboxRemoteRpcParam = Exact<{
   vers: InboxVers,
   query?: ?GetInboxQuery,
@@ -2430,6 +2460,7 @@ type localPostTextNonblockResult = PostLocalNonblockRes
 type localSetAppNotificationSettingsLocalResult = SetAppNotificationSettingsLocalRes
 type localSetConversationStatusLocalResult = SetConversationStatusLocalRes
 type localUnboxMobilePushNotificationResult = string
+type remoteDeleteConversationResult = DeleteConversationRemoteRes
 type remoteGetGlobalAppNotificationSettingsResult = GlobalAppNotificationSettings
 type remoteGetInboxRemoteResult = GetInboxRemoteRes
 type remoteGetInboxVersionResult = InboxVers

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -247,6 +247,14 @@ export function localCancelPostRpcPromise (request: (requestCommon & requestErro
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.CancelPost', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localDeleteConversationLocalRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: localDeleteConversationLocalResult) => void} & {param: localDeleteConversationLocalRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.deleteConversationLocal', request)
+}
+
+export function localDeleteConversationLocalRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: localDeleteConversationLocalResult) => void} & {param: localDeleteConversationLocalRpcParam})): Promise<localDeleteConversationLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.deleteConversationLocal', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localDownloadAttachmentLocalRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.DownloadAttachmentLocal', request)
 }
@@ -1038,6 +1046,11 @@ export type ConversationStatus =
   | 3 // BLOCKED_3
   | 4 // MUTED_4
   | 5 // REPORTED_5
+
+export type DeleteConversationLocalRes = {
+  offline: boolean,
+  rateLimits?: ?Array<RateLimit>,
+}
 
 export type DeleteConversationRemoteRes = {
   rateLimit?: ?RateLimit,
@@ -2045,6 +2058,10 @@ export type localCancelPostRpcParam = Exact<{
   outboxID: OutboxID
 }>
 
+export type localDeleteConversationLocalRpcParam = Exact<{
+  convID: ConversationID
+}>
+
 export type localDownloadAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
   messageID: MessageID,
@@ -2428,6 +2445,7 @@ export type remoteUpdateTypingRemoteRpcParam = Exact<{
   convID: ConversationID,
   typing: boolean
 }>
+type localDeleteConversationLocalResult = DeleteConversationLocalRes
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
 type localFindConversationsLocalResult = FindConversationsLocalRes


### PR DESCRIPTION
Patch does the following:

1.) Adds a new local RPC `DeleteConversationLocal` which will delete a specified conv. Will interact with chat UI to confirm with user that they really wanted to do this.
2.) Add sync logic for conversations being deleted, and trigger a full inbox reload message if that is the case.
3.) Add `keybase chat delete-channel <team> <channel>`, and implement CLI chat UI endpoint to drive it.
4.) Remove spurious empty thread stale message on full inbox reload. At some point this was probably necessary, but not anymore (frontend ignores it)
