### PR TITLE
Enable seitan rkm coverage check

### DIFF
--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -641,10 +641,6 @@ func (l *TeamLoader) checkReaderKeyMaskCoverage(ctx context.Context,
 	state *keybase1.TeamData, gen keybase1.PerTeamKeyGeneration) error {
 
 	for _, app := range keybase1.TeamApplicationMap {
-		if app == keybase1.TeamApplication_SEITAN_INVITE_TOKEN {
-			// QUICKFIX don't check seitan coverage: may want to bust team cache later to fix this
-			continue
-		}
 		if _, ok := state.ReaderKeyMasks[app]; !ok {
 			return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
 		}

--- a/go/teams/storage.go
+++ b/go/teams/storage.go
@@ -89,7 +89,7 @@ type DiskStorage struct {
 }
 
 // Increment to invalidate the disk cache.
-const diskStorageVersion = 6
+const diskStorageVersion = 7
 
 type DiskStorageItem struct {
 	Version int                `codec:"V"`

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -11,6 +11,9 @@ protocol teams {
     OWNER_4
   }
 
+  // Note: If you add to this list, take heed.
+  // The client will try to assert RKM coverage or the new application.
+  // First update the server and run add_new_team_app.
   enum TeamApplication {
     KBFS_1,
     CHAT_2,


### PR DESCRIPTION
I ran the backfill on the server and tested against master. This should be fine now, right?