### PR TITLE
Add team.public for some server->client message

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -921,6 +921,7 @@ func (o TeamName) DeepCopy() TeamName {
 
 type TeamCLKRMsg struct {
 	TeamID     TeamID               `codec:"teamID" json:"team_id"`
+	Public     bool                 `codec:"public" json:"public"`
 	Generation PerTeamKeyGeneration `codec:"generation" json:"generation"`
 	Score      int                  `codec:"score" json:"score"`
 }
@@ -928,6 +929,7 @@ type TeamCLKRMsg struct {
 func (o TeamCLKRMsg) DeepCopy() TeamCLKRMsg {
 	return TeamCLKRMsg{
 		TeamID:     o.TeamID.DeepCopy(),
+		Public:     o.Public,
 		Generation: o.Generation.DeepCopy(),
 		Score:      o.Score,
 	}
@@ -935,6 +937,7 @@ func (o TeamCLKRMsg) DeepCopy() TeamCLKRMsg {
 
 type TeamChangeRow struct {
 	Id                TeamID `codec:"id" json:"id"`
+	Public            bool   `codec:"public" json:"public"`
 	Name              string `codec:"name" json:"name"`
 	KeyRotated        bool   `codec:"keyRotated" json:"key_rotated"`
 	MembershipChanged bool   `codec:"membershipChanged" json:"membership_changed"`
@@ -944,6 +947,7 @@ type TeamChangeRow struct {
 func (o TeamChangeRow) DeepCopy() TeamChangeRow {
 	return TeamChangeRow{
 		Id:                o.Id.DeepCopy(),
+		Public:            o.Public,
 		Name:              o.Name,
 		KeyRotated:        o.KeyRotated,
 		MembershipChanged: o.MembershipChanged,
@@ -952,12 +956,14 @@ func (o TeamChangeRow) DeepCopy() TeamChangeRow {
 }
 
 type TeamExitRow struct {
-	Id TeamID `codec:"id" json:"id"`
+	Id     TeamID `codec:"id" json:"id"`
+	Public bool   `codec:"public" json:"public"`
 }
 
 func (o TeamExitRow) DeepCopy() TeamExitRow {
 	return TeamExitRow{
-		Id: o.Id.DeepCopy(),
+		Id:     o.Id.DeepCopy(),
+		Public: o.Public,
 	}
 }
 
@@ -979,6 +985,7 @@ func (o TeamInvitee) DeepCopy() TeamInvitee {
 
 type TeamSBSMsg struct {
 	TeamID   TeamID        `codec:"teamID" json:"team_id"`
+	Public   bool          `codec:"public" json:"public"`
 	Score    int           `codec:"score" json:"score"`
 	Invitees []TeamInvitee `codec:"invitees" json:"invitees"`
 }
@@ -986,6 +993,7 @@ type TeamSBSMsg struct {
 func (o TeamSBSMsg) DeepCopy() TeamSBSMsg {
 	return TeamSBSMsg{
 		TeamID: o.TeamID.DeepCopy(),
+		Public: o.Public,
 		Score:  o.Score,
 		Invitees: (func(x []TeamInvitee) []TeamInvitee {
 			if x == nil {
@@ -1015,12 +1023,14 @@ func (o TeamAccessRequest) DeepCopy() TeamAccessRequest {
 
 type TeamOpenReqMsg struct {
 	TeamID TeamID              `codec:"teamID" json:"team_id"`
+	Public bool                `codec:"public" json:"public"`
 	Tars   []TeamAccessRequest `codec:"tars" json:"tars"`
 }
 
 func (o TeamOpenReqMsg) DeepCopy() TeamOpenReqMsg {
 	return TeamOpenReqMsg{
 		TeamID: o.TeamID.DeepCopy(),
+		Public: o.Public,
 		Tars: (func(x []TeamAccessRequest) []TeamAccessRequest {
 			if x == nil {
 				return nil

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -277,12 +277,14 @@ protocol teams {
   record TeamCLKRMsg {
     @jsonkey("team_id")
     TeamID teamID;
+    boolean public; // whether the team is public
     PerTeamKeyGeneration generation;
     int score;
   }
 
   record TeamChangeRow {
     TeamID id;
+    boolean public; // whether the team is public
     string name;
     @jsonkey("key_rotated")
     boolean keyRotated;
@@ -294,6 +296,7 @@ protocol teams {
 
   record TeamExitRow {
     TeamID id;
+    boolean public; // whether the team is public
   }
 
   record TeamInvitee {
@@ -310,6 +313,7 @@ protocol teams {
   record TeamSBSMsg {
     @jsonkey("team_id")
     TeamID teamID;
+    boolean public; // whether the team is public
     int score;
     array<TeamInvitee> invitees;
   }
@@ -324,6 +328,7 @@ protocol teams {
   record TeamOpenReqMsg {
     @jsonkey("team_id")
     TeamID teamID;
+    boolean public; // whether the team is public
     array<TeamAccessRequest> tars;
   }
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4779,6 +4779,7 @@ export type TeamApplicationKey = {
 
 export type TeamCLKRMsg = {
   teamID: TeamID,
+  public: boolean,
   generation: PerTeamKeyGeneration,
   score: int,
 }
@@ -4794,6 +4795,7 @@ export type TeamChangeReq = {
 
 export type TeamChangeRow = {
   id: TeamID,
+  public: boolean,
   name: string,
   keyRotated: boolean,
   membershipChanged: boolean,
@@ -4829,6 +4831,7 @@ export type TeamDetails = {
 
 export type TeamExitRow = {
   id: TeamID,
+  public: boolean,
 }
 
 export type TeamID = string
@@ -4925,6 +4928,7 @@ export type TeamNamePart = string
 
 export type TeamOpenReqMsg = {
   teamID: TeamID,
+  public: boolean,
   tars?: ?Array<TeamAccessRequest>,
 }
 
@@ -4954,6 +4958,7 @@ export type TeamRole =
 
 export type TeamSBSMsg = {
   teamID: TeamID,
+  public: boolean,
   score: int,
   invitees?: ?Array<TeamInvitee>,
 }

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -718,6 +718,10 @@
           "jsonkey": "team_id"
         },
         {
+          "type": "boolean",
+          "name": "public"
+        },
+        {
           "type": "PerTeamKeyGeneration",
           "name": "generation"
         },
@@ -735,6 +739,10 @@
         {
           "type": "TeamID",
           "name": "id"
+        },
+        {
+          "type": "boolean",
+          "name": "public"
         },
         {
           "type": "string",
@@ -764,6 +772,10 @@
         {
           "type": "TeamID",
           "name": "id"
+        },
+        {
+          "type": "boolean",
+          "name": "public"
         }
       ]
     },
@@ -799,6 +811,10 @@
           "type": "TeamID",
           "name": "teamID",
           "jsonkey": "team_id"
+        },
+        {
+          "type": "boolean",
+          "name": "public"
         },
         {
           "type": "int",
@@ -837,6 +853,10 @@
           "type": "TeamID",
           "name": "teamID",
           "jsonkey": "team_id"
+        },
+        {
+          "type": "boolean",
+          "name": "public"
         },
         {
           "type": {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4779,6 +4779,7 @@ export type TeamApplicationKey = {
 
 export type TeamCLKRMsg = {
   teamID: TeamID,
+  public: boolean,
   generation: PerTeamKeyGeneration,
   score: int,
 }
@@ -4794,6 +4795,7 @@ export type TeamChangeReq = {
 
 export type TeamChangeRow = {
   id: TeamID,
+  public: boolean,
   name: string,
   keyRotated: boolean,
   membershipChanged: boolean,
@@ -4829,6 +4831,7 @@ export type TeamDetails = {
 
 export type TeamExitRow = {
   id: TeamID,
+  public: boolean,
 }
 
 export type TeamID = string
@@ -4925,6 +4928,7 @@ export type TeamNamePart = string
 
 export type TeamOpenReqMsg = {
   teamID: TeamID,
+  public: boolean,
   tars?: ?Array<TeamAccessRequest>,
 }
 
@@ -4954,6 +4958,7 @@ export type TeamRole =
 
 export type TeamSBSMsg = {
   teamID: TeamID,
+  public: boolean,
   score: int,
   invitees?: ?Array<TeamInvitee>,
 }


### PR DESCRIPTION
When the server tells you something about a team, need to know its id and whether it's public. This gets the gregor items. We'll want more of this sort of thing in RPCs but this is a start.