### PR TITLE
CLI: Use Examples instead of Description

### DIFF
--- a/go/client/cmd_team_remove_member.go
+++ b/go/client/cmd_team_remove_member.go
@@ -33,7 +33,15 @@ func newCmdTeamRemoveMember(cl *libcmdline.CommandLine, g *libkb.GlobalContext) 
 		Name:         "remove-member",
 		ArgumentHelp: "<team name> --user=<username>",
 		Usage:        "Remove a user from a team.",
-		Description:  teamRemoveMemberDoc,
+		Examples: `
+Remove a user from the team:
+    keybase team remove-member acme --user roadrunner
+Cancel an email invite:
+    keybase team remove-member acme --email roadrunner@acme.com
+Cancel a secret token invite (like sms):
+    keybase team list-members acme --show-invite-id # to get the invite ID
+    keybase team remove-member acme --invite-id 9cfd13f927bcd1f6832fefa084bb2127
+`,
 		Action: func(c *cli.Context) {
 			cmd := &CmdTeamRemoveMember{Contextified: libkb.NewContextified(g)}
 			cl.ChooseCommand(cmd, "remove-member", c)
@@ -178,15 +186,3 @@ func (c *CmdTeamRemoveMember) GetUsage() libkb.Usage {
 		KbKeyring: true,
 	}
 }
-
-const teamRemoveMemberDoc = `"keybase team remove-member" lets you remove members and cancel invites
-
-EXAMPLES:
-    Remove a user from the team:
-        keybase team remove-member acme --user roadrunner
-    Cancel an email invite:
-        keybase team remove-member acme --email roadrunner@acme.com
-    Cancel a secret token invite (like sms):
-        keybase team list-members acme --show-invite-id # to get the invite ID
-        keybase team remove-member acme --invite-id 9cfd13f927bcd1f6832fefa084bb2127
-`

--- a/go/client/cmd_team_settings.go
+++ b/go/client/cmd_team_settings.go
@@ -29,7 +29,20 @@ func newCmdTeamSettings(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 		Name:         "settings",
 		ArgumentHelp: "<team name>",
 		Usage:        "Edit team settings.",
-		Description:  teamSettingsDoc,
+		Examples: `
+Review team settings:
+    keybase team settings acme
+Open a team so anyone can join as a reader:
+    keybase team settings acme --open-team=reader
+Showcase a team publicly:
+    keybase team settings acme --showcase=yes
+Promote a team on your profile:
+    keybase team settings acme --profile-promote=yes
+Set a description for the team to show if promoted:
+    keybase team settings acme --description="Rocket-Powered Products"
+Clear the team description:
+    keybase team settings acme --description=""
+`,
 		Action: func(c *cli.Context) {
 			cmd := NewCmdTeamSettingsRunner(g)
 			cl.ChooseCommand(cmd, "settings", c)
@@ -296,20 +309,3 @@ func (c *CmdTeamSettings) GetUsage() libkb.Usage {
 		KbKeyring: true,
 	}
 }
-
-const teamSettingsDoc = `"keybase team settings" lets you edit settings for a team
-
-EXAMPLES:
-    Review team settings:
-        keybase team settings acme
-    Open a team so anyone can join as a reader:
-        keybase team settings acme --open-team=reader
-    Showcase a team publicly:
-        keybase team settings acme --showcase=yes
-    Promote a team on your profile:
-        keybase team settings acme --profile-promote=yes
-    Set a description for the team to show if promoted:
-        keybase team settings acme --description="Rocket-Powered Products"
-    Clear the team description:
-        keybase team settings acme --description=""
-`

--- a/go/client/help.go
+++ b/go/client/help.go
@@ -199,7 +199,10 @@ USAGE:
    keybase {{.FullName}}{{ if .Subcommands }} <command>{{ end }}{{if .Flags}} [command options]{{end}} {{ .ArgumentHelp }}{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}{{ if .Subcommands }}
+   {{.Description}}{{end}}{{ if .Examples }}
+
+EXAMPLES:
+{{.ExamplesFormatted}}{{ end }}{{ if .Subcommands }}
 
 COMMANDS:
    {{range .Subcommands}}{{if .Usage }}{{join .Names ", "}}{{ "\t" }}{{.Usage}}{{ end }}

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -424,10 +424,6 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 			Usage: "Enable debugging mode.",
 		},
 		cli.BoolFlag{
-			Name:  "support-per-user-key",
-			Usage: "Support per-user keys. Experimental, may break sigchain!",
-		},
-		cli.BoolFlag{
 			Name:  "upgrade-per-user-key",
 			Usage: "Create new per-user-keys. Experimental, will break sigchain!",
 		},

--- a/go/vendor/github.com/keybase/cli/command.go
+++ b/go/vendor/github.com/keybase/cli/command.go
@@ -18,6 +18,8 @@ type Command struct {
 	Usage string
 	// A longer explanation of how the command works
 	Description string
+	// Example usage
+	Examples string
 	// The function to call when checking for bash command completions
 	BashComplete func(context *Context)
 	// An action to execute before any sub-subcommands are run, but after the context is ready
@@ -149,6 +151,12 @@ func (c Command) HasName(name string) bool {
 		}
 	}
 	return false
+}
+
+// Strips and indents with 3 spaces examples.
+func (c Command) ExamplesFormatted() string {
+	prefix := "   "
+	return prefix + strings.Join(strings.Split(strings.TrimSpace(c.Examples), "\n"), "\n"+prefix)
 }
 
 func (c Command) startApp(ctx *Context) error {

--- a/go/vendor/github.com/keybase/cli/help.go
+++ b/go/vendor/github.com/keybase/cli/help.go
@@ -44,7 +44,10 @@ USAGE:
    command {{.FullName}}{{if .Flags}} [command options]{{end}} [arguments...]{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}{{if .Flags}}
+   {{.Description}}{{end}}{{if .Examples}}
+
+EXAMPLES:
+{{.ExamplesFormatted}}{{end}}{{if .Flags}}
 
 OPTIONS:
    {{range .Flags}}{{.}}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -178,10 +178,10 @@
 			"revisionTime": "2016-05-17T06:10:00Z"
 		},
 		{
-			"checksumSHA1": "spYlTa7zTW8av4Vs4kDdCu/IREI=",
+			"checksumSHA1": "As/C2CDekxCEGyFN5sOcrEt/r0Q=",
 			"path": "github.com/keybase/cli",
-			"revision": "ec1463eaf32381cd4a10218b484023629244c822",
-			"revisionTime": "2017-11-08T19:15:45Z"
+			"revision": "f7d0b25da714078d8c84ac64afe8d88794d587e3",
+			"revisionTime": "2017-11-10T20:24:45Z"
 		},
 		{
 			"path": "github.com/keybase/clockwork",


### PR DESCRIPTION
Make Examples a first class citizen of Command. Now we don't have to write repetitive descriptions to get examples in.

Fun fact: If you fumble the the template text it will _panic_.

```
$ kbu team remove-member cn3team3 -h
NAME:
   keybase team remove-member - Remove a user from a team.

USAGE:
   keybase team remove-member [command options] <team name> --user=<username>

EXAMPLES:
   Remove a user from the team:
       keybase team remove-member acme --user roadrunner
   Cancel an email invite:
       keybase team remove-member acme --email roadrunner@acme.com
   Cancel a secret token invite (like sms):
       keybase team list-members acme --show-invite-id # to get the invite ID
       keybase team remove-member acme --invite-id 9cfd13f927bcd1f6832fefa084bb2127

OPTIONS:
   -u, --user   username
   --email      cancel a pending invite by email address
   --invite-id  cancel a pending invite by ID
   -f, --force  don't ask for confirmation
```