### PR TITLE
Fix 'missing secrets' error from poisoned subteam cache

### DIFF
--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -386,7 +386,6 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	} else if !l.hasSyncedSecrets(ret) {
 		// The cached secrets are behind the cached chain.
 		// We may need to hit the server for secrets, even though there are no new links.
-
 		if arg.needAdmin {
 			l.G().Log.CDebugf(ctx, "TeamLoader fetching: NeedAdmin")
 			// Admins should always have up-to-date secrets
@@ -401,16 +400,10 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 			fetchLinksAndOrSecrets = true
 		}
 		if arg.readSubteamID == nil {
-			// This is not a recursive load.
-			// If we are in the team, we should have the keys.
-			myCachedRole, err := TeamSigChainState{ret.Chain}.GetUserRole(arg.me)
-			if err != nil {
-				myCachedRole = keybase1.TeamRole_NONE
-			}
-			if myCachedRole.IsReaderOrAbove() {
-				l.G().Log.CDebugf(ctx, "TeamLoader fetching: role: %v", myCachedRole)
-				fetchLinksAndOrSecrets = true
-			}
+			// This is not a recursive load. We should have the keys.
+			// This may be an extra round trip for public teams you're not in.
+			l.G().Log.CDebugf(ctx, "TeamLoader fetching: primary load")
+			fetchLinksAndOrSecrets = true
 		}
 	}
 

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -834,7 +834,7 @@ func TestRotateSubteamByExplicitReader(t *testing.T) {
 }
 
 // TestLoaderCORE_7201 tests a case that came up.
-// A user had trouble loading A.B because it was stuck in a secretless in the cache.
+// A user had trouble loading A.B because the cached object was stuck as secretless.
 // U1 is an   ADMIN in A
 // U1 is only IMP implicitly in A.B
 // U1 is a    WRITER in A.B.C

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -832,3 +832,53 @@ func TestRotateSubteamByExplicitReader(t *testing.T) {
 		require.NoError(t, err, "load as %v", i)
 	}
 }
+
+// TestLoaderCORE_7201 tests a case that came up.
+// A user had trouble loading A.B because it was stuck in a secretless in the cache.
+// U1 is an   ADMIN in A
+// U1 is only IMP implicitly in A.B
+// U1 is a    WRITER in A.B.C
+func TestLoaderCORE_7201(t *testing.T) {
+	fus, tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	t.Logf("U0 creates A")
+	rootName, rootID := createTeam2(*tcs[0])
+
+	t.Logf("U0 adds U1 to A")
+	_, err := AddMember(context.TODO(), tcs[0].G, rootName.String(), fus[1].Username, keybase1.TeamRole_ADMIN)
+	require.NoError(t, err, "add member")
+
+	t.Logf("U0 creates A.B")
+	subBName, subBID := createSubteam(tcs[0], rootName, "bbb")
+
+	t.Logf("U0 creates A.B.C")
+	subCName, subCID := createSubteam(tcs[0], subBName, "ccc")
+
+	t.Logf("U0 adds U1 to A.B.C")
+	_, err = AddMember(context.TODO(), tcs[0].G, subCName.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+	require.NoError(t, err, "add member")
+	t.Logf("setup complete")
+
+	t.Logf("U1 loads and caches A.B.C")
+	// Causing A.B to get cached. Secretless?
+	_, err = Load(context.TODO(), tcs[1].G, keybase1.LoadTeamArg{
+		ID:          subCID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err)
+
+	t.Logf("U1 loads A")
+	_, err = Load(context.TODO(), tcs[1].G, keybase1.LoadTeamArg{
+		ID:          rootID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err)
+
+	t.Logf("U1 loads A.B")
+	_, err = Load(context.TODO(), tcs[1].G, keybase1.LoadTeamArg{
+		ID:          subBID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Tricky bug. If a team cache object is out of sync that's fine for recursive loads. And the out of sync objects are stored. But they aren't allowed to be returned from `load1`. The part that's changed was responsible for filling the secrets when the team is being loaded explicitly. But it didn't work for implicit admins.

**out of sync**: The off-chain stored secrets are behind the on-chain keys.
**recursive**: A team load of a parent that is only done in order to load its subteam. For example to get admin rights and parent team name.