### PR TITLE
Only use the payload from the sig for v1 trusted links 

### DIFF
--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -621,7 +621,7 @@ func (c *ChainLink) Unpack(trusted bool, selfUID keybase1.UID, packed []byte) er
 	}
 
 	var payload []byte
-	if trusted {
+	if trusted && tmp.sigVersion == 1 {
 		// use payload from sig
 		payload, err = tmp.Payload()
 		if err != nil {


### PR DESCRIPTION
trusted means it came from leveldb local storage.

For v2 links, that tmp.Payload() call fails to get the payload because it hasn't been unpacked yet, so just don't use it.

Thanks to @zapu for reporting the bug.

cc @joshblum who also noticed it.