### PR TITLE
Db nuke clears team in-memory cache

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -599,6 +599,8 @@ type TeamLoader interface {
 	// Delete the cache entry. Does not error if there is no cache entry.
 	Delete(ctx context.Context, teamID keybase1.TeamID) error
 	OnLogout()
+	// Clear the in-memory cache. Does not affect the disk cache.
+	ClearMem()
 }
 
 type KVStoreContext interface {

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -50,3 +50,5 @@ func (n nullTeamLoader) Delete(context.Context, keybase1.TeamID) error {
 }
 
 func (n nullTeamLoader) OnLogout() {}
+
+func (n nullTeamLoader) ClearMem() {}

--- a/go/service/ctl.go
+++ b/go/service/ctl.go
@@ -62,6 +62,11 @@ func (c *CtlHandler) DbNuke(_ context.Context, sessionID int) error {
 	}
 	ctx.LogUI.Warning("Nuking chat database %s", fn)
 
+	teamLoader := c.G().GetTeamLoader()
+	if teamLoader != nil {
+		teamLoader.ClearMem()
+	}
+
 	// Now drop caches, since we had the DB's state in-memory too.
 	return c.G().ConfigureCaches()
 }

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -848,7 +848,12 @@ func (l *TeamLoader) lows(ctx context.Context, state *keybase1.TeamData) getLink
 }
 
 func (l *TeamLoader) OnLogout() {
-	l.storage.onLogout()
+	l.storage.clearMem()
+}
+
+// Clear the in-memory cache.
+func (l *TeamLoader) ClearMem() {
+	l.storage.clearMem()
 }
 
 func (l *TeamLoader) VerifyTeamName(ctx context.Context, id keybase1.TeamID, name keybase1.TeamName) error {

--- a/go/teams/storage.go
+++ b/go/teams/storage.go
@@ -74,8 +74,9 @@ func (s *Storage) Delete(ctx context.Context, teamID keybase1.TeamID, public boo
 	return s.disk.Delete(ctx, teamID, public)
 }
 
-func (s *Storage) onLogout() {
-	s.mem.onLogout()
+// Clear the in-memory storage.
+func (s *Storage) clearMem() {
+	s.mem.Clear()
 }
 
 // --------------------------------------------------
@@ -219,7 +220,7 @@ func (s *MemoryStorage) Delete(ctx context.Context, teamID keybase1.TeamID, publ
 	s.lru.Remove(s.key(teamID, public))
 }
 
-func (s *MemoryStorage) onLogout() {
+func (s *MemoryStorage) Clear() {
 	s.lru.Purge()
 }
 


### PR DESCRIPTION
Before this change db nuke would clear the team cache but then any team operations would write back in with results from the memory cache. Now nuke clears the in-memory cache. Stuff can still race past, but much less likely.