### PR TITLE
Change notifications settings on mobile if notifications are disabled

### DIFF
--- a/shared/settings/dumb.desktop.js
+++ b/shared/settings/dumb.desktop.js
@@ -319,6 +319,7 @@ const commonSettings = {
   onSave: () => console.log('onSave'),
   onToggle: (name: string) => console.log('on toggle', name),
   onToggleUnsubscribeAll: () => console.log('on subscribe all'),
+  mobileHasPermissions: true,
 }
 
 let unsubSettings = commonSettings

--- a/shared/settings/index.js
+++ b/shared/settings/index.js
@@ -9,6 +9,7 @@ import {type Tab} from '../constants/types/settings'
 const getNavBadges = (state: TypedState) => state.notifications.get('navBadges')
 
 type StateProps = {
+  badgeNotifications: boolean,
   badgeNumbers: {[key: Tab]: number},
   isModal: boolean,
   selectedTab: Tab,
@@ -21,6 +22,7 @@ const mapStateToProps = (
   // $FlowIssue
   const badgeNumbers: {[key: Tab]: number} = getNavBadges(state).toObject()
   return {
+    badgeNotifications: !state.push.hasPermissions,
     badgeNumbers,
     isModal: routeLeafTags.modal,
     // TODO: Is there a way to validate that routeSelected is a Tab?

--- a/shared/settings/nav/index.js.flow
+++ b/shared/settings/nav/index.js.flow
@@ -14,6 +14,7 @@ export type Props = {
   selectedTab: Tab,
   onTabChange: (tab: Tab) => void,
   onLogout: () => void,
+  badgeNotifications?: boolean,
   badgeNumbers: {[key: TabConstants.Tab]: number},
 }
 

--- a/shared/settings/nav/index.native.js
+++ b/shared/settings/nav/index.native.js
@@ -31,7 +31,7 @@ export function SettingsItem({
   )
 }
 
-function SettingsNav({badgeNumbers, selectedTab, onTabChange, onLogout}: Props) {
+function SettingsNav({badgeNotifications, badgeNumbers, selectedTab, onTabChange, onLogout}: Props) {
   return (
     <NativeScrollView style={{width: '100%', height: '100%'}}>
       <Box style={styleNavBox}>
@@ -52,7 +52,7 @@ function SettingsNav({badgeNumbers, selectedTab, onTabChange, onLogout}: Props) 
         />
         <SettingsItem
           text="Notifications"
-          badgeNumber={0}
+          badgeNumber={badgeNotifications ? 1 : 0}
           onClick={() => onTabChange(Constants.notificationsTab)}
         />
         <SettingsItem

--- a/shared/settings/notifications/container.js
+++ b/shared/settings/notifications/container.js
@@ -6,6 +6,7 @@ import {navigateUp} from '../../actions/route-tree'
 
 const mapStateToProps = (state: TypedState, ownProps: {}) => ({
   ...state.settings.notifications,
+  mobileHasPermissions: state.push.hasPermissions,
   waitingForResponse: state.settings.waitingForResponse,
 })
 

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import {Box, Checkbox, ProgressIndicator, Text} from '../../common-adapters'
 import {globalStyles, globalMargins} from '../../styles'
-
 import type {NotificationsSettingsState} from '../../constants/types/settings'
 import type {Props} from './index'
 
@@ -85,7 +84,8 @@ const Notifications = (props: Props) =>
         unsubscribedFromAll={props.groups.email && props.groups.email.unsubscribedFromAll}
       />
 
-      {props.groups.app_push &&
+      {props.mobileHasPermissions &&
+        props.groups.app_push &&
         props.groups.app_push.settings && (
           <Group
             allowEdit={props.allowEdit}
@@ -99,7 +99,8 @@ const Notifications = (props: Props) =>
           />
         )}
 
-      {props.groups.security &&
+      {props.mobileHasPermissions &&
+        props.groups.security &&
         props.groups.security.settings && (
           <Group
             allowEdit={props.allowEdit}

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import {Box, Checkbox, ProgressIndicator, Text} from '../../common-adapters'
-import {globalStyles, globalMargins} from '../../styles'
+import {globalStyles, globalMargins, isMobile} from '../../styles'
 import type {NotificationsSettingsState} from '../../constants/types/settings'
 import type {Props} from './index'
 
@@ -84,7 +84,7 @@ const Notifications = (props: Props) =>
         unsubscribedFromAll={props.groups.email && props.groups.email.unsubscribedFromAll}
       />
 
-      {props.mobileHasPermissions &&
+      {(!isMobile || props.mobileHasPermissions) &&
         props.groups.app_push &&
         props.groups.app_push.settings && (
           <Group
@@ -99,7 +99,7 @@ const Notifications = (props: Props) =>
           />
         )}
 
-      {props.mobileHasPermissions &&
+      {(!isMobile || props.mobileHasPermissions) &&
         props.groups.security &&
         props.groups.security.settings && (
           <Group

--- a/shared/settings/notifications/index.js.flow
+++ b/shared/settings/notifications/index.js.flow
@@ -1,16 +1,16 @@
 // @flow
 import {Component} from 'react'
 
-export type Group = {
-  settings: Settings,
-  unsubscribedFromAll: boolean,
-}
-
 export type Settings = Array<{
   description: string,
   name: string,
   subscribed: boolean,
 }>
+
+export type Group = {
+  settings: Settings,
+  unsubscribedFromAll: boolean,
+}
 
 export type Props = {
   allowEdit: boolean,
@@ -23,6 +23,7 @@ export type Props = {
   onRefresh: () => void,
   onToggle: (groupName: string, name: string) => void,
   onToggleUnsubscribeAll: (group: string) => void,
+  mobileHasPermissions: boolean,
   waitingForResponse: boolean,
 }
 

--- a/shared/settings/notifications/index.native.js
+++ b/shared/settings/notifications/index.native.js
@@ -3,11 +3,13 @@ import * as React from 'react'
 import {HeaderHoc, NativeScrollView} from '../../common-adapters/index.native'
 import {globalStyles} from '../../styles'
 import Notifications from './index.js'
+import TurnOnNotifications from './turn-on-notifications.native'
 
 import type {Props} from './index'
 
 const MobileNotifications = (props: Props) => (
   <NativeScrollView style={{...globalStyles.flexBoxColumn, flex: 1}}>
+    {!props.mobileHasPermissions && <TurnOnNotifications />}
     <Notifications {...props} />
   </NativeScrollView>
 )

--- a/shared/settings/notifications/turn-on-notifications.native.js
+++ b/shared/settings/notifications/turn-on-notifications.native.js
@@ -17,6 +17,7 @@ const TurnOnNotifications = (props: Props) => (
       width: '100%',
       height: 330,
       backgroundColor: globalColors.red,
+      overflow: 'hidden',
     }}
   >
     <Box style={{height: 270, width: 250, position: 'absolute', top: -20, left: globalMargins.medium}}>

--- a/shared/settings/notifications/turn-on-notifications.native.js
+++ b/shared/settings/notifications/turn-on-notifications.native.js
@@ -1,0 +1,57 @@
+// @flow
+import * as React from 'react'
+import {Box, Text, NativeImage} from '../../common-adapters/index.native'
+import {globalStyles, globalColors, globalMargins} from '../../styles'
+import * as PushGen from '../../actions/push-gen'
+import {connect} from '../../util/container'
+
+export type Props = {
+  onEnable: () => void,
+}
+
+const TurnOnNotifications = (props: Props) => (
+  <Box
+    style={{
+      ...globalStyles.flexBoxColumn,
+      position: 'relative',
+      width: '100%',
+      height: 330,
+      backgroundColor: globalColors.red,
+    }}
+  >
+    <Box style={{height: 270, width: 250, position: 'absolute', top: -20, left: globalMargins.medium}}>
+      <NativeImage
+        resizeMode="contain"
+        source={require('../../images/illustrations/illustration-turn-on-notifications-460-x-252.png')}
+      />
+    </Box>
+    <Text
+      type="BodySemibold"
+      backgroundMode="HighRisk"
+      style={{
+        textAlign: 'center',
+        position: 'absolute',
+        bottom: globalMargins.medium,
+        left: globalMargins.small,
+        right: globalMargins.small,
+      }}
+    >
+      You turned off native notifications for Keybase. It’s{' '}
+      <Text type="BodySemiboldItalic" backgroundMode="HighRisk">
+        very
+      </Text>{' '}
+      important you turn them back on.{'\n'}
+      <Text onClick={props.onEnable} type="BodySemiboldLink" backgroundMode="HighRisk">
+        Enable notifications
+      </Text>
+    </Text>
+  </Box>
+)
+
+const mapStateToProps = () => ({})
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onEnable: () => dispatch(PushGen.createPermissionsRequest()),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(TurnOnNotifications)

--- a/shared/settings/notifications/turn-on-notifications.native.js
+++ b/shared/settings/notifications/turn-on-notifications.native.js
@@ -5,6 +5,8 @@ import {globalStyles, globalColors, globalMargins} from '../../styles'
 import * as PushGen from '../../actions/push-gen'
 import {connect} from '../../util/container'
 
+const notificationMonster = '../../images/illustrations/illustration-turn-on-notifications-460-x-252.png'
+
 export type Props = {
   onEnable: () => void,
 }
@@ -21,10 +23,7 @@ const TurnOnNotifications = (props: Props) => (
     }}
   >
     <Box style={{height: 270, width: 250, position: 'absolute', top: -20, left: globalMargins.medium}}>
-      <NativeImage
-        resizeMode="contain"
-        source={require('../../images/illustrations/illustration-turn-on-notifications-460-x-252.png')}
-      />
+      <NativeImage resizeMode="contain" source={require(notificationMonster)} />
     </Box>
     <Text
       type="BodySemibold"

--- a/shared/settings/render.js.flow
+++ b/shared/settings/render.js.flow
@@ -9,6 +9,7 @@ export type Props = {
   selectedTab: Tab,
   onTabChange: (tab: Tab) => void,
   onLogout: () => void,
+  badgeNotifications?: boolean,
 }
 
 export default class Render extends React.Component<Props> {}

--- a/shared/settings/render.native.js
+++ b/shared/settings/render.native.js
@@ -7,6 +7,7 @@ import type {Props} from './render'
 function SettingsRender(props: Props) {
   return (
     <SettingsNav
+      badgeNotifications={props.badgeNotifications}
       badgeNumbers={props.badgeNumbers}
       selectedTab={props.selectedTab}
       onTabChange={props.onTabChange}


### PR DESCRIPTION
When notifications are disabled:
* Adds badge to Notifications item in mobile settings page
* Hides push notification settings
* Adds banner to push notifications with link that prompts / opens settings

<img src="https://user-images.githubusercontent.com/11968340/36284706-abc8396c-1276-11e8-812e-9b406d9890ff.jpg" width="200" />

r? @keybase/react-hackers 
