### PR TITLE
Remove leave team option if you're not in the team

### DIFF
--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -191,6 +191,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const showAddYourselfBanner = !youAreMember && !youExplicitAdmin && youImplicitAdmin
   const youCanAddPeople = youAdmin
   const youCanCreateSubteam = youAdmin
+  const youCanLeaveTeam = youAreMember
 
   const onAddSelf = () => dispatchProps._onAddSelf(stateProps.name, you)
   const onSetOpenTeamRole = () =>
@@ -239,6 +240,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     youAdmin,
     youCanAddPeople,
     youImplicitAdmin,
+    youCanLeaveTeam,
     youCanCreateSubteam,
     youCanShowcase,
   }

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -65,6 +65,7 @@ export type Props = {
   yourRole: ?Types.TeamRoleType,
   youAdmin: boolean,
   youImplicitAdmin: boolean,
+  youCanLeaveTeam: boolean,
   youCanShowcase: boolean,
   youCanAddPeople: boolean,
   youCanCreateSubteam: boolean,
@@ -263,6 +264,7 @@ class Team extends React.PureComponent<Props> {
       yourRole,
       youAdmin,
       youImplicitAdmin,
+      youCanLeaveTeam,
       youCanAddPeople,
       youCanCreateSubteam,
       youCanShowcase,
@@ -459,10 +461,11 @@ class Team extends React.PureComponent<Props> {
       )
     }
 
-    const popupMenuItems = [
-      {onClick: onManageChat, title: 'Manage chat channels'},
-      {onClick: onLeaveTeam, title: 'Leave team', danger: true},
-    ]
+    const popupMenuItems = [{onClick: onManageChat, title: 'Manage chat channels'}]
+
+    if (youCanLeaveTeam) {
+      popupMenuItems.push({onClick: onLeaveTeam, title: 'Leave team', danger: true})
+    }
 
     if (youCanCreateSubteam) {
       popupMenuItems.push({onClick: onCreateSubteam, title: 'Create subteam'})


### PR DESCRIPTION
Fixes the black bar when an implicit admin tries to leave a team they're not in.

@keybase/react-hackers 