### PR TITLE
Transactional AddMember

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2145,6 +2145,14 @@ func (req *TeamChangeReq) AddUVWithRole(uv UserVersion, role TeamRole) error {
 	return nil
 }
 
+func (req *TeamChangeReq) GetAllAdds() (ret []UserVersion) {
+	ret = append(ret, req.Readers...)
+	ret = append(ret, req.Writers...)
+	ret = append(ret, req.Admins...)
+	ret = append(ret, req.Owners...)
+	return ret
+}
+
 func TotalNumberOfCommits(refs []GitRefMetadata) (total int) {
 	for _, ref := range refs {
 		total += len(ref.Commits)

--- a/go/systests/standalone_test.go
+++ b/go/systests/standalone_test.go
@@ -70,6 +70,8 @@ func makeUserStandalone(t *testing.T, pre string, opts standaloneUserArgs) *user
 	u.deviceClient = keybase1.DeviceClient{Cli: cli}
 	u.teamsClient = keybase1.TeamsClient{Cli: cli}
 
+	u.device.userClient = keybase1.UserClient{Cli: cli}
+
 	return &u
 }
 

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -478,12 +478,11 @@ func TestSweepObsoleteKeybaseInvites(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Use a raw tx.AddMember to add bob without sweeping his keybase
+	// Use ChangeMembership to add bob without sweeping his keybase
 	// invite.
-	tx := teams.CreateAddMemberTx(teamObj)
-	err = tx.AddMember(bob.userVersion(), keybase1.TeamRole_WRITER)
-	require.NoError(t, err)
-	err = tx.Post(context.Background())
+	err = teamObj.ChangeMembership(context.Background(), keybase1.TeamChangeReq{
+		Writers: []keybase1.UserVersion{bob.userVersion()},
+	})
 	require.NoError(t, err)
 
 	// Bob then leaves team.

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -471,16 +471,25 @@ func TestSweepObsoleteKeybaseInvites(t *testing.T) {
 	bob.perUserKeyUpgrade()
 	t.Logf("Bob (%s) gets PUK", bob.username)
 
-	// TODO: Once CORE-6905 is done, this will automatically complete
-	// invite, breaking this test. But there are other tests that do
-	// not involve the server to check the same thing:
-	// TestObsoletingInvites*.
-	ann.addTeamMember(team, bob.username, keybase1.TeamRole_WRITER)
+	teamObj, err := teams.Load(context.Background(), ann.tc.G, keybase1.LoadTeamArg{
+		Name:        team,
+		ForceRepoll: true,
+		NeedAdmin:   true,
+	})
+	require.NoError(t, err)
+
+	// Use a raw tx.AddMember to add bob without sweeping his keybase
+	// invite.
+	tx := teams.CreateAddMemberTx(teamObj)
+	err = tx.AddMember(bob.userVersion(), keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+	err = tx.Post(context.Background())
+	require.NoError(t, err)
 
 	// Bob then leaves team.
 	bob.leave(team)
 
-	teamObj, err := teams.Load(context.Background(), ann.tc.G, keybase1.LoadTeamArg{
+	teamObj, err = teams.Load(context.Background(), ann.tc.G, keybase1.LoadTeamArg{
 		Name:        team,
 		ForceRepoll: true,
 	})

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -277,8 +277,8 @@ func TestTeamTxMultipleMembers(t *testing.T) {
 }
 
 func TestTeamTxSubteamAdmins(t *testing.T) {
-	// Test if AddMemberTx properly keys implicit admins to implicit
-	// teams.
+	// Test if AddMemberTx properly keys implicit admins to teams
+	// through the use of 'implicit_team_keys'.
 
 	tt := newTeamTester(t)
 	defer tt.cleanup()

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -65,10 +65,8 @@ func TestTeamTx1(t *testing.T) {
 	bob.perUserKeyUpgrade()
 
 	teamObj = ann.loadTeam(team, true /* admin */)
-
 	tx = teams.CreateAddMemberTx(teamObj)
 	tx.AddMemberTransaction(context.Background(), bob.username, keybase1.TeamRole_WRITER)
-	tx.RemoveMember(tracy.userVersion())
 
 	err = tx.Post(context.Background())
 	require.NoError(t, err)
@@ -77,7 +75,8 @@ func TestTeamTx1(t *testing.T) {
 	members, err = teamObj.Members()
 	require.NoError(t, err)
 	require.Equal(t, 1, len(members.Owners))
-	require.Equal(t, 0, len(members.Admins)+len(members.Readers))
+	require.Equal(t, 0, len(members.Admins))
+	require.Equal(t, 1, len(members.Readers))
 	require.Equal(t, 1, len(members.Writers))
 	require.EqualValues(t, bob.userVersion(), members.Writers[0])
 	require.Equal(t, 0, len(teamObj.GetActiveAndObsoleteInvites()))

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -191,6 +191,9 @@ func TestTeamTxSweepMembers(t *testing.T) {
 
 	t.Logf("Bob (%s) resets and reprovisions, he is now: %v", bob.username, bob.userVersion())
 
+	// Wait for CLKR and RotateKey link.
+	ann.waitForRotateByID(ann.loadTeam(team, false /* admin */).ID, keybase1.Seqno(3))
+
 	teamObj := ann.loadTeam(team, true /* admin */)
 	tx := teams.CreateAddMemberTx(teamObj)
 	err := tx.AddMemberTransaction(context.Background(), bob.username, keybase1.TeamRole_READER)

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -48,6 +48,7 @@ func TestTeamTransactions(t *testing.T) {
 	require.NoError(t, err)
 
 	// TRANSACTION 2 - bob gets puk, add bob but not through SBS.
+
 	bob.perUserKeyUpgrade()
 
 	teamObj, err = teams.Load(context.Background(), ann.tc.G, keybase1.LoadTeamArg{
@@ -61,6 +62,74 @@ func TestTeamTransactions(t *testing.T) {
 	tx.AddMemberTransaction(context.Background(), ann.tc.G, bob.username, keybase1.TeamRole_WRITER)
 	tx.RemoveMember(tracy.userVersion())
 	spew.Dump(tx.DebugPayloads())
+
+	err = tx.Post(context.Background(), ann.tc.G)
+	require.NoError(t, err)
+}
+
+func TestTeamTxDependency(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	ann := makeUserStandalone(t, "ann", standaloneUserArgs{
+		disableGregor:            true,
+		suppressTeamChatAnnounce: true,
+	})
+	tt.users = append(tt.users, ann)
+	t.Logf("Signed up ann (%s)", ann.username)
+
+	bob := tt.addPuklessUser("bob")
+	t.Logf("Signed up PUK-less user bob (%s)", bob.username)
+
+	tracy := tt.addUser("trc")
+	t.Logf("Signed up PUK-ful user trc (%s)", tracy.username)
+
+	team := ann.createTeam()
+	t.Logf("Team created (%s)", team)
+
+	ann.addTeamMember(team, bob.username, keybase1.TeamRole_WRITER)
+
+	bob.perUserKeyUpgrade()
+
+	// Transaction time!
+
+	// The transaction will try to achieve the following:
+	// 1) Add Tracy as crypto member,
+	// 2) sweep old bob@keybase invite (pukless member),
+	// 3) add bob as crypto member.
+
+	// The catch is that (3) depends on (2), so signature that does
+	// (3) has to happen after (2). Signatures in flight after (2) are
+	// as follows:
+	// 1. change_membership (adds: trc)
+	// 2. invite (cancel: bob@keybase)
+
+	// Adding bob as a crypto member should not mutate change_membership 1.,
+	// but instead create new change_membership.
+
+	// As of 16.01.2018 this is just future proofing teamtx code -
+	// server wouldn't have cared if we added duplicate bob when
+	// invite was still active. But we may flip the switch in the
+	// future.
+
+	// TODO: Same test is needed but with flipped logic:
+	// bob starts as crypto member, but then resets and admin wants to
+	// read them as pukless. invite signature for bob@keybase would
+	// have a dependency on change_signature sweeping bob.
+
+	teamObj, err := teams.Load(context.Background(), ann.tc.G, keybase1.LoadTeamArg{
+		Name:      team,
+		NeedAdmin: true,
+	})
+	require.NoError(t, err)
+
+	tx := teams.CreateAddMemberTx(teamObj)
+	tx.AddMemberTransaction(context.Background(), ann.tc.G, tracy.username, keybase1.TeamRole_READER)
+	tx.AddMemberTransaction(context.Background(), ann.tc.G, bob.username, keybase1.TeamRole_WRITER)
+
+	payloads := tx.DebugPayloads()
+	// TODO: this has to pass once this feature actually work.
+	// require.Equal(t, 3, len(payloads))
 
 	err = tx.Post(context.Background(), ann.tc.G)
 	require.NoError(t, err)

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -1,0 +1,38 @@
+package systests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestTeamTransactions(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	ann := tt.addUser("ann")
+	t.Logf("Signed up ann (%s)", ann.username)
+
+	bob := tt.addPuklessUser("bob")
+	t.Logf("Signed up PUK-less user bob (%s)", bob.username)
+
+	team := ann.createTeam()
+	t.Logf("Team created (%s)", team)
+
+	teamObj, err := teams.Load(context.Background(), ann.tc.G, keybase1.LoadTeamArg{
+		Name:      team,
+		NeedAdmin: true,
+	})
+	require.NoError(t, err)
+
+	tx := teams.CreateAddMemberTx(teamObj)
+	tx.AddMemberTransaction(context.Background(), ann.tc.G, bob.username, keybase1.TeamRole_WRITER)
+
+	spew.Dump(tx.DebugPayloads())
+}

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -22,6 +22,9 @@ func TestTeamTransactions(t *testing.T) {
 	bob := tt.addPuklessUser("bob")
 	t.Logf("Signed up PUK-less user bob (%s)", bob.username)
 
+	tracy := tt.addUser("trc")
+	t.Logf("Signed up PUK-ful user trc (%s)", tracy.username)
+
 	team := ann.createTeam()
 	t.Logf("Team created (%s)", team)
 
@@ -33,6 +36,10 @@ func TestTeamTransactions(t *testing.T) {
 
 	tx := teams.CreateAddMemberTx(teamObj)
 	tx.AddMemberTransaction(context.Background(), ann.tc.G, bob.username, keybase1.TeamRole_WRITER)
+	//tx.AddMemberTransaction(context.Background(), ann.tc.G, tracy.username, keybase1.TeamRole_READER)
 
 	spew.Dump(tx.DebugPayloads())
+
+	err = tx.Post(context.Background(), ann.tc.G)
+	require.NoError(t, err)
 }

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -41,10 +41,10 @@ func TestTeamTransactions(t *testing.T) {
 	require.NoError(t, err)
 
 	tx := teams.CreateAddMemberTx(teamObj)
-	tx.AddMemberTransaction(context.Background(), ann.tc.G, bob.username, keybase1.TeamRole_WRITER)
-	tx.AddMemberTransaction(context.Background(), ann.tc.G, tracy.username, keybase1.TeamRole_READER)
+	tx.AddMemberTransaction(context.Background(), bob.username, keybase1.TeamRole_WRITER)
+	tx.AddMemberTransaction(context.Background(), tracy.username, keybase1.TeamRole_READER)
 
-	err = tx.Post(context.Background(), ann.tc.G)
+	err = tx.Post(context.Background())
 	require.NoError(t, err)
 
 	// TRANSACTION 2 - bob gets puk, add bob but not through SBS.
@@ -59,11 +59,11 @@ func TestTeamTransactions(t *testing.T) {
 	require.NoError(t, err)
 
 	tx = teams.CreateAddMemberTx(teamObj)
-	tx.AddMemberTransaction(context.Background(), ann.tc.G, bob.username, keybase1.TeamRole_WRITER)
+	tx.AddMemberTransaction(context.Background(), bob.username, keybase1.TeamRole_WRITER)
 	tx.RemoveMember(tracy.userVersion())
 	spew.Dump(tx.DebugPayloads())
 
-	err = tx.Post(context.Background(), ann.tc.G)
+	err = tx.Post(context.Background())
 	require.NoError(t, err)
 }
 
@@ -124,13 +124,14 @@ func TestTeamTxDependency(t *testing.T) {
 	require.NoError(t, err)
 
 	tx := teams.CreateAddMemberTx(teamObj)
-	tx.AddMemberTransaction(context.Background(), ann.tc.G, tracy.username, keybase1.TeamRole_READER)
-	tx.AddMemberTransaction(context.Background(), ann.tc.G, bob.username, keybase1.TeamRole_WRITER)
+	tx.AddMemberTransaction(context.Background(), tracy.username, keybase1.TeamRole_READER)
+	tx.AddMemberTransaction(context.Background(), bob.username, keybase1.TeamRole_WRITER)
 
 	payloads := tx.DebugPayloads()
 	// TODO: this has to pass once this feature actually work.
 	// require.Equal(t, 3, len(payloads))
+	_ = payloads
 
-	err = tx.Post(context.Background(), ann.tc.G)
+	err = tx.Post(context.Background())
 	require.NoError(t, err)
 }

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -130,7 +130,7 @@ func TestTeamTxDependency(t *testing.T) {
 	// Adding bob as a crypto member should not mutate change_membership 1.,
 	// but instead create new change_membership.
 
-	// As of 16.01.2018 this is just future proofing teamtx code -
+	// As of 2018.01.16 this is just future proofing teamtx code -
 	// server wouldn't have cared if we added duplicate bob when
 	// invite was still active. But we may flip the switch in the
 	// future.
@@ -146,12 +146,15 @@ func TestTeamTxDependency(t *testing.T) {
 	tx.AddMemberByUsername(context.Background(), tracy.username, keybase1.TeamRole_READER)
 	tx.AddMemberByUsername(context.Background(), bob.username, keybase1.TeamRole_WRITER)
 
-	// TODO: this has to pass once this feature is in.
+	// TODO: this has to pass once this feature is in. See ticket CORE-7147.
 	// payloads := tx.DebugPayloads()
 	// require.Equal(t, 3, len(payloads))
 
 	err = tx.Post(context.Background())
 	require.NoError(t, err)
+
+	// State is still fine even without ordering, because nor server
+	// neither team player cares about that.
 
 	teamObj = ann.loadTeam(team, true /* admin */)
 	members, err = teamObj.Members()

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -35,8 +35,8 @@ func TestTeamTx1(t *testing.T) {
 	teamObj := ann.loadTeam(team, true /* admin */)
 
 	tx := teams.CreateAddMemberTx(teamObj)
-	tx.AddMemberTransaction(context.Background(), bob.username, keybase1.TeamRole_WRITER)
-	tx.AddMemberTransaction(context.Background(), tracy.username, keybase1.TeamRole_READER)
+	tx.AddMemberByUsername(context.Background(), bob.username, keybase1.TeamRole_WRITER)
+	tx.AddMemberByUsername(context.Background(), tracy.username, keybase1.TeamRole_READER)
 
 	err := tx.Post(context.Background())
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestTeamTx1(t *testing.T) {
 
 	teamObj = ann.loadTeam(team, true /* admin */)
 	tx = teams.CreateAddMemberTx(teamObj)
-	tx.AddMemberTransaction(context.Background(), bob.username, keybase1.TeamRole_WRITER)
+	tx.AddMemberByUsername(context.Background(), bob.username, keybase1.TeamRole_WRITER)
 
 	err = tx.Post(context.Background())
 	require.NoError(t, err)
@@ -143,8 +143,8 @@ func TestTeamTxDependency(t *testing.T) {
 	teamObj = ann.loadTeam(team, true /* admin */)
 
 	tx := teams.CreateAddMemberTx(teamObj)
-	tx.AddMemberTransaction(context.Background(), tracy.username, keybase1.TeamRole_READER)
-	tx.AddMemberTransaction(context.Background(), bob.username, keybase1.TeamRole_WRITER)
+	tx.AddMemberByUsername(context.Background(), tracy.username, keybase1.TeamRole_READER)
+	tx.AddMemberByUsername(context.Background(), bob.username, keybase1.TeamRole_WRITER)
 
 	// TODO: this has to pass once this feature is in.
 	// payloads := tx.DebugPayloads()
@@ -195,7 +195,7 @@ func TestTeamTxSweepMembers(t *testing.T) {
 
 	teamObj := ann.loadTeam(team, true /* admin */)
 	tx := teams.CreateAddMemberTx(teamObj)
-	err := tx.AddMemberTransaction(context.Background(), bob.username, keybase1.TeamRole_READER)
+	err := tx.AddMemberByUsername(context.Background(), bob.username, keybase1.TeamRole_READER)
 	require.NoError(t, err)
 	err = tx.Post(context.Background())
 	require.NoError(t, err)
@@ -238,7 +238,7 @@ func TestTeamTxMultipleMembers(t *testing.T) {
 	teamObj := ann.loadTeam(team, true /* admin */)
 	tx := teams.CreateAddMemberTx(teamObj)
 	for i := 1; i < 7; i++ {
-		err := tx.AddMemberTransaction(context.Background(), tt.users[i].username, keybase1.TeamRole_WRITER)
+		err := tx.AddMemberByUsername(context.Background(), tt.users[i].username, keybase1.TeamRole_WRITER)
 		require.NoError(t, err)
 	}
 	err := tx.Post(context.Background())
@@ -254,7 +254,7 @@ func TestTeamTxMultipleMembers(t *testing.T) {
 	teamObj = ann.loadTeam(team, true /* admin */)
 	tx = teams.CreateAddMemberTx(teamObj)
 	for i := 4; i <= 5; i++ {
-		err := tx.AddMemberTransaction(context.Background(), tt.users[i].username, keybase1.TeamRole_WRITER)
+		err := tx.AddMemberByUsername(context.Background(), tt.users[i].username, keybase1.TeamRole_WRITER)
 		require.NoError(t, err)
 	}
 	err = tx.Post(context.Background())
@@ -300,7 +300,7 @@ func TestTeamTxSubteamAdmins(t *testing.T) {
 
 	teamObj := ann.loadTeam(team, true /* admin */)
 	tx := teams.CreateAddMemberTx(teamObj)
-	err = tx.AddMemberTransaction(context.Background(), bob.username, keybase1.TeamRole_ADMIN)
+	err = tx.AddMemberByUsername(context.Background(), bob.username, keybase1.TeamRole_ADMIN)
 	require.NoError(t, err)
 	err = tx.Post(context.Background())
 	require.NoError(t, err)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -304,6 +304,16 @@ func (u *userPlusDevice) addTeamMemberEmail(team, email string, role keybase1.Te
 	}
 }
 
+func (u *userPlusDevice) loadTeam(teamname string, admin bool) *teams.Team {
+	team, err := teams.Load(context.Background(), u.tc.G, keybase1.LoadTeamArg{
+		Name:        teamname,
+		NeedAdmin:   admin,
+		ForceRepoll: true,
+	})
+	require.NoError(u.tc.T, err)
+	return team
+}
+
 func (u *userPlusDevice) readInviteEmails(email string) []string {
 	arg := libkb.NewAPIArg("test/team/get_tokens")
 	arg.Args = libkb.NewHTTPArgs()

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -478,8 +478,8 @@ func makeSigchainOuterLinkV2(
 
 	// TODO: The plan here was to return OuterLinkV2WithMetadata, so
 	// caller can have more insight into what link has been created,
-	// but that struct seems internal (all but one fields are
-	// private), so for now it just returns sig, linkid, err.
+	// but that struct seems internal (all fields but one are hidden),
+	// so for now it returns sig, linkid, err.
 	linkID = libkb.ComputeLinkID(encodedOuterLink)
 	return sig, linkID, nil
 }

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -208,7 +208,7 @@ func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me *lib
 		return err
 	}
 	seqType := seqTypeForTeamPublicness(public)
-	v2Sig, err := makeSigchainV2OuterSig(
+	v2Sig, _, err := makeSigchainV2OuterSig(
 		deviceSigningKey,
 		libkb.LinkTypeTeamRoot,
 		1, /* seqno */
@@ -431,24 +431,6 @@ func makeSigchainV2OuterSig(
 	hasRevokes bool,
 	seqType keybase1.SeqType,
 	ignoreIfUnsupported bool,
-) (string, error) {
-	ret, _, err := makeSigchainOuterLinkV2(signingKey, v1LinkType, seqno, innerLinkJSON,
-		prevLinkID, hasRevokes, seqType, ignoreIfUnsupported)
-	if err != nil {
-		return "", err
-	}
-	return ret, nil
-}
-
-func makeSigchainOuterLinkV2(
-	signingKey libkb.GenericKey,
-	v1LinkType libkb.LinkType,
-	seqno keybase1.Seqno,
-	innerLinkJSON []byte,
-	prevLinkID libkb.LinkID,
-	hasRevokes bool,
-	seqType keybase1.SeqType,
-	ignoreIfUnsupported bool,
 ) (sig string, linkID libkb.LinkID, err error) {
 	currLinkID := libkb.ComputeLinkID(innerLinkJSON)
 
@@ -499,7 +481,7 @@ func generateNewSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.User,
 		return nil, err
 	}
 	seqType := seqTypeForTeamPublicness(parentTeam.IsPublic())
-	v2Sig, err := makeSigchainV2OuterSig(
+	v2Sig, _, err := makeSigchainV2OuterSig(
 		signingKey,
 		libkb.LinkTypeNewSubteam,
 		parentTeam.GetLatestSeqno()+1,
@@ -589,7 +571,7 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 	}
 
 	seqType := seqTypeForTeamPublicness(parentTeam.IsPublic())
-	v2Sig, err := makeSigchainV2OuterSig(
+	v2Sig, _, err := makeSigchainV2OuterSig(
 		signingKey,
 		libkb.LinkTypeSubteamHead,
 		1, /* seqno */

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -458,10 +458,6 @@ func makeSigchainV2OuterSig(
 		return sig, linkID, err
 	}
 
-	// TODO: The plan here was to return OuterLinkV2WithMetadata, so
-	// caller can have more insight into what link has been created,
-	// but that struct seems internal (all fields but one are hidden),
-	// so for now it returns sig, linkid, err.
 	linkID = libkb.ComputeLinkID(encodedOuterLink)
 	return sig, linkID, nil
 }

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -36,6 +36,18 @@ func newMemberSetChange(ctx context.Context, g *libkb.GlobalContext, req keybase
 	return set, nil
 }
 
+func (m *memberSet) appendMemberSet(other *memberSet) {
+	m.Owners = append(m.Owners, other.Owners...)
+	m.Admins = append(m.Admins, other.Admins...)
+	m.Writers = append(m.Writers, other.Writers...)
+	m.Readers = append(m.Readers, other.Readers...)
+	m.None = append(m.None, other.None...)
+
+	for k, v := range other.recipients {
+		m.recipients[k] = v
+	}
+}
+
 func (m *memberSet) nonAdmins() []member {
 	var ret []member
 	ret = append(ret, m.Readers...)

--- a/go/teams/rename.go
+++ b/go/teams/rename.go
@@ -148,7 +148,7 @@ func generateRenameSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.Us
 		return nil, err
 	}
 	seqType := seqTypeForTeamPublicness(parentTeam.IsPublic())
-	v2Sig, err := makeSigchainV2OuterSig(
+	v2Sig, _, err := makeSigchainV2OuterSig(
 		signingKey,
 		libkb.LinkTypeRenameSubteam,
 		parentTeam.GetLatestSeqno()+1,
@@ -205,7 +205,7 @@ func generateRenameUpPointerSigForSubteamChain(g *libkb.GlobalContext, me *libkb
 		return nil, err
 	}
 	seqType := seqTypeForTeamPublicness(teams.subteam.IsPublic())
-	v2Sig, err := makeSigchainV2OuterSig(
+	v2Sig, _, err := makeSigchainV2OuterSig(
 		signingKey,
 		libkb.LinkTypeRenameUpPointer,
 		teams.subteam.GetLatestSeqno()+1,

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -283,6 +283,12 @@ func AddMemberByID(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.
 			return err
 		}
 
+		if inviteRequired && !uv.Uid.Exists() {
+			// Handle social invites without transactions.
+			res, err = t.InviteMember(ctx, username, role, resolvedUsername, uv)
+			return err
+		}
+
 		// TODO: Recreate this in transactions.go
 		// TODO: Or remove commented code if we don't.
 		// timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 2*time.Second)

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -218,7 +218,7 @@ func AddMemberByID(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.
 		}
 
 		tx := CreateAddMemberTx(t)
-		err = tx.AddMemberTransaction(ctx, username, role)
+		err = tx.AddMemberTransaction(ctx, resolvedUsername.String(), role)
 		if err != nil {
 			return err
 		}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -283,46 +283,30 @@ func AddMemberByID(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.
 			return err
 		}
 
-		if inviteRequired {
-			res, err = t.InviteMember(ctx, username, role, resolvedUsername, uv)
-			return err
-		}
+		// TODO: Recreate this in transactions.go
+		// TODO: Or remove commented code if we don't.
+		// timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 2*time.Second)
+		// if err := tryToCompleteInvites(timeoutCtx, g, t, username, uv, &req); err != nil {
+		// 	g.Log.CWarningf(ctx, "team.AddMember: error during tryToCompleteInvites: %v", err)
+		// }
+		// timeoutCancel()
 
-		if t.IsMember(ctx, uv) {
-			showUsername := fmt.Sprintf("%q", resolvedUsername.String())
-			if username != resolvedUsername.String() {
-				showUsername = fmt.Sprintf("%q (%s)", username, resolvedUsername.String())
-			}
-			return libkb.ExistsError{Msg: fmt.Sprintf("user %s is already a member of team %q", showUsername,
-				t.Name())}
-		}
-		req, err := reqFromRole(uv, role)
+		tx := CreateAddMemberTx(t)
+		err = tx.AddMemberTransaction(ctx, username, role)
 		if err != nil {
 			return err
 		}
-		existingUV, err := t.UserVersionByUID(ctx, uv.Uid)
-		if err == nil {
-			g.Log.CDebugf(ctx, "found existing UV %v", existingUV.PercentForm())
-			// Case where same UV (uid+seqno) already exists is covered by
-			// `t.IsMember` check above. This only checks if there is a reset
-			// member in the team to automatically remove them (so AddMember
-			// can function as a Re-Add).
-			// Case where uv.EldestSeqno=0 is covered by errInviteRequired above.
-			if existingUV.EldestSeqno > uv.EldestSeqno {
-				return fmt.Errorf("newer version of user %q already exists in team %q (%v > %v)", resolvedUsername, t.Name(), existingUV.EldestSeqno, uv.EldestSeqno)
-			}
-			req.None = []keybase1.UserVersion{existingUV}
-		}
-		timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 2*time.Second)
-		if err := tryToCompleteInvites(timeoutCtx, g, t, username, uv, &req); err != nil {
-			g.Log.CWarningf(ctx, "team.AddMember: error during tryToCompleteInvites: %v", err)
-		}
-		timeoutCancel()
-		if err := t.ChangeMembership(ctx, req); err != nil {
+
+		err = tx.Post(ctx)
+		if err != nil {
 			return err
 		}
+
 		// return value assign to escape closure
-		res = keybase1.TeamAddMemberResult{User: &keybase1.User{Uid: uv.Uid, Username: resolvedUsername.String()}}
+		res = keybase1.TeamAddMemberResult{
+			User:    &keybase1.User{Uid: uv.Uid, Username: resolvedUsername.String()},
+			Invited: inviteRequired,
+		}
 		return nil
 	})
 	return res, err

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -217,14 +217,6 @@ func AddMemberByID(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.
 			return err
 		}
 
-		// TODO: Recreate this in transactions.go
-		// TODO: Or remove commented code if we don't.
-		// timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 2*time.Second)
-		// if err := tryToCompleteInvites(timeoutCtx, g, t, username, uv, &req); err != nil {
-		// 	g.Log.CWarningf(ctx, "team.AddMember: error during tryToCompleteInvites: %v", err)
-		// }
-		// timeoutCancel()
-
 		tx := CreateAddMemberTx(t)
 		err = tx.AddMemberTransaction(ctx, username, role)
 		if err != nil {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -218,7 +218,7 @@ func AddMemberByID(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.
 		}
 
 		tx := CreateAddMemberTx(t)
-		err = tx.AddMemberTransaction(ctx, resolvedUsername.String(), role)
+		err = tx.AddMemberByUsername(ctx, resolvedUsername.String(), role)
 		if err != nil {
 			return err
 		}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -655,6 +655,21 @@ func loadUserVersionPlusByUsername(ctx context.Context, g *libkb.GlobalContext, 
 	return res.GetNormalizedUsername(), uv, nil
 }
 
+func loadUserVersionAndPUKedByUsername(ctx context.Context, g *libkb.GlobalContext, username string) (uname libkb.NormalizedUsername, uv keybase1.UserVersion, hasPUK bool, err error) {
+	uname, uv, err = loadUserVersionPlusByUsername(ctx, g, username)
+	if err == nil {
+		hasPUK = true
+	} else {
+		if err == errInviteRequired {
+			err = nil
+			hasPUK = false
+		} else {
+			return "", keybase1.UserVersion{}, false, err
+		}
+	}
+	return uname, uv, hasPUK, nil
+}
+
 func loadUserVersionByUsername(ctx context.Context, g *libkb.GlobalContext, username string) (keybase1.UserVersion, error) {
 	res := g.Resolver.ResolveWithBody(username)
 	if res.GetError() != nil {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1154,7 +1154,7 @@ func (t *Team) sigTeamItemRaw(ctx context.Context, section SCTeamSection, linkTy
 	if err != nil {
 		return libkb.SigMultiItem{}, "", err
 	}
-	v2Sig, newLinkID, err := makeSigchainOuterLinkV2(
+	v2Sig, newLinkID, err := makeSigchainV2OuterSig(
 		deviceSigningKey,
 		linkType,
 		nextSeqno,

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1154,7 +1154,7 @@ func (t *Team) sigTeamItemRaw(ctx context.Context, section SCTeamSection, linkTy
 	if err != nil {
 		return libkb.SigMultiItem{}, "", err
 	}
-	v2Sig, err := makeSigchainV2OuterSig(
+	v2Sig, newLinkID, err := makeSigchainOuterLinkV2(
 		deviceSigningKey,
 		linkType,
 		nextSeqno,
@@ -1183,9 +1183,7 @@ func (t *Team) sigTeamItemRaw(ctx context.Context, section SCTeamSection, linkTy
 		}
 	}
 
-	linkID := keybase1.LinkID(libkb.ComputeLinkID(sigJSON).String())
-	fmt.Printf("Posting, prev link ID is %s, cur is %s\n", latestLinkID, linkID)
-	return sigMultiItem, linkID, nil
+	return sigMultiItem, keybase1.LinkID(newLinkID.String()), nil
 }
 
 func (t *Team) recipientBoxes(ctx context.Context, memSet *memberSet) (*PerTeamSharedSecretBoxes, map[keybase1.TeamID]*PerTeamSharedSecretBoxes, *SCPerTeamKey, error) {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -923,7 +923,7 @@ func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error
 		return err
 	}
 
-	err = t.precheckLinkToPost(ctx, sigMultiItem)
+	err = t.precheckLinksToPost(ctx, []libkb.SigMultiItem{sigMultiItem})
 	if err != nil {
 		return fmt.Errorf("cannot post link (precheck): %v", err)
 	}
@@ -1042,7 +1042,7 @@ func (t *Team) postChangeItem(ctx context.Context, section SCTeamSection, linkTy
 		return err
 	}
 
-	err = t.precheckLinkToPost(ctx, sigMultiItem)
+	err = t.precheckLinksToPost(ctx, []libkb.SigMultiItem{sigMultiItem})
 	if err != nil {
 		return fmt.Errorf("cannot post link (precheck): %v", err)
 	}
@@ -1451,12 +1451,12 @@ func (t *Team) parseSocial(username string) (typ string, name string, err error)
 	return typ, name, nil
 }
 
-func (t *Team) precheckLinkToPost(ctx context.Context, sigMultiItem libkb.SigMultiItem) (err error) {
+func (t *Team) precheckLinksToPost(ctx context.Context, sigMultiItems []libkb.SigMultiItem) (err error) {
 	uv, err := t.currentUserUV(ctx)
 	if err != nil {
 		return err
 	}
-	return precheckLinkToPost(ctx, t.G(), sigMultiItem, t.chain(), uv)
+	return precheckLinksToPost(ctx, t.G(), sigMultiItems, t.chain(), uv)
 }
 
 // Try to run `post` (expected to post new team sigchain links).

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -100,7 +100,7 @@ func (tx *AddMemberTx) CreateInvite(uv keybase1.UserVersion, role keybase1.TeamR
 	case keybase1.TeamRole_ADMIN:
 		payload.Admins = appendToInviteList(invite, payload.Admins)
 	case keybase1.TeamRole_OWNER:
-		return fmt.Errorf("Cannot add invites as owners")
+		payload.Owners = appendToInviteList(invite, payload.Owners)
 	default:
 		return fmt.Errorf("Unexpected role: %v", role)
 	}

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -1,0 +1,176 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package teams
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type AddMemberTx struct {
+	team     *Team
+	payloads []interface{}
+}
+
+func CreateAddMemberTx(t *Team) *AddMemberTx {
+	return &AddMemberTx{team: t}
+}
+
+func (tx *AddMemberTx) invitePayload() *SCTeamInvites {
+	for _, v := range tx.payloads {
+		if ret, ok := v.(*SCTeamInvites); ok {
+			return ret
+		}
+	}
+
+	ret := &SCTeamInvites{}
+	tx.payloads = append(tx.payloads, ret)
+	return ret
+}
+
+func (tx *AddMemberTx) changeMembershipPayload() *keybase1.TeamChangeReq {
+	for _, v := range tx.payloads {
+		if ret, ok := v.(*keybase1.TeamChangeReq); ok {
+			return ret
+		}
+	}
+
+	ret := &keybase1.TeamChangeReq{}
+	tx.payloads = append(tx.payloads, ret)
+	return ret
+}
+
+func (tx *AddMemberTx) RemoveMember(uv keybase1.UserVersion) error {
+	payload := tx.changeMembershipPayload()
+	payload.None = append(payload.None, uv)
+	return nil
+}
+
+func (tx *AddMemberTx) AddMember(uv keybase1.UserVersion, role keybase1.TeamRole) error {
+	payload := tx.changeMembershipPayload()
+	payload.AddUVWithRole(uv, role)
+	return nil
+}
+
+func (tx *AddMemberTx) CancelInvite(id keybase1.TeamInviteID) error {
+	payload := tx.invitePayload()
+	if payload.Cancel == nil {
+		payload.Cancel = &[]SCTeamInviteID{SCTeamInviteID(id)}
+	} else {
+		tmp := append(*payload.Cancel, SCTeamInviteID(id))
+		payload.Cancel = &tmp
+	}
+	return nil
+}
+
+func appendToInviteList(inv SCTeamInvite, list *[]SCTeamInvite) *[]SCTeamInvite {
+	var tmp []SCTeamInvite
+	if list == nil {
+		tmp = []SCTeamInvite{inv}
+		return &tmp
+	} else {
+		tmp = *list
+		tmp = append(tmp, inv)
+		return &tmp
+	}
+}
+
+func (tx *AddMemberTx) CreateInvite(uv keybase1.UserVersion, role keybase1.TeamRole) error {
+	payload := tx.invitePayload()
+
+	invite := SCTeamInvite{
+		Type: "keybase",
+		Name: uv.TeamInviteName(),
+		ID:   NewInviteID(),
+	}
+
+	switch role {
+	case keybase1.TeamRole_READER:
+		payload.Readers = appendToInviteList(invite, payload.Readers)
+	case keybase1.TeamRole_WRITER:
+		payload.Writers = appendToInviteList(invite, payload.Writers)
+	case keybase1.TeamRole_ADMIN:
+		payload.Admins = appendToInviteList(invite, payload.Admins)
+	case keybase1.TeamRole_OWNER:
+		return fmt.Errorf("Cannot add invites as owners")
+	default:
+		return fmt.Errorf("Unexpected role: %v", role)
+	}
+	return nil
+}
+
+func (tx *AddMemberTx) SweepMembers(uv keybase1.UserVersion) {
+	team := tx.team
+	for chainUv := range team.chain().inner.UserLog {
+		if chainUv.Uid == uv.Uid && team.chain().getUserRole(uv) != keybase1.TeamRole_NONE {
+			tx.RemoveMember(chainUv)
+		}
+	}
+}
+
+func (tx *AddMemberTx) SweepKeybaseInvites(uv keybase1.UserVersion) {
+	team := tx.team
+	for _, invite := range team.chain().inner.ActiveInvites {
+		if inviteUv, err := invite.KeybaseUserVersion(); err != nil {
+			if inviteUv.Uid == uv.Uid {
+				tx.CancelInvite(invite.Id)
+			}
+		}
+	}
+}
+
+func (tx *AddMemberTx) AddMemberTransaction(ctx context.Context, g *libkb.GlobalContext, username string, role keybase1.TeamRole) error {
+	inviteRequired := false
+	normalizedUsername, uv, err := loadUserVersionPlusByUsername(ctx, g, username)
+	if err != nil {
+		if err == errInviteRequired {
+			inviteRequired = true
+			g.Log.CDebugf(ctx, "Invite required for %+v", uv)
+		} else {
+			return err
+		}
+	}
+
+	// Do not do partial updates here. If error is returned, it is
+	// assumed that tx is untouched, and caller can continue with
+	// other attempts. This is used in batch member adds, when even if
+	// some users can't be added, it skips them and continues with
+	// others.
+
+	team := tx.team
+
+	if team.IsMember(ctx, uv) {
+		if inviteRequired {
+			return fmt.Errorf("user is already member but we got errInviteRequired")
+		}
+		return libkb.ExistsError{Msg: fmt.Sprintf("user %s is already a member of team %q",
+			normalizedUsername, team.Name())}
+	}
+
+	ok, err := team.HasActiveInvite(uv.TeamInviteName(), "keybase")
+	if err != nil {
+		return err
+	}
+	if ok {
+		if !inviteRequired {
+			return fmt.Errorf("???")
+		}
+		return libkb.ExistsError{Msg: fmt.Sprintf("user %s is already a pukless member of team %q",
+			normalizedUsername, team.Name())}
+	}
+
+	tx.SweepMembers(uv)        // Sweep all existing crypto members
+	tx.SweepKeybaseInvites(uv) // Sweep all existing keybase type invites
+
+	if inviteRequired {
+		tx.CreateInvite(uv, role)
+	} else {
+		tx.AddMember(uv, role)
+	}
+	return nil
+}

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -168,7 +168,10 @@ func (tx *AddMemberTx) AddMemberTransaction(ctx context.Context, username string
 		// TODO: Might be able to collapse the two assertions together - the one
 		// above with team.IsMember and this one which checking Uid/Eldest.
 
-		if existingUV.EldestSeqno > uv.EldestSeqno {
+		// There is an edge case where user is in the middle of
+		// resetting (after reset, before provisioning) and has
+		// EldestSeqno=0.
+		if !inviteRequired && existingUV.EldestSeqno > uv.EldestSeqno {
 			return fmt.Errorf("newer version of user %s (uid:%s) already exists in the team %q (%v > %v)",
 				normalizedUsername, uv.Uid, team.Name(), existingUV.EldestSeqno, uv.EldestSeqno)
 		}

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -15,7 +15,7 @@ import (
 
 type AddMemberTx struct {
 	team     *Team
-	payloads []interface{}
+	payloads []interface{} // *SCTeamInvites or *keybase1.TeamChangeReq
 }
 
 func CreateAddMemberTx(t *Team) *AddMemberTx {
@@ -78,11 +78,10 @@ func (tx *AddMemberTx) CancelInvite(id keybase1.TeamInviteID) error {
 
 func appendToInviteList(inv SCTeamInvite, list *[]SCTeamInvite) *[]SCTeamInvite {
 	var tmp []SCTeamInvite
-	if list == nil {
-		tmp = []SCTeamInvite{inv}
-	} else {
-		tmp = append(*list, inv)
+	if list != nil {
+		tmp = *list
 	}
+	tmp = append(tmp, inv)
 	return &tmp
 }
 
@@ -452,6 +451,8 @@ func (tx *AddMemberTx) Post(ctx context.Context) (err error) {
 			linkType = libkb.LinkTypeChangeMembership
 		case *SCTeamInvites:
 			linkType = libkb.LinkTypeInvite
+		default:
+			return fmt.Errorf("Unhandled case in AddMemberTx.Post, unknown type: %T", tx.payloads[i])
 		}
 
 		sigMultiItem, linkID, err := team.sigTeamItemRaw(ctx, section, linkType,

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -200,8 +200,20 @@ func (tx *AddMemberTx) AddMemberTransaction(ctx context.Context, username string
 
 	// No going back after this point!
 
-	tx.SweepMembers(uv.Uid)        // Sweep all existing crypto members
-	tx.SweepKeybaseInvites(uv.Uid) // Sweep all existing keybase type invites
+	if team.IsImplicit() {
+		// Separate logic for sweeping in implicit teams, since memberships
+		// there have to be sound for every signature, so we can't post e.g.
+		// one sig that removes UV and another that adds invite.
+
+		if inviteRequired {
+			tx.SweepKeybaseInvites(uv.Uid)
+		} else {
+			tx.SweepMembers(uv.Uid)
+		}
+	} else {
+		tx.SweepMembers(uv.Uid)        // Sweep all existing crypto members
+		tx.SweepKeybaseInvites(uv.Uid) // Sweep all existing keybase type invites
+	}
 
 	if inviteRequired {
 		return tx.CreateInvite(uv, role)

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -109,7 +109,7 @@ func (tx *AddMemberTx) CreateInvite(uv keybase1.UserVersion, role keybase1.TeamR
 func (tx *AddMemberTx) SweepMembers(uv keybase1.UserVersion) {
 	team := tx.team
 	for chainUv := range team.chain().inner.UserLog {
-		if chainUv.Uid == uv.Uid && team.chain().getUserRole(uv) != keybase1.TeamRole_NONE {
+		if chainUv.Uid == uv.Uid && team.chain().getUserRole(chainUv) != keybase1.TeamRole_NONE {
 			tx.RemoveMember(chainUv)
 		}
 	}

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -50,6 +50,9 @@ func (tx *AddMemberTx) changeMembershipPayload() *keybase1.TeamChangeReq {
 	return ret
 }
 
+// Low-level API: Find the right payload and add/remove
+// membership/invite.
+
 func (tx *AddMemberTx) RemoveMember(uv keybase1.UserVersion) error {
 	payload := tx.changeMembershipPayload()
 	payload.None = append(payload.None, uv)
@@ -127,6 +130,12 @@ func (tx *AddMemberTx) SweepKeybaseInvites(uid keybase1.UID) {
 	}
 }
 
+// High level API:
+
+// AddMemberTransaction will add member by username and role. It
+// checks if given username can become crypto member or a PUKless
+// member. It will also clean up old invites and memberships if
+// necessary.
 func (tx *AddMemberTx) AddMemberTransaction(ctx context.Context, username string, role keybase1.TeamRole) error {
 	team := tx.team
 	g := team.G()
@@ -189,10 +198,7 @@ func (tx *AddMemberTx) AddMemberTransaction(ctx context.Context, username string
 			normalizedUsername, team.Name())}
 	}
 
-	// TODO: Complete invite using curInvite in tx.AddMember branch.
-	// Or decide if we want this - maybe complete_invites should be
-	// reserved for "real" invite resolutions, as in these that come
-	// from SBS handler.
+	// No going back after this point!
 
 	tx.SweepMembers(uv.Uid)        // Sweep all existing crypto members
 	tx.SweepKeybaseInvites(uv.Uid) // Sweep all existing keybase type invites

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -109,6 +109,8 @@ func (tx *AddMemberTx) CreateInvite(uv keybase1.UserVersion, role keybase1.TeamR
 	return nil
 }
 
+// SweepMembers will queue "removes" for all cryptomembers with given
+// UID.
 func (tx *AddMemberTx) SweepMembers(uid keybase1.UID) {
 	team := tx.team
 	for chainUv := range team.chain().inner.UserLog {
@@ -118,6 +120,8 @@ func (tx *AddMemberTx) SweepMembers(uid keybase1.UID) {
 	}
 }
 
+// SweepKeybaseInvites will queue "cancels" for all keybase-type
+// invites (PUKless members) for given UID.
 func (tx *AddMemberTx) SweepKeybaseInvites(uid keybase1.UID) {
 	team := tx.team
 	for _, invite := range team.chain().inner.ActiveInvites {
@@ -193,7 +197,7 @@ func (tx *AddMemberTx) AddMemberTransaction(ctx context.Context, username string
 		curInvite = nil
 	}
 	if curInvite != nil && inviteRequired {
-		return libkb.ExistsError{Msg: fmt.Sprintf("user %s is already a pukless member of team %q",
+		return libkb.ExistsError{Msg: fmt.Sprintf("user %s is already invited to team %q",
 			normalizedUsername, team.Name())}
 	}
 

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -373,11 +373,7 @@ func (tx *AddMemberTx) Post(ctx context.Context) (err error) {
 				return err
 			}
 
-			// TODO: Instead of loading members twice, have a "append"
-			// function in memberSet.
-			if err := memSet.loadMembers(ctx, g, *payload, true /* forcePoll */); err != nil {
-				return err
-			}
+			memSet.appendMemberSet(payloadMemberSet)
 
 			section.Members, err = payloadMemberSet.Section()
 			if err != nil {

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -106,7 +106,7 @@ func (tx *AddMemberTx) createInvite(uv keybase1.UserVersion, role keybase1.TeamR
 	return nil
 }
 
-// SweepMembers will queue "removes" for all cryptomembers with given
+// sweepMembers will queue "removes" for all cryptomembers with given
 // UID.
 func (tx *AddMemberTx) sweepMembers(uid keybase1.UID) {
 	team := tx.team
@@ -117,7 +117,7 @@ func (tx *AddMemberTx) sweepMembers(uid keybase1.UID) {
 	}
 }
 
-// SweepKeybaseInvites will queue "cancels" for all keybase-type
+// sweepKeybaseInvites will queue "cancels" for all keybase-type
 // invites (PUKless members) for given UID.
 func (tx *AddMemberTx) sweepKeybaseInvites(uid keybase1.UID) {
 	team := tx.team
@@ -130,20 +130,20 @@ func (tx *AddMemberTx) sweepKeybaseInvites(uid keybase1.UID) {
 	}
 }
 
-// AddMemberTransaction will add member by username and role. It
+// AddMemberByUsername will add member by username and role. It
 // checks if given username can become crypto member or a PUKless
 // member. It will also clean up old invites and memberships if
 // necessary.
-func (tx *AddMemberTx) AddMemberTransaction(ctx context.Context, username string, role keybase1.TeamRole) (err error) {
+func (tx *AddMemberTx) AddMemberByUsername(ctx context.Context, username string, role keybase1.TeamRole) (err error) {
 	team := tx.team
 	g := team.G()
 
-	defer g.CTrace(ctx, fmt.Sprintf("AddMemberTx.AddMemberTransaction(%s,%v)", username, role), func() error { return err })()
-	g.Log.CDebugf(ctx, "AddMemberTransaction(%s, %v) to team %q", username, role, team.Name())
+	defer g.CTrace(ctx, fmt.Sprintf("AddMemberTx.AddMemberByUsername(%s,%v)", username, role), func() error { return err })()
+	g.Log.CDebugf(ctx, "AddMemberByUsername(%s, %v) to team %q", username, role, team.Name())
 
 	inviteRequired := false
 	normalizedUsername, uv, err := loadUserVersionPlusByUsername(ctx, g, username)
-	g.Log.CDebugf(ctx, "AddMemberTransaction: loaded user %q -> (%q, %v, %v)", username, normalizedUsername, uv, err)
+	g.Log.CDebugf(ctx, "AddMemberByUsername: loaded user %q -> (%q, %v, %v)", username, normalizedUsername, uv, err)
 	if err != nil {
 		if err == errInviteRequired {
 			inviteRequired = true

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -430,13 +430,17 @@ func (tx *AddMemberTx) Post(ctx context.Context) (err error) {
 
 	if perTeamKeySection != nil {
 		// We have a new per team key, find first TeamChangeReq
-		// section created and add perTeamKeySection.
-		// TODO: Should it be the first ChangeMembership sig or the last?
+		// section that removes users and add it there.
+		found := false
 		for i, v := range tx.payloads {
-			if _, ok := v.(*keybase1.TeamChangeReq); ok {
+			if req, ok := v.(*keybase1.TeamChangeReq); ok && len(req.None) > 0 {
 				sections[i].PerTeamKey = perTeamKeySection
+				found = true
 				break
 			}
+		}
+		if !found {
+			return fmt.Errorf("AddMemberTx.Post got a PerTeamKey but couldn't find a link with None to attach it")
 		}
 	}
 

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -209,19 +209,15 @@ func (tx *AddMemberTx) AddMemberByUsername(ctx context.Context, username string,
 
 	// No going back after this point!
 
-	if team.IsImplicit() {
-		// Separate logic for sweeping in implicit teams, since memberships
-		// there have to be "constant" at every signature, so we can't post e.g.
-		// one sig that removes UV and another that adds invite.
+	// Separate logic for sweeping in implicit teams, since memberships
+	// there have to be "constant" at every signature, so we can't post e.g.
+	// one sig that removes UV and another that adds invite.
 
-		if !hasPUK {
-			tx.sweepKeybaseInvites(uv.Uid)
-		} else {
-			tx.sweepCryptoMembers(uv.Uid)
-		}
-	} else {
-		tx.sweepCryptoMembers(uv.Uid)  // Sweep all existing crypto members
-		tx.sweepKeybaseInvites(uv.Uid) // Sweep all existing keybase type invites
+	if !team.IsImplicit() || !hasPUK {
+		tx.sweepKeybaseInvites(uv.Uid)
+	}
+	if !team.IsImplicit() || hasPUK {
+		tx.sweepCryptoMembers(uv.Uid)
 	}
 
 	if !hasPUK {

--- a/go/teams/transactions_test.go
+++ b/go/teams/transactions_test.go
@@ -18,7 +18,8 @@ func TestTransactions1(t *testing.T) {
 	defer tc.Cleanup()
 
 	team, err := Load(context.Background(), tc.G, keybase1.LoadTeamArg{
-		Name: name,
+		Name:      name,
+		NeedAdmin: true,
 	})
 	require.NoError(t, err)
 

--- a/go/teams/transactions_test.go
+++ b/go/teams/transactions_test.go
@@ -9,8 +9,6 @@ import (
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 func TestTransactions1(t *testing.T) {
@@ -24,7 +22,6 @@ func TestTransactions1(t *testing.T) {
 	require.NoError(t, err)
 
 	tx := CreateAddMemberTx(team)
-	//tx.AddMemberTransaction(context.Background(), tc.G, "t_rosetta", keybase1.TeamRole_READER)
 	tx.AddMemberTransaction(context.Background(), "t_alice", keybase1.TeamRole_WRITER)
 	tx.AddMemberTransaction(context.Background(), other.Username, keybase1.TeamRole_WRITER)
 	tx.AddMemberTransaction(context.Background(), "t_tracy", keybase1.TeamRole_ADMIN)
@@ -32,8 +29,6 @@ func TestTransactions1(t *testing.T) {
 	// 3rd add (pukless member) should re-use first signature instead
 	// of creating new one.
 	require.Equal(t, 2, len(tx.payloads))
-
-	spew.Dump(tx.payloads)
 
 	err = tx.Post(context.Background())
 	require.NoError(t, err)

--- a/go/teams/transactions_test.go
+++ b/go/teams/transactions_test.go
@@ -24,8 +24,17 @@ func TestTransactions1(t *testing.T) {
 	require.NoError(t, err)
 
 	tx := CreateAddMemberTx(team)
-	tx.AddMemberTransaction(context.Background(), tc.G, other.Username, keybase1.TeamRole_WRITER)
+	//tx.AddMemberTransaction(context.Background(), tc.G, "t_rosetta", keybase1.TeamRole_READER)
 	tx.AddMemberTransaction(context.Background(), tc.G, "t_alice", keybase1.TeamRole_WRITER)
+	tx.AddMemberTransaction(context.Background(), tc.G, other.Username, keybase1.TeamRole_WRITER)
+	tx.AddMemberTransaction(context.Background(), tc.G, "t_tracy", keybase1.TeamRole_ADMIN)
+
+	// 3rd add (pukless member) should re-use first signature instead
+	// of creating new one.
+	require.Equal(t, 2, len(tx.payloads))
 
 	spew.Dump(tx.payloads)
+
+	err = tx.Post(context.Background(), tc.G)
+	require.NoError(t, err)
 }

--- a/go/teams/transactions_test.go
+++ b/go/teams/transactions_test.go
@@ -25,9 +25,9 @@ func TestTransactions1(t *testing.T) {
 
 	tx := CreateAddMemberTx(team)
 	//tx.AddMemberTransaction(context.Background(), tc.G, "t_rosetta", keybase1.TeamRole_READER)
-	tx.AddMemberTransaction(context.Background(), tc.G, "t_alice", keybase1.TeamRole_WRITER)
-	tx.AddMemberTransaction(context.Background(), tc.G, other.Username, keybase1.TeamRole_WRITER)
-	tx.AddMemberTransaction(context.Background(), tc.G, "t_tracy", keybase1.TeamRole_ADMIN)
+	tx.AddMemberTransaction(context.Background(), "t_alice", keybase1.TeamRole_WRITER)
+	tx.AddMemberTransaction(context.Background(), other.Username, keybase1.TeamRole_WRITER)
+	tx.AddMemberTransaction(context.Background(), "t_tracy", keybase1.TeamRole_ADMIN)
 
 	// 3rd add (pukless member) should re-use first signature instead
 	// of creating new one.
@@ -35,6 +35,6 @@ func TestTransactions1(t *testing.T) {
 
 	spew.Dump(tx.payloads)
 
-	err = tx.Post(context.Background(), tc.G)
+	err = tx.Post(context.Background())
 	require.NoError(t, err)
 }

--- a/go/teams/transactions_test.go
+++ b/go/teams/transactions_test.go
@@ -1,0 +1,30 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package teams
+
+import (
+	"context"
+	"testing"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestTransactions1(t *testing.T) {
+	tc, _, other, _, name := memberSetupMultiple(t)
+	defer tc.Cleanup()
+
+	team, err := Load(context.Background(), tc.G, keybase1.LoadTeamArg{
+		Name: name,
+	})
+	require.NoError(t, err)
+
+	tx := CreateAddMemberTx(team)
+	tx.AddMemberTransaction(context.Background(), tc.G, other.Username, keybase1.TeamRole_WRITER)
+	tx.AddMemberTransaction(context.Background(), tc.G, "t_alice", keybase1.TeamRole_WRITER)
+
+	spew.Dump(tx.payloads)
+}

--- a/go/teams/transactions_test.go
+++ b/go/teams/transactions_test.go
@@ -22,16 +22,16 @@ func TestTransactions1(t *testing.T) {
 	require.NoError(t, err)
 
 	tx := CreateAddMemberTx(team)
-	tx.AddMemberTransaction(context.Background(), "t_alice", keybase1.TeamRole_WRITER)
+	tx.AddMemberByUsername(context.Background(), "t_alice", keybase1.TeamRole_WRITER)
 	require.Equal(t, 1, len(tx.payloads))
 	require.IsType(t, &SCTeamInvites{}, tx.payloads[0])
 
-	tx.AddMemberTransaction(context.Background(), other.Username, keybase1.TeamRole_WRITER)
+	tx.AddMemberByUsername(context.Background(), other.Username, keybase1.TeamRole_WRITER)
 	require.Equal(t, 2, len(tx.payloads))
 	require.IsType(t, &SCTeamInvites{}, tx.payloads[0])
 	require.IsType(t, &keybase1.TeamChangeReq{}, tx.payloads[1])
 
-	tx.AddMemberTransaction(context.Background(), "t_tracy", keybase1.TeamRole_ADMIN)
+	tx.AddMemberByUsername(context.Background(), "t_tracy", keybase1.TeamRole_ADMIN)
 
 	// 3rd add (pukless member) should re-use first signature instead
 	// of creating new one.

--- a/go/teams/transactions_test.go
+++ b/go/teams/transactions_test.go
@@ -23,13 +23,69 @@ func TestTransactions1(t *testing.T) {
 
 	tx := CreateAddMemberTx(team)
 	tx.AddMemberTransaction(context.Background(), "t_alice", keybase1.TeamRole_WRITER)
+	require.Equal(t, 1, len(tx.payloads))
+	require.IsType(t, &SCTeamInvites{}, tx.payloads[0])
+
 	tx.AddMemberTransaction(context.Background(), other.Username, keybase1.TeamRole_WRITER)
+	require.Equal(t, 2, len(tx.payloads))
+	require.IsType(t, &SCTeamInvites{}, tx.payloads[0])
+	require.IsType(t, &keybase1.TeamChangeReq{}, tx.payloads[1])
+
 	tx.AddMemberTransaction(context.Background(), "t_tracy", keybase1.TeamRole_ADMIN)
 
 	// 3rd add (pukless member) should re-use first signature instead
 	// of creating new one.
 	require.Equal(t, 2, len(tx.payloads))
+	require.IsType(t, &SCTeamInvites{}, tx.payloads[0])
+	require.IsType(t, &keybase1.TeamChangeReq{}, tx.payloads[1])
 
 	err = tx.Post(context.Background())
 	require.NoError(t, err)
+}
+
+func TestTransactionRotateKey(t *testing.T) {
+	tc, _, otherA, otherB, name := memberSetupMultiple(t)
+	defer tc.Cleanup()
+
+	loadTeam := func() *Team {
+		team, err := Load(context.Background(), tc.G, keybase1.LoadTeamArg{
+			Name:        name,
+			NeedAdmin:   true,
+			ForceRepoll: true,
+		})
+		require.NoError(t, err)
+		return team
+	}
+
+	team := loadTeam()
+	err := team.ChangeMembership(context.Background(), keybase1.TeamChangeReq{
+		Writers: []keybase1.UserVersion{otherA.GetUserVersion()},
+	})
+	require.NoError(t, err)
+
+	team = loadTeam()
+	require.EqualValues(t, 1, team.Generation())
+
+	tx := CreateAddMemberTx(team)
+	// Create payloads manually so user add and user del happen in
+	// separate links.
+	tx.payloads = []interface{}{
+		&keybase1.TeamChangeReq{
+			Writers: []keybase1.UserVersion{otherB.GetUserVersion()},
+		},
+		&keybase1.TeamChangeReq{
+			None: []keybase1.UserVersion{otherA.GetUserVersion()},
+		},
+	}
+	err = tx.Post(context.Background())
+	require.NoError(t, err)
+
+	// Also if the transaction didn't create new PerTeamKey, bunch of
+	// assertions would have failed on the server. It doesn't matter
+	// which link the PerTeamKey is attached to, because key coverage
+	// is checked for the entire transaction, not individual links,
+	// but we always attach it to the first ChangeMembership link with
+	// member removals.
+	team = loadTeam()
+	require.EqualValues(t, 2, team.Generation())
 }


### PR DESCRIPTION
This pull request adds a new file `teams/transactions.go` that introduces `AddMemberTx` struct with methods. It can be used to add one or more member to a team that may or may not need to post multiple signatures to achieve the task, e.g.:
1) first cancel existing keybase-type invite, then add member with `ChangeMembership` (two sigs)
2) first remove existing member old UV, then add new member UV (one sig)
3) first remove existing member old UV, then add new keybase-type invite (two sigs).

`AddMemberTx` has `payloads` list of values that are either `*SCTeamInvites` or `*keybase1.TeamChangeReq`. When adding members, functions will either find existing payload of needed type, or add a new one. When `tx.Post` is called, `payloads` are transformed to SCTeamSections, and then chain of signatures is created to be posted using `sig/multi`. No serverside changes were needed to get this to work.