### PR TITLE
send chat welcome message when an invite is taken CORE-6243

### DIFF
--- a/go/chat/globals/globals.go
+++ b/go/chat/globals/globals.go
@@ -59,3 +59,5 @@ func NewChatContextified(gc *ChatContext) ChatContextified {
 func (c ChatContextified) ChatG() *ChatContext {
 	return c.gc
 }
+
+var DefaultTeamTopic = "general"

--- a/go/chat/helper_test.go
+++ b/go/chat/helper_test.go
@@ -81,13 +81,14 @@ func TestSendTextByName(t *testing.T) {
 		}
 
 		getRi := func() chat1.RemoteInterface { return ri2 }
-		require.NoError(t, SendTextByName(ctx, tc.Context(), name, nil,
-			mt, keybase1.TLFIdentifyBehavior_CHAT_CLI, "HI", getRi))
+		helper := NewHelper(tc.Context(), getRi)
+		require.NoError(t, helper.SendTextByName(ctx, name, nil,
+			mt, keybase1.TLFIdentifyBehavior_CHAT_CLI, "HI"))
 		inbox, _, err := tc.Context().InboxSource.Read(ctx, uid, nil, true, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(inbox.Convs))
-		require.NoError(t, SendTextByName(ctx, tc.Context(), name, nil,
-			mt, keybase1.TLFIdentifyBehavior_CHAT_CLI, "HI", getRi))
+		require.NoError(t, helper.SendTextByName(ctx, name, nil,
+			mt, keybase1.TLFIdentifyBehavior_CHAT_CLI, "HI"))
 		inbox, _, err = tc.Context().InboxSource.Read(ctx, uid, nil, true, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(inbox.Convs))
@@ -99,8 +100,8 @@ func TestSendTextByName(t *testing.T) {
 
 		t.Logf("sending into new topic name")
 		topicName := "MIKE"
-		err = SendTextByName(ctx, tc.Context(), name, &topicName,
-			mt, keybase1.TLFIdentifyBehavior_CHAT_CLI, "HI", getRi)
+		err = helper.SendTextByName(ctx, name, &topicName,
+			mt, keybase1.TLFIdentifyBehavior_CHAT_CLI, "HI")
 		require.NoError(t, err)
 		inbox, _, err = tc.Context().InboxSource.Read(ctx, uid, nil, true, nil, nil)
 		require.NoError(t, err)

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -193,6 +193,7 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	pushHandler := NewPushHandler(g)
 	pushHandler.SetClock(world.Fc)
 	g.PushHandler = pushHandler
+	g.ChatHelper = NewHelper(g, getRI)
 
 	return ctx, world, ri, sender, baseSender, &listener
 }

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -32,8 +32,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var DefaultTeamTopic = "general"
-
 type ServerConnection interface {
 	Reconnect(context.Context) (bool, error)
 	GetClient() chat1.RemoteInterface

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2350,7 +2350,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			})
 		require.NoError(t, err)
 		require.Equal(t, 3, len(getTLFRes.Convs))
-		require.Equal(t, DefaultTeamTopic, getTLFRes.Convs[0].Channel)
+		require.Equal(t, globals.DefaultTeamTopic, getTLFRes.Convs[0].Channel)
 		require.Equal(t, topicName, getTLFRes.Convs[1].Channel)
 		creatorInfo := getTLFRes.Convs[2].CreatorInfo
 		require.NotNil(t, creatorInfo)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -313,6 +313,8 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	pushHandler.SetClock(c.world.Fc)
 	g.PushHandler = pushHandler
 
+	tc.G.ChatHelper = NewHelper(g, func() chat1.RemoteInterface { return ri })
+
 	tuc := &chatTestUserContext{
 		h:        h,
 		u:        user,

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/keybase/cli"
-	"github.com/keybase/client/go/chat"
+	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -179,7 +179,7 @@ func annotateResolvingRequest(g *libkb.GlobalContext, req *chatConversationResol
 
 	// Set the default topic name to #general if none is specified
 	if req.MembersType == chat1.ConversationMembersType_TEAM && len(req.TopicName) == 0 {
-		req.TopicName = chat.DefaultTeamTopic
+		req.TopicName = globals.DefaultTeamTopic
 	}
 
 	return nil

--- a/go/client/cmd_chat_read.go
+++ b/go/client/cmd_chat_read.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/cli"
-	"github.com/keybase/client/go/chat"
+	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -54,7 +54,7 @@ func (c *CmdChatRead) SetTeamChatForTest(n string) {
 		},
 		resolvingRequest: chatConversationResolvingRequest{
 			TlfName:     n,
-			TopicName:   chat.DefaultTeamTopic,
+			TopicName:   globals.DefaultTeamTopic,
 			MembersType: chat1.ConversationMembersType_TEAM,
 			TopicType:   chat1.TopicType_CHAT,
 			Visibility:  keybase1.TLFVisibility_PRIVATE,

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/cli"
-	"github.com/keybase/client/go/chat"
+	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/msgchecker"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
@@ -43,7 +43,7 @@ func (c *CmdChatSend) SetTeamChatForTest(n string) {
 	c.team = true
 	c.resolvingRequest = chatConversationResolvingRequest{
 		TlfName:     n,
-		TopicName:   chat.DefaultTeamTopic,
+		TopicName:   globals.DefaultTeamTopic,
 		MembersType: chat1.ConversationMembersType_TEAM,
 		TopicType:   chat1.TopicType_CHAT,
 		Visibility:  keybase1.TLFVisibility_PRIVATE,

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -62,6 +62,7 @@ type GlobalContext struct {
 	Output           io.Writer            // where 'Stdout'-style output goes
 	DNSNSFetcher     DNSNameServerFetcher // The mobile apps potentially pass an implementor of this interface which is used to grab currently configured DNS name servers
 	AppState         *AppState            // The state of focus for the currently running instance of the app
+	ChatHelper       ChatHelper           // conveniently send chat messages
 
 	cacheMu        *sync.RWMutex   // protects all caches
 	ProofCache     *ProofCache     // where to cache proof results

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -651,3 +651,24 @@ type UIDMapper interface {
 	// like a warning. But if, for instance, the mapper runs out of time budget, it will return the data
 	MapUIDsToUsernamePackages(ctx context.Context, g UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networktimeBudget time.Duration, forceNetworkForFullNames bool) ([]UsernamePackage, error)
 }
+
+type ChatHelper interface {
+	SendTextByID(ctx context.Context, convID chat1.ConversationID,
+		trip chat1.ConversationIDTriple, tlfName string, text string) error
+	SendMsgByID(ctx context.Context, convID chat1.ConversationID,
+		trip chat1.ConversationIDTriple, tlfName string, body chat1.MessageBody, msgType chat1.MessageType) error
+	SendTextByIDNonblock(ctx context.Context, convID chat1.ConversationID,
+		trip chat1.ConversationIDTriple, tlfName string, text string) error
+	SendMsgByIDNonblock(ctx context.Context, convID chat1.ConversationID,
+		trip chat1.ConversationIDTriple, tlfName string, body chat1.MessageBody, msgType chat1.MessageType) error
+	SendTextByName(ctx context.Context, name string, topicName *string,
+		membersType chat1.ConversationMembersType, ident keybase1.TLFIdentifyBehavior, text string) error
+	SendMsgByName(ctx context.Context, name string, topicName *string,
+		membersType chat1.ConversationMembersType, ident keybase1.TLFIdentifyBehavior, body chat1.MessageBody,
+		msgType chat1.MessageType) error
+	SendTextByNameNonblock(ctx context.Context, name string, topicName *string,
+		membersType chat1.ConversationMembersType, ident keybase1.TLFIdentifyBehavior, text string) error
+	SendMsgByNameNonblock(ctx context.Context, name string, topicName *string,
+		membersType chat1.ConversationMembersType, ident keybase1.TLFIdentifyBehavior, body chat1.MessageBody,
+		msgType chat1.MessageType) error
+}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -348,6 +348,8 @@ func (d *Service) createChatModules() {
 	// Add a tlfHandler into the user changed handler group so we can keep identify info
 	// fresh
 	g.AddUserChangedHandler(chat.NewIdentifyChangedHandler(g))
+
+	g.ChatHelper = chat.NewHelper(g, ri)
 }
 
 func (d *Service) configureRekey(uir *UIRouter) {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -89,7 +89,7 @@ func (h *TeamsHandler) TeamCreateWithSettings(ctx context.Context, arg keybase1.
 			// Just bail with no error here
 			return res, nil
 		}
-		res.ChatSent = teams.SendTeamChatWelcomeMessage(ctx, h.G(), teamDetails,
+		res.ChatSent = teams.SendTeamChatWelcomeMessage(ctx, h.G().ExternalG(), teamDetails,
 			teamName.String(), h.G().Env.GetUsername().String())
 	}
 	return res, nil
@@ -154,7 +154,7 @@ func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMe
 		return result, nil
 	}
 
-	result.ChatSent = teams.SendTeamChatWelcomeMessage(ctx, h.G(), teamDetails, arg.Name,
+	result.ChatSent = teams.SendTeamChatWelcomeMessage(ctx, h.G().ExternalG(), teamDetails, arg.Name,
 		result.User.Username)
 	return result, nil
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -83,13 +83,7 @@ func (h *TeamsHandler) TeamCreateWithSettings(ctx context.Context, arg keybase1.
 	}
 
 	if arg.SendChatNotification {
-		teamDetails, err := teams.Details(ctx, h.G().ExternalG(), teamName.String(), true)
-		if err != nil {
-			h.G().Log.CDebugf(ctx, "failed to get team details for welcome message: %s", err)
-			// Just bail with no error here
-			return res, nil
-		}
-		res.ChatSent = teams.SendTeamChatWelcomeMessage(ctx, h.G().ExternalG(), teamDetails,
+		res.ChatSent = teams.SendTeamChatWelcomeMessage(ctx, h.G().ExternalG(),
 			teamName.String(), h.G().Env.GetUsername().String())
 	}
 	return res, nil
@@ -147,14 +141,7 @@ func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMe
 		return result, nil
 	}
 
-	teamDetails, err := teams.Details(ctx, h.G().ExternalG(), arg.Name, true)
-	if err != nil {
-		h.G().Log.CDebugf(ctx, "failed to get team details for welcome message: %s", err)
-		// Just bail with no error here
-		return result, nil
-	}
-
-	result.ChatSent = teams.SendTeamChatWelcomeMessage(ctx, h.G().ExternalG(), teamDetails, arg.Name,
+	result.ChatSent = teams.SendTeamChatWelcomeMessage(ctx, h.G().ExternalG(), arg.Name,
 		result.User.Username)
 	return result, nil
 }

--- a/go/teams/chatmessaging.go
+++ b/go/teams/chatmessaging.go
@@ -11,14 +11,19 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func SendTeamChatWelcomeMessage(ctx context.Context, g *libkb.GlobalContext, teamDetails keybase1.TeamDetails,
-	team, user string) (res bool) {
+func SendTeamChatWelcomeMessage(ctx context.Context, g *libkb.GlobalContext, team, user string) (res bool) {
 	var err error
 	defer func() {
 		if err != nil {
 			g.Log.CWarningf(ctx, "failed to send team welcome message: %s", err.Error())
 		}
 	}()
+
+	teamDetails, err := Details(ctx, g, team, true)
+	if err != nil {
+		g.Log.CDebugf(ctx, "failed to get team details for welcome message: %s", err)
+		return false
+	}
 
 	var ownerNames, adminNames, writerNames, readerNames []string
 	for _, owner := range teamDetails.Members.Owners {

--- a/go/teams/chatmessaging.go
+++ b/go/teams/chatmessaging.go
@@ -78,16 +78,17 @@ func SendChatInviteWelcomeMessage(ctx context.Context, g *libkb.GlobalContext, t
 	}
 	switch category {
 	case keybase1.TeamInviteCategory_KEYBASE:
-		msg = fmt.Sprintf("I just auto-added %s to this team, whom %s invited previously, but who was missing a new-enough version of the Keybase app. (This is an automated message; my app responded first.)",
+		msg = fmt.Sprintf("I just auto-added @%s to this team, whom @%s invited previously, but who was missing a new-enough version of the Keybase app. (This is an automated message; my app responded first.)",
 			inviteeName, inviterName)
 	case keybase1.TeamInviteCategory_EMAIL:
-		msg = fmt.Sprintf("I just auto-added %s to this team, whom %s invited over email. (This is an automated message; my app responded first.)", inviteeName, inviterName)
+		msg = fmt.Sprintf("I just auto-added @%s to this team, whom @%s invited over email. (This is an automated message; my app responded first.)", inviteeName, inviterName)
 	case keybase1.TeamInviteCategory_SBS:
-		msg = fmt.Sprintf("I just auto-added %s to this team, whom %s invited with a social assertion. (This is an automated message; my app responded first.)", inviteeName, inviterName)
+		msg = fmt.Sprintf("I just auto-added @%s to this team, whom @%s invited with a social assertion. (This is an automated message; my app responded first.)", inviteeName, inviterName)
 	}
 
 	if err = g.ChatHelper.SendTextByName(ctx, team, &globals.DefaultTeamTopic,
 		chat1.ConversationMembersType_TEAM, keybase1.TLFIdentifyBehavior_CHAT_CLI, msg); err != nil {
+		g.Log.CDebugf(ctx, "sendChatInviteWelcomeMessage: failed to send message: %s", err)
 		return false
 	}
 

--- a/go/teams/chatmessaging.go
+++ b/go/teams/chatmessaging.go
@@ -1,0 +1,94 @@
+package teams
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+func SendTeamChatWelcomeMessage(ctx context.Context, g *globals.Context, teamDetails keybase1.TeamDetails,
+	team, user string) (res bool) {
+	var err error
+	defer func() {
+		if err != nil {
+			g.Log.CWarningf(ctx, "failed to send team welcome message: %s", err.Error())
+		}
+	}()
+
+	var ownerNames, adminNames, writerNames, readerNames []string
+	for _, owner := range teamDetails.Members.Owners {
+		ownerNames = append(ownerNames, owner.Username)
+	}
+	for _, admin := range teamDetails.Members.Admins {
+		adminNames = append(adminNames, admin.Username)
+	}
+	for _, writer := range teamDetails.Members.Writers {
+		writerNames = append(writerNames, writer.Username)
+	}
+	for _, reader := range teamDetails.Members.Readers {
+		readerNames = append(readerNames, reader.Username)
+	}
+	var lines []string
+	if len(ownerNames) > 0 {
+		lines = append(lines, fmt.Sprintf("  owners: %s", strings.Join(ownerNames, ",")))
+	}
+	if len(adminNames) > 0 {
+		lines = append(lines, fmt.Sprintf("  admins: %s", strings.Join(adminNames, ",")))
+	}
+	if len(writerNames) > 0 {
+		lines = append(lines, fmt.Sprintf("  writers: %s", strings.Join(writerNames, ",")))
+	}
+	if len(readerNames) > 0 {
+		lines = append(lines, fmt.Sprintf("  readers: %s", strings.Join(readerNames, ",")))
+	}
+	memberBody := strings.Join(lines, "\n")
+	body := fmt.Sprintf("Hello! I've just added @%s to this team. Current members:\n\n```​%s```\n\n_More info on teams:_ keybase.io/blog/introducing-keybase-teams\n_To leave this team, visit the team tab or run `keybase team leave %s`_",
+		user, memberBody, team)
+
+	// Ensure we have chat available, since TeamAddMember may also be
+	// coming from a standalone launch.
+	g.StartStandaloneChat()
+
+	if err = g.ChatHelper.SendTextByName(ctx, team, &globals.DefaultTeamTopic,
+		chat1.ConversationMembersType_TEAM, keybase1.TLFIdentifyBehavior_CHAT_CLI, body); err != nil {
+		return false
+	}
+
+	return true
+}
+
+func SendChatInviteWelcomeMessage(ctx context.Context, g *globals.Context, team string,
+	category keybase1.TeamInviteCategory, inviter, invitee keybase1.UID) (res bool) {
+	var msg string
+
+	inviterName, err := g.GetUPAKLoader().LookupUsername(ctx, inviter)
+	if err != nil {
+		g.Log.CDebugf(ctx, "sendChatInviteWelcomeMessage: failed to lookup inviter username: %s", err)
+		return false
+	}
+	inviteeName, err := g.GetUPAKLoader().LookupUsername(ctx, invitee)
+	if err != nil {
+		g.Log.CDebugf(ctx, "sendChatInviteWelcomeMessage: failed to lookup invitee username: %s", err)
+		return false
+	}
+	switch category {
+	case keybase1.TeamInviteCategory_KEYBASE:
+		msg = fmt.Sprintf("I just auto-added %s to this team, whom %s invited previously, but who was missing a new-enough version of the Keybase app. (This is an automated message; my app responded first.)",
+			inviteeName, inviterName)
+	case keybase1.TeamInviteCategory_EMAIL:
+		msg = fmt.Sprintf("I just auto-added %s to this team, whom %s invited over email. (This is an automated message; my app responded first.)", inviteeName, inviterName)
+	case keybase1.TeamInviteCategory_SBS:
+		msg = fmt.Sprintf("I just auto-added %s to this team, whom %s invited with a social assertion. (This is an automated message; my app responded first.)", inviteeName, inviterName)
+	}
+
+	if err = g.ChatHelper.SendTextByName(ctx, team, &globals.DefaultTeamTopic,
+		chat1.ConversationMembersType_TEAM, keybase1.TLFIdentifyBehavior_CHAT_CLI, msg); err != nil {
+		return false
+	}
+
+	return true
+}

--- a/go/teams/chatmessaging.go
+++ b/go/teams/chatmessaging.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func SendTeamChatWelcomeMessage(ctx context.Context, g *globals.Context, teamDetails keybase1.TeamDetails,
+func SendTeamChatWelcomeMessage(ctx context.Context, g *libkb.GlobalContext, teamDetails keybase1.TeamDetails,
 	team, user string) (res bool) {
 	var err error
 	defer func() {
@@ -61,7 +62,7 @@ func SendTeamChatWelcomeMessage(ctx context.Context, g *globals.Context, teamDet
 	return true
 }
 
-func SendChatInviteWelcomeMessage(ctx context.Context, g *globals.Context, team string,
+func SendChatInviteWelcomeMessage(ctx context.Context, g *libkb.GlobalContext, team string,
 	category keybase1.TeamInviteCategory, inviter, invitee keybase1.UID) (res bool) {
 	var msg string
 

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -183,7 +183,11 @@ func handleSBSSingle(ctx context.Context, g *libkb.GlobalContext, teamID keybase
 
 	g.Log.CDebugf(ctx, "checks passed, proceeding with team.ChangeMembership, req = %+v", req)
 
-	return team.ChangeMembership(ctx, req)
+	if err = team.ChangeMembership(ctx, req); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func assertCanAcceptKeybaseInvite(ctx context.Context, g *libkb.GlobalContext, untrustedInviteeFromGregor keybase1.TeamInvitee, chainInvite keybase1.TeamInvite) error {

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -188,6 +188,7 @@ func handleSBSSingle(ctx context.Context, g *libkb.GlobalContext, teamID keybase
 	}
 
 	// Send chat welcome message
+	g.Log.CDebugf(ctx, "sending welcome message for successful SBS handle")
 	SendChatInviteWelcomeMessage(ctx, g, team.Name().String(), category, invite.Inviter.Uid,
 		untrustedInviteeFromGregor.Uid)
 

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -187,6 +187,10 @@ func handleSBSSingle(ctx context.Context, g *libkb.GlobalContext, teamID keybase
 		return err
 	}
 
+	// Send chat welcome message
+	SendChatInviteWelcomeMessage(ctx, g, team.Name().String(), category, invite.Inviter.Uid,
+		untrustedInviteeFromGregor.Uid)
+
 	return nil
 }
 


### PR DESCRIPTION
Patch does the following:

1.) Add `libkb.ChatHelper` and add it to `G` so that we can use chat without worrying about Go package dependencies. 
2.) Add new chat message when an admin adds an invitee into the team.