### PR TITLE
make `keybase log send` read from journalctl when running under systemd

### DIFF
--- a/go/libkb/log_send.go
+++ b/go/libkb/log_send.go
@@ -262,7 +262,13 @@ func tailSystemdJournal(log logger.Logger, which string, numBytes int) (ret stri
 	guessedLines := numBytes / 150
 	maxBytes := numBytes * 2
 
-	journalCmd := exec.Command("journalctl", "--user", "--unit", which, "--lines", strconv.Itoa(guessedLines))
+	journalCmd := exec.Command(
+		"journalctl",
+		"--user",
+		"--unit="+which,
+		"--lines="+strconv.Itoa(guessedLines),
+		"--output=cat",
+	)
 	journalCmd.Stderr = os.Stderr
 	stdout, err := journalCmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
r? @maxtaco 

Commits from https://github.com/keybase/client/pull/9373 and https://github.com/keybase/client/pull/9343 are dependencies here, so I've included them in this branch. But please only look at the topmost commit, currently 2bb2484.

~This is the third and final Pull The Lever PR. These three will all need to go in at the same time. (We could consider adding some kind of feature gate, but it would need to somehow get read by both client Go code and the run_keybase script, so I've avoided doing it.)~ Edit: Changed it to be gated on `KEYBASE_SYSTEMD=1` like the others.