### PR TITLE
Android Keystore Fixes

### DIFF
--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -9,6 +9,8 @@ const isLargeScreen = true
 const isSimulator = false
 const isStoryBook = false
 const isIPhoneX = false
+const isDeviceSecureAndroid: boolean = false
+const isAndroidNewerThanM: boolean = false
 
 const isElectron = true
 const isDarwin = process.platform === 'darwin'
@@ -159,7 +161,9 @@ export {
   dataRoot,
   fileUIName,
   isAndroid,
+  isAndroidNewerThanM,
   isDarwin,
+  isDeviceSecureAndroid,
   isElectron,
   isIOS,
   isIPhoneX,

--- a/shared/constants/platform.js.flow
+++ b/shared/constants/platform.js.flow
@@ -13,6 +13,8 @@ export const isLinux: boolean = false
 export const isSimulator: boolean = false
 export const isStoryBook: boolean = false
 export const isIPhoneX: boolean = false
+export const isDeviceSecureAndroid: boolean = false
+export const isAndroidNewerThanM: boolean = false
 declare export var fileUIName: string
 declare export var version: string
 declare export var appVersionName: string

--- a/shared/constants/platform.native.js
+++ b/shared/constants/platform.native.js
@@ -7,12 +7,18 @@ NativeModules.ObjcEngine || {
   appVersionName: 'fallback',
   appVersionCode: 'fallback',
   usingSimulator: 'fallback',
+  isDeviceSecure: 'fallback',
 }
 const isStoryBook = (NativeModules.Storybook && NativeModules.Storybook.isStorybook) || false
 const version = nativeBridge.version
 const appVersionName = nativeBridge.appVersionName
 const appVersionCode = nativeBridge.appVersionCode
 const isSimulator = nativeBridge.usingSimulator === '1'
+// Currently this is given to us as a boolean, but no real documentation on this, so just in case it changes in the future.
+// Android only field that tells us if there is a lock screen.
+const isDeviceSecureAndroid: boolean = typeof nativeBridge.isDeviceSecure === 'boolean'
+  ? nativeBridge.isDeviceSecure
+  : nativeBridge.isDeviceSecure === 'true' || false
 
 const runMode = 'prod'
 const isIOS = Platform.OS === 'ios'
@@ -25,6 +31,7 @@ const isLinux = false
 const isWindows = false
 const fileUIName = 'File Explorer'
 const mobileOsVersion = Platform.Version
+const isAndroidNewerThanM = parseInt(mobileOsVersion) > 22
 
 const isIPhoneX =
   Platform.OS === 'ios' && !Platform.isPad && !Platform.isTVOS && Dimensions.get('window').height === 812
@@ -38,17 +45,19 @@ export {
   appVersionName,
   fileUIName,
   isAndroid,
+  isAndroidNewerThanM,
   isDarwin,
+  isDeviceSecureAndroid,
   isElectron,
   isIOS,
+  isIPhoneX,
   isLargeScreen,
   isLinux,
   isMobile,
   isSimulator,
+  isStoryBook,
   isWindows,
   mobileOsVersion,
   runMode,
   version,
-  isStoryBook,
-  isIPhoneX,
 }

--- a/shared/login/login/index.native.js
+++ b/shared/login/login/index.native.js
@@ -8,6 +8,7 @@ import {
   FormWithCheckbox,
   NativeScrollView,
 } from '../../common-adapters/index.native'
+import {isDeviceSecureAndroid, isAndroidNewerThanM} from '../../constants/platform'
 import Dropdown from './dropdown.native'
 import {globalStyles, globalMargins, globalColors} from '../../styles'
 
@@ -38,6 +39,13 @@ class LoginRender extends Component<Props> {
     return (
       <NativeScrollView>
         <Box style={styles.container}>
+          {!isDeviceSecureAndroid &&
+            !isAndroidNewerThanM &&
+            <Box style={deviceNotSecureStyle}>
+              <Text type="Body" backgroundMode="Information" style={{flex: 1, textAlign: 'center'}}>
+                Since you don't have a lock screen, you'll have to type your passphrase everytime.
+              </Text>
+            </Box>}
           <UserCard username={this.props.selectedUser} outerStyle={styles.card}>
             <Dropdown
               type="Username"
@@ -95,6 +103,13 @@ const styles = {
     marginTop: globalMargins.medium,
     width: '100%',
   },
+}
+
+const deviceNotSecureStyle = {
+  alignSelf: 'stretch',
+  backgroundColor: globalColors.yellow,
+  paddingTop: globalMargins.tiny,
+  paddingBottom: globalMargins.tiny,
 }
 
 export default LoginRender

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KeyStore.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KeyStore.java
@@ -25,7 +25,6 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
-import keybase.Keybase;
 import keybase.UnsafeExternalKeyStore;
 import io.keybase.ossifrage.keystore.KeyStoreHelper;
 
@@ -82,12 +81,7 @@ public class KeyStore implements UnsafeExternalKeyStore {
     @Override
     public synchronized byte[] retrieveSecret(final String serviceName, final String key) throws Exception {
         final byte[] wrappedSecret = readWrappedSecret(prefs, sharedPrefKeyPrefix(serviceName) + key);
-        Entry entry;
-        try {
-            entry = ks.getEntry(keyStoreAlias(serviceName), null);
-        } catch (Exception e) {
-            throw new KeyStoreException("Failed to get the RSA keys from the keystore");
-        }
+        Entry entry = ks.getEntry(keyStoreAlias(serviceName), null);
 
         if (entry == null){
             throw new KeyStoreException("No RSA keys in the keystore");
@@ -115,12 +109,10 @@ public class KeyStore implements UnsafeExternalKeyStore {
         try {
             final Entry entry = ks.getEntry(keyStoreAlias(serviceName), null);
             if (entry == null) {
-                throw new NullPointerException("Null Entry");
+                ks.deleteEntry(keyStoreAlias(serviceName));
+                KeyStoreHelper.generateRSAKeyPair(context, keyStoreAlias(serviceName));
             }
-        } catch (Exception e) {
-            ks.deleteEntry(keyStoreAlias(serviceName));
-            KeyStoreHelper.generateRSAKeyPair(context, keyStoreAlias(serviceName));
-        } finally {
+         } finally {
           // Reload the keystore
           ks = java.security.KeyStore.getInstance("AndroidKeyStore");
           ks.load(null);
@@ -129,13 +121,7 @@ public class KeyStore implements UnsafeExternalKeyStore {
 
     @Override
     public synchronized void storeSecret(final String serviceName, final String key, final byte[] bytes) throws Exception {
-        Entry entry = null;
-
-        try {
-            entry = ks.getEntry(keyStoreAlias(serviceName), null);
-        } catch (Exception e) {
-            throw new KeyStoreException("Failed to get the RSA keys from the keystore");
-        }
+        Entry entry = ks.getEntry(keyStoreAlias(serviceName), null);
 
         if (entry == null) {
             throw new KeyStoreException("No RSA keys in the keystore");

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/keystore/KeyStoreHelper.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/keystore/KeyStoreHelper.java
@@ -61,15 +61,4 @@ public class KeyStoreHelper {
         kpg.initialize(spec);
         KeyPair kp = kpg.generateKeyPair();
     }
-
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-    public static boolean isOnHardware(PrivateKey privateKey) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeySpecException {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            SecretKeyFactory factory = SecretKeyFactory.getInstance(privateKey.getAlgorithm(), "AndroidKeyStore");
-            final KeyInfo keyInfo = (KeyInfo) factory.getKeySpec((SecretKey) privateKey, KeyInfo.class);
-            return keyInfo.isInsideSecureHardware();
-        }
-        return KeyChain.isBoundKeyAlgorithm("RSA");
-
-    }
 }

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -1,5 +1,7 @@
 package io.keybase.ossifrage.modules;
 
+import android.app.KeyguardManager;
+import android.content.Context;
 import android.util.Log;
 
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -100,12 +102,21 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
     public Map<String, Object> getConstants() {
         String versionCode = String.valueOf(BuildConfig.VERSION_CODE);
         String versionName = BuildConfig.VERSION_NAME;
+        boolean isDeviceSecure = false;
+
+        try {
+            final KeyguardManager keyguardManager = (KeyguardManager) this.reactContext.getSystemService(Context.KEYGUARD_SERVICE);
+            isDeviceSecure = keyguardManager.isKeyguardSecure();
+        } catch (Exception e) {
+            Log.w(NAME, "Error reading keyguard secure state", e);
+        }
 
         final Map<String, Object> constants = new HashMap<>();
         constants.put("eventName", RPC_EVENT_NAME);
         constants.put("appVersionName", versionName);
         constants.put("appVersionCode", versionCode);
         constants.put("version", version());
+        constants.put("isDeviceSecure", isDeviceSecure);
         return constants;
     }
 


### PR DESCRIPTION
A couple things:

1. Don't eat errors. This will return the actual errors to go which will get logged. This should help debug future errors. Before we were catching errors and rethrowing a generic error – lame.

1. Add a warning screen if user is android version <=22 to tell them they need a lock screen or they'll have to type their password everytime (see screenshot)

1. Fix a bug that happens on versions >22 that results in the secret store not working because there is a permanently invalid key. This can happen if you originally have a lock screen and then remove it.

@patrickxb @keybase/react-hackers 
<img width="769" alt="screen shot 2017-10-12 at 2 35 01 pm" src="https://user-images.githubusercontent.com/594035/31522926-651ff74e-af65-11e7-9b05-a0d686a91f0d.png">
 