### PR TITLE
fix RPM packaging on OpenSUSE

### DIFF
--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -100,10 +100,10 @@ build_one_architecture() {
 
 export rpm_arch=i386
 export debian_arch=i386
-dependencies="Requires: at, fuse, libappindicator1, libXss.so.1"
+dependencies="Requires: at, fuse, libXss.so.1"
 build_one_architecture
 
 export rpm_arch=x86_64
 export debian_arch=amd64
-dependencies="Requires: at, fuse, libappindicator1, libXss.so.1()(64bit)"
+dependencies="Requires: at, fuse, libXss.so.1()(64bit)"
 build_one_architecture

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -26,12 +26,6 @@ mode="$(cat "$build_root/MODE")"
 
 name="$("$here/../../binary_name.sh" "$mode")"
 
-if [ "$rpm_arch" = "x86_64" ] ; then
-  dependencies="Requires: at, fuse, libappindicator1, 'libXss.so.1()(64bit)'"
-else
-  dependencies="Requires: at, fuse, libappindicator1, 'libXss.so.1'"
-fi
-
 if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/rpm/repo"
 elif [ "$mode" = "prerelease" ] ; then
@@ -106,8 +100,10 @@ build_one_architecture() {
 
 export rpm_arch=i386
 export debian_arch=i386
+dependencies="Requires: at, fuse, libappindicator1, libXss.so.1"
 build_one_architecture
 
 export rpm_arch=x86_64
 export debian_arch=amd64
+dependencies="Requires: at, fuse, libappindicator1, libXss.so.1()(64bit)"
 build_one_architecture

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -26,12 +26,16 @@ mode="$(cat "$build_root/MODE")"
 
 name="$("$here/../../binary_name.sh" "$mode")"
 
-dependencies="Requires: at"
+if [ "$rpm_arch" = "x86_64" ] ; then
+  dependencies="Requires: at, fuse, libappindicator1, 'libXss.so.1()(64bit)'"
+else
+  dependencies="Requires: at, fuse, libappindicator1, 'libXss.so.1'"
+fi
+
 if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/rpm/repo"
 elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/rpm"
-  dependencies="Requires: at, fuse, libXScrnSaver"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -100,10 +100,15 @@ build_one_architecture() {
 
 export rpm_arch=i386
 export debian_arch=i386
+# On Fedora, it would be more correct to require "libXScrnSaver", which
+# provides libXss.so. Unfortunately that doesn't work on OpenSUSE. This is the
+# most compatible set of dependencies we've found.
 dependencies="Requires: at, fuse, libXss.so.1"
 build_one_architecture
 
 export rpm_arch=x86_64
 export debian_arch=amd64
+# Requiring "libXss.so" here installs the 32-bit version. See
+# https://github.com/keybase/client/pull/5226.
 dependencies="Requires: at, fuse, libXss.so.1()(64bit)"
 build_one_architecture


### PR DESCRIPTION
These tweaks seem to fix the OpenSUSE dependency issues from https://github.com/keybase/client/pull/5226. I've tested installation on:

- OpenSUSE 42.3 (64 bit)
- Fedora 25 (64 bit)
- Fedora 27 (32 bit)

@marceloatie, there are a couple changes from your PR. I had to remove the single quotes around the library name, since the packaging scripts seem to think that's invalid (has that changed since we last tested it?). I also had to remove the `libappindicator1` dependency, since Fedora doesn't seem to have anything by that name in its repos. But what's here does seem to work. Do you have time to look at it and try it out?

r? @cjb 