### PR TITLE
dont overwrite real data if metadata is null

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -97,8 +97,10 @@ function* onInboxStale(param: Constants.InboxStale): SagaGenerator<any, any> {
 
     const author = yield select(usernameSelector)
     const snippets = (inbox.items || []).reduce((map, c) => {
-      const snippet = c.localMetadata ? c.localMetadata.snippet : ''
-      map[c.convID] = new HiddenString(Constants.makeSnippet(snippet) || '')
+      // If we don't have metaData ignore it
+      if (c.localMetadata) {
+        map[c.convID] = new HiddenString(Constants.makeSnippet(c.localMetadata.snippet ) || '')
+      }
       return map
     }, {})
 

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -99,7 +99,7 @@ function* onInboxStale(param: Constants.InboxStale): SagaGenerator<any, any> {
     const snippets = (inbox.items || []).reduce((map, c) => {
       // If we don't have metaData ignore it
       if (c.localMetadata) {
-        map[c.convID] = new HiddenString(Constants.makeSnippet(c.localMetadata.snippet ) || '')
+        map[c.convID] = new HiddenString(Constants.makeSnippet(c.localMetadata.snippet) || '')
       }
       return map
     }, {})


### PR DESCRIPTION
@keybase/react-hackers cc: @mmaxim 
I saw this on mike's computer and I'm conjecturing this is the issue. 
something causes a stale and somehow the cache is lost and we overwrite the exsiting snippets. 