### PR TITLE
Work around truncated log lines

### DIFF
--- a/shared/logger/__test__/native-logger.test.js
+++ b/shared/logger/__test__/native-logger.test.js
@@ -11,4 +11,44 @@ describe('parseLine', () => {
     expect(ts2).toEqual(ts)
     expect(logLine2).toEqual(logLine)
   })
+
+  it('parse with whitespace', () => {
+    const ts = Date.now()
+    const logLine = 'test log line'
+
+    {
+      const [ts2, logLine2] = parseLine(`[${ts}, "${logLine}"]`)
+      expect(ts2).toEqual(ts)
+      expect(logLine2).toEqual(logLine)
+    }
+
+    {
+      const [ts2, logLine2] = parseLine(` [  ${ts}  ,  "${logLine}" ]`)
+      expect(ts2).toEqual(ts)
+      expect(logLine2).toEqual(logLine)
+    }
+
+    {
+      const [ts2, logLine2] = parseLine(`[${ts},"${logLine}"]`)
+      expect(ts2).toEqual(ts)
+      expect(logLine2).toEqual(logLine)
+    }
+  })
+
+  it('parse truncated', () => {
+    const ts = Date.now()
+    const logLine = 'test log line'
+
+    {
+      const [ts2, logLine2] = parseLine(`[${ts}, "${logLine}"`)
+      expect(ts2).toEqual(ts)
+      expect(logLine2).toEqual(logLine)
+    }
+
+    {
+      const [ts2, logLine2] = parseLine(`[${ts}, "${logLine}`)
+      expect(ts2).toEqual(ts)
+      expect(logLine2).toEqual(logLine)
+    }
+  })
 })

--- a/shared/logger/__test__/native-logger.test.js
+++ b/shared/logger/__test__/native-logger.test.js
@@ -35,6 +35,15 @@ describe('parseLine', () => {
     }
   })
 
+  it('parse empty', () => {
+    {
+      const ts = Date.now()
+      const [ts2, logLine2] = parseLine(`[${ts}, ""]`)
+      expect(ts2).toEqual(ts)
+      expect(logLine2).toEqual('')
+    }
+  })
+
   it('parse truncated', () => {
     const ts = Date.now()
     const logLine = 'test log line'

--- a/shared/logger/__test__/native-logger.test.js
+++ b/shared/logger/__test__/native-logger.test.js
@@ -1,0 +1,14 @@
+// @flow
+/* eslint-env jest */
+import {dumpLine, parseLine} from '../native-logger'
+
+describe('parseLine', () => {
+  it('dump/parse round trip', () => {
+    const ts = Date.now()
+    const logLine = 'test log line'
+    const s = dumpLine(ts, logLine)
+    const [ts2, logLine2] = parseLine(s)
+    expect(ts2).toEqual(ts)
+    expect(logLine2).toEqual(logLine)
+  })
+})

--- a/shared/logger/native-logger.js
+++ b/shared/logger/native-logger.js
@@ -1,7 +1,11 @@
 // @flow
 import {log, dump} from '../native/logger'
-import type {Logger, LogLine, LogLevel} from './types'
+import type {Logger, LogLine, LogLevel, Timestamp} from './types'
 import {toStringForLog} from '../util/string'
+
+const dumpLine = (timestamp: Timestamp, toLog: string) => {
+  return JSON.stringify([timestamp, toLog])
+}
 
 const parseLine = (l: string): LogLine => {
   try {
@@ -36,7 +40,7 @@ class NativeLogger implements Logger {
 
   log = (...s: Array<any>) => {
     const toLog = s.map(toStringForLog).join(' ')
-    log(this._tagPrefix, JSON.stringify([Date.now(), toLog]))
+    log(this._tagPrefix, dumpLine(Date.now(), toLog))
   }
 
   dump(levelPrefix: LogLevel) {
@@ -54,4 +58,5 @@ class NativeLogger implements Logger {
   }
 }
 
+export {dumpLine, parseLine}
 export default NativeLogger

--- a/shared/logger/types.js
+++ b/shared/logger/types.js
@@ -1,7 +1,7 @@
 // @flow
 // Separate type file because standard is failing
 
-type Timestamp = number
+export type Timestamp = number
 type ISOTimestamp = string
 
 export type LogLevel = 'Error' | 'Warn' | 'Info' | 'Action' | 'Debug'


### PR DESCRIPTION
This makes log sending work again, even in the presence of truncated
log lines.