### PR TITLE
Provide all (pre-reset) device names to PromptNewDeviceName

### DIFF
--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -44,6 +44,7 @@ type FakeUser struct {
 	Passphrase    string
 	User          *libkb.User
 	EncryptionKey libkb.GenericKey
+	DeviceName    string
 }
 
 func NewFakeUser(prefix string) (fu *FakeUser, err error) {
@@ -122,6 +123,7 @@ func CreateAndSignupFakeUser2(tc libkb.TestContext, prefix string) (*FakeUser, *
 	fu := NewFakeUserOrBust(tc.T, prefix)
 	tc.G.Log.Debug("New test user: %s / %s", fu.Username, fu.Email)
 	arg := MakeTestSignupEngineRunArg(fu)
+	fu.DeviceName = arg.DeviceName
 	eng := SignupFakeUserWithArg(tc, fu, arg)
 	return fu, eng
 }

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -483,11 +483,15 @@ func (e *loginProvision) ppStream(ctx *Context) (*libkb.PassphraseStream, error)
 
 // deviceName gets a new device name from the user.
 func (e *loginProvision) deviceName(ctx *Context) (string, error) {
-	names, err := e.arg.User.DeviceNames()
+	var names []string
+	upk, _, err := e.G().GetUPAKLoader().LoadV2(libkb.NewLoadUserByUIDArg(ctx.GetNetContext(), e.G(), e.arg.User.GetUID()).WithPublicKeyOptional().WithForcePoll(true))
 	if err != nil {
-		e.G().Log.Debug("error getting device names: %s", err)
+		e.G().Log.Debug("error getting device names via upak: %s", err)
 		e.G().Log.Debug("proceeding to ask user for a device name despite error...")
+	} else {
+		names = upk.AllDeviceNames()
 	}
+
 	arg := keybase1.PromptNewDeviceNameArg{
 		ExistingDevices: names,
 	}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1273,6 +1273,25 @@ func (u UserPlusKeysV2AllIncarnations) IsOlderThan(v UserPlusKeysV2AllIncarnatio
 	return false
 }
 
+func (u UserPlusKeysV2AllIncarnations) AllDeviceNames() []string {
+	var names []string
+
+	for _, k := range u.Current.DeviceKeys {
+		if k.DeviceDescription != "" && (k.DeviceType == "mobile" || k.DeviceType == "desktop") {
+			names = append(names, k.DeviceDescription)
+		}
+	}
+	for _, v := range u.PastIncarnations {
+		for _, k := range v.DeviceKeys {
+			if k.DeviceDescription != "" && (k.DeviceType == "mobile" || k.DeviceType == "desktop") {
+				names = append(names, k.DeviceDescription)
+			}
+		}
+	}
+
+	return names
+}
+
 func (ut UserOrTeamID) String() string {
 	return string(ut)
 }


### PR DESCRIPTION
1. Adds a test to make sure PromptNewDeviceName existingDevices list contains pre-reset device names.
2. Uses upak all incarnations to get a list of all device names for a user, instead of the active devices