### PR TITLE
save gpg sigs when we save deb and rpm packages

### DIFF
--- a/packaging/linux/build_and_push_packages.sh
+++ b/packaging/linux/build_and_push_packages.sh
@@ -83,12 +83,14 @@ dot_deb_blobs="$(s3cmd ls -r "s3://$BUCKET_NAME/deb" | awk '{print $4}' | grep '
 for blob in $dot_deb_blobs ; do
   s3cmd modify --remove-header "Cache-Control" "$blob"
   s3cmd cp "$blob" "s3://$BUCKET_NAME/linux_binaries/deb/"
+  s3cmd cp "$blob.sig" "s3://$BUCKET_NAME/linux_binaries/deb/"
 done
 echo Unsetting .rpm Cache-Control headers...
 dot_rpm_blobs="$(s3cmd ls -r "s3://$BUCKET_NAME/rpm" | awk '{print $4}' | grep '\.rpm$')"
 for blob in $dot_rpm_blobs ; do
   s3cmd modify --remove-header "Cache-Control" "$blob"
   s3cmd cp "$blob" "s3://$BUCKET_NAME/linux_binaries/rpm/"
+  s3cmd cp "$blob.sig" "s3://$BUCKET_NAME/linux_binaries/rpm/"
 done
 
 # Make yet another copy of the .deb and .rpm packages we just made, in a
@@ -98,8 +100,6 @@ done
 # do here in the build (x86_64 vs amd64).
 another_copy() {
   s3cmd put --follow-symlinks "$1" "$2"
-  code_signing_fingerprint="$(cat "$here/code_signing_fingerprint")"
-  gpg --detach-sign --armor --use-agent --default-key "$code_signing_fingerprint" -o "$1.sig" "$1"
   s3cmd put --follow-symlinks "$1.sig" "$2.sig"
 }
 another_copy "$build_dir/deb_repo/keybase-latest-amd64.deb" "s3://$BUCKET_NAME/keybase_amd64.deb"

--- a/packaging/linux/rpm/layout_repo.sh
+++ b/packaging/linux/rpm/layout_repo.sh
@@ -67,10 +67,17 @@ for arch in i386 x86_64 ; do
    --define '__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}' \
    --addsign "$rpmcopy" < /dev/null
 
+  # Add a standalone signature file, for user convenience. Other packaging
+  # steps will pick this up and copy it around.
+  code_signing_fingerprint="$(cat "$here/../code_signing_fingerprint")"
+  gpg --detach-sign --armor --use-agent --default-key "$code_signing_fingerprint" \
+      -o "$rpmcopy.sig" "$rpmcopy"
+
   # Update the latest pointer. Even though the RPM repo is split by
   # architecture, put these links at the root of it with the arch in the
   # filename, for consistency with what we're doing in Debian.
   ln -sf "repo/$arch/$rpmname" "$repo_root/$binary_name-latest-$arch.rpm"
+  ln -sf "repo/$arch/$rpmname.sig" "$repo_root/$binary_name-latest-$arch.rpm.sig"
 
   # Run createrepo to update the database files.
   "$CREATEREPO" "$repo_root/repo/$arch"


### PR DESCRIPTION
This has us make GPG standalone sigs earlier in the build process, so we can copy them to more places. See https://keybase.atlassian.net/browse/CORE-5773.

r? @cjb 