### PR TITLE
add ability to post KBFS crypt keys to the associated implicit team CORE-6834

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2159,3 +2159,19 @@ func RefNames(refs []GitRefMetadata) string {
 	}
 	return strings.Join(names, ", ")
 }
+
+func TeamEncryptedKBFSKeysetHashFromString(s string) TeamEncryptedKBFSKeysetHash {
+	return TeamEncryptedKBFSKeysetHash(s)
+}
+
+func (e TeamEncryptedKBFSKeysetHash) String() string {
+	return string(e)
+}
+
+func (e TeamEncryptedKBFSKeysetHash) Bytes() []byte {
+	return []byte(e.String())
+}
+
+func (e TeamEncryptedKBFSKeysetHash) SecureEqual(l TeamEncryptedKBFSKeysetHash) bool {
+	return hmac.Equal(e.Bytes(), l.Bytes())
+}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2164,6 +2164,10 @@ func TeamEncryptedKBFSKeysetHashFromString(s string) TeamEncryptedKBFSKeysetHash
 	return TeamEncryptedKBFSKeysetHash(s)
 }
 
+func TeamEncryptedKBFSKeysetHashFromBytes(s []byte) TeamEncryptedKBFSKeysetHash {
+	return TeamEncryptedKBFSKeysetHashFromString(hex.EncodeToString(s))
+}
+
 func (e TeamEncryptedKBFSKeysetHash) String() string {
 	return string(e)
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -751,40 +751,44 @@ func (o TeamEncryptedKBFSKeyset) DeepCopy() TeamEncryptedKBFSKeyset {
 	}
 }
 
-type TeamEncryptedKBFSCryptKeys struct {
-	Generation PerTeamKeyGeneration    `codec:"generation" json:"generation"`
-	Keyset     TeamEncryptedKBFSKeyset `codec:"keyset" json:"keyset"`
+type TeamGetLegacyTLFUpgrade struct {
+	EncryptedKeyset  string               `codec:"encryptedKeyset" json:"encrypted_keyset"`
+	TeamGeneration   PerTeamKeyGeneration `codec:"teamGeneration" json:"team_generation"`
+	LegacyGeneration int                  `codec:"legacyGeneration" json:"legacy_generation"`
+	AppType          TeamApplication      `codec:"appType" json:"app_type"`
 }
 
-func (o TeamEncryptedKBFSCryptKeys) DeepCopy() TeamEncryptedKBFSCryptKeys {
-	return TeamEncryptedKBFSCryptKeys{
-		Generation: o.Generation.DeepCopy(),
-		Keyset:     o.Keyset.DeepCopy(),
+func (o TeamGetLegacyTLFUpgrade) DeepCopy() TeamGetLegacyTLFUpgrade {
+	return TeamGetLegacyTLFUpgrade{
+		EncryptedKeyset:  o.EncryptedKeyset,
+		TeamGeneration:   o.TeamGeneration.DeepCopy(),
+		LegacyGeneration: o.LegacyGeneration,
+		AppType:          o.AppType.DeepCopy(),
 	}
 }
 
 type TeamSigChainState struct {
-	Reader          UserVersion                                    `codec:"reader" json:"reader"`
-	Id              TeamID                                         `codec:"id" json:"id"`
-	Implicit        bool                                           `codec:"implicit" json:"implicit"`
-	Public          bool                                           `codec:"public" json:"public"`
-	RootAncestor    TeamName                                       `codec:"rootAncestor" json:"rootAncestor"`
-	NameDepth       int                                            `codec:"nameDepth" json:"nameDepth"`
-	NameLog         []TeamNameLogPoint                             `codec:"nameLog" json:"nameLog"`
-	LastSeqno       Seqno                                          `codec:"lastSeqno" json:"lastSeqno"`
-	LastLinkID      LinkID                                         `codec:"lastLinkID" json:"lastLinkID"`
-	ParentID        *TeamID                                        `codec:"parentID,omitempty" json:"parentID,omitempty"`
-	UserLog         map[UserVersion][]UserLogPoint                 `codec:"userLog" json:"userLog"`
-	SubteamLog      map[TeamID][]SubteamLogPoint                   `codec:"subteamLog" json:"subteamLog"`
-	PerTeamKeys     map[PerTeamKeyGeneration]PerTeamKey            `codec:"perTeamKeys" json:"perTeamKeys"`
-	LinkIDs         map[Seqno]LinkID                               `codec:"linkIDs" json:"linkIDs"`
-	StubbedLinks    map[Seqno]bool                                 `codec:"stubbedLinks" json:"stubbedLinks"`
-	ActiveInvites   map[TeamInviteID]TeamInvite                    `codec:"activeInvites" json:"activeInvites"`
-	ObsoleteInvites map[TeamInviteID]TeamInvite                    `codec:"obsoleteInvites" json:"obsoleteInvites"`
-	Open            bool                                           `codec:"open" json:"open"`
-	OpenTeamJoinAs  TeamRole                                       `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
-	TlfID           TLFID                                          `codec:"tlfID" json:"tlfID"`
-	TlfCryptKeys    map[TeamApplication]TeamEncryptedKBFSCryptKeys `codec:"tlfCryptKeys" json:"tlfCryptKeys"`
+	Reader           UserVersion                         `codec:"reader" json:"reader"`
+	Id               TeamID                              `codec:"id" json:"id"`
+	Implicit         bool                                `codec:"implicit" json:"implicit"`
+	Public           bool                                `codec:"public" json:"public"`
+	RootAncestor     TeamName                            `codec:"rootAncestor" json:"rootAncestor"`
+	NameDepth        int                                 `codec:"nameDepth" json:"nameDepth"`
+	NameLog          []TeamNameLogPoint                  `codec:"nameLog" json:"nameLog"`
+	LastSeqno        Seqno                               `codec:"lastSeqno" json:"lastSeqno"`
+	LastLinkID       LinkID                              `codec:"lastLinkID" json:"lastLinkID"`
+	ParentID         *TeamID                             `codec:"parentID,omitempty" json:"parentID,omitempty"`
+	UserLog          map[UserVersion][]UserLogPoint      `codec:"userLog" json:"userLog"`
+	SubteamLog       map[TeamID][]SubteamLogPoint        `codec:"subteamLog" json:"subteamLog"`
+	PerTeamKeys      map[PerTeamKeyGeneration]PerTeamKey `codec:"perTeamKeys" json:"perTeamKeys"`
+	LinkIDs          map[Seqno]LinkID                    `codec:"linkIDs" json:"linkIDs"`
+	StubbedLinks     map[Seqno]bool                      `codec:"stubbedLinks" json:"stubbedLinks"`
+	ActiveInvites    map[TeamInviteID]TeamInvite         `codec:"activeInvites" json:"activeInvites"`
+	ObsoleteInvites  map[TeamInviteID]TeamInvite         `codec:"obsoleteInvites" json:"obsoleteInvites"`
+	Open             bool                                `codec:"open" json:"open"`
+	OpenTeamJoinAs   TeamRole                            `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
+	TlfID            TLFID                               `codec:"tlfID" json:"tlfID"`
+	TlfLegacyUpgrade map[TeamApplication]string          `codec:"tlfLegacyUpgrade" json:"tlfLegacyUpgrade"`
 }
 
 func (o TeamSigChainState) DeepCopy() TeamSigChainState {
@@ -922,18 +926,18 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 		Open:           o.Open,
 		OpenTeamJoinAs: o.OpenTeamJoinAs.DeepCopy(),
 		TlfID:          o.TlfID.DeepCopy(),
-		TlfCryptKeys: (func(x map[TeamApplication]TeamEncryptedKBFSCryptKeys) map[TeamApplication]TeamEncryptedKBFSCryptKeys {
+		TlfLegacyUpgrade: (func(x map[TeamApplication]string) map[TeamApplication]string {
 			if x == nil {
 				return nil
 			}
-			ret := make(map[TeamApplication]TeamEncryptedKBFSCryptKeys)
+			ret := make(map[TeamApplication]string)
 			for k, v := range x {
 				kCopy := k.DeepCopy()
-				vCopy := v.DeepCopy()
+				vCopy := v
 				ret[kCopy] = vCopy
 			}
 			return ret
-		})(o.TlfCryptKeys),
+		})(o.TlfLegacyUpgrade),
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -727,27 +727,52 @@ func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
 	}
 }
 
+type TeamEncryptedKBFSKeyset struct {
+	V int    `codec:"v" json:"v"`
+	E []byte `codec:"e" json:"e"`
+	N []byte `codec:"n" json:"n"`
+}
+
+func (o TeamEncryptedKBFSKeyset) DeepCopy() TeamEncryptedKBFSKeyset {
+	return TeamEncryptedKBFSKeyset{
+		V: o.V,
+		E: (func(x []byte) []byte {
+			if x == nil {
+				return nil
+			}
+			return append([]byte{}, x...)
+		})(o.E),
+		N: (func(x []byte) []byte {
+			if x == nil {
+				return nil
+			}
+			return append([]byte{}, x...)
+		})(o.N),
+	}
+}
+
 type TeamSigChainState struct {
-	Reader          UserVersion                         `codec:"reader" json:"reader"`
-	Id              TeamID                              `codec:"id" json:"id"`
-	Implicit        bool                                `codec:"implicit" json:"implicit"`
-	Public          bool                                `codec:"public" json:"public"`
-	RootAncestor    TeamName                            `codec:"rootAncestor" json:"rootAncestor"`
-	NameDepth       int                                 `codec:"nameDepth" json:"nameDepth"`
-	NameLog         []TeamNameLogPoint                  `codec:"nameLog" json:"nameLog"`
-	LastSeqno       Seqno                               `codec:"lastSeqno" json:"lastSeqno"`
-	LastLinkID      LinkID                              `codec:"lastLinkID" json:"lastLinkID"`
-	ParentID        *TeamID                             `codec:"parentID,omitempty" json:"parentID,omitempty"`
-	UserLog         map[UserVersion][]UserLogPoint      `codec:"userLog" json:"userLog"`
-	SubteamLog      map[TeamID][]SubteamLogPoint        `codec:"subteamLog" json:"subteamLog"`
-	PerTeamKeys     map[PerTeamKeyGeneration]PerTeamKey `codec:"perTeamKeys" json:"perTeamKeys"`
-	LinkIDs         map[Seqno]LinkID                    `codec:"linkIDs" json:"linkIDs"`
-	StubbedLinks    map[Seqno]bool                      `codec:"stubbedLinks" json:"stubbedLinks"`
-	ActiveInvites   map[TeamInviteID]TeamInvite         `codec:"activeInvites" json:"activeInvites"`
-	ObsoleteInvites map[TeamInviteID]TeamInvite         `codec:"obsoleteInvites" json:"obsoleteInvites"`
-	Open            bool                                `codec:"open" json:"open"`
-	OpenTeamJoinAs  TeamRole                            `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
-	TlfID           TLFID                               `codec:"tlfID" json:"tlfID"`
+	Reader          UserVersion                                 `codec:"reader" json:"reader"`
+	Id              TeamID                                      `codec:"id" json:"id"`
+	Implicit        bool                                        `codec:"implicit" json:"implicit"`
+	Public          bool                                        `codec:"public" json:"public"`
+	RootAncestor    TeamName                                    `codec:"rootAncestor" json:"rootAncestor"`
+	NameDepth       int                                         `codec:"nameDepth" json:"nameDepth"`
+	NameLog         []TeamNameLogPoint                          `codec:"nameLog" json:"nameLog"`
+	LastSeqno       Seqno                                       `codec:"lastSeqno" json:"lastSeqno"`
+	LastLinkID      LinkID                                      `codec:"lastLinkID" json:"lastLinkID"`
+	ParentID        *TeamID                                     `codec:"parentID,omitempty" json:"parentID,omitempty"`
+	UserLog         map[UserVersion][]UserLogPoint              `codec:"userLog" json:"userLog"`
+	SubteamLog      map[TeamID][]SubteamLogPoint                `codec:"subteamLog" json:"subteamLog"`
+	PerTeamKeys     map[PerTeamKeyGeneration]PerTeamKey         `codec:"perTeamKeys" json:"perTeamKeys"`
+	LinkIDs         map[Seqno]LinkID                            `codec:"linkIDs" json:"linkIDs"`
+	StubbedLinks    map[Seqno]bool                              `codec:"stubbedLinks" json:"stubbedLinks"`
+	ActiveInvites   map[TeamInviteID]TeamInvite                 `codec:"activeInvites" json:"activeInvites"`
+	ObsoleteInvites map[TeamInviteID]TeamInvite                 `codec:"obsoleteInvites" json:"obsoleteInvites"`
+	Open            bool                                        `codec:"open" json:"open"`
+	OpenTeamJoinAs  TeamRole                                    `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
+	TlfID           TLFID                                       `codec:"tlfID" json:"tlfID"`
+	TlfCryptKeys    map[TeamApplication]TeamEncryptedKBFSKeyset `codec:"tlfCryptKeys" json:"tlfCryptKeys"`
 }
 
 func (o TeamSigChainState) DeepCopy() TeamSigChainState {
@@ -885,6 +910,18 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 		Open:           o.Open,
 		OpenTeamJoinAs: o.OpenTeamJoinAs.DeepCopy(),
 		TlfID:          o.TlfID.DeepCopy(),
+		TlfCryptKeys: (func(x map[TeamApplication]TeamEncryptedKBFSKeyset) map[TeamApplication]TeamEncryptedKBFSKeyset {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[TeamApplication]TeamEncryptedKBFSKeyset)
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := v.DeepCopy()
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.TlfCryptKeys),
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -775,32 +775,38 @@ func (o TeamEncryptedKBFSKeyset) DeepCopy() TeamEncryptedKBFSKeyset {
 }
 
 type TeamGetLegacyTLFUpgrade struct {
-	EncryptedKeyset  string          `codec:"encryptedKeyset" json:"encrypted_keyset"`
-	TeamGeneration   int             `codec:"teamGeneration" json:"team_generation"`
-	LegacyGeneration int             `codec:"legacyGeneration" json:"legacy_generation"`
-	AppType          TeamApplication `codec:"appType" json:"app_type"`
+	EncryptedKeyset  string               `codec:"encryptedKeyset" json:"encrypted_keyset"`
+	TeamGeneration   PerTeamKeyGeneration `codec:"teamGeneration" json:"team_generation"`
+	LegacyGeneration int                  `codec:"legacyGeneration" json:"legacy_generation"`
+	AppType          TeamApplication      `codec:"appType" json:"app_type"`
 }
 
 func (o TeamGetLegacyTLFUpgrade) DeepCopy() TeamGetLegacyTLFUpgrade {
 	return TeamGetLegacyTLFUpgrade{
 		EncryptedKeyset:  o.EncryptedKeyset,
-		TeamGeneration:   o.TeamGeneration,
+		TeamGeneration:   o.TeamGeneration.DeepCopy(),
 		LegacyGeneration: o.LegacyGeneration,
 		AppType:          o.AppType.DeepCopy(),
 	}
 }
 
+type TeamEncryptedKBFSKeysetHash string
+
+func (o TeamEncryptedKBFSKeysetHash) DeepCopy() TeamEncryptedKBFSKeysetHash {
+	return o
+}
+
 type TeamLegacyTLFUpgradeChainInfo struct {
-	KeysetHash       string          `codec:"keysetHash" json:"keysetHash"`
-	TeamGeneration   int             `codec:"teamGeneration" json:"teamGeneration"`
-	LegacyGeneration int             `codec:"legacyGeneration" json:"legacyGeneration"`
-	AppType          TeamApplication `codec:"appType" json:"appType"`
+	KeysetHash       TeamEncryptedKBFSKeysetHash `codec:"keysetHash" json:"keysetHash"`
+	TeamGeneration   PerTeamKeyGeneration        `codec:"teamGeneration" json:"teamGeneration"`
+	LegacyGeneration int                         `codec:"legacyGeneration" json:"legacyGeneration"`
+	AppType          TeamApplication             `codec:"appType" json:"appType"`
 }
 
 func (o TeamLegacyTLFUpgradeChainInfo) DeepCopy() TeamLegacyTLFUpgradeChainInfo {
 	return TeamLegacyTLFUpgradeChainInfo{
-		KeysetHash:       o.KeysetHash,
-		TeamGeneration:   o.TeamGeneration,
+		KeysetHash:       o.KeysetHash.DeepCopy(),
+		TeamGeneration:   o.TeamGeneration.DeepCopy(),
 		LegacyGeneration: o.LegacyGeneration,
 		AppType:          o.AppType.DeepCopy(),
 	}

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -751,28 +751,40 @@ func (o TeamEncryptedKBFSKeyset) DeepCopy() TeamEncryptedKBFSKeyset {
 	}
 }
 
+type TeamEncryptedKBFSCryptKeys struct {
+	Generation PerTeamKeyGeneration    `codec:"generation" json:"generation"`
+	Keyset     TeamEncryptedKBFSKeyset `codec:"keyset" json:"keyset"`
+}
+
+func (o TeamEncryptedKBFSCryptKeys) DeepCopy() TeamEncryptedKBFSCryptKeys {
+	return TeamEncryptedKBFSCryptKeys{
+		Generation: o.Generation.DeepCopy(),
+		Keyset:     o.Keyset.DeepCopy(),
+	}
+}
+
 type TeamSigChainState struct {
-	Reader          UserVersion                                 `codec:"reader" json:"reader"`
-	Id              TeamID                                      `codec:"id" json:"id"`
-	Implicit        bool                                        `codec:"implicit" json:"implicit"`
-	Public          bool                                        `codec:"public" json:"public"`
-	RootAncestor    TeamName                                    `codec:"rootAncestor" json:"rootAncestor"`
-	NameDepth       int                                         `codec:"nameDepth" json:"nameDepth"`
-	NameLog         []TeamNameLogPoint                          `codec:"nameLog" json:"nameLog"`
-	LastSeqno       Seqno                                       `codec:"lastSeqno" json:"lastSeqno"`
-	LastLinkID      LinkID                                      `codec:"lastLinkID" json:"lastLinkID"`
-	ParentID        *TeamID                                     `codec:"parentID,omitempty" json:"parentID,omitempty"`
-	UserLog         map[UserVersion][]UserLogPoint              `codec:"userLog" json:"userLog"`
-	SubteamLog      map[TeamID][]SubteamLogPoint                `codec:"subteamLog" json:"subteamLog"`
-	PerTeamKeys     map[PerTeamKeyGeneration]PerTeamKey         `codec:"perTeamKeys" json:"perTeamKeys"`
-	LinkIDs         map[Seqno]LinkID                            `codec:"linkIDs" json:"linkIDs"`
-	StubbedLinks    map[Seqno]bool                              `codec:"stubbedLinks" json:"stubbedLinks"`
-	ActiveInvites   map[TeamInviteID]TeamInvite                 `codec:"activeInvites" json:"activeInvites"`
-	ObsoleteInvites map[TeamInviteID]TeamInvite                 `codec:"obsoleteInvites" json:"obsoleteInvites"`
-	Open            bool                                        `codec:"open" json:"open"`
-	OpenTeamJoinAs  TeamRole                                    `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
-	TlfID           TLFID                                       `codec:"tlfID" json:"tlfID"`
-	TlfCryptKeys    map[TeamApplication]TeamEncryptedKBFSKeyset `codec:"tlfCryptKeys" json:"tlfCryptKeys"`
+	Reader          UserVersion                                    `codec:"reader" json:"reader"`
+	Id              TeamID                                         `codec:"id" json:"id"`
+	Implicit        bool                                           `codec:"implicit" json:"implicit"`
+	Public          bool                                           `codec:"public" json:"public"`
+	RootAncestor    TeamName                                       `codec:"rootAncestor" json:"rootAncestor"`
+	NameDepth       int                                            `codec:"nameDepth" json:"nameDepth"`
+	NameLog         []TeamNameLogPoint                             `codec:"nameLog" json:"nameLog"`
+	LastSeqno       Seqno                                          `codec:"lastSeqno" json:"lastSeqno"`
+	LastLinkID      LinkID                                         `codec:"lastLinkID" json:"lastLinkID"`
+	ParentID        *TeamID                                        `codec:"parentID,omitempty" json:"parentID,omitempty"`
+	UserLog         map[UserVersion][]UserLogPoint                 `codec:"userLog" json:"userLog"`
+	SubteamLog      map[TeamID][]SubteamLogPoint                   `codec:"subteamLog" json:"subteamLog"`
+	PerTeamKeys     map[PerTeamKeyGeneration]PerTeamKey            `codec:"perTeamKeys" json:"perTeamKeys"`
+	LinkIDs         map[Seqno]LinkID                               `codec:"linkIDs" json:"linkIDs"`
+	StubbedLinks    map[Seqno]bool                                 `codec:"stubbedLinks" json:"stubbedLinks"`
+	ActiveInvites   map[TeamInviteID]TeamInvite                    `codec:"activeInvites" json:"activeInvites"`
+	ObsoleteInvites map[TeamInviteID]TeamInvite                    `codec:"obsoleteInvites" json:"obsoleteInvites"`
+	Open            bool                                           `codec:"open" json:"open"`
+	OpenTeamJoinAs  TeamRole                                       `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
+	TlfID           TLFID                                          `codec:"tlfID" json:"tlfID"`
+	TlfCryptKeys    map[TeamApplication]TeamEncryptedKBFSCryptKeys `codec:"tlfCryptKeys" json:"tlfCryptKeys"`
 }
 
 func (o TeamSigChainState) DeepCopy() TeamSigChainState {
@@ -910,11 +922,11 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 		Open:           o.Open,
 		OpenTeamJoinAs: o.OpenTeamJoinAs.DeepCopy(),
 		TlfID:          o.TlfID.DeepCopy(),
-		TlfCryptKeys: (func(x map[TeamApplication]TeamEncryptedKBFSKeyset) map[TeamApplication]TeamEncryptedKBFSKeyset {
+		TlfCryptKeys: (func(x map[TeamApplication]TeamEncryptedKBFSCryptKeys) map[TeamApplication]TeamEncryptedKBFSCryptKeys {
 			if x == nil {
 				return nil
 			}
-			ret := make(map[TeamApplication]TeamEncryptedKBFSKeyset)
+			ret := make(map[TeamApplication]TeamEncryptedKBFSCryptKeys)
 			for k, v := range x {
 				kCopy := k.DeepCopy()
 				vCopy := v.DeepCopy()

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -504,6 +504,7 @@ type TeamData struct {
 	ReaderKeyMasks  map[TeamApplication]map[PerTeamKeyGeneration]MaskB64 `codec:"readerKeyMasks" json:"readerKeyMasks"`
 	LatestSeqnoHint Seqno                                                `codec:"latestSeqnoHint" json:"latestSeqnoHint"`
 	CachedAt        Time                                                 `codec:"cachedAt" json:"cachedAt"`
+	TlfCryptKeys    map[TeamApplication][]CryptKey                       `codec:"tlfCryptKeys" json:"tlfCryptKeys"`
 }
 
 func (o TeamData) DeepCopy() TeamData {
@@ -548,6 +549,28 @@ func (o TeamData) DeepCopy() TeamData {
 		})(o.ReaderKeyMasks),
 		LatestSeqnoHint: o.LatestSeqnoHint.DeepCopy(),
 		CachedAt:        o.CachedAt.DeepCopy(),
+		TlfCryptKeys: (func(x map[TeamApplication][]CryptKey) map[TeamApplication][]CryptKey {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[TeamApplication][]CryptKey)
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := (func(x []CryptKey) []CryptKey {
+					if x == nil {
+						return nil
+					}
+					var ret []CryptKey
+					for _, v := range x {
+						vCopy := v.DeepCopy()
+						ret = append(ret, vCopy)
+					}
+					return ret
+				})(v)
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.TlfCryptKeys),
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -775,43 +775,59 @@ func (o TeamEncryptedKBFSKeyset) DeepCopy() TeamEncryptedKBFSKeyset {
 }
 
 type TeamGetLegacyTLFUpgrade struct {
-	EncryptedKeyset  string               `codec:"encryptedKeyset" json:"encrypted_keyset"`
-	TeamGeneration   PerTeamKeyGeneration `codec:"teamGeneration" json:"team_generation"`
-	LegacyGeneration int                  `codec:"legacyGeneration" json:"legacy_generation"`
-	AppType          TeamApplication      `codec:"appType" json:"app_type"`
+	EncryptedKeyset  string          `codec:"encryptedKeyset" json:"encrypted_keyset"`
+	TeamGeneration   int             `codec:"teamGeneration" json:"team_generation"`
+	LegacyGeneration int             `codec:"legacyGeneration" json:"legacy_generation"`
+	AppType          TeamApplication `codec:"appType" json:"app_type"`
 }
 
 func (o TeamGetLegacyTLFUpgrade) DeepCopy() TeamGetLegacyTLFUpgrade {
 	return TeamGetLegacyTLFUpgrade{
 		EncryptedKeyset:  o.EncryptedKeyset,
-		TeamGeneration:   o.TeamGeneration.DeepCopy(),
+		TeamGeneration:   o.TeamGeneration,
+		LegacyGeneration: o.LegacyGeneration,
+		AppType:          o.AppType.DeepCopy(),
+	}
+}
+
+type TeamLegacyTLFUpgradeChainInfo struct {
+	KeysetHash       string          `codec:"keysetHash" json:"keysetHash"`
+	TeamGeneration   int             `codec:"teamGeneration" json:"teamGeneration"`
+	LegacyGeneration int             `codec:"legacyGeneration" json:"legacyGeneration"`
+	AppType          TeamApplication `codec:"appType" json:"appType"`
+}
+
+func (o TeamLegacyTLFUpgradeChainInfo) DeepCopy() TeamLegacyTLFUpgradeChainInfo {
+	return TeamLegacyTLFUpgradeChainInfo{
+		KeysetHash:       o.KeysetHash,
+		TeamGeneration:   o.TeamGeneration,
 		LegacyGeneration: o.LegacyGeneration,
 		AppType:          o.AppType.DeepCopy(),
 	}
 }
 
 type TeamSigChainState struct {
-	Reader           UserVersion                         `codec:"reader" json:"reader"`
-	Id               TeamID                              `codec:"id" json:"id"`
-	Implicit         bool                                `codec:"implicit" json:"implicit"`
-	Public           bool                                `codec:"public" json:"public"`
-	RootAncestor     TeamName                            `codec:"rootAncestor" json:"rootAncestor"`
-	NameDepth        int                                 `codec:"nameDepth" json:"nameDepth"`
-	NameLog          []TeamNameLogPoint                  `codec:"nameLog" json:"nameLog"`
-	LastSeqno        Seqno                               `codec:"lastSeqno" json:"lastSeqno"`
-	LastLinkID       LinkID                              `codec:"lastLinkID" json:"lastLinkID"`
-	ParentID         *TeamID                             `codec:"parentID,omitempty" json:"parentID,omitempty"`
-	UserLog          map[UserVersion][]UserLogPoint      `codec:"userLog" json:"userLog"`
-	SubteamLog       map[TeamID][]SubteamLogPoint        `codec:"subteamLog" json:"subteamLog"`
-	PerTeamKeys      map[PerTeamKeyGeneration]PerTeamKey `codec:"perTeamKeys" json:"perTeamKeys"`
-	LinkIDs          map[Seqno]LinkID                    `codec:"linkIDs" json:"linkIDs"`
-	StubbedLinks     map[Seqno]bool                      `codec:"stubbedLinks" json:"stubbedLinks"`
-	ActiveInvites    map[TeamInviteID]TeamInvite         `codec:"activeInvites" json:"activeInvites"`
-	ObsoleteInvites  map[TeamInviteID]TeamInvite         `codec:"obsoleteInvites" json:"obsoleteInvites"`
-	Open             bool                                `codec:"open" json:"open"`
-	OpenTeamJoinAs   TeamRole                            `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
-	TlfID            TLFID                               `codec:"tlfID" json:"tlfID"`
-	TlfLegacyUpgrade map[TeamApplication]string          `codec:"tlfLegacyUpgrade" json:"tlfLegacyUpgrade"`
+	Reader           UserVersion                                       `codec:"reader" json:"reader"`
+	Id               TeamID                                            `codec:"id" json:"id"`
+	Implicit         bool                                              `codec:"implicit" json:"implicit"`
+	Public           bool                                              `codec:"public" json:"public"`
+	RootAncestor     TeamName                                          `codec:"rootAncestor" json:"rootAncestor"`
+	NameDepth        int                                               `codec:"nameDepth" json:"nameDepth"`
+	NameLog          []TeamNameLogPoint                                `codec:"nameLog" json:"nameLog"`
+	LastSeqno        Seqno                                             `codec:"lastSeqno" json:"lastSeqno"`
+	LastLinkID       LinkID                                            `codec:"lastLinkID" json:"lastLinkID"`
+	ParentID         *TeamID                                           `codec:"parentID,omitempty" json:"parentID,omitempty"`
+	UserLog          map[UserVersion][]UserLogPoint                    `codec:"userLog" json:"userLog"`
+	SubteamLog       map[TeamID][]SubteamLogPoint                      `codec:"subteamLog" json:"subteamLog"`
+	PerTeamKeys      map[PerTeamKeyGeneration]PerTeamKey               `codec:"perTeamKeys" json:"perTeamKeys"`
+	LinkIDs          map[Seqno]LinkID                                  `codec:"linkIDs" json:"linkIDs"`
+	StubbedLinks     map[Seqno]bool                                    `codec:"stubbedLinks" json:"stubbedLinks"`
+	ActiveInvites    map[TeamInviteID]TeamInvite                       `codec:"activeInvites" json:"activeInvites"`
+	ObsoleteInvites  map[TeamInviteID]TeamInvite                       `codec:"obsoleteInvites" json:"obsoleteInvites"`
+	Open             bool                                              `codec:"open" json:"open"`
+	OpenTeamJoinAs   TeamRole                                          `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
+	TlfID            TLFID                                             `codec:"tlfID" json:"tlfID"`
+	TlfLegacyUpgrade map[TeamApplication]TeamLegacyTLFUpgradeChainInfo `codec:"tlfLegacyUpgrade" json:"tlfLegacyUpgrade"`
 }
 
 func (o TeamSigChainState) DeepCopy() TeamSigChainState {
@@ -949,14 +965,14 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 		Open:           o.Open,
 		OpenTeamJoinAs: o.OpenTeamJoinAs.DeepCopy(),
 		TlfID:          o.TlfID.DeepCopy(),
-		TlfLegacyUpgrade: (func(x map[TeamApplication]string) map[TeamApplication]string {
+		TlfLegacyUpgrade: (func(x map[TeamApplication]TeamLegacyTLFUpgradeChainInfo) map[TeamApplication]TeamLegacyTLFUpgradeChainInfo {
 			if x == nil {
 				return nil
 			}
-			ret := make(map[TeamApplication]string)
+			ret := make(map[TeamApplication]TeamLegacyTLFUpgradeChainInfo)
 			for k, v := range x {
 				kCopy := k.DeepCopy()
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret[kCopy] = vCopy
 			}
 			return ret

--- a/go/teams/appkeys.go
+++ b/go/teams/appkeys.go
@@ -1,0 +1,119 @@
+package teams
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+func AllApplicationKeys(ctx context.Context, teamData *keybase1.TeamData,
+	application keybase1.TeamApplication, latestGen keybase1.PerTeamKeyGeneration) (res []keybase1.TeamApplicationKey, err error) {
+	for gen := keybase1.PerTeamKeyGeneration(1); gen <= latestGen; gen++ {
+		appKey, err := ApplicationKeyAtGeneration(teamData, application, gen)
+		if err != nil {
+			return res, err
+		}
+		res = append(res, appKey)
+	}
+	return res, nil
+
+}
+
+func ApplicationKeyAtGeneration(teamData *keybase1.TeamData,
+	application keybase1.TeamApplication, generation keybase1.PerTeamKeyGeneration) (res keybase1.TeamApplicationKey, err error) {
+
+	item, ok := teamData.PerTeamKeySeeds[generation]
+	if !ok {
+		return res, libkb.NotFoundError{
+			Msg: fmt.Sprintf("no team secret found at generation %v", generation)}
+	}
+
+	var rkm *keybase1.ReaderKeyMask
+	if UseRKMForApp(application) {
+		rkmReal, err := readerKeyMask(teamData, application, generation)
+		if err != nil {
+			return res, err
+		}
+		rkm = &rkmReal
+	} else {
+		var zeroMask [32]byte
+		zeroRKM := keybase1.ReaderKeyMask{
+			Application: application,
+			Generation:  generation,
+			Mask:        zeroMask[:],
+		}
+		rkm = &zeroRKM
+	}
+
+	return applicationKeyForMask(*rkm, item.Seed)
+}
+
+func UseRKMForApp(application keybase1.TeamApplication) bool {
+	switch application {
+	case keybase1.TeamApplication_SEITAN_INVITE_TOKEN:
+		// Seitan tokens do not use RKMs because implicit admins have all the privileges of explicit members.
+		return false
+	default:
+		return true
+	}
+}
+
+func applicationKeyForMask(mask keybase1.ReaderKeyMask, secret keybase1.PerTeamKeySeed) (keybase1.TeamApplicationKey, error) {
+	if secret.IsZero() {
+		return keybase1.TeamApplicationKey{}, errors.New("nil shared secret in Team#applicationKeyForMask")
+	}
+	var derivationString string
+	switch mask.Application {
+	case keybase1.TeamApplication_KBFS:
+		derivationString = libkb.TeamKBFSDerivationString
+	case keybase1.TeamApplication_CHAT:
+		derivationString = libkb.TeamChatDerivationString
+	case keybase1.TeamApplication_SALTPACK:
+		derivationString = libkb.TeamSaltpackDerivationString
+	case keybase1.TeamApplication_GIT_METADATA:
+		derivationString = libkb.TeamGitMetadataDerivationString
+	case keybase1.TeamApplication_SEITAN_INVITE_TOKEN:
+		derivationString = libkb.TeamSeitanTokenDerivationString
+	default:
+		return keybase1.TeamApplicationKey{}, fmt.Errorf("unrecognized application id: %v", mask.Application)
+	}
+
+	key := keybase1.TeamApplicationKey{
+		Application:   mask.Application,
+		KeyGeneration: mask.Generation,
+	}
+
+	if len(mask.Mask) != 32 {
+		return keybase1.TeamApplicationKey{}, fmt.Errorf("mask length: %d, expected 32", len(mask.Mask))
+	}
+
+	secBytes := make([]byte, len(mask.Mask))
+	n := libkb.XORBytes(secBytes, derivedSecret(secret, derivationString), mask.Mask)
+	if n != 32 {
+		return key, errors.New("invalid derived secret xor mask size")
+	}
+	copy(key.Key[:], secBytes)
+
+	return key, nil
+}
+
+func readerKeyMask(teamData *keybase1.TeamData,
+	application keybase1.TeamApplication, generation keybase1.PerTeamKeyGeneration) (res keybase1.ReaderKeyMask, err error) {
+
+	m2, ok := teamData.ReaderKeyMasks[application]
+	if !ok {
+		return res, NewKeyMaskNotFoundErrorForApplication(application)
+	}
+	mask, ok := m2[generation]
+	if !ok {
+		return res, NewKeyMaskNotFoundErrorForApplicationAndGeneration(application, generation)
+	}
+	return keybase1.ReaderKeyMask{
+		Application: application,
+		Generation:  generation,
+		Mask:        mask,
+	}, nil
+}

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -909,7 +909,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 				StubbedLinks:    make(map[keybase1.Seqno]bool),
 				ActiveInvites:   make(map[keybase1.TeamInviteID]keybase1.TeamInvite),
 				ObsoleteInvites: make(map[keybase1.TeamInviteID]keybase1.TeamInvite),
-				TlfCryptKeys:    make(map[keybase1.TeamApplication]keybase1.TeamEncryptedKBFSKeyset),
+				TlfCryptKeys:    make(map[keybase1.TeamApplication]keybase1.TeamEncryptedKBFSCryptKeys),
 			}}
 
 		t.updateMembership(&res.newState, roleUpdates, payload.SignatureMetadata())
@@ -2112,7 +2112,10 @@ func (t *TeamSigChainPlayer) parseKBFSTLFUpgrade(upgrade *SCTeamKBFS, newState *
 			return err
 		}
 
-		newState.inner.TlfCryptKeys[upgrade.Upgrade.AppType] = encryptedKeyset
+		newState.inner.TlfCryptKeys[upgrade.Upgrade.AppType] = keybase1.TeamEncryptedKBFSCryptKeys{
+			Keyset:     encryptedKeyset,
+			Generation: keybase1.PerTeamKeyGeneration(upgrade.Upgrade.TeamGeneration),
+		}
 	}
 	return nil
 }

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -905,7 +905,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 				StubbedLinks:     make(map[keybase1.Seqno]bool),
 				ActiveInvites:    make(map[keybase1.TeamInviteID]keybase1.TeamInvite),
 				ObsoleteInvites:  make(map[keybase1.TeamInviteID]keybase1.TeamInvite),
-				TlfLegacyUpgrade: make(map[keybase1.TeamApplication]string),
+				TlfLegacyUpgrade: make(map[keybase1.TeamApplication]keybase1.TeamLegacyTLFUpgradeChainInfo),
 			}}
 
 		t.updateMembership(&res.newState, roleUpdates, payload.SignatureMetadata())
@@ -2091,7 +2091,12 @@ func (t *TeamSigChainPlayer) parseKBFSTLFUpgrade(upgrade *SCTeamKBFS, newState *
 		newState.inner.TlfID = upgrade.TLF.ID
 	}
 	if upgrade.Keyset != nil {
-		newState.inner.TlfLegacyUpgrade[upgrade.Keyset.AppType] = upgrade.Keyset.KeysetHash
+		newState.inner.TlfLegacyUpgrade[upgrade.Keyset.AppType] = keybase1.TeamLegacyTLFUpgradeChainInfo{
+			KeysetHash:       upgrade.Keyset.KeysetHash,
+			TeamGeneration:   upgrade.Keyset.TeamGeneration,
+			LegacyGeneration: upgrade.Keyset.LegacyGeneration,
+			AppType:          upgrade.Keyset.AppType,
+		}
 	}
 	return nil
 }

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -110,10 +110,10 @@ type SCTeamKBFSTLF struct {
 }
 
 type SCTeamKBFSLegacyUpgrade struct {
-	AppType          keybase1.TeamApplication `json:"app_type"`
-	TeamGeneration   int                      `json:"team_generation"`
-	LegacyGeneration int                      `json:"legacy_generation"`
-	KeysetHash       string                   `json:"encrypted_keyset_hash"`
+	AppType          keybase1.TeamApplication             `json:"app_type"`
+	TeamGeneration   keybase1.PerTeamKeyGeneration        `json:"team_generation"`
+	LegacyGeneration int                                  `json:"legacy_generation"`
+	KeysetHash       keybase1.TeamEncryptedKBFSKeysetHash `json:"encrypted_keyset_hash"`
 }
 
 func (a SCTeamAdmin) SigChainLocation() keybase1.SigChainLocation {

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -101,11 +101,20 @@ type SCTeamSettingsOpen struct {
 }
 
 type SCTeamKBFS struct {
-	TLF *SCTeamKBFSTLF `json:"tlf,omitempty"`
+	TLF     *SCTeamKBFSTLF           `json:"tlf,omitempty"`
+	Upgrade *SCTeamKBFSLegacyUpgrade `json:"legacy_upgrade,omitempty"`
 }
 
 type SCTeamKBFSTLF struct {
 	ID keybase1.TLFID `json:"id"`
+}
+
+type SCTeamKBFSLegacyUpgrade struct {
+	TeamGeneration   int
+	LegacyGeneration int
+	Keyset           string
+	KeysetHash       string
+	AppType          keybase1.TeamApplication
 }
 
 func (a SCTeamAdmin) SigChainLocation() keybase1.SigChainLocation {

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -110,11 +110,10 @@ type SCTeamKBFSTLF struct {
 }
 
 type SCTeamKBFSLegacyUpgrade struct {
-	TeamGeneration   int
-	LegacyGeneration int
-	Keyset           string
-	KeysetHash       string
-	AppType          keybase1.TeamApplication
+	TeamGeneration   int                      `json:"team_generation"`
+	LegacyGeneration int                      `json:"legacy_generation"`
+	KeysetHash       string                   `json:"encrypted_keyset_hash"`
+	AppType          keybase1.TeamApplication `json:"app_type"`
 }
 
 func (a SCTeamAdmin) SigChainLocation() keybase1.SigChainLocation {

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -101,8 +101,8 @@ type SCTeamSettingsOpen struct {
 }
 
 type SCTeamKBFS struct {
-	TLF     *SCTeamKBFSTLF           `json:"tlf,omitempty"`
-	Upgrade *SCTeamKBFSLegacyUpgrade `json:"legacy_upgrade,omitempty"`
+	TLF    *SCTeamKBFSTLF           `json:"tlf,omitempty"`
+	Keyset *SCTeamKBFSLegacyUpgrade `json:"legacy_tlf_upgrade,omitempty"`
 }
 
 type SCTeamKBFSTLF struct {
@@ -110,10 +110,8 @@ type SCTeamKBFSTLF struct {
 }
 
 type SCTeamKBFSLegacyUpgrade struct {
-	TeamGeneration   int                      `json:"team_generation"`
-	LegacyGeneration int                      `json:"legacy_generation"`
-	KeysetHash       string                   `json:"encrypted_keyset_hash"`
-	AppType          keybase1.TeamApplication `json:"app_type"`
+	AppType    keybase1.TeamApplication `json:"app_type"`
+	KeysetHash string                   `json:"encrypted_keyset_hash"`
 }
 
 func (a SCTeamAdmin) SigChainLocation() keybase1.SigChainLocation {

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -110,8 +110,10 @@ type SCTeamKBFSTLF struct {
 }
 
 type SCTeamKBFSLegacyUpgrade struct {
-	AppType    keybase1.TeamApplication `json:"app_type"`
-	KeysetHash string                   `json:"encrypted_keyset_hash"`
+	AppType          keybase1.TeamApplication `json:"app_type"`
+	TeamGeneration   int                      `json:"team_generation"`
+	LegacyGeneration int                      `json:"legacy_generation"`
+	KeysetHash       string                   `json:"encrypted_keyset_hash"`
 }
 
 func (a SCTeamAdmin) SigChainLocation() keybase1.SigChainLocation {

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -20,8 +20,9 @@ type rawTeam struct {
 	ReaderKeyMasks []keybase1.ReaderKeyMask                               `json:"reader_key_masks"`
 	// Whether the user is only being allowed to view the chain
 	// because they are a member of a descendent team.
-	SubteamReader bool                  `json:"subteam_reader"`
-	Showcase      keybase1.TeamShowcase `json:"showcase"`
+	SubteamReader    bool                             `json:"subteam_reader"`
+	Showcase         keybase1.TeamShowcase            `json:"showcase"`
+	LegacyTLFUpgrade keybase1.TeamGetLegacyTLFUpgrade `json:"legacy_tlf_upgrade"`
 }
 
 func (r *rawTeam) GetAppStatus() *libkb.AppStatus {

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -20,9 +20,9 @@ type rawTeam struct {
 	ReaderKeyMasks []keybase1.ReaderKeyMask                               `json:"reader_key_masks"`
 	// Whether the user is only being allowed to view the chain
 	// because they are a member of a descendent team.
-	SubteamReader    bool                             `json:"subteam_reader"`
-	Showcase         keybase1.TeamShowcase            `json:"showcase"`
-	LegacyTLFUpgrade keybase1.TeamGetLegacyTLFUpgrade `json:"legacy_tlf_upgrade"`
+	SubteamReader    bool                               `json:"subteam_reader"`
+	Showcase         keybase1.TeamShowcase              `json:"showcase"`
+	LegacyTLFUpgrade []keybase1.TeamGetLegacyTLFUpgrade `json:"legacy_tlf_upgrade"`
 }
 
 func (r *rawTeam) GetAppStatus() *libkb.AppStatus {

--- a/go/teams/kbfs_test.go
+++ b/go/teams/kbfs_test.go
@@ -1,0 +1,55 @@
+package teams
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func makeCryptKey(t *testing.T, gen int) keybase1.CryptKey {
+	var key [libkb.NaclDHKeysize]byte
+	_, err := rand.Read(key[:])
+	require.NoError(t, err)
+	return keybase1.CryptKey{
+		KeyGeneration: gen,
+		Key:           key,
+	}
+}
+
+func makeTLFID(t *testing.T) keybase1.TLFID {
+	b, err := libkb.RandBytesWithSuffix(16, 0x16)
+	require.NoError(t, err)
+	return keybase1.TLFID(hex.EncodeToString(b))
+}
+
+func TestKBFSUpgradeTeam(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	defer tc.Cleanup()
+
+	ctx := context.TODO()
+	user, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+	require.NoError(t, err)
+
+	teamID, _, _, _, err := LookupOrCreateImplicitTeam(ctx, tc.G, user.Username, false)
+	require.NoError(t, err)
+
+	team, err := Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
+		ID: teamID,
+	})
+	require.NoError(t, err)
+
+	tlfID := makeTLFID(t)
+	t.Logf("TLFID: %s", tlfID)
+	cryptKeys := []keybase1.CryptKey{
+		makeCryptKey(t, 1),
+		makeCryptKey(t, 2),
+		makeCryptKey(t, 3),
+	}
+	require.NoError(t, team.AssociateWithTLFKeyset(ctx, tlfID, cryptKeys, keybase1.TeamApplication_CHAT))
+}

--- a/go/teams/kbfs_test.go
+++ b/go/teams/kbfs_test.go
@@ -52,4 +52,14 @@ func TestKBFSUpgradeTeam(t *testing.T) {
 		makeCryptKey(t, 3),
 	}
 	require.NoError(t, team.AssociateWithTLFKeyset(ctx, tlfID, cryptKeys, keybase1.TeamApplication_CHAT))
+
+	team, err = Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
+		ID:          teamID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err)
+	resKeys := team.KBFSCryptKeys(ctx, keybase1.TeamApplication_CHAT)
+	require.Len(t, resKeys, len(cryptKeys))
+	require.Equal(t, cryptKeys, resKeys)
+	require.Equal(t, tlfID, team.KBFSTLFID())
 }

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -507,6 +507,13 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 				if err != nil {
 					return nil, fmt.Errorf("loading team secrets: %v", err)
 				}
+
+				if teamUpdate.LegacyTLFUpgrade != nil {
+					ret, err = l.addKBFSCryptKeys(ctx, ret, teamUpdate.LegacyTLFUpgrade)
+					if err != nil {
+						return nil, fmt.Errorf("loading KBFS crypt kerys: %v", err)
+					}
+				}
 			}
 		}
 	}

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -511,7 +511,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 				if teamUpdate.LegacyTLFUpgrade != nil {
 					ret, err = l.addKBFSCryptKeys(ctx, ret, teamUpdate.LegacyTLFUpgrade)
 					if err != nil {
-						return nil, fmt.Errorf("loading KBFS crypt kerys: %v", err)
+						return nil, fmt.Errorf("loading KBFS crypt keys: %v", err)
 					}
 				}
 			}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -3,7 +3,6 @@ package teams
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -536,7 +535,7 @@ func (l *TeamLoader) unboxKBFSCryptKeys(ctx context.Context, key keybase1.TeamAp
 
 	// Check hash
 	sbytes := sha256.Sum256([]byte(encryptedKeyset))
-	if !keysetHash.SecureEqual(keybase1.TeamEncryptedKBFSKeysetHashFromString(hex.EncodeToString(sbytes[:]))) {
+	if !keysetHash.SecureEqual(keybase1.TeamEncryptedKBFSKeysetHashFromBytes(sbytes[:])) {
 		return nil, errors.New("encrypted TLF upgrade does not match sigchain hash")
 	}
 

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -532,11 +532,11 @@ func (l *TeamLoader) checkProofs(ctx context.Context,
 }
 
 func (l *TeamLoader) unboxKBFSCryptKeys(ctx context.Context, key keybase1.TeamApplicationKey,
-	keysetHash string, encryptedKeyset string) ([]keybase1.CryptKey, error) {
+	keysetHash keybase1.TeamEncryptedKBFSKeysetHash, encryptedKeyset string) ([]keybase1.CryptKey, error) {
 
 	// Check hash
 	sbytes := sha256.Sum256([]byte(encryptedKeyset))
-	if hex.EncodeToString(sbytes[:]) != keysetHash {
+	if !keysetHash.SecureEqual(keybase1.TeamEncryptedKBFSKeysetHashFromString(hex.EncodeToString(sbytes[:]))) {
 		return nil, errors.New("encrypted TLF upgrade does not match sigchain hash")
 	}
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1156,7 +1156,7 @@ func CreateTLF(ctx context.Context, g *libkb.GlobalContext, arg keybase1.CreateT
 		if !role.IsWriterOrAbove() {
 			return fmt.Errorf("permission denied: need writer access (or above)")
 		}
-		return t.associateTLFID(ctx, arg.TlfID)
+		return t.AssociateWithTLFID(ctx, arg.TlfID)
 	})
 }
 

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/keybase/go-codec/codec"
 
@@ -1536,6 +1537,11 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 		t.G().Log.CDebugf(ctx, "AssociateWithTLFKeyset: no crypt keys given, just posting TLF ID")
 		return t.AssociateWithTLFID(ctx, tlfID)
 	}
+
+	// Sort crypt keys by generation (just in case they aren't naturally)
+	sort.Slice(cryptKeys, func(i, j int) bool {
+		return cryptKeys[i].KeyGeneration < cryptKeys[j].KeyGeneration
+	})
 
 	teamKeys, err := t.AllApplicationKeys(ctx, appType)
 	if err != nil {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -79,8 +79,8 @@ func (t *Team) KBFSTLFID() keybase1.TLFID {
 	return t.chain().inner.TlfID
 }
 
-func (t *Team) KBFSCryptKeys(ctx context.Context, appType keybase1.TeamApplication) (res []keybase1.CryptKey, err error) {
-	return nil, nil
+func (t *Team) KBFSCryptKeys(ctx context.Context, appType keybase1.TeamApplication) []keybase1.CryptKey {
+	return t.Data.TlfCryptKeys[appType]
 }
 
 func (t *Team) SharedSecret(ctx context.Context) (ret keybase1.PerTeamKeySeed, err error) {
@@ -1551,8 +1551,10 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 	}
 
 	upgrade := SCTeamKBFSLegacyUpgrade{
-		AppType:    appType,
-		KeysetHash: hashStr,
+		AppType:          appType,
+		KeysetHash:       hashStr,
+		LegacyGeneration: cryptKeys[len(cryptKeys)-1].Generation(),
+		TeamGeneration:   latestKey.Generation(),
 	}
 	teamSection := SCTeamSection{
 		ID:       SCTeamID(t.ID),

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1558,9 +1558,9 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 
 	upgrade := SCTeamKBFSLegacyUpgrade{
 		AppType:          appType,
-		KeysetHash:       hashStr,
+		KeysetHash:       keybase1.TeamEncryptedKBFSKeysetHashFromString(hashStr),
 		LegacyGeneration: cryptKeys[len(cryptKeys)-1].Generation(),
-		TeamGeneration:   latestKey.Generation(),
+		TeamGeneration:   latestKey.KeyGeneration,
 	}
 	teamSection := SCTeamSection{
 		ID:       SCTeamID(t.ID),
@@ -1588,7 +1588,7 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 		legacyTLFUpgrade: &keybase1.TeamGetLegacyTLFUpgrade{
 			EncryptedKeyset:  encStr,
 			LegacyGeneration: cryptKeys[len(cryptKeys)-1].Generation(),
-			TeamGeneration:   latestKey.Generation(),
+			TeamGeneration:   latestKey.KeyGeneration,
 			AppType:          appType,
 		},
 	})

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1534,8 +1534,8 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 
 	// If we get no crypt keys, just associate TLF ID and bail
 	if len(cryptKeys) == 0 {
-		t.G().Log.CDebugf(ctx, "AssociateWithTLFKeyset: no crypt keys given, just posting TLF ID")
-		return t.AssociateWithTLFID(ctx, tlfID)
+		t.G().Log.CDebugf(ctx, "AssociateWithTLFKeyset: no crypt keys given, aborting")
+		return nil
 	}
 
 	// Sort crypt keys by generation (just in case they aren't naturally)
@@ -1567,9 +1567,6 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 		Implicit: t.IsImplicit(),
 		Public:   t.IsPublic(),
 		KBFS: &SCTeamKBFS{
-			TLF: &SCTeamKBFSTLF{
-				ID: tlfID,
-			},
 			Keyset: &upgrade,
 		},
 	}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1585,7 +1585,7 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 		legacyTLFUpgrade: &keybase1.TeamGetLegacyTLFUpgrade{
 			EncryptedKeyset:  encStr,
 			LegacyGeneration: cryptKeys[len(cryptKeys)-1].Generation(),
-			TeamGeneration:   keybase1.PerTeamKeyGeneration(latestKey.Generation()),
+			TeamGeneration:   latestKey.Generation(),
 			AppType:          appType,
 		},
 	})

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -88,6 +88,7 @@ func (t *Team) KBFSCryptKeys(ctx context.Context, appType keybase1.TeamApplicati
 	t.kbfsCryptKeysLock.Lock()
 	defer t.kbfsCryptKeysLock.Unlock()
 
+	// Check to see if we have already computed this value
 	var ok bool
 	if res, ok = t.kbfsCryptKeys[appType]; ok {
 		return res, nil
@@ -1390,6 +1391,7 @@ type sigPayloadArgs struct {
 	implicitAdminBoxes map[keybase1.TeamID]*PerTeamSharedSecretBoxes
 	lease              *libkb.Lease
 	prePayload         libkb.JSONPayload
+	kbfsTLFKeyset      string
 }
 
 func (t *Team) sigPayload(sigMultiItem libkb.SigMultiItem, args sigPayloadArgs) libkb.JSONPayload {
@@ -1407,6 +1409,9 @@ func (t *Team) sigPayload(sigMultiItem libkb.SigMultiItem, args sigPayloadArgs) 
 	}
 	if args.lease != nil {
 		payload["downgrade_lease_id"] = args.lease.LeaseID
+	}
+	if args.kbfsTLFKeyset != "" {
+		payload["encrypted_keyset"] = args.kbfsTLFKeyset
 	}
 
 	if t.G().VDL.DumpPayload() {
@@ -1676,7 +1681,6 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 		AppType:          appType,
 		LegacyGeneration: cryptKeys[len(cryptKeys)-1].Generation(),
 		TeamGeneration:   latestKey.Generation(),
-		Keyset:           encStr,
 		KeysetHash:       hashStr,
 	}
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -159,6 +159,9 @@ protocol teams {
 
     // Should only be used by TeamLoader (because it is mutable, not threadsafe to read)
     Time cachedAt;
+
+    // Associated TLF crypt keys
+    map<TeamApplication, array<CryptKey>> tlfCryptKeys;
   }
 
   enum TeamInviteCategory {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -214,16 +214,19 @@ protocol teams {
     @jsonkey("encrypted_keyset")
     string encryptedKeyset;
     @jsonkey("team_generation")
-    int teamGeneration;
+    PerTeamKeyGeneration teamGeneration;
     @jsonkey("legacy_generation")
     int legacyGeneration;
     @jsonkey("app_type")
     TeamApplication appType;
   }
 
+  @typedef("string")
+  record TeamEncryptedKBFSKeysetHash {}
+
   record TeamLegacyTLFUpgradeChainInfo {
-    string keysetHash;
-    int teamGeneration;
+    TeamEncryptedKBFSKeysetHash keysetHash;
+    PerTeamKeyGeneration teamGeneration;
     int legacyGeneration;
     TeamApplication appType;
   }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -214,10 +214,17 @@ protocol teams {
     @jsonkey("encrypted_keyset")
     string encryptedKeyset;
     @jsonkey("team_generation")
-    PerTeamKeyGeneration teamGeneration;
+    int teamGeneration;
     @jsonkey("legacy_generation")
     int legacyGeneration;
     @jsonkey("app_type")
+    TeamApplication appType;
+  }
+
+  record TeamLegacyTLFUpgradeChainInfo {
+    string keysetHash;
+    int teamGeneration;
+    int legacyGeneration;
     TeamApplication appType;
   }
 
@@ -288,7 +295,7 @@ protocol teams {
 
     // Information about KBFS TLF crypt keys for the TLF associated with this team. The latest
     // link per app type is what shows up here.
-    map<TeamApplication, string> tlfLegacyUpgrade;
+    map<TeamApplication, TeamLegacyTLFUpgradeChainInfo> tlfLegacyUpgrade;
   }
 
   // The team got this name at this point in time.

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -201,6 +201,12 @@ protocol teams {
     boolean userActive;
   }
 
+  record TeamEncryptedKBFSKeyset {
+    int v;
+    bytes e;
+    bytes n;
+  }
+
   // State of a parsed team sigchain.
   // Should be treated as immutable when outside TeamSigChainPlayer.
   // Modified internally to TeamSigChainPlayer.
@@ -265,6 +271,10 @@ protocol teams {
     // here, and we are not concerned about historical associations that have been
     // overwritten (for now). An empty TLFID is given by an empty string.
     TLFID tlfID;
+
+    // Information about KBFS TLF crypt keys for the TLF associated with this team. The latest
+    // link per app type is what shows up here.
+    map<TeamApplication, TeamEncryptedKBFSKeyset> tlfCryptKeys;
   }
 
   // The team got this name at this point in time.

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -207,6 +207,11 @@ protocol teams {
     bytes n;
   }
 
+  record TeamEncryptedKBFSCryptKeys {
+    PerTeamKeyGeneration generation;
+    TeamEncryptedKBFSKeyset keyset;
+  }
+
   // State of a parsed team sigchain.
   // Should be treated as immutable when outside TeamSigChainPlayer.
   // Modified internally to TeamSigChainPlayer.
@@ -274,7 +279,7 @@ protocol teams {
 
     // Information about KBFS TLF crypt keys for the TLF associated with this team. The latest
     // link per app type is what shows up here.
-    map<TeamApplication, TeamEncryptedKBFSKeyset> tlfCryptKeys;
+    map<TeamApplication, TeamEncryptedKBFSCryptKeys> tlfCryptKeys;
   }
 
   // The team got this name at this point in time.

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -207,9 +207,15 @@ protocol teams {
     bytes n;
   }
 
-  record TeamEncryptedKBFSCryptKeys {
-    PerTeamKeyGeneration generation;
-    TeamEncryptedKBFSKeyset keyset;
+  record TeamGetLegacyTLFUpgrade {
+    @jsonkey("encrypted_keyset")
+    string encryptedKeyset;
+    @jsonkey("team_generation")
+    PerTeamKeyGeneration teamGeneration;
+    @jsonkey("legacy_generation")
+    int legacyGeneration;
+    @jsonkey("app_type")
+    TeamApplication appType;
   }
 
   // State of a parsed team sigchain.
@@ -279,7 +285,7 @@ protocol teams {
 
     // Information about KBFS TLF crypt keys for the TLF associated with this team. The latest
     // link per app type is what shows up here.
-    map<TeamApplication, TeamEncryptedKBFSCryptKeys> tlfCryptKeys;
+    map<TeamApplication, string> tlfLegacyUpgrade;
   }
 
   // The team got this name at this point in time.

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3537,9 +3537,11 @@ export type TeamDetails = $ReadOnly<{members: TeamMembersDetails, keyGeneration:
 
 export type TeamEncryptedKBFSKeyset = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
+export type TeamEncryptedKBFSKeysetHash = String
+
 export type TeamExitRow = $ReadOnly<{id: TeamID}>
 
-export type TeamGetLegacyTLFUpgrade = $ReadOnly<{encryptedKeyset: String, teamGeneration: Int, legacyGeneration: Int, appType: TeamApplication}>
+export type TeamGetLegacyTLFUpgrade = $ReadOnly<{encryptedKeyset: String, teamGeneration: PerTeamKeyGeneration, legacyGeneration: Int, appType: TeamApplication}>
 
 export type TeamID = String
 
@@ -3569,7 +3571,7 @@ export type TeamInvitee = $ReadOnly<{inviteID: TeamInviteID, uid: UID, eldestSeq
 
 export type TeamJoinRequest = $ReadOnly<{name: String, username: String}>
 
-export type TeamLegacyTLFUpgradeChainInfo = $ReadOnly<{keysetHash: String, teamGeneration: Int, legacyGeneration: Int, appType: TeamApplication}>
+export type TeamLegacyTLFUpgradeChainInfo = $ReadOnly<{keysetHash: TeamEncryptedKBFSKeysetHash, teamGeneration: PerTeamKeyGeneration, legacyGeneration: Int, appType: TeamApplication}>
 
 export type TeamList = $ReadOnly<{teams?: ?Array<MemberInfo>}>
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3529,7 +3529,7 @@ export type TeamChangeSet = $ReadOnly<{membershipChanged: Boolean, keyRotated: B
 
 export type TeamCreateResult = $ReadOnly<{teamID: TeamID, chatSent: Boolean, creatorAdded: Boolean}>
 
-export type TeamData = $ReadOnly<{secretless: Boolean, name: TeamName, chain: TeamSigChainState, perTeamKeySeeds: {[key: string]: PerTeamKeySeedItem}, readerKeyMasks: {[key: string]: {[key: string]: MaskB64}}, latestSeqnoHint: Seqno, cachedAt: Time}>
+export type TeamData = $ReadOnly<{secretless: Boolean, name: TeamName, chain: TeamSigChainState, perTeamKeySeeds: {[key: string]: PerTeamKeySeedItem}, readerKeyMasks: {[key: string]: {[key: string]: MaskB64}}, latestSeqnoHint: Seqno, cachedAt: Time, tlfCryptKeys: {[key: string]: ?Array<CryptKey>}}>
 
 export type TeamDebugRes = $ReadOnly<{chain: TeamSigChainState}>
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3535,11 +3535,11 @@ export type TeamDebugRes = $ReadOnly<{chain: TeamSigChainState}>
 
 export type TeamDetails = $ReadOnly<{members: TeamMembersDetails, keyGeneration: PerTeamKeyGeneration, annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}, settings: TeamSettings, showcase: TeamShowcase}>
 
-export type TeamEncryptedKBFSCryptKeys = $ReadOnly<{generation: PerTeamKeyGeneration, keyset: TeamEncryptedKBFSKeyset}>
-
 export type TeamEncryptedKBFSKeyset = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
 export type TeamExitRow = $ReadOnly<{id: TeamID}>
+
+export type TeamGetLegacyTLFUpgrade = $ReadOnly<{encryptedKeyset: String, teamGeneration: PerTeamKeyGeneration, legacyGeneration: Int, appType: TeamApplication}>
 
 export type TeamID = String
 
@@ -3618,7 +3618,7 @@ export type TeamSettings = $ReadOnly<{open: Boolean, joinAs: TeamRole}>
 
 export type TeamShowcase = $ReadOnly<{isShowcased: Boolean, description?: ?String, setByUID?: ?UID, anyMemberShowcase: Boolean}>
 
-export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfCryptKeys: {[key: string]: TeamEncryptedKBFSCryptKeys}}>
+export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfLegacyUpgrade: {[key: string]: String}}>
 
 export type TeamTreeEntry = $ReadOnly<{name: TeamName, admin: Boolean}>
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3539,7 +3539,7 @@ export type TeamEncryptedKBFSKeyset = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
 export type TeamExitRow = $ReadOnly<{id: TeamID}>
 
-export type TeamGetLegacyTLFUpgrade = $ReadOnly<{encryptedKeyset: String, teamGeneration: PerTeamKeyGeneration, legacyGeneration: Int, appType: TeamApplication}>
+export type TeamGetLegacyTLFUpgrade = $ReadOnly<{encryptedKeyset: String, teamGeneration: Int, legacyGeneration: Int, appType: TeamApplication}>
 
 export type TeamID = String
 
@@ -3568,6 +3568,8 @@ export type TeamInviteType = {c: 1, unknown: ?String} | {c: 4, sbs: ?TeamInviteS
 export type TeamInvitee = $ReadOnly<{inviteID: TeamInviteID, uid: UID, eldestSeqno: Seqno, role: TeamRole}>
 
 export type TeamJoinRequest = $ReadOnly<{name: String, username: String}>
+
+export type TeamLegacyTLFUpgradeChainInfo = $ReadOnly<{keysetHash: String, teamGeneration: Int, legacyGeneration: Int, appType: TeamApplication}>
 
 export type TeamList = $ReadOnly<{teams?: ?Array<MemberInfo>}>
 
@@ -3618,7 +3620,7 @@ export type TeamSettings = $ReadOnly<{open: Boolean, joinAs: TeamRole}>
 
 export type TeamShowcase = $ReadOnly<{isShowcased: Boolean, description?: ?String, setByUID?: ?UID, anyMemberShowcase: Boolean}>
 
-export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfLegacyUpgrade: {[key: string]: String}}>
+export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfLegacyUpgrade: {[key: string]: TeamLegacyTLFUpgradeChainInfo}}>
 
 export type TeamTreeEntry = $ReadOnly<{name: TeamName, admin: Boolean}>
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3535,6 +3535,8 @@ export type TeamDebugRes = $ReadOnly<{chain: TeamSigChainState}>
 
 export type TeamDetails = $ReadOnly<{members: TeamMembersDetails, keyGeneration: PerTeamKeyGeneration, annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}, settings: TeamSettings, showcase: TeamShowcase}>
 
+export type TeamEncryptedKBFSCryptKeys = $ReadOnly<{generation: PerTeamKeyGeneration, keyset: TeamEncryptedKBFSKeyset}>
+
 export type TeamEncryptedKBFSKeyset = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
 export type TeamExitRow = $ReadOnly<{id: TeamID}>
@@ -3616,7 +3618,7 @@ export type TeamSettings = $ReadOnly<{open: Boolean, joinAs: TeamRole}>
 
 export type TeamShowcase = $ReadOnly<{isShowcased: Boolean, description?: ?String, setByUID?: ?UID, anyMemberShowcase: Boolean}>
 
-export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfCryptKeys: {[key: string]: TeamEncryptedKBFSKeyset}}>
+export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfCryptKeys: {[key: string]: TeamEncryptedKBFSCryptKeys}}>
 
 export type TeamTreeEntry = $ReadOnly<{name: TeamName, admin: Boolean}>
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3535,6 +3535,8 @@ export type TeamDebugRes = $ReadOnly<{chain: TeamSigChainState}>
 
 export type TeamDetails = $ReadOnly<{members: TeamMembersDetails, keyGeneration: PerTeamKeyGeneration, annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}, settings: TeamSettings, showcase: TeamShowcase}>
 
+export type TeamEncryptedKBFSKeyset = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
+
 export type TeamExitRow = $ReadOnly<{id: TeamID}>
 
 export type TeamID = String
@@ -3614,7 +3616,7 @@ export type TeamSettings = $ReadOnly<{open: Boolean, joinAs: TeamRole}>
 
 export type TeamShowcase = $ReadOnly<{isShowcased: Boolean, description?: ?String, setByUID?: ?UID, anyMemberShowcase: Boolean}>
 
-export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID}>
+export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfCryptKeys: {[key: string]: TeamEncryptedKBFSKeyset}}>
 
 export type TeamTreeEntry = $ReadOnly<{name: TeamName, admin: Boolean}>
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -575,6 +575,20 @@
     },
     {
       "type": "record",
+      "name": "TeamEncryptedKBFSCryptKeys",
+      "fields": [
+        {
+          "type": "PerTeamKeyGeneration",
+          "name": "generation"
+        },
+        {
+          "type": "TeamEncryptedKBFSKeyset",
+          "name": "keyset"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "TeamSigChainState",
       "fields": [
         {
@@ -700,7 +714,7 @@
         {
           "type": {
             "type": "map",
-            "values": "TeamEncryptedKBFSKeyset",
+            "values": "TeamEncryptedKBFSCryptKeys",
             "keys": "TeamApplication"
           },
           "name": "tlfCryptKeys"

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -557,6 +557,24 @@
     },
     {
       "type": "record",
+      "name": "TeamEncryptedKBFSKeyset",
+      "fields": [
+        {
+          "type": "int",
+          "name": "v"
+        },
+        {
+          "type": "bytes",
+          "name": "e"
+        },
+        {
+          "type": "bytes",
+          "name": "n"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "TeamSigChainState",
       "fields": [
         {
@@ -678,6 +696,14 @@
         {
           "type": "TLFID",
           "name": "tlfID"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "TeamEncryptedKBFSKeyset",
+            "keys": "TeamApplication"
+          },
+          "name": "tlfCryptKeys"
         }
       ]
     },

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -594,7 +594,7 @@
           "jsonkey": "encrypted_keyset"
         },
         {
-          "type": "PerTeamKeyGeneration",
+          "type": "int",
           "name": "teamGeneration",
           "jsonkey": "team_generation"
         },
@@ -607,6 +607,28 @@
           "type": "TeamApplication",
           "name": "appType",
           "jsonkey": "app_type"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "TeamLegacyTLFUpgradeChainInfo",
+      "fields": [
+        {
+          "type": "string",
+          "name": "keysetHash"
+        },
+        {
+          "type": "int",
+          "name": "teamGeneration"
+        },
+        {
+          "type": "int",
+          "name": "legacyGeneration"
+        },
+        {
+          "type": "TeamApplication",
+          "name": "appType"
         }
       ]
     },
@@ -737,7 +759,7 @@
         {
           "type": {
             "type": "map",
-            "values": "string",
+            "values": "TeamLegacyTLFUpgradeChainInfo",
             "keys": "TeamApplication"
           },
           "name": "tlfLegacyUpgrade"

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -594,7 +594,7 @@
           "jsonkey": "encrypted_keyset"
         },
         {
-          "type": "int",
+          "type": "PerTeamKeyGeneration",
           "name": "teamGeneration",
           "jsonkey": "team_generation"
         },
@@ -612,14 +612,20 @@
     },
     {
       "type": "record",
+      "name": "TeamEncryptedKBFSKeysetHash",
+      "fields": [],
+      "typedef": "string"
+    },
+    {
+      "type": "record",
       "name": "TeamLegacyTLFUpgradeChainInfo",
       "fields": [
         {
-          "type": "string",
+          "type": "TeamEncryptedKBFSKeysetHash",
           "name": "keysetHash"
         },
         {
-          "type": "int",
+          "type": "PerTeamKeyGeneration",
           "name": "teamGeneration"
         },
         {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -575,15 +575,27 @@
     },
     {
       "type": "record",
-      "name": "TeamEncryptedKBFSCryptKeys",
+      "name": "TeamGetLegacyTLFUpgrade",
       "fields": [
         {
-          "type": "PerTeamKeyGeneration",
-          "name": "generation"
+          "type": "string",
+          "name": "encryptedKeyset",
+          "jsonkey": "encrypted_keyset"
         },
         {
-          "type": "TeamEncryptedKBFSKeyset",
-          "name": "keyset"
+          "type": "PerTeamKeyGeneration",
+          "name": "teamGeneration",
+          "jsonkey": "team_generation"
+        },
+        {
+          "type": "int",
+          "name": "legacyGeneration",
+          "jsonkey": "legacy_generation"
+        },
+        {
+          "type": "TeamApplication",
+          "name": "appType",
+          "jsonkey": "app_type"
         }
       ]
     },
@@ -714,10 +726,10 @@
         {
           "type": {
             "type": "map",
-            "values": "TeamEncryptedKBFSCryptKeys",
+            "values": "string",
             "keys": "TeamApplication"
           },
-          "name": "tlfCryptKeys"
+          "name": "tlfLegacyUpgrade"
         }
       ]
     },

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -430,6 +430,17 @@
         {
           "type": "Time",
           "name": "cachedAt"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": {
+              "type": "array",
+              "items": "CryptKey"
+            },
+            "keys": "TeamApplication"
+          },
+          "name": "tlfCryptKeys"
         }
       ]
     },

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3537,9 +3537,11 @@ export type TeamDetails = $ReadOnly<{members: TeamMembersDetails, keyGeneration:
 
 export type TeamEncryptedKBFSKeyset = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
+export type TeamEncryptedKBFSKeysetHash = String
+
 export type TeamExitRow = $ReadOnly<{id: TeamID}>
 
-export type TeamGetLegacyTLFUpgrade = $ReadOnly<{encryptedKeyset: String, teamGeneration: Int, legacyGeneration: Int, appType: TeamApplication}>
+export type TeamGetLegacyTLFUpgrade = $ReadOnly<{encryptedKeyset: String, teamGeneration: PerTeamKeyGeneration, legacyGeneration: Int, appType: TeamApplication}>
 
 export type TeamID = String
 
@@ -3569,7 +3571,7 @@ export type TeamInvitee = $ReadOnly<{inviteID: TeamInviteID, uid: UID, eldestSeq
 
 export type TeamJoinRequest = $ReadOnly<{name: String, username: String}>
 
-export type TeamLegacyTLFUpgradeChainInfo = $ReadOnly<{keysetHash: String, teamGeneration: Int, legacyGeneration: Int, appType: TeamApplication}>
+export type TeamLegacyTLFUpgradeChainInfo = $ReadOnly<{keysetHash: TeamEncryptedKBFSKeysetHash, teamGeneration: PerTeamKeyGeneration, legacyGeneration: Int, appType: TeamApplication}>
 
 export type TeamList = $ReadOnly<{teams?: ?Array<MemberInfo>}>
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3529,7 +3529,7 @@ export type TeamChangeSet = $ReadOnly<{membershipChanged: Boolean, keyRotated: B
 
 export type TeamCreateResult = $ReadOnly<{teamID: TeamID, chatSent: Boolean, creatorAdded: Boolean}>
 
-export type TeamData = $ReadOnly<{secretless: Boolean, name: TeamName, chain: TeamSigChainState, perTeamKeySeeds: {[key: string]: PerTeamKeySeedItem}, readerKeyMasks: {[key: string]: {[key: string]: MaskB64}}, latestSeqnoHint: Seqno, cachedAt: Time}>
+export type TeamData = $ReadOnly<{secretless: Boolean, name: TeamName, chain: TeamSigChainState, perTeamKeySeeds: {[key: string]: PerTeamKeySeedItem}, readerKeyMasks: {[key: string]: {[key: string]: MaskB64}}, latestSeqnoHint: Seqno, cachedAt: Time, tlfCryptKeys: {[key: string]: ?Array<CryptKey>}}>
 
 export type TeamDebugRes = $ReadOnly<{chain: TeamSigChainState}>
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3535,11 +3535,11 @@ export type TeamDebugRes = $ReadOnly<{chain: TeamSigChainState}>
 
 export type TeamDetails = $ReadOnly<{members: TeamMembersDetails, keyGeneration: PerTeamKeyGeneration, annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}, settings: TeamSettings, showcase: TeamShowcase}>
 
-export type TeamEncryptedKBFSCryptKeys = $ReadOnly<{generation: PerTeamKeyGeneration, keyset: TeamEncryptedKBFSKeyset}>
-
 export type TeamEncryptedKBFSKeyset = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
 export type TeamExitRow = $ReadOnly<{id: TeamID}>
+
+export type TeamGetLegacyTLFUpgrade = $ReadOnly<{encryptedKeyset: String, teamGeneration: PerTeamKeyGeneration, legacyGeneration: Int, appType: TeamApplication}>
 
 export type TeamID = String
 
@@ -3618,7 +3618,7 @@ export type TeamSettings = $ReadOnly<{open: Boolean, joinAs: TeamRole}>
 
 export type TeamShowcase = $ReadOnly<{isShowcased: Boolean, description?: ?String, setByUID?: ?UID, anyMemberShowcase: Boolean}>
 
-export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfCryptKeys: {[key: string]: TeamEncryptedKBFSCryptKeys}}>
+export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfLegacyUpgrade: {[key: string]: String}}>
 
 export type TeamTreeEntry = $ReadOnly<{name: TeamName, admin: Boolean}>
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3539,7 +3539,7 @@ export type TeamEncryptedKBFSKeyset = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
 export type TeamExitRow = $ReadOnly<{id: TeamID}>
 
-export type TeamGetLegacyTLFUpgrade = $ReadOnly<{encryptedKeyset: String, teamGeneration: PerTeamKeyGeneration, legacyGeneration: Int, appType: TeamApplication}>
+export type TeamGetLegacyTLFUpgrade = $ReadOnly<{encryptedKeyset: String, teamGeneration: Int, legacyGeneration: Int, appType: TeamApplication}>
 
 export type TeamID = String
 
@@ -3568,6 +3568,8 @@ export type TeamInviteType = {c: 1, unknown: ?String} | {c: 4, sbs: ?TeamInviteS
 export type TeamInvitee = $ReadOnly<{inviteID: TeamInviteID, uid: UID, eldestSeqno: Seqno, role: TeamRole}>
 
 export type TeamJoinRequest = $ReadOnly<{name: String, username: String}>
+
+export type TeamLegacyTLFUpgradeChainInfo = $ReadOnly<{keysetHash: String, teamGeneration: Int, legacyGeneration: Int, appType: TeamApplication}>
 
 export type TeamList = $ReadOnly<{teams?: ?Array<MemberInfo>}>
 
@@ -3618,7 +3620,7 @@ export type TeamSettings = $ReadOnly<{open: Boolean, joinAs: TeamRole}>
 
 export type TeamShowcase = $ReadOnly<{isShowcased: Boolean, description?: ?String, setByUID?: ?UID, anyMemberShowcase: Boolean}>
 
-export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfLegacyUpgrade: {[key: string]: String}}>
+export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfLegacyUpgrade: {[key: string]: TeamLegacyTLFUpgradeChainInfo}}>
 
 export type TeamTreeEntry = $ReadOnly<{name: TeamName, admin: Boolean}>
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3535,6 +3535,8 @@ export type TeamDebugRes = $ReadOnly<{chain: TeamSigChainState}>
 
 export type TeamDetails = $ReadOnly<{members: TeamMembersDetails, keyGeneration: PerTeamKeyGeneration, annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}, settings: TeamSettings, showcase: TeamShowcase}>
 
+export type TeamEncryptedKBFSCryptKeys = $ReadOnly<{generation: PerTeamKeyGeneration, keyset: TeamEncryptedKBFSKeyset}>
+
 export type TeamEncryptedKBFSKeyset = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
 export type TeamExitRow = $ReadOnly<{id: TeamID}>
@@ -3616,7 +3618,7 @@ export type TeamSettings = $ReadOnly<{open: Boolean, joinAs: TeamRole}>
 
 export type TeamShowcase = $ReadOnly<{isShowcased: Boolean, description?: ?String, setByUID?: ?UID, anyMemberShowcase: Boolean}>
 
-export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfCryptKeys: {[key: string]: TeamEncryptedKBFSKeyset}}>
+export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfCryptKeys: {[key: string]: TeamEncryptedKBFSCryptKeys}}>
 
 export type TeamTreeEntry = $ReadOnly<{name: TeamName, admin: Boolean}>
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3535,6 +3535,8 @@ export type TeamDebugRes = $ReadOnly<{chain: TeamSigChainState}>
 
 export type TeamDetails = $ReadOnly<{members: TeamMembersDetails, keyGeneration: PerTeamKeyGeneration, annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}, settings: TeamSettings, showcase: TeamShowcase}>
 
+export type TeamEncryptedKBFSKeyset = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
+
 export type TeamExitRow = $ReadOnly<{id: TeamID}>
 
 export type TeamID = String
@@ -3614,7 +3616,7 @@ export type TeamSettings = $ReadOnly<{open: Boolean, joinAs: TeamRole}>
 
 export type TeamShowcase = $ReadOnly<{isShowcased: Boolean, description?: ?String, setByUID?: ?UID, anyMemberShowcase: Boolean}>
 
-export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID}>
+export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfCryptKeys: {[key: string]: TeamEncryptedKBFSKeyset}}>
 
 export type TeamTreeEntry = $ReadOnly<{name: TeamName, admin: Boolean}>
 


### PR DESCRIPTION
Patch does the following:

1.) Adds a new section to the KBFS settings team link type to hold the KBFS crypt keys and generation information.
2.) Adds a function to `Team` as an entry point to post a sig with this information on it.
3.) Adds logic to the team loader to properly decrypt the crypt keys information from the server and validate that it matches what is on the sig chain. Also stores the decrypted crypt keys in the team loader cache. 