### PR TITLE
add IMPTEAMUPGRADE so we can distinguish them from normal imp team chats CORE-7014

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/teams"
 	context "golang.org/x/net/context"
 )
 
@@ -396,17 +395,11 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv types.U
 			case chat1.ConversationMembersType_TEAM:
 				// early out of team convs
 				return nil
-			case chat1.ConversationMembersType_IMPTEAM:
+			case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE:
 				s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
 				tlfID := msg.Valid().ClientHeader.Conv.Tlfid
-				teamID, err := keybase1.TeamIDFromString(tlfID.String())
-				if err != nil {
-					return err
-				}
-				team, err := teams.Load(ctx, s.G().ExternalG(), keybase1.LoadTeamArg{
-					ID:     teamID,
-					Public: msg.Valid().ClientHeader.TlfPublic,
-				})
+				team, err := LoadTeam(ctx, s.G().ExternalG(), tlfID, conv.GetMembersType(),
+					msg.Valid().ClientHeader.TlfPublic, nil)
 				if err != nil {
 					return err
 				}

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -533,12 +533,16 @@ L:
 		rl = append(rl, irl...)
 		if ierr != nil || len(res) == 0 {
 			if ierr != nil {
-				debugger.Debug(ctx, "FindConversations: fail reason: %s mt: %v", err, mt)
+				debugger.Debug(ctx, "FindConversations: fail reason: %s mt: %v", ierr, mt)
 			} else {
 				debugger.Debug(ctx, "FindConversations: fail reason: no convs mt: %v", mt)
 			}
 			var newMT chat1.ConversationMembersType
 			switch mt {
+			case chat1.ConversationMembersType_TEAM:
+				err = ierr
+				debugger.Debug(ctx, "FindConversations: failed with team, aborting")
+				break L
 			case chat1.ConversationMembersType_IMPTEAMUPGRADE:
 				if !attempts[chat1.ConversationMembersType_IMPTEAMNATIVE] {
 					newMT = chat1.ConversationMembersType_IMPTEAMNATIVE

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -525,6 +525,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 	var irl []chat1.RateLimit
 	attempts := make(map[chat1.ConversationMembersType]bool)
 	mt := membersTypeIn
+L:
 	for {
 		attempts[mt] = true
 		res, irl, err = findConvosWithMembersType(mt)
@@ -546,14 +547,14 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 				}
 			case chat1.ConversationMembersType_KBFS:
 				debugger.Debug(ctx, "FindConversations: failed with KBFS, aborting")
-				break
+				break L
 			}
 			debugger.Debug(ctx,
 				"FindConversations: failing to find anything for %v, trying again for %v", mt, newMT)
 			mt = newMT
 		} else {
 			debugger.Debug(ctx, "FindConversations: success with mt: %v", mt)
-			break
+			break L
 		}
 	}
 	return res, utils.AggRateLimits(rl), err

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -531,6 +531,11 @@ L:
 		res, irl, err = findConvosWithMembersType(mt)
 		rl = append(rl, irl...)
 		if err != nil || len(res) == 0 {
+			if err != nil {
+				debugger.Debug(ctx, "FindConversations: fail reason: %s mt: %v", err, mt)
+			} else {
+				debugger.Debug(ctx, "FindConversations: fail reason: no convs mt: %v", mt)
+			}
 			var newMT chat1.ConversationMembersType
 			switch mt {
 			case chat1.ConversationMembersType_IMPTEAMUPGRADE:

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -413,6 +413,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 	oneChatPerTLF *bool) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
 
 	findConvosWithMembersType := func(membersType chat1.ConversationMembersType) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
+
 		query := &chat1.GetInboxLocalQuery{
 			Name: &chat1.NameQuery{
 				Name:        tlfName,
@@ -520,24 +521,42 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 		}
 		return res, rl, nil
 	}
-	res, rl, err = findConvosWithMembersType(membersTypeIn)
-	if err != nil || len(res) == 0 {
-		switch membersTypeIn {
-		case chat1.ConversationMembersType_IMPTEAM:
-			// Try again with KBFS
-			debugger.Debug(ctx,
-				"FindConversations: failing to find anything for IMPTEAM, trying again for KBFS")
-			kres, krl, kerr := findConvosWithMembersType(chat1.ConversationMembersType_KBFS)
-			rl = utils.AggRateLimits(append(rl, krl...))
-			if kerr == nil {
-				res = kres
-				err = nil
-				debugger.Debug(ctx,
-					"FindConversations: KBFS pass succeeded without error, returning that result")
+
+	var irl []chat1.RateLimit
+	attempts := make(map[chat1.ConversationMembersType]bool)
+	mt := membersTypeIn
+	for {
+		attempts[mt] = true
+		res, irl, err = findConvosWithMembersType(mt)
+		rl = append(rl, irl...)
+		if err != nil || len(res) == 0 {
+			var newMT chat1.ConversationMembersType
+			switch mt {
+			case chat1.ConversationMembersType_IMPTEAMUPGRADE:
+				if !attempts[chat1.ConversationMembersType_IMPTEAMNATIVE] {
+					newMT = chat1.ConversationMembersType_IMPTEAMNATIVE
+				} else {
+					newMT = chat1.ConversationMembersType_KBFS
+				}
+			case chat1.ConversationMembersType_IMPTEAMNATIVE:
+				if !attempts[chat1.ConversationMembersType_IMPTEAMUPGRADE] {
+					newMT = chat1.ConversationMembersType_IMPTEAMUPGRADE
+				} else {
+					newMT = chat1.ConversationMembersType_KBFS
+				}
+			case chat1.ConversationMembersType_KBFS:
+				debugger.Debug(ctx, "FindConversations: failed with KBFS, aborting")
+				break
 			}
+			debugger.Debug(ctx,
+				"FindConversations: failing to find anything for %v, trying again for %v", mt, newMT)
+			mt = newMT
+		} else {
+			debugger.Debug(ctx, "FindConversations: success with mt: %v", mt)
+			break
 		}
 	}
-	return res, rl, err
+	return res, utils.AggRateLimits(rl), err
 }
 
 // Post a join or leave message. Must be called when the user is in the conv.
@@ -726,12 +745,6 @@ type newConversationHelper struct {
 func newNewConversationHelper(g *globals.Context, uid gregor1.UID, tlfName string, topicName *string,
 	topicType chat1.TopicType, membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility,
 	ri func() chat1.RemoteInterface) *newConversationHelper {
-
-	if membersType == chat1.ConversationMembersType_IMPTEAM && g.ExternalG().Env.GetChatMemberType() != "impteam" {
-		g.Log.Debug("### note: impteam mt requested, but feature flagged off, using kbfs")
-		membersType = chat1.ConversationMembersType_KBFS
-	}
-
 	return &newConversationHelper{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "newConversationHelper", false),
@@ -794,7 +807,7 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 			// let it slide in devel for tests
 			if n.G().ExternalG().Env.GetRunMode() != libkb.DevelRunMode {
 				n.Debug(ctx, "KBFS conversations deprecated; switching membersType from KBFS to IMPTEAM")
-				n.membersType = chat1.ConversationMembersType_IMPTEAM
+				n.membersType = chat1.ConversationMembersType_IMPTEAMNATIVE
 			}
 		}
 	}
@@ -804,7 +817,7 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 	isPublic := n.vis == keybase1.TLFVisibility_PUBLIC
 	info, err := CtxKeyFinder(ctx, n.G()).Find(ctx, n.tlfName, n.membersType, isPublic)
 	if err != nil {
-		if n.membersType != chat1.ConversationMembersType_IMPTEAM {
+		if n.membersType != chat1.ConversationMembersType_IMPTEAMNATIVE {
 			return res, rl, err
 		}
 		if _, ok := err.(teams.TeamDoesNotExistError); !ok {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2578,7 +2578,8 @@ func (h *Server) AddTeamMemberAfterReset(ctx context.Context,
 	}
 	conv := iboxRes.Convs[0]
 	switch conv.Info.MembersType {
-	case chat1.ConversationMembersType_IMPTEAM, chat1.ConversationMembersType_TEAM:
+	case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE,
+		chat1.ConversationMembersType_TEAM:
 		// this is ok for these convs
 	default:
 		return fmt.Errorf("unable to add member back to non team conversation: %v",

--- a/go/chat/team.go
+++ b/go/chat/team.go
@@ -33,7 +33,9 @@ func LoadTeam(ctx context.Context, g *libkb.GlobalContext, tlfID chat1.TLFID,
 		}
 		return teams.Load(ctx, g, ltarg(teamID))
 	case chat1.ConversationMembersType_IMPTEAMUPGRADE:
-		res, err := g.API.Get(libkb.NewAPIArgWithNetContext(ctx, "team/id"))
+		arg := libkb.NewAPIArgWithNetContext(ctx, "team/id")
+		arg.Args.Add("tlf_id", libkb.S{Val: tlfID.String()})
+		res, err := g.API.Get()
 		if err != nil {
 			return team, err
 		}

--- a/go/chat/team.go
+++ b/go/chat/team.go
@@ -35,7 +35,7 @@ func LoadTeam(ctx context.Context, g *libkb.GlobalContext, tlfID chat1.TLFID,
 	case chat1.ConversationMembersType_IMPTEAMUPGRADE:
 		arg := libkb.NewAPIArgWithNetContext(ctx, "team/id")
 		arg.Args.Add("tlf_id", libkb.S{Val: tlfID.String()})
-		res, err := g.API.Get()
+		res, err := g.API.Get(arg)
 		if err != nil {
 			return team, err
 		}

--- a/go/chat/team.go
+++ b/go/chat/team.go
@@ -1,0 +1,57 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
+)
+
+func LoadTeam(ctx context.Context, g *libkb.GlobalContext, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool,
+	loadTeamArgOverride func(keybase1.TeamID) keybase1.LoadTeamArg) (team *teams.Team, err error) {
+
+	// Set up load team argument construction, possibly controlled by the caller
+	ltarg := func(teamID keybase1.TeamID) keybase1.LoadTeamArg {
+		return keybase1.LoadTeamArg{
+			ID:     teamID,
+			Public: public,
+		}
+	}
+	if loadTeamArgOverride != nil {
+		ltarg = loadTeamArgOverride
+	}
+
+	switch membersType {
+	case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_TEAM:
+		teamID, err := keybase1.TeamIDFromString(tlfID.String())
+		if err != nil {
+			return team, err
+		}
+		return teams.Load(ctx, g, ltarg(teamID))
+	case chat1.ConversationMembersType_IMPTEAMUPGRADE:
+		res, err := g.API.Get(libkb.NewAPIArgWithNetContext(ctx, "team/id"))
+		if err != nil {
+			return team, err
+		}
+		st, err := res.Body.AtKey("team_id").GetString()
+		if err != nil {
+			return team, err
+		}
+		teamID, err := keybase1.TeamIDFromString(st)
+		if err != nil {
+			return team, err
+		}
+		team, err = teams.Load(ctx, g, ltarg(teamID))
+		if err != nil {
+			return team, err
+		}
+		// TODO: validate the tlfID on the team returned here is the same as the server
+		// told us.
+		return team, nil
+	}
+	return team, fmt.Errorf("invalid impteam members type: %v", membersType)
+}

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -91,7 +91,7 @@ func (c ChatChannel) GetMembersType(e *libkb.Env) chat1.ConversationMembersType 
 		return typ
 	}
 	if e.GetChatMemberType() == "impteam" {
-		return chat1.ConversationMembersType_IMPTEAM
+		return chat1.ConversationMembersType_IMPTEAMNATIVE
 	}
 	return chat1.ConversationMembersType_KBFS
 }

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -165,7 +165,7 @@ func annotateResolvingRequest(g *libkb.GlobalContext, req *chatConversationResol
 	switch *userOrTeamResult {
 	case keybase1.UserOrTeamResult_USER:
 		if g.Env.GetChatMemberType() == "impteam" {
-			req.MembersType = chat1.ConversationMembersType_IMPTEAM
+			req.MembersType = chat1.ConversationMembersType_IMPTEAMNATIVE
 		} else {
 			req.MembersType = chat1.ConversationMembersType_KBFS
 		}

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -100,7 +100,8 @@ func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.Conver
 	switch conv.GetMembersType() {
 	case chat1.ConversationMembersType_TEAM:
 		return v.convNameTeam(g, conv)
-	case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAM:
+	case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAMNATIVE,
+		chat1.ConversationMembersType_IMPTEAMUPGRADE:
 		return v.convNameKBFS(g, conv, myUsername)
 	}
 	return ""

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -90,7 +90,7 @@ func (r *chatConversationResolver) completeAndCanonicalizeTLFName(ctx context.Co
 			return fmt.Errorf("failed to open chat conversation: %v", err)
 		}
 		req.ctx.canonicalizedTlfName = string(cname.CanonicalName)
-	case chat1.ConversationMembersType_IMPTEAM:
+	case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE:
 		// Add our name out front
 		if req.Visibility != keybase1.TLFVisibility_PUBLIC {
 			username := r.G.Env.GetUsername()

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -800,7 +800,8 @@ func (c *chatServiceHandler) getExistingConvs(ctx context.Context, id chat1.Conv
 
 	var tlfName string
 	switch channel.GetMembersType(c.G().GetEnv()) {
-	case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAM:
+	case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAMNATIVE,
+		chat1.ConversationMembersType_IMPTEAMUPGRADE:
 		tlfQ := keybase1.TLFQuery{
 			TlfName:          channel.Name,
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,

--- a/go/client/cmd_chat_delete_history.go
+++ b/go/client/cmd_chat_delete_history.go
@@ -65,7 +65,8 @@ func (c *CmdChatDeleteHistory) Run() (err error) {
 
 	if c.G().Standalone {
 		switch c.resolvingRequest.MembersType {
-		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
+		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAMNATIVE,
+			chat1.ConversationMembersType_IMPTEAMUPGRADE:
 			c.G().StartStandaloneChat()
 		default:
 			err = CantRunInStandaloneError{}

--- a/go/client/cmd_chat_delete_history_dev.go
+++ b/go/client/cmd_chat_delete_history_dev.go
@@ -62,7 +62,8 @@ func (c *CmdChatDeleteHistoryDev) Run() (err error) {
 
 	if c.G().Standalone {
 		switch c.resolvingRequest.MembersType {
-		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
+		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAMNATIVE,
+			chat1.ConversationMembersType_IMPTEAMUPGRADE:
 			c.G().StartStandaloneChat()
 		default:
 			err = CantRunInStandaloneError{}

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -86,7 +86,8 @@ func (c *CmdChatSend) Run() (err error) {
 	// in finding existing conversations.
 	if c.G().Standalone {
 		switch c.resolvingRequest.MembersType {
-		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAM:
+		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAMNATIVE,
+			chat1.ConversationMembersType_IMPTEAMUPGRADE:
 			c.G().StartStandaloneChat()
 		default:
 			err = CantRunInStandaloneError{}

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -143,23 +143,26 @@ func (e ConversationExistence) String() string {
 type ConversationMembersType int
 
 const (
-	ConversationMembersType_KBFS    ConversationMembersType = 0
-	ConversationMembersType_TEAM    ConversationMembersType = 1
-	ConversationMembersType_IMPTEAM ConversationMembersType = 2
+	ConversationMembersType_KBFS           ConversationMembersType = 0
+	ConversationMembersType_TEAM           ConversationMembersType = 1
+	ConversationMembersType_IMPTEAMNATIVE  ConversationMembersType = 2
+	ConversationMembersType_IMPTEAMUPGRADE ConversationMembersType = 3
 )
 
 func (o ConversationMembersType) DeepCopy() ConversationMembersType { return o }
 
 var ConversationMembersTypeMap = map[string]ConversationMembersType{
-	"KBFS":    0,
-	"TEAM":    1,
-	"IMPTEAM": 2,
+	"KBFS":           0,
+	"TEAM":           1,
+	"IMPTEAMNATIVE":  2,
+	"IMPTEAMUPGRADE": 3,
 }
 
 var ConversationMembersTypeRevMap = map[ConversationMembersType]string{
 	0: "KBFS",
 	1: "TEAM",
-	2: "IMPTEAM",
+	2: "IMPTEAMNATIVE",
+	3: "IMPTEAMUPGRADE",
 }
 
 func (e ConversationMembersType) String() string {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -25,7 +25,8 @@ protocol common {
   enum ConversationMembersType {
     KBFS_0,
     TEAM_1,
-    IMPTEAM_2
+    IMPTEAMNATIVE_2,
+    IMPTEAMUPGRADE_3
   }
 
   enum SyncInboxResType {

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -31,7 +31,8 @@ export const commonConversationMemberStatus = {
 export const commonConversationMembersType = {
   kbfs: 0,
   team: 1,
-  impteam: 2,
+  impteamnative: 2,
+  impteamupgrade: 3,
 }
 
 export const commonConversationStatus = {
@@ -675,7 +676,8 @@ export type ConversationMemberStatus =
 export type ConversationMembersType =
   | 0 // KBFS_0
   | 1 // TEAM_1
-  | 2 // IMPTEAM_2
+  | 2 // IMPTEAMNATIVE_2
+  | 3 // IMPTEAMUPGRADE_3
 
 export type ConversationMetadata = $ReadOnly<{idTriple: ConversationIDTriple, conversationID: ConversationID, visibility: Keybase1.TLFVisibility, status: ConversationStatus, membersType: ConversationMembersType, teamType: TeamType, existence: ConversationExistence, version: ConversationVers, finalizeInfo?: ?ConversationFinalizeInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>, activeList?: ?Array<Gregor1.UID>, allList?: ?Array<Gregor1.UID>, resetList?: ?Array<Gregor1.UID>}>
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -98,7 +98,8 @@
       "symbols": [
         "KBFS_0",
         "TEAM_1",
-        "IMPTEAM_2"
+        "IMPTEAMNATIVE_2",
+        "IMPTEAMUPGRADE_3"
       ]
     },
     {

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -233,7 +233,10 @@ function* _processConversation(c: RPCChatTypes.InboxUIItem): Generator<any, void
   const conversationIDKey = c.convID
 
   // Update reset participants (only implicit teams)
-  if (c.membersType === RPCChatTypes.commonConversationMembersType.impteam) {
+  if (
+    c.membersType === RPCChatTypes.commonConversationMembersType.impteamnative ||
+    c.membersType === RPCChatTypes.commonConversationMembersType.impteamupgrade
+  ) {
     yield Saga.put(
       ChatGen.createUpdateResetParticipants({
         conversationIDKey,

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -44,7 +44,7 @@ function* startNewConversation(
     return [null, null]
   }
   const membersType = flags.impTeamChatEnabled
-    ? RPCChatTypes.commonConversationMembersType.impteam
+    ? RPCChatTypes.commonConversationMembersType.impteamnative
     : RPCChatTypes.commonConversationMembersType.kbfs
   const result = yield call(RPCChatTypes.localNewConversationLocalRpcPromise, {
     identifyBehavior: RPCTypes.tlfKeysTLFIdentifyBehavior.chatGui,

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -31,7 +31,8 @@ export const commonConversationMemberStatus = {
 export const commonConversationMembersType = {
   kbfs: 0,
   team: 1,
-  impteam: 2,
+  impteamnative: 2,
+  impteamupgrade: 3,
 }
 
 export const commonConversationStatus = {
@@ -675,7 +676,8 @@ export type ConversationMemberStatus =
 export type ConversationMembersType =
   | 0 // KBFS_0
   | 1 // TEAM_1
-  | 2 // IMPTEAM_2
+  | 2 // IMPTEAMNATIVE_2
+  | 3 // IMPTEAMUPGRADE_3
 
 export type ConversationMetadata = $ReadOnly<{idTriple: ConversationIDTriple, conversationID: ConversationID, visibility: Keybase1.TLFVisibility, status: ConversationStatus, membersType: ConversationMembersType, teamType: TeamType, existence: ConversationExistence, version: ConversationVers, finalizeInfo?: ?ConversationFinalizeInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>, activeList?: ?Array<Gregor1.UID>, allList?: ?Array<Gregor1.UID>, resetList?: ?Array<Gregor1.UID>}>
 


### PR DESCRIPTION
Patch does the following:

1.) Adds `IMPTEAMUPGRADE` and `IMPTEAMNATIVE` members types. `IMPTEAMNATIVE` is the same value as the old `IMPTEAM`.
2.) `IMPTEAMUPGRADE` first hits the API server to get the team ID from the TLF ID associated with the conversation. Otherwise the flows are the same for now. 

I am delaying doing much testing here until we can actually do the upgrade. 