### PR TITLE
Add naive bordering to people items

### DIFF
--- a/shared/people/follow-notification/index.js
+++ b/shared/people/follow-notification/index.js
@@ -99,7 +99,7 @@ export const MultiFollowNotification = (props: Props) => {
         following you.
       </Text>
       <ScrollView
-        {...(isMobile ? {horizontal: true} : {})} // Causes error on desktop
+        {...(isMobile ? {horizontal: true, alwaysBounceHorizontal: false} : {})} // Causes error on desktop
         contentContainerStyle={{
           ...globalStyles.flexBoxRow,
           ...(isMobile

--- a/shared/people/follow-suggestions/index.js
+++ b/shared/people/follow-suggestions/index.js
@@ -59,7 +59,7 @@ export default (props: Props) => (
       Consider following...
     </Text>
     <ScrollView
-      {...(isMobile ? {horizontal: true} : {})} // Causes error on desktop
+      {...(isMobile ? {horizontal: true, alwaysBounceHorizontal: false} : {})} // Causes error on desktop
       contentContainerStyle={{
         ...globalStyles.flexBoxRow,
         ...(isMobile

--- a/shared/people/item/index.js
+++ b/shared/people/item/index.js
@@ -46,6 +46,7 @@ export default (props: Props) => (
       position: 'relative',
       borderBottomWidth: 1,
       borderBottomColor: props.badged ? globalColors.white : globalColors.black_05,
+      borderBottomStyle: 'solid',
     }}
   >
     <Box style={{marginRight: 20, width: isMobile ? 48 : 32}}>{props.icon}</Box>

--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -31168,6 +31168,7 @@ exports[`Storyshots People/Follow notification A few people followed you 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -31606,6 +31607,7 @@ exports[`Storyshots People/Follow notification Many people followed you 1`] = `
         Object {
           "backgroundColor": "#ffffff",
           "borderBottomColor": "rgba(0, 0, 0, 0.05)",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -32028,6 +32030,7 @@ exports[`Storyshots People/Follow notification Someone followed you 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -32267,6 +32270,7 @@ exports[`Storyshots People/Follow notification Someone you follow followed you 1
         Object {
           "backgroundColor": "#ffffff",
           "borderBottomColor": "rgba(0, 0, 0, 0.05)",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -32441,6 +32445,7 @@ exports[`Storyshots People/Todos Chat 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -32659,6 +32664,7 @@ exports[`Storyshots People/Todos Fill out bio 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -32882,6 +32888,7 @@ exports[`Storyshots People/Todos Follow someone 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -33112,6 +33119,7 @@ exports[`Storyshots People/Todos Install on phone 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -33342,6 +33350,7 @@ exports[`Storyshots People/Todos Make a folder 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -33572,6 +33581,7 @@ exports[`Storyshots People/Todos Make a git 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -33790,6 +33800,7 @@ exports[`Storyshots People/Todos Make a paper key 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -34013,6 +34024,7 @@ exports[`Storyshots People/Todos Make a team 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -34243,6 +34255,7 @@ exports[`Storyshots People/Todos Prove something 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",
@@ -34473,6 +34486,7 @@ exports[`Storyshots People/Todos Set publicity 1`] = `
         Object {
           "backgroundColor": "#ebf5fc",
           "borderBottomColor": "#ffffff",
+          "borderBottomStyle": "solid",
           "borderBottomWidth": 1,
           "display": "flex",
           "flexDirection": "row",


### PR DESCRIPTION
This pr adds `borderBottomStyle: 'solid'` to the people page items, causing them to render on desktop. For now the last in the list still shows a bottom border, later on we can pipe through a boolean to turn it off.

It also adds `alwaysBounceHorizontal={false}` to the horizontal ScrollViews on moble.

r? @keybase/react-hackers cc @mlsteele @cecileboucheron 