### PR TITLE
Fix QR code display crasher on Android

### DIFF
--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -171,6 +171,7 @@ dependencies {
     // @see DESKTOP-1703
     compile 'com.facebook.fresco:animated-base-support:0.14.1'
     compile 'com.facebook.fresco:animated-gif:0.14.1'
+    compile 'com.facebook.fresco:fresco:1.5.0'
     debugCompile 'com.hanhuy.android:viewserver:1.0.3'
     compile project(':keybaselib')
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
@keybase/react-hackers 

Fixes:
```
10-02 17:53:09.492 5405-5488/io.keybase.ossifrage.debug E/AndroidRuntime: FATAL EXCEPTION: Thread-7
Process: io.keybase.ossifrage.debug, PID: 5405
java.lang.NoClassDefFoundError: Failed resolution of: Lcom/facebook/imagepipeline/memory/PooledByteBuffer;
```