### PR TITLE
add new RPC for setting channel name

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1021,6 +1021,36 @@ func (h *Server) PostHeadline(ctx context.Context, arg chat1.PostHeadlineArg) (c
 	return h.PostLocal(ctx, parg)
 }
 
+func (h *Server) PostMetadataNonblock(ctx context.Context, arg chat1.PostMetadataNonblockArg) (chat1.PostLocalNonblockRes, error) {
+	var parg chat1.PostLocalNonblockArg
+	parg.ClientPrev = arg.ClientPrev
+	parg.ConversationID = arg.ConversationID
+	parg.IdentifyBehavior = arg.IdentifyBehavior
+	parg.OutboxID = arg.OutboxID
+	parg.Msg.ClientHeader.MessageType = chat1.MessageType_METADATA
+	parg.Msg.ClientHeader.TlfName = arg.TlfName
+	parg.Msg.ClientHeader.TlfPublic = arg.TlfPublic
+	parg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
+		ConversationTitle: arg.ChannelName,
+	})
+
+	return h.PostLocalNonblock(ctx, parg)
+}
+
+func (h *Server) PostMetadata(ctx context.Context, arg chat1.PostMetadataArg) (chat1.PostLocalRes, error) {
+	var parg chat1.PostLocalArg
+	parg.ConversationID = arg.ConversationID
+	parg.IdentifyBehavior = arg.IdentifyBehavior
+	parg.Msg.ClientHeader.MessageType = chat1.MessageType_METADATA
+	parg.Msg.ClientHeader.TlfName = arg.TlfName
+	parg.Msg.ClientHeader.TlfPublic = arg.TlfPublic
+	parg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
+		ConversationTitle: arg.ChannelName,
+	})
+
+	return h.PostLocal(ctx, parg)
+}
+
 func (h *Server) GenerateOutboxID(ctx context.Context) (res chat1.OutboxID, err error) {
 	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_SKIP, nil, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GenerateOutboxID")()

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2340,7 +2340,7 @@ func consumeJoinConv(t *testing.T, listener *serverChatListener) {
 	select {
 	case <-listener.joinedConv:
 	case <-time.After(20 * time.Second):
-		require.Fail(t, "failed to get team type notification")
+		require.Fail(t, "failed to get join conv notification")
 	}
 }
 
@@ -2348,7 +2348,7 @@ func consumeLeaveConv(t *testing.T, listener *serverChatListener) {
 	select {
 	case <-listener.leftConv:
 	case <-time.After(20 * time.Second):
-		require.Fail(t, "failed to get team type notification")
+		require.Fail(t, "failed to get leave conv notification")
 	}
 }
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -16,7 +16,6 @@ import (
 
 	"encoding/base64"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/msgchecker"
 	"github.com/keybase/client/go/chat/storage"
@@ -1725,14 +1724,36 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		defer ctc.cleanup()
 		users := ctc.users()
 
+		tc := ctc.as(t, users[0])
 		listener := newServerChatListener()
 		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
 		ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
 
 		var err error
-		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
-			mt, ctc.as(t, users[1]).user())
+		var created chat1.ConversationInfoLocal
+		switch mt {
+		case chat1.ConversationMembersType_TEAM:
+			first := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+				mt, ctc.as(t, users[1]).user())
+			consumeNewMsg(t, listener, chat1.MessageType_JOIN)
+			topicName := "mike"
+			ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(tc.startCtx,
+				chat1.NewConversationLocalArg{
+					TlfName:       first.TlfName,
+					TopicName:     &topicName,
+					TopicType:     chat1.TopicType_CHAT,
+					TlfVisibility: keybase1.TLFVisibility_PRIVATE,
+					MembersType:   chat1.ConversationMembersType_TEAM,
+				})
+			require.NoError(t, err)
+			created = ncres.Conv.Info
+			consumeNewMsg(t, listener, chat1.MessageType_JOIN)
+			consumeNewMsg(t, listener, chat1.MessageType_TEXT)
+		default:
+			created = mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+				mt, ctc.as(t, users[1]).user())
+		}
 
 		t.Logf("send a text message")
 		arg := chat1.PostTextNonblockArg{
@@ -1742,45 +1763,16 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			Body:             "hi",
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		}
-		tc := ctc.as(t, users[0])
 		res, err := ctc.as(t, users[0]).chatLocalHandler().PostTextNonblock(tc.startCtx, arg)
 		require.NoError(t, err)
 		var unboxed chat1.UIMessage
-		switch mt {
-		case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAM:
-			// pass
-		case chat1.ConversationMembersType_TEAM:
-			select {
-			case info := <-listener.newMessage:
-				unboxed = info.Message
-				require.True(t, unboxed.IsValid(), "invalid message")
-				if unboxed.GetMessageType() != chat1.MessageType_JOIN {
-					t.Logf("failing.. expected JOIN")
-					select {
-					case info2 := <-listener.newMessage:
-						t.Logf("info (1): %v", spew.Sdump(info))
-						t.Logf("info (2): %v", spew.Sdump(info2))
-					case <-time.After(30 * time.Second):
-						t.Logf("no second message in the pipe")
-					}
-					t.Logf("info (1): %v", spew.Sdump(info))
-					require.Equal(t, chat1.MessageType_JOIN, unboxed.GetMessageType(), "unexpected type")
-				}
-				require.Equal(t, chat1.MessageType_JOIN, unboxed.GetMessageType(), "unexpected type")
-				require.Nil(t, unboxed.Valid().OutboxID, "surprise outbox ID on JOIN")
-			case <-time.After(20 * time.Second):
-				require.Fail(t, "no event received")
-			}
-		default:
-			t.Fatalf("unknown members type: %v", mt)
-		}
 		select {
 		case info := <-listener.newMessage:
 			unboxed = info.Message
 			require.True(t, unboxed.IsValid(), "invalid message")
 			require.NotNil(t, unboxed.Valid().OutboxID, "no outbox ID")
-			require.Equal(t, res.OutboxID.String(), *unboxed.Valid().OutboxID, "mismatch outbox ID")
 			require.Equal(t, chat1.MessageType_TEXT, unboxed.GetMessageType(), "invalid type")
+			require.Equal(t, res.OutboxID.String(), *unboxed.Valid().OutboxID, "mismatch outbox ID")
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
 		}
@@ -1874,6 +1866,32 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			switch mt {
 			case chat1.ConversationMembersType_TEAM:
 				require.Equal(t, headline, unboxed.Valid().MessageBody.Headline().Headline)
+			}
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no event received")
+		}
+
+		t.Logf("change name")
+		topicName := "NEWNAME"
+		marg := chat1.PostMetadataNonblockArg{
+			ConversationID:   created.Id,
+			TlfName:          created.TlfName,
+			TlfPublic:        created.Visibility == keybase1.TLFVisibility_PUBLIC,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+			ChannelName:      topicName,
+		}
+		res, err = ctc.as(t, users[0]).chatLocalHandler().PostMetadataNonblock(tc.startCtx, marg)
+		require.NoError(t, err)
+		select {
+		case info := <-listener.newMessage:
+			unboxed = info.Message
+			require.True(t, unboxed.IsValid(), "invalid message")
+			require.NotNil(t, unboxed.Valid().OutboxID, "no outbox ID")
+			require.Equal(t, res.OutboxID.String(), *unboxed.Valid().OutboxID, "mismatch outbox ID")
+			require.Equal(t, chat1.MessageType_METADATA, unboxed.GetMessageType(), "invalid type")
+			switch mt {
+			case chat1.ConversationMembersType_TEAM:
+				require.Equal(t, topicName, unboxed.Valid().MessageBody.Metadata().ConversationTitle)
 			}
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
@@ -2314,7 +2332,7 @@ func consumeMembersUpdate(t *testing.T, listener *serverChatListener) {
 	select {
 	case <-listener.membersUpdate:
 	case <-time.After(20 * time.Second):
-		require.Fail(t, "failed to get team type notification")
+		require.Fail(t, "failed to get members update notification")
 	}
 }
 

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -461,6 +461,7 @@ func (m *ChatRemoteMock) createBogusBody(typ chat1.MessageType) chat1.MessageBod
 		Join__:               &chat1.MessageJoin{},
 		Leave__:              &chat1.MessageLeave{},
 		Headline__:           &chat1.MessageHeadline{},
+		Metadata__:           &chat1.MessageConversationMetadata{},
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3585,6 +3585,52 @@ func (o PostHeadlineArg) DeepCopy() PostHeadlineArg {
 	}
 }
 
+type PostMetadataNonblockArg struct {
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
+	ChannelName      string                       `codec:"channelName" json:"channelName"`
+	OutboxID         *OutboxID                    `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	ClientPrev       MessageID                    `codec:"clientPrev" json:"clientPrev"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+}
+
+func (o PostMetadataNonblockArg) DeepCopy() PostMetadataNonblockArg {
+	return PostMetadataNonblockArg{
+		ConversationID: o.ConversationID.DeepCopy(),
+		TlfName:        o.TlfName,
+		TlfPublic:      o.TlfPublic,
+		ChannelName:    o.ChannelName,
+		OutboxID: (func(x *OutboxID) *OutboxID {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.OutboxID),
+		ClientPrev:       o.ClientPrev.DeepCopy(),
+		IdentifyBehavior: o.IdentifyBehavior.DeepCopy(),
+	}
+}
+
+type PostMetadataArg struct {
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
+	ChannelName      string                       `codec:"channelName" json:"channelName"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+}
+
+func (o PostMetadataArg) DeepCopy() PostMetadataArg {
+	return PostMetadataArg{
+		ConversationID:   o.ConversationID.DeepCopy(),
+		TlfName:          o.TlfName,
+		TlfPublic:        o.TlfPublic,
+		ChannelName:      o.ChannelName,
+		IdentifyBehavior: o.IdentifyBehavior.DeepCopy(),
+	}
+}
+
 type SetConversationStatusLocalArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
 	Status           ConversationStatus           `codec:"status" json:"status"`
@@ -4029,6 +4075,8 @@ type LocalInterface interface {
 	PostEditNonblock(context.Context, PostEditNonblockArg) (PostLocalNonblockRes, error)
 	PostHeadlineNonblock(context.Context, PostHeadlineNonblockArg) (PostLocalNonblockRes, error)
 	PostHeadline(context.Context, PostHeadlineArg) (PostLocalRes, error)
+	PostMetadataNonblock(context.Context, PostMetadataNonblockArg) (PostLocalNonblockRes, error)
+	PostMetadata(context.Context, PostMetadataArg) (PostLocalRes, error)
 	SetConversationStatusLocal(context.Context, SetConversationStatusLocalArg) (SetConversationStatusLocalRes, error)
 	NewConversationLocal(context.Context, NewConversationLocalArg) (NewConversationLocalRes, error)
 	GetInboxSummaryForCLILocal(context.Context, GetInboxSummaryForCLILocalQuery) (GetInboxSummaryForCLILocalRes, error)
@@ -4258,6 +4306,38 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.PostHeadline(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"postMetadataNonblock": {
+				MakeArg: func() interface{} {
+					ret := make([]PostMetadataNonblockArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]PostMetadataNonblockArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]PostMetadataNonblockArg)(nil), args)
+						return
+					}
+					ret, err = i.PostMetadataNonblock(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"postMetadata": {
+				MakeArg: func() interface{} {
+					ret := make([]PostMetadataArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]PostMetadataArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]PostMetadataArg)(nil), args)
+						return
+					}
+					ret, err = i.PostMetadata(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -4711,6 +4791,16 @@ func (c LocalClient) PostHeadlineNonblock(ctx context.Context, __arg PostHeadlin
 
 func (c LocalClient) PostHeadline(ctx context.Context, __arg PostHeadlineArg) (res PostLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.postHeadline", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) PostMetadataNonblock(ctx context.Context, __arg PostMetadataNonblockArg) (res PostLocalNonblockRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.postMetadataNonblock", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) PostMetadata(ctx context.Context, __arg PostMetadataArg) (res PostLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.postMetadata", []interface{}{__arg}, &res)
 	return
 }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -529,6 +529,8 @@ protocol local {
   PostLocalNonblockRes postEditNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, MessageID supersedes, string body, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalNonblockRes postHeadlineNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic,  string headline, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalRes postHeadline(ConversationID conversationID, string tlfName, boolean tlfPublic, string headline, keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalNonblockRes postMetadataNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic,  string channelName, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalRes postMetadata(ConversationID conversationID, string tlfName, boolean tlfPublic, string channelName, keybase1.TLFIdentifyBehavior identifyBehavior);
 
 
   @lint("ignore")

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -485,6 +485,22 @@ export function localPostLocalRpcPromise (request: (requestCommon & {callback?: 
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localPostMetadataNonblockRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: localPostMetadataNonblockResult) => void} & {param: localPostMetadataNonblockRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postMetadataNonblock', request)
+}
+
+export function localPostMetadataNonblockRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: localPostMetadataNonblockResult) => void} & {param: localPostMetadataNonblockRpcParam})): Promise<localPostMetadataNonblockResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postMetadataNonblock', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function localPostMetadataRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: localPostMetadataResult) => void} & {param: localPostMetadataRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postMetadata', request)
+}
+
+export function localPostMetadataRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: localPostMetadataResult) => void} & {param: localPostMetadataRpcParam})): Promise<localPostMetadataResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postMetadata', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localPostTextNonblockRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postTextNonblock', request)
 }
@@ -2330,6 +2346,24 @@ export type localPostLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
+export type localPostMetadataNonblockRpcParam = Exact<{
+  conversationID: ConversationID,
+  tlfName: string,
+  tlfPublic: boolean,
+  channelName: string,
+  outboxID?: ?OutboxID,
+  clientPrev: MessageID,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localPostMetadataRpcParam = Exact<{
+  conversationID: ConversationID,
+  tlfName: string,
+  tlfPublic: boolean,
+  channelName: string,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
 export type localPostTextNonblockRpcParam = Exact<{
   conversationID: ConversationID,
   tlfName: string,
@@ -2554,6 +2588,8 @@ type localPostHeadlineNonblockResult = PostLocalNonblockRes
 type localPostHeadlineResult = PostLocalRes
 type localPostLocalNonblockResult = PostLocalNonblockRes
 type localPostLocalResult = PostLocalRes
+type localPostMetadataNonblockResult = PostLocalNonblockRes
+type localPostMetadataResult = PostLocalRes
 type localPostTextNonblockResult = PostLocalNonblockRes
 type localSetAppNotificationSettingsLocalResult = SetAppNotificationSettingsLocalRes
 type localSetConversationStatusLocalResult = SetConversationStatusLocalRes

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2353,6 +2353,67 @@
       ],
       "response": "PostLocalRes"
     },
+    "postMetadataNonblock": {
+      "request": [
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        },
+        {
+          "name": "channelName",
+          "type": "string"
+        },
+        {
+          "name": "outboxID",
+          "type": [
+            null,
+            "OutboxID"
+          ]
+        },
+        {
+          "name": "clientPrev",
+          "type": "MessageID"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        }
+      ],
+      "response": "PostLocalNonblockRes"
+    },
+    "postMetadata": {
+      "request": [
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        },
+        {
+          "name": "channelName",
+          "type": "string"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        }
+      ],
+      "response": "PostLocalRes"
+    },
     "SetConversationStatusLocal": {
       "request": [
         {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -485,6 +485,22 @@ export function localPostLocalRpcPromise (request: (requestCommon & {callback?: 
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localPostMetadataNonblockRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: localPostMetadataNonblockResult) => void} & {param: localPostMetadataNonblockRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postMetadataNonblock', request)
+}
+
+export function localPostMetadataNonblockRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: localPostMetadataNonblockResult) => void} & {param: localPostMetadataNonblockRpcParam})): Promise<localPostMetadataNonblockResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postMetadataNonblock', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function localPostMetadataRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: localPostMetadataResult) => void} & {param: localPostMetadataRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postMetadata', request)
+}
+
+export function localPostMetadataRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: localPostMetadataResult) => void} & {param: localPostMetadataRpcParam})): Promise<localPostMetadataResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postMetadata', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localPostTextNonblockRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postTextNonblock', request)
 }
@@ -2330,6 +2346,24 @@ export type localPostLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
+export type localPostMetadataNonblockRpcParam = Exact<{
+  conversationID: ConversationID,
+  tlfName: string,
+  tlfPublic: boolean,
+  channelName: string,
+  outboxID?: ?OutboxID,
+  clientPrev: MessageID,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localPostMetadataRpcParam = Exact<{
+  conversationID: ConversationID,
+  tlfName: string,
+  tlfPublic: boolean,
+  channelName: string,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
 export type localPostTextNonblockRpcParam = Exact<{
   conversationID: ConversationID,
   tlfName: string,
@@ -2554,6 +2588,8 @@ type localPostHeadlineNonblockResult = PostLocalNonblockRes
 type localPostHeadlineResult = PostLocalRes
 type localPostLocalNonblockResult = PostLocalNonblockRes
 type localPostLocalResult = PostLocalRes
+type localPostMetadataNonblockResult = PostLocalNonblockRes
+type localPostMetadataResult = PostLocalRes
 type localPostTextNonblockResult = PostLocalNonblockRes
 type localSetAppNotificationSettingsLocalResult = SetAppNotificationSettingsLocalRes
 type localSetConversationStatusLocalResult = SetConversationStatusLocalRes


### PR DESCRIPTION
Adds `PostMetadataNonblock` and `PostMetadata` in order to make forming the argument for a channel name change a little easier on the frontend. Works basically the same as `PostTextNonblock` and company. 

cc @MarcoPolo 