### PR TITLE
deprecate GetBehavior

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2062,15 +2062,3 @@ func (r *GitRepoResult) GetIfOk() (res GitRepoInfo, err error) {
 	}
 	return res, fmt.Errorf("git repo unknown error")
 }
-
-func (b MDGetBehavior) ShouldCreateClassicTLF() bool {
-	switch b {
-	case MDGetBehavior_GET_CLASSIC_TLF_NO_CREATE:
-		return false
-	case MDGetBehavior_GET_OR_CREATE_CLASSIC_TLF:
-		return true
-	default:
-		// This shouldn't happen in production as we have TestMDGetBehavior.
-		panic("~>.<~ need to update extras.go after adding MDGetBehavior values")
-	}
-}

--- a/go/protocol/keybase1/extras_test.go
+++ b/go/protocol/keybase1/extras_test.go
@@ -87,15 +87,6 @@ func TestUserOrTeamIDChecking(t *testing.T) {
 	}
 }
 
-func TestMDGetBehavior(t *testing.T) {
-	// Makes sure any potential addition to the MDGetBehavior enum without
-	// extending ShouldCreateClassicTLF would fail on CI, so that we don't
-	// panic elsewhere.
-	for _, b := range MDGetBehaviorMap {
-		b.ShouldCreateClassicTLF()
-	}
-}
-
 func TestTeamNameFromString(t *testing.T) {
 	formatMsg := "Keybase team names must be letters (a-z), numbers, and underscores. Also, they can't start with underscores or use double underscores, to avoid confusion."
 	subteamMsg := "Could not parse name as team; bad name component "

--- a/go/protocol/keybase1/metadata.go
+++ b/go/protocol/keybase1/metadata.go
@@ -148,32 +148,6 @@ func (o LockContext) DeepCopy() LockContext {
 	}
 }
 
-type MDGetBehavior int
-
-const (
-	MDGetBehavior_GET_OR_CREATE_CLASSIC_TLF MDGetBehavior = 0
-	MDGetBehavior_GET_CLASSIC_TLF_NO_CREATE MDGetBehavior = 1
-)
-
-func (o MDGetBehavior) DeepCopy() MDGetBehavior { return o }
-
-var MDGetBehaviorMap = map[string]MDGetBehavior{
-	"GET_OR_CREATE_CLASSIC_TLF": 0,
-	"GET_CLASSIC_TLF_NO_CREATE": 1,
-}
-
-var MDGetBehaviorRevMap = map[MDGetBehavior]string{
-	0: "GET_OR_CREATE_CLASSIC_TLF",
-	1: "GET_CLASSIC_TLF_NO_CREATE",
-}
-
-func (e MDGetBehavior) String() string {
-	if v, ok := MDGetBehaviorRevMap[e]; ok {
-		return v
-	}
-	return ""
-}
-
 type GetChallengeArg struct {
 }
 
@@ -199,7 +173,6 @@ type GetMetadataArg struct {
 	StopRevision  int64             `codec:"stopRevision" json:"stopRevision"`
 	LogTags       map[string]string `codec:"logTags" json:"logTags"`
 	LockBeforeGet *LockID           `codec:"lockBeforeGet,omitempty" json:"lockBeforeGet,omitempty"`
-	GetBehavior   MDGetBehavior     `codec:"getBehavior" json:"getBehavior"`
 }
 
 type RegisterForUpdatesArg struct {

--- a/protocol/avdl/keybase1/metadata.avdl
+++ b/protocol/avdl/keybase1/metadata.avdl
@@ -52,15 +52,10 @@ protocol metadata {
     boolean releaseAfterSuccess;
   }
 
-  enum MDGetBehavior {
-    GET_OR_CREATE_CLASSIC_TLF_0,
-    GET_CLASSIC_TLF_NO_CREATE_1
-  }
-
   ChallengeInfo getChallenge();
   int authenticate(string signature);
   void putMetadata(MDBlock mdBlock, KeyBundle readerKeyBundle, KeyBundle writerKeyBundle, map<string> logTags, union{null, LockContext} lockContext, MDPriority priority);
-  MetadataResponse getMetadata(string folderID, bytes folderHandle, string branchID, boolean unmerged, long startRevision, long stopRevision, map<string> logTags, union{null, LockID} lockBeforeGet, MDGetBehavior getBehavior);
+  MetadataResponse getMetadata(string folderID, bytes folderHandle, string branchID, boolean unmerged, long startRevision, long stopRevision, map<string> logTags, union{null, LockID} lockBeforeGet);
   void registerForUpdates(string folderID, long currRevision, map<string> logTags);
   void pruneBranch(string folderID, string branchID, map<string> logTags);
   void putKeys(array<KeyHalf> keyHalves, map<string> logTags);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1081,11 +1081,6 @@ export const metadataLockRpcChannelMap = (configKeys: Array<string>, request: Re
 
 export const metadataLockRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: MetadataLockRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.metadata.lock', request, (error, result) => error ? reject(error) : resolve(result)))
 
-export const metadataMDGetBehavior = {
-  getOrCreateClassicTlf: 0,
-  getClassicTlfNoCreate: 1,
-}
-
 export const metadataPing2RpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: MetadataPing2Result) => void}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.metadata.ping2', request)
 
 export const metadataPing2RpcPromise = (request: ?(RequestCommon & {callback?: ?(err: ?any, response: MetadataPing2Result) => void})): Promise<MetadataPing2Result> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.metadata.ping2', request, (error, result) => error ? reject(error) : resolve(result)))
@@ -2608,10 +2603,6 @@ export type LookupImplicitTeamRes = {|teamID: TeamID,name: TeamName,displayName:
 
 export type MDBlock = {|version: Int,timestamp: Time,block: Bytes,|}
 
-export type MDGetBehavior =0 // GET_OR_CREATE_CLASSIC_TLF_0
- | 1 // GET_CLASSIC_TLF_NO_CREATE_1
-
-
 export type MDPriority = Int
 
 export type MaskB64 = Bytes
@@ -2674,8 +2665,7 @@ export type MetadataGetMetadataRpcParam = {|  folderID: String,
   startRevision: Long,
   stopRevision: Long,
   logTags: {[key: string]: String},
-  lockBeforeGet?: ?LockID,
-  getBehavior: MDGetBehavior|}
+  lockBeforeGet?: ?LockID|}
 
 export type MetadataLockRpcParam = {|  folderID: String,
   lockID: LockID|}

--- a/protocol/json/keybase1/metadata.json
+++ b/protocol/json/keybase1/metadata.json
@@ -139,14 +139,6 @@
           "name": "releaseAfterSuccess"
         }
       ]
-    },
-    {
-      "type": "enum",
-      "name": "MDGetBehavior",
-      "symbols": [
-        "GET_OR_CREATE_CLASSIC_TLF_0",
-        "GET_CLASSIC_TLF_NO_CREATE_1"
-      ]
     }
   ],
   "messages": {
@@ -237,10 +229,6 @@
             null,
             "LockID"
           ]
-        },
-        {
-          "name": "getBehavior",
-          "type": "MDGetBehavior"
         }
       ],
       "response": "MetadataResponse"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1081,11 +1081,6 @@ export const metadataLockRpcChannelMap = (configKeys: Array<string>, request: Re
 
 export const metadataLockRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: MetadataLockRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.metadata.lock', request, (error, result) => error ? reject(error) : resolve(result)))
 
-export const metadataMDGetBehavior = {
-  getOrCreateClassicTlf: 0,
-  getClassicTlfNoCreate: 1,
-}
-
 export const metadataPing2RpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: MetadataPing2Result) => void}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.metadata.ping2', request)
 
 export const metadataPing2RpcPromise = (request: ?(RequestCommon & {callback?: ?(err: ?any, response: MetadataPing2Result) => void})): Promise<MetadataPing2Result> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.metadata.ping2', request, (error, result) => error ? reject(error) : resolve(result)))
@@ -2608,10 +2603,6 @@ export type LookupImplicitTeamRes = {|teamID: TeamID,name: TeamName,displayName:
 
 export type MDBlock = {|version: Int,timestamp: Time,block: Bytes,|}
 
-export type MDGetBehavior =0 // GET_OR_CREATE_CLASSIC_TLF_0
- | 1 // GET_CLASSIC_TLF_NO_CREATE_1
-
-
 export type MDPriority = Int
 
 export type MaskB64 = Bytes
@@ -2674,8 +2665,7 @@ export type MetadataGetMetadataRpcParam = {|  folderID: String,
   startRevision: Long,
   stopRevision: Long,
   logTags: {[key: string]: String},
-  lockBeforeGet?: ?LockID,
-  getBehavior: MDGetBehavior|}
+  lockBeforeGet?: ?LockID|}
 
 export type MetadataLockRpcParam = {|  folderID: String,
   lockID: LockID|}


### PR DESCRIPTION
We haven't started using that in our clients, and the new design doesn't need it.