### PR TITLE
Installer and startup-shortcut fixes

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -22,6 +22,7 @@
     <Feature Id="ProductFeature" Title="Keybase Application" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
       <ComponentGroupRef Id="GuiComps" />
+      <ComponentRef Id="GUIShortCutComponent" />
       <ComponentGroupRef Id="StartupShortcuts" />
       <ComponentGroupRef Id="GuiStartMenuTileColors" />
       <ComponentGroupRef Id="BrowserExtensionKbnm" />
@@ -30,12 +31,12 @@
 
     <InstallExecuteSequence>
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
-      <Custom Action="StopMainApp" Before="StopUpdater"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
-      <Custom Action="StopUpdater" Before="StopGUI"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
+      <Custom Action="StopMainApp" Before="StopUpdater"><![CDATA[Installed OR UPGRADINGPRODUCTCODE]]></Custom>
+      <Custom Action="StopUpdater" Before="StopGUI"><![CDATA[Installed OR UPGRADINGPRODUCTCODE]]></Custom>
       <Custom Action="RemoveBrowserExtension" Before="InstallValidate"><![CDATA[Installed]]></Custom>
-      <Custom Action="RemoveGUIShortcut" Before="InstallValidate"><![CDATA[REMOVE ~= "ALL" AND NOT WIX_UPGRADE_DETECTED]]></Custom>
+      <Custom Action="RemoveGUIShortcut" Before="InstallValidate"><![CDATA[REMOVE ~= "ALL" AND NOT UPGRADINGPRODUCTCODE]]></Custom>
       <!-- StopGUI is legacy and to be removed after enough people are updated -->
-      <Custom Action="StopGUI" Before="InstallValidate"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
+      <Custom Action="StopGUI" Before="InstallValidate"><![CDATA[Installed OR UPGRADINGPRODUCTCODE]]></Custom>
       <Custom Action="RunMainApp" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="RunGUI" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="AddBrowserExtension" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
@@ -81,13 +82,6 @@
         </RegistryKey>
         <File Id="keybase.exe" Source="$(env.GOPATH)\src\github.com\keybase\client\go\keybase\keybase.exe" Checksum="yes"/>
 			</Component>
-      <Component Id="GUIRunOnce">
-        <RegistryKey
-          Key="SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce"
-          Root="HKCU">
-          <RegistryValue Name="electron.app.Keybase" Type="string" Value="[GuiDir]Keybase.exe" />
-        </RegistryKey>
-      </Component>
       <Component Id="keybaserq.exe" Guid="{4A8A451F-973A-4E59-AC42-A8A9878FC94B}">
         <CreateFolder />
         <RemoveFolder Id="RemoveMyKeybaseRQ" On="uninstall" />
@@ -156,10 +150,6 @@
           <RegistryValue Name="ShortCutStartUp" Type="integer" Value="1" KeyPath="yes"  />
         </RegistryKey>
       </Component>
-      <Component Id="GUIShortCutStartUpComponent" Guid="804f1054-a702-47f2-8da2-17ab4ea67877">
-        <CreateFolder />
-        <RemoveFile Id="RemoveGUIStartupLink" Directory="StartupFolder" Name="GUIStartup.lnk" On="uninstall" />
-      </Component>
     </ComponentGroup>    
   </Fragment>
   <Fragment>
@@ -189,6 +179,17 @@
 
     </ComponentGroup>
   </Fragment>
+  <Fragment>
+    <Component Id="GUIShortCutComponent" Guid="{95AB14DC-1529-423E-A20C-C0A8C63AF94E}" Directory="ProgramMenuFolder">
+      <Shortcut Id="GUIShortCut"
+                Name="Keybase"
+                Description="Start GUI"
+                Target="[GuiDir]Keybase.exe"
+                WorkingDirectory="GuiDir"/>
+      <RegistryValue Root="HKCU" Key="Software\Keybase\Keybase" Name="ShortCutGUI" Type="integer" Value="1" KeyPath="yes"/>
+    </Component>
+  </Fragment>
+
   <Fragment>
     <CustomAction Id="RunMainApp"
               Directory="INSTALLFOLDER"
@@ -243,12 +244,12 @@
     <CustomAction Id="RemoveGUIShortcut"
                   Script="vbscript">
       <![CDATA[
-        const HKLM = &H80000002
+        const HKCU = &H80000001
         strComputer = "."
         Set oReg=GetObject("winmgmts:{impersonationLevel=impersonate}!\\" & strComputer & "\root\default:StdRegProv")
         strKeyPath = "SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
         strValueName = "electron.app.Keybase"
-        oReg.DeleteValue HKLM,strKeyPath,strValueName
+        oReg.DeleteValue HKCU,strKeyPath,strValueName
       ]]>
     </CustomAction>
   </Fragment>  

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -34,7 +34,7 @@
       <Custom Action="StopMainApp" Before="StopUpdater"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="StopUpdater" Before="StopGUI"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="RemoveBrowserExtension" Before="InstallValidate"><![CDATA[Installed]]></Custom>
-      <Custom Action="RemoveGUIShortcut" Before="InstallValidate"><![CDATA[REMOVE ~= "ALL" AND NOT UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
+      <Custom Action="RemoveGUIStartupShortcut" Before="InstallValidate"><![CDATA[REMOVE ~= "ALL" AND NOT (UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED)]]></Custom>
       <!-- StopGUI is legacy and to be removed after enough people are updated -->
       <Custom Action="StopGUI" Before="InstallValidate"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="RunMainApp" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
@@ -241,7 +241,7 @@
               Return="ignore"/>
   </Fragment>
   <Fragment>
-    <CustomAction Id="RemoveGUIShortcut"
+    <CustomAction Id="RemoveGUIStartupShortcut"
                   Script="vbscript">
       <![CDATA[
         const HKCU = &H80000001

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -32,7 +32,8 @@
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
       <Custom Action="StopMainApp" Before="StopUpdater"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="StopUpdater" Before="StopGUI"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
-      <Custom Action="RemoveBrowserExtension" Before="InstallValidate"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
+      <Custom Action="RemoveBrowserExtension" Before="InstallValidate"><![CDATA[Installed]]></Custom>
+      <Custom Action="RemoveGUIShortcut" Before="InstallValidate"><![CDATA[REMOVE ~= "ALL" AND NOT WIX_UPGRADE_DETECTED]]></Custom>
       <!-- StopGUI is legacy and to be removed after enough people are updated -->
       <Custom Action="StopGUI" Before="InstallValidate"><![CDATA[Installed OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="RunMainApp" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
@@ -80,6 +81,13 @@
         </RegistryKey>
         <File Id="keybase.exe" Source="$(env.GOPATH)\src\github.com\keybase\client\go\keybase\keybase.exe" Checksum="yes"/>
 			</Component>
+      <Component Id="GUIRunOnce">
+        <RegistryKey
+          Key="SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce"
+          Root="HKCU">
+          <RegistryValue Name="electron.app.Keybase" Type="string" Value="[GuiDir]Keybase.exe" />
+        </RegistryKey>
+      </Component>
       <Component Id="keybaserq.exe" Guid="{4A8A451F-973A-4E59-AC42-A8A9878FC94B}">
         <CreateFolder />
         <RemoveFolder Id="RemoveMyKeybaseRQ" On="uninstall" />
@@ -231,4 +239,18 @@
               Execute="immediate"
               Return="ignore"/>
   </Fragment>
+  <Fragment>
+    <CustomAction Id="RemoveGUIShortcut"
+                  Script="vbscript">
+      <![CDATA[
+        const HKLM = &H80000002
+        strComputer = "."
+        Set oReg=GetObject("winmgmts:{impersonationLevel=impersonate}!\\" & strComputer & "\root\default:StdRegProv")
+        strKeyPath = "SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+        strValueName = "electron.app.Keybase"
+        oReg.DeleteValue HKLM,strKeyPath,strValueName
+      ]]>
+    </CustomAction>
+  </Fragment>  
+
 </Wix>

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -31,12 +31,12 @@
 
     <InstallExecuteSequence>
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
-      <Custom Action="StopMainApp" Before="StopUpdater"><![CDATA[Installed OR UPGRADINGPRODUCTCODE]]></Custom>
-      <Custom Action="StopUpdater" Before="StopGUI"><![CDATA[Installed OR UPGRADINGPRODUCTCODE]]></Custom>
+      <Custom Action="StopMainApp" Before="StopUpdater"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
+      <Custom Action="StopUpdater" Before="StopGUI"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="RemoveBrowserExtension" Before="InstallValidate"><![CDATA[Installed]]></Custom>
-      <Custom Action="RemoveGUIShortcut" Before="InstallValidate"><![CDATA[REMOVE ~= "ALL" AND NOT UPGRADINGPRODUCTCODE]]></Custom>
+      <Custom Action="RemoveGUIShortcut" Before="InstallValidate"><![CDATA[REMOVE ~= "ALL" AND NOT UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
       <!-- StopGUI is legacy and to be removed after enough people are updated -->
-      <Custom Action="StopGUI" Before="InstallValidate"><![CDATA[Installed OR UPGRADINGPRODUCTCODE]]></Custom>
+      <Custom Action="StopGUI" Before="InstallValidate"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="RunMainApp" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="RunGUI" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="AddBrowserExtension" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>

--- a/shared/desktop/app/app-state.js
+++ b/shared/desktop/app/app-state.js
@@ -82,12 +82,11 @@ export default class AppState {
     })
 
     ipcMain.on('setAppState', (event, data) => {
-      let openAtLogin = this.state.openAtLogin
       this.state = {
         ...this.state,
         ...data,
       }
-      this.saveState({openAtLoginChanged: openAtLogin !== this.state.openAtLogin})
+      this.saveState()
     })
 
     this._loadStateSync()
@@ -100,7 +99,7 @@ export default class AppState {
   // > Note that it is unsafe to use fs.writeFile multiple times on the same file without waiting for the callback.
   //
   // It's hard to reproduce, but I have seen cases where this app-state.json file gets messed up.
-  saveState(arg) {
+  saveState() {
     try {
       let configPath = this.config.path
       let stateToSave = this.state
@@ -108,9 +107,8 @@ export default class AppState {
     } catch (err) {
       console.log(`Error saving file: ${err}`)
     }
-    let options = arg || {}
 
-    if (options.openAtLoginChanged) {
+    if (app.getLoginItemSettings().openAtLogin !== this.state.openAtLogin) {
       console.log(`Login item settings changed! now ${this.state.openAtLogin ? 'true' : 'false'}`)
       this.setOSLoginState()
     }

--- a/shared/desktop/app/app-state.js
+++ b/shared/desktop/app/app-state.js
@@ -125,10 +125,10 @@ export default class AppState {
   }
 
   setOSLoginState() {
-/*     if (__DEV__) {
+    if (__DEV__) {
       console.log('Skipping auto login state change due to dev env. ')
       return
-    } */
+    }
     // Comment this out if you want to test auto login stuff
 
     const isDarwin = process.platform === 'darwin'

--- a/shared/desktop/app/app-state.js
+++ b/shared/desktop/app/app-state.js
@@ -82,11 +82,12 @@ export default class AppState {
     })
 
     ipcMain.on('setAppState', (event, data) => {
+      let openAtLogin = this.state.openAtLogin
       this.state = {
         ...this.state,
         ...data,
       }
-      this.saveState()
+      this.saveState({openAtLoginChanged: openAtLogin !== this.state.openAtLogin})
     })
 
     this._loadStateSync()
@@ -99,7 +100,7 @@ export default class AppState {
   // > Note that it is unsafe to use fs.writeFile multiple times on the same file without waiting for the callback.
   //
   // It's hard to reproduce, but I have seen cases where this app-state.json file gets messed up.
-  saveState() {
+  saveState(arg) {
     try {
       let configPath = this.config.path
       let stateToSave = this.state
@@ -107,8 +108,9 @@ export default class AppState {
     } catch (err) {
       console.log(`Error saving file: ${err}`)
     }
+    let options = arg || {}
 
-    if (app.getLoginItemSettings().openAtLogin !== this.state.openAtLogin) {
+    if (options.openAtLoginChanged) {
       console.log(`Login item settings changed! now ${this.state.openAtLogin ? 'true' : 'false'}`)
       this.setOSLoginState()
     }

--- a/shared/desktop/app/app-state.js
+++ b/shared/desktop/app/app-state.js
@@ -125,10 +125,10 @@ export default class AppState {
   }
 
   setOSLoginState() {
-    if (__DEV__) {
+/*     if (__DEV__) {
       console.log('Skipping auto login state change due to dev env. ')
       return
-    }
+    } */
     // Comment this out if you want to test auto login stuff
 
     const isDarwin = process.platform === 'darwin'
@@ -217,35 +217,7 @@ export default class AppState {
   }
 
   setWinLoginState() {
-    // Note that setLoginItemSettings uses the registry. We use a .lnk file
-    // because it is easier for the installer to remove on uninstall.
-    if (!process.env.APPDATA) {
-      throw new Error('APPDATA unexpectedly empty')
-    }
-    const appDataPath = '' + process.env.APPDATA
-    const linkpath = path.join(
-      appDataPath,
-      'Microsoft\\Windows\\Start Menu\\Programs\\Startup\\GUIStartup.lnk'
-    )
-    if (this.state.openAtLogin) {
-      if (!fs.existsSync(linkpath)) {
-        var ws = require('windows-shortcuts')
-        if (!process.env.APPDATA) {
-          throw new Error('APPDATA unexpectedly empty')
-        }
-        ws.create(linkpath, path.join(appDataPath, 'Keybase\\gui\\Keybase.exe'))
-      }
-    } else {
-      if (fs.existsSync(linkpath)) {
-        fs.unlink(linkpath, err => {
-          if (err) {
-            console.log('An error occurred unlinking the shortcut ' + err.message)
-          }
-        })
-      } else {
-        console.log("Keybase.lnk file doesn't exist, cannot delete")
-      }
-    }
+    app.setLoginItemSettings({openAtLogin: !!this.state.openAtLogin})
   }
 
   manageWindow(win: any) {

--- a/shared/desktop/yarn-helper/index.js
+++ b/shared/desktop/yarn-helper/index.js
@@ -33,7 +33,6 @@ const commands = {
       makeShims(['net', 'tls', 'msgpack'])
       if (process.platform !== 'win32') {
         makeShims(['regedit'])
-        makeShims(['windows-shortcuts'])
       }
     },
     help: 'all: install global eslint. dummy modules',

--- a/shared/package.json
+++ b/shared/package.json
@@ -202,7 +202,6 @@
     "webpack-merge": "4.1.1"
   },
   "optionalDependencies": {
-    "regedit": "2.2.7",
-    "windows-shortcuts": "^0.1.6"
+    "regedit": "2.2.7"
   }
 }

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -10267,10 +10267,6 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
-windows-shortcuts@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/windows-shortcuts/-/windows-shortcuts-0.1.6.tgz#27970c5c346ffd81821c3e12528c0babca0a5a99"
-
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"


### PR DESCRIPTION
Use the Electron startup thing after all.
Installers with these tweaks seem OK, this is the one I'd like to ship (unless it blows up before then).
@keybase/react-hackers 