### PR TITLE
turn back on branch island and remove arm7/7s

### DIFF
--- a/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -1468,8 +1468,6 @@
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
-					"-Xlinker",
-					"-no_branch_islands",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios;
 				PRODUCT_NAME = Keybase;
@@ -1478,6 +1476,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				VALID_ARCHS = arm64;
 			};
 			name = Debug;
 		};
@@ -1517,8 +1516,6 @@
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
-					"-Xlinker",
-					"-no_branch_islands",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios;
 				PRODUCT_NAME = Keybase;
@@ -1526,6 +1523,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Keybase/Keybase-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				VALID_ARCHS = arm64;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
@keybase/react-hackers @mmaxim 
this turns off branch island disabling and removes supports for older devices. Should work on iphone 6 and newer which i think is good enough