### PR TITLE
Map smart apostrophes to ASCII

### DIFF
--- a/shared/login/register/set-public-name/container.js
+++ b/shared/login/register/set-public-name/container.js
@@ -91,7 +91,11 @@ const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => ({
 const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
   clearDeviceNameError: () => dispatch(clearDeviceNameError()),
   onBack: () => dispatch(Creators.onBack()),
-  onSubmit: deviceName => dispatch(Creators.submitDeviceName(deviceName)),
+  onSubmit: deviceName => {
+    // map 'smart apostrophes' to ASCII (typewriter apostrophe)
+    deviceName = deviceName.replace(/[\u2018\u2019\u0060\u00B4]/g, "'")
+    dispatch(Creators.submitDeviceName(deviceName))
+  },
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(_SetPublicName)


### PR DESCRIPTION
This fixes the issue with smartphone keyboards automagically inserting a 'smart' apostrophe into device names, rendering them invalid.

@keybase/react-hackers 