### PR TITLE
Don't log private key bundle

### DIFF
--- a/go/libkb/sync_secret.go
+++ b/go/libkb/sync_secret.go
@@ -144,7 +144,7 @@ func (ss *SecretSyncer) syncFromServer(uid keybase1.UID, sr SessionReader) (err 
 		return
 	}
 
-	ss.G().Log.Debug("| Returned object: %+v\n", obj)
+	ss.G().Log.Debug("| Returned object: {Status: %v, Version: %d, #pgpkeys: %d, #devices: %d}", obj.Status, obj.Version, len(obj.PrivateKeys), len(obj.Devices))
 	if ss.keys == nil || obj.Version > ss.keys.Version {
 		ss.G().Log.Debug("| upgrade to version -> %d", obj.Version)
 		ss.keys = &obj


### PR DESCRIPTION
Saw a private pgp key bundle in a log.  This leaves that part out of the log message.

@maxtaco let me know if you wanted that logged for some reason.

(for those curious, this is a **locked** pgp private key bundle)