### PR TITLE
Don't blow away architecture specifiers

### DIFF
--- a/packaging/linux/deb/cron.template
+++ b/packaging/linux/deb/cron.template
@@ -27,6 +27,7 @@ DEFAULTS_FILE="/etc/default/@@NAME@@"
 # sources.list setting for @@NAME@@ updates.
 REPOCONFIG="deb @@REPO_URL@@ stable main"
 SSLREPOCONFIG="deb @@REPO_SSL_URL@@ stable main"
+REPOGREP="deb (\[.*\] )?(@@REPO_URL@@|@@REPO_SSL_URL@@) stable main"
 
 APT_GET="`which apt-get 2> /dev/null`"
 APT_CONFIG="`which apt-config 2> /dev/null`"
@@ -164,7 +165,7 @@ update_bad_sources() {
   ACTIVECONFIGS=$(grep -v "^[[:space:]]*\(#.*\)\?$" "$SOURCELIST" 2>/dev/null)
 
   # Check if the correct repository configuration is in there.
-  REPOMATCH=$(grep -E "^[[:space:]#]*\b($REPOCONFIG|$SSLREPOCONFIG)\b" "$SOURCELIST" \
+  REPOMATCH=$(grep -E "^[[:space:]#]*\b$REPOGREP\b" "$SOURCELIST" \
     2>/dev/null)
 
   # Check if the correct repository is disabled.


### PR DESCRIPTION
When using multiarch on Debian, apt will (by default) produce a warning
for each and every repository that does not contain one or more of the
architectures that was added to the configuration with "dpkg
--add-architecture". However, this warning can be silenced by adding an
architecture specifier to an apt line, which (in the case of
keybase) could look like so:

    deb [arch=amd64,i386] http://prerelease.keybase.io/deb stable main

The grep in the current version of the cron job does not match that
(optional) architecture specifier, therefore does not match the line,
and therefore blows it away. This is annoying.

Fix by changing the grep line to allow for it.