### PR TITLE
if we have no inbox, dont return an error from this RPC

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -291,6 +291,10 @@ func (r *recentConversationParticipants) getActiveScore(ctx context.Context, con
 func (r *recentConversationParticipants) get(ctx context.Context, myUID gregor1.UID) (res []gregor1.UID, err error) {
 	_, convs, err := storage.NewInbox(r.G(), myUID).ReadAll(ctx)
 	if err != nil {
+		if _, ok := err.(storage.MissError); ok {
+			r.Debug(ctx, "get: no inbox, returning blank results")
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes a black bar error when you don't have a chat inbox cached on `InterestingPeople` call.

cc @chrisnojima 