### PR TITLE
packaging: linux uses per-user mountpoint, /keybase is a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _testmain.go
 *.prof
 
 go/keybase/keybase
+go/mounter/keybase-mount-helper/keybase-mount-helper
 go/revision
 
 *-fuzz.zip

--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -180,8 +180,8 @@ func (c *CmdStatus) load() (*fstatus, error) {
 		status.KBFS.Running = true
 		// This just gets the mountpoint from the environment; the
 		// user could have technically passed a different mountpoint
-		// to KBFS on macOS or Linux.  TODO: fetch the actual
-		// mountpoint with a new RPC from KBFS.
+		// to KBFS on macOS or Linux.  TODO(KBFS-2723): fetch the
+		// actual mountpoint with a new RPC from KBFS.
 		mountDir, err := c.G().Env.GetMountDir()
 		if err != nil {
 			return nil, err

--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -79,6 +79,7 @@ type fstatus struct {
 		Running bool
 		Pid     string
 		Log     string
+		Mount   string
 	}
 	Desktop struct {
 		Version string
@@ -177,6 +178,15 @@ func (c *CmdStatus) load() (*fstatus, error) {
 	if kbfs := getFirstClient(extStatus.Clients, keybase1.ClientType_KBFS); kbfs != nil {
 		status.KBFS.Version = kbfs.Version
 		status.KBFS.Running = true
+		// This just gets the mountpoint from the environment; the
+		// user could have technically passed a different mountpoint
+		// to KBFS on macOS or Linux.  TODO: fetch the actual
+		// mountpoint with a new RPC from KBFS.
+		mountDir, err := c.G().Env.GetMountDir()
+		if err != nil {
+			return nil, err
+		}
+		status.KBFS.Mount = mountDir
 	} else {
 		kbfsVersion, err := install.KBFSBundleVersion(c.G(), "")
 		if err == nil {
@@ -271,6 +281,7 @@ func (c *CmdStatus) outputTerminal(status *fstatus) error {
 	dui.Printf("    status:    %s\n", BoolString(status.KBFS.Running, "running", "not running"))
 	dui.Printf("    version:   %s\n", status.KBFS.Version)
 	dui.Printf("    log:       %s\n", status.KBFS.Log)
+	dui.Printf("    mount:     %s\n", status.KBFS.Mount)
 	dui.Printf("\nService:\n")
 	dui.Printf("    status:    %s\n", BoolString(status.Service.Running, "running", "not running"))
 	dui.Printf("    version:   %s\n", status.Service.Version)

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -221,15 +221,15 @@ func (e *Env) GetUpdaterConfig() UpdaterConfigReader {
 }
 
 func (e *Env) GetMountDir() (string, error) {
-	var mountsubdir string
+	var darwinMountsubdir string
 	runMode := e.GetRunMode()
 	switch runMode {
 	case DevelRunMode:
-		mountsubdir = "keybase.devel"
+		darwinMountsubdir = "keybase.devel"
 	case StagingRunMode:
-		mountsubdir = "keybase.staging"
+		darwinMountsubdir = "keybase.staging"
 	case ProductionRunMode:
-		mountsubdir = "keybase"
+		darwinMountsubdir = "keybase"
 	default:
 		return "", fmt.Errorf("Invalid run mode: %s", runMode)
 	}
@@ -241,11 +241,8 @@ func (e *Env) GetMountDir() (string, error) {
 		func() string {
 			switch runtime.GOOS {
 			case "darwin":
-				s, err := filepath.Abs(mountsubdir)
-				if err != nil {
-					return ""
-				}
-				return s
+				return filepath.Join(
+					string(filepath.Separator), darwinMountsubdir)
 			case "linux":
 				return filepath.Join(e.GetDataDir(), "fs")
 			default:

--- a/go/mounter/keybase-mount-helper/main.go
+++ b/go/mounter/keybase-mount-helper/main.go
@@ -1,0 +1,194 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+// keybase-mount-helper is a simple program intended to be run with
+// SUID permissions as a keybase helper user, which manages the
+// /var/lib/keybase/mount1 symlink, pointing to a user's KBFS
+// mountpoint.  The first user to run this program captures the
+// symlink; others will get an error.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/user"
+	"runtime"
+	"strconv"
+	"syscall"
+)
+
+const (
+	kbUsername = "keybasehelper"
+)
+
+var (
+	fFirstMountLink           string
+	fOriginalFirstMountTarget string
+	fUserMount                string
+)
+
+func getDefaultUserMount() string {
+	return fmt.Sprintf("/run/user/%d/keybase/fs", os.Getuid())
+}
+
+func init() {
+	flag.StringVar(&fFirstMountLink, "first-mount-link",
+		"/var/lib/keybase/mount1",
+		"path to an existing symlink that should be switched to be a link to "+
+			"the given user mount directory, if it's not already claimed "+
+			"by another user")
+	flag.StringVar(&fOriginalFirstMountTarget, "original-first-mount-target",
+		"/opt/keybase/mount-readme",
+		"the target of the first mount symlink when Keybase was installed")
+	// Get the calling user's UID before doing a SYS_SETUID.
+	flag.StringVar(&fUserMount, "user-mount", getDefaultUserMount(),
+		"path to an existing directory that will serve as the true mountpoint "+
+			"for the Keybase user")
+}
+
+func checkLink(firstMountLink, originalFirstMountTarget, userMount string) (
+	firstMount bool, makeMount bool, err error) {
+	currLink, err := os.Readlink(firstMountLink)
+	if err != nil {
+		return false, false, err
+	}
+
+	if currLink == userMount {
+		// User already owns the link.
+		return true, false, nil
+	}
+
+	if currLink != originalFirstMountTarget {
+		// Another user already owns this link.
+		return false, false, nil
+	}
+
+	// User may try to make the link.
+	return true, true, nil
+}
+
+func takeLock(firstMountLink string) (lockFile *os.File, err error) {
+	// Take an flock to ensure only one user tries to get the link.
+	lockFilename := firstMountLink + ".lock"
+	lockFile, err = os.Create(lockFilename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			lockErr := lockFile.Close()
+			if lockErr != nil {
+				fmt.Fprintf(os.Stderr, "Couldn't close lock file: %+v", lockErr)
+			}
+		}
+	}()
+
+	err = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX)
+	if err != nil {
+		return nil, err
+	}
+	return lockFile, nil
+}
+
+func checkAndSwitchMount(
+	firstMountLink, originalFirstMountTarget, userMount string) (
+	firstMount bool, err error) {
+	firstMount, makeMount, err := checkLink(
+		firstMountLink, originalFirstMountTarget, userMount)
+	if err != nil {
+		return false, err
+	}
+	if !makeMount {
+		return firstMount, nil
+	}
+
+	lockFile, err := takeLock(firstMountLink)
+	if err != nil {
+		return false, err
+	}
+
+	defer func() {
+		lockErr := lockFile.Close()
+		if err == nil {
+			err = lockErr
+		}
+	}()
+
+	// Make sure the link is in the same state after taking the lock.
+	firstMount, makeMount, err = checkLink(
+		firstMountLink, originalFirstMountTarget, userMount)
+	if err != nil {
+		return false, err
+	}
+	if !makeMount {
+		return firstMount, nil
+	}
+
+	// Make a symlink for the new user, and swap it over the existing
+	// symlink.
+	tmpLink := firstMountLink + ".tmp"
+	err = os.Symlink(userMount, tmpLink)
+	if err != nil {
+		return false, err
+	}
+
+	defer func() {
+		if err != nil {
+			rmErr := os.Remove(tmpLink)
+			if rmErr != nil {
+				fmt.Fprintf(os.Stderr,
+					"Can't remove %s on error: %+v\n", tmpLink, rmErr)
+			}
+		}
+	}()
+
+	err = os.Rename(tmpLink, firstMountLink)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func main() {
+	flag.Parse()
+
+	// Figure out the helper UID.
+	khUser, err := user.Lookup(kbUsername)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot get %s user: %+v\n", kbUsername, err)
+		os.Exit(1)
+	}
+	khUid, err := strconv.Atoi(khUser.Uid)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Bad UID for %s user: %+v\n", kbUsername, err)
+		os.Exit(1)
+	}
+
+	// Lock the thread (because SYS_SETUID only sets the UID of the
+	// current OS thread) and switch to the helper user.
+	runtime.LockOSThread()
+	_, _, errNo := syscall.Syscall(syscall.SYS_SETUID, uintptr(khUid), 0, 0)
+	if errNo != 0 {
+		fmt.Fprintf(os.Stderr, "Can't setuid: %+v\n", errNo)
+		os.Exit(1)
+	}
+
+	// Check the mount and switch it to the calling user's mountpoint
+	// if possible.
+	firstMount, err := checkAndSwitchMount(
+		fFirstMountLink, fOriginalFirstMountTarget, fUserMount)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't switch mountpoint: %+v\n", err)
+		os.Exit(1)
+	}
+
+	if !firstMount {
+		fmt.Printf("Your mountpoint is %s; consider `ln -s %s ~/keybase\n",
+			fUserMount, fUserMount)
+	}
+}

--- a/go/mounter/keybase-mount-helper/main.go
+++ b/go/mounter/keybase-mount-helper/main.go
@@ -230,8 +230,12 @@ func main() {
 		suggestedLink := filepath.Join(home, runModeToKeybase())
 		target, err := os.Readlink(suggestedLink)
 		if err != nil || target != fUserMount {
-			fmt.Printf("Your mountpoint is %s; consider `ln -s %s %s`\n",
-				fUserMount, fUserMount, suggestedLink)
+			if fUserMount == suggestedLink {
+				fmt.Printf("Your mountpoint is %s\n", fUserMount)
+			} else {
+				fmt.Printf("Your mountpoint is %s; consider `ln -s %s %s`\n",
+					fUserMount, fUserMount, suggestedLink)
+			}
 		}
 	}
 }

--- a/go/mounter/keybase-mount-helper/main.go
+++ b/go/mounter/keybase-mount-helper/main.go
@@ -66,7 +66,7 @@ func getDefaultUserMount() string {
 		return filepath.Join(
 			home, "Library", "Application Support", mountDir, "fs")
 	default:
-		xdgDataDir := os.Getenv("XDG_DATA_DIR")
+		xdgDataDir := os.Getenv("XDG_DATA_HOME")
 		if len(xdgDataDir) > 0 {
 			return filepath.Join(xdgDataDir, mountDir, "fs")
 		}

--- a/go/mounter/keybase-mount-helper/main.go
+++ b/go/mounter/keybase-mount-helper/main.go
@@ -163,7 +163,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Cannot get %s user: %+v\n", kbUsername, err)
 		os.Exit(1)
 	}
-	khUid, err := strconv.Atoi(khUser.Uid)
+	khUID, err := strconv.Atoi(khUser.Uid)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Bad UID for %s user: %+v\n", kbUsername, err)
 		os.Exit(1)
@@ -172,7 +172,7 @@ func main() {
 	// Lock the thread (because SYS_SETUID only sets the UID of the
 	// current OS thread) and switch to the helper user.
 	runtime.LockOSThread()
-	_, _, errNo := syscall.Syscall(syscall.SYS_SETUID, uintptr(khUid), 0, 0)
+	_, _, errNo := syscall.Syscall(syscall.SYS_SETUID, uintptr(khUID), 0, 0)
 	if errNo != 0 {
 		fmt.Fprintf(os.Stderr, "Can't setuid: %+v\n", errNo)
 		os.Exit(1)

--- a/go/mounter/keybase-mount-helper/main.go
+++ b/go/mounter/keybase-mount-helper/main.go
@@ -33,6 +33,9 @@ var (
 )
 
 func getDefaultUserMount() string {
+	// On linux, `run_keybase` passes in an explicit mountpoint in
+	// ${XDG_DATA_HOME:-$HOME/.local/share}, so in practice the
+	// default here probably isn't used.
 	return fmt.Sprintf("/run/user/%d/keybase/fs", os.Getuid())
 }
 
@@ -188,7 +191,7 @@ func main() {
 	}
 
 	if !firstMount {
-		fmt.Printf("Your mountpoint is %s; consider `ln -s %s ~/keybase\n",
+		fmt.Printf("Your mountpoint is %s; consider `ln -s %s ~/keybase`\n",
 			fUserMount, fUserMount)
 	}
 }

--- a/go/mounter/keybase-mount-helper/main_test.go
+++ b/go/mounter/keybase-mount-helper/main_test.go
@@ -1,0 +1,127 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFirstMount(t *testing.T) {
+	tempdir, err := ioutil.TempDir(os.TempDir(), "keybasemounthelper")
+	require.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(tempdir)
+		assert.NoError(t, err)
+	}()
+
+	originalTarget := filepath.Join(tempdir, "target")
+	err = os.Mkdir(originalTarget, 0700)
+	require.NoError(t, err)
+
+	firstMountLink := filepath.Join(tempdir, "mount1")
+	err = os.Symlink(originalTarget, firstMountLink)
+	require.NoError(t, err)
+
+	userMount1 := filepath.Join(tempdir, "user1")
+	err = os.Mkdir(userMount1, 0700)
+	require.NoError(t, err)
+
+	t.Log("First attempt should succeed and create the link")
+	firstMount, err := checkAndSwitchMount(
+		firstMountLink, originalTarget, userMount1)
+	require.NoError(t, err)
+	require.True(t, firstMount)
+	currLink, err := os.Readlink(firstMountLink)
+	require.NoError(t, err)
+	require.Equal(t, userMount1, currLink)
+
+	t.Log("Second attempt shouldn't succeed; no link created")
+	userMount2 := filepath.Join(tempdir, "user2")
+	err = os.Mkdir(userMount2, 0700)
+	require.NoError(t, err)
+	firstMount, err = checkAndSwitchMount(
+		firstMountLink, originalTarget, userMount2)
+	require.NoError(t, err)
+	require.False(t, firstMount)
+	currLink, err = os.Readlink(firstMountLink)
+	require.NoError(t, err)
+	require.Equal(t, userMount1, currLink)
+}
+
+func TestFirstMountRace(t *testing.T) {
+	tempdir, err := ioutil.TempDir(os.TempDir(), "keybasemounthelper")
+	require.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(tempdir)
+		assert.NoError(t, err)
+	}()
+
+	originalTarget := filepath.Join(tempdir, "target")
+	err = os.Mkdir(originalTarget, 0700)
+	require.NoError(t, err)
+
+	firstMountLink := filepath.Join(tempdir, "mount1")
+	err = os.Symlink(originalTarget, firstMountLink)
+	require.NoError(t, err)
+
+	userMount1 := filepath.Join(tempdir, "user1")
+	err = os.Mkdir(userMount1, 0700)
+	require.NoError(t, err)
+
+	userMount2 := filepath.Join(tempdir, "user2")
+	err = os.Mkdir(userMount2, 0700)
+	require.NoError(t, err)
+
+	fileLock, err := takeLock(firstMountLink)
+	require.NoError(t, err)
+	defer fileLock.Close()
+
+	t.Log("First user with lock takes the symlink in a goroutine")
+	errCh1 := make(chan error, 1)
+	go func() {
+		err = os.Remove(firstMountLink)
+		if err != nil {
+			errCh1 <- err
+			return
+		}
+		errCh1 <- os.Symlink(userMount1, firstMountLink)
+	}()
+
+	t.Log("Second user without lock has to block, " +
+		"then will fail to get the mount")
+	firstMountCh := make(chan bool, 1)
+	errCh2 := make(chan error, 1)
+	go func() {
+		firstMount, err := checkAndSwitchMount(
+			firstMountLink, originalTarget, userMount2)
+		firstMountCh <- firstMount
+		errCh2 <- err
+	}()
+
+	err = <-errCh1
+	require.NoError(t, err)
+	// No guarantee that the second user has blocked before we close
+	// this file, but if there are bugs this should uncover them
+	// eventually after enough runs.
+	t.Log("Unlock for the second user")
+	err = fileLock.Close()
+	require.NoError(t, err)
+	err = <-errCh2
+	require.NoError(t, err)
+	firstMount := <-firstMountCh
+	require.False(t, firstMount)
+
+	currLink, err := os.Readlink(firstMountLink)
+	require.NoError(t, err)
+	require.Equal(t, userMount1, currLink)
+}

--- a/packaging/linux/README.mount
+++ b/packaging/linux/README.mount
@@ -1,0 +1,8 @@
+This is where you can access the Keybase File System (KBFS)!  See
+https://keybase.io/docs/kbfs for more details.
+
+The first user to run `run_keybase` will find their file system
+available at `/keybase` (via a symlink).  Subsequent users will have
+unique mountpoints (printed out by `run_keybase` and available via
+`keybase status`) that can be symlinked from a convenient location
+(such as ~/keybase) if desired.

--- a/packaging/linux/arch/PKGBUILD.bin.in
+++ b/packaging/linux/arch/PKGBUILD.bin.in
@@ -18,10 +18,10 @@ depends=(fuse gconf libxss gtk2) # don't change this without changing the SRCINF
 # keybase-release is a deprecated AUR package
 conflicts=(keybase keybase-release keybase-git)
 source_i686=(
-  "${src_prefix}keybase_${deb_pkgver}_i386.deb"
+  "${src_prefix}/keybase_${deb_pkgver}_i386.deb"
 )
 source_x86_64=(
-  "${src_prefix}keybase_${deb_pkgver}_amd64.deb"
+  "${src_prefix}/keybase_${deb_pkgver}_amd64.deb"
 )
 install=keybase.install
 

--- a/packaging/linux/arch/PKGBUILD.bin.in
+++ b/packaging/linux/arch/PKGBUILD.bin.in
@@ -9,6 +9,7 @@ pkgdesc='the Keybase Go client, filesystem, and GUI'
 license=('BSD')
 url='https://keybase.io'
 pkgver=@@PKGVER@@
+srcprefix=@@SRCPREFIX@@
 deb_pkgver="${pkgver/_/-}"
 deb_pkgver="${deb_pkgver/+/.}"
 pkgrel=1
@@ -17,10 +18,10 @@ depends=(fuse gconf libxss gtk2) # don't change this without changing the SRCINF
 # keybase-release is a deprecated AUR package
 conflicts=(keybase keybase-release keybase-git)
 source_i686=(
-  "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${deb_pkgver}_i386.deb"
+  "${src_prefix}keybase_${deb_pkgver}_i386.deb"
 )
 source_x86_64=(
-  "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${deb_pkgver}_amd64.deb"
+  "${src_prefix}keybase_${deb_pkgver}_amd64.deb"
 )
 install=keybase.install
 

--- a/packaging/linux/arch/arch_common.sh
+++ b/packaging/linux/arch/arch_common.sh
@@ -1,0 +1,63 @@
+#! /usr/bin/env bash
+
+clone_maybe() {
+  if [ ! -e "$2" ] ; then
+    git clone "$1" "$2"
+  fi
+}
+
+setup_arch_build() {
+    build_root="$1"
+    git_url="$2"
+    src_prefix="$3"
+
+    # build_binaries.sh and deb/package_binaries.sh must already have
+    # been run on this build root.
+    here="$(dirname "$BASH_SOURCE")"
+
+    mkdir -p "$build_root/arch"
+
+    ###
+    ### keybase-bin
+    ###
+
+    keybase_bin_repo="$build_root/arch/keybase-bin"
+    clone_maybe "$git_url" "$keybase_bin_repo"
+
+    cp "$here/keybase.install" "$keybase_bin_repo"
+
+    # Arch doesn't allow dashes in its version numbers.
+    pkgver="$(cat "$build_root/VERSION" | sed s/-/_/)"
+
+    # Debian replaces the + with a . to avoid URL mangling.
+    # Note that we've duplicated this logic in the PKGBUILD, to make our diffs
+    # nicer, as per "Eschwartz commented on 2017-07-28 20:41" at
+    # https://aur.archlinux.org/packages/keybase-bin.
+    debver="$(cat "$build_root/VERSION" | sed s/+/./)"
+
+    deb_i386="$(ls "$build_root"/deb/i386/*.deb)"
+    sum_i386="$(sha256sum "$deb_i386" | awk '{print $1}')"
+
+    deb_amd64="$(ls "$build_root"/deb/amd64/*.deb)"
+    sum_amd64="$(sha256sum "$deb_amd64" | awk '{print $1}')"
+
+    if [ "$src_prefix" = "." ]; then
+        cp $deb_i386 $keybase_bin_repo/keybase_${debver}_i386.deb
+        cp $deb_amd64 $keybase_bin_repo/keybase_${debver}_amd64.deb
+    fi
+
+    cat "$here/PKGBUILD.bin.in" \
+        | sed "s/@@PKGVER@@/$pkgver/g" \
+        | sed "s/@@SUM_i686@@/$sum_i386/g" \
+        | sed "s/@@SUM_x86_64@@/$sum_amd64/g" \
+        | sed "s/@@SRC_PREFIX@@/$src_prefix/g" \
+              > "$keybase_bin_repo/PKGBUILD"
+
+    cat "$here/DOT_SRCINFO.bin.in" \
+        | sed "s/@@PKGVER@@/$pkgver/g" \
+        | sed "s/@@DEBVER@@/$debver/g" \
+        | sed "s/@@SUM_i686@@/$sum_i386/g" \
+        | sed "s/@@SUM_x86_64@@/$sum_amd64/g" \
+        | sed "s/@@SRC_PREFIX@@/$src_prefix/g" \
+              > "$keybase_bin_repo/.SRCINFO"
+}

--- a/packaging/linux/arch/arch_common.sh
+++ b/packaging/linux/arch/arch_common.sh
@@ -17,10 +17,6 @@ setup_arch_build() {
 
     mkdir -p "$build_root/arch"
 
-    ###
-    ### keybase-bin
-    ###
-
     keybase_bin_repo="$build_root/arch/keybase-bin"
     clone_maybe "$git_url" "$keybase_bin_repo"
 

--- a/packaging/linux/arch/build_test_package.sh
+++ b/packaging/linux/arch/build_test_package.sh
@@ -3,7 +3,7 @@
 set -e -u -o pipefail
 
 here="$(dirname "$BASH_SOURCE")"
-. "$here/arch_common.sh"
+source "$here/arch_common.sh"
 
 build_root="$1"
 

--- a/packaging/linux/arch/build_test_package.sh
+++ b/packaging/linux/arch/build_test_package.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+set -e -u -o pipefail
+
+here="$(dirname "$BASH_SOURCE")"
+. "$here/arch_common.sh"
+
+build_root="$1"
+
+git_url="https://aur.archlinux.org/keybase-bin.git"
+src_prefix="."
+
+setup_arch_build $build_root $git_url $src_prefix
+keybase_bin_repo="$build_root/arch/keybase-bin"
+
+cd $keybase_bin_repo
+makepkg

--- a/packaging/linux/arch/update_aur_packages.sh
+++ b/packaging/linux/arch/update_aur_packages.sh
@@ -5,7 +5,7 @@
 set -e -u -o pipefail
 
 here="$(dirname "$BASH_SOURCE")"
-. "$here/arch_common.sh"
+source "$here/arch_common.sh"
 
 build_root="$1"
 

--- a/packaging/linux/arch/update_aur_packages.sh
+++ b/packaging/linux/arch/update_aur_packages.sh
@@ -4,79 +4,19 @@
 
 set -e -u -o pipefail
 
-# build_binaries.sh and deb/package_binaries.sh must already have been run on
-# this build root.
-build_root="$1"
 here="$(dirname "$BASH_SOURCE")"
+. "$here/arch_common.sh"
 
-mkdir -p "$build_root/arch"
+build_root="$1"
 
-clone_maybe() {
-  if [ ! -e "$2" ] ; then
-    git clone "$1" "$2"
-  fi
-}
-
-###
-### keybase-bin
-###
-
-keybase_bin_repo="$build_root/arch/keybase-bin"
 git_url="aur@aur.archlinux.org:keybase-bin"
-if [ -n "${KEYBASE_LOCAL_BUILD:-}" ] ; then
-    git_url="https://aur.archlinux.org/keybase-bin.git"
-fi
-clone_maybe "$git_url" "$keybase_bin_repo"
+src_prefix="https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb"
 
-cp "$here/keybase.install" "$keybase_bin_repo"
+setup_arch_build $build_root $git_url $src_prefix
+keybase_bin_repo="$build_root/arch/keybase-bin"
 
-# Arch doesn't allow dashes in its version numbers.
-pkgver="$(cat "$build_root/VERSION" | sed s/-/_/)"
-
-# Debian replaces the + with a . to avoid URL mangling.
-# Note that we've duplicated this logic in the PKGBUILD, to make our diffs
-# nicer, as per "Eschwartz commented on 2017-07-28 20:41" at
-# https://aur.archlinux.org/packages/keybase-bin.
-debver="$(cat "$build_root/VERSION" | sed s/+/./)"
-
-deb_i386="$(ls "$build_root"/deb/i386/*.deb)"
-sum_i386="$(sha256sum "$deb_i386" | awk '{print $1}')"
-
-deb_amd64="$(ls "$build_root"/deb/amd64/*.deb)"
-sum_amd64="$(sha256sum "$deb_amd64" | awk '{print $1}')"
-
-url_src_prefix="https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/"
-src_prefix=$url_src_prefix
-if [ -n "${KEYBASE_LOCAL_BUILD:-}" ] ; then
-    src_prefix=""
-    cp $deb_i386 $keybase_bin_repo/keybase_${debver}_i386.deb
-    cp $deb_amd64 $keybase_bin_repo/keybase_${debver}_amd64.deb
-fi
-
-cat "$here/PKGBUILD.bin.in" \
-  | sed "s/@@PKGVER@@/$pkgver/g" \
-  | sed "s/@@SUM_i686@@/$sum_i386/g" \
-  | sed "s/@@SUM_x86_64@@/$sum_amd64/g" \
-  | sed "s/@@SRC_PREFIX@@/$src_prefix/g" \
-  > "$keybase_bin_repo/PKGBUILD"
-
-cat "$here/DOT_SRCINFO.bin.in" \
-  | sed "s/@@PKGVER@@/$pkgver/g" \
-  | sed "s/@@DEBVER@@/$debver/g" \
-  | sed "s/@@SUM_i686@@/$sum_i386/g" \
-  | sed "s/@@SUM_x86_64@@/$sum_amd64/g" \
-  | sed "s/@@SRC_PREFIX@@/$src_prefix/g" \
-  > "$keybase_bin_repo/.SRCINFO"
-
-if [ -n "${KEYBASE_LOCAL_BUILD:-}" ] ; then
-    cd $keybase_bin_repo
-    makepkg
-elif git -C "$keybase_bin_repo" commit -am "version bump" ; then
-  echo Pushing keybase-bin...
-  git -C "$keybase_bin_repo" push origin master
-else
-  echo No changes in keybase-bin. Skipping push.
-fi
+echo Pushing keybase-bin...
+git -C "$keybase_bin_repo" push origin master
 
 # We used to also update the keybase-git package here, but apparently that was
 # against AUR policy.

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -114,6 +114,13 @@ build_one_architecture() {
   go build -tags "$go_tags" -ldflags "$ldflags_kbfs" -o \
     "$layout_dir/usr/bin/git-remote-keybase" github.com/keybase/kbfs/kbfsgit/git-remote-keybase
 
+  # Build the mount-helper binary, and add the mount readme directory.
+  echo "Building keybase-mount-helper for $GOARCH..."
+  go build -tags "$go_tags" -ldflags "$ldflags_client" -o \
+  "$layout_dir/usr/bin/keybase-mount-helper" github.com/keybase/client/go/mounter/keybase-mount-helper
+  mkdir -p "$layout_dir/opt/keybase/mount-readme"
+  cp "$here/README.mount" "$layout_dir/opt/keybase/mount-readme/README"
+
   # Build the kbnm binary
   echo "Building kbnm for $GOARCH..."
   go build -tags "$go_tags" -ldflags "$ldflags_kbnm" -o \

--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -30,7 +30,8 @@ if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/deb/repo"
 elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/deb"
-  dependencies="Depends: libappindicator1, fuse, libgconf-2-4"
+  # "initscripts' provides "killall", which is used in run_keybase.
+  dependencies="Depends: libappindicator1, fuse, libgconf-2-4, initscripts"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean repo

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -24,26 +24,26 @@ if useradd --system -s /bin/false -U -M $khuser &> /dev/null ; then
     echo Created $khuser system user for managing mountpoints.
 fi
 
-chown $khuser:$khuser $khbin
-chmod 4755 $khbin
+chown "$khuser":"$khuser" "$khbin"
+chmod 4755 "$khbin"
 if mkdir $vardir &> /dev/null ; then
-    ln -s $sample $mount1
-    chown -R $khuser:$khuser $vardir
+    ln -s "$sample" "$mount1"
+    chown -R "$khuser":"$khuser" "$vardir"
 fi
 
 currlink=`readlink $rootlink`
 if [ -z "$currlink" ] ; then
-    if fusermount -uz /keybase &> /dev/null ; then
+    if fusermount -uz "$rootlink" &> /dev/null ; then
         # Remove any existing legacy mount.
-        echo Unmounting /keybase...
+        echo Unmounting $rootlink...
         if killall kbfsfuse &> /dev/null ; then
             echo Shutting down kbfsfuse...
         fi
-        rmdir $rootlink
+        rmdir "$rootlink"
         echo You must run run_keybase to restore file system access.
     fi
-    if ln -s $mount1 $rootlink &> /dev/null ; then
-        chown keybasehelper $rootlink
+    if ln -s "$mount1" "$rootlink" &> /dev/null ; then
+        chown "$khuser":"$khuser" "$rootlink"
     fi
 fi
 

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -7,12 +7,44 @@
 
 set -u
 
-# Create the /keybase root dir, if it doesn't already exist. We can't use a
-# regular [ -e ... ] check, because stat'ing /keybase fails with a permissions
-# error when kbfsfuse is mounted, so that check always returns false. Instead
-# we check whether mkdir succeeds.
-if mkdir /keybase &>/dev/null ; then
-  chmod 777 /keybase
+# Create the /keybase symlink to the first mountpoint, if it doesn't
+# already exist. We can't use a regular [ -e ... ] check, because
+# stat'ing /keybase fails with a permissions error when kbfsfuse is
+# mounted, so that check always returns false. Instead we check
+# whether mkdir succeeds.
+rootlink="/keybase"
+vardir="/var/lib/keybase"
+mount1="$vardir/mount1"
+sample="/opt/keybase/mount-readme"
+khuser="keybasehelper"
+khbin="/usr/bin/keybase-mount-helper"
+
+# Create the keybasehelper system user, without login privileges.
+if useradd --system -s /bin/false -U -M $khuser &> /dev/null ; then
+    echo Created $khuser system user for managing mountpoints.
+fi
+
+chown $khuser:$khuser $khbin
+chmod 4755 $khbin
+if mkdir $vardir &> /dev/null ; then
+    ln -s $sample $mount1
+    chown -R $khuser:$khuser $vardir
+fi
+
+currlink=`readlink $rootlink`
+if [ -z "$currlink" ] ; then
+    if fusermount -uz /keybase &> /dev/null ; then
+        # Remove any existing legacy mount.
+        echo Unmounting /keybase...
+        if killall kbfsfuse &> /dev/null ; then
+            echo Shutting down kbfsfuse...
+        fi
+        rmdir $rootlink
+        echo You must run run_keybase to restore file system access.
+    fi
+    if ln -s $mount1 $rootlink &> /dev/null ; then
+        chown keybasehelper $rootlink
+    fi
 fi
 
 # Update the GTK icon cache, if possible.

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -111,12 +111,12 @@ export debian_arch=i386
 # On Fedora, it would be more correct to require "libXScrnSaver", which
 # provides libXss.so. Unfortunately that doesn't work on OpenSUSE. This is the
 # most compatible set of dependencies we've found.
-dependencies="Requires: at, fuse, libXss.so.1"
+dependencies="Requires: at, fuse, libXss.so.1, initscripts"
 build_one_architecture
 
 export rpm_arch=x86_64
 export debian_arch=amd64
 # Requiring "libXss.so" here installs the 32-bit version. See
 # https://github.com/keybase/client/pull/5226.
-dependencies="Requires: at, fuse, libXss.so.1()(64bit)"
+dependencies="Requires: at, fuse, libXss.so.1()(64bit), initscripts"
 build_one_architecture

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -108,9 +108,11 @@ build_one_architecture() {
 
 export rpm_arch=i386
 export debian_arch=i386
-# On Fedora, it would be more correct to require "libXScrnSaver", which
-# provides libXss.so. Unfortunately that doesn't work on OpenSUSE. This is the
-# most compatible set of dependencies we've found.
+# On Fedora, it would be more correct to require "libXScrnSaver",
+# which provides libXss.so. Unfortunately that doesn't work on
+# OpenSUSE. This is the most compatible set of dependencies we've
+# found.  "initscripts' provides "killall", which is used in
+# run_keybase.
 dependencies="Requires: at, fuse, libXss.so.1, initscripts"
 build_one_architecture
 

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -13,8 +13,19 @@ set -e -u -o pipefail
 runtime_dir="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase"
 mkdir -p "$runtime_dir"
 startup_token="$runtime_dir/startup_mode"
-mountdir="${XDG_DATA_HOME:-$HOME/.local/share}/keybase/fs"
+if keybase config get mountdir &> /dev/null ; then
+    mountdir=`keybase config get mountdir 2> /dev/null`
+else
+    # The user has no mountpoint configured yet, so pick a default one
+    # and record the default setting in a separate config field, so
+    # later we can tell whether the user changed it away from the
+    # default or not.
+    mountdir="${XDG_DATA_HOME:-$HOME/.local/share}/keybase/fs"
+    keybase config set mountdir "$mountdir"
+    keybase config set mountdirdefault "$mountdir"
+fi
 export KEYBASE_MOUNTDIR=$mountdir
+
 # Don't make the mountpoint until after unmounting/killing the
 # previous mount, otherwise `mkdir` will fail.
 
@@ -174,7 +185,6 @@ main() {
   #    we tell them to do it after updates.
   kill_all
   mkdir -p "$mountdir"
-  keybase config set mountdir "$mountdir"
 
   if wants_systemd ; then
       start_systemd

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -139,22 +139,6 @@ start_systemd() {
 
   keybase-mount-helper -user-mount "$mountdir"
 
-  forwarded_kbfs_env_vars=(
-      # Needed to determine the mountdir inside the service, to set
-      # the mountpoint on the command line.
-      KEYBASE_MOUNTDIR
-  )
-  forward_vars "$runtime_dir/kbfs.env" forwarded_kbfs_env_vars[@]
-
-  forwarded_service_env_vars=(
-      # Needed to determine the mountdir inside the service, to return
-      # the mountpoint as part of `keybase status`.  TODO(KBFS-2723):
-      # we should be fetching the mountpoint from the kbfs binary if
-      # possible.
-      KEYBASE_MOUNTDIR
-  )
-  forward_vars "$runtime_dir/keybase.env" forwarded_service_env_vars[@]
-
   # The keybase.gui.service unit has keybase.service and kbfs.service as
   # dependencies, so we don't have to list them here. But including them lets
   # us report an error if they fail to start. Also prefer `restart` to `start`

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -15,6 +15,8 @@ mkdir -p "$runtime_dir"
 startup_token="$runtime_dir/startup_mode"
 mountdir="${XDG_DATA_HOME:-$HOME/.local/share}/keybase/fs"
 export KEYBASE_MOUNTDIR=$mountdir
+# Don't make the mountpoint until after unmounting/killing the
+# previous mount, otherwise `mkdir` will fail.
 
 # NOTE: This logic is duplicated in systemd_linux.go. If you make changes here,
 # keep them in sync.
@@ -94,13 +96,13 @@ kill_all() {
 }
 
 forward_vars() {
-  filename=$1
+  filename="$1"
   vars=("${!2}")
-  cat /dev/null > $filename
+  cat /dev/null > "$filename"
   for varname in "${vars[@]}" ; do
       # Include set-but-empty variables but not unset variables.
       if [ -n "${!varname+x}" ] ; then
-          echo "$varname=${!varname}" >> $filename
+          echo "$varname=${!varname}" >> "$filename"
       fi
   done
 }
@@ -134,17 +136,20 @@ start_systemd() {
   )
   forward_vars "$runtime_dir/keybase.gui.env" forwarded_gui_env_vars[@]
 
-  mkdir -p "$mountdir"
   keybase-mount-helper -user-mount "$mountdir"
 
   forwarded_kbfs_env_vars=(
-      # Needed to determine the mountdir inside the service.
+      # Needed to determine the mountdir inside the service, to set
+      # the mountpoint on the command line.
       KEYBASE_MOUNTDIR
   )
   forward_vars "$runtime_dir/kbfs.env" forwarded_kbfs_env_vars[@]
 
   forwarded_service_env_vars=(
-      # Needed to determine the mountdir inside the service.
+      # Needed to determine the mountdir inside the service, to return
+      # the mountpoint as part of `keybase status`.  TODO(KBFS-2723):
+      # we should be fetching the mountpoint from the kbfs binary if
+      # possible.
       KEYBASE_MOUNTDIR
   )
   forward_vars "$runtime_dir/keybase.env" forwarded_service_env_vars[@]
@@ -162,13 +167,12 @@ start_background() {
   export KEYBASE_DEBUG=1
   logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
   mkdir -p "$logdir"
-  mkdir -p "$mountdir"
 
   echo Launching keybase service...
   # We set the --auto-forked flag here so that updated clients that try to
   # restart this service will know to re-fork it themselves. That's all it does.
   keybase -d --log-file="$logdir/keybase.service.log" service --auto-forked &>> "$logdir/keybase.start.log" &
-  echo Mounting /keybase...
+  echo Mounting the file system...
   keybase-mount-helper -user-mount "$mountdir"
   kbfsfuse -debug -log-to-file "$mountdir" &>> "$logdir/keybase.start.log" &
   echo Launching Keybase GUI...
@@ -184,7 +188,8 @@ main() {
   # 2) Users have come to expect that run_keybase will restart everything, and
   #    we tell them to do it after updates.
   kill_all
-
+  mkdir -p "$mountdir"
+  
   if wants_systemd ; then
       start_systemd
   else

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -70,10 +70,11 @@ kill_all() {
   fi
   # In case the package upgrade wasn't able to unmount and remove /keybase
   if fusermount -uz /keybase &> /dev/null ; then
-    # Remove any existing legacy mount.
-    echo Unmounting /keybase and converting to symlink...
-    rmdir /keybase
-    ln -s /opt/keybase/mount-readme /keybase
+    # Remove any existing legacy mount.  This should never happen
+    # because it should have already been done by post_install.sh.
+    # Just in case, let the user know how to fix it.
+    echo Unmounting /keybase.  Run `sudo rmdir /keybase; sudo ln -s /opt/keybase/mount-readme /keybase; sudo chown keybasehelper:keybasehelper /keybase` and then run this command again.
+    exit -1
   fi
   if fusermount -uz $mountdir &> /dev/null ; then
     echo Unmounting $mountdir...
@@ -189,7 +190,8 @@ main() {
   #    we tell them to do it after updates.
   kill_all
   mkdir -p "$mountdir"
-  
+  keybase config set mountdir "$mountdir"
+
   if wants_systemd ; then
       start_systemd
   else

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -13,6 +13,8 @@ set -e -u -o pipefail
 runtime_dir="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase"
 mkdir -p "$runtime_dir"
 startup_token="$runtime_dir/startup_mode"
+mountdir="${XDG_DATA_HOME:-$HOME/.local/share}/keybase/fs"
+export KEYBASE_MOUNTDIR=$mountdir
 
 # NOTE: This logic is duplicated in systemd_linux.go. If you make changes here,
 # keep them in sync.
@@ -64,8 +66,15 @@ kill_all() {
   if killall Keybase &> /dev/null ; then
     echo Shutting down Keybase GUI...
   fi
+  # In case the package upgrade wasn't able to unmount and remove /keybase
   if fusermount -uz /keybase &> /dev/null ; then
-    echo Unmounting /keybase...
+    # Remove any existing legacy mount.
+    echo Unmounting /keybase and converting to symlink...
+    rmdir /keybase
+    ln -s /opt/keybase/mount-readme /keybase
+  fi
+  if fusermount -uz $mountdir &> /dev/null ; then
+    echo Unmounting $mountdir...
   fi
   if killall kbfsfuse &> /dev/null ; then
     echo Shutting down kbfsfuse...
@@ -84,13 +93,25 @@ kill_all() {
   fi
 }
 
+forward_vars() {
+  filename=$1
+  vars=("${!2}")
+  cat /dev/null > $filename
+  for varname in "${vars[@]}" ; do
+      # Include set-but-empty variables but not unset variables.
+      if [ -n "${!varname+x}" ] ; then
+          echo "$varname=${!varname}" >> $filename
+      fi
+  done
+}
+
 start_systemd() {
   echo Starting via systemd.
   # This script is intended to be run after updates, so we need to reload
   # potentially changed unit files.
   systemctl --user daemon-reload
 
-  forwarded_env_vars=(
+  forwarded_gui_env_vars=(
       # The autostart file sets this to "hideWindow" to prevent opening the
       # Keybase main window when the app is autostarted.
       KEYBASE_START_UI
@@ -111,13 +132,22 @@ start_systemd() {
       QT4_IM_MODULE
       XMODIFIERS
   )
-  cat /dev/null > "$runtime_dir/keybase.gui.env"
-  for varname in "${forwarded_env_vars[@]}" ; do
-      # Include set-but-empty variables but not unset variables.
-      if [ -n "${!varname+x}" ] ; then
-          echo "$varname=${!varname}" >> "$runtime_dir/keybase.gui.env"
-      fi
-  done
+  forward_vars "$runtime_dir/keybase.gui.env" forwarded_gui_env_vars[@]
+
+  mkdir -p "$mountdir"
+  keybase-mount-helper -user-mount "$mountdir"
+
+  forwarded_kbfs_env_vars=(
+      # Needed to determine the mountdir inside the service.
+      KEYBASE_MOUNTDIR
+  )
+  forward_vars "$runtime_dir/kbfs.env" forwarded_kbfs_env_vars[@]
+
+  forwarded_service_env_vars=(
+      # Needed to determine the mountdir inside the service.
+      KEYBASE_MOUNTDIR
+  )
+  forward_vars "$runtime_dir/keybase.env" forwarded_service_env_vars[@]
 
   # The keybase.gui.service unit has keybase.service and kbfs.service as
   # dependencies, so we don't have to list them here. But including them lets
@@ -132,13 +162,15 @@ start_background() {
   export KEYBASE_DEBUG=1
   logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
   mkdir -p "$logdir"
+  mkdir -p "$mountdir"
 
   echo Launching keybase service...
   # We set the --auto-forked flag here so that updated clients that try to
   # restart this service will know to re-fork it themselves. That's all it does.
   keybase -d --log-file="$logdir/keybase.service.log" service --auto-forked &>> "$logdir/keybase.start.log" &
   echo Mounting /keybase...
-  kbfsfuse -debug -log-to-file /keybase &>> "$logdir/keybase.start.log" &
+  keybase-mount-helper -user-mount "$mountdir"
+  kbfsfuse -debug -log-to-file "$mountdir" &>> "$logdir/keybase.start.log" &
   echo Launching Keybase GUI...
   /opt/keybase/Keybase &>> "$logdir/Keybase.app.log" &
   write_startup_token "background"

--- a/packaging/linux/systemd/kbfs.service
+++ b/packaging/linux/systemd/kbfs.service
@@ -11,8 +11,9 @@ Type=notify
 # Without this line, `systemctl --user restart kbfs.service` will hit mount
 # failures if there are any running shells cd'd into a Keybase folder.
 ExecStartPre=-/usr/bin/env fusermount -uz /keybase
-ExecStart=/usr/bin/kbfsfuse -debug -log-to-file /keybase
+ExecStart=/usr/bin/kbfsfuse -debug -log-to-file $KEYBASE_MOUNTDIR
 Restart=on-failure
+EnvironmentFile=-%t/keybase/kbfs.env
 
 [Install]
 WantedBy=default.target

--- a/packaging/linux/systemd/kbfs.service
+++ b/packaging/linux/systemd/kbfs.service
@@ -10,7 +10,7 @@ Type=notify
 # because some systems put fusermount in /bin and others put it in /usr/bin.
 # Without this line, `systemctl --user restart kbfs.service` will hit mount
 # failures if there are any running shells cd'd into a Keybase folder.
-ExecStartPre=-/usr/bin/env fusermount -uz /keybase
+ExecStartPre=-/usr/bin/bash -c '/usr/bin/env fusermount -uz `keybase config get mountdir`'
 ExecStart=/usr/bin/kbfsfuse -debug -log-to-file
 Restart=on-failure
 

--- a/packaging/linux/systemd/kbfs.service
+++ b/packaging/linux/systemd/kbfs.service
@@ -11,9 +11,8 @@ Type=notify
 # Without this line, `systemctl --user restart kbfs.service` will hit mount
 # failures if there are any running shells cd'd into a Keybase folder.
 ExecStartPre=-/usr/bin/env fusermount -uz /keybase
-ExecStart=/usr/bin/kbfsfuse -debug -log-to-file $KEYBASE_MOUNTDIR
+ExecStart=/usr/bin/kbfsfuse -debug -log-to-file
 Restart=on-failure
-EnvironmentFile=-%t/keybase/kbfs.env
 
 [Install]
 WantedBy=default.target

--- a/packaging/linux/systemd/keybase.service
+++ b/packaging/linux/systemd/keybase.service
@@ -7,7 +7,6 @@ Type=notify
 Environment=KEYBASE_SERVICE_TYPE=systemd
 ExecStart=/usr/bin/keybase --debug --log-file=%h/.cache/keybase/keybase.service.log service
 Restart=on-failure
-EnvironmentFile=-%t/keybase/keybase.env
 
 [Install]
 WantedBy=default.target

--- a/packaging/linux/systemd/keybase.service
+++ b/packaging/linux/systemd/keybase.service
@@ -7,6 +7,7 @@ Type=notify
 Environment=KEYBASE_SERVICE_TYPE=systemd
 ExecStart=/usr/bin/keybase --debug --log-file=%h/.cache/keybase/keybase.service.log service
 Restart=on-failure
+EnvironmentFile=-%t/keybase/keybase.env
 
 [Install]
 WantedBy=default.target

--- a/packaging/linux/test/README.md
+++ b/packaging/linux/test/README.md
@@ -1,0 +1,113 @@
+Debian/Ubuntu:
+=======
+
+To build a package for debian from a local branch in client (on amd64):
+
+    cd $GOPATH/src/github.com/keybase/client/packaging/linux
+    docker build -t keybase_packaging_v14 .
+    mkdir /var/tmp/keybase_build_work
+    docker run -v /var/tmp/keybase_build_work:/root -v $GOPATH/src/github.com/keybase/client:/CLIENT:ro -v $GOPATH/src/github.com/keybase/kbfs:/KBFS:ro  -e NOWAIT -ti keybase_packaging_v14 bash
+
+Then, from inside the docker environment:
+
+    cd /root
+    git clone https://github.com/keybase/client.git client --reference /CLIENT
+    git clone https://github.com/keybase/kbfs.git kbfs --reference /KBFS
+    cd client
+    git remote add localclient /CLIENT
+    git checkout localclient/<NAME_OF_LOCAL_BRANCH_TO_TEST>
+    KEYBASE_SKIP_32_BIT=1 packaging/linux/build_binaries.sh prerelease /root/build
+    packaging/linux/deb/package_binaries.sh /root/build
+    packaging/linux/rpm/package_binaries.sh /root/build
+    exit
+
+Now you can test it in a fresh ubuntu environment:
+
+    docker pull ubuntu
+    docker build -t keybase-ubuntu-test $GOPATH/src/github.com/keybase/client/packaging/linux/test/keybase-ubuntu-test
+    docker run --privileged -v /var/tmp/keybase_build_work:/root -ti keybase-ubuntu-test bash
+
+From inside the Ubuntu docker environment:
+
+    cd /root/build/deb/amd64
+    dpkg -i `ls -tr *.deb | tail -1`
+    useradd -m strib
+    su - strib
+    run_keybase
+
+To test an upgrade, start a different docker container:
+
+    docker run --privileged -v /var/tmp/keybase_build_work:/root -ti keybase-ubuntu-test bash
+
+Then inside it:
+
+    cd /tmp/
+    curl -O https://prerelease.keybase.io/keybase_amd64.deb
+    dpkg -i keybase_amd64.deb
+    useradd -m strib
+    su - strib
+    run_keybase
+
+After that you can upgrade it:
+    exit  # back to root
+    cd /root/build/deb/amd64
+    dpkg -i `ls -tr *.deb | tail -1`
+
+Ubuntu with systemd:
+=======
+
+Systemd requires that the docker container be run as a daemon:
+
+    docker pull solita/ubuntu-systemd
+    docker build -t keybase-ubuntu-systemd-test $GOPATH/src/github.com/keybase/client/packaging/linux/test/keybase-ubuntu-systemd-test
+    docker run --rm --privileged -v /:/host solita/ubuntu-systemd setup
+    docker run -d --privileged -v /var/tmp/keybase_build_work:/root --security-opt seccomp:unconfined -v /sys/fs/cgroup:/sys/fs/cgroup:ro --tmpfs /run --tmpfs /run/lock --name systemd -ti keybase-ubuntu-systemd-test
+    docker exec -ti systemd bash
+
+Then inside the container you can use the same steps as above to
+install and start keybase.
+
+Centos:
+========
+
+    docker pull centos
+    docker build -t keybase-centos-test $GOPATH/src/github.com/keybase/client/packaging/linux/test/keybase-centos-test
+    docker run --privileged -v /var/tmp/keybase_build_work:/root -ti keybase-centos-test bash
+
+From inside the Centos docker environment:
+
+    cd /root/build/rpm/x86_64/RPMS/x86_64
+    rpm -Uvh `ls -tr *.rpm | tail -1`
+
+To test an upgrade, start a different docker container:
+
+Then inside it:
+
+    yum install https://prerelease.keybase.io/keybase_amd64.rpm
+    useradd -m strib
+    su - strib
+    run_keybase
+
+After that you can upgrade it:
+    exit  # back to root
+    cd /root/build/rpm/x86_64/RPMS/x86_64
+    rpm -Uvh `ls -tr *.rpm | tail -1`
+
+Arch:
+=====
+
+    docker pull base/archlinux
+    docker build -t keybase-arch-test $GOPATH/src/github.com/keybase/client/packaging/linux/test/keybase-arch-test
+    docker run --privileged -v /var/tmp/keybase_build_work:/root -ti keybase-arch-test bash
+
+From inside the Arch docker environment:
+
+    chmod a+rw /root/build
+    useradd -m strib
+    su - strib
+    cd /root/client/packaging/linux/arch/
+    KEYBASE_LOCAL_BUILD=1 ./update_aur_packages.sh /root/build
+    exit  # back to root
+    pacman -U --noconfirm  `ls -tr /root/build/arch/keybase-bin/*.xz | tail -1`
+    su - strib
+    run_keybase

--- a/packaging/linux/test/README.md
+++ b/packaging/linux/test/README.md
@@ -106,7 +106,7 @@ From inside the Arch docker environment:
     useradd -m strib
     su - strib
     cd /root/client/packaging/linux/arch/
-    KEYBASE_LOCAL_BUILD=1 ./update_aur_packages.sh /root/build
+    ./build_test_package.sh /root/build
     exit  # back to root
     pacman -U --noconfirm  `ls -tr /root/build/arch/keybase-bin/*.xz | tail -1`
     su - strib

--- a/packaging/linux/test/keybase-arch-test/Dockerfile
+++ b/packaging/linux/test/keybase-arch-test/Dockerfile
@@ -1,0 +1,7 @@
+FROM base/archlinux
+MAINTAINER Keybase <admin@keybase.io>
+
+RUN pacman -Syy
+
+RUN pacman -S --noconfirm git binutils fuse gconf libxss gtk2 fakeroot
+

--- a/packaging/linux/test/keybase-centos-test/Dockerfile
+++ b/packaging/linux/test/keybase-centos-test/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos
+MAINTAINER Keybase <admin@keybase.io>
+
+# Install dependencies for keybase
+RUN yum install -y at fuse libXScrnSaver.x86_64 initscripts psmisc
+
+# Nice to have
+RUN yum install -y vim less curl
+

--- a/packaging/linux/test/keybase-ubuntu-systemd-test/Dockerfile
+++ b/packaging/linux/test/keybase-ubuntu-systemd-test/Dockerfile
@@ -1,0 +1,11 @@
+FROM solita/ubuntu-systemd
+MAINTAINER Keybase <admin@keybase.io>
+
+RUN apt-get update
+
+# Install dependencies for keybase
+RUN apt-get install -y libappindicator1 fuse libgconf-2-4 psmisc
+
+# Nice to have
+RUN apt-get install -y vim less curl
+

--- a/packaging/linux/test/keybase-ubuntu-test/Dockerfile
+++ b/packaging/linux/test/keybase-ubuntu-test/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu
+MAINTAINER Keybase <admin@keybase.io>
+
+RUN apt-get update
+
+# Install dependencies for keybase
+RUN apt-get install -y libappindicator1 fuse libgconf-2-4 psmisc
+
+# Nice to have
+RUN apt-get install -y vim less curl
+


### PR DESCRIPTION
To address security concerns with having a world-writeable mountpoint directory in root, this PR changes the Linux packaging so that:

* Install creates a `keybasehelper` system user.
* Install creates a `/var/lib/keybase` directory, owned by `keybasehelper`.
* Install creates a `/var/lib/keybase/mount1` subdirectory, initially pointing to an `/opt/keybase` directory containing a README file which explains about KBFS.
* For new installs, install creates a `/keybase` symlink, owned by root, that points to `/var/lib/keybase/mount1`.
* Install adds a new binary, `/usr/bin/keybase-mount-helper`, that can SUID to `keybasehelper`.
* On every `run_keybase` call, the `keybase-mount-helper` binary checks `mount1` and if it doesn't point to the initial readme directory, it turns it into a symlink to a user-specific mountpoint.  The mountpoint defaults to `~/.local/share/keybase/fs`, but can be overriden with the `$XDG_DATA_HOME` environment variable.
* The first user to use `run_keybase` gets the /keybase symlink (via `mount1`) forever. If the symlink is already taken, `run_keybase` prints out a message like:
> Your mountpoint is /home/strib2/.local/share/keybase/fs; consider `ln -s /home/strib2/.local/share/keybase/fs ~/keybase"
* On upgrades, the install process forcibly unmounts `/keybase` and turns `/keybase` into a symlink pointing to the readme directory, as above.
* For systemd, we now pass a `$KEYBASE_MOUNTDIR` env var to both KBFS and the service.
* `keybase status` now prints out the KBFS mountpoint based on the `$KEYBASE_MOUNTDIR` environment variable, if it's available.
* This also adds Dockerfiles for testing package-level stuff in different distros, and instructions on how to do so.

Similar changes will come to macOS in a future PR; for now it is unchanged.

Issue: KBFS-2692