### PR TITLE
Add git rpc logging

### DIFF
--- a/go/git/errors.go
+++ b/go/git/errors.go
@@ -4,15 +4,18 @@ import (
 	"fmt"
 
 	"github.com/keybase/client/go/libkb"
+	"golang.org/x/net/context"
 )
 
 // For errors that expect, replace them with nice strings for the user. The GUI
 // will show these directly.
-func HumanizeGitErrors(err error) error {
+func HumanizeGitErrors(ctx context.Context, g *libkb.GlobalContext, err error) error {
 	switch e := err.(type) {
 	case libkb.RepoAlreadyExistsError:
+		g.Log.CDebugf(ctx, "replacing error: %v", err)
 		return fmt.Errorf("A repo named %q already exists.", e.ExistingName)
 	case libkb.InvalidRepoNameError:
+		g.Log.CDebugf(ctx, "replacing error: %v", err)
 		return fmt.Errorf("%q isn't a valid repo name.", e.Name)
 	default:
 		return err

--- a/go/git/put.go
+++ b/go/git/put.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -29,7 +30,7 @@ func PutMetadata(ctx context.Context, g *libkb.GlobalContext, arg keybase1.PutGi
 	enc := codec.NewEncoderBytes(&msgpackLocalMetadata, &mh)
 	err = enc.Encode(localMetadataVersioned)
 	if err != nil {
-		return err
+		return fmt.Errorf("encoding git metadata:%v", err)
 	}
 	encryptedMetadata, err := cryptoer.Box(ctx, msgpackLocalMetadata, teamIDVis)
 	if err != nil {


### PR DESCRIPTION
Log rpcs and error values and add a context tag. Don't log super secret repo names.

Motivated by finding that the error path is not logged