### PR TITLE
Fix searchv3 crash after failed search

### DIFF
--- a/shared/search/user-input/container.js
+++ b/shared/search/user-input/container.js
@@ -122,7 +122,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {searchKey}) => ({
       dispatch(SearchGen.createSearchSuggestions({searchKey}))
     }
   },
-  onAddUser: id => dispatch(SearchGen.createAddResultsToUserInput({searchKey, searchResults: [id]})),
+  onAddUser: id => id && dispatch(SearchGen.createAddResultsToUserInput({searchKey, searchResults: [id]})),
   clearSearchResults: () => dispatch(SearchGen.createClearSearchResults({searchKey})),
   onUpdateSelectedSearchResult: id => {
     dispatch(SearchGen.createUpdateSelectedSearchResult({searchKey, id}))


### PR DESCRIPTION
@keybase/react-hackers 

If you searched for a string with no matches (e.g. `foo@bar.com`) and hit enter, we'd still fire an action that adds `[null]` to the search results in the store, and then later code would barf on that.  So this PR just checks whether we're actually showing a result when you hit enter to add.