### PR TITLE
avoid stripping dots in FB usernames

### DIFF
--- a/go/externals/proof_support_facebook.go
+++ b/go/externals/proof_support_facebook.go
@@ -45,8 +45,9 @@ func (t FacebookServiceType) NormalizeUsername(s string) (string, error) {
 	if !facebookUsernameRegexp.MatchString(s) {
 		return "", libkb.NewBadUsernameError(s)
 	}
-	// Convert to lowercase and strip out dots.
-	return strings.ToLower(strings.Replace(s, ".", "", -1)), nil
+	// Convert to lowercase. Don't strip out dots, because while Facebook makes
+	// them optional, there are still dots in a user's "canonical" account name.
+	return strings.ToLower(s), nil
 }
 
 func (t FacebookServiceType) NormalizeRemoteName(ctx libkb.ProofContext, s string) (string, error) {


### PR DESCRIPTION
This was making `keybase id mike.maxim@facebook` fail before. Now it works, though supplying the name without dots still doesn't work. Filed https://keybase.atlassian.net/browse/CORE-6971 to deal with that problem later.

r? @mmaxim 
  