### PR TITLE
label users in member list as inactive if reset

### DIFF
--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -323,11 +323,12 @@ const _getDetails = function*(action: Types.GetDetails): Saga.SagaGenerator<any,
     }
     types.forEach(type => {
       const members = details.members[type] || []
-      members.forEach(({username}) => {
+      members.forEach(({username, active}) => {
         infos.push(
           Constants.makeMemberInfo({
             type: typeMap[type],
             username,
+            active,
           })
         )
         memberNames = memberNames.add(username)

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -20,6 +20,7 @@ export const makeChannelInfo: I.RecordFactory<Types._ChannelInfo> = I.Record({
 export const makeMemberInfo: I.RecordFactory<Types._MemberInfo> = I.Record({
   type: null,
   username: '',
+  active: true,
 })
 
 export const makeInviteInfo: I.RecordFactory<Types._InviteInfo> = I.Record({

--- a/shared/constants/types/teams.js
+++ b/shared/constants/types/teams.js
@@ -151,6 +151,7 @@ export type ChannelInfo = I.RecordOf<_ChannelInfo>
 export type _MemberInfo = {
   type: ?TeamRoleType,
   username: string,
+  active: boolean,
 }
 
 export type MemberInfo = I.RecordOf<_MemberInfo>

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -252,6 +252,7 @@ class Team extends React.PureComponent<Props> {
       username: member.username,
       teamname: name,
       active: member.active,
+      key: member.username + member.active.toString(),
     }))
     const requestProps = requests.map(req => ({
       key: req.username,
@@ -314,6 +315,7 @@ class Team extends React.PureComponent<Props> {
           <List
             items={requestsAndInvites}
             fixedHeight={48}
+            keyProperty="key"
             renderItem={TeamRequestOrDividerOrInviteRow}
             style={{alignSelf: 'stretch'}}
           />

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -248,7 +248,11 @@ class Team extends React.PureComponent<Props> {
     const admin = Constants.isAdmin(yourRole) || Constants.isOwner(yourRole)
 
     // massage data for rowrenderers
-    const memberProps = members.map(member => ({username: member.username, teamname: name}))
+    const memberProps = members.map(member => ({
+      username: member.username,
+      teamname: name,
+      active: member.active,
+    }))
     const requestProps = requests.map(req => ({
       key: req.username,
       teamname: name,

--- a/shared/teams/team/member-row/container.js
+++ b/shared/teams/team/member-row/container.js
@@ -12,6 +12,7 @@ import type {TypedState} from '../../../constants/reducer'
 type OwnProps = {
   username: string,
   teamname: string,
+  active: boolean,
 }
 
 const getFollowing = (state, username: string) => {
@@ -21,13 +22,15 @@ const getFollowing = (state, username: string) => {
 
 type StateProps = {
   following: boolean,
+  active: boolean,
   you: ?string,
   _members: I.Set<Types.MemberInfo>,
 }
 
-const mapStateToProps = (state: TypedState, {teamname, username}: OwnProps): StateProps => ({
+const mapStateToProps = (state: TypedState, {teamname, username, active}: OwnProps): StateProps => ({
   following: getFollowing(state, username),
   you: state.config.username,
+  active,
   _members: state.entities.getIn(['teams', 'teamNameToMembers', teamname], I.Set()),
 })
 

--- a/shared/teams/team/member-row/index.js
+++ b/shared/teams/team/member-row/index.js
@@ -13,6 +13,7 @@ export type Props = {
   teamname: string,
   you: ?string,
   type: ?string,
+  active: boolean,
   onClick: () => void,
 }
 
@@ -24,7 +25,7 @@ const showCrown: TypeMap = {
 }
 
 export const TeamMemberRow = (props: Props) => {
-  const {username, onClick, you, following, type} = props
+  const {username, onClick, you, following, type, active} = props
   return (
     <ClickableBox
       style={{
@@ -56,7 +57,7 @@ export const TeamMemberRow = (props: Props) => {
                 marginRight: globalMargins.xtiny,
               }}
             />}
-          <Text type="BodySmall">{type && typeToLabel[type]}</Text>
+          <Text type="BodySmall">{type && typeToLabel[type]} {!active && '(inactive due to reset)'}</Text>
         </Box>
       </Box>
     </ClickableBox>

--- a/shared/teams/team/member-row/index.js
+++ b/shared/teams/team/member-row/index.js
@@ -36,7 +36,7 @@ export const TeamMemberRow = (props: Props) => {
         padding: globalMargins.tiny,
         width: '100%',
       }}
-      onClick={onClick}
+      onClick={active ? onClick : undefined}
     >
       <Avatar username={username} size={isMobile ? 48 : 32} />
       <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.small}}>

--- a/shared/teams/team/member-row/index.js
+++ b/shared/teams/team/member-row/index.js
@@ -40,7 +40,7 @@ export const TeamMemberRow = (props: Props) => {
     >
       <Avatar username={username} size={isMobile ? 48 : 32} />
       <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.small}}>
-        <Box style={{...globalStyles.flexBoxRow, justifyContent: 'center'}}>
+        <Box style={globalStyles.flexBoxRow}>
           <Usernames
             type="BodySemibold"
             colorFollowing={true}
@@ -64,7 +64,11 @@ export const TeamMemberRow = (props: Props) => {
                 marginRight: globalMargins.xtiny,
               }}
             />}
-          <Text type="BodySmall">{type && typeToLabel[type]} {!active && '(inactive due to reset)'}</Text>
+          <Text type="BodySmall">
+            {active && type && typeToLabel[type]}
+            {' '}
+            {!active && 'Has reset their account; admin(s) can re-invite'}
+          </Text>
         </Box>
       </Box>
     </ClickableBox>

--- a/shared/teams/team/member-row/index.js
+++ b/shared/teams/team/member-row/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
-import {Avatar, Box, ClickableBox, Text, Icon, Usernames} from '../../../common-adapters'
-import {globalMargins, globalStyles} from '../../../styles'
+import {Avatar, Box, ClickableBox, Text, Icon, Usernames, Meta} from '../../../common-adapters'
+import {globalMargins, globalStyles, globalColors} from '../../../styles'
 import {isMobile} from '../../../constants/platform'
 import {roleIconColorMap} from '../../role-picker/index.meta'
 import {typeToLabel} from '../../../constants/teams'
@@ -40,11 +40,18 @@ export const TeamMemberRow = (props: Props) => {
     >
       <Avatar username={username} size={isMobile ? 48 : 32} />
       <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.small}}>
-        <Usernames
-          type="BodySemibold"
-          colorFollowing={true}
-          users={[{username, following, you: you === username}]}
-        />
+        <Box style={{...globalStyles.flexBoxRow, justifyContent: 'center'}}>
+          <Usernames
+            type="BodySemibold"
+            colorFollowing={true}
+            users={[{username, following, you: you === username}]}
+          />
+          {!active &&
+            <Meta
+              title="LOCKED OUT"
+              style={{background: globalColors.red, marginLeft: globalMargins.xtiny, marginTop: 4}}
+            />}
+        </Box>
         <Box style={globalStyles.flexBoxRow}>
           {type &&
             !!showCrown[type] &&


### PR DESCRIPTION
@keybase/react-hackers 

I didn't see any design for this on Zeplin, so I just made something up. This labels each member in the team page view as being "inactive" if the service sends this data up from `TeamGet`. The CLI already does this, and it is confusing to see these reset users being listed as equivalent to real users. cc @malgorithms if you have an objection.

![image](https://user-images.githubusercontent.com/1250314/33641380-478b31bc-da03-11e7-8dd2-7cc9caf84527.png)
