### PR TITLE
cleaner fix to the public team load from proof checking

### DIFF
--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -27,7 +27,7 @@ type LoaderContext interface {
 	// Get the current user's per-user-key's derived encryption key (full).
 	perUserEncryptionKey(ctx context.Context, userSeqno keybase1.Seqno) (*libkb.NaclDHKeyPair, error)
 	merkleLookup(ctx context.Context, teamID keybase1.TeamID, public bool) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error)
-	merkleLookupTripleAtHashMeta(ctx context.Context, leafID keybase1.UserOrTeamID, hm keybase1.HashMeta) (triple *libkb.MerkleTriple, err error)
+	merkleLookupTripleAtHashMeta(ctx context.Context, isPublic bool, leafID keybase1.UserOrTeamID, hm keybase1.HashMeta) (triple *libkb.MerkleTriple, err error)
 	forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap linkMapT, err error)
 	loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (keybase1.UserVersion, *keybase1.PublicKeyV2NaCl, linkMapT, error)
 }
@@ -199,12 +199,12 @@ func (l *LoaderContextG) merkleLookup(ctx context.Context, teamID keybase1.TeamI
 	return leaf.Private.Seqno, leaf.Private.LinkID.Export(), nil
 }
 
-func (l *LoaderContextG) merkleLookupTripleAtHashMeta(ctx context.Context, leafID keybase1.UserOrTeamID, hm keybase1.HashMeta) (triple *libkb.MerkleTriple, err error) {
+func (l *LoaderContextG) merkleLookupTripleAtHashMeta(ctx context.Context, isPublic bool, leafID keybase1.UserOrTeamID, hm keybase1.HashMeta) (triple *libkb.MerkleTriple, err error) {
 	leaf, err := l.G().MerkleClient.LookupLeafAtHashMeta(ctx, leafID, hm)
 	if err != nil {
 		return nil, err
 	}
-	if leafID.IsPublic() {
+	if isPublic {
 		triple = leaf.Public
 	} else {
 		triple = leaf.Private

--- a/go/teams/loader_ctx_test.go
+++ b/go/teams/loader_ctx_test.go
@@ -239,7 +239,7 @@ func (l *MockLoaderContext) merkleLookup(ctx context.Context, teamID keybase1.Te
 }
 
 func (l *MockLoaderContext) merkleLookupTripleAtHashMeta(ctx context.Context,
-	leafID keybase1.UserOrTeamID, hm keybase1.HashMeta) (triple *libkb.MerkleTriple, err error) {
+	isPublic bool, leafID keybase1.UserOrTeamID, hm keybase1.HashMeta) (triple *libkb.MerkleTriple, err error) {
 
 	key := fmt.Sprintf("%s-%s", leafID, hm)
 	triple1, ok := l.unit.MerkleTriples[key]

--- a/go/teams/proofs.go
+++ b/go/teams/proofs.go
@@ -49,6 +49,9 @@ type proofIndex struct {
 }
 
 func (t proofTerm) seqno() keybase1.Seqno { return t.sigMeta.SigChainLocation.Seqno }
+func (t proofTerm) isPublic() bool {
+	return t.sigMeta.SigChainLocation.SeqType == keybase1.SeqType_PUBLIC
+}
 
 // comparison method only valid if `t` and `u` are known to be on the same chain
 func (t proofTerm) lessThanOrEqual(u proofTerm) bool {
@@ -195,7 +198,7 @@ func (p *proofSetT) AllProofs() []proof {
 // lookupMerkleTreeChain loads the path up to the merkle tree and back down that corresponds
 // to this proof. It will contact the API server.  Returns the sigchain tail on success.
 func (p proof) lookupMerkleTreeChain(ctx context.Context, world LoaderContext) (ret *libkb.MerkleTriple, err error) {
-	return world.merkleLookupTripleAtHashMeta(ctx, p.a.leafID, p.b.sigMeta.PrevMerkleRootSigned.HashMeta)
+	return world.merkleLookupTripleAtHashMeta(ctx, p.a.isPublic(), p.a.leafID, p.b.sigMeta.PrevMerkleRootSigned.HashMeta)
 }
 
 // check a single proof. Call to the merkle API enddpoint, and then ensure that the


### PR DESCRIPTION
- plumb the public bit all the way through, don't rely on the ID suffix.