### PR TITLE
Mobile team page tweaks

### DIFF
--- a/shared/chat/manage-channels/index.native.js
+++ b/shared/chat/manage-channels/index.native.js
@@ -89,7 +89,6 @@ const ManageChannels = (props: Props) => (
     </ScrollView>
     <Box
       style={{
-        flex: 2,
         ...globalStyles.flexBoxColumn,
         justifyContent: 'flex-end',
         paddingBottom: globalMargins.small,

--- a/shared/teams/add-people/index.js
+++ b/shared/teams/add-people/index.js
@@ -67,11 +67,11 @@ const AddPeople = (props: Props) => (
         style={{
           ...(isMobile ? globalStyles.flexBoxColumn : globalStyles.flexBoxRow),
           alignItems: 'center',
-          margin: globalMargins.small,
+          margin: isMobile ? 0 : globalMargins.small,
         }}
       >
-        <Text style={{margin: globalMargins.tiny}} type="Body">
-          Add these team members to {props.name} as:
+        <Text type="Body">
+          Add these members to {props.name} as:
         </Text>
         <ClickableBox onClick={() => props.onOpenRolePicker()}>
           <Dropdown

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -334,7 +334,13 @@ class Team extends React.PureComponent<Props> {
                 paddingTop: globalMargins.small,
               }}
             >
-              <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', paddingRight: globalMargins.tiny}}>
+              <Box
+                style={{
+                  ...globalStyles.flexBoxColumn,
+                  alignItems: 'center',
+                  paddingRight: globalMargins.tiny,
+                }}
+              >
                 <Checkbox
                   checked={publicityMember}
                   disabled={!youCanShowcase}
@@ -362,11 +368,7 @@ class Team extends React.PureComponent<Props> {
 
               <Box style={stylesSettingsTabRow}>
                 <Box style={stylesPublicitySettingsBox}>
-                  <Checkbox
-                    checked={publicityAnyMember}
-                    label=""
-                    onCheck={setPublicityAnyMember}
-                  />
+                  <Checkbox checked={publicityAnyMember} label="" onCheck={setPublicityAnyMember} />
                 </Box>
                 <Box style={{...globalStyles.flexBoxColumn, flexShrink: 1}}>
                   <Text type="Body">
@@ -380,11 +382,7 @@ class Team extends React.PureComponent<Props> {
 
               <Box style={stylesSettingsTabRow}>
                 <Box style={stylesPublicitySettingsBox}>
-                  <Checkbox
-                    checked={publicityTeam}
-                    label=""
-                    onCheck={setPublicityTeam}
-                  />
+                  <Checkbox checked={publicityTeam} label="" onCheck={setPublicityTeam} />
                 </Box>
                 <Box style={{...globalStyles.flexBoxColumn, flexShrink: 1}}>
                   <Text type="Body">
@@ -407,7 +405,9 @@ class Team extends React.PureComponent<Props> {
                     style={{paddingRight: globalMargins.xtiny}}
                   />
                 </Box>
-                <Box style={{...globalStyles.flexBoxColumn, flexShrink: 1, paddingRight: globalMargins.small}}>
+                <Box
+                  style={{...globalStyles.flexBoxColumn, flexShrink: 1, paddingRight: globalMargins.small}}
+                >
                   <Text type="Body">
                     Make this an open team
                   </Text>

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -334,7 +334,7 @@ class Team extends React.PureComponent<Props> {
                 paddingTop: globalMargins.small,
               }}
             >
-              <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center'}}>
+              <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', paddingRight: globalMargins.tiny}}>
                 <Checkbox
                   checked={publicityMember}
                   disabled={!youCanShowcase}
@@ -361,12 +361,11 @@ class Team extends React.PureComponent<Props> {
               </Box>
 
               <Box style={stylesSettingsTabRow}>
-                <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center'}}>
+                <Box style={stylesPublicitySettingsBox}>
                   <Checkbox
                     checked={publicityAnyMember}
                     label=""
                     onCheck={setPublicityAnyMember}
-                    style={{paddingRight: globalMargins.xtiny}}
                   />
                 </Box>
                 <Box style={{...globalStyles.flexBoxColumn, flexShrink: 1}}>
@@ -380,12 +379,11 @@ class Team extends React.PureComponent<Props> {
               </Box>
 
               <Box style={stylesSettingsTabRow}>
-                <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center'}}>
+                <Box style={stylesPublicitySettingsBox}>
                   <Checkbox
                     checked={publicityTeam}
                     label=""
                     onCheck={setPublicityTeam}
-                    style={{paddingRight: globalMargins.xtiny}}
                   />
                 </Box>
                 <Box style={{...globalStyles.flexBoxColumn, flexShrink: 1}}>
@@ -401,7 +399,7 @@ class Team extends React.PureComponent<Props> {
               </Box>
 
               <Box style={stylesSettingsTabRow}>
-                <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center'}}>
+                <Box style={stylesPublicitySettingsBox}>
                   <Checkbox
                     checked={openTeam}
                     label=""
@@ -409,7 +407,7 @@ class Team extends React.PureComponent<Props> {
                     style={{paddingRight: globalMargins.xtiny}}
                   />
                 </Box>
-                <Box style={{...globalStyles.flexBoxColumn, flexShrink: 1}}>
+                <Box style={{...globalStyles.flexBoxColumn, flexShrink: 1, paddingRight: globalMargins.small}}>
                   <Text type="Body">
                     Make this an open team
                   </Text>
@@ -432,7 +430,7 @@ class Team extends React.PureComponent<Props> {
             style={{
               ...stylesSettingsTabRow,
               justifyContent: 'center',
-              paddingTop: isMobile ? globalMargins.xtiny : globalMargins.tiny,
+              padding: globalMargins.small,
             }}
           >
             <Button
@@ -547,6 +545,12 @@ const stylesAddYourselfBanner = {
 const stylesAddYourselfBannerText = {
   color: globalColors.white,
   textAlign: 'center',
+}
+
+const stylesPublicitySettingsBox = {
+  ...globalStyles.flexBoxColumn,
+  alignItems: 'center',
+  paddingRight: globalMargins.small,
 }
 
 const stylesSettingsTabRow = {


### PR DESCRIPTION
@keybase/react-hackers 

* Free up some vertical space on "Add People" to team so that the results aren't totally covered by the keyboard on iPhone SE

* Fix the Save button overlapping the channel list on Manage Channels

* Add some padding to the checkboxes on publicity settings