### PR TITLE
check for notification save state which can be null

### DIFF
--- a/shared/chat/conversation/info-panel/notifications/container.js
+++ b/shared/chat/conversation/info-panel/notifications/container.js
@@ -95,7 +95,7 @@ export default compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
   lifecycle({
     componentDidMount: function() {
-      this.props._resetNotificationSaveState()
+      this.props._resetNotificationSaveState && this.props._resetNotificationSaveState()
     },
   }),
   // $FlowIssue doesn't like dynamic props like we do above


### PR DESCRIPTION
@keybase/react-hackers mergeProps can return {} in this component and it tries to not render the component by using a branch, but lifecycle will get access to this empty props so _resetNotificationSaveState can be null. 
cc: @akalin-keybase  who touched this last week