### PR TITLE
More gen 23: Explicit reducer cases

### DIFF
--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -13,9 +13,10 @@ import {
   withHandlers,
   createSelector,
   createImmutableEqualSelector,
+  type TypedState,
+  type Dispatch,
 } from '../../util/container'
 import {scoreFilter, passesStringFilter} from './filtering'
-import type {TypedState} from '../../constants/reducer'
 
 const smallTeamsCollapsedMaxShown = 5
 const getAlwaysShow = (state: TypedState) => state.chat.get('inboxAlwaysShow')
@@ -224,7 +225,7 @@ const mapStateToProps = (state: TypedState, {isActiveRoute, routeState}: OwnProp
   }
 }
 
-const mapDispatchToProps = (dispatch: any => void, {focusFilter, routeState, setRouteState}: OwnProps) => ({
+const mapDispatchToProps = (dispatch: Dispatch, {focusFilter, routeState, setRouteState}: OwnProps) => ({
   loadInbox: () => dispatch(ChatGen.createLoadInbox()),
   _onSelectNext: (rows: Array<Inbox.RowItemSmall | Inbox.RowItemBig>, direction: -1 | 1) =>
     dispatch(

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -214,7 +214,7 @@ function reducer(state: Types.State = initialState, action: ChatGen.Actions) {
       } else {
         console.warn("couldn't find pending to upgrade", oldKey)
       }
-      break
+      return state
     }
     case ChatGen.updateFinalizedState: {
       const fs = action.payload.finalizedState
@@ -251,7 +251,7 @@ function reducer(state: Types.State = initialState, action: ChatGen.Actions) {
           .map(conversation => conversation.set('loadedOffline', false))
         return state.set('conversationStates', newConversationStates)
       }
-      break
+      return state
     }
     case ChatGen.setInboxGlobalUntrustedState: {
       return state.set('inboxGlobalUntrustedState', action.payload.inboxGlobalUntrustedState)
@@ -281,9 +281,67 @@ function reducer(state: Types.State = initialState, action: ChatGen.Actions) {
       const {payload: {teamJoinSuccess}} = action
       return state.set('teamJoinSuccess', teamJoinSuccess)
     }
-  }
+    // Saga only actions
+    case ChatGen.updateBadging:
+    case ChatGen.attachmentLoaded:
+    case ChatGen.attachmentSaveFailed:
+    case ChatGen.attachmentSaveStart:
+    case ChatGen.attachmentSaved:
+    case ChatGen.badgeAppForChat:
+    case ChatGen.blockConversation:
+    case ChatGen.deleteMessage:
+    case ChatGen.downloadProgress:
+    case ChatGen.editMessage:
+    case ChatGen.getInboxAndUnbox:
+    case ChatGen.inboxStale:
+    case ChatGen.inboxStoreLoaded:
+    case ChatGen.incomingMessage:
+    case ChatGen.incomingTyping:
+    case ChatGen.joinConversation:
+    case ChatGen.leaveConversation:
+    case ChatGen.loadAttachment:
+    case ChatGen.loadAttachmentPreview:
+    case ChatGen.loadInbox:
+    case ChatGen.loadMoreMessages:
+    case ChatGen.markSeenMessage:
+    case ChatGen.muteConversation:
+    case ChatGen.openAttachmentPopup:
+    case ChatGen.openConversation:
+    case ChatGen.openFolder:
+    case ChatGen.openTeamConversation:
+    case ChatGen.openTlfInChat:
+    case ChatGen.outboxMessageBecameReal:
+    case ChatGen.postMessage:
+    case ChatGen.removeOutboxMessage:
+    case ChatGen.retryAttachment:
+    case ChatGen.retryMessage:
+    case ChatGen.saveAttachment:
+    case ChatGen.saveAttachmentNative:
+    case ChatGen.selectAttachment:
+    case ChatGen.selectConversation:
+    case ChatGen.selectNext:
+    case ChatGen.setNotifications:
+    case ChatGen.setupChatHandlers:
+    case ChatGen.shareAttachment:
+    case ChatGen.startConversation:
+    case ChatGen.toggleChannelWideNotifications:
+    case ChatGen.unboxConversations:
+    case ChatGen.unboxMore:
+    case ChatGen.updateInboxComplete:
+    case ChatGen.updateMetadata:
+    case ChatGen.updateSnippet:
+    case ChatGen.updateTempMessage:
+    case ChatGen.updateThread:
+    case ChatGen.updateTyping:
+    case ChatGen.updatedNotifications:
+    case ChatGen.uploadProgress:
+      return state
 
-  return state
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
+  }
 }
 
 export default reducer

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -143,7 +143,16 @@ export default function(
         ...state,
         userActive,
       }
+    // Saga only actions
+    case ConfigGen.bootstrap:
+    case ConfigGen.clearRouteState:
+    case ConfigGen.getExtendedStatus:
+    case ConfigGen.persistRouteState:
+    case ConfigGen.retryBootstrap:
+      return state
     default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
       return state
   }
 }

--- a/shared/reducers/dev.js
+++ b/shared/reducers/dev.js
@@ -24,7 +24,9 @@ export default function(state: Types.State = Constants.initialState, action: Dev
         ...state,
         debugCount: state.debugCount + 1,
       }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-
-  return state
 }

--- a/shared/reducers/devices.js
+++ b/shared/reducers/devices.js
@@ -16,7 +16,15 @@ export default function(state: Types.State = initialState, action: DevicesGen.Ac
     case DevicesGen.loaded:
       const {deviceIDs} = action.payload
       return state.set('deviceIDs', I.List(deviceIDs))
+    // Saga only actions
+    case DevicesGen.load:
+    case DevicesGen.paperKeyMake:
+    case DevicesGen.revoke:
+    case DevicesGen.showRevokePage:
+      return state
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-
-  return state
 }

--- a/shared/reducers/engine.js
+++ b/shared/reducers/engine.js
@@ -14,7 +14,12 @@ export default function(state: Types.State = initialState, action: EngineGen.Act
       return state.update('rpcWaitingStates', waitingStates =>
         waitingStates.set(payload.name, payload.waiting)
       )
+    // Saga only actions
+    case EngineGen.errorInRpc:
+      return state
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-
-  return state
 }

--- a/shared/reducers/entities.js
+++ b/shared/reducers/entities.js
@@ -29,8 +29,8 @@ export default function(state: State = initialState, action: Actions): State {
       return state.updateIn(keyPath, set => set.subtract(entities))
     }
     default:
-      break
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-
-  return state
 }

--- a/shared/reducers/favorite.js
+++ b/shared/reducers/favorite.js
@@ -128,7 +128,9 @@ export default function(
         ...state,
         kbfsOpening: opening,
       }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-
-  return state
 }

--- a/shared/reducers/favorite.js
+++ b/shared/reducers/favorite.js
@@ -128,6 +128,20 @@ export default function(
         ...state,
         kbfsOpening: opening,
       }
+    // Saga only actions
+    case FavoriteGen.favoriteAdd:
+    case FavoriteGen.favoriteAdded:
+    case FavoriteGen.favoriteIgnore:
+    case FavoriteGen.favoriteIgnored:
+    case FavoriteGen.favoriteList:
+    case FavoriteGen.setupKBFSChangedHandler:
+    case KBFSGen.installKBFSResult:
+    case KBFSGen.list:
+    case KBFSGen.listed:
+    case KBFSGen.open:
+    case KBFSGen.openInFileUI:
+    case KBFSGen.uninstallKBFS:
+      return state
     default:
       // eslint-disable-next-line no-unused-expressions
       (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't

--- a/shared/reducers/gregor.js
+++ b/shared/reducers/gregor.js
@@ -24,6 +24,9 @@ export default function(state: Types.State = Constants.initialState, action: Gre
         ...state,
         reachability,
       }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-  return state
 }

--- a/shared/reducers/gregor.js
+++ b/shared/reducers/gregor.js
@@ -24,6 +24,12 @@ export default function(state: Types.State = Constants.initialState, action: Gre
         ...state,
         reachability,
       }
+    // Saga only actions
+    case GregorGen.checkReachability:
+    case GregorGen.injectItem:
+    case GregorGen.pushOOBM:
+    case GregorGen.pushState:
+      return state
     default:
       // eslint-disable-next-line no-unused-expressions
       (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -111,6 +111,26 @@ export default function(state: Types.State = Constants.initialState, action: Log
       const {deletedUsername} = action.payload
       return {...state, justDeletedSelf: deletedUsername}
     }
+    // Saga only actions
+    case LoginGen.addNewDevice:
+    case LoginGen.chooseGPGMethod:
+    case LoginGen.loginDone:
+    case LoginGen.logout:
+    case LoginGen.logoutDone:
+    case LoginGen.navBasedOnLoginAndInitialState:
+    case LoginGen.onBack:
+    case LoginGen.onFinish:
+    case LoginGen.onWont:
+    case LoginGen.openAccountResetPage:
+    case LoginGen.provisionTextCodeEntered:
+    case LoginGen.relogin:
+    case LoginGen.selectDeviceId:
+    case LoginGen.someoneElse:
+    case LoginGen.startLogin:
+    case LoginGen.submitDeviceName:
+    case LoginGen.submitPassphrase:
+    case LoginGen.submitUsernameOrEmail:
+      return state
     default:
       // eslint-disable-next-line no-unused-expressions
       (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -112,6 +112,8 @@ export default function(state: Types.State = Constants.initialState, action: Log
       return {...state, justDeletedSelf: deletedUsername}
     }
     default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
       return state
   }
 }

--- a/shared/reducers/notifications.js
+++ b/shared/reducers/notifications.js
@@ -59,6 +59,9 @@ export default function(state: Types.State = initialState, action: Notifications
       let newState = state.update('keyState', ks => ks.set(key, on))
       newState = _updateWidgetBadge(newState)
       return newState
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-  return state
 }

--- a/shared/reducers/notifications.js
+++ b/shared/reducers/notifications.js
@@ -59,6 +59,11 @@ export default function(state: Types.State = initialState, action: Notifications
       let newState = state.update('keyState', ks => ks.set(key, on))
       newState = _updateWidgetBadge(newState)
       return newState
+    // Saga only actions
+    case NotificationsGen.listenForKBFSNotifications:
+    case NotificationsGen.listenForNotifications:
+    case NotificationsGen.log:
+      return state
     default:
       // eslint-disable-next-line no-unused-expressions
       (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't

--- a/shared/reducers/pgp.js
+++ b/shared/reducers/pgp.js
@@ -18,6 +18,9 @@ export default function(state: Types.State = Constants.initialState, action: Pgp
         ...state,
         open: false,
       }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-  return state
 }

--- a/shared/reducers/pinentry.js
+++ b/shared/reducers/pinentry.js
@@ -50,7 +50,7 @@ export default function(
           },
         }
       }
-      break
+      return state
     case PinentryGen.onCancel: // fallthrough
     case PinentryGen.onSubmit: {
       const {sessionID} = action.payload
@@ -69,9 +69,11 @@ export default function(
           },
         }
       }
-      break
+      return state
     }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-
-  return state
 }

--- a/shared/reducers/plan-billing.js
+++ b/shared/reducers/plan-billing.js
@@ -57,6 +57,9 @@ export default function(
         ...state,
         errorMessage: null,
       }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-  return state
 }

--- a/shared/reducers/profile.js
+++ b/shared/reducers/profile.js
@@ -87,7 +87,7 @@ export default function(state: Types.State = Constants.initialState, action: Pro
     case ProfileGen.updatePgpInfo:
       if (action.error) {
         // TODO
-        break
+        return state
       }
 
       const {info} = action.payload
@@ -104,7 +104,9 @@ export default function(state: Types.State = Constants.initialState, action: Pro
         ...state,
         pgpPublicKey,
       }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-
-  return state
 }

--- a/shared/reducers/profile.js
+++ b/shared/reducers/profile.js
@@ -104,6 +104,27 @@ export default function(state: Types.State = Constants.initialState, action: Pro
         ...state,
         pgpPublicKey,
       }
+    // Saga only actions
+    case ProfileGen.addProof:
+    case ProfileGen.backToProfile:
+    case ProfileGen.cancelAddProof:
+    case ProfileGen.cancelPgpGen:
+    case ProfileGen.checkProof:
+    case ProfileGen.dropPgp:
+    case ProfileGen.editProfile:
+    case ProfileGen.finishRevoking:
+    case ProfileGen.finishedWithKeyGen:
+    case ProfileGen.generatePgp:
+    case ProfileGen.onClickAvatar:
+    case ProfileGen.onClickFollowers:
+    case ProfileGen.onClickFollowing:
+    case ProfileGen.outputInstructionsActionLink:
+    case ProfileGen.showUserProfile:
+    case ProfileGen.submitBTCAddress:
+    case ProfileGen.submitRevokeProof:
+    case ProfileGen.submitUsername:
+    case ProfileGen.submitZcashAddress:
+      return state
     default:
       // eslint-disable-next-line no-unused-expressions
       (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't

--- a/shared/reducers/push.js
+++ b/shared/reducers/push.js
@@ -26,8 +26,11 @@ function reducer(state: Types.State = Constants.initialState, action: PushGen.Ac
         token,
         tokenType,
       }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-  return state
 }
 
 export default reducer

--- a/shared/reducers/push.js
+++ b/shared/reducers/push.js
@@ -26,6 +26,16 @@ function reducer(state: Types.State = Constants.initialState, action: PushGen.Ac
         token,
         tokenType,
       }
+    // Saga only actions
+    case PushGen.configurePush:
+    case PushGen.error:
+    case PushGen.notification:
+    case PushGen.permissionsNo:
+    case PushGen.permissionsRequest:
+    case PushGen.pushToken:
+    case PushGen.registrationError:
+    case PushGen.savePushToken:
+      return state
     default:
       // eslint-disable-next-line no-unused-expressions
       (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't

--- a/shared/reducers/settings.js
+++ b/shared/reducers/settings.js
@@ -178,8 +178,11 @@ function reducer(state: Types.State = Constants.initialState, action: SettingsGe
         ...state,
         waitingForResponse: waiting,
       }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-  return state
 }
 
 export default reducer

--- a/shared/reducers/settings.js
+++ b/shared/reducers/settings.js
@@ -178,6 +178,20 @@ function reducer(state: Types.State = Constants.initialState, action: SettingsGe
         ...state,
         waitingForResponse: waiting,
       }
+    // Saga only actions
+    case SettingsGen.dbNuke:
+    case SettingsGen.deleteAccountForever:
+    case SettingsGen.invitesReclaim:
+    case SettingsGen.invitesReclaimed:
+    case SettingsGen.invitesRefresh:
+    case SettingsGen.invitesSend:
+    case SettingsGen.loadSettings:
+    case SettingsGen.notificationsRefresh:
+    case SettingsGen.onChangeShowPassphrase:
+    case SettingsGen.onSubmitNewEmail:
+    case SettingsGen.onSubmitNewPassphrase:
+    case SettingsGen.onUpdatePGPSettings:
+      return state
     default:
       // eslint-disable-next-line no-unused-expressions
       (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -164,6 +164,9 @@ export default function(state: Types.State = Constants.initialState, action: Sig
         passphraseError: null,
         phase: 'inviteCode',
       }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-  return state
 }

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -116,7 +116,7 @@ export default function(
           hidden: false,
         }))
       }
-      break
+      return state
     }
     case TrackerGen.updateUsername: {
       const {username} = action.payload
@@ -394,6 +394,9 @@ export default function(
         }))
       }
     }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-  return state
 }

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -394,6 +394,9 @@ export default function(
         }))
       }
     }
+    // Saga only actions
+    case TrackerGen.parseFriendship:
+      return state
     default:
       // eslint-disable-next-line no-unused-expressions
       (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't

--- a/shared/reducers/unlock-folders.js
+++ b/shared/reducers/unlock-folders.js
@@ -68,6 +68,9 @@ export default function(
         sessionID: action.payload.sessionID,
       }
     }
+    // Saga only actions
+    case UnlockFoldersGen.registerRekeyListener:
+      return state
     default:
       // eslint-disable-next-line no-unused-expressions
       (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't

--- a/shared/reducers/unlock-folders.js
+++ b/shared/reducers/unlock-folders.js
@@ -68,6 +68,9 @@ export default function(
         sessionID: action.payload.sessionID,
       }
     }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-  return state
 }

--- a/shared/reducers/waiting.js
+++ b/shared/reducers/waiting.js
@@ -16,9 +16,11 @@ function reducer(state: Types.State = Constants.initialState, action: Waiting.Ac
       const {payload: {key}} = action
       return state.update(key, 0, n => n + 1)
     }
+    default:
+      // eslint-disable-next-line no-unused-expressions
+      (action: empty) // if you get a flow error here it means there's an action you claim to handle but didn't
+      return state
   }
-
-  return state
 }
 
 export default reducer

--- a/shared/util/container.js
+++ b/shared/util/container.js
@@ -33,3 +33,4 @@ export {
   createSelectorCreator,
   defaultMemoize,
 }
+export {Dispatch} from '../constants/types/flux'


### PR DESCRIPTION
- [x] add dispatch/ etc to util/container
- [x] add a flow expression to all reducers to catch any unhandled actions.
In practice this means if you have an action in your reducer like

```export default function(state: Types.State = Constants.initialState, action: DevGen.Actions) {
```
if you have a missing DevGen.Action it'll now complain

You'll see i've added a fallthrough for any ones we already don't handle