### PR TITLE
 system messages are visible messages, and fix desktop notifications

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -352,7 +352,7 @@ func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 		apptype := keybase1.DeviceType_DESKTOP
 		kind := chat1.NotificationKind_GENERIC
 		switch typ {
-		case chat1.MessageType_TEXT:
+		case chat1.MessageType_TEXT, chat1.MessageType_SYSTEM:
 			for _, at := range msg.Valid().AtMentions {
 				if at.Eq(uid) {
 					kind = chat1.NotificationKind_ATMENTION

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1046,6 +1046,7 @@ func TestChatSrvPostLocalAtMention(t *testing.T) {
 			require.True(t, info.Message.IsValid())
 			require.Equal(t, chat1.MessageType_SYSTEM, info.Message.GetMessageType())
 			require.Equal(t, 1, len(info.Message.Valid().AtMentions))
+			require.Equal(t, users[1].Username, info.Message.Valid().AtMentions[0])
 			require.Equal(t, chat1.ChannelMention_NONE, info.Message.Valid().ChannelMention)
 			require.True(t, info.DisplayDesktopNotification)
 		case <-time.After(20 * time.Second):

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1036,7 +1036,7 @@ func TestChatSrvPostLocalAtMention(t *testing.T) {
 			require.Fail(t, "no new message")
 		}
 
-		// Test that system messages to the right thing
+		// Test that system messages do the right thing
 		subBody := chat1.NewMessageSystemWithAddedtoteam(chat1.MessageSystemAddedToTeam{
 			Addee: users[1].Username,
 		})

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1035,6 +1035,22 @@ func TestChatSrvPostLocalAtMention(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no new message")
 		}
+
+		// Test that system messages to the right thing
+		subBody := chat1.NewMessageSystemWithAddedtoteam(chat1.MessageSystemAddedToTeam{
+			Addee: users[1].Username,
+		})
+		mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithSystem(subBody))
+		select {
+		case info := <-listener.newMessage:
+			require.True(t, info.Message.IsValid())
+			require.Equal(t, chat1.MessageType_SYSTEM, info.Message.GetMessageType())
+			require.Equal(t, 1, len(info.Message.Valid().AtMentions))
+			require.Equal(t, chat1.ChannelMention_NONE, info.Message.Valid().ChannelMention)
+			require.True(t, info.DisplayDesktopNotification)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no new message")
+		}
 	})
 }
 

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -295,6 +295,7 @@ func VisibleChatMessageTypes() []chat1.MessageType {
 	return []chat1.MessageType{
 		chat1.MessageType_TEXT,
 		chat1.MessageType_ATTACHMENT,
+		chat1.MessageType_SYSTEM,
 	}
 }
 

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -308,6 +308,23 @@ func IsVisibleChatMessageType(messageType chat1.MessageType) bool {
 	return false
 }
 
+func IsNotifiableChatMessageType(messageType chat1.MessageType, atMentions []gregor1.UID, chanMention chat1.ChannelMention) bool {
+	if IsVisibleChatMessageType(messageType) {
+		return true
+	}
+
+	if messageType != chat1.MessageType_EDIT {
+		return false
+	}
+
+	// an edit with atMention or channel mention should generate notifications
+	if len(atMentions) > 0 || chanMention != chat1.ChannelMention_NONE {
+		return true
+	}
+
+	return false
+}
+
 type DebugLabeler struct {
 	log     logger.Logger
 	label   string


### PR DESCRIPTION
Make sure system messages get first class treatment.

1.) Add system type to the visible message type list.
2.) Make system message trigger desktop notifications.

cc @malgorithms 