### PR TITLE
Add button to trace for 30 seconds

### DIFF
--- a/shared/actions/json/settings.json
+++ b/shared/actions/json/settings.json
@@ -66,7 +66,9 @@
     "setAllowDeleteAccount": {
       "allow": "boolean"
     },
-    "trace": {},
+    "trace": {
+      "duration": "number",
+    },
     "waitingForResponse": {
       "waiting": "boolean"
     }

--- a/shared/actions/json/settings.json
+++ b/shared/actions/json/settings.json
@@ -66,6 +66,7 @@
     "setAllowDeleteAccount": {
       "allow": "boolean"
     },
+    "trace": {},
     "waitingForResponse": {
       "waiting": "boolean"
     }

--- a/shared/actions/json/settings.json
+++ b/shared/actions/json/settings.json
@@ -67,7 +67,7 @@
       "allow": "boolean"
     },
     "trace": {
-      "duration": "number",
+      "durationSeconds": "number",
     },
     "waitingForResponse": {
       "waiting": "boolean"

--- a/shared/actions/settings-gen.js
+++ b/shared/actions/settings-gen.js
@@ -78,7 +78,7 @@ export const createOnUpdatePGPSettings = () => ({error: false, payload: undefine
 export const createOnUpdatePassphraseError = (payload: $ReadOnly<{error: Error}>) => ({error: false, payload, type: onUpdatePassphraseError})
 export const createOnUpdatedPGPSettings = (payload: $ReadOnly<{hasKeys: boolean}>) => ({error: false, payload, type: onUpdatedPGPSettings})
 export const createSetAllowDeleteAccount = (payload: $ReadOnly<{allow: boolean}>) => ({error: false, payload, type: setAllowDeleteAccount})
-export const createTrace = (payload: $ReadOnly<{duration: number}>) => ({error: false, payload, type: trace})
+export const createTrace = (payload: $ReadOnly<{durationSeconds: number}>) => ({error: false, payload, type: trace})
 export const createWaitingForResponse = (payload: $ReadOnly<{waiting: boolean}>) => ({error: false, payload, type: waitingForResponse})
 
 // Action Payloads

--- a/shared/actions/settings-gen.js
+++ b/shared/actions/settings-gen.js
@@ -36,6 +36,7 @@ export const onUpdatePGPSettings = 'settings:onUpdatePGPSettings'
 export const onUpdatePassphraseError = 'settings:onUpdatePassphraseError'
 export const onUpdatedPGPSettings = 'settings:onUpdatedPGPSettings'
 export const setAllowDeleteAccount = 'settings:setAllowDeleteAccount'
+export const trace = 'settings:trace'
 export const waitingForResponse = 'settings:waitingForResponse'
 
 // Action Creators
@@ -77,6 +78,7 @@ export const createOnUpdatePGPSettings = () => ({error: false, payload: undefine
 export const createOnUpdatePassphraseError = (payload: $ReadOnly<{error: Error}>) => ({error: false, payload, type: onUpdatePassphraseError})
 export const createOnUpdatedPGPSettings = (payload: $ReadOnly<{hasKeys: boolean}>) => ({error: false, payload, type: onUpdatedPGPSettings})
 export const createSetAllowDeleteAccount = (payload: $ReadOnly<{allow: boolean}>) => ({error: false, payload, type: setAllowDeleteAccount})
+export const createTrace = () => ({error: false, payload: undefined, type: trace})
 export const createWaitingForResponse = (payload: $ReadOnly<{waiting: boolean}>) => ({error: false, payload, type: waitingForResponse})
 
 // Action Payloads
@@ -106,6 +108,7 @@ export type OnUpdatePGPSettingsPayload = More.ReturnType<typeof createOnUpdatePG
 export type OnUpdatePassphraseErrorPayload = More.ReturnType<typeof createOnUpdatePassphraseError>
 export type OnUpdatedPGPSettingsPayload = More.ReturnType<typeof createOnUpdatedPGPSettings>
 export type SetAllowDeleteAccountPayload = More.ReturnType<typeof createSetAllowDeleteAccount>
+export type TracePayload = More.ReturnType<typeof createTrace>
 export type WaitingForResponsePayload = More.ReturnType<typeof createWaitingForResponse>
 
 // All Actions
@@ -139,5 +142,6 @@ export type Actions =
   | More.ReturnType<typeof createOnUpdatePassphraseError>
   | More.ReturnType<typeof createOnUpdatedPGPSettings>
   | More.ReturnType<typeof createSetAllowDeleteAccount>
+  | More.ReturnType<typeof createTrace>
   | More.ReturnType<typeof createWaitingForResponse>
   | {type: 'common:resetStore', payload: void}

--- a/shared/actions/settings-gen.js
+++ b/shared/actions/settings-gen.js
@@ -78,7 +78,7 @@ export const createOnUpdatePGPSettings = () => ({error: false, payload: undefine
 export const createOnUpdatePassphraseError = (payload: $ReadOnly<{error: Error}>) => ({error: false, payload, type: onUpdatePassphraseError})
 export const createOnUpdatedPGPSettings = (payload: $ReadOnly<{hasKeys: boolean}>) => ({error: false, payload, type: onUpdatedPGPSettings})
 export const createSetAllowDeleteAccount = (payload: $ReadOnly<{allow: boolean}>) => ({error: false, payload, type: setAllowDeleteAccount})
-export const createTrace = () => ({error: false, payload: undefined, type: trace})
+export const createTrace = (payload: $ReadOnly<{duration: number}>) => ({error: false, payload, type: trace})
 export const createWaitingForResponse = (payload: $ReadOnly<{waiting: boolean}>) => ({error: false, payload, type: waitingForResponse})
 
 // Action Payloads

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -349,10 +349,10 @@ function _deleteAccountForeverSaga(action: SettingsGen.DeleteAccountForeverPaylo
 const _loadSettings = () => Saga.call(RPCTypes.userLoadMySettingsRpcPromise)
 const _loadSettingsSuccess = emailState => Saga.put(SettingsGen.createLoadedSettings({emailState}))
 
-const _traceSaga = () =>
+const _traceSaga = (action: SettingsGen.TracePayload) =>
   Saga.call(RPCTypes.pprofTraceRpcPromise, {
     traceFile: `${cachesDirectoryPath}/Keybase/trace.out`,
-    traceDurationSeconds: 30,
+    traceDurationSeconds: action.payload.durationSeconds,
   })
 
 function* settingsSaga(): Saga.SagaGenerator<any, any> {

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -12,7 +12,7 @@ import trim from 'lodash/trim'
 import {delay} from 'redux-saga'
 import {navigateAppend, navigateUp} from '../actions/route-tree'
 import {type TypedState} from '../constants/reducer'
-import {cachesDirectoryPath} from '../util/file'
+import {traceFileName} from '../constants/platform'
 
 function* _onUpdatePGPSettings(): Saga.SagaGenerator<any, any> {
   try {
@@ -351,7 +351,9 @@ const _loadSettingsSuccess = emailState => Saga.put(SettingsGen.createLoadedSett
 
 const _traceSaga = (action: SettingsGen.TracePayload) =>
   Saga.call(RPCTypes.pprofTraceRpcPromise, {
-    traceFile: `${cachesDirectoryPath}/Keybase/trace.out`,
+    // TODO: Make the go side ensure that the directory exists.
+    // TODO: Include any trace output in a log send.
+    traceFile: traceFileName(),
     traceDurationSeconds: action.payload.durationSeconds,
   })
 

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -12,6 +12,7 @@ import trim from 'lodash/trim'
 import {delay} from 'redux-saga'
 import {navigateAppend, navigateUp} from '../actions/route-tree'
 import {type TypedState} from '../constants/reducer'
+import {cachesDirectoryPath} from '../util/file'
 
 function* _onUpdatePGPSettings(): Saga.SagaGenerator<any, any> {
   try {
@@ -348,6 +349,12 @@ function _deleteAccountForeverSaga(action: SettingsGen.DeleteAccountForeverPaylo
 const _loadSettings = () => Saga.call(RPCTypes.userLoadMySettingsRpcPromise)
 const _loadSettingsSuccess = emailState => Saga.put(SettingsGen.createLoadedSettings({emailState}))
 
+const _traceSaga = () =>
+  Saga.call(RPCTypes.pprofTraceRpcPromise, {
+    traceFile: `${cachesDirectoryPath}/Keybase/trace.out`,
+    traceDurationSeconds: 30,
+  })
+
 function* settingsSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEvery(SettingsGen.invitesReclaim, _reclaimInviteSaga)
   yield Saga.safeTakeLatest(SettingsGen.invitesRefresh, _refreshInvitesSaga)
@@ -360,6 +367,7 @@ function* settingsSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEvery(SettingsGen.onSubmitNewEmail, _onSubmitNewEmail)
   yield Saga.safeTakeEvery(SettingsGen.onSubmitNewPassphrase, _onSubmitNewPassphrase)
   yield Saga.safeTakeEvery(SettingsGen.onUpdatePGPSettings, _onUpdatePGPSettings)
+  yield Saga.safeTakeLatestPure(SettingsGen.trace, _traceSaga)
 }
 
 export default settingsSaga

--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -159,6 +159,18 @@ const jsonDebugFileName = (function() {
   throw new Error(`Unknown platform ${process.platform}`)
 })()
 
+function traceFileName(): string {
+  switch (process.platform) {
+    case 'darwin':
+      return `${logDir()}/${envedPathOSX[runMode]}.trace.out`
+    case 'linux':
+      return `${logDir()}/trace.out`
+    case 'win32':
+      return `${logDir()}\\trace.out`
+  }
+  throw new Error(`Unknown platform ${process.platform}`)
+}
+
 const socketPath = findSocketDialPath()
 const dataRoot = findDataRoot()
 const cacheRoot = findCacheRoot()
@@ -190,5 +202,6 @@ export {
   mobileOsVersion,
   runMode,
   socketPath,
+  traceFileName,
   version,
 }

--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -122,14 +122,27 @@ function findCacheRoot(): string {
   throw new Error(`Unknown platform ${process.platform}`)
 }
 
+function logDir(): string {
+  switch (process.platform) {
+    case 'darwin':
+      return `${getenv('HOME', '')}/Library/Logs`
+    case 'linux':
+      const linuxDefaultRoot = `${getenv('HOME', '')}/.local/share`
+      return `${getenv('XDG_DATA_HOME', linuxDefaultRoot)}/${envedPathLinux[runMode]}`
+    case 'win32':
+      return `${getenv('LOCALAPPDATA', '')}\\${envedPathWin32[runMode]}`
+  }
+  throw new Error(`Unknown platform ${process.platform}`)
+}
+
 function logFileName(): string {
   switch (process.platform) {
     case 'darwin':
-      return `${getenv('HOME', '')}/Library/Logs/${envedPathOSX[runMode]}.app.log`
+      return `${logDir()}/${envedPathOSX[runMode]}.app.log`
     case 'linux':
       return '' // linux is '' because we can redirect stdout
     case 'win32':
-      return `${getenv('LOCALAPPDATA', '')}\\${envedPathWin32[runMode]}\\keybase.app.log`
+      return `${logDir()}\\keybase.app.log`
   }
   throw new Error(`Unknown platform ${process.platform}`)
 }
@@ -137,12 +150,11 @@ function logFileName(): string {
 const jsonDebugFileName = (function() {
   switch (process.platform) {
     case 'darwin':
-      return `${getenv('HOME', '')}/Library/Logs/${envedPathOSX[runMode]}.app.debug`
+      return `${logDir()}/${envedPathOSX[runMode]}.app.debug`
     case 'linux':
-      const linuxDefaultRoot = `${getenv('HOME', '')}/.local/share`
-      return `${getenv('XDG_DATA_HOME', linuxDefaultRoot)}/${envedPathLinux[runMode]}/keybase.app.debug`
+      return `${logDir()}/keybase.app.debug`
     case 'win32':
-      return `${getenv('LOCALAPPDATA', '')}\\${envedPathWin32[runMode]}\\keybase.app.debug`
+      return `${logDir()}\\keybase.app.debug`
   }
   throw new Error(`Unknown platform ${process.platform}`)
 })()

--- a/shared/constants/platform.js.flow
+++ b/shared/constants/platform.js.flow
@@ -20,3 +20,4 @@ declare export var appVersionName: string
 declare export var appVersionCode: string
 declare export var mobileOsVersion: string
 declare export var logFileName: () => string
+declare export var traceFileName: () => string

--- a/shared/constants/platform.native.js
+++ b/shared/constants/platform.native.js
@@ -1,6 +1,6 @@
 // @flow
 import {Dimensions, Platform, NativeModules} from 'react-native'
-import {cachesDirectoryPath} from '../util/file'
+import {cachesDirectoryPath} from '../util/file.native'
 
 // Modules from the native part of the code. Differently named on android/ios
 const nativeBridge = NativeModules.KeybaseEngine ||

--- a/shared/constants/platform.native.js
+++ b/shared/constants/platform.native.js
@@ -52,6 +52,10 @@ function logFileName(): string {
   return _logPath
 }
 
+function traceFileName(): string {
+  return `${_dir}/trace.out`
+}
+
 export {
   appVersionCode,
   appVersionName,
@@ -73,4 +77,5 @@ export {
   version,
   logFileName,
   logFileDir,
+  traceFileName,
 }

--- a/shared/constants/settings.js
+++ b/shared/constants/settings.js
@@ -1,6 +1,7 @@
 // @flow
 import * as Types from './types/settings'
 import HiddenString from '../util/hidden-string'
+import type {TypedState} from './reducer'
 
 const initialState: Types.State = {
   allowDeleteAccount: false,
@@ -40,6 +41,10 @@ const initialState: Types.State = {
   waitingForResponse: false,
 }
 
+const traceInProgressKey = 'traceInProgress'
+
+const traceInProgress = (state: TypedState) => state.waiting.get(traceInProgressKey, 0) !== 0
+
 export const aboutTab = 'settingsTabs:aboutTab'
 export const advancedTab = 'settingsTabs:advancedTab'
 export const deleteMeTab = 'settingsTabs:deleteMeTab'
@@ -55,4 +60,4 @@ export const passphraseTab = 'settingsTabs:passphrase'
 export const screenprotectorTab = 'settingsTabs:screenprotector'
 export const updatePaymentTab = 'settingsTabs:updatePaymentTab'
 export const securityGroup = 'security'
-export {initialState}
+export {initialState, traceInProgressKey, traceInProgress}

--- a/shared/reducers/settings.js
+++ b/shared/reducers/settings.js
@@ -192,6 +192,7 @@ function reducer(state: Types.State = Constants.initialState, action: SettingsGe
     case SettingsGen.onSubmitNewEmail:
     case SettingsGen.onSubmitNewPassphrase:
     case SettingsGen.onUpdatePGPSettings:
+    case SettingsGen.trace:
       return state
     default:
       // eslint-disable-next-line no-unused-expressions

--- a/shared/settings/advanced/container.js
+++ b/shared/settings/advanced/container.js
@@ -1,9 +1,10 @@
 // @flow
 import * as ConfigGen from '../../actions/config-gen'
+import {createTrace} from '../../actions/settings-gen'
 import {navigateAppend, navigateUp} from '../../actions/route-tree'
 import {HeaderHoc} from '../../common-adapters'
 import {compose} from 'recompose'
-import DBNuke from './index'
+import Advanced from './index'
 import {connect, type TypedState} from '../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({
@@ -17,8 +18,12 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onDBNuke: () => {
     dispatch(navigateAppend(['dbNukeConfirm']))
   },
+  onTrace: () => {
+    const durationSeconds = 5
+    dispatch(createTrace({durationSeconds}))
+  },
   onSetOpenAtLogin: (open: boolean) => dispatch(ConfigGen.createSetOpenAtLogin({open, writeFile: true})),
 })
 
-const connectedDBNuke = compose(connect(mapStateToProps, mapDispatchToProps), HeaderHoc)(DBNuke)
-export default connectedDBNuke
+const connectedAdvanced = compose(connect(mapStateToProps, mapDispatchToProps), HeaderHoc)(Advanced)
+export default connectedAdvanced

--- a/shared/settings/advanced/container.js
+++ b/shared/settings/advanced/container.js
@@ -3,12 +3,14 @@ import * as ConfigGen from '../../actions/config-gen'
 import {createTrace} from '../../actions/settings-gen'
 import {navigateAppend, navigateUp} from '../../actions/route-tree'
 import {HeaderHoc} from '../../common-adapters'
+import * as Constants from '../../constants/settings'
 import {compose} from 'recompose'
 import Advanced from './index'
 import {connect, type TypedState} from '../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({
   openAtLogin: state.config.openAtLogin,
+  traceInProgress: Constants.traceInProgress(state),
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/shared/settings/advanced/container.js
+++ b/shared/settings/advanced/container.js
@@ -19,7 +19,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(navigateAppend(['dbNukeConfirm']))
   },
   onTrace: () => {
-    const durationSeconds = 5
+    const durationSeconds = 30
     dispatch(createTrace({durationSeconds}))
   },
   onSetOpenAtLogin: (open: boolean) => dispatch(ConfigGen.createSetOpenAtLogin({open, writeFile: true})),

--- a/shared/settings/advanced/container.js
+++ b/shared/settings/advanced/container.js
@@ -18,8 +18,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onDBNuke: () => {
     dispatch(navigateAppend(['dbNukeConfirm']))
   },
-  onTrace: () => {
-    const durationSeconds = 30
+  onTrace: (durationSeconds: number) => {
     dispatch(createTrace({durationSeconds}))
   },
   onSetOpenAtLogin: (open: boolean) => dispatch(ConfigGen.createSetOpenAtLogin({open, writeFile: true})),

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -7,7 +7,7 @@ type Props = {
   openAtLogin: boolean,
   onSetOpenAtLogin: (open: boolean) => void,
   onDBNuke: () => void,
-  onTrace: () => void,
+  onTrace: (durationSeconds: number) => void,
   onBack: () => void,
 }
 
@@ -65,7 +65,7 @@ function Developer(props: Props) {
         style={{marginTop: globalMargins.small}}
         type="Danger"
         label="Trace (30s)"
-        onClick={props.onTrace}
+        onClick={() => props.onTrace(30)}
       />
       <Box style={{flex: 1}} />
     </Box>

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -9,6 +9,7 @@ type Props = {
   onDBNuke: () => void,
   onTrace: (durationSeconds: number) => void,
   onBack: () => void,
+  traceInProgress: boolean,
 }
 
 const Advanced = (props: Props) => (
@@ -40,31 +41,20 @@ const Advanced = (props: Props) => (
 
 type TraceButtonProps = {
   durationSeconds: number,
+  traceInProgress: boolean,
   onTrace: (durationSeconds: number) => void,
 }
 
-type TraceButtonState = {
-  enabled: boolean,
-}
-
-class TraceButton extends React.Component<TraceButtonProps, TraceButtonState> {
-  state = {
-    enabled: true,
-  }
-
+class TraceButton extends React.Component<TraceButtonProps> {
   _onClick = () => {
-    this.setState({enabled: false})
     this.props.onTrace(this.props.durationSeconds)
-    setTimeout(() => {
-      this.setState({enabled: true})
-    }, this.props.durationSeconds * 1000)
   }
 
   render() {
     const label = `Trace (${this.props.durationSeconds}s)`
     return (
       <Button
-        disabled={!this.state.enabled}
+        disabled={this.props.traceInProgress}
         style={{marginTop: globalMargins.small}}
         type="Danger"
         label={label}
@@ -97,7 +87,7 @@ function Developer(props: Props) {
         label="DB Nuke"
         onClick={props.onDBNuke}
       />
-      <TraceButton durationSeconds={30} onTrace={props.onTrace} />
+      <TraceButton durationSeconds={30} onTrace={props.onTrace} traceInProgress={props.traceInProgress} />
       <Box style={{flex: 1}} />
     </Box>
   )

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -43,15 +43,32 @@ type TraceButtonProps = {
   onTrace: (durationSeconds: number) => void,
 }
 
-class TraceButton extends React.Component<TraceButtonProps> {
+type TraceButtonState = {
+  enabled: boolean,
+}
+
+class TraceButton extends React.Component<TraceButtonProps, TraceButtonState> {
+  state = {
+    enabled: true,
+  }
+
+  _onClick = () => {
+    this.setState({enabled: false})
+    this.props.onTrace(this.props.durationSeconds)
+    setTimeout(() => {
+      this.setState({enabled: true})
+    }, this.props.durationSeconds * 1000)
+  }
+
   render() {
     const label = `Trace (${this.props.durationSeconds}s)`
     return (
       <Button
+        disabled={!this.state.enabled}
         style={{marginTop: globalMargins.small}}
         type="Danger"
         label={label}
-        onClick={() => this.props.onTrace(this.props.durationSeconds)}
+        onClick={this._onClick}
       />
     )
   }

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -61,7 +61,6 @@ function Developer(props: Props) {
         label="DB Nuke"
         onClick={props.onDBNuke}
       />
-      <Box style={{flex: 1}} />
       <Button
         style={{marginTop: globalMargins.small}}
         type="Danger"

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -7,6 +7,7 @@ type Props = {
   openAtLogin: boolean,
   onSetOpenAtLogin: (open: boolean) => void,
   onDBNuke: () => void,
+  onTrace: () => void,
   onBack: () => void,
 }
 
@@ -33,11 +34,11 @@ const Advanced = (props: Props) => (
         />
       </Box>
     )}
-    <DBNuke {...props} />
+    <Developer {...props} />
   </Box>
 )
 
-function DBNuke(props: Props) {
+function Developer(props: Props) {
   return (
     <Box
       style={{
@@ -61,6 +62,15 @@ function DBNuke(props: Props) {
         onClick={props.onDBNuke}
       />
       <Box style={{flex: 1}} />
+      {isMobile && (
+        <Button
+          style={{marginTop: globalMargins.small}}
+          type="Danger"
+          label="Trace (30s)"
+          onClick={props.onTrace}
+        />
+      )}
+      {isMobile && <Box style={{flex: 1}} />}
     </Box>
   )
 }

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -62,15 +62,13 @@ function Developer(props: Props) {
         onClick={props.onDBNuke}
       />
       <Box style={{flex: 1}} />
-      {isMobile && (
-        <Button
-          style={{marginTop: globalMargins.small}}
-          type="Danger"
-          label="Trace (30s)"
-          onClick={props.onTrace}
-        />
-      )}
-      {isMobile && <Box style={{flex: 1}} />}
+      <Button
+        style={{marginTop: globalMargins.small}}
+        type="Danger"
+        label="Trace (30s)"
+        onClick={props.onTrace}
+      />
+      <Box style={{flex: 1}} />
     </Box>
   )
 }

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -38,6 +38,25 @@ const Advanced = (props: Props) => (
   </Box>
 )
 
+type TraceButtonProps = {
+  durationSeconds: number,
+  onTrace: (durationSeconds: number) => void,
+}
+
+class TraceButton extends React.Component<TraceButtonProps> {
+  render() {
+    const label = `Trace (${this.props.durationSeconds}s)`
+    return (
+      <Button
+        style={{marginTop: globalMargins.small}}
+        type="Danger"
+        label={label}
+        onClick={() => this.props.onTrace(this.props.durationSeconds)}
+      />
+    )
+  }
+}
+
 function Developer(props: Props) {
   return (
     <Box
@@ -61,12 +80,7 @@ function Developer(props: Props) {
         label="DB Nuke"
         onClick={props.onDBNuke}
       />
-      <Button
-        style={{marginTop: globalMargins.small}}
-        type="Danger"
-        label="Trace (30s)"
-        onClick={() => props.onTrace(30)}
-      />
+      <TraceButton durationSeconds={30} onTrace={props.onTrace} />
       <Box style={{flex: 1}} />
     </Box>
   )

--- a/shared/util/file.desktop.js
+++ b/shared/util/file.desktop.js
@@ -79,14 +79,4 @@ function writeStream(filepath: string, encoding: string, append?: boolean): Prom
   return Promise.reject(new Error('not implemented'))
 }
 
-export {
-  copy,
-  downloadFilePath,
-  exists,
-  stat,
-  tmpDir,
-  tmpFile,
-  tmpRandFile,
-  unlink,
-  writeStream,
-}
+export {copy, downloadFilePath, exists, stat, tmpDir, tmpFile, tmpRandFile, unlink, writeStream}

--- a/shared/util/file.desktop.js
+++ b/shared/util/file.desktop.js
@@ -75,15 +75,11 @@ function unlink(filepath: string): Promise<void> {
   return new Promise((resolve, reject) => fs.unlink(filepath, () => resolve()))
 }
 
-// TODO implemented for mobile, not here
-const cachesDirectoryPath = ''
-
 function writeStream(filepath: string, encoding: string, append?: boolean): Promise<*> {
   return Promise.reject(new Error('not implemented'))
 }
 
 export {
-  cachesDirectoryPath,
   copy,
   downloadFilePath,
   exists,

--- a/shared/util/file.js.flow
+++ b/shared/util/file.js.flow
@@ -14,6 +14,4 @@ declare function stat(filename: string): Promise<StatResult>
 declare function writeStream(filepath: string, encoding: string, append?: boolean): Promise<*>
 declare function unlink(filepath: string): Promise<void>
 
-declare var cachesDirectoryPath: string
-
-export {cachesDirectoryPath, copy, exists, downloadFilePath, stat, tmpDir, tmpFile, unlink, writeStream}
+export {copy, exists, downloadFilePath, stat, tmpDir, tmpFile, unlink, writeStream}


### PR DESCRIPTION
The idea is that users can click this button and the resulting trace
file will be included in a log send (in a future PR), or if testing,
a developer can pull it from the phone's filesystem.