### PR TITLE
default to reader instead of none in team settings

### DIFF
--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -285,6 +285,11 @@ const _getDetails = function*(action: Types.GetDetails): Saga.SagaGenerator<any,
       forceRepoll: false,
     })
 
+    // Don't allow the none default
+    if (details.settings.joinAs === RPCTypes.teamsTeamRole.none) {
+      details.settings.joinAs = RPCTypes.teamsTeamRole.reader
+    }
+
     const implicitAdminDetails: Array<
       RPCTypes.TeamMemberDetails
     > = (yield Saga.call(RPCTypes.teamsTeamImplicitAdminsRpcPromise, {


### PR DESCRIPTION
We get a 'none' value as the value from the daemon which we plumb through. Instead we default to reader
@keybase/react-hackers 