### PR TITLE
Define getFollowingMap in team constants

### DIFF
--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -219,7 +219,7 @@ const getConversationIDKeyFromChannelName = (state: TypedState, channelname: str
 const getParticipants = (state: TypedState, conversationIDKey: ChatConstants.ConversationIDKey) =>
   state.entities.getIn(['teams', 'convIDToChannelInfo', conversationIDKey, 'participants'], I.Set())
 
-export const getFollowingMap = ChatConstants.getFollowingMap
+export const getFollowingMap = (state: TypedState) => state.config.following
 export const getFollowerMap = (state: TypedState) => state.config.followers
 
 export {getConversationIDKeyFromChannelName, getParticipants, userIsInTeamHelper}


### PR DESCRIPTION
For some reason, plumbing through `getFollowingMap` from `constants/chat` isn't working anymore. This broke the team page, which I plumbed the selector through for. One-liner to fix.

r? @keybase/react-hackers 

(also, I have no clue why plumbing through the export isn't working anymore. @chrisnojima any insight?)