### PR TITLE
load more messages into thread in serial

### DIFF
--- a/shared/actions/chat/thread-content.js
+++ b/shared/actions/chat/thread-content.js
@@ -755,6 +755,9 @@ function* _appendOrPrependMessagesToConversation(
   } else {
     nextMessages = I.OrderedSet(messages.map(m => m.key)).concat(currentMessages)
   }
+  console.log(
+    `arg: ${JSON.stringify(arg)} currentMessages: ${JSON.stringify(currentMessages)} nextMessage: ${JSON.stringify(nextMessages)}`
+  )
   yield Saga.put(
     EntityCreators.replaceEntity(['conversationMessages'], I.Map({[conversationIDKey]: nextMessages}))
   )

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -35,6 +35,7 @@ let config = {
 }
 
 // Developer settings
+config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = false
   config.enableStoreLogging = false
@@ -42,7 +43,6 @@ if (__DEV__) {
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
-  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false


### PR DESCRIPTION
@chrisnojima what do you think of this? Seems like this will line up all requests to modify threads so that we don't get in a situation where two sagas are trying to update at the same time. Really this will just guard against all scenarios where we issue two `loadMoreMessages` calls for the same convo (I don't know why that happens). 