### PR TITLE
hide internal fields of libkb.LoadUserArg

### DIFF
--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -105,8 +105,7 @@ func getSigningKeyPairForTest(t *testing.T, tc *kbtest.ChatTestContext, u *kbtes
 }
 
 func getActiveDevicesAndKeys(tc *kbtest.ChatTestContext, u *kbtest.FakeUser) ([]*libkb.Device, []libkb.GenericKey) {
-	arg := libkb.NewLoadUserByNameArg(tc.G, u.Username)
-	arg.PublicKeyOptional = true
+	arg := libkb.NewLoadUserByNameArg(tc.G, u.Username).WithPublicKeyOptional()
 	user, err := libkb.LoadUser(arg)
 	if err != nil {
 		tc.T.Fatal(err)

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -213,10 +213,8 @@ func newBaseInboxSource(g *globals.Context, ibs types.InboxSource,
 
 func (b *baseInboxSource) notifyTlfFinalize(ctx context.Context, username string) {
 	// Let the rest of the system know this user has changed
-	finalizeUser, err := libkb.LoadUser(libkb.LoadUserArg{
-		Name:              username,
-		PublicKeyOptional: true,
-	})
+	arg := libkb.NewLoadUserArg(b.G().ExternalG()).WithName(username).WithPublicKeyOptional()
+	finalizeUser, err := libkb.LoadUser(arg)
 	if err != nil {
 		b.Debug(ctx, "notifyTlfFinalize: failed to load finalize user, skipping user changed notification: err: %s", err.Error())
 	} else {

--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -34,7 +34,7 @@ func isUserConfigInMemory(tc libkb.TestContext) bool {
 }
 
 func getNumKeys(tc libkb.TestContext, fu FakeUser) int {
-	loaded, err := libkb.LoadUser(libkb.LoadUserArg{Name: fu.Username, ForceReload: true})
+	loaded, err := libkb.LoadUser(libkb.NewLoadUserArg(tc.G).WithName(fu.Username).WithForceReload())
 	if err != nil {
 		switch err.(type) {
 		case libkb.NoKeyError:

--- a/go/engine/device_history.go
+++ b/go/engine/device_history.go
@@ -76,9 +76,9 @@ func (e *DeviceHistory) Devices() []keybase1.DeviceDetail {
 func (e *DeviceHistory) loadUserArg() libkb.LoadUserArg {
 	arg := libkb.NewLoadUserPubOptionalArg(e.G())
 	if len(e.username) == 0 {
-		arg.Self = true
+		arg = arg.WithSelf(true)
 	} else {
-		arg.Name = e.username
+		arg = arg.WithName(e.username)
 	}
 	return arg
 }

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -251,8 +251,7 @@ func (e *Kex2Provisionee) handleDidCounterSign(sig []byte, perUserKeyBox *keybas
 
 	// load self user (to load merkle root)
 	e.G().Log.Debug("| running for username %s", e.username)
-	loadArg := libkb.NewLoadUserByNameArg(e.G(), e.username)
-	loadArg.LoginContext = e.ctx.LoginContext
+	loadArg := libkb.NewLoadUserByNameArg(e.G(), e.username).WithLoginContext(e.ctx.LoginContext)
 	_, err = libkb.LoadUser(loadArg)
 	if err != nil {
 		return err
@@ -411,8 +410,7 @@ func (e *Kex2Provisionee) addDeviceSibkey(jw *jsonw.Wrapper) error {
 		e.G().Log.Debug("kex2 provisionee: proceeding to prompt user for device name, but figure out how this happened...")
 
 		// need user to get existing device names
-		loadArg := libkb.NewLoadUserByNameArg(e.G(), e.username)
-		loadArg.LoginContext = e.ctx.LoginContext
+		loadArg := libkb.NewLoadUserByNameArg(e.G(), e.username).WithLoginContext(e.ctx.LoginContext)
 		user, err := libkb.LoadUser(loadArg)
 		if err != nil {
 			return err

--- a/go/engine/list_trackers2.go
+++ b/go/engine/list_trackers2.go
@@ -53,8 +53,7 @@ func (e *ListTrackers2Engine) lookupUID() error {
 		return nil
 	}
 
-	larg := libkb.NewLoadUserPubOptionalArg(e.G())
-	larg.Name = e.arg.Assertion
+	larg := libkb.NewLoadUserPubOptionalArg(e.G()).WithName(e.arg.Assertion)
 	u, err := libkb.LoadUser(larg)
 	if err != nil {
 		return err

--- a/go/engine/list_tracking.go
+++ b/go/engine/list_tracking.go
@@ -65,7 +65,7 @@ func (e *ListTrackingEngine) Run(ctx *Context) (err error) {
 	if len(e.arg.ForAssertion) > 0 {
 		arg = libkb.NewLoadUserByNameArg(e.G(), e.arg.ForAssertion)
 	} else {
-		arg.Self = true
+		arg = libkb.NewLoadUserArg(e.G()).WithSelf(true)
 	}
 
 	err = e.G().GetFullSelfer().WithUser(arg, func(user *libkb.User) error {

--- a/go/engine/login_load_user.go
+++ b/go/engine/login_load_user.go
@@ -63,8 +63,7 @@ func (e *loginLoadUser) Run(ctx *Context) error {
 
 	e.G().Log.Debug("loginLoadUser: found username %q", username)
 
-	arg := libkb.NewLoadUserByNameArg(e.G(), username)
-	arg.PublicKeyOptional = true
+	arg := libkb.NewLoadUserByNameArg(e.G(), username).WithPublicKeyOptional()
 	user, err := libkb.LoadUser(arg)
 	if err != nil {
 		return err

--- a/go/engine/login_offline.go
+++ b/go/engine/login_offline.go
@@ -83,11 +83,7 @@ func (e *LoginOffline) run(ctx *Context) error {
 		deviceID = e.G().Env.GetDeviceIDForUID(uid)
 
 		// use the UPAKLoader with StaleOK, CachedOnly in order to get cached upak
-		arg := libkb.NewLoadUserByUIDArg(ctx.NetContext, e.G(), uid)
-		arg.PublicKeyOptional = true
-		arg.StaleOK = true
-		arg.CachedOnly = true
-		arg.LoginContext = a
+		arg := libkb.NewLoadUserByUIDArg(ctx.NetContext, e.G(), uid).WithPublicKeyOptional().WithStaleOK(true).WithCachedOnly().WithLoginContext(a)
 		upak, _, err := e.G().GetUPAKLoader().Load(arg)
 		if err != nil {
 			e.G().Log.Debug("LoginOffline: upak.Load err: %s", err)

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -272,8 +272,8 @@ func (e *loginProvision) deviceWithType(ctx *Context, provisionerType keybase1.D
 		}
 
 		// Load me again so that keys will be up to date.
-		loadArg := libkb.NewLoadUserArgBase(e.G()).WithSelf(true).WithUID(e.arg.User.GetUID()).WithNetContext(ctx.NetContext)
-		e.arg.User, err = libkb.LoadUser(*loadArg)
+		loadArg := libkb.NewLoadUserArg(e.G()).WithSelf(true).WithUID(e.arg.User.GetUID()).WithNetContext(ctx.NetContext)
+		e.arg.User, err = libkb.LoadUser(loadArg)
 		if err != nil {
 			return err
 		}

--- a/go/engine/login_provisioned_device.go
+++ b/go/engine/login_provisioned_device.go
@@ -88,20 +88,17 @@ func (e *LoginProvisionedDevice) run(ctx *Context) error {
 	}
 
 	var config *libkb.UserConfig
-	loadUserArg := libkb.LoadUserArg{
-		PublicKeyOptional: true,
-		ForceReload:       true,
-	}
+	loadUserArg := libkb.NewLoadUserArg(e.G()).WithPublicKeyOptional().WithForceReload()
 	var nu libkb.NormalizedUsername
 	if len(e.username) == 0 {
 		e.G().Log.Debug("| using current username")
 		config, err = e.G().Env.GetConfig().GetUserConfig()
-		loadUserArg.Self = true
+		loadUserArg = loadUserArg.WithSelf(true)
 	} else {
 		e.G().Log.Debug("| using new username %s", e.username)
 		nu = libkb.NewNormalizedUsername(e.username)
 		config, err = e.G().Env.GetConfig().GetUserConfigForUsername(nu)
-		loadUserArg.Name = e.username
+		loadUserArg = loadUserArg.WithName(e.username)
 	}
 	if err != nil {
 		e.G().Log.Debug("error getting user config: %s (%T)", err, err)

--- a/go/engine/paperkey_test.go
+++ b/go/engine/paperkey_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func paperDevs(tc libkb.TestContext, fu *FakeUser) (*libkb.User, []*libkb.Device) {
-	arg := libkb.NewLoadUserForceArg(tc.G)
-	arg.Name = fu.Username
+	arg := libkb.NewLoadUserForceArg(tc.G).WithName(fu.Username)
 	u, err := libkb.LoadUser(arg)
 	if err != nil {
 		tc.T.Fatal(err)

--- a/go/engine/pgp_update_test.go
+++ b/go/engine/pgp_update_test.go
@@ -21,8 +21,7 @@ func doUpdate(fingerprints []string, all bool, fu *FakeUser, tc libkb.TestContex
 }
 
 func getFakeUsersKeyBundleFromServer(tc libkb.TestContext, fu *FakeUser) *libkb.PGPKeyBundle {
-	arg := libkb.NewLoadUserForceArg(tc.G)
-	arg.Name = fu.Username
+	arg := libkb.NewLoadUserForceArg(tc.G).WithName(fu.Username)
 	user, err := libkb.LoadUser(arg)
 	if err != nil {
 		tc.T.Fatal("Failed loading user", err)
@@ -36,8 +35,7 @@ func getFakeUsersKeyBundleFromServer(tc libkb.TestContext, fu *FakeUser) *libkb.
 }
 
 func getFakeUsersBundlesList(tc libkb.TestContext, fu *FakeUser) []string {
-	arg := libkb.NewLoadUserForceArg(tc.G)
-	arg.Name = fu.Username
+	arg := libkb.NewLoadUserForceArg(tc.G).WithName(fu.Username)
 	user, err := libkb.LoadUser(arg)
 	if err != nil {
 		tc.T.Fatal("Failed loading user", err)

--- a/go/engine/puk_roll.go
+++ b/go/engine/puk_roll.go
@@ -71,12 +71,12 @@ func (e *PerUserKeyRoll) inner(ctx *Context) error {
 	if me == nil {
 		e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyRoll load self")
 
-		loadArg := libkb.NewLoadUserArgBase(e.G()).
+		loadArg := libkb.NewLoadUserArg(e.G()).
 			WithNetContext(ctx.GetNetContext()).
 			WithUID(uid).
 			WithSelf(true).
 			WithPublicKeyOptional()
-		me, err = libkb.LoadUser(*loadArg)
+		me, err = libkb.LoadUser(loadArg)
 		if err != nil {
 			return err
 		}

--- a/go/engine/puk_upgrade.go
+++ b/go/engine/puk_upgrade.go
@@ -69,12 +69,12 @@ func (e *PerUserKeyUpgrade) inner(ctx *Context) error {
 		return libkb.NoUIDError{}
 	}
 
-	loadArg := libkb.NewLoadUserArgBase(e.G()).
+	loadArg := libkb.NewLoadUserArg(e.G()).
 		WithNetContext(ctx.GetNetContext()).
 		WithUID(uid).
 		WithSelf(true).
 		WithPublicKeyOptional()
-	upak, me, err := e.G().GetUPAKLoader().LoadV2(*loadArg)
+	upak, me, err := e.G().GetUPAKLoader().LoadV2(loadArg)
 	if err != nil {
 		return err
 	}

--- a/go/engine/puk_upgrade_test.go
+++ b/go/engine/puk_upgrade_test.go
@@ -50,8 +50,7 @@ func TestPerUserKeyUpgrade(t *testing.T) {
 	require.False(t, upgrade().DidNewKey, "did not create key")
 
 	t.Logf("check SignedByKID field of the PUKs")
-	loadArg := libkb.NewLoadUserSelfArg(tc.G)
-	loadArg.UID = fu.UID()
+	loadArg := libkb.NewLoadUserSelfArg(tc.G).WithUID(fu.UID())
 	upak, _, err := tc.G.GetUPAKLoader().LoadV2(loadArg)
 	require.NoError(t, err)
 	require.Len(t, upak.Current.PerUserKeys, 2, "PUK count")

--- a/go/engine/puk_upkeep.go
+++ b/go/engine/puk_upkeep.go
@@ -71,12 +71,12 @@ func (e *PerUserKeyUpkeep) inner(ctx *Context) error {
 		return libkb.NoUIDError{}
 	}
 
-	loadArg := libkb.NewLoadUserArgBase(e.G()).
+	loadArg := libkb.NewLoadUserArg(e.G()).
 		WithNetContext(ctx.GetNetContext()).
 		WithUID(uid).
 		WithSelf(true).
 		WithPublicKeyOptional()
-	upak, me, err := e.G().GetUPAKLoader().LoadV2(*loadArg)
+	upak, me, err := e.G().GetUPAKLoader().LoadV2(loadArg)
 	if err != nil {
 		return err
 	}

--- a/go/engine/puk_upkeep_background_test.go
+++ b/go/engine/puk_upkeep_background_test.go
@@ -99,12 +99,12 @@ func TestPerUserKeyUpkeepBackgroundWork(t *testing.T) {
 	// Upkeep hits the cache. It's ok that upkeep doesn't notice a deprovision
 	// right away. Bust the upak cache as a way of simulating time passing
 	// for the sake of this test.
-	loadArg := libkb.NewLoadUserArgBase(tc.G).
+	loadArg := libkb.NewLoadUserArg(tc.G).
 		WithUID(fu.UID()).
 		WithSelf(true).
-		WithForcePoll(). // <-
+		WithForcePoll(true). // <-
 		WithPublicKeyOptional()
-	_, _, err := tc.G.GetUPAKLoader().LoadV2(*loadArg)
+	_, _, err := tc.G.GetUPAKLoader().LoadV2(loadArg)
 	require.NoError(t, err)
 
 	advance := func(d time.Duration) {

--- a/go/engine/puk_upkeep_test.go
+++ b/go/engine/puk_upkeep_test.go
@@ -55,12 +55,12 @@ func TestPerUserKeyUpkeep(t *testing.T) {
 	// Upkeep hits the cache. It's ok that upkeep doesn't notice a deprovision
 	// right away. Bust the upak cache as a way of simulating time passing
 	// for the sake of this test.
-	loadArg := libkb.NewLoadUserArgBase(tc.G).
+	loadArg := libkb.NewLoadUserArg(tc.G).
 		WithUID(fu.UID()).
 		WithSelf(true).
-		WithForcePoll(). // <-
+		WithForcePoll(true). // <-
 		WithPublicKeyOptional()
-	_, _, err := tc.G.GetUPAKLoader().LoadV2(*loadArg)
+	_, _, err := tc.G.GetUPAKLoader().LoadV2(loadArg)
 	require.NoError(t, err)
 
 	require.True(t, upkeep().DidRollKey, "roll after deprovision")

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func getActiveDevicesAndKeys(tc libkb.TestContext, u *FakeUser) ([]*libkb.Device, []libkb.GenericKey) {
-	arg := libkb.NewLoadUserByNameArg(tc.G, u.Username)
-	arg.PublicKeyOptional = true
+	arg := libkb.NewLoadUserByNameArg(tc.G, u.Username).WithPublicKeyOptional()
 	user, err := libkb.LoadUser(arg)
 	if err != nil {
 		tc.T.Fatal(err)

--- a/go/engine/secretkeys_test.go
+++ b/go/engine/secretkeys_test.go
@@ -40,9 +40,7 @@ func TestSecretKeys(t *testing.T) {
 	}
 
 	// Check the signing keypair's KID is in the user's KeyFamily.
-	testUser, err := libkb.LoadUser(libkb.LoadUserArg{
-		Name: u.Username,
-	})
+	testUser, err := libkb.LoadUser(libkb.NewLoadUserArg(tc.G).WithName(u.Username))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -189,7 +189,8 @@ func (s *SignupEngine) join(a libkb.LoginContext, username, email, inviteCode st
 	a.CreateStreamCache(s.tsec, s.ppStream)
 
 	s.uid = res.UID
-	user, err := libkb.LoadUser(libkb.LoadUserArg{Self: true, UID: res.UID, PublicKeyOptional: true, Contextified: libkb.NewContextified(s.G())})
+	luArg := libkb.NewLoadUserArg(s.G()).WithSelf(true).WithUID(res.UID).WithPublicKeyOptional()
+	user, err := libkb.LoadUser(luArg)
 	if err != nil {
 		return err
 	}
@@ -259,7 +260,7 @@ func (s *SignupEngine) genPaperKeys(ctx *Context, lctx libkb.LoginContext) error
 	s.G().Log.CDebugf(ctx.NetContext, "SignupEngine#genPaperKeys")
 	// Load me again so that keys will be up to date.
 	var err error
-	s.me, err = libkb.LoadUser(libkb.LoadUserArg{Self: true, UID: s.me.GetUID(), PublicKeyOptional: true, Contextified: libkb.NewContextified(s.G())})
+	s.me, err = libkb.LoadUser(libkb.NewLoadUserArg(s.G()).WithSelf(true).WithUID(s.me.GetUID()).WithPublicKeyOptional())
 	if err != nil {
 		return err
 	}

--- a/go/engine/sigslist.go
+++ b/go/engine/sigslist.go
@@ -59,12 +59,11 @@ func (e *SigsList) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *SigsList) Run(ctx *Context) error {
-	arg := libkb.LoadUserArg{Contextified: libkb.NewContextified(e.G())}
-	arg.SetGlobalContext(e.G())
+	arg := libkb.NewLoadUserArg(e.G())
 	if len(e.Username) > 0 {
-		arg.Name = e.Username
+		arg = arg.WithName(e.Username)
 	} else {
-		arg.Self = true
+		arg = arg.WithSelf(true)
 	}
 
 	var err error

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -75,8 +75,8 @@ func (e *TrackEngine) Run(ctx *Context) error {
 
 	upk := ieng.Result().Upk
 	var err error
-	loadarg := libkb.NewLoadUserArgBase(e.G()).WithNetContext(ctx.NetContext).WithUID(upk.Uid).WithPublicKeyOptional()
-	e.them, err = libkb.LoadUser(*loadarg)
+	loadarg := libkb.NewLoadUserArg(e.G()).WithNetContext(ctx.NetContext).WithUID(upk.Uid).WithPublicKeyOptional()
+	e.them, err = libkb.LoadUser(loadarg)
 	if err != nil {
 		return err
 	}

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -182,8 +182,7 @@ func (e *TrackToken) loadMe() error {
 
 func (e *TrackToken) loadThem(username libkb.NormalizedUsername) error {
 
-	arg := libkb.NewLoadUserByNameArg(e.G(), username.String())
-	arg.PublicKeyOptional = true
+	arg := libkb.NewLoadUserByNameArg(e.G(), username.String()).WithPublicKeyOptional()
 	them, err := libkb.LoadUser(arg)
 	if err != nil {
 		return err

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -38,8 +38,7 @@ func TestLoadDeviceKeyNew(t *testing.T) {
 		tc.T.Fatal(err)
 	}
 	t.Logf("using username:%+v", fu.Username)
-	loadArg := libkb.NewLoadUserByNameArg(tc.G, fu.Username)
-	loadArg.PublicKeyOptional = true
+	loadArg := libkb.NewLoadUserByNameArg(tc.G, fu.Username).WithPublicKeyOptional()
 	user, err := libkb.LoadUser(loadArg)
 	if err != nil {
 		tc.T.Fatal(err)
@@ -135,8 +134,7 @@ func TestLoadDeviceKeyRevoked(t *testing.T) {
 
 	fu := CreateAndSignupFakeUserPaper(tc, "rev")
 	t.Logf("using username:%+v", fu.Username)
-	loadArg := libkb.NewLoadUserByNameArg(tc.G, fu.Username)
-	loadArg.PublicKeyOptional = true
+	loadArg := libkb.NewLoadUserByNameArg(tc.G, fu.Username).WithPublicKeyOptional()
 	user, err := libkb.LoadUser(loadArg)
 	if err != nil {
 		tc.T.Fatal(err)
@@ -349,11 +347,7 @@ func TestLoadAfterAcctReset1(t *testing.T) {
 
 	loadUpak := func() error {
 		t.Logf("loadUpak: using username:%+v", fu.Username)
-		loadArg := libkb.NewLoadUserArg(tc.G)
-		loadArg.UID = fu.UID()
-		loadArg.PublicKeyOptional = false
-		loadArg.NetContext = context.TODO()
-		loadArg.StaleOK = false
+		loadArg := libkb.NewLoadUserArg(tc.G).WithUID(fu.UID()).WithNetContext(context.TODO()).WithStaleOK(false)
 
 		upak, _, err := tc.G.GetUPAKLoader().Load(loadArg)
 		if err != nil {
@@ -407,12 +401,7 @@ func TestLoadAfterAcctReset2(t *testing.T) {
 
 	loadUpak := func() (*keybase1.UserPlusAllKeys, error) {
 		t.Logf("loadUpak: using username:%+v", fu.Username)
-		loadArg := libkb.NewLoadUserArg(tc.G)
-		loadArg.UID = fu.UID()
-		loadArg.PublicKeyOptional = false
-		loadArg.NetContext = context.TODO()
-		loadArg.StaleOK = false
-
+		loadArg := libkb.NewLoadUserArg(tc.G).WithUID(fu.UID()).WithPublicKeyOptional().WithNetContext(context.TODO()).WithStaleOK(false)
 		upak, _, err := tc.G.GetUPAKLoader().Load(loadArg)
 		if err != nil {
 			return nil, err

--- a/go/git/get.go
+++ b/go/git/get.go
@@ -191,7 +191,7 @@ func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keyba
 		}
 
 		// Load UPAKs to get the last writer username and device name.
-		lastWriterUPAK, _, err := g.GetUPAKLoader().LoadV2(libkb.LoadUserArg{UID: responseRepo.LastModifyingUID})
+		lastWriterUPAK, _, err := g.GetUPAKLoader().LoadV2(libkb.NewLoadUserArg(g).WithUID(responseRepo.LastModifyingUID))
 		if err != nil {
 			return nil, err
 		}
@@ -213,7 +213,7 @@ func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keyba
 		if err != nil {
 			return nil, err
 		}
-		selfUPAK, _, err := g.GetUPAKLoader().LoadV2(libkb.LoadUserArg{UID: g.Env.GetUID()})
+		selfUPAK, _, err := g.GetUPAKLoader().LoadV2(libkb.NewLoadUserArg(g).WithSelf(true).WithUID(g.GetMyUID()))
 		if err != nil {
 			return nil, err
 		}

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -413,7 +413,7 @@ func (a *Account) UserInfo() (uid keybase1.UID, username NormalizedUsername,
 		return
 	}
 
-	arg := LoadUserArg{LoginContext: a, Contextified: NewContextified(a.G()), Self: true}
+	arg := NewLoadUserArg(a.G()).WithLoginContext(a).WithSelf(true)
 	err = a.G().GetFullSelfer().WithUser(arg, func(user *User) error {
 		var err error
 		deviceSubkey, err = user.GetDeviceSubkey()

--- a/go/libkb/bug_3964_repairman.go
+++ b/go/libkb/bug_3964_repairman.go
@@ -121,7 +121,7 @@ func (b *bug3964Repairman) fixLKSClientHalf(lctx LoginContext, lksec *LKSec, ppg
 	var encKey GenericKey
 	var ctext string
 
-	me, err = LoadMe(LoadUserArg{Contextified: NewContextified(b.G()), LoginContext: lctx})
+	me, err = LoadMe(NewLoadUserArg(b.G()).WithLoginContext(lctx))
 	if err != nil {
 		return err
 	}

--- a/go/libkb/check_tracking.go
+++ b/go/libkb/check_tracking.go
@@ -6,8 +6,7 @@ package libkb
 func CheckTracking(g *GlobalContext) error {
 	// LoadUser automatically fires off UserChanged notifications when it
 	// discovers new track or untrack chain links.
-	arg := NewLoadUserArg(g)
-	arg.AbortIfSigchainUnchanged = true
+	arg := NewLoadUserArg(g).WithAbortIfSigchainUnchanged()
 	_, err := LoadMe(arg)
 	return err
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -907,8 +907,7 @@ func (g *GlobalContext) SetTeamLoader(l TeamLoader) {
 }
 
 func (g *GlobalContext) LoadUserByUID(uid keybase1.UID) (*User, error) {
-	arg := NewLoadUserByUIDArg(nil, g, uid)
-	arg.PublicKeyOptional = true
+	arg := NewLoadUserByUIDArg(nil, g, uid).WithPublicKeyOptional()
 	return LoadUser(arg)
 }
 

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -15,18 +15,18 @@ import (
 
 type LoadUserArg struct {
 	Contextified
-	UID                      keybase1.UID
-	Name                     string // Can also be an assertion like foo@twitter
-	PublicKeyOptional        bool
-	NoCacheResult            bool // currently ignore
-	Self                     bool
-	ForceReload              bool
-	ForcePoll                bool // for cached user load, force a repoll
-	StaleOK                  bool // if stale cached versions are OK (for immutable fields)
-	CachedOnly               bool // only return cached data (StaleOK should be true as well)
-	LoginContext             LoginContext
-	AbortIfSigchainUnchanged bool
-	ResolveBody              *jsonw.Wrapper // some load paths plumb this through
+	uid                      keybase1.UID
+	name                     string // Can also be an assertion like foo@twitter
+	publicKeyOptional        bool
+	noCacheResult            bool // currently ignore
+	self                     bool
+	forceReload              bool
+	forcePoll                bool // for cached user load, force a repoll
+	staleOK                  bool // if stale cached versions are OK (for immutable fields)
+	cachedOnly               bool // only return cached data (StaleOK should be true as well)
+	loginContext             LoginContext
+	abortIfSigchainUnchanged bool
+	resolveBody              *jsonw.Wrapper // some load paths plumb this through
 
 	// NOTE: We used to have these feature flags, but we got rid of them, to
 	// avoid problems where a yes-features load doesn't accidentally get served
@@ -38,18 +38,18 @@ type LoadUserArg struct {
 
 	// We might have already loaded these if we're falling back from a
 	// failed LoadUserPlusKeys load
-	MerkleLeaf *MerkleUserLeaf
-	SigHints   *SigHints
+	merkleLeaf *MerkleUserLeaf
+	sigHints   *SigHints
 
 	// NetContext is the context to build on top of.  We'll make a new
 	// Debug Tag for this LoadUser Operation.
-	NetContext context.Context
+	netContext context.Context
 }
 
 func (arg LoadUserArg) String() string {
 	return fmt.Sprintf("{UID:%s Name:%q PublicKeyOptional:%v NoCacheResult:%v Self:%v ForceReload:%v ForcePoll:%v StaleOK:%v AbortIfSigchainUnchanged:%v CachedOnly:%v}",
-		arg.UID, arg.Name, arg.PublicKeyOptional, arg.NoCacheResult, arg.Self, arg.ForceReload,
-		arg.ForcePoll, arg.StaleOK, arg.AbortIfSigchainUnchanged, arg.CachedOnly)
+		arg.uid, arg.name, arg.publicKeyOptional, arg.noCacheResult, arg.self, arg.forceReload,
+		arg.forcePoll, arg.staleOK, arg.abortIfSigchainUnchanged, arg.cachedOnly)
 }
 
 func NewLoadUserArg(g *GlobalContext) LoadUserArg {
@@ -59,80 +59,96 @@ func NewLoadUserArg(g *GlobalContext) LoadUserArg {
 func NewLoadUserArgWithContext(ctx context.Context, g *GlobalContext) LoadUserArg {
 	return LoadUserArg{
 		Contextified: NewContextified(g),
-		NetContext:   ctx,
+		netContext:   ctx,
 	}
 }
 
 func NewLoadUserSelfArg(g *GlobalContext) LoadUserArg {
 	ret := NewLoadUserArg(g)
-	ret.Self = true
+	ret.self = true
 	return ret
 }
 
 func NewLoadUserForceArg(g *GlobalContext) LoadUserArg {
 	arg := NewLoadUserPubOptionalArg(g)
-	arg.ForceReload = true
+	arg.forceReload = true
 	return arg
 }
 
 func NewLoadUserByNameArg(g *GlobalContext, name string) LoadUserArg {
 	arg := NewLoadUserArg(g)
-	arg.Name = name
+	arg.name = name
 	return arg
 }
 
 func NewLoadUserByUIDArg(ctx context.Context, g *GlobalContext, uid keybase1.UID) LoadUserArg {
 	arg := NewLoadUserArg(g)
-	arg.UID = uid
-	arg.NetContext = ctx
+	arg.uid = uid
+	arg.netContext = ctx
 	return arg
 }
 
 func NewLoadUserByUIDForceArg(g *GlobalContext, uid keybase1.UID) LoadUserArg {
 	arg := NewLoadUserArg(g)
-	arg.UID = uid
-	arg.ForceReload = true
+	arg.uid = uid
+	arg.forceReload = true
 	return arg
 }
 
 func NewLoadUserPubOptionalArg(g *GlobalContext) LoadUserArg {
 	arg := NewLoadUserArg(g)
-	arg.PublicKeyOptional = true
+	arg.publicKeyOptional = true
 	return arg
 }
 
-func NewLoadUserArgBase(g *GlobalContext) *LoadUserArg {
-	return &LoadUserArg{Contextified: NewContextified(g)}
-}
-
-func (arg *LoadUserArg) WithSelf(self bool) *LoadUserArg {
-	arg.Self = self
+func (arg LoadUserArg) WithSelf(self bool) LoadUserArg {
+	arg.self = self
 	return arg
 }
 
-func (arg *LoadUserArg) WithNetContext(ctx context.Context) *LoadUserArg {
-	arg.NetContext = ctx
+func (arg LoadUserArg) WithCachedOnly() LoadUserArg {
+	arg.cachedOnly = true
 	return arg
 }
 
-func (arg *LoadUserArg) WithUID(uid keybase1.UID) *LoadUserArg {
-	arg.UID = uid
+func (arg LoadUserArg) WithResolveBody(r *jsonw.Wrapper) LoadUserArg {
+	arg.resolveBody = r
 	return arg
 }
 
-func (arg *LoadUserArg) WithPublicKeyOptional() *LoadUserArg {
-	arg.PublicKeyOptional = true
+func (arg LoadUserArg) WithName(n string) LoadUserArg {
+	arg.name = n
 	return arg
 }
 
-func (arg *LoadUserArg) WithForcePoll() *LoadUserArg {
-	arg.ForcePoll = true
+func (arg LoadUserArg) WithNetContext(ctx context.Context) LoadUserArg {
+	arg.netContext = ctx
 	return arg
 }
 
-func (arg *LoadUserArg) GetNetContext() context.Context {
-	if arg.NetContext != nil {
-		return arg.NetContext
+func (arg LoadUserArg) WithUID(uid keybase1.UID) LoadUserArg {
+	arg.uid = uid
+	return arg
+}
+
+func (arg LoadUserArg) WithPublicKeyOptional() LoadUserArg {
+	arg.publicKeyOptional = true
+	return arg
+}
+
+func (arg LoadUserArg) WithForcePoll(fp bool) LoadUserArg {
+	arg.forcePoll = fp
+	return arg
+}
+
+func (arg LoadUserArg) WithStaleOK(b bool) LoadUserArg {
+	arg.staleOK = b
+	return arg
+}
+
+func (arg LoadUserArg) GetNetContext() context.Context {
+	if arg.netContext != nil {
+		return arg.netContext
 	}
 	if ctx := arg.G().NetContext; ctx != nil {
 		return ctx
@@ -140,33 +156,48 @@ func (arg *LoadUserArg) GetNetContext() context.Context {
 	return context.Background()
 }
 
+func (arg LoadUserArg) WithLoginContext(l LoginContext) LoadUserArg {
+	arg.loginContext = l
+	return arg
+}
+
+func (arg LoadUserArg) WithAbortIfSigchainUnchanged() LoadUserArg {
+	arg.abortIfSigchainUnchanged = true
+	return arg
+}
+
+func (arg LoadUserArg) WithForceReload() LoadUserArg {
+	arg.forceReload = true
+	return arg
+}
+
 func (arg *LoadUserArg) WithLogTag() context.Context {
 	ctx := WithLogTag(arg.GetNetContext(), "LU")
-	arg.NetContext = ctx
+	arg.netContext = ctx
 	arg.SetGlobalContext(arg.G().CloneWithNetContextAndNewLogger(ctx))
 	return ctx
 }
 
 func (arg *LoadUserArg) checkUIDName() error {
-	if arg.UID.Exists() {
+	if arg.uid.Exists() {
 		return nil
 	}
 
-	if len(arg.Name) == 0 && !arg.Self {
+	if len(arg.name) == 0 && !arg.self {
 		return fmt.Errorf("no username given to LoadUser")
 	}
 
-	if len(arg.Name) > 0 && arg.Self {
+	if len(arg.name) > 0 && arg.self {
 		return fmt.Errorf("If loading self, can't provide a username")
 	}
 
-	if !arg.Self {
+	if !arg.self {
 		return nil
 	}
 
-	if arg.UID = myUID(arg.G(), arg.LoginContext); arg.UID.IsNil() {
-		arg.Name = arg.G().Env.GetUsername().String()
-		if len(arg.Name) == 0 {
+	if arg.uid = myUID(arg.G(), arg.loginContext); arg.uid.IsNil() {
+		arg.name = arg.G().Env.GetUsername().String()
+		if len(arg.name) == 0 {
 			return SelfNotFoundError{msg: "could not find UID or username for self"}
 		}
 	}
@@ -175,41 +206,41 @@ func (arg *LoadUserArg) checkUIDName() error {
 
 func (arg *LoadUserArg) resolveUID() (ResolveResult, error) {
 	var rres ResolveResult
-	if arg.UID.Exists() {
+	if arg.uid.Exists() {
 		return rres, nil
 	}
-	if len(arg.Name) == 0 {
+	if len(arg.name) == 0 {
 		// this won't happen anymore because check moved to
 		// checkUIDName() func, but just in case
 		return rres, fmt.Errorf("resolveUID: no uid or name")
 	}
 
-	if rres = arg.G().Resolver.ResolveWithBody(arg.Name); rres.err != nil {
+	if rres = arg.G().Resolver.ResolveWithBody(arg.name); rres.err != nil {
 		return rres, rres.err
 	}
 
 	if rres.uid.IsNil() {
-		return rres, fmt.Errorf("No resolution for name=%s", arg.Name)
+		return rres, fmt.Errorf("No resolution for name=%s", arg.name)
 	}
 
-	arg.UID = rres.uid
+	arg.uid = rres.uid
 	return rres, nil
 }
 
 // after resolution, check if this is a self load
 func (arg *LoadUserArg) checkSelf() {
-	if arg.Self {
+	if arg.self {
 		return
 	}
 
-	myuid := myUID(arg.G(), arg.LoginContext)
-	if myuid.Exists() && arg.UID.Exists() && myuid.Equal(arg.UID) {
-		arg.Self = true
+	myuid := myUID(arg.G(), arg.loginContext)
+	if myuid.Exists() && arg.uid.Exists() && myuid.Equal(arg.uid) {
+		arg.self = true
 	}
 }
 
 func LoadMe(arg LoadUserArg) (*User, error) {
-	arg.Self = true
+	arg.self = true
 	return LoadUser(arg)
 }
 
@@ -243,7 +274,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 		return nil, err
 	}
 
-	arg.G().Log.CDebugf(ctx, "+ LoadUser(uid=%v, name=%v)", arg.UID, arg.Name)
+	arg.G().Log.CDebugf(ctx, "+ LoadUser(uid=%v, name=%v)", arg.uid, arg.name)
 
 	// resolve the uid from the name, if necessary
 	rres, err := arg.resolveUID()
@@ -254,27 +285,27 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	// check to see if this is a self load
 	arg.checkSelf()
 
-	arg.G().Log.CDebugf(ctx, "| resolved to %s", arg.UID)
+	arg.G().Log.CDebugf(ctx, "| resolved to %s", arg.uid)
 
 	// We can get the user object's body from either the resolution result or
 	// if it was plumbed through as a parameter.
 	resolveBody := rres.body
 	if resolveBody == nil {
-		resolveBody = arg.ResolveBody
+		resolveBody = arg.resolveBody
 	}
 
 	// get sig hints from local db in order to populate during merkle leaf lookup
 	// They might have already been loaded in.
 	var sigHints *SigHints
-	if sigHints = arg.SigHints; sigHints == nil {
-		sigHints, err = LoadSigHints(ctx, arg.UID, arg.G())
+	if sigHints = arg.sigHints; sigHints == nil {
+		sigHints, err = LoadSigHints(ctx, arg.uid, arg.G())
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// load user from local, remote
-	ret, refresh, err = loadUser(ctx, arg.G(), arg.UID, resolveBody, sigHints, arg.ForceReload, arg.MerkleLeaf)
+	ret, refresh, err = loadUser(ctx, arg.G(), arg.uid, resolveBody, sigHints, arg.forceReload, arg.merkleLeaf)
 	if err != nil {
 		return nil, err
 	}
@@ -284,15 +315,15 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	// Match the returned User object to the Merkle tree. Also make sure
 	// that the username queried for matches the User returned (if it
 	// was indeed queried for)
-	if err = ret.leaf.MatchUser(ret, arg.UID, rres.GetNormalizedQueriedUsername()); err != nil {
+	if err = ret.leaf.MatchUser(ret, arg.uid, rres.GetNormalizedQueriedUsername()); err != nil {
 		return ret, err
 	}
 
-	if err = ret.LoadSigChains(ctx, &ret.leaf, arg.Self); err != nil {
+	if err = ret.LoadSigChains(ctx, &ret.leaf, arg.self); err != nil {
 		return ret, err
 	}
 
-	if arg.AbortIfSigchainUnchanged && ret.sigChain().wasFullyCached {
+	if arg.abortIfSigchainUnchanged && ret.sigChain().wasFullyCached {
 		return nil, nil
 	}
 
@@ -316,11 +347,11 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 			return ret, err
 		}
 
-	} else if !arg.PublicKeyOptional {
+	} else if !arg.publicKeyOptional {
 		arg.G().Log.CDebugf(ctx, "No active key for user: %s", ret.GetUID())
 
 		var emsg string
-		if arg.Self {
+		if arg.self {
 			emsg = "You don't have a public key; try `keybase pgp select` or `keybase pgp import` if you have a key; or `keybase pgp gen` if you don't"
 		}
 		err = NoKeyError{emsg}

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -69,6 +69,13 @@ func NewLoadUserSelfArg(g *GlobalContext) LoadUserArg {
 	return ret
 }
 
+func NewLoadUserSelfAndUIDArg(g *GlobalContext) LoadUserArg {
+	ret := NewLoadUserArg(g)
+	ret.self = true
+	ret.uid = g.GetMyUID()
+	return ret
+}
+
 func NewLoadUserForceArg(g *GlobalContext) LoadUserArg {
 	arg := NewLoadUserPubOptionalArg(g)
 	arg.forceReload = true

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -566,7 +566,7 @@ func (s *LoginState) pubkeyLoginHelper(lctx LoginContext, username string, getSe
 	}
 
 	var me *User
-	if me, err = LoadUser(LoadUserArg{Name: username, LoginContext: lctx, Contextified: NewContextified(s.G())}); err != nil {
+	if me, err = LoadUser(NewLoadUserByNameArg(s.G(), username).WithLoginContext(lctx)); err != nil {
 		return
 	}
 

--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -454,8 +454,7 @@ func (s *PerUserKeyring) getUPAK(ctx context.Context, lctx LoginContext, upak *k
 	if upak != nil {
 		return upak, nil
 	}
-	upakArg := NewLoadUserByUIDArg(ctx, s.G(), s.uid)
-	upakArg.LoginContext = lctx
+	upakArg := NewLoadUserByUIDArg(ctx, s.G(), s.uid).WithLoginContext(lctx)
 	upak, _, err := s.G().GetUPAKLoader().Load(upakArg)
 	return upak, err
 }

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -243,20 +243,20 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 	// Add a LU= tax to this context, for all subsequent debugging
 	ctx := arg.WithLogTag()
 
-	defer g.CVTrace(ctx, VLog0, culDebug(arg.UID), func() error { return err })()
+	defer g.CVTrace(ctx, VLog0, culDebug(arg.uid), func() error { return err })()
 
-	if arg.UID.IsNil() {
-		if len(arg.Name) == 0 {
+	if arg.uid.IsNil() {
+		if len(arg.name) == 0 {
 			return nil, nil, errors.New("need a UID or username to load UPAK from loader")
 		}
 		// Modifies the load arg, setting a UID
-		arg.UID, err = u.LookupUID(ctx, NewNormalizedUsername(arg.Name))
+		arg.uid, err = u.LookupUID(ctx, NewNormalizedUsername(arg.name))
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
-	lock := u.locktab.AcquireOnName(ctx, g, arg.UID.String())
+	lock := u.locktab.AcquireOnName(ctx, g, arg.uid.String())
 
 	defer func() {
 		lock.Release(ctx)
@@ -291,17 +291,17 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 	var upak *keybase1.UserPlusKeysV2AllIncarnations
 	var fresh bool
 
-	if !arg.ForceReload {
-		upak, fresh = u.getCachedUPAK(ctx, arg.UID, info)
+	if !arg.forceReload {
+		upak, fresh = u.getCachedUPAK(ctx, arg.uid, info)
 	}
-	if arg.ForcePoll {
-		g.VDL.CLogf(ctx, VLog0, "%s: force-poll required us to repoll (fresh=%v)", culDebug(arg.UID), fresh)
+	if arg.forcePoll {
+		g.VDL.CLogf(ctx, VLog0, "%s: force-poll required us to repoll (fresh=%v)", culDebug(arg.uid), fresh)
 		fresh = false
 	}
 
 	if upak != nil {
-		g.VDL.CLogf(ctx, VLog0, "%s: cache-hit; fresh=%v", culDebug(arg.UID), fresh)
-		if fresh || arg.StaleOK {
+		g.VDL.CLogf(ctx, VLog0, "%s: cache-hit; fresh=%v", culDebug(arg.uid), fresh)
+		if fresh || arg.staleOK {
 			return returnUPAK(upak, true)
 		}
 		if info != nil {
@@ -311,7 +311,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		var sigHints *SigHints
 		var leaf *MerkleUserLeaf
 
-		sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(ctx, u.G(), arg.UID, true)
+		sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(ctx, u.G(), arg.uid, true)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -321,21 +321,21 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		}
 
 		if leaf.eldest == "" {
-			g.VDL.CLogf(ctx, VLog0, "%s: cache-hit; but user is nuked, evicting", culDebug(arg.UID))
+			g.VDL.CLogf(ctx, VLog0, "%s: cache-hit; but user is nuked, evicting", culDebug(arg.uid))
 
 			// Our cached user turned out to be in reset state (without
 			// current sigchain), remove from cache, and then fall
 			// through. LoadUser shall return an error, which we will
 			// return to the caller.
-			u.removeMemCache(ctx, arg.UID)
+			u.removeMemCache(ctx, arg.uid)
 
-			err := u.G().LocalDb.Delete(culDBKeyV2(arg.UID))
+			err := u.G().LocalDb.Delete(culDBKeyV2(arg.uid))
 			if err != nil {
-				u.G().Log.Warning("Failed to remove %s from disk cache: %s", arg.UID, err)
+				u.G().Log.Warning("Failed to remove %s from disk cache: %s", arg.uid, err)
 			}
-			u.deleteV1UPAK(arg.UID)
+			u.deleteV1UPAK(arg.uid)
 		} else if leaf.public != nil && leaf.public.Seqno == keybase1.Seqno(upak.Uvv.SigChain) {
-			g.VDL.CLogf(ctx, VLog0, "%s: cache-hit; fresh after poll", culDebug(arg.UID))
+			g.VDL.CLogf(ctx, VLog0, "%s: cache-hit; fresh after poll", culDebug(arg.uid))
 
 			upak.Uvv.CachedAt = keybase1.ToTime(g.Clock().Now())
 			// This is only necessary to update the levelDB representation,
@@ -348,13 +348,13 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		if info != nil {
 			info.StaleVersion = true
 		}
-		arg.SigHints = sigHints
-		arg.MerkleLeaf = leaf
-	} else if arg.CachedOnly {
-		return nil, nil, UserNotFoundError{UID: arg.UID, Msg: "no cached user found"}
+		arg.sigHints = sigHints
+		arg.merkleLeaf = leaf
+	} else if arg.cachedOnly {
+		return nil, nil, UserNotFoundError{UID: arg.uid, Msg: "no cached user found"}
 	}
 
-	g.VDL.CLogf(ctx, VLog0, "%s: LoadUser", culDebug(arg.UID))
+	g.VDL.CLogf(ctx, VLog0, "%s: LoadUser", culDebug(arg.uid))
 	user, err = LoadUser(arg)
 	if info != nil {
 		info.LoadedUser = true
@@ -378,7 +378,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 	}
 
 	if user == nil {
-		return nil, nil, UserNotFoundError{UID: arg.UID, Msg: "LoadUser failed"}
+		return nil, nil, UserNotFoundError{UID: arg.uid, Msg: "LoadUser failed"}
 	}
 
 	err = u.putUPAKToCache(ctx, ret)
@@ -422,8 +422,7 @@ func (u *CachedUPAKLoader) LoadV2(arg LoadUserArg) (*keybase1.UserPlusKeysV2AllI
 func (u *CachedUPAKLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error) {
 
 	var info CachedUserLoadInfo
-	larg := NewLoadUserByUIDArg(ctx, u.G(), uid)
-	larg.PublicKeyOptional = true
+	larg := NewLoadUserByUIDArg(ctx, u.G(), uid).WithPublicKeyOptional()
 	upak, _, err := u.loadWithInfo(larg, &info, nil, false)
 
 	if err != nil {
@@ -433,7 +432,7 @@ func (u *CachedUPAKLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID,
 	if found || info.LoadedLeaf || info.LoadedUser {
 		return found, revokedAt, deleted, nil
 	}
-	larg.ForceReload = true
+	larg = larg.WithForceReload()
 	upak, _, err = u.loadWithInfo(larg, nil, nil, false)
 	if err != nil {
 		return false, nil, false, err
@@ -448,16 +447,12 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 		return up, NoUIDError{}
 	}
 
-	arg := NewLoadUserArg(u.G())
-	arg.UID = uid
-	arg.PublicKeyOptional = true
-	arg.NetContext = ctx
-
+	arg := NewLoadUserArg(u.G()).WithUID(uid).WithPublicKeyOptional().WithNetContext(ctx)
 	forcePollValues := []bool{false, true}
 
 	for _, fp := range forcePollValues {
 
-		arg.ForcePoll = fp
+		arg = arg.WithForcePoll(fp)
 
 		upak, _, err := u.Load(arg)
 		if err != nil {
@@ -484,16 +479,13 @@ func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid 
 		return nil, nil, nil, NoUIDError{}
 	}
 
-	arg := NewLoadUserArg(u.G())
-	arg.UID = uid
-	arg.PublicKeyOptional = true
-	arg.NetContext = ctx
+	arg := NewLoadUserArg(u.G()).WithUID(uid).WithPublicKeyOptional().WithNetContext(ctx)
 
 	forcePollValues := []bool{false, true}
 
 	for _, fp := range forcePollValues {
 
-		arg.ForcePoll = fp
+		arg = arg.WithForcePoll(fp)
 
 		upak, _, err := u.LoadV2(arg)
 		if err != nil {
@@ -552,7 +544,7 @@ func (u *CachedUPAKLoader) LoadDeviceKey(ctx context.Context, uid keybase1.UID, 
 	}
 
 	// Try again with a forced load in case the device is very new.
-	larg.ForcePoll = true
+	larg = larg.WithForcePoll(true)
 	upakV2, _, err = u.loadWithInfo(larg, nil, nil, false)
 	if err != nil {
 		return nil, nil, nil, err
@@ -565,8 +557,7 @@ func (u *CachedUPAKLoader) LoadDeviceKey(ctx context.Context, uid keybase1.UID, 
 
 func (u *CachedUPAKLoader) LookupUsername(ctx context.Context, uid keybase1.UID) (NormalizedUsername, error) {
 	var info CachedUserLoadInfo
-	arg := NewLoadUserByUIDArg(ctx, u.G(), uid)
-	arg.StaleOK = true
+	arg := NewLoadUserByUIDArg(ctx, u.G(), uid).WithStaleOK(true)
 	var ret NormalizedUsername
 	_, _, err := u.loadWithInfo(arg, &info, func(upak *keybase1.UserPlusKeysV2AllIncarnations) error {
 		if upak == nil {
@@ -605,7 +596,7 @@ func (u *CachedUPAKLoader) lookupUsernameAndDeviceWithInfo(ctx context.Context, 
 	// mappings, so the second time through, we request a fresh object.
 	staleOK := []bool{true, false}
 	for _, b := range staleOK {
-		arg.StaleOK = b
+		arg = arg.WithStaleOK(b)
 		found := false
 		u.loadWithInfo(arg, info, func(upak *keybase1.UserPlusKeysV2AllIncarnations) error {
 			if upak == nil {

--- a/go/libkb/upak_loader_test.go
+++ b/go/libkb/upak_loader_test.go
@@ -22,9 +22,7 @@ func TestCachedUserLoad(t *testing.T) {
 	tc.G.SetClock(fakeClock)
 
 	// Load t_alice a few different ways
-	arg := LoadUserArg{
-		UID: keybase1.UID("295a7eea607af32040647123732bc819"),
-	}
+	arg := NewLoadUserArg(tc.G).WithUID(keybase1.UID("295a7eea607af32040647123732bc819"))
 	var info CachedUserLoadInfo
 	_, _, err := tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &info, nil, true)
 	if err != nil {
@@ -113,8 +111,7 @@ func TestCacheFallbacks(t *testing.T) {
 	test := func() *CachedUserLoadInfo {
 		var ret CachedUserLoadInfo
 		uid := keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")
-		var arg LoadUserArg
-		arg.UID = uid
+		arg := NewLoadUserArg(tc.G).WithUID(uid)
 		upk, _, err := tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &ret, nil, false)
 		require.NoError(t, err)
 		require.Equal(t, upk.Current.Username, "t_tracy", "tracy was right")

--- a/go/service/git.go
+++ b/go/service/git.go
@@ -54,7 +54,7 @@ func isRoleAtLeast(ctx context.Context, g *libkb.GlobalContext, teamName string,
 	if err != nil {
 		return false, err
 	}
-	self, _, err := g.GetUPAKLoader().LoadV2(libkb.LoadUserArg{UID: g.GetMyUID()})
+	self, _, err := g.GetUPAKLoader().LoadV2(libkb.NewLoadUserSelfAndUIDArg(g))
 	if err != nil {
 		return false, err
 	}

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -99,9 +99,7 @@ func (h *TrackHandler) CheckTracking(_ context.Context, sessionID int) error {
 }
 
 func (h *TrackHandler) FakeTrackingChanged(_ context.Context, arg keybase1.FakeTrackingChangedArg) error {
-	user, err := libkb.LoadUser(libkb.LoadUserArg{
-		Name: arg.Username,
-	})
+	user, err := libkb.LoadUser(libkb.NewLoadUserArg(h.G()).WithName(arg.Username))
 	if err != nil {
 		return err
 	}

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -99,8 +99,7 @@ func (h *UserHandler) ListTrackingJSON(_ context.Context, arg keybase1.ListTrack
 }
 
 func (h *UserHandler) LoadUser(ctx context.Context, arg keybase1.LoadUserArg) (user keybase1.User, err error) {
-	loadUserArg := libkb.NewLoadUserByUIDArg(ctx, h.G(), arg.Uid)
-	loadUserArg.PublicKeyOptional = true
+	loadUserArg := libkb.NewLoadUserByUIDArg(ctx, h.G(), arg.Uid).WithPublicKeyOptional()
 	u, err := libkb.LoadUser(loadUserArg)
 	if err != nil {
 		return
@@ -111,8 +110,7 @@ func (h *UserHandler) LoadUser(ctx context.Context, arg keybase1.LoadUserArg) (u
 }
 
 func (h *UserHandler) LoadUserByName(_ context.Context, arg keybase1.LoadUserByNameArg) (user keybase1.User, err error) {
-	loadUserArg := libkb.NewLoadUserByNameArg(h.G(), arg.Username)
-	loadUserArg.PublicKeyOptional = true
+	loadUserArg := libkb.NewLoadUserByNameArg(h.G(), arg.Username).WithPublicKeyOptional()
 	u, err := libkb.LoadUser(loadUserArg)
 	if err != nil {
 		return
@@ -173,12 +171,12 @@ func (h *UserHandler) LoadMySettings(ctx context.Context, sessionID int) (us key
 }
 
 func (h *UserHandler) LoadPublicKeys(ctx context.Context, arg keybase1.LoadPublicKeysArg) (keys []keybase1.PublicKey, err error) {
-	larg := libkb.LoadUserArg{UID: arg.Uid, Contextified: libkb.NewContextified(h.G())}
+	larg := libkb.NewLoadUserArg(h.G()).WithUID(arg.Uid)
 	return h.loadPublicKeys(ctx, larg)
 }
 
 func (h *UserHandler) LoadMyPublicKeys(ctx context.Context, sessionID int) (keys []keybase1.PublicKey, err error) {
-	larg := libkb.LoadUserArg{Self: true, Contextified: libkb.NewContextified(h.G())}
+	larg := libkb.NewLoadUserArg(h.G()).WithSelf(true)
 	return h.loadPublicKeys(ctx, larg)
 }
 
@@ -260,10 +258,7 @@ func (h *UserHandler) ProfileEdit(nctx context.Context, arg keybase1.ProfileEdit
 }
 
 func (h *UserHandler) loadUsername(ctx context.Context, uid keybase1.UID) (string, error) {
-	arg := libkb.NewLoadUserByUIDArg(ctx, h.G(), uid)
-	arg.PublicKeyOptional = true
-	arg.StaleOK = true
-	arg.CachedOnly = true
+	arg := libkb.NewLoadUserByUIDArg(ctx, h.G(), uid).WithPublicKeyOptional().WithStaleOK(true).WithCachedOnly()
 	upak, _, err := h.G().GetUPAKLoader().Load(arg)
 	if err != nil {
 		return "", err

--- a/go/systests/common_test.go
+++ b/go/systests/common_test.go
@@ -136,8 +136,7 @@ func (n nullProvisionUI) ProvisionerSuccess(context.Context, keybase1.Provisione
 }
 
 func getActiveDevicesAndKeys(tc *libkb.TestContext, username string) ([]*libkb.Device, []libkb.GenericKey) {
-	arg := libkb.NewLoadUserByNameArg(tc.G, username)
-	arg.PublicKeyOptional = true
+	arg := libkb.NewLoadUserByNameArg(tc.G, username).WithPublicKeyOptional()
 	user, err := libkb.LoadUser(arg)
 	if err != nil {
 		tc.T.Fatal(err)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -623,10 +623,7 @@ func TestTeamSignedByRevokedDevice(t *testing.T) {
 
 	t.Logf("bob updates cache of alice's info")
 	{
-		arg := libkb.NewLoadUserArg(bob.tc.G)
-		arg.UID = alice.uid
-		arg.PublicKeyOptional = true
-		arg.ForcePoll = true
+		arg := libkb.NewLoadUserArg(bob.tc.G).WithUID(alice.uid).WithPublicKeyOptional().WithForcePoll(true)
 		_, _, err := bob.tc.G.GetUPAKLoader().LoadV2(arg)
 		require.NoError(t, err)
 	}
@@ -707,10 +704,7 @@ func TestTeamSignedByRevokedDevice2(t *testing.T) {
 
 	t.Logf("bob updates cache of alice's info")
 	{
-		arg := libkb.NewLoadUserArg(bob.tc.G)
-		arg.UID = alice.uid
-		arg.PublicKeyOptional = true
-		arg.ForcePoll = true
+		arg := libkb.NewLoadUserArg(bob.tc.G).WithUID(alice.uid).WithPublicKeyOptional().WithForcePoll(true)
 		_, _, err := bob.tc.G.GetUPAKLoader().LoadV2(arg)
 		require.NoError(t, err)
 	}

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -27,10 +27,8 @@ func CreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, impTeam key
 	// Load all the Keybase users
 	loadUsernameList := func(usernames []string) (res []*keybase1.UserPlusKeysV2, err error) {
 		for _, username := range usernames {
-			upak, _, err := g.GetUPAKLoader().LoadV2(libkb.LoadUserArg{
-				Name:       username,
-				NetContext: ctx,
-			})
+			arg := libkb.NewLoadUserArg(g).WithName(username).WithNetContext(ctx)
+			upak, _, err := g.GetUPAKLoader().LoadV2(arg)
 			if err != nil {
 				g.Log.CDebugf(ctx, "CreateImplicitTeam: failed to load user: %s msg: %s", username, err)
 				return res, err

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -206,7 +206,7 @@ func (l *LoaderContextG) merkleLookupTripleAtHashMeta(ctx context.Context, leafI
 
 func (l *LoaderContextG) forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap linkMapT, err error) {
 	arg := libkb.NewLoadUserArg(l.G()).WithNetContext(ctx).WithUID(uid).WithForcePoll(true)
-	upak, _, err := l.G().GetUPAKLoader().LoadV2(*arg)
+	upak, _, err := l.G().GetUPAKLoader().LoadV2(arg)
 	if err != nil {
 		return nil, err
 	}

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -110,12 +110,12 @@ func (l *LoaderContextG) getLinksFromServer(ctx context.Context,
 }
 
 func (l *LoaderContextG) getMe(ctx context.Context) (res keybase1.UserVersion, err error) {
-	loadMeArg := libkb.NewLoadUserArgBase(l.G()).
+	loadMeArg := libkb.NewLoadUserArg(l.G()).
 		WithNetContext(ctx).
 		WithUID(l.G().Env.GetUID()).
 		WithSelf(true).
 		WithPublicKeyOptional()
-	upak, _, err := l.G().GetUPAKLoader().LoadV2(*loadMeArg)
+	upak, _, err := l.G().GetUPAKLoader().LoadV2(loadMeArg)
 	if err != nil {
 		return keybase1.UserVersion{}, err
 	}
@@ -205,7 +205,7 @@ func (l *LoaderContextG) merkleLookupTripleAtHashMeta(ctx context.Context, leafI
 }
 
 func (l *LoaderContextG) forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap linkMapT, err error) {
-	arg := libkb.NewLoadUserArgBase(l.G()).WithNetContext(ctx).WithUID(uid).WithForcePoll()
+	arg := libkb.NewLoadUserArg(l.G()).WithNetContext(ctx).WithUID(uid).WithForcePoll(true)
 	upak, _, err := l.G().GetUPAKLoader().LoadV2(*arg)
 	if err != nil {
 		return nil, err

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -102,11 +102,11 @@ func (m *memberSet) loadGroup(ctx context.Context, g *libkb.GlobalContext, group
 func loadUPAK2(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, forcePoll bool) (ret *keybase1.UserPlusKeysV2AllIncarnations, err error) {
 	defer g.CTrace(ctx, fmt.Sprintf("loadUPAK2(%s)", uid), func() error { return err })()
 
-	arg := libkb.NewLoadUserArgBase(g).WithNetContext(ctx).WithUID(uid).WithPublicKeyOptional()
+	arg := libkb.NewLoadUserArg(g).WithNetContext(ctx).WithUID(uid).WithPublicKeyOptional()
 	if forcePoll {
-		arg = arg.WithForcePoll()
+		arg = arg.WithForcePoll(true)
 	}
-	upak, _, err := g.GetUPAKLoader().LoadV2(*arg)
+	upak, _, err := g.GetUPAKLoader().LoadV2(arg)
 	return upak, err
 }
 


### PR DESCRIPTION
- force all entry via NewLoadUserArg() and friends
- this should require, hopefully, the arg to always be contextified
- which will ease the nuking of libkb.G, since bad LoadUserArgs was the single biggest issue I saw