### PR TITLE
Mitigate race in GetTeamAndMemberShowcase

### DIFF
--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -154,6 +154,7 @@ const (
 	StatusCode_SCTeamKeyMaskNotFound       StatusCode = 2697
 	StatusCode_SCTeamBanned                StatusCode = 2702
 	StatusCode_SCTeamInvalidBan            StatusCode = 2703
+	StatusCode_SCTeamShowcasePermDenied    StatusCode = 2711
 	StatusCode_SCTeamProvisionalCanKey     StatusCode = 2721
 	StatusCode_SCTeamProvisionalCannotKey  StatusCode = 2722
 )
@@ -305,6 +306,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamKeyMaskNotFound":       2697,
 	"SCTeamBanned":                2702,
 	"SCTeamInvalidBan":            2703,
+	"SCTeamShowcasePermDenied":    2711,
 	"SCTeamProvisionalCanKey":     2721,
 	"SCTeamProvisionalCannotKey":  2722,
 }
@@ -454,6 +456,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2697: "SCTeamKeyMaskNotFound",
 	2702: "SCTeamBanned",
 	2703: "SCTeamInvalidBan",
+	2711: "SCTeamShowcasePermDenied",
 	2721: "SCTeamProvisionalCanKey",
 	2722: "SCTeamProvisionalCannotKey",
 }

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -146,6 +146,7 @@ protocol constants {
     SCTeamKeyMaskNotFound_2697,
     SCTeamBanned_2702,
     SCTeamInvalidBan_2703,
+    SCTeamShowcasePermDenied_2711,
     SCTeamProvisionalCanKey_2721,
     SCTeamProvisionalCannotKey_2722
   }

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -516,6 +516,7 @@ export const constantsStatusCode = {
   scteamkeymasknotfound: 2697,
   scteambanned: 2702,
   scteaminvalidban: 2703,
+  scteamshowcasepermdenied: 2711,
   scteamprovisionalcankey: 2721,
   scteamprovisionalcannotkey: 2722,
 }
@@ -3496,6 +3497,7 @@ export type StatusCode =
   | 2697 // SCTeamKeyMaskNotFound_2697
   | 2702 // SCTeamBanned_2702
   | 2703 // SCTeamInvalidBan_2703
+  | 2711 // SCTeamShowcasePermDenied_2711
   | 2721 // SCTeamProvisionalCanKey_2721
   | 2722 // SCTeamProvisionalCannotKey_2722
 

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -150,6 +150,7 @@
         "SCTeamKeyMaskNotFound_2697",
         "SCTeamBanned_2702",
         "SCTeamInvalidBan_2703",
+        "SCTeamShowcasePermDenied_2711",
         "SCTeamProvisionalCanKey_2721",
         "SCTeamProvisionalCannotKey_2722"
       ]

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -516,6 +516,7 @@ export const constantsStatusCode = {
   scteamkeymasknotfound: 2697,
   scteambanned: 2702,
   scteaminvalidban: 2703,
+  scteamshowcasepermdenied: 2711,
   scteamprovisionalcankey: 2721,
   scteamprovisionalcannotkey: 2722,
 }
@@ -3496,6 +3497,7 @@ export type StatusCode =
   | 2697 // SCTeamKeyMaskNotFound_2697
   | 2702 // SCTeamBanned_2702
   | 2703 // SCTeamInvalidBan_2703
+  | 2711 // SCTeamShowcasePermDenied_2711
   | 2721 // SCTeamProvisionalCanKey_2721
   | 2722 // SCTeamProvisionalCannotKey_2722
 


### PR DESCRIPTION
Turns out I was only half-right on this bug. It is a race due to joining and leaving the team in quick succession, but the race is within one function on core side.