### PR TITLE
revert mistaken kbfsmount status change

### DIFF
--- a/go/install/fuse_status_windows.go
+++ b/go/install/fuse_status_windows.go
@@ -12,7 +12,7 @@ import (
 
 func KeybaseFuseStatus(bundleVersion string, log Log) keybase1.FuseStatus {
 	status := keybase1.FuseStatus{}
-	if installed, _ := checkRegistryKeybaseDokan(log); installed {
+	if checkKeybaseDokanCodes(log) {
 		status.InstallStatus = keybase1.InstallStatus_INSTALLED
 		status.InstallAction = keybase1.InstallAction_NONE
 		status.KextStarted = true
@@ -23,16 +23,27 @@ func KeybaseFuseStatus(bundleVersion string, log Log) keybase1.FuseStatus {
 	return status
 }
 
+func checkKeybaseDokanCodes(log Log) bool {
+	foundDokan, err := checkRegistryKeybaseDokan("DOKANPRODUCT64", log)
+	if !foundDokan || err != nil {
+		foundDokan, err = checkRegistryKeybaseDokan("DOKANPRODUCT86", log)
+	}
+	if err != nil {
+		log.Errorf("checkKeybaseDokanCodes error: %v", err.Error())
+	}
+	return foundDokan
+}
+
 // Our installer writes the dokan product codes to our registry location,
 // which we can then look for in the list of windows uninstall keys.
 // Another alternative might be to look for %windir%\system32\dokan1.dll
-func checkRegistryKeybaseDokan(log Log) (bool, error) {
+func checkRegistryKeybaseDokan(productIDKey string, log Log) (bool, error) {
 	k, err := registry.OpenKey(registry.CURRENT_USER, `SOFTWARE\Keybase\Keybase\`, registry.QUERY_VALUE|registry.WOW64_64KEY)
 	if err != nil {
 		return false, err
 	}
 	defer k.Close()
-	productID, _, err := k.GetStringValue("BUNDLEKEY")
+	productID, _, err := k.GetStringValue(productIDKey)
 	if err != nil {
 		return false, err
 	}
@@ -41,7 +52,7 @@ func checkRegistryKeybaseDokan(log Log) (bool, error) {
 		log.Info("CheckRegistryKeybaseDokan: Empty product ID, returning false")
 		return false, err
 	}
-	k2, err := registry.OpenKey(registry.CURRENT_USER, `SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\`+productID, registry.QUERY_VALUE|registry.WOW64_64KEY)
+	k2, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\`+productID, registry.QUERY_VALUE|registry.WOW64_64KEY)
 	if err == nil {
 		return true, nil
 	}


### PR DESCRIPTION
I confounded detecting whether dokan was installed with the invocation of the 2nd half of split install. Again, this is just a revert of this file.