### PR TITLE
Ignore teamlist errors due to offline

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -486,6 +486,12 @@ const _getTeams = function*(action: TeamsGen.GetTeamsPayload): Saga.SagaGenerato
         })
       )
     )
+  } catch (err) {
+    if (err.code === RPCTypes.constantsStatusCode.scapinetworkerror) {
+      // Ignore API errors due to offline
+    } else {
+      throw err
+    }
   } finally {
     yield Saga.put(replaceEntity(['teams'], I.Map([['loaded', true]])))
   }


### PR DESCRIPTION
@keybase/react-hackers 

Loading the Chat Inbox offline would cause a black bar GlobalError -- while we normally ignore offline errors when in the Chat tab, navigating to the Inbox now causes a `teamList` operation to happen too, so that we can e.g. populate the team member counts in the context menu for each team in the Inbox view, and we weren't ignoring offline errors from that RPC.  So this PR does that.