### PR TITLE
Add handler for clicking a channel you're already in in manage-channels

### DIFF
--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -38,13 +38,13 @@ const mapStateToProps = (state: TypedState, {routeProps, routeState}) => {
     .filter(Boolean)
     .sort((a, b) => a.name.localeCompare(b.name))
 
-  const previousPath = pathSelector(state)
+  const currentPath = pathSelector(state)
 
   return {
     channels,
     teamname: routeProps.get('teamname'),
     waitingForSave,
-    previousPath,
+    currentPath,
   }
 }
 
@@ -74,6 +74,9 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
         navigateTo([chatTab, {selected: conversationIDKey, props: {previousPath: previousPath || null}}])
       )
     },
+    _onView: (conversationIDKey: string) => {
+      dispatch(navigateTo([chatTab, conversationIDKey]))
+    },
   }
 }
 
@@ -94,8 +97,14 @@ export default compose(
       })),
     onSaveSubscriptions: props => () =>
       props._saveSubscriptions(props.oldChannelState, props.nextChannelState),
-    onPreview: ({previousPath, _onPreview}) => (conversationIDKey: string) =>
-      _onPreview(conversationIDKey, previousPath),
+    onClickChannel: ({channels, currentPath, _onPreview, _onView}) => (conversationIDKey: string) => {
+      const channel = channels.find(c => c.convID === conversationIDKey)
+      if (channel.selected) {
+        _onView(conversationIDKey)
+      } else {
+        _onPreview(conversationIDKey, currentPath)
+      }
+    },
   }),
   lifecycle({
     componentWillReceiveProps: function(nextProps) {

--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -75,7 +75,8 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
       )
     },
     _onView: (conversationIDKey: string) => {
-      dispatch(navigateTo([chatTab, conversationIDKey]))
+      dispatch(ChatGen.createSetInboxFilter({filter: ''}))
+      dispatch(ChatGen.createSelectConversation({conversationIDKey, fromUser: true}))
     },
   }
 }

--- a/shared/chat/manage-channels/index.desktop.js
+++ b/shared/chat/manage-channels/index.desktop.js
@@ -25,7 +25,7 @@ const Row = (
     onToggle: () => void,
     showEdit: boolean,
     onEdit: () => void,
-    onPreview: () => void,
+    onClickChannel: () => void,
   }
 ) => (
   <Box
@@ -47,7 +47,7 @@ const Row = (
           />
         </Box>
         <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.tiny, minHeight: 32}}>
-          <Text type="BodySemiboldLink" onClick={props.onPreview} style={{color: globalColors.blue}}>
+          <Text type="BodySemiboldLink" onClick={props.onClickChannel} style={{color: globalColors.blue}}>
             #{props.name}
           </Text>
           <Text type="BodySmall">{props.description}</Text>
@@ -94,7 +94,7 @@ const ManageChannels = (props: Props) => (
             onToggle={() => props.onToggle(c.name)}
             showEdit={!props.unsavedSubscriptions}
             onEdit={() => props.onEdit(c.convID)}
-            onPreview={() => props.onPreview(c.convID)}
+            onClickChannel={() => props.onClickChannel(c.convID)}
           />
         ))}
       </ScrollView>

--- a/shared/chat/manage-channels/index.js.flow
+++ b/shared/chat/manage-channels/index.js.flow
@@ -14,7 +14,7 @@ export type Props = {
   onToggle: (channel: string) => void,
   onEdit: (channel: string) => void,
   onClose: () => void,
-  onPreview: (conversationIDKey: string) => void,
+  onClickChannel: (conversationIDKey: string) => void,
   teamname: string,
   unsavedSubscriptions: boolean,
   onSaveSubscriptions: () => void,

--- a/shared/chat/manage-channels/index.native.js
+++ b/shared/chat/manage-channels/index.native.js
@@ -29,7 +29,7 @@ const Row = (
     onToggle: () => void,
     showEdit: boolean,
     onEdit: () => void,
-    onPreview: () => void,
+    onClickChannel: () => void,
   }
 ) => (
   <Box style={_rowBox}>
@@ -39,7 +39,7 @@ const Row = (
     >
       <Text
         type="BodySemiboldLink"
-        onClick={props.onPreview}
+        onClick={props.onClickChannel}
         style={{color: globalColors.blue, maxWidth: '100%'}}
         lineClamp={1}
       >
@@ -83,7 +83,7 @@ const ManageChannels = (props: Props) => (
           onToggle={() => props.onToggle(c.name)}
           showEdit={!props.unsavedSubscriptions}
           onEdit={() => props.onEdit(c.convID)}
-          onPreview={() => props.onPreview(c.convID)}
+          onClickChannel={() => props.onClickChannel(c.convID)}
         />
       ))}
     </ScrollView>

--- a/shared/chat/manage-channels/index.stories.js
+++ b/shared/chat/manage-channels/index.stories.js
@@ -65,7 +65,7 @@ const load = () => {
           onCreate={action('onCreate')}
           unsavedSubscriptions={false}
           onSaveSubscriptions={action('onSaveSubscriptions')}
-          onPreview={action('onPreview')}
+          onClickChannel={action('onClickChannel')}
           waitingForSave={false}
           nextChannelState={channels.reduce((acc, c) => {
             acc[c.name] = c.selected
@@ -86,7 +86,7 @@ const load = () => {
           onCreate={action('onCreate')}
           unsavedSubscriptions={true}
           onSaveSubscriptions={action('onSaveSubscriptions')}
-          onPreview={action('onPreview')}
+          onClickChannel={action('onClickChannel')}
           waitingForSave={false}
           nextChannelState={channels.reduce((acc, c) => {
             acc[c.name] = c.selected


### PR DESCRIPTION
This adds an `_onView` handler in manage channels for a case I forgot to cover while doing [DESKTOP-5404](https://keybase.atlassian.net/browse/DESKTOP-5404)

r? @keybase/react-hackers 