### PR TITLE
GetTeamTypesForTeams RPC

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2756,7 +2756,7 @@ func (h *Server) GetSearchRegexp(ctx context.Context, arg chat1.GetSearchRegexpA
 	}, nil
 }
 
-func (h *Server) GetTeamTypesForTeams(ctx context.Context, teamNames []string) (res map[string]chat1.TeamType, err error) {
+func (h *Server) GetTeamTypesForTeams(ctx context.Context) (res map[string]chat1.TeamType, err error) {
 	defer h.Trace(ctx, func() error { return err }, "GetTeamTypesForTeams")()
 
 	// Make it possible to call this RPC from standalone mode.

--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -29,6 +30,7 @@ type CmdTeamListMemberships struct {
 	verbose              bool
 	showInviteID         bool
 	verified             bool
+	showTeamType         bool
 	tabw                 *tabwriter.Writer
 }
 
@@ -69,6 +71,10 @@ func newCmdTeamListMemberships(cl *libcmdline.CommandLine, g *libkb.GlobalContex
 		cli.BoolFlag{
 			Name:  "show-invite-id",
 			Usage: "Show invite IDs",
+		},
+		cli.BoolFlag{
+			Name:  "show-team-type",
+			Usage: "Show team types (small/complex) when listing teams",
 		},
 		cli.BoolFlag{
 			Name:  "v, verbose",
@@ -121,6 +127,7 @@ func (c *CmdTeamListMemberships) ParseArgv(ctx *cli.Context) error {
 
 	c.json = ctx.Bool("json")
 	c.forcePoll = ctx.Bool("force-poll")
+	c.showTeamType = ctx.Bool("show-team-type")
 	c.verbose = ctx.Bool("verbose")
 
 	return nil
@@ -181,6 +188,19 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 		return list.Teams[i].FqName < list.Teams[j].FqName
 	})
 
+	var teamTypes map[string]chat1.TeamType
+
+	if c.showTeamType {
+		resolver, err := newChatConversationResolver(c.G())
+		if err != nil {
+			return err
+		}
+		teamTypes, err = resolver.ChatClient.GetTeamTypesForTeams(context.Background(), []string{})
+		if err != nil {
+			return err
+		}
+	}
+
 	if c.json {
 		b, err := json.Marshal(list)
 		if err != nil {
@@ -202,6 +222,7 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 		fmt.Fprintf(c.tabw, "Team\tRole\tMembers\n")
 	}
 	for _, t := range list.Teams {
+		teamName := t.FqName
 		var role string
 		if t.Implicit != nil {
 			role += "implied admin"
@@ -212,6 +233,17 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 			}
 			role += strings.ToLower(t.Role.String())
 		}
+		if c.showTeamType {
+			teamType, found := teamTypes[teamName]
+			if found {
+				switch teamType {
+				case chat1.TeamType_SIMPLE:
+					teamName = fmt.Sprintf("%s (small)", teamName)
+				case chat1.TeamType_COMPLEX:
+					teamName = fmt.Sprintf("%s (big)", teamName)
+				}
+			}
+		}
 		if c.showAll {
 			var reset string
 			if !t.Active {
@@ -220,9 +252,9 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 					reset = " " + reset
 				}
 			}
-			fmt.Fprintf(c.tabw, "%s\t%s\t%s\t%s%s\n", t.FqName, role, t.Username, t.FullName, reset)
+			fmt.Fprintf(c.tabw, "%s\t%s\t%s\t%s%s\n", teamName, role, t.Username, t.FullName, reset)
 		} else {
-			fmt.Fprintf(c.tabw, "%s\t%s\t%d\n", t.FqName, role, t.MemberCount)
+			fmt.Fprintf(c.tabw, "%s\t%s\t%d\n", teamName, role, t.MemberCount)
 		}
 	}
 	if c.showAll {

--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -195,7 +195,7 @@ func (c *CmdTeamListMemberships) runUser(cli keybase1.TeamsClient) error {
 		if err != nil {
 			return err
 		}
-		teamTypes, err = resolver.ChatClient.GetTeamTypesForTeams(context.Background(), []string{})
+		teamTypes, err = resolver.ChatClient.GetTeamTypesForTeams(context.Background())
 		if err != nil {
 			return err
 		}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -4081,6 +4081,10 @@ type GetSearchRegexpArg struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
+type GetTeamTypesForTeamsArg struct {
+	TeamNames []string `codec:"teamNames" json:"teamNames"`
+}
+
 type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
 	GetCachedThread(context.Context, GetCachedThreadArg) (GetThreadLocalRes, error)
@@ -4129,6 +4133,7 @@ type LocalInterface interface {
 	SetTeamRetentionLocal(context.Context, SetTeamRetentionLocalArg) error
 	UpgradeKBFSConversationToImpteam(context.Context, ConversationID) error
 	GetSearchRegexp(context.Context, GetSearchRegexpArg) (GetSearchRegexpRes, error)
+	GetTeamTypesForTeams(context.Context, []string) (map[string]TeamType, error)
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -4877,6 +4882,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"getTeamTypesForTeams": {
+				MakeArg: func() interface{} {
+					ret := make([]GetTeamTypesForTeamsArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]GetTeamTypesForTeamsArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]GetTeamTypesForTeamsArg)(nil), args)
+						return
+					}
+					ret, err = i.GetTeamTypesForTeams(ctx, (*typedArgs)[0].TeamNames)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -5125,5 +5146,11 @@ func (c LocalClient) UpgradeKBFSConversationToImpteam(ctx context.Context, convI
 
 func (c LocalClient) GetSearchRegexp(ctx context.Context, __arg GetSearchRegexpArg) (res GetSearchRegexpRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.getSearchRegexp", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) GetTeamTypesForTeams(ctx context.Context, teamNames []string) (res map[string]TeamType, err error) {
+	__arg := GetTeamTypesForTeamsArg{TeamNames: teamNames}
+	err = c.Cli.Call(ctx, "chat.1.local.getTeamTypesForTeams", []interface{}{__arg}, &res)
 	return
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -4082,7 +4082,6 @@ type GetSearchRegexpArg struct {
 }
 
 type GetTeamTypesForTeamsArg struct {
-	TeamNames []string `codec:"teamNames" json:"teamNames"`
 }
 
 type LocalInterface interface {
@@ -4133,7 +4132,7 @@ type LocalInterface interface {
 	SetTeamRetentionLocal(context.Context, SetTeamRetentionLocalArg) error
 	UpgradeKBFSConversationToImpteam(context.Context, ConversationID) error
 	GetSearchRegexp(context.Context, GetSearchRegexpArg) (GetSearchRegexpRes, error)
-	GetTeamTypesForTeams(context.Context, []string) (map[string]TeamType, error)
+	GetTeamTypesForTeams(context.Context) (map[string]TeamType, error)
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -4888,12 +4887,7 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]GetTeamTypesForTeamsArg)
-					if !ok {
-						err = rpc.NewTypeError((*[]GetTeamTypesForTeamsArg)(nil), args)
-						return
-					}
-					ret, err = i.GetTeamTypesForTeams(ctx, (*typedArgs)[0].TeamNames)
+					ret, err = i.GetTeamTypesForTeams(ctx)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -5149,8 +5143,7 @@ func (c LocalClient) GetSearchRegexp(ctx context.Context, __arg GetSearchRegexpA
 	return
 }
 
-func (c LocalClient) GetTeamTypesForTeams(ctx context.Context, teamNames []string) (res map[string]TeamType, err error) {
-	__arg := GetTeamTypesForTeamsArg{TeamNames: teamNames}
-	err = c.Cli.Call(ctx, "chat.1.local.getTeamTypesForTeams", []interface{}{__arg}, &res)
+func (c LocalClient) GetTeamTypesForTeams(ctx context.Context) (res map[string]TeamType, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.getTeamTypesForTeams", []interface{}{GetTeamTypesForTeamsArg{}}, &res)
 	return
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -796,5 +796,5 @@ protocol local {
 
   GetSearchRegexpRes getSearchRegexp(int sessionID, ConversationID conversationID, string query, boolean isRegex, int maxHits, int maxMessages, keybase1.TLFIdentifyBehavior identifyBehavior);
 
-  map<string,TeamType> getTeamTypesForTeams(array<string> teamNames);
+  map<string,TeamType> getTeamTypesForTeams();
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -795,4 +795,6 @@ protocol local {
   }
 
   GetSearchRegexpRes getSearchRegexp(int sessionID, ConversationID conversationID, string query, boolean isRegex, int maxHits, int maxMessages, keybase1.TLFIdentifyBehavior identifyBehavior);
+
+  map<string,TeamType> getTeamTypesForTeams(array<string> teamNames);
 }

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -883,7 +883,7 @@ export type LocalGetSearchRegexpRpcParam = $ReadOnly<{conversationID: Conversati
 
 export type LocalGetTLFConversationsLocalRpcParam = $ReadOnly<{tlfName: String, topicType: TopicType, membersType: ConversationMembersType, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type LocalGetTeamTypesForTeamsRpcParam = $ReadOnly<{teamNames?: ?Array<String>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type LocalGetTeamTypesForTeamsRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalGetThreadLocalRpcParam = $ReadOnly<{conversationID: ConversationID, query?: ?GetThreadQuery, pagination?: ?Pagination, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -199,6 +199,10 @@ export const localGetTLFConversationsLocalRpcChannelMap = (configKeys: Array<str
 
 export const localGetTLFConversationsLocalRpcPromise = (request: LocalGetTLFConversationsLocalRpcParam): Promise<LocalGetTLFConversationsLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.getTLFConversationsLocal', request, (error: RPCError, result: LocalGetTLFConversationsLocalResult) => (error ? reject(error) : resolve(result))))
 
+export const localGetTeamTypesForTeamsRpcChannelMap = (configKeys: Array<string>, request: LocalGetTeamTypesForTeamsRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getTeamTypesForTeams', request)
+
+export const localGetTeamTypesForTeamsRpcPromise = (request: LocalGetTeamTypesForTeamsRpcParam): Promise<LocalGetTeamTypesForTeamsResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.getTeamTypesForTeams', request, (error: RPCError, result: LocalGetTeamTypesForTeamsResult) => (error ? reject(error) : resolve(result))))
+
 export const localGetThreadLocalRpcChannelMap = (configKeys: Array<string>, request: LocalGetThreadLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getThreadLocal', request)
 
 export const localGetThreadLocalRpcPromise = (request: LocalGetThreadLocalRpcParam): Promise<LocalGetThreadLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.getThreadLocal', request, (error: RPCError, result: LocalGetThreadLocalResult) => (error ? reject(error) : resolve(result))))
@@ -879,6 +883,8 @@ export type LocalGetSearchRegexpRpcParam = $ReadOnly<{conversationID: Conversati
 
 export type LocalGetTLFConversationsLocalRpcParam = $ReadOnly<{tlfName: String, topicType: TopicType, membersType: ConversationMembersType, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type LocalGetTeamTypesForTeamsRpcParam = $ReadOnly<{teamNames?: ?Array<String>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type LocalGetThreadLocalRpcParam = $ReadOnly<{conversationID: ConversationID, query?: ?GetThreadQuery, pagination?: ?Pagination, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalGetThreadNonblockRpcParam = $ReadOnly<{conversationID: ConversationID, cbMode: GetThreadNonblockCbMode, query?: ?GetThreadQuery, pagination?: ?UIPagination, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -1359,6 +1365,7 @@ type LocalGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
 type LocalGetMessagesLocalResult = GetMessagesLocalRes
 type LocalGetSearchRegexpResult = GetSearchRegexpRes
 type LocalGetTLFConversationsLocalResult = GetTLFConversationsLocalRes
+type LocalGetTeamTypesForTeamsResult = {[key: string]: TeamType}
 type LocalGetThreadLocalResult = GetThreadLocalRes
 type LocalGetThreadNonblockResult = NonblockFetchRes
 type LocalJoinConversationByIDLocalResult = JoinLeaveConversationLocalRes

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -3337,15 +3337,7 @@
       "response": "GetSearchRegexpRes"
     },
     "getTeamTypesForTeams": {
-      "request": [
-        {
-          "name": "teamNames",
-          "type": {
-            "type": "array",
-            "items": "string"
-          }
-        }
-      ],
+      "request": [],
       "response": {
         "type": "map",
         "values": "TeamType",

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -3335,6 +3335,22 @@
         }
       ],
       "response": "GetSearchRegexpRes"
+    },
+    "getTeamTypesForTeams": {
+      "request": [
+        {
+          "name": "teamNames",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
+        }
+      ],
+      "response": {
+        "type": "map",
+        "values": "TeamType",
+        "keys": "string"
+      }
     }
   },
   "namespace": "chat.1"

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -883,7 +883,7 @@ export type LocalGetSearchRegexpRpcParam = $ReadOnly<{conversationID: Conversati
 
 export type LocalGetTLFConversationsLocalRpcParam = $ReadOnly<{tlfName: String, topicType: TopicType, membersType: ConversationMembersType, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type LocalGetTeamTypesForTeamsRpcParam = $ReadOnly<{teamNames?: ?Array<String>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type LocalGetTeamTypesForTeamsRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalGetThreadLocalRpcParam = $ReadOnly<{conversationID: ConversationID, query?: ?GetThreadQuery, pagination?: ?Pagination, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -199,6 +199,10 @@ export const localGetTLFConversationsLocalRpcChannelMap = (configKeys: Array<str
 
 export const localGetTLFConversationsLocalRpcPromise = (request: LocalGetTLFConversationsLocalRpcParam): Promise<LocalGetTLFConversationsLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.getTLFConversationsLocal', request, (error: RPCError, result: LocalGetTLFConversationsLocalResult) => (error ? reject(error) : resolve(result))))
 
+export const localGetTeamTypesForTeamsRpcChannelMap = (configKeys: Array<string>, request: LocalGetTeamTypesForTeamsRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getTeamTypesForTeams', request)
+
+export const localGetTeamTypesForTeamsRpcPromise = (request: LocalGetTeamTypesForTeamsRpcParam): Promise<LocalGetTeamTypesForTeamsResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.getTeamTypesForTeams', request, (error: RPCError, result: LocalGetTeamTypesForTeamsResult) => (error ? reject(error) : resolve(result))))
+
 export const localGetThreadLocalRpcChannelMap = (configKeys: Array<string>, request: LocalGetThreadLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getThreadLocal', request)
 
 export const localGetThreadLocalRpcPromise = (request: LocalGetThreadLocalRpcParam): Promise<LocalGetThreadLocalResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('chat.1.local.getThreadLocal', request, (error: RPCError, result: LocalGetThreadLocalResult) => (error ? reject(error) : resolve(result))))
@@ -879,6 +883,8 @@ export type LocalGetSearchRegexpRpcParam = $ReadOnly<{conversationID: Conversati
 
 export type LocalGetTLFConversationsLocalRpcParam = $ReadOnly<{tlfName: String, topicType: TopicType, membersType: ConversationMembersType, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type LocalGetTeamTypesForTeamsRpcParam = $ReadOnly<{teamNames?: ?Array<String>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type LocalGetThreadLocalRpcParam = $ReadOnly<{conversationID: ConversationID, query?: ?GetThreadQuery, pagination?: ?Pagination, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalGetThreadNonblockRpcParam = $ReadOnly<{conversationID: ConversationID, cbMode: GetThreadNonblockCbMode, query?: ?GetThreadQuery, pagination?: ?UIPagination, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -1359,6 +1365,7 @@ type LocalGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
 type LocalGetMessagesLocalResult = GetMessagesLocalRes
 type LocalGetSearchRegexpResult = GetSearchRegexpRes
 type LocalGetTLFConversationsLocalResult = GetTLFConversationsLocalRes
+type LocalGetTeamTypesForTeamsResult = {[key: string]: TeamType}
 type LocalGetThreadLocalResult = GetThreadLocalRes
 type LocalGetThreadNonblockResult = NonblockFetchRes
 type LocalJoinConversationByIDLocalResult = JoinLeaveConversationLocalRes


### PR DESCRIPTION
Rough attempt. Seems pretty slow on my "real" account, though, the first time I run it, so different approach might be needed. 

Consumers of this API should be fine with giving it list of teams to get TeamType for, would it be faster to call `GetInboxAndUnboxLocal` for each team? Caveat is that they will usually give us list of all teams anyway.