### PR TITLE
fix my previous fix: show New Conversation from Start a Chat

### DIFF
--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -215,6 +215,7 @@ const mapStateToProps = (state: TypedState, {isActiveRoute, routeState}: OwnProp
   }
 
   const inboxGlobalUntrustedState = state.chat.get('inboxGlobalUntrustedState')
+  const selectedConversationIDKey = Constants.getSelectedConversation(state)
 
   return {
     ...rowMetadata,
@@ -223,7 +224,9 @@ const mapStateToProps = (state: TypedState, {isActiveRoute, routeState}: OwnProp
     isLoading: inboxGlobalUntrustedState === 'loading' || state.chat.get('inboxSyncingState') === 'syncing',
     neverLoaded: inboxGlobalUntrustedState === 'unloaded',
     _user: Constants.getYou(state),
-    inSearch: state.chat.get('inSearch'),
+    showNewConversation: state.chat.get('inSearch') ||
+      // $FlowIssue this is a string
+      Constants.isPendingConversationIDKey(selectedConversationIDKey),
   }
 }
 
@@ -279,7 +282,7 @@ const mergeProps = (
     smallTeamsExpanded: stateProps.smallTeamsExpanded,
     toggleSmallTeamsExpanded: dispatchProps.toggleSmallTeamsExpanded,
     filterFocusCount: ownProps.filterFocusCount,
-    inSearch: stateProps.inSearch,
+    showNewConversation: stateProps.showNewConversation,
   }
 }
 

--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -224,9 +224,9 @@ const mapStateToProps = (state: TypedState, {isActiveRoute, routeState}: OwnProp
     isLoading: inboxGlobalUntrustedState === 'loading' || state.chat.get('inboxSyncingState') === 'syncing',
     neverLoaded: inboxGlobalUntrustedState === 'unloaded',
     _user: Constants.getYou(state),
-    showNewConversation: state.chat.get('inSearch') ||
+    showNewConversation: state.chat.get('inSearch') || (selectedConversationIDKey && 
       // $FlowIssue this is a string
-      Constants.isPendingConversationIDKey(selectedConversationIDKey),
+      Constants.isPendingConversationIDKey(selectedConversationIDKey)),
   }
 }
 

--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -224,9 +224,10 @@ const mapStateToProps = (state: TypedState, {isActiveRoute, routeState}: OwnProp
     isLoading: inboxGlobalUntrustedState === 'loading' || state.chat.get('inboxSyncingState') === 'syncing',
     neverLoaded: inboxGlobalUntrustedState === 'unloaded',
     _user: Constants.getYou(state),
-    showNewConversation: state.chat.get('inSearch') || (selectedConversationIDKey && 
-      // $FlowIssue this is a string
-      Constants.isPendingConversationIDKey(selectedConversationIDKey)),
+    showNewConversation: state.chat.get('inSearch') ||
+      (selectedConversationIDKey &&
+        // $FlowIssue this is a string
+        Constants.isPendingConversationIDKey(selectedConversationIDKey)),
   }
 }
 

--- a/shared/chat/inbox/index.desktop.js
+++ b/shared/chat/inbox/index.desktop.js
@@ -131,7 +131,7 @@ class Inbox extends PureComponent<Props, State> {
             onSelectUp={this.props.onSelectUp}
             onSelectDown={this.props.onSelectDown}
           />
-          {this.props.inSearch && <NewConversation />}
+          {this.props.showNewConversation && <NewConversation />}
           <div style={_scrollableStyle} onScroll={this._onScroll}>
             <ReactList
               ref={this._setRef}

--- a/shared/chat/inbox/index.js.flow
+++ b/shared/chat/inbox/index.js.flow
@@ -55,7 +55,6 @@ export type Props = {
   smallTeamsHiddenBadgeCount: number,
   smallTeamsHiddenRowCount: number,
   toggleSmallTeamsExpanded: () => void,
-  inSearch: boolean,
 }
 
 export default class Inbox extends React.Component<Props> {}


### PR DESCRIPTION
@akalin-keybase @MarcoPolo We've tried a few things but this seems simplest for now. I'm just not sure whether there are any other kinds of PendingConversation for which "New Conversation" should NOT be shown - if so, this is wrong too.
@keybase/react-hackers 