### PR TITLE
Add support for aarch64 via separate linux logger

### DIFF
--- a/go/logger/redirect_stderr_linux.go
+++ b/go/logger/redirect_stderr_linux.go
@@ -1,16 +1,15 @@
 // Copyright 2016 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-// +build darwin freebsd openbsd
+// +build linux,!android
 
 package logger
 
 import (
-	"os"
-	"syscall"
+       "os"
+       "syscall"
 )
 
 func tryRedirectStderrTo(f *os.File) error {
-	// Calling dup2 first closes the current stderr and then dups the new handle there.
-	return syscall.Dup2(int(f.Fd()), 2)
+       return syscall.Dup3(int(f.Fd()), 2, 0)
 }


### PR DESCRIPTION
This is an initial attempt to add support for aarch64 to keybase.

Since aarch64 doesn't support the Dup2 syscall, only Dup3, I've added a separate logger file that uses Dup3, which has 3 arguments instead of Dup2's 2 arguments.

This should definitely be reviewed as I'm not certain I used the correct flag here.  Everything seems to be working okay on my ODROID-C2, but I'd rather let someone who is far more familiar with what it's doing make sure I have the correct flag.  

This is an attempt to address #7021 