### PR TITLE
fix revoke screen

### DIFF
--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -17,7 +17,7 @@ import {isLoading} from '../constants/tracker'
 import {isTesting} from '../local-debug'
 import {navigateAppend, navigateUp} from '../actions/route-tree'
 import {openInKBFS} from '../actions/kbfs'
-import {peopleTab, profileTab} from '../constants/tabs'
+import {peopleTab} from '../constants/tabs'
 import {startConversation} from '../actions/chat'
 
 import type {MissingProof} from '../common-adapters/user-proofs'
@@ -63,8 +63,7 @@ export default pausableConnect(
     return {
       currentFriendshipsTab: routeState.currentFriendshipsTab,
       myUsername,
-      profileIsRoot: routePath.size === 1 &&
-        (routePath.first() === profileTab || routePath.first() === peopleTab),
+      profileIsRoot: routePath.size === 1 && routePath.first() === peopleTab,
       trackerState: state.tracker.trackers[username],
       username,
     }
@@ -119,7 +118,7 @@ export default pausableConnect(
               selected: 'revoke',
             },
           ],
-          [profileTab]
+          [peopleTab]
         )
       )
     },


### PR DESCRIPTION
@keybase/react-hackers 
When we renamed the profiletab/peopletab this is a leftover that wasn't updated so the route was changed so revoking no longer worked