### PR TITLE
use a reasonable default value instead of 0, especially since no caller ever passes this var

### DIFF
--- a/shared/actions/search.js
+++ b/shared/actions/search.js
@@ -232,7 +232,7 @@ function* searchSuggestions({payload: {maxUsers, searchKey}}: SearchGen.SearchSu
   let suggestions: Array<
     RPCTypes.InterestingPerson
   > = yield Saga.call(RPCTypes.userInterestingPeopleRpcPromise, {
-    maxUsers: maxUsers || 0,
+    maxUsers: maxUsers || 50,
   })
 
   // No search results (e.g. this user doesn't follow/chat anyone)


### PR DESCRIPTION
@keybase/react-hackers 