### PR TITLE
drop a 15 second timeout on calls into KBFS

### DIFF
--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -11,6 +11,7 @@ import (
 
 var ErrChatServerTimeout = errors.New("timeout calling chat server")
 var ErrDuplicateConnection = errors.New("duplicate chat server connection established, failing")
+var ErrKeyServerTimeout = errors.New("timeout calling into key server")
 
 type UnboxingError interface {
 	Error() string


### PR DESCRIPTION
The reconnect into mdserver is broken, and so these calls can hang forever. Drop a 15 second timeout on them to surface the error to the frontend, and hopefully we can get an idea for how often this problem strikes.

cc @songgao 