### PR TITLE
Dismiss new team dialog on new team creation

### DIFF
--- a/shared/actions/teams/creators.js
+++ b/shared/actions/teams/creators.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Constants from '../../constants/teams'
+import * as I from 'immutable'
 import type {ConversationIDKey} from '../../constants/chat'
 
 function createNewTeam(name: string, routePath: I.List<string>) {

--- a/shared/actions/teams/creators.js
+++ b/shared/actions/teams/creators.js
@@ -3,8 +3,13 @@ import * as Constants from '../../constants/teams'
 import * as I from 'immutable'
 import type {ConversationIDKey} from '../../constants/chat'
 
-function createNewTeam(name: string, routePath: I.List<string>) {
-  return {payload: {name, routePath}, type: 'teams:createNewTeam'}
+function createNewTeam(
+  name: string,
+  tab: string,
+  sourceSubPath: I.List<string>,
+  destSubPath: I.List<string>
+) {
+  return {payload: {name, tab, sourceSubPath, destSubPath}, type: 'teams:createNewTeam'}
 }
 
 function createNewTeamFromConversation(conversationIDKey: ConversationIDKey, name: string) {

--- a/shared/actions/teams/creators.js
+++ b/shared/actions/teams/creators.js
@@ -5,11 +5,11 @@ import type {ConversationIDKey} from '../../constants/chat'
 
 function createNewTeam(
   name: string,
-  tab: string,
+  rootPath: I.List<string>,
   sourceSubPath: I.List<string>,
   destSubPath: I.List<string>
 ) {
-  return {payload: {name, tab, sourceSubPath, destSubPath}, type: 'teams:createNewTeam'}
+  return {payload: {name, rootPath, sourceSubPath, destSubPath}, type: 'teams:createNewTeam'}
 }
 
 function createNewTeamFromConversation(conversationIDKey: ConversationIDKey, name: string) {

--- a/shared/actions/teams/creators.js
+++ b/shared/actions/teams/creators.js
@@ -2,8 +2,8 @@
 import * as Constants from '../../constants/teams'
 import type {ConversationIDKey} from '../../constants/chat'
 
-function createNewTeam(name: string) {
-  return {payload: {name}, type: 'teams:createNewTeam'}
+function createNewTeam(name: string, routePath: I.List<string>) {
+  return {payload: {name, routePath}, type: 'teams:createNewTeam'}
 }
 
 function createNewTeamFromConversation(conversationIDKey: ConversationIDKey, name: string) {

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -35,7 +35,9 @@ const _createNewTeam = function*(action: Constants.CreateNewTeam) {
     })
 
     // Dismiss the create team dialog.
-    yield Saga.put(putActionIfOnPath(sourceSubPath, navigateTo(destSubPath, rootPath), rootPath))
+    yield Saga.put(
+      putActionIfOnPath(rootPath.concat(sourceSubPath), navigateTo(destSubPath, rootPath), rootPath)
+    )
 
     // No error if we get here.
     yield Saga.put(navigateTo([isMobile ? chatTab : teamsTab]))

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -16,7 +16,7 @@ import engine from '../../engine'
 import {replaceEntity} from '../entities'
 import {usernameSelector} from '../../constants/selectors'
 import {isMobile} from '../../constants/platform'
-import {navigateTo} from '../route-tree'
+import {putActionIfOnPath, navigateTo} from '../route-tree'
 import {chatTab, teamsTab} from '../../constants/tabs'
 import openSMS from '../../util/sms'
 import {createDecrementWaiting, createIncrementWaiting} from '../../actions/waiting-gen'
@@ -26,7 +26,7 @@ import {convertToError} from '../../util/errors'
 import type {TypedState} from '../../constants/reducer'
 
 const _createNewTeam = function*(action: Constants.CreateNewTeam) {
-  const {payload: {name, routePath}} = action
+  const {payload: {name, rootPath, sourceSubPath, destSubPath}} = action
   yield Saga.put(Creators.setTeamCreationError(''))
   yield Saga.put(Creators.setTeamCreationPending(true))
   try {
@@ -35,7 +35,7 @@ const _createNewTeam = function*(action: Constants.CreateNewTeam) {
     })
 
     // Dismiss the create team dialog.
-    yield Saga.put(navigateTo([], routePath.butLast()))
+    yield Saga.put(putActionIfOnPath(sourceSubPath, navigateTo(destSubPath, rootPath), rootPath))
 
     // No error if we get here.
     yield Saga.put(navigateTo([isMobile ? chatTab : teamsTab]))

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -26,13 +26,16 @@ import {convertToError} from '../../util/errors'
 import type {TypedState} from '../../constants/reducer'
 
 const _createNewTeam = function*(action: Constants.CreateNewTeam) {
-  const {payload: {name}} = action
+  const {payload: {name, routePath}} = action
   yield Saga.put(Creators.setTeamCreationError(''))
   yield Saga.put(Creators.setTeamCreationPending(true))
   try {
     yield Saga.call(RPCTypes.teamsTeamCreateRpcPromise, {
       param: {name, sendChatNotification: true},
     })
+
+    // Dismiss the create team dialog.
+    yield Saga.put(navigateTo([], routePath.butLast()))
 
     // No error if we get here.
     yield Saga.put(navigateTo([isMobile ? chatTab : teamsTab]))

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -21,7 +21,9 @@ export type CreateNewTeam = NoErrorTypedAction<
   'teams:createNewTeam',
   {
     name: string,
-    routePath: I.List<string>,
+    rootPath: I.List<string>,
+    sourceSubPath: I.List<string>,
+    destSubPath: I.List<string>,
   }
 >
 

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -21,6 +21,7 @@ export type CreateNewTeam = NoErrorTypedAction<
   'teams:createNewTeam',
   {
     name: string,
+    routePath: I.List<string>,
   }
 >
 

--- a/shared/teams/new-team/container.js
+++ b/shared/teams/new-team/container.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state: TypedState) => ({
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath}) => ({
   _onCreateNewTeam: name => {
     const rootPath = routePath.take(1)
-    const sourceSubPath = rootPath.rest()
+    const sourceSubPath = routePath.rest()
     const destSubPath = sourceSubPath.butLast()
     dispatch(createNewTeam(name, rootPath, sourceSubPath, destSubPath))
   },

--- a/shared/teams/new-team/container.js
+++ b/shared/teams/new-team/container.js
@@ -11,7 +11,10 @@ const mapStateToProps = (state: TypedState) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath}) => ({
   _onCreateNewTeam: name => {
-    dispatch(createNewTeam(name, routePath))
+    const rootPath = routePath.take(1)
+    const sourceSubPath = rootPath.rest()
+    const destSubPath = sourceSubPath.butLast()
+    dispatch(createNewTeam(name, rootPath, sourceSubPath, destSubPath))
   },
   _onSetTeamCreationError: error => {
     dispatch(setTeamCreationError(error))

--- a/shared/teams/new-team/container.js
+++ b/shared/teams/new-team/container.js
@@ -9,9 +9,9 @@ const mapStateToProps = (state: TypedState) => ({
   pending: state.chat.teamCreationPending,
 })
 
-const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
+const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath}) => ({
   _onCreateNewTeam: name => {
-    dispatch(createNewTeam(name))
+    dispatch(createNewTeam(name, routePath))
   },
   _onSetTeamCreationError: error => {
     dispatch(setTeamCreationError(error))


### PR DESCRIPTION
Otherwise, on mobile where we switch to the chat tab, if you switch
back to the teams tab, you'll still see the new team dialog.