### PR TITLE
Add 'Create subteam' popup menu option for teams

### DIFF
--- a/shared/teams/new-team/container.js
+++ b/shared/teams/new-team/container.js
@@ -19,9 +19,15 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
   onBack: () => dispatch(navigateUp()),
 })
 
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...stateProps,
+  ...dispatchProps,
+  name: ownProps.routeProps.get('name'),
+})
+
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  withState('name', 'onNameChange', ''),
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  withState('name', 'onNameChange', props => props.name),
   withHandlers({
     onSubmit: ({name, _onCreateNewTeam}) => () => _onCreateNewTeam(name),
   }),

--- a/shared/teams/new-team/container.js
+++ b/shared/teams/new-team/container.js
@@ -27,7 +27,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
-  withState('name', 'onNameChange', props => props.name),
+  withState('name', 'onNameChange', props => props.name || ''),
   withHandlers({
     onSubmit: ({name, _onCreateNewTeam}) => () => _onCreateNewTeam(name),
   }),

--- a/shared/teams/new-team/index.js
+++ b/shared/teams/new-team/index.js
@@ -6,6 +6,32 @@ import {globalColors, globalMargins, globalStyles} from '../../styles'
 
 import type {Props} from './'
 
+const validTeamname = (s: string): boolean => {
+  // This logic is copied from go/protocol/keybase1/extras.go.
+  if (s.length < 2 || s.length > 16) {
+    return false
+  }
+
+  return /^([a-zA-Z0-9][a-zA-Z0-9_]?)+$/.test(s)
+}
+
+const headerText = (errorText: string, name: string): string => {
+  if (errorText) {
+    return errorText
+  }
+
+  const i = name.indexOf('.')
+  if (i >= 0) {
+    const teamname = name.substring(0, i)
+    if (validTeamname(teamname)) {
+      return `You're creating a subteam of ${teamname}.`
+    }
+    // TODO: Display an error if teamname isn't valid.
+  }
+
+  return "For security reasons, team names are unique and can't be changed, so choose carefully."
+}
+
 const Contents = ({errorText, name, onNameChange, onSubmit, pending}: Props) => (
   <ScrollView>
     <Box style={globalStyles.flexBoxColumn}>
@@ -15,8 +41,7 @@ const Contents = ({errorText, name, onNameChange, onSubmit, pending}: Props) => 
           type="BodySemibold"
           backgroundMode={errorText ? 'HighRisk' : 'Announcements'}
         >
-          {errorText ||
-            "For security reasons, team names are unique and can't be changed, so choose carefully."}
+          {headerText(errorText, name)}
         </Text>
       </Box>
 

--- a/shared/teams/new-team/index.js
+++ b/shared/teams/new-team/index.js
@@ -31,7 +31,8 @@ const headerText = (errorText: string, name: string): string => {
     if (validTeamname(baseTeamname)) {
       return `You're creating a subteam of ${baseTeamname}.`
     }
-    // TODO: Display an error if teamname isn't valid.
+    // TODO: Display an error and disable the submit button if
+    // teamname isn't valid.
   }
 
   return "For security reasons, team names are unique and can't be changed, so choose carefully."

--- a/shared/teams/new-team/index.js
+++ b/shared/teams/new-team/index.js
@@ -6,8 +6,9 @@ import {globalColors, globalMargins, globalStyles} from '../../styles'
 
 import type {Props} from './'
 
-const validTeamname = (s: string): boolean => {
-  // This logic is copied from go/protocol/keybase1/extras.go.
+// This logic is copied from go/protocol/keybase1/extras.go.
+
+const validTeamnamePart = (s: string): boolean => {
   if (s.length < 2 || s.length > 16) {
     return false
   }
@@ -15,16 +16,20 @@ const validTeamname = (s: string): boolean => {
   return /^([a-zA-Z0-9][a-zA-Z0-9_]?)+$/.test(s)
 }
 
+const validTeamname = (s: string): boolean => {
+  return s.split('.').every(validTeamnamePart)
+}
+
 const headerText = (errorText: string, name: string): string => {
   if (errorText) {
     return errorText
   }
 
-  const i = name.indexOf('.')
+  const i = name.lastIndexOf('.')
   if (i >= 0) {
-    const teamname = name.substring(0, i)
-    if (validTeamname(teamname)) {
-      return `You're creating a subteam of ${teamname}.`
+    const baseTeamname = name.substring(0, i)
+    if (validTeamname(baseTeamname)) {
+      return `You're creating a subteam of ${baseTeamname}.`
     }
     // TODO: Display an error if teamname isn't valid.
   }

--- a/shared/teams/routes.js
+++ b/shared/teams/routes.js
@@ -51,14 +51,16 @@ const reallyRemoveMember = {
   tags: makeLeafTags({layerOnTop: !isMobile}),
 }
 
+const showNewTeamDialog = {
+  children: {},
+  component: NewTeamDialog,
+  tags: makeLeafTags({layerOnTop: !isMobile}),
+}
+
 const routeTree = makeRouteDefNode({
   children: {
     ...makeManageChannels,
-    showNewTeamDialog: {
-      children: {},
-      component: NewTeamDialog,
-      tags: makeLeafTags({layerOnTop: !isMobile}),
-    },
+    showNewTeamDialog,
     showJoinTeamDialog: {
       children: {},
       component: JoinTeamDialog,
@@ -80,6 +82,7 @@ const routeTree = makeRouteDefNode({
         rolePicker,
         reallyLeaveTeam,
         reallyRemoveMember,
+        showNewTeamDialog,
         member: {
           children: {
             rolePicker,

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -54,7 +54,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, setRouteState, rout
   _onAddPeople: (teamname: Constants.Teamname) =>
     dispatch(navigateAppend([{props: {teamname}, selected: 'addPeople'}])),
   _onCreateSubteam: (teamname: Constants.Teamname) =>
-    dispatch(navigateAppend([{props: {teamname}, selected: 'showNewTeamDialog'}])),
+    dispatch(navigateAppend([{props: {name: `${teamname}.`}, selected: 'showNewTeamDialog'}])),
   _onInviteByEmail: (teamname: Constants.Teamname) =>
     dispatch(navigateAppend([{props: {teamname}, selected: 'inviteByEmail'}])),
   _onLeaveTeam: (teamname: Constants.Teamname) =>

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -53,6 +53,10 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, setRouteState, rout
   _loadTeam: teamname => dispatch(Creators.getDetails(teamname)),
   _onAddPeople: (teamname: Constants.Teamname) =>
     dispatch(navigateAppend([{props: {teamname}, selected: 'addPeople'}])),
+  _onCreateSubteam: (teamname: Constants.Teamname) =>
+    dispatch(navigateAppend([{props: {teamname}, selected: 'createSubteam'}])),
+  _onDeleteTeam: (teamname: Constants.Teamname) =>
+    dispatch(navigateAppend([{props: {teamname}, selected: 'reallyDeleteTeam'}])),
   _onInviteByEmail: (teamname: Constants.Teamname) =>
     dispatch(navigateAppend([{props: {teamname}, selected: 'inviteByEmail'}])),
   _onLeaveTeam: (teamname: Constants.Teamname) =>
@@ -86,8 +90,12 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const onManageChat = () => dispatchProps._onManageChat(stateProps.name)
   const onLeaveTeam = () => dispatchProps._onLeaveTeam(stateProps.name)
   const onClickOpenTeamSetting = () => dispatchProps._onClickOpenTeamSetting(stateProps.isTeamOpen)
+  const onCreateSubteam = () => dispatchProps._onCreateSubteam(stateProps.name)
+  const onDeleteTeam = () => dispatchProps._onDeleteTeam(stateProps.name)
   const yourType = stateProps._memberInfo.find(member => member.username === stateProps.you)
   const youCanAddPeople = yourType && (yourType.type === 'owner' || yourType.type === 'admin')
+  const youCanCreateSubteam = youCanAddPeople
+  const youCanDeleteTeam = yourType && yourType.type === 'owner'
 
   const customComponent = (
     <CustomComponent
@@ -109,11 +117,15 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     requests: stateProps._requests.toJS(),
     onAddPeople,
     onInviteByEmail,
+    onCreateSubteam,
+    onDeleteTeam,
     onLeaveTeam,
     onManageChat,
     onOpenFolder,
     onClickOpenTeamSetting,
     youCanAddPeople,
+    youCanCreateSubteam,
+    youCanDeleteTeam,
   }
 }
 

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -54,7 +54,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, setRouteState, rout
   _onAddPeople: (teamname: Constants.Teamname) =>
     dispatch(navigateAppend([{props: {teamname}, selected: 'addPeople'}])),
   _onCreateSubteam: (teamname: Constants.Teamname) =>
-    dispatch(navigateAppend([{props: {teamname}, selected: 'createSubteam'}])),
+    dispatch(navigateAppend([{props: {teamname}, selected: 'showNewTeamDialog'}])),
   _onInviteByEmail: (teamname: Constants.Teamname) =>
     dispatch(navigateAppend([{props: {teamname}, selected: 'inviteByEmail'}])),
   _onLeaveTeam: (teamname: Constants.Teamname) =>

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -55,8 +55,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, setRouteState, rout
     dispatch(navigateAppend([{props: {teamname}, selected: 'addPeople'}])),
   _onCreateSubteam: (teamname: Constants.Teamname) =>
     dispatch(navigateAppend([{props: {teamname}, selected: 'createSubteam'}])),
-  _onDeleteTeam: (teamname: Constants.Teamname) =>
-    dispatch(navigateAppend([{props: {teamname}, selected: 'reallyDeleteTeam'}])),
   _onInviteByEmail: (teamname: Constants.Teamname) =>
     dispatch(navigateAppend([{props: {teamname}, selected: 'inviteByEmail'}])),
   _onLeaveTeam: (teamname: Constants.Teamname) =>
@@ -91,11 +89,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const onLeaveTeam = () => dispatchProps._onLeaveTeam(stateProps.name)
   const onClickOpenTeamSetting = () => dispatchProps._onClickOpenTeamSetting(stateProps.isTeamOpen)
   const onCreateSubteam = () => dispatchProps._onCreateSubteam(stateProps.name)
-  const onDeleteTeam = () => dispatchProps._onDeleteTeam(stateProps.name)
   const yourType = stateProps._memberInfo.find(member => member.username === stateProps.you)
   const youCanAddPeople = yourType && (yourType.type === 'owner' || yourType.type === 'admin')
   const youCanCreateSubteam = youCanAddPeople
-  const youCanDeleteTeam = yourType && yourType.type === 'owner'
 
   const customComponent = (
     <CustomComponent
@@ -118,14 +114,12 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     onAddPeople,
     onInviteByEmail,
     onCreateSubteam,
-    onDeleteTeam,
     onLeaveTeam,
     onManageChat,
     onOpenFolder,
     onClickOpenTeamSetting,
     youCanAddPeople,
     youCanCreateSubteam,
-    youCanDeleteTeam,
   }
 }
 

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -38,14 +38,12 @@ export type Props = {
   onInviteByEmail: () => void,
   setSelectedTab: (t: ?Constants.TabKey) => void,
   onCreateSubteam: () => void,
-  onDeleteTeam: () => void,
   onLeaveTeam: () => void,
   onManageChat: () => void,
   onClickOpenTeamSetting: () => void,
   isTeamOpen: boolean,
   youCanAddPeople: boolean,
   youCanCreateSubteam: boolean,
-  youCanDeleteTeam: boolean,
 }
 
 const Help = isMobile
@@ -142,7 +140,6 @@ class Team extends React.PureComponent<Props> {
       setShowMenu,
       onAddPeople,
       onCreateSubteam,
-      onDeleteTeam,
       onInviteByEmail,
       onLeaveTeam,
       selectedTab,
@@ -151,7 +148,6 @@ class Team extends React.PureComponent<Props> {
       you,
       youCanAddPeople,
       youCanCreateSubteam,
-      youCanDeleteTeam,
     } = this.props
 
     const me = members.find(member => member.username === you)
@@ -229,10 +225,6 @@ class Team extends React.PureComponent<Props> {
 
     if (youCanCreateSubteam) {
       popupMenuItems.push({onClick: onCreateSubteam, title: 'Create subteam'})
-    }
-
-    if (youCanDeleteTeam) {
-      popupMenuItems.push({onClick: onDeleteTeam, title: 'Delete team', danger: true})
     }
 
     return (

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -37,11 +37,15 @@ export type Props = {
   onAddPeople: () => void,
   onInviteByEmail: () => void,
   setSelectedTab: (t: ?Constants.TabKey) => void,
+  onCreateSubteam: () => void,
+  onDeleteTeam: () => void,
   onLeaveTeam: () => void,
   onManageChat: () => void,
   onClickOpenTeamSetting: () => void,
   isTeamOpen: boolean,
   youCanAddPeople: boolean,
+  youCanCreateSubteam: boolean,
+  youCanDeleteTeam: boolean,
 }
 
 const Help = isMobile
@@ -137,6 +141,8 @@ class Team extends React.PureComponent<Props> {
       showMenu,
       setShowMenu,
       onAddPeople,
+      onCreateSubteam,
+      onDeleteTeam,
       onInviteByEmail,
       onLeaveTeam,
       selectedTab,
@@ -144,6 +150,8 @@ class Team extends React.PureComponent<Props> {
       onManageChat,
       you,
       youCanAddPeople,
+      youCanCreateSubteam,
+      youCanDeleteTeam,
     } = this.props
 
     const me = members.find(member => member.username === you)
@@ -214,6 +222,19 @@ class Team extends React.PureComponent<Props> {
       }
     }
 
+    const popupMenuItems = [
+      {onClick: onManageChat, title: 'Manage chat channels'},
+      {onClick: onLeaveTeam, title: 'Leave team', danger: true},
+    ]
+
+    if (youCanCreateSubteam) {
+      popupMenuItems.push({onClick: onCreateSubteam, title: 'Create subteam'})
+    }
+
+    if (youCanDeleteTeam) {
+      popupMenuItems.push({onClick: onDeleteTeam, title: 'Delete team', danger: true})
+    }
+
     return (
       <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', flex: 1}}>
         <Avatar isTeam={true} teamname={name} size={64} />
@@ -252,10 +273,7 @@ class Team extends React.PureComponent<Props> {
         {contents}
         {showMenu &&
           <PopupMenu
-            items={[
-              {onClick: onManageChat, title: 'Manage chat channels'},
-              {onClick: onLeaveTeam, title: 'Leave team', danger: true},
-            ]}
+            items={popupMenuItems}
             onHidden={() => setShowMenu(false)}
             style={{position: 'absolute', right: globalMargins.tiny, top: globalMargins.large}}
           />}


### PR DESCRIPTION
Hook it up to the standard create team dialog, but with the
team prefix filled in.

Have a different message if it detects that the user is trying to
create a subteam.