### PR TITLE
Add another license hash

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -47,6 +47,7 @@ dependencies:
     - mkdir -p /usr/local/android-sdk-linux/licenses
     - if [[ ! -e "$ANDROID_HOME/ndk-bundle" ]]; then wget -nv http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip -O android-ndk-r11c-linux-x86_64.zip && unzip -o android-ndk-r11c-linux-x86_64.zip -d "$ANDROID_HOME" && mv "$ANDROID_HOME/android-ndk-r11c" "$ANDROID_HOME/ndk-bundle"; fi
     - echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > /usr/local/android-sdk-linux/licenses/android-sdk-license
+    - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" >> /usr/local/android-sdk-linux/licenses/android-sdk-license
     # Install Yarn
   cache_directories:
     - ~/downloads


### PR DESCRIPTION
@keybase/react-hackers This should fix an issue where we need a new license hash because we are downloading a newer sdk tool