### PR TITLE
move channel name mentions parsing to frontend presentation functions CORE-6555

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -417,8 +417,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 				debugger.Debug(ctx, "FindConversations: failed to get TLFID from name: %s", err.Error())
 				return res, rl, err
 			}
-			tlfConvs, irl, err := g.TeamChannelSource.GetChannelsFull(ctx, uid, nameInfo.ID, topicType,
-				membersType)
+			tlfConvs, irl, err := g.TeamChannelSource.GetChannelsFull(ctx, uid, nameInfo.ID, topicType)
 			if err != nil {
 				debugger.Debug(ctx, "FindConversations: failed to list TLF conversations: %s", err.Error())
 				return res, rl, err

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -461,7 +461,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				}
 				desktopNotification := g.shouldDisplayDesktopNotification(ctx, uid, conv, decmsg)
 				activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-					Message: utils.PresentMessageUnboxed(decmsg),
+					Message: utils.PresentMessageUnboxed(ctx, decmsg, uid, g.G().TeamChannelSource),
 					ConvID:  nm.ConvID,
 					Conv:    g.presentUIItem(conv),
 					DisplayDesktopNotification: desktopNotification,

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -331,7 +331,7 @@ func (s *BlockingSender) checkTopicNameAndGetState(ctx context.Context, msg chat
 		topicType := msg.ClientHeader.Conv.TopicType
 		newTopicName := msg.MessageBody.Metadata().ConversationTitle
 		convs, _, err := s.G().TeamChannelSource.GetChannelsFull(ctx, msg.ClientHeader.Sender, tlfID,
-			topicType, membersType)
+			topicType)
 		if err != nil {
 			return topicNameState, err
 		}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3364,9 +3364,11 @@ func TestChatSrvTeamChannelNameMentions(t *testing.T) {
 				},
 			})
 			require.NoError(t, err)
-			require.Equal(t, 1, len(tv.Thread.Messages))
-			require.Equal(t, 1, len(tv.Thread.Messages[0].Valid().ChannelNameMentions))
-			require.Equal(t, topicName, tv.Thread.Messages[0].Valid().ChannelNameMentions[0])
+			uid := users[0].User.GetUID().ToBytes()
+			ptv := utils.PresentThreadView(ctx, uid, tv.Thread, ctc.as(t, users[0]).h.G().TeamChannelSource)
+			require.Equal(t, 1, len(ptv.Messages))
+			require.Equal(t, 1, len(ptv.Messages[0].Valid().ChannelNameMentions))
+			require.Equal(t, topicName, ptv.Messages[0].Valid().ChannelNameMentions[0])
 		}
 	})
 }

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -63,7 +63,6 @@ func (t *basicSupersedesTransform) transformEdit(msg chat1.MessageUnboxed, super
 		AtMentions:            superMsg.Valid().AtMentions,
 		AtMentionUsernames:    superMsg.Valid().AtMentionUsernames,
 		ChannelMention:        superMsg.Valid().ChannelMention,
-		ChannelNameMentions:   superMsg.Valid().ChannelNameMentions,
 	})
 	return &newMsg
 }

--- a/go/chat/teamchannelsource.go
+++ b/go/chat/teamchannelsource.go
@@ -116,6 +116,7 @@ func (c *CachingTeamChannelSource) GetChannelsTopicName(ctx context.Context, uid
 		SummarizeMaxMsgs: false,
 	})
 	if err != nil {
+		c.Debug(ctx, "GetChannelsTopicName: failed to get TLF convos: %s", err)
 		return res, rl, err
 	}
 	if tlfRes.RateLimit != nil {

--- a/go/chat/teamchannelsource.go
+++ b/go/chat/teamchannelsource.go
@@ -72,13 +72,11 @@ func (c *CachingTeamChannelSource) invalidate(ctx context.Context, teamID chat1.
 }
 
 func (c *CachingTeamChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID, teamID chat1.TLFID,
-	topicType chat1.TopicType, membersType chat1.ConversationMembersType) (res []chat1.ConversationLocal,
-	rl []chat1.RateLimit, err error) {
+	topicType chat1.TopicType) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
 	var convs []chat1.Conversation
 	tlfRes, err := c.ri().GetTLFConversations(ctx, chat1.GetTLFConversationsArg{
 		TlfID:            teamID,
 		TopicType:        topicType,
-		MembersType:      membersType,
 		SummarizeMaxMsgs: false,
 	})
 	if err != nil {
@@ -103,7 +101,7 @@ func (c *CachingTeamChannelSource) GetChannelsFull(ctx context.Context, uid greg
 }
 
 func (c *CachingTeamChannelSource) GetChannelsTopicName(ctx context.Context, uid gregor1.UID,
-	teamID chat1.TLFID, topicType chat1.TopicType, membersType chat1.ConversationMembersType) (res []types.ConvIDAndTopicName, rl []chat1.RateLimit, err error) {
+	teamID chat1.TLFID, topicType chat1.TopicType) (res []types.ConvIDAndTopicName, rl []chat1.RateLimit, err error) {
 
 	var ok bool
 	if res, ok = c.fetchFromCache(ctx, teamID); ok {
@@ -115,7 +113,6 @@ func (c *CachingTeamChannelSource) GetChannelsTopicName(ctx context.Context, uid
 	tlfRes, err := c.ri().GetTLFConversations(ctx, chat1.GetTLFConversationsArg{
 		TlfID:            teamID,
 		TopicType:        topicType,
-		MembersType:      membersType,
 		SummarizeMaxMsgs: false,
 	})
 	if err != nil {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -169,9 +169,7 @@ type AppState interface {
 type TeamChannelSource interface {
 	Offlinable
 
-	GetChannelsFull(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType,
-		chat1.ConversationMembersType) ([]chat1.ConversationLocal, []chat1.RateLimit, error)
-	GetChannelsTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType,
-		chat1.ConversationMembersType) ([]ConvIDAndTopicName, []chat1.RateLimit, error)
+	GetChannelsFull(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType) ([]chat1.ConversationLocal, []chat1.RateLimit, error)
+	GetChannelsTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType) ([]ConvIDAndTopicName, []chat1.RateLimit, error)
 	ChannelsChanged(context.Context, chat1.TLFID)
 }

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -407,12 +407,12 @@ func GetSupersedes(msg chat1.MessageUnboxed) ([]chat1.MessageID, error) {
 var chanNameMentionRegExp = regexp.MustCompile(`\B#([0-9a-zA-Z_-]+)`)
 
 func ParseChannelNameMentions(ctx context.Context, body string, uid gregor1.UID, teamID chat1.TLFID,
-	membersType chat1.ConversationMembersType, ts types.TeamChannelSource) (res []string) {
+	ts types.TeamChannelSource) (res []string) {
 	names := parseRegexpNames(ctx, body, chanNameMentionRegExp)
 	if len(names) == 0 {
 		return nil
 	}
-	chanResponse, _, err := ts.GetChannelsTopicName(ctx, uid, teamID, chat1.TopicType_CHAT, membersType)
+	chanResponse, _, err := ts.GetChannelsTopicName(ctx, uid, teamID, chat1.TopicType_CHAT)
 	if err != nil {
 		return nil
 	}
@@ -727,7 +727,8 @@ func PresentConversationLocals(convs []chat1.ConversationLocal) (res []chat1.Inb
 	return res
 }
 
-func PresentMessageUnboxed(rawMsg chat1.MessageUnboxed) (res chat1.UIMessage) {
+func PresentMessageUnboxed(ctx context.Context, rawMsg chat1.MessageUnboxed, uid gregor1.UID,
+	tcs types.TeamChannelSource) (res chat1.UIMessage) {
 	state, err := rawMsg.State()
 	if err != nil {
 		res = chat1.NewUIMessageWithError(chat1.MessageUnboxedError{
@@ -737,8 +738,19 @@ func PresentMessageUnboxed(rawMsg chat1.MessageUnboxed) (res chat1.UIMessage) {
 		})
 		return res
 	}
+
 	switch state {
 	case chat1.MessageUnboxedState_VALID:
+		// Get channel name mentions (only frontend really cares about these, so just get it here)
+		var channelNameMentions []string
+		switch rawMsg.GetMessageType() {
+		case chat1.MessageType_TEXT:
+			channelNameMentions = ParseChannelNameMentions(ctx, rawMsg.Valid().MessageBody.Text().Body, uid,
+				rawMsg.Valid().ClientHeader.Conv.Tlfid, tcs)
+		case chat1.MessageType_EDIT:
+			channelNameMentions = ParseChannelNameMentions(ctx, rawMsg.Valid().MessageBody.Edit().Body, uid,
+				rawMsg.Valid().ClientHeader.Conv.Tlfid, tcs)
+		}
 		var strOutboxID *string
 		if rawMsg.Valid().ClientHeader.OutboxID != nil {
 			so := rawMsg.Valid().ClientHeader.OutboxID.String()
@@ -756,7 +768,7 @@ func PresentMessageUnboxed(rawMsg chat1.MessageUnboxed) (res chat1.UIMessage) {
 			Superseded:            rawMsg.Valid().ServerHeader.SupersededBy != 0,
 			AtMentions:            rawMsg.Valid().AtMentionUsernames,
 			ChannelMention:        rawMsg.Valid().ChannelMention,
-			ChannelNameMentions:   rawMsg.Valid().ChannelNameMentions,
+			ChannelNameMentions:   channelNameMentions,
 		})
 	case chat1.MessageUnboxedState_OUTBOX:
 		var body string

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -727,6 +727,15 @@ func PresentConversationLocals(convs []chat1.ConversationLocal) (res []chat1.Inb
 	return res
 }
 
+func PresentThreadView(ctx context.Context, uid gregor1.UID, tv chat1.ThreadView,
+	tcs types.TeamChannelSource) (res chat1.UIMessages) {
+	res.Pagination = PresentPagination(tv.Pagination)
+	for _, msg := range tv.Messages {
+		res.Messages = append(res.Messages, PresentMessageUnboxed(ctx, msg, uid, tcs))
+	}
+	return res
+}
+
 func PresentMessageUnboxed(ctx context.Context, rawMsg chat1.MessageUnboxed, uid gregor1.UID,
 	tcs types.TeamChannelSource) (res chat1.UIMessage) {
 	state, err := rawMsg.State()

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -51,7 +51,7 @@ func newTestTeamChannelSource(channels []string) *testTeamChannelSource {
 }
 
 func (t *testTeamChannelSource) GetChannelsTopicName(ctx context.Context, uid gregor1.UID,
-	teamID chat1.TLFID, topicType chat1.TopicType, membersType chat1.ConversationMembersType) (res []types.ConvIDAndTopicName, rl []chat1.RateLimit, err error) {
+	teamID chat1.TLFID, topicType chat1.TopicType) (res []types.ConvIDAndTopicName, rl []chat1.RateLimit, err error) {
 	for _, c := range t.channels {
 		res = append(res, types.ConvIDAndTopicName{
 			TopicName: c,
@@ -61,7 +61,7 @@ func (t *testTeamChannelSource) GetChannelsTopicName(ctx context.Context, uid gr
 }
 
 func (t *testTeamChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID,
-	teamID chat1.TLFID, topicType chat1.TopicType, membersType chat1.ConversationMembersType) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
+	teamID chat1.TLFID, topicType chat1.TopicType) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
 	return res, rl, nil
 }
 
@@ -79,7 +79,7 @@ func TestParseChannelNameMentions(t *testing.T) {
 	teamID := chat1.TLFID{0}
 	chans := []string{"general", "random", "miketime"}
 	text := "#miketime is secret. #general has everyone. #random exists. #offtopic does not."
-	matches := ParseChannelNameMentions(context.TODO(), text, uid, teamID, chat1.ConversationMembersType_TEAM,
+	matches := ParseChannelNameMentions(context.TODO(), text, uid, teamID,
 		newTestTeamChannelSource(chans))
 	expected := []string{"miketime", "general", "random"}
 	require.Equal(t, expected, matches)

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -465,6 +465,27 @@ func (m *ChatRemoteMock) createBogusBody(typ chat1.MessageType) chat1.MessageBod
 	}
 }
 
+type dummyChannelSource struct{}
+
+func (d dummyChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID, tlfID chat1.TLFID,
+	topicType chat1.TopicType) ([]chat1.ConversationLocal, []chat1.RateLimit, error) {
+	return nil, nil, nil
+}
+
+func (d dummyChannelSource) GetChannelsTopicName(ctx context.Context, uid gregor1.UID, tlfID chat1.TLFID,
+	topicType chat1.TopicType) ([]types.ConvIDAndTopicName, []chat1.RateLimit, error) {
+	return nil, nil, nil
+}
+
+func (d dummyChannelSource) ChannelsChanged(ctx context.Context, tlfID chat1.TLFID) {}
+
+func (d dummyChannelSource) IsOffline(ctx context.Context) bool {
+	return false
+}
+
+func (d dummyChannelSource) Connected(ctx context.Context)    {}
+func (d dummyChannelSource) Disconnected(ctx context.Context) {}
+
 func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg) (res chat1.PostRemoteRes, err error) {
 	uid := arg.MessageBoxed.ClientHeader.Sender
 	conv := m.world.GetConversationByID(arg.ConversationID)
@@ -487,12 +508,12 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 	// hit notify router with new message
 	if m.world.TcsByID[uid.String()].G.NotifyRouter != nil {
 		activity := chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-			Message: utils.PresentMessageUnboxed(
+			Message: utils.PresentMessageUnboxed(ctx,
 				chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
 					ClientHeader: m.headerToVerifiedForTesting(inserted.ClientHeader),
 					ServerHeader: *inserted.ServerHeader,
 					MessageBody:  m.createBogusBody(inserted.GetMessageType()),
-				})),
+				}), uid, dummyChannelSource{}),
 		})
 		m.world.TcsByID[uid.String()].G.NotifyRouter.HandleNewChatActivity(context.Background(),
 			keybase1.UID(uid.String()), &activity)

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1976,7 +1976,6 @@ type MessageUnboxedValid struct {
 	AtMentionUsernames    []string                    `codec:"atMentionUsernames" json:"atMentionUsernames"`
 	AtMentions            []gregor1.UID               `codec:"atMentions" json:"atMentions"`
 	ChannelMention        ChannelMention              `codec:"channelMention" json:"channelMention"`
-	ChannelNameMentions   []string                    `codec:"channelNameMentions" json:"channelNameMentions"`
 }
 
 func (o MessageUnboxedValid) DeepCopy() MessageUnboxedValid {
@@ -2038,17 +2037,6 @@ func (o MessageUnboxedValid) DeepCopy() MessageUnboxedValid {
 			return ret
 		})(o.AtMentions),
 		ChannelMention: o.ChannelMention.DeepCopy(),
-		ChannelNameMentions: (func(x []string) []string {
-			if x == nil {
-				return nil
-			}
-			var ret []string
-			for _, v := range x {
-				vCopy := v
-				ret = append(ret, vCopy)
-			}
-			return ret
-		})(o.ChannelNameMentions),
 	}
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -850,17 +850,6 @@ type GetTLFConversationsArg struct {
 	SummarizeMaxMsgs bool      `codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
 }
 
-<<<<<<< HEAD
-=======
-func (o GetTLFConversationsArg) DeepCopy() GetTLFConversationsArg {
-	return GetTLFConversationsArg{
-		TlfID:            o.TlfID.DeepCopy(),
-		TopicType:        o.TopicType.DeepCopy(),
-		SummarizeMaxMsgs: o.SummarizeMaxMsgs,
-	}
-}
-
->>>>>>> move channel name mention parsing to present
 type SetAppNotificationSettingsArg struct {
 	ConvID   ConversationID               `codec:"convID" json:"convID"`
 	Settings ConversationNotificationInfo `codec:"settings" json:"settings"`

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -845,12 +845,22 @@ type DeleteConversationArg struct {
 }
 
 type GetTLFConversationsArg struct {
-	TlfID            TLFID                   `codec:"tlfID" json:"tlfID"`
-	TopicType        TopicType               `codec:"topicType" json:"topicType"`
-	MembersType      ConversationMembersType `codec:"membersType" json:"membersType"`
-	SummarizeMaxMsgs bool                    `codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
+	TlfID            TLFID     `codec:"tlfID" json:"tlfID"`
+	TopicType        TopicType `codec:"topicType" json:"topicType"`
+	SummarizeMaxMsgs bool      `codec:"summarizeMaxMsgs" json:"summarizeMaxMsgs"`
 }
 
+<<<<<<< HEAD
+=======
+func (o GetTLFConversationsArg) DeepCopy() GetTLFConversationsArg {
+	return GetTLFConversationsArg{
+		TlfID:            o.TlfID.DeepCopy(),
+		TopicType:        o.TopicType.DeepCopy(),
+		SummarizeMaxMsgs: o.SummarizeMaxMsgs,
+	}
+}
+
+>>>>>>> move channel name mention parsing to present
 type SetAppNotificationSettingsArg struct {
 	ConvID   ConversationID               `codec:"convID" json:"convID"`
 	Settings ConversationNotificationInfo `codec:"settings" json:"settings"`

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -327,7 +327,6 @@ protocol local {
     array<string> atMentionUsernames;
     array<gregor1.UID> atMentions;
     ChannelMention channelMention;
-    array<string> channelNameMentions;
   }
 
   enum MessageUnboxedErrorType {

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -238,7 +238,7 @@ protocol remote {
     array<Conversation> conversations;
     union { null, RateLimit } rateLimit;
   }
-  GetTLFConversationsRes getTLFConversations(TLFID tlfID, TopicType topicType, ConversationMembersType membersType, boolean summarizeMaxMsgs);
+  GetTLFConversationsRes getTLFConversations(TLFID tlfID, TopicType topicType, boolean summarizeMaxMsgs);
 
   // Chat notification configuration endpoint. Does not need to be complete, just a delta on the
   // currently configured settings.

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1069,7 +1069,7 @@ export type MessageUnboxedState =1 // VALID_1
  | 4 // PLACEHOLDER_4
 
 
-export type MessageUnboxedValid = {|clientHeader: MessageClientHeaderVerified,serverHeader: MessageServerHeader,messageBody: MessageBody,senderUsername: String,senderDeviceName: String,senderDeviceType: String,bodyHash: Hash,headerHash: Hash,headerSignature?: ?SignatureInfo,verificationKey?: ?Bytes,senderDeviceRevokedAt?: ?Gregor1.Time,atMentionUsernames?: ?Array<String>,atMentions?: ?Array<Gregor1.UID>,channelMention: ChannelMention,channelNameMentions?: ?Array<String>,|}
+export type MessageUnboxedValid = {|clientHeader: MessageClientHeaderVerified,serverHeader: MessageServerHeader,messageBody: MessageBody,senderUsername: String,senderDeviceName: String,senderDeviceType: String,bodyHash: Hash,headerHash: Hash,headerSignature?: ?SignatureInfo,verificationKey?: ?Bytes,senderDeviceRevokedAt?: ?Gregor1.Time,atMentionUsernames?: ?Array<String>,atMentions?: ?Array<Gregor1.UID>,channelMention: ChannelMention,|}
 
 export type NameQuery = {|name: String,membersType: ConversationMembersType,|}
 
@@ -1178,7 +1178,6 @@ export type RemoteGetS3ParamsRpcParam = {|  conversationID: ConversationID|}
 
 export type RemoteGetTLFConversationsRpcParam = {|  tlfID: TLFID,
   topicType: TopicType,
-  membersType: ConversationMembersType,
   summarizeMaxMsgs: Boolean|}
 
 export type RemoteGetThreadRemoteRpcParam = {|  conversationID: ConversationID,

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -984,13 +984,6 @@
         {
           "type": "ChannelMention",
           "name": "channelMention"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "string"
-          },
-          "name": "channelNameMentions"
         }
       ]
     },

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -928,10 +928,6 @@
           "type": "TopicType"
         },
         {
-          "name": "membersType",
-          "type": "ConversationMembersType"
-        },
-        {
           "name": "summarizeMaxMsgs",
           "type": "boolean"
         }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1069,7 +1069,7 @@ export type MessageUnboxedState =1 // VALID_1
  | 4 // PLACEHOLDER_4
 
 
-export type MessageUnboxedValid = {|clientHeader: MessageClientHeaderVerified,serverHeader: MessageServerHeader,messageBody: MessageBody,senderUsername: String,senderDeviceName: String,senderDeviceType: String,bodyHash: Hash,headerHash: Hash,headerSignature?: ?SignatureInfo,verificationKey?: ?Bytes,senderDeviceRevokedAt?: ?Gregor1.Time,atMentionUsernames?: ?Array<String>,atMentions?: ?Array<Gregor1.UID>,channelMention: ChannelMention,channelNameMentions?: ?Array<String>,|}
+export type MessageUnboxedValid = {|clientHeader: MessageClientHeaderVerified,serverHeader: MessageServerHeader,messageBody: MessageBody,senderUsername: String,senderDeviceName: String,senderDeviceType: String,bodyHash: Hash,headerHash: Hash,headerSignature?: ?SignatureInfo,verificationKey?: ?Bytes,senderDeviceRevokedAt?: ?Gregor1.Time,atMentionUsernames?: ?Array<String>,atMentions?: ?Array<Gregor1.UID>,channelMention: ChannelMention,|}
 
 export type NameQuery = {|name: String,membersType: ConversationMembersType,|}
 
@@ -1178,7 +1178,6 @@ export type RemoteGetS3ParamsRpcParam = {|  conversationID: ConversationID|}
 
 export type RemoteGetTLFConversationsRpcParam = {|  tlfID: TLFID,
   topicType: TopicType,
-  membersType: ConversationMembersType,
   summarizeMaxMsgs: Boolean|}
 
 export type RemoteGetThreadRemoteRpcParam = {|  conversationID: ConversationID,


### PR DESCRIPTION
Patch does the following:

1.) Moves the code for getting channel name mentions into the function that creates the frontend type, `PresentMessageUnboxed`.  We essentially don't care about these mentions at all anywhere on the backend, so doing it at this level seems like the right place.
2.) In the old location of this code, we could get a deadlock if we are unboxing a conversation that is channel mentioned in a different conversation.