### PR TITLE
workaround PGP keys with extra junk on the first header line 

### DIFF
--- a/go/libkb/generickey.go
+++ b/go/libkb/generickey.go
@@ -108,7 +108,7 @@ func IsPGP(key GenericKey) bool {
 func ParseGenericKey(bundle string) (GenericKey, *Warnings, error) {
 	if isPGPBundle(bundle) {
 		// PGP key
-		return ReadOneKeyFromString(bundle)
+		return ReadOneKeyFromStringLiberal(bundle)
 	}
 	// NaCl key
 	key, err := ImportKeypairFromKID(keybase1.KIDFromString(bundle))

--- a/go/libkb/pgp_clean_test.go
+++ b/go/libkb/pgp_clean_test.go
@@ -23,7 +23,7 @@ func TestKeithWinstein(t *testing.T) {
 	}
 }
 
-func TestBug8162Prepass(t *testing.T) {
+func TestBug8612Prepass(t *testing.T) {
 
 	whackyKey := `-----BEGIN PGP PUBLIC KEY BLOCK-----              [1/2]
 
@@ -63,8 +63,8 @@ UzzykQlAfLl74336wrkSZfa2GnBBJQHvlnLosnmbGCzsd3KMkuJv90hxxt1rqjN6
 =sJQD
 -----END PGP PUBLIC KEY BLOCK-----`
 
-	require.Equal(t, regularKey, bug8162Prepass(regularKey))
-	require.Equal(t, regularKey, bug8162Prepass(whackyKey))
+	require.Equal(t, regularKey, bug8612Prepass(regularKey))
+	require.Equal(t, regularKey, bug8612Prepass(whackyKey))
 
 	_, _, err := ReadOneKeyFromString(whackyKey)
 	require.Error(t, err)

--- a/go/libkb/pgp_clean_test.go
+++ b/go/libkb/pgp_clean_test.go
@@ -5,6 +5,7 @@ package libkb
 
 import (
 	"encoding/base64"
+	require "github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -20,4 +21,54 @@ func TestKeithWinstein(t *testing.T) {
 	} else if _, _, err = ReadOneKeyFromString(string(key)); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestCore6142Prepass(t *testing.T) {
+
+	whackyKey := `-----BEGIN PGP PUBLIC KEY BLOCK-----              [1/2]
+
+mI0EWcknrwEEAK2X5lKA76pf6i5D1aVcApUAH6NnZ4NkFeSxKT92soiSWkFn+I/G
+VKJfTvx2dzxOAB4rvyFjUzjgAwhK3FblCnfXwgPAh6/vukF/YBwynCVyNxOVAVHY
+gCkw/+7zIM24RUxzI3V9wzJ6i/SpfNnWKkKqJXIt4Xzv3Rs/UXk5DMY5ABEBAAG0
+I01heCBUZXN0IDc3NyA8dGhlbWF4Kzc3N0BnbWFpbC5jb20+iLgEEwECACIFAlnJ
+J68CGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEM5jclcHa4v8ssQD/RJA
+JTrfydAkLzffGgZyKafs/aTraVDNtDv1sF+5iBtZvOB0FFjzivl3BGlplEqnPquB
+bg8/OQuxFLYM/f8+WgP5MDqBce8s6h5kGZPj73zP4GQLZWojS5/H3J1sDBmNTSnd
+ByELhvVxJmJiHdz2jMb74+thB/ZK4xf+zAkRF4WZuI0EWcknrwEEALk0Bsp/xJ+4
+75hswySLZmvNh79CyIC0K1gzXiEPDwqGy6xT1PbXLJ5HcXna4HJdNAgXf1T/n+zR
+19xJMAB6NSv2zigRaYAyy4It2p2cRPHseWWTcP7lMUpwqtQsnqNKJ14RuAaMOQtG
+xSaQMgMGZx6lxFWNaK40SxSnqFRtfRs9ABEBAAGInwQYAQIACQUCWcknrwIbDAAK
+CRDOY3JXB2uL/PX/A/9HvpLPVDrEMr9+vzmS8Ez0br2kgeoPh7yOAlEotS7OBNWU
+UzzykQlAfLl74336wrkSZfa2GnBBJQHvlnLosnmbGCzsd3KMkuJv90hxxt1rqjN6
+3GFiwBVdsSuyEb3uQJ/ytAyVozwwxjMQZ+gJTYfK8syPdf2T1W6cv7lfHp8E8g==
+=sJQD
+-----END PGP PUBLIC KEY BLOCK-----`
+
+	regularKey := `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mI0EWcknrwEEAK2X5lKA76pf6i5D1aVcApUAH6NnZ4NkFeSxKT92soiSWkFn+I/G
+VKJfTvx2dzxOAB4rvyFjUzjgAwhK3FblCnfXwgPAh6/vukF/YBwynCVyNxOVAVHY
+gCkw/+7zIM24RUxzI3V9wzJ6i/SpfNnWKkKqJXIt4Xzv3Rs/UXk5DMY5ABEBAAG0
+I01heCBUZXN0IDc3NyA8dGhlbWF4Kzc3N0BnbWFpbC5jb20+iLgEEwECACIFAlnJ
+J68CGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEM5jclcHa4v8ssQD/RJA
+JTrfydAkLzffGgZyKafs/aTraVDNtDv1sF+5iBtZvOB0FFjzivl3BGlplEqnPquB
+bg8/OQuxFLYM/f8+WgP5MDqBce8s6h5kGZPj73zP4GQLZWojS5/H3J1sDBmNTSnd
+ByELhvVxJmJiHdz2jMb74+thB/ZK4xf+zAkRF4WZuI0EWcknrwEEALk0Bsp/xJ+4
+75hswySLZmvNh79CyIC0K1gzXiEPDwqGy6xT1PbXLJ5HcXna4HJdNAgXf1T/n+zR
+19xJMAB6NSv2zigRaYAyy4It2p2cRPHseWWTcP7lMUpwqtQsnqNKJ14RuAaMOQtG
+xSaQMgMGZx6lxFWNaK40SxSnqFRtfRs9ABEBAAGInwQYAQIACQUCWcknrwIbDAAK
+CRDOY3JXB2uL/PX/A/9HvpLPVDrEMr9+vzmS8Ez0br2kgeoPh7yOAlEotS7OBNWU
+UzzykQlAfLl74336wrkSZfa2GnBBJQHvlnLosnmbGCzsd3KMkuJv90hxxt1rqjN6
+3GFiwBVdsSuyEb3uQJ/ytAyVozwwxjMQZ+gJTYfK8syPdf2T1W6cv7lfHp8E8g==
+=sJQD
+-----END PGP PUBLIC KEY BLOCK-----`
+
+	require.Equal(t, regularKey, core6142Prepass(regularKey))
+	require.Equal(t, regularKey, core6142Prepass(whackyKey))
+
+	_, _, err := ReadOneKeyFromString(whackyKey)
+	require.Error(t, err)
+	_, _, err = ReadOneKeyFromStringLiberal(whackyKey)
+	require.NoError(t, err)
+
 }

--- a/go/libkb/pgp_clean_test.go
+++ b/go/libkb/pgp_clean_test.go
@@ -23,7 +23,7 @@ func TestKeithWinstein(t *testing.T) {
 	}
 }
 
-func TestCore6142Prepass(t *testing.T) {
+func TestBug8162Prepass(t *testing.T) {
 
 	whackyKey := `-----BEGIN PGP PUBLIC KEY BLOCK-----              [1/2]
 
@@ -63,8 +63,8 @@ UzzykQlAfLl74336wrkSZfa2GnBBJQHvlnLosnmbGCzsd3KMkuJv90hxxt1rqjN6
 =sJQD
 -----END PGP PUBLIC KEY BLOCK-----`
 
-	require.Equal(t, regularKey, core6142Prepass(regularKey))
-	require.Equal(t, regularKey, core6142Prepass(whackyKey))
+	require.Equal(t, regularKey, bug8162Prepass(regularKey))
+	require.Equal(t, regularKey, bug8162Prepass(whackyKey))
 
 	_, _, err := ReadOneKeyFromString(whackyKey)
 	require.Error(t, err)

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -347,7 +347,7 @@ func cleanPGPInput(s string) string {
 // note:  openpgp.ReadArmoredKeyRing only returns the first block.
 // It will never return multiple entities.
 func ReadOneKeyFromString(originalArmor string) (*PGPKeyBundle, *Warnings, error) {
-	return readOneKeyFromString(originalArmor /* liberal */, false)
+	return readOneKeyFromString(originalArmor, false /* liberal */)
 }
 
 // bug8612Prepass cleans off any garbage trailing the "-----" in the first line of a PGP
@@ -377,7 +377,7 @@ func bug8612Prepass(a string) string {
 // note:  openpgp.ReadArmoredKeyRing only returns the first block.
 // It will never return multiple entities.
 func ReadOneKeyFromStringLiberal(originalArmor string) (*PGPKeyBundle, *Warnings, error) {
-	return readOneKeyFromString(originalArmor /* liberal */, true)
+	return readOneKeyFromString(originalArmor, true /* liberal */)
 }
 
 func readOneKeyFromString(originalArmor string, liberal bool) (*PGPKeyBundle, *Warnings, error) {

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -335,7 +335,7 @@ func (k *PGPKeyBundle) EncodeToStream(wc io.WriteCloser, private bool) error {
 }
 
 var cleanPGPInputRxx = regexp.MustCompile(`[ \t\r]*\n[ \t\r]*`)
-var bug8162PrepassRxx = regexp.MustCompile(`^(?P<header>-{5}BEGIN PGP (.*?)-{5})(\s*(?P<junk>.+?))$`)
+var bug8612PrepassRxx = regexp.MustCompile(`^(?P<header>-{5}BEGIN PGP (.*?)-{5})(\s*(?P<junk>.+?))$`)
 
 func cleanPGPInput(s string) string {
 	s = strings.TrimSpace(s)
@@ -350,23 +350,23 @@ func ReadOneKeyFromString(originalArmor string) (*PGPKeyBundle, *Warnings, error
 	return readOneKeyFromString(originalArmor /* liberal */, false)
 }
 
-// bug8162Prepass cleans off any garbage trailing the "-----" in the first line of a PGP
+// bug8612Prepass cleans off any garbage trailing the "-----" in the first line of a PGP
 // key. For years, the server allowed this junk through, so some keys on the server side
 // (and hashed into chains) have junk here. It's pretty safe to strip it out when replaying
 // sigchains, so do it.
-func bug8162Prepass(a string) string {
+func bug8612Prepass(a string) string {
 	idx := strings.Index(a, "\n")
 	if idx < 0 {
 		return a
 	}
 	line0 := a[0:idx]
 	rest := a[idx:]
-	match := bug8162PrepassRxx.FindStringSubmatch(line0)
+	match := bug8612PrepassRxx.FindStringSubmatch(line0)
 	if len(match) == 0 {
 		return a
 	}
 	result := make(map[string]string)
-	for i, name := range bug8162PrepassRxx.SubexpNames() {
+	for i, name := range bug8612PrepassRxx.SubexpNames() {
 		if i != 0 {
 			result[name] = match[i]
 		}
@@ -383,7 +383,7 @@ func ReadOneKeyFromStringLiberal(originalArmor string) (*PGPKeyBundle, *Warnings
 func readOneKeyFromString(originalArmor string, liberal bool) (*PGPKeyBundle, *Warnings, error) {
 	cleanArmor := cleanPGPInput(originalArmor)
 	if liberal {
-		cleanArmor = bug8162Prepass(cleanArmor)
+		cleanArmor = bug8612Prepass(cleanArmor)
 	}
 	reader := strings.NewReader(cleanArmor)
 	el, err := openpgp.ReadArmoredKeyRing(reader)

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -335,6 +335,7 @@ func (k *PGPKeyBundle) EncodeToStream(wc io.WriteCloser, private bool) error {
 }
 
 var cleanPGPInputRxx = regexp.MustCompile(`[ \t\r]*\n[ \t\r]*`)
+var core6142PrepassRxx = regexp.MustCompile(`^(?P<header>-{5}BEGIN PGP (.*?)-{5})(\s*(?P<junk>.+?))$`)
 
 func cleanPGPInput(s string) string {
 	s = strings.TrimSpace(s)
@@ -346,7 +347,44 @@ func cleanPGPInput(s string) string {
 // note:  openpgp.ReadArmoredKeyRing only returns the first block.
 // It will never return multiple entities.
 func ReadOneKeyFromString(originalArmor string) (*PGPKeyBundle, *Warnings, error) {
+	return readOneKeyFromString(originalArmor /* liberal */, false)
+}
+
+// core6142Prepass cleans off any garbage trailing the "-----" in the first line of a PGP
+// key. For years, the server allowed this junk through, so some keys on the server side
+// (and hashed into chains) have junk here. It's pretty safe to strip it out when replaying
+// sigchains, so do it.
+func core6142Prepass(a string) string {
+	idx := strings.Index(a, "\n")
+	if idx < 0 {
+		return a
+	}
+	line0 := a[0:idx]
+	rest := a[idx:]
+	match := core6142PrepassRxx.FindStringSubmatch(line0)
+	if len(match) == 0 {
+		return a
+	}
+	result := make(map[string]string)
+	for i, name := range core6142PrepassRxx.SubexpNames() {
+		if i != 0 {
+			result[name] = match[i]
+		}
+	}
+	return result["header"] + rest
+}
+
+// note:  openpgp.ReadArmoredKeyRing only returns the first block.
+// It will never return multiple entities.
+func ReadOneKeyFromStringLiberal(originalArmor string) (*PGPKeyBundle, *Warnings, error) {
+	return readOneKeyFromString(originalArmor /* liberal */, true)
+}
+
+func readOneKeyFromString(originalArmor string, liberal bool) (*PGPKeyBundle, *Warnings, error) {
 	cleanArmor := cleanPGPInput(originalArmor)
+	if liberal {
+		cleanArmor = core6142Prepass(cleanArmor)
+	}
 	reader := strings.NewReader(cleanArmor)
 	el, err := openpgp.ReadArmoredKeyRing(reader)
 	return finishReadOne(el, originalArmor, err)


### PR DESCRIPTION
- the server was letting these through since time immemorial, so we can tell the client to let them though too
- but let's still prevent them from being uploaded going forward
- see internal bug CORE-6142