### PR TITLE
More secure SecretStoreFile

### DIFF
--- a/go/libkb/secret_store_file.go
+++ b/go/libkb/secret_store_file.go
@@ -4,6 +4,8 @@
 package libkb
 
 import (
+	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -31,6 +33,33 @@ func (s *SecretStoreFile) RetrieveSecret(username NormalizedUsername) (LKSecFull
 			return LKSecFullSecret{}, ErrSecretForUserNotFound
 		}
 
+		return LKSecFullSecret{}, err
+	}
+
+	return newLKSecFullSecretFromBytes(secret)
+}
+
+func (s *SecretStoreFile) retrieveSecretV2(username NormalizedUsername) (LKSecFullSecret, error) {
+	xor, err := ioutil.ReadFile(s.userpathV2(username))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return LKSecFullSecret{}, ErrSecretForUserNotFound
+		}
+
+		return LKSecFullSecret{}, err
+	}
+
+	noise, err := ioutil.ReadFile(s.noisepathV2(username))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return LKSecFullSecret{}, ErrSecretForUserNotFound
+		}
+
+		return LKSecFullSecret{}, err
+	}
+
+	secret, err := s.noiseXOR(xor, noise)
+	if err != nil {
 		return LKSecFullSecret{}, err
 	}
 
@@ -87,7 +116,122 @@ func (s *SecretStoreFile) StoreSecret(username NormalizedUsername, secret LKSecF
 	return nil
 }
 
+func (s *SecretStoreFile) noiseXOR(secret, noise []byte) ([]byte, error) {
+	sum := sha256.Sum256(noise)
+	if len(sum) != len(secret) {
+		return nil, errors.New("LKSecLen or sha256.Size is no longer 32")
+	}
+
+	xor := make([]byte, len(sum))
+	for i := 0; i < len(sum); i++ {
+		xor[i] = sum[i] ^ secret[i]
+	}
+
+	return xor, nil
+}
+
+func (s *SecretStoreFile) storeSecretV2(username NormalizedUsername, secret LKSecFullSecret) error {
+	noise, err := RandBytes(1024 * 1024 * 2)
+	if err != nil {
+		return err
+	}
+	xor, err := s.noiseXOR(secret.Bytes(), noise)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(s.dir, 0700); err != nil {
+		return err
+	}
+
+	fsec, err := ioutil.TempFile(s.dir, username.String())
+	if err != nil {
+		return err
+	}
+	fnoise, err := ioutil.TempFile(s.dir, username.String())
+	if err != nil {
+		return err
+	}
+
+	// remove the temp file if it still exists at the end of this function
+	defer os.Remove(fsec.Name())
+	defer os.Remove(fnoise.Name())
+
+	if runtime.GOOS != "windows" {
+		// os.Fchmod not supported on windows
+		if err := fsec.Chmod(0600); err != nil {
+			return err
+		}
+		if err := fnoise.Chmod(0600); err != nil {
+			return err
+		}
+	}
+	if _, err := fsec.Write(xor); err != nil {
+		return err
+	}
+	if err := fsec.Close(); err != nil {
+		return err
+	}
+	if _, err := fnoise.Write(noise); err != nil {
+		return err
+	}
+	if err := fnoise.Close(); err != nil {
+		return err
+	}
+
+	finalSec := s.userpathV2(username)
+	finalNoise := s.noisepathV2(username)
+
+	exists, err := FileExists(finalSec)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		// shred the existing secret
+		if err := s.clearSecretV2(username); err != nil {
+			return err
+		}
+	}
+
+	if err := os.Rename(fsec.Name(), finalSec); err != nil {
+		return err
+	}
+	if err := os.Rename(fnoise.Name(), finalNoise); err != nil {
+		return err
+	}
+
+	if err := os.Chmod(finalSec, 0600); err != nil {
+		return err
+	}
+	if err := os.Chmod(finalNoise, 0600); err != nil {
+		return err
+	}
+
+	// if we just created the secret store file for the
+	// first time, notify anyone interested.
+	if !exists && s.notifyCreate != nil {
+		s.notifyCreate(username)
+	}
+
+	return nil
+}
+
 func (s *SecretStoreFile) ClearSecret(username NormalizedUsername) error {
+	// try both
+	errV1 := s.clearSecretV1(username)
+	errV2 := s.clearSecretV2(username)
+
+	if errV1 != nil {
+		return errV1
+	}
+	if errV2 != nil {
+		return errV2
+	}
+	return nil
+}
+
+func (s *SecretStoreFile) clearSecretV1(username NormalizedUsername) error {
 	if err := os.Remove(s.userpath(username)); err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -95,6 +239,34 @@ func (s *SecretStoreFile) ClearSecret(username NormalizedUsername) error {
 		return err
 	}
 
+	return nil
+}
+
+func (s *SecretStoreFile) clearSecretV2(username NormalizedUsername) error {
+	exists, err := FileExists(s.userpathV2(username))
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	for i := 0; i < 3; i++ {
+		noise, err := RandBytes(1024 * 1024 * 2)
+		if err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(s.noisepathV2(username), noise, 0600); err != nil {
+			return err
+		}
+	}
+
+	if err := os.Remove(s.noisepathV2(username)); err != nil {
+		return err
+	}
+	if err := os.Remove(s.userpathV2(username)); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -112,6 +284,14 @@ func (s *SecretStoreFile) GetUsersWithStoredSecrets() ([]string, error) {
 
 func (s *SecretStoreFile) userpath(username NormalizedUsername) string {
 	return filepath.Join(s.dir, fmt.Sprintf("%s.ss", username))
+}
+
+func (s *SecretStoreFile) userpathV2(username NormalizedUsername) string {
+	return filepath.Join(s.dir, fmt.Sprintf("%s.ss2", username))
+}
+
+func (s *SecretStoreFile) noisepathV2(username NormalizedUsername) string {
+	return filepath.Join(s.dir, fmt.Sprintf("%s.ns2", username))
 }
 
 func stripExt(path string) string {

--- a/go/libkb/secret_store_file_test.go
+++ b/go/libkb/secret_store_file_test.go
@@ -259,6 +259,9 @@ func TestSecretStoreFileNoise(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// flip one bit
+	noise[0] ^= 0x01
+
 	if err := ioutil.WriteFile(filepath.Join(td, "ogden.ns2"), noise, 0600); err != nil {
 		t.Fatal(err)
 	}

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -12,8 +12,10 @@ import (
 	"encoding/base32"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
 	"math/big"
 	"os"
@@ -782,4 +784,27 @@ func IsNoSpaceOnDeviceError(err error) bool {
 	}
 
 	return false
+}
+
+func ShredFile(filename string) error {
+	stat, err := os.Stat(filename)
+	if err != nil {
+		return err
+	}
+	if stat.IsDir() {
+		return errors.New("cannot shread a directory")
+	}
+	size := int(stat.Size())
+
+	for i := 0; i < 3; i++ {
+		noise, err := RandBytes(size)
+		if err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(filename, noise, stat.Mode().Perm()); err != nil {
+			return err
+		}
+	}
+
+	return os.Remove(filename)
 }

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -796,6 +796,8 @@ func ShredFile(filename string) error {
 	}
 	size := int(stat.Size())
 
+	defer os.Remove(filename)
+
 	for i := 0; i < 3; i++ {
 		noise, err := RandBytes(size)
 		if err != nil {


### PR DESCRIPTION
This patch makes SecretStoreFile more secure when the secret is cleared by introducing a noise file and shredding it before unlinking it.
