### PR TITLE
Don't crash on null pending team join requests

### DIFF
--- a/shared/actions/teams/index.js
+++ b/shared/actions/teams/index.js
@@ -505,7 +505,7 @@ const _toggleChannelMembership = function*(
 
 const _checkRequestedAccess = function*(action: Types.CheckRequestedAccess): Saga.SagaGenerator<any, any> {
   const result = yield Saga.call(RPCTypes.teamsTeamListMyAccessRequestsRpcPromise, {})
-  const teams = result.map(row => row.parts[0])
+  const teams = result ? result.map(row => row.parts[0]) : []
   yield Saga.put(replaceEntity(['teams'], I.Map([['teamAccessRequestsPending', I.Set(teams)]])))
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

The empty array comes through from golang as null rather than [] so we can't call map without testing for null first.