### PR TITLE
Servertrust fast team list

### DIFF
--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -147,11 +147,11 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 	var err error
 	var list keybase1.AnnotatedTeamList
 	if !c.showAll {
-		arg := keybase1.TeamListArg{
+		arg := keybase1.TeamListUnverifiedArg{
 			UserAssertion:        c.userAssertion,
 			IncludeImplicitTeams: c.includeImplicitTeams,
 		}
-		list, err = cli.TeamList(context.Background(), arg)
+		list, err = cli.TeamListUnverified(context.Background(), arg)
 	} else {
 		arg := keybase1.TeamListTeammatesArg{
 			IncludeImplicitTeams: c.includeImplicitTeams,

--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -144,12 +144,21 @@ func (c *CmdTeamListMemberships) runGet(cli keybase1.TeamsClient) error {
 }
 
 func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
-	arg := keybase1.TeamListArg{
-		UserAssertion:        c.userAssertion,
-		All:                  c.showAll,
-		IncludeImplicitTeams: c.includeImplicitTeams,
+	var err error
+	var list keybase1.AnnotatedTeamList
+	if !c.showAll {
+		arg := keybase1.TeamListArg{
+			UserAssertion:        c.userAssertion,
+			IncludeImplicitTeams: c.includeImplicitTeams,
+		}
+		list, err = cli.TeamList(context.Background(), arg)
+	} else {
+		arg := keybase1.TeamListTeammatesArg{
+			IncludeImplicitTeams: c.includeImplicitTeams,
+		}
+		list, err = cli.TeamListTeammates(context.Background(), arg)
 	}
-	list, err := cli.TeamList(context.Background(), arg)
+
 	if err != nil {
 		return err
 	}

--- a/go/client/team_api_handler.go
+++ b/go/client/team_api_handler.go
@@ -358,11 +358,11 @@ func (t *teamAPIHandler) listUserMemberships(ctx context.Context, c Call, w io.W
 		return t.encodeErr(c, err, w)
 	}
 
-	arg := keybase1.TeamListArg{
+	arg := keybase1.TeamListUnverifiedArg{
 		UserAssertion:        opts.UserAssertion,
 		IncludeImplicitTeams: opts.IncludeImplicitTeams,
 	}
-	list, err := t.cli.TeamList(ctx, arg)
+	list, err := t.cli.TeamListUnverified(ctx, arg)
 	if err != nil {
 		return t.encodeErr(c, err, w)
 	}

--- a/go/client/team_api_handler.go
+++ b/go/client/team_api_handler.go
@@ -304,10 +304,7 @@ func (t *teamAPIHandler) leaveTeam(ctx context.Context, c Call, w io.Writer) err
 }
 
 func (t *teamAPIHandler) listSelfMemberships(ctx context.Context, c Call, w io.Writer) error {
-	arg := keybase1.TeamListArg{
-		All: true,
-	}
-	list, err := t.cli.TeamList(ctx, arg)
+	list, err := t.cli.TeamListTeammates(ctx, keybase1.TeamListTeammatesArg{})
 	if err != nil {
 		return t.encodeErr(c, err, w)
 	}

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1845,7 +1845,7 @@ type TeamImplicitAdminsArg struct {
 	TeamName  string `codec:"teamName" json:"teamName"`
 }
 
-type TeamListArg struct {
+type TeamListUnverifiedArg struct {
 	SessionID            int    `codec:"sessionID" json:"sessionID"`
 	UserAssertion        string `codec:"userAssertion" json:"userAssertion"`
 	IncludeImplicitTeams bool   `codec:"includeImplicitTeams" json:"includeImplicitTeams"`
@@ -2034,7 +2034,7 @@ type TeamsInterface interface {
 	TeamCreateWithSettings(context.Context, TeamCreateWithSettingsArg) (TeamCreateResult, error)
 	TeamGet(context.Context, TeamGetArg) (TeamDetails, error)
 	TeamImplicitAdmins(context.Context, TeamImplicitAdminsArg) ([]TeamMemberDetails, error)
-	TeamList(context.Context, TeamListArg) (AnnotatedTeamList, error)
+	TeamListUnverified(context.Context, TeamListUnverifiedArg) (AnnotatedTeamList, error)
 	TeamListTeammates(context.Context, TeamListTeammatesArg) (AnnotatedTeamList, error)
 	TeamListVerified(context.Context, TeamListVerifiedArg) (AnnotatedTeamList, error)
 	TeamListSubteamsRecursive(context.Context, TeamListSubteamsRecursiveArg) ([]TeamIDAndName, error)
@@ -2140,18 +2140,18 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"teamList": {
+			"teamListUnverified": {
 				MakeArg: func() interface{} {
-					ret := make([]TeamListArg, 1)
+					ret := make([]TeamListUnverifiedArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]TeamListArg)
+					typedArgs, ok := args.(*[]TeamListUnverifiedArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]TeamListArg)(nil), args)
+						err = rpc.NewTypeError((*[]TeamListUnverifiedArg)(nil), args)
 						return
 					}
-					ret, err = i.TeamList(ctx, (*typedArgs)[0])
+					ret, err = i.TeamListUnverified(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -2696,8 +2696,8 @@ func (c TeamsClient) TeamImplicitAdmins(ctx context.Context, __arg TeamImplicitA
 	return
 }
 
-func (c TeamsClient) TeamList(ctx context.Context, __arg TeamListArg) (res AnnotatedTeamList, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamList", []interface{}{__arg}, &res)
+func (c TeamsClient) TeamListUnverified(ctx context.Context, __arg TeamListUnverifiedArg) (res AnnotatedTeamList, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamListUnverified", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1848,8 +1848,12 @@ type TeamImplicitAdminsArg struct {
 type TeamListArg struct {
 	SessionID            int    `codec:"sessionID" json:"sessionID"`
 	UserAssertion        string `codec:"userAssertion" json:"userAssertion"`
-	All                  bool   `codec:"all" json:"all"`
 	IncludeImplicitTeams bool   `codec:"includeImplicitTeams" json:"includeImplicitTeams"`
+}
+
+type TeamListTeammatesArg struct {
+	SessionID            int  `codec:"sessionID" json:"sessionID"`
+	IncludeImplicitTeams bool `codec:"includeImplicitTeams" json:"includeImplicitTeams"`
 }
 
 type TeamListVerifiedArg struct {
@@ -2031,6 +2035,7 @@ type TeamsInterface interface {
 	TeamGet(context.Context, TeamGetArg) (TeamDetails, error)
 	TeamImplicitAdmins(context.Context, TeamImplicitAdminsArg) ([]TeamMemberDetails, error)
 	TeamList(context.Context, TeamListArg) (AnnotatedTeamList, error)
+	TeamListTeammates(context.Context, TeamListTeammatesArg) (AnnotatedTeamList, error)
 	TeamListVerified(context.Context, TeamListVerifiedArg) (AnnotatedTeamList, error)
 	TeamListSubteamsRecursive(context.Context, TeamListSubteamsRecursiveArg) ([]TeamIDAndName, error)
 	TeamChangeMembership(context.Context, TeamChangeMembershipArg) error
@@ -2147,6 +2152,22 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.TeamList(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"teamListTeammates": {
+				MakeArg: func() interface{} {
+					ret := make([]TeamListTeammatesArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]TeamListTeammatesArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]TeamListTeammatesArg)(nil), args)
+						return
+					}
+					ret, err = i.TeamListTeammates(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -2677,6 +2698,11 @@ func (c TeamsClient) TeamImplicitAdmins(ctx context.Context, __arg TeamImplicitA
 
 func (c TeamsClient) TeamList(ctx context.Context, __arg TeamListArg) (res AnnotatedTeamList, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamList", []interface{}{__arg}, &res)
+	return
+}
+
+func (c TeamsClient) TeamListTeammates(ctx context.Context, __arg TeamListTeammatesArg) (res AnnotatedTeamList, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamListTeammates", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -125,6 +125,20 @@ func (h *TeamsHandler) TeamList(ctx context.Context, arg keybase1.TeamListArg) (
 	return *x, nil
 }
 
+func (h *TeamsHandler) TeamListVerified(ctx context.Context, arg keybase1.TeamListVerifiedArg) (res keybase1.AnnotatedTeamList, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamListVerified(%s)", arg.UserAssertion), func() error { return err })()
+	x, err := teams.ListTeams(ctx, h.G().ExternalG(), keybase1.TeamListArg{
+		SessionID:            arg.SessionID,
+		UserAssertion:        arg.UserAssertion,
+		IncludeImplicitTeams: arg.IncludeImplicitTeams,
+	})
+	if err != nil {
+		return keybase1.AnnotatedTeamList{}, err
+	}
+	return *x, nil
+}
+
 func (h *TeamsHandler) TeamListSubteamsRecursive(ctx context.Context, arg keybase1.TeamListSubteamsRecursiveArg) (res []keybase1.TeamIDAndName, err error) {
 	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamListSubteamsRecursive(%s)", arg.ParentTeamName), func() error { return err })()

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -115,7 +115,7 @@ func (h *TeamsHandler) TeamImplicitAdmins(ctx context.Context, arg keybase1.Team
 	return teams.ImplicitAdmins(ctx, h.G().ExternalG(), teamID)
 }
 
-func (h *TeamsHandler) TeamList(ctx context.Context, arg keybase1.TeamListArg) (res keybase1.AnnotatedTeamList, err error) {
+func (h *TeamsHandler) TeamListUnverified(ctx context.Context, arg keybase1.TeamListUnverifiedArg) (res keybase1.AnnotatedTeamList, err error) {
 	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamList(%s)", arg.UserAssertion), func() error { return err })()
 	x, err := teams.ListTeamsUnverified(ctx, h.G().ExternalG(), arg)
@@ -138,11 +138,7 @@ func (h *TeamsHandler) TeamListTeammates(ctx context.Context, arg keybase1.TeamL
 func (h *TeamsHandler) TeamListVerified(ctx context.Context, arg keybase1.TeamListVerifiedArg) (res keybase1.AnnotatedTeamList, err error) {
 	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamListVerified(%s)", arg.UserAssertion), func() error { return err })()
-	x, err := teams.ListTeams(ctx, h.G().ExternalG(), keybase1.TeamListArg{
-		SessionID:            arg.SessionID,
-		UserAssertion:        arg.UserAssertion,
-		IncludeImplicitTeams: arg.IncludeImplicitTeams,
-	})
+	x, err := teams.ListTeamsVerified(ctx, h.G().ExternalG(), arg)
 	if err != nil {
 		return keybase1.AnnotatedTeamList{}, err
 	}

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -118,7 +118,17 @@ func (h *TeamsHandler) TeamImplicitAdmins(ctx context.Context, arg keybase1.Team
 func (h *TeamsHandler) TeamList(ctx context.Context, arg keybase1.TeamListArg) (res keybase1.AnnotatedTeamList, err error) {
 	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamList(%s)", arg.UserAssertion), func() error { return err })()
-	x, err := teams.List(ctx, h.G().ExternalG(), arg)
+	x, err := teams.ListTeamsUnverified(ctx, h.G().ExternalG(), arg)
+	if err != nil {
+		return keybase1.AnnotatedTeamList{}, err
+	}
+	return *x, nil
+}
+
+func (h *TeamsHandler) TeamListTeammates(ctx context.Context, arg keybase1.TeamListTeammatesArg) (res keybase1.AnnotatedTeamList, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamListTeammates(%t)", arg.IncludeImplicitTeams), func() error { return err })()
+	x, err := teams.ListAll(ctx, h.G().ExternalG(), arg)
 	if err != nil {
 		return keybase1.AnnotatedTeamList{}, err
 	}

--- a/go/systests/team_list_test.go
+++ b/go/systests/team_list_test.go
@@ -117,15 +117,24 @@ func TestTeamList(t *testing.T) {
 
 	// Examine results from TeamList (mostly MemberCount)
 
-	list, err := teamCli.TeamList(context.TODO(), keybase1.TeamListArg{})
+	check := func(list *keybase1.AnnotatedTeamList) {
+		require.Equal(t, 1, len(list.Teams))
+		require.Equal(t, 0, len(list.AnnotatedActiveInvites))
+
+		teamInfo := list.Teams[0]
+		require.Equal(t, team.name, teamInfo.FqName)
+		require.Equal(t, 5, teamInfo.MemberCount)
+	}
+
+	list, err := teamCli.TeamListVerified(context.TODO(), keybase1.TeamListVerifiedArg{})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(list.Teams))
-	require.Equal(t, 0, len(list.AnnotatedActiveInvites))
+	check(&list)
 
-	teamInfo := list.Teams[0]
-	require.Equal(t, team.name, teamInfo.FqName)
-	require.Equal(t, 5, teamInfo.MemberCount)
+	list, err = teamCli.TeamListUnverified(context.TODO(), keybase1.TeamListUnverifiedArg{})
+	require.NoError(t, err)
+
+	check(&list)
 }
 
 func TestTeamDuplicateUIDList(t *testing.T) {
@@ -194,7 +203,7 @@ func TestTeamDuplicateUIDList(t *testing.T) {
 	check(&list)
 
 	t.Logf("Calling TeamList")
-	list, err = teamCli.TeamList(context.TODO(), keybase1.TeamListArg{})
+	list, err = teamCli.TeamListUnverified(context.TODO(), keybase1.TeamListUnverifiedArg{})
 	require.NoError(t, err)
 
 	check(&list)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -349,7 +349,7 @@ func (u *userPlusDevice) acceptInviteOrRequestAccess(tokenOrName string) keybase
 
 func (u *userPlusDevice) teamList(userAssertion string, all, includeImplicitTeams bool) keybase1.AnnotatedTeamList {
 	cli := u.teamsClient
-	res, err := cli.TeamList(context.TODO(), keybase1.TeamListArg{
+	res, err := cli.TeamListUnverified(context.TODO(), keybase1.TeamListUnverifiedArg{
 		UserAssertion:        userAssertion,
 		IncludeImplicitTeams: includeImplicitTeams,
 	})

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -351,7 +351,15 @@ func (u *userPlusDevice) teamList(userAssertion string, all, includeImplicitTeam
 	cli := u.teamsClient
 	res, err := cli.TeamList(context.TODO(), keybase1.TeamListArg{
 		UserAssertion:        userAssertion,
-		All:                  all,
+		IncludeImplicitTeams: includeImplicitTeams,
+	})
+	require.NoError(u.tc.T, err)
+	return res
+}
+
+func (u *userPlusDevice) teamListTeammates(includeImplicitTeams bool) keybase1.AnnotatedTeamList {
+	cli := u.teamsClient
+	res, err := cli.TeamListTeammates(context.TODO(), keybase1.TeamListTeammatesArg{
 		IncludeImplicitTeams: includeImplicitTeams,
 	})
 	require.NoError(u.tc.T, err)

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -122,8 +122,8 @@ func getUsernameAndFullName(ctx context.Context, g *libkb.GlobalContext, uid key
 	return username, fullName, err
 }
 
-func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg) (*keybase1.AnnotatedTeamList, error) {
-	tracer := g.CTimeTracer(ctx, "TeamList.ListTeams")
+func ListTeamsVerified(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListVerifiedArg) (*keybase1.AnnotatedTeamList, error) {
+	tracer := g.CTimeTracer(ctx, "TeamList.ListTeamsVerified")
 	defer tracer.Finish()
 
 	tracer.Stage("Resolve QueryUID")

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -235,6 +235,10 @@ func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamLis
 
 		anMemberInfo.MemberCount = len(memberUIDs)
 		res.Teams = append(res.Teams, *anMemberInfo)
+
+		if anMemberInfo.MemberCount != memberInfo.MemberCount {
+			g.Log.CDebugf(ctx, "| Disagreed with the server about member count for %q. Server says %d, we think %d", team.ID, memberInfo.memberCount, anMemberInfo.MemberCount)
+		}
 	}
 
 	if len(res.Teams) == 0 && !expectEmptyList {
@@ -362,7 +366,8 @@ func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg)
 	if arg.All {
 		return ListAll(ctx, g, arg)
 	}
-	return ListTeams(ctx, g, arg)
+
+	return ListTeamsFast(ctx, g, arg)
 }
 
 func ListSubteamsRecursive(ctx context.Context, g *libkb.GlobalContext, parentTeamName string, forceRepoll bool) (res []keybase1.TeamIDAndName, err error) {

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -246,7 +246,7 @@ func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamLis
 	return res, nil
 }
 
-func ListAll(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg) (*keybase1.AnnotatedTeamList, error) {
+func ListAll(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListTeammatesArg) (*keybase1.AnnotatedTeamList, error) {
 	tracer := g.CTimeTracer(ctx, "TeamList.ListAll")
 	defer tracer.Finish()
 
@@ -358,14 +358,6 @@ func ListAll(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListA
 	}
 
 	return res, nil
-}
-
-func List(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg) (*keybase1.AnnotatedTeamList, error) {
-	if arg.All {
-		return ListAll(ctx, g, arg)
-	}
-
-	return ListTeamsFast(ctx, g, arg)
 }
 
 func ListSubteamsRecursive(ctx context.Context, g *libkb.GlobalContext, parentTeamName string, forceRepoll bool) (res []keybase1.TeamIDAndName, err error) {

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -237,7 +237,7 @@ func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamLis
 		res.Teams = append(res.Teams, *anMemberInfo)
 
 		if anMemberInfo.MemberCount != memberInfo.MemberCount {
-			g.Log.CDebugf(ctx, "| Disagreed with the server about member count for %q. Server says %d, we think %d", team.ID, memberInfo.memberCount, anMemberInfo.MemberCount)
+			g.Log.CDebugf(ctx, "| Disagreed with the server about member count for %q. Server says %d, we think %d", team.ID, memberInfo.MemberCount, anMemberInfo.MemberCount)
 		}
 	}
 

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -215,16 +215,6 @@ func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamLis
 			continue
 		}
 
-		// See "TODO" after this for-loop.
-		/*
-			for _, uv := range members.AllUserVersions() {
-				membersForTeams = append(membersForTeams, pendingTeamMember{
-					team: team.ID,
-					uv:   uv,
-				})
-			}
-		*/
-
 		memberUIDs := make(map[keybase1.UID]bool)
 		for _, uv := range members.AllUserVersions() {
 			memberUIDs[uv.Uid] = true
@@ -246,12 +236,6 @@ func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamLis
 				}
 
 				memberUIDs[uv.Uid] = true
-				/*
-					membersForTeams = append(membersForTeams, pendingTeamMember{
-						team: team.ID,
-						uv:   uv,
-					})
-				*/
 			}
 
 		}
@@ -268,33 +252,6 @@ func ListTeams(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamLis
 	for _, member := range membersForTeams {
 		uids = append(uids, member.uv.Uid)
 	}
-
-	// TODO: For now, we decided that reset-user members still count
-	// towards final team member count. If we want to change this
-	// decision, commented out is code to check members with UIDMapper
-	// and only count non-reset members as well as non-reset pukless
-	// members.
-	/*
-		namePkgs, err := uidmap.MapUIDsReturnMap(ctx, g.UIDMapper, g, uids, 0, 10*time.Second, true)
-		if err != nil {
-			g.Log.CWarningf(ctx, "| Unable to verify team members - member counts were not loaded: %v", err)
-			return res, nil
-		}
-
-		for _, member := range membersForTeams {
-			pkg := namePkgs[member.uv.Uid]
-			var memberReset bool
-			if pkg.FullName != nil && pkg.FullName.EldestSeqno != member.uv.EldestSeqno {
-				memberReset = true
-			}
-
-			if !memberReset {
-				if i, ok := teamPositionInList[member.team]; ok {
-					res.Teams[i].MemberCount++
-				}
-			}
-		}
-	*/
 
 	if len(res.Teams) == 0 && !expectEmptyList {
 		return res, fmt.Errorf("multiple errors while loading team list")

--- a/go/teams/list_fast.go
+++ b/go/teams/list_fast.go
@@ -17,8 +17,8 @@ import (
 
 // See also: teams/list.go
 
-func ListTeamsFast(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg) (*keybase1.AnnotatedTeamList, error) {
-	tracer := g.CTimeTracer(ctx, "TeamList.ListTeamsFast")
+func ListTeamsUnverified(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg) (*keybase1.AnnotatedTeamList, error) {
+	tracer := g.CTimeTracer(ctx, "TeamList.ListTeamsUnverified")
 	defer tracer.Finish()
 
 	tracer.Stage("Resolve QueryUID")
@@ -63,7 +63,7 @@ func ListTeamsFast(ctx context.Context, g *libkb.GlobalContext, arg keybase1.Tea
 
 	for _, memberInfo := range teams {
 		if memberInfo.IsImplicitTeam && !arg.IncludeImplicitTeams {
-			g.Log.CDebugf(ctx, "| ListTeamsFast skipping implicit team: server-team:%v server-uid:%v", memberInfo.TeamID, memberInfo.UserID)
+			g.Log.CDebugf(ctx, "| ListTeamsUnverified skipping implicit team: server-team:%v server-uid:%v", memberInfo.TeamID, memberInfo.UserID)
 			continue
 		}
 

--- a/go/teams/list_fast.go
+++ b/go/teams/list_fast.go
@@ -37,7 +37,7 @@ func ListTeamsFast(ctx context.Context, g *libkb.GlobalContext, arg keybase1.Tea
 	}
 
 	tracer.Stage("Server")
-	teams, err := getTeamsListFromServer(ctx, g, queryUID, false)
+	teams, err := getTeamsListFromServer(ctx, g, queryUID, false /* all */, true /* countMembers */)
 	if err != nil {
 		return nil, err
 	}

--- a/go/teams/list_fast.go
+++ b/go/teams/list_fast.go
@@ -1,0 +1,82 @@
+package teams
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// This is server trust version of TeamList functionality. It will not
+// perform any team loads to verify if server does not lie about our
+// membership in returned teams. It will also rely on the server to
+// return member counts for each team. All of this makes this version
+// much faster and less heavy on the server - even though UIDMapper is
+// used in the untrusting functions, a lot of calls were made anyway
+// during team loads (e.g. merkle paths).
+
+// See also: teams/list.go
+
+func ListTeamsFast(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg) (*keybase1.AnnotatedTeamList, error) {
+	tracer := g.CTimeTracer(ctx, "TeamList.ListTeamsFast")
+	defer tracer.Finish()
+
+	tracer.Stage("Resolve QueryUID")
+	var queryUID keybase1.UID
+	if arg.UserAssertion != "" {
+		res := g.Resolver.ResolveFullExpression(ctx, arg.UserAssertion)
+		if res.GetError() != nil {
+			return nil, res.GetError()
+		}
+		queryUID = res.GetUID()
+	}
+
+	meUID := g.ActiveDevice.UID()
+	if meUID.IsNil() {
+		return nil, libkb.LoginRequiredError{}
+	}
+
+	tracer.Stage("Server")
+	teams, err := getTeamsListFromServer(ctx, g, queryUID, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if arg.UserAssertion == "" {
+		queryUID = meUID
+	}
+
+	tracer.Stage("LookupQueryUsername")
+	queryUsername, queryFullName, err := getUsernameAndFullName(context.Background(), g, queryUID)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &keybase1.AnnotatedTeamList{
+		Teams: nil,
+		AnnotatedActiveInvites: make(map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite),
+	}
+
+	if len(teams) == 0 {
+		return res, nil
+	}
+
+	for _, memberInfo := range teams {
+		anMemberInfo := keybase1.AnnotatedMemberInfo{
+			TeamID:         memberInfo.TeamID,
+			FqName:         memberInfo.FqName,
+			UserID:         memberInfo.UserID,
+			Role:           memberInfo.Role,
+			IsImplicitTeam: memberInfo.IsImplicitTeam,
+			Implicit:       memberInfo.Implicit,
+			Username:       queryUsername.String(),
+			FullName:       queryFullName,
+			MemberCount:    0,
+			Active:         true,
+		}
+
+		res.Teams = append(res.Teams, anMemberInfo)
+	}
+
+	return nil, nil
+}

--- a/go/teams/list_fast.go
+++ b/go/teams/list_fast.go
@@ -62,6 +62,11 @@ func ListTeamsFast(ctx context.Context, g *libkb.GlobalContext, arg keybase1.Tea
 	}
 
 	for _, memberInfo := range teams {
+		if memberInfo.IsImplicitTeam && !arg.IncludeImplicitTeams {
+			g.Log.CDebugf(ctx, "| ListTeamsFast skipping implicit team: server-team:%v server-uid:%v", memberInfo.TeamID, memberInfo.UserID)
+			continue
+		}
+
 		anMemberInfo := keybase1.AnnotatedMemberInfo{
 			TeamID:         memberInfo.TeamID,
 			FqName:         memberInfo.FqName,
@@ -78,5 +83,5 @@ func ListTeamsFast(ctx context.Context, g *libkb.GlobalContext, arg keybase1.Tea
 		res.Teams = append(res.Teams, anMemberInfo)
 	}
 
-	return nil, nil
+	return res, nil
 }

--- a/go/teams/list_fast.go
+++ b/go/teams/list_fast.go
@@ -17,7 +17,7 @@ import (
 
 // See also: teams/list.go
 
-func ListTeamsUnverified(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListArg) (*keybase1.AnnotatedTeamList, error) {
+func ListTeamsUnverified(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListUnverifiedArg) (*keybase1.AnnotatedTeamList, error) {
 	tracer := g.CTimeTracer(ctx, "TeamList.ListTeamsUnverified")
 	defer tracer.Finish()
 

--- a/go/teams/list_fast.go
+++ b/go/teams/list_fast.go
@@ -76,7 +76,7 @@ func ListTeamsFast(ctx context.Context, g *libkb.GlobalContext, arg keybase1.Tea
 			Implicit:       memberInfo.Implicit,
 			Username:       queryUsername.String(),
 			FullName:       queryFullName,
-			MemberCount:    0,
+			MemberCount:    memberInfo.MemberCount,
 			Active:         true,
 		}
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -449,7 +449,7 @@ func TestMemberAddEmail(t *testing.T) {
 	// existing invite should be untouched
 	assertInvite(tc, name, address, "email", keybase1.TeamRole_READER)
 
-	annotatedTeamList, err := List(context.TODO(), tc.G, keybase1.TeamListArg{UserAssertion: "", All: true})
+	annotatedTeamList, err := ListAll(context.TODO(), tc.G, keybase1.TeamListTeammatesArg{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,7 +520,7 @@ func TestMemberListInviteUsername(t *testing.T) {
 		ForceRepoll: true,
 	})
 
-	annotatedTeamList, err := List(context.TODO(), tc.G, keybase1.TeamListArg{UserAssertion: "", All: true})
+	annotatedTeamList, err := ListAll(context.TODO(), tc.G, keybase1.TeamListTeammatesArg{})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(annotatedTeamList.AnnotatedActiveInvites))
 	require.Equal(t, 2, len(annotatedTeamList.Teams))

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -594,15 +594,19 @@ protocol teams {
   // Includes admins of the specified team only if they are also admins of ancestor teams.
   array<TeamMemberDetails> teamImplicitAdmins(int sessionID, string teamName);
 
-  // List known team memberships for given userAssertion.
-  AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean includeImplicitTeams);
+  // List known team memberships for given userAssertion or current
+  // user if userAssertion is not given. This RPC uses fast server-
+  // trust path and returned list is not checked.
+  AnnotatedTeamList teamListUnverified(int sessionID, string userAssertion, boolean includeImplicitTeams);
 
-  // List all team mates from all teams for current user. 
+  // List all team mates from all teams for current user. Results are
+  // checked - team members returned from the server are verified
+  // locally with team sigchains.
   AnnotatedTeamList teamListTeammates(int sessionID, boolean includeImplicitTeams);
 
   // List verified known team memberships for given userAssertion.
-  // This function is slower than teamList because it has to load
-  // every team.
+  // This function is slower than teamListUnverified because it loads
+  // and checks every team membership.
   AnnotatedTeamList teamListVerified(int sessionID, string userAssertion, boolean includeImplicitTeams);
 
   // admin only

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -594,9 +594,11 @@ protocol teams {
   // Includes admins of the specified team only if they are also admins of ancestor teams.
   array<TeamMemberDetails> teamImplicitAdmins(int sessionID, string teamName);
 
-  // List either known team memberships for given userAssertion, or
-  // all team collegaues if `all` is true.
-  AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean all, boolean includeImplicitTeams);
+  // List known team memberships for given userAssertion.
+  AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean includeImplicitTeams);
+
+  // List all team mates from all teams for current user. 
+  AnnotatedTeamList teamListTeammates(int sessionID, boolean includeImplicitTeams);
 
   // List verified known team memberships for given userAssertion.
   // This function is slower than teamList because it has to load

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -487,6 +487,8 @@ protocol teams {
     boolean isImplicitTeam;
     TeamRole role;
     union{null, ImplicitRole} implicit;
+    @jsonkey("member_count")
+    int memberCount;
   }
 
   record TeamList {
@@ -592,7 +594,14 @@ protocol teams {
   // Includes admins of the specified team only if they are also admins of ancestor teams.
   array<TeamMemberDetails> teamImplicitAdmins(int sessionID, string teamName);
 
+  // List either known team memberships for given userAssertion, or
+  // all team collegaues if `all` is true.
   AnnotatedTeamList teamList(int sessionID, string userAssertion, boolean all, boolean includeImplicitTeams);
+
+  // List verified known team memberships for given userAssertion.
+  // This function is slower than teamList because it has to load
+  // every team.
+  AnnotatedTeamList teamListVerified(int sessionID, string userAssertion, boolean includeImplicitTeams);
 
   // admin only
   array<TeamIDAndName> teamListSubteamsRecursive(int sessionID, string parentTeamName, boolean forceRepoll);

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1620,6 +1620,10 @@ export const teamsTeamListSubteamsRecursiveRpcChannelMap = (configKeys: Array<st
 
 export const teamsTeamListSubteamsRecursiveRpcPromise = (request: TeamsTeamListSubteamsRecursiveRpcParam): Promise<TeamsTeamListSubteamsRecursiveResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListSubteamsRecursive', request, (error: RPCError, result: TeamsTeamListSubteamsRecursiveResult) => (error ? reject(error) : resolve(result))))
 
+export const teamsTeamListTeammatesRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListTeammatesRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListTeammates', request)
+
+export const teamsTeamListTeammatesRpcPromise = (request: TeamsTeamListTeammatesRpcParam): Promise<TeamsTeamListTeammatesResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListTeammates', request, (error: RPCError, result: TeamsTeamListTeammatesResult) => (error ? reject(error) : resolve(result))))
+
 export const teamsTeamListVerifiedRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListVerifiedRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListVerified', request)
 
 export const teamsTeamListVerifiedRpcPromise = (request: TeamsTeamListVerifiedRpcParam): Promise<TeamsTeamListVerifiedResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListVerified', request, (error: RPCError, result: TeamsTeamListVerifiedResult) => (error ? reject(error) : resolve(result))))
@@ -3626,9 +3630,11 @@ export type TeamsTeamListMyAccessRequestsRpcParam = {|teamName?: ?String, incomi
 
 export type TeamsTeamListRequestsRpcParam = ?{|incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type TeamsTeamListRpcParam = {|userAssertion: String, all: Boolean, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+export type TeamsTeamListRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type TeamsTeamListSubteamsRecursiveRpcParam = {|parentTeamName: String, forceRepoll: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
+export type TeamsTeamListTeammatesRpcParam = {|includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type TeamsTeamListVerifiedRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -3977,6 +3983,7 @@ type TeamsTeamListMyAccessRequestsResult = ?Array<TeamName>
 type TeamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type TeamsTeamListResult = AnnotatedTeamList
 type TeamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
+type TeamsTeamListTeammatesResult = AnnotatedTeamList
 type TeamsTeamListVerifiedResult = AnnotatedTeamList
 type TeamsTeamRequestAccessResult = TeamRequestAccessResult
 type TeamsTeamTreeResult = TeamTreeResult

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1612,10 +1612,6 @@ export const teamsTeamListRequestsRpcChannelMap = (configKeys: Array<string>, re
 
 export const teamsTeamListRequestsRpcPromise = (request: TeamsTeamListRequestsRpcParam): Promise<TeamsTeamListRequestsResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListRequests', request, (error: RPCError, result: TeamsTeamListRequestsResult) => (error ? reject(error) : resolve(result))))
 
-export const teamsTeamListRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamList', request)
-
-export const teamsTeamListRpcPromise = (request: TeamsTeamListRpcParam): Promise<TeamsTeamListResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamList', request, (error: RPCError, result: TeamsTeamListResult) => (error ? reject(error) : resolve(result))))
-
 export const teamsTeamListSubteamsRecursiveRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListSubteamsRecursiveRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListSubteamsRecursive', request)
 
 export const teamsTeamListSubteamsRecursiveRpcPromise = (request: TeamsTeamListSubteamsRecursiveRpcParam): Promise<TeamsTeamListSubteamsRecursiveResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListSubteamsRecursive', request, (error: RPCError, result: TeamsTeamListSubteamsRecursiveResult) => (error ? reject(error) : resolve(result))))
@@ -1623,6 +1619,10 @@ export const teamsTeamListSubteamsRecursiveRpcPromise = (request: TeamsTeamListS
 export const teamsTeamListTeammatesRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListTeammatesRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListTeammates', request)
 
 export const teamsTeamListTeammatesRpcPromise = (request: TeamsTeamListTeammatesRpcParam): Promise<TeamsTeamListTeammatesResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListTeammates', request, (error: RPCError, result: TeamsTeamListTeammatesResult) => (error ? reject(error) : resolve(result))))
+
+export const teamsTeamListUnverifiedRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListUnverifiedRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListUnverified', request)
+
+export const teamsTeamListUnverifiedRpcPromise = (request: TeamsTeamListUnverifiedRpcParam): Promise<TeamsTeamListUnverifiedResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListUnverified', request, (error: RPCError, result: TeamsTeamListUnverifiedResult) => (error ? reject(error) : resolve(result))))
 
 export const teamsTeamListVerifiedRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListVerifiedRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListVerified', request)
 
@@ -3630,11 +3630,11 @@ export type TeamsTeamListMyAccessRequestsRpcParam = {|teamName?: ?String, incomi
 
 export type TeamsTeamListRequestsRpcParam = ?{|incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type TeamsTeamListRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
-
 export type TeamsTeamListSubteamsRecursiveRpcParam = {|parentTeamName: String, forceRepoll: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type TeamsTeamListTeammatesRpcParam = {|includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
+export type TeamsTeamListUnverifiedRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type TeamsTeamListVerifiedRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -3981,9 +3981,9 @@ type TeamsTeamGetResult = TeamDetails
 type TeamsTeamImplicitAdminsResult = ?Array<TeamMemberDetails>
 type TeamsTeamListMyAccessRequestsResult = ?Array<TeamName>
 type TeamsTeamListRequestsResult = ?Array<TeamJoinRequest>
-type TeamsTeamListResult = AnnotatedTeamList
 type TeamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
 type TeamsTeamListTeammatesResult = AnnotatedTeamList
+type TeamsTeamListUnverifiedResult = AnnotatedTeamList
 type TeamsTeamListVerifiedResult = AnnotatedTeamList
 type TeamsTeamRequestAccessResult = TeamRequestAccessResult
 type TeamsTeamTreeResult = TeamTreeResult

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1620,6 +1620,10 @@ export const teamsTeamListSubteamsRecursiveRpcChannelMap = (configKeys: Array<st
 
 export const teamsTeamListSubteamsRecursiveRpcPromise = (request: TeamsTeamListSubteamsRecursiveRpcParam): Promise<TeamsTeamListSubteamsRecursiveResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListSubteamsRecursive', request, (error: RPCError, result: TeamsTeamListSubteamsRecursiveResult) => (error ? reject(error) : resolve(result))))
 
+export const teamsTeamListVerifiedRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListVerifiedRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListVerified', request)
+
+export const teamsTeamListVerifiedRpcPromise = (request: TeamsTeamListVerifiedRpcParam): Promise<TeamsTeamListVerifiedResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListVerified', request, (error: RPCError, result: TeamsTeamListVerifiedResult) => (error ? reject(error) : resolve(result))))
+
 export const teamsTeamReAddMemberAfterResetRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamReAddMemberAfterResetRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamReAddMemberAfterReset', request)
 
 export const teamsTeamReAddMemberAfterResetRpcPromise = (request: TeamsTeamReAddMemberAfterResetRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamReAddMemberAfterReset', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
@@ -2606,7 +2610,7 @@ export type MDPriority = Int
 
 export type MaskB64 = Bytes
 
-export type MemberInfo = {|userID: UID, teamID: TeamID, fqName: String, isImplicitTeam: Boolean, role: TeamRole, implicit?: ?ImplicitRole|}
+export type MemberInfo = {|userID: UID, teamID: TeamID, fqName: String, isImplicitTeam: Boolean, role: TeamRole, implicit?: ?ImplicitRole, memberCount: Int|}
 
 export type MerkleGetCurrentMerkleRootRpcParam = {|freshnessMsec: Int, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -3626,6 +3630,8 @@ export type TeamsTeamListRpcParam = {|userAssertion: String, all: Boolean, inclu
 
 export type TeamsTeamListSubteamsRecursiveRpcParam = {|parentTeamName: String, forceRepoll: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
+export type TeamsTeamListVerifiedRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
 export type TeamsTeamReAddMemberAfterResetRpcParam = {|id: TeamID, username: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type TeamsTeamRemoveMemberRpcParam = {|name: String, username: String, email: String, inviteID: TeamInviteID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
@@ -3971,6 +3977,7 @@ type TeamsTeamListMyAccessRequestsResult = ?Array<TeamName>
 type TeamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type TeamsTeamListResult = AnnotatedTeamList
 type TeamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
+type TeamsTeamListVerifiedResult = AnnotatedTeamList
 type TeamsTeamRequestAccessResult = TeamRequestAccessResult
 type TeamsTeamTreeResult = TeamTreeResult
 type TeamsUiConfirmRootTeamDeleteResult = Boolean

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1179,6 +1179,11 @@
             "ImplicitRole"
           ],
           "name": "implicit"
+        },
+        {
+          "type": "int",
+          "name": "memberCount",
+          "jsonkey": "member_count"
         }
       ]
     },
@@ -1713,6 +1718,23 @@
         {
           "name": "all",
           "type": "boolean"
+        },
+        {
+          "name": "includeImplicitTeams",
+          "type": "boolean"
+        }
+      ],
+      "response": "AnnotatedTeamList"
+    },
+    "teamListVerified": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "userAssertion",
+          "type": "string"
         },
         {
           "name": "includeImplicitTeams",

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1705,7 +1705,7 @@
         "items": "TeamMemberDetails"
       }
     },
-    "teamList": {
+    "teamListUnverified": {
       "request": [
         {
           "name": "sessionID",

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1716,8 +1716,17 @@
           "type": "string"
         },
         {
-          "name": "all",
+          "name": "includeImplicitTeams",
           "type": "boolean"
+        }
+      ],
+      "response": "AnnotatedTeamList"
+    },
+    "teamListTeammates": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
         },
         {
           "name": "includeImplicitTeams",

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -465,7 +465,6 @@ const _getTeams = function*(action: TeamsGen.GetTeamsPayload): Saga.SagaGenerato
   yield Saga.put(replaceEntity(['teams'], I.Map([['loaded', false]])))
   try {
     const results: RPCTypes.AnnotatedTeamList = yield Saga.call(RPCTypes.teamsTeamListRpcPromise, {
-      all: false,
       includeImplicitTeams: false,
       userAssertion: username,
     })

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -464,7 +464,7 @@ const _getTeams = function*(action: TeamsGen.GetTeamsPayload): Saga.SagaGenerato
   }
   yield Saga.put(replaceEntity(['teams'], I.Map([['loaded', false]])))
   try {
-    const results: RPCTypes.AnnotatedTeamList = yield Saga.call(RPCTypes.teamsTeamListRpcPromise, {
+    const results: RPCTypes.AnnotatedTeamList = yield Saga.call(RPCTypes.teamsTeamListUnverifiedRpcPromise, {
       includeImplicitTeams: false,
       userAssertion: username,
     })

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1620,6 +1620,10 @@ export const teamsTeamListSubteamsRecursiveRpcChannelMap = (configKeys: Array<st
 
 export const teamsTeamListSubteamsRecursiveRpcPromise = (request: TeamsTeamListSubteamsRecursiveRpcParam): Promise<TeamsTeamListSubteamsRecursiveResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListSubteamsRecursive', request, (error: RPCError, result: TeamsTeamListSubteamsRecursiveResult) => (error ? reject(error) : resolve(result))))
 
+export const teamsTeamListTeammatesRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListTeammatesRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListTeammates', request)
+
+export const teamsTeamListTeammatesRpcPromise = (request: TeamsTeamListTeammatesRpcParam): Promise<TeamsTeamListTeammatesResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListTeammates', request, (error: RPCError, result: TeamsTeamListTeammatesResult) => (error ? reject(error) : resolve(result))))
+
 export const teamsTeamListVerifiedRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListVerifiedRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListVerified', request)
 
 export const teamsTeamListVerifiedRpcPromise = (request: TeamsTeamListVerifiedRpcParam): Promise<TeamsTeamListVerifiedResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListVerified', request, (error: RPCError, result: TeamsTeamListVerifiedResult) => (error ? reject(error) : resolve(result))))
@@ -3626,9 +3630,11 @@ export type TeamsTeamListMyAccessRequestsRpcParam = {|teamName?: ?String, incomi
 
 export type TeamsTeamListRequestsRpcParam = ?{|incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type TeamsTeamListRpcParam = {|userAssertion: String, all: Boolean, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+export type TeamsTeamListRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type TeamsTeamListSubteamsRecursiveRpcParam = {|parentTeamName: String, forceRepoll: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
+export type TeamsTeamListTeammatesRpcParam = {|includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type TeamsTeamListVerifiedRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -3977,6 +3983,7 @@ type TeamsTeamListMyAccessRequestsResult = ?Array<TeamName>
 type TeamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type TeamsTeamListResult = AnnotatedTeamList
 type TeamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
+type TeamsTeamListTeammatesResult = AnnotatedTeamList
 type TeamsTeamListVerifiedResult = AnnotatedTeamList
 type TeamsTeamRequestAccessResult = TeamRequestAccessResult
 type TeamsTeamTreeResult = TeamTreeResult

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1612,10 +1612,6 @@ export const teamsTeamListRequestsRpcChannelMap = (configKeys: Array<string>, re
 
 export const teamsTeamListRequestsRpcPromise = (request: TeamsTeamListRequestsRpcParam): Promise<TeamsTeamListRequestsResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListRequests', request, (error: RPCError, result: TeamsTeamListRequestsResult) => (error ? reject(error) : resolve(result))))
 
-export const teamsTeamListRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamList', request)
-
-export const teamsTeamListRpcPromise = (request: TeamsTeamListRpcParam): Promise<TeamsTeamListResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamList', request, (error: RPCError, result: TeamsTeamListResult) => (error ? reject(error) : resolve(result))))
-
 export const teamsTeamListSubteamsRecursiveRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListSubteamsRecursiveRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListSubteamsRecursive', request)
 
 export const teamsTeamListSubteamsRecursiveRpcPromise = (request: TeamsTeamListSubteamsRecursiveRpcParam): Promise<TeamsTeamListSubteamsRecursiveResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListSubteamsRecursive', request, (error: RPCError, result: TeamsTeamListSubteamsRecursiveResult) => (error ? reject(error) : resolve(result))))
@@ -1623,6 +1619,10 @@ export const teamsTeamListSubteamsRecursiveRpcPromise = (request: TeamsTeamListS
 export const teamsTeamListTeammatesRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListTeammatesRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListTeammates', request)
 
 export const teamsTeamListTeammatesRpcPromise = (request: TeamsTeamListTeammatesRpcParam): Promise<TeamsTeamListTeammatesResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListTeammates', request, (error: RPCError, result: TeamsTeamListTeammatesResult) => (error ? reject(error) : resolve(result))))
+
+export const teamsTeamListUnverifiedRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListUnverifiedRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListUnverified', request)
+
+export const teamsTeamListUnverifiedRpcPromise = (request: TeamsTeamListUnverifiedRpcParam): Promise<TeamsTeamListUnverifiedResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListUnverified', request, (error: RPCError, result: TeamsTeamListUnverifiedResult) => (error ? reject(error) : resolve(result))))
 
 export const teamsTeamListVerifiedRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListVerifiedRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListVerified', request)
 
@@ -3630,11 +3630,11 @@ export type TeamsTeamListMyAccessRequestsRpcParam = {|teamName?: ?String, incomi
 
 export type TeamsTeamListRequestsRpcParam = ?{|incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type TeamsTeamListRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
-
 export type TeamsTeamListSubteamsRecursiveRpcParam = {|parentTeamName: String, forceRepoll: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type TeamsTeamListTeammatesRpcParam = {|includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
+export type TeamsTeamListUnverifiedRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type TeamsTeamListVerifiedRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -3981,9 +3981,9 @@ type TeamsTeamGetResult = TeamDetails
 type TeamsTeamImplicitAdminsResult = ?Array<TeamMemberDetails>
 type TeamsTeamListMyAccessRequestsResult = ?Array<TeamName>
 type TeamsTeamListRequestsResult = ?Array<TeamJoinRequest>
-type TeamsTeamListResult = AnnotatedTeamList
 type TeamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
 type TeamsTeamListTeammatesResult = AnnotatedTeamList
+type TeamsTeamListUnverifiedResult = AnnotatedTeamList
 type TeamsTeamListVerifiedResult = AnnotatedTeamList
 type TeamsTeamRequestAccessResult = TeamRequestAccessResult
 type TeamsTeamTreeResult = TeamTreeResult

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1620,6 +1620,10 @@ export const teamsTeamListSubteamsRecursiveRpcChannelMap = (configKeys: Array<st
 
 export const teamsTeamListSubteamsRecursiveRpcPromise = (request: TeamsTeamListSubteamsRecursiveRpcParam): Promise<TeamsTeamListSubteamsRecursiveResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListSubteamsRecursive', request, (error: RPCError, result: TeamsTeamListSubteamsRecursiveResult) => (error ? reject(error) : resolve(result))))
 
+export const teamsTeamListVerifiedRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamListVerifiedRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamListVerified', request)
+
+export const teamsTeamListVerifiedRpcPromise = (request: TeamsTeamListVerifiedRpcParam): Promise<TeamsTeamListVerifiedResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamListVerified', request, (error: RPCError, result: TeamsTeamListVerifiedResult) => (error ? reject(error) : resolve(result))))
+
 export const teamsTeamReAddMemberAfterResetRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamReAddMemberAfterResetRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamReAddMemberAfterReset', request)
 
 export const teamsTeamReAddMemberAfterResetRpcPromise = (request: TeamsTeamReAddMemberAfterResetRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamReAddMemberAfterReset', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
@@ -2606,7 +2610,7 @@ export type MDPriority = Int
 
 export type MaskB64 = Bytes
 
-export type MemberInfo = {|userID: UID, teamID: TeamID, fqName: String, isImplicitTeam: Boolean, role: TeamRole, implicit?: ?ImplicitRole|}
+export type MemberInfo = {|userID: UID, teamID: TeamID, fqName: String, isImplicitTeam: Boolean, role: TeamRole, implicit?: ?ImplicitRole, memberCount: Int|}
 
 export type MerkleGetCurrentMerkleRootRpcParam = {|freshnessMsec: Int, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
@@ -3626,6 +3630,8 @@ export type TeamsTeamListRpcParam = {|userAssertion: String, all: Boolean, inclu
 
 export type TeamsTeamListSubteamsRecursiveRpcParam = {|parentTeamName: String, forceRepoll: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
+export type TeamsTeamListVerifiedRpcParam = {|userAssertion: String, includeImplicitTeams: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
 export type TeamsTeamReAddMemberAfterResetRpcParam = {|id: TeamID, username: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type TeamsTeamRemoveMemberRpcParam = {|name: String, username: String, email: String, inviteID: TeamInviteID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
@@ -3971,6 +3977,7 @@ type TeamsTeamListMyAccessRequestsResult = ?Array<TeamName>
 type TeamsTeamListRequestsResult = ?Array<TeamJoinRequest>
 type TeamsTeamListResult = AnnotatedTeamList
 type TeamsTeamListSubteamsRecursiveResult = ?Array<TeamIDAndName>
+type TeamsTeamListVerifiedResult = AnnotatedTeamList
 type TeamsTeamRequestAccessResult = TeamRequestAccessResult
 type TeamsTeamTreeResult = TeamTreeResult
 type TeamsUiConfirmRootTeamDeleteResult = Boolean


### PR DESCRIPTION
Old "slow" version is still available via another RPC: `teamListVerified`. I'm not sure if we need it, though. 

This PR also cleans up commented code and unused code/types from teams/list - leftovers from where we used to not count reset members towards memberCount.