### PR TITLE
Add nicer SubteamOwnersError

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -1665,20 +1665,20 @@ func (t *TeamSigChainPlayer) sanityCheckMembers(members SCTeamMembers, options s
 
 	if options.requireOwners {
 		if members.Owners == nil {
-			return nil, fmt.Errorf("team has no owner list: %+v", members)
+			return nil, fmt.Errorf("team has no owner list")
 		}
 		if len(*members.Owners) < 1 {
-			return nil, fmt.Errorf("team has no owners: %+v", members)
+			return nil, fmt.Errorf("team has no owners")
 		}
 	}
 	if options.disallowOwners {
 		if members.Owners != nil && len(*members.Owners) > 0 {
-			return nil, fmt.Errorf("team has owners: %+v", members)
+			return nil, fmt.Errorf("team has owners")
 		}
 	}
 	if !options.allowRemovals {
 		if members.None != nil && len(*members.None) != 0 {
-			return nil, fmt.Errorf("team has removals in link: %+v", members)
+			return nil, fmt.Errorf("team has removals in link")
 		}
 	}
 

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -260,3 +260,11 @@ func NewTeamDeletedError() error { return &TeamDeletedError{} }
 func (e TeamDeletedError) Error() string {
 	return "team has been deleted"
 }
+
+type SubteamOwnersError struct{}
+
+func NewSubteamOwnersError() error { return &SubteamOwnersError{} }
+
+func (e SubteamOwnersError) Error() string {
+	return "Subteams cannot have owners. Try admin instead."
+}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -15,6 +15,20 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
+func LoadTeamPlusApplicationKeys(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID,
+	application keybase1.TeamApplication, refreshers keybase1.TeamRefreshers) (res keybase1.TeamPlusApplicationKeys, err error) {
+
+	team, err := Load(ctx, g, keybase1.LoadTeamArg{
+		ID:         id,
+		Public:     id.IsPublic(), // infer publicness from id
+		Refreshers: refreshers,
+	})
+	if err != nil {
+		return res, err
+	}
+	return team.ExportToTeamPlusApplicationKeys(ctx, keybase1.Time(0), application)
+}
+
 func membersUIDsToUsernames(ctx context.Context, g *libkb.GlobalContext, m keybase1.TeamMembers, forceRepoll bool) (keybase1.TeamMembersDetails, error) {
 	var ret keybase1.TeamMembersDetails
 	var err error


### PR DESCRIPTION
Before
```
$ kbu team add-member cn3team6.sub1 --user=cn3 --role=owner
▶ ERROR cannot post link (precheck): appending 1->2: team has owners
```

After
```
$ kbu team add-member cn3team6.sub1 --user=cn3 --role=owner
▶ ERROR Subteams cannot have owners. Try admin instead.
```