### PR TITLE
Fix login after reset

### DIFF
--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -409,6 +409,14 @@ func ResetAccount(tc libkb.TestContext, u *FakeUser) {
 	Logout(tc)
 }
 
+func ResetAccountNoLogout(tc libkb.TestContext, u *FakeUser) {
+	err := tc.G.LoginState().ResetAccount(u.Username)
+	if err != nil {
+		tc.T.Fatalf("In account reset: %s", err)
+	}
+	tc.T.Logf("Account reset for user %s", u.Username)
+}
+
 func ForcePUK(tc libkb.TestContext) {
 	arg := &PerUserKeyUpgradeArgs{}
 	eng := NewPerUserKeyUpgrade(tc.G, arg)

--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -185,7 +185,7 @@ func (e *Login) checkLoggedInAndNotRevoked(ctx *Context) (bool, error) {
 
 	e.G().Log.Debug("user is logged in, checking if on a revoked device")
 	validDevice := false
-	err = e.G().GetFullSelfer().WithSelf(ctx.GetNetContext(), func(me *libkb.User) error {
+	err = e.G().GetFullSelfer().WithSelfForcePoll(ctx.GetNetContext(), func(me *libkb.User) error {
 		validDevice = me.HasCurrentDeviceInCurrentInstall()
 		return nil
 	})

--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -184,11 +184,15 @@ func (e *Login) checkLoggedInAndNotRevoked(ctx *Context) (bool, error) {
 	}
 
 	e.G().Log.Debug("user is logged in, checking if on a revoked device")
-	me, err := libkb.LoadMe(libkb.NewLoadUserForceArg(e.G()))
+	validDevice := false
+	err = e.G().GetFullSelfer().WithSelf(ctx.GetNetContext(), func(me *libkb.User) error {
+		validDevice = me.HasCurrentDeviceInCurrentInstall()
+		return nil
+	})
 	if err != nil {
 		return false, err
 	}
-	if me.HasCurrentDeviceInCurrentInstall() {
+	if validDevice {
 		e.G().Log.Debug("user is logged in on a valid device")
 		return true, nil
 	}

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2163,6 +2163,30 @@ func TestResetAccount(t *testing.T) {
 	testUserHasDeviceKey(tc)
 }
 
+// create a standard user with device keys, reset account (but don't logout), login.
+func TestResetAccountNoLogout(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	u := CreateAndSignupFakeUser(tc, "login")
+	originalDevice := tc.G.Env.GetDeviceID()
+	ResetAccountNoLogout(tc, u)
+
+	// this will reprovision as an eldest device:
+	u.LoginOrBust(tc)
+	if err := AssertProvisioned(tc); err != nil {
+		t.Fatal(err)
+	}
+
+	newDevice := tc.G.Env.GetDeviceID()
+
+	if newDevice == originalDevice {
+		t.Errorf("device id did not change: %s", newDevice)
+	}
+
+	testUserHasDeviceKey(tc)
+}
+
 // After resetting account, try provisioning in a clean home dir.
 func TestResetAccountNewHome(t *testing.T) {
 	tc := SetupEngineTest(t, "login")

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2187,6 +2187,38 @@ func TestResetAccountNoLogout(t *testing.T) {
 	testUserHasDeviceKey(tc)
 }
 
+// create a standard user with device keys, reset account (but don't logout), login.
+// Prime the FullSelfer cache before reset.
+func TestResetAccountNoLogoutSelfCache(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	u := CreateAndSignupFakeUser(tc, "login")
+	originalDevice := tc.G.Env.GetDeviceID()
+
+	// make sure FullSelf is cached
+	tc.G.GetFullSelfer().WithSelf(context.TODO(), func(u *libkb.User) error {
+		t.Logf("full self user: %s", u.GetName())
+		return nil
+	})
+
+	ResetAccountNoLogout(tc, u)
+
+	// this will reprovision as an eldest device:
+	u.LoginOrBust(tc)
+	if err := AssertProvisioned(tc); err != nil {
+		t.Fatal(err)
+	}
+
+	newDevice := tc.G.Env.GetDeviceID()
+
+	if newDevice == originalDevice {
+		t.Errorf("device id did not change: %s", newDevice)
+	}
+
+	testUserHasDeviceKey(tc)
+}
+
 // After resetting account, try provisioning in a clean home dir.
 func TestResetAccountNewHome(t *testing.T) {
 	tc := SetupEngineTest(t, "login")

--- a/go/externals/test_common.go
+++ b/go/externals/test_common.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/pvlsource"
-	"github.com/keybase/client/go/uidmap"
 )
 
 func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
 	ret := libkb.SetupTest(tb, name, depth+1)
 
 	ret.G.SetServices(GetServices())
-	ret.G.SetUIDMapper(uidmap.NewUIDMap(10000))
+	// XXX this breaks TestUPAKDeadlock
+	// ret.G.SetUIDMapper(uidmap.NewUIDMap(10000))
 	pvlsource.NewPvlSourceAndInstall(ret.G)
 	return ret
 }

--- a/go/externals/test_common.go
+++ b/go/externals/test_common.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/pvlsource"
+	"github.com/keybase/client/go/uidmap"
 )
 
 func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
 	ret := libkb.SetupTest(tb, name, depth+1)
 
 	ret.G.SetServices(GetServices())
-	// XXX this breaks TestUPAKDeadlock
-	// ret.G.SetUIDMapper(uidmap.NewUIDMap(10000))
+	ret.G.SetUIDMapper(uidmap.NewUIDMap(10000))
 	pvlsource.NewPvlSourceAndInstall(ret.G)
 	return ret
 }

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -172,7 +172,6 @@ func (s *LoginState) LoginWithPrompt(username string, loginUI LoginUI, secretUI 
 }
 
 func (s *LoginState) LoginWithStoredSecret(username string, after afterFn) (err error) {
-	debug.PrintStack()
 	s.G().Log.Debug("+ LoginWithStoredSecret(%s) called", username)
 	defer func() { s.G().Log.Debug("- LoginWithStoredSecret -> %s", ErrToOk(err)) }()
 

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -587,7 +587,7 @@ func (u *CachedUPAKLoader) LookupUsername(ctx context.Context, uid keybase1.UID)
 // LookupUsernameUPAK uses the upak loader to find a username for uid.
 func (u *CachedUPAKLoader) LookupUsernameUPAK(ctx context.Context, uid keybase1.UID) (NormalizedUsername, error) {
 	var info CachedUserLoadInfo
-	arg := NewLoadUserByUIDArg(ctx, u.G(), uid).WithStaleOK(true)
+	arg := NewLoadUserByUIDArg(ctx, u.G(), uid).WithStaleOK(true).WithPublicKeyOptional()
 	var ret NormalizedUsername
 	_, _, err := u.loadWithInfo(arg, &info, func(upak *keybase1.UserPlusKeysV2AllIncarnations) error {
 		if upak == nil {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1201,6 +1201,9 @@ func (g *gregorHandler) loggedIn(ctx context.Context) (uid keybase1.UID, token s
 		g.G().Log.Debug("gregorHandler APIServerSessionStatus error: %s (returning loggedInMaybe)", err)
 		return uid, token, loggedInMaybe
 	}
+	if status == nil {
+		return uid, token, loggedInNo
+	}
 
 	return status.UID, status.SessionToken, loggedInYes
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -493,6 +493,11 @@ func (d *Service) writeServiceInfo() error {
 }
 
 func (d *Service) hourlyChecks() {
+	// do this right away
+	if err := d.G().LogoutIfRevoked(); err != nil {
+		d.G().Log.Debug("LogoutIfRevoked error: %s", err)
+	}
+
 	ticker := time.NewTicker(1 * time.Hour)
 	d.G().PushShutdownHook(func() error {
 		d.G().Log.Debug("stopping hourlyChecks loop")


### PR DESCRIPTION
There were some issues with logging in after resetting your account.

Although we test login after reset in login_test.go, there is always a logout before the relogin attempt.  This adds a new test for logging in after reset but without logging out.

Also, manual testing of gui in various states revealed a few other issues.

1. logged in, quit app
2. reset self on website
3. start app

would have device keys unlocked, but they would be revoked and the user wouldn't load and it would be a mess until the background task that checks for being on a revoked device ran.

There's also an APIServerSession call that the gregor connection uses.  I believe this would cause issues on foregrounding mobile app after reset, so it is fixed to logout if it detects the state of unlocked device keys but a user with no keys.

There's a companion desktop PR that I'm going to test next that should make it so the reset user logging in doesn't see any errors.