### PR TITLE
add channel name mention info to messages CORE-6105

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -527,7 +527,8 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 		if err == nil {
 			// Since we are using the "holey" collector, we need to resolve any placeholder
 			// messages that may have been fetched.
-			s.Debug(ctx, "Pull: cache hit: convID: %s uid: %s holes: %d", convID, uid, rc.Holes())
+			s.Debug(ctx, "Pull: cache hit: convID: %s uid: %s holes: %d msgs: %d", convID, uid, rc.Holes(),
+				len(thread.Messages))
 			err = s.resolveHoles(ctx, uid, &thread, conv)
 		}
 		if err == nil {

--- a/go/chat/globals/globals.go
+++ b/go/chat/globals/globals.go
@@ -14,6 +14,7 @@ type ChatContext struct {
 	FetchRetrier        types.FetchRetrier        // For retrying failed fetch requests
 	ConvLoader          types.ConvLoader          // background conversation loader
 	PushHandler         types.PushHandler         // for handling push notifications from chat server
+	TeamChannelSource   types.TeamChannelSource   // source of all channels in a team
 }
 
 type Context struct {

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -581,6 +581,7 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 	if joinRes.RateLimit != nil {
 		rl = append(rl, *joinRes.RateLimit)
 	}
+
 	// Clear team channel source
 	g.TeamChannelSource.ChannelsChanged(ctx, nil)
 
@@ -638,6 +639,7 @@ func LeaveConversation(ctx context.Context, g *globals.Context, debugger utils.D
 	if leaveRes.RateLimit != nil {
 		rl = append(rl, *leaveRes.RateLimit)
 	}
+
 	// Clear team channel source
 	g.TeamChannelSource.ChannelsChanged(ctx, nil)
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -338,108 +338,6 @@ func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
 	return inbox.ConvsUnverified[0].Conv, ratelim, nil
 }
 
-func GetTLFConversations(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
-	ri func() chat1.RemoteInterface, uid gregor1.UID, tlfID chat1.TLFID, topicType chat1.TopicType,
-	membersType chat1.ConversationMembersType) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
-
-	tlfRes, err := ri().GetTLFConversations(ctx, chat1.GetTLFConversationsArg{
-		TlfID:            tlfID,
-		TopicType:        topicType,
-		MembersType:      membersType,
-		SummarizeMaxMsgs: false,
-	})
-	if err != nil {
-		return res, rl, err
-	}
-	if tlfRes.RateLimit != nil {
-		rl = append(rl, *tlfRes.RateLimit)
-	}
-
-	// Localize the conversations
-	res, err = NewBlockingLocalizer(g).Localize(ctx, uid, types.Inbox{
-		ConvsUnverified: utils.RemoteConvs(tlfRes.Conversations),
-	})
-	if err != nil {
-		debugger.Debug(ctx, "GetTLFConversations: failed to localize conversations: %s", err.Error())
-		return res, rl, err
-	}
-	sort.Sort(utils.ConvLocalByTopicName(res))
-	rl = utils.AggRateLimits(rl)
-	return res, rl, nil
-}
-
-type GetTLFConversationTopicNamesRes struct {
-	ConvID    chat1.ConversationID
-	TopicName string
-}
-
-func GetTLFConversationTopicNames(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
-	ri func() chat1.RemoteInterface, uid gregor1.UID, tlfID chat1.TLFID, topicType chat1.TopicType,
-	membersType chat1.ConversationMembersType) (res []GetTLFConversationTopicNamesRes, rl []chat1.RateLimit, err error) {
-
-	tlfRes, err := ri().GetTLFConversations(ctx, chat1.GetTLFConversationsArg{
-		TlfID:            tlfID,
-		TopicType:        topicType,
-		MembersType:      membersType,
-		SummarizeMaxMsgs: false,
-	})
-	if err != nil {
-		return res, rl, err
-	}
-	if tlfRes.RateLimit != nil {
-		rl = append(rl, *tlfRes.RateLimit)
-	}
-
-	getMetadataMsg := func(conv chat1.Conversation) (chat1.MessageBoxed, bool) {
-		for _, msg := range conv.MaxMsgs {
-			if msg.GetMessageType() == chat1.MessageType_METADATA {
-				return msg, true
-			}
-		}
-		return chat1.MessageBoxed{}, false
-	}
-
-	// Find metadata messages in this result and unbox them
-	for _, conv := range tlfRes.Conversations {
-		msg, ok := getMetadataMsg(conv)
-		if ok {
-			unboxeds, err := g.ConvSource.GetMessagesWithRemotes(ctx, conv, uid, []chat1.MessageBoxed{msg})
-			if err != nil {
-				debugger.Debug(ctx, "GetTLFConversationTopicNames: failed to unbox metadata message for: convID: %s err: %s", conv.GetConvID(), err)
-				continue
-			}
-			if len(unboxeds) != 1 {
-				debugger.Debug(ctx, "GetTLFConversationTopicNames: empty result: convID: %s", conv.GetConvID())
-				continue
-			}
-			unboxed := unboxeds[0]
-			if !unboxed.IsValid() {
-				debugger.Debug(ctx, "GetTLFConversationTopicNames: metadata message invalid: convID, %s",
-					conv.GetConvID())
-				continue
-			}
-			body := unboxed.Valid().MessageBody
-			typ, err := body.MessageType()
-			if err != nil {
-				debugger.Debug(ctx, "GetTLFConversationTopicNames: error getting message type: convID, %s",
-					conv.GetConvID(), err)
-				continue
-			}
-			if typ != chat1.MessageType_METADATA {
-				debugger.Debug(ctx, "GetTLFConversationTopicNames: message not a real metadata message: convID, %s msgID: %d", conv.GetConvID(), unboxed.GetMessageID())
-				continue
-			}
-
-			res = append(res, GetTLFConversationTopicNamesRes{
-				ConvID:    conv.GetConvID(),
-				TopicName: body.Metadata().ConversationTitle,
-			})
-		}
-	}
-
-	return res, rl, nil
-}
-
 func GetTopicNameState(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
 	convs []chat1.ConversationLocal,
 	uid gregor1.UID, tlfID chat1.TLFID, topicType chat1.TopicType,
@@ -515,8 +413,8 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 				debugger.Debug(ctx, "FindConversations: failed to get TLFID from name: %s", err.Error())
 				return res, rl, err
 			}
-			tlfConvs, irl, err := GetTLFConversations(ctx, g, debugger, ri,
-				uid, nameInfo.ID, topicType, membersType)
+			tlfConvs, irl, err := g.TeamChannelSource.GetChannelsFull(ctx, uid, nameInfo.ID, topicType,
+				membersType)
 			if err != nil {
 				debugger.Debug(ctx, "FindConversations: failed to list TLF conversations: %s", err.Error())
 				return res, rl, err

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -582,9 +582,6 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 		rl = append(rl, *joinRes.RateLimit)
 	}
 
-	// Clear team channel source
-	g.TeamChannelSource.ChannelsChanged(ctx, nil)
-
 	if _, err = g.InboxSource.MembershipUpdate(ctx, uid, 0, []chat1.ConversationMember{
 		chat1.ConversationMember{
 			Uid:    uid,
@@ -639,9 +636,6 @@ func LeaveConversation(ctx context.Context, g *globals.Context, debugger utils.D
 	if leaveRes.RateLimit != nil {
 		rl = append(rl, *leaveRes.RateLimit)
 	}
-
-	// Clear team channel source
-	g.TeamChannelSource.ChannelsChanged(ctx, nil)
 
 	return rl, nil
 }
@@ -849,6 +843,9 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 		if err = n.G().InboxSource.NewConversation(ctx, n.uid, 0, updateConv.Conv); err != nil {
 			return res, rl, err
 		}
+
+		// Clear team channel source
+		n.G().TeamChannelSource.ChannelsChanged(ctx, updateConv.Conv.Metadata.IdTriple.Tlfid)
 
 		if res.Error != nil {
 			return res, rl, errors.New(res.Error.Message)

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -581,6 +581,9 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 	if joinRes.RateLimit != nil {
 		rl = append(rl, *joinRes.RateLimit)
 	}
+	// Clear team channel source
+	g.TeamChannelSource.ChannelsChanged(ctx, nil)
+
 	if _, err = g.InboxSource.MembershipUpdate(ctx, uid, 0, []chat1.ConversationMember{
 		chat1.ConversationMember{
 			Uid:    uid,
@@ -635,6 +638,8 @@ func LeaveConversation(ctx context.Context, g *globals.Context, debugger utils.D
 	if leaveRes.RateLimit != nil {
 		rl = append(rl, *leaveRes.RateLimit)
 	}
+	// Clear team channel source
+	g.TeamChannelSource.ChannelsChanged(ctx, nil)
 
 	return rl, nil
 }

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -330,8 +330,8 @@ func (s *BlockingSender) checkTopicNameAndGetState(ctx context.Context, msg chat
 		tlfID := msg.ClientHeader.Conv.Tlfid
 		topicType := msg.ClientHeader.Conv.TopicType
 		newTopicName := msg.MessageBody.Metadata().ConversationTitle
-		convs, _, err := GetTLFConversations(ctx, s.G(), s.DebugLabeler, s.getRi,
-			msg.ClientHeader.Sender, tlfID, topicType, membersType)
+		convs, _, err := s.G().TeamChannelSource.GetChannelsFull(ctx, msg.ClientHeader.Sender, tlfID,
+			topicType, membersType)
 		if err != nil {
 			return topicNameState, err
 		}

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -194,6 +194,7 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	pushHandler.SetClock(world.Fc)
 	g.PushHandler = pushHandler
 	g.ChatHelper = NewHelper(g, getRI)
+	g.TeamChannelSource = NewCachingTeamChannelSource(g, getRI)
 
 	return ctx, world, ri, sender, baseSender, &listener
 }

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2213,8 +2213,8 @@ func (h *Server) GetTLFConversationsLocal(ctx context.Context, arg chat1.GetTLFC
 	}
 
 	var convs []chat1.ConversationLocal
-	convs, res.RateLimits, err = GetTLFConversations(ctx, h.G(), h.DebugLabeler,
-		h.remoteClient, uid, nameInfo.ID, arg.TopicType, arg.MembersType)
+	convs, res.RateLimits, err = h.G().TeamChannelSource.GetChannelsFull(ctx, uid, nameInfo.ID, arg.TopicType,
+		arg.MembersType)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -59,6 +59,8 @@ func (t *basicSupersedesTransform) transformEdit(msg chat1.MessageUnboxed, super
 		SenderDeviceRevokedAt: msg.Valid().SenderDeviceRevokedAt,
 		AtMentions:            superMsg.Valid().AtMentions,
 		AtMentionUsernames:    superMsg.Valid().AtMentionUsernames,
+		ChannelMention:        superMsg.Valid().ChannelMention,
+		ChannelNameMentions:   superMsg.Valid().ChannelNameMentions,
 	})
 	return &newMsg
 }

--- a/go/chat/teamchannelsource.go
+++ b/go/chat/teamchannelsource.go
@@ -53,7 +53,7 @@ func (c *CachingTeamChannelSource) fetchFromCache(ctx context.Context, teamID ch
 		return nil, false
 	}
 	// Check to see if the entry is stale, and get it out of there if so
-	if time.Now().Sub(item.entry) > 5*time.Minute {
+	if time.Now().Sub(item.entry) > time.Hour {
 		c.invalidate(ctx, teamID)
 		return nil, false
 	}

--- a/go/chat/teamchannelsource.go
+++ b/go/chat/teamchannelsource.go
@@ -1,0 +1,130 @@
+package chat
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashicorp/golang-lru"
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+)
+
+type CachingTeamChannelSource struct {
+	globals.Contextified
+	utils.DebugLabeler
+
+	cache *lru.Cache
+	ri    func() chat1.RemoteInterface
+}
+
+func NewCachingTeamChannelSource(g *globals.Context, ri func() chat1.RemoteInterface) *CachingTeamChannelSource {
+	c, _ := lru.New(100)
+	return &CachingTeamChannelSource{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "CachingTeamChannelSource", false),
+		cache:        c,
+		ri:           ri,
+	}
+}
+
+func (c *CachingTeamChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID, teamID chat1.TLFID,
+	topicType chat1.TopicType, membersType chat1.ConversationMembersType) (res []chat1.ConversationLocal,
+	rl []chat1.RateLimit, err error) {
+
+	tlfRes, err := c.ri().GetTLFConversations(ctx, chat1.GetTLFConversationsArg{
+		TlfID:            teamID,
+		TopicType:        topicType,
+		MembersType:      membersType,
+		SummarizeMaxMsgs: false,
+	})
+	if err != nil {
+		return res, rl, err
+	}
+	if tlfRes.RateLimit != nil {
+		rl = append(rl, *tlfRes.RateLimit)
+	}
+
+	// Localize the conversations
+	res, err = NewBlockingLocalizer(c.G()).Localize(ctx, uid, types.Inbox{
+		ConvsUnverified: utils.RemoteConvs(tlfRes.Conversations),
+	})
+	if err != nil {
+		c.Debug(ctx, "GetTLFConversations: failed to localize conversations: %s", err.Error())
+		return res, rl, err
+	}
+	sort.Sort(utils.ConvLocalByTopicName(res))
+	rl = utils.AggRateLimits(rl)
+	return res, rl, nil
+}
+
+func (c *CachingTeamChannelSource) GetChannelsTopicName(ctx context.Context, uid gregor1.UID,
+	teamID chat1.TLFID, topicType chat1.TopicType, membersType chat1.ConversationMembersType) (res []types.ConvIDAndTopicName, rl []chat1.RateLimit, err error) {
+	tlfRes, err := c.ri().GetTLFConversations(ctx, chat1.GetTLFConversationsArg{
+		TlfID:            teamID,
+		TopicType:        topicType,
+		MembersType:      membersType,
+		SummarizeMaxMsgs: false,
+	})
+	if err != nil {
+		return res, rl, err
+	}
+	if tlfRes.RateLimit != nil {
+		rl = append(rl, *tlfRes.RateLimit)
+	}
+
+	getMetadataMsg := func(conv chat1.Conversation) (chat1.MessageBoxed, bool) {
+		for _, msg := range conv.MaxMsgs {
+			if msg.GetMessageType() == chat1.MessageType_METADATA {
+				return msg, true
+			}
+		}
+		return chat1.MessageBoxed{}, false
+	}
+
+	// Find metadata messages in this result and unbox them
+	for _, conv := range tlfRes.Conversations {
+		msg, ok := getMetadataMsg(conv)
+		if ok {
+			unboxeds, err := c.G().ConvSource.GetMessagesWithRemotes(ctx, conv, uid, []chat1.MessageBoxed{msg})
+			if err != nil {
+				c.Debug(ctx, "GetTLFConversationTopicNames: failed to unbox metadata message for: convID: %s err: %s", conv.GetConvID(), err)
+				continue
+			}
+			if len(unboxeds) != 1 {
+				c.Debug(ctx, "GetTLFConversationTopicNames: empty result: convID: %s", conv.GetConvID())
+				continue
+			}
+			unboxed := unboxeds[0]
+			if !unboxed.IsValid() {
+				c.Debug(ctx, "GetTLFConversationTopicNames: metadata message invalid: convID, %s",
+					conv.GetConvID())
+				continue
+			}
+			body := unboxed.Valid().MessageBody
+			typ, err := body.MessageType()
+			if err != nil {
+				c.Debug(ctx, "GetTLFConversationTopicNames: error getting message type: convID, %s",
+					conv.GetConvID(), err)
+				continue
+			}
+			if typ != chat1.MessageType_METADATA {
+				c.Debug(ctx, "GetTLFConversationTopicNames: message not a real metadata message: convID, %s msgID: %d", conv.GetConvID(), unboxed.GetMessageID())
+				continue
+			}
+
+			res = append(res, types.ConvIDAndTopicName{
+				ConvID:    conv.GetConvID(),
+				TopicName: body.Metadata().ConversationTitle,
+			})
+		}
+	}
+
+	return res, rl, nil
+}
+
+func (c *CachingTeamChannelSource) ChannelsChanged(ctx context.Context, teamID chat1.TLFID) {
+
+}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -159,3 +159,11 @@ type AppState interface {
 	State() keybase1.AppState
 	NextUpdate() chan keybase1.AppState
 }
+
+type TeamChannelSource interface {
+	GetChannelsFull(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType,
+		chat1.ConversationMembersType) ([]chat1.ConversationLocal, []chat1.RateLimit, error)
+	GetChannelsTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType,
+		chat1.ConversationMembersType) ([]ConvIDAndTopicName, []chat1.RateLimit, error)
+	ChannelsChanged(context.Context, chat1.TLFID)
+}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -161,6 +161,8 @@ type AppState interface {
 }
 
 type TeamChannelSource interface {
+	Offlinable
+
 	GetChannelsFull(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType,
 		chat1.ConversationMembersType) ([]chat1.ConversationLocal, []chat1.RateLimit, error)
 	GetChannelsTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType,

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -62,3 +62,8 @@ type Inbox struct {
 	Convs           []chat1.ConversationLocal
 	Pagination      *chat1.Pagination
 }
+
+type ConvIDAndTopicName struct {
+	ConvID    chat1.ConversationID
+	TopicName string
+}

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -18,6 +18,7 @@ var PushTyping = "chat.typing"
 var PushMembershipUpdate = "chat.membershipUpdate"
 var PushTLFFinalize = "chat.tlffinalize"
 var PushTLFResolve = "chat.tlfresolve"
+var PushTeamChannels = "chat.teamchannels"
 
 type NameInfo struct {
 	ID               chat1.TLFID

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,5 +34,50 @@ func TestParseAtMentionsNames(t *testing.T) {
 	text = "@mike@jim"
 	matches = ParseAtMentionsNames(context.TODO(), text)
 	expected = []string{"mike"}
+	require.Equal(t, expected, matches)
+}
+
+type testTeamChannelSource struct {
+	channels []string
+}
+
+func newTestTeamChannelSource(channels []string) *testTeamChannelSource {
+	return &testTeamChannelSource{
+		channels: channels,
+	}
+}
+
+func (t *testTeamChannelSource) GetChannelsTopicName(ctx context.Context, uid gregor1.UID,
+	teamID chat1.TLFID, topicType chat1.TopicType, membersType chat1.ConversationMembersType) (res []types.ConvIDAndTopicName, rl []chat1.RateLimit, err error) {
+	for _, c := range t.channels {
+		res = append(res, types.ConvIDAndTopicName{
+			TopicName: c,
+		})
+	}
+	return res, rl, nil
+}
+
+func (t *testTeamChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID,
+	teamID chat1.TLFID, topicType chat1.TopicType, membersType chat1.ConversationMembersType) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
+	return res, rl, nil
+}
+
+func (t *testTeamChannelSource) ChannelsChanged(ctx context.Context, teamID chat1.TLFID) {}
+
+func (t *testTeamChannelSource) IsOffline(ctx context.Context) bool {
+	return false
+}
+
+func (t *testTeamChannelSource) Connected(ctx context.Context)    {}
+func (t *testTeamChannelSource) Disconnected(ctx context.Context) {}
+
+func TestParseChannelNameMentions(t *testing.T) {
+	uid := gregor1.UID{0}
+	teamID := chat1.TLFID{0}
+	chans := []string{"general", "random", "miketime"}
+	text := "#miketime is secret. #general has everyone. #random exists. #offtopic does not."
+	matches := ParseChannelNameMentions(context.TODO(), text, uid, teamID, chat1.ConversationMembersType_TEAM,
+		newTestTeamChannelSource(chans))
+	expected := []string{"miketime", "general", "random"}
 	require.Equal(t, expected, matches)
 }

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -302,6 +302,7 @@ type UIMessageValid struct {
 	SenderDeviceRevokedAt *gregor1.Time  `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
 	AtMentions            []string       `codec:"atMentions" json:"atMentions"`
 	ChannelMention        ChannelMention `codec:"channelMention" json:"channelMention"`
+	ChannelNameMentions   []string       `codec:"channelNameMentions" json:"channelNameMentions"`
 }
 
 func (o UIMessageValid) DeepCopy() UIMessageValid {
@@ -339,6 +340,17 @@ func (o UIMessageValid) DeepCopy() UIMessageValid {
 			return ret
 		})(o.AtMentions),
 		ChannelMention: o.ChannelMention.DeepCopy(),
+		ChannelNameMentions: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ChannelNameMentions),
 	}
 }
 

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -288,6 +288,16 @@ func (o UpdateConversationMembership) DeepCopy() UpdateConversationMembership {
 	}
 }
 
+type TeamChannelUpdate struct {
+	TeamID TLFID `codec:"teamID" json:"teamID"`
+}
+
+func (o TeamChannelUpdate) DeepCopy() TeamChannelUpdate {
+	return TeamChannelUpdate{
+		TeamID: o.TeamID.DeepCopy(),
+	}
+}
+
 type GregorInterface interface {
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1721,6 +1721,7 @@ type MessageUnboxedValid struct {
 	AtMentionUsernames    []string                    `codec:"atMentionUsernames" json:"atMentionUsernames"`
 	AtMentions            []gregor1.UID               `codec:"atMentions" json:"atMentions"`
 	ChannelMention        ChannelMention              `codec:"channelMention" json:"channelMention"`
+	ChannelNameMentions   []string                    `codec:"channelNameMentions" json:"channelNameMentions"`
 }
 
 func (o MessageUnboxedValid) DeepCopy() MessageUnboxedValid {
@@ -1782,6 +1783,17 @@ func (o MessageUnboxedValid) DeepCopy() MessageUnboxedValid {
 			return ret
 		})(o.AtMentions),
 		ChannelMention: o.ChannelMention.DeepCopy(),
+		ChannelNameMentions: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ChannelNameMentions),
 	}
 }
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -339,6 +339,9 @@ func (d *Service) createChatModules() {
 	sender := chat.NewBlockingSender(g, chat.NewBoxer(g), d.attachmentstore, ri)
 	g.MessageDeliverer = chat.NewDeliverer(g, sender)
 
+	// team channel source
+	g.TeamChannelSource = chat.NewCachingTeamChannelSource(g, ri)
+
 	// Set up Offlinables on Syncer
 	chatSyncer.RegisterOfflinable(g.InboxSource)
 	chatSyncer.RegisterOfflinable(g.ConvSource)

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -86,6 +86,7 @@ protocol chatUi {
     union {null, gregor1.Time} senderDeviceRevokedAt;
     array<string> atMentions;
     ChannelMention channelMention;
+    array<string> channelNameMentions;
   }
 
   record UIMessageOutbox {

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -96,4 +96,8 @@ protocol gregor {
         array<ConversationMember> reset;
         union { null, UnreadUpdate } unreadUpdate;
     }
+
+    record TeamChannelUpdate {
+        TLFID teamID;
+    }
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -292,6 +292,7 @@ protocol local {
     array<string> atMentionUsernames;
     array<gregor1.UID> atMentions;
     ChannelMention channelMention;
+    array<string> channelNameMentions;
   }
 
   enum MessageUnboxedErrorType {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1589,6 +1589,7 @@ export type MessageUnboxedValid = {
   atMentionUsernames?: ?Array<string>,
   atMentions?: ?Array<gregor1.UID>,
   channelMention: ChannelMention,
+  channelNameMentions?: ?Array<string>,
 }
 
 export type NameQuery = {
@@ -1993,6 +1994,7 @@ export type UIMessageValid = {
   senderDeviceRevokedAt?: ?gregor1.Time,
   atMentions?: ?Array<string>,
   channelMention: ChannelMention,
+  channelNameMentions?: ?Array<string>,
 }
 
 export type UIMessages = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1915,6 +1915,10 @@ export type TLFResolveUpdate = {
   inboxVers: InboxVers,
 }
 
+export type TeamChannelUpdate = {
+  teamID: TLFID,
+}
+
 export type TeamType =
     0 // NONE_0
   | 1 // SIMPLE_1

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -350,6 +350,13 @@
         {
           "type": "ChannelMention",
           "name": "channelMention"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "channelNameMentions"
         }
       ]
     },

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -317,6 +317,16 @@
           "name": "unreadUpdate"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "TeamChannelUpdate",
+      "fields": [
+        {
+          "type": "TLFID",
+          "name": "teamID"
+        }
+      ]
     }
   ],
   "messages": {},

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -855,6 +855,13 @@
         {
           "type": "ChannelMention",
           "name": "channelMention"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "channelNameMentions"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1589,6 +1589,7 @@ export type MessageUnboxedValid = {
   atMentionUsernames?: ?Array<string>,
   atMentions?: ?Array<gregor1.UID>,
   channelMention: ChannelMention,
+  channelNameMentions?: ?Array<string>,
 }
 
 export type NameQuery = {
@@ -1993,6 +1994,7 @@ export type UIMessageValid = {
   senderDeviceRevokedAt?: ?gregor1.Time,
   atMentions?: ?Array<string>,
   channelMention: ChannelMention,
+  channelNameMentions?: ?Array<string>,
 }
 
 export type UIMessages = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1915,6 +1915,10 @@ export type TLFResolveUpdate = {
   inboxVers: InboxVers,
 }
 
+export type TeamChannelUpdate = {
+  teamID: TLFID,
+}
+
 export type TeamType =
     0 // NONE_0
   | 1 // SIMPLE_1


### PR DESCRIPTION
Patch does the following:

1.) Add a new field to `MessageUnboxedValid` and `UIMessage` to indicate which valid channel mentions are in a message.
2.) Add a new type `TeamChannelSource` which provides channel information in full and just topic names (for hopefully a faster call). Also add `CachingTeamChannelSource` which caches the results of the topic name query since it might get used more.
3.) Process Gregor team channel changed message to clear the cache, but also stick a one hour max timer on it just in case. Also gets cleared on re-connect.

cc @chrisnojima this should unblock the channel mention ticket on your side.