### PR TITLE
Fix proof checker when team link map is stale

### DIFF
--- a/go/systests/common_test.go
+++ b/go/systests/common_test.go
@@ -13,7 +13,7 @@ import (
 	context "golang.org/x/net/context"
 )
 
-func setupTest(t *testing.T, nm string) *libkb.TestContext {
+func setupTest(t testing.TB, nm string) *libkb.TestContext {
 	tc := externals.SetupTest(t, nm, 2)
 	tc.SetRuntimeDir(filepath.Join(tc.Tp.Home, "run"))
 	if err := tc.G.ConfigureSocketInfo(); err != nil {

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -138,16 +138,19 @@ func (tt *teamTester) addUser(pre string) *userPlusDevice {
 	}
 	tt.t.Logf("signed up %s", userInfo.username)
 
+	u.tc = tc
+	u.userInfo = userInfo
 	u.username = userInfo.username
 	u.passphrase = userInfo.passphrase
 	u.uid = libkb.UsernameToUID(u.username)
-	u.tc = tc
 
 	cli, xp, err := client.GetRPCClientWithContext(g)
 	if err != nil {
 		tt.t.Fatal(err)
 	}
+
 	u.deviceClient = keybase1.DeviceClient{Cli: cli}
+	u.device.userClient = keybase1.UserClient{Cli: cli}
 
 	// register for notifications
 	u.notifications = newTeamNotifyHandler()
@@ -166,6 +169,14 @@ func (tt *teamTester) addUser(pre string) *userPlusDevice {
 
 	g.ConfigureConfig()
 
+	devices, backups := u.device.loadEncryptionKIDs()
+	require.Len(tt.t, devices, 1, "devices")
+	u.device.deviceKey.KID = devices[0]
+	require.True(tt.t, u.device.deviceKey.KID.Exists())
+	require.Len(tt.t, backups, 1, "backup keys")
+	u.backupKey = backups[0]
+	u.backupKey.secret = signupUI.info.displayedPaperKey
+
 	tt.users = append(tt.users, &u)
 	return &u
 }
@@ -180,6 +191,8 @@ type userPlusDevice struct {
 	uid           keybase1.UID
 	username      string
 	passphrase    string
+	userInfo      *signupInfo
+	backupKey     backupKey
 	device        *deviceWrapper
 	tc            *libkb.TestContext
 	deviceClient  keybase1.DeviceClient
@@ -446,6 +459,54 @@ func (u *userPlusDevice) newSecretUI() *libkb.TestSecretUI {
 	return &libkb.TestSecretUI{Passphrase: u.passphrase}
 }
 
+func (u *userPlusDevice) provisionNewDevice() *deviceWrapper {
+	tc := setupTest(u.tc.T, "sub")
+	t := tc.T
+	g := tc.G
+
+	device := &deviceWrapper{tctx: tc}
+	device.start(0)
+
+	// ui for provisioning
+	ui := &rekeyProvisionUI{username: u.username, backupKey: u.backupKey}
+	// var loginClient keybase1.LoginClient
+	{
+		_, xp, err := client.GetRPCClientWithContext(g)
+		require.NoError(t, err)
+		srv := rpc.NewServer(xp, nil)
+		protocols := []rpc.Protocol{
+			keybase1.LoginUiProtocol(ui),
+			keybase1.SecretUiProtocol(ui),
+			keybase1.ProvisionUiProtocol(ui),
+		}
+		for _, prot := range protocols {
+			err = srv.Register(prot)
+			require.NoError(t, err)
+		}
+		// loginClient = keybase1.LoginClient{Cli: cli}
+		// _ = loginClient
+	}
+
+	// g.SetUI(ui)
+
+	cmd := client.NewCmdLoginRunner(g)
+	err := cmd.Run()
+	require.NoError(t, err, "login")
+
+	// Clear the paper key.
+	err = g.LoginState().Account(func(a *libkb.Account) {
+		a.ClearPaperKeys()
+	}, "provisionNewDevice")
+	require.NoError(t, err, "clear paper key")
+
+	skey, err := g.ActiveDevice.SigningKey()
+	require.NoError(t, err)
+	device.deviceKey.KID = skey.GetKID()
+	require.True(t, device.deviceKey.KID.Exists())
+
+	return device
+}
+
 func kickTeamRekeyd(g *libkb.GlobalContext, t testing.TB) {
 	apiArg := libkb.APIArg{
 		Endpoint: "test/accelerate_team_rekeyd",
@@ -520,7 +581,7 @@ func TestGetTeamRootID(t *testing.T) {
 	getAndCompare(parentID)
 }
 
-// test that we can still load a valid link a signed by a now-revoked device.
+// Test that we can still load a valid link a signed by a now-revoked device.
 func TestTeamSignedByRevokedDevice(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
@@ -546,6 +607,90 @@ func TestTeamSignedByRevokedDevice(t *testing.T) {
 		}
 		require.NotNil(t, target)
 		revokedKID = target.Kid
+
+		revokeEngine := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{
+			ID:        target.ID,
+			ForceSelf: true,
+			ForceLast: false,
+		}, alice.tc.G)
+		ectx := &engine.Context{
+			LogUI:    alice.tc.G.Log,
+			SecretUI: alice.newSecretUI(),
+		}
+		err := engine.RunEngine(revokeEngine, ectx)
+		require.NoError(t, err)
+	}
+
+	t.Logf("bob updates cache of alice's info")
+	{
+		arg := libkb.NewLoadUserArg(bob.tc.G)
+		arg.UID = alice.uid
+		arg.PublicKeyOptional = true
+		arg.ForcePoll = true
+		_, _, err := bob.tc.G.GetUPAKLoader().LoadV2(arg)
+		require.NoError(t, err)
+	}
+
+	t.Logf("bob should see alice's key is revoked")
+	{
+		_, pubKey, _, err := bob.tc.G.GetUPAKLoader().LoadKeyV2(context.TODO(), alice.uid, revokedKID)
+		require.NoError(t, err)
+		t.Logf("%v", spew.Sdump(pubKey))
+		require.NotNil(t, pubKey.Base.Revocation, "key should be revoked: %v", revokedKID)
+	}
+
+	t.Logf("bob loads the team")
+	_, err := teams.Load(context.TODO(), bob.tc.G, keybase1.LoadTeamArg{
+		Name:            teamName,
+		ForceRepoll:     true,
+		ForceFullReload: true, // don't use the cache
+	})
+	require.NoError(t, err)
+}
+
+// Another test of loading a team with a valid link signed by a now-revoked device.
+// The previous test didn't catch a bug.
+// In this test at the time when the device is revoked the team sigchain points to
+// a link that was signed by a never-revoked device and is subsequent to the link
+// signed by the revoked device.
+func TestTeamSignedByRevokedDevice2(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	// the signer
+	alice := tt.addUser("alice")
+	aliced2 := alice.provisionNewDevice()
+
+	// the loader
+	bob := tt.addUser("bob")
+
+	teamName := alice.createTeam()
+
+	t.Logf("sign a link with the to-be-revoked device (aliced2)")
+	{
+		eng := client.NewCmdTeamAddMemberRunner(aliced2.tctx.G)
+		eng.Team = teamName
+		eng.Username = bob.username
+		eng.Role = keybase1.TeamRole_ADMIN
+		err := eng.Run()
+		require.NoError(t, err)
+	}
+
+	alice.changeTeamMember(teamName, bob.username, keybase1.TeamRole_ADMIN)
+
+	t.Logf("alice revokes a device used to sign team links (alice2)")
+	revokedKID := aliced2.KID()
+	require.True(t, revokedKID.Exists())
+	{
+		devices, _ := getActiveDevicesAndKeys(alice.tc, alice.username)
+		var target *libkb.Device
+		for _, device := range devices {
+			t.Logf("scan device: ID:%v KID:%v", device.ID, device.Kid)
+			if device.Kid.Equal(revokedKID) {
+				target = device
+			}
+		}
+		require.NotNil(t, target)
 
 		revokeEngine := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{
 			ID:        target.ID,

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -321,7 +321,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*load2ResT,
 		}
 
 		var signer *signerX
-		signer, proofSet, err = l.verifyLink(ctx, arg.teamID, ret, arg.me, link, readSubteamID, proofSet)
+		signer, err = l.verifyLink(ctx, arg.teamID, ret, arg.me, link, readSubteamID, proofSet)
 		if err != nil {
 			return nil, err
 		}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -506,6 +506,13 @@ func (l *TeamLoader) checkOneParentChildOperation(ctx context.Context,
 func (l *TeamLoader) checkProofs(ctx context.Context,
 	state *keybase1.TeamData, proofSet *proofSetT) error {
 
+	if state == nil {
+		return fmt.Errorf("teamloader fault: nil team for proof ordering check")
+	}
+	// Give the most up-to-date linkmap to the ordering checker.
+	// Without this it would fail in some cases when the team is on the left.
+	// Because the team linkmap in the proof objects is stale.
+	proofSet.SetTeamLinkMap(ctx, state.Chain.Id, state.Chain.LinkIDs)
 	return proofSet.check(ctx, l.world)
 }
 

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -57,7 +57,7 @@ func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
 		}
 
 		var signer *signerX
-		signer, proofSet, err = l.verifyLink(ctx, teamID, state, me, link, readSubteamID, proofSet)
+		signer, err = l.verifyLink(ctx, teamID, state, me, link, readSubteamID, proofSet)
 		if err != nil {
 			return state, proofSet, parentChildOperations, err
 		}
@@ -129,15 +129,14 @@ func (l *TeamLoader) verifySignatureAndExtractKID(ctx context.Context, outer lib
 	return outer.Verify(l.G().Log)
 }
 
-func addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, teamLinkMap map[keybase1.Seqno]keybase1.LinkID, link *chainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap map[keybase1.Seqno]keybase1.LinkID, proofSet *proofSetT) *proofSetT {
+func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, teamLinkMap map[keybase1.Seqno]keybase1.LinkID, link *chainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap map[keybase1.Seqno]keybase1.LinkID, proofSet *proofSetT) {
 	a := newProofTerm(uid.AsUserOrTeam(), key.Base.Provisioning, userLinkMap)
 	b := newProofTerm(teamID.AsUserOrTeam(), link.SignatureMetadata(), teamLinkMap)
 	c := key.Base.Revocation
-	proofSet = proofSet.AddNeededHappensBeforeProof(ctx, a, b, "user key provisioned before team link")
+	proofSet.AddNeededHappensBeforeProof(ctx, a, b, "user key provisioned before team link")
 	if c != nil {
-		proofSet = proofSet.AddNeededHappensBeforeProof(ctx, b, newProofTerm(uid.AsUserOrTeam(), *c, userLinkMap), "team link before user key revocation")
+		proofSet.AddNeededHappensBeforeProof(ctx, b, newProofTerm(uid.AsUserOrTeam(), *c, userLinkMap), "team link before user key revocation")
 	}
-	return proofSet
 }
 
 // Verify aspects of a link:
@@ -153,33 +152,33 @@ func addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, 
 // Returns the signer, or nil if the link was stubbed
 func (l *TeamLoader) verifyLink(ctx context.Context,
 	teamID keybase1.TeamID, state *keybase1.TeamData, me keybase1.UserVersion, link *chainLinkUnpacked,
-	readSubteamID keybase1.TeamID, proofSet *proofSetT) (*signerX, *proofSetT, error) {
+	readSubteamID keybase1.TeamID, proofSet *proofSetT) (*signerX, error) {
 
 	if link.isStubbed() {
-		return nil, proofSet, nil
+		return nil, nil
 	}
 
 	err := link.AssertInnerOuterMatch()
 	if err != nil {
-		return nil, proofSet, err
+		return nil, err
 	}
 
 	if !teamID.Eq(link.innerTeamID) {
-		return nil, proofSet, fmt.Errorf("team ID mismatch: %s != %s", teamID, link.innerTeamID)
+		return nil, fmt.Errorf("team ID mismatch: %s != %s", teamID, link.innerTeamID)
 	}
 
 	kid, err := l.verifySignatureAndExtractKID(ctx, *link.outerLink)
 	if err != nil {
-		return nil, proofSet, err
+		return nil, err
 	}
 
 	signerUV, key, linkMap, err := l.loadUserAndKeyFromLinkInner(ctx, *link.inner)
 	if err != nil {
-		return nil, proofSet, err
+		return nil, err
 	}
 
 	if !kid.Equal(key.Base.Kid) {
-		return nil, proofSet, libkb.NewWrongKidError(kid, key.Base.Kid)
+		return nil, libkb.NewWrongKidError(kid, key.Base.Kid)
 	}
 
 	teamLinkMap := make(map[keybase1.Seqno]keybase1.LinkID)
@@ -192,14 +191,14 @@ func (l *TeamLoader) verifyLink(ctx context.Context,
 	// add on the link that is being checked
 	teamLinkMap[link.Seqno()] = link.LinkID().Export()
 
-	proofSet = addProofsForKeyInUserSigchain(ctx, teamID, teamLinkMap, link, signerUV.Uid, key, linkMap, proofSet)
+	l.addProofsForKeyInUserSigchain(ctx, teamID, teamLinkMap, link, signerUV.Uid, key, linkMap, proofSet)
 
 	signer := signerX{signer: signerUV}
 
 	// For a root team link, or a subteam_head, there is no reason to check adminship
 	// or writership (or readership) for the team.
 	if state == nil {
-		return &signer, proofSet, nil
+		return &signer, nil
 	}
 
 	var isReaderOrAbove bool
@@ -211,9 +210,9 @@ func (l *TeamLoader) verifyLink(ctx context.Context,
 		// Check for admin permissions if they are not an on-chain reader/writer
 		// because they might be an implicit admin.
 		// Reassigns signer, might set implicitAdmin.
-		proofSet, signer, err = l.verifyAdminPermissions(ctx, state, me, link, readSubteamID, signerUV, proofSet)
+		signer, err = l.verifyAdminPermissions(ctx, state, me, link, readSubteamID, signerUV, proofSet)
 	}
-	return &signer, proofSet, err
+	return &signer, err
 }
 
 func (l *TeamLoader) verifyWriterOrReaderPermissions(ctx context.Context,
@@ -259,20 +258,19 @@ func (l *TeamLoader) walkUpToAdmin(
 	return &TeamSigChainState{inner: team.Chain}, nil
 }
 
-func addProofsForAdminPermission(ctx context.Context, t keybase1.TeamSigChainState, link *chainLinkUnpacked, bookends proofTermBookends, proofSet *proofSetT) *proofSetT {
+func (l *TeamLoader) addProofsForAdminPermission(ctx context.Context, t keybase1.TeamSigChainState, link *chainLinkUnpacked, bookends proofTermBookends, proofSet *proofSetT) {
 	a := bookends.left
 	b := newProofTerm(t.Id.AsUserOrTeam(), link.SignatureMetadata(), t.LinkIDs)
 	c := bookends.right
-	proofSet = proofSet.AddNeededHappensBeforeProof(ctx, a, b, "became admin before team link")
+	proofSet.AddNeededHappensBeforeProof(ctx, a, b, "became admin before team link")
 	if c != nil {
-		proofSet = proofSet.AddNeededHappensBeforeProof(ctx, b, *c, "team link before adminship demotion")
+		proofSet.AddNeededHappensBeforeProof(ctx, b, *c, "team link before adminship demotion")
 	}
-	return proofSet
 }
 
 func (l *TeamLoader) verifyAdminPermissions(ctx context.Context,
 	state *keybase1.TeamData, me keybase1.UserVersion, link *chainLinkUnpacked, readSubteamID keybase1.TeamID,
-	uv keybase1.UserVersion, proofSet *proofSetT) (*proofSetT, signerX, error) {
+	uv keybase1.UserVersion, proofSet *proofSetT) (signerX, error) {
 
 	signer := signerX{signer: uv}
 	explicitAdmin := link.inner.TeamAdmin()
@@ -282,18 +280,18 @@ func (l *TeamLoader) verifyAdminPermissions(ctx context.Context,
 	// the current chain at or before the signature in question.
 	if explicitAdmin == nil {
 		err := teamChain.AssertWasAdminAt(uv, link.SigChainLocation())
-		return proofSet, signer, err
+		return signer, err
 	}
 
 	// The more complicated case is that there's an explicit admin permssion given, perhaps
 	// of a parent team.
 	adminTeam, err := l.walkUpToAdmin(ctx, state, me, readSubteamID, uv, *explicitAdmin)
 	if err != nil {
-		return proofSet, signer, err
+		return signer, err
 	}
 	adminBookends, err := adminTeam.assertBecameAdminAt(uv, explicitAdmin.SigChainLocation())
 	if err != nil {
-		return proofSet, signer, err
+		return signer, err
 	}
 
 	// This was an implicit admin action if the team from which admin-power was derived (adminTeam)
@@ -302,8 +300,8 @@ func (l *TeamLoader) verifyAdminPermissions(ctx context.Context,
 		signer.implicitAdmin = true
 	}
 
-	proofSet = addProofsForAdminPermission(ctx, state.Chain, link, adminBookends, proofSet)
-	return proofSet, signer, nil
+	l.addProofsForAdminPermission(ctx, state.Chain, link, adminBookends, proofSet)
+	return signer, nil
 }
 
 // Whether the chain link is of a (child-half) type

--- a/go/teams/proofs.go
+++ b/go/teams/proofs.go
@@ -99,7 +99,7 @@ func newProofSet(g *libkb.GlobalContext) *proofSetT {
 // to a merkle tree lookup, so it makes sense to be stingy. Return the modified
 // proof set with the new proofs needed, but the original arugment p will
 // be mutated.
-func (p *proofSetT) AddNeededHappensBeforeProof(ctx context.Context, a proofTerm, b proofTerm, reason string) *proofSetT {
+func (p *proofSetT) AddNeededHappensBeforeProof(ctx context.Context, a proofTerm, b proofTerm, reason string) {
 
 	var action string
 	defer func() {
@@ -114,14 +114,14 @@ func (p *proofSetT) AddNeededHappensBeforeProof(ctx context.Context, a proofTerm
 			// The proof is self-evident.
 			// Discard it.
 			action = "discard-easy"
-			return p
+			return
 		}
 		// The proof is self-evident FALSE.
 		// Add it and return immediately so the rest of this function doesn't have to trip over it.
 		// It should be failed later by the checker.
 		action = "added-easy-false"
 		p.proofs[idx] = append(p.proofs[idx], proof{a, b, reason})
-		return p
+		return
 	}
 
 	set := p.proofs[idx]
@@ -133,18 +133,18 @@ func (p *proofSetT) AddNeededHappensBeforeProof(ctx context.Context, a proofTerm
 			existing.b = existing.b.min(b)
 			set[i] = existing
 			action = "collapsed"
-			return p
+			return
 		}
 		if existing.a.equal(a) && existing.b.lessThanOrEqual(b) {
 			// If the new proof is the same on the left and weaker on the right.
 			// Discard the new proof, as it is implied by the existing one.
 			action = "discard-weak"
-			return p
+			return
 		}
 	}
 	action = "added"
 	p.proofs[idx] = append(p.proofs[idx], proof{a, b, reason})
-	return p
+	return
 }
 
 func (p *proofSetT) AllProofs() []proof {

--- a/go/teams/proofs_test.go
+++ b/go/teams/proofs_test.go
@@ -66,15 +66,15 @@ func TestProofSetAdd(t *testing.T) {
 	q := createProofTerm(2, keybase1.Seqno(403))
 	r := createProofTerm(1, keybase1.Seqno(49))
 
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), a, b, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), c, d, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), e, f, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), g, h, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), i, j, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), k, l, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), m, n, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), o, p, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), q, r, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), a, b, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), c, d, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), e, f, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), g, h, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), i, j, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), k, l, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), m, n, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), o, p, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), q, r, "")
 
 	ret := ps.AllProofs()
 
@@ -95,9 +95,9 @@ func TestProofSetImply(t *testing.T) {
 	c := createProofTerm(2, keybase1.Seqno(2)) // signed link
 	d := createProofTerm(2, keybase1.Seqno(3)) // signed link
 
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), a, b, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), a, c, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), a, d, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), a, b, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), a, c, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), a, d, "")
 
 	ret := ps.AllProofs()
 	for _, p := range ret {
@@ -116,8 +116,8 @@ func TestProofSetSameChain(t *testing.T) {
 	b := createProofTerm(1, keybase1.Seqno(11))
 	c := createProofTerm(1, keybase1.Seqno(12))
 
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), a, b, "")
-	ps = ps.AddNeededHappensBeforeProof(context.TODO(), b, c, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), a, b, "")
+	ps.AddNeededHappensBeforeProof(context.TODO(), b, c, "")
 
 	ret := ps.AllProofs()
 	for _, p := range ret {


### PR DESCRIPTION
Part two, https://github.com/keybase/client/pull/8499 only fixed some cases.

The deal is that the `linkMap` attached to `proof`s is put created when only partway through the team chain. So it's missing newer seqnos.

For example:
DA and DB are devices for U, DB will be revoked. T1 is team T's seqno 1.
Events:
- Create (T1) (by DA)
- Add-member (T2) (by DB)
- Add-member (T3) (by DA)
- Revoke DB (U2)

When checking there's a proof requirement that: *T2 happened before U2*
At the hashmeta when U2 happened, T was at T3. The problem was that the linkmap for this proof only went up to T2 because that's when it was added. Even though at the point when the proof checker is running, T3 has been processed. The fix is to give the checker the latest linkmap right before it checks.

Test coming up.