### PR TITLE
Don't cancel seitan on bad akey

### DIFF
--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -333,8 +333,7 @@ func HandleTeamSeitan(ctx context.Context, g *libkb.GlobalContext, msg keybase1.
 
 		err := handleSeitanSingle(ctx, g, team, invite, seitan)
 		if err != nil {
-			g.Log.CDebugf(ctx, "Provided AKey failed to verify with error: \"%v\"; canceling invite.", err)
-			invitesToCancel = append(invitesToCancel, invite.Id)
+			g.Log.CDebugf(ctx, "Provided AKey failed to verify with error: %v; ignoring", err)
 			continue
 		}
 


### PR DESCRIPTION
As fallout from changing ikey format @mmaxim found that old clients will cancel bad seitan akeys. This won't fix the issue. But it seems our lives will be easier in the future if bad akeys are skipped

This has the downside that bad akeys can pileup in rekeyd forever.