### PR TITLE
systemd support for GUI and packaging

### DIFF
--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -147,6 +147,11 @@ build_one_architecture() {
   mkdir -p "$apps_dir"
   cp "$here/keybase.desktop" "$apps_dir"
 
+  # Copy in the systemd unit files.
+  units_dir="$layout_dir/usr/lib/systemd/user"
+  mkdir -p "$units_dir"
+  cp "$here/systemd"/* "$units_dir"
+
   # Check for whitespace in all the filenames we've copied. We don't support
   # whitespace in our later build scripts (for example RPM packaging), and even
   # if we did, it would be bad practice to use it.

--- a/packaging/linux/systemd/keybase.gui.service
+++ b/packaging/linux/systemd/keybase.gui.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Keybase GUI
+Wants=keybase.service kbfs.service
+
+[Service]
+Type=simple
+ExecStart=/opt/keybase/Keybase
+
+# We don't set Restart=, since a GUI crash is probably visible to the user.
+
+# We don't have an [Install] section, since the app is intended to be started
+# from ~/.config/autostart. Running it in e.g. an SSH session is unlikely to be
+# correct.


### PR DESCRIPTION
r? @maxtaco 

The plan is to avoid using systemd to autostart or restart the GUI, but still to log to the systemd journal, for consistency with the core and kbfs services.