### PR TITLE
Handle deleted team link types

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -1439,8 +1439,10 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		res.newState = prevState.DeepCopy()
 		err = t.parseTeamSettings(team.Settings, &res.newState)
 		return res, err
-	case "":
-		return res, errors.New("empty body type")
+	case libkb.LinkTypeDeleteRoot:
+		return res, NewTeamDeletedError()
+	case libkb.LinkTypeDeleteUpPointer:
+		return res, NewTeamDeletedError()
 	default:
 		return res, fmt.Errorf("unsupported link type: %s", payload.Body.Type)
 	}

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -245,10 +245,18 @@ func NewKeyMaskNotFoundErrorForApplicationAndGeneration(a keybase1.TeamApplicati
 	return libkb.KeyMaskNotFoundError{App: a, Gen: g}
 }
 
-type ImplicitAdminCannotLeave struct{}
+type ImplicitAdminCannotLeaveError struct{}
 
-func NewImplicitAdminCannotLeave() error { return &ImplicitAdminCannotLeave{} }
+func NewImplicitAdminCannotLeaveError() error { return &ImplicitAdminCannotLeaveError{} }
 
-func (e ImplicitAdminCannotLeave) Error() string {
+func (e ImplicitAdminCannotLeaveError) Error() string {
 	return "You cannot leave this team. You are an implicit admin (admin of a parent team) but not an explicit member."
+}
+
+type TeamDeletedError struct{}
+
+func NewTeamDeletedError() error { return &TeamDeletedError{} }
+
+func (e TeamDeletedError) Error() string {
+	return "team has been deleted"
 }

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -308,6 +308,8 @@ func (l *TeamLoader) verifyAdminPermissions(ctx context.Context,
 // Whether the chain link is of a (child-half) type
 // that affects a parent and child chain in lockstep.
 // So far these events: subteam create, and subteam rename
+// Technically subteam delete is one of these too, but we don't
+// bother because the subteam is rendered inaccessible.
 func (l *TeamLoader) isParentChildOperation(ctx context.Context,
 	link *chainLinkUnpacked) bool {
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -677,7 +677,7 @@ func TestLeaveSubteamWithImplicitAdminship(t *testing.T) {
 	require.NoError(t, err)
 	err = Leave(context.TODO(), tc.G, subteamName, false)
 	require.Error(t, err)
-	require.IsType(t, &ImplicitAdminCannotLeave{}, err, "wrong error type")
+	require.IsType(t, &ImplicitAdminCannotLeaveError{}, err, "wrong error type")
 }
 
 func TestMemberAddResolveCache(t *testing.T) {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -532,7 +532,7 @@ func (t *Team) Leave(ctx context.Context, permanent bool) error {
 	if role == keybase1.TeamRole_NONE {
 		_, err := t.getAdminPermission(ctx, false)
 		if err == nil {
-			return NewImplicitAdminCannotLeave()
+			return NewImplicitAdminCannotLeaveError()
 		}
 	}
 


### PR DESCRIPTION
This shouldn't come up because the server won't give you links for a deleted team.