### PR TITLE
Fix TeamLoader bug again (stale linkmap)

### DIFF
--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -109,7 +109,7 @@ func (l *TeamLoader) checkStubbed(ctx context.Context, arg load2ArgT, link *chai
 
 func (l *TeamLoader) loadUserAndKeyFromLinkInner(ctx context.Context,
 	inner SCChainLinkPayload) (
-	signerUV keybase1.UserVersion, key *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
+	signerUV keybase1.UserVersion, key *keybase1.PublicKeyV2NaCl, linkMap linkMapT, err error) {
 
 	defer l.G().CTrace(ctx, fmt.Sprintf("TeamLoader#loadUserForSigVerification(%d)", int(inner.Seqno)), func() error { return err })()
 	keySection := inner.Body.Key
@@ -129,7 +129,7 @@ func (l *TeamLoader) verifySignatureAndExtractKID(ctx context.Context, outer lib
 	return outer.Verify(l.G().Log)
 }
 
-func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, teamLinkMap map[keybase1.Seqno]keybase1.LinkID, link *chainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap map[keybase1.Seqno]keybase1.LinkID, proofSet *proofSetT) {
+func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, teamLinkMap linkMapT, link *chainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap linkMapT, proofSet *proofSetT) {
 	a := newProofTerm(uid.AsUserOrTeam(), key.Base.Provisioning, userLinkMap)
 	b := newProofTerm(teamID.AsUserOrTeam(), link.SignatureMetadata(), teamLinkMap)
 	c := key.Base.Revocation
@@ -181,7 +181,7 @@ func (l *TeamLoader) verifyLink(ctx context.Context,
 		return nil, libkb.NewWrongKidError(kid, key.Base.Kid)
 	}
 
-	teamLinkMap := make(map[keybase1.Seqno]keybase1.LinkID)
+	teamLinkMap := make(linkMapT)
 	if state != nil {
 		// copy over the stored links
 		for k, v := range state.Chain.LinkIDs {

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -237,10 +237,11 @@ func (l *TeamLoader) walkUpToAdmin(
 			return nil, NewAdminNotFoundError(admin)
 		}
 		arg := load2ArgT{
-			teamID:        *parent,
-			reason:        "walkUpToAdmin",
-			me:            me,
-			staleOK:       true,
+			teamID: *parent,
+			reason: "walkUpToAdmin",
+			me:     me,
+			// Get the latest so that the linkmap is up to date for the proof order checker.
+			forceRepoll:   true,
 			readSubteamID: &readSubteamID,
 		}
 		if target.Eq(*parent) {

--- a/go/teams/loader_chain_test.go
+++ b/go/teams/loader_chain_test.go
@@ -29,9 +29,9 @@ type TestCase struct {
 		} `json:"team_key_boxes"`
 	} `json:"teams"`
 	Users map[string] /*user label*/ struct {
-		UID               keybase1.UID                       `json:"uid"`
-		EldestSeqno       keybase1.Seqno                     `json:"eldest_seqno"`
-		LinkMap           map[keybase1.Seqno]keybase1.LinkID `json:"link_map"`
+		UID               keybase1.UID   `json:"uid"`
+		EldestSeqno       keybase1.Seqno `json:"eldest_seqno"`
+		LinkMap           linkMapT       `json:"link_map"`
 		PerUserKeySecrets map[keybase1.Seqno]string/*hex of PerUserKeySeed*/ `json:"puk_secrets"`
 	} `json:"users"`
 	KeyOwners        map[keybase1.KID] /*kid*/ string/*username*/ `json:"key_owners"`

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -28,8 +28,8 @@ type LoaderContext interface {
 	perUserEncryptionKey(ctx context.Context, userSeqno keybase1.Seqno) (*libkb.NaclDHKeyPair, error)
 	merkleLookup(ctx context.Context, teamID keybase1.TeamID) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error)
 	merkleLookupTripleAtHashMeta(ctx context.Context, leafID keybase1.UserOrTeamID, hm keybase1.HashMeta) (triple *libkb.MerkleTriple, err error)
-	forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap map[keybase1.Seqno]keybase1.LinkID, err error)
-	loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (keybase1.UserVersion, *keybase1.PublicKeyV2NaCl, map[keybase1.Seqno]keybase1.LinkID, error)
+	forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap linkMapT, err error)
+	loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (keybase1.UserVersion, *keybase1.PublicKeyV2NaCl, linkMapT, error)
 }
 
 // The main LoaderContext is G.
@@ -204,7 +204,7 @@ func (l *LoaderContextG) merkleLookupTripleAtHashMeta(ctx context.Context, leafI
 	return triple, nil
 }
 
-func (l *LoaderContextG) forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
+func (l *LoaderContextG) forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap linkMapT, err error) {
 	arg := libkb.NewLoadUserArgBase(l.G()).WithNetContext(ctx).WithUID(uid).WithForcePoll()
 	upak, _, err := l.G().GetUPAKLoader().LoadV2(*arg)
 	if err != nil {
@@ -214,7 +214,7 @@ func (l *LoaderContextG) forceLinkMapRefreshForUser(ctx context.Context, uid key
 }
 
 func (l *LoaderContextG) loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (
-	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID,
+	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap linkMapT,
 	err error) {
 
 	user, pubKey, linkMap, err := l.G().GetUPAKLoader().LoadKeyV2(ctx, uid, kid)

--- a/go/teams/loader_ctx_test.go
+++ b/go/teams/loader_ctx_test.go
@@ -252,7 +252,7 @@ func (l *MockLoaderContext) merkleLookupTripleAtHashMeta(ctx context.Context,
 	return &triple1, nil
 }
 
-func (l *MockLoaderContext) forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
+func (l *MockLoaderContext) forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap linkMapT, err error) {
 	panic("TODO")
 	// if !ok {
 	// 	return nil, NewMockBoundsError("ForceLinkMapRefreshForUser", "uid", uid)
@@ -261,7 +261,7 @@ func (l *MockLoaderContext) forceLinkMapRefreshForUser(ctx context.Context, uid 
 }
 
 func (l *MockLoaderContext) loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (
-	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID,
+	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap linkMapT,
 	err error) {
 
 	defer func() {

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -634,3 +634,56 @@ func TestLoaderCORE_6230(t *testing.T) {
 	//   proof error for proof 'became admin before team link': no linkID for seqno 3
 	require.NoError(t, err, "load team")
 }
+
+func TestLoaderCORE_6230_2(t *testing.T) {
+	fus, tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	t.Logf("U0 creates A")
+	rootName, rootID := createTeam2(*tcs[0])
+
+	t.Logf("U0 adds U1 to A")
+	_, err := AddMember(context.TODO(), tcs[0].G, rootName.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+	require.NoError(t, err, "add member")
+
+	t.Logf("U1 loads and caches A")
+	_, err = Load(context.TODO(), tcs[1].G, keybase1.LoadTeamArg{
+		ID:          rootID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err, "load team")
+
+	t.Logf("U0 creates A.B")
+	subteamName, subteamID := createSubteam(tcs[0], rootName, "bbb")
+
+	t.Logf("U0 adds U1 to A.B")
+	_, err = AddMember(context.TODO(), tcs[0].G, subteamName.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+	require.NoError(t, err, "add member")
+
+	t.Logf("U1 loads A.B")
+	_, err = Load(context.TODO(), tcs[1].G, keybase1.LoadTeamArg{
+		ID:          subteamID,
+		ForceRepoll: true,
+	})
+	_ = err // ignore the error if there is one, not testing that part.
+
+	t.Logf("U1 loads A.B (again, in case there was a bug above)")
+	_, err = Load(context.TODO(), tcs[1].G, keybase1.LoadTeamArg{
+		ID:          subteamID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err, "load team")
+
+	t.Logf("U0 adds a link to A")
+	_, err = AddMember(context.TODO(), tcs[0].G, rootName.String(), "foobar@rooter", keybase1.TeamRole_READER)
+
+	t.Logf("U0 does an admin action to A.B")
+	_, err = AddMember(context.TODO(), tcs[0].G, subteamName.String(), fus[0].Username, keybase1.TeamRole_READER)
+
+	t.Logf("U1 loads A.B")
+	_, err = Load(context.TODO(), tcs[1].G, keybase1.LoadTeamArg{
+		ID:          subteamID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err, "load team")
+}

--- a/go/teams/proofs.go
+++ b/go/teams/proofs.go
@@ -11,14 +11,16 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func newProofTerm(i keybase1.UserOrTeamID, s keybase1.SignatureMetadata, lm map[keybase1.Seqno]keybase1.LinkID) proofTerm {
+func newProofTerm(i keybase1.UserOrTeamID, s keybase1.SignatureMetadata, lm linkMapT) proofTerm {
 	return proofTerm{leafID: i, sigMeta: s, linkMap: lm}
 }
+
+type linkMapT map[keybase1.Seqno]keybase1.LinkID
 
 type proofTerm struct {
 	leafID  keybase1.UserOrTeamID
 	sigMeta keybase1.SignatureMetadata
-	linkMap map[keybase1.Seqno]keybase1.LinkID
+	linkMap linkMapT
 }
 
 func (t *proofTerm) shortForm() string {
@@ -81,14 +83,14 @@ func newProofIndex(a keybase1.UserOrTeamID, b keybase1.UserOrTeamID) proofIndex 
 type proofSetT struct {
 	libkb.Contextified
 	proofs       map[proofIndex][]proof
-	teamLinkMaps map[keybase1.TeamID]map[keybase1.Seqno]keybase1.LinkID
+	teamLinkMaps map[keybase1.TeamID]linkMapT
 }
 
 func newProofSet(g *libkb.GlobalContext) *proofSetT {
 	return &proofSetT{
 		Contextified: libkb.NewContextified(g),
 		proofs:       make(map[proofIndex][]proof),
-		teamLinkMaps: make(map[keybase1.TeamID]map[keybase1.Seqno]keybase1.LinkID),
+		teamLinkMaps: make(map[keybase1.TeamID]linkMapT),
 	}
 }
 
@@ -150,7 +152,7 @@ func (p *proofSetT) AddNeededHappensBeforeProof(ctx context.Context, a proofTerm
 }
 
 // Set the latest link map for the team
-func (p *proofSetT) SetTeamLinkMap(ctx context.Context, teamID keybase1.TeamID, linkMap map[keybase1.Seqno]keybase1.LinkID) {
+func (p *proofSetT) SetTeamLinkMap(ctx context.Context, teamID keybase1.TeamID, linkMap linkMapT) {
 	p.teamLinkMaps[teamID] = linkMap
 }
 


### PR DESCRIPTION
This should fix this class of bugs where when a team link is A in "A must come before B" then we might fail when team A's link map is out of date. This comes at the cost of performance for subteams. Each subteam link processed that uses implicit admin priveleges will do [subteam depth] roundtrips.

There are faster but more complicated ways to deal with this.