### PR TITLE
libkb: add "copy" to expected implicit team conflict suffix

### DIFF
--- a/go/externals/implicit_team_test.go
+++ b/go/externals/implicit_team_test.go
@@ -56,7 +56,7 @@ func TestParseImplicitTeamTLFName(t *testing.T) {
 	require.True(t, firstSocial == aliceExpected || firstSocial == bobExpected)
 	require.True(t, secondSocial == aliceExpected || secondSocial == bobExpected)
 
-	goodName = "/keybase/public/dave,bob@facebook#alice (conflicted 2017-03-04)"
+	goodName = "/keybase/public/dave,bob@facebook#alice (conflicted copy 2017-03-04)"
 	name, err = libkb.ParseImplicitTeamTLFName(MakeAssertionContext(), goodName)
 	require.NoError(t, err)
 	require.Equal(t, name.IsPublic, true)
@@ -65,7 +65,7 @@ func TestParseImplicitTeamTLFName(t *testing.T) {
 	require.True(t, containsString(name.Writers.KeybaseUsers, "dave"))
 	require.Equal(t, name.ConflictInfo.Generation, keybase1.ConflictGeneration(1), "right conflict info")
 
-	goodName = "/keybase/public/dave,bob@facebook#alice (conflicted 2017-03-04 #2)"
+	goodName = "/keybase/public/dave,bob@facebook#alice (conflicted copy 2017-03-04 #2)"
 	name, err = libkb.ParseImplicitTeamTLFName(MakeAssertionContext(), goodName)
 	require.NoError(t, err)
 	require.Equal(t, name.IsPublic, true)

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -671,12 +671,12 @@ func parseImplicitTeamPart(ctx AssertionContext, s string) (typ string, name str
 }
 
 func FormatImplicitTeamDisplayNameSuffix(conflict keybase1.ImplicitTeamConflictInfo) string {
-	return fmt.Sprintf("(conflicted %v #%v)",
+	return fmt.Sprintf("(conflicted copy %v #%v)",
 		conflict.Time.Time().UTC().Format("2006-01-02"),
 		conflict.Generation)
 }
 
-// Parse a name like "mlsteele,malgorithms@twitter#bot (conflicted 2017-03-04 #2)"
+// Parse a name like "mlsteele,malgorithms@twitter#bot (conflicted copy 2017-03-04 #2)"
 func ParseImplicitTeamDisplayName(ctx AssertionContext, s string, isPublic bool) (ret keybase1.ImplicitTeamDisplayName, err error) {
 	// Turn the whole string tolower
 	s = strings.ToLower(s)
@@ -726,7 +726,7 @@ func ParseImplicitTeamDisplayName(ctx AssertionContext, s string, isPublic bool)
 	return ret, nil
 }
 
-var implicitTeamDisplayNameConflictRxx = regexp.MustCompile(`^\(conflicted (\d{4}-\d{2}-\d{2})( #(\d+))?\)$`)
+var implicitTeamDisplayNameConflictRxx = regexp.MustCompile(`^\(conflicted copy (\d{4}-\d{2}-\d{2})( #(\d+))?\)$`)
 
 func ParseImplicitTeamDisplayNameSuffix(suffix string) (ret *keybase1.ImplicitTeamConflictInfo, err error) {
 	if len(suffix) == 0 {
@@ -785,7 +785,7 @@ func parseImplicitTeamUserSet(ctx AssertionContext, s string, seen map[string]bo
 	return ret, nil
 }
 
-// Parse a name like "/keybase/private/mlsteele,malgorithms@twitter#bot (conflicted 2017-03-04 #2)"
+// Parse a name like "/keybase/private/mlsteele,malgorithms@twitter#bot (conflicted copy 2017-03-04 #2)"
 func ParseImplicitTeamTLFName(ctx AssertionContext, s string) (keybase1.ImplicitTeamDisplayName, error) {
 	ret := keybase1.ImplicitTeamDisplayName{}
 	s = strings.ToLower(s)

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -18,7 +18,7 @@ type implicitTeamConflict struct {
 }
 
 func (i *implicitTeamConflict) parse() (*keybase1.ImplicitTeamConflictInfo, error) {
-	return libkb.ParseImplicitTeamDisplayNameSuffix(fmt.Sprintf("(conflicted %s #%d)", i.ConflictDate, i.Generation))
+	return libkb.ParseImplicitTeamDisplayNameSuffix(fmt.Sprintf("(conflicted copy %s #%d)", i.ConflictDate, i.Generation))
 }
 
 type implicitTeam struct {
@@ -33,7 +33,7 @@ func (i *implicitTeam) GetAppStatus() *libkb.AppStatus {
 	return &i.Status
 }
 
-// Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted 2017-03-04 #1)"
+// Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted copy 2017-03-04 #1)"
 // Resolves social assertions.
 func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (
 	teamID keybase1.TeamID, teamName keybase1.TeamName, impTeamName keybase1.ImplicitTeamDisplayName, tlfID keybase1.TLFID, err error) {
@@ -42,7 +42,7 @@ func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName
 	return teamID, teamName, impTeamName, tlfID, err
 }
 
-// Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted 2017-03-04 #1)"
+// Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted copy 2017-03-04 #1)"
 // Resolves social assertions.
 func LookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (
 	teamID keybase1.TeamID, teamName keybase1.TeamName, impTeamName keybase1.ImplicitTeamDisplayName, tlfID keybase1.TLFID, conflicts []keybase1.ImplicitTeamConflictInfo, err error) {
@@ -53,7 +53,7 @@ func LookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	return lookupImplicitTeamAndConflicts(ctx, g, displayName, impName)
 }
 
-// Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted 2017-03-04 #1)"
+// Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted copy 2017-03-04 #1)"
 // Does not resolve social assertions.
 // preResolveDisplayName is used for logging and errors
 func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
@@ -152,7 +152,7 @@ func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	return teamID, team.Name(), impTeamName, tlfID, conflicts, nil
 }
 
-// Lookup or create an implicit team by name like "alice,bob+bob@twitter (conflicted 2017-03-04 #1)"
+// Lookup or create an implicit team by name like "alice,bob+bob@twitter (conflicted copy 2017-03-04 #1)"
 // Resolves social assertions.
 func LookupOrCreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (res keybase1.TeamID, teamName keybase1.TeamName, impTeamName keybase1.ImplicitTeamDisplayName, tlfID keybase1.TLFID, err error) {
 	defer g.CTraceTimed(ctx, fmt.Sprintf("LookupOrCreateImplicitTeam(%v)", displayName),

--- a/go/teams/resolve.go
+++ b/go/teams/resolve.go
@@ -47,8 +47,8 @@ func ResolveNameToID(ctx context.Context, g *libkb.GlobalContext, name keybase1.
 }
 
 // Resolve assertions in an implicit team display name and verify the result.
-// Resolve an implicit team name with assertions like "alice,bob+bob@twitter#char (conflicted 2017-03-04 #1)"
-// Into "alice,bob#char (conflicted 2017-03-04 #1)"
+// Resolve an implicit team name with assertions like "alice,bob+bob@twitter#char (conflicted copy 2017-03-04 #1)"
+// Into "alice,bob#char (conflicted copy 2017-03-04 #1)"
 // The input can contain compound assertions, but if compound assertions are left unresolved, an error will be returned.
 func ResolveImplicitTeamDisplayName(ctx context.Context, g *libkb.GlobalContext,
 	name string, public bool) (res keybase1.ImplicitTeamDisplayName, err error) {


### PR DESCRIPTION
To be backwards-compatible with the current KBFS behavior.

Issue: KBFS-2652