### PR TITLE
Virtualize the big team info panel

### DIFF
--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -17,7 +17,7 @@ import {
 import {globalColors, globalMargins, globalStyles, isMobile} from '../../../styles'
 import {branch} from 'recompose'
 import Notifications from './notifications/container'
-import Participants, {RenderParticipant} from './participants'
+import Participants, {Participant} from './participants'
 
 const border = `1px solid ${globalColors.black_05}`
 const scrollViewStyle = {
@@ -299,11 +299,7 @@ const _renderBigTeamRow = (i: number, props: BigTeamRow) => {
       )
     case 'participant':
       return (
-        <RenderParticipant
-          key={props.key}
-          participant={props.participant}
-          onShowProfile={props.onShowProfile}
-        />
+        <Participant key={props.key} participant={props.participant} onShowProfile={props.onShowProfile} />
       )
   }
 }

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -304,9 +304,10 @@ const _renderBigTeamRow = (i: number, props: BigTeamRow) => {
   }
 }
 
-const _rowSizeEstimator = (index, cache) => {
+const _rowSizeEstimator = (index, cache: {[index: number]: number}) => {
+  // Cache is an array of [index]: height
   if (index === 0) {
-    return cache[1] || 429 // estimate basd on size of header in non-admin non-preview mode
+    return cache[0] || 429 // estimate basd on size of header in non-admin non-preview mode
   }
   return 56
 }

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -307,7 +307,7 @@ const _renderBigTeamRow = (i: number, props: BigTeamRow) => {
 const _rowSizeEstimator = (index, cache: {[index: number]: number}) => {
   // Cache is an array of [index]: height
   if (index === 0) {
-    return cache[0] || 429 // estimate basd on size of header in non-admin non-preview mode
+    return cache[0] || 429 // estimate based on size of header in non-admin non-preview mode
   }
   return 56
 }

--- a/shared/chat/conversation/info-panel/participants.js
+++ b/shared/chat/conversation/info-panel/participants.js
@@ -46,6 +46,47 @@ const Participants = ({participants, onShowProfile}: Props) => (
   </Box>
 )
 
+type ParticipantProps = {
+  onShowProfile: (user: string) => void,
+  participant: {
+    username: string,
+    following: boolean,
+    fullname: string,
+    broken: boolean,
+    isYou: boolean,
+  },
+}
+
+const RenderParticipant = ({
+  participant: {username, following, fullname, broken, isYou},
+  onShowProfile,
+}: ParticipantProps) => (
+  <Box style={{...globalStyles.flexBoxColumn, paddingTop: globalMargins.tiny}}>
+    <ClickableBox key={username} onClick={() => onShowProfile(username)}>
+      <Box style={isMobile ? rowStyleMobile : rowStyle}>
+        <Box
+          style={{
+            ...globalStyles.flexBoxRow,
+            alignItems: 'center',
+            flex: 1,
+            marginRight: globalMargins.tiny,
+          }}
+        >
+          <Avatar size={isMobile ? 40 : 32} username={username} />
+          <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.small}}>
+            <Usernames
+              colorFollowing={true}
+              type="BodySemibold"
+              users={[{broken, following, username, you: isYou}]}
+            />
+            {fullname !== '' && <Text type="BodySmall">{fullname}</Text>}
+          </Box>
+        </Box>
+      </Box>
+    </ClickableBox>
+  </Box>
+)
+
 const rowStyle = {
   ...globalStyles.flexBoxColumn,
   ...globalStyles.clickable,
@@ -58,5 +99,5 @@ const rowStyleMobile = {
   ...rowStyle,
   minHeight: 56,
 }
-
+export {RenderParticipant}
 export default Participants

--- a/shared/chat/conversation/info-panel/participants.js
+++ b/shared/chat/conversation/info-panel/participants.js
@@ -16,31 +16,9 @@ type Props = {
 
 const Participants = ({participants, onShowProfile}: Props) => (
   <Box style={{...globalStyles.flexBoxColumn, paddingTop: globalMargins.tiny}}>
-    {participants.map(info => {
-      const {username, following, fullname, broken, isYou} = info
+    {participants.map(participant => {
       return (
-        <ClickableBox key={username} onClick={() => onShowProfile(username)}>
-          <Box style={isMobile ? rowStyleMobile : rowStyle}>
-            <Box
-              style={{
-                ...globalStyles.flexBoxRow,
-                alignItems: 'center',
-                flex: 1,
-                marginRight: globalMargins.tiny,
-              }}
-            >
-              <Avatar size={isMobile ? 40 : 32} username={username} />
-              <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.small}}>
-                <Usernames
-                  colorFollowing={true}
-                  type="BodySemibold"
-                  users={[{broken, following, username, you: isYou}]}
-                />
-                {fullname !== '' && <Text type="BodySmall">{fullname}</Text>}
-              </Box>
-            </Box>
-          </Box>
-        </ClickableBox>
+        <Participant key={participant.username} participant={participant} onShowProfile={onShowProfile} />
       )
     })}
   </Box>
@@ -57,7 +35,7 @@ type ParticipantProps = {
   },
 }
 
-const RenderParticipant = ({
+const Participant = ({
   participant: {username, following, fullname, broken, isYou},
   onShowProfile,
 }: ParticipantProps) => (
@@ -99,5 +77,5 @@ const rowStyleMobile = {
   ...rowStyle,
   minHeight: 56,
 }
-export {RenderParticipant}
+export {Participant}
 export default Participants

--- a/shared/common-adapters/list.desktop.js
+++ b/shared/common-adapters/list.desktop.js
@@ -22,6 +22,13 @@ class List extends PureComponent<Props<*>, void> {
     }
   }
 
+  _getType() {
+    if (this.props.itemSizeEstimator) {
+      return 'variable'
+    }
+    return this.props.fixedHeight ? 'uniform' : 'simple'
+  }
+
   render() {
     return (
       <div
@@ -44,8 +51,9 @@ class List extends PureComponent<Props<*>, void> {
               useTranslate3d={true}
               useStaticSize={!!this.props.fixedHeight}
               itemRenderer={this._itemRender}
+              itemSizeEstimator={this.props.itemSizeEstimator}
               length={this.props.items.length}
-              type={this.props.fixedHeight ? 'uniform' : 'simple'}
+              type={this._getType()}
             />
           </div>
         </div>

--- a/shared/common-adapters/list.js.flow
+++ b/shared/common-adapters/list.js.flow
@@ -6,8 +6,9 @@ export type Props<Item> = {
   style?: any,
   fixedHeight?: ?number,
   renderItem: (index: number, item: Item) => React.Node,
-  keyProperty?: string, // if passed uses item[keyProperty] for the item keys
+  keyProperty?: string, // if passed uses item[keyProperty] for the item keys (does nothing on desktop)
   selectedIndex?: number, // TODO work on mobile
+  itemSizeEstimator?: (index: number, cache: any) => number, // Desktop only
 }
 
 export default class List<Item> extends React.Component<Props<Item>, void> {}

--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -693,316 +693,346 @@ exports[`Storyshots Chat/Conversation/InfoPanel Participants (with add button) 1
         }
       >
         <div
-          onClick={[Function]}
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
           style={
             Object {
-              "alignItems": "stretch",
-              "borderRadius": 0,
-              "cursor": "pointer",
               "display": "flex",
               "flexDirection": "column",
-              "height": undefined,
-              "lineHeight": 0,
-              "minWidth": undefined,
-              "position": "relative",
-              "textAlign": "left",
-              "transform": "none",
-              "transition": "none",
+              "paddingTop": 8,
             }
           }
         >
           <div
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
             style={
               Object {
+                "alignItems": "stretch",
+                "borderRadius": 0,
                 "cursor": "pointer",
                 "display": "flex",
                 "flexDirection": "column",
-                "minHeight": 48,
-                "paddingLeft": 16,
-                "paddingRight": 16,
+                "height": undefined,
+                "lineHeight": 0,
+                "minWidth": undefined,
+                "position": "relative",
+                "textAlign": "left",
+                "transform": "none",
+                "transition": "none",
               }
             }
           >
             <div
               style={
                 Object {
-                  "alignItems": "center",
+                  "cursor": "pointer",
                   "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "marginRight": 8,
+                  "flexDirection": "column",
+                  "minHeight": 48,
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
                 }
               }
             >
               <div
-                onClick={undefined}
                 style={
                   Object {
-                    "height": 32,
-                    "maxWidth": 32,
-                    "minHeight": 32,
-                    "minWidth": 32,
-                    "position": "relative",
-                    "userSelect": "none",
-                  }
-                }
-              >
-                <div
-                  className="glamor-0"
-                />
-                <div
-                  className="glamor-1"
-                />
-              </div>
-              <div
-                style={
-                  Object {
+                    "alignItems": "center",
                     "display": "flex",
-                    "flexDirection": "column",
-                    "marginLeft": 16,
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "marginRight": 8,
                   }
                 }
               >
-                <span
-                  className="glamor-4"
+                <div
                   onClick={undefined}
-                  title={undefined}
+                  style={
+                    Object {
+                      "height": 32,
+                      "maxWidth": 32,
+                      "minHeight": 32,
+                      "minWidth": 32,
+                      "position": "relative",
+                      "userSelect": "none",
+                    }
+                  }
+                >
+                  <div
+                    className="glamor-0"
+                  />
+                  <div
+                    className="glamor-1"
+                  />
+                </div>
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "column",
+                      "marginLeft": 16,
+                    }
+                  }
                 >
                   <span
-                    className="glamor-3"
+                    className="glamor-4"
                     onClick={undefined}
                     title={undefined}
                   >
                     <span
-                      className="glamor-2"
+                      className="glamor-3"
                       onClick={undefined}
                       title={undefined}
                     >
-                      akalin
+                      <span
+                        className="glamor-2"
+                        onClick={undefined}
+                        title={undefined}
+                      >
+                        akalin
+                      </span>
                     </span>
                   </span>
-                </span>
-                <span
-                  className="glamor-5"
-                  onClick={undefined}
-                  title={undefined}
-                >
-                  Fred Akalin
-                </span>
+                  <span
+                    className="glamor-5"
+                    onClick={undefined}
+                    title={undefined}
+                  >
+                    Fred Akalin
+                  </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
         <div
-          onClick={[Function]}
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
           style={
             Object {
-              "alignItems": "stretch",
-              "borderRadius": 0,
-              "cursor": "pointer",
               "display": "flex",
               "flexDirection": "column",
-              "height": undefined,
-              "lineHeight": 0,
-              "minWidth": undefined,
-              "position": "relative",
-              "textAlign": "left",
-              "transform": "none",
-              "transition": "none",
+              "paddingTop": 8,
             }
           }
         >
           <div
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
             style={
               Object {
+                "alignItems": "stretch",
+                "borderRadius": 0,
                 "cursor": "pointer",
                 "display": "flex",
                 "flexDirection": "column",
-                "minHeight": 48,
-                "paddingLeft": 16,
-                "paddingRight": 16,
+                "height": undefined,
+                "lineHeight": 0,
+                "minWidth": undefined,
+                "position": "relative",
+                "textAlign": "left",
+                "transform": "none",
+                "transition": "none",
               }
             }
           >
             <div
               style={
                 Object {
-                  "alignItems": "center",
+                  "cursor": "pointer",
                   "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "marginRight": 8,
+                  "flexDirection": "column",
+                  "minHeight": 48,
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
                 }
               }
             >
               <div
-                onClick={undefined}
                 style={
                   Object {
-                    "height": 32,
-                    "maxWidth": 32,
-                    "minHeight": 32,
-                    "minWidth": 32,
-                    "position": "relative",
-                    "userSelect": "none",
-                  }
-                }
-              >
-                <div
-                  className="glamor-0"
-                />
-                <div
-                  className="glamor-1"
-                />
-              </div>
-              <div
-                style={
-                  Object {
+                    "alignItems": "center",
                     "display": "flex",
-                    "flexDirection": "column",
-                    "marginLeft": 16,
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "marginRight": 8,
                   }
                 }
               >
-                <span
-                  className="glamor-4"
+                <div
                   onClick={undefined}
-                  title={undefined}
+                  style={
+                    Object {
+                      "height": 32,
+                      "maxWidth": 32,
+                      "minHeight": 32,
+                      "minWidth": 32,
+                      "position": "relative",
+                      "userSelect": "none",
+                    }
+                  }
+                >
+                  <div
+                    className="glamor-0"
+                  />
+                  <div
+                    className="glamor-1"
+                  />
+                </div>
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "column",
+                      "marginLeft": 16,
+                    }
+                  }
                 >
                   <span
-                    className="glamor-3"
+                    className="glamor-4"
                     onClick={undefined}
                     title={undefined}
                   >
                     <span
-                      className="glamor-8"
+                      className="glamor-3"
                       onClick={undefined}
                       title={undefined}
                     >
-                      strib
+                      <span
+                        className="glamor-8"
+                        onClick={undefined}
+                        title={undefined}
+                      >
+                        strib
+                      </span>
                     </span>
                   </span>
-                </span>
-                <span
-                  className="glamor-5"
-                  onClick={undefined}
-                  title={undefined}
-                >
-                  Jeremy Stribling
-                </span>
+                  <span
+                    className="glamor-5"
+                    onClick={undefined}
+                    title={undefined}
+                  >
+                    Jeremy Stribling
+                  </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
         <div
-          onClick={[Function]}
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
           style={
             Object {
-              "alignItems": "stretch",
-              "borderRadius": 0,
-              "cursor": "pointer",
               "display": "flex",
               "flexDirection": "column",
-              "height": undefined,
-              "lineHeight": 0,
-              "minWidth": undefined,
-              "position": "relative",
-              "textAlign": "left",
-              "transform": "none",
-              "transition": "none",
+              "paddingTop": 8,
             }
           }
         >
           <div
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
             style={
               Object {
+                "alignItems": "stretch",
+                "borderRadius": 0,
                 "cursor": "pointer",
                 "display": "flex",
                 "flexDirection": "column",
-                "minHeight": 48,
-                "paddingLeft": 16,
-                "paddingRight": 16,
+                "height": undefined,
+                "lineHeight": 0,
+                "minWidth": undefined,
+                "position": "relative",
+                "textAlign": "left",
+                "transform": "none",
+                "transition": "none",
               }
             }
           >
             <div
               style={
                 Object {
-                  "alignItems": "center",
+                  "cursor": "pointer",
                   "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "marginRight": 8,
+                  "flexDirection": "column",
+                  "minHeight": 48,
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
                 }
               }
             >
               <div
-                onClick={undefined}
                 style={
                   Object {
-                    "height": 32,
-                    "maxWidth": 32,
-                    "minHeight": 32,
-                    "minWidth": 32,
-                    "position": "relative",
-                    "userSelect": "none",
-                  }
-                }
-              >
-                <div
-                  className="glamor-0"
-                />
-                <div
-                  className="glamor-1"
-                />
-              </div>
-              <div
-                style={
-                  Object {
+                    "alignItems": "center",
                     "display": "flex",
-                    "flexDirection": "column",
-                    "marginLeft": 16,
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "marginRight": 8,
                   }
                 }
               >
-                <span
-                  className="glamor-4"
+                <div
                   onClick={undefined}
-                  title={undefined}
+                  style={
+                    Object {
+                      "height": 32,
+                      "maxWidth": 32,
+                      "minHeight": 32,
+                      "minWidth": 32,
+                      "position": "relative",
+                      "userSelect": "none",
+                    }
+                  }
+                >
+                  <div
+                    className="glamor-0"
+                  />
+                  <div
+                    className="glamor-1"
+                  />
+                </div>
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "column",
+                      "marginLeft": 16,
+                    }
+                  }
                 >
                   <span
-                    className="glamor-3"
+                    className="glamor-4"
                     onClick={undefined}
                     title={undefined}
                   >
                     <span
-                      className="glamor-14"
+                      className="glamor-3"
                       onClick={undefined}
                       title={undefined}
                     >
-                      max
+                      <span
+                        className="glamor-14"
+                        onClick={undefined}
+                        title={undefined}
+                      >
+                        max
+                      </span>
                     </span>
                   </span>
-                </span>
-                <span
-                  className="glamor-5"
-                  onClick={undefined}
-                  title={undefined}
-                >
-                  Max Krohn
-                </span>
+                  <span
+                    className="glamor-5"
+                    onClick={undefined}
+                    title={undefined}
+                  >
+                    Max Krohn
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1152,316 +1182,346 @@ exports[`Storyshots Chat/Conversation/InfoPanel Participants 1`] = `
         }
       >
         <div
-          onClick={[Function]}
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
           style={
             Object {
-              "alignItems": "stretch",
-              "borderRadius": 0,
-              "cursor": "pointer",
               "display": "flex",
               "flexDirection": "column",
-              "height": undefined,
-              "lineHeight": 0,
-              "minWidth": undefined,
-              "position": "relative",
-              "textAlign": "left",
-              "transform": "none",
-              "transition": "none",
+              "paddingTop": 8,
             }
           }
         >
           <div
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
             style={
               Object {
+                "alignItems": "stretch",
+                "borderRadius": 0,
                 "cursor": "pointer",
                 "display": "flex",
                 "flexDirection": "column",
-                "minHeight": 48,
-                "paddingLeft": 16,
-                "paddingRight": 16,
+                "height": undefined,
+                "lineHeight": 0,
+                "minWidth": undefined,
+                "position": "relative",
+                "textAlign": "left",
+                "transform": "none",
+                "transition": "none",
               }
             }
           >
             <div
               style={
                 Object {
-                  "alignItems": "center",
+                  "cursor": "pointer",
                   "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "marginRight": 8,
+                  "flexDirection": "column",
+                  "minHeight": 48,
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
                 }
               }
             >
               <div
-                onClick={undefined}
                 style={
                   Object {
-                    "height": 32,
-                    "maxWidth": 32,
-                    "minHeight": 32,
-                    "minWidth": 32,
-                    "position": "relative",
-                    "userSelect": "none",
-                  }
-                }
-              >
-                <div
-                  className="glamor-0"
-                />
-                <div
-                  className="glamor-1"
-                />
-              </div>
-              <div
-                style={
-                  Object {
+                    "alignItems": "center",
                     "display": "flex",
-                    "flexDirection": "column",
-                    "marginLeft": 16,
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "marginRight": 8,
                   }
                 }
               >
-                <span
-                  className="glamor-4"
+                <div
                   onClick={undefined}
-                  title={undefined}
+                  style={
+                    Object {
+                      "height": 32,
+                      "maxWidth": 32,
+                      "minHeight": 32,
+                      "minWidth": 32,
+                      "position": "relative",
+                      "userSelect": "none",
+                    }
+                  }
+                >
+                  <div
+                    className="glamor-0"
+                  />
+                  <div
+                    className="glamor-1"
+                  />
+                </div>
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "column",
+                      "marginLeft": 16,
+                    }
+                  }
                 >
                   <span
-                    className="glamor-3"
+                    className="glamor-4"
                     onClick={undefined}
                     title={undefined}
                   >
                     <span
-                      className="glamor-2"
+                      className="glamor-3"
                       onClick={undefined}
                       title={undefined}
                     >
-                      akalin
+                      <span
+                        className="glamor-2"
+                        onClick={undefined}
+                        title={undefined}
+                      >
+                        akalin
+                      </span>
                     </span>
                   </span>
-                </span>
-                <span
-                  className="glamor-5"
-                  onClick={undefined}
-                  title={undefined}
-                >
-                  Fred Akalin
-                </span>
+                  <span
+                    className="glamor-5"
+                    onClick={undefined}
+                    title={undefined}
+                  >
+                    Fred Akalin
+                  </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
         <div
-          onClick={[Function]}
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
           style={
             Object {
-              "alignItems": "stretch",
-              "borderRadius": 0,
-              "cursor": "pointer",
               "display": "flex",
               "flexDirection": "column",
-              "height": undefined,
-              "lineHeight": 0,
-              "minWidth": undefined,
-              "position": "relative",
-              "textAlign": "left",
-              "transform": "none",
-              "transition": "none",
+              "paddingTop": 8,
             }
           }
         >
           <div
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
             style={
               Object {
+                "alignItems": "stretch",
+                "borderRadius": 0,
                 "cursor": "pointer",
                 "display": "flex",
                 "flexDirection": "column",
-                "minHeight": 48,
-                "paddingLeft": 16,
-                "paddingRight": 16,
+                "height": undefined,
+                "lineHeight": 0,
+                "minWidth": undefined,
+                "position": "relative",
+                "textAlign": "left",
+                "transform": "none",
+                "transition": "none",
               }
             }
           >
             <div
               style={
                 Object {
-                  "alignItems": "center",
+                  "cursor": "pointer",
                   "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "marginRight": 8,
+                  "flexDirection": "column",
+                  "minHeight": 48,
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
                 }
               }
             >
               <div
-                onClick={undefined}
                 style={
                   Object {
-                    "height": 32,
-                    "maxWidth": 32,
-                    "minHeight": 32,
-                    "minWidth": 32,
-                    "position": "relative",
-                    "userSelect": "none",
-                  }
-                }
-              >
-                <div
-                  className="glamor-0"
-                />
-                <div
-                  className="glamor-1"
-                />
-              </div>
-              <div
-                style={
-                  Object {
+                    "alignItems": "center",
                     "display": "flex",
-                    "flexDirection": "column",
-                    "marginLeft": 16,
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "marginRight": 8,
                   }
                 }
               >
-                <span
-                  className="glamor-4"
+                <div
                   onClick={undefined}
-                  title={undefined}
+                  style={
+                    Object {
+                      "height": 32,
+                      "maxWidth": 32,
+                      "minHeight": 32,
+                      "minWidth": 32,
+                      "position": "relative",
+                      "userSelect": "none",
+                    }
+                  }
+                >
+                  <div
+                    className="glamor-0"
+                  />
+                  <div
+                    className="glamor-1"
+                  />
+                </div>
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "column",
+                      "marginLeft": 16,
+                    }
+                  }
                 >
                   <span
-                    className="glamor-3"
+                    className="glamor-4"
                     onClick={undefined}
                     title={undefined}
                   >
                     <span
-                      className="glamor-8"
+                      className="glamor-3"
                       onClick={undefined}
                       title={undefined}
                     >
-                      strib
+                      <span
+                        className="glamor-8"
+                        onClick={undefined}
+                        title={undefined}
+                      >
+                        strib
+                      </span>
                     </span>
                   </span>
-                </span>
-                <span
-                  className="glamor-5"
-                  onClick={undefined}
-                  title={undefined}
-                >
-                  Jeremy Stribling
-                </span>
+                  <span
+                    className="glamor-5"
+                    onClick={undefined}
+                    title={undefined}
+                  >
+                    Jeremy Stribling
+                  </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
         <div
-          onClick={[Function]}
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
           style={
             Object {
-              "alignItems": "stretch",
-              "borderRadius": 0,
-              "cursor": "pointer",
               "display": "flex",
               "flexDirection": "column",
-              "height": undefined,
-              "lineHeight": 0,
-              "minWidth": undefined,
-              "position": "relative",
-              "textAlign": "left",
-              "transform": "none",
-              "transition": "none",
+              "paddingTop": 8,
             }
           }
         >
           <div
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
             style={
               Object {
+                "alignItems": "stretch",
+                "borderRadius": 0,
                 "cursor": "pointer",
                 "display": "flex",
                 "flexDirection": "column",
-                "minHeight": 48,
-                "paddingLeft": 16,
-                "paddingRight": 16,
+                "height": undefined,
+                "lineHeight": 0,
+                "minWidth": undefined,
+                "position": "relative",
+                "textAlign": "left",
+                "transform": "none",
+                "transition": "none",
               }
             }
           >
             <div
               style={
                 Object {
-                  "alignItems": "center",
+                  "cursor": "pointer",
                   "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "marginRight": 8,
+                  "flexDirection": "column",
+                  "minHeight": 48,
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
                 }
               }
             >
               <div
-                onClick={undefined}
                 style={
                   Object {
-                    "height": 32,
-                    "maxWidth": 32,
-                    "minHeight": 32,
-                    "minWidth": 32,
-                    "position": "relative",
-                    "userSelect": "none",
-                  }
-                }
-              >
-                <div
-                  className="glamor-0"
-                />
-                <div
-                  className="glamor-1"
-                />
-              </div>
-              <div
-                style={
-                  Object {
+                    "alignItems": "center",
                     "display": "flex",
-                    "flexDirection": "column",
-                    "marginLeft": 16,
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "marginRight": 8,
                   }
                 }
               >
-                <span
-                  className="glamor-4"
+                <div
                   onClick={undefined}
-                  title={undefined}
+                  style={
+                    Object {
+                      "height": 32,
+                      "maxWidth": 32,
+                      "minHeight": 32,
+                      "minWidth": 32,
+                      "position": "relative",
+                      "userSelect": "none",
+                    }
+                  }
+                >
+                  <div
+                    className="glamor-0"
+                  />
+                  <div
+                    className="glamor-1"
+                  />
+                </div>
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "column",
+                      "marginLeft": 16,
+                    }
+                  }
                 >
                   <span
-                    className="glamor-3"
+                    className="glamor-4"
                     onClick={undefined}
                     title={undefined}
                   >
                     <span
-                      className="glamor-14"
+                      className="glamor-3"
                       onClick={undefined}
                       title={undefined}
                     >
-                      max
+                      <span
+                        className="glamor-14"
+                        onClick={undefined}
+                        title={undefined}
+                      >
+                        max
+                      </span>
                     </span>
                   </span>
-                </span>
-                <span
-                  className="glamor-5"
-                  onClick={undefined}
-                  title={undefined}
-                >
-                  Max Krohn
-                </span>
+                  <span
+                    className="glamor-5"
+                    onClick={undefined}
+                    title={undefined}
+                  >
+                    Max Krohn
+                  </span>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR makes use of `List` to speed up loading the big team info panel. I added an additional prop to `List` [`itemSizeEstimator`](https://github.com/coderiety/react-list#itemsizeestimatorindex-cache) which sets `ReactList`'s type to`variable`, making it cache pre-measured row heights with help from the estimator function.

r? @keybase/react-hackers 