### PR TITLE
Load public teams more places

### DIFF
--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -144,9 +144,9 @@ func (k *KeyFinderImpl) FindForDecryption(ctx context.Context,
 		}
 		team, err := teams.Load(ctx, k.G().ExternalG(), keybase1.LoadTeamArg{
 			ID:         teamID,
+			Public:     public,
 			Refreshers: refreshers,
 			StaleOK:    true,
-			Public:     public,
 		})
 		if err != nil {
 			return res, err

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -31,6 +31,7 @@ func (t *TeamsNameInfoSource) Lookup(ctx context.Context, name string, vis keyba
 
 	team, err := teams.Load(ctx, t.G().ExternalG(), keybase1.LoadTeamArg{
 		Name:        name, // Loading by name is a last resort and will always cause an extra roundtrip.
+		Public:      vis == keybase1.TLFVisibility_PUBLIC,
 		ForceRepoll: true,
 	})
 	if err != nil {
@@ -102,7 +103,10 @@ func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, v
 		return res, err
 	}
 	if vis == keybase1.TLFVisibility_PRIVATE {
-		team, err := teams.Load(ctx, t.G().ExternalG(), keybase1.LoadTeamArg{ID: teamID})
+		team, err := teams.Load(ctx, t.G().ExternalG(), keybase1.LoadTeamArg{
+			ID:     teamID,
+			Public: false,
+		})
 		if err != nil {
 			return res, err
 		}
@@ -167,7 +171,8 @@ func (t *ImplicitTeamsNameInfoSource) lookupInternalName(ctx context.Context, na
 	res.CanonicalName = name
 	if public {
 		team, err := teams.Load(ctx, t.G().ExternalG(), keybase1.LoadTeamArg{
-			Name: name,
+			Name:   name,
+			Public: public,
 		})
 		if err != nil {
 			return res, err

--- a/go/git/teamer.go
+++ b/go/git/teamer.go
@@ -53,6 +53,7 @@ func (t *TeamerImpl) lookupTeam(ctx context.Context, folder keybase1.Folder) (re
 	}
 	team, err := teams.Load(ctx, t.G(), keybase1.LoadTeamArg{
 		Name:        folder.Name,
+		Public:      !folder.Private,
 		ForceRepoll: false, // if subteams get renamed in a racy way, just let this fail
 	})
 	if err != nil {

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1066,24 +1066,24 @@ func (o TeamRefreshers) DeepCopy() TeamRefreshers {
 type LoadTeamArg struct {
 	ID              TeamID         `codec:"ID" json:"ID"`
 	Name            string         `codec:"name" json:"name"`
+	Public          bool           `codec:"public" json:"public"`
 	NeedAdmin       bool           `codec:"needAdmin" json:"needAdmin"`
 	Refreshers      TeamRefreshers `codec:"refreshers" json:"refreshers"`
 	ForceFullReload bool           `codec:"forceFullReload" json:"forceFullReload"`
 	ForceRepoll     bool           `codec:"forceRepoll" json:"forceRepoll"`
 	StaleOK         bool           `codec:"staleOK" json:"staleOK"`
-	Public          bool           `codec:"public" json:"public"`
 }
 
 func (o LoadTeamArg) DeepCopy() LoadTeamArg {
 	return LoadTeamArg{
 		ID:              o.ID.DeepCopy(),
 		Name:            o.Name,
+		Public:          o.Public,
 		NeedAdmin:       o.NeedAdmin,
 		Refreshers:      o.Refreshers.DeepCopy(),
 		ForceFullReload: o.ForceFullReload,
 		ForceRepoll:     o.ForceRepoll,
 		StaleOK:         o.StaleOK,
-		Public:          o.Public,
 	}
 }
 

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -228,6 +228,7 @@ func (h *IdentifyHandler) resolveIdentifyImplicitTeamHelper(ctx context.Context,
 
 	team, err := teams.Load(ctx, h.G(), keybase1.LoadTeamArg{
 		ID:          teamID,
+		Public:      arg.IsPublic,
 		ForceRepoll: true,
 	})
 	if err != nil {

--- a/go/systests/standalone_test.go
+++ b/go/systests/standalone_test.go
@@ -78,7 +78,7 @@ func TestStandaloneTeamMemberOps(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check if adding worked
-	t0, err := teams.GetForTeamManagementByStringName(context.TODO(), g, team, true)
+	t0, err := teams.GetTeamByNameForTest(context.TODO(), t, g, team, false, true)
 	require.NoError(t, err)
 	writers, err := t0.UsersWithRole(keybase1.TeamRole_WRITER)
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestStandaloneTeamMemberOps(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check if removal worked
-	t0, err = teams.GetForTeamManagementByStringName(context.TODO(), g, team, true)
+	t0, err = teams.GetTeamByNameForTest(context.TODO(), t, g, team, false, true)
 	require.NoError(t, err)
 	writers, err = t0.UsersWithRole(keybase1.TeamRole_WRITER)
 	require.NoError(t, err)

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -40,7 +40,7 @@ func TestTeamInviteRooter(t *testing.T) {
 	tt.users[1].waitForTeamChangedGregor(team, keybase1.Seqno(3))
 
 	// the team should have user 1 in it now as a writer
-	t0, err := teams.GetForTeamManagementByStringName(context.TODO(), tt.users[0].tc.G, team, true)
+	t0, err := teams.GetTeamByNameForTest(context.TODO(), t, tt.users[0].tc.G, team, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestTeamInviteEmail(t *testing.T) {
 	tt.users[1].waitForTeamChangedGregor(team, keybase1.Seqno(3))
 
 	// the team should have user 1 in it now as a writer
-	t0, err := teams.GetForTeamManagementByStringName(context.TODO(), tt.users[0].tc.G, team, true)
+	t0, err := teams.GetTeamByNameForTest(context.TODO(), t, tt.users[0].tc.G, team, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestTeamInviteAcceptOrRequest(t *testing.T) {
 	tt.users[1].waitForTeamChangedGregor(team, keybase1.Seqno(3))
 
 	// the team should have user 1 in it now as a writer
-	t0, err := teams.GetForTeamManagementByStringName(context.TODO(), tt.users[0].tc.G, team, true)
+	t0, err := teams.GetTeamByNameForTest(context.TODO(), t, tt.users[0].tc.G, team, false, true)
 	require.NoError(t, err)
 	writers, err := t0.UsersWithRole(keybase1.TeamRole_WRITER)
 	require.NoError(t, err)
@@ -408,7 +408,7 @@ func TestClearSocialInvitesOnAdd(t *testing.T) {
 	// member instead of making an invitation.
 	ann.addTeamMember(team, bob.username+"@rooter", keybase1.TeamRole_WRITER)
 
-	t0, err := teams.GetForTeamManagementByStringName(context.TODO(), ann.tc.G, team, true)
+	t0, err := teams.GetTeamByNameForTest(context.TODO(), t, ann.tc.G, team, false, true)
 	require.NoError(t, err)
 
 	writers, err := t0.UsersWithRole(keybase1.TeamRole_WRITER)

--- a/go/teams/delete_test.go
+++ b/go/teams/delete_test.go
@@ -21,7 +21,7 @@ func TestDeleteRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := GetForTeamManagementByStringName(context.Background(), tc.G, teamname, false)
+	_, err := GetTeamByNameForTest(context.Background(), t, tc.G, teamname, false, false)
 	require.Error(t, err, "no error getting deleted team")
 	require.IsType(t, TeamDoesNotExistError{}, err)
 }
@@ -50,7 +50,7 @@ func TestDeleteSubteamAdmin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = GetForTeamManagementByStringName(context.Background(), tc.G, sub, false)
+	_, err = GetTeamByNameForTest(context.Background(), t, tc.G, sub, false, false)
 	if err == nil {
 		t.Fatal("no error getting deleted team")
 	}
@@ -82,7 +82,7 @@ func TestDeleteSubteamImpliedAdmin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := GetForTeamManagementByStringName(context.Background(), tc.G, sub, false)
+	_, err := GetTeamByNameForTest(context.Background(), t, tc.G, sub, false, false)
 	if err == nil {
 		t.Fatal("no error getting deleted team")
 	}

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -45,37 +45,31 @@ func GetForTeamManagementByStringName(ctx context.Context, g *libkb.GlobalContex
 
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
 		Name:        name,
+		Public:      public,
 		ForceRepoll: true,
 		NeedAdmin:   needAdmin,
-		Public:      public,
 	})
 
 	return team, fixupTeamGetError(ctx, g, err, name, public)
 }
 
 func GetForTeamManagementByTeamID(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID, needAdmin bool) (*Team, error) {
-	// CORE-6322 find out if this is for a public team
-	public := false
-
 	return Load(ctx, g, keybase1.LoadTeamArg{
 		ID:          id,
+		Public:      id.IsPublic(), // infer publicness from team id
 		ForceRepoll: true,
 		NeedAdmin:   needAdmin,
-		Public:      public,
 	})
 }
 
 // Get a team with no stubbed links if we are an admin. Use this instead of NeedAdmin when you don't
 // know whether you are an admin. This always causes roundtrips. Doesn't work for implicit admins.
-func GetMaybeAdminByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*Team, error) {
-	// CORE-6322 find out if this is for a public team
-	public := false
-
+func GetMaybeAdminByStringName(ctx context.Context, g *libkb.GlobalContext, name string, public bool) (*Team, error) {
 	// Find out our up-to-date role.
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
 		Name:        name,
-		ForceRepoll: true,
 		Public:      public,
+		ForceRepoll: true,
 	})
 	if err != nil {
 		return nil, fixupTeamGetError(ctx, g, err, name, public)
@@ -93,6 +87,7 @@ func GetMaybeAdminByStringName(ctx context.Context, g *libkb.GlobalContext, name
 		// and are now an admin.
 		team, err = Load(ctx, g, keybase1.LoadTeamArg{
 			Name:      name,
+			Public:    public,
 			NeedAdmin: true,
 		})
 		if err != nil {

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -157,7 +157,7 @@ func TestGetMaybeAdminByStringName(t *testing.T) {
 	require.Equal(t, 0, len(team.chain().inner.SubteamLog), "still doesn't know about any subteams")
 
 	t.Logf("U1 loads and realizes they're an admin")
-	team, err = GetMaybeAdminByStringName(context.TODO(), tcs[1].G, teamName.String())
+	team, err = GetMaybeAdminByStringName(context.TODO(), tcs[1].G, teamName.String(), false /*isPublic*/)
 	require.NoError(t, err)
 	role, err = team.MemberRole(context.TODO(), fus[1].GetUserVersion())
 	require.NoError(t, err)

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -117,8 +117,8 @@ func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	}
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
 		ID:          imp.TeamID,
-		ForceRepoll: true,
 		Public:      impTeamName.IsPublic,
+		ForceRepoll: true,
 	})
 	if err != nil {
 		return teamID, teamName, impTeamName, conflicts, err

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -835,7 +835,8 @@ func (l *TeamLoader) VerifyTeamName(ctx context.Context, id keybase1.TeamID, nam
 		return nil
 	}
 	teamData, err := l.Load(ctx, keybase1.LoadTeamArg{
-		ID: id,
+		ID:     id,
+		Public: id.IsPublic(),
 	})
 	if err != nil {
 		return err
@@ -860,6 +861,7 @@ func (l *TeamLoader) ImplicitAdmins(ctx context.Context, teamID keybase1.TeamID)
 	// Load the argument team
 	team, err := l.load1(ctx, me, keybase1.LoadTeamArg{
 		ID:      teamID,
+		Public:  teamID.IsPublic(),
 		StaleOK: true, // We only use immutable fields.
 	})
 	if err != nil {

--- a/go/teams/rpc_exim.go
+++ b/go/teams/rpc_exim.go
@@ -33,7 +33,7 @@ func (t *Team) ExportToTeamPlusApplicationKeys(ctx context.Context, idTime keyba
 	ret = keybase1.TeamPlusApplicationKeys{
 		Id:              t.chain().GetID(),
 		Name:            t.Name().String(),
-		Implicit:        t.chain().IsImplicit(),
+		Implicit:        t.IsImplicit(),
 		Public:          t.IsPublic(),
 		Application:     application,
 		Writers:         writers,

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -40,8 +40,11 @@ func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepo
 	tracer := g.CTimeTracer(ctx, "TeamDetails")
 	defer tracer.Finish()
 
+	// Assume private team
+	public := false
+
 	tracer.Stage("load team")
-	t, err := GetMaybeAdminByStringName(ctx, g, name)
+	t, err := GetMaybeAdminByStringName(ctx, g, name, public)
 	if err != nil {
 		return res, err
 	}
@@ -739,6 +742,7 @@ func apiArg(ctx context.Context, endpoint string) libkb.APIArg {
 func GetRootID(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (keybase1.TeamID, error) {
 	team, err := g.GetTeamLoader().Load(ctx, keybase1.LoadTeamArg{
 		ID:      id,
+		Public:  id.IsPublic(),
 		StaleOK: true,
 	})
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -356,11 +356,14 @@ protocol teams {
 
   record LoadTeamArg {
     // One of these must be specified.
-    // ID is preferred. Name will always hit the server.
+    // ID is preferred. Name will always hit the server for subteams.
     // If both are specified ID will be used and Name will be checked.
     @lint("ignore")
     TeamID ID;
     string name;
+
+    // Whether to load a public or private team.
+    boolean public;
 
     // Whether we need to be an admin.
     // Will fail unless we are an admin in the returned Team.
@@ -373,7 +376,6 @@ protocol teams {
     boolean forceFullReload;      // Ignore local data and fetch from the server.
     boolean forceRepoll;          // Force a sync with merkle.
     boolean staleOK;              // If a very stale cache hit is OK.
-    boolean public;               // For public teams.
   }
 
   record ImplicitRole {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3672,12 +3672,12 @@ export type LoadDeviceErr = {
 export type LoadTeamArg = {
   ID: TeamID,
   name: string,
+  public: boolean,
   needAdmin: boolean,
   refreshers: TeamRefreshers,
   forceFullReload: boolean,
   forceRepoll: boolean,
   staleOK: boolean,
-  public: boolean,
 }
 
 export type LockContext = {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -889,6 +889,10 @@
         },
         {
           "type": "boolean",
+          "name": "public"
+        },
+        {
+          "type": "boolean",
           "name": "needAdmin"
         },
         {
@@ -906,10 +910,6 @@
         {
           "type": "boolean",
           "name": "staleOK"
-        },
-        {
-          "type": "boolean",
-          "name": "public"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3672,12 +3672,12 @@ export type LoadDeviceErr = {
 export type LoadTeamArg = {
   ID: TeamID,
   name: string,
+  public: boolean,
   needAdmin: boolean,
   refreshers: TeamRefreshers,
   forceFullReload: boolean,
   forceRepoll: boolean,
   staleOK: boolean,
-  public: boolean,
 }
 
 export type LockContext = {


### PR DESCRIPTION
Plumb through `public` for loading teams. I did a scan through all `LoadTeamArg`s and did what made sense to me. Sometimes that was plumbing a `public` bool around, sometimes inferring the publicness from the ID suffix.

For the RPCs that only use the team name (like `TeamGet`, `TeamRemoveMember`, etc), I left them like this:
- private normal team: Works
- public normal team: Error out (these don't exist)
- private implicit team: Error out (this could work, but I disabled it so that we don't paint ourselves into a corner of not supporting public iteams)
- public implicit team: Error out (need publicness bool but not available in rpc interface)
Technically we could figure out publicness from the name but I think it would be a mistake. Better to rework the interfaces to use IDs in my opinion.