### PR TITLE
Make 'checking' proofs clickable

### DIFF
--- a/shared/common-adapters/user-proofs.desktop.js
+++ b/shared/common-adapters/user-proofs.desktop.js
@@ -8,7 +8,7 @@ import type {Proof} from '../constants/types/tracker'
 import {Box, Icon, Text, Meta} from '../common-adapters/index'
 import {defaultColor} from '../common-adapters/icon.shared'
 import {globalStyles, globalColors, globalMargins} from '../styles'
-import {metaNone, checking as proofChecking} from '../constants/tracker'
+import {metaNone} from '../constants/tracker'
 
 function MissingProofRow({missingProof}: {missingProof: MissingProof}): React.Node {
   const missingColor = globalColors.black_20
@@ -177,15 +177,11 @@ class ProofsRender extends React.Component<Props> {
   }
 
   _onClickProof(proof: Proof): void {
-    if (proof.state !== proofChecking) {
-      proof.humanUrl && openUrl(proof.humanUrl)
-    }
+    proof.humanUrl && openUrl(proof.humanUrl)
   }
 
   _onClickProfile(proof: Proof): void {
-    if (proof.state !== proofChecking) {
-      proof.profileUrl && openUrl(proof.profileUrl)
-    }
+    proof.profileUrl && openUrl(proof.profileUrl)
   }
 
   render() {

--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -144,13 +144,13 @@ class ProofsRender extends React.Component<Props> {
   }
 
   _onClickProof(proof: Proof): void {
-    if (proof.state !== proofChecking && proof.humanUrl) {
+    if (proof.humanUrl) {
       openUrl(this._ensureUrlProtocal(proof.humanUrl))
     }
   }
 
   _onClickProfile(proof: Proof): void {
-    if (proof.state !== proofChecking && proof.profileUrl) {
+    if (proof.profileUrl) {
       openUrl(this._ensureUrlProtocal(proof.profileUrl))
     }
   }


### PR DESCRIPTION
Removes the conditional for proofs that are in a `checking` state to make them clickable. r? @keybase/react-hackers 