### PR TITLE
use members type settings from env for default in JSON API

### DIFF
--- a/go/client/chat_api_doc.go
+++ b/go/client/chat_api_doc.go
@@ -23,7 +23,7 @@ If you're on the nth page and want to go back, set the previous field instead.
     {"method": "read", "params": {"options": {"channel": {"name": "you,them"}, "pagination": {"previous": "<result.pagination.previous from last reply>", "num": 10}}}}
 
 Send a message:
-    {"method": "send", "params": {"options": {"channel": {"name": "you,them"}, "message": {"body": "is it cold today?"}}}
+    {"method": "send", "params": {"options": {"channel": {"name": "you,them"}, "message": {"body": "is it cold today?"}}}}
 
 Delete a message:
     {"method": "delete", "params": {"options": {"channel": {"name": "you,them"}, "message_id": 314}}}

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"golang.org/x/net/context"
 )
@@ -85,9 +86,12 @@ func (c ChatChannel) Valid() bool {
 	return validTyp
 }
 
-func (c ChatChannel) GetMembersType() chat1.ConversationMembersType {
+func (c ChatChannel) GetMembersType(e *libkb.Env) chat1.ConversationMembersType {
 	if typ, ok := chat1.ConversationMembersTypeMap[strings.ToUpper(c.MembersType)]; ok {
 		return typ
+	}
+	if e.GetChatMemberType() == "impteam" {
+		return chat1.ConversationMembersType_IMPTEAM
 	}
 	return chat1.ConversationMembersType_KBFS
 }

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -742,7 +742,7 @@ func (c *chatServiceHandler) makePostHeader(ctx context.Context, arg sendArgV1, 
 			TopicName:        topicName,
 			TopicType:        tt,
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-			MembersType:      arg.channel.GetMembersType(),
+			MembersType:      arg.channel.GetMembersType(c.G().GetEnv()),
 		})
 		if err != nil {
 			return nil, err
@@ -799,7 +799,8 @@ func (c *chatServiceHandler) getExistingConvs(ctx context.Context, id chat1.Conv
 	}
 
 	var tlfName string
-	if channel.GetMembersType() == chat1.ConversationMembersType_KBFS {
+	switch channel.GetMembersType(c.G().GetEnv()) {
+	case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAM:
 		tlfQ := keybase1.TLFQuery{
 			TlfName:          channel.Name,
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
@@ -817,7 +818,7 @@ func (c *chatServiceHandler) getExistingConvs(ctx context.Context, id chat1.Conv
 			}
 			tlfName = cname.CanonicalName.String()
 		}
-	} else {
+	default:
 		tlfName = channel.Name
 	}
 
@@ -832,7 +833,7 @@ func (c *chatServiceHandler) getExistingConvs(ctx context.Context, id chat1.Conv
 
 	findRes, err := client.FindConversationsLocal(ctx, chat1.FindConversationsLocalArg{
 		TlfName:          tlfName,
-		MembersType:      channel.GetMembersType(),
+		MembersType:      channel.GetMembersType(c.G().GetEnv()),
 		Visibility:       vis,
 		TopicType:        tt,
 		TopicName:        channel.TopicName,


### PR DESCRIPTION
This way you can use `IMPTEAM` convs with JSON API without explicitly mentioning `members_type`.