### PR TITLE
osx: remove git-remote-keybase when uninstalling CLI tools

### DIFF
--- a/go/install/install.go
+++ b/go/install/install.go
@@ -212,12 +212,7 @@ func defaultLinkPath() (string, error) {
 	return linkPath, nil
 }
 
-func uninstallCommandLine(log Log) error {
-	linkPath, err := defaultLinkPath()
-	if err != nil {
-		return nil
-	}
-
+func uninstallLink(linkPath string, log Log) error {
 	log.Debug("Link path: %s", linkPath)
 	fi, err := os.Lstat(linkPath)
 	if os.IsNotExist(err) {
@@ -230,6 +225,23 @@ func uninstallCommandLine(log Log) error {
 	}
 	log.Info("Removing %s", linkPath)
 	return os.Remove(linkPath)
+}
+
+func uninstallCommandLine(log Log) error {
+	linkPath, err := defaultLinkPath()
+	if err != nil {
+		return nil
+	}
+
+	err = uninstallLink(linkPath, log)
+	if err != nil {
+		return err
+	}
+
+	// Now the git binary.
+	gitBinFilename := "git-remote-keybase"
+	gitLinkPath := filepath.Join(filepath.Dir(linkPath), gitBinFilename)
+	return uninstallLink(gitLinkPath, log)
 }
 
 func chooseBinPath(bp string) (string, error) {

--- a/osx/KBKit/KBKit/Component/KBCommandLine.m
+++ b/osx/KBKit/KBKit/Component/KBCommandLine.m
@@ -34,19 +34,21 @@
     return;
   }
 
-
   NSDictionary *params = @{@"directory": self.servicePath, @"name": self.config.serviceBinName, @"appName": self.config.appName};
   DDLogDebug(@"Helper: addToPath(%@)", params);
   [self.helperTool.helper sendRequest:@"addToPath" params:@[params] completion:^(NSError *error, id value) {
     DDLogDebug(@"Result: %@", value);
-    completion(error);
-  }];
+    if (error) {
+      completion(error);
+      return;
+    }
 
-  NSDictionary *gitParams = @{@"directory": self.servicePath, @"name": self.config.gitRemoteHelperName, @"appName": self.config.appName};
-  DDLogDebug(@"Helper: addToPath(%@)", gitParams);
-  [self.helperTool.helper sendRequest:@"addToPath" params:@[gitParams] completion:^(NSError *error, id value) {
-    DDLogDebug(@"Result: %@", value);
-    completion(error);
+    NSDictionary *gitParams = @{@"directory": self.servicePath, @"name": self.config.gitRemoteHelperName, @"appName": self.config.appName};
+    DDLogDebug(@"Helper: addToPath(%@)", gitParams);
+    [self.helperTool.helper sendRequest:@"addToPath" params:@[gitParams] completion:^(NSError *error, id value) {
+      DDLogDebug(@"Result: %@", value);
+      completion(error);
+    }];
   }];
 }
 
@@ -55,7 +57,17 @@
   DDLogDebug(@"Helper: removeFromPath(%@)", params);
   [self.helperTool.helper sendRequest:@"removeFromPath" params:@[params] completion:^(NSError *error, id value) {
     DDLogDebug(@"Result: %@", value);
-    completion(error);
+    if (error) {
+      completion(error);
+      return;
+    }
+
+    NSDictionary *gitParams = @{@"directory": self.servicePath, @"name": self.config.gitRemoteHelperName, @"appName": self.config.appName};
+    DDLogDebug(@"Helper: removeFromPath(%@)", gitParams);
+    [self.helperTool.helper sendRequest:@"removeFromPath" params:@[gitParams] completion:^(NSError *error, id value) {
+      DDLogDebug(@"Result: %@", value);
+      completion(error);
+    }];
   }];
 }
 


### PR DESCRIPTION
Currently it just removes /usr/local/bin/keybase, but it should remove the link to the git binary as well.

@songgao your comment prompted me to fix the fact that the link to `git-remote-keybase` is not properly removed from `/usr/local/bin`, but for the root redirector work I'm not actually going to make a link to the binary because I don't think regular users should have to ever run it themselves, so it won't need to be uninstalled.