### PR TITLE
remove inbox entry for hidden conversations

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -314,7 +314,7 @@ function* _processConversation(c: RPCChatTypes.InboxUIItem): Generator<any, void
 
   if (inboxState) {
     // We blocked it
-    if (['blocked', 'reported'].includes(inboxState.status)) {
+    if (['ignored', 'blocked', 'reported'].includes(inboxState.status)) {
       yield Saga.put(
         ChatGen.createDeleteEntity({
           keyPath: ['inboxSmallTimestamps'],


### PR DESCRIPTION
@keybase/react-hackers 

We should drop the row if someone does `keybase chat hide` from the CLI. Looks like this was probably busted at some point.

cc @malgorithms 