### PR TITLE
kill G from libkb/kbpackets

### DIFF
--- a/go/libkb/kbpackets.go
+++ b/go/libkb/kbpackets.go
@@ -183,9 +183,8 @@ func (p *KeybasePacket) unpackBody(ch *codec.MsgpackHandle) error {
 
 	switch p.Tag {
 	case TagP3skb:
-		// XXX this function should get a G passed into it, but to do that requires
-		// a lot of changes upstream.
-		body = NewSKB(G)
+		// We can't use this SKB until it's been SetContext'ed
+		body = NewSKB()
 	case TagSignature:
 		body = &NaclSigInfo{}
 	case TagEncryption:

--- a/go/libkb/lksec.go
+++ b/go/libkb/lksec.go
@@ -510,7 +510,7 @@ func (s *LKSec) ToSKB(key GenericKey) (ret *SKB, err error) {
 	if s == nil {
 		return nil, errors.New("nil lks")
 	}
-	ret = NewSKB(s.G())
+	ret = NewSKBWithGlobalContext(s.G())
 
 	var publicKey RawPublicKey
 	var privateKey RawPrivateKey

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -58,8 +58,12 @@ type SKB struct {
 	sync.Mutex // currently only for uid
 }
 
-func NewSKB(gc *GlobalContext) *SKB {
-	return &SKB{Contextified: NewContextified(gc)}
+func NewSKB() *SKB {
+	return &SKB{}
+}
+
+func NewSKBWithGlobalContext(g *GlobalContext) *SKB {
+	return &SKB{Contextified: NewContextified(g)}
 }
 
 type SKBPriv struct {
@@ -77,7 +81,7 @@ func ToServerSKB(gc *GlobalContext, key GenericKey, tsec Triplesec, gen Passphra
 
 func (key *PGPKeyBundle) ToServerSKB(gc *GlobalContext, tsec Triplesec, gen PassphraseGeneration) (ret *SKB, err error) {
 
-	ret = NewSKB(gc)
+	ret = NewSKBWithGlobalContext(gc)
 
 	var pk, sk bytes.Buffer
 
@@ -424,13 +428,14 @@ func (s *SKB) ArmoredEncode() (ret string, err error) {
 	return PacketArmoredEncode(s)
 }
 
-func (p KeybasePackets) ToListOfSKBs() ([]*SKB, error) {
+func (p KeybasePackets) ToListOfSKBs(g *GlobalContext) ([]*SKB, error) {
 	ret := make([]*SKB, len(p))
 	for i, e := range p {
 		k, ok := e.Body.(*SKB)
 		if !ok {
 			return nil, fmt.Errorf("Bad SKB sequence; got packet of wrong type %T", e.Body)
 		}
+		k.SetGlobalContext(g)
 		ret[i] = k
 	}
 	return ret, nil

--- a/go/libkb/skb_keyring.go
+++ b/go/libkb/skb_keyring.go
@@ -85,7 +85,7 @@ func (k *SKBKeyringFile) loadLocked() (err error) {
 		}
 
 	} else if err == nil {
-		k.Blocks, err = packets.ToListOfSKBs()
+		k.Blocks, err = packets.ToListOfSKBs(k.G())
 	}
 
 	k.G().Log.Debug("- Loaded SKB keyring: %s -> %s", k.filename, ErrToOk(err))

--- a/go/libkb/skb_test.go
+++ b/go/libkb/skb_test.go
@@ -59,7 +59,7 @@ func TestDecodeSKBSequence(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to decode packets: %s", err)
 	}
-	p3skbs, err := packets.ToListOfSKBs()
+	p3skbs, err := packets.ToListOfSKBs(nil)
 	if err != nil {
 		t.Errorf("Failed to make a list of SKBs: %s", err)
 	}


### PR DESCRIPTION
- don't try to inject G from inside the parsing routine; instead, inject in the caller of the parser.