### PR TITLE
store messages in a normal list and apply ordering based on message ID CORE-6633

### DIFF
--- a/go/chat/storage/outbox_test.go
+++ b/go/chat/storage/outbox_test.go
@@ -47,9 +47,12 @@ func TestChatOutbox(t *testing.T) {
 	var obrs []chat1.OutboxRecord
 	conv := makeConvo(gregor1.Time(5), 1, 1)
 
+	prevOrdinal := 1
 	for i := 0; i < 5; i++ {
 		obr, err := ob.PushMessage(context.TODO(), conv.GetConvID(), makeMsgPlaintext("hi", uid),
 			nil, keybase1.TLFIdentifyBehavior_CHAT_CLI)
+		require.Equal(t, obr.Ordinal, prevOrdinal)
+		prevOrdinal++
 		require.NoError(t, err)
 		obrs = append(obrs, obr)
 		cl.Advance(time.Millisecond)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -754,6 +754,10 @@ func PresentThreadView(ctx context.Context, uid gregor1.UID, tv chat1.ThreadView
 	return res
 }
 
+func computeOutboxOrdinal(obr chat1.OutboxRecord) float64 {
+	return float64(obr.Msg.ClientHeader.OutboxInfo.Prev) + float64(obr.Ordinal)/1000.0
+}
+
 func PresentMessageUnboxed(ctx context.Context, rawMsg chat1.MessageUnboxed, uid gregor1.UID,
 	tcs types.TeamChannelSource) (res chat1.UIMessage) {
 	state, err := rawMsg.State()
@@ -812,6 +816,7 @@ func PresentMessageUnboxed(ctx context.Context, rawMsg chat1.MessageUnboxed, uid
 			MessageType: typ,
 			Body:        body,
 			Ctime:       rawMsg.Outbox().Ctime,
+			Ordinal:     computeOutboxOrdinal(rawMsg.Outbox()),
 		})
 	case chat1.MessageUnboxedState_ERROR:
 		res = chat1.NewUIMessageWithError(rawMsg.Error())

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -360,6 +360,7 @@ type UIMessageOutbox struct {
 	MessageType MessageType  `codec:"messageType" json:"messageType"`
 	Body        string       `codec:"body" json:"body"`
 	Ctime       gregor1.Time `codec:"ctime" json:"ctime"`
+	Ordinal     float64      `codec:"ordinal" json:"ordinal"`
 }
 
 func (o UIMessageOutbox) DeepCopy() UIMessageOutbox {
@@ -369,6 +370,7 @@ func (o UIMessageOutbox) DeepCopy() UIMessageOutbox {
 		MessageType: o.MessageType.DeepCopy(),
 		Body:        o.Body,
 		Ctime:       o.Ctime.DeepCopy(),
+		Ordinal:     o.Ordinal,
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1088,6 +1088,7 @@ type OutboxRecord struct {
 	Ctime            gregor1.Time                 `codec:"ctime" json:"ctime"`
 	Msg              MessagePlaintext             `codec:"Msg" json:"Msg"`
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+	Ordinal          int                          `codec:"ordinal" json:"ordinal"`
 }
 
 func (o OutboxRecord) DeepCopy() OutboxRecord {
@@ -1098,6 +1099,7 @@ func (o OutboxRecord) DeepCopy() OutboxRecord {
 		Ctime:            o.Ctime.DeepCopy(),
 		Msg:              o.Msg.DeepCopy(),
 		IdentifyBehavior: o.IdentifyBehavior.DeepCopy(),
+		Ordinal:          o.Ordinal,
 	}
 }
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -95,6 +95,7 @@ protocol chatUi {
     MessageType messageType;
     string body;
     gregor1.Time ctime;
+    double ordinal;
   }
 
   enum MessageUnboxedState {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -174,6 +174,7 @@ protocol local {
     @lint("ignore")
     MessagePlaintext Msg;
     keybase1.TLFIdentifyBehavior identifyBehavior;
+    int ordinal; // the position of this outbox record behind the clientPrev in Msg
   }
 
   enum HeaderPlaintextVersion {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -992,7 +992,7 @@ export type OutboxID = Bytes
 
 export type OutboxInfo = {|prev: MessageID,composeTime: Gregor1.Time,|}
 
-export type OutboxRecord = {|state: OutboxState,outboxID: OutboxID,convID: ConversationID,ctime: Gregor1.Time,Msg: MessagePlaintext,identifyBehavior: Keybase1.TLFIdentifyBehavior,|}
+export type OutboxRecord = {|state: OutboxState,outboxID: OutboxID,convID: ConversationID,ctime: Gregor1.Time,Msg: MessagePlaintext,identifyBehavior: Keybase1.TLFIdentifyBehavior,ordinal: Int,|}
 
 export type OutboxState ={ state: 0, sending: ?Int } | { state: 1, error: ?OutboxStateError }
 
@@ -1169,7 +1169,7 @@ export type TyperInfo = {|uid: Keybase1.UID,username: String,deviceID: Keybase1.
 
 export type UIMessage ={ state: 1, valid: ?UIMessageValid } | { state: 2, error: ?MessageUnboxedError } | { state: 3, outbox: ?UIMessageOutbox } | { state: 4, placeholder: ?MessageUnboxedPlaceholder }
 
-export type UIMessageOutbox = {|state: OutboxState,outboxID: String,messageType: MessageType,body: String,ctime: Gregor1.Time,|}
+export type UIMessageOutbox = {|state: OutboxState,outboxID: String,messageType: MessageType,body: String,ctime: Gregor1.Time,ordinal: Double,|}
 
 export type UIMessageValid = {|messageID: MessageID,ctime: Gregor1.Time,outboxID?: ?String,messageBody: MessageBody,senderUsername: String,senderDeviceName: String,senderDeviceType: String,superseded: Boolean,senderDeviceRevokedAt?: ?Gregor1.Time,atMentions?: ?Array<String>,channelMention: ChannelMention,channelNameMentions?: ?Array<String>,|}
 

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -383,6 +383,10 @@
         {
           "type": "gregor1.Time",
           "name": "ctime"
+        },
+        {
+          "type": "double",
+          "name": "ordinal"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -582,6 +582,10 @@
         {
           "type": "keybase1.TLFIdentifyBehavior",
           "name": "identifyBehavior"
+        },
+        {
+          "type": "int",
+          "name": "ordinal"
         }
       ]
     },

--- a/shared/actions/chat/__test__/addmessages.test.js
+++ b/shared/actions/chat/__test__/addmessages.test.js
@@ -1,0 +1,80 @@
+// @noflow
+/* eslint-env jest */
+import {type TypedState} from '../../../constants/reducer'
+import * as Constants from '../../../constants/chat'
+import * as Entities from '../../../constants/entities'
+import {addMessagesToConversation} from '../thread-content'
+
+function makeState(): TypedState {
+  const entityState = Entities.makeState()
+  const chatState = Constants.makeState()
+  return {
+    entities: entityState,
+    chat: chatState,
+  }
+}
+
+function makeMsg(type: string, state: string, id: number): Constants.ServerMessage {
+  let ordinalField = 'rawMessageID'
+  switch (type) {
+    case 'Attachment':
+    case 'Text':
+      if (state === 'pending' || state === 'failed') {
+        ordinalField = 'ordinal'
+      }
+  }
+  return {
+    [ordinalField]: id,
+    type,
+    messageState: state,
+    key: id,
+  }
+}
+
+describe('addMessagesToConversation', () => {
+  it('defaults', () => {
+    const state = makeState()
+    const convIDKey = 'mike'
+    const currentMessages = Constants.getConversationMessages(state, convIDKey)
+    expect(currentMessages.high).toBe(-1)
+    expect(currentMessages.low).toBe(-1)
+    expect(currentMessages.messages.size).toBe(0)
+  })
+  it('basic', () => {
+    const state = makeState()
+    const convIDKey = 'mike'
+    const messages = [
+      makeMsg('Text', 'sent', 10),
+      makeMsg('Text', 'pending', 11.1),
+      makeMsg('Text', 'sent', 12),
+    ]
+    let newConvMsgs = addMessagesToConversation(state, convIDKey, messages)
+    expect(newConvMsgs.high).toBe(12)
+    expect(newConvMsgs.low).toBe(10)
+    expect(newConvMsgs.messages.get(0)).toBe(10)
+    expect(newConvMsgs.messages.get(-1)).toBe(12)
+    const appendMessages = [
+      makeMsg('Text', 'sent', 8),
+      makeMsg('Text', 'sent', 9),
+      makeMsg('Text', 'sent', 10),
+      makeMsg('Text', 'pending', 11.1),
+      makeMsg('Text', 'sent', 12),
+      makeMsg('Text', 'pending', 13.001),
+    ]
+    newConvMsgs = addMessagesToConversation(state, convIDKey, appendMessages)
+    expect(newConvMsgs.high).toBe(13.001)
+    expect(newConvMsgs.low).toBe(8)
+    expect(newConvMsgs.messages.get(0)).toBe(8)
+    expect(newConvMsgs.messages.get(-1)).toBe(13.001)
+    expect(newConvMsgs.messages.size).toBe(6)
+  })
+  it('edges', () => {
+    const state = makeState()
+    const convIDKey = 'mike'
+    const messages = []
+    let newConvMsgs = addMessagesToConversation(state, convIDKey, messages)
+    expect(newConvMsgs.high).toBe(-1)
+    expect(newConvMsgs.low).toBe(-1)
+    expect(newConvMsgs.messages.size).toBe(0)
+  })
+})

--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -218,6 +218,7 @@ function* _appendAttachmentPlaceholder(
   uploadPath: string
 ): Generator<any, Types.AttachmentMessage, any> {
   const author = yield Saga.select(usernameSelector)
+  const lastOrd = yield Saga.select(Constants.lastOrdinal, conversationIDKey)
   const message: Types.AttachmentMessage = {
     author,
     conversationIDKey,
@@ -235,6 +236,7 @@ function* _appendAttachmentPlaceholder(
     ...Constants.getAttachmentInfo(preview),
     title,
     uploadPath,
+    ordinal: Constants.nextFractionalOrdinal(lastOrd), // Add an ordinal here to keep in correct order
   }
 
   const selectedConversation = yield Saga.select(Constants.getSelectedConversation)

--- a/shared/actions/chat/send-messages.js
+++ b/shared/actions/chat/send-messages.js
@@ -100,7 +100,6 @@ function* postMessage(action: ChatGen.PostMessagePayload): SagaGenerator<any, an
   const outboxID = yield Saga.call(RPCChatTypes.localGenerateOutboxIDRpcPromise)
   const author = yield Saga.select(usernameSelector)
   const outboxIDKey = Constants.outboxIDToKey(outboxID)
-  const clientPrev = lastMessageID ? Constants.parseMessageID(lastMessageID).msgID : 0
   const lastOrd = yield Saga.select(Constants.lastOrdinal, conversationIDKey)
 
   const message: Types.TextMessage = {

--- a/shared/actions/chat/send-messages.js
+++ b/shared/actions/chat/send-messages.js
@@ -100,6 +100,8 @@ function* postMessage(action: ChatGen.PostMessagePayload): SagaGenerator<any, an
   const outboxID = yield Saga.call(RPCChatTypes.localGenerateOutboxIDRpcPromise)
   const author = yield Saga.select(usernameSelector)
   const outboxIDKey = Constants.outboxIDToKey(outboxID)
+  const clientPrev = lastMessageID ? Constants.parseMessageID(lastMessageID).msgID : 0
+  const lastOrd = yield Saga.select(Constants.lastOrdinal, conversationIDKey)
 
   const message: Types.TextMessage = {
     author,
@@ -119,6 +121,7 @@ function* postMessage(action: ChatGen.PostMessagePayload): SagaGenerator<any, an
     timestamp: Date.now(),
     type: 'Text',
     you: author,
+    ordinal: Constants.nextFractionalOrdinal(lastOrd),
   }
 
   const selectedConversation = yield Saga.select(Constants.getSelectedConversation)

--- a/shared/actions/chat/thread-content.js
+++ b/shared/actions/chat/thread-content.js
@@ -21,7 +21,10 @@ import {type TypedState} from '../../constants/reducer'
 
 function* _clearConversationMessages({payload: {conversationIDKey}}: ChatGen.ClearMessagesPayload) {
   yield Saga.put(
-    EntityCreators.replaceEntity(['conversationMessages'], I.Map({[conversationIDKey]: I.OrderedSet()}))
+    EntityCreators.replaceEntity(
+      ['conversationMessages'],
+      I.Map({[conversationIDKey]: Constants.emptyConversationMessages()})
+    )
   )
 }
 
@@ -124,7 +127,8 @@ function* _loadMoreMessages(action: ChatGen.LoadMoreMessagesPayload): Saga.SagaG
       .map(k => ChatTypes.commonMessageType[k])
     const conversationID = Constants.keyToConversationID(conversationIDKey)
 
-    const messageKeys = yield Saga.select(Constants.getConversationMessages, conversationIDKey)
+    const convMsgs = yield Saga.select(Constants.getConversationMessages, conversationIDKey)
+    const messageKeys = convMsgs.messages
     // Find a real message id (ignore outbox etc)
     let pivotMessageKey = recent
       ? messageKeys.findLast(Constants.messageKeyKindIsMessageID)
@@ -383,8 +387,7 @@ function _unboxedToMessage(
       // $FlowIssue
       ? _decodeFailureDescription(payload.state.error.typ)
       : null
-    // $FlowIssue
-    const messageText: ChatTypes.MessageText = message.outbox.body
+    const messageText = message.outbox.body
     const outboxIDKey = payload.outboxID && Constants.stringOutboxIDToKey(payload.outboxID)
 
     return {
@@ -397,7 +400,7 @@ function _unboxedToMessage(
       failureDescription,
       key: Constants.messageKey(conversationIDKey, 'outboxIDText', outboxIDKey),
       mentions: I.Set(),
-      message: new HiddenString((messageText && messageText.body) || ''),
+      message: new HiddenString(messageText),
       messageState,
       outboxID: outboxIDKey,
       rawMessageID: -1,
@@ -405,6 +408,7 @@ function _unboxedToMessage(
       timestamp: payload.ctime,
       type: 'Text',
       you: yourName,
+      ordinal: payload.ordinal,
     }
   }
 
@@ -425,6 +429,7 @@ function _unboxedToMessage(
         senderDeviceRevokedAt: payload.senderDeviceRevokedAt,
         timestamp: payload.ctime,
         you: yourName,
+        ordinal: payload.messageID,
       }
 
       switch (payload.messageBody.messageType) {
@@ -486,6 +491,7 @@ function _unboxedToMessage(
               common.messageID
             ),
             messageID: common.messageID,
+            rawMessageID: common.rawMessageID,
             targetMessageID: Constants.rpcMessageIDToMessageID(attachmentUploaded.messageID),
             timestamp: common.timestamp,
             type: 'UpdateAttachment',
@@ -502,8 +508,10 @@ function _unboxedToMessage(
             type: 'Deleted',
             timestamp: payload.ctime,
             messageID: common.messageID,
+            rawMessageID: common.rawMessageID,
             key: Constants.messageKey(common.conversationIDKey, 'messageIDDeleted', common.messageID),
             deletedIDs,
+            ordinal: common.ordinal,
           }
         case ChatTypes.commonMessageType.edit: {
           const message = new HiddenString(
@@ -516,12 +524,14 @@ function _unboxedToMessage(
             key: Constants.messageKey(common.conversationIDKey, 'messageIDEdit', common.messageID),
             message,
             messageID: common.messageID,
+            rawMessageID: common.rawMessageID,
             outboxID: common.outboxID,
             mentions: common.mentions,
             channelMention: common.channelMention,
             targetMessageID,
             timestamp: common.timestamp,
             type: 'Edit',
+            ordinal: common.ordinal,
           }
         }
         case ChatTypes.commonMessageType.join: {
@@ -529,10 +539,12 @@ function _unboxedToMessage(
           return {
             type: 'JoinedLeft',
             messageID: common.messageID,
+            rawMessageID: common.rawMessageID,
             author: common.author,
             timestamp: common.timestamp,
             message,
             key: Constants.messageKey(common.conversationIDKey, 'joinedleft', common.messageID),
+            ordinal: common.ordinal,
           }
         }
         case ChatTypes.commonMessageType.leave: {
@@ -540,10 +552,12 @@ function _unboxedToMessage(
           return {
             type: 'JoinedLeft',
             messageID: common.messageID,
+            rawMessageID: common.rawMessageID,
             author: common.author,
             timestamp: common.timestamp,
             message,
             key: Constants.messageKey(common.conversationIDKey, 'joinedleft', common.messageID),
+            ordinal: common.ordinal,
           }
         }
         case ChatTypes.commonMessageType.system: {
@@ -608,6 +622,7 @@ function _unboxedToMessage(
               Constants.rpcMessageIDToMessageID(error.messageID)
             ),
             messageID: Constants.rpcMessageIDToMessageID(error.messageID),
+            rawMessageID: error.messageID,
             reason: error.errMsg || '',
             timestamp: error.ctime,
             type: 'Error',
@@ -622,6 +637,7 @@ function _unboxedToMessage(
             ),
             data: message,
             messageID: Constants.rpcMessageIDToMessageID(error.messageID),
+            rawMessageID: error.messageID,
             timestamp: error.ctime,
             type: 'InvisibleError',
           }
@@ -631,6 +647,7 @@ function _unboxedToMessage(
 
   return {
     type: 'Error',
+    rawMessageID: -1,
     key: Constants.messageKey(
       conversationIDKey,
       'error',
@@ -705,10 +722,18 @@ function* _updateThread({
       yourDeviceName,
       conversationIDKey
     )
+
+    // If we find a sent message in the list of messages we are adding to the thread, then double check
+    // that we do not have any pending messages with the same outbox ID also in the list. If we do, then
+    // that pending message was sent and we just missed word about it, so let's just remove it here.
     const messageFromYou =
       message.deviceName === yourDeviceName && message.author && yourName === message.author
-
-    if ((message.type === 'Text' || message.type === 'Attachment') && messageFromYou && message.outboxID) {
+    if (
+      (message.type === 'Text' || message.type === 'Attachment') &&
+      messageFromYou &&
+      message.outboxID &&
+      message.messageState !== 'pending'
+    ) {
       const outboxID: Types.OutboxIDKey = message.outboxID
       const state = yield Saga.select()
       const pendingMessage = Shared.messageOutboxIDSelector(state, conversationIDKey, outboxID)
@@ -746,21 +771,65 @@ function* _updateThread({
   }
 }
 
-function* _appendMessagesToConversation({
-  payload: {conversationIDKey, messages},
-}: ChatGen.AppendMessagesPayload) {
-  const currentMessages = yield Saga.select(Constants.getConversationMessages, conversationIDKey)
-  const nextMessages = currentMessages.concat(messages.map(m => m.key))
-  yield Saga.put(
-    EntityCreators.replaceEntity(['conversationMessages'], I.Map({[conversationIDKey]: nextMessages}))
-  )
+function _getMessageOrdinal(m: Constants.ServerMessage): number {
+  switch (m.type) {
+    case 'Attachment':
+    case 'Text':
+      // These pending messages do not have message IDs, instead getting the special ordinal
+      // values that will keep them in the correct order in the message list.
+      if (m.messageState === 'pending' || m.messageState === 'failed') {
+        return m.ordinal
+      }
+      return m.rawMessageID
+    default:
+      return m.rawMessageID
+  }
 }
 
-function* _prependMessagesToConversation({
+function addMessagesToConversation(
+  state: TypedState,
+  conversationIDKey: Constants.ConversationIDKey,
+  messages: Array<Constants.ServerMessage>
+): Constants.ConversationMessages {
+  const currentMessages = Constants.getConversationMessages(state, conversationIDKey)
+  // Find all those messages that will grow the current set of messages in either direction. This process
+  // both orders the messages correctly, as well as de-dupes.
+  const lowMessages = messages.filter((m: Constants.ServerMessage) => {
+    return _getMessageOrdinal(m) < currentMessages.low
+  })
+  const highMessages = messages.filter((m: Constants.ServerMessage) => {
+    return _getMessageOrdinal(m) > currentMessages.high
+  })
+  const incrMessages = lowMessages.concat(highMessages)
+
+  // Figure out the new bounds for the set of messages. Note the special case for the first setting of low,
+  // using the special value of -1, which cannot be set by a normal call
+  const newLow = incrMessages.length > 0 &&
+    (currentMessages.low < 0 || _getMessageOrdinal(incrMessages[0]) < currentMessages.low)
+    ? _getMessageOrdinal(incrMessages[0])
+    : currentMessages.low
+  const newHigh = incrMessages.length > 0 &&
+    _getMessageOrdinal(incrMessages[incrMessages.length - 1]) > currentMessages.high
+    ? _getMessageOrdinal(incrMessages[incrMessages.length - 1])
+    : currentMessages.high
+
+  // Join the new lists together in the correct order and return the properly formatted result
+  const newMessages = lowMessages
+    .map(m => m.key)
+    .concat(currentMessages.messages.toArray())
+    .concat(highMessages.map(m => m.key))
+  return Constants.makeConversationMessages({
+    high: newHigh,
+    low: newLow,
+    messages: I.List(newMessages),
+  })
+}
+
+function* _addMessagesToConversationSaga({
   payload: {conversationIDKey, messages},
 }: ChatGen.AppendMessagesPayload) {
-  const currentMessages = yield Saga.select(Constants.getConversationMessages, conversationIDKey)
-  const nextMessages = I.OrderedSet(messages.map(m => m.key)).concat(currentMessages)
+  const state: TypedState = yield Saga.select()
+  const nextMessages = addMessagesToConversation(state, conversationIDKey, messages)
   yield Saga.put(
     EntityCreators.replaceEntity(['conversationMessages'], I.Map({[conversationIDKey]: nextMessages}))
   )
@@ -787,15 +856,21 @@ function _removeOutboxMessage(
   {payload: {conversationIDKey, outboxID}}: ChatGen.RemoveOutboxMessagePayload,
   s: TypedState
 ) {
-  const msgKeys: I.OrderedSet<Types.MessageKey> = Constants.getConversationMessages(s, conversationIDKey)
-  const nextMessages = msgKeys.filter(k => {
-    const {messageID} = Constants.splitMessageIDKey(k)
-    return messageID !== outboxID
+  const convMsgs = Constants.getConversationMessages(s, conversationIDKey)
+  const msgKeys: I.List<Types.MessageKey> = convMsgs.messages
+  const nextMessages = Constants.makeConversationMessages({
+    high: convMsgs.high,
+    low: convMsgs.low,
+    messages: msgKeys.filter(k => {
+      const {messageID} = Constants.splitMessageIDKey(k)
+      return messageID !== outboxID
+    }),
   })
 
   if (nextMessages.equals(msgKeys)) {
     return
   }
+  console.log('removed outbox message')
   return Saga.put(
     EntityCreators.replaceEntity(['conversationMessages'], I.Map({[conversationIDKey]: nextMessages}))
   )
@@ -807,7 +882,11 @@ function* _updateOutboxMessageToReal({
   const localMessageState = yield Saga.select(Constants.getLocalMessageStateFromMessageKey, oldMessageKey)
   const conversationIDKey = Constants.messageKeyConversationIDKey(newMessageKey)
   const currentMessages = yield Saga.select(Constants.getConversationMessages, conversationIDKey)
-  const nextMessages = currentMessages.map(k => (k === oldMessageKey ? newMessageKey : k))
+  const nextMessages = Constants.makeConversationMessages({
+    high: currentMessages.high,
+    low: currentMessages.low,
+    messages: currentMessages.messages.map(k => (k === oldMessageKey ? newMessageKey : k)),
+  })
   yield Saga.all([
     Saga.put(
       EntityCreators.replaceEntity(['conversationMessages'], I.Map({[conversationIDKey]: nextMessages}))
@@ -962,8 +1041,7 @@ function* registerSagas(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEvery(ChatGen.updateThread, _updateThread)
   yield Saga.safeTakeEveryPure(ChatGen.updateBadging, _updateBadging)
   yield Saga.safeTakeEveryPure(ChatGen.updateTempMessage, _updateMessageEntity)
-  yield Saga.safeTakeEvery(ChatGen.appendMessages, _appendMessagesToConversation)
-  yield Saga.safeTakeEvery(ChatGen.prependMessages, _prependMessagesToConversation)
+  yield Saga.safeTakeEvery([ChatGen.appendMessages, ChatGen.prependMessages], _addMessagesToConversationSaga)
   yield Saga.safeTakeEveryPure(ChatGen.removeOutboxMessage, _removeOutboxMessage)
   yield Saga.safeTakeEvery(ChatGen.outboxMessageBecameReal, _updateOutboxMessageToReal)
   yield Saga.safeTakeEvery(ChatGen.openConversation, _openConversation)
@@ -978,4 +1056,4 @@ function* registerSagas(): Saga.SagaGenerator<any, any> {
   }
 }
 
-export {registerSagas}
+export {registerSagas, addMessagesToConversation}

--- a/shared/actions/chat/thread-content.js
+++ b/shared/actions/chat/thread-content.js
@@ -771,7 +771,7 @@ function* _updateThread({
   }
 }
 
-function _getMessageOrdinal(m: Constants.ServerMessage): number {
+function _getMessageOrdinal(m: Types.ServerMessage): number {
   switch (m.type) {
     case 'Attachment':
     case 'Text':
@@ -788,16 +788,16 @@ function _getMessageOrdinal(m: Constants.ServerMessage): number {
 
 function addMessagesToConversation(
   state: TypedState,
-  conversationIDKey: Constants.ConversationIDKey,
-  messages: Array<Constants.ServerMessage>
-): Constants.ConversationMessages {
+  conversationIDKey: Types.ConversationIDKey,
+  messages: Array<Types.ServerMessage>
+): Types.ConversationMessages {
   const currentMessages = Constants.getConversationMessages(state, conversationIDKey)
   // Find all those messages that will grow the current set of messages in either direction. This process
   // both orders the messages correctly, as well as de-dupes.
-  const lowMessages = messages.filter((m: Constants.ServerMessage) => {
+  const lowMessages = messages.filter((m: Types.ServerMessage) => {
     return _getMessageOrdinal(m) < currentMessages.low
   })
-  const highMessages = messages.filter((m: Constants.ServerMessage) => {
+  const highMessages = messages.filter((m: Types.ServerMessage) => {
     return _getMessageOrdinal(m) > currentMessages.high
   })
   const incrMessages = lowMessages.concat(highMessages)

--- a/shared/chat/conversation/list/container.js
+++ b/shared/chat/conversation/list/container.js
@@ -46,7 +46,8 @@ const getMessageKeysForSelectedConv = (state: TypedState) => {
   if (!conversationIDKey) {
     return List()
   }
-  return Constants.getConversationMessages(state, conversationIDKey)
+  const convMsgs = Constants.getConversationMessages(state, conversationIDKey)
+  return convMsgs.messages
 }
 
 const getDeletedIDsForSelectedConv = (state: TypedState) => {

--- a/shared/chat/conversation/list/index.stories.js
+++ b/shared/chat/conversation/list/index.stories.js
@@ -78,6 +78,7 @@ function makeMessage(
     mentions: I.Set(),
     channelMention: 'None',
     rawMessageID: -1,
+    ordinal: 0,
   }
 }
 

--- a/shared/chat/conversation/messages/dumb.js
+++ b/shared/chat/conversation/messages/dumb.js
@@ -54,6 +54,7 @@ function textMessageMock(
   return {
     type: 'Text',
     editedCount: 0,
+    ordinal: 0,
     ...messageMock(messageState, author, you, extraProps),
   }
 }
@@ -435,7 +436,13 @@ const mockStore = {
         return acc
       }, {})
     ),
-    conversationMessages: I.Map({[convID]: I.OrderedSet(msgs.map(m => m.key))}),
+    conversationMessages: I.Map({
+      [convID]: ChatConstants.makeConversationMessages({
+        low: -1,
+        high: 0,
+        messages: I.List(msgs.map(m => m.key)),
+      }),
+    }),
   }),
 }
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -578,7 +578,7 @@ const getUserItems = createShallowEqualSelector(
     })
 )
 
-function emptyConversationMessages(): ConversationMessages {
+function emptyConversationMessages(): Types.ConversationMessages {
   return makeConversationMessages({high: -1, low: -1, messages: I.List()})
 }
 
@@ -718,7 +718,7 @@ function lastMessageID(state: TypedState, conversationIDKey: Types.ConversationI
   return lastMessageKey ? messageKeyValue(lastMessageKey) : null
 }
 
-function lastOrdinal(state: TypedState, conversationIDKey: ConversationIDKey): number {
+function lastOrdinal(state: TypedState, conversationIDKey: Types.ConversationIDKey): number {
   const convMsgs = getConversationMessages(state, conversationIDKey)
   return convMsgs.high
 }

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -578,11 +578,15 @@ const getUserItems = createShallowEqualSelector(
     })
 )
 
+function emptyConversationMessages(): ConversationMessages {
+  return makeConversationMessages({high: -1, low: -1, messages: I.List()})
+}
+
 function getConversationMessages(
   state: TypedState,
   convIDKey: Types.ConversationIDKey
-): I.OrderedSet<Types.MessageKey> {
-  return state.entities.conversationMessages.get(convIDKey, I.OrderedSet())
+): Types.ConversationMessages {
+  return state.entities.conversationMessages.get(convIDKey, emptyConversationMessages())
 }
 
 function getDeletedMessageIDs(state: TypedState, convIDKey: Types.ConversationIDKey): I.Set<Types.MessageID> {
@@ -685,7 +689,8 @@ function getMessageKeyFromConvKeyMessageID(
   messageID: Types.MessageID | Types.OutboxIDKey // Works for outbox id too since it uses the message key
 ) {
   const convMsgs = getConversationMessages(state, conversationIDKey)
-  return convMsgs.find(k => {
+  const messageKeys = convMsgs.messages
+  return messageKeys.find(k => {
     const {messageID: mID} = splitMessageIDKey(k)
     return messageID === mID
   })
@@ -701,7 +706,8 @@ function getMessageFromConvKeyMessageID(
 }
 
 function lastMessageID(state: TypedState, conversationIDKey: Types.ConversationIDKey): ?Types.MessageID {
-  const messageKeys = getConversationMessages(state, conversationIDKey)
+  const convMsgs = getConversationMessages(state, conversationIDKey)
+  const messageKeys = convMsgs.messages
   const lastMessageKey = messageKeys.findLast(m => {
     if (m) {
       const {type: msgIDType} = parseMessageID(messageKeyValue(m))
@@ -710,6 +716,16 @@ function lastMessageID(state: TypedState, conversationIDKey: Types.ConversationI
   })
 
   return lastMessageKey ? messageKeyValue(lastMessageKey) : null
+}
+
+function lastOrdinal(state: TypedState, conversationIDKey: ConversationIDKey): number {
+  const convMsgs = getConversationMessages(state, conversationIDKey)
+  return convMsgs.high
+}
+
+function nextFractionalOrdinal(ord: number): number {
+  // Mimic what the service does with outbox items
+  return ord + 0.001
 }
 
 const getDownloadProgress = (
@@ -774,6 +790,12 @@ function getPaginationPrev(state: TypedState, conversationIDKey: Types.Conversat
   return state.entities.pagination.prev.get(conversationIDKey, null)
 }
 
+const makeConversationMessages = I.Record({
+  high: 0,
+  low: 0,
+  messages: I.List(),
+})
+
 export {
   getBrokenUsers,
   getConversationMessages,
@@ -802,6 +824,7 @@ export {
   convSupersededByInfo,
   keyToConversationID,
   keyToOutboxID,
+  makeConversationMessages,
   makeSnippet,
   makeTeamTitle,
   messageKey,
@@ -842,4 +865,7 @@ export {
   parseMessageID,
   lastMessageID,
   getGeneralChannelOfSelectedInbox,
+  lastOrdinal,
+  nextFractionalOrdinal,
+  emptyConversationMessages,
 }

--- a/shared/constants/types/chat.js
+++ b/shared/constants/types/chat.js
@@ -66,6 +66,7 @@ export type TextMessage = {
   editedCount: number, // increase as we edit it
   mentions: Mentions,
   channelMention: ChannelMention,
+  ordinal: number,
 }
 export type ErrorMessage = {
   type: 'Error',
@@ -74,6 +75,7 @@ export type ErrorMessage = {
   conversationIDKey: ConversationIDKey,
   messageID?: MessageID,
   key: MessageKey,
+  rawMessageID: number,
 }
 
 export type InvisibleErrorMessage = {
@@ -83,6 +85,7 @@ export type InvisibleErrorMessage = {
   messageID: MessageID,
   key: MessageKey,
   data: any,
+  rawMessageID: number,
 }
 
 export type UnhandledMessage = {
@@ -91,6 +94,7 @@ export type UnhandledMessage = {
   conversationIDKey: ConversationIDKey,
   messageID: MessageID,
   key: MessageKey,
+  rawMessageID: number,
 }
 
 export type AttachmentSize = {
@@ -127,6 +131,7 @@ export type AttachmentMessage = {
   senderDeviceRevokedAt: ?number,
   key: MessageKey,
   failureDescription?: ?string,
+  ordinal: number,
 }
 
 export type TimestampMessage = {
@@ -148,19 +153,23 @@ export type ChatSecuredHeaderMessage = {
 export type JoinedLeftMessage = {
   type: 'JoinedLeft',
   messageID?: MessageID,
+  rawMessageID: number,
   author: string,
   timestamp: number,
   message: HiddenString,
   key: MessageKey,
+  ordinal: number,
 }
 
 export type SystemMessage = {
   type: 'System',
   messageID?: MessageID,
+  rawMessageID: number,
   author: string,
   timestamp: number,
   message: HiddenString,
   key: MessageKey,
+  ordinal: number,
 }
 
 export type SupersedesMessage = {
@@ -176,6 +185,7 @@ export type DeletedMessage = {
   timestamp: number,
   key: MessageKey,
   messageID: MessageID,
+  rawMessageID: number,
   deletedIDs: Array<MessageID>,
 }
 
@@ -184,17 +194,20 @@ export type EditingMessage = {
   key: MessageKey,
   message: HiddenString,
   messageID: MessageID,
+  rawMessageID: number,
   outboxID?: ?OutboxIDKey,
   targetMessageID: MessageID,
   timestamp: number,
   mentions: Mentions,
   channelMention: ChannelMention,
+  ordinal: number,
 }
 
 export type UpdatingAttachment = {
   type: 'UpdateAttachment',
   key: MessageKey,
   messageID: MessageID,
+  rawMessageID: number,
   targetMessageID: MessageID,
   timestamp: number,
   updates: {
@@ -226,6 +239,12 @@ export type ServerMessage =
   | JoinedLeftMessage
 
 export type Message = ClientMessage | ServerMessage
+
+export type ConversationMessages = I.RecordOf<{
+  high: number,
+  low: number,
+  messages: I.List<MessageKey>,
+}>
 
 export type MaybeTimestamp = TimestampMessage | null
 export type _ConversationState = {

--- a/shared/constants/types/entities.js
+++ b/shared/constants/types/entities.js
@@ -51,7 +51,7 @@ export type _State = {
   attachmentPreviewProgress: I.Map<ChatTypes.MessageKey, ?number>,
   attachmentSavedPath: I.Map<ChatTypes.MessageKey, ?string>,
   attachmentUploadProgress: I.Map<ChatTypes.MessageKey, ?number>,
-  conversationMessages: I.Map<ChatTypes.ConversationIDKey, I.OrderedSet<ChatTypes.MessageKey>>,
+  conversationMessages: I.Map<ChatTypes.ConversationIDKey, ChatTypes.ConversationMessages>,
   deletedIDs: I.Map<ChatTypes.ConversationIDKey, I.Set<ChatTypes.MessageID>>,
   devices: I.Map<string, DeviceDetail>,
   git: Git.State,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -992,7 +992,7 @@ export type OutboxID = Bytes
 
 export type OutboxInfo = {|prev: MessageID,composeTime: Gregor1.Time,|}
 
-export type OutboxRecord = {|state: OutboxState,outboxID: OutboxID,convID: ConversationID,ctime: Gregor1.Time,Msg: MessagePlaintext,identifyBehavior: Keybase1.TLFIdentifyBehavior,|}
+export type OutboxRecord = {|state: OutboxState,outboxID: OutboxID,convID: ConversationID,ctime: Gregor1.Time,Msg: MessagePlaintext,identifyBehavior: Keybase1.TLFIdentifyBehavior,ordinal: Int,|}
 
 export type OutboxState ={ state: 0, sending: ?Int } | { state: 1, error: ?OutboxStateError }
 
@@ -1169,7 +1169,7 @@ export type TyperInfo = {|uid: Keybase1.UID,username: String,deviceID: Keybase1.
 
 export type UIMessage ={ state: 1, valid: ?UIMessageValid } | { state: 2, error: ?MessageUnboxedError } | { state: 3, outbox: ?UIMessageOutbox } | { state: 4, placeholder: ?MessageUnboxedPlaceholder }
 
-export type UIMessageOutbox = {|state: OutboxState,outboxID: String,messageType: MessageType,body: String,ctime: Gregor1.Time,|}
+export type UIMessageOutbox = {|state: OutboxState,outboxID: String,messageType: MessageType,body: String,ctime: Gregor1.Time,ordinal: Double,|}
 
 export type UIMessageValid = {|messageID: MessageID,ctime: Gregor1.Time,outboxID?: ?String,messageBody: MessageBody,senderUsername: String,senderDeviceName: String,senderDeviceType: String,superseded: Boolean,senderDeviceRevokedAt?: ?Gregor1.Time,atMentions?: ?Array<String>,channelMention: ChannelMention,channelNameMentions?: ?Array<String>,|}
 


### PR DESCRIPTION
@keybase/react-hackers 

This patch addresses a bad bug where it is possible for the UI to display old messages from previous pages as the newest messages in a thread. In order to understand why I made the sweeping change I did, it makes sense to understand how the old system could go wrong. Imagine the case where I have in the store the value `[1,2,3]`, and I am about to append the set of messages `[0,1,2,3]`. Using the `OrderedSet`, I would end up with `[1,2,3,0]` because the `[1,2,3]` portion are dupes. This could happen for a variety of different reasons when loading messages. The changes I made are the following:

1.) Use a new type, `ConversationMessages`, as the new type for messages in the store. This type stores all the message keys in a normal `I.List<string>`, but also has additional values, `high` and `low`, which store the message "ordinal" of the highest and lowest value in that list.
2.) Get rid of `appendMessages` and `prependMessages`, and replace with `addMessagesToConversation` which will take a list of new messages and merge it into the existing values in the store. It makes sure to de-dupe, and set new `high` and `low` values.
3.) Attach an "ordinal" value to pending messages, which allows them to be ordered just like normal messages with sent message IDs. All pending messages get an ordinal value that is some fraction plus the previous message ID in front of them. 
4.) *Fix*: pending messages were not rendering any text, the reason being that the code that filled in the text read the wrong field. 
5.) *Fix*: Removed some code that would remove a pending message from the message list when loading it from scratch. I'm not sure why this code was in there at all, so if someone knows please let me know, but it was buggy to have it in there. 