### PR TITLE
turn off branch islands in linker, don't think we need it and it breaks the build

### DIFF
--- a/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -57,6 +57,20 @@
 			remoteGlobalIDString = 014A3B5C1C6CF33500B6D375;
 			remoteInfo = RNImagePicker;
 		};
+		27B80F581FB4C0F3008EF78B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB2BD1B21DE7D97900BB7989 /* RCTWebSocket.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3DBE0D001F3B181A0099AA32;
+			remoteInfo = fishhook;
+		};
+		27B80F5A1FB4C0F3008EF78B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB2BD1B21DE7D97900BB7989 /* RCTWebSocket.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3DBE0D0D1F3B181C0099AA32;
+			remoteInfo = "fishhook-tvOS";
+		};
 		37D298091F9A48D600D43971 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6266E16BBFF8461CAF2DDCB9 /* RCTContacts.xcodeproj */;
@@ -648,6 +662,8 @@
 			children = (
 				DB2BD1E21DE7D97900BB7989 /* libRCTWebSocket.a */,
 				DB2BD1E41DE7D97900BB7989 /* libRCTWebSocket-tvOS.a */,
+				27B80F591FB4C0F3008EF78B /* libfishhook.a */,
+				27B80F5B1FB4C0F3008EF78B /* libfishhook-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -889,6 +905,20 @@
 			fileType = archive.ar;
 			path = libRNImagePicker.a;
 			remoteRef = 27429B071E64A7A90058A4F9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		27B80F591FB4C0F3008EF78B /* libfishhook.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libfishhook.a;
+			remoteRef = 27B80F581FB4C0F3008EF78B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		27B80F5B1FB4C0F3008EF78B /* libfishhook-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libfishhook-tvOS.a";
+			remoteRef = 27B80F5A1FB4C0F3008EF78B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		37D2980A1F9A48D600D43971 /* libRCTContacts.a */ = {
@@ -1326,6 +1356,8 @@
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
+					"-Xlinker",
+					"-no_branch_islands",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios;
 				PRODUCT_NAME = Keybase;
@@ -1379,6 +1411,8 @@
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
+					"-Xlinker",
+					"-no_branch_islands",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios;
 				PRODUCT_NAME = Keybase;


### PR DESCRIPTION
Turns off the "branch islands" pass in the Apple linker, which I think might be buggy? I don't think anything in our code base actually needs this algorithm to be run on it, and it seems to get triggered just based on the size of the app. Anyway, I am running the app now with it off and it seems to work, but I'd be fine with people rejecting this solution.