### PR TITLE
Use sh, not bash, in keybase.gui.service

### DIFF
--- a/packaging/linux/systemd/keybase.gui.service
+++ b/packaging/linux/systemd/keybase.gui.service
@@ -5,7 +5,7 @@ Wants=keybase.service kbfs.service
 [Service]
 Type=simple
 ExecStartPre=/usr/bin/env mkdir -p %h/.cache/keybase
-ExecStart=/usr/bin/env bash -c "/opt/keybase/Keybase &>> %h/.cache/keybase/Keybase.app.log"
+ExecStart=/usr/bin/env sh -c "/opt/keybase/Keybase &>> %h/.cache/keybase/Keybase.app.log"
 # The environment file lets run_keybase pass along KEYBASE_START_UI. The
 # autostart file will set that to suppress showing the main window during boot.
 # %t is the XDG_RUNTIME_DIR, and the leading - means it's ok if the file is


### PR DESCRIPTION
A minor tweak. There is no need to use `bash` here, and not using it could potentially be more portable. `sh` can be generic in that certain distros link other shells (like `dash`) to `/bin/sh`.