### PR TITLE
Disable storyshots again

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -53,6 +53,7 @@
     "setupFiles": [
       "raf/polyfill"
     ],
+    "testPathIgnorePatterns": ["/node_modules/", "/stories/"],
     "snapshotSerializers": [
         "jest-glamor-react"
     ],


### PR DESCRIPTION
generates the same code but out of order
merging but @keybase/react-hackers 