### PR TITLE
Change internals of LoginState GetUID

### DIFF
--- a/go/engine/common.go
+++ b/go/engine/common.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/keybase/client/go/libkb"
-	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 func IsLoggedIn(e Engine, ctx *Context) (ret bool, uid keybase1.UID, err error) {

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -1121,8 +1121,20 @@ func (s *LoginState) LocalSession(h func(*Session), name string) error {
 	}, name)
 }
 
-func (s *LoginState) GetUID() (ret keybase1.UID) {
-	return s.G().ActiveDevice.UID()
+func (s *LoginState) GetUID() (uid keybase1.UID) {
+	uid = s.G().ActiveDevice.UID()
+	if !uid.IsNil() {
+		return uid
+	}
+
+	// This path is only hit during tests (specifically those that
+	// replicate a web-only user without device keys and those that
+	// reset the login state without logging in), so falling
+	// back to getting the UID this way:
+	s.Account(func(a *Account) {
+		uid = a.GetUID()
+	}, "GetUID")
+	return uid
 }
 
 func (s *LoginState) LoginSession(h func(*LoginSession), name string) error {

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -1122,10 +1122,7 @@ func (s *LoginState) LocalSession(h func(*Session), name string) error {
 }
 
 func (s *LoginState) GetUID() (ret keybase1.UID) {
-	s.Account(func(a *Account) {
-		ret = a.GetUID()
-	}, "GetUID")
-	return ret
+	return s.G().ActiveDevice.UID()
 }
 
 func (s *LoginState) LoginSession(h func(*LoginSession), name string) error {


### PR DESCRIPTION
Instead of removing GetUID from LoginState API (which isn't a trivial change), this replaces how it figures it out so it doesn't enter the LoginState serial request loop.

