### PR TITLE
Clear social invitations when adding a user

### DIFF
--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -138,3 +138,10 @@ func (e *ResolveThenIdentify2) TrackToken() keybase1.TrackToken {
 func (e *ResolveThenIdentify2) ConfirmResult() keybase1.ConfirmResult {
 	return e.i2eng.ConfirmResult()
 }
+
+func (e *ResolveThenIdentify2) GetProofSet() *libkb.ProofSet {
+	if e.i2eng == nil {
+		return nil
+	}
+	return e.i2eng.GetProofSet()
+}

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -390,7 +390,7 @@ func TestImpTeamWithMultipleRooters(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestClearInvitesOnAdd(t *testing.T) {
+func TestClearSocialInvitesOnAdd(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
@@ -422,10 +422,12 @@ func TestClearInvitesOnAdd(t *testing.T) {
 	require.Equal(t, len(writers), 1)
 	require.True(t, writers[0].Uid.Equal(bob.uid))
 
+	// Adding should have cleared bob...@rooter
 	hasInv, err := t0.HasActiveInvite(keybase1.TeamInviteName(bob.username), "rooter")
 	require.NoError(t, err)
 	require.False(t, hasInv)
 
+	// But should not have cleared otherbob...@rooter
 	hasInv, err = t0.HasActiveInvite(keybase1.TeamInviteName(bobBadRooter), "rooter")
 	require.NoError(t, err)
 	require.True(t, hasInv)

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -403,7 +403,10 @@ func TestClearInvitesOnAdd(t *testing.T) {
 
 	t.Logf("Ann created team %q", team)
 
+	bobBadRooter := "other" + bob.username
+
 	ann.addTeamMember(team, bob.username+"@rooter", keybase1.TeamRole_WRITER)
+	ann.addTeamMember(team, bobBadRooter+"@rooter", keybase1.TeamRole_WRITER)
 
 	bob.proveRooter()
 
@@ -422,4 +425,8 @@ func TestClearInvitesOnAdd(t *testing.T) {
 	hasInv, err := t0.HasActiveInvite(keybase1.TeamInviteName(bob.username), "rooter")
 	require.NoError(t, err)
 	require.False(t, hasInv)
+
+	hasInv, err = t0.HasActiveInvite(keybase1.TeamInviteName(bobBadRooter), "rooter")
+	require.NoError(t, err)
+	require.True(t, hasInv)
 }


### PR DESCRIPTION
In a rare case where user is invited via social assertion that is not automatically resolved, clear the old assertions when someone manually adds user as member.

PR is still work in progress, we are waiting for some code in https://github.com/keybase/client/pull/8414 to simplify this.