### PR TITLE
pass the notify_team query param when creating a git repo 

### DIFF
--- a/go/git/put.go
+++ b/go/git/put.go
@@ -50,6 +50,7 @@ func PutMetadata(ctx context.Context, g *libkb.GlobalContext, arg keybase1.PutGi
 			"key_generation":     libkb.I{Val: int(encryptedMetadata.Gen)},
 			"device_id":          libkb.S{Val: string(g.Env.GetDeviceID())},
 			"encryption_version": libkb.I{Val: encryptedMetadata.V},
+			"notify_team":        libkb.B{Val: arg.NotifyTeam},
 		},
 	}
 	_, err = g.GetAPI().Post(apiArg)

--- a/go/protocol/keybase1/git.go
+++ b/go/protocol/keybase1/git.go
@@ -166,16 +166,18 @@ func (o GitRepoResult) DeepCopy() GitRepoResult {
 }
 
 type PutGitMetadataArg struct {
-	Folder   Folder           `codec:"folder" json:"folder"`
-	RepoID   RepoID           `codec:"repoID" json:"repoID"`
-	Metadata GitLocalMetadata `codec:"metadata" json:"metadata"`
+	Folder     Folder           `codec:"folder" json:"folder"`
+	RepoID     RepoID           `codec:"repoID" json:"repoID"`
+	Metadata   GitLocalMetadata `codec:"metadata" json:"metadata"`
+	NotifyTeam bool             `codec:"notifyTeam" json:"notifyTeam"`
 }
 
 func (o PutGitMetadataArg) DeepCopy() PutGitMetadataArg {
 	return PutGitMetadataArg{
-		Folder:   o.Folder.DeepCopy(),
-		RepoID:   o.RepoID.DeepCopy(),
-		Metadata: o.Metadata.DeepCopy(),
+		Folder:     o.Folder.DeepCopy(),
+		RepoID:     o.RepoID.DeepCopy(),
+		Metadata:   o.Metadata.DeepCopy(),
+		NotifyTeam: o.NotifyTeam,
 	}
 }
 

--- a/protocol/avdl/keybase1/git.avdl
+++ b/protocol/avdl/keybase1/git.avdl
@@ -48,7 +48,8 @@ protocol git {
     string lastModifyingDeviceName;
   }
 
-  void putGitMetadata(Folder folder, RepoID repoID, GitLocalMetadata metadata);
+  // This RPC is only exposed for testing. Public commands won't call it directly.
+  void putGitMetadata(Folder folder, RepoID repoID, GitLocalMetadata metadata, boolean notifyTeam);
 
   record GitRepoResult {
     Folder folder;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5419,7 +5419,8 @@ export type gitGetGitMetadataRpcParam = Exact<{
 export type gitPutGitMetadataRpcParam = Exact<{
   folder: Folder,
   repoID: RepoID,
-  metadata: GitLocalMetadata
+  metadata: GitLocalMetadata,
+  notifyTeam: boolean
 }>
 
 export type gpgUiSelectKeyAndPushOptionRpcParam = Exact<{

--- a/protocol/json/keybase1/git.json
+++ b/protocol/json/keybase1/git.json
@@ -158,6 +158,10 @@
         {
           "name": "metadata",
           "type": "GitLocalMetadata"
+        },
+        {
+          "name": "notifyTeam",
+          "type": "boolean"
         }
       ],
       "response": null

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5419,7 +5419,8 @@ export type gitGetGitMetadataRpcParam = Exact<{
 export type gitPutGitMetadataRpcParam = Exact<{
   folder: Folder,
   repoID: RepoID,
-  metadata: GitLocalMetadata
+  metadata: GitLocalMetadata,
+  notifyTeam: boolean
 }>
 
 export type gpgUiSelectKeyAndPushOptionRpcParam = Exact<{


### PR DESCRIPTION
This used to be implicit, but it's easier to respect the "Notify the
team" checkbox if we make it explicit. We can do this, because KBFS is
dropping the feature where repos can magically be created just by
pushing them (which would not have gone through our create repo RPC).

Depends on https://github.com/keybase/keybase/pull/1764.

r? @mmaxim 