### PR TITLE
bind: adapt to new KBFS libgit RPC method

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -174,9 +174,11 @@ type serviceCn struct {
 func (s serviceCn) NewKeybaseService(config libkbfs.Config, params libkbfs.InitParams, ctx libkbfs.Context, log logger.Logger) (libkbfs.KeybaseService, error) {
 	keybaseService := libkbfs.NewKeybaseDaemonRPC(
 		config, ctx, log, true, nil, nil)
+	// TODO: plumb the func somewhere it can be called on shutdown?
+	gitrpc, _ := libgit.NewRPCHandlerWithCtx(ctx, config, nil)
 	keybaseService.AddProtocols([]rpc.Protocol{
 		keybase1.FsProtocol(fsrpc.NewFS(config, log)),
-		keybase1.KBFSGitProtocol(libgit.NewRPCHandlerWithCtx(ctx, config, nil)),
+		keybase1.KBFSGitProtocol(gitrpc),
 	})
 	return keybaseService, nil
 }


### PR DESCRIPTION
Needs keybase/kbfs#1420 to pass circleci.

Issue: KBFS-2677