### PR TITLE
call CloneWithAddedDepth everywhere we wrap a logging function

### DIFF
--- a/go/libkb/vdebug.go
+++ b/go/libkb/vdebug.go
@@ -38,7 +38,7 @@ func (v *VDebugLog) Log(lev VDebugLevel, fs string, args ...interface{}) {
 	if lev <= v.lev {
 		prfx := fmt.Sprintf("{VDL:%d} ", int(lev))
 		fs = prfx + fs
-		v.log.Debug(fs, args...)
+		v.log.CloneWithAddedDepth(1).Debug(fs, args...)
 	}
 }
 
@@ -46,7 +46,7 @@ func (v *VDebugLog) CLogf(ctx context.Context, lev VDebugLevel, fs string, args 
 	if lev <= v.lev {
 		prfx := fmt.Sprintf("{VDL:%d} ", int(lev))
 		fs = prfx + fs
-		v.log.CDebugf(ctx, fs, args...)
+		v.log.CloneWithAddedDepth(1).CDebugf(ctx, fs, args...)
 	}
 }
 

--- a/go/logger/single_context_logger.go
+++ b/go/logger/single_context_logger.go
@@ -18,52 +18,52 @@ func NewSingleContextLogger(ctx context.Context, l Logger) *SingleContextLogger 
 var _ Logger = (*SingleContextLogger)(nil)
 
 func (s *SingleContextLogger) Debug(format string, args ...interface{}) {
-	s.logger.CDebugf(s.ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CDebugf(s.ctx, format, args...)
 }
 func (s *SingleContextLogger) CDebugf(ctx context.Context, format string, args ...interface{}) {
-	s.logger.CDebugf(ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CDebugf(ctx, format, args...)
 }
 func (s *SingleContextLogger) Info(format string, args ...interface{}) {
-	s.logger.CInfof(s.ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CInfof(s.ctx, format, args...)
 }
 func (s *SingleContextLogger) CInfof(ctx context.Context, format string, args ...interface{}) {
-	s.logger.CInfof(ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CInfof(ctx, format, args...)
 }
 func (s *SingleContextLogger) Notice(format string, args ...interface{}) {
-	s.logger.CNoticef(s.ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CNoticef(s.ctx, format, args...)
 }
 func (s *SingleContextLogger) CNoticef(ctx context.Context, format string, args ...interface{}) {
-	s.logger.CNoticef(ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CNoticef(ctx, format, args...)
 }
 func (s *SingleContextLogger) Warning(format string, args ...interface{}) {
-	s.logger.CWarningf(s.ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CWarningf(s.ctx, format, args...)
 }
 func (s *SingleContextLogger) CWarningf(ctx context.Context, format string, args ...interface{}) {
-	s.logger.CWarningf(ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CWarningf(ctx, format, args...)
 }
 func (s *SingleContextLogger) Error(format string, args ...interface{}) {
-	s.logger.CErrorf(s.ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CErrorf(s.ctx, format, args...)
 }
 func (s *SingleContextLogger) Errorf(format string, args ...interface{}) {
-	s.logger.CErrorf(s.ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CErrorf(s.ctx, format, args...)
 }
 func (s *SingleContextLogger) CErrorf(ctx context.Context, format string, args ...interface{}) {
-	s.logger.CErrorf(ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CErrorf(ctx, format, args...)
 }
 func (s *SingleContextLogger) Critical(format string, args ...interface{}) {
-	s.logger.CCriticalf(s.ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CCriticalf(s.ctx, format, args...)
 }
 func (s *SingleContextLogger) CCriticalf(ctx context.Context, format string, args ...interface{}) {
-	s.logger.CCriticalf(ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CCriticalf(ctx, format, args...)
 }
 func (s *SingleContextLogger) Fatalf(format string, args ...interface{}) {
-	s.logger.CFatalf(s.ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CFatalf(s.ctx, format, args...)
 }
 func (s *SingleContextLogger) CFatalf(ctx context.Context, format string, args ...interface{}) {
-	s.logger.CFatalf(ctx, format, args...)
+	s.logger.CloneWithAddedDepth(1).CFatalf(ctx, format, args...)
 }
 func (s *SingleContextLogger) Profile(fmts string, arg ...interface{}) {
-	s.logger.Profile(fmts, arg...)
+	s.logger.CloneWithAddedDepth(1).Profile(fmts, arg...)
 }
 func (s *SingleContextLogger) Configure(style string, debug bool, filename string) {
 	s.logger.Configure(style, debug, filename)

--- a/go/logger/single_context_logger.go
+++ b/go/logger/single_context_logger.go
@@ -72,7 +72,10 @@ func (s *SingleContextLogger) RotateLogFile() error {
 	return s.logger.RotateLogFile()
 }
 func (s *SingleContextLogger) CloneWithAddedDepth(depth int) Logger {
-	return s.logger.CloneWithAddedDepth(depth)
+	return &SingleContextLogger{
+		ctx:    s.ctx,
+		logger: s.logger.CloneWithAddedDepth(depth),
+	}
 }
 func (s *SingleContextLogger) SetExternalHandler(handler ExternalHandler) {
 	s.logger.SetExternalHandler(handler)

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -175,7 +175,7 @@ func (log *Standard) Debug(fmt string, arg ...interface{}) {
 func (log *Standard) CDebugf(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.DEBUG) {
-		log.Debug(prepareString(ctx, fmt), arg...)
+		log.CloneWithAddedDepth(1).Debug(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -189,7 +189,7 @@ func (log *Standard) Info(fmt string, arg ...interface{}) {
 func (log *Standard) CInfof(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.INFO) {
-		log.Info(prepareString(ctx, fmt), arg...)
+		log.CloneWithAddedDepth(1).Info(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -203,7 +203,7 @@ func (log *Standard) Notice(fmt string, arg ...interface{}) {
 func (log *Standard) CNoticef(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.NOTICE) {
-		log.Notice(prepareString(ctx, fmt), arg...)
+		log.CloneWithAddedDepth(1).Notice(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -217,7 +217,7 @@ func (log *Standard) Warning(fmt string, arg ...interface{}) {
 func (log *Standard) CWarningf(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.WARNING) {
-		log.Warning(prepareString(ctx, fmt), arg...)
+		log.CloneWithAddedDepth(1).Warning(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -229,13 +229,13 @@ func (log *Standard) Error(fmt string, arg ...interface{}) {
 }
 
 func (log *Standard) Errorf(fmt string, arg ...interface{}) {
-	log.Error(fmt, arg...)
+	log.CloneWithAddedDepth(1).Error(fmt, arg...)
 }
 
 func (log *Standard) CErrorf(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.ERROR) {
-		log.Error(prepareString(ctx, fmt), arg...)
+		log.CloneWithAddedDepth(1).Error(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -249,7 +249,7 @@ func (log *Standard) Critical(fmt string, arg ...interface{}) {
 func (log *Standard) CCriticalf(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.CRITICAL) {
-		log.Critical(prepareString(ctx, fmt), arg...)
+		log.CloneWithAddedDepth(1).Critical(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -262,11 +262,11 @@ func (log *Standard) Fatalf(fmt string, arg ...interface{}) {
 
 func (log *Standard) CFatalf(ctx context.Context, fmt string,
 	arg ...interface{}) {
-	log.Fatalf(prepareString(ctx, fmt), arg...)
+	log.CloneWithAddedDepth(1).Fatalf(prepareString(ctx, fmt), arg...)
 }
 
 func (log *Standard) Profile(fmts string, arg ...interface{}) {
-	log.Debug(fmts, arg...)
+	log.CloneWithAddedDepth(1).Debug(fmts, arg...)
 }
 
 // Configure sets the style of the log file, whether debugging (verbose)

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -329,15 +329,15 @@ func (g *gregorHandler) getRPCCli() rpc.GenericClient {
 }
 
 func (g *gregorHandler) Debug(ctx context.Context, s string, args ...interface{}) {
-	g.G().Log.CDebugf(ctx, "PushHandler: "+s, args...)
+	g.G().Log.CloneWithAddedDepth(1).CDebugf(ctx, "PushHandler: "+s, args...)
 }
 
 func (g *gregorHandler) Warning(ctx context.Context, s string, args ...interface{}) {
-	g.G().Log.CWarningf(ctx, "PushHandler: "+s, args...)
+	g.G().Log.CloneWithAddedDepth(1).CWarningf(ctx, "PushHandler: "+s, args...)
 }
 
 func (g *gregorHandler) Errorf(ctx context.Context, s string, args ...interface{}) {
-	g.G().Log.CErrorf(ctx, "PushHandler: "+s, args...)
+	g.G().Log.CloneWithAddedDepth(1).CErrorf(ctx, "PushHandler: "+s, args...)
 }
 
 func (g *gregorHandler) SetPushStateFilter(f func(m gregor.Message) bool) {


### PR DESCRIPTION
Many log lines in our service output used to say they were from
"standard.go" or something similar, because that's where we defined out
logging wrappers. The problem is that logging functions have a built-in
notion of how many stackframes they need to pop to get the caller's
name, and wrapping them breaks this. Use CloneWithAddedDepth(1) in most
of the places where we do this sort of wrapping, to fix the issue. I
didn't try to be exhaustive here -- I just kept knocking off wrappers
until all the logs I saw during service startup looked correct.

r? @maxtaco @strib 