### PR TITLE
Fixes problem when Alt-Shift opens menu on Linux

### DIFF
--- a/shared/desktop/app/menu-helper.js
+++ b/shared/desktop/app/menu-helper.js
@@ -106,12 +106,15 @@ export default function makeMenu(window: any) {
       },
       {
         ...editMenu,
+        label: '&Edit',
       },
       {
         ...windowMenu,
+        label: '&Window',
       },
       {
         ...helpMenu,
+        label: '&Help',
       },
     ]
     const menu = Menu.buildFromTemplate(template)


### PR DESCRIPTION
Electron has issue when Alt+Shift opens menu on Linux. It is really killing when people use it for language switching.
 
Similar problems with other projects:
- https://github.com/RocketChat/Rocket.Chat.Electron/issues/50
- https://github.com/mattermost/desktop/issues/104

This PR uses solution applied for projects mentioned above.
