### PR TITLE
Use CITimeMutliplier to extend timeouts in CI (fix TestGitTeamer CI flake)

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -396,7 +396,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 // a canceler, and an error. The canceler ought to be called before the caller (or its caller) is done
 // with this request.
 func doTimeout(origCtx context.Context, g Contextifier, cli *Client, req *http.Request, timeout time.Duration) (*http.Response, func(), error) {
-	ctx, cancel := context.WithTimeout(origCtx, timeout*CITimeMultiplier(g))
+	ctx, cancel := context.WithTimeout(origCtx, timeout*CITimeMultiplier(g.G()))
 	resp, err := ctxhttp.Do(ctx, cli.cli, req)
 	return resp, cancel, err
 }

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -955,7 +955,7 @@ func (s *LoginState) acctHandle(f acctHandler, name string) error {
 	select {
 	case s.acctReqs <- *req:
 		s.G().Log.Debug("* acctHandle sent: %s", req)
-	case <-time.After(5 * time.Second * CITimeMultiplier(s)):
+	case <-time.After(5 * time.Second * CITimeMultiplier(s.G())):
 		s.G().Log.Debug("- acctHandle timeout: %s, active request: %s", req, s.activeReq)
 		if s.G().Env.GetDebug() {
 			debug.PrintStack()

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -687,8 +687,8 @@ func SleepUntilWithContext(ctx context.Context, clock clockwork.Clock, deadline 
 	}
 }
 
-func CITimeMultiplier(g Contextifier) time.Duration {
-	if g.G().GetEnv().RunningInCI() {
+func CITimeMultiplier(g *GlobalContext) time.Duration {
+	if g.GetEnv().RunningInCI() {
 		return time.Duration(3)
 	}
 	return time.Duration(1)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -371,7 +371,7 @@ func (u *userPlusDevice) waitForTeamChangedGregor(team string, toSeqno keybase1.
 				return
 			}
 			u.tc.T.Logf("ignoring change message for team %q seqno %d %+v (expected team = %q, seqno = %d)", arg.TeamName, arg.LatestSeqno, arg.Changes, team, toSeqno)
-		case <-time.After(1 * time.Second):
+		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
 		}
 	}
 	u.tc.T.Fatalf("timed out waiting for team rotate %s", team)
@@ -388,7 +388,7 @@ func (u *userPlusDevice) waitForTeamIDChangedGregor(teamID keybase1.TeamID, toSe
 				return
 			}
 			u.tc.T.Logf("ignoring change message (expected teamID = %q, seqno = %d)", teamID.String(), toSeqno)
-		case <-time.After(1 * time.Second):
+		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
 		}
 	}
 	u.tc.T.Fatalf("timed out waiting for team rotate %s", teamID)
@@ -400,7 +400,7 @@ func (u *userPlusDevice) drainGregor() {
 		case <-u.notifications.rotateCh:
 			u.tc.T.Logf("dropped notification")
 			// drop
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(500 * time.Millisecond * libkb.CITimeMultiplier(u.tc.G)):
 			u.tc.T.Logf("no notification received, drain complete")
 			return
 		}
@@ -424,7 +424,7 @@ func (u *userPlusDevice) waitForRotate(team string, toSeqno keybase1.Seqno) {
 				return
 			}
 			u.tc.T.Logf("ignoring rotate message")
-		case <-time.After(1 * time.Second):
+		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
 		}
 	}
 	u.tc.T.Fatalf("timed out waiting for team rotate %s", team)
@@ -446,7 +446,7 @@ func (u *userPlusDevice) waitForRotateByID(teamID keybase1.TeamID, toSeqno keyba
 				return
 			}
 			u.tc.T.Logf("ignoring rotate message")
-		case <-time.After(1 * time.Second):
+		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
 		}
 	}
 	u.tc.T.Fatalf("timed out waiting for team rotate %s", teamID)
@@ -463,7 +463,7 @@ func (u *userPlusDevice) waitForTeamChangedAndRotated(team string, toSeqno keyba
 				return
 			}
 			u.tc.T.Logf("ignoring change message (expected team = %q, seqno = %d)", team, toSeqno)
-		case <-time.After(1 * time.Second):
+		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
 		}
 	}
 	u.tc.T.Fatalf("timed out waiting for team rotate %s", team)
@@ -635,6 +635,7 @@ func TestGetTeamRootID(t *testing.T) {
 	require.NoError(t, err)
 
 	subteamName, err := parentName.Append("mysubteam")
+	require.NoError(t, err)
 
 	t.Logf("create a sub-subteam")
 	subteamID2, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "teamofsubs", subteamName)


### PR DESCRIPTION
The timeouts in some teams systests were pretty tight.  This patch multiplies them by the CITimeMultiplier to extend them a bit.