### PR TITLE
Plumb through support for TeamProvisionalError

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -284,6 +284,8 @@ const (
 	SCTeamInviteBadToken       = int(keybase1.StatusCode_SCTeamInviteBadToken)
 	SCTeamInviteTokenReused    = int(keybase1.StatusCode_SCTeamInviteTokenReused)
 	SCTeamBadMembership        = int(keybase1.StatusCode_SCTeamBadMembership)
+	SCTeamProvisionalCanKey    = int(keybase1.StatusCode_SCTeamProvisionalCanKey)
+	SCTeamProvisionalCannotKey = int(keybase1.StatusCode_SCTeamProvisionalCannotKey)
 )
 
 const (

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2242,3 +2242,25 @@ func (e TeamBadMembershipError) Error() string {
 }
 
 //=============================================================================
+
+type TeamProvisionalError struct {
+	CanKey                bool
+	IsPublic              bool
+	PreResolveDisplayName string
+}
+
+func (e TeamProvisionalError) Error() string {
+	ret := "team is provisional"
+	if e.CanKey {
+		ret += ", but the user can key"
+	} else {
+		ret += ", and the user cannot key"
+	}
+	return ret
+}
+
+func NewTeamProvisionalError(canKey bool, isPublic bool, dn string) error {
+	return TeamProvisionalError{canKey, isPublic, dn}
+}
+
+//=============================================================================

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -661,6 +661,22 @@ func ImportStatusAsError(g *GlobalContext, s *keybase1.Status) error {
 		return TeamInviteTokenReusedError{}
 	case SCTeamBadMembership:
 		return TeamBadMembershipError{}
+	case SCTeamProvisionalCanKey, SCTeamProvisionalCannotKey:
+		e := TeamProvisionalError{}
+		for _, field := range s.Fields {
+			switch field.Key {
+			case "IsPublic":
+				if field.Value == "1" {
+					e.IsPublic = true
+				}
+			case "PreResolveDisplayName":
+				e.PreResolveDisplayName = field.Value
+			}
+		}
+		if s.Code == SCTeamProvisionalCanKey {
+			e.CanKey = true
+		}
+		return e
 	default:
 		ase := AppStatusError{
 			Code:   s.Code,
@@ -2199,4 +2215,21 @@ func (e TeamBadMembershipError) ToStatus() (s keybase1.Status) {
 	s.Code = SCTeamBadMembership
 	s.Name = "TEAM_BAD_MEMBERSHIP"
 	return
+}
+
+func (e TeamProvisionalError) ToStatus() keybase1.Status {
+	var ret keybase1.Status
+	if e.CanKey {
+		ret.Code = SCTeamProvisionalCanKey
+		ret.Name = "TEAM_PROVISIONAL_CAN_KEY"
+		ret.Fields = append(ret.Fields, keybase1.StringKVPair{Key: "CanKey", Value: "1"})
+	} else {
+		ret.Code = SCTeamProvisionalCannotKey
+		ret.Name = "TEAM_PROVISIONAL_CANNOT_KEY"
+	}
+	ret.Fields = append(ret.Fields, keybase1.StringKVPair{Key: "PreResolveDisplayName", Value: e.PreResolveDisplayName})
+	if e.IsPublic {
+		ret.Fields = append(ret.Fields, keybase1.StringKVPair{Key: "IsPublic", Value: "1"})
+	}
+	return ret
 }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -154,6 +154,8 @@ const (
 	StatusCode_SCTeamKeyMaskNotFound       StatusCode = 2697
 	StatusCode_SCTeamBanned                StatusCode = 2702
 	StatusCode_SCTeamInvalidBan            StatusCode = 2703
+	StatusCode_SCTeamProvisionalCanKey     StatusCode = 2721
+	StatusCode_SCTeamProvisionalCannotKey  StatusCode = 2722
 )
 
 func (o StatusCode) DeepCopy() StatusCode { return o }
@@ -303,6 +305,8 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamKeyMaskNotFound":       2697,
 	"SCTeamBanned":                2702,
 	"SCTeamInvalidBan":            2703,
+	"SCTeamProvisionalCanKey":     2721,
+	"SCTeamProvisionalCannotKey":  2722,
 }
 
 var StatusCodeRevMap = map[StatusCode]string{
@@ -450,6 +454,8 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2697: "SCTeamKeyMaskNotFound",
 	2702: "SCTeamBanned",
 	2703: "SCTeamInvalidBan",
+	2721: "SCTeamProvisionalCanKey",
+	2722: "SCTeamProvisionalCannotKey",
 }
 
 func (e StatusCode) String() string {

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -81,10 +81,16 @@ func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	}
 	var imp implicitTeam
 	if err = g.API.GetDecode(arg, &imp); err != nil {
-		if aerr, ok := err.(libkb.AppStatusError); ok &&
-			keybase1.StatusCode(aerr.Code) == keybase1.StatusCode_SCTeamReadError {
-			return teamID, teamName, impTeamName, tlfID, conflicts, NewTeamDoesNotExistError(
-				impTeamName.IsPublic, preResolveDisplayName)
+		if aerr, ok := err.(libkb.AppStatusError); ok {
+			code := keybase1.StatusCode(aerr.Code)
+			switch code {
+			case keybase1.StatusCode_SCTeamReadError:
+				return teamID, teamName, impTeamName, tlfID, conflicts, NewTeamDoesNotExistError(
+					impTeamName.IsPublic, preResolveDisplayName)
+			case keybase1.StatusCode_SCTeamProvisionalCanKey, keybase1.StatusCode_SCTeamProvisionalCannotKey:
+				return teamID, teamName, impTeamName, tlfID, conflicts, libkb.NewTeamProvisionalError(
+					(code == keybase1.StatusCode_SCTeamProvisionalCanKey), impTeamName.IsPublic, preResolveDisplayName)
+			}
 		}
 		return teamID, teamName, impTeamName, tlfID, conflicts, err
 	}

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -145,6 +145,8 @@ protocol constants {
     SCTeamInviteTokenReused_2696,
     SCTeamKeyMaskNotFound_2697,
     SCTeamBanned_2702,
-    SCTeamInvalidBan_2703
+    SCTeamInvalidBan_2703,
+    SCTeamProvisionalCanKey_2721,
+    SCTeamProvisionalCannotKey_2722
   }
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -509,6 +509,8 @@ export const constantsStatusCode = {
   scteamkeymasknotfound: 2697,
   scteambanned: 2702,
   scteaminvalidban: 2703,
+  scteamprovisionalcankey: 2721,
+  scteamprovisionalcannotkey: 2722,
 }
 
 export const cryptoSignED25519ForKBFSRpcChannelMap = (configKeys: Array<string>, request: CryptoSignED25519ForKBFSRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.crypto.signED25519ForKBFS', request)
@@ -3397,6 +3399,8 @@ export type StatusCode =0 // SCOk_0
  | 2697 // SCTeamKeyMaskNotFound_2697
  | 2702 // SCTeamBanned_2702
  | 2703 // SCTeamInvalidBan_2703
+ | 2721 // SCTeamProvisionalCanKey_2721
+ | 2722 // SCTeamProvisionalCannotKey_2722
 
 
 export type Stream = {|fd: Int,|}

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -149,7 +149,9 @@
         "SCTeamInviteTokenReused_2696",
         "SCTeamKeyMaskNotFound_2697",
         "SCTeamBanned_2702",
-        "SCTeamInvalidBan_2703"
+        "SCTeamInvalidBan_2703",
+        "SCTeamProvisionalCanKey_2721",
+        "SCTeamProvisionalCannotKey_2722"
       ]
     }
   ],

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -509,6 +509,8 @@ export const constantsStatusCode = {
   scteamkeymasknotfound: 2697,
   scteambanned: 2702,
   scteaminvalidban: 2703,
+  scteamprovisionalcankey: 2721,
+  scteamprovisionalcannotkey: 2722,
 }
 
 export const cryptoSignED25519ForKBFSRpcChannelMap = (configKeys: Array<string>, request: CryptoSignED25519ForKBFSRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.crypto.signED25519ForKBFS', request)
@@ -3397,6 +3399,8 @@ export type StatusCode =0 // SCOk_0
  | 2697 // SCTeamKeyMaskNotFound_2697
  | 2702 // SCTeamBanned_2702
  | 2703 // SCTeamInvalidBan_2703
+ | 2721 // SCTeamProvisionalCanKey_2721
+ | 2722 // SCTeamProvisionalCannotKey_2722
 
 
 export type Stream = {|fd: Int,|}


### PR DESCRIPTION
- Plumb the error code from the API server through to KBFS
- We don't have any tests now that would need this in the client/ repo, but
kbfs should hit this error path.