### PR TITLE
run ibm replay off the OnConnect thread CORE-6713

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1173,7 +1173,6 @@ func (g *gregorHandler) Shutdown() {
 	// Alert chat syncer that we are now disconnected
 	g.G().Syncer.Disconnected(context.Background())
 
-	close(g.replayCh)
 	close(g.shutdownCh)
 	g.conn.Shutdown()
 	g.conn = nil

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -96,13 +96,20 @@ func (h *gregorFirehoseHandler) PushOutOfBandMessages(m []gregor1.OutOfBandMessa
 	}
 }
 
+type testingReplayRes struct {
+	replayed []gregor.InBandMessage
+	err      error
+}
+
 type testingEvents struct {
 	broadcastSentCh chan error
+	replayThreadCh  chan testingReplayRes
 }
 
 func newTestingEvents() *testingEvents {
 	return &testingEvents{
 		broadcastSentCh: make(chan error),
+		replayThreadCh:  make(chan testingReplayRes, 10),
 	}
 }
 
@@ -124,6 +131,12 @@ func (c connectionAuthError) ShouldRetry() bool {
 
 func (c connectionAuthError) Error() string {
 	return fmt.Sprintf("connection auth error: msg: %s shouldRetry: %v", c.msg, c.shouldRetry)
+}
+
+type replayThreadArg struct {
+	cli gregor1.IncomingInterface
+	t   time.Time
+	ctx context.Context
 }
 
 type gregorHandler struct {
@@ -159,6 +172,7 @@ type gregorHandler struct {
 
 	shutdownCh  chan struct{}
 	broadcastCh chan gregor1.Message
+	replayCh    chan replayThreadArg
 
 	// Testing
 	testingEvents       *testingEvents
@@ -201,6 +215,7 @@ func newGregorHandler(g *globals.Context) *gregorHandler {
 		broadcastCh:       make(chan gregor1.Message, 10000),
 		forceSessionCheck: false,
 		connectHappened:   make(chan struct{}),
+		replayCh:          make(chan replayThreadArg, 10),
 	}
 	return gh
 }
@@ -218,6 +233,9 @@ func (g *gregorHandler) Init() {
 
 	// Start the app state monitor thread
 	go g.monitorAppState()
+
+	// Start replay thread
+	go g.syncReplayThread()
 }
 
 func (g *gregorHandler) monitorAppState() {
@@ -539,11 +557,28 @@ func (g *gregorHandler) IsConnected() bool {
 	return g.conn != nil && g.conn.IsConnected()
 }
 
+func (g *gregorHandler) syncReplayThread() {
+	for rarg := range g.replayCh {
+		var trr testingReplayRes
+		replayedMsgs, err := g.replayInBandMessages(rarg.ctx, rarg.cli, rarg.t, nil)
+		if err != nil {
+			g.Debug(rarg.ctx, "serverSync: replayThread: replay messages failed: %s", err)
+			trr.err = err
+		} else {
+			g.Debug(rarg.ctx, "serverSync: replayThread: replayed %d messages", len(replayedMsgs))
+			trr.replayed = replayedMsgs
+		}
+		if g.testingEvents != nil {
+			g.testingEvents.replayThreadCh <- trr
+		}
+	}
+}
+
 // serverSync is called from
 // gregord. This can happen either on initial startup, or after a reconnect. Needs
 // to be called with gregorHandler locked.
 func (g *gregorHandler) serverSync(ctx context.Context,
-	cli gregor1.IncomingInterface, gcli *grclient.Client, syncRes *chat1.SyncAllNotificationRes) ([]gregor.InBandMessage, []gregor.InBandMessage, error) {
+	cli gregor1.IncomingInterface, gcli *grclient.Client, syncRes *chat1.SyncAllNotificationRes) ([]gregor.InBandMessage, error) {
 
 	// Get time of the last message we synced (unless this is our first time syncing)
 	var t time.Time
@@ -561,18 +596,19 @@ func (g *gregorHandler) serverSync(ctx context.Context,
 	consumedMsgs, err := gcli.Sync(ctx, cli, syncRes)
 	if err != nil {
 		g.Debug(ctx, "serverSync: error syncing from the server, reason: %s", err)
-		return nil, nil, err
+		return nil, err
 	}
+	g.Debug(ctx, "serverSync: consumed %d messages", len(consumedMsgs))
 
-	// Replay in-band messages
-	replayedMsgs, err := g.replayInBandMessages(ctx, cli, t, nil)
-	if err != nil {
-		g.Errorf(ctx, "serverSync: replay messages failed: %s", err)
-		return nil, nil, err
+	// Schedule replay of in-band messages
+	g.replayCh <- replayThreadArg{
+		cli: cli,
+		t:   t,
+		ctx: chat.BackgroundContext(ctx, g.G()),
 	}
 
 	g.pushState(keybase1.PushReason_RECONNECTED)
-	return replayedMsgs, consumedMsgs, nil
+	return consumedMsgs, nil
 }
 
 func (g *gregorHandler) makeReconnectOobm() gregor1.Message {
@@ -653,6 +689,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
 		chat.NewIdentifyNotifier(g.G()))
+	g.chatLog.Debug(ctx, "OnConnect begin")
 	syncAllRes, err := chatCli.SyncAll(ctx, chat1.SyncAllArg{
 		Uid:       uid,
 		DeviceID:  gcli.Device.(gregor1.DeviceID),
@@ -684,13 +721,9 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	}
 
 	// Sync down events since we have been dead
-	replayedMsgs, consumedMsgs, err := g.serverSync(ctx, gregor1.IncomingClient{Cli: timeoutCli}, gcli,
-		&syncAllRes.Notification)
-	if err != nil {
-		g.chatLog.Debug(ctx, "sync failure: %s", err.Error())
-	} else {
-		g.chatLog.Debug(ctx, "sync success: replayed: %d consumed: %d", len(replayedMsgs),
-			len(consumedMsgs))
+	if _, err := g.serverSync(ctx, gregor1.IncomingClient{Cli: timeoutCli}, gcli,
+		&syncAllRes.Notification); err != nil {
+		g.chatLog.Debug(ctx, "serverSync: failure: %s", err.Error())
 	}
 
 	// Sync badge state in the background
@@ -717,6 +750,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	g.firstConnect = false
 	// On successful login we can reset this guy to not force a check
 	g.forceSessionCheck = false
+	g.chatLog.Debug(ctx, "OnConnect complete")
 
 	return nil
 }
@@ -1139,6 +1173,7 @@ func (g *gregorHandler) Shutdown() {
 	// Alert chat syncer that we are now disconnected
 	g.G().Syncer.Disconnected(context.Background())
 
+	close(g.replayCh)
 	close(g.shutdownCh)
 	g.conn.Shutdown()
 	g.conn = nil

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -435,9 +435,17 @@ func doServerSync(t *testing.T, h *gregorHandler, srv mockGregord) ([]gregor.InB
 		Ctime:    ctime,
 	})
 	require.NoError(t, err)
-	r, c, err := h.serverSync(context.TODO(), srv, h.gregorCli, &sres.Notification)
+	c, err := h.serverSync(context.TODO(), srv, h.gregorCli, &sres.Notification)
 	require.NoError(t, err)
-	return r, c
+	require.NotNil(t, h.testingEvents)
+	select {
+	case r := <-h.testingEvents.replayThreadCh:
+		require.NoError(t, r.err)
+		return r.replayed, c
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no replay event received")
+		return nil, nil
+	}
 }
 
 func TestSyncFresh(t *testing.T) {
@@ -535,6 +543,7 @@ func TestSyncSaveRestoreFresh(t *testing.T) {
 
 	// Create a new gregor handler, this will restore our saved state
 	h = newGregorHandler(globals.NewContext(tc.G, &globals.ChatContext{}))
+	h.testingEvents = newTestingEvents()
 	h.Init()
 
 	// Sync from the server
@@ -580,6 +589,7 @@ func TestSyncSaveRestoreNonFresh(t *testing.T) {
 
 	// Create a new gregor handler, this will restore our saved state
 	h = newGregorHandler(globals.NewContext(tc.G, nil))
+	h.testingEvents = newTestingEvents()
 	h.Init()
 
 	// Turn off fresh replay
@@ -644,7 +654,7 @@ func TestGregorBadgesIBM(t *testing.T) {
 
 	// Sync from the server
 	t.Logf("client sync")
-	_, _, err := h.serverSync(context.TODO(), server, h.gregorCli, nil)
+	_, err := h.serverSync(context.TODO(), server, h.gregorCli, nil)
 	require.NoError(t, err)
 	t.Logf("client sync complete")
 
@@ -661,7 +671,7 @@ func TestGregorBadgesIBM(t *testing.T) {
 	require.NoError(t, server.ConsumeMessage(context.TODO(), msg))
 
 	t.Logf("client sync")
-	_, _, err = h.serverSync(context.TODO(), server, h.gregorCli, nil)
+	_, err = h.serverSync(context.TODO(), server, h.gregorCli, nil)
 	require.NoError(t, err)
 	t.Logf("client sync complete")
 
@@ -695,7 +705,7 @@ func TestGregorTeamBadges(t *testing.T) {
 
 	// Sync from the server
 	t.Logf("client sync")
-	_, _, err := h.serverSync(context.TODO(), server, h.gregorCli, nil)
+	_, err := h.serverSync(context.TODO(), server, h.gregorCli, nil)
 	require.NoError(t, err)
 	t.Logf("client sync complete")
 


### PR DESCRIPTION
Patch does the following:

1.) Make a new background thread `syncReplayThread`, which will run Gregor IBM replay one at a time as read from the `replayCh` channel.
2.) The purpose of this change is to make it so that `OnConnect` is not delayed by a lengthy IBM replay process. My own personal Gregor state consistently has around 100 items, and plowing through them all (even if most are no-ops), slows down chat on mobile for no real reason. We should also fix the bloated nature of the Gregor state, but this change aims to limit the damage to chat.

cc @maxtaco 