### PR TITLE
KeyFinder caches all requests, refactor a bunch of NameInfo stuff, and fix imp team identify story CORE-7121

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -232,9 +232,9 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv
 		// transient error. Rekey errors come through here
 		return chat1.MessageUnboxed{}, NewTransientUnboxingError(err)
 	}
-
 	var encryptionKey types.CryptKey
-	for _, key := range nameInfo.CryptKeys[keyMembersType] {
+	keys := nameInfo.CryptKeys[keyMembersType]
+	for _, key := range keys {
 		if key.Generation() == boxed.KeyGeneration {
 			encryptionKey = key
 			break
@@ -242,7 +242,7 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv
 	}
 
 	if encryptionKey == nil {
-		err := fmt.Errorf("no key found for generation %d (%d keys checked)", boxed.KeyGeneration, len(nameInfo.CryptKeys))
+		err := fmt.Errorf("no key found for generation %d (%d keys checked)", boxed.KeyGeneration, len(keys))
 		return chat1.MessageUnboxed{}, NewTransientUnboxingError(err)
 	}
 

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -1419,6 +1419,8 @@ func NewKeyFinderMock(cryptKeys []keybase1.CryptKey) KeyFinder {
 	return &KeyFinderMock{cryptKeys}
 }
 
+func (k *KeyFinderMock) Reset() {}
+
 func (k *KeyFinderMock) Find(ctx context.Context, tlfName string,
 	membersType chat1.ConversationMembersType, tlfPublic bool) (res *types.NameInfo, err error) {
 	res = types.NewNameInfo()

--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -56,14 +57,18 @@ func CtxKeyFinder(ctx context.Context, g *globals.Context) KeyFinder {
 	return NewKeyFinder(g)
 }
 
-func CtxIdentifyNotifier(ctx context.Context) *IdentifyNotifier {
-	var in *IdentifyNotifier
+func CtxIdentifyNotifier(ctx context.Context) types.IdentifyNotifier {
+	var in types.IdentifyNotifier
 	var ok bool
 	val := ctx.Value(inKey)
-	if in, ok = val.(*IdentifyNotifier); ok {
+	if in, ok = val.(types.IdentifyNotifier); ok {
 		return in
 	}
 	return nil
+}
+
+func CtxModifyIdentifyNotifier(ctx context.Context, notifier types.IdentifyNotifier) context.Context {
+	return context.WithValue(ctx, inKey, notifier)
 }
 
 func CtxTrace(ctx context.Context) (string, bool) {
@@ -96,7 +101,7 @@ func CtxAddLogTags(ctx context.Context, env appTypeSource) context.Context {
 }
 
 func Context(ctx context.Context, g *globals.Context, mode keybase1.TLFIdentifyBehavior,
-	breaks *[]keybase1.TLFIdentifyFailure, notifier *IdentifyNotifier) context.Context {
+	breaks *[]keybase1.TLFIdentifyFailure, notifier types.IdentifyNotifier) context.Context {
 	if breaks == nil {
 		breaks = new([]keybase1.TLFIdentifyFailure)
 	}
@@ -106,7 +111,7 @@ func Context(ctx context.Context, g *globals.Context, mode keybase1.TLFIdentifyB
 		res = context.WithValue(res, kfKey, NewKeyFinder(g))
 	}
 	val = res.Value(inKey)
-	if _, ok := val.(*IdentifyNotifier); !ok {
+	if _, ok := val.(types.IdentifyNotifier); !ok {
 		res = context.WithValue(res, inKey, notifier)
 	}
 	res = CtxAddLogTags(res, g.GetEnv())

--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -105,7 +105,10 @@ func Context(ctx context.Context, g *globals.Context, mode keybase1.TLFIdentifyB
 	if _, ok := val.(KeyFinder); !ok {
 		res = context.WithValue(res, kfKey, NewKeyFinder(g))
 	}
-	res = context.WithValue(res, inKey, notifier)
+	val = res.Value(inKey)
+	if _, ok := val.(*IdentifyNotifier); !ok {
+		res = context.WithValue(res, inKey, notifier)
+	}
 	res = CtxAddLogTags(res, g.GetEnv())
 	return res
 }

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -35,7 +35,7 @@ type BackgroundConvLoader struct {
 	started       bool
 	queue         chan clTask
 	stop          chan bool
-	identNotifier *IdentifyNotifier
+	identNotifier types.IdentifyNotifier
 
 	// for testing, make this and can check conv load successes
 	loads                 chan chat1.ConversationID
@@ -49,7 +49,7 @@ func NewBackgroundConvLoader(g *globals.Context) *BackgroundConvLoader {
 		Contextified:  globals.NewContextified(g),
 		DebugLabeler:  utils.NewDebugLabeler(g.GetLog(), "BackgroundConvLoader", false),
 		stop:          make(chan bool),
-		identNotifier: NewIdentifyNotifier(g),
+		identNotifier: NewCachingIdentifyNotifier(g),
 	}
 	b.identNotifier.ResetOnGUIConnect()
 

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -412,8 +412,7 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv types.U
 
 			s.Debug(ctx, "identifyTLF: identifying from msg ID: %d names: %v convID: %s",
 				msg.GetMessageID(), names, conv.GetConvID())
-			_, err := NewNameIdentifier(s.G()).Identify(ctx, names, !msg.Valid().ClientHeader.TlfPublic,
-				idMode)
+			_, err := NewNameIdentifier(s.G()).Identify(ctx, names, !msg.Valid().ClientHeader.TlfPublic)
 			if err != nil {
 				s.Debug(ctx, "identifyTLF: failure: name: %s convID: %s err: %s", tlfName, conv.GetConvID(),
 					err)

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
-	"github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
 )
 
@@ -372,20 +371,15 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv types.U
 		return nil
 	}
 
-	idMode, _, haveMode := IdentifyMode(ctx)
 	for _, msg := range msgs {
 		if msg.IsValid() {
 
-			// Early out if we are in GUI mode and don't have any breaks stored
+			// Early out if we have stored a clean identify at some point
 			idBroken := s.storage.IsTLFIdentifyBroken(ctx, msg.Valid().ClientHeader.Conv.Tlfid)
-			if haveMode && idMode == keybase1.TLFIdentifyBehavior_CHAT_GUI && !idBroken {
+			if !idBroken {
 				s.Debug(ctx, "identifyTLF: not performing identify because we stored a clean identify")
 				return nil
 			}
-			if !haveMode {
-				idMode = keybase1.TLFIdentifyBehavior_CHAT_GUI
-			}
-
 			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(conv.GetFinalizeInfo())
 
 			var names []string

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -640,7 +640,7 @@ func TestConversationLocking(t *testing.T) {
 	t.Logf("Trace 1 can get multiple locks")
 	var breaks []keybase1.TLFIdentifyFailure
 	ctx = Context(context.TODO(), tc.Context(), keybase1.TLFIdentifyBehavior_CHAT_CLI, &breaks,
-		NewIdentifyNotifier(tc.Context()))
+		NewCachingIdentifyNotifier(tc.Context()))
 	acquires := 5
 	for i := 0; i < acquires; i++ {
 		timedAcquire(ctx, uid, conv.GetConvID())
@@ -652,7 +652,7 @@ func TestConversationLocking(t *testing.T) {
 
 	t.Logf("Trace 2 properly blocked by Trace 1")
 	ctx2 := Context(context.TODO(), tc.Context(), keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		&breaks, NewIdentifyNotifier(tc.Context()))
+		&breaks, NewCachingIdentifyNotifier(tc.Context()))
 	blockCb := make(chan struct{})
 	hcs.lockTab.blockCb = &blockCb
 	cb := make(chan struct{})

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -355,9 +355,20 @@ func (f failingTlf) CompleteAndCanonicalizePrivateTlfName(context.Context, strin
 	return keybase1.CanonicalTLFNameAndIDWithBreaks{}, nil
 }
 
-func (f failingTlf) Lookup(context.Context, string, keybase1.TLFVisibility) (*types.NameInfo, error) {
+func (f failingTlf) Lookup(context.Context, string, bool) (*types.NameInfo, error) {
 	require.Fail(f.t, "Lookup call")
 	return nil, nil
+}
+
+func (f failingTlf) EncryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (*types.NameInfo, error) {
+	return f.Lookup(ctx, tlfName, public)
+}
+
+func (f failingTlf) DecryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool,
+	keyGeneration int, kbfsEncrypted bool) (*types.NameInfo, error) {
+	return f.Lookup(ctx, tlfName, public)
 }
 
 type failingUpak struct {

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -550,17 +550,17 @@ L:
 			case chat1.ConversationMembersType_IMPTEAMUPGRADE:
 				if !attempts[chat1.ConversationMembersType_IMPTEAMNATIVE] {
 					newMT = chat1.ConversationMembersType_IMPTEAMNATIVE
+					err = ierr
 				} else {
 					newMT = chat1.ConversationMembersType_KBFS
 				}
-				err = ierr
 			case chat1.ConversationMembersType_IMPTEAMNATIVE:
 				if !attempts[chat1.ConversationMembersType_IMPTEAMUPGRADE] {
 					newMT = chat1.ConversationMembersType_IMPTEAMUPGRADE
+					err = ierr
 				} else {
 					newMT = chat1.ConversationMembersType_KBFS
 				}
-				err = ierr
 			case chat1.ConversationMembersType_KBFS:
 				debugger.Debug(ctx, "FindConversations: failed with KBFS, aborting")
 				// We don't want to return random errors from KBFS if we are falling back to it,

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -550,6 +550,7 @@ L:
 			case chat1.ConversationMembersType_IMPTEAMUPGRADE:
 				if !attempts[chat1.ConversationMembersType_IMPTEAMNATIVE] {
 					newMT = chat1.ConversationMembersType_IMPTEAMNATIVE
+					// Only set the error if the members type is the same as what was passed in
 					err = ierr
 				} else {
 					newMT = chat1.ConversationMembersType_KBFS
@@ -557,6 +558,7 @@ L:
 			case chat1.ConversationMembersType_IMPTEAMNATIVE:
 				if !attempts[chat1.ConversationMembersType_IMPTEAMUPGRADE] {
 					newMT = chat1.ConversationMembersType_IMPTEAMUPGRADE
+					// Only set the error if the members type is the same as what was passed in
 					err = ierr
 				} else {
 					newMT = chat1.ConversationMembersType_KBFS

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -189,7 +189,7 @@ func (s *sendHelper) SendText(ctx context.Context, text string) error {
 }
 
 func (s *sendHelper) SendBody(ctx context.Context, body chat1.MessageBody, mtype chat1.MessageType) error {
-	ctx = Context(ctx, s.G(), s.ident, nil, NewIdentifyNotifier(s.G()))
+	ctx = Context(ctx, s.G(), s.ident, nil, NewCachingIdentifyNotifier(s.G()))
 	if err := s.nameInfo(ctx); err != nil {
 		return err
 	}
@@ -353,7 +353,7 @@ func (r *recentConversationParticipants) get(ctx context.Context, myUID gregor1.
 }
 
 func RecentConversationParticipants(ctx context.Context, g *globals.Context, myUID gregor1.UID) ([]gregor1.UID, error) {
-	ctx = Context(ctx, g, keybase1.TLFIdentifyBehavior_CHAT_GUI, nil, NewIdentifyNotifier(g))
+	ctx = Context(ctx, g, keybase1.TLFIdentifyBehavior_CHAT_GUI, nil, NewCachingIdentifyNotifier(g))
 	return newRecentConversationParticipants(g).get(ctx, myUID)
 }
 

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -289,6 +289,7 @@ func (t *NameIdentifier) Identify(ctx context.Context, names []string, private b
 	}
 
 	if idNotifier != nil {
+		t.Debug(ctx, "sending update through ident notifier: %d breaks", len(res))
 		idNotifier.Send(keybase1.CanonicalTLFNameAndIDWithBreaks{
 			Breaks: keybase1.TLFBreak{
 				Breaks: res,

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -321,6 +321,7 @@ func (t *NameIdentifier) Identify(ctx context.Context, names []string, private b
 		return nil, err
 	}
 
+	// Run the updates through the identify notifier
 	if idNotifier != nil {
 		t.Debug(ctx, "sending update through ident notifier: %d breaks", len(res))
 		idNotifier.Send(ctx, keybase1.CanonicalTLFNameAndIDWithBreaks{

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -20,6 +20,7 @@ type KeyFinder interface {
 	FindForDecryption(ctx context.Context, tlfName string, teamID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool, keyGeneration int,
 		kbfsEncrypted bool) (*types.NameInfo, error)
+	Reset()
 	SetNameInfoSourceOverride(types.NameInfoSource)
 }
 
@@ -41,6 +42,10 @@ func NewKeyFinder(g *globals.Context) KeyFinder {
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "KeyFinder", false),
 		keys:         make(map[string]*types.NameInfo),
 	}
+}
+
+func (k *KeyFinderImpl) Reset() {
+	k.keys = make(map[string]*types.NameInfo)
 }
 
 func (k *KeyFinderImpl) cacheKey(name string, membersType chat1.ConversationMembersType, public bool) string {

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -102,7 +102,7 @@ func (k *KeyFinderImpl) Find(ctx context.Context, name string,
 		return existing, nil
 	}
 	defer func() {
-		if err != nil {
+		if err == nil {
 			k.writeKey(ckey, res)
 		}
 	}()
@@ -128,7 +128,7 @@ func (k *KeyFinderImpl) FindForEncryption(ctx context.Context, tlfName string, t
 		return existing, nil
 	}
 	defer func() {
-		if err != nil {
+		if err == nil {
 			k.writeKey(ckey, res)
 		}
 	}()
@@ -155,7 +155,7 @@ func (k *KeyFinderImpl) FindForDecryption(ctx context.Context,
 		return existing, nil
 	}
 	defer func() {
-		if err != nil {
+		if err == nil {
 			k.writeKey(ckey, res)
 		}
 	}()

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -173,7 +173,7 @@ type PushHandler struct {
 	sync.Mutex
 
 	badger        *badges.Badger
-	identNotifier *IdentifyNotifier
+	identNotifier types.IdentifyNotifier
 	orderer       *gregorMessageOrderer
 	typingMonitor *TypingMonitor
 }
@@ -182,7 +182,7 @@ func NewPushHandler(g *globals.Context) *PushHandler {
 	p := &PushHandler{
 		Contextified:  globals.NewContextified(g),
 		DebugLabeler:  utils.NewDebugLabeler(g.GetLog(), "PushHandler", false),
-		identNotifier: NewIdentifyNotifier(g),
+		identNotifier: NewCachingIdentifyNotifier(g),
 		orderer:       newGregorMessageOrderer(g),
 		typingMonitor: NewTypingMonitor(g),
 	}

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -674,7 +674,7 @@ type Deliverer struct {
 
 	sender        types.Sender
 	outbox        *storage.Outbox
-	identNotifier *IdentifyNotifier
+	identNotifier types.IdentifyNotifier
 	shutdownCh    chan chan struct{}
 	msgSentCh     chan struct{}
 	reconnectCh   chan struct{}
@@ -697,7 +697,7 @@ func NewDeliverer(g *globals.Context, sender types.Sender) *Deliverer {
 		msgSentCh:     make(chan struct{}, 100),
 		reconnectCh:   make(chan struct{}, 100),
 		sender:        sender,
-		identNotifier: NewIdentifyNotifier(g),
+		identNotifier: NewCachingIdentifyNotifier(g),
 		clock:         clockwork.NewRealClock(),
 	}
 

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -52,7 +52,7 @@ type Server struct {
 	uiSource      UISource
 	boxer         *Boxer
 	store         *AttachmentStore
-	identNotifier *IdentifyNotifier
+	identNotifier types.IdentifyNotifier
 
 	// Only for testing
 	rc                chat1.RemoteInterface
@@ -71,7 +71,7 @@ func NewServer(g *globals.Context, store *AttachmentStore, serverConn ServerConn
 		uiSource:      uiSource,
 		store:         store,
 		boxer:         NewBoxer(g),
-		identNotifier: NewIdentifyNotifier(g),
+		identNotifier: NewCachingIdentifyNotifier(g),
 	}
 }
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2969,7 +2969,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			select {
 			case update = <-listener.identifyUpdate:
 				t.Logf("identify update: %+v", update)
-			case <-time.After(2 * time.Second):
+			case <-time.After(20 * time.Second):
 				require.Fail(t, "no identify")
 			}
 			require.Empty(t, update.Breaks.Breaks)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2955,11 +2955,34 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 
 		users := ctc.users()
 		displayName := users[0].Username + "," + users[1].Username
-
-		listener := newServerChatListener()
-		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
-
 		tc := ctc.world.Tcs[users[0].Username]
+
+		listener0 := newServerChatListener()
+		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
+		listener1 := newServerChatListener()
+		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener1)
+
+		consumeIdentify := func(ctx context.Context, listener *serverChatListener, ref string,
+			tlfID chat1.TLFID) {
+			// check identify updates
+			var update keybase1.CanonicalTLFNameAndIDWithBreaks
+			select {
+			case update = <-listener.identifyUpdate:
+				t.Logf("identify update: %+v", update)
+			case <-time.After(2 * time.Second):
+				require.Fail(t, "no identify")
+			}
+			if ref != "" {
+				require.EqualValues(t, update.CanonicalName, ref)
+			}
+			if !tlfID.IsNil() {
+				require.Equal(t, tlfID, chat1.TLFID(update.TlfID.ToBytes()))
+			}
+			require.Empty(t, update.Breaks.Breaks)
+			CtxIdentifyNotifier(ctx).Reset()
+			CtxKeyFinder(ctx, tc.Context()).Reset()
+		}
+
 		ctx := ctc.as(t, users[0]).startCtx
 		res, err := ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(ctx,
 			chat1.FindConversationsLocalArg{
@@ -2971,6 +2994,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Conversations), "conv found")
+		consumeIdentify(ctx, listener0, "", nil)
 
 		// create a new conversation
 		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
@@ -2982,8 +3006,8 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 			})
 		require.NoError(t, err)
+		consumeIdentify(ctx, listener0, ncres.Conv.Info.TlfName, ncres.Conv.Info.Triple.Tlfid)
 
-		ctx = ctc.as(t, users[0]).startCtx
 		uid := users[0].User.GetUID().ToBytes()
 		conv, _, err := GetUnverifiedConv(ctx, tc.Context(), uid, ncres.Conv.Info.Id, false)
 		require.NoError(t, err)
@@ -3008,17 +3032,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-
-		// check identify updates
-		var update keybase1.CanonicalTLFNameAndIDWithBreaks
-		select {
-		case update = <-listener.identifyUpdate:
-			t.Logf("identify update: %+v", update)
-		case <-time.After(20 * time.Second):
-			t.Fatal("timed out waiting for identify update")
-		}
-		require.EqualValues(t, update.CanonicalName, ncres.Conv.Info.TlfName)
-		require.Empty(t, update.Breaks.Breaks)
+		consumeIdentify(ctx, listener0, ncres.Conv.Info.TlfName, ncres.Conv.Info.Triple.Tlfid)
 
 		// user 1 sends a message to conv
 		ctx = ctc.as(t, users[1]).startCtx
@@ -3036,6 +3050,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
+		consumeIdentify(ctx, listener1, ncres.Conv.Info.TlfName, ncres.Conv.Info.Triple.Tlfid)
 
 		// user 1 finds the conversation
 		tc = ctc.world.Tcs[users[1].Username]
@@ -3050,6 +3065,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(res.Conversations), "no convs found")
+		consumeIdentify(ctx, listener1, ncres.Conv.Info.TlfName, ncres.Conv.Info.Triple.Tlfid)
 	})
 }
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2989,6 +2989,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Conversations), "conv found")
 		consumeIdentify(ctx, listener0)
+		consumeIdentify(ctx, listener0)
 
 		// create a new conversation
 		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
@@ -3026,7 +3027,9 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		consumeIdentify(ctx, listener0)
+		consumeIdentify(ctx, listener0) // Pull
+		consumeIdentify(ctx, listener0) // EncryptionKeys
+		consumeIdentify(ctx, listener0) // DecryptionKeys
 
 		// user 1 sends a message to conv
 		ctx = ctc.as(t, users[1]).startCtx
@@ -3065,8 +3068,6 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 		select {
 		case <-listener0.identifyUpdate:
 			require.Fail(t, "leftover identifies 0")
-		case <-listener1.identifyUpdate:
-			require.Fail(t, "leftover identifies 1")
 		default:
 		}
 	})

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2977,6 +2977,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 		}
 
 		ctx := ctc.as(t, users[0]).startCtx
+		CtxIdentifyNotifier(ctx).DisableCaching()
 		res, err := ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(ctx,
 			chat1.FindConversationsLocalArg{
 				TlfName:          displayName,
@@ -3059,6 +3060,15 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(res.Conversations), "no convs found")
 		consumeIdentify(ctx, listener1)
+
+		// Check to see if we accounted for all identifies
+		select {
+		case <-listener0.identifyUpdate:
+			require.Fail(t, "leftover identifies 0")
+		case <-listener1.identifyUpdate:
+			require.Fail(t, "leftover identifies 1")
+		default:
+		}
 	})
 }
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2962,8 +2962,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 		listener1 := newServerChatListener()
 		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener1)
 
-		consumeIdentify := func(ctx context.Context, listener *serverChatListener, ref string,
-			tlfID chat1.TLFID) {
+		consumeIdentify := func(ctx context.Context, listener *serverChatListener) {
 			// check identify updates
 			var update keybase1.CanonicalTLFNameAndIDWithBreaks
 			select {
@@ -2971,12 +2970,6 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 				t.Logf("identify update: %+v", update)
 			case <-time.After(2 * time.Second):
 				require.Fail(t, "no identify")
-			}
-			if ref != "" {
-				require.EqualValues(t, update.CanonicalName, ref)
-			}
-			if !tlfID.IsNil() {
-				require.Equal(t, tlfID, chat1.TLFID(update.TlfID.ToBytes()))
 			}
 			require.Empty(t, update.Breaks.Breaks)
 			CtxIdentifyNotifier(ctx).Reset()
@@ -2994,7 +2987,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Conversations), "conv found")
-		consumeIdentify(ctx, listener0, "", nil)
+		consumeIdentify(ctx, listener0)
 
 		// create a new conversation
 		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
@@ -3006,7 +2999,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 			})
 		require.NoError(t, err)
-		consumeIdentify(ctx, listener0, ncres.Conv.Info.TlfName, ncres.Conv.Info.Triple.Tlfid)
+		consumeIdentify(ctx, listener0)
 
 		uid := users[0].User.GetUID().ToBytes()
 		conv, _, err := GetUnverifiedConv(ctx, tc.Context(), uid, ncres.Conv.Info.Id, false)
@@ -3032,7 +3025,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		consumeIdentify(ctx, listener0, ncres.Conv.Info.TlfName, ncres.Conv.Info.Triple.Tlfid)
+		consumeIdentify(ctx, listener0)
 
 		// user 1 sends a message to conv
 		ctx = ctc.as(t, users[1]).startCtx
@@ -3050,7 +3043,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		consumeIdentify(ctx, listener1, ncres.Conv.Info.TlfName, ncres.Conv.Info.Triple.Tlfid)
+		consumeIdentify(ctx, listener1)
 
 		// user 1 finds the conversation
 		tc = ctc.world.Tcs[users[1].Username]
@@ -3065,7 +3058,7 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(res.Conversations), "no convs found")
-		consumeIdentify(ctx, listener1, ncres.Conv.Info.TlfName, ncres.Conv.Info.Triple.Tlfid)
+		consumeIdentify(ctx, listener1)
 	})
 }
 

--- a/go/chat/storage/storage_breaks.go
+++ b/go/chat/storage/storage_breaks.go
@@ -31,8 +31,8 @@ func (b *breakTracker) makeDbKey(tlfID chat1.TLFID) libkb.DbKey {
 }
 
 func (b *breakTracker) UpdateTLF(ctx context.Context, tlfID chat1.TLFID,
-	breaks []keybase1.TLFIdentifyFailure) error {
-
+	breaks []keybase1.TLFIdentifyFailure) (err error) {
+	defer b.Trace(ctx, func() error { return err }, "UpdateTLF(%s)", tlfID)()
 	key := b.makeDbKey(tlfID)
 
 	dat, err := encode(breaks)
@@ -46,8 +46,8 @@ func (b *breakTracker) UpdateTLF(ctx context.Context, tlfID chat1.TLFID,
 	return nil
 }
 
-func (b *breakTracker) IsTLFBroken(ctx context.Context, tlfID chat1.TLFID) (bool, error) {
-
+func (b *breakTracker) IsTLFBroken(ctx context.Context, tlfID chat1.TLFID) (res bool, err error) {
+	defer b.Trace(ctx, func() error { return err }, "IsTLFBroken(%s)", tlfID)()
 	key := b.makeDbKey(tlfID)
 	raw, found, err := b.G().LocalChatDb.GetRaw(key)
 	if err != nil {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -171,7 +171,13 @@ func (t *ImplicitTeamsNameInfoSource) identify(ctx context.Context, tlfID chat1.
 	if !ok {
 		return res, errors.New("invalid context with no chat metadata")
 	}
-	res, err = t.Identify(ctx, names, true)
+	res, err = t.Identify(ctx, names, true,
+		func() keybase1.TLFID {
+			return keybase1.TLFID(tlfID.String())
+		},
+		func() keybase1.CanonicalTlfName {
+			return keybase1.CanonicalTlfName(impTeamName.String())
+		})
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -28,6 +28,7 @@ func addNameInfoCryptKey(keys types.AllCryptKeys, key types.CryptKey, implicit b
 }
 
 func getTeamKeys(ctx context.Context, team *teams.Team, public bool) (res types.AllCryptKeys, err error) {
+	res = types.NewAllCryptKeys()
 	if !public {
 		chatKeys, err := team.AllApplicationKeys(ctx, keybase1.TeamApplication_CHAT)
 		if err != nil {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -15,39 +15,69 @@ import (
 	context "golang.org/x/net/context"
 )
 
-func addNameInfoCryptKey(ni *types.NameInfo, key types.CryptKey, implicit bool) {
+func addNameInfoCryptKey(keys types.AllCryptKeys, key types.CryptKey, implicit bool) {
 	if implicit {
-		ni.CryptKeys[chat1.ConversationMembersType_IMPTEAMNATIVE] =
-			append(ni.CryptKeys[chat1.ConversationMembersType_IMPTEAMNATIVE], key)
-		ni.CryptKeys[chat1.ConversationMembersType_IMPTEAMUPGRADE] =
-			append(ni.CryptKeys[chat1.ConversationMembersType_IMPTEAMUPGRADE], key)
+		keys[chat1.ConversationMembersType_IMPTEAMNATIVE] =
+			append(keys[chat1.ConversationMembersType_IMPTEAMNATIVE], key)
+		keys[chat1.ConversationMembersType_IMPTEAMUPGRADE] =
+			append(keys[chat1.ConversationMembersType_IMPTEAMUPGRADE], key)
 	} else {
-		ni.CryptKeys[chat1.ConversationMembersType_TEAM] =
-			append(ni.CryptKeys[chat1.ConversationMembersType_TEAM], key)
+		keys[chat1.ConversationMembersType_TEAM] =
+			append(keys[chat1.ConversationMembersType_TEAM], key)
 	}
 }
 
-func addNameInfoTeamKeys(ctx context.Context, ni *types.NameInfo, team *teams.Team,
-	vis keybase1.TLFVisibility) error {
-	if vis == keybase1.TLFVisibility_PRIVATE {
+func getTeamKeys(ctx context.Context, team *teams.Team, public bool) (res types.AllCryptKeys, err error) {
+	if !public {
 		chatKeys, err := team.AllApplicationKeys(ctx, keybase1.TeamApplication_CHAT)
 		if err != nil {
-			return err
+			return res, err
 		}
 		for _, key := range chatKeys {
-			addNameInfoCryptKey(ni, key, team.IsImplicit())
+			addNameInfoCryptKey(res, key, team.IsImplicit())
 		}
 
 		kbfsKeys := team.KBFSCryptKeys(ctx, keybase1.TeamApplication_CHAT)
 		for _, key := range kbfsKeys {
-			ni.CryptKeys[chat1.ConversationMembersType_KBFS] =
-				append(ni.CryptKeys[chat1.ConversationMembersType_KBFS], key)
+			res[chat1.ConversationMembersType_KBFS] =
+				append(res[chat1.ConversationMembersType_KBFS], key)
 		}
 	} else {
-		addNameInfoCryptKey(ni, publicCryptKey, team.IsImplicit())
-		ni.CryptKeys[chat1.ConversationMembersType_KBFS] = []types.CryptKey{publicCryptKey}
+		addNameInfoCryptKey(res, publicCryptKey, team.IsImplicit())
+		res[chat1.ConversationMembersType_KBFS] = []types.CryptKey{publicCryptKey}
 	}
-	return nil
+	return res, nil
+}
+
+func loadTeamForDecryption(ctx context.Context, g *libkb.GlobalContext, name string, teamID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool,
+	keyGeneration int, kbfsEncrypted bool) (*teams.Team, error) {
+
+	var refreshers keybase1.TeamRefreshers
+	if !public {
+		// Only need keys for private teams.
+		if !kbfsEncrypted {
+			refreshers.NeedKeyGeneration = keybase1.PerTeamKeyGeneration(keyGeneration)
+		} else {
+			refreshers.NeedKBFSKeyGeneration = keybase1.TeamKBFSKeyRefresher{
+				Generation: keyGeneration,
+				AppType:    keybase1.TeamApplication_CHAT,
+			}
+		}
+	}
+	team, err := LoadTeam(ctx, g, teamID, membersType, public,
+		func(teamID keybase1.TeamID) keybase1.LoadTeamArg {
+			return keybase1.LoadTeamArg{
+				ID:         teamID,
+				Public:     public,
+				Refreshers: refreshers,
+				StaleOK:    true,
+			}
+		})
+	if err != nil {
+		return nil, err
+	}
+	return team, nil
 }
 
 type TeamsNameInfoSource struct {
@@ -62,39 +92,54 @@ func NewTeamsNameInfoSource(g *globals.Context) *TeamsNameInfoSource {
 	}
 }
 
-func (t *TeamsNameInfoSource) Lookup(ctx context.Context, name string, vis keybase1.TLFVisibility) (res *types.NameInfo, err error) {
-	defer t.Trace(ctx, func() error { return err }, fmt.Sprintf("Lookup(%s)", name))()
-
-	team, err := teams.Load(ctx, t.G().ExternalG(), keybase1.LoadTeamArg{
-		Name:        name, // Loading by name is a last resort and will always cause an extra roundtrip.
-		Public:      vis == keybase1.TLFVisibility_PUBLIC,
-		ForceRepoll: true,
-	})
-	if err != nil {
-		return res, err
-	}
-	return teamToNameInfo(ctx, team, vis)
-}
-
-func teamToNameInfo(ctx context.Context, team *teams.Team, vis keybase1.TLFVisibility) (res *types.NameInfo, err error) {
+func (t *TeamsNameInfoSource) makeNameInfo(ctx context.Context, team *teams.Team, public bool) (res *types.NameInfo, err error) {
 	res = types.NewNameInfo()
 	res.ID, err = chat1.TeamIDToTLFID(team.ID)
 	if err != nil {
 		return res, err
 	}
-	if team.IsImplicit() {
-		res.CanonicalName, err = team.ImplicitTeamDisplayNameString(ctx)
-		if err != nil {
-			return res, err
-		}
-	} else {
-		res.CanonicalName = team.Name().String()
-	}
-
-	if err := addNameInfoTeamKeys(ctx, res, team, vis); err != nil {
+	res.CanonicalName = team.Name().String()
+	if res.CryptKeys, err = getTeamKeys(ctx, team, public); err != nil {
 		return res, err
 	}
 	return res, nil
+}
+
+func (t *TeamsNameInfoSource) Lookup(ctx context.Context, name string, public bool) (res *types.NameInfo, err error) {
+	defer t.Trace(ctx, func() error { return err }, fmt.Sprintf("Lookup(%s)", name))()
+	team, err := teams.Load(ctx, t.G().ExternalG(), keybase1.LoadTeamArg{
+		Name:        name, // Loading by name is a last resort and will always cause an extra roundtrip.
+		Public:      public,
+		ForceRepoll: true,
+	})
+	if err != nil {
+		return res, err
+	}
+	return t.makeNameInfo(ctx, team, public)
+}
+
+func (t *TeamsNameInfoSource) EncryptionKeys(ctx context.Context, name string, teamID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (res *types.NameInfo, err error) {
+	defer t.Trace(ctx, func() error { return err },
+		fmt.Sprintf("EncryptionKeys(%s,%s,%v)", name, teamID, public))()
+	team, err := LoadTeam(ctx, t.G().ExternalG(), teamID, membersType, public, nil)
+	if err != nil {
+		return res, err
+	}
+	return t.makeNameInfo(ctx, team, public)
+}
+
+func (t *TeamsNameInfoSource) DecryptionKeys(ctx context.Context, name string, teamID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool,
+	keyGeneration int, kbfsEncrypted bool) (res *types.NameInfo, err error) {
+	defer t.Trace(ctx, func() error { return err },
+		fmt.Sprintf("DecryptionKeys(%s,%s,%v,%d,%v)", name, teamID, public, keyGeneration, kbfsEncrypted))()
+	team, err := loadTeamForDecryption(ctx, t.G().ExternalG(), name, teamID, membersType, public,
+		keyGeneration, kbfsEncrypted)
+	if err != nil {
+		return res, err
+	}
+	return t.makeNameInfo(ctx, team, public)
 }
 
 type ImplicitTeamsNameInfoSource struct {
@@ -113,35 +158,8 @@ func NewImplicitTeamsNameInfoSource(g *globals.Context, lookupUpgraded bool) *Im
 	}
 }
 
-func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, vis keybase1.TLFVisibility) (res *types.NameInfo, err error) {
-	// check if name is prefixed
-	if strings.HasPrefix(name, keybase1.ImplicitTeamPrefix) {
-		return t.lookupInternalName(ctx, name, vis)
-	}
-	res = types.NewNameInfo()
-
-	// Always create here to simulate behavior of GetTLFCryptKeys
-	team, _, impTeamName, err := teams.LookupOrCreateImplicitTeam(ctx, t.G().ExternalG(), name,
-		vis == keybase1.TLFVisibility_PUBLIC)
-	if err != nil {
-		return res, err
-	}
-	if !team.ID.IsRootTeam() {
-		panic(fmt.Sprintf("implicit team found via LookupImplicitTeam not root team: %s", team.ID))
-	}
-
-	res.CanonicalName = impTeamName.String()
-	if t.lookupUpgraded {
-		res.ID = chat1.TLFID(team.KBFSTLFID().ToBytes())
-	} else {
-		res.ID, err = chat1.TeamIDToTLFID(team.ID)
-		if err != nil {
-			return res, err
-		}
-	}
-	if err := addNameInfoTeamKeys(ctx, res, team, vis); err != nil {
-		return res, err
-	}
+func (t *ImplicitTeamsNameInfoSource) identify(ctx context.Context, tlfID chat1.TLFID,
+	impTeamName keybase1.ImplicitTeamDisplayName) (res []keybase1.TLFIdentifyFailure, err error) {
 
 	var names []string
 	names = append(names, impTeamName.Writers.KeybaseUsers...)
@@ -157,31 +175,108 @@ func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, v
 		return res, err
 	}
 	// use id breaks calculated by Identify
-	res.IdentifyFailures = ib
+	res = ib
 
 	if in := CtxIdentifyNotifier(ctx); in != nil {
 		update := keybase1.CanonicalTLFNameAndIDWithBreaks{
-			TlfID:         keybase1.TLFID(res.ID),
-			CanonicalName: keybase1.CanonicalTlfName(res.CanonicalName),
+			TlfID:         keybase1.TLFID(tlfID.String()),
+			CanonicalName: keybase1.CanonicalTlfName(impTeamName.String()),
 			Breaks: keybase1.TLFBreak{
-				Breaks: res.IdentifyFailures,
+				Breaks: res,
 			},
 		}
 		in.Send(update)
 	}
-	*breaks = appendBreaks(*breaks, res.IdentifyFailures)
+	*breaks = appendBreaks(*breaks, res)
 
 	// GUI Strict mode errors are swallowed earlier, return an error now (key is that it is
 	// after send to IdentifyNotifier)
-	if identBehavior == keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT && len(res.IdentifyFailures) > 0 {
-		return res, libkb.NewIdentifySummaryError(res.IdentifyFailures[0])
+	if identBehavior == keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT && len(res) > 0 {
+		return res, libkb.NewIdentifySummaryError(res[0])
 	}
 
 	return res, nil
 }
 
-func (t *ImplicitTeamsNameInfoSource) lookupInternalName(ctx context.Context, name string, vis keybase1.TLFVisibility) (res *types.NameInfo, err error) {
-	public := vis != keybase1.TLFVisibility_PRIVATE
+func (t *ImplicitTeamsNameInfoSource) makeNameInfo(ctx context.Context, team *teams.Team,
+	tlfID chat1.TLFID, impTeamName keybase1.ImplicitTeamDisplayName, public bool) (res *types.NameInfo, err error) {
+	res = types.NewNameInfo()
+	res.ID = tlfID
+	res.CanonicalName = impTeamName.String()
+	if res.CryptKeys, err = getTeamKeys(ctx, team, public); err != nil {
+		return res, err
+	}
+	if res.IdentifyFailures, err = t.identify(ctx, tlfID, impTeamName); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, public bool) (res *types.NameInfo, err error) {
+	// check if name is prefixed
+	if strings.HasPrefix(name, keybase1.ImplicitTeamPrefix) {
+		return t.lookupInternalName(ctx, name, public)
+	}
+	res = types.NewNameInfo()
+
+	// Always create here to simulate behavior of GetTLFCryptKeys
+	team, _, impTeamName, err := teams.LookupOrCreateImplicitTeam(ctx, t.G().ExternalG(), name, public)
+	if err != nil {
+		return res, err
+	}
+	if !team.ID.IsRootTeam() {
+		panic(fmt.Sprintf("implicit team found via LookupImplicitTeam not root team: %s", team.ID))
+	}
+
+	var tlfID chat1.TLFID
+	if t.lookupUpgraded {
+		tlfID = chat1.TLFID(team.KBFSTLFID().ToBytes())
+	} else {
+		tlfID, err = chat1.TeamIDToTLFID(team.ID)
+		if err != nil {
+			return res, err
+		}
+	}
+	return t.makeNameInfo(ctx, team, tlfID, impTeamName, public)
+}
+
+func (t *ImplicitTeamsNameInfoSource) EncryptionKeys(ctx context.Context, name string, teamID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (res *types.NameInfo, err error) {
+	defer t.Trace(ctx, func() error { return err },
+		fmt.Sprintf("EncryptionKeys(%s,%s,%v)", name, teamID, public))()
+
+	team, err := LoadTeam(ctx, t.G().ExternalG(), teamID, membersType, public, nil)
+	if err != nil {
+		return res, err
+	}
+	impTeamName, err := team.ImplicitTeamDisplayName(ctx)
+	if err != nil {
+		return res, err
+	}
+	return t.makeNameInfo(ctx, team, teamID, impTeamName, public)
+}
+
+func (t *ImplicitTeamsNameInfoSource) DecryptionKeys(ctx context.Context, name string, teamID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool,
+	keyGeneration int, kbfsEncrypted bool) (res *types.NameInfo, err error) {
+	defer t.Trace(ctx, func() error { return err },
+		fmt.Sprintf("DecryptionKeys(%s,%s,%v,%d,%v)", name, teamID, public, keyGeneration, kbfsEncrypted))()
+
+	team, err := loadTeamForDecryption(ctx, t.G().ExternalG(), name, teamID, membersType, public,
+		keyGeneration, kbfsEncrypted)
+	if err != nil {
+		return res, err
+	}
+	// Identify before returning any information
+	impTeamName, err := team.ImplicitTeamDisplayName(ctx)
+	if err != nil {
+		return res, err
+	}
+
+	return t.makeNameInfo(ctx, team, teamID, impTeamName, public)
+}
+
+func (t *ImplicitTeamsNameInfoSource) lookupInternalName(ctx context.Context, name string, public bool) (res *types.NameInfo, err error) {
 	teamName, err := keybase1.TeamNameFromString(name)
 	if err != nil {
 		return res, err
@@ -199,10 +294,9 @@ func (t *ImplicitTeamsNameInfoSource) lookupInternalName(ctx context.Context, na
 	if err != nil {
 		return res, err
 	}
-	if err := addNameInfoTeamKeys(ctx, res, team, vis); err != nil {
+	if res.CryptKeys, err = getTeamKeys(ctx, team, public); err != nil {
 		return res, err
 	}
-
 	return res, nil
 }
 

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -163,6 +163,7 @@ func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res
 	if err := group.Wait(); err != nil {
 		return keybase1.GetTLFCryptKeysRes{}, err
 	}
+	res.NameIDBreaks.Breaks.Breaks = ib
 
 	// GUI Strict mode errors are swallowed earlier, return an error now (key is that it is
 	// after send to IdentifyNotifier)
@@ -230,6 +231,7 @@ func (t *KBFSNameInfoSource) PublicCanonicalTLFNameAndID(ctx context.Context, tl
 	if err := group.Wait(); err != nil {
 		return keybase1.CanonicalTLFNameAndIDWithBreaks{}, err
 	}
+	res.Breaks.Breaks = ib
 
 	// GUI Strict mode errors are swallowed earlier, return an error now (key is that it is
 	// after send to IdentifyNotifier)

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -46,11 +46,14 @@ func (t *KBFSNameInfoSource) tlfKeysClient() (*keybase1.TlfKeysClient, error) {
 	}, nil
 }
 
-func (t *KBFSNameInfoSource) Lookup(ctx context.Context, tlfName string,
-	visibility keybase1.TLFVisibility) (res *types.NameInfo, err error) {
+func (t *KBFSNameInfoSource) Lookup(ctx context.Context, tlfName string, public bool) (res *types.NameInfo, err error) {
 	defer t.Trace(ctx, func() error { return err }, fmt.Sprintf("Lookup(%s)", tlfName))()
 	var lastErr error
 	res = types.NewNameInfo()
+	visibility := keybase1.TLFVisibility_PRIVATE
+	if public {
+		visibility = keybase1.TLFVisibility_PUBLIC
+	}
 	for i := 0; i < 5; i++ {
 		if visibility == keybase1.TLFVisibility_PUBLIC {
 			var pres keybase1.CanonicalTLFNameAndIDWithBreaks
@@ -83,6 +86,17 @@ func (t *KBFSNameInfoSource) Lookup(ctx context.Context, tlfName string,
 	}
 
 	return res, lastErr
+}
+
+func (t *KBFSNameInfoSource) EncryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (*types.NameInfo, error) {
+	return t.Lookup(ctx, tlfName, public)
+}
+
+func (t *KBFSNameInfoSource) DecryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool,
+	keyGeneration int, kbfsEncrypted bool) (*types.NameInfo, error) {
+	return t.Lookup(ctx, tlfName, public)
 }
 
 func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res keybase1.GetTLFCryptKeysRes, ferr error) {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -24,8 +24,15 @@ type CryptKey interface {
 	Generation() int
 }
 
+type AllCryptKeys map[chat1.ConversationMembersType][]CryptKey
+
 type NameInfoSource interface {
-	Lookup(ctx context.Context, name string, vis keybase1.TLFVisibility) (*NameInfo, error)
+	Lookup(ctx context.Context, name string, public bool) (*NameInfo, error)
+	EncryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+		membersType chat1.ConversationMembersType, public bool) (*NameInfo, error)
+	DecryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+		membersType chat1.ConversationMembersType, public bool,
+		keyGeneration int, kbfsEncrypted bool) (*NameInfo, error)
 }
 
 type UnboxConversationInfo interface {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -186,3 +186,9 @@ type TeamChannelSource interface {
 	GetChannelsTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType) ([]ConvIDAndTopicName, []chat1.RateLimit, error)
 	ChannelsChanged(context.Context, chat1.TLFID)
 }
+
+type IdentifyNotifier interface {
+	Reset()
+	ResetOnGUIConnect()
+	Send(ctx context.Context, update keybase1.CanonicalTLFNameAndIDWithBreaks)
+}

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -23,6 +23,10 @@ var PushKBFSUpgrade = "chat.kbfsupgrade"
 var PushConvRetention = "chat.convretention"
 var PushTeamRetention = "chat.teamretention"
 
+func NewAllCryptKeys() AllCryptKeys {
+	return make(AllCryptKeys)
+}
+
 type NameInfo struct {
 	ID               chat1.TLFID
 	CanonicalName    string

--- a/go/chat/upgrade_test.go
+++ b/go/chat/upgrade_test.go
@@ -52,6 +52,7 @@ func TestChatKBFSUpgradeMixed(t *testing.T) {
 	require.NoError(t, teams.UpgradeTLFIDToImpteam(ctx, tc.G, u.Username, tlfID, false,
 		keybase1.TeamApplication_CHAT, cres.CryptKeys))
 
+	conv.Metadata.MembersType = chat1.ConversationMembersType_IMPTEAMUPGRADE
 	header = chat1.MessageClientHeader{
 		TlfPublic:   false,
 		TlfName:     u.Username,
@@ -67,7 +68,6 @@ func TestChatKBFSUpgradeMixed(t *testing.T) {
 		MessageID: 3,
 	}
 
-	conv.Metadata.MembersType = chat1.ConversationMembersType_IMPTEAMUPGRADE
 	unboxed, err := boxer.UnboxMessages(ctx, []chat1.MessageBoxed{*teamBoxed, *kbfsBoxed}, conv)
 	require.NoError(t, err)
 	require.Len(t, unboxed, 2)

--- a/go/chat/upgrade_test.go
+++ b/go/chat/upgrade_test.go
@@ -53,6 +53,7 @@ func TestChatKBFSUpgradeMixed(t *testing.T) {
 		keybase1.TeamApplication_CHAT, cres.CryptKeys))
 
 	conv.Metadata.MembersType = chat1.ConversationMembersType_IMPTEAMUPGRADE
+	CtxKeyFinder(ctx, tc.Context()).SetNameInfoSourceOverride(nil)
 	header = chat1.MessageClientHeader{
 		TlfPublic:   false,
 		TlfName:     u.Username,

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -191,7 +191,7 @@ func (m TlfMock) getTlfID(cname keybase1.CanonicalTlfName) (keybase1.TLFID, erro
 	return keybase1.TLFID(hex.EncodeToString([]byte(tlfID))), nil
 }
 
-func (m TlfMock) Lookup(ctx context.Context, tlfName string, vis keybase1.TLFVisibility) (res *types.NameInfo, err error) {
+func (m TlfMock) Lookup(ctx context.Context, tlfName string, public bool) (res *types.NameInfo, err error) {
 	var tlfID keybase1.TLFID
 	res = types.NewNameInfo()
 	name := CanonicalTlfNameForTest(tlfName)
@@ -200,6 +200,10 @@ func (m TlfMock) Lookup(ctx context.Context, tlfName string, vis keybase1.TLFVis
 		return res, err
 	}
 	res.ID = tlfID.ToBytes()
+	vis := keybase1.TLFVisibility_PRIVATE
+	if public {
+		vis = keybase1.TLFVisibility_PUBLIC
+	}
 	if vis == keybase1.TLFVisibility_PRIVATE {
 		cres, err := m.CryptKeys(ctx, tlfName)
 		if err != nil {
@@ -211,6 +215,17 @@ func (m TlfMock) Lookup(ctx context.Context, tlfName string, vis keybase1.TLFVis
 		}
 	}
 	return res, nil
+}
+
+func (m TlfMock) EncryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (*types.NameInfo, error) {
+	return m.Lookup(ctx, tlfName, public)
+}
+
+func (m TlfMock) DecryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool,
+	keyGeneration int, kbfsEncrypted bool) (*types.NameInfo, error) {
+	return m.Lookup(ctx, tlfName, public)
 }
 
 func (m TlfMock) CryptKeys(ctx context.Context, tlfName string) (res keybase1.GetTLFCryptKeysRes, err error) {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -666,7 +666,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	// various resync procedures for chat and notifications
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
-		chat.NewIdentifyNotifier(g.G()))
+		chat.NewCachingIdentifyNotifier(g.G()))
 	g.chatLog.Debug(ctx, "OnConnect begin")
 	syncAllRes, err := chatCli.SyncAll(ctx, chat1.SyncAllArg{
 		Uid:       uid,

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -102,7 +102,7 @@ func (h *KBFSHandler) notifyConversation(uid keybase1.UID, filename string) {
 
 	g := globals.NewContext(h.G(), h.ChatG())
 	ctx := chat.Context(context.Background(), g, keybase1.TLFIdentifyBehavior_CHAT_SKIP,
-		nil, chat.NewIdentifyNotifier(g))
+		nil, chat.NewCachingIdentifyNotifier(g))
 	h.ChatG().FetchRetrier.Rekey(ctx, tlf, chat1.ConversationMembersType_KBFS, public)
 }
 

--- a/go/service/tlf.go
+++ b/go/service/tlf.go
@@ -36,7 +36,7 @@ func (h *tlfHandler) CryptKeys(ctx context.Context, arg keybase1.TLFQuery) (res 
 	defer h.Trace(ctx, func() error { return err },
 		fmt.Sprintf("CryptKeys(tlf=%s,mode=%v)", arg.TlfName, arg.IdentifyBehavior))()
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, h.G(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
+	ctx = chat.Context(ctx, h.G(), arg.IdentifyBehavior, &breaks, chat.NewCachingIdentifyNotifier(h.G()))
 	return h.tlfInfoSource.CryptKeys(ctx, arg.TlfName)
 }
 
@@ -45,7 +45,7 @@ func (h *tlfHandler) PublicCanonicalTLFNameAndID(ctx context.Context, arg keybas
 		fmt.Sprintf("PublicCanonicalTLFNameAndID(tlf=%s,mode=%v)", arg.TlfName,
 			arg.IdentifyBehavior))()
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, h.G(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
+	ctx = chat.Context(ctx, h.G(), arg.IdentifyBehavior, &breaks, chat.NewCachingIdentifyNotifier(h.G()))
 	return h.tlfInfoSource.PublicCanonicalTLFNameAndID(ctx, arg.TlfName)
 }
 
@@ -54,6 +54,6 @@ func (h *tlfHandler) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, 
 		fmt.Sprintf("CompleteAndCanonicalizePrivateTlfName(tlf=%s,mode=%v)", arg.TlfName,
 			arg.IdentifyBehavior))()
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, h.G(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
+	ctx = chat.Context(ctx, h.G(), arg.IdentifyBehavior, &breaks, chat.NewCachingIdentifyNotifier(h.G()))
 	return h.tlfInfoSource.CompleteAndCanonicalizePrivateTlfName(ctx, arg.TlfName)
 }


### PR DESCRIPTION
Patch does the following:

1.) Changes `KeyFinderImpl` so that it caches all requests for keys, including the specific functions for encryption and decryption keys.
2.) Move all per members type logic out of `KeyFinder` and into the relevant `NameInfoSource`.
3.) Don't identify as much in `HybridConversationSource`, skip identify for all identify behaviors if we have something stored.
4.) Add some more `IdentifyNotifier` implementations for testing.
5.) Run `Identify` in all cases where we get crypt keys for implicit team chats.
6.) Move logic for invoking the `IdentifyNotifier` into the `NameIdentifier` so that we make sure to send the notifications (and store their results) whenever we identify.