### PR TITLE
fix for redhat issues with systemd and DBUS

### DIFF
--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -108,8 +108,10 @@ main() {
   #    we tell them to do it after updates.
   kill_all
 
-  if wants_systemd ; then
+  if [ ! -e /etc/redhat-release ] ; then
+    if wants_systemd ; then
       start_systemd
+    fi
   else
       start_background
   fi


### PR DESCRIPTION
RedHat based systems are failing to start keybase as they seem to need DBUS and systemd. Temporary fix for that is to remove dependency from systemd. Not sure if it;s actually needed for RH type of systems. Got an impression it was mostly done for Arch and Ubuntu.