### PR TITLE
Load messages when previewing a channel

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -986,7 +986,12 @@ function _joinConversation(action: ChatGen.JoinConversationPayload) {
 
 function _previewChannel(action: ChatGen.PreviewChannelPayload) {
   const convID = Constants.keyToConversationID(action.payload.conversationIDKey)
-  return Saga.call(RPCChatTypes.localPreviewConversationByIDLocalRpcPromise, {convID})
+  return Saga.sequentially([
+    Saga.call(RPCChatTypes.localPreviewConversationByIDLocalRpcPromise, {convID}),
+    Saga.put(
+      ChatGen.createSelectConversation({conversationIDKey: action.payload.conversationIDKey, fromUser: true})
+    ),
+  ])
 }
 
 function _resetChatWithoutThem(action: ChatGen.ResetChatWithoutThemPayload, state: TypedState) {


### PR DESCRIPTION
@keybase/react-hackers apparently we weren't doing this so messages would never load when you previewed the channel. Any idea how this used to work, @buoyad ?