### PR TITLE
Desktop: inbox menu

### DIFF
--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -4,6 +4,7 @@ import * as More from '../../constants/types/more'
 import * as Types from '../../constants/types/chat'
 import * as Inbox from '.'
 import * as ChatGen from '../../actions/chat-gen'
+import {getTeams} from '../../actions/teams/creators'
 import * as I from 'immutable'
 import {
   pausableConnect,
@@ -227,6 +228,7 @@ const mapStateToProps = (state: TypedState, {isActiveRoute, routeState}: OwnProp
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {focusFilter, routeState, setRouteState}: OwnProps) => ({
+  getTeams: () => dispatch(getTeams()),
   loadInbox: () => dispatch(ChatGen.createLoadInbox()),
   _onSelectNext: (rows: Array<Inbox.RowItemSmall | Inbox.RowItemBig>, direction: -1 | 1) =>
     dispatch(
@@ -257,10 +259,11 @@ const mergeProps = (
 ) => {
   return {
     filter: stateProps.filter,
+    getTeams: dispatchProps.getTeams,
     isActiveRoute: stateProps.isActiveRoute,
     isLoading: stateProps.isLoading,
-    neverLoaded: stateProps.neverLoaded,
     loadInbox: dispatchProps.loadInbox,
+    neverLoaded: stateProps.neverLoaded,
     _user: stateProps._user,
     onHotkey: dispatchProps.onHotkey,
     onNewChat: dispatchProps.onNewChat,
@@ -290,6 +293,8 @@ export default compose(
     componentDidMount: function() {
       if (this.props.neverLoaded) {
         this.props.loadInbox()
+        // Get team counts for team headers in the inbox
+        this.props.getTeams()
       }
     },
   })

--- a/shared/chat/inbox/row/big-team-header/container.js
+++ b/shared/chat/inbox/row/big-team-header/container.js
@@ -1,24 +1,36 @@
 // @flow
-import {pausableConnect, type TypedState} from '../../../../util/container'
+import {compose, pausableConnect, withState, type TypedState} from '../../../../util/container'
+import * as I from 'immutable'
 import {BigTeamHeader} from '.'
 // Typically you'd use the navigateAppend from the routeable component but this is a child* of that
 // and I'd prefer not to plumb through anything that could cause render thrashing so using the
 // global one here
-import {navigateAppend} from '../../../../actions/route-tree'
+import {navigateAppend, navigateTo} from '../../../../actions/route-tree'
+import {teamsTab} from '../../../../constants/tabs'
 
-const mapStateToProps = (state: TypedState, {teamname, isActiveRoute}) => {
-  return {isActiveRoute, teamname}
-}
+const mapStateToProps = (state: TypedState, {teamname, isActiveRoute}) => ({
+  _teammembercounts: state.entities.getIn(['teams', 'teammembercounts'], I.Map()),
+  isActiveRoute,
+  teamname,
+})
 
 const mapDispatchToProps = dispatch => ({
-  _onShowMenu: (teamname: string) =>
+  _onManageChannels: (teamname: string) =>
     dispatch(navigateAppend([{props: {teamname}, selected: 'manageChannels'}])),
+  _onViewTeam: (teamname: string) => dispatch(navigateTo([teamsTab, {props: {teamname}, selected: 'team'}])),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   isActiveRoute: stateProps.isActiveRoute,
-  onShowMenu: () => dispatchProps._onShowMenu(stateProps.teamname),
+  memberCount: stateProps._teammembercounts.get(stateProps.teamname),
+  onManageChannels: () => dispatchProps._onManageChannels(stateProps.teamname),
+  onSetShowMenu: ownProps.onSetShowMenu,
+  onViewTeam: () => dispatchProps._onViewTeam(stateProps.teamname),
+  showMenu: ownProps.showMenu,
   teamname: stateProps.teamname,
 })
 
-export default pausableConnect(mapStateToProps, mapDispatchToProps, mergeProps)(BigTeamHeader)
+export default compose(
+  withState('showMenu', 'onSetShowMenu', false),
+  pausableConnect(mapStateToProps, mapDispatchToProps, mergeProps)
+)(BigTeamHeader)

--- a/shared/chat/inbox/row/big-team-header/index.js
+++ b/shared/chat/inbox/row/big-team-header/index.js
@@ -38,11 +38,12 @@ class BigTeamHeader extends React.PureComponent<Props, State> {
           type="iconfont-gear"
           onClick={e => {
             if (!isMobile) {
+              // $FlowIssue doesn't know about getBoundingClientRect
               const {top} = e.currentTarget.getBoundingClientRect()
               this.setState({popTop: top})
               props.onSetShowMenu(true)
             } else {
-              props.onManageChannels(props.teamname)
+              props.onManageChannels()
             }
           }}
           style={iconStyle}

--- a/shared/chat/inbox/row/big-team-header/index.js
+++ b/shared/chat/inbox/row/big-team-header/index.js
@@ -40,8 +40,10 @@ class BigTeamHeader extends React.PureComponent<Props, State> {
             if (!isMobile) {
               const {top} = e.currentTarget.getBoundingClientRect()
               this.setState({popTop: top})
+              props.onSetShowMenu(true)
+            } else {
+              props.onManageChannels(props.teamname)
             }
-            props.onSetShowMenu(true)
           }}
           style={iconStyle}
         />

--- a/shared/chat/inbox/row/big-team-header/index.js
+++ b/shared/chat/inbox/row/big-team-header/index.js
@@ -1,21 +1,79 @@
 // @flow
-import React, {PureComponent} from 'react'
-import {Avatar, Box, Text, Icon} from '../../../../common-adapters'
+import React from 'react'
+import {Avatar, Box, Text, Icon, PopupMenu} from '../../../../common-adapters'
 import {globalStyles, globalColors, globalMargins, glamorous} from '../../../../styles'
 import {isMobile} from '../../../../constants/platform'
 
 type Props = {
+  memberCount: number,
+  onManageChannels: () => void,
+  onSetShowMenu: boolean => void,
+  onViewTeam: () => void,
+  showMenu: boolean,
   teamname: string,
-  onShowMenu: () => void,
 }
 
-class BigTeamHeader extends PureComponent<Props> {
+const zIndexMenu = 20
+
+type State = {
+  popTop: ?number,
+}
+
+class BigTeamHeader extends React.PureComponent<Props, State> {
+  state = {
+    popTop: null,
+  }
+
   render() {
+    const props = this.props
+
     return (
       <HeaderBox>
-        <Avatar teamname={this.props.teamname} size={isMobile ? 24 : 16} />
-        <Text type="BodySmallSemibold" style={teamStyle}>{this.props.teamname}</Text>
-        <Icon className="icon" type="iconfont-gear" onClick={this.props.onShowMenu} style={iconStyle} />
+        <Avatar teamname={props.teamname} size={isMobile ? 24 : 16} />
+        <Text type="BodySmallSemibold" style={teamStyle}>
+          {props.teamname}
+        </Text>
+        <Icon
+          className="icon"
+          type="iconfont-gear"
+          onClick={e => {
+            if (!isMobile) {
+              const {top} = e.currentTarget.getBoundingClientRect()
+              this.setState({popTop: top})
+            }
+            props.onSetShowMenu(true)
+          }}
+          style={iconStyle}
+        />
+        {props.showMenu &&
+          <PopupMenu
+            header={{
+              title: 'Header',
+              view: (
+                <Box style={teamHeaderStyle}>
+                  <Avatar teamname={props.teamname} size={16} />
+                  <Text type="BodySmallSemibold" style={teamStyle}>{props.teamname}</Text>
+                  <Text type="BodySmall">
+                    {props.memberCount + ' member' + (props.memberCount !== 1 ? 's' : '')}
+                  </Text>
+                </Box>
+              ),
+            }}
+            items={[
+              {onClick: props.onManageChannels, title: 'Manage chat channels'},
+              {onClick: props.onViewTeam, title: 'View team'},
+            ]}
+            onHidden={() => props.onSetShowMenu(false)}
+            style={{
+              position: isMobile ? 'relative' : 'absolute',
+              right: globalMargins.tiny,
+              top: isMobile ? globalMargins.small : this.state.popTop,
+              zIndex: zIndexMenu,
+            }}
+            styleCatcher={{
+              zIndex: 1,
+            }}
+          />}
       </HeaderBox>
     )
   }
@@ -31,6 +89,13 @@ const iconStyle = {
     : {
         hoverColor: globalColors.black_75,
       }),
+}
+
+const teamHeaderStyle = {
+  ...globalStyles.flexBoxColumn,
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: globalMargins.tiny,
 }
 
 const teamRowContainerStyle = {
@@ -60,7 +125,7 @@ const HeaderBox = glamorous(Box)({
 
 const teamStyle = {
   color: globalColors.darkBlue,
-  flex: 1,
+  flexGrow: 1,
   marginLeft: globalMargins.tiny,
   marginRight: globalMargins.tiny,
 }

--- a/shared/chat/inbox/row/index.stories.js
+++ b/shared/chat/inbox/row/index.stories.js
@@ -76,7 +76,14 @@ const load = () => {
     ))
     .add('Team', () => (
       <Box style={{borderColor: 'black', borderStyle: 'solid', borderWidth: 1, width: 240}}>
-        <BigTeamHeader teamname="Keybase" onShowMenu={action('onShowHeader')} />
+        <BigTeamHeader
+          memberCount={30}
+          onManageChannels={action('onManageChannels')}
+          onSetShowMenu={action('onSetShowMenu')}
+          onViewTeam={action('onViewTeam')}
+          showMenu={false}
+          teamname="Keybase"
+        />
         <BigTeamChannel teamname="Keybase" channelname="#general" {...commonChannel} />
         <BigTeamChannel teamname="Keybase" channelname="#random" showBold={true} {...commonChannel} />
         <BigTeamChannel
@@ -87,7 +94,14 @@ const load = () => {
           {...commonChannel}
         />
         <BigTeamChannel teamname="Keybase" channelname="#video-games" isMuted={true} {...commonChannel} />
-        <BigTeamHeader teamname="techtonica" onShowMenu={action('onShowHeader')} />
+        <BigTeamHeader
+          memberCount={30}
+          onManageChannels={action('onManageChannels')}
+          onSetShowMenu={action('onSetShowMenu')}
+          onViewTeam={action('onViewTeam')}
+          showMenu={false}
+          teamname="techtonica"
+        />
         <BigTeamChannel teamname="techtonica" channelname="#general" isSelected={true} {...commonChannel} />
         <BigTeamChannel teamname="techtonica" channelname="#ignore-selected-below" {...commonChannel} />
         <BigTeamChannel

--- a/shared/chat/inbox/row/team-info-menu/index.js
+++ b/shared/chat/inbox/row/team-info-menu/index.js
@@ -1,0 +1,59 @@
+// @flow
+import React from 'react'
+import {Avatar, Box, Text, PopupMenu} from '../../../../common-adapters'
+import {globalStyles, globalColors, globalMargins} from '../../../../styles'
+import {isMobile} from '../../../../constants/platform'
+
+type Props = {
+  memberCount: number,
+  onManageChannels: () => void,
+  onSetShowMenu: boolean => void,
+  onViewTeam: () => void,
+  teamname: string,
+}
+
+const zIndexMenu = 20
+
+const TeamInfoMenu = (props: Props) => (
+  <PopupMenu
+    header={{
+      title: 'Header',
+      view: (
+        <Box style={teamHeaderStyle}>
+          <Avatar teamname={props.teamname} size={16} />
+          <Text type="BodySmallSemibold" style={teamStyle}>{props.teamname}</Text>
+          <Text type="BodySmall">
+            {props.memberCount + ' member' + (props.memberCount !== 1 ? 's' : '')}
+          </Text>
+        </Box>
+      ),
+    }}
+    items={[
+      {onClick: props.onManageChannels, title: 'Manage chat channels'},
+      {onClick: props.onViewTeam, title: 'View team'},
+    ]}
+    onHidden={() => props.onSetShowMenu(false)}
+    style={{
+      position: isMobile ? 'relative' : 'absolute',
+      right: globalMargins.tiny,
+      top: globalMargins.small,
+      zIndex: zIndexMenu,
+    }}
+  />
+)
+
+const teamHeaderStyle = {
+  ...globalStyles.flexBoxColumn,
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: globalMargins.tiny,
+}
+
+const teamStyle = {
+  color: globalColors.darkBlue,
+  flexGrow: 1,
+  marginLeft: globalMargins.tiny,
+  marginRight: globalMargins.tiny,
+}
+
+export {TeamInfoMenu}

--- a/shared/common-adapters/popup-menu.desktop.js
+++ b/shared/common-adapters/popup-menu.desktop.js
@@ -21,7 +21,7 @@ class PopupMenu extends Component<Props> {
     return (
       <EscapeHandler onESC={this.props.onHidden}>
         <Box
-          style={stylesMenuCatcher}
+          style={{...stylesMenuCatcher, ...this.props.styleCatcher}}
           onClick={e => {
             this.props.onHidden()
             e.stopPropagation()

--- a/shared/common-adapters/popup-menu.js.flow
+++ b/shared/common-adapters/popup-menu.js.flow
@@ -24,6 +24,7 @@ export type HeaderTextProps = {
   backgroundColor: string,
   style?: Object,
   children?: React.Node,
+  styleCatcher?: ?Object
 }
 
 class PopupHeaderText extends React.Component<HeaderTextProps> {}

--- a/shared/common-adapters/popup-menu.js.flow
+++ b/shared/common-adapters/popup-menu.js.flow
@@ -17,6 +17,7 @@ export type Props = {
   header?: ?MenuItem,
   onHidden: () => void,
   style?: Object,
+  styleCatcher?: ?Object,
 }
 
 export type HeaderTextProps = {
@@ -24,7 +25,6 @@ export type HeaderTextProps = {
   backgroundColor: string,
   style?: Object,
   children?: React.Node,
-  styleCatcher?: ?Object
 }
 
 class PopupHeaderText extends React.Component<HeaderTextProps> {}


### PR DESCRIPTION
@keybase/react-hackers 

Here's a rebase of #9319: that PR had been sitting open because we didn't have a satisfying way of doing in-place popups on desktop and mobile.  We still don't -- might as well merge this for desktop-only for now though, since that's where it's most useful.

Screenshot:

<img width="316" alt="screen shot 2017-11-27 at 6 42 01 pm" src="https://user-images.githubusercontent.com/21217/33299950-c8b9dbd8-d3a2-11e7-9da3-66a421c30640.png">
