### PR TITLE
Refresh UI on team changes

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -888,6 +888,19 @@ function* _incomingMessage(action: ChatGen.IncomingMessagePayload): Saga.SagaGen
         }
       }
       break
+    case RPCChatTypes.notifyChatChatActivityType.membersUpdate:
+      const info = action.payload.activity && action.payload.activity.membersUpdate
+      const convID = info && info.convID
+      const conversationIDKey = Constants.conversationIDToKey(convID)
+
+      yield Saga.put(
+        ChatGen.createUnboxConversations({
+          conversationIDKeys: [conversationIDKey],
+          reason: 'Membership updated',
+          force: true,
+        })
+      )
+      break
   }
 }
 

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -647,9 +647,16 @@ function* _setPublicityTeam(action: Constants.SetPublicityTeam) {
 
 function* _setupTeamHandlers(): Saga.SagaGenerator<any, any> {
   yield Saga.put((dispatch: Dispatch) => {
-    engine().setIncomingHandler('keybase.1.NotifyTeam.teamChanged', () => {
-      dispatch(Creators.getTeams())
-    })
+    engine().setIncomingHandler(
+      'keybase.1.NotifyTeam.teamChanged',
+      (args: RPCTypes.NotifyTeamTeamChangedRpcParam) => {
+        dispatch(Creators.getDetails(args.teamName))
+        dispatch(Creators.getTeams())
+        if (args.changes.membershipChanged) {
+          dispatch(ChatGen.createInboxStale({reason: 'Team membership changed'}))
+        }
+      }
+    )
     engine().setIncomingHandler('keybase.1.NotifyTeam.teamDeleted', () => {
       dispatch(Creators.getTeams())
     })

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -652,9 +652,6 @@ function* _setupTeamHandlers(): Saga.SagaGenerator<any, any> {
       (args: RPCTypes.NotifyTeamTeamChangedRpcParam) => {
         dispatch(Creators.getDetails(args.teamName))
         dispatch(Creators.getTeams())
-        if (args.changes.membershipChanged) {
-          dispatch(ChatGen.createInboxStale({reason: 'Team membership changed'}))
-        }
       }
     )
     engine().setIncomingHandler('keybase.1.NotifyTeam.teamDeleted', () => {


### PR DESCRIPTION
Calls `getDetails` on relevant team when it changes. Also processes conversations with changing membership to get live updates to the info panel.

r? @keybase/react-hackers 