### PR TITLE
Improved handling of keys where the private key is not accessible

### DIFF
--- a/go/engine/scankeys.go
+++ b/go/engine/scankeys.go
@@ -311,6 +311,12 @@ func (s *ScanKeys) unlockByID(id uint64) openpgp.EntityList {
 			continue
 		}
 
+		keyState := pubkey.CheckSecretKey()
+		if _, ok := keyState.(libkb.NoSecretKeyError); ok {
+			// no secret key (might be in smartcard)
+			continue
+		}
+
 		// some key in the bundle matched, so unlock everything:
 		parg := libkb.SecretKeyPromptArg{
 			Reason:   unlockReason,


### PR DESCRIPTION
# Issue

> I get asked for a passphrase to decrypt my key, I have tried inputting the Yubikey pin, but regardless of the value input it keeps prompting until I close the popup, at which point it repeats the process for the other Yubikey, before giving up.

https://github.com/keybase/keybase-issues/issues/3126

# Attempted fix

I have added handling to the scanning code, so that keys which have no secret key are not considered for use decrypting, as the passphrase prompt cannot be successful.

# Possible modifications

- Maybe showing a message saying that gpg might need to be used to decrypt the message