### PR TITLE
Clear inbox memory cache on logout

### DIFF
--- a/go/chat/storage/inbox_memcache.go
+++ b/go/chat/storage/inbox_memcache.go
@@ -39,4 +39,11 @@ func (i *inboxMemCacheImpl) Clear(uid gregor1.UID) {
 	delete(i.datMap, uid.String())
 }
 
+func (i *inboxMemCacheImpl) OnLogout() error {
+	i.Lock()
+	defer i.Unlock()
+	i.datMap = make(map[string]*inboxDiskData)
+	return nil
+}
+
 var inboxMemCache = newInboxMemCacheImpl()

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -828,3 +828,14 @@ func TestMembershipUpdate(t *testing.T) {
 		}
 	}
 }
+
+// TestInboxCacheOnLogout checks that calling OnLogout() clears the cache.
+func TestInboxCacheOnLogout(t *testing.T) {
+	uid := keybase1.MakeTestUID(3)
+	inboxMemCache.Put(gregor1.UID(uid), &inboxDiskData{})
+	require.NotEmpty(t, len(inboxMemCache.datMap))
+	err := inboxMemCache.OnLogout()
+	require.NoError(t, err)
+	require.Nil(t, inboxMemCache.Get(gregor1.UID(uid)))
+	require.Empty(t, len(inboxMemCache.datMap))
+}


### PR DESCRIPTION
This clears the inbox memory cache on logout for all users.

There is a unit test that checks that if OnLogout is called that it does indeed clear the cache, but if you'd like a deeper integration test I can add one.