### PR TITLE
Infer team publicness in gregor handlers, enable tests

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -596,11 +596,7 @@ type TeamLoader interface {
 	NotifyTeamRename(ctx context.Context, id keybase1.TeamID, newName string) error
 	Load(context.Context, keybase1.LoadTeamArg) (*keybase1.TeamData, error)
 	// Delete the cache entry. Does not error if there is no cache entry.
-	Delete(ctx context.Context, teamID keybase1.TeamID, public bool) error
-	// Delete the cache entry for both the public and private team.
-	// CORE-6322 Anywhere this method is used is a place where it would be _much_ better to use Delete.
-	//           This method should be deleted after that works.
-	DeleteBoth(ctx context.Context, teamID keybase1.TeamID) error
+	Delete(ctx context.Context, teamID keybase1.TeamID) error
 	OnLogout()
 }
 

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -45,11 +45,7 @@ func (n nullTeamLoader) Load(context.Context, keybase1.LoadTeamArg) (*keybase1.T
 	return nil, fmt.Errorf("null team loader")
 }
 
-func (n nullTeamLoader) Delete(context.Context, keybase1.TeamID, bool) error {
-	return nil
-}
-
-func (n nullTeamLoader) DeleteBoth(context.Context, keybase1.TeamID) error {
+func (n nullTeamLoader) Delete(context.Context, keybase1.TeamID) error {
 	return nil
 }
 

--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -60,9 +60,7 @@ func (r *teamHandler) rotateTeam(ctx context.Context, cli gregor1.IncomingInterf
 	}
 	r.G().Log.Debug("team.clkr unmarshaled: %+v", msg)
 
-	// CORE-6322 find out whether this is for a public team
-	public := false
-	if err := teams.HandleRotateRequest(ctx, r.G(), msg.TeamID, public, keybase1.PerTeamKeyGeneration(msg.Generation)); err != nil {
+	if err := teams.HandleRotateRequest(ctx, r.G(), msg.TeamID, keybase1.PerTeamKeyGeneration(msg.Generation)); err != nil {
 		return err
 	}
 

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -113,7 +113,6 @@ func TestImplicitTeamRotateOnRevokePrivate(t *testing.T) {
 }
 
 func TestImplicitTeamRotateOnRevokePublic(t *testing.T) {
-	t.Skip("Test skipped until CORE-6322: public team support")
 	testImplicitTeamRotateOnRevoke(t, true)
 }
 

--- a/go/teams/common_test.go
+++ b/go/teams/common_test.go
@@ -36,6 +36,14 @@ func GetForTestByStringName(ctx context.Context, g *libkb.GlobalContext, name st
 	})
 }
 
+func GetForTestByID(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (*Team, error) {
+	return Load(ctx, g, keybase1.LoadTeamArg{
+		ID:          id,
+		Public:      id.IsPublic(),
+		ForceRepoll: true,
+	})
+}
+
 func createTeamName(t *testing.T, root string, parts ...string) keybase1.TeamName {
 	name, err := keybase1.TeamNameFromString(root)
 	require.NoError(t, err)
@@ -79,4 +87,17 @@ func setupNTestsWithPukless(t *testing.T, n, nPukless int) ([]*kbtest.FakeUser, 
 		t.Logf("U%d: %v %v", i, fu.Username, fu.GetUserVersion())
 	}
 	return fus, tcs, cleanup
+}
+
+func runMany(t *testing.T, f func(implicit, public bool)) {
+	for _, implicit := range []bool{false, true} {
+		for _, public := range []bool{false, true} {
+			if !implicit && public {
+				// public teams not supported
+				continue
+			}
+			t.Logf("running test with implicit:%v public:%v", implicit, public)
+			f(implicit, public)
+		}
+	}
 }

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -81,8 +81,7 @@ func HandleDeleteNotification(ctx context.Context, g *libkb.GlobalContext, rows 
 
 	for _, row := range rows {
 		g.Log.CDebugf(ctx, "team.HandleDeleteNotification: (%+v)", row)
-		// We don't know whether this is about a public or private team, so delete and notify both.
-		err := g.GetTeamLoader().DeleteBoth(ctx, row.Id)
+		err := g.GetTeamLoader().Delete(ctx, row.Id)
 		if err != nil {
 			g.Log.CDebugf(ctx, "team.HandleDeleteNotification: error deleting team cache: %v", err)
 		}
@@ -96,8 +95,7 @@ func HandleExitNotification(ctx context.Context, g *libkb.GlobalContext, rows []
 
 	for _, row := range rows {
 		g.Log.CDebugf(ctx, "team.HandleExitNotification: (%+v)", row)
-		// We don't know whether this is about a public or private team, so delete and notify both.
-		err := g.GetTeamLoader().DeleteBoth(ctx, row.Id)
+		err := g.GetTeamLoader().Delete(ctx, row.Id)
 		if err != nil {
 			g.Log.CDebugf(ctx, "team.HandleExitNotification: error deleting team cache: %v", err)
 		}

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -9,15 +9,14 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func HandleRotateRequest(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, public bool, generation keybase1.PerTeamKeyGeneration) (err error) {
+func HandleRotateRequest(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, generation keybase1.PerTeamKeyGeneration) (err error) {
 
 	ctx = libkb.WithLogTag(ctx, "CLKR")
-	defer g.CTrace(ctx, fmt.Sprintf("HandleRotateRequest(%s,%v,%d)", teamID, public, generation), func() error { return err })()
+	defer g.CTrace(ctx, fmt.Sprintf("HandleRotateRequest(%s,%d)", teamID, generation), func() error { return err })()
 
-	// CORE-6322 this load needs to know if it's public
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
 		ID:          teamID,
-		Public:      public,
+		Public:      teamID.IsPublic(),
 		ForceRepoll: true,
 	})
 	if err != nil {
@@ -29,18 +28,17 @@ func HandleRotateRequest(ctx context.Context, g *libkb.GlobalContext, teamID key
 		return nil
 	}
 
-	g.Log.CDebugf(ctx, "rotating team %s (%s, public:%v)", team.Name(), teamID, public)
+	g.Log.CDebugf(ctx, "rotating team %s (%s)", team.Name(), teamID)
 	if err := team.Rotate(ctx); err != nil {
-		g.Log.CDebugf(ctx, "rotating team %s (%s, public:%v) error: %s", team.Name(), teamID, public, err)
+		g.Log.CDebugf(ctx, "rotating team %s (%s) error: %s", team.Name(), teamID, err)
 		return err
 	}
 
-	g.Log.CDebugf(ctx, "sucess rotating team %s (%s, public:%v)", team.Name(), teamID, public)
+	g.Log.CDebugf(ctx, "sucess rotating team %s (%s)", team.Name(), teamID)
 	return nil
 }
 
 func reloadLocal(ctx context.Context, g *libkb.GlobalContext, row keybase1.TeamChangeRow, change keybase1.TeamChangeSet) error {
-	// CORE-6322 this load needs to know if it's public
 	if change.Renamed {
 		// This force reloads the team as a side effect
 		return g.GetTeamLoader().NotifyTeamRename(ctx, row.Id, row.Name)
@@ -48,6 +46,7 @@ func reloadLocal(ctx context.Context, g *libkb.GlobalContext, row keybase1.TeamC
 
 	_, err := Load(ctx, g, keybase1.LoadTeamArg{
 		ID:          row.Id,
+		Public:      row.Id.IsPublic(),
 		ForceRepoll: true,
 	})
 	return err
@@ -59,7 +58,6 @@ func handleChangeSingle(ctx context.Context, g *libkb.GlobalContext, row keybase
 
 	defer g.CTrace(ctx, fmt.Sprintf("team.handleChangeSingle(%+v, %+v)", row, change), func() error { return err })()
 
-	// CORE-6322 this load needs to know if it's public
 	if err = reloadLocal(ctx, g, row, change); err != nil {
 		return err
 	}
@@ -110,7 +108,6 @@ func HandleExitNotification(ctx context.Context, g *libkb.GlobalContext, rows []
 func HandleSBSRequest(ctx context.Context, g *libkb.GlobalContext, msg keybase1.TeamSBSMsg) (err error) {
 	ctx = libkb.WithLogTag(ctx, "CLKR")
 	defer g.CTrace(ctx, "HandleSBSRequest", func() error { return err })()
-	// CORE-6322 this load needs to know if it's public
 	for _, invitee := range msg.Invitees {
 		if err := handleSBSSingle(ctx, g, msg.TeamID, invitee); err != nil {
 			return err
@@ -131,6 +128,7 @@ func handleSBSSingle(ctx context.Context, g *libkb.GlobalContext, teamID keybase
 
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
 		ID:          teamID,
+		Public:      teamID.IsPublic(),
 		ForceRepoll: true,
 	})
 	if err != nil {
@@ -220,9 +218,9 @@ func HandleOpenTeamAccessRequest(ctx context.Context, g *libkb.GlobalContext, ms
 	ctx = libkb.WithLogTag(ctx, "CLKR")
 	defer g.CTrace(ctx, "HandleOpenTeamAccessRequest", func() error { return err })()
 
-	// CORE-6322 this load needs to know if it's public
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
 		ID:          msg.TeamID,
+		Public:      msg.TeamID.IsPublic(),
 		ForceRepoll: true,
 	})
 	if err != nil {

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -65,27 +65,14 @@ func (l *TeamLoader) Load(ctx context.Context, lArg keybase1.LoadTeamArg) (res *
 	return l.load1(ctx, me, lArg)
 }
 
-func (l *TeamLoader) Delete(ctx context.Context, teamID keybase1.TeamID, public bool) (err error) {
-	defer l.G().CTraceTimed(ctx, fmt.Sprintf("TeamLoader#Delete(%v,public:%v)", teamID, public), func() error { return err })()
-
-	// Single-flight lock by team ID.
-	lock := l.locktab.AcquireOnName(ctx, l.G(), teamID.String())
-	defer lock.Release(ctx)
-
-	return l.storage.Delete(ctx, teamID, public)
-}
-
-func (l *TeamLoader) DeleteBoth(ctx context.Context, teamID keybase1.TeamID) (err error) {
+func (l *TeamLoader) Delete(ctx context.Context, teamID keybase1.TeamID) (err error) {
 	defer l.G().CTraceTimed(ctx, fmt.Sprintf("TeamLoader#Delete(%v)", teamID), func() error { return err })()
 
 	// Single-flight lock by team ID.
 	lock := l.locktab.AcquireOnName(ctx, l.G(), teamID.String())
 	defer lock.Release(ctx)
 
-	return libkb.PickFirstError(
-		l.storage.Delete(ctx, teamID, true),
-		l.storage.Delete(ctx, teamID, false),
-	)
+	return l.storage.Delete(ctx, teamID, teamID.IsPublic())
 }
 
 // Load1 unpacks the loadArg, calls load2, and does some final checks.

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -650,6 +650,25 @@ func assertRole(tc libkb.TestContext, name, username string, expected keybase1.T
 	}
 }
 
+func assertRole2(tc libkb.TestContext, teamID keybase1.TeamID, username string, expected keybase1.TeamRole) {
+	team, err := Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
+		ID:          teamID,
+		Public:      teamID.IsPublic(),
+		ForceRepoll: true,
+	})
+	require.NoError(tc.T, err)
+
+	uv, err := loadUserVersionByUsername(context.TODO(), tc.G, username)
+	require.NoError(tc.T, err)
+
+	role, err := team.MemberRole(context.TODO(), uv)
+	require.NoError(tc.T, err)
+
+	if role != expected {
+		tc.T.Fatalf("role: %s, expected %s", role, expected)
+	}
+}
+
 func assertInvite(tc libkb.TestContext, name, username, typ string, role keybase1.TeamRole) {
 	tc.T.Logf("looking for invite for %s/%s w/ role %s in team %s", username, typ, role, name)
 	iname := keybase1.TeamInviteName(username)

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -471,8 +471,7 @@ func Leave(ctx context.Context, g *libkb.GlobalContext, teamname string, permane
 		return err
 	}
 	// Assume this is for the private team
-	public := false
-	err = g.GetTeamLoader().Delete(ctx, t.ID, public)
+	err = g.GetTeamLoader().Delete(ctx, t.ID)
 	if err != nil {
 		g.Log.CDebugf(ctx, "team.Leave: error deleting team cache: %v", err)
 	}


### PR DESCRIPTION
Team IDs now indicate whether the team is public. Use this info in the gregor handlers so they work with public iteams. Haven't decided how to use it for the service things yet. Re-enable some more public iteam tests.

There's been a lot of back and forth on this, but `TestImplicitTeamRotateOnRevokePublic` working is the real forward progress.