### PR TITLE
dont' invoke selectConversation when entering app from a push notification

### DIFF
--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -1,13 +1,12 @@
 // @flow
 import logger from '../logger'
-import * as ChatGen from './chat-gen'
 import * as PushGen from './push-gen'
 import * as ChatTypes from '../constants/types/rpc-chat-gen'
 import * as Saga from '../util/saga'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import {isMobile} from '../constants/platform'
 import {chatTab} from '../constants/tabs'
-import {switchTo} from './route-tree'
+import {navigateTo} from './route-tree'
 import {createShowUserProfile} from './profile-gen'
 import {
   requestPushPermissions,
@@ -90,13 +89,13 @@ function* pushNotificationSaga(notification: PushGen.NotificationPayload): Saga.
           logger.error('Push chat notification payload missing conversation ID')
           return
         }
+        logger.info(`Push notification: new message: convID: ${convID}`)
         // Short term hack: this just ensures that the service definitely knows we are now in the
         // foreground for the GetThreadLocal call coming from selectConversation.
         yield Saga.call(RPCTypes.appStateUpdateAppStateRpcPromise, {
           state: RPCTypes.appStateAppState.foreground,
         })
-        yield Saga.put(ChatGen.createSelectConversation({conversationIDKey: convID, fromUser: true}))
-        yield Saga.put(switchTo([chatTab]))
+        yield Saga.put(navigateTo([convID], [chatTab]))
       } else if (payload.type === 'follow') {
         const {username} = payload
         if (!username) {

--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -90,11 +90,6 @@ function* pushNotificationSaga(notification: PushGen.NotificationPayload): Saga.
           return
         }
         logger.info(`Push notification: new message: convID: ${convID}`)
-        // Short term hack: this just ensures that the service definitely knows we are now in the
-        // foreground for the GetThreadLocal call coming from selectConversation.
-        yield Saga.call(RPCTypes.appStateUpdateAppStateRpcPromise, {
-          state: RPCTypes.appStateAppState.foreground,
-        })
         yield Saga.put(navigateTo([convID], [chatTab]))
       } else if (payload.type === 'follow') {
         const {username} = payload

--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -6,7 +6,7 @@ import * as Saga from '../util/saga'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import {isMobile} from '../constants/platform'
 import {chatTab} from '../constants/tabs'
-import {navigateTo} from './route-tree'
+import {navigateTo, switchTo} from './route-tree'
 import {createShowUserProfile} from './profile-gen'
 import {
   requestPushPermissions,
@@ -90,6 +90,7 @@ function* pushNotificationSaga(notification: PushGen.NotificationPayload): Saga.
           return
         }
         logger.info(`Push notification: new message: convID: ${convID}`)
+        yield Saga.put(switchTo([chatTab]))
         yield Saga.put(navigateTo([convID], [chatTab]))
       } else if (payload.type === 'follow') {
         const {username} = payload

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -34,13 +34,13 @@ let config = {
 }
 
 // Developer settings
+config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
-  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -34,13 +34,13 @@ let config = {
 }
 
 // Developer settings
-config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
+  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false


### PR DESCRIPTION
@keybase/react-hackers 

`selectConversation` invokes a call to the service to fetch the current thread. If we are coming into the app via push notification, then we are going to be getting word from the service to reload the thread anyway (since there is a new message). As a result, in the current code we end up loading the thread twice. Instead, let's just switch to the chat tab and navigate to the relevant conversation, and then wait for the message from the service to load.