### PR TITLE
[KBFS-2740] Navigation breadcrumbs for Files

### DIFF
--- a/shared/constants/types/fs.js
+++ b/shared/constants/types/fs.js
@@ -43,7 +43,7 @@ export type State = I.RecordOf<_State>
 
 export type Visibility = 'private' | 'public' | 'team' | null
 
-export const stringToPath = (s: string): Path => (s.indexOf('/keybase') !== -1 ? s : null)
+export const stringToPath = (s: string): Path => (s.indexOf('/') === 0 ? s : null)
 export const pathToString = (p: Path): string => (!p ? '' : p)
 export const getPathName = (p: Path): string => (!p ? '' : p.split('/').pop())
 export const getPathElements = (p: Path): Array<string> => (!p ? [] : p.split('/').slice(1))
@@ -76,4 +76,5 @@ export const stringToPathType = (s: string): PathType => {
   }
 }
 export const pathTypeToString = (p: PathType): string => p
-export const pathConcat = (p: Path, s: string): Path => stringToPath(pathToString(p) + '/' + s)
+export const pathConcat = (p: Path, s: string): Path =>
+  p === '/' ? stringToPath('/' + s) : stringToPath(pathToString(p) + '/' + s)

--- a/shared/constants/types/fs.js
+++ b/shared/constants/types/fs.js
@@ -46,6 +46,7 @@ export type Visibility = 'private' | 'public' | 'team' | null
 export const stringToPath = (s: string): Path => (s.indexOf('/keybase') !== -1 ? s : null)
 export const pathToString = (p: Path): string => (!p ? '' : p)
 export const getPathName = (p: Path): string => (!p ? '' : p.split('/').pop())
+export const getPathElements = (p: Path): Array<string> => (!p ? [] : p.split('/').slice(1))
 export const getPathVisibility = (p: Path): Visibility => {
   if (!p) return null
   const [, , visibility] = p.split('/')

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -1,6 +1,6 @@
 // @flow
 import * as I from 'immutable'
-import {connect, type TypedState, type Dispatch} from '../util/container'
+import {compose, connect, type TypedState, setDisplayName, type Dispatch} from '../util/container'
 import Files from '.'
 import * as Types from '../constants/types/fs'
 import * as Constants from '../constants/fs'
@@ -38,4 +38,6 @@ const mergeProps = ({path, items}: StateProps, dispatchProps: DispatchProps, own
   ...dispatchProps,
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Files)
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps), setDisplayName('Files'))(
+  Files
+)

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -2,7 +2,6 @@
 import * as I from 'immutable'
 import {connect, type TypedState, type Dispatch} from '../util/container'
 import Files from '.'
-import {navigateUp} from '../actions/route-tree'
 import * as Types from '../constants/types/fs'
 import * as Constants from '../constants/fs'
 
@@ -15,9 +14,7 @@ type StateProps = {
   items: I.List<Types.Path>,
 }
 
-type DispatchProps = {
-  onBack: () => void,
-}
+type DispatchProps = {}
 
 const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => {
   const path = Types.stringToPath(routeProps.get('path', Constants.defaultPath))
@@ -29,9 +26,7 @@ const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => {
   }
 }
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  onBack: () => dispatch(navigateUp()),
-})
+const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 const mergeProps = ({path, items}: StateProps, dispatchProps: DispatchProps, ownProps) => ({
   items: items.toArray(),

--- a/shared/fs/header-container.js
+++ b/shared/fs/header-container.js
@@ -1,0 +1,14 @@
+// @flow
+import * as Types from '../constants/types/fs'
+import {connect, type Dispatch} from '../util/container'
+import {navigateAppend} from '../actions/route-tree'
+
+const mapStateToProps = (state, ownProps) => ownProps
+
+const mapDispatchToProps = (dispatch: Dispatch, ownProps) => ({
+  onOpen: (path: Types.Path) => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),
+  ...ownProps,
+})
+
+const FolderHeaderBreadcrumbConnector = connect(mapStateToProps, mapDispatchToProps)
+export {FolderHeaderBreadcrumbConnector}

--- a/shared/fs/header-container.js
+++ b/shared/fs/header-container.js
@@ -1,13 +1,13 @@
 // @flow
 import * as Types from '../constants/types/fs'
-import {connect, type Dispatch} from '../util/container'
+import {connect, type TypedState, type Dispatch} from '../util/container'
 import {navigateAppend} from '../actions/route-tree'
 
 type OwnProps = {
   path: Types.Path,
 }
 
-const mapStateToProps = (state, ownProps: OwnProps) => ownProps
+const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ownProps
 
 const mapDispatchToProps = (dispatch: Dispatch, {path}: OwnProps) => ({
   onOpen: () => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),

--- a/shared/fs/header-container.js
+++ b/shared/fs/header-container.js
@@ -3,11 +3,14 @@ import * as Types from '../constants/types/fs'
 import {connect, type Dispatch} from '../util/container'
 import {navigateAppend} from '../actions/route-tree'
 
-const mapStateToProps = (state, ownProps) => ownProps
+type OwnProps = {
+  path: Types.Path,
+}
 
-const mapDispatchToProps = (dispatch: Dispatch, ownProps) => ({
-  onOpen: (path: Types.Path) => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),
-  ...ownProps,
+const mapStateToProps = (state, ownProps: OwnProps) => ownProps
+
+const mapDispatchToProps = (dispatch: Dispatch, {path}: OwnProps) => ({
+  onOpen: () => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),
 })
 
 const FolderHeaderBreadcrumbConnector = connect(mapStateToProps, mapDispatchToProps)

--- a/shared/fs/header-container.js
+++ b/shared/fs/header-container.js
@@ -1,6 +1,6 @@
 // @flow
 import * as Types from '../constants/types/fs'
-import {connect, type Dispatch} from '../util/container'
+import {compose, connect, setDisplayName, type Dispatch} from '../util/container'
 import {navigateAppend} from '../actions/route-tree'
 
 type OwnProps = {
@@ -29,4 +29,7 @@ const mergeProps = (stateProps, dispatchProps, {path}: OwnProps) => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  setDisplayName('FolderHeader')
+)

--- a/shared/fs/header-container.js
+++ b/shared/fs/header-container.js
@@ -9,8 +9,10 @@ type OwnProps = {
 
 const mapStateToProps = (state: TypedState, {path}: OwnProps) => {
   let acc = Types.stringToPath('/')
+  const elems = Types.getPathElements(path)
   return {
-    items: Types.getPathElements(path).map(e => {
+    isTeamPath: elems.length >= 2 && elems[1] === 'team',
+    items: elems.map(e => {
       acc = Types.pathConcat(acc, e)
       return {
         name: e,

--- a/shared/fs/header-container.js
+++ b/shared/fs/header-container.js
@@ -7,11 +7,21 @@ type OwnProps = {
   path: Types.Path,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ownProps
+const mapStateToProps = (state: TypedState, {path}: OwnProps) => {
+  let acc = Types.stringToPath('/')
+  return {
+    items: Types.getPathElements(path).map(e => {
+      acc = Types.pathConcat(acc, e)
+      return {
+        name: e,
+        path: acc,
+      }
+    }),
+  }
+}
 
-const mapDispatchToProps = (dispatch: Dispatch, {path}: OwnProps) => ({
-  onOpen: () => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onOpenBreadcrumb: (path: Types.Path) => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),
 })
 
-const FolderHeaderBreadcrumbConnector = connect(mapStateToProps, mapDispatchToProps)
-export {FolderHeaderBreadcrumbConnector}
+export default connect(mapStateToProps, mapDispatchToProps)

--- a/shared/fs/header-container.js
+++ b/shared/fs/header-container.js
@@ -1,16 +1,23 @@
 // @flow
 import * as Types from '../constants/types/fs'
-import {connect, type TypedState, type Dispatch} from '../util/container'
+import {connect, type Dispatch} from '../util/container'
 import {navigateAppend} from '../actions/route-tree'
 
 type OwnProps = {
   path: Types.Path,
 }
 
-const mapStateToProps = (state: TypedState, {path}: OwnProps) => {
+const mapStateToProps = () => ({})
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onOpenBreadcrumb: (path: Types.Path) => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),
+})
+
+const mergeProps = (stateProps, dispatchProps, {path}: OwnProps) => {
   let acc = Types.stringToPath('/')
   const elems = Types.getPathElements(path)
   return {
+    ...dispatchProps,
     isTeamPath: elems.length >= 2 && elems[1] === 'team',
     items: elems.map(e => {
       acc = Types.pathConcat(acc, e)
@@ -22,8 +29,4 @@ const mapStateToProps = (state: TypedState, {path}: OwnProps) => {
   }
 }
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  onOpenBreadcrumb: (path: Types.Path) => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),
-})
-
-export default connect(mapStateToProps, mapDispatchToProps)
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)

--- a/shared/fs/header-container.js
+++ b/shared/fs/header-container.js
@@ -10,7 +10,8 @@ type OwnProps = {
 const mapStateToProps = () => ({})
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  onOpenBreadcrumb: (path: Types.Path) => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),
+  onOpenBreadcrumb: (path: string) =>
+    dispatch(navigateAppend([{props: {path: Types.stringToPath(path)}, selected: 'folder'}])),
 })
 
 const mergeProps = (stateProps, dispatchProps, {path}: OwnProps) => {
@@ -23,7 +24,7 @@ const mergeProps = (stateProps, dispatchProps, {path}: OwnProps) => {
       acc = Types.pathConcat(acc, e)
       return {
         name: e,
-        path: acc,
+        path: Types.pathToString(acc),
       }
     }),
   }

--- a/shared/fs/header.js
+++ b/shared/fs/header.js
@@ -79,7 +79,7 @@ const FolderHeaderBreadcrumb = FolderHeaderBreadcrumbConnector(
   }
 )
 
-const FolderHeaderRow = ({index, totalCrumbs, visibility, item, path}: FolderBreadcrumbProps) => {
+const FolderHeaderItem = ({index, totalCrumbs, visibility, item, path}: FolderBreadcrumbProps) => {
   let separator = <Icon type="iconfont-back" style={iconStyle} />
   if (index === 0) {
     separator = null
@@ -133,7 +133,7 @@ class FolderHeader extends React.Component<FolderHeaderProps, FolderHeaderState>
               const pelems = pathElems.slice(0, index + 1)
               const path = Types.stringToPath('/' + pelems.join('/'))
               return (
-                <FolderHeaderRow
+                <FolderHeaderItem
                   key={index}
                   index={index}
                   visibility={visibility}

--- a/shared/fs/header.js
+++ b/shared/fs/header.js
@@ -3,17 +3,53 @@ import * as React from 'react'
 import * as Types from '../constants/types/fs'
 import {globalStyles, globalColors, globalMargins, isMobile} from '../styles'
 import {Avatar, Box, ClickableBox, Icon, Text} from '../common-adapters'
-import {FolderHeaderBreadcrumbConnector} from './header-container'
+import HeaderConnector from './header-container'
 
 type FolderHeaderProps = {
-  path: Types.Path,
+  items: Array<{
+    name: string,
+    path: Types.Path,
+  }>,
+  onOpenBreadcrumb: (path: Types.Path) => void,
 }
+
+const FolderHeader = HeaderConnector(({items, onOpenBreadcrumb}: FolderHeaderProps) => (
+  <Box>
+    {items.length === 1 ? (
+      <Box style={folderHeaderStyleRoot}>
+        <Text type="BodyBig">Keybase Files</Text>
+      </Box>
+    ) : (
+      <Box style={folderHeaderStyleTree}>
+        {items.length < 4 &&
+          items.map((i, idx) => (
+            <Box key={Types.pathToString(i.path)} style={folderBreadcrumbStyle}>
+              {idx !== 0 && <Icon type="iconfont-back" style={iconStyle} />}
+              {idx === 2 &&
+                i.name === 'team' && (
+                  <Avatar size={12} teamname={i.name} isTeam={true} style={styleTeamAvatar} />
+                )}
+              {idx === items.length - 1 ? (
+                <Text type="BodyBig">{i.name}</Text>
+              ) : (
+                <ClickableBox onClick={() => onOpenBreadcrumb(i.path)}>
+                  <Text type="BodySmallSemibold" style={styleParentBreadcrumb}>
+                    {i.name}
+                  </Text>
+                </ClickableBox>
+              )}
+            </Box>
+          ))}
+      </Box>
+    )}
+  </Box>
+))
 
 const stylesCommonRow = {
   ...globalStyles.flexBoxRow,
   alignItems: 'center',
-  borderBottomWidth: 1,
   borderBottomColor: globalColors.black_05,
+  borderBottomWidth: 1,
   minHeight: isMobile ? 64 : 48,
 }
 
@@ -37,31 +73,8 @@ const folderBreadcrumbStyle = {
   paddingRight: 0,
 }
 
-const rootHeaderContent = (
-  <Box style={folderHeaderStyleRoot}>
-    <Text type="BodyBig">Keybase Files</Text>
-  </Box>
-)
+const styleParentBreadcrumb = {color: globalColors.black_60}
 
-type FolderHeaderState = {
-  pathElems: Array<string>,
-}
-
-type FolderBreadcrumbProps = {
-  index: number,
-  totalCrumbs: number,
-  visibility: Types.Visibility,
-  item: string,
-  path: Types.Path,
-}
-
-type FolderBreadcrumbConnectedProps = {
-  visibility: Types.Visibility,
-  item: string,
-  onOpen: () => void,
-}
-
-const headerPathStyleParent = {color: globalColors.black_60}
 const iconStyle = {
   fontSize: 11,
   marginLeft: globalMargins.xtiny,
@@ -70,98 +83,6 @@ const iconStyle = {
 
 const styleTeamAvatar = {
   marginRight: globalMargins.xtiny,
-}
-
-const FolderHeaderBreadcrumb = FolderHeaderBreadcrumbConnector(
-  ({visibility, item, onOpen}: FolderBreadcrumbConnectedProps) => {
-    return (
-      <ClickableBox onClick={onOpen}>
-        <Text type="BodySmallSemibold" style={headerPathStyleParent}>
-          {item}
-        </Text>
-      </ClickableBox>
-    )
-  }
-)
-
-const FolderHeaderItem = ({index, totalCrumbs, visibility, item, path}: FolderBreadcrumbProps) => {
-  let separator = <Icon type="iconfont-back" style={iconStyle} />
-  if (index === 0) {
-    separator = null
-  }
-  if (index === totalCrumbs - 1) {
-    return (
-      <Box style={folderBreadcrumbStyle}>
-        {separator}
-        {visibility === 'team' &&
-          index === 2 && <Avatar size={12} teamname={item} isTeam={true} style={styleTeamAvatar} />}
-        <Text type="BodyBig">{item}</Text>
-      </Box>
-    )
-  } else {
-    return (
-      <Box style={folderBreadcrumbStyle}>
-        {separator}
-        {visibility === 'team' &&
-          index === 2 && <Avatar size={12} teamname={item} isTeam={true} style={styleTeamAvatar} />}
-        <FolderHeaderBreadcrumb visibility={visibility} item={item} path={path} />
-      </Box>
-    )
-  }
-}
-
-class FolderHeader extends React.Component<FolderHeaderProps, FolderHeaderState> {
-  state: FolderHeaderState
-
-  constructor(props: FolderHeaderProps) {
-    super(props)
-    this.state = {
-      pathElems: Types.getPathElements(props.path),
-    }
-  }
-
-  componentWillReceiveProps = (nextProps: FolderHeaderProps) => {
-    this.setState(prevState => ({pathElems: Types.getPathElements(nextProps.path)}))
-  }
-
-  _createBreadcrumbs = () => {
-    switch (this.state.pathElems.length) {
-      case 1:
-        return rootHeaderContent
-      case 2:
-      // {private, public, team}
-      // fallthrough
-      case 3:
-        // TLF
-        const visibility = Types.getPathVisibility(this.props.path)
-        return (
-          <Box style={folderHeaderStyleTree}>
-            {this.state.pathElems.map((elem, index, pathElems) => {
-              // TODO: make this more efficient, currently it's doing repeated
-              // work for each item.
-              const pelems = pathElems.slice(0, index + 1)
-              const path = Types.stringToPath('/' + pelems.join('/'))
-              return (
-                <FolderHeaderItem
-                  key={index}
-                  index={index}
-                  visibility={visibility}
-                  item={elem}
-                  totalCrumbs={pathElems.length}
-                  path={path}
-                />
-              )
-            })}
-          </Box>
-        )
-      default:
-      // TODO: fix with list
-    }
-  }
-
-  render() {
-    return <Box>{this._createBreadcrumbs()}</Box>
-  }
 }
 
 export default FolderHeader

--- a/shared/fs/header.js
+++ b/shared/fs/header.js
@@ -1,0 +1,106 @@
+// @flow
+import * as React from 'react'
+import * as Types from '../constants/types/fs'
+import {globalStyles, globalColors, globalMargins, isMobile} from '../styles'
+import {Box, Icon, List, Text} from '../common-adapters'
+
+type FolderHeaderProps = {
+  path: Types.Path,
+}
+
+const stylesCommonRow = {
+  ...globalStyles.flexBoxRow,
+  alignItems: 'center',
+  borderBottomWidth: 0,
+  justifyContent: 'center',
+  minHeight: isMobile ? 64 : 40,
+}
+
+const folderHeaderStyleRoot = {
+  ...stylesCommonRow,
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+const folderHeaderStyleTree = {
+  ...stylesCommonRow,
+  alignItems: 'center',
+  justifyContent: 'left',
+  paddingLeft: 16,
+  paddingRight: 16,
+}
+
+const rootHeaderContent = (
+  <Box style={folderHeaderStyleRoot}>
+    <Text type="BodyBig">Keybase Files</Text>
+  </Box>
+)
+
+type FolderHeaderState = {
+  pathElems: Array<string>,
+}
+
+const headerPathStyleParent = {color: globalColors.black_60}
+const iconStyle = {marginRight: globalMargins.small}
+
+class FolderHeader extends React.Component<FolderHeaderProps, FolderHeaderState> {
+  state: FolderHeaderState
+
+  constructor(props: FolderHeaderProps) {
+    super(props)
+    this.state = {
+      pathElems: Types.getPathElements(props.path),
+    }
+  }
+
+  componentWillReceiveProps = (nextProps: FolderHeaderProps) => {
+    this.setState(prevState => ({pathElems: Types.getPathElements(nextProps.path)}))
+  }
+
+  _renderItem = (index, item) => {
+    switch (this.state.pathElems.length) {
+      case 2:
+      // {private, public, team}
+      // fallthrough
+      case 3:
+        // TLF
+        let separator = <Icon type="iconfont-back" style={{...iconStyle}} />
+        if (index === 0) {
+          separator = null
+        }
+        if (index === this.state.pathElems.length - 1) {
+          return (
+            <Box>
+              {separator}
+              <Text type="BodyBig">{item}</Text>
+            </Box>
+          )
+        } else {
+          return (
+            <Box>
+              {separator}
+              <Text type="BodySmallSemibold" style={{...headerPathStyleParent}}>
+                {item}
+              </Text>
+            </Box>
+          )
+        }
+      default:
+      // Subfolder within TLF
+    }
+  }
+
+  render() {
+    let content = rootHeaderContent
+    if (this.state.pathElems.length > 1) {
+      content = (
+        <Box style={folderHeaderStyleTree}>
+          <List items={this.state.pathElems} renderItem={this._renderItem} />
+        </Box>
+      )
+    }
+    return <Box>{content}</Box>
+  }
+}
+
+export default FolderHeader

--- a/shared/fs/header.js
+++ b/shared/fs/header.js
@@ -10,10 +10,11 @@ type FolderHeaderProps = {
     name: string,
     path: Types.Path,
   }>,
+  isTeamPath: boolean,
   onOpenBreadcrumb: (path: Types.Path) => void,
 }
 
-const FolderHeader = HeaderConnector(({items, onOpenBreadcrumb}: FolderHeaderProps) => (
+const FolderHeader = HeaderConnector(({items, isTeamPath, onOpenBreadcrumb}: FolderHeaderProps) => (
   <Box>
     {items.length === 1 ? (
       <Box style={folderHeaderStyleRoot}>
@@ -26,9 +27,7 @@ const FolderHeader = HeaderConnector(({items, onOpenBreadcrumb}: FolderHeaderPro
             <Box key={Types.pathToString(i.path)} style={folderBreadcrumbStyle}>
               {idx !== 0 && <Icon type="iconfont-back" style={iconStyle} />}
               {idx === 2 &&
-                i.name === 'team' && (
-                  <Avatar size={12} teamname={i.name} isTeam={true} style={styleTeamAvatar} />
-                )}
+                isTeamPath && <Avatar size={12} teamname={i.name} isTeam={true} style={styleTeamAvatar} />}
               {idx === items.length - 1 ? (
                 <Text type="BodyBig">{i.name}</Text>
               ) : (

--- a/shared/fs/header.js
+++ b/shared/fs/header.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as Types from '../constants/types/fs'
 import {globalStyles, globalColors, globalMargins, isMobile} from '../styles'
-import {Box, Icon, List, Text} from '../common-adapters'
+import {Box, Icon, Text} from '../common-adapters'
 
 type FolderHeaderProps = {
   path: Types.Path,
@@ -11,9 +11,9 @@ type FolderHeaderProps = {
 const stylesCommonRow = {
   ...globalStyles.flexBoxRow,
   alignItems: 'center',
-  borderBottomWidth: 0,
-  justifyContent: 'center',
-  minHeight: isMobile ? 64 : 40,
+  borderBottomWidth: 1,
+  borderBottomColor: globalColors.black_05,
+  minHeight: isMobile ? 64 : 48,
 }
 
 const folderHeaderStyleRoot = {
@@ -25,9 +25,15 @@ const folderHeaderStyleRoot = {
 const folderHeaderStyleTree = {
   ...stylesCommonRow,
   alignItems: 'center',
-  justifyContent: 'left',
   paddingLeft: 16,
   paddingRight: 16,
+}
+
+const folderBreadcrumbStyle = {
+  ...globalStyles.flexBoxRow,
+  paddingLeft: 0,
+  paddingRight: 0,
+  alignItems: 'end',
 }
 
 const rootHeaderContent = (
@@ -40,8 +46,43 @@ type FolderHeaderState = {
   pathElems: Array<string>,
 }
 
+type FolderBreadcrumbProps = {
+  index: number,
+  totalCrumbs: number,
+  visibility: Types.Visibility,
+  item: string,
+}
+
 const headerPathStyleParent = {color: globalColors.black_60}
-const iconStyle = {marginRight: globalMargins.small}
+const iconStyle = {
+  fontSize: 11,
+  marginLeft: globalMargins.xtiny,
+  marginRight: globalMargins.xtiny,
+}
+
+const FolderHeaderBreadcrumb = ({index, totalCrumbs, visibility, item}: FolderBreadcrumbProps) => {
+  let separator = <Icon type="iconfont-back" style={iconStyle} />
+  if (index === 0) {
+    separator = null
+  }
+  if (index === totalCrumbs - 1) {
+    return (
+      <Box style={folderBreadcrumbStyle}>
+        {separator}
+        <Text type="BodyBig">{item}</Text>
+      </Box>
+    )
+  } else {
+    return (
+      <Box style={folderBreadcrumbStyle}>
+        {separator}
+        <Text type="BodySmallSemibold" style={headerPathStyleParent}>
+          {item}
+        </Text>
+      </Box>
+    )
+  }
+}
 
 class FolderHeader extends React.Component<FolderHeaderProps, FolderHeaderState> {
   state: FolderHeaderState
@@ -57,49 +98,36 @@ class FolderHeader extends React.Component<FolderHeaderProps, FolderHeaderState>
     this.setState(prevState => ({pathElems: Types.getPathElements(nextProps.path)}))
   }
 
-  _renderItem = (index, item) => {
+  _createBreadcrumbs = () => {
     switch (this.state.pathElems.length) {
+      case 1:
+        return rootHeaderContent
       case 2:
       // {private, public, team}
       // fallthrough
       case 3:
         // TLF
-        let separator = <Icon type="iconfont-back" style={{...iconStyle}} />
-        if (index === 0) {
-          separator = null
-        }
-        if (index === this.state.pathElems.length - 1) {
-          return (
-            <Box>
-              {separator}
-              <Text type="BodyBig">{item}</Text>
-            </Box>
-          )
-        } else {
-          return (
-            <Box>
-              {separator}
-              <Text type="BodySmallSemibold" style={{...headerPathStyleParent}}>
-                {item}
-              </Text>
-            </Box>
-          )
-        }
+        const visibility = Types.getPathVisibility(this.props.path)
+        return (
+          <Box style={folderHeaderStyleTree}>
+            {this.state.pathElems.map((elem, index, pathElems) => (
+              <FolderHeaderBreadcrumb
+                key={index}
+                index={index}
+                visibility={visibility}
+                item={elem}
+                totalCrumbs={pathElems.length}
+              />
+            ))}
+          </Box>
+        )
       default:
-      // Subfolder within TLF
+      // TODO: fix with list
     }
   }
 
   render() {
-    let content = rootHeaderContent
-    if (this.state.pathElems.length > 1) {
-      content = (
-        <Box style={folderHeaderStyleTree}>
-          <List items={this.state.pathElems} renderItem={this._renderItem} />
-        </Box>
-      )
-    }
-    return <Box>{content}</Box>
+    return <Box>{this._createBreadcrumbs()}</Box>
   }
 }
 

--- a/shared/fs/header.js
+++ b/shared/fs/header.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as Types from '../constants/types/fs'
 import {globalStyles, globalColors, globalMargins, isMobile} from '../styles'
-import {Box, ClickableBox, Icon, Text} from '../common-adapters'
+import {Avatar, Box, ClickableBox, Icon, Text} from '../common-adapters'
 import {FolderHeaderBreadcrumbConnector} from './header-container'
 
 type FolderHeaderProps = {
@@ -32,6 +32,7 @@ const folderHeaderStyleTree = {
 
 const folderBreadcrumbStyle = {
   ...globalStyles.flexBoxRow,
+  alignItems: 'center',
   paddingLeft: 0,
   paddingRight: 0,
 }
@@ -67,6 +68,10 @@ const iconStyle = {
   marginRight: globalMargins.xtiny,
 }
 
+const styleTeamAvatar = {
+  marginRight: globalMargins.xtiny,
+}
+
 const FolderHeaderBreadcrumb = FolderHeaderBreadcrumbConnector(
   ({visibility, item, onOpen}: FolderBreadcrumbConnectedProps) => {
     return (
@@ -88,6 +93,8 @@ const FolderHeaderItem = ({index, totalCrumbs, visibility, item, path}: FolderBr
     return (
       <Box style={folderBreadcrumbStyle}>
         {separator}
+        {visibility === 'team' &&
+          index === 2 && <Avatar size={12} teamname={item} isTeam={true} style={styleTeamAvatar} />}
         <Text type="BodyBig">{item}</Text>
       </Box>
     )
@@ -95,6 +102,8 @@ const FolderHeaderItem = ({index, totalCrumbs, visibility, item, path}: FolderBr
     return (
       <Box style={folderBreadcrumbStyle}>
         {separator}
+        {visibility === 'team' &&
+          index === 2 && <Avatar size={12} teamname={item} isTeam={true} style={styleTeamAvatar} />}
         <FolderHeaderBreadcrumb visibility={visibility} item={item} path={path} />
       </Box>
     )

--- a/shared/fs/header.js
+++ b/shared/fs/header.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import * as Types from '../constants/types/fs'
 import {globalStyles, globalColors, globalMargins, isMobile} from '../styles'
 import {Avatar, Box, ClickableBox, Icon, Text} from '../common-adapters'
 import HeaderConnector from './header-container'
@@ -8,10 +7,10 @@ import HeaderConnector from './header-container'
 type FolderHeaderProps = {
   items: Array<{
     name: string,
-    path: Types.Path,
+    path: string,
   }>,
   isTeamPath: boolean,
-  onOpenBreadcrumb: (path: Types.Path) => void,
+  onOpenBreadcrumb: (path: string) => void,
 }
 
 const FolderHeader = HeaderConnector(({items, isTeamPath, onOpenBreadcrumb}: FolderHeaderProps) => (
@@ -24,7 +23,7 @@ const FolderHeader = HeaderConnector(({items, isTeamPath, onOpenBreadcrumb}: Fol
       <Box style={folderHeaderStyleTree}>
         {items.length < 4 &&
           items.map((i, idx) => (
-            <Box key={Types.pathToString(i.path)} style={folderBreadcrumbStyle}>
+            <Box key={i.path} style={folderBreadcrumbStyle}>
               {idx !== 0 && <Icon type="iconfont-back" style={iconStyle} />}
               {idx === 2 &&
                 isTeamPath && <Avatar size={12} teamname={i.name} isTeam={true} style={styleTeamAvatar} />}

--- a/shared/fs/index.js
+++ b/shared/fs/index.js
@@ -2,21 +2,19 @@
 import * as React from 'react'
 import * as Types from '../constants/types/fs'
 import {globalStyles, globalColors, globalMargins, isMobile} from '../styles'
-import {Box, BackButton, ClickableBox, Icon, List, Text} from '../common-adapters'
+import {Box, ClickableBox, Icon, List, Text} from '../common-adapters'
 import {type IconType} from '../common-adapters/icon'
 import {RowConnector} from './row'
+import FolderHeader from './header'
 
-const stylesCommonCore = {
+const stylesCommonRow = {
+  ...globalStyles.flexBoxRow,
   alignItems: 'center',
   borderBottomColor: globalColors.black_05,
   borderBottomWidth: 1,
   justifyContent: 'center',
-}
-
-const stylesCommonRow = {
-  ...globalStyles.flexBoxRow,
-  ...stylesCommonCore,
   minHeight: isMobile ? 64 : 40,
+  paddingLeft: 16,
 }
 
 const stylesContainer = {
@@ -25,8 +23,10 @@ const stylesContainer = {
   flex: 1,
 }
 
-type FolderHeaderProps = {
-  path: Types.Path,
+const stylesRowBox = {
+  ...globalStyles.flexBoxRow,
+  alignItems: 'center',
+  flex: 1,
 }
 
 type FileRowProps = {
@@ -39,101 +39,21 @@ type FileRowProps = {
 type FolderProps = {
   items: Array<Types.Path>,
   path: Types.Path,
-  onBack: () => void,
 }
 
 const folderBoxStyle = {...globalStyles.flexBoxColumn, flex: 1, justifyContent: 'stretch'}
-
-const folderHeaderStyleRoot = {...stylesCommonRow, alignItems: 'center', borderBottomWidth: 0}
-
-const folderHeaderStyleTree = {
-  ...stylesCommonRow,
-  alignItems: 'left',
-  borderBottomWidth: 0,
-  paddingLeft: 16,
-  paddingRight: 16,
-}
 
 const styleOuterContainer = {
   height: '100%',
   position: 'relative',
 }
 
-const rootHeaderContent = (
-  <Box style={folderHeaderStyleRoot}>
-    <Text type="BodyBig">Keybase Files</Text>
-  </Box>
-)
-
-type FolderHeaderState = {
-  pathElems: Array<string>,
-}
-
-const headerPathStyleParent = {color: globalColors.black_60}
 const iconStyle = {marginRight: globalMargins.small}
-
-class FolderHeader extends React.Component<FolderHeaderProps, FolderHeaderState> {
-  state: FolderHeaderState
-
-  constructor(props) {
-    super(props)
-    this.state = {
-      pathElems: Types.getPathElements(props.path),
-    }
-  }
-
-  componentWillReceiveProps = (nextProps: FolderHeaderProps) => {
-    this.setState(prevState => ({pathElems: Types.getPathElements(nextProps.path)}))
-  }
-
-  _renderItem = (index, item) => {
-    switch (this.state.pathElems.length) {
-      case 2:
-      // {private, public, team}
-      // fallthrough
-      case 3:
-        // TLF
-        let separator = <Icon type="iconfont-back" style={{...iconStyle}} />
-        if (index === 0) {
-          separator = null
-        }
-        if (index === this.state.pathElems.length - 1) {
-          return (
-            <Box>
-              {separator}(<Text type="BodyBig">{item}</Text>)
-            </Box>
-          )
-        } else {
-          return (
-            <Box>
-              {separator}(<Text type="BodySmallSemibold" style={{...headerPathStyleParent}}>
-                {item}
-              </Text>)
-            </Box>
-          )
-        }
-      default:
-      // Subfolder within TLF
-    }
-  }
-
-  render() {
-    let content = rootHeaderContent
-    if (this.state.pathElems.length > 1) {
-      content = (
-        <Box style={{...folderHeaderStyleTree}}>
-          <List items={this.state.pathElems} renderItem={this._renderItem} />
-        </Box>
-      )
-    }
-    return <Box>{content}</Box>
-  }
-}
 
 const FileRow = RowConnector(({path, name, icon, onOpen}: FileRowProps) => (
   <ClickableBox onClick={onOpen} style={stylesCommonRow}>
-    <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', flex: 1}}>
-      <Icon type={icon} style={{...iconStyle}} />
+    <Box style={stylesRowBox}>
+      <Icon type={icon} style={iconStyle} />
       <Box style={folderBoxStyle}>
         <Text type="Body">{name}</Text>
       </Box>
@@ -145,16 +65,10 @@ class Files extends React.PureComponent<FolderProps> {
   _renderRow = (index, item) => <FileRow key={Types.pathToString(item)} path={item} />
 
   render() {
-    const {onBack, path, items} = this.props
+    const {path, items} = this.props
     return (
       <Box style={styleOuterContainer}>
         <Box style={stylesContainer}>
-          {onBack &&
-            Types.pathToString(path) !== '/keybase' && (
-              <Box style={globalStyles.flexBoxColumn}>
-                <BackButton onClick={onBack} style={{left: 16, position: 'absolute', top: 16}} />
-              </Box>
-            )}
           <FolderHeader path={path} />
           <List items={items} renderItem={this._renderRow} />
         </Box>

--- a/shared/fs/index.js
+++ b/shared/fs/index.js
@@ -26,7 +26,7 @@ const stylesContainer = {
 }
 
 type FolderHeaderProps = {
-  title: string,
+  path: Types.Path,
 }
 
 type FileRowProps = {
@@ -44,25 +44,96 @@ type FolderProps = {
 
 const folderBoxStyle = {...globalStyles.flexBoxColumn, flex: 1, justifyContent: 'stretch'}
 
-const folderHeaderStyle = {...stylesCommonRow, alignItems: 'center', borderBottomWidth: 0}
+const folderHeaderStyleRoot = {...stylesCommonRow, alignItems: 'center', borderBottomWidth: 0}
+
+const folderHeaderStyleTree = {
+  ...stylesCommonRow,
+  alignItems: 'left',
+  borderBottomWidth: 0,
+  paddingLeft: 16,
+  paddingRight: 16,
+}
 
 const styleOuterContainer = {
   height: '100%',
   position: 'relative',
 }
 
-const FolderHeader = ({title}: FolderHeaderProps) => (
-  <Box>
-    <Box style={folderHeaderStyle}>
-      <Text type="BodyBig">{title}</Text>
-    </Box>
+const rootHeaderContent = (
+  <Box style={folderHeaderStyleRoot}>
+    <Text type="BodyBig">Keybase Files</Text>
   </Box>
 )
+
+type FolderHeaderState = {
+  pathElems: Array<string>,
+}
+
+const headerPathStyleParent = {color: globalColors.black_60}
+const iconStyle = {marginRight: globalMargins.small}
+
+class FolderHeader extends React.Component<FolderHeaderProps, FolderHeaderState> {
+  state: FolderHeaderState
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      pathElems: Types.getPathElements(props.path),
+    }
+  }
+
+  componentWillReceiveProps = (nextProps: FolderHeaderProps) => {
+    this.setState(prevState => ({pathElems: Types.getPathElements(nextProps.path)}))
+  }
+
+  _renderItem = (index, item) => {
+    switch (this.state.pathElems.length) {
+      case 2:
+      // {private, public, team}
+      // fallthrough
+      case 3:
+        // TLF
+        let separator = <Icon type="iconfont-back" style={{...iconStyle}} />
+        if (index === 0) {
+          separator = null
+        }
+        if (index === this.state.pathElems.length - 1) {
+          return (
+            <Box>
+              {separator}(<Text type="BodyBig">{item}</Text>)
+            </Box>
+          )
+        } else {
+          return (
+            <Box>
+              {separator}(<Text type="BodySmallSemibold" style={{...headerPathStyleParent}}>
+                {item}
+              </Text>)
+            </Box>
+          )
+        }
+      default:
+      // Subfolder within TLF
+    }
+  }
+
+  render() {
+    let content = rootHeaderContent
+    if (this.state.pathElems.length > 1) {
+      content = (
+        <Box style={{...folderHeaderStyleTree}}>
+          <List items={this.state.pathElems} renderItem={this._renderItem} />
+        </Box>
+      )
+    }
+    return <Box>{content}</Box>
+  }
+}
 
 const FileRow = RowConnector(({path, name, icon, onOpen}: FileRowProps) => (
   <ClickableBox onClick={onOpen} style={stylesCommonRow}>
     <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', flex: 1}}>
-      <Icon type={icon} style={{marginRight: globalMargins.small}} />
+      <Icon type={icon} style={{...iconStyle}} />
       <Box style={folderBoxStyle}>
         <Text type="Body">{name}</Text>
       </Box>
@@ -84,7 +155,7 @@ class Files extends React.PureComponent<FolderProps> {
                 <BackButton onClick={onBack} style={{left: 16, position: 'absolute', top: 16}} />
               </Box>
             )}
-          <FolderHeader title={'Folders: ' + Types.pathToString(path)} />
+          <FolderHeader path={path} />
           <List items={items} renderItem={this._renderRow} />
         </Box>
       </Box>

--- a/shared/fs/index.js
+++ b/shared/fs/index.js
@@ -4,7 +4,7 @@ import * as Types from '../constants/types/fs'
 import {globalStyles, globalColors, globalMargins, isMobile} from '../styles'
 import {Box, ClickableBox, Icon, List, Text} from '../common-adapters'
 import {type IconType} from '../common-adapters/icon'
-import {RowConnector} from './row'
+import RowConnector from './row'
 import FolderHeader from './header'
 
 const stylesCommonRow = {

--- a/shared/fs/index.stories.js
+++ b/shared/fs/index.stories.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react'
 import * as Types from '../constants/types/fs'
-import {Box} from '../common-adapters'
 import {action, storiesOf, createPropProvider} from '../stories/storybook'
 import Files from '.'
 
@@ -16,17 +15,26 @@ const provider = createPropProvider({
     ],
     onOpenBreadcrumb: action('onOpenBreadcrumb'),
   }),
+  FileRow: ({path}: {path: Types.Path}) => ({
+    icon: 'icon-folder-private-24',
+    name: Types.getPathName(path),
+    path,
+    onOpen: () => {},
+  }),
 })
 
 const load = () => {
   storiesOf('Files', module)
     .addDecorator(provider)
     .add('Root', () => (
-      <Box style={{width: '100%'}}>
-        <Files path={Types.stringToPath('/keybase')} items={[]} onBack={() => {}} />
-        <Files path={Types.stringToPath('/keybase/private')} items={[]} onBack={() => {}} />
-        <Files path={Types.stringToPath('/keybase/public')} items={[]} onBack={() => {}} />
-      </Box>
+      <Files
+        path={Types.stringToPath('/keybase')}
+        items={[
+          Types.stringToPath('/keybase/private'),
+          Types.stringToPath('/keybase/public'),
+          Types.stringToPath('/keybase/team'),
+        ]}
+      />
     ))
 }
 

--- a/shared/fs/index.stories.js
+++ b/shared/fs/index.stories.js
@@ -2,17 +2,32 @@
 import React from 'react'
 import * as Types from '../constants/types/fs'
 import {Box} from '../common-adapters'
-import {storiesOf} from '../stories/storybook'
+import {action, storiesOf, createPropProvider} from '../stories/storybook'
 import Files from '.'
 
+const provider = createPropProvider({
+  FolderHeader: () => ({
+    isTeamPath: false,
+    items: [
+      {
+        name: 'keybase',
+        path: '/keybase',
+      },
+    ],
+    onOpenBreadcrumb: action('onOpenBreadcrumb'),
+  }),
+})
+
 const load = () => {
-  storiesOf('Files', module).add('Root', () => (
-    <Box style={{width: '100%'}}>
-      <Files path={Types.stringToPath('/keybase')} items={[]} onBack={() => {}} />
-      <Files path={Types.stringToPath('/keybase/private')} items={[]} onBack={() => {}} />
-      <Files path={Types.stringToPath('/keybase/public')} items={[]} onBack={() => {}} />
-    </Box>
-  ))
+  storiesOf('Files', module)
+    .addDecorator(provider)
+    .add('Root', () => (
+      <Box style={{width: '100%'}}>
+        <Files path={Types.stringToPath('/keybase')} items={[]} onBack={() => {}} />
+        <Files path={Types.stringToPath('/keybase/private')} items={[]} onBack={() => {}} />
+        <Files path={Types.stringToPath('/keybase/public')} items={[]} onBack={() => {}} />
+      </Box>
+    ))
 }
 
 export default load

--- a/shared/fs/row.js
+++ b/shared/fs/row.js
@@ -1,6 +1,6 @@
 // @flow
 import * as Types from '../constants/types/fs'
-import {connect, type TypedState, type Dispatch} from '../util/container'
+import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../util/container'
 import {isMobile} from '../constants/platform'
 import {navigateAppend} from '../actions/route-tree'
 import type {IconType} from '../common-adapters/icon'
@@ -45,5 +45,4 @@ const mergeProps = ({type, path}, {_onOpen}: DispatchProps) => {
   }
 }
 
-const RowConnector = connect(mapStateToProps, mapDispatchToProps, mergeProps)
-export {RowConnector}
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps), setDisplayName('FileRow'))

--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -27050,28 +27050,13 @@ exports[`Storyshots Edit team description Description unchanged 1`] = `
 exports[`Storyshots Files Root 1`] = `
 .glamor-0,
 [data-glamor-0] {
-  font-size: 13px;
-  line-height: 20px;
-  color: #000000;
+  font-size: 14px;
+  line-height: 18px;
+  color: rgba(0, 0, 0, 0.75);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
-  font-family: Source Code Pro;
-  margin-bottom: 8px;
-}
-
-.glamor-1,
-[data-glamor-1] {
-  font-size: 13px;
-  line-height: 20px;
-  color: #a8d7ff;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  font-family: Source Code Pro;
-  user-select: text;
-  cursor: text;
-  -webkit-user-select: text;
-  -moz-user-select: text;
-  -ms-user-select: text;
+  font-family: OpenSans;
+  font-weight: 600;
 }
 
 <div
@@ -27092,58 +27077,74 @@ exports[`Storyshots Files Root 1`] = `
     <div
       style={
         Object {
-          "borderColor": "rgba(255,0,0,0.75)",
-          "borderStyle": "solid",
-          "borderWidth": 2,
-          "display": "flex",
-          "flexDirection": "column",
-          "padding": 10,
+          "height": "100%",
+          "position": "relative",
         }
       }
     >
-      <span
-        className="glamor-0"
-        onClick={undefined}
-        title={undefined}
-      >
-        🛑 An error occurred in a connected child component. Did you supply all props the child expects?
-      </span>
       <div
         style={
           Object {
-            "backgroundColor": "#003563",
-            "borderRadius": 4,
             "display": "flex",
+            "flex": 1,
             "flexDirection": "column",
-            "padding": 10,
-            "whiteSpace": "pre-line",
+            "height": "100%",
           }
         }
       >
-        <span
-          className="glamor-1"
-          onClick={undefined}
-          title={undefined}
+        <div>
+          <div
+            style={
+              Object {
+                "alignItems": "center",
+                "borderBottomColor": "rgba(0, 0, 0, 0.05)",
+                "borderBottomWidth": 1,
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "minHeight": 48,
+              }
+            }
+          >
+            <span
+              className="glamor-0"
+              onClick={undefined}
+              title={undefined}
+            >
+              Keybase Files
+            </span>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "flexGrow": 1,
+              "position": "relative",
+            }
+          }
         >
-          Error: In calling propSelector for Component: 
-          Your propProvider is probably missing a key for this connected component. See shared/storybook/README.md for more details.
-
-          TypeError: state[name] is not a function
-          
-    in ConnectAdvanced(Component) (created by Files)
-    in div (created by Box)
-    in Box (created by Files)
-    in div (created by Box)
-    in Box (created by Files)
-    in Files
-    in div (created by Box)
-    in Box
-    in StorybookErrorBoundary
-    in Provider
-    in div (created by ScrollView)
-    in div (created by ScrollView)
-    in ScrollView
-        </span>
+          <div
+            style={
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "height": "100%",
+                  "overflowY": "auto",
+                  "width": "100%",
+                }
+              }
+            />
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -27050,30 +27050,28 @@ exports[`Storyshots Edit team description Description unchanged 1`] = `
 exports[`Storyshots Files Root 1`] = `
 .glamor-0,
 [data-glamor-0] {
-  font-size: 14px;
-  line-height: 18px;
-  color: rgba(0, 0, 0, 0.75);
+  font-size: 13px;
+  line-height: 20px;
+  color: #000000;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
-  font-family: OpenSans;
-  font-weight: 600;
+  font-family: Source Code Pro;
+  margin-bottom: 8px;
 }
 
 .glamor-1,
 [data-glamor-1] {
-  color: rgba(0, 0, 0, 0.40);
-}
-
-.glamor-2,
-[data-glamor-2] {
   font-size: 13px;
-  line-height: 17px;
-  color: #33a0ff;
-  cursor: pointer;
+  line-height: 20px;
+  color: #a8d7ff;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
-  font-family: OpenSans;
-  font-weight: 400;
+  font-family: Source Code Pro;
+  user-select: text;
+  cursor: text;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
 }
 
 <div
@@ -27094,340 +27092,58 @@ exports[`Storyshots Files Root 1`] = `
     <div
       style={
         Object {
-          "width": "100%",
+          "borderColor": "rgba(255,0,0,0.75)",
+          "borderStyle": "solid",
+          "borderWidth": 2,
+          "display": "flex",
+          "flexDirection": "column",
+          "padding": 10,
         }
       }
     >
+      <span
+        className="glamor-0"
+        onClick={undefined}
+        title={undefined}
+      >
+        🛑 An error occurred in a connected child component. Did you supply all props the child expects?
+      </span>
       <div
         style={
           Object {
-            "height": "100%",
-            "position": "relative",
+            "backgroundColor": "#003563",
+            "borderRadius": 4,
+            "display": "flex",
+            "flexDirection": "column",
+            "padding": 10,
+            "whiteSpace": "pre-line",
           }
         }
       >
-        <div
-          style={
-            Object {
-              "display": "flex",
-              "flex": 1,
-              "flexDirection": "column",
-              "height": "100%",
-            }
-          }
+        <span
+          className="glamor-1"
+          onClick={undefined}
+          title={undefined}
         >
-          <div>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "borderBottomColor": "rgba(0, 0, 0, 0.05)",
-                  "borderBottomWidth": 0,
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "minHeight": 40,
-                }
-              }
-            >
-              <span
-                className="glamor-0"
-                onClick={undefined}
-                title={undefined}
-              >
-                Folders: /keybase
-              </span>
-            </div>
-          </div>
-          <div
-            style={
-              Object {
-                "flexGrow": 1,
-                "position": "relative",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "height": "100%",
-                    "overflowY": "auto",
-                    "width": "100%",
-                  }
-                }
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "height": "100%",
-            "position": "relative",
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "display": "flex",
-              "flex": 1,
-              "flexDirection": "column",
-              "height": "100%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "display": "flex",
-                "flexDirection": "column",
-              }
-            }
-          >
-            <div
-              onClick={[Function]}
-              style={
-                Object {
-                  "alignItems": "center",
-                  "cursor": "pointer",
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "left": 16,
-                  "position": "absolute",
-                  "top": 16,
-                }
-              }
-            >
-              <div>
-                <span
-                  className="glamor-1"
-                  onClick={null}
-                  onMouseEnter={undefined}
-                  onMouseLeave={undefined}
-                  style={
-                    Object {
-                      "WebkitFontSmoothing": "antialiased",
-                      "fontFamily": "kb",
-                      "fontSize": 16,
-                      "fontStyle": "normal",
-                      "fontVariant": "normal",
-                      "fontWeight": "normal",
-                      "lineHeight": 1,
-                      "marginRight": 6,
-                      "speak": "none",
-                      "textTransform": "none",
-                      "userSelect": "none",
-                    }
-                  }
-                >
-                  
-                </span>
-              </div>
-              <span
-                className="glamor-2"
-                onClick={[Function]}
-                title={undefined}
-              >
-                Back
-              </span>
-            </div>
-          </div>
-          <div>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "borderBottomColor": "rgba(0, 0, 0, 0.05)",
-                  "borderBottomWidth": 0,
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "minHeight": 40,
-                }
-              }
-            >
-              <span
-                className="glamor-0"
-                onClick={undefined}
-                title={undefined}
-              >
-                Folders: /keybase/private
-              </span>
-            </div>
-          </div>
-          <div
-            style={
-              Object {
-                "flexGrow": 1,
-                "position": "relative",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "height": "100%",
-                    "overflowY": "auto",
-                    "width": "100%",
-                  }
-                }
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "height": "100%",
-            "position": "relative",
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "display": "flex",
-              "flex": 1,
-              "flexDirection": "column",
-              "height": "100%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "display": "flex",
-                "flexDirection": "column",
-              }
-            }
-          >
-            <div
-              onClick={[Function]}
-              style={
-                Object {
-                  "alignItems": "center",
-                  "cursor": "pointer",
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "left": 16,
-                  "position": "absolute",
-                  "top": 16,
-                }
-              }
-            >
-              <div>
-                <span
-                  className="glamor-1"
-                  onClick={null}
-                  onMouseEnter={undefined}
-                  onMouseLeave={undefined}
-                  style={
-                    Object {
-                      "WebkitFontSmoothing": "antialiased",
-                      "fontFamily": "kb",
-                      "fontSize": 16,
-                      "fontStyle": "normal",
-                      "fontVariant": "normal",
-                      "fontWeight": "normal",
-                      "lineHeight": 1,
-                      "marginRight": 6,
-                      "speak": "none",
-                      "textTransform": "none",
-                      "userSelect": "none",
-                    }
-                  }
-                >
-                  
-                </span>
-              </div>
-              <span
-                className="glamor-2"
-                onClick={[Function]}
-                title={undefined}
-              >
-                Back
-              </span>
-            </div>
-          </div>
-          <div>
-            <div
-              style={
-                Object {
-                  "alignItems": "center",
-                  "borderBottomColor": "rgba(0, 0, 0, 0.05)",
-                  "borderBottomWidth": 0,
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "minHeight": 40,
-                }
-              }
-            >
-              <span
-                className="glamor-0"
-                onClick={undefined}
-                title={undefined}
-              >
-                Folders: /keybase/public
-              </span>
-            </div>
-          </div>
-          <div
-            style={
-              Object {
-                "flexGrow": 1,
-                "position": "relative",
-              }
-            }
-          >
-            <div
-              style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                }
-              }
-            >
-              <div
-                style={
-                  Object {
-                    "height": "100%",
-                    "overflowY": "auto",
-                    "width": "100%",
-                  }
-                }
-              />
-            </div>
-          </div>
-        </div>
+          Error: In calling propSelector for Component: 
+          Your propProvider is probably missing a key for this connected component. See shared/storybook/README.md for more details.
+
+          TypeError: state[name] is not a function
+          
+    in ConnectAdvanced(Component) (created by Files)
+    in div (created by Box)
+    in Box (created by Files)
+    in div (created by Box)
+    in Box (created by Files)
+    in Files
+    in div (created by Box)
+    in Box
+    in StorybookErrorBoundary
+    in Provider
+    in div (created by ScrollView)
+    in div (created by ScrollView)
+    in ScrollView
+        </span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Root:
<kbd>
<img width="325" alt="screen shot 2018-02-06 at 5 06 04 pm" src="https://user-images.githubusercontent.com/59594/35892844-12a5069c-0b60-11e8-9e01-64a5e4613486.png">
</kbd>

Inside navigation tree:
<kbd>
<img width="168" alt="screen shot 2018-02-06 at 5 06 00 pm" src="https://user-images.githubusercontent.com/59594/35892846-163c2588-0b60-11e8-9a72-bb34955482b8.png">
</kbd>

TODO: reverse the arrow once the new font is in (cc @cecileboucheron)

cc @keybase/react-hackers 