### PR TITLE
Shell completion

### DIFF
--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -379,7 +379,7 @@ func NewCommandLine(addHelp bool, extraFlags []cli.Flag) *CommandLine {
 func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 	app := p.app
 	app.Name = "keybase"
-	app.EnableBaseCompletion = true
+	app.EnableBashCompletion = true
 	app.Version = libkb.VersionString()
 	app.Usage = "Keybase command line client."
 

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -379,6 +379,7 @@ func NewCommandLine(addHelp bool, extraFlags []cli.Flag) *CommandLine {
 func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 	app := p.app
 	app.Name = "keybase"
+	app.EnableBaseCompletion = true
 	app.Version = libkb.VersionString()
 	app.Usage = "Keybase command line client."
 


### PR DESCRIPTION
A simple WIP PR to enable basic shell completion using `urfave/cli`'s built in [shell completion](https://github.com/urfave/cli#bash-completion) function.

The method has two parts:
 - An "autocomplete" script that, when sourced ([source is here](https://github.com/urfave/cli/blob/master/autocomplete/bash_autocomplete)), adds the completion to the shell
- A `--generate-<shell>-completion` function that outputs the inline subcommands for the above script.

I've enabled the second part (it's just one line), but the first would need to be distributed in some way along with the CLI. Since I don't know your install methods, any insight here would be appreciated.

For an example of how this can be done in practice, see [here](https://github.com/vapor-ware/synse-cli/blob/master/utils/shellcompletion.go)

If approved, `zsh` completion can easily be added along with `bash`.

References:
 - https://github.com/keybase/keybase-issues/issues/147
 - https://github.com/keybase/keybase-issues/issues/519