### PR TITLE
cleanup seitan reformatting

### DIFF
--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -242,10 +242,9 @@ func (h *TeamsHandler) TeamAcceptInvite(ctx context.Context, arg keybase1.TeamAc
 		return err
 	}
 
-	// If token is valid seitan, don't pass to functions that might log or send to server.
-	seitan, err := teams.GenerateIKeyFromString(arg.Token)
-	if err == nil {
-		return teams.AcceptSeitan(ctx, h.G().ExternalG(), seitan)
+	// If token looks at all like Seitan, don't pass to functions that might log or send to server.
+	if teams.IsSeitany(arg.Token) {
+		return teams.ParseAndAcceptSeitanToken(ctx, h.G().ExternalG(), arg.Token)
 	}
 
 	return teams.AcceptInvite(ctx, h.G().ExternalG(), arg.Token)

--- a/go/teams/seitan.go
+++ b/go/teams/seitan.go
@@ -30,17 +30,9 @@ const SeitanEncodedIKeyLength = 18
 const seitanEncodedIKeyPlusOffset = 5
 
 // Key-Base 30 encoding. lower case letters except "ilot", and digits except for '0' and '1'.
+// See TestSeitanParams for a test to make sure these two parameters match up.
 const KBase30EncodeStd = "abcdefghjkmnpqrsuvwxyz23456789"
-const base30BitMask = 0x1f
-
-func init() {
-	if len(KBase30EncodeStd) > base30BitMask {
-		panic(fmt.Sprintf("Bad base30BitMask; failed %d <= %d assertion", len(KBase30EncodeStd), base30BitMask))
-	}
-	if base30BitMask > 0xff {
-		panic(fmt.Sprintf("base30BitMask (%x) is greater than 2^8; this should never happen", base30BitMask))
-	}
-}
+const base30BitMask = byte(0x1f)
 
 // "Invite Key"
 type SeitanIKey string
@@ -66,7 +58,7 @@ func GenerateIKey() (ikey SeitanIKey, err error) {
 			if err != nil {
 				return byte(0), err
 			}
-			i := int(b[0]) & base30BitMask
+			i := int(b[0] & base30BitMask)
 			if i < len(alphabet) {
 				return alphabet[i], nil
 			}

--- a/go/teams/seitan.go
+++ b/go/teams/seitan.go
@@ -105,8 +105,8 @@ func GenerateIKeyFromString(token string) (ikey SeitanIKey, err error) {
 	if len(token) != SeitanEncodedIKeyLength {
 		return ikey, fmt.Errorf("invalid token length: expected %d characters, got %d", SeitanEncodedIKeyLength, len(token))
 	}
-	if token[4] != '+' {
-		return ikey, fmt.Errorf("invalid token format: expected fourth character to be '+'")
+	if token[seitanEncodedIKeyPlusOffset] != '+' {
+		return ikey, fmt.Errorf("invalid token format: expected %dth character to be '+'", seitanEncodedIKeyPlusOffset)
 	}
 
 	return SeitanIKey(strings.ToLower(token)), nil

--- a/go/teams/seitan_test.go
+++ b/go/teams/seitan_test.go
@@ -159,3 +159,13 @@ func TestSeitanKnownSamples(t *testing.T) {
 	require.Equal(t, peiKey.RandomNonce, peiKey2.RandomNonce)
 	require.Equal(t, peiKey.EncryptedIKeyAndLabel, peiKey2.EncryptedIKeyAndLabel)
 }
+
+func TestIsSeitany(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		ikey, err := GenerateIKey()
+		require.NoError(t, err)
+		require.True(t, IsSeitany(ikey.String()))
+		require.True(t, IsSeitany(ikey.String()[2:10]))
+		require.True(t, IsSeitany(ikey.String()[3:13]))
+	}
+}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -642,6 +642,14 @@ func AcceptInvite(ctx context.Context, g *libkb.GlobalContext, token string) err
 	return err
 }
 
+func ParseAndAcceptSeitanToken(ctx context.Context, g *libkb.GlobalContext, tok string) error {
+	seitan, err := GenerateIKeyFromString(tok)
+	if err != nil {
+		return err
+	}
+	return AcceptSeitan(ctx, g, seitan)
+}
+
 func AcceptSeitan(ctx context.Context, g *libkb.GlobalContext, ikey SeitanIKey) error {
 	me, err := libkb.LoadMe(libkb.NewLoadUserArgWithContext(ctx, g))
 	if err != nil {


### PR DESCRIPTION
- don't use BaseX encoding, it's overkill and too complicated here
- simplify IKey generation
- be way more conservative in asking what's a Seitan token, via `IsSeitany`