### PR TITLE
mark snapshots as generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,5 @@
 shared/actions/*-gen.js linguist-generated=true
 shared/constants/types/rpc*.js linguist-generated=true
 protocol/js/rpc*.js linguist-generated=true
+*.snap linguist-generated=true
 *.json linguist-language=JSON5


### PR DESCRIPTION
@keybase/react-hackers make github collapse snapshot output by default