### PR TITLE
Fix AnnotateInvites failing for implicit admins on seitan decryption

### DIFF
--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -527,6 +527,12 @@ func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, team *Team) (m
 		} else if category == keybase1.TeamInviteCategory_SEITAN {
 			name, err = AnnotateSeitanInvite(ctx, team, invite)
 			if err != nil {
+				if _, ok := err.(SeitanNotAvailableError); ok {
+					// If user is an implicit admin, they have access to
+					// invite links but are not able to decrypt seitan
+					// tokens. Do not error out.
+					continue
+				}
 				return annotatedInvites, err
 			}
 		}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1124,6 +1124,11 @@ func CreateSeitanToken(ctx context.Context, g *libkb.GlobalContext, teamname str
 	}
 	ikey, err := t.InviteSeitan(ctx, role, label)
 	if err != nil {
+		if _, ok := err.(libkb.KeyMaskNotFoundError); ok {
+			// Return more descriptive error instead of
+			// "You don't have access to SEITAN_INVITE_TOKEN for this team".
+			return "", fmt.Errorf("Implicit admins cannot create invite tokens. If you want to create tokens for %q, add yourself as an admin member.", t.Name().String())
+		}
 		return "", err
 	}
 


### PR DESCRIPTION
This PR adds new error type `SeitanNotAvailableError` which is returned when `DecryptIKeyAndLabel` fails to decrypt ikey because of missing keymask. This usually means that the token itself is fine, but the admins has no access to team encryption keys. 

On the technical level, it just "catches" `KeyMaskNotFoundError` and returns `SeitanNotAvailableError` which will be more descriptive given the context.