### PR TITLE
clean up the Linux build scripts

### DIFF
--- a/packaging/linux/Dockerfile
+++ b/packaging/linux/Dockerfile
@@ -10,9 +10,10 @@ MAINTAINER Keybase <admin@keybase.io>
 #   - 'build-essential' pulls in gcc etc., which Go requires.
 #   - python and pip for recent versions of s3cmd
 #   - libc6-dev-i386 for the i386 cgo part of the build
+#   - gnupg1 to avoid a password issue in key import
 RUN apt-get update
 RUN apt-get install -y fakeroot reprepro rpm createrepo git wget \
-  build-essential curl python python-pip libc6-dev-i386
+  build-essential curl python python-pip libc6-dev-i386 gnupg1
 
 # Install s3cmd. See this issue for why we need a version newer than what's in
 # the Debian repos: https://github.com/s3tools/s3cmd/issues/437

--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -1,7 +1,7 @@
 Oh my god so many steps I'm really sorry.
 
-Clone kbfs and server-ops adjacent to client (this repo). The exact path
-doesn't matter.
+Clone kbfs adjacent to client (this repo). The exact path doesn't
+matter.
 
 Get all the credentials. Run test_all_credentials.sh in this directory
 to see what you're missing and check that everything's working. Note

--- a/packaging/linux/build_and_push_packages.sh
+++ b/packaging/linux/build_and_push_packages.sh
@@ -4,7 +4,8 @@
 #   1) Build Linux binaries with Go and Electron
 #   2) Make .deb packages, and lay them out in a signed repo.
 #   3) Make .rpm packages, sign them, and lay them out in a repo.
-#   4) Push all of this to server-ops or S3.
+#   4) Push all of this to S3.
+#   5) Push new version metadata to our Arch Linux AUR package.
 
 set -e -u -o pipefail
 
@@ -13,7 +14,6 @@ build_dir="$2"
 
 here="$(dirname "$BASH_SOURCE")"
 client_dir="$(git -C "$here" rev-parse --show-toplevel)"
-serverops_dir="$client_dir/../server-ops"
 kbfs_dir="$client_dir/../kbfs"
 
 if [ "${KEYBASE_DRY_RUN:-}" = 1 ] ; then

--- a/packaging/linux/docker_build.sh
+++ b/packaging/linux/docker_build.sh
@@ -6,10 +6,8 @@
 #   2) run the "inside_docker_main.sh" script in that image, sharing several
 #      directories from your host, which does all the following...
 #   3) build .deb and .rpm packages and lay them out along with the new repo
-#      metadata and signatures in your server-ops repo (which is shared
-#      read-write with the container)
-#   4) commit and push the server-ops repo, or for prerelease builds, push to
-#      our S3 bucket
+#      metadata and signatures
+#   4) push the packages and repo metadata to our prerelease.keybase.io S3 bucket
 #
 # This script mostly concerns itself with updating git repos and organizing
 # GPG/SSH/S3 keys for the docker container.
@@ -27,11 +25,10 @@ here="$(dirname "$BASH_SOURCE")"
 
 clientdir="$(git -C "$here" rev-parse --show-toplevel)"
 kbfsdir="$clientdir/../kbfs"
-serveropsdir="$clientdir/../server-ops"
 
 # Run `git fetch` in all the repos we'll share with the container. This
 # prevents an unattended build machine from falling behind over time.
-for repo in "$clientdir" "$kbfsdir" "$serveropsdir" ; do
+for repo in "$clientdir" "$kbfsdir" ; do
   echo "Fetching $repo"
   git -C "$repo" fetch
 done
@@ -86,7 +83,6 @@ docker run "${interactive_args[@]:+${interactive_args[@]}}" \
   -v "$work_dir:/root" \
   -v "$clientdir:/CLIENT:ro" \
   -v "$kbfsdir:/KBFS:ro" \
-  -v "$serveropsdir:/SERVEROPS:ro" \
   -v "$gpg_tempdir:/GPG" \
   -v "$HOME/.ssh:/SSH:ro" \
   -v "$s3cmd_temp:/S3CMD:ro" \

--- a/packaging/linux/docker_build.sh
+++ b/packaging/linux/docker_build.sh
@@ -90,5 +90,6 @@ docker run "${interactive_args[@]:+${interactive_args[@]}}" \
   -e BUCKET_NAME \
   -e NOWAIT \
   -e KEYBASE_DRY_RUN \
+  --rm \
   "$image" \
   bash /CLIENT/packaging/linux/inside_docker_main.sh "$@"

--- a/packaging/linux/docker_build.sh
+++ b/packaging/linux/docker_build.sh
@@ -59,7 +59,7 @@ gpg_tempfile="$gpg_tempdir/code_signing_key"
 gpg --export-secret-key --armor "$code_signing_fingerprint" > "$gpg_tempfile"
 
 # Make sure the Docker image is built.
-image=keybase_packaging_v13
+image=keybase_packaging_v14
 if [ -z "$(docker images -q "$image")" ] ; then
   echo "Docker image '$image' not yet built. Building..."
   docker build -t "$image" "$clientdir/packaging/linux"

--- a/packaging/linux/inside_docker_main.sh
+++ b/packaging/linux/inside_docker_main.sh
@@ -32,7 +32,10 @@ cp -r /SSH ~/.ssh
 # interrupt the build later.
 echo "Loading the Keybase code signing key in the container..."
 code_signing_fingerprint="$(cat /CLIENT/packaging/linux/code_signing_fingerprint)"
-gpg --import --quiet < /GPG/code_signing_key
+# Specifically use GnuPG v1 for the import, because modern versions need the
+# decryption password here, for some stupid reason, totally duplicative of the
+# password they'll need again below when we load the key into the agent.
+gpg1 --import < /GPG/code_signing_key
 true > /GPG/code_signing_key  # truncate it, just in case
 # Use very long lifetimes for the key in memory, so that we don't forget it in
 # the middle of a nightly loop.

--- a/packaging/linux/inside_docker_main.sh
+++ b/packaging/linux/inside_docker_main.sh
@@ -14,7 +14,6 @@ commit="$2"
 
 client_clone="/root/client"
 kbfs_clone="/root/kbfs"
-serverops_clone="/root/server-ops"
 build_dir="/root/build"
 
 # Copy the s3cmd config to root's home dir.
@@ -44,19 +43,13 @@ gpg --sign --use-agent --default-key "$code_signing_fingerprint" \
 # Clone all the repos we'll use in the build. The --reference flag makes this
 # pretty cheap. (The shared repos we're referencing were just updated by
 # docker_build.sh, so we shouldn't need any new objects.) Configure the
-# user.name and user.email so that we can make commits in kbfs,
-# server-ops, and the AUR package repo.
+# user.name and user.email so that we can make commits in the AUR package repo.
 git config --global user.name "Keybase Linux Build"
 git config --global user.email "example@example.com"
 echo "Cloning the client repo..."
 git clone git@github.com:keybase/client "$client_clone" --reference /CLIENT
 echo "Cloning the kbfs repo..."
 git clone git@github.com:keybase/kbfs "$kbfs_clone" --reference /KBFS
-# The server-ops repo is like a gigabyte, so don't clone it unnecessarily.
-if [ "$mode" != prerelease ] ; then
-  echo "Cloning the server-ops repo..."
-  git clone git@github.com:keybase/server-ops "$serverops_clone" --reference /SERVEROPS
-fi
 
 # Check out the given client commit.
 git -C "$client_clone" checkout -f "$commit"

--- a/packaging/linux/test_all_credentials.sh
+++ b/packaging/linux/test_all_credentials.sh
@@ -16,10 +16,7 @@ bucket="${BUCKET_NAME:-prerelease.keybase.io}"
 echo "Checking credentials for s3://$bucket (~/.s3cfg)..."
 s3cmd ls "s3://$bucket" > /dev/null
 
-echo 'Checking GitHub credentials (~/.ssh)...'
-git ls-remote git@github.com:keybase/server-ops > /dev/null
-
-echo 'Checking Arch AUR credentials (also ~/.ssh)...'
+echo 'Checking Arch AUR credentials (~/.ssh)...'
 git ls-remote aur@aur.archlinux.org:keybase-git > /dev/null
 
 # The release tool needs a GitHub API token to check test status. This is


### PR DESCRIPTION
Two main improvements:

- No longer depend on the `server-ops` repo. It was giant, and totally obsolete.
- Fix a broken gpg password prompt in the docker build. This wasn't affecting our automation, but running the build manually in your own terminal was broken.

r? @cjb (feel free to punt :) )