### PR TITLE
Fix proof checker missing error check

### DIFF
--- a/go/teams/proofs.go
+++ b/go/teams/proofs.go
@@ -262,7 +262,6 @@ func (p proof) findLink(ctx context.Context, g *libkb.GlobalContext, world Loade
 			return linkID, err
 		}
 		linkID, ok = lm[seqno]
-		return linkID, nil
 	}
 
 	if !ok {


### PR DESCRIPTION
Fall through to the `ok` check