### PR TITLE
support iphone x layout

### DIFF
--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -186,7 +186,7 @@ class MainNavStack extends Component<any, any> {
       .toArray()
 
     const content = (
-      <Box style={_contentStyle}>
+      <Box style={globalStyles.flexGrow}>
         {stacks}
         {![chatTab].includes(props.routeSelected)
           ? <Offline key="offline" reachable={props.reachable} appFocused={true} />
@@ -205,10 +205,6 @@ class MainNavStack extends Component<any, any> {
       </Box>
     )
   }
-}
-
-const _contentStyle = {
-  ...globalStyles.flexGrow,
 }
 
 // TODO glamour

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -18,7 +18,7 @@ import CardStackTransitioner from 'react-navigation/src/views/CardStack/CardStac
 import {chatTab, loginTab, peopleTab, folderTab, settingsTab} from '../constants/tabs'
 import {connect} from 'react-redux'
 import {globalColors, globalStyles, statusBarHeight} from '../styles/index.native'
-import {isIOS} from '../constants/platform'
+import {isIOS, isIPhoneX} from '../constants/platform'
 import {navigateTo, navigateUp, switchTo} from '../actions/route-tree'
 
 import type {Props, OwnProps} from './nav'
@@ -126,16 +126,24 @@ const barStyle = (showStatusBarDarkContent, underStatusBar) => {
 }
 
 function renderStackRoute(route, isActiveRoute, shouldRender) {
-  const {underStatusBar, hideStatusBar, showStatusBarDarkContent} = route.tags
+  const {underStatusBar, hideStatusBar, showStatusBarDarkContent, root} = route.tags
+
+  let style
+  if (root) {
+    style = sceneWrapStyleNoStatusBarPadding
+  } else {
+    style = route.tags.underStatusBar ? sceneWrapStyleNoStatusBarPadding : sceneWrapStyleWithStatusBarPadding
+  }
 
   return (
-    <Box style={route.tags.underStatusBar ? sceneWrapStyleUnder : sceneWrapStyleOver}>
-      <NativeStatusBar
-        hidden={hideStatusBar}
-        translucent={true}
-        backgroundColor="rgba(0, 26, 51, 0.25)"
-        barStyle={barStyle(showStatusBarDarkContent, underStatusBar)}
-      />
+    <Box style={style}>
+      {!isIPhoneX &&
+        <NativeStatusBar
+          hidden={hideStatusBar && !isIPhoneX}
+          translucent={true}
+          backgroundColor="rgba(0, 26, 51, 0.25)"
+          barStyle={barStyle(showStatusBarDarkContent, underStatusBar)}
+        />}
       {route.component({isActiveRoute, shouldRender})}
     </Box>
   )
@@ -178,7 +186,7 @@ class MainNavStack extends Component<any, any> {
       .toArray()
 
     const content = (
-      <Box style={globalStyles.flexGrow}>
+      <Box style={_contentStyle}>
         {stacks}
         {![chatTab].includes(props.routeSelected)
           ? <Offline key="offline" reachable={props.reachable} appFocused={true} />
@@ -197,6 +205,10 @@ class MainNavStack extends Component<any, any> {
       </Box>
     )
   }
+}
+
+const _contentStyle = {
+  ...globalStyles.flexGrow,
 }
 
 // TODO glamour
@@ -312,7 +324,7 @@ class Nav extends Component<Props, {keyboardShowing: boolean}> {
           routeStack={mainScreens}
         />
       ),
-      tags: {underStatusBar: true}, // don't pad nav stack (child screens have own padding)
+      tags: {root: true}, // special case to avoid padding else we'll double pad
     })
 
     const shim = (
@@ -340,14 +352,14 @@ class Nav extends Component<Props, {keyboardShowing: boolean}> {
   }
 }
 
-const sceneWrapStyleUnder = {
+const sceneWrapStyleNoStatusBarPadding = {
   ...globalStyles.fullHeight,
   backgroundColor: globalColors.white,
 }
 
-const sceneWrapStyleOver = {
-  ...sceneWrapStyleUnder,
-  paddingTop: statusBarHeight,
+const sceneWrapStyleWithStatusBarPadding = {
+  ...sceneWrapStyleNoStatusBarPadding,
+  paddingTop: isIPhoneX ? 40 : statusBarHeight,
 }
 
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({

--- a/shared/app/tab-bar/index.render.native.js
+++ b/shared/app/tab-bar/index.render.native.js
@@ -5,6 +5,7 @@ import {Box} from '../../common-adapters'
 import flags from '../../util/feature-flags'
 import {TabBarButton} from '../../common-adapters/tab-bar'
 import {globalStyles, globalColors} from '../../styles'
+import {isIPhoneX} from '../../constants/platform'
 
 import type {Props} from './index.render'
 
@@ -50,13 +51,18 @@ const _selectedIconStyle = {
   color: globalColors.white,
 }
 
-const tabBarHeight = 48
+const tabBarHeight = isIPhoneX ? 80 : 48
 
 const stylesTabBar = {
   ...globalStyles.flexBoxRow,
   backgroundColor: globalColors.darkBlue2,
   height: tabBarHeight,
   justifyContent: 'flex-start',
+  ...(isIPhoneX
+    ? {
+        paddingBottom: 30,
+      }
+    : {}),
 }
 
 export default TabBarRender

--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -7,7 +7,8 @@ const isAndroid = false
 const isIOS = false
 const isLargeScreen = true
 const isSimulator = false
-const isStoryBook: boolean = false
+const isStoryBook = false
+const isIPhoneX = false
 
 const isElectron = true
 const isDarwin = process.platform === 'darwin'

--- a/shared/constants/platform.js.flow
+++ b/shared/constants/platform.js.flow
@@ -12,9 +12,9 @@ export const isWindows: boolean = false
 export const isLinux: boolean = false
 export const isSimulator: boolean = false
 export const isStoryBook: boolean = false
+export const isIPhoneX: boolean = false
 declare export var fileUIName: string
 declare export var version: string
 declare export var appVersionName: string
 declare export var appVersionCode: string
 declare export var mobileOsVersion: string
-

--- a/shared/constants/platform.native.js
+++ b/shared/constants/platform.native.js
@@ -26,6 +26,9 @@ const isWindows = false
 const fileUIName = 'File Explorer'
 const mobileOsVersion = Platform.Version
 
+const isIPhoneX =
+  Platform.OS === 'ios' && !Platform.isPad && !Platform.isTVOS && Dimensions.get('window').height === 812
+
 // isLargeScreen means you have at larger screen like iPhone 6,7 or Pixel
 // See https://material.io/devices/
 const isLargeScreen = Dimensions.get('window').height >= 667
@@ -47,4 +50,5 @@ export {
   runMode,
   version,
   isStoryBook,
+  isIPhoneX,
 }

--- a/shared/profile/index.native.js
+++ b/shared/profile/index.native.js
@@ -3,6 +3,7 @@ import * as shared from './index.shared'
 import ErrorComponent from '../common-adapters/error-profile'
 import LoadingWrapper from '../common-adapters/loading-wrapper.native'
 import React, {Component} from 'react'
+import {isIPhoneX} from '../constants/platform'
 import orderBy from 'lodash/orderBy'
 import chunk from 'lodash/chunk'
 import moment from 'moment'
@@ -278,7 +279,7 @@ class Profile extends Component<Props, State> {
             ...styleHeader,
             backgroundColor: trackerStateColors.header.background,
             paddingBottom: globalMargins.tiny,
-            paddingTop: globalMargins.tiny + statusBarHeight,
+            paddingTop: isIPhoneX ? 40 : globalMargins.tiny + statusBarHeight,
           }}
         >
           {this.props.onBack &&

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -24,6 +24,7 @@ export const LeafTags: (spec?: LeafTagsParams) => LeafTagsParams & I.Record<Leaf
   showStatusBarDarkContent: false,
   fullscreen: false,
   keepKeyboardOnLeave: false,
+  root: false, // only used by the root shim to allow special padding logic as its the root container
 })
 
 const _RouteDefNode = I.Record({


### PR DESCRIPTION
This adds support for the iPhone X layout

- [x] adds new routetag 'root' for the root container
- [x] change root nav to pad correctly
- [x] change profile padding (the only component that uses underStatusbar tag)
- [x] pad tabbar

To test you likey want to get xcode beta 11.1