### PR TITLE
Speed up TestClearSocialInvitesOnAdd

### DIFF
--- a/go/client/cmd_team_create.go
+++ b/go/client/cmd_team_create.go
@@ -12,8 +12,9 @@ import (
 )
 
 type CmdTeamCreate struct {
-	TeamName  keybase1.TeamName
-	SessionID int
+	TeamName                 keybase1.TeamName
+	SuppressTeamChatAnnounce bool
+	SessionID                int
 	libkb.Contextified
 }
 
@@ -38,7 +39,7 @@ func (v *CmdTeamCreate) Run() (err error) {
 	// only send a chat notification if creating a root team.
 	// (if creating a sub team, the creator is not a member of the team
 	// and thus can't send a chat message)
-	sendChatNotification := v.TeamName.IsRootTeam()
+	sendChatNotification := v.TeamName.IsRootTeam() && !v.SuppressTeamChatAnnounce
 
 	createRes, err := cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{
 		Name:                 v.TeamName.String(),

--- a/go/systests/standalone_test.go
+++ b/go/systests/standalone_test.go
@@ -14,12 +14,15 @@ import (
 )
 
 type standaloneUserArgs struct {
-	disableGregor bool
+	disableGregor            bool
+	suppressTeamChatAnnounce bool
 }
 
 func makeUserStandalone(t *testing.T, pre string, opts standaloneUserArgs) *userPlusDevice {
 	tctx := setupTest(t, pre)
 	var u userPlusDevice
+
+	u.suppressTeamChatAnnounce = opts.suppressTeamChatAnnounce
 
 	g := tctx.G
 	if opts.disableGregor {

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -391,41 +391,53 @@ func TestClearSocialInvitesOnAdd(t *testing.T) {
 
 	// Disable gregor in this test so Ann does not immediately add Bob
 	// through SBS handler when bob proves Rooter.
-	ann := makeUserStandalone(t, "ann", standaloneUserArgs{disableGregor: true})
+	ann := makeUserStandalone(t, "ann", standaloneUserArgs{
+		disableGregor:            true,
+		suppressTeamChatAnnounce: true,
+	})
 	tt.users = append(tt.users, ann)
 
+	tracer := ann.tc.G.CTimeTracer(context.Background(), "test-tracer")
+	defer tracer.Finish()
+
+	tracer.Stage("bob")
 	bob := tt.addUser("bob")
 
+	tracer.Stage("team")
 	team := ann.createTeam()
 
 	t.Logf("Ann created team %q", team)
 
 	bobBadRooter := "other" + bob.username
 
+	tracer.Stage("add 1")
 	ann.addTeamMember(team, bob.username+"@rooter", keybase1.TeamRole_WRITER)
+	tracer.Stage("add 2")
 	ann.addTeamMember(team, bobBadRooter+"@rooter", keybase1.TeamRole_WRITER)
 
+	tracer.Stage("prove rooter")
 	bob.proveRooter()
 
 	// Because bob@rooter is now proven by bob, this will add bob as a
 	// member instead of making an invitation.
+	tracer.Stage("add 3")
 	ann.addTeamMember(team, bob.username+"@rooter", keybase1.TeamRole_WRITER)
 
+	tracer.Stage("get team")
 	t0, err := teams.GetTeamByNameForTest(context.TODO(), ann.tc.G, team, false, true)
 	require.NoError(t, err)
 
+	tracer.Stage("assertions")
 	writers, err := t0.UsersWithRole(keybase1.TeamRole_WRITER)
 	require.NoError(t, err)
 	require.Equal(t, len(writers), 1)
 	require.True(t, writers[0].Uid.Equal(bob.uid))
 
-	// Adding should have cleared bob...@rooter
 	hasInv, err := t0.HasActiveInvite(keybase1.TeamInviteName(bob.username), "rooter")
 	require.NoError(t, err)
-	require.False(t, hasInv)
+	require.False(t, hasInv, "Adding should have cleared bob...@rooter")
 
-	// But should not have cleared otherbob...@rooter
 	hasInv, err = t0.HasActiveInvite(keybase1.TeamInviteName(bobBadRooter), "rooter")
 	require.NoError(t, err)
-	require.True(t, hasInv)
+	require.True(t, hasInv, "But should not have cleared otherbob...@rooter")
 }

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -200,16 +200,17 @@ func (tt *teamTester) cleanup() {
 }
 
 type userPlusDevice struct {
-	uid           keybase1.UID
-	username      string
-	passphrase    string
-	userInfo      *signupInfo
-	backupKey     backupKey
-	device        *deviceWrapper
-	tc            *libkb.TestContext
-	deviceClient  keybase1.DeviceClient
-	teamsClient   keybase1.TeamsClient
-	notifications *teamNotifyHandler
+	uid                      keybase1.UID
+	username                 string
+	passphrase               string
+	userInfo                 *signupInfo
+	backupKey                backupKey
+	device                   *deviceWrapper
+	tc                       *libkb.TestContext
+	deviceClient             keybase1.DeviceClient
+	teamsClient              keybase1.TeamsClient
+	notifications            *teamNotifyHandler
+	suppressTeamChatAnnounce bool
 }
 
 func (u *userPlusDevice) createTeam() string {
@@ -223,6 +224,9 @@ func (u *userPlusDevice) createTeam() string {
 		u.tc.T.Fatal(err)
 	}
 	create.TeamName = name
+	create.SuppressTeamChatAnnounce = u.suppressTeamChatAnnounce
+	tracer := u.tc.G.CTimeTracer(context.Background(), "tracer-create-team")
+	defer tracer.Finish()
 	if err := create.Run(); err != nil {
 		u.tc.T.Fatal(err)
 	}
@@ -243,6 +247,7 @@ func (u *userPlusDevice) addTeamMember(team, username string, role keybase1.Team
 	add.Team = team
 	add.Username = username
 	add.Role = role
+	add.SkipChatNotification = u.suppressTeamChatAnnounce
 	if err := add.Run(); err != nil {
 		u.tc.T.Fatal(err)
 	}

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -258,7 +258,7 @@ func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me *lib
 }
 
 func CreateRootTeam(ctx context.Context, g *libkb.GlobalContext, nameString string, settings keybase1.TeamSettings) (err error) {
-	defer g.CTrace(ctx, "CreateRootTeam", func() error { return err })()
+	defer g.CTraceTimed(ctx, "CreateRootTeam", func() error { return err })()
 
 	perUserKeyUpgradeSoft(ctx, g, "create-root-team")
 


### PR DESCRIPTION
This test was taking 20s. This speeds it up to 7s.

The slowdown was chat failing to send team announcement messages, which it had no hope of because gregor was explicitly disabled for this test. This PR disabled the chat sends at the command runner level.

```
:chat-trace=SLlJQRwMDpUW]
        test_logger.go:66: ^M2017-11-13 15:19:55.35037 gregor.go:268: [D] ++Chat: | PushHandler: GetClient: shutdown, using OfflineClient for chat1.RemoteClient (waited 4s for connectHappened)
        test_logger.go:66: ^M2017-11-13 15:19:55.35044 helper.go:782: [D] ++Chat: - newConversationHelper: newConversationHelper -> ERROR: error preparing message: operation failed: no connection to chat server (8.008125064s) [tags:chat-
trace=SLlJQRwMDpUW]
        test_logger.go:66: ^M2017-11-13 15:19:55.35047 chatmessaging.go:16: [W] failed to send team welcome message: error preparing message: operation failed: no connection to chat server
        test_logger.go:66: ^M2017-11-13 15:19:55.35049 teams.go:54: [D] - TeamCreate(ttrdwvnnli) -> <nil> [time=8.300145366s]
        test_logger.go:66: ^M2017-11-13 15:19:55.35060 teams_test.go:231: [D] - tracer-create-team [time=8.300376789s]
```