### PR TITLE
Subteams: QA review

### DIFF
--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -123,11 +123,16 @@ function* handleTLFUpdate(items: Array<Types.NonNullGregorItem>): SagaGenerator<
   }
 }
 
-function* handleChatBanner(items: Array<Types.NonNullGregorItem>): SagaGenerator<any, any> {
+function* handleIntroBanners(items: Array<Types.NonNullGregorItem>): SagaGenerator<any, any> {
   const sawChatBanner = items.find(i => i.item && i.item.category === 'sawChatBanner')
+  const sawSubteamsBanner = items.find(i => i.item && i.item.category === 'sawSubteamsBanner')
   if (sawChatBanner) {
     // TODO move this to teams eventually
     yield Saga.put(replaceEntity(['teams'], I.Map([['sawChatBanner', true]])))
+  }
+  if (sawSubteamsBanner) {
+    // TODO move this to teams eventually
+    yield Saga.put(replaceEntity(['teams'], I.Map([['sawSubteamsBanner', true]])))
   }
 }
 
@@ -141,7 +146,7 @@ function _handlePushState(pushAction: GregorGen.PushStatePayload) {
 
     return Saga.sequentially([
       Saga.call(handleTLFUpdate, nonNullItems),
-      Saga.call(handleChatBanner, nonNullItems),
+      Saga.call(handleIntroBanners, nonNullItems),
     ])
   } else {
     logger.debug('Error in gregor pushState', pushAction.payload)

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -50,6 +50,7 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   convIDToChannelInfo: I.Map(),
   loaded: false,
   sawChatBanner: false,
+  sawSubteamsBanner: false,
   teamAccessRequestsPending: I.Set(),
   teamNameToConvIDs: I.Map(),
   teamNameToInvites: I.Map(),

--- a/shared/constants/types/teams.js
+++ b/shared/constants/types/teams.js
@@ -63,6 +63,7 @@ export type _SubteamInfo = {
   key: string,
   members: number,
   onCreateSubteam: ?(e: SyntheticEvent<>) => void,
+  onHideSubteamsBanner: () => void,
   onReadMore: () => void,
   teamname: string,
   type: 'addSubteam' | 'intro' | 'noSubteams' | 'subteam',
@@ -79,6 +80,7 @@ export type TypeMap = {
 export type _State = {
   convIDToChannelInfo: I.Map<ConversationIDKey, ChannelInfo>,
   sawChatBanner: boolean,
+  sawSubteamsBanner: boolean,
   teamAccessRequestsPending: I.Set<Teamname>,
   teamNameToConvIDs: I.Map<Teamname, I.Set<ConversationIDKey>>,
   teamNameToInvites: I.Map<

--- a/shared/teams/container.js
+++ b/shared/teams/container.js
@@ -36,7 +36,7 @@ const mapStateToProps = (state: TypedState): StateProps => {
 
 type DispatchProps = {
   onCreateTeam: () => void,
-  onHideBanner: () => void,
+  onHideChatBanner: () => void,
   onJoinTeam: () => void,
   onManageChat: (teamname: Teamname) => void,
   onOpenFolder: (teamname: Teamname) => void,
@@ -56,7 +56,7 @@ const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
       ])
     )
   },
-  onHideBanner: () => dispatch(GregorGen.createInjectItem({category: 'sawChatBanner', body: 'true'})),
+  onHideChatBanner: () => dispatch(GregorGen.createInjectItem({category: 'sawChatBanner', body: 'true'})),
   onJoinTeam: () => {
     dispatch(navigateAppend(['showJoinTeamDialog']))
   },

--- a/shared/teams/main/banner.js
+++ b/shared/teams/main/banner.js
@@ -5,10 +5,10 @@ import {globalColors, globalMargins, globalStyles, isMobile} from '../../styles'
 
 export type Props = {
   onReadMore: () => void,
-  onHideBanner: () => void,
+  onHideChatBanner: () => void,
 }
 
-const Banner = ({onReadMore, onHideBanner}: Props) => (
+const Banner = ({onReadMore, onHideChatBanner}: Props) => (
   <Box
     style={{
       ...(isMobile
@@ -58,7 +58,7 @@ const Banner = ({onReadMore, onHideBanner}: Props) => (
       </Text>
     </Box>
     <Box style={closeIconStyle}>
-      <Icon type="iconfont-close" onClick={onHideBanner} />
+      <Icon type="iconfont-close" onClick={onHideChatBanner} />
     </Box>
   </Box>
 )

--- a/shared/teams/main/index.js
+++ b/shared/teams/main/index.js
@@ -25,7 +25,9 @@ const Teams = (props: Props) => (
           alignItems: 'center',
         }}
       >
-        {!props.sawChatBanner && <Banner onReadMore={props.onReadMore} onHideBanner={props.onHideBanner} />}
+        {!props.sawChatBanner && (
+          <Banner onReadMore={props.onReadMore} onHideChatBanner={props.onHideChatBanner} />
+        )}
         <TeamList {...props} />
         <BetaNote {...props} />
       </ScrollView>

--- a/shared/teams/routes.js
+++ b/shared/teams/routes.js
@@ -64,6 +64,42 @@ const showNewTeamDialog = {
   tags: makeLeafTags({layerOnTop: !isMobile}),
 }
 
+const teamRoute = makeRouteDefNode({
+  children: {
+    ...makeManageChannels,
+    controlledRolePicker,
+    rolePicker,
+    reallyLeaveTeam,
+    reallyRemoveMember,
+    showNewTeamDialog,
+    team: () => teamRoute,
+    member: {
+      children: {
+        rolePicker,
+        reallyLeaveTeam,
+        reallyRemoveMember,
+      },
+      component: Member,
+    },
+    addPeople: {
+      children: {controlledRolePicker},
+      component: AddPeopleDialog,
+      tags: makeLeafTags({layerOnTop: !isMobile}),
+    },
+    inviteByEmail: {
+      children: {controlledRolePicker},
+      component: InviteByEmailDialog,
+      tags: makeLeafTags({layerOnTop: !isMobile}),
+    },
+    editTeamDescription: {
+      children: {},
+      component: MaybePopupHoc(true)(EditTeamDescription),
+      tags: makeLeafTags({layerOnTop: !isMobile}),
+    },
+  },
+  component: Team,
+})
+
 const routeTree = makeRouteDefNode({
   children: {
     ...makeManageChannels,
@@ -73,40 +109,7 @@ const routeTree = makeRouteDefNode({
       component: JoinTeamDialog,
       tags: makeLeafTags({layerOnTop: !isMobile}),
     },
-    team: {
-      children: {
-        ...makeManageChannels,
-        controlledRolePicker,
-        rolePicker,
-        reallyLeaveTeam,
-        reallyRemoveMember,
-        showNewTeamDialog,
-        member: {
-          children: {
-            rolePicker,
-            reallyLeaveTeam,
-            reallyRemoveMember,
-          },
-          component: Member,
-        },
-        addPeople: {
-          children: {controlledRolePicker},
-          component: AddPeopleDialog,
-          tags: makeLeafTags({layerOnTop: !isMobile}),
-        },
-        inviteByEmail: {
-          children: {controlledRolePicker},
-          component: InviteByEmailDialog,
-          tags: makeLeafTags({layerOnTop: !isMobile}),
-        },
-        editTeamDescription: {
-          children: {},
-          component: MaybePopupHoc(true)(EditTeamDescription),
-          tags: makeLeafTags({layerOnTop: !isMobile}),
-        },
-      },
-      component: Team,
-    },
+    team: teamRoute,
   },
   component: TeamsContainer,
   tags: makeLeafTags({title: 'Teams'}),

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -3,6 +3,7 @@ import * as Constants from '../../constants/teams'
 import * as Types from '../../constants/types/teams'
 import * as RPCTypes from '../../constants/types/rpc-gen'
 import * as TeamsGen from '../../actions/teams-gen'
+import * as GregorGen from '../../actions/gregor-gen'
 import * as SearchGen from '../../actions/search-gen'
 import * as I from 'immutable'
 import * as KBFSGen from '../../actions/kbfs-gen'
@@ -33,6 +34,7 @@ type StateProps = {
   publicityAnyMember: boolean,
   publicityMember: boolean,
   publicityTeam: boolean,
+  sawSubteamsBanner: boolean,
   selectedTab: string,
   waitingForSavePublicity: boolean,
   you: ?string,
@@ -52,6 +54,7 @@ const mapStateToProps = (state: TypedState, {routeProps, routeState}): StateProp
   const subteams = state.entities
     .getIn(['teams', 'teamNameToSubteams', teamname], I.Set())
     .filter(team => team.startsWith(teamname + '.'))
+    .sort()
 
   return {
     _memberInfo: memberInfo,
@@ -80,6 +83,7 @@ const mapStateToProps = (state: TypedState, {routeProps, routeState}): StateProp
       false
     ),
     publicityTeam: state.entities.getIn(['teams', 'teamNameToPublicitySettings', teamname, 'team'], false),
+    sawSubteamsBanner: state.entities.getIn(['teams', 'sawSubteamsBanner'], false),
     selectedTab: routeState.get('selectedTab') || 'members',
     subteams,
     waitingForSavePublicity: anyWaiting(state, `setPublicity:${teamname}`, `getDetails:${teamname}`),
@@ -153,6 +157,8 @@ const mapDispatchToProps = (
   },
   _savePublicity: (teamname: Types.Teamname, settings: Types.PublicitySettings) =>
     dispatch(TeamsGen.createSetPublicity({teamname, settings})),
+  onHideSubteamsBanner: () =>
+    dispatch(GregorGen.createInjectItem({body: 'true', category: 'sawSubteamsBanner'})),
   onReadMoreAboutSubteams: () => {
     openURL('https://keybase.io/docs/teams/design')
   },

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -433,7 +433,7 @@ class Team extends React.PureComponent<Props> {
             ]
           : []),
         ...(yourOperations.manageSubteams ? [{key: 'addSubteam', type: 'addSubteam', onCreateSubteam}] : []),
-        ...subteams.map(subteam => ({key: 'subteam', teamname: subteam, type: 'subteam'})),
+        ...subteams.map(subteam => ({key: subteam, teamname: subteam, type: 'subteam'})),
         ...(noSubteams ? [{key: 'noSubteams', type: 'noSubteams'}] : []),
       ]
 
@@ -652,19 +652,21 @@ class Team extends React.PureComponent<Props> {
             {memberCount + ' member' + (memberCount !== 1 ? 's' : '')} •{' '}
             {yourRole && Constants.typeToLabel[yourRole]}
           </Text>
-          {!loading &&
-            (yourOperations.editChannelDescription || description) && (
-              <Text
-                style={{
-                  paddingTop: globalMargins.tiny,
-                  color: description ? globalColors.black_75 : globalColors.black_20,
-                }}
-                onClick={yourOperations.editChannelDescription ? onEditDescription : null}
-                type={yourOperations.editChannelDescription ? 'BodySecondaryLink' : 'Body'}
-              >
-                {description || (yourOperations.editChannelDescription && 'Write a brief description')}
-              </Text>
-            )}
+
+          {!loading && (yourOperations.editChannelDescription || description) ? (
+            <Text
+              style={{
+                paddingTop: globalMargins.tiny,
+                color: description ? globalColors.black_75 : globalColors.black_20,
+              }}
+              onClick={yourOperations.editChannelDescription ? onEditDescription : null}
+              type={yourOperations.editChannelDescription ? 'BodySecondaryLink' : 'Body'}
+            >
+              {description || (yourOperations.editChannelDescription && 'Write a brief description')}
+            </Text>
+          ) : (
+            <Box />
+          )}
 
           {yourOperations.manageMembers && (
             <ButtonBar>

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -47,6 +47,7 @@ export type Props = {
   setSelectedTab: (t: ?Types.TabKey) => void,
   onCreateSubteam: () => void,
   onEditDescription: () => void,
+  onHideSubteamsBanner: () => void,
   onLeaveTeam: () => void,
   onManageChat: () => void,
   onReadMoreAboutSubteams: () => void,
@@ -59,6 +60,7 @@ export type Props = {
   publicitySettingsChanged: boolean,
   publicityTeam: boolean,
   requests: Array<RequestRowProps>,
+  sawSubteamsBanner: boolean,
   selectedTab: Types.TabKey,
   showAddYourselfBanner: boolean,
   setIgnoreAccessRequests: (checked: boolean) => void,
@@ -141,7 +143,12 @@ type TeamTabsProps = {
 }
 
 const SubteamsIntro = ({row}) => (
-  <SubteamBanner key={row.key} onReadMore={row.onReadMore} teamname={row.teamname} />
+  <SubteamBanner
+    key={row.key}
+    onHideSubteamsBanner={row.onHideSubteamsBanner}
+    onReadMore={row.onReadMore}
+    teamname={row.teamname}
+  />
 )
 
 const SubteamRow = ({row}) => (
@@ -343,6 +350,7 @@ class Team extends React.PureComponent<Props> {
       selectedTab,
       loading,
       memberCount,
+      onHideSubteamsBanner,
       onManageChat,
       onReadMoreAboutSubteams,
       onSavePublicity,
@@ -352,6 +360,7 @@ class Team extends React.PureComponent<Props> {
       publicityMember,
       publicitySettingsChanged,
       publicityTeam,
+      sawSubteamsBanner,
       setIgnoreAccessRequests,
       setOpenTeam,
       setPublicityAnyMember,
@@ -363,17 +372,18 @@ class Team extends React.PureComponent<Props> {
       yourOperations,
     } = this.props
 
+    const teamname = name
     // massage data for rowrenderers
     const memberProps = members.map(member => ({
       fullName: member.fullName,
       username: member.username,
-      teamname: name,
+      teamname,
       active: member.active,
       key: member.username + member.active.toString(),
     }))
     const requestProps = requests.map(req => ({
       key: req.username,
-      teamname: name,
+      teamname,
       type: 'request',
       username: req.username,
     }))
@@ -388,7 +398,7 @@ class Team extends React.PureComponent<Props> {
       }
       return {
         ...inviteInfo,
-        teamname: name,
+        teamname,
         username: invite.username,
         id: invite.id,
         type: 'invite',
@@ -410,15 +420,22 @@ class Team extends React.PureComponent<Props> {
     } else if (selectedTab === 'subteams') {
       const noSubteams = subteams.isEmpty()
       const subTeamsItems = [
-        ...(noSubteams
-          ? [{key: 'intro', type: 'intro', teamname: name, onReadMore: onReadMoreAboutSubteams}]
+        ...(!sawSubteamsBanner
+          ? [
+              {
+                key: 'intro',
+                teamname,
+                type: 'intro',
+                onHideSubteamsBanner,
+                onReadMore: onReadMoreAboutSubteams,
+              },
+            ]
           : []),
         ...(yourOperations.manageSubteams ? [{key: 'addSubteam', type: 'addSubteam', onCreateSubteam}] : []),
         ...subteams.map(subteam => ({key: 'subteam', teamname: subteam, type: 'subteam'})),
         ...(noSubteams ? [{key: 'noSubteams', type: 'noSubteams'}] : []),
       ]
 
-      console.warn('subTeamsItems is', subTeamsItems)
       contents = !loading && (
         <List
           items={subTeamsItems}
@@ -443,7 +460,7 @@ class Team extends React.PureComponent<Props> {
         contents = (
           <Text
             type="BodySmall"
-            style={{color: globalColors.black_40, textAlign: 'center', marginTop: globalMargins.xlarge}}
+            style={{color: globalColors.black_40, marginTop: globalMargins.xlarge, textAlign: 'center'}}
           >
             This team has no pending invites.
           </Text>

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -238,7 +238,7 @@ const TeamTabs = (props: TeamTabsProps) => {
     yourOperations,
   } = props
   let membersLabel = 'MEMBERS'
-  membersLabel += !loading || members.length !== 0 ? ' (' + members.length + ')' : ''
+  membersLabel += !loading && members.length !== 0 ? ` (${members.length})` : ''
   const tabs = [
     <Text
       key="members"
@@ -261,7 +261,8 @@ const TeamTabs = (props: TeamTabsProps) => {
   }
 
   if (admin) {
-    const invitesLabel = `INVITES (${invites.length})`
+    let invitesLabel = 'INVITES'
+    invitesLabel += !loading && invites.length !== 0 ? ` (${invites.length})` : ''
     tabs.push(
       <Box key="invites" style={{...globalStyles.flexBoxRow, alignItems: 'center'}}>
         <Text
@@ -278,7 +279,7 @@ const TeamTabs = (props: TeamTabsProps) => {
   }
 
   let subteamsLabel = 'SUBTEAMS'
-  subteamsLabel += !loading || subteams.length !== 0 ? ' (' + subteams.count() + ')' : ''
+  subteamsLabel += !loading && subteams.count() !== 0 ? ` (${subteams.count()})` : ''
   if (subteams.count() > 0 || yourOperations.manageSubteams) {
     tabs.push(
       <Text

--- a/shared/teams/team/subteam-banner.js
+++ b/shared/teams/team/subteam-banner.js
@@ -6,11 +6,11 @@ import type {Teamname} from '../../constants/types/teams'
 
 export type Props = {
   onReadMore: () => void,
-  onHideBanner?: () => void,
+  onHideSubteamsBanner: () => void,
   teamname: Teamname,
 }
 
-const Banner = ({onReadMore, onHideBanner, teamname}: Props) => (
+const Banner = ({onReadMore, onHideSubteamsBanner, teamname}: Props) => (
   <Box
     style={{
       ...(isMobile ? styleMobile : styleDesktop),
@@ -42,7 +42,7 @@ const Banner = ({onReadMore, onHideBanner, teamname}: Props) => (
         • {teamname}.legal
       </Text>
       <Text backgroundMode="Terminal" type="BodySemibold">
-        • {teamname}.customers.nike
+        • {teamname}.customers.vip
       </Text>
 
       <Text
@@ -55,9 +55,9 @@ const Banner = ({onReadMore, onHideBanner, teamname}: Props) => (
         Read more about subteams
       </Text>
     </Box>
-    {onHideBanner && (
+    {onHideSubteamsBanner && (
       <Box style={closeIconStyle}>
-        <Icon type="iconfont-close" onClick={onHideBanner} />
+        <Icon type="iconfont-close" onClick={onHideSubteamsBanner} />
       </Box>
     )}
   </Box>

--- a/shared/teams/team/subteam-row/container.js
+++ b/shared/teams/team/subteam-row/container.js
@@ -3,9 +3,8 @@ import * as I from 'immutable'
 import * as Types from '../../../constants/types/teams'
 import * as Constants from '../../../constants/teams'
 import {TeamRow} from '../../main/team-list'
-import {teamsTab} from '../../../constants/tabs'
 import {connect, type TypedState} from '../../../util/container'
-import {navigateAppend, navigateTo} from '../../../actions/route-tree'
+import {navigateAppend} from '../../../actions/route-tree'
 import * as KBFSGen from '../../../actions/kbfs-gen'
 
 type OwnProps = {
@@ -26,7 +25,7 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
   _onOpenFolder: (teamname: Types.Teamname) =>
     dispatch(KBFSGen.createOpen({path: `/keybase/team/${teamname}`})),
   _onViewTeam: (teamname: Types.Teamname) => {
-    dispatch(navigateTo([teamsTab, {props: {teamname}, selected: 'team'}]))
+    dispatch(navigateAppend([{props: {teamname}, selected: 'team'}]))
   },
 })
 


### PR DESCRIPTION
@keybase/react-hackers 

- [x] Sort subteams in the Team->Subteams tab
- [x] Only show the subteams intro banner once per user, use a Gregor category to control
- [x] s/customers.nike/customers.vip/ in the intro example per Coyne
- [x] Only show numbers next to team member/invite counts if they're non-zero and we're done loading.
- [x] Fix a RawText crash on Android when using `{foo && <Text>}`.
- [x] Use a recursive route for subteam viewing so that the back button goes up one level.