### PR TITLE
use a gregor message to cache-bust the UIDMapper

### DIFF
--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -174,7 +174,7 @@ func (b *BadgeState) UpdateWithGregor(gstate gregor.State) error {
 				b.state.NewTeamAccessRequests = append(b.state.NewTeamAccessRequests, x.TeamName)
 			}
 		case "team.member_out_from_reset":
-			var body memberOutBody
+			var body keybase1.TeamMemberOutFromReset
 			if err := json.Unmarshal(item.Body().Bytes(), &body); err != nil {
 				b.log.Warning("BadgeState unmarshal error for team.member_out_from_reset item: %v", err)
 				continue

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -131,6 +131,7 @@ type LocalDb interface {
 type KVStorer interface {
 	GetInto(obj interface{}, id DbKey) (found bool, err error)
 	PutObj(id DbKey, aliases []DbKey, obj interface{}) (err error)
+	Delete(id DbKey) error
 }
 
 type ConfigReader interface {
@@ -653,6 +654,10 @@ type UIDMapper interface {
 	// SetTestingNoCachingMode puts the UID mapper into a mode where it never serves cached results, *strictly
 	// for use in tests*
 	SetTestingNoCachingMode(enabled bool)
+
+	// ClearUID is called to clear the given UID out of the cache, if the given eldest
+	// seqno doesn't match what's currently cached.
+	ClearUIDAtEldestSeqno(context.Context, UIDMapperContext, keybase1.UID, keybase1.Seqno) error
 }
 
 type ChatHelper interface {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -476,6 +476,10 @@ func NewTestUIDMapper(ul UPAKLoader) TestUIDMapper {
 	}
 }
 
+func (t TestUIDMapper) ClearUIDAtEldestSeqno(_ context.Context, _ UIDMapperContext, _ keybase1.UID, _ keybase1.Seqno) error {
+	return nil
+}
+
 func (t TestUIDMapper) CheckUIDAgainstUsername(uid keybase1.UID, un NormalizedUsername) bool {
 	return true
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -943,6 +943,32 @@ func (o TeamCLKRMsg) DeepCopy() TeamCLKRMsg {
 	}
 }
 
+type TeamResetUser struct {
+	Username    string `codec:"username" json:"username"`
+	Uid         UID    `codec:"uid" json:"uid"`
+	EldestSeqno Seqno  `codec:"eldestSeqno" json:"eldest_seqno"`
+}
+
+func (o TeamResetUser) DeepCopy() TeamResetUser {
+	return TeamResetUser{
+		Username:    o.Username,
+		Uid:         o.Uid.DeepCopy(),
+		EldestSeqno: o.EldestSeqno.DeepCopy(),
+	}
+}
+
+type TeamMemberOutFromReset struct {
+	TeamName  string        `codec:"teamName" json:"team_name"`
+	ResetUser TeamResetUser `codec:"resetUser" json:"reset_user"`
+}
+
+func (o TeamMemberOutFromReset) DeepCopy() TeamMemberOutFromReset {
+	return TeamMemberOutFromReset{
+		TeamName:  o.TeamName,
+		ResetUser: o.ResetUser.DeepCopy(),
+	}
+}
+
 type TeamChangeRow struct {
 	Id                TeamID `codec:"id" json:"id"`
 	Name              string `codec:"name" json:"name"`

--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -50,35 +50,55 @@ func (r *teamHandler) Create(ctx context.Context, cli gregor1.IncomingInterface,
 		return true, r.exitTeam(ctx, cli, item)
 	case "team.seitan":
 		return true, r.seitanCompletion(ctx, cli, item)
+	case "team.member_out_from_reset":
+		return true, r.memberOutFromReset(ctx, cli, item)
 	default:
 		return false, fmt.Errorf("unknown teamHandler category: %q", category)
 	}
 }
 
 func (r *teamHandler) rotateTeam(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
-	r.G().Log.Debug("team.clkr received")
+	r.G().Log.CDebugf(ctx, "team.clkr received")
 	var msg keybase1.TeamCLKRMsg
 	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
-		r.G().Log.Debug("error unmarshaling team.clkr item: %s", err)
+		r.G().Log.CDebugf(ctx, "error unmarshaling team.clkr item: %s", err)
 		return err
 	}
-	r.G().Log.Debug("team.clkr unmarshaled: %+v", msg)
+	r.G().Log.CDebugf(ctx, "team.clkr unmarshaled: %+v", msg)
 
 	if err := teams.HandleRotateRequest(ctx, r.G(), msg.TeamID, keybase1.PerTeamKeyGeneration(msg.Generation)); err != nil {
 		return err
 	}
 
-	r.G().Log.Debug("dismissing team.clkr item since rotate succeeded")
+	r.G().Log.CDebugf(ctx, "dismissing team.clkr item since rotate succeeded")
 	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())
+}
+
+func (r *teamHandler) memberOutFromReset(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
+	nm := "team.member_out_from_reset"
+	r.G().Log.CDebugf(ctx, "%s received", nm)
+	var msg keybase1.TeamMemberOutFromReset
+	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
+		r.G().Log.CDebugf(ctx, "error unmarshaling %s item: %s", nm, err)
+		return err
+	}
+	r.G().Log.CDebugf(ctx, "%s unmarshaled: %+v", nm, msg)
+
+	if err := r.G().UIDMapper.ClearUIDAtEldestSeqno(ctx, r.G(), msg.ResetUser.Uid, msg.ResetUser.EldestSeqno); err != nil {
+		return err
+	}
+
+	r.G().Log.CDebugf(ctx, "%s: cleared UIDMap cache for %s%%%d", nm, msg.ResetUser.Uid, msg.ResetUser.EldestSeqno)
+	return nil
 }
 
 func (r *teamHandler) changeTeam(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item, changes keybase1.TeamChangeSet) error {
 	var rows []keybase1.TeamChangeRow
 	if err := json.Unmarshal(item.Body().Bytes(), &rows); err != nil {
-		r.G().Log.Debug("error unmarshaling team.(change|rename) item: %s", err)
+		r.G().Log.CDebugf(ctx, "error unmarshaling team.(change|rename) item: %s", err)
 		return err
 	}
-	r.G().Log.Debug("team.(change|rename) unmarshaled: %+v", rows)
+	r.G().Log.CDebugf(ctx, "team.(change|rename) unmarshaled: %+v", rows)
 
 	return teams.HandleChangeNotification(ctx, r.G(), rows, changes)
 }
@@ -86,10 +106,10 @@ func (r *teamHandler) changeTeam(ctx context.Context, cli gregor1.IncomingInterf
 func (r *teamHandler) deleteTeam(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
 	var rows []keybase1.TeamChangeRow
 	if err := json.Unmarshal(item.Body().Bytes(), &rows); err != nil {
-		r.G().Log.Debug("error unmarshaling team.(change|rename) item: %s", err)
+		r.G().Log.CDebugf(ctx, "error unmarshaling team.(change|rename) item: %s", err)
 		return err
 	}
-	r.G().Log.Debug("team.delete unmarshaled: %+v", rows)
+	r.G().Log.CDebugf(ctx, "team.delete unmarshaled: %+v", rows)
 
 	err := teams.HandleDeleteNotification(ctx, r.G(), rows)
 	if err != nil {
@@ -102,10 +122,10 @@ func (r *teamHandler) deleteTeam(ctx context.Context, cli gregor1.IncomingInterf
 func (r *teamHandler) exitTeam(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
 	var rows []keybase1.TeamExitRow
 	if err := json.Unmarshal(item.Body().Bytes(), &rows); err != nil {
-		r.G().Log.Debug("error unmarshaling team.exit item: %s", err)
+		r.G().Log.CDebugf(ctx, "error unmarshaling team.exit item: %s", err)
 		return err
 	}
-	r.G().Log.Debug("team.exit unmarshaled: %+v", rows)
+	r.G().Log.CDebugf(ctx, "team.exit unmarshaled: %+v", rows)
 	err := teams.HandleExitNotification(ctx, r.G(), rows)
 	if err != nil {
 		return err
@@ -116,13 +136,13 @@ func (r *teamHandler) exitTeam(ctx context.Context, cli gregor1.IncomingInterfac
 }
 
 func (r *teamHandler) sharingBeforeSignup(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
-	r.G().Log.Debug("team.sbs received")
+	r.G().Log.CDebugf(ctx, "team.sbs received")
 	var msg keybase1.TeamSBSMsg
 	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
-		r.G().Log.Debug("error unmarshaling team.sbs item: %s", err)
+		r.G().Log.CDebugf(ctx, "error unmarshaling team.sbs item: %s", err)
 		return err
 	}
-	r.G().Log.Debug("team.sbs unmarshaled: %+v", msg)
+	r.G().Log.CDebugf(ctx, "team.sbs unmarshaled: %+v", msg)
 
 	if err := teams.HandleSBSRequest(ctx, r.G(), msg); err != nil {
 		return err
@@ -133,36 +153,36 @@ func (r *teamHandler) sharingBeforeSignup(ctx context.Context, cli gregor1.Incom
 }
 
 func (r *teamHandler) openTeamAccessRequest(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
-	r.G().Log.Debug("team.openreq received")
+	r.G().Log.CDebugf(ctx, "team.openreq received")
 	var msg keybase1.TeamOpenReqMsg
 	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
-		r.G().Log.Debug("error unmarshaling team.openreq item: %s", err)
+		r.G().Log.CDebugf(ctx, "error unmarshaling team.openreq item: %s", err)
 		return err
 	}
-	r.G().Log.Debug("team.openreq unmarshaled: %+v", msg)
+	r.G().Log.CDebugf(ctx, "team.openreq unmarshaled: %+v", msg)
 
 	if err := teams.HandleOpenTeamAccessRequest(ctx, r.G(), msg); err != nil {
 		return err
 	}
 
-	r.G().Log.Debug("dismissing team.openreq item since it succeeded")
+	r.G().Log.CDebugf(ctx, "dismissing team.openreq item since it succeeded")
 	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())
 }
 
 func (r *teamHandler) seitanCompletion(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
-	r.G().Log.Debug("team.seitan received")
+	r.G().Log.CDebugf(ctx, "team.seitan received")
 	var msg keybase1.TeamSeitanMsg
 	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
-		r.G().Log.Debug("error unmarshaling team.seitan item: %s", err)
+		r.G().Log.CDebugf(ctx, "error unmarshaling team.seitan item: %s", err)
 		return err
 	}
-	r.G().Log.Debug("team.seitan unmarshaled: %+v", msg)
+	r.G().Log.CDebugf(ctx, "team.seitan unmarshaled: %+v", msg)
 
 	if err := teams.HandleTeamSeitan(ctx, r.G(), msg); err != nil {
 		return err
 	}
 
-	r.G().Log.Debug("dismissing team.seitan item since it succeeded")
+	r.G().Log.CDebugf(ctx, "dismissing team.seitan item since it succeeded")
 	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())
 }
 

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -174,7 +174,11 @@ func TestTeamReset(t *testing.T) {
 	cam := ctx.installKeybaseForUser("cam", 10)
 	cam.signup()
 	divDebug(ctx, "Signed up cam (%s, %s)", cam.username, cam.uid())
-	users := []*smuUser{ann, bob, cam}
+
+	// Note that ann (the admin) has a UIDMapper that should get pubsub updates
+	// since she is an admin for the team in question. cam won't get those
+	// pubsub updates
+	users := []*smuUser{bob, cam}
 	for _, user := range users {
 		for _, device := range user.devices {
 			device.tctx.G.UIDMapper.SetTestingNoCachingMode(true)
@@ -198,7 +202,10 @@ func TestTeamReset(t *testing.T) {
 	bob.reset()
 	divDebug(ctx, "Reset bob (%s)", bob.username)
 
-	// Fast forward clock to clear out UID map
+	// NOTE(maxtaco): This might be racy! If so, please talk to me.
+	// I couldn't get it to race in my tests, but what does that mean.
+	// The race is that a gregor message is needed to clear out the UIDMap,
+	// and it's not guaranteed to come in before the team gets updated.
 	pollForMembershipUpdate(team, ann, bob, cam)
 	divDebug(ctx, "Polled for rekey")
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -294,6 +294,21 @@ protocol teams {
     int score;
   }
 
+  record TeamResetUser {
+    string username;
+    UID uid;
+    @jsonkey("eldest_seqno")
+    Seqno eldestSeqno;
+  }
+
+  // team.member_out_from_reset message body
+  record TeamMemberOutFromReset {
+    @jsonkey("team_name")
+    string teamName;
+    @jsonkey("reset_user")
+    TeamResetUser resetUser;
+  }
+
   record TeamChangeRow {
     TeamID id;
     string name;
@@ -392,7 +407,7 @@ protocol teams {
   record TeamSeitanMsg {
     @jsonkey("team_id")
     TeamID teamID;
-    array<TeamSeitanRequest> seitans; 
+    array<TeamSeitanRequest> seitans;
   }
 
   /**

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3587,6 +3587,8 @@ export type TeamMember = {|uid: UID,role: TeamRole,eldestSeqno: Seqno,userEldest
 
 export type TeamMemberDetails = {|uv: UserVersion,username: String,active: Boolean,needsPUK: Boolean,|}
 
+export type TeamMemberOutFromReset = {|teamName: String,resetUser: TeamResetUser,|}
+
 export type TeamMemberOutReset = {|teamname: String,username: String,id: Gregor1.MsgID,|}
 
 export type TeamMembers = {|owners?: ?Array<UserVersion>,admins?: ?Array<UserVersion>,writers?: ?Array<UserVersion>,readers?: ?Array<UserVersion>,|}
@@ -3606,6 +3608,8 @@ export type TeamPlusApplicationKeys = {|id: TeamID,name: String,implicit: Boolea
 export type TeamRefreshers = {|needKeyGeneration: PerTeamKeyGeneration,wantMembers?: ?Array<UserVersion>,wantMembersRole: TeamRole,|}
 
 export type TeamRequestAccessResult = {|open: Boolean,|}
+
+export type TeamResetUser = {|username: String,uid: UID,eldestSeqno: Seqno,|}
 
 export type TeamRole =0 // NONE_0
  | 1 // READER_1

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -740,6 +740,41 @@
     },
     {
       "type": "record",
+      "name": "TeamResetUser",
+      "fields": [
+        {
+          "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "UID",
+          "name": "uid"
+        },
+        {
+          "type": "Seqno",
+          "name": "eldestSeqno",
+          "jsonkey": "eldest_seqno"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "TeamMemberOutFromReset",
+      "fields": [
+        {
+          "type": "string",
+          "name": "teamName",
+          "jsonkey": "team_name"
+        },
+        {
+          "type": "TeamResetUser",
+          "name": "resetUser",
+          "jsonkey": "reset_user"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "TeamChangeRow",
       "fields": [
         {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3587,6 +3587,8 @@ export type TeamMember = {|uid: UID,role: TeamRole,eldestSeqno: Seqno,userEldest
 
 export type TeamMemberDetails = {|uv: UserVersion,username: String,active: Boolean,needsPUK: Boolean,|}
 
+export type TeamMemberOutFromReset = {|teamName: String,resetUser: TeamResetUser,|}
+
 export type TeamMemberOutReset = {|teamname: String,username: String,id: Gregor1.MsgID,|}
 
 export type TeamMembers = {|owners?: ?Array<UserVersion>,admins?: ?Array<UserVersion>,writers?: ?Array<UserVersion>,readers?: ?Array<UserVersion>,|}
@@ -3606,6 +3608,8 @@ export type TeamPlusApplicationKeys = {|id: TeamID,name: String,implicit: Boolea
 export type TeamRefreshers = {|needKeyGeneration: PerTeamKeyGeneration,wantMembers?: ?Array<UserVersion>,wantMembersRole: TeamRole,|}
 
 export type TeamRequestAccessResult = {|open: Boolean,|}
+
+export type TeamResetUser = {|username: String,uid: UID,eldestSeqno: Seqno,|}
 
 export type TeamRole =0 // NONE_0
  | 1 // READER_1


### PR DESCRIPTION
- test by disabling SetTestCacheMode on the UIDMapper for admins (it doesn't send messages for non-admins)