### PR TITLE
Lower JS engine destroy timeout on Android

### DIFF
--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -86,7 +86,11 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
     public void destroy(){
         try {
             executor.shutdownNow();
-            executor.awaitTermination(30, TimeUnit.SECONDS);
+            // We often hit this timeout during app resume, e.g. hit the back
+            // button to go to home screen and then tap Keybase app icon again.
+            if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {
+                Log.w(NAME, "Executor pool didn't shut down cleanly");
+            }
             executor = null;
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
@keybase/react-hackers 

We end up hanging on this 30 second wait in Android KeybaseEngine on app resume from background sometimes.  (I think the ultimate cause is maybe a race on the way down -- during backgrounding rather than resuming -- with whether this engine shutdown code runs before vs after the backgrounding happens, but I haven't chased that down.)

Lowering the delay from 30 seconds to 3 seconds has no obvious bad effects, and does make the hang only last 3 seconds.  And I've added a log line when it happens so that we won't forget that we did this and it's causing a 3 second delay sometimes.  @chrisnojima, what'd you think?  Is the approach okay, and would you rather use a different number of seconds delay?