### PR TITLE
fix team settings tab scrollview

### DIFF
--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -347,7 +347,13 @@ class Team extends React.PureComponent<Props> {
       const teamsLink = 'keybase.io/popular-teams'
       contents = (
         <ScrollView
-          style={{...globalStyles.flexBoxColumn, alignSelf: 'stretch', padding: globalMargins.medium}}
+          style={{
+            ...globalStyles.flexBoxColumn,
+            alignSelf: 'stretch',
+            padding: globalMargins.medium,
+            flexBasis: 0,
+            flexGrow: 1,
+          }}
         >
           {!youImplicitAdmin &&
             <Box


### PR DESCRIPTION
This sets `flexBasis: 0, flexGrow: 1` on the team settings container so it doesn't try to take up more space than what's left over

before:
<img width="1052" alt="screen shot 2017-12-20 at 10 04 42 am" src="https://user-images.githubusercontent.com/11968340/34213514-712c29a2-e56d-11e7-9ccf-2399ea0dfa9c.png">

after:
<img width="1080" alt="screen shot 2017-12-20 at 10 04 27 am" src="https://user-images.githubusercontent.com/11968340/34213524-754a33d0-e56d-11e7-86b2-397314362576.png">

r? @keybase/react-hackers 