### PR TITLE
Disallow editing non-sent messages

### DIFF
--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -146,7 +146,7 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
   const conversationIDKey: Constants.ConversationIDKey = attrs.conversationIDKey
   const messageID: Constants.ParsedMessageID = Constants.parseMessageID(attrs.messageID)
   if (messageID.type !== 'rpcMessageID') {
-    console.warn('Editing message with invalid message ID type:', message, messageID)
+    console.warn('Editing message without RPC message ID:', message, messageID)
     return
   }
   let supersedes: ChatTypes.MessageID = messageID.msgID
@@ -156,16 +156,14 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
     select(Constants.lastMessageID, conversationIDKey),
   ])
 
-  let clientPrev: number
+  let clientPrev: ChatTypes.MessageID
   if (lastMessageID) {
     const clientPrevMessageID = Constants.parseMessageID(lastMessageID)
-    if (clientPrevMessageID.type === 'invalid') {
-      console.warn('Editing message with invalid last message ID:', message, lastMessageID)
-      return
-    } else if (typeof clientPrevMessageID.msgID !== 'number') {
-      console.warn('Editing message with non-numeric last message ID:', message, lastMessageID)
+    if (clientPrevMessageID.type !== 'rpcMessageID') {
+      console.warn('Editing message without RPC last message ID:', message, clientPrevMessageID)
       return
     }
+
     clientPrev = clientPrevMessageID.msgID
   } else {
     clientPrev = 0

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -137,21 +137,22 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
 
 function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
   const {message} = action.payload
-  let messageID: ?Constants.ParsedMessageID
-  let conversationIDKey: Constants.ConversationIDKey = ''
+  let tuple: ?[Constants.ParsedMessageID, Constants.ConversationIDKey]
   switch (message.type) {
     case 'Text':
     case 'Attachment': // fallthrough
       const attrs = Constants.splitMessageIDKey(message.key)
-      messageID = Constants.parseMessageID(attrs.messageID)
-      conversationIDKey = attrs.conversationIDKey
+      tuple = [Constants.parseMessageID(attrs.messageID), attrs.conversationIDKey]
       break
   }
 
-  if (!messageID) {
+  if (!tuple) {
     console.warn('Editing message with unknown message type:', message)
     return
-  } else if (messageID.type === 'invalid') {
+  }
+
+  const [messageID, conversationIDKey] = tuple
+  if (messageID.type === 'invalid') {
     console.warn('Editing message with invalid message ID type:', message)
     return
   } else if (typeof messageID.msgID !== 'number') {

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -158,6 +158,12 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
     select(Constants.lastMessageID, conversationIDKey),
   ])
 
+  if (!inboxConvo.name) {
+    console.warn('Editing message for non-existent TLF:', message)
+    return
+  }
+  const tlfName: string = inboxConvo.name
+
   // Not editing anymore
   yield put(Creators.showEditor(null))
 
@@ -169,18 +175,17 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
   }
 
   const outboxID = yield call(ChatTypes.localGenerateOutboxIDRpcPromise)
-  yield call(ChatTypes.localPostEditNonblockRpcPromise, {
-    param: {
-      body: newMessageText,
-      clientPrev: lastMessageID ? Constants.parseMessageID(lastMessageID).msgID : 0,
-      conversationID: Constants.keyToConversationID(conversationIDKey),
-      identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
-      outboxID,
-      supersedes: messageID,
-      tlfName: inboxConvo.name,
-      tlfPublic: false,
-    },
-  })
+  const param: ChatTypes.localPostEditNonblockRpcParam = {
+    body: newMessageText,
+    clientPrev: lastMessageID ? Constants.parseMessageID(lastMessageID).msgID : 0,
+    conversationID: Constants.keyToConversationID(conversationIDKey),
+    identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
+    outboxID,
+    supersedes: messageID,
+    tlfName,
+    tlfPublic: false,
+  }
+  yield call(ChatTypes.localPostEditNonblockRpcPromise, {param})
 }
 
 function* retryMessage(action: Constants.RetryMessage): SagaGenerator<any, any> {

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -141,10 +141,10 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
     console.warn('Editing non-text message:', message)
     return
   }
-
-  const attrs = Constants.splitMessageIDKey(message.key)
-  const conversationIDKey = attrs.conversationIDKey
-  const messageID = Constants.parseMessageID(attrs.messageID)
+  const textMessage = (message: Constants.TextMessage)
+  const attrs = Constants.splitMessageIDKey(textMessage.key)
+  const conversationIDKey: Constants.ConversationIDKey = attrs.conversationIDKey
+  const messageID: Constants.ParsedMessageID = Constants.parseMessageID(attrs.messageID)
   if (messageID.type === 'invalid') {
     console.warn('Editing message with invalid message ID type:', message)
     return
@@ -184,7 +184,7 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
   yield put(Creators.showEditor(null))
 
   // if message post-edit is the same as message pre-edit, skip call and marking message as 'EDITED'
-  const prevMessageText = message.message.stringValue()
+  const prevMessageText = textMessage.message.stringValue()
   const newMessageText = action.payload.text.stringValue()
   if (prevMessageText === newMessageText) {
     return

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -140,7 +140,6 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
   let tuple: ?[Constants.ParsedMessageID, Constants.ConversationIDKey]
   switch (message.type) {
     case 'Text':
-    case 'Attachment': // fallthrough
       const attrs = Constants.splitMessageIDKey(message.key)
       tuple = [Constants.parseMessageID(attrs.messageID), attrs.conversationIDKey]
       break

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -137,20 +137,14 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
 
 function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
   const {message} = action.payload
-  let tuple: ?[Constants.ParsedMessageID, Constants.ConversationIDKey]
-  switch (message.type) {
-    case 'Text':
-      const attrs = Constants.splitMessageIDKey(message.key)
-      tuple = [Constants.parseMessageID(attrs.messageID), attrs.conversationIDKey]
-      break
-  }
-
-  if (!tuple) {
-    console.warn('Editing message with unknown message type:', message)
+  if (message.type !== 'Text') {
+    console.warn('Editing non-text message:', message)
     return
   }
 
-  const [messageID, conversationIDKey] = tuple
+  const attrs = Constants.splitMessageIDKey(message.key)
+  const conversationIDKey = attrs.conversationIDKey
+  const messageID = Constants.parseMessageID(attrs.messageID)
   if (messageID.type === 'invalid') {
     console.warn('Editing message with invalid message ID type:', message)
     return

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -137,19 +137,19 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
 
 function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
   const {message} = action.payload
-  let messageID
+  let messageID: ?Constants.ParsedMessageID
   let conversationIDKey: Constants.ConversationIDKey = ''
   switch (message.type) {
     case 'Text':
     case 'Attachment': // fallthrough
       const attrs = Constants.splitMessageIDKey(message.key)
-      messageID = Constants.parseMessageID(attrs.messageID).msgID
+      messageID = Constants.parseMessageID(attrs.messageID)
       conversationIDKey = attrs.conversationIDKey
       break
   }
 
   if (!messageID) {
-    console.warn('Editing unknown message type', message)
+    console.warn('Editing message of type:', message)
     return
   }
 
@@ -181,7 +181,7 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
     conversationID: Constants.keyToConversationID(conversationIDKey),
     identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
     outboxID,
-    supersedes: messageID,
+    supersedes: messageID.msgID,
     tlfName,
     tlfPublic: false,
   }

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -145,14 +145,11 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
   const attrs = Constants.splitMessageIDKey(textMessage.key)
   const conversationIDKey: Constants.ConversationIDKey = attrs.conversationIDKey
   const messageID: Constants.ParsedMessageID = Constants.parseMessageID(attrs.messageID)
-  if (messageID.type === 'invalid') {
-    console.warn('Editing message with invalid message ID type:', message)
-    return
-  } else if (typeof messageID.msgID !== 'number') {
-    console.warn('Editing message with non-numeric message ID type:', message)
+  if (messageID.type !== 'rpcMessageID') {
+    console.warn('Editing message with invalid message ID type:', message, messageID)
     return
   }
-  let supersedes: number = messageID.msgID
+  let supersedes: ChatTypes.MessageID = messageID.msgID
 
   const [inboxConvo, lastMessageID]: [Constants.InboxState, ?Constants.MessageID] = yield all([
     select(Constants.getInbox, conversationIDKey),

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -149,9 +149,16 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
   }
 
   if (!messageID) {
-    console.warn('Editing message of type:', message)
+    console.warn('Editing message with unknown message type:', message)
+    return
+  } else if (messageID.type === 'invalid') {
+    console.warn('Editing message with invalid message ID type:', message)
+    return
+  } else if (typeof messageID.msgID !== 'number') {
+    console.warn('Editing message with non-numeric message ID type:', message)
     return
   }
+  let supersedes: number = messageID.msgID
 
   const [inboxConvo, lastMessageID]: [Constants.InboxState, ?Constants.MessageID] = yield all([
     select(Constants.getInbox, conversationIDKey),
@@ -181,7 +188,7 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
     conversationID: Constants.keyToConversationID(conversationIDKey),
     identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
     outboxID,
-    supersedes: messageID.msgID,
+    supersedes,
     tlfName,
     tlfPublic: false,
   }

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -264,20 +264,21 @@ class PopupEnabledList extends BaseList {
 
   // How this works is kinda crappy. We have to plumb through this key => message helper and all this DOM stuff just to support this
   _onEditLastMessage = () => {
-    const entry: any = this.props.messageKeys.findLastEntry(k => {
-      const m = this.props.getMessageFromMessageKey(k)
-      return !!(m && m.type === 'Text' && m.author === this.props.you)
+    let tuple: ?[number, Constants.MessageKey, Constants.TextMessage]
+    this.props.messageKeys.findLastKey((v, k) => {
+      const m = this.props.getMessageFromMessageKey(v)
+      if (m && m.type === 'Text' && m.author === this.props.you) {
+        tuple = [k, v, m]
+        return true
+      }
+      return false
     })
 
-    if (!entry) {
+    if (!tuple) {
       return
     }
 
-    const idx: number = entry[0]
-    const messageKey: Constants.MessageKey = entry[1]
-    // $ForceType
-    const message: Constants.TextMessage = this.props.getMessageFromMessageKey(messageKey)
-
+    let [idx, messageKey, message] = tuple
     if (message.messageState !== 'sent') {
       // For now, disallow editing of non-sent messages. In the
       // future, we may want to do something more intelligent.

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -269,27 +269,39 @@ class PopupEnabledList extends BaseList {
       return !!(m && m.type === 'Text' && m.author === this.props.you)
     })
 
-    if (entry) {
-      const idx: number = entry[0]
-      const messageKey: Constants.MessageKey = entry[1]
-      // $ForceType
-      const message: Constants.TextMessage = this.props.getMessageFromMessageKey(messageKey)
-
-      this._keepIdxVisible = idx
-      this.setState({listRerender: this.state.listRerender + 1})
-
-      const listNode = ReactDOM.findDOMNode(this._list)
-      if (listNode) {
-        // $FlowIssue
-        const messageNodes = listNode.querySelectorAll(`[data-message-key="${messageKey}"]`)
-        if (messageNodes) {
-          const messageNode = messageNodes[0]
-          if (messageNode) {
-            this._showEditor(message, this._domNodeToRect(messageNode))
-          }
-        }
-      }
+    if (!entry) {
+      return
     }
+
+    const idx: number = entry[0]
+    const messageKey: Constants.MessageKey = entry[1]
+    // $ForceType
+    const message: Constants.TextMessage = this.props.getMessageFromMessageKey(messageKey)
+
+    if (message.messageState !== 'sent') {
+      return
+    }
+
+    this._keepIdxVisible = idx
+    this.setState({listRerender: this.state.listRerender + 1})
+
+    const listNode = ReactDOM.findDOMNode(this._list)
+    if (!listNode) {
+      return
+    }
+
+    // $FlowIssue
+    const messageNodes = listNode.querySelectorAll(`[data-message-key="${messageKey}"]`)
+    if (!messageNodes) {
+      return
+    }
+
+    const messageNode = messageNodes[0]
+    if (!messageNode) {
+      return
+    }
+
+    this._showEditor(message, this._domNodeToRect(messageNode))
   }
 
   _renderPopup(

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -279,9 +279,7 @@ class PopupEnabledList extends BaseList {
     }
 
     const [idx, messageKey, message] = tuple
-    if (message.messageState !== 'sent') {
-      // For now, disallow editing of non-sent messages. In the
-      // future, we may want to do something more intelligent.
+    if (!Constants.textMessageEditable(message)) {
       return
     }
 

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -265,7 +265,7 @@ class PopupEnabledList extends BaseList {
   // How this works is kinda crappy. We have to plumb through this key => message helper and all this DOM stuff just to support this
   _onEditLastMessage = () => {
     let tuple: ?[number, Constants.MessageKey, Constants.TextMessage]
-    this.props.messageKeys.findLastKey((v, k) => {
+    this.props.messageKeys.findLastEntry((v, k) => {
       const m = this.props.getMessageFromMessageKey(v)
       if (m && m.type === 'Text' && m.author === this.props.you) {
         tuple = [k, v, m]

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -288,11 +288,10 @@ class PopupEnabledList extends BaseList {
     this.setState({listRerender: this.state.listRerender + 1})
 
     const listNode = ReactDOM.findDOMNode(this._list)
-    if (!listNode) {
+    if (!(listNode instanceof 'Element')) {
       return
     }
 
-    // $FlowIssue
     const messageNodes = listNode.querySelectorAll(`[data-message-key="${messageKey}"]`)
     if (!messageNodes) {
       return

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -289,7 +289,7 @@ class PopupEnabledList extends BaseList {
     this.setState({listRerender: this.state.listRerender + 1})
 
     const listNode = ReactDOM.findDOMNode(this._list)
-    if (!(listNode instanceof 'Element')) {
+    if (!(listNode instanceof window.Element)) {
       return
     }
 

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -278,7 +278,7 @@ class PopupEnabledList extends BaseList {
       return
     }
 
-    let [idx, messageKey, message] = tuple
+    const [idx, messageKey, message] = tuple
     if (message.messageState !== 'sent') {
       // For now, disallow editing of non-sent messages. In the
       // future, we may want to do something more intelligent.

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -279,6 +279,8 @@ class PopupEnabledList extends BaseList {
     const message: Constants.TextMessage = this.props.getMessageFromMessageKey(messageKey)
 
     if (message.messageState !== 'sent') {
+      // For now, disallow editing of non-sent messages. In the
+      // future, we may want to do something more intelligent.
       return
     }
 

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -284,7 +284,7 @@ class PopupEnabledList extends BaseList {
     }
 
     this._keepIdxVisible = idx
-    this.setState({listRerender: this.state.listRerender + 1})
+    this.setState(prevState => ({listRerender: prevState.listRerender + 1}))
 
     const listNode = ReactDOM.findDOMNode(this._list)
     if (!(listNode instanceof window.Element)) {

--- a/shared/chat/conversation/messages/popup.desktop.js
+++ b/shared/chat/conversation/messages/popup.desktop.js
@@ -15,12 +15,10 @@ const stylePopup = {
 export const TextPopupMenu = ({message, onShowEditor, onDeleteMessage, onHidden, style, you}: TextProps) => {
   let items = []
   if (message.author === you) {
-    const disabled = message.messageState !== 'sent'
     items = [
-      {disabled, onClick: () => onShowEditor(message), title: 'Edit'},
+      {disabled: message.messageState !== 'sent', onClick: () => onShowEditor(message), title: 'Edit'},
       {
         danger: true,
-        disabled,
         onClick: () => onDeleteMessage(message),
         subTitle: 'Deletes for everyone',
         title: 'Delete',

--- a/shared/chat/conversation/messages/popup.desktop.js
+++ b/shared/chat/conversation/messages/popup.desktop.js
@@ -15,10 +15,12 @@ const stylePopup = {
 export const TextPopupMenu = ({message, onShowEditor, onDeleteMessage, onHidden, style, you}: TextProps) => {
   let items = []
   if (message.author === you) {
+    const disabled = message.messageState !== 'sent'
     items = [
-      {onClick: () => onShowEditor(message), title: 'Edit'},
+      {disabled, onClick: () => onShowEditor(message), title: 'Edit'},
       {
         danger: true,
+        disabled,
         onClick: () => onDeleteMessage(message),
         subTitle: 'Deletes for everyone',
         title: 'Delete',

--- a/shared/chat/conversation/messages/popup.desktop.js
+++ b/shared/chat/conversation/messages/popup.desktop.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import {PopupMenu} from '../../../common-adapters'
+import {textMessageEditable} from '../../../constants/chat'
 import {fileUIName} from '../../../constants/platform'
 
 import MessagePopupHeader from './popup-header'
@@ -15,19 +16,22 @@ const stylePopup = {
 export const TextPopupMenu = ({message, onShowEditor, onDeleteMessage, onHidden, style, you}: TextProps) => {
   let items = []
   if (message.author === you) {
-    items = [
-      {disabled: message.messageState !== 'sent', onClick: () => onShowEditor(message), title: 'Edit'},
-      {
-        danger: true,
-        onClick: () => onDeleteMessage(message),
-        subTitle: 'Deletes for everyone',
-        title: 'Delete',
-      },
-    ]
-
     if (!message.senderDeviceRevokedAt) {
-      items.unshift('Divider')
+      items.push('Divider')
     }
+
+    if (textMessageEditable(message)) {
+      items.push({onClick: () => onShowEditor(message), title: 'Edit'})
+    } else {
+      items.push({disabled: true, title: 'Edit'})
+    }
+
+    items.push({
+      danger: true,
+      onClick: () => onDeleteMessage(message),
+      subTitle: 'Deletes for everyone',
+      title: 'Delete',
+    })
   }
   const header = {
     title: 'header',

--- a/shared/common-adapters/popup-menu.desktop.js
+++ b/shared/common-adapters/popup-menu.desktop.js
@@ -141,7 +141,6 @@ const stylesMenu = {
 }
 
 const stylesMenuText = {
-  ...globalStyles.clickable,
   color: undefined,
 }
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -81,6 +81,11 @@ export type TextMessage = {
   mentions: Mentions,
   channelMention: ChannelMention,
 }
+export function textMessageEditable(message: TextMessage): boolean {
+  // For now, disallow editing of non-sent messages. In the future, we
+  // may want to do something more intelligent.
+  return message.messageState === 'sent'
+}
 
 export type ErrorMessage = {
   type: 'Error',

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -840,7 +840,7 @@ function messageIDToSelfInventedID(msgID: MessageID) {
   return parseInt(msgID.substring(_selfInventedID.length), 16)
 }
 
-type ParsedMessageID =
+export type ParsedMessageID =
   | {
       type: 'rpcMessageID',
       msgID: ChatTypes.MessageID,


### PR DESCRIPTION
...by disabling the up-arrow shortcut, and also disabling
the edit per-message menu item. Also fix bug where disabled menu
items still get a hand cursor.

Also type-check editMessage better, so that we don't send a param
with unexpected types.