### PR TITLE
fix race w/ profile loading

### DIFF
--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -128,7 +128,7 @@ export default function(
     }
     case TrackerGen.updateUsername: {
       const {username} = action.payload
-      return updateUserState(state, username, s => Constants.initialTrackerState(username))
+      return updateUserState(state, username, s => s || Constants.initialTrackerState(username))
     }
     case TrackerGen.identifyStarted:
       return updateUserState(state, action.payload.username, s => ({


### PR DESCRIPTION
@keybase/react-hackers found this while I was doing the remote window stuff.

The tracker code is some of the oldest code we have and we haven't been able to modernize it (immutable etc) until my remote changes are in. That'll happen sometime in the short term future.

What's happening is we get some info on the profile and start building out data structure. If we then get this message to update the username we'd blow it all away (including these flags on what we already loaded). Instead if we get this message and we already have an object we just keep what we had.

What you'd see in the app was a partially loaded profile and possibly an infinitely running loading spinner on the friendships lists