### PR TITLE
dont allow store logging into the logger ever. reduce the ring sizes

### DIFF
--- a/shared/logger/index.js
+++ b/shared/logger/index.js
@@ -122,13 +122,13 @@ const devLoggers = () => ({
 const prodLoggers = () => ({
   action: isMobile
     ? new NativeLogger()
-    : new DumpPeriodicallyLogger(new RingLogger(5000), 10 * 60e3, writeLogLinesToFile, 'Action'),
+    : new DumpPeriodicallyLogger(new RingLogger(500), 10 * 60e3, writeLogLinesToFile, 'Action'),
   debug: new NullLogger(),
   error: isMobile
     ? new NativeLogger()
-    : new DumpPeriodicallyLogger(new RingLogger(1000), 1 * 60e3, writeLogLinesToFile, 'Error'),
-  info: new RingLogger(1000),
-  warn: new RingLogger(1000),
+    : new DumpPeriodicallyLogger(new RingLogger(100), 1 * 60e3, writeLogLinesToFile, 'Error'),
+  info: new RingLogger(100),
+  warn: new RingLogger(100),
 })
 
 // Settings

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -54,7 +54,7 @@ if (enableStoreLogging) {
     },
     stateTransformer: (...args) => {
       // This is noisy, so let's not show it while filtering action logs
-      !filterActionLogs && logger.info('State:', ...args)
+      !filterActionLogs && console.log('State:', ...args) // DON'T use the logger here, we never want this in the logs
       return null
     },
     titleFormatter: () => null,


### PR DESCRIPTION
else if you have a .debug file with store logging on and the production app you'll get out of memory as its trying to dump the entire store as a string into the ring buffer and that overwhelms it immediately

also i don't think we need more than the last 100 of these console types in prod. if we find we're lacking this stuff in the log sends we can up it

@keybase/react-hackers 