### PR TITLE
Exit search when selecting a conversation

### DIFF
--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -113,10 +113,10 @@ const loadAttachmentPreviewTransformer = ({
   type,
 })
 
-function exitSearch(): Constants.ExitSearch {
+function exitSearch(forSelectConversation: boolean): Constants.ExitSearch {
   return {
+    payload: {forSelectConversation},
     type: 'chat:exitSearch',
-    payload: {},
   }
 }
 

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -113,9 +113,9 @@ const loadAttachmentPreviewTransformer = ({
   type,
 })
 
-function exitSearch(forSelectConversation: boolean): Constants.ExitSearch {
+function exitSearch(skipSelectPreviousConversation: boolean): Constants.ExitSearch {
   return {
-    payload: {forSelectConversation},
+    payload: {skipSelectPreviousConversation},
     type: 'chat:exitSearch',
   }
 }

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -1240,12 +1240,12 @@ function* _updateTempSearchConversation(
   yield all(actionsToPut)
 }
 
-function* _exitSearch() {
-  const inboxSearch = yield select(inboxSearchSelector)
+function* _exitSearch({payload: {forSelectConversation}}: Constants.ExitSearch) {
+  const inboxSearch = forSelectConversation ? null : yield select(inboxSearchSelector)
   yield put(Creators.clearSearchResults())
   yield put(Creators.setInboxSearch([]))
   yield put(Creators.removeTempPendingConversations())
-  if (inboxSearch.count() === 0) {
+  if (inboxSearch !== null && inboxSearch.count() === 0) {
     yield put(Creators.selectConversation(yield select(previousConversationSelector), false))
   }
 }

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -867,9 +867,7 @@ function* _selectConversation(action: Constants.SelectConversation): SagaGenerat
   const {conversationIDKey, fromUser} = action.payload
 
   if (fromUser) {
-    yield put(Creators.clearSearchResults())
-    yield put(Creators.setInboxSearch([]))
-    yield put(Creators.removeTempPendingConversations())
+    yield put(Creators.exitSearch(true))
   }
 
   // Load the inbox item always

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -866,6 +866,10 @@ function* _updateMetadata(action: Constants.UpdateMetadata): SagaGenerator<any, 
 function* _selectConversation(action: Constants.SelectConversation): SagaGenerator<any, any> {
   const {conversationIDKey, fromUser} = action.payload
 
+  if (fromUser) {
+    yield put(Creators.exitSearch())
+  }
+
   // Load the inbox item always
   if (conversationIDKey) {
     yield put(Creators.getInboxAndUnbox([conversationIDKey]))

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -867,7 +867,9 @@ function* _selectConversation(action: Constants.SelectConversation): SagaGenerat
   const {conversationIDKey, fromUser} = action.payload
 
   if (fromUser) {
-    yield put(Creators.exitSearch())
+    yield put(Creators.clearSearchResults())
+    yield put(Creators.setInboxSearch([]))
+    yield put(Creators.removeTempPendingConversations())
   }
 
   // Load the inbox item always

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -1238,8 +1238,8 @@ function* _updateTempSearchConversation(
   yield all(actionsToPut)
 }
 
-function* _exitSearch({payload: {forSelectConversation}}: Constants.ExitSearch) {
-  const inboxSearch = forSelectConversation ? null : yield select(inboxSearchSelector)
+function* _exitSearch({payload: {skipSelectPreviousConversation}}: Constants.ExitSearch) {
+  const inboxSearch = skipSelectPreviousConversation ? null : yield select(inboxSearchSelector)
   yield put(Creators.clearSearchResults())
   yield put(Creators.setInboxSearch([]))
   yield put(Creators.removeTempPendingConversations())

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -80,7 +80,7 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
   // that is deleted by exitSearch().
   const inSearch = yield select((state: TypedState) => state.chat.get('inSearch'))
   if (inSearch) {
-    yield put(Creators.exitSearch())
+    yield put(Creators.exitSearch(false))
   }
 
   const [inboxConvo, lastMessageID]: [Constants.InboxState, ?Constants.MessageID] = yield all([

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -109,7 +109,7 @@ const mapDispatchToProps = (
   dispatch: Dispatch,
   {setRouteState, navigateUp, navigateAppend}
 ): DispatchProps => ({
-  onExitSearch: () => dispatch(Creators.exitSearch()),
+  onExitSearch: () => dispatch(Creators.exitSearch(false)),
   _onAttach: (selectedConversation, inputs: Array<Constants.AttachmentInput>) => {
     dispatch(
       navigateAppend([

--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -276,8 +276,9 @@ const mapDispatchToProps = (dispatch: Dispatch, {focusFilter, routeState, setRou
     }
   },
   onNewChat: () => dispatch(newChat()),
-  onSelect: (conversationIDKey: ?Constants.ConversationIDKey) =>
-    conversationIDKey && dispatch(selectConversation(conversationIDKey, true)),
+  onSelect: (conversationIDKey: ?Constants.ConversationIDKey) => {
+    dispatch(selectConversation(conversationIDKey, true))
+  },
   onSetFilter: (filter: string) => dispatch(setInboxFilter(filter)),
   toggleSmallTeamsExpanded: () => setRouteState({smallTeamsExpanded: !routeState.smallTeamsExpanded}),
   onUntrustedInboxVisible: (converationIDKey, rowsVisible) =>

--- a/shared/chat/inbox/row/container.js
+++ b/shared/chat/inbox/row/container.js
@@ -144,7 +144,6 @@ const mapDispatchToProps = dispatch => ({
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   ...ownProps,
   ...stateProps,
-  ...dispatchProps,
   onSelectConversation: () => dispatchProps._onSelectConversation(stateProps.conversationIDKey),
   onShowMenu: () => dispatchProps._onShowMenu(stateProps.teamname),
 })

--- a/shared/chat/search-header.js
+++ b/shared/chat/search-header.js
@@ -40,7 +40,7 @@ const mapStateToProps = createSelector(
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   onRemoveUser: id => dispatch(Creators.unstageUserForSearch(id)),
-  onExitSearch: () => dispatch(Creators.exitSearch()),
+  onExitSearch: () => dispatch(Creators.exitSearch(false)),
   clearSearchResults: () => dispatch(Creators.clearSearchResults()),
   search: (term: string, service) => {
     if (term) {

--- a/shared/chat/search.js
+++ b/shared/chat/search.js
@@ -28,7 +28,7 @@ const mapStateToProps = createSelector(
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   onRemoveUser: id => dispatch(Creators.unstageUserForSearch(id)),
-  onExitSearch: () => dispatch(Creators.exitSearch()),
+  onExitSearch: () => dispatch(Creators.exitSearch(false)),
   clearSearchResults: () => dispatch(Creators.clearSearchResults()),
   search: (term: string, service) => {
     if (term) {

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -463,7 +463,7 @@ export type ClearSearchResults = NoErrorTypedAction<'chat:clearSearchResults', {
 export type ClearRekey = NoErrorTypedAction<'chat:clearRekey', {conversationIDKey: ConversationIDKey}>
 export type DeleteMessage = NoErrorTypedAction<'chat:deleteMessage', {message: Message}>
 export type EditMessage = NoErrorTypedAction<'chat:editMessage', {message: Message, text: HiddenString}>
-export type ExitSearch = NoErrorTypedAction<'chat:exitSearch', {}>
+export type ExitSearch = NoErrorTypedAction<'chat:exitSearch', {forSelectConversation: boolean}>
 export type GetInboxAndUnbox = NoErrorTypedAction<
   'chat:getInboxAndUnbox',
   {conversationIDKeys: Array<ConversationIDKey>}

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -463,7 +463,7 @@ export type ClearSearchResults = NoErrorTypedAction<'chat:clearSearchResults', {
 export type ClearRekey = NoErrorTypedAction<'chat:clearRekey', {conversationIDKey: ConversationIDKey}>
 export type DeleteMessage = NoErrorTypedAction<'chat:deleteMessage', {message: Message}>
 export type EditMessage = NoErrorTypedAction<'chat:editMessage', {message: Message, text: HiddenString}>
-export type ExitSearch = NoErrorTypedAction<'chat:exitSearch', {forSelectConversation: boolean}>
+export type ExitSearch = NoErrorTypedAction<'chat:exitSearch', {skipSelectPreviousConversation: boolean}>
 export type GetInboxAndUnbox = NoErrorTypedAction<
   'chat:getInboxAndUnbox',
   {conversationIDKeys: Array<ConversationIDKey>}


### PR DESCRIPTION
...take 2.

This time, prevent exitSearch from calling selectConversation if
it's being invoked on behalf of selectConversation.