### PR TITLE
better error for IA can't leave team

### DIFF
--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -244,3 +244,11 @@ func NewKeyMaskNotFoundErrorForApplication(a keybase1.TeamApplication) libkb.Key
 func NewKeyMaskNotFoundErrorForApplicationAndGeneration(a keybase1.TeamApplication, g keybase1.PerTeamKeyGeneration) libkb.KeyMaskNotFoundError {
 	return libkb.KeyMaskNotFoundError{App: a, Gen: g}
 }
+
+type ImplicitAdminCannotLeave struct{}
+
+func NewImplicitAdminCannotLeave() error { return &ImplicitAdminCannotLeave{} }
+
+func (e ImplicitAdminCannotLeave) Error() string {
+	return "You cannot leave this team. You are an implicit admin (admin of a parent team) but not an explicit member."
+}

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -666,6 +666,17 @@ func TestLeaveSubteamWithImplicitAdminship(t *testing.T) {
 	if team.IsMember(context.TODO(), otherB.GetUserVersion()) {
 		t.Fatal("Writer user is still member after leave.")
 	}
+
+	// Try to leave the team again.
+	// They are now an implicit admin and not an explicit member.
+	// So this should fail, but with a reasonable error.
+	t.Logf("try to leave again")
+	tc.G.Logout()
+	err = otherA.Login(tc.G)
+	require.NoError(t, err)
+	err = Leave(context.TODO(), tc.G, subteamName, false)
+	require.Error(t, err)
+	require.IsType(t, &ImplicitAdminCannotLeave{}, err, "wrong error type")
 }
 
 func TestMemberAddResolveCache(t *testing.T) {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -108,6 +108,15 @@ func (t *Team) MemberRole(ctx context.Context, uv keybase1.UserVersion) (keybase
 	return t.chain().GetUserRole(uv)
 }
 
+func (t *Team) myRole(ctx context.Context) (keybase1.TeamRole, error) {
+	me, err := t.loadMe(ctx)
+	if err != nil {
+		return keybase1.TeamRole_NONE, err
+	}
+	role, err := t.MemberRole(ctx, me.ToUserVersion())
+	return role, err
+}
+
 func (t *Team) UserVersionByUID(ctx context.Context, uid keybase1.UID) (keybase1.UserVersion, error) {
 	return t.chain().GetLatestUVWithUID(uid)
 }
@@ -470,6 +479,8 @@ func (t *Team) ChangeMembership(ctx context.Context, req keybase1.TeamChangeReq)
 }
 
 func (t *Team) downgradeIfOwnerOrAdmin(ctx context.Context) (needsReload bool, err error) {
+	defer t.G().CTrace(ctx, "Team#downgradeIfOwnerOrAdmin", func() error { return err })()
+
 	me, err := t.loadMe(ctx)
 	if err != nil {
 		return false, err
@@ -507,6 +518,19 @@ func (t *Team) Leave(ctx context.Context, permanent bool) error {
 		})
 		if err != nil {
 			return err
+		}
+	}
+
+	// Check if we are an implicit admin with no explicit membership
+	// in order to give a nice error.
+	role, err := t.myRole(ctx)
+	if err != nil {
+		role = keybase1.TeamRole_NONE
+	}
+	if role == keybase1.TeamRole_NONE {
+		_, err := t.getAdminPermission(ctx, false)
+		if err == nil {
+			return NewImplicitAdminCannotLeave()
 		}
 	}
 


### PR DESCRIPTION
Fix the error message for when an implicit admin can't leave a team because they are not an explicit member.

Long ago it was
```
bad leave; you aren't an explicit member of this team
```

Then I ruined it
```
$ keybase-prod team leave testergoofteam2.sub5
▶ ERROR cannot post link (precheck): appending 2->3: link signer does not have permission to leave: {{eb08cb06e608ea41bd893946445d7919 1} true} is a NONE
```

Now it's nice again
```
$ keybase team leave testergoofteam2.sub5
▶ ERROR You cannot leave this team. You are an implicit admin (admin of a parent team) but not an explicit member.
```