### PR TITLE
Team remove-member will ban iff openteam

### DIFF
--- a/go/client/cmd_team_remove_member.go
+++ b/go/client/cmd_team_remove_member.go
@@ -16,11 +16,10 @@ import (
 
 type CmdTeamRemoveMember struct {
 	libkb.Contextified
-	Team      string
-	Username  string
-	Email     string
-	Force     bool
-	Permanent bool
+	Team     string
+	Username string
+	Email    string
+	Force    bool
 }
 
 func NewCmdTeamRemoveMemberRunner(g *libkb.GlobalContext) *CmdTeamRemoveMember {
@@ -49,10 +48,6 @@ func newCmdTeamRemoveMember(cl *libcmdline.CommandLine, g *libkb.GlobalContext) 
 				Name:  "f, force",
 				Usage: "bypass warnings",
 			},
-			cli.BoolFlag{
-				Name:  "p, permanent",
-				Usage: "prevent user from re-joining (open teams only)",
-			},
 		},
 	}
 }
@@ -67,7 +62,6 @@ func (c *CmdTeamRemoveMember) ParseArgv(ctx *cli.Context) error {
 	c.Username = ctx.String("user")
 	c.Email = ctx.String("email")
 	c.Force = ctx.Bool("force")
-	c.Permanent = ctx.Bool("permanent")
 
 	if len(c.Username) > 0 && len(c.Email) > 0 {
 		return errors.New("You cannot specify --user and --email.  Please choose one.")
@@ -126,10 +120,9 @@ func (c *CmdTeamRemoveMember) Run() error {
 	}
 
 	arg := keybase1.TeamRemoveMemberArg{
-		Name:      c.Team,
-		Username:  c.Username,
-		Email:     c.Email,
-		Permanent: c.Permanent,
+		Name:     c.Team,
+		Username: c.Username,
+		Email:    c.Email,
 	}
 
 	if err = cli.TeamRemoveMember(context.Background(), arg); err != nil {

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1538,7 +1538,6 @@ type TeamRemoveMemberArg struct {
 	Name      string `codec:"name" json:"name"`
 	Username  string `codec:"username" json:"username"`
 	Email     string `codec:"email" json:"email"`
-	Permanent bool   `codec:"permanent" json:"permanent"`
 }
 
 func (o TeamRemoveMemberArg) DeepCopy() TeamRemoveMemberArg {
@@ -1547,7 +1546,6 @@ func (o TeamRemoveMemberArg) DeepCopy() TeamRemoveMemberArg {
 		Name:      o.Name,
 		Username:  o.Username,
 		Email:     o.Email,
-		Permanent: o.Permanent,
 	}
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -158,7 +158,7 @@ func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRe
 		return teams.CancelEmailInvite(ctx, h.G().ExternalG(), arg.Name, arg.Email)
 	}
 	h.G().Log.CDebugf(ctx, "TeamRemoveMember: using RemoveMember for %q in team %q", arg.Username, arg.Name)
-	return teams.RemoveMember(ctx, h.G().ExternalG(), arg.Name, arg.Username, arg.Permanent)
+	return teams.RemoveMember(ctx, h.G().ExternalG(), arg.Name, arg.Username)
 }
 
 func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEditMemberArg) (err error) {

--- a/go/systests/team_open_test.go
+++ b/go/systests/team_open_test.go
@@ -207,7 +207,6 @@ func TestTeamOpenBans(t *testing.T) {
 	removeRunner.Team = team
 	removeRunner.Username = bob.username
 	removeRunner.Force = true
-	removeRunner.Permanent = true
 	err = removeRunner.Run()
 	require.NoError(t, err)
 

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -137,7 +137,7 @@ func TestLoaderKeyGen(t *testing.T) {
 	t.Logf("rotate the key a bunch of times")
 	// Rotate the key by removing and adding B from the team
 	for i := 0; i < 3; i++ {
-		err = RemoveMember(context.TODO(), tcs[0].G, teamName.String(), fus[1].Username, false)
+		err = RemoveMember(context.TODO(), tcs[0].G, teamName.String(), fus[1].Username)
 		require.NoError(t, err)
 
 		_, err = AddMember(context.TODO(), tcs[0].G, teamName.String(), fus[1].Username, keybase1.TeamRole_READER)
@@ -237,7 +237,7 @@ func TestLoaderWantMembers(t *testing.T) {
 	require.Equal(t, keybase1.TeamRole_WRITER, role)
 
 	t.Logf("U0 bumps the sigchain (removemember) (5)")
-	err = RemoveMember(context.TODO(), tcs[0].G, teamName.String(), fus[3].Username, false)
+	err = RemoveMember(context.TODO(), tcs[0].G, teamName.String(), fus[3].Username)
 	require.NoError(t, err)
 
 	t.Logf("U1 loads with WantMembers=U2 and it hits the cache")

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -169,7 +169,7 @@ func TestMemberRemove(t *testing.T) {
 	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, name, other.Username, keybase1.TeamRole_WRITER)
 
-	if err := RemoveMember(context.TODO(), tc.G, name, other.Username, false); err != nil {
+	if err := RemoveMember(context.TODO(), tc.G, name, other.Username); err != nil {
 		t.Fatal(err)
 	}
 
@@ -269,7 +269,7 @@ func TestMemberRemoveRotatesKeys(t *testing.T) {
 	if err := SetRoleWriter(context.TODO(), tc.G, name, other.Username); err != nil {
 		t.Fatal(err)
 	}
-	if err := RemoveMember(context.TODO(), tc.G, name, other.Username, false); err != nil {
+	if err := RemoveMember(context.TODO(), tc.G, name, other.Username); err != nil {
 		t.Fatal(err)
 	}
 
@@ -784,7 +784,7 @@ func TestMemberCancelInviteNoKeys(t *testing.T) {
 	assertInvite(tc, name, "561247eb1cc3b0f5dc9d9bf299da5e19%0", "keybase", keybase1.TeamRole_READER)
 	assertRole(tc, name, username, keybase1.TeamRole_NONE)
 
-	if err := RemoveMember(context.TODO(), tc.G, name, username, false); err != nil {
+	if err := RemoveMember(context.TODO(), tc.G, name, username); err != nil {
 		t.Fatal(err)
 	}
 
@@ -805,7 +805,7 @@ func TestMemberCancelInviteSocial(t *testing.T) {
 	}
 	assertInvite(tc, name, "not_on_kb_yet", "twitter", keybase1.TeamRole_READER)
 
-	if err := RemoveMember(context.TODO(), tc.G, name, username, false); err != nil {
+	if err := RemoveMember(context.TODO(), tc.G, name, username); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/teams/rename_test.go
+++ b/go/teams/rename_test.go
@@ -152,7 +152,7 @@ func TestRenameIntoMovedSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U0 removes U1 from R.B (1)")
-	err = RemoveMember(context.TODO(), tcs[0].G, subteamNameB.String(), fus[1].Username, false)
+	err = RemoveMember(context.TODO(), tcs[0].G, subteamNameB.String(), fus[1].Username)
 	require.NoError(t, err)
 
 	t.Logf("U0 renames R.B (1) to R.C")

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -429,7 +429,7 @@ func MemberRole(ctx context.Context, g *libkb.GlobalContext, teamname, username 
 	return t.MemberRole(ctx, uv)
 }
 
-func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string, permanent bool) error {
+func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
 	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
 	if err != nil {
 		return err
@@ -458,9 +458,8 @@ func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 	}
 	req := keybase1.TeamChangeReq{None: []keybase1.UserVersion{existingUV}}
 
-	if permanent && !t.IsOpen() {
-		return fmt.Errorf("team %q is not open, cannot permanently remove member", teamname)
-	}
+	// Ban for open teams only.
+	permanent := t.IsOpen()
 	return t.ChangeMembershipPermanent(ctx, req, permanent)
 }
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -460,7 +460,7 @@ protocol teams {
   array<TeamIDAndName> teamListSubteamsRecursive(int sessionID, string parentTeamName, boolean forceRepoll);
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);
   TeamAddMemberResult teamAddMember(int sessionID, string name, string email, string username, TeamRole role, boolean sendChatNotification);
-  void teamRemoveMember(int sessionID, string name, string username, string email, boolean permanent);
+  void teamRemoveMember(int sessionID, string name, string username, string email);
   void teamLeave(int sessionID, string name, boolean permanent);
   void teamEditMember(int sessionID, string name, string username, TeamRole role);
   void teamRename(int sessionID, TeamName prevName, TeamName newName);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6305,8 +6305,7 @@ export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
 export type teamsTeamRemoveMemberRpcParam = Exact<{
   name: string,
   username: string,
-  email: string,
-  permanent: boolean
+  email: string
 }>
 
 export type teamsTeamRenameRpcParam = Exact<{

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1409,10 +1409,6 @@
         {
           "name": "email",
           "type": "string"
-        },
-        {
-          "name": "permanent",
-          "type": "boolean"
         }
       ],
       "response": null

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6305,8 +6305,7 @@ export type teamsTeamReAddMemberAfterResetRpcParam = Exact<{
 export type teamsTeamRemoveMemberRpcParam = Exact<{
   name: string,
   username: string,
-  email: string,
-  permanent: boolean
+  email: string
 }>
 
 export type teamsTeamRenameRpcParam = Exact<{


### PR DESCRIPTION
Removes the 'permanent' option from the remove-member rpc and just uses 'permanent' if the team is open.