### PR TITLE
use the /usr/lib64 prefix for the Firefox native messaging manifest

### DIFF
--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -59,6 +59,14 @@ build_one_architecture() {
   cp -r "$binaries_path"/* "$copied_binaries/"
   echo "copied_binaries: $copied_binaries"
 
+  # RPM-based distros (though not Debian or Arch, see
+  # https://wiki.debian.org/Multiarch/TheCaseForMultiarch) distinguish between
+  # /usr/lib and /usr/lib64, and on 64-bit systems Firefox will not search for
+  # native messaging manifests under /usr/lib. Copy the manifests into both
+  # places, for good measure.
+  mkdir -p "$copied_binaries/usr/lib64/mozilla"
+  cp -r "$copied_binaries/usr/lib/mozilla/native-messaging-hosts" "$copied_binaries/usr/lib64/mozilla/"
+
   # We need to copy in the cron file before we collect the list of all files
   # below.
   cron_file="$copied_binaries/etc/cron.daily/$name"


### PR DESCRIPTION
This should fix https://github.com/keybase/client/issues/8754.

r? @maxtaco 

@shazow do you have a moment to eyeball this? Let me know if you remember dealing with the same issue in a different way.