### PR TITLE
Team delete shows instructions if there are subteams

### DIFF
--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -58,6 +58,7 @@ const (
 	PromptDescriptorFSOverwrite
 	PromptDescriptorRemoveMember
 	PromptDescriptorDeleteRootTeam
+	PromptDescriptorDeleteSubteam
 )
 
 const (

--- a/go/client/teams_ui.go
+++ b/go/client/teams_ui.go
@@ -25,11 +25,22 @@ func NewTeamsUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
 func (t *TeamsUI) ConfirmRootTeamDelete(ctx context.Context, arg keybase1.ConfirmRootTeamDeleteArg) (bool, error) {
 	term := t.G().UI.GetTerminalUI()
 	term.Printf("WARNING: This will:\n\n")
-	term.Printf("(1) destroy all data in %s's chats and KBFS folders\n", arg.TeamName)
-	term.Printf("(2) do the same to any of %s's subteams\n", arg.TeamName)
-	term.Printf("(3) prevent %q from being used again as a team name.\n\n", arg.TeamName)
+	term.Printf("(1) destroy all data in %s's chats, KBFS folders, and git repositories.\n", arg.TeamName)
+	term.Printf("(2) prevent %q from being used again as a team name.\n\n", arg.TeamName)
 	confirm := fmt.Sprintf("nuke %s", arg.TeamName)
 	response, err := term.Prompt(PromptDescriptorDeleteRootTeam,
+		fmt.Sprintf("** if you are sure, please type: %q > ", confirm))
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(response) == confirm, nil
+}
+
+func (t *TeamsUI) ConfirmSubteamDelete(ctx context.Context, arg keybase1.ConfirmSubteamDeleteArg) (bool, error) {
+	term := t.G().UI.GetTerminalUI()
+	term.Printf("WARNING: This will destroy all data in %s's chats, KBFS folders, and git repositories.\n\n", arg.TeamName)
+	confirm := fmt.Sprintf("nuke %s", arg.TeamName)
+	response, err := term.Prompt(PromptDescriptorDeleteSubteam,
 		fmt.Sprintf("** if you are sure, please type: %q > ", confirm))
 	if err != nil {
 		return false, err

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -727,3 +727,11 @@ func (t *TimeTracer) Finish() {
 	}
 	t.log.CDebugf(t.ctx, "- %s [time=%s]", t.label, t.clock.Since(t.start))
 }
+
+func IsAppStatusCode(err error, code keybase1.StatusCode) bool {
+	switch err := err.(type) {
+	case AppStatusError:
+		return err.Code == int(code)
+	}
+	return false
+}

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -275,6 +275,18 @@ func (o TeamIDWithVisibility) DeepCopy() TeamIDWithVisibility {
 	}
 }
 
+type TeamIDAndName struct {
+	Id   TeamID   `codec:"id" json:"id"`
+	Name TeamName `codec:"name" json:"name"`
+}
+
+func (o TeamIDAndName) DeepCopy() TeamIDAndName {
+	return TeamIDAndName{
+		Id:   o.Id.DeepCopy(),
+		Name: o.Name.DeepCopy(),
+	}
+}
+
 type Seqno int64
 
 func (o Seqno) DeepCopy() Seqno {

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1349,6 +1349,20 @@ func (o TeamListArg) DeepCopy() TeamListArg {
 	}
 }
 
+type TeamListSubteamsRecursiveArg struct {
+	SessionID      int    `codec:"sessionID" json:"sessionID"`
+	ParentTeamName string `codec:"parentTeamName" json:"parentTeamName"`
+	ForceRepoll    bool   `codec:"forceRepoll" json:"forceRepoll"`
+}
+
+func (o TeamListSubteamsRecursiveArg) DeepCopy() TeamListSubteamsRecursiveArg {
+	return TeamListSubteamsRecursiveArg{
+		SessionID:      o.SessionID,
+		ParentTeamName: o.ParentTeamName,
+		ForceRepoll:    o.ForceRepoll,
+	}
+}
+
 type TeamChangeMembershipArg struct {
 	SessionID int           `codec:"sessionID" json:"sessionID"`
 	Name      string        `codec:"name" json:"name"`
@@ -1593,6 +1607,7 @@ type TeamsInterface interface {
 	TeamCreate(context.Context, TeamCreateArg) (TeamCreateResult, error)
 	TeamGet(context.Context, TeamGetArg) (TeamDetails, error)
 	TeamList(context.Context, TeamListArg) (AnnotatedTeamList, error)
+	TeamListSubteamsRecursive(context.Context, TeamListSubteamsRecursiveArg) ([]TeamIDAndName, error)
 	TeamChangeMembership(context.Context, TeamChangeMembershipArg) error
 	TeamAddMember(context.Context, TeamAddMemberArg) (TeamAddMemberResult, error)
 	TeamRemoveMember(context.Context, TeamRemoveMemberArg) error
@@ -1664,6 +1679,22 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.TeamList(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"teamListSubteamsRecursive": {
+				MakeArg: func() interface{} {
+					ret := make([]TeamListSubteamsRecursiveArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]TeamListSubteamsRecursiveArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]TeamListSubteamsRecursiveArg)(nil), args)
+						return
+					}
+					ret, err = i.TeamListSubteamsRecursive(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1976,6 +2007,11 @@ func (c TeamsClient) TeamGet(ctx context.Context, __arg TeamGetArg) (res TeamDet
 
 func (c TeamsClient) TeamList(ctx context.Context, __arg TeamListArg) (res AnnotatedTeamList, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamList", []interface{}{__arg}, &res)
+	return
+}
+
+func (c TeamsClient) TeamListSubteamsRecursive(ctx context.Context, __arg TeamListSubteamsRecursiveArg) (res []TeamIDAndName, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamListSubteamsRecursive", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/keybase1/teams_ui.go
+++ b/go/protocol/keybase1/teams_ui.go
@@ -20,8 +20,21 @@ func (o ConfirmRootTeamDeleteArg) DeepCopy() ConfirmRootTeamDeleteArg {
 	}
 }
 
+type ConfirmSubteamDeleteArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	TeamName  string `codec:"teamName" json:"teamName"`
+}
+
+func (o ConfirmSubteamDeleteArg) DeepCopy() ConfirmSubteamDeleteArg {
+	return ConfirmSubteamDeleteArg{
+		SessionID: o.SessionID,
+		TeamName:  o.TeamName,
+	}
+}
+
 type TeamsUiInterface interface {
 	ConfirmRootTeamDelete(context.Context, ConfirmRootTeamDeleteArg) (bool, error)
+	ConfirmSubteamDelete(context.Context, ConfirmSubteamDeleteArg) (bool, error)
 }
 
 func TeamsUiProtocol(i TeamsUiInterface) rpc.Protocol {
@@ -44,6 +57,22 @@ func TeamsUiProtocol(i TeamsUiInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"confirmSubteamDelete": {
+				MakeArg: func() interface{} {
+					ret := make([]ConfirmSubteamDeleteArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ConfirmSubteamDeleteArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ConfirmSubteamDeleteArg)(nil), args)
+						return
+					}
+					ret, err = i.ConfirmSubteamDelete(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -54,5 +83,10 @@ type TeamsUiClient struct {
 
 func (c TeamsUiClient) ConfirmRootTeamDelete(ctx context.Context, __arg ConfirmRootTeamDeleteArg) (res bool, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teamsUi.confirmRootTeamDelete", []interface{}{__arg}, &res)
+	return
+}
+
+func (c TeamsUiClient) ConfirmSubteamDelete(ctx context.Context, __arg ConfirmSubteamDeleteArg) (res bool, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teamsUi.confirmSubteamDelete", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/remote_teams_ui.go
+++ b/go/service/remote_teams_ui.go
@@ -12,6 +12,8 @@ type RemoteTeamsUI struct {
 	cli       keybase1.TeamsUiClient
 }
 
+var _ keybase1.TeamsUiInterface = (*RemoteTeamsUI)(nil)
+
 func NewRemoteTeamsUI(sessionID int, c *rpc.Client) *RemoteTeamsUI {
 	return &RemoteTeamsUI{
 		sessionID: sessionID,
@@ -22,4 +24,9 @@ func NewRemoteTeamsUI(sessionID int, c *rpc.Client) *RemoteTeamsUI {
 func (r *RemoteTeamsUI) ConfirmRootTeamDelete(ctx context.Context, arg keybase1.ConfirmRootTeamDeleteArg) (bool, error) {
 	arg.SessionID = r.sessionID
 	return r.cli.ConfirmRootTeamDelete(ctx, arg)
+}
+
+func (r *RemoteTeamsUI) ConfirmSubteamDelete(ctx context.Context, arg keybase1.ConfirmSubteamDeleteArg) (bool, error) {
+	arg.SessionID = r.sessionID
+	return r.cli.ConfirmSubteamDelete(ctx, arg)
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -80,6 +80,11 @@ func (h *TeamsHandler) TeamList(ctx context.Context, arg keybase1.TeamListArg) (
 	return *x, nil
 }
 
+func (h *TeamsHandler) TeamListSubteamsRecursive(ctx context.Context, arg keybase1.TeamListSubteamsRecursiveArg) (res []keybase1.TeamIDAndName, err error) {
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamListSubteamsRecursive(%s)", arg.ParentTeamName), func() error { return err })()
+	return teams.ListSubteamsRecursive(ctx, h.G().ExternalG(), arg.ParentTeamName, arg.ForceRepoll)
+}
+
 func (h *TeamsHandler) TeamChangeMembership(ctx context.Context, arg keybase1.TeamChangeMembershipArg) error {
 	return teams.ChangeRoles(ctx, h.G().ExternalG(), arg.Name, arg.Req)
 }

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -375,11 +375,6 @@ func (t *TeamSigChainState) informSubteamDelete(id keybase1.TeamID, seqno keybas
 	return nil
 }
 
-type TeamIDAndName struct {
-	ID   keybase1.TeamID
-	Name keybase1.TeamName
-}
-
 // Only call this on a Team that has been loaded with NeedAdmin.
 // Otherwise, you might get incoherent answers due to links that
 // were stubbed over the life of the cached object.
@@ -389,7 +384,7 @@ type TeamIDAndName struct {
 // The list will not contain duplicate names.
 // Since this should only be called when you are an admin,
 // none of that should really come up, but it's here just to be less fragile.
-func (t *TeamSigChainState) ListSubteams() (res []TeamIDAndName) {
+func (t *TeamSigChainState) ListSubteams() (res []keybase1.TeamIDAndName) {
 	type Entry struct {
 		ID   keybase1.TeamID
 		Name keybase1.TeamName
@@ -420,8 +415,8 @@ func (t *TeamSigChainState) ListSubteams() (res []TeamIDAndName) {
 		}
 	}
 	for _, entry := range resMap {
-		res = append(res, TeamIDAndName{
-			ID:   entry.ID,
+		res = append(res, keybase1.TeamIDAndName{
+			Id:   entry.ID,
 			Name: entry.Name,
 		})
 	}

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -403,6 +403,10 @@ func (t *TeamSigChainState) ListSubteams() (res []keybase1.TeamIDAndName) {
 			continue
 		}
 		lastPoint := points[len(points)-1]
+		if lastPoint.Name.IsNil() {
+			// the subteam has been deleted
+			continue
+		}
 		entry := Entry{
 			ID:    subteamID,
 			Name:  lastPoint.Name,

--- a/go/teams/delete_test.go
+++ b/go/teams/delete_test.go
@@ -171,3 +171,7 @@ type teamsUI struct{}
 func (t *teamsUI) ConfirmRootTeamDelete(context.Context, keybase1.ConfirmRootTeamDeleteArg) (bool, error) {
 	return true, nil
 }
+
+func (t *teamsUI) ConfirmSubteamDelete(context.Context, keybase1.ConfirmSubteamDeleteArg) (bool, error) {
+	return true, nil
+}

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -226,7 +226,7 @@ func ListSubteamsRecursive(ctx context.Context, g *libkb.GlobalContext, parentTe
 		return nil, err
 	}
 
-	teams, err := parent.loadAllTransitiveSubteams(ctx)
+	teams, err := parent.loadAllTransitiveSubteams(ctx, forceRepoll)
 	if err != nil {
 		return nil, err
 	}

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -216,6 +216,30 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 	return res, err
 }
 
+func ListSubteamsRecursive(ctx context.Context, g *libkb.GlobalContext, parentTeamName string, forceRepoll bool) (res []keybase1.TeamIDAndName, err error) {
+	parent, err := Load(ctx, g, keybase1.LoadTeamArg{
+		Name:        parentTeamName,
+		NeedAdmin:   true,
+		ForceRepoll: forceRepoll,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	teams, err := parent.loadAllTransitiveSubteams(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, team := range teams {
+		res = append(res, keybase1.TeamIDAndName{
+			Id:   team.ID,
+			Name: team.Name(),
+		})
+	}
+	return res, nil
+}
+
 func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, invites map[keybase1.TeamInviteID]keybase1.TeamInvite, teamName string) (map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite, error) {
 
 	annotatedInvites := make(map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite, len(invites))

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -526,7 +526,7 @@ func TestHiddenSubteam(t *testing.T) {
 	require.NoError(t, err, "load team")
 	t.Logf(spew.Sdump(team.chain().inner.SubteamLog))
 	require.Len(t, team.chain().ListSubteams(), 1, "subteam list")
-	require.Equal(t, *subteamID, team.chain().ListSubteams()[0].ID, "subteam ID")
+	require.Equal(t, *subteamID, team.chain().ListSubteams()[0].Id, "subteam ID")
 	require.Equal(t, subteamName1.String(), team.chain().ListSubteams()[0].Name.String(), "subteam name")
 
 	t.Logf("U1 loads A")

--- a/go/teams/rename_test.go
+++ b/go/teams/rename_test.go
@@ -50,7 +50,7 @@ func TestRenameSimple(t *testing.T) {
 	subteamList := parent.chain().ListSubteams()
 	require.Len(t, subteamList, 1, "has 1 subteam")
 	require.Equal(t, subteamList[0].Name.String(), parentTeamName.String()+".bb2")
-	require.Equal(t, subteamList[0].ID.String(), subteamID.String())
+	require.Equal(t, subteamList[0].Id.String(), subteamID.String())
 	require.Len(t, parent.chain().inner.SubteamLog, 1, "subteam log has 1 series")
 	require.Len(t, parent.chain().inner.SubteamLog[*subteamID], 2, "subteam log has 2 entries")
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -359,7 +359,7 @@ func Delete(ctx context.Context, g *libkb.GlobalContext, ui keybase1.TeamsUiInte
 	}
 
 	if t.chain().IsSubteam() {
-		return t.deleteSubteam(ctx)
+		return t.deleteSubteam(ctx, ui)
 	}
 	return t.deleteRoot(ctx, ui)
 }

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -542,7 +542,7 @@ func (t *Team) deleteRoot(ctx context.Context, ui keybase1.TeamsUiInterface) err
 	return t.postMulti(payload)
 }
 
-func (t *Team) deleteSubteam(ctx context.Context) error {
+func (t *Team) deleteSubteam(ctx context.Context, ui keybase1.TeamsUiInterface) error {
 
 	// subteam delete consists of two links:
 	// 1. delete_subteam in parent chain
@@ -560,6 +560,14 @@ func (t *Team) deleteSubteam(ctx context.Context) error {
 	admin, err := parentTeam.getAdminPermission(ctx, true)
 	if err != nil {
 		return err
+	}
+
+	confirmed, err := ui.ConfirmSubteamDelete(ctx, keybase1.ConfirmSubteamDeleteArg{TeamName: t.Name().String()})
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		return errors.New("team delete not confirmed")
 	}
 
 	subteamName := SCTeamName(t.Data.Name.String())

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1159,7 +1159,7 @@ func (t *Team) loadAllTransitiveSubteams(ctx context.Context) ([]*Team, error) {
 	for _, idAndName := range t.chain().ListSubteams() {
 		// Load each subteam...
 		subteam, err := Load(ctx, t.G(), keybase1.LoadTeamArg{
-			ID:          idAndName.ID,
+			ID:          idAndName.Id,
 			NeedAdmin:   true,
 			ForceRepoll: true,
 		})

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -982,7 +982,7 @@ func (t *Team) recipientBoxes(ctx context.Context, memSet *memberSet) (*PerTeamS
 	adminAndOwnerRecipients := memSet.adminAndOwnerRecipients()
 	if len(adminAndOwnerRecipients) > 0 {
 		implicitAdminBoxes = map[keybase1.TeamID]*PerTeamSharedSecretBoxes{}
-		subteams, err := t.loadAllTransitiveSubteams(ctx)
+		subteams, err := t.loadAllTransitiveSubteams(ctx, true /*forceRepoll*/)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1162,7 +1162,7 @@ func LoadTeamPlusApplicationKeys(ctx context.Context, g *libkb.GlobalContext, id
 // Only call this on a Team that has been loaded with NeedAdmin.
 // Otherwise, you might get incoherent answers due to links that
 // were stubbed over the life of the cached object.
-func (t *Team) loadAllTransitiveSubteams(ctx context.Context) ([]*Team, error) {
+func (t *Team) loadAllTransitiveSubteams(ctx context.Context, forceRepoll bool) ([]*Team, error) {
 	subteams := []*Team{}
 	for _, idAndName := range t.chain().ListSubteams() {
 		// Load each subteam...
@@ -1185,7 +1185,7 @@ func (t *Team) loadAllTransitiveSubteams(ctx context.Context) ([]*Team, error) {
 		subteams = append(subteams, subteam)
 
 		// ...and then recursively load each subteam's children.
-		recursiveSubteams, err := subteam.loadAllTransitiveSubteams(ctx)
+		recursiveSubteams, err := subteam.loadAllTransitiveSubteams(ctx, forceRepoll)
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -82,6 +82,11 @@ protocol Common {
     TLFVisibility visibility;
   }
 
+  record TeamIDAndName {
+    TeamID id;
+    TeamName name;
+  }
+
   @typedef("int64") @lint("ignore")
   record Seqno {}
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -418,6 +418,8 @@ protocol teams {
   TeamCreateResult teamCreate(int sessionID, string name, boolean sendChatNotification);
   TeamDetails teamGet(int sessionID, string name, boolean forceRepoll);
   AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean all, boolean includeImplicitTeams);
+  // admin only
+  array<TeamIDAndName> teamListSubteamsRecursive(int sessionID, string parentTeamName, boolean forceRepoll);
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);
   TeamAddMemberResult teamAddMember(int sessionID, string name, string email, string username, TeamRole role, boolean sendChatNotification);
   void teamRemoveMember(int sessionID, string name, string username);

--- a/protocol/avdl/keybase1/teams_ui.avdl
+++ b/protocol/avdl/keybase1/teams_ui.avdl
@@ -1,4 +1,5 @@
 @namespace("keybase.1")
 protocol teamsUi {
   boolean confirmRootTeamDelete(int sessionID, string teamName);
+  boolean confirmSubteamDelete(int sessionID, string teamName);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2471,6 +2471,14 @@ export function teamsTeamListRpcPromise (request: (requestCommon & {callback?: ?
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamList', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamListSubteamsRecursiveRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamListSubteamsRecursiveResult) => void} & {param: teamsTeamListSubteamsRecursiveRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListSubteamsRecursive', request)
+}
+
+export function teamsTeamListSubteamsRecursiveRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamListSubteamsRecursiveResult) => void} & {param: teamsTeamListSubteamsRecursiveRpcParam})): Promise<teamsTeamListSubteamsRecursiveResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamListSubteamsRecursive', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamReAddMemberAfterResetRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamReAddMemberAfterResetRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamReAddMemberAfterReset', request)
 }
@@ -4788,6 +4796,11 @@ export type TeamExitRow = {
 
 export type TeamID = string
 
+export type TeamIDAndName = {
+  id: TeamID,
+  name: TeamName,
+}
+
 export type TeamIDWithVisibility = {
   teamID: TeamID,
   visibility: TLFVisibility,
@@ -6183,6 +6196,11 @@ export type teamsTeamListRpcParam = Exact<{
   includeImplicitTeams: boolean
 }>
 
+export type teamsTeamListSubteamsRecursiveRpcParam = Exact<{
+  parentTeamName: string,
+  forceRepoll: boolean
+}>
+
 export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
   id: TeamID,
   username: string
@@ -6469,6 +6487,7 @@ type teamsTeamCreateResult = TeamCreateResult
 type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList
+type teamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
 type teamsTeamTreeResult = TeamTreeResult
 type teamsUiConfirmRootTeamDeleteResult = boolean
 type testTestCallbackResult = string

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6228,6 +6228,10 @@ export type teamsUiConfirmRootTeamDeleteRpcParam = Exact<{
   teamName: string
 }>
 
+export type teamsUiConfirmSubteamDeleteRpcParam = Exact<{
+  teamName: string
+}>
+
 export type testPanicRpcParam = Exact<{
   message: string
 }>
@@ -6490,6 +6494,7 @@ type teamsTeamListResult = AnnotatedTeamList
 type teamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
 type teamsTeamTreeResult = TeamTreeResult
 type teamsUiConfirmRootTeamDeleteResult = boolean
+type teamsUiConfirmSubteamDeleteResult = boolean
 type testTestCallbackResult = string
 type testTestResult = Test
 type tlfCompleteAndCanonicalizePrivateTlfNameResult = CanonicalTLFNameAndIDWithBreaks
@@ -7175,6 +7180,16 @@ export type incomingCallMapType = Exact<{
     response: {
       error: RPCErrorHandler,
       result: (result: teamsUiConfirmRootTeamDeleteResult) => void,
+    }
+  ) => void,
+  'keybase.1.teamsUi.confirmSubteamDelete'?: (
+    params: Exact<{
+      sessionID: int,
+      teamName: string
+    }>,
+    response: {
+      error: RPCErrorHandler,
+      result: (result: teamsUiConfirmSubteamDeleteResult) => void,
     }
   ) => void,
   'keybase.1.ui.promptYesNo'?: (

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -177,6 +177,20 @@
     },
     {
       "type": "record",
+      "name": "TeamIDAndName",
+      "fields": [
+        {
+          "type": "TeamID",
+          "name": "id"
+        },
+        {
+          "type": "TeamName",
+          "name": "name"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "Seqno",
       "fields": [],
       "typedef": "int64",

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1178,6 +1178,26 @@
       ],
       "response": "AnnotatedTeamList"
     },
+    "teamListSubteamsRecursive": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "parentTeamName",
+          "type": "string"
+        },
+        {
+          "name": "forceRepoll",
+          "type": "boolean"
+        }
+      ],
+      "response": {
+        "type": "array",
+        "items": "TeamIDAndName"
+      }
+    },
     "teamChangeMembership": {
       "request": [
         {

--- a/protocol/json/keybase1/teams_ui.json
+++ b/protocol/json/keybase1/teams_ui.json
@@ -15,6 +15,19 @@
         }
       ],
       "response": "boolean"
+    },
+    "confirmSubteamDelete": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "teamName",
+          "type": "string"
+        }
+      ],
+      "response": "boolean"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2471,6 +2471,14 @@ export function teamsTeamListRpcPromise (request: (requestCommon & {callback?: ?
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamList', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamListSubteamsRecursiveRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamListSubteamsRecursiveResult) => void} & {param: teamsTeamListSubteamsRecursiveRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListSubteamsRecursive', request)
+}
+
+export function teamsTeamListSubteamsRecursiveRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamListSubteamsRecursiveResult) => void} & {param: teamsTeamListSubteamsRecursiveRpcParam})): Promise<teamsTeamListSubteamsRecursiveResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamListSubteamsRecursive', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamReAddMemberAfterResetRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamReAddMemberAfterResetRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamReAddMemberAfterReset', request)
 }
@@ -4788,6 +4796,11 @@ export type TeamExitRow = {
 
 export type TeamID = string
 
+export type TeamIDAndName = {
+  id: TeamID,
+  name: TeamName,
+}
+
 export type TeamIDWithVisibility = {
   teamID: TeamID,
   visibility: TLFVisibility,
@@ -6183,6 +6196,11 @@ export type teamsTeamListRpcParam = Exact<{
   includeImplicitTeams: boolean
 }>
 
+export type teamsTeamListSubteamsRecursiveRpcParam = Exact<{
+  parentTeamName: string,
+  forceRepoll: boolean
+}>
+
 export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
   id: TeamID,
   username: string
@@ -6469,6 +6487,7 @@ type teamsTeamCreateResult = TeamCreateResult
 type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList
+type teamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
 type teamsTeamTreeResult = TeamTreeResult
 type teamsUiConfirmRootTeamDeleteResult = boolean
 type testTestCallbackResult = string

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6228,6 +6228,10 @@ export type teamsUiConfirmRootTeamDeleteRpcParam = Exact<{
   teamName: string
 }>
 
+export type teamsUiConfirmSubteamDeleteRpcParam = Exact<{
+  teamName: string
+}>
+
 export type testPanicRpcParam = Exact<{
   message: string
 }>
@@ -6490,6 +6494,7 @@ type teamsTeamListResult = AnnotatedTeamList
 type teamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
 type teamsTeamTreeResult = TeamTreeResult
 type teamsUiConfirmRootTeamDeleteResult = boolean
+type teamsUiConfirmSubteamDeleteResult = boolean
 type testTestCallbackResult = string
 type testTestResult = Test
 type tlfCompleteAndCanonicalizePrivateTlfNameResult = CanonicalTLFNameAndIDWithBreaks
@@ -7175,6 +7180,16 @@ export type incomingCallMapType = Exact<{
     response: {
       error: RPCErrorHandler,
       result: (result: teamsUiConfirmRootTeamDeleteResult) => void,
+    }
+  ) => void,
+  'keybase.1.teamsUi.confirmSubteamDelete'?: (
+    params: Exact<{
+      sessionID: int,
+      teamName: string
+    }>,
+    response: {
+      error: RPCErrorHandler,
+      result: (result: teamsUiConfirmSubteamDeleteResult) => void,
     }
   ) => void,
   'keybase.1.ui.promptYesNo'?: (


### PR DESCRIPTION
```
$ kbu team delete cn5team2

Cannot delete team cn5team2 because it has active subteams.
Delete all of its subteams first:
- cn5team2.sub
- cn5team2.sub.bub

▶ ERROR team has active subteams
$ kbu team delete cn5team2.sub

Cannot delete team cn5team2.sub because it has active subteams.
Delete all of its subteams first:
- cn5team2.sub.bub

▶ ERROR team has active subteams
$ kbu team delete cn5team2.sub.bub
WARNING: This will destroy all data in cn5team2.sub.bub's chats, KBFS folders, and git repositories.

** if you are sure, please type: "nuke cn5team2.sub.bub" > nuke cn5team2.sub.bub
Success! Team cn5team2.sub.bub deleted.
$ kbu team delete cn5team2.sub
WARNING: This will destroy all data in cn5team2.sub's chats, KBFS folders, and git repositories.

** if you are sure, please type: "nuke cn5team2.sub" > nuke cn5team2.sub
Success! Team cn5team2.sub deleted.
$ kbu team delete cn5team2
WARNING: This will:

(1) destroy all data in cn5team2's chats, KBFS folders, and git repositories.
(2) prevent "cn5team2" from being used again as a team name.

** if you are sure, please type: "nuke cn5team2" > nuke cn5team2
Success! Team cn5team2 deleted.
$
```