### PR TITLE
Fix "Expected [K, V] Tuple..." exception when trying to revoke a device with TLF warnings

### DIFF
--- a/shared/reducers/devices.js
+++ b/shared/reducers/devices.js
@@ -13,7 +13,7 @@ export default function(state: Types.State = initialState, action: DevicesGen.Ac
     case DevicesGen.devicesLoaded:
       return action.error ? state : state.set('idToDetail', I.Map(action.payload.idToDetail))
     case DevicesGen.endangeredTLFsLoaded:
-      return state.mergeIn(['idToEndangeredTLFs', action.payload.deviceID], I.Set(action.payload.tlfs))
+      return state.setIn(['idToEndangeredTLFs', action.payload.deviceID], I.Set(action.payload.tlfs))
     // Saga only actions
     case DevicesGen.deviceRevoke:
     case DevicesGen.deviceRevoked:


### PR DESCRIPTION
It was thrown in the reducer by Immutable `Record#mergeIn`, because the keypath doesn't exist before the call happens. I changed it to a `setIn` because we probably don't want to keep old entries there on subsequent calls (cc @chrisnojima)

r? @keybase/react-hackers cc @jzila 