### PR TITLE
Fix git settings when not in broadcast channel

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -150,6 +150,17 @@ func (h *Helper) FindConversationsByID(ctx context.Context, convIDs []chat1.Conv
 	return inbox.Convs, nil
 }
 
+func (h *Helper) GetChannelTopicName(ctx context.Context, tlfID chat1.TLFID,
+	topicType chat1.TopicType, convID chat1.ConversationID) (topicName string, err error) {
+	kuid, err := CurrentUID(h.G())
+	if err != nil {
+		return topicName, err
+	}
+	uid := gregor1.UID(kuid.ToBytes())
+	topicName, _, err = h.G().TeamChannelSource.GetChannelTopicName(ctx, uid, tlfID, topicType, convID)
+	return topicName, err
+}
+
 type sendHelper struct {
 	utils.DebugLabeler
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -191,6 +191,7 @@ type TeamChannelSource interface {
 
 	GetChannelsFull(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType) ([]chat1.ConversationLocal, []chat1.RateLimit, error)
 	GetChannelsTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType) ([]ConvIDAndTopicName, []chat1.RateLimit, error)
+	GetChannelTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType, chat1.ConversationID) (string, []chat1.RateLimit, error)
 	ChannelsChanged(context.Context, chat1.TLFID)
 }
 

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -44,6 +45,8 @@ type testTeamChannelSource struct {
 	channels []string
 }
 
+var _ types.TeamChannelSource = (*testTeamChannelSource)(nil)
+
 func newTestTeamChannelSource(channels []string) *testTeamChannelSource {
 	return &testTeamChannelSource{
 		channels: channels,
@@ -58,6 +61,11 @@ func (t *testTeamChannelSource) GetChannelsTopicName(ctx context.Context, uid gr
 		})
 	}
 	return res, rl, nil
+}
+
+func (t *testTeamChannelSource) GetChannelTopicName(ctx context.Context, uid gregor1.UID,
+	teamID chat1.TLFID, topicType chat1.TopicType, convID chat1.ConversationID) (string, []chat1.RateLimit, error) {
+	return "", nil, fmt.Errorf("testTeamChannelSource.GetChannelTopicName not implemented")
 }
 
 func (t *testTeamChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID,

--- a/go/git/common_test.go
+++ b/go/git/common_test.go
@@ -2,8 +2,10 @@ package git
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -46,6 +48,8 @@ type mockChatHelper struct {
 	sentMessages []MockMessage
 	convs        map[string]chat1.ConversationLocal
 }
+
+var _ libkb.ChatHelper = (*mockChatHelper)(nil)
 
 func newMockChatHelper() *mockChatHelper {
 	return &mockChatHelper{
@@ -146,6 +150,16 @@ func (m *mockChatHelper) FindConversationsByID(ctx context.Context, convIDs []ch
 		}
 	}
 	return convs, nil
+}
+
+func (m *mockChatHelper) GetChannelTopicName(ctx context.Context, teamID keybase1.TeamID,
+	topicType chat1.TopicType, convID chat1.ConversationID) (string, error) {
+	for _, v := range m.convs {
+		if v.Info.Id.Eq(convID) {
+			return utils.GetTopicName(v), nil
+		}
+	}
+	return "", fmt.Errorf("mockChatHelper.GetChannelTopicName conv not found %v", convID)
 }
 
 func (m *mockChatHelper) convKey(name string, topicName *string) string {

--- a/go/git/get.go
+++ b/go/git/get.go
@@ -122,6 +122,7 @@ func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keyba
 			if firstErr == nil {
 				firstErr = err
 			}
+			g.Log.CDebugf(ctx, "git.getMetadataInner error (team:%v, repo:%v): %v", responseRepo.TeamID, responseRepo.RepoID, err)
 			resultList = append(resultList, keybase1.NewGitRepoResultWithErr(err.Error()))
 		} else {
 			if !skip {
@@ -265,7 +266,7 @@ func getMetadataInnerSingle(ctx context.Context, g *libkb.GlobalContext,
 
 	var settings *keybase1.GitTeamRepoSettings
 	if repoFolder.FolderType == keybase1.FolderType_TEAM {
-		pset, err := convertTeamRepoSettings(ctx, g, responseRepo.ChatConvID, responseRepo.ChatDisabled)
+		pset, err := convertTeamRepoSettings(ctx, g, responseRepo.TeamID, responseRepo.ChatConvID, responseRepo.ChatDisabled)
 		if err != nil {
 			return nil, false, err
 		}

--- a/go/git/settings.go
+++ b/go/git/settings.go
@@ -40,10 +40,6 @@ func GetTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, arg keybas
 
 func convertTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext,
 	teamID keybase1.TeamID, chatConvID string, chatDisabled bool) (keybase1.GitTeamRepoSettings, error) {
-	tlfID, err := chat1.TeamIDToTLFID(teamID)
-	if err != nil {
-		return keybase1.GitTeamRepoSettings{}, err
-	}
 	settings := keybase1.GitTeamRepoSettings{
 		ChatDisabled: chatDisabled,
 	}
@@ -58,7 +54,7 @@ func convertTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext,
 			if err != nil {
 				return keybase1.GitTeamRepoSettings{}, err
 			}
-			channelName, err := g.ChatHelper.GetChannelTopicName(ctx, tlfID,
+			channelName, err := g.ChatHelper.GetChannelTopicName(ctx, teamID,
 				chat1.TopicType_CHAT, convID)
 			if err != nil {
 				return keybase1.GitTeamRepoSettings{}, err

--- a/go/git/settings.go
+++ b/go/git/settings.go
@@ -2,11 +2,9 @@ package git
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 
 	"github.com/keybase/client/go/chat/globals"
-	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -27,7 +25,7 @@ func GetTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, arg keybas
 		return keybase1.GitTeamRepoSettings{ChatDisabled: true}, nil
 	}
 
-	apiArg, err := settingsArg(ctx, g, arg.Folder, arg.RepoID)
+	apiArg, teamID, err := settingsArg(ctx, g, arg.Folder, arg.RepoID)
 	if err != nil {
 		return keybase1.GitTeamRepoSettings{}, err
 	}
@@ -37,10 +35,15 @@ func GetTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, arg keybas
 		return keybase1.GitTeamRepoSettings{}, err
 	}
 
-	return convertTeamRepoSettings(ctx, g, resp.ChatConvID, resp.ChatDisabled)
+	return convertTeamRepoSettings(ctx, g, teamID, resp.ChatConvID, resp.ChatDisabled)
 }
 
-func convertTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, chatConvID string, chatDisabled bool) (keybase1.GitTeamRepoSettings, error) {
+func convertTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext,
+	teamID keybase1.TeamID, chatConvID string, chatDisabled bool) (keybase1.GitTeamRepoSettings, error) {
+	tlfID, err := chat1.TeamIDToTLFID(teamID)
+	if err != nil {
+		return keybase1.GitTeamRepoSettings{}, err
+	}
 	settings := keybase1.GitTeamRepoSettings{
 		ChatDisabled: chatDisabled,
 	}
@@ -51,22 +54,16 @@ func convertTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, chatCo
 			settings.ChannelName = &globals.DefaultTeamTopic
 		} else {
 			// lookup the channel name
-			convID, err := hex.DecodeString(chatConvID)
+			convID, err := chat1.MakeConvID(chatConvID)
 			if err != nil {
 				return keybase1.GitTeamRepoSettings{}, err
 			}
-			convs, err := g.ChatHelper.FindConversationsByID(ctx, []chat1.ConversationID{convID})
+			channelName, err := g.ChatHelper.GetChannelTopicName(ctx, tlfID,
+				chat1.TopicType_CHAT, convID)
 			if err != nil {
 				return keybase1.GitTeamRepoSettings{}, err
 			}
-			if len(convs) == 0 {
-				return keybase1.GitTeamRepoSettings{}, errors.New("no channel found")
-			}
-			if len(convs) > 1 {
-				return keybase1.GitTeamRepoSettings{}, errors.New("multiple conversations found")
-			}
-			name := utils.GetTopicName(convs[0])
-			settings.ChannelName = &name
+			settings.ChannelName = &channelName
 		}
 	}
 
@@ -78,7 +75,7 @@ func SetTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, arg keybas
 	if arg.Folder.FolderType != keybase1.FolderType_TEAM {
 		return errors.New("SetTeamRepoSettings denied: this repo is not a team repo")
 	}
-	apiArg, err := settingsArg(ctx, g, arg.Folder, arg.RepoID)
+	apiArg, _, err := settingsArg(ctx, g, arg.Folder, arg.RepoID)
 	if err != nil {
 		return err
 	}
@@ -108,14 +105,14 @@ func SetTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, arg keybas
 	return err
 }
 
-func settingsArg(ctx context.Context, g *libkb.GlobalContext, folder keybase1.Folder, repoID keybase1.RepoID) (*libkb.APIArg, error) {
+func settingsArg(ctx context.Context, g *libkb.GlobalContext,
+	folder keybase1.Folder, repoID keybase1.RepoID) (apiArg *libkb.APIArg, teamID keybase1.TeamID, err error) {
 	teamer := NewTeamer(g)
 	teamIDVis, err := teamer.LookupOrCreate(ctx, folder)
 	if err != nil {
-		return nil, err
+		return nil, teamID, err
 	}
-
-	arg := &libkb.APIArg{
+	apiArg = &libkb.APIArg{
 		Endpoint:    "kbfs/git/team/settings",
 		SessionType: libkb.APISessionTypeREQUIRED,
 		NetContext:  ctx,
@@ -124,6 +121,5 @@ func settingsArg(ctx context.Context, g *libkb.GlobalContext, folder keybase1.Fo
 			"repo_id": libkb.S{Val: string(repoID)},
 		},
 	}
-
-	return arg, nil
+	return apiArg, teamIDVis.TeamID, nil
 }

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -495,7 +495,7 @@ func (m *ChatRemoteMock) createBogusBody(typ chat1.MessageType) chat1.MessageBod
 
 type dummyChannelSource struct{}
 
-var _ ChannelSource = (*dummyChannelSource)(nil)
+var _ types.TeamChannelSource = (*dummyChannelSource)(nil)
 
 func (d dummyChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID, tlfID chat1.TLFID,
 	topicType chat1.TopicType) ([]chat1.ConversationLocal, []chat1.RateLimit, error) {
@@ -505,6 +505,11 @@ func (d dummyChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID
 func (d dummyChannelSource) GetChannelsTopicName(ctx context.Context, uid gregor1.UID, tlfID chat1.TLFID,
 	topicType chat1.TopicType) ([]types.ConvIDAndTopicName, []chat1.RateLimit, error) {
 	return nil, nil, nil
+}
+
+func (d dummyChannelSource) GetChannelTopicName(ctx context.Context, uid gregor1.UID, tlfID chat1.TLFID,
+	topicType chat1.TopicType, convID chat1.ConversationID) (string, []chat1.RateLimit, error) {
+	return "", nil, nil
 }
 
 func (d dummyChannelSource) ChannelsChanged(ctx context.Context, tlfID chat1.TLFID) {}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -495,6 +495,8 @@ func (m *ChatRemoteMock) createBogusBody(typ chat1.MessageType) chat1.MessageBod
 
 type dummyChannelSource struct{}
 
+var _ ChannelSource = (*dummyChannelSource)(nil)
+
 func (d dummyChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID, tlfID chat1.TLFID,
 	topicType chat1.TopicType) ([]chat1.ConversationLocal, []chat1.RateLimit, error) {
 	return nil, nil, nil

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -717,5 +717,5 @@ type ChatHelper interface {
 	FindConversations(ctx context.Context, name string, topicName *string, topicType chat1.TopicType,
 		membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility) ([]chat1.ConversationLocal, error)
 	FindConversationsByID(ctx context.Context, convIDs []chat1.ConversationID) ([]chat1.ConversationLocal, error)
-	GetChannelTopicName(context.Context, chat1.TLFID, chat1.TopicType, chat1.ConversationID) (string, error)
+	GetChannelTopicName(context.Context, keybase1.TeamID, chat1.TopicType, chat1.ConversationID) (string, error)
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -717,4 +717,5 @@ type ChatHelper interface {
 	FindConversations(ctx context.Context, name string, topicName *string, topicType chat1.TopicType,
 		membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility) ([]chat1.ConversationLocal, error)
 	FindConversationsByID(ctx context.Context, convIDs []chat1.ConversationID) ([]chat1.ConversationLocal, error)
+	GetChannelTopicName(context.Context, chat1.TLFID, chat1.TopicType, chat1.ConversationID) (string, error)
 }


### PR DESCRIPTION
The problem was that when you tried to interact with the metadata for a git repo that is set to broadcast to a channel that you were not in it would error out.
```$ keybase-devprod-cli git list
Error in repo: no channel found

...
list of repos missing one
...
```

Even being in preview mode for the channel would fix the problem. The problem was `convertTeamRepoSettings` couldn't find the chat channel because it's not in ConvSource. It was using `g.ChatHelper.FindConversationsByID` which doesn't work. I switched it to use `CachingTeamChannelSource.GetChannelsTopicName` which seems to work, and is cached separately. Didn't bother making `FindConversationsByID` work for convs you're not in.