### PR TITLE
add local dismissal feature for gregor message playback CORE-6810

### DIFF
--- a/go/badges/badger.go
+++ b/go/badges/badger.go
@@ -94,7 +94,7 @@ func (b *Badger) Resync(ctx context.Context, chatRemote func() chat1.RemoteInter
 		b.G().Log.Debug("Badger: Resync(): skipping remote call, data previously obtained")
 	}
 
-	state, err := gcli.StateMachineState(ctx, nil)
+	state, err := gcli.StateMachineState(ctx, nil, false)
 	if err != nil {
 		b.G().Log.Debug("Badger: Resync(): unable to get state: %s", err.Error())
 		state = gregor1.State{}

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -425,6 +425,10 @@ func (d *FakeGregorDismisser) DismissItem(ctx context.Context, cli gregor1.Incom
 	return nil
 }
 
+func (d *FakeGregorDismisser) LocalDismissItem(ctx context.Context, id gregor.MsgID) error {
+	return nil
+}
+
 func TestTrackWithTokenDismissesGregor(t *testing.T) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()

--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keybase/client/go/logger"
+
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"golang.org/x/net/context"
-
-	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
 type LocalStorageEngine interface {
@@ -24,13 +24,13 @@ type Client struct {
 	Device  gregor.DeviceID
 	Sm      gregor.StateMachine
 	Storage LocalStorageEngine
-	Log     rpc.LogOutput
+	Log     logger.Logger
 
 	SaveTimer <-chan time.Time
 }
 
 func NewClient(user gregor.UID, device gregor.DeviceID, sm gregor.StateMachine,
-	storage LocalStorageEngine, saveInterval time.Duration, log rpc.LogOutput) *Client {
+	storage LocalStorageEngine, saveInterval time.Duration, log logger.Logger) *Client {
 	c := &Client{
 		User:      user,
 		Device:    device,
@@ -123,19 +123,19 @@ func (c *Client) SyncFromTime(ctx context.Context, cli gregor1.IncomingInterface
 
 	// Grab the events from gregord
 	if syncResult == nil {
-		c.Log.Debug("Sync(): start time: %s", gregor1.FromTime(arg.Ctime))
+		c.Log.CDebugf(ctx, "Sync(): start time: %s", gregor1.FromTime(arg.Ctime))
 		syncResult = new(gregor1.SyncResult)
 		*syncResult, err = cli.Sync(ctx, arg)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		c.Log.Debug("Sync(): skipping sync call, data previously obtained")
+		c.Log.CDebugf(ctx, "Sync(): skipping sync call, data previously obtained")
 	}
 
-	c.Log.Debug("Sync(): consuming %d messages", len(syncResult.Msgs))
+	c.Log.CDebugf(ctx, "Sync(): consuming %d messages", len(syncResult.Msgs))
 	for _, ibm := range syncResult.Msgs {
-		c.Log.Debug("Sync(): consuming msgid: %s", ibm.Metadata().MsgID())
+		c.Log.CDebugf(ctx, "Sync(): consuming msgid: %s", ibm.Metadata().MsgID())
 		m := gregor1.Message{Ibm_: &ibm}
 		msgs = append(msgs, ibm)
 		c.Sm.ConsumeMessage(ctx, m)
@@ -150,9 +150,9 @@ func (c *Client) SyncFromTime(ctx context.Context, cli gregor1.IncomingInterface
 	if err != nil {
 		return nil, err
 	}
-	c.Log.Debug("Sync(): state items: %d", len(items))
+	c.Log.CDebugf(ctx, "Sync(): state items: %d", len(items))
 	for _, it := range items {
-		c.Log.Debug("Sync(): state item: %s", it.Metadata().MsgID())
+		c.Log.CDebugf(ctx, "Sync(): state item: %s", it.Metadata().MsgID())
 	}
 	hash, err := state.Hash()
 	if err != nil {
@@ -165,7 +165,7 @@ func (c *Client) SyncFromTime(ctx context.Context, cli gregor1.IncomingInterface
 	return msgs, nil
 }
 
-func (c *Client) freshSync(cli gregor1.IncomingInterface, state *gregor.State) ([]gregor.InBandMessage, error) {
+func (c *Client) freshSync(ctx context.Context, cli gregor1.IncomingInterface, state *gregor.State) ([]gregor.InBandMessage, error) {
 
 	var msgs []gregor.InBandMessage
 	var err error
@@ -178,7 +178,7 @@ func (c *Client) freshSync(cli gregor1.IncomingInterface, state *gregor.State) (
 			return msgs, err
 		}
 	} else {
-		c.Log.Debug("Sync(): freshSync(): skipping State call, data previously obtained")
+		c.Log.CDebugf(ctx, "Sync(): freshSync(): skipping State call, data previously obtained")
 	}
 
 	if msgs, err = c.InBandMessagesFromState(*state); err != nil {
@@ -195,29 +195,29 @@ func (c *Client) Sync(ctx context.Context, cli gregor1.IncomingInterface,
 	syncRes *chat1.SyncAllNotificationRes) (res []gregor.InBandMessage, err error) {
 	defer func() {
 		if err == nil {
-			c.Log.Debug("Sync(): sync success!")
+			c.Log.CDebugf(ctx, "Sync(): sync success!")
 			if err = c.Save(ctx); err != nil {
-				c.Log.Debug("Sync(): error save state: %s", err.Error())
+				c.Log.CDebugf(ctx, "Sync(): error save state: %s", err.Error())
 			}
 		} else {
-			c.Log.Debug("Sync(): failure: %s", err)
+			c.Log.CDebugf(ctx, "Sync(): failure: %s", err)
 		}
 	}()
 
 	var syncResult *gregor1.SyncResult
 	if syncRes != nil {
-		c.Log.Debug("Sync(): using previously obtained data")
+		c.Log.CDebugf(ctx, "Sync(): using previously obtained data")
 		typ, err := syncRes.Typ()
 		if err != nil {
 			return res, err
 		}
 		switch typ {
 		case chat1.SyncAllNotificationType_STATE:
-			c.Log.Debug("Sync(): using previously obtained state result for freshSync")
+			c.Log.CDebugf(ctx, "Sync(): using previously obtained state result for freshSync")
 			st := gregor.State(syncRes.State())
-			return c.freshSync(cli, &st)
+			return c.freshSync(ctx, cli, &st)
 		case chat1.SyncAllNotificationType_INCREMENTAL:
-			c.Log.Debug("Sync(): using previously obtained incremental result")
+			c.Log.CDebugf(ctx, "Sync(): using previously obtained incremental result")
 			inc := syncRes.Incremental()
 			syncResult = &inc
 		}
@@ -228,7 +228,7 @@ func (c *Client) Sync(ctx context.Context, cli gregor1.IncomingInterface,
 	if err != nil {
 		if _, ok := err.(ErrHashMismatch); ok {
 			c.Log.Debug("Sync(): hash check failure: %v", err)
-			return c.freshSync(cli, nil)
+			return c.freshSync(ctx, cli, nil)
 		}
 		return msgs, err
 	}
@@ -279,10 +279,10 @@ func (c *Client) StateMachineConsumeMessage(ctx context.Context, m gregor1.Messa
 	// Check to see if we should save
 	select {
 	case <-c.SaveTimer:
-		c.Log.Debug("StateMachineConsumeMessage(): saving local state")
+		c.Log.CDebugf(ctx, "StateMachineConsumeMessage(): saving local state")
 		return c.Save(ctx)
 	default:
-		c.Log.Debug("StateMachineConsumeMessage(): not saving local state")
+		c.Log.CDebugf(ctx, "StateMachineConsumeMessage(): not saving local state")
 		// Plow through if the timer isn't up
 	}
 
@@ -301,13 +301,15 @@ func (c *Client) StateMachineInBandMessagesSince(ctx context.Context, t time.Tim
 	if filterLocalDismissals {
 		ldmap, err := c.localDismissalMap(ctx)
 		if err != nil {
-			c.Log.Debug("StateMachineInBandMessagesSince: failed to get local dismissal map: %s", err)
+			c.Log.CDebugf(ctx, "filterLocalDismissals: failed to get local dismissal map: %s", err)
 			return ibms, nil
 		}
 		var filteredIbms []gregor.InBandMessage
 		for _, ibm := range ibms {
 			if !ldmap[ibm.Metadata().MsgID().String()] {
 				filteredIbms = append(filteredIbms, ibm)
+			} else {
+				c.Log.CDebugf(ctx, "filterLocalDismissals: filtered message: %s", ibm.Metadata().MsgID())
 			}
 		}
 		return filteredIbms, nil
@@ -330,22 +332,25 @@ func (c *Client) localDismissalMap(ctx context.Context) (map[string]bool, error)
 func (c *Client) filterLocalDismissals(ctx context.Context, state gregor.State) gregor.State {
 	ldmap, err := c.localDismissalMap(ctx)
 	if err != nil {
-		c.Log.Debug("filterLocalDismissals: failed to read local dismissals, just returning state: %s", err)
+		c.Log.CDebugf(ctx, "filterLocalDismissals: failed to read local dismissals, just returning state: %s",
+			err)
 	}
 	items, err := state.Items()
 	if err != nil {
-		c.Log.Debug("filterLocalDismissals: failed to get state items: %s", err)
+		c.Log.CDebugf(ctx, "filterLocalDismissals: failed to get state items: %s", err)
 		return state
 	}
 	var filteredItems []gregor.Item
 	for _, it := range items {
 		if !ldmap[it.Metadata().MsgID().String()] {
 			filteredItems = append(filteredItems, it)
+		} else {
+			c.Log.CDebugf(ctx, "filterLocalDismissals: filtered state item: %s", it.Metadata().MsgID())
 		}
 	}
 	filteredState, err := c.Sm.ObjFactory().MakeState(filteredItems)
 	if err != nil {
-		c.Log.Debug("filterLocalDismissals: failed to make state: %s", err)
+		c.Log.CDebugf(ctx, "filterLocalDismissals: failed to make state: %s", err)
 	}
 	return filteredState
 }

--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -146,6 +146,11 @@ func (c *Client) SyncFromTime(ctx context.Context, cli gregor1.IncomingInterface
 	if err != nil {
 		return nil, err
 	}
+	items, err := state.Items()
+	if err != nil {
+		return nil, err
+	}
+	c.Log.Debug("Sync(): state items: %d", len(items))
 	hash, err := state.Hash()
 	if err != nil {
 		return nil, err

--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -17,6 +17,9 @@ import (
 type LocalStorageEngine interface {
 	Store(gregor.UID, []byte) error
 	Load(gregor.UID) ([]byte, error)
+	LocalDismiss(u gregor.UID, msgID gregor.MsgID) error
+	ClearLocalDismissal(u gregor.UID, msgID gregor.MsgID) error
+	FetchLocalDismissals(u gregor.UID) ([][]byte, error)
 }
 
 type Client struct {

--- a/go/gregor/interface.go
+++ b/go/gregor/interface.go
@@ -202,6 +202,15 @@ type StateMachine interface {
 	// How long we lock access to reminders; after this time, it's open to other
 	// consumers.
 	ReminderLockDuration() time.Duration
+
+	// Local dismissals for the device this state machine runs on
+	LocalDismissals(context.Context, UID) ([]MsgID, error)
+
+	// Set local dismissals on the state machine storage to the given list
+	InitLocalDismissals(context.Context, UID, []MsgID) error
+
+	// Consume a local dismissal in state machine storage
+	ConsumeLocalDismissal(context.Context, UID, MsgID) error
 }
 
 type ObjFactory interface {

--- a/go/gregor/storage/mem_sm.go
+++ b/go/gregor/storage/mem_sm.go
@@ -222,7 +222,6 @@ func (u *user) isLocallyDismissed(msgID gregor.MsgID) bool {
 
 func (u *user) state(now time.Time, f gregor.ObjFactory, d gregor.DeviceID, t gregor.TimeOrOffset) (gregor.State, error) {
 	var items []gregor.Item
-	u.logger.Debug("STATE: BEGIN")
 	table := make(map[string]gregor.Item)
 	for _, i := range u.items {
 		md := i.item.Metadata()
@@ -236,10 +235,7 @@ func (u *user) state(now time.Time, f gregor.ObjFactory, d gregor.DeviceID, t gr
 		if i.isDismissedAt(toTime(now, t)) {
 			continue
 		}
-		if u.isLocallyDismissed(md.MsgID()) {
-			u.logger.Debug("STATE: LOCALDIS: %s", md.MsgID())
-			continue
-		}
+
 		exported, err := i.export(f)
 		if err != nil {
 			return nil, err
@@ -283,9 +279,6 @@ func (u *user) replayLog(now time.Time, d gregor.DeviceID, t time.Time) (msgs []
 
 		allmsgs[msg.m.Metadata().MsgID().String()] = msg.m
 		if msg.isDismissedAt(now) {
-			continue
-		}
-		if u.isLocallyDismissed(msg.m.Metadata().MsgID()) {
 			continue
 		}
 
@@ -340,7 +333,6 @@ func (m *MemEngine) InitLocalDismissals(ctx context.Context, u gregor.UID, msgID
 	for _, msgID := range msgIDs {
 		user.localDismissals[msgID.String()] = msgID
 	}
-	m.log.CDebugf(ctx, "INITLOCALDISMISSALS: %d", len(msgIDs))
 	return nil
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -447,6 +447,7 @@ type Clock interface {
 
 type GregorDismisser interface {
 	DismissItem(ctx context.Context, cli gregor1.IncomingInterface, id gregor.MsgID) error
+	LocalDismissItem(ctx context.Context, id gregor.MsgID) error
 }
 
 type GregorInBandMessageHandler interface {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -460,6 +460,10 @@ func (f *FakeGregorDismisser) DismissItem(_ context.Context, cli gregor1.Incomin
 	return nil
 }
 
+func (f *FakeGregorDismisser) LocalDismissItem(ctx context.Context, id gregor.MsgID) error {
+	return nil
+}
+
 // ResetLoginState is only used for testing...
 // Bypasses locks.
 func (g *GlobalContext) ResetLoginState() {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1597,7 +1597,7 @@ func (g *gregorHandler) LocalDismissItem(ctx context.Context, id gregor.MsgID) (
 
 func (g *gregorHandler) DismissCategory(ctx context.Context, category gregor1.Category) error {
 	var err error
-	defer g.G().CTrace(ctx.fmt.Sprintf("gregorHandler.DismissCategory(%s)", category.String()),
+	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.DismissCategory(%s)", category.String()),
 		func() error { return err },
 	)()
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1560,7 +1560,7 @@ func (g *gregorHandler) DismissItem(ctx context.Context, cli gregor1.IncomingInt
 		return nil
 	}
 	var err error
-	defer g.G().Trace(fmt.Sprintf("gregorHandler.dismissItem(%s)", id.String()),
+	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.dismissItem(%s)", id.String()),
 		func() error { return err },
 	)()
 
@@ -1584,7 +1584,7 @@ func (g *gregorHandler) LocalDismissItem(ctx context.Context, id gregor.MsgID) (
 	if id == nil {
 		return nil
 	}
-	defer g.G().Trace(fmt.Sprintf("gregorHandler.localDismissItem(%s)", id.String()),
+	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.localDismissItem(%s)", id.String()),
 		func() error { return err },
 	)()
 
@@ -1597,7 +1597,7 @@ func (g *gregorHandler) LocalDismissItem(ctx context.Context, id gregor.MsgID) (
 
 func (g *gregorHandler) DismissCategory(ctx context.Context, category gregor1.Category) error {
 	var err error
-	defer g.G().Trace(fmt.Sprintf("gregorHandler.DismissCategory(%s)", category.String()),
+	defer g.G().CTrace(ctx.fmt.Sprintf("gregorHandler.DismissCategory(%s)", category.String()),
 		func() error { return err },
 	)()
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -183,29 +183,6 @@ type gregorHandler struct {
 var _ libkb.GregorDismisser = (*gregorHandler)(nil)
 var _ libkb.GregorListener = (*gregorHandler)(nil)
 
-type gregorLocalDb struct {
-	libkb.Contextified
-}
-
-func newLocalDB(g *libkb.GlobalContext) *gregorLocalDb {
-	return &gregorLocalDb{
-		Contextified: libkb.NewContextified(g),
-	}
-}
-
-func dbKey(u gregor.UID) libkb.DbKey {
-	return libkb.DbKey{Typ: libkb.DBGregor, Key: hex.EncodeToString(u.Bytes())}
-}
-
-func (db *gregorLocalDb) Store(u gregor.UID, b []byte) error {
-	return db.G().LocalDb.PutRaw(dbKey(u), b)
-}
-
-func (db *gregorLocalDb) Load(u gregor.UID) (res []byte, e error) {
-	res, _, err := db.G().LocalDb.GetRaw(dbKey(u))
-	return res, err
-}
-
 func newGregorHandler(g *globals.Context) *gregorHandler {
 	gh := &gregorHandler{
 		Contextified:      globals.NewContextified(g),
@@ -329,7 +306,7 @@ func (g *gregorHandler) resetGregorClient() (err error) {
 	}
 
 	// Create client object
-	gcli := grclient.NewClient(guid, gdid, sm, newLocalDB(g.G().ExternalG()),
+	gcli := grclient.NewClient(guid, gdid, sm, storage.NewLocalDB(g.G().ExternalG()),
 		g.G().Env.GetGregorSaveInterval(), g.G().Log)
 
 	// Bring up local state

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -484,7 +484,7 @@ func (g *gregorHandler) replayInBandMessages(ctx context.Context, cli gregor1.In
 
 	if t.IsZero() {
 		g.Debug(ctx, "replayInBandMessages: fresh replay: using state items")
-		state, err := gcli.StateMachineState(ctx, nil)
+		state, err := gcli.StateMachineState(ctx, nil, true)
 		if err != nil {
 			g.Debug(ctx, "replayInBandMessages: unable to fetch state for replay: %s", err)
 			return nil, err
@@ -495,7 +495,7 @@ func (g *gregorHandler) replayInBandMessages(ctx context.Context, cli gregor1.In
 		}
 	} else {
 		g.Debug(ctx, "replayInBandMessages: incremental replay: using ibms since")
-		if msgs, err = gcli.StateMachineInBandMessagesSince(ctx, t); err != nil {
+		if msgs, err = gcli.StateMachineInBandMessagesSince(ctx, t, true); err != nil {
 			g.Debug(ctx, "replayInBandMessages: unable to fetch messages for replay: %s", err)
 			return nil, err
 		}
@@ -809,7 +809,7 @@ func (g *gregorHandler) broadcastMessageOnce(ctx context.Context, m gregor1.Mess
 		}
 		// Check to see if this is already in our state
 		msgID := ibm.Metadata().MsgID()
-		state, err := gcli.StateMachineState(ctx, nil)
+		state, err := gcli.StateMachineState(ctx, nil, false)
 		if err != nil {
 			g.Debug(ctx, "BroadcastMessage: no state machine available: %s", err.Error())
 			return err
@@ -918,7 +918,7 @@ func (g *gregorHandler) handleInBandMessageWithHandler(ctx context.Context, cli 
 	if err != nil {
 		return false, err
 	}
-	state, err := gcli.StateMachineState(ctx, nil)
+	state, err := gcli.StateMachineState(ctx, nil, false)
 	if err != nil {
 		return false, err
 	}
@@ -1698,7 +1698,7 @@ func (g *gregorHandler) getState(ctx context.Context) (res gregor1.State, err er
 		return res, errors.New("gregor service not available (are you in standalone?)")
 	}
 
-	s, err = g.gregorCli.StateMachineState(ctx, nil)
+	s, err = g.gregorCli.StateMachineState(ctx, nil, false)
 	if err != nil {
 		return res, err
 	}

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"bytes"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -354,7 +353,7 @@ func (m mockGregord) newIbm2(uid gregor1.UID, category gregor1.Category, body gr
 	}
 }
 
-func (m mockGregord) newDismissal(uid gregor1.UID, msg gregor1.Message) gregor1.Message {
+func (m mockGregord) newDismissal(uid gregor1.UID, msg gregor.Message) gregor.Message {
 	m.fc.Advance(time.Minute)
 	dismissalID := msg.ToInBandMessage().Metadata().MsgID().(gregor1.MsgID)
 	return gregor1.Message{
@@ -402,22 +401,12 @@ func setupSyncTests(t *testing.T, tc libkb.TestContext) (*gregorHandler, mockGre
 
 func checkMessages(t *testing.T, source string, msgs []gregor.InBandMessage,
 	refMsgs []gregor.InBandMessage) {
-
-	if len(msgs) != len(refMsgs) {
-		for _, m := range msgs {
-			t.Logf("msgID: %s", m.Metadata().MsgID().String())
-		}
-		t.Fatalf("messages lists unequal size, %d != %d, source: %s", len(msgs), len(refMsgs), source)
-	}
-
+	require.Len(t, msgs, len(refMsgs))
 	for index, refMsg := range refMsgs {
 		msg := msgs[index]
 		msgID := msg.Metadata().MsgID()
 		refMsgID := refMsg.Metadata().MsgID()
-
-		if !bytes.Equal(msgID.Bytes(), refMsgID.Bytes()) {
-			t.Fatalf("message IDs do not match, %s != %s, source: %s", msgID, refMsgID, source)
-		}
+		require.Equal(t, refMsgID.Bytes(), msgID.Bytes())
 	}
 }
 
@@ -615,7 +604,7 @@ func TestSyncDismissal(t *testing.T) {
 
 	// Dismiss message
 	dismissal := server.newDismissal(uid, msg)
-	server.ConsumeMessage(context.TODO(), dismissal)
+	server.ConsumeMessage(context.TODO(), dismissal.(gregor1.Message))
 
 	// Sync from the server
 	replayedMessages, consumedMessages := doServerSync(t, h, server)
@@ -803,7 +792,7 @@ func TestSyncDismissalExistingState(t *testing.T) {
 
 	// Dismiss message
 	dismissal := server.newDismissal(uid, msg)
-	server.ConsumeMessage(context.TODO(), dismissal)
+	server.ConsumeMessage(context.TODO(), dismissal.(gregor1.Message))
 	refReplayMsgs = append(refReplayMsgs, dismissal.ToInBandMessage())
 	refConsumeMsgs = append(refConsumeMsgs, dismissal.ToInBandMessage())
 
@@ -840,7 +829,7 @@ func TestSyncFutureDismissals(t *testing.T) {
 
 	// Dismiss message
 	dismissal := server.newDismissal(uid, msg2)
-	server.ConsumeMessage(context.TODO(), dismissal)
+	server.ConsumeMessage(context.TODO(), dismissal.(gregor1.Message))
 
 	// Sync from the server
 	h.firstConnect = false
@@ -904,4 +893,40 @@ func badgeStateStats(bs keybase1.BadgeState) (res BadgeStateStats) {
 		}
 	}
 	return
+}
+
+func TestLocalDismissals(t *testing.T) {
+	tc := libkb.SetupTest(t, "gregor", 2)
+	defer tc.Cleanup()
+	tc.G.SetService()
+
+	// Set up client and server
+	h, server, uid := setupSyncTests(t, tc)
+
+	var refReplayMsgs []gregor.InBandMessage
+	var refConsumeMsgs []gregor.InBandMessage
+	msg := server.newIbm(uid)
+	require.NoError(t, server.ConsumeMessage(context.TODO(), msg))
+	refConsumeMsgs = append(refConsumeMsgs, msg.ToInBandMessage())
+	refReplayMsgs = append(refReplayMsgs, msg.ToInBandMessage())
+
+	lmsg := server.newIbm(uid)
+	require.NoError(t, server.ConsumeMessage(context.TODO(), lmsg))
+	refConsumeMsgs = append(refConsumeMsgs, lmsg.ToInBandMessage())
+
+	require.NoError(t, h.LocalDismissItem(context.TODO(), lmsg.ToInBandMessage().Metadata().MsgID()))
+
+	replayedMessages, consumedMessages := doServerSync(t, h, server)
+	checkMessages(t, "replayed messages", replayedMessages, refReplayMsgs)
+	checkMessages(t, "consumed messages", consumedMessages, refConsumeMsgs)
+
+	dis := server.newDismissal(uid, lmsg)
+	require.NoError(t, server.ConsumeMessage(context.TODO(), dis.(gregor1.Message)))
+	require.NoError(t, broadcastMessageTesting(t, h, dis.(gregor1.Message)))
+
+	gcli, err := h.getGregorCli()
+	require.NoError(t, err)
+	lds, err := gcli.Sm.LocalDismissals(context.TODO(), uid)
+	require.NoError(t, err)
+	require.Zero(t, len(lds))
 }

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -377,7 +377,7 @@ func newGregordMock(logger logger.Logger) mockGregord {
 	var of gregor1.ObjFactory
 	fc := clockwork.NewFakeClock()
 
-	sm := storage.NewMemEngine(of, fc)
+	sm := storage.NewMemEngine(of, fc, logger)
 
 	return mockGregord{sm: sm, fc: fc, log: logger}
 }

--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -58,7 +58,7 @@ func (r *teamHandler) Create(ctx context.Context, cli gregor1.IncomingInterface,
 }
 
 func (r *teamHandler) rotateTeam(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
-	r.G().Log.CDebugf(ctx, "team.clkr received")
+	r.G().Log.CDebugf(ctx, "teamHandler: team.clkr received")
 	var msg keybase1.TeamCLKRMsg
 	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
 		r.G().Log.CDebugf(ctx, "error unmarshaling team.clkr item: %s", err)
@@ -76,7 +76,7 @@ func (r *teamHandler) rotateTeam(ctx context.Context, cli gregor1.IncomingInterf
 
 func (r *teamHandler) memberOutFromReset(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
 	nm := "team.member_out_from_reset"
-	r.G().Log.CDebugf(ctx, "%s received", nm)
+	r.G().Log.CDebugf(ctx, "teamHandler: %s received", nm)
 	var msg keybase1.TeamMemberOutFromReset
 	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
 		r.G().Log.CDebugf(ctx, "error unmarshaling %s item: %s", nm, err)
@@ -94,6 +94,7 @@ func (r *teamHandler) memberOutFromReset(ctx context.Context, cli gregor1.Incomi
 
 func (r *teamHandler) changeTeam(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item, changes keybase1.TeamChangeSet) error {
 	var rows []keybase1.TeamChangeRow
+	r.G().Log.CDebugf(ctx, "teamHandler: changeTeam received")
 	if err := json.Unmarshal(item.Body().Bytes(), &rows); err != nil {
 		r.G().Log.CDebugf(ctx, "error unmarshaling team.(change|rename) item: %s", err)
 		return err
@@ -116,7 +117,7 @@ func (r *teamHandler) deleteTeam(ctx context.Context, cli gregor1.IncomingInterf
 		r.G().Log.CDebugf(ctx, "error unmarshaling team.(change|rename) item: %s", err)
 		return err
 	}
-	r.G().Log.CDebugf(ctx, "team.delete unmarshaled: %+v", rows)
+	r.G().Log.CDebugf(ctx, "teamHandler: team.delete unmarshaled: %+v", rows)
 
 	err := teams.HandleDeleteNotification(ctx, r.G(), rows)
 	if err != nil {
@@ -132,7 +133,7 @@ func (r *teamHandler) exitTeam(ctx context.Context, cli gregor1.IncomingInterfac
 		r.G().Log.CDebugf(ctx, "error unmarshaling team.exit item: %s", err)
 		return err
 	}
-	r.G().Log.CDebugf(ctx, "team.exit unmarshaled: %+v", rows)
+	r.G().Log.CDebugf(ctx, "teamHandler: team.exit unmarshaled: %+v", rows)
 	err := teams.HandleExitNotification(ctx, r.G(), rows)
 	if err != nil {
 		return err
@@ -143,7 +144,7 @@ func (r *teamHandler) exitTeam(ctx context.Context, cli gregor1.IncomingInterfac
 }
 
 func (r *teamHandler) sharingBeforeSignup(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
-	r.G().Log.CDebugf(ctx, "team.sbs received")
+	r.G().Log.CDebugf(ctx, "teamHandler: team.sbs received")
 	var msg keybase1.TeamSBSMsg
 	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
 		r.G().Log.CDebugf(ctx, "error unmarshaling team.sbs item: %s", err)
@@ -160,7 +161,7 @@ func (r *teamHandler) sharingBeforeSignup(ctx context.Context, cli gregor1.Incom
 }
 
 func (r *teamHandler) openTeamAccessRequest(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
-	r.G().Log.CDebugf(ctx, "team.openreq received")
+	r.G().Log.CDebugf(ctx, "teamHandler: team.openreq received")
 	var msg keybase1.TeamOpenReqMsg
 	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
 		r.G().Log.CDebugf(ctx, "error unmarshaling team.openreq item: %s", err)
@@ -177,7 +178,7 @@ func (r *teamHandler) openTeamAccessRequest(ctx context.Context, cli gregor1.Inc
 }
 
 func (r *teamHandler) seitanCompletion(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
-	r.G().Log.CDebugf(ctx, "team.seitan received")
+	r.G().Log.CDebugf(ctx, "teamHandler: team.seitan received")
 	var msg keybase1.TeamSeitanMsg
 	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
 		r.G().Log.CDebugf(ctx, "error unmarshaling team.seitan item: %s", err)


### PR DESCRIPTION
Patch does the following:

1.) Add the ability to create "local dismissals" for items from the Gregor state on a device. These local dismissals serve to prevent replaying a Gregor item more than once. Any handler can selectively locally dismiss depending on the message. The item will still be in the state, but just not considered for replay. The advantage is we can continue to transmit the device independent Gregor messages with short expirations, but also not have to continually process them on devices that have already done so.
2.) Change `team.changed` to locally dismiss any items after successfully processing them.