### PR TITLE
use the fetch retrier instead of loading chats on demand from rekey notification CORe-6039

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -66,7 +66,7 @@ func (b *BlockingLocalizer) Name() string {
 }
 
 type NonblockInboxResult struct {
-	ConvID   chat1.ConversationID
+	Conv     chat1.Conversation
 	Err      *chat1.ConversationErrorLocal
 	ConvRes  *chat1.ConversationLocal
 	InboxRes *chat1.Inbox
@@ -812,13 +812,13 @@ func (s *localizerPipeline) localizeConversationsPipeline(ctx context.Context, u
 						s.Debug(ctx, "error localizing: convID: %s err: %s", conv.conv.GetConvID(),
 							convLocal.Error.Message)
 						*localizeCb <- NonblockInboxResult{
-							Err:    convLocal.Error,
-							ConvID: conv.conv.Metadata.ConversationID,
+							Err:  convLocal.Error,
+							Conv: conv.conv,
 						}
 					} else {
 						*localizeCb <- NonblockInboxResult{
 							ConvRes: &convLocal,
-							ConvID:  convLocal.Info.Id,
+							Conv:    conv.conv,
 						}
 					}
 				}

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -35,17 +35,19 @@ type ConversationRetry struct {
 	utils.DebugLabeler
 
 	convID chat1.ConversationID
+	tlfID  *chat1.TLFID
 	kind   FetchType
 }
 
 var _ types.RetryDescription = (*ConversationRetry)(nil)
 
-func NewConversationRetry(g *globals.Context, convID chat1.ConversationID, kind FetchType) *ConversationRetry {
+func NewConversationRetry(g *globals.Context, convID chat1.ConversationID, tlfID *chat1.TLFID, kind FetchType) *ConversationRetry {
 	dstr := fmt.Sprintf("ConversationRetry(%s,%v)", convID, kind)
 	return &ConversationRetry{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), dstr, false),
 		convID:       convID,
+		tlfID:        tlfID,
 		kind:         kind,
 	}
 }

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -58,7 +58,7 @@ func TestFetchRetry(t *testing.T) {
 	require.NotNil(t, inbox.Convs[2].Error)
 	require.Nil(t, inbox.Convs[0].Error)
 	tc.ChatG.FetchRetrier.Failure(ctx, uid,
-		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), ThreadLoad))
+		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), nil, ThreadLoad))
 
 	// Advance clock and check for errors on all conversations
 	t.Logf("advancing clock and checking for stale")
@@ -80,7 +80,7 @@ func TestFetchRetry(t *testing.T) {
 
 	t.Logf("trying to use Force")
 	tc.ChatG.FetchRetrier.Failure(ctx, uid,
-		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), ThreadLoad))
+		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), nil, ThreadLoad))
 	tc.ChatG.FetchRetrier.Force(ctx)
 	select {
 	case cids := <-list.threadsStale:

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -82,6 +82,7 @@ func (t *KBFSNameInfoSource) Lookup(ctx context.Context, tlfName string,
 }
 
 func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res keybase1.GetTLFCryptKeysRes, ferr error) {
+	idNotifier := CtxIdentifyNotifier(ctx)
 	identBehavior, breaks, ok := IdentifyMode(ctx)
 	if !ok {
 		return res, fmt.Errorf("invalid context with no chat metadata")
@@ -102,17 +103,28 @@ func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res
 	group, ectx := errgroup.WithContext(BackgroundContext(ctx, t.G()))
 
 	var ib []keybase1.TLFIdentifyFailure
-	group.Go(func() error {
-		query := keybase1.TLFQuery{
-			TlfName:          tlfName,
-			IdentifyBehavior: identBehavior,
+	if identBehavior != keybase1.TLFIdentifyBehavior_CHAT_SKIP {
+		t.Debug(ectx, "CryptKeys: running identify")
+		group.Go(func() error {
+			query := keybase1.TLFQuery{
+				TlfName:          tlfName,
+				IdentifyBehavior: identBehavior,
+			}
+			var err error
+			ib, err = t.Identify(ectx, query, true)
+			return err
+		})
+		// use id breaks calculated by Identify
+		res.NameIDBreaks.Breaks.Breaks = ib
+
+		if idNotifier != nil {
+			idNotifier.Send(res.NameIDBreaks)
 		}
-		var err error
-		ib, err = t.Identify(ectx, query, true)
-		return err
-	})
+		*breaks = appendBreaks(*breaks, res.NameIDBreaks.Breaks.Breaks)
+	}
 
 	group.Go(func() error {
+		t.Debug(ectx, "CryptKeys: running GetTLFCryptKeys on KFBS daemon")
 		tlfClient, err := t.tlfKeysClient()
 		if err != nil {
 			return err
@@ -132,14 +144,6 @@ func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res
 		return keybase1.GetTLFCryptKeysRes{}, err
 	}
 
-	// use id breaks calculated by Identify
-	res.NameIDBreaks.Breaks.Breaks = ib
-
-	if in := CtxIdentifyNotifier(ctx); in != nil {
-		in.Send(res.NameIDBreaks)
-	}
-	*breaks = appendBreaks(*breaks, res.NameIDBreaks.Breaks.Breaks)
-
 	// GUI Strict mode errors are swallowed earlier, return an error now (key is that it is
 	// after send to IdentifyNotifier)
 	if identBehavior == keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT &&
@@ -151,6 +155,7 @@ func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res
 }
 
 func (t *KBFSNameInfoSource) PublicCanonicalTLFNameAndID(ctx context.Context, tlfName string) (res keybase1.CanonicalTLFNameAndIDWithBreaks, ferr error) {
+	idNotifier := CtxIdentifyNotifier(ctx)
 	identBehavior, breaks, ok := IdentifyMode(ctx)
 	if !ok {
 		return res, fmt.Errorf("invalid context with no chat metadata")
@@ -162,16 +167,25 @@ func (t *KBFSNameInfoSource) PublicCanonicalTLFNameAndID(ctx context.Context, tl
 	group, ectx := errgroup.WithContext(BackgroundContext(ctx, t.G()))
 
 	var ib []keybase1.TLFIdentifyFailure
-	group.Go(func() error {
-		query := keybase1.TLFQuery{
-			TlfName:          tlfName,
-			IdentifyBehavior: identBehavior,
-		}
+	if identBehavior != keybase1.TLFIdentifyBehavior_CHAT_SKIP {
+		group.Go(func() error {
+			query := keybase1.TLFQuery{
+				TlfName:          tlfName,
+				IdentifyBehavior: identBehavior,
+			}
 
-		var err error
-		ib, err = t.Identify(ectx, query, false)
-		return err
-	})
+			var err error
+			ib, err = t.Identify(ectx, query, false)
+			return err
+		})
+
+		// use id breaks calculated by Identify
+		res.Breaks.Breaks = ib
+		if idNotifier != nil {
+			idNotifier.Send(res)
+		}
+		*breaks = appendBreaks(*breaks, res.Breaks.Breaks)
+	}
 
 	group.Go(func() error {
 		tlfClient, err := t.tlfKeysClient()
@@ -192,13 +206,6 @@ func (t *KBFSNameInfoSource) PublicCanonicalTLFNameAndID(ctx context.Context, tl
 	if err := group.Wait(); err != nil {
 		return keybase1.CanonicalTLFNameAndIDWithBreaks{}, err
 	}
-
-	// use id breaks calculated by Identify
-	res.Breaks.Breaks = ib
-	if in := CtxIdentifyNotifier(ctx); in != nil {
-		in.Send(res)
-	}
-	*breaks = appendBreaks(*breaks, res.Breaks.Breaks)
 
 	// GUI Strict mode errors are swallowed earlier, return an error now (key is that it is
 	// after send to IdentifyNotifier)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -125,6 +125,7 @@ type RetryDescription interface {
 	Fix(ctx context.Context, uid gregor1.UID) error
 	SendStale(ctx context.Context, uid gregor1.UID)
 	String() string
+	RekeyFixable(ctx context.Context, tlfID chat1.TLFID) bool
 }
 
 type FetchRetrier interface {
@@ -134,6 +135,8 @@ type FetchRetrier interface {
 	Failure(ctx context.Context, uid gregor1.UID, desc RetryDescription) error
 	Success(ctx context.Context, uid gregor1.UID, desc RetryDescription) error
 	Force(ctx context.Context)
+	Rekey(ctx context.Context, name string, membersType chat1.ConversationMembersType,
+		public bool)
 }
 
 type ConvLoader interface {

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -100,7 +100,7 @@ func (h *KBFSHandler) notifyConversation(uid keybase1.UID, filename string) {
 	public := findFolderList(filename) == "public"
 
 	g := globals.NewContext(h.G(), h.ChatG())
-	ctx := chat.Context(context.Background(), g, keybase1.TLFIdentifyBehavior_CHAT_GUI,
+	ctx := chat.Context(context.Background(), g, keybase1.TLFIdentifyBehavior_CHAT_SKIP,
 		nil, chat.NewIdentifyNotifier(g))
 	h.ChatG().FetchRetrier.Rekey(ctx, tlf, chat1.ConversationMembersType_KBFS, public)
 }

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -79,7 +79,7 @@ func (h *KBFSHandler) checkConversationRekey(arg keybase1.FSNotification) {
 
 	h.G().Log.Debug("received rekey finished notification for %s, checking for conversations", arg.Filename)
 
-	go h.notifyConversation(uid, arg.Filename)
+	h.notifyConversation(uid, arg.Filename)
 }
 
 // findFolderList returns the type of KBFS folder list containing the
@@ -98,56 +98,9 @@ func findFolderList(filename string) string {
 func (h *KBFSHandler) notifyConversation(uid keybase1.UID, filename string) {
 	tlf := filepath.Base(filename)
 	public := findFolderList(filename) == "public"
-	convIDs, err := h.conversationIDs(uid, tlf, public)
-	if err != nil {
-		h.G().Log.Debug("error getting conversation IDs for tlf %q: %s", tlf, err)
-		return
-	}
 
-	if len(convIDs) == 0 {
-		h.G().Log.Debug("no conversations for tlf %s (public: %v)", tlf, public)
-		return
-	}
-
-	h.G().Log.Debug("sending ChatThreadsStale notification (conversations: %d)", len(convIDs))
-	var updates []chat1.ConversationStaleUpdate
-	for _, convID := range convIDs {
-		updates = append(updates, chat1.ConversationStaleUpdate{
-			ConvID:     convID,
-			UpdateType: chat1.StaleUpdateType_CLEAR,
-		})
-	}
-	h.ChatG().Syncer.SendChatStaleNotifications(context.Background(), uid.ToBytes(), updates, false)
-}
-
-func (h *KBFSHandler) conversationIDs(uid keybase1.UID, tlf string, public bool) ([]chat1.ConversationID, error) {
-	vis := keybase1.TLFVisibility_PRIVATE
-	if public {
-		vis = keybase1.TLFVisibility_PUBLIC
-	}
-
-	toptype := chat1.TopicType_CHAT
-	query := chat1.GetInboxLocalQuery{
-		Name: &chat1.NameQuery{
-			Name:        tlf,
-			MembersType: chat1.ConversationMembersType_KBFS,
-		},
-		TlfVisibility: &vis,
-		TopicType:     &toptype,
-	}
-
-	var identBreaks []keybase1.TLFIdentifyFailure
 	g := globals.NewContext(h.G(), h.ChatG())
 	ctx := chat.Context(context.Background(), g, keybase1.TLFIdentifyBehavior_CHAT_GUI,
-		&identBreaks, chat.NewIdentifyNotifier(g))
-	ib, _, err := h.ChatG().InboxSource.Read(ctx, uid.ToBytes(), nil, true, &query, nil)
-	if err != nil {
-		return nil, err
-	}
-	ids := make([]chat1.ConversationID, len(ib.Convs))
-	for i, c := range ib.Convs {
-		ids[i] = c.Info.Id
-	}
-
-	return ids, nil
+		nil, chat.NewIdentifyNotifier(g))
+	h.ChatG().FetchRetrier.Rekey(ctx, tlf, chat1.ConversationMembersType_KBFS, public)
 }


### PR DESCRIPTION
Patch has the following effect:

1.) We now store `TLFID` alongside chats in `FetchRetrier` if they are relevant (like trying to read a convo).
2.) Instead of just loading a chat on demand when we get a rekey notification, we instead instruct the fetch retrier to try and find conversations that match the `TLFID` of the folder that has been rekeyed. Also, since KBFS seems to just not generate these notifications properly, this is just safer.
3.) This should make rekeying much better for large inboxes, since before we would be spam loading the entire inbox when someone added a new device.