### PR TITLE
Move externals/test_common.go into its own package

### DIFF
--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/keybase/client/go/chat/signencrypt"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/engine"
-	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/externalstest"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -67,7 +67,7 @@ func textMsgWithHeader(t *testing.T, text string, header chat1.MessageClientHead
 }
 
 func setupChatTest(t *testing.T, name string) (*kbtest.ChatTestContext, *Boxer) {
-	tc := externals.SetupTest(t, name, 2)
+	tc := externalstest.SetupTest(t, name, 2)
 
 	// use an insecure triplesec in tests
 	tc.G.NewTriplesec = func(passphrase []byte, salt []byte) (libkb.Triplesec, error) {

--- a/go/chat/storage/common_test.go
+++ b/go/chat/storage/common_test.go
@@ -3,13 +3,13 @@ package storage
 import (
 	"testing"
 
-	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/externalstest"
 	"github.com/keybase/client/go/libkb"
 	insecureTriplesec "github.com/keybase/go-triplesec-insecure"
 )
 
 func setupCommonTest(t testing.TB, name string) libkb.TestContext {
-	tc := externals.SetupTest(t, name, 2)
+	tc := externalstest.SetupTest(t, name, 2)
 
 	// use an insecure triplesec in tests
 	tc.G.NewTriplesec = func(passphrase []byte, salt []byte) (libkb.Triplesec, error) {

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/externalstest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	insecureTriplesec "github.com/keybase/go-triplesec-insecure"
@@ -18,7 +18,7 @@ import (
 )
 
 func SetupEngineTest(tb libkb.TestingTB, name string) libkb.TestContext {
-	tc := externals.SetupTest(tb, name, 2)
+	tc := externalstest.SetupTest(tb, name, 2)
 
 	// use an insecure triplesec in tests
 	tc.G.NewTriplesec = func(passphrase []byte, salt []byte) (libkb.Triplesec, error) {
@@ -33,7 +33,7 @@ func SetupEngineTest(tb libkb.TestingTB, name string) libkb.TestContext {
 }
 
 func SetupEngineTestRealTriplesec(tb libkb.TestingTB, name string) libkb.TestContext {
-	tc := externals.SetupTest(tb, name, 2)
+	tc := externalstest.SetupTest(tb, name, 2)
 	tc.G.NewTriplesec = libkb.NewSecureTriplesec
 	return tc
 }

--- a/go/externalstest/test_common.go
+++ b/go/externalstest/test_common.go
@@ -3,9 +3,10 @@
 
 // +build !production
 
-package externals
+package externalstest
 
 import (
+	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/pvlsource"
 	"github.com/keybase/client/go/uidmap"
@@ -14,7 +15,7 @@ import (
 func SetupTest(tb libkb.TestingTB, name string, depth int) (tc libkb.TestContext) {
 	ret := libkb.SetupTest(tb, name, depth+1)
 
-	ret.G.SetServices(GetServices())
+	ret.G.SetServices(externals.GetServices())
 	ret.G.SetUIDMapper(uidmap.NewUIDMap(10000))
 	pvlsource.NewPvlSourceAndInstall(ret.G)
 	return ret

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -15,7 +15,7 @@ import (
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
-	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/externalstest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
@@ -70,7 +70,7 @@ func NewChatMockWorld(t *testing.T, name string, numUsers int) (world *ChatMockW
 		Msgs:    make(map[string][]*chat1.MessageBoxed),
 	}
 	for i := 0; i < numUsers; i++ {
-		kbTc := externals.SetupTest(t, "chat_"+name, 0)
+		kbTc := externalstest.SetupTest(t, "chat_"+name, 0)
 		tc := ChatTestContext{
 			TestContext: kbTc,
 			ChatG:       &globals.ChatContext{},

--- a/go/systests/common_test.go
+++ b/go/systests/common_test.go
@@ -6,14 +6,14 @@ package systests
 import (
 	"path/filepath"
 
-	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/externalstest"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
 )
 
 func setupTest(t libkb.TestingTB, nm string) *libkb.TestContext {
-	tc := externals.SetupTest(t, nm, 2)
+	tc := externalstest.SetupTest(t, nm, 2)
 	tc.SetRuntimeDir(filepath.Join(tc.Tp.Home, "run"))
 	if err := tc.G.ConfigureSocketInfo(); err != nil {
 		t.Fatal(err)

--- a/go/teams/common_test.go
+++ b/go/teams/common_test.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/externalstest"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -14,7 +14,7 @@ import (
 )
 
 func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
-	tc = externals.SetupTest(tb, name, depth+1)
+	tc = externalstest.SetupTest(tb, name, depth+1)
 
 	// use an insecure triplesec in tests
 	tc.G.NewTriplesec = func(passphrase []byte, salt []byte) (libkb.Triplesec, error) {


### PR DESCRIPTION
This is so that packages that want to use externals for proof checking
etc. don't have to pull in the large uidmap package.