### PR TITLE
Refactor profile navigation logic

### DIFF
--- a/shared/actions/profile/__test__/profile-path.test.js
+++ b/shared/actions/profile/__test__/profile-path.test.js
@@ -1,0 +1,170 @@
+// @noflow
+/* eslint-env jest */
+import {getProfilePath} from '../../../constants/profile'
+import * as I from 'immutable'
+import type {PropsPath} from '../../../route-tree/index'
+import {peopleTab} from '../../../constants/tabs'
+
+// These tests are for navigation with newPeopleTab: false
+// when the new people tab is going to be released these
+// expectedPaths must change to reflect the new root behavior
+describe('getProfilePath', () => {
+  const state = {
+    entities: {
+      search: {
+        searchResults: {
+          get: () => null,
+        },
+      },
+    },
+  }
+
+  const noPath = I.List()
+  const baseTab = I.List([{node: peopleTab, props: I.Map({})}])
+  const oneProfile = I.List([
+    {node: peopleTab, props: I.Map({})},
+    {node: 'profile', props: I.Map({username: 'chrisnojima'})},
+  ])
+  const editProfile = I.List([
+    {node: peopleTab, props: I.Map({})},
+    {node: 'profile', props: I.Map({username: 'ayoubd'})},
+    {node: 'editProfile', props: I.Map({})},
+  ])
+  const nonUserOnTop = I.List([
+    {node: peopleTab, props: I.Map({})},
+    {node: 'profile', props: I.Map({username: 'chris'})},
+    {
+      node: 'nonUserProfile',
+      props: I.Map({
+        fullUsername: 'realdonaldtrump@twitter',
+        serviceName: 'Twitter',
+        username: 'realdonaldtrump',
+      }),
+    },
+  ])
+  const proofOnTop = I.List([
+    {node: peopleTab, props: I.Map({})},
+    {node: 'profile', props: I.Map({username: 'chris'})},
+    {node: 'proveEnterUsername', props: I.Map({})},
+  ])
+
+  function check(
+    peopleRouteProps: I.List<{node: ?string, props: I.Map<string, any>}>,
+    username: string,
+    me: string,
+    expectedPath: PropsPath<*>
+  ) {
+    const result = getProfilePath(peopleRouteProps, username, me, state)
+    expect(result).toMatchObject(expectedPath)
+  }
+
+  it('Navigates correctly to user profiles', () => {
+    check(noPath, 'ayoubd', 'ayoubd', [peopleTab])
+    check(noPath, 'chris', 'ayoubd', [peopleTab, {selected: 'profile', props: {username: 'chris'}}])
+
+    check(baseTab, 'ayoubd', 'ayoubd', [peopleTab])
+    check(baseTab, 'chris', 'ayoubd', [peopleTab, {selected: 'profile', props: {username: 'chris'}}])
+
+    check(oneProfile, 'chrisnojima', 'ayoubd', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'chrisnojima'}},
+    ])
+    check(oneProfile, 'ayoubd', 'ayoubd', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'chrisnojima'}},
+      {selected: 'profile', props: {username: 'ayoubd'}},
+    ])
+
+    check(editProfile, 'ayoubd', 'ayoubd', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'ayoubd'}},
+    ])
+    check(editProfile, 'mlsteele', 'ayoubd', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'ayoubd'}},
+      {selected: 'profile', props: {username: 'mlsteele'}},
+    ])
+
+    check(nonUserOnTop, 'ayoubd', 'ayoubd', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'chris'}},
+      {
+        selected: 'nonUserProfile',
+        props: {
+          fullUsername: 'realdonaldtrump@twitter',
+          serviceName: 'Twitter',
+          username: 'realdonaldtrump',
+        },
+      },
+      {selected: 'profile', props: {username: 'ayoubd'}},
+    ])
+
+    check(proofOnTop, 'chris', 'chris', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'chris'}},
+    ])
+    check(proofOnTop, 'ayoubd', 'chris', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'chris'}},
+      {selected: 'profile', props: {username: 'ayoubd'}},
+    ])
+  })
+
+  it('Navigates correctly to non user profiles', () => {
+    check(baseTab, 'realdonaldtrump@twitter', 'ayoubd', [
+      {selected: peopleTab, props: {}},
+      {
+        selected: 'nonUserProfile',
+        props: {fullUsername: 'realdonaldtrump@twitter', serviceName: 'Twitter', username: 'realdonaldtrump'},
+      },
+    ])
+
+    check(oneProfile, 'realdonaldtrump@twitter', 'ayoubd', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'chrisnojima'}},
+      {
+        selected: 'nonUserProfile',
+        props: {fullUsername: 'realdonaldtrump@twitter', serviceName: 'Twitter', username: 'realdonaldtrump'},
+      },
+    ])
+
+    check(editProfile, 'realdonaldtrump@twitter', 'ayoubd', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'ayoubd'}},
+      {
+        selected: 'nonUserProfile',
+        props: {fullUsername: 'realdonaldtrump@twitter', serviceName: 'Twitter', username: 'realdonaldtrump'},
+      },
+    ])
+
+    check(nonUserOnTop, 'realdonaldtrump@twitter', 'ayoubd', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'chris'}},
+      {
+        selected: 'nonUserProfile',
+        props: {fullUsername: 'realdonaldtrump@twitter', serviceName: 'Twitter', username: 'realdonaldtrump'},
+      },
+    ])
+    check(nonUserOnTop, 'keybaseIO@twitter', 'ayoubd', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'chris'}},
+      {
+        selected: 'nonUserProfile',
+        props: {fullUsername: 'realdonaldtrump@twitter', serviceName: 'Twitter', username: 'realdonaldtrump'},
+      },
+      {
+        selected: 'nonUserProfile',
+        props: {fullUsername: 'keybaseIO@twitter', serviceName: 'Twitter', username: 'keybaseIO'},
+      },
+    ])
+
+    check(proofOnTop, 'realdonaldtrump@twitter', 'chris', [
+      {selected: peopleTab, props: {}},
+      {selected: 'profile', props: {username: 'chris'}},
+      {
+        selected: 'nonUserProfile',
+        props: {fullUsername: 'realdonaldtrump@twitter', serviceName: 'Twitter', username: 'realdonaldtrump'},
+      },
+    ])
+  })
+})

--- a/shared/actions/profile/index.js
+++ b/shared/actions/profile/index.js
@@ -52,7 +52,6 @@ function _showUserProfile(action: ProfileGen.ShowUserProfilePayload, state: Type
   const {username: userId} = action.payload
   const searchResultMap = Selectors.searchResultMapSelector(state)
   const username = SearchConstants.maybeUpgradeSearchResultIdToKeybaseId(searchResultMap, userId)
-  // get data on whose profile is currently being shown
   const me = Selectors.usernameSelector(state) || ''
   // Get the peopleTab path
   const peopleRouteProps = getPathProps(state.routeTree.routeState, [peopleTab])

--- a/shared/actions/profile/index.js
+++ b/shared/actions/profile/index.js
@@ -12,7 +12,7 @@ import URL from 'url-parse'
 import keybaseUrl from '../../constants/urls'
 import openURL from '../../util/open-url'
 import {getPathProps} from '../../route-tree'
-import {navigateTo, navigateUp, putActionIfOnPath} from '../../actions/route-tree'
+import {navigateTo, navigateUp} from '../../actions/route-tree'
 import {loginTab, peopleTab} from '../../constants/tabs'
 import {pgpSaga} from './pgp'
 import {proofsSaga} from './proofs'
@@ -22,7 +22,6 @@ import type {TypedState} from '../../constants/reducer'
 
 function _editProfile(action: ProfileGen.EditProfilePayload) {
   const {bio, fullname, location} = action.payload
-  const {newPeopleTab} = flags
   return Saga.sequentially([
     Saga.call(RPCTypes.userProfileEditRpcPromise, {
       bio,
@@ -30,13 +29,7 @@ function _editProfile(action: ProfileGen.EditProfilePayload) {
       location,
     }),
     // If the profile tab remained on the edit profile screen, navigate back to the top level.
-    Saga.put(
-      putActionIfOnPath(
-        newPeopleTab ? [peopleTab, 'profile', 'editProfile'] : [peopleTab, 'editProfile'],
-        newPeopleTab ? navigateTo(['profile'], [peopleTab]) : navigateTo([], [peopleTab]),
-        [peopleTab]
-      )
-    ),
+    Saga.put(navigateUp()),
   ])
 }
 

--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -81,7 +81,6 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
     // On click switch to people tab and push current user onto people route stack
     if (tab === profileTab) {
       me && dispatch(createShowUserProfile({username: me}))
-      dispatch(switchTo([peopleTab]))
       return
     }
 

--- a/shared/constants/profile.js
+++ b/shared/constants/profile.js
@@ -1,5 +1,13 @@
 // @flow
 import type {State} from './types/profile'
+import * as I from 'immutable'
+import {type TypedState} from '../util/container'
+import flags from '../util/feature-flags'
+import {peopleTab} from '../constants/tabs'
+import {serviceIdToService} from './search'
+import {parseUserId} from '../util/platforms'
+import {searchResultSelector} from './selectors'
+import {type PropsPath} from '../route-tree'
 
 const initialState: State = {
   errorCode: null,
@@ -113,4 +121,72 @@ function urlToUsername(url: URL): ?string {
   return username
 }
 
-export {urlToUsername, maxProfileBioChars, initialState, checkUsernameValid, cleanupUsername}
+const getProfilePath = (
+  peopleRouteProps: I.List<{node: ?string, props: I.Map<string, any>}>,
+  username: string,
+  me: string,
+  state: TypedState
+): PropsPath<*> => {
+  const {newPeopleTab} = flags
+  const onlyProfilesProps = peopleRouteProps.filter(segment =>
+    [peopleTab, 'profile', 'nonUserProfile'].includes(segment.node)
+  )
+  const onlyProfilesPath = onlyProfilesProps.toArray().map(segment => ({
+    selected: segment.node || null,
+    props: segment.props.toObject(),
+  }))
+  // Assume user exists
+  if (!username.includes('@')) {
+    if (onlyProfilesProps.size <= 1) {
+      // There's nothing on the peopleTab stack
+      if (username === me && !newPeopleTab) {
+        // I'm already the root of the tab
+        return [peopleTab]
+      }
+      return [peopleTab, {selected: 'profile', props: {username}}]
+    }
+    // check last entry in path
+    const topNode = onlyProfilesProps.get(onlyProfilesProps.size - 1)
+    if (!topNode) {
+      // Will never happen
+      throw new Error('topProps undefined in _showUserProfile!')
+    }
+    if (topNode.node === 'profile' && topNode.props.get('username') === username) {
+      return onlyProfilesPath
+    }
+    return [...onlyProfilesPath, {selected: 'profile', props: {username}}]
+  }
+
+  // search for user first
+  let props = {}
+  const searchResult = searchResultSelector(state, username)
+  if (searchResult) {
+    props = {
+      fullname: searchResult.leftFullname,
+      fullUsername: username,
+      serviceName: searchResult.leftService,
+      username: searchResult.leftUsername,
+    }
+  } else {
+    const {username: parsedUsername, serviceId} = parseUserId(username)
+    props = {
+      fullUsername: username,
+      serviceName: serviceIdToService(serviceId),
+      username: parsedUsername,
+    }
+  }
+  if (onlyProfilesPath.length > 0) {
+    // don't allow dupe
+    const topProfile = onlyProfilesPath[onlyProfilesPath.length - 1]
+    if (
+      // $FlowIssue not sure why it thinks topProfile is a string
+      topProfile.props.fullUsername !== props.fullUsername ||
+      topProfile.props.serviceName !== props.serviceName
+    ) {
+      onlyProfilesPath.push({selected: 'nonUserProfile', props})
+    }
+  }
+  return onlyProfilesPath
+}
+
+export {checkUsernameValid, cleanupUsername, getProfilePath, initialState, maxProfileBioChars, urlToUsername}

--- a/shared/constants/profile.js
+++ b/shared/constants/profile.js
@@ -146,14 +146,16 @@ const getProfilePath = (
       return [peopleTab, {selected: 'profile', props: {username}}]
     }
     // check last entry in path
-    const topNode = onlyProfilesProps.get(onlyProfilesProps.size - 1)
-    if (!topNode) {
+    const topProfile = onlyProfilesProps.get(onlyProfilesProps.size - 1)
+    if (!topProfile) {
       // Will never happen
       throw new Error('topProps undefined in _showUserProfile!')
     }
-    if (topNode.node === 'profile' && topNode.props.get('username') === username) {
+    if (topProfile.node === 'profile' && topProfile.props.get('username') === username) {
+      // This user is already the top profile
       return onlyProfilesPath
     }
+    // Push the user onto the stack
     return [...onlyProfilesPath, {selected: 'profile', props: {username}}]
   }
 
@@ -176,13 +178,14 @@ const getProfilePath = (
     }
   }
   if (onlyProfilesPath.length > 0) {
-    // don't allow dupe
+    // Check for duplicates
     const topProfile = onlyProfilesPath[onlyProfilesPath.length - 1]
     if (
       // $FlowIssue not sure why it thinks topProfile is a string
       topProfile.props.fullUsername !== props.fullUsername ||
       topProfile.props.serviceName !== props.serviceName
     ) {
+      // This user is not the top profile, push on top
       onlyProfilesPath.push({selected: 'nonUserProfile', props})
     }
   }

--- a/shared/constants/profile.js
+++ b/shared/constants/profile.js
@@ -181,9 +181,8 @@ const getProfilePath = (
     // Check for duplicates
     const topProfile = onlyProfilesPath[onlyProfilesPath.length - 1]
     if (
-      // $FlowIssue not sure why it thinks topProfile is a string
-      topProfile.props.fullUsername !== props.fullUsername ||
-      topProfile.props.serviceName !== props.serviceName
+      (topProfile.props && topProfile.props.fullUsername !== props.fullUsername) ||
+      (topProfile.props && topProfile.props.serviceName !== props.serviceName)
     ) {
       // This user is not the top profile, push on top
       onlyProfilesPath.push({selected: 'nonUserProfile', props})

--- a/shared/profile/routes.js
+++ b/shared/profile/routes.js
@@ -46,6 +46,9 @@ const profileRoute = makeRouteDefNode({
     },
     nonUserProfile: {
       component: NonUserProfile,
+      children: {
+        profile: () => profileRoute,
+      },
     },
     proveEnterUsername,
     proveWebsiteChoice: {


### PR DESCRIPTION
Before, we would check for duplicates on the top of the profile stack, but we didn't handle cases where the top of the stack had something other than a profile such as `editProfile` or `editAvatar`. We also didn't check for the top of the stack being `nonUserProfile`, which didn't handle profileroutes as children. 

This PR changes the logic to introspect the route state of the people tab. It filters out all non-profiles from the stack and checks for duplicates on the leaf, including for `nonUserProfile`. It also allows `nonUserProfile` to have profiles as children. The path determination logic was moved to `constants/profie` so it can be tested.

r? @keybase/react-hackers 