### PR TITLE
canUserPerform for non-member

### DIFF
--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1058,6 +1058,6 @@ func TestTeamCanUserPerform(t *testing.T) {
 	require.False(t, donnyPerms.SetMemberShowcase)
 	require.False(t, donnyPerms.ChangeOpenTeam)
 	require.False(t, donnyPerms.ListFirst)
-	require.True(t, donnyPerms.JoinTeam)
+	// TBD: require.True(t, donnyPerms.JoinTeam)
 	require.False(t, donnyPerms.SetPublicityAny)
 }

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1043,21 +1043,21 @@ func TestTeamCanUserPerform(t *testing.T) {
 	_, err = teams.CanUserPerform(context.TODO(), pam.tc.G, subteam)
 
 	// Non-membership shouldn't be an error
-	donnovan := tt.addUser("donnovan")
-	donnovanPerms, err := teams.CanUserPerform(context.TODO(), donnovan.tc.G, team)
+	donny := tt.addUser("donny")
+	donnyPerms, err := teams.CanUserPerform(context.TODO(), donny.tc.G, team)
 	require.NoError(t, err, "non-member canUserPerform")
 
 	// Make sure a non-member can't do stuff
-	require.False(t, donnovanPerms.ManageMembers)
-	require.False(t, donnovanPerms.ManageSubteams)
-	require.False(t, donnovanPerms.CreateChannel)
-	require.False(t, donnovanPerms.DeleteChannel)
-	require.False(t, donnovanPerms.RenameChannel)
-	require.False(t, donnovanPerms.EditChannelDescription)
-	require.False(t, donnovanPerms.SetTeamShowcase)
-	require.False(t, donnovanPerms.SetMemberShowcase)
-	require.False(t, donnovanPerms.ChangeOpenTeam) // not a member of the subteam
-	require.False(t, donnovanPerms.ListFirst)
+	require.False(t, donnyPerms.ManageMembers)
+	require.False(t, donnyPerms.ManageSubteams)
+	require.False(t, donnyPerms.CreateChannel)
+	require.False(t, donnyPerms.DeleteChannel)
+	require.False(t, donnyPerms.RenameChannel)
+	require.False(t, donnyPerms.EditChannelDescription)
+	require.False(t, donnyPerms.SetTeamShowcase)
+	require.False(t, donnyPerms.SetMemberShowcase)
+	require.False(t, donnyPerms.ChangeOpenTeam) // not a member of the subteam
+	require.False(t, donnyPerms.ListFirst)
 	// require.True(t, annPerms.JoinTeam) // TODO: not sure about this one
-	require.False(t, donnovanPerms.SetPublicityAny)
+	require.False(t, donnyPerms.SetPublicityAny)
 }

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1056,8 +1056,8 @@ func TestTeamCanUserPerform(t *testing.T) {
 	require.False(t, donnyPerms.EditChannelDescription)
 	require.False(t, donnyPerms.SetTeamShowcase)
 	require.False(t, donnyPerms.SetMemberShowcase)
-	require.False(t, donnyPerms.ChangeOpenTeam) // not a member of the subteam
+	require.False(t, donnyPerms.ChangeOpenTeam)
 	require.False(t, donnyPerms.ListFirst)
-	// require.True(t, annPerms.JoinTeam) // TODO: not sure about this one
+	require.True(t, donnyPerms.JoinTeam)
 	require.False(t, donnyPerms.SetPublicityAny)
 }

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1041,5 +1041,23 @@ func TestTeamCanUserPerform(t *testing.T) {
 
 	// Invalid team for pam
 	_, err = teams.CanUserPerform(context.TODO(), pam.tc.G, subteam)
-	require.Error(t, err)
+
+	// Non-membership shouldn't be an error
+	donnovan := tt.addUser("donnovan")
+	donnovanPerms, err := teams.CanUserPerform(context.TODO(), donnovan.tc.G, team)
+	require.NoError(t, err, "non-member canUserPerform")
+
+	// Make sure a non-member can't do stuff
+	require.False(t, donnovanPerms.ManageMembers)
+	require.False(t, donnovanPerms.ManageSubteams)
+	require.False(t, donnovanPerms.CreateChannel)
+	require.False(t, donnovanPerms.DeleteChannel)
+	require.False(t, donnovanPerms.RenameChannel)
+	require.False(t, donnovanPerms.EditChannelDescription)
+	require.False(t, donnovanPerms.SetTeamShowcase)
+	require.False(t, donnovanPerms.SetMemberShowcase)
+	require.False(t, donnovanPerms.ChangeOpenTeam) // not a member of the subteam
+	require.False(t, donnovanPerms.ListFirst)
+	// require.True(t, annPerms.JoinTeam) // TODO: not sure about this one
+	require.False(t, donnovanPerms.SetPublicityAny)
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1193,8 +1193,10 @@ func CanUserPerform(ctx context.Context, g *libkb.GlobalContext, teamname string
 			return false, nil
 		}
 		uvs, err := g.GetTeamLoader().ImplicitAdmins(ctx, team.ID)
+		// Note: we eat the error here, assuming it meant this user
+		// is not a member
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		for _, uv := range uvs {
 			if uv == meUV {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1181,7 +1181,10 @@ func CanUserPerform(ctx context.Context, g *libkb.GlobalContext, teamname string
 		Public:  false, // assume private team
 	})
 	if err != nil {
-		return ret, err
+		// Note: we eat the error here, assuming it meant this user
+		// is not a member
+		g.Log.CWarningf(ctx, "CanUserPerform team Load failure, continuing: %v)", err)
+		return ret, nil
 	}
 	meUV, err := team.currentUserUV(ctx)
 	if err != nil {
@@ -1193,10 +1196,8 @@ func CanUserPerform(ctx context.Context, g *libkb.GlobalContext, teamname string
 			return false, nil
 		}
 		uvs, err := g.GetTeamLoader().ImplicitAdmins(ctx, team.ID)
-		// Note: we eat the error here, assuming it meant this user
-		// is not a member
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 		for _, uv := range uvs {
 			if uv == meUV {


### PR DESCRIPTION
Adds a test for a non-member calling CanUserPerform, and skips returning the team load error because of the chicken-and-egg problem of checking whether the user is an implicit admin when they're not allowed to load the team.

Also note that joining the team is gated on being an implicit admin, per the old logic: https://github.com/keybase/client/pull/10067/files#diff-e0de75ddcbf2a51c697722e50b5a78fdL215
I don't really get that.

@mmaxim @zapu  @keybase/react-hackers 