### PR TITLE
UIDMapper cache refreshers to bust the server cache

### DIFF
--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -162,12 +162,12 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 	})
 
 	if c.json {
-		b, err := json.MarshalIndent(list, "", "    ")
+		b, err := json.Marshal(list)
 		if err != nil {
 			return err
 		}
-		dui := c.G().UI.GetDumbOutputUI()
-		_, err = dui.Printf(string(b) + "\n")
+		tui := c.G().UI.GetTerminalUI()
+		err = tui.OutputDesc(OutputDescriptorTeamList, string(b)+"\n")
 		return err
 	}
 

--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -67,4 +67,5 @@ const (
 	OutputDescriptorEndageredTLFs
 	OutputDescriptorHomeDump
 	OutputDescriptorBadgeDump
+	OutputDescriptorTeamList
 )

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -682,6 +682,13 @@ type UIDMapper interface {
 	// ClearUID is called to clear the given UID out of the cache, if the given eldest
 	// seqno doesn't match what's currently cached.
 	ClearUIDAtEldestSeqno(context.Context, UIDMapperContext, keybase1.UID, keybase1.Seqno) error
+
+	// InformOfEldestSeqno informs the mapper of an up-to-date (uid,eldestSeqno) pair.
+	// If the cache has a different value, it will clear the cache and then plumb
+	// the pair all the way through to the server, whose cache may also be in need
+	// of busting. Will return true if the cached value was up-to-date, and false
+	// otherwise.
+	InformOfEldestSeqno(context.Context, UIDMapperContext, keybase1.UserVersion) (bool, error)
 }
 
 type ChatHelper interface {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -488,6 +488,10 @@ func (t TestUIDMapper) CheckUIDAgainstUsername(uid keybase1.UID, un NormalizedUs
 	return true
 }
 
+func (t TestUIDMapper) InformOfEldestSeqno(ctx context.Context, g UIDMapperContext, uv keybase1.UserVersion) (bool, error) {
+	return true, nil
+}
+
 func (t TestUIDMapper) MapUIDsToUsernamePackages(ctx context.Context, g UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networkTimeBudget time.Duration, forceNetworkForFullNames bool) ([]UsernamePackage, error) {
 	var res []UsernamePackage
 	for _, uid := range uids {

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1334,26 +1334,28 @@ func (o TeamRefreshers) DeepCopy() TeamRefreshers {
 }
 
 type LoadTeamArg struct {
-	ID              TeamID         `codec:"ID" json:"ID"`
-	Name            string         `codec:"name" json:"name"`
-	Public          bool           `codec:"public" json:"public"`
-	NeedAdmin       bool           `codec:"needAdmin" json:"needAdmin"`
-	Refreshers      TeamRefreshers `codec:"refreshers" json:"refreshers"`
-	ForceFullReload bool           `codec:"forceFullReload" json:"forceFullReload"`
-	ForceRepoll     bool           `codec:"forceRepoll" json:"forceRepoll"`
-	StaleOK         bool           `codec:"staleOK" json:"staleOK"`
+	ID               TeamID         `codec:"ID" json:"ID"`
+	Name             string         `codec:"name" json:"name"`
+	Public           bool           `codec:"public" json:"public"`
+	NeedAdmin        bool           `codec:"needAdmin" json:"needAdmin"`
+	RefreshUIDMapper bool           `codec:"refreshUIDMapper" json:"refreshUIDMapper"`
+	Refreshers       TeamRefreshers `codec:"refreshers" json:"refreshers"`
+	ForceFullReload  bool           `codec:"forceFullReload" json:"forceFullReload"`
+	ForceRepoll      bool           `codec:"forceRepoll" json:"forceRepoll"`
+	StaleOK          bool           `codec:"staleOK" json:"staleOK"`
 }
 
 func (o LoadTeamArg) DeepCopy() LoadTeamArg {
 	return LoadTeamArg{
-		ID:              o.ID.DeepCopy(),
-		Name:            o.Name,
-		Public:          o.Public,
-		NeedAdmin:       o.NeedAdmin,
-		Refreshers:      o.Refreshers.DeepCopy(),
-		ForceFullReload: o.ForceFullReload,
-		ForceRepoll:     o.ForceRepoll,
-		StaleOK:         o.StaleOK,
+		ID:               o.ID.DeepCopy(),
+		Name:             o.Name,
+		Public:           o.Public,
+		NeedAdmin:        o.NeedAdmin,
+		RefreshUIDMapper: o.RefreshUIDMapper,
+		Refreshers:       o.Refreshers.DeepCopy(),
+		ForceFullReload:  o.ForceFullReload,
+		ForceRepoll:      o.ForceRepoll,
+		StaleOK:          o.StaleOK,
 	}
 }
 

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -86,9 +86,10 @@ func GetTeamByNameForTest(ctx context.Context, g *libkb.GlobalContext, name stri
 func GetMaybeAdminByStringName(ctx context.Context, g *libkb.GlobalContext, name string, public bool) (*Team, error) {
 	// Find out our up-to-date role.
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
-		Name:        name,
-		Public:      public,
-		ForceRepoll: true,
+		Name:             name,
+		Public:           public,
+		ForceRepoll:      true,
+		RefreshUIDMapper: true,
 	})
 	if err != nil {
 		return nil, fixupTeamGetError(ctx, g, err, name, public)

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -76,10 +76,11 @@ func verifyMemberRoleInTeam(ctx context.Context, userID keybase1.UID, expectedRo
 // trigger a reload with ForceRepoll if cached state does not match.
 func getTeamForMember(ctx context.Context, g *libkb.GlobalContext, member keybase1.MemberInfo, needAdmin bool) (team *Team, uv keybase1.UserVersion, err error) {
 	team, err = Load(ctx, g, keybase1.LoadTeamArg{
-		ID:          member.TeamID,
-		NeedAdmin:   needAdmin,
-		Public:      member.TeamID.IsPublic(),
-		ForceRepoll: false,
+		ID:               member.TeamID,
+		NeedAdmin:        needAdmin,
+		Public:           member.TeamID.IsPublic(),
+		ForceRepoll:      false,
+		RefreshUIDMapper: true,
 	})
 	if err != nil {
 		return nil, uv, err

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -21,7 +21,15 @@ func Load(ctx context.Context, g *libkb.GlobalContext, lArg keybase1.LoadTeamArg
 	if err != nil {
 		return nil, err
 	}
-	return NewTeam(ctx, g, teamData), nil
+	ret := NewTeam(ctx, g, teamData)
+
+	if lArg.RefreshUIDMapper {
+		// If we just loaded the group, then inform the UIDMapper of any UID->EldestSeqno
+		// mappings, so that we're guaranteed they aren't stale.
+		ret.refreshUIDMapper(ctx, g)
+	}
+
+	return ret, nil
 }
 
 // Loader of keybase1.TeamData objects. Handles caching.

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -107,7 +107,6 @@ protocol teams {
   @typedef("string")
   record UserVersionPercentForm {}
 
-
   record TeamChangeReq {
     array<UserVersion> owners;
     array<UserVersion> admins;
@@ -458,6 +457,12 @@ protocol teams {
     // may not work even if the loading user is an admin.
     boolean needAdmin;
 
+    // Whether we should refresh the UIDMapper with UID/Eldest pairs
+    // needed for display of the user's reset status. This flag is expensive,
+    // since it can incur a disk read per team member (via LevelDB cache).
+    // So only use it when you need to display all the team's members.
+    boolean refreshUIDMapper;
+
     TeamRefreshers refreshers;
 
     boolean forceFullReload;      // Ignore local data and fetch from the server.
@@ -688,7 +693,7 @@ protocol teams {
   TeamAndMemberShowcase getTeamAndMemberShowcase(string name);
   void setTeamShowcase(string name, union { null, boolean } isShowcased, union { null, string } description, union { null, boolean } anyMemberShowcase);
   void setTeamMemberShowcase(string name, boolean isShowcased);
-  
+
   record TeamOperation {
     boolean manageMembers;
     boolean manageSubteams;

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2540,7 +2540,7 @@ export type ListResult = {|files?: ?Array<File>|}
 
 export type LoadDeviceErr = {|where: String, desc: String|}
 
-export type LoadTeamArg = {|ID: TeamID, name: String, public: Boolean, needAdmin: Boolean, refreshers: TeamRefreshers, forceFullReload: Boolean, forceRepoll: Boolean, staleOK: Boolean|}
+export type LoadTeamArg = {|ID: TeamID, name: String, public: Boolean, needAdmin: Boolean, refreshUIDMapper: Boolean, refreshers: TeamRefreshers, forceFullReload: Boolean, forceRepoll: Boolean, staleOK: Boolean|}
 
 export type LockContext = {|requireLockID: LockID, releaseAfterSuccess: Boolean|}
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1106,6 +1106,10 @@
           "name": "needAdmin"
         },
         {
+          "type": "boolean",
+          "name": "refreshUIDMapper"
+        },
+        {
           "type": "TeamRefreshers",
           "name": "refreshers"
         },

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2540,7 +2540,7 @@ export type ListResult = {|files?: ?Array<File>|}
 
 export type LoadDeviceErr = {|where: String, desc: String|}
 
-export type LoadTeamArg = {|ID: TeamID, name: String, public: Boolean, needAdmin: Boolean, refreshers: TeamRefreshers, forceFullReload: Boolean, forceRepoll: Boolean, staleOK: Boolean|}
+export type LoadTeamArg = {|ID: TeamID, name: String, public: Boolean, needAdmin: Boolean, refreshUIDMapper: Boolean, refreshers: TeamRefreshers, forceFullReload: Boolean, forceRepoll: Boolean, staleOK: Boolean|}
 
 export type LockContext = {|requireLockID: LockID, releaseAfterSuccess: Boolean|}
 


### PR DESCRIPTION
- when we load teams for display, we tell the UIDmapper of the high eldest we know for a user (ignoring =0 resets)
- if that value is less than what's cached, we bust the cache, and tell the server to bust its cache
- a test to confirm this worked; i confirmed the test worked by breaking it on the client and server side and making sure the test failed
- all of this is very complicated; we could, instead, only apply the Alive check against the UIDMapper value when the UIDMapper's eldest is greater than the team's. I think that would achieve roughly the same effect with like 200 less LoC. However, let's give this a try
- note we're still not getting the eldest_seqno=0 case perfect anyways. it's because if the team say eldest=0 and the UIDmapper disagrees, or vice versa, we don't know who is right. the right thing to do, long run, is to have eldest_seqno given by a <Seqno,bool> pair, meaning <latestEldest,isAlive>. That would resolve any amibuguities. but it's a huge change
