### PR TITLE
add convenience function for adding a user back into a team conversation

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/teams"
+
 	"encoding/base64"
 	"encoding/hex"
 
@@ -2507,4 +2509,36 @@ func (h *Server) GetGlobalAppNotificationSettingsLocal(ctx context.Context) (res
 		return res, err
 	}
 	return h.remoteClient().GetGlobalAppNotificationSettings(ctx)
+}
+
+func (h *Server) AddImplicitTeamMemberAfterReset(ctx context.Context,
+	arg chat1.AddImplicitTeamMemberAfterResetArg) (err error) {
+	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, nil, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, "AddImplicitTeamMemberAfterReset")()
+	if err = h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
+	uid := gregor1.UID(h.G().Env.GetUID().ToBytes())
+
+	// Lookup conversation to get team ID
+	iboxRes, _, err := h.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
+		ConvIDs: []chat1.ConversationID{arg.ConvID},
+	}, nil)
+	if err != nil {
+		return err
+	}
+	if len(iboxRes.Convs) != 1 {
+		return errors.New("failed to find conversation to add reset user back into")
+	}
+	conv := iboxRes.Convs[0]
+	switch conv.Info.MembersType {
+	case chat1.ConversationMembersType_IMPTEAM, chat1.ConversationMembersType_TEAM:
+		// this is ok for these convs
+	default:
+		return fmt.Errorf("unable to add member back to non team conversation: %v",
+			conv.Info.MembersType)
+	}
+
+	teamID := keybase1.TeamID(conv.Info.Triple.Tlfid.String())
+	return teams.ReAddMemberAfterReset(ctx, h.G().ExternalG(), teamID, arg.Username)
 }

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2511,10 +2511,10 @@ func (h *Server) GetGlobalAppNotificationSettingsLocal(ctx context.Context) (res
 	return h.remoteClient().GetGlobalAppNotificationSettings(ctx)
 }
 
-func (h *Server) AddImplicitTeamMemberAfterReset(ctx context.Context,
-	arg chat1.AddImplicitTeamMemberAfterResetArg) (err error) {
+func (h *Server) AddTeamMemberAfterReset(ctx context.Context,
+	arg chat1.AddTeamMemberAfterResetArg) (err error) {
 	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, nil, h.identNotifier)
-	defer h.Trace(ctx, func() error { return err }, "AddImplicitTeamMemberAfterReset")()
+	defer h.Trace(ctx, func() error { return err }, "AddTeamMemberAfterReset")()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return err
 	}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3405,8 +3405,8 @@ func TestChatSrvUserReset(t *testing.T) {
 		require.NoError(t, g1.Logout())
 		require.NoError(t, users[1].Login(g1))
 
-		require.NoError(t, ctc.as(t, users[0]).chatLocalHandler().AddImplicitTeamMemberAfterReset(ctx,
-			chat1.AddImplicitTeamMemberAfterResetArg{
+		require.NoError(t, ctc.as(t, users[0]).chatLocalHandler().AddTeamMemberAfterReset(ctx,
+			chat1.AddTeamMemberAfterResetArg{
 				Username: users[1].Username,
 				ConvID:   conv.Id,
 			}))

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3405,10 +3405,11 @@ func TestChatSrvUserReset(t *testing.T) {
 		require.NoError(t, g1.Logout())
 		require.NoError(t, users[1].Login(g1))
 
-		teamID, err := tlfIDToTeamdID(conv.Triple.Tlfid)
-		require.NoError(t, err)
-		require.NoError(t, teams.ReAddMemberAfterReset(ctx, ctc.as(t, users[0]).h.G().ExternalG(),
-			teamID, users[1].Username))
+		require.NoError(t, ctc.as(t, users[0]).chatLocalHandler().AddImplicitTeamMemberAfterReset(ctx,
+			chat1.AddImplicitTeamMemberAfterResetArg{
+				Username: users[1].Username,
+				ConvID:   conv.Id,
+			}))
 		consumeMembersUpdate(t, listener0)
 		consumeJoinConv(t, listener1)
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3870,7 +3870,7 @@ type UnboxMobilePushNotificationArg struct {
 	PushIDs     []string                `codec:"pushIDs" json:"pushIDs"`
 }
 
-type AddImplicitTeamMemberAfterResetArg struct {
+type AddTeamMemberAfterResetArg struct {
 	Username string         `codec:"username" json:"username"`
 	ConvID   ConversationID `codec:"convID" json:"convID"`
 }
@@ -3916,7 +3916,7 @@ type LocalInterface interface {
 	SetGlobalAppNotificationSettingsLocal(context.Context, map[string]bool) error
 	GetGlobalAppNotificationSettingsLocal(context.Context) (GlobalAppNotificationSettings, error)
 	UnboxMobilePushNotification(context.Context, UnboxMobilePushNotificationArg) (string, error)
-	AddImplicitTeamMemberAfterReset(context.Context, AddImplicitTeamMemberAfterResetArg) error
+	AddTeamMemberAfterReset(context.Context, AddTeamMemberAfterResetArg) error
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -4553,18 +4553,18 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"addImplicitTeamMemberAfterReset": {
+			"addTeamMemberAfterReset": {
 				MakeArg: func() interface{} {
-					ret := make([]AddImplicitTeamMemberAfterResetArg, 1)
+					ret := make([]AddTeamMemberAfterResetArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]AddImplicitTeamMemberAfterResetArg)
+					typedArgs, ok := args.(*[]AddTeamMemberAfterResetArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]AddImplicitTeamMemberAfterResetArg)(nil), args)
+						err = rpc.NewTypeError((*[]AddTeamMemberAfterResetArg)(nil), args)
 						return
 					}
-					err = i.AddImplicitTeamMemberAfterReset(ctx, (*typedArgs)[0])
+					err = i.AddTeamMemberAfterReset(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -4785,7 +4785,7 @@ func (c LocalClient) UnboxMobilePushNotification(ctx context.Context, __arg Unbo
 	return
 }
 
-func (c LocalClient) AddImplicitTeamMemberAfterReset(ctx context.Context, __arg AddImplicitTeamMemberAfterResetArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.addImplicitTeamMemberAfterReset", []interface{}{__arg}, nil)
+func (c LocalClient) AddTeamMemberAfterReset(ctx context.Context, __arg AddTeamMemberAfterResetArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.addTeamMemberAfterReset", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3870,6 +3870,11 @@ type UnboxMobilePushNotificationArg struct {
 	PushIDs     []string                `codec:"pushIDs" json:"pushIDs"`
 }
 
+type AddImplicitTeamMemberAfterResetArg struct {
+	Username string         `codec:"username" json:"username"`
+	ConvID   ConversationID `codec:"convID" json:"convID"`
+}
+
 type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
 	GetCachedThread(context.Context, GetCachedThreadArg) (GetThreadLocalRes, error)
@@ -3911,6 +3916,7 @@ type LocalInterface interface {
 	SetGlobalAppNotificationSettingsLocal(context.Context, map[string]bool) error
 	GetGlobalAppNotificationSettingsLocal(context.Context) (GlobalAppNotificationSettings, error)
 	UnboxMobilePushNotification(context.Context, UnboxMobilePushNotificationArg) (string, error)
+	AddImplicitTeamMemberAfterReset(context.Context, AddImplicitTeamMemberAfterResetArg) error
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -4547,6 +4553,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"addImplicitTeamMemberAfterReset": {
+				MakeArg: func() interface{} {
+					ret := make([]AddImplicitTeamMemberAfterResetArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]AddImplicitTeamMemberAfterResetArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]AddImplicitTeamMemberAfterResetArg)(nil), args)
+						return
+					}
+					err = i.AddImplicitTeamMemberAfterReset(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -4760,5 +4782,10 @@ func (c LocalClient) GetGlobalAppNotificationSettingsLocal(ctx context.Context) 
 
 func (c LocalClient) UnboxMobilePushNotification(ctx context.Context, __arg UnboxMobilePushNotificationArg) (res string, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.unboxMobilePushNotification", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) AddImplicitTeamMemberAfterReset(ctx context.Context, __arg AddImplicitTeamMemberAfterResetArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.addImplicitTeamMemberAfterReset", []interface{}{__arg}, nil)
 	return
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -758,4 +758,7 @@ protocol local {
   // Unpack message from a push notification
   string unboxMobilePushNotification(string payload, string convID, ConversationMembersType membersType, array<string> pushIDs);
 
+  // Convenience interface for adding someone back to a reset impteam convo
+  void addImplicitTeamMemberAfterReset(string username, ConversationID convID);
+
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -758,7 +758,7 @@ protocol local {
   // Unpack message from a push notification
   string unboxMobilePushNotification(string payload, string convID, ConversationMembersType membersType, array<string> pushIDs);
 
-  // Convenience interface for adding someone back to a reset impteam convo
-  void addImplicitTeamMemberAfterReset(string username, ConversationID convID);
+  // Convenience interface for adding someone back to a reset team convo
+  void addTeamMemberAfterReset(string username, ConversationID convID);
 
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -94,9 +94,9 @@ export const commonTopicType = {
   dev: 2,
 }
 
-export const localAddImplicitTeamMemberAfterResetRpcChannelMap = (configKeys: Array<string>, request: LocalAddImplicitTeamMemberAfterResetRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.addImplicitTeamMemberAfterReset', request)
+export const localAddTeamMemberAfterResetRpcChannelMap = (configKeys: Array<string>, request: LocalAddTeamMemberAfterResetRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.addTeamMemberAfterReset', request)
 
-export const localAddImplicitTeamMemberAfterResetRpcPromise = (request: LocalAddImplicitTeamMemberAfterResetRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.addImplicitTeamMemberAfterReset', request, (error: RPCError, result: void) => error ? reject(error) : resolve()))
+export const localAddTeamMemberAfterResetRpcPromise = (request: LocalAddTeamMemberAfterResetRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.addTeamMemberAfterReset', request, (error: RPCError, result: void) => error ? reject(error) : resolve()))
 
 export const localAssetMetadataType = {
   none: 0,
@@ -761,7 +761,7 @@ export type JoinLeaveConversationLocalRes = {|offline: Boolean,rateLimits?: ?Arr
 
 export type JoinLeaveConversationRemoteRes = {|rateLimit?: ?RateLimit,|}
 
-export type LocalAddImplicitTeamMemberAfterResetRpcParam = {|username: String,convID: ConversationID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
+export type LocalAddTeamMemberAfterResetRpcParam = {|username: String,convID: ConversationID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 
 export type LocalCancelPostRpcParam = {|outboxID: OutboxID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -94,6 +94,10 @@ export const commonTopicType = {
   dev: 2,
 }
 
+export const localAddImplicitTeamMemberAfterResetRpcChannelMap = (configKeys: Array<string>, request: LocalAddImplicitTeamMemberAfterResetRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.addImplicitTeamMemberAfterReset', request)
+
+export const localAddImplicitTeamMemberAfterResetRpcPromise = (request: LocalAddImplicitTeamMemberAfterResetRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.addImplicitTeamMemberAfterReset', request, (error: RPCError, result: void) => error ? reject(error) : resolve()))
+
 export const localAssetMetadataType = {
   none: 0,
   image: 1,
@@ -756,6 +760,8 @@ export type IncomingMessage = {|message: UIMessage,convID: ConversationID,displa
 export type JoinLeaveConversationLocalRes = {|offline: Boolean,rateLimits?: ?Array<RateLimit>,|}
 
 export type JoinLeaveConversationRemoteRes = {|rateLimit?: ?RateLimit,|}
+
+export type LocalAddImplicitTeamMemberAfterResetRpcParam = {|username: String,convID: ConversationID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 
 export type LocalCancelPostRpcParam = {|outboxID: OutboxID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -3074,7 +3074,7 @@
       ],
       "response": "string"
     },
-    "addImplicitTeamMemberAfterReset": {
+    "addTeamMemberAfterReset": {
       "request": [
         {
           "name": "username",

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -3073,6 +3073,19 @@
         }
       ],
       "response": "string"
+    },
+    "addImplicitTeamMemberAfterReset": {
+      "request": [
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "chat.1"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -94,9 +94,9 @@ export const commonTopicType = {
   dev: 2,
 }
 
-export const localAddImplicitTeamMemberAfterResetRpcChannelMap = (configKeys: Array<string>, request: LocalAddImplicitTeamMemberAfterResetRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.addImplicitTeamMemberAfterReset', request)
+export const localAddTeamMemberAfterResetRpcChannelMap = (configKeys: Array<string>, request: LocalAddTeamMemberAfterResetRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.addTeamMemberAfterReset', request)
 
-export const localAddImplicitTeamMemberAfterResetRpcPromise = (request: LocalAddImplicitTeamMemberAfterResetRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.addImplicitTeamMemberAfterReset', request, (error: RPCError, result: void) => error ? reject(error) : resolve()))
+export const localAddTeamMemberAfterResetRpcPromise = (request: LocalAddTeamMemberAfterResetRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.addTeamMemberAfterReset', request, (error: RPCError, result: void) => error ? reject(error) : resolve()))
 
 export const localAssetMetadataType = {
   none: 0,
@@ -761,7 +761,7 @@ export type JoinLeaveConversationLocalRes = {|offline: Boolean,rateLimits?: ?Arr
 
 export type JoinLeaveConversationRemoteRes = {|rateLimit?: ?RateLimit,|}
 
-export type LocalAddImplicitTeamMemberAfterResetRpcParam = {|username: String,convID: ConversationID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
+export type LocalAddTeamMemberAfterResetRpcParam = {|username: String,convID: ConversationID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 
 export type LocalCancelPostRpcParam = {|outboxID: OutboxID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -94,6 +94,10 @@ export const commonTopicType = {
   dev: 2,
 }
 
+export const localAddImplicitTeamMemberAfterResetRpcChannelMap = (configKeys: Array<string>, request: LocalAddImplicitTeamMemberAfterResetRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.addImplicitTeamMemberAfterReset', request)
+
+export const localAddImplicitTeamMemberAfterResetRpcPromise = (request: LocalAddImplicitTeamMemberAfterResetRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.addImplicitTeamMemberAfterReset', request, (error: RPCError, result: void) => error ? reject(error) : resolve()))
+
 export const localAssetMetadataType = {
   none: 0,
   image: 1,
@@ -756,6 +760,8 @@ export type IncomingMessage = {|message: UIMessage,convID: ConversationID,displa
 export type JoinLeaveConversationLocalRes = {|offline: Boolean,rateLimits?: ?Array<RateLimit>,|}
 
 export type JoinLeaveConversationRemoteRes = {|rateLimit?: ?RateLimit,|}
+
+export type LocalAddImplicitTeamMemberAfterResetRpcParam = {|username: String,convID: ConversationID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 
 export type LocalCancelPostRpcParam = {|outboxID: OutboxID,incomingCallMap?: IncomingCallMapType,waitingHandler?: WaitingHandlerType|}
 


### PR DESCRIPTION
Frontend doesn't really have team IDs in chat world, so let them pass in a conversation ID.

cc @chrisnojima 