### PR TITLE
Add rotate test, unskip test

### DIFF
--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -243,16 +243,17 @@ func (h *TeamsHandler) TeamDelete(ctx context.Context, arg keybase1.TeamDeleteAr
 }
 
 func (h *TeamsHandler) TeamSetSettings(ctx context.Context, arg keybase1.TeamSetSettingsArg) (err error) {
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamSetSettings(%s)", arg.Name), func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
 	}
 	return teams.ChangeTeamSettings(ctx, h.G().ExternalG(), arg.Name, arg.Settings)
 }
 
-func (h *TeamsHandler) LoadTeamPlusApplicationKeys(netCtx context.Context, arg keybase1.LoadTeamPlusApplicationKeysArg) (keybase1.TeamPlusApplicationKeys, error) {
-	netCtx = libkb.WithLogTag(netCtx, "LTPAK")
-	h.G().Log.CDebugf(netCtx, "+ TeamHandler#LoadTeamPlusApplicationKeys(%+v)", arg)
-	return teams.LoadTeamPlusApplicationKeys(netCtx, h.G().ExternalG(), arg.Id, arg.Application, arg.Refreshers)
+func (h *TeamsHandler) LoadTeamPlusApplicationKeys(ctx context.Context, arg keybase1.LoadTeamPlusApplicationKeysArg) (res keybase1.TeamPlusApplicationKeys, err error) {
+	ctx = libkb.WithLogTag(ctx, "LTPAK")
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LoadTeamPlusApplicationKeys(%s)", arg.Id), func() error { return err })()
+	return teams.LoadTeamPlusApplicationKeys(ctx, h.G().ExternalG(), arg.Id, arg.Application, arg.Refreshers)
 }
 
 func (h *TeamsHandler) GetTeamRootID(ctx context.Context, id keybase1.TeamID) (keybase1.TeamID, error) {
@@ -277,7 +278,8 @@ func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keyba
 	return res, err
 }
 
-func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybase1.TeamReAddMemberAfterResetArg) error {
+func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybase1.TeamReAddMemberAfterResetArg) (err error) {
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamReAddMemberAfterReset(%s)", arg.Id), func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
 	}

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -440,7 +440,6 @@ func TestImplicitTeamReset(t *testing.T) {
 }
 
 func TestImplicitTeamUserReset(t *testing.T) {
-	t.Skip()
 	ctx := newSMUContext(t)
 	defer ctx.cleanup()
 

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1346,6 +1346,7 @@ func RetryOnSigOldSeqnoError(ctx context.Context, g *libkb.GlobalContext, post f
 		}
 		return err
 	}
+	g.Log.CDebugf(ctx, "| RetryOnSigOldSeqnoError exhausted attempts")
 	if err == nil {
 		// Should never happen
 		return fmt.Errorf("failed retryable team operation")


### PR DESCRIPTION
Re-enable `TestImplicitTeamUserReset` now that a supporting server PR has landed. Third time's the charm. Also add `TestRotateRace` which tests hermetically the condition that `TestImplicitTeamUserReset` found.