### PR TITLE
Add client support for DeleteHistory

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -1045,7 +1045,8 @@ func (b *Boxer) preBoxCheck(ctx context.Context, messagePlaintext chat1.MessageP
 	e := func(format string, args ...interface{}) error {
 		return errors.New(fmt.Sprintf("malformed %v message: ", typ) + fmt.Sprintf(format, args...))
 	}
-	if typ == chat1.MessageType_DELETEHISTORY {
+	switch typ {
+	case chat1.MessageType_DELETEHISTORY:
 		body := messagePlaintext.MessageBody.Deletehistory()
 		dhHeader := messagePlaintext.ClientHeader.DeleteHistory
 		if dhHeader == nil {
@@ -1054,8 +1055,7 @@ func (b *Boxer) preBoxCheck(ctx context.Context, messagePlaintext chat1.MessageP
 		if *dhHeader != body {
 			return e("header-body mismatch")
 		}
-
-	} else {
+	default:
 		if messagePlaintext.ClientHeader.DeleteHistory != nil {
 			return e("cannot have delete-history header")
 		}

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -1037,7 +1037,6 @@ func (b *Boxer) attachMerkleRoot(ctx context.Context, msg *chat1.MessagePlaintex
 }
 
 func (b *Boxer) preBoxCheck(ctx context.Context, messagePlaintext chat1.MessagePlaintext) error {
-
 	typ, err := messagePlaintext.MessageBody.MessageType()
 	if err != nil {
 		return err
@@ -1066,7 +1065,6 @@ func (b *Boxer) preBoxCheck(ctx context.Context, messagePlaintext chat1.MessageP
 
 func (b *Boxer) box(ctx context.Context, messagePlaintext chat1.MessagePlaintext, encryptionKey types.CryptKey,
 	signingKeyPair libkb.NaclSigningKeyPair, version chat1.MessageBoxedVersion) (*chat1.MessageBoxed, error) {
-
 	err := b.preBoxCheck(ctx, messagePlaintext)
 	if err != nil {
 		return nil, err

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -17,6 +17,11 @@ import (
 )
 
 func TestGetThreadSupersedes(t *testing.T) {
+	testGetThreadSupersedes(t, false)
+	testGetThreadSupersedes(t, true)
+}
+
+func testGetThreadSupersedes(t *testing.T, deleteHistory bool) {
 	ctx, world, ri, _, sender, _ := setupTest(t, 1)
 	defer world.Cleanup()
 
@@ -93,18 +98,31 @@ func TestGetThreadSupersedes(t *testing.T) {
 	require.Equal(t, "EDITED", thread.Messages[0].Valid().MessageBody.Text().Body, "wrong body")
 
 	t.Logf("testing a delete")
+	delTyp := chat1.MessageType_DELETE
+	delBody := chat1.NewMessageBodyWithDelete(chat1.MessageDelete{
+		MessageIDs: []chat1.MessageID{msgID, editMsgID},
+	})
+	delSupersedes := msgID
+	var delHeader *chat1.MessageDeleteHistory
+	if deleteHistory {
+		delTyp = chat1.MessageType_DELETEHISTORY
+		delHeader = &chat1.MessageDeleteHistory{
+			Upto: editMsgID + 1,
+		}
+		delBody = chat1.NewMessageBodyWithDeletehistory(*delHeader)
+		delSupersedes = 0
+	}
 	_, deleteMsgBoxed, _, err := sender.Send(ctx, res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
-			Conv:        trip,
-			Sender:      u.User.GetUID().ToBytes(),
-			TlfName:     u.Username,
-			TlfPublic:   false,
-			MessageType: chat1.MessageType_DELETE,
-			Supersedes:  msgID,
+			Conv:          trip,
+			Sender:        u.User.GetUID().ToBytes(),
+			TlfName:       u.Username,
+			TlfPublic:     false,
+			MessageType:   delTyp,
+			Supersedes:    delSupersedes,
+			DeleteHistory: delHeader,
 		},
-		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{
-			MessageIDs: []chat1.MessageID{msgID, editMsgID},
-		}),
+		MessageBody: delBody,
 	}, 0, nil)
 	require.NoError(t, err)
 	deleteMsgID := deleteMsgBoxed.GetMessageID()
@@ -121,7 +139,9 @@ func TestGetThreadSupersedes(t *testing.T) {
 			MessageTypes: []chat1.MessageType{
 				chat1.MessageType_TEXT,
 				chat1.MessageType_EDIT,
-				chat1.MessageType_DELETE},
+				chat1.MessageType_DELETE,
+				chat1.MessageType_DELETEHISTORY,
+			},
 			DisableResolveSupersedes: true,
 		}, nil)
 	require.NoError(t, err)

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -292,6 +292,11 @@ func (f failingRemote) DeleteConversation(ctx context.Context, convID chat1.Conv
 	return chat1.DeleteConversationRemoteRes{}, nil
 }
 
+func (f failingRemote) GetMessageBefore(ctx context.Context, arg chat1.GetMessageBeforeArg) (chat1.GetMessageBeforeRes, error) {
+	require.Fail(f.t, "GetMessageBefore")
+	return chat1.GetMessageBeforeRes{}, nil
+}
+
 func (f failingRemote) RemoteNotificationSuccessful(ctx context.Context,
 	arg chat1.RemoteNotificationSuccessfulArg) error {
 	require.Fail(f.t, "RemoteNotificationSuccessful")

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -647,6 +647,7 @@ func (s *HybridInboxSource) getConvLocal(ctx context.Context, uid gregor1.UID,
 func (s *HybridInboxSource) NewMessage(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	convID chat1.ConversationID, msg chat1.MessageBoxed) (conv *chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "NewMessage")()
+
 	if cerr := storage.NewInbox(s.G(), uid).NewMessage(ctx, vers, convID, msg); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -647,7 +647,6 @@ func (s *HybridInboxSource) getConvLocal(ctx context.Context, uid gregor1.UID,
 func (s *HybridInboxSource) NewMessage(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	convID chat1.ConversationID, msg chat1.MessageBoxed) (conv *chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "NewMessage")()
-
 	if cerr := storage.NewInbox(s.G(), uid).NewMessage(ctx, vers, convID, msg); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1045,19 +1045,11 @@ func (h *Server) PostMetadata(ctx context.Context, arg chat1.PostMetadataArg) (c
 	return h.PostLocal(ctx, parg)
 }
 
-func (h *Server) PostDeleteHistory(ctx context.Context, arg chat1.PostDeleteHistoryArg) (res chat1.PostLocalRes, err error) {
+func (h *Server) PostDeleteHistoryByID(ctx context.Context, arg chat1.PostDeleteHistoryByIDArg) (res chat1.PostLocalRes, err error) {
 	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, nil, h.identNotifier)
-	defer h.Trace(ctx, func() error { return err }, "PostDeleteHistory")()
+	defer h.Trace(ctx, func() error { return err }, "PostDeleteHistoryByID")()
 
-	gmRes, err := h.remoteClient().GetMessageBefore(ctx, chat1.GetMessageBeforeArg{
-		ConvID: arg.ConversationID,
-		Age:    arg.Age,
-	})
-	if err != nil {
-		return res, err
-	}
-
-	delh := chat1.MessageDeleteHistory{Upto: gmRes.MsgID + 1}
+	delh := chat1.MessageDeleteHistory{Upto: arg.Upto}
 
 	var parg chat1.PostLocalArg
 	parg.ConversationID = arg.ConversationID
@@ -1068,9 +1060,31 @@ func (h *Server) PostDeleteHistory(ctx context.Context, arg chat1.PostDeleteHist
 	parg.Msg.ClientHeader.DeleteHistory = &delh
 	parg.Msg.MessageBody = chat1.NewMessageBodyWithDeletehistory(delh)
 
-	h.Debug(ctx, "PostDeleteHistory: deleting upto msgid:%v (age:%v)", delh.Upto, arg.Age)
+	h.Debug(ctx, "PostDeleteHistoryByID: deleting upto msgid:%v", delh.Upto)
 
 	return h.PostLocal(ctx, parg)
+}
+
+func (h *Server) PostDeleteHistoryByAge(ctx context.Context, arg chat1.PostDeleteHistoryByAgeArg) (res chat1.PostLocalRes, err error) {
+	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, nil, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, "PostDeleteHistoryByAge")()
+
+	gmRes, err := h.remoteClient().GetMessageBefore(ctx, chat1.GetMessageBeforeArg{
+		ConvID: arg.ConversationID,
+		Age:    arg.Age,
+	})
+	if err != nil {
+		return res, err
+	}
+	upto := gmRes.MsgID + 1
+	h.Debug(ctx, "PostDeleteHistoryByAge: deleting upto msgid:%v (age:%v)", upto, arg.Age)
+	return h.PostDeleteHistoryByID(ctx, chat1.PostDeleteHistoryByIDArg{
+		ConversationID:   arg.ConversationID,
+		TlfName:          arg.TlfName,
+		TlfPublic:        arg.TlfPublic,
+		IdentifyBehavior: arg.IdentifyBehavior,
+		Upto:             upto,
+	})
 }
 
 func (h *Server) GenerateOutboxID(ctx context.Context) (res chat1.OutboxID, err error) {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1045,9 +1045,9 @@ func (h *Server) PostMetadata(ctx context.Context, arg chat1.PostMetadataArg) (c
 	return h.PostLocal(ctx, parg)
 }
 
-func (h *Server) PostDeleteHistoryByID(ctx context.Context, arg chat1.PostDeleteHistoryByIDArg) (res chat1.PostLocalRes, err error) {
+func (h *Server) PostDeleteHistoryUpto(ctx context.Context, arg chat1.PostDeleteHistoryUptoArg) (res chat1.PostLocalRes, err error) {
 	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, nil, h.identNotifier)
-	defer h.Trace(ctx, func() error { return err }, "PostDeleteHistoryByID")()
+	defer h.Trace(ctx, func() error { return err }, "PostDeleteHistoryUpto")()
 
 	delh := chat1.MessageDeleteHistory{Upto: arg.Upto}
 
@@ -1060,7 +1060,7 @@ func (h *Server) PostDeleteHistoryByID(ctx context.Context, arg chat1.PostDelete
 	parg.Msg.ClientHeader.DeleteHistory = &delh
 	parg.Msg.MessageBody = chat1.NewMessageBodyWithDeletehistory(delh)
 
-	h.Debug(ctx, "PostDeleteHistoryByID: deleting upto msgid:%v", delh.Upto)
+	h.Debug(ctx, "PostDeleteHistoryUpto: deleting upto msgid:%v", delh.Upto)
 
 	return h.PostLocal(ctx, parg)
 }
@@ -1078,7 +1078,7 @@ func (h *Server) PostDeleteHistoryByAge(ctx context.Context, arg chat1.PostDelet
 	}
 	upto := gmRes.MsgID + 1
 	h.Debug(ctx, "PostDeleteHistoryByAge: deleting upto msgid:%v (age:%v)", upto, arg.Age)
-	return h.PostDeleteHistoryByID(ctx, chat1.PostDeleteHistoryByIDArg{
+	return h.PostDeleteHistoryUpto(ctx, chat1.PostDeleteHistoryUptoArg{
 		ConversationID:   arg.ConversationID,
 		TlfName:          arg.TlfName,
 		TlfPublic:        arg.TlfPublic,

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1045,6 +1045,34 @@ func (h *Server) PostMetadata(ctx context.Context, arg chat1.PostMetadataArg) (c
 	return h.PostLocal(ctx, parg)
 }
 
+func (h *Server) PostDeleteHistory(ctx context.Context, arg chat1.PostDeleteHistoryArg) (res chat1.PostLocalRes, err error) {
+	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, nil, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, "PostDeleteHistory")()
+
+	gmRes, err := h.remoteClient().GetMessageBefore(ctx, chat1.GetMessageBeforeArg{
+		ConvID: arg.ConversationID,
+		Age:    arg.Age,
+	})
+	if err != nil {
+		return res, err
+	}
+
+	delh := chat1.MessageDeleteHistory{Upto: gmRes.MsgID + 1}
+
+	var parg chat1.PostLocalArg
+	parg.ConversationID = arg.ConversationID
+	parg.IdentifyBehavior = arg.IdentifyBehavior
+	parg.Msg.ClientHeader.MessageType = chat1.MessageType_DELETEHISTORY
+	parg.Msg.ClientHeader.TlfName = arg.TlfName
+	parg.Msg.ClientHeader.TlfPublic = arg.TlfPublic
+	parg.Msg.ClientHeader.DeleteHistory = &delh
+	parg.Msg.MessageBody = chat1.NewMessageBodyWithDeletehistory(delh)
+
+	h.Debug(ctx, "PostDeleteHistory: deleting upto msgid:%v (age:%v)", delh.Upto, arg.Age)
+
+	return h.PostLocal(ctx, parg)
+}
+
 func (h *Server) GenerateOutboxID(ctx context.Context) (res chat1.OutboxID, err error) {
 	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_SKIP, nil, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GenerateOutboxID")()

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -951,7 +951,7 @@ func TestChatSrvPostLocal(t *testing.T) {
 		require.Equal(t, chat1.MessageType_HEADLINE, msg.GetMessageType())
 
 		t.Logf("try delete-history RPC interface")
-		_, err = ctc.as(t, users[0]).chatLocalHandler().PostDeleteHistory(ctx, chat1.PostDeleteHistoryArg{
+		_, err = ctc.as(t, users[0]).chatLocalHandler().PostDeleteHistoryByAge(ctx, chat1.PostDeleteHistoryByAgeArg{
 			ConversationID:   created.Id,
 			TlfName:          created.TlfName,
 			TlfPublic:        false,
@@ -963,7 +963,7 @@ func TestChatSrvPostLocal(t *testing.T) {
 			nil)
 		require.NoError(t, err)
 		t.Logf("nmsg: %v", len(tv.Messages))
-		// Teams don't use the remote mock. So PostDeleteHistory won't have gotten a good answer from GetMessageBefore.
+		// Teams don't use the remote mock. So PostDeleteHistoryByAge won't have gotten a good answer from GetMessageBefore.
 		if useRemoteMock {
 			t.Logf("check that the deletable messages are gone")
 			for _, m := range tv.Messages {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -922,6 +922,7 @@ func TestChatSrvPostLocal(t *testing.T) {
 		tv, _, err := tc.Context().ConvSource.Pull(ctx, created.Id, uid, nil,
 			nil)
 		require.NoError(t, err)
+		t.Logf("nmsg: %v", len(tv.Messages))
 		require.NotZero(t, len(tv.Messages))
 		msg := tv.Messages[0]
 
@@ -932,7 +933,7 @@ func TestChatSrvPostLocal(t *testing.T) {
 		require.NotZero(t, len(msg.Valid().ClientHeader.SenderDevice.Bytes()))
 
 		t.Logf("try headline specific RPC interface")
-		_, err = ctc.as(t, users[0]).chatLocalHandler().PostHeadline(ctx, chat1.PostHeadlineArg{
+		res, err := ctc.as(t, users[0]).chatLocalHandler().PostHeadline(ctx, chat1.PostHeadlineArg{
 			ConversationID:   created.Id,
 			TlfName:          created.TlfName,
 			TlfPublic:        false,
@@ -940,12 +941,36 @@ func TestChatSrvPostLocal(t *testing.T) {
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		})
 		require.NoError(t, err)
+		t.Logf("headline -> msgid:%v", res.MessageID)
 		tv, _, err = tc.Context().ConvSource.Pull(ctx, created.Id, uid, nil,
 			nil)
 		require.NoError(t, err)
+		t.Logf("nmsg: %v", len(tv.Messages))
 		require.NotZero(t, len(tv.Messages))
 		msg = tv.Messages[0]
 		require.Equal(t, chat1.MessageType_HEADLINE, msg.GetMessageType())
+
+		t.Logf("try delete-history RPC interface")
+		_, err = ctc.as(t, users[0]).chatLocalHandler().PostDeleteHistory(ctx, chat1.PostDeleteHistoryArg{
+			ConversationID:   created.Id,
+			TlfName:          created.TlfName,
+			TlfPublic:        false,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+			Age:              0,
+		})
+		require.NoError(t, err)
+		tv, _, err = tc.Context().ConvSource.Pull(ctx, created.Id, uid, nil,
+			nil)
+		require.NoError(t, err)
+		t.Logf("nmsg: %v", len(tv.Messages))
+		// Teams don't use the remote mock. So PostDeleteHistory won't have gotten a good answer from GetMessageBefore.
+		if useRemoteMock {
+			t.Logf("check that the deletable messages are gone")
+			for _, m := range tv.Messages {
+				require.False(t, chat1.IsDeletableByDeleteHistory(m.GetMessageType()),
+					"deletable message found: %v %v", m.GetMessageID(), m.GetMessageType())
+			}
+		}
 	})
 }
 

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -777,7 +777,9 @@ func (i *Inbox) NewMessage(ctx context.Context, vers chat1.InboxVers, convID cha
 
 	// Check for a delete, if so just auto return a version mismatch to resync. The reason
 	// is it is tricky to update max messages in this case.
-	if msg.GetMessageType() == chat1.MessageType_DELETE {
+	switch msg.GetMessageType() {
+	case chat1.MessageType_DELETE,
+		chat1.MessageType_DELETEHISTORY:
 		i.Debug(ctx, "NewMessage: returning fake version mismatch error because of delete")
 		return NewVersionMismatchError(ibox.InboxVersion, vers)
 	}

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -34,6 +34,7 @@ type Storage struct {
 	engine       storageEngine
 	idtracker    *msgIDTracker
 	breakTracker *breakTracker
+	delhTracker  *delhTracker
 }
 
 type storageEngine interface {
@@ -51,6 +52,7 @@ func New(g *globals.Context) *Storage {
 		engine:       newBlockEngine(g),
 		idtracker:    newMsgIDTracker(g),
 		breakTracker: newBreakTracker(g),
+		delhTracker:  newDelhTracker(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "Storage", false),
 	}
 }
@@ -250,7 +252,16 @@ func (s *Storage) GetMaxMsgID(ctx context.Context, convID chat1.ConversationID, 
 	return maxMsgID, nil
 }
 
-func (s *Storage) Merge(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed) Error {
+type MergeResult struct {
+	DeletedHistory bool
+}
+
+// msgs must be sorted by descending message ID
+func (s *Storage) Merge(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed) (MergeResult, Error) {
+
+	var res MergeResult
+
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functons.
 	locks.Storage.Lock()
@@ -262,32 +273,48 @@ func (s *Storage) Merge(ctx context.Context, convID chat1.ConversationID, uid gr
 	// Fetch secret key
 	key, ierr := getSecretBoxKey(ctx, s.G().ExternalG(), DefaultSecretUI)
 	if ierr != nil {
-		return MiscError{Msg: "unable to get secret key: " + ierr.Error()}
+		return res, MiscError{Msg: "unable to get secret key: " + ierr.Error()}
 	}
 
 	ctx, err = s.engine.Init(ctx, key, convID, uid)
 	if err != nil {
-		return err
+		return res, err
 	}
+
+	// @@@ TODO delete messages on arrival that are older than the last processed deletehistory (?)
 
 	// Write out new data into blocks
 	if err = s.engine.WriteMessages(ctx, convID, uid, msgs); err != nil {
-		return s.MaybeNuke(false, err, convID, uid)
+		return res, s.MaybeNuke(false, err, convID, uid)
 	}
 
 	// Update supersededBy pointers
 	if err = s.updateAllSupersededBy(ctx, convID, uid, msgs); err != nil {
-		return s.MaybeNuke(false, err, convID, uid)
+		return res, s.MaybeNuke(false, err, convID, uid)
 	}
+
+	if err = s.updateMinDeletableMessage(ctx, convID, uid, msgs); err != nil {
+		return res, s.MaybeNuke(false, err, convID, uid)
+	}
+
+	// Process any DeleteHistory messages
+	deletedHistory, err := s.handleDeleteHistory(ctx, convID, uid, msgs)
+	if err != nil {
+		return res, s.MaybeNuke(false, err, convID, uid)
+	}
+	res.DeletedHistory = deletedHistory
 
 	// Update max msg ID if needed
 	if len(msgs) > 0 {
 		if err := s.idtracker.bumpMaxMessageID(ctx, convID, uid, msgs[0].GetMessageID()); err != nil {
-			return s.MaybeNuke(false, err, convID, uid)
+			return res, s.MaybeNuke(false, err, convID, uid)
 		}
 	}
 
-	return nil
+	// @@@ TODO notify frontend?
+	// @@@ TODO inform inboxsource that it may need to delete/recalculate snippets
+
+	return res, nil
 }
 
 func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.ConversationID,
@@ -303,21 +330,20 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 			continue
 		}
 
-		superIDs, ierr := utils.GetSupersedes(msg)
+		supersededIDs, ierr := utils.GetSupersedes(msg)
 		if ierr != nil {
 			continue
 		}
-		if len(superIDs) > 0 {
-			s.Debug(ctx, "updateSupersededBy: msgID: %d supersedes: %v", msgid, superIDs)
+		if len(supersededIDs) > 0 {
+			s.Debug(ctx, "updateSupersededBy: msgID: %d supersedes: %v", msgid, supersededIDs)
 		}
 
 		// Set all supersedes targets
-		for _, superID := range superIDs {
-			s.Debug(ctx, "updateSupersededBy: supersedes: id: %d supersedes: %d", msgid, superID)
-			// Read super msg
-			var superMsgs []chat1.MessageUnboxed
+		for _, supersededID := range supersededIDs {
+			s.Debug(ctx, "updateSupersededBy: supersedes: id: %d supersedes: %d", msgid, supersededID)
+			// Read superseded msg
 			rc := NewSimpleResultCollector(1)
-			err := s.engine.ReadMessages(ctx, rc, convID, uid, superID)
+			err := s.engine.ReadMessages(ctx, rc, convID, uid, supersededID)
 			if err != nil {
 				// If we don't have the message, just keep going
 				if _, ok := err.(MissError); ok {
@@ -325,7 +351,7 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 				}
 				return err
 			}
-			superMsgs = rc.Result()
+			superMsgs := rc.Result()
 			if len(superMsgs) == 0 {
 				continue
 			}
@@ -334,7 +360,7 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 			// the superseder is a deletion, delete the body as well.
 			superMsg := superMsgs[0]
 			if superMsg.IsValid() {
-				s.Debug(ctx, "updateSupersededBy: writing: id: %d superseded: %d", msgid, superID)
+				s.Debug(ctx, "updateSupersededBy: writing: id: %d superseded: %d", msgid, supersededID)
 				mvalid := superMsg.Valid()
 				mvalid.ServerHeader.SupersededBy = msgid
 				if msg.GetMessageType() == chat1.MessageType_DELETE {
@@ -353,6 +379,202 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 	}
 
 	return nil
+}
+
+func (s *Storage) updateMinDeletableMessage(ctx context.Context, convID chat1.ConversationID,
+	uid gregor1.UID, msgs []chat1.MessageUnboxed) Error {
+
+	de := func(format string, args ...interface{}) {
+		s.Debug(ctx, "updateMinDeletableMessage: "+fmt.Sprintf(format, args...))
+	}
+
+	// The min deletable message ID in this new batch of messages.
+	var minDeletableMessageBatch *chat1.MessageID
+	for _, msg := range msgs {
+		msgid := msg.GetMessageID()
+		if !msg.IsValid() {
+			de("skipping message marked as error: %d", msgid)
+			continue
+		}
+		if !chat1.IsDeletableByDeleteHistory(msg.GetMessageType()) {
+			continue
+		}
+		if msg.Valid().MessageBody.IsNil() {
+			continue
+		}
+		if minDeletableMessageBatch == nil || msgid < *minDeletableMessageBatch {
+			minDeletableMessageBatch = &msgid
+		}
+	}
+
+	// Update the tracker to min(mem, batch)
+	if minDeletableMessageBatch != nil {
+		mem, err := s.delhTracker.getEntry(ctx, convID, uid)
+		switch err.(type) {
+		case nil:
+			if mem.MinDeletableMessage > 0 && *minDeletableMessageBatch >= mem.MinDeletableMessage {
+				// no need to update
+				return nil
+			}
+		case MissError:
+			// We have no memory
+		default:
+			return err
+		}
+
+		err = s.delhTracker.setMinDeletableMessage(ctx, convID, uid, *minDeletableMessageBatch)
+		if err != nil {
+			de("failed to store delh track: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Apply any new DeleteHistory from msgs.
+// Returns whether local deletes happened.
+// Shortcircuits so it's ok to call a lot.
+func (s *Storage) handleDeleteHistory(ctx context.Context, convID chat1.ConversationID,
+	uid gregor1.UID, msgs []chat1.MessageUnboxed) (bool, Error) {
+
+	type delhTagged struct {
+		source chat1.MessageUnboxedValid
+		delh   chat1.MessageDeleteHistory
+	}
+
+	de := func(format string, args ...interface{}) {
+		s.Debug(ctx, "handleDeleteHistory: "+fmt.Sprintf(format, args...))
+	}
+
+	// Find the DeleteHistory message with the maximum upto value.
+	var delhActive *delhTagged
+	for _, msg := range msgs {
+		msgid := msg.GetMessageID()
+		if !msg.IsValid() {
+			de("skipping message marked as error: %d", msgid)
+			continue
+		}
+		if msg.GetMessageType() != chat1.MessageType_DELETEHISTORY {
+			continue
+		}
+		mvalid := msg.Valid()
+		bodyType, err := mvalid.MessageBody.MessageType()
+		if err != nil {
+			de("skipping corrupted message body: %v", err)
+			continue
+		}
+		if bodyType != chat1.MessageType_DELETEHISTORY {
+			de("skipping wrong message body type: %v", err)
+			continue
+		}
+		delh := mvalid.MessageBody.Deletehistory()
+		de("found DeleteHistory: id:%v upto:%v", msgid, delh.Upto)
+		if delh.Upto <= 0 {
+			de("skipping malformed delh")
+			continue
+		}
+
+		if delhActive == nil || (delh.Upto > delhActive.delh.Upto) {
+			delhActive = &delhTagged{
+				source: mvalid,
+				delh:   delh,
+			}
+		}
+	}
+
+	// Noop if there are no DeleteHistory messages
+	if delhActive == nil {
+		return false, nil
+	}
+
+	mem, err := s.delhTracker.getEntry(ctx, convID, uid)
+	switch err.(type) {
+	case nil:
+		if mem.MaxDeleteHistoryUpto >= delhActive.delh.Upto {
+			// No-op if the effect has already been applied locally
+			de("skipping delh with no new effect: (upto local:%v >= msg:%v)", mem.MaxDeleteHistoryUpto, delhActive.delh.Upto)
+			return false, nil
+		}
+		if delhActive.delh.Upto < mem.MinDeletableMessage {
+			// Record-only if it would delete messages earlier than the local min.
+			de("record-only delh: (%v < %v)", delhActive.delh.Upto, mem.MinDeletableMessage)
+			err := s.delhTracker.setMaxDeleteHistoryUpto(ctx, convID, uid, delhActive.delh.Upto)
+			if err != nil {
+				de("failed to store delh track: %v", err)
+			}
+			return false, nil
+		}
+		// No shortcuts, fallthrough to apply.
+	case MissError:
+		// We have no memory, assume it needs to be applied
+	default:
+		return false, err
+	}
+
+	return s.applyDeleteHistory(ctx, convID, uid, delhActive.source, delhActive.delh)
+}
+
+// Apply a delete history.
+// Returns whether local deletes happened.
+// Always runs through local messages.
+func (s *Storage) applyDeleteHistory(ctx context.Context, convID chat1.ConversationID,
+	uid gregor1.UID, source chat1.MessageUnboxedValid, delh chat1.MessageDeleteHistory) (bool, Error) {
+
+	s.Debug(ctx, "applyDeleteHistory(%v, %v, %v)", convID, uid, delh.Upto)
+
+	de := func(format string, args ...interface{}) {
+		s.Debug(ctx, "applyDeleteHistory: "+fmt.Sprintf(format, args...))
+	}
+
+	rc := NewSimpleResultCollector(-1) // collect all messages
+	err := s.engine.ReadMessages(ctx, rc, convID, uid, delh.Upto-1)
+	switch err.(type) {
+	case nil:
+		// ok
+	case MissError:
+		de("record-only delh: no local messages")
+		err := s.delhTracker.setMaxDeleteHistoryUpto(ctx, convID, uid, delh.Upto)
+		if err != nil {
+			de("failed to store delh track: %v", err)
+		}
+		return false, nil
+	default:
+		return false, err
+	}
+
+	var writeback []chat1.MessageUnboxed
+	for _, msg := range rc.Result() {
+		if !chat1.IsDeletableByDeleteHistory(msg.GetMessageType()) {
+			// Skip message types that cannot be deleted this way
+			continue
+		}
+		if !msg.IsValid() {
+			de("skipping invalid msg: %v", msg.GetMessageID())
+		}
+		mvalid := msg.Valid()
+		if mvalid.MessageBody.IsNil() {
+			de("skipping already deleted msg: %v", msg.GetMessageID())
+			continue
+		}
+		mvalid.ServerHeader.SupersededBy = source.ServerHeader.MessageID
+		var emptyBody chat1.MessageBody
+		mvalid.MessageBody = emptyBody
+		writeback = append(writeback, chat1.NewMessageUnboxedWithValid(mvalid))
+	}
+	de("deleting %v messages", len(writeback))
+
+	err = s.engine.WriteMessages(ctx, convID, uid, writeback)
+	if err != nil {
+		de("write messages failed: %v", err)
+		return false, err
+	}
+
+	err = s.delhTracker.setDeletedUpto(ctx, convID, uid, delh.Upto)
+	if err != nil {
+		de("failed to store delh track: %v", err)
+	}
+
+	return true, nil
 }
 
 func (s *Storage) ResultCollectorFromQuery(ctx context.Context, query *chat1.GetThreadQuery,

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -281,8 +281,6 @@ func (s *Storage) Merge(ctx context.Context,
 		return res, err
 	}
 
-	// @@@ TODO delete messages on arrival that are older than the last processed deletehistory (?)
-
 	// Write out new data into blocks
 	if err = s.engine.WriteMessages(ctx, convID, uid, msgs); err != nil {
 		return res, s.MaybeNuke(false, err, convID, uid)
@@ -310,9 +308,6 @@ func (s *Storage) Merge(ctx context.Context,
 			return res, s.MaybeNuke(false, err, convID, uid)
 		}
 	}
-
-	// @@@ TODO notify frontend?
-	// @@@ TODO inform inboxsource that it may need to delete/recalculate snippets
 
 	return res, nil
 }
@@ -550,6 +545,7 @@ func (s *Storage) applyDeleteHistory(ctx context.Context, convID chat1.Conversat
 		}
 		if !msg.IsValid() {
 			de("skipping invalid msg: %v", msg.GetMessageID())
+			continue
 		}
 		mvalid := msg.Valid()
 		if mvalid.MessageBody.IsNil() {

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -23,7 +23,7 @@ type blockEngine struct {
 func newBlockEngine(g *globals.Context) *blockEngine {
 	return &blockEngine{
 		Contextified: globals.NewContextified(g),
-		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "BlockEngine", true),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "BlockEngine", false),
 	}
 }
 
@@ -370,6 +370,7 @@ func (be *blockEngine) WriteMessages(ctx context.Context, convID chat1.Conversat
 
 func (be *blockEngine) ReadMessages(ctx context.Context, res ResultCollector,
 	convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID) (err Error) {
+	be.Debug(ctx, "readMessages: hi")
 
 	// Run all errors through resultCollector
 	defer func() {

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -23,7 +23,7 @@ type blockEngine struct {
 func newBlockEngine(g *globals.Context) *blockEngine {
 	return &blockEngine{
 		Contextified: globals.NewContextified(g),
-		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "BlockEngine", false),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "BlockEngine", true),
 	}
 }
 
@@ -370,7 +370,6 @@ func (be *blockEngine) WriteMessages(ctx context.Context, convID chat1.Conversat
 
 func (be *blockEngine) ReadMessages(ctx context.Context, res ResultCollector,
 	convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID) (err Error) {
-	be.Debug(ctx, "readMessages: hi")
 
 	// Run all errors through resultCollector
 	defer func() {

--- a/go/chat/storage/storage_breaks.go
+++ b/go/chat/storage/storage_breaks.go
@@ -23,7 +23,7 @@ func newBreakTracker(g *globals.Context) *breakTracker {
 	}
 }
 
-func (b *breakTracker) makeKey(tlfID chat1.TLFID) libkb.DbKey {
+func (b *breakTracker) makeDbKey(tlfID chat1.TLFID) libkb.DbKey {
 	return libkb.DbKey{
 		Typ: libkb.DBChatBlocks,
 		Key: fmt.Sprintf("breaks:%s", tlfID),
@@ -33,7 +33,7 @@ func (b *breakTracker) makeKey(tlfID chat1.TLFID) libkb.DbKey {
 func (b *breakTracker) UpdateTLF(ctx context.Context, tlfID chat1.TLFID,
 	breaks []keybase1.TLFIdentifyFailure) error {
 
-	key := b.makeKey(tlfID)
+	key := b.makeDbKey(tlfID)
 
 	dat, err := encode(breaks)
 	if err != nil {
@@ -48,7 +48,7 @@ func (b *breakTracker) UpdateTLF(ctx context.Context, tlfID chat1.TLFID,
 
 func (b *breakTracker) IsTLFBroken(ctx context.Context, tlfID chat1.TLFID) (bool, error) {
 
-	key := b.makeKey(tlfID)
+	key := b.makeDbKey(tlfID)
 	raw, found, err := b.G().LocalChatDb.GetRaw(key)
 	if err != nil {
 		return true, NewInternalError(ctx, b.DebugLabeler, "GetRaw error: %s", err.Error())

--- a/go/chat/storage/storage_delh.go
+++ b/go/chat/storage/storage_delh.go
@@ -1,0 +1,153 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"golang.org/x/net/context"
+)
+
+type delhTracker struct {
+	globals.Contextified
+	utils.DebugLabeler
+}
+
+type delhTrackerEntry struct {
+	StorageVersion int `codec:"v"`
+	// The latest DeleteHistory upto value that has been applied locally
+	MaxDeleteHistoryUpto chat1.MessageID `codec:"ldhu"`
+	// The most ancient message that a new DeleteHistory could affect
+	MinDeletableMessage chat1.MessageID `codec:"em"`
+}
+
+const delhTrackerDiskVersion = 1
+
+func newDelhTracker(g *globals.Context) *delhTracker {
+	return &delhTracker{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "DelhTracker", false),
+	}
+}
+
+func (t *delhTracker) makeDbKey(convID chat1.ConversationID, uid gregor1.UID) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatBlocks,
+		Key: fmt.Sprintf("delh:%s:%s", uid, convID),
+	}
+}
+
+func (t *delhTracker) getEntry(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID) (delhTrackerEntry, Error) {
+
+	var blank delhTrackerEntry
+	var res delhTrackerEntry
+
+	dbKey := t.makeDbKey(convID, uid)
+	raw, found, err := t.G().LocalChatDb.GetRaw(dbKey)
+	if err != nil {
+		return res, NewInternalError(ctx, t.DebugLabeler, "GetRaw error: %s", err.Error())
+	}
+	if !found {
+		return res, MissError{}
+	}
+
+	err = decode(raw, &res)
+	if err != nil {
+		return blank, NewInternalError(ctx, t.DebugLabeler, "decode error: %s", err.Error())
+	}
+	switch res.StorageVersion {
+	case delhTrackerDiskVersion:
+		return res, nil
+	default:
+		// ignore other versions
+		return blank, MissError{}
+	}
+}
+
+func (t *delhTracker) setEntry(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID, entry delhTrackerEntry) Error {
+
+	entry.StorageVersion = delhTrackerDiskVersion
+	data, err := encode(entry)
+	if err != nil {
+		return NewInternalError(ctx, t.DebugLabeler, "encode error: %s", err.Error())
+	}
+
+	dbKey := t.makeDbKey(convID, uid)
+	err = t.G().LocalChatDb.PutRaw(dbKey, data)
+	if err != nil {
+		return NewInternalError(ctx, t.DebugLabeler, "PutRaw error: %s", err.Error())
+	}
+	t.Debug(ctx, "delhTracker.setEntry(%v, %+v)", convID, entry)
+	return nil
+}
+
+func (t *delhTracker) setMaxDeleteHistoryUpto(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID, msgid chat1.MessageID) Error {
+
+	// No need to use transaction here since the Storage class takes lock.
+
+	entry, err := t.getEntry(ctx, convID, uid)
+	switch err.(type) {
+	case nil:
+	case MissError:
+	default:
+		return err
+	}
+	entry.MaxDeleteHistoryUpto = msgid
+	return t.setEntry(ctx, convID, uid, entry)
+}
+
+func (t *delhTracker) setMinDeletableMessage(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID, msgid chat1.MessageID) Error {
+
+	entry, err := t.getEntry(ctx, convID, uid)
+	switch err.(type) {
+	case nil:
+	case MissError:
+	default:
+		return err
+	}
+	entry.MinDeletableMessage = msgid
+	return t.setEntry(ctx, convID, uid, entry)
+}
+
+// Set both values to msgid
+func (t *delhTracker) setDeletedUpto(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID, msgid chat1.MessageID) Error {
+
+	entry, err := t.getEntry(ctx, convID, uid)
+	switch err.(type) {
+	case nil:
+	case MissError:
+	default:
+		return err
+	}
+	entry.MaxDeleteHistoryUpto = msgid
+	entry.MinDeletableMessage = msgid
+	return t.setEntry(ctx, convID, uid, entry)
+}
+
+func (t *delhTracker) modify(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID, mod func(*delhTrackerEntry) (delhTrackerEntry, Error)) Error {
+
+	var before *delhTrackerEntry
+	tmp, err := t.getEntry(ctx, convID, uid)
+	switch err.(type) {
+	case nil:
+		before = &tmp
+	case MissError:
+		// ok
+	default:
+		return err
+	}
+	after, err := mod(before)
+	if err != nil {
+		return err
+	}
+	return t.setEntry(ctx, convID, uid, after)
+}

--- a/go/chat/storage/storage_delh.go
+++ b/go/chat/storage/storage_delh.go
@@ -131,23 +131,3 @@ func (t *delhTracker) setDeletedUpto(ctx context.Context,
 	entry.MinDeletableMessage = msgid
 	return t.setEntry(ctx, convID, uid, entry)
 }
-
-func (t *delhTracker) modify(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID, mod func(*delhTrackerEntry) (delhTrackerEntry, Error)) Error {
-
-	var before *delhTrackerEntry
-	tmp, err := t.getEntry(ctx, convID, uid)
-	switch err.(type) {
-	case nil:
-		before = &tmp
-	case MissError:
-		// ok
-	default:
-		return err
-	}
-	after, err := mod(before)
-	if err != nil {
-		return err
-	}
-	return t.setEntry(ctx, convID, uid, after)
-}

--- a/go/chat/storage/storage_msgid_tracker.go
+++ b/go/chat/storage/storage_msgid_tracker.go
@@ -23,7 +23,7 @@ func newMsgIDTracker(g *globals.Context) *msgIDTracker {
 	}
 }
 
-func (t *msgIDTracker) makeMaxMsgIDKey(convID chat1.ConversationID, uid gregor1.UID) libkb.DbKey {
+func (t *msgIDTracker) makeDbKey(convID chat1.ConversationID, uid gregor1.UID) libkb.DbKey {
 	return libkb.DbKey{
 		Typ: libkb.DBChatBlocks,
 		Key: fmt.Sprintf("maxMsgID:%s:%s", uid, convID),
@@ -35,7 +35,7 @@ func (t *msgIDTracker) bumpMaxMessageID(
 
 	// No need to use transaction here since the Storage class takes lock.
 
-	maxMsgIDKey := t.makeMaxMsgIDKey(convID, uid)
+	maxMsgIDKey := t.makeDbKey(convID, uid)
 
 	raw, found, err := t.G().LocalChatDb.GetRaw(maxMsgIDKey)
 	if err != nil {
@@ -65,7 +65,7 @@ func (t *msgIDTracker) bumpMaxMessageID(
 func (t *msgIDTracker) getMaxMessageID(
 	ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (chat1.MessageID, Error) {
 
-	maxMsgIDKey := t.makeMaxMsgIDKey(convID, uid)
+	maxMsgIDKey := t.makeDbKey(convID, uid)
 
 	raw, found, err := t.G().LocalChatDb.GetRaw(maxMsgIDKey)
 	if err != nil {

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -165,6 +165,7 @@ func (t *basicSupersedesTransform) Run(ctx context.Context,
 	var newMsgs []chat1.MessageUnboxed
 	for _, msg := range originalMsgs {
 		if msg.IsValid() {
+			// Hide messages which are or should have been deleted by a DeleteHistory.
 			if msg.GetMessageID() < deleteHistoryUpto && chat1.IsDeletableByDeleteHistory(msg.GetMessageType()) {
 				continue
 			}

--- a/go/client/chat_send_common.go
+++ b/go/client/chat_send_common.go
@@ -15,15 +15,18 @@ import (
 
 type ChatSendArg struct {
 	resolvingRequest chatConversationResolvingRequest
+
 	// Only one of these should be set
 	message       string
 	setTopicName  string
 	setHeadline   string
 	clearHeadline bool
-	hasTTY        bool
-	nonBlock      bool
-	team          bool
-	mustNotExist  bool
+	deleteHistory *chat1.MessageDeleteHistory
+
+	hasTTY       bool
+	nonBlock     bool
+	team         bool // TODO is this field used?
+	mustNotExist bool
 }
 
 func chatSend(ctx context.Context, g *libkb.GlobalContext, c ChatSendArg) error {
@@ -68,6 +71,10 @@ func chatSend(ctx context.Context, g *libkb.GlobalContext, c ChatSendArg) error 
 	case c.clearHeadline:
 		msg.ClientHeader.MessageType = chat1.MessageType_HEADLINE
 		msg.MessageBody = chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: ""})
+	case c.deleteHistory != nil:
+		msg.ClientHeader.MessageType = chat1.MessageType_DELETEHISTORY
+		msg.ClientHeader.DeleteHistory = c.deleteHistory
+		msg.MessageBody = chat1.NewMessageBodyWithDeletehistory(*c.deleteHistory)
 	default:
 		// Ask for message contents
 		if len(c.message) == 0 {

--- a/go/client/cmd_chat.go
+++ b/go/client/cmd_chat.go
@@ -10,28 +10,30 @@ import (
 )
 
 func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	subcommands := []cli.Command{
+		newCmdChatAPI(cl, g),
+		newCmdChatDeleteChannel(cl, g),
+		newCmdChatDownload(cl, g),
+		newCmdChatHide(cl, g),
+		newCmdChatJoinChannel(cl, g),
+		newCmdChatLeaveChannel(cl, g),
+		newCmdChatRenameChannel(cl, g),
+		newCmdChatCreateChannel(cl, g),
+		newCmdChatList(cl, g),
+		newCmdChatListChannels(cl, g),
+		newCmdChatListMembers(cl, g),
+		newCmdChatListUnread(cl, g),
+		newCmdChatMute(cl, g),
+		newCmdChatRead(cl, g),
+		newCmdChatReport(cl, g),
+		newCmdChatSend(cl, g),
+		newCmdChatUpload(cl, g),
+	}
+	subcommands = append(subcommands, getBuildSpecificChatCommands(cl, g)...)
 	return cli.Command{
 		Name:         "chat",
 		Usage:        "Chat securely with keybase users",
 		ArgumentHelp: "[arguments...]",
-		Subcommands: []cli.Command{
-			newCmdChatAPI(cl, g),
-			newCmdChatDeleteChannel(cl, g),
-			newCmdChatDownload(cl, g),
-			newCmdChatHide(cl, g),
-			newCmdChatJoinChannel(cl, g),
-			newCmdChatLeaveChannel(cl, g),
-			newCmdChatRenameChannel(cl, g),
-			newCmdChatCreateChannel(cl, g),
-			newCmdChatList(cl, g),
-			newCmdChatListChannels(cl, g),
-			newCmdChatListMembers(cl, g),
-			newCmdChatListUnread(cl, g),
-			newCmdChatMute(cl, g),
-			newCmdChatRead(cl, g),
-			newCmdChatReport(cl, g),
-			newCmdChatSend(cl, g),
-			newCmdChatUpload(cl, g),
-		},
+		Subcommands:  subcommands,
 	}
 }

--- a/go/client/cmd_chat.go
+++ b/go/client/cmd_chat.go
@@ -13,6 +13,7 @@ func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 	subcommands := []cli.Command{
 		newCmdChatAPI(cl, g),
 		newCmdChatDeleteChannel(cl, g),
+		newCmdChatDeleteHistory(cl, g),
 		newCmdChatDownload(cl, g),
 		newCmdChatHide(cl, g),
 		newCmdChatJoinChannel(cl, g),

--- a/go/client/cmd_chat_delete_history.go
+++ b/go/client/cmd_chat_delete_history.go
@@ -1,0 +1,112 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	isatty "github.com/mattn/go-isatty"
+)
+
+type CmdChatDeleteHistory struct {
+	libkb.Contextified
+	resolvingRequest chatConversationResolvingRequest
+	upto             chat1.MessageID
+	hasTTY           bool
+}
+
+func NewCmdChatDeleteHistoryRunner(g *libkb.GlobalContext) *CmdChatDeleteHistory {
+	return &CmdChatDeleteHistory{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatDeleteHistory(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "delete-history",
+		Usage:        "Delete chat history in a conversation",
+		ArgumentHelp: "[conversation] --upto=<messageid>",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatDeleteHistoryRunner(g), "delete-history", c)
+			cl.SetNoStandalone()
+		},
+		Flags: append(getConversationResolverFlags(), []cli.Flag{
+			cli.IntFlag{
+				Name:  "upto",
+				Usage: `Up to this message ID (exclusive)`,
+			},
+		}...),
+	}
+}
+
+func (c *CmdChatDeleteHistory) Run() (err error) {
+	if c.resolvingRequest.TlfName != "" {
+		err = annotateResolvingRequest(c.G(), &c.resolvingRequest)
+		if err != nil {
+			return err
+		}
+	}
+	// TLFVisibility_ANY doesn't make any sense for send, so switch that to PRIVATE:
+	if c.resolvingRequest.Visibility == keybase1.TLFVisibility_ANY {
+		c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
+	}
+
+	if c.G().Standalone {
+		switch c.resolvingRequest.MembersType {
+		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
+			c.G().StartStandaloneChat()
+		default:
+			err = CantRunInStandaloneError{}
+			return err
+		}
+	}
+
+	return chatSend(context.TODO(), c.G(), ChatSendArg{
+		resolvingRequest: c.resolvingRequest,
+
+		deleteHistory: &chat1.MessageDeleteHistory{
+			Upto: c.upto,
+		},
+
+		hasTTY: c.hasTTY,
+	})
+}
+
+func (c *CmdChatDeleteHistory) ParseArgv(ctx *cli.Context) (err error) {
+	c.hasTTY = isatty.IsTerminal(os.Stdin.Fd())
+
+	var tlfName string
+	// Get the TLF name from the first position arg
+	if len(ctx.Args()) >= 1 {
+		tlfName = ctx.Args().Get(0)
+	}
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+		return err
+	}
+
+	// Send a normal message.
+	upto := ctx.Int("upto")
+	if upto == 0 {
+		cli.ShowCommandHelp(ctx, "delete-history")
+		return fmt.Errorf("upto must be > 0")
+	}
+	c.upto = chat1.MessageID(upto)
+
+	return nil
+}
+
+func (c *CmdChatDeleteHistory) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/cmd_chat_delete_history.go
+++ b/go/client/cmd_chat_delete_history.go
@@ -22,7 +22,7 @@ import (
 type CmdChatDeleteHistory struct {
 	libkb.Contextified
 	resolvingRequest chatConversationResolvingRequest
-	age              gregor1.Seconds
+	age              gregor1.DurationSec
 	hasTTY           bool
 }
 
@@ -104,7 +104,7 @@ func (c *CmdChatDeleteHistory) GetUsage() libkb.Usage {
 	}
 }
 
-func (c *CmdChatDeleteHistory) parseAge(s string) (gregor1.Seconds, error) {
+func (c *CmdChatDeleteHistory) parseAge(s string) (gregor1.DurationSec, error) {
 	generalErr := fmt.Errorf("duration must be an integer and suffix [s,h,d,w,m] like: 10d")
 	if len(s) < 2 {
 		return 0, generalErr
@@ -132,7 +132,7 @@ func (c *CmdChatDeleteHistory) parseAge(s string) (gregor1.Seconds, error) {
 		return 0, fmt.Errorf("age cannot be negative")
 	}
 	d := time.Duration(base) * factor
-	return gregor1.Seconds(d.Seconds()), nil
+	return gregor1.DurationSec(d.Seconds()), nil
 }
 
 // Like chatSend but uses PostDeleteHistory.

--- a/go/client/cmd_chat_delete_history.go
+++ b/go/client/cmd_chat_delete_history.go
@@ -135,7 +135,7 @@ func (c *CmdChatDeleteHistory) parseAge(s string) (gregor1.DurationSec, error) {
 	return gregor1.DurationSec(d.Seconds()), nil
 }
 
-// Like chatSend but uses PostDeleteHistory.
+// Like chatSend but uses PostDeleteHistoryByAge.
 func (c *CmdChatDeleteHistory) chatSendDeleteHistory(ctx context.Context) error {
 	resolver, err := newChatConversationResolver(c.G())
 	if err != nil {
@@ -153,7 +153,7 @@ func (c *CmdChatDeleteHistory) chatSendDeleteHistory(ctx context.Context) error 
 	}
 	conversationInfo := conversation.Info
 
-	arg := chat1.PostDeleteHistoryArg{
+	arg := chat1.PostDeleteHistoryByAgeArg{
 		ConversationID:   conversationInfo.Id,
 		TlfName:          conversationInfo.TlfName,
 		TlfPublic:        (conversationInfo.Visibility == keybase1.TLFVisibility_PUBLIC),
@@ -168,6 +168,6 @@ func (c *CmdChatDeleteHistory) chatSendDeleteHistory(ctx context.Context) error 
 		return err
 	}
 
-	_, err = resolver.ChatClient.PostDeleteHistory(ctx, arg)
+	_, err = resolver.ChatClient.PostDeleteHistoryByAge(ctx, arg)
 	return err
 }

--- a/go/client/cmd_chat_delete_history_dev.go
+++ b/go/client/cmd_chat_delete_history_dev.go
@@ -1,0 +1,112 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	isatty "github.com/mattn/go-isatty"
+)
+
+type CmdChatDeleteHistoryDev struct {
+	libkb.Contextified
+	resolvingRequest chatConversationResolvingRequest
+	upto             chat1.MessageID
+	hasTTY           bool
+}
+
+func NewCmdChatDeleteHistoryDevRunner(g *libkb.GlobalContext) *CmdChatDeleteHistoryDev {
+	return &CmdChatDeleteHistoryDev{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatDeleteHistoryDev(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "delete-history-dev",
+		Usage:        "Delete chat history in a conversation up to a message ID",
+		ArgumentHelp: "[conversation] --upto=<messageid>",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatDeleteHistoryDevRunner(g), "delete-history-dev", c)
+			cl.SetNoStandalone()
+		},
+		Flags: append(getConversationResolverFlags(), []cli.Flag{
+			cli.IntFlag{
+				Name:  "upto",
+				Usage: `Up to this message ID (exclusive)`,
+			},
+		}...),
+	}
+}
+
+func (c *CmdChatDeleteHistoryDev) Run() (err error) {
+	if c.resolvingRequest.TlfName != "" {
+		err = annotateResolvingRequest(c.G(), &c.resolvingRequest)
+		if err != nil {
+			return err
+		}
+	}
+	// TLFVisibility_ANY doesn't make any sense for send, so switch that to PRIVATE:
+	if c.resolvingRequest.Visibility == keybase1.TLFVisibility_ANY {
+		c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
+	}
+
+	if c.G().Standalone {
+		switch c.resolvingRequest.MembersType {
+		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
+			c.G().StartStandaloneChat()
+		default:
+			err = CantRunInStandaloneError{}
+			return err
+		}
+	}
+
+	return chatSend(context.TODO(), c.G(), ChatSendArg{
+		resolvingRequest: c.resolvingRequest,
+
+		deleteHistory: &chat1.MessageDeleteHistory{
+			Upto: c.upto,
+		},
+
+		hasTTY: c.hasTTY,
+	})
+}
+
+func (c *CmdChatDeleteHistoryDev) ParseArgv(ctx *cli.Context) (err error) {
+	c.hasTTY = isatty.IsTerminal(os.Stdin.Fd())
+
+	var tlfName string
+	// Get the TLF name from the first position arg
+	if len(ctx.Args()) >= 1 {
+		tlfName = ctx.Args().Get(0)
+	}
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+		return err
+	}
+
+	// Send a normal message.
+	upto := ctx.Int("upto")
+	if upto == 0 {
+		cli.ShowCommandHelp(ctx, "delete-history-dev")
+		return fmt.Errorf("upto must be > 0")
+	}
+	c.upto = chat1.MessageID(upto)
+
+	return nil
+}
+
+func (c *CmdChatDeleteHistoryDev) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/cmd_rekey_devel.go
+++ b/go/client/cmd_rekey_devel.go
@@ -11,7 +11,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 )
 
-// These are the production rekey commands
+// These are the devel rekey commands
 func NewCmdRekey(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "rekey",

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -36,6 +36,12 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 	}
 }
 
+func getBuildSpecificChatCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
+	return []cli.Command{
+		newCmdChatDeleteHistory(cl, g),
+	}
+}
+
 var restrictedSignupFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "p, passphrase",

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -38,7 +38,7 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 
 func getBuildSpecificChatCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
 	return []cli.Command{
-		newCmdChatDeleteHistory(cl, g),
+		newCmdChatDeleteHistoryDev(cl, g),
 	}
 }
 

--- a/go/client/commands_production.go
+++ b/go/client/commands_production.go
@@ -17,6 +17,10 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 	return []cli.Command{}
 }
 
+func getBuildSpecificChatCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
+	return []cli.Command{}
+}
+
 const develUsage = false
 
 var restrictedSignupFlags = []cli.Flag{}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -213,6 +213,23 @@ func (m MessageUnboxed) IsValid() bool {
 	return false
 }
 
+func (m MessageUnboxedValid) AsDeleteHistory() (res MessageDeleteHistory, err error) {
+	if m.ClientHeader.MessageType != MessageType_DELETEHISTORY {
+		return res, fmt.Errorf("message is %v not %v", m.ClientHeader.MessageType, MessageType_DELETEHISTORY)
+	}
+	if m.MessageBody.IsNil() {
+		return res, fmt.Errorf("missing message body")
+	}
+	btyp, err := m.MessageBody.MessageType()
+	if err != nil {
+		return res, err
+	}
+	if btyp != MessageType_DELETEHISTORY {
+		return res, fmt.Errorf("message has wrong body type: %v", btyp)
+	}
+	return m.MessageBody.Deletehistory(), nil
+}
+
 func (b MessageBody) IsNil() bool {
 	return b == MessageBody{}
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -5,6 +5,7 @@ package chat1
 
 import (
 	"errors"
+
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -3709,7 +3710,15 @@ type PostMetadataArg struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
-type PostDeleteHistoryArg struct {
+type PostDeleteHistoryByIDArg struct {
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+	Upto             MessageID                    `codec:"upto" json:"upto"`
+}
+
+type PostDeleteHistoryByAgeArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
 	TlfName          string                       `codec:"tlfName" json:"tlfName"`
 	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
@@ -3897,7 +3906,8 @@ type LocalInterface interface {
 	PostHeadline(context.Context, PostHeadlineArg) (PostLocalRes, error)
 	PostMetadataNonblock(context.Context, PostMetadataNonblockArg) (PostLocalNonblockRes, error)
 	PostMetadata(context.Context, PostMetadataArg) (PostLocalRes, error)
-	PostDeleteHistory(context.Context, PostDeleteHistoryArg) (PostLocalRes, error)
+	PostDeleteHistoryByID(context.Context, PostDeleteHistoryByIDArg) (PostLocalRes, error)
+	PostDeleteHistoryByAge(context.Context, PostDeleteHistoryByAgeArg) (PostLocalRes, error)
 	SetConversationStatusLocal(context.Context, SetConversationStatusLocalArg) (SetConversationStatusLocalRes, error)
 	NewConversationLocal(context.Context, NewConversationLocalArg) (NewConversationLocalRes, error)
 	GetInboxSummaryForCLILocal(context.Context, GetInboxSummaryForCLILocalQuery) (GetInboxSummaryForCLILocalRes, error)
@@ -4165,18 +4175,34 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"postDeleteHistory": {
+			"postDeleteHistoryByID": {
 				MakeArg: func() interface{} {
-					ret := make([]PostDeleteHistoryArg, 1)
+					ret := make([]PostDeleteHistoryByIDArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]PostDeleteHistoryArg)
+					typedArgs, ok := args.(*[]PostDeleteHistoryByIDArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]PostDeleteHistoryArg)(nil), args)
+						err = rpc.NewTypeError((*[]PostDeleteHistoryByIDArg)(nil), args)
 						return
 					}
-					ret, err = i.PostDeleteHistory(ctx, (*typedArgs)[0])
+					ret, err = i.PostDeleteHistoryByID(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"postDeleteHistoryByAge": {
+				MakeArg: func() interface{} {
+					ret := make([]PostDeleteHistoryByAgeArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]PostDeleteHistoryByAgeArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]PostDeleteHistoryByAgeArg)(nil), args)
+						return
+					}
+					ret, err = i.PostDeleteHistoryByAge(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -4675,8 +4701,13 @@ func (c LocalClient) PostMetadata(ctx context.Context, __arg PostMetadataArg) (r
 	return
 }
 
-func (c LocalClient) PostDeleteHistory(ctx context.Context, __arg PostDeleteHistoryArg) (res PostLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistory", []interface{}{__arg}, &res)
+func (c LocalClient) PostDeleteHistoryByID(ctx context.Context, __arg PostDeleteHistoryByIDArg) (res PostLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistoryByID", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) PostDeleteHistoryByAge(ctx context.Context, __arg PostDeleteHistoryByAgeArg) (res PostLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistoryByAge", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -5,7 +5,6 @@ package chat1
 
 import (
 	"errors"
-
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3714,7 +3714,7 @@ type PostDeleteHistoryArg struct {
 	TlfName          string                       `codec:"tlfName" json:"tlfName"`
 	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
-	Age              gregor1.Seconds              `codec:"age" json:"age"`
+	Age              gregor1.DurationSec          `codec:"age" json:"age"`
 }
 
 type SetConversationStatusLocalArg struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -344,14 +344,12 @@ func (o MessageSystem) DeepCopy() MessageSystem {
 }
 
 type MessageDeleteHistory struct {
-	UptoTime gregor1.Time `codec:"uptoTime" json:"uptoTime"`
-	Upto     MessageID    `codec:"upto" json:"upto"`
+	Upto MessageID `codec:"upto" json:"upto"`
 }
 
 func (o MessageDeleteHistory) DeepCopy() MessageDeleteHistory {
 	return MessageDeleteHistory{
-		UptoTime: o.UptoTime.DeepCopy(),
-		Upto:     o.Upto.DeepCopy(),
+		Upto: o.Upto.DeepCopy(),
 	}
 }
 
@@ -3711,6 +3709,14 @@ type PostMetadataArg struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
+type PostDeleteHistoryArg struct {
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+	Age              gregor1.Seconds              `codec:"age" json:"age"`
+}
+
 type SetConversationStatusLocalArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
 	Status           ConversationStatus           `codec:"status" json:"status"`
@@ -3891,6 +3897,7 @@ type LocalInterface interface {
 	PostHeadline(context.Context, PostHeadlineArg) (PostLocalRes, error)
 	PostMetadataNonblock(context.Context, PostMetadataNonblockArg) (PostLocalNonblockRes, error)
 	PostMetadata(context.Context, PostMetadataArg) (PostLocalRes, error)
+	PostDeleteHistory(context.Context, PostDeleteHistoryArg) (PostLocalRes, error)
 	SetConversationStatusLocal(context.Context, SetConversationStatusLocalArg) (SetConversationStatusLocalRes, error)
 	NewConversationLocal(context.Context, NewConversationLocalArg) (NewConversationLocalRes, error)
 	GetInboxSummaryForCLILocal(context.Context, GetInboxSummaryForCLILocalQuery) (GetInboxSummaryForCLILocalRes, error)
@@ -4154,6 +4161,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.PostMetadata(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"postDeleteHistory": {
+				MakeArg: func() interface{} {
+					ret := make([]PostDeleteHistoryArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]PostDeleteHistoryArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]PostDeleteHistoryArg)(nil), args)
+						return
+					}
+					ret, err = i.PostDeleteHistory(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -4649,6 +4672,11 @@ func (c LocalClient) PostMetadataNonblock(ctx context.Context, __arg PostMetadat
 
 func (c LocalClient) PostMetadata(ctx context.Context, __arg PostMetadataArg) (res PostLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.postMetadata", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) PostDeleteHistory(ctx context.Context, __arg PostDeleteHistoryArg) (res PostLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistory", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3709,7 +3709,7 @@ type PostMetadataArg struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
-type PostDeleteHistoryByIDArg struct {
+type PostDeleteHistoryUptoArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
 	TlfName          string                       `codec:"tlfName" json:"tlfName"`
 	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
@@ -3905,7 +3905,7 @@ type LocalInterface interface {
 	PostHeadline(context.Context, PostHeadlineArg) (PostLocalRes, error)
 	PostMetadataNonblock(context.Context, PostMetadataNonblockArg) (PostLocalNonblockRes, error)
 	PostMetadata(context.Context, PostMetadataArg) (PostLocalRes, error)
-	PostDeleteHistoryByID(context.Context, PostDeleteHistoryByIDArg) (PostLocalRes, error)
+	PostDeleteHistoryUpto(context.Context, PostDeleteHistoryUptoArg) (PostLocalRes, error)
 	PostDeleteHistoryByAge(context.Context, PostDeleteHistoryByAgeArg) (PostLocalRes, error)
 	SetConversationStatusLocal(context.Context, SetConversationStatusLocalArg) (SetConversationStatusLocalRes, error)
 	NewConversationLocal(context.Context, NewConversationLocalArg) (NewConversationLocalRes, error)
@@ -4174,18 +4174,18 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"postDeleteHistoryByID": {
+			"postDeleteHistoryUpto": {
 				MakeArg: func() interface{} {
-					ret := make([]PostDeleteHistoryByIDArg, 1)
+					ret := make([]PostDeleteHistoryUptoArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]PostDeleteHistoryByIDArg)
+					typedArgs, ok := args.(*[]PostDeleteHistoryUptoArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]PostDeleteHistoryByIDArg)(nil), args)
+						err = rpc.NewTypeError((*[]PostDeleteHistoryUptoArg)(nil), args)
 						return
 					}
-					ret, err = i.PostDeleteHistoryByID(ctx, (*typedArgs)[0])
+					ret, err = i.PostDeleteHistoryUpto(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -4700,8 +4700,8 @@ func (c LocalClient) PostMetadata(ctx context.Context, __arg PostMetadataArg) (r
 	return
 }
 
-func (c LocalClient) PostDeleteHistoryByID(ctx context.Context, __arg PostDeleteHistoryByIDArg) (res PostLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistoryByID", []interface{}{__arg}, &res)
+func (c LocalClient) PostDeleteHistoryUpto(ctx context.Context, __arg PostDeleteHistoryUptoArg) (res PostLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.postDeleteHistoryUpto", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -867,8 +867,8 @@ type DeleteConversationArg struct {
 }
 
 type GetMessageBeforeArg struct {
-	ConvID ConversationID  `codec:"convID" json:"convID"`
-	Age    gregor1.Seconds `codec:"age" json:"age"`
+	ConvID ConversationID      `codec:"convID" json:"convID"`
+	Age    gregor1.DurationSec `codec:"age" json:"age"`
 }
 
 type GetTLFConversationsArg struct {

--- a/go/protocol/gregor1/common.go
+++ b/go/protocol/gregor1/common.go
@@ -305,6 +305,12 @@ func (o DurationMsec) DeepCopy() DurationMsec {
 	return o
 }
 
+type DurationSec int64
+
+func (o DurationSec) DeepCopy() DurationSec {
+	return o
+}
+
 type Category string
 
 func (o Category) DeepCopy() Category {
@@ -364,12 +370,6 @@ func (o Body) DeepCopy() Body {
 type Time int64
 
 func (o Time) DeepCopy() Time {
-	return o
-}
-
-type Seconds int64
-
-func (o Seconds) DeepCopy() Seconds {
 	return o
 }
 

--- a/go/protocol/gregor1/common.go
+++ b/go/protocol/gregor1/common.go
@@ -367,6 +367,12 @@ func (o Time) DeepCopy() Time {
 	return o
 }
 
+type Seconds int64
+
+func (o Seconds) DeepCopy() Seconds {
+	return o
+}
+
 type SessionID string
 
 func (o SessionID) DeepCopy() SessionID {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -68,8 +68,6 @@ protocol local {
   }
 
   record MessageDeleteHistory {
-    // Delete message before this time.
-    gregor1.Time uptoTime;
     // Delete messages up to this ID (exclusive).
     MessageID upto;
   }
@@ -581,7 +579,7 @@ protocol local {
   PostLocalRes postHeadline(ConversationID conversationID, string tlfName, boolean tlfPublic, string headline, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalNonblockRes postMetadataNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic,  string channelName, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalRes postMetadata(ConversationID conversationID, string tlfName, boolean tlfPublic, string channelName, keybase1.TLFIdentifyBehavior identifyBehavior);
-
+  PostLocalRes postDeleteHistory(ConversationID conversationID, string tlfName, boolean tlfPublic, keybase1.TLFIdentifyBehavior identifyBehavior, gregor1.Seconds age);
 
   @lint("ignore")
   SetConversationStatusLocalRes SetConversationStatusLocal(ConversationID conversationID, ConversationStatus status, keybase1.TLFIdentifyBehavior identifyBehavior);

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -579,7 +579,7 @@ protocol local {
   PostLocalRes postHeadline(ConversationID conversationID, string tlfName, boolean tlfPublic, string headline, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalNonblockRes postMetadataNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic,  string channelName, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalRes postMetadata(ConversationID conversationID, string tlfName, boolean tlfPublic, string channelName, keybase1.TLFIdentifyBehavior identifyBehavior);
-  PostLocalRes postDeleteHistoryByID(ConversationID conversationID, string tlfName, boolean tlfPublic, keybase1.TLFIdentifyBehavior identifyBehavior, MessageID upto);
+  PostLocalRes postDeleteHistoryUpto(ConversationID conversationID, string tlfName, boolean tlfPublic, keybase1.TLFIdentifyBehavior identifyBehavior, MessageID upto);
   PostLocalRes postDeleteHistoryByAge(ConversationID conversationID, string tlfName, boolean tlfPublic, keybase1.TLFIdentifyBehavior identifyBehavior, gregor1.DurationSec age);
 
   @lint("ignore")

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -579,7 +579,7 @@ protocol local {
   PostLocalRes postHeadline(ConversationID conversationID, string tlfName, boolean tlfPublic, string headline, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalNonblockRes postMetadataNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic,  string channelName, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalRes postMetadata(ConversationID conversationID, string tlfName, boolean tlfPublic, string channelName, keybase1.TLFIdentifyBehavior identifyBehavior);
-  PostLocalRes postDeleteHistory(ConversationID conversationID, string tlfName, boolean tlfPublic, keybase1.TLFIdentifyBehavior identifyBehavior, gregor1.Seconds age);
+  PostLocalRes postDeleteHistory(ConversationID conversationID, string tlfName, boolean tlfPublic, keybase1.TLFIdentifyBehavior identifyBehavior, gregor1.DurationSec age);
 
   @lint("ignore")
   SetConversationStatusLocalRes SetConversationStatusLocal(ConversationID conversationID, ConversationStatus status, keybase1.TLFIdentifyBehavior identifyBehavior);

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -579,7 +579,8 @@ protocol local {
   PostLocalRes postHeadline(ConversationID conversationID, string tlfName, boolean tlfPublic, string headline, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalNonblockRes postMetadataNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic,  string channelName, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalRes postMetadata(ConversationID conversationID, string tlfName, boolean tlfPublic, string channelName, keybase1.TLFIdentifyBehavior identifyBehavior);
-  PostLocalRes postDeleteHistory(ConversationID conversationID, string tlfName, boolean tlfPublic, keybase1.TLFIdentifyBehavior identifyBehavior, gregor1.DurationSec age);
+  PostLocalRes postDeleteHistoryByID(ConversationID conversationID, string tlfName, boolean tlfPublic, keybase1.TLFIdentifyBehavior identifyBehavior, MessageID upto);
+  PostLocalRes postDeleteHistoryByAge(ConversationID conversationID, string tlfName, boolean tlfPublic, keybase1.TLFIdentifyBehavior identifyBehavior, gregor1.DurationSec age);
 
   @lint("ignore")
   SetConversationStatusLocalRes SetConversationStatusLocal(ConversationID conversationID, ConversationStatus status, keybase1.TLFIdentifyBehavior identifyBehavior);

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -245,7 +245,7 @@ protocol remote {
     MessageID msgID;
     union { null, RateLimit } rateLimit;
   }
-  GetMessageBeforeRes getMessageBefore(ConversationID convID, gregor1.Seconds age);
+  GetMessageBeforeRes getMessageBefore(ConversationID convID, gregor1.DurationSec age);
 
   record GetTLFConversationsRes {
     array<Conversation> conversations;

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -241,6 +241,12 @@ protocol remote {
   }
   DeleteConversationRemoteRes deleteConversation(ConversationID convID);
 
+  record GetMessageBeforeRes {
+    MessageID msgID;
+    union { null, RateLimit } rateLimit;
+  }
+  GetMessageBeforeRes getMessageBefore(ConversationID convID, gregor1.Seconds age);
+
   record GetTLFConversationsRes {
     array<Conversation> conversations;
     union { null, RateLimit } rateLimit;

--- a/protocol/avdl/gregor1/common.avdl
+++ b/protocol/avdl/gregor1/common.avdl
@@ -92,6 +92,7 @@ protocol common {
   @typedef("bytes") record DeviceID {}
   @typedef("bytes") record Body {}
   @typedef("long") record Time {}
+  @typedef("long") record Seconds {}
   @typedef("string") record SessionID {}
   @typedef("string") record SessionToken {}
 }

--- a/protocol/avdl/gregor1/common.avdl
+++ b/protocol/avdl/gregor1/common.avdl
@@ -85,6 +85,7 @@ protocol common {
   }
 
   @typedef("int64") @lint("ignore") record DurationMsec {}
+  @typedef("int64") @lint("ignore") record DurationSec {}
   @typedef("string") record Category {}
   @typedef("string") record System {}
   @typedef("bytes") record UID {}
@@ -92,7 +93,6 @@ protocol common {
   @typedef("bytes") record DeviceID {}
   @typedef("bytes") record Body {}
   @typedef("long") record Time {}
-  @typedef("long") record Seconds {}
   @typedef("string") record SessionID {}
   @typedef("string") record SessionToken {}
 }

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -263,6 +263,10 @@ export const localPostAttachmentLocalRpcChannelMap = (configKeys: Array<string>,
 
 export const localPostAttachmentLocalRpcPromise = (request: LocalPostAttachmentLocalRpcParam): Promise<LocalPostAttachmentLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postAttachmentLocal', request, (error: RPCError, result: LocalPostAttachmentLocalResult) => (error ? reject(error) : resolve(result))))
 
+export const localPostDeleteHistoryRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistory', request)
+
+export const localPostDeleteHistoryRpcPromise = (request: LocalPostDeleteHistoryRpcParam): Promise<LocalPostDeleteHistoryResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistory', request, (error: RPCError, result: LocalPostDeleteHistoryResult) => (error ? reject(error) : resolve(result))))
+
 export const localPostDeleteNonblockRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteNonblockRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteNonblock', request)
 
 export const localPostDeleteNonblockRpcPromise = (request: LocalPostDeleteNonblockRpcParam): Promise<LocalPostDeleteNonblockResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteNonblock', request, (error: RPCError, result: LocalPostDeleteNonblockResult) => (error ? reject(error) : resolve(result))))
@@ -369,6 +373,10 @@ export const remoteGetInboxRemoteRpcPromise = (request: RemoteGetInboxRemoteRpcP
 export const remoteGetInboxVersionRpcChannelMap = (configKeys: Array<string>, request: RemoteGetInboxVersionRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getInboxVersion', request)
 
 export const remoteGetInboxVersionRpcPromise = (request: RemoteGetInboxVersionRpcParam): Promise<RemoteGetInboxVersionResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.getInboxVersion', request, (error: RPCError, result: RemoteGetInboxVersionResult) => (error ? reject(error) : resolve(result))))
+
+export const remoteGetMessageBeforeRpcChannelMap = (configKeys: Array<string>, request: RemoteGetMessageBeforeRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getMessageBefore', request)
+
+export const remoteGetMessageBeforeRpcPromise = (request: RemoteGetMessageBeforeRpcParam): Promise<RemoteGetMessageBeforeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.getMessageBefore', request, (error: RPCError, result: RemoteGetMessageBeforeResult) => (error ? reject(error) : resolve(result))))
 
 export const remoteGetMessagesRemoteRpcChannelMap = (configKeys: Array<string>, request: RemoteGetMessagesRemoteRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getMessagesRemote', request)
 
@@ -694,6 +702,8 @@ export type GetInboxSummaryForCLILocalQuery = {|topicType: TopicType, after: Str
 
 export type GetInboxSummaryForCLILocalRes = {|conversations?: ?Array<ConversationLocal>, offline: Boolean, rateLimits?: ?Array<RateLimit>|}
 
+export type GetMessageBeforeRes = {|msgID: MessageID, rateLimit?: ?RateLimit|}
+
 export type GetMessagesLocalRes = {|messages?: ?Array<MessageUnboxed>, offline: Boolean, rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>|}
 
 export type GetMessagesRemoteRes = {|msgs?: ?Array<MessageBoxed>, rateLimit?: ?RateLimit|}
@@ -809,6 +819,8 @@ export type LocalNewConversationLocalRpcParam = {|tlfName: String, topicType: To
 
 export type LocalPostAttachmentLocalRpcParam = {|conversationID: ConversationID, tlfName: String, visibility: Keybase1.TLFVisibility, attachment: LocalSource, preview?: ?MakePreviewRes, title: String, metadata: Bytes, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
+export type LocalPostDeleteHistoryRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.Seconds, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
 export type LocalPostDeleteNonblockRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, clientPrev: MessageID, outboxID?: ?OutboxID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type LocalPostEditNonblockRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, body: String, outboxID?: ?OutboxID, clientPrev: MessageID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
@@ -876,7 +888,7 @@ export type MessageConversationMetadata = {|conversationTitle: String|}
 
 export type MessageDelete = {|messageIDs?: ?Array<MessageID>|}
 
-export type MessageDeleteHistory = {|uptoTime: Gregor1.Time, upto: MessageID|}
+export type MessageDeleteHistory = {|upto: MessageID|}
 
 export type MessageEdit = {|messageID: MessageID, body: String|}
 
@@ -1035,6 +1047,8 @@ export type RemoteGetGlobalAppNotificationSettingsRpcParam = ?{|incomingCallMap?
 export type RemoteGetInboxRemoteRpcParam = {|vers: InboxVers, query?: ?GetInboxQuery, pagination?: ?Pagination, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type RemoteGetInboxVersionRpcParam = {|uid: Gregor1.UID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
+export type RemoteGetMessageBeforeRpcParam = {|convID: ConversationID, age: Gregor1.Seconds, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type RemoteGetMessagesRemoteRpcParam = {|conversationID: ConversationID, messageIDs?: ?Array<MessageID>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -1225,6 +1239,7 @@ type LocalMakePreviewResult = MakePreviewRes
 type LocalMarkAsReadLocalResult = MarkAsReadLocalRes
 type LocalNewConversationLocalResult = NewConversationLocalRes
 type LocalPostAttachmentLocalResult = PostLocalRes
+type LocalPostDeleteHistoryResult = PostLocalRes
 type LocalPostDeleteNonblockResult = PostLocalNonblockRes
 type LocalPostEditNonblockResult = PostLocalNonblockRes
 type LocalPostFileAttachmentLocalResult = PostLocalRes
@@ -1243,6 +1258,7 @@ type RemoteDeleteConversationResult = DeleteConversationRemoteRes
 type RemoteGetGlobalAppNotificationSettingsResult = GlobalAppNotificationSettings
 type RemoteGetInboxRemoteResult = GetInboxRemoteRes
 type RemoteGetInboxVersionResult = InboxVers
+type RemoteGetMessageBeforeResult = GetMessageBeforeRes
 type RemoteGetMessagesRemoteResult = GetMessagesRemoteRes
 type RemoteGetPublicConversationsResult = GetPublicConversationsRes
 type RemoteGetS3ParamsResult = S3Params

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -263,9 +263,13 @@ export const localPostAttachmentLocalRpcChannelMap = (configKeys: Array<string>,
 
 export const localPostAttachmentLocalRpcPromise = (request: LocalPostAttachmentLocalRpcParam): Promise<LocalPostAttachmentLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postAttachmentLocal', request, (error: RPCError, result: LocalPostAttachmentLocalResult) => (error ? reject(error) : resolve(result))))
 
-export const localPostDeleteHistoryRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistory', request)
+export const localPostDeleteHistoryByAgeRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryByAgeRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistoryByAge', request)
 
-export const localPostDeleteHistoryRpcPromise = (request: LocalPostDeleteHistoryRpcParam): Promise<LocalPostDeleteHistoryResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistory', request, (error: RPCError, result: LocalPostDeleteHistoryResult) => (error ? reject(error) : resolve(result))))
+export const localPostDeleteHistoryByAgeRpcPromise = (request: LocalPostDeleteHistoryByAgeRpcParam): Promise<LocalPostDeleteHistoryByAgeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistoryByAge', request, (error: RPCError, result: LocalPostDeleteHistoryByAgeResult) => (error ? reject(error) : resolve(result))))
+
+export const localPostDeleteHistoryByIDRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryByIDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistoryByID', request)
+
+export const localPostDeleteHistoryByIDRpcPromise = (request: LocalPostDeleteHistoryByIDRpcParam): Promise<LocalPostDeleteHistoryByIDResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistoryByID', request, (error: RPCError, result: LocalPostDeleteHistoryByIDResult) => (error ? reject(error) : resolve(result))))
 
 export const localPostDeleteNonblockRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteNonblockRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteNonblock', request)
 
@@ -819,7 +823,9 @@ export type LocalNewConversationLocalRpcParam = {|tlfName: String, topicType: To
 
 export type LocalPostAttachmentLocalRpcParam = {|conversationID: ConversationID, tlfName: String, visibility: Keybase1.TLFVisibility, attachment: LocalSource, preview?: ?MakePreviewRes, title: String, metadata: Bytes, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type LocalPostDeleteHistoryRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+export type LocalPostDeleteHistoryByAgeRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
+export type LocalPostDeleteHistoryByIDRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, upto: MessageID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type LocalPostDeleteNonblockRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, clientPrev: MessageID, outboxID?: ?OutboxID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -1239,7 +1245,8 @@ type LocalMakePreviewResult = MakePreviewRes
 type LocalMarkAsReadLocalResult = MarkAsReadLocalRes
 type LocalNewConversationLocalResult = NewConversationLocalRes
 type LocalPostAttachmentLocalResult = PostLocalRes
-type LocalPostDeleteHistoryResult = PostLocalRes
+type LocalPostDeleteHistoryByAgeResult = PostLocalRes
+type LocalPostDeleteHistoryByIDResult = PostLocalRes
 type LocalPostDeleteNonblockResult = PostLocalNonblockRes
 type LocalPostEditNonblockResult = PostLocalNonblockRes
 type LocalPostFileAttachmentLocalResult = PostLocalRes

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -819,7 +819,7 @@ export type LocalNewConversationLocalRpcParam = {|tlfName: String, topicType: To
 
 export type LocalPostAttachmentLocalRpcParam = {|conversationID: ConversationID, tlfName: String, visibility: Keybase1.TLFVisibility, attachment: LocalSource, preview?: ?MakePreviewRes, title: String, metadata: Bytes, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type LocalPostDeleteHistoryRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.Seconds, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+export type LocalPostDeleteHistoryRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type LocalPostDeleteNonblockRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, clientPrev: MessageID, outboxID?: ?OutboxID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -1048,7 +1048,7 @@ export type RemoteGetInboxRemoteRpcParam = {|vers: InboxVers, query?: ?GetInboxQ
 
 export type RemoteGetInboxVersionRpcParam = {|uid: Gregor1.UID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type RemoteGetMessageBeforeRpcParam = {|convID: ConversationID, age: Gregor1.Seconds, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+export type RemoteGetMessageBeforeRpcParam = {|convID: ConversationID, age: Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type RemoteGetMessagesRemoteRpcParam = {|conversationID: ConversationID, messageIDs?: ?Array<MessageID>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -267,9 +267,9 @@ export const localPostDeleteHistoryByAgeRpcChannelMap = (configKeys: Array<strin
 
 export const localPostDeleteHistoryByAgeRpcPromise = (request: LocalPostDeleteHistoryByAgeRpcParam): Promise<LocalPostDeleteHistoryByAgeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistoryByAge', request, (error: RPCError, result: LocalPostDeleteHistoryByAgeResult) => (error ? reject(error) : resolve(result))))
 
-export const localPostDeleteHistoryByIDRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryByIDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistoryByID', request)
+export const localPostDeleteHistoryUptoRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryUptoRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistoryUpto', request)
 
-export const localPostDeleteHistoryByIDRpcPromise = (request: LocalPostDeleteHistoryByIDRpcParam): Promise<LocalPostDeleteHistoryByIDResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistoryByID', request, (error: RPCError, result: LocalPostDeleteHistoryByIDResult) => (error ? reject(error) : resolve(result))))
+export const localPostDeleteHistoryUptoRpcPromise = (request: LocalPostDeleteHistoryUptoRpcParam): Promise<LocalPostDeleteHistoryUptoResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistoryUpto', request, (error: RPCError, result: LocalPostDeleteHistoryUptoResult) => (error ? reject(error) : resolve(result))))
 
 export const localPostDeleteNonblockRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteNonblockRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteNonblock', request)
 
@@ -825,7 +825,7 @@ export type LocalPostAttachmentLocalRpcParam = {|conversationID: ConversationID,
 
 export type LocalPostDeleteHistoryByAgeRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type LocalPostDeleteHistoryByIDRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, upto: MessageID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+export type LocalPostDeleteHistoryUptoRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, upto: MessageID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type LocalPostDeleteNonblockRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, clientPrev: MessageID, outboxID?: ?OutboxID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -1246,7 +1246,7 @@ type LocalMarkAsReadLocalResult = MarkAsReadLocalRes
 type LocalNewConversationLocalResult = NewConversationLocalRes
 type LocalPostAttachmentLocalResult = PostLocalRes
 type LocalPostDeleteHistoryByAgeResult = PostLocalRes
-type LocalPostDeleteHistoryByIDResult = PostLocalRes
+type LocalPostDeleteHistoryUptoResult = PostLocalRes
 type LocalPostDeleteNonblockResult = PostLocalNonblockRes
 type LocalPostEditNonblockResult = PostLocalNonblockRes
 type LocalPostFileAttachmentLocalResult = PostLocalRes

--- a/protocol/js/rpc-gregor-gen.js
+++ b/protocol/js/rpc-gregor-gen.js
@@ -140,6 +140,8 @@ export type ReminderID = {|uid: UID, msgID: MsgID, seqno: Int|}
 
 export type ReminderSet = {|reminders?: ?Array<Reminder>, moreRemindersReady: Boolean|}
 
+export type Seconds = Long
+
 export type SessionID = String
 
 export type SessionToken = String

--- a/protocol/js/rpc-gregor-gen.js
+++ b/protocol/js/rpc-gregor-gen.js
@@ -92,6 +92,8 @@ export type Dismissal = {|msgIDs?: ?Array<MsgID>, ranges?: ?Array<MsgRange>|}
 
 export type DurationMsec = Int64
 
+export type DurationSec = Int64
+
 export type InBandMessage = {|stateUpdate?: ?StateUpdateMessage, stateSync?: ?StateSyncMessage|}
 
 export type IncomingConsumeMessageMultiRpcParam = {|msg: Message, uids?: ?Array<UID>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
@@ -139,8 +141,6 @@ export type Reminder = {|item: ItemAndMetadata, seqno: Int, remindTime: Time|}
 export type ReminderID = {|uid: UID, msgID: MsgID, seqno: Int|}
 
 export type ReminderSet = {|reminders?: ?Array<Reminder>, moreRemindersReady: Boolean|}
-
-export type Seconds = Long
 
 export type SessionID = String
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2579,7 +2579,32 @@
       ],
       "response": "PostLocalRes"
     },
-    "postDeleteHistory": {
+    "postDeleteHistoryByID": {
+      "request": [
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        },
+        {
+          "name": "upto",
+          "type": "MessageID"
+        }
+      ],
+      "response": "PostLocalRes"
+    },
+    "postDeleteHistoryByAge": {
       "request": [
         {
           "name": "conversationID",

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2579,7 +2579,7 @@
       ],
       "response": "PostLocalRes"
     },
-    "postDeleteHistoryByID": {
+    "postDeleteHistoryUpto": {
       "request": [
         {
           "name": "conversationID",

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -223,10 +223,6 @@
       "name": "MessageDeleteHistory",
       "fields": [
         {
-          "type": "gregor1.Time",
-          "name": "uptoTime"
-        },
-        {
           "type": "MessageID",
           "name": "upto"
         }
@@ -2579,6 +2575,31 @@
         {
           "name": "identifyBehavior",
           "type": "keybase1.TLFIdentifyBehavior"
+        }
+      ],
+      "response": "PostLocalRes"
+    },
+    "postDeleteHistory": {
+      "request": [
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        },
+        {
+          "name": "age",
+          "type": "gregor1.Seconds"
         }
       ],
       "response": "PostLocalRes"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2599,7 +2599,7 @@
         },
         {
           "name": "age",
-          "type": "gregor1.Seconds"
+          "type": "gregor1.DurationSec"
         }
       ],
       "response": "PostLocalRes"

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -951,7 +951,7 @@
         },
         {
           "name": "age",
-          "type": "gregor1.Seconds"
+          "type": "gregor1.DurationSec"
         }
       ],
       "response": "GetMessageBeforeRes"

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -487,6 +487,23 @@
     },
     {
       "type": "record",
+      "name": "GetMessageBeforeRes",
+      "fields": [
+        {
+          "type": "MessageID",
+          "name": "msgID"
+        },
+        {
+          "type": [
+            null,
+            "RateLimit"
+          ],
+          "name": "rateLimit"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "GetTLFConversationsRes",
       "fields": [
         {
@@ -925,6 +942,19 @@
         }
       ],
       "response": "DeleteConversationRemoteRes"
+    },
+    "getMessageBefore": {
+      "request": [
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "age",
+          "type": "gregor1.Seconds"
+        }
+      ],
+      "response": "GetMessageBeforeRes"
     },
     "getTLFConversations": {
       "request": [

--- a/protocol/json/gregor1/common.json
+++ b/protocol/json/gregor1/common.json
@@ -330,6 +330,12 @@
     },
     {
       "type": "record",
+      "name": "Seconds",
+      "fields": [],
+      "typedef": "long"
+    },
+    {
+      "type": "record",
       "name": "SessionID",
       "fields": [],
       "typedef": "string"

--- a/protocol/json/gregor1/common.json
+++ b/protocol/json/gregor1/common.json
@@ -288,6 +288,13 @@
     },
     {
       "type": "record",
+      "name": "DurationSec",
+      "fields": [],
+      "typedef": "int64",
+      "lint": "ignore"
+    },
+    {
+      "type": "record",
       "name": "Category",
       "fields": [],
       "typedef": "string"
@@ -325,12 +332,6 @@
     {
       "type": "record",
       "name": "Time",
-      "fields": [],
-      "typedef": "long"
-    },
-    {
-      "type": "record",
-      "name": "Seconds",
       "fields": [],
       "typedef": "long"
     },

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -263,6 +263,10 @@ export const localPostAttachmentLocalRpcChannelMap = (configKeys: Array<string>,
 
 export const localPostAttachmentLocalRpcPromise = (request: LocalPostAttachmentLocalRpcParam): Promise<LocalPostAttachmentLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postAttachmentLocal', request, (error: RPCError, result: LocalPostAttachmentLocalResult) => (error ? reject(error) : resolve(result))))
 
+export const localPostDeleteHistoryRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistory', request)
+
+export const localPostDeleteHistoryRpcPromise = (request: LocalPostDeleteHistoryRpcParam): Promise<LocalPostDeleteHistoryResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistory', request, (error: RPCError, result: LocalPostDeleteHistoryResult) => (error ? reject(error) : resolve(result))))
+
 export const localPostDeleteNonblockRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteNonblockRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteNonblock', request)
 
 export const localPostDeleteNonblockRpcPromise = (request: LocalPostDeleteNonblockRpcParam): Promise<LocalPostDeleteNonblockResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteNonblock', request, (error: RPCError, result: LocalPostDeleteNonblockResult) => (error ? reject(error) : resolve(result))))
@@ -369,6 +373,10 @@ export const remoteGetInboxRemoteRpcPromise = (request: RemoteGetInboxRemoteRpcP
 export const remoteGetInboxVersionRpcChannelMap = (configKeys: Array<string>, request: RemoteGetInboxVersionRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getInboxVersion', request)
 
 export const remoteGetInboxVersionRpcPromise = (request: RemoteGetInboxVersionRpcParam): Promise<RemoteGetInboxVersionResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.getInboxVersion', request, (error: RPCError, result: RemoteGetInboxVersionResult) => (error ? reject(error) : resolve(result))))
+
+export const remoteGetMessageBeforeRpcChannelMap = (configKeys: Array<string>, request: RemoteGetMessageBeforeRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getMessageBefore', request)
+
+export const remoteGetMessageBeforeRpcPromise = (request: RemoteGetMessageBeforeRpcParam): Promise<RemoteGetMessageBeforeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.getMessageBefore', request, (error: RPCError, result: RemoteGetMessageBeforeResult) => (error ? reject(error) : resolve(result))))
 
 export const remoteGetMessagesRemoteRpcChannelMap = (configKeys: Array<string>, request: RemoteGetMessagesRemoteRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getMessagesRemote', request)
 
@@ -694,6 +702,8 @@ export type GetInboxSummaryForCLILocalQuery = {|topicType: TopicType, after: Str
 
 export type GetInboxSummaryForCLILocalRes = {|conversations?: ?Array<ConversationLocal>, offline: Boolean, rateLimits?: ?Array<RateLimit>|}
 
+export type GetMessageBeforeRes = {|msgID: MessageID, rateLimit?: ?RateLimit|}
+
 export type GetMessagesLocalRes = {|messages?: ?Array<MessageUnboxed>, offline: Boolean, rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>|}
 
 export type GetMessagesRemoteRes = {|msgs?: ?Array<MessageBoxed>, rateLimit?: ?RateLimit|}
@@ -809,6 +819,8 @@ export type LocalNewConversationLocalRpcParam = {|tlfName: String, topicType: To
 
 export type LocalPostAttachmentLocalRpcParam = {|conversationID: ConversationID, tlfName: String, visibility: Keybase1.TLFVisibility, attachment: LocalSource, preview?: ?MakePreviewRes, title: String, metadata: Bytes, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
+export type LocalPostDeleteHistoryRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.Seconds, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
 export type LocalPostDeleteNonblockRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, clientPrev: MessageID, outboxID?: ?OutboxID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type LocalPostEditNonblockRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, body: String, outboxID?: ?OutboxID, clientPrev: MessageID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
@@ -876,7 +888,7 @@ export type MessageConversationMetadata = {|conversationTitle: String|}
 
 export type MessageDelete = {|messageIDs?: ?Array<MessageID>|}
 
-export type MessageDeleteHistory = {|uptoTime: Gregor1.Time, upto: MessageID|}
+export type MessageDeleteHistory = {|upto: MessageID|}
 
 export type MessageEdit = {|messageID: MessageID, body: String|}
 
@@ -1035,6 +1047,8 @@ export type RemoteGetGlobalAppNotificationSettingsRpcParam = ?{|incomingCallMap?
 export type RemoteGetInboxRemoteRpcParam = {|vers: InboxVers, query?: ?GetInboxQuery, pagination?: ?Pagination, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type RemoteGetInboxVersionRpcParam = {|uid: Gregor1.UID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
+export type RemoteGetMessageBeforeRpcParam = {|convID: ConversationID, age: Gregor1.Seconds, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type RemoteGetMessagesRemoteRpcParam = {|conversationID: ConversationID, messageIDs?: ?Array<MessageID>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -1225,6 +1239,7 @@ type LocalMakePreviewResult = MakePreviewRes
 type LocalMarkAsReadLocalResult = MarkAsReadLocalRes
 type LocalNewConversationLocalResult = NewConversationLocalRes
 type LocalPostAttachmentLocalResult = PostLocalRes
+type LocalPostDeleteHistoryResult = PostLocalRes
 type LocalPostDeleteNonblockResult = PostLocalNonblockRes
 type LocalPostEditNonblockResult = PostLocalNonblockRes
 type LocalPostFileAttachmentLocalResult = PostLocalRes
@@ -1243,6 +1258,7 @@ type RemoteDeleteConversationResult = DeleteConversationRemoteRes
 type RemoteGetGlobalAppNotificationSettingsResult = GlobalAppNotificationSettings
 type RemoteGetInboxRemoteResult = GetInboxRemoteRes
 type RemoteGetInboxVersionResult = InboxVers
+type RemoteGetMessageBeforeResult = GetMessageBeforeRes
 type RemoteGetMessagesRemoteResult = GetMessagesRemoteRes
 type RemoteGetPublicConversationsResult = GetPublicConversationsRes
 type RemoteGetS3ParamsResult = S3Params

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -263,9 +263,13 @@ export const localPostAttachmentLocalRpcChannelMap = (configKeys: Array<string>,
 
 export const localPostAttachmentLocalRpcPromise = (request: LocalPostAttachmentLocalRpcParam): Promise<LocalPostAttachmentLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postAttachmentLocal', request, (error: RPCError, result: LocalPostAttachmentLocalResult) => (error ? reject(error) : resolve(result))))
 
-export const localPostDeleteHistoryRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistory', request)
+export const localPostDeleteHistoryByAgeRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryByAgeRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistoryByAge', request)
 
-export const localPostDeleteHistoryRpcPromise = (request: LocalPostDeleteHistoryRpcParam): Promise<LocalPostDeleteHistoryResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistory', request, (error: RPCError, result: LocalPostDeleteHistoryResult) => (error ? reject(error) : resolve(result))))
+export const localPostDeleteHistoryByAgeRpcPromise = (request: LocalPostDeleteHistoryByAgeRpcParam): Promise<LocalPostDeleteHistoryByAgeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistoryByAge', request, (error: RPCError, result: LocalPostDeleteHistoryByAgeResult) => (error ? reject(error) : resolve(result))))
+
+export const localPostDeleteHistoryByIDRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryByIDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistoryByID', request)
+
+export const localPostDeleteHistoryByIDRpcPromise = (request: LocalPostDeleteHistoryByIDRpcParam): Promise<LocalPostDeleteHistoryByIDResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistoryByID', request, (error: RPCError, result: LocalPostDeleteHistoryByIDResult) => (error ? reject(error) : resolve(result))))
 
 export const localPostDeleteNonblockRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteNonblockRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteNonblock', request)
 
@@ -819,7 +823,9 @@ export type LocalNewConversationLocalRpcParam = {|tlfName: String, topicType: To
 
 export type LocalPostAttachmentLocalRpcParam = {|conversationID: ConversationID, tlfName: String, visibility: Keybase1.TLFVisibility, attachment: LocalSource, preview?: ?MakePreviewRes, title: String, metadata: Bytes, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type LocalPostDeleteHistoryRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+export type LocalPostDeleteHistoryByAgeRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
+export type LocalPostDeleteHistoryByIDRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, upto: MessageID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type LocalPostDeleteNonblockRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, clientPrev: MessageID, outboxID?: ?OutboxID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -1239,7 +1245,8 @@ type LocalMakePreviewResult = MakePreviewRes
 type LocalMarkAsReadLocalResult = MarkAsReadLocalRes
 type LocalNewConversationLocalResult = NewConversationLocalRes
 type LocalPostAttachmentLocalResult = PostLocalRes
-type LocalPostDeleteHistoryResult = PostLocalRes
+type LocalPostDeleteHistoryByAgeResult = PostLocalRes
+type LocalPostDeleteHistoryByIDResult = PostLocalRes
 type LocalPostDeleteNonblockResult = PostLocalNonblockRes
 type LocalPostEditNonblockResult = PostLocalNonblockRes
 type LocalPostFileAttachmentLocalResult = PostLocalRes

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -819,7 +819,7 @@ export type LocalNewConversationLocalRpcParam = {|tlfName: String, topicType: To
 
 export type LocalPostAttachmentLocalRpcParam = {|conversationID: ConversationID, tlfName: String, visibility: Keybase1.TLFVisibility, attachment: LocalSource, preview?: ?MakePreviewRes, title: String, metadata: Bytes, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type LocalPostDeleteHistoryRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.Seconds, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+export type LocalPostDeleteHistoryRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type LocalPostDeleteNonblockRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, clientPrev: MessageID, outboxID?: ?OutboxID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -1048,7 +1048,7 @@ export type RemoteGetInboxRemoteRpcParam = {|vers: InboxVers, query?: ?GetInboxQ
 
 export type RemoteGetInboxVersionRpcParam = {|uid: Gregor1.UID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type RemoteGetMessageBeforeRpcParam = {|convID: ConversationID, age: Gregor1.Seconds, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+export type RemoteGetMessageBeforeRpcParam = {|convID: ConversationID, age: Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type RemoteGetMessagesRemoteRpcParam = {|conversationID: ConversationID, messageIDs?: ?Array<MessageID>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -267,9 +267,9 @@ export const localPostDeleteHistoryByAgeRpcChannelMap = (configKeys: Array<strin
 
 export const localPostDeleteHistoryByAgeRpcPromise = (request: LocalPostDeleteHistoryByAgeRpcParam): Promise<LocalPostDeleteHistoryByAgeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistoryByAge', request, (error: RPCError, result: LocalPostDeleteHistoryByAgeResult) => (error ? reject(error) : resolve(result))))
 
-export const localPostDeleteHistoryByIDRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryByIDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistoryByID', request)
+export const localPostDeleteHistoryUptoRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteHistoryUptoRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteHistoryUpto', request)
 
-export const localPostDeleteHistoryByIDRpcPromise = (request: LocalPostDeleteHistoryByIDRpcParam): Promise<LocalPostDeleteHistoryByIDResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistoryByID', request, (error: RPCError, result: LocalPostDeleteHistoryByIDResult) => (error ? reject(error) : resolve(result))))
+export const localPostDeleteHistoryUptoRpcPromise = (request: LocalPostDeleteHistoryUptoRpcParam): Promise<LocalPostDeleteHistoryUptoResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.postDeleteHistoryUpto', request, (error: RPCError, result: LocalPostDeleteHistoryUptoResult) => (error ? reject(error) : resolve(result))))
 
 export const localPostDeleteNonblockRpcChannelMap = (configKeys: Array<string>, request: LocalPostDeleteNonblockRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteNonblock', request)
 
@@ -825,7 +825,7 @@ export type LocalPostAttachmentLocalRpcParam = {|conversationID: ConversationID,
 
 export type LocalPostDeleteHistoryByAgeRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, age: Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type LocalPostDeleteHistoryByIDRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, upto: MessageID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+export type LocalPostDeleteHistoryUptoRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, upto: MessageID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type LocalPostDeleteNonblockRpcParam = {|conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, clientPrev: MessageID, outboxID?: ?OutboxID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -1246,7 +1246,7 @@ type LocalMarkAsReadLocalResult = MarkAsReadLocalRes
 type LocalNewConversationLocalResult = NewConversationLocalRes
 type LocalPostAttachmentLocalResult = PostLocalRes
 type LocalPostDeleteHistoryByAgeResult = PostLocalRes
-type LocalPostDeleteHistoryByIDResult = PostLocalRes
+type LocalPostDeleteHistoryUptoResult = PostLocalRes
 type LocalPostDeleteNonblockResult = PostLocalNonblockRes
 type LocalPostEditNonblockResult = PostLocalNonblockRes
 type LocalPostFileAttachmentLocalResult = PostLocalRes

--- a/shared/constants/types/rpc-gregor-gen.js
+++ b/shared/constants/types/rpc-gregor-gen.js
@@ -140,6 +140,8 @@ export type ReminderID = {|uid: UID, msgID: MsgID, seqno: Int|}
 
 export type ReminderSet = {|reminders?: ?Array<Reminder>, moreRemindersReady: Boolean|}
 
+export type Seconds = Long
+
 export type SessionID = String
 
 export type SessionToken = String

--- a/shared/constants/types/rpc-gregor-gen.js
+++ b/shared/constants/types/rpc-gregor-gen.js
@@ -92,6 +92,8 @@ export type Dismissal = {|msgIDs?: ?Array<MsgID>, ranges?: ?Array<MsgRange>|}
 
 export type DurationMsec = Int64
 
+export type DurationSec = Int64
+
 export type InBandMessage = {|stateUpdate?: ?StateUpdateMessage, stateSync?: ?StateSyncMessage|}
 
 export type IncomingConsumeMessageMultiRpcParam = {|msg: Message, uids?: ?Array<UID>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
@@ -139,8 +141,6 @@ export type Reminder = {|item: ItemAndMetadata, seqno: Int, remindTime: Time|}
 export type ReminderID = {|uid: UID, msgID: MsgID, seqno: Int|}
 
 export type ReminderSet = {|reminders?: ?Array<Reminder>, moreRemindersReady: Boolean|}
-
-export type Seconds = Long
 
 export type SessionID = String
 


### PR DESCRIPTION
Added an RPC the gui can use to delete history.
```
PostLocalRes postDeleteHistory(
  ConversationID conversationID,
  string tlfName,
  boolean tlfPublic,
  keybase1.TLFIdentifyBehavior identifyBehavior,
  gregor1.Seconds age);
```

Added a CLI command to delete history. Optionally beyond a certain `--age`.
```
keybase chat delete-history alice,bob --age 5d
```

Added a dev-only command to delete history upto the specified message ID.
```
keybase chat delete-history-dev alice,bob --upto 12
```

Added support to Storage for processing DeleteHistory messages. Which basically runs through all messages and deletes the ones that are older than the cutoff. But there are stored trackers (`storage_delh.go`) so that will short-circuit most of the time as an optimization. ConvSource will notify `CLEAR` to the frontend when a new one is received.

Changed `supersedes.go` so that it hides messages before the cutoff.

Checks when boxing a DeleteHistory message that the unsigned outer part and the the secret messagebody match. This is the only thing that ever checks this invariant.

- [ ] Requires https://github.com/keybase/keybase/pull/2008

- [ ] Bug: When deleting all history, snippets don't get removed from the gui

Also when you delete history the conv jumps down in the inbox to where it would be if no messages had been sent since the cutoff. This makes some sense but is not great ui. If you delete all history the conversation will actually disappear, but can be 're-created'.