### PR TITLE
Fix open in chat button on files page

### DIFF
--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -22,7 +22,7 @@ type Props = $Shape<{
   ignoreFolder: (path: string) => void,
   favoriteFolder: (path: string) => void,
   openInKBFS: (path: string) => void,
-  openTlfInChat: ({tlf: string, isTeam: boolean}) => void,
+  openTlfInChat: (tlf: string, isTeam: boolean) => void,
 }>
 
 type State = {
@@ -68,8 +68,7 @@ class Files extends Component<Props, State> {
     }
     const openConversationFromFolder = () => {
       const tlf = this.props && this.props.folder && this.props.folder.sortName
-      tlf &&
-        this.props.openTlfInChat({tlf: tlf, isTeam: this.props.folder ? this.props.folder.isTeam : false})
+      tlf && this.props.openTlfInChat(tlf, this.props.folder ? this.props.folder.isTeam : false)
     }
     const ignoreCurrentFolder = () => {
       this.props.ignoreFolder(this.props.path)


### PR DESCRIPTION
one-liner to fix the`Open in chat` button on the files page. r? @keybase/react-hackers 