### PR TITLE
Team lists stability

### DIFF
--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -452,7 +452,6 @@ class Team extends React.PureComponent<Props> {
       contents = !loading && (
         <List
           items={subTeamsItems}
-          fixedHeight={48}
           keyProperty="key"
           renderItem={subTeamsRow}
           style={{alignSelf: 'stretch'}}

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -144,7 +144,6 @@ type TeamTabsProps = {
 
 const SubteamsIntro = ({row}) => (
   <SubteamBanner
-    key={row.key}
     onHideSubteamsBanner={row.onHideSubteamsBanner}
     onReadMore={row.onReadMore}
     teamname={row.teamname}
@@ -152,14 +151,13 @@ const SubteamsIntro = ({row}) => (
 )
 
 const SubteamRow = ({row}) => (
-  <Box key={row.teamname + 'row'}>
+  <Box>
     <TeamSubteamRow teamname={row.teamname} />
   </Box>
 )
 
 const AddSubTeam = ({row}) => (
   <Box
-    key="addSubteam"
     style={{
       ...globalStyles.flexBoxRow,
       alignItems: 'center',
@@ -183,7 +181,6 @@ const AddSubTeam = ({row}) => (
 
 const NoSubteams = ({row}) => (
   <Box
-    key="noSubteams"
     style={{
       ...globalStyles.flexBoxRow,
       alignItems: 'center',
@@ -202,13 +199,13 @@ const NoSubteams = ({row}) => (
 const subTeamsRow = (index, row) => {
   switch (row.type) {
     case 'intro':
-      return <SubteamsIntro row={row} />
+      return <SubteamsIntro key={row.key} row={row} />
     case 'addSubteam':
-      return <AddSubTeam row={row} />
+      return <AddSubTeam key={row.key} row={row} />
     case 'noSubteams':
-      return <NoSubteams row={row} />
+      return <NoSubteams key={row.key} row={row} />
     default:
-      return <SubteamRow row={row} />
+      return <SubteamRow key={row.key} row={row} />
   }
 }
 


### PR DESCRIPTION
Adds keys to the immediate children of the subteams list to hopefully get rid of some issues @patrickxb was seeing

- [x] Subteams list
- [x] Members list

Turns out setting `fixedHeight` on the subteams list while having the subteams banner (which doesn't have a fixed height) completely hoses all the `List`s on the page.

r? @keybase/react-hackers 