### PR TITLE
Handle no space on device better

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -105,6 +105,12 @@ func (b *Boxer) detectKBFSPermanentServerError(err error) bool {
 	case teams.TeamDoesNotExistError:
 		return true
 	}
+
+	// Check for no space left on device errors
+	if libkb.IsNoSpaceOnDeviceError(err) {
+		return true
+	}
+
 	return false
 }
 
@@ -191,9 +197,9 @@ func (p *publicUnboxConversationInfo) GetFinalizeInfo() *chat1.ConversationFinal
 // non-permanent errors, and (MessageUnboxedError, nil) for permanent errors.
 // Permanent errors can be cached and must be treated as a value to deal with,
 // whereas temporary errors are transient failures.
-func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv unboxConversationInfo) (chat1.MessageUnboxed, UnboxingError) {
+func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv unboxConversationInfo) (m chat1.MessageUnboxed, uberr UnboxingError) {
 	b.Debug(ctx, "+ UnboxMessage for convID %s msg_id %s", conv.GetConvID().String(), boxed.GetMessageID().String())
-	defer b.Debug(ctx, "- UnboxMessage for convID %s msg_id %s", conv.GetConvID().String(), boxed.GetMessageID().String())
+	defer b.Debug(ctx, "- UnboxMessage for convID %s msg_id %s -> %s", conv.GetConvID().String(), boxed.GetMessageID().String(), libkb.ErrToOk(uberr))
 	tlfName := boxed.ClientHeader.TLFNameExpanded(conv.GetFinalizeInfo())
 	nameInfo, err := CtxKeyFinder(ctx, b.G()).FindForDecryption(ctx,
 		tlfName, boxed.ClientHeader.Conv.Tlfid, conv.GetMembersType(),

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -279,6 +279,7 @@ const (
 	SCGitRepoDoesntExist       = int(keybase1.StatusCode_SCGitRepoDoesntExist)
 	SCTeamBanned               = int(keybase1.StatusCode_SCTeamBanned)
 	SCTeamInvalidBan           = int(keybase1.StatusCode_SCTeamInvalidBan)
+	SCNoSpaceOnDevice          = int(keybase1.StatusCode_SCNoSpaceOnDevice)
 )
 
 const (

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2206,3 +2206,13 @@ type NoOpError struct {
 func (e NoOpError) Error() string {
 	return e.Desc
 }
+
+//=============================================================================
+
+type NoSpaceOnDeviceError struct {
+	Desc string
+}
+
+func (e NoSpaceOnDeviceError) Error() string {
+	return e.Desc
+}

--- a/go/libkb/full_self_cacher.go
+++ b/go/libkb/full_self_cacher.go
@@ -186,7 +186,9 @@ func (m *CachedFullSelf) WithUser(arg LoadUserArg, f func(u *User) error) (err e
 			m.G().Log.CDebugf(ctx, "| CachedFullSelf#WithUser: cache populate")
 			m.cacheMe(u)
 			if ldr := m.G().GetUPAKLoader(); ldr != nil {
-				ldr.PutUserToCache(ctx, u)
+				if err := ldr.PutUserToCache(ctx, u); err != nil {
+					m.G().Log.CDebugf(ctx, "| CachedFullSelf#WithUser: continuing past error putting user to cache: %s", err)
+				}
 			}
 		} else {
 			m.G().Log.CDebugf(ctx, "| CachedFullSelf#WithUser: other user")

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -653,6 +653,8 @@ func ImportStatusAsError(g *GlobalContext, s *keybase1.Status) error {
 		return e
 	case SCNoOp:
 		return NoOpError{Desc: s.Desc}
+	case SCNoSpaceOnDevice:
+		return NoSpaceOnDeviceError{Desc: s.Desc}
 	default:
 		ase := AppStatusError{
 			Code:   s.Code,
@@ -2164,6 +2166,13 @@ func (e RepoDoesntExistError) ToStatus() (s keybase1.Status) {
 func (e NoOpError) ToStatus() (s keybase1.Status) {
 	s.Code = SCNoOp
 	s.Name = "SC_NO_OP"
+	s.Desc = e.Desc
+	return
+}
+
+func (e NoSpaceOnDeviceError) ToStatus() (s keybase1.Status) {
+	s.Code = SCNoSpaceOnDevice
+	s.Name = "NO_SPACE_ON_DEVICE"
 	s.Desc = e.Desc
 	return
 }

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -1207,9 +1207,9 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 	if err = l.chain.VerifyChain(l.ctx); err != nil {
 		return
 	}
-	stage("Store")
+	stage("StoreChain")
 	if err = l.chain.Store(l.ctx); err != nil {
-		return
+		l.G().Log.CDebugf(l.ctx, "| continuing past error storing chain links: %s", err)
 	}
 	stage("VerifySig")
 	if err = l.VerifySigsAndComputeKeys(); err != nil {
@@ -1217,8 +1217,8 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 	}
 	stage("Store")
 	if err = l.Store(); err != nil {
-		return
+		l.G().Log.CDebugf(l.ctx, "| continuing past error storing chain: %s", err)
 	}
 
-	return
+	return ret, nil
 }

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -341,7 +341,9 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 			upak.Uvv.CachedAt = keybase1.ToTime(g.Clock().Now())
 			// This is only necessary to update the levelDB representation,
 			// since the previous line updates the in-memory cache satisfactorially.
-			u.putUPAKToCache(ctx, upak)
+			if err := u.putUPAKToCache(ctx, upak); err != nil {
+				u.G().Log.CDebugf(ctx, "continuing past error in putUPAKToCache: %s", err)
+			}
 
 			return returnUPAK(upak, true)
 		}
@@ -382,7 +384,9 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		return nil, nil, UserNotFoundError{UID: arg.uid, Msg: "LoadUser failed"}
 	}
 
-	err = u.putUPAKToCache(ctx, ret)
+	if err := u.putUPAKToCache(ctx, ret); err != nil {
+		u.G().Log.CDebugf(ctx, "continuing past error in putUPAKToCache: %s", err)
+	}
 
 	if u.TestDeadlocker != nil {
 		u.TestDeadlocker()

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 	"unicode"
 
@@ -803,4 +804,24 @@ func MobilePermissionDeniedCheck(g *GlobalContext, err error, msg string) {
 	}
 	g.Log.Warning("file open permission denied on mobile (%s): %s", msg, err)
 	panic(fmt.Sprintf("panic due to file open permission denied on mobile (%s)", msg))
+}
+
+// IsNoSpaceOnDeviceError will return true if err is an `os` error
+// for "no space left on device".
+func IsNoSpaceOnDeviceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch err := err.(type) {
+	case NoSpaceOnDeviceError:
+		return true
+	case *os.PathError:
+		return err.Err == syscall.ENOSPC
+	case *os.LinkError:
+		return err.Err == syscall.ENOSPC
+	case *os.SyscallError:
+		return err.Err == syscall.ENOSPC
+	}
+
+	return false
 }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -35,6 +35,7 @@ const (
 	StatusCode_SCNoSession                 StatusCode = 283
 	StatusCode_SCAccountReset              StatusCode = 290
 	StatusCode_SCIdentifiesFailed          StatusCode = 295
+	StatusCode_SCNoSpaceOnDevice           StatusCode = 297
 	StatusCode_SCBadEmail                  StatusCode = 472
 	StatusCode_SCBadSignupUsernameTaken    StatusCode = 701
 	StatusCode_SCBadInvitationCode         StatusCode = 707
@@ -150,7 +151,6 @@ const (
 	StatusCode_SCTeamKeyMaskNotFound       StatusCode = 2697
 	StatusCode_SCTeamBanned                StatusCode = 2702
 	StatusCode_SCTeamInvalidBan            StatusCode = 2703
-	StatusCode_SCNoSpaceOnDevice           StatusCode = 2900
 )
 
 func (o StatusCode) DeepCopy() StatusCode { return o }
@@ -181,6 +181,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCNoSession":                 283,
 	"SCAccountReset":              290,
 	"SCIdentifiesFailed":          295,
+	"SCNoSpaceOnDevice":           297,
 	"SCBadEmail":                  472,
 	"SCBadSignupUsernameTaken":    701,
 	"SCBadInvitationCode":         707,
@@ -296,7 +297,6 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamKeyMaskNotFound":       2697,
 	"SCTeamBanned":                2702,
 	"SCTeamInvalidBan":            2703,
-	"SCNoSpaceOnDevice":           2900,
 }
 
 var StatusCodeRevMap = map[StatusCode]string{
@@ -325,6 +325,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	283:  "SCNoSession",
 	290:  "SCAccountReset",
 	295:  "SCIdentifiesFailed",
+	297:  "SCNoSpaceOnDevice",
 	472:  "SCBadEmail",
 	701:  "SCBadSignupUsernameTaken",
 	707:  "SCBadInvitationCode",
@@ -440,7 +441,6 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2697: "SCTeamKeyMaskNotFound",
 	2702: "SCTeamBanned",
 	2703: "SCTeamInvalidBan",
-	2900: "SCNoSpaceOnDevice",
 }
 
 func (e StatusCode) String() string {

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -150,6 +150,7 @@ const (
 	StatusCode_SCTeamKeyMaskNotFound       StatusCode = 2697
 	StatusCode_SCTeamBanned                StatusCode = 2702
 	StatusCode_SCTeamInvalidBan            StatusCode = 2703
+	StatusCode_SCNoSpaceOnDevice           StatusCode = 2900
 )
 
 func (o StatusCode) DeepCopy() StatusCode { return o }
@@ -295,6 +296,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamKeyMaskNotFound":       2697,
 	"SCTeamBanned":                2702,
 	"SCTeamInvalidBan":            2703,
+	"SCNoSpaceOnDevice":           2900,
 }
 
 var StatusCodeRevMap = map[StatusCode]string{
@@ -438,6 +440,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2697: "SCTeamKeyMaskNotFound",
 	2702: "SCTeamBanned",
 	2703: "SCTeamInvalidBan",
+	2900: "SCNoSpaceOnDevice",
 }
 
 func (e StatusCode) String() string {

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -27,6 +27,7 @@ protocol constants {
     SCNoSession_283,
     SCAccountReset_290,
     SCIdentifiesFailed_295,
+    SCNoSpaceOnDevice_297,
     SCBadEmail_472,
     SCBadSignupUsernameTaken_701,
     SCBadInvitationCode_707,
@@ -141,7 +142,6 @@ protocol constants {
     SCTeamImplicitBadRemove_2686,
     SCTeamKeyMaskNotFound_2697,
     SCTeamBanned_2702,
-    SCTeamInvalidBan_2703,
-    SCNoSpaceOnDevice_2900
+    SCTeamInvalidBan_2703
   }
 }

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -141,6 +141,7 @@ protocol constants {
     SCTeamImplicitBadRemove_2686,
     SCTeamKeyMaskNotFound_2697,
     SCTeamBanned_2702,
-    SCTeamInvalidBan_2703
+    SCTeamInvalidBan_2703,
+    SCNoSpaceOnDevice_2900
   }
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -390,6 +390,7 @@ export const constantsStatusCode = {
   scnosession: 283,
   scaccountreset: 290,
   scidentifiesfailed: 295,
+  scnospaceondevice: 297,
   scbademail: 472,
   scbadsignupusernametaken: 701,
   scbadinvitationcode: 707,
@@ -505,7 +506,6 @@ export const constantsStatusCode = {
   scteamkeymasknotfound: 2697,
   scteambanned: 2702,
   scteaminvalidban: 2703,
-  scnospaceondevice: 2900,
 }
 
 export const cryptoSignED25519ForKBFSRpcChannelMap = (configKeys: Array<string>, request: CryptoSignED25519ForKBFSRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.crypto.signED25519ForKBFS', request)
@@ -3225,6 +3225,7 @@ export type StatusCode =0 // SCOk_0
  | 283 // SCNoSession_283
  | 290 // SCAccountReset_290
  | 295 // SCIdentifiesFailed_295
+ | 297 // SCNoSpaceOnDevice_297
  | 472 // SCBadEmail_472
  | 701 // SCBadSignupUsernameTaken_701
  | 707 // SCBadInvitationCode_707
@@ -3340,7 +3341,6 @@ export type StatusCode =0 // SCOk_0
  | 2697 // SCTeamKeyMaskNotFound_2697
  | 2702 // SCTeamBanned_2702
  | 2703 // SCTeamInvalidBan_2703
- | 2900 // SCNoSpaceOnDevice_2900
 
 
 export type Stream = {|fd: Int,|}

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -505,6 +505,7 @@ export const constantsStatusCode = {
   scteamkeymasknotfound: 2697,
   scteambanned: 2702,
   scteaminvalidban: 2703,
+  scnospaceondevice: 2900,
 }
 
 export const cryptoSignED25519ForKBFSRpcChannelMap = (configKeys: Array<string>, request: CryptoSignED25519ForKBFSRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.crypto.signED25519ForKBFS', request)
@@ -3339,6 +3340,7 @@ export type StatusCode =0 // SCOk_0
  | 2697 // SCTeamKeyMaskNotFound_2697
  | 2702 // SCTeamBanned_2702
  | 2703 // SCTeamInvalidBan_2703
+ | 2900 // SCNoSpaceOnDevice_2900
 
 
 export type Stream = {|fd: Int,|}

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -31,6 +31,7 @@
         "SCNoSession_283",
         "SCAccountReset_290",
         "SCIdentifiesFailed_295",
+        "SCNoSpaceOnDevice_297",
         "SCBadEmail_472",
         "SCBadSignupUsernameTaken_701",
         "SCBadInvitationCode_707",
@@ -145,8 +146,7 @@
         "SCTeamImplicitBadRemove_2686",
         "SCTeamKeyMaskNotFound_2697",
         "SCTeamBanned_2702",
-        "SCTeamInvalidBan_2703",
-        "SCNoSpaceOnDevice_2900"
+        "SCTeamInvalidBan_2703"
       ]
     }
   ],

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -145,7 +145,8 @@
         "SCTeamImplicitBadRemove_2686",
         "SCTeamKeyMaskNotFound_2697",
         "SCTeamBanned_2702",
-        "SCTeamInvalidBan_2703"
+        "SCTeamInvalidBan_2703",
+        "SCNoSpaceOnDevice_2900"
       ]
     }
   ],

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -390,6 +390,7 @@ export const constantsStatusCode = {
   scnosession: 283,
   scaccountreset: 290,
   scidentifiesfailed: 295,
+  scnospaceondevice: 297,
   scbademail: 472,
   scbadsignupusernametaken: 701,
   scbadinvitationcode: 707,
@@ -505,7 +506,6 @@ export const constantsStatusCode = {
   scteamkeymasknotfound: 2697,
   scteambanned: 2702,
   scteaminvalidban: 2703,
-  scnospaceondevice: 2900,
 }
 
 export const cryptoSignED25519ForKBFSRpcChannelMap = (configKeys: Array<string>, request: CryptoSignED25519ForKBFSRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.crypto.signED25519ForKBFS', request)
@@ -3225,6 +3225,7 @@ export type StatusCode =0 // SCOk_0
  | 283 // SCNoSession_283
  | 290 // SCAccountReset_290
  | 295 // SCIdentifiesFailed_295
+ | 297 // SCNoSpaceOnDevice_297
  | 472 // SCBadEmail_472
  | 701 // SCBadSignupUsernameTaken_701
  | 707 // SCBadInvitationCode_707
@@ -3340,7 +3341,6 @@ export type StatusCode =0 // SCOk_0
  | 2697 // SCTeamKeyMaskNotFound_2697
  | 2702 // SCTeamBanned_2702
  | 2703 // SCTeamInvalidBan_2703
- | 2900 // SCNoSpaceOnDevice_2900
 
 
 export type Stream = {|fd: Int,|}

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -505,6 +505,7 @@ export const constantsStatusCode = {
   scteamkeymasknotfound: 2697,
   scteambanned: 2702,
   scteaminvalidban: 2703,
+  scnospaceondevice: 2900,
 }
 
 export const cryptoSignED25519ForKBFSRpcChannelMap = (configKeys: Array<string>, request: CryptoSignED25519ForKBFSRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.crypto.signED25519ForKBFS', request)
@@ -3339,6 +3340,7 @@ export type StatusCode =0 // SCOk_0
  | 2697 // SCTeamKeyMaskNotFound_2697
  | 2702 // SCTeamBanned_2702
  | 2703 // SCTeamInvalidBan_2703
+ | 2900 // SCNoSpaceOnDevice_2900
 
 
 export type Stream = {|fd: Int,|}


### PR DESCRIPTION
Users who ran out of disk space ended up in a perpetual identify loop.

They would try to read a conversation, which would result in an identify error because the storage to leveldb failed, which would be marked as a transient error, and the chat system would keep trying to unbox the message.

This patch fixes it in a few different ways:

1. sig chain loader no longer errors out when there is a storage error
2. no space on device errors are permanent chat unboxing errors
3. leveldb operations convert os syscall errors to libkb rpc-exportable errors so that something like service.GetCryptKeys -> kbfs -> service.Identify -> kbfs -> service will get an error type and not just a generic string error.  

@maxtaco please check sigchain changes
@mmaxim please check chat permanent errors

