### PR TITLE
Skip public iteam tests

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1808,6 +1808,12 @@ func TestChatSrvFindConversations(t *testing.T) {
 		if mt == chat1.ConversationMembersType_TEAM {
 			return
 		}
+
+		// CORE-6335 remove this
+		if mt == chat1.ConversationMembersType_IMPTEAM {
+			return
+		}
+
 		ctc := makeChatTestContext(t, "FindConversations", 3)
 		defer ctc.cleanup()
 		users := ctc.users()

--- a/go/systests/git_test.go
+++ b/go/systests/git_test.go
@@ -45,15 +45,16 @@ func TestGitTeamer(t *testing.T) {
 	require.Equal(t, res.TeamID, teamID)
 	require.Equal(t, res.Visibility, keybase1.TLFVisibility_PRIVATE)
 
-	t.Logf("public team")
-	teamID, teamName = tt.users[0].createTeam2()
-	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
-		Name:       teamName.String(),
-		Private:    false,
-		FolderType: keybase1.FolderType_TEAM,
-	})
-	require.Error(t, err)
-	require.Regexp(t, `not supported`, err.Error())
+	// CORE-6335 re-enable
+	// t.Logf("public team")
+	// teamID, teamName = tt.users[0].createTeam2()
+	// res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
+	// 	Name:       teamName.String(),
+	// 	Private:    false,
+	// 	FolderType: keybase1.FolderType_TEAM,
+	// })
+	// require.Error(t, err)
+	// require.Regexp(t, `not supported`, err.Error())
 
 	t.Logf("iteam that doesn't exist (gets created)")
 	bob := tt.addUser("bob")
@@ -84,19 +85,20 @@ func TestGitTeamer(t *testing.T) {
 	require.Equal(t, res.TeamID, teamID, "teamer should return the same team that was created earlier")
 	require.Equal(t, res.Visibility, keybase1.TLFVisibility_PRIVATE)
 
-	t.Logf("public iteam")
-	bob = tt.addUser("bob")
-	gil = tt.addUser("gil")
-	frag = fmt.Sprintf("%v,%v#%v", alice.username, bob.username, gil.username)
-	teamID, _, _, err = teams.LookupOrCreateImplicitTeam(context.Background(), g, frag, true /*isPublic*/)
-	res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
-		Name:       frag,
-		Private:    false,
-		FolderType: keybase1.FolderType_PUBLIC,
-	})
-	require.NoError(t, err)
-	require.Equal(t, res.TeamID, teamID, "teamer should return the same team that was created earlier")
-	require.Equal(t, res.Visibility, keybase1.TLFVisibility_PUBLIC)
+	// CORE-6335 re-enable
+	// t.Logf("public iteam")
+	// bob = tt.addUser("bob")
+	// gil = tt.addUser("gil")
+	// frag = fmt.Sprintf("%v,%v#%v", alice.username, bob.username, gil.username)
+	// teamID, _, _, err = teams.LookupOrCreateImplicitTeam(context.Background(), g, frag, true /*isPublic*/)
+	// res, err = teamer.LookupOrCreate(context.Background(), keybase1.Folder{
+	// 	Name:       frag,
+	// 	Private:    false,
+	// 	FolderType: keybase1.FolderType_PUBLIC,
+	// })
+	// require.NoError(t, err)
+	// require.Equal(t, res.TeamID, teamID, "teamer should return the same team that was created earlier")
+	// require.Equal(t, res.Visibility, keybase1.TLFVisibility_PUBLIC)
 
 	t.Logf("iteam conflict")
 	alice.drainGregor()

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -67,10 +67,10 @@ func TestLookupImplicitTeams(t *testing.T) {
 
 	displayName := strings.Join(usernames, ",")
 	lookupAndCreate(displayName, false)
-	lookupAndCreate(displayName, true)
+	// lookupAndCreate(displayName, true) // CORE-6335 re-enable
 	displayName = fmt.Sprintf("mike@twitter,%s,james@github", displayName)
 	lookupAndCreate(displayName, false)
-	lookupAndCreate(displayName, true)
+	// lookupAndCreate(displayName, true) // CORE-6335 re-enable
 
 	_, _, _, err := LookupOrCreateImplicitTeam(context.TODO(), tc.G, "dksjdskjs/sxs?", false)
 	require.Error(t, err)


### PR DESCRIPTION
Skip all the client tests that deal public teams in the client so that https://github.com/keybase/keybase/pull/1791 can be merged. After that we can change the client to match the server (new public team id suffixes) and re-enable these tests.

I found these by running tests against that server PR in `teams`, `chat`, and `systests`. Any other packages that might fail? It would be annoying if I missed any because merging the server PR would cause client master to fail CI.

cc @oconnor663 @mmaxim sorry, will re-enable your tests soonish