### PR TITLE
Show channel creation errors

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -614,7 +614,7 @@ function* _createChannel(action: TeamsGen.CreateChannelPayload) {
     yield Saga.put(ChatGen.createSelectConversation({conversationIDKey: newConversationIDKey}))
     yield Saga.put(navigateTo([chatTab]))
   } catch (error) {
-    yield Saga.put(TeamsGen.createSetTeamCreationError({error: error.desc}))
+    yield Saga.put(TeamsGen.createSetChannelCreationError({error: error.desc}))
   }
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

Looks like just a copy-paste typo, we were using the teamCreationError action instead of channelCreationError action when we get an error back from the service.