### PR TITLE
Chat thread uses new pagination API

### DIFF
--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -180,10 +180,11 @@ function loadMoreMessages(
   conversationIDKey: Constants.ConversationIDKey,
   onlyIfUnloaded: boolean,
   fromUser?: boolean = false,
-  onlyNewerThan?: string
+  wantNewer?: boolean = false, // new messages, else older ones
+  numberOverride?: number // how many to ask for
 ): Constants.LoadMoreMessages {
   return {
-    payload: {conversationIDKey, onlyIfUnloaded, fromUser, onlyNewerThan},
+    payload: {conversationIDKey, onlyIfUnloaded, fromUser, wantNewer, numberOverride},
     type: 'chat:loadMoreMessages',
   }
 }
@@ -349,12 +350,10 @@ function prependMessages(
   conversationIDKey: Constants.ConversationIDKey,
   messages: Array<Constants.Message>,
   moreToLoad: boolean,
-  paginationNext: ?string,
-  paginationPrevious: ?string
 ): Constants.PrependMessages {
   return {
     logTransformer: prependMessagesActionTransformer,
-    payload: {conversationIDKey, messages, moreToLoad, paginationNext, paginationPrevious},
+    payload: {conversationIDKey, messages, moreToLoad},
     type: 'chat:prependMessages',
   }
 }

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -41,7 +41,6 @@ const appendMessageActionTransformer = (action: Constants.AppendMessages) => ({
 const prependMessagesActionTransformer = (action: Constants.PrependMessages) => ({
   payload: {
     conversationIDKey: action.payload.conversationIDKey,
-    hasPaginationNext: !!action.payload.paginationNext,
     messages: action.payload.messages.map(safeServerMessageMap),
     moreToLoad: action.payload.moreToLoad,
   },
@@ -181,7 +180,7 @@ function loadMoreMessages(
   onlyIfUnloaded: boolean,
   fromUser?: boolean = false,
   wantNewer?: boolean = false, // new messages, else older ones
-  numberOverride?: number // how many to ask for
+  numberOverride?: ?number // how many to ask for
 ): Constants.LoadMoreMessages {
   return {
     payload: {conversationIDKey, onlyIfUnloaded, fromUser, wantNewer, numberOverride},
@@ -349,7 +348,7 @@ function setLoaded(conversationIDKey: Constants.ConversationIDKey, isLoaded: boo
 function prependMessages(
   conversationIDKey: Constants.ConversationIDKey,
   messages: Array<Constants.Message>,
-  moreToLoad: boolean,
+  moreToLoad: boolean
 ): Constants.PrependMessages {
   return {
     logTransformer: prependMessagesActionTransformer,

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -327,13 +327,13 @@ function* _updateThread({
     const appFocused = yield select(Shared.focusedSelector)
 
     yield put(
-        Creators.appendMessages(
-          conversationIDKey,
-          conversationIDKey === selectedConversationIDKey,
-          appFocused,
-          newMessages,
-          false
-        )
+      Creators.appendMessages(
+        conversationIDKey,
+        conversationIDKey === selectedConversationIDKey,
+        appFocused,
+        newMessages,
+        false
+      )
     )
   } else {
     const last = thread && thread.pagination && thread.pagination.last

--- a/shared/chat/conversation/list/container.js
+++ b/shared/chat/conversation/list/container.js
@@ -23,7 +23,7 @@ const getValidatedState = (state: TypedState) => {
       return true
     }
   }
-  return untrustedState === 'unboxed'
+  return ['reUnboxing', 'unboxed'].includes(untrustedState)
 }
 
 const supersedesIfNoMoreToLoadSelector = createSelector(

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -503,7 +503,13 @@ export type LeaveConversation = NoErrorTypedAction<
 export type LoadInbox = NoErrorTypedAction<'chat:loadInbox', void>
 export type LoadMoreMessages = NoErrorTypedAction<
   'chat:loadMoreMessages',
-  {conversationIDKey: ConversationIDKey, onlyIfUnloaded: boolean}
+  {
+    conversationIDKey: ConversationIDKey,
+    onlyIfUnloaded: boolean,
+    fromUser: boolean,
+    wantNewer: boolean,
+    numberOverride: ?number,
+  }
 >
 export type LoadingMessages = NoErrorTypedAction<
   'chat:loadingMessages',
@@ -546,8 +552,6 @@ export type PrependMessages = NoErrorTypedAction<
     conversationIDKey: ConversationIDKey,
     messages: Array<Message>,
     moreToLoad: boolean,
-    paginationNext: ?string,
-    paginationPrevious: ?string,
   }
 >
 export type RemoveOutboxMessage = NoErrorTypedAction<

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -1092,6 +1092,10 @@ function messageKeyConversationIDKey(key: MessageKey): ConversationIDKey {
   return key.split(':')[0]
 }
 
+function messageKeyKindIsMessageID(key: MessageKey): boolean {
+  return messageKeyKind(key).startsWith('messageID')
+}
+
 function messageKeyKind(key: MessageKey): MessageKeyKind {
   const [, kind] = key.split(':')
   switch (kind) {
@@ -1390,6 +1394,7 @@ export {
   makeTeamTitle,
   messageKey,
   messageKeyKind,
+  messageKeyKindIsMessageID,
   messageKeyValue,
   messageKeyConversationIDKey,
   splitMessageIDKey,


### PR DESCRIPTION
We use the new API exposed by core to not have to send paginationNext/prev anymore
Instead we find the first / last valid messageID we've seen and use that as the pagination 'pivot'

Additionally we pass an explicit number to load more in the sync+append case. We were sending 9999 originally which had a side effect of giving you older values which we'd then just throw away as dupes. This is now calculated (it was before) and now it's plumbed through to the load action

Found an unrelated bug where the conversation list would blank out due to props.validated being false which only was valid if the state was 'unboxed' when reUnboxing is also a valid state to keep itself shown (as in after a sync+append)

@keybase/react-hackers 
cc: @mmaxim 