### PR TITLE
adjust "keybase search" social proof output syntax

### DIFF
--- a/go/client/cmd_search.go
+++ b/go/client/cmd_search.go
@@ -92,7 +92,7 @@ func (c *CmdSearch) showRegularResults(results []keybase1.UserSummary) error {
 	for _, user := range results {
 		GlobUI.Printf("%s", user.Username)
 		for _, social := range user.Proofs.Social {
-			GlobUI.Printf(" %s:%s", social.ProofType, social.ProofName)
+			GlobUI.Printf(" %s@%s", social.ProofName, social.ProofType)
 		}
 		for _, web := range user.Proofs.Web {
 			for _, protocol := range web.Protocols {


### PR DESCRIPTION
Adjust "keybase search" social proof output syntax to follow what seems to be the usual convention. 