### PR TITLE
dont lose track of members type for error convs

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -415,6 +415,7 @@ function* _chatInboxFailedSubSaga(params: RPCChatTypes.ChatUiChatInboxFailedRpcP
       : RPCChatTypes.commonConversationMemberStatus.active,
     status: Constants.ConversationStatusByEnum[error.remoteConv.metadata.status],
     version: error.remoteConv.metadata.version,
+    name: error.unverifiedTLFName,
     teamname,
   })
 

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -407,9 +407,14 @@ function* _chatInboxFailedSubSaga(params: RPCChatTypes.ChatUiChatInboxFailedRpcP
     participants: error.rekeyInfo
       ? I.List([].concat(error.rekeyInfo.writerNames, error.rekeyInfo.readerNames).filter(Boolean))
       : I.List(error.unverifiedTLFName.split(',')),
-    status: 'unfiled',
     time: error.remoteConv.readerInfo ? error.remoteConv.readerInfo.mtime : 0,
     membersType: error.remoteConv.metadata.membersType,
+    teamType: error.remoteConv.metadata.teamType,
+    memberStatus: error.remoteConv.readerInfo
+      ? error.remoteConv.readerInfo.status
+      : RPCChatTypes.commonConversationMemberStatus.active,
+    status: Constants.ConversationStatusByEnum[error.remoteConv.metadata.status],
+    version: error.remoteConv.metadata.version,
     teamname,
   })
 

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -398,6 +398,10 @@ function* _chatInboxFailedSubSaga(params: RPCChatTypes.ChatUiChatInboxFailedRpcP
   const conversationIDKey = Constants.conversationIDToKey(convID)
 
   // Valid inbox item for rekey errors only
+  let teamname = null
+  if (error.remoteConv.metadata.membersType === RPCChatTypes.commonConversationMembersType.team) {
+    teamname = error.unverifiedTLFName
+  }
   const conversation = Constants.makeInboxState({
     conversationIDKey,
     participants: error.rekeyInfo
@@ -405,6 +409,8 @@ function* _chatInboxFailedSubSaga(params: RPCChatTypes.ChatUiChatInboxFailedRpcP
       : I.List(error.unverifiedTLFName.split(',')),
     status: 'unfiled',
     time: error.remoteConv.readerInfo ? error.remoteConv.readerInfo.mtime : 0,
+    membersType: error.remoteConv.metadata.membersType,
+    teamname,
   })
 
   yield Saga.put(

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -402,6 +402,7 @@ function* _chatInboxFailedSubSaga(params: RPCChatTypes.ChatUiChatInboxFailedRpcP
   if (error.remoteConv.metadata.membersType === RPCChatTypes.commonConversationMembersType.team) {
     teamname = error.unverifiedTLFName
   }
+  const notifications = error.remoteConv.notifications && parseNotifications(error.remoteConv.notifications)
   const conversation = Constants.makeInboxState({
     conversationIDKey,
     participants: error.rekeyInfo
@@ -416,6 +417,7 @@ function* _chatInboxFailedSubSaga(params: RPCChatTypes.ChatUiChatInboxFailedRpcP
     status: Constants.ConversationStatusByEnum[error.remoteConv.metadata.status],
     version: error.remoteConv.metadata.version,
     name: error.unverifiedTLFName,
+    notifications,
     teamname,
   })
 


### PR DESCRIPTION
@keybase/react-hackers 

If a team conversation is in an error state, the JS was losing track of what kind of conversation it is.