### PR TITLE
quiet down installer build output

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
@@ -25,7 +25,7 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <SuppressValidation>False</SuppressValidation>
-    <SuppressIces>ICE20;ICE38</SuppressIces>
+    <SuppressIces>ICE20;ICE38;ICE91;ICE60</SuppressIces>
     <DefineConstants>GuiSourceDir=$(GOPATH)\src\github.com\keybase\client\shared\desktop\release\win32-ia32\Keybase-win32-ia32</DefineConstants>
     <CompilerAdditionalOptions>
     </CompilerAdditionalOptions>


### PR DESCRIPTION
These warnings are harmless but they fill up some 90% of our build logs, e.g. https://s3.amazonaws.com/prerelease.keybase.io/logs/keybase.build.windows.log-MRYQVXIDJ7BGHZSSSXL3BZA3562A7FTV5MKQU3X4FA6D77VDFNZQ.txt
@maxtaco @keybase/react-hackers 