### PR TITLE
Test logging changes

### DIFF
--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -43,11 +43,30 @@ func NewTestLogger(log TestLogBackend) *TestLogger {
 // Verify TestLogger fully implements the Logger interface.
 var _ Logger = (*TestLogger)(nil)
 
+// ctx can be `nil`
+func (log *TestLogger) common(ctx context.Context, lvl logging.Level, useFatal bool, fmts string, arg ...interface{}) {
+	if ctx != nil {
+		if useFatal {
+			log.log.Fatalf(prepareString(ctx,
+				log.prefixCaller(log.extraDepth, lvl, fmts)), arg...)
+		} else {
+			log.log.Logf(prepareString(ctx,
+				log.prefixCaller(log.extraDepth, lvl, fmts)), arg...)
+		}
+	} else {
+		if useFatal {
+			log.log.Fatalf(log.prefixCaller(log.extraDepth, lvl, fmts), arg...)
+		} else {
+			log.log.Logf(log.prefixCaller(log.extraDepth, lvl, fmts), arg...)
+		}
+	}
+}
+
 func (log *TestLogger) prefixCaller(extraDepth int, lvl logging.Level, fmts string) string {
 	// The testing library doesn't let us control the stack depth,
 	// and it always prints out its own prefix, so use \r to clear
 	// it out (at least on a terminal) and do our own formatting.
-	_, file, line, _ := runtime.Caller(2 + extraDepth)
+	_, file, line, _ := runtime.Caller(3 + extraDepth)
 	elements := strings.Split(file, "/")
 	failed := ""
 	if log.log.Failed() {
@@ -59,81 +78,74 @@ func (log *TestLogger) prefixCaller(extraDepth int, lvl logging.Level, fmts stri
 }
 
 func (log *TestLogger) Debug(fmts string, arg ...interface{}) {
-	log.log.Logf(log.prefixCaller(log.extraDepth, logging.DEBUG, fmts), arg...)
+	log.common(nil, logging.INFO, false, fmts, arg...)
 }
 
 func (log *TestLogger) CDebugf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prepareString(ctx,
-		log.prefixCaller(log.extraDepth, logging.DEBUG, fmts)), arg...)
+	log.common(ctx, logging.DEBUG, false, fmts, arg...)
 }
 
 func (log *TestLogger) Info(fmts string, arg ...interface{}) {
-	log.log.Logf(log.prefixCaller(log.extraDepth, logging.INFO, fmts), arg...)
+	log.common(nil, logging.INFO, false, fmts, arg...)
 }
 
 func (log *TestLogger) CInfof(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prepareString(ctx,
-		log.prefixCaller(log.extraDepth, logging.INFO, fmts)), arg...)
+	log.common(ctx, logging.INFO, false, fmts, arg...)
 }
 
 func (log *TestLogger) Notice(fmts string, arg ...interface{}) {
-	log.log.Logf(log.prefixCaller(log.extraDepth, logging.NOTICE, fmts), arg...)
+	log.common(nil, logging.NOTICE, false, fmts, arg...)
 }
 
 func (log *TestLogger) CNoticef(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prepareString(ctx,
-		log.prefixCaller(log.extraDepth, logging.NOTICE, fmts)), arg...)
+	log.common(ctx, logging.NOTICE, false, fmts, arg...)
 }
 
 func (log *TestLogger) Warning(fmts string, arg ...interface{}) {
-	log.log.Logf(log.prefixCaller(log.extraDepth, logging.WARNING, fmts), arg...)
+	log.common(nil, logging.WARNING, false, fmts, arg...)
 }
 
 func (log *TestLogger) CWarningf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prepareString(ctx,
-		log.prefixCaller(log.extraDepth, logging.WARNING, fmts)), arg...)
+	log.common(ctx, logging.WARNING, false, fmts, arg...)
 }
 
 func (log *TestLogger) Error(fmts string, arg ...interface{}) {
-	log.log.Logf(log.prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
+	log.common(nil, logging.ERROR, false, fmts, arg...)
 }
 
 func (log *TestLogger) Errorf(fmts string, arg ...interface{}) {
-	log.log.Logf(log.prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
+	log.common(nil, logging.ERROR, false, fmts, arg...)
 }
 
 func (log *TestLogger) CErrorf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prepareString(ctx,
-		log.prefixCaller(log.extraDepth, logging.ERROR, fmts)), arg...)
+	log.common(ctx, logging.ERROR, false, fmts, arg...)
 }
 
 func (log *TestLogger) Critical(fmts string, arg ...interface{}) {
-	log.log.Logf(log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.common(nil, logging.CRITICAL, false, fmts, arg...)
 }
 
 func (log *TestLogger) CCriticalf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prepareString(ctx,
-		log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
+	log.common(ctx, logging.CRITICAL, false, fmts, arg...)
 }
 
 func (log *TestLogger) Fatalf(fmts string, arg ...interface{}) {
-	log.log.Fatalf(log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.common(nil, logging.CRITICAL, true, fmts, arg...)
 }
 
 func (log *TestLogger) CFatalf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Fatalf(prepareString(ctx,
-		log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
+	log.common(ctx, logging.CRITICAL, true, fmts, arg...)
 }
 
 func (log *TestLogger) Profile(fmts string, arg ...interface{}) {
-	log.log.Logf(log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.common(nil, logging.CRITICAL, false, fmts, arg...)
 }
 
 func (log *TestLogger) Configure(style string, debug bool, filename string) {

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -53,7 +53,8 @@ func (log *TestLogger) prefixCaller(extraDepth int, lvl logging.Level, fmts stri
 	if log.log.Failed() {
 		failed = "[X] "
 	}
-	return fmt.Sprintf("\r%s %s%s:%d: [%.1s] %s", time.Now(),
+
+	return fmt.Sprintf("\r%s %s%s:%d: [%.1s] %s", time.Now().Format("2006-01-02 15:04:05.00000"),
 		failed, elements[len(elements)-1], line, lvl, fmts)
 }
 

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -24,6 +24,7 @@ type TestLogBackend interface {
 	Fatalf(format string, args ...interface{})
 	Log(args ...interface{})
 	Logf(format string, args ...interface{})
+	Failed() bool
 }
 
 // TestLogger is a Logger that writes to a TestLogBackend.  All
@@ -42,92 +43,96 @@ func NewTestLogger(log TestLogBackend) *TestLogger {
 // Verify TestLogger fully implements the Logger interface.
 var _ Logger = (*TestLogger)(nil)
 
-func prefixCaller(extraDepth int, lvl logging.Level, fmts string) string {
+func (log *TestLogger) prefixCaller(extraDepth int, lvl logging.Level, fmts string) string {
 	// The testing library doesn't let us control the stack depth,
 	// and it always prints out its own prefix, so use \r to clear
 	// it out (at least on a terminal) and do our own formatting.
 	_, file, line, _ := runtime.Caller(2 + extraDepth)
 	elements := strings.Split(file, "/")
-	return fmt.Sprintf("\r%s %s:%d: [%.1s] %s", time.Now(),
-		elements[len(elements)-1], line, lvl, fmts)
+	failed := ""
+	if log.log.Failed() {
+		failed = "[X] "
+	}
+	return fmt.Sprintf("\r%s %s%s:%d: [%.1s] %s", time.Now(),
+		failed, elements[len(elements)-1], line, lvl, fmts)
 }
 
 func (log *TestLogger) Debug(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.DEBUG, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.DEBUG, fmts), arg...)
 }
 
 func (log *TestLogger) CDebugf(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.DEBUG, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.DEBUG, fmts)), arg...)
 }
 
 func (log *TestLogger) Info(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.INFO, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.INFO, fmts), arg...)
 }
 
 func (log *TestLogger) CInfof(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.INFO, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.INFO, fmts)), arg...)
 }
 
 func (log *TestLogger) Notice(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.NOTICE, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.NOTICE, fmts), arg...)
 }
 
 func (log *TestLogger) CNoticef(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.NOTICE, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.NOTICE, fmts)), arg...)
 }
 
 func (log *TestLogger) Warning(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.WARNING, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.WARNING, fmts), arg...)
 }
 
 func (log *TestLogger) CWarningf(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.WARNING, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.WARNING, fmts)), arg...)
 }
 
 func (log *TestLogger) Error(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
 }
 
 func (log *TestLogger) Errorf(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
 }
 
 func (log *TestLogger) CErrorf(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.ERROR, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.ERROR, fmts)), arg...)
 }
 
 func (log *TestLogger) Critical(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
 }
 
 func (log *TestLogger) CCriticalf(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
 }
 
 func (log *TestLogger) Fatalf(fmts string, arg ...interface{}) {
-	log.log.Fatalf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log.Fatalf(log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
 }
 
 func (log *TestLogger) CFatalf(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Fatalf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
 }
 
 func (log *TestLogger) Profile(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
 }
 
 func (log *TestLogger) Configure(style string, debug bool, filename string) {


### PR DESCRIPTION
Reading test failure logs was no fun, especially on jenkins. I've spent lots of times scrolling up and down looking for the failure site with hiding above 100s of lines of output from cleanup tasks.

This PR does 3 things:
- Print a little `[X]` on all lines logged after the test has failed. To find a failure look for the first `[X]`.
- Print `TEST FAILED: TestTheNameOfTest` before the first line logged after the test failed
- Make the date format shorter. Don't need timezones in tests

@strib I'm guessing kbfs would get this too with vendoring.

Looks like this:

```
...
2017-10-19 13:07:39.02994 loader2.go:544: [D] TeamLoader#addSecrets: received:1->1 nseeds:1 nprevs:0 [tags:LT=vlJdcHxK7uOt]
2017-10-19 13:07:39.03009 loader2.go:576: [D] TeamLoader got old keys, re-checking as if new [tags:LT=vlJdcHxK7uOt]
2017-10-19 13:07:39.03035 crypto.go:23: [D] found cached device key in ActiveDevice [tags:LT=vlJdcHxK7uOt]
2017-10-19 13:07:39.03043 loader.go:222: [D] - TeamLoader#load2(aa06e81159d78ca460bc3f8bb3ad1a24, public:false) -> <nil> [time=485.954736ms] [tags:LT=vlJdcHxK7uOt]
        loader_test.go:34: failed to interpolate splines
        test_logger.go:54: TEST FAILED: TestLoaderBasic
2017-10-19 13:07:39.03045 [X] test_common.go:82: [D] global context shutdown:
2017-10-19 13:07:39.03046 [X] globals.go:495: [D] Calling shutdown first time through
2017-10-19 13:07:39.03046 [X] login_state.go:1107: [D] + Account "LoginState - Shutdown"
2017-10-19 13:07:39.03047 [X] login_state.go:954: [D] + acctHandle sending: acctReq LoginState - Shutdown [iozs52Ik]
2017-10-19 13:07:39.03048 [X] login_state.go:957: [D] * acctHandle sent: acctReq LoginState - Shutdown [iozs52Ik] (15.809µs)
2017-10-19 13:07:39.03049 [X] login_state.go:1009: [D] * LoginState running account request: acctReq LoginState - Shutdown [iozs52Ik]
2017-10-19 13:07:39.03050 [X] login_state.go:1012: [D] * LoginState account request complete: acctReq LoginState - Shutdown [iozs52Ik]
...
```

