### PR TITLE
Windows split installer: leave more definitive breadcrumbs

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -124,6 +124,7 @@
               Action="createAndRemoveOnUninstall">
           <RegistryValue Type="string" Name="DOKANPRODUCT86" Value="[DOKANPRODUCT86]"/>
           <RegistryValue Type="string" Name="DOKANPRODUCT64" Value="[DOKANPRODUCT64]"/>
+	  <RegistryValue Type="string" Name="BUNDLEKEY" Value="[BUNDLEKEY]"/>
         </RegistryKey>
       </Component>
       

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -253,6 +253,7 @@
                   Permanent="no">
         <MsiProperty Name="DOKANPRODUCT86" Value="$(var.DokanProductCodeX86)" />
         <MsiProperty Name="DOKANPRODUCT64" Value="$(var.DokanProductCodeX64)" />
+	<MsiProperty Name="BUNDLEKEY" Value="[WixBundleProviderKey]" />        
       </MsiPackage>
 
     </Chain>

--- a/shared/actions/kbfs/index.platform.desktop.js
+++ b/shared/actions/kbfs/index.platform.desktop.js
@@ -171,12 +171,13 @@ function findKeybaseUninstallString(): Promise<string> {
     const regedit = require('regedit')
     const keybaseRegPath = 'HKCU\\SOFTWARE\\Keybase\\Keybase'
     regedit.list(keybaseRegPath).on('data', function(entry) {
-      if (entry.data.values.BUNDLEKEY) {
+      if (entry.data.values && entry.data.values.BUNDLEKEY) {
         const uninstallRegPath =
           'HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\' + entry.data.values.BUNDLEKEY
 
         regedit.list(uninstallRegPath).on('data', function(entry) {
           if (
+            entry.data.values &&
             entry.data.values.DisplayName &&
             entry.data.values.DisplayName.value === 'Keybase' &&
             entry.data.values.Publisher &&


### PR DESCRIPTION
instead of searching the registry for things named "Keybase".
Some users seemed to have multiple keybase entries in the uninstall key somehow - this will let them add the mount.
@keybase/react-hackers 