### PR TITLE
store important UI elements in inbox cache, and deliver as part of untrusted phase of GetInboxNonblock CORE-6041

### DIFF
--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -95,15 +95,16 @@ func (h *IdentifyChangedHandler) getTLFtoCrypt(ctx context.Context, uid gregor1.
 	}
 
 	for _, conv := range allConvs {
-		if conv.Includes(uid) {
-			maxText, err := conv.GetMaxMessage(chat1.MessageType_TEXT)
+		if conv.Conv.Includes(uid) {
+			maxText, err := conv.Conv.GetMaxMessage(chat1.MessageType_TEXT)
 			if err != nil {
 				h.Debug(ctx, "failed to get a max message from conv: uid: %s convID: %s err: %s",
 					uid, conv.GetConvID(), err.Error())
 				continue
 			}
 
-			return maxText.TLFNameExpanded(conv.Metadata.FinalizeInfo), conv.Metadata.IdTriple.Tlfid, nil
+			return maxText.TLFNameExpanded(conv.Conv.Metadata.FinalizeInfo),
+				conv.Conv.Metadata.IdTriple.Tlfid, nil
 		}
 	}
 

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -503,6 +503,13 @@ func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	if err != nil {
 		return inbox, rl, err
 	}
+
+	// Write metadata to the inbox cache
+	if err = storage.NewInbox(s.G(), uid).MergeLocalMetadata(ctx, inbox.Convs); err != nil {
+		// Don't abort the operaton on this kind of error
+		s.Debug(ctx, "Read: unable to write inbox local metadata: %s", err)
+	}
+
 	return inbox, rl, nil
 }
 

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -562,7 +562,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			uid := m.UID().Bytes()
 
 			// We need to get this conversation and then localize it
-			var inbox chat1.Inbox
+			var inbox types.Inbox
 			if inbox, _, err = g.G().InboxSource.Read(ctx, uid, nil, false, &chat1.GetInboxLocalQuery{
 				ConvIDs: []chat1.ConversationID{nm.ConvID},
 			}, nil); err != nil {
@@ -573,7 +573,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				g.Debug(ctx, "chat activity: unable to find conversation")
 				return
 			}
-			updateConv := inbox.ConvsUnverified[0]
+			updateConv := inbox.ConvsUnverified[0].Conv
 			if err = g.G().InboxSource.NewConversation(ctx, uid, nm.InboxVers, updateConv); err != nil {
 				g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
 			}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -220,6 +220,7 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 		start := time.Now()
 		h.Debug(ctx, "GetInboxNonblockLocal: sending unverified inbox: %d convs",
 			len(lres.InboxRes.ConvsUnverified))
+		h.Debug(ctx, "GetInboxNonblockLocal: JSON: %s", jbody)
 		chatUI.ChatInboxUnverified(ctx, chat1.ChatInboxUnverifiedArg{
 			SessionID: arg.SessionID,
 			Inbox:     string(jbody),

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -221,7 +221,6 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 		start := time.Now()
 		h.Debug(ctx, "GetInboxNonblockLocal: sending unverified inbox: %d convs",
 			len(lres.InboxRes.ConvsUnverified))
-		h.Debug(ctx, "GetInboxNonblockLocal: JSON: %s", jbody)
 		chatUI.ChatInboxUnverified(ctx, chat1.ChatInboxUnverifiedArg{
 			SessionID: arg.SessionID,
 			Inbox:     string(jbody),

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -679,6 +679,7 @@ func TestChatSrvGetInboxNonblockLocalMetadata(t *testing.T) {
 			for index, conv := range ibox.InboxRes.Items {
 				require.NotNil(t, conv.LocalMetadata)
 				require.Equal(t, fmt.Sprintf("%d", numconvs-index), conv.LocalMetadata.Snippet)
+				require.Equal(t, 2, len(conv.LocalMetadata.WriterNames))
 				switch mt {
 				case chat1.ConversationMembersType_TEAM:
 					require.Equal(t, fmt.Sprintf("%d", numconvs-index), conv.LocalMetadata.ChannelName)

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -261,8 +261,6 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, convs []chat1.Conversati
 	}
 	for index, rc := range ibox.Conversations {
 		if convLocal, ok := convMap[rc.GetConvID().String()]; ok {
-			i.Debug(ctx, "merging local info: tlf: %s topicname: %s", convLocal.Info.TlfName,
-				utils.GetTopicName(convLocal))
 			ibox.Conversations[index].LocalMetadata = &types.RemoteConversationMetadata{
 				TopicName: utils.GetTopicName(convLocal),
 				Headline:  utils.GetHeadline(convLocal),

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -255,16 +255,16 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, convs []chat1.Conversati
 		return nil
 	}
 
-	convMap := make(map[string]*chat1.ConversationLocal)
+	convMap := make(map[string]chat1.ConversationLocal)
 	for _, conv := range convs {
-		convMap[conv.GetConvID().String()] = &conv
+		convMap[conv.GetConvID().String()] = conv
 	}
 	for index, rc := range ibox.Conversations {
 		if convLocal, ok := convMap[rc.GetConvID().String()]; ok {
 			ibox.Conversations[index].LocalMetadata = &types.RemoteConversationMetadata{
-				TopicName: utils.GetTopicName(*convLocal),
-				Headline:  utils.GetHeadline(*convLocal),
-				Snippet:   utils.GetConvSnippet(*convLocal),
+				TopicName: utils.GetTopicName(convLocal),
+				Headline:  utils.GetHeadline(convLocal),
+				Snippet:   utils.GetConvSnippet(convLocal),
 			}
 		}
 	}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -262,9 +262,10 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, convs []chat1.Conversati
 	for index, rc := range ibox.Conversations {
 		if convLocal, ok := convMap[rc.GetConvID().String()]; ok {
 			ibox.Conversations[index].LocalMetadata = &types.RemoteConversationMetadata{
-				TopicName: utils.GetTopicName(convLocal),
-				Headline:  utils.GetHeadline(convLocal),
-				Snippet:   utils.GetConvSnippet(convLocal),
+				TopicName:   utils.GetTopicName(convLocal),
+				Headline:    utils.GetHeadline(convLocal),
+				Snippet:     utils.GetConvSnippet(convLocal),
+				WriterNames: convLocal.Info.WriterNames,
 			}
 		}
 	}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -261,6 +261,8 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, convs []chat1.Conversati
 	}
 	for index, rc := range ibox.Conversations {
 		if convLocal, ok := convMap[rc.GetConvID().String()]; ok {
+			i.Debug(ctx, "merging local info: tlf: %s topicname: %s", convLocal.Info.TlfName,
+				utils.GetTopicName(convLocal))
 			ibox.Conversations[index].LocalMetadata = &types.RemoteConversationMetadata{
 				TopicName: utils.GetTopicName(convLocal),
 				Headline:  utils.GetHeadline(convLocal),

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 
 	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -34,26 +35,29 @@ func makeTlfID() chat1.TLFID {
 	return randBytes(8)
 }
 
-func makeConvo(mtime gregor1.Time, rmsg chat1.MessageID, mmsg chat1.MessageID) chat1.Conversation {
-	return chat1.Conversation{
-		Metadata: chat1.ConversationMetadata{
-			ConversationID: randBytes(8),
-			IdTriple: chat1.ConversationIDTriple{
-				Tlfid:     makeTlfID(),
-				TopicType: chat1.TopicType_CHAT,
-				TopicID:   randBytes(8),
+func makeConvo(mtime gregor1.Time, rmsg chat1.MessageID, mmsg chat1.MessageID) types.RemoteConversation {
+	c := types.RemoteConversation{
+		Conv: chat1.Conversation{
+			Metadata: chat1.ConversationMetadata{
+				ConversationID: randBytes(8),
+				IdTriple: chat1.ConversationIDTriple{
+					Tlfid:     makeTlfID(),
+					TopicType: chat1.TopicType_CHAT,
+					TopicID:   randBytes(8),
+				},
+				Visibility: keybase1.TLFVisibility_PRIVATE,
+				Status:     chat1.ConversationStatus_UNFILED,
 			},
-			Visibility: keybase1.TLFVisibility_PRIVATE,
-			Status:     chat1.ConversationStatus_UNFILED,
+			ReaderInfo: &chat1.ConversationReaderInfo{
+				Mtime:     mtime,
+				ReadMsgid: rmsg,
+				MaxMsgid:  mmsg,
+			},
+			// Make it look like there's a visible message in here too
+			MaxMsgSummaries: []chat1.MessageSummary{{MessageType: chat1.MessageType_TEXT}},
 		},
-		ReaderInfo: &chat1.ConversationReaderInfo{
-			Mtime:     mtime,
-			ReadMsgid: rmsg,
-			MaxMsgid:  mmsg,
-		},
-		// Make it look like there's a visible message in here too
-		MaxMsgSummaries: []chat1.MessageSummary{{MessageType: chat1.MessageType_TEXT}},
 	}
+	return c
 }
 
 func makeInboxMsg(id chat1.MessageID, typ chat1.MessageType) chat1.MessageBoxed {
@@ -67,7 +71,7 @@ func makeInboxMsg(id chat1.MessageID, typ chat1.MessageType) chat1.MessageBoxed 
 	}
 }
 
-func convListCompare(t *testing.T, l []chat1.Conversation, r []chat1.Conversation, name string) {
+func convListCompare(t *testing.T, l []types.RemoteConversation, r []types.RemoteConversation, name string) {
 	require.Equal(t, len(l), len(r), name+" size mismatch")
 	for i := 0; i < len(l); i++ {
 		t.Logf("convListCompare: l: %s(%d) r: %s(%d)", l[i].GetConvID(), l[i].GetMtime(),
@@ -82,13 +86,13 @@ func TestInboxBasic(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
 	}
 
 	// Fetch with no query parameter
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 	vers, res, _, err := inbox.Read(context.TODO(), nil, nil)
 
 	require.NoError(t, err)
@@ -101,7 +105,7 @@ func TestInboxBasic(t *testing.T) {
 		Num: numConvs / 2,
 	})
 	require.IsType(t, MissError{}, err, "expected miss error")
-	require.NoError(t, inbox.Merge(context.TODO(), 2, convs, nil, &chat1.Pagination{
+	require.NoError(t, inbox.Merge(context.TODO(), 2, utils.PluckConvs(convs), nil, &chat1.Pagination{
 		Num: numConvs / 2,
 	}))
 	vers, res, _, err = inbox.Read(context.TODO(), nil, &chat1.Pagination{
@@ -117,7 +121,7 @@ func TestInboxSummarize(t *testing.T) {
 
 	conv := makeConvo(gregor1.Time(1), 1, 1)
 	maxMsgID := chat1.MessageID(6)
-	conv.MaxMsgs = []chat1.MessageBoxed{chat1.MessageBoxed{
+	conv.Conv.MaxMsgs = []chat1.MessageBoxed{chat1.MessageBoxed{
 		ClientHeader: chat1.MessageClientHeader{
 			MessageType: chat1.MessageType_TEXT,
 		},
@@ -126,12 +130,12 @@ func TestInboxSummarize(t *testing.T) {
 		},
 	}}
 
-	require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{conv}, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{conv.Conv}, nil, nil))
 	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
-	require.Zero(t, len(res[0].MaxMsgs))
-	require.Equal(t, 1, len(res[0].MaxMsgSummaries))
-	require.Equal(t, maxMsgID, res[0].MaxMsgSummaries[0].GetMessageID())
+	require.Zero(t, len(res[0].Conv.MaxMsgs))
+	require.Equal(t, 1, len(res[0].Conv.MaxMsgSummaries))
+	require.Equal(t, maxMsgID, res[0].Conv.MaxMsgSummaries[0].GetMessageID())
 }
 
 func TestInboxQueries(t *testing.T) {
@@ -140,20 +144,20 @@ func TestInboxQueries(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 20
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := 0; i < numConvs; i++ {
 		conv := makeConvo(gregor1.Time(i), 1, 1)
 		convs = append(convs, conv)
 	}
 
 	// Make two dev convos
-	var devs, publics, unreads, ignored, muted, full []chat1.Conversation
-	convs[3].Metadata.IdTriple.TopicType = chat1.TopicType_DEV
-	convs[7].Metadata.IdTriple.TopicType = chat1.TopicType_DEV
-	devs = append(devs, []chat1.Conversation{convs[7], convs[3]}...)
+	var devs, publics, unreads, ignored, muted, full []types.RemoteConversation
+	convs[3].Conv.Metadata.IdTriple.TopicType = chat1.TopicType_DEV
+	convs[7].Conv.Metadata.IdTriple.TopicType = chat1.TopicType_DEV
+	devs = append(devs, []types.RemoteConversation{convs[7], convs[3]}...)
 
 	// Make one public convos
-	convs[13].Metadata.Visibility = keybase1.TLFVisibility_PUBLIC
+	convs[13].Conv.Metadata.Visibility = keybase1.TLFVisibility_PUBLIC
 	publics = append(publics, convs[13])
 
 	// Make three unread convos
@@ -161,26 +165,26 @@ func TestInboxQueries(t *testing.T) {
 		ri.MaxMsgid = 5
 		ri.ReadMsgid = 3
 	}
-	makeUnread(convs[5].ReaderInfo)
-	makeUnread(convs[13].ReaderInfo)
-	makeUnread(convs[19].ReaderInfo)
-	unreads = append(unreads, []chat1.Conversation{convs[19], convs[13], convs[5]}...)
+	makeUnread(convs[5].Conv.ReaderInfo)
+	makeUnread(convs[13].Conv.ReaderInfo)
+	makeUnread(convs[19].Conv.ReaderInfo)
+	unreads = append(unreads, []types.RemoteConversation{convs[19], convs[13], convs[5]}...)
 
 	// Make two ignored
-	convs[18].Metadata.Status = chat1.ConversationStatus_IGNORED
-	convs[4].Metadata.Status = chat1.ConversationStatus_IGNORED
-	ignored = append(ignored, []chat1.Conversation{convs[18], convs[4]}...)
+	convs[18].Conv.Metadata.Status = chat1.ConversationStatus_IGNORED
+	convs[4].Conv.Metadata.Status = chat1.ConversationStatus_IGNORED
+	ignored = append(ignored, []types.RemoteConversation{convs[18], convs[4]}...)
 
 	// Make one muted
-	convs[12].Metadata.Status = chat1.ConversationStatus_MUTED
-	muted = append(muted, []chat1.Conversation{convs[12]}...)
+	convs[12].Conv.Metadata.Status = chat1.ConversationStatus_MUTED
+	muted = append(muted, []types.RemoteConversation{convs[12]}...)
 
 	// Mark one as finalized and superseded by
-	convs[6].Metadata.FinalizeInfo = &chat1.ConversationFinalizeInfo{
+	convs[6].Conv.Metadata.FinalizeInfo = &chat1.ConversationFinalizeInfo{
 		ResetFull: "reset",
 	}
-	convs[6].Metadata.SupersededBy = append(convs[6].Metadata.SupersededBy, convs[17].Metadata)
-	convs[17].Metadata.Supersedes = append(convs[17].Metadata.Supersedes, convs[6].Metadata)
+	convs[6].Conv.Metadata.SupersededBy = append(convs[6].Conv.Metadata.SupersededBy, convs[17].Conv.Metadata)
+	convs[17].Conv.Metadata.Supersedes = append(convs[17].Conv.Metadata.Supersedes, convs[6].Conv.Metadata)
 	for i := len(convs) - 1; i >= 0; i-- {
 		if i == 6 {
 			continue
@@ -191,11 +195,11 @@ func TestInboxQueries(t *testing.T) {
 		t.Logf("convID: %s", conv.GetConvID())
 	}
 
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 
 	// Merge in queries and try to read them back out
 	var q *chat1.GetInboxQuery
-	mergeReadAndCheck := func(t *testing.T, ref []chat1.Conversation, name string) {
+	mergeReadAndCheck := func(t *testing.T, ref []types.RemoteConversation, name string) {
 		require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{}, q, nil))
 		_, res, _, err := inbox.Read(context.TODO(), q, nil)
 		require.NoError(t, err)
@@ -228,8 +232,8 @@ func TestInboxQueries(t *testing.T) {
 	mergeReadAndCheck(t, muted, "muted")
 
 	t.Logf("merging tlf ID query")
-	q = &chat1.GetInboxQuery{TlfID: &full[0].Metadata.IdTriple.Tlfid}
-	tlfIDs := []chat1.Conversation{full[0]}
+	q = &chat1.GetInboxQuery{TlfID: &full[0].Conv.Metadata.IdTriple.Tlfid}
+	tlfIDs := []types.RemoteConversation{full[0]}
 	mergeReadAndCheck(t, tlfIDs, "tlfids")
 
 	t.Logf("merging after query")
@@ -261,15 +265,15 @@ func TestInboxEmptySuperseder(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 20
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := 0; i < numConvs; i++ {
 		conv := makeConvo(gregor1.Time(i), 1, 1)
-		conv.MaxMsgSummaries = nil
+		conv.Conv.MaxMsgSummaries = nil
 		convs = append(convs, conv)
 	}
-	var full, superseded []chat1.Conversation
-	convs[6].Metadata.SupersededBy = append(convs[6].Metadata.SupersededBy, convs[17].Metadata)
-	convs[17].Metadata.Supersedes = append(convs[17].Metadata.Supersedes, convs[6].Metadata)
+	var full, superseded []types.RemoteConversation
+	convs[6].Conv.Metadata.SupersededBy = append(convs[6].Conv.Metadata.SupersededBy, convs[17].Conv.Metadata)
+	convs[17].Conv.Metadata.Supersedes = append(convs[17].Conv.Metadata.Supersedes, convs[6].Conv.Metadata)
 	for i := len(convs) - 1; i >= 0; i-- {
 		// Don't skip the superseded one, since it's not supposed to be filtered out
 		// by an empty superseder
@@ -279,11 +283,11 @@ func TestInboxEmptySuperseder(t *testing.T) {
 		t.Logf("convID: %s", conv.GetConvID())
 	}
 
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 
 	// Merge in queries and try to read them back out
 	var q *chat1.GetInboxQuery
-	mergeReadAndCheck := func(t *testing.T, ref []chat1.Conversation, name string) {
+	mergeReadAndCheck := func(t *testing.T, ref []types.RemoteConversation, name string) {
 		require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{}, q, nil))
 		_, res, _, err := inbox.Read(context.TODO(), q, nil)
 		require.NoError(t, err)
@@ -307,8 +311,8 @@ func TestInboxEmptySuperseder(t *testing.T) {
 
 	// Now test OneChatTypePerTLF
 	_, inbox, _ = setupInboxTest(t, "queries2")
-	full = []chat1.Conversation{}
-	superseded = []chat1.Conversation{}
+	full = []types.RemoteConversation{}
+	superseded = []types.RemoteConversation{}
 	for i := len(convs) - 1; i >= 0; i-- {
 		// skip the superseded one, since it's supposed to be filtered out
 		// if not OneChatTypePerTLF
@@ -317,7 +321,7 @@ func TestInboxEmptySuperseder(t *testing.T) {
 		}
 		full = append(full, convs[i])
 	}
-	require.NoError(t, inbox.Merge(context.TODO(), 1, full, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(full), nil, nil))
 	for _, conv := range full {
 		superseded = append(superseded, conv)
 	}
@@ -333,7 +337,7 @@ func TestInboxPagination(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 50
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
 	}
@@ -341,7 +345,7 @@ func TestInboxPagination(t *testing.T) {
 	secondPage := convs[10:20]
 	thirdPage := convs[20:35]
 
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 
 	// Get first page
 	t.Logf("first page")
@@ -410,41 +414,41 @@ func TestInboxNewConversation(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
 	}
-	convs[5].Metadata.FinalizeInfo = &chat1.ConversationFinalizeInfo{
+	convs[5].Conv.Metadata.FinalizeInfo = &chat1.ConversationFinalizeInfo{
 		ResetFull: "reset",
 	}
 
 	t.Logf("basic newconv")
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 	newConv := makeConvo(gregor1.Time(11), 1, 1)
-	require.NoError(t, inbox.NewConversation(context.TODO(), 2, newConv))
+	require.NoError(t, inbox.NewConversation(context.TODO(), 2, newConv.Conv))
 	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
-	convs = append([]chat1.Conversation{newConv}, convs...)
+	convs = append([]types.RemoteConversation{newConv}, convs...)
 	convListCompare(t, convs, res, "newconv")
 
 	t.Logf("repeat conv")
-	require.NoError(t, inbox.NewConversation(context.TODO(), 3, newConv))
+	require.NoError(t, inbox.NewConversation(context.TODO(), 3, newConv.Conv))
 	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 	convListCompare(t, convs, res, "repeatconv")
 
 	t.Logf("supersede newconv")
 	newConv = makeConvo(gregor1.Time(12), 1, 1)
-	newConv.Metadata.Supersedes = append(newConv.Metadata.Supersedes, convs[6].Metadata)
-	require.NoError(t, inbox.NewConversation(context.TODO(), 4, newConv))
+	newConv.Conv.Metadata.Supersedes = append(newConv.Conv.Metadata.Supersedes, convs[6].Conv.Metadata)
+	require.NoError(t, inbox.NewConversation(context.TODO(), 4, newConv.Conv))
 	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
-	convs = append([]chat1.Conversation{newConv}, convs...)
+	convs = append([]types.RemoteConversation{newConv}, convs...)
 	convListCompare(t, append(convs[:7], convs[8:]...), res, "newconv finalized")
 
 	require.Equal(t, numConvs+2, len(convs), "n convs")
 
-	err = inbox.NewConversation(context.TODO(), 10, newConv)
+	err = inbox.NewConversation(context.TODO(), 10, newConv.Conv)
 	require.IsType(t, VersionMismatchError{}, err)
 }
 
@@ -454,7 +458,7 @@ func TestInboxNewMessage(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
 	}
@@ -465,12 +469,12 @@ func TestInboxNewMessage(t *testing.T) {
 	uid3, err := hex.DecodeString("33")
 	require.NoError(t, err)
 
-	convs[5].Metadata.ActiveList = []gregor1.UID{uid2, uid3, uid1}
-	convs[6].Metadata.ActiveList = []gregor1.UID{uid2, uid3}
+	convs[5].Conv.Metadata.ActiveList = []gregor1.UID{uid2, uid3, uid1}
+	convs[6].Conv.Metadata.ActiveList = []gregor1.UID{uid2, uid3}
 	conv := convs[5]
 	msg := makeInboxMsg(2, chat1.MessageType_TEXT)
 	msg.ClientHeader.Sender = uid1
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, convs[0].GetConvID(), res[0].GetConvID(), "conv not promoted")
@@ -478,10 +482,10 @@ func TestInboxNewMessage(t *testing.T) {
 	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, conv.GetConvID(), res[0].GetConvID(), "conv not promoted")
-	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.MaxMsgid, "wrong max msgid")
-	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.ReadMsgid, "wrong read msgid")
-	require.Equal(t, []gregor1.UID{uid1, uid2, uid3}, res[0].Metadata.ActiveList, "active list")
-	maxMsg, err := res[0].GetMaxMessage(chat1.MessageType_TEXT)
+	require.Equal(t, chat1.MessageID(2), res[0].Conv.ReaderInfo.MaxMsgid, "wrong max msgid")
+	require.Equal(t, chat1.MessageID(2), res[0].Conv.ReaderInfo.ReadMsgid, "wrong read msgid")
+	require.Equal(t, []gregor1.UID{uid1, uid2, uid3}, res[0].Conv.Metadata.ActiveList, "active list")
+	maxMsg, err := res[0].Conv.GetMaxMessage(chat1.MessageType_TEXT)
 	require.NoError(t, err)
 	require.Equal(t, chat1.MessageID(2), maxMsg.GetMessageID(), "max msg not updated")
 
@@ -490,7 +494,7 @@ func TestInboxNewMessage(t *testing.T) {
 	require.NoError(t, inbox.NewMessage(context.TODO(), 3, conv.GetConvID(), msg))
 	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, []gregor1.UID{uid1, uid2, uid3}, res[0].Metadata.ActiveList, "active list")
+	require.Equal(t, []gregor1.UID{uid1, uid2, uid3}, res[0].Conv.Metadata.ActiveList, "active list")
 
 	// Send another one from a diff User
 	msg = makeInboxMsg(3, chat1.MessageType_TEXT)
@@ -498,10 +502,10 @@ func TestInboxNewMessage(t *testing.T) {
 	require.NoError(t, inbox.NewMessage(context.TODO(), 4, conv.GetConvID(), msg))
 	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, chat1.MessageID(3), res[0].ReaderInfo.MaxMsgid, "wrong max msgid")
-	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.ReadMsgid, "wrong read msgid")
-	require.Equal(t, []gregor1.UID{uid2, uid1, uid3}, res[0].Metadata.ActiveList, "active list")
-	maxMsg, err = res[0].GetMaxMessage(chat1.MessageType_TEXT)
+	require.Equal(t, chat1.MessageID(3), res[0].Conv.ReaderInfo.MaxMsgid, "wrong max msgid")
+	require.Equal(t, chat1.MessageID(2), res[0].Conv.ReaderInfo.ReadMsgid, "wrong read msgid")
+	require.Equal(t, []gregor1.UID{uid2, uid1, uid3}, res[0].Conv.Metadata.ActiveList, "active list")
+	maxMsg, err = res[0].Conv.GetMaxMessage(chat1.MessageType_TEXT)
 	require.NoError(t, err)
 	require.Equal(t, chat1.MessageID(3), maxMsg.GetMessageID(), "max msg not updated")
 
@@ -518,12 +522,12 @@ func TestInboxReadMessage(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
 	}
 
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 
@@ -533,13 +537,13 @@ func TestInboxReadMessage(t *testing.T) {
 	require.NoError(t, inbox.NewMessage(context.TODO(), 2, conv.GetConvID(), msg))
 	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.MaxMsgid, "wrong max msgid")
-	require.Equal(t, chat1.MessageID(1), res[0].ReaderInfo.ReadMsgid, "wrong read msgid")
+	require.Equal(t, chat1.MessageID(2), res[0].Conv.ReaderInfo.MaxMsgid, "wrong max msgid")
+	require.Equal(t, chat1.MessageID(1), res[0].Conv.ReaderInfo.ReadMsgid, "wrong read msgid")
 	require.NoError(t, inbox.ReadMessage(context.TODO(), 3, conv.GetConvID(), 2))
 	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.MaxMsgid, "wrong max msgid")
-	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.ReadMsgid, "wrong read msgid")
+	require.Equal(t, chat1.MessageID(2), res[0].Conv.ReaderInfo.MaxMsgid, "wrong max msgid")
+	require.Equal(t, chat1.MessageID(2), res[0].Conv.ReaderInfo.ReadMsgid, "wrong read msgid")
 
 	err = inbox.ReadMessage(context.TODO(), 10, conv.GetConvID(), 3)
 	require.IsType(t, VersionMismatchError{}, err)
@@ -551,13 +555,13 @@ func TestInboxSetStatus(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
 	}
 
 	conv := convs[5]
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 	require.NoError(t, inbox.SetStatus(context.TODO(), 2, conv.GetConvID(),
 		chat1.ConversationStatus_IGNORED))
 
@@ -588,13 +592,13 @@ func TestInboxSetStatusMuted(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
 	}
 
 	conv := convs[5]
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 	require.NoError(t, inbox.SetStatus(context.TODO(), 2, conv.GetConvID(),
 		chat1.ConversationStatus_MUTED))
 
@@ -625,20 +629,20 @@ func TestInboxTlfFinalize(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
 	}
 
 	conv := convs[5]
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 	require.NoError(t, inbox.TlfFinalize(context.TODO(), 2, []chat1.ConversationID{conv.GetConvID()},
 		chat1.ConversationFinalizeInfo{ResetFull: "reset"}))
 	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, len(convs), len(res), "length")
 	require.Equal(t, conv.GetConvID(), res[5].GetConvID(), "id")
-	require.NotNil(t, res[5].Metadata.FinalizeInfo, "finalize info")
+	require.NotNil(t, res[5].Conv.Metadata.FinalizeInfo, "finalize info")
 
 	err = inbox.TlfFinalize(context.TODO(), 10, []chat1.ConversationID{conv.GetConvID()},
 		chat1.ConversationFinalizeInfo{ResetFull: "reset"})
@@ -650,22 +654,22 @@ func TestInboxSync(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
 	}
 
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 
 	var syncConvs []chat1.Conversation
-	convs[0].Metadata.Status = chat1.ConversationStatus_MUTED
-	convs[6].Metadata.Status = chat1.ConversationStatus_MUTED
-	syncConvs = append(syncConvs, convs[0])
-	syncConvs = append(syncConvs, convs[6])
+	convs[0].Conv.Metadata.Status = chat1.ConversationStatus_MUTED
+	convs[6].Conv.Metadata.Status = chat1.ConversationStatus_MUTED
+	syncConvs = append(syncConvs, convs[0].Conv)
+	syncConvs = append(syncConvs, convs[6].Conv)
 	newConv := makeConvo(gregor1.Time(60), 1, 1)
-	syncConvs = append(syncConvs, newConv)
+	syncConvs = append(syncConvs, newConv.Conv)
 
 	vers, err := inbox.Version(context.TODO())
 	require.NoError(t, err)
@@ -676,21 +680,21 @@ func TestInboxSync(t *testing.T) {
 	require.Equal(t, vers+1, newVers)
 	require.Equal(t, len(res)+1, len(newRes))
 	require.Equal(t, newConv.GetConvID(), newRes[0].GetConvID())
-	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[1].Metadata.Status)
-	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[7].Metadata.Status)
-	require.Equal(t, chat1.ConversationStatus_UNFILED, newRes[4].Metadata.Status)
+	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[1].Conv.Metadata.Status)
+	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[7].Conv.Metadata.Status)
+	require.Equal(t, chat1.ConversationStatus_UNFILED, newRes[4].Conv.Metadata.Status)
 	require.False(t, syncRes.TeamTypeChanged)
 
 	syncConvs = nil
 	vers, err = inbox.Version(context.TODO())
 	require.NoError(t, err)
-	convs[8].Metadata.TeamType = chat1.TeamType_COMPLEX
-	syncConvs = append(syncConvs, convs[8])
+	convs[8].Conv.Metadata.TeamType = chat1.TeamType_COMPLEX
+	syncConvs = append(syncConvs, convs[8].Conv)
 	syncRes, err = inbox.Sync(context.TODO(), vers+1, syncConvs)
 	newVers, newRes, _, err = inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, vers+1, newVers)
-	require.Equal(t, chat1.TeamType_COMPLEX, newRes[9].Metadata.TeamType)
+	require.Equal(t, chat1.TeamType_COMPLEX, newRes[9].Conv.Metadata.TeamType)
 	require.True(t, syncRes.TeamTypeChanged)
 }
 
@@ -699,12 +703,12 @@ func TestInboxServerVersion(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
 	}
 
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, numConvs, len(res))
@@ -719,7 +723,7 @@ func TestInboxServerVersion(t *testing.T) {
 	require.Error(t, err)
 	require.IsType(t, MissError{}, err)
 
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
 	idata, err := inbox.readDiskInbox(context.TODO())
 	require.NoError(t, err)
 	require.Equal(t, 5, idata.ServerVersion)
@@ -740,19 +744,19 @@ func TestMembershipUpdate(t *testing.T) {
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
-	var convs []chat1.Conversation
+	var convs []types.RemoteConversation
 	for i := numConvs - 1; i >= 0; i-- {
 		conv := makeConvo(gregor1.Time(i), 1, 1)
-		conv.Metadata.AllList = []gregor1.UID{uid, uid3}
+		conv.Conv.Metadata.AllList = []gregor1.UID{uid, uid3}
 		convs = append(convs, conv)
 	}
 
-	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
-	var joinedConvs []chat1.Conversation
+	require.NoError(t, inbox.Merge(context.TODO(), 1, utils.PluckConvs(convs), nil, nil))
+	var joinedConvs []types.RemoteConversation
 	numJoinedConvs := 5
 	for i := 0; i < numJoinedConvs; i++ {
 		conv := makeConvo(gregor1.Time(i), 1, 1)
-		conv.Metadata.AllList = []gregor1.UID{uid, uid3}
+		conv.Conv.Metadata.AllList = []gregor1.UID{uid, uid3}
 		joinedConvs = append(joinedConvs, conv)
 	}
 
@@ -766,7 +770,7 @@ func TestMembershipUpdate(t *testing.T) {
 		Uid:    uid3,
 		ConvID: otherRemovedConvID,
 	}}
-	require.NoError(t, inbox.MembershipUpdate(context.TODO(), 2, joinedConvs,
+	require.NoError(t, inbox.MembershipUpdate(context.TODO(), 2, utils.PluckConvs(joinedConvs),
 		[]chat1.ConversationID{convs[5].GetConvID()}, otherJoinedConvs, otherRemovedConvs))
 
 	vers, res, err := inbox.ReadAll(context.TODO())
@@ -774,29 +778,29 @@ func TestMembershipUpdate(t *testing.T) {
 	require.Equal(t, chat1.InboxVers(2), vers)
 	for _, c := range res {
 		if c.GetConvID().Eq(convs[5].GetConvID()) {
-			require.Equal(t, chat1.ConversationMemberStatus_LEFT, c.ReaderInfo.Status)
-			convs[5].ReaderInfo.Status = chat1.ConversationMemberStatus_LEFT
-			convs[5].Metadata.Version = chat1.ConversationVers(2)
+			require.Equal(t, chat1.ConversationMemberStatus_LEFT, c.Conv.ReaderInfo.Status)
+			convs[5].Conv.ReaderInfo.Status = chat1.ConversationMemberStatus_LEFT
+			convs[5].Conv.Metadata.Version = chat1.ConversationVers(2)
 		}
 	}
 	expected := append(convs, joinedConvs...)
-	sort.Sort(utils.ConvByConvID(expected))
-	sort.Sort(utils.ConvByConvID(res))
+	sort.Sort(utils.RemoteConvByConvID(expected))
+	sort.Sort(utils.RemoteConvByConvID(res))
 	require.Equal(t, len(expected), len(res))
 	for i := 0; i < len(res); i++ {
-		sort.Sort(chat1.ByUID(res[i].Metadata.AllList))
-		sort.Sort(chat1.ByUID(expected[i].Metadata.AllList))
+		sort.Sort(chat1.ByUID(res[i].Conv.Metadata.AllList))
+		sort.Sort(chat1.ByUID(expected[i].Conv.Metadata.AllList))
 		if res[i].GetConvID().Eq(otherJoinConvID) {
 			allUsers := []gregor1.UID{uid, uid2, uid3}
 			sort.Sort(chat1.ByUID(allUsers))
-			require.Equal(t, allUsers, res[i].Metadata.AllList)
+			require.Equal(t, allUsers, res[i].Conv.Metadata.AllList)
 		} else if res[i].GetConvID().Eq(otherRemovedConvID) {
 			allUsers := []gregor1.UID{uid}
-			require.Equal(t, allUsers, res[i].Metadata.AllList)
+			require.Equal(t, allUsers, res[i].Conv.Metadata.AllList)
 		} else {
 			allUsers := []gregor1.UID{uid, uid3}
 			sort.Sort(chat1.ByUID(allUsers))
-			require.Equal(t, allUsers, res[i].Metadata.AllList)
+			require.Equal(t, allUsers, res[i].Conv.Metadata.AllList)
 			require.Equal(t, expected[i], res[i])
 		}
 	}

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -162,7 +162,7 @@ func TestSyncerConnected(t *testing.T) {
 	require.Equal(t, len(convs), len(iconvs))
 	for _, ic := range iconvs {
 		if ic.GetConvID().Eq(mconv.GetConvID()) {
-			require.Equal(t, chat1.ConversationStatus_MUTED, ic.Metadata.Status)
+			require.Equal(t, chat1.ConversationStatus_MUTED, ic.Conv.Metadata.Status)
 		}
 	}
 	require.Equal(t, chat1.ConversationStatus_UNFILED, convs[1].Metadata.Status)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -64,7 +64,7 @@ type Sender interface {
 }
 
 type ChatLocalizer interface {
-	Localize(ctx context.Context, uid gregor1.UID, inbox chat1.Inbox) ([]chat1.ConversationLocal, error)
+	Localize(ctx context.Context, uid gregor1.UID, inbox Inbox) ([]chat1.ConversationLocal, error)
 	Name() string
 	SetOffline()
 }
@@ -73,9 +73,9 @@ type InboxSource interface {
 	Offlinable
 
 	Read(ctx context.Context, uid gregor1.UID, localizer ChatLocalizer, useLocalData bool,
-		query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (chat1.Inbox, *chat1.RateLimit, error)
+		query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (Inbox, *chat1.RateLimit, error)
 	ReadUnverified(ctx context.Context, uid gregor1.UID, useLocalData bool,
-		query *chat1.GetInboxQuery, p *chat1.Pagination) (chat1.Inbox, *chat1.RateLimit, error)
+		query *chat1.GetInboxQuery, p *chat1.Pagination) (Inbox, *chat1.RateLimit, error)
 	IsMember(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (bool, *chat1.RateLimit, error)
 
 	NewConversation(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -30,4 +31,30 @@ type MembershipUpdateRes struct {
 	UserRemovedConvs   []chat1.ConversationID
 	OthersJoinedConvs  []chat1.ConversationMember
 	OthersRemovedConvs []chat1.ConversationMember
+}
+
+type RemoteConversationMetadata struct {
+	TopicName string `codec:"t"`
+	Snippet   string `codec:"s"`
+	Headline  string `codec:"h"`
+}
+
+type RemoteConversation struct {
+	Conv          chat1.Conversation          `codec:"c"`
+	LocalMetadata *RemoteConversationMetadata `codec:"l"`
+}
+
+func (rc RemoteConversation) GetMtime() gregor1.Time {
+	return rc.Conv.GetMtime()
+}
+
+func (rc RemoteConversation) GetConvID() chat1.ConversationID {
+	return rc.Conv.GetConvID()
+}
+
+type Inbox struct {
+	Version         chat1.InboxVers
+	ConvsUnverified []RemoteConversation
+	Convs           []chat1.ConversationLocal
+	Pagination      *chat1.Pagination
 }

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -34,9 +34,10 @@ type MembershipUpdateRes struct {
 }
 
 type RemoteConversationMetadata struct {
-	TopicName string `codec:"t"`
-	Snippet   string `codec:"s"`
-	Headline  string `codec:"h"`
+	TopicName   string   `codec:"t"`
+	Snippet     string   `codec:"s"`
+	Headline    string   `codec:"h"`
+	WriterNames []string `codec:"w"`
 }
 
 type RemoteConversation struct {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -605,6 +605,7 @@ func PresentRemoteConversation(rc types.RemoteConversation) (res chat1.Unverifie
 			ChannelName: rc.LocalMetadata.TopicName,
 			Headline:    rc.LocalMetadata.Headline,
 			Snippet:     rc.LocalMetadata.Snippet,
+			WriterNames: rc.LocalMetadata.WriterNames,
 		}
 	}
 	return res

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -576,6 +576,10 @@ func GetConvSnippet(conv chat1.ConversationLocal) string {
 	if err != nil {
 		return ""
 	}
+	return GetMsgSnippet(msg)
+}
+
+func GetMsgSnippet(msg chat1.MessageUnboxed) string {
 	switch msg.GetMessageType() {
 	case chat1.MessageType_TEXT:
 		return msg.Valid().MessageBody.Text().Body

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -733,6 +733,14 @@ func (c ConvByConvID) Less(i, j int) bool {
 	return c[i].GetConvID().Less(c[j].GetConvID())
 }
 
+type RemoteConvByConvID []types.RemoteConversation
+
+func (c RemoteConvByConvID) Len() int      { return len(c) }
+func (c RemoteConvByConvID) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c RemoteConvByConvID) Less(i, j int) bool {
+	return c[i].GetConvID().Less(c[j].GetConvID())
+}
+
 type ConvLocalByTopicName []chat1.ConversationLocal
 
 func (c ConvLocalByTopicName) Len() int      { return len(c) }

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 
 	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/kbfs"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
@@ -584,6 +585,27 @@ func GetConvSnippet(conv chat1.ConversationLocal) string {
 	return ""
 }
 
+func PresentRemoteConversation(rc types.RemoteConversation) (res chat1.UnverifiedInboxUIItem) {
+	rawConv := rc.Conv
+	res.ConvID = rawConv.GetConvID().String()
+	res.Name = rawConv.MaxMsgSummaries[0].TlfName
+	res.Status = rawConv.Metadata.Status
+	res.Time = GetConvMtime(rawConv)
+	res.Visibility = rawConv.Metadata.Visibility
+	res.Notifications = rawConv.Notifications
+	res.MembersType = rawConv.GetMembersType()
+	res.TeamType = rawConv.Metadata.TeamType
+	res.Version = rawConv.Metadata.Version
+	if rc.LocalMetadata != nil {
+		res.LocalMetadata = &chat1.UnverifiedInboxUIItemMetadata{
+			ChannelName: rc.LocalMetadata.TopicName,
+			Headline:    rc.LocalMetadata.Headline,
+			Snippet:     rc.LocalMetadata.Snippet,
+		}
+	}
+	return res
+}
+
 func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxUIItem) {
 	res.ConvID = rawConv.GetConvID().String()
 	res.Name = rawConv.Info.TlfName
@@ -785,4 +807,20 @@ func DecodeBase64(enc []byte) ([]byte, error) {
 	b := make([]byte, base64.StdEncoding.DecodedLen(len(enc)))
 	n, err := base64.StdEncoding.Decode(b, enc)
 	return b[:n], err
+}
+
+func RemoteConvs(convs []chat1.Conversation) (res []types.RemoteConversation) {
+	for _, conv := range convs {
+		res = append(res, types.RemoteConversation{
+			Conv: conv,
+		})
+	}
+	return res
+}
+
+func PluckConvs(rcs []types.RemoteConversation) (res []chat1.Conversation) {
+	for _, rc := range rcs {
+		res = append(res, rc.Conv)
+	}
+	return res
 }

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -27,16 +27,31 @@ func (o UIPagination) DeepCopy() UIPagination {
 	}
 }
 
+type UnverifiedInboxUIItemMetadata struct {
+	ChannelName string `codec:"channelName" json:"channelName"`
+	Headline    string `codec:"headline" json:"headline"`
+	Snippet     string `codec:"snippet" json:"snippet"`
+}
+
+func (o UnverifiedInboxUIItemMetadata) DeepCopy() UnverifiedInboxUIItemMetadata {
+	return UnverifiedInboxUIItemMetadata{
+		ChannelName: o.ChannelName,
+		Headline:    o.Headline,
+		Snippet:     o.Snippet,
+	}
+}
+
 type UnverifiedInboxUIItem struct {
-	ConvID        string                        `codec:"convID" json:"convID"`
-	Name          string                        `codec:"name" json:"name"`
-	Visibility    keybase1.TLFVisibility        `codec:"visibility" json:"visibility"`
-	Status        ConversationStatus            `codec:"status" json:"status"`
-	MembersType   ConversationMembersType       `codec:"membersType" json:"membersType"`
-	TeamType      TeamType                      `codec:"teamType" json:"teamType"`
-	Notifications *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
-	Time          gregor1.Time                  `codec:"time" json:"time"`
-	Version       ConversationVers              `codec:"version" json:"version"`
+	ConvID        string                         `codec:"convID" json:"convID"`
+	Name          string                         `codec:"name" json:"name"`
+	Visibility    keybase1.TLFVisibility         `codec:"visibility" json:"visibility"`
+	Status        ConversationStatus             `codec:"status" json:"status"`
+	MembersType   ConversationMembersType        `codec:"membersType" json:"membersType"`
+	TeamType      TeamType                       `codec:"teamType" json:"teamType"`
+	Notifications *ConversationNotificationInfo  `codec:"notifications,omitempty" json:"notifications,omitempty"`
+	Time          gregor1.Time                   `codec:"time" json:"time"`
+	Version       ConversationVers               `codec:"version" json:"version"`
+	LocalMetadata *UnverifiedInboxUIItemMetadata `codec:"localMetadata,omitempty" json:"localMetadata,omitempty"`
 }
 
 func (o UnverifiedInboxUIItem) DeepCopy() UnverifiedInboxUIItem {
@@ -56,6 +71,13 @@ func (o UnverifiedInboxUIItem) DeepCopy() UnverifiedInboxUIItem {
 		})(o.Notifications),
 		Time:    o.Time.DeepCopy(),
 		Version: o.Version.DeepCopy(),
+		LocalMetadata: (func(x *UnverifiedInboxUIItemMetadata) *UnverifiedInboxUIItemMetadata {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.LocalMetadata),
 	}
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -28,9 +28,10 @@ func (o UIPagination) DeepCopy() UIPagination {
 }
 
 type UnverifiedInboxUIItemMetadata struct {
-	ChannelName string `codec:"channelName" json:"channelName"`
-	Headline    string `codec:"headline" json:"headline"`
-	Snippet     string `codec:"snippet" json:"snippet"`
+	ChannelName string   `codec:"channelName" json:"channelName"`
+	Headline    string   `codec:"headline" json:"headline"`
+	Snippet     string   `codec:"snippet" json:"snippet"`
+	WriterNames []string `codec:"writerNames" json:"writerNames"`
 }
 
 func (o UnverifiedInboxUIItemMetadata) DeepCopy() UnverifiedInboxUIItemMetadata {
@@ -38,6 +39,17 @@ func (o UnverifiedInboxUIItemMetadata) DeepCopy() UnverifiedInboxUIItemMetadata 
 		ChannelName: o.ChannelName,
 		Headline:    o.Headline,
 		Snippet:     o.Snippet,
+		WriterNames: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.WriterNames),
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -846,48 +846,6 @@ func (o OutboxRecord) DeepCopy() OutboxRecord {
 	}
 }
 
-type Inbox struct {
-	Version         InboxVers           `codec:"version" json:"version"`
-	ConvsUnverified []Conversation      `codec:"convsUnverified" json:"convsUnverified"`
-	Convs           []ConversationLocal `codec:"convs" json:"convs"`
-	Pagination      *Pagination         `codec:"pagination,omitempty" json:"pagination,omitempty"`
-}
-
-func (o Inbox) DeepCopy() Inbox {
-	return Inbox{
-		Version: o.Version.DeepCopy(),
-		ConvsUnverified: (func(x []Conversation) []Conversation {
-			if x == nil {
-				return nil
-			}
-			var ret []Conversation
-			for _, v := range x {
-				vCopy := v.DeepCopy()
-				ret = append(ret, vCopy)
-			}
-			return ret
-		})(o.ConvsUnverified),
-		Convs: (func(x []ConversationLocal) []ConversationLocal {
-			if x == nil {
-				return nil
-			}
-			var ret []ConversationLocal
-			for _, v := range x {
-				vCopy := v.DeepCopy()
-				ret = append(ret, vCopy)
-			}
-			return ret
-		})(o.Convs),
-		Pagination: (func(x *Pagination) *Pagination {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.Pagination),
-	}
-}
-
 type HeaderPlaintextVersion int
 
 const (

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -16,6 +16,7 @@ protocol chatUi {
     string channelName;
     string headline;
     string snippet;
+    array<string> writerNames;
   }
 
   record UnverifiedInboxUIItem {

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -12,6 +12,12 @@ protocol chatUi {
     boolean last;
   }
 
+  record UnverifiedInboxUIItemMetadata {
+    string channelName;
+    string headline;
+    string snippet;
+  }
+
   record UnverifiedInboxUIItem {
     string convID;
     string name;
@@ -22,6 +28,7 @@ protocol chatUi {
     union{ null, ConversationNotificationInfo } notifications;
     gregor1.Time time;
     ConversationVers version;
+    union { null , UnverifiedInboxUIItemMetadata } localMetadata;
   }
 
   record UnverifiedInboxUIItems {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -141,13 +141,6 @@ protocol local {
     keybase1.TLFIdentifyBehavior identifyBehavior;
   }
 
-  record Inbox {
-    InboxVers version;
-    array<Conversation> convsUnverified;
-    array<ConversationLocal> convs;
-    union { null, Pagination } pagination;
-  }
-
   enum HeaderPlaintextVersion {
     V1_1,
     V2_2,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2001,6 +2001,13 @@ export type UnverifiedInboxUIItem = {
   notifications?: ?ConversationNotificationInfo,
   time: gregor1.Time,
   version: ConversationVers,
+  localMetadata?: ?UnverifiedInboxUIItemMetadata,
+}
+
+export type UnverifiedInboxUIItemMetadata = {
+  channelName: string,
+  headline: string,
+  snippet: string,
 }
 
 export type UnverifiedInboxUIItems = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2008,6 +2008,7 @@ export type UnverifiedInboxUIItemMetadata = {
   channelName: string,
   headline: string,
   snippet: string,
+  writerNames?: ?Array<string>,
 }
 
 export type UnverifiedInboxUIItems = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1291,13 +1291,6 @@ export type HeaderPlaintextVersion =
   | 9 // V9_9
   | 10 // V10_10
 
-export type Inbox = {
-  version: InboxVers,
-  convsUnverified?: ?Array<Conversation>,
-  convs?: ?Array<ConversationLocal>,
-  pagination?: ?Pagination,
-}
-
 export type InboxResType =
     0 // VERSIONHIT_0
   | 1 // FULL_1

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -50,6 +50,13 @@
         {
           "type": "string",
           "name": "snippet"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "writerNames"
         }
       ]
     },

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -37,6 +37,24 @@
     },
     {
       "type": "record",
+      "name": "UnverifiedInboxUIItemMetadata",
+      "fields": [
+        {
+          "type": "string",
+          "name": "channelName"
+        },
+        {
+          "type": "string",
+          "name": "headline"
+        },
+        {
+          "type": "string",
+          "name": "snippet"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "UnverifiedInboxUIItem",
       "fields": [
         {
@@ -77,6 +95,13 @@
         {
           "type": "ConversationVers",
           "name": "version"
+        },
+        {
+          "type": [
+            null,
+            "UnverifiedInboxUIItemMetadata"
+          ],
+          "name": "localMetadata"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -457,37 +457,6 @@
       ]
     },
     {
-      "type": "record",
-      "name": "Inbox",
-      "fields": [
-        {
-          "type": "InboxVers",
-          "name": "version"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "Conversation"
-          },
-          "name": "convsUnverified"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "ConversationLocal"
-          },
-          "name": "convs"
-        },
-        {
-          "type": [
-            null,
-            "Pagination"
-          ],
-          "name": "pagination"
-        }
-      ]
-    },
-    {
       "type": "enum",
       "name": "HeaderPlaintextVersion",
       "symbols": [

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -135,16 +135,13 @@ function* onInboxStale(): SagaGenerator<any, any> {
     const author = yield select(usernameSelector)
     const snippets = (inbox.items || []).reduce((map, c) => {
       const snippet = c.localMetadata ? c.localMetadata.snippet : ''
-      console.warn(`SNIPPET: id: ${c.convID} snippet: ${snippet}`)
       map[c.convID] = new HiddenString(Constants.makeSnippet(snippet) || '')
       return map
     }, {})
-    console.warn(`SNIPPET MAP: ${JSON.stringify(snippets)}`)
 
     const conversations: List<Constants.InboxState> = List(
       (inbox.items || [])
         .map(c => {
-          console.warn(`METADATA: name: ${c.name} metadata: ${JSON.stringify(c.localMetadata)}`)
           return new Constants.InboxStateRecord({
             channelname: c.membersType === ChatTypes.CommonConversationMembersType.team && c.localMetadata
               ? c.localMetadata.channelName

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -142,6 +142,9 @@ function* onInboxStale(): SagaGenerator<any, any> {
     const conversations: List<Constants.InboxState> = List(
       (inbox.items || [])
         .map(c => {
+          const parts = c.localMetadata
+            ? List(c.localMetadata.writerNames || [])
+            : List(parseFolderNameToUsers(author, c.name).map(ul => ul.username))
           return new Constants.InboxStateRecord({
             channelname: c.membersType === ChatTypes.CommonConversationMembersType.team && c.localMetadata
               ? c.localMetadata.channelName
@@ -149,7 +152,7 @@ function* onInboxStale(): SagaGenerator<any, any> {
             conversationIDKey: c.convID,
             info: null,
             membersType: c.membersType,
-            participants: List(parseFolderNameToUsers(author, c.name).map(ul => ul.username)),
+            participants: parts,
             status: Constants.ConversationStatusByEnum[c.status || 0],
             teamname: c.membersType === ChatTypes.CommonConversationMembersType.team ? c.name : undefined,
             teamType: c.teamType,

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -135,15 +135,20 @@ function* onInboxStale(): SagaGenerator<any, any> {
     const author = yield select(usernameSelector)
     const snippets = (inbox.items || []).reduce((map, c) => {
       const snippet = c.localMetadata ? c.localMetadata.snippet : ''
+      console.warn(`SNIPPET: id: ${c.convID} snippet: ${snippet}`)
       map[c.convID] = new HiddenString(Constants.makeSnippet(snippet) || '')
       return map
     }, {})
+    console.warn(`SNIPPET MAP: ${JSON.stringify(snippets)}`)
 
     const conversations: List<Constants.InboxState> = List(
       (inbox.items || [])
         .map(c => {
+          console.warn(`METADATA: name: ${c.name} metadata: ${JSON.stringify(c.localMetadata)}`)
           return new Constants.InboxStateRecord({
-            channelname: c.membersType === ChatTypes.CommonConversationMembersType.team ? '-' : undefined,
+            channelname: c.membersType === ChatTypes.CommonConversationMembersType.team && c.localMetadata
+              ? c.localMetadata.channelName
+              : undefined,
             conversationIDKey: c.convID,
             info: null,
             membersType: c.membersType,
@@ -153,7 +158,6 @@ function* onInboxStale(): SagaGenerator<any, any> {
             teamType: c.teamType,
             time: c.time,
             version: c.version,
-            channelname: c.localMetadata ? c.localMetadata.channelName : null,
           })
         })
         .filter(Boolean)

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2001,6 +2001,13 @@ export type UnverifiedInboxUIItem = {
   notifications?: ?ConversationNotificationInfo,
   time: gregor1.Time,
   version: ConversationVers,
+  localMetadata?: ?UnverifiedInboxUIItemMetadata,
+}
+
+export type UnverifiedInboxUIItemMetadata = {
+  channelName: string,
+  headline: string,
+  snippet: string,
 }
 
 export type UnverifiedInboxUIItems = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2008,6 +2008,7 @@ export type UnverifiedInboxUIItemMetadata = {
   channelName: string,
   headline: string,
   snippet: string,
+  writerNames?: ?Array<string>,
 }
 
 export type UnverifiedInboxUIItems = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1291,13 +1291,6 @@ export type HeaderPlaintextVersion =
   | 9 // V9_9
   | 10 // V10_10
 
-export type Inbox = {
-  version: InboxVers,
-  convsUnverified?: ?Array<Conversation>,
-  convs?: ?Array<ConversationLocal>,
-  pagination?: ?Pagination,
-}
-
 export type InboxResType =
     0 // VERSIONHIT_0
   | 1 // FULL_1


### PR DESCRIPTION
Patch does the following:

1.) Changes the `Inbox` to store a `types.RemoteConversation` instead of `chat1.Conversation`. This has the advantage that we can stash elements from a previous unboxing on the inbox cache directly, allowing the UI to render the last known good value. 
2.) Plays out this non-trivial refactor across all components that deal with the `Inbox`.
3.) Calls the new `MergeLocalMetadata` on the inbox from any `HybridInboxSource.Read`, as well as at the end of `GetInboxNonblock`. Unfortunately, we don't have the unboxed conversations in `HybridInboxSource.Read` for the non-blocking localizer, so we have to add the extra code in `GetInboxNonblock`. 
4.) Change frontend code to use these new fields when rendering the initial inbox.