### PR TITLE
add a new identify regime for saltpack

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1096,7 +1096,8 @@ func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
 		TLFIdentifyBehavior_CHAT_GUI_STRICT,
 		TLFIdentifyBehavior_CHAT_CLI,
 		TLFIdentifyBehavior_KBFS_REKEY,
-		TLFIdentifyBehavior_KBFS_QR:
+		TLFIdentifyBehavior_KBFS_QR,
+		TLFIdentifyBehavior_SALTPACK:
 		// These are identifies that either happen without user interaction at
 		// all, or happen while you're staring at some Keybase UI that can
 		// report errors on its own. No popups needed.

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1056,7 +1056,8 @@ func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
 	switch b {
 	case TLFIdentifyBehavior_CHAT_CLI,
 		TLFIdentifyBehavior_CHAT_GUI,
-		TLFIdentifyBehavior_CHAT_GUI_STRICT:
+		TLFIdentifyBehavior_CHAT_GUI_STRICT,
+		TLFIdentifyBehavior_SALTPACK:
 		return true
 	default:
 		return false
@@ -1066,7 +1067,8 @@ func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
 func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 	switch b {
 	case TLFIdentifyBehavior_CHAT_GUI,
-		TLFIdentifyBehavior_CHAT_GUI_STRICT:
+		TLFIdentifyBehavior_CHAT_GUI_STRICT,
+		TLFIdentifyBehavior_SALTPACK:
 		return true
 	default:
 		// TLFIdentifyBehavior_DEFAULT_KBFS, for filesystem activity that

--- a/go/protocol/keybase1/tlf_keys.go
+++ b/go/protocol/keybase1/tlf_keys.go
@@ -18,6 +18,7 @@ const (
 	TLFIdentifyBehavior_KBFS_REKEY      TLFIdentifyBehavior = 4
 	TLFIdentifyBehavior_KBFS_QR         TLFIdentifyBehavior = 5
 	TLFIdentifyBehavior_CHAT_SKIP       TLFIdentifyBehavior = 6
+	TLFIdentifyBehavior_SALTPACK        TLFIdentifyBehavior = 7
 )
 
 func (o TLFIdentifyBehavior) DeepCopy() TLFIdentifyBehavior { return o }
@@ -30,6 +31,7 @@ var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
 	"KBFS_REKEY":      4,
 	"KBFS_QR":         5,
 	"CHAT_SKIP":       6,
+	"SALTPACK":        7,
 }
 
 var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
@@ -40,6 +42,7 @@ var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
 	4: "KBFS_REKEY",
 	5: "KBFS_QR",
 	6: "CHAT_SKIP",
+	7: "SALTPACK",
 }
 
 func (e TLFIdentifyBehavior) String() string {

--- a/protocol/avdl/keybase1/tlf_keys.avdl
+++ b/protocol/avdl/keybase1/tlf_keys.avdl
@@ -13,7 +13,8 @@ protocol tlfKeys {
     CHAT_GUI_STRICT_3,
     KBFS_REKEY_4,
     KBFS_QR_5,
-    CHAT_SKIP_6
+    CHAT_SKIP_6,
+    SALTPACK_7
   }
 
   @typedef("string")

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1693,6 +1693,7 @@ export const tlfKeysTLFIdentifyBehavior = {
   kbfsRekey: 4,
   kbfsQr: 5,
   chatSkip: 6,
+  saltpack: 7,
 }
 
 export const tlfPublicCanonicalTLFNameAndIDRpcChannelMap = (configKeys: Array<string>, request: TlfPublicCanonicalTLFNameAndIDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.tlf.publicCanonicalTLFNameAndID', request)
@@ -3438,6 +3439,7 @@ export type TLFIdentifyBehavior =0 // DEFAULT_KBFS_0
  | 4 // KBFS_REKEY_4
  | 5 // KBFS_QR_5
  | 6 // CHAT_SKIP_6
+ | 7 // SALTPACK_7
 
 
 export type TLFIdentifyFailure = {|user: User,breaks?: ?IdentifyTrackBreaks,|}

--- a/protocol/json/keybase1/tlf_keys.json
+++ b/protocol/json/keybase1/tlf_keys.json
@@ -21,7 +21,8 @@
         "CHAT_GUI_STRICT_3",
         "KBFS_REKEY_4",
         "KBFS_QR_5",
-        "CHAT_SKIP_6"
+        "CHAT_SKIP_6",
+        "SALTPACK_7"
       ]
     },
     {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1693,6 +1693,7 @@ export const tlfKeysTLFIdentifyBehavior = {
   kbfsRekey: 4,
   kbfsQr: 5,
   chatSkip: 6,
+  saltpack: 7,
 }
 
 export const tlfPublicCanonicalTLFNameAndIDRpcChannelMap = (configKeys: Array<string>, request: TlfPublicCanonicalTLFNameAndIDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.tlf.publicCanonicalTLFNameAndID', request)
@@ -3438,6 +3439,7 @@ export type TLFIdentifyBehavior =0 // DEFAULT_KBFS_0
  | 4 // KBFS_REKEY_4
  | 5 // KBFS_QR_5
  | 6 // CHAT_SKIP_6
+ | 7 // SALTPACK_7
 
 
 export type TLFIdentifyFailure = {|user: User,breaks?: ?IdentifyTrackBreaks,|}


### PR DESCRIPTION
- don't just use CHAT, since CHAT is going to change to mean something else with implicit teams upgrade
- after KBFS handles this, we need to call into this at saltpack_encrypt.go