### PR TITLE
Return NotFoundError if kid not found

### DIFF
--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -504,6 +504,10 @@ func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid 
 		}
 		ret = nil
 	}
+	if ret == nil {
+		return nil, nil, nil, NotFoundError{}
+	}
+
 	return ret, key, linkMap, nil
 }
 

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -505,7 +505,7 @@ func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid 
 		ret = nil
 	}
 
-	return ret, key, linkMap, NotFoundError{}
+	return nil, nil, nil, NotFoundError{}
 }
 
 func (u *CachedUPAKLoader) Invalidate(ctx context.Context, uid keybase1.UID) {

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -475,7 +475,7 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 // KID, as well as the Key data associated with that KID. It picks the latest such
 // incarnation if there are multiple.
 func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (ret *keybase1.UserPlusKeysV2, key *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
-	defer u.G().CVTrace(ctx, VLog0, fmt.Sprintf("uid:%s,kid:%s", uid, kid), func() error { return err })()
+	defer u.G().CVTrace(ctx, VLog0, fmt.Sprintf("LoadKeyV2 uid:%s,kid:%s", uid, kid), func() error { return err })()
 	if uid.IsNil() {
 		return nil, nil, nil, NoUIDError{}
 	}
@@ -500,15 +500,12 @@ func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid 
 		ret, key = upak.FindKID(kid)
 		if key != nil {
 			u.G().VDL.CLogf(ctx, VLog0, "- found kid in UPAK: %v", *ret)
-			break
+			return ret, key, linkMap, nil
 		}
 		ret = nil
 	}
-	if ret == nil {
-		return nil, nil, nil, NotFoundError{}
-	}
 
-	return ret, key, linkMap, nil
+	return ret, key, linkMap, NotFoundError{}
 }
 
 func (u *CachedUPAKLoader) Invalidate(ctx context.Context, uid keybase1.UID) {

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -232,6 +232,9 @@ func (l *LoaderContextG) loadKeyV2(ctx context.Context, uid keybase1.UID, kid ke
 	if err != nil {
 		return
 	}
+	if user == nil {
+		return uv, pubKey, linkMap, libkb.NotFoundError{}
+	}
 
 	return user.ToUserVersion(), pubKey, linkMap, nil
 }


### PR DESCRIPTION
Regardless of how it happened that LoadV2() returned `nil, nil, X, nil`, I think this is better than crashing.