### PR TITLE
People QA 3

### DIFF
--- a/shared/actions/profile/proofs.js
+++ b/shared/actions/profile/proofs.js
@@ -224,10 +224,10 @@ function* _addServiceProof(service: ProvablePlatformsType): Saga.SagaGenerator<a
   }
 }
 
-function _cancelAddProof() {
+function _cancelAddProof(_, state: TypedState) {
   return Saga.sequentially([
     Saga.put(ProfileGen.createUpdateErrorText({})),
-    Saga.put(navigateTo([], [peopleTab])),
+    Saga.put(ProfileGen.createShowUserProfile({username: state.config.username || ''})),
   ])
 }
 

--- a/shared/common-adapters/usernames.js
+++ b/shared/common-adapters/usernames.js
@@ -51,16 +51,17 @@ function usernameText({
         >
           {u.username}
         </Text>
-        {i !== users.length - 1 && ( // Injecting the commas here so we never wrap and have newlines starting with a ,
-          <Text
-            type={type}
-            backgroundMode={backgroundMode}
-            style={{...style, color: commaColor, marginRight: 1, textDecoration: 'none'}}
-          >
-            ,
-            {inlineGrammar && ' '}
-          </Text>
-        )}
+        {i !== users.length - 1 &&
+        users.length > 2 && ( // Injecting the commas here so we never wrap and have newlines starting with a ,
+            <Text
+              type={type}
+              backgroundMode={backgroundMode}
+              style={{...style, color: commaColor, marginRight: 1, textDecoration: 'none'}}
+            >
+              ,
+            </Text>
+          )}
+        {inlineGrammar && ' '}
       </Text>
     )
   })

--- a/shared/people/follow-notification/index.js
+++ b/shared/people/follow-notification/index.js
@@ -32,7 +32,9 @@ export const FollowNotification = (props: Props) => {
   return (
     <PeopleItem
       badged={props.badged}
-      icon={<Avatar username={username} size={isMobile ? 48 : 32} />}
+      icon={
+        <Avatar username={username} onClick={() => props.onClickUser(username)} size={isMobile ? 48 : 32} />
+      }
       when={props.notificationTime}
       contentStyle={{justifyContent: 'center'}}
     >

--- a/shared/people/follow-notification/index.js
+++ b/shared/people/follow-notification/index.js
@@ -15,7 +15,7 @@ const connectedUsernamesProps = {
 
 export type NewFollow = Types.FollowedNotification
 
-export type Props = Types._FollowedNotificationItem
+export type Props = Types._FollowedNotificationItem & {onClickUser: (username: string) => void}
 
 export default (props: Props) => {
   if (props.newFollows.length === 1) {
@@ -37,7 +37,12 @@ export const FollowNotification = (props: Props) => {
       contentStyle={{justifyContent: 'center'}}
     >
       <Text type="Body" style={{marginTop: 2}}>
-        <ConnectedUsernames {...connectedUsernamesProps} usernames={[username]} /> followed you.
+        <ConnectedUsernames
+          {...connectedUsernamesProps}
+          usernames={[username]}
+          onUsernameClicked={props.onClickUser}
+        />{' '}
+        followed you.
       </Text>
     </PeopleItem>
   )
@@ -86,6 +91,7 @@ export const MultiFollowNotification = (props: Props) => {
           showAnd={!props.numAdditional}
           {...connectedUsernamesProps}
           usernames={usernames}
+          onUsernameClicked={props.onClickUser}
         />
         {!!props.numAdditional && props.numAdditional > 0 && ` and ${props.numAdditional} others `} started
         following you.

--- a/shared/people/follow-notification/index.js
+++ b/shared/people/follow-notification/index.js
@@ -106,7 +106,13 @@ export const MultiFollowNotification = (props: Props) => {
         }}
       >
         {usernames.map(username => (
-          <Avatar username={username} size={32} key={username} style={{marginRight: globalMargins.xtiny}} />
+          <Avatar
+            onClick={() => props.onClickUser(username)}
+            username={username}
+            size={32}
+            key={username}
+            style={{marginRight: globalMargins.xtiny}}
+          />
         ))}
       </ScrollView>
     </PeopleItem>

--- a/shared/people/follow-notification/index.stories.js
+++ b/shared/people/follow-notification/index.stories.js
@@ -4,7 +4,7 @@ import * as C from '../../constants/people'
 import {Provider} from 'react-redux'
 import {createStore} from 'redux'
 import {Set} from 'immutable'
-import {storiesOf} from '../../stories/storybook'
+import {action, storiesOf} from '../../stories/storybook'
 import FollowNotification, {type Props} from '.'
 import moment from 'moment'
 
@@ -20,6 +20,7 @@ const singleFollowProps1: Props = {
   newFollows: [C.makeFollowedNotification({username: 'mmaxim'})],
   badged: true,
   notificationTime: new Date(),
+  onClickUser: action('onClickUser'),
 }
 
 const singleFollowProps2: Props = {
@@ -29,6 +30,7 @@ const singleFollowProps2: Props = {
   notificationTime: moment()
     .subtract(3, 'days')
     .toDate(),
+  onClickUser: action('onClickUser'),
 }
 
 const multiFollowProps1: Props = {
@@ -43,6 +45,7 @@ const multiFollowProps1: Props = {
     .subtract(3, 'weeks')
     .toDate(),
   numAdditional: 0,
+  onClickUser: action('onClickUser'),
 }
 
 const multiFollowProps2: Props = {
@@ -58,6 +61,7 @@ const multiFollowProps2: Props = {
     .subtract(3, 'months')
     .toDate(),
   numAdditional: 5,
+  onClickUser: action('onClickUser'),
 }
 
 const load = () => {

--- a/shared/people/index.shared.js
+++ b/shared/people/index.shared.js
@@ -8,12 +8,12 @@ import FollowSuggestions from './follow-suggestions'
 import {type Props} from '.'
 import {globalStyles, globalColors, globalMargins} from '../styles'
 
-export const itemToComponent: Types._PeopleScreenItem => React.Node = (item, actions) => {
+export const itemToComponent: (Types._PeopleScreenItem, Props) => React.Node = (item, props) => {
   switch (item.type) {
     case 'todo':
       return <Todo {...item} key={item.todoType} />
     case 'notification':
-      return <FollowNotification {...item} key={item.notificationTime} />
+      return <FollowNotification {...item} key={item.notificationTime} onClickUser={props.onClickUser} />
   }
 }
 
@@ -50,9 +50,9 @@ export const PeoplePageSearchBar = (
 
 export const PeoplePageList = (props: Props) => (
   <Box style={{...globalStyles.flexBoxColumn, width: '100%', position: 'relative', marginTop: 48}}>
-    {props.newItems.map(item => itemToComponent(item))}
+    {props.newItems.map(item => itemToComponent(item, props))}
     <FollowSuggestions suggestions={props.followSuggestions} onClickUser={props.onClickUser} />
-    {props.oldItems.map(item => itemToComponent(item))}
+    {props.oldItems.map(item => itemToComponent(item, props))}
   </Box>
 )
 

--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -31332,9 +31332,10 @@ exports[`Storyshots People/Follow notification A few people followed you 1`] = `
             }
           >
             <div
-              onClick={undefined}
+              onClick={[Function]}
               style={
                 Object {
+                  "cursor": "pointer",
                   "height": 32,
                   "marginRight": 4,
                   "maxWidth": 32,
@@ -31353,9 +31354,10 @@ exports[`Storyshots People/Follow notification A few people followed you 1`] = `
               />
             </div>
             <div
-              onClick={undefined}
+              onClick={[Function]}
               style={
                 Object {
+                  "cursor": "pointer",
                   "height": 32,
                   "marginRight": 4,
                   "maxWidth": 32,
@@ -31374,9 +31376,10 @@ exports[`Storyshots People/Follow notification A few people followed you 1`] = `
               />
             </div>
             <div
-              onClick={undefined}
+              onClick={[Function]}
               style={
                 Object {
+                  "cursor": "pointer",
                   "height": 32,
                   "marginRight": 4,
                   "maxWidth": 32,
@@ -31787,9 +31790,10 @@ exports[`Storyshots People/Follow notification Many people followed you 1`] = `
             }
           >
             <div
-              onClick={undefined}
+              onClick={[Function]}
               style={
                 Object {
+                  "cursor": "pointer",
                   "height": 32,
                   "marginRight": 4,
                   "maxWidth": 32,
@@ -31808,9 +31812,10 @@ exports[`Storyshots People/Follow notification Many people followed you 1`] = `
               />
             </div>
             <div
-              onClick={undefined}
+              onClick={[Function]}
               style={
                 Object {
+                  "cursor": "pointer",
                   "height": 32,
                   "marginRight": 4,
                   "maxWidth": 32,
@@ -31829,9 +31834,10 @@ exports[`Storyshots People/Follow notification Many people followed you 1`] = `
               />
             </div>
             <div
-              onClick={undefined}
+              onClick={[Function]}
               style={
                 Object {
+                  "cursor": "pointer",
                   "height": 32,
                   "marginRight": 4,
                   "maxWidth": 32,
@@ -31850,9 +31856,10 @@ exports[`Storyshots People/Follow notification Many people followed you 1`] = `
               />
             </div>
             <div
-              onClick={undefined}
+              onClick={[Function]}
               style={
                 Object {
+                  "cursor": "pointer",
                   "height": 32,
                   "marginRight": 4,
                   "maxWidth": 32,
@@ -32038,9 +32045,10 @@ exports[`Storyshots People/Follow notification Someone followed you 1`] = `
         }
       >
         <div
-          onClick={undefined}
+          onClick={[Function]}
           style={
             Object {
+              "cursor": "pointer",
               "height": 32,
               "maxWidth": 32,
               "minHeight": 32,
@@ -32095,7 +32103,8 @@ exports[`Storyshots People/Follow notification Someone followed you 1`] = `
               </span>
             </span>
           </span>
-           followed you.
+           
+          followed you.
         </span>
       </div>
       <div
@@ -32275,9 +32284,10 @@ exports[`Storyshots People/Follow notification Someone you follow followed you 1
         }
       >
         <div
-          onClick={undefined}
+          onClick={[Function]}
           style={
             Object {
+              "cursor": "pointer",
               "height": 32,
               "maxWidth": 32,
               "minHeight": 32,
@@ -32332,7 +32342,8 @@ exports[`Storyshots People/Follow notification Someone you follow followed you 1
               </span>
             </span>
           </span>
-           followed you.
+           
+          followed you.
         </span>
       </div>
       <div

--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -31271,8 +31271,8 @@ exports[`Storyshots People/Follow notification A few people followed you 1`] = `
                 title={undefined}
               >
                 ,
-                 
               </span>
+               
             </span>
             <span
               className="glamor-3"
@@ -31292,8 +31292,8 @@ exports[`Storyshots People/Follow notification A few people followed you 1`] = `
                 title={undefined}
               >
                 ,
-                 
               </span>
+               
             </span>
             <span
               className="glamor-3"
@@ -31308,6 +31308,7 @@ exports[`Storyshots People/Follow notification A few people followed you 1`] = `
               >
                 chrisnojima
               </span>
+               
             </span>
           </span>
            started following you.
@@ -31708,8 +31709,8 @@ exports[`Storyshots People/Follow notification Many people followed you 1`] = `
                 title={undefined}
               >
                 ,
-                 
               </span>
+               
             </span>
             <span
               className="glamor-3"
@@ -31729,8 +31730,8 @@ exports[`Storyshots People/Follow notification Many people followed you 1`] = `
                 title={undefined}
               >
                 ,
-                 
               </span>
+               
             </span>
             <span
               className="glamor-3"
@@ -31750,8 +31751,8 @@ exports[`Storyshots People/Follow notification Many people followed you 1`] = `
                 title={undefined}
               >
                 ,
-                 
               </span>
+               
             </span>
             <span
               className="glamor-3"
@@ -31765,6 +31766,7 @@ exports[`Storyshots People/Follow notification Many people followed you 1`] = `
               >
                 chris
               </span>
+               
             </span>
           </span>
            and 5 others 

--- a/shared/util/feature-flags.native.js
+++ b/shared/util/feature-flags.native.js
@@ -6,7 +6,7 @@ const ff: FeatureFlags = {
   admin: __DEV__,
   fsEnabled: __DEV__,
   impTeamChatEnabled: true,
-  newPeopleTab: __DEV__,
+  newPeopleTab: true,
   plansEnabled: false,
   tabGitEnabled: true,
   tabPeopleEnabled: false,


### PR DESCRIPTION
* Makes usernames in follow notifications navigate to profiles (rather than tracker popups) on desktop
* Make avatars on follow notifications clickable & navigate to profiles
* Make proof cancellation call `showUserProfile` on the current user (current behavior is navigating to the root of the people tab) (depends on #10179)

~I skipped adding latency to the pageload calls for a future PR~ nevermind, @maxtaco added this to the service

r? @keybase/react-hackers 