### PR TITLE
Fix fetching because of NeedKeyGeneration, re-enable chat test

### DIFF
--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -137,13 +137,16 @@ func (k *KeyFinderImpl) FindForDecryption(ctx context.Context,
 		if err != nil {
 			return res, err
 		}
+		var refreshers keybase1.TeamRefreshers
+		if !public {
+			// Only need keys for private teams.
+			refreshers.NeedKeyGeneration = keybase1.PerTeamKeyGeneration(keyGeneration)
+		}
 		team, err := teams.Load(ctx, k.G().ExternalG(), keybase1.LoadTeamArg{
-			ID: teamID,
-			Refreshers: keybase1.TeamRefreshers{
-				NeedKeyGeneration: keybase1.PerTeamKeyGeneration(keyGeneration),
-			},
-			StaleOK: true,
-			Public:  public,
+			ID:         teamID,
+			Refreshers: refreshers,
+			StaleOK:    true,
+			Public:     public,
 		})
 		if err != nil {
 			return res, err

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1808,10 +1808,6 @@ func TestChatSrvFindConversations(t *testing.T) {
 		if mt == chat1.ConversationMembersType_TEAM {
 			return
 		}
-		if mt == chat1.ConversationMembersType_IMPTEAM {
-			// CORE-6322 public implicit teams don't work ye.
-			return
-		}
 		ctc := makeChatTestContext(t, "FindConversations", 3)
 		defer ctc.cleanup()
 		users := ctc.users()


### PR DESCRIPTION
This re-enables `TestChatSrvFindConversations` for implicit teams.
2 bugs down:
- in TeamLoader if the chain hasn't changed we still need to fetch if we need secrets (wasn't really the problem here)
- in chat, don't set `NeedKeyGeneration` for public iteams. We don't really need the key and if we're not in the chat then we can't get it.