### PR TITLE
make the main service config readable in the background on iOS when device is locked

### DIFF
--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -89,6 +89,7 @@ const BOOL isDebug = NO;
   [self addSkipBackupAttributeToItemAtPath:keybasePath];
 
   // Create LevelDB and log directories with a slightly lower data protection mode so we can use them in the background
+  [self createBackgroundReadableDirectory:keybasePath];
   [self createBackgroundReadableDirectory:chatLevelDBPath];
   [self createBackgroundReadableDirectory:levelDBPath];
   [self createBackgroundReadableDirectory:logPath];


### PR DESCRIPTION
A lot of plaintext notifications fail on iOS because in order to successfully process them we need to start the app fresh. If the device is locked, this basically means that we cannot read config.json and the app dies. 

Everything sensitive in this directory is already encrypted, so I think this is safe (this change doesn't affect any keychain access rules). 