### PR TITLE
expand uidmapper to fullnames

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -92,7 +92,9 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 	kbCtx = libkb.G
 	kbCtx.Init()
 	kbCtx.SetServices(externals.GetServices())
-	kbCtx.SetUIDMapper(uidmap.NewUIDMap())
+
+	// 10k uid -> FullName cache entries allowed
+	kbCtx.SetUIDMapper(uidmap.NewUIDMap(10000))
 	usage := libkb.Usage{
 		Config:    true,
 		API:       true,

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -1112,7 +1112,13 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		for _, uid := range conversationRemote.Metadata.AllList {
 			kuids = append(kuids, keybase1.UID(uid.String()))
 		}
-		unames, err := s.G().UIDMapper.MapUIDsToUsernames(ctx, s.G(), kuids)
+
+		rows, err := s.G().UIDMapper.MapUIDsToUsernamePackages(ctx, s.G(), kuids, 0, 0, false)
+		unames := make([]libkb.NormalizedUsername, len(rows), len(rows))
+		for i, row := range rows {
+			unames[i] = row.NormalizedUsername
+		}
+
 		if err == nil {
 			for _, uname := range unames {
 				conversationLocal.Info.WriterNames = append(conversationLocal.Info.WriterNames,

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -275,6 +275,14 @@ func (p CommandLine) GetUPAKCacheSize() (int, bool) {
 	return 0, false
 }
 
+func (p CommandLine) GetUIDMapFullNameCacheSize() (int, bool) {
+	ret := p.GetGInt("uid-map-full-name-cache-size")
+	if ret != 0 {
+		return ret, true
+	}
+	return 0, false
+}
+
 func (p CommandLine) GetLocalTrackMaxAge() (time.Duration, bool) {
 	ret, err := p.GetGDuration("local-track-maxage")
 	if err != nil {

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -613,6 +613,10 @@ func (f JSONConfigFile) GetUPAKCacheSize() (int, bool) {
 	return f.getCacheSize("cache.limits.upak")
 }
 
+func (f JSONConfigFile) GetUIDMapFullNameCacheSize() (int, bool) {
+	return f.getCacheSize("cache.limits.uid_map_full_name")
+}
+
 func (f JSONConfigFile) GetLevelDBNumFiles() (int, bool) {
 	return f.GetIntAtPath("leveldb.num_files")
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -109,7 +109,8 @@ const (
 	LinkCacheSize     = 0x10000
 	LinkCacheCleanDur = 1 * time.Minute
 
-	UPAKCacheSize = 2000
+	UPAKCacheSize           = 2000
+	UIDMapFullNameCacheSize = 100000
 
 	SigShortIDBytes  = 27
 	LocalTrackMaxAge = 48 * time.Hour

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -170,6 +170,7 @@ const (
 	// NOTE: This file needs to stay consistent with config/id.iced on the
 	// website, and that one has IDs on the lower end of the range that aren't
 	// represented here.
+	DBUidToFullName           = 0xdd
 	DBUidToUsername           = 0xde
 	DBUserPlusKeysVersioned   = 0xdf
 	DBLink                    = 0xe0

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -40,6 +40,7 @@ func (n NullConfiguration) GetProofCacheShortDur() (time.Duration, bool)        
 func (n NullConfiguration) GetLinkCacheSize() (int, bool)                                  { return 0, false }
 func (n NullConfiguration) GetLinkCacheCleanDur() (time.Duration, bool)                    { return 0, false }
 func (n NullConfiguration) GetUPAKCacheSize() (int, bool)                                  { return 0, false }
+func (n NullConfiguration) GetUIDMapFullNameCacheSize() (int, bool)                        { return 0, false }
 func (n NullConfiguration) GetMerkleKIDs() []string                                        { return nil }
 func (n NullConfiguration) GetCodeSigningKIDs() []string                                   { return nil }
 func (n NullConfiguration) GetPinentry() string                                            { return "" }
@@ -790,6 +791,14 @@ func (e *Env) GetUPAKCacheSize() int {
 		e.cmd.GetUPAKCacheSize,
 		func() (int, bool) { return e.getEnvInt("KEYBASE_UPAK_CACHE_SIZE") },
 		e.config.GetUPAKCacheSize,
+	)
+}
+
+func (e *Env) GetUIDMapFullNameCacheSize() int {
+	return e.GetInt(UIDMapFullNameCacheSize,
+		e.cmd.GetUIDMapFullNameCacheSize,
+		func() (int, bool) { return e.getEnvInt("KEYBASE_UID_MAP_FULL_NAME_CACHE_SIZE") },
+		e.config.GetUIDMapFullNameCacheSize,
 	)
 }
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -148,6 +148,7 @@ func (g *GlobalContext) GetNetContext() context.Context                { return 
 func (g *GlobalContext) GetEnv() *Env                                  { return g.Env }
 func (g *GlobalContext) GetDNSNameServerFetcher() DNSNameServerFetcher { return g.DNSNSFetcher }
 func (g *GlobalContext) GetKVStore() KVStorer                          { return g.LocalDb }
+func (g *GlobalContext) GetClock() clockwork.Clock                     { return g.Clock() }
 
 type LogGetter func() logger.Logger
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -25,6 +25,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	clockwork "github.com/keybase/clockwork"
 	jsonw "github.com/keybase/go-jsonw"
 )
 
@@ -72,6 +73,7 @@ type configGetter interface {
 	GetTorMode() (TorMode, error)
 	GetTorProxy() string
 	GetUPAKCacheSize() (int, bool)
+	GetUIDMapFullNameCacheSize() (int, bool)
 	GetUpdaterConfigFilename() string
 	GetUserCacheMaxAge() (time.Duration, bool)
 	GetVDebugSetting() string
@@ -602,10 +604,20 @@ type KVStoreContext interface {
 	GetKVStore() KVStorer
 }
 
+type ClockContext interface {
+	GetClock() clockwork.Clock
+}
+
 type UIDMapperContext interface {
 	LogContext
 	APIContext
 	KVStoreContext
+	ClockContext
+}
+
+type UsernamePackage struct {
+	NormalizedUsername NormalizedUsername
+	FullName           *keybase1.FullNamePackage
 }
 
 type UIDMapper interface {
@@ -614,8 +626,14 @@ type UIDMapper interface {
 	// hardcoded map.
 	CheckUIDAgainstUsername(uid keybase1.UID, un NormalizedUsername) bool
 
-	// MapUIDToUsernames maps the given set of UIDs to the normalized usernames. It can check
-	// caches or go to the server, but guarantees that any names returned pass the check
-	// as in CheckUIDAgainstUsername
-	MapUIDsToUsernames(ctx context.Context, g UIDMapperContext, uids []keybase1.UID) ([]NormalizedUsername, error)
+	// MapUIDToUsernamePackages maps the given set of UIDs to the username packages, which include
+	// a username and a fullname, and when the mapping was loaded from the server. It blocks
+	// on the network until all usernames are known. If the `forceNetworkForFullNames` flag is specified,
+	// it will block on the network too. If the flag is not specified, then stale values (or unknown values)
+	// are OK, we won't go to network if we lack them. All network calls are limited by the given timeBudget,
+	// or if 0 is specified, there is indefinite budget. In the response, a nil FullNamePackage means that the
+	// lookup failed. A non-nil FullNamePackage means that some previous lookup worked, but
+	// might be arbitrarily out of date (depending on the cachedAt time). A non-nil FullNamePackage
+	// with an empty fullName field means that the user just hasn't supplied a fullName.
+	MapUIDsToUsernamePackages(ctx context.Context, g UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networktimeBudget time.Duration, forceNetworkForFullNames bool) ([]UsernamePackage, error)
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -635,5 +635,8 @@ type UIDMapper interface {
 	// lookup failed. A non-nil FullNamePackage means that some previous lookup worked, but
 	// might be arbitrarily out of date (depending on the cachedAt time). A non-nil FullNamePackage
 	// with an empty fullName field means that the user just hasn't supplied a fullName.
+	//
+	// *NOTE* that this function can return useful data and an error. In this regard, the error is more
+	// like a warning. But if, for instance, the mapper runs out of time budget, it will return the data
 	MapUIDsToUsernamePackages(ctx context.Context, g UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networktimeBudget time.Duration, forceNetworkForFullNames bool) ([]UsernamePackage, error)
 }

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -470,13 +471,14 @@ func (t TestUIDMapper) CheckUIDAgainstUsername(uid keybase1.UID, un NormalizedUs
 	return true
 }
 
-func (t TestUIDMapper) MapUIDsToUsernames(ctx context.Context, g UIDMapperContext, uids []keybase1.UID) (res []NormalizedUsername, err error) {
+func (t TestUIDMapper) MapUIDsToUsernamePackages(ctx context.Context, g UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networkTimeBudget time.Duration, forceNetworkForFullNames bool) ([]UsernamePackage, error) {
+	var res []UsernamePackage
 	for _, uid := range uids {
 		name, err := t.ul.LookupUsername(ctx, uid)
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, name)
+		res = append(res, UsernamePackage{NormalizedUsername: name})
 	}
 	return res, nil
 }

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -814,6 +814,49 @@ func (o UserResolution) DeepCopy() UserResolution {
 	}
 }
 
+type FullName string
+
+func (o FullName) DeepCopy() FullName {
+	return o
+}
+
+type FullNamePackageVersion int
+
+const (
+	FullNamePackageVersion_V0 FullNamePackageVersion = 0
+)
+
+func (o FullNamePackageVersion) DeepCopy() FullNamePackageVersion { return o }
+
+var FullNamePackageVersionMap = map[string]FullNamePackageVersion{
+	"V0": 0,
+}
+
+var FullNamePackageVersionRevMap = map[FullNamePackageVersion]string{
+	0: "V0",
+}
+
+func (e FullNamePackageVersion) String() string {
+	if v, ok := FullNamePackageVersionRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type FullNamePackage struct {
+	Version  FullNamePackageVersion `codec:"version" json:"version"`
+	FullName FullName               `codec:"fullName" json:"fullName"`
+	CachedAt Time                   `codec:"cachedAt" json:"cachedAt"`
+}
+
+func (o FullNamePackage) DeepCopy() FullNamePackage {
+	return FullNamePackage{
+		Version:  o.Version.DeepCopy(),
+		FullName: o.FullName.DeepCopy(),
+		CachedAt: o.CachedAt.DeepCopy(),
+	}
+}
+
 type CommonInterface interface {
 }
 

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -126,7 +126,7 @@ func (u *UIDMap) findFullNameLocally(ctx context.Context, g libkb.UIDMapperConte
 	}
 
 	if when, expired := isStale(g, tmp, fullNameFreshness); expired {
-		g.GetLog().CDebugf(ctx, "fullName disk mapping %s -> %s is expired (%s ago)", when)
+		g.GetLog().CDebugf(ctx, "fullName disk mapping %s -> %+v is expired (%s ago)", uid, tmp, when)
 		if when < staleExpired {
 			staleFullName = &tmp
 		}

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -1,27 +1,41 @@
 package uidmap
 
 import (
+	"errors"
 	"fmt"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 	"strings"
 	"sync"
+	"time"
 )
 
 type UIDMap struct {
 	sync.Mutex
-	m map[keybase1.UID]libkb.NormalizedUsername
+	usernameCache     map[keybase1.UID]libkb.NormalizedUsername
+	fullNameCache     *lru.Cache
+	testBatchIterHook func()
 }
 
-func NewUIDMap() *UIDMap {
+func NewUIDMap(fullNameCacheSize int) *UIDMap {
+	cache, err := lru.New(fullNameCacheSize)
+	if err != nil {
+		panic(fmt.Sprintf("failed to make an LRU size=%d: %s", fullNameCacheSize, err))
+	}
 	return &UIDMap{
-		m: make(map[keybase1.UID]libkb.NormalizedUsername),
+		usernameCache: make(map[keybase1.UID]libkb.NormalizedUsername),
+		fullNameCache: cache,
 	}
 }
 
-func dbKey(u keybase1.UID) libkb.DbKey {
+func usernameDBKey(u keybase1.UID) libkb.DbKey {
 	return libkb.DbKey{Typ: libkb.DBUidToUsername, Key: string(u)}
+}
+
+func fullNameDBKey(u keybase1.UID) libkb.DbKey {
+	return libkb.DbKey{Typ: libkb.DBUidToFullName, Key: string(u)}
 }
 
 type mapStatus int
@@ -31,6 +45,7 @@ const (
 	foundInMem     mapStatus = iota
 	foundOnDisk    mapStatus = iota
 	notFound       mapStatus = iota
+	stale          mapStatus = iota
 )
 
 // The number of UIDs per batch to send. It's not `const` so we can twiddle it in our tests.
@@ -39,20 +54,100 @@ var batchSize = 250
 func (u *UIDMap) Clear() {
 	u.Lock()
 	defer u.Unlock()
-	u.m = make(map[keybase1.UID]libkb.NormalizedUsername)
+	u.usernameCache = make(map[keybase1.UID]libkb.NormalizedUsername)
+	u.fullNameCache.Purge()
 }
 
-func (u *UIDMap) findOneLocally(ctx context.Context, g libkb.UIDMapperContext, uid keybase1.UID) (libkb.NormalizedUsername, mapStatus) {
+func (u *UIDMap) findUsernamePackageLocally(ctx context.Context, g libkb.UIDMapperContext, uid keybase1.UID, fullNameFreshness time.Duration, forceNetworkForFullNames bool) (ret *libkb.UsernamePackage, stats mapStatus) {
+	nun, usernameStatus := u.findUsernameLocally(ctx, g, uid)
+	g.GetLog().CDebugf(ctx, "| local username lookup %s -> %s (status=%d)", uid, nun, usernameStatus)
+	if usernameStatus == notFound {
+		return nil, notFound
+	}
+	fullName, fullNameStatus := u.findFullNameLocally(ctx, g, uid, fullNameFreshness)
+	g.GetLog().CDebugf(ctx, "| local fullname lookup %s -> %+v (status=%d)", uid, fullName, fullNameStatus)
+	return &libkb.UsernamePackage{NormalizedUsername: nun, FullName: fullName}, fullNameStatus
+}
+
+const CurrentFullNamePackageVersion = keybase1.FullNamePackageVersion_V0
+
+func isStale(g libkb.UIDMapperContext, m keybase1.FullNamePackage, dur time.Duration) (time.Duration, bool) {
+	if dur == time.Duration(0) {
+		return time.Duration(0), false
+	}
+	now := g.GetClock().Now()
+	cachedAt := m.CachedAt.Time()
+	diff := now.Sub(cachedAt)
+	expired := (diff > dur)
+	return diff, expired
+}
+
+func (u *UIDMap) findFullNameLocally(ctx context.Context, g libkb.UIDMapperContext, uid keybase1.UID, fullNameFreshness time.Duration) (ret *keybase1.FullNamePackage, status mapStatus) {
+
+	var staleFullName *keybase1.FullNamePackage
+	var staleExpired time.Duration
+
+	doNotFoundReturn := func() (*keybase1.FullNamePackage, mapStatus) {
+		if staleFullName != nil {
+			return staleFullName, stale
+		}
+		return nil, notFound
+	}
+
+	voidp, ok := u.fullNameCache.Get(uid)
+	if ok {
+		tmp, ok := voidp.(keybase1.FullNamePackage)
+		if !ok {
+			g.GetLog().CDebugf(ctx, "Found non-FullNamePackage in LRU cache for uid=%s", uid)
+		} else if when, expired := isStale(g, tmp, fullNameFreshness); expired {
+			staleFullName = &tmp
+			staleExpired = when
+			g.GetLog().CDebugf(ctx, "fullName memory mapping %s -> %+v is expired (%s ago)", uid, tmp, when)
+		} else {
+			ret = &tmp
+			return ret, foundInMem
+		}
+	}
+
+	var tmp keybase1.FullNamePackage
+	key := fullNameDBKey(uid)
+	found, err := g.GetKVStore().GetInto(&tmp, key)
+	if err != nil {
+		g.GetLog().CInfof(ctx, "failed to get dbkey %v: %s", key, err)
+		return doNotFoundReturn()
+	}
+	if !found {
+		return doNotFoundReturn()
+	}
+
+	if tmp.Version != CurrentFullNamePackageVersion {
+		g.GetLog().CDebugf(ctx, "Old version (=%d) found for dbkey %s", tmp.Version, key)
+		return doNotFoundReturn()
+	}
+
+	if when, expired := isStale(g, tmp, fullNameFreshness); expired {
+		g.GetLog().CDebugf(ctx, "fullName disk mapping %s -> %s is expired (%s ago)", when)
+		if when < staleExpired {
+			staleFullName = &tmp
+		}
+		return doNotFoundReturn()
+	}
+
+	u.fullNameCache.Add(uid, tmp)
+	return ret, foundOnDisk
+}
+
+func (u *UIDMap) findUsernameLocally(ctx context.Context, g libkb.UIDMapperContext, uid keybase1.UID) (libkb.NormalizedUsername, mapStatus) {
 	un := findHardcoded(uid)
 	if !un.IsNil() {
 		return un, foundHardCoded
 	}
-	un, ok := u.m[uid]
+	un, ok := u.usernameCache[uid]
 	if ok {
 		return un, foundInMem
 	}
 	var s string
-	key := dbKey(uid)
+	key := usernameDBKey(uid)
 	found, err := g.GetKVStore().GetInto(&s, key)
 	if err != nil {
 		g.GetLog().CInfof(ctx, "failed to get dbkey %v: %s", key, err)
@@ -62,13 +157,18 @@ func (u *UIDMap) findOneLocally(ctx context.Context, g libkb.UIDMapperContext, u
 		return libkb.NormalizedUsername(""), notFound
 	}
 	ret := libkb.NewNormalizedUsername(s)
-	u.m[uid] = ret
+	u.usernameCache[uid] = ret
 	return ret, foundOnDisk
 }
 
+type apiRow struct {
+	Username string `json:"username"`
+	FullName string `json:"full_name,omitempty"`
+}
+
 type apiReply struct {
-	Status    libkb.AppStatus         `json:"status"`
-	Usernames map[keybase1.UID]string `json:"usernames"`
+	Status libkb.AppStatus         `json:"status"`
+	Users  map[keybase1.UID]apiRow `json:"users"`
 }
 
 func (a *apiReply) GetAppStatus() *libkb.AppStatus {
@@ -83,96 +183,134 @@ func uidsToString(uids []keybase1.UID) string {
 	return strings.Join(s, ",")
 }
 
-func (u *UIDMap) lookupUIDsFromServerBatch(ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID) ([]libkb.NormalizedUsername, error) {
-	arg := libkb.NewRetryAPIArg("user/uid_to_username")
+func (u *UIDMap) lookupFromServerBatch(ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID, networkTimeBudget time.Duration) ([]libkb.UsernamePackage, error) {
+	arg := libkb.NewRetryAPIArg("user/names")
 	arg.NetContext = ctx
 	arg.SessionType = libkb.APISessionTypeNONE
 	arg.Args = libkb.HTTPArgs{
 		"uids": libkb.S{Val: uidsToString(uids)},
+	}
+	if networkTimeBudget > time.Duration(0) {
+		arg.InitialTimeout = networkTimeBudget
+		arg.RetryCount = 0
 	}
 	var r apiReply
 	err := g.GetAPI().PostDecode(arg, &r)
 	if err != nil {
 		return nil, err
 	}
-	ret := make([]libkb.NormalizedUsername, len(uids), len(uids))
+	ret := make([]libkb.UsernamePackage, len(uids), len(uids))
+	cachedAt := keybase1.ToTime(g.GetClock().Now())
 	for i, uid := range uids {
-		if un, ok := r.Usernames[uid]; ok {
-			nun := libkb.NewNormalizedUsername(un)
+		if row, ok := r.Users[uid]; ok {
+			nun := libkb.NewNormalizedUsername(row.Username)
 			if !u.CheckUIDAgainstUsername(uid, nun) {
 				g.GetLog().CWarningf(ctx, "Server returned bad UID -> username mapping: %s -> %s", uid, nun)
 			} else {
-				ret[i] = nun
+				ret[i] = libkb.UsernamePackage{
+					NormalizedUsername: nun,
+					FullName: &keybase1.FullNamePackage{
+						Version:  CurrentFullNamePackageVersion,
+						FullName: keybase1.FullName(row.FullName),
+						CachedAt: cachedAt,
+					},
+				}
 			}
 		}
 	}
 	return ret, nil
 }
 
-func (u *UIDMap) lookupUIDsFromServer(ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID) ([]libkb.NormalizedUsername, error) {
+func (u *UIDMap) lookupFromServer(ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID, networkTimeBudget time.Duration) ([]libkb.UsernamePackage, error) {
 
-	var ret []libkb.NormalizedUsername
+	start := g.GetClock().Now()
+	end := start.Add(networkTimeBudget)
+
+	var ret []libkb.UsernamePackage
 	for i := 0; i < len(uids); i += batchSize {
 		high := i + batchSize
 		if high > len(uids) {
 			high = len(uids)
 		}
 		inb := uids[i:high]
-		outb, err := u.lookupUIDsFromServerBatch(ctx, g, inb)
+		var budget time.Duration
+
+		// Only useful for testing...
+		if u.testBatchIterHook != nil {
+			u.testBatchIterHook()
+		}
+
+		if networkTimeBudget > time.Duration(0) {
+			now := g.GetClock().Now()
+			if now.After(end) {
+				return ret, errors.New("ran out of time")
+			}
+			budget = end.Sub(now)
+		}
+		outb, err := u.lookupFromServerBatch(ctx, g, inb, budget)
 		if err != nil {
-			return nil, err
+			return ret, err
 		}
 		ret = append(ret, outb...)
 	}
 	return ret, nil
 }
 
-func (u *UIDMap) MapUIDsToUsernames(ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID) (res []libkb.NormalizedUsername, err error) {
-	defer libkb.CTrace(ctx, g.GetLog(), fmt.Sprintf("MapUIDsToUsernames(%s)", uidsToString(uids)), func() error { return err })()
+func (u *UIDMap) MapUIDsToUsernamePackages(ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networkTimeBudget time.Duration, forceNetworkForFullNames bool) (res []libkb.UsernamePackage, err error) {
+	defer libkb.CTrace(ctx, g.GetLog(), fmt.Sprintf("MapUIDsToUserPackages(%s)", uidsToString(uids)), func() error { return err })()
 
 	u.Lock()
 	defer u.Unlock()
 
-	res = make([]libkb.NormalizedUsername, len(uids), len(uids))
+	res = make([]libkb.UsernamePackage, len(uids), len(uids))
 	apiLookupIndex := make(map[int]int)
 
 	var uidsToLookup []keybase1.UID
 
 	for i, uid := range uids {
-		un, status := u.findOneLocally(ctx, g, uid)
-		if status != notFound {
-			res[i] = un
-			g.GetLog().CDebugf(ctx, "| found lookup resolution %s -> %s (status=%d)", uid, un, status)
-			continue
+		up, status := u.findUsernamePackageLocally(ctx, g, uid, fullNameFreshness, forceNetworkForFullNames)
+		if up != nil {
+			res[i] = *up
 		}
-		apiLookupIndex[len(uidsToLookup)] = i
-		uidsToLookup = append(uidsToLookup, uid)
+		if up == nil || (status == notFound && forceNetworkForFullNames) || (status == stale) {
+			apiLookupIndex[len(uidsToLookup)] = i
+			uidsToLookup = append(uidsToLookup, uid)
+		}
 	}
 
 	if len(uidsToLookup) > 0 {
-		var apiUsernames []libkb.NormalizedUsername
+		var apiResults []libkb.UsernamePackage
 
-		apiUsernames, err = u.lookupUIDsFromServer(ctx, g, uidsToLookup)
-		if err != nil {
-			return nil, err
-		}
+		apiResults, err = u.lookupFromServer(ctx, g, uidsToLookup, networkTimeBudget)
+		if err == nil {
 
-		for i, un := range apiUsernames {
-			uid := uidsToLookup[i]
-			g.GetLog().CDebugf(ctx, "| API server resolution %s -> %s", uid, un)
-			if !un.IsNil() {
-				u.m[uid] = un
-				key := dbKey(uid)
-				err := g.GetKVStore().PutObj(key, nil, un.String())
-				if err != nil {
-					g.GetLog().CInfof(ctx, "failed to put %v -> %s: %s", key, un, err)
+			for i, row := range apiResults {
+				uid := uidsToLookup[i]
+				g.GetLog().CDebugf(ctx, "| API server resolution %s -> %v", uid, row)
+
+				if nun := row.NormalizedUsername; !nun.IsNil() {
+					u.usernameCache[uid] = nun
+					key := usernameDBKey(uid)
+					err := g.GetKVStore().PutObj(key, nil, nun.String())
+					if err != nil {
+						g.GetLog().CInfof(ctx, "failed to put %v -> %s: %s", key, nun, err)
+					}
 				}
+
+				if fn := row.FullName; fn != nil {
+					u.fullNameCache.Add(uid, *fn)
+					key := fullNameDBKey(uid)
+					err := g.GetKVStore().PutObj(key, nil, *fn)
+					if err != nil {
+						g.GetLog().CInfof(ctx, "failed to put %v -> %v: %s", key, *fn, err)
+					}
+				}
+				res[apiLookupIndex[i]] = row
 			}
-			res[apiLookupIndex[i]] = un
 		}
 	}
 
-	return res, nil
+	return res, err
 }
 
 func (u *UIDMap) CheckUIDAgainstUsername(uid keybase1.UID, un libkb.NormalizedUsername) bool {

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -268,6 +268,10 @@ func (u *UIDMap) lookupFromServer(ctx context.Context, g libkb.UIDMapperContext,
 // FullNames can be cached bt the UIDMap, but expire after networkTimeBudget duration. If that value
 // is 0, then infinitely stale names are allowed. If non-zero, and some names aren't stale, we'll
 // have to go to the network.
+//
+// *NOTE* that this function can return useful data and an error. In this regard, the error is more
+// like a warning. But if, for instance, the mapper runs out of time budget, it will return the data
+// it was able to get, and also the error.
 func (u *UIDMap) MapUIDsToUsernamePackages(ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networkTimeBudget time.Duration, forceNetworkForFullNames bool) (res []libkb.UsernamePackage, err error) {
 	defer libkb.CTrace(ctx, g.GetLog(), fmt.Sprintf("MapUIDsToUserPackages(%s)", uidsToString(uids)), func() error { return err })()
 

--- a/go/uidmap/uidmap_test.go
+++ b/go/uidmap/uidmap_test.go
@@ -3,9 +3,11 @@ package uidmap
 import (
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 	"testing"
+	"time"
 )
 
 type testPair struct {
@@ -13,7 +15,10 @@ type testPair struct {
 	username string
 }
 
-func TestLookup(t *testing.T) {
+const mikem = keybase1.UID("95e88f2087e480cae28f08d81554bc00")
+const max = keybase1.UID("dbb165b7879fe7b1174df73bed0b9500")
+
+func TestLookupUsernameOnly(t *testing.T) {
 	tc := libkb.SetupTest(t, "TestLookup", 1)
 	defer tc.Cleanup()
 
@@ -24,9 +29,9 @@ func TestLookup(t *testing.T) {
 		{"00000000000000000000000000000219", ""},
 		{"9cbca30c38afba6ab02d76b206515919", "t_helen"},
 		{"00000000000000000000000000000319", ""},
-		{"dbb165b7879fe7b1174df73bed0b9500", "max"},
+		{string(max), "max"},
 		{"00000000000000000000000000000419", ""},
-		{"95e88f2087e480cae28f08d81554bc00", "mikem"},
+		{string(mikem), "mikem"},
 		{"00000000000000000000000000000519", ""},
 		{"9f9611a4b7920637b1c2a839b2a0e119", "t_george"},
 		{"00000000000000000000000000000619", ""},
@@ -47,16 +52,124 @@ func TestLookup(t *testing.T) {
 		uids = append(uids, uid)
 	}
 
-	uidMap := NewUIDMap()
+	uidMap := NewUIDMap(10)
 
 	for i := 0; i < 4; i++ {
-		usernames, err := uidMap.MapUIDsToUsernames(context.TODO(), tc.G, uids)
+		results, err := uidMap.MapUIDsToUsernamePackages(context.TODO(), tc.G, uids, 0, 0, false)
 		require.NoError(t, err)
 		for j, test := range tests {
-			require.True(t, usernames[j].Eq(libkb.NewNormalizedUsername(test.username)))
+			require.True(t, results[j].NormalizedUsername.Eq(libkb.NewNormalizedUsername(test.username)))
 		}
 		if i == 2 {
 			uidMap.Clear()
 		}
 	}
+}
+
+const tKB = keybase1.UID("7b7248a1c09d17451f9002d9edc8df19")
+
+func TestRanOutOfTime(t *testing.T) {
+	tc := libkb.SetupTest(t, "TestLookup", 1)
+	defer tc.Cleanup()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	uidMap := NewUIDMap(10)
+	uids := []keybase1.UID{tKB}
+	errmsg := "ran out of time"
+
+	// This hook runs at the beginning of every iteration though the batch-fetch loop.
+	// It allows us to bump our fake clock forward.
+	hit := false
+	var cachedAt time.Time
+	setCachedAt := false
+	uidMap.testBatchIterHook = func() {
+		hit = true
+		fakeClock.Advance(time.Minute)
+		if setCachedAt {
+			cachedAt = fakeClock.Now()
+		}
+	}
+
+	// user t_kb has a fullname, but we're not giving ourselves enough time to grab it
+	results, err := uidMap.MapUIDsToUsernamePackages(context.TODO(), tc.G, uids, 0, time.Nanosecond, true)
+	require.Error(t, err)
+	require.True(t, hit)
+	require.Equal(t, err.Error(), errmsg)
+	require.True(t, results[0].NormalizedUsername.IsNil())
+	require.Nil(t, results[0].FullName)
+
+	// user mikem has a fullname, but we're again not giving ourselves enough time to grab it;
+	// however, he has a hard-coded UID mapping so we should be able to still grab his username
+	uids = []keybase1.UID{mikem}
+	hit = false
+	results, err = uidMap.MapUIDsToUsernamePackages(context.TODO(), tc.G, uids, 0, time.Nanosecond, true)
+	require.Error(t, err)
+	require.True(t, hit)
+	require.Equal(t, err.Error(), errmsg)
+	require.True(t, results[0].NormalizedUsername.Eq(libkb.NewNormalizedUsername("mikem")))
+	require.Nil(t, results[0].FullName)
+
+	// now success for user t_kb, who has a non-hardcoded username and a fullname on the
+	// server
+	uids = []keybase1.UID{tKB}
+	hit = false
+	results, err = uidMap.MapUIDsToUsernamePackages(context.TODO(), tc.G, uids, 0, 0, true)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, results[0].NormalizedUsername, libkb.NewNormalizedUsername("t_kb"))
+	require.Equal(t, results[0].FullName.FullName, keybase1.FullName("Joe Keybaser"))
+	cachedAt = fakeClock.Now()
+
+	// Now we're going to simulate that the fullname resolution became expired, and there
+	// was an attempt to fetch it from the server, but that we ran out of network fetch time
+	// budget. So we should see the stale result and also the error.
+	fakeClock.Advance(time.Hour)
+	hit = false
+	results, err = uidMap.MapUIDsToUsernamePackages(context.TODO(), tc.G, uids, time.Second, time.Nanosecond, false)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), errmsg)
+	require.True(t, hit)
+	require.Equal(t, results[0].NormalizedUsername, libkb.NewNormalizedUsername("t_kb"))
+	require.Equal(t, results[0].FullName.FullName, keybase1.FullName("Joe Keybaser"))
+	require.Equal(t, results[0].FullName.CachedAt, keybase1.ToTime(cachedAt))
+
+	// Same as above, but give enough time to refresh the name from the server
+	hit = false
+	setCachedAt = true
+	results, err = uidMap.MapUIDsToUsernamePackages(context.TODO(), tc.G, uids, time.Second, 0, false)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, results[0].NormalizedUsername, libkb.NewNormalizedUsername("t_kb"))
+	require.Equal(t, results[0].FullName.FullName, keybase1.FullName("Joe Keybaser"))
+	require.Equal(t, results[0].FullName.CachedAt, keybase1.ToTime(cachedAt))
+
+	// In this case, there's not enough time to make any fetches, but it doesn't matter, since our
+	// previous fetch is fresh enough. We should never even hit testBatchIterHook
+	fakeClock.Advance(time.Minute)
+	hit = false
+	setCachedAt = false
+	results, err = uidMap.MapUIDsToUsernamePackages(context.TODO(), tc.G, uids, time.Hour, time.Nanosecond, false)
+	require.NoError(t, err)
+	require.False(t, hit)
+	require.Equal(t, results[0].NormalizedUsername, libkb.NewNormalizedUsername("t_kb"))
+	require.Equal(t, results[0].FullName.FullName, keybase1.FullName("Joe Keybaser"))
+	require.Equal(t, results[0].FullName.CachedAt, keybase1.ToTime(cachedAt))
+
+	// Do a happy path for several users:
+	uids = []keybase1.UID{mikem, tKB, max}
+	results, err = uidMap.MapUIDsToUsernamePackages(context.TODO(), tc.G, uids, 0, 0, false)
+	require.NoError(t, err)
+
+	// Everyone gets back a normalized username
+	require.Equal(t, results[0].NormalizedUsername, libkb.NewNormalizedUsername("mikem"))
+	require.Equal(t, results[1].NormalizedUsername, libkb.NewNormalizedUsername("t_kb"))
+	require.Equal(t, results[2].NormalizedUsername, libkb.NewNormalizedUsername("max"))
+
+	// But only t_kb has a fullname that's found
+	require.Nil(t, results[0].FullName)
+	require.Equal(t, results[1].FullName.FullName, keybase1.FullName("Joe Keybaser"))
+	require.Equal(t, results[1].FullName.CachedAt, keybase1.ToTime(cachedAt))
+	require.Nil(t, results[2].FullName)
 }

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -288,4 +288,17 @@ protocol Common {
       UID userID;
   }
 
+  @typedef("string")
+  record FullName {}
+
+  enum FullNamePackageVersion {
+    V0_0
+  }
+
+  record FullNamePackage {
+    FullNamePackageVersion version;
+    FullName fullName;
+    Time cachedAt;
+  }
+
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -81,6 +81,10 @@ export const CommonDeviceType = {
   mobile: 1,
 }
 
+export const CommonFullNamePackageVersion = {
+  v0: 0,
+}
+
 export const CommonLogLevel = {
   none: 0,
   debug: 1,
@@ -3259,6 +3263,17 @@ export type ForkType =
   | 1 // AUTO_1
   | 2 // WATCHDOG_2
   | 3 // LAUNCHD_3
+
+export type FullName = string
+
+export type FullNamePackage = {
+  version: FullNamePackageVersion,
+  fullName: FullName,
+  cachedAt: Time,
+}
+
+export type FullNamePackageVersion =
+    0 // V0_0
 
 export type FuseMountInfo = {
   path: string,

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -646,6 +646,37 @@
         }
       ],
       "doc": "UserResolution maps how an unresolved user assertion has been resolved."
+    },
+    {
+      "type": "record",
+      "name": "FullName",
+      "fields": [],
+      "typedef": "string"
+    },
+    {
+      "type": "enum",
+      "name": "FullNamePackageVersion",
+      "symbols": [
+        "V0_0"
+      ]
+    },
+    {
+      "type": "record",
+      "name": "FullNamePackage",
+      "fields": [
+        {
+          "type": "FullNamePackageVersion",
+          "name": "version"
+        },
+        {
+          "type": "FullName",
+          "name": "fullName"
+        },
+        {
+          "type": "Time",
+          "name": "cachedAt"
+        }
+      ]
     }
   ],
   "messages": {},

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -81,6 +81,10 @@ export const CommonDeviceType = {
   mobile: 1,
 }
 
+export const CommonFullNamePackageVersion = {
+  v0: 0,
+}
+
 export const CommonLogLevel = {
   none: 0,
   debug: 1,
@@ -3259,6 +3263,17 @@ export type ForkType =
   | 1 // AUTO_1
   | 2 // WATCHDOG_2
   | 3 // LAUNCHD_3
+
+export type FullName = string
+
+export type FullNamePackage = {
+  version: FullNamePackageVersion,
+  fullName: FullName,
+  cachedAt: Time,
+}
+
+export type FullNamePackageVersion =
+    0 // V0_0
 
 export type FuseMountInfo = {
   path: string,


### PR DESCRIPTION
- uidmapper now returns a map of normalized usernames and fullnames
- the cache discipline is up to the caller, who can specify staleness, amount of network to consume, and also if to force network trips
- use two separate caches: one for username that grows without bounds and never expires; and also an LRU for fullnames that expires
  according to the caller's wishes.
- some decent testing but could use some more