### PR TITLE
Fix bulk email split

### DIFF
--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -482,21 +482,23 @@ func TestMemberAddEmailBulk(t *testing.T) {
 	tc, _, name := memberSetup(t)
 	defer tc.Cleanup()
 
-	blob := "u1@keybase.io u2@keybase.io\nu3@keybase.io,u4@keybase.io\tu5@keybase.io,u6@keybase.io, u7@keybase.io\n\n\n"
+	blob := "u1@keybase.io, u2@keybase.io\nu3@keybase.io,u4@keybase.io, u5@keybase.io,u6@keybase.io, u7@keybase.io\n\n\nFull Name <fullname@keybase.io>, Someone Else <someone@keybase.io>,u8@keybase.io\n\n"
 
 	res, err := AddEmailsBulk(context.TODO(), tc.G, name, blob, keybase1.TeamRole_WRITER)
 	if err != nil {
 		t.Fatal(err)
 	}
-	emails := []string{"u1@keybase.io", "u2@keybase.io", "u3@keybase.io", "u4@keybase.io", "u5@keybase.io", "u6@keybase.io", "u7@keybase.io"}
+	emails := []string{"u1@keybase.io", "u2@keybase.io", "u3@keybase.io", "u4@keybase.io", "u5@keybase.io", "u6@keybase.io", "u7@keybase.io", "u8@keybase.io"}
 
 	if len(res.Invited) != len(emails) {
+		t.Logf("invited: %+v", res.Invited)
 		t.Errorf("num invited: %d, expected %d", len(res.Invited), len(emails))
 	}
 	if len(res.AlreadyInvited) != 0 {
 		t.Errorf("num already invited: %d, expected 0", len(res.AlreadyInvited))
 	}
-	if len(res.Malformed) != 0 {
+	if len(res.Malformed) != 2 {
+		t.Logf("malformed: %+v", res.Malformed)
 		t.Errorf("num malformed: %d, expected 0", len(res.Malformed))
 	}
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"golang.org/x/net/context"
 
@@ -1141,12 +1140,16 @@ func removeInviteID(ctx context.Context, team *Team, invID keybase1.TeamInviteID
 	return team.postTeamInvites(ctx, invites)
 }
 
-// splitBulk splits on whitespace or comma.
+// splitBulk splits on newline or comma.
 func splitBulk(s string) []string {
 	f := func(c rune) bool {
-		return unicode.IsSpace(c) || c == ','
+		return c == '\n' || c == ','
 	}
-	return strings.FieldsFunc(s, f)
+	split := strings.FieldsFunc(s, f)
+	for i, s := range split {
+		split[i] = strings.TrimSpace(s)
+	}
+	return split
 }
 
 func CreateSeitanToken(ctx context.Context, g *libkb.GlobalContext, teamname string, role keybase1.TeamRole, label keybase1.SeitanIKeyLabel) (keybase1.SeitanIKey, error) {


### PR DESCRIPTION
So if someone entered an email address like 

    Joe Schmo <joe@schmo.com>

it would explode into a horrible black bar error.

This is a quick fix to split the bulk email list on comma and newline instead of whitespace and comma.  Frontend UI specifies split with comma, so should be good, but allows someone to paste in a newline separated list.

It will return any emails of the form

    Full name <fullname@email.org>

in the list of malformed email addresses in the response.  There will be a new core ticket to parse those correctly, but for now, this stops the black bar error.

cc @buoyad 
