### PR TITLE
thread conversation version up to frontend, and fix inbox storage bugs CORE-6042

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -601,6 +601,7 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 	if !alreadyIn {
 		// Send a message to the channel after joining.
 		joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
+		debugger.Debug(ctx, "JoinConversation: sending join message to: %s", convID)
 		irl, err := postJoinLeave(ctx, g, ri, uid, convID, joinMessageBody)
 		if err != nil {
 			debugger.Debug(ctx, "JoinConversation: posting join-conv message failed: %v", err)

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -918,6 +918,7 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		Status:      conversationRemote.Metadata.Status,
 		MembersType: conversationRemote.Metadata.MembersType,
 		TeamType:    conversationRemote.Metadata.TeamType,
+		Version:     conversationRemote.Metadata.Version,
 	}
 	conversationLocal.Info.FinalizeInfo = conversationRemote.Metadata.FinalizeInfo
 	for _, super := range conversationRemote.Metadata.Supersedes {

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -486,7 +486,6 @@ func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	if err != nil {
 		return inbox, rl, err
 	}
-	s.Debug(ctx, "Read: tlfInfo: %+v", tlfInfo)
 	inbox, rl, err = s.ReadUnverified(ctx, uid, useLocalData, rquery, p)
 	if err != nil {
 		return inbox, rl, err

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -546,9 +546,11 @@ func (s *HybridInboxSource) ReadUnverified(ctx context.Context, uid gregor1.UID,
 			return res, rl, err
 		}
 
-		// Write out to local storage
-		if cerr = inboxStore.Merge(ctx, inbox.Version, inbox.ConvsUnverified, query, p); cerr != nil {
-			s.Debug(ctx, "ReadUnverified: failed to write inbox to local storage: %s", cerr.Error())
+		// Write out to local storage only if we are using local daata
+		if useLocalData {
+			if cerr = inboxStore.Merge(ctx, inbox.Version, inbox.ConvsUnverified, query, p); cerr != nil {
+				s.Debug(ctx, "ReadUnverified: failed to write inbox to local storage: %s", cerr.Error())
+			}
 		}
 
 		res = chat1.Inbox{

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -599,7 +599,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 
 	// Write new message out to cache
 	s.Debug(ctx, "sending local updates to chat sources")
-	if _, _, err = s.G().ConvSource.Push(ctx, convID, msg.ClientHeader.Sender, *boxed); err != nil {
+	if _, _, err = s.G().ConvSource.Push(ctx, convID, boxed.ClientHeader.Sender, *boxed); err != nil {
 		return chat1.OutboxID{}, nil, nil, err
 	}
 	if _, err = s.G().InboxSource.NewMessage(ctx, boxed.ClientHeader.Sender, 0, convID, *boxed); err != nil {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -157,6 +157,7 @@ func (h *Server) presentUnverifiedInbox(ctx context.Context, vres chat1.GetInbox
 		conv.Notifications = rawConv.Notifications
 		conv.MembersType = rawConv.GetMembersType()
 		conv.TeamType = rawConv.Metadata.TeamType
+		conv.Version = rawConv.Metadata.Version
 		res.Items = append(res.Items, conv)
 	}
 	res.Pagination = utils.PresentPagination(vres.Pagination)

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const inboxVersion = 14
+const inboxVersion = 15
 
 type queryHash []byte
 

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -634,6 +634,7 @@ func (i *Inbox) NewConversation(ctx context.Context, vers chat1.InboxVers, conv 
 					i.Debug(ctx, "NewConversation: setting supersededBy: target: %s superseder: %s",
 						iconv.GetConvID(), conv.GetConvID())
 					iconv.Metadata.SupersededBy = append(iconv.Metadata.SupersededBy, conv.Metadata)
+					iconv.Metadata.Version = vers.ToConvVers()
 				}
 			}
 		}
@@ -757,6 +758,7 @@ func (i *Inbox) NewMessage(ctx context.Context, vers chat1.InboxVers, convID cha
 	if utils.GetConversationStatusBehavior(conv.Metadata.Status).ActivityRemovesStatus {
 		conv.Metadata.Status = chat1.ConversationStatus_UNFILED
 	}
+	conv.Metadata.Version = vers.ToConvVers()
 
 	// Slot in at the top
 	mconv := *conv
@@ -810,6 +812,7 @@ func (i *Inbox) ReadMessage(ctx context.Context, vers chat1.InboxVers, convID ch
 		conv.ReaderInfo.Mtime = gregor1.ToTime(time.Now())
 		conv.ReaderInfo.ReadMsgid = msgID
 	}
+	conv.Metadata.Version = vers.ToConvVers()
 
 	// Write out to disk
 	ibox.InboxVersion = vers
@@ -851,6 +854,7 @@ func (i *Inbox) SetStatus(ctx context.Context, vers chat1.InboxVers, convID chat
 
 	conv.ReaderInfo.Mtime = gregor1.ToTime(time.Now())
 	conv.Metadata.Status = status
+	conv.Metadata.Version = vers.ToConvVers()
 
 	// Write out to disk
 	ibox.InboxVersion = vers
@@ -894,6 +898,7 @@ func (i *Inbox) SetAppNotificationSettings(ctx context.Context, vers chat1.Inbox
 		}
 	}
 	conv.Notifications.ChannelWide = settings.ChannelWide
+	conv.Metadata.Version = vers.ToConvVers()
 
 	// Write out to disk
 	ibox.InboxVersion = vers
@@ -932,6 +937,7 @@ func (i *Inbox) TeamTypeChanged(ctx context.Context, vers chat1.InboxVers,
 		return i.Clear(ctx)
 	}
 	conv.Metadata.TeamType = teamType
+	conv.Metadata.Version = vers.ToConvVers()
 
 	// Write out to disk
 	ibox.InboxVersion = vers
@@ -973,6 +979,7 @@ func (i *Inbox) TlfFinalize(ctx context.Context, vers chat1.InboxVers, convIDs [
 		}
 
 		conv.Metadata.FinalizeInfo = &finalizeInfo
+		conv.Metadata.Version = vers.ToConvVers()
 	}
 
 	// Write out to disk
@@ -1102,6 +1109,7 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers,
 		if removedMap[conv.GetConvID().String()] {
 			conv.ReaderInfo.Status = chat1.ConversationMemberStatus_LEFT
 		}
+		conv.Metadata.Version = vers.ToConvVers()
 		ibox.Conversations = append(ibox.Conversations, conv)
 	}
 	sort.Sort(ByDatabaseOrder(ibox.Conversations))

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -1108,8 +1108,8 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers,
 	for _, conv := range convs {
 		if removedMap[conv.GetConvID().String()] {
 			conv.ReaderInfo.Status = chat1.ConversationMemberStatus_LEFT
+			conv.Metadata.Version = vers.ToConvVers()
 		}
-		conv.Metadata.Version = vers.ToConvVers()
 		ibox.Conversations = append(ibox.Conversations, conv)
 	}
 	sort.Sort(ByDatabaseOrder(ibox.Conversations))
@@ -1122,6 +1122,7 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers,
 	for _, oj := range othersJoined {
 		if cp, ok := convMap[oj.ConvID.String()]; ok {
 			cp.Metadata.AllList = append(cp.Metadata.AllList, oj.Uid)
+			cp.Metadata.Version = vers.ToConvVers()
 		}
 	}
 	for _, or := range othersRemoved {
@@ -1133,6 +1134,7 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers,
 				}
 			}
 			cp.Metadata.AllList = newAllList
+			cp.Metadata.Version = vers.ToConvVers()
 		}
 	}
 

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -776,6 +776,7 @@ func TestMembershipUpdate(t *testing.T) {
 		if c.GetConvID().Eq(convs[5].GetConvID()) {
 			require.Equal(t, chat1.ConversationMemberStatus_LEFT, c.ReaderInfo.Status)
 			convs[5].ReaderInfo.Status = chat1.ConversationMemberStatus_LEFT
+			convs[5].Metadata.Version = chat1.ConversationVers(2)
 		}
 	}
 	expected := append(convs, joinedConvs...)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -602,6 +602,7 @@ func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxU
 	res.Notifications = rawConv.Notifications
 	res.CreatorInfo = rawConv.CreatorInfo
 	res.TeamType = rawConv.Info.TeamType
+	res.Version = rawConv.Info.Version
 	return res
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -36,6 +36,7 @@ type UnverifiedInboxUIItem struct {
 	TeamType      TeamType                      `codec:"teamType" json:"teamType"`
 	Notifications *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
 	Time          gregor1.Time                  `codec:"time" json:"time"`
+	Version       ConversationVers              `codec:"version" json:"version"`
 }
 
 func (o UnverifiedInboxUIItem) DeepCopy() UnverifiedInboxUIItem {
@@ -53,7 +54,8 @@ func (o UnverifiedInboxUIItem) DeepCopy() UnverifiedInboxUIItem {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Notifications),
-		Time: o.Time.DeepCopy(),
+		Time:    o.Time.DeepCopy(),
+		Version: o.Version.DeepCopy(),
 	}
 }
 
@@ -99,6 +101,7 @@ type InboxUIItem struct {
 	Time          gregor1.Time                  `codec:"time" json:"time"`
 	Notifications *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
 	CreatorInfo   *ConversationCreatorInfoLocal `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
+	Version       ConversationVers              `codec:"version" json:"version"`
 	FinalizeInfo  *ConversationFinalizeInfo     `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
 	Supersedes    []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
 	SupersededBy  []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
@@ -139,6 +142,7 @@ func (o InboxUIItem) DeepCopy() InboxUIItem {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.CreatorInfo),
+		Version: o.Version.DeepCopy(),
 		FinalizeInfo: (func(x *ConversationFinalizeInfo) *ConversationFinalizeInfo {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -83,6 +83,12 @@ func (o InboxVers) DeepCopy() InboxVers {
 	return o
 }
 
+type ConversationVers uint64
+
+func (o ConversationVers) DeepCopy() ConversationVers {
+	return o
+}
+
 type OutboxID []byte
 
 func (o OutboxID) DeepCopy() OutboxID {
@@ -635,6 +641,7 @@ type ConversationMetadata struct {
 	MembersType    ConversationMembersType   `codec:"membersType" json:"membersType"`
 	TeamType       TeamType                  `codec:"teamType" json:"teamType"`
 	Existence      ConversationExistence     `codec:"existence" json:"existence"`
+	Version        ConversationVers          `codec:"version" json:"version"`
 	FinalizeInfo   *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
 	Supersedes     []ConversationMetadata    `codec:"supersedes" json:"supersedes"`
 	SupersededBy   []ConversationMetadata    `codec:"supersededBy" json:"supersededBy"`
@@ -651,6 +658,7 @@ func (o ConversationMetadata) DeepCopy() ConversationMetadata {
 		MembersType:    o.MembersType.DeepCopy(),
 		TeamType:       o.TeamType.DeepCopy(),
 		Existence:      o.Existence.DeepCopy(),
+		Version:        o.Version.DeepCopy(),
 		FinalizeInfo: (func(x *ConversationFinalizeInfo) *ConversationFinalizeInfo {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -691,3 +691,7 @@ func AllConversationExistences() (res []ConversationExistence) {
 	}
 	return res
 }
+
+func (v InboxVers) ToConvVers() ConversationVers {
+	return ConversationVers(v)
+}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2023,6 +2023,7 @@ type ConversationInfoLocal struct {
 	MembersType  ConversationMembersType   `codec:"membersType" json:"membersType"`
 	TeamType     TeamType                  `codec:"teamType" json:"teamType"`
 	Existence    ConversationExistence     `codec:"existence" json:"existence"`
+	Version      ConversationVers          `codec:"version" json:"version"`
 	WriterNames  []string                  `codec:"writerNames" json:"writerNames"`
 	ReaderNames  []string                  `codec:"readerNames" json:"readerNames"`
 	FinalizeInfo *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
@@ -2039,6 +2040,7 @@ func (o ConversationInfoLocal) DeepCopy() ConversationInfoLocal {
 		MembersType: o.MembersType.DeepCopy(),
 		TeamType:    o.TeamType.DeepCopy(),
 		Existence:   o.Existence.DeepCopy(),
+		Version:     o.Version.DeepCopy(),
 		WriterNames: (func(x []string) []string {
 			var ret []string
 			for _, v := range x {

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -21,6 +21,7 @@ protocol chatUi {
     TeamType teamType;
     union{ null, ConversationNotificationInfo } notifications;
     gregor1.Time time;
+    ConversationVers version;
   }
 
   record UnverifiedInboxUIItems {
@@ -44,6 +45,7 @@ protocol chatUi {
     gregor1.Time time;
     union { null, ConversationNotificationInfo } notifications;
     union { null, ConversationCreatorInfoLocal } creatorInfo;
+    ConversationVers version;
 
     // Finalized convo stuff
     union { null, ConversationFinalizeInfo } finalizeInfo;

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -12,6 +12,7 @@ protocol common {
   @typedef("bytes")  record TLFID {}
   @typedef("bytes")  record Hash {}
   @typedef("uint64") @lint("ignore") record InboxVers {}
+  @typedef("uint64") @lint("ignore") record ConversationVers {}
   @typedef("bytes")  record OutboxID {}
   @typedef("bytes")  record TopicNameState {}
 
@@ -186,6 +187,7 @@ protocol common {
     ConversationMembersType membersType;
     TeamType teamType;
     ConversationExistence existence;
+    ConversationVers version;
 
     // Finalize info for underlying TLF
     union { null, ConversationFinalizeInfo } finalizeInfo;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -356,6 +356,7 @@ protocol local {
     ConversationMembersType membersType;
     TeamType teamType;
     ConversationExistence existence;
+    ConversationVers version;
 
     // Lists of usernames, always complete, optionally sorted by activity.
     array<string> writerNames;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -969,6 +969,7 @@ export type ConversationInfoLocal = {
   membersType: ConversationMembersType,
   teamType: TeamType,
   existence: ConversationExistence,
+  version: ConversationVers,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
   finalizeInfo?: ?ConversationFinalizeInfo,
@@ -1011,6 +1012,7 @@ export type ConversationMetadata = {
   membersType: ConversationMembersType,
   teamType: TeamType,
   existence: ConversationExistence,
+  version: ConversationVers,
   finalizeInfo?: ?ConversationFinalizeInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -1046,6 +1048,8 @@ export type ConversationStatus =
   | 3 // BLOCKED_3
   | 4 // MUTED_4
   | 5 // REPORTED_5
+
+export type ConversationVers = uint64
 
 export type DeleteConversationLocalRes = {
   offline: boolean,
@@ -1313,6 +1317,7 @@ export type InboxUIItem = {
   time: gregor1.Time,
   notifications?: ?ConversationNotificationInfo,
   creatorInfo?: ?ConversationCreatorInfoLocal,
+  version: ConversationVers,
   finalizeInfo?: ?ConversationFinalizeInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -1995,6 +2000,7 @@ export type UnverifiedInboxUIItem = {
   teamType: TeamType,
   notifications?: ?ConversationNotificationInfo,
   time: gregor1.Time,
+  version: ConversationVers,
 }
 
 export type UnverifiedInboxUIItems = {

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -73,6 +73,10 @@
         {
           "type": "gregor1.Time",
           "name": "time"
+        },
+        {
+          "type": "ConversationVers",
+          "name": "version"
         }
       ]
     },
@@ -168,6 +172,10 @@
             "ConversationCreatorInfoLocal"
           ],
           "name": "creatorInfo"
+        },
+        {
+          "type": "ConversationVers",
+          "name": "version"
         },
         {
           "type": [

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -66,6 +66,13 @@
     },
     {
       "type": "record",
+      "name": "ConversationVers",
+      "fields": [],
+      "typedef": "uint64",
+      "lint": "ignore"
+    },
+    {
+      "type": "record",
       "name": "OutboxID",
       "fields": [],
       "typedef": "bytes"
@@ -451,6 +458,10 @@
         {
           "type": "ConversationExistence",
           "name": "existence"
+        },
+        {
+          "type": "ConversationVers",
+          "name": "version"
         },
         {
           "type": [

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1035,6 +1035,10 @@
           "name": "existence"
         },
         {
+          "type": "ConversationVers",
+          "name": "version"
+        },
+        {
           "type": {
             "type": "array",
             "items": "string"

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -145,6 +145,7 @@ function* onInboxStale(): SagaGenerator<any, any> {
             teamname: c.membersType === ChatTypes.CommonConversationMembersType.team ? c.name : undefined,
             teamType: c.teamType,
             time: c.time,
+            version: c.version,
           })
         })
         .filter(Boolean)
@@ -484,6 +485,7 @@ function _conversationLocalToInboxState(c: ?ChatTypes.InboxUIItem): ?Constants.I
     teamType: c.teamType,
     time: c.time,
     visibility: c.visibility,
+    version: c.version,
   })
 }
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -286,6 +286,7 @@ export const InboxStateRecord = Record({
   name: '',
   visibility: CommonTLFVisibility.private,
   teamType: ChatTypes.CommonTeamType.none,
+  version: 0,
 })
 
 export type InboxState = KBRecord<{
@@ -302,6 +303,7 @@ export type InboxState = KBRecord<{
   status: ConversationStateEnum,
   time: number,
   teamType: ChatTypes.TeamType,
+  version: ChatTypes.ConversationVers,
 }>
 
 export type SupersedeInfo = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -969,6 +969,7 @@ export type ConversationInfoLocal = {
   membersType: ConversationMembersType,
   teamType: TeamType,
   existence: ConversationExistence,
+  version: ConversationVers,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
   finalizeInfo?: ?ConversationFinalizeInfo,
@@ -1011,6 +1012,7 @@ export type ConversationMetadata = {
   membersType: ConversationMembersType,
   teamType: TeamType,
   existence: ConversationExistence,
+  version: ConversationVers,
   finalizeInfo?: ?ConversationFinalizeInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -1046,6 +1048,8 @@ export type ConversationStatus =
   | 3 // BLOCKED_3
   | 4 // MUTED_4
   | 5 // REPORTED_5
+
+export type ConversationVers = uint64
 
 export type DeleteConversationLocalRes = {
   offline: boolean,
@@ -1313,6 +1317,7 @@ export type InboxUIItem = {
   time: gregor1.Time,
   notifications?: ?ConversationNotificationInfo,
   creatorInfo?: ?ConversationCreatorInfoLocal,
+  version: ConversationVers,
   finalizeInfo?: ?ConversationFinalizeInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
@@ -1995,6 +2000,7 @@ export type UnverifiedInboxUIItem = {
   teamType: TeamType,
   notifications?: ?ConversationNotificationInfo,
   time: gregor1.Time,
+  version: ConversationVers,
 }
 
 export type UnverifiedInboxUIItems = {

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -151,6 +151,9 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
       const newInbox = action.payload.inbox.map(newRow => {
         const id = newRow.get('conversationIDKey')
         const existingRow = existingRows.find(existingRow => existingRow.get('conversationIDKey') === id)
+        console.warn(
+          `existing tlf: ${existingRow.teamname} existing name: ${existingRow.channelname} existing.version: ${existingRow.version} new.version: ${newRow.version}`
+        )
         return existingRow ? (existingRow.version < newRow.version ? newRow : existingRow) : newRow
       })
 

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -151,7 +151,7 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
       const newInbox = action.payload.inbox.map(newRow => {
         const id = newRow.get('conversationIDKey')
         const existingRow = existingRows.find(existingRow => existingRow.get('conversationIDKey') === id)
-        return existingRow ? (existingRow.teamType !== newRow.teamType ? newRow : existingRow) : newRow
+        return existingRow ? (existingRow.version < newRow.version ? newRow : existingRow) : newRow
       })
 
       return state.set('inbox', newInbox).set('rekeyInfos', Map())

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -151,10 +151,7 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
       const newInbox = action.payload.inbox.map(newRow => {
         const id = newRow.get('conversationIDKey')
         const existingRow = existingRows.find(existingRow => existingRow.get('conversationIDKey') === id)
-        console.warn(
-          `existing tlf: ${existingRow.teamname} existing name: ${existingRow.channelname} existing.version: ${existingRow.version} new.version: ${newRow.version}`
-        )
-        return existingRow ? (existingRow.version < newRow.version ? newRow : existingRow) : newRow
+        return existingRow ? (existingRow.version !== newRow.version ? newRow : existingRow) : newRow
       })
 
       return state.set('inbox', newInbox).set('rekeyInfos', Map())


### PR DESCRIPTION
Patch does the following:

1.) Threads the new conversation version number up to the frontend so they can use it better diff inbox results against what they currently have.
2.) Fixes some key inbox storage bugs that was causing us to blast away the on disk copy way more than we should.
3.) Change frontend to use the new version number when deciding which rows need to be updated.