### PR TITLE
Inbox Filter - Enter unfocus the input and clears the filter

### DIFF
--- a/shared/chat/inbox/row/chat-filter-row.js
+++ b/shared/chat/inbox/row/chat-filter-row.js
@@ -48,9 +48,23 @@ class _ChatFilterRow extends Component<Props, State> {
       this.props.onSetFilter('')
       this._stopEditing()
     } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      e.stopPropagation()
       this.props.onSelectDown()
     } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      e.stopPropagation()
       this.props.onSelectUp()
+    }
+  }
+
+  _onEnterKeyDown = (e: SyntheticKeyboardEvent<>) => {
+    if (!isMobile) {
+      e.preventDefault()
+      e.stopPropagation()
+      this.props.onSetFilter('')
+      this._stopEditing()
+      this._input && this._input.blur()
     }
   }
 
@@ -91,6 +105,7 @@ class _ChatFilterRow extends Component<Props, State> {
           onFocus={this._startEditing}
           onBlur={this._stopEditing}
           onKeyDown={this._onKeyDown}
+          onEnterKeyDown={this._onEnterKeyDown}
           ref={this._setRef}
           style={{marginRight: globalMargins.tiny}}
         />,


### PR DESCRIPTION
@keybase/react-hackers 
enter key currently behaves identically to escape.

Doesn't do anything fancy that we might want like:

if the selected conv isn't visible with the filter, we should make enter select the first conversation visible by the filter.