### PR TITLE
Consume retention expunges

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -22,6 +22,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 }
 
 func testGetThreadSupersedes(t *testing.T, deleteHistory bool) {
+	t.Logf("stage deleteHistory:%v", deleteHistory)
 	ctx, world, ri, _, sender, _ := setupTest(t, 1)
 	defer world.Cleanup()
 

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -441,6 +441,11 @@ func (s *RemoteInboxSource) MembershipUpdate(ctx context.Context, uid gregor1.UI
 	return res, err
 }
 
+func (s *RemoteInboxSource) Expunge(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
+	expunge chat1.Expunge, maxMsgs []chat1.MessageSummary) (res *chat1.ConversationLocal, err error) {
+	return res, err
+}
+
 func (s *RemoteInboxSource) SetConvRetention(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	convID chat1.ConversationID, policy chat1.RetentionPolicy) (res *chat1.ConversationLocal, err error) {
 	return res, err
@@ -854,6 +859,13 @@ func (s *HybridInboxSource) MembershipUpdate(ctx context.Context, uid gregor1.UI
 	}
 
 	return res, nil
+}
+
+func (s *HybridInboxSource) Expunge(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
+	expunge chat1.Expunge, maxMsgs []chat1.MessageSummary) (*chat1.ConversationLocal, error) {
+	return s.modConversation(ctx, "Expunge", uid, convID, func(ctx context.Context, ib *storage.Inbox) error {
+		return ib.Expunge(ctx, vers, convID, expunge, maxMsgs)
+	})
 }
 
 func (s *HybridInboxSource) SetConvRetention(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3168,6 +3168,7 @@ func TestChatSrvRetentionSweepTeam(t *testing.T) {
 			var nText int
 			for _, msg := range tvres.Thread.Messages {
 				require.True(t, msg.IsValidFull())
+				require.Equal(t, chat1.MessageID(0), msg.Valid().ServerHeader.SupersededBy)
 				if msg.GetMessageType() == chat1.MessageType_TEXT {
 					nText++
 				}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3082,7 +3082,7 @@ func TestChatSrvRetentionSweepConv(t *testing.T) {
 
 		expungeInfo := consumeExpunge(t, listener)
 		require.True(t, expungeInfo.ConvID.Eq(created.Id))
-		require.Equal(t, chat1.Expunge{Upto: 4}, expungeInfo.Expunge)
+		require.Equal(t, chat1.Expunge{Upto: 4}, expungeInfo.Expunge, "expunge upto")
 
 		tvres, err := ctc.as(t, users[1]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{ConversationID: created.Id})
 		require.NoError(t, err)
@@ -3174,7 +3174,7 @@ func TestChatSrvRetentionSweepTeam(t *testing.T) {
 				}
 			}
 			if expectDeleted {
-				require.Equal(t, 0, nText)
+				require.Equal(t, 0, nText, "conv contents should be deleted: %v", convID.DbShortFormString())
 			} else {
 				require.Equal(t, 1, nText)
 			}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -986,6 +986,7 @@ func (i *Inbox) SetAppNotificationSettings(ctx context.Context, vers chat1.Inbox
 }
 
 // Mark the expunge on the stored inbox
+// The inbox Expunge tag is kept up to date for retention but not for delete-history.
 // Does not delete any messages. Relies on separate server mechanism to delete clear max messages.
 func (i *Inbox) Expunge(ctx context.Context, vers chat1.InboxVers,
 	convID chat1.ConversationID, expunge chat1.Expunge, maxMsgs []chat1.MessageSummary) (err Error) {

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -124,6 +124,8 @@ func (t *basicSupersedesTransform) Run(ctx context.Context,
 
 	// Get superseding messages
 	var deleteHistoryUpto chat1.MessageID
+	// If there are no superseding messages we still need to run
+	// the bottom loop to filter out messages deleted by retention.
 	if len(superMsgIDs) > 0 {
 		msgs, err := t.messagesFunc(ctx, conv, uid, superMsgIDs)
 		if err != nil {

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -330,7 +330,6 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		} else {
 			s.handleMembersTypeChanged(ctx, uid, iboxSyncRes.MembersTypeChanged)
 			for _, expunge := range iboxSyncRes.Expunges {
-				// @@@ TODO Is it ok to access convsource here like this? Chance of deadlock or recursion?
 				err := s.G().ConvSource.Expunge(ctx, expunge.ConvID, uid, expunge.Expunge)
 				if err != nil {
 					s.Debug(ctx, "Sync: failed to expunge: %v", err)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -59,6 +59,8 @@ type ConversationSource interface {
 	Clear(convID chat1.ConversationID, uid gregor1.UID) error
 	TransformSupersedes(ctx context.Context, conv chat1.Conversation, uid gregor1.UID,
 		msgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error)
+	Expunge(ctx context.Context, convID chat1.ConversationID,
+		uid gregor1.UID, expunge chat1.Expunge) error
 
 	SetRemoteInterface(func() chat1.RemoteInterface)
 }
@@ -116,6 +118,8 @@ type InboxSource interface {
 	TeamTypeChanged(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
 		teamType chat1.TeamType) (*chat1.ConversationLocal, error)
 	UpgradeKBFSToImpteam(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID) (*chat1.ConversationLocal, error)
+	Expunge(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
+		expunge chat1.Expunge, maxMsgs []chat1.MessageSummary) (*chat1.ConversationLocal, error)
 	SetConvRetention(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
 		policy chat1.RetentionPolicy) (*chat1.ConversationLocal, error)
 	SetTeamRetention(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, teamID keybase1.TeamID,

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -913,7 +913,7 @@ func PresentMessageUnboxed(ctx context.Context, rawMsg chat1.MessageUnboxed, uid
 			MessageID:             rawMsg.GetMessageID(),
 			Ctime:                 valid.ServerHeader.Ctime,
 			OutboxID:              strOutboxID,
-			MessageBody:           body,
+			MessageBody:           valid.MessageBody,
 			SenderUsername:        valid.SenderUsername,
 			SenderDeviceName:      valid.SenderDeviceName,
 			SenderDeviceType:      valid.SenderDeviceType,

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -913,7 +913,7 @@ func PresentMessageUnboxed(ctx context.Context, rawMsg chat1.MessageUnboxed, uid
 			MessageID:             rawMsg.GetMessageID(),
 			Ctime:                 valid.ServerHeader.Ctime,
 			OutboxID:              strOutboxID,
-			MessageBody:           valid.MessageBody,
+			MessageBody:           body,
 			SenderUsername:        valid.SenderUsername,
 			SenderDeviceName:      valid.SenderDeviceName,
 			SenderDeviceType:      valid.SenderDeviceType,

--- a/go/client/chat_common.go
+++ b/go/client/chat_common.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -39,4 +40,40 @@ When considering %s as a username or a list of usernames, received error: %v.
 When considering %s as a team name, received error: %v.`
 
 	return nil, libkb.NotFoundError{Msg: fmt.Sprintf(msg, name, tlfError, name, teamError)}
+}
+
+// Post a retention policy
+// Set's the channel policy if `setChannel`, otherwise sets the team-wide policy. `setChannel` is ignored if using a non-team.
+// UI is optional if `doPrompt` is false.
+func postRetentionPolicy(ctx context.Context, lcli chat1.LocalClient, tui libkb.TerminalUI,
+	conv *chat1.ConversationLocal, policy chat1.RetentionPolicy, setChannel bool, doPrompt bool) (err error) {
+	teamInvolved := (conv.Info.MembersType == chat1.ConversationMembersType_TEAM)
+	teamWide := teamInvolved && !setChannel
+
+	if doPrompt {
+		promptText := fmt.Sprintf("Set the conversation retention policy?\nHit Enter, or Ctrl-C to cancel.")
+		if teamInvolved {
+			promptText = fmt.Sprintf("Set the channel retention policy?\nHit Enter, or Ctrl-C to cancel.")
+		}
+		if teamWide {
+			promptText = fmt.Sprintf("Set the team-wide retention policy?\nHit Enter, or Ctrl-C to cancel.")
+		}
+		_, err = tui.Prompt(PromptDescriptorChatSetRetention, promptText)
+		if err != nil {
+			return err
+		}
+	}
+
+	if teamWide {
+		teamID, err := keybase1.TeamIDFromString(conv.Info.Triple.Tlfid.String())
+		if err != nil {
+			return err
+		}
+		return lcli.SetTeamRetentionLocal(ctx, chat1.SetTeamRetentionLocalArg{
+			TeamID: teamID,
+			Policy: policy})
+	}
+	return lcli.SetConvRetentionLocal(ctx, chat1.SetConvRetentionLocalArg{
+		ConvID: conv.Info.Id,
+		Policy: policy})
 }

--- a/go/client/cmd_chat_retention_dev.go
+++ b/go/client/cmd_chat_retention_dev.go
@@ -1,0 +1,131 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	gregor1 "github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+type CmdChatSetRetentionDev struct {
+	libkb.Contextified
+	resolvingRequest chatConversationResolvingRequest
+	policy           *chat1.RetentionPolicy
+
+	setPolicy  *chat1.RetentionPolicy
+	setChannel bool // whether to set team-wide or just channel
+}
+
+func NewCmdChatSetRetentionDevRunner(g *libkb.GlobalContext) *CmdChatSetRetentionDev {
+	return &CmdChatSetRetentionDev{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatSetRetentionDev(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "retention-policy-dev",
+		Usage: "Set a retention policy to EXPIRE with an exact seconds count",
+		Examples: `
+Please don't actually use retention-policy-dev:
+    keybase chat retention-policy-dev patrick,mlsteele 86400
+    keybase chat retention-policy-dev 10 --channel '#general' ateam
+`,
+		ArgumentHelp: "<conversation> <seconds>",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatSetRetentionDevRunner(g), "retention-policy-dev", c)
+		},
+		Flags: getConversationResolverFlags(),
+	}
+}
+
+func (c *CmdChatSetRetentionDev) Run() (err error) {
+	if c.resolvingRequest.TlfName != "" {
+		err = annotateResolvingRequest(c.G(), &c.resolvingRequest)
+		if err != nil {
+			return err
+		}
+	}
+	// TLFVisibility_ANY doesn't make any sense for send, so switch that to PRIVATE:
+	if c.resolvingRequest.Visibility == keybase1.TLFVisibility_ANY {
+		c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
+	}
+
+	if c.G().Standalone {
+		switch c.resolvingRequest.MembersType {
+		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE:
+			c.G().StartStandaloneChat()
+		default:
+			err = CantRunInStandaloneError{}
+			return err
+		}
+	}
+
+	conv, err := c.resolve(context.TODO())
+	if err != nil {
+		return err
+	}
+	return c.postPolicy(context.TODO(), conv, *c.setPolicy, c.setChannel)
+}
+
+func (c *CmdChatSetRetentionDev) ParseArgv(ctx *cli.Context) (err error) {
+	var tlfName string
+	// Get the TLF name from the first position arg
+	if len(ctx.Args()) != 2 {
+		return fmt.Errorf("conversation or team name required and seconds required")
+	}
+	tlfName = ctx.Args().Get(0)
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+		return err
+	}
+
+	ageInt, err := strconv.Atoi(ctx.Args().Get(1))
+	if err != nil {
+		return err
+	}
+	age := gregor1.DurationSec(ageInt)
+	p := chat1.NewRetentionPolicyWithExpire(chat1.RpExpire{
+		Age: age,
+	})
+	c.setPolicy = &p
+	c.setChannel = len(ctx.String("channel")) > 0
+
+	return nil
+}
+
+func (c *CmdChatSetRetentionDev) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}
+
+func (c *CmdChatSetRetentionDev) resolve(ctx context.Context) (*chat1.ConversationLocal, error) {
+	resolver, err := newChatConversationResolver(c.G())
+	if err != nil {
+		return nil, err
+	}
+	conv, _, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
+		CreateIfNotExists: false,
+		MustNotExist:      false,
+		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	})
+	return conv, err
+}
+
+func (c *CmdChatSetRetentionDev) postPolicy(ctx context.Context, conv *chat1.ConversationLocal, policy chat1.RetentionPolicy, setChannel bool) (err error) {
+	lcli, err := GetChatLocalClient(c.G())
+	if err != nil {
+		return err
+	}
+	return postRetentionPolicy(ctx, lcli, c.G().UI.GetTerminalUI(), conv, policy, setChannel, false /*doPrompt*/)
+}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -40,6 +40,7 @@ func getBuildSpecificChatCommands(cl *libcmdline.CommandLine, g *libkb.GlobalCon
 	return []cli.Command{
 		newCmdChatDeleteHistoryDev(cl, g),
 		newCmdChatSetRetention(cl, g),
+		newCmdChatSetRetentionDev(cl, g),
 		newCmdChatKBFSUpgrade(cl, g),
 	}
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -227,20 +227,15 @@ func (m MessageUnboxed) IsValid() bool {
 	return false
 }
 
-// IsValidFull returns whether the message is all of:
+// IsValidFull returns whether the message is both:
 // 1. Valid
 // 2. Has a non-deleted body with a type matching the header
 //    (TLFNAME is an exception as it has no body)
-// 3. Supersededby == 0
 func (m MessageUnboxed) IsValidFull() bool {
 	if !m.IsValid() {
 		return false
 	}
 	valid := m.Valid()
-	if valid.ServerHeader.SupersededBy != 0 {
-		// Message marked as superseded
-		return false
-	}
 	headerType := valid.ClientHeader.MessageType
 	switch headerType {
 	case MessageType_NONE:
@@ -256,7 +251,10 @@ func (m MessageUnboxed) IsValidFull() bool {
 	return bodyType == headerType
 }
 
-func (m MessageUnboxed) DebugString() string {
+func (m *MessageUnboxed) DebugString() string {
+	if m == nil {
+		return "[nil]"
+	}
 	state, err := m.State()
 	if err != nil {
 		return fmt.Sprintf("[INVALID err:%v]", err)
@@ -265,29 +263,42 @@ func (m MessageUnboxed) DebugString() string {
 		merr := m.Error()
 		return fmt.Sprintf("[%v %v mt:%v (%v)]", state, m.GetMessageID(), merr.ErrType, merr.ErrMsg)
 	}
-	if state != MessageUnboxedState_VALID {
+	switch state {
+	case MessageUnboxedState_VALID:
+		valid := m.Valid()
+		headerType := valid.ClientHeader.MessageType
+		s := fmt.Sprintf("%v %v", state, valid.ServerHeader.MessageID)
+		bodyType, err := valid.MessageBody.MessageType()
+		if err != nil {
+			return fmt.Sprintf("[INVALID-BODY err:%v]", err)
+		}
+		if headerType == bodyType {
+			s = fmt.Sprintf("%v %v", s, headerType)
+		} else {
+			if headerType == MessageType_TLFNAME {
+				s = fmt.Sprintf("%v h:%v (b:%v)", s, headerType, bodyType)
+			} else {
+				s = fmt.Sprintf("%v h:%v != b:%v", s, headerType, bodyType)
+			}
+		}
+		if valid.ServerHeader.SupersededBy != 0 {
+			s = fmt.Sprintf("%v supBy:%v", s, valid.ServerHeader.SupersededBy)
+		}
+		return fmt.Sprintf("[%v]", s)
+	case MessageUnboxedState_OUTBOX:
+		obr := m.Outbox()
+		ostateStr := "CORRUPT"
+		ostate, err := obr.State.State()
+		if err != nil {
+			ostateStr = "CORRUPT"
+		} else {
+			ostateStr = fmt.Sprintf("%v", ostate)
+		}
+		return fmt.Sprintf("[%v obid:%v prev:%v ostate:%v %v]",
+			state, obr.OutboxID, obr.Msg.ClientHeader.OutboxInfo.Prev, ostateStr, obr.Msg.ClientHeader.MessageType)
+	default:
 		return fmt.Sprintf("[state:%v %v]", state, m.GetMessageID())
 	}
-	valid := m.Valid()
-	headerType := valid.ClientHeader.MessageType
-	s := fmt.Sprintf("%v %v", state, valid.ServerHeader.MessageID)
-	bodyType, err := valid.MessageBody.MessageType()
-	if err != nil {
-		return fmt.Sprintf("[INVALID-BODY err:%v]", err)
-	}
-	if headerType == bodyType {
-		s = fmt.Sprintf("%v %v", s, headerType)
-	} else {
-		if headerType == MessageType_TLFNAME {
-			s = fmt.Sprintf("%v h:%v (b:%v)", s, headerType, bodyType)
-		} else {
-			s = fmt.Sprintf("%v h:%v != b:%v", s, headerType, bodyType)
-		}
-	}
-	if valid.ServerHeader.SupersededBy != 0 {
-		s = fmt.Sprintf("%v supBy:%v", s, valid.ServerHeader.SupersededBy)
-	}
-	return fmt.Sprintf("[%v]", s)
 }
 
 func MessageUnboxedDebugStrings(ms []MessageUnboxed) (res []string) {

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -747,14 +747,16 @@ func (o SetRetentionRes) DeepCopy() SetRetentionRes {
 }
 
 type SweepRes struct {
-	FoundTask       bool `codec:"foundTask" json:"foundTask"`
-	DeletedMessages bool `codec:"deletedMessages" json:"deletedMessages"`
+	FoundTask       bool    `codec:"foundTask" json:"foundTask"`
+	DeletedMessages bool    `codec:"deletedMessages" json:"deletedMessages"`
+	Expunge         Expunge `codec:"expunge" json:"expunge"`
 }
 
 func (o SweepRes) DeepCopy() SweepRes {
 	return SweepRes{
 		FoundTask:       o.FoundTask,
 		DeletedMessages: o.DeletedMessages,
+		Expunge:         o.Expunge.DeepCopy(),
 	}
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -263,7 +263,9 @@
     // creator info for the conversation
     union { null, ConversationCreatorInfo } creatorInfo;
 
-    Expunge expunge; // The latest history deletion. Defaults to zeroes.
+    // The latest history deletion. Defaults to zeroes.
+    // The client keeps this synced for retention but not for delete-history messages.
+    Expunge expunge;
     union { null, RetentionPolicy } convRetention;
     union { null, RetentionPolicy } teamRetention;
   }

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -277,6 +277,7 @@ protocol remote {
   record SweepRes {
   boolean foundTask;
     boolean deletedMessages;
+    Expunge expunge;
   }
   SweepRes retentionSweepConv(ConversationID convID);
 

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -1258,7 +1258,7 @@ export type StaleUpdateType =
   | 0 // CLEAR_0
   | 1 // NEWACTIVITY_1
 
-export type SweepRes = $ReadOnly<{foundTask: Boolean, deletedMessages: Boolean}>
+export type SweepRes = $ReadOnly<{foundTask: Boolean, deletedMessages: Boolean, expunge: Expunge}>
 
 export type SyncAllNotificationRes = {typ: 0, state: ?Gregor1.State} | {typ: 1, incremental: ?Gregor1.SyncResult}
 

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -564,6 +564,10 @@
         {
           "type": "boolean",
           "name": "deletedMessages"
+        },
+        {
+          "type": "Expunge",
+          "name": "expunge"
         }
       ]
     }

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -1258,7 +1258,7 @@ export type StaleUpdateType =
   | 0 // CLEAR_0
   | 1 // NEWACTIVITY_1
 
-export type SweepRes = $ReadOnly<{foundTask: Boolean, deletedMessages: Boolean}>
+export type SweepRes = $ReadOnly<{foundTask: Boolean, deletedMessages: Boolean, expunge: Expunge}>
 
 export type SyncAllNotificationRes = {typ: 0, state: ?Gregor1.State} | {typ: 1, incremental: ?Gregor1.SyncResult}
 


### PR DESCRIPTION
NOTE: Clients before this PR can **crash** if any conversation they interact with has had a retention policy sweep.

Clients consume Expunge notifications and delete their local messages.

The CLI `keybase chat retention-policy` is still dev-only.

- [x] Depends on https://github.com/keybase/keybase/pull/2115
- [x] I have some questions which are in the code as `@@@ TODO`
- [x] Needs https://github.com/keybase/keybase/pull/2142 for tests

Compatibility:
- Manually tested between two clients after this PR.
- Clients at the last mobile release (02aaf2cfc) will PANIC. So we should wait until everyone has a new release before using this feature. They panic when trying to present messages that are deleted but have supersededby=0.
- A client that received messages before this PR and then upgrades will in some cases not delete messages. If the conv is inactive after the upgrade then the client will think it's synced but it's not. To fix this we should bust the inbox and conv caches. But I'm not sure whether to do that in this PR or a subsequent one where we actually make this available.