### PR TITLE
move git errors into core so that we can examine their types

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -267,6 +267,10 @@ const (
 	SCRevokeCurrentDevice      = int(keybase1.StatusCode_SCRevokeCurrentDevice)
 	SCRevokeLastDevice         = int(keybase1.StatusCode_SCRevokeLastDevice)
 	SCTeamKeyMaskNotFound      = int(keybase1.StatusCode_SCTeamKeyMaskNotFound)
+	SCGitInternal              = int(keybase1.StatusCode_SCGitInternal)
+	SCGitRepoAlreadyExists     = int(keybase1.StatusCode_SCGitRepoAlreadyExists)
+	SCGitInvalidRepoName       = int(keybase1.StatusCode_SCGitInvalidRepoName)
+	SCGitCannotDelete          = int(keybase1.StatusCode_SCGitCannotDelete)
 )
 
 const (

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2138,3 +2138,28 @@ func UserErrorFromStatus(s keybase1.StatusCode) error {
 }
 
 //=============================================================================
+
+// InvalidRepoNameError indicates that a repo name is invalid.
+type InvalidRepoNameError struct {
+	Name string
+}
+
+func (e InvalidRepoNameError) Error() string {
+	return fmt.Sprintf("Invalid repo name %q", e.Name)
+}
+
+//=============================================================================
+
+// RepoAlreadyCreatedError is returned when trying to create a repo
+// that already exists.
+type RepoAlreadyExistsError struct {
+	DesiredName  string
+	ExistingName string
+	ExistingID   string
+}
+
+func (e RepoAlreadyExistsError) Error() string {
+	return fmt.Sprintf(
+		"A repo named %s (id=%s) already existed when trying to create "+
+			"a repo named %s", e.ExistingName, e.ExistingID, e.DesiredName)
+}

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -613,6 +613,28 @@ func ImportStatusAsError(g *GlobalContext, s *keybase1.Status) error {
 		return e
 	case SCDeviceProvisionOffline:
 		return ProvisionFailedOfflineError{}
+	case SCGitInvalidRepoName:
+		e := InvalidRepoNameError{}
+		for _, field := range s.Fields {
+			switch field.Key {
+			case "Name":
+				e.Name = field.Value
+			}
+		}
+		return e
+	case SCGitRepoAlreadyExists:
+		e := RepoAlreadyExistsError{}
+		for _, field := range s.Fields {
+			switch field.Key {
+			case "DesiredName":
+				e.DesiredName = field.Value
+			case "ExistingName":
+				e.ExistingName = field.Value
+			case "ExistingID":
+				e.ExistingID = field.Value
+			}
+		}
+		return e
 
 	default:
 		ase := AppStatusError{
@@ -2080,4 +2102,26 @@ func (e ProvisionFailedOfflineError) ToStatus() keybase1.Status {
 		Name: "SC_DEVICE_PROVISION_OFFLINE",
 		Desc: e.Error(),
 	}
+}
+
+func (e InvalidRepoNameError) ToStatus() (s keybase1.Status) {
+	s.Code = int(keybase1.StatusCode_SCGitInvalidRepoName)
+	s.Name = "GIT_INVALID_REPO_NAME"
+	s.Desc = e.Error()
+	s.Fields = []keybase1.StringKVPair{
+		{Key: "Name", Value: e.Name},
+	}
+	return
+}
+
+func (e RepoAlreadyExistsError) ToStatus() (s keybase1.Status) {
+	s.Code = int(keybase1.StatusCode_SCGitRepoAlreadyExists)
+	s.Name = "GIT_REPO_ALREADY_EXISTS"
+	s.Desc = e.Error()
+	s.Fields = []keybase1.StringKVPair{
+		{Key: "DesiredName", Value: e.DesiredName},
+		{Key: "ExistingName", Value: e.ExistingName},
+		{Key: "ExistingID", Value: e.ExistingID},
+	}
+	return
 }


### PR DESCRIPTION
r? @patrickxb 

cc @strib 

A PR for kbfs will follow this, to use the moved types.