### PR TITLE
allow kbfs commits to pass through correctly

### DIFF
--- a/packaging/android/build_and_publish.sh
+++ b/packaging/android/build_and_publish.sh
@@ -42,7 +42,7 @@ trap reset EXIT
 
 if [ -n "$kbfs_commit" ]; then
   cd "$kbfs_dir"
-  echo "Checking out $kbfs_commit on client (will reset to $kbfs_branch)"
+  echo "Checking out $kbfs_commit on kbfs (will reset to $kbfs_branch)"
   git checkout "$kbfs_commit"
   # tell gobuild.sh to use our local commit
   export LOCAL_KBFS=1

--- a/packaging/android/build_and_publish.sh
+++ b/packaging/android/build_and_publish.sh
@@ -4,6 +4,7 @@ set -eE -u -o pipefail # Fail on error, call ERR trap
 
 automated_build=${AUTOMATED_BUILD:-}
 gopath=${GOPATH:-}
+kbfs_dir="$gopath/src/github.com/keybase/kbfs"
 client_dir="$gopath/src/github.com/keybase/client"
 shared_dir="$gopath/src/github.com/keybase/client/shared"
 rn_dir="$gopath/src/github.com/keybase/client/shared/react-native"
@@ -11,6 +12,7 @@ android_dir="$gopath/src/github.com/keybase/client/shared/react-native/android"
 cache_npm=${CACHE_NPM:-}
 cache_go_lib=${CACHE_GO_LIB:-}
 client_commit=${CLIENT_COMMIT:-}
+kbfs_commit=${KBFS_COMMIT:-}
 check_ci=${CHECK_CI:-1}
 
 # Notify Slack on failure
@@ -24,9 +26,11 @@ trap notify_slack ERR
 "$client_dir/packaging/check_status_and_pull.sh" "$client_dir"
 
 # Reset on exit
+kbfs_branch=`cd "$kbfs_dir" && git rev-parse --abbrev-ref HEAD`
 client_branch=`cd "$client_dir" && git rev-parse --abbrev-ref HEAD`
 rn_packager_pid=""
 function reset {
+  (cd "$kbfs_dir" && git checkout $kbfs_branch)
   (cd "$client_dir" && git checkout $client_branch)
 
   if [ ! "$rn_packager_pid" = "" ]; then
@@ -35,6 +39,14 @@ function reset {
   fi
 }
 trap reset EXIT
+
+if [ -n "$kbfs_commit" ]; then
+  cd "$client_dir"
+  echo "Checking out $kbfs_commit on client (will reset to $kbfs_branch)"
+  git checkout "$kbfs_commit"
+  # tell gobuild.sh to use our local commit
+  export LOCAL_KBFS=1
+fi
 
 if [ -n "$client_commit" ]; then
   cd "$client_dir"

--- a/packaging/android/build_and_publish.sh
+++ b/packaging/android/build_and_publish.sh
@@ -41,7 +41,7 @@ function reset {
 trap reset EXIT
 
 if [ -n "$kbfs_commit" ]; then
-  cd "$client_dir"
+  cd "$kbfs_dir"
   echo "Checking out $kbfs_commit on client (will reset to $kbfs_branch)"
   git checkout "$kbfs_commit"
   # tell gobuild.sh to use our local commit

--- a/packaging/android/build_and_publish.sh
+++ b/packaging/android/build_and_publish.sh
@@ -44,7 +44,7 @@ if [ -n "$kbfs_commit" ]; then
   cd "$kbfs_dir"
   echo "Checking out $kbfs_commit on kbfs (will reset to $kbfs_branch)"
   git checkout "$kbfs_commit"
-  # tell gobuild.sh to use our local commit
+  # tell gobuild.sh (called via "yarn run rn-gobuild-android" below) to use our local commit
   export LOCAL_KBFS=1
 fi
 

--- a/packaging/check_status_and_pull.sh
+++ b/packaging/check_status_and_pull.sh
@@ -29,7 +29,7 @@ if [ ! -d ".git" ] ; then
   exit 1
 fi
 
-current_branch="$(git symbolic-ref --short HEAD)"
+current_branch="$(git git rev-parse --abbrev-ref HEAD)"
 if [ "$current_branch" != "master" ] ; then
   echo "Repo '$repo' doesn't have master checked out."
   exit 1

--- a/packaging/ios/build_and_publish.sh
+++ b/packaging/ios/build_and_publish.sh
@@ -23,8 +23,6 @@ function notify_slack {
 }
 trap notify_slack ERR
 
-"$client_dir/packaging/check_status_and_pull.sh" "$client_dir"
-
 # Reset on exit
 kbfs_branch=`cd "$kbfs_dir" && git rev-parse --abbrev-ref HEAD`
 client_branch=`cd "$client_dir" && git rev-parse --abbrev-ref HEAD`
@@ -42,7 +40,7 @@ function reset {
 trap reset EXIT
 
 if [ -n "$kbfs_commit" ]; then
-  cd "$client_dir"
+  cd "$kbfs_dir"
   echo "Checking out $kbfs_commit on client (will reset to $kbfs_branch)"
   git checkout "$kbfs_commit"
   # tell gobuild.sh to use our local commit
@@ -53,6 +51,8 @@ if [ -n "$client_commit" ]; then
   cd "$client_dir"
   echo "Checking out $client_commit on client (will reset to $client_branch)"
   git checkout "$client_commit"
+else
+  "$client_dir/packaging/check_status_and_pull.sh" "$client_dir"
 fi
 
 cd "$shared_dir"

--- a/packaging/ios/build_and_publish.sh
+++ b/packaging/ios/build_and_publish.sh
@@ -4,6 +4,7 @@ set -eE -u -o pipefail # Fail on error, call ERR trap
 
 automated_build=${AUTOMATED_BUILD:-}
 gopath=${GOPATH:-}
+kbfs_dir="$gopath/src/github.com/keybase/kbfs"
 client_dir="$gopath/src/github.com/keybase/client"
 shared_dir="$gopath/src/github.com/keybase/client/shared"
 rn_dir="$gopath/src/github.com/keybase/client/shared/react-native"
@@ -11,6 +12,7 @@ ios_dir="$gopath/src/github.com/keybase/client/shared/react-native/ios"
 cache_npm=${CACHE_NPM:-}
 cache_go_lib=${CACHE_GO_LIB:-}
 client_commit=${CLIENT_COMMIT:-}
+kbfs_commit=${KBFS_COMMIT:-}
 check_ci=${CHECK_CI:-1}
 
 # Notify Slack on failure
@@ -24,9 +26,11 @@ trap notify_slack ERR
 "$client_dir/packaging/check_status_and_pull.sh" "$client_dir"
 
 # Reset on exit
+kbfs_branch=`cd "$kbfs_dir" && git rev-parse --abbrev-ref HEAD`
 client_branch=`cd "$client_dir" && git rev-parse --abbrev-ref HEAD`
 rn_packager_pid=""
 function reset {
+  (cd "$kbfs_dir" && git checkout $kbfs_branch)
   (cd "$client_dir" && git checkout $client_branch)
   (cd "$client_dir" && git checkout shared/react-native/ios/)
 
@@ -36,6 +40,14 @@ function reset {
   fi
 }
 trap reset EXIT
+
+if [ -n "$kbfs_commit" ]; then
+  cd "$client_dir"
+  echo "Checking out $kbfs_commit on client (will reset to $kbfs_branch)"
+  git checkout "$kbfs_commit"
+  # tell gobuild.sh to use our local commit
+  export LOCAL_KBFS=1
+fi
 
 if [ -n "$client_commit" ]; then
   cd "$client_dir"

--- a/packaging/ios/build_and_publish.sh
+++ b/packaging/ios/build_and_publish.sh
@@ -41,7 +41,7 @@ trap reset EXIT
 
 if [ -n "$kbfs_commit" ]; then
   cd "$kbfs_dir"
-  echo "Checking out $kbfs_commit on client (will reset to $kbfs_branch)"
+  echo "Checking out $kbfs_commit on kbfs (will reset to $kbfs_branch)"
   git checkout "$kbfs_commit"
   # tell gobuild.sh to use our local commit
   export LOCAL_KBFS=1

--- a/packaging/ios/build_and_publish.sh
+++ b/packaging/ios/build_and_publish.sh
@@ -43,7 +43,7 @@ if [ -n "$kbfs_commit" ]; then
   cd "$kbfs_dir"
   echo "Checking out $kbfs_commit on kbfs (will reset to $kbfs_branch)"
   git checkout "$kbfs_commit"
-  # tell gobuild.sh to use our local commit
+  # tell gobuild.sh (called via "yarn run rn-gobuild-ios" below) to use our local commit
   export LOCAL_KBFS=1
 fi
 


### PR DESCRIPTION
@keybase/react-hackers this should (hopefully) allow slackbot --kbfs-commit= to work. i think before it'd be plumbed through but then when it runs rn-gobuild-ios it'd still have KBFS_LOCAL undefined so it wouldn't use the local checkout