### PR TITLE
set the right item in the store for inbox sync

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -532,7 +532,7 @@ function* unboxConversations(action: ChatGen.UnboxConversationsPayload): SagaGen
     }
   }
   if (forInboxSync) {
-    yield Saga.put(ChatGen.createSetInboxGlobalUntrustedState({inboxGlobalUntrustedState: 'loaded'}))
+    yield Saga.put(ChatGen.createSetInboxSyncingState({inboxSyncingState: 'notSyncing'}))
   }
 }
 


### PR DESCRIPTION
Looks like this got missed for the logout/login change. This line should set the syncing state, and not the inbox loaded state.

@keybase/react-hackers @malgorithms 