### PR TITLE
bring up keybase.service after versionfix auto-restart

### DIFF
--- a/go/client/fork_server_nix.go
+++ b/go/client/fork_server_nix.go
@@ -18,11 +18,12 @@ import (
 func spawnServer(g *libkb.GlobalContext, cl libkb.CommandLine, forkType keybase1.ForkType) (pid int, err error) {
 
 	// If we're running under systemd, start the service as a user unit instead
-	// of forking it directly. We do this here instead of higher up, because we
-	// want to handle the case where the service was previously autoforked, and
-	// then the user upgrades their keybase package to a version with systemd
-	// support. The flock-checking code will short-circuit before we get here,
-	// if the service is running, so we don't have to worry about a conflict.
+	// of forking it directly. We do this here in the generic auto-fork branch,
+	// rather than a higher-level systemd branch, because we want to handle the
+	// case where the service was previously autoforked, and then the user
+	// upgrades their keybase package to a version with systemd support. The
+	// flock-checking code will short-circuit before we get here, if the
+	// service is running, so we don't have to worry about a conflict.
 	//
 	// We only do this in prod mode, because keybase.service always starts
 	// /usr/bin/keybase, which is probably not what you want if you're

--- a/go/client/versionfix.go
+++ b/go/client/versionfix.go
@@ -176,7 +176,7 @@ func FixVersionClash(g *libkb.GlobalContext, cl libkb.CommandLine) (err error) {
 	g.Log.Debug("Waiting for shutdown...")
 	time.Sleep(1 * time.Second)
 
-	if serviceConfig.ForkType == keybase1.ForkType_AUTO {
+	if serviceConfig.ForkType == keybase1.ForkType_AUTO || serviceConfig.ForkType == keybase1.ForkType_SYSTEMD {
 		g.Log.Info("Restarting service...")
 		_, err = AutoForkServer(g, cl)
 	}


### PR DESCRIPTION
Previously we were killing the old service but failing to start the new
one, because the start code was gated on the AUTOFORK type. Now we run
it for both AUTOFORK and SYSTEMD.

r? @maxtaco 