### PR TITLE
More info in RPC errors

### DIFF
--- a/shared/app/global-errors/index.desktop.js
+++ b/shared/app/global-errors/index.desktop.js
@@ -48,7 +48,7 @@ class GlobalError extends Component<Props, State> {
     if (newError) {
       this.timerID = this.props.setTimeout(() => {
         this.props.onDismiss()
-      }, 5000)
+      }, 10000)
     }
   }
 

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -329,14 +329,15 @@ class Engine {
       sessionID,
       incomingCallMap,
       waitingHandler,
-      (method, param, cb) =>
-        this._rpcClient.invoke(method, param, (...args) => {
-          // If first argument is set, convert it to an Error type
+      (method, param, cb) => {
+        const callback = method => (...args) => {
           if (args.length > 0 && !!args[0]) {
-            args[0] = convertToError(args[0])
+            args[0] = convertToError(args[0], method)
           }
           cb(...args)
-        }),
+        }
+        this._rpcClient.invoke(method, param, callback(method))
+      },
       (session: Session) => this._sessionEnded(session),
       cancelHandler,
       dangling

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -331,6 +331,7 @@ class Engine {
       waitingHandler,
       (method, param, cb) => {
         const callback = method => (...args) => {
+          // If first argument is set, convert it to an Error type
           if (args.length > 0 && !!args[0]) {
             args[0] = convertToError(args[0], method)
           }

--- a/shared/util/errors.js
+++ b/shared/util/errors.js
@@ -63,7 +63,7 @@ export function convertToError(err: Object, method?: string): Error {
 
 export function convertToRPCError(
   err: {code: number, desc: string, fields?: any, name?: string},
-  method?: string
+  method?: ?string
 ): RPCError {
   return new RPCError(err.desc, err.code, err.fields, err.name, method)
 }

--- a/shared/util/errors.js
+++ b/shared/util/errors.js
@@ -1,15 +1,17 @@
 // @flow
 
 export class RPCError extends Error {
-  code: number
+  code: number // Consult type StatusCode in flow-types.js for what this means
   fields: any
   desc: string // Don't use! This is for compatibility with RPC error object.
+  name: string
 
-  constructor(message: string, code: number, fields: ?any) {
-    super(message || 'Unknown RPC Error')
-    this.code = code
+  constructor(message: string, code: number, fields: ?any, name: ?string) {
+    super(message || (name && `RPC Error: ${name}`) || 'Unknown RPC Error')
+    this.code = code // Consult type StatusCode in flow-types.js for what this means
     this.fields = fields
     this.desc = message // Don't use! This is for compatibility with RPC error object.
+    this.name = name || ''
   }
 }
 
@@ -41,6 +43,6 @@ export function convertToError(err: Object): Error {
   return new Error(`Unknown error: ${JSON.stringify(err)}`)
 }
 
-export function convertToRPCError(err: {code: number, desc: string, fields?: any}): RPCError {
-  return new RPCError(err.desc, err.code, err.fields)
+export function convertToRPCError(err: {code: number, desc: string, fields?: any, name?: string}): RPCError {
+  return new RPCError(err.desc, err.code, err.fields, err.name)
 }

--- a/shared/util/errors.js
+++ b/shared/util/errors.js
@@ -7,12 +7,26 @@ export class RPCError extends Error {
   name: string
 
   constructor(message: string, code: number, fields: ?any, name: ?string) {
-    super(message || (name && `RPC Error: ${name}`) || 'Unknown RPC Error')
+    super(paramsToErrorMsg(message, code, fields, name))
     this.code = code // Consult type StatusCode in flow-types.js for what this means
     this.fields = fields
     this.desc = message // Don't use! This is for compatibility with RPC error object.
     this.name = name || ''
   }
+}
+
+const paramsToErrorMsg: (string, number, ?any, ?string) => string = (
+  message: string,
+  code: number,
+  fields: ?any,
+  name: ?string
+) => {
+  let msg = ''
+  if (code) {
+    msg += `ERROR CODE ${code} - `
+  }
+  msg += message || (name && `RPC Error: ${name}`) || 'Unknown RPC Error'
+  return msg
 }
 
 export class RPCTimeoutError extends Error {

--- a/shared/util/errors.js
+++ b/shared/util/errors.js
@@ -6,7 +6,7 @@ export class RPCError extends Error {
   desc: string // Don't use! This is for compatibility with RPC error object.
   name: string
 
-  constructor(message: string, code: number, fields: ?any, name: ?string, method: ?string) {
+  constructor(message: string, code: number, fields: any, name: ?string, method: ?string) {
     super(paramsToErrorMsg(message, code, fields, name, method))
     this.code = code // Consult type StatusCode in flow-types.js for what this means
     this.fields = fields
@@ -15,13 +15,13 @@ export class RPCError extends Error {
   }
 }
 
-const paramsToErrorMsg: (string, number, ?any, ?string, ?string) => string = (
+const paramsToErrorMsg = (
   message: string,
   code: number,
-  fields: ?any,
+  fields: any,
   name: ?string,
   method: ?string
-) => {
+): string => {
   let msg = ''
   if (code) {
     msg += `ERROR CODE ${code} - `


### PR DESCRIPTION
before:
<img width="761" alt="screen shot 2017-11-21 at 2 27 51 pm" src="https://user-images.githubusercontent.com/11968340/33093768-ef6c8d24-cecb-11e7-9a26-d7deed662149.png">
after:
<img width="762" alt="screen shot 2017-11-21 at 2 27 21 pm" src="https://user-images.githubusercontent.com/11968340/33093779-f84cc83c-cecb-11e7-9a72-a0076fb38f23.png">

Open to ideas on the error text, I just whipped up what sounded ok with the available information. Broken apart, the contained info is:

1. Code - [this type](https://github.com/keybase/client/blob/master/shared/constants/types/flow-types.js) enumerates what rpc error codes mean
2. Name (e.g. `LOGIN_REQUIRED`) - sometimes(?) passed back by core, corresponds to code
3. Method - the RPC called

r? @keybase/react-hackers 