### PR TITLE
fix remote windows broken after logger changes

### DIFF
--- a/shared/desktop/remote/component-loader.js
+++ b/shared/desktop/remote/component-loader.js
@@ -13,9 +13,7 @@ import {disable as disableDragDrop} from '../../util/drag-drop'
 import {globalColors, globalStyles} from '../../styles'
 import {remote, BrowserWindow} from 'electron'
 import {setupContextMenu} from '../app/menu-helper'
-import {setupSource} from '../../util/forward-logs'
 
-setupSource()
 disableDragDrop()
 
 module.hot && module.hot.accept()

--- a/shared/util/forward-logs.js.flow
+++ b/shared/util/forward-logs.js.flow
@@ -1,7 +1,5 @@
 // @flow
 import type {LogLineWithLevelISOTimestamp} from '../logger/types'
-export const setupSource = () => {}
-export const setupTarget = () => {}
 
 export const localLog = (...args: any) => {}
 export const localWarn = (...args: any) => {}


### PR DESCRIPTION
@keybase/react-hackers cc: @cjb @MarcoPolo 
The forward-logs flow file wasn't correct so flow didn't complain when these functions got killed