### PR TITLE
handle account resets for imp team chats CORE-5292

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -585,7 +585,7 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 			Uid:    uid,
 			ConvID: convID,
 		},
-	}, nil); err != nil {
+	}, nil, nil); err != nil {
 		debugger.Debug(ctx, "JoinConversation: failed to apply membership update: %s", err.Error())
 	}
 

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -774,7 +774,7 @@ func (g *PushHandler) MembershipUpdate(ctx context.Context, m gregor.OutOfBandMe
 
 		// Write out changes to local storage
 		updateRes, err := g.G().InboxSource.MembershipUpdate(ctx, uid, update.InboxVers, update.Joined,
-			update.Removed)
+			update.Removed, update.Reset)
 		if err != nil {
 			g.Debug(ctx, "MembershipUpdate: failed to update membership on inbox: %s", err.Error())
 			return err

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -127,8 +127,9 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 	}
 }
 
-func (n *chatListener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)    {}
-func (n *chatListener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID) {}
+func (n *chatListener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)     {}
+func (n *chatListener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)  {}
+func (n *chatListener) ChatResetConversation(uid keybase1.UID, convID chat1.ConversationID) {}
 
 func newConvTriple(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, username string) chat1.ConversationIDTriple {
 	nameInfo, err := CtxKeyFinder(ctx, tc.Context()).Find(ctx, username,

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2338,7 +2338,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		select {
 		case act := <-listener0.membersUpdate:
 			require.Equal(t, act.ConvID, ncres.Conv.GetConvID())
-			require.Equal(t, chat1.ConversationExistence_ACTIVE, act.Status)
+			require.Equal(t, chat1.ConversationMemberStatus_ACTIVE, act.Status)
 			require.Equal(t, users[1].Username, act.Member)
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "failed to get members update")

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -366,7 +366,8 @@ func (i *Inbox) applyQuery(ctx context.Context, query *chat1.GetInboxQuery, rcs 
 
 		// Member status check
 		switch conv.ReaderInfo.Status {
-		case chat1.ConversationMemberStatus_ACTIVE, chat1.ConversationMemberStatus_PREVIEW:
+		case chat1.ConversationMemberStatus_ACTIVE, chat1.ConversationMemberStatus_PREVIEW,
+			chat1.ConversationMemberStatus_RESET:
 			// only let these states through
 		default:
 			ok = false

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -1156,7 +1156,22 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers,
 	}
 	for _, oj := range othersJoined {
 		if cp, ok := convMap[oj.ConvID.String()]; ok {
-			cp.Conv.Metadata.AllList = append(cp.Conv.Metadata.AllList, oj.Uid)
+			// Check reset list for this UID, if we find it remove it instead of adding to all list
+			isReset := false
+			var resetIndex int
+			var r gregor1.UID
+			for resetIndex, r = range cp.Conv.Metadata.ResetList {
+				if r.Eq(oj.Uid) {
+					isReset = true
+					break
+				}
+			}
+			if isReset {
+				cp.Conv.Metadata.ResetList = append(cp.Conv.Metadata.ResetList[:resetIndex],
+					cp.Conv.Metadata.ResetList[resetIndex+1:]...)
+			} else {
+				cp.Conv.Metadata.AllList = append(cp.Conv.Metadata.AllList, oj.Uid)
+			}
 			cp.Conv.Metadata.Version = vers.ToConvVers()
 		}
 	}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -91,7 +91,8 @@ type InboxSource interface {
 	TlfFinalize(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
 	MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
-		joined []chat1.ConversationMember, removed []chat1.ConversationMember) (MembershipUpdateRes, error)
+		joined []chat1.ConversationMember, removed []chat1.ConversationMember,
+		resets []chat1.ConversationMember) (MembershipUpdateRes, error)
 	TeamTypeChanged(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
 		teamType chat1.TeamType) (*chat1.ConversationLocal, error)
 

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -29,15 +29,18 @@ type NameInfo struct {
 type MembershipUpdateRes struct {
 	UserJoinedConvs    []chat1.ConversationLocal
 	UserRemovedConvs   []chat1.ConversationID
+	UserResetConvs     []chat1.ConversationID
 	OthersJoinedConvs  []chat1.ConversationMember
 	OthersRemovedConvs []chat1.ConversationMember
+	OthersResetConvs   []chat1.ConversationMember
 }
 
 type RemoteConversationMetadata struct {
-	TopicName   string   `codec:"t"`
-	Snippet     string   `codec:"s"`
-	Headline    string   `codec:"h"`
-	WriterNames []string `codec:"w"`
+	TopicName         string   `codec:"t"`
+	Snippet           string   `codec:"s"`
+	Headline          string   `codec:"h"`
+	WriterNames       []string `codec:"w"`
+	ResetParticipants []string `codec:"r"`
 }
 
 type RemoteConversation struct {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -602,10 +602,11 @@ func PresentRemoteConversation(rc types.RemoteConversation) (res chat1.Unverifie
 	res.Version = rawConv.Metadata.Version
 	if rc.LocalMetadata != nil {
 		res.LocalMetadata = &chat1.UnverifiedInboxUIItemMetadata{
-			ChannelName: rc.LocalMetadata.TopicName,
-			Headline:    rc.LocalMetadata.Headline,
-			Snippet:     rc.LocalMetadata.Snippet,
-			WriterNames: rc.LocalMetadata.WriterNames,
+			ChannelName:       rc.LocalMetadata.TopicName,
+			Headline:          rc.LocalMetadata.Headline,
+			Snippet:           rc.LocalMetadata.Snippet,
+			WriterNames:       rc.LocalMetadata.WriterNames,
+			ResetParticipants: rc.LocalMetadata.ResetParticipants,
 		}
 	}
 	return res
@@ -625,6 +626,7 @@ func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxU
 	res.Channel = GetTopicName(rawConv)
 	res.Headline = GetHeadline(rawConv)
 	res.Participants = rawConv.Info.WriterNames
+	res.ResetParticipants = rawConv.Info.ResetNames
 	res.Status = rawConv.Info.Status
 	res.MembersType = rawConv.GetMembersType()
 	res.Visibility = rawConv.Info.Visibility

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -115,6 +115,7 @@ func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.Conversation
 func (n *nlistener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate)                       {}
 func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)         {}
 func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)      {}
+func (n *nlistener) ChatResetConversation(uid keybase1.UID, convID chat1.ConversationID)     {}
 func (n *nlistener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
 func (n *nlistener) TeamDeleted(teamID keybase1.TeamID)                             {}

--- a/go/engine/puk_upgrade.go
+++ b/go/engine/puk_upgrade.go
@@ -69,6 +69,8 @@ func (e *PerUserKeyUpgrade) inner(ctx *Context) error {
 		return libkb.NoUIDError{}
 	}
 
+	e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyUpgrade upgrading: %d", uid)
+
 	loadArg := libkb.NewLoadUserArg(e.G()).
 		WithNetContext(ctx.GetNetContext()).
 		WithUID(uid).

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -28,10 +28,11 @@ func (o UIPagination) DeepCopy() UIPagination {
 }
 
 type UnverifiedInboxUIItemMetadata struct {
-	ChannelName string   `codec:"channelName" json:"channelName"`
-	Headline    string   `codec:"headline" json:"headline"`
-	Snippet     string   `codec:"snippet" json:"snippet"`
-	WriterNames []string `codec:"writerNames" json:"writerNames"`
+	ChannelName       string   `codec:"channelName" json:"channelName"`
+	Headline          string   `codec:"headline" json:"headline"`
+	Snippet           string   `codec:"snippet" json:"snippet"`
+	WriterNames       []string `codec:"writerNames" json:"writerNames"`
+	ResetParticipants []string `codec:"resetParticipants" json:"resetParticipants"`
 }
 
 func (o UnverifiedInboxUIItemMetadata) DeepCopy() UnverifiedInboxUIItemMetadata {
@@ -50,6 +51,17 @@ func (o UnverifiedInboxUIItemMetadata) DeepCopy() UnverifiedInboxUIItemMetadata 
 			}
 			return ret
 		})(o.WriterNames),
+		ResetParticipants: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ResetParticipants),
 	}
 }
 
@@ -59,6 +71,7 @@ type UnverifiedInboxUIItem struct {
 	Visibility    keybase1.TLFVisibility         `codec:"visibility" json:"visibility"`
 	Status        ConversationStatus             `codec:"status" json:"status"`
 	MembersType   ConversationMembersType        `codec:"membersType" json:"membersType"`
+	MemberStatus  ConversationMemberStatus       `codec:"memberStatus" json:"memberStatus"`
 	TeamType      TeamType                       `codec:"teamType" json:"teamType"`
 	Notifications *ConversationNotificationInfo  `codec:"notifications,omitempty" json:"notifications,omitempty"`
 	Time          gregor1.Time                   `codec:"time" json:"time"`
@@ -68,12 +81,13 @@ type UnverifiedInboxUIItem struct {
 
 func (o UnverifiedInboxUIItem) DeepCopy() UnverifiedInboxUIItem {
 	return UnverifiedInboxUIItem{
-		ConvID:      o.ConvID,
-		Name:        o.Name,
-		Visibility:  o.Visibility.DeepCopy(),
-		Status:      o.Status.DeepCopy(),
-		MembersType: o.MembersType.DeepCopy(),
-		TeamType:    o.TeamType.DeepCopy(),
+		ConvID:       o.ConvID,
+		Name:         o.Name,
+		Visibility:   o.Visibility.DeepCopy(),
+		Status:       o.Status.DeepCopy(),
+		MembersType:  o.MembersType.DeepCopy(),
+		MemberStatus: o.MemberStatus.DeepCopy(),
+		TeamType:     o.TeamType.DeepCopy(),
 		Notifications: (func(x *ConversationNotificationInfo) *ConversationNotificationInfo {
 			if x == nil {
 				return nil
@@ -124,24 +138,26 @@ func (o UnverifiedInboxUIItems) DeepCopy() UnverifiedInboxUIItems {
 }
 
 type InboxUIItem struct {
-	ConvID        string                        `codec:"convID" json:"convID"`
-	IsEmpty       bool                          `codec:"isEmpty" json:"isEmpty"`
-	Name          string                        `codec:"name" json:"name"`
-	Snippet       string                        `codec:"snippet" json:"snippet"`
-	Channel       string                        `codec:"channel" json:"channel"`
-	Headline      string                        `codec:"headline" json:"headline"`
-	Visibility    keybase1.TLFVisibility        `codec:"visibility" json:"visibility"`
-	Participants  []string                      `codec:"participants" json:"participants"`
-	Status        ConversationStatus            `codec:"status" json:"status"`
-	MembersType   ConversationMembersType       `codec:"membersType" json:"membersType"`
-	TeamType      TeamType                      `codec:"teamType" json:"teamType"`
-	Time          gregor1.Time                  `codec:"time" json:"time"`
-	Notifications *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
-	CreatorInfo   *ConversationCreatorInfoLocal `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
-	Version       ConversationVers              `codec:"version" json:"version"`
-	FinalizeInfo  *ConversationFinalizeInfo     `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
-	Supersedes    []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
-	SupersededBy  []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
+	ConvID            string                        `codec:"convID" json:"convID"`
+	IsEmpty           bool                          `codec:"isEmpty" json:"isEmpty"`
+	Name              string                        `codec:"name" json:"name"`
+	Snippet           string                        `codec:"snippet" json:"snippet"`
+	Channel           string                        `codec:"channel" json:"channel"`
+	Headline          string                        `codec:"headline" json:"headline"`
+	Visibility        keybase1.TLFVisibility        `codec:"visibility" json:"visibility"`
+	Participants      []string                      `codec:"participants" json:"participants"`
+	ResetParticipants []string                      `codec:"resetParticipants" json:"resetParticipants"`
+	Status            ConversationStatus            `codec:"status" json:"status"`
+	MembersType       ConversationMembersType       `codec:"membersType" json:"membersType"`
+	MemberStatus      ConversationMemberStatus      `codec:"memberStatus" json:"memberStatus"`
+	TeamType          TeamType                      `codec:"teamType" json:"teamType"`
+	Time              gregor1.Time                  `codec:"time" json:"time"`
+	Notifications     *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
+	CreatorInfo       *ConversationCreatorInfoLocal `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
+	Version           ConversationVers              `codec:"version" json:"version"`
+	FinalizeInfo      *ConversationFinalizeInfo     `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
+	Supersedes        []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
+	SupersededBy      []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
 }
 
 func (o InboxUIItem) DeepCopy() InboxUIItem {
@@ -164,10 +180,22 @@ func (o InboxUIItem) DeepCopy() InboxUIItem {
 			}
 			return ret
 		})(o.Participants),
-		Status:      o.Status.DeepCopy(),
-		MembersType: o.MembersType.DeepCopy(),
-		TeamType:    o.TeamType.DeepCopy(),
-		Time:        o.Time.DeepCopy(),
+		ResetParticipants: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ResetParticipants),
+		Status:       o.Status.DeepCopy(),
+		MembersType:  o.MembersType.DeepCopy(),
+		MemberStatus: o.MemberStatus.DeepCopy(),
+		TeamType:     o.TeamType.DeepCopy(),
+		Time:         o.Time.DeepCopy(),
 		Notifications: (func(x *ConversationNotificationInfo) *ConversationNotificationInfo {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -453,6 +453,7 @@ const (
 	ConversationMemberStatus_REMOVED ConversationMemberStatus = 1
 	ConversationMemberStatus_LEFT    ConversationMemberStatus = 2
 	ConversationMemberStatus_PREVIEW ConversationMemberStatus = 3
+	ConversationMemberStatus_RESET   ConversationMemberStatus = 4
 )
 
 func (o ConversationMemberStatus) DeepCopy() ConversationMemberStatus { return o }
@@ -462,6 +463,7 @@ var ConversationMemberStatusMap = map[string]ConversationMemberStatus{
 	"REMOVED": 1,
 	"LEFT":    2,
 	"PREVIEW": 3,
+	"RESET":   4,
 }
 
 var ConversationMemberStatusRevMap = map[ConversationMemberStatus]string{
@@ -469,6 +471,7 @@ var ConversationMemberStatusRevMap = map[ConversationMemberStatus]string{
 	1: "REMOVED",
 	2: "LEFT",
 	3: "PREVIEW",
+	4: "RESET",
 }
 
 func (e ConversationMemberStatus) String() string {

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -697,6 +697,7 @@ type ConversationMetadata struct {
 	SupersededBy   []ConversationMetadata    `codec:"supersededBy" json:"supersededBy"`
 	ActiveList     []gregor1.UID             `codec:"activeList" json:"activeList"`
 	AllList        []gregor1.UID             `codec:"allList" json:"allList"`
+	ResetList      []gregor1.UID             `codec:"resetList" json:"resetList"`
 }
 
 func (o ConversationMetadata) DeepCopy() ConversationMetadata {
@@ -760,6 +761,17 @@ func (o ConversationMetadata) DeepCopy() ConversationMetadata {
 			}
 			return ret
 		})(o.AllList),
+		ResetList: (func(x []gregor1.UID) []gregor1.UID {
+			if x == nil {
+				return nil
+			}
+			var ret []gregor1.UID
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ResetList),
 	}
 }
 

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -238,6 +238,7 @@ type UpdateConversationMembership struct {
 	InboxVers    InboxVers            `codec:"inboxVers" json:"inboxVers"`
 	Joined       []ConversationMember `codec:"joined" json:"joined"`
 	Removed      []ConversationMember `codec:"removed" json:"removed"`
+	Reset        []ConversationMember `codec:"reset" json:"reset"`
 	UnreadUpdate *UnreadUpdate        `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
@@ -266,6 +267,17 @@ func (o UpdateConversationMembership) DeepCopy() UpdateConversationMembership {
 			}
 			return ret
 		})(o.Removed),
+		Reset: (func(x []ConversationMember) []ConversationMember {
+			if x == nil {
+				return nil
+			}
+			var ret []ConversationMember
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Reset),
 		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2003,26 +2003,29 @@ type ConversationInfoLocal struct {
 	Visibility   keybase1.TLFVisibility    `codec:"visibility" json:"visibility"`
 	Status       ConversationStatus        `codec:"status" json:"status"`
 	MembersType  ConversationMembersType   `codec:"membersType" json:"membersType"`
+	MemberStatus ConversationMemberStatus  `codec:"memberStatus" json:"memberStatus"`
 	TeamType     TeamType                  `codec:"teamType" json:"teamType"`
 	Existence    ConversationExistence     `codec:"existence" json:"existence"`
 	Version      ConversationVers          `codec:"version" json:"version"`
 	WriterNames  []string                  `codec:"writerNames" json:"writerNames"`
 	ReaderNames  []string                  `codec:"readerNames" json:"readerNames"`
 	FinalizeInfo *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
+	ResetNames   []string                  `codec:"resetNames" json:"resetNames"`
 }
 
 func (o ConversationInfoLocal) DeepCopy() ConversationInfoLocal {
 	return ConversationInfoLocal{
-		Id:          o.Id.DeepCopy(),
-		Triple:      o.Triple.DeepCopy(),
-		TlfName:     o.TlfName,
-		TopicName:   o.TopicName,
-		Visibility:  o.Visibility.DeepCopy(),
-		Status:      o.Status.DeepCopy(),
-		MembersType: o.MembersType.DeepCopy(),
-		TeamType:    o.TeamType.DeepCopy(),
-		Existence:   o.Existence.DeepCopy(),
-		Version:     o.Version.DeepCopy(),
+		Id:           o.Id.DeepCopy(),
+		Triple:       o.Triple.DeepCopy(),
+		TlfName:      o.TlfName,
+		TopicName:    o.TopicName,
+		Visibility:   o.Visibility.DeepCopy(),
+		Status:       o.Status.DeepCopy(),
+		MembersType:  o.MembersType.DeepCopy(),
+		MemberStatus: o.MemberStatus.DeepCopy(),
+		TeamType:     o.TeamType.DeepCopy(),
+		Existence:    o.Existence.DeepCopy(),
+		Version:      o.Version.DeepCopy(),
 		WriterNames: (func(x []string) []string {
 			if x == nil {
 				return nil
@@ -2052,6 +2055,17 @@ func (o ConversationInfoLocal) DeepCopy() ConversationInfoLocal {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.FinalizeInfo),
+		ResetNames: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ResetNames),
 	}
 }
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1577,6 +1577,10 @@ func (t TeamMembers) AllUserVersions() []UserVersion {
 	return all
 }
 
+func (t TeamMember) IsReset() bool {
+	return t.EldestSeqno != t.UserEldestSeqno
+}
+
 func (t TeamName) IsNil() bool {
 	return len(t.Parts) == 0
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -166,16 +166,18 @@ func (o PerTeamKeySeedItem) DeepCopy() PerTeamKeySeedItem {
 }
 
 type TeamMember struct {
-	Uid         UID      `codec:"uid" json:"uid"`
-	Role        TeamRole `codec:"role" json:"role"`
-	EldestSeqno Seqno    `codec:"eldestSeqno" json:"eldestSeqno"`
+	Uid             UID      `codec:"uid" json:"uid"`
+	Role            TeamRole `codec:"role" json:"role"`
+	EldestSeqno     Seqno    `codec:"eldestSeqno" json:"eldestSeqno"`
+	UserEldestSeqno Seqno    `codec:"userEldestSeqno" json:"userEldestSeqno"`
 }
 
 func (o TeamMember) DeepCopy() TeamMember {
 	return TeamMember{
-		Uid:         o.Uid.DeepCopy(),
-		Role:        o.Role.DeepCopy(),
-		EldestSeqno: o.EldestSeqno.DeepCopy(),
+		Uid:             o.Uid.DeepCopy(),
+		Role:            o.Role.DeepCopy(),
+		EldestSeqno:     o.EldestSeqno.DeepCopy(),
+		UserEldestSeqno: o.UserEldestSeqno.DeepCopy(),
 	}
 }
 

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -111,11 +111,12 @@ func (n *nlistener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationI
 }
 func (n *nlistener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {
 }
-func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)    {}
-func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID) {}
-func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                    {}
-func (n *nlistener) ChatInboxSynced(uid keybase1.UID, syncRes chat1.ChatSyncResult)     {}
-func (n *nlistener) ChatInboxSyncStarted(uid keybase1.UID)                              {}
+func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.InboxUIItem)     {}
+func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)  {}
+func (n *nlistener) ChatResetConversation(uid keybase1.UID, convID chat1.ConversationID) {}
+func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                     {}
+func (n *nlistener) ChatInboxSynced(uid keybase1.UID, syncRes chat1.ChatSyncResult)      {}
+func (n *nlistener) ChatInboxSyncStarted(uid keybase1.UID)                               {}
 func (n *nlistener) TeamChanged(teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
 }
 func (n *nlistener) TeamDeleted(teamID keybase1.TeamID) {}

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -17,6 +17,7 @@ protocol chatUi {
     string headline;
     string snippet;
     array<string> writerNames;
+    array<string> resetParticipants;
   }
 
   record UnverifiedInboxUIItem {
@@ -25,6 +26,7 @@ protocol chatUi {
     keybase1.TLFVisibility visibility;
     ConversationStatus status;
     ConversationMembersType membersType;
+    ConversationMemberStatus memberStatus;
     TeamType teamType;
     union{ null, ConversationNotificationInfo } notifications;
     gregor1.Time time;
@@ -47,15 +49,17 @@ protocol chatUi {
     string headline;
     keybase1.TLFVisibility visibility;
     array<string> participants;
+    array<string> resetParticipants;
     ConversationStatus status;
     ConversationMembersType membersType;
+    ConversationMemberStatus memberStatus;
     TeamType teamType;
     gregor1.Time time;
     union { null, ConversationNotificationInfo } notifications;
     union { null, ConversationCreatorInfoLocal } creatorInfo;
     ConversationVers version;
 
-    // Finalized convo stuff
+    // Finalized convo stuff (KBFS only)
     union { null, ConversationFinalizeInfo } finalizeInfo;
     array<ConversationMetadata> supersedes;
     array<ConversationMetadata> supersededBy;

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -196,7 +196,7 @@ protocol common {
     ConversationExistence existence;
     ConversationVers version;
 
-    // Finalize info for underlying TLF
+    // Finalize info for underlying TLF (only makes sense for KBFS convos)
     union { null, ConversationFinalizeInfo } finalizeInfo;
 
     array<ConversationMetadata> supersedes; // metadata about the conversations this supersedes from a TLF finalize (if any).
@@ -207,8 +207,8 @@ protocol common {
     // *** Empty for TEAM chats. ***
     array<gregor1.UID> activeList;
 
-    // All of the users in the conversation, regardless of active status.
-    array<gregor1.UID> allList;
+    array<gregor1.UID> allList;   // all of the users in the conversation
+    array<gregor1.UID> resetList; // all of the reset users in the conversation (only for TEAM and IMPTEAM chats)
   }
 
   record ConversationNotificationInfo {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -124,7 +124,8 @@ protocol common {
     ACTIVE_0,  // in the channel
     REMOVED_1, // removed from channel forcibly
     LEFT_2,    // voluntarily left conversation
-    PREVIEW_3  // use is previewing the channel from an @mention
+    PREVIEW_3, // use is previewing the channel from an @mention
+    RESET_4    // status of having an account reset in an impteam
   }
 
   record Pagination {

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -93,6 +93,7 @@ protocol gregor {
         InboxVers inboxVers;
         array<ConversationMember> joined;
         array<ConversationMember> removed;
+        array<ConversationMember> reset;
         union { null, UnreadUpdate } unreadUpdate;
     }
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -347,6 +347,7 @@ protocol local {
     keybase1.TLFVisibility visibility;
     ConversationStatus status;
     ConversationMembersType membersType;
+    ConversationMemberStatus memberStatus;
     TeamType teamType;
     ConversationExistence existence;
     ConversationVers version;
@@ -355,7 +356,10 @@ protocol local {
     array<string> writerNames;
     array<string> readerNames;
 
+    // Only ever set for KBFS conversations
     union { null, ConversationFinalizeInfo } finalizeInfo;
+    // Only ever set for TEAM and IMPTEAM conversations
+    array<string> resetNames;
   }
 
   enum ConversationErrorType {

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -52,7 +52,7 @@ protocol NotifyChat {
   record MembersUpdateInfo {
     ConversationID convID;
     string member;
-    boolean joined;
+    ConversationMemberStatus status;
   }
 
   record TeamTypeInfo {
@@ -141,6 +141,10 @@ protocol NotifyChat {
   @notify("")
   @lint("ignore")
   void ChatLeftConversation(keybase1.UID uid, ConversationID convID);
+
+  @notify("")
+  @lint("ignore")
+  void ChatResetConversation(keybase1.UID uid, ConversationID convID);
 
   @notify("")
   @lint("ignore")

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -61,7 +61,8 @@ protocol teams {
   record TeamMember {
     UID uid;
     TeamRole role;
-    Seqno eldestSeqno;
+    Seqno eldestSeqno;     // eldest seqno of the team member record
+    Seqno userEldestSeqno; // actual eldest seqno of the user
   }
 
   record TeamMembers {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1397,7 +1397,7 @@ export type MarkAsReadRes = {
 export type MembersUpdateInfo = {
   convID: ConversationID,
   member: string,
-  joined: boolean,
+  status: ConversationMemberStatus,
 }
 
 export type MerkleRoot = {
@@ -1654,6 +1654,11 @@ export type NotifyChatChatJoinedConversationRpcParam = Exact<{
 }>
 
 export type NotifyChatChatLeftConversationRpcParam = Exact<{
+  uid: keybase1.UID,
+  convID: ConversationID
+}>
+
+export type NotifyChatChatResetConversationRpcParam = Exact<{
   uid: keybase1.UID,
   convID: ConversationID
 }>
@@ -2718,6 +2723,14 @@ export type incomingCallMapType = Exact<{
     */
   ) => void,
   'keybase.1.NotifyChat.ChatLeftConversation'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convID: ConversationID
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatResetConversation'?: (
     params: Exact<{
       uid: keybase1.UID,
       convID: ConversationID

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -73,6 +73,7 @@ export const CommonConversationMemberStatus = {
   removed: 1,
   left: 2,
   preview: 3,
+  reset: 4,
 }
 
 export const CommonConversationMembersType = {
@@ -1007,6 +1008,7 @@ export type ConversationMemberStatus =
   | 1 // REMOVED_1
   | 2 // LEFT_2
   | 3 // PREVIEW_3
+  | 4 // RESET_4
 
 export type ConversationMembersType =
     0 // KBFS_0

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -977,12 +977,14 @@ export type ConversationInfoLocal = {
   visibility: keybase1.TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  memberStatus: ConversationMemberStatus,
   teamType: TeamType,
   existence: ConversationExistence,
   version: ConversationVers,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
   finalizeInfo?: ?ConversationFinalizeInfo,
+  resetNames?: ?Array<string>,
 }
 
 export type ConversationLocal = {
@@ -1029,6 +1031,7 @@ export type ConversationMetadata = {
   supersededBy?: ?Array<ConversationMetadata>,
   activeList?: ?Array<gregor1.UID>,
   allList?: ?Array<gregor1.UID>,
+  resetList?: ?Array<gregor1.UID>,
 }
 
 export type ConversationNotificationInfo = {
@@ -1316,8 +1319,10 @@ export type InboxUIItem = {
   headline: string,
   visibility: keybase1.TLFVisibility,
   participants?: ?Array<string>,
+  resetParticipants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  memberStatus: ConversationMemberStatus,
   teamType: TeamType,
   time: gregor1.Time,
   notifications?: ?ConversationNotificationInfo,
@@ -2011,6 +2016,7 @@ export type UnverifiedInboxUIItem = {
   visibility: keybase1.TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  memberStatus: ConversationMemberStatus,
   teamType: TeamType,
   notifications?: ?ConversationNotificationInfo,
   time: gregor1.Time,
@@ -2023,6 +2029,7 @@ export type UnverifiedInboxUIItemMetadata = {
   headline: string,
   snippet: string,
   writerNames?: ?Array<string>,
+  resetParticipants?: ?Array<string>,
 }
 
 export type UnverifiedInboxUIItems = {
@@ -2035,6 +2042,7 @@ export type UpdateConversationMembership = {
   inboxVers: InboxVers,
   joined?: ?Array<ConversationMember>,
   removed?: ?Array<ConversationMember>,
+  reset?: ?Array<ConversationMember>,
   unreadUpdate?: ?UnreadUpdate,
 }
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4889,6 +4889,7 @@ export type TeamMember = {
   uid: UID,
   role: TeamRole,
   eldestSeqno: Seqno,
+  userEldestSeqno: Seqno,
 }
 
 export type TeamMemberDetails = {

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -57,6 +57,13 @@
             "items": "string"
           },
           "name": "writerNames"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "resetParticipants"
         }
       ]
     },
@@ -83,6 +90,10 @@
         {
           "type": "ConversationMembersType",
           "name": "membersType"
+        },
+        {
+          "type": "ConversationMemberStatus",
+          "name": "memberStatus"
         },
         {
           "type": "TeamType",
@@ -176,12 +187,23 @@
           "name": "participants"
         },
         {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "resetParticipants"
+        },
+        {
           "type": "ConversationStatus",
           "name": "status"
         },
         {
           "type": "ConversationMembersType",
           "name": "membersType"
+        },
+        {
+          "type": "ConversationMemberStatus",
+          "name": "memberStatus"
         },
         {
           "type": "TeamType",

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -239,7 +239,8 @@
         "ACTIVE_0",
         "REMOVED_1",
         "LEFT_2",
-        "PREVIEW_3"
+        "PREVIEW_3",
+        "RESET_4"
       ]
     },
     {

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -507,6 +507,13 @@
             "items": "gregor1.UID"
           },
           "name": "allList"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "gregor1.UID"
+          },
+          "name": "resetList"
         }
       ]
     },

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -303,6 +303,13 @@
           "name": "removed"
         },
         {
+          "type": {
+            "type": "array",
+            "items": "ConversationMember"
+          },
+          "name": "reset"
+        },
+        {
           "type": [
             null,
             "UnreadUpdate"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -996,6 +996,10 @@
           "name": "membersType"
         },
         {
+          "type": "ConversationMemberStatus",
+          "name": "memberStatus"
+        },
+        {
           "type": "TeamType",
           "name": "teamType"
         },
@@ -1027,6 +1031,13 @@
             "ConversationFinalizeInfo"
           ],
           "name": "finalizeInfo"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "resetNames"
         }
       ]
     },

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -147,8 +147,8 @@
           "name": "member"
         },
         {
-          "type": "boolean",
-          "name": "joined"
+          "type": "ConversationMemberStatus",
+          "name": "status"
         }
       ]
     },
@@ -480,6 +480,21 @@
       "lint": "ignore"
     },
     "ChatLeftConversation": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        },
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
+    },
+    "ChatResetConversation": {
       "request": [
         {
           "name": "uid",

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -138,6 +138,10 @@
         {
           "type": "Seqno",
           "name": "eldestSeqno"
+        },
+        {
+          "type": "Seqno",
+          "name": "userEldestSeqno"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1397,7 +1397,7 @@ export type MarkAsReadRes = {
 export type MembersUpdateInfo = {
   convID: ConversationID,
   member: string,
-  joined: boolean,
+  status: ConversationMemberStatus,
 }
 
 export type MerkleRoot = {
@@ -1654,6 +1654,11 @@ export type NotifyChatChatJoinedConversationRpcParam = Exact<{
 }>
 
 export type NotifyChatChatLeftConversationRpcParam = Exact<{
+  uid: keybase1.UID,
+  convID: ConversationID
+}>
+
+export type NotifyChatChatResetConversationRpcParam = Exact<{
   uid: keybase1.UID,
   convID: ConversationID
 }>
@@ -2718,6 +2723,14 @@ export type incomingCallMapType = Exact<{
     */
   ) => void,
   'keybase.1.NotifyChat.ChatLeftConversation'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convID: ConversationID
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatResetConversation'?: (
     params: Exact<{
       uid: keybase1.UID,
       convID: ConversationID

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -73,6 +73,7 @@ export const CommonConversationMemberStatus = {
   removed: 1,
   left: 2,
   preview: 3,
+  reset: 4,
 }
 
 export const CommonConversationMembersType = {
@@ -1007,6 +1008,7 @@ export type ConversationMemberStatus =
   | 1 // REMOVED_1
   | 2 // LEFT_2
   | 3 // PREVIEW_3
+  | 4 // RESET_4
 
 export type ConversationMembersType =
     0 // KBFS_0

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -977,12 +977,14 @@ export type ConversationInfoLocal = {
   visibility: keybase1.TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  memberStatus: ConversationMemberStatus,
   teamType: TeamType,
   existence: ConversationExistence,
   version: ConversationVers,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
   finalizeInfo?: ?ConversationFinalizeInfo,
+  resetNames?: ?Array<string>,
 }
 
 export type ConversationLocal = {
@@ -1029,6 +1031,7 @@ export type ConversationMetadata = {
   supersededBy?: ?Array<ConversationMetadata>,
   activeList?: ?Array<gregor1.UID>,
   allList?: ?Array<gregor1.UID>,
+  resetList?: ?Array<gregor1.UID>,
 }
 
 export type ConversationNotificationInfo = {
@@ -1316,8 +1319,10 @@ export type InboxUIItem = {
   headline: string,
   visibility: keybase1.TLFVisibility,
   participants?: ?Array<string>,
+  resetParticipants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  memberStatus: ConversationMemberStatus,
   teamType: TeamType,
   time: gregor1.Time,
   notifications?: ?ConversationNotificationInfo,
@@ -2011,6 +2016,7 @@ export type UnverifiedInboxUIItem = {
   visibility: keybase1.TLFVisibility,
   status: ConversationStatus,
   membersType: ConversationMembersType,
+  memberStatus: ConversationMemberStatus,
   teamType: TeamType,
   notifications?: ?ConversationNotificationInfo,
   time: gregor1.Time,
@@ -2023,6 +2029,7 @@ export type UnverifiedInboxUIItemMetadata = {
   headline: string,
   snippet: string,
   writerNames?: ?Array<string>,
+  resetParticipants?: ?Array<string>,
 }
 
 export type UnverifiedInboxUIItems = {
@@ -2035,6 +2042,7 @@ export type UpdateConversationMembership = {
   inboxVers: InboxVers,
   joined?: ?Array<ConversationMember>,
   removed?: ?Array<ConversationMember>,
+  reset?: ?Array<ConversationMember>,
   unreadUpdate?: ?UnreadUpdate,
 }
 

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4889,6 +4889,7 @@ export type TeamMember = {
   uid: UID,
   role: TeamRole,
   eldestSeqno: Seqno,
+  userEldestSeqno: Seqno,
 }
 
 export type TeamMemberDetails = {


### PR DESCRIPTION
Patch does the following:

1.) Process the new `RESET` member status for people in a conversation that are currently reset.
2.) Update the inbox properly with `AllList` and `ResetList` depending on the style of members update.
3.) Add reset users onto all information in `ConversationLocal` and `InboxUIItem` so we can render information about the reset users in a convo.
4.) Send proper notifications to the frontend when memberships changes because of a reset.
5.) Test everything.