### PR TITLE
intro message ID control, which we can translate into pagination

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -422,6 +422,11 @@ func (h *Server) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg
 		return chat1.GetThreadLocalRes{}, err
 	}
 
+	// Xlate pager control into pagination if given
+	if arg.Query != nil {
+		arg.Pagination = utils.XlateMessageIDControlToPagination(arg.Query.MessageIDControl)
+	}
+
 	// Get messages from the source
 	uid := h.G().Env.GetUID()
 	thread, rl, err := h.G().ConvSource.Pull(ctx, arg.ConversationID,
@@ -478,6 +483,11 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 	pagination, err := utils.DecodePagination(arg.Pagination)
 	if err != nil {
 		return res, err
+	}
+
+	// Xlate pager control into pagination if given
+	if arg.Query != nil {
+		pagination = utils.XlateMessageIDControlToPagination(arg.Query.MessageIDControl)
 	}
 
 	// Grab local copy first

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keybase/client/go/chat/pager"
+
 	"regexp"
 
 	"github.com/keybase/client/go/chat/globals"
@@ -905,4 +907,32 @@ func UsernamePackageToParticipant(p libkb.UsernamePackage) chat1.ConversationLoc
 		Username: p.NormalizedUsername.String(),
 		Fullname: fullName,
 	}
+}
+
+type pagerMsg struct {
+	msgID chat1.MessageID
+}
+
+func (p pagerMsg) GetMessageID() chat1.MessageID {
+	return p.msgID
+}
+
+func XlateMessageIDControlToPagination(control *chat1.MessageIDControl) (res *chat1.Pagination) {
+	if control == nil {
+		return res
+	}
+	pag := pager.NewThreadPager()
+	res = new(chat1.Pagination)
+	res.Num = control.Num
+	pm := pagerMsg{msgID: control.Pivot}
+	var err error
+	if control.Recent {
+		res.Previous, err = pag.MakeIndex(pm)
+	} else {
+		res.Next, err = pag.MakeIndex(pm)
+	}
+	if err != nil {
+		return nil
+	}
+	return res
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2348,12 +2348,27 @@ func (o ThreadView) DeepCopy() ThreadView {
 	}
 }
 
+type MessageIDControl struct {
+	Pivot  MessageID `codec:"pivot" json:"pivot"`
+	Recent bool      `codec:"recent" json:"recent"`
+	Num    int       `codec:"num" json:"num"`
+}
+
+func (o MessageIDControl) DeepCopy() MessageIDControl {
+	return MessageIDControl{
+		Pivot:  o.Pivot.DeepCopy(),
+		Recent: o.Recent,
+		Num:    o.Num,
+	}
+}
+
 type GetThreadQuery struct {
-	MarkAsRead               bool          `codec:"markAsRead" json:"markAsRead"`
-	MessageTypes             []MessageType `codec:"messageTypes" json:"messageTypes"`
-	DisableResolveSupersedes bool          `codec:"disableResolveSupersedes" json:"disableResolveSupersedes"`
-	Before                   *gregor1.Time `codec:"before,omitempty" json:"before,omitempty"`
-	After                    *gregor1.Time `codec:"after,omitempty" json:"after,omitempty"`
+	MarkAsRead               bool              `codec:"markAsRead" json:"markAsRead"`
+	MessageTypes             []MessageType     `codec:"messageTypes" json:"messageTypes"`
+	DisableResolveSupersedes bool              `codec:"disableResolveSupersedes" json:"disableResolveSupersedes"`
+	Before                   *gregor1.Time     `codec:"before,omitempty" json:"before,omitempty"`
+	After                    *gregor1.Time     `codec:"after,omitempty" json:"after,omitempty"`
+	MessageIDControl         *MessageIDControl `codec:"messageIDControl,omitempty" json:"messageIDControl,omitempty"`
 }
 
 func (o GetThreadQuery) DeepCopy() GetThreadQuery {
@@ -2385,6 +2400,13 @@ func (o GetThreadQuery) DeepCopy() GetThreadQuery {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.After),
+		MessageIDControl: (func(x *MessageIDControl) *MessageIDControl {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.MessageIDControl),
 	}
 }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -430,6 +430,12 @@ protocol local {
     union { null, Pagination } pagination;
   }
 
+  record MessageIDControl {
+    MessageID pivot;
+    boolean recent;
+    int num;
+  }
+
   GetThreadLocalRes getThreadLocal(ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
   record GetThreadQuery {
     boolean markAsRead;
@@ -438,6 +444,8 @@ protocol local {
 
     union { null, gregor1.Time } before;
     union { null, gregor1.Time } after;
+    union { null, MessageIDControl } messageIDControl;
+
   }
   record GetThreadLocalRes {
     ThreadView thread;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1249,6 +1249,7 @@ export type GetThreadQuery = {
   disableResolveSupersedes: boolean,
   before?: ?gregor1.Time,
   after?: ?gregor1.Time,
+  messageIDControl?: ?MessageIDControl,
 }
 
 export type GetThreadRemoteRes = {
@@ -1503,6 +1504,12 @@ export type MessageHeadline = {
 }
 
 export type MessageID = uint
+
+export type MessageIDControl = {
+  pivot: MessageID,
+  recent: boolean,
+  num: int,
+}
 
 export type MessageJoin = {}
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1248,6 +1248,24 @@
     },
     {
       "type": "record",
+      "name": "MessageIDControl",
+      "fields": [
+        {
+          "type": "MessageID",
+          "name": "pivot"
+        },
+        {
+          "type": "boolean",
+          "name": "recent"
+        },
+        {
+          "type": "int",
+          "name": "num"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "GetThreadQuery",
       "fields": [
         {
@@ -1278,6 +1296,13 @@
             "gregor1.Time"
           ],
           "name": "after"
+        },
+        {
+          "type": [
+            null,
+            "MessageIDControl"
+          ],
+          "name": "messageIDControl"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1249,6 +1249,7 @@ export type GetThreadQuery = {
   disableResolveSupersedes: boolean,
   before?: ?gregor1.Time,
   after?: ?gregor1.Time,
+  messageIDControl?: ?MessageIDControl,
 }
 
 export type GetThreadRemoteRes = {
@@ -1503,6 +1504,12 @@ export type MessageHeadline = {
 }
 
 export type MessageID = uint
+
+export type MessageIDControl = {
+  pivot: MessageID,
+  recent: boolean,
+  num: int,
+}
 
 export type MessageJoin = {}
 


### PR DESCRIPTION
Point of the patch is so that the frontend doesn't need to maintain next/prev pagination pointers anymore, and they can just use their own message store to control which messages they get. The new type is `MessageIDControl`, and it takes `Pivot` (a messageID), `Recent` (which direction the new messages should come from), and `Num` (how many to get). Should be easier to deal with.

cc @chrisnojima @MarcoPolo 