### PR TITLE
Stop memberSet.loadMember from returning zero key

### DIFF
--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -252,7 +252,7 @@ func HandleOpenTeamAccessRequest(ctx context.Context, g *libkb.GlobalContext, ms
 		}
 
 		if !team.IsOpen() {
-			g.Log.CDebugf(ctx, "team %q is not an open team", team.Name)
+			g.Log.CDebugf(ctx, "team %q is not an open team", team.Name())
 			return nil // Not an error - let the handler dismiss the message.
 		}
 

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -118,7 +118,7 @@ func (l *LoaderContextG) getMe(ctx context.Context) (res keybase1.UserVersion, e
 	if err != nil {
 		return keybase1.UserVersion{}, err
 	}
-	return NewUserVersion(upak.Current.Uid, upak.Current.EldestSeqno), nil
+	return upak.Current.ToUserVersion(), nil
 }
 
 func (l *LoaderContextG) lookupEldestSeqno(ctx context.Context, uid keybase1.UID) (keybase1.Seqno, error) {


### PR DESCRIPTION
There are ways to accidentally try to add a pukless user as a real member. Such as handling an openreq for a user that was in the team but hence reset. This might have been part of the event last week.

Used to get a vague error:
```
2017-11-14 13:15:38.96824 teams.go:506: [D] - Team.ChangeMembershipPermanent -> ERROR: Bad key found: KID was way too short [tags:CLKR=PUh8_WuBpkYG]
```

Now you get a more descriptive error (earlier):
```
2017-11-14 13:12:40.88472 teams.go:506: [D] - Team.ChangeMembershipPermanent -> ERROR: user has no per-user key: d23116337a2d9bcdfa2d96686b228019%0 (bob_a656318ad2) [tags:CLKR=fbUZ2qRTGGnW]
```