### PR TITLE
preliminary workaround for retro terminals

### DIFF
--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -161,7 +161,9 @@ main() {
 
   echo 'Success!'
   # Magical squirrel produced by https://github.com/erkin/ponysay
-  cat /opt/keybase/crypto_squirrel.txt
+  if [ "$KEYBASE_NO_SQUIRREL" != "1" ]; then
+    cat /opt/keybase/crypto_squirrel.txt
+  fi
 }
 
 main


### PR DESCRIPTION
I got user feedback that the crypto squirrel was screwing over xterms running the `C` locale.