### PR TITLE
fix reading a thread that is not in our inbox with superseded messages in it CORE-6477

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -510,13 +510,6 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	conv, ratelim, err := GetUnverifiedConv(ctx, s.G(), uid, convID, true)
 	rl = append(rl, ratelim)
 
-	// Post process thread before returning
-	defer func() {
-		if err == nil {
-			err = s.postProcessThread(ctx, uid, conv, &thread, query, nil, true)
-		}
-	}()
-
 	var unboxConv unboxConversationInfo
 	if err == nil {
 		unboxConv = conv

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
@@ -10,7 +11,7 @@ import (
 
 type supersedesTransform interface {
 	Run(ctx context.Context,
-		conv chat1.Conversation, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error)
+		conv types.UnboxConversationInfo, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error)
 }
 
 type nullSupersedesTransform struct {
@@ -25,7 +26,7 @@ func newNullSupersedesTransform() nullSupersedesTransform {
 	return nullSupersedesTransform{}
 }
 
-type getMessagesFunc func(context.Context, chat1.Conversation, gregor1.UID, []chat1.MessageID) ([]chat1.MessageUnboxed, error)
+type getMessagesFunc func(context.Context, types.UnboxConversationInfo, gregor1.UID, []chat1.MessageID) ([]chat1.MessageUnboxed, error)
 
 type basicSupersedesTransform struct {
 	globals.Contextified
@@ -112,7 +113,7 @@ func (t *basicSupersedesTransform) SetMessagesFunc(f getMessagesFunc) {
 }
 
 func (t *basicSupersedesTransform) Run(ctx context.Context,
-	conv chat1.Conversation, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error) {
+	conv types.UnboxConversationInfo, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error) {
 
 	// MessageIDs that supersede
 	var superMsgIDs []chat1.MessageID

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -1,6 +1,8 @@
 package chat
 
 import (
+	"fmt"
+
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
@@ -113,7 +115,8 @@ func (t *basicSupersedesTransform) SetMessagesFunc(f getMessagesFunc) {
 }
 
 func (t *basicSupersedesTransform) Run(ctx context.Context,
-	conv types.UnboxConversationInfo, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error) {
+	conv types.UnboxConversationInfo, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed) (res []chat1.MessageUnboxed, err error) {
+	defer t.Trace(ctx, func() error { return err }, fmt.Sprintf("Run(%s)", conv.GetConvID()))()
 
 	// MessageIDs that supersede
 	var superMsgIDs []chat1.MessageID

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -28,6 +28,12 @@ type NameInfoSource interface {
 	Lookup(ctx context.Context, name string, vis keybase1.TLFVisibility) (NameInfo, error)
 }
 
+type UnboxConversationInfo interface {
+	GetConvID() chat1.ConversationID
+	GetMembersType() chat1.ConversationMembersType
+	GetFinalizeInfo() *chat1.ConversationFinalizeInfo
+}
+
 type ConversationSource interface {
 	Offlinable
 
@@ -37,7 +43,7 @@ type ConversationSource interface {
 		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 		query *chat1.GetThreadQuery, p *chat1.Pagination) (chat1.ThreadView, error)
-	GetMessages(ctx context.Context, conv chat1.Conversation, uid gregor1.UID, msgIDs []chat1.MessageID) ([]chat1.MessageUnboxed, error)
+	GetMessages(ctx context.Context, conv UnboxConversationInfo, uid gregor1.UID, msgIDs []chat1.MessageID) ([]chat1.MessageUnboxed, error)
 	GetMessagesWithRemotes(ctx context.Context, conv chat1.Conversation, uid gregor1.UID,
 		msgs []chat1.MessageBoxed) ([]chat1.MessageUnboxed, error)
 	Clear(convID chat1.ConversationID, uid gregor1.UID) error


### PR DESCRIPTION
If we tried to read messages from a conversation we are keyed for but is not in our inbox (like public convos or team channels we are not in) we could get in trouble if the messages have a superseded by message in it. We were silently passing a blank `chat1.Conversation` object through to the supersedes logic which was then happily sending a blank conversation ID to the server which rejected it.