### PR TITLE
Add a way to use SecretStoreFile on MacOS

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1260,6 +1260,11 @@ func (e *Env) WantsSystemd() bool {
 		os.Getenv("KEYBASE_SYSTEMD") == "1")
 }
 
+func (e *Env) DarwinForceSecretStoreFile() bool {
+	return (e.GetRunMode() == DevelRunMode &&
+		os.Getenv("KEYBASE_SECRET_STORE_FILE") == "1")
+}
+
 func GetPlatformString() string {
 	if isIOS {
 		return "ios"

--- a/go/libkb/secret_store_darwin.go
+++ b/go/libkb/secret_store_darwin.go
@@ -99,9 +99,12 @@ func (k KeychainSecretStore) ClearSecret(accountName NormalizedUsername) error {
 }
 
 func NewSecretStoreAll(g *GlobalContext) SecretStoreAll {
-	return KeychainSecretStore{
-		context: g,
+	if g.Env.DarwinForceSecretStoreFile() {
+		// Allow use of file secret store for development/testing
+		// on MacOS.
+		return NewSecretStoreFile(g.Env.GetDataDir())
 	}
+	return KeychainSecretStore{context: g}
 }
 
 func NewTestSecretStoreAll(c SecretStoreContext, g *GlobalContext) SecretStoreAll {


### PR DESCRIPTION
When `KEYBASE_SECRET_STORE_FILE=1` is defined and in devel run mode, Keybase on MacOS will "fall back" to SecretStoreFile instead of keychain-based secret store, allowing for running multiple test users on one machine easier.