### PR TITLE
Fix proof checker when left side is latest team link

### DIFF
--- a/go/systests/common_test.go
+++ b/go/systests/common_test.go
@@ -4,12 +4,13 @@
 package systests
 
 import (
+	"path/filepath"
+	"testing"
+
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
-	"path/filepath"
-	"testing"
 )
 
 func setupTest(t *testing.T, nm string) *libkb.TestContext {
@@ -132,4 +133,23 @@ func (n nullProvisionUI) ProvisioneeSuccess(context.Context, keybase1.Provisione
 }
 func (n nullProvisionUI) ProvisionerSuccess(context.Context, keybase1.ProvisionerSuccessArg) error {
 	return nil
+}
+
+func getActiveDevicesAndKeys(tc *libkb.TestContext, username string) ([]*libkb.Device, []libkb.GenericKey) {
+	arg := libkb.NewLoadUserByNameArg(tc.G, username)
+	arg.PublicKeyOptional = true
+	user, err := libkb.LoadUser(arg)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	sibkeys := user.GetComputedKeyFamily().GetAllActiveSibkeys()
+	subkeys := user.GetComputedKeyFamily().GetAllActiveSubkeys()
+
+	activeDevices := []*libkb.Device{}
+	for _, device := range user.GetComputedKeyFamily().GetAllDevices() {
+		if device.Status != nil && *device.Status == libkb.DeviceStatusActive {
+			activeDevices = append(activeDevices, device)
+		}
+	}
+	return activeDevices, append(sibkeys, subkeys...)
 }

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -7,7 +7,9 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/client/go/client"
+	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
@@ -137,6 +139,7 @@ func (tt *teamTester) addUser(pre string) *userPlusDevice {
 	tt.t.Logf("signed up %s", userInfo.username)
 
 	u.username = userInfo.username
+	u.passphrase = userInfo.passphrase
 	u.uid = libkb.UsernameToUID(u.username)
 	u.tc = tc
 
@@ -176,6 +179,7 @@ func (tt *teamTester) cleanup() {
 type userPlusDevice struct {
 	uid           keybase1.UID
 	username      string
+	passphrase    string
 	device        *deviceWrapper
 	tc            *libkb.TestContext
 	deviceClient  keybase1.DeviceClient
@@ -438,6 +442,10 @@ func (u *userPlusDevice) lookupImplicitTeam(create bool, displayName string, pub
 	return teamID, err
 }
 
+func (u *userPlusDevice) newSecretUI() *libkb.TestSecretUI {
+	return &libkb.TestSecretUI{Passphrase: u.passphrase}
+}
+
 func kickTeamRekeyd(g *libkb.GlobalContext, t testing.TB) {
 	apiArg := libkb.APIArg{
 		Endpoint: "test/accelerate_team_rekeyd",
@@ -510,4 +518,71 @@ func TestGetTeamRootID(t *testing.T) {
 	getAndCompare(*subteamID)
 	getAndCompare(*subteamID2)
 	getAndCompare(parentID)
+}
+
+// test that we can still load a valid link a signed by a now-revoked device.
+func TestTeamSignedByRevokedDevice(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	// the signer
+	alice := tt.addUser("alice")
+
+	// the loader
+	bob := tt.addUser("bob")
+
+	teamName := alice.createTeam()
+	alice.addTeamMember(teamName, bob.username, keybase1.TeamRole_ADMIN)
+
+	t.Logf("alice revokes the device used to sign team links")
+	var revokedKID keybase1.KID
+	{
+		devices, _ := getActiveDevicesAndKeys(alice.tc, alice.username)
+		var target *libkb.Device
+		for _, device := range devices {
+			if device.Type != libkb.DeviceTypePaper {
+				target = device
+			}
+		}
+		require.NotNil(t, target)
+		revokedKID = target.Kid
+
+		revokeEngine := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{
+			ID:        target.ID,
+			ForceSelf: true,
+			ForceLast: false,
+		}, alice.tc.G)
+		ectx := &engine.Context{
+			LogUI:    alice.tc.G.Log,
+			SecretUI: alice.newSecretUI(),
+		}
+		err := engine.RunEngine(revokeEngine, ectx)
+		require.NoError(t, err)
+	}
+
+	t.Logf("bob updates cache of alice's info")
+	{
+		arg := libkb.NewLoadUserArg(bob.tc.G)
+		arg.UID = alice.uid
+		arg.PublicKeyOptional = true
+		arg.ForcePoll = true
+		_, _, err := bob.tc.G.GetUPAKLoader().LoadV2(arg)
+		require.NoError(t, err)
+	}
+
+	t.Logf("bob should see alice's key is revoked")
+	{
+		_, pubKey, _, err := bob.tc.G.GetUPAKLoader().LoadKeyV2(context.TODO(), alice.uid, revokedKID)
+		require.NoError(t, err)
+		t.Logf("%v", spew.Sdump(pubKey))
+		require.NotNil(t, pubKey.Base.Revocation, "key should be revoked: %v", revokedKID)
+	}
+
+	t.Logf("bob loads the team")
+	_, err := teams.Load(context.TODO(), bob.tc.G, keybase1.LoadTeamArg{
+		Name:            teamName,
+		ForceRepoll:     true,
+		ForceFullReload: true, // don't use the cache
+	})
+	require.NoError(t, err)
 }

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -127,7 +127,7 @@ func NewProofError(p proof, s string) ProofError {
 }
 
 func (p ProofError) Error() string {
-	return fmt.Sprintf("proof error for proof %+v: %s", p.p, p.msg)
+	return fmt.Sprintf("proof error for proof '%s': %s", p.p.reason, p.msg)
 }
 
 type PermissionError struct {

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -182,10 +182,15 @@ func (l *TeamLoader) verifyLink(ctx context.Context,
 		return nil, proofSet, libkb.NewWrongKidError(kid, key.Base.Kid)
 	}
 
-	var teamLinkMap map[keybase1.Seqno]keybase1.LinkID
+	teamLinkMap := make(map[keybase1.Seqno]keybase1.LinkID)
 	if state != nil {
-		teamLinkMap = state.Chain.LinkIDs
+		// copy over the stored links
+		for k, v := range state.Chain.LinkIDs {
+			teamLinkMap[k] = v
+		}
 	}
+	// add on the link that is being checked
+	teamLinkMap[link.Seqno()] = link.LinkID().Export()
 
 	proofSet = addProofsForKeyInUserSigchain(ctx, teamID, teamLinkMap, link, signerUV.Uid, key, linkMap, proofSet)
 


### PR DESCRIPTION
Fix the bug.

Apparent symptom: Can't load team because link signed by revoked device fails the ordering check. The check that device-revoke happened before team-link.
Real symptom: Can't do any proof checks when the left side (the _before_ location) is the _latest_ link of the team proof.
Cause: The team link map didn't include the latest link because it was still being ingested.

There is another weirdness not fixed which is that the revocation seqnos are 0 (dead wrong) for revoked devices. But luckily the proof ordering checker doesn't use the right side (the _after_ location) seqno at all, instead using the prevmerkleroot.