### PR TITLE
Try to speed up systests some more

### DIFF
--- a/go/git/common_test.go
+++ b/go/git/common_test.go
@@ -15,6 +15,7 @@ import (
 // Copied from the teams tests.
 func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
 	tc = libkb.SetupTest(tb, name, depth+1)
+	InstallInsecureTriplesec(tc.G)
 	tc.G.SetServices(externals.GetServices())
 	tc.G.ChatHelper = newMockChatHelper()
 	teams.ServiceInit(tc.G)

--- a/go/systests/common_test.go
+++ b/go/systests/common_test.go
@@ -14,6 +14,7 @@ import (
 
 func setupTest(t libkb.TestingTB, nm string) *libkb.TestContext {
 	tc := externalstest.SetupTest(t, nm, 2)
+	installInsecureTriplesec(tc.G)
 	tc.SetRuntimeDir(filepath.Join(tc.Tp.Home, "run"))
 	if err := tc.G.ConfigureSocketInfo(); err != nil {
 		t.Fatal(err)

--- a/go/systests/device_common_test.go
+++ b/go/systests/device_common_test.go
@@ -222,6 +222,8 @@ func (s *testDeviceSet) newDevice(nm string) *testDevice {
 		s.log = tctx.G.Log
 	}
 
+	installInsecureTriplesec(tctx.G)
+
 	ret := &testDevice{t: s.t, tctx: tctx, deviceName: nm}
 	s.devices = append(s.devices, ret)
 	return ret

--- a/go/systests/home_test.go
+++ b/go/systests/home_test.go
@@ -126,7 +126,7 @@ func TestHome(t *testing.T) {
 	// item, and then we will still have two todo items lined up next with
 	// one badged. This is a bit brittle since if the server-side logic
 	// changes, this test will break. But let's leave it for now.
-	tt.addUser("alice")
+	tt.addUserWithPaper("alice")
 	alice := tt.users[0]
 	g := alice.tc.G
 

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -179,6 +179,7 @@ func (smc *smuContext) setupDeviceHelper(u *smuUser, puk bool) *smuDeviceWrapper
 	tctx := setupTest(smc.t, u.usernamePrefix)
 	tctx.Tp.DisableUpgradePerUserKey = !puk
 	tctx.G.SetClock(smc.fakeClock)
+	installInsecureTriplesec(tctx.G)
 	ret := &smuDeviceWrapper{ctx: smc, tctx: tctx}
 	u.devices = append(u.devices, ret)
 	if u.primary == nil {

--- a/go/systests/team_open_test.go
+++ b/go/systests/team_open_test.go
@@ -37,11 +37,11 @@ func TestTeamOpenAutoAddMember(t *testing.T) {
 
 	t.Logf("Open team name is %q", teamName)
 
+	roo.kickTeamRekeyd()
 	ret, err := roo.teamsClient.TeamRequestAccess(context.TODO(), keybase1.TeamRequestAccessArg{Name: teamName})
 	require.NoError(t, err)
 	require.Equal(t, true, ret.Open)
 
-	own.kickTeamRekeyd()
 	own.waitForTeamChangedGregor(teamID, keybase1.Seqno(2))
 
 	teamObj, err := teams.Load(context.TODO(), own.tc.G, keybase1.LoadTeamArg{
@@ -124,11 +124,13 @@ func TestOpenSubteamAdd(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, subteamObj.IsOpen(), true)
 
+	// Kick rekeyd so team request notifications come quicker.
+	roo.kickTeamRekeyd()
+
 	// User requesting access
 	subteamNameStr := subteamObj.Name().String()
 	roo.teamsClient.TeamRequestAccess(context.TODO(), keybase1.TeamRequestAccessArg{Name: subteamNameStr})
 
-	own.kickTeamRekeyd()
 	own.waitForTeamChangedGregor(*subteam, keybase1.Seqno(3))
 
 	subteamObj, err = teams.Load(context.TODO(), own.tc.G, keybase1.LoadTeamArg{
@@ -162,10 +164,11 @@ func TestTeamOpenMultipleTars(t *testing.T) {
 	err := teams.ChangeTeamSettings(context.TODO(), own.tc.G, teamName.String(), keybase1.TeamSettings{Open: true, JoinAs: keybase1.TeamRole_READER})
 	require.NoError(t, err)
 
+	tar3.kickTeamRekeyd()
+
 	// tar3 requests, but rekeyd will grab all requests
 	tar3.teamsClient.TeamRequestAccess(context.TODO(), keybase1.TeamRequestAccessArg{Name: teamName.String()})
 
-	own.kickTeamRekeyd()
 	own.waitForTeamChangedGregor(teamID, keybase1.Seqno(3))
 
 	teamObj, err := teams.Load(context.TODO(), own.tc.G, keybase1.LoadTeamArg{
@@ -233,10 +236,10 @@ func TestTeamOpenPuklessRequest(t *testing.T) {
 	err := teams.ChangeTeamSettings(context.TODO(), own.tc.G, team, keybase1.TeamSettings{Open: true, JoinAs: keybase1.TeamRole_READER})
 	require.NoError(t, err)
 
+	bob.kickTeamRekeyd()
 	_, err = bob.teamsClient.TeamRequestAccess(context.TODO(), keybase1.TeamRequestAccessArg{Name: team})
 	require.NoError(t, err)
 
-	own.kickTeamRekeyd()
 	own.pollForTeamSeqnoLink(team, keybase1.Seqno(3))
 
 	teamObj, err := teams.Load(context.TODO(), own.tc.G, keybase1.LoadTeamArg{

--- a/go/systests/team_seitan_invite_v2_test.go
+++ b/go/systests/team_seitan_invite_v2_test.go
@@ -84,6 +84,7 @@ func testTeamInviteSeitanHappy(t *testing.T, implicitAdmin bool, seitanVersion t
 		require.Equal(t, keybase1.TeamInviteName("bugs (0000)"), invite.Name)
 	}
 
+	roo.kickTeamRekeyd()
 	err := roo.teamsClient.TeamAcceptInvite(context.TODO(), keybase1.TeamAcceptInviteArg{
 		Token: token,
 	})
@@ -91,7 +92,6 @@ func testTeamInviteSeitanHappy(t *testing.T, implicitAdmin bool, seitanVersion t
 
 	t.Logf("User used token, waiting for rekeyd")
 
-	own.kickTeamRekeyd()
 	own.waitForTeamChangedGregor(teamID, keybase1.Seqno(3))
 
 	t0, err := teams.GetTeamByNameForTest(context.TODO(), own.tc.G, teamName.String(), false /* public */, true /* needAdmin */)

--- a/go/systests/teams_implicit_test.go
+++ b/go/systests/teams_implicit_test.go
@@ -30,7 +30,7 @@ func testImplicitTeamRotateOnRevoke(t *testing.T, public bool) {
 	defer tt.cleanup()
 
 	alice := tt.addUser("alice")
-	bob := tt.addUser("bob")
+	bob := tt.addUserWithPaper("bob")
 
 	iTeamName := strings.Join([]string{alice.username, bob.username}, ",")
 

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/keybase/client/go/teams"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/stretchr/testify/require"
+
+	insecureTriplesec "github.com/keybase/go-triplesec-insecure"
 )
 
 func TestTeamCreate(t *testing.T) {
@@ -129,6 +131,16 @@ func (tt *teamTester) addPuklessUser(pre string) *userPlusDevice {
 	return tt.addUserHelper(pre, false, true)
 }
 
+func installInsecureTriplesec(g *libkb.GlobalContext) {
+	g.NewTriplesec = func(passphrase []byte, salt []byte) (libkb.Triplesec, error) {
+		warner := func() { g.Log.Warning("Installing insecure Triplesec with weak stretch parameters") }
+		isProduction := func() bool {
+			return g.Env.GetRunMode() == libkb.ProductionRunMode
+		}
+		return insecureTriplesec.NewCipher(passphrase, salt, warner, isProduction)
+	}
+}
+
 func (tt *teamTester) addUserHelper(pre string, puk bool, paper bool) *userPlusDevice {
 	tctx := setupTest(tt.t, pre)
 	if !puk {
@@ -142,6 +154,8 @@ func (tt *teamTester) addUserHelper(pre string, puk bool, paper bool) *userPlusD
 	require.True(tt.t, libkb.CheckUsername.F(userInfo.username), "username check failed (%v): %v", libkb.CheckUsername.Hint, userInfo.username)
 	tc := u.device.tctx
 	g := tc.G
+	installInsecureTriplesec(g)
+
 	signupUI := signupUI{
 		info:         userInfo,
 		Contextified: libkb.NewContextified(g),

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -72,7 +72,7 @@ func TestTeamRotateOnRevoke(t *testing.T) {
 	defer tt.cleanup()
 
 	tt.addUser("onr")
-	tt.addUser("wtr")
+	tt.addUserWithPaper("wtr")
 
 	teamID, teamName := tt.users[0].createTeam2()
 	tt.users[0].addTeamMember(teamName.String(), tt.users[1].username, keybase1.TeamRole_WRITER)
@@ -120,15 +120,15 @@ func newTeamTester(t *testing.T) *teamTester {
 }
 
 func (tt *teamTester) addUser(pre string) *userPlusDevice {
-	return tt.addUserHelper(pre, true, true)
-}
-
-func (tt *teamTester) addUserNoPaper(pre string) *userPlusDevice {
 	return tt.addUserHelper(pre, true, false)
 }
 
+func (tt *teamTester) addUserWithPaper(pre string) *userPlusDevice {
+	return tt.addUserHelper(pre, true, true)
+}
+
 func (tt *teamTester) addPuklessUser(pre string) *userPlusDevice {
-	return tt.addUserHelper(pre, false, true)
+	return tt.addUserHelper(pre, false, false)
 }
 
 func installInsecureTriplesec(g *libkb.GlobalContext) {
@@ -572,6 +572,8 @@ func (u *userPlusDevice) provisionNewDevice() *deviceWrapper {
 	device := &deviceWrapper{tctx: tc}
 	device.start(0)
 
+	require.NotNil(t, u.backupKey, "Add user with paper key to use provisionNewDevice")
+
 	// ui for provisioning
 	ui := &rekeyProvisionUI{username: u.username, backupKey: u.backupKey}
 	{
@@ -757,7 +759,7 @@ func TestTeamSignedByRevokedDevice(t *testing.T) {
 	defer tt.cleanup()
 
 	// the signer
-	alice := tt.addUser("alice")
+	alice := tt.addUserWithPaper("alice")
 
 	// the loader
 	bob := tt.addUser("bob")
@@ -825,7 +827,7 @@ func TestTeamSignedByRevokedDevice2(t *testing.T) {
 	defer tt.cleanup()
 
 	// the signer
-	alice := tt.addUser("alice")
+	alice := tt.addUserWithPaper("alice")
 	aliced2 := alice.provisionNewDevice()
 
 	// the loader


### PR DESCRIPTION
1) Reorganized few kick rekeyd calls that were missed before. This did not seem to have any effect when running systests locally.
2) Systests now use insecure triplesec. This seems to make systests faster by 5 - 10%.
3) Systests users will not sign up with paper keys unless tests specifically need them, like some revoke and reprovisioning tests, home tests etc.

Overall this has brought down systests runtime time on my machine from ~280s to ~200s

I think first two have no disadvantages but we might think about 3 some more, maybe having paper keys everywhere was beneficial to avoid various regressions related to paper keys or having multiple devices in general.

cc @maxtaco 