### PR TITLE
set right path for startup gui shortcut

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -186,7 +186,7 @@
                   Description="Start GUI at boot"
                   Target="[INSTALLFOLDER]keybaserq.exe"
                   Arguments="&quot;[GuiDir]Keybase.exe&quot;"
-                  WorkingDirectory="INSTALLFOLDER"/>
+                  WorkingDirectory="GuiDir"/>
         <RegistryKey Root="HKCU" Key="Software\Keybase\Keybase">
           <RegistryValue Name="ShortCutStartUpGUI" Type="integer" Value="1" KeyPath="yes"  />
         </RegistryKey>


### PR DESCRIPTION
There was still one more bug: split install wouldn't work after reboot, since the location it was given was not right relative to the regedit files we just added. Confident a smoketest pair with this will be good.
@keybase/react-hackers 