### PR TITLE
json api for teams

### DIFF
--- a/go/client/chat_api_decoder.go
+++ b/go/client/chat_api_decoder.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -44,32 +43,6 @@ func NewChatAPIDecoder(h ChatAPIHandler) *ChatAPIDecoder {
 	return &ChatAPIDecoder{
 		handler: h,
 	}
-}
-
-func (d *ChatAPIDecoder) Decode(ctx context.Context, r io.Reader, w io.Writer) error {
-	dec := json.NewDecoder(r)
-	for {
-		var c Call
-		if err := dec.Decode(&c); err == io.EOF {
-			break
-		} else if err != nil {
-			if err == io.ErrUnexpectedEOF {
-				return ErrInvalidJSON{message: "expected more JSON in input"}
-			}
-			return err
-		}
-
-		switch c.Params.Version {
-		case 0, 1:
-			if err := d.handleV1(ctx, c, w); err != nil {
-				return err
-			}
-		default:
-			return ErrInvalidVersion{version: c.Params.Version}
-		}
-	}
-
-	return nil
 }
 
 func (d *ChatAPIDecoder) handle(ctx context.Context, c Call, w io.Writer) error {

--- a/go/client/chat_api_decoder.go
+++ b/go/client/chat_api_decoder.go
@@ -4,36 +4,10 @@
 package client
 
 import (
-	"fmt"
 	"io"
 
 	"golang.org/x/net/context"
 )
-
-type ErrInvalidMethod struct {
-	name    string
-	version int
-}
-
-func (e ErrInvalidMethod) Error() string {
-	return fmt.Sprintf("invalid v%d method %q", e.version, e.name)
-}
-
-type ErrInvalidVersion struct {
-	version int
-}
-
-func (e ErrInvalidVersion) Error() string {
-	return fmt.Sprintf("invalid version %d", e.version)
-}
-
-type ErrInvalidJSON struct {
-	message string
-}
-
-func (e ErrInvalidJSON) Error() string {
-	return fmt.Sprintf("invalid JSON: %s", e.message)
-}
 
 type ChatAPIDecoder struct {
 	handler ChatAPIHandler

--- a/go/client/chat_api_decoder.go
+++ b/go/client/chat_api_decoder.go
@@ -72,6 +72,15 @@ func (d *ChatAPIDecoder) Decode(ctx context.Context, r io.Reader, w io.Writer) e
 	return nil
 }
 
+func (d *ChatAPIDecoder) handle(ctx context.Context, c Call, w io.Writer) error {
+	switch c.Params.Version {
+	case 0, 1:
+		return d.handleV1(ctx, c, w)
+	default:
+		return ErrInvalidVersion{version: c.Params.Version}
+	}
+}
+
 func (d *ChatAPIDecoder) handleV1(ctx context.Context, c Call, w io.Writer) error {
 	switch c.Method {
 	case methodList:

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -26,38 +26,6 @@ const (
 	methodMark      = "mark"
 )
 
-// ErrInvalidOptions is returned when the options aren't valid.
-type ErrInvalidOptions struct {
-	method  string
-	version int
-	err     error
-}
-
-func (e ErrInvalidOptions) Error() string {
-	return fmt.Sprintf("invalid %s v%d options: %s", e.method, e.version, e.err)
-}
-
-// Call represents a JSON chat call.
-type Call struct {
-	Jsonrpc string
-	ID      int
-	Method  string
-	Params  Params
-}
-
-// Params represents the `params` portion of the JSON chat call.
-type Params struct {
-	Version int
-	Options json.RawMessage
-}
-
-// CallError is the result when there is an error.
-type CallError struct {
-	Code    int         `json:"code"`
-	Message string      `json:"message"`
-	Data    interface{} `json:"data,omitempty"`
-}
-
 type RateLimit struct {
 	Tank     string `json:"tank"`
 	Capacity int    `json:"capacity"`

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -37,14 +37,6 @@ type RateLimits struct {
 	RateLimits []RateLimit `json:"ratelimits,omitempty"`
 }
 
-// Reply is returned with the results of procressing a Call.
-type Reply struct {
-	Jsonrpc string      `json:"jsonrpc,omitempty"`
-	ID      int         `json:"id,omitempty"`
-	Error   *CallError  `json:"error,omitempty"`
-	Result  interface{} `json:"result,omitempty"`
-}
-
 // ChatAPIHandler can handle all of the chat json api methods.
 type ChatAPIHandler interface {
 	ListV1(context.Context, Call, io.Writer) error

--- a/go/client/chat_api_test.go
+++ b/go/client/chat_api_test.go
@@ -157,8 +157,9 @@ func TestChatAPIDecoderTop(t *testing.T) {
 	for i, test := range topTests {
 		h := new(handlerTracker)
 		d := NewChatAPIDecoder(h)
+		c := &cmdAPI{}
 		var buf bytes.Buffer
-		err := d.Decode(context.Background(), strings.NewReader(test.input), &buf)
+		err := c.decode(context.Background(), strings.NewReader(test.input), &buf, d)
 		if test.err != nil {
 			if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
 				t.Errorf("test %d: error type %T, expected %T", i, err, test.err)
@@ -375,8 +376,9 @@ func TestChatAPIDecoderOptions(t *testing.T) {
 	for i, test := range optTests {
 		h := &ChatAPI{svcHandler: new(chatEcho)}
 		d := NewChatAPIDecoder(h)
+		c := &cmdAPI{}
 		var buf bytes.Buffer
-		err := d.Decode(context.Background(), strings.NewReader(test.input), &buf)
+		err := c.decode(context.Background(), strings.NewReader(test.input), &buf, d)
 		if test.err != nil {
 			if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
 				t.Errorf("test %d: input: %s", i, test.input)
@@ -465,7 +467,8 @@ func TestChatAPIEcho(t *testing.T) {
 		h := &ChatAPI{svcHandler: new(chatEcho)}
 		d := NewChatAPIDecoder(h)
 		var buf bytes.Buffer
-		err := d.Decode(context.Background(), strings.NewReader(test.input), &buf)
+		c := &cmdAPI{}
+		err := c.decode(context.Background(), strings.NewReader(test.input), &buf, d)
 		if test.err != nil {
 			if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
 				t.Errorf("test %d: error type %T, expected %T", i, err, test.err)

--- a/go/client/chat_api_test.go
+++ b/go/client/chat_api_test.go
@@ -151,12 +151,12 @@ var topTests = []topTest{
 	{input: `{"id": 39, "method": "mark", "params":{"version": 1}}`, markV1: 1},
 }
 
-// TestChatAPIDecoderTop tests that the "top-level" of the chat json makes it to
+// TestChatAPIVersionHandlerTop tests that the "top-level" of the chat json makes it to
 // the correct functions in a ChatAPIHandler.
-func TestChatAPIDecoderTop(t *testing.T) {
+func TestChatAPIVersionHandlerTop(t *testing.T) {
 	for i, test := range topTests {
 		h := new(handlerTracker)
-		d := NewChatAPIDecoder(h)
+		d := NewChatAPIVersionHandler(h)
 		c := &cmdAPI{}
 		var buf bytes.Buffer
 		err := c.decode(context.Background(), strings.NewReader(test.input), &buf, d)
@@ -371,11 +371,11 @@ var optTests = []optTest{
 	},
 }
 
-// TestChatAPIDecoderOptions tests the option decoding.
-func TestChatAPIDecoderOptions(t *testing.T) {
+// TestChatAPIVersionHandlerOptions tests the option decoding.
+func TestChatAPIVersionHandlerOptions(t *testing.T) {
 	for i, test := range optTests {
 		h := &ChatAPI{svcHandler: new(chatEcho)}
-		d := NewChatAPIDecoder(h)
+		d := NewChatAPIVersionHandler(h)
 		c := &cmdAPI{}
 		var buf bytes.Buffer
 		err := c.decode(context.Background(), strings.NewReader(test.input), &buf, d)
@@ -465,7 +465,7 @@ var echoTests = []echoTest{
 func TestChatAPIEcho(t *testing.T) {
 	for i, test := range echoTests {
 		h := &ChatAPI{svcHandler: new(chatEcho)}
-		d := NewChatAPIDecoder(h)
+		d := NewChatAPIVersionHandler(h)
 		var buf bytes.Buffer
 		c := &cmdAPI{}
 		err := c.decode(context.Background(), strings.NewReader(test.input), &buf, d)

--- a/go/client/chat_api_version_handler.go
+++ b/go/client/chat_api_version_handler.go
@@ -9,17 +9,17 @@ import (
 	"golang.org/x/net/context"
 )
 
-type ChatAPIDecoder struct {
+type ChatAPIVersionHandler struct {
 	handler ChatAPIHandler
 }
 
-func NewChatAPIDecoder(h ChatAPIHandler) *ChatAPIDecoder {
-	return &ChatAPIDecoder{
+func NewChatAPIVersionHandler(h ChatAPIHandler) *ChatAPIVersionHandler {
+	return &ChatAPIVersionHandler{
 		handler: h,
 	}
 }
 
-func (d *ChatAPIDecoder) handle(ctx context.Context, c Call, w io.Writer) error {
+func (d *ChatAPIVersionHandler) handle(ctx context.Context, c Call, w io.Writer) error {
 	switch c.Params.Version {
 	case 0, 1:
 		return d.handleV1(ctx, c, w)
@@ -28,7 +28,7 @@ func (d *ChatAPIDecoder) handle(ctx context.Context, c Call, w io.Writer) error 
 	}
 }
 
-func (d *ChatAPIDecoder) handleV1(ctx context.Context, c Call, w io.Writer) error {
+func (d *ChatAPIVersionHandler) handleV1(ctx context.Context, c Call, w io.Writer) error {
 	switch c.Method {
 	case methodList:
 		return d.handler.ListV1(ctx, c, w)

--- a/go/client/cmd_chat_api.go
+++ b/go/client/cmd_chat_api.go
@@ -18,15 +18,15 @@ func newCmdChatAPI(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 	return newCmdAPI(cl, NewCmdChatAPIRunner(g), "JSON api", chatAPIDoc)
 }
 
+func NewCmdChatAPIRunner(g *libkb.GlobalContext) *CmdChatAPI {
+	return &CmdChatAPI{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
 func (c *CmdChatAPI) Run() error {
 	h := newChatServiceHandler(c.G())
 	d := NewChatAPIDecoder(&ChatAPI{svcHandler: h, indent: c.indent})
 
 	return c.runHandler(d)
-}
-
-func NewCmdChatAPIRunner(g *libkb.GlobalContext) *CmdChatAPI {
-	return &CmdChatAPI{
-		Contextified: libkb.NewContextified(g),
-	}
 }

--- a/go/client/cmd_chat_api.go
+++ b/go/client/cmd_chat_api.go
@@ -4,116 +4,29 @@
 package client
 
 import (
-	"errors"
-	"io"
-	"os"
-	"strings"
-
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
-	"golang.org/x/net/context"
 )
 
 type CmdChatAPI struct {
 	libkb.Contextified
-	indent     bool
-	inputFile  string
-	outputFile string
-	message    string
+	cmdAPI
 }
 
 func newCmdChatAPI(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
-	return cli.Command{
-		Name:  "api",
-		Usage: "JSON api",
-		Action: func(c *cli.Context) {
-			cmd := NewCmdChatAPIRunner(g)
-			cl.ChooseCommand(cmd, "api", c)
-		},
-		Flags: []cli.Flag{
-			cli.BoolFlag{
-				Name:  "p, pretty",
-				Usage: "Output pretty (indented) JSON.",
-			},
-			cli.StringFlag{
-				Name:  "m",
-				Usage: "Specify JSON as string instead of stdin",
-			},
-			cli.StringFlag{
-				Name:  "i, infile",
-				Usage: "Specify JSON input file (stdin default)",
-			},
-			cli.StringFlag{
-				Name:  "o, outfile",
-				Usage: "Specify output file (stdout default)",
-			},
-		},
-		Description: chatAPIDoc,
-	}
-}
-
-func (c *CmdChatAPI) ParseArgv(ctx *cli.Context) error {
-	if len(ctx.Args()) != 0 {
-		return errors.New("api takes no arguments")
-	}
-	c.indent = ctx.Bool("pretty")
-	c.inputFile = ctx.String("infile")
-	c.outputFile = ctx.String("outfile")
-	c.message = ctx.String("m")
-
-	if len(c.message) > 0 && len(c.inputFile) > 0 {
-		return errors.New("specify -m or -i, but not both")
-	}
-
-	return nil
+	return newCmdAPI(cl, NewCmdChatAPIRunner(g), "JSON api", chatAPIDoc)
 }
 
 func (c *CmdChatAPI) Run() error {
 	h := newChatServiceHandler(c.G())
 	d := NewChatAPIDecoder(&ChatAPI{svcHandler: h, indent: c.indent})
 
-	var r io.Reader
-	r = os.Stdin
-	if len(c.message) > 0 {
-		r = strings.NewReader(c.message)
-	} else if len(c.inputFile) > 0 {
-		f, err := os.Open(c.inputFile)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		r = f
-	}
-
-	var w io.Writer
-	w = os.Stdout
-	if len(c.outputFile) > 0 {
-		f, err := os.Create(c.outputFile)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		w = f
-	}
-
-	return d.Decode(context.Background(), r, w)
+	return c.runHandler(d)
 }
 
 func NewCmdChatAPIRunner(g *libkb.GlobalContext) *CmdChatAPI {
 	return &CmdChatAPI{
 		Contextified: libkb.NewContextified(g),
-	}
-}
-
-func (c *CmdChatAPI) SetMessage(m string) {
-	c.message = m
-}
-
-func (c *CmdChatAPI) GetUsage() libkb.Usage {
-	return libkb.Usage{
-		API:       true,
-		KbKeyring: true,
-		Config:    true,
 	}
 }

--- a/go/client/cmd_chat_api.go
+++ b/go/client/cmd_chat_api.go
@@ -26,7 +26,7 @@ func NewCmdChatAPIRunner(g *libkb.GlobalContext) *CmdChatAPI {
 
 func (c *CmdChatAPI) Run() error {
 	h := newChatServiceHandler(c.G())
-	d := NewChatAPIDecoder(&ChatAPI{svcHandler: h, indent: c.indent})
+	d := NewChatAPIVersionHandler(&ChatAPI{svcHandler: h, indent: c.indent})
 
 	return c.runHandler(d)
 }

--- a/go/client/cmd_team.go
+++ b/go/client/cmd_team.go
@@ -28,6 +28,7 @@ func NewCmdTeam(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 			newCmdTeamAcceptInvite(cl, g),
 			newCmdTeamLeave(cl, g),
 			newCmdTeamDelete(cl, g),
+			newCmdTeamAPI(cl, g),
 		},
 	}
 }

--- a/go/client/cmd_team_api.go
+++ b/go/client/cmd_team_api.go
@@ -1,11 +1,33 @@
 package client
 
-import "github.com/keybase/client/go/libkb"
+import (
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
 
 type CmdTeamAPI struct {
 	libkb.Contextified
-	indent     bool
-	inputFile  string
-	outputFile string
-	message    string
+	cmdAPI
+}
+
+func newCmdTeamAPI(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return newCmdAPI(cl, NewCmdTeamAPIRunner(g), "JSON api", teamAPIDoc)
+}
+
+func NewCmdTeamAPIRunner(g *libkb.GlobalContext) *CmdTeamAPI {
+	return &CmdTeamAPI{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func (c *CmdTeamAPI) Run() error {
+
+	/*
+		h := newChatServiceHandler(c.G())
+		d := NewChatAPIDecoder(&ChatAPI{svcHandler: h, indent: c.indent})
+
+		return c.runHandler(d)
+	*/
+	return nil
 }

--- a/go/client/cmd_team_api.go
+++ b/go/client/cmd_team_api.go
@@ -22,12 +22,6 @@ func NewCmdTeamAPIRunner(g *libkb.GlobalContext) *CmdTeamAPI {
 }
 
 func (c *CmdTeamAPI) Run() error {
-
-	/*
-		h := newChatServiceHandler(c.G())
-		d := NewChatAPIDecoder(&ChatAPI{svcHandler: h, indent: c.indent})
-
-		return c.runHandler(d)
-	*/
-	return nil
+	h := newTeamAPIHandler(c.G(), c.indent)
+	return c.runHandler(h)
 }

--- a/go/client/cmd_team_api.go
+++ b/go/client/cmd_team_api.go
@@ -1,0 +1,11 @@
+package client
+
+import "github.com/keybase/client/go/libkb"
+
+type CmdTeamAPI struct {
+	libkb.Contextified
+	indent     bool
+	inputFile  string
+	outputFile string
+	message    string
+}

--- a/go/client/cmd_team_create.go
+++ b/go/client/cmd_team_create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"golang.org/x/net/context"
 )
 
@@ -35,12 +34,6 @@ func (v *CmdTeamCreate) Run() (err error) {
 	}
 
 	dui := v.G().UI.GetDumbOutputUI()
-	protocols := []rpc.Protocol{
-		NewSecretUIProtocol(v.G()),
-	}
-	if err = RegisterProtocolsWithContext(protocols, v.G()); err != nil {
-		return err
-	}
 
 	// only send a chat notification if creating a root team.
 	// (if creating a sub team, the creator is not a member of the team

--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -23,7 +23,6 @@ type CmdTeamListMemberships struct {
 	json                 bool
 	forcePoll            bool
 	userAssertion        string
-	includeSubteams      bool
 	includeImplicitTeams bool
 	showAll              bool
 	verbose              bool
@@ -100,7 +99,6 @@ func (c *CmdTeamListMemberships) ParseArgv(ctx *cli.Context) error {
 		c.team = ctx.Args()[0]
 	}
 	c.userAssertion = ctx.String("user")
-	c.includeSubteams = ctx.Bool("include-subteams")
 	c.includeImplicitTeams = ctx.Bool("include-implicit-teams")
 	c.showAll = ctx.Bool("all")
 

--- a/go/client/json_api_common.go
+++ b/go/client/json_api_common.go
@@ -185,16 +185,6 @@ func (c *cmdAPI) decode(ctx context.Context, r io.Reader, w io.Writer, h handler
 		if err := h.handle(ctx, c, w); err != nil {
 			return err
 		}
-		/*
-			switch c.Params.Version {
-			case 0, 1:
-				if err := d.handleV1(ctx, c, w); err != nil {
-					return err
-				}
-			default:
-				return ErrInvalidVersion{version: c.Params.Version}
-			}
-		*/
 	}
 
 	return nil

--- a/go/client/json_api_common.go
+++ b/go/client/json_api_common.go
@@ -137,6 +137,10 @@ func (c *cmdAPI) SetMessage(m string) {
 	c.message = m
 }
 
+func (c *cmdAPI) SetOutputFile(f string) {
+	c.outputFile = f
+}
+
 func (c *cmdAPI) GetUsage() libkb.Usage {
 	return libkb.Usage{
 		API:       true,

--- a/go/client/json_api_common.go
+++ b/go/client/json_api_common.go
@@ -72,6 +72,14 @@ type CallError struct {
 	Data    interface{} `json:"data,omitempty"`
 }
 
+// Reply is returned with the results of procressing a Call.
+type Reply struct {
+	Jsonrpc string      `json:"jsonrpc,omitempty"`
+	ID      int         `json:"id,omitempty"`
+	Error   *CallError  `json:"error,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
+}
+
 // cmdAPI contains common functionality for json api commands
 type cmdAPI struct {
 	indent     bool

--- a/go/client/json_api_common.go
+++ b/go/client/json_api_common.go
@@ -26,6 +26,31 @@ func (e ErrInvalidOptions) Error() string {
 	return fmt.Sprintf("invalid %s v%d options: %s", e.method, e.version, e.err)
 }
 
+type ErrInvalidMethod struct {
+	name    string
+	version int
+}
+
+func (e ErrInvalidMethod) Error() string {
+	return fmt.Sprintf("invalid v%d method %q", e.version, e.name)
+}
+
+type ErrInvalidVersion struct {
+	version int
+}
+
+func (e ErrInvalidVersion) Error() string {
+	return fmt.Sprintf("invalid version %d", e.version)
+}
+
+type ErrInvalidJSON struct {
+	message string
+}
+
+func (e ErrInvalidJSON) Error() string {
+	return fmt.Sprintf("invalid JSON: %s", e.message)
+}
+
 // Call represents a JSON api call.
 type Call struct {
 	Jsonrpc string
@@ -110,10 +135,6 @@ func (c *cmdAPI) GetUsage() libkb.Usage {
 		KbKeyring: true,
 		Config:    true,
 	}
-}
-
-type decoder interface {
-	Decode(ctx context.Context, r io.Reader, w io.Writer) error
 }
 
 type handler interface {

--- a/go/client/json_api_common.go
+++ b/go/client/json_api_common.go
@@ -1,0 +1,181 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+// ErrInvalidOptions is returned when the options aren't valid.
+type ErrInvalidOptions struct {
+	method  string
+	version int
+	err     error
+}
+
+func (e ErrInvalidOptions) Error() string {
+	return fmt.Sprintf("invalid %s v%d options: %s", e.method, e.version, e.err)
+}
+
+// Call represents a JSON api call.
+type Call struct {
+	Jsonrpc string
+	ID      int
+	Method  string
+	Params  Params
+}
+
+// Params represents the `params` portion of the JSON api call.
+type Params struct {
+	Version int
+	Options json.RawMessage
+}
+
+// CallError is the result when there is an error.
+type CallError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// cmdAPI contains common functionality for json api commands
+type cmdAPI struct {
+	indent     bool
+	inputFile  string
+	outputFile string
+	message    string
+}
+
+func newCmdAPI(cl *libcmdline.CommandLine, cmd libcmdline.Command, usage, description string) cli.Command {
+	return cli.Command{
+		Name:  "api",
+		Usage: usage,
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(cmd, "api", c)
+		},
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "p, pretty",
+				Usage: "Output pretty (indented) JSON.",
+			},
+			cli.StringFlag{
+				Name:  "m",
+				Usage: "Specify JSON as string instead of stdin",
+			},
+			cli.StringFlag{
+				Name:  "i, infile",
+				Usage: "Specify JSON input file (stdin default)",
+			},
+			cli.StringFlag{
+				Name:  "o, outfile",
+				Usage: "Specify output file (stdout default)",
+			},
+		},
+		Description: description,
+	}
+}
+
+func (c *cmdAPI) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 0 {
+		return errors.New("api takes no arguments")
+	}
+	c.indent = ctx.Bool("pretty")
+	c.inputFile = ctx.String("infile")
+	c.outputFile = ctx.String("outfile")
+	c.message = ctx.String("m")
+
+	if len(c.message) > 0 && len(c.inputFile) > 0 {
+		return errors.New("specify -m or -i, but not both")
+	}
+
+	return nil
+}
+
+func (c *cmdAPI) SetMessage(m string) {
+	c.message = m
+}
+
+func (c *cmdAPI) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		API:       true,
+		KbKeyring: true,
+		Config:    true,
+	}
+}
+
+type decoder interface {
+	Decode(ctx context.Context, r io.Reader, w io.Writer) error
+}
+
+type handler interface {
+	handle(ctx context.Context, c Call, w io.Writer) error
+}
+
+func (c *cmdAPI) runHandler(h handler) error {
+	var r io.Reader
+	r = os.Stdin
+	if len(c.message) > 0 {
+		r = strings.NewReader(c.message)
+	} else if len(c.inputFile) > 0 {
+		f, err := os.Open(c.inputFile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		r = f
+	}
+
+	var w io.Writer
+	w = os.Stdout
+	if len(c.outputFile) > 0 {
+		f, err := os.Create(c.outputFile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		w = f
+	}
+
+	return c.decode(context.Background(), r, w, h)
+}
+
+func (c *cmdAPI) decode(ctx context.Context, r io.Reader, w io.Writer, h handler) error {
+	dec := json.NewDecoder(r)
+	for {
+		var c Call
+		if err := dec.Decode(&c); err == io.EOF {
+			break
+		} else if err != nil {
+			if err == io.ErrUnexpectedEOF {
+				return ErrInvalidJSON{message: "expected more JSON in input"}
+			}
+			return err
+		}
+
+		if err := h.handle(ctx, c, w); err != nil {
+			return err
+		}
+		/*
+			switch c.Params.Version {
+			case 0, 1:
+				if err := d.handleV1(ctx, c, w); err != nil {
+					return err
+				}
+			default:
+				return ErrInvalidVersion{version: c.Params.Version}
+			}
+		*/
+	}
+
+	return nil
+
+}

--- a/go/client/team_api_doc.go
+++ b/go/client/team_api_doc.go
@@ -1,0 +1,9 @@
+package client
+
+const teamAPIDoc = `"keybase team api" provides a JSON API to Keybase teams.
+
+EXAMPLES:
+
+List
+etc.
+`

--- a/go/client/team_api_doc.go
+++ b/go/client/team_api_doc.go
@@ -7,13 +7,31 @@ EXAMPLES:
 List all your team memberships:
     {"method": "list-self-memberships"}
 
+List memberships on one team:
+    {"method": "list-team-memberships", "params": {"options": {"team": "phoenix"}}}
+
+List memberships for a user:
+    {"method": "list-user-memberships", "params": {"options": {"username": "cleo"}}}
+
 Create a team:
     {"method": "create-team", "params": {"options": {"team": "phoenix"}}}
+
+Add members to a team:
+    {"method": "add-members", "params": {"options": {"team": "phoenix", "emails": [{"email": "alice@keybase.io", "role": "writer"}, {"email": "cleo@keybase.io", "role": "admin"}], "usernames": [{"username": "frank", "role": "reader"}, {"username": "keybaseio@twitter", "role": "writer"}]}}}
+
+Change a member's role:
+    {"method": "edit-member", "params": {"options": {"team": "phoenix", "username": "frank", "role": "writer"}}}
+
+Remove a member:
+    {"method": "remove-member", "params": {"options": {"team": "phoenix", "username": "frank"}}}
 
 Create a subteam:
     {"method": "create-team", "params": {"options": {"team": "phoenix.bots"}}}
 
-Add members to a team:
-    {"method": "add-members", "params": {"options": {"team": "treehouse", "emails": [{"email": "alice@treehouse.org", "role": "writer"}, {"email": "cleo@treehose.hor", "role": "admin"}], "usernames": [{"username": "frank", "role": "reader"}, {"username": "keybaseio@twitter", "role": "writer"}]}}}
+Rename a subteam:
+    {"method": "rename-subteam", "params": {"options": {"team": "phoenix.bots", "new-team-name": "phoenix.humans"}}}
+
+Leave a team:
+    {"method": "leave-team", "params": {"options": {"team": "phoenix.humans", "permanent": true}}}
 
 `

--- a/go/client/team_api_doc.go
+++ b/go/client/team_api_doc.go
@@ -7,6 +7,12 @@ EXAMPLES:
 List all your team memberships:
     {"method": "list-self-memberships"}
 
+Create a team:
+    {"method": "create-team", "params": {"options": {"team": "phoenix"}}}
+
+Create a subteam:
+    {"method": "create-team", "params": {"options": {"team": "phoenix.bots"}}}
+
 Add members to a team:
     {"method": "add-members", "params": {"options": {"team": "treehouse", "emails": [{"email": "alice@treehouse.org", "role": "writer"}, {"email": "cleo@treehose.hor", "role": "admin"}], "usernames": [{"username": "frank", "role": "reader"}, {"username": "keybaseio@twitter", "role": "writer"}]}}}
 

--- a/go/client/team_api_doc.go
+++ b/go/client/team_api_doc.go
@@ -4,6 +4,10 @@ const teamAPIDoc = `"keybase team api" provides a JSON API to Keybase teams.
 
 EXAMPLES:
 
-List
-etc.
+List all your team memberships:
+    {"method": "list-self-memberships"}
+
+Add members to a team:
+    {"method": "add-members", "params": {"options": {"team": "treehouse", "emails": [{"email": "alice@treehouse.org", "role": "writer"}, {"email": "cleo@treehose.hor", "role": "admin"}], "usernames": [{"username": "frank", "role": "reader"}, {"username": "keybaseio@twitter", "role": "writer"}]}}}
+
 `

--- a/go/client/team_api_handler.go
+++ b/go/client/team_api_handler.go
@@ -242,7 +242,17 @@ type listTeamOptions struct {
 	ForcePoll       bool   `json:"force-poll"`
 }
 
+func (c *listTeamOptions) Check() error {
+	_, err := keybase1.TeamNameFromString(c.Team)
+	return err
+}
+
 func (t *teamAPIHandler) listTeamMemberships(ctx context.Context, c Call, w io.Writer) error {
+	var opts listTeamOptions
+	if err := t.unmarshalOptions(c, &opts); err != nil {
+		return t.encodeErr(c, err, w)
+	}
+	_ = opts
 	return nil
 }
 

--- a/go/client/team_api_handler.go
+++ b/go/client/team_api_handler.go
@@ -353,7 +353,6 @@ func (c *removeMemberOptions) Check() error {
 	return nil
 }
 
-// XXX implement Email option after CORE-6223 merged
 func (t *teamAPIHandler) removeMember(ctx context.Context, c Call, w io.Writer) error {
 	var opts removeMemberOptions
 	if err := t.unmarshalOptions(c, &opts); err != nil {

--- a/go/client/team_api_handler.go
+++ b/go/client/team_api_handler.go
@@ -30,7 +30,7 @@ func (t *teamAPIHandler) handle(ctx context.Context, c Call, w io.Writer) error 
 }
 
 func (t *teamAPIHandler) handleV1(ctx context.Context, c Call, w io.Writer) error {
-	if err := t.requireOptions(c); err != nil {
+	if err := t.requireOptionsV1(c); err != nil {
 		return err
 	}
 
@@ -67,22 +67,6 @@ func (t *teamAPIHandler) handleV1(ctx context.Context, c Call, w io.Writer) erro
 }
 
 func (t *teamAPIHandler) createTeam(ctx context.Context, c Call, w io.Writer) error {
-	/*
-		var opts listOptionsV1
-		// Options are optional for list
-		if len(c.Params.Options) != 0 {
-			if err := json.Unmarshal(c.Params.Options, &opts); err != nil {
-				return err
-			}
-		}
-		if err := opts.Check(); err != nil {
-			return err
-		}
-
-		// opts are valid for list v1
-
-		return a.encodeReply(c, a.svcHandler.ListV1(ctx, opts), w)
-	*/
 	return nil
 }
 
@@ -139,7 +123,7 @@ func (t *teamAPIHandler) deleteTeam(ctx context.Context, c Call, w io.Writer) er
 	return nil
 }
 
-func (t *teamAPIHandler) requireOptions(c Call) error {
+func (t *teamAPIHandler) requireOptionsV1(c Call) error {
 	if len(c.Params.Options) == 0 {
 		if c.Method != "list-self-memberships" {
 			return ErrInvalidOptions{version: 1, method: c.Method, err: errors.New("empty options")}

--- a/go/client/team_api_handler.go
+++ b/go/client/team_api_handler.go
@@ -1,0 +1,173 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+type teamAPIHandler struct {
+	libkb.Contextified
+	cli    keybase1.TeamsClient
+	indent bool
+}
+
+func newTeamAPIHandler(g *libkb.GlobalContext, indentOutput bool) *teamAPIHandler {
+	return &teamAPIHandler{Contextified: libkb.NewContextified(g), indent: indentOutput}
+}
+
+func (t *teamAPIHandler) handle(ctx context.Context, c Call, w io.Writer) error {
+	switch c.Params.Version {
+	case 0, 1:
+		return t.handleV1(ctx, c, w)
+	default:
+		return ErrInvalidVersion{version: c.Params.Version}
+	}
+}
+
+func (t *teamAPIHandler) handleV1(ctx context.Context, c Call, w io.Writer) error {
+	if err := t.requireOptions(c); err != nil {
+		return err
+	}
+
+	cli, err := GetTeamsClient(t.G())
+	if err != nil {
+		return err
+	}
+	t.cli = cli
+
+	switch c.Method {
+	case "create":
+		return t.createTeam(ctx, c, w)
+	case "add-member":
+		return t.addMember(ctx, c, w)
+	case "remove-member":
+		return t.removeMember(ctx, c, w)
+	case "edit-member":
+		return t.editMember(ctx, c, w)
+	case "list-team-memberships":
+		return t.listTeamMemberships(ctx, c, w)
+	case "list-user-memberships":
+		return t.listUserMemberships(ctx, c, w)
+	case "list-self-memberships":
+		return t.listSelfMemberships(ctx, c, w)
+	case "rename":
+		return t.renameSubteam(ctx, c, w)
+	case "leave":
+		return t.leaveTeam(ctx, c, w)
+	case "delete":
+		return t.deleteTeam(ctx, c, w)
+	default:
+		return ErrInvalidMethod{name: c.Method, version: 1}
+	}
+}
+
+func (t *teamAPIHandler) createTeam(ctx context.Context, c Call, w io.Writer) error {
+	/*
+		var opts listOptionsV1
+		// Options are optional for list
+		if len(c.Params.Options) != 0 {
+			if err := json.Unmarshal(c.Params.Options, &opts); err != nil {
+				return err
+			}
+		}
+		if err := opts.Check(); err != nil {
+			return err
+		}
+
+		// opts are valid for list v1
+
+		return a.encodeReply(c, a.svcHandler.ListV1(ctx, opts), w)
+	*/
+	return nil
+}
+
+func (t *teamAPIHandler) addMember(ctx context.Context, c Call, w io.Writer) error {
+	return nil
+}
+
+func (t *teamAPIHandler) removeMember(ctx context.Context, c Call, w io.Writer) error {
+	return nil
+}
+
+func (t *teamAPIHandler) editMember(ctx context.Context, c Call, w io.Writer) error {
+	return nil
+}
+
+type listTeamOptions struct {
+	Team            string `json:"team"`
+	IncludeSubteams bool   `json:"include-subteams"`
+	ForcePoll       bool   `json:"force-poll"`
+}
+
+func (t *teamAPIHandler) listTeamMemberships(ctx context.Context, c Call, w io.Writer) error {
+	return nil
+}
+
+type listUserOptions struct {
+	UserAssertion string `json:"user"`
+}
+
+func (t *teamAPIHandler) listUserMemberships(ctx context.Context, c Call, w io.Writer) error {
+	return nil
+}
+
+func (t *teamAPIHandler) listSelfMemberships(ctx context.Context, c Call, w io.Writer) error {
+	arg := keybase1.TeamListArg{
+		All: true,
+	}
+	list, err := t.cli.TeamList(ctx, arg)
+	if err != nil {
+		return t.encodeErr(c, err, w)
+	}
+	return t.encodeResult(c, list, w)
+}
+
+func (t *teamAPIHandler) renameSubteam(ctx context.Context, c Call, w io.Writer) error {
+	return nil
+}
+
+func (t *teamAPIHandler) leaveTeam(ctx context.Context, c Call, w io.Writer) error {
+	return nil
+}
+
+func (t *teamAPIHandler) deleteTeam(ctx context.Context, c Call, w io.Writer) error {
+	return nil
+}
+
+func (t *teamAPIHandler) requireOptions(c Call) error {
+	if len(c.Params.Options) == 0 {
+		if c.Method != "list-self-memberships" {
+			return ErrInvalidOptions{version: 1, method: c.Method, err: errors.New("empty options")}
+		}
+	}
+	return nil
+
+}
+
+func (t *teamAPIHandler) encodeResult(call Call, result interface{}, w io.Writer) error {
+	reply := Reply{
+		Result: result,
+	}
+	return t.encodeReply(call, reply, w)
+}
+
+func (t *teamAPIHandler) encodeErr(call Call, err error, w io.Writer) error {
+	reply := Reply{Error: &CallError{Message: err.Error()}}
+	return t.encodeReply(call, reply, w)
+}
+
+func (t *teamAPIHandler) encodeReply(call Call, reply Reply, w io.Writer) error {
+	reply.Jsonrpc = call.Jsonrpc
+	reply.ID = call.ID
+
+	enc := json.NewEncoder(w)
+	if t.indent {
+		enc.SetIndent("", "    ")
+	}
+	return enc.Encode(reply)
+}

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -451,6 +451,15 @@ func RandStringB64(numTriads int) string {
 	return base64.URLEncoding.EncodeToString(buf)
 }
 
+func RandHexString(prefix string, numbytes int) (string, error) {
+	buf, err := RandBytes(numbytes)
+	if err != nil {
+		return "", err
+	}
+	str := hex.EncodeToString(buf)
+	return prefix + str, nil
+}
+
 func Trace(log logger.Logger, msg string, f func() error) func() {
 	log.Debug("+ %s", msg)
 	return func() { log.Debug("- %s -> %s", msg, ErrToOk(f())) }

--- a/go/systests/team_api_test.go
+++ b/go/systests/team_api_test.go
@@ -1,0 +1,83 @@
+package systests
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/keybase/client/go/client"
+	"github.com/keybase/client/go/libkb"
+)
+
+func TestTeamAPI(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	tt.addUser("onr")
+	tt.addUser("wtr")
+
+	assertTeamAPIOutput(t, tt.users[0],
+		`{"method": "list-self-memberships"}`,
+		`{"result":{"teams":null,"annotatedActiveInvites":{}}}`)
+
+	teamName, err := libkb.RandHexString("t", 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertTeamAPIOutput(t, tt.users[0],
+		`{"method": "create-team", "params": {"options": {"team": "`+teamName+`"}}}`,
+		`{"result":{"chatSent":true,"creatorAdded":true}}`)
+
+	assertTeamAPIOutput(t, tt.users[0],
+		`{"method": "add-members", "params": {"options": {"team": "`+teamName+`", "usernames": [{"username": "`+tt.users[1].username+`", "role": "reader"}]}}}`,
+		`{"result":[{"invited":false,"user":{"uid":"`+tt.users[1].uid.String()+`","username":"`+tt.users[1].username+`"},"emailSent":false,"chatSent":false}]}`)
+
+	assertTeamAPIOutput(t, tt.users[0],
+		`{"method": "create-team", "params": {"options": {"team": "`+teamName+`.sub"}}}`,
+		`{"result":{"chatSent":false,"creatorAdded":false}}`)
+
+	assertTeamAPIOutput(t, tt.users[0],
+		`{"method": "rename-subteam", "params": {"options": {"team": "`+teamName+`.sub", "new-team-name": "`+teamName+`.sub2"}}}`,
+		`{}`)
+
+	assertTeamAPIOutput(t, tt.users[0],
+		`{"method": "edit-member", "params": {"options": {"team": "`+teamName+`", "username": "`+tt.users[1].username+`", "role": "writer"}}}`,
+		`{}`)
+
+	assertTeamAPIOutput(t, tt.users[0],
+		`{"method": "remove-member", "params": {"options": {"team": "`+teamName+`", "username": "`+tt.users[1].username+`"}}}`,
+		`{}`)
+}
+
+func assertTeamAPIOutput(t *testing.T, u *userPlusDevice, in, expectedOut string) {
+	out, err := runTeamAPI(t, u, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out = strings.TrimSpace(out)
+	if out != expectedOut {
+		t.Errorf("json command:\n\n%s\n\noutput:\n\n%s\n\nexpected:\n\n%s\n\n", in, out, expectedOut)
+	}
+}
+
+func runTeamAPI(t *testing.T, u *userPlusDevice, json string) (string, error) {
+	cmd := client.NewCmdTeamAPIRunner(u.tc.G)
+	cmd.SetMessage(json)
+	r, err := libkb.RandString("teamapi", 4)
+	if err != nil {
+		return "", err
+	}
+	filename := filepath.Join(os.TempDir(), r+".json")
+	cmd.SetOutputFile(filename)
+	defer os.Remove(filename)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	out, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}


### PR DESCRIPTION
This adds a json api for teams.  From `keybase team api -h`:

```
List all your team memberships:
    {"method": "list-self-memberships"}

List memberships on one team:
    {"method": "list-team-memberships", "params": {"options": {"team": "phoenix"}}}

List memberships for a user:
    {"method": "list-user-memberships", "params": {"options": {"username": "cleo"}}}

Create a team:
    {"method": "create-team", "params": {"options": {"team": "phoenix"}}}

Add members to a team:
    {"method": "add-members", "params": {"options": {"team": "phoenix", "emails": [{"email": "alice@keybase.io", "role": "writer"}, {"email": "cleo@keybase.io", "role": "admin"}], "usernames": [{"username": "frank", "role": "reader"}, {"username": "keybaseio@twitter", "role": "writer"}]}}}

Change a member's role:
    {"method": "edit-member", "params": {"options": {"team": "phoenix", "username": "frank", "role": "writer"}}}

Remove a member:
    {"method": "remove-member", "params": {"options": {"team": "phoenix", "username": "frank"}}}

Create a subteam:
    {"method": "create-team", "params": {"options": {"team": "phoenix.bots"}}}

Rename a subteam:
    {"method": "rename-subteam", "params": {"options": {"team": "phoenix.bots", "new-team-name": "phoenix.humans"}}}

Leave a team:
    {"method": "leave-team", "params": {"options": {"team": "phoenix.humans", "permanent": true}}}

```

@mmaxim fair amount of refactor to `chat api` too to reuse some of its code.  More could be done to clean up its code in general, but out of scope of this ticket.