### PR TITLE
reenable skipped home tests

### DIFF
--- a/go/client/cmd_signup.go
+++ b/go/client/cmd_signup.go
@@ -91,6 +91,11 @@ func (s *CmdSignup) SetTest() {
 	s.genPaper = true
 }
 
+func (s *CmdSignup) SetTestWithPaper(b bool) {
+	s.skipMail = true
+	s.genPaper = b
+}
+
 func (s *CmdSignup) ParseArgv(ctx *cli.Context) error {
 	nargs := len(ctx.Args())
 	var err error


### PR DESCRIPTION
- it's a bit brittle since if the home logic changes again on badge timing, we might get another failure.
- however, let's leave it in for now, since it is providing reasonable test coverage on parsing the output
  format of the home's JSON output, and the badging end-to-end logic