### PR TITLE
CLI: revamp team settings to include showcase

### DIFF
--- a/go/client/cmd_team_settings.go
+++ b/go/client/cmd_team_settings.go
@@ -29,6 +29,7 @@ func newCmdTeamSettings(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 		Name:         "settings",
 		ArgumentHelp: "<team name>",
 		Usage:        "Edit team settings.",
+		Description:  teamSettingsDoc,
 		Action: func(c *cli.Context) {
 			cmd := NewCmdTeamSettingsRunner(g)
 			cl.ChooseCommand(cmd, "settings", c)
@@ -267,10 +268,8 @@ func (c *CmdTeamSettings) printCurrentSettings(ctx context.Context, cli keybase1
 	if showcaseInfo != nil && showcaseInfo.TeamShowcase.Description != nil {
 		dui.Printf("  Description:     %v\n", *showcaseInfo.TeamShowcase.Description)
 	}
-	dui.Printf("  Open:            %v\n", c.tfToYn(details.Settings.Open, ""))
-	if details.Settings.Open {
-		dui.Printf("  New member role: %s\n", strings.ToLower(details.Settings.JoinAs.String()))
-	}
+	dui.Printf("  Open:            %v\n", c.tfToYn(details.Settings.Open,
+		fmt.Sprintf("default membership = %v", strings.ToLower(details.Settings.JoinAs.String()))))
 	if showcaseInfo != nil {
 		dui.Printf("  Showcased:       %v\n", c.tfToYn(showcaseInfo.TeamShowcase.IsShowcased, "on keybase.io/popular-teams"))
 		dui.Printf("  Promoted:        %v\n", c.tfToYn(showcaseInfo.IsMemberShowcased, "on your profile"))
@@ -297,3 +296,16 @@ func (c *CmdTeamSettings) GetUsage() libkb.Usage {
 		KbKeyring: true,
 	}
 }
+
+const teamSettingsDoc = `"keybase team settings" lets you edit settings for a team
+
+EXAMPLES:
+Review team settings:
+    keybase team settings acme
+Open a team so anyone can join as a reader:
+    keybase team settings acme --open-team=reader
+Showcase a team publicly:
+    keybase team settings acme --showcase=yes
+Promote a team on your profile:
+    keybase team settings acme --profile-promote=yes
+`

--- a/go/client/cmd_team_settings.go
+++ b/go/client/cmd_team_settings.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/keybase/cli"
@@ -13,9 +13,15 @@ import (
 
 type CmdTeamSettings struct {
 	libkb.Contextified
-	Team      keybase1.TeamName
-	PrintOnly bool
-	Settings  keybase1.TeamSettings
+
+	Team keybase1.TeamName
+
+	// These fields are non-zero valued when their action is requested
+	Description         *string
+	JoinAsRole          *keybase1.TeamRole
+	ProfilePromote      *bool
+	AllowProfilePromote *bool
+	Showcase            *bool
 }
 
 func newCmdTeamSettings(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -28,17 +34,32 @@ func newCmdTeamSettings(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 			cl.ChooseCommand(cmd, "settings", c)
 		},
 		Flags: []cli.Flag{
+			// Many of these are StringFlag instead of BoolFlag because BoolFlag is displeasing.
+			// For example `keybase team settings teamname --bool-flag false` sets the flag to true.
+
 			cli.BoolFlag{
-				Name:  "set-open",
-				Usage: "set team to open",
-			},
-			cli.BoolFlag{
-				Name:  "set-closed",
-				Usage: "set team to closed",
+				Name:  "p, print",
+				Usage: "Print all your team settings",
 			},
 			cli.StringFlag{
-				Name:  "join-as",
-				Usage: "team role (writer, reader) [required when changing team to open]",
+				Name:  "description",
+				Usage: "Set the team description",
+			},
+			cli.StringFlag{
+				Name:  "open-team",
+				Usage: "[reader|writer|off] Set whether anyone can join without being invited and the role they become",
+			},
+			cli.StringFlag{
+				Name:  "profile-promote",
+				Usage: "[yes|no] Set whether your own profile should promote this team and its description",
+			},
+			cli.StringFlag{
+				Name:  "allow-profile-promote",
+				Usage: "[yes|no] Set whether non-admins are allowed to promote this team and its description on their profiles",
+			},
+			cli.StringFlag{
+				Name:  "showcase",
+				Usage: "[yes|no] Set whether to promote this team and its description on keybase.io/popular-teams",
 			},
 		},
 	}
@@ -48,67 +69,148 @@ func NewCmdTeamSettingsRunner(g *libkb.GlobalContext) *CmdTeamSettings {
 	return &CmdTeamSettings{Contextified: libkb.NewContextified(g)}
 }
 
-func (c *CmdTeamSettings) ParseArgv(ctx *cli.Context) error {
-	var err error
+func (c *CmdTeamSettings) ParseArgv(ctx *cli.Context) (err error) {
 	c.Team, err = ParseOneTeamNameK1(ctx)
 	if err != nil {
 		return err
 	}
 
-	if ctx.NumFlags() == 0 {
-		// Just a team name and no other flags - print current team settings.
-		c.PrintOnly = true
-		return nil
+	var exclusiveActions []string
+
+	if ctx.IsSet("description") {
+		exclusiveActions = append(exclusiveActions, "description")
+		desc := ctx.String("description")
+		c.Description = &desc
 	}
 
-	if ctx.Bool("set-open") && ctx.Bool("set-closed") {
-		return errors.New("cannot use --set-open and --set-closed at the same time")
+	if ctx.IsSet("open-team") {
+		exclusiveActions = append(exclusiveActions, "open-team")
 
-	}
-
-	if ctx.Bool("set-open") {
-		c.Settings.Open = true
-
-		srole := ctx.String("join-as")
-		if srole == "" {
-			return errors.New("team role required via --join-as flag")
-		}
-
-		role, ok := keybase1.TeamRoleMap[strings.ToUpper(srole)]
-		if !ok {
-			return errors.New("invalid team role, please use writer, or reader")
-		}
-
-		switch role {
-		case keybase1.TeamRole_READER, keybase1.TeamRole_WRITER:
-			break
+		role := keybase1.TeamRole_NONE
+		val := ctx.String("open-team")
+		switch val {
+		case "reader":
+			role = keybase1.TeamRole_READER
+		case "writer":
+			role = keybase1.TeamRole_WRITER
 		default:
-			return errors.New("invalid team role, please use writer, or reader")
+			open, err := cli.ParseBoolFriendly(val)
+			if err != nil || open {
+				return fmt.Errorf("open-team must be one of [reader|writer|off]")
+			}
 		}
+		c.JoinAsRole = &role
+	}
 
-		c.Settings.JoinAs = role
-	} else if ctx.Bool("set-closed") {
-		c.Settings.Open = false
-	} else {
-		// Happens when user supplies --join-as only:
-		// > keybase team edit teamname --join-as reader
-		// For simplicity, we require always --set-open/--set-closed flag,
-		// even if user just wants to change join_as role.
-		return errors.New("--set-open or --set-closed flag is required")
+	if ctx.IsSet("profile-promote") {
+		exclusiveActions = append(exclusiveActions, "profile-promote")
+		val, err := ctx.BoolStrict("profile-promote")
+		if err != nil {
+			return err
+		}
+		c.ProfilePromote = &val
+	}
+
+	if ctx.IsSet("allow-profile-promote") {
+		exclusiveActions = append(exclusiveActions, "allow-profile-promote")
+		val, err := ctx.BoolStrict("allow-profile-promote")
+		if err != nil {
+			return err
+		}
+		c.AllowProfilePromote = &val
+	}
+
+	if ctx.IsSet("showcase") {
+		exclusiveActions = append(exclusiveActions, "showcase")
+		val, err := ctx.BoolStrict("showcase")
+		if err != nil {
+			return err
+		}
+		c.Showcase = &val
+	}
+
+	if len(exclusiveActions) > 1 {
+		return fmt.Errorf("only one of these actions a time: %v", strings.Join(exclusiveActions, ", "))
 	}
 
 	return nil
 }
 
-func (c *CmdTeamSettings) applySettings(cli keybase1.TeamsClient) error {
-	dui := c.G().UI.GetTerminalUI()
+func (c *CmdTeamSettings) Run() error {
+	ctx, ctxCancel := context.WithCancel(context.TODO())
+	defer ctxCancel()
+	ctx = libkb.WithLogTag(ctx, "CTS")
 
-	arg := keybase1.TeamSetSettingsArg{
-		Name:     c.Team.String(),
-		Settings: c.Settings,
+	cli, err := GetTeamsClient(c.G())
+	if err != nil {
+		return err
 	}
 
-	err := cli.TeamSetSettings(context.Background(), arg)
+	if c.Description != nil {
+		err = c.setDescription(ctx, cli, *c.Description)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.JoinAsRole != nil {
+		err = c.setOpenness(ctx, cli, *c.JoinAsRole)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.ProfilePromote != nil {
+		err = c.setProfilePromote(ctx, cli, *c.ProfilePromote)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.AllowProfilePromote != nil {
+		err = c.setAllowProfilePromote(ctx, cli, *c.AllowProfilePromote)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.Showcase != nil {
+		err = c.setShowcase(ctx, cli, *c.Showcase)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = c.printCurrentSettings(ctx, cli)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CmdTeamSettings) setDescription(ctx context.Context, cli keybase1.TeamsClient, desc string) error {
+	return cli.SetTeamShowcase(ctx, keybase1.SetTeamShowcaseArg{
+		Name:        c.Team.String(),
+		IsShowcased: nil,
+		Description: &desc,
+	})
+}
+
+func (c *CmdTeamSettings) setOpenness(ctx context.Context, cli keybase1.TeamsClient, joinAsRole keybase1.TeamRole) error {
+	dui := c.G().UI.GetTerminalUI()
+
+	open := joinAsRole != keybase1.TeamRole_NONE
+
+	arg := keybase1.TeamSetSettingsArg{
+		Name: c.Team.String(),
+		Settings: keybase1.TeamSettings{
+			Open:   open,
+			JoinAs: joinAsRole,
+		},
+	}
+
+	err := cli.TeamSetSettings(ctx, arg)
 	if err != nil {
 		if e, ok := err.(libkb.NoOpError); ok {
 			dui.Printf("%s\n", e.Desc)
@@ -118,37 +220,74 @@ func (c *CmdTeamSettings) applySettings(cli keybase1.TeamsClient) error {
 		return err
 	}
 
-	dui.Printf("Team settings were changed.\n")
+	if open {
+		dui.Printf("Team set to open.\n")
+	} else {
+		dui.Printf("Team set to closed.\n")
+	}
 	return nil
 }
 
-func (c *CmdTeamSettings) Run() error {
-	cli, err := GetTeamsClient(c.G())
+func (c *CmdTeamSettings) setProfilePromote(ctx context.Context, cli keybase1.TeamsClient, promote bool) error {
+	return cli.SetTeamMemberShowcase(ctx, keybase1.SetTeamMemberShowcaseArg{
+		Name:        c.Team.String(),
+		IsShowcased: promote,
+	})
+}
+
+func (c *CmdTeamSettings) setAllowProfilePromote(ctx context.Context, cli keybase1.TeamsClient, allow bool) error {
+	// awaiting CORE-6550
+	return fmt.Errorf("The ability to allow non-admins to promote your team is coming soon!")
+}
+
+func (c *CmdTeamSettings) setShowcase(ctx context.Context, cli keybase1.TeamsClient, showcase bool) error {
+	return cli.SetTeamShowcase(ctx, keybase1.SetTeamShowcaseArg{
+		Name:        c.Team.String(),
+		IsShowcased: &showcase,
+		Description: nil,
+	})
+}
+
+func (c *CmdTeamSettings) printCurrentSettings(ctx context.Context, cli keybase1.TeamsClient) error {
+	details, err := cli.TeamGet(ctx, keybase1.TeamGetArg{Name: c.Team.String(), ForceRepoll: true})
 	if err != nil {
 		return err
 	}
 
-	if !c.PrintOnly {
-		if err := c.applySettings(cli); err != nil {
-			return err
-		}
-	}
-
-	details, err := cli.TeamGet(context.Background(), keybase1.TeamGetArg{Name: c.Team.String(), ForceRepoll: !c.PrintOnly})
+	var showcaseInfo *keybase1.TeamAndMemberShowcase
+	tmp, err := cli.GetTeamAndMemberShowcase(ctx, c.Team.String())
 	if err != nil {
-		return err
+		c.G().Log.CDebugf(ctx, "failed to get team showcase info: %v", err)
+	} else {
+		showcaseInfo = &tmp
 	}
 
 	dui := c.G().UI.GetTerminalUI()
-	dui.Printf("Current settings of team %q:\n", c.Team.String())
+	dui.Printf("Current settings for team %q:\n", c.Team.String())
+	if showcaseInfo != nil && showcaseInfo.TeamShowcase.Description != nil {
+		dui.Printf("  Description:     %v\n", *showcaseInfo.TeamShowcase.Description)
+	}
+	dui.Printf("  Open:            %v\n", c.tfToYn(details.Settings.Open, ""))
 	if details.Settings.Open {
-		dui.Printf("  Open:\t\t\ttrue\n")
-		dui.Printf("  New member role:\t%s\n", strings.ToLower(details.Settings.JoinAs.String()))
-	} else {
-		dui.Printf("  Open:\tfalse\n")
+		dui.Printf("  New member role: %s\n", strings.ToLower(details.Settings.JoinAs.String()))
+	}
+	if showcaseInfo != nil {
+		dui.Printf("  Showcased:       %v\n", c.tfToYn(showcaseInfo.TeamShowcase.IsShowcased, "on keybase.io/popular-teams"))
+		dui.Printf("  Promoted:        %v\n", c.tfToYn(showcaseInfo.IsMemberShowcased, "on your profile"))
+		// CORE-6550: show whether non-admins are allowed to promote
 	}
 
 	return nil
+}
+
+func (c *CmdTeamSettings) tfToYn(x bool, parenthetical string) string {
+	if x {
+		if len(parenthetical) > 0 {
+			return fmt.Sprintf("yes (%v)", parenthetical)
+		}
+		return "yes"
+	}
+	return "no"
 }
 
 func (c *CmdTeamSettings) GetUsage() libkb.Usage {

--- a/go/systests/team_open_test.go
+++ b/go/systests/team_open_test.go
@@ -196,10 +196,8 @@ func TestTeamOpenBans(t *testing.T) {
 	t.Logf("Trying team edit cli...")
 	runner := client.NewCmdTeamSettingsRunner(own.tc.G)
 	runner.Team = teamName
-	runner.Settings = keybase1.TeamSettings{
-		Open:   true,
-		JoinAs: keybase1.TeamRole_READER,
-	}
+	joinAsRole := keybase1.TeamRole_READER
+	runner.JoinAsRole = &joinAsRole
 	err = runner.Run()
 	require.NoError(t, err)
 

--- a/go/teams/showcase_helper.go
+++ b/go/teams/showcase_helper.go
@@ -85,7 +85,11 @@ func SetTeamShowcase(ctx context.Context, g *libkb.GlobalContext, teamname strin
 		arg.Args.Add("is_showcased", libkb.B{Val: *isShowcased})
 	}
 	if description != nil {
-		arg.Args.Add("description", libkb.S{Val: *description})
+		if len(*description) > 0 {
+			arg.Args.Add("description", libkb.S{Val: *description})
+		} else {
+			arg.Args.Add("clear_description", libkb.B{Val: true})
+		}
 	}
 	_, err = g.API.Post(arg)
 	return err


### PR DESCRIPTION
Add support for showcasing to settings. Also rejigger settings command to accommodate more subcommands.

Does this look easy to use?
Do you think that any of these require confirmation prompts? I was thinking they don't.

Examples:
```
$ kbu team settings
Error parsing command line arguments: team name argument required

NAME:
   keybase team settings - Edit team settings.

USAGE:
   keybase team settings [command options] <team name>

OPTIONS:
   -p, --print			Print all your team settings
   --description 		Set the team description
   --open-team 			[reader|writer|off] Set whether anyone can join without being invited and the role they become
   --profile-promote 		[yes|no] Set whether your own profile should promote this team and its description
   --allow-profile-promote 	[yes|no] Set whether non-admins are allowed to promote this team and its description on their profiles
   --showcase 			[yes|no] Set whether to promote this team and its description on keybase.io/popular-teams

$ kbu team settings -p
Error parsing command line arguments: team name argument required

NAME:
   keybase team settings - Edit team settings.

USAGE:
   keybase team settings [command options] <team name>

OPTIONS:
   -p, --print			Print all your team settings
   --description 		Set the team description
   --open-team 			[reader|writer|off] Set whether anyone can join without being invited and the role they become
   --profile-promote 		[yes|no] Set whether your own profile should promote this team and its description
   --allow-profile-promote 	[yes|no] Set whether non-admins are allowed to promote this team and its description on their profiles
   --showcase 			[yes|no] Set whether to promote this team and its description on keybase.io/popular-teams

$ kbu team settings cn3team3 -p
Current settings for team "cn3team3":
  Description:     w
  Open:            no
  Showcased:       yes (on keybase.io/popular-teams)
  Promoted:        yes (on your profile)

$ kbu team settings cn3team3
Current settings for team "cn3team3":
  Description:     w
  Open:            no
  Showcased:       yes (on keybase.io/popular-teams)
  Promoted:        yes (on your profile)

$ kbu team settings cn3team3 --open-team false
Team is already closed.
Current settings for team "cn3team3":
  Description:     w
  Open:            no
  Showcased:       yes (on keybase.io/popular-teams)
  Promoted:        yes (on your profile)

$ kbu team settings cn3team3 --open-team writer
Team set to open.
Current settings for team "cn3team3":
  Description:     w
  Open:            yes
  New member role: writer
  Showcased:       yes (on keybase.io/popular-teams)
  Promoted:        yes (on your profile)

$ kbu team settings cn3team3 --showcase yes
Current settings for team "cn3team3":
  Description:     w
  Open:            yes
  New member role: writer
  Showcased:       yes (on keybase.io/popular-teams)
  Promoted:        yes (on your profile)

$ kbu team settings cn3team3 --profile-promote yes
Current settings for team "cn3team3":
  Description:     w
  Open:            yes
  New member role: writer
  Showcased:       yes (on keybase.io/popular-teams)
  Promoted:        yes (on your profile)

$ kbu team settings cn3team3 --profile-promote no
Current settings for team "cn3team3":
  Description:     w
  Open:            yes
  New member role: writer
  Showcased:       yes (on keybase.io/popular-teams)
  Promoted:        no

$ kbu team settings cn3team3 --allow-profile-promote yes
▶ ERROR The ability to allow non-admins to promote your team is coming soon!

$ kbu team settings cn3team3 --open-team writer
Team is already open with default role: writer.
Current settings for team "cn3team3":
  Description:     w
  Open:            yes
  New member role: writer
  Showcased:       yes (on keybase.io/popular-teams)
  Promoted:        no

$ kbu team settings cn3team3 --description "great team"
Current settings for team "cn3team3":
  Description:     great team
  Open:            yes
  New member role: writer
  Showcased:       yes (on keybase.io/popular-teams)
  Promoted:        no

$ kbu team settings cn3team3 --description ""
Current settings for team "cn3team3":
  Description:
  Open:            yes
  New member role: writer
  Showcased:       yes (on keybase.io/popular-teams)
  Promoted:        no

$ kbu team settings cn3team3 --description "ok team" --open-team reader
Error parsing command line arguments: only one of these actions a time: description, open-team

NAME:
   keybase team settings - Edit team settings.

USAGE:
   keybase team settings [command options] <team name>

OPTIONS:
   -p, --print			Print all your team settings
   --description 		Set the team description
   --open-team 			[reader|writer|off] Set whether anyone can join without being invited and the role they become
   --profile-promote 		[yes|no] Set whether your own profile should promote this team and its description
   --allow-profile-promote 	[yes|no] Set whether non-admins are allowed to promote this team and its description on their profiles
   --showcase 			[yes|no] Set whether to promote this team and its description on keybase.io/popular-teams

$ kbu team settings cn3team3 --description
Error parsing command line arguments: team name argument required

NAME:
   keybase team settings - Edit team settings.

USAGE:
   keybase team settings [command options] <team name>

OPTIONS:
   -p, --print			Print all your team settings
   --description 		Set the team description
   --open-team 			[reader|writer|off] Set whether anyone can join without being invited and the role they become
   --profile-promote 		[yes|no] Set whether your own profile should promote this team and its description
   --allow-profile-promote 	[yes|no] Set whether non-admins are allowed to promote this team and its description on their profiles
   --showcase 			[yes|no] Set whether to promote this team and its description on keybase.io/popular-teams

$ kbu team settings cn3team3 --open-team
Error parsing command line arguments: team name argument required

NAME:
   keybase team settings - Edit team settings.

USAGE:
   keybase team settings [command options] <team name>

OPTIONS:
   -p, --print			Print all your team settings
   --description 		Set the team description
   --open-team 			[reader|writer|off] Set whether anyone can join without being invited and the role they become
   --profile-promote 		[yes|no] Set whether your own profile should promote this team and its description
   --allow-profile-promote 	[yes|no] Set whether non-admins are allowed to promote this team and its description on their profiles
   --showcase 			[yes|no] Set whether to promote this team and its description on keybase.io/popular-teams
```