### PR TITLE
Git repos error individually

### DIFF
--- a/go/git/delete.go
+++ b/go/git/delete.go
@@ -22,7 +22,12 @@ func DeleteMetadata(ctx context.Context, g *libkb.GlobalContext, folder keybase1
 		return err
 	}
 	var repoID keybase1.RepoID
-	for _, repo := range repos {
+	for _, repoResult := range repos {
+		repo, err := repoResult.GetIfOk()
+		if err != nil {
+			g.Log.CDebugf(ctx, "%v", err)
+			continue
+		}
 		if repo.LocalMetadata.RepoName == repoName {
 			repoID = repo.RepoID
 			break

--- a/go/git/get.go
+++ b/go/git/get.go
@@ -81,9 +81,9 @@ func folderFromTeamID(ctx context.Context, g *libkb.GlobalContext, teamID keybas
 	}, nil
 }
 
+// If folder is nil, get for all folders.
 func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keybase1.Folder) ([]keybase1.GitRepoResult, error) {
 	teamer := NewTeamer(g)
-	cryptoer := NewCrypto(g)
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "kbfs/git/team/get",
@@ -112,137 +112,170 @@ func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keyba
 	// "[]" instead of "null" in the final JSON output on the CLI, which is
 	// preferable.
 	resultList := []keybase1.GitRepoResult{}
+	var firstErr error
+	var anySuccess bool
 	for _, responseRepo := range serverResponse.Repos {
-		// If the folder was passed in, use it. Otherwise, load the team to
-		// figure it out.
-		var repoFolder keybase1.Folder
-		if folder != nil {
-			repoFolder = *folder
+		info, skip, err := getMetadataInnerSingle(ctx, g, folder, responseRepo)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			resultList = append(resultList, keybase1.NewGitRepoResultWithErr(err.Error()))
 		} else {
-			repoFolder, err = folderFromTeamID(ctx, g, responseRepo.TeamID)
-			if err != nil {
-				return nil, err
-			}
-
-			// Currently we want to pretend that multi-user personal repos
-			// (/keybase/{private,public}/chris,max/...) don't exist. Short circuit here
-			// to keep those out of the results list.
-			if repoFolder.Name != g.Env.GetUsername().String() &&
-				(repoFolder.FolderType == keybase1.FolderType_PRIVATE || repoFolder.FolderType == keybase1.FolderType_PUBLIC) {
-
-				continue
+			if !skip {
+				anySuccess = true
+				resultList = append(resultList, keybase1.NewGitRepoResultWithOk(*info))
 			}
 		}
+	}
 
-		teamIDVis := keybase1.TeamIDWithVisibility{
-			TeamID: responseRepo.TeamID,
-		}
-		if repoFolder.Private {
-			teamIDVis.Visibility = keybase1.TLFVisibility_PRIVATE
-		} else {
-			teamIDVis.Visibility = keybase1.TLFVisibility_PUBLIC
-		}
+	// If there were no repos, return ok
+	// If all repos failed, return the first error (something is probably wrong that's not repo-specific)
+	// If no repos failed, return ok
 
-		ciphertext, err := base64.StdEncoding.DecodeString(responseRepo.EncryptedMetadata)
-		if err != nil {
-			return nil, err
-		}
-
-		nonceSlice, err := base64.StdEncoding.DecodeString(responseRepo.Nonce)
-		if err != nil {
-			return nil, err
-		}
-		if len(nonceSlice) != len(keybase1.BoxNonce{}) {
-			return nil, fmt.Errorf("expected a nonce of length %d, found %d", len(keybase1.BoxNonce{}), len(nonceSlice))
-		}
-		var nonce keybase1.BoxNonce
-		copy(nonce[:], nonceSlice)
-
-		encryptedMetadata := keybase1.EncryptedGitMetadata{
-			V:   responseRepo.EncryptionVersion,
-			E:   ciphertext,
-			N:   nonce,
-			Gen: responseRepo.KeyGeneration,
-		}
-		msgpackPlaintext, err := cryptoer.Unbox(ctx, teamIDVis, &encryptedMetadata)
-		if err != nil {
-			return nil, err
-		}
-
-		var localMetadataVersioned keybase1.GitLocalMetadataVersioned
-		mh := codec.MsgpackHandle{WriteExt: true}
-		dec := codec.NewDecoderBytes(msgpackPlaintext, &mh)
-		err = dec.Decode(&localMetadataVersioned)
-		if err != nil {
-			return nil, err
-		}
-
-		// Translate back from GitLocalMetadataVersioned to the decoupled type
-		// that we use for local RPC.
-		version, err := localMetadataVersioned.Version()
-		if err != nil {
-			return nil, err
-		}
-		var localMetadata keybase1.GitLocalMetadata
-		switch version {
-		case keybase1.GitLocalMetadataVersion_V1:
-			localMetadata = keybase1.GitLocalMetadata{
-				RepoName: localMetadataVersioned.V1().RepoName,
-			}
-		default:
-			return nil, fmt.Errorf("unrecognized variant of GitLocalMetadataVersioned: %#v", version)
-		}
-
-		// Load UPAKs to get the last writer username and device name.
-		lastWriterUPAK, _, err := g.GetUPAKLoader().LoadV2(libkb.NewLoadUserArg(g).WithUID(responseRepo.LastModifyingUID))
-		if err != nil {
-			return nil, err
-		}
-		var deviceName string
-		for _, deviceKey := range lastWriterUPAK.Current.DeviceKeys {
-			if deviceKey.DeviceID.Eq(responseRepo.LastModifyingDeviceID) {
-				deviceName = deviceKey.DeviceDescription
-				break
-			}
-		}
-		if deviceName == "" {
-			return nil, fmt.Errorf("can't find device name for %s's device ID %s", lastWriterUPAK.Current.Username, responseRepo.LastModifyingDeviceID)
-		}
-
-		// Load the team to get the current user's role, for canDelete.
-		team, err := teams.Load(ctx, g, keybase1.LoadTeamArg{
-			ID:     responseRepo.TeamID,
-			Public: !repoFolder.Private,
-		})
-		if err != nil {
-			return nil, err
-		}
-		selfUPAK, _, err := g.GetUPAKLoader().LoadV2(libkb.NewLoadUserArg(g).WithSelf(true).WithUID(g.GetMyUID()))
-		if err != nil {
-			return nil, err
-		}
-		role, err := team.MemberRole(ctx, selfUPAK.Current.ToUserVersion())
-		if err != nil {
-			return nil, err
-		}
-
-		resultList = append(resultList, keybase1.GitRepoResult{
-			Folder:         repoFolder,
-			RepoID:         responseRepo.RepoID,
-			RepoUrl:        formatRepoURL(repoFolder, string(localMetadata.RepoName)),
-			GlobalUniqueID: formatUniqueRepoID(responseRepo.TeamID, responseRepo.RepoID),
-			CanDelete:      role.IsAdminOrAbove(),
-			LocalMetadata:  localMetadata,
-			ServerMetadata: keybase1.GitServerMetadata{
-				Ctime: keybase1.ToTime(responseRepo.CTime),
-				Mtime: keybase1.ToTime(responseRepo.MTime),
-				LastModifyingUsername:   lastWriterUPAK.Current.Username,
-				LastModifyingDeviceID:   responseRepo.LastModifyingDeviceID,
-				LastModifyingDeviceName: deviceName,
-			},
-		})
+	if len(resultList) == 0 {
+		return resultList, nil
+	}
+	if !anySuccess {
+		return resultList, firstErr
 	}
 	return resultList, nil
+}
+
+// if skip is true the other return values are nil
+func getMetadataInnerSingle(ctx context.Context, g *libkb.GlobalContext,
+	folder *keybase1.Folder, responseRepo ServerResponseRepo) (info *keybase1.GitRepoInfo, skip bool, err error) {
+
+	cryptoer := NewCrypto(g)
+
+	// If the folder was passed in, use it. Otherwise, load the team to
+	// figure it out.
+	var repoFolder keybase1.Folder
+	if folder != nil {
+		repoFolder = *folder
+	} else {
+		repoFolder, err = folderFromTeamID(ctx, g, responseRepo.TeamID)
+		if err != nil {
+			return nil, false, err
+		}
+
+		// Currently we want to pretend that multi-user personal repos
+		// (/keybase/{private,public}/chris,max/...) don't exist. Short circuit here
+		// to keep those out of the results list.
+		if repoFolder.Name != g.Env.GetUsername().String() &&
+			(repoFolder.FolderType == keybase1.FolderType_PRIVATE || repoFolder.FolderType == keybase1.FolderType_PUBLIC) {
+
+			return nil, true, nil
+		}
+	}
+
+	teamIDVis := keybase1.TeamIDWithVisibility{
+		TeamID: responseRepo.TeamID,
+	}
+	if repoFolder.Private {
+		teamIDVis.Visibility = keybase1.TLFVisibility_PRIVATE
+	} else {
+		teamIDVis.Visibility = keybase1.TLFVisibility_PUBLIC
+	}
+
+	ciphertext, err := base64.StdEncoding.DecodeString(responseRepo.EncryptedMetadata)
+	if err != nil {
+		return nil, false, err
+	}
+
+	nonceSlice, err := base64.StdEncoding.DecodeString(responseRepo.Nonce)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(nonceSlice) != len(keybase1.BoxNonce{}) {
+		return nil, false, fmt.Errorf("expected a nonce of length %d, found %d", len(keybase1.BoxNonce{}), len(nonceSlice))
+	}
+	var nonce keybase1.BoxNonce
+	copy(nonce[:], nonceSlice)
+
+	encryptedMetadata := keybase1.EncryptedGitMetadata{
+		V:   responseRepo.EncryptionVersion,
+		E:   ciphertext,
+		N:   nonce,
+		Gen: responseRepo.KeyGeneration,
+	}
+	msgpackPlaintext, err := cryptoer.Unbox(ctx, teamIDVis, &encryptedMetadata)
+	if err != nil {
+		return nil, false, fmt.Errorf("repo tid:%v visibility:%s: %v", teamIDVis.TeamID, teamIDVis.Visibility, err)
+	}
+
+	var localMetadataVersioned keybase1.GitLocalMetadataVersioned
+	mh := codec.MsgpackHandle{WriteExt: true}
+	dec := codec.NewDecoderBytes(msgpackPlaintext, &mh)
+	err = dec.Decode(&localMetadataVersioned)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Translate back from GitLocalMetadataVersioned to the decoupled type
+	// that we use for local RPC.
+	version, err := localMetadataVersioned.Version()
+	if err != nil {
+		return nil, false, err
+	}
+	var localMetadata keybase1.GitLocalMetadata
+	switch version {
+	case keybase1.GitLocalMetadataVersion_V1:
+		localMetadata = keybase1.GitLocalMetadata{
+			RepoName: localMetadataVersioned.V1().RepoName,
+		}
+	default:
+		return nil, false, fmt.Errorf("unrecognized variant of GitLocalMetadataVersioned: %#v", version)
+	}
+
+	// Load UPAKs to get the last writer username and device name.
+	lastWriterUPAK, _, err := g.GetUPAKLoader().LoadV2(libkb.NewLoadUserArg(g).WithUID(responseRepo.LastModifyingUID))
+	if err != nil {
+		return nil, false, err
+	}
+	var deviceName string
+	for _, deviceKey := range lastWriterUPAK.Current.DeviceKeys {
+		if deviceKey.DeviceID.Eq(responseRepo.LastModifyingDeviceID) {
+			deviceName = deviceKey.DeviceDescription
+			break
+		}
+	}
+	if deviceName == "" {
+		return nil, false, fmt.Errorf("can't find device name for %s's device ID %s", lastWriterUPAK.Current.Username, responseRepo.LastModifyingDeviceID)
+	}
+
+	// Load the team to get the current user's role, for canDelete.
+	team, err := teams.Load(ctx, g, keybase1.LoadTeamArg{
+		ID:     responseRepo.TeamID,
+		Public: !repoFolder.Private,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	selfUPAK, _, err := g.GetUPAKLoader().LoadV2(libkb.NewLoadUserArg(g).WithSelf(true).WithUID(g.GetMyUID()))
+	if err != nil {
+		return nil, false, err
+	}
+	role, err := team.MemberRole(ctx, selfUPAK.Current.ToUserVersion())
+	if err != nil {
+		return nil, false, err
+	}
+
+	return &keybase1.GitRepoInfo{
+		Folder:         repoFolder,
+		RepoID:         responseRepo.RepoID,
+		RepoUrl:        formatRepoURL(repoFolder, string(localMetadata.RepoName)),
+		GlobalUniqueID: formatUniqueRepoID(responseRepo.TeamID, responseRepo.RepoID),
+		CanDelete:      role.IsAdminOrAbove(),
+		LocalMetadata:  localMetadata,
+		ServerMetadata: keybase1.GitServerMetadata{
+			Ctime: keybase1.ToTime(responseRepo.CTime),
+			Mtime: keybase1.ToTime(responseRepo.MTime),
+			LastModifyingUsername:   lastWriterUPAK.Current.Username,
+			LastModifyingDeviceID:   responseRepo.LastModifyingDeviceID,
+			LastModifyingDeviceName: deviceName,
+		},
+	}, false, nil
 }
 
 func GetMetadata(ctx context.Context, g *libkb.GlobalContext, folder keybase1.Folder) ([]keybase1.GitRepoResult, error) {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2008,3 +2008,17 @@ func (p StringKVPair) IntValue() int {
 	}
 	return i
 }
+
+func (r *GitRepoResult) GetIfOk() (res GitRepoInfo, err error) {
+	state, err := r.State()
+	if err != nil {
+		return res, err
+	}
+	switch state {
+	case GitRepoResultState_ERR:
+		return res, fmt.Errorf(r.Err())
+	case GitRepoResultState_OK:
+		return r.Ok(), nil
+	}
+	return res, fmt.Errorf("git repo unknown error")
+}

--- a/go/protocol/keybase1/git.go
+++ b/go/protocol/keybase1/git.go
@@ -143,7 +143,109 @@ func (o GitServerMetadata) DeepCopy() GitServerMetadata {
 	}
 }
 
+type GitRepoResultState int
+
+const (
+	GitRepoResultState_ERR GitRepoResultState = 0
+	GitRepoResultState_OK  GitRepoResultState = 1
+)
+
+func (o GitRepoResultState) DeepCopy() GitRepoResultState { return o }
+
+var GitRepoResultStateMap = map[string]GitRepoResultState{
+	"ERR": 0,
+	"OK":  1,
+}
+
+var GitRepoResultStateRevMap = map[GitRepoResultState]string{
+	0: "ERR",
+	1: "OK",
+}
+
+func (e GitRepoResultState) String() string {
+	if v, ok := GitRepoResultStateRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type GitRepoResult struct {
+	State__ GitRepoResultState `codec:"state" json:"state"`
+	Err__   *string            `codec:"err,omitempty" json:"err,omitempty"`
+	Ok__    *GitRepoInfo       `codec:"ok,omitempty" json:"ok,omitempty"`
+}
+
+func (o *GitRepoResult) State() (ret GitRepoResultState, err error) {
+	switch o.State__ {
+	case GitRepoResultState_ERR:
+		if o.Err__ == nil {
+			err = errors.New("unexpected nil value for Err__")
+			return ret, err
+		}
+	case GitRepoResultState_OK:
+		if o.Ok__ == nil {
+			err = errors.New("unexpected nil value for Ok__")
+			return ret, err
+		}
+	}
+	return o.State__, nil
+}
+
+func (o GitRepoResult) Err() (res string) {
+	if o.State__ != GitRepoResultState_ERR {
+		panic("wrong case accessed")
+	}
+	if o.Err__ == nil {
+		return
+	}
+	return *o.Err__
+}
+
+func (o GitRepoResult) Ok() (res GitRepoInfo) {
+	if o.State__ != GitRepoResultState_OK {
+		panic("wrong case accessed")
+	}
+	if o.Ok__ == nil {
+		return
+	}
+	return *o.Ok__
+}
+
+func NewGitRepoResultWithErr(v string) GitRepoResult {
+	return GitRepoResult{
+		State__: GitRepoResultState_ERR,
+		Err__:   &v,
+	}
+}
+
+func NewGitRepoResultWithOk(v GitRepoInfo) GitRepoResult {
+	return GitRepoResult{
+		State__: GitRepoResultState_OK,
+		Ok__:    &v,
+	}
+}
+
+func (o GitRepoResult) DeepCopy() GitRepoResult {
+	return GitRepoResult{
+		State__: o.State__.DeepCopy(),
+		Err__: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.Err__),
+		Ok__: (func(x *GitRepoInfo) *GitRepoInfo {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Ok__),
+	}
+}
+
+type GitRepoInfo struct {
 	Folder         Folder            `codec:"folder" json:"folder"`
 	RepoID         RepoID            `codec:"repoID" json:"repoID"`
 	LocalMetadata  GitLocalMetadata  `codec:"localMetadata" json:"localMetadata"`
@@ -153,8 +255,8 @@ type GitRepoResult struct {
 	CanDelete      bool              `codec:"canDelete" json:"canDelete"`
 }
 
-func (o GitRepoResult) DeepCopy() GitRepoResult {
-	return GitRepoResult{
+func (o GitRepoInfo) DeepCopy() GitRepoInfo {
+	return GitRepoInfo{
 		Folder:         o.Folder.DeepCopy(),
 		RepoID:         o.RepoID.DeepCopy(),
 		LocalMetadata:  o.LocalMetadata.DeepCopy(),

--- a/protocol/avdl/keybase1/git.avdl
+++ b/protocol/avdl/keybase1/git.avdl
@@ -52,7 +52,17 @@ protocol git {
   void putGitMetadata(Folder folder, RepoID repoID, GitLocalMetadata metadata, boolean notifyTeam);
   void deleteGitMetadata(Folder folder, GitRepoName repoName);
 
-  record GitRepoResult {
+  enum GitRepoResultState {
+    ERR_0,
+    OK_1
+  }
+
+  variant GitRepoResult switch (GitRepoResultState state) {
+    case ERR: string;
+    case OK: GitRepoInfo;
+  }
+
+  record GitRepoInfo {
     Folder folder;
     RepoID repoID;
     GitLocalMetadata localMetadata;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -297,6 +297,11 @@ export const GitGitLocalMetadataVersion = {
   v1: 1,
 }
 
+export const GitGitRepoResultState = {
+  err: 0,
+  ok: 1,
+}
+
 export const GregorUIPushReason = {
   none: 0,
   reconnected: 1,
@@ -3413,9 +3418,7 @@ export type GitLocalMetadataVersion =
 export type GitLocalMetadataVersioned =
     { version: 1, v1: ?GitLocalMetadataV1 }
 
-export type GitRepoName = string
-
-export type GitRepoResult = {
+export type GitRepoInfo = {
   folder: Folder,
   repoID: RepoID,
   localMetadata: GitLocalMetadata,
@@ -3424,6 +3427,16 @@ export type GitRepoResult = {
   globalUniqueID: string,
   canDelete: boolean,
 }
+
+export type GitRepoName = string
+
+export type GitRepoResult =
+    { state: 0, err: ?string }
+  | { state: 1, ok: ?GitRepoInfo }
+
+export type GitRepoResultState =
+    0 // ERR_0
+  | 1 // OK_1
 
 export type GitServerMetadata = {
   ctime: Time,

--- a/protocol/json/keybase1/git.json
+++ b/protocol/json/keybase1/git.json
@@ -110,8 +110,40 @@
       ]
     },
     {
-      "type": "record",
+      "type": "enum",
+      "name": "GitRepoResultState",
+      "symbols": [
+        "ERR_0",
+        "OK_1"
+      ]
+    },
+    {
+      "type": "variant",
       "name": "GitRepoResult",
+      "switch": {
+        "type": "GitRepoResultState",
+        "name": "state"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "ERR",
+            "def": false
+          },
+          "body": "string"
+        },
+        {
+          "label": {
+            "name": "OK",
+            "def": false
+          },
+          "body": "GitRepoInfo"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "GitRepoInfo",
       "fields": [
         {
           "type": "Folder",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -297,6 +297,11 @@ export const GitGitLocalMetadataVersion = {
   v1: 1,
 }
 
+export const GitGitRepoResultState = {
+  err: 0,
+  ok: 1,
+}
+
 export const GregorUIPushReason = {
   none: 0,
   reconnected: 1,
@@ -3413,9 +3418,7 @@ export type GitLocalMetadataVersion =
 export type GitLocalMetadataVersioned =
     { version: 1, v1: ?GitLocalMetadataV1 }
 
-export type GitRepoName = string
-
-export type GitRepoResult = {
+export type GitRepoInfo = {
   folder: Folder,
   repoID: RepoID,
   localMetadata: GitLocalMetadata,
@@ -3424,6 +3427,16 @@ export type GitRepoResult = {
   globalUniqueID: string,
   canDelete: boolean,
 }
+
+export type GitRepoName = string
+
+export type GitRepoResult =
+    { state: 0, err: ?string }
+  | { state: 1, ok: ?GitRepoInfo }
+
+export type GitRepoResultState =
+    0 // ERR_0
+  | 1 // OK_1
 
 export type GitServerMetadata = {
   ctime: Time,


### PR DESCRIPTION
When getting the list of git repos you get a list of `GitRepoResult`'s which are either `ok -> GitRepoInfo` or `err -> string`. An error is not returned unless all of the repos error out. Because chances are in that case something not repo-specific is afoot.

The gui experience is that you get a global error for each erroring repo, but the rest of your repos show up fine. Previously an error would make none of your repos appear.

This breaks service<->gui compatibility across this PR for the git tab.