### PR TITLE
send incoming message notification after PostRemote for faster gray->black

### DIFF
--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -617,7 +617,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	var unboxedMsg chat1.MessageUnboxed
 	var convLocal *chat1.ConversationLocal
 	s.Debug(ctx, "sending local updates to chat sources")
-	if unboxedMsg, _, cerr = s.G().ConvSource.Push(ctx, convID, boxed.ClientHeader.Sender, *boxed); err != nil {
+	if unboxedMsg, _, cerr = s.G().ConvSource.Push(ctx, convID, boxed.ClientHeader.Sender, *boxed); cerr != nil {
 		s.Debug(ctx, "failed to push new message into convsource: %s", err)
 	}
 	if convLocal, err = s.G().InboxSource.NewMessage(ctx, boxed.ClientHeader.Sender, 0, convID,

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -486,6 +486,14 @@ func (s *BlockingSender) Sign(payload []byte) ([]byte, error) {
 	return ri.S3Sign(context.Background(), arg)
 }
 
+func (s *BlockingSender) presentUIItem(conv *chat1.ConversationLocal) (res *chat1.InboxUIItem) {
+	if conv != nil {
+		pc := utils.PresentConversationLocal(*conv)
+		res = &pc
+	}
+	return res
+}
+
 func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	msg chat1.MessagePlaintext, clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (obid chat1.OutboxID, boxed *chat1.MessageBoxed, rl *chat1.RateLimit, err error) {
 	defer s.Trace(ctx, func() error { return err }, fmt.Sprintf("Send(%s)", convID))()
@@ -605,23 +613,29 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	}
 
 	// Write new message out to cache
+	var cerr error
 	var unboxedMsg chat1.MessageUnboxed
+	var convLocal *chat1.ConversationLocal
 	s.Debug(ctx, "sending local updates to chat sources")
-	if unboxedMsg, _, err = s.G().ConvSource.Push(ctx, convID, boxed.ClientHeader.Sender, *boxed); err != nil {
+	if unboxedMsg, _, cerr = s.G().ConvSource.Push(ctx, convID, boxed.ClientHeader.Sender, *boxed); err != nil {
 		s.Debug(ctx, "failed to push new message into convsource: %s", err)
 	}
-	if _, err = s.G().InboxSource.NewMessage(ctx, boxed.ClientHeader.Sender, 0, convID, *boxed); err != nil {
+	if convLocal, err = s.G().InboxSource.NewMessage(ctx, boxed.ClientHeader.Sender, 0, convID,
+		*boxed); err != nil {
 		s.Debug(ctx, "failed to update inbox: %s", err)
 	}
 	// Send up to frontend
-	activity := chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-		Message: utils.PresentMessageUnboxed(ctx, unboxedMsg, boxed.ClientHeader.Sender,
-			s.G().TeamChannelSource),
-		ConvID: convID,
-		DisplayDesktopNotification: false,
-	})
-	s.G().NotifyRouter.HandleNewChatActivity(ctx, keybase1.UID(boxed.ClientHeader.Sender.String()), &activity)
-
+	if cerr == nil {
+		activity := chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
+			Message: utils.PresentMessageUnboxed(ctx, unboxedMsg, boxed.ClientHeader.Sender,
+				s.G().TeamChannelSource),
+			ConvID: convID,
+			DisplayDesktopNotification: false,
+			Conv: s.presentUIItem(convLocal),
+		})
+		s.G().NotifyRouter.HandleNewChatActivity(ctx, keybase1.UID(boxed.ClientHeader.Sender.String()),
+			&activity)
+	}
 	return []byte{}, boxed, plres.RateLimit, nil
 }
 

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -79,6 +79,7 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 			if strOutboxID != nil {
 				outboxID, _ := hex.DecodeString(*strOutboxID)
 				n.obids = append(n.obids, chat1.OutboxID(outboxID))
+				fmt.Printf("OBID: %x\n", outboxID)
 				select {
 				case n.incoming <- len(n.obids):
 				case <-time.After(5 * time.Second):
@@ -365,7 +366,7 @@ func TestNonblockTimer(t *testing.T) {
 
 	// Should get a blast of all 5
 	var olen int
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 10; i++ {
 		select {
 		case olen = <-listener.incoming:
 		case <-time.After(20 * time.Second):
@@ -373,7 +374,7 @@ func TestNonblockTimer(t *testing.T) {
 		}
 
 		require.Equal(t, i+1, olen, "wrong length")
-		require.Equal(t, obids[i], listener.obids[i], "wrong obid")
+		require.Equal(t, listener.obids[i], obids[i/2], "wrong obid")
 	}
 
 	// Make sure it is really empty
@@ -499,12 +500,14 @@ func TestDisconnectedFailure(t *testing.T) {
 	default:
 	}
 	tc.ChatG.MessageDeliverer.Connected(ctx)
-	select {
-	case inc := <-listener.incoming:
-		require.Equal(t, 1, inc)
-		require.Equal(t, obid, listener.obids[0])
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no incoming message")
+	for i := 0; i < 2; i++ {
+		select {
+		case inc := <-listener.incoming:
+			require.Equal(t, i+1, inc)
+			require.Equal(t, obid, listener.obids[0])
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no incoming message")
+		}
 	}
 	listener.obids = nil
 
@@ -575,7 +578,7 @@ func TestDisconnectedFailure(t *testing.T) {
 	for {
 		select {
 		case inc := <-listener.incoming:
-			if inc >= len(obids) {
+			if inc >= 2*len(obids) {
 				break
 			}
 			continue
@@ -585,8 +588,11 @@ func TestDisconnectedFailure(t *testing.T) {
 		}
 		break
 	}
-	require.Equal(t, len(obids), len(listener.obids), "wrong amount of successes")
-	require.Equal(t, obids, listener.obids, "wrong obids for successes")
+	require.Equal(t, 2*len(obids), len(listener.obids), "wrong amount of successes")
+	for index, obid := range listener.obids {
+		fmt.Printf("OBID: %s REF: %s\n", obid, obids[index/2])
+		require.Equal(t, obid, obids[index/2])
+	}
 }
 
 // The sender is responsible for making sure that a deletion of a single

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -79,7 +79,6 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 			if strOutboxID != nil {
 				outboxID, _ := hex.DecodeString(*strOutboxID)
 				n.obids = append(n.obids, chat1.OutboxID(outboxID))
-				fmt.Printf("OBID: %x\n", outboxID)
 				select {
 				case n.incoming <- len(n.obids):
 				case <-time.After(5 * time.Second):
@@ -590,7 +589,6 @@ func TestDisconnectedFailure(t *testing.T) {
 	}
 	require.Equal(t, 2*len(obids), len(listener.obids), "wrong amount of successes")
 	for index, obid := range listener.obids {
-		fmt.Printf("OBID: %s REF: %s\n", obid, obids[index/2])
 		require.Equal(t, obid, obids[index/2])
 	}
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1755,6 +1755,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			first := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
 				mt, ctc.as(t, users[1]).user())
 			consumeNewMsg(t, listener, chat1.MessageType_JOIN)
+			consumeNewMsg(t, listener, chat1.MessageType_JOIN)
 			topicName := "mike"
 			ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(tc.startCtx,
 				chat1.NewConversationLocalArg{
@@ -1767,6 +1768,8 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			require.NoError(t, err)
 			created = ncres.Conv.Info
 			consumeNewMsg(t, listener, chat1.MessageType_JOIN)
+			consumeNewMsg(t, listener, chat1.MessageType_JOIN)
+			consumeNewMsg(t, listener, chat1.MessageType_SYSTEM)
 			consumeNewMsg(t, listener, chat1.MessageType_SYSTEM)
 		default:
 			created = mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
@@ -1794,6 +1797,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
 		}
+		consumeNewMsg(t, listener, chat1.MessageType_TEXT)
 
 		t.Logf("post text message with prefetched outbox ID")
 		genOutboxID, err := ctc.as(t, users[0]).chatLocalHandler().GenerateOutboxID(context.TODO())
@@ -1819,6 +1823,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
 		}
+		consumeNewMsg(t, listener, chat1.MessageType_TEXT)
 
 		t.Logf("edit the message")
 		earg := chat1.PostEditNonblockArg{
@@ -1841,6 +1846,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
 		}
+		consumeNewMsg(t, listener, chat1.MessageType_EDIT)
 
 		t.Logf("delete the message")
 		darg := chat1.PostDeleteNonblockArg{
@@ -1862,6 +1868,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
 		}
+		consumeNewMsg(t, listener, chat1.MessageType_DELETE)
 
 		t.Logf("post headline")
 		headline := "SILENCE!"
@@ -1888,6 +1895,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
 		}
+		consumeNewMsg(t, listener, chat1.MessageType_HEADLINE)
 
 		t.Logf("change name")
 		topicName := "NEWNAME"
@@ -1914,6 +1922,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no event received")
 		}
+		consumeNewMsg(t, listener, chat1.MessageType_METADATA)
 	})
 }
 
@@ -2405,6 +2414,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
 			mt, ctc.as(t, users[1]).user(), ctc.as(t, users[2]).user())
 		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
 		consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
 		consumeNewMsg(t, listener2, chat1.MessageType_JOIN)
 		t.Logf("first conv: %s", conv.Id)
@@ -2421,15 +2431,21 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			})
 		require.NoError(t, err)
 		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(t, listener0, chat1.MessageType_SYSTEM)
 		consumeNewMsg(t, listener0, chat1.MessageType_SYSTEM)
 		consumeNewMsg(t, listener1, chat1.MessageType_SYSTEM)
 		consumeNewMsg(t, listener2, chat1.MessageType_SYSTEM)
 		_, err = postLocalForTest(t, ctc, users[1], ncres.Conv.Info, chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: fmt.Sprintf("JOINME"),
 		}))
-		consumeAllMsgJoins := func(listener *serverChatListener) {
+		consumeAllMsgJoins := func(listener *serverChatListener, sender bool) {
 			msgMap := make(map[chat1.MessageType]bool)
-			for i := 0; i < 2; i++ {
+			rounds := 2
+			if sender {
+				rounds = 4
+			}
+			for i := 0; i < rounds; i++ {
 				select {
 				case msg := <-listener.newMessage:
 					t.Logf("recvd: %v convID: %s", msg.Message.GetMessageType(), msg.ConvID)
@@ -2441,8 +2457,8 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			require.True(t, msgMap[chat1.MessageType_TEXT])
 			require.True(t, msgMap[chat1.MessageType_JOIN])
 		}
-		consumeAllMsgJoins(listener0)
-		consumeAllMsgJoins(listener1)
+		consumeAllMsgJoins(listener0, false)
+		consumeAllMsgJoins(listener1, true)
 		select {
 		case conv := <-listener1.joinedConv:
 			require.Equal(t, conv.GetConvID(), ncres.Conv.GetConvID())
@@ -2465,6 +2481,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		require.NoError(t, err)
 		consumeNewMsg(t, listener0, chat1.MessageType_HEADLINE)
 		consumeNewMsg(t, listener1, chat1.MessageType_HEADLINE)
+		consumeNewMsg(t, listener1, chat1.MessageType_HEADLINE)
 
 		t.Logf("create a new channel, and check GetTLFConversation result")
 		topicName = "miketime"
@@ -2477,6 +2494,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 				MembersType:   chat1.ConversationMembersType_TEAM,
 			})
 		require.NoError(t, err)
+		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
 		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
 		getTLFRes, err := ctc.as(t, users[1]).chatLocalHandler().GetTLFConversationsLocal(ctx1,
 			chat1.GetTLFConversationsLocalArg{
@@ -2507,6 +2525,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		require.NoError(t, err)
 		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
 		consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
+		consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
 		select {
 		case conv := <-listener1.joinedConv:
 			require.Equal(t, conv.GetConvID(), getTLFRes.Convs[1].GetConvID())
@@ -2530,6 +2549,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		require.NoError(t, err)
 		consumeJoinConv(t, listener2)
 		consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
+		consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
 		consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
 		consumeNewMsg(t, listener2, chat1.MessageType_TEXT)
 
@@ -2557,8 +2577,8 @@ func TestChatSrvTeamChannels(t *testing.T) {
 			Body: "FAIL",
 		}))
 		require.NoError(t, err)
-		consumeAllMsgJoins(listener0)
-		consumeAllMsgJoins(listener2)
+		consumeAllMsgJoins(listener0, false)
+		consumeAllMsgJoins(listener2, true)
 		select {
 		case conv := <-listener2.joinedConv:
 			require.Equal(t, conv.GetConvID(), getTLFRes.Convs[1].GetConvID())
@@ -2583,6 +2603,7 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		})
 		require.NoError(t, err)
 		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
 		consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
 		consumeNewMsg(t, listener2, chat1.MessageType_JOIN)
 
@@ -2677,6 +2698,7 @@ func TestChatSrvSetAppNotificationSettings(t *testing.T) {
 		default:
 			t.Fatalf("unknown members type: %v", mt)
 		}
+		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
 		select {
 		case info := <-listener0.newMessage:
 			require.Equal(t, chat1.MessageType_TEXT, info.Message.GetMessageType())
@@ -3168,6 +3190,7 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
 			ctc.as(t, users[1]).user())
 		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
 		consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
 
 		_, err := ctc.as(t, users[0]).chatLocalHandler().DeleteConversationLocal(ctx,
@@ -3189,8 +3212,10 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 		t.Logf("conv: %s chan: %s", conv.Id, channel.Conv.GetConvID())
 		require.NoError(t, err)
 		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
 		consumeTeamType(t, listener0)
 		consumeTeamType(t, listener1)
+		consumeNewMsg(t, listener0, chat1.MessageType_SYSTEM)
 		consumeNewMsg(t, listener0, chat1.MessageType_SYSTEM)
 		consumeNewMsg(t, listener1, chat1.MessageType_SYSTEM)
 
@@ -3198,6 +3223,7 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 			channel.Conv.GetConvID())
 		require.NoError(t, err)
 		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
 		consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
 		consumeMembersUpdate(t, listener0)
 		consumeJoinConv(t, listener1)
@@ -3472,6 +3498,7 @@ func TestChatSrvTeamChannelNameMentions(t *testing.T) {
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
 			ctc.as(t, users[1]).user())
 		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
+		consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
 		consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
 
 		topicNames := []string{"miketime", "random", "hi"}
@@ -3487,14 +3514,17 @@ func TestChatSrvTeamChannelNameMentions(t *testing.T) {
 			t.Logf("conv: %s chan: %s", conv.Id, channel.Conv.GetConvID())
 			require.NoError(t, err)
 			consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
+			consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
 			if index == 0 {
 				consumeNewMsg(t, listener0, chat1.MessageType_SYSTEM)
+				consumeNewMsg(t, listener1, chat1.MessageType_SYSTEM)
 				consumeNewMsg(t, listener1, chat1.MessageType_SYSTEM)
 			}
 
 			_, err = ctc.as(t, users[0]).chatLocalHandler().JoinConversationByIDLocal(ctx1,
 				channel.Conv.GetConvID())
 			require.NoError(t, err)
+			consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
 			consumeNewMsg(t, listener0, chat1.MessageType_JOIN)
 			consumeNewMsg(t, listener1, chat1.MessageType_JOIN)
 
@@ -3513,6 +3543,7 @@ func TestChatSrvTeamChannelNameMentions(t *testing.T) {
 			})
 			require.NoError(t, err)
 			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
+			consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
 			consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
 
 			tv, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{


### PR DESCRIPTION
Patch does the following:

1.) Sends an incoming message notification as soon as `PostRemote` returns. This is different than now, which waits for the Gregor message corresponding to that sent message.
2.) Luckily, the frontend seems to do the right thing here, and no changes are needed. 

cc @chrisnojima @malgorithms @maxtaco 