### PR TITLE
Small bugfixes

### DIFF
--- a/shared/chat/conversation/messages/joinedleft/container.js
+++ b/shared/chat/conversation/messages/joinedleft/container.js
@@ -5,11 +5,11 @@ import JoinedLeftNotice from '.'
 import createCachedSelector from 're-reselect'
 import {compose} from 'recompose'
 import {connect} from 'react-redux'
-import {navigateTo, switchTo} from '../../../../actions/route-tree'
-import {teamsTab} from '../../../../constants/tabs'
+import {navigateAppend, navigateTo} from '../../../../actions/route-tree'
 import {isMobile} from '../../../../constants/platform'
 import {createShowUserProfile} from '../../../../actions/profile-gen'
 import {getProfile} from '../../../../actions/tracker'
+import {chatTab} from '../../../../constants/tabs'
 
 import type {TypedState} from '../../../../constants/reducer'
 import type {OwnProps} from './container'
@@ -52,10 +52,10 @@ const getDetails = createCachedSelector(
 const mapStateToProps = (state: TypedState, {messageKey}: OwnProps) => getDetails(state, messageKey)
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  _onManageChannels: (teamname: string) => {
-    dispatch(navigateTo([{props: {teamname}, selected: 'manageChannels'}], [teamsTab]))
-    dispatch(switchTo([teamsTab]))
-  },
+  _onManageChannels: (teamname: string) =>
+    isMobile
+      ? dispatch(navigateTo([{props: {teamname}, selected: 'manageChannels'}], [chatTab]))
+      : dispatch(navigateAppend([{props: {teamname}, selected: 'manageChannels'}])),
   onUsernameClicked: (username: string) => {
     isMobile ? dispatch(createShowUserProfile({username})) : dispatch(getProfile(username, true, true))
   },

--- a/shared/teams/main/beta-note.js
+++ b/shared/teams/main/beta-note.js
@@ -30,19 +30,13 @@ const BetaNote = (props: Props) => (
       />
       <Box style={{backgroundColor: globalColors.black_05, height: 1, width: 24}} />
     </Box>
-    <Text type="BodySmall">Teams are still very early-stage!</Text>
-    <Text style={{maxWidth: 426, textAlign: 'center'}} type="BodySmall">
-      For now the GUI only allows you to create simple teams
-      with no channels or subteams, but you can get to more complex teams
-      using the command line.
-    </Text>
     <Text
       type="BodySmallSemibold"
       className="hover-underline"
       onClick={props.onReadMore}
       style={{...globalStyles.clickable}}
     >
-      Read more
+      Read more about teams here
     </Text>
   </Box>
 )

--- a/shared/teams/role-picker/index.js
+++ b/shared/teams/role-picker/index.js
@@ -59,7 +59,7 @@ const makeRoleOption = (
     <Icon type="iconfont-check" style={{alignSelf: 'center', color: globalColors.white, fontSize: 24}} />
     <Box style={{...globalStyles.flexBoxColumn, paddingLeft: globalMargins.tiny}}>
       <Box style={globalStyles.flexBoxRow}>
-        {roleIconMap[role] &&
+        {!!roleIconMap[role] &&
           <Icon
             type={roleIconMap[role]}
             style={{

--- a/shared/teams/team/member/index.js
+++ b/shared/teams/team/member/index.js
@@ -62,7 +62,7 @@ export const TeamMember = (props: Props) => {
             size={64}
           />
           {user.type &&
-            roleIconMap[user.type] &&
+            !!roleIconMap[user.type] &&
             <Icon
               type={roleIconMap[user.type]}
               style={{


### PR DESCRIPTION
- Remove raw rendered text from places rendering role icons
- Make `Manage chat channels` stay within the chat tab, rather than hopping over to the teams tab
- Update teams page notice

@keybase/react-hackers 