### PR TITLE
Refactor team refresh logic

### DIFF
--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -737,7 +737,7 @@ function* _badgeAppForTeams(action: Types.BadgeAppForTeams) {
   const existingNewTeamRequests = yield Saga.select((state: TypedState) =>
     state.entities.getIn(['teams', 'newTeamRequests'], I.List())
   )
-  if (!newTeams.equals(existingNewTeams) || !newTeams.equals(existingNewTeamRequests)) {
+  if (!newTeams.equals(existingNewTeams)) {
     yield Saga.put(Creators.getTeams())
   }
 

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -646,17 +646,30 @@ function* _setupTeamHandlers(): Saga.SagaGenerator<any, any> {
     engine().setIncomingHandler(
       'keybase.1.NotifyTeam.teamChanged',
       (args: RPCTypes.NotifyTeamTeamChangedRpcParam) => {
-        dispatch(Creators.getDetails(args.teamName))
-        dispatch(Creators.getTeams())
+        const actions = getLoadCalls(args.teamName)
+        actions.forEach(action => dispatch(action))
       }
     )
     engine().setIncomingHandler('keybase.1.NotifyTeam.teamDeleted', () => {
-      dispatch(Creators.getTeams())
+      const actions = getLoadCalls()
+      actions.forEach(action => dispatch(action))
     })
     engine().setIncomingHandler('keybase.1.NotifyTeam.teamExit', () => {
-      dispatch(Creators.getTeams())
+      const actions = getLoadCalls()
+      actions.forEach(action => dispatch(action))
     })
   })
+}
+
+function getLoadCalls(teamname?: string) {
+  const actions = []
+  if (_wasOnTeamsTab) {
+    actions.push(Creators.getTeams())
+    if (teamname) {
+      actions.push(Creators.getDetails(teamname))
+    }
+  }
+  return actions
 }
 
 function _updateTopic({payload: {conversationIDKey, newTopic}}: Types.UpdateTopic, state: TypedState) {

--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -647,16 +647,16 @@ function* _setupTeamHandlers(): Saga.SagaGenerator<any, any> {
       'keybase.1.NotifyTeam.teamChanged',
       (args: RPCTypes.NotifyTeamTeamChangedRpcParam) => {
         const actions = getLoadCalls(args.teamName)
-        actions.forEach(action => dispatch(action))
+        actions.forEach(dispatch)
       }
     )
     engine().setIncomingHandler('keybase.1.NotifyTeam.teamDeleted', () => {
       const actions = getLoadCalls()
-      actions.forEach(action => dispatch(action))
+      actions.forEach(dispatch)
     })
     engine().setIncomingHandler('keybase.1.NotifyTeam.teamExit', () => {
       const actions = getLoadCalls()
-      actions.forEach(action => dispatch(action))
+      actions.forEach(dispatch)
     })
   })
 }


### PR DESCRIPTION
This removes the equality check for `newTeamRequests` as a condition for calling `getTeams`. There was a bug in the check, but also incoming team requests shouldn't be a cause for calling `teamList`.

This also adds a conditional to only call these loads (in `setupTeamHandlers` and `badgeAppForTeams`) if we're currently staring at the teams tab

r? @keybase/react-hackers 