### PR TITLE
revert to using logfiles instead of the systemd journal

### DIFF
--- a/go/libkb/log_send.go
+++ b/go/libkb/log_send.go
@@ -362,16 +362,11 @@ func (l *LogSendContext) LogSend(statusJSON, feedback string, sendLogs bool, num
 	var gitLog string
 
 	if sendLogs {
-		if l.G().Env.WantsSystemd() {
-			svcLog = tailSystemdJournal(l.G().Log, "keybase.service", numBytes)
-			kbfsLog = tailSystemdJournal(l.G().Log, "kbfs.service", numBytes)
-			desktopLog = tailSystemdJournal(l.G().Log, "keybase.gui.service", numBytes)
-		} else {
-			svcLog = tail(l.G().Log, "service", logs.Service, numBytes)
-			kbfsLog = tail(l.G().Log, "kbfs", logs.Kbfs, numBytes)
-			desktopLog = tail(l.G().Log, "desktop", logs.Desktop, numBytes)
-		}
+		svcLog = tail(l.G().Log, "service", logs.Service, numBytes)
+		kbfsLog = tail(l.G().Log, "kbfs", logs.Kbfs, numBytes)
+		desktopLog = tail(l.G().Log, "desktop", logs.Desktop, numBytes)
 		updaterLog = tail(l.G().Log, "updater", logs.Updater, numBytes)
+		// TODO: get start logs from systemd?
 		startLog = tail(l.G().Log, "start", logs.Start, numBytes)
 		installLog = tail(l.G().Log, "install", logs.Install, numBytes)
 		systemLog = tail(l.G().Log, "system", logs.System, numBytes)

--- a/packaging/linux/systemd/kbfs.service
+++ b/packaging/linux/systemd/kbfs.service
@@ -11,7 +11,7 @@ Type=notify
 # Without this line, `systemctl --user restart kbfs.service` will hit mount
 # failures if there are any running shells cd'd into a Keybase folder.
 ExecStartPre=-/usr/bin/env fusermount -uz /keybase
-ExecStart=/usr/bin/kbfsfuse -debug /keybase
+ExecStart=/usr/bin/kbfsfuse -debug -log-to-file /keybase
 Restart=on-failure
 
 [Install]

--- a/packaging/linux/systemd/keybase.gui.service
+++ b/packaging/linux/systemd/keybase.gui.service
@@ -4,7 +4,8 @@ Wants=keybase.service kbfs.service
 
 [Service]
 Type=simple
-ExecStart=/opt/keybase/Keybase
+ExecStartPre=/usr/bin/env mkdir -p %h/.cache/keybase
+ExecStart=/usr/bin/env bash -c "/opt/keybase/Keybase &>> %h/.cache/keybase/Keybase.app.log"
 # The environment file lets run_keybase pass along KEYBASE_START_UI. The
 # autostart file will set that to suppress showing the main window during boot.
 # %t is the XDG_RUNTIME_DIR, and the leading - means it's ok if the file is

--- a/packaging/linux/systemd/keybase.service
+++ b/packaging/linux/systemd/keybase.service
@@ -5,7 +5,7 @@ Description=Keybase core service
 # "notify" means we promise to call SdNotify() at the end of startup.
 Type=notify
 Environment=KEYBASE_SERVICE_TYPE=systemd
-ExecStart=/usr/bin/keybase --debug service
+ExecStart=/usr/bin/keybase --debug --log-file=%h/.cache/keybase/keybase.service.log service
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Unfortunately some distros that use systemd don't configure its journal
to be persisted between boots (because they prefer to forward things to
syslog). That means we shouldn't rely on it for `keybase log send`, or
else we'll lose info about e.g. crashes caused by the FUSE kernel
module.

r? @jzila   (cc @MarcoPolo)