### PR TITLE
support for home.avdl RPCs

### DIFF
--- a/go/client/cmd_home.go
+++ b/go/client/cmd_home.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
 package client

--- a/go/client/cmd_home.go
+++ b/go/client/cmd_home.go
@@ -1,0 +1,92 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+	"strings"
+)
+
+type CmdHome struct {
+	libkb.Contextified
+	markViewed bool
+	skipTodo   keybase1.HomeScreenTodoType
+}
+
+func (c *CmdHome) ParseArgv(ctx *cli.Context) error {
+	c.markViewed = ctx.Bool("mark-viewed")
+	s := ctx.String("skip-todo")
+	if len(s) > 0 {
+		var ok bool
+		if c.skipTodo, ok = keybase1.HomeScreenTodoTypeMap[strings.ToUpper(s)]; !ok {
+			return fmt.Errorf("unknown todo type: %s", s)
+		}
+	}
+	return nil
+}
+
+func (c *CmdHome) Run() error {
+	cli, err := GetHomeClient(c.G())
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	if c.skipTodo != keybase1.HomeScreenTodoType_NONE {
+		return c.doSkipTodo(ctx, cli)
+	}
+	return c.getHome(ctx, cli)
+}
+
+func (c *CmdHome) doSkipTodo(ctx context.Context, cli keybase1.HomeClient) error {
+	return cli.HomeSkipTodoType(ctx, c.skipTodo)
+}
+
+func (c *CmdHome) getHome(ctx context.Context, cli keybase1.HomeClient) error {
+	screen, err := cli.HomeGetScreen(ctx, c.markViewed)
+	if err != nil {
+		return err
+	}
+	b, err := json.Marshal(screen)
+	if err != nil {
+		return err
+	}
+	return c.G().UI.GetTerminalUI().OutputDesc(OutputDescriptorHomeDump, string(b)+"\n")
+}
+
+func NewCmdHomeRunner(g *libkb.GlobalContext) *CmdHome {
+	return &CmdHome{Contextified: libkb.NewContextified(g)}
+}
+
+func NewCmdHome(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "home",
+		Usage: "Get and set the 'home' screen",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdHomeRunner(g), "home", c)
+		},
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "mark-viewed",
+				Usage: "Mark the home page as 'viewed'.",
+			},
+			cli.StringFlag{
+				Name:  "skip-todo",
+				Usage: "skip a category of home TODO items",
+			},
+		},
+	}
+}
+
+func (c *CmdHome) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -34,6 +34,7 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdDumpPushNotifications(cl, g),
 		NewCmdEncrypt(cl, g),
 		NewCmdGit(cl, g),
+		NewCmdHome(cl, g),
 		NewCmdID(cl, g),
 		NewCmdInterestingPeople(cl, g),
 		NewCmdListTracking(cl, g),

--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -65,4 +65,5 @@ const (
 	OutputDescriptorGeneric libkb.OutputDescriptor = iota
 	OutputDescriptorPrimaryPaperKey
 	OutputDescriptorEndageredTLFs
+	OutputDescriptorHomeDump
 )

--- a/go/client/rpc.go
+++ b/go/client/rpc.go
@@ -362,3 +362,12 @@ func GetGitClient(g *libkb.GlobalContext) (cli keybase1.GitClient, err error) {
 	cli = keybase1.GitClient{Cli: rcli}
 	return cli, nil
 }
+
+func GetHomeClient(g *libkb.GlobalContext) (cli keybase1.HomeClient, err error) {
+	rcli, _, err := GetRPCClientWithContext(g)
+	if err != nil {
+		return cli, err
+	}
+	cli = keybase1.HomeClient{Cli: rcli}
+	return cli, nil
+}

--- a/go/home/home.go
+++ b/go/home/home.go
@@ -84,9 +84,9 @@ func (h *Home) Get(ctx context.Context, markViewed bool) (ret keybase1.HomeScree
 			h.G().Log.CDebugf(ctx, "| hit cache (cached %s ago)", diff)
 			if markViewed {
 				h.G().Log.CDebugf(ctx, "| going to server to mark view, anyways")
-				tmp := h.markViewed(ctx)
-				if tmp != nil {
-					h.G().Log.CInfof(ctx, "Error marking home as viewed: %s", tmp.Error())
+				tmpErr := h.markViewed(ctx)
+				if tmpErr != nil {
+					h.G().Log.CInfof(ctx, "Error marking home as viewed: %s", tmpErr.Error())
 				}
 			}
 			return h.cache.obj, nil

--- a/go/home/home.go
+++ b/go/home/home.go
@@ -1,0 +1,205 @@
+package home
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/keybase/client/go/gregor"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+	"sync"
+	"time"
+)
+
+type cache struct {
+	obj      keybase1.HomeScreen
+	cachedAt time.Time
+}
+
+type Home struct {
+	libkb.Contextified
+
+	sync.Mutex
+	cache *cache
+}
+
+type rawGetHome struct {
+	Status      libkb.AppStatus `json:"status"`
+	VisitRecord *struct {
+		Visits  int           `json:"visits"`
+		Atime   keybase1.Time `json:"atime"`
+		Version int           `json:"version"`
+	} `json:"visit_record"`
+	TodoList []struct {
+		Badged bool                        `json:"badged"`
+		Type   keybase1.HomeScreenTodoType `json:"type"`
+	} `json:"todo_list"`
+}
+
+func (r *rawGetHome) GetAppStatus() *libkb.AppStatus {
+	return &r.Status
+}
+
+func NewHome(g *libkb.GlobalContext) *Home {
+	home := &Home{Contextified: libkb.NewContextified(g)}
+	g.AddLogoutHook(home)
+	return home
+}
+
+func (h *Home) get(ctx context.Context, markedViewed bool) (ret keybase1.HomeScreen, err error) {
+	defer h.G().CTrace(ctx, "Home#get", func() error { return err })()
+
+	arg := libkb.NewAPIArgWithNetContext(ctx, "home")
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	arg.Args = libkb.HTTPArgs{
+		"record_visit": libkb.B{Val: markedViewed},
+	}
+	var raw rawGetHome
+	if err = h.G().API.GetDecode(arg, &raw); err != nil {
+		return ret, err
+	}
+	for _, item := range raw.TodoList {
+		ret.Items = append(ret.Items, keybase1.HomeScreenItem{
+			Data:   keybase1.NewHomeScreenItemDataWithTodo(keybase1.NewHomeScreenTodoDefault(item.Type)),
+			Badged: item.Badged,
+		})
+	}
+	if raw.VisitRecord != nil {
+		ret.LastViewed = raw.VisitRecord.Atime
+		ret.Version = raw.VisitRecord.Version
+	}
+	return ret, err
+}
+
+func (h *Home) Get(ctx context.Context, markViewed bool) (ret keybase1.HomeScreen, err error) {
+	defer h.G().CTrace(ctx, "Home#Get", func() error { return err })()
+
+	h.Lock()
+	defer h.Unlock()
+
+	if h.cache != nil {
+		diff := h.G().GetClock().Now().Sub(h.cache.cachedAt)
+		if diff < libkb.HomeCacheTimeout {
+			h.G().Log.CDebugf(ctx, "| hit cache (cached %s ago)", diff)
+			if markViewed {
+				h.G().Log.CDebugf(ctx, "| going to server to mark view, anyways")
+				tmp := h.markViewed(ctx)
+				if tmp != nil {
+					h.G().Log.CInfof(ctx, "Error marking home as viewed: %s", tmp.Error())
+				}
+			}
+			return h.cache.obj, nil
+		}
+	}
+
+	ret, err = h.get(ctx, markViewed)
+	if err == nil {
+		h.cache = &cache{
+			obj:      ret,
+			cachedAt: h.G().GetClock().Now(),
+		}
+	}
+	return ret, err
+}
+
+func (h *Home) skipTodoType(ctx context.Context, typ keybase1.HomeScreenTodoType) (err error) {
+	defer h.G().CTrace(ctx, "Home#SkipType", func() error { return err })()
+
+	_, err = h.G().API.Post(libkb.APIArg{
+		Endpoint:    "home/todo/skip",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		Args: libkb.HTTPArgs{
+			"type": libkb.I{Val: int(typ)},
+		},
+		NetContext: ctx,
+	})
+
+	return err
+}
+
+func (h *Home) bustCache(ctx context.Context) {
+	h.G().Log.CDebugf(ctx, "Home#bustCache")
+	h.Lock()
+	defer h.Unlock()
+	h.cache = nil
+}
+
+func (h *Home) SkipTodoType(ctx context.Context, typ keybase1.HomeScreenTodoType) (err error) {
+	var which string
+	var ok bool
+	if which, ok = keybase1.HomeScreenTodoTypeRevMap[typ]; !ok {
+		which = fmt.Sprintf("unknown=%d", int(typ))
+	}
+	defer h.G().CTrace(ctx, fmt.Sprintf("home#SkipTodoType(%s)", which), func() error { return err })()
+	h.bustCache(ctx)
+	return h.skipTodoType(ctx, typ)
+}
+
+func (h *Home) MarkViewed(ctx context.Context) (err error) {
+	defer h.G().CTrace(ctx, "Home#MarkViewed", func() error { return err })()
+	h.bustCache(ctx)
+	return h.markViewed(ctx)
+}
+
+func (h *Home) markViewed(ctx context.Context) (err error) {
+	defer h.G().CTrace(ctx, "Home#markViewed", func() error { return err })()
+
+	_, err = h.G().API.Post(libkb.APIArg{
+		Endpoint:    "home/visit",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		Args:        libkb.HTTPArgs{},
+		NetContext:  ctx,
+	})
+	return err
+}
+
+func (h *Home) ActionTaken(ctx context.Context) (err error) {
+	defer h.G().CTrace(ctx, "Home#ActionTaken", func() error { return err })()
+	h.bustCache(ctx)
+	return err
+}
+
+func (h *Home) OnLogout() error {
+	h.bustCache(context.Background())
+	return nil
+}
+
+type updateGregorMessage struct {
+	Version int `json:"version"`
+}
+
+func (h *Home) handleUpdate(ctx context.Context, item gregor.Item) (err error) {
+	defer h.G().CTrace(ctx, "Home#handleUpdate", func() error { return err })()
+	var msg updateGregorMessage
+	if err = json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
+		h.G().Log.Debug("error unmarshaling home.update item: %s", err.Error())
+		return err
+	}
+	h.G().Log.Debug("home.update unmarshaled: %+v", msg)
+
+	h.Lock()
+	defer h.Unlock()
+	if h.cache != nil && msg.Version > h.cache.obj.Version {
+		h.cache = nil
+	}
+	return nil
+}
+
+func (h *Home) IsAlive() bool {
+	return true
+}
+func (h *Home) Name() string {
+	return "Home"
+}
+func (h *Home) Create(ctx context.Context, cli gregor1.IncomingInterface, category string, ibm gregor.Item) (bool, error) {
+	switch category {
+	case "home.update":
+		return true, h.handleUpdate(ctx, ibm)
+	default:
+		return false, fmt.Errorf("unknown home handler category: %q", category)
+	}
+}
+func (h *Home) Dismiss(ctx context.Context, cli gregor1.IncomingInterface, category string, ibm gregor.Item) (bool, error) {
+	return true, nil
+}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -122,6 +122,8 @@ const (
 
 	// By default, only 64 files can be opened.
 	LevelDBNumFiles = 64
+
+	HomeCacheTimeout = (time.Hour - time.Minute)
 )
 
 const RemoteIdentifyUITimeout = 5 * time.Second

--- a/go/protocol/keybase1/home.go
+++ b/go/protocol/keybase1/home.go
@@ -120,6 +120,7 @@ func (o HomeScreenItemData) DeepCopy() HomeScreenItemData {
 type HomeScreenTodoType int
 
 const (
+	HomeScreenTodoType_NONE          HomeScreenTodoType = 0
 	HomeScreenTodoType_BIO           HomeScreenTodoType = 1
 	HomeScreenTodoType_PROOF         HomeScreenTodoType = 2
 	HomeScreenTodoType_DEVICE        HomeScreenTodoType = 3
@@ -135,6 +136,7 @@ const (
 func (o HomeScreenTodoType) DeepCopy() HomeScreenTodoType { return o }
 
 var HomeScreenTodoTypeMap = map[string]HomeScreenTodoType{
+	"NONE":          0,
 	"BIO":           1,
 	"PROOF":         2,
 	"DEVICE":        3,
@@ -148,6 +150,7 @@ var HomeScreenTodoTypeMap = map[string]HomeScreenTodoType{
 }
 
 var HomeScreenTodoTypeRevMap = map[HomeScreenTodoType]string{
+	0:  "NONE",
 	1:  "BIO",
 	2:  "PROOF",
 	3:  "DEVICE",
@@ -327,20 +330,19 @@ func (o HomeScreenPeopleNotification) DeepCopy() HomeScreenPeopleNotification {
 
 type HomeScreenItem struct {
 	Badged bool               `codec:"badged" json:"badged"`
-	Id     HomeScreenItemID   `codec:"id" json:"id"`
 	Data   HomeScreenItemData `codec:"data" json:"data"`
 }
 
 func (o HomeScreenItem) DeepCopy() HomeScreenItem {
 	return HomeScreenItem{
 		Badged: o.Badged,
-		Id:     o.Id.DeepCopy(),
 		Data:   o.Data.DeepCopy(),
 	}
 }
 
 type HomeScreen struct {
 	LastViewed        Time             `codec:"lastViewed" json:"lastViewed"`
+	Version           int              `codec:"version" json:"version"`
 	Items             []HomeScreenItem `codec:"items" json:"items"`
 	FollowSuggestions []UserSummary    `codec:"followSuggestions" json:"followSuggestions"`
 }
@@ -348,6 +350,7 @@ type HomeScreen struct {
 func (o HomeScreen) DeepCopy() HomeScreen {
 	return HomeScreen{
 		LastViewed: o.LastViewed.DeepCopy(),
+		Version:    o.Version,
 		Items: (func(x []HomeScreenItem) []HomeScreenItem {
 			if x == nil {
 				return nil

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -866,6 +866,7 @@ func (g *gregorHandler) handleInBandMessage(ctx context.Context, cli gregor1.Inc
 	ibm gregor.InBandMessage) (err error) {
 
 	defer g.G().Trace(fmt.Sprintf("gregorHandler#handleInBandMessage with %d handlers", len(g.ibmHandlers)), func() error { return err })()
+	ctx = libkb.WithLogTag(ctx, "GRGIBM")
 
 	var freshHandlers []libkb.GregorInBandMessageHandler
 

--- a/go/service/home.go
+++ b/go/service/home.go
@@ -1,0 +1,45 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// RPC handlers for home operations
+
+package service
+
+import (
+	"github.com/keybase/client/go/home"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"golang.org/x/net/context"
+)
+
+type HomeHandler struct {
+	*BaseHandler
+	home *home.Home
+}
+
+func NewHomeHandler(xp rpc.Transporter, g *libkb.GlobalContext, home *home.Home) *HomeHandler {
+	handler := &HomeHandler{
+		BaseHandler: NewBaseHandler(g, xp),
+		home:        home,
+	}
+	return handler
+}
+
+var _ keybase1.HomeInterface = (*HomeHandler)(nil)
+
+func (h *HomeHandler) HomeGetScreen(ctx context.Context, markViewed bool) (keybase1.HomeScreen, error) {
+	return h.home.Get(ctx, markViewed)
+}
+
+func (h *HomeHandler) HomeSkipTodoType(ctx context.Context, typ keybase1.HomeScreenTodoType) error {
+	return h.home.SkipTodoType(ctx, typ)
+}
+
+func (h *HomeHandler) HomeActionTaken(ctx context.Context) error {
+	return h.home.ActionTaken(ctx)
+}
+
+func (h *HomeHandler) HomeMarkViewed(ctx context.Context) error {
+	return h.home.MarkViewed(ctx)
+}

--- a/go/systests/home_test.go
+++ b/go/systests/home_test.go
@@ -77,9 +77,11 @@ func TestHome(t *testing.T) {
 	attachIdentifyUI(t, g, iui)
 	alice.track(wong.username)
 
+	// Wait for a gregor message to bust this cache, at most ~20s. Hopeully this is enough for
+	// slow CI but you never know.
 	wait := 10 * time.Millisecond
 	found := false
-	for i := 0; i < 6; i++ {
+	for i := 0; i < 10; i++ {
 		home = getHome(t, alice, true)
 		if home.Version == 1 && home.LastViewed > keybase1.Time(0) {
 			found = true

--- a/go/systests/home_test.go
+++ b/go/systests/home_test.go
@@ -77,7 +77,7 @@ func TestHome(t *testing.T) {
 	attachIdentifyUI(t, g, iui)
 	alice.track(wong.username)
 
-	// Wait for a gregor message to bust this cache, at most ~20s. Hopeully this is enough for
+	// Wait for a gregor message to bust this cache, at most ~10s. Hopeully this is enough for
 	// slow CI but you never know.
 	wait := 10 * time.Millisecond
 	found := false

--- a/go/systests/home_test.go
+++ b/go/systests/home_test.go
@@ -1,0 +1,94 @@
+package systests
+
+import (
+	"github.com/keybase/client/go/client"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+	context "golang.org/x/net/context"
+	"testing"
+	"time"
+)
+
+func getHome(t *testing.T, u *userPlusDevice, markViewed bool) keybase1.HomeScreen {
+	g := u.tc.G
+	cli, err := client.GetHomeClient(g)
+	require.NoError(t, err)
+	home, err := cli.HomeGetScreen(context.TODO(), markViewed)
+	require.NoError(t, err)
+	return home
+}
+
+func assertTodoPresent(t *testing.T, home keybase1.HomeScreen, wanted keybase1.HomeScreenTodoType) {
+	for _, item := range home.Items {
+		typ, err := item.Data.T()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if typ == keybase1.HomeScreenItemType_TODO {
+			todo := item.Data.Todo()
+			typ, err := todo.T()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if typ == wanted {
+				return
+			}
+		}
+	}
+	t.Fatalf("Failed to find type %s in %+v", wanted, home)
+}
+
+func assertTodoNotPresent(t *testing.T, home keybase1.HomeScreen, wanted keybase1.HomeScreenTodoType) {
+	for _, item := range home.Items {
+		typ, err := item.Data.T()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if typ == keybase1.HomeScreenItemType_TODO {
+			todo := item.Data.Todo()
+			typ, err := todo.T()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if typ == wanted {
+				t.Fatalf("Found type %s in %+v, but didn't want to ", wanted, home)
+			}
+		}
+	}
+}
+
+func TestHome(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	tt.addUser("alice")
+	alice := tt.users[0]
+	g := alice.tc.G
+	tt.addUser("wong")
+	wong := tt.users[1]
+
+	home := getHome(t, alice, true)
+	require.Equal(t, home.Version, 0, "on home version 0")
+	require.Equal(t, home.LastViewed, keybase1.Time(0), "never viewed before")
+	assertTodoPresent(t, home, keybase1.HomeScreenTodoType_FOLLOW)
+
+	iui := newSimpleIdentifyUI()
+	iui.confirmRes = keybase1.ConfirmResult{IdentityConfirmed: true, RemoteConfirmed: true, AutoConfirmed: true}
+	attachIdentifyUI(t, g, iui)
+	alice.track(wong.username)
+
+	wait := 10 * time.Millisecond
+	found := false
+	for i := 0; i < 6; i++ {
+		home = getHome(t, alice, true)
+		if home.Version == 1 && home.LastViewed > keybase1.Time(0) {
+			found = true
+			break
+		}
+		t.Logf("Didn't get an update; waiting %s more", wait)
+		time.Sleep(wait)
+		wait = wait * 2
+	}
+	require.True(t, found, "we found the new version of home (after waiting for the gregor message to refresh us")
+	assertTodoNotPresent(t, home, keybase1.HomeScreenTodoType_FOLLOW)
+}

--- a/protocol/avdl/keybase1/home.avdl
+++ b/protocol/avdl/keybase1/home.avdl
@@ -16,6 +16,7 @@ protocol home {
   }
 
   enum HomeScreenTodoType {
+    NONE_0,
     BIO_1,
     PROOF_2,
     DEVICE_3,
@@ -54,12 +55,12 @@ protocol home {
 
   record HomeScreenItem {
     boolean badged;
-    HomeScreenItemID id;
     HomeScreenItemData data;
   }
 
   record HomeScreen {
     Time lastViewed;
+    int version;
     array<HomeScreenItem> items;
     array<UserSummary> followSuggestions;
   }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -321,6 +321,7 @@ export const HomeHomeScreenPeopleNotificationType = {
 }
 
 export const HomeHomeScreenTodoType = {
+  none: 0,
   bio: 1,
   proof: 2,
   device: 3,
@@ -3585,13 +3586,13 @@ export type HelloRes = string
 
 export type HomeScreen = {
   lastViewed: Time,
+  version: int,
   items?: ?Array<HomeScreenItem>,
   followSuggestions?: ?Array<UserSummary>,
 }
 
 export type HomeScreenItem = {
   badged: boolean,
-  id: HomeScreenItemID,
   data: HomeScreenItemData,
 }
 
@@ -3627,7 +3628,8 @@ export type HomeScreenTodo =
     { t: any }
 
 export type HomeScreenTodoType =
-    1 // BIO_1
+    0 // NONE_0
+  | 1 // BIO_1
   | 2 // PROOF_2
   | 3 // DEVICE_3
   | 4 // FOLLOW_4

--- a/protocol/json/keybase1/home.json
+++ b/protocol/json/keybase1/home.json
@@ -44,6 +44,7 @@
       "type": "enum",
       "name": "HomeScreenTodoType",
       "symbols": [
+        "NONE_0",
         "BIO_1",
         "PROOF_2",
         "DEVICE_3",
@@ -144,10 +145,6 @@
           "name": "badged"
         },
         {
-          "type": "HomeScreenItemID",
-          "name": "id"
-        },
-        {
           "type": "HomeScreenItemData",
           "name": "data"
         }
@@ -160,6 +157,10 @@
         {
           "type": "Time",
           "name": "lastViewed"
+        },
+        {
+          "type": "int",
+          "name": "version"
         },
         {
           "type": {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -321,6 +321,7 @@ export const HomeHomeScreenPeopleNotificationType = {
 }
 
 export const HomeHomeScreenTodoType = {
+  none: 0,
   bio: 1,
   proof: 2,
   device: 3,
@@ -3585,13 +3586,13 @@ export type HelloRes = string
 
 export type HomeScreen = {
   lastViewed: Time,
+  version: int,
   items?: ?Array<HomeScreenItem>,
   followSuggestions?: ?Array<UserSummary>,
 }
 
 export type HomeScreenItem = {
   badged: boolean,
-  id: HomeScreenItemID,
   data: HomeScreenItemData,
 }
 
@@ -3627,7 +3628,8 @@ export type HomeScreenTodo =
     { t: any }
 
 export type HomeScreenTodoType =
-    1 // BIO_1
+    0 // NONE_0
+  | 1 // BIO_1
   | 2 // PROOF_2
   | 3 // DEVICE_3
   | 4 // FOLLOW_4


### PR DESCRIPTION
- a simple HomeGet RPC for getting the home screen
- cache busting via gregor for this data being cached
- plumb through a POST skipping todo types
- a simple systest for this, but enough to get us started