### PR TITLE
Open team client commands

### DIFF
--- a/go/client/cmd_team.go
+++ b/go/client/cmd_team.go
@@ -29,6 +29,7 @@ func NewCmdTeam(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 			newCmdTeamLeave(cl, g),
 			newCmdTeamDelete(cl, g),
 			newCmdTeamAPI(cl, g),
+			newCmdTeamEdit(cl, g),
 		},
 	}
 }

--- a/go/client/cmd_team.go
+++ b/go/client/cmd_team.go
@@ -29,7 +29,7 @@ func NewCmdTeam(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 			newCmdTeamLeave(cl, g),
 			newCmdTeamDelete(cl, g),
 			newCmdTeamAPI(cl, g),
-			newCmdTeamEdit(cl, g),
+			newCmdTeamSettings(cl, g),
 		},
 	}
 }

--- a/go/client/cmd_team_edit.go
+++ b/go/client/cmd_team_edit.go
@@ -1,0 +1,154 @@
+package client
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"golang.org/x/net/context"
+)
+
+type CmdTeamEdit struct {
+	libkb.Contextified
+	Team     keybase1.TeamName
+	IsSet    bool
+	Settings keybase1.TeamSettings
+}
+
+func newCmdTeamEdit(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "edit",
+		ArgumentHelp: "<team name>",
+		Usage:        "Edit team settings.",
+		Action: func(c *cli.Context) {
+			cmd := NewCmdTeamEditRunner(g)
+			cl.ChooseCommand(cmd, "edit", c)
+		},
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "open",
+				Usage: "Change team to be open or closed",
+			},
+			cli.StringFlag{
+				Name:  "join-as",
+				Usage: "team role (writer, reader) [required when changing team to open]",
+			},
+		},
+	}
+}
+
+func NewCmdTeamEditRunner(g *libkb.GlobalContext) *CmdTeamEdit {
+	return &CmdTeamEdit{Contextified: libkb.NewContextified(g)}
+}
+
+func (c *CmdTeamEdit) ParseArgv(ctx *cli.Context) error {
+	var err error
+	c.Team, err = ParseOneTeamNameK1(ctx)
+	if err != nil {
+		return err
+	}
+
+	if ctx.NumFlags() == 0 {
+		// Just a team name and no other flags - print current team settings.
+		return nil
+	}
+
+	sopen := ctx.String("open")
+	switch sopen {
+	case "true":
+		c.Settings.Open = true
+	case "false":
+		c.Settings.Open = false
+	default:
+		return errors.New("invalid --open flag, please use true or false")
+	}
+
+	if c.Settings.Open {
+		srole := ctx.String("join-as")
+		if srole == "" {
+			return errors.New("team role required via --join-as flag")
+		}
+
+		role, ok := keybase1.TeamRoleMap[strings.ToUpper(srole)]
+		if !ok {
+			return errors.New("invalid team role, please use writer, or reader")
+		}
+
+		switch role {
+		case keybase1.TeamRole_READER, keybase1.TeamRole_WRITER:
+			break
+		default:
+			return errors.New("invalid team role, please use writer, or reader")
+		}
+
+		c.Settings.JoinAs = role
+	}
+
+	c.IsSet = true
+	return nil
+}
+
+func (c *CmdTeamEdit) Run() error {
+	protocols := []rpc.Protocol{
+		NewTeamsUIProtocol(c.G()),
+	}
+	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
+	cli, err := GetTeamsClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	dui := c.G().UI.GetTerminalUI()
+
+	if c.IsSet {
+		details, err := cli.TeamGet(context.Background(), keybase1.TeamGetArg{Name: c.Team.String(), ForceRepoll: false})
+		if err != nil {
+			return err
+		}
+
+		if !details.Settings.Equal(c.Settings) {
+			arg := keybase1.TeamSetSettingsArg{
+				Name:     c.Team.String(),
+				Settings: c.Settings,
+			}
+
+			err = cli.TeamSetSettings(context.Background(), arg)
+			if err != nil {
+				return err
+			}
+
+			dui.Printf("Team settings change was successful!\n")
+		} else {
+			dui.Printf("No changes were needed.\n")
+		}
+	}
+
+	details, err := cli.TeamGet(context.Background(), keybase1.TeamGetArg{Name: c.Team.String(), ForceRepoll: c.IsSet})
+	if err != nil {
+		return err
+	}
+
+	dui.Printf("Current settings of team %q:\n", c.Team.String())
+	if details.Settings.Open {
+		dui.Printf("  Open:\t\t\ttrue\n")
+		dui.Printf("  New member role:\t%s\n", details.Settings.JoinAs)
+	} else {
+		dui.Printf("  Open:\tfalse\n")
+	}
+
+	return nil
+}
+
+func (c *CmdTeamEdit) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/client/cmd_team_edit.go
+++ b/go/client/cmd_team_edit.go
@@ -110,6 +110,11 @@ func (c *CmdTeamEdit) applySettings(cli keybase1.TeamsClient) error {
 
 	err := cli.TeamSetSettings(context.Background(), arg)
 	if err != nil {
+		if e, ok := err.(libkb.NoOpError); ok {
+			dui.Printf("%s\n", e.Desc)
+			return nil
+		}
+
 		return err
 	}
 

--- a/go/client/cmd_team_edit.go
+++ b/go/client/cmd_team_edit.go
@@ -14,9 +14,9 @@ import (
 
 type CmdTeamEdit struct {
 	libkb.Contextified
-	Team     keybase1.TeamName
-	IsSet    bool
-	Settings keybase1.TeamSettings
+	Team      keybase1.TeamName
+	PrintOnly bool
+	Settings  keybase1.TeamSettings
 }
 
 func newCmdTeamEdit(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -54,6 +54,7 @@ func (c *CmdTeamEdit) ParseArgv(ctx *cli.Context) error {
 
 	if ctx.NumFlags() == 0 {
 		// Just a team name and no other flags - print current team settings.
+		c.PrintOnly = true
 		return nil
 	}
 
@@ -88,7 +89,6 @@ func (c *CmdTeamEdit) ParseArgv(ctx *cli.Context) error {
 		c.Settings.JoinAs = role
 	}
 
-	c.IsSet = true
 	return nil
 }
 
@@ -138,13 +138,13 @@ func (c *CmdTeamEdit) Run() error {
 		return err
 	}
 
-	if c.IsSet {
+	if !c.PrintOnly {
 		if err := c.applySettings(cli); err != nil {
 			return err
 		}
 	}
 
-	details, err := cli.TeamGet(context.Background(), keybase1.TeamGetArg{Name: c.Team.String(), ForceRepoll: c.IsSet})
+	details, err := cli.TeamGet(context.Background(), keybase1.TeamGetArg{Name: c.Team.String(), ForceRepoll: !c.PrintOnly})
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_team_remove_member.go
+++ b/go/client/cmd_team_remove_member.go
@@ -16,10 +16,17 @@ import (
 
 type CmdTeamRemoveMember struct {
 	libkb.Contextified
+<<<<<<< HEAD
 	Team     string
 	Username string
 	Email    string
 	Force    bool
+=======
+	Team      string
+	Username  string
+	Force     bool
+	Permanent bool
+>>>>>>> Add `team remove-member --permanent` command
 }
 
 func NewCmdTeamRemoveMemberRunner(g *libkb.GlobalContext) *CmdTeamRemoveMember {
@@ -48,6 +55,10 @@ func newCmdTeamRemoveMember(cl *libcmdline.CommandLine, g *libkb.GlobalContext) 
 				Name:  "f, force",
 				Usage: "bypass warnings",
 			},
+			cli.BoolFlag{
+				Name:  "p, permanent",
+				Usage: "prevent user from re-joining (open teams only)",
+			},
 		},
 	}
 }
@@ -67,6 +78,7 @@ func (c *CmdTeamRemoveMember) ParseArgv(ctx *cli.Context) error {
 		return errors.New("You cannot specify --user and --email.  Please choose one.")
 	}
 
+<<<<<<< HEAD
 	if len(c.Username) == 0 && len(c.Email) == 0 {
 		return errors.New("Username or email required.  Use --user or --email flag.")
 	}
@@ -82,6 +94,10 @@ func (c *CmdTeamRemoveMember) ParseArgv(ctx *cli.Context) error {
 			return fmt.Errorf("Invalid email address %q. If you'd like to remove an existing member for your team, please use their keybase username and the `--user` flag instead of `--email`.", c.Email)
 		}
 	}
+=======
+	c.Force = ctx.Bool("force")
+	c.Permanent = ctx.Bool("permanent")
+>>>>>>> Add `team remove-member --permanent` command
 
 	return nil
 }
@@ -120,9 +136,15 @@ func (c *CmdTeamRemoveMember) Run() error {
 	}
 
 	arg := keybase1.TeamRemoveMemberArg{
+<<<<<<< HEAD
 		Name:     c.Team,
 		Username: c.Username,
 		Email:    c.Email,
+=======
+		Name:      c.Team,
+		Username:  c.Username,
+		Permanent: c.Permanent,
+>>>>>>> Add `team remove-member --permanent` command
 	}
 
 	if err = cli.TeamRemoveMember(context.Background(), arg); err != nil {

--- a/go/client/cmd_team_remove_member.go
+++ b/go/client/cmd_team_remove_member.go
@@ -16,10 +16,10 @@ import (
 
 type CmdTeamRemoveMember struct {
 	libkb.Contextified
-	Team     string
-	Username string
-	Email    string
-	Force    bool
+	Team      string
+	Username  string
+	Email     string
+	Force     bool
 	Permanent bool
 }
 
@@ -128,7 +128,7 @@ func (c *CmdTeamRemoveMember) Run() error {
 	arg := keybase1.TeamRemoveMemberArg{
 		Name:      c.Team,
 		Username:  c.Username,
-		Email:    c.Email,
+		Email:     c.Email,
 		Permanent: c.Permanent,
 	}
 

--- a/go/client/cmd_team_remove_member.go
+++ b/go/client/cmd_team_remove_member.go
@@ -16,17 +16,11 @@ import (
 
 type CmdTeamRemoveMember struct {
 	libkb.Contextified
-<<<<<<< HEAD
 	Team     string
 	Username string
 	Email    string
 	Force    bool
-=======
-	Team      string
-	Username  string
-	Force     bool
 	Permanent bool
->>>>>>> Add `team remove-member --permanent` command
 }
 
 func NewCmdTeamRemoveMemberRunner(g *libkb.GlobalContext) *CmdTeamRemoveMember {
@@ -73,12 +67,12 @@ func (c *CmdTeamRemoveMember) ParseArgv(ctx *cli.Context) error {
 	c.Username = ctx.String("user")
 	c.Email = ctx.String("email")
 	c.Force = ctx.Bool("force")
+	c.Permanent = ctx.Bool("permanent")
 
 	if len(c.Username) > 0 && len(c.Email) > 0 {
 		return errors.New("You cannot specify --user and --email.  Please choose one.")
 	}
 
-<<<<<<< HEAD
 	if len(c.Username) == 0 && len(c.Email) == 0 {
 		return errors.New("Username or email required.  Use --user or --email flag.")
 	}
@@ -94,10 +88,6 @@ func (c *CmdTeamRemoveMember) ParseArgv(ctx *cli.Context) error {
 			return fmt.Errorf("Invalid email address %q. If you'd like to remove an existing member for your team, please use their keybase username and the `--user` flag instead of `--email`.", c.Email)
 		}
 	}
-=======
-	c.Force = ctx.Bool("force")
-	c.Permanent = ctx.Bool("permanent")
->>>>>>> Add `team remove-member --permanent` command
 
 	return nil
 }
@@ -136,15 +126,10 @@ func (c *CmdTeamRemoveMember) Run() error {
 	}
 
 	arg := keybase1.TeamRemoveMemberArg{
-<<<<<<< HEAD
-		Name:     c.Team,
-		Username: c.Username,
-		Email:    c.Email,
-=======
 		Name:      c.Team,
 		Username:  c.Username,
+		Email:    c.Email,
 		Permanent: c.Permanent,
->>>>>>> Add `team remove-member --permanent` command
 	}
 
 	if err = cli.TeamRemoveMember(context.Background(), arg); err != nil {

--- a/go/client/cmd_team_settings.go
+++ b/go/client/cmd_team_settings.go
@@ -11,29 +11,29 @@ import (
 	"golang.org/x/net/context"
 )
 
-type CmdTeamEdit struct {
+type CmdTeamSettings struct {
 	libkb.Contextified
 	Team      keybase1.TeamName
 	PrintOnly bool
 	Settings  keybase1.TeamSettings
 }
 
-func newCmdTeamEdit(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+func newCmdTeamSettings(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
-		Name:         "edit",
+		Name:         "settings",
 		ArgumentHelp: "<team name>",
 		Usage:        "Edit team settings.",
 		Action: func(c *cli.Context) {
-			cmd := NewCmdTeamEditRunner(g)
-			cl.ChooseCommand(cmd, "edit", c)
+			cmd := NewCmdTeamSettingsRunner(g)
+			cl.ChooseCommand(cmd, "settings", c)
 		},
 		Flags: []cli.Flag{
 			cli.BoolFlag{
-				Name:  "open",
+				Name:  "set-open",
 				Usage: "set team to open",
 			},
 			cli.BoolFlag{
-				Name:  "closed",
+				Name:  "set-closed",
 				Usage: "set team to closed",
 			},
 			cli.StringFlag{
@@ -44,11 +44,11 @@ func newCmdTeamEdit(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 	}
 }
 
-func NewCmdTeamEditRunner(g *libkb.GlobalContext) *CmdTeamEdit {
-	return &CmdTeamEdit{Contextified: libkb.NewContextified(g)}
+func NewCmdTeamSettingsRunner(g *libkb.GlobalContext) *CmdTeamSettings {
+	return &CmdTeamSettings{Contextified: libkb.NewContextified(g)}
 }
 
-func (c *CmdTeamEdit) ParseArgv(ctx *cli.Context) error {
+func (c *CmdTeamSettings) ParseArgv(ctx *cli.Context) error {
 	var err error
 	c.Team, err = ParseOneTeamNameK1(ctx)
 	if err != nil {
@@ -61,12 +61,12 @@ func (c *CmdTeamEdit) ParseArgv(ctx *cli.Context) error {
 		return nil
 	}
 
-	if ctx.Bool("open") && ctx.Bool("closed") {
-		return errors.New("cannot use --open and --closed at the same time")
+	if ctx.Bool("set-open") && ctx.Bool("set-closed") {
+		return errors.New("cannot use --set-open and --set-closed at the same time")
 
 	}
 
-	if ctx.Bool("open") {
+	if ctx.Bool("set-open") {
 		c.Settings.Open = true
 
 		srole := ctx.String("join-as")
@@ -87,20 +87,20 @@ func (c *CmdTeamEdit) ParseArgv(ctx *cli.Context) error {
 		}
 
 		c.Settings.JoinAs = role
-	} else if ctx.Bool("closed") {
+	} else if ctx.Bool("set-closed") {
 		c.Settings.Open = false
 	} else {
 		// Happens when user supplies --join-as only:
 		// > keybase team edit teamname --join-as reader
-		// For simplicity, we require always --open/--closed flag,
+		// For simplicity, we require always --set-open/--set-closed flag,
 		// even if user just wants to change join_as role.
-		return errors.New("--open or --closed flag is required")
+		return errors.New("--set-open or --set-closed flag is required")
 	}
 
 	return nil
 }
 
-func (c *CmdTeamEdit) applySettings(cli keybase1.TeamsClient) error {
+func (c *CmdTeamSettings) applySettings(cli keybase1.TeamsClient) error {
 	dui := c.G().UI.GetTerminalUI()
 
 	arg := keybase1.TeamSetSettingsArg{
@@ -122,7 +122,7 @@ func (c *CmdTeamEdit) applySettings(cli keybase1.TeamsClient) error {
 	return nil
 }
 
-func (c *CmdTeamEdit) Run() error {
+func (c *CmdTeamSettings) Run() error {
 	cli, err := GetTeamsClient(c.G())
 	if err != nil {
 		return err
@@ -151,7 +151,7 @@ func (c *CmdTeamEdit) Run() error {
 	return nil
 }
 
-func (c *CmdTeamEdit) GetUsage() libkb.Usage {
+func (c *CmdTeamSettings) GetUsage() libkb.Usage {
 	return libkb.Usage{
 		Config:    true,
 		API:       true,

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -272,6 +272,7 @@ const (
 	SCGitRepoAlreadyExists     = int(keybase1.StatusCode_SCGitRepoAlreadyExists)
 	SCGitInvalidRepoName       = int(keybase1.StatusCode_SCGitInvalidRepoName)
 	SCGitCannotDelete          = int(keybase1.StatusCode_SCGitCannotDelete)
+	SCTeamBanned               = int(keybase1.StatusCode_SCTeamBanned)
 )
 
 const (

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -273,6 +273,7 @@ const (
 	SCGitInvalidRepoName       = int(keybase1.StatusCode_SCGitInvalidRepoName)
 	SCGitCannotDelete          = int(keybase1.StatusCode_SCGitCannotDelete)
 	SCTeamBanned               = int(keybase1.StatusCode_SCTeamBanned)
+	SCNoOp                     = int(keybase1.StatusCode_SCNoOp)
 )
 
 const (

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -260,6 +260,7 @@ const (
 	SCAccountReset             = int(keybase1.StatusCode_SCAccountReset)
 	SCIdentifiesFailed         = int(keybase1.StatusCode_SCIdentifiesFailed)
 	SCTeamReadError            = int(keybase1.StatusCode_SCTeamReadError)
+	SCNoOp                     = int(keybase1.StatusCode_SCNoOp)
 	SCTeamNotFound             = int(keybase1.StatusCode_SCTeamNotFound)
 	SCTeamTarDuplicate         = int(keybase1.StatusCode_SCTeamTarDuplicate)
 	SCTeamTarNotFound          = int(keybase1.StatusCode_SCTeamTarNotFound)
@@ -273,7 +274,7 @@ const (
 	SCGitInvalidRepoName       = int(keybase1.StatusCode_SCGitInvalidRepoName)
 	SCGitCannotDelete          = int(keybase1.StatusCode_SCGitCannotDelete)
 	SCTeamBanned               = int(keybase1.StatusCode_SCTeamBanned)
-	SCNoOp                     = int(keybase1.StatusCode_SCNoOp)
+	SCTeamInvalidBan           = int(keybase1.StatusCode_SCTeamInvalidBan)
 )
 
 const (

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2166,7 +2166,7 @@ func (e RepoAlreadyExistsError) Error() string {
 
 //=============================================================================
 
-// NoOpError is returned when an RPC call is issued but it would be
+// NoOpError is returned when an RPC call is issued but it would
 // result in no change, so the call is dropped.
 type NoOpError struct {
 	Desc string

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2163,3 +2163,15 @@ func (e RepoAlreadyExistsError) Error() string {
 		"A repo named %s (id=%s) already existed when trying to create "+
 			"a repo named %s", e.ExistingName, e.ExistingID, e.DesiredName)
 }
+
+//=============================================================================
+
+// NoOpError is returned when an RPC call is issued but it would be
+// result in no change, so the call is dropped.
+type NoOpError struct {
+	Desc string
+}
+
+func (e NoOpError) Error() string {
+	return e.Desc
+}

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -640,7 +640,8 @@ func ImportStatusAsError(g *GlobalContext, s *keybase1.Status) error {
 			}
 		}
 		return e
-
+	case SCNoOp:
+		return NoOpError{Desc: s.Desc}
 	default:
 		ase := AppStatusError{
 			Code:   s.Code,
@@ -2128,5 +2129,12 @@ func (e RepoAlreadyExistsError) ToStatus() (s keybase1.Status) {
 		{Key: "ExistingName", Value: e.ExistingName},
 		{Key: "ExistingID", Value: e.ExistingID},
 	}
+	return
+}
+
+func (e NoOpError) ToStatus() (s keybase1.Status) {
+	s.Code = SCNoOp
+	s.Name = "SC_NO_OP"
+	s.Desc = e.Desc
 	return
 }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -119,6 +119,7 @@ const (
 	StatusCode_SCTeamNotFound              StatusCode = 2614
 	StatusCode_SCTeamExists                StatusCode = 2619
 	StatusCode_SCTeamReadError             StatusCode = 2623
+	StatusCode_SCNoOp                      StatusCode = 2638
 	StatusCode_SCTeamTarDuplicate          StatusCode = 2663
 	StatusCode_SCTeamTarNotFound           StatusCode = 2664
 	StatusCode_SCTeamMemberExists          StatusCode = 2665
@@ -145,7 +146,7 @@ const (
 	StatusCode_SCTeamImplicitBadRemove     StatusCode = 2686
 	StatusCode_SCTeamKeyMaskNotFound       StatusCode = 2697
 	StatusCode_SCTeamBanned                StatusCode = 2702
-	StatusCode_SCNoOp                      StatusCode = 2703
+	StatusCode_SCTeamInvalidBan            StatusCode = 2703
 )
 
 func (o StatusCode) DeepCopy() StatusCode { return o }
@@ -260,6 +261,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamNotFound":              2614,
 	"SCTeamExists":                2619,
 	"SCTeamReadError":             2623,
+	"SCNoOp":                      2638,
 	"SCTeamTarDuplicate":          2663,
 	"SCTeamTarNotFound":           2664,
 	"SCTeamMemberExists":          2665,
@@ -286,7 +288,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamImplicitBadRemove":     2686,
 	"SCTeamKeyMaskNotFound":       2697,
 	"SCTeamBanned":                2702,
-	"SCNoOp":                      2703,
+	"SCTeamInvalidBan":            2703,
 }
 
 var StatusCodeRevMap = map[StatusCode]string{
@@ -399,6 +401,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2614: "SCTeamNotFound",
 	2619: "SCTeamExists",
 	2623: "SCTeamReadError",
+	2638: "SCNoOp",
 	2663: "SCTeamTarDuplicate",
 	2664: "SCTeamTarNotFound",
 	2665: "SCTeamMemberExists",
@@ -425,7 +428,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2686: "SCTeamImplicitBadRemove",
 	2697: "SCTeamKeyMaskNotFound",
 	2702: "SCTeamBanned",
-	2703: "SCNoOp",
+	2703: "SCTeamInvalidBan",
 }
 
 func (e StatusCode) String() string {

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -144,6 +144,7 @@ const (
 	StatusCode_SCTeamImplicitBadAdd        StatusCode = 2685
 	StatusCode_SCTeamImplicitBadRemove     StatusCode = 2686
 	StatusCode_SCTeamKeyMaskNotFound       StatusCode = 2697
+	StatusCode_SCTeamBanned                StatusCode = 2702
 )
 
 func (o StatusCode) DeepCopy() StatusCode { return o }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -285,6 +285,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamImplicitBadAdd":        2685,
 	"SCTeamImplicitBadRemove":     2686,
 	"SCTeamKeyMaskNotFound":       2697,
+	"SCTeamBanned":                2702,
 	"SCNoOp":                      2703,
 }
 
@@ -423,6 +424,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2685: "SCTeamImplicitBadAdd",
 	2686: "SCTeamImplicitBadRemove",
 	2697: "SCTeamKeyMaskNotFound",
+	2702: "SCTeamBanned",
 	2703: "SCNoOp",
 }
 

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -145,6 +145,7 @@ const (
 	StatusCode_SCTeamImplicitBadRemove     StatusCode = 2686
 	StatusCode_SCTeamKeyMaskNotFound       StatusCode = 2697
 	StatusCode_SCTeamBanned                StatusCode = 2702
+	StatusCode_SCNoOp                      StatusCode = 2703
 )
 
 func (o StatusCode) DeepCopy() StatusCode { return o }
@@ -284,6 +285,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamImplicitBadAdd":        2685,
 	"SCTeamImplicitBadRemove":     2686,
 	"SCTeamKeyMaskNotFound":       2697,
+	"SCNoOp":                      2703,
 }
 
 var StatusCodeRevMap = map[StatusCode]string{
@@ -421,6 +423,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2685: "SCTeamImplicitBadAdd",
 	2686: "SCTeamImplicitBadRemove",
 	2697: "SCTeamKeyMaskNotFound",
+	2703: "SCNoOp",
 }
 
 func (e StatusCode) String() string {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1963,3 +1963,10 @@ func (p StringKVPair) IntValue() int {
 	}
 	return i
 }
+
+func (s TeamSettings) Equal(other TeamSettings) bool {
+	if s.Open {
+		return other.Open && other.JoinAs == s.JoinAs
+	}
+	return !other.Open
+}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1963,10 +1963,3 @@ func (p StringKVPair) IntValue() int {
 	}
 	return i
 }
-
-func (s TeamSettings) Equal(other TeamSettings) bool {
-	if s.Open {
-		return other.Open && other.JoinAs == s.JoinAs
-	}
-	return !other.Open
-}

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1492,6 +1492,7 @@ type TeamRemoveMemberArg struct {
 	Name      string `codec:"name" json:"name"`
 	Username  string `codec:"username" json:"username"`
 	Email     string `codec:"email" json:"email"`
+	Permanent bool   `codec:"permanent" json:"permanent"`
 }
 
 func (o TeamRemoveMemberArg) DeepCopy() TeamRemoveMemberArg {
@@ -1500,6 +1501,7 @@ func (o TeamRemoveMemberArg) DeepCopy() TeamRemoveMemberArg {
 		Name:      o.Name,
 		Username:  o.Username,
 		Email:     o.Email,
+		Permanent: o.Permanent,
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -311,6 +311,7 @@ type TeamDetails struct {
 	Members                TeamMembersDetails                   `codec:"members" json:"members"`
 	KeyGeneration          PerTeamKeyGeneration                 `codec:"keyGeneration" json:"keyGeneration"`
 	AnnotatedActiveInvites map[TeamInviteID]AnnotatedTeamInvite `codec:"annotatedActiveInvites" json:"annotatedActiveInvites"`
+	Settings               TeamSettings                         `codec:"settings" json:"settings"`
 }
 
 func (o TeamDetails) DeepCopy() TeamDetails {
@@ -329,6 +330,7 @@ func (o TeamDetails) DeepCopy() TeamDetails {
 			}
 			return ret
 		})(o.AnnotatedActiveInvites),
+		Settings: o.Settings.DeepCopy(),
 	}
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -242,7 +242,7 @@ func (h *TeamsHandler) TeamDelete(ctx context.Context, arg keybase1.TeamDeleteAr
 }
 
 func (h *TeamsHandler) TeamSetSettings(ctx context.Context, arg keybase1.TeamSetSettingsArg) (err error) {
-	return fmt.Errorf("Not implemented")
+	return teams.ChangeTeamSettings(ctx, h.G().ExternalG(), arg.Name, arg.Settings)
 }
 
 func (h *TeamsHandler) LoadTeamPlusApplicationKeys(netCtx context.Context, arg keybase1.LoadTeamPlusApplicationKeysArg) (keybase1.TeamPlusApplicationKeys, error) {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -180,17 +180,13 @@ func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMe
 func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRemoveMemberArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRemoveMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
-<<<<<<< HEAD
 
 	if len(arg.Email) > 0 {
 		h.G().Log.CDebugf(ctx, "TeamRemoveMember: received email address, using CancelEmailInvite for %q in team %q", arg.Email, arg.Name)
 		return teams.CancelEmailInvite(ctx, h.G().ExternalG(), arg.Name, arg.Email)
 	}
 	h.G().Log.CDebugf(ctx, "TeamRemoveMember: using RemoveMember for %q in team %q", arg.Username, arg.Name)
-	return teams.RemoveMember(ctx, h.G().ExternalG(), arg.Name, arg.Username)
-=======
 	return teams.RemoveMember(ctx, h.G().ExternalG(), arg.Name, arg.Username, arg.Permanent)
->>>>>>> Add `team remove-member --permanent` command
 }
 
 func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEditMemberArg) (err error) {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -180,6 +180,7 @@ func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMe
 func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRemoveMemberArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRemoveMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
+<<<<<<< HEAD
 
 	if len(arg.Email) > 0 {
 		h.G().Log.CDebugf(ctx, "TeamRemoveMember: received email address, using CancelEmailInvite for %q in team %q", arg.Email, arg.Name)
@@ -187,6 +188,9 @@ func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRe
 	}
 	h.G().Log.CDebugf(ctx, "TeamRemoveMember: using RemoveMember for %q in team %q", arg.Username, arg.Name)
 	return teams.RemoveMember(ctx, h.G().ExternalG(), arg.Name, arg.Username)
+=======
+	return teams.RemoveMember(ctx, h.G().ExternalG(), arg.Name, arg.Username, arg.Permanent)
+>>>>>>> Add `team remove-member --permanent` command
 }
 
 func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEditMemberArg) (err error) {

--- a/go/systests/team_open_test.go
+++ b/go/systests/team_open_test.go
@@ -194,7 +194,6 @@ func TestTeamOpenBans(t *testing.T) {
 	t.Logf("Trying team edit cli...")
 	runner := client.NewCmdTeamEditRunner(own.tc.G)
 	runner.Team = teamName
-	runner.IsSet = true
 	runner.Settings = keybase1.TeamSettings{
 		Open:   true,
 		JoinAs: keybase1.TeamRole_READER,

--- a/go/systests/team_open_test.go
+++ b/go/systests/team_open_test.go
@@ -72,13 +72,13 @@ func TestTeamOpenSettings(t *testing.T) {
 	teamObj := loadTeam()
 	require.Equal(t, teamObj.IsOpen(), false)
 
-	err := teams.ChangeTeamSettings(context.TODO(), own.tc.G, teamObj.ID, true)
+	err := teams.ChangeTeamSettings(context.TODO(), own.tc.G, teamName, keybase1.TeamSettings{Open: true, JoinAs: keybase1.TeamRole_READER})
 	require.NoError(t, err)
 
 	teamObj = loadTeam()
 	require.Equal(t, teamObj.IsOpen(), true)
 
-	err = teams.ChangeTeamSettings(context.TODO(), own.tc.G, teamObj.ID, false)
+	err = teams.ChangeTeamSettings(context.TODO(), own.tc.G, teamName, keybase1.TeamSettings{Open: false})
 	require.NoError(t, err)
 
 	teamObj = loadTeam()
@@ -110,7 +110,7 @@ func TestOpenSubteamAdd(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = teams.ChangeTeamSettings(context.TODO(), own.tc.G, subteamObj.ID, true)
+	err = teams.ChangeTeamSettings(context.TODO(), own.tc.G, subteamObj.Name().String(), keybase1.TeamSettings{Open: true, JoinAs: keybase1.TeamRole_READER})
 	require.NoError(t, err)
 
 	subteamObj, err = teams.Load(context.TODO(), own.tc.G, keybase1.LoadTeamArg{
@@ -155,10 +155,7 @@ func TestTeamOpenMultipleTars(t *testing.T) {
 	tar2.teamsClient.TeamRequestAccess(context.TODO(), keybase1.TeamRequestAccessArg{Name: team})
 
 	// Change settings to open
-	teamName, err := keybase1.TeamNameFromString(team)
-	require.NoError(t, err)
-	teamID := teamName.ToTeamID()
-	err = teams.ChangeTeamSettings(context.TODO(), own.tc.G, teamID, true)
+	err := teams.ChangeTeamSettings(context.TODO(), own.tc.G, team, keybase1.TeamSettings{Open: true, JoinAs: keybase1.TeamRole_READER})
 	require.NoError(t, err)
 
 	// tar3 requests, but rekeyd will grab all requests

--- a/go/systests/team_open_test.go
+++ b/go/systests/team_open_test.go
@@ -192,7 +192,7 @@ func TestTeamOpenBans(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Trying team edit cli...")
-	runner := client.NewCmdTeamEditRunner(own.tc.G)
+	runner := client.NewCmdTeamSettingsRunner(own.tc.G)
 	runner.Team = teamName
 	runner.Settings = keybase1.TeamSettings{
 		Open:   true,

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -132,7 +132,7 @@ func TestLoaderKeyGen(t *testing.T) {
 	t.Logf("rotate the key a bunch of times")
 	// Rotate the key by removing and adding B from the team
 	for i := 0; i < 3; i++ {
-		err = RemoveMember(context.TODO(), tcs[0].G, teamName.String(), fus[1].Username)
+		err = RemoveMember(context.TODO(), tcs[0].G, teamName.String(), fus[1].Username, false)
 		require.NoError(t, err)
 
 		_, err = AddMember(context.TODO(), tcs[0].G, teamName.String(), fus[1].Username, keybase1.TeamRole_READER)
@@ -232,7 +232,7 @@ func TestLoaderWantMembers(t *testing.T) {
 	require.Equal(t, keybase1.TeamRole_WRITER, role)
 
 	t.Logf("U0 bumps the sigchain (removemember) (5)")
-	err = RemoveMember(context.TODO(), tcs[0].G, teamName.String(), fus[3].Username)
+	err = RemoveMember(context.TODO(), tcs[0].G, teamName.String(), fus[3].Username, false)
 	require.NoError(t, err)
 
 	t.Logf("U1 loads with WantMembers=U2 and it hits the cache")

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -169,7 +169,7 @@ func TestMemberRemove(t *testing.T) {
 	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, name, other.Username, keybase1.TeamRole_WRITER)
 
-	if err := RemoveMember(context.TODO(), tc.G, name, other.Username); err != nil {
+	if err := RemoveMember(context.TODO(), tc.G, name, other.Username, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -269,7 +269,7 @@ func TestMemberRemoveRotatesKeys(t *testing.T) {
 	if err := SetRoleWriter(context.TODO(), tc.G, name, other.Username); err != nil {
 		t.Fatal(err)
 	}
-	if err := RemoveMember(context.TODO(), tc.G, name, other.Username); err != nil {
+	if err := RemoveMember(context.TODO(), tc.G, name, other.Username, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -737,7 +737,7 @@ func TestMemberCancelInviteNoKeys(t *testing.T) {
 	assertInvite(tc, name, "561247eb1cc3b0f5dc9d9bf299da5e19%0", "keybase", keybase1.TeamRole_READER)
 	assertRole(tc, name, username, keybase1.TeamRole_NONE)
 
-	if err := RemoveMember(context.TODO(), tc.G, name, username); err != nil {
+	if err := RemoveMember(context.TODO(), tc.G, name, username, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -758,7 +758,7 @@ func TestMemberCancelInviteSocial(t *testing.T) {
 	}
 	assertInvite(tc, name, "not_on_kb_yet", "twitter", keybase1.TeamRole_READER)
 
-	if err := RemoveMember(context.TODO(), tc.G, name, username); err != nil {
+	if err := RemoveMember(context.TODO(), tc.G, name, username, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/teams/rename_test.go
+++ b/go/teams/rename_test.go
@@ -152,7 +152,7 @@ func TestRenameIntoMovedSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U0 removes U1 from R.B (1)")
-	err = RemoveMember(context.TODO(), tcs[0].G, subteamNameB.String(), fus[1].Username)
+	err = RemoveMember(context.TODO(), tcs[0].G, subteamNameB.String(), fus[1].Username, false)
 	require.NoError(t, err)
 
 	t.Logf("U0 renames R.B (1) to R.C")

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -705,11 +705,13 @@ func ChangeTeamSettings(ctx context.Context, g *libkb.GlobalContext, teamName st
 	}
 
 	if !settings.Open && !t.IsOpen() {
-		return errors.New("Team is already closed.")
+		return libkb.NoOpError{Desc: "Team is already closed."}
 	}
 
 	if settings.Open && t.IsOpen() && t.OpenTeamJoinAs() == settings.JoinAs {
-		return fmt.Errorf("Team is already open with default role: %s.", strings.ToLower(t.OpenTeamJoinAs().String()))
+		return libkb.NoOpError{
+			Desc: fmt.Sprintf("Team is already open with default role: %s.", strings.ToLower(t.OpenTeamJoinAs().String())),
+		}
 	}
 
 	return t.PostTeamSettings(ctx, settings)

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -82,6 +82,8 @@ func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepo
 		delete(res.AnnotatedActiveInvites, invID)
 	}
 
+	res.Settings.Open = t.IsOpen()
+	res.Settings.JoinAs = t.chain().inner.OpenTeamJoinAs
 	return res, nil
 }
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -342,7 +342,7 @@ func MemberRole(ctx context.Context, g *libkb.GlobalContext, teamname, username 
 	return t.MemberRole(ctx, uv)
 }
 
-func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
+func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string, permanent bool) error {
 	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
 	if err != nil {
 		return err
@@ -370,7 +370,11 @@ func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 		return Leave(ctx, g, teamname, false)
 	}
 	req := keybase1.TeamChangeReq{None: []keybase1.UserVersion{existingUV}}
-	return t.ChangeMembership(ctx, req)
+
+	if permanent && !t.IsOpen() {
+		return fmt.Errorf("team %q is not open, cannot permanently remove member", teamname)
+	}
+	return t.ChangeMembershipPermanent(ctx, req, permanent)
 }
 
 func CancelEmailInvite(ctx context.Context, g *libkb.GlobalContext, teamname, email string) error {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -691,13 +691,13 @@ func ReAddMemberAfterReset(ctx context.Context, g *libkb.GlobalContext, teamID k
 	return t.ChangeMembership(ctx, req)
 }
 
-func ChangeTeamSettings(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, open bool) error {
-	t, err := GetForTeamManagementByTeamID(ctx, g, teamID, true)
+func ChangeTeamSettings(ctx context.Context, g *libkb.GlobalContext, teamName string, settings keybase1.TeamSettings) error {
+	t, err := GetForTeamManagementByStringName(ctx, g, teamName, true)
 	if err != nil {
 		return err
 	}
 
-	return t.PostTeamSettings(ctx, open)
+	return t.PostTeamSettings(ctx, settings)
 }
 
 func removeMemberInvite(ctx context.Context, g *libkb.GlobalContext, team *Team, username string, uv keybase1.UserVersion) error {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -3,6 +3,7 @@ package teams
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"golang.org/x/net/context"
@@ -701,6 +702,14 @@ func ChangeTeamSettings(ctx context.Context, g *libkb.GlobalContext, teamName st
 	t, err := GetForTeamManagementByStringName(ctx, g, teamName, true)
 	if err != nil {
 		return err
+	}
+
+	if !settings.Open && !t.IsOpen() {
+		return errors.New("Team is already closed.")
+	}
+
+	if settings.Open && t.IsOpen() && t.OpenTeamJoinAs() == settings.JoinAs {
+		return fmt.Errorf("Team is already open with default role: %s.", strings.ToLower(t.OpenTeamJoinAs().String()))
 	}
 
 	return t.PostTeamSettings(ctx, settings)

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1201,7 +1201,7 @@ func (t *Team) loadAllTransitiveSubteams(ctx context.Context, forceRepoll bool) 
 	return subteams, nil
 }
 
-func (t *Team) PostTeamSettings(ctx context.Context, open bool) error {
+func (t *Team) PostTeamSettings(ctx context.Context, settings keybase1.TeamSettings) error {
 	if _, err := t.SharedSecret(ctx); err != nil {
 		return err
 	}
@@ -1211,7 +1211,7 @@ func (t *Team) PostTeamSettings(ctx context.Context, open bool) error {
 		return err
 	}
 
-	settings, err := CreateTeamSettings(open, keybase1.TeamRole_READER)
+	scSettings, err := CreateTeamSettings(settings.Open, settings.JoinAs)
 	if err != nil {
 		return err
 	}
@@ -1219,7 +1219,7 @@ func (t *Team) PostTeamSettings(ctx context.Context, open bool) error {
 	section := SCTeamSection{
 		ID:       SCTeamID(t.ID),
 		Admin:    admin,
-		Settings: &settings,
+		Settings: &scSettings,
 	}
 
 	return t.postChangeItem(ctx, section, libkb.LinkTypeSettings, nil, sigPayloadArgs{})

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -58,6 +58,10 @@ func (t *Team) IsOpen() bool {
 	return t.chain().IsOpen()
 }
 
+func (t *Team) OpenTeamJoinAs() keybase1.TeamRole {
+	return t.chain().inner.OpenTeamJoinAs
+}
+
 func (t *Team) SharedSecret(ctx context.Context) (ret keybase1.PerTeamKeySeed, err error) {
 	defer t.G().CTrace(ctx, "Team#SharedSecret", func() error { return err })()
 	gen := t.chain().GetLatestGeneration()

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -111,6 +111,7 @@ protocol constants {
     SCTeamNotFound_2614,
     SCTeamExists_2619,
     SCTeamReadError_2623,
+    SCNoOp_2638,
     SCTeamTarDuplicate_2663,
     SCTeamTarNotFound_2664,
     SCTeamMemberExists_2665,
@@ -137,6 +138,6 @@ protocol constants {
     SCTeamImplicitBadRemove_2686,
     SCTeamKeyMaskNotFound_2697,
     SCTeamBanned_2702,
-    SCNoOp_2703
+    SCTeamInvalidBan_2703
   }
 }

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -135,6 +135,8 @@ protocol constants {
     SCTeamBadAdminSeqnoType_2684,
     SCTeamImplicitBadAdd_2685,
     SCTeamImplicitBadRemove_2686,
-    SCTeamKeyMaskNotFound_2697
+    SCTeamKeyMaskNotFound_2697,
+    SCTeamBanned_2702,
+    SCNoOp_2703
   }
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -452,7 +452,7 @@ protocol teams {
   array<TeamIDAndName> teamListSubteamsRecursive(int sessionID, string parentTeamName, boolean forceRepoll);
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);
   TeamAddMemberResult teamAddMember(int sessionID, string name, string email, string username, TeamRole role, boolean sendChatNotification);
-  void teamRemoveMember(int sessionID, string name, string username, string email);
+  void teamRemoveMember(int sessionID, string name, string username, string email, boolean permanent);
   void teamLeave(int sessionID, string name, boolean permanent);
   void teamEditMember(int sessionID, string name, string username, TeamRole role);
   void teamRename(int sessionID, TeamName prevName, TeamName newName);

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -90,6 +90,7 @@ protocol teams {
     TeamMembersDetails members;
     PerTeamKeyGeneration keyGeneration;
     map<TeamInviteID,AnnotatedTeamInvite> annotatedActiveInvites;
+    TeamSettings settings;
   }
 
   record UserVersion {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6260,7 +6260,8 @@ export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
 export type teamsTeamRemoveMemberRpcParam = Exact<{
   name: string,
   username: string,
-  email: string
+  email: string,
+  permanent: boolean
 }>
 
 export type teamsTeamRenameRpcParam = Exact<{

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -243,6 +243,7 @@ export const ConstantsStatusCode = {
   scteamnotfound: 2614,
   scteamexists: 2619,
   scteamreaderror: 2623,
+  scnoop: 2638,
   scteamtarduplicate: 2663,
   scteamtarnotfound: 2664,
   scteammemberexists: 2665,
@@ -269,7 +270,7 @@ export const ConstantsStatusCode = {
   scteamimplicitbadremove: 2686,
   scteamkeymasknotfound: 2697,
   scteambanned: 2702,
-  scnoop: 2703,
+  scteaminvalidban: 2703,
 }
 
 export const CtlDbType = {
@@ -4671,6 +4672,7 @@ export type StatusCode =
   | 2614 // SCTeamNotFound_2614
   | 2619 // SCTeamExists_2619
   | 2623 // SCTeamReadError_2623
+  | 2638 // SCNoOp_2638
   | 2663 // SCTeamTarDuplicate_2663
   | 2664 // SCTeamTarNotFound_2664
   | 2665 // SCTeamMemberExists_2665
@@ -4697,7 +4699,7 @@ export type StatusCode =
   | 2686 // SCTeamImplicitBadRemove_2686
   | 2697 // SCTeamKeyMaskNotFound_2697
   | 2702 // SCTeamBanned_2702
-  | 2703 // SCNoOp_2703
+  | 2703 // SCTeamInvalidBan_2703
 
 export type Stream = {
   fd: int,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -268,6 +268,8 @@ export const ConstantsStatusCode = {
   scteamimplicitbadadd: 2685,
   scteamimplicitbadremove: 2686,
   scteamkeymasknotfound: 2697,
+  scteambanned: 2702,
+  scnoop: 2703,
 }
 
 export const CtlDbType = {
@@ -4694,6 +4696,8 @@ export type StatusCode =
   | 2685 // SCTeamImplicitBadAdd_2685
   | 2686 // SCTeamImplicitBadRemove_2686
   | 2697 // SCTeamKeyMaskNotFound_2697
+  | 2702 // SCTeamBanned_2702
+  | 2703 // SCNoOp_2703
 
 export type Stream = {
   fd: int,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4818,6 +4818,7 @@ export type TeamDetails = {
   members: TeamMembersDetails,
   keyGeneration: PerTeamKeyGeneration,
   annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite},
+  settings: TeamSettings,
 }
 
 export type TeamExitRow = {

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -139,7 +139,9 @@
         "SCTeamBadAdminSeqnoType_2684",
         "SCTeamImplicitBadAdd_2685",
         "SCTeamImplicitBadRemove_2686",
-        "SCTeamKeyMaskNotFound_2697"
+        "SCTeamKeyMaskNotFound_2697",
+        "SCTeamBanned_2702",
+        "SCNoOp_2703"
       ]
     }
   ],

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -115,6 +115,7 @@
         "SCTeamNotFound_2614",
         "SCTeamExists_2619",
         "SCTeamReadError_2623",
+        "SCNoOp_2638",
         "SCTeamTarDuplicate_2663",
         "SCTeamTarNotFound_2664",
         "SCTeamMemberExists_2665",
@@ -141,7 +142,7 @@
         "SCTeamImplicitBadRemove_2686",
         "SCTeamKeyMaskNotFound_2697",
         "SCTeamBanned_2702",
-        "SCNoOp_2703"
+        "SCTeamInvalidBan_2703"
       ]
     }
   ],

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -251,6 +251,10 @@
             "keys": "TeamInviteID"
           },
           "name": "annotatedActiveInvites"
+        },
+        {
+          "type": "TeamSettings",
+          "name": "settings"
         }
       ]
     },

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1378,6 +1378,10 @@
         {
           "name": "email",
           "type": "string"
+        },
+        {
+          "name": "permanent",
+          "type": "boolean"
         }
       ],
       "response": null

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6260,7 +6260,8 @@ export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
 export type teamsTeamRemoveMemberRpcParam = Exact<{
   name: string,
   username: string,
-  email: string
+  email: string,
+  permanent: boolean
 }>
 
 export type teamsTeamRenameRpcParam = Exact<{

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -243,6 +243,7 @@ export const ConstantsStatusCode = {
   scteamnotfound: 2614,
   scteamexists: 2619,
   scteamreaderror: 2623,
+  scnoop: 2638,
   scteamtarduplicate: 2663,
   scteamtarnotfound: 2664,
   scteammemberexists: 2665,
@@ -269,7 +270,7 @@ export const ConstantsStatusCode = {
   scteamimplicitbadremove: 2686,
   scteamkeymasknotfound: 2697,
   scteambanned: 2702,
-  scnoop: 2703,
+  scteaminvalidban: 2703,
 }
 
 export const CtlDbType = {
@@ -4671,6 +4672,7 @@ export type StatusCode =
   | 2614 // SCTeamNotFound_2614
   | 2619 // SCTeamExists_2619
   | 2623 // SCTeamReadError_2623
+  | 2638 // SCNoOp_2638
   | 2663 // SCTeamTarDuplicate_2663
   | 2664 // SCTeamTarNotFound_2664
   | 2665 // SCTeamMemberExists_2665
@@ -4697,7 +4699,7 @@ export type StatusCode =
   | 2686 // SCTeamImplicitBadRemove_2686
   | 2697 // SCTeamKeyMaskNotFound_2697
   | 2702 // SCTeamBanned_2702
-  | 2703 // SCNoOp_2703
+  | 2703 // SCTeamInvalidBan_2703
 
 export type Stream = {
   fd: int,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -268,6 +268,8 @@ export const ConstantsStatusCode = {
   scteamimplicitbadadd: 2685,
   scteamimplicitbadremove: 2686,
   scteamkeymasknotfound: 2697,
+  scteambanned: 2702,
+  scnoop: 2703,
 }
 
 export const CtlDbType = {
@@ -4694,6 +4696,8 @@ export type StatusCode =
   | 2685 // SCTeamImplicitBadAdd_2685
   | 2686 // SCTeamImplicitBadRemove_2686
   | 2697 // SCTeamKeyMaskNotFound_2697
+  | 2702 // SCTeamBanned_2702
+  | 2703 // SCNoOp_2703
 
 export type Stream = {
   fd: int,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4818,6 +4818,7 @@ export type TeamDetails = {
   members: TeamMembersDetails,
   keyGeneration: PerTeamKeyGeneration,
   annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite},
+  settings: TeamSettings,
 }
 
 export type TeamExitRow = {


### PR DESCRIPTION
This PR adds the following commands to cli:
* `keybase team edit [--open true/false] [--join-as]`
* `keybase team remove-member --permanent`

Team edit command can be used to open or close team. Right now this is the only way to have an open team - create a new, "normal" team and use `edit` command to open it.

In the command runner there is some ugly logic to avoid posting a sig and print a good message when settings change would have no effect - like trying to close a closed team, or open an open team with same `join_as` setting.

`--permanent` flag in remove-member just plumbs `Permanent` boolean to ChangeMembership which sets the flag in post arguments if true. This is similar to permanent Leave.