### PR TITLE
Add Confirmed boolean to DeleteConversation RPC

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2222,6 +2222,12 @@ func (h *Server) DeleteConversationLocal(ctx context.Context, arg chat1.DeleteCo
 		return res, err
 	}
 
+	return h.deleteConversationLocal(ctx, arg)
+}
+
+// deleteConversationLocal contains the functionality of
+// DeleteConversationLocal split off for easier testing.
+func (h *Server) deleteConversationLocal(ctx context.Context, arg chat1.DeleteConversationLocalArg) (res chat1.DeleteConversationLocalRes, err error) {
 	ui := h.getChatUI(arg.SessionID)
 	confirmed := arg.Confirmed
 	if !confirmed {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2223,12 +2223,15 @@ func (h *Server) DeleteConversationLocal(ctx context.Context, arg chat1.DeleteCo
 	}
 
 	ui := h.getChatUI(arg.SessionID)
-	confirmed, err := ui.ChatConfirmChannelDelete(ctx, chat1.ChatConfirmChannelDeleteArg{
-		SessionID: arg.SessionID,
-		Channel:   arg.ChannelName,
-	})
-	if err != nil {
-		return res, err
+	confirmed := arg.Confirmed
+	if !confirmed {
+		confirmed, err = ui.ChatConfirmChannelDelete(ctx, chat1.ChatConfirmChannelDeleteArg{
+			SessionID: arg.SessionID,
+			Channel:   arg.ChannelName,
+		})
+		if err != nil {
+			return res, err
+		}
 	}
 	if !confirmed {
 		return res, errors.New("channel delete unconfirmed")

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3245,13 +3245,15 @@ func (ui fakeUISource) GetChatUI(sessionID int) libkb.ChatUI {
 
 type fakeRemoteInterface struct {
 	chat1.RemoteInterface
+	deleteConversationCalled bool
 }
 
-func (ri fakeRemoteInterface) DeleteConversation(context.Context, chat1.ConversationID) (chat1.DeleteConversationRemoteRes, error) {
+func (ri *fakeRemoteInterface) DeleteConversation(context.Context, chat1.ConversationID) (chat1.DeleteConversationRemoteRes, error) {
+	ri.deleteConversationCalled = true
 	return chat1.DeleteConversationRemoteRes{}, nil
 }
 
-func TestChatSrvDeleteConversationConfirm(t *testing.T) {
+func TestChatSrvDeleteConversationConfirmed(t *testing.T) {
 	gc := libkb.NewGlobalContext()
 	gc.Init()
 	var is fakeInboxSource
@@ -3264,12 +3266,12 @@ func TestChatSrvDeleteConversationConfirm(t *testing.T) {
 	h := NewServer(g, nil, nil, ui)
 
 	var ri fakeRemoteInterface
-	h.setTestRemoteClient(ri)
-	res, err := h.deleteConversationLocal(context.Background(), chat1.DeleteConversationLocalArg{
+	h.setTestRemoteClient(&ri)
+	_, err := h.deleteConversationLocal(context.Background(), chat1.DeleteConversationLocalArg{
 		Confirmed: true,
 	})
 	require.NoError(t, err)
-	require.False(t, res.Offline)
+	require.True(t, ri.deleteConversationCalled)
 }
 
 func TestChatSrvUserReset(t *testing.T) {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3752,6 +3752,7 @@ type DeleteConversationLocalArg struct {
 	SessionID   int            `codec:"sessionID" json:"sessionID"`
 	ConvID      ConversationID `codec:"convID" json:"convID"`
 	ChannelName string         `codec:"channelName" json:"channelName"`
+	Confirmed   bool           `codec:"confirmed" json:"confirmed"`
 }
 
 type GetTLFConversationsLocalArg struct {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -715,7 +715,7 @@ protocol local {
     boolean offline;
     array<RateLimit> rateLimits;
   }
-  DeleteConversationLocalRes deleteConversationLocal(int sessionID, ConversationID convID, string channelName);
+  DeleteConversationLocalRes deleteConversationLocal(int sessionID, ConversationID convID, string channelName, boolean confirmed);
 
   record GetTLFConversationsLocalRes {
     array<InboxUIItem> convs;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -792,7 +792,8 @@ export type JoinLeaveConversationRemoteRes = {|rateLimit?: ?RateLimit,|}
 export type LocalCancelPostRpcParam = {|  outboxID: OutboxID|}
 
 export type LocalDeleteConversationLocalRpcParam = {|  convID: ConversationID,
-  channelName: String|}
+  channelName: String,
+  confirmed: Boolean|}
 
 export type LocalDownloadAttachmentLocalRpcParam = {|  conversationID: ConversationID,
   messageID: MessageID,

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2941,6 +2941,10 @@
         {
           "name": "channelName",
           "type": "string"
+        },
+        {
+          "name": "confirmed",
+          "type": "boolean"
         }
       ],
       "response": "DeleteConversationLocalRes"

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -717,6 +717,7 @@ function* _deleteChannel({payload: {conversationIDKey}}): Saga.SagaGenerator<any
   const param = {
     convID: ChatConstants.keyToConversationID(conversationIDKey),
     channelName,
+    confirmed: false,
   }
 
   yield Saga.call(ChatTypes.localDeleteConversationLocalRpcPromise, {param})

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -792,7 +792,8 @@ export type JoinLeaveConversationRemoteRes = {|rateLimit?: ?RateLimit,|}
 export type LocalCancelPostRpcParam = {|  outboxID: OutboxID|}
 
 export type LocalDeleteConversationLocalRpcParam = {|  convID: ConversationID,
-  channelName: String|}
+  channelName: String,
+  confirmed: Boolean|}
 
 export type LocalDownloadAttachmentLocalRpcParam = {|  conversationID: ConversationID,
   messageID: MessageID,


### PR DESCRIPTION
This is so that the GUI can handle the confirmation dialog itself, and
then just call the RPC as a final step.