### PR TITLE
fix redbox crash on ios

### DIFF
--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -14,7 +14,7 @@ let CustomTextInput
 
 // NEVER load this on ios, it kills it
 if (!isIOS) {
-  CustomTextInput = require('../../../common-adapters/custom-input').default
+  CustomTextInput = require('../../../common-adapters/custom-input')
 }
 
 // TODO we don't autocorrect the last word on submit. We had a solution using blur but this also dismisses they keyboard each time

--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -14,7 +14,7 @@ let CustomTextInput
 
 // NEVER load this on ios, it kills it
 if (!isIOS) {
-  CustomTextInput = require('../../../common-adapters/custom-input')
+  CustomTextInput = require('../../../common-adapters/custom-input.native')
 }
 
 // TODO we don't autocorrect the last word on submit. We had a solution using blur but this also dismisses they keyboard each time

--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -4,13 +4,18 @@
 import {showImagePicker} from 'react-native-image-picker'
 import React, {Component} from 'react'
 import {Box, Icon, Input, Text} from '../../../common-adapters'
-// $FlowIssue
-import CustomTextInput from '../../../common-adapters/custom-input'
 import {globalMargins, globalStyles, globalColors} from '../../../styles'
 import {isIOS} from '../../../constants/platform'
 
 import type {AttachmentInput} from '../../../constants/chat'
 import type {Props} from '.'
+
+let CustomTextInput
+
+// NEVER load this on ios, it kills it
+if (!isIOS) {
+  CustomTextInput = require('../../../common-adapters/custom-input').default
+}
 
 // TODO we don't autocorrect the last word on submit. We had a solution using blur but this also dismisses they keyboard each time
 // See if there's a better workaround later


### PR DESCRIPTION
ios crashes without this

the root cause is

https://github.com/keybase/client/blob/master/shared/common-adapters/custom-input.native.js#L53

but instead of editing this file, we just don't import it on ios (cause its never used anyways)

@keybase/react-hackers 
cc: @MarcoPolo 

testing on android now so waiting on that to merge first