### PR TITLE
Fix a bad case of circular locking w/r/t GetUID in startup

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -484,7 +484,7 @@ func (e *loginProvision) ppStream(ctx *Context) (*libkb.PassphraseStream, error)
 // deviceName gets a new device name from the user.
 func (e *loginProvision) deviceName(ctx *Context) (string, error) {
 	var names []string
-	upk, _, err := e.G().GetUPAKLoader().LoadV2(libkb.NewLoadUserByUIDArg(ctx.GetNetContext(), e.G(), e.arg.User.GetUID()).WithPublicKeyOptional().WithForcePoll(true))
+	upk, _, err := e.G().GetUPAKLoader().LoadV2(libkb.NewLoadUserByUIDArg(ctx.GetNetContext(), e.G(), e.arg.User.GetUID()).WithPublicKeyOptional().WithForcePoll(true).WithSelf(true))
 	if err != nil {
 		e.G().Log.Debug("error getting device names via upak: %s", err)
 		e.G().Log.Debug("proceeding to ask user for a device name despite error...")

--- a/go/libkb/full_self_cacher.go
+++ b/go/libkb/full_self_cacher.go
@@ -217,7 +217,7 @@ func (m *CachedFullSelf) Update(ctx context.Context, u *User) (err error) {
 	//   	return
 	//   }
 	//
-	// BUT IS IT DEADLY! The problem is that m.G().GetMyUID() calls into LoginState, but often
+	// BUT IT IS DEADLY! The problem is that m.G().GetMyUID() calls into LoginState, but often
 	// we're being called from a LoginState context, so we get a circular locking situation.
 	// So the onus is on the caller to check that we're actually loading self.
 

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -268,7 +268,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		if user != nil && err == nil {
 			// Update the full-self cacher after the lock is released, to avoid
 			// any circular locking.
-			if fs := u.G().GetFullSelfer(); fs != nil {
+			if fs := u.G().GetFullSelfer(); fs != nil && arg.self {
 				fs.Update(ctx, user)
 			}
 		}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -406,19 +406,19 @@ func (d *Service) identifySelf() {
 	// identify2 did a load user for self, so find it and cache it in FullSelfer.
 	them := eng.FullThemUser()
 	me := eng.FullMeUser()
-	var u *libkb.User
+	var self *libkb.User
 	if them != nil && them.GetUID().Equal(uid) {
 		d.G().Log.Debug("identifySelf: using them for full user")
-		u = them
+		self = them
 	} else if me != nil && me.GetUID().Equal(uid) {
 		d.G().Log.Debug("identifySelf: using me for full user")
-		u = me
+		self = me
 	}
-	if u != nil {
-		if err := d.G().GetFullSelfer().Update(context.Background(), u); err != nil {
+	if self != nil {
+		if err := d.G().GetFullSelfer().Update(context.Background(), self); err != nil {
 			d.G().Log.Debug("identifySelf: error updating full self cache: %s", err)
 		} else {
-			d.G().Log.Debug("identifySelf: updated full self cache for: %s", u.GetName())
+			d.G().Log.Debug("identifySelf: updated full self cache for: %s", self.GetName())
 		}
 	}
 }


### PR DESCRIPTION
- The first bug was that we had a UPAK load without the 'Self' flag set
- The second bug was that a call into CachedFullSelf from UPAK would attempt to reaccess LoginState to GetMyUID