### PR TITLE
change chat channel CLI commands to be better CORE-6390

### DIFF
--- a/go/client/cmd_chat_createchannel.go
+++ b/go/client/cmd_chat_createchannel.go
@@ -26,7 +26,7 @@ func NewCmdChatCreateChannelRunner(g *libkb.GlobalContext) *CmdChatCreateChannel
 func newCmdChatCreateChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "create-channel",
-		Usage:        "Create a conversation channel",
+		Usage:        "Create a channel",
 		ArgumentHelp: "<team name> <channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatCreateChannelRunner(g), "create-channel", c)

--- a/go/client/cmd_chat_delete_channel.go
+++ b/go/client/cmd_chat_delete_channel.go
@@ -28,8 +28,8 @@ func NewCmdChatDeleteChannelRunner(g *libkb.GlobalContext) *CmdChatDeleteChannel
 func newCmdChatDeleteChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "delete-channel",
-		Usage:        "Delete a conversation channel",
-		ArgumentHelp: "[conversation [channel name]]",
+		Usage:        "Delete a channel",
+		ArgumentHelp: "<team name> <channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatDeleteChannelRunner(g), "delete-channel", c)
 		},
@@ -78,8 +78,7 @@ func (c *CmdChatDeleteChannel) Run() error {
 
 func (c *CmdChatDeleteChannel) ParseArgv(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) != 2 {
-		cli.ShowCommandHelp(ctx, "delete-channel")
-		return fmt.Errorf("Incorrect usage.")
+		return fmt.Errorf("wrong number of arguments")
 	}
 	teamName := ctx.Args().Get(0)
 	topicName := ctx.Args().Get(1)

--- a/go/client/cmd_chat_joinchannel.go
+++ b/go/client/cmd_chat_joinchannel.go
@@ -29,7 +29,7 @@ func newCmdChatJoinChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) c
 	return cli.Command{
 		Name:         "join-channel",
 		Usage:        "Join a conversation channel",
-		ArgumentHelp: "[conversation [channel name]]",
+		ArgumentHelp: "<team name> <channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatJoinChannelRunner(g), "join-channel", c)
 		},
@@ -64,7 +64,7 @@ func (c *CmdChatJoinChannel) ParseArgv(ctx *cli.Context) (err error) {
 
 	if len(ctx.Args()) != 2 {
 		cli.ShowCommandHelp(ctx, "join-channel")
-		return fmt.Errorf("Incorrect usage.")
+		return fmt.Errorf("Incorrect usage")
 	}
 
 	c.teamName = ctx.Args().Get(0)

--- a/go/client/cmd_chat_joinchannel.go
+++ b/go/client/cmd_chat_joinchannel.go
@@ -63,8 +63,7 @@ func (c *CmdChatJoinChannel) ParseArgv(ctx *cli.Context) (err error) {
 	}
 
 	if len(ctx.Args()) != 2 {
-		cli.ShowCommandHelp(ctx, "join-channel")
-		return fmt.Errorf("Incorrect usage")
+		return fmt.Errorf("wrong number of arguments")
 	}
 
 	c.teamName = ctx.Args().Get(0)

--- a/go/client/cmd_chat_leavechannel.go
+++ b/go/client/cmd_chat_leavechannel.go
@@ -27,8 +27,8 @@ func NewCmdChatLeaveChannelRunner(g *libkb.GlobalContext) *CmdChatLeaveChannel {
 func newCmdChatLeaveChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "leave-channel",
-		Usage:        "Leave a conversation channel",
-		ArgumentHelp: "[conversation [channel name]]",
+		Usage:        "Leave a channel",
+		ArgumentHelp: "<team name> <channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatLeaveChannelRunner(g), "leave-channel", c)
 		},

--- a/go/client/cmd_chat_renamechannel.go
+++ b/go/client/cmd_chat_renamechannel.go
@@ -9,16 +9,13 @@ import (
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
-	"github.com/keybase/client/go/protocol/keybase1"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
 type CmdChatRenameChannel struct {
 	libkb.Contextified
-
 	resolvingRequest chatConversationResolvingRequest
 	setTopicName     string
-	nonBlock         bool
-	team             bool
 }
 
 func NewCmdChatRenameChannelRunner(g *libkb.GlobalContext) *CmdChatRenameChannel {
@@ -28,13 +25,12 @@ func NewCmdChatRenameChannelRunner(g *libkb.GlobalContext) *CmdChatRenameChannel
 func newCmdChatRenameChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "rename-channel",
-		Usage:        "Rename a conversation channel",
-		ArgumentHelp: "<team name> <new channel name>",
+		Usage:        "Rename a channel",
+		ArgumentHelp: "<team name> <old channel name> <new channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatRenameChannelRunner(g), "rename-channel", c)
 		},
-		Flags: append(getConversationResolverFlags(),
-			mustGetChatFlags("set-channel", "nonblock")...),
+		Flags: mustGetChatFlags("topic-type"),
 	}
 }
 
@@ -43,7 +39,6 @@ func (c *CmdChatRenameChannel) Run() error {
 	return chatSend(context.TODO(), c.G(), ChatSendArg{
 		resolvingRequest: c.resolvingRequest,
 		setTopicName:     c.setTopicName,
-		nonBlock:         c.nonBlock,
 		team:             true,
 		message:          "",
 		setHeadline:      "",
@@ -53,28 +48,22 @@ func (c *CmdChatRenameChannel) Run() error {
 }
 
 func (c *CmdChatRenameChannel) ParseArgv(ctx *cli.Context) (err error) {
-	c.setTopicName = utils.SanitizeTopicName(ctx.String("set-channel"))
-	c.nonBlock = ctx.Bool("nonblock")
-
-	var tlfName string
-	if len(ctx.Args()) >= 1 {
-		tlfName = ctx.Args().Get(0)
-	} else {
-		return fmt.Errorf("Must supply team name.")
+	if len(ctx.Args()) != 3 {
+		return fmt.Errorf("wrong number of arguments")
 	}
-	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+
+	teamName := ctx.Args().Get(0)
+	oldChannelName := utils.SanitizeTopicName(ctx.Args().Get(1))
+	newChannelName := utils.SanitizeTopicName(ctx.Args().Get(2))
+
+	c.resolvingRequest.TlfName = teamName
+	c.resolvingRequest.TopicName = oldChannelName
+	c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
+	c.resolvingRequest.MembersType = chat1.ConversationMembersType_TEAM
+	if c.resolvingRequest.TopicType, err = parseConversationTopicType(ctx); err != nil {
 		return err
 	}
-	c.resolvingRequest.MembersType = chat1.ConversationMembersType_TEAM
-	if c.resolvingRequest.Visibility == keybase1.TLFVisibility_ANY {
-		c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
-	}
-	if c.setTopicName == "" {
-		return fmt.Errorf("Must supply non-empty channel name")
-	}
-	if len(ctx.Args()) > 1 {
-		return fmt.Errorf("cannot send text message and set channel name simultaneously")
-	}
+	c.setTopicName = newChannelName
 
 	return nil
 }

--- a/go/client/cmd_chat_renamechannel.go
+++ b/go/client/cmd_chat_renamechannel.go
@@ -29,7 +29,7 @@ func newCmdChatRenameChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext)
 	return cli.Command{
 		Name:         "rename-channel",
 		Usage:        "Rename a conversation channel",
-		ArgumentHelp: "[conversation [new channel name]]",
+		ArgumentHelp: "<team name> <new channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatRenameChannelRunner(g), "rename-channel", c)
 		},
@@ -70,7 +70,7 @@ func (c *CmdChatRenameChannel) ParseArgv(ctx *cli.Context) (err error) {
 		c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
 	}
 	if c.setTopicName == "" {
-		return fmt.Errorf("Must supply non-empty channel name.")
+		return fmt.Errorf("Must supply non-empty channel name")
 	}
 	if len(ctx.Args()) > 1 {
 		return fmt.Errorf("cannot send text message and set channel name simultaneously")


### PR DESCRIPTION
Changes are the following:

1.) `keybase chat rename-channel <team> <old channel name> <new channel name>`
2.) Improved help screens for other channel based commands.