### PR TITLE
better cleanup of ios dns call

### DIFF
--- a/go/bind/dns_ios.go
+++ b/go/bind/dns_ios.go
@@ -48,7 +48,7 @@ dnsRes ios_getDNSServers() {
     }
     free(addr_union);
   }
-  res_nclose(res);
+  res_ndestroy(res);
   free(res);
   return dnsSrvs;
 }


### PR DESCRIPTION
@keybase/react-hackers 
cc: @mmaxim 
this fixes a memory leak around dns resolution on ios. On ios specifically theres a res_ndestroy call which is actually required to clean up this system resource. See this fix in chromium: https://src.chromium.org/viewvc/chrome/trunk/src/net/dns/dns_config_service_posix.cc?pathrev=100078