### PR TITLE
logger: add env var to duplicate all logs to stdout

### DIFF
--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -5,6 +5,7 @@ package logger
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -56,6 +57,11 @@ func (log *TestLogger) common(ctx context.Context, lvl logging.Level, useFatal b
 		}
 		log.failReported = true
 		log.Unlock()
+	}
+
+	if os.Getenv("KEYBASE_TEST_DUP_LOG_TO_STDOUT") != "" {
+		fmt.Printf(prepareString(ctx,
+			log.prefixCaller(log.extraDepth, lvl, fmts+"\n")), arg...)
 	}
 
 	if ctx != nil {


### PR DESCRIPTION
This is useful when debugging freezes/timeouts, so we can see the log without having to wait until the test completes.

I'm open to envvar naming suggestions.

Suggested by jzila.