### PR TITLE
don't bail out if we cant lookup impteam name, keep trying CORE-6597

### DIFF
--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -103,10 +103,14 @@ func (r *chatConversationResolver) completeAndCanonicalizeTLFName(ctx context.Co
 			Name:   tlfName,
 			Public: req.Visibility == keybase1.TLFVisibility_PUBLIC,
 		})
+		var canonName string
 		if err != nil {
-			return err
+			r.G.Log.Debug("failed to lookup or create implicit team, not canonicalizing")
+			canonName = tlfName
+		} else {
+			canonName = impRes.DisplayName.String()
 		}
-		req.ctx.canonicalizedTlfName = impRes.DisplayName.String()
+		req.ctx.canonicalizedTlfName = canonName
 	case chat1.ConversationMembersType_TEAM:
 		req.ctx.canonicalizedTlfName = tlfName
 	}

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -105,7 +105,7 @@ func (r *chatConversationResolver) completeAndCanonicalizeTLFName(ctx context.Co
 		})
 		var canonName string
 		if err != nil {
-			r.G.Log.Debug("failed to lookup or create implicit team, not canonicalizing")
+			r.G.Log.Debug("failed to lookup or create implicit team, not canonicalizing: %s", err)
 			canonName = tlfName
 		} else {
 			canonName = impRes.DisplayName.String()


### PR DESCRIPTION
If for some reason we can't successfully run `LookupOrCreateImplicitTeam` in the CLI code, then just keep charging forward using the `tlfName` as the name of the impteam chat. The service knows how to properly fall back to KBFS, but at this point we don't really know anything.