### PR TITLE
add new RPC for explicitly previewing a channel CORE-6566

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -262,6 +262,11 @@ func (f failingRemote) LeaveConversation(ctx context.Context, convID chat1.Conve
 	return chat1.JoinLeaveConversationRemoteRes{}, nil
 }
 
+func (f failingRemote) PreviewConversation(ctx context.Context, convID chat1.ConversationID) (chat1.JoinLeaveConversationRemoteRes, error) {
+	require.Fail(f.t, "PreviewConversation")
+	return chat1.JoinLeaveConversationRemoteRes{}, nil
+}
+
 func (f failingRemote) DeleteConversation(ctx context.Context, convID chat1.ConversationID) (chat1.DeleteConversationRemoteRes, error) {
 	require.Fail(f.t, "DeleteConversation")
 	return chat1.DeleteConversationRemoteRes{}, nil

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -648,8 +648,8 @@ func PreviewConversation(ctx context.Context, g *globals.Context, debugger utils
 	alreadyIn, irl, err := g.InboxSource.IsMember(ctx, uid, convID)
 	if err != nil {
 		debugger.Debug(ctx, "PreviewConversation: IsMember err: %s", err.Error())
-		// Pretend we're in.
-		alreadyIn = true
+		// Assume we aren't in, server will reject us otherwise.
+		alreadyIn = false
 	}
 	if irl != nil {
 		rl = append(rl, *irl)

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -590,7 +590,7 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 			Uid:    uid,
 			ConvID: convID,
 		},
-	}, nil, nil); err != nil {
+	}, nil, nil, nil); err != nil {
 		debugger.Debug(ctx, "JoinConversation: failed to apply membership update: %s", err.Error())
 	}
 

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -436,7 +436,8 @@ func (s *RemoteInboxSource) TlfFinalize(ctx context.Context, uid gregor1.UID, ve
 }
 
 func (s *RemoteInboxSource) MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
-	joined []chat1.ConversationMember, removed []chat1.ConversationMember, resets []chat1.ConversationMember) (res types.MembershipUpdateRes, err error) {
+	joined []chat1.ConversationMember, removed []chat1.ConversationMember, resets []chat1.ConversationMember,
+	previews []chat1.ConversationID) (res types.MembershipUpdateRes, err error) {
 	return res, err
 }
 
@@ -743,7 +744,8 @@ func (s *HybridInboxSource) TlfFinalize(ctx context.Context, uid gregor1.UID, ve
 }
 
 func (s *HybridInboxSource) MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
-	joined []chat1.ConversationMember, removed []chat1.ConversationMember, resets []chat1.ConversationMember) (res types.MembershipUpdateRes, err error) {
+	joined []chat1.ConversationMember, removed []chat1.ConversationMember, resets []chat1.ConversationMember,
+	previews []chat1.ConversationID) (res types.MembershipUpdateRes, err error) {
 	defer s.Trace(ctx, func() error { return err }, "MembershipUpdate")()
 
 	// Separate into joins and removed on uid, and then on other users
@@ -755,6 +757,9 @@ func (s *HybridInboxSource) MembershipUpdate(ctx context.Context, uid gregor1.UI
 			res.OthersJoinedConvs = append(res.OthersJoinedConvs, j)
 		}
 	}
+	// Append any previewed channels as well. We can do this since we just fetch all these conversations from
+	// the server, and that will have the proper member status set.
+	userJoined = append(userJoined, previews...)
 	for _, r := range removed {
 		if r.Uid.Eq(uid) {
 			res.UserRemovedConvs = append(res.UserRemovedConvs, r.ConvID)

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -789,7 +789,7 @@ func (g *PushHandler) MembershipUpdate(ctx context.Context, m gregor.OutOfBandMe
 
 		// Write out changes to local storage
 		updateRes, err := g.G().InboxSource.MembershipUpdate(ctx, uid, update.InboxVers, update.Joined,
-			update.Removed, update.Reset)
+			update.Removed, update.Reset, update.Previewed)
 		if err != nil {
 			g.Debug(ctx, "MembershipUpdate: failed to update membership on inbox: %s", err.Error())
 			return err

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2180,6 +2180,32 @@ func (h *Server) LeaveConversationLocal(ctx context.Context, convID chat1.Conver
 	return res, nil
 }
 
+func (h *Server) PreviewConversationByIDLocal(ctx context.Context, convID chat1.ConversationID) (res chat1.JoinLeaveConversationLocalRes, err error) {
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
+		&identBreaks, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("PreviewConversation(%s)", convID))()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
+	defer func() {
+		if res.Offline {
+			h.Debug(ctx, "PreviewConversationLocal: result obtained offline")
+		}
+	}()
+	uid, err := h.assertLoggedInUID(ctx)
+	if err != nil {
+		return res, err
+	}
+
+	rl, err := PreviewConversation(ctx, h.G(), h.DebugLabeler, h.remoteClient, uid, convID)
+	if err != nil {
+		return res, err
+	}
+
+	res.RateLimits = utils.AggRateLimits(rl)
+	res.Offline = h.G().InboxSource.IsOffline(ctx)
+	return res, nil
+}
+
 func (h *Server) DeleteConversationLocal(ctx context.Context, arg chat1.DeleteConversationLocalArg) (res chat1.DeleteConversationLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI,

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -1126,7 +1126,6 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers,
 	var ujs []types.RemoteConversation
 	for _, uj := range userJoined {
 		i.Debug(ctx, "MembershipUpdate: joined conv: %s", uj.GetConvID())
-		uj.ReaderInfo.Status = chat1.ConversationMemberStatus_ACTIVE
 		ujs = append(ujs, types.RemoteConversation{
 			Conv: uj,
 		})

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -98,7 +98,7 @@ type InboxSource interface {
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
 	MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		joined []chat1.ConversationMember, removed []chat1.ConversationMember,
-		resets []chat1.ConversationMember) (MembershipUpdateRes, error)
+		resets []chat1.ConversationMember, previews []chat1.ConversationID) (MembershipUpdateRes, error)
 	TeamTypeChanged(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
 		teamType chat1.TeamType) (*chat1.ConversationLocal, error)
 

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -690,6 +690,10 @@ func (m *ChatRemoteMock) LeaveConversation(ctx context.Context, convID chat1.Con
 	return chat1.JoinLeaveConversationRemoteRes{}, nil
 }
 
+func (m *ChatRemoteMock) PreviewConversation(ctx context.Context, convID chat1.ConversationID) (chat1.JoinLeaveConversationRemoteRes, error) {
+	return chat1.JoinLeaveConversationRemoteRes{}, nil
+}
+
 func (m *ChatRemoteMock) DeleteConversation(ctx context.Context, convID chat1.ConversationID) (chat1.DeleteConversationRemoteRes, error) {
 	return chat1.DeleteConversationRemoteRes{}, nil
 }

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -239,6 +239,7 @@ type UpdateConversationMembership struct {
 	Joined        []ConversationMember `codec:"joined" json:"joined"`
 	Removed       []ConversationMember `codec:"removed" json:"removed"`
 	Reset         []ConversationMember `codec:"reset" json:"reset"`
+	Previewed     []ConversationID     `codec:"previewed" json:"previewed"`
 	UnreadUpdate  *UnreadUpdate        `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 	UnreadUpdates []UnreadUpdate       `codec:"unreadUpdates" json:"unreadUpdates"`
 }
@@ -279,6 +280,17 @@ func (o UpdateConversationMembership) DeepCopy() UpdateConversationMembership {
 			}
 			return ret
 		})(o.Reset),
+		Previewed: (func(x []ConversationID) []ConversationID {
+			if x == nil {
+				return nil
+			}
+			var ret []ConversationID
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Previewed),
 		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3740,6 +3740,10 @@ type JoinConversationByIDLocalArg struct {
 	ConvID ConversationID `codec:"convID" json:"convID"`
 }
 
+type PreviewConversationByIDLocalArg struct {
+	ConvID ConversationID `codec:"convID" json:"convID"`
+}
+
 type LeaveConversationLocalArg struct {
 	ConvID ConversationID `codec:"convID" json:"convID"`
 }
@@ -3809,6 +3813,7 @@ type LocalInterface interface {
 	UpdateTyping(context.Context, UpdateTypingArg) error
 	JoinConversationLocal(context.Context, JoinConversationLocalArg) (JoinLeaveConversationLocalRes, error)
 	JoinConversationByIDLocal(context.Context, ConversationID) (JoinLeaveConversationLocalRes, error)
+	PreviewConversationByIDLocal(context.Context, ConversationID) (JoinLeaveConversationLocalRes, error)
 	LeaveConversationLocal(context.Context, ConversationID) (JoinLeaveConversationLocalRes, error)
 	DeleteConversationLocal(context.Context, DeleteConversationLocalArg) (DeleteConversationLocalRes, error)
 	GetTLFConversationsLocal(context.Context, GetTLFConversationsLocalArg) (GetTLFConversationsLocalRes, error)
@@ -4329,6 +4334,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"previewConversationByIDLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]PreviewConversationByIDLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]PreviewConversationByIDLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]PreviewConversationByIDLocalArg)(nil), args)
+						return
+					}
+					ret, err = i.PreviewConversationByIDLocal(ctx, (*typedArgs)[0].ConvID)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"leaveConversationLocal": {
 				MakeArg: func() interface{} {
 					ret := make([]LeaveConversationLocalArg, 1)
@@ -4606,6 +4627,12 @@ func (c LocalClient) JoinConversationLocal(ctx context.Context, __arg JoinConver
 func (c LocalClient) JoinConversationByIDLocal(ctx context.Context, convID ConversationID) (res JoinLeaveConversationLocalRes, err error) {
 	__arg := JoinConversationByIDLocalArg{ConvID: convID}
 	err = c.Cli.Call(ctx, "chat.1.local.joinConversationByIDLocal", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) PreviewConversationByIDLocal(ctx context.Context, convID ConversationID) (res JoinLeaveConversationLocalRes, err error) {
+	__arg := PreviewConversationByIDLocalArg{ConvID: convID}
+	err = c.Cli.Call(ctx, "chat.1.local.previewConversationByIDLocal", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -840,6 +840,10 @@ type LeaveConversationArg struct {
 	ConvID ConversationID `codec:"convID" json:"convID"`
 }
 
+type PreviewConversationArg struct {
+	ConvID ConversationID `codec:"convID" json:"convID"`
+}
+
 type DeleteConversationArg struct {
 	ConvID ConversationID `codec:"convID" json:"convID"`
 }
@@ -891,6 +895,7 @@ type RemoteInterface interface {
 	UpdateTypingRemote(context.Context, UpdateTypingRemoteArg) error
 	JoinConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes, error)
 	LeaveConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes, error)
+	PreviewConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes, error)
 	DeleteConversation(context.Context, ConversationID) (DeleteConversationRemoteRes, error)
 	GetTLFConversations(context.Context, GetTLFConversationsArg) (GetTLFConversationsRes, error)
 	SetAppNotificationSettings(context.Context, SetAppNotificationSettingsArg) (SetAppNotificationSettingsRes, error)
@@ -1271,6 +1276,22 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"previewConversation": {
+				MakeArg: func() interface{} {
+					ret := make([]PreviewConversationArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]PreviewConversationArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]PreviewConversationArg)(nil), args)
+						return
+					}
+					ret, err = i.PreviewConversation(ctx, (*typedArgs)[0].ConvID)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"deleteConversation": {
 				MakeArg: func() interface{} {
 					ret := make([]DeleteConversationArg, 1)
@@ -1490,6 +1511,12 @@ func (c RemoteClient) JoinConversation(ctx context.Context, convID ConversationI
 func (c RemoteClient) LeaveConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes, err error) {
 	__arg := LeaveConversationArg{ConvID: convID}
 	err = c.Cli.Call(ctx, "chat.1.remote.leaveConversation", []interface{}{__arg}, &res)
+	return
+}
+
+func (c RemoteClient) PreviewConversation(ctx context.Context, convID ConversationID) (res JoinLeaveConversationRemoteRes, err error) {
+	__arg := PreviewConversationArg{ConvID: convID}
+	err = c.Cli.Call(ctx, "chat.1.remote.previewConversation", []interface{}{__arg}, &res)
 	return
 }
 

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -94,6 +94,8 @@ protocol gregor {
         array<ConversationMember> joined;
         array<ConversationMember> removed;
         array<ConversationMember> reset;
+        array<ConversationID> previewed; // only IDs the user receiving the message has previews are in here
+
         union { null, UnreadUpdate } unreadUpdate;
         array<UnreadUpdate> unreadUpdates;
     }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -709,6 +709,7 @@ protocol local {
   }
   JoinLeaveConversationLocalRes joinConversationLocal(string tlfName, TopicType topicType, keybase1.TLFVisibility visibility, string topicName);
   JoinLeaveConversationLocalRes joinConversationByIDLocal(ConversationID convID);
+  JoinLeaveConversationLocalRes previewConversationByIDLocal(ConversationID convID);
   JoinLeaveConversationLocalRes leaveConversationLocal(ConversationID convID);
   record DeleteConversationLocalRes {
     boolean offline;

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -229,6 +229,7 @@ protocol remote {
   }
   JoinLeaveConversationRemoteRes joinConversation(ConversationID convID);
   JoinLeaveConversationRemoteRes leaveConversation(ConversationID convID);
+  JoinLeaveConversationRemoteRes previewConversation(ConversationID convID);
   record DeleteConversationRemoteRes {
     union { null, RateLimit } rateLimit;
   }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -336,6 +336,10 @@ export const localPostTextNonblockRpcChannelMap = (configKeys: Array<string>, re
 
 export const localPostTextNonblockRpcPromise = (request: (RequestCommon & {callback?: ?(err: ?any, response: LocalPostTextNonblockResult) => void} & {param: LocalPostTextNonblockRpcParam})): Promise<LocalPostTextNonblockResult> => new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postTextNonblock', request, (error, result) => error ? reject(error) : resolve(result)))
 
+export const localPreviewConversationByIDLocalRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: LocalPreviewConversationByIDLocalResult) => void} & {param: LocalPreviewConversationByIDLocalRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.previewConversationByIDLocal', request)
+
+export const localPreviewConversationByIDLocalRpcPromise = (request: (RequestCommon & {callback?: ?(err: ?any, response: LocalPreviewConversationByIDLocalResult) => void} & {param: LocalPreviewConversationByIDLocalRpcParam})): Promise<LocalPreviewConversationByIDLocalResult> => new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.previewConversationByIDLocal', request, (error, result) => error ? reject(error) : resolve(result)))
+
 export const localRetryPostRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: LocalRetryPostRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.RetryPost', request)
 
 export const localRetryPostRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: LocalRetryPostRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.RetryPost', request, (error, result) => error ? reject(error) : resolve(result)))
@@ -452,6 +456,10 @@ export const remoteNewConversationRemoteRpcPromise = (request: (RequestCommon & 
 export const remotePostRemoteRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: RemotePostRemoteResult) => void} & {param: RemotePostRemoteRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.postRemote', request)
 
 export const remotePostRemoteRpcPromise = (request: (RequestCommon & {callback?: ?(err: ?any, response: RemotePostRemoteResult) => void} & {param: RemotePostRemoteRpcParam})): Promise<RemotePostRemoteResult> => new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.postRemote', request, (error, result) => error ? reject(error) : resolve(result)))
+
+export const remotePreviewConversationRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: RemotePreviewConversationResult) => void} & {param: RemotePreviewConversationRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.previewConversation', request)
+
+export const remotePreviewConversationRpcPromise = (request: (RequestCommon & {callback?: ?(err: ?any, response: RemotePreviewConversationResult) => void} & {param: RemotePreviewConversationRpcParam})): Promise<RemotePreviewConversationResult> => new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.previewConversation', request, (error, result) => error ? reject(error) : resolve(result)))
 
 export const remotePublishReadMessageRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: RemotePublishReadMessageRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.publishReadMessage', request)
 
@@ -949,6 +957,8 @@ export type LocalPostTextNonblockRpcParam = {|  conversationID: ConversationID,
   outboxID?: ?OutboxID,
   identifyBehavior: Keybase1.TLFIdentifyBehavior|}
 
+export type LocalPreviewConversationByIDLocalRpcParam = {|  convID: ConversationID|}
+
 export type LocalRetryPostRpcParam = {|  outboxID: OutboxID|}
 
 export type LocalSetAppNotificationSettingsLocalRpcParam = {|  convID: ConversationID,
@@ -1206,6 +1216,8 @@ export type RemotePostRemoteRpcParam = {|  conversationID: ConversationID,
   channelMention: ChannelMention,
   topicNameState?: ?TopicNameState|}
 
+export type RemotePreviewConversationRpcParam = {|  convID: ConversationID|}
+
 export type RemotePublishReadMessageRpcParam = {|  uid: Gregor1.UID,
   convID: ConversationID,
   msgID: MessageID|}
@@ -1369,7 +1381,7 @@ export type UnverifiedInboxUIItemMetadata = {|channelName: String,headline: Stri
 
 export type UnverifiedInboxUIItems = {|items?: ?Array<UnverifiedInboxUIItem>,pagination?: ?UIPagination,offline: Boolean,|}
 
-export type UpdateConversationMembership = {|inboxVers: InboxVers,joined?: ?Array<ConversationMember>,removed?: ?Array<ConversationMember>,reset?: ?Array<ConversationMember>,unreadUpdate?: ?UnreadUpdate,unreadUpdates?: ?Array<UnreadUpdate>,|}
+export type UpdateConversationMembership = {|inboxVers: InboxVers,joined?: ?Array<ConversationMember>,removed?: ?Array<ConversationMember>,reset?: ?Array<ConversationMember>,previewed?: ?Array<ConversationID>,unreadUpdate?: ?UnreadUpdate,unreadUpdates?: ?Array<UnreadUpdate>,|}
 type ChatUiChatConfirmChannelDeleteResult = Boolean
 type LocalDeleteConversationLocalResult = DeleteConversationLocalRes
 type LocalDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
@@ -1403,6 +1415,7 @@ type LocalPostLocalResult = PostLocalRes
 type LocalPostMetadataNonblockResult = PostLocalNonblockRes
 type LocalPostMetadataResult = PostLocalRes
 type LocalPostTextNonblockResult = PostLocalNonblockRes
+type LocalPreviewConversationByIDLocalResult = JoinLeaveConversationLocalRes
 type LocalSetAppNotificationSettingsLocalResult = SetAppNotificationSettingsLocalRes
 type LocalSetConversationStatusLocalResult = SetConversationStatusLocalRes
 type LocalUnboxMobilePushNotificationResult = String
@@ -1422,6 +1435,7 @@ type RemoteMarkAsReadResult = MarkAsReadRes
 type RemoteNewConversationRemote2Result = NewConversationRemoteRes
 type RemoteNewConversationRemoteResult = NewConversationRemoteRes
 type RemotePostRemoteResult = PostRemoteRes
+type RemotePreviewConversationResult = JoinLeaveConversationRemoteRes
 type RemoteS3SignResult = Bytes
 type RemoteSetAppNotificationSettingsResult = SetAppNotificationSettingsRes
 type RemoteSetConversationStatusResult = SetConversationStatusRes

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -310,6 +310,13 @@
           "name": "reset"
         },
         {
+          "type": {
+            "type": "array",
+            "items": "ConversationID"
+          },
+          "name": "previewed"
+        },
+        {
           "type": [
             null,
             "UnreadUpdate"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2910,6 +2910,15 @@
       ],
       "response": "JoinLeaveConversationLocalRes"
     },
+    "previewConversationByIDLocal": {
+      "request": [
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": "JoinLeaveConversationLocalRes"
+    },
     "leaveConversationLocal": {
       "request": [
         {

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -908,6 +908,15 @@
       ],
       "response": "JoinLeaveConversationRemoteRes"
     },
+    "previewConversation": {
+      "request": [
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": "JoinLeaveConversationRemoteRes"
+    },
     "deleteConversation": {
       "request": [
         {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -336,6 +336,10 @@ export const localPostTextNonblockRpcChannelMap = (configKeys: Array<string>, re
 
 export const localPostTextNonblockRpcPromise = (request: (RequestCommon & {callback?: ?(err: ?any, response: LocalPostTextNonblockResult) => void} & {param: LocalPostTextNonblockRpcParam})): Promise<LocalPostTextNonblockResult> => new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postTextNonblock', request, (error, result) => error ? reject(error) : resolve(result)))
 
+export const localPreviewConversationByIDLocalRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: LocalPreviewConversationByIDLocalResult) => void} & {param: LocalPreviewConversationByIDLocalRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.previewConversationByIDLocal', request)
+
+export const localPreviewConversationByIDLocalRpcPromise = (request: (RequestCommon & {callback?: ?(err: ?any, response: LocalPreviewConversationByIDLocalResult) => void} & {param: LocalPreviewConversationByIDLocalRpcParam})): Promise<LocalPreviewConversationByIDLocalResult> => new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.previewConversationByIDLocal', request, (error, result) => error ? reject(error) : resolve(result)))
+
 export const localRetryPostRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: LocalRetryPostRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.RetryPost', request)
 
 export const localRetryPostRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: LocalRetryPostRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.RetryPost', request, (error, result) => error ? reject(error) : resolve(result)))
@@ -452,6 +456,10 @@ export const remoteNewConversationRemoteRpcPromise = (request: (RequestCommon & 
 export const remotePostRemoteRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: RemotePostRemoteResult) => void} & {param: RemotePostRemoteRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.postRemote', request)
 
 export const remotePostRemoteRpcPromise = (request: (RequestCommon & {callback?: ?(err: ?any, response: RemotePostRemoteResult) => void} & {param: RemotePostRemoteRpcParam})): Promise<RemotePostRemoteResult> => new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.postRemote', request, (error, result) => error ? reject(error) : resolve(result)))
+
+export const remotePreviewConversationRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: RemotePreviewConversationResult) => void} & {param: RemotePreviewConversationRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.previewConversation', request)
+
+export const remotePreviewConversationRpcPromise = (request: (RequestCommon & {callback?: ?(err: ?any, response: RemotePreviewConversationResult) => void} & {param: RemotePreviewConversationRpcParam})): Promise<RemotePreviewConversationResult> => new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.previewConversation', request, (error, result) => error ? reject(error) : resolve(result)))
 
 export const remotePublishReadMessageRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: RemotePublishReadMessageRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.publishReadMessage', request)
 
@@ -949,6 +957,8 @@ export type LocalPostTextNonblockRpcParam = {|  conversationID: ConversationID,
   outboxID?: ?OutboxID,
   identifyBehavior: Keybase1.TLFIdentifyBehavior|}
 
+export type LocalPreviewConversationByIDLocalRpcParam = {|  convID: ConversationID|}
+
 export type LocalRetryPostRpcParam = {|  outboxID: OutboxID|}
 
 export type LocalSetAppNotificationSettingsLocalRpcParam = {|  convID: ConversationID,
@@ -1206,6 +1216,8 @@ export type RemotePostRemoteRpcParam = {|  conversationID: ConversationID,
   channelMention: ChannelMention,
   topicNameState?: ?TopicNameState|}
 
+export type RemotePreviewConversationRpcParam = {|  convID: ConversationID|}
+
 export type RemotePublishReadMessageRpcParam = {|  uid: Gregor1.UID,
   convID: ConversationID,
   msgID: MessageID|}
@@ -1369,7 +1381,7 @@ export type UnverifiedInboxUIItemMetadata = {|channelName: String,headline: Stri
 
 export type UnverifiedInboxUIItems = {|items?: ?Array<UnverifiedInboxUIItem>,pagination?: ?UIPagination,offline: Boolean,|}
 
-export type UpdateConversationMembership = {|inboxVers: InboxVers,joined?: ?Array<ConversationMember>,removed?: ?Array<ConversationMember>,reset?: ?Array<ConversationMember>,unreadUpdate?: ?UnreadUpdate,unreadUpdates?: ?Array<UnreadUpdate>,|}
+export type UpdateConversationMembership = {|inboxVers: InboxVers,joined?: ?Array<ConversationMember>,removed?: ?Array<ConversationMember>,reset?: ?Array<ConversationMember>,previewed?: ?Array<ConversationID>,unreadUpdate?: ?UnreadUpdate,unreadUpdates?: ?Array<UnreadUpdate>,|}
 type ChatUiChatConfirmChannelDeleteResult = Boolean
 type LocalDeleteConversationLocalResult = DeleteConversationLocalRes
 type LocalDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
@@ -1403,6 +1415,7 @@ type LocalPostLocalResult = PostLocalRes
 type LocalPostMetadataNonblockResult = PostLocalNonblockRes
 type LocalPostMetadataResult = PostLocalRes
 type LocalPostTextNonblockResult = PostLocalNonblockRes
+type LocalPreviewConversationByIDLocalResult = JoinLeaveConversationLocalRes
 type LocalSetAppNotificationSettingsLocalResult = SetAppNotificationSettingsLocalRes
 type LocalSetConversationStatusLocalResult = SetConversationStatusLocalRes
 type LocalUnboxMobilePushNotificationResult = String
@@ -1422,6 +1435,7 @@ type RemoteMarkAsReadResult = MarkAsReadRes
 type RemoteNewConversationRemote2Result = NewConversationRemoteRes
 type RemoteNewConversationRemoteResult = NewConversationRemoteRes
 type RemotePostRemoteResult = PostRemoteRes
+type RemotePreviewConversationResult = JoinLeaveConversationRemoteRes
 type RemoteS3SignResult = Bytes
 type RemoteSetAppNotificationSettingsResult = SetAppNotificationSettingsRes
 type RemoteSetConversationStatusResult = SetConversationStatusRes


### PR DESCRIPTION
Patch does the following:

1.) Adds a new RPC `PreviewConversatiobByIDLocal` which will add the user into a channel in `PREVIEW` mode.
2.) Process the new `Previewed` section of the `UpdateMembers` Gregor message to properly add the current user in the right mode for the inbox cache.