### PR TITLE
Make LoadUser return DeletedError, because the server does not anymore

### DIFF
--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -317,6 +317,10 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 		return nil, err
 	}
 
+	if ret.status == keybase1.StatusCode_SCDeleted {
+		return nil, DeletedError{}
+	}
+
 	ret.sigHints = sigHints
 
 	// Match the returned User object to the Merkle tree. Also make sure


### PR DESCRIPTION
Client always calls resolver with `load_deleted=1` but a lot of code everywhere expected it to fail with `DeletedError`