### PR TITLE
fix help for JSON API pagination, and also fix pagination itself!

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -427,7 +427,7 @@ func (h *Server) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg
 	}
 
 	// Xlate pager control into pagination if given
-	if arg.Query != nil {
+	if arg.Query != nil && arg.Query.MessageIDControl != nil {
 		arg.Pagination = utils.XlateMessageIDControlToPagination(arg.Query.MessageIDControl)
 	}
 
@@ -482,7 +482,7 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 	}
 
 	// Xlate pager control into pagination if given
-	if arg.Query != nil {
+	if arg.Query != nil && arg.Query.MessageIDControl != nil {
 		pagination = utils.XlateMessageIDControlToPagination(arg.Query.MessageIDControl)
 	}
 

--- a/go/client/chat_api_doc.go
+++ b/go/client/chat_api_doc.go
@@ -11,16 +11,16 @@ Read a conversation:
     {"method": "read", "params": {"options": {"channel": {"name": "you,them"}}}}
 
 Read a conversation (paginated):
-    {"method": "read", "params": {"options": {"channel": {"name": "you,them"}, {"pagination": {"num": 10}}}}}
+    {"method": "read", "params": {"options": {"channel": {"name": "you,them"}, "pagination": {"num": 10}}}}
 
 Then, in the reply, check the result.pagination object, which has a next,
 previous, and last field. If last is false and you want the second page,
 
-    {"method": "read", "params": {"options": {"channel": {"name": "you,them"}, {"pagination": {"next": "<result.pagination.next from reply>", "num": 10}}}}}
+    {"method": "read", "params": {"options": {"channel": {"name": "you,them"}, "pagination": {"next": "<result.pagination.next from reply>", "num": 10}}}}
 
 If you're on the nth page and want to go back, set the previous field instead.
 
-    {"method": "read", "params": {"options": {"channel": {"name": "you,them"}, {"pagination": {"previous": "<result.pagination.previous from last reply>", "num": 10}}}}}
+    {"method": "read", "params": {"options": {"channel": {"name": "you,them"}, "pagination": {"previous": "<result.pagination.previous from last reply>", "num": 10}}}}
 
 Send a message:
     {"method": "send", "params": {"options": {"channel": {"name": "you,them"}, "message": {"body": "is it cold today?"}}}


### PR DESCRIPTION
So the help text was busted for pagination stuff, but also pagination itself was broken too! Thankfully, it works from how the UI does it, but now it also works for JSON API again.