### PR TITLE
Redo teams/list to simplify code and fix multiple bugs

### DIFF
--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -193,7 +193,14 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 			role += strings.ToLower(t.Role.String())
 		}
 		if c.showAll {
-			fmt.Fprintf(c.tabw, "%s\t%s\t%s\t%s\n", t.FqName, role, t.Username, t.FullName)
+			var reset string
+			if !t.Active {
+				reset = "(inactive due to account reset)"
+				if len(t.FullName) > 0 {
+					reset = " " + reset
+				}
+			}
+			fmt.Fprintf(c.tabw, "%s\t%s\t%s\t%s%s\n", t.FqName, role, t.Username, t.FullName, reset)
 		} else {
 			fmt.Fprintf(c.tabw, "%s\t%s\t%d\n", t.FqName, role, t.MemberCount)
 		}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1620,18 +1620,10 @@ func (t TeamMembers) AllUIDs() []UID {
 }
 
 func (t TeamMembers) AllUserVersions() (res []UserVersion) {
-	for _, u := range t.Owners {
-		res = append(res, u)
-	}
-	for _, u := range t.Admins {
-		res = append(res, u)
-	}
-	for _, u := range t.Writers {
-		res = append(res, u)
-	}
-	for _, u := range t.Readers {
-		res = append(res, u)
-	}
+	res = append(res, t.Owners...)
+	res = append(res, t.Admins...)
+	res = append(res, t.Writers...)
+	res = append(res, t.Readers...)
 	return res
 }
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1619,25 +1619,20 @@ func (t TeamMembers) AllUIDs() []UID {
 	return all
 }
 
-func (t TeamMembers) AllUserVersions() []UserVersion {
-	m := make(map[UID]UserVersion)
+func (t TeamMembers) AllUserVersions() (res []UserVersion) {
 	for _, u := range t.Owners {
-		m[u.Uid] = u
+		res = append(res, u)
 	}
 	for _, u := range t.Admins {
-		m[u.Uid] = u
+		res = append(res, u)
 	}
 	for _, u := range t.Writers {
-		m[u.Uid] = u
+		res = append(res, u)
 	}
 	for _, u := range t.Readers {
-		m[u.Uid] = u
+		res = append(res, u)
 	}
-	var all []UserVersion
-	for _, uv := range m {
-		all = append(all, uv)
-	}
-	return all
+	return res
 }
 
 func (t TeamMember) IsReset() bool {

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1420,6 +1420,8 @@ type AnnotatedMemberInfo struct {
 	Implicit       *ImplicitRole `codec:"implicit,omitempty" json:"implicit,omitempty"`
 	NeedsPUK       bool          `codec:"needsPUK" json:"needsPUK"`
 	MemberCount    int           `codec:"memberCount" json:"member_count"`
+	EldestSeqno    Seqno         `codec:"eldestSeqno" json:"member_eldest_seqno"`
+	Active         bool          `codec:"active" json:"active"`
 }
 
 func (o AnnotatedMemberInfo) DeepCopy() AnnotatedMemberInfo {
@@ -1440,6 +1442,8 @@ func (o AnnotatedMemberInfo) DeepCopy() AnnotatedMemberInfo {
 		})(o.Implicit),
 		NeedsPUK:    o.NeedsPUK,
 		MemberCount: o.MemberCount,
+		EldestSeqno: o.EldestSeqno.DeepCopy(),
+		Active:      o.Active,
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -708,6 +708,7 @@ type AnnotatedTeamInvite struct {
 	Inviter         UserVersion    `codec:"inviter" json:"inviter"`
 	InviterUsername string         `codec:"inviterUsername" json:"inviterUsername"`
 	TeamName        string         `codec:"teamName" json:"teamName"`
+	UserActive      bool           `codec:"userActive" json:"userActive"`
 }
 
 func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
@@ -720,6 +721,7 @@ func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
 		Inviter:         o.Inviter.DeepCopy(),
 		InviterUsername: o.InviterUsername,
 		TeamName:        o.TeamName,
+		UserActive:      o.UserActive,
 	}
 }
 

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -407,40 +407,28 @@ func (u *smuUser) lookupImplicitTeam(create bool, displayName string, public boo
 	return smuImplicitTeam{ID: res.TeamID}
 }
 
-func (u *smuUser) addWriter(team smuTeam, w *smuUser) {
+func (u *smuUser) addTeamMember(team smuTeam, member *smuUser, role keybase1.TeamRole) {
 	cli := u.getTeamsClient()
 	_, err := cli.TeamAddMember(context.TODO(), keybase1.TeamAddMemberArg{
 		Name:     team.name,
-		Username: w.username,
-		Role:     keybase1.TeamRole_WRITER,
+		Username: member.username,
+		Role:     role,
 	})
 	if err != nil {
 		u.ctx.t.Fatal(err)
 	}
+}
+
+func (u *smuUser) addWriter(team smuTeam, w *smuUser) {
+	u.addTeamMember(team, w, keybase1.TeamRole_WRITER)
 }
 
 func (u *smuUser) addAdmin(team smuTeam, w *smuUser) {
-	cli := u.getTeamsClient()
-	_, err := cli.TeamAddMember(context.TODO(), keybase1.TeamAddMemberArg{
-		Name:     team.name,
-		Username: w.username,
-		Role:     keybase1.TeamRole_ADMIN,
-	})
-	if err != nil {
-		u.ctx.t.Fatal(err)
-	}
+	u.addTeamMember(team, w, keybase1.TeamRole_ADMIN)
 }
 
 func (u *smuUser) addOwner(team smuTeam, w *smuUser) {
-	cli := u.getTeamsClient()
-	_, err := cli.TeamAddMember(context.TODO(), keybase1.TeamAddMemberArg{
-		Name:     team.name,
-		Username: w.username,
-		Role:     keybase1.TeamRole_OWNER,
-	})
-	if err != nil {
-		u.ctx.t.Fatal(err)
-	}
+	u.addTeamMember(team, w, keybase1.TeamRole_OWNER)
 }
 
 func (u *smuUser) reAddUserAfterReset(team smuImplicitTeam, w *smuUser) {

--- a/go/systests/standalone_test.go
+++ b/go/systests/standalone_test.go
@@ -68,6 +68,7 @@ func makeUserStandalone(t *testing.T, pre string, opts standaloneUserArgs) *user
 	require.NoError(t, err)
 
 	u.deviceClient = keybase1.DeviceClient{Cli: cli}
+	u.teamsClient = keybase1.TeamsClient{Cli: cli}
 
 	return &u
 }

--- a/go/systests/team_list_test.go
+++ b/go/systests/team_list_test.go
@@ -83,7 +83,6 @@ func TestTeamList(t *testing.T) {
 	require.Equal(t, 0, len(details.Members.Admins))
 	require.Equal(t, 4, len(details.Members.Writers))
 	require.Equal(t, 0, len(details.Members.Readers))
-	require.Equal(t, 1, len(details.AnnotatedActiveInvites))
 
 	annMember := findMember(ann, details.Members.Owners)
 	require.NotNil(t, annMember)
@@ -110,6 +109,7 @@ func TestTeamList(t *testing.T) {
 	require.True(t, edMember.Active)
 	require.True(t, edMember.NeedsPUK)
 
+	require.Equal(t, 1, len(details.AnnotatedActiveInvites))
 	for _, invite := range details.AnnotatedActiveInvites {
 		// There should be only one invite
 		require.EqualValues(t, rootername, invite.Name)

--- a/go/systests/team_list_test.go
+++ b/go/systests/team_list_test.go
@@ -1,0 +1,122 @@
+package systests
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func findMember(user *smuUser, members []keybase1.TeamMemberDetails) *keybase1.TeamMemberDetails {
+	for _, member := range members {
+		if member.Username == user.username {
+			return &member
+		}
+	}
+	return nil
+}
+
+func TestTeamList(t *testing.T) {
+	ctx := newSMUContext(t)
+	defer ctx.cleanup()
+
+	ann := ctx.installKeybaseForUser("ann", 10)
+	ann.signup()
+	t.Logf("Signed up ann (%s)", ann.username)
+
+	bob := ctx.installKeybaseForUser("bob", 10)
+	bob.signup()
+	t.Logf("Signed up bob (%s)", bob.username)
+
+	pam := ctx.installKeybaseForUser("pam", 10)
+	pam.signup()
+	t.Logf("Signed up pam (%s)", pam.username)
+
+	john := ctx.installKeybaseForUser("john", 10)
+	john.signupNoPUK()
+	t.Logf("Signed up PUK-less user john (%s)", john.username)
+
+	ed := ctx.installKeybaseForUser("ed", 10)
+	ed.signup()
+	ed.reset()
+	ed.loginAfterResetNoPUK(10)
+	t.Logf("Signed up ed (%s), reset, and reprovisioned without PUK", ed.username)
+
+	team := ann.createTeam([]*smuUser{bob, pam})
+	t.Logf("Team created (%s)", team.name)
+
+	pam.reset()
+	t.Logf("Pam resets (%s)", pam.username)
+
+	ann.addWriter(team, john)
+	t.Logf("Adding john (%s)", john.username)
+
+	ann.addWriter(team, ed)
+	t.Logf("Adding ed (%s)", ed.username)
+
+	teamCli := ann.getTeamsClient()
+
+	rootername := randomUser("arbitrary").username
+	_, err := teamCli.TeamAddMember(context.TODO(), keybase1.TeamAddMemberArg{
+		Name:     team.name,
+		Username: rootername + "@rooter",
+		Role:     keybase1.TeamRole_WRITER,
+	})
+	require.NoError(t, err)
+
+	t.Logf("Added rooter (%s@rooter)", rootername)
+
+	details, err := teamCli.TeamGet(context.TODO(), keybase1.TeamGetArg{
+		Name:        team.name,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(details.Members.Owners))
+	require.Equal(t, 0, len(details.Members.Admins))
+	require.Equal(t, 4, len(details.Members.Writers))
+	require.Equal(t, 0, len(details.Members.Readers))
+	require.Equal(t, 1, len(details.AnnotatedActiveInvites))
+
+	annMember := findMember(ann, details.Members.Owners)
+	require.NotNil(t, annMember)
+	require.True(t, annMember.Active)
+	require.False(t, annMember.NeedsPUK)
+
+	bobMember := findMember(bob, details.Members.Writers)
+	require.NotNil(t, bobMember)
+	require.True(t, bobMember.Active)
+	require.False(t, bobMember.NeedsPUK)
+
+	pamMember := findMember(pam, details.Members.Writers)
+	require.NotNil(t, pamMember)
+	require.False(t, pamMember.Active)
+	require.False(t, pamMember.NeedsPUK)
+
+	johnMember := findMember(john, details.Members.Writers)
+	require.NotNil(t, johnMember)
+	require.True(t, johnMember.Active)
+	require.True(t, johnMember.NeedsPUK)
+
+	edMember := findMember(ed, details.Members.Writers)
+	require.NotNil(t, edMember)
+	require.True(t, edMember.Active)
+	require.True(t, edMember.NeedsPUK)
+
+	for _, invite := range details.AnnotatedActiveInvites {
+		// There should be only one invite
+		require.EqualValues(t, rootername, invite.Name)
+	}
+
+	list, err := teamCli.TeamList(context.TODO(), keybase1.TeamListArg{})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(list.Teams))
+	require.Equal(t, 0, len(list.AnnotatedActiveInvites))
+
+	teamInfo := list.Teams[0]
+	require.Equal(t, team.name, teamInfo.FqName)
+	require.Equal(t, 5, teamInfo.MemberCount)
+}

--- a/go/systests/team_list_test.go
+++ b/go/systests/team_list_test.go
@@ -134,12 +134,13 @@ func TestTeamDuplicateUIDList(t *testing.T) {
 	ctx := newSMUContext(t)
 	defer ctx.cleanup()
 
-	ann := makeUserStandalone(t, "ann", standaloneUserArgs{
-		disableGregor:            true,
-		suppressTeamChatAnnounce: true,
-	})
-	tt.users = append(tt.users, ann)
+	ann := tt.addUser("ann")
 	t.Logf("Signed up ann (%s)", ann.username)
+
+	// We have to disable caching in UIDMapper because after bob
+	// resets and provisions, we have no way to be aware of that, and
+	// we might see cached bob in subsequent teamList calls.
+	ann.tc.G.UIDMapper.SetTestingNoCachingMode(true)
 
 	bob := tt.addPuklessUser("bob")
 	t.Logf("Signed up PUK-less user bob (%s)", bob.username)

--- a/go/systests/team_list_test.go
+++ b/go/systests/team_list_test.go
@@ -22,6 +22,9 @@ func TestTeamList(t *testing.T) {
 	ctx := newSMUContext(t)
 	defer ctx.cleanup()
 
+	// Step 1 - create the initial team with mix of normal members,
+	// reset members, pukless users, social invites etc.
+
 	ann := ctx.installKeybaseForUser("ann", 10)
 	ann.signup()
 	t.Logf("Signed up ann (%s)", ann.username)
@@ -68,6 +71,8 @@ func TestTeamList(t *testing.T) {
 
 	t.Logf("Added rooter (%s@rooter)", rootername)
 
+	// Examine results from TeamGet
+
 	details, err := teamCli.TeamGet(context.TODO(), keybase1.TeamGetArg{
 		Name:        team.name,
 		ForceRepoll: true,
@@ -109,6 +114,8 @@ func TestTeamList(t *testing.T) {
 		// There should be only one invite
 		require.EqualValues(t, rootername, invite.Name)
 	}
+
+	// Examine results from TeamList (mostly MemberCount)
 
 	list, err := teamCli.TeamList(context.TODO(), keybase1.TeamListArg{})
 	require.NoError(t, err)

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -3,7 +3,6 @@ package teams
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -215,12 +214,17 @@ func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamLis
 			continue
 		}
 
-		for _, uv := range members.AllUserVersions() {
-			membersForTeams = append(membersForTeams, pendingTeamMember{
-				team: team.ID,
-				uv:   uv,
-			})
-		}
+		// See "TODO" after this for-loop.
+		/*
+			for _, uv := range members.AllUserVersions() {
+				membersForTeams = append(membersForTeams, pendingTeamMember{
+					team: team.ID,
+					uv:   uv,
+				})
+			}
+		*/
+
+		anMemberInfo.MemberCount = len(members.AllUIDs())
 
 		invites := team.chain().inner.ActiveInvites
 		for invID, invite := range invites {
@@ -231,16 +235,20 @@ func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamLis
 			}
 
 			if category == keybase1.TeamInviteCategory_KEYBASE {
-				uv, err := invite.KeybaseUserVersion()
+				_, err := invite.KeybaseUserVersion()
 				if err != nil {
 					g.Log.CDebugf(ctx, "| Failed parsing invite %q in team %q: %v", invID, team.ID, err)
 					continue
 				}
 
-				membersForTeams = append(membersForTeams, pendingTeamMember{
-					team: team.ID,
-					uv:   uv,
-				})
+				anMemberInfo.MemberCount++
+
+				/*
+					membersForTeams = append(membersForTeams, pendingTeamMember{
+						team: team.ID,
+						uv:   uv,
+					})
+				*/
 			}
 		}
 
@@ -255,25 +263,32 @@ func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamLis
 		uids = append(uids, member.uv.Uid)
 	}
 
-	namePkgs, err := uidmap.MapUIDsReturnMap(g.UIDMapper, ctx, g, uids, 0, 10*time.Second, true)
-	if err != nil {
-		g.Log.CWarningf(ctx, "| Unable to verify team members - member counts were not loaded: %v", err)
-		return res, nil
-	}
-
-	for _, member := range membersForTeams {
-		pkg := namePkgs[member.uv.Uid]
-		var memberReset bool
-		if pkg.FullName != nil && pkg.FullName.EldestSeqno != member.uv.EldestSeqno {
-			memberReset = true
+	// TODO: For now, we decided that reset-user members still count
+	// towards final team member count. If we want to change this
+	// decision, commented out is code to check members with UIDMapper
+	// and only count non-reset members as well as non-reset pukless
+	// members.
+	/*
+		namePkgs, err := uidmap.MapUIDsReturnMap(g.UIDMapper, ctx, g, uids, 0, 10*time.Second, true)
+		if err != nil {
+			g.Log.CWarningf(ctx, "| Unable to verify team members - member counts were not loaded: %v", err)
+			return res, nil
 		}
 
-		if !memberReset {
-			if i, ok := teamPositionInList[member.team]; ok {
-				res.Teams[i].MemberCount++
+		for _, member := range membersForTeams {
+			pkg := namePkgs[member.uv.Uid]
+			var memberReset bool
+			if pkg.FullName != nil && pkg.FullName.EldestSeqno != member.uv.EldestSeqno {
+				memberReset = true
+			}
+
+			if !memberReset {
+				if i, ok := teamPositionInList[member.team]; ok {
+					res.Teams[i].MemberCount++
+				}
 			}
 		}
-	}
+	*/
 
 	if len(res.Teams) == 0 && !expectEmptyList {
 		return res, fmt.Errorf("multiple errors while loading team list")

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -274,7 +274,7 @@ func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamLis
 	// and only count non-reset members as well as non-reset pukless
 	// members.
 	/*
-		namePkgs, err := uidmap.MapUIDsReturnMap(g.UIDMapper, ctx, g, uids, 0, 10*time.Second, true)
+		namePkgs, err := uidmap.MapUIDsReturnMap(ctx, g.UIDMapper, g, uids, 0, 10*time.Second, true)
 		if err != nil {
 			g.Log.CWarningf(ctx, "| Unable to verify team members - member counts were not loaded: %v", err)
 			return res, nil
@@ -379,7 +379,7 @@ func ListAll(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListA
 		uids = append(uids, invite.Inviter.Uid)
 	}
 
-	namePkgs, err := uidmap.MapUIDsReturnMap(g.UIDMapper, ctx, g, uids, 0, 0, true)
+	namePkgs, err := uidmap.MapUIDsReturnMap(ctx, g.UIDMapper, g, uids, 0, 0, true)
 	if err != nil {
 		g.Log.CWarningf(ctx, "| Unable to load team members, uidmap returned: %v", err)
 		return res, nil

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -515,6 +515,7 @@ func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, team *Team) (m
 			return nil, err
 		}
 		var uv keybase1.UserVersion
+		var active = true
 		if category == keybase1.TeamInviteCategory_KEYBASE {
 			// "keybase" invites (i.e. pukless users) have user version for name
 			var err error
@@ -527,7 +528,7 @@ func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, team *Team) (m
 				return nil, err
 			}
 			if uv.EldestSeqno != up.EldestSeqno {
-				continue
+				active = false
 			}
 			name = keybase1.TeamInviteName(up.Username)
 		} else if category == keybase1.TeamInviteCategory_SEITAN {
@@ -546,6 +547,7 @@ func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, team *Team) (m
 			Inviter:         invite.Inviter,
 			InviterUsername: username.String(),
 			TeamName:        teamName,
+			UserActive:      active,
 		}
 	}
 	return annotatedInvites, nil

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -506,20 +506,14 @@ func TestMemberAddEmailBulk(t *testing.T) {
 }
 
 func TestMemberListInviteUsername(t *testing.T) {
-	tc, _, name := memberSetup(t)
+	tc, user, name := memberSetup(t)
 	defer tc.Cleanup()
 
 	username := "t_ellen"
 	res, err := AddMember(context.TODO(), tc.G, name, username, keybase1.TeamRole_READER)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !res.Invited {
-		t.Fatal("res.Invited should be set")
-	}
-	if res.User.Username != username {
-		t.Errorf("AddMember result username %q does not match arg username %q", res.User.Username, username)
-	}
+	require.NoError(t, err)
+	require.True(t, res.Invited)
+	require.Equal(t, username, res.User.Username)
 
 	// List can return stale results for invites, so do a force load of the team to refresh the cache.
 	// In the real world, hopefully gregor would cause this.
@@ -529,20 +523,20 @@ func TestMemberListInviteUsername(t *testing.T) {
 	})
 
 	annotatedTeamList, err := List(context.TODO(), tc.G, keybase1.TeamListArg{UserAssertion: "", All: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(annotatedTeamList.AnnotatedActiveInvites) != 1 {
-		t.Fatalf("active invites: %d, expected 1", len(annotatedTeamList.AnnotatedActiveInvites))
-	}
-	for _, invite := range annotatedTeamList.AnnotatedActiveInvites {
-		if invite.TeamName != name {
-			t.Errorf("invite team name: %q, expected %q", invite.TeamName, name)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(annotatedTeamList.AnnotatedActiveInvites))
+	require.Equal(t, 2, len(annotatedTeamList.Teams))
+
+	var foundMember bool
+	for _, member := range annotatedTeamList.Teams {
+		require.Equal(t, name, member.FqName)
+		if member.Username == username {
+			foundMember = true
+		} else if member.Username != user.Username {
+			t.Fatalf("Unexpected member name %s", member.Username)
 		}
-		if string(invite.Name) != username {
-			t.Errorf("invite username: %q, expected %q", invite.Name, username)
-		}
 	}
+	require.True(t, foundMember)
 }
 
 func TestMemberAddAsImplicitAdmin(t *testing.T) {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -90,7 +90,7 @@ func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepo
 		details := keybase1.TeamMemberDetails{
 			Uv:       invite.Uv,
 			Username: string(invite.Name),
-			Active:   true,
+			Active:   invite.UserActive,
 			NeedsPUK: true,
 		}
 		switch invite.Role {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -205,6 +205,10 @@ func (t *Team) ImplicitTeamDisplayName(ctx context.Context) (res keybase1.Implic
 			// this should never happen
 			return res, fmt.Errorf("missing invite: %v", inviteID)
 		}
+		if !invite.UserActive {
+			// Active invite for inactive member, e.g. keybase-type invite for reset user.
+			continue
+		}
 		invtyp, err := invite.Type.C()
 		if err != nil {
 			continue

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -397,14 +397,14 @@ func (u *UIDMap) ClearUIDAtEldestSeqno(ctx context.Context, g libkb.UIDMapperCon
 	return nil
 }
 
-func MapUIDsReturnMap(u libkb.UIDMapper, ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networkTimeBudget time.Duration, forceNetworkForFullNames bool) (res map[keybase1.UID]libkb.UsernamePackage, err error) {
+func MapUIDsReturnMap(ctx context.Context, u libkb.UIDMapper, g libkb.UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networkTimeBudget time.Duration, forceNetworkForFullNames bool) (res map[keybase1.UID]libkb.UsernamePackage, err error) {
 	var uidList []keybase1.UID
-	uidSet := map[keybase1.UID]int{}
+	uidSet := map[keybase1.UID]bool{}
 
 	for _, uid := range uids {
 		_, found := uidSet[uid]
 		if !found {
-			uidSet[uid] = len(uidList)
+			uidSet[uid] = true
 			uidList = append(uidList, uid)
 		}
 	}

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -410,7 +410,7 @@ func MapUIDsReturnMap(ctx context.Context, u libkb.UIDMapper, g libkb.UIDMapperC
 	}
 
 	resultList, err := u.MapUIDsToUsernamePackages(ctx, g, uidList, fullNameFreshness, networkTimeBudget, forceNetworkForFullNames)
-	if err != nil {
+	if err != nil && len(resultList) != len(uidList) {
 		return res, err
 	}
 
@@ -418,7 +418,7 @@ func MapUIDsReturnMap(ctx context.Context, u libkb.UIDMapper, g libkb.UIDMapperC
 	for i, uid := range uidList {
 		res[uid] = resultList[i]
 	}
-	return res, nil
+	return res, err
 }
 
 var _ libkb.UIDMapper = (*UIDMap)(nil)

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -397,6 +397,30 @@ func (u *UIDMap) ClearUIDAtEldestSeqno(ctx context.Context, g libkb.UIDMapperCon
 	return nil
 }
 
+func MapUIDsReturnMap(u libkb.UIDMapper, ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networkTimeBudget time.Duration, forceNetworkForFullNames bool) (res map[keybase1.UID]libkb.UsernamePackage, err error) {
+	var uidList []keybase1.UID
+	uidSet := map[keybase1.UID]int{}
+
+	for _, uid := range uids {
+		_, found := uidSet[uid]
+		if !found {
+			uidSet[uid] = len(uidList)
+			uidList = append(uidList, uid)
+		}
+	}
+
+	resultList, err := u.MapUIDsToUsernamePackages(ctx, g, uidList, fullNameFreshness, networkTimeBudget, forceNetworkForFullNames)
+	if err != nil {
+		return res, err
+	}
+
+	res = make(map[keybase1.UID]libkb.UsernamePackage)
+	for i, uid := range uidList {
+		res[uid] = resultList[i]
+	}
+	return res, nil
+}
+
 var _ libkb.UIDMapper = (*UIDMap)(nil)
 
 type OfflineUIDMap struct{}

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -198,6 +198,7 @@ protocol teams {
     UserVersion inviter;
     string inviterUsername;
     string teamName;
+    boolean userActive;
   }
 
   // State of a parsed team sigchain.

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -497,6 +497,9 @@ protocol teams {
     boolean needsPUK;
     @jsonkey("member_count")
     int memberCount;
+    @jsonkey("member_eldest_seqno")
+    Seqno eldestSeqno;
+    boolean active;
   }
 
   record AnnotatedTeamList {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1801,7 +1801,7 @@ export type AccountResetAccountRpcParam = ?{|incomingCallMap?: IncomingCallMapTy
 
 export type AnnotatedMemberInfo = {|userID: UID,teamID: TeamID,username: String,fullName: String,fqName: String,isImplicitTeam: Boolean,role: TeamRole,implicit?: ?ImplicitRole,needsPUK: Boolean,memberCount: Int,eldestSeqno: Seqno,active: Boolean,|}
 
-export type AnnotatedTeamInvite = {|role: TeamRole,id: TeamInviteID,type: TeamInviteType,name: TeamInviteName,uv: UserVersion,inviter: UserVersion,inviterUsername: String,teamName: String,|}
+export type AnnotatedTeamInvite = {|role: TeamRole,id: TeamInviteID,type: TeamInviteType,name: TeamInviteName,uv: UserVersion,inviter: UserVersion,inviterUsername: String,teamName: String,userActive: Boolean,|}
 
 export type AnnotatedTeamList = {|teams?: ?Array<AnnotatedMemberInfo>,annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite},|}
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1799,7 +1799,7 @@ export type AccountPassphrasePromptRpcParam = {|guiArg: GUIEntryArg,incomingCall
 
 export type AccountResetAccountRpcParam = ?{|incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 
-export type AnnotatedMemberInfo = {|userID: UID,teamID: TeamID,username: String,fullName: String,fqName: String,isImplicitTeam: Boolean,role: TeamRole,implicit?: ?ImplicitRole,needsPUK: Boolean,memberCount: Int,|}
+export type AnnotatedMemberInfo = {|userID: UID,teamID: TeamID,username: String,fullName: String,fqName: String,isImplicitTeam: Boolean,role: TeamRole,implicit?: ?ImplicitRole,needsPUK: Boolean,memberCount: Int,eldestSeqno: Seqno,active: Boolean,|}
 
 export type AnnotatedTeamInvite = {|role: TeamRole,id: TeamInviteID,type: TeamInviteType,name: TeamInviteName,uv: UserVersion,inviter: UserVersion,inviterUsername: String,teamName: String,|}
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1227,6 +1227,15 @@
           "type": "int",
           "name": "memberCount",
           "jsonkey": "member_count"
+        },
+        {
+          "type": "Seqno",
+          "name": "eldestSeqno",
+          "jsonkey": "member_eldest_seqno"
+        },
+        {
+          "type": "boolean",
+          "name": "active"
         }
       ]
     },

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -544,6 +544,10 @@
         {
           "type": "string",
           "name": "teamName"
+        },
+        {
+          "type": "boolean",
+          "name": "userActive"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1801,7 +1801,7 @@ export type AccountResetAccountRpcParam = ?{|incomingCallMap?: IncomingCallMapTy
 
 export type AnnotatedMemberInfo = {|userID: UID,teamID: TeamID,username: String,fullName: String,fqName: String,isImplicitTeam: Boolean,role: TeamRole,implicit?: ?ImplicitRole,needsPUK: Boolean,memberCount: Int,eldestSeqno: Seqno,active: Boolean,|}
 
-export type AnnotatedTeamInvite = {|role: TeamRole,id: TeamInviteID,type: TeamInviteType,name: TeamInviteName,uv: UserVersion,inviter: UserVersion,inviterUsername: String,teamName: String,|}
+export type AnnotatedTeamInvite = {|role: TeamRole,id: TeamInviteID,type: TeamInviteType,name: TeamInviteName,uv: UserVersion,inviter: UserVersion,inviterUsername: String,teamName: String,userActive: Boolean,|}
 
 export type AnnotatedTeamList = {|teams?: ?Array<AnnotatedMemberInfo>,annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite},|}
 

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1799,7 +1799,7 @@ export type AccountPassphrasePromptRpcParam = {|guiArg: GUIEntryArg,incomingCall
 
 export type AccountResetAccountRpcParam = ?{|incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 
-export type AnnotatedMemberInfo = {|userID: UID,teamID: TeamID,username: String,fullName: String,fqName: String,isImplicitTeam: Boolean,role: TeamRole,implicit?: ?ImplicitRole,needsPUK: Boolean,memberCount: Int,|}
+export type AnnotatedMemberInfo = {|userID: UID,teamID: TeamID,username: String,fullName: String,fqName: String,isImplicitTeam: Boolean,role: TeamRole,implicit?: ?ImplicitRole,needsPUK: Boolean,memberCount: Int,eldestSeqno: Seqno,active: Boolean,|}
 
 export type AnnotatedTeamInvite = {|role: TeamRole,id: TeamInviteID,type: TeamInviteType,name: TeamInviteName,uv: UserVersion,inviter: UserVersion,inviterUsername: String,teamName: String,|}
 


### PR DESCRIPTION
List code did not end up being very compact, but I think it's simpler right now and more correct. Member counting for `keybase team list-members` emulates what frontend is doing, which is only considering unique usernames - we count unique UIDs on our end. Inactive members are also counted.

Most of the optimisation lies in UIDMapper usage. It aims to gather all UIDs and make only one UIDMapper request per call.