### PR TITLE
 make sure notification info gets updated on team type change

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -713,7 +713,6 @@ func (s *HybridInboxSource) TeamTypeChanged(ctx context.Context, uid gregor1.UID
 		s.Debug(ctx, "TeamTypeChanged: failed to read team type conv: %s", err.Error())
 		return nil, err
 	}
-	s.Debug(ctx, "TeamTypeChanged: desktop generic: %v", remoteConv.Notifications.Settings[keybase1.DeviceType_DESKTOP][chat1.NotificationKind_GENERIC])
 	ib := storage.NewInbox(s.G(), uid)
 	if cerr := ib.TeamTypeChanged(ctx, vers, convID, teamType, remoteConv.Notifications); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -946,7 +946,7 @@ func (i *Inbox) SetAppNotificationSettings(ctx context.Context, vers chat1.Inbox
 }
 
 func (i *Inbox) TeamTypeChanged(ctx context.Context, vers chat1.InboxVers,
-	convID chat1.ConversationID, teamType chat1.TeamType) (err Error) {
+	convID chat1.ConversationID, teamType chat1.TeamType, notifInfo *chat1.ConversationNotificationInfo) (err Error) {
 	locks.Inbox.Lock()
 	defer locks.Inbox.Unlock()
 	defer i.Trace(ctx, func() error { return err }, "TeamTypeChanged")()
@@ -972,6 +972,7 @@ func (i *Inbox) TeamTypeChanged(ctx context.Context, vers chat1.InboxVers,
 		i.Debug(ctx, "TeamTypeChanged: no conversation found: convID: %s, clearing", convID)
 		return i.Clear(ctx)
 	}
+	conv.Conv.Notifications = notifInfo
 	conv.Conv.Metadata.TeamType = teamType
 	conv.Conv.Metadata.Version = vers.ToConvVers()
 


### PR DESCRIPTION
There was a bug where the inbox cache was not getting updated notifications when the team type of the #general channel would change.