### PR TITLE
enable implicit team chat by default for new convos CORE-6958

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1028,10 +1028,7 @@ func (e *Env) GetChatInboxSourceLocalizeThreads() int {
 // GetChatMemberType returns the default member type for new conversations.
 // Currently defaults to `kbfs`, but `impteam` will be default in future (and is the default for admins)
 func (e *Env) GetChatMemberType() string {
-	if e.GetFeatureFlags().Admin() {
-		return "impteam"
-	}
-	return "kbfs"
+	return "impteam"
 }
 
 func (e *Env) GetDeviceID() keybase1.DeviceID {

--- a/shared/util/feature-flags.desktop.js
+++ b/shared/util/feature-flags.desktop.js
@@ -18,7 +18,7 @@ const ff: FeatureFlags = {
   tabGitEnabled: true,
   tabPeopleEnabled: true,
   teamChatEnabled: true,
-  impTeamChatEnabled: false,
+  impTeamChatEnabled: true,
 }
 
 const inAdmin: {[key: $Keys<FeatureFlags>]: boolean} = {

--- a/shared/util/feature-flags.native.js
+++ b/shared/util/feature-flags.native.js
@@ -8,7 +8,7 @@ const ff: FeatureFlags = {
   tabPeopleEnabled: false,
   teamChatEnabled: true,
   tabGitEnabled: true,
-  impTeamChatEnabled: false,
+  impTeamChatEnabled: true,
 }
 
 if (__DEV__) {


### PR DESCRIPTION
Ran through a bunch of tests, and I think stuff works really well. It is at least as good as the KBFS side, and brings in all of our improvements as well.