### PR TITLE
Shutdown keybase earlier in the upgrade process

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -30,11 +30,11 @@
 
     <InstallExecuteSequence>
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
-      <Custom Action="StopMainApp" Before="StopUpdater"><![CDATA[Installed]]></Custom>
-      <Custom Action="StopUpdater" Before="StopGUI"><![CDATA[Installed]]></Custom>
-      <Custom Action="RemoveBrowserExtension" Before="InstallValidate"><![CDATA[Installed]]></Custom>
+      <Custom Action="StopMainApp" Before="StopUpdater"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
+      <Custom Action="StopUpdater" Before="StopGUI"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
+      <Custom Action="RemoveBrowserExtension" Before="InstallValidate"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
       <!-- StopGUI is legacy and to be removed after enough people are updated -->
-      <Custom Action="StopGUI" Before="InstallValidate"><![CDATA[Installed]]></Custom>
+      <Custom Action="StopGUI" Before="InstallValidate"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="RunMainApp" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="RunGUI" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="AddBrowserExtension" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>


### PR DESCRIPTION
Not sure if it was windows, or updating wix, or what, but the "costing" stage started waiting for processes to close before proceeding, skipping our shutdown actions because the "Installed" property was not set. Staring at the logs seemed to suggest another property was set earlier in this case, "WIX_UPGRADE_DETECTED", and luckily it worked. Update was taking several minutes before, up to 8, and now it is less than a minute for me. Along with the coherent shutdown changes, this will clear up a lot of user issues.

Try it yourself with http://s3.amazonaws.com/prerelease.keybase.io/windows/Keybase_1.0.41-20180207174450%2B1e86841.386.exe and http://s3.amazonaws.com/prerelease.keybase.io/windows/Keybase_1.0.41-20180207180306%2B1e86841.386.exe

@keybase/react-hackers 