### PR TITLE
normalize followers usernames CORE-6549

### DIFF
--- a/go/libkb/sync_trackers2.go
+++ b/go/libkb/sync_trackers2.go
@@ -122,6 +122,16 @@ func (t *Tracker2Syncer) Result() keybase1.UserSummary2Set {
 	if t.res == nil {
 		return keybase1.UserSummary2Set{}
 	}
+
+	// Normalize usernames
+	var normalizedUsers []keybase1.UserSummary2
+	for _, u := range t.res.Users {
+		normalizedUser := u
+		normalizedUser.Username = NewNormalizedUsername(u.Username).String()
+		normalizedUsers = append(normalizedUsers, normalizedUser)
+	}
+	t.res.Users = normalizedUsers
+
 	return *t.res
 }
 


### PR DESCRIPTION
JS completely stops if it tries to load a mixed case username now, and the followers lists would leak them out. Let me know if there might be a better place to put this code.