### PR TITLE
kill G altogether

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -89,7 +89,7 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 		fmt.Printf("Go: DNS Server: %s\n", srv)
 	}
 
-	kbCtx = libkb.G
+	kbCtx = libkb.NewGlobalContext()
 	kbCtx.Init()
 	kbCtx.SetServices(externals.GetServices())
 

--- a/go/engine/fakeusers_test.go
+++ b/go/engine/fakeusers_test.go
@@ -68,6 +68,7 @@ func createFakeUserWithPGPOnly(t *testing.T, tc libkb.TestContext) *FakeUser {
 	}
 	gen.AddDefaultUID(tc.G)
 	peng := NewPGPKeyImportEngine(PGPKeyImportEngineArg{
+		Ctx:        tc.G,
 		Gen:        &gen,
 		PushSecret: true,
 		Lks:        s.lks,
@@ -185,7 +186,7 @@ func createFakeUserWithPGPMultSubset(t *testing.T, tc libkb.TestContext, alterna
 	secui := &libkb.TestSecretUI{Passphrase: fu.Passphrase}
 	s := NewSignupEngine(nil, tc.G)
 	ctx := &Context{
-		GPGUI:    newGPGSelectEmailUI(fu.Email),
+		GPGUI:    newGPGSelectEmailUI(tc.G, fu.Email),
 		SecretUI: secui,
 		LogUI:    tc.G.UI.GetLogUI(),
 		LoginUI:  &libkb.TestLoginUI{Username: fu.Username},

--- a/go/engine/fakeusers_test.go
+++ b/go/engine/fakeusers_test.go
@@ -228,6 +228,7 @@ func createFakeUserWithPGPSibkey(tc libkb.TestContext) *FakeUser {
 			PrimaryBits: 768,
 			SubkeyBits:  768,
 		},
+		Ctx: tc.G,
 	}
 	arg.Gen.MakeAllIds(tc.G)
 	ctx := Context{
@@ -250,6 +251,7 @@ func createFakeUserWithPGPSibkeyPaper(tc libkb.TestContext) *FakeUser {
 			PrimaryBits: 768,
 			SubkeyBits:  768,
 		},
+		Ctx: tc.G,
 	}
 	arg.Gen.MakeAllIds(tc.G)
 	ctx := Context{

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -210,6 +210,7 @@ func (e *GPGImportKeyEngine) Run(ctx *Context) (err error) {
 	e.G().Log.Info("Bundle unlocked: %s", selected.GetFingerprint().ToKeyID())
 
 	eng := NewPGPKeyImportEngine(PGPKeyImportEngineArg{
+		Ctx:         e.G(),
 		Pregen:      bundle,
 		SigningKey:  e.arg.Signer,
 		Me:          me,

--- a/go/engine/gpg_test.go
+++ b/go/engine/gpg_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 type gpgtestui struct {
+	libkb.Contextified
 	index          int
 	keyChosenCount int
 }
@@ -53,7 +54,7 @@ func (g *gpgtestui) Sign(_ context.Context, arg keybase1.SignArg) (string, error
 	if err != nil {
 		return "", err
 	}
-	cli := libkb.G.GetGpgClient()
+	cli := g.G().GetGpgClient()
 	if err := cli.Configure(); err != nil {
 		return "", err
 	}
@@ -91,9 +92,9 @@ type gpgSelectEmailUI struct {
 	Email string
 }
 
-func newGPGSelectEmailUI(email string) *gpgSelectEmailUI {
+func newGPGSelectEmailUI(g *libkb.GlobalContext, email string) *gpgSelectEmailUI {
 	return &gpgSelectEmailUI{
-		gpgtestui: &gpgtestui{},
+		gpgtestui: &gpgtestui{Contextified: libkb.NewContextified(g)},
 		Email:     email,
 	}
 }

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -31,7 +31,9 @@ func importTrackingLink(t *testing.T, g *libkb.GlobalContext) *libkb.TrackChainL
 }
 
 func TestIdentify2WithUIDImportTrackingLink(t *testing.T) {
-	link := importTrackingLink(t, nil)
+	tc := libkb.SetupTest(t, "TestIdentify2WithUIDImportTrackingLink", 0)
+	defer tc.Cleanup()
+	link := importTrackingLink(t, tc.G)
 	if link == nil {
 		t.Fatalf("link import failed")
 	}

--- a/go/engine/list_tracking.go
+++ b/go/engine/list_tracking.go
@@ -60,7 +60,7 @@ func (e *ListTrackingEngine) SubConsumers() []libkb.UIConsumer { return nil }
 
 func (e *ListTrackingEngine) Run(ctx *Context) (err error) {
 
-	var arg libkb.LoadUserArg
+	arg := libkb.NewLoadUserArg(e.G())
 
 	if len(e.arg.ForAssertion) > 0 {
 		arg = libkb.NewLoadUserByNameArg(e.G(), e.arg.ForAssertion)

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -1234,7 +1234,7 @@ func TestProvisionGPGSign(t *testing.T) {
 			LogUI:       tc2.G.UI.GetLogUI(),
 			SecretUI:    u1.NewSecretUI(),
 			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-			GPGUI:       &gpgtestui{},
+			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
 		}
 		eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 		if err := RunEngine(eng, ctx); err != nil {
@@ -1354,7 +1354,7 @@ func TestProvisionGPGSignSecretStore(t *testing.T) {
 			LogUI:       tc2.G.UI.GetLogUI(),
 			SecretUI:    secUI,
 			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-			GPGUI:       &gpgtestui{},
+			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
 		}
 		eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 		if err := RunEngine(eng, ctx); err != nil {
@@ -1425,7 +1425,7 @@ func TestProvisionGPGSwitchToSign(t *testing.T) {
 			LogUI:       tc2.G.UI.GetLogUI(),
 			SecretUI:    u1.NewSecretUI(),
 			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-			GPGUI:       &gpgtestui{},
+			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
 		}
 
 		arg := loginProvisionArg{
@@ -1507,7 +1507,7 @@ func TestProvisionGPGNoSwitchToSign(t *testing.T) {
 		LogUI:       tc2.G.UI.GetLogUI(),
 		SecretUI:    u1.NewSecretUI(),
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-		GPGUI:       &gpgtestui{},
+		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
 	}
 
 	arg := loginProvisionArg{
@@ -1542,7 +1542,7 @@ func TestProvisionGPGNoKeyring(t *testing.T) {
 		LogUI:       tc2.G.UI.GetLogUI(),
 		SecretUI:    u1.NewSecretUI(),
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-		GPGUI:       &gpgtestui{},
+		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
 	}
 	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	if err := RunEngine(eng, ctx); err == nil {
@@ -1575,7 +1575,7 @@ func TestProvisionGPGNoMatch(t *testing.T) {
 		LogUI:       tc2.G.UI.GetLogUI(),
 		SecretUI:    u1.NewSecretUI(),
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-		GPGUI:       &gpgtestui{},
+		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
 	}
 	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	if err := RunEngine(eng, ctx); err == nil {
@@ -1605,7 +1605,7 @@ func TestProvisionGPGNoGPGExecutable(t *testing.T) {
 		LogUI:       tc2.G.UI.GetLogUI(),
 		SecretUI:    u1.NewSecretUI(),
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-		GPGUI:       &gpgtestui{},
+		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
 	}
 	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	err := RunEngine(eng, ctx)
@@ -1638,7 +1638,7 @@ func TestProvisionGPGNoGPGFound(t *testing.T) {
 		LogUI:       tc2.G.UI.GetLogUI(),
 		SecretUI:    u1.NewSecretUI(),
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-		GPGUI:       &gpgtestui{},
+		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
 	}
 	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	err := RunEngine(eng, ctx)
@@ -2388,6 +2388,7 @@ func TestResetThenPGPOnlyThenProvision(t *testing.T) {
 	}
 	gen.AddDefaultUID(tc.G)
 	peng := NewPGPKeyImportEngine(PGPKeyImportEngineArg{
+		Ctx:        tc.G,
 		Gen:        &gen,
 		PushSecret: true,
 		NoSave:     true,
@@ -3084,7 +3085,7 @@ func TestBootstrapAfterGPGSign(t *testing.T) {
 			LogUI:       tc2.G.UI.GetLogUI(),
 			SecretUI:    u1.NewSecretUI(),
 			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-			GPGUI:       &gpgtestui{},
+			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
 		}
 		eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 		if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -1234,7 +1234,7 @@ func TestProvisionGPGSign(t *testing.T) {
 			LogUI:       tc2.G.UI.GetLogUI(),
 			SecretUI:    u1.NewSecretUI(),
 			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
+			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc2.G)},
 		}
 		eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 		if err := RunEngine(eng, ctx); err != nil {
@@ -1354,7 +1354,7 @@ func TestProvisionGPGSignSecretStore(t *testing.T) {
 			LogUI:       tc2.G.UI.GetLogUI(),
 			SecretUI:    secUI,
 			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
+			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc2.G)},
 		}
 		eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 		if err := RunEngine(eng, ctx); err != nil {
@@ -1425,7 +1425,7 @@ func TestProvisionGPGSwitchToSign(t *testing.T) {
 			LogUI:       tc2.G.UI.GetLogUI(),
 			SecretUI:    u1.NewSecretUI(),
 			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
+			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc2.G)},
 		}
 
 		arg := loginProvisionArg{
@@ -1507,7 +1507,7 @@ func TestProvisionGPGNoSwitchToSign(t *testing.T) {
 		LogUI:       tc2.G.UI.GetLogUI(),
 		SecretUI:    u1.NewSecretUI(),
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
+		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc2.G)},
 	}
 
 	arg := loginProvisionArg{
@@ -1575,7 +1575,7 @@ func TestProvisionGPGNoMatch(t *testing.T) {
 		LogUI:       tc2.G.UI.GetLogUI(),
 		SecretUI:    u1.NewSecretUI(),
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
+		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc2.G)},
 	}
 	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	if err := RunEngine(eng, ctx); err == nil {
@@ -1605,7 +1605,7 @@ func TestProvisionGPGNoGPGExecutable(t *testing.T) {
 		LogUI:       tc2.G.UI.GetLogUI(),
 		SecretUI:    u1.NewSecretUI(),
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
+		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc2.G)},
 	}
 	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	err := RunEngine(eng, ctx)
@@ -1638,7 +1638,7 @@ func TestProvisionGPGNoGPGFound(t *testing.T) {
 		LogUI:       tc2.G.UI.GetLogUI(),
 		SecretUI:    u1.NewSecretUI(),
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
+		GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc2.G)},
 	}
 	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	err := RunEngine(eng, ctx)
@@ -3085,7 +3085,7 @@ func TestBootstrapAfterGPGSign(t *testing.T) {
 			LogUI:       tc2.G.UI.GetLogUI(),
 			SecretUI:    u1.NewSecretUI(),
 			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc.G)},
+			GPGUI:       &gpgtestui{Contextified: libkb.NewContextified(tc2.G)},
 		}
 		eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 		if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/passphrase_change_test.go
+++ b/go/engine/passphrase_change_test.go
@@ -651,6 +651,7 @@ func TestPassphraseChangeLoggedOutBackupKeySecretStorePGP(t *testing.T) {
 			SubkeyBits:  768,
 		},
 		PushSecret: true,
+		Ctx:        tc.G,
 	}
 	arg.Gen.MakeAllIds(tc.G)
 	ctx := &Context{
@@ -722,6 +723,7 @@ func TestPassphraseChangePGP3SecMultiple(t *testing.T) {
 		PushSecret: true,
 		NoSave:     true,
 		AllowMulti: true,
+		Ctx:        tc.G,
 	}
 	parg.Gen.MakeAllIds(tc.G)
 	pctx := &Context{
@@ -839,6 +841,7 @@ func TestPassphraseGenerationStored(t *testing.T) {
 			PrimaryBits: 768,
 			SubkeyBits:  768,
 		},
+		Ctx: tc.G,
 	}
 	pgpArg.Gen.MakeAllIds(tc.G)
 	pgpEng := NewPGPKeyImportEngine(pgpArg)

--- a/go/engine/pgp_decrypt_test.go
+++ b/go/engine/pgp_decrypt_test.go
@@ -199,7 +199,6 @@ func TestPGPDecryptSignedOther(t *testing.T) {
 	// signer logs out, recipient logs in:
 	t.Logf("signer (%q) logging out", signer.Username)
 	Logout(tcSigner)
-	libkb.G = tcRecipient.G
 	// G = libkb.G
 	t.Logf("recipient (%q) logging in", recipient.Username)
 	recipient.LoginOrBust(tcRecipient)
@@ -262,7 +261,6 @@ func TestPGPDecryptSignedIdentify(t *testing.T) {
 	// signer logs out, recipient logs in:
 	t.Logf("signer (%q) logging out", signer.Username)
 	Logout(tcSigner)
-	libkb.G = tcRecipient.G
 	t.Logf("recipient (%q) logging in", recipient.Username)
 	recipient.LoginOrBust(tcRecipient)
 

--- a/go/engine/pgp_test.go
+++ b/go/engine/pgp_test.go
@@ -21,6 +21,7 @@ func TestGenerateNewPGPKey(t *testing.T) {
 			PrimaryBits: 768,
 			SubkeyBits:  768,
 		},
+		Ctx: tc.G,
 	}
 	arg.Gen.MakeAllIds(tc.G)
 	ctx := Context{

--- a/go/engine/pgp_update_test.go
+++ b/go/engine/pgp_update_test.go
@@ -111,6 +111,7 @@ func TestPGPUpdateMultiKey(t *testing.T) {
 			PrimaryBits: 768,
 			SubkeyBits:  768,
 		},
+		Ctx: tc.G,
 	}
 	arg.Gen.MakeAllIds(tc.G)
 	ctx := Context{

--- a/go/engine/revoke_sigs_test.go
+++ b/go/engine/revoke_sigs_test.go
@@ -35,6 +35,7 @@ func TestRevokeSig(t *testing.T) {
 			SubkeyBits:  768,
 		},
 		AllowMulti: true,
+		Ctx:        tc.G,
 	}
 	arg.Gen.MakeAllIds(tc.G)
 	pgpEngine := NewPGPKeyImportEngine(arg)

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -243,6 +243,7 @@ func TestIssue280(t *testing.T) {
 			PrimaryBits: 768,
 			SubkeyBits:  768,
 		},
+		Ctx: tc.G,
 	}
 	arg.Gen.MakeAllIds(tc.G)
 	ctx := Context{

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -161,7 +161,7 @@ func TestLocalKeySecurity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lks := libkb.NewLKSec(s.ppStream, s.uid, nil)
+	lks := libkb.NewLKSec(s.ppStream, s.uid, tc.G)
 	if err := lks.Load(nil); err != nil {
 		t.Fatal(err)
 	}

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -57,6 +57,9 @@ func main() {
 		g.Log.Errorf("SaferDLLLoading error: %v", err.Error())
 	}
 
+	// Set our panel of external services.
+	g.SetServices(externals.GetServices())
+
 	go HandleSignals(g)
 	err = mainInner(g)
 
@@ -162,8 +165,6 @@ func mainInner(g *libkb.GlobalContext) error {
 }
 
 func configOtherLibraries(g *libkb.GlobalContext) error {
-	// Set our panel of external services.
-	g.SetServices(externals.GetServices())
 	// Set our UID -> Username mapping service
 	g.SetUIDMapper(uidmap.NewUIDMap(g.Env.GetUIDMapFullNameCacheSize()))
 	return nil

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -28,9 +28,6 @@ import (
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
-// Keep this around to simplify things
-var G = libkb.G
-
 var cmd libcmdline.Command
 
 var errParseArgs = errors.New("failed to parse command line arguments")
@@ -51,7 +48,7 @@ func main() {
 		return
 	}
 
-	g := G
+	g := libkb.NewGlobalContext()
 	g.Init()
 
 	// Don't abort here. This should not happen on any known version of Windows, but
@@ -60,10 +57,7 @@ func main() {
 		g.Log.Errorf("SaferDLLLoading error: %v", err.Error())
 	}
 
-	// Set our panel of external services.
-	g.SetServices(externals.GetServices())
-
-	go HandleSignals()
+	go HandleSignals(g)
 	err = mainInner(g)
 
 	if g.Env.GetDebug() {
@@ -168,6 +162,8 @@ func mainInner(g *libkb.GlobalContext) error {
 }
 
 func configOtherLibraries(g *libkb.GlobalContext) error {
+	// Set our panel of external services.
+	g.SetServices(externals.GetServices())
 	// Set our UID -> Username mapping service
 	g.SetUIDMapper(uidmap.NewUIDMap(g.Env.GetUIDMapFullNameCacheSize()))
 	return nil
@@ -335,34 +331,34 @@ func configurePath(g *libkb.GlobalContext, cl *libcmdline.CommandLine) error {
 	return client.SendPath(g)
 }
 
-func HandleSignals() {
+func HandleSignals(g *libkb.GlobalContext) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, os.Kill)
 	for {
 		s := <-c
 		if s != nil {
-			G.Log.Debug("trapped signal %v", s)
+			g.Log.Debug("trapped signal %v", s)
 
 			// if the current command has a Stop function, then call it.
 			// It will do its own stopping of the process and calling
 			// shutdown
 			if stop, ok := cmd.(client.Stopper); ok {
-				G.Log.Debug("Stopping command cleanly via stopper")
+				g.Log.Debug("Stopping command cleanly via stopper")
 				stop.Stop(keybase1.ExitCode_OK)
 				return
 			}
 
 			// if the current command has a Cancel function, then call it:
 			if canc, ok := cmd.(client.Canceler); ok {
-				G.Log.Debug("canceling running command")
+				g.Log.Debug("canceling running command")
 				if err := canc.Cancel(); err != nil {
-					G.Log.Warning("error canceling command: %s", err)
+					g.Log.Warning("error canceling command: %s", err)
 				}
 			}
 
-			G.Log.Debug("calling shutdown")
-			G.Shutdown()
-			G.Log.Error("interrupted")
+			g.Log.Debug("calling shutdown")
+			g.Shutdown()
+			g.Log.Error("interrupted")
 			os.Exit(3)
 		}
 	}

--- a/go/libkb/api_stub.go
+++ b/go/libkb/api_stub.go
@@ -9,9 +9,9 @@ type StubAPIEngine struct {
 	*ExternalAPIEngine
 }
 
-func NewStubAPIEngine() *StubAPIEngine {
+func NewStubAPIEngine(g *GlobalContext) *StubAPIEngine {
 	return &StubAPIEngine{
-		ExternalAPIEngine: &ExternalAPIEngine{BaseAPIEngine{clients: make(map[int]*Client)}},
+		ExternalAPIEngine: &ExternalAPIEngine{BaseAPIEngine{Contextified: NewContextified(g), clients: make(map[int]*Client)}},
 	}
 }
 

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -461,6 +461,7 @@ func (c *ChainLink) UnpackLocal() (err error) {
 
 func (c *ChainLink) UnpackComputedKeyInfos(jw *jsonw.Wrapper) (err error) {
 	var tmp ComputedKeyInfos
+	tmp.SetGlobalContext(c.G())
 	if jw == nil || jw.IsNil() {
 		return
 	}

--- a/go/libkb/file_test.go
+++ b/go/libkb/file_test.go
@@ -4,6 +4,7 @@
 package libkb
 
 import (
+	"github.com/keybase/client/go/logger"
 	"os"
 	"runtime"
 	"sync"
@@ -16,7 +17,7 @@ func TestFileSave(t *testing.T) {
 
 	file := NewFile(filename, []byte("test data"), 0644)
 	t.Logf("Saving")
-	err := file.Save(G.Log)
+	err := file.Save(logger.NewTestLogger(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,13 +30,15 @@ func TestFileSaveConcurrent(t *testing.T) {
 	filename := "file_test.tmp"
 	defer os.Remove(filename)
 
+	log := logger.NewTestLogger(t)
+
 	var wg sync.WaitGroup
 	for i := 0; i < 20; i++ {
 		wg.Add(1)
 		go func() {
 			file := NewFile(filename, []byte("test data"), 0644)
 			t.Logf("Saving")
-			err := file.Save(G.Log)
+			err := file.Save(log)
 			if err != nil {
 				t.Errorf("save err: %s", err)
 			}
@@ -49,7 +52,7 @@ func TestFileSaveConcurrent(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		wg2.Add(1)
 		go func() {
-			err := file.Save(G.Log)
+			err := file.Save(log)
 			if err != nil {
 				t.Errorf("save err: %s", err)
 			}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -191,10 +191,7 @@ func (g *GlobalContext) CloneWithNetContext(netCtx context.Context) *GlobalConte
 	return &tmp
 }
 
-var G *GlobalContext
-
 func init() {
-	G = NewGlobalContext()
 }
 
 func (g *GlobalContext) SetCommandLine(cmd CommandLine) { g.Env.SetCommandLine(cmd) }
@@ -673,10 +670,7 @@ type Contextified struct {
 }
 
 func (c Contextified) G() *GlobalContext {
-	if c.g != nil {
-		return c.g
-	}
-	return G
+	return c.g
 }
 
 func (c Contextified) GStrict() *GlobalContext {

--- a/go/libkb/gpg_index_test.go
+++ b/go/libkb/gpg_index_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 func parse(t *testing.T, kr string) *GpgKeyIndex {
+	tc := SetupTest(t, "parse", 2)
+	defer tc.Cleanup()
 	buf := bytes.NewBufferString(kr)
-	i, w, e := ParseGpgIndexStream(G, buf)
+	i, w, e := ParseGpgIndexStream(tc.G, buf)
 	if e != nil {
 		t.Fatalf("failure in parse: %s", e)
 	}
@@ -145,7 +147,7 @@ pub:u:4096:1:63847B4B83930F0C:1380929487:1607159887::u:::escaESCA:
 fpr:::::::::4475293306243408FA5958DC63847B4B83930F0C:
 uid:u::::1387217771::759D5C7C38AD60551D46D2E6F34BA03640FE4379::Maxwell Krohn <themax@gmail.com>:
 uid:u::::1380929487::14BC0C35326061518657E0B8F71A23E0CA537034::Max Krohn <themax@gmail.com>:
-sub:u:4096:1:2FE01C454348DA39:1380929487:1507159887:::::esa:
+sub:u:4096:1:2FE01C454348DA39:1380929487:1607159887:::::esa:
 fpr:::::::::C4EE7BCBCE2F0953DCF9E8902FE01C454348DA39:
 pub:u:2048:1:2EE0695E30C55BEF:1392816673:1708176673::u:::scESC:
 fpr:::::::::F1DEFAA6B3DB297FB824CB512EE0695E30C55BEF:

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -237,6 +237,7 @@ func (cki *ComputedKeyInfos) PaperDevices() []*Device {
 // https://github.com/keybase/client/issues/414 .
 func (cki ComputedKeyInfos) ShallowCopy() *ComputedKeyInfos {
 	ret := &ComputedKeyInfos{
+		Contextified:  NewContextified(cki.G()),
 		dirty:         cki.dirty,
 		Version:       cki.Version,
 		Infos:         make(map[keybase1.KID]*ComputedKeyInfo, len(cki.Infos)),

--- a/go/libkb/pgp_dec_test.go
+++ b/go/libkb/pgp_dec_test.go
@@ -28,7 +28,7 @@ func TestPGPDecryptBasic(t *testing.T) {
 	}
 
 	out := NewBufferCloser()
-	if _, err := PGPDecryptWithBundles(G, mid, out, recipients); err != nil {
+	if _, err := PGPDecryptWithBundles(tc.G, mid, out, recipients); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/libkb/pgp_enc_test.go
+++ b/go/libkb/pgp_enc_test.go
@@ -161,7 +161,7 @@ func TestPGPEncryptLong(t *testing.T) {
 
 	rand.Read(msg)
 
-	G.Log.Info("msg size: %d", len(msg))
+	tc.G.Log.Info("msg size: %d", len(msg))
 
 	sink := NewBufferCloser()
 	recipients := []*PGPKeyBundle{bundleSrc, bundleDst}

--- a/go/libkb/ratelimit_test.go
+++ b/go/libkb/ratelimit_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestRateLimit(t *testing.T) {
-	limits := NewRateLimits(G)
+	tc := SetupTest(t, "rateLimit", 0)
+	defer tc.Cleanup()
+	limits := NewRateLimits(tc.G)
 	if !limits.GetPermission(TestEventRateLimit, 1*time.Minute) {
 		t.Fatal("expected to get permission")
 	}

--- a/go/libkb/sig_chain_test.go
+++ b/go/libkb/sig_chain_test.go
@@ -136,7 +136,7 @@ func TestAllChains(t *testing.T) {
 	sort.Strings(testNames)
 	for _, name := range testNames {
 		testCase := testList.Tests[name]
-		G.Log.Info("starting sigchain test case %s (%s)", name, testCase.Input)
+		tc.G.Log.Info("starting sigchain test case %s (%s)", name, testCase.Input)
 		doChainTest(t, tc, testCase)
 	}
 }
@@ -185,7 +185,7 @@ func doChainTest(t *testing.T, tc TestContext, testCase TestCase) {
 	}
 
 	// Parse all the key bundles.
-	keyFamily, err := createKeyFamily(input.Keys)
+	keyFamily, err := createKeyFamily(tc.G, input.Keys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func doChainTest(t *testing.T, tc TestContext, testCase TestCase) {
 	// Run the actual sigchain parsing and verification. This is most of the
 	// code that's actually being tested.
 	var sigchainErr error
-	ckf := ComputedKeyFamily{kf: keyFamily}
+	ckf := ComputedKeyFamily{Contextified: NewContextified(tc.G), kf: keyFamily}
 	sigchain := SigChain{
 		username:          NewNormalizedUsername(input.Username),
 		uid:               uid,
@@ -202,7 +202,7 @@ func doChainTest(t *testing.T, tc TestContext, testCase TestCase) {
 	}
 	for i := 0; i < chainLen; i++ {
 		linkBlob := inputBlob.AtKey("chain").AtIndex(i)
-		link, err := ImportLinkFromServer(nil, &sigchain, linkBlob, uid)
+		link, err := ImportLinkFromServer(tc.G, &sigchain, linkBlob, uid)
 		if err != nil {
 			sigchainErr = err
 			break
@@ -229,7 +229,7 @@ func doChainTest(t *testing.T, tc TestContext, testCase TestCase) {
 		}
 		if expectedTypes[foundType] {
 			// Success! We found the error we expected. This test is done.
-			G.Log.Debug("EXPECTED error encountered: %s", sigchainErr)
+			tc.G.Log.Debug("EXPECTED error encountered: %s", sigchainErr)
 			return
 		}
 
@@ -251,7 +251,7 @@ func doChainTest(t *testing.T, tc TestContext, testCase TestCase) {
 	unrevokedCount := 0
 
 	// XXX we should really contextify this
-	idtable, err := NewIdentityTable(nil, eldestKID, &sigchain, nil)
+	idtable, err := NewIdentityTable(tc.G, eldestKID, &sigchain, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -368,7 +368,7 @@ func storeAndLoad(t *testing.T, tc TestContext, chain *SigChain) {
 	}
 }
 
-func createKeyFamily(bundles []string) (*KeyFamily, error) {
+func createKeyFamily(g *GlobalContext, bundles []string) (*KeyFamily, error) {
 	allKeys := jsonw.NewArray(len(bundles))
 	for i, bundle := range bundles {
 		err := allKeys.SetIndex(i, jsonw.NewString(bundle))
@@ -378,7 +378,7 @@ func createKeyFamily(bundles []string) (*KeyFamily, error) {
 	}
 	publicKeys := jsonw.NewDictionary()
 	publicKeys.SetKey("all_bundles", allKeys)
-	return ParseKeyFamily(G, publicKeys)
+	return ParseKeyFamily(g, publicKeys)
 }
 
 func getCurrentTimeForTest(sigChain SigChain, keyFamily *KeyFamily) time.Time {

--- a/go/libkb/sig_chain_test.go
+++ b/go/libkb/sig_chain_test.go
@@ -250,7 +250,6 @@ func doChainTest(t *testing.T, tc TestContext, testCase TestCase) {
 	// Check the expected results: total unrevoked links, sibkeys, and subkeys.
 	unrevokedCount := 0
 
-	// XXX we should really contextify this
 	idtable, err := NewIdentityTable(tc.G, eldestKID, &sigchain, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -40,29 +40,6 @@ func MakeThinGlobalContextForTesting(t *testing.T) *GlobalContext {
 	return g
 }
 
-func (c *TestConfig) InitTest(t *testing.T, initConfig string) {
-	G.Log = logger.NewTestLogger(t)
-	G.Init()
-
-	var f *os.File
-	var err error
-	if f, err = ioutil.TempFile(os.TempDir(), "testconfig"); err != nil {
-		t.Fatalf("couldn't create temp file: %s", err)
-	}
-	c.configFileName = f.Name()
-	if _, err = f.WriteString(initConfig); err != nil {
-		t.Fatalf("couldn't write config file: %s", err)
-	}
-	f.Close()
-
-	// XXX: The global G prevents us from running tests in parallel
-	G.Env.Test.ConfigFilename = c.configFileName
-
-	if err = G.ConfigureConfig(); err != nil {
-		t.Fatalf("couldn't configure the config: %s", err)
-	}
-}
-
 func makeLogGetter(t *testing.T) func() logger.Logger {
 	return func() logger.Logger { return logger.NewTestLogger(t) }
 }
@@ -245,7 +222,7 @@ func setupTestContext(tb testing.TB, name string, tcPrev *TestContext) (tc TestC
 	}
 
 	// use stub engine for external api
-	g.XAPI = NewStubAPIEngine()
+	g.XAPI = NewStubAPIEngine(g)
 
 	if err = g.ConfigureConfig(); err != nil {
 		return
@@ -269,14 +246,11 @@ func setupTestContext(tb testing.TB, name string, tcPrev *TestContext) (tc TestC
 
 	g.GregorDismisser = &FakeGregorDismisser{}
 	g.SetUIDMapper(NewTestUIDMapper(g.GetUPAKLoader()))
-
-	tc.PrevGlobal = G
-	G = g
 	tc.G = g
 	tc.T = tb
 
-	if G.SecretStoreAll == nil {
-		G.SecretStoreAll = &SecretStoreLocked{SecretStoreAll: NewTestSecretStoreAll(G, G)}
+	if g.SecretStoreAll == nil {
+		g.SecretStoreAll = &SecretStoreLocked{SecretStoreAll: NewTestSecretStoreAll(g, g)}
 	}
 
 	return

--- a/go/systests/account_deadlock_test.go
+++ b/go/systests/account_deadlock_test.go
@@ -20,8 +20,6 @@ func TestAccountDeadlock(t *testing.T) {
 	tc := setupTest(t, "deadlock")
 	tc2 := cloneContext(tc)
 
-	libkb.G.LocalDb = nil
-
 	defer tc.Cleanup()
 
 	stopCh := make(chan error)

--- a/go/systests/delegate_ui_test.go
+++ b/go/systests/delegate_ui_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/client"
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/service"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -165,9 +164,6 @@ func TestDelegateUI(t *testing.T) {
 	tc := setupTest(t, "delegate_ui")
 	tc1 := cloneContext(tc)
 	tc2 := cloneContext(tc)
-
-	// Make sure we're not using G anywhere in our tests.
-	libkb.G.LocalDb = nil
 
 	defer tc.Cleanup()
 

--- a/go/systests/passphrase_test.go
+++ b/go/systests/passphrase_test.go
@@ -21,8 +21,6 @@ func TestPassphraseChange(t *testing.T) {
 	tc := setupTest(t, "pp")
 	tc2 := cloneContext(tc)
 
-	libkb.G.LocalDb = nil
-
 	defer tc.Cleanup()
 
 	stopCh := make(chan error)
@@ -112,7 +110,6 @@ func startNewService(tc *libkb.TestContext) (*serviceHandle, error) {
 // Tests recovering a passphrase on a second machine by logging in with paperkey.
 func TestPassphraseRecover(t *testing.T) {
 	t.Logf("Start")
-	libkb.G.LocalDb = nil
 
 	// Service contexts.
 	// Make a new context with cloneContext for each client session.

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -27,8 +27,6 @@ func TestRPCs(t *testing.T) {
 	tc := setupTest(t, "rpcs")
 	tc2 := cloneContext(tc)
 
-	libkb.G.LocalDb = nil
-
 	defer tc.Cleanup()
 
 	stopCh := make(chan error)

--- a/go/systests/secret_ui_test.go
+++ b/go/systests/secret_ui_test.go
@@ -20,9 +20,6 @@ func TestSecretUI(t *testing.T) {
 	tc1 := cloneContext(tc)
 	tc2 := cloneContext(tc)
 
-	// Make sure we're not using G anywhere in our tests.
-	libkb.G.LocalDb = nil
-
 	defer tc.Cleanup()
 
 	stopCh := make(chan error)

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -7,7 +7,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
 	"github.com/stretchr/testify/require"
@@ -235,7 +234,6 @@ func TestTeamReInviteAfterReset(t *testing.T) {
 
 	t.Logf("Trying to get a PUK")
 
-	libkb.G = bob.getPrimaryGlobalContext()
 	bob.primaryDevice().tctx.Tp.DisableUpgradePerUserKey = false
 
 	err := bob.perUserKeyUpgrade()
@@ -354,11 +352,7 @@ func TestImpTeamWithMultipleRooters(t *testing.T) {
 
 	require.NotEqual(t, team1, team2)
 
-	// proveRooter has a problem where some code path relies on global
-	// libkb.G context, so we need to change it before for each user.
-	libkb.G = bob.tc.G
 	bob.proveRooter()
-	libkb.G = charlie.tc.G
 	charlie.proveRooter()
 
 	alice.kickTeamRekeyd()

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -98,8 +98,6 @@ func TestTrackingNotifications(t *testing.T) {
 	tc2 := cloneContext(tc)
 	tc5 := cloneContext(tc)
 
-	libkb.G.LocalDb = nil
-
 	// Hack the various portions of the service that aren't
 	// properly contextified.
 

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -223,8 +223,6 @@ func TestSignupLogout(t *testing.T) {
 	tc2 := cloneContext(tc)
 	tc5 := cloneContext(tc)
 
-	libkb.G.LocalDb = nil
-
 	// Hack the various portions of the service that aren't
 	// properly contextified.
 


### PR DESCRIPTION
this is another crack at #8746, but rebased and using other PRs for `LoadUserArg` refactors, and `client` de-G-ification