### PR TITLE
Fix TestClearSocialInvitesOnAdd

### DIFF
--- a/go/systests/standalone_test.go
+++ b/go/systests/standalone_test.go
@@ -13,11 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeUserStandalone(t *testing.T, pre string) *userPlusDevice {
+func makeUserStandalone(t *testing.T, pre string, disableGregor bool) *userPlusDevice {
 	tctx := setupTest(t, pre)
 	var u userPlusDevice
 
 	g := tctx.G
+	if disableGregor {
+		g.Env.GetConfigWriter().SetBoolAtPath("push.disabled", true)
+	}
 
 	u.device = &deviceWrapper{tctx: tctx}
 
@@ -62,7 +65,7 @@ func TestStandaloneTeamMemberOps(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
-	tt.users = append(tt.users, makeUserStandalone(t, "user1"))
+	tt.users = append(tt.users, makeUserStandalone(t, "user1", false /* disableGregor */))
 	tt.addUser("user2")
 
 	team := tt.users[0].createTeam()

--- a/go/systests/standalone_test.go
+++ b/go/systests/standalone_test.go
@@ -13,12 +13,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeUserStandalone(t *testing.T, pre string, disableGregor bool) *userPlusDevice {
+type standaloneUserArgs struct {
+	disableGregor bool
+}
+
+func makeUserStandalone(t *testing.T, pre string, opts standaloneUserArgs) *userPlusDevice {
 	tctx := setupTest(t, pre)
 	var u userPlusDevice
 
 	g := tctx.G
-	if disableGregor {
+	if opts.disableGregor {
+		// Some tests may want to disable gregor loop completely to
+		// simulate user that stays offline when not doing anything.
+		// Useful for teams tests to have a user that can post sigs
+		// but will not respond to any rekeyd messages.
 		g.Env.GetConfigWriter().SetBoolAtPath("push.disabled", true)
 	}
 
@@ -65,7 +73,7 @@ func TestStandaloneTeamMemberOps(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
-	tt.users = append(tt.users, makeUserStandalone(t, "user1", false /* disableGregor */))
+	tt.users = append(tt.users, makeUserStandalone(t, "user1", standaloneUserArgs{}))
 	tt.addUser("user2")
 
 	team := tt.users[0].createTeam()

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -385,7 +385,6 @@ func TestImpTeamWithMultipleRooters(t *testing.T) {
 }
 
 func TestClearSocialInvitesOnAdd(t *testing.T) {
-	t.Skip()
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -388,7 +388,9 @@ func TestClearSocialInvitesOnAdd(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
-	ann := makeUserStandalone(t, "ann")
+	// Disable gregor in this test so Ann does not immediately add Bob
+	// through SBS handler when bob proves Rooter.
+	ann := makeUserStandalone(t, "ann", true /* disableGregor */)
 	tt.users = append(tt.users, ann)
 
 	bob := tt.addUser("bob")

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -390,7 +390,7 @@ func TestClearSocialInvitesOnAdd(t *testing.T) {
 
 	// Disable gregor in this test so Ann does not immediately add Bob
 	// through SBS handler when bob proves Rooter.
-	ann := makeUserStandalone(t, "ann", true /* disableGregor */)
+	ann := makeUserStandalone(t, "ann", standaloneUserArgs{disableGregor: true})
 	tt.users = append(tt.users, ann)
 
 	bob := tt.addUser("bob")


### PR DESCRIPTION
The failing test was supposed to do the following:

1) ann adds bob@rooter to team
2) ann adds otherbob@rooter to team
3) bob proves rooter (but ann is in standalone mode and offline so he will not get automatically added)
4) ann adds bob@rooter (now proven as bob) to team - it's expected to also automatically clear the bob@rooter social invitation: see `func tryToCompleteInvites` in `service_helper.go`

3 did not quite work correctly - gregor was still online so if the timing was right, SBS handler executed before 4 ran.

This PR attempts to disable gregor handlers with `g.Env.GetConfigWriter().SetBoolAtPath("push.disabled", true)`.

cc @maxtaco 