### PR TITLE
Optimize createSubteam + add a test for chat

### DIFF
--- a/go/client/cmd_team_create.go
+++ b/go/client/cmd_team_create.go
@@ -15,7 +15,7 @@ type CmdTeamCreate struct {
 	TeamName  keybase1.TeamName
 	SessionID int
 	libkb.Contextified
-	joinSubteam bool
+	JoinSubteam bool
 }
 
 func (v *CmdTeamCreate) ParseArgv(ctx *cli.Context) error {
@@ -25,7 +25,7 @@ func (v *CmdTeamCreate) ParseArgv(ctx *cli.Context) error {
 		return err
 	}
 
-	v.joinSubteam = ctx.Bool("join-subteam")
+	v.JoinSubteam = ctx.Bool("join-subteam")
 
 	return nil
 }
@@ -41,7 +41,7 @@ func (v *CmdTeamCreate) Run() (err error) {
 	createRes, err := cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{
 		Name:        v.TeamName.String(),
 		SessionID:   v.SessionID,
-		JoinSubteam: v.joinSubteam,
+		JoinSubteam: v.JoinSubteam,
 	})
 	if err != nil {
 		return err

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -76,21 +76,16 @@ func (h *TeamsHandler) TeamCreateWithSettings(ctx context.Context, arg keybase1.
 		if err != nil {
 			return res, err
 		}
-		teamID, err := teams.CreateSubteam(ctx, h.G().ExternalG(), string(teamName.LastPart()), parentName)
+		teamID, err := teams.CreateSubteam(ctx, h.G().ExternalG(), string(teamName.LastPart()),
+			parentName, true /* addSelf */)
 		if err != nil {
 			return res, err
 		}
 		res.TeamID = *teamID
 
 		// join the team to send the Create message
-		h.G().Log.CDebugf(ctx, "TeamCreate: joining just-created subteam %s temporarily to set it up", arg.Name)
+		h.G().Log.CDebugf(ctx, "TeamCreate: created subteam %s with self in it temporarily to set it up", arg.Name)
 		username := h.G().Env.GetUsername().String()
-		_, err = teams.AddMember(ctx, h.G().ExternalG(), teamName.String(), username, keybase1.TeamRole_ADMIN)
-		if err != nil {
-			h.G().Log.CDebugf(ctx, "TeamCreate: error adding self to new subteam %s: %s", arg.Name, err)
-			return res, err
-		}
-		res.CreatorAdded = true
 		res.ChatSent = teams.SendTeamChatCreateMessage(ctx, h.G().ExternalG(), teamName.String(), username)
 
 		if !arg.JoinSubteam {

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -2,6 +2,7 @@ package systests
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	engine "github.com/keybase/client/go/engine"
 	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
+	chat1 "github.com/keybase/client/go/protocol/chat1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	service "github.com/keybase/client/go/service"
 	teams "github.com/keybase/client/go/teams"
@@ -648,6 +650,66 @@ func (u *smuUser) requestAccess(team smuTeam) {
 	_, err := cli.TeamRequestAccess(context.Background(), keybase1.TeamRequestAccessArg{
 		Name: team.name,
 	})
+	if err != nil {
+		u.ctx.t.Fatal(err)
+	}
+}
+
+func (u *smuUser) readChatsWithError(team smuTeam) (messages []chat1.MessageUnboxed, err error) {
+	return u.readChatsWithErrorAndDevice(team, u.primaryDevice(), 0)
+}
+
+func (u *smuUser) readChatsWithErrorAndDevice(team smuTeam, dev *smuDeviceWrapper, nMessages int) (messages []chat1.MessageUnboxed, err error) {
+	tctx := dev.popClone()
+
+	wait := time.Second
+	var totalWait time.Duration
+	for i := 0; i < 10; i++ {
+		runner := client.NewCmdChatReadRunner(tctx.G)
+		runner.SetTeamChatForTest(team.name)
+		_, messages, err = runner.Fetch()
+
+		if err == nil && len(messages) == nMessages {
+			if i != 0 {
+				u.ctx.t.Logf("readChatsWithErrorAndDevice success after retrying %d times, polling for %s", i, totalWait)
+			}
+			return messages, nil
+		}
+
+		if err != nil {
+			u.ctx.t.Logf("readChatsWithErrorAndDevice failure: %s", err.Error())
+		}
+
+		u.ctx.t.Logf("readChatsWithErrorAndDevice trying again")
+		time.Sleep(wait)
+		totalWait += wait
+	}
+
+	u.ctx.t.Logf("Failed to readChatsWithErrorAndDevice after polling for %s", totalWait)
+	return messages, err
+}
+
+func (u *smuUser) readChats(team smuTeam, nMessages int) {
+	u.readChatsWithDevice(team, u.primaryDevice(), nMessages)
+}
+
+func (u *smuUser) readChatsWithDevice(team smuTeam, dev *smuDeviceWrapper, nMessages int) {
+	messages, err := u.readChatsWithErrorAndDevice(team, dev, nMessages)
+	t := u.ctx.t
+	require.NoError(t, err)
+	require.Equal(t, nMessages, len(messages))
+	for i, msg := range messages {
+		require.Equal(t, msg.Valid().MessageBody.Text().Body, fmt.Sprintf("%d", len(messages)-i-1))
+	}
+	divDebug(u.ctx, "readChat success for %s", u.username)
+}
+
+func (u *smuUser) sendChat(t smuTeam, msg string) {
+	tctx := u.primaryDevice().popClone()
+	runner := client.NewCmdChatSendRunner(tctx.G)
+	runner.SetTeamChatForTest(t.name)
+	runner.SetMessage(msg)
+	err := runner.Run()
 	if err != nil {
 		u.ctx.t.Fatal(err)
 	}

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -486,9 +486,7 @@ func (u *smuUser) addTeamMember(team smuTeam, member *smuUser, role keybase1.Tea
 		Username: member.username,
 		Role:     role,
 	})
-	if err != nil {
-		u.ctx.t.Fatal(err)
-	}
+	require.NoError(u.ctx.t, err)
 }
 
 func (u *smuUser) addWriter(team smuTeam, w *smuUser) {
@@ -697,11 +695,19 @@ func (u *smuUser) readChatsWithDevice(team smuTeam, dev *smuDeviceWrapper, nMess
 	messages, err := u.readChatsWithErrorAndDevice(team, dev, nMessages)
 	t := u.ctx.t
 	require.NoError(t, err)
-	require.Equal(t, nMessages, len(messages))
+	require.Len(t, messages, nMessages)
 	for i, msg := range messages {
 		require.Equal(t, msg.Valid().MessageBody.Text().Body, fmt.Sprintf("%d", len(messages)-i-1))
 	}
 	divDebug(u.ctx, "readChat success for %s", u.username)
+}
+
+func (u *smuUser) readLastChat(team smuTeam) string {
+	messages, err := u.readChatsWithErrorAndDevice(team, u.primaryDevice(), 1)
+	t := u.ctx.t
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	return messages[0].Valid().MessageBody.Text().Body
 }
 
 func (u *smuUser) sendChat(t smuTeam, msg string) {

--- a/go/systests/team_create_test.go
+++ b/go/systests/team_create_test.go
@@ -1,0 +1,45 @@
+package systests
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubteamChats(t *testing.T) {
+	ctx := newSMUContext(t)
+	defer ctx.cleanup()
+
+	ann := ctx.installKeybaseForUser("ann", 3)
+	ann.signup()
+	t.Logf("Signed up ann (%s, %s)", ann.username, ann.uid())
+	bob := ctx.installKeybaseForUser("bob", 5)
+	bob.signup()
+	t.Logf("Signed up bob (%s, %s)", bob.username, bob.uid())
+
+	team := ann.createTeam([]*smuUser{})
+	t.Logf("Team created %q", team.name)
+
+	subteamName := team.name + ".subt"
+	cli := ann.getTeamsClient()
+	_, err := cli.TeamCreate(context.Background(), keybase1.TeamCreateArg{Name: subteamName})
+	require.NoError(t, err)
+
+	t.Logf("Subteam created %q", subteamName)
+
+	subteam := smuTeam{name: subteamName}
+	ann.addTeamMember(subteam, bob, keybase1.TeamRole_READER)
+
+	// Can we chat after being added to subteam as sole reader? If
+	// chats are not initialized in the subteam, sendChat will fail
+	// with: "error creating conversation: error from chat server:
+	// team readers are unable to create conversations". It's rather
+	// imperfect test, ideally we would be checking if there is any
+	// existing chat channel in the subteam instead of trying to send
+	// chat messages.
+	bob.sendChat(subteam, "0")
+	bob.readChats(subteam, 1)
+}

--- a/go/systests/team_list_test.go
+++ b/go/systests/team_list_test.go
@@ -271,7 +271,7 @@ func TestTeamTree(t *testing.T) {
 	}
 
 	createSubteam := func(parentName, subteamName string) string {
-		subteam, err := teams.CreateSubteam(context.Background(), ann.tc.G, subteamName, TeamNameFromString(parentName), false /* addSelf */)
+		subteam, err := teams.CreateSubteam(context.Background(), ann.tc.G, subteamName, TeamNameFromString(parentName), keybase1.TeamRole_NONE /* addSelfAs */)
 		require.NoError(t, err)
 		subteamObj, err := teams.Load(context.Background(), ann.tc.G, keybase1.LoadTeamArg{ID: *subteam})
 		require.NoError(t, err)

--- a/go/systests/team_list_test.go
+++ b/go/systests/team_list_test.go
@@ -271,7 +271,7 @@ func TestTeamTree(t *testing.T) {
 	}
 
 	createSubteam := func(parentName, subteamName string) string {
-		subteam, err := teams.CreateSubteam(context.Background(), ann.tc.G, subteamName, TeamNameFromString(parentName))
+		subteam, err := teams.CreateSubteam(context.Background(), ann.tc.G, subteamName, TeamNameFromString(parentName), false /* addSelf */)
 		require.NoError(t, err)
 		subteamObj, err := teams.Load(context.Background(), ann.tc.G, keybase1.LoadTeamArg{ID: *subteam})
 		require.NoError(t, err)

--- a/go/systests/team_open_test.go
+++ b/go/systests/team_open_test.go
@@ -103,7 +103,7 @@ func TestOpenSubteamAdd(t *testing.T) {
 	parentName, err := keybase1.TeamNameFromString(team)
 	require.NoError(t, err)
 
-	subteam, err := teams.CreateSubteam(context.TODO(), own.tc.G, "zzz", parentName, false /* addSelf */)
+	subteam, err := teams.CreateSubteam(context.TODO(), own.tc.G, "zzz", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("Open team name is %q, subteam is %q", team, subteam)

--- a/go/systests/team_open_test.go
+++ b/go/systests/team_open_test.go
@@ -103,7 +103,7 @@ func TestOpenSubteamAdd(t *testing.T) {
 	parentName, err := keybase1.TeamNameFromString(team)
 	require.NoError(t, err)
 
-	subteam, err := teams.CreateSubteam(context.TODO(), own.tc.G, "zzz", parentName)
+	subteam, err := teams.CreateSubteam(context.TODO(), own.tc.G, "zzz", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("Open team name is %q, subteam is %q", team, subteam)

--- a/go/systests/team_seitan_invite_v2_test.go
+++ b/go/systests/team_seitan_invite_v2_test.go
@@ -36,7 +36,7 @@ func testTeamInviteSeitanHappy(t *testing.T, implicitAdmin bool, seitanVersion t
 	teamName := teamNameParent
 	t.Logf("Created team %v %v", teamIDParent, teamNameParent)
 	if implicitAdmin {
-		subteamID, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "sub1", teamNameParent, false /* addSelf */)
+		subteamID, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "sub1", teamNameParent, keybase1.TeamRole_NONE /* addSelfAs */)
 		require.NoError(t, err)
 		teamID = *subteamID
 		subteamName, err := teamNameParent.Append("sub1")

--- a/go/systests/team_seitan_invite_v2_test.go
+++ b/go/systests/team_seitan_invite_v2_test.go
@@ -36,7 +36,7 @@ func testTeamInviteSeitanHappy(t *testing.T, implicitAdmin bool, seitanVersion t
 	teamName := teamNameParent
 	t.Logf("Created team %v %v", teamIDParent, teamNameParent)
 	if implicitAdmin {
-		subteamID, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "sub1", teamNameParent)
+		subteamID, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "sub1", teamNameParent, false /* addSelf */)
 		require.NoError(t, err)
 		teamID = *subteamID
 		subteamName, err := teamNameParent.Append("sub1")

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -296,9 +296,9 @@ func TestTeamTxSubteamAdmins(t *testing.T) {
 
 	teamName, err := keybase1.TeamNameFromString(team)
 	require.NoError(t, err)
-	_, err = teams.CreateSubteam(context.Background(), ann.tc.G, "golfers", teamName, false /* addSelf */)
+	_, err = teams.CreateSubteam(context.Background(), ann.tc.G, "golfers", teamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
-	_, err = teams.CreateSubteam(context.Background(), ann.tc.G, "pokerpals", teamName, false /* addSelf */)
+	_, err = teams.CreateSubteam(context.Background(), ann.tc.G, "pokerpals", teamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	teamObj := ann.loadTeam(team, true /* admin */)

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -296,9 +296,9 @@ func TestTeamTxSubteamAdmins(t *testing.T) {
 
 	teamName, err := keybase1.TeamNameFromString(team)
 	require.NoError(t, err)
-	_, err = teams.CreateSubteam(context.Background(), ann.tc.G, "golfers", teamName)
+	_, err = teams.CreateSubteam(context.Background(), ann.tc.G, "golfers", teamName, false /* addSelf */)
 	require.NoError(t, err)
-	_, err = teams.CreateSubteam(context.Background(), ann.tc.G, "pokerpals", teamName)
+	_, err = teams.CreateSubteam(context.Background(), ann.tc.G, "pokerpals", teamName, false /* addSelf */)
 	require.NoError(t, err)
 
 	teamObj := ann.loadTeam(team, true /* admin */)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -807,14 +807,14 @@ func TestGetTeamRootID(t *testing.T) {
 	parentID := parentName.ToPrivateTeamID()
 
 	t.Logf("create a subteam")
-	subteamID, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "mysubteam", parentName, false /* addSelf */)
+	subteamID, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "mysubteam", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	subteamName, err := parentName.Append("mysubteam")
 	require.NoError(t, err)
 
 	t.Logf("create a sub-subteam")
-	subteamID2, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "teamofsubs", subteamName, false /* addSelf */)
+	subteamID2, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "teamofsubs", subteamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	getAndCompare := func(id keybase1.TeamID) {
@@ -1048,7 +1048,7 @@ func TestTeamCanUserPerform(t *testing.T) {
 	parentName, err := keybase1.TeamNameFromString(team)
 	require.NoError(t, err)
 
-	_, err = teams.CreateSubteam(context.TODO(), ann.tc.G, "mysubteam", parentName, false /* addSelf */)
+	_, err = teams.CreateSubteam(context.TODO(), ann.tc.G, "mysubteam", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	subteam := team + ".mysubteam"
 

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -807,14 +807,14 @@ func TestGetTeamRootID(t *testing.T) {
 	parentID := parentName.ToPrivateTeamID()
 
 	t.Logf("create a subteam")
-	subteamID, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "mysubteam", parentName)
+	subteamID, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "mysubteam", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	subteamName, err := parentName.Append("mysubteam")
 	require.NoError(t, err)
 
 	t.Logf("create a sub-subteam")
-	subteamID2, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "teamofsubs", subteamName)
+	subteamID2, err := teams.CreateSubteam(context.TODO(), tt.users[0].tc.G, "teamofsubs", subteamName, false /* addSelf */)
 	require.NoError(t, err)
 
 	getAndCompare := func(id keybase1.TeamID) {
@@ -1048,7 +1048,7 @@ func TestTeamCanUserPerform(t *testing.T) {
 	parentName, err := keybase1.TeamNameFromString(team)
 	require.NoError(t, err)
 
-	_, err = teams.CreateSubteam(context.TODO(), ann.tc.G, "mysubteam", parentName)
+	_, err = teams.CreateSubteam(context.TODO(), ann.tc.G, "mysubteam", parentName, false /* addSelf */)
 	require.NoError(t, err)
 	subteam := team + ".mysubteam"
 

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -80,7 +80,7 @@ func TestCreateSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	subteamBasename := "mysubteam"
-	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, false /* addSelf */)
+	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	// Fetch the subteam we just created, to make sure it's there.
@@ -100,7 +100,7 @@ func TestCreateSubteam(t *testing.T) {
 	// Test joining with addSelf=true
 
 	subteamBasename = "mysubteam2"
-	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, true /* addSelf */)
+	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, keybase1.TeamRole_ADMIN /* addSelfAs */)
 	require.NoError(t, err)
 
 	subteamFQName, err = parentTeamName.Append(subteamBasename)
@@ -121,7 +121,7 @@ func TestCreateSubSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	subteamBasename := "bbb"
-	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, false /* addSelf */)
+	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	subteamName, err := parentTeamName.Append(subteamBasename)
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func TestCreateSubSubteam(t *testing.T) {
 	assertRole(tc, subteamName.String(), u.Username, keybase1.TeamRole_NONE)
 
 	subsubteamBasename := "ccc"
-	_, err = CreateSubteam(context.TODO(), tc.G, subsubteamBasename, subteamName, false /* addSelf */)
+	_, err = CreateSubteam(context.TODO(), tc.G, subsubteamBasename, subteamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	subsubteamName, err := parentTeamName.Append(subteamBasename)

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -80,7 +80,7 @@ func TestCreateSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	subteamBasename := "mysubteam"
-	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName)
+	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, false /* addSelf */)
 	require.NoError(t, err)
 
 	// Fetch the subteam we just created, to make sure it's there.
@@ -94,8 +94,18 @@ func TestCreateSubteam(t *testing.T) {
 	require.Equal(t, keybase1.Seqno(1), subteam.chain().GetLatestSeqno())
 
 	// creator of subteam should *not* be a member of the subteam, they
-	// need to explicitly join it.
+	// need to explicitly ask to create it with themself in it.
 	assertRole(tc, subteamFQName.String(), u.Username, keybase1.TeamRole_NONE)
+
+	// Test joining with addSelf=true
+
+	subteamBasename = "mysubteam2"
+	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, true /* addSelf */)
+	require.NoError(t, err)
+
+	subteamFQName, err = parentTeamName.Append(subteamBasename)
+	require.NoError(t, err)
+	assertRole(tc, subteamFQName.String(), u.Username, keybase1.TeamRole_ADMIN)
 }
 
 func TestCreateSubSubteam(t *testing.T) {
@@ -111,7 +121,7 @@ func TestCreateSubSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	subteamBasename := "bbb"
-	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName)
+	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, false /* addSelf */)
 	require.NoError(t, err)
 	subteamName, err := parentTeamName.Append(subteamBasename)
 	require.NoError(t, err)
@@ -119,7 +129,7 @@ func TestCreateSubSubteam(t *testing.T) {
 	assertRole(tc, subteamName.String(), u.Username, keybase1.TeamRole_NONE)
 
 	subsubteamBasename := "ccc"
-	_, err = CreateSubteam(context.TODO(), tc.G, subsubteamBasename, subteamName)
+	_, err = CreateSubteam(context.TODO(), tc.G, subsubteamBasename, subteamName, false /* addSelf */)
 	require.NoError(t, err)
 
 	subsubteamName, err := parentTeamName.Append(subteamBasename)

--- a/go/teams/delete_test.go
+++ b/go/teams/delete_test.go
@@ -118,7 +118,7 @@ func TestRecreateSubteam(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = CreateSubteam(context.Background(), tc.G, string(name.LastPart()), parent)
+	_, err = CreateSubteam(context.Background(), tc.G, string(name.LastPart()), parent, false /* addSelf */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestDeleteTwoSubteams(t *testing.T) {
 	subteamName2 := createTeamName(t, parentName.String(), "ccc")
 
 	t.Logf("U0 creates A.B")
-	_, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName)
+	_, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("U0 deletes A.B")
@@ -146,7 +146,7 @@ func TestDeleteTwoSubteams(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U0 creates A.C")
-	_, err = CreateSubteam(context.TODO(), tcs[0].G, "ccc", parentName)
+	_, err = CreateSubteam(context.TODO(), tcs[0].G, "ccc", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("U0 deletes A.C")

--- a/go/teams/delete_test.go
+++ b/go/teams/delete_test.go
@@ -118,7 +118,7 @@ func TestRecreateSubteam(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = CreateSubteam(context.Background(), tc.G, string(name.LastPart()), parent, false /* addSelf */)
+	_, err = CreateSubteam(context.Background(), tc.G, string(name.LastPart()), parent, keybase1.TeamRole_NONE /* addSelfAs */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestDeleteTwoSubteams(t *testing.T) {
 	subteamName2 := createTeamName(t, parentName.String(), "ccc")
 
 	t.Logf("U0 creates A.B")
-	_, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, false /* addSelf */)
+	_, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("U0 deletes A.B")
@@ -146,7 +146,7 @@ func TestDeleteTwoSubteams(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U0 creates A.C")
-	_, err = CreateSubteam(context.TODO(), tcs[0].G, "ccc", parentName, false /* addSelf */)
+	_, err = CreateSubteam(context.TODO(), tcs[0].G, "ccc", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("U0 deletes A.C")

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -125,7 +125,7 @@ func TestTeamDetailsAsImplicitAdmin(t *testing.T) {
 	teamName, _ := createTeam2(*tcs[0])
 
 	t.Logf("creates a subteam")
-	_, err := CreateSubteam(context.Background(), tcs[0].G, "bbb", teamName, false /* addSelf */)
+	_, err := CreateSubteam(context.Background(), tcs[0].G, "bbb", teamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("loads the subteam")
@@ -146,7 +146,7 @@ func TestGetMaybeAdminByStringName(t *testing.T) {
 	teamName, _ := createTeam2(*tcs[0])
 
 	t.Logf("U0 creates a subteam")
-	_, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", teamName, false /* addSelf */)
+	_, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", teamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("U0 adds U1 as a reader")
@@ -223,7 +223,7 @@ func createTeam2(tc libkb.TestContext) (keybase1.TeamName, keybase1.TeamID) {
 func createSubteam(tc *libkb.TestContext, parent keybase1.TeamName, subteamNamePart string) (keybase1.TeamName, keybase1.TeamID) {
 	subteamName, err := parent.Append(subteamNamePart)
 	require.NoError(tc.T, err)
-	subteamID, err := CreateSubteam(context.TODO(), tc.G, subteamNamePart, parent, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tc.G, subteamNamePart, parent, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(tc.T, err)
 	return subteamName, *subteamID
 }

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -125,7 +125,7 @@ func TestTeamDetailsAsImplicitAdmin(t *testing.T) {
 	teamName, _ := createTeam2(*tcs[0])
 
 	t.Logf("creates a subteam")
-	_, err := CreateSubteam(context.Background(), tcs[0].G, "bbb", teamName)
+	_, err := CreateSubteam(context.Background(), tcs[0].G, "bbb", teamName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("loads the subteam")
@@ -146,7 +146,7 @@ func TestGetMaybeAdminByStringName(t *testing.T) {
 	teamName, _ := createTeam2(*tcs[0])
 
 	t.Logf("U0 creates a subteam")
-	_, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", teamName)
+	_, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", teamName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("U0 adds U1 as a reader")
@@ -223,7 +223,7 @@ func createTeam2(tc libkb.TestContext) (keybase1.TeamName, keybase1.TeamID) {
 func createSubteam(tc *libkb.TestContext, parent keybase1.TeamName, subteamNamePart string) (keybase1.TeamName, keybase1.TeamID) {
 	subteamName, err := parent.Append(subteamNamePart)
 	require.NoError(tc.T, err)
-	subteamID, err := CreateSubteam(context.TODO(), tc.G, subteamNamePart, parent)
+	subteamID, err := CreateSubteam(context.TODO(), tc.G, subteamNamePart, parent, false /* addSelf */)
 	require.NoError(tc.T, err)
 	return subteamName, *subteamID
 }

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -296,7 +296,7 @@ func TestLoaderParentEasy(t *testing.T) {
 	teamName, teamID := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", teamName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", teamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("load the parent")
@@ -327,7 +327,7 @@ func TestLoaderSubteamEasy(t *testing.T) {
 	parentName, parentID := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("load the subteam")
@@ -354,7 +354,7 @@ func TestLoaderFillStubbed(t *testing.T) {
 	parentName, parentID := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("add U1 to the parent")
@@ -390,7 +390,7 @@ func TestLoaderNotInParent(t *testing.T) {
 	parentName, _ := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("add U1 to the subteam")
@@ -416,13 +416,13 @@ func TestLoaderMultilevel(t *testing.T) {
 	parentName, _ := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	_, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", parentName, false /* addSelf */)
+	_, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("create a sub-subteam")
 	subTeamName, err := parentName.Append("abc")
 	require.NoError(t, err)
-	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "def", subTeamName, false /* addSelf */)
+	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "def", subTeamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	expectedSubsubTeamName, err := subTeamName.Append("def")
@@ -507,7 +507,7 @@ func TestLoaderGetImplicitAdminsList(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U2 creates a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[2].G, "sub", parentName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[2].G, "sub", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	subteamName, err := parentName.Append("sub")
 	require.NoError(t, err)
@@ -558,7 +558,7 @@ func TestLoaderHiddenSubteam(t *testing.T) {
 	subteamName1 := createTeamName(t, parentName.String(), "bbb")
 
 	t.Logf("U0 creates A.B")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("U0 adds U1 to A as a WRITER")
@@ -752,13 +752,13 @@ func TestInflateAfterPermissionsChange(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 creates fennel_network.lair")
-	subteamLairID, err := CreateSubteam(context.Background(), tcs[1].G, "lair", rootName, false /* addSelf */)
+	subteamLairID, err := CreateSubteam(context.Background(), tcs[1].G, "lair", rootName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	subteamLairName, err := rootName.Append("lair")
 	require.NoError(t, err)
 
 	t.Logf("U1 creates fennel_network.chitchat")
-	subteamChitchatID, err := CreateSubteam(context.Background(), tcs[1].G, "chitchat", rootName, false /* addSelf */)
+	subteamChitchatID, err := CreateSubteam(context.Background(), tcs[1].G, "chitchat", rootName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	subteamChitchatName, err := rootName.Append("chitchat")
 	require.NoError(t, err)
@@ -808,7 +808,7 @@ func TestRotateSubteamByExplicitReader(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U0 creates fennel_network.sub1")
-	subteamID, err := CreateSubteam(context.Background(), tcs[0].G, "sub1", rootName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.Background(), tcs[0].G, "sub1", rootName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	subteamName, err := rootName.Append("sub1")
 	require.NoError(t, err)

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -296,7 +296,7 @@ func TestLoaderParentEasy(t *testing.T) {
 	teamName, teamID := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", teamName)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", teamName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("load the parent")
@@ -327,7 +327,7 @@ func TestLoaderSubteamEasy(t *testing.T) {
 	parentName, parentID := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("load the subteam")
@@ -354,7 +354,7 @@ func TestLoaderFillStubbed(t *testing.T) {
 	parentName, parentID := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("add U1 to the parent")
@@ -390,7 +390,7 @@ func TestLoaderNotInParent(t *testing.T) {
 	parentName, _ := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("add U1 to the subteam")
@@ -416,13 +416,13 @@ func TestLoaderMultilevel(t *testing.T) {
 	parentName, _ := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	_, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", parentName)
+	_, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("create a sub-subteam")
 	subTeamName, err := parentName.Append("abc")
 	require.NoError(t, err)
-	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "def", subTeamName)
+	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "def", subTeamName, false /* addSelf */)
 	require.NoError(t, err)
 
 	expectedSubsubTeamName, err := subTeamName.Append("def")
@@ -507,7 +507,7 @@ func TestLoaderGetImplicitAdminsList(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U2 creates a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[2].G, "sub", parentName)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[2].G, "sub", parentName, false /* addSelf */)
 	require.NoError(t, err)
 	subteamName, err := parentName.Append("sub")
 	require.NoError(t, err)
@@ -558,7 +558,7 @@ func TestLoaderHiddenSubteam(t *testing.T) {
 	subteamName1 := createTeamName(t, parentName.String(), "bbb")
 
 	t.Logf("U0 creates A.B")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("U0 adds U1 to A as a WRITER")
@@ -752,13 +752,13 @@ func TestInflateAfterPermissionsChange(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 creates fennel_network.lair")
-	subteamLairID, err := CreateSubteam(context.Background(), tcs[1].G, "lair", rootName)
+	subteamLairID, err := CreateSubteam(context.Background(), tcs[1].G, "lair", rootName, false /* addSelf */)
 	require.NoError(t, err)
 	subteamLairName, err := rootName.Append("lair")
 	require.NoError(t, err)
 
 	t.Logf("U1 creates fennel_network.chitchat")
-	subteamChitchatID, err := CreateSubteam(context.Background(), tcs[1].G, "chitchat", rootName)
+	subteamChitchatID, err := CreateSubteam(context.Background(), tcs[1].G, "chitchat", rootName, false /* addSelf */)
 	require.NoError(t, err)
 	subteamChitchatName, err := rootName.Append("chitchat")
 	require.NoError(t, err)
@@ -808,7 +808,7 @@ func TestRotateSubteamByExplicitReader(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U0 creates fennel_network.sub1")
-	subteamID, err := CreateSubteam(context.Background(), tcs[0].G, "sub1", rootName)
+	subteamID, err := CreateSubteam(context.Background(), tcs[0].G, "sub1", rootName, false /* addSelf */)
 	require.NoError(t, err)
 	subteamName, err := rootName.Append("sub1")
 	require.NoError(t, err)

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -77,7 +77,7 @@ func memberSetupSubteam(t *testing.T) (tc libkb.TestContext, owner, otherA, othe
 		t.Fatal(err)
 	}
 	subPart := "sub"
-	_, err = CreateSubteam(context.TODO(), tc.G, subPart, rootTeamName)
+	_, err = CreateSubteam(context.TODO(), tc.G, subPart, rootTeamName, false /* addSelf */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -845,7 +845,7 @@ func TestImplicitAdminsKeyedForSubteam(t *testing.T) {
 	parentName, _ := createTeam2(*tcs[0])
 
 	t.Logf("U0 creates a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "sub", parentName)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "sub", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("U1 and U2 can't load the subteam")
@@ -880,7 +880,7 @@ func TestImplicitAdminsKeyedForSubteamAfterUpgrade(t *testing.T) {
 	parentName, _ := createTeam2(*tcs[0])
 	t.Logf("U0 created a root team %q", parentName)
 
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "sub", parentName)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "sub", parentName, false /* addSelf */)
 	require.NoError(t, err)
 	t.Logf("U0 created a subteam %q", subteamID)
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -77,7 +77,7 @@ func memberSetupSubteam(t *testing.T) (tc libkb.TestContext, owner, otherA, othe
 		t.Fatal(err)
 	}
 	subPart := "sub"
-	_, err = CreateSubteam(context.TODO(), tc.G, subPart, rootTeamName, false /* addSelf */)
+	_, err = CreateSubteam(context.TODO(), tc.G, subPart, rootTeamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -845,7 +845,7 @@ func TestImplicitAdminsKeyedForSubteam(t *testing.T) {
 	parentName, _ := createTeam2(*tcs[0])
 
 	t.Logf("U0 creates a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "sub", parentName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "sub", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("U1 and U2 can't load the subteam")
@@ -880,7 +880,7 @@ func TestImplicitAdminsKeyedForSubteamAfterUpgrade(t *testing.T) {
 	parentName, _ := createTeam2(*tcs[0])
 	t.Logf("U0 created a root team %q", parentName)
 
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "sub", parentName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "sub", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	t.Logf("U0 created a subteam %q", subteamID)
 

--- a/go/teams/rename_test.go
+++ b/go/teams/rename_test.go
@@ -22,7 +22,7 @@ func TestRenameSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	subteamBasename := "bb1"
-	subteamID, err := CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName)
+	subteamID, err := CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, false /* addSelf */)
 	require.NoError(t, err)
 	subteamName, err := parentTeamName.Append(subteamBasename)
 	require.NoError(t, err)
@@ -77,11 +77,11 @@ func TestRenameInflateSubteamAfterRenameParent(t *testing.T) {
 	subsubteamName2 := createTeamName(t, parentName.String(), "bb2", "cc")
 
 	t.Logf("U0 creates A.B1")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "bb1", parentName)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "bb1", parentName, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("U0 creates A.B1.C")
-	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "cc", subteamName1)
+	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "cc", subteamName1, false /* addSelf */)
 	require.NoError(t, err)
 
 	t.Logf("U0 adds U1 to A.B1 as a writer")
@@ -136,7 +136,7 @@ func TestRenameIntoMovedSubteam(t *testing.T) {
 	subteamNameC := createTeamName(t, parentName.String(), "ccc")
 
 	t.Logf("U0 creates R.B (subteam 1)")
-	subteamID1, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName)
+	subteamID1, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, false /* addSelf */)
 	require.NoError(t, err)
 	_ = subteamID1
 
@@ -160,7 +160,7 @@ func TestRenameIntoMovedSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U0 creates R.B (subteam 2) which is the SECOND R.B to be created")
-	subteamID2, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName)
+	subteamID2, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, false /* addSelf */)
 	require.NoError(t, err)
 	_ = subteamID2
 

--- a/go/teams/rename_test.go
+++ b/go/teams/rename_test.go
@@ -22,7 +22,7 @@ func TestRenameSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	subteamBasename := "bb1"
-	subteamID, err := CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	subteamName, err := parentTeamName.Append(subteamBasename)
 	require.NoError(t, err)
@@ -77,11 +77,11 @@ func TestRenameInflateSubteamAfterRenameParent(t *testing.T) {
 	subsubteamName2 := createTeamName(t, parentName.String(), "bb2", "cc")
 
 	t.Logf("U0 creates A.B1")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "bb1", parentName, false /* addSelf */)
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "bb1", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("U0 creates A.B1.C")
-	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "cc", subteamName1, false /* addSelf */)
+	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "cc", subteamName1, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 
 	t.Logf("U0 adds U1 to A.B1 as a writer")
@@ -136,7 +136,7 @@ func TestRenameIntoMovedSubteam(t *testing.T) {
 	subteamNameC := createTeamName(t, parentName.String(), "ccc")
 
 	t.Logf("U0 creates R.B (subteam 1)")
-	subteamID1, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, false /* addSelf */)
+	subteamID1, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	_ = subteamID1
 
@@ -160,7 +160,7 @@ func TestRenameIntoMovedSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U0 creates R.B (subteam 2) which is the SECOND R.B to be created")
-	subteamID2, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, false /* addSelf */)
+	subteamID2, err := CreateSubteam(context.TODO(), tcs[0].G, "bbb", parentName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	_ = subteamID2
 


### PR DESCRIPTION
The goals of this PR are:
1. Change `TeamCreateWithSettings` to post one less link by adding admin to subteam using SubteamHead link instead of separate ChangeMembership link. There is slight API change: `addSelfAs keybase1.TeamRole` argument in `teams.CreateSubteam`.
2. When creating a subteam without staying in, create subteam with self as `WRITER`, so chat channel can be initialized, but when leaving user does not have to downgrade themselves first.
3. When creating a subteam to stay, add self as `ADMIN`. This also has nice effect of creating just one `SubteamHead` link.
4. Add a test to lock-in the behaviour of initialising chat channel when creating a team. It's in `team_create_test.go`.
5. Chat-related smuUser test functions were moved from `team_reset_test.go` to `multiuser_common_test.go` to encourage use from other test files, not necessarily related to resets.

In general, the case of creating a team and leaving it was optimized from 5 links:
`SubteamHead, ChangeMembership (add self as admin), ChangeMembership (downgrade self to writer), Leave, RotateKey`
to 3 links:
`SubteamHead (with self as writer), Leave, RotateKey`.