### PR TITLE
Full names in teamGet

### DIFF
--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -257,7 +257,7 @@ func (c *CmdTeamListMemberships) outputRole(role string, members []keybase1.Team
 		if !member.Active {
 			reset = " (inactive due to account reset)"
 		}
-		fmt.Fprintf(c.tabw, "%s\t%s\t%s%s\n", c.team, role, member.Username, reset)
+		fmt.Fprintf(c.tabw, "%s\t%s\t%s\t%s%s\n", c.team, role, member.Username, member.FullName, reset)
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -243,6 +243,7 @@ func (o TeamMembers) DeepCopy() TeamMembers {
 type TeamMemberDetails struct {
 	Uv       UserVersion `codec:"uv" json:"uv"`
 	Username string      `codec:"username" json:"username"`
+	FullName FullName    `codec:"fullName" json:"fullName"`
 	Active   bool        `codec:"active" json:"active"`
 	NeedsPUK bool        `codec:"needsPUK" json:"needsPUK"`
 }
@@ -251,6 +252,7 @@ func (o TeamMemberDetails) DeepCopy() TeamMemberDetails {
 	return TeamMemberDetails{
 		Uv:       o.Uv.DeepCopy(),
 		Username: o.Username,
+		FullName: o.FullName.DeepCopy(),
 		Active:   o.Active,
 		NeedsPUK: o.NeedsPUK,
 	}
@@ -709,6 +711,7 @@ type AnnotatedTeamInvite struct {
 	InviterUsername string         `codec:"inviterUsername" json:"inviterUsername"`
 	TeamName        string         `codec:"teamName" json:"teamName"`
 	UserActive      bool           `codec:"userActive" json:"userActive"`
+	FullName        *FullName      `codec:"fullName,omitempty" json:"fullName,omitempty"`
 }
 
 func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
@@ -722,6 +725,13 @@ func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
 		InviterUsername: o.InviterUsername,
 		TeamName:        o.TeamName,
 		UserActive:      o.UserActive,
+		FullName: (func(x *FullName) *FullName {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.FullName),
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -711,7 +711,6 @@ type AnnotatedTeamInvite struct {
 	InviterUsername string         `codec:"inviterUsername" json:"inviterUsername"`
 	TeamName        string         `codec:"teamName" json:"teamName"`
 	UserActive      bool           `codec:"userActive" json:"userActive"`
-	FullName        *FullName      `codec:"fullName,omitempty" json:"fullName,omitempty"`
 }
 
 func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
@@ -725,13 +724,6 @@ func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
 		InviterUsername: o.InviterUsername,
 		TeamName:        o.TeamName,
 		UserActive:      o.UserActive,
-		FullName: (func(x *FullName) *FullName {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.FullName),
 	}
 }
 

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -490,7 +490,9 @@ func AnnotateSeitanInvite(ctx context.Context, team *Team, invite keybase1.TeamI
 	return "", nil
 }
 
-func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, team *Team) (map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite, error) {
+type AnnotatedInviteMap map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite
+
+func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, team *Team) (AnnotatedInviteMap, error) {
 	invites := team.chain().inner.ActiveInvites
 	teamName := team.Name().String()
 

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -526,8 +526,6 @@ func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, team *Team) (A
 				active = false
 			}
 			name = keybase1.TeamInviteName(up.Username)
-			// TODO: Add support for full name here. FullName field in
-			// AnnotatedTeamInvite.
 		} else if category == keybase1.TeamInviteCategory_SEITAN {
 			name, err = AnnotateSeitanInvite(ctx, team, invite)
 			if err != nil {

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -553,6 +553,121 @@ func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, team *Team) (A
 	return annotatedInvites, nil
 }
 
+// AnnotateInvitesUIDMapper does what AnnotateInvites does but using
+// UIDMapper, so it's fast but may be wrong. It also puts any keybase
+// invites to members set which reference should be passed as argument.
+// PUKless members also will not be present in returned AnnotatedInviteMap.
+func AnnotateInvitesUIDMapper(ctx context.Context, g *libkb.GlobalContext, team *Team, members *keybase1.TeamMembersDetails) (AnnotatedInviteMap, error) {
+	invites := team.chain().inner.ActiveInvites
+	annotatedInvites := make(map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite, len(invites))
+	if len(invites) == 0 {
+		return annotatedInvites, nil
+	}
+
+	// UID list to pass to UIDMapper to get full names. Duplicate UIDs
+	// are fine, MapUIDsReturnMap will filter them out.
+	var uids []keybase1.UID
+	for _, invite := range invites {
+		uids = append(uids, invite.Inviter.Uid)
+
+		category, err := invite.Type.C()
+		if err != nil {
+			return nil, err
+		}
+		if category == keybase1.TeamInviteCategory_KEYBASE {
+			uv, err := invite.KeybaseUserVersion()
+			if err != nil {
+				return nil, err
+			}
+			uids = append(uids, uv.Uid)
+		}
+	}
+
+	namePkgs, err := uidmap.MapUIDsReturnMap(ctx, g.UIDMapper, g, uids, 0, 0, true)
+	if err != nil {
+		// UIDMap returned an error, but there may be useful data in the result.
+		g.Log.CDebugf(ctx, "AnnotateInvitesUIDMapper: MapUIDsReturnMap returned: %v", err)
+	}
+
+	teamName := team.Name().String()
+	for id, invite := range invites {
+		username := namePkgs[invite.Inviter.Uid].NormalizedUsername
+
+		name := invite.Name
+		category, err := invite.Type.C()
+		if err != nil {
+			return nil, err
+		}
+		var uv keybase1.UserVersion
+		if category == keybase1.TeamInviteCategory_KEYBASE {
+			// "keybase" invites (i.e. pukless users) have user version for name
+			uv, err := invite.KeybaseUserVersion()
+			if err != nil {
+				return nil, err
+			}
+			var active = true
+			var fullName keybase1.FullName
+			pkg := namePkgs[uv.Uid]
+			if pkg.FullName != nil {
+				if pkg.FullName.EldestSeqno != uv.EldestSeqno {
+					active = false
+				}
+				fullName = pkg.FullName.FullName
+			}
+
+			if !active {
+				// Skip inactive puk-less members for now. Causes
+				// duplicate usernames in team list which we don't
+				// want.
+				continue
+			}
+
+			details := keybase1.TeamMemberDetails{
+				Uv:       uv,
+				Username: pkg.NormalizedUsername.String(),
+				Active:   active,
+				NeedsPUK: true,
+				FullName: fullName,
+			}
+
+			switch invite.Role {
+			case keybase1.TeamRole_OWNER:
+				members.Owners = append(members.Owners, details)
+			case keybase1.TeamRole_ADMIN:
+				members.Admins = append(members.Admins, details)
+			case keybase1.TeamRole_WRITER:
+				members.Writers = append(members.Writers, details)
+			case keybase1.TeamRole_READER:
+				members.Readers = append(members.Readers, details)
+			}
+
+			// Continue to skip adding this invite to annotatedInvites
+			continue
+		} else if category == keybase1.TeamInviteCategory_SEITAN {
+			name, err = AnnotateSeitanInvite(ctx, team, invite)
+			if err != nil {
+				// There are seitan invites in the wild from before https://github.com/keybase/client/pull/9816
+				// These can no longer be decrypted, we hide them.
+				g.Log.CDebugf(ctx, "error annotating seitan invite (%v): %v", id, err)
+				continue
+			}
+		}
+
+		annotatedInvites[id] = keybase1.AnnotatedTeamInvite{
+			Role:            invite.Role,
+			Id:              invite.Id,
+			Type:            invite.Type,
+			Name:            name,
+			Uv:              uv,
+			Inviter:         invite.Inviter,
+			InviterUsername: username.String(),
+			TeamName:        teamName,
+		}
+	}
+
+	return annotatedInvites, nil
+}
+
 func parseInvitesNoAnnotate(ctx context.Context, g *libkb.GlobalContext, team *Team, res *keybase1.AnnotatedTeamList) {
 	invites := team.chain().inner.ActiveInvites
 	for invID, invite := range invites {

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -524,6 +524,8 @@ func AnnotateInvites(ctx context.Context, g *libkb.GlobalContext, team *Team) (m
 				active = false
 			}
 			name = keybase1.TeamInviteName(up.Username)
+			// TODO: Add support for full name here. FullName field in
+			// AnnotatedTeamInvite.
 		} else if category == keybase1.TeamInviteCategory_SEITAN {
 			name, err = AnnotateSeitanInvite(ctx, team, invite)
 			if err != nil {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -133,6 +133,12 @@ func membersFromInvites(ctx context.Context, g *libkb.GlobalContext, invites Ann
 		}
 	}
 
+	if len(uids) == 0 {
+		// Invites had no keybase-type invites that could be mapped to
+		// members.
+		return nil
+	}
+
 	namePkgs, err := uidmap.MapUIDsReturnMap(ctx, g.UIDMapper, g, uids, 0, 0, true)
 	if err != nil {
 		// UIDMap returned an error, but there may be useful data in the result.

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -12,7 +12,6 @@ import (
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/uidmap"
 )
 
 func LoadTeamPlusApplicationKeys(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID,
@@ -70,18 +69,12 @@ func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepo
 		return res, err
 	}
 
-	tracer.Stage("annotate")
-	annotatedInvites, err := AnnotateInvites(ctx, g, t)
+	tracer.Stage("invites")
+	annotatedInvites, err := AnnotateInvitesUIDMapper(ctx, g, t, &res.Members)
 	if err != nil {
 		return res, err
 	}
 	res.AnnotatedActiveInvites = annotatedInvites
-
-	tracer.Stage("invites")
-	err = membersFromInvites(ctx, g, annotatedInvites, &res.Members)
-	if err != nil {
-		return res, err
-	}
 
 	res.Settings.Open = t.IsOpen()
 	res.Settings.JoinAs = t.chain().inner.OpenTeamJoinAs
@@ -110,85 +103,6 @@ func members(ctx context.Context, g *libkb.GlobalContext, t *Team, forceRepoll b
 		return keybase1.TeamMembersDetails{}, err
 	}
 	return membersUIDsToUsernames(ctx, g, members, forceRepoll)
-}
-
-// membersFromInvites puts any keybase invites in the members list,
-// passed as pointer to TeamMemberDetails. AnnotatedInviteMap is also
-// mutated - all keybase-type invites that became members are removed.
-// TODO: This is only needed until list.go:AnnotateInvites gets UIDMapper
-// support and can do it by itself.
-func membersFromInvites(ctx context.Context, g *libkb.GlobalContext, invites AnnotatedInviteMap, members *keybase1.TeamMembersDetails) error {
-	// remember invite ids to remove from map
-	var keybaseInviteIDs []keybase1.TeamInviteID
-	// uid to pass to uidmapper to get full names
-	var uids []keybase1.UID
-
-	for _, invite := range invites {
-		cat, err := invite.Type.C()
-		if err != nil {
-			return err
-		}
-		if cat == keybase1.TeamInviteCategory_KEYBASE && invite.UserActive {
-			uids = append(uids, invite.Uv.Uid)
-		}
-	}
-
-	if len(uids) == 0 {
-		// Invites had no keybase-type invites that could be mapped to
-		// members.
-		return nil
-	}
-
-	namePkgs, err := uidmap.MapUIDsReturnMap(ctx, g.UIDMapper, g, uids, 0, 0, true)
-	if err != nil {
-		// UIDMap returned an error, but there may be useful data in the result.
-		g.Log.CDebugf(ctx, "membersFromInvites: MapUIDsReturnMap returned: %v", err)
-	}
-
-	for invID, invite := range invites {
-		cat, err := invite.Type.C()
-		if err != nil {
-			return err
-		}
-		if cat != keybase1.TeamInviteCategory_KEYBASE {
-			continue
-		}
-
-		// Save inviteID to filter `invites` map after we are done.
-		keybaseInviteIDs = append(keybaseInviteIDs, invID)
-
-		if !invite.UserActive {
-			// Skip inactive puk-less members for now. Causes
-			// duplicate usernames in team list which we don't want.
-			continue
-		}
-		details := keybase1.TeamMemberDetails{
-			Uv:       invite.Uv,
-			Username: string(invite.Name),
-			Active:   invite.UserActive,
-			NeedsPUK: true,
-		}
-		if pkg, ok := namePkgs[invite.Uv.Uid]; ok && pkg.FullName != nil {
-			details.FullName = pkg.FullName.FullName
-		}
-
-		switch invite.Role {
-		case keybase1.TeamRole_OWNER:
-			members.Owners = append(members.Owners, details)
-		case keybase1.TeamRole_ADMIN:
-			members.Admins = append(members.Admins, details)
-		case keybase1.TeamRole_WRITER:
-			members.Writers = append(members.Writers, details)
-		case keybase1.TeamRole_READER:
-			members.Readers = append(members.Readers, details)
-		}
-	}
-
-	for _, invID := range keybaseInviteIDs {
-		delete(invites, invID)
-	}
-
-	return nil
 }
 
 func userVersionsToDetails(ctx context.Context, g *libkb.GlobalContext, uvs []keybase1.UserVersion, forceRepoll bool) (ret []keybase1.TeamMemberDetails, err error) {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -200,8 +200,6 @@ protocol teams {
     string inviterUsername;
     string teamName;
     boolean userActive;
-    // Full name may only be available for KEYBASE invites.
-    union { null, FullName } fullName;
   }
 
   // State of a parsed team sigchain.

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -79,6 +79,7 @@ protocol teams {
   record TeamMemberDetails {
     UserVersion uv;
     string username;
+    FullName fullName;
     boolean active;
     @lint("ignore")
     boolean needsPUK;
@@ -199,6 +200,8 @@ protocol teams {
     string inviterUsername;
     string teamName;
     boolean userActive;
+    // Full name may only be available for KEYBASE invites.
+    union { null, FullName } fullName;
   }
 
   // State of a parsed team sigchain.

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1847,7 +1847,7 @@ export type AccountResetAccountRpcParam = ?{|incomingCallMap?: IncomingCallMapTy
 
 export type AnnotatedMemberInfo = {|userID: UID, teamID: TeamID, username: String, fullName: String, fqName: String, isImplicitTeam: Boolean, role: TeamRole, implicit?: ?ImplicitRole, needsPUK: Boolean, memberCount: Int, eldestSeqno: Seqno, active: Boolean|}
 
-export type AnnotatedTeamInvite = {|role: TeamRole, id: TeamInviteID, type: TeamInviteType, name: TeamInviteName, uv: UserVersion, inviter: UserVersion, inviterUsername: String, teamName: String, userActive: Boolean|}
+export type AnnotatedTeamInvite = {|role: TeamRole, id: TeamInviteID, type: TeamInviteType, name: TeamInviteName, uv: UserVersion, inviter: UserVersion, inviterUsername: String, teamName: String, userActive: Boolean, fullName?: ?FullName|}
 
 export type AnnotatedTeamList = {|teams?: ?Array<AnnotatedMemberInfo>, annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}|}
 
@@ -3514,7 +3514,7 @@ export type TeamList = {|teams?: ?Array<MemberInfo>|}
 
 export type TeamMember = {|uid: UID, role: TeamRole, eldestSeqno: Seqno, userEldestSeqno: Seqno|}
 
-export type TeamMemberDetails = {|uv: UserVersion, username: String, active: Boolean, needsPUK: Boolean|}
+export type TeamMemberDetails = {|uv: UserVersion, username: String, fullName: FullName, active: Boolean, needsPUK: Boolean|}
 
 export type TeamMemberOutFromReset = {|teamName: String, resetUser: TeamResetUser|}
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1847,7 +1847,7 @@ export type AccountResetAccountRpcParam = ?{|incomingCallMap?: IncomingCallMapTy
 
 export type AnnotatedMemberInfo = {|userID: UID, teamID: TeamID, username: String, fullName: String, fqName: String, isImplicitTeam: Boolean, role: TeamRole, implicit?: ?ImplicitRole, needsPUK: Boolean, memberCount: Int, eldestSeqno: Seqno, active: Boolean|}
 
-export type AnnotatedTeamInvite = {|role: TeamRole, id: TeamInviteID, type: TeamInviteType, name: TeamInviteName, uv: UserVersion, inviter: UserVersion, inviterUsername: String, teamName: String, userActive: Boolean, fullName?: ?FullName|}
+export type AnnotatedTeamInvite = {|role: TeamRole, id: TeamInviteID, type: TeamInviteType, name: TeamInviteName, uv: UserVersion, inviter: UserVersion, inviterUsername: String, teamName: String, userActive: Boolean|}
 
 export type AnnotatedTeamList = {|teams?: ?Array<AnnotatedMemberInfo>, annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}|}
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -552,13 +552,6 @@
         {
           "type": "boolean",
           "name": "userActive"
-        },
-        {
-          "type": [
-            null,
-            "FullName"
-          ],
-          "name": "fullName"
         }
       ]
     },

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -193,6 +193,10 @@
           "name": "username"
         },
         {
+          "type": "FullName",
+          "name": "fullName"
+        },
+        {
           "type": "boolean",
           "name": "active"
         },
@@ -548,6 +552,13 @@
         {
           "type": "boolean",
           "name": "userActive"
+        },
+        {
+          "type": [
+            null,
+            "FullName"
+          ],
+          "name": "fullName"
         }
       ]
     },

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1847,7 +1847,7 @@ export type AccountResetAccountRpcParam = ?{|incomingCallMap?: IncomingCallMapTy
 
 export type AnnotatedMemberInfo = {|userID: UID, teamID: TeamID, username: String, fullName: String, fqName: String, isImplicitTeam: Boolean, role: TeamRole, implicit?: ?ImplicitRole, needsPUK: Boolean, memberCount: Int, eldestSeqno: Seqno, active: Boolean|}
 
-export type AnnotatedTeamInvite = {|role: TeamRole, id: TeamInviteID, type: TeamInviteType, name: TeamInviteName, uv: UserVersion, inviter: UserVersion, inviterUsername: String, teamName: String, userActive: Boolean|}
+export type AnnotatedTeamInvite = {|role: TeamRole, id: TeamInviteID, type: TeamInviteType, name: TeamInviteName, uv: UserVersion, inviter: UserVersion, inviterUsername: String, teamName: String, userActive: Boolean, fullName?: ?FullName|}
 
 export type AnnotatedTeamList = {|teams?: ?Array<AnnotatedMemberInfo>, annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}|}
 
@@ -3514,7 +3514,7 @@ export type TeamList = {|teams?: ?Array<MemberInfo>|}
 
 export type TeamMember = {|uid: UID, role: TeamRole, eldestSeqno: Seqno, userEldestSeqno: Seqno|}
 
-export type TeamMemberDetails = {|uv: UserVersion, username: String, active: Boolean, needsPUK: Boolean|}
+export type TeamMemberDetails = {|uv: UserVersion, username: String, fullName: FullName, active: Boolean, needsPUK: Boolean|}
 
 export type TeamMemberOutFromReset = {|teamName: String, resetUser: TeamResetUser|}
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1847,7 +1847,7 @@ export type AccountResetAccountRpcParam = ?{|incomingCallMap?: IncomingCallMapTy
 
 export type AnnotatedMemberInfo = {|userID: UID, teamID: TeamID, username: String, fullName: String, fqName: String, isImplicitTeam: Boolean, role: TeamRole, implicit?: ?ImplicitRole, needsPUK: Boolean, memberCount: Int, eldestSeqno: Seqno, active: Boolean|}
 
-export type AnnotatedTeamInvite = {|role: TeamRole, id: TeamInviteID, type: TeamInviteType, name: TeamInviteName, uv: UserVersion, inviter: UserVersion, inviterUsername: String, teamName: String, userActive: Boolean, fullName?: ?FullName|}
+export type AnnotatedTeamInvite = {|role: TeamRole, id: TeamInviteID, type: TeamInviteType, name: TeamInviteName, uv: UserVersion, inviter: UserVersion, inviterUsername: String, teamName: String, userActive: Boolean|}
 
 export type AnnotatedTeamList = {|teams?: ?Array<AnnotatedMemberInfo>, annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}|}
 


### PR DESCRIPTION
Cryptomembers were easy because they already use UIDMapper and thus FullNames were available in FullNamePackage. PUKless members came from AnnotateInvites which uses UPAKLoader. I've factored out Invite->PUKless member mapping code to `service_helper.go:membersFromInvites` and added UIDMapper support there just to get full names. The downside is that it is now two UIDMapper calls per teamGet. 

Long term plan is to use UIDMapper in AnnotateInvites but it's probably blocked on CORE-6885 and CORE-6788 - cache issues in AnnotateInvites would be bad because impteams uses it in `ImplicitTeamDisplayName`.