### PR TITLE
CLI: Add support for canceling invites by ID

### DIFF
--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -27,6 +27,7 @@ type CmdTeamListMemberships struct {
 	includeImplicitTeams bool
 	showAll              bool
 	verbose              bool
+	showInviteID         bool
 	tabw                 *tabwriter.Writer
 }
 
@@ -61,12 +62,12 @@ func newCmdTeamListMemberships(cl *libcmdline.CommandLine, g *libkb.GlobalContex
 			Usage: "List memberships for a user assertion",
 		},
 		cli.BoolFlag{
-			Name:  "include-subteams",
-			Usage: "Include any subteam memberships as well",
-		},
-		cli.BoolFlag{
 			Name:  "all",
 			Usage: "Show all members of all teams you belong to",
+		},
+		cli.BoolFlag{
+			Name:  "show-invite-id",
+			Usage: "Show invite IDs",
 		},
 		cli.BoolFlag{
 			Name:  "v, verbose",
@@ -102,6 +103,7 @@ func (c *CmdTeamListMemberships) ParseArgv(ctx *cli.Context) error {
 	c.userAssertion = ctx.String("user")
 	c.includeImplicitTeams = ctx.Bool("include-implicit-teams")
 	c.showAll = ctx.Bool("all")
+	c.showInviteID = ctx.Bool("show-invite-id")
 
 	if c.showAll {
 		if c.team != "" {
@@ -270,9 +272,26 @@ func (c *CmdTeamListMemberships) formatInviteName(invite keybase1.AnnotatedTeamI
 
 func (c *CmdTeamListMemberships) outputInvites(invites map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite) {
 	for _, invite := range invites {
-		fmtstring := "%s\t%s*\t%s\t(* added by %s; awaiting acceptance)\n"
+		category, err := invite.Type.C()
+		if err != nil {
+			category = keybase1.TeamInviteCategory_UNKNOWN
+		}
+		trailer := fmt.Sprintf("(* invited by %s, awaiting acceptance)", invite.InviterUsername)
+		switch category {
+		case keybase1.TeamInviteCategory_EMAIL:
+			trailer = fmt.Sprintf("(* invited via email by %s, awaiting acceptance)", invite.InviterUsername)
+		case keybase1.TeamInviteCategory_SEITAN:
+			inviteIDTrailer := ""
+			if c.showInviteID {
+				// Show invite IDs for SEITAN tokens, which can be used to cancel the invite.
+				inviteIDTrailer = fmt.Sprintf(" (Invite ID: %s)", invite.Id)
+			}
+			trailer = fmt.Sprintf("(* invited via secret token by %s, awaiting acceptance)%s",
+				invite.InviterUsername, inviteIDTrailer)
+		}
+		fmtstring := "%s\t%s*\t%s\t%s\n"
 		fmt.Fprintf(c.tabw, fmtstring, invite.TeamName, strings.ToLower(invite.Role.String()),
-			c.formatInviteName(invite), invite.InviterUsername)
+			c.formatInviteName(invite), trailer)
 	}
 }
 

--- a/go/client/cmd_team_settings.go
+++ b/go/client/cmd_team_settings.go
@@ -300,16 +300,16 @@ func (c *CmdTeamSettings) GetUsage() libkb.Usage {
 const teamSettingsDoc = `"keybase team settings" lets you edit settings for a team
 
 EXAMPLES:
-Review team settings:
-    keybase team settings acme
-Open a team so anyone can join as a reader:
-    keybase team settings acme --open-team=reader
-Showcase a team publicly:
-    keybase team settings acme --showcase=yes
-Promote a team on your profile:
-    keybase team settings acme --profile-promote=yes
-Set a description for the team to show if promoted:
-    keybase team settings acme --description="Rocket-Powered Products"
-Clear the team description:
-    keybase team settings acme --description=""
+    Review team settings:
+        keybase team settings acme
+    Open a team so anyone can join as a reader:
+        keybase team settings acme --open-team=reader
+    Showcase a team publicly:
+        keybase team settings acme --showcase=yes
+    Promote a team on your profile:
+        keybase team settings acme --profile-promote=yes
+    Set a description for the team to show if promoted:
+        keybase team settings acme --description="Rocket-Powered Products"
+    Clear the team description:
+        keybase team settings acme --description=""
 `

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -306,7 +306,7 @@ func (t *Team) applicationKeyForMask(mask keybase1.ReaderKeyMask, secret keybase
 	case keybase1.TeamApplication_SEITAN_INVITE_TOKEN:
 		derivationString = libkb.TeamSeitanTokenDerivationString
 	default:
-		return keybase1.TeamApplicationKey{}, errors.New("invalid application id")
+		return keybase1.TeamApplicationKey{}, fmt.Errorf("unrecognized application id: %v", mask.Application)
 	}
 
 	key := keybase1.TeamApplicationKey{

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -343,6 +343,8 @@ protocol teams {
   @typedef("string")
   record SeitanAKey {}
 
+  // The secret shared with the recipient.
+  // With this information one can accept an invite.
   @typedef("string")
   record SeitanIKey {}
 


### PR DESCRIPTION
Add support for canceling invites by ID. Used for seitan invites. Add --show-invite-id to list-members which will list all members and invites and annotate _only_ seitan invites with their invite ID.

```
$ kbu team remove-member -h
NAME:
   keybase team remove-member - Remove a user from a team.

USAGE:
   keybase team remove-member [command options] <team name> --user=<username>

DESCRIPTION:
   "keybase team remove-member" lets you remove members and cancel invites

EXAMPLES:
    Remove a user from the team:
        keybase team remove-member acme --user roadrunner
    Cancel an email invite:
        keybase team remove-member acme --email roadrunner@acme.com
    Cancel a secret token invite (like sms):
        keybase team list-members acme --show-invite-id # to get the invite ID
        keybase team remove-member acme --invite-id 9cfd13f927bcd1f6832fefa084bb2127


OPTIONS:
   -u, --user   username
   --email      cancel a pending invite by email address
   --invite-id  cancel a pending invite by ID
   -f, --force  don't ask for confirmation

$ kbu team list-members cn3team3 --show-invite-id
cn3team3  owner    cn4
cn3team3  owner    cn3
cn3team3  admin    t_alice
cn3team3  admin*   123             (* invited via secret token by cn3, awaiting acceptance) (Invite ID: 785459cdf858018b8c9366f3cebd6c27)
cn3team3  reader*  mcjagger (123)  (* invited via secret token by cn3, awaiting acceptance) (Invite ID: bd9746e7d783116799fa874f6f634d27)
cn3team3  admin*   123             (* invited via secret token by cn3, awaiting acceptance) (Invite ID: 0aa4e9771cb0ad92e35c8837afdf7c27)
cn3team3  admin*   mcjagger        (* invited via secret token by cn3, awaiting acceptance) (Invite ID: abf63b5f17ad3878f9b2d51160939e27)
cn3team3  reader*  mcjagger (123)  (* invited via secret token by cn3, awaiting acceptance) (Invite ID: d953bea00c05ad2af38379b4a77e2827)
cn3team3  writer*  mcjagger (123)  (* invited via secret token by cn3, awaiting acceptance) (Invite ID: b26c60d4151e422558de1ddf012b6c27)
cn3team3  admin*   asdf@asdf.asdf  (* invited via email by cn3, awaiting acceptance)
cn3team3  admin*   mcjagger (123)  (* invited via secret token by cn3, awaiting acceptance) (Invite ID: ff7efceb47babb3d54e27361e6c84d27)

$ kbu team remove-member cn3team3 --invite-id abf63b5f17ad3878f9b2d51160939e27
Are you sure? [y/N] y
Success! Invitation canceled for team cn3team3.

$ kbu team remove-member cn3team3 --invite-id abf63b5f17ad3878f9b2d51160939e27
Are you sure? [y/N] y
▶ ERROR not all invite IDs could be canceled (code 2645)

$ kbu team remove-member cn3team3 --invite-id xxx
Error parsing command line arguments: Invite IDs are 32 characters and end in '27' (encoding/hex: odd length hex string). Use `keybase team list-members cn3team3 --show-invite-id` to find one.
...

$ kbu team remove-member cn3team3 --invite-id abf63b5f17ad3878f9b2d51160939e27 --email asdf@asdf.asdf
Error parsing command line arguments: Specify one of 'user', 'email', 'invite-id'
...
```