### PR TITLE
fix forgetting to clear the repos list in badge state

### DIFF
--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -64,6 +64,7 @@ func (b *BadgeState) UpdateWithGregor(gstate gregor.State) error {
 	b.state.NewTlfs = 0
 	b.state.NewFollowers = 0
 	b.state.RekeysNeeded = 0
+	b.state.NewGitRepoGlobalUniqueIDs = []string{}
 
 	items, err := gstate.Items()
 	if err != nil {


### PR DESCRIPTION
The BadgeState struct gets reused, and we were forgetting to
reinitialize the new repos list, so it was adding dups every time it was
loaded.

r? @mmaxim 

cc @chrisnojima 