### PR TITLE
Danny/desktop 4906/chat tweaks

### DIFF
--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -160,6 +160,8 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
 
   // Not editing anymore
   yield put(Creators.showEditor(null))
+
+  // if message post-edit is the same as message pre-edit, skip call and marking message as 'EDITED'
   const [prevMessageText, newMessageText] = [message.message.stringValue(), action.payload.text.stringValue()]
   if (prevMessageText === newMessageText) {
     return

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -160,11 +160,14 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
 
   // Not editing anymore
   yield put(Creators.showEditor(null))
-
+  const [prevMessageText, newMessageText] = [message.message.stringValue(), action.payload.text.stringValue()]
+  if (prevMessageText === newMessageText) {
+    return
+  }
   const outboxID = yield call(ChatTypes.localGenerateOutboxIDRpcPromise)
   yield call(ChatTypes.localPostEditNonblockRpcPromise, {
     param: {
-      body: action.payload.text.stringValue(),
+      body: newMessageText,
       clientPrev: lastMessageID ? Constants.parseMessageID(lastMessageID).msgID : 0,
       conversationID: Constants.keyToConversationID(conversationIDKey),
       identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,

--- a/shared/package.json
+++ b/shared/package.json
@@ -99,7 +99,7 @@
     "react-navigation": "git://github.com/keybase/react-navigation#keybase-fixes-off-beta-12",
     "react-redux": "5.0.6",
     "react-transition-group": "2.2.0",
-    "react-virtualized": "9.9.0",
+    "react-virtualized": "9.10.1",
     "recompose": "0.25.0",
     "redux": "3.7.2",
     "redux-batched-subscribe": "0.1.6",

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -7399,11 +7399,11 @@ react-treebeard@^2.0.3:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react-virtualized@9.9.0:
-  version "9.9.0"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.9.0.tgz#799a6f23819eeb82860d59b82fad33d1d420325e"
+react-virtualized@9.10.1:
+  version "9.10.1"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.10.1.tgz#d32365d0edf49debbe25fbfe73b5f55f6d9d8c72"
   dependencies:
-    babel-runtime "^6.11.6"
+    babel-runtime "^6.23.0"
     classnames "^2.2.3"
     dom-helpers "^2.4.0 || ^3.0.0"
     loose-envify "^1.3.0"


### PR DESCRIPTION
Removes the update message RPC call when an edited message is the same as the original message.

Also updates react-virtualized to the latest version, which reduces some of the lag between sending a message (pressing enter) and having it appear on the list.