### PR TITLE
never call reset from outside of the service

### DIFF
--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -86,7 +86,6 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
     public void destroy(){
         try {
             executor.shutdownNow();
-            reset();
             executor.awaitTermination(30, TimeUnit.SECONDS);
             executor = null;
         } catch (Exception e) {


### PR DESCRIPTION
We think this call is hosing the Go side of the b64 bridge for mobile. At the very least, it is not needed and could likely cause a problem, so seeing what happens without is probably worth it.

cc @maxtaco @chrisnojima 