### PR TITLE
use middleware and a regular store for the remote store

### DIFF
--- a/shared/desktop/remote/component-loader.js
+++ b/shared/desktop/remote/component-loader.js
@@ -62,11 +62,12 @@ class RemoteComponentLoader extends Component<Props> {
 
   componentWillMount() {
     this._window = remote.getCurrentWindow()
-    this._store = new RemoteStore({
+    const remoteStore = new RemoteStore({
       gotPropsCallback: this._onGotProps,
       windowComponent: this.props.windowComponent,
       windowParam: this.props.windowParam,
     })
+    this._store = remoteStore.getStore()
     this._ComponentClass = this._getComponent(this.props.windowComponent)
 
     setupContextMenu(this._window)


### PR DESCRIPTION
@keybase/react-hackers before we had a totally 'fake' remote store that had code to handle internal state and subscriptions and etc. This PR makes the remote store a canonical store made w/ createStore but with a special reducer and a custom middleware