### PR TITLE
drop armv7 support

### DIFF
--- a/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -1465,8 +1465,6 @@
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
-					"-Xlinker",
-					"-no_branch_islands",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios;
 				PRODUCT_NAME = Keybase;
@@ -1475,6 +1473,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				VALID_ARCHS = "arm64 armv7s";
 			};
 			name = Debug;
 		};
@@ -1515,8 +1514,6 @@
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
-					"-Xlinker",
-					"-no_branch_islands",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios;
 				PRODUCT_NAME = Keybase;
@@ -1524,6 +1521,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Keybase/Keybase-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				VALID_ARCHS = "arm64 armv7s";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Patch does the following:

1.) Remove support for ARMv7, which fixes the linker problem. 
2.) Re-enable the "branch islands" linker algorithm. 

I believe with these two architectures we support down to iPhone 5. The newest phone that won't work would be the iPhone 4S. See: https://stackoverflow.com/questions/12569339/what-is-armv7s. I think that would be acceptable, Apple doesn't even release OS's for these phones anymore.

Anyway, let me know what you all think.  cc @malgorithms @maxtaco 