### PR TITLE
fix a nil context getting passed to OutputSignatureSuccessNonKeybase

### DIFF
--- a/go/client/log.go
+++ b/go/client/log.go
@@ -25,21 +25,22 @@ func (s LogUIServer) Log(_ context.Context, arg keybase1.LogArg) error {
 	buf := new(bytes.Buffer)
 	RenderText(s.G(), buf, arg.Text)
 	msg := buf.String()
+	logger := s.G().Log.CloneWithAddedDepth(1)
 	switch arg.Level {
 	case keybase1.LogLevel_DEBUG:
-		s.G().Log.Debug("%s", msg)
+		logger.Debug("%s", msg)
 	case keybase1.LogLevel_INFO:
-		s.G().Log.Info("%s", msg)
+		logger.Info("%s", msg)
 	case keybase1.LogLevel_WARN:
-		s.G().Log.Warning("%s", msg)
+		logger.Warning("%s", msg)
 	case keybase1.LogLevel_ERROR:
-		s.G().Log.Errorf("%s", msg)
+		logger.Errorf("%s", msg)
 	case keybase1.LogLevel_NOTICE:
-		s.G().Log.Notice("%s", msg)
+		logger.Notice("%s", msg)
 	case keybase1.LogLevel_CRITICAL:
-		s.G().Log.Critical("%s", msg)
+		logger.Critical("%s", msg)
 	default:
-		s.G().Log.Warning("%s", msg)
+		logger.Warning("%s", msg)
 	}
 	return nil
 }

--- a/go/engine/pgp_common.go
+++ b/go/engine/pgp_common.go
@@ -7,28 +7,26 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
 // OutputSignatureSuccess prints the details of a successful verification.
-func OutputSignatureSuccess(ctx *Context, fingerprint libkb.PGPFingerprint, owner *libkb.User, signatureTime time.Time) {
+func OutputSignatureSuccess(ctx *Context, fingerprint libkb.PGPFingerprint, owner *libkb.User, signatureTime time.Time) error {
 	arg := keybase1.OutputSignatureSuccessArg{
 		Fingerprint: fingerprint.String(),
 		Username:    owner.GetName(),
 		SignedAt:    keybase1.TimeFromSeconds(signatureTime.Unix()),
 	}
-	ctx.PgpUI.OutputSignatureSuccess(context.TODO(), arg)
+	return ctx.PgpUI.OutputSignatureSuccess(ctx.GetNetContext(), arg)
 }
 
 // OutputSignatureSuccessNonKeybase prints the details of successful signature verification
 // when signing key is not known to keybase.
-func OutputSignatureSuccessNonKeybase(ctx *Context, keyID uint64, signatureTime time.Time) {
+func OutputSignatureSuccessNonKeybase(ctx *Context, keyID uint64, signatureTime time.Time) error {
 	arg := keybase1.OutputSignatureSuccessNonKeybaseArg{
 		KeyID:    fmt.Sprintf("%X", keyID),
 		SignedAt: keybase1.TimeFromSeconds(signatureTime.Unix()),
 	}
-	ctx.PgpUI.OutputSignatureSuccessNonKeybase(ctx.NetContext, arg)
+	return ctx.PgpUI.OutputSignatureSuccessNonKeybase(ctx.GetNetContext(), arg)
 }

--- a/go/engine/pgp_decrypt.go
+++ b/go/engine/pgp_decrypt.go
@@ -126,8 +126,7 @@ func (e *PGPDecrypt) Run(ctx *Context) (err error) {
 		if e.signer == nil {
 			// signer isn't a keybase user
 			e.G().Log.Debug("message signed by key unknown to keybase: %X", e.signStatus.KeyID)
-			OutputSignatureSuccessNonKeybase(ctx, e.signStatus.KeyID, e.signStatus.SignatureTime)
-			return nil
+			return OutputSignatureSuccessNonKeybase(ctx, e.signStatus.KeyID, e.signStatus.SignatureTime)
 		}
 
 		// identify the signer
@@ -154,8 +153,7 @@ func (e *PGPDecrypt) Run(ctx *Context) (err error) {
 	}
 
 	bundle := libkb.NewPGPKeyBundle(e.signStatus.Entity)
-	OutputSignatureSuccess(ctx, bundle.GetFingerprint(), e.signer, e.signStatus.SignatureTime)
-	return nil
+	return OutputSignatureSuccess(ctx, bundle.GetFingerprint(), e.signer, e.signStatus.SignatureTime)
 }
 
 func (e *PGPDecrypt) SignatureStatus() *libkb.SignatureStatus {


### PR DESCRIPTION
The original issue (CORE-6440) was that `keybase pgp verify` wasn't
printing anything for valid messages signed by revoked keys. This turned
out to be caused by a nil context (`ctx.NetContext`) that was getting
passed into an RPC call. That caused the rpc library to short-circuit
immediately with `errors.New("No Context provided for this call")`,
however we were dropping the error. As part of fixing the nil context,
make sure we propagate errors here.

TODO?: There are many other places in the codebase referencing
`ctx.NetContext` directly, as this code did. Are all of them suspect?

r? @patrickxb 