### PR TITLE
Clear reset member badge state on team changes

### DIFF
--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -271,3 +271,17 @@ func (b *BadgeState) updateWithChat(update chat1.UnreadUpdate) {
 		}
 	}
 }
+
+func (b *BadgeState) FindResetMemberBadges(teamName string) (badges []keybase1.TeamMemberOutReset) {
+	b.Lock()
+	defer b.Unlock()
+
+	for _, badge := range b.state.TeamsWithResetUsers {
+		if badge.Teamname != teamName {
+			continue
+		}
+		badges = append(badges, badge)
+	}
+
+	return badges
+}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1670,16 +1670,16 @@ func (t TeamMember) IsReset() bool {
 func (t TeamMembersDetails) ActiveUsernames() map[string]bool {
 	m := make(map[string]bool)
 	for _, u := range t.Owners {
-		m[u.Username] = u.Active
+		m[u.Username] = m[u.Username] || u.Active
 	}
 	for _, u := range t.Admins {
-		m[u.Username] = u.Active
+		m[u.Username] = m[u.Username] || u.Active
 	}
 	for _, u := range t.Writers {
-		m[u.Username] = u.Active
+		m[u.Username] = m[u.Username] || u.Active
 	}
 	for _, u := range t.Readers {
-		m[u.Username] = u.Active
+		m[u.Username] = m[u.Username] || u.Active
 	}
 	return m
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1666,6 +1666,31 @@ func (t TeamMember) IsReset() bool {
 	return t.EldestSeqno != t.UserEldestSeqno
 }
 
+func (t TeamMembersDetails) ActiveUsernames() map[string]bool {
+	m := make(map[string]bool)
+	for _, u := range t.Owners {
+		if u.Active {
+			m[u.Username] = true
+		}
+	}
+	for _, u := range t.Admins {
+		if u.Active {
+			m[u.Username] = true
+		}
+	}
+	for _, u := range t.Writers {
+		if u.Active {
+			m[u.Username] = true
+		}
+	}
+	for _, u := range t.Readers {
+		if u.Active {
+			m[u.Username] = true
+		}
+	}
+	return m
+}
+
 func (t TeamName) IsNil() bool {
 	return len(t.Parts) == 0
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1666,27 +1666,20 @@ func (t TeamMember) IsReset() bool {
 	return t.EldestSeqno != t.UserEldestSeqno
 }
 
+// ActiveUsernames returns a map of username -> active status
 func (t TeamMembersDetails) ActiveUsernames() map[string]bool {
 	m := make(map[string]bool)
 	for _, u := range t.Owners {
-		if u.Active {
-			m[u.Username] = true
-		}
+		m[u.Username] = u.Active
 	}
 	for _, u := range t.Admins {
-		if u.Active {
-			m[u.Username] = true
-		}
+		m[u.Username] = u.Active
 	}
 	for _, u := range t.Writers {
-		if u.Active {
-			m[u.Username] = true
-		}
+		m[u.Username] = u.Active
 	}
 	for _, u := range t.Readers {
-		if u.Active {
-			m[u.Username] = true
-		}
+		m[u.Username] = u.Active
 	}
 	return m
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -464,7 +464,7 @@ func (d *Service) startupGregor() {
 		// TODO -- get rid of this?
 		d.gregor.PushHandler(newRekeyLogHandler(d.G()))
 
-		d.gregor.PushHandler(newTeamHandler(d.G()))
+		d.gregor.PushHandler(newTeamHandler(d.G(), d.badger))
 		d.gregor.PushHandler(d.home)
 
 		// Connect to gregord

--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -157,10 +157,18 @@ func (r *teamHandler) changeTeam(ctx context.Context, cli gregor1.IncomingInterf
 		activeUsernames := details.Members.ActiveUsernames()
 
 		for _, badge := range badges {
-			if activeUsernames[badge.Username] {
-				// they are active in the team, so dismiss the gregor message
+			active, inTeam := activeUsernames[badge.Username]
+			if !inTeam {
+				// the user is not in the team anymore, so dismiss the
+				// gregor message for this badge
+				r.G().Log.CDebugf(ctx, "user %s is not in team %s, dismissing TeamMemberOutFromReset badge", badge.Username, row.Name)
+				if err := r.G().GregorDismisser.DismissItem(ctx, cli, badge.Id); err != nil {
+					r.G().Log.CDebugf(ctx, "failed to dismiss TeamMemberOutFromReset badge: %s", err)
+				}
+			} else if active {
+				// the user is active in the team, so dismiss the gregor message
 				// for this badge
-				r.G().Log.CDebugf(ctx, "user %s is in team %s, dismissing TeamMemberOutFromReset badge", badge.Username, row.Name)
+				r.G().Log.CDebugf(ctx, "user %s is active in team %s, dismissing TeamMemberOutFromReset badge", badge.Username, row.Name)
 				if err := r.G().GregorDismisser.DismissItem(ctx, cli, badge.Id); err != nil {
 					r.G().Log.CDebugf(ctx, "failed to dismiss TeamMemberOutFromReset badge: %s", err)
 				}

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -909,6 +909,8 @@ func TestTeamResetBadges(t *testing.T) {
 	tt.users[0].addTeamMember(teamName.String(), tt.users[1].username, keybase1.TeamRole_WRITER)
 	tt.users[1].reset()
 	tt.users[0].waitForTeamChangedGregor(teamID, keybase1.Seqno(2))
+	// wait for badge state to have 1 team w/ reset member
+	tt.users[0].waitForBadgeStateWithReset(1)
 
 	// users[0] should be badged since users[1] reset
 	badgeState := getBadgeState(t, tt.users[0])
@@ -929,7 +931,10 @@ func TestTeamResetBadges(t *testing.T) {
 	// users[0] adds users[1] back to the team
 	tt.users[0].addTeamMember(teamName.String(), tt.users[1].username, keybase1.TeamRole_WRITER)
 
-	tt.users[0].waitForTeamChangedGregor(teamID, keybase1.Seqno(3))
+	// tt.users[0].waitForTeamChangedGregor(teamID, keybase1.Seqno(3))
+
+	// wait for badge state to have no teams w/ reset member
+	tt.users[0].waitForBadgeStateWithReset(0)
 
 	// badge state should be cleared
 	badgeState = getBadgeState(t, tt.users[0])

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -931,12 +931,22 @@ func TestTeamResetBadges(t *testing.T) {
 	// users[0] adds users[1] back to the team
 	tt.users[0].addTeamMember(teamName.String(), tt.users[1].username, keybase1.TeamRole_WRITER)
 
-	// tt.users[0].waitForTeamChangedGregor(teamID, keybase1.Seqno(3))
-
 	// wait for badge state to have no teams w/ reset member
 	tt.users[0].waitForBadgeStateWithReset(0)
 
 	// badge state should be cleared
+	badgeState = getBadgeState(t, tt.users[0])
+	if len(badgeState.TeamsWithResetUsers) != 0 {
+		t.Errorf("badge state for TeamsWithResetUsers not empty: %d", len(badgeState.TeamsWithResetUsers))
+	}
+
+	// users[1] resets again
+	tt.users[1].reset()
+	tt.users[0].waitForBadgeStateWithReset(1)
+	// users[0] removes users[1] from the team
+	tt.users[0].removeTeamMember(teamName.String(), tt.users[1].username)
+	// badge state should clear
+	tt.users[0].waitForBadgeStateWithReset(0)
 	badgeState = getBadgeState(t, tt.users[0])
 	if len(badgeState.TeamsWithResetUsers) != 0 {
 		t.Errorf("badge state for TeamsWithResetUsers not empty: %d", len(badgeState.TeamsWithResetUsers))

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -896,8 +896,8 @@ func TestTeamAfterDeleteUser(t *testing.T) {
 
 // TestTeamResetBadges checks that badges show up for admins
 // when a member of the team resets, and that they are dismissed
-// when the reset user is added or removed.
-func TestTeamResetBadges(t *testing.T) {
+// when the reset user is added.
+func TestTeamResetBadgesOnAdd(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
@@ -939,14 +939,46 @@ func TestTeamResetBadges(t *testing.T) {
 	if len(badgeState.TeamsWithResetUsers) != 0 {
 		t.Errorf("badge state for TeamsWithResetUsers not empty: %d", len(badgeState.TeamsWithResetUsers))
 	}
+}
 
-	// users[1] resets again
+// TestTeamResetBadgesOnRemove checks that badges show up for admins
+// when a member of the team resets, and that they are dismissed
+// when the reset user is removed.
+func TestTeamResetBadgesOnRemove(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	tt.addUser("own")
+	tt.addUser("roo")
+
+	teamID, teamName := tt.users[0].createTeam2()
+	tt.users[0].kickTeamRekeyd()
+	tt.users[0].addTeamMember(teamName.String(), tt.users[1].username, keybase1.TeamRole_WRITER)
 	tt.users[1].reset()
+	tt.users[0].waitForTeamChangedGregor(teamID, keybase1.Seqno(2))
+	// wait for badge state to have 1 team w/ reset member
 	tt.users[0].waitForBadgeStateWithReset(1)
+
+	// users[0] should be badged since users[1] reset
+	badgeState := getBadgeState(t, tt.users[0])
+	if len(badgeState.TeamsWithResetUsers) == 0 {
+		t.Fatal("TeamsWithResetUsers is empty after reset")
+	}
+	out := badgeState.TeamsWithResetUsers[0]
+	if out.Teamname != teamName.String() {
+		t.Errorf("badged team name: %s, expected %s", out.Teamname, teamName)
+	}
+	if out.Username != tt.users[1].username {
+		t.Errorf("badged user: %s, expected %s", out.Username, tt.users[1].username)
+	}
+
 	// users[0] removes users[1] from the team
 	tt.users[0].removeTeamMember(teamName.String(), tt.users[1].username)
-	// badge state should clear
+
+	// wait for badge state to have no teams w/ reset member
 	tt.users[0].waitForBadgeStateWithReset(0)
+
+	// badge state should be cleared
 	badgeState = getBadgeState(t, tt.users[0])
 	if len(badgeState.TeamsWithResetUsers) != 0 {
 		t.Errorf("badge state for TeamsWithResetUsers not empty: %d", len(badgeState.TeamsWithResetUsers))

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -281,6 +281,16 @@ func (u *userPlusDevice) addTeamMember(team, username string, role keybase1.Team
 	}
 }
 
+func (u *userPlusDevice) removeTeamMember(team, username string) {
+	rm := client.NewCmdTeamRemoveMemberRunner(u.tc.G)
+	rm.Team = team
+	rm.Username = username
+	rm.Force = true
+	if err := rm.Run(); err != nil {
+		u.tc.T.Fatal(err)
+	}
+}
+
 func (u *userPlusDevice) leave(team string) {
 	leave := client.NewCmdTeamLeaveRunner(u.tc.G)
 	leave.Team = team
@@ -435,8 +445,9 @@ func (u *userPlusDevice) waitForBadgeStateWithReset(numReset int) {
 	for i := 0; i < 10; i++ {
 		select {
 		case arg := <-u.notifications.badgeCh:
-			u.tc.T.Logf("badge state received: %+v", arg)
+			u.tc.T.Logf("badge state received: %+v", arg.TeamsWithResetUsers)
 			if len(arg.TeamsWithResetUsers) == numReset {
+				u.tc.T.Logf("badge state length match")
 				return
 			}
 		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -55,6 +55,7 @@ func handleChangeSingle(ctx context.Context, g *libkb.GlobalContext, row keybase
 	}
 	// Send teamID and teamName in two separate notifications. It is server-trust that they are the same team.
 	g.NotifyRouter.HandleTeamChangedByBothKeys(ctx, row.Id, row.Name, row.LatestSeqno, row.ImplicitTeam, change)
+
 	return nil
 }
 


### PR DESCRIPTION
This patch checks to see if reset member badges should be cleared when a device receives a team.change message.

Includes tests for clearing when the user is added to the team after reset and when the user is removed from the team after reset.  

(GUI has interface for add/remove on the badged team member)

cc @buoyad 