### PR TITLE
give a long gregor reconnect backoff to devices that don't send chats

### DIFF
--- a/go/chat/active.go
+++ b/go/chat/active.go
@@ -1,0 +1,82 @@
+package chat
+
+import (
+	"context"
+	"time"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
+)
+
+// All devices are presumed active for the first 24 hours. See comment below.
+var InitialAssumedActiveInterval = 24 * time.Hour
+var ActiveIntervalAfterSend = 30 * 24 * time.Hour
+
+func chatActiveDBKey(name string) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatActive,
+		Key: name,
+	}
+}
+
+func firstQueryTimeDbKey() libkb.DbKey {
+	return chatActiveDBKey("first_query_time")
+}
+
+func lastSendTimeDbKey() libkb.DbKey {
+	return chatActiveDBKey("last_send_time")
+}
+
+// If no first query time is found in the local db, this function writes the
+// current time.
+func TouchFirstChatActiveQueryTime(ctx context.Context, g *globals.Context, log utils.DebugLabeler) time.Time {
+	now := time.Now()
+	var firstQueryUnixTime int64
+	found, err := g.LocalChatDb.GetInto(&firstQueryUnixTime, firstQueryTimeDbKey())
+	// Warn for errors and bail.
+	if err != nil {
+		log.Debug(ctx, "Failed to get chat active query time: %s", err)
+		return now
+	}
+	// If the first query time doesn't exist, store Now(). Don't return Now()
+	// directly, though, since that has extra metadata in it what won't be
+	// there when we deserialize from the db.
+	if !found {
+		log.Debug(ctx, "Chat active query time not found. Storing current time.")
+		firstQueryUnixTime = now.Unix()
+		err := g.LocalChatDb.PutObj(firstQueryTimeDbKey(), nil, firstQueryUnixTime)
+		if err != nil {
+			log.Debug(ctx, "Failed to store chat active query time: %s", err)
+		}
+	}
+	// Otherwise return what we found.
+	return time.Unix(firstQueryUnixTime, 0)
+}
+
+// Returns the zero time if there is no recorded last send time (either because
+// the device has never sent a message, or because it hasn't sent one since we
+// started recording).
+func GetLastSendTime(ctx context.Context, g *globals.Context, log utils.DebugLabeler) time.Time {
+	var zeroTime time.Time
+	var lastSendUnixTime int64
+	found, err := g.LocalChatDb.GetInto(&lastSendUnixTime, lastSendTimeDbKey())
+	// Warn for errors and return zero.
+	if err != nil {
+		log.Debug(ctx, "Failed to get chat active last send time: %s", err)
+		return zeroTime
+	}
+	// If the last time doesn't exist, again return zero.
+	if !found {
+		return zeroTime
+	}
+	// Otherwise return what we found.
+	return time.Unix(lastSendUnixTime, 0)
+}
+
+func RecordChatSend(ctx context.Context, g *globals.Context, log utils.DebugLabeler) {
+	err := g.LocalChatDb.PutObj(lastSendTimeDbKey(), nil, time.Now().Unix())
+	if err != nil {
+		log.Debug(ctx, "Failed to store chat last send time: %s", err)
+	}
+}

--- a/go/chat/active_test.go
+++ b/go/chat/active_test.go
@@ -1,0 +1,54 @@
+package chat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatActive(t *testing.T) {
+	ctx, world, _, _, _, _ := setupTest(t, 1)
+
+	u := world.GetUsers()[0]
+	tc := world.Tcs[u.Username]
+	defer tc.Cleanup()
+	g := globals.NewContext(tc.G, tc.ChatG)
+	log := utils.NewDebugLabeler(g.GetLog(), "TestChatActive", false)
+
+	// The first chat active query should store the current time. Use Unix
+	// times, because truncating seconds on only one half of the comparison
+	// throws everything off.
+	beforeTouch := time.Now().Unix()
+	touch := TouchFirstChatActiveQueryTime(ctx, g, log).Unix()
+	afterTouch := time.Now().Unix()
+	if touch < beforeTouch {
+		t.Fatalf("touch unexpectly early: %d < %d", touch, beforeTouch)
+	}
+	if touch > afterTouch {
+		t.Fatalf("touch unexpectly late: %d > %d", touch, afterTouch)
+	}
+
+	// Subsequent queries shouldn't change the first query time.
+	touchAgain := TouchFirstChatActiveQueryTime(ctx, g, log).Unix()
+	require.Equal(t, touch, touchAgain)
+
+	// Initially the last send time should be zero.
+	zeroLastSend := GetLastSendTime(ctx, g, log)
+	require.True(t, zeroLastSend.IsZero())
+
+	// Now do the same exercise with the last send time as we did with the
+	// first query time above.
+	beforeSend := time.Now().Unix()
+	RecordChatSend(ctx, g, log)
+	lastSend := GetLastSendTime(ctx, g, log).Unix()
+	afterSend := time.Now().Unix()
+	if lastSend < beforeSend {
+		t.Fatalf("send unexpectly early: %d < %d", lastSend, beforeSend)
+	}
+	if lastSend > afterSend {
+		t.Fatalf("send unexpectly late: %d > %d", lastSend, afterSend)
+	}
+}

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -490,6 +490,10 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	msg chat1.MessagePlaintext, clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (obid chat1.OutboxID, boxed *chat1.MessageBoxed, rl *chat1.RateLimit, err error) {
 	defer s.Trace(ctx, func() error { return err }, fmt.Sprintf("Send(%s)", convID))()
 
+	// Record that this user is "active in chat", which we use to determine
+	// gregor reconnect backoffs.
+	RecordChatSend(ctx, s.G(), s.DebugLabeler)
+
 	ri := s.getRi()
 	if ri == nil {
 		return chat1.OutboxID{}, nil, nil, fmt.Errorf("Send(): no remote client found")

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -183,6 +183,7 @@ const (
 	DBSigChainTailPublic       = 0xe7
 	DBSigChainTailSemiprivate  = 0xe8
 	DBSigChainTailEncrypted    = 0xe9
+	DBChatActive               = 0xea
 	DBMerkleRoot               = 0xf0
 	DBTrackers                 = 0xf1
 	DBGregor                   = 0xf2

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -284,10 +284,10 @@
 			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
-			"checksumSHA1": "ub85JBvVGqt8k0uYhH4n0JmeOaA=",
+			"checksumSHA1": "BdtHbEo/t/HE+WRJSaQzcZiwg/o=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "b123be5e037d718432cc16a4d37a972b2b4dddd7",
-			"revisionTime": "2017-12-05T16:34:57Z"
+			"revision": "c416da7cf9cfb85545098e346be6583a1649b0d5",
+			"revisionTime": "2017-12-06T17:53:16Z"
 		},
 		{
 			"checksumSHA1": "RLs8GIV4e+D350pyzZh5RC3mgQg=",


### PR DESCRIPTION
This should mitigate some of the reconnect flood that the gregor servers
    have to deal with when they restart. Most idle clients in the wild
    aren't participating in chat, and don't need to reconnect very
    aggressively.
    
There were a few different heuristics we could've used here, and others
    we might want to use in the future. One in particular we almost chose
    was "has this user ever received a message". However, we sometimes send
    system-wide messages, like when Linux updates are broken, which could
    confuse that heuristic. Chat sending is a surer sign of activity than
    receiving, and it also has the benefit of being
    individual-device-specific.
    
Two things had to change to make this work. First, we had to configure a
    chat-activity-based backoff (using a couple new keys in LevelDB).
    Second, we had to make sure that the backoff was respected on reconnect,
    which required the new ForceInitialBackoff ConnectionOpts parameter
    upstream, since we don't keep a persisitent Connection object after
    disconnects.