### PR TITLE
show the right message when PGP key is removed on tracker popup

### DIFF
--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -563,7 +563,7 @@ function _serverCallMap(
           } else {
             dispatch({
               type: Constants.updateReason,
-              payload: {username, reason: `${username} has deleted a proof.`},
+              payload: {username, reason: `${username} has deleted a PGP key.`},
             })
           }
           dispatch({type: Constants.updateProofState, payload: {username}})

--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -555,10 +555,17 @@ function _serverCallMap(
       addToIdleResponseQueue(() => {
         if (key.breaksTracking) {
           dispatch({type: Constants.updateEldestKidChanged, payload: {username}})
-          dispatch({
-            type: Constants.updateReason,
-            payload: {username, reason: `${username} has reset their account!`},
-          })
+          if (key.trackDiff.type === RPCTypes.IdentifyCommonTrackDiffType.newEldest) {
+            dispatch({
+              type: Constants.updateReason,
+              payload: {username, reason: `${username} has reset their account!`},
+            })
+          } else {
+            dispatch({
+              type: Constants.updateReason,
+              payload: {username, reason: `${username} has deleted a proof.`},
+            })
+          }
           dispatch({type: Constants.updateProofState, payload: {username}})
           if (!isGetProfile) {
             dispatch({type: Constants.showTracker, payload: {username}})

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -152,6 +152,7 @@ function updateUserState(
         lastAction: 'refollowed',
         reason: `You have re-followed ${state.username}.`,
         trackerState: 'normal',
+        eldestKidChanged: false,
       }
     case Constants.onUnfollow:
       return {


### PR DESCRIPTION
Feel free to reject this patch, but it does the following:

1.) Only shows the "has reset their account" text if that is the actual nature of the message from the service.
2.) Properly clears red bar if someone refollows form a reset (or deleted proof).

cc @maxtaco 