### PR TITLE
Add logging for list-members

### DIFF
--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -507,7 +507,7 @@ func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid 
 		linkMap = upak.SeqnoLinkIDs
 		ret, key = upak.FindKID(kid)
 		if key != nil {
-			u.G().VDL.CLogf(ctx, VLog0, "- found kid in UPAK: %v", *ret)
+			u.G().VDL.CLogf(ctx, VLog0, "- found kid in UPAK: %v", ret.Uid)
 			return ret, key, linkMap, nil
 		}
 		ret = nil

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -703,6 +703,7 @@ type TimeTracer struct {
 
 func NewTimeTracer(ctx context.Context, log logger.Logger, clock clockwork.Clock, label string) *TimeTracer {
 	now := clock.Now()
+	log.CDebugf(ctx, "+ %s", label)
 	return &TimeTracer{
 		ctx:    ctx,
 		log:    log,

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -36,16 +36,22 @@ func membersUIDsToUsernames(ctx context.Context, g *libkb.GlobalContext, m keyba
 }
 
 func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepoll bool) (res keybase1.TeamDetails, err error) {
+	tracer := g.CTimeTracer(ctx, "TeamDetails")
+	defer tracer.Finish()
+
+	tracer.Stage("load team")
 	t, err := GetMaybeAdminByStringName(ctx, g, name)
 	if err != nil {
 		return res, err
 	}
 	res.KeyGeneration = t.Generation()
+	tracer.Stage("members")
 	res.Members, err = members(ctx, g, t, forceRepoll)
 	if err != nil {
 		return res, err
 	}
 
+	tracer.Stage("annotate")
 	activeInvites := t.chain().inner.ActiveInvites
 	annotatedInvites, err := AnnotateInvites(ctx, g, activeInvites, t.Name().String())
 	if err != nil {
@@ -53,6 +59,7 @@ func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepo
 	}
 	res.AnnotatedActiveInvites = annotatedInvites
 
+	tracer.Stage("invites")
 	// put any keybase invites in the members list
 	for invID, invite := range annotatedInvites {
 		cat, err := invite.Type.C()


### PR DESCRIPTION
Loading all the users is the slowest part.

No cache:
```
2017-10-10T10:52:32.654899-04:00 ▶ + TeamGet(keybasefriends)
2017-10-10T10:52:32.654941-04:00 ▶ | TeamDetails:init [time=696ns]
2017-10-10T10:52:43.370984-04:00 ▶ | TeamDetails:load team [time=10.716024163s]
2017-10-10T10:54:01.697323-04:00 ▶ | TeamDetails:members [time=1m18.326325445s]
2017-10-10T10:54:01.697345-04:00 ▶ | TeamDetails:annotate [time=9.046µs]
2017-10-10T10:54:01.697360-04:00 ▶ | TeamDetails:invites [time=664ns]
2017-10-10T10:54:01.697372-04:00 ▶ - TeamDetails [time=1m29.04243286s]
2017-10-10T10:54:01.697386-04:00 ▶ - TeamGet(keybasefriends) -> <nil> [time=1m29.042449997s]
```

Second run:
```
2017-10-10T10:55:12.969345-04:00 ▶ + TeamGet(keybasefriends)
2017-10-10T10:55:12.969373-04:00 ▶ | TeamDetails:init [time=565ns]
2017-10-10T10:55:13.074325-04:00 ▶ | TeamDetails:load team [time=104.938008ms]
2017-10-10T10:55:13.138910-04:00 ▶ | TeamDetails:members [time=64.572791ms]
2017-10-10T10:55:13.138922-04:00 ▶ | TeamDetails:annotate [time=1.807µs]
2017-10-10T10:55:13.138934-04:00 ▶ | TeamDetails:invites [time=746ns]
2017-10-10T10:55:13.138944-04:00 ▶ - TeamDetails [time=169.572761ms]
2017-10-10T10:55:13.138957-04:00 ▶ - TeamGet(keybasefriends) -> <nil> [time=169.585609ms]
```
