### PR TITLE
Ship and install git-remote-keybase on macOS

### DIFF
--- a/go/install/install_darwin.go
+++ b/go/install/install_darwin.go
@@ -528,6 +528,15 @@ func installCommandLine(context Context, binPath string, force bool, log Log) er
 		return err
 	}
 
+	// Now the git remote helper. Lives next to the keybase binary, same dir
+	gitBinPath := filepath.Join(filepath.Dir(bp), "git-remote-keybase")
+	gitLinkPath := filepath.Join(filepath.Dir(linkPath), "git-remote-keybase")
+	err = installCommandLineForBinPath(gitBinPath, gitLinkPath, force, log)
+	if err != nil {
+		log.Errorf("Git remote helper not installed properly (%s)", err)
+		return err
+	}
+
 	return nil
 }
 

--- a/go/install/install_darwin.go
+++ b/go/install/install_darwin.go
@@ -529,8 +529,9 @@ func installCommandLine(context Context, binPath string, force bool, log Log) er
 	}
 
 	// Now the git remote helper. Lives next to the keybase binary, same dir
-	gitBinPath := filepath.Join(filepath.Dir(bp), "git-remote-keybase")
-	gitLinkPath := filepath.Join(filepath.Dir(linkPath), "git-remote-keybase")
+	gitBinFilename := "git-remote-keybase"
+	gitBinPath := filepath.Join(filepath.Dir(bp), gitBinFilename)
+	gitLinkPath := filepath.Join(filepath.Dir(linkPath), gitBinFilename)
 	err = installCommandLineForBinPath(gitBinPath, gitLinkPath, force, log)
 	if err != nil {
 		log.Errorf("Git remote helper not installed properly (%s)", err)

--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.58</string>
+	<string>1.1.59</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.58</string>
+	<string>1.1.59</string>
 	<key>KBFuseBuild</key>
 	<string>3.6.3</string>
 	<key>KBFuseVersion</key>

--- a/osx/KBKit/KBKit/Component/KBCommandLine.m
+++ b/osx/KBKit/KBKit/Component/KBCommandLine.m
@@ -34,6 +34,7 @@
     return;
   }
 
+
   NSDictionary *params = @{@"directory": self.servicePath, @"name": self.config.serviceBinName, @"appName": self.config.appName};
   DDLogDebug(@"Helper: addToPath(%@)", params);
   [self.helperTool.helper sendRequest:@"addToPath" params:@[params] completion:^(NSError *error, id value) {

--- a/osx/KBKit/KBKit/Component/KBCommandLine.m
+++ b/osx/KBKit/KBKit/Component/KBCommandLine.m
@@ -34,10 +34,16 @@
     return;
   }
 
-
   NSDictionary *params = @{@"directory": self.servicePath, @"name": self.config.serviceBinName, @"appName": self.config.appName};
   DDLogDebug(@"Helper: addToPath(%@)", params);
   [self.helperTool.helper sendRequest:@"addToPath" params:@[params] completion:^(NSError *error, id value) {
+    DDLogDebug(@"Result: %@", value);
+    completion(error);
+  }];
+
+  NSDictionary *gitParams = @{@"directory": self.servicePath, @"name": self.config.gitRemoteHelperName, @"appName": self.config.appName};
+  DDLogDebug(@"Helper: addToPath(%@)", gitParams);
+  [self.helperTool.helper sendRequest:@"addToPath" params:@[gitParams] completion:^(NSError *error, id value) {
     DDLogDebug(@"Result: %@", value);
     completion(error);
   }];

--- a/osx/KBKit/KBKit/System/KBEnvConfig.h
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.h
@@ -67,6 +67,7 @@ typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
 - (NSString *)serviceBinName;
 - (NSString *)serviceBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath;
 - (NSString *)kbfsBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath;
+- (NSString *)gitRemoteHelperName;
 
 - (BOOL)validate:(NSError **)error;
 

--- a/osx/KBKit/KBKit/System/KBEnvConfig.m
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.m
@@ -146,7 +146,7 @@
 }
 
 - (NSString *)gitRemoteHelperName {
-  return @"git-remote-keybase"
+  return @"git-remote-keybase";
 }
 
 - (NSString *)kbfsBinName {

--- a/osx/KBKit/KBKit/System/KBEnvConfig.m
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.m
@@ -145,6 +145,10 @@
   return [KBPath pathInDir:servicePath path:[self kbfsBinName] options:pathOptions];
 }
 
+- (NSString *)gitRemoteHelperName {
+  return @"git-remote-keybase"
+}
+
 - (NSString *)kbfsBinName {
   switch(_runMode) {
     case KBRunModeDevel: return @"kbfsdev";

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -15,7 +15,7 @@ cd $dir
 client_dir="$dir/../.."
 fuse_dir="$client_dir/osx/Fuse"
 tmp_dir="/tmp/desktop-kbfuse"
-installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.58-darwin.tgz"
+installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.59-darwin.tgz"
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -36,6 +36,7 @@ kbfs_version=${KBFS_VERSION:-}
 comment=""
 
 keybase_binpath=${KEYBASE_BINPATH:-}
+git_remote_keybase_binpath=${GIT_REMOTE_KEYBASE_BINPATH:-}
 kbfs_binpath=${KBFS_BINPATH:-}
 kbnm_binpath=${KBNM_BINPATH:-}
 updater_binpath=${UPDATER_BINPATH:-}
@@ -149,6 +150,7 @@ get_deps() {(
   if [ ! "$kbfs_binpath" = "" ]; then
     echo "Using local kbfs binpath: $kbfs_binpath"
     cp "$kbfs_binpath" .
+    cp "$git_remote_keybase_binpath" .
   else
     kbfs_url="https://github.com/keybase/kbfs/releases/download/v$kbfs_version/kbfs-$kbfs_version-darwin.tgz"
     echo "Getting $kbfs_url"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -36,7 +36,9 @@ kbfs_version=${KBFS_VERSION:-}
 comment=""
 
 keybase_binpath=${KEYBASE_BINPATH:-}
-git_remote_keybase_binpath=${GIT_REMOTE_KEYBASE_BINPATH:-}
+# FIXME: Replace before merging.
+# git_remote_keybase_binpath=${GIT_REMOTE_KEYBASE_BINPATH:-}
+git_remote_keybase_binpath='/tmp/build_kbfs/git-remote-keybase'
 kbfs_binpath=${KBFS_BINPATH:-}
 kbnm_binpath=${KBNM_BINPATH:-}
 updater_binpath=${UPDATER_BINPATH:-}

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -98,7 +98,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.58-darwin.tgz"
+installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.59-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://prerelease.keybase.io/darwin-package/KeybaseUpdater-1.0.6-darwin.tgz"
 
@@ -151,12 +151,6 @@ get_deps() {(
 
   if [ ! "$kbfs_binpath" = "" ]; then
     echo "Using local kbfs binpath: $kbfs_binpath"
-    echo $kbfs_binpath
-    echo $git_remote_keybase_binpath
-    ls -l $kbfs_binpath
-    ls -l $git_remote_keybase_binpath
-    ls -l /tmp/build_kbfs
-    ls -l /tmp/build_kbfs/*
     cp "$kbfs_binpath" .
     cp "$git_remote_keybase_binpath" .
   else

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -100,6 +100,7 @@ installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1
 updater_url="https://prerelease.keybase.io/darwin-package/KeybaseUpdater-1.0.6-darwin.tgz"
 
 keybase_bin="$tmp_dir/keybase"
+git_remote_keybase_bin="$tmp_dir/git-remote-keybase"
 kbfs_bin="$tmp_dir/kbfs"
 kbnm_bin="$tmp_dir/kbnm"
 updater_bin="$tmp_dir/updater"
@@ -201,6 +202,7 @@ package_app() {(
   echo "Copying keybase binaries"
   mkdir -p "$shared_support_dir/bin"
   cp "$keybase_bin" "$shared_support_dir/bin"
+  cp "$git_remote_keybase_bin" "$shared_support_dir/bin"
   cp "$kbfs_bin" "$shared_support_dir/bin"
   cp "$kbnm_bin" "$shared_support_dir/bin"
   cp "$updater_bin" "$shared_support_dir/bin"
@@ -230,6 +232,7 @@ sign() {(
   codesign --verify --verbose=4 "$app_name.app"
   spctl --assess --verbose=4 "$app_name.app"
   codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/keybase"
+  codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/git-remote-keybase"
   codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/kbfs"
   codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/kbnm"
   codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/updater"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -149,6 +149,12 @@ get_deps() {(
 
   if [ ! "$kbfs_binpath" = "" ]; then
     echo "Using local kbfs binpath: $kbfs_binpath"
+    echo $kbfs_binpath
+    echo $git_remote_keybase_binpath
+    ls -l $kbfs_binpath
+    ls -l $git_remote_keybase_binpath
+    ls -l /tmp/build_kbfs
+    ls -l /tmp/build_kbfs/*
     cp "$kbfs_binpath" .
     cp "$git_remote_keybase_binpath" .
   else

--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -124,7 +124,7 @@ for ((i=1; i<=$number_of_builds; i++)); do
   rm -rf "$save_dir"
 
   if [ "$platform" = "darwin" ]; then
-    SAVE_DIR="$save_dir" KEYBASE_BINPATH="$build_dir_keybase/keybase" KBFS_BINPATH="$build_dir_kbfs/kbfs" KBNM_BINPATH="$build_dir_kbnm/kbnm" \
+    SAVE_DIR="$save_dir" KEYBASE_BINPATH="$build_dir_keybase/keybase" KBFS_BINPATH="$build_dir_kbfs/kbfs" GIT_REMOTE_KEYBASE_BINPATH="$build_dir_kbfs/git-remote-keybase" KBNM_BINPATH="$build_dir_kbnm/kbnm" \
       UPDATER_BINPATH="$build_dir_updater/updater" BUCKET_NAME="$bucket_name" S3HOST="$s3host" "$dir/../desktop/package_darwin.sh"
   else
     # TODO: Support linux build here?

--- a/packaging/prerelease/build_kbfs.sh
+++ b/packaging/prerelease/build_kbfs.sh
@@ -20,7 +20,7 @@ kbfs_build=${KBFS_BUILD:-$build}
 tags=${TAGS:-"prerelease production"}
 ldflags="-X github.com/keybase/kbfs/libkbfs.PrereleaseBuild=$kbfs_build"
 pkg="github.com/keybase/kbfs/kbfsfuse"
-git_remote_helper_pkg="github.com/keybase/kbfs/kbfsgit"
+git_remote_helper_pkg="github.com/keybase/kbfs/kbfsgit/git-remote-keybase"
 
 if [ "$PLATFORM" = "windows" ]; then
   pkg="github.com/keybase/kbfs/kbfsdokan"

--- a/packaging/prerelease/build_kbfs.sh
+++ b/packaging/prerelease/build_kbfs.sh
@@ -20,6 +20,7 @@ kbfs_build=${KBFS_BUILD:-$build}
 tags=${TAGS:-"prerelease production"}
 ldflags="-X github.com/keybase/kbfs/libkbfs.PrereleaseBuild=$kbfs_build"
 pkg="github.com/keybase/kbfs/kbfsfuse"
+git_remote_helper_pkg="github.com/keybase/kbfs/kbfsgit"
 
 if [ "$PLATFORM" = "windows" ]; then
   pkg="github.com/keybase/kbfs/kbfsdokan"
@@ -28,10 +29,14 @@ fi
 echo "Building $build_dir/kbfs ($kbfs_build) with $(go version)"
 go build -a -tags "$tags" -ldflags "$ldflags" -o "$build_dir/kbfs" $pkg
 
+echo "Building $build_dir/kbfs/kbfsgit ($kbfs_build) with $(go version)"
+go build -a -tags "$tags" -ldflags "$ldflags" -o "$build_dir/git-remote-keybase" $git_remote_helper_pkg
+
 if [ "$PLATFORM" = "darwin" ]; then
-  echo "Signing binary..."
+  echo "Signing binaries..."
   code_sign_identity="98767D13871765E702355A74358822D31C0EF51A" # "Developer ID Application: Keybase, Inc. (99229SGT5K)"
   codesign --verbose --force --deep --sign "$code_sign_identity" $build_dir/kbfs
+  codesign --verbose --force --deep --sign "$code_sign_identity" $build_dir/git-remote-keybase
 elif [ "$PLATFORM" = "linux" ]; then
   echo "No codesigning for linux"
 elif [ "$PLATFORM" = "windows" ]; then


### PR DESCRIPTION
@keybase/react-hackers 

This needs more testing, and there's a FIXME line to swap out before hitting the merge button.

This PR:

* builds git-remote-keybase as part of doing a KBFS build (the code lives in the KBFS repo)
* codesigns it
* copies it into the Keybase.app/SharedSupport/bin/ dir inside the bundle being created
* checks that the codesign validates
* bumps the installer version
* asks the installer/helper to install /usr/local/bin/git-remote-keybase at the same time it's installing /usr/local/bin/keybase
* tells the build scripts to pull this newer version of the installer

The installer, unlike almost everything else, is not actually *built* as part of the build process.  It's just downloaded from a tarball on S3.  It's meant to be built, signed and uploaded locally.  That's why this PR bumps the installer version number.  I'm able to build/sign/upload it on my laptop.

It looks like there are changes that have been merged to the macOS installer but not built/shipped (!) that were merged as part of the split installer merge.  That might explain some of the bugs we've been seeing -- perhaps they're fixed with this code that's been merged but not shipped -- but it also means we should be extra cautious about these changes, since they're larger than we expected.