### PR TITLE
handle plaintext and read message notifications on Android

### DIFF
--- a/shared/actions/platform-specific.desktop.js
+++ b/shared/actions/platform-specific.desktop.js
@@ -36,6 +36,10 @@ function displayNewMessageNotification(text: string, convID: ?string, badgeCount
   throw new Error('Display new message notification not available on this platform')
 }
 
+function clearAllNotifications() {
+  throw new Error('Clear all notifications not available on this platform')
+}
+
 export {
   requestPushPermissions,
   showMainWindow,
@@ -44,4 +48,5 @@ export {
   showShareActionSheet,
   setNoPushPermissions,
   displayNewMessageNotification,
+  clearAllNotifications,
 }

--- a/shared/actions/platform-specific.js.flow
+++ b/shared/actions/platform-specific.js.flow
@@ -16,6 +16,7 @@ declare function displayNewMessageNotification(
   badgeCount: ?number,
   myMsgID: ?number
 ): void
+declare function clearAllNotifications(): void
 
 export {
   requestPushPermissions,
@@ -25,4 +26,5 @@ export {
   showShareActionSheet,
   setNoPushPermissions,
   displayNewMessageNotification,
+  clearAllNotifications,
 }

--- a/shared/actions/platform-specific.native.js
+++ b/shared/actions/platform-specific.native.js
@@ -57,6 +57,10 @@ function saveAttachmentDialog(filePath: string): Promise<NextURI> {
   return Promise.resolve(goodPath)
 }
 
+function clearAllNotifications() {
+  PushNotifications.cancelAllLocalNotifications()
+}
+
 function displayNewMessageNotification(text: string, convID: ?string, badgeCount: ?number, myMsgID: ?number) {
   // Dismiss any non-plaintext notifications for the same message ID
   if (isIOS) {
@@ -177,4 +181,5 @@ export {
   saveAttachmentDialog,
   setNoPushPermissions,
   showShareActionSheet,
+  clearAllNotifications,
 }

--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -81,7 +81,7 @@ function* pushNotificationSaga(notification: PushGen.NotificationPayload): Saga.
     }
 
     // Handle types from user interaction
-    if (payload.userInteration) {
+    if (payload.userInteraction) {
       if (payload.type === 'chat.newmessage') {
         const {convID} = payload
         // Check for conversation ID so we know where to navigate to

--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -47,6 +47,7 @@ function* pushNotificationSaga(notification: PushGen.NotificationPayload): Saga.
   logger.info('Push notification:', notification)
   const payload = notification.payload.notification
   if (payload) {
+    // Handle types that are not from user interaction
     if (payload.type === 'chat.newmessageSilent') {
       logger.info('Push notification: silent notification received')
       try {
@@ -78,6 +79,8 @@ function* pushNotificationSaga(notification: PushGen.NotificationPayload): Saga.
         clearAllNotifications()
       }
     }
+
+    // Handle types from user interaction
     if (payload.userInteration) {
       if (payload.type === 'chat.newmessage') {
         const {convID} = payload

--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -12,6 +12,7 @@ import {
   requestPushPermissions,
   configurePush,
   displayNewMessageNotification,
+  clearAllNotifications,
   setNoPushPermissions,
 } from './platform-specific'
 
@@ -45,16 +46,16 @@ function* permissionsRequestSaga(): Saga.SagaGenerator<any, any> {
 function* pushNotificationSaga(notification: PushGen.NotificationPayload): Saga.SagaGenerator<any, any> {
   logger.info('Push notification:', notification)
   const payload = notification.payload.notification
-  if (payload && payload.userInteraction) {
+  if (payload) {
     if (payload.type === 'chat.newmessageSilent') {
       logger.info('Push notification: silent notification received')
       try {
         const unboxRes = yield Saga.call(ChatTypes.localUnboxMobilePushNotificationRpcPromise, {
           convID: payload.c || '',
           // $FlowIssue payload.t isn't ConversationMembersType
-          membersType: payload.t,
+          membersType: typeof payload.t === 'string' ? parseInt(payload.t) : payload.t,
           payload: payload.m || '',
-          pushIDs: payload.p,
+          pushIDs: typeof payload.p === 'string' ? JSON.parse(payload.p) : payload.p,
         })
         if (payload.x && payload.x > 0) {
           const num = payload.x
@@ -70,24 +71,33 @@ function* pushNotificationSaga(notification: PushGen.NotificationPayload): Saga.
       } catch (err) {
         logger.info('failed to unbox silent notification', err)
       }
-    } else if (payload.type === 'chat.newmessage') {
-      const {convID} = payload
-      // Check for conversation ID so we know where to navigate to
-      if (!convID) {
-        logger.error('Push chat notification payload missing conversation ID')
-        return
+    } else if (payload.type === 'chat.readmessage') {
+      logger.info('Push notification: read message notification received')
+      const b = typeof payload.b === 'string' ? parseInt(payload.b) : payload.b
+      if (b === 0) {
+        clearAllNotifications()
       }
-      yield Saga.put(navigateTo([chatTab, convID]))
-    } else if (payload.type === 'follow') {
-      const {username} = payload
-      if (!username) {
-        logger.error('Follow notification payload missing username', JSON.stringify(payload))
-        return
+    }
+    if (payload.userInteration) {
+      if (payload.type === 'chat.newmessage') {
+        const {convID} = payload
+        // Check for conversation ID so we know where to navigate to
+        if (!convID) {
+          logger.error('Push chat notification payload missing conversation ID')
+          return
+        }
+        yield Saga.put(navigateTo([chatTab, convID]))
+      } else if (payload.type === 'follow') {
+        const {username} = payload
+        if (!username) {
+          logger.error('Follow notification payload missing username', JSON.stringify(payload))
+          return
+        }
+        logger.info('Push notification: follow received, follower= ', username)
+        yield Saga.put(createShowUserProfile({username}))
+      } else {
+        logger.error('Push notification payload missing or unknown type')
       }
-      logger.info('Push notification: follow received, follower= ', username)
-      yield Saga.put(createShowUserProfile({username}))
-    } else {
-      logger.error('Push notification payload missing or unknown type')
     }
   }
 }


### PR DESCRIPTION
Patch does the following:

1.) Implement plaintext notifications on Android.
2.) Handle the new `chat.readmessage` push notifications to clear out notifications from the Android notification tray when the messages are read on a different device. The mechanics are the same as iOS, we clear all notifications when the badge count is 0.