### PR TITLE
Fix Pagination

### DIFF
--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -261,12 +261,21 @@ function updateSupersededByState(
 
 function updatePaginationNext(
   conversationIDKey: Constants.ConversationIDKey,
-  paginationNext: ?string,
-  paginationPrevious: ?string
+  paginationNext: ?string
 ): Constants.UpdatePaginationNext {
   return {
-    payload: {conversationIDKey, paginationNext, paginationPrevious},
+    payload: {conversationIDKey, paginationNext},
     type: 'chat:updatePaginationNext',
+  }
+}
+
+function updatePaginationPrev(
+  conversationIDKey: Constants.ConversationIDKey,
+  paginationPrev: ?string
+): Constants.UpdatePaginationPrev {
+  return {
+    payload: {conversationIDKey, paginationPrev},
+    type: 'chat:updatePaginationPrev',
   }
 }
 
@@ -699,6 +708,7 @@ export {
   updateLatestMessage,
   updateMetadata,
   updatePaginationNext,
+  updatePaginationPrev,
   updateSnippet,
   updateSupersededByState,
   updateSupersedesState,

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -628,7 +628,11 @@ export type UpdateLatestMessage = NoErrorTypedAction<
 export type UpdateMetadata = NoErrorTypedAction<'chat:updateMetadata', {users: Array<string>}>
 export type UpdatePaginationNext = NoErrorTypedAction<
   'chat:updatePaginationNext',
-  {conversationIDKey: ConversationIDKey, paginationNext: ?string, paginationPrevious: ?string}
+  {conversationIDKey: ConversationIDKey, paginationNext: ?string}
+>
+export type UpdatePaginationPrev = NoErrorTypedAction<
+  'chat:updatePaginationPrev',
+  {conversationIDKey: ConversationIDKey, paginationPrev: ?string}
 >
 export type UpdateSupersededByState = NoErrorTypedAction<
   'chat:updateSupersededByState',
@@ -1321,6 +1325,14 @@ function getSnippet(state: TypedState, conversationIDKey: ConversationIDKey): st
   return snippet ? snippet.stringValue() : ''
 }
 
+function getPaginationNext(state: TypedState, conversationIDKey: ConversationIDKey): ?string {
+  return state.entities.pagination.next.get(conversationIDKey, null)
+}
+
+function getPaginationPrev(state: TypedState, conversationIDKey: ConversationIDKey): ?string {
+  return state.entities.pagination.prev.get(conversationIDKey, null)
+}
+
 function applyMessageUpdates(message: Message, updates: I.OrderedSet<EditingMessage | UpdatingAttachment>) {
   if (updates.isEmpty()) {
     return message
@@ -1363,6 +1375,8 @@ export {
   getAttachmentPreviewPath,
   getAttachmentSavedPath,
   getDownloadProgress,
+  getPaginationNext,
+  getPaginationPrev,
   getPreviewProgress,
   getUploadProgress,
   getSnippet,

--- a/shared/constants/entities.js
+++ b/shared/constants/entities.js
@@ -51,6 +51,16 @@ const makeSearchSubState: I.RecordFactory<_SearchSubState> = I.Record({
   searchKeyToClearSearchTextInput: I.Map(),
 })
 
+type PaginationState = I.RecordOf<{
+  next: I.Map<ChatConstants.ConversationIDKey, string>, // Pass this when we want to get older messages
+  prev: I.Map<ChatConstants.ConversationIDKey, string>, // For when we want to get newer messages
+}>
+
+const makePaginationState = I.Record({
+  next: I.Map(),
+  prev: I.Map(),
+})
+
 // State
 type _State = {
   attachmentDownloadProgress: I.Map<ChatConstants.MessageKey, ?number>,
@@ -80,6 +90,7 @@ type _State = {
     I.Map<ChatConstants.MessageID, I.OrderedSet<ChatConstants.MessageKey>>
   >,
   messages: I.Map<ChatConstants.MessageKey, ChatConstants.Message>,
+  pagination: PaginationState,
   search: SearchSubState,
   searchQueryToResult: I.Map<SearchConstants.SearchQuery, I.List<SearchConstants.SearchResultId>>,
   searchResults: I.Map<SearchConstants.SearchResultId, SearchConstants.SearchResult>,
@@ -116,4 +127,5 @@ export const makeState: I.RecordFactory<_State> = I.Record({
   searchQueryToResult: I.Map(),
   searchResults: I.Map(),
   teams: Teams.makeState(),
+  pagination: makePaginationState(),
 })

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -47,14 +47,11 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
       return state.set('conversationStates', newConversationStates)
     }
     case 'chat:prependMessages': {
-      const {moreToLoad, paginationNext, conversationIDKey, paginationPrevious} = action.payload
+      const {moreToLoad, conversationIDKey} = action.payload
       const newConversationStates = state
         .get('conversationStates')
         .update(conversationIDKey, initialConversation, conversation => {
-          return conversation
-            .set('moreToLoad', moreToLoad)
-            .set('paginationNext', paginationNext)
-            .set('paginationPrevious', paginationPrevious)
+          return conversation.set('moreToLoad', moreToLoad)
         })
 
       return state.set('conversationStates', newConversationStates)
@@ -131,15 +128,6 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
         .get('conversationStates')
         .update(conversationIDKey, initialConversation, conversation =>
           conversation.set('isRequesting', isRequesting)
-        )
-      return state.set('conversationStates', newConversationStates)
-    }
-    case 'chat:updatePaginationNext': {
-      const {conversationIDKey, paginationNext, paginationPrevious} = action.payload
-      const newConversationStates = state
-        .get('conversationStates')
-        .update(conversationIDKey, initialConversation, conversation =>
-          conversation.set('paginationNext', paginationNext).set('paginationPrevious', paginationPrevious)
         )
       return state.set('conversationStates', newConversationStates)
     }


### PR DESCRIPTION
@keybase/react-hackers 

Fixes the issue with out of order messages and likely the issue with stuck on digging for ancient messages.

We were always updating the pagination pointers whenever we got a new message. Eventually with enough new messages the pagination pointer didn't reference messages we haven't seen. Only messages we've already seen. Then the way we prepend messages meant that we'd remove messages from the middle and prepend them to the beginning. This caused the out of order messages.

The fix is to better handle our pagination pointers. When we append a message (get a new message or whatever) we update the previous pointer (and only that one). When we prepend messages we update the next pointer (and only that one).


@mmaxim 