### PR TITLE
Add team sigchain race retry for AddMember

### DIFF
--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -58,6 +58,7 @@ const (
 	StatusCode_SCKeySyncedPGPNotFound      StatusCode = 929
 	StatusCode_SCKeyNoMatchingGPG          StatusCode = 930
 	StatusCode_SCKeyRevoked                StatusCode = 931
+	StatusCode_SCSigOldSeqno               StatusCode = 1010
 	StatusCode_SCBadTrackSession           StatusCode = 1301
 	StatusCode_SCDeviceBadName             StatusCode = 1404
 	StatusCode_SCDeviceNameInUse           StatusCode = 1408
@@ -201,6 +202,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCKeySyncedPGPNotFound":      929,
 	"SCKeyNoMatchingGPG":          930,
 	"SCKeyRevoked":                931,
+	"SCSigOldSeqno":               1010,
 	"SCBadTrackSession":           1301,
 	"SCDeviceBadName":             1404,
 	"SCDeviceNameInUse":           1408,
@@ -342,6 +344,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	929:  "SCKeySyncedPGPNotFound",
 	930:  "SCKeyNoMatchingGPG",
 	931:  "SCKeyRevoked",
+	1010: "SCSigOldSeqno",
 	1301: "SCBadTrackSession",
 	1404: "SCDeviceBadName",
 	1408: "SCDeviceNameInUse",

--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
+// Handlers for team-related gregor messages
+
 package service
 
 import (

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
+// RPC handlers for team operations
+
 package service
 
 import (

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -911,6 +911,7 @@ func TestMemberCancelInviteEmail(t *testing.T) {
 
 // Test two users racing to post chain links to the same team.
 // In this case, adding different users to the team.
+// The expected behavior is that they both succeed.
 func TestMemberAddRace(t *testing.T) {
 	fus, tcs, cleanup := setupNTests(t, 4)
 	defer cleanup()
@@ -969,5 +970,86 @@ func TestMemberAddRace(t *testing.T) {
 
 		assertNoErr(mod(0, 2, false))
 		assertNoErr(mod(1, 3, false))
+	}
+}
+
+// Test two users racing to post chain links to the same team.
+// In this case, adding the same user to the team.
+// The expected behavior is that one will win and one will fail with a nice error.
+func TestMemberAddRaceConflict(t *testing.T) {
+	fus, tcs, cleanup := setupNTests(t, 4)
+	defer cleanup()
+
+	t.Logf("U0 creates A")
+	rootName, _ := createTeam2(*tcs[0])
+
+	t.Logf("U0 adds U1")
+	_, err := AddMember(context.TODO(), tcs[0].G, rootName.String(), fus[1].Username, keybase1.TeamRole_ADMIN)
+	require.NoError(t, err, "add member")
+
+	// add or remove a user from the team
+	mod := func(userIndexOperator, userIndexTarget int, add bool) <-chan error {
+		errCh := make(chan error)
+		go func() {
+			ctx := context.TODO()
+			ctx = libkb.WithLogTag(ctx, "TEST")
+			var err error
+			desc := "removes"
+			if add {
+				desc = "adds"
+			}
+			t.Logf("U%v %v U%v", userIndexOperator, desc, userIndexTarget)
+			if add {
+				_, err = AddMember(context.TODO(),
+					tcs[userIndexOperator].G, rootName.String(), fus[userIndexTarget].Username, keybase1.TeamRole_READER)
+			} else {
+				err = RemoveMember(context.TODO(),
+					tcs[userIndexOperator].G, rootName.String(), fus[userIndexTarget].Username)
+			}
+			errCh <- err
+		}()
+		return errCh
+	}
+
+	assertNoErr := func(errCh <-chan error, msgAndArgs ...interface{}) {
+		select {
+		case err := <-errCh:
+			require.NoError(t, err, msgAndArgs...)
+		case <-time.After(20 * time.Second):
+			require.FailNow(t, "timeout waiting for return channel")
+		}
+	}
+
+	// Exactly one error comes from the list of channels
+	assertOneErr := func(errChs []<-chan error, msgAndArgs ...interface{}) (retErr error) {
+		for i, errCh := range errChs {
+			select {
+			case err := <-errCh:
+				if retErr == nil {
+					retErr = err
+				} else {
+					require.NoError(t, err, msgAndArgs...)
+				}
+			case <-time.After(20 * time.Second):
+				require.FailNow(t, "timeout waiting for return channel: %v", i)
+			}
+		}
+		return retErr
+	}
+
+	for i := 0; i < 5; i++ {
+		t.Logf("round %v", i)
+
+		t.Logf("parallel start")
+
+		errCh1 := mod(0, 2, true)
+		errCh2 := mod(1, 2, true)
+		err := assertOneErr([](<-chan error){errCh1, errCh2})
+		require.Errorf(t, err, "round %v", i)
+		require.IsType(t, libkb.ExistsError{}, err, "user should already be in team (round %v)", i)
+
+		t.Logf("parallel end")
+
+		assertNoErr(mod(0, 2, false))
 	}
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -303,7 +303,11 @@ func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username s
 		}
 
 		if t.IsMember(ctx, uv) {
-			return libkb.ExistsError{Msg: fmt.Sprintf("user %q (%s) is already a member of team %q", username, resolvedUsername, teamname)}
+			showUsername := fmt.Sprintf("%q", resolvedUsername.String())
+			if username != resolvedUsername.String() {
+				showUsername = fmt.Sprintf("%q (%s)", username, resolvedUsername.String())
+			}
+			return libkb.ExistsError{Msg: fmt.Sprintf("user %s is already a member of team %q", showUsername, teamname)}
 		}
 		req, err := reqFromRole(uv, role)
 		if err != nil {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -274,23 +274,22 @@ func tryToCompleteInvites(ctx context.Context, g *libkb.GlobalContext, team *Tea
 	return nil
 }
 
-func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string, role keybase1.TeamRole) (keybase1.TeamAddMemberResult, error) {
+func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string, role keybase1.TeamRole) (res keybase1.TeamAddMemberResult, err error) {
 	var inviteRequired bool
 	resolvedUsername, uv, err := loadUserVersionPlusByUsername(ctx, g, username)
 	g.Log.CDebugf(ctx, "team.AddMember: loadUserVersionPlusByUsername(%s) -> (%s, %v, %v)", username, resolvedUsername, uv, err)
 	if err != nil {
 		if err == errInviteRequired {
 			inviteRequired = true
-		}
-		if _, ok := err.(libkb.NotFoundError); ok {
+		} else if _, ok := err.(libkb.NotFoundError); ok {
 			return keybase1.TeamAddMemberResult{}, libkb.NotFoundError{
 				Msg: fmt.Sprintf("User not found: %v", username),
 			}
+		} else {
+			return keybase1.TeamAddMemberResult{}, err
 		}
-		return keybase1.TeamAddMemberResult{}, err
 	}
 
-	var res keybase1.TeamAddMemberResult
 	err = RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
 		t, err := GetForTeamManagementByStringName(ctx, g, teamname, true /*needAdmin*/)
 		if err != nil {
@@ -332,6 +331,7 @@ func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username s
 		if err := t.ChangeMembership(ctx, req); err != nil {
 			return err
 		}
+		// return value assign to escape closure
 		res = keybase1.TeamAddMemberResult{User: &keybase1.User{Uid: uv.Uid, Username: resolvedUsername.String()}}
 		return nil
 	})
@@ -339,190 +339,225 @@ func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username s
 }
 
 func InviteEmailMember(ctx context.Context, g *libkb.GlobalContext, teamname, email string, role keybase1.TeamRole) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
-	if err != nil {
-		return err
-	}
+	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
+		if err != nil {
+			return err
+		}
 
-	return t.InviteEmailMember(ctx, email, role)
+		return t.InviteEmailMember(ctx, email, role)
+	})
 }
 
-func AddEmailsBulk(ctx context.Context, g *libkb.GlobalContext, teamname, emails string, role keybase1.TeamRole) (keybase1.BulkRes, error) {
-	var res keybase1.BulkRes
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
-	if err != nil {
-		return keybase1.BulkRes{}, err
-	}
-
+func AddEmailsBulk(ctx context.Context, g *libkb.GlobalContext, teamname, emails string, role keybase1.TeamRole) (resOuter keybase1.BulkRes, err error) {
 	emailList := splitBulk(emails)
 	g.Log.CDebugf(ctx, "team %s: bulk email invite count: %d", teamname, len(emailList))
 
-	var invites []SCTeamInvite
-	for _, e := range emailList {
-		if !libkb.CheckEmail.F(e) {
-			g.Log.CDebugf(ctx, "team %s: skipping malformed email %q", teamname, e)
-			res.Malformed = append(res.Malformed, e)
-			continue
-		}
-		name := keybase1.TeamInviteName(e)
-		existing, err := t.HasActiveInvite(name, "email")
+	err = RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		var res keybase1.BulkRes
+
+		t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
 		if err != nil {
-			return keybase1.BulkRes{}, err
+			return err
 		}
-		if existing {
-			g.Log.CDebugf(ctx, "team %s: invite for %s already exists, omitting from invite list", teamname, e)
-			res.AlreadyInvited = append(res.AlreadyInvited, e)
-			continue
-		}
-		inv := SCTeamInvite{
-			Type: "email",
-			Name: name,
-			ID:   NewInviteID(),
-		}
-		invites = append(invites, inv)
-		res.Invited = append(res.Invited, e)
-	}
-	if len(invites) == 0 {
-		g.Log.CDebugf(ctx, "team %s: after exisitng filter, no one to invite", teamname)
-		return res, nil
-	}
 
-	var teamInvites SCTeamInvites
-	switch role {
-	case keybase1.TeamRole_ADMIN:
-		teamInvites.Admins = &invites
-	case keybase1.TeamRole_WRITER:
-		teamInvites.Writers = &invites
-	case keybase1.TeamRole_READER:
-		teamInvites.Readers = &invites
-	case keybase1.TeamRole_OWNER:
-		teamInvites.Owners = &invites
-	default:
-		return keybase1.BulkRes{}, fmt.Errorf("unknown team role: %s", role)
-	}
+		var invites []SCTeamInvite
+		for _, e := range emailList {
+			if !libkb.CheckEmail.F(e) {
+				g.Log.CDebugf(ctx, "team %s: skipping malformed email %q", teamname, e)
+				res.Malformed = append(res.Malformed, e)
+				continue
+			}
+			name := keybase1.TeamInviteName(e)
+			existing, err := t.HasActiveInvite(name, "email")
+			if err != nil {
+				return err
+			}
+			if existing {
+				g.Log.CDebugf(ctx, "team %s: invite for %s already exists, omitting from invite list", teamname, e)
+				res.AlreadyInvited = append(res.AlreadyInvited, e)
+				continue
+			}
+			inv := SCTeamInvite{
+				Type: "email",
+				Name: name,
+				ID:   NewInviteID(),
+			}
+			invites = append(invites, inv)
+			res.Invited = append(res.Invited, e)
+		}
+		if len(invites) == 0 {
+			g.Log.CDebugf(ctx, "team %s: after exisitng filter, no one to invite", teamname)
+			// return value assign to escape closure
+			resOuter = res
+			return nil
+		}
 
-	g.Log.CDebugf(ctx, "team %s: after exisitng filter, inviting %d emails as %s", teamname, len(invites), role)
-	err = t.postTeamInvites(ctx, teamInvites)
-	if err != nil {
-		return keybase1.BulkRes{}, err
-	}
-	return res, nil
+		var teamInvites SCTeamInvites
+		switch role {
+		case keybase1.TeamRole_ADMIN:
+			teamInvites.Admins = &invites
+		case keybase1.TeamRole_WRITER:
+			teamInvites.Writers = &invites
+		case keybase1.TeamRole_READER:
+			teamInvites.Readers = &invites
+		case keybase1.TeamRole_OWNER:
+			teamInvites.Owners = &invites
+		default:
+			return fmt.Errorf("unknown team role: %s", role)
+		}
+
+		g.Log.CDebugf(ctx, "team %s: after exisitng filter, inviting %d emails as %s", teamname, len(invites), role)
+		err = t.postTeamInvites(ctx, teamInvites)
+		if err != nil {
+			return err
+		}
+		// return value assign to escape closure
+		resOuter = res
+		return nil
+	})
+	return resOuter, err
 }
 
 func EditMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string, role keybase1.TeamRole) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
-	if err != nil {
-		return err
-	}
 	uv, err := loadUserVersionByUsername(ctx, g, username)
 	if err != nil {
 		return err
 	}
-	if !t.IsMember(ctx, uv) {
-		return fmt.Errorf("user %q is not a member of team %q", username, teamname)
-	}
-	existingRole, err := t.MemberRole(ctx, uv)
-	if err != nil {
-		return err
-	}
-	if existingRole == role {
-		return fmt.Errorf("user %q in team %q already has the role %s", username, teamname, role)
-	}
 
-	req, err := reqFromRole(uv, role)
-	if err != nil {
-		return err
-	}
+	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
+		if err != nil {
+			return err
+		}
+		if !t.IsMember(ctx, uv) {
+			return fmt.Errorf("user %q is not a member of team %q", username, teamname)
+		}
+		existingRole, err := t.MemberRole(ctx, uv)
+		if err != nil {
+			return err
+		}
+		if existingRole == role {
+			return fmt.Errorf("user %q in team %q already has the role %s", username, teamname, role)
+		}
 
-	return t.ChangeMembership(ctx, req)
+		req, err := reqFromRole(uv, role)
+		if err != nil {
+			return err
+		}
+
+		return t.ChangeMembership(ctx, req)
+	})
 }
 
-func MemberRole(ctx context.Context, g *libkb.GlobalContext, teamname, username string) (keybase1.TeamRole, error) {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, false)
-	if err != nil {
-		return keybase1.TeamRole_NONE, err
-	}
+func MemberRole(ctx context.Context, g *libkb.GlobalContext, teamname, username string) (role keybase1.TeamRole, err error) {
 	uv, err := loadUserVersionByUsername(ctx, g, username)
 	if err != nil {
 		return keybase1.TeamRole_NONE, err
 	}
-	return t.MemberRole(ctx, uv)
+
+	err = RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		t, err := GetForTeamManagementByStringName(ctx, g, teamname, false)
+		if err != nil {
+			return err
+		}
+		// return value assign to escape closure
+		role, err = t.MemberRole(ctx, uv)
+		return err
+	})
+	return role, err
 }
 
 func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
-	if err != nil {
-		return err
-	}
 
+	var inviteRequired bool
 	uv, err := loadUserVersionByUsername(ctx, g, username)
 	if err != nil {
 		if err == errInviteRequired {
+			inviteRequired = true
+		} else {
+			return err
+		}
+	}
+
+	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
+		if err != nil {
+			return err
+		}
+
+		if inviteRequired {
 			return removeMemberInvite(ctx, g, t, username, uv)
 		}
-		return err
-	}
 
-	existingUV, err := t.UserVersionByUID(ctx, uv.Uid)
-	if err != nil {
-		return libkb.NotFoundError{Msg: fmt.Sprintf("user %q is not a member of team %q", username, teamname)}
-	}
+		existingUV, err := t.UserVersionByUID(ctx, uv.Uid)
+		if err != nil {
+			return libkb.NotFoundError{Msg: fmt.Sprintf("user %q is not a member of team %q", username, teamname)}
+		}
 
-	me, err := libkb.LoadMe(libkb.NewLoadUserArgWithContext(ctx, g))
-	if err != nil {
-		return err
-	}
+		me, err := libkb.LoadMe(libkb.NewLoadUserArgWithContext(ctx, g))
+		if err != nil {
+			return err
+		}
 
-	if me.GetNormalizedName().Eq(libkb.NewNormalizedUsername(username)) {
-		return Leave(ctx, g, teamname, false)
-	}
-	req := keybase1.TeamChangeReq{None: []keybase1.UserVersion{existingUV}}
+		if me.GetNormalizedName().Eq(libkb.NewNormalizedUsername(username)) {
+			return Leave(ctx, g, teamname, false)
+		}
+		req := keybase1.TeamChangeReq{None: []keybase1.UserVersion{existingUV}}
 
-	// Ban for open teams only.
-	permanent := t.IsOpen()
-	return t.ChangeMembershipPermanent(ctx, req, permanent)
+		// Ban for open teams only.
+		permanent := t.IsOpen()
+		return t.ChangeMembershipPermanent(ctx, req, permanent)
+	})
 }
 
 func CancelEmailInvite(ctx context.Context, g *libkb.GlobalContext, teamname, email string) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
-	if err != nil {
-		return err
-	}
+	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
+		if err != nil {
+			return err
+		}
 
-	if !libkb.CheckEmail.F(email) {
-		return errors.New("Invalid email address")
-	}
+		if !libkb.CheckEmail.F(email) {
+			return errors.New("Invalid email address")
+		}
 
-	return removeMemberInviteOfType(ctx, g, t, keybase1.TeamInviteName(email), "email")
+		return removeMemberInviteOfType(ctx, g, t, keybase1.TeamInviteName(email), "email")
+	})
 }
 
 func Leave(ctx context.Context, g *libkb.GlobalContext, teamname string, permanent bool) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, false)
-	if err != nil {
-		return err
-	}
-	err = t.Leave(ctx, permanent)
-	if err != nil {
-		return err
-	}
-	// Assume this is for the private team
-	err = g.GetTeamLoader().Delete(ctx, t.ID)
-	if err != nil {
-		g.Log.CDebugf(ctx, "team.Leave: error deleting team cache: %v", err)
-	}
-	return nil
+	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		t, err := GetForTeamManagementByStringName(ctx, g, teamname, false)
+		if err != nil {
+			return err
+		}
+		err = t.Leave(ctx, permanent)
+		if err != nil {
+			return err
+		}
+		// Assume this is for the private team
+		err = g.GetTeamLoader().Delete(ctx, t.ID)
+		if err != nil {
+			g.Log.CDebugf(ctx, "team.Leave: error deleting team cache: %v", err)
+		}
+		return nil
+	})
 }
 
 func Delete(ctx context.Context, g *libkb.GlobalContext, ui keybase1.TeamsUiInterface, teamname string) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
-	if err != nil {
-		return err
-	}
+	// This retry can cause multiple confirmation popups for the user
+	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
+		if err != nil {
+			return err
+		}
 
-	if t.chain().IsSubteam() {
-		return t.deleteSubteam(ctx, ui)
-	}
-	return t.deleteRoot(ctx, ui)
+		if t.chain().IsSubteam() {
+			return t.deleteSubteam(ctx, ui)
+		}
+		return t.deleteRoot(ctx, ui)
+	})
 }
 
 func AcceptInvite(ctx context.Context, g *libkb.GlobalContext, token string) error {
@@ -533,12 +568,14 @@ func AcceptInvite(ctx context.Context, g *libkb.GlobalContext, token string) err
 }
 
 func ChangeRoles(ctx context.Context, g *libkb.GlobalContext, teamname string, req keybase1.TeamChangeReq) error {
-	// Don't needAdmin because we might be leaving, and this needs no information from stubbable links.
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, false)
-	if err != nil {
-		return err
-	}
-	return t.ChangeMembership(ctx, req)
+	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		// Don't needAdmin because we might be leaving, and this needs no information from stubbable links.
+		t, err := GetForTeamManagementByStringName(ctx, g, teamname, false)
+		if err != nil {
+			return err
+		}
+		return t.ChangeMembership(ctx, req)
+	})
 }
 
 var errInviteRequired = errors.New("invite required for username")
@@ -778,57 +815,61 @@ func GetRootID(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) 
 }
 
 func ReAddMemberAfterReset(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, username string) error {
-	t, err := GetForTeamManagementByTeamID(ctx, g, teamID, true)
-	if err != nil {
-		return err
-	}
 	uv, err := loadUserVersionByUsername(ctx, g, username)
 	if err != nil {
 		return err
 	}
 
-	existingUV, err := t.UserVersionByUID(ctx, uv.Uid)
-	if err != nil {
-		return libkb.NotFoundError{Msg: fmt.Sprintf("user %q has never been a member of this team.", username)}
-	}
+	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		t, err := GetForTeamManagementByTeamID(ctx, g, teamID, true)
+		if err != nil {
+			return err
+		}
+		existingUV, err := t.UserVersionByUID(ctx, uv.Uid)
+		if err != nil {
+			return libkb.NotFoundError{Msg: fmt.Sprintf("user %q has never been a member of this team.", username)}
+		}
 
-	if existingUV.EldestSeqno == uv.EldestSeqno {
-		return libkb.ExistsError{Msg: fmt.Sprintf("user %q has not reset, no need to re-add", username)}
-	} else if existingUV.EldestSeqno > uv.EldestSeqno {
-		return fmt.Errorf("newer version of user %q already exists in team %q (%v > %v)", username, teamID, existingUV.EldestSeqno, uv.EldestSeqno)
-	}
+		if existingUV.EldestSeqno == uv.EldestSeqno {
+			return libkb.ExistsError{Msg: fmt.Sprintf("user %q has not reset, no need to re-add", username)}
+		} else if existingUV.EldestSeqno > uv.EldestSeqno {
+			return fmt.Errorf("newer version of user %q already exists in team %q (%v > %v)", username, teamID, existingUV.EldestSeqno, uv.EldestSeqno)
+		}
 
-	existingRole, err := t.MemberRole(ctx, existingUV)
-	if err != nil {
-		return err
-	}
+		existingRole, err := t.MemberRole(ctx, existingUV)
+		if err != nil {
+			return err
+		}
 
-	req, err := reqFromRole(uv, existingRole)
-	if err != nil {
-		return err
-	}
+		req, err := reqFromRole(uv, existingRole)
+		if err != nil {
+			return err
+		}
 
-	req.None = []keybase1.UserVersion{existingUV}
-	return t.ChangeMembership(ctx, req)
+		req.None = []keybase1.UserVersion{existingUV}
+		return t.ChangeMembership(ctx, req)
+	})
 }
 
 func ChangeTeamSettings(ctx context.Context, g *libkb.GlobalContext, teamName string, settings keybase1.TeamSettings) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamName, true)
-	if err != nil {
-		return err
-	}
-
-	if !settings.Open && !t.IsOpen() {
-		return libkb.NoOpError{Desc: "Team is already closed."}
-	}
-
-	if settings.Open && t.IsOpen() && t.OpenTeamJoinAs() == settings.JoinAs {
-		return libkb.NoOpError{
-			Desc: fmt.Sprintf("Team is already open with default role: %s.", strings.ToLower(t.OpenTeamJoinAs().String())),
+	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+		t, err := GetForTeamManagementByStringName(ctx, g, teamName, true)
+		if err != nil {
+			return err
 		}
-	}
 
-	return t.PostTeamSettings(ctx, settings)
+		if !settings.Open && !t.IsOpen() {
+			return libkb.NoOpError{Desc: "Team is already closed."}
+		}
+
+		if settings.Open && t.IsOpen() && t.OpenTeamJoinAs() == settings.JoinAs {
+			return libkb.NoOpError{
+				Desc: fmt.Sprintf("Team is already open with default role: %s.", strings.ToLower(t.OpenTeamJoinAs().String())),
+			}
+		}
+
+		return t.PostTeamSettings(ctx, settings)
+	})
 }
 
 func removeMemberInvite(ctx context.Context, g *libkb.GlobalContext, team *Team, username string, uv keybase1.UserVersion) error {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -671,6 +671,8 @@ func (t *Team) HasActiveInvite(name keybase1.TeamInviteName, typ string) (bool, 
 	return t.chain().HasActiveInvite(name, it)
 }
 
+// If uv.Uid is set, then username is ignored.
+// Otherwise resolvedUsername and uv are ignored.
 func (t *Team) InviteMember(ctx context.Context, username string, role keybase1.TeamRole, resolvedUsername libkb.NormalizedUsername, uv keybase1.UserVersion) (keybase1.TeamAddMemberResult, error) {
 
 	// if a user version was previously loaded, then there is a keybase user for username, but
@@ -687,8 +689,8 @@ func (t *Team) InviteMember(ctx context.Context, username string, role keybase1.
 		return t.inviteKeybaseMember(ctx, uv, role, resolvedUsername)
 	}
 
-	// If a social, or email, or other type of invite, assert it's now an owner.
-	if role == keybase1.TeamRole_OWNER {
+	// If a social, or email, or other type of invite, assert it's not an owner.
+	if role.IsOrAbove(keybase1.TeamRole_OWNER) {
 		return keybase1.TeamAddMemberResult{}, errors.New("You cannot invite an owner to a team.")
 	}
 

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -12,6 +12,8 @@ import (
 	jsonw "github.com/keybase/go-jsonw"
 )
 
+// A snapshot of a team's state.
+// Not threadsafe.
 type Team struct {
 	libkb.Contextified
 

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -50,6 +50,7 @@ protocol constants {
     SCKeySyncedPGPNotFound_929,
     SCKeyNoMatchingGPG_930,
     SCKeyRevoked_931,
+    SCSigOldSeqno_1010,
     SCBadTrackSession_1301,
     SCDeviceBadName_1404,
     SCDeviceNameInUse_1408,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -183,6 +183,7 @@ export const ConstantsStatusCode = {
   sckeysyncedpgpnotfound: 929,
   sckeynomatchinggpg: 930,
   sckeyrevoked: 931,
+  scsigoldseqno: 1010,
   scbadtracksession: 1301,
   scdevicebadname: 1404,
   scdevicenameinuse: 1408,
@@ -4663,6 +4664,7 @@ export type StatusCode =
   | 929 // SCKeySyncedPGPNotFound_929
   | 930 // SCKeyNoMatchingGPG_930
   | 931 // SCKeyRevoked_931
+  | 1010 // SCSigOldSeqno_1010
   | 1301 // SCBadTrackSession_1301
   | 1404 // SCDeviceBadName_1404
   | 1408 // SCDeviceNameInUse_1408

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -54,6 +54,7 @@
         "SCKeySyncedPGPNotFound_929",
         "SCKeyNoMatchingGPG_930",
         "SCKeyRevoked_931",
+        "SCSigOldSeqno_1010",
         "SCBadTrackSession_1301",
         "SCDeviceBadName_1404",
         "SCDeviceNameInUse_1408",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -183,6 +183,7 @@ export const ConstantsStatusCode = {
   sckeysyncedpgpnotfound: 929,
   sckeynomatchinggpg: 930,
   sckeyrevoked: 931,
+  scsigoldseqno: 1010,
   scbadtracksession: 1301,
   scdevicebadname: 1404,
   scdevicenameinuse: 1408,
@@ -4663,6 +4664,7 @@ export type StatusCode =
   | 929 // SCKeySyncedPGPNotFound_929
   | 930 // SCKeyNoMatchingGPG_930
   | 931 // SCKeyRevoked_931
+  | 1010 // SCSigOldSeqno_1010
   | 1301 // SCBadTrackSession_1301
   | 1404 // SCDeviceBadName_1404
   | 1408 // SCDeviceNameInUse_1408


### PR DESCRIPTION
If two clients try to modify the sigchain, now they can both succeed by retrying. This is how it would look with just `AddMember` hooked up to retry. To really fix the problem in all cases, the retry would have to be sprinkled all over the place (RemoveMember, Rotate, Leave, etc). It has to happen pretty high up in the stack to get all the random pre-checks like `"newer version of user %q already exists in team"`.
