### PR TITLE
Fix small teams converting to big teams

### DIFF
--- a/shared/reducers/entities.js
+++ b/shared/reducers/entities.js
@@ -14,7 +14,7 @@ export default function(state: State = initialState, action: Actions): State {
     case 'entity:delete': {
       const {keyPath, ids} = action.payload
       // $FlowIssue doesn't understand this API
-      // works in flow 4
+      // works in immutable 4
       // return state.updateIn(keyPath, map => map.deleteAll(ids))
       return state.updateIn(keyPath, map =>
         map.withMutations(map => {

--- a/shared/reducers/entities.js
+++ b/shared/reducers/entities.js
@@ -14,7 +14,15 @@ export default function(state: State = initialState, action: Actions): State {
     case 'entity:delete': {
       const {keyPath, ids} = action.payload
       // $FlowIssue doesn't understand this API
-      return state.updateIn(keyPath, map => map.deleteAll(ids))
+      // works in flow 4
+      // return state.updateIn(keyPath, map => map.deleteAll(ids))
+      return state.updateIn(keyPath, map =>
+        map.withMutations(map => {
+          ids.forEach(id => {
+            map = map.delete(id)
+          })
+        })
+      )
     }
     case 'entity:merge': {
       const {keyPath, entities} = action.payload

--- a/shared/reducers/entities.js
+++ b/shared/reducers/entities.js
@@ -13,9 +13,9 @@ export default function(state: State = initialState, action: Actions): State {
     }
     case 'entity:delete': {
       const {keyPath, ids} = action.payload
-      // $FlowIssue doesn't understand this API
       // works in immutable 4
       // return state.updateIn(keyPath, map => map.deleteAll(ids))
+      // $FlowIssue doesn't understand this API
       return state.updateIn(keyPath, map =>
         map.withMutations(map => {
           ids.forEach(id => {


### PR DESCRIPTION
After a team goes from small to big the untrusted call still tells us the team is small. We then unbox and we see its big and we update our 'big' data structures and not our small ones. This means that since we split up the data structure into a couple of pieces they could get out of sync and thing could be wrong. @mmaxim will fix up the untrusted call so its correct soon but in the meantime we just update the bookkeeping on small/big upon unboxing

@keybase/react-hackers 