### PR TITLE
osx: client commands for installing/uninstalling redirector

### DIFF
--- a/go/client/cmd_install_osx.go
+++ b/go/client/cmd_install_osx.go
@@ -93,6 +93,7 @@ var defaultInstallComponents = []string{
 	install.ComponentNameMountDir.String(),
 	install.ComponentNameKBFS.String(),
 	install.ComponentNameKBNM.String(),
+	install.ComponentNameRedirector.String(),
 }
 
 func (v *CmdInstall) ParseArgv(ctx *cli.Context) error {

--- a/go/install/install.go
+++ b/go/install/install.go
@@ -61,12 +61,14 @@ const (
 	ComponentNameMountDir ComponentName = "mountdir"
 	// ComponentNameCLIPaths is for /etc/paths.d/Keybase
 	ComponentNameCLIPaths ComponentName = "clipaths"
+	// ComponentNameRedirector is the KBFS redirector
+	ComponentNameRedirector ComponentName = "redirector"
 	// ComponentNameUnknown is placeholder for unknown components
 	ComponentNameUnknown ComponentName = "unknown"
 )
 
 // ComponentNames are all the valid component names
-var ComponentNames = []ComponentName{ComponentNameCLI, ComponentNameService, ComponentNameKBFS, ComponentNameUpdater, ComponentNameFuse, ComponentNameHelper, ComponentNameApp, ComponentNameKBNM, ComponentNameCLIPaths}
+var ComponentNames = []ComponentName{ComponentNameCLI, ComponentNameService, ComponentNameKBFS, ComponentNameUpdater, ComponentNameFuse, ComponentNameHelper, ComponentNameApp, ComponentNameKBNM, ComponentNameRedirector, ComponentNameCLIPaths}
 
 // String returns string for ComponentName
 func (c ComponentName) String() string {
@@ -94,6 +96,8 @@ func (c ComponentName) Description() string {
 		return "Browser Native Messaging"
 	case ComponentNameCLIPaths:
 		return "Command Line (privileged)"
+	case ComponentNameRedirector:
+		return "Redirector (privileged)"
 	}
 	return "Unknown"
 }
@@ -119,6 +123,8 @@ func ComponentNameFromString(s string) ComponentName {
 		return ComponentNameHelper
 	case string(ComponentNameCLIPaths):
 		return ComponentNameCLIPaths
+	case string(ComponentNameRedirector):
+		return ComponentNameRedirector
 	}
 	return ComponentNameUnknown
 }

--- a/go/install/install_darwin.go
+++ b/go/install/install_darwin.go
@@ -412,6 +412,7 @@ func InstallAuto(context Context, binPath string, sourcePath string, timeout tim
 			ComponentNameHelper.String(),
 			ComponentNameFuse.String(),
 			ComponentNameMountDir.String(),
+			ComponentNameRedirector.String(),
 			ComponentNameKBFS.String(),
 			ComponentNameKBNM.String(),
 		}
@@ -496,6 +497,14 @@ func Install(context Context, binPath string, sourcePath string, components []st
 		componentResults = append(componentResults, componentResult(string(ComponentNameKBFS), err))
 		if err != nil {
 			log.Errorf("Error installing KBFS: %s", err)
+		}
+	}
+
+	if libkb.IsIn(string(ComponentNameRedirector), components, false) {
+		err = libnativeinstaller.InstallRedirector(context.GetRunMode(), log)
+		componentResults = append(componentResults, componentResult(string(ComponentNameRedirector), err))
+		if err != nil {
+			log.Errorf("Error starting redirector: %s", err)
 		}
 	}
 
@@ -681,6 +690,14 @@ func Uninstall(context Context, components []string, log Log) keybase1.Uninstall
 	componentResults := []keybase1.ComponentResult{}
 
 	log.Debug("Uninstalling components: %s", components)
+
+	if libkb.IsIn(string(ComponentNameRedirector), components, false) {
+		err = libnativeinstaller.UninstallRedirector(context.GetRunMode(), log)
+		componentResults = append(componentResults, componentResult(string(ComponentNameRedirector), err))
+		if err != nil {
+			log.Errorf("Error uninstalling mount dir: %s", err)
+		}
+	}
 
 	if libkb.IsIn(string(ComponentNameKBFS), components, false) {
 		var mountDir string

--- a/go/install/install_darwin.go
+++ b/go/install/install_darwin.go
@@ -695,7 +695,7 @@ func Uninstall(context Context, components []string, log Log) keybase1.Uninstall
 		err = libnativeinstaller.UninstallRedirector(context.GetRunMode(), log)
 		componentResults = append(componentResults, componentResult(string(ComponentNameRedirector), err))
 		if err != nil {
-			log.Errorf("Error uninstalling mount dir: %s", err)
+			log.Errorf("Error stopping the redirector: %s", err)
 		}
 	}
 

--- a/go/install/libnativeinstaller/app.go
+++ b/go/install/libnativeinstaller/app.go
@@ -89,6 +89,17 @@ func UninstallMountDir(runMode libkb.RunMode, log Log) error {
 	return execNativeInstallerWithArg([]string{"--uninstall-mountdir"}, runMode, log)
 }
 
+// InstallRedirector calls the installer with --install-redirector.
+func InstallRedirector(runMode libkb.RunMode, log Log) error {
+	log.Info("Starting redirector")
+	return execNativeInstallerWithArg([]string{"--install-redirector"}, runMode, log)
+}
+
+// UninstallRedirector calls the installer with --uninstall-redirector.
+func UninstallRedirector(runMode libkb.RunMode, log Log) error {
+	return execNativeInstallerWithArg([]string{"--uninstall-redirector"}, runMode, log)
+}
+
 // InstallFuse calls the installer with --install-fuse.
 func InstallFuse(runMode libkb.RunMode, log Log) error {
 	log.Info("Installing KBFuse")

--- a/go/service/install.go
+++ b/go/service/install.go
@@ -42,7 +42,12 @@ func (h *InstallHandler) InstallKBFS(context.Context) (keybase1.InstallResult, e
 }
 
 func (h *InstallHandler) UninstallKBFS(context.Context) (keybase1.UninstallResult, error) {
-	components := []string{"kbfs", "mountdir", "fuse"}
+	// If we're uninstalling the FUSE kext, we need to uninstall the
+	// redirector first because it uses that module. That means one
+	// user's uninstall request will affect the other users on the
+	// same machine -- but that was true anyway when uninstalling the
+	// kext if the other users didn't have KBFS actively mounted.
+	components := []string{"redirector", "kbfs", "mountdir", "fuse"}
 	result := install.Uninstall(h.G(), components, h.G().Log)
 	return result, nil
 }

--- a/go/service/install.go
+++ b/go/service/install.go
@@ -36,7 +36,7 @@ func (h *InstallHandler) InstallFuse(context.Context) (keybase1.InstallResult, e
 }
 
 func (h *InstallHandler) InstallKBFS(context.Context) (keybase1.InstallResult, error) {
-	components := []string{"mountdir", "kbfs"}
+	components := []string{"mountdir", "kbfs", "redirector"}
 	result := install.Install(h.G(), "", "", components, false, 120, h.G().Log)
 	return result, nil
 }


### PR DESCRIPTION
The redirector is installed as part of "--install-auto" and when KBFS is installed.  It's uninstalled only when the user explicitly uninstalls the FUSE kext.

With this PR, the redirector will start automatically after install/upgrade/restart.

Issue: KBFS-2786