### PR TITLE
repro chat crash on deleted user

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -67,6 +67,16 @@ func (i *identifyUser) GetName() string {
 	panic("null user")
 }
 
+func (i *identifyUser) GetStatus() keybase1.StatusCode {
+	if i.thin != nil {
+		return i.thin.GetStatus()
+	}
+	if i.full != nil {
+		return i.full.GetStatus()
+	}
+	panic("null user")
+}
+
 func (i *identifyUser) GetNormalizedName() libkb.NormalizedUsername {
 	return libkb.NewNormalizedUsername(i.GetName())
 }
@@ -889,6 +899,9 @@ func (e *Identify2WithUID) loadThem(ctx *Context) (err error) {
 	}
 	if e.them == nil {
 		return libkb.UserNotFoundError{UID: arg.UID, Msg: "in Identify2WithUID"}
+	}
+	if err = libkb.UserErrorFromStatus(e.them.GetStatus()); err != nil {
+		return err
 	}
 	return nil
 }

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2123,3 +2123,18 @@ type ProvisionFailedOfflineError struct{}
 func (e ProvisionFailedOfflineError) Error() string {
 	return "Device provisioning failed because the device is offline"
 }
+
+//=============================================================================
+
+func UserErrorFromStatus(s keybase1.StatusCode) error {
+	switch s {
+	case keybase1.StatusCode_SCOk:
+		return nil
+	case keybase1.StatusCode_SCDeleted:
+		return DeletedError{}
+	default:
+		return &APIError{Code: int(s), Msg: "user status error"}
+	}
+}
+
+//=============================================================================

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -439,7 +439,8 @@ func LoadUserFromServer(ctx context.Context, g *GlobalContext, uid keybase1.UID,
 			Endpoint:    "user/lookup",
 			SessionType: APISessionTypeNONE,
 			Args: HTTPArgs{
-				"uid": UIDArg(uid),
+				"uid":          UIDArg(uid),
+				"load_deleted": B{true},
 			},
 			NetContext: ctx,
 		})

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -436,6 +436,14 @@ func ComputeLoginPackage(lctx LoginContext, username string) (ret PDPKALoginPack
 }
 
 func (s *LoginState) ResetAccount(un string) (err error) {
+	return s.resetOrDelete(un, "nuke")
+}
+
+func (s *LoginState) DeleteAccount(un string) (err error) {
+	return s.resetOrDelete(un, "delete")
+}
+
+func (s *LoginState) resetOrDelete(un string, which string) (err error) {
 	var aerr error
 	err = s.loginHandle(func(lctx LoginContext) error {
 		aerr = lctx.LoadLoginSession(un)
@@ -447,7 +455,7 @@ func (s *LoginState) ResetAccount(un string) (err error) {
 			return aerr
 		}
 		arg := APIArg{
-			Endpoint:    "nuke",
+			Endpoint:    which,
 			SessionType: APISessionTypeREQUIRED,
 			Args:        NewHTTPArgs(),
 			SessionR:    lctx.LocalSession(),
@@ -455,10 +463,10 @@ func (s *LoginState) ResetAccount(un string) (err error) {
 		pdpka.PopulateArgs(&arg.Args)
 		res, aerr := s.G().API.Post(arg)
 		if aerr == nil {
-			s.G().Log.Info("NUKE Result: %+v\n", res.AppStatus)
+			s.G().Log.Info("%s Result: %+v\n", which, res.AppStatus)
 		}
 		return aerr
-	}, nil, "ResetAccount")
+	}, nil, ("ResetAccount:" + which))
 	if aerr != nil {
 		return aerr
 	}

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -692,6 +692,7 @@ func (mc *MerkleClient) lookupPathAndSkipSequenceHelper(ctx context.Context, q H
 	}
 
 	q.Add("poll", I{w})
+	q.Add("load_deleted", B{true})
 
 	// Add the local db sigHints version
 	if sigHints != nil {

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -284,6 +284,7 @@ func (r *Resolver) resolveURLViaServerLookup(ctx context.Context, au AssertionUR
 
 	ha := HTTPArgsFromKeyValuePair(key, S{val})
 	ha.Add("multi", I{1})
+	ha.Add("load_deleted", B{true})
 	fields := "basics"
 	if withBody {
 		fields += ",public_keys,pictures"

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -244,7 +244,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 	// Add a LU= tax to this context, for all subsequent debugging
 	ctx := arg.WithLogTag()
 
-	defer g.CVTrace(ctx, VLog0, culDebug(arg.UID), func() error { return err })()
+	defer g.CVTrace(ctx, VLog0, culDebug(arg.UID)+" "+u.G().GetMyUID().String(), func() error { return err })()
 
 	if arg.UID.IsNil() {
 		if len(arg.Name) == 0 {
@@ -482,6 +482,7 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 // KID, as well as the Key data associated with that KID. It picks the latest such
 // incarnation if there are multiple.
 func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (ret *keybase1.UserPlusKeysV2, key *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
+	defer u.G().CVTrace(ctx, VLog0, fmt.Sprintf("uid:%s,kid:%s", uid, kid), func() error { return err })()
 	if uid.IsNil() {
 		return nil, nil, nil, NoUIDError{}
 	}
@@ -508,6 +509,7 @@ func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid 
 		linkMap = upak.SeqnoLinkIDs
 		ret, key = upak.FindKID(kid)
 		if key != nil {
+			u.G().VDL.CLogf(ctx, VLog0, "- found kid in UPAK: %v", *ret)
 			break
 		}
 		ret = nil

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -84,7 +84,7 @@ func (u *CachedUPAKLoader) ClearMemory() {
 	u.m = make(map[string]*keybase1.UserPlusKeysV2AllIncarnations)
 }
 
-const UPK2MinorVersionCurrent = keybase1.UPK2MinorVersion_V3
+const UPK2MinorVersionCurrent = keybase1.UPK2MinorVersion_V4
 
 func (u *CachedUPAKLoader) getCachedUPAK(ctx context.Context, uid keybase1.UID, info *CachedUserLoadInfo) (*keybase1.UserPlusKeysV2AllIncarnations, bool) {
 

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -33,6 +33,7 @@ type User struct {
 	sigChainMem *SigChain
 	idTable     *IdentityTable
 	sigHints    *SigHints
+	status      keybase1.StatusCode
 
 	leaf MerkleUserLeaf
 
@@ -59,6 +60,10 @@ func NewUser(g *GlobalContext, o *jsonw.Wrapper) (*User, error) {
 	if err != nil {
 		return nil, fmt.Errorf("user object for %s lacks a name", uid)
 	}
+	status, err := o.AtPath("basics.status").GetInt()
+	if err != nil {
+		return nil, fmt.Errorf("user object for %s lacks a status field", uid)
+	}
 
 	kf, err := ParseKeyFamily(g, o.AtKey("public_keys"))
 	if err != nil {
@@ -72,6 +77,7 @@ func NewUser(g *GlobalContext, o *jsonw.Wrapper) (*User, error) {
 		keyFamily:    kf,
 		id:           uid,
 		name:         name,
+		status:       keybase1.StatusCode(status),
 		dirty:        false,
 		Contextified: NewContextified(g),
 	}, nil
@@ -93,6 +99,7 @@ func NewUserFromLocalStorage(g *GlobalContext, o *jsonw.Wrapper) (*User, error) 
 func (u *User) GetNormalizedName() NormalizedUsername { return NewNormalizedUsername(u.name) }
 func (u *User) GetName() string                       { return u.name }
 func (u *User) GetUID() keybase1.UID                  { return u.id }
+func (u *User) GetStatus() keybase1.StatusCode        { return u.status }
 
 func (u *User) GetIDVersion() (int64, error) {
 	return u.basics.AtKey("id_version").GetInt64()

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -596,6 +596,7 @@ type UserPlusKeys struct {
 	Uid               UID               `codec:"uid" json:"uid"`
 	Username          string            `codec:"username" json:"username"`
 	EldestSeqno       Seqno             `codec:"eldestSeqno" json:"eldestSeqno"`
+	Status            StatusCode        `codec:"status" json:"status"`
 	DeviceKeys        []PublicKey       `codec:"deviceKeys" json:"deviceKeys"`
 	RevokedDeviceKeys []RevokedKey      `codec:"revokedDeviceKeys" json:"revokedDeviceKeys"`
 	PGPKeyCount       int               `codec:"pgpKeyCount" json:"pgpKeyCount"`
@@ -609,6 +610,7 @@ func (o UserPlusKeys) DeepCopy() UserPlusKeys {
 		Uid:         o.Uid.DeepCopy(),
 		Username:    o.Username,
 		EldestSeqno: o.EldestSeqno.DeepCopy(),
+		Status:      o.Status.DeepCopy(),
 		DeviceKeys: (func(x []PublicKey) []PublicKey {
 			var ret []PublicKey
 			for _, v := range x {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1086,6 +1086,10 @@ func (u UserPlusKeys) GetName() string {
 	return u.Username
 }
 
+func (u UserPlusKeys) GetStatus() StatusCode {
+	return u.Status
+}
+
 func (u UserPlusAllKeys) GetRemoteTrack(s string) *RemoteTrack {
 	i := sort.Search(len(u.RemoteTracks), func(j int) bool {
 		return u.RemoteTracks[j].Username >= s
@@ -1105,6 +1109,10 @@ func (u UserPlusAllKeys) GetUID() UID {
 
 func (u UserPlusAllKeys) GetName() string {
 	return u.Base.GetName()
+}
+
+func (u UserPlusAllKeys) GetStatus() StatusCode {
+	return u.Base.GetStatus()
 }
 
 func (u UserPlusAllKeys) GetDeviceID(kid KID) (ret DeviceID, err error) {
@@ -1445,6 +1453,7 @@ func UPAKFromUPKV2AI(uV2 UserPlusKeysV2AllIncarnations) UserPlusAllKeys {
 			Uid:               uV2.Current.Uid,
 			Username:          uV2.Current.Username,
 			EldestSeqno:       uV2.Current.EldestSeqno,
+			Status:            uV2.Current.Status,
 			DeviceKeys:        deviceKeysV1,
 			RevokedDeviceKeys: revokedDeviceKeysV1,
 			DeletedDeviceKeys: deletedDeviceKeysV1,

--- a/go/protocol/keybase1/upk.go
+++ b/go/protocol/keybase1/upk.go
@@ -55,6 +55,7 @@ const (
 	UPK2MinorVersion_V1 UPK2MinorVersion = 1
 	UPK2MinorVersion_V2 UPK2MinorVersion = 2
 	UPK2MinorVersion_V3 UPK2MinorVersion = 3
+	UPK2MinorVersion_V4 UPK2MinorVersion = 4
 )
 
 func (o UPK2MinorVersion) DeepCopy() UPK2MinorVersion { return o }
@@ -64,6 +65,7 @@ var UPK2MinorVersionMap = map[string]UPK2MinorVersion{
 	"V1": 1,
 	"V2": 2,
 	"V3": 3,
+	"V4": 4,
 }
 
 var UPK2MinorVersionRevMap = map[UPK2MinorVersion]string{
@@ -71,6 +73,7 @@ var UPK2MinorVersionRevMap = map[UPK2MinorVersion]string{
 	1: "V1",
 	2: "V2",
 	3: "V3",
+	4: "V4",
 }
 
 func (e UPK2MinorVersion) String() string {
@@ -301,6 +304,7 @@ type UserPlusKeysV2 struct {
 	Uid          UID                           `codec:"uid" json:"uid"`
 	Username     string                        `codec:"username" json:"username"`
 	EldestSeqno  Seqno                         `codec:"eldestSeqno" json:"eldestSeqno"`
+	Status       StatusCode                    `codec:"status" json:"status"`
 	PerUserKeys  []PerUserKey                  `codec:"perUserKeys" json:"perUserKeys"`
 	DeviceKeys   map[KID]PublicKeyV2NaCl       `codec:"deviceKeys" json:"deviceKeys"`
 	PGPKeys      map[KID]PublicKeyV2PGPSummary `codec:"pgpKeys" json:"pgpKeys"`
@@ -312,6 +316,7 @@ func (o UserPlusKeysV2) DeepCopy() UserPlusKeysV2 {
 		Uid:         o.Uid.DeepCopy(),
 		Username:    o.Username,
 		EldestSeqno: o.EldestSeqno.DeepCopy(),
+		Status:      o.Status.DeepCopy(),
 		PerUserKeys: (func(x []PerUserKey) []PerUserKey {
 			var ret []PerUserKey
 			for _, v := range x {

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -229,6 +229,21 @@ func (h *UserHandler) ResetUser(ctx context.Context, sessionID int) error {
 	return nil
 }
 
+func (h *UserHandler) DeleteUser(ctx context.Context, sessionID int) error {
+	if h.G().Env.GetRunMode() != libkb.DevelRunMode {
+		return errors.New("can only delete user via service RPC in dev mode")
+	}
+	err := h.G().LoginState().DeleteAccount(h.G().Env.GetUsername().String())
+	if err != nil {
+		return err
+	}
+	err = h.G().Logout()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (h *UserHandler) ProfileEdit(nctx context.Context, arg keybase1.ProfileEditArg) error {
 	eng := engine.NewProfileEdit(h.G(), arg)
 	ctx := &engine.Context{NetContext: nctx}

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -96,6 +96,11 @@ func (d *smuDeviceWrapper) stop() error {
 	return <-d.stopCh
 }
 
+func (d *smuDeviceWrapper) clearUPAKCache() {
+	d.tctx.G.LocalDb.Nuke()
+	d.tctx.G.GetUPAKLoader().ClearMemory()
+}
+
 type smuTerminalUI struct{}
 
 func (t smuTerminalUI) ErrorWriter() io.Writer                                        { return nil }
@@ -475,6 +480,13 @@ func (u *smuUser) reAddUserAfterReset(team smuImplicitTeam, w *smuUser) {
 
 func (u *smuUser) reset() {
 	err := u.primaryDevice().userClient().ResetUser(context.TODO(), 0)
+	if err != nil {
+		u.ctx.t.Fatal(err)
+	}
+}
+
+func (u *smuUser) delete() {
+	err := u.primaryDevice().userClient().DeleteUser(context.TODO(), 0)
 	if err != nil {
 		u.ctx.t.Fatal(err)
 	}

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -207,6 +207,9 @@ protocol Common {
       string username;
       Seqno eldestSeqno;
 
+      // =0 for an active user, and =216 for a deleted user
+      StatusCode status;
+
       // deviceKeys is a list of active device keys.  It does
       // not include PGP keys.
       array<PublicKey> deviceKeys;

--- a/protocol/avdl/keybase1/upk.avdl
+++ b/protocol/avdl/keybase1/upk.avdl
@@ -15,7 +15,8 @@ protocol UPK {
     V0_0,
     V1_1,
     V2_2,
-    V3_3
+    V3_3,
+    V4_4
   }
 
   record MerkleRootV2 {
@@ -77,6 +78,8 @@ protocol UPK {
       UID uid;
       string username;
       Seqno eldestSeqno;
+      // =0 for healty users, and 216 for deleted users
+      StatusCode status;
       // Sorted by generation ascending
       array<PerUserKey> perUserKeys;
       map<KID, PublicKeyV2NaCl> deviceKeys;

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -143,4 +143,7 @@ protocol user {
 
   // resetUser resets the user. Only works in Dev mode since it's so dangerous
   void resetUser(int sessionID);
+  // deleteUser deletes the user. Only works in Dev mode since it's so dangerous
+  void deleteUser(int sessionID);
+
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -621,6 +621,7 @@ export const UPKUPK2MinorVersion = {
   v1: 1,
   v2: 2,
   v3: 3,
+  v4: 4,
 }
 
 export const UiPromptDefault = {
@@ -4964,6 +4965,7 @@ export type UPK2MinorVersion =
   | 1 // V1_1
   | 2 // V2_2
   | 3 // V3_3
+  | 4 // V4_4
 
 export type UnboxAnyRes = {
   kid: KID,
@@ -5020,6 +5022,7 @@ export type UserPlusKeys = {
   uid: UID,
   username: string,
   eldestSeqno: Seqno,
+  status: StatusCode,
   deviceKeys?: ?Array<PublicKey>,
   revokedDeviceKeys?: ?Array<RevokedKey>,
   pgpKeyCount: int,
@@ -5032,6 +5035,7 @@ export type UserPlusKeysV2 = {
   uid: UID,
   username: string,
   eldestSeqno: Seqno,
+  status: StatusCode,
   perUserKeys?: ?Array<PerUserKey>,
   deviceKeys: {[key: string]: PublicKeyV2NaCl},
   pgpKeys: {[key: string]: PublicKeyV2PGPSummary},

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2597,6 +2597,14 @@ export function trackUntrackRpcPromise (request: (requestCommon & requestErrorCa
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.track.untrack', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function userDeleteUserRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.deleteUser', request)
+}
+
+export function userDeleteUserRpcPromise (request: ?(requestCommon & requestErrorCallback)): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.user.deleteUser', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function userInterestingPeopleRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: userInterestingPeopleResult) => void} & {param: userInterestingPeopleRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.interestingPeople', request)
 }

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -493,6 +493,10 @@
           "name": "eldestSeqno"
         },
         {
+          "type": "StatusCode",
+          "name": "status"
+        },
+        {
           "type": {
             "type": "array",
             "items": "PublicKey"

--- a/protocol/json/keybase1/upk.json
+++ b/protocol/json/keybase1/upk.json
@@ -29,7 +29,8 @@
         "V0_0",
         "V1_1",
         "V2_2",
-        "V3_3"
+        "V3_3",
+        "V4_4"
       ]
     },
     {
@@ -237,6 +238,10 @@
         {
           "type": "Seqno",
           "name": "eldestSeqno"
+        },
+        {
+          "type": "StatusCode",
+          "name": "status"
         },
         {
           "type": {

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -549,6 +549,15 @@
         }
       ],
       "response": null
+    },
+    "deleteUser": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -621,6 +621,7 @@ export const UPKUPK2MinorVersion = {
   v1: 1,
   v2: 2,
   v3: 3,
+  v4: 4,
 }
 
 export const UiPromptDefault = {
@@ -4964,6 +4965,7 @@ export type UPK2MinorVersion =
   | 1 // V1_1
   | 2 // V2_2
   | 3 // V3_3
+  | 4 // V4_4
 
 export type UnboxAnyRes = {
   kid: KID,
@@ -5020,6 +5022,7 @@ export type UserPlusKeys = {
   uid: UID,
   username: string,
   eldestSeqno: Seqno,
+  status: StatusCode,
   deviceKeys?: ?Array<PublicKey>,
   revokedDeviceKeys?: ?Array<RevokedKey>,
   pgpKeyCount: int,
@@ -5032,6 +5035,7 @@ export type UserPlusKeysV2 = {
   uid: UID,
   username: string,
   eldestSeqno: Seqno,
+  status: StatusCode,
   perUserKeys?: ?Array<PerUserKey>,
   deviceKeys: {[key: string]: PublicKeyV2NaCl},
   pgpKeys: {[key: string]: PublicKeyV2PGPSummary},

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2597,6 +2597,14 @@ export function trackUntrackRpcPromise (request: (requestCommon & requestErrorCa
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.track.untrack', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function userDeleteUserRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.deleteUser', request)
+}
+
+export function userDeleteUserRpcPromise (request: ?(requestCommon & requestErrorCallback)): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.user.deleteUser', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function userInterestingPeopleRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: userInterestingPeopleResult) => void} & {param: userInterestingPeopleRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.interestingPeople', request)
 }


### PR DESCRIPTION
This test yields the chat failure on a deleted user, where the failure comes as a result of a UPAK load in a team load.  This PR won't pass CI since there's no fix for the bug yet. That fix is a server-fix and a complementary client-side fix.