### PR TITLE
Do not log Errors in pgp pull on deleted users

### DIFF
--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -216,9 +216,15 @@ func (e *PGPPullEngine) runLoggedIn(ctx *Context, summaries []keybase1.UserSumma
 		}
 
 		// Get user data from the server.
-		user, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(e.G(), userSummary.Username))
+		user, err := libkb.LoadUser(
+			libkb.NewLoadUserByNameArg(e.G(), userSummary.Username).
+				WithPublicKeyOptional())
 		if err != nil {
 			ctx.LogUI.Errorf("Failed to load user %s: %s", userSummary.Username, err)
+			continue
+		}
+		if user.GetStatus() == keybase1.StatusCode_SCDeleted {
+			e.G().Log.Debug("User %q is deleted, skipping", userSummary.Username)
 			continue
 		}
 


### PR DESCRIPTION
There are two functions: `runLoggedIn` and `processUserWhenLoggedOut`. `runLoggedIn` goes through all followees, this PR changes it so it eats up problems with deleted users and logs it with Debug instead of Error. Note that while it would spit errors, it would still continue with other users, so this is purely cosmetic issue.

I left `processUserWhenLoggedOut` as is because it requires passing usernames in command line, so it would be nice to know that it failed because requested user is deleted.

@oconnor663 blast from the past? :)

Fixes https://github.com/keybase/client/issues/10557