### PR TITLE
just send leave message to leave a channel CORE-6577

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -620,24 +620,15 @@ func LeaveConversation(ctx context.Context, g *globals.Context, debugger utils.D
 		rl = append(rl, *irl)
 	}
 
-	// Send a message to the channel before leaving
+	// Send a message to the channel to leave the conversation
 	if alreadyIn {
 		leaveMessageBody := chat1.NewMessageBodyWithLeave(chat1.MessageLeave{})
 		irl, err := postJoinLeave(ctx, g, ri, uid, convID, leaveMessageBody)
 		if err != nil {
 			debugger.Debug(ctx, "LeaveConversation: posting leave-conv message failed: %v", err)
-			// ignore the error
+			return rl, err
 		}
 		rl = append(rl, irl...)
-	}
-
-	leaveRes, err := ri().LeaveConversation(ctx, convID)
-	if err != nil {
-		debugger.Debug(ctx, "LeaveConversation: failed to leave conversation: %s", err.Error())
-		return rl, err
-	}
-	if leaveRes.RateLimit != nil {
-		rl = append(rl, *leaveRes.RateLimit)
 	}
 
 	return rl, nil

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -442,6 +442,13 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				DeviceID: keybase1.DeviceID(nm.Message.ClientHeader.SenderDevice.String()),
 			}, convID, false)
 
+			// Check for a leave message from ourselves and just bail out if it is
+			if nm.Message.GetMessageType() == chat1.MessageType_LEAVE &&
+				nm.Message.ClientHeader.Sender.Eq(uid) {
+				g.Debug(ctx, "chat activity: ignoring leave message from oursevles")
+				return
+			}
+
 			decmsg, appended, pushErr := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 			if pushErr != nil {
 				g.Debug(ctx, "chat activity: unable to push message: %s", pushErr.Error())

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -603,10 +603,10 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	// Write new message out to cache
 	s.Debug(ctx, "sending local updates to chat sources")
 	if _, _, err = s.G().ConvSource.Push(ctx, convID, boxed.ClientHeader.Sender, *boxed); err != nil {
-		return chat1.OutboxID{}, nil, nil, err
+		s.Debug(ctx, "failed to push new message into convsource: %s", err)
 	}
 	if _, err = s.G().InboxSource.NewMessage(ctx, boxed.ClientHeader.Sender, 0, convID, *boxed); err != nil {
-		return chat1.OutboxID{}, nil, nil, err
+		s.Debug(ctx, "failed to update inbox: %s", err)
 	}
 	return []byte{}, boxed, plres.RateLimit, nil
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2390,14 +2390,17 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		listener0 := newServerChatListener()
 		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
+		ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
 
 		listener1 := newServerChatListener()
 		ctc.as(t, users[1]).h.G().SetService()
 		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener1)
+		ctc.world.Tcs[users[1].Username].ChatG.Syncer.(*Syncer).isConnected = true
 
 		listener2 := newServerChatListener()
 		ctc.as(t, users[2]).h.G().SetService()
 		ctc.as(t, users[2]).h.G().NotifyRouter.SetListener(listener2)
+		ctc.world.Tcs[users[2].Username].ChatG.Syncer.(*Syncer).isConnected = true
 
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
 			mt, ctc.as(t, users[1]).user(), ctc.as(t, users[2]).user())
@@ -2534,7 +2537,6 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			ncres.Conv.GetConvID())
 		require.NoError(t, err)
 		consumeNewMsg(t, listener0, chat1.MessageType_LEAVE)
-		consumeNewMsg(t, listener1, chat1.MessageType_LEAVE)
 		consumeNewMsg(t, listener2, chat1.MessageType_LEAVE)
 		select {
 		case convID := <-listener1.leftConv:
@@ -2606,7 +2608,6 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		require.NoError(t, err)
 		consumeNewMsg(t, listener0, chat1.MessageType_LEAVE)
 		consumeNewMsg(t, listener1, chat1.MessageType_LEAVE)
-		consumeNewMsg(t, listener2, chat1.MessageType_LEAVE)
 		consumeLeaveConv(t, listener2)
 		_, err = ctc.as(t, users[2]).chatLocalHandler().PreviewConversationByIDLocal(ctx2, ncres.Conv.Info.Id)
 		require.NoError(t, err)


### PR DESCRIPTION
Patch does the following:

1.) Use new server API to leave a channel upon reception of a leave message. This way we don't have a built in race about leaving a channel and then generating the leave message into the channel.
2.) Ignore Gregor new messages that are leave messages from ourselves. These will just fail anyway, so save ourselves the trouble and don't even try.

Depends on https://github.com/keybase/keybase/pull/1986 being live.