### PR TITLE
Fix for iOS RefreshControl getting stuck

### DIFF
--- a/shared/actions/people.js
+++ b/shared/actions/people.js
@@ -126,7 +126,7 @@ const _onTabChange = (action: RouteTypes.SwitchTo, state: TypedState) => {
 }
 
 const peopleSaga = function*(): Saga.SagaGenerator<any, any> {
-  yield Saga.safeTakeLatestPure(PeopleGen.getPeopleData, _getPeopleData, _processPeopleData, () =>
+  yield Saga.safeTakeEveryPure(PeopleGen.getPeopleData, _getPeopleData, _processPeopleData, () =>
     // TODO replace this with engine handling once that lands
     Saga.put(createDecrementWaiting({key: Constants.getPeopleDataWaitingKey}))
   )

--- a/shared/actions/people.js
+++ b/shared/actions/people.js
@@ -90,9 +90,15 @@ const _skipTodo = (action: PeopleGen.SkipTodoPayload) => {
   ])
 }
 
-let _wasOnPeopleTab = false
+let _wasOnPeopleTab = true
 const _setupPeopleHandlers = () => {
   return Saga.put((dispatch: Dispatch) => {
+    engine().listenOnConnect('registerHomeUI', () => {
+      RPCTypes.delegateUiCtlRegisterHomeUIRpcPromise()
+        .then(() => console.log('Registered home UI'))
+        .catch(error => console.warn('Error in registering home UI:', error))
+    })
+
     engine().setIncomingHandler('keybase.1.homeUI.homeUIRefresh', (args: {||}) => {
       if (_wasOnPeopleTab) {
         dispatch(

--- a/shared/actions/people.js
+++ b/shared/actions/people.js
@@ -23,6 +23,7 @@ const _getPeopleData = function(action: PeopleGen.GetPeopleDataPayload, state: T
     }),
     Saga.identity(state.config.following),
     Saga.identity(state.config.followers),
+    Saga.put(createDecrementWaiting({key: Constants.getPeopleDataWaitingKey})),
   ])
 }
 
@@ -60,18 +61,15 @@ const _processPeopleData = function(fromGetPeopleData: any[]) {
       }, I.List())) ||
     I.List()
 
-  return Saga.all([
-    Saga.put(
-      PeopleGen.createPeopleDataProcessed({
-        oldItems,
-        newItems,
-        lastViewed: new Date(data.lastViewed),
-        followSuggestions,
-        version: data.version,
-      })
-    ),
-    Saga.put(createDecrementWaiting({key: Constants.getPeopleDataWaitingKey})),
-  ])
+  return Saga.put(
+    PeopleGen.createPeopleDataProcessed({
+      oldItems,
+      newItems,
+      lastViewed: new Date(data.lastViewed),
+      followSuggestions,
+      version: data.version,
+    })
+  )
 }
 
 const _markViewed = (action: PeopleGen.MarkViewedPayload) =>

--- a/shared/people/index.native.js
+++ b/shared/people/index.native.js
@@ -10,12 +10,15 @@ import {
 import {PeoplePageSearchBar, PeoplePageList} from './index.shared'
 import {type Props} from '.'
 import {globalColors, globalStyles} from '../styles'
+import {isIOS} from '../constants/platform'
 
 const People = (props: Props) => (
   <NativeSafeAreaView>
     <ScrollView
       style={{...globalStyles.fullHeight}}
-      refreshControl={<NativeRefreshControl refreshing={props.waiting} onRefresh={() => props.getData()} />}
+      refreshControl={
+        <NativeRefreshControl refreshing={isIOS ? false : props.waiting} onRefresh={() => props.getData()} />
+      }
     >
       <PeoplePageSearchBar
         {...props}

--- a/shared/people/index.native.js
+++ b/shared/people/index.native.js
@@ -17,6 +17,8 @@ const People = (props: Props) => (
     <ScrollView
       style={{...globalStyles.fullHeight}}
       refreshControl={
+        // TODO set refreshing to the actual prop once the bug in RN gets fixed
+        // see https://github.com/facebook/react-native/issues/5839
         <NativeRefreshControl refreshing={isIOS ? false : props.waiting} onRefresh={() => props.getData()} />
       }
     >


### PR DESCRIPTION
There's a bug in react native where `RefreshControl` doesn't properly stop rendering the spinner under certain conditions (https://github.com/facebook/react-native/issues/5839). This PR sets `refreshing={false}` on iOS as a workaround, which allows the user to pull down to refresh and see the spinner for a moment before it disappears. 

The UX is pretty much identical for user triggered refreshes, but the loading spinner won't appear for the loads that are triggered automatically.

This also closes `incrementWaiting` & `decrementWaiting` interval to just the RPC, rather than including the processing.

r? @keybase/react-hackers 