### PR TITLE
Chat cli show system messages

### DIFF
--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
 )
 
 const publicConvNamePrefix = "(public) "
@@ -216,6 +217,7 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 		for _, m := range conv.MaxMessages {
 			mv2, err := newMessageView(g, conv.Info.Id, m)
 			if err != nil {
+				g.Log.CDebugf(context.TODO(), "Message render error: %s", err)
 				continue
 			}
 			if !mv2.Renderable {
@@ -430,14 +432,14 @@ func formatSystemMessage(body chat1.MessageSystem) string {
 	typ, _ := body.SystemType()
 	switch typ {
 	case chat1.MessageSystemType_ADDEDTOTEAM:
-		return fmt.Sprintf("Hello! I've just added @%s to this team.", body.Addedtoteam().Addee)
+		return fmt.Sprintf("[Added @%s to the team]", body.Addedtoteam().Addee)
 	case chat1.MessageSystemType_INVITEADDEDTOTEAM:
-		return fmt.Sprintf("Hello! I've just added @%s to the team. This user had been invited by @%s.",
+		return fmt.Sprintf("[Added %s to the team (invited by @%s)]",
 			body.Inviteaddedtoteam().Invitee, body.Inviteaddedtoteam().Inviter)
 	case chat1.MessageSystemType_COMPLEXTEAM:
-		return fmt.Sprintf(`Attention @channel! I have just created a new channel in team %s. Here are some things that are now different: 1.) Notifications will not happen for every message. Click or tap the info icon on the right to configure them. 2.) The #general channel is now in the "Big Teams" section of the inbox. 3.) You can hit the three dots next to %s in the inbox view to join other channels. Enjoy!`, body.Complexteam().Team, body.Complexteam().Team)
+		return fmt.Sprintf("[Created a new channel in %s]", body.Complexteam().Team)
 	case chat1.MessageSystemType_CREATETEAM:
-		return fmt.Sprintf("Team %s created by %s.", body.Createteam().Team, body.Createteam().Creator)
+		return fmt.Sprintf("[%s created the team %s]", body.Createteam().Creator, body.Createteam().Team)
 	}
 	return "<unknown system message>"
 }

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -211,17 +211,22 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 		}
 
 		unread := ""
-		// show the last TEXT message
+		// Show the last visible message.
 		var msg *chat1.MessageUnboxed
 		for _, m := range conv.MaxMessages {
-			if m.GetMessageType() == chat1.MessageType_TEXT || m.GetMessageType() == chat1.MessageType_ATTACHMENT {
-				if conv.ReaderInfo.ReadMsgid < m.GetMessageID() {
-					unread = "*"
-				}
-				if msg == nil || m.GetMessageID() > msg.GetMessageID() {
-					mCopy := m
-					msg = &mCopy
-				}
+			mv2, err := newMessageView(g, conv.Info.Id, m)
+			if err != nil {
+				continue
+			}
+			if !mv2.Renderable {
+				continue
+			}
+			if conv.ReaderInfo.ReadMsgid < m.GetMessageID() {
+				unread = "*"
+			}
+			if msg == nil || m.GetMessageID() > msg.GetMessageID() {
+				mCopy := m
+				msg = &mCopy
 			}
 		}
 		if msg == nil {
@@ -490,10 +495,10 @@ func newMessageViewValid(g *libkb.GlobalContext, conversationID chat1.Conversati
 		mv.Renderable = false
 	case chat1.MessageType_JOIN:
 		mv.Renderable = true
-		mv.Body = "<joined the channel>"
+		mv.Body = "[Joined the channel]"
 	case chat1.MessageType_LEAVE:
 		mv.Renderable = true
-		mv.Body = "<left the channel>"
+		mv.Body = "[Left the channel]"
 	case chat1.MessageType_SYSTEM:
 		mv.Renderable = true
 		mv.Body = formatSystemMessage(m.MessageBody.System())

--- a/go/client/cmd_chat_leavechannel.go
+++ b/go/client/cmd_chat_leavechannel.go
@@ -63,7 +63,7 @@ func (c *CmdChatLeaveChannel) Run() error {
 
 func (c *CmdChatLeaveChannel) ParseArgv(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) != 2 {
-		cli.ShowCommandHelp(ctx, "join-channel")
+		cli.ShowCommandHelp(ctx, "leave-channel")
 		return fmt.Errorf("Incorrect usage.")
 	}
 	teamName := ctx.Args().Get(0)


### PR DESCRIPTION
Fix CLI display of system, join, and leave messages. Also tone down system messages to be more robotic so they don't sound like the person typed them out.

Show this:
```
$ kbu chat ls
[1]  cn3team9 [#general]  [cn3 11m] hi
[2]  cn3team13 [#general] [cn3 3d] [cn3 created the team cn3team13]
[3]  cn3team12 [#general] [cn3 3d] [Added @cn4 to the team]
[4]  cn3team12 [#store]   [cn3 2m] [Joined the channel]
```

Instead of this:
```
$ _kbu_ chat ls
[1]  cn3team9 [#general]  [cn3 40s] hi
...
[4]  cn3team10 [#general]     [???] <<chat read error: <no snippet available>>>
```
