### PR TITLE
Use selectable property almost everywhere

### DIFF
--- a/shared/app/global-errors/index.desktop.js
+++ b/shared/app/global-errors/index.desktop.js
@@ -123,7 +123,7 @@ class GlobalError extends Component<Props, State> {
             <Icon type="iconfont-close" onClick={onDismiss} style={{color: globalColors.white_75}} />
           )}
         </Box>
-        <Text type="BodyBig" style={detailStyle}>
+        <Text type="BodyBig" selectable={true} style={detailStyle}>
           {details}
         </Text>
       </Box>
@@ -167,7 +167,6 @@ const summaryRowErrorStyle = {
 }
 
 const detailStyle = {
-  ...globalStyles.selectable,
   backgroundColor: globalColors.black_75,
   color: globalColors.white_75,
   padding: 8,

--- a/shared/app/global-errors/index.native.js
+++ b/shared/app/global-errors/index.native.js
@@ -116,7 +116,7 @@ class GlobalError extends Component<Props, State> {
           </Box>
         </NativeTouchableWithoutFeedback>
         <NativeScrollView>
-          <Text type="BodySmall" style={detailStyle}>
+          <Text type="BodySmall" selectable={true} style={detailStyle}>
             {this.props.error && this.props.error.message}
             {'\n\n'}
             {details}
@@ -149,7 +149,6 @@ const summaryRowStyle = {
 }
 
 const detailStyle = {
-  ...globalStyles.selectable,
   color: globalColors.white_75,
   fontSize: 13,
   lineHeight: 17,

--- a/shared/chat/conversation/block-conversation-warning/index.desktop.js
+++ b/shared/chat/conversation/block-conversation-warning/index.desktop.js
@@ -25,10 +25,7 @@ const Contents = ({conversationIDKey, onBack, participants, onBlock, onBlockAndR
     <Text type="Body" style={{marginTop: globalMargins.small}}>
       To unblock it, run:
     </Text>
-    <Text
-      type="Terminal"
-      style={{...globalStyles.selectable, alignSelf: 'center', marginTop: globalMargins.small}}
-    >
+    <Text type="Terminal" selectable={true} style={{alignSelf: 'center', marginTop: globalMargins.small}}>
       keybase chat hide -u {participants}
     </Text>
     <Text type="Body" style={{marginTop: globalMargins.small}}>

--- a/shared/chat/conversation/block-conversation-warning/index.native.js
+++ b/shared/chat/conversation/block-conversation-warning/index.native.js
@@ -39,7 +39,7 @@ const _Contents = ({conversationIDKey, onBack, participants, onBlock, onBlockAnd
             padding: globalMargins.tiny,
           }}
         >
-          <Text type="Terminal" style={{...globalStyles.selectable, alignSelf: 'center'}}>
+          <Text type="Terminal" selectable={true} style={{alignSelf: 'center'}}>
             keybase chat hide -u {participants}
           </Text>
         </Box>

--- a/shared/chat/conversation/messages/text/index.js
+++ b/shared/chat/conversation/messages/text/index.js
@@ -41,13 +41,13 @@ const editingStyle = {
 }
 
 const sentStyle = {
-  ...globalStyles.selectable,
   flex: 1,
   ...(isMobile
     ? {
         color: globalColors.black_75,
       }
     : {
+        ...globalStyles.selectable,
         whiteSpace: 'pre-wrap',
       }),
 }

--- a/shared/chat/conversation/messages/text/index.js
+++ b/shared/chat/conversation/messages/text/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat'
 import {Markdown} from '../../../../common-adapters'
-import {globalStyles, globalColors, isMobile} from '../../../../styles'
+import {globalColors, isMobile} from '../../../../styles'
 
 export type Props = {
   text: string,
@@ -47,8 +47,11 @@ const sentStyle = {
         color: globalColors.black_75,
       }
     : {
-        ...globalStyles.selectable,
         whiteSpace: 'pre-wrap',
+        // Make text selectable. On mobile we implement that
+        // differently.
+        userSelect: 'text',
+        cursor: 'text',
       }),
 }
 

--- a/shared/common-adapters/text.desktop.js
+++ b/shared/common-adapters/text.desktop.js
@@ -92,7 +92,12 @@ function getStyle(
   const cursorStyle = meta.isLink ? {cursor: 'pointer'} : null
   const lineClampStyle = lineClampNum ? lineClamp(lineClampNum) : null
   const clickableStyle = clickable ? globalStyles.clickable : null
-  const selectableStyle = selectable ? globalStyles.selectable : null
+  const selectableStyle = selectable
+    ? {
+        userSelect: 'text',
+        cursor: 'text',
+      }
+    : null
   const textDecoration = meta.isLink && backgroundMode !== 'Normal' ? {textDecoration: 'underline'} : null
 
   return {

--- a/shared/common-adapters/user-proofs.desktop.js
+++ b/shared/common-adapters/user-proofs.desktop.js
@@ -318,7 +318,6 @@ const styleProofNameLabelContainer = {
 }
 
 const styleProofName = {
-  ...globalStyles.selectable,
   ...globalStyles.clickable,
   display: 'inline-block',
   wordBreak: 'break-all',

--- a/shared/common-adapters/user-proofs.desktop.js
+++ b/shared/common-adapters/user-proofs.desktop.js
@@ -29,7 +29,7 @@ function MissingProofRow({missingProof}: {missingProof: MissingProof}): React.No
       </Box>
       <Box style={styleProofNameSection}>
         <Box style={styleProofNameLabelContainer}>
-          <Text className="user-proof-row__name" type="Body" style={styleProofName}>
+          <Text className="user-proof-row__name" type="Body" selectable={true} style={styleProofName}>
             {missingProof.message}
           </Text>
         </Box>
@@ -93,6 +93,7 @@ class ProofRow extends React.PureComponent<ProofRowProps, ProofRowState> {
               className="hover-underline-container"
               type="Body"
               onClick={() => onClickProfile(proof)}
+              selectable={true}
               style={styleProofName}
             >
               <Text
@@ -101,7 +102,6 @@ class ProofRow extends React.PureComponent<ProofRowProps, ProofRowState> {
                 className="hover-underline"
                 style={{
                   ...shared.proofNameStyle(proof),
-                  ...globalStyles.selectable,
                   ...globalStyles.clickable,
                 }}
               >

--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -30,7 +30,7 @@ function MissingProofRow({missingProof, style}: {missingProof: MissingProof, sty
         </Box>
         <Box style={styleProofNameSection}>
           <Box style={styleProofNameLabelContainer}>
-            <Text type="Body" style={{...styleProofName, color: missingColor}}>
+            <Text type="Body" selectable={true} style={{...styleProofName, color: missingColor}}>
               {missingProof.message}
             </Text>
           </Box>
@@ -73,7 +73,7 @@ function ProofRow({proof, onClickStatus, onClickProfile, hasMenu, style}: ProofR
       </Box>
       <Box style={styleProofNameSection}>
         <Box style={styleProofNameLabelContainer}>
-          <Text type="Body" onClick={() => onClickProfile(proof)} style={styleProofName}>
+          <Text type="Body" onClick={() => onClickProfile(proof)} selectable={true} style={styleProofName}>
             <Text type="Body" style={shared.proofNameStyle(proof)}>
               {proof.name}
             </Text>

--- a/shared/login/register/code-page/index.desktop.js
+++ b/shared/login/register/code-page/index.desktop.js
@@ -52,7 +52,7 @@ const CodePageText = ({onBack, textCode, otherDeviceRole, setCodePageMode}) => (
     </Text>
     <SubTitle usePhone={_otherIsPhone(otherDeviceRole)} />
     <DeviceIcon usePhone={_otherIsPhone(otherDeviceRole)} />
-    <Text type="Body" style={stylesPaperkey}>
+    <Text type="Body" selectable={true} style={stylesPaperkey}>
       {textCode}
     </Text>
     {_otherIsPhone(otherDeviceRole) && (
@@ -159,7 +159,6 @@ const stylesContainer = {
 const stylesPaperkey = {
   ...getStyle('Header', 'Normal'),
   ...globalStyles.fontTerminal,
-  ...globalStyles.selectable,
   color: globalColors.darkBlue,
   display: 'inline-block',
   lineHeight: '20px',

--- a/shared/login/register/code-page/index.native.js
+++ b/shared/login/register/code-page/index.native.js
@@ -98,7 +98,7 @@ class CodePage extends Component<Props> {
   renderShowText() {
     return (
       <Box style={stylesShowText}>
-        <Text type="Terminal" style={stylesTextCode}>
+        <Text type="Terminal" selectable={true} style={stylesTextCode}>
           {this.props.textCode}
         </Text>
       </Box>
@@ -347,7 +347,6 @@ const stylesShowText = {
 }
 
 const stylesTextCode = {
-  ...globalStyles.selectable,
   ...globalStyles.fontTerminalSemibold,
   paddingTop: globalMargins.tiny,
   fontSize: 19,

--- a/shared/login/signup/success/index.render.desktop.js
+++ b/shared/login/signup/success/index.render.desktop.js
@@ -21,7 +21,7 @@ class SuccessRender extends Component<Props, State> {
   render() {
     const contents = this.props.paperkey ? (
       <Box style={stylesPaperKeyContainer}>
-        <Text type="Header" style={stylesPaperkey}>
+        <Text type="Header" selectable={true} style={stylesPaperkey}>
           {this.props.paperkey.stringValue()}
         </Text>
         <Icon type="icon-paper-key-corner" style={stylesPaperCorner} />
@@ -98,7 +98,6 @@ const stylesCheck = {
 }
 const stylesPaperkey = {
   ...getStyle('Header', 'Normal'),
-  ...globalStyles.selectable,
   ...globalStyles.fontTerminal,
   color: globalColors.darkBlue,
   display: 'inline-block',

--- a/shared/login/signup/success/index.render.native.js
+++ b/shared/login/signup/success/index.render.native.js
@@ -27,7 +27,7 @@ class SuccessRender extends Component<Props, State> {
         </Text>
 
         <Box style={paperKeyContainerStyle}>
-          <Text type="Header" style={paperkeyStyle}>
+          <Text type="Header" selectable={true} style={paperkeyStyle}>
             {this.props.paperkey.stringValue()}
           </Text>
           <Box style={paperCornerStyle}>

--- a/shared/profile/non-user-profile.desktop.js
+++ b/shared/profile/non-user-profile.desktop.js
@@ -25,12 +25,12 @@ const NonUserRender = (props: Props) => (
           <Avatar url={props.avatar} size={AVATAR_SIZE} />
           <Box style={styleUsernameRow}>
             <Icon type={platformToLogo24(props.serviceName)} />
-            <Text type="HeaderBig" style={styleUsername}>
+            <Text type="HeaderBig" selectable={true} style={styleUsername}>
               {props.username}
             </Text>
           </Box>
           {props.fullname && (
-            <Text type="BodySemibold" style={styleFullname}>
+            <Text type="BodySemibold" selectable={true} style={styleFullname}>
               {props.fullname}
             </Text>
           )}
@@ -104,12 +104,10 @@ const styleUsernameRow = {
 }
 
 const styleUsername = {
-  ...globalStyles.selectable,
   marginLeft: globalMargins.xtiny,
 }
 
 const styleFullname = {
-  ...globalStyles.selectable,
   color: globalColors.black_75,
   marginTop: 2,
 }

--- a/shared/profile/non-user-profile.native.js
+++ b/shared/profile/non-user-profile.native.js
@@ -20,12 +20,12 @@ const NonUserRender = (props: Props) => (
       />
       <Box style={styleUsernameRow} onClick={() => openURL(props.profileUrl)}>
         <Icon type={platformToLogo24(props.serviceName)} />
-        <Text type="HeaderBig" style={styleUsername}>
+        <Text type="HeaderBig" selectable={true} style={styleUsername}>
           {props.username}
         </Text>
       </Box>
       {props.fullname && (
-        <Text type="BodySemibold" style={styleFullname}>
+        <Text type="BodySemibold" selectable={true} style={styleFullname}>
           {props.fullname}
         </Text>
       )}
@@ -72,12 +72,10 @@ const styleUsernameRow = {
 }
 
 const styleUsername = {
-  ...globalStyles.selectable,
   marginLeft: globalMargins.xtiny,
 }
 
 const styleFullname = {
-  ...globalStyles.selectable,
   color: globalColors.black_75,
   marginTop: 2,
 }

--- a/shared/settings/invite-generated/index.desktop.js
+++ b/shared/settings/invite-generated/index.desktop.js
@@ -45,7 +45,7 @@ class InviteGeneratedRender extends Component<Props> {
             type="iconfont-link"
             style={{color: globalColors.black_10, marginRight: globalMargins.tiny, height: 14}}
           />
-          <Text type="BodySemibold" style={{...globalStyles.selectable, color: globalColors.green2}}>
+          <Text type="BodySemibold" selectable={true} style={{color: globalColors.green2}}>
             {this.props.link}
           </Text>
         </Box>

--- a/shared/settings/invites/index.desktop.js
+++ b/shared/settings/invites/index.desktop.js
@@ -179,7 +179,7 @@ function PendingURLContent({invite}: {invite: PendingInvite}) {
           marginTop: 3,
         }}
       />
-      <Text type="Body" style={{...globalStyles.selectable, color: globalColors.blue}}>
+      <Text type="Body" selectable={true} style={{color: globalColors.blue}}>
         {invite.url}
       </Text>
     </Box>

--- a/shared/stories/storybook.shared.js
+++ b/shared/stories/storybook.shared.js
@@ -57,7 +57,7 @@ class StorybookErrorBoundary extends React.Component<
               whiteSpace: 'pre-line',
             }}
           >
-            <Text type="Terminal" backgroundMode="Terminal" style={globalStyles.selectable}>
+            <Text type="Terminal" backgroundMode="Terminal" selectable={true}>
               {this.state.error && this.state.error.toString()}
               {this.state.info && this.state.info.componentStack}
             </Text>

--- a/shared/styles/index.desktop.js
+++ b/shared/styles/index.desktop.js
@@ -88,12 +88,6 @@ const util = {
   scrollable: {
     overflowY: 'auto',
   },
-  // TODO: Get rid of this in favor of the selectable property of Text, since
-  // native doesn't have this style.
-  selectable: {
-    userSelect: 'text',
-    cursor: 'text',
-  },
   noSelect: {
     userSelect: 'none',
   },

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -656,7 +656,7 @@ class Team extends React.PureComponent<Props> {
         )}
         <Box style={stylesTeamHeader}>
           <Avatar isTeam={true} teamname={name} size={64} />
-          <Text type="HeaderBig" style={{...globalStyles.selectable, marginTop: globalMargins.tiny}}>
+          <Text type="HeaderBig" selectable={true} style={{marginTop: globalMargins.tiny}}>
             {name}
           </Text>
           <Box style={globalStyles.flexBoxRow}>

--- a/shared/tracker/non-user.desktop.js
+++ b/shared/tracker/non-user.desktop.js
@@ -38,6 +38,7 @@ const Top = ({onClose, reason, inviteLink, name, isPrivate}) => {
               ref={r => {
                 textRef = r
               }}
+              selectable={true}
               style={stylesLink}
               type="BodySemibold"
             >
@@ -122,7 +123,6 @@ const stylesLinkBox = {
 }
 
 const stylesLink = {
-  ...globalStyles.selectable,
   ...globalStyles.windowDraggingClickable,
   marginLeft: 7,
   color: globalColors.green2,


### PR DESCRIPTION
Add selectable property in some native Text blocks, to match desktop
side.

Remove globalStyles.selectable.