### PR TITLE
Fix infinite recursion in _getDetails

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -409,7 +409,7 @@ const _getTeamOperations = function*(
     })
     yield Saga.put(replaceEntity(['teams', 'teamNameToCanPerform'], I.Map({[teamname]: teamOperation})))
   } finally {
-    yield Saga.put((dispatch: Dispatch) => dispatch(TeamsGen.createGetDetails({teamname}))) // getDetails will unset loading
+    yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, false]])))
   }
 }
 


### PR DESCRIPTION
@keybase/react-hackers CC @MarcoPolo 

PR #9982 introduced an infinite recursion triggered by going to a Team page on the Teams tab.  The PR makes `_getDetails` call `_getTeamOperations`, but that saga calls `_getDetails` at the bottom of itself:
```
-> _getDetails
  -> _getTeamOperations
    -> _getDetails
       ...
```
Since the only reason `_getTeamOperations` was calling `_getDetails` was to reset the loading state for the team, I think the easiest way out is to just unset loading explicitly ourselves.

Paused the Linux build since this could cause API server issues if it goes out.