### PR TITLE
Allow setting an initial routeState selected tab on the team page

### DIFF
--- a/shared/chat/conversation/messages/system/container.js
+++ b/shared/chat/conversation/messages/system/container.js
@@ -5,7 +5,7 @@ import {AddedToTeamNotice, ComplexTeamNotice, InviteAddedToTeamNotice, GitPushIn
 import {compose, branch, renderComponent, renderNothing} from 'recompose'
 import createCachedSelector from 're-reselect'
 import {connect} from 'react-redux'
-import {navigateAppend, navigateTo} from '../../../../actions/route-tree'
+import {navigateAppend, navigateTo, setRouteState} from '../../../../actions/route-tree'
 import {teamsTab} from '../../../../constants/tabs'
 import {getRole, isAdmin, isOwner} from '../../../../constants/teams'
 import {type TeamRoleType} from '../../../../constants/types/teams'
@@ -30,8 +30,10 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onManageChannels: (teamname: string) => {
     dispatch(navigateAppend([{props: {teamname}, selected: 'manageChannels'}]))
   },
-  onViewTeam: (teamname: string) =>
-    dispatch(navigateTo([teamsTab, {props: {selectedTab: 'members', teamname}, selected: 'team'}])),
+  onViewTeam: (teamname: string) => {
+    dispatch(setRouteState([teamsTab, 'team'], {selectedTab: 'members'}))
+    dispatch(navigateTo([teamsTab, {props: {teamname}, selected: 'team'}]))
+  },
 })
 
 const mergeProps = (stateProps, dispatchProps) => {

--- a/shared/chat/conversation/messages/system/container.js
+++ b/shared/chat/conversation/messages/system/container.js
@@ -30,7 +30,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onManageChannels: (teamname: string) => {
     dispatch(navigateAppend([{props: {teamname}, selected: 'manageChannels'}]))
   },
-  onViewTeam: (teamname: string) => dispatch(navigateTo([teamsTab, {props: {teamname}, selected: 'team'}])),
+  onViewTeam: (teamname: string) =>
+    dispatch(navigateTo([teamsTab, {props: {selectedTab: 'members', teamname}, selected: 'team'}])),
 })
 
 const mergeProps = (stateProps, dispatchProps) => {

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -36,7 +36,6 @@ type StateProps = {
   publicityTeam: boolean,
   sawSubteamsBanner: boolean,
   selectedTab: string,
-  initialSelectedTab: string,
   waitingForSavePublicity: boolean,
   you: ?string,
   yourRole: ?Types.TeamRoleType,
@@ -86,7 +85,6 @@ const mapStateToProps = (state: TypedState, {routeProps, routeState}): StateProp
     publicityTeam: state.entities.getIn(['teams', 'teamNameToPublicitySettings', teamname, 'team'], false),
     sawSubteamsBanner: state.entities.getIn(['teams', 'sawSubteamsBanner'], false),
     selectedTab: routeState.get('selectedTab') || 'members',
-    initialSelectedTab: routeProps.get('selectedTab'),
     subteams,
     waitingForSavePublicity: anyWaiting(state, `setPublicity:${teamname}`, `getDetails:${teamname}`),
     you: state.config.username,
@@ -293,11 +291,6 @@ export default compose(
       }),
   }),
   lifecycle({
-    componentWillMount: function() {
-      if (this.props.initialSelectedTab) {
-        this.props.setSelectedTab(this.props.initialSelectedTab)
-      }
-    },
     componentDidMount: function() {
       this.props._loadTeam(this.props.name)
     },

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -36,6 +36,7 @@ type StateProps = {
   publicityTeam: boolean,
   sawSubteamsBanner: boolean,
   selectedTab: string,
+  initialSelectedTab: string,
   waitingForSavePublicity: boolean,
   you: ?string,
   yourRole: ?Types.TeamRoleType,
@@ -85,6 +86,7 @@ const mapStateToProps = (state: TypedState, {routeProps, routeState}): StateProp
     publicityTeam: state.entities.getIn(['teams', 'teamNameToPublicitySettings', teamname, 'team'], false),
     sawSubteamsBanner: state.entities.getIn(['teams', 'sawSubteamsBanner'], false),
     selectedTab: routeState.get('selectedTab') || 'members',
+    initialSelectedTab: routeProps.get('selectedTab'),
     subteams,
     waitingForSavePublicity: anyWaiting(state, `setPublicity:${teamname}`, `getDetails:${teamname}`),
     you: state.config.username,
@@ -291,6 +293,11 @@ export default compose(
       }),
   }),
   lifecycle({
+    componentWillMount: function() {
+      if (this.props.initialSelectedTab) {
+        this.props.setSelectedTab(this.props.initialSelectedTab)
+      }
+    },
     componentDidMount: function() {
       this.props._loadTeam(this.props.name)
     },


### PR DESCRIPTION
~Now we can set `props: {selectedTab: 'members' | 'settings' | etc.}` when navigating to a team to set an initially selected tab.~

This adds a `setRouteState` at the call site to change the tab to `members`

r? @keybase/react-hackers 