### PR TITLE
only make new badge state on full clear, otherwise apply diff CORE-6443

### DIFF
--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -145,7 +145,12 @@ func (b *BadgeState) UpdateWithChatFull(update chat1.UnreadUpdateFull) {
 		return
 	}
 
-	b.chatUnreadMap = make(map[string]keybase1.BadgeConversationInfo)
+	switch update.InboxSyncStatus {
+	case chat1.SyncInboxResType_CURRENT:
+	case chat1.SyncInboxResType_INCREMENTAL:
+	case chat1.SyncInboxResType_CLEAR:
+		b.chatUnreadMap = make(map[string]keybase1.BadgeConversationInfo)
+	}
 
 	for _, upd := range update.Updates {
 		b.updateWithChat(upd)

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -340,15 +340,17 @@ func (e ChannelMention) String() string {
 }
 
 type UnreadUpdateFull struct {
-	Ignore    bool           `codec:"ignore" json:"ignore"`
-	InboxVers InboxVers      `codec:"inboxVers" json:"inboxVers"`
-	Updates   []UnreadUpdate `codec:"updates" json:"updates"`
+	Ignore          bool             `codec:"ignore" json:"ignore"`
+	InboxVers       InboxVers        `codec:"inboxVers" json:"inboxVers"`
+	InboxSyncStatus SyncInboxResType `codec:"inboxSyncStatus" json:"inboxSyncStatus"`
+	Updates         []UnreadUpdate   `codec:"updates" json:"updates"`
 }
 
 func (o UnreadUpdateFull) DeepCopy() UnreadUpdateFull {
 	return UnreadUpdateFull{
-		Ignore:    o.Ignore,
-		InboxVers: o.InboxVers.DeepCopy(),
+		Ignore:          o.Ignore,
+		InboxVers:       o.InboxVers.DeepCopy(),
+		InboxSyncStatus: o.InboxSyncStatus.DeepCopy(),
 		Updates: (func(x []UnreadUpdate) []UnreadUpdate {
 			if x == nil {
 				return nil
@@ -487,6 +489,32 @@ func (o SyncChatRes) DeepCopy() SyncChatRes {
 		CacheVers: o.CacheVers.DeepCopy(),
 		InboxRes:  o.InboxRes.DeepCopy(),
 	}
+}
+
+type SyncAllProtVers int
+
+const (
+	SyncAllProtVers_V0 SyncAllProtVers = 0
+	SyncAllProtVers_V1 SyncAllProtVers = 1
+)
+
+func (o SyncAllProtVers) DeepCopy() SyncAllProtVers { return o }
+
+var SyncAllProtVersMap = map[string]SyncAllProtVers{
+	"V0": 0,
+	"V1": 1,
+}
+
+var SyncAllProtVersRevMap = map[SyncAllProtVers]string{
+	0: "V0",
+	1: "V1",
+}
+
+func (e SyncAllProtVers) String() string {
+	if v, ok := SyncAllProtVersRevMap[e]; ok {
+		return v
+	}
+	return ""
 }
 
 type SyncAllNotificationType int
@@ -935,6 +963,7 @@ type SyncAllArg struct {
 	InboxVers InboxVers            `codec:"inboxVers" json:"inboxVers"`
 	Ctime     gregor1.Time         `codec:"ctime" json:"ctime"`
 	Fresh     bool                 `codec:"fresh" json:"fresh"`
+	ProtVers  SyncAllProtVers      `codec:"protVers" json:"protVers"`
 }
 
 func (o SyncAllArg) DeepCopy() SyncAllArg {
@@ -945,6 +974,7 @@ func (o SyncAllArg) DeepCopy() SyncAllArg {
 		InboxVers: o.InboxVers.DeepCopy(),
 		Ctime:     o.Ctime.DeepCopy(),
 		Fresh:     o.Fresh,
+		ProtVers:  o.ProtVers.DeepCopy(),
 	}
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -660,6 +660,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 		InboxVers: iboxVers,
 		Ctime:     latestCtime,
 		Fresh:     g.firstConnect,
+		ProtVers:  chat1.SyncAllProtVers_V1,
 	})
 	if err != nil {
 		// This will cause us to try and refresh session on the next attempt

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -710,6 +710,7 @@ func TestGregorBadgesOOBM(t *testing.T) {
 			{ConvID: chat1.ConversationID(`b`), UnreadMessages: 0},
 			{ConvID: chat1.ConversationID(`c`), UnreadMessages: 3},
 		},
+		InboxSyncStatus: chat1.SyncInboxResType_CLEAR,
 	})
 	h.badger.Send()
 	bs = listener.getBadgeState(t)

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -133,6 +133,9 @@ protocol remote {
       boolean ignore;
       // The inbox version that this full update was derived from
       InboxVers inboxVers;
+      // Inbox sync status
+      SyncInboxResType inboxSyncStatus;
+
       array<UnreadUpdate> updates;
   }
 
@@ -182,6 +185,11 @@ protocol remote {
 
   SyncChatRes syncChat(InboxVers vers);
 
+  enum SyncAllProtVers {
+    V0_0,
+    V1_1
+  }
+
   enum SyncAllNotificationType {
     STATE_0,
     INCREMENTAL_1
@@ -199,7 +207,7 @@ protocol remote {
     UnreadUpdateFull badge;
   }
 
-  SyncAllResult syncAll(gregor1.UID uid, gregor1.DeviceID deviceID, gregor1.SessionToken session, InboxVers inboxVers, gregor1.Time ctime, boolean fresh);
+  SyncAllResult syncAll(gregor1.UID uid, gregor1.DeviceID deviceID, gregor1.SessionToken session, InboxVers inboxVers, gregor1.Time ctime, boolean fresh, SyncAllProtVers protVers);
 
   // tlfFinalize is an endpoint for kbfstlfd to notify Gregor that a TLF ID has been finalized.
   // Gregor keeps an internal record of these TLF IDs, so that it can always return the latest

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -240,6 +240,11 @@ export const RemoteSyncAllNotificationType = {
   incremental: 1,
 }
 
+export const RemoteSyncAllProtVers = {
+  v0: 0,
+  v1: 1,
+}
+
 export function localCancelPostRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.CancelPost', request)
 }
@@ -1873,6 +1878,10 @@ export type SyncAllNotificationType =
     0 // STATE_0
   | 1 // INCREMENTAL_1
 
+export type SyncAllProtVers =
+    0 // V0_0
+  | 1 // V1_1
+
 export type SyncAllResult = {
   auth: gregor1.AuthResult,
   chat: SyncChatRes,
@@ -2018,6 +2027,7 @@ export type UnreadUpdate = {
 export type UnreadUpdateFull = {
   ignore: boolean,
   inboxVers: InboxVers,
+  inboxSyncStatus: SyncInboxResType,
   updates?: ?Array<UnreadUpdate>,
 }
 
@@ -2468,7 +2478,8 @@ export type remoteSyncAllRpcParam = Exact<{
   session: gregor1.SessionToken,
   inboxVers: InboxVers,
   ctime: gregor1.Time,
-  fresh: boolean
+  fresh: boolean,
+  protVers: SyncAllProtVers
 }>
 
 export type remoteSyncChatRpcParam = Exact<{

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -275,6 +275,10 @@
           "name": "inboxVers"
         },
         {
+          "type": "SyncInboxResType",
+          "name": "inboxSyncStatus"
+        },
+        {
           "type": {
             "type": "array",
             "items": "UnreadUpdate"
@@ -391,6 +395,14 @@
           "type": "SyncInboxRes",
           "name": "inboxRes"
         }
+      ]
+    },
+    {
+      "type": "enum",
+      "name": "SyncAllProtVers",
+      "symbols": [
+        "V0_0",
+        "V1_1"
       ]
     },
     {
@@ -763,6 +775,10 @@
         {
           "name": "fresh",
           "type": "boolean"
+        },
+        {
+          "name": "protVers",
+          "type": "SyncAllProtVers"
         }
       ],
       "response": "SyncAllResult"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -240,6 +240,11 @@ export const RemoteSyncAllNotificationType = {
   incremental: 1,
 }
 
+export const RemoteSyncAllProtVers = {
+  v0: 0,
+  v1: 1,
+}
+
 export function localCancelPostRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.CancelPost', request)
 }
@@ -1873,6 +1878,10 @@ export type SyncAllNotificationType =
     0 // STATE_0
   | 1 // INCREMENTAL_1
 
+export type SyncAllProtVers =
+    0 // V0_0
+  | 1 // V1_1
+
 export type SyncAllResult = {
   auth: gregor1.AuthResult,
   chat: SyncChatRes,
@@ -2018,6 +2027,7 @@ export type UnreadUpdate = {
 export type UnreadUpdateFull = {
   ignore: boolean,
   inboxVers: InboxVers,
+  inboxSyncStatus: SyncInboxResType,
   updates?: ?Array<UnreadUpdate>,
 }
 
@@ -2468,7 +2478,8 @@ export type remoteSyncAllRpcParam = Exact<{
   session: gregor1.SessionToken,
   inboxVers: InboxVers,
   ctime: gregor1.Time,
-  fresh: boolean
+  fresh: boolean,
+  protVers: SyncAllProtVers
 }>
 
 export type remoteSyncChatRpcParam = Exact<{


### PR DESCRIPTION
Patch does the following:

1.) Uses new `InboxSyncStatus` portion of the badger result from `SyncAll` to inform how to update the badge state. 
2.) Add new protocol changes for SyncAll protocol version. 

Companion to https://github.com/keybase/keybase/pull/1832