### PR TITLE
Better installer errors

### DIFF
--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -107,7 +107,7 @@ function checkErrors(result: InstallResult): CheckErrorsResult {
         errors.push(`There was an error trying to install the ${cr.name}.`)
         if (cr.name === 'kbnm') {
          hasKBNMError = true
-         errors.push(`\n\n{cr.desc}`)
+         errors.push(`\n\n${cr.desc}`)
         }
       }
     }

--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -49,7 +49,12 @@ export default (callback: (err: any) => void): void => {
   const args = ['--debug', 'install-auto', '--format=json', '--timeout=' + timeout + 's']
 
   exec(keybaseBin, args, 'darwin', 'prod', true, (err, attempted, stdout, stderr) => {
-    let errorsResult: CheckErrorsResult = {errors: [], hasCLIError: false, hasFUSEError: false, hasKBNMError: false}
+    let errorsResult: CheckErrorsResult = {
+      errors: [],
+      hasCLIError: false,
+      hasFUSEError: false,
+      hasKBNMError: false,
+    }
     if (err) {
       errorsResult.errors = [`There was an error trying to run the install (${err.code}).`]
     } else if (stdout !== '') {
@@ -68,7 +73,7 @@ export default (callback: (err: any) => void): void => {
     }
 
     if (errorsResult.errors.length > 0) {
-      showError(errorsResult.errors, (errorsResult.hasFUSEError || errorsResult.hasKBNMError), callback)
+      showError(errorsResult.errors, errorsResult.hasFUSEError || errorsResult.hasKBNMError, callback)
       return
     }
 
@@ -92,7 +97,7 @@ function checkErrors(result: InstallResult): CheckErrorsResult {
   for (let cr of crs) {
     if (cr.status.code !== 0) {
       if (cr.name === 'fuse') {
-        let hasFUSEError = true
+        hasFUSEError = true
         if (cr.exitCode === ExitCodeFuseKextError) {
           errors.push(
             `We were unable to load KBFS (Fuse kext). This may be due to a limitation in MacOS where there aren't any device slots available. Device slots can be taken up by apps such as VMWare, VirtualBox, anti-virus programs, VPN programs and Intel HAXM.`
@@ -106,8 +111,8 @@ function checkErrors(result: InstallResult): CheckErrorsResult {
       } else {
         errors.push(`There was an error trying to install the ${cr.name}.`)
         if (cr.name === 'kbnm') {
-         hasKBNMError = true
-         errors.push(`\n${cr.status.desc}`)
+          hasKBNMError = true
+          errors.push(`\n${cr.status.desc}`)
         }
       }
     }

--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -18,8 +18,8 @@ const installerState = new InstallerData('installer.json', {promptedForCLI: fals
 type CheckErrorsResult = {
   errors: Array<string>,
   hasCLIError: boolean,
-  hasKBNMError: boolean,
   hasFUSEError: boolean,
+  hasKBNMError: boolean,
 }
 
 // Install.

--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -107,7 +107,7 @@ function checkErrors(result: InstallResult): CheckErrorsResult {
         errors.push(`There was an error trying to install the ${cr.name}.`)
         if (cr.name === 'kbnm') {
          hasKBNMError = true
-         errors.push(`\n\n${cr.desc}`)
+         errors.push(`\n${cr.status.desc}`)
         }
       }
     }

--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -18,6 +18,8 @@ const installerState = new InstallerData('installer.json', {promptedForCLI: fals
 type CheckErrorsResult = {
   errors: Array<string>,
   hasCLIError: boolean,
+  hasKBNMError: boolean,
+  hasFUSEError: boolean,
 }
 
 // Install.
@@ -47,7 +49,7 @@ export default (callback: (err: any) => void): void => {
   const args = ['--debug', 'install-auto', '--format=json', '--timeout=' + timeout + 's']
 
   exec(keybaseBin, args, 'darwin', 'prod', true, (err, attempted, stdout, stderr) => {
-    let errorsResult: CheckErrorsResult = {errors: [], hasCLIError: false}
+    let errorsResult: CheckErrorsResult = {errors: [], hasCLIError: false, hasFUSEError: false, hasKBNMError: false}
     if (err) {
       errorsResult.errors = [`There was an error trying to run the install (${err.code}).`]
     } else if (stdout !== '') {
@@ -66,7 +68,7 @@ export default (callback: (err: any) => void): void => {
     }
 
     if (errorsResult.errors.length > 0) {
-      showError(errorsResult.errors, callback)
+      showError(errorsResult.errors, (errorsResult.hasFUSEError || errorsResult.hasKBNMError), callback)
       return
     }
 
@@ -84,10 +86,13 @@ export default (callback: (err: any) => void): void => {
 function checkErrors(result: InstallResult): CheckErrorsResult {
   let errors = []
   let hasCLIError = false
+  let hasFUSEError = false
+  let hasKBNMError = false
   const crs = (result && result.componentResults) || []
   for (let cr of crs) {
     if (cr.status.code !== 0) {
       if (cr.name === 'fuse') {
+        let hasFUSEError = true
         if (cr.exitCode === ExitCodeFuseKextError) {
           errors.push(
             `We were unable to load KBFS (Fuse kext). This may be due to a limitation in MacOS where there aren't any device slots available. Device slots can be taken up by apps such as VMWare, VirtualBox, anti-virus programs, VPN programs and Intel HAXM.`
@@ -100,18 +105,22 @@ function checkErrors(result: InstallResult): CheckErrorsResult {
         hasCLIError = true
       } else {
         errors.push(`There was an error trying to install the ${cr.name}.`)
+        if (cr.name === 'kbnm') {
+         hasKBNMError = true
+         errors.push(`\n\n{cr.desc}`)
+        }
       }
     }
   }
-  return {errors, hasCLIError}
+  return {errors, hasCLIError, hasFUSEError, hasKBNMError}
 }
 
-function showError(errors: Array<string>, callback: (err: ?Error) => void) {
+function showError(errors: Array<string>, showOkay: boolean, callback: (err: ?Error) => void) {
   const detail = errors.join('\n') + `\n\nPlease run \`keybase log send\` to report the error.`
   dialog.showMessageBox(
     {
-      buttons: ['Ignore', 'Quit'],
-      detail: detail,
+      buttons: showOkay ? ['Okay'] : ['Ignore', 'Quit'],
+      detail,
       message: 'Keybase Install Error',
     },
     resp => {


### PR DESCRIPTION
@keybase/react-hackers CC @maxtaco 

Before:

<img width="489" alt="screen shot 2017-10-05 at 5 23 00 pm" src="https://user-images.githubusercontent.com/21217/31258141-f0085ec4-a9f1-11e7-87f6-17bbea1d0bc8.png">

After:

<img width="450" alt="screen shot 2017-10-05 at 4 50 49 pm" src="https://user-images.githubusercontent.com/21217/31258146-f6f02276-a9f1-11e7-8d0c-61c0f7c3c1a6.png">

(So, we no longer offer the Quit option for non-fatal errors, and we pass through a description of the error to the dialog box.)