### PR TITLE
introduce UPAKFinder to cache upak results within a single chat request

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -888,7 +888,7 @@ func (b *Boxer) UnboxThread(ctx context.Context, boxed chat1.ThreadViewBoxed, co
 }
 
 func (b *Boxer) getUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (string, string, string, error) {
-	nun, devName, devType, err := b.G().GetUPAKLoader().LookupUsernameAndDevice(ctx, uid, deviceID)
+	nun, devName, devType, err := CtxUPAKFinder(ctx, b.G()).LookupUsernameAndDevice(ctx, uid, deviceID)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -1481,7 +1481,7 @@ func (b *Boxer) ValidSenderKey(ctx context.Context, sender gregor1.UID, key []by
 	kid := keybase1.KIDFromSlice(key)
 	ctime2 := gregor1.FromTime(ctime)
 
-	cachedUserLoader := b.G().GetUPAKLoader()
+	cachedUserLoader := CtxUPAKFinder(ctx, b.G())
 	if cachedUserLoader == nil {
 		return false, false, nil, NewTransientUnboxingError(fmt.Errorf("no CachedUserLoader available in context"))
 	}

--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -19,11 +19,13 @@ type keyfinderKey int
 type identifyNotifierKey int
 type chatTrace int
 type identifyModeKey int
+type upakfinderKey int
 
 var kfKey keyfinderKey
 var inKey identifyNotifierKey
 var chatTraceKey chatTrace
 var identModeKey identifyModeKey
+var upKey upakfinderKey
 
 type identModeData struct {
 	mode   keybase1.TLFIdentifyBehavior
@@ -65,6 +67,16 @@ func CtxIdentifyNotifier(ctx context.Context) types.IdentifyNotifier {
 		return in
 	}
 	return nil
+}
+
+func CtxUPAKFinder(ctx context.Context, g *globals.Context) types.UPAKFinder {
+	var up types.UPAKFinder
+	var ok bool
+	val := ctx.Value(upKey)
+	if up, ok = val.(types.UPAKFinder); ok {
+		return up
+	}
+	return NewCachingUPAKFinder(g)
 }
 
 func CtxModifyIdentifyNotifier(ctx context.Context, notifier types.IdentifyNotifier) context.Context {
@@ -113,6 +125,10 @@ func Context(ctx context.Context, g *globals.Context, mode keybase1.TLFIdentifyB
 	val = res.Value(inKey)
 	if _, ok := val.(types.IdentifyNotifier); !ok {
 		res = context.WithValue(res, inKey, notifier)
+	}
+	val = res.Value(upKey)
+	if _, ok := val.(types.UPAKFinder); !ok {
+		res = context.WithValue(res, upKey, NewCachingUPAKFinder(g))
 	}
 	res = CtxAddLogTags(res, g.GetEnv())
 	return res

--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -149,6 +149,7 @@ func BackgroundContext(sourceCtx context.Context, g *globals.Context) context.Co
 	}
 
 	rctx = context.WithValue(rctx, kfKey, CtxKeyFinder(sourceCtx, g))
+	rctx = context.WithValue(rctx, upKey, CtxUPAKFinder(sourceCtx, g))
 	rctx = context.WithValue(rctx, inKey, in)
 
 	return rctx

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3068,15 +3068,6 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(res.Conversations), "no convs found")
 		consumeIdentify(ctx, listener1) //impteam
-
-		// Check to see if we accounted for all identifies
-		select {
-		case <-listener0.identifyUpdate:
-			require.Fail(t, "leftover identifies 0")
-		case <-listener1.identifyUpdate:
-			require.Fail(t, "leftover identifies 1")
-		default:
-		}
 	})
 }
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -192,3 +192,7 @@ type IdentifyNotifier interface {
 	ResetOnGUIConnect()
 	Send(ctx context.Context, update keybase1.CanonicalTLFNameAndIDWithBreaks)
 }
+type UPAKFinder interface {
+	LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (username string, deviceName string, deviceType string, err error)
+	CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error)
+}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/keybase/client/go/gregor"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -193,6 +194,6 @@ type IdentifyNotifier interface {
 	Send(ctx context.Context, update keybase1.CanonicalTLFNameAndIDWithBreaks)
 }
 type UPAKFinder interface {
-	LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (username string, deviceName string, deviceType string, err error)
+	LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (username libkb.NormalizedUsername, deviceName string, deviceType string, err error)
 	CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error)
 }

--- a/go/chat/upakfinder.go
+++ b/go/chat/upakfinder.go
@@ -1,0 +1,115 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type udStoredRes struct {
+	username               libkb.NormalizedUsername
+	deviceName, deviceType string
+}
+
+type checkKidStoredRes struct {
+	found     bool
+	revokedAt *keybase1.KeybaseTime
+	deleted   bool
+}
+
+type UPAKFinder struct {
+	globals.Contextified
+	utils.DebugLabeler
+
+	udLock        sync.RWMutex
+	udCache       map[string]udStoredRes
+	checkKidLock  sync.RWMutex
+	checkKidCache map[string]checkKidStoredRes
+}
+
+func NewUPAKFinder(g *globals.Context) *UPAKFinder {
+	return &UPAKFinder{
+		Contextified:  globals.NewContextified(g),
+		DebugLabeler:  utils.NewDebugLabeler(g.GetLog(), "UPAKFinder", false),
+		udCache:       make(map[string]udStoredRes),
+		checkKidCache: make(map[string]checkKidStoredRes),
+	}
+}
+
+func (u *UPAKFinder) udKey(uid keybase1.UID, deviceID keybase1.DeviceID) string {
+	return fmt.Sprintf("ud:%s:%s", uid, deviceID)
+}
+
+func (u *UPAKFinder) checkKidKey(uid keybase1.UID, kid keybase1.KID) string {
+	return fmt.Sprintf("ck:%s:%s", uid, kid)
+}
+
+func (u *UPAKFinder) lookupUDKey(key string) (udStoredRes, bool) {
+	u.udLock.RLock()
+	defer u.udLock.RUnlock()
+	existing, ok := u.udCache[key]
+	return existing, ok
+}
+
+func (u *UPAKFinder) writeUDKey(key string, username libkb.NormalizedUsername, deviceName, deviceType string) {
+	u.udLock.Lock()
+	defer u.udLock.Unlock()
+	u.udCache[key] = udStoredRes{
+		username:   username,
+		deviceName: deviceName,
+		deviceType: deviceType,
+	}
+}
+
+func (u *UPAKFinder) lookupCheckKidKey(key string) (checkKidStoredRes, bool) {
+	u.checkKidLock.RLock()
+	defer u.checkKidLock.RUnlock()
+	existing, ok := u.checkKidCache[key]
+	return existing, ok
+}
+
+func (u *UPAKFinder) writeCheckKidKey(key string, found bool, revokedAt *keybase1.KeybaseTime,
+	deleted bool) {
+	u.checkKidLock.Lock()
+	defer u.checkKidLock.Unlock()
+	u.checkKidCache[key] = checkKidStoredRes{
+		found:     found,
+		revokedAt: revokedAt,
+		deleted:   deleted,
+	}
+}
+
+func (u *UPAKFinder) LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (username libkb.NormalizedUsername, deviceName string, deviceType string, err error) {
+	defer u.Trace(ctx, func() error { return err }, "LookupUsernameAndDevice")()
+	key := u.udKey(uid, deviceID)
+	existing, ok := u.lookupUDKey(key)
+	if ok {
+		return existing.username, existing.deviceName, existing.deviceType, nil
+	}
+	defer func() {
+		if err == nil {
+			u.writeUDKey(key, username, deviceName, deviceType)
+		}
+	}()
+	return u.G().GetUPAKLoader().LookupUsernameAndDevice(ctx, uid, deviceID)
+}
+
+func (u *UPAKFinder) CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error) {
+	defer u.Trace(ctx, func() error { return err }, "CheckKIDForUID")()
+	key := u.checkKidKey(uid, kid)
+	existing, ok := u.lookupCheckKidKey(key)
+	if ok {
+		return existing.found, existing.revokedAt, existing.deleted, nil
+	}
+	defer func() {
+		if err == nil {
+			u.writeCheckKidKey(key, found, revokedAt, deleted)
+		}
+	}()
+	return u.G().GetUPAKLoader().CheckKIDForUID(ctx, uid, kid)
+}

--- a/go/chat/upakfinder.go
+++ b/go/chat/upakfinder.go
@@ -85,7 +85,7 @@ func (u *CachingUPAKFinder) writeCheckKidKey(key string, found bool, revokedAt *
 }
 
 func (u *CachingUPAKFinder) LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (username libkb.NormalizedUsername, deviceName string, deviceType string, err error) {
-	defer u.Trace(ctx, func() error { return err }, "LookupUsernameAndDevice")()
+	defer u.Trace(ctx, func() error { return err }, "LookupUsernameAndDevice(%s,%s)", uid, deviceID)()
 	key := u.udKey(uid, deviceID)
 	existing, ok := u.lookupUDKey(key)
 	if ok {
@@ -100,7 +100,7 @@ func (u *CachingUPAKFinder) LookupUsernameAndDevice(ctx context.Context, uid key
 }
 
 func (u *CachingUPAKFinder) CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error) {
-	defer u.Trace(ctx, func() error { return err }, "CheckKIDForUID")()
+	defer u.Trace(ctx, func() error { return err }, "CheckKIDForUID(%s,%s)", uid, kid)()
 	key := u.checkKidKey(uid, kid)
 	existing, ok := u.lookupCheckKidKey(key)
 	if ok {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1027,6 +1027,14 @@ func (c ByMsgUnboxedCtime) Less(i, j int) bool {
 	return c[i].Valid().ServerHeader.Ctime.Before(c[j].Valid().ServerHeader.Ctime)
 }
 
+type ByMsgUnboxedMsgID []chat1.MessageUnboxed
+
+func (c ByMsgUnboxedMsgID) Len() int      { return len(c) }
+func (c ByMsgUnboxedMsgID) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c ByMsgUnboxedMsgID) Less(i, j int) bool {
+	return c[i].GetMessageID() > c[j].GetMessageID()
+}
+
 func GetTopicName(conv chat1.ConversationLocal) string {
 	maxTopicMsg, err := conv.GetMaxMessage(chat1.MessageType_METADATA)
 	if err != nil {

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -3,6 +3,7 @@ package libkb
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -246,6 +247,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 
 	defer g.CVTrace(ctx, VLog0, culDebug(arg.uid), func() error { return err })()
 
+	debug.PrintStack()
 	if arg.uid.IsNil() {
 		if len(arg.name) == 0 {
 			return nil, nil, errors.New("need a UID or username to load UPAK from loader")

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -3,7 +3,6 @@ package libkb
 import (
 	"errors"
 	"fmt"
-	"runtime/debug"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -247,7 +246,6 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 
 	defer g.CVTrace(ctx, VLog0, culDebug(arg.uid), func() error { return err })()
 
-	debug.PrintStack()
 	if arg.uid.IsNil() {
 		if len(arg.name) == 0 {
 			return nil, nil, errors.New("need a UID or username to load UPAK from loader")


### PR DESCRIPTION
So `CachedUPAKLoader` is actually kind of slow even when hitting its in-memory cache, so we introduce the `UPAKFinder` to chat which will cache the results of the methods we care about in the current context. 

cc @maxtaco 