### PR TITLE
show participants from general channel for team @ mention complete

### DIFF
--- a/shared/chat/hud/mention-hud-container.js
+++ b/shared/chat/hud/mention-hud-container.js
@@ -3,7 +3,7 @@ import React from 'react'
 import {MentionHud} from '.'
 import {createSelector} from 'reselect'
 import {connect, type MapStateToProps} from 'react-redux'
-import {getSelectedInbox} from '../../constants/chat'
+import {getGeneralChannelOfSelectedInbox} from '../../constants/chat'
 
 type ConnectedMentionHudProps = {
   onPickUser: (user: string) => void,
@@ -15,9 +15,12 @@ type ConnectedMentionHudProps = {
   style?: Object,
 }
 
-const fullNameSelector = createSelector(getSelectedInbox, inbox => (inbox ? inbox.get('fullNames') : null))
+const fullNameSelector = createSelector(
+  getGeneralChannelOfSelectedInbox,
+  inbox => (inbox ? inbox.get('fullNames') : null)
+)
 const participantsSelector = createSelector(
-  getSelectedInbox,
+  getGeneralChannelOfSelectedInbox,
   inbox => (inbox ? inbox.get('participants') : null)
 )
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -822,6 +822,7 @@ const getFollowingMap = (state: TypedState) => state.config.following
 const getMetaDataMap = (state: TypedState) => state.chat.get('metaData')
 const getInbox = (state: TypedState, conversationIDKey: ?ConversationIDKey) =>
   conversationIDKey ? state.chat.getIn(['inbox', conversationIDKey]) : null
+const getFullInbox = (state: TypedState) => state.chat.inbox
 const getSelectedInbox = (state: TypedState) => getInbox(state, getSelectedConversation(state))
 const getEditingMessage = (state: TypedState) => state.chat.get('editingMessage')
 
@@ -853,6 +854,17 @@ const getParticipantsWithFullNames = createSelector(
         .toArray()
     }
     return []
+  }
+)
+
+const getGeneralChannelOfSelectedInbox = createSelector(
+  [getSelectedInbox, getFullInbox],
+  (selectedInbox, inbox) => {
+    if (!selectedInbox || selectedInbox.membersType !== ChatTypes.commonConversationMembersType.team) {
+      return selectedInbox
+    }
+    const teamName = selectedInbox.teamname
+    return inbox.find(value => value.teamname === teamName && value.channelname === 'general')
   }
 )
 
@@ -1172,4 +1184,5 @@ export {
   messageIDToSelfInventedID,
   parseMessageID,
   lastMessageID,
+  getGeneralChannelOfSelectedInbox,
 }

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -35,7 +35,6 @@ let config = {
 }
 
 // Developer settings
-config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = false
   config.enableStoreLogging = false
@@ -43,6 +42,7 @@ if (__DEV__) {
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
+  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -35,6 +35,7 @@ let config = {
 }
 
 // Developer settings
+config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = false
   config.enableStoreLogging = false
@@ -42,7 +43,6 @@ if (__DEV__) {
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
-  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false


### PR DESCRIPTION
@keybase/react-hackers 

This patch makes it so that the @ mention autocomplete list is the full team list, instead of the members of the selected conversation. It does this by just using the participant list from the general channel of the team.