### PR TITLE
make the Debian install/cronjob insert out PGP key every time

### DIFF
--- a/packaging/linux/deb/cron.template
+++ b/packaging/linux/deb/cron.template
@@ -308,8 +308,15 @@ if [ -r "$DEFAULTS_FILE" ]; then
   . "$DEFAULTS_FILE"
 fi
 
+# Difference from Chrome here: We unconditionally install the signing key into
+# APT's keyring every time this job runs, rather than only on the first
+# install. The immediate motivation for this change is that we needed to extend
+# the expiration date of our key. We're making it unconditional to avoid
+# needing to parse GPG output. Note that we've only made this change on the
+# Debian side -- it seems RPM isn't bothered as much by expired keys.
+install_key
+
 if [ "$repo_add_once" = "true" ]; then
-  install_key
   create_sources_lists
   RES=$?
   # Sources creation succeeded, so stop trying.


### PR DESCRIPTION
r? @maxtaco 

This is the crucial change that will let us update the code signing key on Debian before it expires in 5 days. We added the updated key body in a0c9ba319161609d2ddeaf6e517508e0b9537bf8.

    I tested this by un-suppressing the output of the apt-key command in the
    cronjob and manually running it repeatedly:
    
    1) The key does get updated. (This happens immediately after the package
       update, because the postinstall script runs the cronjob.)
    2) After the first time, the /etc/apt/trusted.gpg keyring doesn't get
       modified. So we don't have to worry about e.g. the file growing over
       time.
    3) Corrupting the signing key does make apt-key return an error.
