### PR TITLE
Removed unused flag: git list --team

### DIFF
--- a/go/client/cmd_git_list.go
+++ b/go/client/cmd_git_list.go
@@ -25,12 +25,6 @@ func newCmdGitList(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 			cmd := NewCmdGitListRunner(g)
 			cl.ChooseCommand(cmd, "list", c)
 		},
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "team",
-				Usage: "keybase team name (optional)",
-			},
-		},
 	}
 }
 


### PR DESCRIPTION
```
$ keybase-prod git list -h
NAME:
   keybase git list - List the personal and team git repositories you have access to.

USAGE:
   keybase git list [command options]

OPTIONS:
   --team       keybase team name (optional) <--- that one
```