### PR TITLE
Clear passphrase when asking to verify it

### DIFF
--- a/shared/pinentry/index.desktop.js
+++ b/shared/pinentry/index.desktop.js
@@ -44,6 +44,7 @@ class Pinentry extends Component<Props, State> {
 
   _onSubmit = () => {
     this.props.onSubmit(this.state.passphrase)
+    this.setState({passphrase: ''})
   }
 
   componentDidMount() {
@@ -103,6 +104,7 @@ class Pinentry extends Component<Props, State> {
               onChangeText: passphrase => this.setState({passphrase}),
               onEnterKeyDown: this._onSubmit,
               type: this.state.showTyping ? 'passwordVisible' : 'password',
+              value: this.state.passphrase,
               ...typeStyle,
             }}
             checkboxContainerStyle={{paddingLeft: 60, paddingRight: 60, ...checkboxContainerStyle}}


### PR DESCRIPTION
@keybase/react-hackers 

When choosing a new passphrase it was filled in already during the "Verify new passphrase" step.  This is because:

* the passphrase state wasn't being reset when submitting a passphrase

* pinentry was using FormWithCheckbox with an onChangeText that updated the passphrase state, but there was nothing driving the value of the Input element, so even when the state is reset it'd stay at its old value.  Now it's driven by this.state.passphrase directly.