### PR TITLE
set a bit on the message client header to indicate KBFS crypt keys were used CORE-7017

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -1118,17 +1118,18 @@ func (b *Boxer) boxV1(messagePlaintext chat1.MessagePlaintext, key types.CryptKe
 
 	// create the v1 header, adding hash
 	header := chat1.HeaderPlaintextV1{
-		Conv:         messagePlaintext.ClientHeader.Conv,
-		TlfName:      messagePlaintext.ClientHeader.TlfName,
-		TlfPublic:    messagePlaintext.ClientHeader.TlfPublic,
-		MessageType:  messagePlaintext.ClientHeader.MessageType,
-		Prev:         messagePlaintext.ClientHeader.Prev,
-		Sender:       messagePlaintext.ClientHeader.Sender,
-		SenderDevice: messagePlaintext.ClientHeader.SenderDevice,
-		MerkleRoot:   nil, // MerkleRoot cannot be sent in MBv1 messages
-		BodyHash:     bodyHash[:],
-		OutboxInfo:   messagePlaintext.ClientHeader.OutboxInfo,
-		OutboxID:     messagePlaintext.ClientHeader.OutboxID,
+		Conv:              messagePlaintext.ClientHeader.Conv,
+		TlfName:           messagePlaintext.ClientHeader.TlfName,
+		TlfPublic:         messagePlaintext.ClientHeader.TlfPublic,
+		MessageType:       messagePlaintext.ClientHeader.MessageType,
+		Prev:              messagePlaintext.ClientHeader.Prev,
+		Sender:            messagePlaintext.ClientHeader.Sender,
+		SenderDevice:      messagePlaintext.ClientHeader.SenderDevice,
+		MerkleRoot:        nil, // MerkleRoot cannot be sent in MBv1 messages
+		BodyHash:          bodyHash[:],
+		OutboxInfo:        messagePlaintext.ClientHeader.OutboxInfo,
+		OutboxID:          messagePlaintext.ClientHeader.OutboxID,
+		KbfsCryptKeysUsed: messagePlaintext.ClientHeader.KbfsCryptKeysUsed,
 	}
 
 	// sign the header and insert the signature
@@ -1184,17 +1185,18 @@ func (b *Boxer) boxV2(messagePlaintext chat1.MessagePlaintext, baseEncryptionKey
 
 	// create the v1 header, adding hash
 	headerVersioned := chat1.NewHeaderPlaintextWithV1(chat1.HeaderPlaintextV1{
-		Conv:         messagePlaintext.ClientHeader.Conv,
-		TlfName:      messagePlaintext.ClientHeader.TlfName,
-		TlfPublic:    messagePlaintext.ClientHeader.TlfPublic,
-		MessageType:  messagePlaintext.ClientHeader.MessageType,
-		Prev:         messagePlaintext.ClientHeader.Prev,
-		Sender:       messagePlaintext.ClientHeader.Sender,
-		SenderDevice: messagePlaintext.ClientHeader.SenderDevice,
-		BodyHash:     bodyHash,
-		MerkleRoot:   messagePlaintext.ClientHeader.MerkleRoot,
-		OutboxInfo:   messagePlaintext.ClientHeader.OutboxInfo,
-		OutboxID:     messagePlaintext.ClientHeader.OutboxID,
+		Conv:              messagePlaintext.ClientHeader.Conv,
+		TlfName:           messagePlaintext.ClientHeader.TlfName,
+		TlfPublic:         messagePlaintext.ClientHeader.TlfPublic,
+		MessageType:       messagePlaintext.ClientHeader.MessageType,
+		Prev:              messagePlaintext.ClientHeader.Prev,
+		Sender:            messagePlaintext.ClientHeader.Sender,
+		SenderDevice:      messagePlaintext.ClientHeader.SenderDevice,
+		BodyHash:          bodyHash,
+		MerkleRoot:        messagePlaintext.ClientHeader.MerkleRoot,
+		OutboxInfo:        messagePlaintext.ClientHeader.OutboxInfo,
+		OutboxID:          messagePlaintext.ClientHeader.OutboxID,
+		KbfsCryptKeysUsed: messagePlaintext.ClientHeader.KbfsCryptKeysUsed,
 		// In MessageBoxed.V2 HeaderSignature is nil.
 		HeaderSignature: nil,
 	})

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -470,9 +470,10 @@ func (b *Boxer) unboxV1(ctx context.Context, boxed chat1.MessageBoxed,
 			Sender:       hp.Sender,
 			SenderDevice: hp.SenderDevice,
 			// MerkleRoot is not expected to be in any v1 messages. Ignore it.
-			MerkleRoot: nil,
-			OutboxID:   hp.OutboxID,
-			OutboxInfo: hp.OutboxInfo,
+			MerkleRoot:        nil,
+			OutboxID:          hp.OutboxID,
+			OutboxInfo:        hp.OutboxInfo,
+			KbfsCryptKeysUsed: hp.KbfsCryptKeysUsed,
 		}
 	default:
 		return nil,
@@ -685,16 +686,17 @@ func (b *Boxer) unversionHeaderMBV2(ctx context.Context, headerVersioned chat1.H
 				NewPermanentUnboxingError(fmt.Errorf("HeaderSignature non-nil in MBV2"))
 		}
 		return chat1.MessageClientHeaderVerified{
-			Conv:         hp.Conv,
-			TlfName:      hp.TlfName,
-			TlfPublic:    hp.TlfPublic,
-			MessageType:  hp.MessageType,
-			Prev:         hp.Prev,
-			Sender:       hp.Sender,
-			SenderDevice: hp.SenderDevice,
-			MerkleRoot:   hp.MerkleRoot,
-			OutboxID:     hp.OutboxID,
-			OutboxInfo:   hp.OutboxInfo,
+			Conv:              hp.Conv,
+			TlfName:           hp.TlfName,
+			TlfPublic:         hp.TlfPublic,
+			MessageType:       hp.MessageType,
+			Prev:              hp.Prev,
+			Sender:            hp.Sender,
+			SenderDevice:      hp.SenderDevice,
+			MerkleRoot:        hp.MerkleRoot,
+			OutboxID:          hp.OutboxID,
+			OutboxInfo:        hp.OutboxInfo,
+			KbfsCryptKeysUsed: hp.KbfsCryptKeysUsed,
 		}, hp.BodyHash, nil
 	default:
 		return chat1.MessageClientHeaderVerified{}, nil,

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -492,7 +492,7 @@ var maxHolesForPull = 10
 
 func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (thread chat1.ThreadView, rl []*chat1.RateLimit, err error) {
-	defer s.Trace(ctx, func() error { return err }, "Pull")()
+	defer s.Trace(ctx, func() error { return err }, "Pull(%s)", convID)()
 	if convID.IsNil() {
 		return chat1.ThreadView{}, rl, errors.New("HybridConversationSource.Pull called with empty convID")
 	}
@@ -513,8 +513,8 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 		if err == nil {
 			// Since we are using the "holey" collector, we need to resolve any placeholder
 			// messages that may have been fetched.
-			s.Debug(ctx, "Pull: cache hit: convID: %s uid: %s holes: %d msgs: %d", convID, uid, rc.Holes(),
-				len(thread.Messages))
+			s.Debug(ctx, "Pull: cache hit: convID: %s uid: %s holes: %d msgs: %d", unboxConv.GetConvID(), uid,
+				rc.Holes(), len(thread.Messages))
 			err = s.resolveHoles(ctx, uid, &thread, conv)
 		}
 		if err == nil {

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -371,6 +371,10 @@ func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
 	if len(inbox.ConvsUnverified) == 0 {
 		return chat1.Conversation{}, ratelim, errGetUnverifiedConvNotFound
 	}
+	if !inbox.ConvsUnverified[0].GetConvID().Eq(convID) {
+		return chat1.Conversation{}, ratelim, fmt.Errorf("GetUnverifiedConv: convID mismatch: %s != %s",
+			inbox.ConvsUnverified[0].GetConvID(), convID)
+	}
 	return inbox.ConvsUnverified[0].Conv, ratelim, nil
 }
 

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -420,6 +420,14 @@ func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePla
 		s.Debug(ctx, "channel mention: %v", chanMention)
 	}
 
+	// If we are sending a message, and we think the conversation is a KBFS conversation, then set a label
+	// on the client header in case this conversation gets upgrade to impteam.
+	if membersType == chat1.ConversationMembersType_KBFS {
+		s.Debug(ctx, "setting KBFS crypt keys used flag")
+		msg.ClientHeader.KbfsCryptKeysUsed = new(bool)
+		*msg.ClientHeader.KbfsCryptKeysUsed = true
+	}
+
 	// For now, BoxMessage canonicalizes the TLF name. We should try to refactor
 	// it a bit to do it here.
 	boxed, err := s.boxer.BoxMessage(ctx, msg, membersType, skp)

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -14,9 +14,16 @@ import (
 	"golang.org/x/net/context"
 )
 
-func newBlankConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, uid gregor1.UID,
-	ri chat1.RemoteInterface, sender types.Sender, tlfName string) chat1.Conversation {
-	trip := newConvTriple(ctx, t, tc, tlfName)
+func newBlankConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext,
+	uid gregor1.UID, ri chat1.RemoteInterface, sender types.Sender, tlfName string) chat1.Conversation {
+	return newBlankConvWithMembersType(ctx, t, tc, uid, ri, sender, tlfName,
+		chat1.ConversationMembersType_KBFS)
+}
+
+func newBlankConvWithMembersType(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext,
+	uid gregor1.UID, ri chat1.RemoteInterface, sender types.Sender, tlfName string,
+	membersType chat1.ConversationMembersType) chat1.Conversation {
+	trip := newConvTripleWithMembersType(ctx, t, tc, tlfName, membersType)
 	firstMessagePlaintext := chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
@@ -26,12 +33,12 @@ func newBlankConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext,
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
-		chat1.ConversationMembersType_KBFS, nil)
+	firstMessageBoxed, _, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext, membersType, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
-		IdTriple:   trip,
-		TLFMessage: *firstMessageBoxed,
+		IdTriple:    trip,
+		TLFMessage:  *firstMessageBoxed,
+		MembersType: membersType,
 	})
 	require.NoError(t, err)
 

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -1003,19 +1003,20 @@ func (o OutboxInfo) DeepCopy() OutboxInfo {
 }
 
 type MessageClientHeader struct {
-	Conv          ConversationIDTriple     `codec:"conv" json:"conv"`
-	TlfName       string                   `codec:"tlfName" json:"tlfName"`
-	TlfPublic     bool                     `codec:"tlfPublic" json:"tlfPublic"`
-	MessageType   MessageType              `codec:"messageType" json:"messageType"`
-	Supersedes    MessageID                `codec:"supersedes" json:"supersedes"`
-	Deletes       []MessageID              `codec:"deletes" json:"deletes"`
-	Prev          []MessagePreviousPointer `codec:"prev" json:"prev"`
-	DeleteHistory *MessageDeleteHistory    `codec:"deleteHistory,omitempty" json:"deleteHistory,omitempty"`
-	Sender        gregor1.UID              `codec:"sender" json:"sender"`
-	SenderDevice  gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
-	MerkleRoot    *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
-	OutboxID      *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
-	OutboxInfo    *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
+	Conv              ConversationIDTriple     `codec:"conv" json:"conv"`
+	TlfName           string                   `codec:"tlfName" json:"tlfName"`
+	TlfPublic         bool                     `codec:"tlfPublic" json:"tlfPublic"`
+	MessageType       MessageType              `codec:"messageType" json:"messageType"`
+	Supersedes        MessageID                `codec:"supersedes" json:"supersedes"`
+	KbfsCryptKeysUsed *bool                    `codec:"kbfsCryptKeysUsed,omitempty" json:"kbfsCryptKeysUsed,omitempty"`
+	Deletes           []MessageID              `codec:"deletes" json:"deletes"`
+	Prev              []MessagePreviousPointer `codec:"prev" json:"prev"`
+	DeleteHistory     *MessageDeleteHistory    `codec:"deleteHistory,omitempty" json:"deleteHistory,omitempty"`
+	Sender            gregor1.UID              `codec:"sender" json:"sender"`
+	SenderDevice      gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
+	MerkleRoot        *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
+	OutboxID          *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	OutboxInfo        *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
 }
 
 func (o MessageClientHeader) DeepCopy() MessageClientHeader {
@@ -1025,6 +1026,13 @@ func (o MessageClientHeader) DeepCopy() MessageClientHeader {
 		TlfPublic:   o.TlfPublic,
 		MessageType: o.MessageType.DeepCopy(),
 		Supersedes:  o.Supersedes.DeepCopy(),
+		KbfsCryptKeysUsed: (func(x *bool) *bool {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.KbfsCryptKeysUsed),
 		Deletes: (func(x []MessageID) []MessageID {
 			if x == nil {
 				return nil
@@ -1081,16 +1089,17 @@ func (o MessageClientHeader) DeepCopy() MessageClientHeader {
 }
 
 type MessageClientHeaderVerified struct {
-	Conv         ConversationIDTriple     `codec:"conv" json:"conv"`
-	TlfName      string                   `codec:"tlfName" json:"tlfName"`
-	TlfPublic    bool                     `codec:"tlfPublic" json:"tlfPublic"`
-	MessageType  MessageType              `codec:"messageType" json:"messageType"`
-	Prev         []MessagePreviousPointer `codec:"prev" json:"prev"`
-	Sender       gregor1.UID              `codec:"sender" json:"sender"`
-	SenderDevice gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
-	MerkleRoot   *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
-	OutboxID     *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
-	OutboxInfo   *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
+	Conv              ConversationIDTriple     `codec:"conv" json:"conv"`
+	TlfName           string                   `codec:"tlfName" json:"tlfName"`
+	TlfPublic         bool                     `codec:"tlfPublic" json:"tlfPublic"`
+	MessageType       MessageType              `codec:"messageType" json:"messageType"`
+	Prev              []MessagePreviousPointer `codec:"prev" json:"prev"`
+	Sender            gregor1.UID              `codec:"sender" json:"sender"`
+	SenderDevice      gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
+	KbfsCryptKeysUsed *bool                    `codec:"kbfsCryptKeysUsed,omitempty" json:"kbfsCryptKeysUsed,omitempty"`
+	MerkleRoot        *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
+	OutboxID          *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	OutboxInfo        *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
 }
 
 func (o MessageClientHeaderVerified) DeepCopy() MessageClientHeaderVerified {
@@ -1112,6 +1121,13 @@ func (o MessageClientHeaderVerified) DeepCopy() MessageClientHeaderVerified {
 		})(o.Prev),
 		Sender:       o.Sender.DeepCopy(),
 		SenderDevice: o.SenderDevice.DeepCopy(),
+		KbfsCryptKeysUsed: (func(x *bool) *bool {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.KbfsCryptKeysUsed),
 		MerkleRoot: (func(x *MerkleRoot) *MerkleRoot {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1327,18 +1327,19 @@ func (o HeaderPlaintextUnsupported) DeepCopy() HeaderPlaintextUnsupported {
 }
 
 type HeaderPlaintextV1 struct {
-	Conv            ConversationIDTriple     `codec:"conv" json:"conv"`
-	TlfName         string                   `codec:"tlfName" json:"tlfName"`
-	TlfPublic       bool                     `codec:"tlfPublic" json:"tlfPublic"`
-	MessageType     MessageType              `codec:"messageType" json:"messageType"`
-	Prev            []MessagePreviousPointer `codec:"prev" json:"prev"`
-	Sender          gregor1.UID              `codec:"sender" json:"sender"`
-	SenderDevice    gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
-	BodyHash        Hash                     `codec:"bodyHash" json:"bodyHash"`
-	OutboxInfo      *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
-	OutboxID        *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
-	HeaderSignature *SignatureInfo           `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
-	MerkleRoot      *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
+	Conv              ConversationIDTriple     `codec:"conv" json:"conv"`
+	TlfName           string                   `codec:"tlfName" json:"tlfName"`
+	TlfPublic         bool                     `codec:"tlfPublic" json:"tlfPublic"`
+	MessageType       MessageType              `codec:"messageType" json:"messageType"`
+	Prev              []MessagePreviousPointer `codec:"prev" json:"prev"`
+	Sender            gregor1.UID              `codec:"sender" json:"sender"`
+	SenderDevice      gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
+	KbfsCryptKeysUsed *bool                    `codec:"kbfsCryptKeysUsed,omitempty" json:"kbfsCryptKeysUsed,omitempty"`
+	BodyHash          Hash                     `codec:"bodyHash" json:"bodyHash"`
+	OutboxInfo        *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
+	OutboxID          *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	HeaderSignature   *SignatureInfo           `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
+	MerkleRoot        *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
 }
 
 func (o HeaderPlaintextV1) DeepCopy() HeaderPlaintextV1 {
@@ -1360,7 +1361,14 @@ func (o HeaderPlaintextV1) DeepCopy() HeaderPlaintextV1 {
 		})(o.Prev),
 		Sender:       o.Sender.DeepCopy(),
 		SenderDevice: o.SenderDevice.DeepCopy(),
-		BodyHash:     o.BodyHash.DeepCopy(),
+		KbfsCryptKeysUsed: (func(x *bool) *bool {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.KbfsCryptKeysUsed),
+		BodyHash: o.BodyHash.DeepCopy(),
 		OutboxInfo: (func(x *OutboxInfo) *OutboxInfo {
 			if x == nil {
 				return nil

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -301,6 +301,7 @@ protocol common {
     boolean tlfPublic;
     MessageType messageType;
     MessageID supersedes;
+    union { null, boolean } kbfsCryptKeysUsed;
 
     // These 3 fields are hints for the server.
     // They can be derived from the message body, and are not signed.
@@ -334,6 +335,8 @@ protocol common {
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
+    union { null, boolean } kbfsCryptKeysUsed;
+
     // Latest merkle root when sent.
     // Nil from v1 messages. Non-nil from v2 messages.
     union { null, MerkleRoot } merkleRoot;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -238,6 +238,7 @@ protocol local {
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
+    union { null, boolean } kbfsCryptKeysUsed;
 
     // MessageBoxed.V1: Hash of the encrypted body ciphertext.
     // MessageBoxed.V2: Hash of encrypted body (.v || .n || .e)

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -772,7 +772,7 @@ export type HeaderPlaintextMetaInfo = $ReadOnly<{crit: Boolean}>
 
 export type HeaderPlaintextUnsupported = $ReadOnly<{mi: HeaderPlaintextMetaInfo}>
 
-export type HeaderPlaintextV1 = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, bodyHash: Hash, outboxInfo?: ?OutboxInfo, outboxID?: ?OutboxID, headerSignature?: ?SignatureInfo, merkleRoot?: ?MerkleRoot}>
+export type HeaderPlaintextV1 = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, bodyHash: Hash, outboxInfo?: ?OutboxInfo, outboxID?: ?OutboxID, headerSignature?: ?SignatureInfo, merkleRoot?: ?MerkleRoot}>
 
 export type HeaderPlaintextVersion =
   | 1 // V1_1
@@ -925,9 +925,9 @@ export type MessageBoxedVersion =
   | 1 // V1_1
   | 2 // V2_2
 
-export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo}>
+export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo}>
 
-export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo}>
+export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo}>
 
 export type MessageConversationMetadata = $ReadOnly<{conversationTitle: String}>
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -766,6 +766,13 @@
           "name": "supersedes"
         },
         {
+          "type": [
+            null,
+            "boolean"
+          ],
+          "name": "kbfsCryptKeysUsed"
+        },
+        {
           "type": {
             "type": "array",
             "items": "MessageID"
@@ -851,6 +858,13 @@
         {
           "type": "gregor1.DeviceID",
           "name": "senderDevice"
+        },
+        {
+          "type": [
+            null,
+            "boolean"
+          ],
+          "name": "kbfsCryptKeysUsed"
         },
         {
           "type": [

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -746,6 +746,13 @@
           "name": "senderDevice"
         },
         {
+          "type": [
+            null,
+            "boolean"
+          ],
+          "name": "kbfsCryptKeysUsed"
+        },
+        {
           "type": "Hash",
           "name": "bodyHash"
         },

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -772,7 +772,7 @@ export type HeaderPlaintextMetaInfo = $ReadOnly<{crit: Boolean}>
 
 export type HeaderPlaintextUnsupported = $ReadOnly<{mi: HeaderPlaintextMetaInfo}>
 
-export type HeaderPlaintextV1 = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, bodyHash: Hash, outboxInfo?: ?OutboxInfo, outboxID?: ?OutboxID, headerSignature?: ?SignatureInfo, merkleRoot?: ?MerkleRoot}>
+export type HeaderPlaintextV1 = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, bodyHash: Hash, outboxInfo?: ?OutboxInfo, outboxID?: ?OutboxID, headerSignature?: ?SignatureInfo, merkleRoot?: ?MerkleRoot}>
 
 export type HeaderPlaintextVersion =
   | 1 // V1_1
@@ -925,9 +925,9 @@ export type MessageBoxedVersion =
   | 1 // V1_1
   | 2 // V2_2
 
-export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo}>
+export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo}>
 
-export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo}>
+export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo}>
 
 export type MessageConversationMetadata = $ReadOnly<{conversationTitle: String}>
 


### PR DESCRIPTION
The point of this is so that if a conversation is upgraded to `IMPTEAMUPGRADED`, that we know which messages we need to use the KBFS crypt keys for. If this field is missing or `false` then we can grab the KBFS keys from the team sigchain, otherwise we just use the team keys.