### PR TITLE
Allow KBFSSettings links on unimplicit teams too

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -1496,9 +1496,6 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		if err != nil {
 			return res, err
 		}
-		if !team.Implicit {
-			return res, NewExplicitTeamOperationError("KBFS settings")
-		}
 
 		res.newState = prevState.DeepCopy()
 		res.newState.informKBFSSettings(*team.KBFS)


### PR DESCRIPTION
@strib wants to store tlfids on normal teams too.

Getting the TLFID out to KBFS on an RPC we could do any time, but removing this check the sooner the better. Because these links will break the team sigchain for clients before this PR.