### PR TITLE
try opening LevelDb again if there is an error, and also fix LoadSigHints failure

### DIFF
--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -162,7 +162,7 @@ func (l *LevelDb) doWhileOpenAndNukeIfCorrupted(action func() error) (err error)
 	// we should at least try instead of auto returning LevelDBOpenClosederror.
 	if err != nil {
 		l.Lock()
-		if l.db != nil {
+		if l.db == nil {
 			l.G().Log.Debug("LevelDb: doWhileOpenAndNukeIfCorrupted: resetting sync one: %s", err)
 			l.dbOpenerOnce = new(sync.Once)
 		}

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -159,8 +159,8 @@ func (l *LevelDb) doWhileOpenAndNukeIfCorrupted(action func() error) (err error)
 	// in a LevelDBOpenClosedError), because if DB open fails, retrying it
 	// wouldn't help. We should find the root cause and deal with it.
 	// MM: 10/12/2017: I am changing the above policy. I am not so sure retrying it won't help,
-	// we should at least try instead of auto returning LevelDBOpenClosederror. See above.
-	if err != nil {
+	// we should at least try instead of auto returning LevelDBOpenClosederror.
+	if err != nil && l.db == nil {
 		l.Lock()
 		l.G().Log.Debug("LevelDb: doWhileOpenAndNukeIfCorrupted: resetting sync one: %s", err)
 		l.dbOpenerOnce = new(sync.Once)

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -160,10 +160,12 @@ func (l *LevelDb) doWhileOpenAndNukeIfCorrupted(action func() error) (err error)
 	// wouldn't help. We should find the root cause and deal with it.
 	// MM: 10/12/2017: I am changing the above policy. I am not so sure retrying it won't help,
 	// we should at least try instead of auto returning LevelDBOpenClosederror.
-	if err != nil && l.db == nil {
+	if err != nil {
 		l.Lock()
-		l.G().Log.Debug("LevelDb: doWhileOpenAndNukeIfCorrupted: resetting sync one: %s", err)
-		l.dbOpenerOnce = new(sync.Once)
+		if l.db != nil {
+			l.G().Log.Debug("LevelDb: doWhileOpenAndNukeIfCorrupted: resetting sync one: %s", err)
+			l.dbOpenerOnce = new(sync.Once)
+		}
 		l.Unlock()
 	}
 	return err

--- a/go/libkb/leveldb_test.go
+++ b/go/libkb/leveldb_test.go
@@ -199,8 +199,8 @@ func TestLevelDb(t *testing.T) {
 					t.Fatalf("use after close did not error")
 				}
 
-				if err = db.ForceOpen(); err == nil {
-					t.Fatalf("use after close did not error")
+				if err = db.ForceOpen(); err != nil {
+					t.Fatalf("ForceOpen after close did not work")
 				}
 			},
 		},

--- a/go/libkb/sig_hints.go
+++ b/go/libkb/sig_hints.go
@@ -128,7 +128,8 @@ func LoadSigHints(ctx context.Context, uid keybase1.UID, g *GlobalContext) (sh *
 	var jw *jsonw.Wrapper
 	jw, err = g.LocalDb.Get(DbKeyUID(DBSigHints, uid))
 	if err != nil {
-		return
+		jw = nil
+		g.Log.CDebugf(ctx, "| SigHints failed to access local storage: %s", err)
 	}
 	// jw might be nil here, but that's allowed.
 	sh, err = NewSigHints(jw, uid, false, g)


### PR DESCRIPTION
Patch does the following:

1.) Change LevelDb wrapper so that we try opening it more than once on a failure. I have seen phone  apps not be able to load it temporarily, but then our stuff will just not have it for the rest of the lifetime of the app.
2.) Change `LoadSigHints` to not fail out `LoadUser` on LevelDb error.