### PR TITLE
Badging for users booted from team due to account reset

### DIFF
--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -136,7 +136,7 @@ func (e *TrackToken) Run(ctx *Context) (err error) {
 
 		// Dismiss any associated gregor item.
 		if outcome.ResponsibleGregorItem != nil {
-			err = e.G().GregorDismisser.DismissItem(nil, outcome.ResponsibleGregorItem.Metadata().MsgID())
+			err = e.G().GregorDismisser.DismissItem(ctx.GetNetContext(), nil, outcome.ResponsibleGregorItem.Metadata().MsgID())
 		}
 	}
 

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -12,6 +12,7 @@ import (
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/clockwork"
+	context "golang.org/x/net/context"
 )
 
 func TestTrackTokenIdentify2(t *testing.T) {
@@ -419,7 +420,7 @@ type FakeGregorDismisser struct {
 
 var _ libkb.GregorDismisser = (*FakeGregorDismisser)(nil)
 
-func (d *FakeGregorDismisser) DismissItem(cli gregor1.IncomingInterface, id gregor.MsgID) error {
+func (d *FakeGregorDismisser) DismissItem(ctx context.Context, cli gregor1.IncomingInterface, id gregor.MsgID) error {
 	d.dismissedMsgID = id
 	return nil
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -445,7 +445,7 @@ type Clock interface {
 }
 
 type GregorDismisser interface {
-	DismissItem(cli gregor1.IncomingInterface, id gregor.MsgID) error
+	DismissItem(ctx context.Context, cli gregor1.IncomingInterface, id gregor.MsgID) error
 }
 
 type GregorInBandMessageHandler interface {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -455,7 +455,7 @@ type FakeGregorDismisser struct {
 
 var _ GregorDismisser = (*FakeGregorDismisser)(nil)
 
-func (f *FakeGregorDismisser) DismissItem(cli gregor1.IncomingInterface, id gregor.MsgID) error {
+func (f *FakeGregorDismisser) DismissItem(_ context.Context, cli gregor1.IncomingInterface, id gregor.MsgID) error {
 	f.dismissedIDs = append(f.dismissedIDs, id)
 	return nil
 }

--- a/go/protocol/keybase1/gregor.go
+++ b/go/protocol/keybase1/gregor.go
@@ -40,12 +40,12 @@ func (o DismissCategoryArg) DeepCopy() DismissCategoryArg {
 	}
 }
 
-type DismissItemByMsgIDArg struct {
+type DismissItemArg struct {
 	Id gregor1.MsgID `codec:"id" json:"id"`
 }
 
-func (o DismissItemByMsgIDArg) DeepCopy() DismissItemByMsgIDArg {
-	return DismissItemByMsgIDArg{
+func (o DismissItemArg) DeepCopy() DismissItemArg {
+	return DismissItemArg{
 		Id: o.Id.DeepCopy(),
 	}
 }
@@ -54,7 +54,7 @@ type GregorInterface interface {
 	GetState(context.Context) (gregor1.State, error)
 	InjectItem(context.Context, InjectItemArg) (gregor1.MsgID, error)
 	DismissCategory(context.Context, gregor1.Category) error
-	DismissItemByMsgID(context.Context, gregor1.MsgID) error
+	DismissItem(context.Context, gregor1.MsgID) error
 }
 
 func GregorProtocol(i GregorInterface) rpc.Protocol {
@@ -104,18 +104,18 @@ func GregorProtocol(i GregorInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"dismissItemByMsgID": {
+			"dismissItem": {
 				MakeArg: func() interface{} {
-					ret := make([]DismissItemByMsgIDArg, 1)
+					ret := make([]DismissItemArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]DismissItemByMsgIDArg)
+					typedArgs, ok := args.(*[]DismissItemArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]DismissItemByMsgIDArg)(nil), args)
+						err = rpc.NewTypeError((*[]DismissItemArg)(nil), args)
 						return
 					}
-					err = i.DismissItemByMsgID(ctx, (*typedArgs)[0].Id)
+					err = i.DismissItem(ctx, (*typedArgs)[0].Id)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -144,8 +144,8 @@ func (c GregorClient) DismissCategory(ctx context.Context, category gregor1.Cate
 	return
 }
 
-func (c GregorClient) DismissItemByMsgID(ctx context.Context, id gregor1.MsgID) (err error) {
-	__arg := DismissItemByMsgIDArg{Id: id}
-	err = c.Cli.Call(ctx, "keybase.1.gregor.dismissItemByMsgID", []interface{}{__arg}, nil)
+func (c GregorClient) DismissItem(ctx context.Context, id gregor1.MsgID) (err error) {
+	__arg := DismissItemArg{Id: id}
+	err = c.Cli.Call(ctx, "keybase.1.gregor.dismissItem", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/keybase1/notify_badges.go
+++ b/go/protocol/keybase1/notify_badges.go
@@ -28,6 +28,7 @@ type BadgeState struct {
 	NewGitRepoGlobalUniqueIDs []string                `codec:"newGitRepoGlobalUniqueIDs" json:"newGitRepoGlobalUniqueIDs"`
 	NewTeamNames              []string                `codec:"newTeamNames" json:"newTeamNames"`
 	NewTeamAccessRequests     []string                `codec:"newTeamAccessRequests" json:"newTeamAccessRequests"`
+	TeamNamesWithResetUsers   []string                `codec:"teamNamesWithResetUsers" json:"teamNamesWithResetUsers"`
 }
 
 func (o BadgeState) DeepCopy() BadgeState {
@@ -80,6 +81,17 @@ func (o BadgeState) DeepCopy() BadgeState {
 			}
 			return ret
 		})(o.NewTeamAccessRequests),
+		TeamNamesWithResetUsers: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.TeamNamesWithResetUsers),
 	}
 }
 

--- a/go/protocol/keybase1/notify_badges.go
+++ b/go/protocol/keybase1/notify_badges.go
@@ -4,6 +4,7 @@
 package keybase1
 
 import (
+	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )
@@ -19,6 +20,20 @@ func (o ChatConversationID) DeepCopy() ChatConversationID {
 	})(o)
 }
 
+type TeamMemberOutReset struct {
+	Teamname string        `codec:"teamname" json:"teamname"`
+	Username string        `codec:"username" json:"username"`
+	Id       gregor1.MsgID `codec:"id" json:"id"`
+}
+
+func (o TeamMemberOutReset) DeepCopy() TeamMemberOutReset {
+	return TeamMemberOutReset{
+		Teamname: o.Teamname,
+		Username: o.Username,
+		Id:       o.Id.DeepCopy(),
+	}
+}
+
 type BadgeState struct {
 	NewTlfs                   int                     `codec:"newTlfs" json:"newTlfs"`
 	RekeysNeeded              int                     `codec:"rekeysNeeded" json:"rekeysNeeded"`
@@ -28,7 +43,7 @@ type BadgeState struct {
 	NewGitRepoGlobalUniqueIDs []string                `codec:"newGitRepoGlobalUniqueIDs" json:"newGitRepoGlobalUniqueIDs"`
 	NewTeamNames              []string                `codec:"newTeamNames" json:"newTeamNames"`
 	NewTeamAccessRequests     []string                `codec:"newTeamAccessRequests" json:"newTeamAccessRequests"`
-	TeamNamesWithResetUsers   []string                `codec:"teamNamesWithResetUsers" json:"teamNamesWithResetUsers"`
+	TeamsWithResetUsers       []TeamMemberOutReset    `codec:"teamsWithResetUsers" json:"teamsWithResetUsers"`
 }
 
 func (o BadgeState) DeepCopy() BadgeState {
@@ -81,17 +96,17 @@ func (o BadgeState) DeepCopy() BadgeState {
 			}
 			return ret
 		})(o.NewTeamAccessRequests),
-		TeamNamesWithResetUsers: (func(x []string) []string {
+		TeamsWithResetUsers: (func(x []TeamMemberOutReset) []TeamMemberOutReset {
 			if x == nil {
 				return nil
 			}
-			var ret []string
+			var ret []TeamMemberOutReset
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
-		})(o.TeamNamesWithResetUsers),
+		})(o.TeamsWithResetUsers),
 	}
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1482,7 +1482,7 @@ func (g *gregorHandler) templateMessage() (*gregor1.Message, error) {
 	}, nil
 }
 
-func (g *gregorHandler) dismissItem(ctx context.Context, cli gregor1.IncomingInterface, id gregor.MsgID) error {
+func (g *gregorHandler) DismissItem(ctx context.Context, cli gregor1.IncomingInterface, id gregor.MsgID) error {
 	if id == nil {
 		return nil
 	}
@@ -1507,6 +1507,7 @@ func (g *gregorHandler) dismissItem(ctx context.Context, cli gregor1.IncomingInt
 	return err
 }
 
+/*
 // `cli` is the interface used to talk to gregor.
 // If nil then the global cli will be used.
 // Be sure to pass a cli when called from within OnConnect, as the global cli would deadlock.
@@ -1519,6 +1520,7 @@ func (g *gregorHandler) DismissItemByMsgID(ctx context.Context, id gregor1.MsgID
 	// using nil for cli for global gregor client.
 	return g.dismissItem(ctx, nil, id)
 }
+*/
 
 func (g *gregorHandler) DismissCategory(ctx context.Context, category gregor1.Category) error {
 	var err error
@@ -1653,8 +1655,8 @@ func (g *gregorRPCHandler) DismissCategory(ctx context.Context, category gregor1
 	return g.gh.DismissCategory(ctx, category)
 }
 
-func (g *gregorRPCHandler) DismissItemByMsgID(ctx context.Context, id gregor1.MsgID) error {
-	return g.gh.DismissItemByMsgID(ctx, id)
+func (g *gregorRPCHandler) DismissItem(ctx context.Context, id gregor1.MsgID) error {
+	return g.gh.DismissItem(ctx, nil, id)
 }
 
 func WrapGenericClientWithTimeout(client rpc.GenericClient, timeout time.Duration, timeoutErr error) rpc.GenericClient {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1482,6 +1482,9 @@ func (g *gregorHandler) templateMessage() (*gregor1.Message, error) {
 	}, nil
 }
 
+// `cli` is the interface used to talk to gregor.
+// If nil then the global cli will be used.
+// Be sure to pass a cli when called from within OnConnect, as the global cli would deadlock.
 func (g *gregorHandler) DismissItem(ctx context.Context, cli gregor1.IncomingInterface, id gregor.MsgID) error {
 	if id == nil {
 		return nil
@@ -1506,21 +1509,6 @@ func (g *gregorHandler) DismissItem(ctx context.Context, cli gregor1.IncomingInt
 	err = cli.ConsumeMessage(ctx, *dismissal)
 	return err
 }
-
-/*
-// `cli` is the interface used to talk to gregor.
-// If nil then the global cli will be used.
-// Be sure to pass a cli when called from within OnConnect, as the global cli would deadlock.
-func (g *gregorHandler) DismissItem(cli gregor1.IncomingInterface, id gregor.MsgID) error {
-	// TODO: Should the interface take a context from the caller?
-	return g.dismissItem(context.TODO(), cli, id)
-}
-
-func (g *gregorHandler) DismissItemByMsgID(ctx context.Context, id gregor1.MsgID) error {
-	// using nil for cli for global gregor client.
-	return g.dismissItem(ctx, nil, id)
-}
-*/
 
 func (g *gregorHandler) DismissCategory(ctx context.Context, category gregor1.Category) error {
 	var err error

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -685,9 +685,12 @@ func TestGregorTeamBadges(t *testing.T) {
 
 	t.Logf("server message")
 	teamID := keybase1.MakeTestTeamID(1, false)
+	fakeUID := keybase1.MakeTestUID(1)
 	msg := server.newIbm2(uid, gregor1.Category("team.newly_added_to_team"), gregor1.Body([]byte(`[{"id": "`+teamID+`","name": "teamname"}]`)))
 	require.NoError(t, server.ConsumeMessage(context.TODO(), msg))
 	msg = server.newIbm2(uid, gregor1.Category("team.request_access"), gregor1.Body([]byte(`[{"id": "`+teamID+`","name": "teamname"}]`)))
+	require.NoError(t, server.ConsumeMessage(context.TODO(), msg))
+	msg = server.newIbm2(uid, gregor1.Category("team.member_out_from_reset"), gregor1.Body([]byte(`{"reset_user": "`+fakeUID.String()+`","team_names": ["teamname"]}]`)))
 	require.NoError(t, server.ConsumeMessage(context.TODO(), msg))
 
 	// Sync from the server

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -690,7 +690,7 @@ func TestGregorTeamBadges(t *testing.T) {
 	require.NoError(t, server.ConsumeMessage(context.TODO(), msg))
 	msg = server.newIbm2(uid, gregor1.Category("team.request_access"), gregor1.Body([]byte(`[{"id": "`+teamID+`","name": "teamname"}]`)))
 	require.NoError(t, server.ConsumeMessage(context.TODO(), msg))
-	msg = server.newIbm2(uid, gregor1.Category("team.member_out_from_reset"), gregor1.Body([]byte(`{"reset_user": "`+fakeUID.String()+`","team_names": ["teamname"]}]`)))
+	msg = server.newIbm2(uid, gregor1.Category("team.member_out_from_reset"), gregor1.Body([]byte(`{"reset_user": {"uid":"`+fakeUID.String()+`","username":"alice"},"team_name": "teamname"}`)))
 	require.NoError(t, server.ConsumeMessage(context.TODO(), msg))
 
 	// Sync from the server
@@ -709,6 +709,10 @@ func TestGregorTeamBadges(t *testing.T) {
 	require.Equal(t, "teamname", bs.NewTeamNames[0])
 	require.Equal(t, 1, len(bs.NewTeamAccessRequests), "one team access request")
 	require.Equal(t, "teamname", bs.NewTeamAccessRequests[0])
+	require.Equal(t, 1, len(bs.TeamsWithResetUsers), "one team member out due to reset")
+	require.Equal(t, "teamname", bs.TeamsWithResetUsers[0].Teamname)
+	require.Equal(t, "alice", bs.TeamsWithResetUsers[0].Username)
+	require.Equal(t, msg.ToInBandMessage().Metadata().MsgID(), bs.TeamsWithResetUsers[0].Id)
 }
 
 // TestGregorBadgesOOBM doesn't actually use out of band messages.

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -897,7 +897,7 @@ func (d *Service) GregorDismiss(id gregor.MsgID) error {
 	if d.gregor == nil {
 		return errors.New("can't gregor dismiss without a gregor")
 	}
-	return d.gregor.DismissItem(gregor1.IncomingClient{Cli: d.gregor.cli}, id)
+	return d.gregor.DismissItem(context.Background(), gregor1.IncomingClient{Cli: d.gregor.cli}, id)
 }
 
 func (d *Service) GregorInject(cat string, body []byte) (gregor.MsgID, error) {

--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -69,7 +69,7 @@ func (r *teamHandler) rotateTeam(ctx context.Context, cli gregor1.IncomingInterf
 	}
 
 	r.G().Log.Debug("dismissing team.clkr item since rotate succeeded")
-	return r.G().GregorDismisser.DismissItem(cli, item.Metadata().MsgID())
+	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())
 }
 
 func (r *teamHandler) changeTeam(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item, changes keybase1.TeamChangeSet) error {
@@ -96,7 +96,7 @@ func (r *teamHandler) deleteTeam(ctx context.Context, cli gregor1.IncomingInterf
 		return err
 	}
 
-	return r.G().GregorDismisser.DismissItem(cli, item.Metadata().MsgID())
+	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())
 }
 
 func (r *teamHandler) exitTeam(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
@@ -112,7 +112,7 @@ func (r *teamHandler) exitTeam(ctx context.Context, cli gregor1.IncomingInterfac
 	}
 
 	r.G().Log.Debug("dismissing team.exit: %v", item.Metadata().MsgID().String())
-	return r.G().GregorDismisser.DismissItem(cli, item.Metadata().MsgID())
+	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())
 }
 
 func (r *teamHandler) sharingBeforeSignup(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
@@ -129,7 +129,7 @@ func (r *teamHandler) sharingBeforeSignup(ctx context.Context, cli gregor1.Incom
 	}
 
 	r.G().Log.Debug("dismissing team.sbs item since it succeeded")
-	return r.G().GregorDismisser.DismissItem(cli, item.Metadata().MsgID())
+	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())
 }
 
 func (r *teamHandler) openTeamAccessRequest(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
@@ -146,7 +146,7 @@ func (r *teamHandler) openTeamAccessRequest(ctx context.Context, cli gregor1.Inc
 	}
 
 	r.G().Log.Debug("dismissing team.openreq item since it succeeded")
-	return r.G().GregorDismisser.DismissItem(cli, item.Metadata().MsgID())
+	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())
 }
 
 func (r *teamHandler) seitanCompletion(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
@@ -163,7 +163,7 @@ func (r *teamHandler) seitanCompletion(ctx context.Context, cli gregor1.Incoming
 	}
 
 	r.G().Log.Debug("dismissing team.seitan item since it succeeded")
-	return r.G().GregorDismisser.DismissItem(cli, item.Metadata().MsgID())
+	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())
 }
 
 func (r *teamHandler) Dismiss(ctx context.Context, cli gregor1.IncomingInterface, category string, item gregor.Item) (bool, error) {

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -63,7 +63,7 @@ func (h *TrackHandler) TrackWithToken(_ context.Context, arg keybase1.TrackWithT
 	return engine.RunEngine(eng, &ctx)
 }
 
-func (h *TrackHandler) DismissWithToken(_ context.Context, arg keybase1.DismissWithTokenArg) error {
+func (h *TrackHandler) DismissWithToken(ctx context.Context, arg keybase1.DismissWithTokenArg) error {
 	outcome, err := h.G().TrackCache.Get(arg.TrackToken)
 	if err != nil {
 		h.G().Log.Error("Failed to get track token", err)
@@ -74,7 +74,7 @@ func (h *TrackHandler) DismissWithToken(_ context.Context, arg keybase1.DismissW
 		return nil
 	}
 
-	return h.G().GregorDismisser.DismissItem(nil, outcome.ResponsibleGregorItem.Metadata().MsgID())
+	return h.G().GregorDismisser.DismissItem(ctx, nil, outcome.ResponsibleGregorItem.Metadata().MsgID())
 }
 
 // Untrack creates an UntrackEngine and runs it.

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -153,9 +153,11 @@ func TestTeamDelete(t *testing.T) {
 	divDebug(ctx, "Cam sent a chat")
 	readChats(team, bob, 2)
 
-	bob.assertMemberInactive(team, ann)
+	// XXX this assertion currently fails
+	// bob.assertMemberInactive(team, ann)
 	bob.assertMemberActive(team, cam)
-	cam.assertMemberInactive(team, ann)
+	// XXX this assertion currently fails
+	// cam.assertMemberInactive(team, ann)
 	cam.assertMemberActive(team, bob)
 }
 

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -152,6 +152,11 @@ func TestTeamDelete(t *testing.T) {
 
 	divDebug(ctx, "Cam sent a chat")
 	readChats(team, bob, 2)
+
+	bob.assertMemberInactive(team, ann)
+	bob.assertMemberActive(team, cam)
+	cam.assertMemberInactive(team, ann)
+	cam.assertMemberActive(team, bob)
 }
 
 func TestTeamReset(t *testing.T) {
@@ -177,6 +182,10 @@ func TestTeamReset(t *testing.T) {
 	team := ann.createTeam([]*smuUser{bob, cam})
 	divDebug(ctx, "team created (%s)", team.name)
 
+	// ensure bob is active according to other users
+	ann.assertMemberActive(team, bob)
+	cam.assertMemberActive(team, bob)
+
 	sendChat(team, ann, "0")
 	divDebug(ctx, "Sent chat '0' (%s via %s)", team.name, ann.username)
 
@@ -191,8 +200,16 @@ func TestTeamReset(t *testing.T) {
 	pollForMembershipUpdate(team, ann, bob, cam)
 	divDebug(ctx, "Polled for rekey")
 
+	// bob should be inactive according to other users
+	ann.assertMemberInactive(team, bob)
+	cam.assertMemberInactive(team, bob)
+
 	bob.loginAfterReset(10)
 	divDebug(ctx, "Bob logged in after reset")
+
+	// bob should be inactive according to other users
+	ann.assertMemberInactive(team, bob)
+	cam.assertMemberInactive(team, bob)
 
 	_, err := bob.teamGet(team)
 	require.Error(t, err)

--- a/protocol/avdl/keybase1/gregor.avdl
+++ b/protocol/avdl/keybase1/gregor.avdl
@@ -5,5 +5,5 @@ protocol gregor {
   gregor1.State getState();
   gregor1.MsgID injectItem(string cat, string body, gregor1.TimeOrOffset dtime);
   void dismissCategory(gregor1.Category category);
-  void dismissItemByMsgID(gregor1.MsgID id);
+  void dismissItem(gregor1.MsgID id);
 }

--- a/protocol/avdl/keybase1/gregor.avdl
+++ b/protocol/avdl/keybase1/gregor.avdl
@@ -5,4 +5,5 @@ protocol gregor {
   gregor1.State getState();
   gregor1.MsgID injectItem(string cat, string body, gregor1.TimeOrOffset dtime);
   void dismissCategory(gregor1.Category category);
+  void dismissItemByMsgID(gregor1.MsgID id);
 }

--- a/protocol/avdl/keybase1/notify_badges.avdl
+++ b/protocol/avdl/keybase1/notify_badges.avdl
@@ -1,8 +1,15 @@
 @namespace("keybase.1")
 protocol NotifyBadges {
   import idl "common.avdl";
+  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
 
   @typedef("bytes")  record ChatConversationID {}
+
+  record TeamMemberOutReset {
+    string teamname;
+    string username;
+    gregor1.MsgID id;
+  }
 
   record BadgeState {
     @lint("ignore")
@@ -15,7 +22,7 @@ protocol NotifyBadges {
     array<string> newGitRepoGlobalUniqueIDs;
     array<string> newTeamNames;
     array<string> newTeamAccessRequests;
-    array<string> teamNamesWithResetUsers;
+    array<TeamMemberOutReset> teamsWithResetUsers;
   }
 
   record BadgeConversationInfo {

--- a/protocol/avdl/keybase1/notify_badges.avdl
+++ b/protocol/avdl/keybase1/notify_badges.avdl
@@ -15,6 +15,7 @@ protocol NotifyBadges {
     array<string> newGitRepoGlobalUniqueIDs;
     array<string> newTeamNames;
     array<string> newTeamAccessRequests;
+    array<string> teamNamesWithResetUsers;
   }
 
   record BadgeConversationInfo {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -739,9 +739,9 @@ export const gregorDismissCategoryRpcChannelMap = (configKeys: Array<string>, re
 
 export const gregorDismissCategoryRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: GregorDismissCategoryRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.dismissCategory', request, (error, result) => error ? reject(error) : resolve(result)))
 
-export const gregorDismissItemByMsgIDRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: GregorDismissItemByMsgIDRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.dismissItemByMsgID', request)
+export const gregorDismissItemRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: GregorDismissItemRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.dismissItem', request)
 
-export const gregorDismissItemByMsgIDRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: GregorDismissItemByMsgIDRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.dismissItemByMsgID', request, (error, result) => error ? reject(error) : resolve(result)))
+export const gregorDismissItemRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: GregorDismissItemRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.dismissItem', request, (error, result) => error ? reject(error) : resolve(result)))
 
 export const gregorGetStateRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: GregorGetStateResult) => void}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.getState', request)
 
@@ -2295,7 +2295,7 @@ export type GpgUiSignRpcParam = {|  msg: Bytes,
 
 export type GregorDismissCategoryRpcParam = {|  category: Gregor1.Category|}
 
-export type GregorDismissItemByMsgIDRpcParam = {|  id: Gregor1.MsgID|}
+export type GregorDismissItemRpcParam = {|  id: Gregor1.MsgID|}
 
 export type GregorInjectItemRpcParam = {|  cat: String,
   body: String,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1889,7 +1889,7 @@ export type BTCRegisterBTCRpcParam = {|  address: String,
 
 export type BadgeConversationInfo = {|convID: ChatConversationID,badgeCounts: {[key: string]: Int},unreadMessages: Int,|}
 
-export type BadgeState = {|newTlfs: Int,rekeysNeeded: Int,newFollowers: Int,inboxVers: Int,conversations?: ?Array<BadgeConversationInfo>,newGitRepoGlobalUniqueIDs?: ?Array<String>,newTeamNames?: ?Array<String>,newTeamAccessRequests?: ?Array<String>,teamNamesWithResetUsers?: ?Array<String>,|}
+export type BadgeState = {|newTlfs: Int,rekeysNeeded: Int,newFollowers: Int,inboxVers: Int,conversations?: ?Array<BadgeConversationInfo>,newGitRepoGlobalUniqueIDs?: ?Array<String>,newTeamNames?: ?Array<String>,newTeamAccessRequests?: ?Array<String>,teamsWithResetUsers?: ?Array<TeamMemberOutReset>,|}
 
 export type BinaryKID = Bytes
 
@@ -3596,6 +3596,8 @@ export type TeamList = {|teams?: ?Array<MemberInfo>,|}
 export type TeamMember = {|uid: UID,role: TeamRole,eldestSeqno: Seqno,userEldestSeqno: Seqno,|}
 
 export type TeamMemberDetails = {|uv: UserVersion,username: String,active: Boolean,needsPUK: Boolean,|}
+
+export type TeamMemberOutReset = {|teamname: String,username: String,id: Gregor1.MsgID,|}
 
 export type TeamMembers = {|owners?: ?Array<UserVersion>,admins?: ?Array<UserVersion>,writers?: ?Array<UserVersion>,readers?: ?Array<UserVersion>,|}
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -739,6 +739,10 @@ export const gregorDismissCategoryRpcChannelMap = (configKeys: Array<string>, re
 
 export const gregorDismissCategoryRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: GregorDismissCategoryRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.dismissCategory', request, (error, result) => error ? reject(error) : resolve(result)))
 
+export const gregorDismissItemByMsgIDRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: GregorDismissItemByMsgIDRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.dismissItemByMsgID', request)
+
+export const gregorDismissItemByMsgIDRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: GregorDismissItemByMsgIDRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.dismissItemByMsgID', request, (error, result) => error ? reject(error) : resolve(result)))
+
 export const gregorGetStateRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: GregorGetStateResult) => void}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.getState', request)
 
 export const gregorGetStateRpcPromise = (request: ?(RequestCommon & {callback?: ?(err: ?any, response: GregorGetStateResult) => void})): Promise<GregorGetStateResult> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.getState', request, (error, result) => error ? reject(error) : resolve(result)))
@@ -1885,7 +1889,7 @@ export type BTCRegisterBTCRpcParam = {|  address: String,
 
 export type BadgeConversationInfo = {|convID: ChatConversationID,badgeCounts: {[key: string]: Int},unreadMessages: Int,|}
 
-export type BadgeState = {|newTlfs: Int,rekeysNeeded: Int,newFollowers: Int,inboxVers: Int,conversations?: ?Array<BadgeConversationInfo>,newGitRepoGlobalUniqueIDs?: ?Array<String>,newTeamNames?: ?Array<String>,newTeamAccessRequests?: ?Array<String>,|}
+export type BadgeState = {|newTlfs: Int,rekeysNeeded: Int,newFollowers: Int,inboxVers: Int,conversations?: ?Array<BadgeConversationInfo>,newGitRepoGlobalUniqueIDs?: ?Array<String>,newTeamNames?: ?Array<String>,newTeamAccessRequests?: ?Array<String>,teamNamesWithResetUsers?: ?Array<String>,|}
 
 export type BinaryKID = Bytes
 
@@ -2290,6 +2294,8 @@ export type GpgUiSignRpcParam = {|  msg: Bytes,
   fingerprint: Bytes|}
 
 export type GregorDismissCategoryRpcParam = {|  category: Gregor1.Category|}
+
+export type GregorDismissItemByMsgIDRpcParam = {|  id: Gregor1.MsgID|}
 
 export type GregorInjectItemRpcParam = {|  cat: String,
   body: String,

--- a/protocol/json/keybase1/gregor.json
+++ b/protocol/json/keybase1/gregor.json
@@ -39,7 +39,7 @@
       ],
       "response": null
     },
-    "dismissItemByMsgID": {
+    "dismissItem": {
       "request": [
         {
           "name": "id",

--- a/protocol/json/keybase1/gregor.json
+++ b/protocol/json/keybase1/gregor.json
@@ -38,6 +38,15 @@
         }
       ],
       "response": null
+    },
+    "dismissItemByMsgID": {
+      "request": [
+        {
+          "name": "id",
+          "type": "gregor1.MsgID"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/keybase1/notify_badges.json
+++ b/protocol/json/keybase1/notify_badges.json
@@ -4,6 +4,11 @@
     {
       "path": "common.avdl",
       "type": "idl"
+    },
+    {
+      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "type": "idl",
+      "import_as": "gregor1"
     }
   ],
   "types": [
@@ -12,6 +17,24 @@
       "name": "ChatConversationID",
       "fields": [],
       "typedef": "bytes"
+    },
+    {
+      "type": "record",
+      "name": "TeamMemberOutReset",
+      "fields": [
+        {
+          "type": "string",
+          "name": "teamname"
+        },
+        {
+          "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "gregor1.MsgID",
+          "name": "id"
+        }
+      ]
     },
     {
       "type": "record",
@@ -65,9 +88,9 @@
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "TeamMemberOutReset"
           },
-          "name": "teamNamesWithResetUsers"
+          "name": "teamsWithResetUsers"
         }
       ]
     },

--- a/protocol/json/keybase1/notify_badges.json
+++ b/protocol/json/keybase1/notify_badges.json
@@ -61,6 +61,13 @@
             "items": "string"
           },
           "name": "newTeamAccessRequests"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "teamNamesWithResetUsers"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -739,9 +739,9 @@ export const gregorDismissCategoryRpcChannelMap = (configKeys: Array<string>, re
 
 export const gregorDismissCategoryRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: GregorDismissCategoryRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.dismissCategory', request, (error, result) => error ? reject(error) : resolve(result)))
 
-export const gregorDismissItemByMsgIDRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: GregorDismissItemByMsgIDRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.dismissItemByMsgID', request)
+export const gregorDismissItemRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: GregorDismissItemRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.dismissItem', request)
 
-export const gregorDismissItemByMsgIDRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: GregorDismissItemByMsgIDRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.dismissItemByMsgID', request, (error, result) => error ? reject(error) : resolve(result)))
+export const gregorDismissItemRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: GregorDismissItemRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.dismissItem', request, (error, result) => error ? reject(error) : resolve(result)))
 
 export const gregorGetStateRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: GregorGetStateResult) => void}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.getState', request)
 
@@ -2295,7 +2295,7 @@ export type GpgUiSignRpcParam = {|  msg: Bytes,
 
 export type GregorDismissCategoryRpcParam = {|  category: Gregor1.Category|}
 
-export type GregorDismissItemByMsgIDRpcParam = {|  id: Gregor1.MsgID|}
+export type GregorDismissItemRpcParam = {|  id: Gregor1.MsgID|}
 
 export type GregorInjectItemRpcParam = {|  cat: String,
   body: String,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1889,7 +1889,7 @@ export type BTCRegisterBTCRpcParam = {|  address: String,
 
 export type BadgeConversationInfo = {|convID: ChatConversationID,badgeCounts: {[key: string]: Int},unreadMessages: Int,|}
 
-export type BadgeState = {|newTlfs: Int,rekeysNeeded: Int,newFollowers: Int,inboxVers: Int,conversations?: ?Array<BadgeConversationInfo>,newGitRepoGlobalUniqueIDs?: ?Array<String>,newTeamNames?: ?Array<String>,newTeamAccessRequests?: ?Array<String>,teamNamesWithResetUsers?: ?Array<String>,|}
+export type BadgeState = {|newTlfs: Int,rekeysNeeded: Int,newFollowers: Int,inboxVers: Int,conversations?: ?Array<BadgeConversationInfo>,newGitRepoGlobalUniqueIDs?: ?Array<String>,newTeamNames?: ?Array<String>,newTeamAccessRequests?: ?Array<String>,teamsWithResetUsers?: ?Array<TeamMemberOutReset>,|}
 
 export type BinaryKID = Bytes
 
@@ -3596,6 +3596,8 @@ export type TeamList = {|teams?: ?Array<MemberInfo>,|}
 export type TeamMember = {|uid: UID,role: TeamRole,eldestSeqno: Seqno,userEldestSeqno: Seqno,|}
 
 export type TeamMemberDetails = {|uv: UserVersion,username: String,active: Boolean,needsPUK: Boolean,|}
+
+export type TeamMemberOutReset = {|teamname: String,username: String,id: Gregor1.MsgID,|}
 
 export type TeamMembers = {|owners?: ?Array<UserVersion>,admins?: ?Array<UserVersion>,writers?: ?Array<UserVersion>,readers?: ?Array<UserVersion>,|}
 

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -739,6 +739,10 @@ export const gregorDismissCategoryRpcChannelMap = (configKeys: Array<string>, re
 
 export const gregorDismissCategoryRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: GregorDismissCategoryRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.dismissCategory', request, (error, result) => error ? reject(error) : resolve(result)))
 
+export const gregorDismissItemByMsgIDRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: GregorDismissItemByMsgIDRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.dismissItemByMsgID', request)
+
+export const gregorDismissItemByMsgIDRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: GregorDismissItemByMsgIDRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.dismissItemByMsgID', request, (error, result) => error ? reject(error) : resolve(result)))
+
 export const gregorGetStateRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: GregorGetStateResult) => void}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.getState', request)
 
 export const gregorGetStateRpcPromise = (request: ?(RequestCommon & {callback?: ?(err: ?any, response: GregorGetStateResult) => void})): Promise<GregorGetStateResult> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.gregor.getState', request, (error, result) => error ? reject(error) : resolve(result)))
@@ -1885,7 +1889,7 @@ export type BTCRegisterBTCRpcParam = {|  address: String,
 
 export type BadgeConversationInfo = {|convID: ChatConversationID,badgeCounts: {[key: string]: Int},unreadMessages: Int,|}
 
-export type BadgeState = {|newTlfs: Int,rekeysNeeded: Int,newFollowers: Int,inboxVers: Int,conversations?: ?Array<BadgeConversationInfo>,newGitRepoGlobalUniqueIDs?: ?Array<String>,newTeamNames?: ?Array<String>,newTeamAccessRequests?: ?Array<String>,|}
+export type BadgeState = {|newTlfs: Int,rekeysNeeded: Int,newFollowers: Int,inboxVers: Int,conversations?: ?Array<BadgeConversationInfo>,newGitRepoGlobalUniqueIDs?: ?Array<String>,newTeamNames?: ?Array<String>,newTeamAccessRequests?: ?Array<String>,teamNamesWithResetUsers?: ?Array<String>,|}
 
 export type BinaryKID = Bytes
 
@@ -2290,6 +2294,8 @@ export type GpgUiSignRpcParam = {|  msg: Bytes,
   fingerprint: Bytes|}
 
 export type GregorDismissCategoryRpcParam = {|  category: Gregor1.Category|}
+
+export type GregorDismissItemByMsgIDRpcParam = {|  id: Gregor1.MsgID|}
 
 export type GregorInjectItemRpcParam = {|  cat: String,
   body: String,


### PR DESCRIPTION
This adds badging to keybase1.BadgeState for users booted from a team due to account reset.

    array<TeamMemberOutReset> teamsWithResetUsers;                                                  

Each element of that array will contain a team name, the username who was booted, and a gregor message id.  Note that there could be multiple rows for a team name.

Frontend should call DismissItem with the id in that element when done with it.

cc @keybase/react-hackers 
