### PR TITLE
Don't block conversation input with keyboard when in-call status bar is active

### DIFF
--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -3,6 +3,7 @@ import CardStackTransitioner from 'react-navigation/src/views/CardStack/CardStac
 import GlobalError from './global-errors/container'
 import Offline from '../offline'
 import React, {Component} from 'react'
+import {EmitterListener} from 'react-native'
 import TabBar from './tab-bar/container'
 import {
   Box,
@@ -16,7 +17,7 @@ import {chatTab, loginTab, peopleTab, folderTab, settingsTab, type Tab} from '..
 import {compose} from 'recompose'
 import {connect, type TypedState} from '../util/container'
 import {globalColors, globalStyles, statusBarHeight} from '../styles/index.native'
-import {statusBarSize} from '../styles/status-bar'
+import {addSizeListener} from '../styles/status-bar'
 import * as I from 'immutable'
 import {isIOS, isIPhoneX} from '../constants/platform'
 import {navigateTo, navigateUp, switchTo} from '../actions/route-tree'
@@ -158,8 +159,22 @@ const tabIsCached = {
 }
 
 class MainNavStack extends Component<any, any> {
+  _listener: EmitterListener
   state = {
     stackCache: I.Map(),
+    verticalOffset: 0,
+  }
+
+  componentWillMount() {
+    this._listener = addSizeListener(this.statusBarListener)
+  }
+
+  componentWillUnmount() {
+    this._listener && this._listener.remove()
+  }
+
+  statusBarListener = (frameData: any) => {
+    this.setState({verticalOffset: frameData.frame.height - 20})
   }
 
   componentWillReceiveProps() {
@@ -207,7 +222,7 @@ class MainNavStack extends Component<any, any> {
         <NativeKeyboardAvoidingView
           style={_keyboardStyle}
           behavior={isIOS ? 'padding' : undefined}
-          keyboardVerticalOffset={isIOS ? statusBarSize.currentOffset : undefined}
+          keyboardVerticalOffset={this.state.verticalOffset}
         >
           {content}
         </NativeKeyboardAvoidingView>

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -3,7 +3,7 @@ import CardStackTransitioner from 'react-navigation/src/views/CardStack/CardStac
 import GlobalError from './global-errors/container'
 import Offline from '../offline'
 import React, {Component} from 'react'
-import {EmitterListener} from 'react-native'
+import {type EmitterListener} from 'react-native'
 import TabBar from './tab-bar/container'
 import {
   Box,

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -16,6 +16,7 @@ import {chatTab, loginTab, peopleTab, folderTab, settingsTab, type Tab} from '..
 import {compose} from 'recompose'
 import {connect, type TypedState} from '../util/container'
 import {globalColors, globalStyles, statusBarHeight} from '../styles/index.native'
+import {statusBarSize} from '../styles/status-bar'
 import * as I from 'immutable'
 import {isIOS, isIPhoneX} from '../constants/platform'
 import {navigateTo, navigateUp, switchTo} from '../actions/route-tree'
@@ -203,7 +204,11 @@ class MainNavStack extends Component<any, any> {
     )
     return (
       <Box style={globalStyles.fullHeight}>
-        <NativeKeyboardAvoidingView style={_keyboardStyle} behavior={isIOS ? 'padding' : undefined}>
+        <NativeKeyboardAvoidingView
+          style={_keyboardStyle}
+          behavior={isIOS ? 'padding' : undefined}
+          keyboardVerticalOffset={isIOS ? statusBarSize.currentOffset : undefined}
+        >
           {content}
         </NativeKeyboardAvoidingView>
       </Box>

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -174,7 +174,7 @@ class MainNavStack extends Component<any, any> {
   }
 
   statusBarListener = (frameData: any) => {
-    this.setState({verticalOffset: frameData.frame.height - 20})
+    this.setState({verticalOffset: frameData.height - 20})
   }
 
   componentWillReceiveProps() {

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -174,7 +174,11 @@ class MainNavStack extends Component<any, any> {
   }
 
   statusBarListener = (frameData: any) => {
-    this.setState({verticalOffset: frameData.height - 20})
+    // the iPhone X has default status bar height of 45px
+    // and it doesn't increase in height like earlier devices.
+    // (so this should always be 0 on an iPhone X, but this should still
+    // be correct if it expands)
+    this.setState({verticalOffset: frameData.height - (isIPhoneX ? 45 : 20)})
   }
 
   componentWillReceiveProps() {
@@ -222,6 +226,11 @@ class MainNavStack extends Component<any, any> {
         <NativeKeyboardAvoidingView
           style={_keyboardStyle}
           behavior={isIOS ? 'padding' : undefined}
+          /** TODO get rid of this once a better fix exists
+           * keyboardVerticalOffset is to work around a bug in KeyboardAvoidingView
+           * when the in-call status bar is active. See https://github.com/facebook/react-native/issues/17862
+           * We need to account for the extra offset made by the larger in call status bar (on pre-iPhone X devices).
+           */
           keyboardVerticalOffset={this.state.verticalOffset}
         >
           {content}

--- a/shared/styles/status-bar.android.js
+++ b/shared/styles/status-bar.android.js
@@ -1,14 +1,7 @@
 // @flow
-import {StatusBar} from 'react-native'
 
-class StatusBarSize {
-  // $FlowIssue
-  get currentHeight() {
-    return StatusBar.currentHeight
-  }
-  currentOffset = 0
-}
+const addSizeListener = (cb: any) => ({
+  remove: () => {},
+})
 
-const statusBarSize = new StatusBarSize()
-
-export {statusBarSize}
+export {addSizeListener}

--- a/shared/styles/status-bar.android.js
+++ b/shared/styles/status-bar.android.js
@@ -1,0 +1,14 @@
+// @flow
+import {StatusBar} from 'react-native'
+
+class StatusBarSize {
+  // $FlowIssue
+  get currentHeight() {
+    return StatusBar.currentHeight
+  }
+  currentOffset = 0
+}
+
+const statusBarSize = new StatusBarSize()
+
+export {statusBarSize}

--- a/shared/styles/status-bar.ios.js
+++ b/shared/styles/status-bar.ios.js
@@ -1,0 +1,36 @@
+// @flow
+import {StatusBarIOS, NativeModules, EmitterSubscription} from 'react-native'
+
+const {StatusBarManager} = NativeModules
+
+class StatusBarSize {
+  currentHeight: number
+  currentOffset: number
+  listener: EmitterSubscription
+
+  constructor() {
+    StatusBarManager.getHeight(statusBarFrameData => (this.currentHeight = statusBarFrameData.height))
+    this.registerListener()
+  }
+
+  registerListener = () => {
+    if (this.listener) {
+      return
+    }
+    this.listener = StatusBarIOS.addListener('statusBarFrameWillChange', statusBarData => {
+      this.currentHeight = statusBarData.frame.height
+      this.currentOffset = this.currentHeight - 20
+    })
+  }
+
+  removeListener = () => {
+    if (this.listener) {
+      this.listener.remove()
+      this.listener = null
+    }
+  }
+}
+
+const statusBarSize = new StatusBarSize()
+
+export {statusBarSize}

--- a/shared/styles/status-bar.ios.js
+++ b/shared/styles/status-bar.ios.js
@@ -1,36 +1,6 @@
 // @flow
-import {StatusBarIOS, NativeModules, EmitterSubscription} from 'react-native'
+import {StatusBarIOS} from 'react-native'
 
-const {StatusBarManager} = NativeModules
+const addSizeListener = (cb: Function) => StatusBarIOS.addListener('statusBarFrameWillChange', cb)
 
-class StatusBarSize {
-  currentHeight: number
-  currentOffset: number
-  listener: EmitterSubscription
-
-  constructor() {
-    StatusBarManager.getHeight(statusBarFrameData => (this.currentHeight = statusBarFrameData.height))
-    this.registerListener()
-  }
-
-  registerListener = () => {
-    if (this.listener) {
-      return
-    }
-    this.listener = StatusBarIOS.addListener('statusBarFrameWillChange', statusBarData => {
-      this.currentHeight = statusBarData.frame.height
-      this.currentOffset = this.currentHeight - 20
-    })
-  }
-
-  removeListener = () => {
-    if (this.listener) {
-      this.listener.remove()
-      this.listener = null
-    }
-  }
-}
-
-const statusBarSize = new StatusBarSize()
-
-export {statusBarSize}
+export {addSizeListener}

--- a/shared/styles/status-bar.ios.js
+++ b/shared/styles/status-bar.ios.js
@@ -1,6 +1,11 @@
 // @flow
-import {StatusBarIOS} from 'react-native'
+import {StatusBarIOS, NativeModules} from 'react-native'
+const {StatusBarManager} = NativeModules
 
-const addSizeListener = (cb: Function) => StatusBarIOS.addListener('statusBarFrameWillChange', cb)
+const addSizeListener = (cb: Function) => {
+  // gcall with initial value
+  StatusBarManager.getHeight(cb)
+  return StatusBarIOS.addListener('statusBarFrameWillChange', statusBarData => cb(statusBarData.frame))
+}
 
 export {addSizeListener}

--- a/shared/styles/status-bar.ios.js
+++ b/shared/styles/status-bar.ios.js
@@ -3,7 +3,7 @@ import {StatusBarIOS, NativeModules} from 'react-native'
 const {StatusBarManager} = NativeModules
 
 const addSizeListener = (cb: Function) => {
-  // gcall with initial value
+  // call with initial value
   StatusBarManager.getHeight(cb)
   return StatusBarIOS.addListener('statusBarFrameWillChange', statusBarData => cb(statusBarData.frame))
 }

--- a/shared/styles/status-bar.js.flow
+++ b/shared/styles/status-bar.js.flow
@@ -1,0 +1,31 @@
+// @flow
+
+declare class StatusBarSize {
+  currentHeight: number;
+
+  /**
+   * (iOS only)
+   * Register the status bar height listener
+   */
+  registerListener: () => void;
+
+  /**
+   * (iOS only)
+   * Remove the status bar height listener
+   */
+  removeListener: () => void;
+
+  /**
+   * Get current status bar height
+   * (set by listener on iOS, set via NativeStatusBar on Android)
+   */
+  currentHeight: () => number;
+
+  /**
+   * Returns currentStatusBarHeight - normalStatusBarHeight
+   * (always 0 on android)
+   */
+  currentOffset: number;
+}
+
+declare export var statusBarSize: StatusBarSize

--- a/shared/styles/status-bar.js.flow
+++ b/shared/styles/status-bar.js.flow
@@ -1,31 +1,4 @@
 // @flow
+import {EmitterSubscription} from 'react-native'
 
-declare class StatusBarSize {
-  currentHeight: number;
-
-  /**
-   * (iOS only)
-   * Register the status bar height listener
-   */
-  registerListener: () => void;
-
-  /**
-   * (iOS only)
-   * Remove the status bar height listener
-   */
-  removeListener: () => void;
-
-  /**
-   * Get current status bar height
-   * (set by listener on iOS, set via NativeStatusBar on Android)
-   */
-  currentHeight: () => number;
-
-  /**
-   * Returns currentStatusBarHeight - normalStatusBarHeight
-   * (always 0 on android)
-   */
-  currentOffset: number;
-}
-
-declare export var statusBarSize: StatusBarSize
+declare export var addSizeListener: (cb: Function) => EmitterSubscription


### PR DESCRIPTION
See https://github.com/facebook/react-native/issues/17862

Before (sometimes):
<img width="484" alt="image" src="https://user-images.githubusercontent.com/11968340/35818602-83085c9c-0a6e-11e8-9076-34a3fd3fa4df.png">

After:
<img width="484" alt="image" src="https://user-images.githubusercontent.com/11968340/35818620-9112c3d6-0a6e-11e8-9fea-c09540605e04.png">

r? @keybase/react-hackers cc @chrisnojima 
