### PR TITLE
Keep openAtLoginSet state, use writeFileSync

### DIFF
--- a/shared/desktop/app/app-state.js
+++ b/shared/desktop/app/app-state.js
@@ -199,12 +199,13 @@ export default class AppState {
     }
     try {
       const stateLoaded = JSON.parse(fs.readFileSync(configPath, {encoding: 'utf8'}))
-      if (this._isValidState(stateLoaded)) {
-        this.state = stateLoaded
-      } else {
-        // still keep the openAtLoginSet state even if the display changes
-        this.state.openAtLoginSet = stateLoaded.openAtLoginSet
+
+      if (!this._isValidState(stateLoaded)) {
+        stateLoaded.x = null
+        stateLoaded.y = null
       }
+
+      this.state = stateLoaded
     } catch (e) {
       console.warn('Error loading app state:', e)
     }

--- a/shared/desktop/app/app-state.js
+++ b/shared/desktop/app/app-state.js
@@ -176,7 +176,7 @@ export default class AppState {
     clearTimeout(this.managed.debounceChangeTimer)
   }
 
-  _isValidState(state: State): boolean {
+  _isValidWindowState(state: State): boolean {
     // Check if the display where the window was last open is still available
     let rect = {
       x: state.x || 0,
@@ -200,7 +200,7 @@ export default class AppState {
     try {
       const stateLoaded = JSON.parse(fs.readFileSync(configPath, {encoding: 'utf8'}))
 
-      if (!this._isValidState(stateLoaded)) {
+      if (!this._isValidWindowState(stateLoaded)) {
         stateLoaded.x = null
         stateLoaded.y = null
       }

--- a/shared/desktop/app/app-state.js
+++ b/shared/desktop/app/app-state.js
@@ -79,15 +79,17 @@ export default class AppState {
     this._loadAppListeners()
   }
 
+  // Changing this to use fs.writeFileSync because:
+  //
+  // https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback
+  // > Note that it is unsafe to use fs.writeFile multiple times on the same file without waiting for the callback.
+  //
+  // It's hard to reproduce, but I have seen cases where this app-state.json file gets messed up.
   saveState() {
     try {
       let configPath = this.config.path
       let stateToSave = this.state
-      fs.writeFile(configPath, JSON.stringify(stateToSave), err => {
-        if (err) {
-          throw err
-        }
-      })
+      fs.writeFileSync(configPath, JSON.stringify(stateToSave))
     } catch (err) {
       console.log(`Error saving file: ${err}`)
     }
@@ -199,6 +201,9 @@ export default class AppState {
       const stateLoaded = JSON.parse(fs.readFileSync(configPath, {encoding: 'utf8'}))
       if (this._isValidState(stateLoaded)) {
         this.state = stateLoaded
+      } else {
+        // still keep the openAtLoginSet state even if the display changes
+        this.state.openAtLoginSet = stateLoaded.openAtLoginSet
       }
     } catch (e) {
       console.warn('Error loading app state:', e)


### PR DESCRIPTION
We have some GH reports of users who are removing the keybase login item via system preferences but then it comes back when they start the app.

I've repro'd this twice, and I think the writeFileSync change will fix those as they appear to be races writing the app-state.json file.  If that file gets hosed, it uses the defaults which will always install the login item.

The other weird thing is that if your display resolution changes, it considers app-state.json to be invalid, so the openAtLoginSet state was lost and the login item gets installed.

My other theory is that permissions on the file and/or directory are messed up and the app can't save the openAtLoginSet state.  Waiting to hear back from a user about that.  My guess is this is the issue because it sounds like it happens every time for the user.

cc @maxtaco 