### PR TITLE
listen for GUI connect in background identify notifiers and clear cache CORE-7112

### DIFF
--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -51,6 +51,7 @@ func NewBackgroundConvLoader(g *globals.Context) *BackgroundConvLoader {
 		stop:          make(chan bool),
 		identNotifier: NewIdentifyNotifier(g),
 	}
+	b.identNotifier.ResetOnGUIConnect()
 
 	b.newQueue()
 

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -36,6 +36,19 @@ func NewIdentifyNotifier(g *globals.Context) *IdentifyNotifier {
 	}
 }
 
+func (i *IdentifyNotifier) ResetOnGUIConnect() {
+	i.G().ConnectionManager.RegisterLabelCallback(func(typ keybase1.ClientType) {
+		switch typ {
+		case keybase1.ClientType_GUI_HELPER, keybase1.ClientType_GUI_MAIN:
+			i.Reset()
+		}
+	})
+}
+
+func (i *IdentifyNotifier) Reset() {
+	i.identCache = make(map[string]keybase1.CanonicalTLFNameAndIDWithBreaks)
+}
+
 func (i *IdentifyNotifier) Send(update keybase1.CanonicalTLFNameAndIDWithBreaks) {
 
 	// Send to storage as well (charge forward on error)

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -179,13 +179,15 @@ type PushHandler struct {
 }
 
 func NewPushHandler(g *globals.Context) *PushHandler {
-	return &PushHandler{
+	p := &PushHandler{
 		Contextified:  globals.NewContextified(g),
 		DebugLabeler:  utils.NewDebugLabeler(g.GetLog(), "PushHandler", false),
 		identNotifier: NewIdentifyNotifier(g),
 		orderer:       newGregorMessageOrderer(g),
 		typingMonitor: NewTypingMonitor(g),
 	}
+	p.identNotifier.ResetOnGUIConnect()
+	return p
 }
 
 func (g *PushHandler) SetBadger(badger *badges.Badger) {

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -706,6 +706,8 @@ func NewDeliverer(g *globals.Context, sender types.Sender) *Deliverer {
 		return nil
 	})
 
+	d.identNotifier.ResetOnGUIConnect()
+
 	return d
 }
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -305,6 +305,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 
 	h.setTestRemoteClient(ri)
 
+	tc.G.SetService()
 	baseSender := NewBlockingSender(g, h.boxer, nil, func() chat1.RemoteInterface { return ri })
 	deliverer := NewDeliverer(g, baseSender)
 	deliverer.SetClock(c.world.Fc)
@@ -996,7 +997,6 @@ func TestChatSrvPostLocalAtMention(t *testing.T) {
 		}
 
 		listener := newServerChatListener()
-		ctc.as(t, users[1]).h.G().SetService()
 		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener)
 		ctx := ctc.as(t, users[0]).startCtx
 
@@ -1349,7 +1349,6 @@ func TestChatSrvGracefulUnboxing(t *testing.T) {
 		users := ctc.users()
 
 		listener := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
 
 		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
@@ -1647,7 +1646,6 @@ func TestChatSrvGap(t *testing.T) {
 		}
 
 		listener := newServerChatListener()
-		tc.G.SetService()
 		tc.G.NotifyRouter.SetListener(listener)
 
 		mh := codec.MsgpackHandle{WriteExt: true}
@@ -1773,7 +1771,6 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 
 		tc := ctc.as(t, users[0])
 		listener := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
 		ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
 
@@ -2153,7 +2150,6 @@ func TestChatSrvGetThreadNonblockError(t *testing.T) {
 		users := ctc.users()
 
 		listener := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
 
 		uid := users[0].User.GetUID().ToBytes()
@@ -2210,7 +2206,6 @@ func TestChatSrvGetInboxNonblockError(t *testing.T) {
 		users := ctc.users()
 
 		listener := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
 
 		uid := users[0].User.GetUID().ToBytes()
@@ -2424,17 +2419,14 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		ctx2 := ctc.as(t, users[2]).startCtx
 
 		listener0 := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
 		ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
 
 		listener1 := newServerChatListener()
-		ctc.as(t, users[1]).h.G().SetService()
 		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener1)
 		ctc.world.Tcs[users[1].Username].ChatG.Syncer.(*Syncer).isConnected = true
 
 		listener2 := newServerChatListener()
-		ctc.as(t, users[2]).h.G().SetService()
 		ctc.as(t, users[2]).h.G().NotifyRouter.SetListener(listener2)
 		ctc.world.Tcs[users[2].Username].ChatG.Syncer.(*Syncer).isConnected = true
 
@@ -2678,7 +2670,6 @@ func TestChatSrvSetAppNotificationSettings(t *testing.T) {
 		}
 
 		listener0 := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
 
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
@@ -2966,7 +2957,6 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 		displayName := users[0].Username + "," + users[1].Username
 
 		listener := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
 
 		tc := ctc.world.Tcs[users[0].Username]
@@ -3094,10 +3084,8 @@ func TestChatSrvTeamTypeChanged(t *testing.T) {
 
 		ctx := ctc.as(t, users[0]).startCtx
 		listener0 := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
 		listener1 := newServerChatListener()
-		ctc.as(t, users[1]).h.G().SetService()
 		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener1)
 
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
@@ -3178,10 +3166,8 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 		ctx := ctc.as(t, users[0]).startCtx
 		ctx1 := ctc.as(t, users[1]).startCtx
 		listener0 := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
 		listener1 := newServerChatListener()
-		ctc.as(t, users[1]).h.G().SetService()
 		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener1)
 		inboxCb := make(chan kbtest.NonblockInboxResult, 100)
 		threadCb := make(chan kbtest.NonblockThreadResult, 100)
@@ -3374,13 +3360,10 @@ func TestChatSrvUserReset(t *testing.T) {
 		ctx1 := ctc.as(t, users[1]).startCtx
 		ctx2 := ctc.as(t, users[2]).startCtx
 		listener0 := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
 		listener1 := newServerChatListener()
-		ctc.as(t, users[1]).h.G().SetService()
 		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener1)
 		listener2 := newServerChatListener()
-		ctc.as(t, users[2]).h.G().SetService()
 		ctc.as(t, users[2]).h.G().NotifyRouter.SetListener(listener2)
 		t.Logf("u0: %s u1: %s u2: %s", users[0].GetUID(), users[1].GetUID(), users[2].GetUID())
 
@@ -3561,10 +3544,8 @@ func TestChatSrvTeamChannelNameMentions(t *testing.T) {
 		ctx := ctc.as(t, users[0]).startCtx
 		ctx1 := ctc.as(t, users[1]).startCtx
 		listener0 := newServerChatListener()
-		ctc.as(t, users[0]).h.G().SetService()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
 		listener1 := newServerChatListener()
-		ctc.as(t, users[1]).h.G().SetService()
 		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener1)
 
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,

--- a/go/libkb/connmgr.go
+++ b/go/libkb/connmgr.go
@@ -192,8 +192,8 @@ func (c *ConnectionManager) run() {
 				err = NotFoundError{Msg: fmt.Sprintf("connection %d not found", id)}
 			}
 			// Hit all the callbacks with the client type
-			for _, l := range c.labelCbs {
-				l(labelConnectionObj.details.ClientType)
+			for _, lloop := range c.labelCbs {
+				go func(l LabelCb) { l(labelConnectionObj.details.ClientType) }(lloop)
 			}
 			labelConnectionObj.ch <- err
 		case retCh := <-c.listAllCh:


### PR DESCRIPTION
Patch does the following:

1.) Adds ability to register for a callback for new labelled service connections.
2.) For background `IdentifyNotifier` objects, listen for GUI clients connecting and reset the internal send cache if they do. This solve the problem of a restarted UI not getting any identify events for background tasks (like sending a message from the outbox).

cc @chrisnojima 