### PR TITLE
Clear add to team selections when closing the dialog

### DIFF
--- a/shared/teams/add-people/container.js
+++ b/shared/teams/add-people/container.js
@@ -28,7 +28,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
     dispatch(SearchCreators.setUserInputItems('addToTeamSearch', []))
   },
   onClose: () => {
-    dispatch(navigateUp()),
+    dispatch(navigateUp())
     dispatch(SearchCreators.clearSearchResults('addToTeamSearch'))
     dispatch(SearchCreators.setUserInputItems('addToTeamSearch', []))
   },

--- a/shared/teams/add-people/container.js
+++ b/shared/teams/add-people/container.js
@@ -27,7 +27,11 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
     dispatch(SearchCreators.clearSearchResults('addToTeamSearch'))
     dispatch(SearchCreators.setUserInputItems('addToTeamSearch', []))
   },
-  onClose: () => dispatch(navigateUp()),
+  onClose: () => {
+    dispatch(navigateUp()),
+    dispatch(SearchCreators.clearSearchResults('addToTeamSearch'))
+    dispatch(SearchCreators.setUserInputItems('addToTeamSearch', []))
+  },
   onOpenRolePicker: (role: string, onComplete: string => void) => {
     dispatch(
       navigateAppend([


### PR DESCRIPTION
@keybase/react-hackers 

We were clearing the add-to-team search when you add someone, but not when you just close the dialog.