### PR TITLE
Render system messages as boxes instead of strings

### DIFF
--- a/shared/actions/chat/thread-content.js
+++ b/shared/actions/chat/thread-content.js
@@ -529,23 +529,23 @@ function _unboxedToMessage(
         case ChatTypes.commonMessageType.join: {
           const message = new HiddenString('joined')
           return {
-            type: 'System',
+            type: 'JoinedLeft',
             messageID: common.messageID,
             author: common.author,
             timestamp: common.timestamp,
             message,
-            key: Constants.messageKey(common.conversationIDKey, 'system', common.messageID),
+            key: Constants.messageKey(common.conversationIDKey, 'joinedleft', common.messageID),
           }
         }
         case ChatTypes.commonMessageType.leave: {
           const message = new HiddenString('left')
           return {
-            type: 'System',
+            type: 'JoinedLeft',
             messageID: common.messageID,
             author: common.author,
             timestamp: common.timestamp,
             message,
-            key: Constants.messageKey(common.conversationIDKey, 'system', common.messageID),
+            key: Constants.messageKey(common.conversationIDKey, 'joinedleft', common.messageID),
           }
         }
         case ChatTypes.commonMessageType.system: {
@@ -572,12 +572,12 @@ function _unboxedToMessage(
             }
           }
           return {
-            type: 'Text',
+            type: 'System',
             ...common,
             editedCount: payload.superseded ? 1 : 0, // mark it as edited if it's been superseded
             message: new HiddenString(sysMsgText),
-            messageState: 'sent', // TODO, distinguish sent/pending once CORE sends it.
-            key: Constants.messageKey(common.conversationIDKey, 'messageIDText', common.messageID),
+            messageState: 'sent',
+            key: Constants.messageKey(common.conversationIDKey, 'system', common.messageID),
           }
         }
         default:

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -3,6 +3,7 @@ import * as Constants from '../../../constants/chat'
 import Attachment from './attachment/container'
 import ErrorMessage from './error/container'
 import Header from './header/container'
+import JoinedLeft from './joinedleft/container'
 import System from './system/container'
 import ProfileResetNotice from '../notices/profile-reset-notice/container'
 import * as React from 'react'
@@ -25,6 +26,8 @@ const factory = (
 ) => {
   const kind = Constants.messageKeyKind(messageKey)
   switch (kind) {
+    case 'joinedleft':
+      return <JoinedLeft messageKey={messageKey} />
     case 'system':
       return <System messageKey={messageKey} />
     case 'header':

--- a/shared/chat/conversation/messages/joinedleft/container.js
+++ b/shared/chat/conversation/messages/joinedleft/container.js
@@ -1,0 +1,69 @@
+// @flow
+import * as Constants from '../../../../constants/chat'
+import JoinedLeftNotice from '.'
+import createCachedSelector from 're-reselect'
+import {compose} from 'recompose'
+import {connect} from 'react-redux'
+import {navigateTo, switchTo} from '../../../../actions/route-tree'
+import {teamsTab} from '../../../../constants/tabs'
+import {isMobile} from '../../../../constants/platform'
+import {showUserProfile} from '../../../../actions/profile'
+import {getProfile} from '../../../../actions/tracker'
+
+import type {TypedState} from '../../../../constants/reducer'
+import type {OwnProps} from './container'
+
+type StateProps = {
+  channelname: string,
+  message: Constants.TextMessage,
+  teamname: string,
+  you: string,
+}
+
+type DispatchProps = {
+  _onManageChannels: (teamname: string) => void,
+  onUsernameClicked: (username: string) => void,
+}
+
+const getDetails = createCachedSelector(
+  [
+    Constants.getMessageFromMessageKey,
+    Constants.getYou,
+    Constants.getChannelName,
+    Constants.getTeamName,
+    Constants.getFollowingMap,
+  ],
+  (
+    message: Constants.JoinedLeftMessage,
+    you: string,
+    channelname: string,
+    teamname: string,
+    following: {[key: string]: ?boolean}
+  ) => ({
+    channelname,
+    following: !!following[message.author],
+    message,
+    teamname,
+    you,
+  })
+)((state, messageKey) => messageKey)
+
+const mapStateToProps = (state: TypedState, {messageKey}: OwnProps) => getDetails(state, messageKey)
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  _onManageChannels: (teamname: string) => {
+    dispatch(navigateTo([{props: {teamname}, selected: 'manageChannels'}], [teamsTab]))
+    dispatch(switchTo([teamsTab]))
+  },
+  onUsernameClicked: (username: string) => {
+    isMobile ? dispatch(showUserProfile(username)) : dispatch(getProfile(username, true, true))
+  },
+})
+
+const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps) => ({
+  ...stateProps,
+  onManageChannels: () => dispatchProps._onManageChannels(stateProps.teamname),
+  onUsernameClicked: dispatchProps.onUsernameClicked,
+})
+
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps))(JoinedLeftNotice)

--- a/shared/chat/conversation/messages/joinedleft/container.js.flow
+++ b/shared/chat/conversation/messages/joinedleft/container.js.flow
@@ -1,0 +1,9 @@
+// @flow
+import {Component} from 'react'
+import * as Constants from '../../../../constants/chat'
+
+export type OwnProps = {
+  messageKey: Constants.MessageKey,
+}
+
+export default class JoinedLeft extends Component<OwnProps> {}

--- a/shared/chat/conversation/messages/joinedleft/index.js
+++ b/shared/chat/conversation/messages/joinedleft/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {Text} from '../../../../common-adapters'
+import {Text, Usernames} from '../../../../common-adapters'
 import UserNotice from '../../notices/user-notice'
 import {globalColors, globalMargins} from '../../../../styles'
 import {formatTimeForMessages} from '../../../../util/timestamp'
@@ -17,22 +17,41 @@ type Props = {
   you: string,
 }
 
-const SystemNotice = ({channelname, message, onManageChannels, you, following, onUsernameClicked}: Props) => (
+const JoinedLeftNotice = ({
+  channelname,
+  message,
+  onManageChannels,
+  you,
+  following,
+  onUsernameClicked,
+}: Props) => (
   <UserNotice style={{marginTop: globalMargins.small}} username={message.author} bgColor={globalColors.blue4}>
     <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
       {formatTimeForMessages(message.timestamp)}
     </Text>
-    {message.message.stringValue().split('\n').map(line => (
-      <Text
-        key={line}
+    <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
+      <Usernames
+        inline={true}
         type="BodySmallSemibold"
+        onUsernameClicked={onUsernameClicked}
+        colorFollowing={true}
+        users={[{username: message.author, following, you: you === message.author}]}
+      />
+      {' '}
+      {message.message.stringValue()}
+      {' '}
+      #{channelname}.
+    </Text>
+    {message.author === you &&
+      <Text
         backgroundMode="Announcements"
-        style={{color: globalColors.black_40}}
+        onClick={onManageChannels}
+        style={{color: globalColors.blue}}
+        type="BodySmallPrimaryLink"
       >
-        {line}
-      </Text>
-    ))}
+        Manage channel subscriptions.
+      </Text>}
   </UserNotice>
 )
 
-export default SystemNotice
+export default JoinedLeftNotice

--- a/shared/chat/conversation/messages/system/container.js
+++ b/shared/chat/conversation/messages/system/container.js
@@ -4,66 +4,19 @@ import SystemNotice from '.'
 import createCachedSelector from 're-reselect'
 import {compose} from 'recompose'
 import {connect} from 'react-redux'
-import {navigateTo, switchTo} from '../../../../actions/route-tree'
-import {teamsTab} from '../../../../constants/tabs'
-import {isMobile} from '../../../../constants/platform'
-import {showUserProfile} from '../../../../actions/profile'
-import {getProfile} from '../../../../actions/tracker'
 
 import type {TypedState} from '../../../../constants/reducer'
 import type {OwnProps} from './container'
 
-type StateProps = {
-  channelname: string,
-  message: Constants.TextMessage,
-  teamname: string,
-  you: string,
-}
-
-type DispatchProps = {
-  _onManageChannels: (teamname: string) => void,
-  onUsernameClicked: (username: string) => void,
-}
-
 const getDetails = createCachedSelector(
-  [
-    Constants.getMessageFromMessageKey,
-    Constants.getYou,
-    Constants.getChannelName,
-    Constants.getTeamName,
-    Constants.getFollowingMap,
-  ],
-  (
-    message: Constants.SystemMessage,
-    you: string,
-    channelname: string,
-    teamname: string,
-    following: {[key: string]: ?boolean}
-  ) => ({
-    channelname,
+  [Constants.getMessageFromMessageKey, Constants.getYou, Constants.getFollowingMap],
+  (message: Constants.SystemMessage, you: string, following: {[key: string]: ?boolean}) => ({
     following: !!following[message.author],
     message,
-    teamname,
     you,
   })
 )((state, messageKey) => messageKey)
 
 const mapStateToProps = (state: TypedState, {messageKey}: OwnProps) => getDetails(state, messageKey)
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  _onManageChannels: (teamname: string) => {
-    dispatch(navigateTo([{props: {teamname}, selected: 'manageChannels'}], [teamsTab]))
-    dispatch(switchTo([teamsTab]))
-  },
-  onUsernameClicked: (username: string) => {
-    isMobile ? dispatch(showUserProfile(username)) : dispatch(getProfile(username, true, true))
-  },
-})
-
-const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps) => ({
-  ...stateProps,
-  onManageChannels: () => dispatchProps._onManageChannels(stateProps.teamname),
-  onUsernameClicked: dispatchProps.onUsernameClicked,
-})
-
-export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps))(SystemNotice)
+export default compose(connect(mapStateToProps, () => {}))(SystemNotice)

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -40,6 +40,7 @@ type MessageKeyKind =
   | 'timestamp'
   | 'supersedes'
   | 'system'
+  | 'joinedleft'
 
 // TODO: Ideally, this would be 'Text' | 'Error' | etc.
 export type MessageType = string
@@ -166,6 +167,16 @@ export type ChatSecuredHeaderMessage = {
   type: 'ChatSecuredHeader',
   key: MessageKey,
 }
+
+export type JoinedLeftMessage = {
+  type: 'JoinedLeft',
+  messageID?: MessageID,
+  author: string,
+  timestamp: number,
+  message: HiddenString,
+  key: MessageKey,
+}
+
 export type SystemMessage = {
   type: 'System',
   messageID?: MessageID,
@@ -235,6 +246,7 @@ export type ServerMessage =
   | UpdatingAttachment
   | InvisibleErrorMessage
   | SystemMessage
+  | JoinedLeftMessage
 
 export type Message = ClientMessage | ServerMessage
 
@@ -860,6 +872,8 @@ function messageKeyKindIsMessageID(key: MessageKey): boolean {
 function messageKeyKind(key: MessageKey): MessageKeyKind {
   const [, kind] = key.split(':')
   switch (kind) {
+    case 'joinedleft':
+      return 'joinedleft'
     case 'system':
       return 'system'
     case 'error':


### PR DESCRIPTION
@keybase/react-hackers 

This PR takes the text messages that we were synthesizing for system messages and turns them into System component messages instead.  Also makes a new JoinedLeft message type for those messages.. they have more specific needs (click on usernames, manage channels link) than these raw system text messages.