### PR TITLE
create more first class sync protocol that should improve speed, logging, and allows for a progress bar CORE-6063

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1601,6 +1601,7 @@ type serverChatListener struct {
 	appNotificationSettings chan chat1.SetAppNotificationSettingsInfo
 	identifyUpdate          chan keybase1.CanonicalTLFNameAndIDWithBreaks
 	teamType                chan chat1.TeamTypeInfo
+	inboxSynced             chan chat1.ChatSyncResult
 }
 
 func (n *serverChatListener) Logout()                                                             {}
@@ -1619,6 +1620,7 @@ func (n *serverChatListener) KeyfamilyChanged(uid keybase1.UID)                 
 func (n *serverChatListener) PGPKeyInSecretStoreFile()                                            {}
 func (n *serverChatListener) BadgeState(badgeState keybase1.BadgeState)                           {}
 func (n *serverChatListener) ReachabilityChanged(r keybase1.Reachability)                         {}
+func (n *serverChatListener) ChatInboxSyncStarted(u keybase1.UID)                                 {}
 func (n *serverChatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {
 	n.identifyUpdate <- update
 }
@@ -1635,6 +1637,11 @@ func (n *serverChatListener) ChatInboxStale(uid keybase1.UID) {
 func (n *serverChatListener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationStaleUpdate) {
 	n.threadsStale <- cids
 }
+
+func (n *serverChatListener) ChatInboxSynced(uid keybase1.UID, syncRes chat1.ChatSyncResult) {
+	n.inboxSynced <- syncRes
+}
+
 func (n *serverChatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity) {
 	typ, _ := activity.ActivityType()
 	switch typ {
@@ -1668,6 +1675,7 @@ func newServerChatListener() *serverChatListener {
 		appNotificationSettings: make(chan chat1.SetAppNotificationSettingsInfo, 100),
 		identifyUpdate:          make(chan keybase1.CanonicalTLFNameAndIDWithBreaks, 100),
 		teamType:                make(chan chat1.TeamTypeInfo, 100),
+		inboxSynced:             make(chan chat1.ChatSyncResult, 100),
 	}
 }
 

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -252,9 +252,7 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		s.Debug(ctx, "Sync: aborting because currently offline")
 		return OfflineError{}
 	}
-	// Let people know we are trying to sync
 	kuid := keybase1.UID(uid.String())
-	s.G().NotifyRouter.HandleChatInboxSyncStarted(ctx, kuid)
 
 	// Grab current on disk version
 	ibox := storage.NewInbox(s.G(), uid)

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -252,6 +252,9 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		s.Debug(ctx, "Sync: aborting because currently offline")
 		return OfflineError{}
 	}
+	// Let people know we are trying to sync
+	kuid := keybase1.UID(uid.String())
+	s.G().NotifyRouter.HandleChatInboxSyncStarted(ctx, kuid)
 
 	// Grab current on disk version
 	ibox := storage.NewInbox(s.G(), uid)
@@ -294,7 +297,6 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		rtyp = chat1.SyncInboxResType_CLEAR
 	}
 
-	kuid := keybase1.UID(uid.String())
 	switch rtyp {
 	case chat1.SyncInboxResType_CLEAR:
 		s.Debug(ctx, "Sync: version out of date, clearing inbox: %v", vers)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -611,6 +611,13 @@ func PresentRemoteConversation(rc types.RemoteConversation) (res chat1.Unverifie
 	return res
 }
 
+func PresentRemoteConversations(rcs []types.RemoteConversation) (res []chat1.UnverifiedInboxUIItem) {
+	for _, rc := range rcs {
+		res = append(res, PresentRemoteConversation(rc))
+	}
+	return res
+}
+
 func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxUIItem) {
 	res.ConvID = rawConv.GetConvID().String()
 	res.Name = rawConv.Info.TlfName

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -117,4 +117,6 @@ func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUII
 func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)      {}
 func (n *nlistener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
-func (n *nlistener) TeamDeleted(teamID keybase1.TeamID) {}
+func (n *nlistener) TeamDeleted(teamID keybase1.TeamID)                             {}
+func (n *nlistener) ChatInboxSynced(uid keybase1.UID, syncRes chat1.ChatSyncResult) {}
+func (n *nlistener) ChatInboxSyncStarted(uid keybase1.UID)                          {}

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -48,7 +48,7 @@ type NotifyListener interface {
 		resolveInfo chat1.ConversationResolveInfo)
 	ChatInboxStale(uid keybase1.UID)
 	ChatThreadsStale(uid keybase1.UID, updates []chat1.ConversationStaleUpdate)
-	ChatInboxSynced(uid keybase1.UID, convs []chat1.UnverifiedInboxUIItem)
+	ChatInboxSynced(uid keybase1.UID, syncRes chat1.ChatSyncResult)
 	ChatInboxSyncStarted(uid keybase1.UID)
 	ChatTypingUpdate([]chat1.ConvTypingUpdate)
 	ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)
@@ -651,7 +651,7 @@ func (n *NotifyRouter) HandleChatThreadsStale(ctx context.Context, uid keybase1.
 }
 
 func (n *NotifyRouter) HandleChatInboxSynced(ctx context.Context, uid keybase1.UID,
-	convs []chat1.UnverifiedInboxUIItem) {
+	syncRes chat1.ChatSyncResult) {
 	if n == nil {
 		return
 	}
@@ -664,8 +664,8 @@ func (n *NotifyRouter) HandleChatInboxSynced(ctx context.Context, uid keybase1.U
 				(chat1.NotifyChatClient{
 					Cli: rpc.NewClient(xp, NewContextifiedErrorUnwrapper(n.G()), nil),
 				}).ChatInboxSynced(context.Background(), chat1.ChatInboxSyncedArg{
-					Uid:   uid,
-					Convs: convs,
+					Uid:     uid,
+					SyncRes: syncRes,
 				})
 				wg.Done()
 			}()
@@ -674,7 +674,7 @@ func (n *NotifyRouter) HandleChatInboxSynced(ctx context.Context, uid keybase1.U
 	})
 	wg.Wait()
 	if n.listener != nil {
-		n.listener.ChatInboxSynced(uid, convs)
+		n.listener.ChatInboxSynced(uid, syncRes)
 	}
 	n.G().Log.CDebugf(ctx, "- Sent ChatInboxSynced notification")
 }

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -169,6 +169,35 @@ func (e ConversationMembersType) String() string {
 	return ""
 }
 
+type SyncInboxResType int
+
+const (
+	SyncInboxResType_CURRENT     SyncInboxResType = 0
+	SyncInboxResType_INCREMENTAL SyncInboxResType = 1
+	SyncInboxResType_CLEAR       SyncInboxResType = 2
+)
+
+func (o SyncInboxResType) DeepCopy() SyncInboxResType { return o }
+
+var SyncInboxResTypeMap = map[string]SyncInboxResType{
+	"CURRENT":     0,
+	"INCREMENTAL": 1,
+	"CLEAR":       2,
+}
+
+var SyncInboxResTypeRevMap = map[SyncInboxResType]string{
+	0: "CURRENT",
+	1: "INCREMENTAL",
+	2: "CLEAR",
+}
+
+func (e SyncInboxResType) String() string {
+	if v, ok := SyncInboxResTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type MessageType int
 
 const (

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3313,6 +3313,7 @@ func (o GetInboxAndUnboxLocalArg) DeepCopy() GetInboxAndUnboxLocalArg {
 type GetInboxNonblockLocalArg struct {
 	SessionID        int                          `codec:"sessionID" json:"sessionID"`
 	MaxUnbox         *int                         `codec:"maxUnbox,omitempty" json:"maxUnbox,omitempty"`
+	SkipUnverified   bool                         `codec:"skipUnverified" json:"skipUnverified"`
 	Query            *GetInboxLocalQuery          `codec:"query,omitempty" json:"query,omitempty"`
 	Pagination       *Pagination                  `codec:"pagination,omitempty" json:"pagination,omitempty"`
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
@@ -3328,6 +3329,7 @@ func (o GetInboxNonblockLocalArg) DeepCopy() GetInboxNonblockLocalArg {
 			tmp := (*x)
 			return &tmp
 		})(o.MaxUnbox),
+		SkipUnverified: o.SkipUnverified,
 		Query: (func(x *GetInboxLocalQuery) *GetInboxLocalQuery {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -537,6 +537,84 @@ func (o ConversationStaleUpdate) DeepCopy() ConversationStaleUpdate {
 	}
 }
 
+type ChatSyncIncrementalInfo struct {
+	Items []UnverifiedInboxUIItem `codec:"items" json:"items"`
+}
+
+func (o ChatSyncIncrementalInfo) DeepCopy() ChatSyncIncrementalInfo {
+	return ChatSyncIncrementalInfo{
+		Items: (func(x []UnverifiedInboxUIItem) []UnverifiedInboxUIItem {
+			if x == nil {
+				return nil
+			}
+			var ret []UnverifiedInboxUIItem
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Items),
+	}
+}
+
+type ChatSyncResult struct {
+	SyncType__    SyncInboxResType         `codec:"syncType" json:"syncType"`
+	Incremental__ *ChatSyncIncrementalInfo `codec:"incremental,omitempty" json:"incremental,omitempty"`
+}
+
+func (o *ChatSyncResult) SyncType() (ret SyncInboxResType, err error) {
+	switch o.SyncType__ {
+	case SyncInboxResType_INCREMENTAL:
+		if o.Incremental__ == nil {
+			err = errors.New("unexpected nil value for Incremental__")
+			return ret, err
+		}
+	}
+	return o.SyncType__, nil
+}
+
+func (o ChatSyncResult) Incremental() (res ChatSyncIncrementalInfo) {
+	if o.SyncType__ != SyncInboxResType_INCREMENTAL {
+		panic("wrong case accessed")
+	}
+	if o.Incremental__ == nil {
+		return
+	}
+	return *o.Incremental__
+}
+
+func NewChatSyncResultWithCurrent() ChatSyncResult {
+	return ChatSyncResult{
+		SyncType__: SyncInboxResType_CURRENT,
+	}
+}
+
+func NewChatSyncResultWithClear() ChatSyncResult {
+	return ChatSyncResult{
+		SyncType__: SyncInboxResType_CLEAR,
+	}
+}
+
+func NewChatSyncResultWithIncremental(v ChatSyncIncrementalInfo) ChatSyncResult {
+	return ChatSyncResult{
+		SyncType__:    SyncInboxResType_INCREMENTAL,
+		Incremental__: &v,
+	}
+}
+
+func (o ChatSyncResult) DeepCopy() ChatSyncResult {
+	return ChatSyncResult{
+		SyncType__: o.SyncType__.DeepCopy(),
+		Incremental__: (func(x *ChatSyncIncrementalInfo) *ChatSyncIncrementalInfo {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Incremental__),
+	}
+}
+
 type NewChatActivityArg struct {
 	Uid      keybase1.UID `codec:"uid" json:"uid"`
 	Activity ChatActivity `codec:"activity" json:"activity"`
@@ -682,24 +760,14 @@ func (o ChatInboxSyncStartedArg) DeepCopy() ChatInboxSyncStartedArg {
 }
 
 type ChatInboxSyncedArg struct {
-	Uid   keybase1.UID            `codec:"uid" json:"uid"`
-	Convs []UnverifiedInboxUIItem `codec:"convs" json:"convs"`
+	Uid     keybase1.UID   `codec:"uid" json:"uid"`
+	SyncRes ChatSyncResult `codec:"syncRes" json:"syncRes"`
 }
 
 func (o ChatInboxSyncedArg) DeepCopy() ChatInboxSyncedArg {
 	return ChatInboxSyncedArg{
-		Uid: o.Uid.DeepCopy(),
-		Convs: (func(x []UnverifiedInboxUIItem) []UnverifiedInboxUIItem {
-			if x == nil {
-				return nil
-			}
-			var ret []UnverifiedInboxUIItem
-			for _, v := range x {
-				vCopy := v.DeepCopy()
-				ret = append(ret, vCopy)
-			}
-			return ret
-		})(o.Convs),
+		Uid:     o.Uid.DeepCopy(),
+		SyncRes: o.SyncRes.DeepCopy(),
 	}
 }
 

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -947,7 +947,7 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 					err = i.ChatInboxSyncStarted(ctx, (*typedArgs)[0].Uid)
 					return
 				},
-				MethodType: rpc.MethodNotify,
+				MethodType: rpc.MethodCall,
 			},
 			"ChatInboxSynced": {
 				MakeArg: func() interface{} {
@@ -1023,7 +1023,7 @@ func (c NotifyChatClient) ChatLeftConversation(ctx context.Context, __arg ChatLe
 
 func (c NotifyChatClient) ChatInboxSyncStarted(ctx context.Context, uid keybase1.UID) (err error) {
 	__arg := ChatInboxSyncStartedArg{Uid: uid}
-	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatInboxSyncStarted", []interface{}{__arg})
+	err = c.Cli.Call(ctx, "chat.1.NotifyChat.ChatInboxSyncStarted", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -947,7 +947,7 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 					err = i.ChatInboxSyncStarted(ctx, (*typedArgs)[0].Uid)
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 			"ChatInboxSynced": {
 				MakeArg: func() interface{} {
@@ -1023,7 +1023,7 @@ func (c NotifyChatClient) ChatLeftConversation(ctx context.Context, __arg ChatLe
 
 func (c NotifyChatClient) ChatInboxSyncStarted(ctx context.Context, uid keybase1.UID) (err error) {
 	__arg := ChatInboxSyncStartedArg{Uid: uid}
-	err = c.Cli.Call(ctx, "chat.1.NotifyChat.ChatInboxSyncStarted", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatInboxSyncStarted", []interface{}{__arg})
 	return
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -383,35 +383,6 @@ func (o S3Params) DeepCopy() S3Params {
 	}
 }
 
-type SyncInboxResType int
-
-const (
-	SyncInboxResType_CURRENT     SyncInboxResType = 0
-	SyncInboxResType_INCREMENTAL SyncInboxResType = 1
-	SyncInboxResType_CLEAR       SyncInboxResType = 2
-)
-
-func (o SyncInboxResType) DeepCopy() SyncInboxResType { return o }
-
-var SyncInboxResTypeMap = map[string]SyncInboxResType{
-	"CURRENT":     0,
-	"INCREMENTAL": 1,
-	"CLEAR":       2,
-}
-
-var SyncInboxResTypeRevMap = map[SyncInboxResType]string{
-	0: "CURRENT",
-	1: "INCREMENTAL",
-	2: "CLEAR",
-}
-
-func (e SyncInboxResType) String() string {
-	if v, ok := SyncInboxResTypeRevMap[e]; ok {
-		return v
-	}
-	return ""
-}
-
 type SyncIncrementalRes struct {
 	Vers  InboxVers      `codec:"vers" json:"vers"`
 	Convs []Conversation `codec:"convs" json:"convs"`

--- a/go/protocol/gregor1/extras.go
+++ b/go/protocol/gregor1/extras.go
@@ -19,6 +19,7 @@ func (u UID) String() string { return hex.EncodeToString(u) }
 func (u UID) Eq(other UID) bool {
 	return bytes.Equal(u.Bytes(), other.Bytes())
 }
+
 func (d DeviceID) Bytes() []byte  { return []byte(d) }
 func (d DeviceID) String() string { return hex.EncodeToString(d) }
 func (d DeviceID) Eq(other DeviceID) bool {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -230,9 +230,6 @@ func (g *gregorHandler) monitorAppState() {
 		case keybase1.AppState_FOREGROUND:
 			// Make sure the URI is set before attempting this (possible it isnt in a race)
 			if g.uri != nil {
-				// Let people know we are trying to sync
-				g.G().NotifyRouter.HandleChatInboxSyncStarted(context.Background(),
-					g.G().Env.GetUID())
 				g.chatLog.Debug(context.Background(), "foregrounded, reconnecting")
 				if err := g.Connect(g.uri); err != nil {
 					g.chatLog.Debug(context.Background(), "error reconnecting")
@@ -643,9 +640,6 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	}
 	iboxVers := g.inboxParams(ctx, uid)
 	latestCtime := g.notificationParams(ctx, gcli)
-
-	// Let people know we are trying to sync
-	g.G().NotifyRouter.HandleChatInboxSyncStarted(ctx, keybase1.UID(uid.String()))
 
 	// Run SyncAll to both authenticate, and grab all the data we will need to run the
 	// various resync procedures for chat and notifications
@@ -1381,6 +1375,8 @@ func (g *gregorHandler) connectTLS() error {
 		return fmt.Errorf("No bundled CA for %s", uri.Host)
 	}
 	g.chatLog.Debug(ctx, "Using CA for gregor: %s", libkb.ShortCA(rawCA))
+	// Let people know we are trying to sync
+	g.G().NotifyRouter.HandleChatInboxSyncStarted(ctx, g.G().Env.GetUID())
 
 	constBackoff := backoff.NewConstantBackOff(GregorConnectionRetryInterval)
 	opts := rpc.ConnectionOpts{

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -641,6 +641,9 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	iboxVers := g.inboxParams(ctx, uid)
 	latestCtime := g.notificationParams(ctx, gcli)
 
+	// Let people know we are trying to sync
+	g.G().NotifyRouter.HandleChatInboxSyncStarted(ctx, keybase1.UID(uid.String()))
+
 	// Run SyncAll to both authenticate, and grab all the data we will need to run the
 	// various resync procedures for chat and notifications
 	var identBreaks []keybase1.TLFIdentifyFailure

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -230,6 +230,9 @@ func (g *gregorHandler) monitorAppState() {
 		case keybase1.AppState_FOREGROUND:
 			// Make sure the URI is set before attempting this (possible it isnt in a race)
 			if g.uri != nil {
+				// Let people know we are trying to sync
+				g.G().NotifyRouter.HandleChatInboxSyncStarted(context.Background(),
+					g.G().Env.GetUID())
 				g.chatLog.Debug(context.Background(), "foregrounded, reconnecting")
 				if err := g.Connect(g.uri); err != nil {
 					g.chatLog.Debug(context.Background(), "error reconnecting")

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -114,6 +114,8 @@ func (n *nlistener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID
 func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)    {}
 func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID) {}
 func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                    {}
+func (n *nlistener) ChatInboxSynced(uid keybase1.UID, syncRes chat1.ChatSyncResult)     {}
+func (n *nlistener) ChatInboxSyncStarted(uid keybase1.UID)                              {}
 func (n *nlistener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
 func (n *nlistener) TeamDeleted(teamID keybase1.TeamID) {}

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -28,6 +28,12 @@ protocol common {
     IMPTEAM_2
   }
 
+  enum SyncInboxResType {
+    CURRENT_0,
+    INCREMENTAL_1,
+    CLEAR_2
+  }
+
   @go("nostring")
   enum MessageType {
     NONE_0,

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -490,7 +490,7 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  NonblockFetchRes getInboxNonblockLocal(int sessionID, union { null, int } maxUnbox, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
+  NonblockFetchRes getInboxNonblockLocal(int sessionID, union { null, int } maxUnbox, boolean skipUnverified, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
 
   PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext msg, keybase1.TLFIdentifyBehavior identifyBehavior);
   record PostLocalRes {
@@ -687,4 +687,5 @@ protocol local {
 
   // Unpack message from a push notification
   string unboxMobilePushNotification(string payload, string convID, ConversationMembersType membersType, array<string> pushIDs);
+
 }

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -95,6 +95,16 @@ protocol NotifyChat {
     StaleUpdateType updateType;
   }
 
+  record ChatSyncIncrementalInfo {
+    array<UnverifiedInboxUIItem> items;
+  }
+
+  variant ChatSyncResult switch (SyncInboxResType syncType) {
+    case CURRENT: void;
+    case CLEAR: void;
+    case INCREMENTAL: ChatSyncIncrementalInfo;
+  }
+
   @notify("")
   @lint("ignore")
   void NewChatActivity(keybase1.UID uid, ChatActivity activity);
@@ -138,6 +148,6 @@ protocol NotifyChat {
 
   @notify("")
   @lint("ignore")
-  void ChatInboxSynced(keybase1.UID uid, array<UnverifiedInboxUIItem> convs);
+  void ChatInboxSynced(keybase1.UID uid, ChatSyncResult syncRes);
 
 }

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -134,6 +134,10 @@ protocol NotifyChat {
 
   @notify("")
   @lint("ignore")
+  void ChatInboxSyncStarted(keybase1.UID uid);
+
+  @notify("")
+  @lint("ignore")
   void ChatInboxSynced(keybase1.UID uid, array<UnverifiedInboxUIItem> convs);
 
 }

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -132,4 +132,8 @@ protocol NotifyChat {
   @lint("ignore")
   void ChatLeftConversation(keybase1.UID uid, ConversationID convID);
 
+  @notify("")
+  @lint("ignore")
+  void ChatInboxSynced(keybase1.UID uid, array<UnverifiedInboxUIItem> convs);
+
 }

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -142,7 +142,6 @@ protocol NotifyChat {
   @lint("ignore")
   void ChatLeftConversation(keybase1.UID uid, ConversationID convID);
 
-  @notify("")
   @lint("ignore")
   void ChatInboxSyncStarted(keybase1.UID uid);
 

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -142,6 +142,7 @@ protocol NotifyChat {
   @lint("ignore")
   void ChatLeftConversation(keybase1.UID uid, ConversationID convID);
 
+  @notify("")
   @lint("ignore")
   void ChatInboxSyncStarted(keybase1.UID uid);
 

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -155,12 +155,6 @@ protocol remote {
   // Get the inbox version for a user
   InboxVers getInboxVersion(gregor1.UID uid);
 
-  enum SyncInboxResType {
-    CURRENT_0,
-    INCREMENTAL_1,
-    CLEAR_2
-  }
-
   record SyncIncrementalRes {
     InboxVers vers;
     array<Conversation> convs;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2717,9 +2717,8 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatInboxSyncStarted'?: (
     params: Exact<{
       uid: keybase1.UID
-    }> /* ,
-    response: {} // Notify call
-    */
+    }>,
+    response: CommonResponseHandler
   ) => void,
   'keybase.1.NotifyChat.ChatInboxSynced'?: (
     params: Exact<{

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2717,8 +2717,9 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatInboxSyncStarted'?: (
     params: Exact<{
       uid: keybase1.UID
-    }>,
-    response: CommonResponseHandler
+    }> /* ,
+    response: {} // Notify call
+    */
   ) => void,
   'keybase.1.NotifyChat.ChatInboxSynced'?: (
     params: Exact<{

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -120,6 +120,12 @@ export const CommonNotificationKind = {
   atmention: 1,
 }
 
+export const CommonSyncInboxResType = {
+  current: 0,
+  incremental: 1,
+  clear: 2,
+}
+
 export const CommonTeamType = {
   none: 0,
   simple: 1,
@@ -231,12 +237,6 @@ export const RemoteMessageBoxedVersion = {
 export const RemoteSyncAllNotificationType = {
   state: 0,
   incremental: 1,
-}
-
-export const RemoteSyncInboxResType = {
-  current: 0,
-  incremental: 1,
-  clear: 2,
 }
 
 export function localCancelPostRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}): EngineChannel {
@@ -880,6 +880,15 @@ export type ChatActivityType =
   | 6 // MEMBERS_UPDATE_6
   | 7 // SET_APP_NOTIFICATION_SETTINGS_7
   | 8 // TEAMTYPE_8
+
+export type ChatSyncIncrementalInfo = {
+  items?: ?Array<UnverifiedInboxUIItem>,
+}
+
+export type ChatSyncResult =
+    { syncType: 0 }
+  | { syncType: 2 }
+  | { syncType: 1, incremental: ?ChatSyncIncrementalInfo }
 
 export type ConvTypingUpdate = {
   convID: ConversationID,
@@ -1628,7 +1637,7 @@ export type NotifyChatChatInboxSyncStartedRpcParam = Exact<{
 
 export type NotifyChatChatInboxSyncedRpcParam = Exact<{
   uid: keybase1.UID,
-  convs?: ?Array<UnverifiedInboxUIItem>
+  syncRes: ChatSyncResult
 }>
 
 export type NotifyChatChatJoinedConversationRpcParam = Exact<{
@@ -2715,7 +2724,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatInboxSynced'?: (
     params: Exact<{
       uid: keybase1.UID,
-      convs?: ?Array<UnverifiedInboxUIItem>
+      syncRes: ChatSyncResult
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1622,6 +1622,11 @@ export type NotifyChatChatInboxStaleRpcParam = Exact<{
   uid: keybase1.UID
 }>
 
+export type NotifyChatChatInboxSyncedRpcParam = Exact<{
+  uid: keybase1.UID,
+  convs?: ?Array<UnverifiedInboxUIItem>
+}>
+
 export type NotifyChatChatJoinedConversationRpcParam = Exact<{
   uid: keybase1.UID,
   conv: InboxUIItem
@@ -2119,6 +2124,7 @@ export type localGetInboxAndUnboxLocalRpcParam = Exact<{
 
 export type localGetInboxNonblockLocalRpcParam = Exact<{
   maxUnbox?: ?int,
+  skipUnverified: boolean,
   query?: ?GetInboxLocalQuery,
   pagination?: ?Pagination,
   identifyBehavior: keybase1.TLFIdentifyBehavior
@@ -2691,6 +2697,14 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       uid: keybase1.UID,
       convID: ConversationID
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatInboxSynced'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convs?: ?Array<UnverifiedInboxUIItem>
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1622,6 +1622,10 @@ export type NotifyChatChatInboxStaleRpcParam = Exact<{
   uid: keybase1.UID
 }>
 
+export type NotifyChatChatInboxSyncStartedRpcParam = Exact<{
+  uid: keybase1.UID
+}>
+
 export type NotifyChatChatInboxSyncedRpcParam = Exact<{
   uid: keybase1.UID,
   convs?: ?Array<UnverifiedInboxUIItem>
@@ -2697,6 +2701,13 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       uid: keybase1.UID,
       convID: ConversationID
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatInboxSyncStarted'?: (
+    params: Exact<{
+      uid: keybase1.UID
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -103,6 +103,15 @@
     },
     {
       "type": "enum",
+      "name": "SyncInboxResType",
+      "symbols": [
+        "CURRENT_0",
+        "INCREMENTAL_1",
+        "CLEAR_2"
+      ]
+    },
+    {
+      "type": "enum",
       "name": "MessageType",
       "symbols": [
         "NONE_0",

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2051,6 +2051,10 @@
           ]
         },
         {
+          "name": "skipUnverified",
+          "type": "boolean"
+        },
+        {
           "name": "query",
           "type": [
             null,

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -450,6 +450,17 @@
       "notify": "",
       "lint": "ignore"
     },
+    "ChatInboxSyncStarted": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
+    },
     "ChatInboxSynced": {
       "request": [
         {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -502,7 +502,6 @@
         }
       ],
       "response": null,
-      "notify": "",
       "lint": "ignore"
     },
     "ChatInboxSynced": {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -502,6 +502,7 @@
         }
       ],
       "response": null,
+      "notify": "",
       "lint": "ignore"
     },
     "ChatInboxSynced": {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -449,6 +449,24 @@
       "response": null,
       "notify": "",
       "lint": "ignore"
+    },
+    "ChatInboxSynced": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        },
+        {
+          "name": "convs",
+          "type": {
+            "type": "array",
+            "items": "UnverifiedInboxUIItem"
+          }
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -303,6 +303,50 @@
           "name": "updateType"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "ChatSyncIncrementalInfo",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "UnverifiedInboxUIItem"
+          },
+          "name": "items"
+        }
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "ChatSyncResult",
+      "switch": {
+        "type": "SyncInboxResType",
+        "name": "syncType"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "CURRENT",
+            "def": false
+          },
+          "body": null
+        },
+        {
+          "label": {
+            "name": "CLEAR",
+            "def": false
+          },
+          "body": null
+        },
+        {
+          "label": {
+            "name": "INCREMENTAL",
+            "def": false
+          },
+          "body": "ChatSyncIncrementalInfo"
+        }
+      ]
     }
   ],
   "messages": {
@@ -468,11 +512,8 @@
           "type": "keybase1.UID"
         },
         {
-          "name": "convs",
-          "type": {
-            "type": "array",
-            "items": "UnverifiedInboxUIItem"
-          }
+          "name": "syncRes",
+          "type": "ChatSyncResult"
         }
       ],
       "response": null,

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -314,15 +314,6 @@
       ]
     },
     {
-      "type": "enum",
-      "name": "SyncInboxResType",
-      "symbols": [
-        "CURRENT_0",
-        "INCREMENTAL_1",
-        "CLEAR_2"
-      ]
-    },
-    {
       "type": "record",
       "name": "SyncIncrementalRes",
       "fields": [

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -429,6 +429,10 @@ function markThreadsStale(updates: Array<ChatTypes.ConversationStaleUpdate>): Co
   return {payload: {updates}, type: 'chat:markThreadsStale'}
 }
 
+function inboxSynced(convs: Array<ChatTypes.UnverifiedInboxUIItem>): Constants.InboxSynced {
+  return {payload: {convs}, type: 'chat:inboxSynced'}
+}
+
 function loadingMessages(
   conversationIDKey: Constants.ConversationIDKey,
   isRequesting: boolean
@@ -701,9 +705,10 @@ function updateSnippet(
 
 function unboxConversations(
   conversationIDKeys: Array<Constants.ConversationIDKey>,
-  force?: boolean = false
+  force?: boolean = false,
+  forInboxSync?: boolean = false
 ): Constants.UnboxConversations {
-  return {payload: {conversationIDKeys, force}, type: 'chat:unboxConversations'}
+  return {payload: {conversationIDKeys, force, forInboxSync}, type: 'chat:unboxConversations'}
 }
 
 function unboxMore(): Constants.UnboxMore {
@@ -728,6 +733,7 @@ export {
   exitSearch,
   getInboxAndUnbox,
   inboxStale,
+  inboxSynced,
   incomingMessage,
   incomingTyping,
   leaveConversation,

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -106,6 +106,7 @@ function* onInboxStale(): SagaGenerator<any, any> {
           identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
           maxUnbox: 0,
           query: _getInboxQuery,
+          skipUnverified: false,
         },
       }
     )

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -1198,6 +1198,13 @@ function* _inboxSynced(action: Constants.InboxSynced): SagaGenerator<any, any> {
   }, [])
   yield all(updateActions)
   yield put(Creators.unboxConversations(convIDs, true, true))
+
+  const selectedConversation = yield select(Constants.getSelectedConversation)
+  if (!selectedConversation || convIDs.indexOf(selectedConversation) < 0) {
+    return
+  }
+  yield put(Creators.clearMessages(selectedConversation))
+  yield put(Creators.loadMoreMessages(selectedConversation, false))
 }
 
 function _threadIsCleared(originalAction: Action, checkAction: Action): boolean {

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -1188,14 +1188,8 @@ function* _inboxSynced(action: Constants.InboxSynced): SagaGenerator<any, any> {
   const author = yield select(usernameSelector)
   const items: List<Constants.InboxState> = Shared.makeInboxStateRecords(author, convs)
 
-  const convIDs = items.reduce(function(l, item) {
-    l.push(item.conversationIDKey)
-    return l
-  }, [])
-  const updateActions = items.reduce(function(l, item) {
-    l.push(put(Creators.updateInbox(item)))
-    return l
-  }, [])
+  const convIDs = items.map(item => item.conversationIDKey).toArray()
+  const updateActions = items.map(item => put(Creators.updateInbox(item)))
   yield all(updateActions)
   yield put(Creators.unboxConversations(convIDs, true, true))
 

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -275,9 +275,14 @@ function* _setupChatHandlers(): SagaGenerator<any, any> {
     return null
   })
 
-  engine().setIncomingActionCreator('chat.1.NotifyChat.ChatInboxSynced', ({convs}) => {
-    if (convs) {
-      return Creators.inboxSynced(convs)
+  engine().setIncomingActionCreator('chat.1.NotifyChat.ChatInboxSynced', ({syncRes}) => {
+    switch (syncRes.syncType) {
+      case ChatTypes.CommonSyncInboxResType.clear:
+        return Creators.inboxStale()
+      case ChatTypes.CommonSyncInboxResType.current:
+        return Creators.setInboxUntrustedState('loaded')
+      case ChatTypes.CommonSyncInboxResType.incremental:
+        return Creators.inboxSynced(syncRes.incremental.items)
     }
     return Creators.inboxStale()
   })

--- a/shared/chat/inbox/row/chat-filter-row.js
+++ b/shared/chat/inbox/row/chat-filter-row.js
@@ -139,7 +139,7 @@ class _ChatFilterRow extends Component<Props, State> {
           onClick={this.props.onNewChat}
         />
         {this.props.isLoading &&
-          <Box style={{bottom: 0, left: 0, position: 'absolute', right: 0}}>
+          <Box style={{bottom: 0, left: 0, position: 'absolute', height: 1, right: 0}}>
             <LoadingLine />
           </Box>}
       </Box>

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -431,7 +431,7 @@ export const blankChat = 'chat:blankChat'
 export type UnboxMore = NoErrorTypedAction<'chat:unboxMore', void>
 export type UnboxConversations = NoErrorTypedAction<
   'chat:unboxConversations',
-  {conversationIDKeys: Array<ConversationIDKey>, force: boolean}
+  {conversationIDKeys: Array<ConversationIDKey>, force: boolean, forInboxSync: boolean}
 >
 
 export type AddPendingConversation = NoErrorTypedAction<
@@ -488,6 +488,10 @@ export type LoadingMessages = NoErrorTypedAction<
 export type MarkThreadsStale = NoErrorTypedAction<
   'chat:markThreadsStale',
   {updates: Array<ChatTypes.ConversationStaleUpdate>}
+>
+export type InboxSynced = NoErrorTypedAction<
+  'chat:inboxSynced',
+  {convs: Array<ChatTypes.UnverifiedInboxUIItem>}
 >
 export type MuteConversation = NoErrorTypedAction<
   'chat:muteConversation',

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2717,9 +2717,8 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatInboxSyncStarted'?: (
     params: Exact<{
       uid: keybase1.UID
-    }> /* ,
-    response: {} // Notify call
-    */
+    }>,
+    response: CommonResponseHandler
   ) => void,
   'keybase.1.NotifyChat.ChatInboxSynced'?: (
     params: Exact<{

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2717,8 +2717,9 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatInboxSyncStarted'?: (
     params: Exact<{
       uid: keybase1.UID
-    }>,
-    response: CommonResponseHandler
+    }> /* ,
+    response: {} // Notify call
+    */
   ) => void,
   'keybase.1.NotifyChat.ChatInboxSynced'?: (
     params: Exact<{

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -120,6 +120,12 @@ export const CommonNotificationKind = {
   atmention: 1,
 }
 
+export const CommonSyncInboxResType = {
+  current: 0,
+  incremental: 1,
+  clear: 2,
+}
+
 export const CommonTeamType = {
   none: 0,
   simple: 1,
@@ -231,12 +237,6 @@ export const RemoteMessageBoxedVersion = {
 export const RemoteSyncAllNotificationType = {
   state: 0,
   incremental: 1,
-}
-
-export const RemoteSyncInboxResType = {
-  current: 0,
-  incremental: 1,
-  clear: 2,
 }
 
 export function localCancelPostRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}): EngineChannel {
@@ -880,6 +880,15 @@ export type ChatActivityType =
   | 6 // MEMBERS_UPDATE_6
   | 7 // SET_APP_NOTIFICATION_SETTINGS_7
   | 8 // TEAMTYPE_8
+
+export type ChatSyncIncrementalInfo = {
+  items?: ?Array<UnverifiedInboxUIItem>,
+}
+
+export type ChatSyncResult =
+    { syncType: 0 }
+  | { syncType: 2 }
+  | { syncType: 1, incremental: ?ChatSyncIncrementalInfo }
 
 export type ConvTypingUpdate = {
   convID: ConversationID,
@@ -1628,7 +1637,7 @@ export type NotifyChatChatInboxSyncStartedRpcParam = Exact<{
 
 export type NotifyChatChatInboxSyncedRpcParam = Exact<{
   uid: keybase1.UID,
-  convs?: ?Array<UnverifiedInboxUIItem>
+  syncRes: ChatSyncResult
 }>
 
 export type NotifyChatChatJoinedConversationRpcParam = Exact<{
@@ -2715,7 +2724,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatInboxSynced'?: (
     params: Exact<{
       uid: keybase1.UID,
-      convs?: ?Array<UnverifiedInboxUIItem>
+      syncRes: ChatSyncResult
     }> /* ,
     response: {} // Notify call
     */

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1622,6 +1622,11 @@ export type NotifyChatChatInboxStaleRpcParam = Exact<{
   uid: keybase1.UID
 }>
 
+export type NotifyChatChatInboxSyncedRpcParam = Exact<{
+  uid: keybase1.UID,
+  convs?: ?Array<UnverifiedInboxUIItem>
+}>
+
 export type NotifyChatChatJoinedConversationRpcParam = Exact<{
   uid: keybase1.UID,
   conv: InboxUIItem
@@ -2119,6 +2124,7 @@ export type localGetInboxAndUnboxLocalRpcParam = Exact<{
 
 export type localGetInboxNonblockLocalRpcParam = Exact<{
   maxUnbox?: ?int,
+  skipUnverified: boolean,
   query?: ?GetInboxLocalQuery,
   pagination?: ?Pagination,
   identifyBehavior: keybase1.TLFIdentifyBehavior
@@ -2691,6 +2697,14 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       uid: keybase1.UID,
       convID: ConversationID
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatInboxSynced'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convs?: ?Array<UnverifiedInboxUIItem>
     }> /* ,
     response: {} // Notify call
     */

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1622,6 +1622,10 @@ export type NotifyChatChatInboxStaleRpcParam = Exact<{
   uid: keybase1.UID
 }>
 
+export type NotifyChatChatInboxSyncStartedRpcParam = Exact<{
+  uid: keybase1.UID
+}>
+
 export type NotifyChatChatInboxSyncedRpcParam = Exact<{
   uid: keybase1.UID,
   convs?: ?Array<UnverifiedInboxUIItem>
@@ -2697,6 +2701,13 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       uid: keybase1.UID,
       convID: ConversationID
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatInboxSyncStarted'?: (
+    params: Exact<{
+      uid: keybase1.UID
     }> /* ,
     response: {} // Notify call
     */

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -106,6 +106,18 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
         })
       )
     }
+    case 'chat:inboxSynced': {
+      const {convs} = action.payload
+      const convIDs = convs.map(u => u.convID)
+      return state.update('conversationStates', conversationStates =>
+        conversationStates.map((conversationState, conversationIDKey) => {
+          if (convIDs.length === 0 || convIDs.includes(conversationIDKey)) {
+            return conversationState.set('isStale', true)
+          }
+          return conversationState
+        })
+      )
+    }
     case 'chat:updateLatestMessage':
       // Clear new messages id of conversation
       const newConversationStates = state


### PR DESCRIPTION
Patch does the following:

1.) Adds two new `NotifyRouter` RPCs, `ChatInboxSynced` and `ChatInboxSyncStarted`. `ChatInboxSyncStarted` lets all listeners know that the service is going to sync against the server. This allows the UI to render a blue bar.
2.) `ChatInboxSynced` sends up a result similar to what Gregor gives the service, with three possible states given the outcome: `CLEAR`, `CURRENT`, or `INCREMENTAL`. `CLEAR` and `CURRENT` are implemented straightforwardly in JS, and `INCREMENTAL` triggers a new action `inboxSynced`.
3.) `inboxSynced` causes the JS to run `GetInboxNonblock` in a special mode where it does not deliver the untrusted inbox, since that data is already available from the `ChatInboxSynced` call.  It then updates the inbox in the normal way, and marks any affected threads as stale for the purposes of calling `GetThreadNonblock` on them.

The main tangible result here is that now when foregrounding the mobile app, we get a nice blue bar indicating that the sync is happening, so there is less confusion form the user foregrounding. 