### PR TITLE
Remove GetSecretKeyWithPrompt fallback from GetMySecretKey

### DIFF
--- a/go/engine/crypto_test.go
+++ b/go/engine/crypto_test.go
@@ -87,8 +87,8 @@ func TestCryptoSignED25519NoSigningKey(t *testing.T) {
 		Msg: []byte("test message"),
 	})
 
-	if _, ok := err.(libkb.SelfNotFoundError); !ok {
-		t.Errorf("expected SelfNotFoundError, got %v", err)
+	if _, ok := err.(libkb.LoginRequiredError); !ok {
+		t.Errorf("expected LoginRequiredError, got %v", err)
 	}
 }
 
@@ -216,8 +216,8 @@ func TestCryptoUnboxBytes32NoEncryptionKey(t *testing.T) {
 	}
 	_, err := UnboxBytes32(context.TODO(), tc.G, f, keybase1.UnboxBytes32Arg{})
 
-	if _, ok := err.(libkb.SelfNotFoundError); !ok {
-		t.Errorf("expected SelfNotFoundError, got %v", err)
+	if _, ok := err.(libkb.LoginRequiredError); !ok {
+		t.Errorf("expected LoginRequiredError, got %v", err)
 	}
 }
 

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -368,8 +368,8 @@ func TestSignAfterRevoke(t *testing.T) {
 	if err == nil {
 		t.Fatal("nil error signing after LogoutIfRevoked")
 	}
-	if _, ok := err.(libkb.KeyRevokedError); !ok {
-		t.Errorf("error type: %T, expected libkb.KeyRevokedError", err)
+	if _, ok := err.(libkb.LoginRequiredError); !ok {
+		t.Errorf("error type: %T, expected libkb.LoginRequiredError", err)
 	}
 }
 


### PR DESCRIPTION
GetSecretKeyWithPrompt is problematic and shouldn't be used to unlock device keys, they should only be unlocked during login.

It ended up causing bad kbfs UX during logout for user, see CORE-6427 for details.

cc @strib 