### PR TITLE
Change GitLocalMetadata protocol for expanded commit message support

### DIFF
--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -441,8 +441,10 @@ func formatSystemMessage(body chat1.MessageSystem) string {
 	case chat1.MessageSystemType_CREATETEAM:
 		return fmt.Sprintf("[%s created the team %s]", body.Createteam().Creator, body.Createteam().Team)
 	case chat1.MessageSystemType_GITPUSH:
+		total := keybase1.TotalNumberOfCommits(body.Gitpush().Refs)
+		names := keybase1.RefNames(body.Gitpush().Refs)
 		return fmt.Sprintf("[git (%s) %s pushed %d commits to %s]", body.Gitpush().RepoName,
-			body.Gitpush().Pusher, len(body.Gitpush().CommitMsgs), body.Gitpush().BranchName)
+			body.Gitpush().Pusher, total, names)
 	}
 	return "<unknown system message>"
 }

--- a/go/git/put.go
+++ b/go/git/put.go
@@ -93,16 +93,15 @@ func sendChat(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamI
 		return nil
 	}
 
+	g.StartStandaloneChat()
+
 	subBody := chat1.NewMessageSystemWithGitpush(chat1.MessageSystemGitPush{
-		Team:       arg.Folder.Name,
-		Pusher:     g.Env.GetUsername().String(),
-		RepoName:   string(arg.Metadata.RepoName),
-		BranchName: arg.Metadata.BranchName,
-		CommitMsgs: arg.Metadata.CommitMsgs,
+		Team:     arg.Folder.Name,
+		Pusher:   g.Env.GetUsername().String(),
+		RepoName: string(arg.Metadata.RepoName),
+		Refs:     arg.Metadata.Refs,
 	})
 	body := chat1.NewMessageBodyWithSystem(subBody)
-
-	g.StartStandaloneChat()
 
 	g.Log.CDebugf(ctx, "sending git push system chat message to %s/%s", arg.Folder.Name, *settings.ChannelName)
 	return g.ChatHelper.SendMsgByNameNonblock(ctx, arg.Folder.Name, settings.ChannelName,

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -211,30 +211,28 @@ func (o MessageSystemCreateTeam) DeepCopy() MessageSystemCreateTeam {
 }
 
 type MessageSystemGitPush struct {
-	Team       string   `codec:"team" json:"team"`
-	Pusher     string   `codec:"pusher" json:"pusher"`
-	RepoName   string   `codec:"repoName" json:"repoName"`
-	BranchName string   `codec:"branchName" json:"branchName"`
-	CommitMsgs []string `codec:"commitMsgs" json:"commitMsgs"`
+	Team     string                    `codec:"team" json:"team"`
+	Pusher   string                    `codec:"pusher" json:"pusher"`
+	RepoName string                    `codec:"repoName" json:"repoName"`
+	Refs     []keybase1.GitRefMetadata `codec:"refs" json:"refs"`
 }
 
 func (o MessageSystemGitPush) DeepCopy() MessageSystemGitPush {
 	return MessageSystemGitPush{
-		Team:       o.Team,
-		Pusher:     o.Pusher,
-		RepoName:   o.RepoName,
-		BranchName: o.BranchName,
-		CommitMsgs: (func(x []string) []string {
+		Team:     o.Team,
+		Pusher:   o.Pusher,
+		RepoName: o.RepoName,
+		Refs: (func(x []keybase1.GitRefMetadata) []keybase1.GitRefMetadata {
 			if x == nil {
 				return nil
 			}
-			var ret []string
+			var ret []keybase1.GitRefMetadata
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
-		})(o.CommitMsgs),
+		})(o.Refs),
 	}
 }
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2129,3 +2129,18 @@ func (req *TeamChangeReq) AddUVWithRole(uv UserVersion, role TeamRole) error {
 	}
 	return nil
 }
+
+func TotalNumberOfCommits(refs []GitRefMetadata) (total int) {
+	for _, ref := range refs {
+		total += len(ref.Commits)
+	}
+	return total
+}
+
+func RefNames(refs []GitRefMetadata) string {
+	names := make([]string, len(refs))
+	for i, ref := range refs {
+		names[i] = ref.RefName
+	}
+	return strings.Join(names, ", ")
+}

--- a/go/protocol/keybase1/git.go
+++ b/go/protocol/keybase1/git.go
@@ -115,27 +115,67 @@ func (o GitLocalMetadataVersioned) DeepCopy() GitLocalMetadataVersioned {
 	}
 }
 
+type GitCommit struct {
+	CommitHash  string `codec:"commitHash" json:"commitHash"`
+	Message     string `codec:"message" json:"message"`
+	AuthorName  string `codec:"authorName" json:"authorName"`
+	AuthorEmail string `codec:"authorEmail" json:"authorEmail"`
+	Ctime       Time   `codec:"ctime" json:"ctime"`
+}
+
+func (o GitCommit) DeepCopy() GitCommit {
+	return GitCommit{
+		CommitHash:  o.CommitHash,
+		Message:     o.Message,
+		AuthorName:  o.AuthorName,
+		AuthorEmail: o.AuthorEmail,
+		Ctime:       o.Ctime.DeepCopy(),
+	}
+}
+
+type GitRefMetadata struct {
+	RefName              string      `codec:"refName" json:"refName"`
+	Commits              []GitCommit `codec:"commits" json:"commits"`
+	MoreCommitsAvailable bool        `codec:"moreCommitsAvailable" json:"moreCommitsAvailable"`
+}
+
+func (o GitRefMetadata) DeepCopy() GitRefMetadata {
+	return GitRefMetadata{
+		RefName: o.RefName,
+		Commits: (func(x []GitCommit) []GitCommit {
+			if x == nil {
+				return nil
+			}
+			var ret []GitCommit
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Commits),
+		MoreCommitsAvailable: o.MoreCommitsAvailable,
+	}
+}
+
 type GitLocalMetadata struct {
-	RepoName   GitRepoName `codec:"repoName" json:"repoName"`
-	BranchName string      `codec:"branchName" json:"branchName"`
-	CommitMsgs []string    `codec:"commitMsgs" json:"commitMsgs"`
+	RepoName GitRepoName      `codec:"repoName" json:"repoName"`
+	Refs     []GitRefMetadata `codec:"refs" json:"refs"`
 }
 
 func (o GitLocalMetadata) DeepCopy() GitLocalMetadata {
 	return GitLocalMetadata{
-		RepoName:   o.RepoName.DeepCopy(),
-		BranchName: o.BranchName,
-		CommitMsgs: (func(x []string) []string {
+		RepoName: o.RepoName.DeepCopy(),
+		Refs: (func(x []GitRefMetadata) []GitRefMetadata {
 			if x == nil {
 				return nil
 			}
-			var ret []string
+			var ret []GitRefMetadata
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
-		})(o.CommitMsgs),
+		})(o.Refs),
 	}
 }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -65,8 +65,7 @@ protocol local {
     string team;
     string pusher;
     string repoName;
-    string branchName;
-    array<string> commitMsgs;
+    array<keybase1.GitRefMetadata> refs;
   }
 
   variant MessageSystem switch (MessageSystemType systemType) {

--- a/protocol/avdl/keybase1/git.avdl
+++ b/protocol/avdl/keybase1/git.avdl
@@ -30,6 +30,20 @@ protocol git {
     case V1 : GitLocalMetadataV1;
   }
 
+  record GitCommit {
+    string commitHash;
+    string message;
+    string authorName;
+    string authorEmail;
+    Time ctime; // unix time in milliseconds
+  }
+
+  record GitRefMetadata {
+    string refName;    
+    array<GitCommit> commits;
+    boolean moreCommitsAvailable; // true if `commits` doesn't include all
+  }
+
   // GitLocalMetadata is the struct that local RPCs use to read and write repo
   // metadata. It's decoupled from GitLocalMetadataVersioned, which is the
   // format that we serialize and encrypt, in case we ever need to support
@@ -37,8 +51,7 @@ protocol git {
   // the only current variant, GitLocalMetadataV1.
   record GitLocalMetadata {
     GitRepoName repoName;
-    string branchName;
-    array<string> commitMsgs;
+    array<GitRefMetadata> refs;
   }
 
   // Additional metadata maintained by the server, returned with query results.

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -926,7 +926,7 @@ export type MessageSystemComplexTeam = {|team: String|}
 
 export type MessageSystemCreateTeam = {|team: String, creator: String|}
 
-export type MessageSystemGitPush = {|team: String, pusher: String, repoName: String, branchName: String, commitMsgs?: ?Array<String>|}
+export type MessageSystemGitPush = {|team: String, pusher: String, repoName: String, refs?: ?Array<Keybase1.GitRefMetadata>|}
 
 export type MessageSystemInviteAddedToTeam = {|team: String, inviter: String, invitee: String, adder: String, inviteType: Keybase1.TeamInviteCategory|}
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2255,6 +2255,8 @@ export type GetPassphraseRes = {|passphrase: String, storeSecret: Boolean|}
 
 export type GetTLFCryptKeysRes = {|nameIDBreaks: CanonicalTLFNameAndIDWithBreaks, CryptKeys?: ?Array<CryptKey>|}
 
+export type GitCommit = {|commitHash: String, message: String, authorName: String, authorEmail: String, ctime: Time|}
+
 export type GitCreatePersonalRepoRpcParam = {|repoName: GitRepoName, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type GitCreateTeamRepoRpcParam = {|repoName: GitRepoName, teamName: TeamName, notifyTeam: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
@@ -2275,7 +2277,7 @@ export type GitGetGitMetadataRpcParam = {|folder: Folder, incomingCallMap?: Inco
 
 export type GitGetTeamRepoSettingsRpcParam = {|folder: Folder, repoID: RepoID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type GitLocalMetadata = {|repoName: GitRepoName, branchName: String, commitMsgs?: ?Array<String>|}
+export type GitLocalMetadata = {|repoName: GitRepoName, refs?: ?Array<GitRefMetadata>|}
 
 export type GitLocalMetadataV1 = {|repoName: GitRepoName|}
 
@@ -2284,6 +2286,8 @@ export type GitLocalMetadataVersion = 1 // V1_1
 export type GitLocalMetadataVersioned = {version: 1, v1: ?GitLocalMetadataV1}
 
 export type GitPutGitMetadataRpcParam = {|folder: Folder, repoID: RepoID, metadata: GitLocalMetadata, notifyTeam: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
+export type GitRefMetadata = {|refName: String, commits?: ?Array<GitCommit>, moreCommitsAvailable: Boolean|}
 
 export type GitRepoInfo = {|folder: Folder, repoID: RepoID, localMetadata: GitLocalMetadata, serverMetadata: GitServerMetadata, repoUrl: String, globalUniqueID: String, canDelete: Boolean|}
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -198,15 +198,11 @@
           "name": "repoName"
         },
         {
-          "type": "string",
-          "name": "branchName"
-        },
-        {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "keybase1.GitRefMetadata"
           },
-          "name": "commitMsgs"
+          "name": "refs"
         }
       ]
     },

--- a/protocol/json/keybase1/git.json
+++ b/protocol/json/keybase1/git.json
@@ -75,6 +75,53 @@
     },
     {
       "type": "record",
+      "name": "GitCommit",
+      "fields": [
+        {
+          "type": "string",
+          "name": "commitHash"
+        },
+        {
+          "type": "string",
+          "name": "message"
+        },
+        {
+          "type": "string",
+          "name": "authorName"
+        },
+        {
+          "type": "string",
+          "name": "authorEmail"
+        },
+        {
+          "type": "Time",
+          "name": "ctime"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "GitRefMetadata",
+      "fields": [
+        {
+          "type": "string",
+          "name": "refName"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "GitCommit"
+          },
+          "name": "commits"
+        },
+        {
+          "type": "boolean",
+          "name": "moreCommitsAvailable"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "GitLocalMetadata",
       "fields": [
         {
@@ -82,15 +129,11 @@
           "name": "repoName"
         },
         {
-          "type": "string",
-          "name": "branchName"
-        },
-        {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "GitRefMetadata"
           },
-          "name": "commitMsgs"
+          "name": "refs"
         }
       ]
     },

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -926,7 +926,7 @@ export type MessageSystemComplexTeam = {|team: String|}
 
 export type MessageSystemCreateTeam = {|team: String, creator: String|}
 
-export type MessageSystemGitPush = {|team: String, pusher: String, repoName: String, branchName: String, commitMsgs?: ?Array<String>|}
+export type MessageSystemGitPush = {|team: String, pusher: String, repoName: String, refs?: ?Array<Keybase1.GitRefMetadata>|}
 
 export type MessageSystemInviteAddedToTeam = {|team: String, inviter: String, invitee: String, adder: String, inviteType: Keybase1.TeamInviteCategory|}
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2255,6 +2255,8 @@ export type GetPassphraseRes = {|passphrase: String, storeSecret: Boolean|}
 
 export type GetTLFCryptKeysRes = {|nameIDBreaks: CanonicalTLFNameAndIDWithBreaks, CryptKeys?: ?Array<CryptKey>|}
 
+export type GitCommit = {|commitHash: String, message: String, authorName: String, authorEmail: String, ctime: Time|}
+
 export type GitCreatePersonalRepoRpcParam = {|repoName: GitRepoName, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
 export type GitCreateTeamRepoRpcParam = {|repoName: GitRepoName, teamName: TeamName, notifyTeam: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
@@ -2275,7 +2277,7 @@ export type GitGetGitMetadataRpcParam = {|folder: Folder, incomingCallMap?: Inco
 
 export type GitGetTeamRepoSettingsRpcParam = {|folder: Folder, repoID: RepoID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
 
-export type GitLocalMetadata = {|repoName: GitRepoName, branchName: String, commitMsgs?: ?Array<String>|}
+export type GitLocalMetadata = {|repoName: GitRepoName, refs?: ?Array<GitRefMetadata>|}
 
 export type GitLocalMetadataV1 = {|repoName: GitRepoName|}
 
@@ -2284,6 +2286,8 @@ export type GitLocalMetadataVersion = 1 // V1_1
 export type GitLocalMetadataVersioned = {version: 1, v1: ?GitLocalMetadataV1}
 
 export type GitPutGitMetadataRpcParam = {|folder: Folder, repoID: RepoID, metadata: GitLocalMetadata, notifyTeam: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType|}
+
+export type GitRefMetadata = {|refName: String, commits?: ?Array<GitCommit>, moreCommitsAvailable: Boolean|}
 
 export type GitRepoInfo = {|folder: Folder, repoID: RepoID, localMetadata: GitLocalMetadata, serverMetadata: GitServerMetadata, repoUrl: String, globalUniqueID: String, canDelete: Boolean|}
 


### PR DESCRIPTION
This patch contains a protocol change for GitLocalMetadata to support the data that kbfs has for git pushes from discussions with @jzila.

Note:  it doesn't try to be backwards-compatible to the version that was released in admin builds yesterday.  Felt it was ok to break those messages.

After this goes in and the corresponding kbfs change, we can improve the frontend system message to include the new data.