### PR TITLE
retry loading JSON config file if we get permission denied CORE-6578

### DIFF
--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -65,7 +65,7 @@ func (f *JSONFile) Load(warnOnNotFound bool) (err error) {
 				return nil
 			}
 			if os.IsPermission(err) {
-				f.G().Log.Warning("Permission denied opening %s file %s", f.which, f.filename)
+				f.G().Log.Warning("Permission denied opening %s file %s: %s", f.which, f.filename, err)
 				if i == maxPermissionRetries-1 {
 					return nil
 				}

--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -69,7 +69,7 @@ func (f *JSONFile) Load(warnOnNotFound bool) (err error) {
 				if i == maxPermissionRetries-1 {
 					return nil
 				}
-				time.Sleep(200 * time.Millisecond)
+				time.Sleep(time.Second)
 				continue
 			}
 			return err


### PR DESCRIPTION
I'm not sure I fully understand the race here, but we can fail to read config.json when starting the app because of a permission denied failure on iOS. This might happen other places as well. If we get this error, sleep for a second and then retry. We do this 5 times before giving up. I've been running this on my phone for about half a day and have not seen the random logout yet, so I am hopeful. 

cc @maxtaco 