### PR TITLE
Exit search when successfully creating a new team from chat

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -279,7 +279,8 @@ const _createNewTeamFromConversation = function*(
           })
         }
       }
-      yield Saga.put(ChatGen.createSelectConversation({conversationIDKey: null}))
+      yield Saga.put(ChatGen.createExitSearch({skipSelectPreviousConversation: true}))
+      yield Saga.put(ChatGen.createOpenTeamConversation({teamname, channelname: 'general'}))
     } catch (error) {
       yield Saga.put(TeamsGen.createSetTeamCreationError({error: error.desc}))
     } finally {

--- a/shared/chat/conversation/create-team-header/container.js
+++ b/shared/chat/conversation/create-team-header/container.js
@@ -9,9 +9,9 @@ import type {TypedState} from '../../../constants/reducer'
 import type {StateProps, DispatchProps} from './container'
 
 const mapStateToProps = (state: TypedState) => {
-  const selectedConversationIDKey = Constants.getSelectedConversation(state)
+  const selectedConversationIDKey = Constants.getSelectedConversation(state) || ''
   if (!selectedConversationIDKey) {
-    throw new Error('no selected conversation')
+    console.warn('no selected conversation in chat create team header')
   }
 
   return {


### PR DESCRIPTION
We weren't exiting the chat search view when creating a new team from a conversation. Additionally, the `Make it a team?` header crashed when it received a null `conversationIDKey`. This PR makes it so on success we navigate to the newly created team.

r? @keybase/react-hackers 