### PR TITLE
Better warnings for delete-history CLI

### DIFF
--- a/go/client/cmd_chat_delete_history.go
+++ b/go/client/cmd_chat_delete_history.go
@@ -23,6 +23,7 @@ type CmdChatDeleteHistory struct {
 	libkb.Contextified
 	resolvingRequest chatConversationResolvingRequest
 	age              gregor1.DurationSec
+	ageDesc          string
 	hasTTY           bool
 }
 
@@ -88,7 +89,7 @@ func (c *CmdChatDeleteHistory) ParseArgv(ctx *cli.Context) (err error) {
 	}
 
 	if timeStr := ctx.String("age"); len(timeStr) > 0 {
-		c.age, err = c.parseAge(timeStr)
+		c.age, c.ageDesc, err = c.parseAge(timeStr)
 		if err != nil {
 			return err
 		}
@@ -104,35 +105,47 @@ func (c *CmdChatDeleteHistory) GetUsage() libkb.Usage {
 	}
 }
 
-func (c *CmdChatDeleteHistory) parseAge(s string) (gregor1.DurationSec, error) {
+// Returns a duration and english string like "2 days".
+func (c *CmdChatDeleteHistory) parseAge(s string) (gregor1.DurationSec, string, error) {
 	generalErr := fmt.Errorf("duration must be an integer and suffix [s,h,d,w,m] like: 10d")
 	if len(s) < 2 {
-		return 0, generalErr
+		return 0, "", generalErr
 	}
 	factor := time.Second
+	unitName := ""
 	switch s[len(s)-1] {
 	case 's':
 		factor = time.Second
+		unitName = "second"
 	case 'm':
 		factor = time.Minute
+		unitName = "minute"
 	case 'h':
 		factor = time.Hour
+		unitName = "hour"
 	case 'd':
 		factor = 24 * time.Hour
+		unitName = "day"
 	case 'w':
 		factor = 7 * 24 * time.Hour
+		unitName = "week"
 	default:
-		return 0, generalErr
+		return 0, "", generalErr
 	}
 	base, err := strconv.Atoi(s[:len(s)-1])
 	if err != nil {
-		return 0, generalErr
+		return 0, "", generalErr
 	}
 	if base < 0 {
-		return 0, fmt.Errorf("age cannot be negative")
+		return 0, "", fmt.Errorf("age cannot be negative")
 	}
 	d := time.Duration(base) * factor
-	return gregor1.DurationSec(d.Seconds()), nil
+	plural := "s"
+	if base == 1 {
+		plural = ""
+	}
+	desc := fmt.Sprintf("%v %v%v", base, unitName, plural)
+	return gregor1.DurationSec(d.Seconds()), desc, nil
 }
 
 // Like chatSend but uses PostDeleteHistoryByAge.
@@ -161,8 +174,12 @@ func (c *CmdChatDeleteHistory) chatSendDeleteHistory(ctx context.Context) error 
 		Age:              c.age,
 	}
 
-	// Always ask for confirmation for this destructive operation.
-	promptText := fmt.Sprintf("Delete history of [%s]? Hit Enter, or Ctrl-C to cancel.", conversationInfo.TlfName)
+	// Ask for confirmation on this destructive operation.
+	promptText := fmt.Sprintf("Permanently delete ALL chat history of [%s]?\nHit Enter, or Ctrl-C to cancel.", conversationInfo.TlfName)
+	if c.age != gregor1.DurationSec(0) {
+		promptText = fmt.Sprintf("Permanently delete all chat messages in [%s] older than %v?\nHit Enter, or Ctrl-C to cancel.",
+			conversationInfo.TlfName, c.ageDesc)
+	}
 	_, err = c.G().UI.GetTerminalUI().Prompt(PromptDescriptorEnterChatMessage, promptText)
 	if err != nil {
 		return err

--- a/go/client/cmd_chat_delete_history.go
+++ b/go/client/cmd_chat_delete_history.go
@@ -117,9 +117,6 @@ func (c *CmdChatDeleteHistory) parseAge(s string) (gregor1.DurationSec, string, 
 	case 's':
 		factor = time.Second
 		unitName = "second"
-	case 'm':
-		factor = time.Minute
-		unitName = "minute"
 	case 'h':
 		factor = time.Hour
 		unitName = "hour"
@@ -129,6 +126,9 @@ func (c *CmdChatDeleteHistory) parseAge(s string) (gregor1.DurationSec, string, 
 	case 'w':
 		factor = 7 * 24 * time.Hour
 		unitName = "week"
+	case 'm':
+		factor = 30 * 24 * time.Hour
+		unitName = "month"
 	default:
 		return 0, "", generalErr
 	}
@@ -140,6 +140,10 @@ func (c *CmdChatDeleteHistory) parseAge(s string) (gregor1.DurationSec, string, 
 		return 0, "", fmt.Errorf("age cannot be negative")
 	}
 	d := time.Duration(base) * factor
+	if unitName == "month" {
+		base *= 30
+		unitName = "day"
+	}
 	plural := "s"
 	if base == 1 {
 		plural = ""

--- a/go/client/cmd_chat_delete_history_dev.go
+++ b/go/client/cmd_chat_delete_history_dev.go
@@ -96,7 +96,6 @@ func (c *CmdChatDeleteHistoryDev) ParseArgv(ctx *cli.Context) (err error) {
 	// Send a normal message.
 	upto := ctx.Int("upto")
 	if upto == 0 {
-		cli.ShowCommandHelp(ctx, "delete-history-dev")
 		return fmt.Errorf("upto must be > 0")
 	}
 	c.upto = chat1.MessageID(upto)


### PR DESCRIPTION
More explicit confirmations for `delete-history`. Also changed `m` to mean month/30days instead of minutes.

```$ keybase chat delete-history testergoof --age 1d
Found PRIVATE CHAT conversation: mlsteele,testergoof
Permanently delete all chat messages in [mlsteele,testergoof] older than 1 day?
Hit Enter, or Ctrl-C to cancel.▶ ERROR input canceled

$ keybase chat delete-history testergoof --age 2d
Found PRIVATE CHAT conversation: mlsteele,testergoof
Permanently delete all chat messages in [mlsteele,testergoof] older than 2 days?
Hit Enter, or Ctrl-C to cancel.▶ ERROR input canceled

$ keybase chat delete-history testergoof
Found PRIVATE CHAT conversation: mlsteele,testergoof
Permanently delete ALL chat history of [mlsteele,testergoof]?
Hit Enter, or Ctrl-C to cancel.▶ ERROR input canceled

$ keybase chat delete-history testergoof --age 2m
Found PRIVATE CHAT conversation: mlsteele,testergoof
Permanently delete all chat messages in [mlsteele,testergoof] older than 60 days?
Hit Enter, or Ctrl-C to cancel.
```