### PR TITLE
Check TeamList results from server

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -886,7 +886,7 @@ func (o TeamSBSMsg) DeepCopy() TeamSBSMsg {
 }
 
 // * TeamRefreshData are needed or wanted data requirements that, if unmet, will cause
-// * a refresh of the cached.
+// * a refresh of the cache.
 type TeamRefreshers struct {
 	NeedKeyGeneration PerTeamKeyGeneration `codec:"needKeyGeneration" json:"needKeyGeneration"`
 	WantMembers       []UserVersion        `codec:"wantMembers" json:"wantMembers"`

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -3,8 +3,11 @@ package teams
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
@@ -42,98 +45,168 @@ func getTeamsListFromServer(ctx context.Context, g *libkb.GlobalContext, uid key
 	return list.Teams, nil
 }
 
+// List info about teams
+// If an error is encountered while loading some teams, the team is skipped and no error is returned.
+// If an error occurs loading all the info, an error is returned.
 func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg) (*keybase1.AnnotatedTeamList, error) {
 	tracer := g.CTimeTracer(ctx, "TeamList")
 	defer tracer.Finish()
 
-	var uid keybase1.UID
+	var queryUID keybase1.UID
 	if arg.UserAssertion != "" {
 		res := g.Resolver.ResolveFullExpression(ctx, arg.UserAssertion)
 		if res.GetError() != nil {
 			return nil, res.GetError()
 		}
-		uid = res.GetUID()
+		queryUID = res.GetUID()
 	}
 
 	meUID := g.ActiveDevice.UID()
 
 	tracer.Stage("server")
-	teams, err := getTeamsListFromServer(ctx, g, uid, arg.All)
+	teams, err := getTeamsListFromServer(ctx, g, queryUID, arg.All)
 	if err != nil {
 		return nil, err
 	}
 
-	tracer.Stage("loop1")
-	teamList := make(map[string]keybase1.TeamID)
-	upakLoader := g.GetUPAKLoader()
-	var annotatedTeams []keybase1.AnnotatedMemberInfo
-	administeredTeams := make(map[string]bool)
+	tracer.Stage("loads")
+
+	var resLock sync.Mutex
+	res := &keybase1.AnnotatedTeamList{
+		Teams: nil,
+		AnnotatedActiveInvites: make(map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite),
+	}
+
+	// Process all the teams in parallel. Limit to 15 in parallel so we don't crush the server.
+	// errgroup collects errors and returns the first non-nil.
+	// subctx is canceled when the group finishes.
+	const parallelLimit int64 = 15
+	sem := semaphore.NewWeighted(parallelLimit)
+	group, subctx := errgroup.WithContext(ctx)
 	for _, memberInfo := range teams {
-		// Skip implicit teams unless --include-implicit-teams was passed from above.
-		if memberInfo.IsImplicitTeam && !arg.IncludeImplicitTeams {
-			continue
-		}
+		memberInfo := memberInfo // https://golang.org/doc/faq#closures_and_goroutines
+		group.Go(func() error {
+			// Grab one of the parallelLimit slots
+			err := sem.Acquire(subctx, 1)
+			if err != nil {
+				return err
+			}
+			defer sem.Release(1)
 
-		teamList[memberInfo.FqName] = memberInfo.TeamID
-		if memberInfo.UserID == meUID && (memberInfo.Role.IsAdminOrAbove() || (memberInfo.Implicit != nil && memberInfo.Implicit.Role.IsAdminOrAbove())) {
-			administeredTeams[memberInfo.FqName] = true
-		}
+			// Skip implicit teams unless --include-implicit-teams was passed from above.
+			if memberInfo.IsImplicitTeam && !arg.IncludeImplicitTeams {
+				return nil
+			}
 
-		memberuid := memberInfo.UserID
-		username, err := upakLoader.LookupUsername(context.Background(), memberuid)
-		if err != nil {
-			return nil, err
-		}
-		fullName, err := engine.GetFullName(context.Background(), g, memberuid)
-		if err != nil {
-			return nil, err
-		}
-		annotatedTeams = append(annotatedTeams, keybase1.AnnotatedMemberInfo{
-			TeamID:         memberInfo.TeamID,
-			FqName:         memberInfo.FqName,
-			UserID:         memberInfo.UserID,
-			Role:           memberInfo.Role,
-			IsImplicitTeam: memberInfo.IsImplicitTeam,
-			Implicit:       memberInfo.Implicit,
-			Username:       username.String(),
-			FullName:       fullName,
+			var isAdminSaysServer bool
+			if memberInfo.UserID == meUID &&
+				(memberInfo.Role.IsAdminOrAbove() || (memberInfo.Implicit != nil && memberInfo.Implicit.Role.IsAdminOrAbove())) {
+
+				isAdminSaysServer = true
+			}
+
+			memberUID := memberInfo.UserID
+
+			username, err := g.GetUPAKLoader().LookupUsername(context.Background(), memberUID)
+			if err != nil {
+				return err
+			}
+			fullName, err := engine.GetFullName(context.Background(), g, memberUID)
+			if err != nil {
+				return err
+			}
+
+			type AnnotatedTeamInviteMap map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite
+
+			loadTeamForAMI := func(force bool) (anMemberInfo *keybase1.AnnotatedMemberInfo, anInvites AnnotatedTeamInviteMap,
+				retry bool, err error) {
+
+				g.Log.CDebugf(subctx, "TeamList loading(%v, force=%v)", memberInfo.TeamID, force)
+
+				team, err := Load(subctx, g, keybase1.LoadTeamArg{
+					ID:          memberInfo.TeamID,
+					NeedAdmin:   isAdminSaysServer,
+					ForceRepoll: force,
+				})
+				if err != nil {
+					return nil, nil, false, err
+				}
+
+				role := keybase1.TeamRole_NONE
+				if memberInfo.Role != keybase1.TeamRole_NONE {
+					memberUV, err := team.chain().GetLatestUVWithUID(memberUID)
+					if err != nil {
+						// retryable because the role of this member might have changed since cache hit
+						return nil, nil, true, fmt.Errorf("did not find %v (for role %v)", username, memberInfo.Role)
+					}
+					role, err = team.chain().GetUserRole(memberUV)
+					if err != nil {
+						return nil, nil, false, err
+					}
+				}
+				if role != memberInfo.Role {
+					return nil, nil, true, fmt.Errorf("got unexpected role: %v", role.String())
+				}
+
+				anMemberInfo = &keybase1.AnnotatedMemberInfo{
+					TeamID:         team.ID,
+					FqName:         team.Name().String(),
+					UserID:         memberUID,
+					Role:           role,
+					IsImplicitTeam: team.IsImplicit(),
+					Implicit:       memberInfo.Implicit, // This part is still server trust
+					Username:       username.String(),
+					FullName:       fullName,
+				}
+
+				anInvites = make(AnnotatedTeamInviteMap)
+				if isAdminSaysServer {
+					anInvites, err = AnnotateInvites(subctx, g, team.chain().inner.ActiveInvites, team.Name().String())
+					if err != nil {
+						return nil, nil, false, err
+					}
+				}
+
+				return anMemberInfo, anInvites, false, nil
+			}
+
+			var anMemberInfo *keybase1.AnnotatedMemberInfo
+			var anInvites AnnotatedTeamInviteMap
+
+			// Load the team in order to use local data instead of server-trust for fields.
+			// Try once without ForceRepoll and then once with. In case the cache is stale.
+			// This could be simpler and faster if the server returned the latest seqno as a hint.
+			anMemberInfo, anInvites, retry, err := loadTeamForAMI(false)
+			if err != nil {
+				if retry {
+					anMemberInfo, anInvites, retry, err = loadTeamForAMI(false)
+				}
+			}
+			if err != nil {
+				g.Log.Warning("Error while getting team (%s): %v", memberInfo.FqName, err)
+				return nil
+			}
+
+			// After this lock it is safe to write out results
+			resLock.Lock()
+			defer resLock.Unlock()
+
+			res.Teams = append(res.Teams, *anMemberInfo)
+			for teamInviteID, annotatedTeamInvite := range anInvites {
+				res.AnnotatedActiveInvites[teamInviteID] = annotatedTeamInvite
+			}
+
+			return nil
 		})
 	}
 
-	tracer.Stage("loop2")
-	annotatedInvites := make(map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite)
-	for teamName, teamID := range teamList {
-		_, ok := administeredTeams[teamName]
-		if ok {
-			t, err := Load(ctx, g, keybase1.LoadTeamArg{
-				ID:        teamID,
-				NeedAdmin: true,
-			})
-			if err != nil {
-				g.Log.Warning("Error while getting team (%s): %v", teamName, err)
-				continue
-			}
-			if t.Name().String() != teamName {
-				// This could trigger if we have cached an old name and have not gotten updates.
-				g.Log.Warning("Error while getting team (%s): %v", teamName, fmt.Errorf("team name mismatch"))
-				continue
-			}
-			teamAnnotatedInvites, err := AnnotateInvites(ctx, g, t.chain().inner.ActiveInvites, teamName)
-			if err != nil {
-				return nil, err
-			}
-			for teamInviteID, annotatedTeamInvite := range teamAnnotatedInvites {
-				annotatedInvites[teamInviteID] = annotatedTeamInvite
-			}
-		}
+	err = group.Wait()
+
+	if len(res.Teams) == 0 && len(teams) > 0 {
+		return res, fmt.Errorf("multiple errors while loading team list")
 	}
 
-	tl := keybase1.AnnotatedTeamList{
-		Teams: annotatedTeams,
-		AnnotatedActiveInvites: annotatedInvites,
-	}
-
-	return &tl, nil
+	return res, err
 }
 
 func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, invites map[keybase1.TeamInviteID]keybase1.TeamInvite, teamName string) (map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite, error) {

--- a/go/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/go/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,131 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"sync"
+
+	// Use the old context because packages that depend on this one
+	// (e.g. cloud.google.com/go/...) must run on Go 1.6.
+	// TODO(jba): update to "context" when possible.
+	"golang.org/x/net/context"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking only until ctx
+// is done. On success, returns nil. On failure, returns ctx.Err() and leaves
+// the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			s.waiters.Remove(elem)
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: bad release")
+	}
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+	s.mu.Unlock()
+}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -741,6 +741,12 @@
 			"revisionTime": "2016-07-15T18:54:39Z"
 		},
 		{
+			"checksumSHA1": "vcN67ZjTbGpLLwSghHCbAEvmzMo=",
+			"path": "golang.org/x/sync/semaphore",
+			"revision": "f52d1811a62927559de87708c8913c1650ce4f26",
+			"revisionTime": "2017-05-17T20:25:26Z"
+		},
+		{
 			"path": "golang.org/x/sys/windows",
 			"revision": "f64b50fbea64174967a8882830d621a18ee1548e",
 			"revisionTime": "2016-04-14T16:31:22+03:00"

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -304,7 +304,7 @@ protocol teams {
 
   /**
    * TeamRefreshData are needed or wanted data requirements that, if unmet, will cause
-   * a refresh of the cached.
+   * a refresh of the cache.
    */
   record TeamRefreshers {
     // Load at least up to the keygen. Returns an error if the keygen is not loaded.

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -803,7 +803,7 @@
           "name": "wantMembersRole"
         }
       ],
-      "doc": "* TeamRefreshData are needed or wanted data requirements that, if unmet, will cause\n   * a refresh of the cached."
+      "doc": "* TeamRefreshData are needed or wanted data requirements that, if unmet, will cause\n   * a refresh of the cache."
     },
     {
       "type": "record",


### PR DESCRIPTION
Load teams locally and use local checked data. The server can still omit teams. Also the `Implicit` sections is still server-trust, because it would probably be easier to redo the api than fix that. Also do it in parallel.

The error handling is a little different. If a team errors out, it's just skipped. In the long term we might want an error field in the response. But really this RPC signature seems weird to me and anything with different requirements might want a new one.

Seems about the same speed as before for a test user with a bunch of (easy to load) teams. In my previous PRs maybe I only listed hot-cache numbers, seems misleading, sorry.
```before:
list-members cold 4s
list-members hot 0s
list-members --all cold 5.5
list-members --all lukewarm 2.8
list-members --all hot 0
list-members --user somebody 0

after:
list-members cold 2s
list-members hot .1s
list-members --all cold 2s
list-members --all hot .1s
list-members --user somebody .5s (depends)
list-members --user somebody cold .1s (depends)```