### PR TITLE
Fix save team settings button on mobile

### DIFF
--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -353,6 +353,7 @@ class Team extends React.PureComponent<Props> {
             flexBasis: 0,
             flexGrow: 1,
           }}
+          contentContainerStyle={isMobile ? {paddingBottom: globalMargins.large} : {}}
         >
           {!youImplicitAdmin && (
             <Box

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -349,11 +349,10 @@ class Team extends React.PureComponent<Props> {
           style={{
             ...globalStyles.flexBoxColumn,
             alignSelf: 'stretch',
-            padding: globalMargins.medium,
             flexBasis: 0,
             flexGrow: 1,
           }}
-          contentContainerStyle={isMobile ? {paddingBottom: globalMargins.large} : {}}
+          contentContainerStyle={{padding: globalMargins.medium}}
         >
           {!youImplicitAdmin && (
             <Box


### PR DESCRIPTION
I tried setting `height: '100%'` on the root along with `flex: 1` on the settings `ScrollView` (direct child), but for some reason the view height kept extending underneath the nav. This sets a larger `containerStyle` padding on mobile to add the extra space.

<img width="496" alt="image" src="https://user-images.githubusercontent.com/11968340/34693492-bde528ba-f491-11e7-99c6-03fe3fe99e69.png">

r? @keybase/react-hackers 