### PR TITLE
Fix multiple reset bugs in systests' teamTester 

### DIFF
--- a/go/client/rpc.go
+++ b/go/client/rpc.go
@@ -96,6 +96,7 @@ func RegisterProtocolsWithContext(prots []rpc.Protocol, g *libkb.GlobalContext) 
 			if _, ok := err.(rpc.AlreadyRegisteredError); !ok {
 				return err
 			}
+			g.Log.Debug("Protocol already resgistered: %v", err)
 			err = nil
 		}
 	}

--- a/go/client/rpc.go
+++ b/go/client/rpc.go
@@ -96,7 +96,7 @@ func RegisterProtocolsWithContext(prots []rpc.Protocol, g *libkb.GlobalContext) 
 			if _, ok := err.(rpc.AlreadyRegisteredError); !ok {
 				return err
 			}
-			g.Log.Debug("Protocol already resgistered: %v", err)
+			g.Log.Debug("Protocol already registered: %v", err)
 			err = nil
 		}
 	}

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -525,13 +525,13 @@ func (e *loginProvision) deviceName(ctx *Context) (string, error) {
 		}
 
 		if duplicate {
+			e.G().Log.Debug("Device name reused: %q", devname)
 			arg.ErrorMessage = fmt.Sprintf("Device name %q already used", devname)
 			continue
 		}
 
 		return devname, nil
 	}
-
 	return "", libkb.RetryExhaustedError{}
 }
 

--- a/go/libkb/passphrase_helper.go
+++ b/go/libkb/passphrase_helper.go
@@ -141,7 +141,6 @@ func GetPassphraseUntilCheck(g *GlobalContext, arg keybase1.GUIEntryArg, prompte
 		}
 		arg.RetryLabel = err.Error()
 	}
-
 	return keybase1.GetPassphraseRes{}, RetryExhaustedError{}
 }
 

--- a/go/protocol/keybase1/user.go
+++ b/go/protocol/keybase1/user.go
@@ -353,7 +353,8 @@ type DeleteUserArg struct {
 }
 
 type MeUserVersionArg struct {
-	SessionID int `codec:"sessionID" json:"sessionID"`
+	SessionID int  `codec:"sessionID" json:"sessionID"`
+	ForcePoll bool `codec:"forcePoll" json:"forcePoll"`
 }
 
 type GetUPAKArg struct {
@@ -395,7 +396,7 @@ type UserInterface interface {
 	InterestingPeople(context.Context, int) ([]InterestingPerson, error)
 	ResetUser(context.Context, int) error
 	DeleteUser(context.Context, int) error
-	MeUserVersion(context.Context, int) (UserVersion, error)
+	MeUserVersion(context.Context, MeUserVersionArg) (UserVersion, error)
 	// getUPAK returns a UPAK. Used mainly for debugging.
 	GetUPAK(context.Context, UID) (UPAKVersioned, error)
 }
@@ -719,7 +720,7 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]MeUserVersionArg)(nil), args)
 						return
 					}
-					ret, err = i.MeUserVersion(ctx, (*typedArgs)[0].SessionID)
+					ret, err = i.MeUserVersion(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -864,8 +865,7 @@ func (c UserClient) DeleteUser(ctx context.Context, sessionID int) (err error) {
 	return
 }
 
-func (c UserClient) MeUserVersion(ctx context.Context, sessionID int) (res UserVersion, err error) {
-	__arg := MeUserVersionArg{SessionID: sessionID}
+func (c UserClient) MeUserVersion(ctx context.Context, __arg MeUserVersionArg) (res UserVersion, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.user.meUserVersion", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -316,11 +316,12 @@ func (h *UserHandler) InterestingPeople(ctx context.Context, maxUsers int) (res 
 	return res, nil
 }
 
-func (h *UserHandler) MeUserVersion(ctx context.Context, sessionID int) (res keybase1.UserVersion, err error) {
+func (h *UserHandler) MeUserVersion(ctx context.Context, arg keybase1.MeUserVersionArg) (res keybase1.UserVersion, err error) {
 	loadMeArg := libkb.NewLoadUserArg(h.G()).
 		WithNetContext(ctx).
 		WithUID(h.G().Env.GetUID()).
 		WithSelf(true).
+		WithForcePoll(arg.ForcePoll).
 		WithPublicKeyOptional()
 	upak, _, err := h.G().GetUPAKLoader().LoadV2(loadMeArg)
 	if err != nil {

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -600,6 +600,7 @@ func (u *userPlusDevice) reset() {
 	uvAfter := u.userVersion()
 	require.NotEqual(u.tc.T, uvBefore.EldestSeqno, uvAfter.EldestSeqno,
 		"eldest seqno should change as result of reset")
+	u.tc.T.Logf("User reset; eldest seqno %d -> %d", uvBefore.EldestSeqno, uvAfter.EldestSeqno)
 }
 
 func (u *userPlusDevice) loginAfterReset() {
@@ -614,12 +615,15 @@ func (u *userPlusDevice) loginAfterResetHelper(puk bool) {
 	t := u.device.tctx.T
 	u.device.tctx.Tp.DisableUpgradePerUserKey = !puk
 	g := u.device.tctx.G
+	devName := randomDevice()
+	g.ResetSocket(true)
+	g.Log.Debug("loginAfterResetHelper: new device name is %q", devName)
 
 	ui := genericUI{
 		g:           g,
 		SecretUI:    signupInfoSecretUI{u.userInfo, u.tc.G.GetLog()},
 		LoginUI:     usernameLoginUI{u.username},
-		ProvisionUI: nullProvisionUI{randomDevice()},
+		ProvisionUI: nullProvisionUI{devName},
 	}
 	g.SetUI(&ui)
 	loginCmd := client.NewCmdLoginRunner(g)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -615,8 +615,14 @@ func (u *userPlusDevice) loginAfterResetHelper(puk bool) {
 	t := u.device.tctx.T
 	u.device.tctx.Tp.DisableUpgradePerUserKey = !puk
 	g := u.device.tctx.G
-	devName := randomDevice()
+
+	// We have to reset a socket here, since we need to regigster
+	// the protocols in the genericUI below. If we reuse the previous
+	// socket, then the RPC protocols will not update, and we'll wind
+	// up reusing the old device name.
 	g.ResetSocket(true)
+
+	devName := randomDevice()
 	g.Log.Debug("loginAfterResetHelper: new device name is %q", devName)
 
 	ui := genericUI{

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -628,6 +628,23 @@ func (u *userPlusDevice) loginAfterResetHelper(puk bool) {
 	require.NoError(t, err, "login after reset")
 }
 
+func TestTeamTesterMultipleResets(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	ann := tt.addUser("ann")
+	t.Logf("Signed up ann (%s)", ann.username)
+
+	ann.reset()
+	ann.loginAfterReset()
+
+	t.Logf("Ann resets for first time, uv is %v", ann.userVersion())
+
+	ann.reset()
+	ann.loginAfterReset()
+	t.Logf("Ann reset twice, uv is %v", ann.userVersion())
+}
+
 func (u *userPlusDevice) perUserKeyUpgrade() {
 	t := u.device.tctx.T
 	u.device.tctx.Tp.DisableUpgradePerUserKey = false

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -395,7 +395,7 @@ func (u *userPlusDevice) devices() []keybase1.Device {
 }
 
 func (u *userPlusDevice) userVersion() keybase1.UserVersion {
-	uv, err := u.device.userClient.MeUserVersion(context.TODO(), 0)
+	uv, err := u.device.userClient.MeUserVersion(context.TODO(), keybase1.MeUserVersionArg{ForcePoll: true})
 	require.NoError(u.tc.T, err)
 	return uv
 }

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -146,7 +146,7 @@ protocol user {
   // deleteUser deletes the user. Only works in Dev mode since it's so dangerous
   void deleteUser(int sessionID);
 
-  UserVersion meUserVersion(int sessionID);
+  UserVersion meUserVersion(int sessionID, boolean forcePoll);
 
   /**
    getUPAK returns a UPAK. Used mainly for debugging.

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3872,7 +3872,7 @@ export type UserLoadUserRpcParam = $ReadOnly<{uid: UID, incomingCallMap?: Incomi
 
 export type UserLogPoint = $ReadOnly<{role: TeamRole, sigMeta: SignatureMetadata}>
 
-export type UserMeUserVersionRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type UserMeUserVersionRpcParam = $ReadOnly<{forcePoll: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type UserOrTeamID = String
 

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -564,6 +564,10 @@
         {
           "name": "sessionID",
           "type": "int"
+        },
+        {
+          "name": "forcePoll",
+          "type": "boolean"
         }
       ],
       "response": "UserVersion"

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3872,7 +3872,7 @@ export type UserLoadUserRpcParam = $ReadOnly<{uid: UID, incomingCallMap?: Incomi
 
 export type UserLogPoint = $ReadOnly<{role: TeamRole, sigMeta: SignatureMetadata}>
 
-export type UserMeUserVersionRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type UserMeUserVersionRpcParam = $ReadOnly<{forcePoll: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type UserOrTeamID = String
 


### PR DESCRIPTION
@mlsteele can you give this a look? this test fails in mysterious ways, first on an assertion because `userClient.MeUserVersion(context.TODO(), 0)` does not return eldestseqno=0 after reset. Clearing UPAKLoader cache beforehand doesn't seem to help. Removing this assertion creates more failures along the way in loginAfterReset.