### PR TITLE
Decrease LinkCacheSize default to 4000

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -106,7 +106,7 @@ const (
 	// could be stale.
 	CachedUserTimeout = 10 * time.Minute
 
-	LinkCacheSize     = 0x10000
+	LinkCacheSize     = 4000
 	LinkCacheCleanDur = 1 * time.Minute
 
 	UPAKCacheSize                     = 2000

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1207,8 +1207,7 @@ func (c AppConfig) GetLevelDBNumFiles() (int, bool) {
 	return 50, true
 }
 
-// Default is 0x10000 (65,536).  Turning down on mobile to
-// reduce memory usage.
+// Default is 4000. Turning down on mobile to reduce memory usage.
 func (c AppConfig) GetLinkCacheSize() (int, bool) {
 	return 1000, true
 }


### PR DESCRIPTION
Changes default link cache size for desktop.