### PR TITLE
dont do logout revoked check until the rest of service starts

### DIFF
--- a/go/service/main.go
+++ b/go/service/main.go
@@ -503,7 +503,6 @@ func (d *Service) hourlyChecks() {
 		return nil
 	})
 	go func() {
-		<-time.After(5 * time.Second)
 		// do this quickly
 		if err := d.G().LogoutIfRevoked(); err != nil {
 			d.G().Log.Debug("LogoutIfRevoked error: %s", err)

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -496,11 +496,6 @@ func (d *Service) writeServiceInfo() error {
 }
 
 func (d *Service) hourlyChecks() {
-	// do this right away
-	if err := d.G().LogoutIfRevoked(); err != nil {
-		d.G().Log.Debug("LogoutIfRevoked error: %s", err)
-	}
-
 	ticker := time.NewTicker(1 * time.Hour)
 	d.G().PushShutdownHook(func() error {
 		d.G().Log.Debug("stopping hourlyChecks loop")
@@ -508,6 +503,11 @@ func (d *Service) hourlyChecks() {
 		return nil
 	})
 	go func() {
+		<-time.After(5 * time.Second)
+		// do this quickly
+		if err := d.G().LogoutIfRevoked(); err != nil {
+			d.G().Log.Debug("LogoutIfRevoked error: %s", err)
+		}
 		for {
 			<-ticker.C
 			d.G().Log.Debug("+ hourly check loop")


### PR DESCRIPTION
@chrisnojima @malgorithms I think this should block the release.

Without this change, the app does not start offline. Delay the logout if revoked check 5 seconds so the service can respond to RPC calls from the frontend so it doesn't die.