### PR TITLE
hide manage chat icon for implicit admins

### DIFF
--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -209,6 +209,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       onOpenFolder={onOpenFolder}
       onManageChat={onManageChat}
       onShowMenu={() => ownProps.setShowMenu(true)}
+      canManageChat={yourOperations.leaveTeam}
     />
   )
   const publicitySettingsChanged =

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -744,13 +744,14 @@ const CustomComponent = ({onOpenFolder, onManageChat, onShowMenu, canManageChat}
           style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
         />
       )}
-    {!isMobile && (
-      <Icon
-        onClick={onOpenFolder}
-        type="iconfont-folder-private"
-        style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
-      />
-    )}
+    {!isMobile &&
+      canManageChat && (
+        <Icon
+          onClick={onOpenFolder}
+          type="iconfont-folder-private"
+          style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
+        />
+      )}
     <Icon
       onClick={onShowMenu}
       type="iconfont-ellipsis"

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -731,17 +731,19 @@ type CustomProps = {
   onOpenFolder: () => void,
   onManageChat: () => void,
   onShowMenu: () => void,
+  canManageChat: boolean,
 }
 
-const CustomComponent = ({onOpenFolder, onManageChat, onShowMenu}: CustomProps) => (
+const CustomComponent = ({onOpenFolder, onManageChat, onShowMenu, canManageChat}: CustomProps) => (
   <Box style={{...globalStyles.flexBoxRow, position: 'absolute', right: 0}}>
-    {!isMobile && (
-      <Icon
-        onClick={onManageChat}
-        type="iconfont-chat"
-        style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
-      />
-    )}
+    {!isMobile &&
+      canManageChat && (
+        <Icon
+          onClick={onManageChat}
+          type="iconfont-chat"
+          style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
+        />
+      )}
     {!isMobile && (
       <Icon
         onClick={onOpenFolder}


### PR DESCRIPTION
Seems we would want to broaden this restriction beyond just implicit admins who are not on the team but that's what the ticket says
@keybase/react-hackers @buoyad 