### PR TITLE
Prevent iOS crasher on saving a chat attachment

### DIFF
--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -32,7 +32,13 @@ function* onSaveAttachmentNative({
 }: ChatGen.SaveAttachmentNativePayload): SagaGenerator<any, any> {
   const path = yield Saga.call(onSaveAttachment, ChatGen.createSaveAttachment({messageKey}))
   if (path) {
-    yield Saga.call(saveAttachmentDialog, path)
+    logger.info('Trying to save chat attachment to camera roll')
+    try {
+      yield Saga.call(saveAttachmentDialog, path)
+    } catch (err) {
+      logger.info('Failed to save attachment: ' + err)
+      throw new Error('Save attachment failed. Enable photo access in privacy settings.')
+    }
   }
 }
 

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -39,6 +39,8 @@
 	<string></string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Attaching images to chat messages</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Saving images from chat messages</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>OpenSans_bold.ttf</string>


### PR DESCRIPTION
Fixes a crasher caused by trying to save a chat attachment before photo permissions were requested (via attaching a photo). `RCTCameraRoll` uses `NSPhotoLibraryAddUsageDescription` as of iOS11, which wasn't present in our plist and caused the crash. Now `RCTCameraRoll` will ask for permission first, and we'll throw an error if we get denied access.

On android master, this already failed with a global error `Permission Denied`. The affect of this PR is `Permission Denied` -> `Save attachment failed. Enable photo access in privacy settings.`

r? @keybase/react-hackers 