### PR TITLE
Remove packed and payloadJSON for memory savings

### DIFF
--- a/go/engine/list_tracking.go
+++ b/go/engine/list_tracking.go
@@ -200,7 +200,7 @@ func (e *ListTrackingEngine) runJSON(trackList TrackList, verbose bool) error {
 		var rec *jsonw.Wrapper
 		var e2 error
 		if verbose {
-			rec = link.GetPayloadJSON()
+			rec = link.UnmarshalPayloadJSON()
 		} else if rec, e2 = condenseRecord(link); e2 != nil {
 			e.G().Log.Warning("In conversion to JSON: %s", e2)
 		}

--- a/go/engine/track_proof_test.go
+++ b/go/engine/track_proof_test.go
@@ -51,7 +51,7 @@ func checkTrackCommon(tc libkb.TestContext, blocks []sb, outcome *keybase1.Ident
 	if s == nil {
 		tc.T.Fatal("me.TrackChainLinkFor(...) returned nil, nil")
 	}
-	tc.T.Logf("payload json:\n%s", s.GetPayloadJSON().MarshalPretty())
+	tc.T.Logf("payload json:\n%s", s.UnmarshalPayloadJSON().MarshalPretty())
 
 	sbs := s.ToServiceBlocks()
 	if len(sbs) != len(blocks) {

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -291,6 +291,14 @@ func (p CommandLine) GetUIDMapFullNameCacheSize() (int, bool) {
 	return 0, false
 }
 
+func (p CommandLine) GetPayloadCacheSize() (int, bool) {
+	ret := p.GetGInt("payload-cache-size")
+	if ret != 0 {
+		return ret, true
+	}
+	return 0, false
+}
+
 func (p CommandLine) GetLocalTrackMaxAge() (time.Duration, bool) {
 	ret, err := p.GetGDuration("local-track-maxage")
 	if err != nil {

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -285,11 +285,13 @@ func (c *ChainLink) GetUID() keybase1.UID {
 }
 
 func (c *ChainLink) UnmarshalPayloadJSON() *jsonw.Wrapper {
-	payloadJSON, err := jsonw.Unmarshal([]byte(c.unpacked.payloadJSONStr))
+	jw, err := c.G().PayloadCache.GetOrPrime(c)
 	if err != nil {
+		// Any unmarshal error here would already have
+		// happened in Unpack
 		return nil
 	}
-	return payloadJSON
+	return jw
 }
 
 func (c *ChainLink) ToSigChainLocation() keybase1.SigChainLocation {

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -968,15 +968,9 @@ func (c *ChainLink) GetSigchainV2Type() (SigchainV2Type, error) {
 func (c *ChainLink) checkServerSignatureMetadata(ckf ComputedKeyFamily) (ret keybase1.KID, err error) {
 	var serverKID, linkKID, verifyKID keybase1.KID
 
-	/*
-		if jw := c.packed.AtKey("kid"); !jw.IsNil() {
-			serverKID, err = GetKID(jw)
-			if err != nil {
-				return ret, err
-			}
-		}
-	*/
-
+	// PC: i'm not sure what exactly this was trying to do since
+	// c.packed.kid can only be equal to c.unpacked.kid at this point.
+	// The following two lines result in the least changes below:
 	serverKID = c.unpacked.kid
 	linkKID = c.unpacked.kid
 

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -284,7 +284,7 @@ func (c *ChainLink) GetUID() keybase1.UID {
 	return c.unpacked.uid
 }
 
-func (c *ChainLink) GetPayloadJSON() *jsonw.Wrapper {
+func (c *ChainLink) UnmarshalPayloadJSON() *jsonw.Wrapper {
 	payloadJSON, err := jsonw.Unmarshal([]byte(c.unpacked.payloadJSONStr))
 	if err != nil {
 		return nil
@@ -335,7 +335,7 @@ func (c *ChainLink) GetMerkleSeqno() keybase1.Seqno {
 	if c.IsStubbed() {
 		return 0
 	}
-	i, err := c.GetPayloadJSON().AtPath("body.merkle_root.seqno").GetInt()
+	i, err := c.UnmarshalPayloadJSON().AtPath("body.merkle_root.seqno").GetInt()
 	if err != nil {
 		i = 0
 	}
@@ -346,7 +346,7 @@ func (c *ChainLink) GetMerkleHashMeta() (keybase1.HashMeta, error) {
 	if c.IsStubbed() {
 		return nil, nil
 	}
-	s, err := c.GetPayloadJSON().AtPath("body.merkle_root.hash_meta").GetString()
+	s, err := c.UnmarshalPayloadJSON().AtPath("body.merkle_root.hash_meta").GetString()
 	if err != nil {
 		return nil, nil
 	}
@@ -362,7 +362,7 @@ func (c *ChainLink) GetRevocations() []keybase1.SigID {
 		return nil
 	}
 	var ret []keybase1.SigID
-	jw := c.GetPayloadJSON().AtKey("body").AtKey("revoke")
+	jw := c.UnmarshalPayloadJSON().AtKey("body").AtKey("revoke")
 	s, err := GetSigID(jw.AtKey("sig_id"), true)
 	if err == nil {
 		ret = append(ret, s)
@@ -385,7 +385,7 @@ func (c *ChainLink) GetRevokeKids() []keybase1.KID {
 		return nil
 	}
 	var ret []keybase1.KID
-	jw := c.GetPayloadJSON().AtKey("body").AtKey("revoke")
+	jw := c.UnmarshalPayloadJSON().AtKey("body").AtKey("revoke")
 	if jw.IsNil() {
 		return nil
 	}
@@ -958,7 +958,7 @@ func (c *ChainLink) HasRevocations() bool {
 }
 
 func (c *ChainLink) GetSigchainV2Type() (SigchainV2Type, error) {
-	t, err := c.GetPayloadJSON().AtPath("body.type").GetString()
+	t, err := c.UnmarshalPayloadJSON().AtPath("body.type").GetString()
 	if err != nil {
 		return SigchainV2TypeNone, err
 	}

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -200,9 +200,9 @@ type ChainLink struct {
 	dirty           bool
 
 	// packed      *jsonw.Wrapper
-	payloadJSON *jsonw.Wrapper
-	unpacked    *ChainLinkUnpacked
-	cki         *ComputedKeyInfos
+	// payloadJSON *jsonw.Wrapper
+	unpacked *ChainLinkUnpacked
+	cki      *ComputedKeyInfos
 
 	typed                  TypedChainLink
 	isOwnNewLinkFromServer bool
@@ -286,14 +286,12 @@ func (c *ChainLink) GetUID() keybase1.UID {
 }
 
 func (c *ChainLink) GetPayloadJSON() *jsonw.Wrapper {
-	return c.payloadJSON
-	/*
-		payloadJSON, err := jsonw.Unmarshal([]byte(c.unpacked.payloadJSONStr))
-		if err != nil {
-			return nil
-		}
-		return payloadJSON
-	*/
+	// return c.payloadJSON
+	payloadJSON, err := jsonw.Unmarshal([]byte(c.unpacked.payloadJSONStr))
+	if err != nil {
+		return nil
+	}
+	return payloadJSON
 }
 
 func (c *ChainLink) ToSigChainLocation() keybase1.SigChainLocation {
@@ -580,7 +578,7 @@ func (c *ChainLink) Unpack(trusted bool, selfUID keybase1.UID, packed *jsonw.Wra
 		if err := tmp.unpackPayloadJSON(payloadJSON, payloadJSONStr); err != nil {
 			return err
 		}
-		c.payloadJSON = payloadJSON
+		// c.payloadJSON = payloadJSON
 	}
 
 	var sigKID, serverKID, payloadKID keybase1.KID

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -489,8 +489,12 @@ func (tmp *ChainLinkUnpacked) unpackPayloadJSON(payloadJSON *jsonw.Wrapper, payl
 }
 
 func (c *ChainLink) UnpackLocal(payloadJSON *jsonw.Wrapper) (err error) {
+	payloadStr, err := payloadJSON.Marshal()
+	if err != nil {
+		return err
+	}
 	tmp := ChainLinkUnpacked{}
-	err = tmp.unpackPayloadJSON(payloadJSON, "")
+	err = tmp.unpackPayloadJSON(payloadJSON, string(payloadStr))
 	if err == nil {
 		c.unpacked = &tmp
 	}

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -326,8 +326,6 @@ func (c *ChainLink) Pack() (*jsonw.Wrapper, error) {
 		p.SetKey("computed_key_infos", jsonw.NewWrapper(*c.cki))
 	}
 
-	// c.packed = p
-
 	return p, nil
 }
 

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -617,6 +617,10 @@ func (f JSONConfigFile) GetUIDMapFullNameCacheSize() (int, bool) {
 	return f.getCacheSize("cache.limits.uid_map_full_name")
 }
 
+func (f JSONConfigFile) GetPayloadCacheSize() (int, bool) {
+	return f.getCacheSize("cache.limits.payloads")
+}
+
 func (f JSONConfigFile) GetLevelDBNumFiles() (int, bool) {
 	return f.GetIntAtPath("leveldb.num_files")
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -113,6 +113,8 @@ const (
 	UIDMapFullNameCacheSize           = 100000
 	ImplicitTeamConflictInfoCacheSize = 10000
 
+	PayloadCacheSize = 1000
+
 	SigShortIDBytes  = 27
 	LocalTrackMaxAge = 48 * time.Hour
 

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -42,6 +42,7 @@ func (n NullConfiguration) GetLinkCacheSize() (int, bool)                       
 func (n NullConfiguration) GetLinkCacheCleanDur() (time.Duration, bool)                    { return 0, false }
 func (n NullConfiguration) GetUPAKCacheSize() (int, bool)                                  { return 0, false }
 func (n NullConfiguration) GetUIDMapFullNameCacheSize() (int, bool)                        { return 0, false }
+func (n NullConfiguration) GetPayloadCacheSize() (int, bool)                               { return 0, false }
 func (n NullConfiguration) GetMerkleKIDs() []string                                        { return nil }
 func (n NullConfiguration) GetCodeSigningKIDs() []string                                   { return nil }
 func (n NullConfiguration) GetPinentry() string                                            { return "" }
@@ -832,6 +833,14 @@ func (e *Env) GetLinkCacheCleanDur() time.Duration {
 	return e.GetDuration(LinkCacheCleanDur,
 		func() (time.Duration, bool) { return e.getEnvDuration("KEYBASE_LINK_CACHE_CLEAN_DUR") },
 		e.GetConfig().GetLinkCacheCleanDur,
+	)
+}
+
+func (e *Env) GetPayloadCacheSize() int {
+	return e.GetInt(PayloadCacheSize,
+		e.cmd.GetPayloadCacheSize,
+		func() (int, bool) { return e.getEnvInt("KEYBASE_PAYLOAD_CACHE_SIZE") },
+		e.GetConfig().GetPayloadCacheSize,
 	)
 }
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -75,6 +75,7 @@ type GlobalContext struct {
 	CardCache      *UserCardCache  // cache of keybase1.UserCard objects
 	fullSelfer     FullSelfer      // a loader that gets the full self object
 	pvlSource      PvlSource       // a cache and fetcher for pvl
+	PayloadCache   *PayloadCache   // cache of ChainLink payload json wrappers
 
 	GpgClient        *GpgCLI        // A standard GPG-client (optional)
 	ShutdownHooks    []ShutdownHook // on shutdown, fire these...
@@ -430,6 +431,7 @@ func (g *GlobalContext) configureMemCachesLocked() {
 	g.Log.Debug("made a new full self cache")
 	g.upakLoader = NewCachedUPAKLoader(g, CachedUserTimeout)
 	g.Log.Debug("made a new cached UPAK loader (timeout=%v)", CachedUserTimeout)
+	g.PayloadCache = NewPayloadCache(g, g.Env.GetPayloadCacheSize())
 }
 
 func (g *GlobalContext) ConfigureMemCaches() {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -374,12 +374,15 @@ func ParseServiceBlock(jw *jsonw.Wrapper, pt keybase1.ProofType) (sb *ServiceBlo
 func ParseWebServiceBinding(base GenericChainLink) (ret RemoteProofChainLink, e error) {
 	jw := base.GetPayloadJSON().AtKey("body").AtKey("service")
 
-	var sptf string
-	ptf := base.packed.AtKey("proof_text_full")
-	if !ptf.IsNil() {
-		// TODO: add test that returning on err here is ok:
-		sptf, _ = ptf.GetString()
-	}
+	/*
+		var sptf string
+		ptf := base.packed.AtKey("proof_text_full")
+		if !ptf.IsNil() {
+			// TODO: add test that returning on err here is ok:
+			sptf, _ = ptf.GetString()
+		}
+	*/
+	sptf := base.unpacked.proofText
 
 	if jw.IsNil() {
 		ret, e = ParseSelfSigChainLink(base)

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -106,7 +106,7 @@ func (g *GenericChainLink) GetUID() keybase1.UID {
 func (g *GenericChainLink) GetDevice() *Device { return nil }
 
 func (g *GenericChainLink) extractPGPFullHash(loc string) string {
-	if jw := g.payloadJSON.AtPath("body." + loc + ".full_hash"); !jw.IsNil() {
+	if jw := g.GetPayloadJSON().AtPath("body." + loc + ".full_hash"); !jw.IsNil() {
 		if ret, err := jw.GetString(); err == nil {
 			return ret
 		}
@@ -372,7 +372,7 @@ func ParseServiceBlock(jw *jsonw.Wrapper, pt keybase1.ProofType) (sb *ServiceBlo
 
 // To be used for signatures in a user's signature chain.
 func ParseWebServiceBinding(base GenericChainLink) (ret RemoteProofChainLink, e error) {
-	jw := base.payloadJSON.AtKey("body").AtKey("service")
+	jw := base.GetPayloadJSON().AtKey("body").AtKey("service")
 
 	var sptf string
 	ptf := base.packed.AtKey("proof_text_full")
@@ -420,14 +420,14 @@ func (l TrackChainLink) IsRemote() bool {
 
 func ParseTrackChainLink(b GenericChainLink) (ret *TrackChainLink, err error) {
 	var tmp string
-	tmp, err = b.payloadJSON.AtPath("body.track.basics.username").GetString()
+	tmp, err = b.GetPayloadJSON().AtPath("body.track.basics.username").GetString()
 	if err != nil {
 		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
 		return
 	}
 	whomUsername := NewNormalizedUsername(tmp)
 
-	whomUID, err := GetUID(b.payloadJSON.AtPath("body.track.id"))
+	whomUID, err := GetUID(b.GetPayloadJSON().AtPath("body.track.id"))
 	if err != nil {
 		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
 		return
@@ -483,7 +483,7 @@ func (l *TrackChainLink) GetTrackedKeys() ([]TrackedKey, error) {
 
 	var res []TrackedKey
 
-	pgpKeysJSON := l.payloadJSON.AtPath("body.track.pgp_keys")
+	pgpKeysJSON := l.GetPayloadJSON().AtPath("body.track.pgp_keys")
 	if !pgpKeysJSON.IsNil() {
 		n, err := pgpKeysJSON.Len()
 		if err != nil {
@@ -505,7 +505,7 @@ func (l *TrackChainLink) GetTrackedKeys() ([]TrackedKey, error) {
 }
 
 func (l *TrackChainLink) GetEldestKID() (kid keybase1.KID, err error) {
-	keyJSON := l.payloadJSON.AtPath("body.track.key")
+	keyJSON := l.GetPayloadJSON().AtPath("body.track.key")
 	if keyJSON.IsNil() {
 		return kid, nil
 	}
@@ -517,11 +517,11 @@ func (l *TrackChainLink) GetEldestKID() (kid keybase1.KID, err error) {
 }
 
 func (l *TrackChainLink) GetTrackedUID() (keybase1.UID, error) {
-	return GetUID(l.payloadJSON.AtPath("body.track.id"))
+	return GetUID(l.GetPayloadJSON().AtPath("body.track.id"))
 }
 
 func (l *TrackChainLink) GetTrackedUsername() (NormalizedUsername, error) {
-	tmp, err := l.payloadJSON.AtPath("body.track.basics.username").GetString()
+	tmp, err := l.GetPayloadJSON().AtPath("body.track.basics.username").GetString()
 	if err != nil {
 		return NormalizedUsername(""), nil
 	}
@@ -533,7 +533,7 @@ func (l *TrackChainLink) IsRevoked() bool {
 }
 
 func (l *TrackChainLink) RemoteKeyProofs() *jsonw.Wrapper {
-	return l.payloadJSON.AtPath("body.track.remote_proofs")
+	return l.GetPayloadJSON().AtPath("body.track.remote_proofs")
 }
 
 func (l *TrackChainLink) ToServiceBlocks() (ret []*ServiceBlock) {
@@ -610,12 +610,12 @@ func ParseEldestChainLink(b GenericChainLink) (ret *EldestChainLink, err error) 
 	var kid keybase1.KID
 	var device *Device
 
-	if kid, err = GetKID(b.payloadJSON.AtPath("body.key.kid")); err != nil {
+	if kid, err = GetKID(b.GetPayloadJSON().AtPath("body.key.kid")); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Bad eldest statement @%s: %s", b.ToDebugString(), err)}
 		return
 	}
 
-	if jw := b.payloadJSON.AtPath("body.device"); !jw.IsNil() {
+	if jw := b.GetPayloadJSON().AtPath("body.device"); !jw.IsNil() {
 		if device, err = ParseDevice(jw, b.GetCTime()); err != nil {
 			return
 		}
@@ -653,19 +653,19 @@ func ParseSibkeyChainLink(b GenericChainLink) (ret *SibkeyChainLink, err error) 
 	var kid keybase1.KID
 	var device *Device
 
-	if kid, err = GetKID(b.payloadJSON.AtPath("body.sibkey.kid")); err != nil {
+	if kid, err = GetKID(b.GetPayloadJSON().AtPath("body.sibkey.kid")); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Bad sibkey statement @%s: %s", b.ToDebugString(), err)}
 		return
 	}
 
 	var rs string
-	if rs, err = b.payloadJSON.AtPath("body.sibkey.reverse_sig").GetString(); err != nil {
+	if rs, err = b.GetPayloadJSON().AtPath("body.sibkey.reverse_sig").GetString(); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Missing reverse_sig in sibkey delegation: @%s: %s",
 			b.ToDebugString(), err)}
 		return
 	}
 
-	if jw := b.payloadJSON.AtPath("body.device"); !jw.IsNil() {
+	if jw := b.GetPayloadJSON().AtPath("body.device"); !jw.IsNil() {
 		if device, err = ParseDevice(jw, b.GetCTime()); err != nil {
 			return
 		}
@@ -705,7 +705,7 @@ func (s *SibkeyChainLink) VerifyReverseSig(ckf ComputedKeyFamily) (err error) {
 		return err
 	}
 
-	return VerifyReverseSig(s.G(), key, "body.sibkey.reverse_sig", s.payloadJSON, s.reverseSig)
+	return VerifyReverseSig(s.G(), key, "body.sibkey.reverse_sig", s.GetPayloadJSON(), s.reverseSig)
 }
 
 //
@@ -720,9 +720,9 @@ type SubkeyChainLink struct {
 
 func ParseSubkeyChainLink(b GenericChainLink) (ret *SubkeyChainLink, err error) {
 	var kid, pkid keybase1.KID
-	if kid, err = GetKID(b.payloadJSON.AtPath("body.subkey.kid")); err != nil {
+	if kid, err = GetKID(b.GetPayloadJSON().AtPath("body.subkey.kid")); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Can't get KID for subkey @%s: %s", b.ToDebugString(), err)}
-	} else if pkid, err = GetKID(b.payloadJSON.AtPath("body.subkey.parent_kid")); err != nil {
+	} else if pkid, err = GetKID(b.GetPayloadJSON().AtPath("body.subkey.parent_kid")); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Can't get parent_kid for subkey @%s: %s", b.ToDebugString(), err)}
 	} else {
 		ret = &SubkeyChainLink{b, kid, pkid}
@@ -759,7 +759,7 @@ func ParsePerUserKeyChainLink(b GenericChainLink) (ret *PerUserKeyChainLink, err
 	var sigKID, encKID keybase1.KID
 	var g int
 	var reverseSig string
-	section := b.payloadJSON.AtPath("body.per_user_key")
+	section := b.GetPayloadJSON().AtPath("body.per_user_key")
 	if sigKID, err = GetKID(section.AtKey("signing_kid")); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Can't get signing KID for per_user_secret: @%s: %s", b.ToDebugString(), err)}
 	} else if encKID, err = GetKID(section.AtKey("encryption_kid")); err != nil {
@@ -807,7 +807,7 @@ func (s *PerUserKeyChainLink) VerifyReverseSig(_ ComputedKeyFamily) (err error) 
 		return fmt.Errorf("Invalid per-user signing KID: %s", s.sigKID)
 	}
 
-	return VerifyReverseSig(s.G(), key, "body.per_user_key.reverse_sig", s.payloadJSON, s.reverseSig)
+	return VerifyReverseSig(s.G(), key, "body.per_user_key.reverse_sig", s.GetPayloadJSON(), s.reverseSig)
 }
 
 //
@@ -828,7 +828,7 @@ type PGPUpdateChainLink struct {
 func ParsePGPUpdateChainLink(b GenericChainLink) (ret *PGPUpdateChainLink, err error) {
 	var kid keybase1.KID
 
-	pgpUpdate := b.payloadJSON.AtPath("body.pgp_update")
+	pgpUpdate := b.GetPayloadJSON().AtPath("body.pgp_update")
 
 	if pgpUpdate.IsNil() {
 		err = ChainLinkError{fmt.Sprintf("missing pgp_update section @%s", b.ToDebugString())}
@@ -867,7 +867,7 @@ type DeviceChainLink struct {
 
 func ParseDeviceChainLink(b GenericChainLink) (ret *DeviceChainLink, err error) {
 	var dobj *Device
-	if dobj, err = ParseDevice(b.payloadJSON.AtPath("body.device"), b.GetCTime()); err != nil {
+	if dobj, err = ParseDevice(b.GetPayloadJSON().AtPath("body.device"), b.GetCTime()); err != nil {
 	} else {
 		ret = &DeviceChainLink{b, dobj}
 	}
@@ -890,14 +890,14 @@ type UntrackChainLink struct {
 
 func ParseUntrackChainLink(b GenericChainLink) (ret *UntrackChainLink, err error) {
 	var tmp string
-	tmp, err = b.payloadJSON.AtPath("body.untrack.basics.username").GetString()
+	tmp, err = b.GetPayloadJSON().AtPath("body.untrack.basics.username").GetString()
 	if err != nil {
 		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
 		return
 	}
 	whomUsername := NewNormalizedUsername(tmp)
 
-	whomUID, err := GetUID(b.payloadJSON.AtPath("body.untrack.id"))
+	whomUID, err := GetUID(b.GetPayloadJSON().AtPath("body.untrack.id"))
 	if err != nil {
 		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
 		return
@@ -952,7 +952,7 @@ func (c CryptocurrencyChainLink) GetAddress() string {
 func ParseCryptocurrencyChainLink(b GenericChainLink) (
 	cl *CryptocurrencyChainLink, err error) {
 
-	jw := b.payloadJSON.AtPath("body.cryptocurrency")
+	jw := b.GetPayloadJSON().AtPath("body.cryptocurrency")
 	var styp, addr string
 	var pkhash []byte
 
@@ -1004,7 +1004,7 @@ type RevokeChainLink struct {
 
 func ParseRevokeChainLink(b GenericChainLink) (ret *RevokeChainLink, err error) {
 	var device *Device
-	if jw := b.payloadJSON.AtPath("body.device"); !jw.IsNil() {
+	if jw := b.GetPayloadJSON().AtPath("body.device"); !jw.IsNil() {
 		if device, err = ParseDevice(jw, b.GetCTime()); err != nil {
 			return
 		}
@@ -1079,7 +1079,7 @@ func (s *SelfSigChainLink) ComputeTrackDiff(tl *TrackLookup) TrackDiff { return 
 func (s *SelfSigChainLink) GetProofType() keybase1.ProofType { return keybase1.ProofType_KEYBASE }
 
 func (s *SelfSigChainLink) ParseDevice() (err error) {
-	if jw := s.payloadJSON.AtPath("body.device"); !jw.IsNil() {
+	if jw := s.GetPayloadJSON().AtPath("body.device"); !jw.IsNil() {
 		s.device, err = ParseDevice(jw, s.GetCTime())
 	}
 	return err
@@ -1148,7 +1148,7 @@ func NewTypedChainLink(cl *ChainLink) (ret TypedChainLink, w Warning) {
 
 	base := GenericChainLink{cl}
 
-	s, err := cl.payloadJSON.AtKey("body").AtKey("type").GetString()
+	s, err := cl.GetPayloadJSON().AtKey("body").AtKey("type").GetString()
 	if len(s) == 0 || err != nil {
 		err = fmt.Errorf("No type in signature @%s", base.ToDebugString())
 	} else {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -413,15 +413,16 @@ func (l TrackChainLink) IsRemote() bool {
 }
 
 func ParseTrackChainLink(b GenericChainLink) (ret *TrackChainLink, err error) {
+	payload := b.GetPayloadJSON()
 	var tmp string
-	tmp, err = b.GetPayloadJSON().AtPath("body.track.basics.username").GetString()
+	tmp, err = payload.AtPath("body.track.basics.username").GetString()
 	if err != nil {
 		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
 		return
 	}
 	whomUsername := NewNormalizedUsername(tmp)
 
-	whomUID, err := GetUID(b.GetPayloadJSON().AtPath("body.track.id"))
+	whomUID, err := GetUID(payload.AtPath("body.track.id"))
 	if err != nil {
 		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
 		return
@@ -604,12 +605,13 @@ func ParseEldestChainLink(b GenericChainLink) (ret *EldestChainLink, err error) 
 	var kid keybase1.KID
 	var device *Device
 
-	if kid, err = GetKID(b.GetPayloadJSON().AtPath("body.key.kid")); err != nil {
+	payload := b.GetPayloadJSON()
+	if kid, err = GetKID(payload.AtPath("body.key.kid")); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Bad eldest statement @%s: %s", b.ToDebugString(), err)}
 		return
 	}
 
-	if jw := b.GetPayloadJSON().AtPath("body.device"); !jw.IsNil() {
+	if jw := payload.AtPath("body.device"); !jw.IsNil() {
 		if device, err = ParseDevice(jw, b.GetCTime()); err != nil {
 			return
 		}
@@ -647,19 +649,20 @@ func ParseSibkeyChainLink(b GenericChainLink) (ret *SibkeyChainLink, err error) 
 	var kid keybase1.KID
 	var device *Device
 
-	if kid, err = GetKID(b.GetPayloadJSON().AtPath("body.sibkey.kid")); err != nil {
+	payload := b.GetPayloadJSON()
+	if kid, err = GetKID(payload.AtPath("body.sibkey.kid")); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Bad sibkey statement @%s: %s", b.ToDebugString(), err)}
 		return
 	}
 
 	var rs string
-	if rs, err = b.GetPayloadJSON().AtPath("body.sibkey.reverse_sig").GetString(); err != nil {
+	if rs, err = payload.AtPath("body.sibkey.reverse_sig").GetString(); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Missing reverse_sig in sibkey delegation: @%s: %s",
 			b.ToDebugString(), err)}
 		return
 	}
 
-	if jw := b.GetPayloadJSON().AtPath("body.device"); !jw.IsNil() {
+	if jw := payload.AtPath("body.device"); !jw.IsNil() {
 		if device, err = ParseDevice(jw, b.GetCTime()); err != nil {
 			return
 		}
@@ -714,9 +717,10 @@ type SubkeyChainLink struct {
 
 func ParseSubkeyChainLink(b GenericChainLink) (ret *SubkeyChainLink, err error) {
 	var kid, pkid keybase1.KID
-	if kid, err = GetKID(b.GetPayloadJSON().AtPath("body.subkey.kid")); err != nil {
+	payload := b.GetPayloadJSON()
+	if kid, err = GetKID(payload.AtPath("body.subkey.kid")); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Can't get KID for subkey @%s: %s", b.ToDebugString(), err)}
-	} else if pkid, err = GetKID(b.GetPayloadJSON().AtPath("body.subkey.parent_kid")); err != nil {
+	} else if pkid, err = GetKID(payload.AtPath("body.subkey.parent_kid")); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Can't get parent_kid for subkey @%s: %s", b.ToDebugString(), err)}
 	} else {
 		ret = &SubkeyChainLink{b, kid, pkid}
@@ -884,14 +888,15 @@ type UntrackChainLink struct {
 
 func ParseUntrackChainLink(b GenericChainLink) (ret *UntrackChainLink, err error) {
 	var tmp string
-	tmp, err = b.GetPayloadJSON().AtPath("body.untrack.basics.username").GetString()
+	payload := b.GetPayloadJSON()
+	tmp, err = payload.AtPath("body.untrack.basics.username").GetString()
 	if err != nil {
 		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
 		return
 	}
 	whomUsername := NewNormalizedUsername(tmp)
 
-	whomUID, err := GetUID(b.GetPayloadJSON().AtPath("body.untrack.id"))
+	whomUID, err := GetUID(payload.AtPath("body.untrack.id"))
 	if err != nil {
 		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
 		return

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -373,15 +373,6 @@ func ParseServiceBlock(jw *jsonw.Wrapper, pt keybase1.ProofType) (sb *ServiceBlo
 // To be used for signatures in a user's signature chain.
 func ParseWebServiceBinding(base GenericChainLink) (ret RemoteProofChainLink, e error) {
 	jw := base.GetPayloadJSON().AtKey("body").AtKey("service")
-
-	/*
-		var sptf string
-		ptf := base.packed.AtKey("proof_text_full")
-		if !ptf.IsNil() {
-			// TODO: add test that returning on err here is ok:
-			sptf, _ = ptf.GetString()
-		}
-	*/
 	sptf := base.unpacked.proofText
 
 	if jw.IsNil() {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -81,6 +81,7 @@ type configGetter interface {
 	GetFeatureFlags() (FeatureFlags, error)
 	GetLevelDBNumFiles() (int, bool)
 	GetChatInboxSourceLocalizeThreads() (int, bool)
+	GetPayloadCacheSize() (int, bool)
 }
 
 type CommandLine interface {

--- a/go/libkb/payload_cache.go
+++ b/go/libkb/payload_cache.go
@@ -1,0 +1,53 @@
+package libkb
+
+import (
+	"encoding/hex"
+
+	lru "github.com/hashicorp/golang-lru"
+	jsonw "github.com/keybase/go-jsonw"
+)
+
+type PayloadCache struct {
+	Contextified
+	cache *lru.Cache
+}
+
+func NewPayloadCache(g *GlobalContext, maxNumElements int) *PayloadCache {
+	c, err := lru.New(maxNumElements)
+	if err != nil {
+		g.Log.Warning("failed to create PayloadCache LRU: %s", err)
+		c = nil
+	}
+
+	return &PayloadCache{
+		Contextified: NewContextified(g),
+		cache:        c,
+	}
+}
+
+func (p *PayloadCache) GetOrPrime(link *ChainLink) (*jsonw.Wrapper, error) {
+	// check if failed to create cache in NewPayloadCache
+	if p.cache == nil {
+		p.G().Log.Debug("PayloadCache no LRU, unmarshal for %x", link.unpacked.payloadHash)
+		return jsonw.Unmarshal([]byte(link.unpacked.payloadJSONStr))
+	}
+
+	key := hex.EncodeToString(link.unpacked.payloadHash)
+
+	obj, ok := p.cache.Get(key)
+	if ok {
+		jw, ok := obj.(*jsonw.Wrapper)
+		if ok {
+			return jw, nil
+		}
+	}
+
+	jw, err := jsonw.Unmarshal([]byte(link.unpacked.payloadJSONStr))
+	if err != nil {
+		return nil, err
+	}
+
+	p.cache.Add(key, jw)
+
+	return jw, nil
+}

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -414,8 +414,8 @@ func localTrackChainLinkFor(tracker, trackee keybase1.UID, localExpires bool, g 
 		return
 	}
 
-	cl := &ChainLink{Contextified: NewContextified(g), payloadJSON: obj, unsigned: true}
-	if err = cl.UnpackLocal(); err != nil {
+	cl := &ChainLink{Contextified: NewContextified(g), unsigned: true}
+	if err = cl.UnpackLocal(obj); err != nil {
 		g.Log.Debug("| unpack failed -> %s", err)
 		return
 	}


### PR DESCRIPTION
This patch is a first stab at reducing the sig chain memory usage.

It removes `ChainLink.packed` and `ChainLink.payloadJSON`.  With both of these gone, some GC happens.  With just one gone (I tried both options), memory usage stays the same.

I tried some other quick changes, but they either didn't work or were super destructive to existing code.

In a memory profile, the in-use memory is cut by about 50%.

In Activity Monitor, with this patch looking at profile in GUI of two users with large sigchains loaded from server shows memory usage of 435MB.  Master shows 690MB for same operation.