### PR TITLE
Fix writer-rekey without also breaking reader-leave

### DIFF
--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -88,17 +88,20 @@ func (t SigchainV2Type) IsSupportedTeamType() bool {
 	}
 }
 
-func (t SigchainV2Type) RequiresAdminPermission() bool {
+func (t SigchainV2Type) RequiresAtLeastRole() keybase1.TeamRole {
 	if !t.IsSupportedTeamType() {
-		return false
+		// Links from the future require a bare minimum.
+		// They should be checked later by a code update that busts the cache.
+		return keybase1.TeamRole_READER
 	}
 	switch t {
 	case SigchainV2TypeTeamRoot,
-		SigchainV2TypeTeamRotateKey,
 		SigchainV2TypeTeamLeave:
-		return false
+		return keybase1.TeamRole_READER
+	case SigchainV2TypeTeamRotateKey:
+		return keybase1.TeamRole_WRITER
 	default:
-		return true
+		return keybase1.TeamRole_ADMIN
 	}
 }
 

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -156,7 +156,7 @@ func (t TeamSigChainState) assertBecameAdminAt(uv keybase1.UserVersion, scl keyb
 				return ret, NewAdminPermissionError(t.GetID(), uv, "not admin permission")
 			}
 			ret.left = newProofTerm(t.GetID().AsUserOrTeam(), point.SigMeta, linkMap)
-			r := findAdminDowngrade(points[(i + 1):])
+			r := findRoleDowngrade(points[(i+1):], keybase1.TeamRole_ADMIN)
 			if r != nil {
 				tmp := newProofTerm(t.GetID().AsUserOrTeam(), *r, linkMap)
 				ret.right = &tmp
@@ -167,68 +167,56 @@ func (t TeamSigChainState) assertBecameAdminAt(uv keybase1.UserVersion, scl keyb
 	return ret, NewAdminPermissionError(t.GetID(), uv, "not found")
 }
 
-func findAdminDowngrade(points []keybase1.UserLogPoint) *keybase1.SignatureMetadata {
+// Find a point where the role is taken away.
+func findRoleDowngrade(points []keybase1.UserLogPoint, role keybase1.TeamRole) *keybase1.SignatureMetadata {
 	for _, p := range points {
-		if !p.Role.IsAdminOrAbove() {
+		if !p.Role.IsOrAbove(role) {
 			return &p.SigMeta
 		}
 	}
 	return nil
 }
 
-func findReaderDowngrade(points []keybase1.UserLogPoint) *keybase1.SignatureMetadata {
-	for _, p := range points {
-		if !p.Role.IsReaderOrAbove() {
-			return &p.SigMeta
+// AssertWasRoleOrAboveAt asserts that user `uv` had `role` or above on the
+// team at the given SigChainLocation `scl`.
+// We start at the point given, go backwards until we find a promotion,
+// then go forwards to make sure there wasn't a demotion before the specified time.
+// If there was, return a PermissionError. If no adminship was found at all, return a PermissionError.
+func (t TeamSigChainState) AssertWasRoleOrAboveAt(uv keybase1.UserVersion,
+	role keybase1.TeamRole, scl keybase1.SigChainLocation) (err error) {
+	mkErr := func(format string, args ...interface{}) error {
+		msg := fmt.Sprintf(format, args...)
+		if role.IsOrAbove(keybase1.TeamRole_ADMIN) {
+			return NewAdminPermissionError(t.GetID(), uv, msg)
+		}
+		return NewPermissionError(t.GetID(), uv, msg)
+	}
+	points := t.inner.UserLog[uv]
+	for i := len(points) - 1; i >= 0; i-- {
+		point := points[i]
+		if point.SigMeta.SigChainLocation.LessThanOrEqualTo(scl) && point.Role.IsOrAbove(role) {
+			// OK great, we found a point with the role in the log that's less than or equal to the given one.
+			// But now we reverse and go forward, and check that it wasn't revoked or downgraded.
+			// If so, that's a problem!
+			if right := findRoleDowngrade(points[(i+1):], role); right != nil && right.SigChainLocation.LessThanOrEqualTo(scl) {
+				return mkErr("%v permission was downgraded too soon!", role)
+			}
+			return nil
 		}
 	}
-	return nil
+	return mkErr("%v role point not found", role)
 }
 
-// AssertWasReaderAt asserts that user (uv) was a reader or above at the team at the given
-// SigChainLocation (scl). Thus, we start at the point given, go backwards until we find a promotion,
-// the go forwards to make sure there wasn't a demotion before the specified time. If there
-// was, we return a PermissionError. If no adminship was found at all, we return a PermissionError.
-// NOTE: This is a copy-pasta of AssertWasAdminAt, but I became sad about having to factor out
-// the commonality, so decided copy-paste was easiest.
 func (t TeamSigChainState) AssertWasReaderAt(uv keybase1.UserVersion, scl keybase1.SigChainLocation) (err error) {
-	points := t.inner.UserLog[uv]
-	for i := len(points) - 1; i >= 0; i-- {
-		point := points[i]
-		// OK great, we found an admin point in the log that's less than or equal to the
-		// given one
-		if point.SigMeta.SigChainLocation.LessThanOrEqualTo(scl) && point.Role.IsReaderOrAbove() {
-			// But now we reverse and go forward, and check that it wasn't revoked or downgraded.
-			// If so, that's a problem!
-			if right := findReaderDowngrade(points[(i + 1):]); right != nil && right.SigChainLocation.LessThanOrEqualTo(scl) {
-				return NewPermissionError(t.GetID(), uv, "permission was downgraded too soon!")
-			}
-			return nil
-		}
-	}
-	return NewPermissionError(t.GetID(), uv, "not found")
+	return t.AssertWasRoleOrAboveAt(uv, keybase1.TeamRole_READER, scl)
 }
 
-// AssertWasAdminAt asserts that user (uv) was an admin (or owner) at the team at the given
-// SigChainLocation (scl). Thus, we start at the point given, go backwards until we find a promotion,
-// the go forwards to make sure there wasn't a demotion before the specified time. If there
-// was, we return an AdminPermissionError. If no adminship was found at all, we return a AdminPermissionError.
+func (t TeamSigChainState) AssertWasWriterAt(uv keybase1.UserVersion, scl keybase1.SigChainLocation) (err error) {
+	return t.AssertWasRoleOrAboveAt(uv, keybase1.TeamRole_WRITER, scl)
+}
+
 func (t TeamSigChainState) AssertWasAdminAt(uv keybase1.UserVersion, scl keybase1.SigChainLocation) (err error) {
-	points := t.inner.UserLog[uv]
-	for i := len(points) - 1; i >= 0; i-- {
-		point := points[i]
-		// OK great, we found an admin point in the log that's less than or equal to the
-		// given one
-		if point.SigMeta.SigChainLocation.LessThanOrEqualTo(scl) && point.Role.IsAdminOrAbove() {
-			// But now we reverse and go forward, and check that it wasn't revoked or downgraded.
-			// If so, that's a problem!
-			if right := findAdminDowngrade(points[(i + 1):]); right != nil && right.SigChainLocation.LessThanOrEqualTo(scl) {
-				return NewAdminPermissionError(t.GetID(), uv, "admin permission was downgraded too soon!")
-			}
-			return nil
-		}
-	}
-	return NewAdminPermissionError(t.GetID(), uv, "not found")
+	return t.AssertWasRoleOrAboveAt(uv, keybase1.TeamRole_ADMIN, scl)
 }
 
 func (t TeamSigChainState) GetUsersWithRole(role keybase1.TeamRole) (res []keybase1.UserVersion, err error) {

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -716,6 +716,37 @@ func TestOnlyOwnerLeaveThenUpgradeFriend(t *testing.T) {
 	}
 }
 
+func TestLeaveAsReader(t *testing.T) {
+	fus, tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	t.Logf("U0 creates fennel_network")
+	teamName, teamID := createTeam2(*tcs[0])
+
+	t.Logf("U0 adds U1 to the root")
+	_, err := AddMember(context.Background(), tcs[0].G, teamName.String(), fus[1].Username, keybase1.TeamRole_READER)
+	require.NoError(t, err)
+
+	t.Logf("U1 leaves the team")
+	err = Leave(context.Background(), tcs[1].G, teamName.String(), false)
+	require.NoError(t, err)
+
+	t.Logf("U0 loads the team")
+	require.NoError(t, err, "loading the team")
+	_, err = Load(context.Background(), tcs[0].G, keybase1.LoadTeamArg{
+		ID:          teamID,
+		ForceRepoll: true,
+	})
+
+	t.Logf("U0 loads the team from scratch")
+	_, err = Load(context.Background(), tcs[0].G, keybase1.LoadTeamArg{
+		ID:              teamID,
+		ForceFullReload: true,
+		ForceRepoll:     true,
+	})
+	require.NoError(t, err, "loading the team FROM SCRATCH")
+}
+
 func TestMemberAddResolveCache(t *testing.T) {
 	tc, _, other, _, name := memberSetupMultiple(t)
 	defer tc.Cleanup()


### PR DESCRIPTION
Here we go again.

The only differences between this and [attempt #1](https://github.com/keybase/client/pull/10312) are:
- `SigchainV2Type.RequiresAdminPermission`
- In `verifyLink`
- Added test `TestLeaveAsReader`

cc @mmaxim @maxtaco 