### PR TITLE
Explicitly copy installer instead of relying on cache

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -27,11 +27,13 @@
       <ComponentGroupRef Id="StartupShortcuts" />
       <ComponentGroupRef Id="GuiStartMenuTileColors" />
       <ComponentGroupRef Id="BrowserExtensionKbnm" />
+      <ComponentGroupRef Id="installerFolderGroup" />
     </Feature>
 
 
     <InstallExecuteSequence>
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
+      <Custom Action="ParseBundlePath" After="CostFinalize">NOT REMOVE AND BUNDLEFILE</Custom>
       <Custom Action="StopUpdater" Before="InstallValidate"><![CDATA[Installed]]></Custom>
       <!-- These roaming actions are temporary, while we switch from appdata to localappdata. -->
       <Custom Action="StopUpdaterRoaming" Before="InstallValidate"><![CDATA[Installed]]></Custom>
@@ -43,6 +45,7 @@
       <Custom Action="RunMainApp" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="RunGUI" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="AddBrowserExtension" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
+      <Custom Action="CopyBundle" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
     </InstallExecuteSequence>
 
 
@@ -63,6 +66,7 @@
 			<Directory Id="LocalAppDataFolder">
         <Directory Id="INSTALLFOLDER" Name="Keybase">
           <Directory Id="PROMPTERFOLDER" Name="prompter"/>
+          <Directory Id="INSTALLERFOLDER" Name="install"/>
         </Directory>
       </Directory>
       <Directory Id="ProgramMenuFolder">
@@ -136,7 +140,7 @@
               Action="createAndRemoveOnUninstall">
           <RegistryValue Type="string" Name="DOKANPRODUCT86" Value="[DOKANPRODUCT86]"/>
           <RegistryValue Type="string" Name="DOKANPRODUCT64" Value="[DOKANPRODUCT64]"/>
-	  <RegistryValue Type="string" Name="BUNDLEKEY" Value="[BUNDLEKEY]"/>
+	        <RegistryValue Type="string" Name="BUNDLEKEY" Value="[BUNDLEKEY]"/>
         </RegistryKey>
       </Component>
     </ComponentGroup>
@@ -249,6 +253,18 @@
 
     </ComponentGroup>
   </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="installerFolderGroup" Directory="INSTALLERFOLDER">
+      <Component Id="installerFolderId" Guid="{DD3552AD-520F-4766-B717-151316F781E4}">
+        <CreateFolder />
+        <RemoveFolder Id='INSTALLERFOLDERRemove' Directory='INSTALLERFOLDER' On='uninstall' />
+        <RegistryKey Root="HKCU" Key="Software\Keybase\Keybase">
+          <RegistryValue Type="string" Name="BUNDLEFILE" Value="[INSTALLERFOLDER][BUNDLENAME]" KeyPath="yes"/>
+        </RegistryKey>        
+      </Component>
+    </ComponentGroup>
+  </Fragment>
   <Fragment>
     <!-- This has to be run so the repairman can finish moving files before upd.exe is run by watchdog2 -->
     <CustomAction Id="RunMainAppDummyForRepair"
@@ -320,5 +336,20 @@
               ExeCommand="[INSTALLFOLDER]keybaserq.exe -wait &quot;[INSTALLFOLDER]kbnm.exe&quot; uninstall"
               Execute="immediate"
               Return="ignore"/>
+  </Fragment>
+  <Fragment>
+    <CustomAction Id="CopyBundle"
+              Directory="INSTALLFOLDER"
+              ExeCommand="[INSTALLFOLDER]keybaserq.exe -wait [SystemFolder]cmd.exe /C copy /Y &quot;[BUNDLEFILE]&quot; [INSTALLERFOLDER]"
+              Execute="immediate"
+              Return="ignore"/>
+  </Fragment>
+  <Fragment>
+    <CustomAction Id="ParseBundlePath" Script="vbscript">
+      <![CDATA[         
+        Set fso = CreateObject("Scripting.FileSystemObject") 
+        Session.Property("BUNDLENAME") = fso.GetBaseName(Session.Property("BUNDLEFILE"))     
+      ]]>
+    </CustomAction>
   </Fragment>
 </Wix>

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -16,7 +16,13 @@
                       Name="PendingFileRenameOperations"
                       Type="raw" />
     </Property>
-    
+    <Property Id="REG_BUNDLEFILE">
+      <RegistrySearch Id="BundlePath"
+                      Root="HKCU"
+                      Key="Software\Keybase\Keybase"
+                      Name="BUNDLEFILE"
+                      Type="raw" />
+    </Property>    
     <MajorUpgrade DowngradeErrorMessage="A newer version of Keybase is already installed." AllowSameVersionUpgrades="yes"  />	
 
     <Feature Id="ProductFeature" Title="Keybase Application" Level="1">
@@ -34,6 +40,7 @@
     <InstallExecuteSequence>
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
       <Custom Action="ParseBundlePath" After="CostFinalize">NOT REMOVE AND BUNDLEFILE</Custom>
+      <Custom Action="RemoveBundle"  Before="InstallValidate"><![CDATA[Installed AND REG_BUNDLEFILE]]></Custom>
       <Custom Action="StopUpdater" Before="InstallValidate"><![CDATA[Installed]]></Custom>
       <!-- These roaming actions are temporary, while we switch from appdata to localappdata. -->
       <Custom Action="StopUpdaterRoaming" Before="InstallValidate"><![CDATA[Installed]]></Custom>
@@ -45,7 +52,7 @@
       <Custom Action="RunMainApp" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="RunGUI" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="AddBrowserExtension" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
-      <Custom Action="CopyBundle" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
+      <Custom Action="CopyBundle" Before="InstallFinalize"><![CDATA[BUNDLEFILE AND NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
     </InstallExecuteSequence>
 
 
@@ -341,6 +348,13 @@
     <CustomAction Id="CopyBundle"
               Directory="INSTALLFOLDER"
               ExeCommand="[INSTALLFOLDER]keybaserq.exe -wait [SystemFolder]cmd.exe /C copy /Y &quot;[BUNDLEFILE]&quot; [INSTALLERFOLDER]"
+              Execute="commit"
+              Return="ignore"/>
+  </Fragment>
+  <Fragment>
+    <CustomAction Id="RemoveBundle"
+              Directory="INSTALLFOLDER"
+              ExeCommand="[INSTALLFOLDER]keybaserq.exe -wait [SystemFolder]cmd.exe /C del &quot;[REG_BUNDLEFILE]&quot;"
               Execute="immediate"
               Return="ignore"/>
   </Fragment>
@@ -348,7 +362,7 @@
     <CustomAction Id="ParseBundlePath" Script="vbscript">
       <![CDATA[         
         Set fso = CreateObject("Scripting.FileSystemObject") 
-        Session.Property("BUNDLENAME") = fso.GetBaseName(Session.Property("BUNDLEFILE"))     
+        Session.Property("BUNDLENAME") = fso.GetFileName(Session.Property("BUNDLEFILE"))     
       ]]>
     </CustomAction>
   </Fragment>

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -256,7 +256,8 @@
                   Permanent="no">
         <MsiProperty Name="DOKANPRODUCT86" Value="$(var.DokanProductCodeX86)" />
         <MsiProperty Name="DOKANPRODUCT64" Value="$(var.DokanProductCodeX64)" />
-	<MsiProperty Name="BUNDLEKEY" Value="[WixBundleProviderKey]" />        
+	      <MsiProperty Name="BUNDLEKEY" Value="[WixBundleProviderKey]" />
+        <MsiProperty Name="BUNDLEFILE" Value="[WixBundleOriginalSource]" />
       </MsiPackage>
 
     </Chain>

--- a/shared/actions/kbfs/index.platform.desktop.js
+++ b/shared/actions/kbfs/index.platform.desktop.js
@@ -175,50 +175,26 @@ function* installFuseSaga(): SagaGenerator<any, any> {
   yield put(finishedAction)
 }
 
-function findKeybaseUninstallString(): Promise<string> {
-  console.log('findKeybaseUninstallString')
+function findKeybaseInstallerString(): Promise<string> {
+  console.log('findKeybaseInstallerString')
   return new Promise((resolve, reject) => {
     const regedit = require('regedit')
     const keybaseRegPath = 'HKCU\\SOFTWARE\\Keybase\\Keybase'
     try {
       regedit.list(keybaseRegPath).on('data', function(entry) {
-        console.log('findKeybaseUninstallString on data')
-        if (entry.data.values && entry.data.values.BUNDLEKEY) {
-          const uninstallRegPath =
-            'HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\' +
-            entry.data.values.BUNDLEKEY.value
-
-          regedit.list(uninstallRegPath).on('data', function(entry) {
-            console.log('findKeybaseUninstallString on data of', uninstallRegPath)
-            if (
-              entry.data.values &&
-              entry.data.values.DisplayName &&
-              entry.data.values.DisplayName.value === 'Keybase' &&
-              entry.data.values.Publisher &&
-              entry.data.values.Publisher.value === 'Keybase, Inc.' &&
-              entry.data.values.ModifyPath &&
-              entry.data.values.BundleCachePath
-            ) {
-              if (fs.existsSync(entry.data.values.BundleCachePath.value)) {
-                var modifyPath = entry.data.values.ModifyPath.value
-                // Remove double quotes - won't work otherwise
-                modifyPath = modifyPath.replace(/"/g, '')
-                // Remove /modify and send it in with the other arguments, below
-                modifyPath = modifyPath.replace(' /modify', '')
-                resolve(modifyPath)
-              } else {
-                reject(new Error(`cached bundle not found:` + uninstallRegPath))
-              }
-            } else {
-              reject(new Error(`Keybase entry not found at` + uninstallRegPath))
-            }
-          })
+        console.log('findKeybaseInstallerString on data')
+        if (entry.data.values && entry.data.values.BUNDLEFILE) {
+          if (fs.existsSync(entry.data.values.BUNDLEFILE)) {
+            resolve(entry.data.values.BUNDLEFILE)
+          } else {
+            reject(new Error(`no BUNDLEFILE at` + entry.data.values.BUNDLEFILE))
+          }
         } else {
-          reject(new Error(`BUNDLEKEY not found at` + keybaseRegPath))
+          reject(new Error(`BUNDLEFILE not found at` + keybaseRegPath))
         }
       })
     } catch (err) {
-      console.log('findKeybaseUninstallString caught', err)
+      console.log('findKeybaseInstallerString caught', err)
     }
   })
 }
@@ -227,7 +203,7 @@ function findKeybaseUninstallString(): Promise<string> {
 // or it won't be visible to the user. The service also does this to support command line
 // operations.
 function installCachedDokan(): Promise<*> {
-  return findKeybaseUninstallString().then(
+  return findKeybaseInstallerString().then(
     modifyCommand =>
       new Promise((resolve, reject) => {
         if (modifyCommand) {

--- a/shared/actions/kbfs/index.platform.desktop.js
+++ b/shared/actions/kbfs/index.platform.desktop.js
@@ -184,10 +184,10 @@ function findKeybaseInstallerString(): Promise<string> {
       regedit.list(keybaseRegPath).on('data', function(entry) {
         console.log('findKeybaseInstallerString on data')
         if (entry.data.values && entry.data.values.BUNDLEFILE) {
-          if (fs.existsSync(entry.data.values.BUNDLEFILE)) {
-            resolve(entry.data.values.BUNDLEFILE)
+          if (fs.existsSync(entry.data.values.BUNDLEFILE.value)) {
+            resolve(entry.data.values.BUNDLEFILE.value)
           } else {
-            reject(new Error(`no BUNDLEFILE at` + entry.data.values.BUNDLEFILE))
+            reject(new Error(`no BUNDLEFILE at` + entry.data.values.BUNDLEFILE.value))
           }
         } else {
           reject(new Error(`BUNDLEFILE not found at` + keybaseRegPath))


### PR DESCRIPTION
Turns out the cache doesn't have everything we need, and we can't add the drivers because the downloaded install has a different name from what was built. This will help those users who download Keybase_setup_386.exe that was renamed from e.g. Keybase_1.0.32-20171003123900+48f9dbe.386.exe.
Longer term it would be better to not rename the installer on its way to the user, but this should work for now.
@keybase/react-hackers 