### PR TITLE
Fix compare in showcasing decision

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -588,7 +588,7 @@ const _setPublicity = function(action: TeamsGen.SetPublicityPayload, state: Type
     team: false,
   })
   const openTeam = teamSettings.open
-  const openTeamRole = teamSettings.joinAs
+  const openTeamRole = Constants.teamRoleByEnum[teamSettings.joinAs]
   const publicityAnyMember = teamPublicitySettings.anyMemberShowcase
   const publicityMember = teamPublicitySettings.member
   const publicityTeam = teamPublicitySettings.team


### PR DESCRIPTION
@keybase/react-hackers 

Comparing the wrong types here made us always think that the default role was changing, so we always tried to call the RPC to set the default role (to itself), but there are situations where trying that will throw.