### PR TITLE
Delete team from cache when team deleted

### DIFF
--- a/go/encrypteddb/encrypteddb.go
+++ b/go/encrypteddb/encrypteddb.go
@@ -114,6 +114,11 @@ func (i *EncryptedDB) Put(ctx context.Context, key libkb.DbKey, data interface{}
 	return db.PutRaw(key, dat)
 }
 
+func (i *EncryptedDB) Delete(ctx context.Context, key libkb.DbKey) error {
+	db := i.getDB(i.G())
+	return db.Delete(key)
+}
+
 func encode(input interface{}) ([]byte, error) {
 	mh := codec.MsgpackHandle{WriteExt: true}
 	var data []byte

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -588,5 +588,7 @@ type TeamLoader interface {
 	MapIDToName(ctx context.Context, id keybase1.TeamID) (keybase1.TeamName, error)
 	NotifyTeamRename(ctx context.Context, id keybase1.TeamID, newName string) error
 	Load(context.Context, keybase1.LoadTeamArg) (*keybase1.TeamData, error)
+	// Delete the cache entry. Does not error if there is no cache entry.
+	Delete(context.Context, keybase1.TeamID) error
 	OnLogout()
 }

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -45,4 +45,8 @@ func (n nullTeamLoader) Load(context.Context, keybase1.LoadTeamArg) (*keybase1.T
 	return nil, fmt.Errorf("null team loader")
 }
 
+func (n nullTeamLoader) Delete(context.Context, keybase1.TeamID) error {
+	return nil
+}
+
 func (n nullTeamLoader) OnLogout() {}

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -74,8 +74,15 @@ func HandleChangeNotification(ctx context.Context, g *libkb.GlobalContext, rows 
 	return nil
 }
 
-func HandleDeleteNotification(ctx context.Context, g *libkb.GlobalContext, rows []keybase1.TeamChangeRow) error {
+func HandleDeleteNotification(ctx context.Context, g *libkb.GlobalContext, rows []keybase1.TeamChangeRow) (err error) {
+	defer g.CTrace(ctx, fmt.Sprintf("team.HandleDeleteNotification(%v)", len(rows)), func() error { return err })()
+
 	for _, row := range rows {
+		g.Log.CDebugf(ctx, "team.HandleDeleteNotification: (%+v)", row)
+		err := g.GetTeamLoader().Delete(ctx, row.Id)
+		if err != nil {
+			g.Log.CDebugf(ctx, "team.HandleDeleteNotification: error deleting team: %v", err)
+		}
 		g.NotifyRouter.HandleTeamDeleted(ctx, row.Id)
 	}
 	return nil

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -64,6 +64,14 @@ func (l *TeamLoader) Load(ctx context.Context, lArg keybase1.LoadTeamArg) (res *
 	return l.load1(ctx, me, lArg)
 }
 
+func (l *TeamLoader) Delete(ctx context.Context, teamID keybase1.TeamID) error {
+	// Single-flight lock by team ID.
+	lock := l.locktab.AcquireOnName(ctx, l.G(), teamID.String())
+	defer lock.Release(ctx)
+
+	return l.storage.Delete(ctx, teamID)
+}
+
 // Load1 unpacks the loadArg, calls load2, and does some final checks.
 // The key difference between load1 and load2 is that load2 is recursive (for subteams).
 func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg keybase1.LoadTeamArg) (*keybase1.TeamData, error) {

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -64,7 +64,9 @@ func (l *TeamLoader) Load(ctx context.Context, lArg keybase1.LoadTeamArg) (res *
 	return l.load1(ctx, me, lArg)
 }
 
-func (l *TeamLoader) Delete(ctx context.Context, teamID keybase1.TeamID) error {
+func (l *TeamLoader) Delete(ctx context.Context, teamID keybase1.TeamID) (err error) {
+	defer l.G().CTraceTimed(ctx, fmt.Sprintf("TeamLoader#Delete(%v)", teamID), func() error { return err })()
+
 	// Single-flight lock by team ID.
 	lock := l.locktab.AcquireOnName(ctx, l.G(), teamID.String())
 	defer lock.Release(ctx)

--- a/go/teams/storage.go
+++ b/go/teams/storage.go
@@ -66,6 +66,14 @@ func (s *Storage) Get(ctx context.Context, teamID keybase1.TeamID) *keybase1.Tea
 	return nil
 }
 
+func (s *Storage) Delete(ctx context.Context, teamID keybase1.TeamID) error {
+	s.Lock()
+	defer s.Unlock()
+
+	s.mem.Delete(ctx, teamID)
+	return s.disk.Delete(ctx, teamID)
+}
+
 func (s *Storage) onLogout() {
 	s.mem.onLogout()
 }
@@ -145,6 +153,14 @@ func (s *DiskStorage) Get(ctx context.Context, teamID keybase1.TeamID) (res *key
 	return item.State, true, nil
 }
 
+func (s *DiskStorage) Delete(ctx context.Context, teamID keybase1.TeamID) error {
+	s.Lock()
+	defer s.Unlock()
+
+	key := s.dbKey(ctx, teamID)
+	return s.encryptedDB.Delete(ctx, key)
+}
+
 func (s *DiskStorage) dbKey(ctx context.Context, teamID keybase1.TeamID) libkb.DbKey {
 	return libkb.DbKey{
 		Typ: libkb.DBChatInbox,
@@ -190,6 +206,10 @@ func (s *MemoryStorage) Get(ctx context.Context, teamID keybase1.TeamID) *keybas
 		return nil
 	}
 	return state
+}
+
+func (s *MemoryStorage) Delete(ctx context.Context, teamID keybase1.TeamID) {
+	s.lru.Remove(teamID)
 }
 
 func (s *MemoryStorage) onLogout() {


### PR DESCRIPTION
Delete the team cache when gregor tells us to with a `team.delete`. Not guaranteed to run, as is the nature of these things.

Is there a gregor message that could be used for when you are removed from a team but not because it is deleted? Do people who are kicked get `team.change`?