### PR TITLE
Add TeamAddEmailsBulk to teams protocol

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1298,6 +1298,50 @@ func (o TeamSettings) DeepCopy() TeamSettings {
 	}
 }
 
+type BulkRes struct {
+	Invited        []string `codec:"invited" json:"invited"`
+	AlreadyInvited []string `codec:"alreadyInvited" json:"alreadyInvited"`
+	Malformed      []string `codec:"malformed" json:"malformed"`
+}
+
+func (o BulkRes) DeepCopy() BulkRes {
+	return BulkRes{
+		Invited: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Invited),
+		AlreadyInvited: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.AlreadyInvited),
+		Malformed: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Malformed),
+	}
+}
+
 type ImplicitTeamUserSet struct {
 	KeybaseUsers    []string          `codec:"keybaseUsers" json:"keybaseUsers"`
 	UnresolvedUsers []SocialAssertion `codec:"unresolvedUsers" json:"unresolvedUsers"`
@@ -1747,7 +1791,7 @@ type TeamsInterface interface {
 	TeamTree(context.Context, TeamTreeArg) (TeamTreeResult, error)
 	TeamDelete(context.Context, TeamDeleteArg) error
 	TeamSetSettings(context.Context, TeamSetSettingsArg) error
-	TeamAddEmailsBulk(context.Context, TeamAddEmailsBulkArg) error
+	TeamAddEmailsBulk(context.Context, TeamAddEmailsBulkArg) (BulkRes, error)
 	LookupImplicitTeam(context.Context, LookupImplicitTeamArg) (LookupImplicitTeamRes, error)
 	LookupOrCreateImplicitTeam(context.Context, LookupOrCreateImplicitTeamArg) (LookupImplicitTeamRes, error)
 	TeamReAddMemberAfterReset(context.Context, TeamReAddMemberAfterResetArg) error
@@ -2077,7 +2121,7 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]TeamAddEmailsBulkArg)(nil), args)
 						return
 					}
-					err = i.TeamAddEmailsBulk(ctx, (*typedArgs)[0])
+					ret, err = i.TeamAddEmailsBulk(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -2266,8 +2310,8 @@ func (c TeamsClient) TeamSetSettings(ctx context.Context, __arg TeamSetSettingsA
 	return
 }
 
-func (c TeamsClient) TeamAddEmailsBulk(ctx context.Context, __arg TeamAddEmailsBulkArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddEmailsBulk", []interface{}{__arg}, nil)
+func (c TeamsClient) TeamAddEmailsBulk(ctx context.Context, __arg TeamAddEmailsBulkArg) (res BulkRes, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddEmailsBulk", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1647,6 +1647,22 @@ func (o TeamSetSettingsArg) DeepCopy() TeamSetSettingsArg {
 	}
 }
 
+type TeamAddEmailsBulkArg struct {
+	SessionID int      `codec:"sessionID" json:"sessionID"`
+	Name      string   `codec:"name" json:"name"`
+	Emails    string   `codec:"emails" json:"emails"`
+	Role      TeamRole `codec:"role" json:"role"`
+}
+
+func (o TeamAddEmailsBulkArg) DeepCopy() TeamAddEmailsBulkArg {
+	return TeamAddEmailsBulkArg{
+		SessionID: o.SessionID,
+		Name:      o.Name,
+		Emails:    o.Emails,
+		Role:      o.Role.DeepCopy(),
+	}
+}
+
 type LookupImplicitTeamArg struct {
 	Name   string `codec:"name" json:"name"`
 	Public bool   `codec:"public" json:"public"`
@@ -1731,6 +1747,7 @@ type TeamsInterface interface {
 	TeamTree(context.Context, TeamTreeArg) (TeamTreeResult, error)
 	TeamDelete(context.Context, TeamDeleteArg) error
 	TeamSetSettings(context.Context, TeamSetSettingsArg) error
+	TeamAddEmailsBulk(context.Context, TeamAddEmailsBulkArg) error
 	LookupImplicitTeam(context.Context, LookupImplicitTeamArg) (LookupImplicitTeamRes, error)
 	LookupOrCreateImplicitTeam(context.Context, LookupOrCreateImplicitTeamArg) (LookupImplicitTeamRes, error)
 	TeamReAddMemberAfterReset(context.Context, TeamReAddMemberAfterResetArg) error
@@ -2049,6 +2066,22 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"teamAddEmailsBulk": {
+				MakeArg: func() interface{} {
+					ret := make([]TeamAddEmailsBulkArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]TeamAddEmailsBulkArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]TeamAddEmailsBulkArg)(nil), args)
+						return
+					}
+					err = i.TeamAddEmailsBulk(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"lookupImplicitTeam": {
 				MakeArg: func() interface{} {
 					ret := make([]LookupImplicitTeamArg, 1)
@@ -2230,6 +2263,11 @@ func (c TeamsClient) TeamDelete(ctx context.Context, __arg TeamDeleteArg) (err e
 
 func (c TeamsClient) TeamSetSettings(ctx context.Context, __arg TeamSetSettingsArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamSetSettings", []interface{}{__arg}, nil)
+	return
+}
+
+func (c TeamsClient) TeamAddEmailsBulk(ctx context.Context, __arg TeamAddEmailsBulkArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddEmailsBulk", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -337,7 +337,7 @@ func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybas
 	return teams.ReAddMemberAfterReset(ctx, h.G().ExternalG(), arg.Id, arg.Username)
 }
 
-func (h *TeamsHandler) TeamAddEmailsBulk(ctx context.Context, arg keybase1.TeamAddEmailsBulkArg) (err error) {
+func (h *TeamsHandler) TeamAddEmailsBulk(ctx context.Context, arg keybase1.TeamAddEmailsBulkArg) (res keybase1.BulkRes, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamAddEmailsBulk(%s)", arg.Name), func() error { return err })()
 
 	return teams.AddEmailsBulk(ctx, h.G().ExternalG(), arg.Name, arg.Emails, arg.Role)

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -35,33 +35,17 @@ func NewTeamsHandler(xp rpc.Transporter, id libkb.ConnectionID, g *globals.Conte
 	}
 }
 
-func (h *TeamsHandler) assertLoggedIn(ctx context.Context) error {
-	loggedIn := h.G().ExternalG().ActiveDevice.Valid()
-	if !loggedIn {
-		return libkb.LoginRequiredError{}
-	}
-	return nil
-}
-
 func (h *TeamsHandler) TeamCreate(ctx context.Context, arg keybase1.TeamCreateArg) (res keybase1.TeamCreateResult, err error) {
 	arg2 := keybase1.TeamCreateWithSettingsArg{
 		SessionID:            arg.SessionID,
 		Name:                 arg.Name,
 		SendChatNotification: arg.SendChatNotification,
 	}
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return res, err
-	}
 	return h.TeamCreateWithSettings(ctx, arg2)
 }
 
 func (h *TeamsHandler) TeamCreateWithSettings(ctx context.Context, arg keybase1.TeamCreateWithSettingsArg) (res keybase1.TeamCreateResult, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamCreate(%s)", arg.Name), func() error { return err })()
-
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return res, err
-	}
-
 	teamName, err := keybase1.TeamNameFromString(arg.Name)
 	if err != nil {
 		return res, err
@@ -111,9 +95,6 @@ func (h *TeamsHandler) TeamListSubteamsRecursive(ctx context.Context, arg keybas
 }
 
 func (h *TeamsHandler) TeamChangeMembership(ctx context.Context, arg keybase1.TeamChangeMembershipArg) error {
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	return teams.ChangeRoles(ctx, h.G().ExternalG(), arg.Name, arg.Req)
 }
 
@@ -174,11 +155,6 @@ func (h *TeamsHandler) sendTeamChatWelcomeMessage(ctx context.Context, team, use
 func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMemberArg) (res keybase1.TeamAddMemberResult, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamAddMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
-
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return res, err
-	}
-
 	if arg.Email != "" {
 		if err := teams.InviteEmailMember(ctx, h.G().ExternalG(), arg.Name, arg.Email, arg.Role); err != nil {
 			return keybase1.TeamAddMemberResult{}, err
@@ -205,9 +181,6 @@ func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRe
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRemoveMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
 
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	if len(arg.Email) > 0 {
 		h.G().Log.CDebugf(ctx, "TeamRemoveMember: received email address, using CancelEmailInvite for %q in team %q", arg.Email, arg.Name)
 		return teams.CancelEmailInvite(ctx, h.G().ExternalG(), arg.Name, arg.Email)
@@ -219,65 +192,41 @@ func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRe
 func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEditMemberArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamEditMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	return teams.EditMember(ctx, h.G().ExternalG(), arg.Name, arg.Username, arg.Role)
 }
 
 func (h *TeamsHandler) TeamLeave(ctx context.Context, arg keybase1.TeamLeaveArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamLeave(%s)", arg.Name), func() error { return err })()
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	return teams.Leave(ctx, h.G().ExternalG(), arg.Name, arg.Permanent)
 }
 
 func (h *TeamsHandler) TeamRename(ctx context.Context, arg keybase1.TeamRenameArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRename(%s)", arg.PrevName), func() error { return err })()
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	return teams.RenameSubteam(ctx, h.G().ExternalG(), arg.PrevName, arg.NewName)
 }
 
 func (h *TeamsHandler) TeamAcceptInvite(ctx context.Context, arg keybase1.TeamAcceptInviteArg) (err error) {
 	defer h.G().CTraceTimed(ctx, "TeamAcceptInvite", func() error { return err })()
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	return teams.AcceptInvite(ctx, h.G().ExternalG(), arg.Token)
 }
 
 func (h *TeamsHandler) TeamRequestAccess(ctx context.Context, arg keybase1.TeamRequestAccessArg) (err error) {
 	h.G().CTraceTimed(ctx, "TeamRequestAccess", func() error { return err })()
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	return teams.RequestAccess(ctx, h.G().ExternalG(), arg.Name)
 }
 
 func (h *TeamsHandler) TeamAcceptInviteOrRequestAccess(ctx context.Context, arg keybase1.TeamAcceptInviteOrRequestAccessArg) (err error) {
 	defer h.G().CTraceTimed(ctx, "TeamAcceptInviteOrRequestAccess", func() error { return err })()
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	return teams.TeamAcceptInviteOrRequestAccess(ctx, h.G().ExternalG(), arg.TokenOrName)
 }
 
 func (h *TeamsHandler) TeamListRequests(ctx context.Context, sessionID int) (res []keybase1.TeamJoinRequest, err error) {
 	defer h.G().CTraceTimed(ctx, "TeamListRequests", func() error { return err })()
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return nil, err
-	}
 	return teams.ListRequests(ctx, h.G().ExternalG())
 }
 
 func (h *TeamsHandler) TeamIgnoreRequest(ctx context.Context, arg keybase1.TeamIgnoreRequestArg) (err error) {
 	defer h.G().CTraceTimed(ctx, "TeamIgnoreRequest", func() error { return err })()
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	return teams.IgnoreRequest(ctx, h.G().ExternalG(), arg.Name, arg.Username)
 }
 
@@ -288,17 +237,11 @@ func (h *TeamsHandler) TeamTree(ctx context.Context, arg keybase1.TeamTreeArg) (
 
 func (h *TeamsHandler) TeamDelete(ctx context.Context, arg keybase1.TeamDeleteArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamDelete(%s)", arg.Name), func() error { return err })()
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	ui := h.getTeamsUI(arg.SessionID)
 	return teams.Delete(ctx, h.G().ExternalG(), ui, arg.Name)
 }
 
 func (h *TeamsHandler) TeamSetSettings(ctx context.Context, arg keybase1.TeamSetSettingsArg) (err error) {
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	return teams.ChangeTeamSettings(ctx, h.G().ExternalG(), arg.Name, arg.Settings)
 }
 
@@ -322,24 +265,17 @@ func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.Look
 func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keybase1.LookupOrCreateImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%s)", arg.Name),
 		func() error { return err })()
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return res, err
-	}
 	res.TeamID, res.Name, res.DisplayName, err = teams.LookupOrCreateImplicitTeam(ctx, h.G().ExternalG(),
 		arg.Name, arg.Public)
 	return res, err
 }
 
 func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybase1.TeamReAddMemberAfterResetArg) error {
-	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
 	return teams.ReAddMemberAfterReset(ctx, h.G().ExternalG(), arg.Id, arg.Username)
 }
 
 func (h *TeamsHandler) TeamAddEmailsBulk(ctx context.Context, arg keybase1.TeamAddEmailsBulkArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamAddEmailsBulk(%s)", arg.Name), func() error { return err })()
 
-	// return teams.Delete(ctx, h.G().ExternalG(), arg.Name)
-	return nil
+	return teams.AddEmailsBulk(ctx, h.G().ExternalG(), arg.Name, arg.Emails, arg.Role)
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -35,17 +35,33 @@ func NewTeamsHandler(xp rpc.Transporter, id libkb.ConnectionID, g *globals.Conte
 	}
 }
 
+func (h *TeamsHandler) assertLoggedIn(ctx context.Context) error {
+	loggedIn := h.G().ExternalG().ActiveDevice.Valid()
+	if !loggedIn {
+		return libkb.LoginRequiredError{}
+	}
+	return nil
+}
+
 func (h *TeamsHandler) TeamCreate(ctx context.Context, arg keybase1.TeamCreateArg) (res keybase1.TeamCreateResult, err error) {
 	arg2 := keybase1.TeamCreateWithSettingsArg{
 		SessionID:            arg.SessionID,
 		Name:                 arg.Name,
 		SendChatNotification: arg.SendChatNotification,
 	}
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return res, err
+	}
 	return h.TeamCreateWithSettings(ctx, arg2)
 }
 
 func (h *TeamsHandler) TeamCreateWithSettings(ctx context.Context, arg keybase1.TeamCreateWithSettingsArg) (res keybase1.TeamCreateResult, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamCreate(%s)", arg.Name), func() error { return err })()
+
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return res, err
+	}
+
 	teamName, err := keybase1.TeamNameFromString(arg.Name)
 	if err != nil {
 		return res, err
@@ -95,6 +111,9 @@ func (h *TeamsHandler) TeamListSubteamsRecursive(ctx context.Context, arg keybas
 }
 
 func (h *TeamsHandler) TeamChangeMembership(ctx context.Context, arg keybase1.TeamChangeMembershipArg) error {
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	return teams.ChangeRoles(ctx, h.G().ExternalG(), arg.Name, arg.Req)
 }
 
@@ -155,6 +174,11 @@ func (h *TeamsHandler) sendTeamChatWelcomeMessage(ctx context.Context, team, use
 func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMemberArg) (res keybase1.TeamAddMemberResult, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamAddMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
+
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return res, err
+	}
+
 	if arg.Email != "" {
 		if err := teams.InviteEmailMember(ctx, h.G().ExternalG(), arg.Name, arg.Email, arg.Role); err != nil {
 			return keybase1.TeamAddMemberResult{}, err
@@ -181,6 +205,9 @@ func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRe
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRemoveMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
 
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	if len(arg.Email) > 0 {
 		h.G().Log.CDebugf(ctx, "TeamRemoveMember: received email address, using CancelEmailInvite for %q in team %q", arg.Email, arg.Name)
 		return teams.CancelEmailInvite(ctx, h.G().ExternalG(), arg.Name, arg.Email)
@@ -192,41 +219,65 @@ func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRe
 func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEditMemberArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamEditMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	return teams.EditMember(ctx, h.G().ExternalG(), arg.Name, arg.Username, arg.Role)
 }
 
 func (h *TeamsHandler) TeamLeave(ctx context.Context, arg keybase1.TeamLeaveArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamLeave(%s)", arg.Name), func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	return teams.Leave(ctx, h.G().ExternalG(), arg.Name, arg.Permanent)
 }
 
 func (h *TeamsHandler) TeamRename(ctx context.Context, arg keybase1.TeamRenameArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRename(%s)", arg.PrevName), func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	return teams.RenameSubteam(ctx, h.G().ExternalG(), arg.PrevName, arg.NewName)
 }
 
 func (h *TeamsHandler) TeamAcceptInvite(ctx context.Context, arg keybase1.TeamAcceptInviteArg) (err error) {
 	defer h.G().CTraceTimed(ctx, "TeamAcceptInvite", func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	return teams.AcceptInvite(ctx, h.G().ExternalG(), arg.Token)
 }
 
 func (h *TeamsHandler) TeamRequestAccess(ctx context.Context, arg keybase1.TeamRequestAccessArg) (err error) {
 	h.G().CTraceTimed(ctx, "TeamRequestAccess", func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	return teams.RequestAccess(ctx, h.G().ExternalG(), arg.Name)
 }
 
 func (h *TeamsHandler) TeamAcceptInviteOrRequestAccess(ctx context.Context, arg keybase1.TeamAcceptInviteOrRequestAccessArg) (err error) {
 	defer h.G().CTraceTimed(ctx, "TeamAcceptInviteOrRequestAccess", func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	return teams.TeamAcceptInviteOrRequestAccess(ctx, h.G().ExternalG(), arg.TokenOrName)
 }
 
 func (h *TeamsHandler) TeamListRequests(ctx context.Context, sessionID int) (res []keybase1.TeamJoinRequest, err error) {
 	defer h.G().CTraceTimed(ctx, "TeamListRequests", func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return nil, err
+	}
 	return teams.ListRequests(ctx, h.G().ExternalG())
 }
 
 func (h *TeamsHandler) TeamIgnoreRequest(ctx context.Context, arg keybase1.TeamIgnoreRequestArg) (err error) {
 	defer h.G().CTraceTimed(ctx, "TeamIgnoreRequest", func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	return teams.IgnoreRequest(ctx, h.G().ExternalG(), arg.Name, arg.Username)
 }
 
@@ -237,11 +288,17 @@ func (h *TeamsHandler) TeamTree(ctx context.Context, arg keybase1.TeamTreeArg) (
 
 func (h *TeamsHandler) TeamDelete(ctx context.Context, arg keybase1.TeamDeleteArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamDelete(%s)", arg.Name), func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	ui := h.getTeamsUI(arg.SessionID)
 	return teams.Delete(ctx, h.G().ExternalG(), ui, arg.Name)
 }
 
 func (h *TeamsHandler) TeamSetSettings(ctx context.Context, arg keybase1.TeamSetSettingsArg) (err error) {
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	return teams.ChangeTeamSettings(ctx, h.G().ExternalG(), arg.Name, arg.Settings)
 }
 
@@ -265,12 +322,18 @@ func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.Look
 func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keybase1.LookupOrCreateImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%s)", arg.Name),
 		func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return res, err
+	}
 	res.TeamID, res.Name, res.DisplayName, err = teams.LookupOrCreateImplicitTeam(ctx, h.G().ExternalG(),
 		arg.Name, arg.Public)
 	return res, err
 }
 
 func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybase1.TeamReAddMemberAfterResetArg) error {
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 	return teams.ReAddMemberAfterReset(ctx, h.G().ExternalG(), arg.Id, arg.Username)
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -336,3 +336,10 @@ func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybas
 	}
 	return teams.ReAddMemberAfterReset(ctx, h.G().ExternalG(), arg.Id, arg.Username)
 }
+
+func (h *TeamsHandler) TeamAddEmailsBulk(ctx context.Context, arg keybase1.TeamAddEmailsBulkArg) (err error) {
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamAddEmailsBulk(%s)", arg.Name), func() error { return err })()
+
+	// return teams.Delete(ctx, h.G().ExternalG(), arg.Name)
+	return nil
+}

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -477,11 +477,22 @@ func TestMemberAddEmailBulk(t *testing.T) {
 
 	blob := "u1@keybase.io u2@keybase.io\nu3@keybase.io,u4@keybase.io\tu5@keybase.io,u6@keybase.io, u7@keybase.io\n\n\n"
 
-	if err := AddEmailsBulk(context.TODO(), tc.G, name, blob, keybase1.TeamRole_WRITER); err != nil {
+	res, err := AddEmailsBulk(context.TODO(), tc.G, name, blob, keybase1.TeamRole_WRITER)
+	if err != nil {
 		t.Fatal(err)
 	}
-
 	emails := []string{"u1@keybase.io", "u2@keybase.io", "u3@keybase.io", "u4@keybase.io", "u5@keybase.io", "u6@keybase.io", "u7@keybase.io"}
+
+	if len(res.Invited) != len(emails) {
+		t.Errorf("num invited: %d, expected %d", len(res.Invited), len(emails))
+	}
+	if len(res.AlreadyInvited) != 0 {
+		t.Errorf("num already invited: %d, expected 0", len(res.AlreadyInvited))
+	}
+	if len(res.Malformed) != 0 {
+		t.Errorf("num malformed: %d, expected 0", len(res.Malformed))
+	}
+
 	for _, e := range emails {
 		assertInvite(tc, name, e, "email", keybase1.TeamRole_WRITER)
 	}

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -471,6 +471,22 @@ func TestMemberAddEmail(t *testing.T) {
 	}
 }
 
+func TestMemberAddEmailBulk(t *testing.T) {
+	tc, _, name := memberSetup(t)
+	defer tc.Cleanup()
+
+	blob := "u1@keybase.io u2@keybase.io\nu3@keybase.io,u4@keybase.io\tu5@keybase.io,u6@keybase.io, u7@keybase.io\n\n\n"
+
+	if err := AddEmailsBulk(context.TODO(), tc.G, name, blob, keybase1.TeamRole_WRITER); err != nil {
+		t.Fatal(err)
+	}
+
+	emails := []string{"u1@keybase.io", "u2@keybase.io", "u3@keybase.io", "u4@keybase.io", "u5@keybase.io", "u6@keybase.io", "u7@keybase.io"}
+	for _, e := range emails {
+		assertInvite(tc, name, e, "email", keybase1.TeamRole_WRITER)
+	}
+}
+
 func TestMemberListInviteUsername(t *testing.T) {
 	tc, _, name := memberSetup(t)
 	defer tc.Cleanup()
@@ -624,6 +640,7 @@ func assertRole(tc libkb.TestContext, name, username string, expected keybase1.T
 }
 
 func assertInvite(tc libkb.TestContext, name, username, typ string, role keybase1.TeamRole) {
+	tc.T.Logf("looking for invite for %s/%s w/ role %s in team %s", username, typ, role, name)
 	iname := keybase1.TeamInviteName(username)
 	itype, err := keybase1.TeamInviteTypeFromString(typ, true)
 	if err != nil {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -314,7 +314,7 @@ func AddEmailsBulk(ctx context.Context, g *libkb.GlobalContext, teamname, emails
 	g.Log.CDebugf(ctx, "team %s: bulk email invite count: %d", teamname, len(emailList))
 
 	var invites []SCTeamInvite
-	for _, e := range splitBulk(emails) {
+	for _, e := range emailList {
 		name := keybase1.TeamInviteName(e)
 		existing, err := t.HasActiveInvite(name, "email")
 		if err != nil {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -315,6 +315,10 @@ func AddEmailsBulk(ctx context.Context, g *libkb.GlobalContext, teamname, emails
 
 	var invites []SCTeamInvite
 	for _, e := range emailList {
+		if !libkb.CheckEmail.F(e) {
+			g.Log.CDebugf(ctx, "team %s: skipping malformed email %q", teamname, e)
+			continue
+		}
 		name := keybase1.TeamInviteName(e)
 		existing, err := t.HasActiveInvite(name, "email")
 		if err != nil {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -469,7 +469,16 @@ protocol teams {
   void teamDelete(int sessionID, string name);
   void teamSetSettings(int sessionID, string name, TeamSettings settings);
 
-  void teamAddEmailsBulk(int sessionID, string name, string emails, TeamRole role);
+  record BulkRes {
+    array<string> invited;
+    array<string> alreadyInvited;
+    array<string> malformed;
+  }
+
+  // emails is a list of email addresses separated by whitespace or commas.
+  // returns a list of emails that were not invited, most likely because of
+  // malformed email addresses.
+  BulkRes teamAddEmailsBulk(int sessionID, string name, string emails, TeamRole role);
 
   record ImplicitTeamUserSet {
     array<string> keybaseUsers;

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -469,6 +469,8 @@ protocol teams {
   void teamDelete(int sessionID, string name);
   void teamSetSettings(int sessionID, string name, TeamSettings settings);
 
+  void teamAddEmailsBulk(int sessionID, string name, string emails, TeamRole role);
+
   record ImplicitTeamUserSet {
     array<string> keybaseUsers;
     array<SocialAssertion> unresolvedUsers;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2394,6 +2394,14 @@ export function teamsTeamAcceptInviteRpcPromise (request: (requestCommon & reque
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamAcceptInvite', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamAddEmailsBulkRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamAddEmailsBulkRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamAddEmailsBulk', request)
+}
+
+export function teamsTeamAddEmailsBulkRpcPromise (request: (requestCommon & requestErrorCallback & {param: teamsTeamAddEmailsBulkRpcParam})): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamAddEmailsBulk', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamAddMemberRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamAddMemberResult) => void} & {param: teamsTeamAddMemberRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamAddMember', request)
 }
@@ -6196,6 +6204,12 @@ export type teamsTeamAcceptInviteOrRequestAccessRpcParam = Exact<{
 
 export type teamsTeamAcceptInviteRpcParam = Exact<{
   token: string
+}>
+
+export type teamsTeamAddEmailsBulkRpcParam = Exact<{
+  name: string,
+  emails: string,
+  role: TeamRole
 }>
 
 export type teamsTeamAddMemberRpcParam = Exact<{

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2394,11 +2394,11 @@ export function teamsTeamAcceptInviteRpcPromise (request: (requestCommon & reque
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamAcceptInvite', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function teamsTeamAddEmailsBulkRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamAddEmailsBulkRpcParam}): EngineChannel {
+export function teamsTeamAddEmailsBulkRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamAddEmailsBulkResult) => void} & {param: teamsTeamAddEmailsBulkRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamAddEmailsBulk', request)
 }
 
-export function teamsTeamAddEmailsBulkRpcPromise (request: (requestCommon & requestErrorCallback & {param: teamsTeamAddEmailsBulkRpcParam})): Promise<void> {
+export function teamsTeamAddEmailsBulkRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamAddEmailsBulkResult) => void} & {param: teamsTeamAddEmailsBulkRpcParam})): Promise<teamsTeamAddEmailsBulkResult> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamAddEmailsBulk', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
@@ -2922,6 +2922,12 @@ export type BootstrapStatus = {
 export type BoxNonce = any
 
 export type BoxPublicKey = any
+
+export type BulkRes = {
+  invited?: ?Array<string>,
+  alreadyInvited?: ?Array<string>,
+  malformed?: ?Array<string>,
+}
 
 export type Bytes32 = any
 
@@ -6564,6 +6570,7 @@ type teamsGetTeamRootIDResult = TeamID
 type teamsLoadTeamPlusApplicationKeysResult = TeamPlusApplicationKeys
 type teamsLookupImplicitTeamResult = LookupImplicitTeamRes
 type teamsLookupOrCreateImplicitTeamResult = LookupImplicitTeamRes
+type teamsTeamAddEmailsBulkResult = BulkRes
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamCreateResult = TeamCreateResult
 type teamsTeamCreateWithSettingsResult = TeamCreateResult

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1552,6 +1552,27 @@
       ],
       "response": null
     },
+    "teamAddEmailsBulk": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "emails",
+          "type": "string"
+        },
+        {
+          "name": "role",
+          "type": "TeamRole"
+        }
+      ],
+      "response": null
+    },
     "lookupImplicitTeam": {
       "request": [
         {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1141,6 +1141,33 @@
     },
     {
       "type": "record",
+      "name": "BulkRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "invited"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "alreadyInvited"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "malformed"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "ImplicitTeamUserSet",
       "fields": [
         {
@@ -1571,7 +1598,7 @@
           "type": "TeamRole"
         }
       ],
-      "response": null
+      "response": "BulkRes"
     },
     "lookupImplicitTeam": {
       "request": [

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2394,6 +2394,14 @@ export function teamsTeamAcceptInviteRpcPromise (request: (requestCommon & reque
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamAcceptInvite', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamAddEmailsBulkRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamAddEmailsBulkRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamAddEmailsBulk', request)
+}
+
+export function teamsTeamAddEmailsBulkRpcPromise (request: (requestCommon & requestErrorCallback & {param: teamsTeamAddEmailsBulkRpcParam})): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamAddEmailsBulk', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamAddMemberRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamAddMemberResult) => void} & {param: teamsTeamAddMemberRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamAddMember', request)
 }
@@ -6196,6 +6204,12 @@ export type teamsTeamAcceptInviteOrRequestAccessRpcParam = Exact<{
 
 export type teamsTeamAcceptInviteRpcParam = Exact<{
   token: string
+}>
+
+export type teamsTeamAddEmailsBulkRpcParam = Exact<{
+  name: string,
+  emails: string,
+  role: TeamRole
 }>
 
 export type teamsTeamAddMemberRpcParam = Exact<{

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2394,11 +2394,11 @@ export function teamsTeamAcceptInviteRpcPromise (request: (requestCommon & reque
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamAcceptInvite', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function teamsTeamAddEmailsBulkRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamAddEmailsBulkRpcParam}): EngineChannel {
+export function teamsTeamAddEmailsBulkRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamAddEmailsBulkResult) => void} & {param: teamsTeamAddEmailsBulkRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamAddEmailsBulk', request)
 }
 
-export function teamsTeamAddEmailsBulkRpcPromise (request: (requestCommon & requestErrorCallback & {param: teamsTeamAddEmailsBulkRpcParam})): Promise<void> {
+export function teamsTeamAddEmailsBulkRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamAddEmailsBulkResult) => void} & {param: teamsTeamAddEmailsBulkRpcParam})): Promise<teamsTeamAddEmailsBulkResult> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamAddEmailsBulk', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
@@ -2922,6 +2922,12 @@ export type BootstrapStatus = {
 export type BoxNonce = any
 
 export type BoxPublicKey = any
+
+export type BulkRes = {
+  invited?: ?Array<string>,
+  alreadyInvited?: ?Array<string>,
+  malformed?: ?Array<string>,
+}
 
 export type Bytes32 = any
 
@@ -6564,6 +6570,7 @@ type teamsGetTeamRootIDResult = TeamID
 type teamsLoadTeamPlusApplicationKeysResult = TeamPlusApplicationKeys
 type teamsLookupImplicitTeamResult = LookupImplicitTeamRes
 type teamsLookupOrCreateImplicitTeamResult = LookupImplicitTeamRes
+type teamsTeamAddEmailsBulkResult = BulkRes
 type teamsTeamAddMemberResult = TeamAddMemberResult
 type teamsTeamCreateResult = TeamCreateResult
 type teamsTeamCreateWithSettingsResult = TeamCreateResult


### PR DESCRIPTION
This adds a new service endpoint for GUI to invite a bunch of email addresses to a team in one call.  

(It also only creates one link for all the invites)

cc @chrisnojima 