### PR TITLE
try to fit entire teamname in seitan text

### DIFF
--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -197,18 +197,17 @@ const _inviteToTeamByPhone = function*(action: Types.InviteToTeamByPhone) {
   })
 
   /* Open SMS */
-  // seitan is 17chars
-  // message sans teamname is 120chars long. Absolute max teamname + descriptor can be is 40chars to fit within 160 sms limit
-  // max length of a teamname is 16chars, + 5|8 chars for descriptor is a max of 24chars for teamDescription
-  let teamDescription
+  // seitan is 18chars
+  // message sans teamname is 118chars. Teamname can be 33 chars before we truncate to 25 and pre-ellipsize
+  let team
   if (teamname.length <= 16) {
-    teamDescription = `${teamname} team`
+    team = `${teamname} team`
+  } else if (teamname.length <= 33) {
+    team = `${teamname} subteam`
   } else {
-    // then this must be a subteam, and won't safely fit into a text
-    const subteams = teamname.split('.')
-    teamDescription = `${subteams[subteams.length - 1]} subteam`
+    team = `..${teamname.substring(teamname.length - 30)} subteam`
   }
-  const bodyText = `Please join the ${teamDescription} on Keybase. Copy this entire message into the "Teams" tab.\n\ntoken: ${seitan.toLowerCase()}\n\nquick install: keybase.io/_/go`
+  const bodyText = `Join the ${team} on Keybase. Copy this message into the "Teams" tab.\n\ntoken: ${seitan.toLowerCase()}\n\ninstall: keybase.io/_/go`
   openSMS([phoneNumber], bodyText).catch(err => console.log('Error sending SMS', err))
 
   yield Saga.put(Creators.getDetails(teamname))


### PR DESCRIPTION
cc @malgorithms 

I went with a simpler version of what we talked about earlier; I trimmed extra words from the input and tried to fit as much teamname as possible into the text. The max length should be 153 characters.