### PR TITLE
Fix link permissions check

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1905,6 +1905,20 @@ func (s SigChainLocation) LessThanOrEqualTo(s2 SigChainLocation) bool {
 	return s.SeqType == s2.SeqType && s.Seqno <= s2.Seqno
 }
 
+func (s SigChainLocation) Comparable(s2 SigChainLocation) error {
+	if s.SeqType != s2.SeqType {
+		return fmt.Errorf("mismatched seqtypes: %v != %v", s.SeqType, s2.SeqType)
+	}
+	return nil
+}
+
+func (s SigChainLocation) Sub1() SigChainLocation {
+	return SigChainLocation{
+		Seqno:   s.Seqno - 1,
+		SeqType: s.SeqType,
+	}
+}
+
 func (r TeamRole) IsAdminOrAbove() bool {
 	return r.IsOrAbove(TeamRole_ADMIN)
 }

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -242,9 +242,10 @@ func (l *TeamLoader) verifyLink(ctx context.Context,
 	}
 }
 
+// Verify that the user had the explicit on-chain role just before this `link`.
 func (l *TeamLoader) verifyExplicitPermission(ctx context.Context, state *keybase1.TeamData,
 	link *chainLinkUnpacked, uv keybase1.UserVersion, atOrAbove keybase1.TeamRole) error {
-	return (TeamSigChainState{state.Chain}).AssertWasRoleOrAboveAt(uv, atOrAbove, link.SigChainLocation())
+	return (TeamSigChainState{state.Chain}).AssertWasRoleOrAboveAt(uv, atOrAbove, link.SigChainLocation().Sub1())
 }
 
 // Does not return a full TeamData because it might get a subteam-reader version.
@@ -308,7 +309,7 @@ func (l *TeamLoader) verifyAdminPermissions(ctx context.Context,
 	// In the simple case, we don't ask for explicit adminship, so we have to be admins of
 	// the current chain at or before the signature in question.
 	if explicitAdmin == nil {
-		err := teamChain.AssertWasAdminAt(uv, link.SigChainLocation())
+		err := teamChain.AssertWasAdminAt(uv, link.SigChainLocation().Sub1())
 		return signer, err
 	}
 


### PR DESCRIPTION
This bothered me. This is a high risk change that probably does not fix any bug.

When a link is verified there is a check that the signing user had permission (the correct role) to sign the link at the time. The check was whether the user had permissions just after the link in question. But the check should have been whether they had permissions just before the link in question.

There is probably no bug because:
1. When appending links to the end (not inflating) the `state` being checked against does not include the new link, so the current check is fine.
2. The types of links that change people's roles (ChangeMembers, Leave, etc) cannot be stubbed, and so cannot be inflated.