### PR TITLE
allow logged-out users to load (public) teams

### DIFF
--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -511,6 +511,10 @@ func (e LoginRequiredError) Error() string {
 	return msg
 }
 
+func NewLoginRequiredError(s string) error {
+	return LoginRequiredError{s}
+}
+
 type ReloginRequiredError struct{}
 
 func (e ReloginRequiredError) Error() string {

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -62,6 +62,9 @@ func (l *TeamLoader) Load(ctx context.Context, lArg keybase1.LoadTeamArg) (res *
 	if err != nil {
 		return nil, err
 	}
+	if me.IsNil() && !lArg.Public {
+		return nil, libkb.NewLoginRequiredError("login required to load a private team")
+	}
 	return l.load1(ctx, me, lArg)
 }
 
@@ -223,6 +226,8 @@ type load2ArgT struct {
 	// Load1 should never ever return a secret-less TeamData.
 	readSubteamID *keybase1.TeamID
 
+	// If the user is logged out, this will be a nil UserVersion, meaning
+	/// me.IsNil() will be true.
 	me keybase1.UserVersion
 }
 

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -114,9 +114,15 @@ func (l *LoaderContextG) getLinksFromServer(ctx context.Context,
 }
 
 func (l *LoaderContextG) getMe(ctx context.Context) (res keybase1.UserVersion, err error) {
+	uid := l.G().ActiveDevice.UID()
+	// If we're logged out, we still should be able to access the team loader
+	// for public teams. So we'll just return a nil UID here, and it should just work.
+	if uid.IsNil() {
+		return res, nil
+	}
 	loadMeArg := libkb.NewLoadUserArg(l.G()).
 		WithNetContext(ctx).
-		WithUID(l.G().Env.GetUID()).
+		WithUID(uid).
 		WithSelf(true).
 		WithPublicKeyOptional()
 	upak, _, err := l.G().GetUPAKLoader().LoadV2(loadMeArg)


### PR DESCRIPTION
- don't use Env.GetUID(), use ActiveDevice.UID()