### PR TITLE
only show 'manage channel subscriptions' for big teams

### DIFF
--- a/shared/chat/conversation/messages/joinedleft/container.js
+++ b/shared/chat/conversation/messages/joinedleft/container.js
@@ -17,6 +17,7 @@ import type {OwnProps} from './container'
 
 type StateProps = {
   channelname: string,
+  isBigTeam: boolean,
   message: Types.TextMessage,
   following: boolean,
   teamname: string,
@@ -35,16 +36,19 @@ const getDetails = createCachedSelector(
     Constants.getChannelName,
     Constants.getTeamName,
     Constants.getFollowing,
+    Constants.getIsBigTeam,
   ],
   (
     message: Types.JoinedLeftMessage,
     you: string,
     channelname: string,
     teamname: string,
-    following: I.Set<Types.Username>
+    following: I.Set<Types.Username>,
+    isBigTeam: boolean
   ) => ({
     channelname,
     following: following.has(message.author),
+    isBigTeam,
     message,
     teamname,
     you,

--- a/shared/chat/conversation/messages/joinedleft/index.js
+++ b/shared/chat/conversation/messages/joinedleft/index.js
@@ -59,7 +59,7 @@ const JoinedLeftNotice = ({
           backgroundMode="Announcements"
           onClick={onManageChannels}
           style={{color: globalColors.blue}}
-          type="BodySmallPrimaryLink"
+          type="BodySmallSemibold"
         >
           Manage channel subscriptions.
         </Text>

--- a/shared/chat/conversation/messages/joinedleft/index.js
+++ b/shared/chat/conversation/messages/joinedleft/index.js
@@ -9,6 +9,7 @@ import type {TextMessage} from '../../../../constants/types/chat'
 
 type Props = {
   channelname: string,
+  isBigTeam: boolean,
   message: TextMessage,
   onManageChannels: () => void,
   onUsernameClicked: (username: string) => void,
@@ -20,8 +21,10 @@ type Props = {
 const JoinedLeftNotice = ({
   channelname,
   message,
+  isBigTeam,
   onManageChannels,
   you,
+  teamname,
   following,
   onUsernameClicked,
 }: Props) => (
@@ -41,18 +44,26 @@ const JoinedLeftNotice = ({
           users={[{username: message.author, following, you: you === message.author}]}
         />
       )}{' '}
-      {message.message.stringValue()} #{channelname}.
+      {message.message.stringValue()}{' '}
+      {isBigTeam ? (
+        `#${channelname}`
+      ) : (
+        <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
+          {teamname}
+        </Text>
+      )}.
     </Text>
-    {message.author === you && (
-      <Text
-        backgroundMode="Announcements"
-        onClick={onManageChannels}
-        style={{color: globalColors.blue}}
-        type="BodySmallPrimaryLink"
-      >
-        Manage channel subscriptions.
-      </Text>
-    )}
+    {message.author === you &&
+      isBigTeam && (
+        <Text
+          backgroundMode="Announcements"
+          onClick={onManageChannels}
+          style={{color: globalColors.blue}}
+          type="BodySmallPrimaryLink"
+        >
+          Manage channel subscriptions.
+        </Text>
+      )}
   </UserNotice>
 )
 

--- a/shared/chat/conversation/messages/system/container.js
+++ b/shared/chat/conversation/messages/system/container.js
@@ -14,9 +14,10 @@ import type {TypedState} from '../../../../constants/reducer'
 import type {OwnProps} from './container'
 
 const getDetails = createCachedSelector(
-  [Constants.getMessageFromMessageKey, Constants.getYou, getRole],
-  (message: Types.SystemMessage, you: string, role: TeamRoleType) => ({
+  [Constants.getMessageFromMessageKey, Constants.getYou, getRole, Constants.getIsBigTeam],
+  (message: Types.SystemMessage, you: string, role: TeamRoleType, isBigTeam: boolean) => ({
     admin: isAdmin(role) || isOwner(role),
+    isBigTeam,
     message,
     info: message.info,
     you,

--- a/shared/chat/conversation/messages/system/index.js
+++ b/shared/chat/conversation/messages/system/index.js
@@ -25,6 +25,7 @@ const connectedUsernamesProps = {
 type Props = {
   admin: boolean,
   channelname: string,
+  isBigTeam: boolean,
   message: SystemMessage,
   onManageChannels: (teamname: string) => void,
   onViewTeam: (teamname: string) => void,
@@ -37,6 +38,7 @@ type AddedToTeamProps = Props & {info: AddedToTeamInfo}
 const AddedToTeamNotice = ({
   admin,
   channelname,
+  isBigTeam,
   message,
   info,
   onManageChannels,
@@ -53,7 +55,7 @@ const AddedToTeamNotice = ({
 
   let manageComponent = null
 
-  if (addee === you) {
+  if (addee === you && isBigTeam) {
     manageComponent = (
       <Text
         onClick={() => onManageChannels(team)}

--- a/shared/chat/conversation/messages/system/index.js
+++ b/shared/chat/conversation/messages/system/index.js
@@ -50,8 +50,9 @@ const AddedToTeamNotice = ({
   const adderComponent =
     adder === you ? 'You' : <ConnectedUsernames {...connectedUsernamesProps} usernames={[adder]} />
 
+  const selfAddee = adder === you ? 'yourself' : 'you'
   const addeeComponent =
-    addee === you ? 'you' : <ConnectedUsernames {...connectedUsernamesProps} usernames={[addee]} />
+    addee === you ? selfAddee : <ConnectedUsernames {...connectedUsernamesProps} usernames={[addee]} />
 
   let manageComponent = null
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -437,6 +437,7 @@ const getInbox = (state: TypedState, conversationIDKey: ?Types.ConversationIDKey
 const getFullInbox = (state: TypedState) => state.chat.inbox
 const getSelectedInbox = (state: TypedState) => getInbox(state, getSelectedConversation(state))
 const getEditingMessage = (state: TypedState) => state.chat.get('editingMessage')
+const getInboxBigChannelsToTeam = (state: TypedState) => state.chat.get('inboxBigChannelsToTeam')
 
 const getParticipants = createSelector(
   [getSelectedInbox, getSelectedConversation],
@@ -498,6 +499,12 @@ const getTeamName = createSelector(
 const getTeamType = createSelector(
   [getSelectedInbox],
   selectedInbox => selectedInbox && selectedInbox.get('teamType')
+)
+
+const getIsBigTeam = createSelector(
+  [getSelectedInbox, getInboxBigChannelsToTeam],
+  (selectedInbox, inboxBigChannelsToTeam) =>
+    inboxBigChannelsToTeam.includes((!!selectedInbox && selectedInbox.teamname) || '')
 )
 
 const getSelectedConversationStates = (state: TypedState): ?Types.ConversationState => {
@@ -746,6 +753,7 @@ export {
   getSnippet,
   getTeamName,
   getTeamType,
+  getIsBigTeam,
   conversationIDToKey,
   convSupersedesInfo,
   convSupersededByInfo,


### PR DESCRIPTION
Also `You added you` -> `You added yourself` for self-adds in subteams

r? @keybase/react-hackers 