### PR TITLE
extra checks on pausableconnect

### DIFF
--- a/shared/util/pausable-connect.js
+++ b/shared/util/pausable-connect.js
@@ -9,6 +9,15 @@ function selectorFactory(dispatch, factoryOptions) {
   let wasActiveRoute = false
   let cachedResult
   const pausableSelector = function(state, ownProps) {
+    // we want to explicitly get isActiveRoute passed in always and not invisibly be paused if
+    // we forget to pass it down cause thats' very confusing
+    if (__DEV__) {
+      if (ownProps.isActiveRoute === undefined) {
+        console.error(
+          "Error: pausableConnect didn't get isActiveRoute passed down. Did you forget to plumb it?"
+        )
+      }
+    }
     // We run the selector the first time the HoC is mounted, even if not
     // active. Some connected components have expectations of the structure of
     // their props, so we can't render them until we have data from the

--- a/shared/util/pausable-connect.js
+++ b/shared/util/pausable-connect.js
@@ -10,7 +10,7 @@ function selectorFactory(dispatch, factoryOptions) {
   let cachedResult
   const pausableSelector = function(state, ownProps) {
     // we want to explicitly get isActiveRoute passed in always and not invisibly be paused if
-    // we forget to pass it down cause thats' very confusing
+    // we forget to pass it down because that's very confusing
     if (__DEV__) {
       if (ownProps.isActiveRoute === undefined) {
         console.error(


### PR DESCRIPTION
mobile inbox wasn't loading because the isActiveRoute prop wasn't being plumbed down in the connector which perma-paused the rows. A very confusing bug that took too long to figure out. 
Instead of that happening again, lets explicitly expect the isActiveRoute flag to come down always and complain if not

@keybase/react-hackers 