### PR TITLE
PresentMessageUnboxed don't panic on deleted messages

### DIFF
--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -184,6 +184,10 @@ func (m MessageUnboxed) IsValid() bool {
 	return false
 }
 
+func (b MessageBody) IsNil() bool {
+	return b == MessageBody{}
+}
+
 func (m UIMessage) IsValid() bool {
 	if state, err := m.State(); err == nil {
 		return state == MessageUnboxedState_VALID


### PR DESCRIPTION
If a client from current master gets a `DELETEHISTORY` message, it will panic the service when the thread is clicked. This is because `supersedes.go` doesn't filter out the message because `DELETEHISTORY` delete but don't have supersede pointers. And then `Present` crashes.

This PR makes `Present` not crash.

Shows this now:
![image](https://user-images.githubusercontent.com/705646/34017183-a84e6e60-e0f2-11e7-8234-10a3221ade86.png)
