### PR TITLE
Fix mobile Inbox unboxing on hover

### DIFF
--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -134,7 +134,7 @@ class Inbox extends React.PureComponent<Props, State> {
     const {viewableItems} = data
     const item = viewableItems && viewableItems[0]
     if (item && item.index) {
-      this._askForUnboxing(viewableItems)
+      this._askForUnboxing(viewableItems.map(i => i.item))
     }
   }, 1000)
 


### PR DESCRIPTION
@keybase/react-hackers 

PR #9013 ("Use entity store inbox map instead of list") refactored `_askForUnboxing` to take a list of items to consider instead of one item at a time, but unintentionally changed the type -- before, that function received a `List<RowItem>`, but now it's receiving a list of:

```
[{index: number, item: RowItem}, ...]
```

So, `_askForUnboxing` fails in this filter on every item:
```js
const toUnbox = rows.filter(r => r.type === 'small' && r.conversationIDKey)
```

Since for it to work the test would have had to be:
```js
const toUnbox = rows.filter(r => r.item.type === 'small' && r.item.conversationIDKey)
```

I decided to keep the definition of `_askForUnboxing` the same, since this way its flowtype becomes correct.