### PR TITLE
 Fix usernames in chat header being blue instead of green when you follow

### DIFF
--- a/shared/chat/conversation/banner/container.js
+++ b/shared/chat/conversation/banner/container.js
@@ -16,8 +16,8 @@ import {createShowUserProfile} from '../../../actions/profile-gen'
 import {Box} from '../../../common-adapters'
 
 const getBannerMessage = createSelector(
-  [Constants.getYou, Constants.getParticipants, Constants.getFollowingMap, Constants.getMetaDataMap],
-  (you, participants, followingMap, metaDataMap) => {
+  [Constants.getYou, Constants.getParticipants, Constants.getMetaDataMap],
+  (you, participants, metaDataMap) => {
     const brokenUsers = Constants.getBrokenUsers(participants, you, metaDataMap)
     if (brokenUsers.length) {
       return {

--- a/shared/chat/conversation/header/container.js
+++ b/shared/chat/conversation/header/container.js
@@ -11,7 +11,7 @@ import {type OwnProps} from './container'
 import * as ChatTypes from '../../../constants/types/flow-types-chat'
 
 const getUsers = createSelector(
-  [Constants.getYou, Constants.getParticipants, Constants.getFollowingMap, Constants.getMetaDataMap],
+  [Constants.getYou, Constants.getParticipants, Constants.getFollowing, Constants.getMetaDataMap],
   (you, participants, followingMap, metaDataMap) =>
     Constants.usernamesToUserListItem(
       Constants.participantFilter(List(participants), you).toArray(),

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -25,7 +25,7 @@ const getParticipants = createSelector(
   [
     Constants.getYou,
     Constants.getParticipantsWithFullNames,
-    Constants.getFollowingMap,
+    Constants.getFollowing,
     Constants.getMetaDataMap,
   ],
   (you, users, followingMap, metaDataMap) => {

--- a/shared/chat/conversation/messages/joinedleft/container.js
+++ b/shared/chat/conversation/messages/joinedleft/container.js
@@ -44,7 +44,7 @@ const getDetails = createCachedSelector(
     following: I.Set<Types.Username>
   ) => ({
     channelname,
-    following: !!following.has(message.author),
+    following: following.has(message.author),
     message,
     teamname,
     you,

--- a/shared/chat/conversation/messages/joinedleft/container.js
+++ b/shared/chat/conversation/messages/joinedleft/container.js
@@ -1,6 +1,7 @@
 // @flow
 import * as Constants from '../../../../constants/chat'
 import * as Types from '../../../../constants/types/chat'
+import * as I from 'immutable'
 import JoinedLeftNotice from '.'
 import createCachedSelector from 're-reselect'
 import {compose} from 'recompose'
@@ -33,17 +34,17 @@ const getDetails = createCachedSelector(
     Constants.getYou,
     Constants.getChannelName,
     Constants.getTeamName,
-    Constants.getFollowingMap,
+    Constants.getFollowing,
   ],
   (
     message: Types.JoinedLeftMessage,
     you: string,
     channelname: string,
     teamname: string,
-    following: {[key: string]: ?boolean}
+    following: I.Set<Types.Username>
   ) => ({
     channelname,
-    following: !!following[message.author],
+    following: !!following.has(message.author),
     message,
     teamname,
     you,

--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -21,7 +21,7 @@ const mapStateToProps = (state: TypedState, {messageKey, prevMessageKey}: OwnPro
   }
   const author = message.author
   const isYou = Constants.getYou(state) === author
-  const isFollowing = Constants.getFollowingMap(state).has(author)
+  const isFollowing = Constants.getFollowing(state).has(author)
   const isBroken = Constants.getMetaDataMap(state).getIn([author, 'brokenTracker'], false)
 
   const {message: _prevMessage} = lookupMessageProps(state, prevMessageKey)

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -224,13 +224,13 @@ function usernamesToUserListItem(
   usernames: Array<string>,
   you: string,
   metaDataMap: Types.MetaDataMap,
-  followingMap: Types.FollowingMap
+  followingSet: Types.FollowingSet
 ): Array<UserListItem> {
   return usernames.map(username => ({
     username,
     broken: metaDataMap.getIn([username, 'brokenTracker'], false),
     you: username === you,
-    following: !!followingMap.get(username),
+    following: !!followingSet.has(username),
   }))
 }
 
@@ -430,7 +430,7 @@ function messageKeyKind(key: Types.MessageKey): Types.MessageKeyKind {
 
 // TODO(mm) type these properly - they return any
 const getYou = (state: TypedState) => state.config.username || ''
-const getFollowingMap = (state: TypedState) => state.config.following
+const getFollowing = (state: TypedState) => state.config.following
 const getMetaDataMap = (state: TypedState) => state.chat.get('metaData')
 const getInbox = (state: TypedState, conversationIDKey: ?Types.ConversationIDKey) =>
   conversationIDKey ? state.chat.getIn(['inbox', conversationIDKey]) : null
@@ -771,7 +771,7 @@ export {
   getAttachmentInfo,
   getSelectedRouteState,
   getYou,
-  getFollowingMap,
+  getFollowing,
   getMetaDataMap,
   getParticipants,
   getParticipantsWithFullNames,

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -230,7 +230,7 @@ function usernamesToUserListItem(
     username,
     broken: metaDataMap.getIn([username, 'brokenTracker'], false),
     you: username === you,
-    following: !!followingSet.has(username),
+    following: followingSet.has(username),
   }))
 }
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -230,7 +230,7 @@ function usernamesToUserListItem(
     username,
     broken: metaDataMap.getIn([username, 'brokenTracker'], false),
     you: username === you,
-    following: !!followingMap[username],
+    following: !!followingMap.get(username),
   }))
 }
 

--- a/shared/constants/types/chat.js
+++ b/shared/constants/types/chat.js
@@ -30,7 +30,7 @@ export type MessageKeyKind =
 
 // TODO: Ideally, this would be 'Text' | 'Error' | etc.
 export type MessageType = string
-export type FollowingMap = {[key: string]: true}
+export type FollowingSet = I.Set<Username>
 
 export type MessageState = 'pending' | 'failed' | 'sent'
 


### PR DESCRIPTION
@keybase/react-hackers 

The type of `state.config.following` became an `I.Set<string>` instead of a `{[key: string]: true}`, but we still had code accessing the values (including in the chat usernames header) as if it were an object.