### PR TITLE
make implicit team chat pass all client tests, and get CLI working CORE-6130

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -144,14 +144,16 @@ func (b *basicUnboxConversationInfo) GetFinalizeInfo() *chat1.ConversationFinali
 }
 
 type publicUnboxConversationInfo struct {
-	convID chat1.ConversationID
+	convID      chat1.ConversationID
+	membersType chat1.ConversationMembersType
 }
 
 var _ unboxConversationInfo = (*publicUnboxConversationInfo)(nil)
 
-func newPublicUnboxConverstionInfo(convID chat1.ConversationID) *publicUnboxConversationInfo {
+func newPublicUnboxConverstionInfo(convID chat1.ConversationID, membersType chat1.ConversationMembersType) *publicUnboxConversationInfo {
 	return &publicUnboxConversationInfo{
-		convID: convID,
+		convID:      convID,
+		membersType: membersType,
 	}
 }
 
@@ -160,9 +162,7 @@ func (p *publicUnboxConversationInfo) GetConvID() chat1.ConversationID {
 }
 
 func (p *publicUnboxConversationInfo) GetMembersType() chat1.ConversationMembersType {
-	// This won't matter for a public conversation, since we don't really encrypt them,
-	// we use a known key in KeyFinder
-	return chat1.ConversationMembersType_KBFS
+	return p.membersType
 }
 
 func (p *publicUnboxConversationInfo) GetFinalizeInfo() *chat1.ConversationFinalizeInfo {

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -404,7 +404,10 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.C
 				if err != nil {
 					return err
 				}
-				team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{ID: teamID})
+				team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{
+					ID:     teamID,
+					Public: conv.Metadata.Visibility == keybase1.TLFVisibility_PUBLIC,
+				})
 				if err != nil {
 					return err
 				}

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 
 	"sync"
 
@@ -393,7 +392,7 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.C
 			var names []string
 			switch conv.GetMembersType() {
 			case chat1.ConversationMembersType_KBFS:
-				names = strings.Split(strings.Fields(tlfName)[0], ",")
+				names = utils.SplitTLFName(tlfName)
 			case chat1.ConversationMembersType_TEAM:
 				// early out of team convs
 				return nil
@@ -415,7 +414,7 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.C
 				if err != nil {
 					return err
 				}
-				names = strings.Split(strings.Fields(display.String())[0], ",")
+				names = utils.SplitTLFName(display.String())
 			}
 
 			s.Debug(ctx, "identifyTLF: identifying from msg ID: %d names: %v convID: %s",

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -448,7 +448,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 			debugger.Debug(ctx, "FindConversations: found team channels: num: %d", len(res))
 		}
 	} else if vis == keybase1.TLFVisibility_PUBLIC {
-		debugger.Debug(ctx, "FindConversation: no conversations found in inbox, trying public chats")
+		debugger.Debug(ctx, "FindConversations: no conversations found in inbox, trying public chats")
 
 		// Check for offline and return an error
 		if g.InboxSource.IsOffline(ctx) {
@@ -487,8 +487,13 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 
 			// Search for conversations that match the topic name
 			for _, convLocal := range convsLocal {
+				if convLocal.Error != nil {
+					debugger.Debug(ctx, "FindConversations: skipping convID: %s localization failure: %s",
+						convLocal.GetConvID(), convLocal.Error.Message)
+					continue
+				}
 				if convLocal.Info.TopicName == topicName {
-					debugger.Debug(ctx, "FindConversation: found matching public conv: id: %s topicName: %s",
+					debugger.Debug(ctx, "FindConversations: found matching public conv: id: %s topicName: %s",
 						convLocal.GetConvID(), topicName)
 					res = append(res, convLocal)
 				}

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -784,8 +784,8 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 		if err != nil {
 			return res, rl, fmt.Errorf("error creating topic ID: %s", err)
 		}
-		n.Debug(ctx, "attempt: %v [tlfID: %s topicType: %d topicID: %s]", i, triple.Tlfid, triple.TopicType,
-			triple.TopicID)
+		n.Debug(ctx, "attempt: %v [tlfID: %s topicType: %d topicID: %s name: %s]", i, triple.Tlfid,
+			triple.TopicType, triple.TopicID, info.CanonicalName)
 		firstMessageBoxed, topicNameState, err := n.makeFirstMessage(ctx, triple, info.CanonicalName,
 			n.membersType, n.vis, n.topicName)
 		if err != nil {

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -397,7 +397,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 
 	if membersType == chat1.ConversationMembersType_IMPTEAM {
 		// in this case, we need to get the hidden implicit team name from the display name
-		_, teamName, err := teams.LookupImplicitTeam(ctx, g.ExternalG(), tlfName, vis == keybase1.TLFVisibility_PUBLIC)
+		_, teamName, _, err := teams.LookupImplicitTeam(ctx, g.ExternalG(), tlfName, vis == keybase1.TLFVisibility_PUBLIC)
 		if err != nil {
 			if _, ok := err.(teams.TeamDoesNotExistError); ok {
 				// no exist is just empty response
@@ -772,7 +772,7 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 
 		// couldn't find implicit team, so make one
 		n.Debug(ctx, "making new implicit team %q", n.tlfName)
-		_, _, err = teams.LookupOrCreateImplicitTeam(ctx, n.G().ExternalG(), n.tlfName, isPublic)
+		_, _, _, err = teams.LookupOrCreateImplicitTeam(ctx, n.G().ExternalG(), n.tlfName, isPublic)
 		if err != nil {
 			return res, rl, err
 		}

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -395,20 +395,6 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 	membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility, topicName string,
 	oneChatPerTLF *bool) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
 
-	if membersType == chat1.ConversationMembersType_IMPTEAM {
-		// in this case, we need to get the hidden implicit team name from the display name
-		_, teamName, _, err := teams.LookupImplicitTeam(ctx, g.ExternalG(), tlfName, vis == keybase1.TLFVisibility_PUBLIC)
-		if err != nil {
-			if _, ok := err.(teams.TeamDoesNotExistError); ok {
-				// no exist is just empty response
-				return res, rl, nil
-			}
-			return res, rl, err
-		}
-		debugger.Debug(ctx, "FindConversations: using implicit team name %q for display name %q", teamName, tlfName)
-		tlfName = teamName.String()
-	}
-
 	query := &chat1.GetInboxLocalQuery{
 		Name: &chat1.NameQuery{
 			Name:        tlfName,

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -210,15 +209,15 @@ func NewNameIdentifier(g *globals.Context) *NameIdentifier {
 	}
 }
 
-func (t *NameIdentifier) Identify(ctx context.Context, arg keybase1.TLFQuery, private bool) ([]keybase1.TLFIdentifyFailure, error) {
+func (t *NameIdentifier) Identify(ctx context.Context, names []string, private bool,
+	identBehavior keybase1.TLFIdentifyBehavior) ([]keybase1.TLFIdentifyFailure, error) {
 	// need new context as errgroup will cancel it.
 	group, ectx := errgroup.WithContext(BackgroundContext(ctx, t.G()))
 	assertions := make(chan string)
 
 	group.Go(func() error {
 		defer close(assertions)
-		pieces := strings.Split(strings.Fields(arg.TlfName)[0], ",")
-		for _, p := range pieces {
+		for _, p := range names {
 			select {
 			case assertions <- p:
 			case <-ectx.Done():
@@ -233,7 +232,7 @@ func (t *NameIdentifier) Identify(ctx context.Context, arg keybase1.TLFQuery, pr
 	for i := 0; i < numIdentifiers; i++ {
 		group.Go(func() error {
 			for assertion := range assertions {
-				f, err := t.identifyUser(ectx, assertion, private, arg.IdentifyBehavior)
+				f, err := t.identifyUser(ectx, assertion, private, identBehavior)
 				if err != nil {
 					return err
 				}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -911,8 +911,8 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 	}
 
 	unverifiedTLFName := getUnverifiedTlfNameForErrors(conversationRemote)
-	s.Debug(ctx, "localizing: TLF: %s convID: %s offline: %v", unverifiedTLFName,
-		conversationRemote.GetConvID(), s.offline)
+	s.Debug(ctx, "localizing: TLF: %s convID: %s offline: %v vis: %v", unverifiedTLFName,
+		conversationRemote.GetConvID(), s.offline, conversationRemote.Metadata.Visibility)
 
 	conversationLocal.Info = chat1.ConversationInfoLocal{
 		Id:          conversationRemote.Metadata.ConversationID,
@@ -1094,8 +1094,10 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		}
 		ok := true
 		var errMsg string
+		s.Debug(ctx, "localizeConversation: trying to load team for %v chat", conversationLocal.Info.Visibility)
 		iteam, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{
-			ID: teamID,
+			ID:     teamID,
+			Public: conversationLocal.Info.Visibility == keybase1.TLFVisibility_PUBLIC,
 		})
 		if err != nil {
 			ok = false

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -103,7 +103,13 @@ func (k *KeyFinderImpl) FindForEncryption(ctx context.Context,
 	membersType chat1.ConversationMembersType, public bool) (res types.NameInfo, err error) {
 
 	switch membersType {
-	case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
+	case chat1.ConversationMembersType_IMPTEAM:
+		if public {
+			// If this is public, then just make sure we get to the name info source
+			return k.Find(ctx, tlfName, membersType, public)
+		}
+		fallthrough
+	case chat1.ConversationMembersType_TEAM:
 		teamID, err := tlfIDToTeamdID(teamID)
 		if err != nil {
 			return res, err
@@ -131,7 +137,13 @@ func (k *KeyFinderImpl) FindForDecryption(ctx context.Context,
 	keyGeneration int) (res types.NameInfo, err error) {
 
 	switch membersType {
-	case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
+	case chat1.ConversationMembersType_IMPTEAM:
+		if public {
+			// If this is public, then just make sure we get to the name info source
+			return k.Find(ctx, tlfName, membersType, public)
+		}
+		fallthrough
+	case chat1.ConversationMembersType_TEAM:
 		teamID, err := tlfIDToTeamdID(teamID)
 		if err != nil {
 			return res, err

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -103,13 +103,7 @@ func (k *KeyFinderImpl) FindForEncryption(ctx context.Context,
 	membersType chat1.ConversationMembersType, public bool) (res types.NameInfo, err error) {
 
 	switch membersType {
-	case chat1.ConversationMembersType_IMPTEAM:
-		if public {
-			// If this is public, then just make sure we get to the name info source
-			return k.Find(ctx, tlfName, membersType, public)
-		}
-		fallthrough
-	case chat1.ConversationMembersType_TEAM:
+	case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
 		teamID, err := tlfIDToTeamdID(teamID)
 		if err != nil {
 			return res, err
@@ -138,13 +132,7 @@ func (k *KeyFinderImpl) FindForDecryption(ctx context.Context,
 	keyGeneration int) (res types.NameInfo, err error) {
 
 	switch membersType {
-	case chat1.ConversationMembersType_IMPTEAM:
-		if public {
-			// If this is public, then just make sure we get to the name info source
-			return k.Find(ctx, tlfName, membersType, public)
-		}
-		fallthrough
-	case chat1.ConversationMembersType_TEAM:
+	case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
 		teamID, err := tlfIDToTeamdID(teamID)
 		if err != nil {
 			return res, err

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -115,7 +115,8 @@ func (k *KeyFinderImpl) FindForEncryption(ctx context.Context,
 			return res, err
 		}
 		team, err := teams.Load(ctx, k.G().ExternalG(), keybase1.LoadTeamArg{
-			ID: teamID,
+			ID:     teamID,
+			Public: public,
 		})
 		if err != nil {
 			return res, err
@@ -154,6 +155,7 @@ func (k *KeyFinderImpl) FindForDecryption(ctx context.Context,
 				NeedKeyGeneration: keybase1.PerTeamKeyGeneration(keyGeneration),
 			},
 			StaleOK: true,
+			Public:  public,
 		})
 		if err != nil {
 			return res, err

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -205,6 +205,9 @@ func (g *PushHandler) TlfFinalize(ctx context.Context, m gregor.OutOfBandMessage
 	if m.Body() == nil {
 		return errors.New("gregor handler for chat.tlffinalize: nil message body")
 	}
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+		g.identNotifier)
 
 	var update chat1.TLFFinalizeUpdate
 	reader := bytes.NewReader(m.Body().Bytes())
@@ -268,6 +271,9 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 	if m.Body() == nil {
 		return errors.New("gregor handler for chat.tlfresolve: nil message body")
 	}
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+		g.identNotifier)
 
 	var update chat1.TLFResolveUpdate
 	reader := bytes.NewReader(m.Body().Bytes())
@@ -304,6 +310,8 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 		resolveInfo := chat1.ConversationResolveInfo{
 			NewTLFName: updateConv.Info.TlfName,
 		}
+		g.Debug(ctx, "TlfResolve: convID: %s new TLF name: %s", updateConv.GetConvID(),
+			updateConv.Info.TlfName)
 
 		if updateConv.GetTopicType() == chat1.TopicType_CHAT {
 			if g.shouldSendNotifications() {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -80,10 +80,6 @@ func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, v
 		return t.lookupInternalName(ctx, name, vis)
 	}
 
-	username := t.G().Env.GetUsername()
-	if len(username) == 0 {
-		return res, libkb.LoginRequiredError{}
-	}
 	teamID, teamName, impTeamName, err := teams.LookupOrCreateImplicitTeam(ctx, t.G().ExternalG(), name,
 		vis == keybase1.TLFVisibility_PUBLIC)
 	if err != nil {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -80,6 +80,10 @@ func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, v
 		return t.lookupInternalName(ctx, name, vis)
 	}
 
+	username := t.G().Env.GetUsername()
+	if len(username) == 0 {
+		return res, libkb.LoginRequiredError{}
+	}
 	teamID, teamName, impTeamName, err := teams.LookupOrCreateImplicitTeam(ctx, t.G().ExternalG(), name,
 		vis == keybase1.TLFVisibility_PUBLIC)
 	if err != nil {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -110,16 +110,16 @@ func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, v
 		res.CryptKeys = []types.CryptKey{publicCryptKey}
 	}
 
+	var names []string
+	names = append(names, impTeamName.Writers.KeybaseUsers...)
+	names = append(names, impTeamName.Readers.KeybaseUsers...)
+
 	// identify the members in the conversation
 	identBehavior, breaks, ok := IdentifyMode(ctx)
 	if !ok {
 		return res, errors.New("invalid context with no chat metadata")
 	}
-	query := keybase1.TLFQuery{
-		TlfName:          impTeamName.String(),
-		IdentifyBehavior: identBehavior,
-	}
-	ib, err := t.Identify(ctx, query, true)
+	ib, err := t.Identify(ctx, names, true, identBehavior)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -2,7 +2,6 @@ package chat
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/keybase/client/go/auth"
@@ -109,7 +108,7 @@ func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res
 		t.Debug(ectx, "CryptKeys: running identify")
 		group.Go(func() error {
 			var err error
-			names := strings.Split(strings.Fields(tlfName)[0], ",")
+			names := utils.SplitTLFName(tlfName)
 			ib, err = t.Identify(ectx, names, true, identBehavior)
 			return err
 		})
@@ -171,7 +170,7 @@ func (t *KBFSNameInfoSource) PublicCanonicalTLFNameAndID(ctx context.Context, tl
 	if identBehavior != keybase1.TLFIdentifyBehavior_CHAT_SKIP {
 		group.Go(func() error {
 			var err error
-			names := strings.Split(strings.Fields(tlfName)[0], ",")
+			names := utils.SplitTLFName(tlfName)
 			ib, err = t.Identify(ectx, names, false, identBehavior)
 			return err
 		})

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keybase/client/go/auth"
@@ -107,12 +108,9 @@ func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res
 	if runIdentify {
 		t.Debug(ectx, "CryptKeys: running identify")
 		group.Go(func() error {
-			query := keybase1.TLFQuery{
-				TlfName:          tlfName,
-				IdentifyBehavior: identBehavior,
-			}
 			var err error
-			ib, err = t.Identify(ectx, query, true)
+			names := strings.Split(strings.Fields(tlfName)[0], ",")
+			ib, err = t.Identify(ectx, names, true, identBehavior)
 			return err
 		})
 	}
@@ -172,13 +170,9 @@ func (t *KBFSNameInfoSource) PublicCanonicalTLFNameAndID(ctx context.Context, tl
 	var ib []keybase1.TLFIdentifyFailure
 	if identBehavior != keybase1.TLFIdentifyBehavior_CHAT_SKIP {
 		group.Go(func() error {
-			query := keybase1.TLFQuery{
-				TlfName:          tlfName,
-				IdentifyBehavior: identBehavior,
-			}
-
 			var err error
-			ib, err = t.Identify(ectx, query, false)
+			names := strings.Split(strings.Fields(tlfName)[0], ",")
+			ib, err = t.Identify(ectx, names, false, identBehavior)
 			return err
 		})
 

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -837,3 +837,7 @@ func PluckConvs(rcs []types.RemoteConversation) (res []chat1.Conversation) {
 	}
 	return res
 }
+
+func SplitTLFName(tlfName string) []string {
+	return strings.Split(strings.Fields(tlfName)[0], ",")
+}

--- a/go/client/chat_cli_fetchers.go
+++ b/go/client/chat_cli_fetchers.go
@@ -21,12 +21,7 @@ type chatCLIConversationFetcher struct {
 }
 
 func (f chatCLIConversationFetcher) fetch(ctx context.Context, g *libkb.GlobalContext) (conversations chat1.ConversationLocal, messages []chat1.MessageUnboxed, err error) {
-	chatClient, err := GetChatLocalClient(g)
-	if err != nil {
-		return chat1.ConversationLocal{}, nil, fmt.Errorf("Getting chat service client error: %s", err)
-	}
-	resolver := &chatConversationResolver{G: g, ChatClient: chatClient}
-	resolver.TlfClient, err = GetTlfClient(g)
+	resolver, err := newChatConversationResolver(g)
 	if err != nil {
 		return chat1.ConversationLocal{}, nil, err
 	}
@@ -52,7 +47,7 @@ func (f chatCLIConversationFetcher) fetch(ctx context.Context, g *libkb.GlobalCo
 		return chat1.ConversationLocal{}, nil, fmt.Errorf("empty conversationInfo.Id: %+v", conversation.Info)
 	}
 
-	gcfclres, err := chatClient.GetConversationForCLILocal(ctx, f.query)
+	gcfclres, err := resolver.ChatClient.GetConversationForCLILocal(ctx, f.query)
 	if err != nil {
 		return chat1.ConversationLocal{}, nil, fmt.Errorf("GetConversationForCLILocal error: %s", err)
 	}

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -99,6 +99,14 @@ func (r *chatConversationResolver) completeAndCanonicalizeTLFName(ctx context.Co
 		}
 		req.ctx.canonicalizedTlfName = string(cname.CanonicalName)
 	case chat1.ConversationMembersType_IMPTEAM:
+		// Add our name out front
+		if req.Visibility == keybase1.TLFVisibility_PRIVATE {
+			username := r.G.Env.GetUsername()
+			if len(username) == 0 {
+				return libkb.LoginRequiredError{}
+			}
+			tlfName = username.String() + "," + tlfName
+		}
 		impRes, err := r.TeamsClient.LookupOrCreateImplicitTeam(ctx, keybase1.LookupOrCreateImplicitTeamArg{
 			Name:   tlfName,
 			Public: req.Visibility == keybase1.TLFVisibility_PUBLIC,

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -99,7 +99,6 @@ func (r *chatConversationResolver) completeAndCanonicalizeTLFName(ctx context.Co
 		}
 		req.ctx.canonicalizedTlfName = string(cname.CanonicalName)
 	case chat1.ConversationMembersType_IMPTEAM:
-		// Put ourselves out front just to make sure we end up on imp team
 		impRes, err := r.TeamsClient.LookupOrCreateImplicitTeam(ctx, keybase1.LookupOrCreateImplicitTeamArg{
 			Name:   tlfName,
 			Public: req.Visibility == keybase1.TLFVisibility_PUBLIC,
@@ -146,6 +145,7 @@ func (r *chatConversationResolver) makeGetInboxAndUnboxLocalArg(
 }
 
 func (r *chatConversationResolver) resolveWithService(ctx context.Context, req chatConversationResolvingRequest, identifyBehavior keybase1.TLFIdentifyBehavior) ([]chat1.ConversationLocal, error) {
+
 	arg, err := r.makeGetInboxAndUnboxLocalArg(ctx, req, identifyBehavior)
 	if err != nil {
 		return nil, err

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -225,6 +225,8 @@ func (r *chatConversationResolver) create(ctx context.Context, req chatConversat
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		r.G.UI.GetTerminalUI().Printf("%s\n", newConversation)
 	}
 
 	var tnp *string

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -45,9 +45,25 @@ type chatConversationResolvingBehavior struct {
 }
 
 type chatConversationResolver struct {
-	G          *libkb.GlobalContext
-	ChatClient chat1.LocalInterface
-	TlfClient  keybase1.TlfInterface
+	G           *libkb.GlobalContext
+	ChatClient  chat1.LocalInterface
+	TlfClient   keybase1.TlfInterface
+	TeamsClient keybase1.TeamsInterface
+}
+
+func newChatConversationResolver(g *libkb.GlobalContext) (c *chatConversationResolver, err error) {
+	c = new(chatConversationResolver)
+	if c.ChatClient, err = GetChatLocalClient(g); err != nil {
+		return c, err
+	}
+	if c.TlfClient, err = GetTlfClient(g); err != nil {
+		return c, err
+	}
+	if c.TeamsClient, err = GetTeamsClient(g); err != nil {
+		return c, err
+	}
+	c.G = g
+	return c, nil
 }
 
 // completeAndCanonicalizeTLFName completes tlfName and canonicalizes it if
@@ -55,31 +71,46 @@ type chatConversationResolver struct {
 // len(tlfName) must > 0
 func (r *chatConversationResolver) completeAndCanonicalizeTLFName(ctx context.Context, tlfName string, req chatConversationResolvingRequest) error {
 
-	query := keybase1.TLFQuery{
-		TlfName:          tlfName,
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	switch req.MembersType {
+	case chat1.ConversationMembersType_KBFS:
+		query := keybase1.TLFQuery{
+			TlfName:          tlfName,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		}
+		var cname keybase1.CanonicalTLFNameAndIDWithBreaks
+		var err error
+		var visout string
+		if req.Visibility == keybase1.TLFVisibility_PUBLIC {
+			visout = "public"
+			cname, err = r.TlfClient.PublicCanonicalTLFNameAndID(ctx, query)
+		} else {
+			visout = "private"
+			cname, err = r.TlfClient.CompleteAndCanonicalizePrivateTlfName(ctx, query)
+		}
+		if err != nil {
+			// When a recipient's proofs are failing, this is the error a CLI user
+			// will see. It needs to be human readable.
+			return fmt.Errorf("failed to open chat conversation: %v", err)
+		}
+		if string(cname.CanonicalName) != tlfName {
+			// If we auto-complete TLF name, we should let users know.
+			// TODO: don't spam user here if it's just re-ordering
+			r.G.UI.GetTerminalUI().Printf("Using %s conversation %s.\n", visout, cname.CanonicalName)
+		}
+		req.ctx.canonicalizedTlfName = string(cname.CanonicalName)
+	case chat1.ConversationMembersType_IMPTEAM:
+		// Put ourselves out front just to make sure we end up on imp team
+		impRes, err := r.TeamsClient.LookupOrCreateImplicitTeam(ctx, keybase1.LookupOrCreateImplicitTeamArg{
+			Name:   tlfName,
+			Public: req.Visibility == keybase1.TLFVisibility_PUBLIC,
+		})
+		if err != nil {
+			return err
+		}
+		req.ctx.canonicalizedTlfName = impRes.DisplayName.String()
+	case chat1.ConversationMembersType_TEAM:
+		req.ctx.canonicalizedTlfName = tlfName
 	}
-	var cname keybase1.CanonicalTLFNameAndIDWithBreaks
-	var err error
-	var visout string
-	if req.Visibility == keybase1.TLFVisibility_PUBLIC {
-		visout = "public"
-		cname, err = r.TlfClient.PublicCanonicalTLFNameAndID(ctx, query)
-	} else {
-		visout = "private"
-		cname, err = r.TlfClient.CompleteAndCanonicalizePrivateTlfName(ctx, query)
-	}
-	if err != nil {
-		// When a recipient's proofs are failing, this is the error a CLI user
-		// will see. It needs to be human readable.
-		return fmt.Errorf("failed to open chat conversation: %v", err)
-	}
-	if string(cname.CanonicalName) != tlfName {
-		// If we auto-complete TLF name, we should let users know.
-		// TODO: don't spam user here if it's just re-ordering
-		r.G.UI.GetTerminalUI().Printf("Using %s conversation %s.\n", visout, cname.CanonicalName)
-	}
-	req.ctx.canonicalizedTlfName = string(cname.CanonicalName)
 
 	return nil
 }
@@ -88,32 +119,13 @@ func (r *chatConversationResolver) makeGetInboxAndUnboxLocalArg(
 	ctx context.Context, req chatConversationResolvingRequest, identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.GetInboxAndUnboxLocalArg, error) {
 
 	var nameQuery *chat1.NameQuery
-	switch req.MembersType {
-	case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAM:
-
-		if len(req.TopicName) > 0 && req.TopicType == chat1.TopicType_CHAT {
-			return chat1.GetInboxAndUnboxLocalArg{},
-				errors.New("multiple topics only supported for teams and dev conversations")
+	if len(req.TlfName) > 0 {
+		if err := r.completeAndCanonicalizeTLFName(ctx, req.TlfName, req); err != nil {
+			return chat1.GetInboxAndUnboxLocalArg{}, err
 		}
-
-		if len(req.TlfName) > 0 {
-			nameQuery = &chat1.NameQuery{
-				Name:        req.TlfName,
-				MembersType: req.MembersType,
-			}
-			if req.MembersType == chat1.ConversationMembersType_KBFS {
-				// resolve KBFS TLF
-				if err := r.completeAndCanonicalizeTLFName(ctx, req.TlfName, req); err != nil {
-					return chat1.GetInboxAndUnboxLocalArg{}, err
-				}
-				nameQuery.Name = req.ctx.canonicalizedTlfName
-			}
-		}
-	case chat1.ConversationMembersType_TEAM:
-		req.ctx.canonicalizedTlfName = req.TlfName
 		nameQuery = &chat1.NameQuery{
-			Name:        req.TlfName,
-			MembersType: chat1.ConversationMembersType_TEAM,
+			Name:        req.ctx.canonicalizedTlfName,
+			MembersType: req.MembersType,
 		}
 	}
 

--- a/go/client/chat_send_common.go
+++ b/go/client/chat_send_common.go
@@ -27,12 +27,7 @@ type ChatSendArg struct {
 }
 
 func chatSend(ctx context.Context, g *libkb.GlobalContext, c ChatSendArg) error {
-	chatClient, err := GetChatLocalClient(g)
-	if err != nil {
-		return err
-	}
-	resolver := &chatConversationResolver{G: g, ChatClient: chatClient}
-	resolver.TlfClient, err = GetTlfClient(g)
+	resolver, err := newChatConversationResolver(g)
 	if err != nil {
 		return err
 	}
@@ -107,11 +102,11 @@ func chatSend(ctx context.Context, g *libkb.GlobalContext, c ChatSendArg) error 
 		nbarg.ConversationID = args.ConversationID
 		nbarg.Msg = args.Msg
 		nbarg.IdentifyBehavior = args.IdentifyBehavior
-		if _, err = chatClient.PostLocalNonblock(ctx, nbarg); err != nil {
+		if _, err = resolver.ChatClient.PostLocalNonblock(ctx, nbarg); err != nil {
 			return err
 		}
 	} else {
-		if _, err = chatClient.PostLocal(ctx, args); err != nil {
+		if _, err = resolver.ChatClient.PostLocal(ctx, args); err != nil {
 			return err
 		}
 	}

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -39,15 +39,6 @@ func newChatServiceHandler(g *libkb.GlobalContext) *chatServiceHandler {
 	}
 }
 
-func (c *chatServiceHandler) channelName(conv chat1.ConversationLocal) string {
-	switch conv.Info.MembersType {
-	case chat1.ConversationMembersType_IMPTEAM:
-		return strings.Join(conv.Info.WriterNames, ",")
-	default:
-		return conv.Info.TlfName
-	}
-}
-
 // ListV1 implements ChatServiceHandler.ListV1.
 func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Reply {
 	var rlimits []chat1.RateLimit
@@ -110,7 +101,7 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 				super.ConversationID.String())
 		}
 		convSummary.Channel = ChatChannel{
-			Name:        c.channelName(conv),
+			Name:        conv.Info.TlfName,
 			Public:      conv.Info.Visibility == keybase1.TLFVisibility_PUBLIC,
 			TopicType:   strings.ToLower(conv.Info.Triple.TopicType.String()),
 			MembersType: strings.ToLower(conv.Info.MembersType.String()),
@@ -212,7 +203,7 @@ func (c *chatServiceHandler) ReadV1(ctx context.Context, opts readOptionsV1) Rep
 		msg := MsgSummary{
 			ID: mv.ServerHeader.MessageID,
 			Channel: ChatChannel{
-				Name:        c.channelName(conv),
+				Name:        conv.Info.TlfName,
 				Public:      mv.ClientHeader.TlfPublic,
 				TopicType:   strings.ToLower(mv.ClientHeader.Conv.TopicType.String()),
 				MembersType: strings.ToLower(conv.GetMembersType().String()),

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -39,6 +39,15 @@ func newChatServiceHandler(g *libkb.GlobalContext) *chatServiceHandler {
 	}
 }
 
+func (c *chatServiceHandler) channelName(conv chat1.ConversationLocal) string {
+	switch conv.Info.MembersType {
+	case chat1.ConversationMembersType_IMPTEAM:
+		return strings.Join(conv.Info.WriterNames, ",")
+	default:
+		return conv.Info.TlfName
+	}
+}
+
 // ListV1 implements ChatServiceHandler.ListV1.
 func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Reply {
 	var rlimits []chat1.RateLimit
@@ -101,7 +110,7 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 				super.ConversationID.String())
 		}
 		convSummary.Channel = ChatChannel{
-			Name:        conv.Info.TlfName,
+			Name:        c.channelName(conv),
 			Public:      conv.Info.Visibility == keybase1.TLFVisibility_PUBLIC,
 			TopicType:   strings.ToLower(conv.Info.Triple.TopicType.String()),
 			MembersType: strings.ToLower(conv.Info.MembersType.String()),
@@ -203,7 +212,7 @@ func (c *chatServiceHandler) ReadV1(ctx context.Context, opts readOptionsV1) Rep
 		msg := MsgSummary{
 			ID: mv.ServerHeader.MessageID,
 			Channel: ChatChannel{
-				Name:        mv.ClientHeader.TlfName,
+				Name:        c.channelName(conv),
 				Public:      mv.ClientHeader.TlfPublic,
 				TopicType:   strings.ToLower(mv.ClientHeader.Conv.TopicType.String()),
 				MembersType: strings.ToLower(conv.GetMembersType().String()),

--- a/go/client/cmd_chat_createchannel.go
+++ b/go/client/cmd_chat_createchannel.go
@@ -37,11 +37,10 @@ func newCmdChatCreateChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext)
 
 func (c *CmdChatCreateChannel) Run() error {
 	c.G().StartStandaloneChat()
-	chatClient, err := GetChatLocalClient(c.G())
+	resolver, err := newChatConversationResolver(c.G())
 	if err != nil {
 		return err
 	}
-	resolver := &chatConversationResolver{G: c.G(), ChatClient: chatClient}
 
 	req := chatConversationResolvingRequest{
 		TlfName:     c.teamName,
@@ -76,7 +75,7 @@ func (c *CmdChatCreateChannel) Run() error {
 
 func (c *CmdChatCreateChannel) ParseArgv(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
-		return errors.New("create channel takes two arguments.")
+		return errors.New("create channel takes two arguments")
 	}
 
 	c.teamName = ctx.Args().Get(0)

--- a/go/client/cmd_chat_delete_channel.go
+++ b/go/client/cmd_chat_delete_channel.go
@@ -49,13 +49,12 @@ func (c *CmdChatDeleteChannel) Run() error {
 		return err
 	}
 
-	chatClient, err := GetChatLocalClient(c.G())
+	resolver, err := newChatConversationResolver(c.G())
 	if err != nil {
 		return err
 	}
 
 	ctx := context.Background()
-	resolver := &chatConversationResolver{G: c.G(), ChatClient: chatClient}
 	conv, _, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
 		CreateIfNotExists: false,
 		MustNotExist:      false,
@@ -66,7 +65,7 @@ func (c *CmdChatDeleteChannel) Run() error {
 		return err
 	}
 
-	_, err = chatClient.DeleteConversationLocal(ctx, chat1.DeleteConversationLocalArg{
+	_, err = resolver.ChatClient.DeleteConversationLocal(ctx, chat1.DeleteConversationLocalArg{
 		ConvID:      conv.GetConvID(),
 		ChannelName: c.resolvingRequest.TopicName,
 	})

--- a/go/client/cmd_chat_hide.go
+++ b/go/client/cmd_chat_hide.go
@@ -67,13 +67,7 @@ func (c *CmdChatHide) ParseArgv(ctx *cli.Context) error {
 func (c *CmdChatHide) Run() error {
 	ctx := context.TODO()
 
-	chatClient, err := GetChatLocalClient(c.G())
-	if err != nil {
-		return err
-	}
-
-	resolver := &chatConversationResolver{G: c.G(), ChatClient: chatClient}
-	resolver.TlfClient, err = GetTlfClient(c.G())
+	resolver, err := newChatConversationResolver(c.G())
 	if err != nil {
 		return err
 	}
@@ -93,7 +87,7 @@ func (c *CmdChatHide) Run() error {
 		Status:         c.status,
 	}
 
-	_, err = chatClient.SetConversationStatusLocal(ctx, setStatusArg)
+	_, err = resolver.ChatClient.SetConversationStatusLocal(ctx, setStatusArg)
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_chat_leavechannel.go
+++ b/go/client/cmd_chat_leavechannel.go
@@ -37,13 +37,12 @@ func newCmdChatLeaveChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) 
 }
 
 func (c *CmdChatLeaveChannel) Run() error {
-	chatClient, err := GetChatLocalClient(c.G())
+	resolver, err := newChatConversationResolver(c.G())
 	if err != nil {
 		return err
 	}
 
 	ctx := context.Background()
-	resolver := &chatConversationResolver{G: c.G(), ChatClient: chatClient}
 	conv, _, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
 		CreateIfNotExists: false,
 		MustNotExist:      false,
@@ -54,7 +53,7 @@ func (c *CmdChatLeaveChannel) Run() error {
 		return err
 	}
 
-	_, err = chatClient.LeaveConversationLocal(ctx, conv.GetConvID())
+	_, err = resolver.ChatClient.LeaveConversationLocal(ctx, conv.GetConvID())
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_chat_mute.go
+++ b/go/client/cmd_chat_mute.go
@@ -60,17 +60,10 @@ func (c *CmdChatMute) ParseArgv(ctx *cli.Context) error {
 func (c *CmdChatMute) Run() error {
 	ctx := context.TODO()
 
-	chatClient, err := GetChatLocalClient(c.G())
+	resolver, err := newChatConversationResolver(c.G())
 	if err != nil {
 		return err
 	}
-
-	resolver := &chatConversationResolver{G: c.G(), ChatClient: chatClient}
-	resolver.TlfClient, err = GetTlfClient(c.G())
-	if err != nil {
-		return err
-	}
-
 	conversation, _, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
 		CreateIfNotExists: false,
 		MustNotExist:      false,
@@ -86,7 +79,7 @@ func (c *CmdChatMute) Run() error {
 		Status:         c.status,
 	}
 
-	_, err = chatClient.SetConversationStatusLocal(ctx, setStatusArg)
+	_, err = resolver.ChatClient.SetConversationStatusLocal(ctx, setStatusArg)
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_chat_report.go
+++ b/go/client/cmd_chat_report.go
@@ -54,13 +54,7 @@ func (c *CmdChatReport) ParseArgv(ctx *cli.Context) error {
 func (c *CmdChatReport) Run() error {
 	ctx := context.Background()
 
-	chatClient, err := GetChatLocalClient(c.G())
-	if err != nil {
-		return err
-	}
-
-	resolver := &chatConversationResolver{G: c.G(), ChatClient: chatClient}
-	resolver.TlfClient, err = GetTlfClient(c.G())
+	resolver, err := newChatConversationResolver(c.G())
 	if err != nil {
 		return err
 	}
@@ -80,7 +74,7 @@ func (c *CmdChatReport) Run() error {
 		Status:         c.status,
 	}
 
-	_, err = chatClient.SetConversationStatusLocal(ctx, setStatusArg)
+	_, err = resolver.ChatClient.SetConversationStatusLocal(ctx, setStatusArg)
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -173,7 +173,7 @@ func (c *CmdChatSend) ParseArgv(ctx *cli.Context) (err error) {
 
 	if nActions < 1 {
 		cli.ShowCommandHelp(ctx, "send")
-		return fmt.Errorf("Incorrect Usage.")
+		return fmt.Errorf("incorrect usage")
 	}
 	if nActions > 1 {
 		cli.ShowCommandHelp(ctx, "send")

--- a/go/git/teamer.go
+++ b/go/git/teamer.go
@@ -88,7 +88,7 @@ func (t *TeamerImpl) lookupOrCreateImplicitTeam(ctx context.Context, folder keyb
 
 	isPublic := !folder.Private
 
-	teamID, _, err := teams.LookupOrCreateImplicitTeam(ctx, t.G(), lookupName, isPublic)
+	teamID, _, _, err := teams.LookupOrCreateImplicitTeam(ctx, t.G(), lookupName, isPublic)
 	if err != nil {
 		return res, err
 	}

--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -116,12 +116,13 @@ func (t SigchainV2Type) TeamAllowStub(role keybase1.TeamRole) bool {
 
 // OuterLinkV2 is the second version of Keybase sigchain signatures.
 type OuterLinkV2 struct {
-	_struct  bool           `codec:",toarray"`
-	Version  int            `codec:"version"`
-	Seqno    keybase1.Seqno `codec:"seqno"`
-	Prev     LinkID         `codec:"prev"`
-	Curr     LinkID         `codec:"curr"`
-	LinkType SigchainV2Type `codec:"type"`
+	_struct  bool             `codec:",toarray"`
+	Version  int              `codec:"version"`
+	Seqno    keybase1.Seqno   `codec:"seqno"`
+	Prev     LinkID           `codec:"prev"`
+	Curr     LinkID           `codec:"curr"`
+	LinkType SigchainV2Type   `codec:"type"`
+	SeqType  keybase1.SeqType `codec:"seqtype"`
 }
 
 type OuterLinkV2WithMetadata struct {

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -599,6 +599,7 @@ type SigMultiItem struct {
 	Sig        string                  `json:"sig"`
 	SigningKID keybase1.KID            `json:"signing_kid"`
 	Type       string                  `json:"type"`
+	SeqType    keybase1.SeqType        `json:"seq_type"`
 	SigInner   string                  `json:"sig_inner"`
 	TeamID     keybase1.TeamID         `json:"team_id"`
 	PublicKeys *SigMultiItemPublicKeys `json:"public_keys,omitempty"`

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -342,8 +342,7 @@ func (arg ProofMetadata) ToJSON(g *GlobalContext) (ret *jsonw.Wrapper, err error
 	// Save what kind of client we're running.
 	ret.SetKey("client", clientInfo(g))
 
-	// SeqTypePublic (1) is the default, and we don't write it out explicitly
-	if arg.SeqType != 0 && arg.SeqType != SeqTypePublic {
+	if arg.SeqType != 0 {
 		ret.SetKey("seq_type", jsonw.NewInt(arg.SeqType))
 	}
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -147,13 +147,15 @@ func (o GetInboxByTLFIDRemoteRes) DeepCopy() GetInboxByTLFIDRemoteRes {
 }
 
 type GetThreadRemoteRes struct {
-	Thread    ThreadViewBoxed `codec:"thread" json:"thread"`
-	RateLimit *RateLimit      `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	Thread      ThreadViewBoxed         `codec:"thread" json:"thread"`
+	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
+	RateLimit   *RateLimit              `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 func (o GetThreadRemoteRes) DeepCopy() GetThreadRemoteRes {
 	return GetThreadRemoteRes{
-		Thread: o.Thread.DeepCopy(),
+		Thread:      o.Thread.DeepCopy(),
+		MembersType: o.MembersType.DeepCopy(),
 		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1355,6 +1355,20 @@ func (o ImplicitTeamConflictInfo) DeepCopy() ImplicitTeamConflictInfo {
 	}
 }
 
+type LookupImplicitTeamRes struct {
+	TeamID      TeamID                  `codec:"teamID" json:"teamID"`
+	Name        TeamName                `codec:"name" json:"name"`
+	DisplayName ImplicitTeamDisplayName `codec:"displayName" json:"displayName"`
+}
+
+func (o LookupImplicitTeamRes) DeepCopy() LookupImplicitTeamRes {
+	return LookupImplicitTeamRes{
+		TeamID:      o.TeamID.DeepCopy(),
+		Name:        o.Name.DeepCopy(),
+		DisplayName: o.DisplayName.DeepCopy(),
+	}
+}
+
 type TeamCreateArg struct {
 	SessionID            int    `codec:"sessionID" json:"sessionID"`
 	Name                 string `codec:"name" json:"name"`
@@ -1702,9 +1716,14 @@ type TeamsInterface interface {
 	TeamIgnoreRequest(context.Context, TeamIgnoreRequestArg) error
 	TeamTree(context.Context, TeamTreeArg) (TeamTreeResult, error)
 	TeamDelete(context.Context, TeamDeleteArg) error
+<<<<<<< HEAD
 	TeamSetSettings(context.Context, TeamSetSettingsArg) error
 	LookupImplicitTeam(context.Context, LookupImplicitTeamArg) (TeamID, error)
 	LookupOrCreateImplicitTeam(context.Context, LookupOrCreateImplicitTeamArg) (TeamID, error)
+=======
+	LookupImplicitTeam(context.Context, LookupImplicitTeamArg) (LookupImplicitTeamRes, error)
+	LookupOrCreateImplicitTeam(context.Context, LookupOrCreateImplicitTeamArg) (LookupImplicitTeamRes, error)
+>>>>>>> wip
 	TeamReAddMemberAfterReset(context.Context, TeamReAddMemberAfterResetArg) error
 	// * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.
 	// * If refreshers are non-empty, then force a refresh of the cache if the requirements
@@ -2200,17 +2219,21 @@ func (c TeamsClient) TeamDelete(ctx context.Context, __arg TeamDeleteArg) (err e
 	return
 }
 
+<<<<<<< HEAD
 func (c TeamsClient) TeamSetSettings(ctx context.Context, __arg TeamSetSettingsArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamSetSettings", []interface{}{__arg}, nil)
 	return
 }
 
 func (c TeamsClient) LookupImplicitTeam(ctx context.Context, __arg LookupImplicitTeamArg) (res TeamID, err error) {
+=======
+func (c TeamsClient) LookupImplicitTeam(ctx context.Context, __arg LookupImplicitTeamArg) (res LookupImplicitTeamRes, err error) {
+>>>>>>> wip
 	err = c.Cli.Call(ctx, "keybase.1.teams.lookupImplicitTeam", []interface{}{__arg}, &res)
 	return
 }
 
-func (c TeamsClient) LookupOrCreateImplicitTeam(ctx context.Context, __arg LookupOrCreateImplicitTeamArg) (res TeamID, err error) {
+func (c TeamsClient) LookupOrCreateImplicitTeam(ctx context.Context, __arg LookupOrCreateImplicitTeamArg) (res LookupImplicitTeamRes, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.lookupOrCreateImplicitTeam", []interface{}{__arg}, &res)
 	return
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1063,6 +1063,7 @@ type LoadTeamArg struct {
 	ForceFullReload bool           `codec:"forceFullReload" json:"forceFullReload"`
 	ForceRepoll     bool           `codec:"forceRepoll" json:"forceRepoll"`
 	StaleOK         bool           `codec:"staleOK" json:"staleOK"`
+	Public          bool           `codec:"public" json:"public"`
 }
 
 func (o LoadTeamArg) DeepCopy() LoadTeamArg {
@@ -1074,6 +1075,7 @@ func (o LoadTeamArg) DeepCopy() LoadTeamArg {
 		ForceFullReload: o.ForceFullReload,
 		ForceRepoll:     o.ForceRepoll,
 		StaleOK:         o.StaleOK,
+		Public:          o.Public,
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1716,14 +1716,9 @@ type TeamsInterface interface {
 	TeamIgnoreRequest(context.Context, TeamIgnoreRequestArg) error
 	TeamTree(context.Context, TeamTreeArg) (TeamTreeResult, error)
 	TeamDelete(context.Context, TeamDeleteArg) error
-<<<<<<< HEAD
 	TeamSetSettings(context.Context, TeamSetSettingsArg) error
-	LookupImplicitTeam(context.Context, LookupImplicitTeamArg) (TeamID, error)
-	LookupOrCreateImplicitTeam(context.Context, LookupOrCreateImplicitTeamArg) (TeamID, error)
-=======
 	LookupImplicitTeam(context.Context, LookupImplicitTeamArg) (LookupImplicitTeamRes, error)
 	LookupOrCreateImplicitTeam(context.Context, LookupOrCreateImplicitTeamArg) (LookupImplicitTeamRes, error)
->>>>>>> wip
 	TeamReAddMemberAfterReset(context.Context, TeamReAddMemberAfterResetArg) error
 	// * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.
 	// * If refreshers are non-empty, then force a refresh of the cache if the requirements
@@ -2219,16 +2214,12 @@ func (c TeamsClient) TeamDelete(ctx context.Context, __arg TeamDeleteArg) (err e
 	return
 }
 
-<<<<<<< HEAD
 func (c TeamsClient) TeamSetSettings(ctx context.Context, __arg TeamSetSettingsArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamSetSettings", []interface{}{__arg}, nil)
 	return
 }
 
-func (c TeamsClient) LookupImplicitTeam(ctx context.Context, __arg LookupImplicitTeamArg) (res TeamID, err error) {
-=======
 func (c TeamsClient) LookupImplicitTeam(ctx context.Context, __arg LookupImplicitTeamArg) (res LookupImplicitTeamRes, err error) {
->>>>>>> wip
 	err = c.Cli.Call(ctx, "keybase.1.teams.lookupImplicitTeam", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -199,9 +199,9 @@ func (h *IdentifyHandler) resolveIdentifyImplicitTeamHelper(ctx context.Context,
 	// Duplicates are also handled by Lookup*. So we might end up doing extra identifies of duplicates out here.
 	// (Duplicates e.g. "me,chris,chris", "me,chris#chris", "me,chris@rooter#chris")
 	if arg.Create {
-		teamID, impName, err = teams.LookupOrCreateImplicitTeam(ctx, h.G(), lookupNameStr, arg.IsPublic)
+		teamID, _, impName, err = teams.LookupOrCreateImplicitTeam(ctx, h.G(), lookupNameStr, arg.IsPublic)
 	} else {
-		teamID, impName, err = teams.LookupImplicitTeam(ctx, h.G(), lookupNameStr, arg.IsPublic)
+		teamID, _, impName, err = teams.LookupImplicitTeam(ctx, h.G(), lookupNameStr, arg.IsPublic)
 	}
 	if err != nil {
 		return res, err

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -249,17 +249,35 @@ func (h *TeamsHandler) GetTeamRootID(ctx context.Context, id keybase1.TeamID) (k
 	return teams.GetRootID(ctx, h.G().ExternalG(), id)
 }
 
-func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.LookupImplicitTeamArg) (res keybase1.TeamID, err error) {
+func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.LookupImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupImplicitTeam(%s)", arg.Name), func() error { return err })()
-	teamID, _, _, err := teams.LookupImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public)
-	return teamID, err
+	if !arg.Public {
+		// Prepend our username on here just in case for private imp teams
+		username := h.G().Env.GetUsername()
+		if len(username) == 0 {
+			return res, libkb.LoginRequiredError{}
+		}
+		arg.Name = username.String() + "," + arg.Name
+	}
+	res.TeamID, res.Name, res.DisplayName, err = teams.LookupImplicitTeam(ctx, h.G().ExternalG(), arg.Name,
+		arg.Public)
+	return res, err
 }
 
-func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keybase1.LookupOrCreateImplicitTeamArg) (res keybase1.TeamID, err error) {
+func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keybase1.LookupOrCreateImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%s)", arg.Name),
 		func() error { return err })()
-	teamID, _, _, err := teams.LookupOrCreateImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public)
-	return teamID, err
+	if !arg.Public {
+		// Prepend our username on here just in case for private imp teams
+		username := h.G().Env.GetUsername()
+		if len(username) == 0 {
+			return res, libkb.LoginRequiredError{}
+		}
+		arg.Name = username.String() + "," + arg.Name
+	}
+	res.TeamID, res.Name, res.DisplayName, err = teams.LookupOrCreateImplicitTeam(ctx, h.G().ExternalG(),
+		arg.Name, arg.Public)
+	return res, err
 }
 
 func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybase1.TeamReAddMemberAfterResetArg) error {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -249,15 +249,23 @@ func (h *TeamsHandler) GetTeamRootID(ctx context.Context, id keybase1.TeamID) (k
 	return teams.GetRootID(ctx, h.G().ExternalG(), id)
 }
 
-func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.LookupImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
-	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupImplicitTeam(%s)", arg.Name), func() error { return err })()
-	if !arg.Public {
+func (h *TeamsHandler) prependUsername(ctx context.Context, name string, public bool) (string, error) {
+	if !public {
 		// Prepend our username on here just in case for private imp teams
 		username := h.G().Env.GetUsername()
 		if len(username) == 0 {
-			return res, libkb.LoginRequiredError{}
+			return "", libkb.LoginRequiredError{}
 		}
-		arg.Name = username.String() + "," + arg.Name
+		return username.String() + "," + name, nil
+	}
+	return name, nil
+}
+
+func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.LookupImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupImplicitTeam(%s)", arg.Name), func() error { return err })()
+
+	if arg.Name, err = h.prependUsername(ctx, arg.Name, arg.Public); err != nil {
+		return res, err
 	}
 	res.TeamID, res.Name, res.DisplayName, err = teams.LookupImplicitTeam(ctx, h.G().ExternalG(), arg.Name,
 		arg.Public)
@@ -267,13 +275,8 @@ func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.Look
 func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keybase1.LookupOrCreateImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%s)", arg.Name),
 		func() error { return err })()
-	if !arg.Public {
-		// Prepend our username on here just in case for private imp teams
-		username := h.G().Env.GetUsername()
-		if len(username) == 0 {
-			return res, libkb.LoginRequiredError{}
-		}
-		arg.Name = username.String() + "," + arg.Name
+	if arg.Name, err = h.prependUsername(ctx, arg.Name, arg.Public); err != nil {
+		return res, err
 	}
 	res.TeamID, res.Name, res.DisplayName, err = teams.LookupOrCreateImplicitTeam(ctx, h.G().ExternalG(),
 		arg.Name, arg.Public)

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -251,14 +251,14 @@ func (h *TeamsHandler) GetTeamRootID(ctx context.Context, id keybase1.TeamID) (k
 
 func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.LookupImplicitTeamArg) (res keybase1.TeamID, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupImplicitTeam(%s)", arg.Name), func() error { return err })()
-	teamID, _, err := teams.LookupImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public)
+	teamID, _, _, err := teams.LookupImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public)
 	return teamID, err
 }
 
 func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keybase1.LookupOrCreateImplicitTeamArg) (res keybase1.TeamID, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%s)", arg.Name),
 		func() error { return err })()
-	teamID, _, err := teams.LookupOrCreateImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public)
+	teamID, _, _, err := teams.LookupOrCreateImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public)
 	return teamID, err
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -249,24 +249,8 @@ func (h *TeamsHandler) GetTeamRootID(ctx context.Context, id keybase1.TeamID) (k
 	return teams.GetRootID(ctx, h.G().ExternalG(), id)
 }
 
-func (h *TeamsHandler) prependUsername(ctx context.Context, name string, public bool) (string, error) {
-	if !public {
-		// Prepend our username on here just in case for private imp teams
-		username := h.G().Env.GetUsername()
-		if len(username) == 0 {
-			return "", libkb.LoginRequiredError{}
-		}
-		return username.String() + "," + name, nil
-	}
-	return name, nil
-}
-
 func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.LookupImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupImplicitTeam(%s)", arg.Name), func() error { return err })()
-
-	if arg.Name, err = h.prependUsername(ctx, arg.Name, arg.Public); err != nil {
-		return res, err
-	}
 	res.TeamID, res.Name, res.DisplayName, err = teams.LookupImplicitTeam(ctx, h.G().ExternalG(), arg.Name,
 		arg.Public)
 	return res, err
@@ -275,9 +259,6 @@ func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.Look
 func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keybase1.LookupOrCreateImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%s)", arg.Name),
 		func() error { return err })()
-	if arg.Name, err = h.prependUsername(ctx, arg.Name, arg.Public); err != nil {
-		return res, err
-	}
 	res.TeamID, res.Name, res.DisplayName, err = teams.LookupOrCreateImplicitTeam(ctx, h.G().ExternalG(),
 		arg.Name, arg.Public)
 	return res, err

--- a/go/systests/git_test.go
+++ b/go/systests/git_test.go
@@ -65,7 +65,7 @@ func TestGitTeamer(t *testing.T) {
 		FolderType: keybase1.FolderType_PRIVATE,
 	})
 	require.NoError(t, err)
-	expectedTeamID, _, err := teams.LookupImplicitTeam(context.Background(), g, frag, false /*isPublic*/)
+	expectedTeamID, _, _, err := teams.LookupImplicitTeam(context.Background(), g, frag, false /*isPublic*/)
 	require.NoError(t, err)
 	require.Equal(t, expectedTeamID, res.TeamID, "teamer should have created a team that was then looked up")
 	require.Equal(t, res.Visibility, keybase1.TLFVisibility_PRIVATE)
@@ -74,7 +74,7 @@ func TestGitTeamer(t *testing.T) {
 	bob = tt.addUser("bob")
 	gil = tt.addUser("gil")
 	frag = fmt.Sprintf("%v,%v#%v", alice.username, bob.username, gil.username)
-	teamID, _, err = teams.LookupOrCreateImplicitTeam(context.Background(), g, frag, false /*isPublic*/)
+	teamID, _, _, err = teams.LookupOrCreateImplicitTeam(context.Background(), g, frag, false /*isPublic*/)
 	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
 		Name:       frag,
 		Private:    true,
@@ -88,7 +88,7 @@ func TestGitTeamer(t *testing.T) {
 	bob = tt.addUser("bob")
 	gil = tt.addUser("gil")
 	frag = fmt.Sprintf("%v,%v#%v", alice.username, bob.username, gil.username)
-	teamID, _, err = teams.LookupOrCreateImplicitTeam(context.Background(), g, frag, true /*isPublic*/)
+	teamID, _, _, err = teams.LookupOrCreateImplicitTeam(context.Background(), g, frag, true /*isPublic*/)
 	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
 		Name:       frag,
 		Private:    false,
@@ -103,15 +103,15 @@ func TestGitTeamer(t *testing.T) {
 	bob = tt.addUser("bob")
 	iTeamNameCreate1 := strings.Join([]string{alice.username, bob.username}, ",")
 	iTeamNameCreate2 := strings.Join([]string{alice.username, bob.username + "@rooter"}, ",")
-	_, _, err = teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate1, false /*isPublic*/)
+	_, _, _, err = teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate1, false /*isPublic*/)
 	require.NoError(t, err)
-	iTeamID2, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate2, false /*isPublic*/)
+	iTeamID2, _, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate2, false /*isPublic*/)
 	require.NoError(t, err)
 	t.Logf("prove to create the conflict")
 	bob.proveRooter()
 	alice.waitForTeamIDChangedGregor(iTeamID2, alice.getTeamSeqno(iTeamID2)+1)
 	t.Logf("find out the conflict suffix")
-	_, _, conflicts, err := teams.LookupImplicitTeamAndConflicts(context.TODO(), g, iTeamNameCreate1, false /*isPublic*/)
+	_, _, _, conflicts, err := teams.LookupImplicitTeamAndConflicts(context.TODO(), g, iTeamNameCreate1, false /*isPublic*/)
 	require.NoError(t, err)
 	require.Len(t, conflicts, 1)
 	t.Logf("check")

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -431,16 +431,16 @@ func (u *smuUser) createTeam(writers []*smuUser) smuTeam {
 func (u *smuUser) lookupImplicitTeam(create bool, displayName string, public bool) smuImplicitTeam {
 	cli := u.getTeamsClient()
 	var err error
-	var teamID keybase1.TeamID
+	var res keybase1.LookupImplicitTeamRes
 	if create {
-		teamID, err = cli.LookupOrCreateImplicitTeam(context.TODO(), keybase1.LookupOrCreateImplicitTeamArg{Name: displayName, Public: public})
+		res, err = cli.LookupOrCreateImplicitTeam(context.TODO(), keybase1.LookupOrCreateImplicitTeamArg{Name: displayName, Public: public})
 	} else {
-		teamID, err = cli.LookupImplicitTeam(context.TODO(), keybase1.LookupImplicitTeamArg{Name: displayName, Public: public})
+		res, err = cli.LookupImplicitTeam(context.TODO(), keybase1.LookupImplicitTeamArg{Name: displayName, Public: public})
 	}
 	if err != nil {
 		u.ctx.t.Fatal(err)
 	}
-	return smuImplicitTeam{ID: teamID}
+	return smuImplicitTeam{ID: res.TeamID}
 }
 
 func (u *smuUser) addWriter(team smuTeam, w *smuUser) {

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -290,7 +290,7 @@ func TestIdentifyLite(t *testing.T) {
 
 	t.Logf("make an implicit team")
 	iTeamCreateName := strings.Join([]string{tt.users[0].username, "bob@github"}, ",")
-	iTeamID, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamCreateName, false /*isPublic*/)
+	iTeamID, _, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamCreateName, false /*isPublic*/)
 	require.NoError(t, err)
 	iTeamImpName := getTeamName(iTeamID)
 	require.True(t, iTeamImpName.IsImplicit())
@@ -399,7 +399,7 @@ func TestResolveIdentifyImplicitTeamWithSocial(t *testing.T) {
 	iTeamNameSorted := strings.Join([]string{tt.users[0].username, "bob@github", wong.username}, ",")
 
 	t.Logf("make an implicit team")
-	iTeamID, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate, false /*isPublic*/)
+	iTeamID, _, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate, false /*isPublic*/)
 	require.NoError(t, err)
 	iTeamImpName := getTeamName(iTeamID)
 	require.True(t, iTeamImpName.IsImplicit())
@@ -439,7 +439,7 @@ func TestResolveIdentifyImplicitTeamWithReaders(t *testing.T) {
 	iTeamNameLookup := tt.users[0].username + "#" + strings.Join([]string{"bob@github", wong.username + "@rooter"}, ",")
 
 	t.Logf("make an implicit team")
-	iTeamID, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate, false /*isPublic*/)
+	iTeamID, _, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate, false /*isPublic*/)
 	require.NoError(t, err)
 
 	cli, err := client.GetIdentifyClient(g)
@@ -492,7 +492,7 @@ func TestResolveIdentifyImplicitTeamWithDuplicates(t *testing.T) {
 	iTeamNameLookup3 := strings.Join([]string{alice.username, bob.username + "@rooter"}, ",") + "#" + bob.username
 
 	t.Logf("make an implicit team")
-	iTeamID, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate, false /*isPublic*/)
+	iTeamID, _, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate, false /*isPublic*/)
 	require.NoError(t, err)
 
 	bob.proveRooter()
@@ -532,9 +532,9 @@ func TestResolveIdentifyImplicitTeamWithConflict(t *testing.T) {
 	iTeamNameCreate2 := strings.Join([]string{tt.users[0].username, wong.username + "@rooter"}, ",")
 
 	t.Logf("make the teams")
-	iTeamID1, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate1, false /*isPublic*/)
+	iTeamID1, _, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate1, false /*isPublic*/)
 	require.NoError(t, err)
-	iTeamID2, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate2, false /*isPublic*/)
+	iTeamID2, _, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate2, false /*isPublic*/)
 	require.NoError(t, err)
 	require.NotEqual(t, iTeamID1, iTeamID2)
 	t.Logf("t1: %v", iTeamID1)
@@ -597,7 +597,7 @@ func TestResolveIdentifyImplicitTeamWithConflict(t *testing.T) {
 	require.Nil(t, res.TrackBreaks, "track breaks")
 
 	t.Logf("find out the conflict suffix")
-	iTeamIDxx, _, conflicts, err := teams.LookupImplicitTeamAndConflicts(context.TODO(), g, iTeamNameCreate1, false /*isPublic*/)
+	iTeamIDxx, _, _, conflicts, err := teams.LookupImplicitTeamAndConflicts(context.TODO(), g, iTeamNameCreate1, false /*isPublic*/)
 	require.NoError(t, err)
 	require.Equal(t, iTeamIDxx, iTeamID1)
 	require.Len(t, conflicts, 1)
@@ -631,7 +631,7 @@ func TestResolveIdentifyImplicitTeamWithIdentifyFailures(t *testing.T) {
 	iTeamNameCreate := strings.Join([]string{tt.users[0].username, wong.username}, ",")
 
 	t.Logf("make an implicit team")
-	iTeamID, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate, false /*isPublic*/)
+	iTeamID, _, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), g, iTeamNameCreate, false /*isPublic*/)
 	require.NoError(t, err)
 
 	cli, err := client.GetIdentifyClient(g)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -445,14 +445,14 @@ func (u *userPlusDevice) kickTeamRekeyd() {
 func (u *userPlusDevice) lookupImplicitTeam(create bool, displayName string, public bool) (keybase1.TeamID, error) {
 	cli := u.teamsClient
 	var err error
-	var teamID keybase1.TeamID
+	var res keybase1.LookupImplicitTeamRes
 	if create {
-		teamID, err = cli.LookupOrCreateImplicitTeam(context.TODO(), keybase1.LookupOrCreateImplicitTeamArg{Name: displayName, Public: public})
+		res, err = cli.LookupOrCreateImplicitTeam(context.TODO(), keybase1.LookupOrCreateImplicitTeamArg{Name: displayName, Public: public})
 	} else {
-		teamID, err = cli.LookupImplicitTeam(context.TODO(), keybase1.LookupImplicitTeamArg{Name: displayName, Public: public})
+		res, err = cli.LookupImplicitTeam(context.TODO(), keybase1.LookupImplicitTeamArg{Name: displayName, Public: public})
 	}
 
-	return teamID, err
+	return res.TeamID, err
 }
 
 func (u *userPlusDevice) newSecretUI() *libkb.TestSecretUI {

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -149,7 +149,7 @@ func TestCreateImplicitTeam(t *testing.T) {
 	}
 	sort.Sort(keybase1.ByUserVersionID(uvs))
 	impTeam.IsPublic = false
-	teamID, err := CreateImplicitTeam(context.TODO(), tc.G, impTeam)
+	teamID, _, err := CreateImplicitTeam(context.TODO(), tc.G, impTeam)
 	require.NoError(t, err)
 	team, err := Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
 		ID: teamID,
@@ -172,7 +172,7 @@ func TestCreateImplicitTeam(t *testing.T) {
 			Service: keybase1.SocialAssertionService("github"),
 		},
 	}
-	teamID, err = CreateImplicitTeam(context.TODO(), tc.G, impTeam)
+	teamID, _, err = CreateImplicitTeam(context.TODO(), tc.G, impTeam)
 	require.NoError(t, err)
 	team, err = Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
 		ID: teamID,

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -117,6 +117,7 @@ func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
 		ID:          imp.TeamID,
 		ForceRepoll: true,
+		Public:      impTeamName.IsPublic,
 	})
 	if err != nil {
 		return teamID, teamName, impTeamName, conflicts, err

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -145,6 +145,8 @@ func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 // Lookup or create an implicit team by name like "alice,bob+bob@twitter (conflicted 2017-03-04 #1)"
 // Resolves social assertions.
 func LookupOrCreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (res keybase1.TeamID, teamName keybase1.TeamName, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
+	defer g.CTraceTimed(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%v)", displayName),
+		func() error { return err })()
 	lookupName, err := ResolveImplicitTeamDisplayName(ctx, g, displayName, public)
 	if err != nil {
 		return res, teamName, impTeamName, err

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -32,26 +32,29 @@ func TestLookupImplicitTeams(t *testing.T) {
 
 	lookupAndCreate := func(displayName string, public bool) {
 		t.Logf("displayName:%v public:%v", displayName, public)
-		_, _, err := LookupImplicitTeam(context.TODO(), tc.G, displayName, public)
+		_, _, _, err := LookupImplicitTeam(context.TODO(), tc.G, displayName, public)
 		require.Error(t, err)
 		require.IsType(t, TeamDoesNotExistError{}, err)
 
-		createdTeamID, impTeamName, err := LookupOrCreateImplicitTeam(context.TODO(), tc.G, displayName, public)
+		createdTeamID, _, impTeamName, err := LookupOrCreateImplicitTeam(context.TODO(), tc.G, displayName,
+			public)
 		require.NoError(t, err)
 		require.Equal(t, public, impTeamName.IsPublic)
 
 		// second time, LookupOrCreate should Lookup the team just created.
-		createdTeamID2, impTeamName2, err := LookupOrCreateImplicitTeam(context.TODO(), tc.G, displayName, public)
+		createdTeamID2, _, impTeamName2, err := LookupOrCreateImplicitTeam(context.TODO(), tc.G, displayName,
+			public)
 		require.NoError(t, err)
 		require.Equal(t, createdTeamID, createdTeamID2)
 		require.Equal(t, impTeamName, impTeamName2, "public: %v", public)
 
-		lookupTeamID, impTeamName, err := LookupImplicitTeam(context.TODO(), tc.G, displayName, public)
+		lookupTeamID, _, impTeamName, err := LookupImplicitTeam(context.TODO(), tc.G, displayName, public)
 		require.NoError(t, err)
 		require.Equal(t, createdTeamID, lookupTeamID)
 
 		team, err := Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
-			ID: createdTeamID,
+			ID:     createdTeamID,
+			Public: public,
 		})
 		require.NoError(t, err)
 		teamDisplay, err := team.ImplicitTeamDisplayNameString(context.TODO())
@@ -63,15 +66,15 @@ func TestLookupImplicitTeams(t *testing.T) {
 	}
 
 	displayName := strings.Join(usernames, ",")
-	lookupAndCreate(displayName, false)
+	//	lookupAndCreate(displayName, false)
 	lookupAndCreate(displayName, true)
 	displayName = fmt.Sprintf("mike@twitter,%s,james@github", displayName)
 	lookupAndCreate(displayName, false)
 	lookupAndCreate(displayName, true)
 
-	_, _, err := LookupOrCreateImplicitTeam(context.TODO(), tc.G, "dksjdskjs/sxs?", false)
+	_, _, _, err := LookupOrCreateImplicitTeam(context.TODO(), tc.G, "dksjdskjs/sxs?", false)
 	require.Error(t, err)
-	_, _, err = LookupOrCreateImplicitTeam(context.TODO(), tc.G, "dksjdskjs/sxs?", true)
+	_, _, _, err = LookupOrCreateImplicitTeam(context.TODO(), tc.G, "dksjdskjs/sxs?", true)
 	require.Error(t, err)
 }
 
@@ -82,14 +85,14 @@ func TestImplicitPukless(t *testing.T) {
 
 	displayName := "" + fus[0].Username + "," + fus[1].Username
 	t.Logf("U0 creates an implicit team: %v", displayName)
-	teamID, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
+	teamID, _, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
 	require.NoError(t, err)
 
-	teamID2, _, err := LookupImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
+	teamID2, _, _, err := LookupImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
 	require.NoError(t, err)
 	require.Equal(t, teamID, teamID2)
 
-	teamID2, _, err = LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
+	teamID2, _, _, err = LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
 	require.NoError(t, err)
 	require.Equal(t, teamID, teamID2)
 
@@ -118,11 +121,11 @@ func TestImplicitTeamReader(t *testing.T) {
 
 	displayName := "" + fus[0].Username + ",bob@twitter#" + fus[1].Username
 	t.Logf("U0 creates an implicit team: %v", displayName)
-	teamID, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*public*/)
+	teamID, _, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*public*/)
 	require.NoError(t, err)
 
 	t.Logf("U1 looks up the team")
-	teamID2, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*public*/)
+	teamID2, _, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*public*/)
 	require.NoError(t, err)
 	require.Equal(t, teamID, teamID2, "users should lookup the same team ID")
 
@@ -215,9 +218,9 @@ func TestLookupImplicitTeamResolvedSocialAssertion(t *testing.T) {
 	displayName1 := "t_tracy@rooter," + fus[0].Username
 	displayName2 := "t_tracy," + fus[0].Username
 
-	teamID1, impTeamName1, err := LookupOrCreateImplicitTeam(context.TODO(), tcs[0].G, displayName1, false /*isPublic*/)
+	teamID1, _, impTeamName1, err := LookupOrCreateImplicitTeam(context.TODO(), tcs[0].G, displayName1, false /*isPublic*/)
 	require.NoError(t, err)
-	teamID2, _, err := LookupOrCreateImplicitTeam(context.TODO(), tcs[0].G, displayName2, false /*isPublic*/)
+	teamID2, _, _, err := LookupOrCreateImplicitTeam(context.TODO(), tcs[0].G, displayName2, false /*isPublic*/)
 	require.NoError(t, err)
 
 	require.Equal(t, teamID1, teamID2, "implicit team ID should be the same for %v and %v", displayName1, displayName2)

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -66,7 +66,7 @@ func TestLookupImplicitTeams(t *testing.T) {
 	}
 
 	displayName := strings.Join(usernames, ",")
-	//	lookupAndCreate(displayName, false)
+	lookupAndCreate(displayName, false)
 	lookupAndCreate(displayName, true)
 	displayName = fmt.Sprintf("mike@twitter,%s,james@github", displayName)
 	lookupAndCreate(displayName, false)

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -384,7 +384,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*load2ResT,
 			ret.Secretless = true
 		} else {
 			// Add the secrets unless this is a secretless team.
-			if !ret.Secretless && !arg.public {
+			if !ret.Secretless && !ret.Chain.Public {
 				ret, err = l.addSecrets(ctx, ret, arg.me, teamUpdate.Box, teamUpdate.Prevs, teamUpdate.ReaderKeyMasks)
 				if err != nil {
 					return nil, fmt.Errorf("loading team secrets: %v", err)

--- a/go/teams/loader_ctx_test.go
+++ b/go/teams/loader_ctx_test.go
@@ -38,7 +38,7 @@ func NewMockLoaderContext(t *testing.T, g *libkb.GlobalContext, unit TestCase) *
 }
 
 func (l *MockLoaderContext) getNewLinksFromServer(ctx context.Context,
-	teamID keybase1.TeamID, lows getLinksLows,
+	teamID keybase1.TeamID, public bool, lows getLinksLows,
 	readSubteamID *keybase1.TeamID) (*rawTeam, error) {
 
 	return l.getLinksFromServerHelper(ctx, teamID, lows, nil, readSubteamID)
@@ -184,7 +184,8 @@ func (l *MockLoaderContext) lookupEldestSeqno(ctx context.Context, uid keybase1.
 	return seqno, NewMockBoundsError("LookupEldestSeqno", "uid", uid)
 }
 
-func (l *MockLoaderContext) resolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName) (id keybase1.TeamID, err error) {
+func (l *MockLoaderContext) resolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName,
+	public bool) (id keybase1.TeamID, err error) {
 	for name, teamSpec := range l.unit.Teams {
 		if teamName.String() == name {
 			id = teamSpec.ID
@@ -225,7 +226,7 @@ func (l *MockLoaderContext) perUserEncryptionKey(ctx context.Context, userSeqno 
 	return key, err
 }
 
-func (l *MockLoaderContext) merkleLookup(ctx context.Context, teamID keybase1.TeamID) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error) {
+func (l *MockLoaderContext) merkleLookup(ctx context.Context, teamID keybase1.TeamID, public bool) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error) {
 	key := fmt.Sprintf("%s", teamID)
 	if l.state.loadSpec.Upto > 0 {
 		key = fmt.Sprintf("%s-seqno:%d", teamID, int64(l.state.loadSpec.Upto))

--- a/go/teams/rename.go
+++ b/go/teams/rename.go
@@ -142,6 +142,7 @@ func generateRenameSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.Us
 		sigJSON,
 		prevLinkID,
 		false, /* hasRevokes */
+		false, /* public */
 	)
 	if err != nil {
 		return nil, err
@@ -195,6 +196,7 @@ func generateRenameUpPointerSigForSubteamChain(g *libkb.GlobalContext, me *libkb
 		sigJSON,
 		prevLinkID,
 		false, /* hasRevokes */
+		false, /* public */
 	)
 	if err != nil {
 		return nil, err

--- a/go/teams/rename.go
+++ b/go/teams/rename.go
@@ -142,7 +142,7 @@ func generateRenameSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.Us
 		sigJSON,
 		prevLinkID,
 		false, /* hasRevokes */
-		false, /* public */
+		keybase1.SeqType_SEMIPRIVATE,
 	)
 	if err != nil {
 		return nil, err
@@ -196,7 +196,7 @@ func generateRenameUpPointerSigForSubteamChain(g *libkb.GlobalContext, me *libkb
 		sigJSON,
 		prevLinkID,
 		false, /* hasRevokes */
-		false, /* public */
+		keybase1.SeqType_SEMIPRIVATE,
 	)
 	if err != nil {
 		return nil, err

--- a/go/teams/sig.go
+++ b/go/teams/sig.go
@@ -20,13 +20,17 @@ import (
 )
 
 func TeamRootSig(me *libkb.User, key libkb.GenericKey, teamSection SCTeamSection) (*jsonw.Wrapper, error) {
+	seqtype := libkb.SeqTypeSemiprivate
+	if teamSection.Public {
+		seqtype = libkb.SeqTypePublic
+	}
 	ret, err := libkb.ProofMetadata{
 		Me:         me,
 		LinkType:   libkb.LinkTypeTeamRoot,
 		SigningKey: key,
 		Seqno:      1,
 		SigVersion: libkb.KeybaseSignatureV2,
-		SeqType:    libkb.SeqTypeSemiprivate,
+		SeqType:    seqtype,
 	}.ToJSON(me.G())
 	if err != nil {
 		return nil, err

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -950,7 +950,7 @@ func (t *Team) sigTeamItem(ctx context.Context, section SCTeamSection, linkType 
 		sigJSON,
 		latestLinkID,
 		false, /* hasRevokes */
-		false, /* public */
+		keybase1.SeqType_SEMIPRIVATE,
 	)
 	if err != nil {
 		return libkb.SigMultiItem{}, err

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -950,6 +950,7 @@ func (t *Team) sigTeamItem(ctx context.Context, section SCTeamSection, linkType 
 		sigJSON,
 		latestLinkID,
 		false, /* hasRevokes */
+		false, /* public */
 	)
 	if err != nil {
 		return libkb.SigMultiItem{}, err

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -64,6 +64,7 @@ protocol remote {
 
   record GetThreadRemoteRes {
     ThreadViewBoxed thread;
+    ConversationMembersType membersType;
     union { null, RateLimit } rateLimit;
   }
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -361,6 +361,7 @@ protocol teams {
     boolean forceFullReload;      // Ignore local data and fetch from the server.
     boolean forceRepoll;          // Force a sync with merkle.
     boolean staleOK;              // If a very stale cache hit is OK.
+    boolean public;               // For public teams.
   }
 
   record ImplicitRole {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -482,8 +482,14 @@ protocol teams {
     Time time;
   }
 
-  TeamID lookupImplicitTeam(string name, boolean public);
-  TeamID lookupOrCreateImplicitTeam(string name, boolean public);
+  record LookupImplicitTeamRes {
+    TeamID teamID;
+    TeamName name;
+    ImplicitTeamDisplayName displayName;
+  }
+
+  LookupImplicitTeamRes lookupImplicitTeam(string name, boolean public);
+  LookupImplicitTeamRes lookupOrCreateImplicitTeam(string name, boolean public);
 
   void teamReAddMemberAfterReset(int sessionID, TeamID id, string username);
 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1230,6 +1230,7 @@ export type GetThreadQuery = {
 
 export type GetThreadRemoteRes = {
   thread: ThreadViewBoxed,
+  membersType: ConversationMembersType,
   rateLimit?: ?RateLimit,
 }
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3665,6 +3665,12 @@ export type LogLevel =
   | 6 // CRITICAL_6
   | 7 // FATAL_7
 
+export type LookupImplicitTeamRes = {
+  teamID: TeamID,
+  name: TeamName,
+  displayName: ImplicitTeamDisplayName,
+}
+
 export type MDBlock = {
   version: int,
   timestamp: Time,
@@ -6529,8 +6535,8 @@ type streamUiReadResult = bytes
 type streamUiWriteResult = int
 type teamsGetTeamRootIDResult = TeamID
 type teamsLoadTeamPlusApplicationKeysResult = TeamPlusApplicationKeys
-type teamsLookupImplicitTeamResult = TeamID
-type teamsLookupOrCreateImplicitTeamResult = TeamID
+type teamsLookupImplicitTeamResult = LookupImplicitTeamRes
+type teamsLookupOrCreateImplicitTeamResult = LookupImplicitTeamRes
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamCreateResult = TeamCreateResult
 type teamsTeamCreateWithSettingsResult = TeamCreateResult

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3646,6 +3646,7 @@ export type LoadTeamArg = {
   forceFullReload: boolean,
   forceRepoll: boolean,
   staleOK: boolean,
+  public: boolean,
 }
 
 export type LockContext = {

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -120,6 +120,10 @@
           "name": "thread"
         },
         {
+          "type": "ConversationMembersType",
+          "name": "membersType"
+        },
+        {
           "type": [
             null,
             "RateLimit"

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -889,6 +889,10 @@
         {
           "type": "boolean",
           "name": "staleOK"
+        },
+        {
+          "type": "boolean",
+          "name": "public"
         }
       ]
     },

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1176,6 +1176,24 @@
           "name": "time"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "LookupImplicitTeamRes",
+      "fields": [
+        {
+          "type": "TeamID",
+          "name": "teamID"
+        },
+        {
+          "type": "TeamName",
+          "name": "name"
+        },
+        {
+          "type": "ImplicitTeamDisplayName",
+          "name": "displayName"
+        }
+      ]
     }
   ],
   "messages": {
@@ -1515,7 +1533,7 @@
           "type": "boolean"
         }
       ],
-      "response": "TeamID"
+      "response": "LookupImplicitTeamRes"
     },
     "lookupOrCreateImplicitTeam": {
       "request": [
@@ -1528,7 +1546,7 @@
           "type": "boolean"
         }
       ],
-      "response": "TeamID"
+      "response": "LookupImplicitTeamRes"
     },
     "teamReAddMemberAfterReset": {
       "request": [

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1230,6 +1230,7 @@ export type GetThreadQuery = {
 
 export type GetThreadRemoteRes = {
   thread: ThreadViewBoxed,
+  membersType: ConversationMembersType,
   rateLimit?: ?RateLimit,
 }
 

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3665,6 +3665,12 @@ export type LogLevel =
   | 6 // CRITICAL_6
   | 7 // FATAL_7
 
+export type LookupImplicitTeamRes = {
+  teamID: TeamID,
+  name: TeamName,
+  displayName: ImplicitTeamDisplayName,
+}
+
 export type MDBlock = {
   version: int,
   timestamp: Time,
@@ -6529,8 +6535,8 @@ type streamUiReadResult = bytes
 type streamUiWriteResult = int
 type teamsGetTeamRootIDResult = TeamID
 type teamsLoadTeamPlusApplicationKeysResult = TeamPlusApplicationKeys
-type teamsLookupImplicitTeamResult = TeamID
-type teamsLookupOrCreateImplicitTeamResult = TeamID
+type teamsLookupImplicitTeamResult = LookupImplicitTeamRes
+type teamsLookupOrCreateImplicitTeamResult = LookupImplicitTeamRes
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamCreateResult = TeamCreateResult
 type teamsTeamCreateWithSettingsResult = TeamCreateResult

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3646,6 +3646,7 @@ export type LoadTeamArg = {
   forceFullReload: boolean,
   forceRepoll: boolean,
   staleOK: boolean,
+  public: boolean,
 }
 
 export type LockContext = {


### PR DESCRIPTION
Patch does the following:

1.) Gets all the chat tests to pass in `IMPTEAM` mode.
2.) Makes CLI work properly with `IMPTEAM` chats.