### PR TITLE
Implement SecretStoreMem, config, RPC for remember passphrase

### DIFF
--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -308,7 +308,7 @@ func TestDeprovisionLoggedOut(t *testing.T) {
 	assertDeprovisionLoggedOut(tc)
 
 	// Now, test codepath with no secret store
-	tc.G.SecretStore() = nil
+	tc.G.SetSecretStoreNilForTests(t)
 	assertDeprovisionLoggedOut(tc)
 }
 

--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -61,7 +61,7 @@ func assertDeprovisionWithSetup(tc libkb.TestContext, targ assertDeprovisionWith
 	fu := NewFakeUserOrBust(tc.T, "dpr")
 	arg := MakeTestSignupEngineRunArg(fu)
 	arg.SkipPaper = false
-	arg.StoreSecret = tc.G.SecretStoreAll != nil
+	arg.StoreSecret = tc.G.SecretStore() != nil
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},
@@ -74,7 +74,7 @@ func assertDeprovisionWithSetup(tc libkb.TestContext, targ assertDeprovisionWith
 		tc.T.Fatal(err)
 	}
 
-	if tc.G.SecretStoreAll != nil {
+	if tc.G.SecretStore() != nil {
 		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 		_, err := secretStore.RetrieveSecret()
 		if err != nil {
@@ -138,7 +138,7 @@ func assertDeprovisionWithSetup(tc libkb.TestContext, targ assertDeprovisionWith
 		tc.T.Error("Unexpectedly still logged in")
 	}
 
-	if tc.G.SecretStoreAll != nil {
+	if tc.G.SecretStore() != nil {
 		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 		secret, err := secretStore.RetrieveSecret()
 		if err == nil {
@@ -174,13 +174,13 @@ func testDeprovision(t *testing.T, upgradePerUserKey bool) {
 	tc := SetupEngineTest(t, "deprovision")
 	defer tc.Cleanup()
 	tc.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
-	if tc.G.SecretStoreAll == nil {
+	if tc.G.SecretStore() == nil {
 		t.Fatal("Need a secret store for this test")
 	}
 	assertDeprovisionWithSetup(tc, assertDeprovisionWithSetupArg{})
 
 	// Now, test deprovision codepath with no secret store
-	tc.G.SecretStoreAll = nil
+	tc.G.SetSecretStoreNilForTests(t)
 	assertDeprovisionWithSetup(tc, assertDeprovisionWithSetupArg{})
 }
 
@@ -196,7 +196,7 @@ func testDeprovisionAfterRevokePaper(t *testing.T, upgradePerUserKey bool) {
 	tc := SetupEngineTest(t, "deprovision")
 	defer tc.Cleanup()
 	tc.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
-	if tc.G.SecretStoreAll == nil {
+	if tc.G.SecretStore() == nil {
 		t.Fatal("Need a secret store for this test")
 	}
 	assertDeprovisionWithSetup(tc, assertDeprovisionWithSetupArg{
@@ -204,7 +204,7 @@ func testDeprovisionAfterRevokePaper(t *testing.T, upgradePerUserKey bool) {
 	})
 
 	// Now, test deprovision codepath with no secret store
-	tc.G.SecretStoreAll = nil
+	tc.G.SetSecretStoreNilForTests(t)
 	assertDeprovisionWithSetup(tc, assertDeprovisionWithSetupArg{
 		makeAndRevokePaperKey: true,
 	})
@@ -217,7 +217,7 @@ func assertDeprovisionLoggedOut(tc libkb.TestContext) {
 	fu := NewFakeUserOrBust(tc.T, "dpr")
 	arg := MakeTestSignupEngineRunArg(fu)
 
-	arg.StoreSecret = tc.G.SecretStoreAll != nil
+	arg.StoreSecret = tc.G.SecretStore() != nil
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},
@@ -230,7 +230,7 @@ func assertDeprovisionLoggedOut(tc libkb.TestContext) {
 		tc.T.Fatal(err)
 	}
 
-	if tc.G.SecretStoreAll != nil {
+	if tc.G.SecretStore() != nil {
 		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 		_, err := secretStore.RetrieveSecret()
 		if err != nil {
@@ -275,7 +275,7 @@ func assertDeprovisionLoggedOut(tc libkb.TestContext) {
 		tc.T.Error("Unexpectedly still logged in")
 	}
 
-	if tc.G.SecretStoreAll != nil {
+	if tc.G.SecretStore() != nil {
 		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 		secret, err := secretStore.RetrieveSecret()
 		if err == nil {
@@ -302,13 +302,13 @@ func assertDeprovisionLoggedOut(tc libkb.TestContext) {
 func TestDeprovisionLoggedOut(t *testing.T) {
 	tc := SetupEngineTest(t, "deprovision")
 	defer tc.Cleanup()
-	if tc.G.SecretStoreAll == nil {
+	if tc.G.SecretStore() == nil {
 		t.Fatalf("Need a secret store for this test")
 	}
 	assertDeprovisionLoggedOut(tc)
 
 	// Now, test codepath with no secret store
-	tc.G.SecretStoreAll = nil
+	tc.G.SecretStore() = nil
 	assertDeprovisionLoggedOut(tc)
 }
 
@@ -319,7 +319,7 @@ func assertCurrentDeviceRevoked(tc libkb.TestContext) {
 	fu := NewFakeUserOrBust(tc.T, "dpr")
 	arg := MakeTestSignupEngineRunArg(fu)
 	arg.SkipPaper = false
-	arg.StoreSecret = tc.G.SecretStoreAll != nil
+	arg.StoreSecret = tc.G.SecretStore() != nil
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},
@@ -332,7 +332,7 @@ func assertCurrentDeviceRevoked(tc libkb.TestContext) {
 		tc.T.Fatal(err)
 	}
 
-	if tc.G.SecretStoreAll != nil {
+	if tc.G.SecretStore() != nil {
 		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 		_, err := secretStore.RetrieveSecret()
 		if err != nil {
@@ -379,7 +379,7 @@ func assertCurrentDeviceRevoked(tc libkb.TestContext) {
 		tc.T.Error("Unexpectedly still logged in")
 	}
 
-	if tc.G.SecretStoreAll != nil {
+	if tc.G.SecretStore() != nil {
 		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 		secret, err := secretStore.RetrieveSecret()
 		if err == nil {
@@ -406,13 +406,13 @@ func assertCurrentDeviceRevoked(tc libkb.TestContext) {
 func TestCurrentDeviceRevoked(t *testing.T) {
 	tc := SetupEngineTest(t, "deprovision")
 	defer tc.Cleanup()
-	if tc.G.SecretStoreAll == nil {
+	if tc.G.SecretStore() == nil {
 		t.Fatalf("Need a secret store for this test")
 	}
 	assertCurrentDeviceRevoked(tc)
 
 	// Now, test codepath with no secret store
-	tc.G.SecretStoreAll = nil
+	tc.G.SetSecretStoreNilForTests(t)
 	assertCurrentDeviceRevoked(tc)
 }
 
@@ -429,7 +429,7 @@ func testDeprovisionLastDevice(t *testing.T, upgradePerUserKey bool) {
 	tc := SetupEngineTest(t, "deprovision")
 	defer tc.Cleanup()
 	tc.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
-	if tc.G.SecretStoreAll == nil {
+	if tc.G.SecretStore() == nil {
 		t.Fatal("Need a secret store for this test")
 	}
 	fu := assertDeprovisionWithSetup(tc, assertDeprovisionWithSetupArg{
@@ -438,7 +438,7 @@ func testDeprovisionLastDevice(t *testing.T, upgradePerUserKey bool) {
 	assertNumDevicesAndKeys(tc, fu, 0, 0)
 
 	// Now, test deprovision codepath with no secret store
-	tc.G.SecretStoreAll = nil
+	tc.G.SetSecretStoreNilForTests(t)
 	fu = assertDeprovisionWithSetup(tc, assertDeprovisionWithSetupArg{
 		revokePaperKey: true,
 	})

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -1118,7 +1118,7 @@ func (e *loginProvision) verifyLocalStorage() {
 	e.verifyRegularFile("secretkeys", e.G().SKBFilenameForUser(normUsername))
 
 	// check secret stored
-	secret, err := e.G().SecretStoreAll.RetrieveSecret(normUsername)
+	secret, err := e.G().SecretStore().RetrieveSecret(normUsername)
 	if err != nil {
 		e.G().Log.Debug("loginProvision(verify): failed to retrieve secret for %s: %s", e.username, err)
 	}

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -272,7 +272,7 @@ func userHasStoredSecretViaConfiguredAccounts(tc *libkb.TestContext, username st
 }
 
 func userHasStoredSecretViaSecretStore(tc *libkb.TestContext, username string) bool {
-	secret, err := tc.G.SecretStoreAll.RetrieveSecret(libkb.NewNormalizedUsername(username))
+	secret, err := tc.G.SecretStore().RetrieveSecret(libkb.NewNormalizedUsername(username))
 	// TODO: Have RetrieveSecret return platform-independent errors
 	// so that we can make sure we got the right one.
 	return (!secret.IsNil() && err == nil)

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -3697,7 +3697,7 @@ func assertPassphraseStreamCache(tc libkb.TestContext) {
 }
 
 func assertSecretStored(tc libkb.TestContext, username string) {
-	secret, err := tc.G.SecretStoreAll.RetrieveSecret(libkb.NewNormalizedUsername(username))
+	secret, err := tc.G.SecretStore().RetrieveSecret(libkb.NewNormalizedUsername(username))
 	if err != nil {
 		tc.T.Fatal(err)
 	}

--- a/go/engine/login_with_paperkey_test.go
+++ b/go/engine/login_with_paperkey_test.go
@@ -94,7 +94,7 @@ func TestLoginWithPaperKeyLoggedInAndLocked(t *testing.T) {
 		a.ClearCachedSecretKeys()
 	}, "test")
 	require.NoError(t, err)
-	err = tc.G.SecretStoreAll.ClearSecret(libkb.NormalizedUsername(u.Username))
+	err = tc.G.SecretStore().ClearSecret(libkb.NormalizedUsername(u.Username))
 	require.NoError(t, err)
 
 	t.Logf("checking logged in status [before]")

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -216,7 +216,7 @@ func TestLocalKeySecurityStoreSecret(t *testing.T) {
 		t.Errorf("Expected %v, got %v", secret, storedSecret)
 	}
 
-	err = tc.G.SecretStoreAll.ClearSecret(fu.NormalizedUsername())
+	err = tc.G.SecretStore().ClearSecret(fu.NormalizedUsername())
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -337,8 +337,8 @@ func (p CommandLine) GetMountDir() string {
 	return p.GetGString("mountdir")
 }
 
-func (p CommandLine) GetUseSecretStoreMem() (bool, bool) {
-	return p.GetBool("secret-store-mem", true)
+func (p CommandLine) GetRememberPassphrase() (bool, bool) {
+	return p.GetBool("remember-passphrase", true)
 }
 
 func (p CommandLine) GetBool(s string, glbl bool) (bool, bool) {
@@ -570,6 +570,10 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.BoolFlag{
 			Name:  "bg-identifier-disabled",
 			Usage: "supply to disable the BG identifier loop",
+		},
+		cli.BoolFlag{
+			Name:  "remember-passphrase",
+			Usage: "Remember keybase passphrase",
 		},
 	}
 	if extraFlags != nil {

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -337,6 +337,10 @@ func (p CommandLine) GetMountDir() string {
 	return p.GetGString("mountdir")
 }
 
+func (p CommandLine) GetUseSecretStoreMem() (bool, bool) {
+	return p.GetBool("secret-store-mem", true)
+}
+
 func (p CommandLine) GetBool(s string, glbl bool) (bool, bool) {
 	var v bool
 	if glbl {

--- a/go/libkb/bug_3964_repairman.go
+++ b/go/libkb/bug_3964_repairman.go
@@ -50,7 +50,7 @@ func (b *bug3964Repairman) loadLKSecServerDetails(lctx LoginContext, lksec *LKSe
 
 func (b *bug3964Repairman) updateSecretStore(nun NormalizedUsername, lksec *LKSec) error {
 	fs := lksec.FullSecret()
-	ss := b.G().SecretStoreAll
+	ss := b.G().SecretStore()
 	if fs.IsNil() {
 		b.G().Log.Warning("Got unexpected nil full secret")
 		return ss.ClearSecret(nun)

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -539,6 +539,9 @@ func (f JSONConfigFile) GetVDebugSetting() string {
 func (f JSONConfigFile) GetAutoFork() (bool, bool) {
 	return f.GetTopLevelBool("auto_fork")
 }
+func (f JSONConfigFile) GetUseSecretStoreMem() (bool, bool) {
+	return f.GetTopLevelBool("secret_store_memory_only")
+}
 func (f JSONConfigFile) GetLogFormat() string {
 	return f.GetTopLevelString("log_format")
 }

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -539,8 +539,8 @@ func (f JSONConfigFile) GetVDebugSetting() string {
 func (f JSONConfigFile) GetAutoFork() (bool, bool) {
 	return f.GetTopLevelBool("auto_fork")
 }
-func (f JSONConfigFile) GetUseSecretStoreMem() (bool, bool) {
-	return f.GetTopLevelBool("secret_store_memory_only")
+func (f JSONConfigFile) GetRememberPassphrase() (bool, bool) {
+	return f.GetTopLevelBool("remember_passphrase")
 }
 func (f JSONConfigFile) GetLogFormat() string {
 	return f.GetTopLevelString("log_format")
@@ -828,4 +828,8 @@ func (f JSONConfigFile) SetBug3964RepairTime(un NormalizedUsername, t time.Time)
 
 func (f JSONConfigFile) GetAppType() AppType {
 	return AppType(f.GetTopLevelString("app_type"))
+}
+
+func (f *JSONConfigFile) SetRememberPassphrase(remember bool) error {
+	return f.SetBoolAtPath("remember_passphrase", remember)
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -89,6 +89,7 @@ func (n NullConfiguration) GetMountDir() string                                 
 func (n NullConfiguration) GetBGIdentifierDisabled() (bool, bool)                          { return false, false }
 func (n NullConfiguration) GetFeatureFlags() (FeatureFlags, error)                         { return FeatureFlags{}, nil }
 func (n NullConfiguration) GetAppType() AppType                                            { return NoAppType }
+func (n NullConfiguration) GetUseSecretStoreMem() (bool, bool)                             { return false, false }
 func (n NullConfiguration) GetLevelDBNumFiles() (int, bool)                                { return 0, false }
 func (n NullConfiguration) GetChatInboxSourceLocalizeThreads() (int, bool)                 { return 1, false }
 func (n NullConfiguration) GetBug3964RepairTime(NormalizedUsername) (time.Time, error) {
@@ -1299,6 +1300,13 @@ func (e *Env) WantsSystemd() bool {
 func (e *Env) DarwinForceSecretStoreFile() bool {
 	return (e.GetRunMode() == DevelRunMode &&
 		os.Getenv("KEYBASE_SECRET_STORE_FILE") == "1")
+}
+
+func (e *Env) UseSecretStoreMem() bool {
+	return e.GetBool(false,
+		e.cmd.GetUseSecretStoreMem,
+		e.GetConfig().GetUseSecretStoreMem,
+	)
 }
 
 func GetPlatformString() string {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -89,7 +89,7 @@ func (n NullConfiguration) GetMountDir() string                                 
 func (n NullConfiguration) GetBGIdentifierDisabled() (bool, bool)                          { return false, false }
 func (n NullConfiguration) GetFeatureFlags() (FeatureFlags, error)                         { return FeatureFlags{}, nil }
 func (n NullConfiguration) GetAppType() AppType                                            { return NoAppType }
-func (n NullConfiguration) GetUseSecretStoreMem() (bool, bool)                             { return false, false }
+func (n NullConfiguration) GetRememberPassphrase() (bool, bool)                            { return false, false }
 func (n NullConfiguration) GetLevelDBNumFiles() (int, bool)                                { return 0, false }
 func (n NullConfiguration) GetChatInboxSourceLocalizeThreads() (int, bool)                 { return 1, false }
 func (n NullConfiguration) GetBug3964RepairTime(NormalizedUsername) (time.Time, error) {
@@ -1302,10 +1302,10 @@ func (e *Env) DarwinForceSecretStoreFile() bool {
 		os.Getenv("KEYBASE_SECRET_STORE_FILE") == "1")
 }
 
-func (e *Env) UseSecretStoreMem() bool {
-	return e.GetBool(false,
-		e.cmd.GetUseSecretStoreMem,
-		e.GetConfig().GetUseSecretStoreMem,
+func (e *Env) RememberPassphrase() bool {
+	return e.GetBool(true,
+		e.cmd.GetRememberPassphrase,
+		e.GetConfig().GetRememberPassphrase,
 	)
 }
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -618,13 +618,17 @@ func (g *GlobalContext) Configure(line CommandLine, usage Usage) error {
 		return err
 	}
 
-	// secretStore must be created after SetCommandLine in order
-	// to correctly use -H,-home flag.
+	if err := g.ConfigureUsage(usage); err != nil {
+		return err
+	}
+
+	// secretStore must be created after SetCommandLine and ConfigureUsage in order
+	// to correctly use -H,-home flag and config vars for remember_passphrase.
 	g.secretStoreMu.Lock()
 	g.secretStore = NewSecretStoreLocked(g)
 	g.secretStoreMu.Unlock()
 
-	return g.ConfigureUsage(usage)
+	return nil
 }
 
 func (g *GlobalContext) ConfigureUsage(usage Usage) error {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -104,7 +104,7 @@ type GlobalContext struct {
 	RateLimits         *RateLimits               // tracks the last time certain actions were taken
 	clockMu            *sync.Mutex               // protects Clock
 	clock              clockwork.Clock           // RealClock unless we're testing
-	secretStoreMu      *sync.Mutex               // protects secretStore
+	secretStoreMu      sync.Mutex                // protects secretStore
 	secretStore        *SecretStoreLocked        // SecretStore
 	hookMu             *sync.RWMutex             // protects loginHooks, logoutHooks
 	loginHooks         []LoginHook               // call these on login

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -104,7 +104,7 @@ type GlobalContext struct {
 	RateLimits         *RateLimits               // tracks the last time certain actions were taken
 	clockMu            *sync.Mutex               // protects Clock
 	clock              clockwork.Clock           // RealClock unless we're testing
-	secretStoreMu      sync.Mutex                // protects secretStore
+	secretStoreMu      *sync.Mutex               // protects secretStore
 	secretStore        *SecretStoreLocked        // SecretStore
 	hookMu             *sync.RWMutex             // protects loginHooks, logoutHooks
 	loginHooks         []LoginHook               // call these on login
@@ -157,6 +157,7 @@ func (g *GlobalContext) GetClock() clockwork.Clock                     { return 
 
 type LogGetter func() logger.Logger
 
+// Note: all these sync.Mutex fields are pointers so that the Clone funcs work.
 func NewGlobalContext() *GlobalContext {
 	log := logger.New("keybase")
 	return &GlobalContext{
@@ -175,6 +176,7 @@ func NewGlobalContext() *GlobalContext {
 		outOfDateInfo:      &keybase1.OutOfDateInfo{},
 		lastUpgradeWarning: new(time.Time),
 		uchMu:              new(sync.Mutex),
+		secretStoreMu:      new(sync.Mutex),
 		NewTriplesec:       NewSecureTriplesec,
 		ActiveDevice:       new(ActiveDevice),
 		NetContext:         context.TODO(),

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -82,7 +82,7 @@ type configGetter interface {
 	GetLevelDBNumFiles() (int, bool)
 	GetChatInboxSourceLocalizeThreads() (int, bool)
 	GetPayloadCacheSize() (int, bool)
-	GetUseSecretStoreMem() (bool, bool)
+	GetRememberPassphrase() (bool, bool)
 }
 
 type CommandLine interface {
@@ -197,6 +197,7 @@ type ConfigWriter interface {
 	SetUpdatePreferenceSnoozeUntil(keybase1.Time) error
 	SetUpdateLastChecked(keybase1.Time) error
 	SetBug3964RepairTime(NormalizedUsername, time.Time) error
+	SetRememberPassphrase(bool) error
 	Reset()
 	BeginTransaction() (ConfigWriterTransacter, error)
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -82,6 +82,7 @@ type configGetter interface {
 	GetLevelDBNumFiles() (int, bool)
 	GetChatInboxSourceLocalizeThreads() (int, bool)
 	GetPayloadCacheSize() (int, bool)
+	GetUseSecretStoreMem() (bool, bool)
 }
 
 type CommandLine interface {

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -321,7 +321,7 @@ func (s *LoginState) GetPassphraseStreamWithPassphrase(passphrase string) (pps *
 }
 
 func (s *LoginState) getStoredPassphraseStream(username NormalizedUsername) (*PassphraseStream, error) {
-	fullSecret, err := s.G().SecretStoreAll.RetrieveSecret(s.G().Env.GetUsername())
+	fullSecret, err := s.G().SecretStore().RetrieveSecret(s.G().Env.GetUsername())
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +355,7 @@ func (s *LoginState) GetPassphraseStreamStored(ui SecretUI) (pps *PassphraseStre
 	}
 
 	// 2. try from secret store
-	if s.G().SecretStoreAll != nil {
+	if s.G().SecretStore() != nil {
 		s.G().Log.Debug("| trying to get passphrase stream from secret store")
 		pps, err = s.getStoredPassphraseStream(s.G().Env.GetUsername())
 		if err == nil {

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -28,8 +28,6 @@ type SecretStoreAll interface {
 	StoreSecret(username NormalizedUsername, secret LKSecFullSecret) error
 	ClearSecret(username NormalizedUsername) error
 	GetUsersWithStoredSecrets() ([]string, error)
-	// GetApprovalPrompt() string
-	// GetTerminalPrompt() string
 }
 
 type SecretStoreContext interface {

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -136,18 +136,22 @@ type SecretStoreLocked struct {
 
 func NewSecretStoreLocked(g *GlobalContext) *SecretStoreLocked {
 	var ss SecretStoreAll
-	if g.Env.UseSecretStoreMem() {
-		// config or command line flag said to use in-memory secret store
-		g.Log.Debug("using memory-only SecretStore")
-		ss = NewSecretStoreMem()
-	} else {
-		// use os-specifig secret store
+
+	if g.Env.RememberPassphrase() {
+		// use os-specific secret store
+		g.Log.Debug("NewSecretStoreLocked: using os-specific SecretStore")
 		ss = NewSecretStoreAll(g)
+	} else {
+		// config or command line flag said to use in-memory secret store
+		g.Log.Debug("NewSecretStoreLocked: using memory-only SecretStore")
+		ss = NewSecretStoreMem()
 	}
+
 	if ss == nil {
 		// right now, some stuff depends on g.SecretStoreAll being nil or not
 		return nil
 	}
+
 	return &SecretStoreLocked{
 		SecretStoreAll: ss,
 	}

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -72,10 +72,11 @@ func (s *SecretStoreImp) StoreSecret(secret LKSecFullSecret) error {
 // a short period of time (i.e. one function block).  Multiple calls to RetrieveSecret()
 // will only call the underlying store.RetrieveSecret once.
 func NewSecretStore(g *GlobalContext, username NormalizedUsername) SecretStore {
-	if g.SecretStoreAll != nil {
+	store := g.SecretStore()
+	if store != nil {
 		return &SecretStoreImp{
 			username: username,
-			store:    g.SecretStoreAll,
+			store:    store,
 		}
 	}
 	return nil
@@ -122,10 +123,11 @@ func GetConfiguredAccounts(c SecretStoreContext, s SecretStoreAll) ([]keybase1.C
 }
 
 func ClearStoredSecret(g *GlobalContext, username NormalizedUsername) error {
-	if g.SecretStoreAll == nil {
+	ss := g.SecretStore()
+	if ss == nil {
 		return nil
 	}
-	return g.SecretStoreAll.ClearSecret(username)
+	return ss.ClearSecret(username)
 }
 
 // SecretStoreLocked protects a SecretStoreAll with a mutex.

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -28,8 +28,8 @@ type SecretStoreAll interface {
 	StoreSecret(username NormalizedUsername, secret LKSecFullSecret) error
 	ClearSecret(username NormalizedUsername) error
 	GetUsersWithStoredSecrets() ([]string, error)
-	GetApprovalPrompt() string
-	GetTerminalPrompt() string
+	// GetApprovalPrompt() string
+	// GetTerminalPrompt() string
 }
 
 type SecretStoreContext interface {

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -135,7 +135,15 @@ type SecretStoreLocked struct {
 }
 
 func NewSecretStoreLocked(g *GlobalContext) *SecretStoreLocked {
-	ss := NewSecretStoreAll(g)
+	var ss SecretStoreAll
+	if g.Env.UseSecretStoreMem() {
+		// config or command line flag said to use in-memory secret store
+		g.Log.Debug("using memory-only SecretStore")
+		ss = NewSecretStoreMem()
+	} else {
+		// use os-specifig secret store
+		ss = NewSecretStoreAll(g)
+	}
 	if ss == nil {
 		// right now, some stuff depends on g.SecretStoreAll being nil or not
 		return nil

--- a/go/libkb/secret_store_darwin.go
+++ b/go/libkb/secret_store_darwin.go
@@ -121,11 +121,3 @@ func (k KeychainSecretStore) GetUsersWithStoredSecrets() ([]string, error) {
 	k.context.GetLog().Debug("KeychainSecretStore.GetUsersWithStoredSecrets() -> %d users", len(users))
 	return users, nil
 }
-
-func (k KeychainSecretStore) GetApprovalPrompt() string {
-	return "Save in Keychain"
-}
-
-func (k KeychainSecretStore) GetTerminalPrompt() string {
-	return "Store your key in Apple's local keychain?"
-}

--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -136,14 +136,6 @@ func (s *secretStoreAccountName) GetUsersWithStoredSecrets() ([]string, error) {
 	return users, err
 }
 
-func (s *secretStoreAccountName) GetTerminalPrompt() string {
-	return "Store secret in Android's KeyStore?"
-}
-
-func (s *secretStoreAccountName) GetApprovalPrompt() string {
-	return "Store secret in Android's KeyStore?"
-}
-
 func (s *secretStoreAccountName) setup() {
 	s.setupOnce.Do(func() {
 		s.context.GetLog().Debug("+ secret_store_external:setup")

--- a/go/libkb/secret_store_file.go
+++ b/go/libkb/secret_store_file.go
@@ -110,14 +110,6 @@ func (s *SecretStoreFile) GetUsersWithStoredSecrets() ([]string, error) {
 	return users, nil
 }
 
-func (s *SecretStoreFile) GetApprovalPrompt() string {
-	return "Remember login key"
-}
-
-func (s *SecretStoreFile) GetTerminalPrompt() string {
-	return "Remember your login key?"
-}
-
 func (s *SecretStoreFile) userpath(username NormalizedUsername) string {
 	return filepath.Join(s.dir, fmt.Sprintf("%s.ss", username))
 }

--- a/go/libkb/secret_store_mem.go
+++ b/go/libkb/secret_store_mem.go
@@ -1,0 +1,47 @@
+package libkb
+
+type SecretStoreMem struct {
+	secrets map[NormalizedUsername]LKSecFullSecret
+}
+
+var _ SecretStoreAll = (*SecretStoreMem)(nil)
+
+func NewSecretStoreMem() *SecretStoreMem {
+	return &SecretStoreMem{
+		secrets: make(map[NormalizedUsername]LKSecFullSecret),
+	}
+}
+
+func (s *SecretStoreMem) RetrieveSecret(username NormalizedUsername) (LKSecFullSecret, error) {
+	secret, ok := s.secrets[username]
+	if !ok {
+		return LKSecFullSecret{}, ErrSecretForUserNotFound
+	}
+	return secret, nil
+}
+
+func (s *SecretStoreMem) StoreSecret(username NormalizedUsername, secret LKSecFullSecret) error {
+	s.secrets[username] = secret
+	return nil
+}
+
+func (s *SecretStoreMem) ClearSecret(username NormalizedUsername) error {
+	delete(s.secrets, username)
+	return nil
+}
+
+func (s *SecretStoreMem) GetUsersWithStoredSecrets() ([]string, error) {
+	var usernames []string
+	for k := range s.secrets {
+		usernames = append(usernames, k.String())
+	}
+	return usernames, nil
+}
+
+func (s *SecretStoreMem) GetApprovalPrompt() string {
+	return ""
+}
+
+func (s *SecretStoreMem) GetTerminalPrompt() string {
+	return ""
+}

--- a/go/libkb/secret_store_mem.go
+++ b/go/libkb/secret_store_mem.go
@@ -37,11 +37,3 @@ func (s *SecretStoreMem) GetUsersWithStoredSecrets() ([]string, error) {
 	}
 	return usernames, nil
 }
-
-func (s *SecretStoreMem) GetApprovalPrompt() string {
-	return ""
-}
-
-func (s *SecretStoreMem) GetTerminalPrompt() string {
-	return ""
-}

--- a/go/libkb/secret_store_mem_test.go
+++ b/go/libkb/secret_store_mem_test.go
@@ -1,0 +1,66 @@
+package libkb
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+)
+
+func TestSecretStoreMem(t *testing.T) {
+	cases := map[string]struct {
+		username NormalizedUsername
+		secret   []byte
+	}{
+		"alice":   {"alice", []byte("alice_first_sec_first_sec_first_")},
+		"charlie": {"charlie", []byte("charliecharliecharliecharliechar")},
+		"replace": {"alice", []byte("alice_next_secret_alice_next_sec")},
+	}
+
+	s := NewSecretStoreMem()
+	for name, test := range cases {
+		fs, err := newLKSecFullSecretFromBytes(test.secret)
+		if err != nil {
+			t.Fatalf("failed to make new full secret: %s", err)
+		}
+		if err := s.StoreSecret(test.username, fs); err != nil {
+			t.Fatalf("%s: %s", name, err)
+		}
+		secret, err := s.RetrieveSecret(test.username)
+		if err != nil {
+			t.Fatalf("%s: %s", name, err)
+		}
+		if !bytes.Equal(secret.Bytes(), test.secret) {
+			t.Errorf("%s: secret: %x, expected %x", name, secret, test.secret)
+		}
+	}
+
+	if _, err := s.RetrieveSecret("nobody"); err != ErrSecretForUserNotFound {
+		t.Fatalf("retrieve err: %s (%T), expected ErrSecretForUserNotFound", err, err)
+	}
+
+	users, err := s.GetUsersWithStoredSecrets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("num users: %d, expected 2", len(users))
+	}
+	sort.Strings(users)
+	if users[0] != "alice" {
+		t.Errorf("user 0: %s, expected alice", users[0])
+	}
+	if users[1] != "charlie" {
+		t.Errorf("user 1: %s, expected charlie", users[1])
+	}
+
+	if err := s.ClearSecret("alice"); err != nil {
+		t.Fatal(err)
+	}
+	secret, err := s.RetrieveSecret("alice")
+	if err != ErrSecretForUserNotFound {
+		t.Fatalf("err: %v, expected %v", err, ErrSecretForUserNotFound)
+	}
+	if !secret.IsNil() {
+		t.Errorf("secret: %+v, expected nil", secret)
+	}
+}

--- a/go/libkb/secret_store_test.go
+++ b/go/libkb/secret_store_test.go
@@ -20,14 +20,14 @@ func TestSecretStoreOps(t *testing.T) {
 
 	var err error
 
-	if err = tc.G.SecretStoreAll.ClearSecret(nu); err != nil {
+	if err = tc.G.SecretStore().ClearSecret(nu); err != nil {
 		t.Error(err)
 	}
 
 	// TODO: Use platform-independent errors so they can be
 	// checked for.
 	var secret LKSecFullSecret
-	if secret, err = tc.G.SecretStoreAll.RetrieveSecret(nu); err == nil {
+	if secret, err = tc.G.SecretStore().RetrieveSecret(nu); err == nil {
 		t.Error("RetrieveSecret unexpectedly returned a nil error")
 	}
 
@@ -40,11 +40,11 @@ func TestSecretStoreOps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = tc.G.SecretStoreAll.StoreSecret(nu, secret); err != nil {
+	if err = tc.G.SecretStore().StoreSecret(nu, secret); err != nil {
 		t.Error(err)
 	}
 
-	if secret, err = tc.G.SecretStoreAll.RetrieveSecret(nu); err != nil {
+	if secret, err = tc.G.SecretStore().RetrieveSecret(nu); err != nil {
 		t.Error(err)
 	}
 
@@ -57,11 +57,11 @@ func TestSecretStoreOps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = tc.G.SecretStoreAll.StoreSecret(nu, secret); err != nil {
+	if err = tc.G.SecretStore().StoreSecret(nu, secret); err != nil {
 		t.Error(err)
 	}
 
-	if secret, err = tc.G.SecretStoreAll.RetrieveSecret(nu); err != nil {
+	if secret, err = tc.G.SecretStore().RetrieveSecret(nu); err != nil {
 		t.Error(err)
 	}
 
@@ -69,7 +69,7 @@ func TestSecretStoreOps(t *testing.T) {
 		t.Errorf("Retrieved secret %s, expected %s", string(secret.Bytes()), string(expectedSecret2))
 	}
 
-	if err = tc.G.SecretStoreAll.ClearSecret(nu); err != nil {
+	if err = tc.G.SecretStore().ClearSecret(nu); err != nil {
 		t.Error(err)
 	}
 }
@@ -79,7 +79,7 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 	tc := SetupTest(t, "get users with stored secrets", 1)
 	defer tc.Cleanup()
 
-	usernames, err := tc.G.SecretStoreAll.GetUsersWithStoredSecrets()
+	usernames, err := tc.G.SecretStore().GetUsersWithStoredSecrets()
 	if err != nil {
 		t.Error(err)
 	}
@@ -96,12 +96,12 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 	for i := 0; i < len(expectedUsernames); i++ {
 		expectedUsernames[i] = fmt.Sprintf("account with unicode テスト %d", i)
 
-		if err := tc.G.SecretStoreAll.StoreSecret(NewNormalizedUsername(expectedUsernames[i]), fs); err != nil {
+		if err := tc.G.SecretStore().StoreSecret(NewNormalizedUsername(expectedUsernames[i]), fs); err != nil {
 			t.Error(err)
 		}
 	}
 
-	usernames, err = tc.G.SecretStoreAll.GetUsersWithStoredSecrets()
+	usernames, err = tc.G.SecretStore().GetUsersWithStoredSecrets()
 	if err != nil {
 		t.Error(err)
 	}
@@ -120,13 +120,13 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 	}
 
 	for i := 0; i < len(expectedUsernames); i++ {
-		err = tc.G.SecretStoreAll.ClearSecret(NewNormalizedUsername(expectedUsernames[i]))
+		err = tc.G.SecretStore().ClearSecret(NewNormalizedUsername(expectedUsernames[i]))
 		if err != nil {
 			t.Error(err)
 		}
 	}
 
-	usernames, err = tc.G.SecretStoreAll.GetUsersWithStoredSecrets()
+	usernames, err = tc.G.SecretStore().GetUsersWithStoredSecrets()
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/libkb/skb_test.go
+++ b/go/libkb/skb_test.go
@@ -147,7 +147,7 @@ func TestBasicSecretStore(t *testing.T) {
 
 	testPromptAndUnlock(t, skb)
 
-	secret, _ := tc.G.SecretStoreAll.RetrieveSecret("testusername")
+	secret, _ := tc.G.SecretStore().RetrieveSecret("testusername")
 	if !secret.Equal(expectedSecret) {
 		t.Errorf("secret doesn't match expected value")
 	}
@@ -175,12 +175,12 @@ func TestCorruptSecretStore(t *testing.T) {
 
 	skb := makeTestSKB(t, lks, tc.G)
 	fs, _ := newLKSecFullSecretFromBytes([]byte("corruptcorruptcorruptcorruptcorr"))
-	tc.G.SecretStoreAll.StoreSecret("testusername", fs)
+	tc.G.SecretStore().StoreSecret("testusername", fs)
 	testPromptAndUnlock(t, skb)
 
 	// The corrupt secret value should be overwritten by the new
 	// correct one.
-	secret, _ := tc.G.SecretStoreAll.RetrieveSecret("testusername")
+	secret, _ := tc.G.SecretStore().RetrieveSecret("testusername")
 	if !secret.Equal(expectedSecret) {
 		t.Errorf("secret doesn't match expected value")
 	}
@@ -207,7 +207,7 @@ func TestUnusedSecretStore(t *testing.T) {
 	// Since there is a non-nil passphraseStream in the login
 	// state, nothing should be stored in the secret store (since
 	// no prompt was shown).
-	secret, _ := tc.G.SecretStoreAll.RetrieveSecret("testusername")
+	secret, _ := tc.G.SecretStore().RetrieveSecret("testusername")
 	if !secret.IsNil() {
 		t.Errorf("secret unexpectedly non-empty")
 	}

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -233,7 +233,9 @@ func setupTestContext(tb TestingTB, name string, tcPrev *TestContext) (tc TestCo
 	g.Env.Test = tc.Tp
 
 	// SecretStoreFile needs test home directory
-	g.SecretStoreAll = NewSecretStoreLocked(g)
+	g.secretStoreMu.Lock()
+	g.secretStore = NewSecretStoreLocked(g)
+	g.secretStoreMu.Unlock()
 
 	g.ConfigureLogging()
 

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -57,6 +57,7 @@ protocol config {
     boolean paperEncKeyCached;
     boolean storedSecret;
     boolean secretPromptSkip;
+    boolean rememberPassphrase;
     union { null, Device } device;
     union { null, LoadDeviceErr } deviceErr; /* if err getting device, this will describe it */
     string logDir;
@@ -152,4 +153,7 @@ protocol config {
     array<string> followers;    // who follows current logged in user
   }
   BootstrapStatus getBootstrapStatus(int sessionID);
+
+  boolean getRememberPassphrase(int sessionID);
+  void setRememberPassphrase(int sessionID, boolean remember);
 }

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -339,6 +339,10 @@ export const configGetExtendedStatusRpcChannelMap = (configKeys: Array<string>, 
 
 export const configGetExtendedStatusRpcPromise = (request: ConfigGetExtendedStatusRpcParam): Promise<ConfigGetExtendedStatusResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.config.getExtendedStatus', request, (error: RPCError, result: ConfigGetExtendedStatusResult) => (error ? reject(error) : resolve(result))))
 
+export const configGetRememberPassphraseRpcChannelMap = (configKeys: Array<string>, request: ConfigGetRememberPassphraseRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.config.getRememberPassphrase', request)
+
+export const configGetRememberPassphraseRpcPromise = (request: ConfigGetRememberPassphraseRpcParam): Promise<ConfigGetRememberPassphraseResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.config.getRememberPassphrase', request, (error: RPCError, result: ConfigGetRememberPassphraseResult) => (error ? reject(error) : resolve(result))))
+
 export const configGetValueRpcChannelMap = (configKeys: Array<string>, request: ConfigGetValueRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.config.getValue', request)
 
 export const configGetValueRpcPromise = (request: ConfigGetValueRpcParam): Promise<ConfigGetValueResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.config.getValue', request, (error: RPCError, result: ConfigGetValueResult) => (error ? reject(error) : resolve(result))))
@@ -350,6 +354,10 @@ export const configHelloIAmRpcPromise = (request: ConfigHelloIAmRpcParam): Promi
 export const configSetPathRpcChannelMap = (configKeys: Array<string>, request: ConfigSetPathRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.config.setPath', request)
 
 export const configSetPathRpcPromise = (request: ConfigSetPathRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.config.setPath', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
+export const configSetRememberPassphraseRpcChannelMap = (configKeys: Array<string>, request: ConfigSetRememberPassphraseRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.config.setRememberPassphrase', request)
+
+export const configSetRememberPassphraseRpcPromise = (request: ConfigSetRememberPassphraseRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.config.setRememberPassphrase', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
 
 export const configSetUserConfigRpcChannelMap = (configKeys: Array<string>, request: ConfigSetUserConfigRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.config.setUserConfig', request)
 
@@ -2035,11 +2043,15 @@ export type ConfigGetCurrentStatusRpcParam = ?$ReadOnly<{incomingCallMap?: Incom
 
 export type ConfigGetExtendedStatusRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type ConfigGetRememberPassphraseRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type ConfigGetValueRpcParam = $ReadOnly<{path: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type ConfigHelloIAmRpcParam = $ReadOnly<{details: ClientDetails, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type ConfigSetPathRpcParam = $ReadOnly<{path: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type ConfigSetRememberPassphraseRpcParam = $ReadOnly<{remember: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type ConfigSetUserConfigRpcParam = $ReadOnly<{username: String, key: String, value: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
@@ -2174,7 +2186,7 @@ export type ExitCode =
   | 2 // NOTOK_2
   | 4 // RESTART_4
 
-export type ExtendedStatus = $ReadOnly<{standalone: Boolean, passphraseStreamCached: Boolean, tsecCached: Boolean, deviceSigKeyCached: Boolean, deviceEncKeyCached: Boolean, paperSigKeyCached: Boolean, paperEncKeyCached: Boolean, storedSecret: Boolean, secretPromptSkip: Boolean, device?: ?Device, deviceErr?: ?LoadDeviceErr, logDir: String, session?: ?SessionStatus, defaultUsername: String, provisionedUsernames?: ?Array<String>, Clients?: ?Array<ClientDetails>, platformInfo: PlatformInfo, defaultDeviceID: DeviceID}>
+export type ExtendedStatus = $ReadOnly<{standalone: Boolean, passphraseStreamCached: Boolean, tsecCached: Boolean, deviceSigKeyCached: Boolean, deviceEncKeyCached: Boolean, paperSigKeyCached: Boolean, paperEncKeyCached: Boolean, storedSecret: Boolean, secretPromptSkip: Boolean, rememberPassphrase: Boolean, device?: ?Device, deviceErr?: ?LoadDeviceErr, logDir: String, session?: ?SessionStatus, defaultUsername: String, provisionedUsernames?: ?Array<String>, Clients?: ?Array<ClientDetails>, platformInfo: PlatformInfo, defaultDeviceID: DeviceID}>
 
 export type FSEditListRequest = $ReadOnly<{folder: Folder, requestID: Int}>
 
@@ -3940,6 +3952,7 @@ type ConfigGetBootstrapStatusResult = BootstrapStatus
 type ConfigGetConfigResult = Config
 type ConfigGetCurrentStatusResult = GetCurrentStatusRes
 type ConfigGetExtendedStatusResult = ExtendedStatus
+type ConfigGetRememberPassphraseResult = Boolean
 type ConfigGetValueResult = ConfigValue
 type ConfigWaitForClientResult = Boolean
 type CryptoSignED25519ForKBFSResult = ED25519SignatureInfo

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -173,6 +173,10 @@
           "name": "secretPromptSkip"
         },
         {
+          "type": "boolean",
+          "name": "rememberPassphrase"
+        },
+        {
           "type": [
             null,
             "Device"
@@ -534,6 +538,28 @@
         }
       ],
       "response": "BootstrapStatus"
+    },
+    "getRememberPassphrase": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": "boolean"
+    },
+    "setRememberPassphrase": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "remember",
+          "type": "boolean"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -339,6 +339,10 @@ export const configGetExtendedStatusRpcChannelMap = (configKeys: Array<string>, 
 
 export const configGetExtendedStatusRpcPromise = (request: ConfigGetExtendedStatusRpcParam): Promise<ConfigGetExtendedStatusResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.config.getExtendedStatus', request, (error: RPCError, result: ConfigGetExtendedStatusResult) => (error ? reject(error) : resolve(result))))
 
+export const configGetRememberPassphraseRpcChannelMap = (configKeys: Array<string>, request: ConfigGetRememberPassphraseRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.config.getRememberPassphrase', request)
+
+export const configGetRememberPassphraseRpcPromise = (request: ConfigGetRememberPassphraseRpcParam): Promise<ConfigGetRememberPassphraseResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.config.getRememberPassphrase', request, (error: RPCError, result: ConfigGetRememberPassphraseResult) => (error ? reject(error) : resolve(result))))
+
 export const configGetValueRpcChannelMap = (configKeys: Array<string>, request: ConfigGetValueRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.config.getValue', request)
 
 export const configGetValueRpcPromise = (request: ConfigGetValueRpcParam): Promise<ConfigGetValueResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.config.getValue', request, (error: RPCError, result: ConfigGetValueResult) => (error ? reject(error) : resolve(result))))
@@ -350,6 +354,10 @@ export const configHelloIAmRpcPromise = (request: ConfigHelloIAmRpcParam): Promi
 export const configSetPathRpcChannelMap = (configKeys: Array<string>, request: ConfigSetPathRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.config.setPath', request)
 
 export const configSetPathRpcPromise = (request: ConfigSetPathRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.config.setPath', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
+export const configSetRememberPassphraseRpcChannelMap = (configKeys: Array<string>, request: ConfigSetRememberPassphraseRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.config.setRememberPassphrase', request)
+
+export const configSetRememberPassphraseRpcPromise = (request: ConfigSetRememberPassphraseRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.config.setRememberPassphrase', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
 
 export const configSetUserConfigRpcChannelMap = (configKeys: Array<string>, request: ConfigSetUserConfigRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.config.setUserConfig', request)
 
@@ -2035,11 +2043,15 @@ export type ConfigGetCurrentStatusRpcParam = ?$ReadOnly<{incomingCallMap?: Incom
 
 export type ConfigGetExtendedStatusRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type ConfigGetRememberPassphraseRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type ConfigGetValueRpcParam = $ReadOnly<{path: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type ConfigHelloIAmRpcParam = $ReadOnly<{details: ClientDetails, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type ConfigSetPathRpcParam = $ReadOnly<{path: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type ConfigSetRememberPassphraseRpcParam = $ReadOnly<{remember: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type ConfigSetUserConfigRpcParam = $ReadOnly<{username: String, key: String, value: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
@@ -2174,7 +2186,7 @@ export type ExitCode =
   | 2 // NOTOK_2
   | 4 // RESTART_4
 
-export type ExtendedStatus = $ReadOnly<{standalone: Boolean, passphraseStreamCached: Boolean, tsecCached: Boolean, deviceSigKeyCached: Boolean, deviceEncKeyCached: Boolean, paperSigKeyCached: Boolean, paperEncKeyCached: Boolean, storedSecret: Boolean, secretPromptSkip: Boolean, device?: ?Device, deviceErr?: ?LoadDeviceErr, logDir: String, session?: ?SessionStatus, defaultUsername: String, provisionedUsernames?: ?Array<String>, Clients?: ?Array<ClientDetails>, platformInfo: PlatformInfo, defaultDeviceID: DeviceID}>
+export type ExtendedStatus = $ReadOnly<{standalone: Boolean, passphraseStreamCached: Boolean, tsecCached: Boolean, deviceSigKeyCached: Boolean, deviceEncKeyCached: Boolean, paperSigKeyCached: Boolean, paperEncKeyCached: Boolean, storedSecret: Boolean, secretPromptSkip: Boolean, rememberPassphrase: Boolean, device?: ?Device, deviceErr?: ?LoadDeviceErr, logDir: String, session?: ?SessionStatus, defaultUsername: String, provisionedUsernames?: ?Array<String>, Clients?: ?Array<ClientDetails>, platformInfo: PlatformInfo, defaultDeviceID: DeviceID}>
 
 export type FSEditListRequest = $ReadOnly<{folder: Folder, requestID: Int}>
 
@@ -3940,6 +3952,7 @@ type ConfigGetBootstrapStatusResult = BootstrapStatus
 type ConfigGetConfigResult = Config
 type ConfigGetCurrentStatusResult = GetCurrentStatusRes
 type ConfigGetExtendedStatusResult = ExtendedStatus
+type ConfigGetRememberPassphraseResult = Boolean
 type ConfigGetValueResult = ConfigValue
 type ConfigWaitForClientResult = Boolean
 type CryptoSignED25519ForKBFSResult = ED25519SignatureInfo


### PR DESCRIPTION
This patch adds a new SecretStore implementation, SecretStoreMem.  It is a memory-only secret store whose contents don't persist when the app quits.

There is a new config variable `remember_passphrase`.  If set to false, it will use SecretStoreMem.

There are RPC endpoints GetRememberPassphrase and SetRememberPassphrase.  

SetRememberPassphrase replaces the SecretStore implementation in G.  Because of this, the existing G.SecretStoreAll had to change to G.SecretStore() so that it could be protected.

cc @maxtaco OOO