### PR TITLE
teamRequestAccess will now return additional data about open teams

### DIFF
--- a/go/client/cmd_team_request_access.go
+++ b/go/client/cmd_team_request_access.go
@@ -56,7 +56,7 @@ func (c *CmdTeamRequestAccess) Run() error {
 
 	dui := c.G().UI.GetDumbOutputUI()
 	if ret.Open {
-		dui.Printf("You have joined %q! Even though %q is an open team, it's still end-to-end encrypted - you'll have to wait till admin's device keys you in.\n", c.Team, c.Team)
+		dui.Printf("You have joined %q! Even though %q is an open team, it's still end-to-end encrypted - you'll have to wait until an admin's device keys you in.\n", c.Team, c.Team)
 	} else {
 		dui.Printf("If %q exists, an email has been sent to its admins, notifying of your request for access.\n", c.Team)
 	}

--- a/go/client/cmd_team_request_access.go
+++ b/go/client/cmd_team_request_access.go
@@ -49,13 +49,17 @@ func (c *CmdTeamRequestAccess) Run() error {
 		Name: c.Team,
 	}
 
-	err = cli.TeamRequestAccess(context.Background(), arg)
+	ret, err := cli.TeamRequestAccess(context.Background(), arg)
 	if err != nil {
 		return err
 	}
 
 	dui := c.G().UI.GetDumbOutputUI()
-	dui.Printf("If %q exists, an email has been sent to its admins, notifying of your request for access.\n", c.Team)
+	if ret.Open {
+		dui.Printf("You have joined %q! Even though %q is an open team, it's still end-to-end encrypted - you'll have to wait till admin's device keys you in.\n", c.Team, c.Team)
+	} else {
+		dui.Printf("If %q exists, an email has been sent to its admins, notifying of your request for access.\n", c.Team)
+	}
 
 	return nil
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1300,6 +1300,16 @@ func (o TeamSettings) DeepCopy() TeamSettings {
 	}
 }
 
+type TeamRequestAccessResult struct {
+	Open bool `codec:"open" json:"open"`
+}
+
+func (o TeamRequestAccessResult) DeepCopy() TeamRequestAccessResult {
+	return TeamRequestAccessResult{
+		Open: o.Open,
+	}
+}
+
 type BulkRes struct {
 	Invited        []string `codec:"invited" json:"invited"`
 	AlreadyInvited []string `codec:"alreadyInvited" json:"alreadyInvited"`
@@ -1784,7 +1794,7 @@ type TeamsInterface interface {
 	TeamEditMember(context.Context, TeamEditMemberArg) error
 	TeamRename(context.Context, TeamRenameArg) error
 	TeamAcceptInvite(context.Context, TeamAcceptInviteArg) error
-	TeamRequestAccess(context.Context, TeamRequestAccessArg) error
+	TeamRequestAccess(context.Context, TeamRequestAccessArg) (TeamRequestAccessResult, error)
 	TeamAcceptInviteOrRequestAccess(context.Context, TeamAcceptInviteOrRequestAccessArg) error
 	TeamListRequests(context.Context, int) ([]TeamJoinRequest, error)
 	TeamIgnoreRequest(context.Context, TeamIgnoreRequestArg) error
@@ -2009,7 +2019,7 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]TeamRequestAccessArg)(nil), args)
 						return
 					}
-					err = i.TeamRequestAccess(ctx, (*typedArgs)[0])
+					ret, err = i.TeamRequestAccess(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -2274,8 +2284,8 @@ func (c TeamsClient) TeamAcceptInvite(ctx context.Context, __arg TeamAcceptInvit
 	return
 }
 
-func (c TeamsClient) TeamRequestAccess(ctx context.Context, __arg TeamRequestAccessArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamRequestAccess", []interface{}{__arg}, nil)
+func (c TeamsClient) TeamRequestAccess(ctx context.Context, __arg TeamRequestAccessArg) (res TeamRequestAccessResult, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamRequestAccess", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -194,10 +194,10 @@ func (h *TeamsHandler) TeamAcceptInvite(ctx context.Context, arg keybase1.TeamAc
 	return teams.AcceptInvite(ctx, h.G().ExternalG(), arg.Token)
 }
 
-func (h *TeamsHandler) TeamRequestAccess(ctx context.Context, arg keybase1.TeamRequestAccessArg) (err error) {
+func (h *TeamsHandler) TeamRequestAccess(ctx context.Context, arg keybase1.TeamRequestAccessArg) (res keybase1.TeamRequestAccessResult, err error) {
 	h.G().CTraceTimed(ctx, "TeamRequestAccess", func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
-		return err
+		return keybase1.TeamRequestAccessResult{}, err
 	}
 	return teams.RequestAccess(ctx, h.G().ExternalG(), arg.Name)
 }

--- a/go/systests/team_open_test.go
+++ b/go/systests/team_open_test.go
@@ -36,7 +36,9 @@ func TestTeamOpenAutoAddMember(t *testing.T) {
 
 	t.Logf("Open team name is %q", teamName)
 
-	roo.teamsClient.TeamRequestAccess(context.TODO(), keybase1.TeamRequestAccessArg{Name: teamName})
+	ret, err := roo.teamsClient.TeamRequestAccess(context.TODO(), keybase1.TeamRequestAccessArg{Name: teamName})
+	require.NoError(t, err)
+	require.Equal(t, true, ret.Open)
 
 	own.kickTeamRekeyd()
 	own.waitForTeamChangedGregor(teamName, keybase1.Seqno(2))
@@ -210,7 +212,7 @@ func TestTeamOpenBans(t *testing.T) {
 	err = removeRunner.Run()
 	require.NoError(t, err)
 
-	err = bob.teamsClient.TeamRequestAccess(context.TODO(), keybase1.TeamRequestAccessArg{Name: team})
+	_, err = bob.teamsClient.TeamRequestAccess(context.TODO(), keybase1.TeamRequestAccessArg{Name: team})
 	require.Error(t, err)
 	appErr, ok := err.(libkb.AppStatusError)
 	require.True(t, ok)

--- a/go/teams/request_test.go
+++ b/go/teams/request_test.go
@@ -20,7 +20,7 @@ func TestAccessRequestAccept(t *testing.T) {
 	if err := u1.Login(tc.G); err != nil {
 		t.Fatal(err)
 	}
-	if err := RequestAccess(context.Background(), tc.G, teamName); err != nil {
+	if _, err := RequestAccess(context.Background(), tc.G, teamName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,7 +56,7 @@ func TestAccessRequestAccept(t *testing.T) {
 	if err := u1.Login(tc.G); err != nil {
 		t.Fatal(err)
 	}
-	err = RequestAccess(context.Background(), tc.G, teamName)
+	_, err = RequestAccess(context.Background(), tc.G, teamName)
 	if err == nil {
 		t.Fatal("second RequestAccess success, expected error")
 	}
@@ -87,7 +87,7 @@ func TestAccessRequestIgnore(t *testing.T) {
 	if err := u1.Login(tc.G); err != nil {
 		t.Fatal(err)
 	}
-	if err := RequestAccess(context.Background(), tc.G, teamName); err != nil {
+	if _, err := RequestAccess(context.Background(), tc.G, teamName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,7 +123,7 @@ func TestAccessRequestIgnore(t *testing.T) {
 	if err := u1.Login(tc.G); err != nil {
 		t.Fatal(err)
 	}
-	err = RequestAccess(context.Background(), tc.G, teamName)
+	_, err = RequestAccess(context.Background(), tc.G, teamName)
 	if err == nil {
 		t.Fatal("second RequestAccess success, expected error")
 	}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -670,7 +670,7 @@ func RequestAccess(ctx context.Context, g *libkb.GlobalContext, teamname string)
 
 	ret := keybase1.TeamRequestAccessResult{}
 	if apiRes != nil && apiRes.Body != nil {
-		// "open" key may not be included in result payload and it's
+		// "is_open" key may not be included in result payload and it's
 		// not an error.
 		ret.Open, _ = apiRes.Body.AtKey("is_open").GetBool()
 	}

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -454,6 +454,10 @@ protocol teams {
     TeamRole joinAs;
   }
 
+  record TeamRequestAccessResult {
+    boolean open;
+  }
+
   TeamCreateResult teamCreate(int sessionID, string name, boolean sendChatNotification);
   TeamCreateResult teamCreateWithSettings(int sessionID, string name, boolean sendChatNotification, TeamSettings settings);
   TeamDetails teamGet(int sessionID, string name, boolean forceRepoll);
@@ -467,7 +471,7 @@ protocol teams {
   void teamEditMember(int sessionID, string name, string username, TeamRole role);
   void teamRename(int sessionID, TeamName prevName, TeamName newName);
   void teamAcceptInvite(int sessionID, string token);
-  void teamRequestAccess(int sessionID, string name);
+  TeamRequestAccessResult teamRequestAccess(int sessionID, string name);
   // Accept an invite or request to join a team, try both.
   void teamAcceptInviteOrRequestAccess(int sessionID, string tokenOrName);
   array<TeamJoinRequest> teamListRequests(int sessionID);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2532,11 +2532,11 @@ export function teamsTeamRenameRpcPromise (request: (requestCommon & requestErro
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRename', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function teamsTeamRequestAccessRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam}): EngineChannel {
+export function teamsTeamRequestAccessRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamRequestAccessResult) => void} & {param: teamsTeamRequestAccessRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamRequestAccess', request)
 }
 
-export function teamsTeamRequestAccessRpcPromise (request: (requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam})): Promise<void> {
+export function teamsTeamRequestAccessRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamRequestAccessResult) => void} & {param: teamsTeamRequestAccessRpcParam})): Promise<teamsTeamRequestAccessResult> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRequestAccess', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
@@ -4973,6 +4973,10 @@ export type TeamRefreshers = {
   wantMembersRole: TeamRole,
 }
 
+export type TeamRequestAccessResult = {
+  open: boolean,
+}
+
 export type TeamRole =
     0 // NONE_0
   | 1 // READER_1
@@ -6596,6 +6600,7 @@ type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList
 type teamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
+type teamsTeamRequestAccessResult = TeamRequestAccessResult
 type teamsTeamTreeResult = TeamTreeResult
 type teamsUiConfirmRootTeamDeleteResult = boolean
 type teamsUiConfirmSubteamDeleteResult = boolean

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1145,6 +1145,16 @@
     },
     {
       "type": "record",
+      "name": "TeamRequestAccessResult",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "open"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "BulkRes",
       "fields": [
         {
@@ -1492,7 +1502,7 @@
           "type": "string"
         }
       ],
-      "response": null
+      "response": "TeamRequestAccessResult"
     },
     "teamAcceptInviteOrRequestAccess": {
       "request": [

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2532,11 +2532,11 @@ export function teamsTeamRenameRpcPromise (request: (requestCommon & requestErro
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRename', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function teamsTeamRequestAccessRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam}): EngineChannel {
+export function teamsTeamRequestAccessRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamRequestAccessResult) => void} & {param: teamsTeamRequestAccessRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamRequestAccess', request)
 }
 
-export function teamsTeamRequestAccessRpcPromise (request: (requestCommon & requestErrorCallback & {param: teamsTeamRequestAccessRpcParam})): Promise<void> {
+export function teamsTeamRequestAccessRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamRequestAccessResult) => void} & {param: teamsTeamRequestAccessRpcParam})): Promise<teamsTeamRequestAccessResult> {
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamRequestAccess', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
@@ -4973,6 +4973,10 @@ export type TeamRefreshers = {
   wantMembersRole: TeamRole,
 }
 
+export type TeamRequestAccessResult = {
+  open: boolean,
+}
+
 export type TeamRole =
     0 // NONE_0
   | 1 // READER_1
@@ -6596,6 +6600,7 @@ type teamsTeamGetResult = TeamDetails
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList
 type teamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
+type teamsTeamRequestAccessResult = TeamRequestAccessResult
 type teamsTeamTreeResult = TeamTreeResult
 type teamsUiConfirmRootTeamDeleteResult = boolean
 type teamsUiConfirmSubteamDeleteResult = boolean


### PR DESCRIPTION
If user is requesting access to an open team, do not print message about "e-mail has been sent to an admin", but say it's an open team and they will be keyed in shortly.