### PR TITLE
use os.Executable() in CurrentBinaryRealpath()

### DIFF
--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -756,11 +756,11 @@ func CanExec(p string) error {
 }
 
 func CurrentBinaryRealpath() (string, error) {
-	absolute, err := filepath.Abs(os.Args[0])
+	executable, err := os.Executable()
 	if err != nil {
 		return "", err
 	}
-	return filepath.EvalSymlinks(absolute)
+	return filepath.EvalSymlinks(executable)
 }
 
 var adminFeatureList = map[keybase1.UID]bool{


### PR DESCRIPTION
The former was added in Go 1.8, and I didn't realize it existed when I
wrote the latter. It correctly handles the case where the current
executable is running out of the $PATH, which previously confused us
because argv[0] isn't a valid filepath.

r? @mlsteele 