### PR TITLE
generate desktop notifications for system messages CORE-6596

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -647,12 +647,11 @@ function* _sendNotifications(action: ChatGen.AppendMessagesPayload): Saga.SagaGe
   )
   // Only send if you're not looking at it and service wants us to
   if (svcDisplay && (!convoIsSelected || !appFocused || !chatTabSelected)) {
-    const me = Selectors.usernameSelector(state)
-    const message = action.payload.messages.reverse().find(m => m.type === 'Text' && m.author !== me)
+    const message = action.payload.messages.reverse().find(m => m.type === 'Text' || m.type === 'System')
     // Is this message part of a muted conversation? If so don't notify.
     const convo = Constants.getInbox(state, action.payload.conversationIDKey)
     if (convo && convo.get('status') !== 'muted') {
-      if (message && message.type === 'Text') {
+      if (message && (message.type === 'Text' || message.type === 'System')) {
         console.log('Sending Chat notification')
         const snippet = Constants.makeSnippet(Constants.serverMessageToMessageText(message))
         yield Saga.put((dispatch: Dispatch) => {

--- a/shared/actions/chat/thread-content.js
+++ b/shared/actions/chat/thread-content.js
@@ -554,19 +554,23 @@ function _unboxedToMessage(
           if (body) {
             switch (body.systemType) {
               case ChatTypes.localMessageSystemType.addedtoteam: {
-                const user = body.addedtoteam ? `@${body.addedtoteam.addee}` : 'someone'
-                sysMsgText = `Hello! I've just added ${user} to this team.`
+                const addee = body.addedtoteam ? `@${body.addedtoteam.addee}` : 'someone'
+                const adder = body.addedtoteam ? `@${body.addedtoteam.adder}` : 'someone'
+                const team = body.addedtoteam ? `${body.addedtoteam.team}` : '???'
+                sysMsgText = `${adder} just added ${addee} to team ${team}.`
                 break
               }
               case ChatTypes.localMessageSystemType.inviteaddedtoteam: {
                 const invitee = body.inviteaddedtoteam ? `@${body.inviteaddedtoteam.invitee}` : 'someone'
+                const adder = body.inviteaddedtoteam ? `@${body.inviteaddedtoteam.adder}` : 'someone'
                 const inviter = body.inviteaddedtoteam ? `@${body.inviteaddedtoteam.inviter}` : 'someone'
-                sysMsgText = `Hello! I've just added ${invitee} to the team. This user had been invited by ${inviter}`
+                const team = body.inviteaddedtoteam ? `${body.inviteaddedtoteam.team}` : '???'
+                sysMsgText = `${adder} just added ${invitee} to team ${team}. This user had been invited by ${inviter}`
                 break
               }
               case ChatTypes.localMessageSystemType.complexteam: {
                 const team = body.complexteam ? body.complexteam.team : '???'
-                sysMsgText = `Attention @channel!\n\nI have just created a new channel in team ${team}. Here are some things that are now different:\n\n1.) Notifications will not happen for every message. Click or tap the info icon on the right to configure them.\n2.) The #general channel is now in the "Big Teams" section of the inbox.\n3.) You can hit the three dots next to ${team} in the inbox view to join other channels.\n\nEnjoy!`
+                sysMsgText = `A new channel has been created in team ${team}. Here are some things that are now different:\n\n1.) Notifications will not happen for every message. Click or tap the info icon on the right to configure them.\n2.) The #general channel is now in the "Big Teams" section of the inbox.\n3.) You can hit the three dots next to ${team} in the inbox view to join other channels.\n\nEnjoy!`
                 break
               }
             }

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -611,6 +611,8 @@ function serverMessageToMessageText(message: ServerMessage): ?string {
   switch (message.type) {
     case 'Text':
       return message.message.stringValue()
+    case 'System':
+      return message.message.stringValue()
     default:
       return null
   }


### PR DESCRIPTION
@keybase/react-hackers 

Patch does the following:
1.) Make the text for system messages less like a message from a user and more like a message from a system (and closer to designs).
2.) Display desktop notifications for system messages. I tried to simplify the code inbox.js for deciding on whether or not to show these but it was impossible with the constraints from Flow.