### PR TITLE
Preview channels from manage channels screen

### DIFF
--- a/shared/actions/chat-gen.js
+++ b/shared/actions/chat-gen.js
@@ -57,6 +57,7 @@ export const outboxMessageBecameReal = 'chat:outboxMessageBecameReal'
 export const pendingToRealConversation = 'chat:pendingToRealConversation'
 export const postMessage = 'chat:postMessage'
 export const prependMessages = 'chat:prependMessages'
+export const previewChannel = 'chat:previewChannel'
 export const removeOutboxMessage = 'chat:removeOutboxMessage'
 export const removeTempPendingConversations = 'chat:removeTempPendingConversations'
 export const replaceEntity = 'chat:replaceEntity'
@@ -143,6 +144,7 @@ export const createOutboxMessageBecameReal = (payload: {|oldMessageKey: Constant
 export const createPendingToRealConversation = (payload: {|oldKey: Constants.ConversationIDKey, newKey: Constants.ConversationIDKey|}) => ({error: false, payload, type: pendingToRealConversation})
 export const createPostMessage = (payload: {|conversationIDKey: Constants.ConversationIDKey, text: HiddenString|}) => ({error: false, payload, type: postMessage})
 export const createPrependMessages = (payload: {|conversationIDKey: Constants.ConversationIDKey, messages: Array<Constants.ServerMessage>, moreToLoad: boolean|}) => ({error: false, payload, type: prependMessages})
+export const createPreviewChannel = (payload: {|conversationIDKey: Constants.ConversationIDKey|}) => ({error: false, payload, type: previewChannel})
 export const createRemoveOutboxMessage = (payload: {|conversationIDKey: Constants.ConversationIDKey, outboxID: Constants.OutboxIDKey|}) => ({error: false, payload, type: removeOutboxMessage})
 export const createRemoveTempPendingConversations = () => ({error: false, payload: undefined, type: removeTempPendingConversations})
 export const createReplaceEntity = (payload: {|keyPath: Array<string>, entities: I.Map<any, any> | I.List<any>|}) => ({error: false, payload, type: replaceEntity})
@@ -229,6 +231,7 @@ export type OutboxMessageBecameRealPayload = ReturnType<typeof createOutboxMessa
 export type PendingToRealConversationPayload = ReturnType<typeof createPendingToRealConversation>
 export type PostMessagePayload = ReturnType<typeof createPostMessage>
 export type PrependMessagesPayload = ReturnType<typeof createPrependMessages>
+export type PreviewChannelPayload = ReturnType<typeof createPreviewChannel>
 export type RemoveOutboxMessagePayload = ReturnType<typeof createRemoveOutboxMessage>
 export type RemoveTempPendingConversationsPayload = ReturnType<typeof createRemoveTempPendingConversations>
 export type ReplaceEntityPayload = ReturnType<typeof createReplaceEntity>
@@ -317,6 +320,7 @@ export type Actions =
   | ReturnType<typeof createPendingToRealConversation>
   | ReturnType<typeof createPostMessage>
   | ReturnType<typeof createPrependMessages>
+  | ReturnType<typeof createPreviewChannel>
   | ReturnType<typeof createRemoveOutboxMessage>
   | ReturnType<typeof createRemoveTempPendingConversations>
   | ReturnType<typeof createReplaceEntity>

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -896,6 +896,11 @@ function _joinConversation(action: ChatGen.JoinConversationPayload) {
   return Saga.call(RPCChatTypes.localJoinConversationByIDLocalRpcPromise, {param: {convID}})
 }
 
+function _previewChannel(action: ChatGen.PreviewChannelPayload) {
+  const convID = Constants.keyToConversationID(action.payload.conversationIDKey)
+  return Saga.call(RPCChatTypes.localPreviewConversationByIDLocalRpcPromise, {param: {convID}})
+}
+
 function* registerSagas(): SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPure(ChatGen.updateSnippet, _updateSnippet)
   yield Saga.safeTakeEvery(ChatGen.getInboxAndUnbox, onGetInboxAndUnbox)
@@ -910,6 +915,7 @@ function* registerSagas(): SagaGenerator<any, any> {
   yield Saga.safeTakeLatest(ChatGen.badgeAppForChat, _badgeAppForChat)
   yield Saga.safeTakeEvery(ChatGen.incomingMessage, _incomingMessage)
   yield Saga.safeTakeEveryPure(ChatGen.joinConversation, _joinConversation)
+  yield Saga.safeTakeEveryPure(ChatGen.previewChannel, _previewChannel)
 }
 
 export {registerSagas}

--- a/shared/actions/json/chat.json
+++ b/shared/actions/json/chat.json
@@ -302,6 +302,9 @@
     },
     "shareAttachment": {
       "messageKey": "Constants.MessageKey"
+    },
+    "previewChannel": {
+      "conversationIDKey": "Constants.ConversationIDKey"
     }
   }
 }

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -3,6 +3,7 @@ import * as Constants from '../../constants/chat'
 import * as SearchConstants from '../../constants/search'
 import * as Creators from '../../actions/chat/creators'
 import * as ChatGen from '../../actions/chat-gen'
+import {type List} from 'immutable'
 import HiddenString from '../../util/hidden-string'
 import Conversation from './index'
 import NoConversation from './no-conversation'
@@ -36,7 +37,7 @@ type StateProps = {|
   showTeamOffer: boolean,
   inboxFilter: ?string,
   showSearchResults: boolean,
-  previousPath: ?(string[]),
+  previousPath: ?List<string>,
 |}
 
 type DispatchProps = {|

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -36,7 +36,7 @@ type StateProps = {|
   showTeamOffer: boolean,
   inboxFilter: ?string,
   showSearchResults: boolean,
-  previousPath: ?(*[]),
+  previousPath: ?(string[]),
 |}
 
 type DispatchProps = {|

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -36,7 +36,7 @@ type StateProps = {|
   showTeamOffer: boolean,
   inboxFilter: ?string,
   showSearchResults: boolean,
-  fromManageChannels: boolean,
+  previousPath: ?(*[]),
 |}
 
 type DispatchProps = {|
@@ -109,7 +109,7 @@ const mapStateToProps = (state: TypedState, {routePath, routeProps}): StateProps
     inSearch,
     defaultChatText,
     showTeamOffer,
-    fromManageChannels: routeProps.get('fromManageChannels'),
+    previousPath: routeProps.get('previousPath'),
   }
 }
 

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -36,6 +36,7 @@ type StateProps = {|
   showTeamOffer: boolean,
   inboxFilter: ?string,
   showSearchResults: boolean,
+  fromManageChannels: boolean,
 |}
 
 type DispatchProps = {|
@@ -50,7 +51,7 @@ type DispatchProps = {|
   onShowTrackerInSearch: (id: string) => void,
 |}
 
-const mapStateToProps = (state: TypedState, {routePath}): StateProps => {
+const mapStateToProps = (state: TypedState, {routePath, routeProps}): StateProps => {
   const selectedConversationIDKey = Constants.getSelectedConversation(state)
   const routeState = Constants.getSelectedRouteState(state)
 
@@ -108,6 +109,7 @@ const mapStateToProps = (state: TypedState, {routePath}): StateProps => {
     inSearch,
     defaultChatText,
     showTeamOffer,
+    fromManageChannels: routeProps.get('fromManageChannels'),
   }
 }
 

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -150,6 +150,7 @@ class Conversation extends Component<Props, State> {
                         focusInputCounter={this.props.focusInputCounter}
                         onEditLastMessage={this.props.onEditLastMessage}
                         onScrollDown={this.props.onScrollDown}
+                        fromManageChannels={this.props.fromManageChannels}
                       />}
                   {this.state.infoPanelOpen &&
                     <div

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -150,7 +150,7 @@ class Conversation extends Component<Props, State> {
                         focusInputCounter={this.props.focusInputCounter}
                         onEditLastMessage={this.props.onEditLastMessage}
                         onScrollDown={this.props.onScrollDown}
-                        fromManageChannels={this.props.fromManageChannels}
+                        previousPath={this.props.previousPath}
                       />}
                   {this.state.infoPanelOpen &&
                     <div

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -1,7 +1,7 @@
 // @flow
 import {Component} from 'react'
 import * as Constants from '../../constants/chat'
-import {type List} from 'immutable'
+import {type PropsPath} from '../../route-tree'
 
 export type Props = {|
   editLastMessageCounter: number,
@@ -26,7 +26,7 @@ export type Props = {|
   chatText: string,
   setChatText: (nextText: string) => void,
   showTeamOffer: boolean,
-  previousPath: ?List<string>,
+  previousPath: ?PropsPath<*>,
 |}
 
 export default class Conversation extends Component<Props> {}

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -1,6 +1,7 @@
 // @flow
 import {Component} from 'react'
 import * as Constants from '../../constants/chat'
+import {type List} from 'immutable'
 
 export type Props = {|
   editLastMessageCounter: number,
@@ -25,7 +26,7 @@ export type Props = {|
   chatText: string,
   setChatText: (nextText: string) => void,
   showTeamOffer: boolean,
-  previousPath: ?(string[]),
+  previousPath: ?List<string>,
 |}
 
 export default class Conversation extends Component<Props> {}

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -25,7 +25,7 @@ export type Props = {|
   chatText: string,
   setChatText: (nextText: string) => void,
   showTeamOffer: boolean,
-  fromManageChannels: ?boolean,
+  previousPath: ?(string[]),
 |}
 
 export default class Conversation extends Component<Props> {}

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -1,7 +1,6 @@
 // @flow
 import {Component} from 'react'
 import * as Constants from '../../constants/chat'
-import * as SearchConstants from '../../constants/search'
 
 export type Props = {|
   editLastMessageCounter: number,
@@ -26,6 +25,7 @@ export type Props = {|
   chatText: string,
   setChatText: (nextText: string) => void,
   showTeamOffer: boolean,
+  fromManageChannels: ?boolean,
 |}
 
 export default class Conversation extends Component<Props> {}

--- a/shared/chat/conversation/index.native.js
+++ b/shared/chat/conversation/index.native.js
@@ -68,7 +68,7 @@ const Conversation = (props: Props) => (
                 focusInputCounter={props.focusInputCounter}
                 onEditLastMessage={props.onEditLastMessage}
                 onScrollDown={props.onScrollDown}
-                fromManageChannels={props.fromManageChannels}
+                previousPath={props.previousPath}
               />}
         </Box>}
   </Box>

--- a/shared/chat/conversation/index.native.js
+++ b/shared/chat/conversation/index.native.js
@@ -68,6 +68,7 @@ const Conversation = (props: Props) => (
                 focusInputCounter={props.focusInputCounter}
                 onEditLastMessage={props.onEditLastMessage}
                 onScrollDown={props.onScrollDown}
+                fromManageChannels={props.fromManageChannels}
               />}
         </Box>}
   </Box>

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -172,6 +172,11 @@ const _BigTeamInfoPanel = (props: BigTeamInfoPanelProps) => (
       <Button type="Danger" small={true} label="Leave channel" onClick={props.onLeaveConversation} />
     </Box>
 
+    {props.isPreview &&
+      <Text type="BodySmall" style={{textAlign: 'center', marginTop: globalMargins.xtiny}}>
+        Anyone in {props.teamname} can join.
+      </Text>}
+
     <Divider style={styleDivider} />
 
     <Text style={{paddingLeft: globalMargins.small}} type="BodySmallSemibold">

--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -16,7 +16,7 @@ import {
   connect,
   type TypedState,
 } from '../../../util/container'
-import {navigateAppend, navigateUp} from '../../../actions/route-tree'
+import {navigateAppend, navigateUp, navigateTo} from '../../../actions/route-tree'
 import throttle from 'lodash/throttle'
 import {createSelector} from 'reselect'
 import {type OwnProps} from './container'
@@ -107,8 +107,8 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
   onLeaveChannel: (selectedConversation: Constants.ConversationIDKey, teamname: string) => {
     dispatch(ChatGen.createLeaveConversation({conversationIDKey: selectedConversation}))
     dispatch(navigateUp())
-    if (ownProps.fromManageChannels) {
-      dispatch(navigateAppend([{props: {teamname}, selected: 'manageChannels'}]))
+    if (ownProps.previousPath) {
+      dispatch(navigateTo(ownProps.previousPath))
     }
   },
 })

--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -16,7 +16,7 @@ import {
   connect,
   type TypedState,
 } from '../../../util/container'
-import {navigateAppend} from '../../../actions/route-tree'
+import {navigateAppend, navigateUp} from '../../../actions/route-tree'
 import throttle from 'lodash/throttle'
 import {createSelector} from 'reselect'
 import {type OwnProps} from './container'
@@ -67,6 +67,7 @@ const stateDependentProps = createSelector(
       defaultText: (routeState && routeState.get('inputText', new HiddenString('')).stringValue()) || '',
       selectedConversationIDKey,
       typing,
+      teamname: inbox && inbox.teamname,
     }
   }
 )
@@ -76,7 +77,7 @@ const mapStateToProps = createSelector([stateDependentProps, ownPropsSelector], 
   ...ownProps,
 }))
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
+const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
   onAttach: (selectedConversation, inputs: Array<Constants.AttachmentInput>) => {
     dispatch(
       navigateAppend([
@@ -103,9 +104,14 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onJoinChannel: (selectedConversation: Constants.ConversationIDKey) => {
     dispatch(ChatGen.createJoinConversation({conversationIDKey: selectedConversation}))
   },
-  onLeaveChannel: (selectedConversation: Constants.ConversationIDKey) => {
+  onLeaveChannel: (selectedConversation: Constants.ConversationIDKey, teamname: string) => {
     dispatch(ChatGen.createLeaveConversation({conversationIDKey: selectedConversation}))
-    dispatch(ChatGen.createSelectConversation({conversationIDKey: null}))
+    if (ownProps.fromManageChannels) {
+      dispatch(navigateUp())
+      dispatch(navigateAppend([{props: {teamname}, selected: 'manageChannels'}]))
+    } else {
+      dispatch(navigateUp())
+    }
   },
 })
 
@@ -145,7 +151,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
       }
     },
     onJoinChannel: () => dispatchProps.onJoinChannel(stateProps.selectedConversationIDKey),
-    onLeaveChannel: () => dispatchProps.onLeaveChannel(stateProps.selectedConversationIDKey),
+    onLeaveChannel: () =>
+      dispatchProps.onLeaveChannel(stateProps.selectedConversationIDKey, stateProps.teamname),
   }
 }
 

--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -106,11 +106,9 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
   },
   onLeaveChannel: (selectedConversation: Constants.ConversationIDKey, teamname: string) => {
     dispatch(ChatGen.createLeaveConversation({conversationIDKey: selectedConversation}))
+    dispatch(navigateUp())
     if (ownProps.fromManageChannels) {
-      dispatch(navigateUp())
       dispatch(navigateAppend([{props: {teamname}, selected: 'manageChannels'}]))
-    } else {
-      dispatch(navigateUp())
     }
   },
 })

--- a/shared/chat/conversation/input/container.js.flow
+++ b/shared/chat/conversation/input/container.js.flow
@@ -1,12 +1,12 @@
 // @flow
 import {Component} from 'react'
-import {type List} from 'immutable'
+import {type PropsPath} from '../../../route-tree'
 
 export type OwnProps = {
   focusInputCounter: number,
   onEditLastMessage: () => void,
   onScrollDown: () => void,
-  previousPath: ?List<string>,
+  previousPath: ?PropsPath<*>,
 }
 
 export default class InputContainer extends Component<OwnProps> {}

--- a/shared/chat/conversation/input/container.js.flow
+++ b/shared/chat/conversation/input/container.js.flow
@@ -1,11 +1,12 @@
 // @flow
 import {Component} from 'react'
+import {type List} from 'immutable'
 
 export type OwnProps = {
   focusInputCounter: number,
   onEditLastMessage: () => void,
   onScrollDown: () => void,
-  previousPath: ?(*[]),
+  previousPath: ?List<string>,
 }
 
 export default class InputContainer extends Component<OwnProps> {}

--- a/shared/chat/conversation/input/container.js.flow
+++ b/shared/chat/conversation/input/container.js.flow
@@ -5,6 +5,7 @@ export type OwnProps = {
   focusInputCounter: number,
   onEditLastMessage: () => void,
   onScrollDown: () => void,
+  fromManageChannels: ?boolean,
 }
 
 export default class InputContainer extends Component<OwnProps> {}

--- a/shared/chat/conversation/input/container.js.flow
+++ b/shared/chat/conversation/input/container.js.flow
@@ -5,7 +5,7 @@ export type OwnProps = {
   focusInputCounter: number,
   onEditLastMessage: () => void,
   onScrollDown: () => void,
-  fromManageChannels: ?boolean,
+  previousPath: ?(*[]),
 }
 
 export default class InputContainer extends Component<OwnProps> {}

--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -44,7 +44,7 @@ const mapStateToProps = (state: TypedState, {routeProps, routeState}) => {
     channels,
     teamname: routeProps.get('teamname'),
     waitingForSave,
-    previousPath: previousPath && previousPath.toArray(),
+    previousPath,
   }
 }
 

--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -66,7 +66,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
     },
     onPreview: (conversationIDKey: string) => {
       dispatch(ChatGen.createPreviewChannel({conversationIDKey}))
-      dispatch(navigateTo([chatTab, conversationIDKey]))
+      dispatch(navigateTo([chatTab, {selected: conversationIDKey, props: {fromManageChannels: true}}]))
     },
   }
 }

--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -68,7 +68,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
       )
       dispatch(saveChannelMembership(teamname, channelsToChange))
     },
-    onPreview: (conversationIDKey: string, previousPath?: string[]) => {
+    _onPreview: (conversationIDKey: string, previousPath?: string[]) => {
       dispatch(ChatGen.createPreviewChannel({conversationIDKey}))
       dispatch(
         navigateTo([chatTab, {selected: conversationIDKey, props: {previousPath: previousPath || null}}])
@@ -94,8 +94,8 @@ export default compose(
       })),
     onSaveSubscriptions: props => () =>
       props._saveSubscriptions(props.oldChannelState, props.nextChannelState),
-    onPreview: ({previousPath, onPreview}) => (conversationIDKey: string) =>
-      onPreview(conversationIDKey, previousPath),
+    onPreview: ({previousPath, _onPreview}) => (conversationIDKey: string) =>
+      _onPreview(conversationIDKey, previousPath),
   }),
   lifecycle({
     componentWillReceiveProps: function(nextProps) {

--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -11,6 +11,7 @@ import {getChannels, saveChannelMembership} from '../../actions/teams/creators'
 import {navigateTo, navigateAppend, pathSelector} from '../../actions/route-tree'
 import {anyWaiting} from '../../constants/waiting'
 import {chatTab} from '../../constants/tabs'
+import '../../constants/route-tree'
 
 type ChannelMembershipState = {[channelname: string]: boolean}
 

--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -3,12 +3,14 @@ import pickBy from 'lodash/pickBy'
 import isEqual from 'lodash/isEqual'
 import * as I from 'immutable'
 import * as Constants from '../../constants/teams'
+import * as ChatGen from '../../actions/chat-gen'
 import ManageChannels from '.'
 import {withHandlers, withState, withPropsOnChange} from 'recompose'
 import {pausableConnect, compose, lifecycle, type TypedState} from '../../util/container'
 import {getChannels, saveChannelMembership} from '../../actions/teams/creators'
 import {navigateTo, navigateAppend} from '../../actions/route-tree'
 import {anyWaiting} from '../../constants/waiting'
+import {chatTab} from '../../constants/tabs'
 
 type ChannelMembershipState = {[channelname: string]: boolean}
 
@@ -61,6 +63,10 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
         (inChannel: boolean, channelname: string) => inChannel !== oldChannelState[channelname]
       )
       dispatch(saveChannelMembership(teamname, channelsToChange))
+    },
+    onPreview: (conversationIDKey: string) => {
+      dispatch(ChatGen.createPreviewChannel({conversationIDKey}))
+      dispatch(navigateTo([chatTab, conversationIDKey]))
     },
   }
 }

--- a/shared/chat/manage-channels/index.desktop.js
+++ b/shared/chat/manage-channels/index.desktop.js
@@ -20,7 +20,13 @@ const Edit = ({onClick, style}: {onClick: () => void, style: Object}) => (
 )
 
 const Row = (
-  props: RowProps & {selected: boolean, onToggle: () => void, showEdit: boolean, onEdit: () => void}
+  props: RowProps & {
+    selected: boolean,
+    onToggle: () => void,
+    showEdit: boolean,
+    onEdit: () => void,
+    onPreview: () => void,
+  }
 ) => (
   <Box
     className={'channel-row'}
@@ -41,7 +47,9 @@ const Row = (
           />
         </Box>
         <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.tiny, minHeight: 32}}>
-          <Text type="BodySemibold" style={{color: globalColors.blue}}>#{props.name}</Text>
+          <Text type="BodySemiboldLink" onClick={props.onPreview} style={{color: globalColors.blue}}>
+            #{props.name}
+          </Text>
           <Text type="BodySmall">{props.description}</Text>
         </Box>
         {props.showEdit &&
@@ -86,6 +94,7 @@ const ManageChannels = (props: Props) => (
             onToggle={() => props.onToggle(c.name)}
             showEdit={!props.unsavedSubscriptions}
             onEdit={() => props.onEdit(c.convID)}
+            onPreview={() => props.onPreview(c.convID)}
           />
         ))}
       </ScrollView>

--- a/shared/chat/manage-channels/index.js.flow
+++ b/shared/chat/manage-channels/index.js.flow
@@ -14,6 +14,7 @@ export type Props = {
   onToggle: (channel: string) => void,
   onEdit: (channel: string) => void,
   onClose: () => void,
+  onPreview: (conversationIDKey: string) => void,
   teamname: string,
   unsavedSubscriptions: boolean,
   onSaveSubscriptions: () => void,

--- a/shared/chat/manage-channels/index.native.js
+++ b/shared/chat/manage-channels/index.native.js
@@ -24,14 +24,25 @@ const Edit = ({onClick, style}: {onClick: () => void, style: Object}) => (
 )
 
 const Row = (
-  props: RowProps & {selected: boolean, onToggle: () => void, showEdit: boolean, onEdit: () => void}
+  props: RowProps & {
+    selected: boolean,
+    onToggle: () => void,
+    showEdit: boolean,
+    onEdit: () => void,
+    onPreview: () => void,
+  }
 ) => (
   <Box style={_rowBox}>
     <Checkbox style={{alignSelf: 'flex-end'}} checked={props.selected} label="" onCheck={props.onToggle} />
     <Box
       style={{...globalStyles.flexBoxColumn, flex: 1, position: 'relative', paddingLeft: globalMargins.tiny}}
     >
-      <Text type="BodySemibold" style={{color: globalColors.blue, maxWidth: '100%'}} lineClamp={1}>
+      <Text
+        type="BodySemiboldLink"
+        onClick={props.onPreview}
+        style={{color: globalColors.blue, maxWidth: '100%'}}
+        lineClamp={1}
+      >
         #{props.name}
       </Text>
       <Text type="BodySmall" lineClamp={1}>{props.description}</Text>
@@ -72,6 +83,7 @@ const ManageChannels = (props: Props) => (
           onToggle={() => props.onToggle(c.name)}
           showEdit={!props.unsavedSubscriptions}
           onEdit={() => props.onEdit(c.convID)}
+          onPreview={() => props.onPreview(c.convID)}
         />
       ))}
     </ScrollView>

--- a/shared/chat/manage-channels/index.stories.js
+++ b/shared/chat/manage-channels/index.stories.js
@@ -65,6 +65,7 @@ const load = () => {
           onCreate={action('onCreate')}
           unsavedSubscriptions={false}
           onSaveSubscriptions={action('onSaveSubscriptions')}
+          onPreview={action('onPreview')}
           waitingForSave={false}
           nextChannelState={channels.reduce((acc, c) => {
             acc[c.name] = c.selected
@@ -85,6 +86,7 @@ const load = () => {
           onCreate={action('onCreate')}
           unsavedSubscriptions={true}
           onSaveSubscriptions={action('onSaveSubscriptions')}
+          onPreview={action('onPreview')}
           waitingForSave={false}
           nextChannelState={channels.reduce((acc, c) => {
             acc[c.name] = c.selected


### PR DESCRIPTION
Intended behavior is that if a channel preview is triggered from an @-mention `No, thanks` navigates to the last viewed chat. If it's triggered from the manage channels dialog, `No,thanks` navigates back to the dialog.

r? @keybase/react-hackers 