### PR TITLE
Better flatlist

### DIFF
--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -153,7 +153,7 @@ class Inbox extends React.PureComponent<Props, State> {
     big: globalMargins.large,
     bigHeader: globalMargins.large,
     divider: 56,
-    small: 64,
+    small: globalMargins.xlarge,
   }
 
   // This is an under documented api to help optimize the FlatList's layout. see https://github.com/facebook/react-native/blob/v0.50.0-rc.0/Libraries/Lists/FlatList.js#L118

--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -41,6 +41,8 @@ type State = {
 
 class Inbox extends React.PureComponent<Props, State> {
   _list: any
+  // Help us calculate row heights and offsets quickly
+  _dividerIndex = -1
 
   state = {
     showFloating: false,
@@ -94,6 +96,9 @@ class Inbox extends React.PureComponent<Props, State> {
   componentWillReceiveProps(nextProps: Props) {
     if (this.props.smallTeamsHiddenRowCount === 0 && nextProps.smallTeamsHiddenRowCount > 0) {
       this._list && this._list.scrollToOffset({animated: false, offset: 0})
+    }
+    if (this.props.rows !== nextProps.rows) {
+      this._dividerIndex = nextProps.rows.findIndex(r => r.type === 'divider')
     }
   }
 
@@ -153,7 +158,36 @@ class Inbox extends React.PureComponent<Props, State> {
     this._list = r
   }
 
-  // TODO maybe we can put getItemLayout back if we do a bunch of pre-calc. The offset could be figured out based on index if we're very careful
+  _itemTypeToHeight = {
+    big: globalMargins.large,
+    bigHeader: globalMargins.large,
+    divider: 56,
+    small: 64,
+  }
+
+  // This is an under documented api to help optimize the FlatList's layout. see https://github.com/facebook/react-native/blob/v0.50.0-rc.0/Libraries/Lists/FlatList.js#L118
+  _getItemLayout = (data, index) => {
+    // We cache the divider location so we can divide the list into small and large. We can calculate the small cause they're all
+    // the same height. We iterate over the big since that list is small and we don't know the number of channels easily
+    const smallHeight = this._itemTypeToHeight['small']
+    if (index < this._dividerIndex || this._dividerIndex === -1) {
+      return {index, length: smallHeight, offset: index ? smallHeight * index : 0}
+    }
+
+    const dividerHeight = this._itemTypeToHeight['divider']
+    if (index === this._dividerIndex) {
+      return {index, length: dividerHeight, offset: smallHeight * index}
+    }
+
+    let offset = smallHeight * (this._dividerIndex - 1) + dividerHeight
+
+    for (let i = this._dividerIndex; i < index; ++i) {
+      offset += this._itemTypeToHeight[data[i].type]
+    }
+
+    return {index, length: this._itemTypeToHeight[data[index].type], offset}
+  }
+
   render() {
     return (
       <ErrorBoundary>
@@ -176,6 +210,7 @@ class Inbox extends React.PureComponent<Props, State> {
             onViewableItemsChanged={this._onViewChanged}
             initialNumToRender={this._maxVisible}
             windowSize={this._maxVisible}
+            getItemLayout={this._getItemLayout}
           />
           {!this.props.isLoading && !this.props.rows.length && <NoChats />}
           {this.state.showFloating &&

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -14,6 +14,11 @@
 #import "LogSend.h"
 #import "RCTLinkingManager.h"
 
+// Systrace is busted due to the new bridge. Uncomment this to force the old bridge.
+// You'll also have to edit the React.xcodeproj. Intructions here:
+// https://github.com/facebook/react-native/issues/15003#issuecomment-323715121
+#define SYSTRACING
+
 @interface AppDelegate ()
 @property UIBackgroundTaskIdentifier backgroundTask;
 @end
@@ -97,6 +102,16 @@ const BOOL isDebug = NO;
                                                    } error:&err];
 }
 
+#ifdef SYSTRACING
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+  return [NSURL URLWithString:@"http://10.0.1.50:8081/index.ios.bundle?platform=ios&dev=true"];
+}
+
+- (BOOL)shouldBridgeUseCxxBridge:(RCTBridge *)bridge {
+  return NO;
+}
+#endif
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   [self setupGo];
@@ -107,11 +122,18 @@ const BOOL isDebug = NO;
   // jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle?platform=ios&dev=false"];
   jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
 
+#ifdef SYSTRACING
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self
+                                            launchOptions:launchOptions];
+
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"Keybase" initialProperties:nil];
+#else
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"Keybase"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
   rootView.backgroundColor = [UIColor whiteColor];
+#endif
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -104,7 +104,7 @@ const BOOL isDebug = NO;
 
 #ifdef SYSTRACING
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
-  return [NSURL URLWithString:@"http://10.0.1.50:8081/index.ios.bundle?platform=ios&dev=true"];
+  return [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle?platform=ios&dev=true"];
 }
 
 - (BOOL)shouldBridgeUseCxxBridge:(RCTBridge *)bridge {

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -17,7 +17,7 @@
 // Systrace is busted due to the new bridge. Uncomment this to force the old bridge.
 // You'll also have to edit the React.xcodeproj. Intructions here:
 // https://github.com/facebook/react-native/issues/15003#issuecomment-323715121
-#define SYSTRACING
+//#define SYSTRACING
 
 @interface AppDelegate ()
 @property UIBackgroundTaskIdentifier backgroundTask;


### PR DESCRIPTION
This PR primary is about adding the layout helper for the inbox flatlist. This allows the inbox to measure better which allows it to be smarter about the rendering of components.
On master if I click the 'show more' divider button there's a tremendous amount of lag. After some systracing(!) I discovered its cause the images thread is getting slammed with requests and there's a ton of random rendering going on. This is fixed by adding the layout helper so the list can know how many items it really needs to render offscreen instead of overshooting that value. We had this before but removed it when the inbox added teams.

The second part is to help actually use systrace on device. Due to a bug in RN: (link in comments) systrace doesn't work out of the box now. This makes an ifdef that'll make the AppDelegate side work easily (you still need to edit some project files)