### PR TITLE
Fix tracker popup jank

### DIFF
--- a/shared/tracker/index.desktop.js
+++ b/shared/tracker/index.desktop.js
@@ -109,6 +109,7 @@ export default class TrackerRender extends PureComponent<RenderProps> {
                 >
                   {this.props.showTeam &&
                     this.props.showTeam.fqName === team.fqName &&
+                    this.props.selectedTeamRect &&
                     <Box key={team.fqName + 'popup'} style={{zIndex: 50}}>
                       <ModalPopupComponent
                         {...this.props}


### PR DESCRIPTION
@keybase/react-hackers 

It can take longer for the update to `selectedTeam` to come in than the update to `selectedTeamRect`.  If that happens, we still try to draw a popup but now we don't have somewhere to put it so it goes in the top left, and appears as a momentary animation glitch.

So, just check that we still have a rect too before drawing anything.