### PR TITLE
mark team read errors that get sent back as "not in team" as permanent

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -101,7 +101,7 @@ func (b *Boxer) detectKBFSPermanentServerError(err error) bool {
 		case keybase1.StatusCode_SCTeamReadError:
 			// These errors get obfuscated by the server on purpose. Just mark this as permanent error
 			// since it likely means the team is in bad shape.
-			return aerr.Error() == "You are not a member of this team"
+			return aerr.Error() == "You are not a member of this team (error 2623)"
 		}
 	}
 

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -94,9 +94,15 @@ func (b *Boxer) detectKBFSPermanentServerError(err error) bool {
 	}
 
 	// Check for team not exist error that is in raw form
-	if aerr, ok := err.(libkb.AppStatusError); ok &&
-		keybase1.StatusCode(aerr.Code) == keybase1.StatusCode_SCTeamNotFound {
-		return true
+	if aerr, ok := err.(libkb.AppStatusError); ok {
+		switch keybase1.StatusCode(aerr.Code) {
+		case keybase1.StatusCode_SCTeamNotFound:
+			return true
+		case keybase1.StatusCode_SCTeamReadError:
+			// These errors get obfuscated by the server on purpose. Just mark this as permanent error
+			// since it likely means the team is in bad shape.
+			return aerr.Error() == "You are not a member of this team"
+		}
 	}
 
 	switch err.(type) {

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -34,13 +34,13 @@ let config = {
 }
 
 // Developer settings
+config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
-  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -34,13 +34,13 @@ let config = {
 }
 
 // Developer settings
-config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
+  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false


### PR DESCRIPTION
Not sure if there is a better way here, but this works...