### PR TITLE
Add TeamImplicitAdmins RPC

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1535,6 +1535,18 @@ func (o TeamGetArg) DeepCopy() TeamGetArg {
 	}
 }
 
+type TeamImplicitAdminsArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	TeamName  string `codec:"teamName" json:"teamName"`
+}
+
+func (o TeamImplicitAdminsArg) DeepCopy() TeamImplicitAdminsArg {
+	return TeamImplicitAdminsArg{
+		SessionID: o.SessionID,
+		TeamName:  o.TeamName,
+	}
+}
+
 type TeamListArg struct {
 	SessionID            int    `codec:"sessionID" json:"sessionID"`
 	UserAssertion        string `codec:"userAssertion" json:"userAssertion"`
@@ -1855,6 +1867,7 @@ type TeamsInterface interface {
 	TeamCreate(context.Context, TeamCreateArg) (TeamCreateResult, error)
 	TeamCreateWithSettings(context.Context, TeamCreateWithSettingsArg) (TeamCreateResult, error)
 	TeamGet(context.Context, TeamGetArg) (TeamDetails, error)
+	TeamImplicitAdmins(context.Context, TeamImplicitAdminsArg) ([]TeamMemberDetails, error)
 	TeamList(context.Context, TeamListArg) (AnnotatedTeamList, error)
 	TeamListSubteamsRecursive(context.Context, TeamListSubteamsRecursiveArg) ([]TeamIDAndName, error)
 	TeamChangeMembership(context.Context, TeamChangeMembershipArg) error
@@ -1931,6 +1944,22 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.TeamGet(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"teamImplicitAdmins": {
+				MakeArg: func() interface{} {
+					ret := make([]TeamImplicitAdminsArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]TeamImplicitAdminsArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]TeamImplicitAdminsArg)(nil), args)
+						return
+					}
+					ret, err = i.TeamImplicitAdmins(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -2323,6 +2352,11 @@ func (c TeamsClient) TeamCreateWithSettings(ctx context.Context, __arg TeamCreat
 
 func (c TeamsClient) TeamGet(ctx context.Context, __arg TeamGetArg) (res TeamDetails, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamGet", []interface{}{__arg}, &res)
+	return
+}
+
+func (c TeamsClient) TeamImplicitAdmins(ctx context.Context, __arg TeamImplicitAdminsArg) (res []TeamMemberDetails, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamImplicitAdmins", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -96,6 +96,19 @@ func (h *TeamsHandler) TeamGet(ctx context.Context, arg keybase1.TeamGetArg) (re
 	return teams.Details(ctx, h.G().ExternalG(), arg.Name, arg.ForceRepoll)
 }
 
+func (h *TeamsHandler) TeamImplicitAdmins(ctx context.Context, arg keybase1.TeamImplicitAdminsArg) (res []keybase1.TeamMemberDetails, err error) {
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamImplicitAdmins(%s)", arg.TeamName), func() error { return err })()
+	teamName, err := keybase1.TeamNameFromString(arg.TeamName)
+	if err != nil {
+		return nil, err
+	}
+	teamID, err := teams.ResolveNameToID(ctx, h.G().ExternalG(), teamName)
+	if err != nil {
+		return nil, err
+	}
+	return teams.ImplicitAdmins(ctx, h.G().ExternalG(), teamID)
+}
+
 func (h *TeamsHandler) TeamList(ctx context.Context, arg keybase1.TeamListArg) (res keybase1.AnnotatedTeamList, err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamList(%s)", arg.UserAssertion), func() error { return err })()
 	x, err := teams.List(ctx, h.G().ExternalG(), arg)

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -1,11 +1,13 @@
 package teams
 
 import (
+	"sort"
 	"testing"
 	"time"
 
 	"golang.org/x/net/context"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
@@ -55,6 +57,10 @@ func memberSetupMultiple(t *testing.T) (tc libkb.TestContext, owner, otherA, oth
 // no members in subteam.
 func memberSetupSubteam(t *testing.T) (tc libkb.TestContext, owner, otherA, otherB *kbtest.FakeUser, root, sub string) {
 	tc, owner, otherA, otherB, root = memberSetupMultiple(t)
+
+	t.Logf("mss owner: %v", owner.Username)
+	t.Logf("mss otherA: %v", otherA.Username)
+	t.Logf("mss otherB: %v", otherB.Username)
 
 	// add otherA and otherB as admins to rootName
 	_, err := AddMember(context.TODO(), tc.G, root, otherA.Username, keybase1.TeamRole_ADMIN)
@@ -546,26 +552,44 @@ func TestMemberAddAsImplicitAdmin(t *testing.T) {
 	// owner created a subteam, otherA is implicit admin, otherB is nobody
 	// (all of that tested in memberSetupSubteam)
 
-	// switch to `otherA` user
-	tc.G.Logout()
-	if err := otherA.Login(tc.G); err != nil {
-		t.Fatal(err)
+	switchTo := func(to *kbtest.FakeUser) {
+		tc.G.Logout()
+		err := to.Login(tc.G)
+		require.NoError(t, err)
 	}
+
+	switchTo(otherA)
 
 	// otherA has the power to add otherB to the subteam
 	res, err := AddMember(context.TODO(), tc.G, subteamName, otherB.Username, keybase1.TeamRole_WRITER)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res.User.Username != otherB.Username {
-		t.Errorf("AddMember result username %q does not match arg username %q", res.User.Username, otherB.Username)
-	}
+	require.NoError(t, err)
+	require.Equal(t, otherB.Username, res.User.Username, "AddMember result username does not match arg")
 	// otherB should now be a writer
 	assertRole(tc, subteamName, otherB.Username, keybase1.TeamRole_WRITER)
 
 	// owner, otherA should still be non-members
 	assertRole(tc, subteamName, owner.Username, keybase1.TeamRole_NONE)
 	assertRole(tc, subteamName, otherA.Username, keybase1.TeamRole_NONE)
+
+	switchTo(otherB)
+	// Test ImplicitAdmins
+	subteamName2, err := keybase1.TeamNameFromString(subteamName)
+	require.NoError(t, err)
+	subteamID, err := ResolveNameToID(context.TODO(), tc.G, subteamName2)
+	require.NoError(t, err)
+	ias, err := ImplicitAdmins(context.TODO(), tc.G, subteamID)
+	require.NoError(t, err)
+	t.Logf("res: %v", spew.Sdump(ias))
+	require.Len(t, ias, 2, "number of implicit admins")
+	sort.Slice(ias, func(i, _ int) bool {
+		return ias[i].Uv.Eq(owner.GetUserVersion())
+	})
+	require.Equal(t, owner.GetUserVersion(), ias[0].Uv)
+	require.Equal(t, owner.Username, ias[0].Username)
+	require.True(t, ias[0].Active)
+	require.Equal(t, otherA.GetUserVersion(), ias[1].Uv)
+	require.Equal(t, otherA.Username, ias[1].Username)
+	require.True(t, ias[1].Active)
 }
 
 func TestLeave(t *testing.T) {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -114,6 +114,22 @@ func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepo
 	return res, nil
 }
 
+// List all the admins of ancestor teams.
+// Includes admins of the specified team only if they are also admins of ancestor teams.
+func ImplicitAdmins(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) (res []keybase1.TeamMemberDetails, err error) {
+	defer g.CTraceTimed(ctx, fmt.Sprintf("teams::ImplicitAdmins(%v)", teamID), func() error { return err })()
+	if teamID.IsRootTeam() {
+		// Root teams have only explicit admins.
+		return nil, nil
+	}
+	uvs, err := g.GetTeamLoader().ImplicitAdmins(ctx, teamID)
+	if err != nil {
+		return nil, err
+	}
+
+	return userVersionsToDetails(ctx, g, uvs, true /* forceRepoll */)
+}
+
 func members(ctx context.Context, g *libkb.GlobalContext, t *Team, forceRepoll bool) (keybase1.TeamMembersDetails, error) {
 	members, err := t.Members()
 	if err != nil {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1275,6 +1275,7 @@ func (t *Team) ForceMerkleRootUpdate(ctx context.Context) error {
 	return err
 }
 
+// All admins, owners, and implicit admins of this team.
 func (t *Team) AllAdmins(ctx context.Context) ([]keybase1.UserVersion, error) {
 	set := make(map[keybase1.UserVersion]bool)
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -485,29 +485,52 @@ protocol teams {
   }
 
   TeamCreateResult teamCreate(int sessionID, string name, boolean sendChatNotification);
+
   TeamCreateResult teamCreateWithSettings(int sessionID, string name, boolean sendChatNotification, TeamSettings settings);
+
   TeamDetails teamGet(int sessionID, string name, boolean forceRepoll);
+
+  // List all the admins of ancestor teams.
+  // Includes admins of the specified team only if they are also admins of ancestor teams.
+  array<TeamMemberDetails> teamImplicitAdmins(int sessionID, string teamName);
+
   AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean all, boolean includeImplicitTeams);
+
   // admin only
   array<TeamIDAndName> teamListSubteamsRecursive(int sessionID, string parentTeamName, boolean forceRepoll);
+
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);
+
   TeamAddMemberResult teamAddMember(int sessionID, string name, string email, string username, TeamRole role, boolean sendChatNotification);
+
   void teamRemoveMember(int sessionID, string name, string username, string email);
+
   void teamLeave(int sessionID, string name, boolean permanent);
+
   void teamEditMember(int sessionID, string name, string username, TeamRole role);
+
   void teamRename(int sessionID, TeamName prevName, TeamName newName);
+
   void teamAcceptInvite(int sessionID, string token);
+
   TeamRequestAccessResult teamRequestAccess(int sessionID, string name);
+
   // Accept an invite or request to join a team, try both.
   void teamAcceptInviteOrRequestAccess(int sessionID, string tokenOrName);
+
   array<TeamJoinRequest> teamListRequests(int sessionID);
+
   void teamIgnoreRequest(int sessionID, string name, string username);
+
   // Get a list of all recursive subteams recursively. Sorted alphabetically like a tree.
   // Team must be a root team.
   // Example: a -> [a, a.b, a.b.c, a.b.d, a.e.f, a.e.g]
   TeamTreeResult teamTree(int sessionID, TeamName name);
+
   void teamDelete(int sessionID, string name);
+
   void teamSetSettings(int sessionID, string name, TeamSettings settings);
+
   string teamCreateSeitanToken(int sessionID, string name, TeamRole role);
 
   record BulkRes {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2498,6 +2498,14 @@ export function teamsTeamIgnoreRequestRpcPromise (request: (requestCommon & requ
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamIgnoreRequest', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamImplicitAdminsRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamImplicitAdminsResult) => void} & {param: teamsTeamImplicitAdminsRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamImplicitAdmins', request)
+}
+
+export function teamsTeamImplicitAdminsRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamImplicitAdminsResult) => void} & {param: teamsTeamImplicitAdminsRpcParam})): Promise<teamsTeamImplicitAdminsResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamImplicitAdmins', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamLeaveRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamLeaveRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamLeave', request)
 }
@@ -6352,6 +6360,10 @@ export type teamsTeamIgnoreRequestRpcParam = Exact<{
   username: string
 }>
 
+export type teamsTeamImplicitAdminsRpcParam = Exact<{
+  teamName: string
+}>
+
 export type teamsTeamLeaveRpcParam = Exact<{
   name: string,
   permanent: boolean
@@ -6665,6 +6677,7 @@ type teamsTeamCreateResult = TeamCreateResult
 type teamsTeamCreateSeitanTokenResult = string
 type teamsTeamCreateWithSettingsResult = TeamCreateResult
 type teamsTeamGetResult = TeamDetails
+type teamsTeamImplicitAdminsResult = ?Array<TeamMemberDetails>
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList
 type teamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1380,6 +1380,22 @@
       ],
       "response": "TeamDetails"
     },
+    "teamImplicitAdmins": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "teamName",
+          "type": "string"
+        }
+      ],
+      "response": {
+        "type": "array",
+        "items": "TeamMemberDetails"
+      }
+    },
     "teamList": {
       "request": [
         {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2498,6 +2498,14 @@ export function teamsTeamIgnoreRequestRpcPromise (request: (requestCommon & requ
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamIgnoreRequest', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsTeamImplicitAdminsRpcChannelMap (configKeys: Array<string>, request: requestCommon & {callback?: ?(err: ?any, response: teamsTeamImplicitAdminsResult) => void} & {param: teamsTeamImplicitAdminsRpcParam}): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamImplicitAdmins', request)
+}
+
+export function teamsTeamImplicitAdminsRpcPromise (request: (requestCommon & {callback?: ?(err: ?any, response: teamsTeamImplicitAdminsResult) => void} & {param: teamsTeamImplicitAdminsRpcParam})): Promise<teamsTeamImplicitAdminsResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.teamImplicitAdmins', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamLeaveRpcChannelMap (configKeys: Array<string>, request: requestCommon & requestErrorCallback & {param: teamsTeamLeaveRpcParam}): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamLeave', request)
 }
@@ -6352,6 +6360,10 @@ export type teamsTeamIgnoreRequestRpcParam = Exact<{
   username: string
 }>
 
+export type teamsTeamImplicitAdminsRpcParam = Exact<{
+  teamName: string
+}>
+
 export type teamsTeamLeaveRpcParam = Exact<{
   name: string,
   permanent: boolean
@@ -6665,6 +6677,7 @@ type teamsTeamCreateResult = TeamCreateResult
 type teamsTeamCreateSeitanTokenResult = string
 type teamsTeamCreateWithSettingsResult = TeamCreateResult
 type teamsTeamGetResult = TeamDetails
+type teamsTeamImplicitAdminsResult = ?Array<TeamMemberDetails>
 type teamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type teamsTeamListResult = AnnotatedTeamList
 type teamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>


### PR DESCRIPTION
Add RPC to get implicit admins. So the gui can show implicit admins in the member list for subteams.

Picture of the goal. This PR is just an RPC.
![image](https://user-images.githubusercontent.com/705646/32251869-478c2f50-be69-11e7-9afd-0ce3833ce972.png)
