### PR TITLE
fix syncing behavior when given full reload CORE-6775

### DIFF
--- a/shared/actions/chat-gen.js
+++ b/shared/actions/chat-gen.js
@@ -169,7 +169,7 @@ export const createStartConversation = (payload: {|+users: Array<string>, +force
 export const createSubtractEntity = (payload: {|+keyPath: Array<string>, +entities: I.List<any>|}) => ({error: false, payload, type: subtractEntity})
 export const createThreadLoadedOffline = (payload: {|+conversationIDKey: Types.ConversationIDKey|}) => ({error: false, payload, type: threadLoadedOffline})
 export const createToggleChannelWideNotifications = (payload: {|+conversationIDKey: Types.ConversationIDKey|}) => ({error: false, payload, type: toggleChannelWideNotifications})
-export const createUnboxConversations = (payload: {|+conversationIDKeys: Array<Types.ConversationIDKey>, +reason: string, +force?: boolean, +forInboxSync?: boolean|}) => ({error: false, payload, type: unboxConversations})
+export const createUnboxConversations = (payload: {|+conversationIDKeys: Array<Types.ConversationIDKey>, +reason: string, +force?: boolean, +forInboxSync?: boolean, +dismissSyncing?: boolean|}) => ({error: false, payload, type: unboxConversations})
 export const createUnboxMore = () => ({error: false, payload: undefined, type: unboxMore})
 export const createUpdateBadging = (payload: {|+conversationIDKey: Types.ConversationIDKey|}) => ({error: false, payload, type: updateBadging})
 export const createUpdateBrokenTracker = (payload: {|+userToBroken: {[username: string]: boolean}|}) => ({error: false, payload, type: updateBrokenTracker})

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -180,7 +180,11 @@ function* onInboxStale(action: ChatGen.InboxStalePayload): SagaGenerator<any, an
       .map(c => c.conversationIDKey)
 
     yield Saga.put(
-      ChatGen.createUnboxConversations({conversationIDKeys: toUnbox, reason: 'reloading entire inbox'})
+      ChatGen.createUnboxConversations({
+        conversationIDKeys: toUnbox,
+        reason: 'reloading entire inbox',
+        dismissSyncing: true,
+      })
     )
   } finally {
     if (yield Saga.cancelled()) {
@@ -451,7 +455,7 @@ const unboxConversationsSagaMap = {
 
 // Loads the trusted inbox segments
 function* unboxConversations(action: ChatGen.UnboxConversationsPayload): SagaGenerator<any, any> {
-  let {conversationIDKeys, reason, force, forInboxSync} = action.payload
+  let {conversationIDKeys, reason, force, forInboxSync, dismissSyncing} = action.payload
 
   const state: TypedState = yield Saga.select()
   const untrustedState = state.chat.inboxUntrustedState
@@ -532,7 +536,7 @@ function* unboxConversations(action: ChatGen.UnboxConversationsPayload): SagaGen
       console.warn('unboxConversations: error in loadInboxRpc', error)
     }
   }
-  if (forInboxSync) {
+  if (dismissSyncing) {
     yield Saga.put(ChatGen.createSetInboxSyncingState({inboxSyncingState: 'notSyncing'}))
   }
 }
@@ -726,6 +730,7 @@ function* _inboxSynced(action: ChatGen.InboxSyncedPayload): Saga.SagaGenerator<a
       reason: 'inbox syncing',
       force: true,
       forInboxSync: true,
+      dismissSyncing: true,
     })
   )
 

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -465,15 +465,9 @@ function* unboxConversations(action: ChatGen.UnboxConversationsPayload): SagaGen
 
   let newConvIDKeys = []
   const newUntrustedState = conversationIDKeys.reduce((map, c) => {
-    if (untrustedState.get(c) === 'unboxed') {
-      // only unbox unboxed if we force
-      if (force) {
-        map[c] = 'reUnboxing'
-        newConvIDKeys.push(c)
-      } else {
-        console.log(`unboxConversations: filtering conv: ${c} state: ${untrustedState.get(c, 'unknown')}`)
-      }
-      // only unbox if we're not currently unboxing
+    if (force) {
+      map[c] = 'reUnboxing'
+      newConvIDKeys.push(c)
     } else if (!['firstUnboxing', 'reUnboxing'].includes(untrustedState.get(c, 'untrusted'))) {
       // This means this is the first unboxing
       map[c] = 'firstUnboxing'

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -469,9 +469,15 @@ function* unboxConversations(action: ChatGen.UnboxConversationsPayload): SagaGen
 
   let newConvIDKeys = []
   const newUntrustedState = conversationIDKeys.reduce((map, c) => {
-    if (force) {
-      map[c] = 'reUnboxing'
-      newConvIDKeys.push(c)
+    if (untrustedState.get(c) === 'unboxed') {
+      // only unbox unboxed if we force
+      if (force) {
+        map[c] = 'reUnboxing'
+        newConvIDKeys.push(c)
+      } else {
+        console.log(`unboxConversations: filtering conv: ${c} state: ${untrustedState.get(c, 'unknown')}`)
+      }
+      // only unbox if we're not currently unboxing
     } else if (!['firstUnboxing', 'reUnboxing'].includes(untrustedState.get(c, 'untrusted'))) {
       // This means this is the first unboxing
       map[c] = 'firstUnboxing'

--- a/shared/actions/json/chat.json
+++ b/shared/actions/json/chat.json
@@ -97,7 +97,8 @@
       "conversationIDKeys": "Array<Types.ConversationIDKey>",
       "reason": "string",
       "force?": "boolean",
-      "forInboxSync?": "boolean"
+      "forInboxSync?": "boolean",
+      "dismissSyncing?": "boolean"
     },
     "selectNext": {
       "rows": "Array<{conversationIDKey: Types.ConversationIDKey}>",

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -133,6 +133,14 @@ function reducer(state: Types.State = initialState, action: ChatGen.Actions) {
         })
       )
     }
+    case ChatGen.inboxStale: {
+      return state.update('conversationStates', conversationStates =>
+        conversationStates.map((conversationState, conversationIDKey) => {
+          console.log(`reducer: setting thread stale from inbox stale: ${conversationIDKey}`)
+          return conversationState.set('isStale', true)
+        })
+      )
+    }
     case ChatGen.updateLatestMessage:
       // Clear new messages id of conversation
       const newConversationStates = state
@@ -302,7 +310,6 @@ function reducer(state: Types.State = initialState, action: ChatGen.Actions) {
     case ChatGen.downloadProgress:
     case ChatGen.editMessage:
     case ChatGen.getInboxAndUnbox:
-    case ChatGen.inboxStale:
     case ChatGen.inboxStoreLoaded:
     case ChatGen.incomingMessage:
     case ChatGen.incomingTyping:


### PR DESCRIPTION
@keybase/react-hackers 

I think this should get into the mobile release, it does the following:

1.) Fixes handling a full inbox reload triggered by the service. The reaction to this is to generate an `inboxStale` action, which previous to this patch would just trigger the `onInboxStale` saga. Now we also add a reducer that marks every thread that we have loaded as stale. This way the next click on that thread will hit the service, instead of showing whatever we had loaded earlier.
2.) Fixes the inbox loading blue bar when receiving this same event. Previously, the blue bar would just get stuck to be always on. 