### PR TITLE
User/channel mentions on Android

### DIFF
--- a/shared/chat/conversation/input/index.js.flow
+++ b/shared/chat/conversation/input/index.js.flow
@@ -44,6 +44,7 @@ export type MentionHocProps = {
   onSelectionChange?: ({selectionStart: number, selectionEnd: number}) => void,
   onBlur?: () => void,
   onFocus?: () => void,
+  insertMentionMarker?: () => void,
 
   onEnterKeyDown: (e: SyntheticKeyboardEvent<>) => void,
   pickSelectedCounter: number,

--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -172,6 +172,7 @@ class ConversationInput extends Component<Props> {
             editingMessage={this.props.editingMessage}
             openFilePicker={this._openFilePicker}
             isLoading={this.props.isLoading}
+            insertMentionMarker={this.props.insertMentionMarker}
           />
         </Box>
       </Box>
@@ -225,7 +226,7 @@ const Typing = ({typing}) => (
   </Box>
 )
 
-const Action = ({text, onSubmit, editingMessage, openFilePicker, isLoading}) =>
+const Action = ({text, onSubmit, editingMessage, openFilePicker, insertMentionMarker, isLoading}) =>
   text ? (
     <Box style={styleActionText}>
       <Text type="BodyBigLink" style={{...(isLoading ? {color: globalColors.grey} : {})}} onClick={onSubmit}>
@@ -234,7 +235,11 @@ const Action = ({text, onSubmit, editingMessage, openFilePicker, isLoading}) =>
     </Box>
   ) : (
     <Box style={styleActionButtonContainer}>
-      <Icon type="iconfont-mention" style={{...styleActionButton, paddingRight: 0}} />
+      <Icon
+        onClick={insertMentionMarker}
+        type="iconfont-mention"
+        style={{...styleActionButton, paddingRight: 0}}
+      />
       <Icon onClick={openFilePicker} type="iconfont-camera" style={styleActionButton} />
     </Box>
   )

--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -150,8 +150,10 @@ class ConversationInput extends Component<Props> {
               autoFocus={false}
               autoGrow={true}
               style={styleInput}
-              onChangeText={this.props.setText}
+              onChangeText={this.props.onChangeText}
               onBlur={this._onBlur}
+              onFocus={this.props.onFocus}
+              onSelectionChange={this.props.onSelectionChange}
               placeholder="Write a message"
               underlineColorAndroid={globalColors.transparent}
               multiline={true}

--- a/shared/chat/conversation/input/mention-handler-hoc.native.js
+++ b/shared/chat/conversation/input/mention-handler-hoc.native.js
@@ -116,11 +116,24 @@ const mentionHoc = (InputComponent: React.ComponentType<Props>) => {
     _replaceWordAtCursor = (w: string) => {
       const word = this._getWordAtCursor(this.props.text)
       const ss = this.state._selection.selectionStart
-      this._inputRef && this._inputRef.replaceText(w, ss - word.length, ss)
+
+      // can't use inputRef.replaceText because android custom input
+      // doesn't support it ootb
+      const existingText = this.props.text
+      const nextText = existingText.slice(0, ss - word.length) + w + existingText.slice(ss)
+      this.props.setText(nextText)
     }
 
-    onSelectionChange = (_selection: {selectionStart: number, selectionEnd: number}) =>
-      this.setState({_selection}, () => this.onChangeText(this.props.text))
+    onSelectionChange = (event: any) =>
+      this.setState(
+        {
+          _selection: {
+            selectionStart: event.nativeEvent.selection.start,
+            selectionEnd: event.nativeEvent.selection.end,
+          },
+        },
+        () => this.onChangeText(this.props.text)
+      )
 
     render = () => (
       <InputComponent

--- a/shared/chat/conversation/input/mention-handler-hoc.native.js
+++ b/shared/chat/conversation/input/mention-handler-hoc.native.js
@@ -105,6 +105,11 @@ const mentionHoc = (InputComponent: React.ComponentType<Props>) => {
       this.onChangeText(this.props.text)
     }
 
+    insertMentionMarker = () => {
+      this._replaceWordAtCursor('@')
+      this._inputRef && this._inputRef.focus()
+    }
+
     insertMention = (u: string) => {
       this._replaceWordAtCursor(`@${u} `)
     }
@@ -144,6 +149,7 @@ const mentionHoc = (InputComponent: React.ComponentType<Props>) => {
         setMentionPopupOpen={this.setMentionPopupOpen}
         setChannelMentionPopupOpen={this.setChannelMentionPopupOpen}
         inputSetRef={this.inputSetRef}
+        insertMentionMarker={this.insertMentionMarker}
         onBlur={this.onBlur}
         onFocus={this.onFocus}
         onEnterKeyDown={this.onEnterKeyDown}

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -180,7 +180,7 @@ class Input extends Component<Props, State> {
           selectionEnd: event.nativeEvent.selection.end,
         },
       },
-      () => this.props.onSelectionChange && this.props.onSelectionChange(this.state.selections)
+      () => this.props.onSelectionChange && this.props.onSelectionChange(event)
     )
   }
 

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -173,15 +173,13 @@ class Input extends Component<Props, State> {
   }
 
   _onSelectionChange = (event: any) => {
-    this.setState(
-      {
-        selections: {
-          selectionStart: event.nativeEvent.selection.start,
-          selectionEnd: event.nativeEvent.selection.end,
-        },
+    this.setState({
+      selections: {
+        selectionStart: event.nativeEvent.selection.start,
+        selectionEnd: event.nativeEvent.selection.end,
       },
-      () => this.props.onSelectionChange && this.props.onSelectionChange(event)
-    )
+    })
+    this.props.onSelectionChange && this.props.onSelectionChange(event)
   }
 
   // WARNING may not be up to date in time sensitive situations


### PR DESCRIPTION
This makes changes to the iOS PR to support the android custom input component. Modifies the `onSelectionChange` logic on the `input.native` to work with the way the custom input does it. Also adds the handler for the `@` action button.

r? @keybase/react-hackers 