### PR TITLE
throw a rekey error for implicit team chats that fail with a team read error CORE-7214

### DIFF
--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -224,6 +224,17 @@ func NewExplicitTeamOperationError(m string) error {
 	return &ExplicitTeamOperationError{msg: m}
 }
 
+func IsTeamReadError(err error) bool {
+	switch e := err.(type) {
+	case libkb.AppStatusError:
+		switch keybase1.StatusCode(e.Code) {
+		case keybase1.StatusCode_SCTeamReadError:
+			return true
+		}
+	}
+	return false
+}
+
 func fixupTeamGetError(ctx context.Context, g *libkb.GlobalContext, e error, teamDescriptor string, publicTeam bool) error {
 	if e == nil {
 		return nil


### PR DESCRIPTION
If we get a team read error when unboxing the inbox item of an `IMPTEAMNATIVE` or `IMPTEAMUPGRADE` conversation, then transform the error into rekey error. After looking through the server code, and similar code in the client, it seems this is the best way to detect this state. 