### PR TITLE
Handle return on the non-list-building search on profile

### DIFF
--- a/shared/profile/search.desktop.js
+++ b/shared/profile/search.desktop.js
@@ -12,7 +12,9 @@ const Search = (props: Props) => (
     <Box style={styleSearchContainer} onClick={e => e.stopPropagation()}>
       <Box style={styleSearchRow}>
         <UserInput
+          disableListBuilding={true}
           searchKey="profileSearch"
+          onSelectUser={props.onClick}
           onExitSearch={props.onClose}
           autoFocus={true}
           placeholder={props.placeholder}

--- a/shared/search/helpers.js
+++ b/shared/search/helpers.js
@@ -79,7 +79,9 @@ const onChangeSelectedSearchResultHoc = compose(
         props._searchDebounced.flush()
         // See whether the current search result term matches the last one submitted
         if (lastSearchTerm === props.searchResultTerm) {
-          props.selectedSearchId && props.onAddUser(props.selectedSearchId)
+          props.selectedSearchId && props.disableListBuilding
+            ? props.onSelectUser(props.selectedSearchId)
+            : props.onAddUser(props.selectedSearchId)
           props.onChangeSearchText && props.onChangeSearchText('')
         }
       },

--- a/shared/search/user-input/container.js
+++ b/shared/search/user-input/container.js
@@ -20,6 +20,8 @@ type OwnProps = {|
   focusInputCounter?: number,
   placeholder: ?string,
   onExitSearch: ?() => void,
+  onSelectUser?: (id: string) => void,
+  disableListBuilding?: boolean,
 |}
 
 const UserInputWithServiceFilter = props => {


### PR DESCRIPTION
@keybase/react-hackers 

We have logic that takes a `disableListBuilding` prop in the `<SearchResults />` component, for when you click on a searchv3 result in a mode that doesn't build a list of users (like the profile search).

But that logic wasn't also in the `<UserInput />` component, which also has to make the same decision about whether to add or select a user when you hit enter in the user input field of a search.  So when you hit enter after typing a username, it would always add it to a list instead of selecting it.  This PR adds that logic.