### PR TITLE
osx: start/stop redirector process from the root helper

### DIFF
--- a/osx/Helper/Info.plist
+++ b/osx/Helper/Info.plist
@@ -9,11 +9,11 @@
 	<key>CFBundleName</key>
 	<string>Helper</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.29</string>
+	<string>1.0.30</string>
 	<key>KBBuild</key>
 	<string>3</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.29</string>
+	<string>1.0.30</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = &quot;99229SGT5K&quot;) and (identifier &quot;keybase.Installer&quot; or identifier &quot;keybase.Keybase&quot;)</string>

--- a/osx/Helper/KBHelper.m
+++ b/osx/Helper/KBHelper.m
@@ -162,18 +162,16 @@
       return;
     }
 
-    NSURL srcUrl = [NSURL fileURLWithPath:redirectorBin];
-    NSURL dstUrl = [NSURL fileURLWithPath:[directoryURL stribByAppendingPathComponent @"keybase-redirector"]];
+    NSURL *srcURL = [NSURL fileURLWithPath:redirectorBin];
+    NSURL *dstURL = [directoryURL URLByAppendingPathComponent:@"keybase-redirector" isDirectory:NO];
     if (![[NSFileManager defaultManager] copyItemAtURL:srcURL toURL:dstURL error:&error]) {
       completion(nil, error);
       return;
     }
 
-    // Make sure the passed-in redirectory binary points to a proper binary
+    // Make sure the passed-in redirector binary points to a proper binary
     // signed by Keybase, we don't want this to be able to run arbitrary code
-    // as root.  TODO: Technically the binary could be swapped out immediately
-    // after the check, so maybe we should come up with a way to protect
-    // against that.  (Perhaps copy the binary first to a root-only location?)
+    // as root.
     SecStaticCodeRef staticCode = NULL;
     CFURLRef url = (__bridge CFURLRef)dstURL;
     SecStaticCodeCreateWithPath(url, kSecCSDefaultFlags, &staticCode);
@@ -187,7 +185,7 @@
     }
 
     NSTask *task = [[NSTask alloc] init];
-    task.launchPath = redirectorBin;
+    task.launchPath = dstURL.path;
     task.arguments = @[directory];
     self.redirector = task;
     [self.redirector launch];

--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -25,9 +25,9 @@
 	<key>KBFuseVersion</key>
 	<string>3.6.3</string>
 	<key>KBHelperBuild</key>
-	<string>1.0.29</string>
+	<string>1.0.30</string>
 	<key>KBHelperVersion</key>
-	<string>1.0.29</string>
+	<string>1.0.30</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/osx/Installer/Options.h
+++ b/osx/Installer/Options.h
@@ -18,8 +18,9 @@ typedef NS_OPTIONS (NSUInteger, UninstallOptions) {
   UninstallOptionMountDir = 1 << 2,
   UninstallOptionHelper = 1 << 3,
   UninstallOptionCLI = 1 << 4,
+  UninstallOptionRedirector = 1 << 5,
 
-  // Uninstall all (except for app)
+  // Uninstall all (except for app and redirector)
   UninstallOptionAll = UninstallOptionMountDir | UninstallOptionFuse | UninstallOptionCLI | UninstallOptionHelper,
 };
 

--- a/osx/Installer/Options.m
+++ b/osx/Installer/Options.m
@@ -93,6 +93,9 @@
   if ([[self.settings objectForKey:@"install-mountdir"] boolValue]) {
     self.installOptions |= KBInstallOptionMountDir;
   }
+  if ([[self.settings objectForKey:@"install-redirector"] boolValue]) {
+    self.installOptions |= KBInstallOptionRedirector;
+  }
   if ([[self.settings objectForKey:@"install-helper"] boolValue]) {
     self.installOptions |= KBInstallOptionHelper;
   }

--- a/osx/Installer/Options.m
+++ b/osx/Installer/Options.m
@@ -44,6 +44,7 @@
   [parser registerSwitch:@"uninstall-mountdir"];
   [parser registerSwitch:@"uninstall-helper"];
   [parser registerSwitch:@"uninstall-cli"];
+  [parser registerSwitch:@"uninstall-redirector"];
   [parser registerSwitch:@"uninstall"];
   [parser registerSwitch:@"install-fuse"];
   [parser registerSwitch:@"install-mountdir"];
@@ -83,6 +84,9 @@
   }
   if ([[self.settings objectForKey:@"uninstall-cli"] boolValue]) {
     self.uninstallOptions |= UninstallOptionCLI;
+  }
+  if ([[self.settings objectForKey:@"uninstall-redirector"] boolValue]) {
+    self.uninstallOptions |= UninstallOptionRedirector;
   }
   if ([[self.settings objectForKey:@"uninstall"] boolValue]) {
     self.installOptions |= UninstallOptionAll;

--- a/osx/Installer/Options.m
+++ b/osx/Installer/Options.m
@@ -47,6 +47,7 @@
   [parser registerSwitch:@"uninstall"];
   [parser registerSwitch:@"install-fuse"];
   [parser registerSwitch:@"install-mountdir"];
+  [parser registerSwitch:@"install-redirector"];
   [parser registerSwitch:@"install-helper"];
   [parser registerSwitch:@"install-app-bundle"];
   [parser registerSwitch:@"install-cli"];

--- a/osx/Installer/Uninstaller.m
+++ b/osx/Installer/Uninstaller.m
@@ -35,7 +35,7 @@
     [installables addObject:environment.helperTool];
   }
   if (options.uninstallOptions & UninstallOptionRedirector) {
-    KBRedirector *redirector = [[KBRedirector alloc] initWithConfig:config helperTool:environment.helperTool];
+    KBRedirector *redirector = [[KBRedirector alloc] initWithConfig:environment.config helperTool:environment.helperTool];
     [installables addObject:redirector];
   }
   if (options.uninstallOptions & UninstallOptionApp) {

--- a/osx/Installer/Uninstaller.m
+++ b/osx/Installer/Uninstaller.m
@@ -34,6 +34,10 @@
   if (options.uninstallOptions & UninstallOptionHelper) {
     [installables addObject:environment.helperTool];
   }
+  if (options.uninstallOptions & UninstallOptionRedirector) {
+    KBRedirector *redirector = [[KBRedirector alloc] initWithConfig:config helperTool:environment.helperTool];
+    [installables addObject:redirector];
+  }
   if (options.uninstallOptions & UninstallOptionApp) {
     [installables addObject:[[KBAppBundle alloc] initWithConfig:environment.config helperTool:environment.helperTool]];
   }

--- a/osx/Installer/Uninstaller.m
+++ b/osx/Installer/Uninstaller.m
@@ -35,7 +35,7 @@
     [installables addObject:environment.helperTool];
   }
   if (options.uninstallOptions & UninstallOptionRedirector) {
-    KBRedirector *redirector = [[KBRedirector alloc] initWithConfig:environment.config helperTool:environment.helperTool];
+    KBRedirector *redirector = [[KBRedirector alloc] initWithConfig:environment.config helperTool:environment.helperTool servicePath:@""];
     [installables addObject:redirector];
   }
   if (options.uninstallOptions & UninstallOptionApp) {

--- a/osx/KBKit/KBKit.xcodeproj/project.pbxproj
+++ b/osx/KBKit/KBKit.xcodeproj/project.pbxproj
@@ -360,7 +360,7 @@
 		00E206681C4DBD170095FD56 /* KBCommandLine.h in Headers */ = {isa = PBXBuildFile; fileRef = 00E206661C4DBD170095FD56 /* KBCommandLine.h */; };
 		00E206691C4DBD170095FD56 /* KBCommandLine.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E206671C4DBD170095FD56 /* KBCommandLine.m */; };
 		206644B0203CEF0700082D09 /* KBRedirector.h in Headers */ = {isa = PBXBuildFile; fileRef = 206644AE203CEF0700082D09 /* KBRedirector.h */; };
-		206644B1203CEF0700082D09 /* KBRedirector.m in Sources */ = {isa = PBXBuildFile; fileRef = 206644AF203CEF0700082D09 /* KBRedirector.m */; };
+		206644B3203CF59B00082D09 /* KBRedirector.m in Sources */ = {isa = PBXBuildFile; fileRef = 206644AF203CEF0700082D09 /* KBRedirector.m */; };
 		5CF627053506EA5AD0D3EC32 /* libPods-KBKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B74D43B87E43EC9A7B5E254 /* libPods-KBKit.a */; };
 /* End PBXBuildFile section */
 
@@ -1681,6 +1681,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				206644B3203CF59B00082D09 /* KBRedirector.m in Sources */,
 				00010C921BE19F8900A9C285 /* KBApp.m in Sources */,
 				00010DA71BE19F8900A9C285 /* KBSecretPromptView.m in Sources */,
 				00010D531BE19F8900A9C285 /* KBKeyImportView.m in Sources */,
@@ -1738,7 +1739,6 @@
 				00010CAE1BE19F8900A9C285 /* KBInstallable.m in Sources */,
 				0033F4761C3F271B00317C79 /* KBMemLogger.m in Sources */,
 				00010DC31BE19F8900A9C285 /* KBUserButtonView.m in Sources */,
-				206644B1203CEF0700082D09 /* KBRedirector.m in Sources */,
 				00010DBD1BE19F8900A9C285 /* KBSearchField.m in Sources */,
 				00010D4F1BE19F8900A9C285 /* KBProgressView.m in Sources */,
 				00010DCB1BE19F8900A9C285 /* KBUserInfoView.m in Sources */,

--- a/osx/KBKit/KBKit.xcodeproj/project.pbxproj
+++ b/osx/KBKit/KBKit.xcodeproj/project.pbxproj
@@ -359,6 +359,8 @@
 		00B82BD31BE9424600C1FC72 /* KBTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 00B82BD11BE9424600C1FC72 /* KBTask.m */; };
 		00E206681C4DBD170095FD56 /* KBCommandLine.h in Headers */ = {isa = PBXBuildFile; fileRef = 00E206661C4DBD170095FD56 /* KBCommandLine.h */; };
 		00E206691C4DBD170095FD56 /* KBCommandLine.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E206671C4DBD170095FD56 /* KBCommandLine.m */; };
+		206644B0203CEF0700082D09 /* KBRedirector.h in Headers */ = {isa = PBXBuildFile; fileRef = 206644AE203CEF0700082D09 /* KBRedirector.h */; };
+		206644B1203CEF0700082D09 /* KBRedirector.m in Sources */ = {isa = PBXBuildFile; fileRef = 206644AF203CEF0700082D09 /* KBRedirector.m */; };
 		5CF627053506EA5AD0D3EC32 /* libPods-KBKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B74D43B87E43EC9A7B5E254 /* libPods-KBKit.a */; };
 /* End PBXBuildFile section */
 
@@ -731,6 +733,8 @@
 		00E206661C4DBD170095FD56 /* KBCommandLine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBCommandLine.h; sourceTree = "<group>"; };
 		00E206671C4DBD170095FD56 /* KBCommandLine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBCommandLine.m; sourceTree = "<group>"; };
 		09A69C34EE77C4A0563C93F3 /* Pods-KBKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KBKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-KBKit/Pods-KBKit.release.xcconfig"; sourceTree = "<group>"; };
+		206644AE203CEF0700082D09 /* KBRedirector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBRedirector.h; sourceTree = "<group>"; };
+		206644AF203CEF0700082D09 /* KBRedirector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBRedirector.m; sourceTree = "<group>"; };
 		479C84E44E80724FA433EBC6 /* Pods-KBKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KBKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-KBKit/Pods-KBKit.debug.xcconfig"; sourceTree = "<group>"; };
 		9B74D43B87E43EC9A7B5E254 /* libPods-KBKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-KBKit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -840,6 +844,8 @@
 		00010B351BE19F8800A9C285 /* Component */ = {
 			isa = PBXGroup;
 			children = (
+				206644AE203CEF0700082D09 /* KBRedirector.h */,
+				206644AF203CEF0700082D09 /* KBRedirector.m */,
 				00010B381BE19F8800A9C285 /* KBComponent.h */,
 				00010B391BE19F8800A9C285 /* KBComponent.m */,
 				00010B3A1BE19F8800A9C285 /* KBComponentStatus.h */,
@@ -1402,6 +1408,7 @@
 				00010D701BE19F8900A9C285 /* KBPGPDecryptFooterView.h in Headers */,
 				00010D1A1BE19F8900A9C285 /* KBDeviceAddView.h in Headers */,
 				00010DAC1BE19F8900A9C285 /* KBProofResult.h in Headers */,
+				206644B0203CEF0700082D09 /* KBRedirector.h in Headers */,
 				00010C9B1BE19F8900A9C285 /* KBNotifications.h in Headers */,
 				00010D081BE19F8900A9C285 /* KBAppDebug.h in Headers */,
 				00010CA31BE19F8900A9C285 /* KBComponentStatus.h in Headers */,
@@ -1731,6 +1738,7 @@
 				00010CAE1BE19F8900A9C285 /* KBInstallable.m in Sources */,
 				0033F4761C3F271B00317C79 /* KBMemLogger.m in Sources */,
 				00010DC31BE19F8900A9C285 /* KBUserButtonView.m in Sources */,
+				206644B1203CEF0700082D09 /* KBRedirector.m in Sources */,
 				00010DBD1BE19F8900A9C285 /* KBSearchField.m in Sources */,
 				00010D4F1BE19F8900A9C285 /* KBProgressView.m in Sources */,
 				00010DCB1BE19F8900A9C285 /* KBUserInfoView.m in Sources */,

--- a/osx/KBKit/KBKit/Component/KBCommandLine.m
+++ b/osx/KBKit/KBKit/Component/KBCommandLine.m
@@ -48,13 +48,6 @@
     DDLogDebug(@"Result: %@", value);
     completion(error);
   }];
-
-  NSDictionary *redirectorParams = @{@"directory": self.servicePath, @"name": self.config.redirectorName, @"appName": self.config.appName};
-  DDLogDebug(@"Helper: addToPath(%@)", redirectorParams);
-  [self.helperTool.helper sendRequest:@"addToPath" params:@[redirectorParams] completion:^(NSError *error, id value) {
-    DDLogDebug(@"Result: %@", value);
-    completion(error);
-  }];
 }
 
 - (void)uninstall:(KBCompletion)completion {

--- a/osx/KBKit/KBKit/Component/KBCommandLine.m
+++ b/osx/KBKit/KBKit/Component/KBCommandLine.m
@@ -48,6 +48,13 @@
     DDLogDebug(@"Result: %@", value);
     completion(error);
   }];
+
+  NSDictionary *redirectorParams = @{@"directory": self.servicePath, @"name": self.config.redirectorName, @"appName": self.config.appName};
+  DDLogDebug(@"Helper: addToPath(%@)", redirectorParams);
+  [self.helperTool.helper sendRequest:@"addToPath" params:@[redirectorParams] completion:^(NSError *error, id value) {
+    DDLogDebug(@"Result: %@", value);
+    completion(error);
+  }];
 }
 
 - (void)uninstall:(KBCompletion)completion {

--- a/osx/KBKit/KBKit/Component/KBRedirector.h
+++ b/osx/KBKit/KBKit/Component/KBRedirector.h
@@ -1,0 +1,20 @@
+//
+//  KBMountDir.h
+//  KBKit
+//
+//  Created by Gabriel on 8/24/16.
+//  Copyright © 2016 Gabriel Handford. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "KBComponent.h"
+#import "KBInstallable.h"
+#import "KBEnvConfig.h"
+#import "KBHelperTool.h"
+
+@interface KBRedirector : KBInstallable
+
+- (instancetype)initWithConfig:(KBEnvConfig *)config helperTool:(KBHelperTool *)helperTool;
+
+@end

--- a/osx/KBKit/KBKit/Component/KBRedirector.h
+++ b/osx/KBKit/KBKit/Component/KBRedirector.h
@@ -1,5 +1,5 @@
 //
-//  KBMountDir.h
+//  KBRedirector.h
 //  KBKit
 //
 //  Created by Gabriel on 8/24/16.

--- a/osx/KBKit/KBKit/Component/KBRedirector.h
+++ b/osx/KBKit/KBKit/Component/KBRedirector.h
@@ -15,6 +15,6 @@
 
 @interface KBRedirector : KBInstallable
 
-- (instancetype)initWithConfig:(KBEnvConfig *)config helperTool:(KBHelperTool *)helperTool;
+- (instancetype)initWithConfig:(KBEnvConfig *)config helperTool:(KBHelperTool *)helperTool servicePath:(NSString *)servicePath;
 
 @end

--- a/osx/KBKit/KBKit/Component/KBRedirector.h
+++ b/osx/KBKit/KBKit/Component/KBRedirector.h
@@ -2,8 +2,7 @@
 //  KBRedirector.h
 //  KBKit
 //
-//  Created by Gabriel on 8/24/16.
-//  Copyright © 2016 Gabriel Handford. All rights reserved.
+//  Created by strib on 2/20/18.
 //
 
 #import <Foundation/Foundation.h>

--- a/osx/KBKit/KBKit/Component/KBRedirector.m
+++ b/osx/KBKit/KBKit/Component/KBRedirector.m
@@ -1,0 +1,41 @@
+//
+//  KBRedirector.m
+//  KBKit
+//
+//  Created by Jeremy on 2/20/18.
+//
+
+#import "KBRedirector.h"
+#import "KBInstaller.h"
+
+@interface KBRedirector ()
+@property KBHelperTool *helperTool;
+@end
+
+@implementation KBRedirector
+
+@synthesize error;
+
+- (instancetype)initWithConfig:(KBEnvConfig *)config helperTool:(KBHelperTool *)helperTool {
+  if ((self = [self initWithConfig:config name:@"Redirector" info:@"Helper tool for redirector" image:nil])) {
+    _helperTool = helperTool;
+  }
+  return self;
+}
+
+- (NSString *)name {
+  return @"Redirector";
+}
+
+- (void)install:(KBCompletion)completion {
+  uid_t uid = 0;
+  gid_t gid = 0;
+  NSNumber *permissions = [NSNumber numberWithShort:0600];
+  NSDictionary *params = @{@"directory": @"/keybase", @"uid": @(uid), @"gid": @(gid), @"permissions": permissions, @"excludeFromBackup": @(YES), @"redirectorBin": "/Applications/Keybase.app/Contents/SharedSupport/bin/keybase-redirector"};
+  DDLogDebug(@"Starting redirector: %@", params);
+  [self.helperTool.helper sendRequest:@"startRedirector" params:@[params] completion:^(NSError *err, id value) {
+    completion(err);
+  }];
+}
+
+@end

--- a/osx/KBKit/KBKit/Component/KBRedirector.m
+++ b/osx/KBKit/KBKit/Component/KBRedirector.m
@@ -38,4 +38,12 @@
   }];
 }
 
+- (void)uninstall:(KBCompletion)completion {
+  NSDictionary *params = @{@"directory": @"/keybase.redirect"};
+  DDLogDebug(@"Stopping redirector: %@", params);
+  [self.helperTool.helper sendRequest:@"stopRedirector" params:@[params] completion:^(NSError *err, id value) {
+    completion(err);
+  }];
+}
+
 @end

--- a/osx/KBKit/KBKit/Component/KBRedirector.m
+++ b/osx/KBKit/KBKit/Component/KBRedirector.m
@@ -31,7 +31,7 @@
   uid_t uid = 0;
   gid_t gid = 0;
   NSNumber *permissions = [NSNumber numberWithShort:0600];
-  NSDictionary *params = @{@"directory": @"/keybase", @"uid": @(uid), @"gid": @(gid), @"permissions": permissions, @"excludeFromBackup": @(YES), @"redirectorBin": "/Applications/Keybase.app/Contents/SharedSupport/bin/keybase-redirector"};
+  NSDictionary *params = @{@"directory": @"/keybase.redirect", @"uid": @(uid), @"gid": @(gid), @"permissions": permissions, @"excludeFromBackup": @(YES), @"redirectorBin": @"/Applications/Keybase.app/Contents/SharedSupport/bin/keybase-redirector"};
   DDLogDebug(@"Starting redirector: %@", params);
   [self.helperTool.helper sendRequest:@"startRedirector" params:@[params] completion:^(NSError *err, id value) {
     completion(err);

--- a/osx/KBKit/KBKit/Component/KBRedirector.m
+++ b/osx/KBKit/KBKit/Component/KBRedirector.m
@@ -10,15 +10,17 @@
 
 @interface KBRedirector ()
 @property KBHelperTool *helperTool;
+@property NSString *servicePath;
 @end
 
 @implementation KBRedirector
 
 @synthesize error;
 
-- (instancetype)initWithConfig:(KBEnvConfig *)config helperTool:(KBHelperTool *)helperTool {
+- (instancetype)initWithConfig:(KBEnvConfig *)config helperTool:(KBHelperTool *)helperTool servicePath:(NSString *)servicePath {
   if ((self = [self initWithConfig:config name:@"Redirector" info:@"Helper tool for redirector" image:nil])) {
     _helperTool = helperTool;
+    _servicePath = servicePath;
   }
   return self;
 }
@@ -31,7 +33,9 @@
   uid_t uid = 0;
   gid_t gid = 0;
   NSNumber *permissions = [NSNumber numberWithShort:0600];
-  NSDictionary *params = @{@"directory": @"/keybase.redirect", @"uid": @(uid), @"gid": @(gid), @"permissions": permissions, @"excludeFromBackup": @(YES), @"redirectorBin": @"/Applications/Keybase.app/Contents/SharedSupport/bin/keybase-redirector"};
+  NSString *mount = [self.config redirectorMount];
+  NSString *binPath = [self.config redirectorBinPathWithPathOptions:0 servicePath:_servicePath];
+  NSDictionary *params = @{@"directory": mount, @"uid": @(uid), @"gid": @(gid), @"permissions": permissions, @"excludeFromBackup": @(YES), @"redirectorBin": binPath};
   DDLogDebug(@"Starting redirector: %@", params);
   [self.helperTool.helper sendRequest:@"startRedirector" params:@[params] completion:^(NSError *err, id value) {
     completion(err);

--- a/osx/KBKit/KBKit/Component/KBRedirector.m
+++ b/osx/KBKit/KBKit/Component/KBRedirector.m
@@ -2,7 +2,7 @@
 //  KBRedirector.m
 //  KBKit
 //
-//  Created by Jeremy on 2/20/18.
+//  Created by strib on 2/21/18.
 //
 
 #import "KBRedirector.h"

--- a/osx/KBKit/KBKit/KBKit.h
+++ b/osx/KBKit/KBKit/KBKit.h
@@ -56,6 +56,7 @@ FOUNDATION_EXPORT const unsigned char KBKitVersionString[];
 #import <KBKit/KBUninstaller.h>
 #import <KBKit/KBAppBundle.h>
 #import <KBKit/KBMountDir.h>
+#import <KBKit/KBRedirector.h>
 
 // IO
 #import <KBKit/KBFileReader.h>

--- a/osx/KBKit/KBKit/System/KBEnvConfig.h
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.h
@@ -68,6 +68,7 @@ typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
 - (NSString *)serviceBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath;
 - (NSString *)kbfsBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath;
 - (NSString *)gitRemoteHelperName;
+- (NSString *)redirectorName;
 
 - (BOOL)validate:(NSError **)error;
 

--- a/osx/KBKit/KBKit/System/KBEnvConfig.h
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.h
@@ -24,6 +24,7 @@ typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
   KBInstallOptionKBFS = 1 << 4,
   KBInstallOptionUpdater = 1 << 5,
   KBInstallOptionMountDir = 1 << 6,
+  KBInstallOptionRedirector = 1 << 7,
   KBInstallOptionCLI = 1 << 10,
   KBInstallOptionAppBundle = 1 << 11,
   KBInstallOptionKBNM = 1 << 12,

--- a/osx/KBKit/KBKit/System/KBEnvConfig.h
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.h
@@ -68,8 +68,10 @@ typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
 - (NSString *)serviceBinName;
 - (NSString *)serviceBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath;
 - (NSString *)kbfsBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath;
+- (NSString *)redirectorBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath;
 - (NSString *)gitRemoteHelperName;
-- (NSString *)redirectorName;
+- (NSString *)redirectorBinName;
+- (NSString *)redirectorMount;
 
 - (BOOL)validate:(NSError **)error;
 

--- a/osx/KBKit/KBKit/System/KBEnvConfig.h
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.h
@@ -68,7 +68,6 @@ typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
 - (NSString *)serviceBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath;
 - (NSString *)kbfsBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath;
 - (NSString *)gitRemoteHelperName;
-- (NSString *)redirectorName;
 
 - (BOOL)validate:(NSError **)error;
 

--- a/osx/KBKit/KBKit/System/KBEnvConfig.m
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.m
@@ -149,6 +149,10 @@
   return @"git-remote-keybase";
 }
 
+- (NSString *)redirectorName {
+  return @"keybase-redirector";
+}
+
 - (NSString *)kbfsBinName {
   switch(_runMode) {
     case KBRunModeDevel: return @"kbfsdev";

--- a/osx/KBKit/KBKit/System/KBEnvConfig.m
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.m
@@ -146,8 +146,8 @@
 }
 
 - (NSString *)redirectorBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath {
-  if (!servicePath) return [self redirectorName];
-  return [KBPath pathInDir:servicePath path:[self redirectorName] options:pathOptions];
+  if (!servicePath) return [self redirectorBinName];
+  return [KBPath pathInDir:servicePath path:[self redirectorBinName] options:pathOptions];
 }
 
 - (NSString *)gitRemoteHelperName {

--- a/osx/KBKit/KBKit/System/KBEnvConfig.m
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.m
@@ -149,10 +149,6 @@
   return @"git-remote-keybase";
 }
 
-- (NSString *)redirectorName {
-  return @"keybase-redirector";
-}
-
 - (NSString *)kbfsBinName {
   switch(_runMode) {
     case KBRunModeDevel: return @"kbfsdev";

--- a/osx/KBKit/KBKit/System/KBEnvConfig.m
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.m
@@ -145,12 +145,27 @@
   return [KBPath pathInDir:servicePath path:[self kbfsBinName] options:pathOptions];
 }
 
+- (NSString *)redirectorBinPathWithPathOptions:(KBPathOptions)pathOptions servicePath:(NSString *)servicePath {
+  if (!servicePath) return [self redirectorName];
+  return [KBPath pathInDir:servicePath path:[self redirectorName] options:pathOptions];
+}
+
 - (NSString *)gitRemoteHelperName {
   return @"git-remote-keybase";
 }
 
-- (NSString *)redirectorName {
+- (NSString *)redirectorBinName {
   return @"keybase-redirector";
+}
+
+- (NSString *)redirectorMount {
+  switch(_runMode) {
+    // TODO: Remove ".redirect" from these names once we move the
+    // mounted directory.
+    case KBRunModeDevel: return @"/keybase.redirect.devel";
+    case KBRunModeStaging: return @"/keybase.redirect.staging";
+    case KBRunModeProd: return @"/keybase.redirect";
+  }
 }
 
 - (NSString *)kbfsBinName {

--- a/osx/KBKit/KBKit/System/KBEnvironment.m
+++ b/osx/KBKit/KBKit/System/KBEnvironment.m
@@ -76,6 +76,12 @@
       [_installables addObject:mountDir];
     }
 
+    if (config.installOptions&KBInstallOptionRedirector) {
+      helperRequired = YES;
+      KBRedirector *redirector = [[KBRedirector alloc] initWithConfig:config helperTool:_helperTool];
+      [_installables addObject:redirector];
+    }
+
     _kbfs = [[KBFSService alloc] initWithConfig:config label:[config launchdKBFSLabel] servicePath:servicePath];
     if (config.installOptions&KBInstallOptionKBFS) {
       [_installables addObject:_kbfs];

--- a/osx/KBKit/KBKit/System/KBEnvironment.m
+++ b/osx/KBKit/KBKit/System/KBEnvironment.m
@@ -79,7 +79,7 @@
 
     if (config.installOptions&KBInstallOptionRedirector) {
       helperRequired = YES;
-      KBRedirector *redirector = [[KBRedirector alloc] initWithConfig:config helperTool:_helperTool];
+      KBRedirector *redirector = [[KBRedirector alloc] initWithConfig:config helperTool:_helperTool servicePath:servicePath];
       [_installables addObject:redirector];
     }
 

--- a/osx/KBKit/KBKit/System/KBEnvironment.m
+++ b/osx/KBKit/KBKit/System/KBEnvironment.m
@@ -15,6 +15,7 @@
 #import "KBCommandLine.h"
 #import "KBUpdaterService.h"
 #import "KBMountDir.h"
+#import "KBRedirector.h"
 #import "KBAppBundle.h"
 #import "KBNM.h"
 

--- a/osx/KBKit/KBKit/System/KBEnvironment.m
+++ b/osx/KBKit/KBKit/System/KBEnvironment.m
@@ -15,7 +15,7 @@
 #import "KBCommandLine.h"
 #import "KBUpdaterService.h"
 #import "KBMountDir.h"
-#import "../Component/KBRedirector.h"
+#import "KBRedirector.h"
 #import "KBAppBundle.h"
 #import "KBNM.h"
 

--- a/osx/KBKit/KBKit/System/KBEnvironment.m
+++ b/osx/KBKit/KBKit/System/KBEnvironment.m
@@ -15,7 +15,7 @@
 #import "KBCommandLine.h"
 #import "KBUpdaterService.h"
 #import "KBMountDir.h"
-#import "KBRedirector.h"
+#import "../Component/KBRedirector.h"
 #import "KBAppBundle.h"
 #import "KBNM.h"
 

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -240,6 +240,7 @@ sign() {(
   spctl --assess --verbose=4 "$app_name.app"
   codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/keybase"
   codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/git-remote-keybase"
+  codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/keybase-redirector"
   codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/kbfs"
   codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/kbnm"
   codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/updater"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -153,10 +153,7 @@ get_deps() {(
     echo "Using local kbfs binpath: $kbfs_binpath"
     cp "$kbfs_binpath" .
     cp "$git_remote_keybase_binpath" .
-<<<<<<< e42ff33beff0d36f68c010ddb5a9d559909722ba
     echo "Using local redirector binpath: $redirector_binpath"
-=======
->>>>>>> packaging: fix redirector path if using old build_app.sh
     cp "$redirector_binpath" .
   else
     kbfs_url="https://github.com/keybase/kbfs/releases/download/v$kbfs_version/kbfs-$kbfs_version-darwin.tgz"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -37,7 +37,6 @@ comment=""
 
 keybase_binpath=${KEYBASE_BINPATH:-}
 git_remote_keybase_binpath=${GIT_REMOTE_KEYBASE_BINPATH:-}
-redirector_binpath=${REDIRECTOR_BINPATH:-}
 kbfs_binpath=${KBFS_BINPATH:-}
 redirector_binpath=${REDIRECTOR_BINPATH:-`dirname $KBFS_BINPATH`/keybase-redirector}
 kbnm_binpath=${KBNM_BINPATH:-}
@@ -154,7 +153,10 @@ get_deps() {(
     echo "Using local kbfs binpath: $kbfs_binpath"
     cp "$kbfs_binpath" .
     cp "$git_remote_keybase_binpath" .
+<<<<<<< e42ff33beff0d36f68c010ddb5a9d559909722ba
     echo "Using local redirector binpath: $redirector_binpath"
+=======
+>>>>>>> packaging: fix redirector path if using old build_app.sh
     cp "$redirector_binpath" .
   else
     kbfs_url="https://github.com/keybase/kbfs/releases/download/v$kbfs_version/kbfs-$kbfs_version-darwin.tgz"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -37,6 +37,7 @@ comment=""
 
 keybase_binpath=${KEYBASE_BINPATH:-}
 git_remote_keybase_binpath=${GIT_REMOTE_KEYBASE_BINPATH:-}
+redirector_binpath=${REDIRECTOR_BINPATH:-}
 kbfs_binpath=${KBFS_BINPATH:-}
 redirector_binpath=${REDIRECTOR_BINPATH:-`dirname $KBFS_BINPATH`/keybase-redirector}
 kbnm_binpath=${KBNM_BINPATH:-}


### PR DESCRIPTION
This PR extends the root helper to be able to start and stop the KBFS redirector.  In particular:
* It adds 2 new RPCs, "startRedirector" and "stopRedirector".
* The start RPC takes a path to a binary, rather than hardcoding a path, to let us be flexible with application paths in the future without needing to update the helper.  However, we obviously don't want the helper to be able to execute arbitrary binaries.  So we copy the binary to a root-only temp dir and check its codesign signature before executing it.
* The redirector is executed as a simple NSTask, rather than using launchd as root.  A future PR will ensure it's always started on reboots.
* Right now the redirector mounts to `/keybase.redirect`.  A future PR will move the per-user mountpoints to `~/keybase` (or possible somewhere not in the home directory, depending on what we decide), and then will rename the redirector mount to `/keybase`.

This is being merged into the root-redirector branch, not to master.

Issue: KBFS-2785