### PR TITLE
load full names when localizing conversations, and hook up frontend to use them CORE-6254

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/storage"
@@ -1165,7 +1166,8 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		}
 
 		conversationLocal.Info.ResetNames = s.getResetUserNames(ctx, s.G().UIDMapper, conversationRemote)
-		rows, err := s.G().UIDMapper.MapUIDsToUsernamePackages(ctx, s.G(), kuids, 0, 0, false)
+		rows, err := s.G().UIDMapper.MapUIDsToUsernamePackages(ctx, s.G(), kuids, time.Hour*24,
+			10*time.Second, true)
 		if err != nil {
 			s.Debug(ctx, "localizeConversation: UIDMapper returned an error: %s", err)
 		}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -17,6 +17,8 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
+	"github.com/keybase/client/go/uidmap"
 	context "golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
@@ -931,10 +933,13 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 	// Pick a source of usernames based on offline status, if we are offline then just use a
 	// type that just returns errors all the time (this will just use TLF name as the ordering)
 	var uloader utils.ReorderUsernameSource
+	var umapper libkb.UIDMapper
 	if s.offline {
 		uloader = nullUsernameSource{}
+		umapper = &uidmap.OfflineUIDMap{}
 	} else {
 		uloader = s.G().GetUPAKLoader()
+		umapper = s.G().UIDMapper
 	}
 
 	unverifiedTLFName := getUnverifiedTlfNameForErrors(conversationRemote)
@@ -1162,29 +1167,26 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 
 		conversationLocal.Info.ResetNames = s.getResetUserNames(ctx, s.G().UIDMapper, conversationRemote)
 		rows, err := s.G().UIDMapper.MapUIDsToUsernamePackages(ctx, s.G(), kuids, 0, 0, false)
-		unames := make([]libkb.NormalizedUsername, len(rows), len(rows))
-		for i, row := range rows {
-			unames[i] = row.NormalizedUsername
+		if err != nil {
+			s.Debug(ctx, "localizeConversation: UIDMapper returned an error: %s", err)
 		}
+		for _, row := range rows {
+			conversationLocal.Info.Participants = append(conversationLocal.Info.Participants,
+				utils.UsernamePackageToParticipant(row))
+		}
+		// Sort alphabetically
+		sort.Slice(conversationLocal.Info.Participants, func(i, j int) bool {
+			return conversationLocal.Info.Participants[i].Username <
+				conversationLocal.Info.Participants[j].Username
+		})
 
-		if err == nil {
-			for _, uname := range unames {
-				conversationLocal.Info.WriterNames = append(conversationLocal.Info.WriterNames,
-					uname.String())
-			}
-			// Sort alphabetically
-			sort.Slice(conversationLocal.Info.WriterNames, func(i, j int) bool {
-				return conversationLocal.Info.WriterNames[i] < conversationLocal.Info.WriterNames[j]
-			})
-		} else {
-			// If we are offline, we just won't know who is in the channel
-			s.Debug(ctx, "localizeConversation: failed to get team channel usernames: %s", err)
-		}
 	case chat1.ConversationMembersType_KBFS:
 		var err error
-		conversationLocal.Info.WriterNames, conversationLocal.Info.ReaderNames, err = utils.ReorderParticipants(
+		conversationLocal.Info.Participants, err = utils.ReorderParticipants(
 			ctx,
+			s.G(),
 			uloader,
+			umapper,
 			conversationLocal.Info.TlfName,
 			conversationRemote.Metadata.ActiveList)
 		if err != nil {
@@ -1257,16 +1259,21 @@ func (s *localizerPipeline) checkRekeyErrorInner(ctx context.Context, fromErr er
 	rekeyInfo.TlfPublic = conversationRemote.MaxMsgSummaries[0].TlfPublic
 
 	// Fill readers and writers
-	writerNames, readerNames, err := utils.ReorderParticipants(
+	parts, err := utils.ReorderParticipants(
 		ctx,
+		s.G(),
 		s.G().GetUPAKLoader(),
+		s.G().UIDMapper,
 		rekeyInfo.TlfName,
 		conversationRemote.Metadata.ActiveList)
 	if err != nil {
 		return nil, err
 	}
+	var writerNames []string
+	for _, p := range parts {
+		writerNames = append(writerNames, p.Username)
+	}
 	rekeyInfo.WriterNames = writerNames
-	rekeyInfo.ReaderNames = readerNames
 
 	// Fill rekeyers list
 	myUsername := string(s.G().Env.GetUsername())

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -1252,7 +1252,6 @@ func (s *localizerPipeline) checkRekeyErrorInner(ctx context.Context, fromErr er
 	parts, err := utils.ReorderParticipants(
 		ctx,
 		s.G(),
-		s.G().GetUPAKLoader(),
 		s.G().UIDMapper,
 		rekeyInfo.TlfName,
 		conversationRemote.Metadata.ActiveList)

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -4,9 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-
-	"github.com/keybase/client/go/teams"
-
 	"strings"
 
 	"github.com/keybase/client/go/chat/globals"
@@ -1146,9 +1143,11 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		}
 		if ok {
 			conversationLocal.Info.ResetNames = s.getResetUserNames(ctx, s.G().UIDMapper, conversationRemote)
-			conversationLocal.Info.WriterNames, conversationLocal.Info.ReaderNames, err = utils.ReorderParticipants(
+			conversationLocal.Info.Participants, err = utils.ReorderParticipants(
 				ctx,
+				s.G(),
 				uloader,
+				umapper,
 				iteamName,
 				conversationRemote.Metadata.ActiveList)
 			if err != nil {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3089,7 +3089,7 @@ func TestChatSrvUserReset(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(iboxRes.Conversations))
 		require.Equal(t, conv.Id, iboxRes.Conversations[0].GetConvID())
-		require.Equal(t, 2, len(iboxRes.Conversations[0].Info.WriterNames))
+		require.Equal(t, 2, len(iboxRes.Conversations[0].Names()))
 		require.Equal(t, 1, len(iboxRes.Conversations[0].Info.ResetNames))
 		require.Equal(t, users[1].Username, iboxRes.Conversations[0].Info.ResetNames[0])
 
@@ -3131,7 +3131,7 @@ func TestChatSrvUserReset(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(iboxRes.Conversations))
 		require.Equal(t, conv.Id, iboxRes.Conversations[0].GetConvID())
-		require.Equal(t, 2, len(iboxRes.Conversations[0].Info.WriterNames))
+		require.Equal(t, 2, len(iboxRes.Conversations[0].Names()))
 		require.Zero(t, len(iboxRes.Conversations[0].Info.ResetNames))
 
 		iboxRes, err = ctc.as(t, users[1]).chatLocalHandler().GetInboxAndUnboxLocal(ctx,
@@ -3139,7 +3139,7 @@ func TestChatSrvUserReset(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(iboxRes.Conversations))
 		require.Equal(t, conv.Id, iboxRes.Conversations[0].GetConvID())
-		require.Equal(t, 2, len(iboxRes.Conversations[0].Info.WriterNames))
+		require.Equal(t, 2, len(iboxRes.Conversations[0].Names()))
 		require.Zero(t, len(iboxRes.Conversations[0].Info.ResetNames))
 		require.Equal(t, chat1.ConversationMemberStatus_ACTIVE, iboxRes.Conversations[0].Info.MemberStatus)
 

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -265,7 +265,7 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, convs []chat1.Conversati
 				TopicName:         utils.GetTopicName(convLocal),
 				Headline:          utils.GetHeadline(convLocal),
 				Snippet:           utils.GetConvSnippet(convLocal),
-				Participants:      convLocal.Info.Participants,
+				WriterNames:       convLocal.Info.WriterNames(),
 				ResetParticipants: convLocal.Info.ResetNames,
 			}
 		}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -265,7 +265,7 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, convs []chat1.Conversati
 				TopicName:         utils.GetTopicName(convLocal),
 				Headline:          utils.GetHeadline(convLocal),
 				Snippet:           utils.GetConvSnippet(convLocal),
-				WriterNames:       convLocal.Info.WriterNames(),
+				WriterNames:       convLocal.Names(),
 				ResetParticipants: convLocal.Info.ResetNames,
 			}
 		}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const inboxVersion = 15
+const inboxVersion = 16
 
 type queryHash []byte
 
@@ -265,7 +265,7 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, convs []chat1.Conversati
 				TopicName:         utils.GetTopicName(convLocal),
 				Headline:          utils.GetHeadline(convLocal),
 				Snippet:           utils.GetConvSnippet(convLocal),
-				WriterNames:       convLocal.Info.WriterNames,
+				Participants:      convLocal.Info.Participants,
 				ResetParticipants: convLocal.Info.ResetNames,
 			}
 		}

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -36,11 +36,11 @@ type MembershipUpdateRes struct {
 }
 
 type RemoteConversationMetadata struct {
-	TopicName         string                               `codec:"t"`
-	Snippet           string                               `codec:"s"`
-	Headline          string                               `codec:"h"`
-	Participants      []chat1.ConversationLocalParticipant `codec:"p"`
-	ResetParticipants []string                             `codec:"r"`
+	TopicName         string   `codec:"t"`
+	Snippet           string   `codec:"s"`
+	Headline          string   `codec:"h"`
+	WriterNames       []string `codec:"w"`
+	ResetParticipants []string `codec:"r"`
 }
 
 type RemoteConversation struct {

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -36,11 +36,11 @@ type MembershipUpdateRes struct {
 }
 
 type RemoteConversationMetadata struct {
-	TopicName         string   `codec:"t"`
-	Snippet           string   `codec:"s"`
-	Headline          string   `codec:"h"`
-	WriterNames       []string `codec:"w"`
-	ResetParticipants []string `codec:"r"`
+	TopicName         string                               `codec:"t"`
+	Snippet           string                               `codec:"s"`
+	Headline          string                               `codec:"h"`
+	Participants      []chat1.ConversationLocalParticipant `codec:"p"`
+	ResetParticipants []string                             `codec:"r"`
 }
 
 type RemoteConversation struct {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -111,13 +111,25 @@ type ReorderUsernameSource interface {
 	LookupUsername(ctx context.Context, uid keybase1.UID) (libkb.NormalizedUsername, error)
 }
 
-// Reorder participants based on the order in activeList.
+// ReorderParticipants based on the order in activeList.
 // Only allows usernames from tlfname in the output.
 // This never fails, worse comes to worst it just returns the split of tlfname.
-func ReorderParticipants(ctx context.Context, uloader ReorderUsernameSource, tlfname string, activeList []gregor1.UID) (writerNames []string, readerNames []string, err error) {
-	srcWriterNames, srcReaderNames, _, err := splitAndNormalizeTLFNameCanonicalize(tlfname, false)
+func ReorderParticipants(ctx context.Context, g libkb.UIDMapperContext, tuloader ReorderUsernameSource,
+	umapper libkb.UIDMapper, tlfname string, activeList []gregor1.UID) (writerNames []chat1.ConversationLocalParticipant, err error) {
+	srcWriterNames, _, _, err := splitAndNormalizeTLFNameCanonicalize(tlfname, false)
 	if err != nil {
-		return writerNames, readerNames, err
+		return writerNames, err
+	}
+	var activeKuids []keybase1.UID
+	for _, a := range activeList {
+		activeKuids = append(activeKuids, keybase1.UID(a.String()))
+	}
+	packages, err := umapper.MapUIDsToUsernamePackages(ctx, g, activeKuids, 0, 0, false)
+	activeMap := make(map[string]chat1.ConversationLocalParticipant)
+	if err == nil {
+		for i := 0; i < len(activeKuids); i++ {
+			activeMap[activeKuids[i].String()] = UsernamePackageToParticipant(packages[i])
+		}
 	}
 
 	allowedWriters := make(map[string]bool)
@@ -130,33 +142,29 @@ func ReorderParticipants(ctx context.Context, uloader ReorderUsernameSource, tlf
 	// Fill from the active list first.
 	for _, uid := range activeList {
 		kbUID := keybase1.UID(uid.String())
-		normalizedUsername, err := uloader.LookupUsername(ctx, kbUID)
-		if err != nil {
+		p, ok := activeMap[kbUID.String()]
+		if !ok {
 			continue
 		}
-		user := normalizedUsername.String()
-		user, err = kbfs.NormalizeAssertionOrName(user)
-		if err != nil {
-			continue
-		}
-		if allowed, _ := allowedWriters[user]; allowed {
-			writerNames = append(writerNames, user)
+		if allowed, _ := allowedWriters[p.Username]; allowed {
+			writerNames = append(writerNames, p)
 			// Allow only one occurrence.
-			allowedWriters[user] = false
+			allowedWriters[p.Username] = false
 		}
 	}
 
 	// Include participants even if they weren't in the active list, in stable order.
 	for _, user := range srcWriterNames {
 		if allowed, _ := allowedWriters[user]; allowed {
-			writerNames = append(writerNames, user)
+			writerNames = append(writerNames, UsernamePackageToParticipant(libkb.UsernamePackage{
+				NormalizedUsername: libkb.NewNormalizedUsername(user),
+				FullName:           nil,
+			}))
 			allowedWriters[user] = false
 		}
 	}
 
-	readerNames = srcReaderNames
-
-	return writerNames, readerNames, nil
+	return writerNames, nil
 }
 
 // Drive splitAndNormalizeTLFName with one attempt to follow TlfNameNotCanonical.
@@ -602,11 +610,18 @@ func PresentRemoteConversation(rc types.RemoteConversation) (res chat1.Unverifie
 	res.Version = rawConv.Metadata.Version
 	if rc.LocalMetadata != nil {
 		res.LocalMetadata = &chat1.UnverifiedInboxUIItemMetadata{
+<<<<<<< HEAD
 			ChannelName:       rc.LocalMetadata.TopicName,
 			Headline:          rc.LocalMetadata.Headline,
 			Snippet:           rc.LocalMetadata.Snippet,
 			WriterNames:       rc.LocalMetadata.WriterNames,
 			ResetParticipants: rc.LocalMetadata.ResetParticipants,
+=======
+			ChannelName:  rc.LocalMetadata.TopicName,
+			Headline:     rc.LocalMetadata.Headline,
+			Snippet:      rc.LocalMetadata.Snippet,
+			Participants: rc.LocalMetadata.Participants,
+>>>>>>> wip
 		}
 	}
 	return res
@@ -625,8 +640,12 @@ func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxU
 	res.Snippet = GetConvSnippet(rawConv)
 	res.Channel = GetTopicName(rawConv)
 	res.Headline = GetHeadline(rawConv)
+<<<<<<< HEAD
 	res.Participants = rawConv.Info.WriterNames
 	res.ResetParticipants = rawConv.Info.ResetNames
+=======
+	res.Participants = rawConv.Info.Participants
+>>>>>>> wip
 	res.Status = rawConv.Info.Status
 	res.MembersType = rawConv.GetMembersType()
 	res.Visibility = rawConv.Info.Visibility
@@ -849,4 +868,15 @@ func PluckConvs(rcs []types.RemoteConversation) (res []chat1.Conversation) {
 
 func SplitTLFName(tlfName string) []string {
 	return strings.Split(strings.Fields(tlfName)[0], ",")
+}
+
+func UsernamePackageToParticipant(p libkb.UsernamePackage) chat1.ConversationLocalParticipant {
+	fullName := "Unknown"
+	if p.FullName != nil {
+		fullName = string(p.FullName.FullName)
+	}
+	return chat1.ConversationLocalParticipant{
+		Username: p.NormalizedUsername.String(),
+		Fullname: fullName,
+	}
 }

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -107,15 +107,11 @@ func AggRateLimits(rlimits []chat1.RateLimit) (res []chat1.RateLimit) {
 	return res
 }
 
-type ReorderUsernameSource interface {
-	LookupUsername(ctx context.Context, uid keybase1.UID) (libkb.NormalizedUsername, error)
-}
-
 // ReorderParticipants based on the order in activeList.
 // Only allows usernames from tlfname in the output.
 // This never fails, worse comes to worst it just returns the split of tlfname.
-func ReorderParticipants(ctx context.Context, g libkb.UIDMapperContext, tuloader ReorderUsernameSource,
-	umapper libkb.UIDMapper, tlfname string, activeList []gregor1.UID) (writerNames []chat1.ConversationLocalParticipant, err error) {
+func ReorderParticipants(ctx context.Context, g libkb.UIDMapperContext, umapper libkb.UIDMapper,
+	tlfname string, activeList []gregor1.UID) (writerNames []chat1.ConversationLocalParticipant, err error) {
 	srcWriterNames, _, _, err := splitAndNormalizeTLFNameCanonicalize(tlfname, false)
 	if err != nil {
 		return writerNames, err

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -124,7 +124,8 @@ func ReorderParticipants(ctx context.Context, g libkb.UIDMapperContext, tuloader
 	for _, a := range activeList {
 		activeKuids = append(activeKuids, keybase1.UID(a.String()))
 	}
-	packages, err := umapper.MapUIDsToUsernamePackages(ctx, g, activeKuids, 0, 0, false)
+	packages, err := umapper.MapUIDsToUsernamePackages(ctx, g, activeKuids, time.Hour*24, 10*time.Second,
+		true)
 	activeMap := make(map[string]chat1.ConversationLocalParticipant)
 	if err == nil {
 		for i := 0; i < len(activeKuids); i++ {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -610,18 +610,11 @@ func PresentRemoteConversation(rc types.RemoteConversation) (res chat1.Unverifie
 	res.Version = rawConv.Metadata.Version
 	if rc.LocalMetadata != nil {
 		res.LocalMetadata = &chat1.UnverifiedInboxUIItemMetadata{
-<<<<<<< HEAD
 			ChannelName:       rc.LocalMetadata.TopicName,
 			Headline:          rc.LocalMetadata.Headline,
 			Snippet:           rc.LocalMetadata.Snippet,
-			WriterNames:       rc.LocalMetadata.WriterNames,
+			Participants:      rc.LocalMetadata.Participants,
 			ResetParticipants: rc.LocalMetadata.ResetParticipants,
-=======
-			ChannelName:  rc.LocalMetadata.TopicName,
-			Headline:     rc.LocalMetadata.Headline,
-			Snippet:      rc.LocalMetadata.Snippet,
-			Participants: rc.LocalMetadata.Participants,
->>>>>>> wip
 		}
 	}
 	return res
@@ -640,12 +633,8 @@ func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxU
 	res.Snippet = GetConvSnippet(rawConv)
 	res.Channel = GetTopicName(rawConv)
 	res.Headline = GetHeadline(rawConv)
-<<<<<<< HEAD
-	res.Participants = rawConv.Info.WriterNames
-	res.ResetParticipants = rawConv.Info.ResetNames
-=======
 	res.Participants = rawConv.Info.Participants
->>>>>>> wip
+	res.ResetParticipants = rawConv.Info.ResetNames
 	res.Status = rawConv.Info.Status
 	res.MembersType = rawConv.GetMembersType()
 	res.Visibility = rawConv.Info.Visibility

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -79,18 +79,14 @@ func (v conversationListView) convNameTeam(g *libkb.GlobalContext, conv chat1.Co
 func (v conversationListView) convNameKBFS(g *libkb.GlobalContext, conv chat1.ConversationLocal, myUsername string) string {
 	var name string
 	if conv.Info.Visibility == keybase1.TLFVisibility_PUBLIC {
-		name = publicConvNamePrefix + strings.Join(conv.Info.WriterNames, ",")
+		name = publicConvNamePrefix + strings.Join(conv.Names(), ",")
 	} else {
-		name = strings.Join(v.without(g, conv.Info.WriterNames, myUsername), ",")
-		if len(conv.Info.WriterNames) == 1 && conv.Info.WriterNames[0] == myUsername {
+		name = strings.Join(v.without(g, conv.Names(), myUsername), ",")
+		if len(conv.Names()) == 1 && conv.Names()[0] == myUsername {
 			// The user is the only writer.
 			name = myUsername
 		}
 	}
-	if len(conv.Info.ReaderNames) > 0 {
-		name += "#" + strings.Join(conv.Info.ReaderNames, ",")
-	}
-
 	if conv.Info.FinalizeInfo != nil {
 		name += " " + conv.Info.FinalizeInfo.BeforeSummary()
 	}

--- a/go/client/cmd_chat_listmembers.go
+++ b/go/client/cmd_chat_listmembers.go
@@ -63,7 +63,7 @@ func (c *CmdChatListMembers) Run() error {
 	}
 
 	ui.Printf("Listing members in %s [#%s]:\n\n", c.tlfName, c.topicName)
-	for _, memb := range inboxRes.Conversations[0].Info.WriterNames {
+	for _, memb := range inboxRes.Conversations[0].Names() {
 		ui.Printf("%s\n", memb)
 	}
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -28,11 +28,11 @@ func (o UIPagination) DeepCopy() UIPagination {
 }
 
 type UnverifiedInboxUIItemMetadata struct {
-	ChannelName       string                         `codec:"channelName" json:"channelName"`
-	Headline          string                         `codec:"headline" json:"headline"`
-	Snippet           string                         `codec:"snippet" json:"snippet"`
-	Participants      []ConversationLocalParticipant `codec:"participants" json:"participants"`
-	ResetParticipants []string                       `codec:"resetParticipants" json:"resetParticipants"`
+	ChannelName       string   `codec:"channelName" json:"channelName"`
+	Headline          string   `codec:"headline" json:"headline"`
+	Snippet           string   `codec:"snippet" json:"snippet"`
+	WriterNames       []string `codec:"writerNames" json:"writerNames"`
+	ResetParticipants []string `codec:"resetParticipants" json:"resetParticipants"`
 }
 
 func (o UnverifiedInboxUIItemMetadata) DeepCopy() UnverifiedInboxUIItemMetadata {
@@ -40,17 +40,17 @@ func (o UnverifiedInboxUIItemMetadata) DeepCopy() UnverifiedInboxUIItemMetadata 
 		ChannelName: o.ChannelName,
 		Headline:    o.Headline,
 		Snippet:     o.Snippet,
-		Participants: (func(x []ConversationLocalParticipant) []ConversationLocalParticipant {
+		WriterNames: (func(x []string) []string {
 			if x == nil {
 				return nil
 			}
-			var ret []ConversationLocalParticipant
+			var ret []string
 			for _, v := range x {
-				vCopy := v.DeepCopy()
+				vCopy := v
 				ret = append(ret, vCopy)
 			}
 			return ret
-		})(o.Participants),
+		})(o.WriterNames),
 		ResetParticipants: (func(x []string) []string {
 			if x == nil {
 				return nil
@@ -138,26 +138,27 @@ func (o UnverifiedInboxUIItems) DeepCopy() UnverifiedInboxUIItems {
 }
 
 type InboxUIItem struct {
-	ConvID            string                         `codec:"convID" json:"convID"`
-	IsEmpty           bool                           `codec:"isEmpty" json:"isEmpty"`
-	Name              string                         `codec:"name" json:"name"`
-	Snippet           string                         `codec:"snippet" json:"snippet"`
-	Channel           string                         `codec:"channel" json:"channel"`
-	Headline          string                         `codec:"headline" json:"headline"`
-	Visibility        keybase1.TLFVisibility         `codec:"visibility" json:"visibility"`
-	Participants      []ConversationLocalParticipant `codec:"participants" json:"participants"`
-	ResetParticipants []string                       `codec:"resetParticipants" json:"resetParticipants"`
-	Status            ConversationStatus             `codec:"status" json:"status"`
-	MembersType       ConversationMembersType        `codec:"membersType" json:"membersType"`
-	MemberStatus      ConversationMemberStatus       `codec:"memberStatus" json:"memberStatus"`
-	TeamType          TeamType                       `codec:"teamType" json:"teamType"`
-	Time              gregor1.Time                   `codec:"time" json:"time"`
-	Notifications     *ConversationNotificationInfo  `codec:"notifications,omitempty" json:"notifications,omitempty"`
-	CreatorInfo       *ConversationCreatorInfoLocal  `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
-	Version           ConversationVers               `codec:"version" json:"version"`
-	FinalizeInfo      *ConversationFinalizeInfo      `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
-	Supersedes        []ConversationMetadata         `codec:"supersedes" json:"supersedes"`
-	SupersededBy      []ConversationMetadata         `codec:"supersededBy" json:"supersededBy"`
+	ConvID            string                        `codec:"convID" json:"convID"`
+	IsEmpty           bool                          `codec:"isEmpty" json:"isEmpty"`
+	Name              string                        `codec:"name" json:"name"`
+	Snippet           string                        `codec:"snippet" json:"snippet"`
+	Channel           string                        `codec:"channel" json:"channel"`
+	Headline          string                        `codec:"headline" json:"headline"`
+	Visibility        keybase1.TLFVisibility        `codec:"visibility" json:"visibility"`
+	Participants      []string                      `codec:"participants" json:"participants"`
+	FullNames         map[string]string             `codec:"fullNames" json:"fullNames"`
+	ResetParticipants []string                      `codec:"resetParticipants" json:"resetParticipants"`
+	Status            ConversationStatus            `codec:"status" json:"status"`
+	MembersType       ConversationMembersType       `codec:"membersType" json:"membersType"`
+	MemberStatus      ConversationMemberStatus      `codec:"memberStatus" json:"memberStatus"`
+	TeamType          TeamType                      `codec:"teamType" json:"teamType"`
+	Time              gregor1.Time                  `codec:"time" json:"time"`
+	Notifications     *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
+	CreatorInfo       *ConversationCreatorInfoLocal `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
+	Version           ConversationVers              `codec:"version" json:"version"`
+	FinalizeInfo      *ConversationFinalizeInfo     `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
+	Supersedes        []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
+	SupersededBy      []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
 }
 
 func (o InboxUIItem) DeepCopy() InboxUIItem {
@@ -169,17 +170,29 @@ func (o InboxUIItem) DeepCopy() InboxUIItem {
 		Channel:    o.Channel,
 		Headline:   o.Headline,
 		Visibility: o.Visibility.DeepCopy(),
-		Participants: (func(x []ConversationLocalParticipant) []ConversationLocalParticipant {
+		Participants: (func(x []string) []string {
 			if x == nil {
 				return nil
 			}
-			var ret []ConversationLocalParticipant
+			var ret []string
 			for _, v := range x {
-				vCopy := v.DeepCopy()
+				vCopy := v
 				ret = append(ret, vCopy)
 			}
 			return ret
 		})(o.Participants),
+		FullNames: (func(x map[string]string) map[string]string {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[string]string)
+			for k, v := range x {
+				kCopy := k
+				vCopy := v
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.FullNames),
 		ResetParticipants: (func(x []string) []string {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -28,11 +28,11 @@ func (o UIPagination) DeepCopy() UIPagination {
 }
 
 type UnverifiedInboxUIItemMetadata struct {
-	ChannelName       string   `codec:"channelName" json:"channelName"`
-	Headline          string   `codec:"headline" json:"headline"`
-	Snippet           string   `codec:"snippet" json:"snippet"`
-	WriterNames       []string `codec:"writerNames" json:"writerNames"`
-	ResetParticipants []string `codec:"resetParticipants" json:"resetParticipants"`
+	ChannelName       string                         `codec:"channelName" json:"channelName"`
+	Headline          string                         `codec:"headline" json:"headline"`
+	Snippet           string                         `codec:"snippet" json:"snippet"`
+	Participants      []ConversationLocalParticipant `codec:"participants" json:"participants"`
+	ResetParticipants []string                       `codec:"resetParticipants" json:"resetParticipants"`
 }
 
 func (o UnverifiedInboxUIItemMetadata) DeepCopy() UnverifiedInboxUIItemMetadata {
@@ -40,17 +40,17 @@ func (o UnverifiedInboxUIItemMetadata) DeepCopy() UnverifiedInboxUIItemMetadata 
 		ChannelName: o.ChannelName,
 		Headline:    o.Headline,
 		Snippet:     o.Snippet,
-		WriterNames: (func(x []string) []string {
+		Participants: (func(x []ConversationLocalParticipant) []ConversationLocalParticipant {
 			if x == nil {
 				return nil
 			}
-			var ret []string
+			var ret []ConversationLocalParticipant
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
-		})(o.WriterNames),
+		})(o.Participants),
 		ResetParticipants: (func(x []string) []string {
 			if x == nil {
 				return nil
@@ -138,26 +138,26 @@ func (o UnverifiedInboxUIItems) DeepCopy() UnverifiedInboxUIItems {
 }
 
 type InboxUIItem struct {
-	ConvID            string                        `codec:"convID" json:"convID"`
-	IsEmpty           bool                          `codec:"isEmpty" json:"isEmpty"`
-	Name              string                        `codec:"name" json:"name"`
-	Snippet           string                        `codec:"snippet" json:"snippet"`
-	Channel           string                        `codec:"channel" json:"channel"`
-	Headline          string                        `codec:"headline" json:"headline"`
-	Visibility        keybase1.TLFVisibility        `codec:"visibility" json:"visibility"`
-	Participants      []string                      `codec:"participants" json:"participants"`
-	ResetParticipants []string                      `codec:"resetParticipants" json:"resetParticipants"`
-	Status            ConversationStatus            `codec:"status" json:"status"`
-	MembersType       ConversationMembersType       `codec:"membersType" json:"membersType"`
-	MemberStatus      ConversationMemberStatus      `codec:"memberStatus" json:"memberStatus"`
-	TeamType          TeamType                      `codec:"teamType" json:"teamType"`
-	Time              gregor1.Time                  `codec:"time" json:"time"`
-	Notifications     *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
-	CreatorInfo       *ConversationCreatorInfoLocal `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
-	Version           ConversationVers              `codec:"version" json:"version"`
-	FinalizeInfo      *ConversationFinalizeInfo     `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
-	Supersedes        []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
-	SupersededBy      []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
+	ConvID            string                         `codec:"convID" json:"convID"`
+	IsEmpty           bool                           `codec:"isEmpty" json:"isEmpty"`
+	Name              string                         `codec:"name" json:"name"`
+	Snippet           string                         `codec:"snippet" json:"snippet"`
+	Channel           string                         `codec:"channel" json:"channel"`
+	Headline          string                         `codec:"headline" json:"headline"`
+	Visibility        keybase1.TLFVisibility         `codec:"visibility" json:"visibility"`
+	Participants      []ConversationLocalParticipant `codec:"participants" json:"participants"`
+	ResetParticipants []string                       `codec:"resetParticipants" json:"resetParticipants"`
+	Status            ConversationStatus             `codec:"status" json:"status"`
+	MembersType       ConversationMembersType        `codec:"membersType" json:"membersType"`
+	MemberStatus      ConversationMemberStatus       `codec:"memberStatus" json:"memberStatus"`
+	TeamType          TeamType                       `codec:"teamType" json:"teamType"`
+	Time              gregor1.Time                   `codec:"time" json:"time"`
+	Notifications     *ConversationNotificationInfo  `codec:"notifications,omitempty" json:"notifications,omitempty"`
+	CreatorInfo       *ConversationCreatorInfoLocal  `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
+	Version           ConversationVers               `codec:"version" json:"version"`
+	FinalizeInfo      *ConversationFinalizeInfo      `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
+	Supersedes        []ConversationMetadata         `codec:"supersedes" json:"supersedes"`
+	SupersededBy      []ConversationMetadata         `codec:"supersededBy" json:"supersededBy"`
 }
 
 func (o InboxUIItem) DeepCopy() InboxUIItem {
@@ -169,13 +169,13 @@ func (o InboxUIItem) DeepCopy() InboxUIItem {
 		Channel:    o.Channel,
 		Headline:   o.Headline,
 		Visibility: o.Visibility.DeepCopy(),
-		Participants: (func(x []string) []string {
+		Participants: (func(x []ConversationLocalParticipant) []ConversationLocalParticipant {
 			if x == nil {
 				return nil
 			}
-			var ret []string
+			var ret []ConversationLocalParticipant
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -360,13 +360,6 @@ func (c ConversationInfoLocal) TLFNameExpandedSummary() string {
 	return c.TlfName + " " + c.FinalizeInfo.BeforeSummary()
 }
 
-func (c ConversationInfoLocal) WriterNames() (res []string) {
-	for _, p := range c.Participants {
-		res = append(res, p.Username)
-	}
-	return res
-}
-
 // TLFNameExpanded returns a TLF name with a reset suffix if it exists.
 // This version can be used in requests to lookup the TLF.
 func (h MessageClientHeader) TLFNameExpanded(finalizeInfo *ConversationFinalizeInfo) string {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -449,6 +449,13 @@ func (c ConversationLocal) GetMaxMessage(typ MessageType) (MessageUnboxed, error
 	return MessageUnboxed{}, fmt.Errorf("max message not found: %v", typ)
 }
 
+func (c ConversationLocal) Names() (res []string) {
+	for _, p := range c.Info.Participants {
+		res = append(res, p.Username)
+	}
+	return res
+}
+
 func (c Conversation) GetMtime() gregor1.Time {
 	return c.ReaderInfo.Mtime
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -360,6 +360,13 @@ func (c ConversationInfoLocal) TLFNameExpandedSummary() string {
 	return c.TlfName + " " + c.FinalizeInfo.BeforeSummary()
 }
 
+func (c ConversationInfoLocal) WriterNames() (res []string) {
+	for _, p := range c.Participants {
+		res = append(res, p.Username)
+	}
+	return res
+}
+
 // TLFNameExpanded returns a TLF name with a reset suffix if it exists.
 // This version can be used in requests to lookup the TLF.
 func (h MessageClientHeader) TLFNameExpanded(finalizeInfo *ConversationFinalizeInfo) string {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1996,14 +1996,20 @@ func (o UnreadFirstNumLimit) DeepCopy() UnreadFirstNumLimit {
 }
 
 type ConversationLocalParticipant struct {
-	Username string `codec:"username" json:"username"`
-	Fullname string `codec:"fullname" json:"fullname"`
+	Username string  `codec:"username" json:"username"`
+	Fullname *string `codec:"fullname,omitempty" json:"fullname,omitempty"`
 }
 
 func (o ConversationLocalParticipant) DeepCopy() ConversationLocalParticipant {
 	return ConversationLocalParticipant{
 		Username: o.Username,
-		Fullname: o.Fullname,
+		Fullname: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.Fullname),
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1995,22 +1995,33 @@ func (o UnreadFirstNumLimit) DeepCopy() UnreadFirstNumLimit {
 	}
 }
 
+type ConversationLocalParticipant struct {
+	Username string `codec:"username" json:"username"`
+	Fullname string `codec:"fullname" json:"fullname"`
+}
+
+func (o ConversationLocalParticipant) DeepCopy() ConversationLocalParticipant {
+	return ConversationLocalParticipant{
+		Username: o.Username,
+		Fullname: o.Fullname,
+	}
+}
+
 type ConversationInfoLocal struct {
-	Id           ConversationID            `codec:"id" json:"id"`
-	Triple       ConversationIDTriple      `codec:"triple" json:"triple"`
-	TlfName      string                    `codec:"tlfName" json:"tlfName"`
-	TopicName    string                    `codec:"topicName" json:"topicName"`
-	Visibility   keybase1.TLFVisibility    `codec:"visibility" json:"visibility"`
-	Status       ConversationStatus        `codec:"status" json:"status"`
-	MembersType  ConversationMembersType   `codec:"membersType" json:"membersType"`
-	MemberStatus ConversationMemberStatus  `codec:"memberStatus" json:"memberStatus"`
-	TeamType     TeamType                  `codec:"teamType" json:"teamType"`
-	Existence    ConversationExistence     `codec:"existence" json:"existence"`
-	Version      ConversationVers          `codec:"version" json:"version"`
-	WriterNames  []string                  `codec:"writerNames" json:"writerNames"`
-	ReaderNames  []string                  `codec:"readerNames" json:"readerNames"`
-	FinalizeInfo *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
-	ResetNames   []string                  `codec:"resetNames" json:"resetNames"`
+	Id           ConversationID                 `codec:"id" json:"id"`
+	Triple       ConversationIDTriple           `codec:"triple" json:"triple"`
+	TlfName      string                         `codec:"tlfName" json:"tlfName"`
+	TopicName    string                         `codec:"topicName" json:"topicName"`
+	Visibility   keybase1.TLFVisibility         `codec:"visibility" json:"visibility"`
+	Status       ConversationStatus             `codec:"status" json:"status"`
+	MembersType  ConversationMembersType        `codec:"membersType" json:"membersType"`
+	MemberStatus ConversationMemberStatus       `codec:"memberStatus" json:"memberStatus"`
+	TeamType     TeamType                       `codec:"teamType" json:"teamType"`
+	Existence    ConversationExistence          `codec:"existence" json:"existence"`
+	Version      ConversationVers               `codec:"version" json:"version"`
+	Participants []ConversationLocalParticipant `codec:"participants" json:"participants"`
+	FinalizeInfo *ConversationFinalizeInfo      `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
+	ResetNames   []string                       `codec:"resetNames" json:"resetNames"`
 }
 
 func (o ConversationInfoLocal) DeepCopy() ConversationInfoLocal {
@@ -2026,28 +2037,17 @@ func (o ConversationInfoLocal) DeepCopy() ConversationInfoLocal {
 		TeamType:     o.TeamType.DeepCopy(),
 		Existence:    o.Existence.DeepCopy(),
 		Version:      o.Version.DeepCopy(),
-		WriterNames: (func(x []string) []string {
+		Participants: (func(x []ConversationLocalParticipant) []ConversationLocalParticipant {
 			if x == nil {
 				return nil
 			}
-			var ret []string
+			var ret []ConversationLocalParticipant
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
-		})(o.WriterNames),
-		ReaderNames: (func(x []string) []string {
-			if x == nil {
-				return nil
-			}
-			var ret []string
-			for _, v := range x {
-				vCopy := v
-				ret = append(ret, vCopy)
-			}
-			return ret
-		})(o.ReaderNames),
+		})(o.Participants),
 		FinalizeInfo: (func(x *ConversationFinalizeInfo) *ConversationFinalizeInfo {
 			if x == nil {
 				return nil

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -3,13 +3,14 @@ package uidmap
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
-	"strings"
-	"sync"
-	"time"
 )
 
 type UIDMap struct {
@@ -360,3 +361,15 @@ func (u *UIDMap) CheckUIDAgainstUsername(uid keybase1.UID, un libkb.NormalizedUs
 }
 
 var _ libkb.UIDMapper = (*UIDMap)(nil)
+
+type OfflineUIDMap struct{}
+
+func (o *OfflineUIDMap) CheckUIDAgainstUsername(uid keybase1.UID, un libkb.NormalizedUsername) bool {
+	return true
+}
+
+func (o *OfflineUIDMap) MapUIDsToUsernamePackages(ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networktimeBudget time.Duration, forceNetworkForFullNames bool) ([]libkb.UsernamePackage, error) {
+	return nil, errors.New("offline uid map always fails")
+}
+
+var _ libkb.UIDMapper = (*OfflineUIDMap)(nil)

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -16,7 +16,7 @@ protocol chatUi {
     string channelName;
     string headline;
     string snippet;
-    array<string> writerNames;
+    array<ConversationLocalParticipant> participants;
     array<string> resetParticipants;
   }
 
@@ -48,7 +48,7 @@ protocol chatUi {
     string channel;
     string headline;
     keybase1.TLFVisibility visibility;
-    array<string> participants;
+    array<ConversationLocalParticipant> participants;
     array<string> resetParticipants;
     ConversationStatus status;
     ConversationMembersType membersType;

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -16,7 +16,7 @@ protocol chatUi {
     string channelName;
     string headline;
     string snippet;
-    array<ConversationLocalParticipant> participants;
+    array<string> writerNames;
     array<string> resetParticipants;
   }
 
@@ -48,7 +48,8 @@ protocol chatUi {
     string channel;
     string headline;
     keybase1.TLFVisibility visibility;
-    array<ConversationLocalParticipant> participants;
+    array<string> participants;
+    map<string, string> fullNames;
     array<string> resetParticipants;
     ConversationStatus status;
     ConversationMembersType membersType;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -340,7 +340,7 @@ protocol local {
 
   record ConversationLocalParticipant {
     string username;
-    string fullname;
+    union { null, string } fullname;
   }
 
   record ConversationInfoLocal {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -338,6 +338,11 @@ protocol local {
     int AtMost;
   }
 
+  record ConversationLocalParticipant {
+    string username;
+    string fullname;
+  }
+
   record ConversationInfoLocal {
     ConversationID id;
     ConversationIDTriple triple;
@@ -353,8 +358,7 @@ protocol local {
     ConversationVers version;
 
     // Lists of usernames, always complete, optionally sorted by activity.
-    array<string> writerNames;
-    array<string> readerNames;
+    array<ConversationLocalParticipant> participants;
 
     // Only ever set for KBFS conversations
     union { null, ConversationFinalizeInfo } finalizeInfo;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1001,7 +1001,7 @@ export type ConversationLocal = {
 
 export type ConversationLocalParticipant = {
   username: string,
-  fullname: string,
+  fullname?: ?string,
 }
 
 export type ConversationMember = {
@@ -1322,7 +1322,8 @@ export type InboxUIItem = {
   channel: string,
   headline: string,
   visibility: keybase1.TLFVisibility,
-  participants?: ?Array<ConversationLocalParticipant>,
+  participants?: ?Array<string>,
+  fullNames: {[key: string]: string},
   resetParticipants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
@@ -2037,7 +2038,7 @@ export type UnverifiedInboxUIItemMetadata = {
   channelName: string,
   headline: string,
   snippet: string,
-  participants?: ?Array<ConversationLocalParticipant>,
+  writerNames?: ?Array<string>,
   resetParticipants?: ?Array<string>,
 }
 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -981,8 +981,7 @@ export type ConversationInfoLocal = {
   teamType: TeamType,
   existence: ConversationExistence,
   version: ConversationVers,
-  writerNames?: ?Array<string>,
-  readerNames?: ?Array<string>,
+  participants?: ?Array<ConversationLocalParticipant>,
   finalizeInfo?: ?ConversationFinalizeInfo,
   resetNames?: ?Array<string>,
 }
@@ -998,6 +997,11 @@ export type ConversationLocal = {
   maxMessages?: ?Array<MessageUnboxed>,
   isEmpty: boolean,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
+}
+
+export type ConversationLocalParticipant = {
+  username: string,
+  fullname: string,
 }
 
 export type ConversationMember = {
@@ -1318,7 +1322,7 @@ export type InboxUIItem = {
   channel: string,
   headline: string,
   visibility: keybase1.TLFVisibility,
-  participants?: ?Array<string>,
+  participants?: ?Array<ConversationLocalParticipant>,
   resetParticipants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
@@ -2033,7 +2037,7 @@ export type UnverifiedInboxUIItemMetadata = {
   channelName: string,
   headline: string,
   snippet: string,
-  writerNames?: ?Array<string>,
+  participants?: ?Array<ConversationLocalParticipant>,
   resetParticipants?: ?Array<string>,
 }
 

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -54,9 +54,9 @@
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "ConversationLocalParticipant"
           },
-          "name": "writerNames"
+          "name": "participants"
         },
         {
           "type": {
@@ -182,7 +182,7 @@
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "ConversationLocalParticipant"
           },
           "name": "participants"
         },

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -54,9 +54,9 @@
         {
           "type": {
             "type": "array",
-            "items": "ConversationLocalParticipant"
+            "items": "string"
           },
-          "name": "participants"
+          "name": "writerNames"
         },
         {
           "type": {
@@ -182,9 +182,17 @@
         {
           "type": {
             "type": "array",
-            "items": "ConversationLocalParticipant"
+            "items": "string"
           },
           "name": "participants"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "string",
+            "keys": "string"
+          },
+          "name": "fullNames"
         },
         {
           "type": {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -972,7 +972,10 @@
           "name": "username"
         },
         {
-          "type": "string",
+          "type": [
+            null,
+            "string"
+          ],
           "name": "fullname"
         }
       ]

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -965,6 +965,20 @@
     },
     {
       "type": "record",
+      "name": "ConversationLocalParticipant",
+      "fields": [
+        {
+          "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "string",
+          "name": "fullname"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "ConversationInfoLocal",
       "fields": [
         {
@@ -1014,16 +1028,9 @@
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "ConversationLocalParticipant"
           },
-          "name": "writerNames"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "string"
-          },
-          "name": "readerNames"
+          "name": "participants"
         },
         {
           "type": [

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -529,6 +529,7 @@ function _conversationLocalToInboxState(c: ?ChatTypes.InboxUIItem): ?Constants.I
   const conversationIDKey = c.convID
 
   let parts = I.List(c.participants || [])
+  let fullNames = I.Map(c.fullNames || {})
   let teamname = null
   let channelname = null
 
@@ -547,6 +548,7 @@ function _conversationLocalToInboxState(c: ?ChatTypes.InboxUIItem): ?Constants.I
     name: c.name,
     notifications,
     participants: parts,
+    fullNames: fullNames,
     state: 'unboxed',
     status: Constants.ConversationStatusByEnum[c.status],
     teamType: c.teamType,

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -157,6 +157,7 @@ function makeInboxStateRecords(
           info: null,
           membersType: c.membersType,
           participants: parts,
+          fullNames: Map(),
           status: Constants.ConversationStatusByEnum[c.status || 0],
           teamname: c.membersType === ChatTypes.CommonConversationMembersType.team ? c.name : undefined,
           teamType: c.teamType,

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -157,7 +157,7 @@ function makeInboxStateRecords(
           info: null,
           membersType: c.membersType,
           participants: parts,
-          fullNames: Map(),
+          fullNames: new I.Map(),
           status: Constants.ConversationStatusByEnum[c.status || 0],
           teamname: c.membersType === ChatTypes.CommonConversationMembersType.team ? c.name : undefined,
           teamType: c.teamType,

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -18,14 +18,18 @@ import {showUserProfile} from '../../../actions/profile'
 import flags from '../../../util/feature-flags'
 
 const getParticipants = createSelector(
-  [Constants.getYou, Constants.getTLF, Constants.getFollowingMap, Constants.getMetaDataMap],
-  (you, tlf, followingMap, metaDataMap) => {
-    const users = tlf.split(',')
-
-    return users.map(username => {
+  [
+    Constants.getYou,
+    Constants.getParticipantsWithFullNames,
+    Constants.getFollowingMap,
+    Constants.getMetaDataMap,
+  ],
+  (you, users, followingMap, metaDataMap) => {
+    return users.map(user => {
+      const username = user.username
       const following = !!followingMap[username]
       const meta = metaDataMap.get(username, Map({}))
-      const fullname = meta.get('fullname') || 'Unknown'
+      const fullname = user.fullname ? user.fullname : meta.get('fullname') || 'Unknown'
       const broken = meta.get('brokenTracker') || false
       return {
         broken,

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -282,6 +282,7 @@ type _InboxState = {
   membersType: ChatTypes.ConversationMembersType,
   notifications: ?NotificationsState,
   participants: I.List<string>,
+  fullNames: I.Map<string, string>,
   state: 'untrusted' | 'unboxed' | 'error' | 'unboxing',
   status: ConversationStateEnum,
   time: number,
@@ -300,6 +301,7 @@ export const makeInboxState: I.RecordFactory<_InboxState> = I.Record({
   membersType: 0,
   notifications: null,
   participants: I.List(),
+  fullNames: I.Map(),
   state: 'untrusted',
   status: 'unfiled',
   time: 0,
@@ -1140,9 +1142,11 @@ const getParticipantsWithFullNames = createSelector(
     if (selected && isPendingConversationIDKey(selected)) {
       return []
     } else if (selected !== nothingSelected && selectedInbox) {
-      return selectedInbox.participants.join(',')
+      return selectedInbox.participants.map(username => {
+        return {username: username, fullname: selectedInbox.fullNames.get(username)}
+      })
     }
-    return ''
+    return []
   }
 )
 
@@ -1381,6 +1385,7 @@ export {
   getYou,
   getFollowingMap,
   getMetaDataMap,
+  getParticipantsWithFullNames,
   getSelectedInbox,
   getTLF,
   getMuted,

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -1134,6 +1134,18 @@ const getTLF = createSelector([getSelectedInbox, getSelectedConversation], (sele
   return ''
 })
 
+const getParticipantsWithFullNames = createSelector(
+  [getSelectedInbox, getSelectedConversation],
+  (selectedInbox, selected) => {
+    if (selected && isPendingConversationIDKey(selected)) {
+      return []
+    } else if (selected !== nothingSelected && selectedInbox) {
+      return selectedInbox.participants.join(',')
+    }
+    return ''
+  }
+)
+
 const getMuted = createSelector(
   [getSelectedInbox],
   selectedInbox => selectedInbox && selectedInbox.get('status') === 'muted'

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1001,7 +1001,7 @@ export type ConversationLocal = {
 
 export type ConversationLocalParticipant = {
   username: string,
-  fullname: string,
+  fullname?: ?string,
 }
 
 export type ConversationMember = {
@@ -1322,7 +1322,8 @@ export type InboxUIItem = {
   channel: string,
   headline: string,
   visibility: keybase1.TLFVisibility,
-  participants?: ?Array<ConversationLocalParticipant>,
+  participants?: ?Array<string>,
+  fullNames: {[key: string]: string},
   resetParticipants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
@@ -2037,7 +2038,7 @@ export type UnverifiedInboxUIItemMetadata = {
   channelName: string,
   headline: string,
   snippet: string,
-  participants?: ?Array<ConversationLocalParticipant>,
+  writerNames?: ?Array<string>,
   resetParticipants?: ?Array<string>,
 }
 

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -981,8 +981,7 @@ export type ConversationInfoLocal = {
   teamType: TeamType,
   existence: ConversationExistence,
   version: ConversationVers,
-  writerNames?: ?Array<string>,
-  readerNames?: ?Array<string>,
+  participants?: ?Array<ConversationLocalParticipant>,
   finalizeInfo?: ?ConversationFinalizeInfo,
   resetNames?: ?Array<string>,
 }
@@ -998,6 +997,11 @@ export type ConversationLocal = {
   maxMessages?: ?Array<MessageUnboxed>,
   isEmpty: boolean,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
+}
+
+export type ConversationLocalParticipant = {
+  username: string,
+  fullname: string,
 }
 
 export type ConversationMember = {
@@ -1318,7 +1322,7 @@ export type InboxUIItem = {
   channel: string,
   headline: string,
   visibility: keybase1.TLFVisibility,
-  participants?: ?Array<string>,
+  participants?: ?Array<ConversationLocalParticipant>,
   resetParticipants?: ?Array<string>,
   status: ConversationStatus,
   membersType: ConversationMembersType,
@@ -2033,7 +2037,7 @@ export type UnverifiedInboxUIItemMetadata = {
   channelName: string,
   headline: string,
   snippet: string,
-  writerNames?: ?Array<string>,
+  participants?: ?Array<ConversationLocalParticipant>,
   resetParticipants?: ?Array<string>,
 }
 


### PR DESCRIPTION
Patch does the following:

1.) Load full names when localizing all conversation types. For `IMPTEAM` and `KBFS`, we change `ReorderParticipants` to use a `libkb.UIDMapper` to get the username+full name pairs, instead of the `UPAKLoader`.
2.) Add a full name map to `InboxUIItem` for use by the fronend.
3.) Change frontend code to use the full name map instead of its metadata deal.