### PR TITLE
turn on imp team chat for admins CORE-6351

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -199,8 +199,8 @@ func runWithMemberTypes(t *testing.T, f func(membersType chat1.ConversationMembe
 	t.Logf("Team Stage End: %v", time.Now().Sub(start))
 
 	t.Logf("Implicit Team Stage Begin")
-	os.Setenv("KEYBASE_CHAT_MEMBER_TYPE", "impteam")
-	defer os.Setenv("KEYBASE_CHAT_MEMBER_TYPE", "")
+	os.Setenv("KEYBASE_FEATURES", "admin")
+	defer os.Setenv("KEYBASE_FEATURES", "")
 	start = time.Now()
 	f(chat1.ConversationMembersType_IMPTEAM)
 	t.Logf("Implicit Team Stage End: %v", time.Now().Sub(start))

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2994,8 +2994,8 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 }
 
 func TestChatSrvImpTeamExistingKBFS(t *testing.T) {
-	os.Setenv("KEYBASE_CHAT_MEMBER_TYPE", "impteam")
-	defer os.Setenv("KEYBASE_CHAT_MEMBER_TYPE", "")
+	os.Setenv("KEYBASE_FEATURES", "admin")
+	defer os.Setenv("KEYBASE_FEATURES", "")
 	ctc := makeChatTestContext(t, "NewConversationLocal", 2)
 	defer ctc.cleanup()
 	users := ctc.users()

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1016,12 +1016,12 @@ func (e *Env) GetChatInboxSourceLocalizeThreads() int {
 }
 
 // GetChatMemberType returns the default member type for new conversations.
-// Currently defaults to `kbfs`, but `impteam` will be default in future.
+// Currently defaults to `kbfs`, but `impteam` will be default in future (and is the default for admins)
 func (e *Env) GetChatMemberType() string {
-	return e.GetString(
-		func() string { return os.Getenv("KEYBASE_CHAT_MEMBER_TYPE") },
-		func() string { return "kbfs" },
-	)
+	if e.GetFeatureFlags().Admin() {
+		return "impteam"
+	}
+	return "kbfs"
 }
 
 func (e *Env) GetDeviceID() keybase1.DeviceID {

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -3,11 +3,11 @@ import * as ChatTypes from '../../constants/types/flow-types-chat'
 import * as Constants from '../../constants/chat'
 import * as ChatGen from '../chat-gen'
 import * as I from 'immutable'
-import getenv from 'getenv'
 import {CommonTLFVisibility, TlfKeysTLFIdentifyBehavior} from '../../constants/types/flow-types'
 import {call, put, select} from 'redux-saga/effects'
 import {parseFolderNameToUsers} from '../../util/kbfs'
 import {usernameSelector} from '../../constants/selectors'
+import flags from '../../util/feature-flags'
 
 import type {TypedState} from '../../constants/reducer'
 
@@ -81,8 +81,7 @@ function* startNewConversation(
     console.warn("Shouldn't happen in practice")
     return [null, null]
   }
-
-  const membersType = getenv('KEYBASE_CHAT_MEMBER_TYPE', 'kbfs') === 'impteam'
+  const membersType = flags.admin
     ? ChatTypes.CommonConversationMembersType.impteam
     : ChatTypes.CommonConversationMembersType.kbfs
   const result = yield call(ChatTypes.localNewConversationLocalRpcPromise, {

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -81,7 +81,7 @@ function* startNewConversation(
     console.warn("Shouldn't happen in practice")
     return [null, null]
   }
-  const membersType = flags.admin
+  const membersType = flags.impTeamChatEnabled
     ? ChatTypes.CommonConversationMembersType.impteam
     : ChatTypes.CommonConversationMembersType.kbfs
   const result = yield call(ChatTypes.localNewConversationLocalRpcPromise, {

--- a/shared/util/feature-flags.desktop.js
+++ b/shared/util/feature-flags.desktop.js
@@ -20,9 +20,12 @@ const ff: FeatureFlags = {
   tabGitEnabled: true,
   tabPeopleEnabled: true,
   teamChatEnabled: true,
+  impTeamChatEnabled: false,
 }
 
-const inAdmin: {[key: $Keys<FeatureFlags>]: boolean} = {}
+const inAdmin: {[key: $Keys<FeatureFlags>]: boolean} = {
+  impTeamChatEnabled: true,
+}
 
 // load overrides
 Object.keys(ff).forEach(k => {

--- a/shared/util/feature-flags.js.flow
+++ b/shared/util/feature-flags.js.flow
@@ -8,6 +8,7 @@ export type FeatureFlags = {|
   tabPeopleEnabled: boolean,
   teamChatEnabled: boolean,
   tabGitEnabled: boolean,
+  impTeamChatEnabled: boolean,
 |}
 
 const ff: FeatureFlags = {
@@ -18,6 +19,7 @@ const ff: FeatureFlags = {
   tabPeopleEnabled: false,
   teamChatEnabled: false,
   tabGitEnabled: false,
+  impTeamChatEnabled: false,
 }
 
 export default ff

--- a/shared/util/feature-flags.native.js
+++ b/shared/util/feature-flags.native.js
@@ -10,6 +10,7 @@ const ff: FeatureFlags = {
   tabPeopleEnabled: false,
   teamChatEnabled: true,
   tabGitEnabled: true,
+  impTeamChatEnabled: false,
 }
 
 if (__DEV__) {


### PR DESCRIPTION
Turns on implicit team chats for admins (`KEYBASE_FEATURES=admin`).