### PR TITLE
change run_keybase to use systemd

### DIFF
--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -5,36 +5,62 @@ set -e -u -o pipefail
 # This is the script responsible for launching keybase on boot on Linux. A
 # .desktop file will be created by the service on first launch in
 # ~/.config/autostart/ to invoke this script.
-#
-# At some point, it would be nice to have all of this done by systemd, so that
-# we could use all the nice facilities for restart-on-crash and dependency
-# relationships and logging. But until systemd is more widely deployed, it's
-# easier to do everything this way.
+
+exit_success() {
+  echo 'Success!'
+  # Magical squirrel produced by https://github.com/erkin/ponysay
+  cat /opt/keybase/crypto_squirrel.txt
+  exit 0
+}
+
+legacy_kill() {
+  if killall Keybase &> /dev/null ; then
+    echo Shutting down Keybase GUI...
+  fi
+  if fusermount -uz /keybase &> /dev/null ; then
+    echo Unmounting /keybase...
+  fi
+  if killall kbfsfuse &> /dev/null ; then
+    echo Shutting down kbfsfuse...
+  fi
+  if killall keybase &> /dev/null ; then
+    echo Shutting down keybase service...
+  fi
+
+  # There is a race condition where if we try to start the keybase service before
+  # the previous process has died, we might fail to lock the pid file and error
+  # out. Avoid this by waiting for the lock file to be free, on systems with flock
+  # installed.
+  lockfile="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase/keybased.pid"
+  if which flock &> /dev/null && [ -e "$lockfile" ] ; then
+    flock "$lockfile" true
+  fi
+}
+
+# If systemd is available, we use it to manage everything.
+if which systemctl > /dev/null ; then
+  # For compatibility reasons, if the services weren't started with systemd, we
+  # need to kill them the old fashioned way. TODO: Eventually delete this.
+  systemd_token="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase/started_with_systemd"
+  if [ ! -e "$systemd_token" ] ; then
+    legacy_kill
+  fi
+  echo Starting via systemd.
+  # The keybase.gui.service unit has keybase.service and kbfs.service as
+  # dependencies, so we don't have to list them here. But including them lets
+  # us report an error if they fail to start.
+  systemctl --user start keybase.service kbfs.service keybase.gui.service
+  mkdir -p "$(dirname "$systemd_token")"
+  touch "$systemd_token"
+  exit_success
+fi
+
+echo Systemd not available. Starting in the background.
 
 # Stop any existing services. These commands will return errors if keybase
 # isn't already running, but putting them in if-statements prevents those
 # errors from aborting the whole script.
-if killall Keybase &> /dev/null ; then
-  echo Shutting down Keybase GUI...
-fi
-if fusermount -uz /keybase &> /dev/null ; then
-  echo Unmounting /keybase...
-fi
-if killall kbfsfuse &> /dev/null ; then
-  echo Shutting down kbfsfuse...
-fi
-if killall keybase &> /dev/null ; then
-  echo Shutting down keybase service...
-fi
-
-# There is a race condition where if we try to start the keybase service before
-# the previous process has died, we might fail to lock the pid file and error
-# out. Avoid this by waiting for the lock file to be free, on systems with flock
-# installed.
-lockfile="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase/keybased.pid"
-if which flock &> /dev/null && [ -e "$lockfile" ] ; then
-  flock "$lockfile" true
-fi
+legacy_kill
 
 export KEYBASE_RUN_MODE="${KEYBASE_RUN_MODE:-prod}"
 export KEYBASE_DEBUG=1
@@ -50,6 +76,4 @@ kbfsfuse -debug -log-to-file /keybase &>> "$logdir/keybase.start.log" &
 echo Launching Keybase GUI...
 /opt/keybase/Keybase &>> "$logdir/Keybase.app.log" &
 
-echo 'Success!'
-# Magical squirrel produced by https://github.com/erkin/ponysay
-cat /opt/keybase/crypto_squirrel.txt
+exit_success

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -5,15 +5,38 @@ set -e -u -o pipefail
 # This is the script responsible for launching keybase on boot on Linux. A
 # .desktop file will be created by the service on first launch in
 # ~/.config/autostart/ to invoke this script.
+#
+# We're in the process of adding support for systemd. If you're running systemd
+# and you set the environment variable KEYBASE_SYSTEMD=1, we'll start as
+# systemd user-level services. At some point
 
-exit_success() {
-  echo 'Success!'
-  # Magical squirrel produced by https://github.com/erkin/ponysay
-  cat /opt/keybase/crypto_squirrel.txt
-  exit 0
+runtime_dir="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase"
+startup_token="$runtime_dir/startup_mode"
+
+systemd_running() {
+    # Mirrors https://www.freedesktop.org/software/systemd/man/sd_booted.html.
+    [ -d "/run/systemd/system" ]
 }
 
-legacy_kill() {
+was_started_with_systemd() {
+    [ -e "$startup_token" ] && [ "$(cat "$startup_token")" = "systemd" ]
+}
+
+# Currently defaults to false unless KEYBASE_SYSTEMD=1. This default will
+# change in the future.
+wants_systemd() {
+    [ "${KEYBASE_SYSTEMD:-0}" = "1" ] && systemd_running
+}
+
+write_startup_token() {
+  mkdir -p "$(dirname "$startup_token")"
+  echo "$1" > "$startup_token"
+}
+
+# This works no matter how the services were started, because our
+# Restart=on-failure configuration won't restart after SIGTERM. However, the
+# systemd-to-systemd case shouldn't call it.
+kill_all() {
   if killall Keybase &> /dev/null ; then
     echo Shutting down Keybase GUI...
   fi
@@ -31,49 +54,58 @@ legacy_kill() {
   # the previous process has died, we might fail to lock the pid file and error
   # out. Avoid this by waiting for the lock file to be free, on systems with flock
   # installed.
-  lockfile="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase/keybased.pid"
+  lockfile="$runtime_dir/keybased.pid"
   if which flock &> /dev/null && [ -e "$lockfile" ] ; then
     flock "$lockfile" true
   fi
 }
 
-# If systemd is available, we use it to manage everything.
-if which systemctl > /dev/null ; then
-  # For compatibility reasons, if the services weren't started with systemd, we
-  # need to kill them the old fashioned way. TODO: Eventually delete this.
-  systemd_token="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase/started_with_systemd"
-  if [ ! -e "$systemd_token" ] ; then
-    legacy_kill
+start_systemd() {
+  # If the services weren't started with systemd, we need to kill them.
+  if ! was_started_with_systemd ; then
+    kill_all
+    # Our non-systemd services tend to delete systemd's socket files. Make sure
+    # they get recreated.
+    systemctl --user stop keybase.socket kbfs.socket
   fi
   echo Starting via systemd.
   # The keybase.gui.service unit has keybase.service and kbfs.service as
   # dependencies, so we don't have to list them here. But including them lets
   # us report an error if they fail to start.
   systemctl --user start keybase.service kbfs.service keybase.gui.service
-  mkdir -p "$(dirname "$systemd_token")"
-  touch "$systemd_token"
-  exit_success
-fi
+  write_startup_token "systemd"
+}
 
-echo Systemd not available. Starting in the background.
+start_background() {
+  # Always restart any running services. (Reliably detecting whether services
+  # are running is tricky. Leave it to systemd.)
+  kill_all
 
-# Stop any existing services. These commands will return errors if keybase
-# isn't already running, but putting them in if-statements prevents those
-# errors from aborting the whole script.
-legacy_kill
+  export KEYBASE_RUN_MODE="${KEYBASE_RUN_MODE:-prod}"
+  export KEYBASE_DEBUG=1
+  logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
+  mkdir -p "$logdir"
 
-export KEYBASE_RUN_MODE="${KEYBASE_RUN_MODE:-prod}"
-export KEYBASE_DEBUG=1
-logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
-mkdir -p "$logdir"
+  echo Launching keybase service...
+  # We set the --auto-forked flag here so that updated clients that try to
+  # restart this service will know to re-fork it themselves. That's all it does.
+  keybase -d --log-file="$logdir/keybase.service.log" service --auto-forked &>> "$logdir/keybase.start.log" &
+  echo Mounting /keybase...
+  kbfsfuse -debug -log-to-file /keybase &>> "$logdir/keybase.start.log" &
+  echo Launching Keybase GUI...
+  /opt/keybase/Keybase &>> "$logdir/Keybase.app.log" &
+  write_startup_token "background"
+}
 
-echo Launching keybase service...
-# We set the --auto-forked flag here so that updated clients that try to
-# restart this service will know to re-fork it themselves. That's all it does.
-keybase -d --log-file="$logdir/keybase.service.log" service --auto-forked &>> "$logdir/keybase.start.log" &
-echo Mounting /keybase...
-kbfsfuse -debug -log-to-file /keybase &>> "$logdir/keybase.start.log" &
-echo Launching Keybase GUI...
-/opt/keybase/Keybase &>> "$logdir/Keybase.app.log" &
+main() {
+  if wants_systemd ; then
+      start_systemd
+  else
+      start_background
+  fi
+  echo 'Success!'
+  # Magical squirrel produced by https://github.com/erkin/ponysay
+  cat /opt/keybase/crypto_squirrel.txt
+}
 
-exit_success
+main


### PR DESCRIPTION
r? @maxtaco 

The main detail here is how we handle the situation where you start the old way, and then updatte your keybase package while those services are still running, then run `run_keybase`.

Landing this will be how we PUSH THE BUTTON for shipping systemd, so I'm not going to merge until everything else is ready.