### PR TITLE
Retention policy setup

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -160,6 +160,8 @@ func newFailingRemote(t *testing.T) failingRemote {
 	}
 }
 
+var _ chat1.RemoteInterface = (*failingRemote)(nil)
+
 func (f failingRemote) GetInboxRemote(context.Context, chat1.GetInboxRemoteArg) (chat1.GetInboxRemoteRes, error) {
 	require.Fail(f.t, "GetInboxRemote call")
 	return chat1.GetInboxRemoteRes{}, nil
@@ -311,6 +313,16 @@ func (f failingRemote) SetGlobalAppNotificationSettings(ctx context.Context, arg
 func (f failingRemote) GetGlobalAppNotificationSettings(ctx context.Context) (chat1.GlobalAppNotificationSettings, error) {
 	require.Fail(f.t, "GetGlobalAppNotificationSettings")
 	return chat1.GlobalAppNotificationSettings{}, nil
+}
+
+func (f failingRemote) SetConvRetention(ctx context.Context, _ chat1.SetConvRetentionArg) (res chat1.SetRetentionRes, err error) {
+	require.Fail(f.t, "SetConvRetention")
+	return res, errors.New("SetConvRetention not mocked")
+}
+
+func (f failingRemote) SetTeamRetention(ctx context.Context, _ chat1.SetTeamRetentionArg) (res chat1.SetRetentionRes, err error) {
+	require.Fail(f.t, "SetTeamRetention")
+	return res, errors.New("SetTeamRetention not mocked")
 }
 
 type failingTlf struct {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -60,6 +60,8 @@ type Server struct {
 	cachedThreadDelay *time.Duration
 }
 
+var _ chat1.LocalInterface = (*Server)(nil)
+
 func NewServer(g *globals.Context, store *AttachmentStore, serverConn ServerConnection,
 	uiSource UISource) *Server {
 	return &Server{
@@ -2583,4 +2585,22 @@ func (h *Server) AddTeamMemberAfterReset(ctx context.Context,
 
 	teamID := keybase1.TeamID(conv.Info.Triple.Tlfid.String())
 	return teams.ReAddMemberAfterReset(ctx, h.G().ExternalG(), teamID, arg.Username)
+}
+
+func (h *Server) SetConvRetentionLocal(ctx context.Context, arg chat1.SetConvRetentionLocalArg) (err error) {
+	defer h.Trace(ctx, func() error { return err }, "SetConvRetention(%v, %v)", arg.ConvID, arg.Policy.Summary())()
+	_, err = h.remoteClient().SetConvRetention(ctx, chat1.SetConvRetentionArg{
+		ConvID: arg.ConvID,
+		Policy: arg.Policy,
+	})
+	return err
+}
+
+func (h *Server) SetTeamRetentionLocal(ctx context.Context, arg chat1.SetTeamRetentionLocalArg) (err error) {
+	defer h.Trace(ctx, func() error { return err }, "SetTeamRetention(%v, %v)", arg.TeamID, arg.Policy.Summary())()
+	_, err = h.remoteClient().SetTeamRetention(ctx, chat1.SetTeamRetentionArg{
+		TeamID: arg.TeamID,
+		Policy: arg.Policy,
+	})
+	return err
 }

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -415,8 +415,9 @@ func (d DebugLabeler) Debug(ctx context.Context, msg string, args ...interface{}
 	}
 }
 
-func (d DebugLabeler) Trace(ctx context.Context, f func() error, msg string) func() {
+func (d DebugLabeler) Trace(ctx context.Context, f func() error, format string, args ...interface{}) func() {
 	if d.showLog() {
+		msg := fmt.Sprintf(format, args...)
 		start := time.Now()
 		d.log.CDebugf(ctx, "++Chat: + %s: %s", d.label, msg)
 		return func() {

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -782,6 +782,14 @@ func (m *ChatRemoteMock) S3Sign(context.Context, chat1.S3SignArg) ([]byte, error
 	return nil, errors.New("GetS3Params not mocked")
 }
 
+func (m *ChatRemoteMock) SetConvRetention(ctx context.Context, _ chat1.SetConvRetentionArg) (res chat1.SetRetentionRes, err error) {
+	return res, errors.New("SetConvRetention not mocked")
+}
+
+func (m *ChatRemoteMock) SetTeamRetention(ctx context.Context, _ chat1.SetTeamRetentionArg) (res chat1.SetRetentionRes, err error) {
+	return res, errors.New("SetTeamRetention not mocked")
+}
+
 type NonblockInboxResult struct {
 	ConvID   chat1.ConversationID
 	Err      error

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -689,6 +689,18 @@ func (o ConversationResolveInfo) DeepCopy() ConversationResolveInfo {
 	}
 }
 
+type Expunge struct {
+	Upto  MessageID `codec:"upto" json:"upto"`
+	Basis MessageID `codec:"basis" json:"basis"`
+}
+
+func (o Expunge) DeepCopy() Expunge {
+	return Expunge{
+		Upto:  o.Upto.DeepCopy(),
+		Basis: o.Basis.DeepCopy(),
+	}
+}
+
 type ConversationMetadata struct {
 	IdTriple       ConversationIDTriple      `codec:"idTriple" json:"idTriple"`
 	ConversationID ConversationID            `codec:"conversationID" json:"conversationID"`
@@ -698,6 +710,9 @@ type ConversationMetadata struct {
 	TeamType       TeamType                  `codec:"teamType" json:"teamType"`
 	Existence      ConversationExistence     `codec:"existence" json:"existence"`
 	Version        ConversationVers          `codec:"version" json:"version"`
+	Expunge        Expunge                   `codec:"expunge" json:"expunge"`
+	ConvRetention  *RetentionPolicy          `codec:"convRetention,omitempty" json:"convRetention,omitempty"`
+	TeamRetention  *RetentionPolicy          `codec:"teamRetention,omitempty" json:"teamRetention,omitempty"`
 	FinalizeInfo   *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
 	Supersedes     []ConversationMetadata    `codec:"supersedes" json:"supersedes"`
 	SupersededBy   []ConversationMetadata    `codec:"supersededBy" json:"supersededBy"`
@@ -716,6 +731,21 @@ func (o ConversationMetadata) DeepCopy() ConversationMetadata {
 		TeamType:       o.TeamType.DeepCopy(),
 		Existence:      o.Existence.DeepCopy(),
 		Version:        o.Version.DeepCopy(),
+		Expunge:        o.Expunge.DeepCopy(),
+		ConvRetention: (func(x *RetentionPolicy) *RetentionPolicy {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.ConvRetention),
+		TeamRetention: (func(x *RetentionPolicy) *RetentionPolicy {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.TeamRetention),
 		FinalizeInfo: (func(x *ConversationFinalizeInfo) *ConversationFinalizeInfo {
 			if x == nil {
 				return nil
@@ -1322,6 +1352,168 @@ func (o InboxView) DeepCopy() InboxView {
 			return &tmp
 		})(o.Full__),
 	}
+}
+
+type RetentionPolicyType int
+
+const (
+	RetentionPolicyType_NONE    RetentionPolicyType = 0
+	RetentionPolicyType_RETAIN  RetentionPolicyType = 1
+	RetentionPolicyType_EXPIRE  RetentionPolicyType = 2
+	RetentionPolicyType_INHERIT RetentionPolicyType = 3
+)
+
+func (o RetentionPolicyType) DeepCopy() RetentionPolicyType { return o }
+
+var RetentionPolicyTypeMap = map[string]RetentionPolicyType{
+	"NONE":    0,
+	"RETAIN":  1,
+	"EXPIRE":  2,
+	"INHERIT": 3,
+}
+
+var RetentionPolicyTypeRevMap = map[RetentionPolicyType]string{
+	0: "NONE",
+	1: "RETAIN",
+	2: "EXPIRE",
+	3: "INHERIT",
+}
+
+func (e RetentionPolicyType) String() string {
+	if v, ok := RetentionPolicyTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type RetentionPolicy struct {
+	Typ__     RetentionPolicyType `codec:"typ" json:"typ"`
+	Retain__  *RpRetain           `codec:"retain,omitempty" json:"retain,omitempty"`
+	Expire__  *RpExpire           `codec:"expire,omitempty" json:"expire,omitempty"`
+	Inherit__ *RpInherit          `codec:"inherit,omitempty" json:"inherit,omitempty"`
+}
+
+func (o *RetentionPolicy) Typ() (ret RetentionPolicyType, err error) {
+	switch o.Typ__ {
+	case RetentionPolicyType_RETAIN:
+		if o.Retain__ == nil {
+			err = errors.New("unexpected nil value for Retain__")
+			return ret, err
+		}
+	case RetentionPolicyType_EXPIRE:
+		if o.Expire__ == nil {
+			err = errors.New("unexpected nil value for Expire__")
+			return ret, err
+		}
+	case RetentionPolicyType_INHERIT:
+		if o.Inherit__ == nil {
+			err = errors.New("unexpected nil value for Inherit__")
+			return ret, err
+		}
+	}
+	return o.Typ__, nil
+}
+
+func (o RetentionPolicy) Retain() (res RpRetain) {
+	if o.Typ__ != RetentionPolicyType_RETAIN {
+		panic("wrong case accessed")
+	}
+	if o.Retain__ == nil {
+		return
+	}
+	return *o.Retain__
+}
+
+func (o RetentionPolicy) Expire() (res RpExpire) {
+	if o.Typ__ != RetentionPolicyType_EXPIRE {
+		panic("wrong case accessed")
+	}
+	if o.Expire__ == nil {
+		return
+	}
+	return *o.Expire__
+}
+
+func (o RetentionPolicy) Inherit() (res RpInherit) {
+	if o.Typ__ != RetentionPolicyType_INHERIT {
+		panic("wrong case accessed")
+	}
+	if o.Inherit__ == nil {
+		return
+	}
+	return *o.Inherit__
+}
+
+func NewRetentionPolicyWithRetain(v RpRetain) RetentionPolicy {
+	return RetentionPolicy{
+		Typ__:    RetentionPolicyType_RETAIN,
+		Retain__: &v,
+	}
+}
+
+func NewRetentionPolicyWithExpire(v RpExpire) RetentionPolicy {
+	return RetentionPolicy{
+		Typ__:    RetentionPolicyType_EXPIRE,
+		Expire__: &v,
+	}
+}
+
+func NewRetentionPolicyWithInherit(v RpInherit) RetentionPolicy {
+	return RetentionPolicy{
+		Typ__:     RetentionPolicyType_INHERIT,
+		Inherit__: &v,
+	}
+}
+
+func (o RetentionPolicy) DeepCopy() RetentionPolicy {
+	return RetentionPolicy{
+		Typ__: o.Typ__.DeepCopy(),
+		Retain__: (func(x *RpRetain) *RpRetain {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Retain__),
+		Expire__: (func(x *RpExpire) *RpExpire {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Expire__),
+		Inherit__: (func(x *RpInherit) *RpInherit {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Inherit__),
+	}
+}
+
+type RpRetain struct {
+}
+
+func (o RpRetain) DeepCopy() RpRetain {
+	return RpRetain{}
+}
+
+type RpExpire struct {
+	Age gregor1.DurationSec `codec:"age" json:"age"`
+}
+
+func (o RpExpire) DeepCopy() RpExpire {
+	return RpExpire{
+		Age: o.Age.DeepCopy(),
+	}
+}
+
+type RpInherit struct {
+}
+
+func (o RpInherit) DeepCopy() RpInherit {
+	return RpInherit{}
 }
 
 type CommonInterface interface {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -40,6 +40,10 @@ func (id TLFID) Bytes() []byte {
 	return []byte(id)
 }
 
+func (id TLFID) IsNil() bool {
+	return len(id) == 0
+}
+
 func MakeConvID(val string) (ConversationID, error) {
 	return hex.DecodeString(val)
 }
@@ -776,4 +780,17 @@ func (c ConversationMemberStatus) ToGregorDBStringAssert() string {
 		panic(err)
 	}
 	return s
+}
+
+func (p RetentionPolicy) Summary() string {
+	typ, err := p.Typ()
+	if err != nil {
+		return "{variant error}"
+	}
+	switch typ {
+	case RetentionPolicyType_EXPIRE:
+		return fmt.Sprintf("{%v age:%v}", typ, p.Expire().Age)
+	default:
+		return fmt.Sprintf("{%v}", typ)
+	}
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3951,6 +3951,16 @@ type AddTeamMemberAfterResetArg struct {
 	ConvID   ConversationID `codec:"convID" json:"convID"`
 }
 
+type SetConvRetentionLocalArg struct {
+	ConvID ConversationID  `codec:"convID" json:"convID"`
+	Policy RetentionPolicy `codec:"policy" json:"policy"`
+}
+
+type SetTeamRetentionLocalArg struct {
+	TeamID keybase1.TeamID `codec:"teamID" json:"teamID"`
+	Policy RetentionPolicy `codec:"policy" json:"policy"`
+}
+
 type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
 	GetCachedThread(context.Context, GetCachedThreadArg) (GetThreadLocalRes, error)
@@ -3995,6 +4005,8 @@ type LocalInterface interface {
 	GetGlobalAppNotificationSettingsLocal(context.Context) (GlobalAppNotificationSettings, error)
 	UnboxMobilePushNotification(context.Context, UnboxMobilePushNotificationArg) (string, error)
 	AddTeamMemberAfterReset(context.Context, AddTeamMemberAfterResetArg) error
+	SetConvRetentionLocal(context.Context, SetConvRetentionLocalArg) error
+	SetTeamRetentionLocal(context.Context, SetTeamRetentionLocalArg) error
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -4679,6 +4691,38 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"setConvRetentionLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]SetConvRetentionLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SetConvRetentionLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SetConvRetentionLocalArg)(nil), args)
+						return
+					}
+					err = i.SetConvRetentionLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"setTeamRetentionLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]SetTeamRetentionLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SetTeamRetentionLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SetTeamRetentionLocalArg)(nil), args)
+						return
+					}
+					err = i.SetTeamRetentionLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -4907,5 +4951,15 @@ func (c LocalClient) UnboxMobilePushNotification(ctx context.Context, __arg Unbo
 
 func (c LocalClient) AddTeamMemberAfterReset(ctx context.Context, __arg AddTeamMemberAfterResetArg) (err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.addTeamMemberAfterReset", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) SetConvRetentionLocal(ctx context.Context, __arg SetConvRetentionLocalArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.setConvRetentionLocal", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) SetTeamRetentionLocal(ctx context.Context, __arg SetTeamRetentionLocalArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.setTeamRetentionLocal", []interface{}{__arg}, nil)
 	return
 }

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -188,6 +188,14 @@ protocol common {
     string newTLFName;
   }
 
+  record Expunge {
+    // Delete upto this message ID (exclusive)
+    MessageID upto;
+    // The message that justifies this deletion.
+    // Can point to a DeleteHistory message or be 0 in the case of a retention sweep.
+    MessageID basis;
+  }
+
   record ConversationMetadata  {
     ConversationIDTriple idTriple;
     ConversationID conversationID;
@@ -197,6 +205,10 @@ protocol common {
     TeamType teamType;
     ConversationExistence existence;
     ConversationVers version;
+    // The latest history deletion. Defaults to zeroes.
+    Expunge expunge;
+    union { null, RetentionPolicy } convRetention;
+    union { null, RetentionPolicy } teamRetention;
 
     // Finalize info for underlying TLF (only makes sense for KBFS convos)
     union { null, ConversationFinalizeInfo } finalizeInfo;
@@ -376,4 +388,27 @@ protocol common {
     case VERSIONHIT: void;
     case FULL: InboxViewFull;
   }
+
+  enum RetentionPolicyType {
+    NONE_0,
+    RETAIN_1, // Keep messages forever
+    EXPIRE_2, // Delete afer a while
+    INHERIT_3 // Use the team's policy
+  }
+
+  variant RetentionPolicy switch (RetentionPolicyType typ){
+    case RETAIN: RpRetain;
+    case EXPIRE: RpExpire;
+    case INHERIT: RpInherit;
+  }
+
+  record RpRetain {}
+
+  record RpExpire {
+    // Delete messages older than this.
+    gregor1.DurationSec age;
+  }
+
+  record RpInherit {}
+
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -770,4 +770,7 @@ protocol local {
   // Convenience interface for adding someone back to a reset team convo
   void addTeamMemberAfterReset(string username, ConversationID convID);
 
+  void setConvRetentionLocal(ConversationID convID, RetentionPolicy policy);
+  void setTeamRetentionLocal(keybase1.TeamID teamID, RetentionPolicy policy);
+
 }

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -2,6 +2,7 @@
 protocol remote {
 
   import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
+  import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
 
   record MessageBoxed {
     // This was not present in most V1 messages.
@@ -264,4 +265,11 @@ protocol remote {
 
   // Endpoint to indicate a high priority push notification has been processed
   void remoteNotificationSuccessful(gregor1.SessionToken authToken, array<string> companionPushIDs);
+
+  record SetRetentionRes {
+    union { null, RateLimit } rateLimit;
+  }
+  SetRetentionRes setConvRetention(ConversationID convID, RetentionPolicy policy);
+  SetRetentionRes setTeamRetention(keybase1.TeamID teamID, RetentionPolicy policy);
+
 }

--- a/protocol/avdl/gregor1/common.avdl
+++ b/protocol/avdl/gregor1/common.avdl
@@ -92,7 +92,7 @@ protocol common {
   @typedef("bytes") record MsgID {}
   @typedef("bytes") record DeviceID {}
   @typedef("bytes") record Body {}
-  @typedef("long") record Time {}
+  @typedef("long") record Time {} // ms since epoch
   @typedef("string") record SessionID {}
   @typedef("string") record SessionToken {}
 }

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -75,6 +75,13 @@ export const commonNotificationKind = {
   atmention: 1,
 }
 
+export const commonRetentionPolicyType = {
+  none: 0,
+  retain: 1,
+  expire: 2,
+  inherit: 3,
+}
+
 export const commonSyncInboxResType = {
   current: 0,
   incremental: 1,
@@ -325,6 +332,10 @@ export const localSetAppNotificationSettingsLocalRpcChannelMap = (configKeys: Ar
 
 export const localSetAppNotificationSettingsLocalRpcPromise = (request: LocalSetAppNotificationSettingsLocalRpcParam): Promise<LocalSetAppNotificationSettingsLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.setAppNotificationSettingsLocal', request, (error: RPCError, result: LocalSetAppNotificationSettingsLocalResult) => (error ? reject(error) : resolve(result))))
 
+export const localSetConvRetentionLocalRpcChannelMap = (configKeys: Array<string>, request: LocalSetConvRetentionLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.setConvRetentionLocal', request)
+
+export const localSetConvRetentionLocalRpcPromise = (request: LocalSetConvRetentionLocalRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.setConvRetentionLocal', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
 export const localSetConversationStatusLocalRpcChannelMap = (configKeys: Array<string>, request: LocalSetConversationStatusLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.SetConversationStatusLocal', request)
 
 export const localSetConversationStatusLocalRpcPromise = (request: LocalSetConversationStatusLocalRpcParam): Promise<LocalSetConversationStatusLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.SetConversationStatusLocal', request, (error: RPCError, result: LocalSetConversationStatusLocalResult) => (error ? reject(error) : resolve(result))))
@@ -332,6 +343,10 @@ export const localSetConversationStatusLocalRpcPromise = (request: LocalSetConve
 export const localSetGlobalAppNotificationSettingsLocalRpcChannelMap = (configKeys: Array<string>, request: LocalSetGlobalAppNotificationSettingsLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.setGlobalAppNotificationSettingsLocal', request)
 
 export const localSetGlobalAppNotificationSettingsLocalRpcPromise = (request: LocalSetGlobalAppNotificationSettingsLocalRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.setGlobalAppNotificationSettingsLocal', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
+export const localSetTeamRetentionLocalRpcChannelMap = (configKeys: Array<string>, request: LocalSetTeamRetentionLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.setTeamRetentionLocal', request)
+
+export const localSetTeamRetentionLocalRpcPromise = (request: LocalSetTeamRetentionLocalRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.setTeamRetentionLocal', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
 
 export const localUnboxMobilePushNotificationRpcChannelMap = (configKeys: Array<string>, request: LocalUnboxMobilePushNotificationRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.unboxMobilePushNotification', request)
 
@@ -462,6 +477,10 @@ export const remoteSetAppNotificationSettingsRpcChannelMap = (configKeys: Array<
 
 export const remoteSetAppNotificationSettingsRpcPromise = (request: RemoteSetAppNotificationSettingsRpcParam): Promise<RemoteSetAppNotificationSettingsResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.setAppNotificationSettings', request, (error: RPCError, result: RemoteSetAppNotificationSettingsResult) => (error ? reject(error) : resolve(result))))
 
+export const remoteSetConvRetentionRpcChannelMap = (configKeys: Array<string>, request: RemoteSetConvRetentionRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.setConvRetention', request)
+
+export const remoteSetConvRetentionRpcPromise = (request: RemoteSetConvRetentionRpcParam): Promise<RemoteSetConvRetentionResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.setConvRetention', request, (error: RPCError, result: RemoteSetConvRetentionResult) => (error ? reject(error) : resolve(result))))
+
 export const remoteSetConversationStatusRpcChannelMap = (configKeys: Array<string>, request: RemoteSetConversationStatusRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.SetConversationStatus', request)
 
 export const remoteSetConversationStatusRpcPromise = (request: RemoteSetConversationStatusRpcParam): Promise<RemoteSetConversationStatusResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.SetConversationStatus', request, (error: RPCError, result: RemoteSetConversationStatusResult) => (error ? reject(error) : resolve(result))))
@@ -469,6 +488,10 @@ export const remoteSetConversationStatusRpcPromise = (request: RemoteSetConversa
 export const remoteSetGlobalAppNotificationSettingsRpcChannelMap = (configKeys: Array<string>, request: RemoteSetGlobalAppNotificationSettingsRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.setGlobalAppNotificationSettings', request)
 
 export const remoteSetGlobalAppNotificationSettingsRpcPromise = (request: RemoteSetGlobalAppNotificationSettingsRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.setGlobalAppNotificationSettings', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
+export const remoteSetTeamRetentionRpcChannelMap = (configKeys: Array<string>, request: RemoteSetTeamRetentionRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.setTeamRetention', request)
+
+export const remoteSetTeamRetentionRpcPromise = (request: RemoteSetTeamRetentionRpcParam): Promise<RemoteSetTeamRetentionResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.setTeamRetention', request, (error: RPCError, result: RemoteSetTeamRetentionResult) => (error ? reject(error) : resolve(result))))
 
 export const remoteSyncAllNotificationType = {
   state: 0,
@@ -652,7 +675,7 @@ export type ConversationMembersType =
   | 1 // TEAM_1
   | 2 // IMPTEAM_2
 
-export type ConversationMetadata = $ReadOnly<{idTriple: ConversationIDTriple, conversationID: ConversationID, visibility: Keybase1.TLFVisibility, status: ConversationStatus, membersType: ConversationMembersType, teamType: TeamType, existence: ConversationExistence, version: ConversationVers, finalizeInfo?: ?ConversationFinalizeInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>, activeList?: ?Array<Gregor1.UID>, allList?: ?Array<Gregor1.UID>, resetList?: ?Array<Gregor1.UID>}>
+export type ConversationMetadata = $ReadOnly<{idTriple: ConversationIDTriple, conversationID: ConversationID, visibility: Keybase1.TLFVisibility, status: ConversationStatus, membersType: ConversationMembersType, teamType: TeamType, existence: ConversationExistence, version: ConversationVers, expunge: Expunge, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy, finalizeInfo?: ?ConversationFinalizeInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>, activeList?: ?Array<Gregor1.UID>, allList?: ?Array<Gregor1.UID>, resetList?: ?Array<Gregor1.UID>}>
 
 export type ConversationNotificationInfo = $ReadOnly<{channelWide: Boolean, settings: {[key: string]: {[key: string]: Boolean}}}>
 
@@ -679,6 +702,8 @@ export type DeleteConversationRemoteRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 export type DownloadAttachmentLocalRes = $ReadOnly<{offline: Boolean, rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 
 export type EncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
+
+export type Expunge = $ReadOnly<{upto: MessageID, basis: MessageID}>
 
 export type FailedMessageInfo = $ReadOnly<{outboxRecords?: ?Array<OutboxRecord>}>
 
@@ -855,9 +880,13 @@ export type LocalRetryPostRpcParam = $ReadOnly<{outboxID: OutboxID, incomingCall
 
 export type LocalSetAppNotificationSettingsLocalRpcParam = $ReadOnly<{convID: ConversationID, channelWide: Boolean, settings?: ?Array<AppNotificationSettingLocal>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type LocalSetConvRetentionLocalRpcParam = $ReadOnly<{convID: ConversationID, policy: RetentionPolicy, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type LocalSetConversationStatusLocalRpcParam = $ReadOnly<{conversationID: ConversationID, status: ConversationStatus, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalSetGlobalAppNotificationSettingsLocalRpcParam = $ReadOnly<{settings: {[key: string]: Bool}, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type LocalSetTeamRetentionLocalRpcParam = $ReadOnly<{teamID: Keybase1.TeamID, policy: RetentionPolicy, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalSource = $ReadOnly<{source: Keybase1.Stream, filename: String, size: Int}>
 
@@ -1098,9 +1127,13 @@ export type RemoteS3SignRpcParam = $ReadOnly<{version: Int, payload: Bytes, inco
 
 export type RemoteSetAppNotificationSettingsRpcParam = $ReadOnly<{convID: ConversationID, settings: ConversationNotificationInfo, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type RemoteSetConvRetentionRpcParam = $ReadOnly<{convID: ConversationID, policy: RetentionPolicy, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type RemoteSetConversationStatusRpcParam = $ReadOnly<{conversationID: ConversationID, status: ConversationStatus, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type RemoteSetGlobalAppNotificationSettingsRpcParam = $ReadOnly<{settings: GlobalAppNotificationSettings, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type RemoteSetTeamRetentionRpcParam = $ReadOnly<{teamID: Keybase1.TeamID, policy: RetentionPolicy, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type RemoteSyncAllRpcParam = $ReadOnly<{uid: Gregor1.UID, deviceID: Gregor1.DeviceID, session: Gregor1.SessionToken, inboxVers: InboxVers, ctime: Gregor1.Time, fresh: Boolean, protVers: SyncAllProtVers, hostName: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
@@ -1115,6 +1148,20 @@ export type RemoteTlfResolveRpcParam = $ReadOnly<{tlfID: TLFID, resolvedWriters?
 export type RemoteUpdateTypingRemoteRpcParam = $ReadOnly<{uid: Gregor1.UID, deviceID: Gregor1.DeviceID, convID: ConversationID, typing: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type RemoteUserTypingUpdate = $ReadOnly<{uid: Gregor1.UID, deviceID: Gregor1.DeviceID, convID: ConversationID, typing: Boolean}>
+
+export type RetentionPolicy = {typ: 1, retain: ?RpRetain} | {typ: 2, expire: ?RpExpire} | {typ: 3, inherit: ?RpInherit}
+
+export type RetentionPolicyType =
+  | 0 // NONE_0
+  | 1 // RETAIN_1
+  | 2 // EXPIRE_2
+  | 3 // INHERIT_3
+
+export type RpExpire = $ReadOnly<{age: Gregor1.DurationSec}>
+
+export type RpInherit = $ReadOnly<{}>
+
+export type RpRetain = $ReadOnly<{}>
 
 export type S3Params = $ReadOnly<{bucket: String, objectKey: String, accessKey: String, acl: String, regionName: String, regionEndpoint: String, regionBucketEndpoint: String}>
 
@@ -1133,6 +1180,8 @@ export type SetAppNotificationSettingsRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 export type SetConversationStatusLocalRes = $ReadOnly<{rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 
 export type SetConversationStatusRes = $ReadOnly<{rateLimit?: ?RateLimit}>
+
+export type SetRetentionRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 
 export type SetStatusInfo = $ReadOnly<{convID: ConversationID, status: ConversationStatus, conv?: ?InboxUIItem}>
 
@@ -1289,7 +1338,9 @@ type RemotePostRemoteResult = PostRemoteRes
 type RemotePreviewConversationResult = JoinLeaveConversationRemoteRes
 type RemoteS3SignResult = Bytes
 type RemoteSetAppNotificationSettingsResult = SetAppNotificationSettingsRes
+type RemoteSetConvRetentionResult = SetRetentionRes
 type RemoteSetConversationStatusResult = SetConversationStatusRes
+type RemoteSetTeamRetentionResult = SetRetentionRes
 type RemoteSyncAllResult = SyncAllResult
 type RemoteSyncChatResult = SyncChatRes
 type RemoteSyncInboxResult = SyncInboxRes

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -441,6 +441,20 @@
     },
     {
       "type": "record",
+      "name": "Expunge",
+      "fields": [
+        {
+          "type": "MessageID",
+          "name": "upto"
+        },
+        {
+          "type": "MessageID",
+          "name": "basis"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "ConversationMetadata",
       "fields": [
         {
@@ -474,6 +488,24 @@
         {
           "type": "ConversationVers",
           "name": "version"
+        },
+        {
+          "type": "Expunge",
+          "name": "expunge"
+        },
+        {
+          "type": [
+            null,
+            "RetentionPolicy"
+          ],
+          "name": "convRetention"
+        },
+        {
+          "type": [
+            null,
+            "RetentionPolicy"
+          ],
+          "name": "teamRetention"
         },
         {
           "type": [
@@ -983,6 +1015,67 @@
           "body": "InboxViewFull"
         }
       ]
+    },
+    {
+      "type": "enum",
+      "name": "RetentionPolicyType",
+      "symbols": [
+        "NONE_0",
+        "RETAIN_1",
+        "EXPIRE_2",
+        "INHERIT_3"
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "RetentionPolicy",
+      "switch": {
+        "type": "RetentionPolicyType",
+        "name": "typ"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "RETAIN",
+            "def": false
+          },
+          "body": "RpRetain"
+        },
+        {
+          "label": {
+            "name": "EXPIRE",
+            "def": false
+          },
+          "body": "RpExpire"
+        },
+        {
+          "label": {
+            "name": "INHERIT",
+            "def": false
+          },
+          "body": "RpInherit"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "RpRetain",
+      "fields": []
+    },
+    {
+      "type": "record",
+      "name": "RpExpire",
+      "fields": [
+        {
+          "type": "gregor1.DurationSec",
+          "name": "age"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "RpInherit",
+      "fields": []
     }
   ],
   "messages": {},

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -3166,6 +3166,32 @@
         }
       ],
       "response": null
+    },
+    "setConvRetentionLocal": {
+      "request": [
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "policy",
+          "type": "RetentionPolicy"
+        }
+      ],
+      "response": null
+    },
+    "setTeamRetentionLocal": {
+      "request": [
+        {
+          "name": "teamID",
+          "type": "keybase1.TeamID"
+        },
+        {
+          "name": "policy",
+          "type": "RetentionPolicy"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -5,6 +5,11 @@
       "path": "github.com/keybase/client/go/protocol/gregor1",
       "type": "idl",
       "import_as": "gregor1"
+    },
+    {
+      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "type": "idl",
+      "import_as": "keybase1"
     }
   ],
   "types": [
@@ -534,6 +539,19 @@
           "name": "rateLimit"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "SetRetentionRes",
+      "fields": [
+        {
+          "type": [
+            null,
+            "RateLimit"
+          ],
+          "name": "rateLimit"
+        }
+      ]
     }
   ],
   "messages": {
@@ -1014,6 +1032,32 @@
         }
       ],
       "response": null
+    },
+    "setConvRetention": {
+      "request": [
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "policy",
+          "type": "RetentionPolicy"
+        }
+      ],
+      "response": "SetRetentionRes"
+    },
+    "setTeamRetention": {
+      "request": [
+        {
+          "name": "teamID",
+          "type": "keybase1.TeamID"
+        },
+        {
+          "name": "policy",
+          "type": "RetentionPolicy"
+        }
+      ],
+      "response": "SetRetentionRes"
     }
   },
   "namespace": "chat.1"

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -75,6 +75,13 @@ export const commonNotificationKind = {
   atmention: 1,
 }
 
+export const commonRetentionPolicyType = {
+  none: 0,
+  retain: 1,
+  expire: 2,
+  inherit: 3,
+}
+
 export const commonSyncInboxResType = {
   current: 0,
   incremental: 1,
@@ -325,6 +332,10 @@ export const localSetAppNotificationSettingsLocalRpcChannelMap = (configKeys: Ar
 
 export const localSetAppNotificationSettingsLocalRpcPromise = (request: LocalSetAppNotificationSettingsLocalRpcParam): Promise<LocalSetAppNotificationSettingsLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.setAppNotificationSettingsLocal', request, (error: RPCError, result: LocalSetAppNotificationSettingsLocalResult) => (error ? reject(error) : resolve(result))))
 
+export const localSetConvRetentionLocalRpcChannelMap = (configKeys: Array<string>, request: LocalSetConvRetentionLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.setConvRetentionLocal', request)
+
+export const localSetConvRetentionLocalRpcPromise = (request: LocalSetConvRetentionLocalRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.setConvRetentionLocal', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
 export const localSetConversationStatusLocalRpcChannelMap = (configKeys: Array<string>, request: LocalSetConversationStatusLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.SetConversationStatusLocal', request)
 
 export const localSetConversationStatusLocalRpcPromise = (request: LocalSetConversationStatusLocalRpcParam): Promise<LocalSetConversationStatusLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.SetConversationStatusLocal', request, (error: RPCError, result: LocalSetConversationStatusLocalResult) => (error ? reject(error) : resolve(result))))
@@ -332,6 +343,10 @@ export const localSetConversationStatusLocalRpcPromise = (request: LocalSetConve
 export const localSetGlobalAppNotificationSettingsLocalRpcChannelMap = (configKeys: Array<string>, request: LocalSetGlobalAppNotificationSettingsLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.setGlobalAppNotificationSettingsLocal', request)
 
 export const localSetGlobalAppNotificationSettingsLocalRpcPromise = (request: LocalSetGlobalAppNotificationSettingsLocalRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.setGlobalAppNotificationSettingsLocal', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
+export const localSetTeamRetentionLocalRpcChannelMap = (configKeys: Array<string>, request: LocalSetTeamRetentionLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.setTeamRetentionLocal', request)
+
+export const localSetTeamRetentionLocalRpcPromise = (request: LocalSetTeamRetentionLocalRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.setTeamRetentionLocal', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
 
 export const localUnboxMobilePushNotificationRpcChannelMap = (configKeys: Array<string>, request: LocalUnboxMobilePushNotificationRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.unboxMobilePushNotification', request)
 
@@ -462,6 +477,10 @@ export const remoteSetAppNotificationSettingsRpcChannelMap = (configKeys: Array<
 
 export const remoteSetAppNotificationSettingsRpcPromise = (request: RemoteSetAppNotificationSettingsRpcParam): Promise<RemoteSetAppNotificationSettingsResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.setAppNotificationSettings', request, (error: RPCError, result: RemoteSetAppNotificationSettingsResult) => (error ? reject(error) : resolve(result))))
 
+export const remoteSetConvRetentionRpcChannelMap = (configKeys: Array<string>, request: RemoteSetConvRetentionRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.setConvRetention', request)
+
+export const remoteSetConvRetentionRpcPromise = (request: RemoteSetConvRetentionRpcParam): Promise<RemoteSetConvRetentionResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.setConvRetention', request, (error: RPCError, result: RemoteSetConvRetentionResult) => (error ? reject(error) : resolve(result))))
+
 export const remoteSetConversationStatusRpcChannelMap = (configKeys: Array<string>, request: RemoteSetConversationStatusRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.SetConversationStatus', request)
 
 export const remoteSetConversationStatusRpcPromise = (request: RemoteSetConversationStatusRpcParam): Promise<RemoteSetConversationStatusResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.SetConversationStatus', request, (error: RPCError, result: RemoteSetConversationStatusResult) => (error ? reject(error) : resolve(result))))
@@ -469,6 +488,10 @@ export const remoteSetConversationStatusRpcPromise = (request: RemoteSetConversa
 export const remoteSetGlobalAppNotificationSettingsRpcChannelMap = (configKeys: Array<string>, request: RemoteSetGlobalAppNotificationSettingsRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.setGlobalAppNotificationSettings', request)
 
 export const remoteSetGlobalAppNotificationSettingsRpcPromise = (request: RemoteSetGlobalAppNotificationSettingsRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.setGlobalAppNotificationSettings', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
+export const remoteSetTeamRetentionRpcChannelMap = (configKeys: Array<string>, request: RemoteSetTeamRetentionRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.setTeamRetention', request)
+
+export const remoteSetTeamRetentionRpcPromise = (request: RemoteSetTeamRetentionRpcParam): Promise<RemoteSetTeamRetentionResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.remote.setTeamRetention', request, (error: RPCError, result: RemoteSetTeamRetentionResult) => (error ? reject(error) : resolve(result))))
 
 export const remoteSyncAllNotificationType = {
   state: 0,
@@ -652,7 +675,7 @@ export type ConversationMembersType =
   | 1 // TEAM_1
   | 2 // IMPTEAM_2
 
-export type ConversationMetadata = $ReadOnly<{idTriple: ConversationIDTriple, conversationID: ConversationID, visibility: Keybase1.TLFVisibility, status: ConversationStatus, membersType: ConversationMembersType, teamType: TeamType, existence: ConversationExistence, version: ConversationVers, finalizeInfo?: ?ConversationFinalizeInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>, activeList?: ?Array<Gregor1.UID>, allList?: ?Array<Gregor1.UID>, resetList?: ?Array<Gregor1.UID>}>
+export type ConversationMetadata = $ReadOnly<{idTriple: ConversationIDTriple, conversationID: ConversationID, visibility: Keybase1.TLFVisibility, status: ConversationStatus, membersType: ConversationMembersType, teamType: TeamType, existence: ConversationExistence, version: ConversationVers, expunge: Expunge, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy, finalizeInfo?: ?ConversationFinalizeInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>, activeList?: ?Array<Gregor1.UID>, allList?: ?Array<Gregor1.UID>, resetList?: ?Array<Gregor1.UID>}>
 
 export type ConversationNotificationInfo = $ReadOnly<{channelWide: Boolean, settings: {[key: string]: {[key: string]: Boolean}}}>
 
@@ -679,6 +702,8 @@ export type DeleteConversationRemoteRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 export type DownloadAttachmentLocalRes = $ReadOnly<{offline: Boolean, rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 
 export type EncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
+
+export type Expunge = $ReadOnly<{upto: MessageID, basis: MessageID}>
 
 export type FailedMessageInfo = $ReadOnly<{outboxRecords?: ?Array<OutboxRecord>}>
 
@@ -855,9 +880,13 @@ export type LocalRetryPostRpcParam = $ReadOnly<{outboxID: OutboxID, incomingCall
 
 export type LocalSetAppNotificationSettingsLocalRpcParam = $ReadOnly<{convID: ConversationID, channelWide: Boolean, settings?: ?Array<AppNotificationSettingLocal>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type LocalSetConvRetentionLocalRpcParam = $ReadOnly<{convID: ConversationID, policy: RetentionPolicy, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type LocalSetConversationStatusLocalRpcParam = $ReadOnly<{conversationID: ConversationID, status: ConversationStatus, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalSetGlobalAppNotificationSettingsLocalRpcParam = $ReadOnly<{settings: {[key: string]: Bool}, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type LocalSetTeamRetentionLocalRpcParam = $ReadOnly<{teamID: Keybase1.TeamID, policy: RetentionPolicy, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalSource = $ReadOnly<{source: Keybase1.Stream, filename: String, size: Int}>
 
@@ -1098,9 +1127,13 @@ export type RemoteS3SignRpcParam = $ReadOnly<{version: Int, payload: Bytes, inco
 
 export type RemoteSetAppNotificationSettingsRpcParam = $ReadOnly<{convID: ConversationID, settings: ConversationNotificationInfo, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type RemoteSetConvRetentionRpcParam = $ReadOnly<{convID: ConversationID, policy: RetentionPolicy, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type RemoteSetConversationStatusRpcParam = $ReadOnly<{conversationID: ConversationID, status: ConversationStatus, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type RemoteSetGlobalAppNotificationSettingsRpcParam = $ReadOnly<{settings: GlobalAppNotificationSettings, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type RemoteSetTeamRetentionRpcParam = $ReadOnly<{teamID: Keybase1.TeamID, policy: RetentionPolicy, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type RemoteSyncAllRpcParam = $ReadOnly<{uid: Gregor1.UID, deviceID: Gregor1.DeviceID, session: Gregor1.SessionToken, inboxVers: InboxVers, ctime: Gregor1.Time, fresh: Boolean, protVers: SyncAllProtVers, hostName: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
@@ -1115,6 +1148,20 @@ export type RemoteTlfResolveRpcParam = $ReadOnly<{tlfID: TLFID, resolvedWriters?
 export type RemoteUpdateTypingRemoteRpcParam = $ReadOnly<{uid: Gregor1.UID, deviceID: Gregor1.DeviceID, convID: ConversationID, typing: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type RemoteUserTypingUpdate = $ReadOnly<{uid: Gregor1.UID, deviceID: Gregor1.DeviceID, convID: ConversationID, typing: Boolean}>
+
+export type RetentionPolicy = {typ: 1, retain: ?RpRetain} | {typ: 2, expire: ?RpExpire} | {typ: 3, inherit: ?RpInherit}
+
+export type RetentionPolicyType =
+  | 0 // NONE_0
+  | 1 // RETAIN_1
+  | 2 // EXPIRE_2
+  | 3 // INHERIT_3
+
+export type RpExpire = $ReadOnly<{age: Gregor1.DurationSec}>
+
+export type RpInherit = $ReadOnly<{}>
+
+export type RpRetain = $ReadOnly<{}>
 
 export type S3Params = $ReadOnly<{bucket: String, objectKey: String, accessKey: String, acl: String, regionName: String, regionEndpoint: String, regionBucketEndpoint: String}>
 
@@ -1133,6 +1180,8 @@ export type SetAppNotificationSettingsRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 export type SetConversationStatusLocalRes = $ReadOnly<{rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 
 export type SetConversationStatusRes = $ReadOnly<{rateLimit?: ?RateLimit}>
+
+export type SetRetentionRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 
 export type SetStatusInfo = $ReadOnly<{convID: ConversationID, status: ConversationStatus, conv?: ?InboxUIItem}>
 
@@ -1289,7 +1338,9 @@ type RemotePostRemoteResult = PostRemoteRes
 type RemotePreviewConversationResult = JoinLeaveConversationRemoteRes
 type RemoteS3SignResult = Bytes
 type RemoteSetAppNotificationSettingsResult = SetAppNotificationSettingsRes
+type RemoteSetConvRetentionResult = SetRetentionRes
 type RemoteSetConversationStatusResult = SetConversationStatusRes
+type RemoteSetTeamRetentionResult = SetRetentionRes
 type RemoteSyncAllResult = SyncAllResult
 type RemoteSyncChatResult = SyncChatRes
 type RemoteSyncInboxResult = SyncInboxRes


### PR DESCRIPTION
Retention policy protocol changes.
Add RPCs for setting the retention policy.
Added slots to conv metadata, but they are not yet used by the client.

This doesn't do anything as of yet, just carving off bite sized PRs.