### PR TITLE
run Linux builds under /var/tmp so that they get cleaned eventually

### DIFF
--- a/packaging/linux/docker_build.sh
+++ b/packaging/linux/docker_build.sh
@@ -48,8 +48,7 @@ cp ~/.github_token "$github_token_temp"
 # Prepare a folder that we'll share with the container, as the container's
 # /root directory, where all the build work gets done. Docker recommends that
 # write-heavy work happen in shared folders, for better performance.
-mkdir -p "$HOME/keybase_builds"
-work_dir="$HOME/keybase_builds/$(date +%Y_%m_%d_%H%M%S)_$mode"
+work_dir="/var/tmp/keybase_build_$(date +%Y_%m_%d_%H%M%S)_$mode"
 mkdir "$work_dir"  # no -p, it's intentionally an error if this exists
 
 # Export the GPG code signing key. We can't just share the ~/.gnupg directory,


### PR DESCRIPTION
r? @mlsteele 