### PR TITLE
Change chain.go to use LinkRules

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -1409,9 +1409,13 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		return res, nil
 	case libkb.LinkTypeInvite:
 		err = enforce(LinkRules{
-			Admin:               TristateOptional,
-			Invites:             TristateRequire,
-			CompletedInvites:    TristateOptional, // @@@ UHOH! This was not banned, but is not processed.
+			Admin:   TristateOptional,
+			Invites: TristateRequire,
+			// TODO: CompletedInvites was historically optional but it is also not processed.
+			// We should ban or process it. In order to do this without breaking any teams
+			// we should make sure that no teams have CompletedInvites in an Invite link before
+			// making a change.
+			CompletedInvites:    TristateOptional,
 			AllowInImplicitTeam: true,
 		})
 		if err != nil {

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -142,13 +142,11 @@ func (s *SCTeamMember) MarshalJSON() (b []byte, err error) {
 // -------------------------
 
 type SCChainLink struct {
-	Seqno keybase1.Seqno `json:"seqno"`
-	Sig   string         `json:"sig"`
-	// string containing json of a SCChainLinkPayload.
-	Payload string `json:"payload_json"`
-	// uid of the signer
-	UID     keybase1.UID `json:"uid"`
-	Version int          `json:"version"`
+	Seqno   keybase1.Seqno `json:"seqno"`
+	Sig     string         `json:"sig"`
+	Payload string         `json:"payload_json"` // String containing json of a SCChainLinkPayload
+	UID     keybase1.UID   `json:"uid"`          // UID of the signer
+	Version int            `json:"version"`
 }
 
 func (link *SCChainLink) UnmarshalPayload() (res SCChainLinkPayload, err error) {


### PR DESCRIPTION
Change how the rules for which sections are allowed in which team link types is expressed in `chain.go`. This is meant to be a translation expressing exactly the same rules. The `LinkRules` strategy is nice because it's less code and stricter. So when adding a new link type or changing stuff you're likely to accidentally be too strict rather than too loose.

If this will conflict with any of your PRs please let me know. I'd rather wait and rebase this because it's relatively easy to rebase than cause more work for you on the hard PRs.

- [ ] Make a ticket for the TODO