### PR TITLE
Check link before posting

### DIFF
--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -2,6 +2,7 @@ package teams
 
 import (
 	"errors"
+	"fmt"
 
 	"golang.org/x/net/context"
 
@@ -233,6 +234,11 @@ func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me *lib
 		},
 	}
 
+	err = precheckLinkToPost(ctx, g, sigMultiItem, nil, me.ToUserVersion())
+	if err != nil {
+		return fmt.Errorf("cannot post link (precheck): %v", err)
+	}
+
 	g.Log.CDebugf(ctx, "makeSigAndPostRootTeam post sigs")
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = []interface{}{sigMultiItem}
@@ -347,6 +353,16 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 	subteamHeadSig, secretboxes, err := generateHeadSigForSubteamChain(ctx, g, me, deviceSigningKey, parentTeam.chain(), subteamName, subteamID, admin, allParentAdmins)
 	if err != nil {
 		return nil, err
+	}
+
+	err = precheckLinkToPost(ctx, g, *newSubteamSig, parentTeam.chain(), me.ToUserVersion())
+	if err != nil {
+		return nil, fmt.Errorf("cannot post link (precheck new subteam): %v", err)
+	}
+
+	err = precheckLinkToPost(ctx, g, *subteamHeadSig, nil, me.ToUserVersion())
+	if err != nil {
+		return nil, fmt.Errorf("cannot post link (precheck subteam head): %v", err)
 	}
 
 	payload := make(libkb.JSONPayload)

--- a/go/teams/loader_types.go
+++ b/go/teams/loader_types.go
@@ -45,7 +45,7 @@ type chainLinkUnpacked struct {
 func unpackChainLink(link *SCChainLink) (*chainLinkUnpacked, error) {
 	outerLink, err := libkb.DecodeOuterLinkV2(link.Sig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unpack outer: %v", err)
 	}
 	err = outerLink.AssertSomeFields(link.Version, link.Seqno)
 	if err != nil {

--- a/go/teams/rename.go
+++ b/go/teams/rename.go
@@ -87,6 +87,16 @@ func RenameSubteam(ctx context.Context, g *libkb.GlobalContext, prevName keybase
 		return err
 	}
 
+	err = precheckLinkToPost(ctx, g, *renameSubteamSig, parent.chain(), me.ToUserVersion())
+	if err != nil {
+		return fmt.Errorf("cannot post link (precheck rename subteam): %v", err)
+	}
+
+	err = precheckLinkToPost(ctx, g, *renameUpPointerSig, subteam.chain(), me.ToUserVersion())
+	if err != nil {
+		return fmt.Errorf("cannot post link (precheck rename up): %v", err)
+	}
+
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = []interface{}{renameSubteamSig, renameUpPointerSig}
 


### PR DESCRIPTION
Before posting any team sigchain links, run them through the local sigchain player. This could catch bugs if the client player is more strict than the server. The operation would fail either way, but with this it would not get immortalized in the sigchain. This runs it through the inner part of the player, which basically checks the inside but none of the proof ordering or off-chain stuff.

I'm on the fence because the other side of the coin is that if this produces a spurious failure then it will prevent people from posting links that are fine. But it is worse if people can't read the chain than if they can't write to it.

What do you think?