### PR TITLE
fix ontoggle being called twice

### DIFF
--- a/shared/login/login/index.desktop.js
+++ b/shared/login/login/index.desktop.js
@@ -83,7 +83,9 @@ class Login extends Component<Props, State> {
               type="Primary"
               label={this.props.selectedUser}
               labelStyle={{color: globalColors.orange, fontSize: 16, paddingLeft: 18}}
-              onClick={this._toggleOpen}
+              onClick={() => {
+                /* handled by the ButtonBox */
+              }}
               style={{backgroundColor: globalColors.white, flex: 1}}
             />
             <Icon type="iconfont-caret-down" inheritColor={true} style={{fontSize: 11}} />


### PR DESCRIPTION
@keybase/react-hackers this fixes the desktop login dropdown
it was all wired up but a recent change caused the toggling to fire twice cause the container and its child both toggled. could fix this by doing an event preverntDefault etc but this works too