### PR TITLE
Fix broken profile on navigating to mixed case username

### DIFF
--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -822,7 +822,7 @@ func ListRequests(ctx context.Context, g *libkb.GlobalContext) ([]keybase1.TeamJ
 	for i, ar := range arList.Requests {
 		joinRequests[i] = keybase1.TeamJoinRequest{
 			Name:     ar.FQName,
-			Username: ar.Username,
+			Username: libkb.NewNormalizedUsername(ar.Username).String(),
 		}
 	}
 

--- a/shared/actions/profile/index.js
+++ b/shared/actions/profile/index.js
@@ -95,7 +95,7 @@ function* _showUserProfile(action: Constants.ShowUserProfile): SagaGenerator<any
   // Assume user exists
   if (!username.includes('@')) {
     yield put(switchTo([peopleTab]))
-    yield put(navigateAppend([{props: {username}, selected: 'profile'}], [peopleTab]))
+    yield put(navigateAppend([{props: {username: username.toLowerCase()}, selected: 'profile'}], [peopleTab]))
     return
   }
 

--- a/shared/actions/profile/index.js
+++ b/shared/actions/profile/index.js
@@ -95,7 +95,7 @@ function* _showUserProfile(action: Constants.ShowUserProfile): SagaGenerator<any
   // Assume user exists
   if (!username.includes('@')) {
     yield put(switchTo([peopleTab]))
-    yield put(navigateAppend([{props: {username: username.toLowerCase()}, selected: 'profile'}], [peopleTab]))
+    yield put(navigateAppend([{props: {username}, selected: 'profile'}], [peopleTab]))
     return
   }
 

--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -54,7 +54,12 @@ class ProfileContainer extends PureComponent<EitherProps<Props>, void> {
 export default pausableConnect(
   (state, {routeProps, routeState, routePath}: OwnProps) => {
     const myUsername = state.config.username
-    const username = routeProps.get('username') ? routeProps.get('username') : myUsername
+    let username = routeProps.get('username')
+    if (username) {
+      username = username.toLowerCase()
+    } else {
+      username = myUsername
+    }
 
     return {
       currentFriendshipsTab: routeState.get('currentFriendshipsTab'),

--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -55,6 +55,9 @@ export default pausableConnect(
   (state, {routeProps, routeState, routePath}: OwnProps) => {
     const myUsername = state.config.username
     const username = routeProps.get('username') ? routeProps.get('username') : myUsername
+    if (username && username !== username.toLowerCase()) {
+      throw new Error('Attempted to navigate to mixed case username.')
+    }
 
     return {
       currentFriendshipsTab: routeState.get('currentFriendshipsTab'),

--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -54,12 +54,7 @@ class ProfileContainer extends PureComponent<EitherProps<Props>, void> {
 export default pausableConnect(
   (state, {routeProps, routeState, routePath}: OwnProps) => {
     const myUsername = state.config.username
-    let username = routeProps.get('username')
-    if (username) {
-      username = username.toLowerCase()
-    } else {
-      username = myUsername
-    }
+    const username = routeProps.get('username') ? routeProps.get('username') : myUsername
 
     return {
       currentFriendshipsTab: routeState.get('currentFriendshipsTab'),


### PR DESCRIPTION
In the profile component, the supplied username should always be all lowercase. Sometimes the `routeProps` supplied to the component have a mixed case `username`, which causes the user bio, etc. to never load correctly. This PR casts `username` to lowercase in the profile container so it should always load correctly, as long as it's a real user.

@keybase/react-hackers 