### PR TITLE
Fix icons showing up for owners on team page

### DIFF
--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -133,7 +133,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       onOpenFolder={onOpenFolder}
       onManageChat={onManageChat}
       onShowMenu={() => ownProps.setShowMenu(true)}
-      canManageChat={yourOperations.leaveTeam}
+      canManageChat={yourOperations.createChannel}
     />
   )
 

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -134,6 +134,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       onManageChat={onManageChat}
       onShowMenu={() => ownProps.setShowMenu(true)}
       canManageChat={yourOperations.createChannel}
+      canViewFolder={!yourOperations.joinTeam}
     />
   )
 

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -388,18 +388,17 @@ const CustomComponent = ({onOpenFolder, onManageChat, onShowMenu, canManageChat}
       canManageChat && (
         <Icon
           onClick={onManageChat}
+          style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
           type="iconfont-chat"
-          style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
         />
       )}
-    {!isMobile &&
-      canManageChat && (
-        <Icon
-          onClick={onOpenFolder}
-          type="iconfont-folder-private"
-          style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
-        />
-      )}
+    {!isMobile && (
+      <Icon
+        onClick={onOpenFolder}
+        style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
+        type="iconfont-folder-private"
+      />
+    )}
     <Icon
       onClick={onShowMenu}
       type="iconfont-ellipsis"

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -380,9 +380,16 @@ type CustomProps = {
   onManageChat: () => void,
   onShowMenu: () => void,
   canManageChat: boolean,
+  canViewFolder: boolean,
 }
 
-const CustomComponent = ({onOpenFolder, onManageChat, onShowMenu, canManageChat}: CustomProps) => (
+const CustomComponent = ({
+  onOpenFolder,
+  onManageChat,
+  onShowMenu,
+  canManageChat,
+  canViewFolder,
+}: CustomProps) => (
   <Box style={{...globalStyles.flexBoxRow, position: 'absolute', right: 0}}>
     {!isMobile &&
       canManageChat && (
@@ -392,13 +399,14 @@ const CustomComponent = ({onOpenFolder, onManageChat, onShowMenu, canManageChat}
           type="iconfont-chat"
         />
       )}
-    {!isMobile && (
-      <Icon
-        onClick={onOpenFolder}
-        style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
-        type="iconfont-folder-private"
-      />
-    )}
+    {!isMobile &&
+      canViewFolder && (
+        <Icon
+          onClick={onOpenFolder}
+          style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
+          type="iconfont-folder-private"
+        />
+      )}
     <Icon
       onClick={onShowMenu}
       type="iconfont-ellipsis"


### PR DESCRIPTION
@keybase/react-hackers 

The reason the folder and chat icons weren't showing up on a team page when you're the owner is that we had `canManageChat` hooked up to the `leaveTeam` capability, and sole owners can't leave a team.

After this PR, always show the folder icon, and show the chat icon if we're able to `createChannel` (which seems like the closest capability for managing channels).

The JIRA also asked for having the chat button switch from Manage Channels to Jump to Chat for the main channel (the small team channel, or the #general channel for a big team).  There's a ticket waiting on CORE for adding an entry to tell us whether a given team is big or small, so that change should be blocked on that ticket.  Filed DESKTOP-6129 to be done after CORE-7089 is unblocked.