### PR TITLE
Remove error print

### DIFF
--- a/go/client/cmd_git_create.go
+++ b/go/client/cmd_git_create.go
@@ -77,7 +77,6 @@ func (c *CmdGitCreate) Run() error {
 	}
 
 	if err != nil {
-		fmt.Printf("%#v\n", err)
 		return err
 	}
 


### PR DESCRIPTION
```
$ keybase-prod git create testrepo1 --team=testergoofteam2.sub4
&errors.errorString{s:"Only team writers may create git repos."} <<<---- delete
▶ ERROR Only team writers may create git repos.
```