### PR TITLE
Optimize KeybasePacket.unpackBody

### DIFF
--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -1155,7 +1155,7 @@ func (c *ChainLink) Store(g *GlobalContext) (didStore bool, err error) {
 	key := DbKey{Typ: DBLink, Key: c.id.String()}
 
 	// Don't write with any aliases
-	if err = g.LocalDb.Put(key, []DbKey{}, packed); err != nil {
+	if err = g.LocalDb.Put(key, nil, packed); err != nil {
 		return false, err
 	}
 	g.VDL.Log(VLog1, "| Store Link %s", c.id)

--- a/go/libkb/kbpackets.go
+++ b/go/libkb/kbpackets.go
@@ -204,13 +204,15 @@ func (p *KeybasePacket) unpackBody(ch *codec.MsgpackHandle) error {
 		si := &NaclSigInfo{
 			Kid:      keybase1.BinaryKID(mb["key"].([]byte)),
 			Payload:  mb["payload"].([]byte),
-			SigType:  int(mb["sig_type"].(int64)),
 			HashType: int(mb["hash_type"].(int64)),
 			Detached: mb["detached"].(bool),
 		}
 
 		if sig, ok := mb["sig"].([]byte); ok {
 			copy(si.Sig[:], sig)
+		}
+		if st, ok := mb["sig_type"].(int64); ok {
+			si.SigType = int(st)
 		}
 		if v, ok := mb["version"].(int64); ok {
 			si.Version = int(v)

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb"
 	errors "github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
@@ -106,9 +107,15 @@ func NewLevelDb(g *GlobalContext, filename func() string) *LevelDb {
 // Explicit open does nothing we'll wait for a lazy open
 func (l *LevelDb) Open() error { return nil }
 
+// Opts returns the options for all leveldb databases.
+//
+// PC: I think it's worth trying a bloom filter.  From docs:
+// "In many cases, a filter can cut down the number of disk
+// seeks from a handful to a single disk seek per DB.Get call."
 func (l *LevelDb) Opts() *opt.Options {
 	return &opt.Options{
 		OpenFilesCacheCapacity: l.G().Env.GetLevelDBNumFiles(),
+		Filter:                 filter.NewBloomFilter(10),
 	}
 }
 


### PR DESCRIPTION
The optimization here is not to Encode/Decode the signature body after determining the type, but instead take the values out of the map directly.

On the large test sigchain, it improves load time from 1.6s to 1.2s, TotalAlloc from 490MB to 430MB.

I tried a bunch of other stuff, but this is the main noticeable difference.  Nothing else seemed to matter much, so wasn't worth changing.

I played around with leveldb options as well.  I think we should try the Filter I added below and see if it gives any noticeable performance difference.  I'm trying it in production desktop now.