### PR TITLE
clear out downgrade lease on failed team op

### DIFF
--- a/go/libkb/downgrade_leases.go
+++ b/go/libkb/downgrade_leases.go
@@ -64,6 +64,18 @@ func RequestDowngradeLeaseByKID(ctx context.Context, g *GlobalContext, kids []ke
 	return leaseWithMerkleRoot(ctx, g, res)
 }
 
+func CancelDowngradeLease(ctx context.Context, g *GlobalContext, l keybase1.LeaseID) error {
+	_, err := g.API.Post(APIArg{
+		Endpoint:    "downgrade/cancel",
+		SessionType: APISessionTypeREQUIRED,
+		NetContext:  ctx,
+		Args: HTTPArgs{
+			"downgrade_lease_id": S{string(l)},
+		},
+	})
+	return err
+}
+
 func RequestDowngradeLeaseBySigIDs(ctx context.Context, g *GlobalContext, sigIDs []keybase1.SigID) (lease *Lease, mr *MerkleRoot, err error) {
 	var res leaseReply
 	err = g.API.PostDecode(APIArg{

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -680,6 +680,26 @@ func TestLeaveSubteamWithImplicitAdminship(t *testing.T) {
 	require.IsType(t, &ImplicitAdminCannotLeaveError{}, err, "wrong error type")
 }
 
+// See CORE-6473
+func TestOnlyOwnerLeaveThenUpgradeFriend(t *testing.T) {
+
+	tc, _, otherA, _, name := memberSetupMultiple(t)
+	defer tc.Cleanup()
+
+	if err := SetRoleWriter(context.TODO(), tc.G, name, otherA.Username); err != nil {
+		t.Fatal(err)
+	}
+	if err := Leave(context.TODO(), tc.G, name, false); err == nil {
+		t.Fatal("expected an error when only owner is leaving")
+	}
+	if err := SetRoleOwner(context.TODO(), tc.G, name, otherA.Username); err != nil {
+		t.Fatal(err)
+	}
+	if err := Leave(context.TODO(), tc.G, name, false); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMemberAddResolveCache(t *testing.T) {
 	tc, _, other, _, name := memberSetupMultiple(t)
 	defer tc.Cleanup()


### PR DESCRIPTION
- got a repro for the original bug without this fix:
```2017-10-27 09:43:11.07839 service_helper.go:593: [D] - RetryOnSigOldSeqnoError -> permission is slated to be deleted (error 289) [time=132.19939ms]
	member_test.go:696: permission is slated to be deleted (error 289)
	test_logger.go:54: TEST FAILED: TestOnlyOwnerLeaveThenUpgradeFriend
```
- the fix is to "cancel" the downgrade lease come rain or sine, so that the next operation won't fail with the lease outstanding