### PR TITLE
Don't just close the search box if someone presses enter on a recommendation

### DIFF
--- a/shared/search/helpers.js
+++ b/shared/search/helpers.js
@@ -63,6 +63,7 @@ const onChangeSelectedSearchResultHoc = compose(
       onAddSelectedUser: (props: OwnPropsWithSearchDebounced) => () => {
         props._searchDebounced.flush()
         // See whether the current search result term matches the last one submitted
+        // -- unless we're showing search suggestions, which don't have a term.
         if (lastSearchTerm === props.searchResultTerm || props.showingSearchSuggestions) {
           props.selectedSearchId && props.disableListBuilding
             ? props.onSelectUser(props.selectedSearchId)

--- a/shared/search/helpers.js
+++ b/shared/search/helpers.js
@@ -63,7 +63,7 @@ const onChangeSelectedSearchResultHoc = compose(
       onAddSelectedUser: (props: OwnPropsWithSearchDebounced) => () => {
         props._searchDebounced.flush()
         // See whether the current search result term matches the last one submitted
-        if (lastSearchTerm === props.searchResultTerm) {
+        if (lastSearchTerm === props.searchResultTerm || props.showingSearchSuggestions) {
           props.selectedSearchId && props.disableListBuilding
             ? props.onSelectUser(props.selectedSearchId)
             : props.onAddUser(props.selectedSearchId)

--- a/shared/search/user-input/container.js
+++ b/shared/search/user-input/container.js
@@ -24,46 +24,45 @@ type OwnProps = {|
   disableListBuilding?: boolean,
 |}
 
-const UserInputWithServiceFilter = props => {
-  return (
-    <Box
-      style={{
-        ...globalStyles.flexBoxColumn,
-        paddingLeft: globalMargins.tiny,
-        borderBottomColor: globalColors.black_05,
-        borderBottomWidth: 1,
-        borderBottom: `1px solid ${globalColors.black_05}`,
-      }}
-    >
-      <UserInput
-        ref={props.setInputRef}
-        autoFocus={props.autoFocus}
-        userItems={props.userItems}
-        onRemoveUser={props.onRemoveUser}
-        onClickAddButton={props.onClickAddButton}
-        placeholder={props.placeholder}
-        usernameText={props.searchText}
-        onChangeText={props.onChangeText}
-        onMoveSelectUp={props.onMoveSelectUp}
-        onMoveSelectDown={props.onMoveSelectDown}
-        onClearSearch={props.onClearSearch}
-        onAddSelectedUser={props.onAddSelectedUser}
-        onEnterEmptyText={props.onExitSearch}
-        onCancel={props.onExitSearch}
-      />
-      {props.showServiceFilter &&
-        <Box
-          style={{
-            ...globalStyles.flexBoxRow,
-            alignItems: 'center',
-          }}
-        >
-          <Text type="BodySmallSemibold" style={{marginRight: globalMargins.tiny}}>Filter:</Text>
-          <ServiceFilter selectedService={props.selectedService} onSelectService={props.onSelectService} />
-        </Box>}
-    </Box>
-  )
-}
+const UserInputWithServiceFilter = props => (
+  <Box
+    style={{
+      ...globalStyles.flexBoxColumn,
+      paddingLeft: globalMargins.tiny,
+      borderBottomColor: globalColors.black_05,
+      borderBottomWidth: 1,
+      borderBottom: `1px solid ${globalColors.black_05}`,
+    }}
+  >
+    <UserInput
+      ref={props.setInputRef}
+      autoFocus={props.autoFocus}
+      userItems={props.userItems}
+      onRemoveUser={props.onRemoveUser}
+      onClickAddButton={props.onClickAddButton}
+      placeholder={props.placeholder}
+      usernameText={props.searchText}
+      onChangeText={props.onChangeText}
+      onMoveSelectUp={props.onMoveSelectUp}
+      onMoveSelectDown={props.onMoveSelectDown}
+      onClearSearch={props.onClearSearch}
+      onAddSelectedUser={props.onAddSelectedUser}
+      onEnterEmptyText={props.onExitSearch}
+      onCancel={props.onExitSearch}
+      selectedSearchId={props.selectedSearchId}
+    />
+    {props.showServiceFilter &&
+      <Box
+        style={{
+          ...globalStyles.flexBoxRow,
+          alignItems: 'center',
+        }}
+      >
+        <Text type="BodySmallSemibold" style={{marginRight: globalMargins.tiny}}>Filter:</Text>
+        <ServiceFilter selectedService={props.selectedService} onSelectService={props.onSelectService} />
+      </Box>}
+  </Box>
+)
 
 const getSearchResultTerm = ({entities}: TypedState, {searchKey}: {searchKey: string}) => {
   const searchResultQuery = entities.getIn(['search', 'searchKeyToSearchResultQuery', searchKey], null)
@@ -102,6 +101,10 @@ const mapStateToProps = (state: TypedState, {searchKey}: OwnProps) => {
   const searchResultTerm = getSearchResultTerm(state, {searchKey})
   const searchResultIds = Constants.getSearchResultIdsArray(state, {searchKey})
   const selectedSearchId = entities.getIn(['search', 'searchKeyToSelectedId', searchKey])
+  const showingSearchSuggestions = entities.getIn(
+    ['search', 'searchKeyToShowSearchSuggestion', searchKey],
+    false
+  )
   const userItems = getUserItems(state, {searchKey})
   const clearSearchTextInput = Constants.getClearSearchTextInput(state, {searchKey})
   return {
@@ -110,6 +113,7 @@ const mapStateToProps = (state: TypedState, {searchKey}: OwnProps) => {
     selectedSearchId,
     userItems,
     searchResultTerm,
+    showingSearchSuggestions,
   }
 }
 

--- a/shared/search/user-input/index.desktop.js
+++ b/shared/search/user-input/index.desktop.js
@@ -91,7 +91,11 @@ class UserInput extends Component<Props, State> {
       !trim(this.props.usernameText) &&
       this.props.onEnterEmptyText
     ) {
-      this.props.onEnterEmptyText()
+      if (this.props.selectedSearchId) {
+        this.props.onAddSelectedUser()
+      } else {
+        this.props.onEnterEmptyText()
+      }
     } else if (ev.key === 'Enter' || ev.key === 'Tab' || ev.key === ',') {
       this.props.onAddSelectedUser()
       ev.preventDefault()

--- a/shared/search/user-input/index.desktop.js
+++ b/shared/search/user-input/index.desktop.js
@@ -91,11 +91,7 @@ class UserInput extends Component<Props, State> {
       !trim(this.props.usernameText) &&
       this.props.onEnterEmptyText
     ) {
-      if (this.props.selectedSearchId) {
-        this.props.onAddSelectedUser()
-      } else {
-        this.props.onEnterEmptyText()
-      }
+      this.props.selectedSearchId ? this.props.onAddSelectedUser() : this.props.onEnterEmptyText()
     } else if (ev.key === 'Enter' || ev.key === 'Tab' || ev.key === ',') {
       this.props.onAddSelectedUser()
       ev.preventDefault()

--- a/shared/search/user-input/index.js.flow
+++ b/shared/search/user-input/index.js.flow
@@ -25,6 +25,7 @@ export type Props = {
   onClearSearch?: () => void,
   onAddSelectedUser: () => void,
   onEnterEmptyText?: () => void,
+  selectedSearchId: ?string,
 }
 
 export default class UserInput extends Component<Props> {


### PR DESCRIPTION
@keybase/react-hackers 

It works to type in a search query, use arrow keys to choose a result, and press enter to select it.

But starting a search, seeing a list of recommendations, using arrow keys to choose one and pressing enter to select it *didn't* work -- it wouldn't do anything other than close the search box.

This is because search had an assumption of "if you press enter in the input box with nothing typed, you aren't choosing a search result" baked in in a few ways:

(1) The search debounce code would check that the selected result matched the search term used, and it doesn't in this case: there is no search term at all when you're viewing recommendations.

(2) The code for handling enter key presses would decide between "just close the search widget" and "add this person to the search" based on whether there was text in the input widget.

To fix (1), plumb through whether we're showing search suggestions, and ignore the debounce test if we are.

To fix (2), plumb through whether there is a selected search result, and if there is then add the person rather than close the widget.