### PR TITLE
Change TLFIdentifyBehavior enum to not use 0 default

### DIFF
--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -31,6 +31,9 @@ type identModeData struct {
 
 func IdentifyModeCtx(ctx context.Context, mode keybase1.TLFIdentifyBehavior,
 	breaks *[]keybase1.TLFIdentifyFailure) context.Context {
+	if mode == keybase1.TLFIdentifyBehavior_UNSET {
+		mode = keybase1.TLFIdentifyBehavior_CHAT_CLI
+	}
 	return context.WithValue(ctx, identModeKey, identModeData{mode: mode, breaks: breaks})
 }
 

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -211,6 +211,11 @@ func NewNameIdentifier(g *globals.Context) *NameIdentifier {
 
 func (t *NameIdentifier) Identify(ctx context.Context, names []string, private bool,
 	identBehavior keybase1.TLFIdentifyBehavior) ([]keybase1.TLFIdentifyFailure, error) {
+
+	if identBehavior == keybase1.TLFIdentifyBehavior_UNSET {
+		panic("identify behavior unset")
+	}
+
 	// need new context as errgroup will cancel it.
 	group, ectx := errgroup.WithContext(BackgroundContext(ctx, t.G()))
 	assertions := make(chan string)

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -211,11 +211,6 @@ func NewNameIdentifier(g *globals.Context) *NameIdentifier {
 
 func (t *NameIdentifier) Identify(ctx context.Context, names []string, private bool,
 	identBehavior keybase1.TLFIdentifyBehavior) ([]keybase1.TLFIdentifyFailure, error) {
-
-	if identBehavior == keybase1.TLFIdentifyBehavior_UNSET {
-		panic("identify behavior unset")
-	}
-
 	// need new context as errgroup will cancel it.
 	group, ectx := errgroup.WithContext(BackgroundContext(ctx, t.G()))
 	assertions := make(chan string)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -406,10 +406,11 @@ func mustCreateConversationForTestNoAdvanceClock(t *testing.T, ctc *chatTestCont
 	tc := ctc.as(t, creator)
 	ncres, err := tc.chatLocalHandler().NewConversationLocal(tc.startCtx,
 		chat1.NewConversationLocalArg{
-			TlfName:       name,
-			TopicType:     topicType,
-			TlfVisibility: visibility,
-			MembersType:   membersType,
+			TlfName:          name,
+			TopicType:        topicType,
+			TlfVisibility:    visibility,
+			MembersType:      membersType,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		})
 	if err != nil {
 		t.Fatalf("NewConversationLocal error: %v\n", err)
@@ -443,6 +444,7 @@ func postLocalForTestNoAdvanceClock(t *testing.T, ctc *chatTestContext, asUser *
 			},
 			MessageBody: msg,
 		},
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	})
 }
 
@@ -535,11 +537,12 @@ func TestChatSrvNewConversationMultiTeam(t *testing.T) {
 		tc := ctc.as(t, users[0])
 		topicName := "MIKETIME"
 		arg := chat1.NewConversationLocalArg{
-			TlfName:       conv.TlfName,
-			TopicName:     &topicName,
-			TopicType:     chat1.TopicType_CHAT,
-			TlfVisibility: keybase1.TLFVisibility_PRIVATE,
-			MembersType:   mt,
+			TlfName:          conv.TlfName,
+			TopicName:        &topicName,
+			TopicType:        chat1.TopicType_CHAT,
+			TlfVisibility:    keybase1.TLFVisibility_PRIVATE,
+			MembersType:      mt,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		}
 		ncres, err := tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
 		switch mt {
@@ -592,6 +595,7 @@ func TestChatSrvGetInboxAndUnboxLocal(t *testing.T) {
 			Query: &chat1.GetInboxLocalQuery{
 				ConvIDs: []chat1.ConversationID{created.Id},
 			},
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		})
 		if err != nil {
 			t.Fatalf("GetInboxAndUnboxLocal error: %v", err)
@@ -646,11 +650,12 @@ func TestChatSrvGetInboxNonblockLocalMetadata(t *testing.T) {
 				topicName := fmt.Sprintf("%d", i+1)
 				ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
 					chat1.NewConversationLocalArg{
-						TlfName:       firstConv.TlfName,
-						TopicName:     &topicName,
-						TopicType:     chat1.TopicType_CHAT,
-						TlfVisibility: keybase1.TLFVisibility_PRIVATE,
-						MembersType:   chat1.ConversationMembersType_TEAM,
+						TlfName:          firstConv.TlfName,
+						TopicName:        &topicName,
+						TopicType:        chat1.TopicType_CHAT,
+						TlfVisibility:    keybase1.TLFVisibility_PRIVATE,
+						MembersType:      chat1.ConversationMembersType_TEAM,
+						IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 					})
 				require.NoError(t, err)
 				created = ncres.Conv.Info
@@ -819,6 +824,7 @@ func TestChatSrvGetInboxNonblock(t *testing.T) {
 						Body: "HI",
 					}),
 				},
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 			})
 			require.NoError(t, err)
 		}
@@ -886,6 +892,7 @@ func TestChatSrvGetInboxAndUnboxLocalTlfName(t *testing.T) {
 				},
 				TlfVisibility: &visibility,
 			},
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		})
 		require.NoError(t, err)
 		conversations := gilres.Conversations
@@ -1024,6 +1031,7 @@ func TestChatSrvPostLocalAtMention(t *testing.T) {
 					Body: "HI",
 				}),
 			},
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		})
 		require.NoError(t, err)
 		consumeNewMsg(t, listener, chat1.MessageType_TEXT)

--- a/go/engine/account_delete_test.go
+++ b/go/engine/account_delete_test.go
@@ -80,7 +80,8 @@ func TestAccountDeleteIdentify(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid: u.GetUID(),
+		Uid:              u.GetUID(),
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	ieng := NewIdentify2WithUID(tc.G, arg)
 	ictx := &Context{IdentifyUI: i}

--- a/go/engine/device_keyfinder.go
+++ b/go/engine/device_keyfinder.go
@@ -88,7 +88,8 @@ func (e *DeviceKeyfinder) identifyUser(ctx *Context, user string) error {
 		Reason: keybase1.IdentifyReason{
 			Type: keybase1.IdentifyReasonType_ENCRYPT,
 		},
-		AlwaysBlock: true,
+		AlwaysBlock:      true,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewResolveThenIdentify2(e.G(), &arg)
 	if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -16,8 +16,9 @@ import (
 func runIdentify(tc *libkb.TestContext, username string) (idUI *FakeIdentifyUI, res *keybase1.Identify2Res, err error) {
 	idUI = &FakeIdentifyUI{}
 	arg := keybase1.Identify2Arg{
-		UserAssertion: username,
-		AlwaysBlock:   true,
+		UserAssertion:    username,
+		AlwaysBlock:      true,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 
 	ctx := Context{

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -249,7 +249,8 @@ func TestIdentify2WithUIDWithoutTrack(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid: tracyUID,
+		Uid:              tracyUID,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewIdentify2WithUID(tc.G, arg)
 	ctx := Context{IdentifyUI: i}
@@ -285,7 +286,8 @@ func TestIdentify2WithUIDWithTrack(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid: tracyUID,
+		Uid:              tracyUID,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewIdentify2WithUID(tc.G, arg)
 
@@ -311,8 +313,9 @@ func TestIdentify2WithUIDWithTrackAndSuppress(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid:           tracyUID,
-		CanSuppressUI: true,
+		Uid:              tracyUID,
+		CanSuppressUI:    true,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewIdentify2WithUID(tc.G, arg)
 
@@ -367,8 +370,9 @@ func identify2WithUIDWithBrokenTrackMakeEngine(t *testing.T, arg *keybase1.Ident
 
 func testIdentify2WithUIDWithBrokenTrack(t *testing.T, suppress bool) {
 	arg := &keybase1.Identify2Arg{
-		Uid:           tracyUID,
-		CanSuppressUI: suppress,
+		Uid:              tracyUID,
+		CanSuppressUI:    suppress,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	waiter, err := identify2WithUIDWithBrokenTrackMakeEngine(t, arg)
 
@@ -485,7 +489,7 @@ func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 	runStandard := func() {
 		// Now run the engine again, but in normal mode, and check that we don't hit
 		// the cached broken gy.
-		eng := NewIdentify2WithUID(tc.G, &keybase1.Identify2Arg{Uid: tracyUID})
+		eng := NewIdentify2WithUID(tc.G, &keybase1.Identify2Arg{Uid: tracyUID, IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI})
 
 		eng.testArgs = &Identify2WithUIDTestArgs{
 			noMe:  true,
@@ -558,8 +562,9 @@ func TestIdentify2WithUIDWithAssertion(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid:           tracyUID,
-		UserAssertion: "tacovontaco@twitter",
+		Uid:              tracyUID,
+		UserAssertion:    "tacovontaco@twitter",
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewIdentify2WithUID(tc.G, arg)
 
@@ -583,8 +588,9 @@ func TestIdentify2WithUIDWithAssertions(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid:           tracyUID,
-		UserAssertion: "tacovontaco@twitter+t_tracy@rooter",
+		Uid:              tracyUID,
+		UserAssertion:    "tacovontaco@twitter+t_tracy@rooter",
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewIdentify2WithUID(tc.G, arg)
 
@@ -608,8 +614,9 @@ func TestIdentify2WithUIDWithNonExistentAssertion(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid:           tracyUID,
-		UserAssertion: "beyonce@twitter",
+		Uid:              tracyUID,
+		UserAssertion:    "beyonce@twitter",
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewIdentify2WithUID(tc.G, arg)
 
@@ -650,8 +657,9 @@ func TestIdentify2WithUIDWithFailedAssertion(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid:           tracyUID,
-		UserAssertion: "tacovontaco@twitter",
+		Uid:              tracyUID,
+		UserAssertion:    "tacovontaco@twitter",
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewIdentify2WithUID(tc.G, arg)
 
@@ -701,8 +709,9 @@ func TestIdentify2WithUIDWithFailedAncillaryAssertion(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid:           tracyUID,
-		UserAssertion: "tacoplusplus@github+t_tracy@rooter",
+		Uid:              tracyUID,
+		UserAssertion:    "tacoplusplus@github+t_tracy@rooter",
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewIdentify2WithUID(tc.G, arg)
 
@@ -753,7 +762,8 @@ func TestIdentify2WithUIDCache(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid: tracyUID,
+		Uid:              tracyUID,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	run := func() {
 		eng := NewIdentify2WithUID(tc.G, arg)
@@ -825,7 +835,8 @@ func TestIdentify2WithUIDLocalAssertions(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		Uid: tracyUID,
+		Uid:              tracyUID,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 
 	run := func() {
@@ -904,7 +915,8 @@ func TestResolveAndIdentify2WithUIDWithAssertions(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		UserAssertion: "tacovontaco@twitter+t_tracy@rooter",
+		UserAssertion:    "tacovontaco@twitter+t_tracy@rooter",
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewResolveThenIdentify2(tc.G, arg)
 	eng.testArgs = &Identify2WithUIDTestArgs{
@@ -929,7 +941,8 @@ func TestIdentify2NoSigchain(t *testing.T) {
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	arg := &keybase1.Identify2Arg{
-		UserAssertion: u,
+		UserAssertion:    u,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewResolveThenIdentify2(tc.G, arg)
 	ctx := Context{IdentifyUI: i}
@@ -963,7 +976,8 @@ func TestIdentifyAfterDbNuke(t *testing.T) {
 
 		i := newIdentify2WithUIDTester(tc.G)
 		arg := &keybase1.Identify2Arg{
-			Uid: aliceUID,
+			Uid:              aliceUID,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 		}
 		eng := NewIdentify2WithUID(tc.G, arg)
 		eng.testArgs = &Identify2WithUIDTestArgs{

--- a/go/engine/pgp_decrypt.go
+++ b/go/engine/pgp_decrypt.go
@@ -106,10 +106,11 @@ func (e *PGPDecrypt) Run(ctx *Context) (err error) {
 
 		// identify the SignedBy assertion
 		arg := keybase1.Identify2Arg{
-			UserAssertion: e.arg.SignedBy,
-			AlwaysBlock:   true,
-			NeedProofSet:  true,
-			NoSkipSelf:    true,
+			UserAssertion:    e.arg.SignedBy,
+			AlwaysBlock:      true,
+			NeedProofSet:     true,
+			NoSkipSelf:       true,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 		}
 		eng := NewResolveThenIdentify2(e.G(), &arg)
 		if err := RunEngine(eng, ctx); err != nil {
@@ -131,10 +132,11 @@ func (e *PGPDecrypt) Run(ctx *Context) (err error) {
 
 		// identify the signer
 		arg := keybase1.Identify2Arg{
-			UserAssertion: e.signer.GetName(),
-			AlwaysBlock:   true,
-			NeedProofSet:  true,
-			NoSkipSelf:    true,
+			UserAssertion:    e.signer.GetName(),
+			AlwaysBlock:      true,
+			NeedProofSet:     true,
+			NoSkipSelf:       true,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 		}
 		eng := NewResolveThenIdentify2(e.G(), &arg)
 		if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -197,7 +197,8 @@ func (e *PGPEncrypt) verifyUsers(ctx *Context, assertions []string, loggedIn boo
 			Reason: keybase1.IdentifyReason{
 				Type: keybase1.IdentifyReasonType_ENCRYPT,
 			},
-			AlwaysBlock: true,
+			AlwaysBlock:      true,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 		}
 		eng := NewResolveThenIdentify2(e.G(), &arg)
 		if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/profile_edit_test.go
+++ b/go/engine/profile_edit_test.go
@@ -1,9 +1,10 @@
 package engine
 
 import (
+	"testing"
+
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestProfileEdit(t *testing.T) {
@@ -18,9 +19,10 @@ func TestProfileEdit(t *testing.T) {
 		// add NoSkipSelf and NeedProofSet to go through with the full identify,
 		// with RPCs to the outside and all.
 		arg := &keybase1.Identify2Arg{
-			Uid:          fu.UID(),
-			NoSkipSelf:   true,
-			NeedProofSet: true,
+			Uid:              fu.UID(),
+			NoSkipSelf:       true,
+			NeedProofSet:     true,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 		}
 		eng := NewIdentify2WithUID(tc.G, arg)
 		ctx := Context{IdentifyUI: i}

--- a/go/engine/saltpack_sender_identify.go
+++ b/go/engine/saltpack_sender_identify.go
@@ -143,6 +143,7 @@ func (e *SaltpackSenderIdentify) identifySender(ctx *Context) (err error) {
 		NoErrorOnTrackFailure: true,
 		Reason:                e.arg.reason,
 		UserAssertion:         e.arg.userAssertion,
+		IdentifyBehavior:      keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewIdentify2WithUID(e.G(), &iarg)
 	if err = RunEngine(eng, ctx); err != nil {

--- a/go/engine/soft_snooze_test.go
+++ b/go/engine/soft_snooze_test.go
@@ -75,8 +75,9 @@ func TestSoftSnooze(t *testing.T) {
 	idUI := &FakeIdentifyUI{}
 	username := "t_tracy"
 	arg := &keybase1.Identify2Arg{
-		UserAssertion: username,
-		NeedProofSet:  true,
+		UserAssertion:    username,
+		NeedProofSet:     true,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	ctx := &Context{
 		LogUI:      tc.G.UI.GetLogUI(),

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -68,6 +68,12 @@ func (e *TrackEngine) Run(ctx *Context) error {
 		AlwaysBlock:           true,
 	}
 
+	if ctx.SessionID != 0 {
+		arg.IdentifyBehavior = keybase1.TLFIdentifyBehavior_GUI
+	} else {
+		arg.IdentifyBehavior = keybase1.TLFIdentifyBehavior_CLI
+	}
+
 	ieng := NewResolveThenIdentify2WithTrack(e.G(), arg, e.arg.Options)
 	if err := RunEngine(ieng, ctx); err != nil {
 		return err

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -326,7 +326,8 @@ func TestIdentifyTrackRaceDetection(t *testing.T) {
 			// is delivered to the UI before we return. Otherwise, the
 			// following call to track might happen before the token
 			// is known.
-			AlwaysBlock: true,
+			AlwaysBlock:      true,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 		}
 		eng := NewResolveThenIdentify2(tc.G, iarg)
 		ctx := Context{IdentifyUI: fui}

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -23,8 +23,9 @@ func TestTrackTokenIdentify2(t *testing.T) {
 	idUI := &FakeIdentifyUI{}
 	username := "t_tracy"
 	arg := &keybase1.Identify2Arg{
-		UserAssertion: username,
-		NeedProofSet:  true,
+		UserAssertion:    username,
+		NeedProofSet:     true,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	ctx := &Context{
 		LogUI:      tc.G.UI.GetLogUI(),
@@ -65,8 +66,9 @@ func TestTrackLocalThenLocalTemp(t *testing.T) {
 	username := "t_tracy"
 
 	arg := &keybase1.Identify2Arg{
-		UserAssertion: username,
-		NeedProofSet:  true,
+		UserAssertion:    username,
+		NeedProofSet:     true,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	ctx := &Context{
 		LogUI:      tc.G.UI.GetLogUI(),
@@ -191,8 +193,9 @@ func TestTrackRemoteThenLocalTemp(t *testing.T) {
 	username := "t_tracy"
 
 	arg := &keybase1.Identify2Arg{
-		UserAssertion: username,
-		NeedProofSet:  true,
+		UserAssertion:    username,
+		NeedProofSet:     true,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	ctx := &Context{
 		LogUI:      tc.G.UI.GetLogUI(),
@@ -312,8 +315,9 @@ func TestTrackFailTempRecover(t *testing.T) {
 	username := "t_tracy"
 
 	arg := &keybase1.Identify2Arg{
-		UserAssertion: username,
-		NeedProofSet:  true,
+		UserAssertion:    username,
+		NeedProofSet:     true,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	ctx := &Context{
 		LogUI:      tc.G.UI.GetLogUI(),
@@ -448,8 +452,9 @@ func TestTrackWithTokenDismissesGregor(t *testing.T) {
 	idUI := &FakeIdentifyUI{}
 	username := "t_tracy"
 	arg := &keybase1.Identify2Arg{
-		UserAssertion: username,
-		NeedProofSet:  true,
+		UserAssertion:    username,
+		NeedProofSet:     true,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	ctx := &Context{
 		LogUI:      tc.G.UI.GetLogUI(),

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1058,6 +1058,8 @@ func (t TLFID) ToBytes() []byte {
 
 func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
 	switch b {
+	case TLFIdentifyBehavior_UNSET:
+		panic("identify behavior unset")
 	case TLFIdentifyBehavior_CHAT_CLI,
 		TLFIdentifyBehavior_CHAT_GUI,
 		TLFIdentifyBehavior_CHAT_GUI_STRICT,
@@ -1070,6 +1072,8 @@ func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
 
 func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 	switch b {
+	case TLFIdentifyBehavior_UNSET:
+		panic("identify behavior unset")
 	case TLFIdentifyBehavior_CHAT_GUI,
 		TLFIdentifyBehavior_CHAT_GUI_STRICT,
 		TLFIdentifyBehavior_SALTPACK:
@@ -1083,6 +1087,8 @@ func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 
 func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 	switch b {
+	case TLFIdentifyBehavior_UNSET:
+		panic("identify behavior unset")
 	case TLFIdentifyBehavior_CHAT_GUI:
 		// The chat GUI (in non-strict mode) is specifically exempted from broken
 		// track errors, because people need to be able to use it to ask each other
@@ -1096,6 +1102,8 @@ func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 // All of the chat modes want to prevent tracker popups.
 func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
 	switch b {
+	case TLFIdentifyBehavior_UNSET:
+		panic("identify behavior unset")
 	case TLFIdentifyBehavior_CHAT_GUI,
 		TLFIdentifyBehavior_CHAT_GUI_STRICT,
 		TLFIdentifyBehavior_CHAT_CLI,
@@ -1117,6 +1125,8 @@ func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
 // identify modes that yield true.
 func (b TLFIdentifyBehavior) SkipExternalChecks() bool {
 	switch b {
+	case TLFIdentifyBehavior_UNSET:
+		panic("identify behavior unset")
 	case TLFIdentifyBehavior_KBFS_QR,
 		TLFIdentifyBehavior_KBFS_REKEY:
 		return true

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1058,8 +1058,6 @@ func (t TLFID) ToBytes() []byte {
 
 func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
 	switch b {
-	case TLFIdentifyBehavior_UNSET:
-		panic("identify behavior unset")
 	case TLFIdentifyBehavior_CHAT_CLI,
 		TLFIdentifyBehavior_CHAT_GUI,
 		TLFIdentifyBehavior_CHAT_GUI_STRICT,
@@ -1072,8 +1070,6 @@ func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
 
 func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 	switch b {
-	case TLFIdentifyBehavior_UNSET:
-		panic("identify behavior unset")
 	case TLFIdentifyBehavior_CHAT_GUI,
 		TLFIdentifyBehavior_CHAT_GUI_STRICT,
 		TLFIdentifyBehavior_SALTPACK:
@@ -1087,8 +1083,6 @@ func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 
 func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 	switch b {
-	case TLFIdentifyBehavior_UNSET:
-		panic("identify behavior unset")
 	case TLFIdentifyBehavior_CHAT_GUI:
 		// The chat GUI (in non-strict mode) is specifically exempted from broken
 		// track errors, because people need to be able to use it to ask each other
@@ -1102,8 +1096,6 @@ func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 // All of the chat modes want to prevent tracker popups.
 func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
 	switch b {
-	case TLFIdentifyBehavior_UNSET:
-		panic("identify behavior unset")
 	case TLFIdentifyBehavior_CHAT_GUI,
 		TLFIdentifyBehavior_CHAT_GUI_STRICT,
 		TLFIdentifyBehavior_CHAT_CLI,
@@ -1125,8 +1117,6 @@ func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
 // identify modes that yield true.
 func (b TLFIdentifyBehavior) SkipExternalChecks() bool {
 	switch b {
-	case TLFIdentifyBehavior_UNSET:
-		panic("identify behavior unset")
 	case TLFIdentifyBehavior_KBFS_QR,
 		TLFIdentifyBehavior_KBFS_REKEY:
 		return true

--- a/go/protocol/keybase1/tlf_keys.go
+++ b/go/protocol/keybase1/tlf_keys.go
@@ -11,7 +11,6 @@ import (
 type TLFIdentifyBehavior int
 
 const (
-	TLFIdentifyBehavior_DEFAULT_KBFS    TLFIdentifyBehavior = 0
 	TLFIdentifyBehavior_CHAT_CLI        TLFIdentifyBehavior = 1
 	TLFIdentifyBehavior_CHAT_GUI        TLFIdentifyBehavior = 2
 	TLFIdentifyBehavior_CHAT_GUI_STRICT TLFIdentifyBehavior = 3
@@ -20,12 +19,12 @@ const (
 	TLFIdentifyBehavior_CHAT_SKIP       TLFIdentifyBehavior = 6
 	TLFIdentifyBehavior_SALTPACK        TLFIdentifyBehavior = 7
 	TLFIdentifyBehavior_CLI             TLFIdentifyBehavior = 8
+	TLFIdentifyBehavior_DEFAULT_KBFS    TLFIdentifyBehavior = 9
 )
 
 func (o TLFIdentifyBehavior) DeepCopy() TLFIdentifyBehavior { return o }
 
 var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
-	"DEFAULT_KBFS":    0,
 	"CHAT_CLI":        1,
 	"CHAT_GUI":        2,
 	"CHAT_GUI_STRICT": 3,
@@ -34,10 +33,10 @@ var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
 	"CHAT_SKIP":       6,
 	"SALTPACK":        7,
 	"CLI":             8,
+	"DEFAULT_KBFS":    9,
 }
 
 var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
-	0: "DEFAULT_KBFS",
 	1: "CHAT_CLI",
 	2: "CHAT_GUI",
 	3: "CHAT_GUI_STRICT",
@@ -46,6 +45,7 @@ var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
 	6: "CHAT_SKIP",
 	7: "SALTPACK",
 	8: "CLI",
+	9: "DEFAULT_KBFS",
 }
 
 func (e TLFIdentifyBehavior) String() string {

--- a/go/protocol/keybase1/tlf_keys.go
+++ b/go/protocol/keybase1/tlf_keys.go
@@ -11,6 +11,7 @@ import (
 type TLFIdentifyBehavior int
 
 const (
+	TLFIdentifyBehavior_UNSET           TLFIdentifyBehavior = 0
 	TLFIdentifyBehavior_CHAT_CLI        TLFIdentifyBehavior = 1
 	TLFIdentifyBehavior_CHAT_GUI        TLFIdentifyBehavior = 2
 	TLFIdentifyBehavior_CHAT_GUI_STRICT TLFIdentifyBehavior = 3
@@ -19,12 +20,14 @@ const (
 	TLFIdentifyBehavior_CHAT_SKIP       TLFIdentifyBehavior = 6
 	TLFIdentifyBehavior_SALTPACK        TLFIdentifyBehavior = 7
 	TLFIdentifyBehavior_CLI             TLFIdentifyBehavior = 8
-	TLFIdentifyBehavior_DEFAULT_KBFS    TLFIdentifyBehavior = 9
+	TLFIdentifyBehavior_GUI             TLFIdentifyBehavior = 9
+	TLFIdentifyBehavior_DEFAULT_KBFS    TLFIdentifyBehavior = 10
 )
 
 func (o TLFIdentifyBehavior) DeepCopy() TLFIdentifyBehavior { return o }
 
 var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
+	"UNSET":           0,
 	"CHAT_CLI":        1,
 	"CHAT_GUI":        2,
 	"CHAT_GUI_STRICT": 3,
@@ -33,19 +36,22 @@ var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
 	"CHAT_SKIP":       6,
 	"SALTPACK":        7,
 	"CLI":             8,
-	"DEFAULT_KBFS":    9,
+	"GUI":             9,
+	"DEFAULT_KBFS":    10,
 }
 
 var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
-	1: "CHAT_CLI",
-	2: "CHAT_GUI",
-	3: "CHAT_GUI_STRICT",
-	4: "KBFS_REKEY",
-	5: "KBFS_QR",
-	6: "CHAT_SKIP",
-	7: "SALTPACK",
-	8: "CLI",
-	9: "DEFAULT_KBFS",
+	0:  "UNSET",
+	1:  "CHAT_CLI",
+	2:  "CHAT_GUI",
+	3:  "CHAT_GUI_STRICT",
+	4:  "KBFS_REKEY",
+	5:  "KBFS_QR",
+	6:  "CHAT_SKIP",
+	7:  "SALTPACK",
+	8:  "CLI",
+	9:  "GUI",
+	10: "DEFAULT_KBFS",
 }
 
 func (e TLFIdentifyBehavior) String() string {

--- a/protocol/avdl/keybase1/tlf_keys.avdl
+++ b/protocol/avdl/keybase1/tlf_keys.avdl
@@ -7,7 +7,6 @@ protocol tlfKeys {
   import idl "identify.avdl";
 
   enum TLFIdentifyBehavior {
-    DEFAULT_KBFS_0,
     CHAT_CLI_1,
     CHAT_GUI_2,
     CHAT_GUI_STRICT_3,
@@ -15,7 +14,8 @@ protocol tlfKeys {
     KBFS_QR_5,
     CHAT_SKIP_6,
     SALTPACK_7,
-    CLI_8
+    CLI_8,
+    DEFAULT_KBFS_9
   }
 
   @typedef("string")

--- a/protocol/avdl/keybase1/tlf_keys.avdl
+++ b/protocol/avdl/keybase1/tlf_keys.avdl
@@ -7,6 +7,7 @@ protocol tlfKeys {
   import idl "identify.avdl";
 
   enum TLFIdentifyBehavior {
+    UNSET_0,
     CHAT_CLI_1,
     CHAT_GUI_2,
     CHAT_GUI_STRICT_3,
@@ -15,7 +16,8 @@ protocol tlfKeys {
     CHAT_SKIP_6,
     SALTPACK_7,
     CLI_8,
-    DEFAULT_KBFS_9
+    GUI_9,
+    DEFAULT_KBFS_10
   }
 
   @typedef("string")

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1719,7 +1719,6 @@ export const tlfKeysGetTLFCryptKeysRpcChannelMap = (configKeys: Array<string>, r
 export const tlfKeysGetTLFCryptKeysRpcPromise = (request: TlfKeysGetTLFCryptKeysRpcParam): Promise<TlfKeysGetTLFCryptKeysResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.tlfKeys.getTLFCryptKeys', request, (error: RPCError, result: TlfKeysGetTLFCryptKeysResult) => (error ? reject(error) : resolve(result))))
 
 export const tlfKeysTLFIdentifyBehavior = {
-  defaultKbfs: 0,
   chatCli: 1,
   chatGui: 2,
   chatGuiStrict: 3,
@@ -1728,6 +1727,7 @@ export const tlfKeysTLFIdentifyBehavior = {
   chatSkip: 6,
   saltpack: 7,
   cli: 8,
+  defaultKbfs: 9,
 }
 
 export const tlfPublicCanonicalTLFNameAndIDRpcChannelMap = (configKeys: Array<string>, request: TlfPublicCanonicalTLFNameAndIDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.tlf.publicCanonicalTLFNameAndID', request)
@@ -3483,7 +3483,6 @@ export type TLFBreak = $ReadOnly<{breaks?: ?Array<TLFIdentifyFailure>}>
 export type TLFID = String
 
 export type TLFIdentifyBehavior =
-  | 0 // DEFAULT_KBFS_0
   | 1 // CHAT_CLI_1
   | 2 // CHAT_GUI_2
   | 3 // CHAT_GUI_STRICT_3
@@ -3492,6 +3491,7 @@ export type TLFIdentifyBehavior =
   | 6 // CHAT_SKIP_6
   | 7 // SALTPACK_7
   | 8 // CLI_8
+  | 9 // DEFAULT_KBFS_9
 
 export type TLFIdentifyFailure = $ReadOnly<{user: User, breaks?: ?IdentifyTrackBreaks}>
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1719,6 +1719,7 @@ export const tlfKeysGetTLFCryptKeysRpcChannelMap = (configKeys: Array<string>, r
 export const tlfKeysGetTLFCryptKeysRpcPromise = (request: TlfKeysGetTLFCryptKeysRpcParam): Promise<TlfKeysGetTLFCryptKeysResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.tlfKeys.getTLFCryptKeys', request, (error: RPCError, result: TlfKeysGetTLFCryptKeysResult) => (error ? reject(error) : resolve(result))))
 
 export const tlfKeysTLFIdentifyBehavior = {
+  unset: 0,
   chatCli: 1,
   chatGui: 2,
   chatGuiStrict: 3,
@@ -1727,7 +1728,8 @@ export const tlfKeysTLFIdentifyBehavior = {
   chatSkip: 6,
   saltpack: 7,
   cli: 8,
-  defaultKbfs: 9,
+  gui: 9,
+  defaultKbfs: 10,
 }
 
 export const tlfPublicCanonicalTLFNameAndIDRpcChannelMap = (configKeys: Array<string>, request: TlfPublicCanonicalTLFNameAndIDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.tlf.publicCanonicalTLFNameAndID', request)
@@ -3483,6 +3485,7 @@ export type TLFBreak = $ReadOnly<{breaks?: ?Array<TLFIdentifyFailure>}>
 export type TLFID = String
 
 export type TLFIdentifyBehavior =
+  | 0 // UNSET_0
   | 1 // CHAT_CLI_1
   | 2 // CHAT_GUI_2
   | 3 // CHAT_GUI_STRICT_3
@@ -3491,7 +3494,8 @@ export type TLFIdentifyBehavior =
   | 6 // CHAT_SKIP_6
   | 7 // SALTPACK_7
   | 8 // CLI_8
-  | 9 // DEFAULT_KBFS_9
+  | 9 // GUI_9
+  | 10 // DEFAULT_KBFS_10
 
 export type TLFIdentifyFailure = $ReadOnly<{user: User, breaks?: ?IdentifyTrackBreaks}>
 

--- a/protocol/json/keybase1/tlf_keys.json
+++ b/protocol/json/keybase1/tlf_keys.json
@@ -15,6 +15,7 @@
       "type": "enum",
       "name": "TLFIdentifyBehavior",
       "symbols": [
+        "UNSET_0",
         "CHAT_CLI_1",
         "CHAT_GUI_2",
         "CHAT_GUI_STRICT_3",
@@ -23,7 +24,8 @@
         "CHAT_SKIP_6",
         "SALTPACK_7",
         "CLI_8",
-        "DEFAULT_KBFS_9"
+        "GUI_9",
+        "DEFAULT_KBFS_10"
       ]
     },
     {

--- a/protocol/json/keybase1/tlf_keys.json
+++ b/protocol/json/keybase1/tlf_keys.json
@@ -15,7 +15,6 @@
       "type": "enum",
       "name": "TLFIdentifyBehavior",
       "symbols": [
-        "DEFAULT_KBFS_0",
         "CHAT_CLI_1",
         "CHAT_GUI_2",
         "CHAT_GUI_STRICT_3",
@@ -23,7 +22,8 @@
         "KBFS_QR_5",
         "CHAT_SKIP_6",
         "SALTPACK_7",
-        "CLI_8"
+        "CLI_8",
+        "DEFAULT_KBFS_9"
       ]
     },
     {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1719,7 +1719,6 @@ export const tlfKeysGetTLFCryptKeysRpcChannelMap = (configKeys: Array<string>, r
 export const tlfKeysGetTLFCryptKeysRpcPromise = (request: TlfKeysGetTLFCryptKeysRpcParam): Promise<TlfKeysGetTLFCryptKeysResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.tlfKeys.getTLFCryptKeys', request, (error: RPCError, result: TlfKeysGetTLFCryptKeysResult) => (error ? reject(error) : resolve(result))))
 
 export const tlfKeysTLFIdentifyBehavior = {
-  defaultKbfs: 0,
   chatCli: 1,
   chatGui: 2,
   chatGuiStrict: 3,
@@ -1728,6 +1727,7 @@ export const tlfKeysTLFIdentifyBehavior = {
   chatSkip: 6,
   saltpack: 7,
   cli: 8,
+  defaultKbfs: 9,
 }
 
 export const tlfPublicCanonicalTLFNameAndIDRpcChannelMap = (configKeys: Array<string>, request: TlfPublicCanonicalTLFNameAndIDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.tlf.publicCanonicalTLFNameAndID', request)
@@ -3483,7 +3483,6 @@ export type TLFBreak = $ReadOnly<{breaks?: ?Array<TLFIdentifyFailure>}>
 export type TLFID = String
 
 export type TLFIdentifyBehavior =
-  | 0 // DEFAULT_KBFS_0
   | 1 // CHAT_CLI_1
   | 2 // CHAT_GUI_2
   | 3 // CHAT_GUI_STRICT_3
@@ -3492,6 +3491,7 @@ export type TLFIdentifyBehavior =
   | 6 // CHAT_SKIP_6
   | 7 // SALTPACK_7
   | 8 // CLI_8
+  | 9 // DEFAULT_KBFS_9
 
 export type TLFIdentifyFailure = $ReadOnly<{user: User, breaks?: ?IdentifyTrackBreaks}>
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1719,6 +1719,7 @@ export const tlfKeysGetTLFCryptKeysRpcChannelMap = (configKeys: Array<string>, r
 export const tlfKeysGetTLFCryptKeysRpcPromise = (request: TlfKeysGetTLFCryptKeysRpcParam): Promise<TlfKeysGetTLFCryptKeysResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.tlfKeys.getTLFCryptKeys', request, (error: RPCError, result: TlfKeysGetTLFCryptKeysResult) => (error ? reject(error) : resolve(result))))
 
 export const tlfKeysTLFIdentifyBehavior = {
+  unset: 0,
   chatCli: 1,
   chatGui: 2,
   chatGuiStrict: 3,
@@ -1727,7 +1728,8 @@ export const tlfKeysTLFIdentifyBehavior = {
   chatSkip: 6,
   saltpack: 7,
   cli: 8,
-  defaultKbfs: 9,
+  gui: 9,
+  defaultKbfs: 10,
 }
 
 export const tlfPublicCanonicalTLFNameAndIDRpcChannelMap = (configKeys: Array<string>, request: TlfPublicCanonicalTLFNameAndIDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.tlf.publicCanonicalTLFNameAndID', request)
@@ -3483,6 +3485,7 @@ export type TLFBreak = $ReadOnly<{breaks?: ?Array<TLFIdentifyFailure>}>
 export type TLFID = String
 
 export type TLFIdentifyBehavior =
+  | 0 // UNSET_0
   | 1 // CHAT_CLI_1
   | 2 // CHAT_GUI_2
   | 3 // CHAT_GUI_STRICT_3
@@ -3491,7 +3494,8 @@ export type TLFIdentifyBehavior =
   | 6 // CHAT_SKIP_6
   | 7 // SALTPACK_7
   | 8 // CLI_8
-  | 9 // DEFAULT_KBFS_9
+  | 9 // GUI_9
+  | 10 // DEFAULT_KBFS_10
 
 export type TLFIdentifyFailure = $ReadOnly<{user: User, breaks?: ?IdentifyTrackBreaks}>
 


### PR DESCRIPTION
This changes keybase1.TLFIdentifyBehavior_DEFAULT_KBFS to not be the zero (default) value.

I had panics in to check when the default was being used and changed them.  All tests pass and I checked many CLI operations manually.