### PR TITLE
add a debug command for UPAKs

### DIFF
--- a/go/client/cmd_upak.go
+++ b/go/client/cmd_upak.go
@@ -1,0 +1,102 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+type cmdUPAK struct {
+	libkb.Contextified
+	uid keybase1.UID
+	kid keybase1.KID
+}
+
+func NewCmdUPAK(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "upak",
+		Description:  "Dump a UPAK",
+		ArgumentHelp: "uid",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "k, kid",
+				Usage: "KID to query",
+			},
+		},
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&cmdUPAK{Contextified: libkb.NewContextified(g)}, "upak", c)
+		},
+	}
+}
+
+func (c *cmdUPAK) Run() error {
+	userClient, err := GetUserClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	if err = RegisterProtocolsWithContext(nil, c.G()); err != nil {
+		return err
+	}
+
+	res, err := userClient.GetUPAK(context.Background(), c.uid)
+	if err != nil {
+		return err
+	}
+	jsonOut, err := json.Marshal(res)
+	if err != nil {
+		return err
+	}
+	if !c.kid.IsNil() {
+		v, err := res.V()
+		if err != nil {
+			return err
+		}
+		if v != keybase1.UPAKVersion_V2 {
+			return fmt.Errorf("didn't get UPAK v2")
+		}
+		upk2, _ := res.V2().FindKID(c.kid)
+		if upk2 == nil {
+			return fmt.Errorf("key %s wasn't found", c.kid)
+		}
+	}
+
+	c.G().UI.GetTerminalUI().Output(string(jsonOut) + "\n")
+	return nil
+}
+
+func (c *cmdUPAK) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		return errors.New("need a UID argument")
+	}
+	var err error
+	c.uid, err = keybase1.UIDFromString(ctx.Args()[0])
+	if err != nil {
+		return err
+	}
+	kid := ctx.String("kid")
+	if len(kid) > 0 {
+		c.kid, err = keybase1.KIDFromStringChecked(kid)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *cmdUPAK) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -59,6 +59,7 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdUnlock(cl, g),
 		NewCmdUntrack(cl, g),
 		NewCmdUpdate(cl, g),
+		NewCmdUPAK(cl, g),
 		NewCmdVerify(cl, g),
 		NewCmdVersion(cl, g),
 	}

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -338,3 +338,16 @@ func (h *UserHandler) MeUserVersion(ctx context.Context, sessionID int) (res key
 	}
 	return upak.Current.ToUserVersion(), nil
 }
+
+func (h *UserHandler) GetUPAK(ctx context.Context, uid keybase1.UID) (ret keybase1.UPAKVersioned, err error) {
+	arg := libkb.NewLoadUserArg(h.G()).WithNetContext(ctx).WithUID(uid).WithPublicKeyOptional()
+	upak, _, err := h.G().GetUPAKLoader().LoadV2(arg)
+	if err != nil {
+		return ret, err
+	}
+	if upak == nil {
+		return ret, libkb.UserNotFoundError{UID: uid, Msg: "upak load failed"}
+	}
+	ret = keybase1.NewUPAKVersionedWithV2(*upak)
+	return ret, err
+}

--- a/protocol/avdl/keybase1/upk.avdl
+++ b/protocol/avdl/keybase1/upk.avdl
@@ -111,4 +111,6 @@ protocol UPK {
       case V1: UserPlusAllKeys;
       case V2: UserPlusKeysV2AllIncarnations;
   }
+
+
 }

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -148,4 +148,9 @@ protocol user {
 
   UserVersion meUserVersion(int sessionID);
 
+  /**
+   getUPAK returns a UPAK. Used mainly for debugging.
+  */
+  @lint("ignore")
+  UPAKVersioned getUPAK(UID uid);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1750,6 +1750,10 @@ export const userDeleteUserRpcChannelMap = (configKeys: Array<string>, request: 
 
 export const userDeleteUserRpcPromise = (request: UserDeleteUserRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.deleteUser', request, (error: RPCError, result: void) => error ? reject(error) : resolve()))
 
+export const userGetUPAKRpcChannelMap = (configKeys: Array<string>, request: UserGetUPAKRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.getUPAK', request)
+
+export const userGetUPAKRpcPromise = (request: UserGetUPAKRpcParam): Promise<UserGetUPAKResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.getUPAK', request, (error: RPCError, result: UserGetUPAKResult) => error ? reject(error) : resolve(result)))
+
 export const userInterestingPeopleRpcChannelMap = (configKeys: Array<string>, request: UserInterestingPeopleRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.interestingPeople', request)
 
 export const userInterestingPeopleRpcPromise = (request: UserInterestingPeopleRpcParam): Promise<UserInterestingPeopleResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.interestingPeople', request, (error: RPCError, result: UserInterestingPeopleResult) => error ? reject(error) : resolve(result)))
@@ -3733,6 +3737,8 @@ export type UserCard = {|following: Int,followers: Int,uid: UID,fullName: String
 
 export type UserDeleteUserRpcParam = ?{|incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 
+export type UserGetUPAKRpcParam = {|uid: UID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
+
 export type UserInterestingPeopleRpcParam = {|maxUsers: Int,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 
 export type UserListTrackers2RpcParam = {|assertion: String,reverse: Boolean,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
@@ -3974,6 +3980,7 @@ type TlfKeysGetTLFCryptKeysResult = GetTLFCryptKeysRes
 type TlfPublicCanonicalTLFNameAndIDResult = CanonicalTLFNameAndIDWithBreaks
 type TrackTrackResult = ConfirmResult
 type UiPromptYesNoResult = Boolean
+type UserGetUPAKResult = UPAKVersioned
 type UserInterestingPeopleResult = ?Array<InterestingPerson>
 type UserListTrackers2Result = UserSummary2Set
 type UserListTrackersByNameResult = ?Array<Tracker>

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -567,6 +567,17 @@
         }
       ],
       "response": "UserVersion"
+    },
+    "getUPAK": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "UID"
+        }
+      ],
+      "response": "UPAKVersioned",
+      "doc": "getUPAK returns a UPAK. Used mainly for debugging.",
+      "lint": "ignore"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1750,6 +1750,10 @@ export const userDeleteUserRpcChannelMap = (configKeys: Array<string>, request: 
 
 export const userDeleteUserRpcPromise = (request: UserDeleteUserRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.deleteUser', request, (error: RPCError, result: void) => error ? reject(error) : resolve()))
 
+export const userGetUPAKRpcChannelMap = (configKeys: Array<string>, request: UserGetUPAKRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.getUPAK', request)
+
+export const userGetUPAKRpcPromise = (request: UserGetUPAKRpcParam): Promise<UserGetUPAKResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.getUPAK', request, (error: RPCError, result: UserGetUPAKResult) => error ? reject(error) : resolve(result)))
+
 export const userInterestingPeopleRpcChannelMap = (configKeys: Array<string>, request: UserInterestingPeopleRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.interestingPeople', request)
 
 export const userInterestingPeopleRpcPromise = (request: UserInterestingPeopleRpcParam): Promise<UserInterestingPeopleResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.interestingPeople', request, (error: RPCError, result: UserInterestingPeopleResult) => error ? reject(error) : resolve(result)))
@@ -3733,6 +3737,8 @@ export type UserCard = {|following: Int,followers: Int,uid: UID,fullName: String
 
 export type UserDeleteUserRpcParam = ?{|incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 
+export type UserGetUPAKRpcParam = {|uid: UID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
+
 export type UserInterestingPeopleRpcParam = {|maxUsers: Int,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 
 export type UserListTrackers2RpcParam = {|assertion: String,reverse: Boolean,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
@@ -3974,6 +3980,7 @@ type TlfKeysGetTLFCryptKeysResult = GetTLFCryptKeysRes
 type TlfPublicCanonicalTLFNameAndIDResult = CanonicalTLFNameAndIDWithBreaks
 type TrackTrackResult = ConfirmResult
 type UiPromptYesNoResult = Boolean
+type UserGetUPAKResult = UPAKVersioned
 type UserInterestingPeopleResult = ?Array<InterestingPerson>
 type UserListTrackers2Result = UserSummary2Set
 type UserListTrackersByNameResult = ?Array<Tracker>


### PR DESCRIPTION
- This command shows it should not be a problem to reset users and check UPAKs. I'm pretty sure the case @mmaxim  found was due to a bad cached object from August
- If we ever do see a problem, this is a useful debugging command to try; you can also query a particular KID to make sure it shows up in the previous incarnations