### PR TITLE
Don't drop error info in ErrorBoundary

### DIFF
--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -6,6 +6,9 @@ import Text from './text'
 import {globalStyles, globalColors} from '../styles'
 import {isMobile} from '../constants/platform'
 
+// Although not mentioned in
+// https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html ,
+// the info parameter to componentDidCatch looks like this.
 type ErrorInfo = {
   componentStack: string,
 }

--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -65,10 +65,6 @@ class ErrorBoundary extends React.PureComponent<any, {error: ?Error, info: ?Erro
     }
   }
 
-  unstable_handleError(error: Error, info: ErrorInfo): void {
-    this.componentDidCatch(error, info)
-  }
-
   componentDidCatch(error: Error, info: ErrorInfo): void {
     console.log('Got boundary error!')
     console.log('Error message:', error.message)

--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -10,6 +10,11 @@ type ErrorInfo = {
   componentStack: string,
 }
 
+const detailStyle = {
+  ...globalStyles.selectable,
+  whiteSpace: 'pre',
+}
+
 // eslint-disable-next-line handle-callback-err
 const Fallback = ({error, info}: *) => {
   const message = error.message || '(No error message)'
@@ -41,11 +46,11 @@ const Fallback = ({error, info}: *) => {
       <Text type="BodySmall" style={globalStyles.selectable}>{message}</Text>
       <Text type="BodySmall" style={{marginTop: 20}}>Error stack: </Text>
       <ScrollView style={{maxHeight: 100, padding: 10}}>
-        <Text type="BodySmall" style={globalStyles.selectable}>{stack}</Text>
+        <Text type="BodySmall" style={detailStyle}>{stack}</Text>
       </ScrollView>
       <Text type="BodySmall" style={{marginTop: 20}}>Component stack: </Text>
       <ScrollView style={{maxHeight: 100, padding: 10}}>
-        <Text type="BodySmall" style={globalStyles.selectable}>{componentStack}</Text>
+        <Text type="BodySmall" style={detailStyle}>{componentStack}</Text>
       </ScrollView>
     </Box>
   )

--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -71,8 +71,9 @@ class ErrorBoundary extends React.PureComponent<any, {error: ?Error, info: ?Erro
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
     console.log('Got boundary error!')
-    console.log(error)
-    console.log(info)
+    console.log('Error message:', error.message)
+    console.log('Error stack:', error.stack)
+    console.log('Component stack:', info.componentStack)
     this.setState({error, info})
   }
 

--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -94,6 +94,7 @@ class ErrorBoundary extends React.PureComponent<any, State> {
       stack: error.stack,
       componentStack: info.componentStack,
     }
+    console.log('Got boundary error:', allInfo)
     this.setState({info: allInfo})
   }
 

--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -74,14 +74,18 @@ const Fallback = ({info: {name, message, stack, componentStack}}: {info: AllErro
   )
 }
 
+type Props = {
+  children: React.Node,
+}
+
 type State = {
   info: ?AllErrorInfo,
 }
 
-class ErrorBoundary extends React.PureComponent<any, State> {
+class ErrorBoundary extends React.PureComponent<Props, State> {
   state = {info: null}
 
-  componentWillReceiveProps(nextProps: any) {
+  componentWillReceiveProps(nextProps: Props) {
     if (this.props.children !== nextProps.children) {
       this.setState({})
     }

--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -20,6 +20,17 @@ type AllErrorInfo = {
   componentStack: string,
 }
 
+const detailHeaderStyle = {
+  marginTop: 20,
+  marginBottom: 10,
+}
+
+const detailContainerStyle = {
+  maxHeight: 100,
+  padding: 10,
+  minWidth: '75%',
+}
+
 const detailStyle = {
   ...globalStyles.selectable,
   whiteSpace: 'pre',
@@ -48,14 +59,15 @@ const Fallback = ({info: {name, message, stack, componentStack}}: {info: AllErro
             keybase log send
           </Text>
         </Box>}
-      <Text type="BodySmall" style={{marginTop: 20}}>Error message: </Text>
-      <Text type="BodySmall" style={globalStyles.selectable}>{`${name}: ${message}`}</Text>
-      <Text type="BodySmall" style={{marginTop: 20}}>Error stack: </Text>
-      <ScrollView style={{maxHeight: 100, padding: 10}}>
+      <Text type="BodySmall" style={detailHeaderStyle}>Error details</Text>
+      <Text type="BodySmall" style={{...globalStyles.selectable, margin: 10}}>{`${name}: ${message}`}</Text>
+      <Text type="BodySmall" style={{marginTop: 20}}>Stack trace</Text>
+      <ScrollView style={detailContainerStyle}>
         <Text type="BodySmall" style={detailStyle}>{stack}</Text>
       </ScrollView>
-      <Text type="BodySmall" style={{marginTop: 20}}>Component stack: </Text>
-      <ScrollView style={{maxHeight: 100, padding: 10}}>
+
+      <Text type="BodySmall" style={detailHeaderStyle}>Component stack trace</Text>
+      <ScrollView style={detailContainerStyle}>
         <Text type="BodySmall" style={detailStyle}>{componentStack}</Text>
       </ScrollView>
     </Box>

--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -12,14 +12,9 @@ type ErrorInfo = {
 
 // eslint-disable-next-line handle-callback-err
 const Fallback = ({error, info}: *) => {
-  let safeError
-  let safeInfo = (info && info.componentStack) || ''
-
-  try {
-    safeError = error.toString()
-  } catch (_) {
-    safeError = ''
-  }
+  const message = error.message || '(No error message)'
+  const stack = error.stack || '(No error stack)'
+  let componentStack = (info && info.componentStack) || '(No component stack)'
 
   return (
     <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', flex: 1, justifyContent: 'center'}}>
@@ -42,10 +37,15 @@ const Fallback = ({error, info}: *) => {
             keybase log send
           </Text>
         </Box>}
-      <Text type="BodySmall" style={{marginTop: 20}}>some details...</Text>
+      <Text type="BodySmall" style={{marginTop: 20}}>Error message: </Text>
+      <Text type="BodySmall" style={globalStyles.selectable}>{message}</Text>
+      <Text type="BodySmall" style={{marginTop: 20}}>Error stack: </Text>
       <ScrollView style={{maxHeight: 100, padding: 10}}>
-        <Text type="BodySmall" style={globalStyles.selectable}>{safeError}</Text>
-        <Text type="BodySmall" style={globalStyles.selectable}>{safeInfo}</Text>
+        <Text type="BodySmall" style={globalStyles.selectable}>{stack}</Text>
+      </ScrollView>
+      <Text type="BodySmall" style={{marginTop: 20}}>Component stack: </Text>
+      <ScrollView style={{maxHeight: 100, padding: 10}}>
+        <Text type="BodySmall" style={globalStyles.selectable}>{componentStack}</Text>
       </ScrollView>
     </Box>
   )

--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -89,7 +89,7 @@ class ErrorBoundary extends React.PureComponent<Props, State> {
 
   componentWillReceiveProps(nextProps: Props) {
     if (this.props.children !== nextProps.children) {
-      this.setState({})
+      this.setState({info: null})
     }
   }
 

--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -6,6 +6,9 @@ import Text from './text'
 import {globalStyles, globalColors} from '../styles'
 import {isMobile} from '../constants/platform'
 
+// NOTE: componentDidCatch doesn't currently work with react-native:
+// https://github.com/facebook/react-native/issues/15571 .
+
 // Although not mentioned in
 // https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html ,
 // the info parameter to componentDidCatch looks like this.

--- a/shared/common-adapters/error-boundary.js
+++ b/shared/common-adapters/error-boundary.js
@@ -36,7 +36,6 @@ const detailStyle = {
   whiteSpace: 'pre',
 }
 
-// eslint-disable-next-line handle-callback-err
 const Fallback = ({info: {name, message, stack, componentStack}}: {info: AllErrorInfo}) => {
   return (
     <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', flex: 1, justifyContent: 'center'}}>


### PR DESCRIPTION
Log a plain object instead of the Error object directly.

Display/log the error stack trace.

Display newlines, too.

Add better typing.