### PR TITLE
Remove time constraints for keys

### DIFF
--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/keystore/KeyStoreHelper.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/keystore/KeyStoreHelper.java
@@ -44,8 +44,6 @@ public class KeyStoreHelper {
               .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
               .setCertificateSerialNumber(BigInteger.ONE)
               .setCertificateSubject(new X500Principal("CN=" + keyAlias))
-              .setKeyValidityStart(Calendar.getInstance().getTime())
-              .setKeyValidityEnd(endTime.getTime())
               .setKeySize(2048)
               .build();
         } else {


### PR DESCRIPTION
@patrickxb These are optional and my guess is that I put them in just to match the older api semantics. But they are not necessary. I think we should get rid of it since it might fix the key not yet valid error. Still not sure why this would result in a key not yet valid.

Unless the keypair was made when the phone's clock was in the future, and you try to access it when the phone's clock gets updated to be in the past.