### PR TITLE
Fix white screens on deletions from inbox

### DIFF
--- a/shared/chat/inbox/row/container.js
+++ b/shared/chat/inbox/row/container.js
@@ -117,7 +117,7 @@ const makeSelector = conversationIDKey => {
         finalizeInfo
       ) => {
         if (!conversation) {
-          return
+          return {type: 'Invalid row'}
         }
         const isError = conversation.get('state') === 'error'
         const isMuted = conversation.get('status') === 'muted'
@@ -175,6 +175,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
 const ConnectedRow = compose(
   // $FlowIssue
   pausableConnect(mapStateToProps, mapDispatchToProps, mergeProps),
+  branch(props => props.type === 'Invalid row', renderNothing),
   branch(
     ({participants, type}) => isSmallOrBig(type) && (!participants || participants.isEmpty() === 0),
     renderNothing

--- a/shared/chat/inbox/row/container.js
+++ b/shared/chat/inbox/row/container.js
@@ -116,6 +116,9 @@ const makeSelector = conversationIDKey => {
         nowOverride,
         finalizeInfo
       ) => {
+        if (!conversation) {
+          return
+        }
         const isError = conversation.get('state') === 'error'
         const isMuted = conversation.get('status') === 'muted'
         const participants = Constants.participantFilter(conversation.get('participants'), you)


### PR DESCRIPTION
@keybase/react-hackers 

This probably isn't the correct fix, but it appears to fix the white screen crashes any time a row is removed from your inbox (due to you blocking a channel, leaving a channel, deleting a channel, deleting a team, being removed from a team, etc).