### PR TITLE
NOMERGE - ignore v2 links fix

### DIFF
--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -621,7 +621,7 @@ func (c *ChainLink) Unpack(trusted bool, selfUID keybase1.UID, packed []byte) er
 	}
 
 	var payload []byte
-	if trusted {
+	if trusted && tmp.sigVersion == 1 {
 		// use payload from sig
 		payload, err = tmp.Payload()
 		if err != nil {

--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -93,7 +93,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 23
         versionCode timestamp()
-        versionName "1.0.13"
+        versionName "1.0.14"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.13</string>
+	<string>1.0.14</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
@keybase/react-hackers this is the branch for the 1.0.14 hotfix