### PR TITLE
just bail out of the app if we cant read local files on mobile

### DIFF
--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -62,6 +62,11 @@ func (f *JSONFile) Load(warnOnNotFound bool) error {
 		}
 
 		if os.IsPermission(err) {
+			// Let's just panic and die here on mobile, there is no reason to continue, since the user
+			// will either need to enter a password or force kill the app anyway
+			if f.G().GetAppType() == MobileAppType {
+				panic("permission denied on mobile app reading config file, thats it!")
+			}
 			f.G().Log.Warning("Permission denied opening %s file %s", f.which, f.filename)
 			return nil
 		}


### PR DESCRIPTION
If we are on mobile and get permission denied reading key files like config.json, then just bail out of the app. Something weird is happening, and it will result in the user being showed the login screen. They will be forced to either re-login, or force kill the app, so us doing it for them is fine.

Also, I believe this only happens when the app starts fresh in the background, so the user won't see it die anyway.