### PR TITLE
Do not set height of box with progress indicator in devices tab

### DIFF
--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -103,7 +103,7 @@ class Devices extends PureComponent<Props> {
   render() {
     if (this.props.waitingForServer) {
       return (
-        <Box style={{...globalStyles.flexBoxRow, height: 64, justifyContent: 'center'}}>
+        <Box style={{...globalStyles.flexBoxRow, justifyContent: 'center'}}>
           <ProgressIndicator />
         </Box>
       )


### PR DESCRIPTION
Before and after screenshot:
![image](https://user-images.githubusercontent.com/451974/30520321-89dfa994-9bab-11e7-843d-9837d48c4326.png)

I have no way to check if it breaks anything on mobile.

cc @keybase/react-hackers 