### PR TITLE
Render create and rename git push system messages properly (CLI)

### DIFF
--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -445,10 +445,17 @@ func formatSystemMessage(body chat1.MessageSystem) string {
 	case chat1.MessageSystemType_CREATETEAM:
 		return fmt.Sprintf("[%s created the team %s]", body.Createteam().Creator, body.Createteam().Team)
 	case chat1.MessageSystemType_GITPUSH:
-		total := keybase1.TotalNumberOfCommits(body.Gitpush().Refs)
-		names := keybase1.RefNames(body.Gitpush().Refs)
-		return fmt.Sprintf("[git (%s) %s pushed %d commits to %s]", body.Gitpush().RepoName,
-			body.Gitpush().Pusher, total, names)
+		switch body.Gitpush().PushType {
+		case keybase1.GitPushType_CREATEREPO:
+			return fmt.Sprintf("[git %s created the repo %s]", body.Gitpush().Pusher, body.Gitpush().RepoName)
+		case keybase1.GitPushType_RENAMEREPO:
+			return fmt.Sprintf("[git %s changed the name of the repo %s to %s]", body.Gitpush().Pusher, body.Gitpush().PreviousRepoName, body.Gitpush().RepoName)
+		default:
+			total := keybase1.TotalNumberOfCommits(body.Gitpush().Refs)
+			names := keybase1.RefNames(body.Gitpush().Refs)
+			return fmt.Sprintf("[git (%s) %s pushed %d commits to %s]", body.Gitpush().RepoName,
+				body.Gitpush().Pusher, total, names)
+		}
 	}
 	return "<unknown system message>"
 }

--- a/go/git/put.go
+++ b/go/git/put.go
@@ -93,6 +93,11 @@ func sendChat(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamI
 		return nil
 	}
 
+	if arg.Metadata.PushType == keybase1.GitPushType_DEFAULT && keybase1.TotalNumberOfCommits(arg.Metadata.Refs) == 0 {
+		g.Log.CDebugf(ctx, "default git push and no commits, not sending chat")
+		return nil
+	}
+
 	g.StartStandaloneChat()
 
 	subBody := chat1.NewMessageSystemWithGitpush(chat1.MessageSystemGitPush{

--- a/go/git/put_get_test.go
+++ b/go/git/put_get_test.go
@@ -27,6 +27,7 @@ func doPut(t *testing.T, g *libkb.GlobalContext, teamName string, repoID string,
 		RepoID: keybase1.RepoID(repoID),
 		Metadata: keybase1.GitLocalMetadata{
 			RepoName: keybase1.GitRepoName(repoName),
+			PushType: keybase1.GitPushType_CREATEREPO,
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
And don't send chat system messages for default git pushes with no commits.