### PR TITLE
dont send outbox messages if they have been sitting for too long CORE-6738

### DIFF
--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -895,6 +895,8 @@ func (s *Deliverer) deliverLoop() {
 			} else if s.clock.Now().Sub(obr.Ctime.Time()) > 10*time.Minute {
 				// If we are re-trying a message after 10 minutes, let's just give up. These times can
 				// get very long if the app is suspended on mobile.
+				s.Debug(bgctx, "expiring pending message because it is too old: obid: %s dur: %v",
+					obr.OutboxID, s.clock.Now().Sub(obr.Ctime.Time()))
 				err = delivererExpireError{}
 			} else {
 				_, _, _, err = s.sender.Send(bctx, obr.ConvID, obr.Msg, 0, nil)

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -646,6 +646,17 @@ type DelivererInfoError interface {
 	IsImmediateFail() (chat1.OutboxErrorType, bool)
 }
 
+// delivererExpireError is used when a message fails because it has languished in the outbox for too long.
+type delivererExpireError struct{}
+
+func (e delivererExpireError) Error() string {
+	return "message failed to send"
+}
+
+func (e delivererExpireError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
+	return chat1.OutboxErrorType_EXPIRED, true
+}
+
 type Deliverer struct {
 	globals.Contextified
 	sync.Mutex
@@ -881,6 +892,10 @@ func (s *Deliverer) deliverLoop() {
 			}
 			if !s.connected {
 				err = errors.New("disconnected from chat server")
+			} else if s.clock.Now().Sub(obr.Ctime.Time()) > 10*time.Minute {
+				// If we are re-trying a message after 10 minutes, let's just give up. These times can
+				// get very long if the app is suspended on mobile.
+				err = delivererExpireError{}
 			} else {
 				_, _, _, err = s.sender.Send(bctx, obr.ConvID, obr.Msg, 0, nil)
 			}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1114,6 +1114,7 @@ const (
 	OutboxErrorType_IDENTIFY  OutboxErrorType = 2
 	OutboxErrorType_TOOLONG   OutboxErrorType = 3
 	OutboxErrorType_DUPLICATE OutboxErrorType = 4
+	OutboxErrorType_EXPIRED   OutboxErrorType = 5
 )
 
 func (o OutboxErrorType) DeepCopy() OutboxErrorType { return o }
@@ -1124,6 +1125,7 @@ var OutboxErrorTypeMap = map[string]OutboxErrorType{
 	"IDENTIFY":  2,
 	"TOOLONG":   3,
 	"DUPLICATE": 4,
+	"EXPIRED":   5,
 }
 
 var OutboxErrorTypeRevMap = map[OutboxErrorType]string{
@@ -1132,6 +1134,7 @@ var OutboxErrorTypeRevMap = map[OutboxErrorType]string{
 	2: "IDENTIFY",
 	3: "TOOLONG",
 	4: "DUPLICATE",
+	5: "EXPIRED",
 }
 
 func (e OutboxErrorType) String() string {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -178,7 +178,8 @@ protocol local {
     OFFLINE_1,
     IDENTIFY_2,
     TOOLONG_3,
-    DUPLICATE_4
+    DUPLICATE_4,
+    EXPIRED_5
   }
 
   record OutboxStateError {

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -253,6 +253,7 @@ export const localOutboxErrorType = {
   identify: 2,
   toolong: 3,
   duplicate: 4,
+  expired: 5,
 }
 
 export const localOutboxStateType = {
@@ -1003,6 +1004,7 @@ export type OutboxErrorType =
   | 2 // IDENTIFY_2
   | 3 // TOOLONG_3
   | 4 // DUPLICATE_4
+  | 5 // EXPIRED_5
 
 export type OutboxID = Bytes
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -593,7 +593,8 @@
         "OFFLINE_1",
         "IDENTIFY_2",
         "TOOLONG_3",
-        "DUPLICATE_4"
+        "DUPLICATE_4",
+        "EXPIRED_5"
       ]
     },
     {

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -253,6 +253,7 @@ export const localOutboxErrorType = {
   identify: 2,
   toolong: 3,
   duplicate: 4,
+  expired: 5,
 }
 
 export const localOutboxStateType = {
@@ -1003,6 +1004,7 @@ export type OutboxErrorType =
   | 2 // IDENTIFY_2
   | 3 // TOOLONG_3
   | 4 // DUPLICATE_4
+  | 5 // EXPIRED_5
 
 export type OutboxID = Bytes
 


### PR DESCRIPTION
Slap an expiration in terms of time on messages in the outbox so we don't end up sending extremely old messages that haven't been getting tried because the app has been suspended.