### PR TITLE
Add GreenLinkError and retry for team merkle-fetch race

### DIFF
--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -681,8 +681,6 @@ func TestGetTeamRootID(t *testing.T) {
 
 // Test that we can still load a valid link a signed by a now-revoked device.
 func TestTeamSignedByRevokedDevice(t *testing.T) {
-	t.Skip("Skipping due to buggy loader. Unskip by 11/2/2017")
-
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -268,3 +268,15 @@ func NewSubteamOwnersError() error { return &SubteamOwnersError{} }
 func (e SubteamOwnersError) Error() string {
 	return "Subteams cannot have owners. Try admin instead."
 }
+
+// The sigchain link is problematically new.
+type GreenLinkError struct{ seqno keybase1.Seqno }
+
+func NewGreenLinkError(seqno keybase1.Seqno) error {
+	return GreenLinkError{seqno: seqno}
+}
+
+func (e GreenLinkError) Error() string {
+	// Report the probable cause for this error.
+	return fmt.Sprintf("team sigchain is being rapidly updated (seqno: %v)", e.seqno)
+}


### PR DESCRIPTION
If a team chain is modified in the middle of a load of a team, there's a race that causes the load to fail. First it fetches from the merkle tree, then fetches links from the server. If a modification happened inbetween then the merkle leaf might be behind links. 

```
load2 = ->
  lastSeqno, lastLinkID := getMerkle() // <--- team at seqno 2
  // <-- seqno 3 posted to the team remotely
  links := fetchLinks() // <-- returns links up to seqno 3
  chain := process links
  assert(lastLinkID == chain.lastLinkID) <--- this would fail
```

This PR 'fixes' it by detecting when a link is fetched that's newer than the snapshot, and retrying the whole load thrice. The load will still fail if this happens 3 times in a row. But at that point there's probably too much contention on the chain to get anything done.

This is supposed to fix the flakiness of `TestTeamSignedByRevokedDevice`.

I have a test specifically for this race but it's not included because it has sleeps and probably isn't worth it.