### PR TITLE
Remove team resolver MapIDToName

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -599,7 +599,6 @@ type ConnectivityMonitor interface {
 type TeamLoader interface {
 	VerifyTeamName(ctx context.Context, id keybase1.TeamID, name keybase1.TeamName) error
 	ImplicitAdmins(ctx context.Context, teamID keybase1.TeamID) (impAdmins []keybase1.UserVersion, err error)
-	MapIDToName(ctx context.Context, id keybase1.TeamID) (keybase1.TeamName, error)
 	NotifyTeamRename(ctx context.Context, id keybase1.TeamID, newName string) error
 	Load(context.Context, keybase1.LoadTeamArg) (*keybase1.TeamData, error)
 	// Delete the cache entry. Does not error if there is no cache entry.

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -209,14 +209,6 @@ func (r *Resolver) getFromUPAKLoader(ctx context.Context, uid keybase1.UID) (ret
 	return &ResolveResult{uid: uid, queriedByUID: true, resolvedKbUsername: nun.String(), mutable: false}
 }
 
-func (r *Resolver) getFromTeamLoader(ctx context.Context, tid keybase1.TeamID) (ret *ResolveResult) {
-	tn, err := r.G().GetTeamLoader().MapIDToName(ctx, tid)
-	if err != nil || tn.IsNil() {
-		return nil
-	}
-	return &ResolveResult{teamID: tid, resolvedTeamName: tn, mutable: false}
-}
-
 func (r *Resolver) resolveURL(ctx context.Context, au AssertionURL, input string, withBody bool, needUsername bool) (res ResolveResult) {
 	ck := au.CacheKey()
 
@@ -253,16 +245,6 @@ func (r *Resolver) resolveURL(ctx context.Context, au AssertionURL, input string
 	// We can check the UPAK loader for the username if we're just mapping a UID to a username.
 	if tmp := au.ToUID(); !withBody && tmp.Exists() {
 		if p := r.getFromUPAKLoader(ctx, tmp); p != nil {
-			trace += "l"
-			r.putToMemCache(ck, *p)
-			return *p
-		}
-	}
-
-	// Similarly, we can check the team loader for the team name if we're just mapping a TeamID
-	// to a team name
-	if tmp := au.ToTeamID(); !withBody && tmp.Exists() {
-		if p := r.getFromTeamLoader(ctx, tmp); p != nil {
 			trace += "l"
 			r.putToMemCache(ck, *p)
 			return *p

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -1074,10 +1074,6 @@ func (l *TeamLoader) implicitAdminsAncestor(ctx context.Context, teamID keybase1
 	return impAdmins, nil
 }
 
-func (l *TeamLoader) MapIDToName(ctx context.Context, id keybase1.TeamID) (keybase1.TeamName, error) {
-	return keybase1.TeamName{}, nil
-}
-
 func (l *TeamLoader) NotifyTeamRename(ctx context.Context, id keybase1.TeamID, newName string) error {
 	// ignore newName from the server
 


### PR DESCRIPTION
`TeamLoader.MapIDToName` doesn't do anything but also returns `err=nil`. This change should not change any behavior.