### PR TITLE
Don't allow submitting bad device name by pressing return

### DIFF
--- a/shared/login/register/set-public-name/index.desktop.js
+++ b/shared/login/register/set-public-name/index.desktop.js
@@ -24,7 +24,7 @@ const SetPublicName = ({
         errorText={deviceNameError}
         style={stylesInput}
         hintText="Device name"
-        onEnterKeyDown={() => onSubmit()}
+        onEnterKeyDown={submitEnabled ? onSubmit : () => {}}
         onChangeText={text => onChange(text)}
         value={deviceName}
       />

--- a/shared/login/register/set-public-name/index.native.js
+++ b/shared/login/register/set-public-name/index.native.js
@@ -26,7 +26,7 @@ const SetPublicName = ({
         errorText={deviceNameError}
         floatingHintTextOverride="Device name"
         hintText="Device name"
-        onEnterKeyDown={() => onSubmit()}
+        onEnterKeyDown={submitEnabled ? onSubmit : () => {}}
         onChangeText={deviceName => onChange(deviceName)}
         value={deviceName}
       />


### PR DESCRIPTION
Small patch: currently a user can get past our disabled `continue` button with a bad device name by pressing return. This disables the return handler if `continue` is disabled.

@keybase/react-hackers 