### PR TITLE
add a time sort for jump to chat, fix exact match, and document scoring function better

### DIFF
--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -137,7 +137,7 @@ const getFilteredSmallRowItems = createSelector(
         return {
           conversationIDKey,
           filterScore: i
-            ? scoreFilter(lcFilter, i.teamname || '', i.get('participants').toArray(), lcYou)
+            ? scoreFilter(lcFilter, i.teamname || '', i.get('participants').toArray(), lcYou, i.get('time'))
             : 0,
         }
       })

--- a/shared/chat/inbox/filtering.js
+++ b/shared/chat/inbox/filtering.js
@@ -13,37 +13,87 @@ const _passesParticipantFilter = (lcFilter: string, lcParticipants: Array<string
   return passesStringFilter(lcFilter, names.join(','))
 }
 
-// // Simple score for a filter. returns 1 for exact match. 0.75 for full name match
-// // in a group conversation. 0.5 for a partial match
-// // 0 for no match
-const scoreFilter = (
+const scoreFilterName = (
   lcFilter: string,
   lcStringToFilterOn: string,
   lcParticipants: Array<string>,
   lcYou: string
 ) => {
+  // If we end up inside this if, that means we are scoring a non-team conversation.
   if (!lcStringToFilterOn && lcParticipants.length) {
-    if (lcFilter === lcYou) {
-      return 1
-    }
+    // We favor smaller groups here, with a conversation of size 1 giving the best score. A conversation
+    // with 100 participants would score 0.75. NOTE: anything over 100 will start to fall below 0.75.
     if (lcParticipants.some(p => p === lcFilter)) {
       return 1 - (lcParticipants.length - 1) / 100 * 0.25
     }
 
+    // As long as we hit something on the conversation, we give it a 0.5
     if (_passesParticipantFilter(lcFilter, lcParticipants, lcYou)) {
       return 0.5
     }
   }
 
-  if (lcFilter === lcStringToFilterOn) {
-    return 1
-  }
-
+  // This likely is checking the team name of the conversation against the filter. If we get any sort
+  // of hit we just give it 0.5
   if (passesStringFilter(lcFilter, lcStringToFilterOn)) {
     return 0.5
   }
 
   return 0
+}
+
+const scoreFilterTime = (lcTime: number) => {
+  // Give a score for how old the time is on a scale of now to 2 weeks ago. Anything older
+  // than two weeks is just all the same to us.
+  const timeVal = 1 - (Date.now() - lcTime) / (86400 * 14 * 1000)
+  return Math.min(1, Math.max(0, timeVal))
+}
+
+const isExactMatch = (
+  lcFilter: string,
+  lcStringToFilterOn: string,
+  lcParticipants: Array<string>,
+  lcYou: string
+) => {
+  const partsWithoutYou = lcParticipants.filter(p => p !== lcYou)
+  if (lcStringToFilterOn) {
+    // Exact match on the supplied name (usually a team name)
+    return lcFilter === lcStringToFilterOn
+  } else if (partsWithoutYou.length === 1) {
+    // Exact match on a the convo name without yourself in it (ex. mikem,max exact matches max when mikem
+    // searches.
+    return partsWithoutYou[0] === lcFilter
+  } else {
+    // Special case when searching for the conversation with yourself
+    return lcParticipants.length === 1 && lcParticipants[0] === lcFilter && lcFilter === lcYou
+  }
+}
+
+// Simple score for a filter.  Weight two quantities equally: the quality of the name match, and how
+// recent the conversation has changed. If it is an exact match, we return a score of 1.
+// [1,0.75] for full name match in a group conversation. 0.5 for a partial match and 0 for no match.
+// The time score is a value that gives max score to a conversation that has changed at the current time,
+// and a 0 to any conversation older than two weeks ago, with a range in between.
+const scoreFilter = (
+  lcFilter: string,
+  lcStringToFilterOn: string,
+  lcParticipants: Array<string>,
+  lcYou: string,
+  lcTime: number
+) => {
+  // Check exact match first to early out with a max score
+  if (isExactMatch(lcFilter, lcStringToFilterOn, lcParticipants, lcYou)) {
+    return 1
+  }
+  // Grab the name score first since it also acts as a filter. A score of 0 here indicates no match.
+  const nameScore = scoreFilterName(lcFilter, lcStringToFilterOn, lcParticipants, lcYou)
+  let timeScore = 0
+  if (nameScore > 0) {
+    // Run the time score if we hit a match at all
+    timeScore = scoreFilterTime(lcTime)
+  }
+  // Weight the two score equally for our final result
+  return 0.5 * nameScore + 0.5 * timeScore
 }
 
 export {scoreFilter, passesStringFilter}


### PR DESCRIPTION
Patch does the following:

1.) Adds a new component to the "Jump to Chat" scoring function, which is the time the conversation last had activity. We weight the score from this function equally with the quality of the name match that we had before. The comments in the diff explain this in more detail.
2.) Make the "exact match" case more explicit in the code.
3.) Fix sorting the conversation with only yourself in it.
4.) Add a lot more comments so it is easier to figure out what is going on in the scoring function.

The purpose of this is to improve the quality of the results we get back from "Jump to Chat". It has been frustrating to search for like "chri", and get like 20 conversations before my "chris" conversation that is near the top of my inbox.

@keybase/react-hackers 