### PR TITLE
Team test grabbag

### DIFF
--- a/go/client/cmd_login.go
+++ b/go/client/cmd_login.go
@@ -40,7 +40,7 @@ func NewCmdLogin(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command
 
 type CmdLogin struct {
 	libkb.Contextified
-	username   string
+	Username   string
 	clientType keybase1.ClientType
 	cancel     func()
 	done       chan struct{}
@@ -82,7 +82,7 @@ func (c *CmdLogin) Run() error {
 
 	err = client.Login(ctx,
 		keybase1.LoginArg{
-			UsernameOrEmail: c.username,
+			UsernameOrEmail: c.Username,
 			DeviceType:      libkb.DeviceTypeDesktop,
 			ClientType:      c.clientType,
 			SessionID:       c.SessionID,
@@ -115,8 +115,8 @@ func (c *CmdLogin) ParseArgv(ctx *cli.Context) error {
 	}
 
 	if nargs == 1 {
-		c.username = ctx.Args()[0]
-		if !libkb.CheckEmailOrUsername.F(c.username) {
+		c.Username = ctx.Args()[0]
+		if !libkb.CheckEmailOrUsername.F(c.Username) {
 			return errors.New("Invalid username or email address format. Please login again via `keybase login [username or email]`")
 		}
 	}

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -86,8 +86,9 @@ func (log *TestLogger) prefixCaller(extraDepth int, lvl logging.Level, fmts stri
 		failed = "[X] "
 	}
 
-	return fmt.Sprintf("\r%s %s%s:%d: [%.1s] %s", time.Now().Format("2006-01-02 15:04:05.00000"),
-		failed, elements[len(elements)-1], line, lvl, fmts)
+	fileLine := fmt.Sprintf("%s:%d", elements[len(elements)-1], line)
+	return fmt.Sprintf("\r%s %s%-23s: [%.1s] %s", time.Now().Format("2006-01-02 15:04:05.00000"),
+		failed, fileLine, lvl, fmts)
 }
 
 func (log *TestLogger) Debug(fmts string, arg ...interface{}) {

--- a/go/protocol/keybase1/user.go
+++ b/go/protocol/keybase1/user.go
@@ -352,6 +352,10 @@ type DeleteUserArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
 }
 
+type MeUserVersionArg struct {
+	SessionID int `codec:"sessionID" json:"sessionID"`
+}
+
 type UserInterface interface {
 	ListTrackers(context.Context, ListTrackersArg) ([]Tracker, error)
 	ListTrackersByName(context.Context, ListTrackersByNameArg) ([]Tracker, error)
@@ -387,6 +391,7 @@ type UserInterface interface {
 	InterestingPeople(context.Context, int) ([]InterestingPerson, error)
 	ResetUser(context.Context, int) error
 	DeleteUser(context.Context, int) error
+	MeUserVersion(context.Context, int) (UserVersion, error)
 }
 
 func UserProtocol(i UserInterface) rpc.Protocol {
@@ -697,6 +702,22 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"meUserVersion": {
+				MakeArg: func() interface{} {
+					ret := make([]MeUserVersionArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]MeUserVersionArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]MeUserVersionArg)(nil), args)
+						return
+					}
+					ret, err = i.MeUserVersion(ctx, (*typedArgs)[0].SessionID)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -818,5 +839,11 @@ func (c UserClient) ResetUser(ctx context.Context, sessionID int) (err error) {
 func (c UserClient) DeleteUser(ctx context.Context, sessionID int) (err error) {
 	__arg := DeleteUserArg{SessionID: sessionID}
 	err = c.Cli.Call(ctx, "keybase.1.user.deleteUser", []interface{}{__arg}, nil)
+	return
+}
+
+func (c UserClient) MeUserVersion(ctx context.Context, sessionID int) (res UserVersion, err error) {
+	__arg := MeUserVersionArg{SessionID: sessionID}
+	err = c.Cli.Call(ctx, "keybase.1.user.meUserVersion", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -43,6 +43,7 @@ func (h *TeamsHandler) assertLoggedIn(ctx context.Context) error {
 }
 
 func (h *TeamsHandler) TeamCreate(ctx context.Context, arg keybase1.TeamCreateArg) (res keybase1.TeamCreateResult, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	arg2 := keybase1.TeamCreateWithSettingsArg{
 		SessionID:            arg.SessionID,
 		Name:                 arg.Name,
@@ -55,6 +56,7 @@ func (h *TeamsHandler) TeamCreate(ctx context.Context, arg keybase1.TeamCreateAr
 }
 
 func (h *TeamsHandler) TeamCreateWithSettings(ctx context.Context, arg keybase1.TeamCreateWithSettingsArg) (res keybase1.TeamCreateResult, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamCreate(%s)", arg.Name), func() error { return err })()
 
 	if err := h.assertLoggedIn(ctx); err != nil {
@@ -92,11 +94,13 @@ func (h *TeamsHandler) TeamCreateWithSettings(ctx context.Context, arg keybase1.
 }
 
 func (h *TeamsHandler) TeamGet(ctx context.Context, arg keybase1.TeamGetArg) (res keybase1.TeamDetails, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamGet(%s)", arg.Name), func() error { return err })()
 	return teams.Details(ctx, h.G().ExternalG(), arg.Name, arg.ForceRepoll)
 }
 
 func (h *TeamsHandler) TeamImplicitAdmins(ctx context.Context, arg keybase1.TeamImplicitAdminsArg) (res []keybase1.TeamMemberDetails, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamImplicitAdmins(%s)", arg.TeamName), func() error { return err })()
 	teamName, err := keybase1.TeamNameFromString(arg.TeamName)
 	if err != nil {
@@ -110,6 +114,7 @@ func (h *TeamsHandler) TeamImplicitAdmins(ctx context.Context, arg keybase1.Team
 }
 
 func (h *TeamsHandler) TeamList(ctx context.Context, arg keybase1.TeamListArg) (res keybase1.AnnotatedTeamList, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamList(%s)", arg.UserAssertion), func() error { return err })()
 	x, err := teams.List(ctx, h.G().ExternalG(), arg)
 	if err != nil {
@@ -119,11 +124,13 @@ func (h *TeamsHandler) TeamList(ctx context.Context, arg keybase1.TeamListArg) (
 }
 
 func (h *TeamsHandler) TeamListSubteamsRecursive(ctx context.Context, arg keybase1.TeamListSubteamsRecursiveArg) (res []keybase1.TeamIDAndName, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamListSubteamsRecursive(%s)", arg.ParentTeamName), func() error { return err })()
 	return teams.ListSubteamsRecursive(ctx, h.G().ExternalG(), arg.ParentTeamName, arg.ForceRepoll)
 }
 
 func (h *TeamsHandler) TeamChangeMembership(ctx context.Context, arg keybase1.TeamChangeMembershipArg) error {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
 	}
@@ -131,6 +138,7 @@ func (h *TeamsHandler) TeamChangeMembership(ctx context.Context, arg keybase1.Te
 }
 
 func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMemberArg) (res keybase1.TeamAddMemberResult, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamAddMember(%s,%s)", arg.Name, arg.Username),
 		func() error { return err })()
 
@@ -162,6 +170,7 @@ func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMe
 }
 
 func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRemoveMemberArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRemoveMember(%s, u:%q, e:%q, i:%q)", arg.Name, arg.Username, arg.Email, arg.InviteID),
 		func() error { return err })()
 
@@ -195,6 +204,7 @@ func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRe
 }
 
 func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEditMemberArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamEditMember(%s,%s,%s)", arg.Name, arg.Username, arg.Role),
 		func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
@@ -204,6 +214,7 @@ func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEdit
 }
 
 func (h *TeamsHandler) TeamLeave(ctx context.Context, arg keybase1.TeamLeaveArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamLeave(%s)", arg.Name), func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
@@ -212,6 +223,7 @@ func (h *TeamsHandler) TeamLeave(ctx context.Context, arg keybase1.TeamLeaveArg)
 }
 
 func (h *TeamsHandler) TeamRename(ctx context.Context, arg keybase1.TeamRenameArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRename(%s)", arg.PrevName), func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
@@ -220,6 +232,7 @@ func (h *TeamsHandler) TeamRename(ctx context.Context, arg keybase1.TeamRenameAr
 }
 
 func (h *TeamsHandler) TeamAcceptInvite(ctx context.Context, arg keybase1.TeamAcceptInviteArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, "TeamAcceptInvite", func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
@@ -232,6 +245,7 @@ func (h *TeamsHandler) TeamAcceptInvite(ctx context.Context, arg keybase1.TeamAc
 }
 
 func (h *TeamsHandler) TeamRequestAccess(ctx context.Context, arg keybase1.TeamRequestAccessArg) (res keybase1.TeamRequestAccessResult, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	h.G().CTraceTimed(ctx, "TeamRequestAccess", func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return keybase1.TeamRequestAccessResult{}, err
@@ -240,6 +254,7 @@ func (h *TeamsHandler) TeamRequestAccess(ctx context.Context, arg keybase1.TeamR
 }
 
 func (h *TeamsHandler) TeamAcceptInviteOrRequestAccess(ctx context.Context, arg keybase1.TeamAcceptInviteOrRequestAccessArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, "TeamAcceptInviteOrRequestAccess", func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
@@ -248,6 +263,7 @@ func (h *TeamsHandler) TeamAcceptInviteOrRequestAccess(ctx context.Context, arg 
 }
 
 func (h *TeamsHandler) TeamListRequests(ctx context.Context, sessionID int) (res []keybase1.TeamJoinRequest, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, "TeamListRequests", func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return nil, err
@@ -256,6 +272,7 @@ func (h *TeamsHandler) TeamListRequests(ctx context.Context, sessionID int) (res
 }
 
 func (h *TeamsHandler) TeamIgnoreRequest(ctx context.Context, arg keybase1.TeamIgnoreRequestArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, "TeamIgnoreRequest", func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
@@ -264,11 +281,13 @@ func (h *TeamsHandler) TeamIgnoreRequest(ctx context.Context, arg keybase1.TeamI
 }
 
 func (h *TeamsHandler) TeamTree(ctx context.Context, arg keybase1.TeamTreeArg) (res keybase1.TeamTreeResult, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, "TeamTree", func() error { return err })()
 	return teams.TeamTree(ctx, h.G().ExternalG(), arg)
 }
 
 func (h *TeamsHandler) TeamDelete(ctx context.Context, arg keybase1.TeamDeleteArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamDelete(%s)", arg.Name), func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
@@ -278,6 +297,7 @@ func (h *TeamsHandler) TeamDelete(ctx context.Context, arg keybase1.TeamDeleteAr
 }
 
 func (h *TeamsHandler) TeamSetSettings(ctx context.Context, arg keybase1.TeamSetSettingsArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamSetSettings(%s)", arg.Name), func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
@@ -286,12 +306,14 @@ func (h *TeamsHandler) TeamSetSettings(ctx context.Context, arg keybase1.TeamSet
 }
 
 func (h *TeamsHandler) LoadTeamPlusApplicationKeys(ctx context.Context, arg keybase1.LoadTeamPlusApplicationKeysArg) (res keybase1.TeamPlusApplicationKeys, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	ctx = libkb.WithLogTag(ctx, "LTPAK")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LoadTeamPlusApplicationKeys(%s)", arg.Id), func() error { return err })()
 	return teams.LoadTeamPlusApplicationKeys(ctx, h.G().ExternalG(), arg.Id, arg.Application, arg.Refreshers)
 }
 
 func (h *TeamsHandler) TeamCreateSeitanToken(ctx context.Context, arg keybase1.TeamCreateSeitanTokenArg) (token keybase1.SeitanIKey, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return "", err
 	}
@@ -299,10 +321,12 @@ func (h *TeamsHandler) TeamCreateSeitanToken(ctx context.Context, arg keybase1.T
 }
 
 func (h *TeamsHandler) GetTeamRootID(ctx context.Context, id keybase1.TeamID) (keybase1.TeamID, error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	return teams.GetRootID(ctx, h.G().ExternalG(), id)
 }
 
 func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.LookupImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupImplicitTeam(%s)", arg.Name), func() error { return err })()
 	res.TeamID, res.Name, res.DisplayName, err = teams.LookupImplicitTeam(ctx, h.G().ExternalG(), arg.Name,
 		arg.Public)
@@ -310,6 +334,7 @@ func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.Look
 }
 
 func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keybase1.LookupOrCreateImplicitTeamArg) (res keybase1.LookupImplicitTeamRes, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%s)", arg.Name),
 		func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
@@ -321,6 +346,7 @@ func (h *TeamsHandler) LookupOrCreateImplicitTeam(ctx context.Context, arg keyba
 }
 
 func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybase1.TeamReAddMemberAfterResetArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamReAddMemberAfterReset(%s)", arg.Id), func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
@@ -329,24 +355,28 @@ func (h *TeamsHandler) TeamReAddMemberAfterReset(ctx context.Context, arg keybas
 }
 
 func (h *TeamsHandler) TeamAddEmailsBulk(ctx context.Context, arg keybase1.TeamAddEmailsBulkArg) (res keybase1.BulkRes, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamAddEmailsBulk(%s)", arg.Name), func() error { return err })()
 
 	return teams.AddEmailsBulk(ctx, h.G().ExternalG(), arg.Name, arg.Emails, arg.Role)
 }
 
 func (h *TeamsHandler) GetTeamShowcase(ctx context.Context, teamname string) (ret keybase1.TeamShowcase, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("GetTeamShowcase(%s)", teamname), func() error { return err })()
 
 	return teams.GetTeamShowcase(ctx, h.G().ExternalG(), teamname)
 }
 
 func (h *TeamsHandler) GetTeamAndMemberShowcase(ctx context.Context, teamname string) (ret keybase1.TeamAndMemberShowcase, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("GetTeamAndMemberShowcase(%s)", teamname), func() error { return err })()
 
 	return teams.GetTeamAndMemberShowcase(ctx, h.G().ExternalG(), teamname)
 }
 
 func (h *TeamsHandler) SetTeamShowcase(ctx context.Context, arg keybase1.SetTeamShowcaseArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("SetTeamShowcase(%s)", arg.Name), func() error { return err })()
 
 	err = teams.SetTeamShowcase(ctx, h.G().ExternalG(), arg.Name, arg.IsShowcased, arg.Description, arg.AnyMemberShowcase)
@@ -354,6 +384,7 @@ func (h *TeamsHandler) SetTeamShowcase(ctx context.Context, arg keybase1.SetTeam
 }
 
 func (h *TeamsHandler) SetTeamMemberShowcase(ctx context.Context, arg keybase1.SetTeamMemberShowcaseArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("SetTeamMemberShowcase(%s)", arg.Name), func() error { return err })()
 
 	err = teams.SetTeamMemberShowcase(ctx, h.G().ExternalG(), arg.Name, arg.IsShowcased)

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -322,3 +322,19 @@ func (h *UserHandler) InterestingPeople(ctx context.Context, maxUsers int) (res 
 	}
 	return res, nil
 }
+
+func (h *UserHandler) MeUserVersion(ctx context.Context, sessionID int) (res keybase1.UserVersion, err error) {
+	loadMeArg := libkb.NewLoadUserArg(h.G()).
+		WithNetContext(ctx).
+		WithUID(h.G().Env.GetUID()).
+		WithSelf(true).
+		WithPublicKeyOptional()
+	upak, _, err := h.G().GetUPAKLoader().LoadV2(loadMeArg)
+	if err != nil {
+		return keybase1.UserVersion{}, err
+	}
+	if upak == nil {
+		return keybase1.UserVersion{}, fmt.Errorf("could not load self upak")
+	}
+	return upak.Current.ToUserVersion(), nil
+}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -344,10 +344,12 @@ func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username s
 		}
 		existingUV, err := t.UserVersionByUID(ctx, uv.Uid)
 		if err == nil {
+			g.Log.CDebugf(ctx, "found existing UV %v", existingUV.PercentForm())
 			// Case where same UV (uid+seqno) already exists is covered by
 			// `t.IsMember` check above. This only checks if there is a reset
 			// member in the team to automatically remove them (so AddMember
 			// can function as a Re-Add).
+			// Case where uv.EldetsSeqno=0 is covered by errInviteRequired above.
 			if existingUV.EldestSeqno > uv.EldestSeqno {
 				return fmt.Errorf("newer version of user %q already exists in team %q (%v > %v)", resolvedUsername, teamname, existingUV.EldestSeqno, uv.EldestSeqno)
 			}

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -146,4 +146,6 @@ protocol user {
   // deleteUser deletes the user. Only works in Dev mode since it's so dangerous
   void deleteUser(int sessionID);
 
+  UserVersion meUserVersion(int sessionID);
+
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1808,6 +1808,10 @@ export const userLoadUserRpcChannelMap = (configKeys: Array<string>, request: Re
 
 export const userLoadUserRpcPromise = (request: (RequestCommon & {callback?: ?(err: ?any, response: UserLoadUserResult) => void} & {param: UserLoadUserRpcParam})): Promise<UserLoadUserResult> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.user.loadUser', request, (error, result) => error ? reject(error) : resolve(result)))
 
+export const userMeUserVersionRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: UserMeUserVersionResult) => void}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.meUserVersion', request)
+
+export const userMeUserVersionRpcPromise = (request: ?(RequestCommon & {callback?: ?(err: ?any, response: UserMeUserVersionResult) => void})): Promise<UserMeUserVersionResult> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.user.meUserVersion', request, (error, result) => error ? reject(error) : resolve(result)))
+
 export const userProfileEditRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: UserProfileEditRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.profileEdit', request)
 
 export const userProfileEditRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: UserProfileEditRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.user.profileEdit', request, (error, result) => error ? reject(error) : resolve(result)))
@@ -4078,6 +4082,7 @@ type UserLoadUncheckedUserSummariesResult = ?Array<UserSummary>
 type UserLoadUserByNameResult = User
 type UserLoadUserPlusKeysResult = UserPlusKeys
 type UserLoadUserResult = User
+type UserMeUserVersionResult = UserVersion
 type UserSearchResult = ?Array<SearchResult>
 
 export type IncomingCallMapType = {|  'keybase.1.gpgUi.wantToAddGPGKey'?: (params: {|      sessionID: Int    |},response: {error: RPCErrorHandler, result: (result: GpgUiWantToAddGPGKeyResult) => void}) => void,  'keybase.1.gpgUi.confirmDuplicateKeyChosen'?: (params: {|      sessionID: Int    |},response: {error: RPCErrorHandler, result: (result: GpgUiConfirmDuplicateKeyChosenResult) => void}) => void,  'keybase.1.gpgUi.selectKeyAndPushOption'?: (params: {|      sessionID: Int,

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -558,6 +558,15 @@
         }
       ],
       "response": null
+    },
+    "meUserVersion": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": "UserVersion"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1808,6 +1808,10 @@ export const userLoadUserRpcChannelMap = (configKeys: Array<string>, request: Re
 
 export const userLoadUserRpcPromise = (request: (RequestCommon & {callback?: ?(err: ?any, response: UserLoadUserResult) => void} & {param: UserLoadUserRpcParam})): Promise<UserLoadUserResult> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.user.loadUser', request, (error, result) => error ? reject(error) : resolve(result)))
 
+export const userMeUserVersionRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & {callback?: ?(err: ?any, response: UserMeUserVersionResult) => void}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.meUserVersion', request)
+
+export const userMeUserVersionRpcPromise = (request: ?(RequestCommon & {callback?: ?(err: ?any, response: UserMeUserVersionResult) => void})): Promise<UserMeUserVersionResult> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.user.meUserVersion', request, (error, result) => error ? reject(error) : resolve(result)))
+
 export const userProfileEditRpcChannelMap = (configKeys: Array<string>, request: RequestCommon & RequestErrorCallback & {param: UserProfileEditRpcParam}): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.profileEdit', request)
 
 export const userProfileEditRpcPromise = (request: (RequestCommon & RequestErrorCallback & {param: UserProfileEditRpcParam})): Promise<void> => new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.user.profileEdit', request, (error, result) => error ? reject(error) : resolve(result)))
@@ -4078,6 +4082,7 @@ type UserLoadUncheckedUserSummariesResult = ?Array<UserSummary>
 type UserLoadUserByNameResult = User
 type UserLoadUserPlusKeysResult = UserPlusKeys
 type UserLoadUserResult = User
+type UserMeUserVersionResult = UserVersion
 type UserSearchResult = ?Array<SearchResult>
 
 export type IncomingCallMapType = {|  'keybase.1.gpgUi.wantToAddGPGKey'?: (params: {|      sessionID: Int    |},response: {error: RPCErrorHandler, result: (result: GpgUiWantToAddGPGKeyResult) => void}) => void,  'keybase.1.gpgUi.confirmDuplicateKeyChosen'?: (params: {|      sessionID: Int    |},response: {error: RPCErrorHandler, result: (result: GpgUiConfirmDuplicateKeyChosenResult) => void}) => void,  'keybase.1.gpgUi.selectKeyAndPushOption'?: (params: {|      sessionID: Int,


### PR DESCRIPTION
A smattering of stuff that will be nice for team tests.
- Add support for `reset` and `loginAfterReset{NoPUK}` to teamtester
- Add support for setting team settings to teamtester
- Code dedup in smu
- Align test log output
- Add `MeUserVersion` rpc for getting current UV from service
- Add `TM` log tags

This was stuff I did while writing `TestTeamOpenRequestForPukless`. But that test is not finished, so not included here. It needs to wait for your current PR. It is described below, but again, not included in this PR
```
// Add users to a team by open team request who have
// - no sigchain
// - no puk
// - reset and no sigchain and were previously on the team
// - reset and no puk and were previously on the team
// - no sigchain and previously invited
func TestTeamOpenRequestForPukless(t *testing.T) {
```