### PR TITLE
add a simple cache to the inbox storage CORE-4985

### DIFF
--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -104,6 +104,7 @@ func (i *Inbox) readDiskInbox(ctx context.Context) (inboxDiskData, Error) {
 
 	// Check in memory cache first
 	if memibox := inboxMemCache.Get(i.uid); memibox != nil {
+		i.Debug(ctx, "hit in memory cache")
 		ibox = *memibox
 	} else {
 		found, err := i.readDiskBox(ctx, i.dbKey(), &ibox)
@@ -114,6 +115,7 @@ func (i *Inbox) readDiskInbox(ctx context.Context) (inboxDiskData, Error) {
 		if !found {
 			return ibox, MissError{}
 		}
+		inboxMemCache.Put(i.uid, &ibox)
 	}
 
 	// Check on disk server version against known server version

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -99,18 +99,25 @@ func (i *Inbox) dbKey() libkb.DbKey {
 }
 
 func (i *Inbox) readDiskInbox(ctx context.Context) (inboxDiskData, Error) {
+
 	var ibox inboxDiskData
-	found, err := i.readDiskBox(ctx, i.dbKey(), &ibox)
-	if err != nil {
-		return ibox, NewInternalError(ctx, i.DebugLabeler,
-			"failed to read inbox: uid: %d err: %s", i.uid, err.Error())
-	}
-	if !found {
-		return ibox, MissError{}
+
+	// Check in memory cache first
+	if memibox := inboxMemCache.Get(i.uid); memibox != nil {
+		ibox = *memibox
+	} else {
+		found, err := i.readDiskBox(ctx, i.dbKey(), &ibox)
+		if err != nil {
+			return ibox, NewInternalError(ctx, i.DebugLabeler,
+				"failed to read inbox: uid: %d err: %s", i.uid, err.Error())
+		}
+		if !found {
+			return ibox, MissError{}
+		}
 	}
 
 	// Check on disk server version against known server version
-	if _, err = i.G().ServerCacheVersions.MatchInbox(ctx, ibox.ServerVersion); err != nil {
+	if _, err := i.G().ServerCacheVersions.MatchInbox(ctx, ibox.ServerVersion); err != nil {
 		i.Debug(ctx, "server version match error, clearing: %s", err.Error())
 		if cerr := i.Clear(ctx); cerr != nil {
 			return ibox, cerr
@@ -146,6 +153,7 @@ func (i *Inbox) writeDiskInbox(ctx context.Context, ibox inboxDiskData) Error {
 	ibox.Conversations = i.summarizeConvs(ibox.Conversations)
 	i.Debug(ctx, "writeDiskInbox: version: %d disk version: %d server version: %d convs: %d",
 		ibox.InboxVersion, ibox.Version, ibox.ServerVersion, len(ibox.Conversations))
+	inboxMemCache.Put(i.uid, &ibox)
 	if ierr := i.writeDiskBox(ctx, i.dbKey(), ibox); ierr != nil {
 		return NewInternalError(ctx, i.DebugLabeler, "failed to write inbox: uid: %s err: %s",
 			i.uid, ierr.Error())
@@ -558,6 +566,7 @@ func (i *Inbox) Read(ctx context.Context, query *chat1.GetInboxQuery, p *chat1.P
 
 func (i *Inbox) Clear(ctx context.Context) (err Error) {
 	defer i.Trace(ctx, func() error { return err }, "Clear")()
+	inboxMemCache.Clear(i.uid)
 	ierr := i.G().LocalChatDb.Delete(i.dbKey())
 	if ierr != nil {
 		return NewInternalError(ctx, i.DebugLabeler,

--- a/go/chat/storage/inbox_memcache.go
+++ b/go/chat/storage/inbox_memcache.go
@@ -7,7 +7,7 @@ import (
 )
 
 type inboxMemCacheImpl struct {
-	sync.Mutex
+	sync.RWMutex
 
 	datMap map[string]*inboxDiskData
 }
@@ -19,8 +19,8 @@ func newInboxMemCacheImpl() *inboxMemCacheImpl {
 }
 
 func (i *inboxMemCacheImpl) Get(uid gregor1.UID) *inboxDiskData {
-	i.Lock()
-	defer i.Unlock()
+	i.RLock()
+	defer i.RUnlock()
 	if ibox, ok := i.datMap[uid.String()]; ok {
 		return ibox
 	}
@@ -34,6 +34,8 @@ func (i *inboxMemCacheImpl) Put(uid gregor1.UID, ibox *inboxDiskData) {
 }
 
 func (i *inboxMemCacheImpl) Clear(uid gregor1.UID) {
+	i.Lock()
+	defer i.Unlock()
 	delete(i.datMap, uid.String())
 }
 

--- a/go/chat/storage/inbox_memcache.go
+++ b/go/chat/storage/inbox_memcache.go
@@ -1,0 +1,40 @@
+package storage
+
+import (
+	"sync"
+
+	"github.com/keybase/client/go/protocol/gregor1"
+)
+
+type inboxMemCacheImpl struct {
+	sync.Mutex
+
+	datMap map[string]*inboxDiskData
+}
+
+func newInboxMemCacheImpl() *inboxMemCacheImpl {
+	return &inboxMemCacheImpl{
+		datMap: make(map[string]*inboxDiskData),
+	}
+}
+
+func (i *inboxMemCacheImpl) Get(uid gregor1.UID) *inboxDiskData {
+	i.Lock()
+	defer i.Unlock()
+	if ibox, ok := i.datMap[uid.String()]; ok {
+		return ibox
+	}
+	return nil
+}
+
+func (i *inboxMemCacheImpl) Put(uid gregor1.UID, ibox *inboxDiskData) {
+	i.Lock()
+	defer i.Unlock()
+	i.datMap[uid.String()] = ibox
+}
+
+func (i *inboxMemCacheImpl) Clear(uid gregor1.UID) {
+	delete(i.datMap, uid.String())
+}
+
+var inboxMemCache = newInboxMemCacheImpl()


### PR DESCRIPTION
Patch does the following:

1.) Adds a simple in memory cache to `inboxDiskData` so we can avoid having to invoke LevelDB at all for the common case.
2.) Every write to the cache hits LevelDB now, but we could potentially optimize that in the future. 