### PR TITLE
Make add-member flow consistent between 'Add people' and accepting requests

### DIFF
--- a/shared/actions/teams/creators.js
+++ b/shared/actions/teams/creators.js
@@ -37,8 +37,12 @@ function saveChannelMembership(
   return {payload: {channelState, teamname}, type: 'teams:saveChannelMembership'}
 }
 
-function addPeopleToTeam(teamname: string, role: string): Constants.AddPeopleToTeam {
-  return {payload: {role, teamname}, type: 'teams:addPeopleToTeam'}
+function addPeopleToTeam(
+  teamname: string,
+  role: string,
+  sendChatNotification: boolean
+): Constants.AddPeopleToTeam {
+  return {payload: {role, teamname, sendChatNotification}, type: 'teams:addPeopleToTeam'}
 }
 
 function inviteToTeamByEmail(

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -66,7 +66,7 @@ const _leaveTeam = function(action: Constants.LeaveTeam) {
 }
 
 const _addPeopleToTeam = function*(action: Constants.AddPeopleToTeam) {
-  const {payload: {role, teamname}} = action
+  const {payload: {role, teamname, sendChatNotification}} = action
   yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, true]])))
   const ids = yield Saga.select(SearchConstants.getUserInputItemIds, {searchKey: 'addToTeamSearch'})
   for (const id of ids) {
@@ -76,7 +76,7 @@ const _addPeopleToTeam = function*(action: Constants.AddPeopleToTeam) {
         email: '',
         username: id,
         role: role ? RPCTypes.teamsTeamRole[role] : RPCTypes.teamsTeamRole.none,
-        sendChatNotification: true,
+        sendChatNotification,
       },
     })
   }

--- a/shared/constants/selectors.js
+++ b/shared/constants/selectors.js
@@ -1,5 +1,6 @@
 // @flow
 // Not use util/container as we have import loops otherwise
+import {Set} from 'immutable'
 import {createSelector} from 'reselect'
 import {type TypedState} from './reducer'
 import {type SearchQuery} from './search'
@@ -34,6 +35,13 @@ const searchResultMapSelector = createSelector(
   searchResults => searchResults
 )
 
+const teamMembersSelector = (state, {teamname}) =>
+  state.entities.getIn(['teams', 'teamNameToMembers', teamname], Set())
+const teamMemberRecordSelector = createSelector(
+  [usernameSelector, teamMembersSelector],
+  (username, members) => members.find(member => member.username === username)
+)
+
 export {
   amIBeingFollowed,
   amIFollowing,
@@ -42,6 +50,7 @@ export {
   previousConversationSelector,
   searchResultMapSelector,
   searchResultSelector,
+  teamMemberRecordSelector,
   userIsInTeam,
   usernameSelector,
 }

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -156,7 +156,10 @@ export type SetTeamCreationPending = NoErrorTypedAction<
 export type SetTeamJoinError = NoErrorTypedAction<'teams:setTeamJoinError', {teamJoinError: string}>
 export type SetTeamJoinSuccess = NoErrorTypedAction<'teams:setTeamJoinSuccess', {teamJoinSuccess: boolean}>
 
-export type AddPeopleToTeam = NoErrorTypedAction<'teams:addPeopleToTeam', {role: string, teamname: string}>
+export type AddPeopleToTeam = NoErrorTypedAction<
+  'teams:addPeopleToTeam',
+  {role: string, teamname: string, sendChatNotification: boolean}
+>
 
 export type InviteToTeamByEmail = NoErrorTypedAction<
   'teams:inviteToTeamByEmail',

--- a/shared/teams/add-people/container.js
+++ b/shared/teams/add-people/container.js
@@ -2,6 +2,7 @@
 import * as Creators from '../../actions/teams/creators'
 import * as SearchCreators from '../../actions/search/creators'
 import * as SearchConstants from '../../constants/search'
+import {teamMemberRecordSelector} from '../../constants/selectors'
 import AddPeople from '.'
 import {HeaderHoc} from '../../common-adapters'
 import {navigateAppend} from '../../actions/route-tree'
@@ -17,6 +18,7 @@ import {
 const mapStateToProps = (state: TypedState, {routeProps}) => ({
   isEmpty: SearchConstants.getUserInputItemIds(state, {searchKey: 'addToTeamSearch'}).length === 0,
   name: routeProps.get('teamname'),
+  _yourMember: teamMemberRecordSelector(state, {teamname: routeProps.get('teamname')}),
 })
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
@@ -73,8 +75,9 @@ export default compose(
         onRoleChange,
         sendNotification,
         setSendNotification,
+        yourMember,
       }) => () => {
-        onOpenRolePicker(role, sendNotification, false, (role, sendNotification) => {
+        onOpenRolePicker(role, sendNotification, yourMember.type === 'owner', (role, sendNotification) => {
           onRoleChange(role)
           setSendNotification(sendNotification)
         })

--- a/shared/teams/add-people/container.js
+++ b/shared/teams/add-people/container.js
@@ -15,11 +15,14 @@ import {
   type TypedState,
 } from '../../util/container'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => ({
-  isEmpty: SearchConstants.getUserInputItemIds(state, {searchKey: 'addToTeamSearch'}).length === 0,
-  name: routeProps.get('teamname'),
-  _yourMember: teamMemberRecordSelector(state, {teamname: routeProps.get('teamname')}),
-})
+const mapStateToProps = (state: TypedState, {routeProps}) => {
+  const teamname = routeProps.get('teamname')
+  return {
+    isEmpty: SearchConstants.getUserInputItemIds(state, {searchKey: 'addToTeamSearch'}).length === 0,
+    name: teamname,
+    _yourMember: teamMemberRecordSelector(state, {teamname: teamname}),
+  }
+}
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
   onAddPeople: (role: string, sendNotification: boolean) => {
@@ -75,9 +78,9 @@ export default compose(
         onRoleChange,
         sendNotification,
         setSendNotification,
-        yourMember,
+        _yourMember,
       }) => () => {
-        onOpenRolePicker(role, sendNotification, yourMember.type === 'owner', (role, sendNotification) => {
+        onOpenRolePicker(role, sendNotification, _yourMember.type === 'owner', (role, sendNotification) => {
           onRoleChange(role)
           setSendNotification(sendNotification)
         })

--- a/shared/teams/add-people/index.js
+++ b/shared/teams/add-people/index.js
@@ -35,10 +35,12 @@ type Props = {
   onAddPeople: () => void,
   onClose: () => void,
   onLeave: () => void,
-  onOpenRolePicker: (currentSelectedRole: TeamRoleType, selectedRoleCallback: (TeamRoleType) => void) => void,
+  onOpenRolePicker: () => void,
   onRoleChange: (role: TeamRoleType) => void,
   name: string,
   role: TeamRoleType,
+  sendNotification: boolean,
+  setSendNotification: (sendNotification: boolean) => void,
 }
 
 const _makeDropdownItem = (item: string) => (
@@ -70,12 +72,7 @@ const AddPeople = (props: Props) => (
         <Text style={{margin: globalMargins.tiny}} type="Body">
           Add these team members to {props.name} as:
         </Text>
-        <ClickableBox
-          onClick={() =>
-            props.onOpenRolePicker(props.role, (selectedRole: TeamRoleType) =>
-              props.onRoleChange(selectedRole)
-            )}
-        >
+        <ClickableBox onClick={() => props.onOpenRolePicker()}>
           <Dropdown
             items={_makeDropdownItems()}
             selected={_makeDropdownItem(props.role)}

--- a/shared/teams/role-picker/controlled-container.js
+++ b/shared/teams/role-picker/controlled-container.js
@@ -15,10 +15,12 @@ import {type TeamRoleType} from '../../constants/teams'
   allowOwner specifies whether the user can choose the 'owner' option
 */
 export type ControlledRolePickerProps = {
-  onComplete: (role: TeamRoleType) => void,
+  onComplete: (role: TeamRoleType, sendNotification: boolean) => void,
   selectedRole?: TeamRoleType,
   allowOwner?: boolean,
   allowAdmin?: boolean,
+  showNotificationCheckbox?: boolean,
+  sendNotificationChecked?: boolean,
 }
 
 const mapStateToProps = (state: TypedState, {routeProps}) => {
@@ -26,6 +28,8 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
   const _onComplete = routeProps.get('onComplete')
   const allowAdmin = routeProps.get('allowAdmin')
   const allowOwner = routeProps.get('allowOwner')
+  const sendNotificationChecked = routeProps.get('sendNotificationChecked')
+  const showSendNotification = routeProps.get('showNotificationCheckbox')
   return {
     _onComplete,
     allowAdmin,
@@ -33,9 +37,8 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
     confirm: false,
     controlled: true,
     currentType,
-    sendNotification: false,
-    setSendNotification: () => {},
-    showSendNotification: false,
+    sendNotificationChecked,
+    showSendNotification,
     username: '',
   }
 }
@@ -59,9 +62,10 @@ const PopupWrapped = props => (
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
   withState('selectedRole', 'setSelectedRole', props => props.currentType),
+  withState('sendNotification', 'setSendNotification', props => props.sendNotificationChecked),
   withHandlers({
-    setConfirm: ({_onComplete, onBack, selectedRole}) => (confirm: boolean) => {
-      _onComplete(selectedRole)
+    setConfirm: ({_onComplete, onBack, selectedRole, sendNotification}) => (confirm: boolean) => {
+      _onComplete(selectedRole, sendNotification)
       onBack()
     },
   })

--- a/shared/teams/role-picker/index.js
+++ b/shared/teams/role-picker/index.js
@@ -27,6 +27,7 @@ export type RolePickerProps = {
   allowOwner?: boolean,
   sendNotification: boolean,
   teamname: string,
+  sendNotificationChecked?: boolean,
   showSendNotification: boolean,
   setConfirm: (confirm: boolean) => void,
   setSelectedRole: (r: TeamRoleType) => void,
@@ -92,6 +93,7 @@ export const RoleOptions = ({
   allowOwner = true,
   setSendNotification,
   sendNotification,
+  sendNotificationChecked,
   setConfirm,
   showSendNotification,
 }: RolePickerProps) => (
@@ -121,7 +123,7 @@ export const RoleOptions = ({
         label={controlled ? 'Select' : 'Continue'}
         type="Primary"
         onClick={() => setConfirm(true)}
-        disabled={selectedRole === currentType}
+        disabled={selectedRole === currentType && sendNotificationChecked === sendNotification}
       />
     </Box>
   </Box>


### PR DESCRIPTION
Wires up the `Send chat notification` checkbox to the add people RPC, and also gets the current user's member type to decide whether they can add members as owners or not.

r? @keybase/react-hackers 