### PR TITLE
Change login error format

### DIFF
--- a/shared/login/register/error/index.js
+++ b/shared/login/register/error/index.js
@@ -220,7 +220,7 @@ const renderError = (error: RPCError) => {
       return (
         <Box style={styleContent}>
           <Text type="BodySemibold" selectable={true}>
-            {error.userMessage}
+            {error.desc}
           </Text>
           <Text type="Body" selectable={true}>
             {error.details}

--- a/shared/login/register/error/index.js
+++ b/shared/login/register/error/index.js
@@ -219,10 +219,10 @@ const renderError = (error: RPCError) => {
     default:
       return (
         <Box style={styleContent}>
-          <Text type="BodySemibold" selectable={true}>
+          <Text style={styleErrorTitle} type="Body" selectable={true}>
             {error.desc}
           </Text>
-          <Text type="Body" selectable={true}>
+          <Text type="BodySmall" selectable={true}>
             {error.details}
           </Text>
         </Box>
@@ -265,6 +265,10 @@ const styleContent = {
   ...globalStyles.flexBoxColumn,
   alignItems: 'center',
   flex: 1,
+}
+
+const styleErrorTitle = {
+  marginBottom: globalMargins.tiny,
 }
 
 export default Render

--- a/shared/login/register/error/index.js
+++ b/shared/login/register/error/index.js
@@ -219,7 +219,12 @@ const renderError = (error: RPCError) => {
     default:
       return (
         <Box style={styleContent}>
-          <Text type="Body">Unknown error: {error.message}</Text>
+          <Text type="BodySemibold" selectable={true}>
+            {error.userMessage}
+          </Text>
+          <Text type="Body" selectable={true}>
+            {error.details}
+          </Text>
         </Box>
       )
   }

--- a/shared/util/errors.js
+++ b/shared/util/errors.js
@@ -3,20 +3,16 @@
 export class RPCError extends Error {
   code: number // Consult type StatusCode in rpc-gen.js for what this means
   fields: any
-  desc: string // Don't use! This is for compatibility with RPC error object.
+  desc: string
   name: string
-
-  userMessage: string // Human-readable-ish message from service about this error
   details: string // Details w/ error code & method if it's present
 
   constructor(message: string, code: number, fields: any, name: ?string, method: ?string) {
     super(paramsToErrorMsg(message, code, fields, name, method))
     this.code = code // Consult type StatusCode in rpc-gen.js for what this means
     this.fields = fields
-    this.desc = message // Don't use! This is for compatibility with RPC error object.
+    this.desc = message
     this.name = name || ''
-
-    this.userMessage = message
     this.details = paramsToErrorDetails(code, name, method)
   }
 }

--- a/shared/util/errors.js
+++ b/shared/util/errors.js
@@ -6,13 +6,30 @@ export class RPCError extends Error {
   desc: string // Don't use! This is for compatibility with RPC error object.
   name: string
 
+  userMessage: string // Human-readable-ish message from service about this error
+  details: string // Details w/ error code & method if it's present
+
   constructor(message: string, code: number, fields: any, name: ?string, method: ?string) {
     super(paramsToErrorMsg(message, code, fields, name, method))
     this.code = code // Consult type StatusCode in rpc-gen.js for what this means
     this.fields = fields
     this.desc = message // Don't use! This is for compatibility with RPC error object.
     this.name = name || ''
+
+    this.userMessage = message
+    this.details = paramsToErrorDetails(code, name, method)
   }
+}
+
+const paramsToErrorDetails = (code: number, name: ?string, method: ?string) => {
+  let res = `Error code ${code}`
+  if (name) {
+    res += `: ${name}`
+  }
+  if (method) {
+    res += ` in method ${method}`
+  }
+  return res
 }
 
 const paramsToErrorMsg = (


### PR DESCRIPTION
Before:
<img width="773" alt="before" src="https://user-images.githubusercontent.com/11968340/36449670-6f28e2e0-1659-11e8-9ee1-c894ae1a6703.png">

After:
<img width="807" alt="screen shot 2018-02-20 at 1 45 03 pm" src="https://user-images.githubusercontent.com/11968340/36450947-7928ba00-165d-11e8-89b8-a0e4974d6f3a.png">


I think this is as granular as we can get given the error data we have. Open to changing the format/ordering if anyone has suggestions. r? @keybase/react-hackers 