### PR TITLE
Transition teamNameToLoading to use waiting actions

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -85,7 +85,7 @@ const _leaveTeam = function(action: TeamsGen.LeaveTeamPayload) {
 
 const _addPeopleToTeam = function*(action: TeamsGen.AddPeopleToTeamPayload) {
   const {role, teamname, sendChatNotification} = action.payload
-  yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, true]])))
+  yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   const state: TypedState = yield Saga.select()
   const ids = SearchConstants.getUserInputItemIds(state, {searchKey: 'addToTeamSearch'})
   for (const id of ids) {
@@ -97,12 +97,12 @@ const _addPeopleToTeam = function*(action: TeamsGen.AddPeopleToTeamPayload) {
       sendChatNotification,
     })
   }
-  yield Saga.put((dispatch: Dispatch) => dispatch(TeamsGen.createGetDetails({teamname}))) // getDetails will unset loading
+  yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
 }
 
 const _inviteByEmail = function*(action: TeamsGen.InviteToTeamByEmailPayload) {
   const {invitees, role, teamname} = action.payload
-  yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, true]])))
+  yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   yield Saga.put(
     replaceEntity(['teams', 'teamNameToLoadingInvites'], I.Map([[teamname, I.Map([[invitees, true]])]]))
   )
@@ -117,14 +117,14 @@ const _inviteByEmail = function*(action: TeamsGen.InviteToTeamByEmailPayload) {
     }
   } finally {
     // TODO handle error, but for now make sure loading is unset
-    yield Saga.put((dispatch: Dispatch) => dispatch(TeamsGen.createGetDetails({teamname}))) // getDetails will unset loading
+    yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
     yield Saga.put(replaceEntity(['teams', 'teamNameToLoadingInvites', teamname], I.Map([[invitees, false]])))
   }
 }
 
 const _addToTeam = function*(action: TeamsGen.AddToTeamPayload) {
   const {teamname, email, username, role, sendChatNotification} = action.payload
-  yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, true]])))
+  yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   try {
     yield Saga.call(RPCTypes.teamsTeamAddMemberRpcPromise, {
       name: teamname,
@@ -135,26 +135,28 @@ const _addToTeam = function*(action: TeamsGen.AddToTeamPayload) {
     })
   } finally {
     // TODO handle error, but for now make sure loading is unset
-    yield Saga.put((dispatch: Dispatch) => dispatch(TeamsGen.createGetDetails({teamname}))) // getDetails will unset loading
+    yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   }
 }
 
 const _editDescription = function*(action: TeamsGen.EditTeamDescriptionPayload) {
   const {teamname, description} = action.payload
-  yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, true]])))
+  yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   try {
     yield Saga.call(RPCTypes.teamsSetTeamShowcaseRpcPromise, {
       description,
       name: teamname,
     })
   } finally {
-    yield Saga.put((dispatch: Dispatch) => dispatch(TeamsGen.createGetDetails({teamname}))) // getDetails will unset loading
+    yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
+    // TODO We don't get a team changed notification for this. Delete this call when CORE-7125 is finished.
+    yield Saga.put((dispatch: Dispatch) => dispatch(TeamsGen.createGetDetails({teamname})))
   }
 }
 
 const _editMembership = function*(action: TeamsGen.EditMembershipPayload) {
   const {teamname, username, role} = action.payload
-  yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, true]])))
+  yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   try {
     yield Saga.call(RPCTypes.teamsTeamEditMemberRpcPromise, {
       name: teamname,
@@ -162,7 +164,7 @@ const _editMembership = function*(action: TeamsGen.EditMembershipPayload) {
       role: role ? RPCTypes.teamsTeamRole[role] : RPCTypes.teamsTeamRole.none,
     })
   } finally {
-    yield Saga.put((dispatch: Dispatch) => dispatch(TeamsGen.createGetDetails({teamname}))) // getDetails will unset loading
+    yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   }
 }
 
@@ -183,11 +185,11 @@ const _removeMemberOrPendingInvite = function*(action: TeamsGen.RemoveMemberOrPe
     throw new Error(errMsg)
   }
 
-  yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, true]])))
+  yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   try {
     yield Saga.call(RPCTypes.teamsTeamRemoveMemberRpcPromise, {email, name: teamname, username, inviteID})
   } finally {
-    yield Saga.put((dispatch: Dispatch) => dispatch(TeamsGen.createGetDetails({teamname}))) // getDetails will unset loading
+    yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
     yield Saga.put(
       replaceEntity(
         ['teams', 'teamNameToLoadingInvites'],
@@ -227,7 +229,7 @@ const _inviteToTeamByPhone = function*(action: TeamsGen.InviteToTeamByPhonePaylo
 
 const _ignoreRequest = function*(action: TeamsGen.IgnoreRequestPayload) {
   const {teamname, username} = action.payload
-  yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, true]])))
+  yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   try {
     yield Saga.call(RPCTypes.teamsTeamIgnoreRequestRpcPromise, {
       name: teamname,
@@ -235,6 +237,8 @@ const _ignoreRequest = function*(action: TeamsGen.IgnoreRequestPayload) {
     })
   } finally {
     // TODO handle error, but for now make sure loading is unset
+    yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
+    // TODO get rid of this once core sends us a notification for this (CORE-7125)
     yield Saga.put((dispatch: Dispatch) => dispatch(TeamsGen.createGetDetails({teamname}))) // getDetails will unset loading
   }
 }
@@ -291,11 +295,8 @@ const _createNewTeamFromConversation = function*(
 
 const _getDetails = function*(action: TeamsGen.GetDetailsPayload): Saga.SagaGenerator<any, any> {
   const teamname = action.payload.teamname
-  const waitingKey = {key: `getDetails:${teamname}`}
-  // TODO completely replace teamNameToLoading with createIncrementWaiting?
-  yield Saga.put(createIncrementWaiting(waitingKey))
+  yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   yield Saga.put(TeamsGen.createGetTeamOperations({teamname}))
-  yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, true]])))
   try {
     const unsafeDetails: RPCTypes.TeamDetails = yield Saga.call(RPCTypes.teamsTeamGetRpcPromise, {
       forceRepoll: false,
@@ -408,8 +409,7 @@ const _getDetails = function*(action: TeamsGen.GetDetailsPayload): Saga.SagaGene
       Saga.put(replaceEntity(['teams', 'teamNameToSubteams'], I.Map([[teamname, I.Set(subteams)]]))),
     ])
   } finally {
-    yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, false]])))
-    yield Saga.put(createDecrementWaiting(waitingKey))
+    yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   }
 }
 
@@ -418,14 +418,14 @@ const _getTeamOperations = function*(
 ): Saga.SagaGenerator<any, any> {
   const teamname = action.payload.teamname
 
-  yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, true]])))
+  yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   try {
     const teamOperation = yield Saga.call(RPCTypes.teamsCanUserPerformRpcPromise, {
       name: teamname,
     })
     yield Saga.put(replaceEntity(['teams', 'teamNameToCanPerform'], I.Map({[teamname]: teamOperation})))
   } finally {
-    yield Saga.put(replaceEntity(['teams', 'teamNameToLoading'], I.Map([[teamname, false]])))
+    yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   }
 }
 
@@ -620,7 +620,7 @@ function* _createChannel(action: TeamsGen.CreateChannelPayload) {
 
 const _setPublicity = function(action: TeamsGen.SetPublicityPayload, state: TypedState) {
   const {teamname, settings} = action.payload
-  const waitingKey = {key: `setPublicity:${teamname}`}
+  const waitingKey = {key: Constants.settingsWaitingKey(teamname)}
   const teamSettings = state.entities.getIn(['teams', 'teamNameToTeamSettings', teamname], {
     open: false,
     joinAs: RPCTypes.teamsTeamRole['reader'],

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -692,6 +692,7 @@ const _setPublicity = function(action: TeamsGen.SetPublicityPayload, state: Type
     Saga.put(createIncrementWaiting(waitingKey)),
     Saga.identity(
       Saga.all([
+        // TODO delete this getDetails call when CORE-7125 is finished
         Saga.put(TeamsGen.createGetDetails({teamname})),
         Saga.put(createDecrementWaiting(waitingKey)),
       ])

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -116,7 +116,7 @@ const _inviteByEmail = function*(action: TeamsGen.InviteToTeamByEmailPayload) {
       throw new Error(`Unable to parse email addresses: ${res.malformed.join('; ')}`)
     }
   } finally {
-    // TODO handle error, but for now make sure loading is unset
+    // TODO handle error
     yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
     yield Saga.put(replaceEntity(['teams', 'teamNameToLoadingInvites', teamname], I.Map([[invitees, false]])))
   }
@@ -134,7 +134,7 @@ const _addToTeam = function*(action: TeamsGen.AddToTeamPayload) {
       sendChatNotification,
     })
   } finally {
-    // TODO handle error, but for now make sure loading is unset
+    // TODO handle error
     yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   }
 }

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -11,6 +11,11 @@ import {type TypedState} from './reducer'
 
 export const teamRoleTypes = ['reader', 'writer', 'admin', 'owner']
 
+// Waiting keys
+// Add granularity as necessary
+export const teamWaitingKey = (teamname: string) => `team:${teamname}`
+export const settingsWaitingKey = (teamname: string) => `teamSettings:${teamname}`
+
 export const makeChannelInfo: I.RecordFactory<Types._ChannelInfo> = I.Record({
   channelname: null,
   description: null,
@@ -56,7 +61,6 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   teamNameToInvites: I.Map(),
   teamNameToIsOpen: I.Map(),
   teamNameToLoadingInvites: I.Map(),
-  teamNameToLoading: I.Map(),
   teamNameToMemberUsernames: I.Map(),
   teamNameToMembers: I.Map(),
   teamNameToRequests: I.Map(),

--- a/shared/constants/types/teams.js
+++ b/shared/constants/types/teams.js
@@ -99,7 +99,6 @@ export type _State = {
   teamNameToLoadingInvites: I.Map<Teamname, I.Map<string, boolean>>,
   teamNameToMembers: I.Map<Teamname, I.Set<MemberInfo>>,
   teamNameToMemberUsernames: I.Map<Teamname, I.Set<string>>,
-  teamNameToLoading: I.Map<Teamname, boolean>,
   teamNameToRequests: I.Map<Teamname, I.Set<RequestInfo>>,
   teamNameToRole: I.Map<Teamname, TeamRoleType>,
   teamNameToSubteams: I.Map<Teamname, I.Set<Teamname>>,

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -61,7 +61,7 @@ const mapStateToProps = (state: TypedState, {routeProps, routeState}): StateProp
       ['teams', 'teamNameToPublicitySettings', teamname, 'ignoreAccessRequests'],
       false
     ),
-    loading: state.entities.getIn(['teams', 'teamNameToLoading', teamname], true),
+    loading: anyWaiting(state, Constants.teamWaitingKey(teamname)),
     memberCount: state.entities.getIn(['teams', 'teammembercounts', teamname], 0),
     name: teamname,
     openTeamRole:
@@ -80,7 +80,11 @@ const mapStateToProps = (state: TypedState, {routeProps, routeState}): StateProp
     sawSubteamsBanner: state.entities.getIn(['teams', 'sawSubteamsBanner'], false),
     selectedTab: routeState.get('selectedTab') || 'members',
     subteams,
-    waitingForSavePublicity: anyWaiting(state, `setPublicity:${teamname}`, `getDetails:${teamname}`),
+    waitingForSavePublicity: anyWaiting(
+      state,
+      Constants.settingsWaitingKey(teamname),
+      Constants.teamWaitingKey(teamname)
+    ),
     you: state.config.username,
     yourRole: Constants.getRole(state, teamname),
     yourOperations: Constants.getCanPerform(state, teamname),

--- a/shared/teams/team/member/container.js
+++ b/shared/teams/team/member/container.js
@@ -9,7 +9,8 @@ import {createShowUserProfile} from '../../../actions/profile-gen'
 import {createStartConversation} from '../../../actions/chat-gen'
 import {TeamMember} from '.'
 import {type TypedState} from '../../../constants/reducer'
-import {getCanPerform} from '../../../constants/teams'
+import {getCanPerform, teamWaitingKey} from '../../../constants/teams'
+import {anyWaiting} from '../../../constants/waiting'
 import * as RPCTypes from '../../../constants/types/rpc-gen'
 
 type StateProps = {
@@ -29,7 +30,7 @@ const mapStateToProps = (state: TypedState, {routeProps}): StateProps => {
 
   return {
     teamname: teamname,
-    loading: state.entities.getIn(['teams', 'teamNameToLoading', teamname], true),
+    loading: anyWaiting(state, teamWaitingKey(teamname)),
     following: amIFollowing(state, username),
     follower: amIBeingFollowed(state, username),
     yourOperations: getCanPerform(state, teamname),


### PR DESCRIPTION
Fixes the team loading indicator disappearing before the team is actually done loading. With teams we have many sagas that can put the team into a loading state, so the increment/decrement waiting structure works well to handle the overlaps.

r? @keybase/react-hackers 