### PR TITLE
Allow login with email address on previously provisioned device

### DIFF
--- a/go/client/cmd_login.go
+++ b/go/client/cmd_login.go
@@ -25,13 +25,8 @@ func NewCmdLogin(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdLoginRunner(g), "login", c)
 		},
-		Flags: []cli.Flag{
-			cli.BoolFlag{
-				Name:  "provision-by-email",
-				Usage: "Use an email address associated with a keybase account to provision a device",
-			},
-		},
 	}
+
 	// Note we'll only be able to set this via mode via Environment variable
 	// since it's too early to check command-line setting of it.
 	if g.Env.GetRunMode() == libkb.DevelRunMode {
@@ -119,30 +114,13 @@ func (c *CmdLogin) ParseArgv(ctx *cli.Context) error {
 		return errors.New("Invalid arguments.")
 	}
 
-	provisionByEmail := ctx.Bool("provision-by-email")
-
 	if nargs == 1 {
 		c.username = ctx.Args()[0]
-		if provisionByEmail {
-			// if --provision-by-email flag set, then they can
-			// use an email address for provisioning.
-			if !libkb.CheckEmail.F(c.username) {
-				return errors.New("Invalid email format. Please login again via `keybase login --provision-by-email [email]`")
-			}
-		} else {
-			// they must use a username
-			if libkb.CheckEmail.F(c.username) {
-				return errors.New("You must use a username. Please login again via `keybase login [username]`")
-			}
-			if !libkb.CheckUsername.F(c.username) {
-				return errors.New("Invalid username format. Please login again via `keybase login [username]`")
-			}
-		}
-
-		if ctx.Bool("emulate-gui") {
-			c.clientType = keybase1.ClientType_GUI_MAIN
+		if !libkb.CheckEmailOrUsername.F(c.username) {
+			return errors.New("Invalid username or email address format. Please login again via `keybase login [username or email]`")
 		}
 	}
+
 	return nil
 }
 

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -241,6 +241,10 @@ func (fu *FakeUser) NewSecretUI() *libkb.TestSecretUI {
 	return &libkb.TestSecretUI{Passphrase: fu.Passphrase}
 }
 
+func (fu *FakeUser) NewCountSecretUI() *libkb.TestCountSecretUI {
+	return &libkb.TestCountSecretUI{Passphrase: fu.Passphrase}
+}
+
 func AssertProvisioned(tc libkb.TestContext) error {
 	prov, err := tc.G.LoginState().LoggedInProvisionedCheck()
 	if err != nil {

--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -217,7 +217,7 @@ func (e *Login) loginProvisionedDevice(ctx *Context, username string) (bool, err
 		return false, err
 	}
 
-	e.G().Log.Debug("loginProvisionedDevice error: %s (can continue to provision this device)", err)
+	e.G().Log.Debug("loginProvisionedDevice error: %s (not fatal, can continue to provision this device)", err)
 
 	return false, nil
 }

--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -217,7 +217,7 @@ func (e *Login) loginProvisionedDevice(ctx *Context, username string) (bool, err
 		return false, err
 	}
 
-	e.G().Log.Debug("loginProvisionedDevice error: %s (continuing with device provisioning...)", err)
+	e.G().Log.Debug("loginProvisionedDevice error: %s (can continue to provision this device)", err)
 
 	return false, nil
 }

--- a/go/libkb/checkers.go
+++ b/go/libkb/checkers.go
@@ -33,7 +33,7 @@ var CheckEmailOrUsername = Checker{
 	F: func(s string) bool {
 		return CheckEmail.F(s) || CheckUsername.F(s)
 	},
-	Hint: "valid usernames are 2-12 letters long",
+	Hint: "valid usernames are 2-16 letters long",
 }
 
 var CheckPassphraseSimple = Checker{

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -802,9 +802,9 @@ func (s *LoginState) passphraseLogin(lctx LoginContext, username, passphrase str
 	//
 	// Can get here without a device ID during device provisioning as this is used to establish a login
 	// session before the device keys are generated.
-	if storeSecret && !s.G().Env.GetDeviceIDForUsername(NewNormalizedUsername(username)).IsNil() {
+	if storeSecret && !s.G().Env.GetDeviceIDForUsername(NewNormalizedUsername(res.username)).IsNil() {
 
-		err = s.doStoreSecret(lctx, username, res)
+		err = s.doStoreSecret(lctx, res)
 		if err != nil {
 			s.G().Log.Debug("| LoginState#passphraseLogin: emergency logout")
 			tmpErr := lctx.Logout()
@@ -813,6 +813,10 @@ func (s *LoginState) passphraseLogin(lctx LoginContext, username, passphrase str
 			}
 			return err
 		}
+	} else if !storeSecret {
+		s.G().Log.Debug("| LoginState#passphraseLogin: not storing secret because storeSecret false")
+	} else if s.G().Env.GetDeviceIDForUsername(NewNormalizedUsername(res.username)).IsNil() {
+		s.G().Log.Debug("| LoginState#passphraseLogin: not storing secret because no device id for username %q", res.username)
 	}
 
 	if repairErr := RunBug3964Repairman(s.G(), lctx, lctx.PassphraseStreamCache().PassphraseStream()); repairErr != nil {
@@ -822,7 +826,7 @@ func (s *LoginState) passphraseLogin(lctx LoginContext, username, passphrase str
 	return nil
 }
 
-func (s *LoginState) doStoreSecret(lctx LoginContext, username string, res *loginAPIResult) (err error) {
+func (s *LoginState) doStoreSecret(lctx LoginContext, res *loginAPIResult) (err error) {
 
 	defer s.G().Trace("LoginState#doStoreSecret", func() error { return err })()
 	pps := lctx.PassphraseStreamCache().PassphraseStream()
@@ -836,7 +840,7 @@ func (s *LoginState) doStoreSecret(lctx LoginContext, username string, res *logi
 		return err
 	}
 
-	secretStore := NewSecretStore(s.G(), NewNormalizedUsername(username))
+	secretStore := NewSecretStore(s.G(), NewNormalizedUsername(res.username))
 	if secretStore == nil {
 		s.G().Log.Debug("secret store requested, but unable to create one")
 		return nil

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -384,6 +384,20 @@ func (t *TestCancelSecretUI) GetPassphrase(_ keybase1.GUIEntryArg, _ *keybase1.S
 	return keybase1.GetPassphraseRes{}, InputCanceledError{}
 }
 
+type TestCountSecretUI struct {
+	Passphrase  string
+	StoreSecret bool
+	CallCount   int
+}
+
+func (t *TestCountSecretUI) GetPassphrase(p keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	t.CallCount++
+	return keybase1.GetPassphraseRes{
+		Passphrase:  t.Passphrase,
+		StoreSecret: t.StoreSecret,
+	}, nil
+}
+
 type TestLoginUI struct {
 	Username                 string
 	RevokeBackup             bool


### PR DESCRIPTION
Before, we only allowed an email address to be used to provision a new device.

This patch makes login via email work on provisioned devices.

It uses LoginProvisionedDevice after loading the login user.
Loading the login user with an email address requires a passphrase and API call.
It fixes a bug so that the secret is stored after the email verification so the subsequent LoginProvisionedDevice works fine (without any extra passphrase prompts).

The GUI doesn't restrict email address login now, so it has been causing many users confusion/frustration.  The CLI login command did restrict it via a flag, which I removed in this patch as now login via email just works.

cc @malgorithms @chrisnojima 