### PR TITLE
define exportable RepoDoesntExistError

### DIFF
--- a/go/git/delete.go
+++ b/go/git/delete.go
@@ -43,7 +43,12 @@ func DeleteMetadata(ctx context.Context, g *libkb.GlobalContext, folder keybase1
 	}
 	_, err = g.GetAPI().Post(apiArg)
 	if err != nil {
-		return err
+		switch err.(type) {
+		case libkb.RepoDoesntExistError:
+			g.Log.Warning("Git repo doesn't exist. Deleting metadata anyway.")
+		default:
+			return err
+		}
 	}
 
 	g.NotifyRouter.HandleRepoDeleted(ctx, folder, teamIDVis.TeamID, repoID, formatUniqueRepoID(teamIDVis.TeamID, repoID))

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -273,6 +273,7 @@ const (
 	SCGitRepoAlreadyExists     = int(keybase1.StatusCode_SCGitRepoAlreadyExists)
 	SCGitInvalidRepoName       = int(keybase1.StatusCode_SCGitInvalidRepoName)
 	SCGitCannotDelete          = int(keybase1.StatusCode_SCGitCannotDelete)
+	SCGitRepoDoesntExist       = int(keybase1.StatusCode_SCGitRepoDoesntExist)
 	SCTeamBanned               = int(keybase1.StatusCode_SCTeamBanned)
 	SCTeamInvalidBan           = int(keybase1.StatusCode_SCTeamInvalidBan)
 )

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2166,6 +2166,17 @@ func (e RepoAlreadyExistsError) Error() string {
 
 //=============================================================================
 
+// RepoDoesntExistError is returned when trying to delete a repo that doesn't exist.
+type RepoDoesntExistError struct {
+	Name string
+}
+
+func (e RepoDoesntExistError) Error() string {
+	return fmt.Sprintf("There is no repo named %q.", e.Name)
+}
+
+//=============================================================================
+
 // NoOpError is returned when an RPC call is issued but it would
 // result in no change, so the call is dropped.
 type NoOpError struct {

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -640,6 +640,15 @@ func ImportStatusAsError(g *GlobalContext, s *keybase1.Status) error {
 			}
 		}
 		return e
+	case SCGitRepoDoesntExist:
+		e := RepoDoesntExistError{}
+		for _, field := range s.Fields {
+			switch field.Key {
+			case "Name":
+				e.Name = field.Value
+			}
+		}
+		return e
 	case SCNoOp:
 		return NoOpError{Desc: s.Desc}
 	default:
@@ -2128,6 +2137,16 @@ func (e RepoAlreadyExistsError) ToStatus() (s keybase1.Status) {
 		{Key: "DesiredName", Value: e.DesiredName},
 		{Key: "ExistingName", Value: e.ExistingName},
 		{Key: "ExistingID", Value: e.ExistingID},
+	}
+	return
+}
+
+func (e RepoDoesntExistError) ToStatus() (s keybase1.Status) {
+	s.Code = int(keybase1.StatusCode_SCGitRepoDoesntExist)
+	s.Name = "GIT_REPO_DOESNT_EXIST"
+	s.Desc = e.Error()
+	s.Fields = []keybase1.StringKVPair{
+		{Key: "Name", Value: e.Name},
 	}
 	return
 }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -95,6 +95,7 @@ const (
 	StatusCode_SCGitRepoAlreadyExists      StatusCode = 2301
 	StatusCode_SCGitInvalidRepoName        StatusCode = 2302
 	StatusCode_SCGitCannotDelete           StatusCode = 2303
+	StatusCode_SCGitRepoDoesntExist        StatusCode = 2304
 	StatusCode_SCLoginStateTimeout         StatusCode = 2400
 	StatusCode_SCChatInternal              StatusCode = 2500
 	StatusCode_SCChatRateLimit             StatusCode = 2501
@@ -237,6 +238,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCGitRepoAlreadyExists":      2301,
 	"SCGitInvalidRepoName":        2302,
 	"SCGitCannotDelete":           2303,
+	"SCGitRepoDoesntExist":        2304,
 	"SCLoginStateTimeout":         2400,
 	"SCChatInternal":              2500,
 	"SCChatRateLimit":             2501,
@@ -377,6 +379,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2301: "SCGitRepoAlreadyExists",
 	2302: "SCGitInvalidRepoName",
 	2303: "SCGitCannotDelete",
+	2304: "SCGitRepoDoesntExist",
 	2400: "SCLoginStateTimeout",
 	2500: "SCChatInternal",
 	2501: "SCChatRateLimit",

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -87,6 +87,7 @@ protocol constants {
     SCGitRepoAlreadyExists_2301,
     SCGitInvalidRepoName_2302,
     SCGitCannotDelete_2303,
+    SCGitRepoDoesntExist_2304,
     SCLoginStateTimeout_2400,
     SCChatInternal_2500,
     SCChatRateLimit_2501,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -219,6 +219,7 @@ export const ConstantsStatusCode = {
   scgitrepoalreadyexists: 2301,
   scgitinvalidreponame: 2302,
   scgitcannotdelete: 2303,
+  scgitrepodoesntexist: 2304,
   scloginstatetimeout: 2400,
   scchatinternal: 2500,
   scchatratelimit: 2501,
@@ -4677,6 +4678,7 @@ export type StatusCode =
   | 2301 // SCGitRepoAlreadyExists_2301
   | 2302 // SCGitInvalidRepoName_2302
   | 2303 // SCGitCannotDelete_2303
+  | 2304 // SCGitRepoDoesntExist_2304
   | 2400 // SCLoginStateTimeout_2400
   | 2500 // SCChatInternal_2500
   | 2501 // SCChatRateLimit_2501

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -91,6 +91,7 @@
         "SCGitRepoAlreadyExists_2301",
         "SCGitInvalidRepoName_2302",
         "SCGitCannotDelete_2303",
+        "SCGitRepoDoesntExist_2304",
         "SCLoginStateTimeout_2400",
         "SCChatInternal_2500",
         "SCChatRateLimit_2501",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -219,6 +219,7 @@ export const ConstantsStatusCode = {
   scgitrepoalreadyexists: 2301,
   scgitinvalidreponame: 2302,
   scgitcannotdelete: 2303,
+  scgitrepodoesntexist: 2304,
   scloginstatetimeout: 2400,
   scchatinternal: 2500,
   scchatratelimit: 2501,
@@ -4677,6 +4678,7 @@ export type StatusCode =
   | 2301 // SCGitRepoAlreadyExists_2301
   | 2302 // SCGitInvalidRepoName_2302
   | 2303 // SCGitCannotDelete_2303
+  | 2304 // SCGitRepoDoesntExist_2304
   | 2400 // SCLoginStateTimeout_2400
   | 2500 // SCChatInternal_2500
   | 2501 // SCChatRateLimit_2501


### PR DESCRIPTION
r? @maxtaco 

After this gets vendored into KBFS, we'll use the error type there, and then add handling for that specific case in `keybase git delete`.