### PR TITLE
don't crash on debug output for expired GPG primary key

### DIFF
--- a/go/libkb/gpg_index.go
+++ b/go/libkb/gpg_index.go
@@ -173,7 +173,11 @@ func (k *GpgPrimaryKey) IsValid() bool {
 	} else {
 		expired := time.Now().After(time.Unix(int64(k.Expires), 0))
 		if expired {
-			k.G().Log.Warning("Skipping expired primary key %s", k.fingerprint.ToQuads())
+			var fp string
+			if k.fingerprint != nil {
+				fp = " (" + k.fingerprint.ToQuads() + ")"
+			}
+			k.G().Log.Warning("Skipping expired primary key%s", fp)
 		}
 		return !expired
 	}


### PR DESCRIPTION
- not entirely sure why the fingerprint wasn't there though