### PR TITLE
Make remove-member remove active invites, too

### DIFF
--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -248,7 +248,7 @@ func (c *CmdTeamListMemberships) outputRole(role string, members []keybase1.Team
 
 func (c *CmdTeamListMemberships) outputInvites(invites map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite) {
 	for _, invite := range invites {
-		fmtstring := "%s\t%s*\t%s\t(* invited by %s; awaiting acceptance)\n"
+		fmtstring := "%s\t%s*\t%s\t(* added by %s; awaiting acceptance)\n"
 		fmt.Fprintf(c.tabw, fmtstring, invite.TeamName, strings.ToLower(invite.Role.String()), invite.Name, invite.InviterUsername)
 	}
 }

--- a/go/client/cmd_team_remove_member.go
+++ b/go/client/cmd_team_remove_member.go
@@ -126,10 +126,23 @@ func (c *CmdTeamRemoveMember) Run() error {
 	}
 
 	if err = cli.TeamRemoveMember(context.Background(), arg); err != nil {
+		switch err.(type) {
+		case libkb.NotFoundError:
+			if len(c.Email) > 0 {
+				ui.Printf("Error: there is currently no pending invitation for %s.\nIf that person is already on your team, please remove them with their keybase username.\n\n", c.Email)
+				return nil
+			}
+			ui.Printf("Error: there is currently no user %s on team %s.\n\n", c.Username, c.Team)
+			return nil
+		}
 		return err
 	}
 
-	ui.Printf("Success! %s removed from team %s.\n", c.Username, c.Team)
+	if len(c.Email) > 0 {
+		ui.Printf("Success! %s invitation canceled for team %s.\n", c.Email, c.Team)
+	} else {
+		ui.Printf("Success! %s removed from team %s.\n", c.Username, c.Team)
+	}
 
 	return nil
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1507,6 +1507,10 @@ func (u UserVersion) TeamInviteName() TeamInviteName {
 	return TeamInviteName(u.PercentForm())
 }
 
+func (u UserVersion) IsNil() bool {
+	return u.Uid.IsNil()
+}
+
 type ByUserVersionID []UserVersion
 
 func (b ByUserVersionID) Len() int      { return len(b) }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -239,6 +239,7 @@ type TeamMemberDetails struct {
 	Uv       UserVersion `codec:"uv" json:"uv"`
 	Username string      `codec:"username" json:"username"`
 	Active   bool        `codec:"active" json:"active"`
+	NeedsPUK bool        `codec:"needsPUK" json:"needsPUK"`
 }
 
 func (o TeamMemberDetails) DeepCopy() TeamMemberDetails {
@@ -246,6 +247,7 @@ func (o TeamMemberDetails) DeepCopy() TeamMemberDetails {
 		Uv:       o.Uv.DeepCopy(),
 		Username: o.Username,
 		Active:   o.Active,
+		NeedsPUK: o.NeedsPUK,
 	}
 }
 
@@ -1144,6 +1146,7 @@ type AnnotatedMemberInfo struct {
 	IsImplicitTeam bool          `codec:"isImplicitTeam" json:"is_implicit_team"`
 	Role           TeamRole      `codec:"role" json:"role"`
 	Implicit       *ImplicitRole `codec:"implicit,omitempty" json:"implicit,omitempty"`
+	NeedsPUK       bool          `codec:"needsPUK" json:"needsPUK"`
 }
 
 func (o AnnotatedMemberInfo) DeepCopy() AnnotatedMemberInfo {
@@ -1162,6 +1165,7 @@ func (o AnnotatedMemberInfo) DeepCopy() AnnotatedMemberInfo {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Implicit),
+		NeedsPUK: o.NeedsPUK,
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1473,6 +1473,7 @@ type TeamRemoveMemberArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	Name      string `codec:"name" json:"name"`
 	Username  string `codec:"username" json:"username"`
+	Email     string `codec:"email" json:"email"`
 }
 
 func (o TeamRemoveMemberArg) DeepCopy() TeamRemoveMemberArg {
@@ -1480,6 +1481,7 @@ func (o TeamRemoveMemberArg) DeepCopy() TeamRemoveMemberArg {
 		SessionID: o.SessionID,
 		Name:      o.Name,
 		Username:  o.Username,
+		Email:     o.Email,
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -690,6 +690,7 @@ type AnnotatedTeamInvite struct {
 	Id              TeamInviteID   `codec:"id" json:"id"`
 	Type            TeamInviteType `codec:"type" json:"type"`
 	Name            TeamInviteName `codec:"name" json:"name"`
+	Uv              UserVersion    `codec:"uv" json:"uv"`
 	Inviter         UserVersion    `codec:"inviter" json:"inviter"`
 	InviterUsername string         `codec:"inviterUsername" json:"inviterUsername"`
 	TeamName        string         `codec:"teamName" json:"teamName"`
@@ -701,6 +702,7 @@ func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
 		Id:              o.Id.DeepCopy(),
 		Type:            o.Type.DeepCopy(),
 		Name:            o.Name.DeepCopy(),
+		Uv:              o.Uv.DeepCopy(),
 		Inviter:         o.Inviter.DeepCopy(),
 		InviterUsername: o.InviterUsername,
 		TeamName:        o.TeamName,

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -180,6 +180,12 @@ func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMe
 func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRemoveMemberArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRemoveMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
+
+	if len(arg.Email) > 0 {
+		h.G().Log.CDebugf(ctx, "TeamRemoveMember: received email address, using CancelEmailInvite for %q in team %q", arg.Email, arg.Name)
+		return teams.CancelEmailInvite(ctx, h.G().ExternalG(), arg.Name, arg.Email)
+	}
+	h.G().Log.CDebugf(ctx, "TeamRemoveMember: using RemoveMember for %q in team %q", arg.Username, arg.Name)
 	return teams.RemoveMember(ctx, h.G().ExternalG(), arg.Name, arg.Username)
 }
 

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -186,7 +186,7 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 			anMemberInfo, anInvites, retry, err := loadTeamForAMI(false)
 			if err != nil {
 				if retry {
-					anMemberInfo, anInvites, retry, err = loadTeamForAMI(false)
+					anMemberInfo, anInvites, retry, err = loadTeamForAMI(true)
 				}
 			}
 			if err != nil {
@@ -255,9 +255,11 @@ func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, invites map[ke
 		if err != nil {
 			return nil, err
 		}
+		var uv keybase1.UserVersion
 		if category == keybase1.TeamInviteCategory_KEYBASE {
 			// "keybase" invites (i.e. pukless users) have user version for name
-			uv, err := invite.KeybaseUserVersion()
+			var err error
+			uv, err = invite.KeybaseUserVersion()
 			if err != nil {
 				return nil, err
 			}
@@ -275,6 +277,7 @@ func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, invites map[ke
 			Id:              invite.Id,
 			Type:            invite.Type,
 			Name:            name,
+			Uv:              uv,
 			Inviter:         invite.Inviter,
 			InviterUsername: username.String(),
 			TeamName:        teamName,

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -778,7 +778,7 @@ func TestMemberCancelInviteEmail(t *testing.T) {
 	}
 	assertInvite(tc, name, address, "email", keybase1.TeamRole_READER)
 
-	if err := RemoveMember(context.TODO(), tc.G, name, address); err != nil {
+	if err := CancelEmailInvite(context.TODO(), tc.G, name, address); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -783,4 +783,22 @@ func TestMemberCancelInviteEmail(t *testing.T) {
 	}
 
 	assertNoInvite(tc, name, address, "email")
+
+	// check error type for an email address with no invite
+	err := CancelEmailInvite(context.TODO(), tc.G, name, "nope@keybase.io")
+	if err == nil {
+		t.Fatal("expected error canceling email invite for unknown email address")
+	}
+	if _, ok := err.(libkb.NotFoundError); !ok {
+		t.Errorf("expected libkb.NotFoundError, got %T", err)
+	}
+
+	// check error type for unknown team
+	err = CancelEmailInvite(context.TODO(), tc.G, "notateam", address)
+	if err == nil {
+		t.Fatal("expected error canceling email invite for unknown team")
+	}
+	if _, ok := err.(TeamDoesNotExistError); !ok {
+		t.Errorf("expected teams.TeamDoesNotExistError, got %T", err)
+	}
 }

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -398,6 +398,24 @@ func TestMemberAddNoKeys(t *testing.T) {
 
 	// existing invite should be untouched
 	assertInvite(tc, name, "561247eb1cc3b0f5dc9d9bf299da5e19%0", "keybase", keybase1.TeamRole_READER)
+
+	// this is a keybase user, so they should show up in the member list
+	// even though they are technically only "invited"
+	details, err := Details(context.TODO(), tc.G, name, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, m := range details.Members.Readers {
+		if m.Username == username {
+			found = true
+			break
+		}
+		t.Logf("not a match: %s != %s", m.Username, username)
+	}
+	if !found {
+		t.Fatal("keybase invited user not in membership list")
+	}
 }
 
 func TestMemberAddEmail(t *testing.T) {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -346,12 +346,6 @@ func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 		return err
 	}
 
-	// if username looks like an email address, then remove an invite
-	// (the loadUserVersionByUsername will fail with an email address)
-	if libkb.CheckEmail.F(username) {
-		return removeMemberInvite(ctx, g, t, username, keybase1.UserVersion{})
-	}
-
 	uv, err := loadUserVersionByUsername(ctx, g, username)
 	if err != nil {
 		if err == errInviteRequired {
@@ -375,6 +369,19 @@ func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 	}
 	req := keybase1.TeamChangeReq{None: []keybase1.UserVersion{existingUV}}
 	return t.ChangeMembership(ctx, req)
+}
+
+func CancelEmailInvite(ctx context.Context, g *libkb.GlobalContext, teamname, email string) error {
+	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
+	if err != nil {
+		return err
+	}
+
+	if !libkb.CheckEmail.F(email) {
+		return errors.New("Invalid email address")
+	}
+
+	return removeMemberInvite(ctx, g, t, email, keybase1.UserVersion{})
 }
 
 func Leave(ctx context.Context, g *libkb.GlobalContext, teamname string, permanent bool) error {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -61,16 +61,8 @@ func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepo
 		if cat != keybase1.TeamInviteCategory_KEYBASE {
 			continue
 		}
-		orig, ok := activeInvites[invID]
-		if !ok {
-			return res, errors.New("couldn't find invite for annotated invite")
-		}
-		uv, err := orig.KeybaseUserVersion()
-		if err != nil {
-			return res, err
-		}
 		details := keybase1.TeamMemberDetails{
-			Uv:       uv,
+			Uv:       invite.Uv,
 			Username: string(invite.Name),
 			Active:   true,
 			NeedsPUK: true,

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -75,6 +75,8 @@ protocol teams {
     UserVersion uv;
     string username;
     boolean active;
+    @lint("ignore")
+    boolean needsPUK;
   }
 
   record TeamMembersDetails {
@@ -399,6 +401,8 @@ protocol teams {
     boolean isImplicitTeam;
     TeamRole role;
     union{null, ImplicitRole} implicit;
+    @lint("ignore")
+    boolean needsPUK;
   }
 
   record AnnotatedTeamList {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -175,6 +175,7 @@ protocol teams {
     TeamInviteID id;
     TeamInviteType type;
     TeamInviteName name;
+    UserVersion uv;
     UserVersion inviter;
     string inviterUsername;
     string teamName;

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -450,7 +450,7 @@ protocol teams {
   array<TeamIDAndName> teamListSubteamsRecursive(int sessionID, string parentTeamName, boolean forceRepoll);
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);
   TeamAddMemberResult teamAddMember(int sessionID, string name, string email, string username, TeamRole role, boolean sendChatNotification);
-  void teamRemoveMember(int sessionID, string name, string username);
+  void teamRemoveMember(int sessionID, string name, string username, string email);
   void teamLeave(int sessionID, string name, boolean permanent);
   void teamEditMember(int sessionID, string name, string username, TeamRole role);
   void teamRename(int sessionID, TeamName prevName, TeamName newName);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2823,6 +2823,7 @@ export type AnnotatedTeamInvite = {
   id: TeamInviteID,
   type: TeamInviteType,
   name: TeamInviteName,
+  uv: UserVersion,
   inviter: UserVersion,
   inviterUsername: string,
   teamName: string,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2815,6 +2815,7 @@ export type AnnotatedMemberInfo = {
   isImplicitTeam: boolean,
   role: TeamRole,
   implicit?: ?ImplicitRole,
+  needsPUK: boolean,
 }
 
 export type AnnotatedTeamInvite = {
@@ -4879,6 +4880,7 @@ export type TeamMemberDetails = {
   uv: UserVersion,
   username: string,
   active: boolean,
+  needsPUK: boolean,
 }
 
 export type TeamMembers = {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6251,7 +6251,8 @@ export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
 
 export type teamsTeamRemoveMemberRpcParam = Exact<{
   name: string,
-  username: string
+  username: string,
+  email: string
 }>
 
 export type teamsTeamRenameRpcParam = Exact<{

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1348,6 +1348,10 @@
         {
           "name": "username",
           "type": "string"
+        },
+        {
+          "name": "email",
+          "type": "string"
         }
       ],
       "response": null

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -513,6 +513,10 @@
         },
         {
           "type": "UserVersion",
+          "name": "uv"
+        },
+        {
+          "type": "UserVersion",
           "name": "inviter"
         },
         {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -190,6 +190,11 @@
         {
           "type": "boolean",
           "name": "active"
+        },
+        {
+          "type": "boolean",
+          "name": "needsPUK",
+          "lint": "ignore"
         }
       ]
     },
@@ -999,6 +1004,11 @@
             "ImplicitRole"
           ],
           "name": "implicit"
+        },
+        {
+          "type": "boolean",
+          "name": "needsPUK",
+          "lint": "ignore"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2823,6 +2823,7 @@ export type AnnotatedTeamInvite = {
   id: TeamInviteID,
   type: TeamInviteType,
   name: TeamInviteName,
+  uv: UserVersion,
   inviter: UserVersion,
   inviterUsername: string,
   teamName: string,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2815,6 +2815,7 @@ export type AnnotatedMemberInfo = {
   isImplicitTeam: boolean,
   role: TeamRole,
   implicit?: ?ImplicitRole,
+  needsPUK: boolean,
 }
 
 export type AnnotatedTeamInvite = {
@@ -4879,6 +4880,7 @@ export type TeamMemberDetails = {
   uv: UserVersion,
   username: string,
   active: boolean,
+  needsPUK: boolean,
 }
 
 export type TeamMembers = {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6251,7 +6251,8 @@ export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
 
 export type teamsTeamRemoveMemberRpcParam = Exact<{
   name: string,
-  username: string
+  username: string,
+  email: string
 }>
 
 export type teamsTeamRenameRpcParam = Exact<{


### PR DESCRIPTION
RemoveMember (and remove-member command) will remove active invites if they exist for a username (keybase, social, or email).

Tests added for all three situations.

Also slight wording change in `list-members` to say "added by..." instead of "invited by..."

```
> kbcl team add-member haaa --user=t_ellen --role=reader

> kbcl -d=0 team list-members haaa
haaa  owner    wool
haaa  reader*  t_ellen  (* added by wool; awaiting acceptance)
> kbcl -d=0 team remove-member haaa --user=t_ellen
Are you sure? [y/N] y
Success! t_ellen removed from team haaa.
> kbcl -d=0 team list-members haaa
haaa  owner  wool
```