### PR TITLE
Add IgnoreIfUnsupported for team chain links from the future

### DIFF
--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -34,7 +34,7 @@ const (
 	// If you add a new one be sure to get all of these too:
 	// - A corresponding libkb.LinkType in constants.go
 	// - SigchainV2TypeFromV1TypeTeams
-	// - SigChainV2Type.IsTeamType
+	// - SigChainV2Type.IsSupportedTeamType
 	// - SigChainV2Type.RequiresAdminPermission
 	// - SigChainV2Type.TeamAllowStub
 	// - TeamSigChainPlayer.addInnerLink (add a case)
@@ -64,7 +64,8 @@ func (t SigchainV2Type) NeedsSignature() bool {
 }
 
 // Whether a type is for team sigchains.
-func (t SigchainV2Type) IsTeamType() bool {
+// Also the list of which types are supported by this client.
+func (t SigchainV2Type) IsSupportedTeamType() bool {
 	switch t {
 	case SigchainV2TypeTeamRoot,
 		SigchainV2TypeTeamNewSubteam,
@@ -87,7 +88,7 @@ func (t SigchainV2Type) IsTeamType() bool {
 }
 
 func (t SigchainV2Type) RequiresAdminPermission() bool {
-	if !t.IsTeamType() {
+	if !t.IsSupportedTeamType() {
 		return false
 	}
 	switch t {
@@ -122,9 +123,9 @@ func (t SigchainV2Type) TeamAllowStub(role keybase1.TeamRole) bool {
 		SigchainV2TypeTeamInvite:
 		return true
 	default:
-		// Disallow stubbing of other including unknown links
-		// TODO CORE-6274 allow stubbing of unknown types
-		return false
+		// Disallow stubbing of other known links.
+		// Allow stubbing of unknown link types for forward compatibility.
+		return !t.IsSupportedTeamType()
 	}
 }
 
@@ -138,6 +139,13 @@ type OuterLinkV2 struct {
 	LinkType SigchainV2Type `codec:"type"`
 	// -- Links exist in the wild that are missing fields below this line.
 	SeqType keybase1.SeqType `codec:"seqtype"`
+	// -- Links exist in the wild that are missing fields below this line too.
+	// Whether the link can be ignored by clients that do not support its link type.
+	// This does _not_ mean the link can be ignored if the client supports the link type.
+	// When it comes to stubbing, if the link is unsupported and this bit is set then
+	// - it can be stubbed for non-admins
+	// - it cannot be stubbed for admins
+	IgnoreIfUnsupported bool `codec:"ignore_if_unsupported"`
 }
 
 type OuterLinkV2WithMetadata struct {

--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -313,6 +313,7 @@ func (o OuterLinkV2) AssertFields(
 	curr LinkID,
 	linkType SigchainV2Type,
 	seqType keybase1.SeqType,
+	ignoreIfUnsupported bool,
 ) (err error) {
 	mkErr := func(format string, arg ...interface{}) error {
 		return SigchainV2MismatchedFieldError{fmt.Sprintf(format, arg...)}
@@ -334,6 +335,9 @@ func (o OuterLinkV2) AssertFields(
 	}
 	if o.SeqType != seqType {
 		return mkErr("seq type: (%d != %d)", o.SeqType, seqType)
+	}
+	if o.IgnoreIfUnsupported != ignoreIfUnsupported {
+		return mkErr("ignore_if_unsupported: (%v != %v)", o.IgnoreIfUnsupported, ignoreIfUnsupported)
 	}
 	return nil
 }

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -281,8 +281,12 @@ func (t TeamSigChainState) HasAnyStubbedLinks() bool {
 	return false
 }
 
-func (t TeamSigChainState) IsLinkFullyPresent(seqno keybase1.Seqno) bool {
+// Whether the link has been processed and is not stubbed.
+func (t TeamSigChainState) IsLinkFilled(seqno keybase1.Seqno) bool {
 	if seqno > t.inner.LastSeqno {
+		return false
+	}
+	if seqno < 0 {
 		return false
 	}
 	return !t.inner.StubbedLinks[seqno]
@@ -1454,6 +1458,11 @@ func (t *TeamSigChainPlayer) addInnerLink(
 	case "":
 		return res, errors.New("empty body type")
 	default:
+		if link.outerLink.IgnoreIfUnsupported {
+			res.newState = prevState.DeepCopy()
+			return res, nil
+		}
+
 		return res, fmt.Errorf("unsupported link type: %s", payload.Body.Type)
 	}
 }

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -141,13 +141,14 @@ func (link *SCChainLink) UnmarshalPayload() (res SCChainLinkPayload, err error) 
 }
 
 type SCChainLinkPayload struct {
-	Body     SCPayloadBody    `json:"body,omitempty"`
-	Ctime    int              `json:"ctime,omitempty"`
-	ExpireIn int              `json:"expire_in,omitempty"`
-	Prev     *string          `json:"prev,omitempty"`
-	SeqType  keybase1.SeqType `json:"seq_type,omitempty"`
-	Seqno    keybase1.Seqno   `json:"seqno,omitempty"`
-	Tag      string           `json:"tag,omitempty"`
+	Body                SCPayloadBody    `json:"body,omitempty"`
+	Ctime               int              `json:"ctime,omitempty"`
+	ExpireIn            int              `json:"expire_in,omitempty"`
+	Prev                *string          `json:"prev,omitempty"`
+	SeqType             keybase1.SeqType `json:"seq_type,omitempty"`
+	Seqno               keybase1.Seqno   `json:"seqno,omitempty"`
+	Tag                 string           `json:"tag,omitempty"`
+	IgnoreIfUnsupported bool             `json:"ignore_if_unsupported,omitempty"`
 }
 
 func (s SCChainLinkPayload) SigChainLocation() keybase1.SigChainLocation {

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -216,6 +216,7 @@ func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me *lib
 		nil,   /* prevLinkID */
 		false, /* hasRevokes */
 		seqType,
+		false, /* ignoreIfUnsupported */
 	)
 	if err != nil {
 		return err
@@ -428,6 +429,7 @@ func makeSigchainV2OuterSig(
 	prevLinkID libkb.LinkID,
 	hasRevokes bool,
 	seqType keybase1.SeqType,
+	ignoreIfUnsupported bool,
 ) (
 	string,
 	error,
@@ -440,12 +442,13 @@ func makeSigchainV2OuterSig(
 	}
 
 	outerLink := libkb.OuterLinkV2{
-		Version:  2,
-		Seqno:    seqno,
-		Prev:     prevLinkID,
-		Curr:     linkID,
-		LinkType: v2LinkType,
-		SeqType:  seqType,
+		Version:             2,
+		Seqno:               seqno,
+		Prev:                prevLinkID,
+		Curr:                linkID,
+		LinkType:            v2LinkType,
+		SeqType:             seqType,
+		IgnoreIfUnsupported: ignoreIfUnsupported,
 	}
 	encodedOuterLink, err := outerLink.Encode()
 	if err != nil {
@@ -483,6 +486,7 @@ func generateNewSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.User,
 		prevLinkID,
 		false, /* hasRevokes */
 		seqType,
+		false, /* ignoreIfUnsupported */
 	)
 	if err != nil {
 		return nil, err
@@ -572,6 +576,7 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 		nil,   /* prevLinkID */
 		false, /* hasRevokes */
 		seqTypeForTeamPublicness(parentTeam.IsPublic()),
+		false, /* ignoreIfUnsupported */
 	)
 	if err != nil {
 		return

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -280,3 +280,19 @@ func (e GreenLinkError) Error() string {
 	// Report the probable cause for this error.
 	return fmt.Sprintf("team sigchain is being rapidly updated (seqno: %v)", e.seqno)
 }
+
+type UnsupportedLinkTypeError struct {
+	outerType libkb.SigchainV2Type
+	innerType string
+}
+
+func NewUnsupportedLinkTypeError(outerType libkb.SigchainV2Type, innerType string) error {
+	return UnsupportedLinkTypeError{
+		outerType: outerType,
+		innerType: innerType,
+	}
+}
+
+func (e UnsupportedLinkTypeError) Error() string {
+	return fmt.Sprintf("unsupported team link type: %v (%v)", e.outerType, e.innerType)
+}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -31,7 +31,7 @@ func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
 	// seqnos needed from the server
 	var requestSeqnos []keybase1.Seqno
 	for _, seqno := range needSeqnos {
-		linkIsAlreadyFilled := TeamSigChainState{inner: state.Chain}.IsLinkFullyPresent(seqno)
+		linkIsAlreadyFilled := TeamSigChainState{inner: state.Chain}.IsLinkFilled(seqno)
 		if seqno <= upperLimit && !linkIsAlreadyFilled {
 			requestSeqnos = append(requestSeqnos, seqno)
 		}
@@ -93,7 +93,7 @@ type getLinksLows struct {
 	ReaderKeyMask keybase1.PerTeamKeyGeneration
 }
 
-// checkStubbed checks if it's OK that a link is stubbed.
+// checkStubbed checks if it's OK if a link is stubbed.
 func (l *TeamLoader) checkStubbed(ctx context.Context, arg load2ArgT, link *chainLinkUnpacked) error {
 	if !link.isStubbed() {
 		return nil

--- a/go/teams/loader_chain_test.go
+++ b/go/teams/loader_chain_test.go
@@ -194,7 +194,7 @@ func runUnit(t *testing.T, unit TestCase) {
 					require.Contains(t, errstr, loadSpec.ErrorSubstr)
 				}
 				if len(loadSpec.ErrorType) > 0 {
-					require.Equal(t, loadSpec.ErrorType, reflect.TypeOf(err).Name(), "unexpected error type")
+					require.Equal(t, loadSpec.ErrorType, reflect.TypeOf(err).Name(), "unexpected error type [%T]", err)
 				}
 			}
 		}

--- a/go/teams/loader_types.go
+++ b/go/teams/loader_types.go
@@ -154,5 +154,12 @@ func (l *chainLinkUnpacked) AssertInnerOuterMatch() (err error) {
 		useSeqType = l.outerLink.SeqType
 	}
 
-	return l.outerLink.AssertFields(l.inner.Body.Version, l.inner.Seqno, prev, l.innerLinkID, linkType, useSeqType)
+	return l.outerLink.AssertFields(
+		l.inner.Body.Version,
+		l.inner.Seqno,
+		prev,
+		l.innerLinkID,
+		linkType,
+		useSeqType,
+		l.inner.IgnoreIfUnsupported)
 }

--- a/go/teams/loader_types.go
+++ b/go/teams/loader_types.go
@@ -126,9 +126,24 @@ func (l *chainLinkUnpacked) AssertInnerOuterMatch() (err error) {
 			return err
 		}
 	}
+
 	linkType, err := libkb.SigchainV2TypeFromV1TypeTeams(l.inner.Body.Type)
 	if err != nil {
-		return err
+		if l.outerLink.LinkType.IsSupportedTeamType() {
+			// Supported outer type but unrecognized inner type.
+			return err
+		}
+		if !l.outerLink.IgnoreIfUnsupported {
+			// Unsupported outer type marked as critical.
+			return NewUnsupportedLinkTypeError(l.outerLink.LinkType, l.inner.Body.Type)
+		}
+
+		// If the inner link type is not recognized, and the outer link type is not a valid
+		// team link type. Then this may be a link type from the future.
+		// Let it slide without really checking that the inner and outer types match
+		// (because this client doesn't know the mapping).
+		// By assigning this tautology, which will always pass AssertFields.
+		linkType = l.outerLink.LinkType
 	}
 
 	useSeqType := l.inner.SeqType

--- a/go/teams/rename.go
+++ b/go/teams/rename.go
@@ -156,6 +156,7 @@ func generateRenameSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.Us
 		prevLinkID,
 		false, /* hasRevokes */
 		seqType,
+		false, /* ignoreIfUnsupported */
 	)
 	if err != nil {
 		return nil, err
@@ -212,6 +213,7 @@ func generateRenameUpPointerSigForSubteamChain(g *libkb.GlobalContext, me *libkb
 		prevLinkID,
 		false, /* hasRevokes */
 		seqType,
+		false, /* ignoreIfUnsupported */
 	)
 	if err != nil {
 		return nil, err

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1116,6 +1116,7 @@ func (t *Team) sigTeamItem(ctx context.Context, section SCTeamSection, linkType 
 		latestLinkID,
 		false, /* hasRevokes */
 		seqType,
+		false, /* ignoreIfUnsupported */
 	)
 	if err != nil {
 		return libkb.SigMultiItem{}, err

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -903,6 +903,11 @@ func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error
 		return err
 	}
 
+	err = t.precheckLinkToPost(ctx, sigMultiItem)
+	if err != nil {
+		return fmt.Errorf("cannot post link (precheck): %v", err)
+	}
+
 	payload := t.sigPayload(sigMultiItem, sigPayloadArgs{})
 	return t.postMulti(payload)
 

--- a/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/mismatch_seqno_type.json
+++ b/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/mismatch_seqno_type.json
@@ -1,0 +1,248 @@
+{
+    "log": [
+        "user:herb key:default",
+        "user:basil key:default",
+        "link team:cabal type:root",
+        "link team:cabal type:change_membership"
+    ],
+    "teams": {
+        "cabal": {
+            "id": "2123209b98b16083c69c91152b861724",
+            "links": [
+                {
+                    "seqno": 1,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTEKZcCAcDEIAYLN+uxSGDmKCASUIE5LFSebmDWI4YVx4jslGVc92nKIQHCo3NpZ8RAUSe0aux1bvn3Sshc/Uc84m+eoo+EnZTBwYbZIwKdMc9IaCRDk6+9agvdes7OyQOqmYsGtm6D6xl7hAgx88wtAqhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\",\"members\":{\"owner\":[\"25852c87d6e47fb8d7d55400be9c7a19\"]},\"name\":\"cabal\",\"per_team_key\":{\"encryption_kid\":\"01216ff492dd6da213b41d22145fed9f0469f7495fd0357beed7ce6b5e5ff060257f0a\",\"generation\":1,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgvIANd4/2v9aWET2qsFioMEZS/OMmqEJmQ7qSg+HlrI4Kp3BheWxvYWTFA3N7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMTAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwibWVtYmVycyI6eyJvd25lciI6WyIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSJdfSwibmFtZSI6ImNhYmFsIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMTZmZjQ5MmRkNmRhMjEzYjQxZDIyMTQ1ZmVkOWYwNDY5Zjc0OTVmZDAzNTdiZWVkN2NlNmI1ZTVmZjA2MDI1N2YwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBiYzgwMGQ3NzhmZjZiZmQ2OTYxMTNkYWFiMDU4YTgzMDQ2NTJmY2UzMjZhODQyNjY0M2JhOTI4M2UxZTVhYzhlMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MTAwMDM3NjIsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJzZXFfdHlwZSI6MSwic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAglN8TEuuBCpa7XcQia4862zP4Gk1x7gysGK0+XW+3a6I91gUpdGlqAFSo93ZHSTgIdXGuh9/c/tGZBO24umTAqhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B\",\"signing_kid\":\"0120bc800d778ff6bfd696113daab058a8304652fce326a8426643ba9283e1e5ac8e0a\"}},\"type\":\"team.root\",\"version\":2},\"ctime\":1510003762,\"expire_in\":157680000,\"seq_type\":1,\"seqno\":1,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 1,
+                        "ctime": 1510003762,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.root",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724",
+                                "name": "cabal",
+                                "members": {
+                                    "owner": [
+                                        "25852c87d6e47fb8d7d55400be9c7a19"
+                                    ]
+                                },
+                                "per_team_key": {
+                                    "reverse_sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgvIANd4/2v9aWET2qsFioMEZS/OMmqEJmQ7qSg+HlrI4Kp3BheWxvYWTFA3N7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMTAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwibWVtYmVycyI6eyJvd25lciI6WyIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSJdfSwibmFtZSI6ImNhYmFsIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMTZmZjQ5MmRkNmRhMjEzYjQxZDIyMTQ1ZmVkOWYwNDY5Zjc0OTVmZDAzNTdiZWVkN2NlNmI1ZTVmZjA2MDI1N2YwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBiYzgwMGQ3NzhmZjZiZmQ2OTYxMTNkYWFiMDU4YTgzMDQ2NTJmY2UzMjZhODQyNjY0M2JhOTI4M2UxZTVhYzhlMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MTAwMDM3NjIsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJzZXFfdHlwZSI6MSwic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAglN8TEuuBCpa7XcQia4862zP4Gk1x7gysGK0+XW+3a6I91gUpdGlqAFSo93ZHSTgIdXGuh9/c/tGZBO24umTAqhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                                    "generation": 1,
+                                    "encryption_kid": "01216ff492dd6da213b41d22145fed9f0469f7495fd0357beed7ce6b5e5ff060257f0a",
+                                    "signing_kid": "0120bc800d778ff6bfd696113daab058a8304652fce326a8426643ba9283e1e5ac8e0a"
+                                }
+                            }
+                        },
+                        "seq_type": 1
+                    },
+                    "debug_link_id": "952c5023485cf1c0855df7bb6e0ee23a027ba0aed8c1d12eb5cd5f96bfe1ccc9"
+                },
+                {
+                    "seqno": 2,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTESpcCAsQglSxQI0hc8cCFXfe7bg7iOgJ7oK7YwdEutc1flr/hzMnEIGqtiOhFdNC6g32ql1nTg8gHBzHB/SeSGBbmml07EhP8IwHCo3NpZ8RA34FCxOEfbEe4dcRVYiyr9m2QW+aGBQI4d0CFRv98okrxoU161o5kTMntRFKSUWpbJtRqf9/M68ejMz9mAiYPDqhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\",\"members\":{\"writer\":[\"579651b0d574971040b531b66efbc519\"]}},\"type\":\"team.change_membership\",\"version\":2},\"ctime\":1510003762,\"expire_in\":157680000,\"prev\":\"952c5023485cf1c0855df7bb6e0ee23a027ba0aed8c1d12eb5cd5f96bfe1ccc9\",\"seq_type\":999,\"seq_type_for_testing\":1,\"seqno\":2,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 2,
+                        "prev": "952c5023485cf1c0855df7bb6e0ee23a027ba0aed8c1d12eb5cd5f96bfe1ccc9",
+                        "ctime": 1510003762,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.change_membership",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724",
+                                "members": {
+                                    "writer": [
+                                        "579651b0d574971040b531b66efbc519"
+                                    ]
+                                }
+                            }
+                        },
+                        "seq_type": 999,
+                        "seq_type_for_testing": 1
+                    },
+                    "debug_link_id": "0ba7594ce51def1aca20cb93ab1f50aa7c5bbf4b981569599dd8b03a653361eb"
+                }
+            ],
+            "team_key_boxes": [
+                {
+                    "seqno": 1,
+                    "box": {
+                        "nonce": "W+rT3NNui23V3QU9cpWeEpFFvRkAAAAB",
+                        "sender_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a",
+                        "generation": 1,
+                        "ctext": "WbcvE7g3d7ZcdQzKfpWq3J+t7DHUJ5L9sOv3L/JvadArE9Wdik4921SqVQCa2uKE",
+                        "per_user_key_seqno": 1
+                    },
+                    "prev": null
+                }
+            ],
+            "debug_tk_secs": [
+                [
+                    "96ae34bcc20c1c1922dbd1ab374a396e0f13cbb85634a5495993f41de616cf9f"
+                ]
+            ],
+            "debug_tk_sig_kids": [
+                [
+                    "0120bc800d778ff6bfd696113daab058a8304652fce326a8426643ba9283e1e5ac8e0a"
+                ]
+            ]
+        }
+    },
+    "users": {
+        "herb": {
+            "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+            "eldest_seqno": 1,
+            "puk_secrets": {
+                "1": "3759ea1c8527a0ecca7be3a447fa35a5ed64969e1651b4c1825dac09b5b6fb42"
+            },
+            "link_map": {
+                "1": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+            },
+            "debug_puk_enc_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a"
+        },
+        "basil": {
+            "uid": "579651b0d574971040b531b66efbc519",
+            "eldest_seqno": 1,
+            "puk_secrets": {
+                "1": "2f93d1fb90f25614da0ca264f42c8da61ee41a9a8ea549e35285906a185b79e9"
+            },
+            "link_map": {
+                "1": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe1"
+            },
+            "debug_puk_enc_kid": "0121f087facd497c93cd138bcd6145910da8d2828d173f3f558c063a68e5ce40d6060a"
+        }
+    },
+    "key_owners": {
+        "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a": "herb",
+        "0120c7f5f37355ccd4b4be822575844ab7903c63a9b831bfd30c940d01f12b39aa470a": "basil"
+    },
+    "key_pubkeyv2nacls": {
+        "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a": {
+            "deviceType": "desktop",
+            "deviceDescription": "home thing",
+            "deviceID": "fbd762facdfad44709aef63a9a8cdf18",
+            "base": {
+                "eTime": 2005146762000,
+                "cTime": 1500570762000,
+                "isEldest": true,
+                "isSibkey": true,
+                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a",
+                "provisioning": {
+                    "sigChainLocation": {
+                        "seqno": 1,
+                        "seqType": 1
+                    },
+                    "signingKID": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a",
+                    "time": 0,
+                    "firstAppearedUnverified": 0,
+                    "prevMerkleRootSigned": {
+                        "hashMeta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc500",
+                        "seqno": 0
+                    }
+                }
+            }
+        },
+        "0120c7f5f37355ccd4b4be822575844ab7903c63a9b831bfd30c940d01f12b39aa470a": {
+            "deviceType": "desktop",
+            "deviceDescription": "home thing",
+            "deviceID": "fbd762facdfad44709aef63a9a8cdf18",
+            "base": {
+                "eTime": 2005146762000,
+                "cTime": 1500570762000,
+                "isEldest": true,
+                "isSibkey": true,
+                "kid": "0120c7f5f37355ccd4b4be822575844ab7903c63a9b831bfd30c940d01f12b39aa470a",
+                "provisioning": {
+                    "sigChainLocation": {
+                        "seqno": 1,
+                        "seqType": 1
+                    },
+                    "signingKID": "0120c7f5f37355ccd4b4be822575844ab7903c63a9b831bfd30c940d01f12b39aa470a",
+                    "time": 0,
+                    "firstAppearedUnverified": 0,
+                    "prevMerkleRootSigned": {
+                        "hashMeta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc500",
+                        "seqno": 0
+                    }
+                }
+            }
+        }
+    },
+    "team_merkle": {
+        "2123209b98b16083c69c91152b861724": {
+            "seqno": 2,
+            "link_id": "0ba7594ce51def1aca20cb93ab1f50aa7c5bbf4b981569599dd8b03a653361eb"
+        },
+        "2123209b98b16083c69c91152b861724-seqno:1": {
+            "seqno": 1,
+            "link_id": "952c5023485cf1c0855df7bb6e0ee23a027ba0aed8c1d12eb5cd5f96bfe1ccc9"
+        },
+        "2123209b98b16083c69c91152b861724-seqno:2": {
+            "seqno": 2,
+            "link_id": "0ba7594ce51def1aca20cb93ab1f50aa7c5bbf4b981569599dd8b03a653361eb"
+        }
+    },
+    "merkle_triples": {
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        },
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        }
+    },
+    "sessions": [
+        {
+            "loads": [
+                {
+                    "error": true,
+                    "error_type": "SigchainV2MismatchedFieldError"
+                }
+            ]
+        },
+        {
+            "loads": [
+                {
+                    "upto": 1
+                },
+                {
+                    "error": true,
+                    "error_type": "SigchainV2MismatchedFieldError"
+                }
+            ]
+        }
+    ]
+}

--- a/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/mismatch_unsupported.json
+++ b/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/mismatch_unsupported.json
@@ -1,0 +1,196 @@
+{
+    "log": [
+        "user:herb key:default",
+        "link team:cabal type:root",
+        "link team:cabal type:unsupported",
+        "ignore_if_unsupported:false link_type:unsupported"
+    ],
+    "teams": {
+        "cabal": {
+            "id": "2123209b98b16083c69c91152b861724",
+            "links": [
+                {
+                    "seqno": 1,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTEKZcCAcDEIPKJc9A3TcSnsI8GsjpLIL/cVH/x6j+AVk27TDgtULutIQHCo3NpZ8RACWPPgPhSF5/iXX2Ip2CUHQb/y4tjO4/tmkSiBcX+cUfmd7qiv1dmDuMt54Cm5Joh2QyYle5ubwmV3E55UMbPBKhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\",\"members\":{\"owner\":[\"25852c87d6e47fb8d7d55400be9c7a19\"]},\"name\":\"cabal\",\"per_team_key\":{\"encryption_kid\":\"0121df1f90362f46c30299233352f173642afd4106fea31a8a69c218b5fefe3a68460a\",\"generation\":1,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg/7SBjzewx/7nB4LRxRI1ldcYu5F48eELOFHohQ23nR8Kp3BheWxvYWTFA3N7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMTAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwibWVtYmVycyI6eyJvd25lciI6WyIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSJdfSwibmFtZSI6ImNhYmFsIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWRmMWY5MDM2MmY0NmMzMDI5OTIzMzM1MmYxNzM2NDJhZmQ0MTA2ZmVhMzFhOGE2OWMyMThiNWZlZmUzYTY4NDYwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBmZmI0ODE4ZjM3YjBjN2ZlZTcwNzgyZDFjNTEyMzU5NWQ3MThiYjkxNzhmMWUxMGIzODUxZTg4NTBkYjc5ZDFmMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MTAwMDM3NjcsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJzZXFfdHlwZSI6MSwic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAnuLnOKUBBlu7F/995scOxJf+0xCCwRGi8mqtlP75Tf2gXG6nWM7f8uRoEPQuxtd6NWomJgQ2bvlSXzwCsRTzBKhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B\",\"signing_kid\":\"0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a\"}},\"type\":\"team.root\",\"version\":2},\"ctime\":1510003767,\"expire_in\":157680000,\"seq_type\":1,\"seqno\":1,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 1,
+                        "ctime": 1510003767,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.root",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724",
+                                "name": "cabal",
+                                "members": {
+                                    "owner": [
+                                        "25852c87d6e47fb8d7d55400be9c7a19"
+                                    ]
+                                },
+                                "per_team_key": {
+                                    "reverse_sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg/7SBjzewx/7nB4LRxRI1ldcYu5F48eELOFHohQ23nR8Kp3BheWxvYWTFA3N7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMTAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwibWVtYmVycyI6eyJvd25lciI6WyIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSJdfSwibmFtZSI6ImNhYmFsIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWRmMWY5MDM2MmY0NmMzMDI5OTIzMzM1MmYxNzM2NDJhZmQ0MTA2ZmVhMzFhOGE2OWMyMThiNWZlZmUzYTY4NDYwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBmZmI0ODE4ZjM3YjBjN2ZlZTcwNzgyZDFjNTEyMzU5NWQ3MThiYjkxNzhmMWUxMGIzODUxZTg4NTBkYjc5ZDFmMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MTAwMDM3NjcsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJzZXFfdHlwZSI6MSwic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAnuLnOKUBBlu7F/995scOxJf+0xCCwRGi8mqtlP75Tf2gXG6nWM7f8uRoEPQuxtd6NWomJgQ2bvlSXzwCsRTzBKhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                                    "generation": 1,
+                                    "encryption_kid": "0121df1f90362f46c30299233352f173642afd4106fea31a8a69c218b5fefe3a68460a",
+                                    "signing_kid": "0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a"
+                                }
+                            }
+                        },
+                        "seq_type": 1
+                    },
+                    "debug_link_id": "0c77f9078aff069666ebf882f4117fb31f418d0a7448f78b18b382afec28ca76"
+                },
+                {
+                    "seqno": 2,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTETJcCAsQgDHf5B4r/BpZm6/iC9BF/sx9BjQp0SPeLGLOCr+woynbEILxSiKVUBxdlB8bQxTijzbDHm0mmqRRX0nvqfETpf0K4zQU5AcOjc2lnxEB+6yPRUokcUL8Rz6QUbuta2njbtNBXbyev4RetJKZYGnm9Zgx589OH1+LLeGtaFl1wXGxQ7XqnxwJPkzeCQbQDqHNpZ190eXBlIKN0YWfNAgKndmVyc2lvbgE=",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\"},\"type\":\"team.unsupported_from_the_future\",\"version\":2},\"ctime\":1510003767,\"expire_in\":157680000,\"ignore_if_unsupported\":false,\"ignore_if_unsupported_for_testing\":true,\"prev\":\"0c77f9078aff069666ebf882f4117fb31f418d0a7448f78b18b382afec28ca76\",\"seq_type\":1,\"seqno\":2,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 2,
+                        "prev": "0c77f9078aff069666ebf882f4117fb31f418d0a7448f78b18b382afec28ca76",
+                        "ctime": 1510003767,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.unsupported_from_the_future",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724"
+                            }
+                        },
+                        "seq_type": 1,
+                        "ignore_if_unsupported": false,
+                        "ignore_if_unsupported_for_testing": true
+                    },
+                    "debug_link_id": "10500d48bdc93b9228670c206b4f253774d0f7d4e7385d10c7849b6771dc0b99"
+                }
+            ],
+            "team_key_boxes": [
+                {
+                    "seqno": 1,
+                    "box": {
+                        "nonce": "S8fEvwgGwCJ7Vw5z8+9Dj7VM0xkAAAAB",
+                        "sender_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a",
+                        "generation": 1,
+                        "ctext": "ZpCKhZpQEohsfIR72rjZWPZ7cgDw9wF7OvS2dygQRo9hbQ9/0nKCQrRvCvZsxtvZ",
+                        "per_user_key_seqno": 1
+                    },
+                    "prev": null
+                }
+            ],
+            "debug_tk_secs": [
+                [
+                    "7f246caab1b80f43c8ff7747bea79c52617c7e066aa8220a66c4645cdca95492"
+                ]
+            ],
+            "debug_tk_sig_kids": [
+                [
+                    "0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a"
+                ]
+            ]
+        }
+    },
+    "users": {
+        "herb": {
+            "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+            "eldest_seqno": 1,
+            "puk_secrets": {
+                "1": "3759ea1c8527a0ecca7be3a447fa35a5ed64969e1651b4c1825dac09b5b6fb42"
+            },
+            "link_map": {
+                "1": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+            },
+            "debug_puk_enc_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a"
+        }
+    },
+    "key_owners": {
+        "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a": "herb"
+    },
+    "key_pubkeyv2nacls": {
+        "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a": {
+            "deviceType": "desktop",
+            "deviceDescription": "home thing",
+            "deviceID": "fbd762facdfad44709aef63a9a8cdf18",
+            "base": {
+                "eTime": 2005146762000,
+                "cTime": 1500570762000,
+                "isEldest": true,
+                "isSibkey": true,
+                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a",
+                "provisioning": {
+                    "sigChainLocation": {
+                        "seqno": 1,
+                        "seqType": 1
+                    },
+                    "signingKID": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a",
+                    "time": 0,
+                    "firstAppearedUnverified": 0,
+                    "prevMerkleRootSigned": {
+                        "hashMeta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc500",
+                        "seqno": 0
+                    }
+                }
+            }
+        }
+    },
+    "team_merkle": {
+        "2123209b98b16083c69c91152b861724": {
+            "seqno": 2,
+            "link_id": "10500d48bdc93b9228670c206b4f253774d0f7d4e7385d10c7849b6771dc0b99"
+        },
+        "2123209b98b16083c69c91152b861724-seqno:1": {
+            "seqno": 1,
+            "link_id": "0c77f9078aff069666ebf882f4117fb31f418d0a7448f78b18b382afec28ca76"
+        },
+        "2123209b98b16083c69c91152b861724-seqno:2": {
+            "seqno": 2,
+            "link_id": "10500d48bdc93b9228670c206b4f253774d0f7d4e7385d10c7849b6771dc0b99"
+        }
+    },
+    "merkle_triples": {
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        },
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        }
+    },
+    "sessions": [
+        {
+            "loads": [
+                {
+                    "error": true,
+                    "error_substr": "ignore_if_unsupported"
+                }
+            ]
+        }
+    ]
+}

--- a/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/unsupported_critical.json
+++ b/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/unsupported_critical.json
@@ -1,0 +1,225 @@
+{
+    "log": [
+        "user:herb key:default",
+        "link team:cabal type:root",
+        "link team:cabal type:unsupported"
+    ],
+    "teams": {
+        "cabal": {
+            "id": "2123209b98b16083c69c91152b861724",
+            "links": [
+                {
+                    "seqno": 1,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTEKZcCAcDEIME7PhuCEMVqKzC4LlLNpVN14F48AtMcsYce+gHH/SjGIQHCo3NpZ8RAJkfZp/XJt6VpYxrhRsyFvzCHj3o/VehDPv3D9ItU0LtqKlBInUriw090nWsN8e4ATmvAtc4veLbmvXNs5s8ECahzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\",\"members\":{\"owner\":[\"25852c87d6e47fb8d7d55400be9c7a19\"]},\"name\":\"cabal\",\"per_team_key\":{\"encryption_kid\":\"0121df1f90362f46c30299233352f173642afd4106fea31a8a69c218b5fefe3a68460a\",\"generation\":1,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg/7SBjzewx/7nB4LRxRI1ldcYu5F48eELOFHohQ23nR8Kp3BheWxvYWTFA3N7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMTAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwibWVtYmVycyI6eyJvd25lciI6WyIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSJdfSwibmFtZSI6ImNhYmFsIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWRmMWY5MDM2MmY0NmMzMDI5OTIzMzM1MmYxNzM2NDJhZmQ0MTA2ZmVhMzFhOGE2OWMyMThiNWZlZmUzYTY4NDYwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBmZmI0ODE4ZjM3YjBjN2ZlZTcwNzgyZDFjNTEyMzU5NWQ3MThiYjkxNzhmMWUxMGIzODUxZTg4NTBkYjc5ZDFmMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MTAwMDM2MTgsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJzZXFfdHlwZSI6MSwic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RACW0+DyAPH3Tu0xS73c/YtZ91b0Cc2B67cYwFGl2sXdXDkarNT7sOQZ9H3crBg9D3U58uLJuUj4viUdbdpHU/C6hzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B\",\"signing_kid\":\"0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a\"}},\"type\":\"team.root\",\"version\":2},\"ctime\":1510003618,\"expire_in\":157680000,\"seq_type\":1,\"seqno\":1,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 1,
+                        "ctime": 1510003618,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.root",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724",
+                                "name": "cabal",
+                                "members": {
+                                    "owner": [
+                                        "25852c87d6e47fb8d7d55400be9c7a19"
+                                    ]
+                                },
+                                "per_team_key": {
+                                    "reverse_sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg/7SBjzewx/7nB4LRxRI1ldcYu5F48eELOFHohQ23nR8Kp3BheWxvYWTFA3N7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMTAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwibWVtYmVycyI6eyJvd25lciI6WyIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSJdfSwibmFtZSI6ImNhYmFsIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWRmMWY5MDM2MmY0NmMzMDI5OTIzMzM1MmYxNzM2NDJhZmQ0MTA2ZmVhMzFhOGE2OWMyMThiNWZlZmUzYTY4NDYwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBmZmI0ODE4ZjM3YjBjN2ZlZTcwNzgyZDFjNTEyMzU5NWQ3MThiYjkxNzhmMWUxMGIzODUxZTg4NTBkYjc5ZDFmMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MTAwMDM2MTgsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJzZXFfdHlwZSI6MSwic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RACW0+DyAPH3Tu0xS73c/YtZ91b0Cc2B67cYwFGl2sXdXDkarNT7sOQZ9H3crBg9D3U58uLJuUj4viUdbdpHU/C6hzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                                    "generation": 1,
+                                    "encryption_kid": "0121df1f90362f46c30299233352f173642afd4106fea31a8a69c218b5fefe3a68460a",
+                                    "signing_kid": "0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a"
+                                }
+                            }
+                        },
+                        "seq_type": 1
+                    },
+                    "debug_link_id": "2650df582303bdeed6256feb9d991f4181bac8e54cc0817dcd414ea42b803fad"
+                },
+                {
+                    "seqno": 2,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTETJcCAsQgJlDfWCMDve7WJW/rnZkfQYG6yOVMwIF9zUFOpCuAP63EIOVy1lmvyKoRt+t4NRBvgFq2PoEu25vX7Lbv+xS/iw1pzQU5AcKjc2lnxECF1zujYqlVrL2WwIaDxgmytbVC9HmZ5GTlDz8sIkVW+AE31+rHlMzCDUfibIUlQIBR01YClfUtfOeQzNWyEGwFqHNpZ190eXBlIKN0YWfNAgKndmVyc2lvbgE=",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\"},\"type\":\"team.unsupported_from_the_future\",\"version\":2},\"ctime\":1510003618,\"expire_in\":157680000,\"prev\":\"2650df582303bdeed6256feb9d991f4181bac8e54cc0817dcd414ea42b803fad\",\"seq_type\":1,\"seqno\":2,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 2,
+                        "prev": "2650df582303bdeed6256feb9d991f4181bac8e54cc0817dcd414ea42b803fad",
+                        "ctime": 1510003618,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.unsupported_from_the_future",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724"
+                            }
+                        },
+                        "seq_type": 1
+                    },
+                    "debug_link_id": "6eac74b390e96702d1eb49ed648157283026073ff56fc3d8d51e4d64956db4b9"
+                }
+            ],
+            "team_key_boxes": [
+                {
+                    "seqno": 1,
+                    "box": {
+                        "nonce": "S8fEvwgGwCJ7Vw5z8+9Dj7VM0xkAAAAB",
+                        "sender_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a",
+                        "generation": 1,
+                        "ctext": "ZpCKhZpQEohsfIR72rjZWPZ7cgDw9wF7OvS2dygQRo9hbQ9/0nKCQrRvCvZsxtvZ",
+                        "per_user_key_seqno": 1
+                    },
+                    "prev": null
+                }
+            ],
+            "debug_tk_secs": [
+                [
+                    "7f246caab1b80f43c8ff7747bea79c52617c7e066aa8220a66c4645cdca95492"
+                ]
+            ],
+            "debug_tk_sig_kids": [
+                [
+                    "0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a"
+                ]
+            ]
+        }
+    },
+    "users": {
+        "herb": {
+            "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+            "eldest_seqno": 1,
+            "puk_secrets": {
+                "1": "3759ea1c8527a0ecca7be3a447fa35a5ed64969e1651b4c1825dac09b5b6fb42"
+            },
+            "link_map": {
+                "1": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+            },
+            "debug_puk_enc_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a"
+        }
+    },
+    "key_owners": {
+        "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a": "herb"
+    },
+    "key_pubkeyv2nacls": {
+        "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a": {
+            "deviceType": "desktop",
+            "deviceDescription": "home thing",
+            "deviceID": "fbd762facdfad44709aef63a9a8cdf18",
+            "base": {
+                "eTime": 2005146762000,
+                "cTime": 1500570762000,
+                "isEldest": true,
+                "isSibkey": true,
+                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a",
+                "provisioning": {
+                    "sigChainLocation": {
+                        "seqno": 1,
+                        "seqType": 1
+                    },
+                    "signingKID": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a",
+                    "time": 0,
+                    "firstAppearedUnverified": 0,
+                    "prevMerkleRootSigned": {
+                        "hashMeta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc500",
+                        "seqno": 0
+                    }
+                }
+            }
+        }
+    },
+    "team_merkle": {
+        "2123209b98b16083c69c91152b861724": {
+            "seqno": 2,
+            "link_id": "6eac74b390e96702d1eb49ed648157283026073ff56fc3d8d51e4d64956db4b9"
+        },
+        "2123209b98b16083c69c91152b861724-seqno:1": {
+            "seqno": 1,
+            "link_id": "2650df582303bdeed6256feb9d991f4181bac8e54cc0817dcd414ea42b803fad"
+        },
+        "2123209b98b16083c69c91152b861724-seqno:2": {
+            "seqno": 2,
+            "link_id": "6eac74b390e96702d1eb49ed648157283026073ff56fc3d8d51e4d64956db4b9"
+        }
+    },
+    "merkle_triples": {
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        },
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        }
+    },
+    "sessions": [
+        {
+            "loads": [
+                {
+                    "error": true,
+                    "error_type": "UnsupportedLinkTypeError"
+                }
+            ]
+        },
+        {
+            "loads": [
+                {
+                    "need_admin": true,
+                    "error": true,
+                    "error_type": "UnsupportedLinkTypeError"
+                }
+            ]
+        },
+        {
+            "loads": [
+                {
+                    "upto": 1
+                },
+                {
+                    "error": true,
+                    "error_type": "UnsupportedLinkTypeError"
+                }
+            ]
+        },
+        {
+            "loads": [
+                {
+                    "need_admin": true,
+                    "stub": [
+                        2
+                    ],
+                    "error": true,
+                    "error_type": "StubbedError"
+                }
+            ]
+        }
+    ]
+}

--- a/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/unsupported_ignore.json
+++ b/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/unsupported_ignore.json
@@ -1,0 +1,234 @@
+{
+    "log": [
+        "user:herb key:default",
+        "link team:cabal type:root",
+        "link team:cabal type:unsupported",
+        "ignore_if_unsupported:true link_type:unsupported"
+    ],
+    "teams": {
+        "cabal": {
+            "id": "2123209b98b16083c69c91152b861724",
+            "links": [
+                {
+                    "seqno": 1,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTEKZcCAcDEIME7PhuCEMVqKzC4LlLNpVN14F48AtMcsYce+gHH/SjGIQHCo3NpZ8RAJkfZp/XJt6VpYxrhRsyFvzCHj3o/VehDPv3D9ItU0LtqKlBInUriw090nWsN8e4ATmvAtc4veLbmvXNs5s8ECahzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\",\"members\":{\"owner\":[\"25852c87d6e47fb8d7d55400be9c7a19\"]},\"name\":\"cabal\",\"per_team_key\":{\"encryption_kid\":\"0121df1f90362f46c30299233352f173642afd4106fea31a8a69c218b5fefe3a68460a\",\"generation\":1,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg/7SBjzewx/7nB4LRxRI1ldcYu5F48eELOFHohQ23nR8Kp3BheWxvYWTFA3N7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMTAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwibWVtYmVycyI6eyJvd25lciI6WyIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSJdfSwibmFtZSI6ImNhYmFsIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWRmMWY5MDM2MmY0NmMzMDI5OTIzMzM1MmYxNzM2NDJhZmQ0MTA2ZmVhMzFhOGE2OWMyMThiNWZlZmUzYTY4NDYwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBmZmI0ODE4ZjM3YjBjN2ZlZTcwNzgyZDFjNTEyMzU5NWQ3MThiYjkxNzhmMWUxMGIzODUxZTg4NTBkYjc5ZDFmMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MTAwMDM2MTgsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJzZXFfdHlwZSI6MSwic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RACW0+DyAPH3Tu0xS73c/YtZ91b0Cc2B67cYwFGl2sXdXDkarNT7sOQZ9H3crBg9D3U58uLJuUj4viUdbdpHU/C6hzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B\",\"signing_kid\":\"0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a\"}},\"type\":\"team.root\",\"version\":2},\"ctime\":1510003618,\"expire_in\":157680000,\"seq_type\":1,\"seqno\":1,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 1,
+                        "ctime": 1510003618,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.root",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724",
+                                "name": "cabal",
+                                "members": {
+                                    "owner": [
+                                        "25852c87d6e47fb8d7d55400be9c7a19"
+                                    ]
+                                },
+                                "per_team_key": {
+                                    "reverse_sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg/7SBjzewx/7nB4LRxRI1ldcYu5F48eELOFHohQ23nR8Kp3BheWxvYWTFA3N7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMTAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwibWVtYmVycyI6eyJvd25lciI6WyIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSJdfSwibmFtZSI6ImNhYmFsIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWRmMWY5MDM2MmY0NmMzMDI5OTIzMzM1MmYxNzM2NDJhZmQ0MTA2ZmVhMzFhOGE2OWMyMThiNWZlZmUzYTY4NDYwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBmZmI0ODE4ZjM3YjBjN2ZlZTcwNzgyZDFjNTEyMzU5NWQ3MThiYjkxNzhmMWUxMGIzODUxZTg4NTBkYjc5ZDFmMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MTAwMDM2MTgsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJzZXFfdHlwZSI6MSwic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RACW0+DyAPH3Tu0xS73c/YtZ91b0Cc2B67cYwFGl2sXdXDkarNT7sOQZ9H3crBg9D3U58uLJuUj4viUdbdpHU/C6hzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                                    "generation": 1,
+                                    "encryption_kid": "0121df1f90362f46c30299233352f173642afd4106fea31a8a69c218b5fefe3a68460a",
+                                    "signing_kid": "0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a"
+                                }
+                            }
+                        },
+                        "seq_type": 1
+                    },
+                    "debug_link_id": "2650df582303bdeed6256feb9d991f4181bac8e54cc0817dcd414ea42b803fad"
+                },
+                {
+                    "seqno": 2,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTETJcCAsQgJlDfWCMDve7WJW/rnZkfQYG6yOVMwIF9zUFOpCuAP63EICPB+AgJW4NgYhKplSxS2bFQA8auCcL8G5sv4gE1UhKWzQU5AcOjc2lnxEBtLo8rn59U5MK5A1kT0ndgFiMIO4ia40nKsz2kubpDURFcH3jIFfRKN0vzRsmKDAUrVkBODk+LpiEM71MYUb0LqHNpZ190eXBlIKN0YWfNAgKndmVyc2lvbgE=",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\"},\"type\":\"team.unsupported_from_the_future\",\"version\":2},\"ctime\":1510003618,\"expire_in\":157680000,\"ignore_if_unsupported\":true,\"prev\":\"2650df582303bdeed6256feb9d991f4181bac8e54cc0817dcd414ea42b803fad\",\"seq_type\":1,\"seqno\":2,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 2,
+                        "prev": "2650df582303bdeed6256feb9d991f4181bac8e54cc0817dcd414ea42b803fad",
+                        "ctime": 1510003618,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.unsupported_from_the_future",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724"
+                            }
+                        },
+                        "seq_type": 1,
+                        "ignore_if_unsupported": true
+                    },
+                    "debug_link_id": "13c0d95e13337b42e8362a764cdfba9d0063dc4005a805fb7d41e3934f219585"
+                }
+            ],
+            "team_key_boxes": [
+                {
+                    "seqno": 1,
+                    "box": {
+                        "nonce": "S8fEvwgGwCJ7Vw5z8+9Dj7VM0xkAAAAB",
+                        "sender_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a",
+                        "generation": 1,
+                        "ctext": "ZpCKhZpQEohsfIR72rjZWPZ7cgDw9wF7OvS2dygQRo9hbQ9/0nKCQrRvCvZsxtvZ",
+                        "per_user_key_seqno": 1
+                    },
+                    "prev": null
+                }
+            ],
+            "debug_tk_secs": [
+                [
+                    "7f246caab1b80f43c8ff7747bea79c52617c7e066aa8220a66c4645cdca95492"
+                ]
+            ],
+            "debug_tk_sig_kids": [
+                [
+                    "0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a"
+                ]
+            ]
+        }
+    },
+    "users": {
+        "herb": {
+            "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+            "eldest_seqno": 1,
+            "puk_secrets": {
+                "1": "3759ea1c8527a0ecca7be3a447fa35a5ed64969e1651b4c1825dac09b5b6fb42"
+            },
+            "link_map": {
+                "1": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+            },
+            "debug_puk_enc_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a"
+        }
+    },
+    "key_owners": {
+        "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a": "herb"
+    },
+    "key_pubkeyv2nacls": {
+        "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a": {
+            "deviceType": "desktop",
+            "deviceDescription": "home thing",
+            "deviceID": "fbd762facdfad44709aef63a9a8cdf18",
+            "base": {
+                "eTime": 2005146762000,
+                "cTime": 1500570762000,
+                "isEldest": true,
+                "isSibkey": true,
+                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a",
+                "provisioning": {
+                    "sigChainLocation": {
+                        "seqno": 1,
+                        "seqType": 1
+                    },
+                    "signingKID": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a",
+                    "time": 0,
+                    "firstAppearedUnverified": 0,
+                    "prevMerkleRootSigned": {
+                        "hashMeta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc500",
+                        "seqno": 0
+                    }
+                }
+            }
+        }
+    },
+    "team_merkle": {
+        "2123209b98b16083c69c91152b861724": {
+            "seqno": 2,
+            "link_id": "13c0d95e13337b42e8362a764cdfba9d0063dc4005a805fb7d41e3934f219585"
+        },
+        "2123209b98b16083c69c91152b861724-seqno:1": {
+            "seqno": 1,
+            "link_id": "2650df582303bdeed6256feb9d991f4181bac8e54cc0817dcd414ea42b803fad"
+        },
+        "2123209b98b16083c69c91152b861724-seqno:2": {
+            "seqno": 2,
+            "link_id": "13c0d95e13337b42e8362a764cdfba9d0063dc4005a805fb7d41e3934f219585"
+        }
+    },
+    "merkle_triples": {
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        },
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        }
+    },
+    "sessions": [
+        {
+            "loads": [
+                {
+                    "error": false
+                }
+            ]
+        },
+        {
+            "loads": [
+                {
+                    "need_admin": true,
+                    "error": false
+                }
+            ]
+        },
+        {
+            "loads": [
+                {
+                    "upto": 1
+                },
+                {
+                    "error": false
+                }
+            ]
+        },
+        {
+            "loads": [
+                {
+                    "stub": [
+                        2
+                    ],
+                    "error": false
+                }
+            ]
+        },
+        {
+            "loads": [
+                {
+                    "need_admin": true,
+                    "stub": [
+                        2
+                    ],
+                    "error": true,
+                    "error_type": "StubbedError"
+                }
+            ]
+        }
+    ]
+}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -344,14 +344,14 @@
 		{
 			"checksumSHA1": "2dhlXqY/z//xieGJNGjMjL4X6Jw=",
 			"path": "github.com/keybase/keybase-test-vectors/go",
-			"revision": "2bfb94411295f18596046369f6bcb3a950ceb1b5",
-			"revisionTime": "2017-08-11T14:07:22Z"
+			"revision": "f14ba3a1aa9ffd72209efaed5342fcc17d66693c",
+			"revisionTime": "2017-11-06T21:33:07Z"
 		},
 		{
-			"checksumSHA1": "x3Cnxu6dehCSPc9aTjS1PO6INLU=",
+			"checksumSHA1": "M0LcepSKs6a5TOM7KXaoiuTKVJ0=",
 			"path": "github.com/keybase/keybase-test-vectors/teamchains",
-			"revision": "c6dbadb0aef19380fc20ff29bf54feb1c549d270",
-			"revisionTime": "2017-09-22T19:43:39Z"
+			"revision": "f14ba3a1aa9ffd72209efaed5342fcc17d66693c",
+			"revisionTime": "2017-11-06T21:33:07Z"
 		},
 		{
 			"path": "github.com/keybase/npipe",

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -243,7 +243,6 @@ protocol teams {
     map<Seqno, LinkID> linkIDs;
 
     // Set of links that are stubbed-out and whose contents are missing.
-    // Keyed by seqno
     map<Seqno, boolean> stubbedLinks;
 
     // All invitations that are currently active.


### PR DESCRIPTION
Add support for the `IgnoreIfUnsupported` property of links. Allows playing of team links with unrecognized link types. Works if their stubbed.

Checks that `IgnoreIfUnsupported` matches on inner and outer links for user and team sigchains. Does _not_ otherwise change anything about user sigchain playing.

Has tests from test-vectors.

Does not include full write support. Just adds the input to `makeSigchainV2OuterSig`. It might be slightly tricky to get the client to write a matching value to the inner and outer links in all cases. I figure we could do that work when we need to use this feature.

TODO:
- [x] vendor server
- [ ] deploy server
- [x] vendor in new test-vectors
