### PR TITLE
Add CLI chat retention-policy, read policy updates

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -1540,7 +1540,7 @@ func (b *Boxer) compareHeadersMBV1(ctx context.Context, hServer chat1.MessageCli
 		return NewPermanentUnboxingError(NewHeaderMismatchError("MessageType"))
 	}
 
-	// Note: Supersedes, Deletes, and DeleteHistory are not checked because they are not
+	// Note: Supersedes, Deletes, and some other fields are not checked because they are not
 	//       part of MessageClientHeaderVerified.
 
 	// Prev

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -161,7 +161,3 @@ func (k *KeyFinderImpl) SetNameInfoSourceOverride(ni types.NameInfoSource) {
 func tlfIDToTeamdID(tlfID chat1.TLFID) (keybase1.TeamID, error) {
 	return keybase1.TeamIDFromString(tlfID.String())
 }
-
-func teamIDToTLFID(teamID keybase1.TeamID) (chat1.TLFID, error) {
-	return chat1.MakeTLFID(teamID.String())
-}

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -495,10 +495,6 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				}}
 				g.G().Syncer.SendChatStaleNotifications(ctx, m.UID().Bytes(), supdate, true)
 			}
-
-			if g.badger != nil && nm.UnreadUpdate != nil {
-				g.badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
-			}
 		case types.ActionReadMessage:
 			var nm chat1.ReadMessagePayload
 			err = dec.Decode(&nm)
@@ -519,10 +515,6 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				ConvID: nm.ConvID,
 				Conv:   g.presentUIItem(conv),
 			})
-
-			if g.badger != nil && nm.UnreadUpdate != nil {
-				g.badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
-			}
 		case types.ActionSetStatus:
 			var nm chat1.SetStatusPayload
 			err = dec.Decode(&nm)
@@ -542,10 +534,6 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				Status: nm.Status,
 				Conv:   g.presentUIItem(conv),
 			})
-
-			if g.badger != nil && nm.UnreadUpdate != nil {
-				g.badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
-			}
 		case types.ActionSetAppNotificationSettings:
 			var nm chat1.SetAppNotificationSettingsPayload
 			err = dec.Decode(&nm)
@@ -598,11 +586,6 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			activity = chat1.NewChatActivityWithNewConversation(chat1.NewConversationInfo{
 				Conv: *g.presentUIItem(conv),
 			})
-
-			if g.badger != nil && nm.UnreadUpdate != nil {
-				g.badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
-			}
-
 		case types.ActionTeamType:
 			var nm chat1.TeamTypePayload
 			err = dec.Decode(&nm)
@@ -621,12 +604,11 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				TeamType: nm.TeamType,
 				Conv:     g.presentUIItem(conv),
 			})
-
-			if g.badger != nil && nm.UnreadUpdate != nil {
-				g.badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
-			}
 		default:
 			g.Debug(ctx, "unhandled chat.activity action %q", action)
+		}
+		if g.badger != nil && gm.UnreadUpdate != nil {
+			g.badger.PushChatUpdate(*gm.UnreadUpdate, gm.InboxVers)
 		}
 		g.notifyNewChatActivity(ctx, m.UID(), convID, conv, &activity)
 	}(bctx)
@@ -861,6 +843,125 @@ func (g *PushHandler) TeamChannels(ctx context.Context, m gregor.OutOfBandMessag
 	return nil
 }
 
+func (g *PushHandler) SetConvRetention(ctx context.Context, m gregor.OutOfBandMessage) (err error) {
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+		g.identNotifier)
+	defer g.Trace(ctx, func() error { return err }, "SetConvRetention")()
+	if m.Body() == nil {
+		return errors.New("gregor handler for SetConvRetention update: nil message body")
+	}
+
+	var update chat1.SetConvRetentionUpdate
+	reader := bytes.NewReader(m.Body().Bytes())
+	dec := codec.NewDecoder(reader, &codec.MsgpackHandle{WriteExt: true})
+	err = dec.Decode(&update)
+	if err != nil {
+		return err
+	}
+	uid := gregor1.UID(m.UID().Bytes())
+
+	// Order updates based on inbox version of the update from the server
+	cb := g.orderer.WaitForTurn(ctx, uid, update.InboxVers)
+	bctx := BackgroundContext(ctx, g.G())
+	go func(ctx context.Context) {
+		defer g.Trace(ctx, func() error { return err }, "SetConvRetention(goroutine)")()
+		<-cb
+		g.Lock()
+		defer g.Unlock()
+		defer g.orderer.CompleteTurn(ctx, uid, update.InboxVers)
+
+		// Update inbox
+		conv, err := g.G().InboxSource.SetConvRetention(ctx, m.UID().Bytes(), update.InboxVers,
+			update.ConvID, update.Policy)
+		if err != nil {
+			g.Debug(ctx, "SetConvRetention: unable to update inbox: %s", err.Error())
+			return
+		}
+		if conv == nil {
+			return
+		}
+		// Send notify for each conversation ID
+		if conv.GetTopicType() == chat1.TopicType_CHAT {
+			if g.shouldSendNotifications() {
+				g.G().NotifyRouter.HandleChatSetConvRetention(ctx, keybase1.UID(uid.String()),
+					conv.GetConvID(), g.presentUIItem(conv))
+			} else {
+				supdate := []chat1.ConversationStaleUpdate{chat1.ConversationStaleUpdate{
+					ConvID:     conv.GetConvID(),
+					UpdateType: chat1.StaleUpdateType_CLEAR,
+				}}
+				g.G().Syncer.SendChatStaleNotifications(ctx, uid, supdate, false)
+			}
+		}
+	}(bctx)
+
+	return nil
+}
+
+func (g *PushHandler) SetTeamRetention(ctx context.Context, m gregor.OutOfBandMessage) (err error) {
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+		g.identNotifier)
+	defer g.Trace(ctx, func() error { return err }, "SetTeamRetention")()
+	if m.Body() == nil {
+		return errors.New("gregor handler for SetTeamRetention update: nil message body")
+	}
+
+	var update chat1.SetTeamRetentionUpdate
+	reader := bytes.NewReader(m.Body().Bytes())
+	dec := codec.NewDecoder(reader, &codec.MsgpackHandle{WriteExt: true})
+	err = dec.Decode(&update)
+	if err != nil {
+		return err
+	}
+	uid := gregor1.UID(m.UID().Bytes())
+
+	// Order updates based on inbox version of the update from the server
+	cb := g.orderer.WaitForTurn(ctx, uid, update.InboxVers)
+	bctx := BackgroundContext(ctx, g.G())
+	go func(ctx context.Context) {
+		defer g.Trace(ctx, func() error { return err }, "SetTeamRetention(goroutine)")()
+		<-cb
+		g.Lock()
+		defer g.Unlock()
+		defer g.orderer.CompleteTurn(ctx, uid, update.InboxVers)
+
+		// Update inbox
+		var convs []chat1.ConversationLocal
+		if convs, err = g.G().InboxSource.SetTeamRetention(ctx, m.UID().Bytes(), update.InboxVers,
+			update.TeamID, update.Policy); err != nil {
+			g.Debug(ctx, "SetTeamRetention: unable to update inbox: %s", err.Error())
+			return
+		}
+		if len(convs) == 0 {
+			g.Debug(ctx, "SetTeamRetention: no local convs affected")
+			return
+		}
+		// Send notify for each conversation ID
+		var convUIItems []chat1.InboxUIItem
+		var staleUpdates []chat1.ConversationStaleUpdate
+		for _, conv := range convs {
+			if conv.GetTopicType() == chat1.TopicType_CHAT {
+				convUIItems = append(convUIItems, *g.presentUIItem(&conv))
+				staleUpdates = append(staleUpdates, chat1.ConversationStaleUpdate{
+					ConvID:     conv.GetConvID(),
+					UpdateType: chat1.StaleUpdateType_CLEAR,
+				})
+			}
+		}
+
+		if g.shouldSendNotifications() {
+			g.G().NotifyRouter.HandleChatSetTeamRetention(ctx, keybase1.UID(uid.String()), update.TeamID, convUIItems)
+		} else {
+			g.G().Syncer.SendChatStaleNotifications(ctx, uid, staleUpdates, false)
+		}
+
+	}(bctx)
+
+	return nil
+}
+
 func (g *PushHandler) HandleOobm(ctx context.Context, obm gregor.OutOfBandMessage) (bool, error) {
 	if obm.System() == nil {
 		return false, errors.New("nil system in out of band message")
@@ -879,6 +980,10 @@ func (g *PushHandler) HandleOobm(ctx context.Context, obm gregor.OutOfBandMessag
 		return true, g.MembershipUpdate(ctx, obm)
 	case types.PushTeamChannels:
 		return true, g.TeamChannels(ctx, obm)
+	case types.PushConvRetention:
+		return true, g.SetConvRetention(ctx, obm)
+	case types.PushTeamRetention:
+		return true, g.SetTeamRetention(ctx, obm)
 	}
 
 	return false, nil

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1727,6 +1727,8 @@ type serverChatListener struct {
 	inboxSynced             chan chat1.ChatSyncResult
 }
 
+var _ libkb.NotifyListener = (*serverChatListener)(nil)
+
 func (n *serverChatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {
 	n.identifyUpdate <- update
 }

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
 	context "golang.org/x/net/context"
@@ -41,7 +42,7 @@ func (t *TeamsNameInfoSource) Lookup(ctx context.Context, name string, vis keyba
 }
 
 func teamToNameInfo(ctx context.Context, team *teams.Team, vis keybase1.TLFVisibility) (res types.NameInfo, err error) {
-	res.ID, err = teamIDToTLFID(team.ID)
+	res.ID, err = chat1.TeamIDToTLFID(team.ID)
 	if err != nil {
 		return res, err
 	}
@@ -99,7 +100,7 @@ func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, v
 	}
 
 	res.CanonicalName = impTeamName.String()
-	res.ID, err = teamIDToTLFID(teamID)
+	res.ID, err = chat1.TeamIDToTLFID(teamID)
 	if err != nil {
 		return res, err
 	}
@@ -165,7 +166,7 @@ func (t *ImplicitTeamsNameInfoSource) lookupInternalName(ctx context.Context, na
 	if err != nil {
 		return res, err
 	}
-	res.ID, err = teamIDToTLFID(teamName.ToTeamID(public))
+	res.ID, err = chat1.TeamIDToTLFID(teamName.ToTeamID(public))
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -101,6 +101,10 @@ type InboxSource interface {
 		resets []chat1.ConversationMember, previews []chat1.ConversationID) (MembershipUpdateRes, error)
 	TeamTypeChanged(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
 		teamType chat1.TeamType) (*chat1.ConversationLocal, error)
+	SetConvRetention(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
+		policy chat1.RetentionPolicy) (*chat1.ConversationLocal, error)
+	SetTeamRetention(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, teamID keybase1.TeamID,
+		policy chat1.RetentionPolicy) ([]chat1.ConversationLocal, error)
 
 	GetInboxQueryLocalToRemote(ctx context.Context,
 		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, NameInfo, error)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -828,6 +828,8 @@ func PresentConversationLocal(rawConv chat1.ConversationLocal) (res chat1.InboxU
 	res.TeamType = rawConv.Info.TeamType
 	res.Version = rawConv.Info.Version
 	res.MaxMsgID = rawConv.ReaderInfo.MaxMsgid
+	res.ConvRetention = rawConv.ConvRetention
+	res.TeamRetention = rawConv.TeamRetention
 	return res
 }
 

--- a/go/client/cmd_chat_delete_history.go
+++ b/go/client/cmd_chat_delete_history.go
@@ -185,7 +185,7 @@ func (c *CmdChatDeleteHistory) chatSendDeleteHistory(ctx context.Context) error 
 		promptText = fmt.Sprintf("Permanently delete all chat messages in [%s] older than %v?\nHit Enter, or Ctrl-C to cancel.",
 			conversationInfo.TlfName, c.ageDesc)
 	}
-	_, err = c.G().UI.GetTerminalUI().Prompt(PromptDescriptorEnterChatMessage, promptText)
+	_, err = c.G().UI.GetTerminalUI().Prompt(PromptDescriptorChatDeleteHistory, promptText)
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_chat_retention.go
+++ b/go/client/cmd_chat_retention.go
@@ -1,0 +1,389 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	gregor1 "github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+type CmdChatSetRetention struct {
+	libkb.Contextified
+	resolvingRequest chatConversationResolvingRequest
+	policy           *chat1.RetentionPolicy
+
+	setPolicy  *chat1.RetentionPolicy
+	setChannel bool // whether to set team-wide or just channel
+}
+
+func NewCmdChatSetRetentionRunner(g *libkb.GlobalContext) *CmdChatSetRetention {
+	return &CmdChatSetRetention{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatSetRetention(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "retention-policy",
+		Usage: "Manage the chat retention policy for a conversation or team",
+		Examples: `
+View the policy for a conversation or team:
+    keybase chat retention-policy patrick,mlsteele
+    keybase chat retention-policy keybasefriends
+    keybase chat retention-policy keybasefriends --channel '#general'
+
+Keep messages indefinitely:
+    keybase chat retention-policy patrick --keep
+
+Keep messages for a week:
+    keybase chat retention-policy patrick --age 1w
+
+Change the team-wide policy:
+    keybase chat retention-policy ateam --age 1y
+
+Use the team policy for this channel:
+    keybase chat retention-policy ateam --channel '#general' --inherit
+`,
+		ArgumentHelp: "[conversation]",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatSetRetentionRunner(g), "retention-policy", c)
+		},
+		Flags: append(getConversationResolverFlags(), []cli.Flag{
+			cli.BoolFlag{
+				Name:  "keep",
+				Usage: `Keep messages indefinitely`,
+			},
+			cli.StringFlag{
+				Name:  "age",
+				Usage: `Delete messages after one of [1d, 1w, 30d, 3m, 1y]`,
+			},
+			cli.BoolFlag{
+				Name:  "inherit",
+				Usage: `Use the team's policy for a channel`,
+			},
+		}...),
+	}
+}
+
+func (c *CmdChatSetRetention) Run() (err error) {
+	if c.resolvingRequest.TlfName != "" {
+		err = annotateResolvingRequest(c.G(), &c.resolvingRequest)
+		if err != nil {
+			return err
+		}
+	}
+	// TLFVisibility_ANY doesn't make any sense for send, so switch that to PRIVATE:
+	if c.resolvingRequest.Visibility == keybase1.TLFVisibility_ANY {
+		c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
+	}
+
+	if c.G().Standalone {
+		switch c.resolvingRequest.MembersType {
+		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE:
+			c.G().StartStandaloneChat()
+		default:
+			err = CantRunInStandaloneError{}
+			return err
+		}
+	}
+
+	conv, err := c.resolve(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	if c.setPolicy != nil {
+		err = c.postPolicy(context.TODO(), conv, *c.setPolicy, c.setChannel)
+		if err != nil {
+			return err
+		}
+		// Reload the conv to show the new setting.
+		conv, err = c.resolve(context.TODO())
+		if err != nil {
+			return err
+		}
+	}
+
+	switch conv.Info.MembersType {
+	case chat1.ConversationMembersType_TEAM:
+		return c.showTeamChannel(conv)
+	default:
+		return c.showNonTeamConv(conv)
+	}
+}
+
+func (c *CmdChatSetRetention) ParseArgv(ctx *cli.Context) (err error) {
+	var tlfName string
+	// Get the TLF name from the first position arg
+	if len(ctx.Args()) < 1 {
+		return fmt.Errorf("conversation or team name required")
+	}
+	if len(ctx.Args()) >= 1 {
+		tlfName = ctx.Args().Get(0)
+	}
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+		return err
+	}
+
+	var age gregor1.DurationSec
+	var keep bool
+	var inherit bool
+	var exclusiveChoices []string
+	if timeStr := ctx.String("age"); len(timeStr) > 0 {
+		age, err = c.parseAgeLimited(timeStr)
+		if err != nil {
+			return err
+		}
+		exclusiveChoices = append(exclusiveChoices, "age")
+	}
+	keep = ctx.Bool("keep")
+	if keep {
+		exclusiveChoices = append(exclusiveChoices, "keep")
+	}
+	inherit = ctx.Bool("inherit")
+	if inherit {
+		exclusiveChoices = append(exclusiveChoices, "inherit")
+	}
+	if len(exclusiveChoices) > 1 {
+		return fmt.Errorf("only one of [%v] allowed", strings.Join(exclusiveChoices, ", "))
+	}
+	if len(exclusiveChoices) > 0 {
+		var p chat1.RetentionPolicy
+		if inherit {
+			p = chat1.NewRetentionPolicyWithInherit(chat1.RpInherit{})
+		} else if keep {
+			p = chat1.NewRetentionPolicyWithRetain(chat1.RpRetain{})
+		} else {
+			p = chat1.NewRetentionPolicyWithExpire(chat1.RpExpire{
+				Age: age,
+			})
+		}
+		c.setPolicy = &p
+		c.setChannel = len(ctx.String("channel")) > 0
+	}
+
+	return nil
+}
+
+func (c *CmdChatSetRetention) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}
+
+func (c *CmdChatSetRetention) resolve(ctx context.Context) (*chat1.ConversationLocal, error) {
+	resolver, err := newChatConversationResolver(c.G())
+	if err != nil {
+		return nil, err
+	}
+	conv, _, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
+		CreateIfNotExists: false,
+		MustNotExist:      false,
+		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	})
+	return conv, err
+}
+
+func (c *CmdChatSetRetention) postPolicy(ctx context.Context, conv *chat1.ConversationLocal, policy chat1.RetentionPolicy, setChannel bool) (err error) {
+	lcli, err := GetChatLocalClient(c.G())
+	if err != nil {
+		return err
+	}
+	teamInvolved := (conv.Info.MembersType == chat1.ConversationMembersType_TEAM)
+	teamWide := teamInvolved && !setChannel
+
+	promptText := fmt.Sprintf("Set the conversation retention policy?\nHit Enter, or Ctrl-C to cancel.")
+	if teamInvolved {
+		promptText = fmt.Sprintf("Set the channel retention policy?\nHit Enter, or Ctrl-C to cancel.")
+	}
+	if teamWide {
+		promptText = fmt.Sprintf("Set the team-wide retention policy?\nHit Enter, or Ctrl-C to cancel.")
+	}
+	_, err = c.G().UI.GetTerminalUI().Prompt(PromptDescriptorChatSetRetention, promptText)
+	if err != nil {
+		return err
+	}
+
+	if teamWide {
+		teamID, err := keybase1.TeamIDFromString(conv.Info.Triple.Tlfid.String())
+		if err != nil {
+			return err
+		}
+		return lcli.SetTeamRetentionLocal(ctx, chat1.SetTeamRetentionLocalArg{
+			TeamID: teamID,
+			Policy: policy})
+	}
+	return lcli.SetConvRetentionLocal(ctx, chat1.SetConvRetentionLocalArg{
+		ConvID: conv.Info.Id,
+		Policy: policy})
+}
+
+// Show a non-team conv policy
+func (c *CmdChatSetRetention) showNonTeamConv(conv *chat1.ConversationLocal) (err error) {
+	dui := c.G().UI.GetDumbOutputUI()
+	if conv.TeamRetention != nil {
+		c.println(dui, "Unexpected team policy set on non-team conversation.\n")
+	}
+	rpType := chat1.RetentionPolicyType_NONE
+	if conv.ConvRetention != nil {
+		rpType, err = conv.ConvRetention.Typ()
+		if err != nil {
+			c.println(dui, "Unrecognized retention policy: %v\n", err)
+			return errUnrecoginzedPolicy
+		}
+	}
+	switch rpType {
+	case chat1.RetentionPolicyType_NONE:
+		c.println(dui, "%v%v", rpRetainMsg, rpDefaultMsg)
+	case chat1.RetentionPolicyType_RETAIN:
+		c.println(dui, rpRetainMsg)
+	case chat1.RetentionPolicyType_EXPIRE:
+		c.println(dui, rpExpireMsg, c.formatExpire(conv.ConvRetention.Expire().Age))
+	case chat1.RetentionPolicyType_INHERIT:
+		c.println(dui, "Unrecognized policy 'inherit'")
+		return errUnrecoginzedPolicy
+	default:
+		c.println(dui, "Unregonized policy type '%v'", rpType)
+		return errUnrecoginzedPolicy
+	}
+	return nil
+}
+
+func (c *CmdChatSetRetention) showTeamChannel(conv *chat1.ConversationLocal) error {
+	return libkb.PickFirstError(
+		c.showTeamChannelHTeam(conv),
+		c.showTeamChannelHChannel(conv))
+}
+
+// Show the team policy
+func (c *CmdChatSetRetention) showTeamChannelHTeam(conv *chat1.ConversationLocal) (err error) {
+	dui := c.G().UI.GetDumbOutputUI()
+	rpType := chat1.RetentionPolicyType_NONE
+	if conv.TeamRetention != nil {
+		rpType, err = conv.TeamRetention.Typ()
+		if err != nil {
+			c.println(dui, "Unrecognized team retention policy: %v\n", err)
+			return errUnrecoginzedPolicy
+		}
+	}
+	var desc string
+	switch rpType {
+	case chat1.RetentionPolicyType_NONE:
+		desc = fmt.Sprintf("%v%v", rpRetainMsg, rpDefaultMsg)
+	case chat1.RetentionPolicyType_RETAIN:
+		desc = rpRetainMsg
+	case chat1.RetentionPolicyType_EXPIRE:
+		desc = fmt.Sprintf(rpExpireMsg, c.formatExpire(conv.TeamRetention.Expire().Age))
+	case chat1.RetentionPolicyType_INHERIT:
+		c.println(dui, "Unrecognized policy 'inherit'")
+		return errUnrecoginzedPolicy
+	default:
+		c.println(dui, "Unregonized policy type '%v'", rpType)
+		return errUnrecoginzedPolicy
+	}
+	c.println(dui, "Team policy: %v", desc)
+	return nil
+}
+
+// Show the channel's policy
+func (c *CmdChatSetRetention) showTeamChannelHChannel(conv *chat1.ConversationLocal) (err error) {
+	dui := c.G().UI.GetDumbOutputUI()
+	rpType := chat1.RetentionPolicyType_NONE
+	if conv.ConvRetention != nil {
+		rpType, err = conv.ConvRetention.Typ()
+		if err != nil {
+			c.println(dui, "Unrecognized team retention policy: %v\n", err)
+			return errUnrecoginzedPolicy
+		}
+	}
+	var desc string
+	switch rpType {
+	case chat1.RetentionPolicyType_NONE:
+		desc = fmt.Sprintf("%v%v", rpInheritMsg, rpDefaultMsg)
+	case chat1.RetentionPolicyType_RETAIN:
+		desc = rpRetainMsg
+	case chat1.RetentionPolicyType_EXPIRE:
+		desc = fmt.Sprintf(rpExpireMsg, c.formatExpire(conv.ConvRetention.Expire().Age))
+	case chat1.RetentionPolicyType_INHERIT:
+		desc = rpInheritMsg
+	default:
+		c.println(dui, "Unregonized policy type '%v'", rpType)
+		return errUnrecoginzedPolicy
+	}
+	c.println(dui, "#%v channel: %v", conv.Info.TopicName, desc)
+	return nil
+}
+
+func (c *CmdChatSetRetention) formatExpire(age gregor1.DurationSec) string {
+	if age < 0 {
+		return "negative age"
+	}
+	if age == 0 {
+		return "0 seconds"
+	}
+	stage := func(acc int64, part int64) (acc2 int64, nParts int64) {
+		nParts = acc / part
+		return acc - (nParts * part), nParts
+	}
+	acc, days := stage(int64(age), 86400)
+	acc, hours := stage(acc, 3600)
+	acc, minutes := stage(acc, 60)
+	seconds := acc
+	s := ""
+	if days > 0 {
+		s = fmt.Sprintf("%v days", days)
+	}
+	if hours > 0 {
+		s = fmt.Sprintf("%v %v hours", s, hours)
+	}
+	if minutes > 0 {
+		s = fmt.Sprintf("%v %v minutes", s, minutes)
+	}
+	if seconds > 0 {
+		s = fmt.Sprintf("%v %v seconds", s, seconds)
+	}
+	return strings.TrimSpace(s)
+}
+
+// Parse an age string from a limited set of choices
+func (c *CmdChatSetRetention) parseAgeLimited(s string) (gregor1.DurationSec, error) {
+	var d time.Duration
+	switch s {
+	case "1d", "24h":
+		d = 24 * time.Hour
+	case "7d", "1w":
+		d = 7 * 24 * time.Hour
+	case "30d", "1m":
+		d = 30 * 24 * time.Hour
+	case "3m":
+		d = 90 * 24 * time.Hour
+	case "12m", "1y":
+		d = 365 * 24 * time.Hour
+	default:
+		return 0, fmt.Errorf("invalid expiration age")
+	}
+	return gregor1.DurationSec(d.Seconds()), nil
+}
+
+func (c *CmdChatSetRetention) println(dui libkb.DumbOutputUI, format string, args ...interface{}) {
+	dui.Printf(fmt.Sprintf(format, args...) + "\n")
+}
+
+const rpRetainMsg = "Keep messages"
+const rpExpireMsg = "Delete messages after %v"
+const rpInheritMsg = "Use team policy"
+const rpDefaultMsg = " (default)"
+
+var errUnrecoginzedPolicy = errors.New("Unrecognized retention policy")

--- a/go/client/cmd_chat_retention.go
+++ b/go/client/cmd_chat_retention.go
@@ -342,17 +342,24 @@ func (c *CmdChatSetRetention) formatExpire(age gregor1.DurationSec) string {
 	acc, minutes := stage(acc, 60)
 	seconds := acc
 	s := ""
+	appendPlural := func(n int64, name string) {
+		suffix := ""
+		if n != 1 {
+			suffix = "s"
+		}
+		s = fmt.Sprintf("%v %v %v%v", s, n, name, suffix)
+	}
 	if days > 0 {
-		s = fmt.Sprintf("%v days", days)
+		appendPlural(days, "day")
 	}
 	if hours > 0 {
-		s = fmt.Sprintf("%v %v hours", s, hours)
+		appendPlural(hours, "hour")
 	}
 	if minutes > 0 {
-		s = fmt.Sprintf("%v %v minutes", s, minutes)
+		appendPlural(minutes, "minute")
 	}
 	if seconds > 0 {
-		s = fmt.Sprintf("%v %v seconds", s, seconds)
+		appendPlural(seconds, "second")
 	}
 	return strings.TrimSpace(s)
 }

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -39,6 +39,7 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 func getBuildSpecificChatCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
 	return []cli.Command{
 		newCmdChatDeleteHistoryDev(cl, g),
+		newCmdChatSetRetention(cl, g),
 	}
 }
 

--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -59,6 +59,8 @@ const (
 	PromptDescriptorRemoveMember
 	PromptDescriptorDeleteRootTeam
 	PromptDescriptorDeleteSubteam
+	PromptDescriptorChatDeleteHistory
+	PromptDescriptorChatSetRetention
 )
 
 const (

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1878,7 +1878,7 @@ type ChatClientError struct {
 }
 
 func (e ChatClientError) Error() string {
-	return fmt.Sprintf("error communicating with chat server: %s", e.Msg)
+	return fmt.Sprintf("error from chat server: %s", e.Msg)
 }
 
 //=============================================================================

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -159,6 +159,8 @@ type InboxUIItem struct {
 	CreatorInfo       *ConversationCreatorInfoLocal `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
 	Version           ConversationVers              `codec:"version" json:"version"`
 	MaxMsgID          MessageID                     `codec:"maxMsgID" json:"maxMsgID"`
+	ConvRetention     *RetentionPolicy              `codec:"convRetention,omitempty" json:"convRetention,omitempty"`
+	TeamRetention     *RetentionPolicy              `codec:"teamRetention,omitempty" json:"teamRetention,omitempty"`
 	FinalizeInfo      *ConversationFinalizeInfo     `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
 	Supersedes        []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
 	SupersededBy      []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
@@ -228,6 +230,20 @@ func (o InboxUIItem) DeepCopy() InboxUIItem {
 		})(o.CreatorInfo),
 		Version:  o.Version.DeepCopy(),
 		MaxMsgID: o.MaxMsgID.DeepCopy(),
+		ConvRetention: (func(x *RetentionPolicy) *RetentionPolicy {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.ConvRetention),
+		TeamRetention: (func(x *RetentionPolicy) *RetentionPolicy {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.TeamRetention),
 		FinalizeInfo: (func(x *ConversationFinalizeInfo) *ConversationFinalizeInfo {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -10,9 +10,10 @@ import (
 )
 
 type GenericPayload struct {
-	Action    string         `codec:"Action" json:"Action"`
-	InboxVers InboxVers      `codec:"inboxVers" json:"inboxVers"`
-	ConvID    ConversationID `codec:"convID" json:"convID"`
+	Action       string         `codec:"Action" json:"Action"`
+	InboxVers    InboxVers      `codec:"inboxVers" json:"inboxVers"`
+	ConvID       ConversationID `codec:"convID" json:"convID"`
+	UnreadUpdate *UnreadUpdate  `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
 func (o GenericPayload) DeepCopy() GenericPayload {
@@ -20,6 +21,13 @@ func (o GenericPayload) DeepCopy() GenericPayload {
 		Action:    o.Action,
 		InboxVers: o.InboxVers.DeepCopy(),
 		ConvID:    o.ConvID.DeepCopy(),
+		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.UnreadUpdate),
 	}
 }
 
@@ -154,10 +162,11 @@ func (o TeamTypePayload) DeepCopy() TeamTypePayload {
 }
 
 type SetAppNotificationSettingsPayload struct {
-	Action    string                       `codec:"Action" json:"Action"`
-	ConvID    ConversationID               `codec:"convID" json:"convID"`
-	InboxVers InboxVers                    `codec:"inboxVers" json:"inboxVers"`
-	Settings  ConversationNotificationInfo `codec:"settings" json:"settings"`
+	Action       string                       `codec:"Action" json:"Action"`
+	ConvID       ConversationID               `codec:"convID" json:"convID"`
+	InboxVers    InboxVers                    `codec:"inboxVers" json:"inboxVers"`
+	Settings     ConversationNotificationInfo `codec:"settings" json:"settings"`
+	UnreadUpdate *UnreadUpdate                `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
 func (o SetAppNotificationSettingsPayload) DeepCopy() SetAppNotificationSettingsPayload {
@@ -166,6 +175,13 @@ func (o SetAppNotificationSettingsPayload) DeepCopy() SetAppNotificationSettings
 		ConvID:    o.ConvID.DeepCopy(),
 		InboxVers: o.InboxVers.DeepCopy(),
 		Settings:  o.Settings.DeepCopy(),
+		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.UnreadUpdate),
 	}
 }
 
@@ -338,28 +354,28 @@ func (o TeamChannelUpdate) DeepCopy() TeamChannelUpdate {
 	}
 }
 
-type ConvRetentionUpdate struct {
+type SetConvRetentionUpdate struct {
 	InboxVers InboxVers       `codec:"inboxVers" json:"inboxVers"`
 	ConvID    ConversationID  `codec:"convID" json:"convID"`
 	Policy    RetentionPolicy `codec:"policy" json:"policy"`
 }
 
-func (o ConvRetentionUpdate) DeepCopy() ConvRetentionUpdate {
-	return ConvRetentionUpdate{
+func (o SetConvRetentionUpdate) DeepCopy() SetConvRetentionUpdate {
+	return SetConvRetentionUpdate{
 		InboxVers: o.InboxVers.DeepCopy(),
 		ConvID:    o.ConvID.DeepCopy(),
 		Policy:    o.Policy.DeepCopy(),
 	}
 }
 
-type TeamRetentionUpdate struct {
+type SetTeamRetentionUpdate struct {
 	InboxVers InboxVers       `codec:"inboxVers" json:"inboxVers"`
 	TeamID    keybase1.TeamID `codec:"teamID" json:"teamID"`
 	Policy    RetentionPolicy `codec:"policy" json:"policy"`
 }
 
-func (o TeamRetentionUpdate) DeepCopy() TeamRetentionUpdate {
-	return TeamRetentionUpdate{
+func (o SetTeamRetentionUpdate) DeepCopy() SetTeamRetentionUpdate {
+	return SetTeamRetentionUpdate{
 		InboxVers: o.InboxVers.DeepCopy(),
 		TeamID:    o.TeamID.DeepCopy(),
 		Policy:    o.Policy.DeepCopy(),

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2609,6 +2609,9 @@ type ConversationLocal struct {
 	MaxMessages      []MessageUnboxed              `codec:"maxMessages" json:"maxMessages"`
 	IsEmpty          bool                          `codec:"isEmpty" json:"isEmpty"`
 	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identifyFailures"`
+	Expunge          Expunge                       `codec:"expunge" json:"expunge"`
+	ConvRetention    *RetentionPolicy              `codec:"convRetention,omitempty" json:"convRetention,omitempty"`
+	TeamRetention    *RetentionPolicy              `codec:"teamRetention,omitempty" json:"teamRetention,omitempty"`
 }
 
 func (o ConversationLocal) DeepCopy() ConversationLocal {
@@ -2681,6 +2684,21 @@ func (o ConversationLocal) DeepCopy() ConversationLocal {
 			}
 			return ret
 		})(o.IdentifyFailures),
+		Expunge: o.Expunge.DeepCopy(),
+		ConvRetention: (func(x *RetentionPolicy) *RetentionPolicy {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.ConvRetention),
+		TeamRetention: (func(x *RetentionPolicy) *RetentionPolicy {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.TeamRetention),
 	}
 }
 

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -674,6 +674,18 @@ type ChatInboxSyncedArg struct {
 	SyncRes ChatSyncResult `codec:"syncRes" json:"syncRes"`
 }
 
+type ChatSetConvRetentionArg struct {
+	Uid    keybase1.UID   `codec:"uid" json:"uid"`
+	ConvID ConversationID `codec:"convID" json:"convID"`
+	Conv   *InboxUIItem   `codec:"conv,omitempty" json:"conv,omitempty"`
+}
+
+type ChatSetTeamRetentionArg struct {
+	Uid    keybase1.UID    `codec:"uid" json:"uid"`
+	TeamID keybase1.TeamID `codec:"teamID" json:"teamID"`
+	Convs  []InboxUIItem   `codec:"convs" json:"convs"`
+}
+
 type NotifyChatInterface interface {
 	NewChatActivity(context.Context, NewChatActivityArg) error
 	ChatIdentifyUpdate(context.Context, keybase1.CanonicalTLFNameAndIDWithBreaks) error
@@ -687,6 +699,8 @@ type NotifyChatInterface interface {
 	ChatResetConversation(context.Context, ChatResetConversationArg) error
 	ChatInboxSyncStarted(context.Context, keybase1.UID) error
 	ChatInboxSynced(context.Context, ChatInboxSyncedArg) error
+	ChatSetConvRetention(context.Context, ChatSetConvRetentionArg) error
+	ChatSetTeamRetention(context.Context, ChatSetTeamRetentionArg) error
 }
 
 func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
@@ -885,6 +899,38 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodNotify,
 			},
+			"ChatSetConvRetention": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatSetConvRetentionArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatSetConvRetentionArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatSetConvRetentionArg)(nil), args)
+						return
+					}
+					err = i.ChatSetConvRetention(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodNotify,
+			},
+			"ChatSetTeamRetention": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatSetTeamRetentionArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatSetTeamRetentionArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatSetTeamRetentionArg)(nil), args)
+						return
+					}
+					err = i.ChatSetTeamRetention(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodNotify,
+			},
 		},
 	}
 }
@@ -954,5 +1000,15 @@ func (c NotifyChatClient) ChatInboxSyncStarted(ctx context.Context, uid keybase1
 
 func (c NotifyChatClient) ChatInboxSynced(ctx context.Context, __arg ChatInboxSyncedArg) (err error) {
 	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatInboxSynced", []interface{}{__arg})
+	return
+}
+
+func (c NotifyChatClient) ChatSetConvRetention(ctx context.Context, __arg ChatSetConvRetentionArg) (err error) {
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatSetConvRetention", []interface{}{__arg})
+	return
+}
+
+func (c NotifyChatClient) ChatSetTeamRetention(ctx context.Context, __arg ChatSetTeamRetentionArg) (err error) {
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatSetTeamRetention", []interface{}{__arg})
 	return
 }

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -61,6 +61,8 @@ protocol chatUi {
     union { null, ConversationCreatorInfoLocal } creatorInfo;
     ConversationVers version;
     MessageID maxMsgID;
+    union { null, RetentionPolicy } convRetention;
+    union { null, RetentionPolicy } teamRetention;
 
     // Finalized convo stuff (KBFS only)
     union { null, ConversationFinalizeInfo } finalizeInfo;

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -9,6 +9,7 @@ protocol gregor {
         string Action;
         InboxVers inboxVers;
         ConversationID convID;
+        union { null, UnreadUpdate } unreadUpdate;
     }
 
     record NewConversationPayload {
@@ -64,6 +65,7 @@ protocol gregor {
         ConversationID convID;
         InboxVers inboxVers;
         ConversationNotificationInfo settings;
+        union { null, UnreadUpdate } unreadUpdate;
     }
 
     record UnreadUpdate {
@@ -111,13 +113,13 @@ protocol gregor {
         TLFID teamID;
     }
 
-    record ConvRetentionUpdate {
+    record SetConvRetentionUpdate {
         InboxVers inboxVers;
         ConversationID convID;
         RetentionPolicy policy;
     }
 
-    record TeamRetentionUpdate {
+    record SetTeamRetentionUpdate {
         InboxVers inboxVers;
         keybase1.TeamID teamID;
         RetentionPolicy policy;
@@ -127,4 +129,5 @@ protocol gregor {
         ConversationID convID;
         InboxVers inboxVers;
     }
+
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -478,6 +478,10 @@ protocol local {
     // This field, if null or empty, indicates identify succeeded without any
     // break.
     array<keybase1.TLFIdentifyFailure> identifyFailures;
+
+    Expunge expunge; // The latest history deletion. Defaults to zeroes.
+    union { null, RetentionPolicy } convRetention;
+    union { null, RetentionPolicy } teamRetention;
   }
 
   record NonblockFetchRes {

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -154,4 +154,12 @@ protocol NotifyChat {
   @lint("ignore")
   void ChatInboxSynced(keybase1.UID uid, ChatSyncResult syncRes);
 
+  @notify("")
+  @lint("ignore")
+  void ChatSetConvRetention(keybase1.UID uid, ConversationID convID, union { null, InboxUIItem } conv);
+
+  @notify("")
+  @lint("ignore")
+  void ChatSetTeamRetention(keybase1.UID uid, keybase1.TeamID teamID, array<InboxUIItem> convs);
+
 }

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -624,8 +624,6 @@ export type ChatUiChatThreadCachedRpcParam = $ReadOnly<{thread?: ?String, incomi
 
 export type ChatUiChatThreadFullRpcParam = $ReadOnly<{thread: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type ConvRetentionUpdate = $ReadOnly<{inboxVers: InboxVers, convID: ConversationID, policy: RetentionPolicy}>
-
 export type ConvTypingUpdate = $ReadOnly<{convID: ConversationID, typers?: ?Array<TyperInfo>}>
 
 export type Conversation = $ReadOnly<{metadata: ConversationMetadata, readerInfo?: ?ConversationReaderInfo, notifications?: ?ConversationNotificationInfo, maxMsgs?: ?Array<MessageBoxed>, maxMsgSummaries?: ?Array<MessageSummary>, creatorInfo?: ?ConversationCreatorInfo, expunge: Expunge, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy}>
@@ -664,7 +662,7 @@ export type ConversationIDTriple = $ReadOnly<{tlfid: TLFID, topicType: TopicType
 
 export type ConversationInfoLocal = $ReadOnly<{id: ConversationID, triple: ConversationIDTriple, tlfName: String, topicName: String, visibility: Keybase1.TLFVisibility, status: ConversationStatus, membersType: ConversationMembersType, memberStatus: ConversationMemberStatus, teamType: TeamType, existence: ConversationExistence, version: ConversationVers, participants?: ?Array<ConversationLocalParticipant>, finalizeInfo?: ?ConversationFinalizeInfo, resetNames?: ?Array<String>}>
 
-export type ConversationLocal = $ReadOnly<{error?: ?ConversationErrorLocal, info: ConversationInfoLocal, readerInfo: ConversationReaderInfo, creatorInfo?: ?ConversationCreatorInfoLocal, notifications?: ?ConversationNotificationInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>, maxMessages?: ?Array<MessageUnboxed>, isEmpty: Boolean, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
+export type ConversationLocal = $ReadOnly<{error?: ?ConversationErrorLocal, info: ConversationInfoLocal, readerInfo: ConversationReaderInfo, creatorInfo?: ?ConversationCreatorInfoLocal, notifications?: ?ConversationNotificationInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>, maxMessages?: ?Array<MessageUnboxed>, isEmpty: Boolean, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>, expunge: Expunge, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy}>
 
 export type ConversationLocalParticipant = $ReadOnly<{username: String, fullname?: ?String}>
 
@@ -717,7 +715,7 @@ export type FailedMessageInfo = $ReadOnly<{outboxRecords?: ?Array<OutboxRecord>}
 
 export type FindConversationsLocalRes = $ReadOnly<{conversations?: ?Array<ConversationLocal>, offline: Boolean, rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 
-export type GenericPayload = $ReadOnly<{Action: String, inboxVers: InboxVers, convID: ConversationID}>
+export type GenericPayload = $ReadOnly<{Action: String, inboxVers: InboxVers, convID: ConversationID, unreadUpdate?: ?UnreadUpdate}>
 
 export type GetConversationForCLILocalQuery = $ReadOnly<{markAsRead: Boolean, MessageTypes?: ?Array<MessageType>, Since?: ?String, limit: UnreadFirstNumLimit, conv: ConversationLocal}>
 
@@ -792,7 +790,7 @@ export type InboxResType =
   | 0 // VERSIONHIT_0
   | 1 // FULL_1
 
-export type InboxUIItem = $ReadOnly<{convID: String, isEmpty: Boolean, name: String, snippet: String, channel: String, headline: String, visibility: Keybase1.TLFVisibility, participants?: ?Array<String>, fullNames: {[key: string]: String}, resetParticipants?: ?Array<String>, status: ConversationStatus, membersType: ConversationMembersType, memberStatus: ConversationMemberStatus, teamType: TeamType, time: Gregor1.Time, notifications?: ?ConversationNotificationInfo, creatorInfo?: ?ConversationCreatorInfoLocal, version: ConversationVers, maxMsgID: MessageID, finalizeInfo?: ?ConversationFinalizeInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>}>
+export type InboxUIItem = $ReadOnly<{convID: String, isEmpty: Boolean, name: String, snippet: String, channel: String, headline: String, visibility: Keybase1.TLFVisibility, participants?: ?Array<String>, fullNames: {[key: string]: String}, resetParticipants?: ?Array<String>, status: ConversationStatus, membersType: ConversationMembersType, memberStatus: ConversationMemberStatus, teamType: TeamType, time: Gregor1.Time, notifications?: ?ConversationNotificationInfo, creatorInfo?: ?ConversationCreatorInfoLocal, version: ConversationVers, maxMsgID: MessageID, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy, finalizeInfo?: ?ConversationFinalizeInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>}>
 
 export type InboxUIItems = $ReadOnly<{items?: ?Array<InboxUIItem>, pagination?: ?UIPagination, offline: Boolean}>
 
@@ -1045,6 +1043,10 @@ export type NotifyChatChatLeftConversationRpcParam = $ReadOnly<{uid: Keybase1.UI
 
 export type NotifyChatChatResetConversationRpcParam = $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type NotifyChatChatSetConvRetentionRpcParam = $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, conv?: ?InboxUIItem, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type NotifyChatChatSetTeamRetentionRpcParam = $ReadOnly<{uid: Keybase1.UID, teamID: Keybase1.TeamID, convs?: ?Array<InboxUIItem>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type NotifyChatChatTLFFinalizeRpcParam = $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, finalizeInfo: ConversationFinalizeInfo, conv?: ?InboxUIItem, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type NotifyChatChatTLFResolveRpcParam = $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, resolveInfo: ConversationResolveInfo, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -1185,9 +1187,11 @@ export type SetAppNotificationSettingsInfo = $ReadOnly<{convID: ConversationID, 
 
 export type SetAppNotificationSettingsLocalRes = $ReadOnly<{offline: Boolean, rateLimits?: ?Array<RateLimit>}>
 
-export type SetAppNotificationSettingsPayload = $ReadOnly<{Action: String, convID: ConversationID, inboxVers: InboxVers, settings: ConversationNotificationInfo}>
+export type SetAppNotificationSettingsPayload = $ReadOnly<{Action: String, convID: ConversationID, inboxVers: InboxVers, settings: ConversationNotificationInfo, unreadUpdate?: ?UnreadUpdate}>
 
 export type SetAppNotificationSettingsRes = $ReadOnly<{rateLimit?: ?RateLimit}>
+
+export type SetConvRetentionUpdate = $ReadOnly<{inboxVers: InboxVers, convID: ConversationID, policy: RetentionPolicy}>
 
 export type SetConversationStatusLocalRes = $ReadOnly<{rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 
@@ -1198,6 +1202,8 @@ export type SetRetentionRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 export type SetStatusInfo = $ReadOnly<{convID: ConversationID, status: ConversationStatus, conv?: ?InboxUIItem}>
 
 export type SetStatusPayload = $ReadOnly<{Action: String, convID: ConversationID, status: ConversationStatus, inboxVers: InboxVers, unreadUpdate?: ?UnreadUpdate}>
+
+export type SetTeamRetentionUpdate = $ReadOnly<{inboxVers: InboxVers, teamID: Keybase1.TeamID, policy: RetentionPolicy}>
 
 export type SignEncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
@@ -1239,8 +1245,6 @@ export type TLFID = Bytes
 export type TLFResolveUpdate = $ReadOnly<{convID: ConversationID, inboxVers: InboxVers}>
 
 export type TeamChannelUpdate = $ReadOnly<{teamID: TLFID}>
-
-export type TeamRetentionUpdate = $ReadOnly<{inboxVers: InboxVers, teamID: Keybase1.TeamID, policy: RetentionPolicy}>
 
 export type TeamType =
   | 0 // NONE_0
@@ -1359,4 +1363,4 @@ type RemoteSyncAllResult = SyncAllResult
 type RemoteSyncChatResult = SyncChatRes
 type RemoteSyncInboxResult = SyncInboxRes
 
-export type IncomingCallMapType = {'keybase.1.chatUi.chatAttachmentUploadOutboxID'?: (params: $ReadOnly<{sessionID: Int, outboxID: OutboxID}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadStart'?: (params: $ReadOnly<{sessionID: Int, metadata: AssetMetadata, placeholderMsgID: MessageID}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadProgress'?: (params: $ReadOnly<{sessionID: Int, bytesComplete: Long, bytesTotal: Long}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentPreviewUploadStart'?: (params: $ReadOnly<{sessionID: Int, metadata: AssetMetadata}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentPreviewUploadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadStart'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadProgress'?: (params: $ReadOnly<{sessionID: Int, bytesComplete: Long, bytesTotal: Long}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxUnverified'?: (params: $ReadOnly<{sessionID: Int, inbox: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxConversation'?: (params: $ReadOnly<{sessionID: Int, conv: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxFailed'?: (params: $ReadOnly<{sessionID: Int, convID: ConversationID, error: ConversationErrorLocal}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatThreadCached'?: (params: $ReadOnly<{sessionID: Int, thread?: ?String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatThreadFull'?: (params: $ReadOnly<{sessionID: Int, thread: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatConfirmChannelDelete'?: (params: $ReadOnly<{sessionID: Int, channel: String}>, response: {error: RPCErrorHandler, result: (result: ChatUiChatConfirmChannelDeleteResult) => void}) => void, 'keybase.1.NotifyChat.NewChatActivity'?: (params: $ReadOnly<{uid: Keybase1.UID, activity: ChatActivity}>) => void, 'keybase.1.NotifyChat.ChatIdentifyUpdate'?: (params: $ReadOnly<{update: Keybase1.CanonicalTLFNameAndIDWithBreaks}>) => void, 'keybase.1.NotifyChat.ChatTLFFinalize'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, finalizeInfo: ConversationFinalizeInfo, conv?: ?InboxUIItem}>) => void, 'keybase.1.NotifyChat.ChatTLFResolve'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, resolveInfo: ConversationResolveInfo}>) => void, 'keybase.1.NotifyChat.ChatInboxStale'?: (params: $ReadOnly<{uid: Keybase1.UID}>) => void, 'keybase.1.NotifyChat.ChatThreadsStale'?: (params: $ReadOnly<{uid: Keybase1.UID, updates?: ?Array<ConversationStaleUpdate>}>) => void, 'keybase.1.NotifyChat.ChatTypingUpdate'?: (params: $ReadOnly<{typingUpdates?: ?Array<ConvTypingUpdate>}>) => void, 'keybase.1.NotifyChat.ChatJoinedConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, conv: InboxUIItem}>) => void, 'keybase.1.NotifyChat.ChatLeftConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID}>) => void, 'keybase.1.NotifyChat.ChatResetConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID}>) => void, 'keybase.1.NotifyChat.ChatInboxSyncStarted'?: (params: $ReadOnly<{uid: Keybase1.UID}>) => void, 'keybase.1.NotifyChat.ChatInboxSynced'?: (params: $ReadOnly<{uid: Keybase1.UID, syncRes: ChatSyncResult}>) => void}
+export type IncomingCallMapType = {'keybase.1.chatUi.chatAttachmentUploadOutboxID'?: (params: $ReadOnly<{sessionID: Int, outboxID: OutboxID}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadStart'?: (params: $ReadOnly<{sessionID: Int, metadata: AssetMetadata, placeholderMsgID: MessageID}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadProgress'?: (params: $ReadOnly<{sessionID: Int, bytesComplete: Long, bytesTotal: Long}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentPreviewUploadStart'?: (params: $ReadOnly<{sessionID: Int, metadata: AssetMetadata}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentPreviewUploadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadStart'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadProgress'?: (params: $ReadOnly<{sessionID: Int, bytesComplete: Long, bytesTotal: Long}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxUnverified'?: (params: $ReadOnly<{sessionID: Int, inbox: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxConversation'?: (params: $ReadOnly<{sessionID: Int, conv: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxFailed'?: (params: $ReadOnly<{sessionID: Int, convID: ConversationID, error: ConversationErrorLocal}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatThreadCached'?: (params: $ReadOnly<{sessionID: Int, thread?: ?String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatThreadFull'?: (params: $ReadOnly<{sessionID: Int, thread: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatConfirmChannelDelete'?: (params: $ReadOnly<{sessionID: Int, channel: String}>, response: {error: RPCErrorHandler, result: (result: ChatUiChatConfirmChannelDeleteResult) => void}) => void, 'keybase.1.NotifyChat.NewChatActivity'?: (params: $ReadOnly<{uid: Keybase1.UID, activity: ChatActivity}>) => void, 'keybase.1.NotifyChat.ChatIdentifyUpdate'?: (params: $ReadOnly<{update: Keybase1.CanonicalTLFNameAndIDWithBreaks}>) => void, 'keybase.1.NotifyChat.ChatTLFFinalize'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, finalizeInfo: ConversationFinalizeInfo, conv?: ?InboxUIItem}>) => void, 'keybase.1.NotifyChat.ChatTLFResolve'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, resolveInfo: ConversationResolveInfo}>) => void, 'keybase.1.NotifyChat.ChatInboxStale'?: (params: $ReadOnly<{uid: Keybase1.UID}>) => void, 'keybase.1.NotifyChat.ChatThreadsStale'?: (params: $ReadOnly<{uid: Keybase1.UID, updates?: ?Array<ConversationStaleUpdate>}>) => void, 'keybase.1.NotifyChat.ChatTypingUpdate'?: (params: $ReadOnly<{typingUpdates?: ?Array<ConvTypingUpdate>}>) => void, 'keybase.1.NotifyChat.ChatJoinedConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, conv: InboxUIItem}>) => void, 'keybase.1.NotifyChat.ChatLeftConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID}>) => void, 'keybase.1.NotifyChat.ChatResetConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID}>) => void, 'keybase.1.NotifyChat.ChatInboxSyncStarted'?: (params: $ReadOnly<{uid: Keybase1.UID}>) => void, 'keybase.1.NotifyChat.ChatInboxSynced'?: (params: $ReadOnly<{uid: Keybase1.UID, syncRes: ChatSyncResult}>) => void, 'keybase.1.NotifyChat.ChatSetConvRetention'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, conv?: ?InboxUIItem}>) => void, 'keybase.1.NotifyChat.ChatSetTeamRetention'?: (params: $ReadOnly<{uid: Keybase1.UID, teamID: Keybase1.TeamID, convs?: ?Array<InboxUIItem>}>) => void}

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -250,6 +250,20 @@
         {
           "type": [
             null,
+            "RetentionPolicy"
+          ],
+          "name": "convRetention"
+        },
+        {
+          "type": [
+            null,
+            "RetentionPolicy"
+          ],
+          "name": "teamRetention"
+        },
+        {
+          "type": [
+            null,
             "ConversationFinalizeInfo"
           ],
           "name": "finalizeInfo"

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -29,6 +29,13 @@
         {
           "type": "ConversationID",
           "name": "convID"
+        },
+        {
+          "type": [
+            null,
+            "UnreadUpdate"
+          ],
+          "name": "unreadUpdate"
         }
       ]
     },
@@ -205,6 +212,13 @@
         {
           "type": "ConversationNotificationInfo",
           "name": "settings"
+        },
+        {
+          "type": [
+            null,
+            "UnreadUpdate"
+          ],
+          "name": "unreadUpdate"
         }
       ]
     },
@@ -361,7 +375,7 @@
     },
     {
       "type": "record",
-      "name": "ConvRetentionUpdate",
+      "name": "SetConvRetentionUpdate",
       "fields": [
         {
           "type": "InboxVers",
@@ -379,7 +393,7 @@
     },
     {
       "type": "record",
-      "name": "TeamRetentionUpdate",
+      "name": "SetTeamRetentionUpdate",
       "fields": [
         {
           "type": "InboxVers",

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1410,6 +1410,24 @@
             "items": "keybase1.TLFIdentifyFailure"
           },
           "name": "identifyFailures"
+        },
+        {
+          "type": "Expunge",
+          "name": "expunge"
+        },
+        {
+          "type": [
+            null,
+            "RetentionPolicy"
+          ],
+          "name": "convRetention"
+        },
+        {
+          "type": [
+            null,
+            "RetentionPolicy"
+          ],
+          "name": "teamRetention"
         }
       ]
     },

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -534,6 +534,50 @@
       "response": null,
       "notify": "",
       "lint": "ignore"
+    },
+    "ChatSetConvRetention": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        },
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "conv",
+          "type": [
+            null,
+            "InboxUIItem"
+          ]
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
+    },
+    "ChatSetTeamRetention": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        },
+        {
+          "name": "teamID",
+          "type": "keybase1.TeamID"
+        },
+        {
+          "name": "convs",
+          "type": {
+            "type": "array",
+            "items": "InboxUIItem"
+          }
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
     }
   },
   "namespace": "chat.1"

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -624,8 +624,6 @@ export type ChatUiChatThreadCachedRpcParam = $ReadOnly<{thread?: ?String, incomi
 
 export type ChatUiChatThreadFullRpcParam = $ReadOnly<{thread: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type ConvRetentionUpdate = $ReadOnly<{inboxVers: InboxVers, convID: ConversationID, policy: RetentionPolicy}>
-
 export type ConvTypingUpdate = $ReadOnly<{convID: ConversationID, typers?: ?Array<TyperInfo>}>
 
 export type Conversation = $ReadOnly<{metadata: ConversationMetadata, readerInfo?: ?ConversationReaderInfo, notifications?: ?ConversationNotificationInfo, maxMsgs?: ?Array<MessageBoxed>, maxMsgSummaries?: ?Array<MessageSummary>, creatorInfo?: ?ConversationCreatorInfo, expunge: Expunge, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy}>
@@ -664,7 +662,7 @@ export type ConversationIDTriple = $ReadOnly<{tlfid: TLFID, topicType: TopicType
 
 export type ConversationInfoLocal = $ReadOnly<{id: ConversationID, triple: ConversationIDTriple, tlfName: String, topicName: String, visibility: Keybase1.TLFVisibility, status: ConversationStatus, membersType: ConversationMembersType, memberStatus: ConversationMemberStatus, teamType: TeamType, existence: ConversationExistence, version: ConversationVers, participants?: ?Array<ConversationLocalParticipant>, finalizeInfo?: ?ConversationFinalizeInfo, resetNames?: ?Array<String>}>
 
-export type ConversationLocal = $ReadOnly<{error?: ?ConversationErrorLocal, info: ConversationInfoLocal, readerInfo: ConversationReaderInfo, creatorInfo?: ?ConversationCreatorInfoLocal, notifications?: ?ConversationNotificationInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>, maxMessages?: ?Array<MessageUnboxed>, isEmpty: Boolean, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
+export type ConversationLocal = $ReadOnly<{error?: ?ConversationErrorLocal, info: ConversationInfoLocal, readerInfo: ConversationReaderInfo, creatorInfo?: ?ConversationCreatorInfoLocal, notifications?: ?ConversationNotificationInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>, maxMessages?: ?Array<MessageUnboxed>, isEmpty: Boolean, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>, expunge: Expunge, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy}>
 
 export type ConversationLocalParticipant = $ReadOnly<{username: String, fullname?: ?String}>
 
@@ -717,7 +715,7 @@ export type FailedMessageInfo = $ReadOnly<{outboxRecords?: ?Array<OutboxRecord>}
 
 export type FindConversationsLocalRes = $ReadOnly<{conversations?: ?Array<ConversationLocal>, offline: Boolean, rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 
-export type GenericPayload = $ReadOnly<{Action: String, inboxVers: InboxVers, convID: ConversationID}>
+export type GenericPayload = $ReadOnly<{Action: String, inboxVers: InboxVers, convID: ConversationID, unreadUpdate?: ?UnreadUpdate}>
 
 export type GetConversationForCLILocalQuery = $ReadOnly<{markAsRead: Boolean, MessageTypes?: ?Array<MessageType>, Since?: ?String, limit: UnreadFirstNumLimit, conv: ConversationLocal}>
 
@@ -792,7 +790,7 @@ export type InboxResType =
   | 0 // VERSIONHIT_0
   | 1 // FULL_1
 
-export type InboxUIItem = $ReadOnly<{convID: String, isEmpty: Boolean, name: String, snippet: String, channel: String, headline: String, visibility: Keybase1.TLFVisibility, participants?: ?Array<String>, fullNames: {[key: string]: String}, resetParticipants?: ?Array<String>, status: ConversationStatus, membersType: ConversationMembersType, memberStatus: ConversationMemberStatus, teamType: TeamType, time: Gregor1.Time, notifications?: ?ConversationNotificationInfo, creatorInfo?: ?ConversationCreatorInfoLocal, version: ConversationVers, maxMsgID: MessageID, finalizeInfo?: ?ConversationFinalizeInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>}>
+export type InboxUIItem = $ReadOnly<{convID: String, isEmpty: Boolean, name: String, snippet: String, channel: String, headline: String, visibility: Keybase1.TLFVisibility, participants?: ?Array<String>, fullNames: {[key: string]: String}, resetParticipants?: ?Array<String>, status: ConversationStatus, membersType: ConversationMembersType, memberStatus: ConversationMemberStatus, teamType: TeamType, time: Gregor1.Time, notifications?: ?ConversationNotificationInfo, creatorInfo?: ?ConversationCreatorInfoLocal, version: ConversationVers, maxMsgID: MessageID, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy, finalizeInfo?: ?ConversationFinalizeInfo, supersedes?: ?Array<ConversationMetadata>, supersededBy?: ?Array<ConversationMetadata>}>
 
 export type InboxUIItems = $ReadOnly<{items?: ?Array<InboxUIItem>, pagination?: ?UIPagination, offline: Boolean}>
 
@@ -1045,6 +1043,10 @@ export type NotifyChatChatLeftConversationRpcParam = $ReadOnly<{uid: Keybase1.UI
 
 export type NotifyChatChatResetConversationRpcParam = $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type NotifyChatChatSetConvRetentionRpcParam = $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, conv?: ?InboxUIItem, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type NotifyChatChatSetTeamRetentionRpcParam = $ReadOnly<{uid: Keybase1.UID, teamID: Keybase1.TeamID, convs?: ?Array<InboxUIItem>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type NotifyChatChatTLFFinalizeRpcParam = $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, finalizeInfo: ConversationFinalizeInfo, conv?: ?InboxUIItem, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type NotifyChatChatTLFResolveRpcParam = $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, resolveInfo: ConversationResolveInfo, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -1185,9 +1187,11 @@ export type SetAppNotificationSettingsInfo = $ReadOnly<{convID: ConversationID, 
 
 export type SetAppNotificationSettingsLocalRes = $ReadOnly<{offline: Boolean, rateLimits?: ?Array<RateLimit>}>
 
-export type SetAppNotificationSettingsPayload = $ReadOnly<{Action: String, convID: ConversationID, inboxVers: InboxVers, settings: ConversationNotificationInfo}>
+export type SetAppNotificationSettingsPayload = $ReadOnly<{Action: String, convID: ConversationID, inboxVers: InboxVers, settings: ConversationNotificationInfo, unreadUpdate?: ?UnreadUpdate}>
 
 export type SetAppNotificationSettingsRes = $ReadOnly<{rateLimit?: ?RateLimit}>
+
+export type SetConvRetentionUpdate = $ReadOnly<{inboxVers: InboxVers, convID: ConversationID, policy: RetentionPolicy}>
 
 export type SetConversationStatusLocalRes = $ReadOnly<{rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 
@@ -1198,6 +1202,8 @@ export type SetRetentionRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 export type SetStatusInfo = $ReadOnly<{convID: ConversationID, status: ConversationStatus, conv?: ?InboxUIItem}>
 
 export type SetStatusPayload = $ReadOnly<{Action: String, convID: ConversationID, status: ConversationStatus, inboxVers: InboxVers, unreadUpdate?: ?UnreadUpdate}>
+
+export type SetTeamRetentionUpdate = $ReadOnly<{inboxVers: InboxVers, teamID: Keybase1.TeamID, policy: RetentionPolicy}>
 
 export type SignEncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
@@ -1239,8 +1245,6 @@ export type TLFID = Bytes
 export type TLFResolveUpdate = $ReadOnly<{convID: ConversationID, inboxVers: InboxVers}>
 
 export type TeamChannelUpdate = $ReadOnly<{teamID: TLFID}>
-
-export type TeamRetentionUpdate = $ReadOnly<{inboxVers: InboxVers, teamID: Keybase1.TeamID, policy: RetentionPolicy}>
 
 export type TeamType =
   | 0 // NONE_0
@@ -1359,4 +1363,4 @@ type RemoteSyncAllResult = SyncAllResult
 type RemoteSyncChatResult = SyncChatRes
 type RemoteSyncInboxResult = SyncInboxRes
 
-export type IncomingCallMapType = {'keybase.1.chatUi.chatAttachmentUploadOutboxID'?: (params: $ReadOnly<{sessionID: Int, outboxID: OutboxID}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadStart'?: (params: $ReadOnly<{sessionID: Int, metadata: AssetMetadata, placeholderMsgID: MessageID}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadProgress'?: (params: $ReadOnly<{sessionID: Int, bytesComplete: Long, bytesTotal: Long}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentPreviewUploadStart'?: (params: $ReadOnly<{sessionID: Int, metadata: AssetMetadata}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentPreviewUploadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadStart'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadProgress'?: (params: $ReadOnly<{sessionID: Int, bytesComplete: Long, bytesTotal: Long}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxUnverified'?: (params: $ReadOnly<{sessionID: Int, inbox: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxConversation'?: (params: $ReadOnly<{sessionID: Int, conv: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxFailed'?: (params: $ReadOnly<{sessionID: Int, convID: ConversationID, error: ConversationErrorLocal}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatThreadCached'?: (params: $ReadOnly<{sessionID: Int, thread?: ?String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatThreadFull'?: (params: $ReadOnly<{sessionID: Int, thread: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatConfirmChannelDelete'?: (params: $ReadOnly<{sessionID: Int, channel: String}>, response: {error: RPCErrorHandler, result: (result: ChatUiChatConfirmChannelDeleteResult) => void}) => void, 'keybase.1.NotifyChat.NewChatActivity'?: (params: $ReadOnly<{uid: Keybase1.UID, activity: ChatActivity}>) => void, 'keybase.1.NotifyChat.ChatIdentifyUpdate'?: (params: $ReadOnly<{update: Keybase1.CanonicalTLFNameAndIDWithBreaks}>) => void, 'keybase.1.NotifyChat.ChatTLFFinalize'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, finalizeInfo: ConversationFinalizeInfo, conv?: ?InboxUIItem}>) => void, 'keybase.1.NotifyChat.ChatTLFResolve'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, resolveInfo: ConversationResolveInfo}>) => void, 'keybase.1.NotifyChat.ChatInboxStale'?: (params: $ReadOnly<{uid: Keybase1.UID}>) => void, 'keybase.1.NotifyChat.ChatThreadsStale'?: (params: $ReadOnly<{uid: Keybase1.UID, updates?: ?Array<ConversationStaleUpdate>}>) => void, 'keybase.1.NotifyChat.ChatTypingUpdate'?: (params: $ReadOnly<{typingUpdates?: ?Array<ConvTypingUpdate>}>) => void, 'keybase.1.NotifyChat.ChatJoinedConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, conv: InboxUIItem}>) => void, 'keybase.1.NotifyChat.ChatLeftConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID}>) => void, 'keybase.1.NotifyChat.ChatResetConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID}>) => void, 'keybase.1.NotifyChat.ChatInboxSyncStarted'?: (params: $ReadOnly<{uid: Keybase1.UID}>) => void, 'keybase.1.NotifyChat.ChatInboxSynced'?: (params: $ReadOnly<{uid: Keybase1.UID, syncRes: ChatSyncResult}>) => void}
+export type IncomingCallMapType = {'keybase.1.chatUi.chatAttachmentUploadOutboxID'?: (params: $ReadOnly<{sessionID: Int, outboxID: OutboxID}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadStart'?: (params: $ReadOnly<{sessionID: Int, metadata: AssetMetadata, placeholderMsgID: MessageID}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadProgress'?: (params: $ReadOnly<{sessionID: Int, bytesComplete: Long, bytesTotal: Long}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentUploadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentPreviewUploadStart'?: (params: $ReadOnly<{sessionID: Int, metadata: AssetMetadata}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentPreviewUploadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadStart'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadProgress'?: (params: $ReadOnly<{sessionID: Int, bytesComplete: Long, bytesTotal: Long}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatAttachmentDownloadDone'?: (params: $ReadOnly<{sessionID: Int}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxUnverified'?: (params: $ReadOnly<{sessionID: Int, inbox: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxConversation'?: (params: $ReadOnly<{sessionID: Int, conv: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatInboxFailed'?: (params: $ReadOnly<{sessionID: Int, convID: ConversationID, error: ConversationErrorLocal}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatThreadCached'?: (params: $ReadOnly<{sessionID: Int, thread?: ?String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatThreadFull'?: (params: $ReadOnly<{sessionID: Int, thread: String}>, response: CommonResponseHandler) => void, 'keybase.1.chatUi.chatConfirmChannelDelete'?: (params: $ReadOnly<{sessionID: Int, channel: String}>, response: {error: RPCErrorHandler, result: (result: ChatUiChatConfirmChannelDeleteResult) => void}) => void, 'keybase.1.NotifyChat.NewChatActivity'?: (params: $ReadOnly<{uid: Keybase1.UID, activity: ChatActivity}>) => void, 'keybase.1.NotifyChat.ChatIdentifyUpdate'?: (params: $ReadOnly<{update: Keybase1.CanonicalTLFNameAndIDWithBreaks}>) => void, 'keybase.1.NotifyChat.ChatTLFFinalize'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, finalizeInfo: ConversationFinalizeInfo, conv?: ?InboxUIItem}>) => void, 'keybase.1.NotifyChat.ChatTLFResolve'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, resolveInfo: ConversationResolveInfo}>) => void, 'keybase.1.NotifyChat.ChatInboxStale'?: (params: $ReadOnly<{uid: Keybase1.UID}>) => void, 'keybase.1.NotifyChat.ChatThreadsStale'?: (params: $ReadOnly<{uid: Keybase1.UID, updates?: ?Array<ConversationStaleUpdate>}>) => void, 'keybase.1.NotifyChat.ChatTypingUpdate'?: (params: $ReadOnly<{typingUpdates?: ?Array<ConvTypingUpdate>}>) => void, 'keybase.1.NotifyChat.ChatJoinedConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, conv: InboxUIItem}>) => void, 'keybase.1.NotifyChat.ChatLeftConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID}>) => void, 'keybase.1.NotifyChat.ChatResetConversation'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID}>) => void, 'keybase.1.NotifyChat.ChatInboxSyncStarted'?: (params: $ReadOnly<{uid: Keybase1.UID}>) => void, 'keybase.1.NotifyChat.ChatInboxSynced'?: (params: $ReadOnly<{uid: Keybase1.UID, syncRes: ChatSyncResult}>) => void, 'keybase.1.NotifyChat.ChatSetConvRetention'?: (params: $ReadOnly<{uid: Keybase1.UID, convID: ConversationID, conv?: ?InboxUIItem}>) => void, 'keybase.1.NotifyChat.ChatSetTeamRetention'?: (params: $ReadOnly<{uid: Keybase1.UID, teamID: Keybase1.TeamID, convs?: ?Array<InboxUIItem>}>) => void}


### PR DESCRIPTION
The client can now deal with updates to retention policy. This does not include when messages actually get deleted.

This comes with a CLI command `chat retention-policy` for managing the policy. The CLI is only available in dev builds, but I plan to make it public when the rest of this system is ready. Below is some example usage.

```
$ kbu chat retention-policy
Error parsing command line arguments: conversation or team name required

NAME:
   keybase chat retention-policy - Manage the chat retention policy for a conversation or team

USAGE:
   keybase chat retention-policy [command options] [conversation]

EXAMPLES:
   View the policy for a conversation or team:
       keybase chat retention-policy patrick,mlsteele
       keybase chat retention-policy keybasefriends
       keybase chat retention-policy keybasefriends --channel '#general'

   Keep messages indefinitely:
       keybase chat retention-policy patrick --keep

   Keep messages for a week:
       keybase chat retention-policy patrick --age 1w

   Change the team-wide policy:
       keybase chat retention-policy ateam --age 1y

   Use the team policy for this channel:
       keybase chat retention-policy ateam --channel '#general' --inherit

OPTIONS:
   --topic-type "chat"  Specify topic type of the conversation. Has to be chat or dev
   --channel            Specify the conversation channel.
   --public             Only select public conversations. Exclusive to --private
   --private            Only select private conversations. Exclusive to --public. If both --public and --private are present, --private takes priority.
   --keep               Keep messages indefinitely
   --age                Delete messages after one of [1d, 1w, 30d, 3m, 1y]
   --inherit            Use the team's policy for a channel

$ kbu chat retention-policy t_tracy
Found PRIVATE CHAT conversation: cn3,t_tracy
Keep messages (default)

$ kbu chat retention-policy t_tracy --inherit
Found PRIVATE CHAT conversation: cn3,t_tracy
Set the conversation retention policy?
Hit Enter, or Ctrl-C to cancel.
▶ ERROR error from chat server: non-team conversation cannot inherit retention policy

$ kbu chat retention-policy cn4team2
Team policy: Delete messages after 365 days
#general channel: Delete messages after 1 days

$ kbu chat retention-policy cn4team2 -keep
Set the team-wide retention policy?
Hit Enter, or Ctrl-C to cancel.
Team policy: Keep messages
#general channel: Delete messages after 1 days

$ kbu chat retention-policy cn4team2 --channel eng --age 3m
Set the channel retention policy?
Hit Enter, or Ctrl-C to cancel.
Team policy: Keep messages
#eng channel: Delete messages after 90 days

$ kbu chat retention-policy cn4team2 --channel eng --inherit
Set the channel retention policy?
Hit Enter, or Ctrl-C to cancel.
Team policy: Keep messages
#eng channel: Use team policy

$ kbu chat retention-policy cn4team2 --inherit
Set the team-wide retention policy?
Hit Enter, or Ctrl-C to cancel.
▶ ERROR error from chat server: team cannot inherit retention policy

$ kbu chat retention-policy t_tracy --inherit --keep
Error parsing command line arguments: only one of [keep, inherit] allowed
... help text ...
```