### PR TITLE
Skip provision-before-sig check, perf tools

### DIFF
--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -480,6 +480,8 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 // incarnation if there are multiple.
 func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (ret *keybase1.UserPlusKeysV2, key *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
 	defer u.G().CVTrace(ctx, VLog0, fmt.Sprintf("LoadKeyV2 uid:%s,kid:%s", uid, kid), func() error { return err })()
+	ctx, tbs := u.G().CTimeBuckets(ctx)
+	defer tbs.Record("CachedUPAKLoader.LoadKeyV2")()
 	if uid.IsNil() {
 		return nil, nil, nil, NoUIDError{}
 	}

--- a/go/profiling/timebuckets.go
+++ b/go/profiling/timebuckets.go
@@ -1,0 +1,61 @@
+package profiling
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/clockwork"
+	"golang.org/x/net/context"
+)
+
+type ctxKeyType string
+
+var ctxKey = ctxKeyType("timebuckets")
+
+type TimeBuckets struct {
+	sync.Mutex
+	clock clockwork.Clock
+	log   logger.Logger
+	times map[string]time.Duration
+}
+
+func NewTimeBuckets(clock clockwork.Clock, log logger.Logger) *TimeBuckets {
+	return &TimeBuckets{
+		clock: clock,
+		log:   log,
+		times: make(map[string]time.Duration),
+	}
+}
+
+func (t *TimeBuckets) Record(bucketName string) finFn {
+	start := t.clock.Now()
+	return func() {
+		duration := t.clock.Since(start)
+		t.Lock()
+		defer t.Unlock()
+		t.times[bucketName] += duration
+	}
+}
+
+func (t *TimeBuckets) Get(bucketName string) time.Duration {
+	t.Lock()
+	defer t.Unlock()
+	return t.times[bucketName]
+}
+
+func (t *TimeBuckets) Log(ctx context.Context, bucketName string) {
+	t.log.CDebugf(ctx, "%s [time=%s]", bucketName, t.Get(bucketName))
+}
+
+type finFn func()
+
+func WithTimeBuckets(ctx context.Context, clock clockwork.Clock, log logger.Logger) (context.Context, *TimeBuckets) {
+	v, ok := ctx.Value(ctxKey).(*TimeBuckets)
+	if ok && v != nil {
+		return ctx, v
+	}
+	buckets := NewTimeBuckets(clock, log)
+	ctx = context.WithValue(ctx, ctxKey, buckets)
+	return ctx, buckets
+}

--- a/go/profiling/timetracer.go
+++ b/go/profiling/timetracer.go
@@ -1,0 +1,75 @@
+package profiling
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/clockwork"
+)
+
+type TimeTracer interface {
+	Stage(format string, args ...interface{})
+	Finish()
+}
+
+type TimeTracerImpl struct {
+	sync.Mutex
+	ctx    context.Context
+	log    logger.Logger
+	clock  clockwork.Clock
+	label  string
+	stage  string
+	staged bool      // whether any stages were used
+	start  time.Time // when the tracer started
+	prev   time.Time // when the active stage started
+}
+
+func NewTimeTracer(ctx context.Context, log logger.Logger, clock clockwork.Clock, label string) TimeTracer {
+	now := clock.Now()
+	log.CDebugf(ctx, "+ %s", label)
+	return &TimeTracerImpl{
+		ctx:    ctx,
+		log:    log,
+		clock:  clock,
+		label:  label,
+		stage:  "init",
+		staged: false,
+		start:  now,
+		prev:   now,
+	}
+}
+
+func (t *TimeTracerImpl) finishStage() {
+	t.log.CDebugf(t.ctx, "| %s:%s [time=%s]", t.label, t.stage, t.clock.Since(t.prev))
+}
+
+func (t *TimeTracerImpl) Stage(format string, args ...interface{}) {
+	t.Lock()
+	defer t.Unlock()
+	t.finishStage()
+	t.stage = fmt.Sprintf(format, args...)
+	t.prev = t.clock.Now()
+	t.staged = true
+}
+
+func (t *TimeTracerImpl) Finish() {
+	t.Lock()
+	defer t.Unlock()
+	if t.staged {
+		t.finishStage()
+	}
+	t.log.CDebugf(t.ctx, "- %s [time=%s]", t.label, t.clock.Since(t.start))
+}
+
+type SilentTimeTracer struct{}
+
+func NewSilentTimeTracer() *SilentTimeTracer {
+	return &SilentTimeTracer{}
+}
+
+func (t *SilentTimeTracer) Stage(format string, args ...interface{}) {}
+
+func (t *SilentTimeTracer) Finish() {}

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -390,7 +390,7 @@ func TestClearSocialInvitesOnAdd(t *testing.T) {
 	})
 	tt.users = append(tt.users, ann)
 
-	tracer := ann.tc.G.CTimeTracer(context.Background(), "test-tracer")
+	tracer := ann.tc.G.CTimeTracer(context.Background(), "test-tracer", true)
 	defer tracer.Finish()
 
 	tracer.Stage("bob")

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -250,7 +250,7 @@ func (u *userPlusDevice) createTeam() string {
 		u.tc.T.Fatal(err)
 	}
 	create.TeamName = name
-	tracer := u.tc.G.CTimeTracer(context.Background(), "tracer-create-team")
+	tracer := u.tc.G.CTimeTracer(context.Background(), "tracer-create-team", true)
 	defer tracer.Finish()
 	if err := create.Run(); err != nil {
 		u.tc.T.Fatal(err)

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -123,7 +123,7 @@ func getUsernameAndFullName(ctx context.Context, g *libkb.GlobalContext, uid key
 }
 
 func ListTeamsVerified(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListVerifiedArg) (*keybase1.AnnotatedTeamList, error) {
-	tracer := g.CTimeTracer(ctx, "TeamList.ListTeamsVerified")
+	tracer := g.CTimeTracer(ctx, "TeamList.ListTeamsVerified", true)
 	defer tracer.Finish()
 
 	tracer.Stage("Resolve QueryUID")
@@ -248,7 +248,7 @@ func ListTeamsVerified(ctx context.Context, g *libkb.GlobalContext, arg keybase1
 }
 
 func ListAll(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListTeammatesArg) (*keybase1.AnnotatedTeamList, error) {
-	tracer := g.CTimeTracer(ctx, "TeamList.ListAll")
+	tracer := g.CTimeTracer(ctx, "TeamList.ListAll", true)
 	defer tracer.Finish()
 
 	meUID := g.ActiveDevice.UID()

--- a/go/teams/list_fast.go
+++ b/go/teams/list_fast.go
@@ -18,7 +18,7 @@ import (
 // See also: teams/list.go
 
 func ListTeamsUnverified(ctx context.Context, g *libkb.GlobalContext, arg keybase1.TeamListUnverifiedArg) (*keybase1.AnnotatedTeamList, error) {
-	tracer := g.CTimeTracer(ctx, "TeamList.ListTeamsUnverified")
+	tracer := g.CTimeTracer(ctx, "TeamList.ListTeamsUnverified", true)
 	defer tracer.Finish()
 
 	tracer.Stage("Resolve QueryUID")

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -115,8 +115,7 @@ func (l *TeamLoader) checkStubbed(ctx context.Context, arg load2ArgT, link *chai
 func (l *TeamLoader) loadUserAndKeyFromLinkInner(ctx context.Context,
 	inner SCChainLinkPayload) (
 	signerUV keybase1.UserVersion, key *keybase1.PublicKeyV2NaCl, linkMap linkMapT, err error) {
-
-	defer l.G().CTrace(ctx, fmt.Sprintf("TeamLoader#loadUserForSigVerification(%d)", int(inner.Seqno)), func() error { return err })()
+	defer l.G().CTraceTimed(ctx, fmt.Sprintf("TeamLoader#loadUserForSigVerification(%d)", int(inner.Seqno)), func() error { return err })()
 	keySection := inner.Body.Key
 	if keySection == nil {
 		return signerUV, nil, nil, libkb.NoUIDError{}
@@ -135,10 +134,8 @@ func (l *TeamLoader) verifySignatureAndExtractKID(ctx context.Context, outer lib
 }
 
 func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, teamLinkMap linkMapT, link *chainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap linkMapT, proofSet *proofSetT) {
-	a := newProofTerm(uid.AsUserOrTeam(), key.Base.Provisioning, userLinkMap)
 	b := newProofTerm(teamID.AsUserOrTeam(), link.SignatureMetadata(), teamLinkMap)
 	c := key.Base.Revocation
-	proofSet.AddNeededHappensBeforeProof(ctx, a, b, "user key provisioned before team link")
 	if c != nil {
 		proofSet.AddNeededHappensBeforeProof(ctx, b, newProofTerm(uid.AsUserOrTeam(), *c, userLinkMap), "team link before user key revocation")
 	}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -134,10 +134,10 @@ func (l *TeamLoader) verifySignatureAndExtractKID(ctx context.Context, outer lib
 }
 
 func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, teamLinkMap linkMapT, link *chainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap linkMapT, proofSet *proofSetT) {
-	b := newProofTerm(teamID.AsUserOrTeam(), link.SignatureMetadata(), teamLinkMap)
-	c := key.Base.Revocation
-	if c != nil {
-		proofSet.AddNeededHappensBeforeProof(ctx, b, newProofTerm(uid.AsUserOrTeam(), *c, userLinkMap), "team link before user key revocation")
+	event1Link := newProofTerm(teamID.AsUserOrTeam(), link.SignatureMetadata(), teamLinkMap)
+	event2Revoke := key.Base.Revocation
+	if event2Revoke != nil {
+		proofSet.AddNeededHappensBeforeProof(ctx, event1Link, newProofTerm(uid.AsUserOrTeam(), *event2Revoke, userLinkMap), "team link before user key revocation")
 	}
 }
 
@@ -283,12 +283,12 @@ func (l *TeamLoader) walkUpToAdmin(
 }
 
 func (l *TeamLoader) addProofsForAdminPermission(ctx context.Context, t keybase1.TeamSigChainState, link *chainLinkUnpacked, bookends proofTermBookends, proofSet *proofSetT) {
-	a := bookends.left
-	b := newProofTerm(t.Id.AsUserOrTeam(), link.SignatureMetadata(), t.LinkIDs)
-	c := bookends.right
-	proofSet.AddNeededHappensBeforeProof(ctx, a, b, "became admin before team link")
-	if c != nil {
-		proofSet.AddNeededHappensBeforeProof(ctx, b, *c, "team link before adminship demotion")
+	event1Promote := bookends.left
+	event2Link := newProofTerm(t.Id.AsUserOrTeam(), link.SignatureMetadata(), t.LinkIDs)
+	event3Demote := bookends.right
+	proofSet.AddNeededHappensBeforeProof(ctx, event1Promote, event2Link, "became admin before team link")
+	if event3Demote != nil {
+		proofSet.AddNeededHappensBeforeProof(ctx, event2Link, *event3Demote, "team link before adminship demotion")
 	}
 }
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -51,7 +51,7 @@ func membersUIDsToUsernames(ctx context.Context, g *libkb.GlobalContext, m keyba
 }
 
 func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepoll bool) (res keybase1.TeamDetails, err error) {
-	tracer := g.CTimeTracer(ctx, "TeamDetails")
+	tracer := g.CTimeTracer(ctx, "TeamDetails", true)
 	defer tracer.Finish()
 
 	// Assume private team


### PR DESCRIPTION
Skip the check that a key was provisioned _before_ it signed a team sigchain link. The real change is at loader2.go line 137. This is a ~6s improvement on cold-loading keybasefriends. This change will be less of an improvement when the UPAK cache is warmed. And will have no effect when the team is cached. Numbers are linked to in the CORE-7097 ticket.

There's also some tooling that I think will continue to be useful.