### PR TITLE
Refactor team list

### DIFF
--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -150,6 +151,13 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 	if err != nil {
 		return err
 	}
+
+	sort.Slice(list.Teams, func(i, j int) bool {
+		if list.Teams[i].FqName == list.Teams[j].FqName {
+			return list.Teams[i].Username < list.Teams[j].Username
+		}
+		return list.Teams[i].FqName < list.Teams[j].FqName
+	})
 
 	if c.json {
 		b, err := json.MarshalIndent(list, "", "    ")

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -133,7 +133,7 @@ func fillUsernames(ctx context.Context, g *libkb.GlobalContext, res *keybase1.An
 		userList = append(userList, member.UserID)
 	}
 
-	namePkgs, err := g.UIDMapper.MapUIDsToUsernamePackages(ctx, g, userList, 0, 0, false)
+	namePkgs, err := g.UIDMapper.MapUIDsToUsernamePackages(ctx, g, userList, 0, 0, true)
 	if err != nil {
 		return err
 	}
@@ -147,8 +147,6 @@ func fillUsernames(ctx context.Context, g *libkb.GlobalContext, res *keybase1.An
 		if fullName := pkg.FullName; fullName != nil {
 			member.FullName = string(fullName.FullName)
 		}
-
-		fmt.Printf("Full Name %+v\n", pkg)
 	}
 
 	return nil
@@ -281,6 +279,8 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 	err = group.Wait()
 
 	if arg.All {
+		tracer.Stage("FillUsernames")
+
 		err := fillUsernames(ctx, g, res)
 		if err != nil {
 			return nil, err

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -278,7 +278,7 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 
 	err = group.Wait()
 
-	if arg.All {
+	if arg.All && len(res.Teams) != 0 {
 		tracer.Stage("FillUsernames")
 
 		err := fillUsernames(ctx, g, res)

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -54,7 +54,7 @@ func memberNeedAdmin(member keybase1.MemberInfo, meUID keybase1.UID) bool {
 // what team chain says. Nothing is checked when MemberInfo's role is
 // NONE, in this context it means that user has implied membership in
 // the team and no role given in sigchain.
-func verifyMemberRoleInTeam(ctx context.Context, userID keybase1.UserID, expectedRole keybase1.TeamRole, team *Team) error {
+func verifyMemberRoleInTeam(ctx context.Context, userID keybase1.UID, expectedRole keybase1.TeamRole, team *Team) error {
 	if expectedRole == keybase1.TeamRole_NONE {
 		return nil
 	}
@@ -261,7 +261,7 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 			if serverSaysNeedAdmin {
 				anInvites, err = AnnotateInvites(subctx, g, team.chain().inner.ActiveInvites, team.Name().String())
 				if err != nil {
-					g.Log.CDebugf(subctx, "| Failed to AnnotateInvites for team %q: %v", teamID, err)
+					g.Log.CDebugf(subctx, "| Failed to AnnotateInvites for team %q: %v", team.ID, err)
 					return nil
 				}
 			}

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -236,8 +236,8 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 			serverSaysNeedAdmin := memberNeedAdmin(memberInfo, meUID)
 			team, err := getTeamForMember(subctx, g, memberInfo, serverSaysNeedAdmin)
 			if err != nil {
-				g.Log.CDebugf(subctx, "| Error in getTeamForMember: %v", err)
-				return err
+				g.Log.CDebugf(subctx, "| Error in getTeamForMember %q: %v; skipping member", memberInfo.UserID, err)
+				return nil
 			}
 
 			type AnnotatedTeamInviteMap map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite
@@ -261,7 +261,8 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 			if serverSaysNeedAdmin {
 				anInvites, err = AnnotateInvites(subctx, g, team.chain().inner.ActiveInvites, team.Name().String())
 				if err != nil {
-					return err
+					g.Log.CDebugf(subctx, "| Failed to AnnotateInvites for team %q: %v", teamID, err)
+					return nil
 				}
 			}
 

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -144,8 +144,8 @@ func fillUsernames(ctx context.Context, g *libkb.GlobalContext, res *keybase1.An
 		pkg := namePkgs[num]
 
 		member.Username = pkg.NormalizedUsername.String()
-		if fullName := pkg.FullName; fullName != nil {
-			member.FullName = string(fullName.FullName)
+		if pkg.FullName != nil {
+			member.FullName = string(pkg.FullName.FullName)
 		}
 	}
 

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -299,7 +299,7 @@ func (u *UIDMap) MapUIDsToUsernamePackages(ctx context.Context, g libkb.UIDMappe
 		//
 		// Thus, if you provide forceNetworkForFullName=false, and fullNameFreshness=0, you can avoid
 		// the network trip as long as all of your username lookups hit the cache or are hardcoded.
-		if up == nil || (status == notFound && forceNetworkForFullNames) || (status == stale) {
+		if up == nil || ((status == notFound || up.FullName == nil) && forceNetworkForFullNames) || (status == stale) {
 			apiLookupIndex[len(uidsToLookup)] = i
 			uidsToLookup = append(uidsToLookup, uid)
 		}

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -299,7 +299,7 @@ func (u *UIDMap) MapUIDsToUsernamePackages(ctx context.Context, g libkb.UIDMappe
 		//
 		// Thus, if you provide forceNetworkForFullName=false, and fullNameFreshness=0, you can avoid
 		// the network trip as long as all of your username lookups hit the cache or are hardcoded.
-		if up == nil || ((status == notFound || up.FullName == nil) && forceNetworkForFullNames) || (status == stale) {
+		if up == nil || (status == notFound && forceNetworkForFullNames) || (status == stale) {
 			apiLookupIndex[len(uidsToLookup)] = i
 			uidsToLookup = append(uidsToLookup, uid)
 		}


### PR DESCRIPTION
Right now it will still load team multiple times when running in `--all` mode. This is hard to get away from because of the "load team and retry with repoll if we can't find member in it" mechanism and the fact that team loads happen concurrently. My attempts at making a team cache (in front of loader cache) did not have any significant impact. Also, the common case of just getting the teams current user is in is fast enough with warm caches. There will be another ticket for simpler version of it that frontend can benefit from (we can skip loading invites for frontend).

This PR introduces code cleanup when some of the functionality is moved to separate function, so indentation level has been dropped by one in `List` function. It also loads username/fullname only once if running in `keybase team list-members` or ``keybase team list-members -u username` mode.

It also adds list sorting on cli side, similar to what front-end does on its side already.