### PR TITLE
Allow deleted msgs in maxmsgs

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -1207,6 +1207,8 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 			} else {
 				if len(newMsg) > 0 {
 					newMaxMsgs = append(newMaxMsgs, newMsg[0])
+				} else {
+					newMaxMsgs = append(newMaxMsgs, mm)
 				}
 			}
 		}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -668,13 +668,8 @@ func CreateTopicNameState(cmp chat1.ConversationIDMessageIDPairs) (chat1.TopicNa
 }
 
 func GetConvMtime(conv chat1.Conversation) gregor1.Time {
-	timeTyps := []chat1.MessageType{
-		chat1.MessageType_TEXT,
-		chat1.MessageType_ATTACHMENT,
-		chat1.MessageType_SYSTEM,
-	}
 	var summaries []chat1.MessageSummary
-	for _, typ := range timeTyps {
+	for _, typ := range VisibleChatMessageTypes() {
 		summary, err := conv.GetMaxMessage(typ)
 		if err == nil {
 			summaries = append(summaries, summary)
@@ -687,11 +682,13 @@ func GetConvMtime(conv chat1.Conversation) gregor1.Time {
 	return summaries[len(summaries)-1].Ctime
 }
 
+// PickLatestMessageUnboxed gets the latest message with one `typs`.
+// This method can return deleted messages which have a blank body.
 func PickLatestMessageUnboxed(conv chat1.ConversationLocal, typs []chat1.MessageType) (res chat1.MessageUnboxed, err error) {
 	var msgs []chat1.MessageUnboxed
 	for _, typ := range typs {
 		msg, err := conv.GetMaxMessage(typ)
-		if err == nil && msg.IsValidFull() {
+		if err == nil && msg.IsValid() {
 			msgs = append(msgs, msg)
 		}
 	}
@@ -703,12 +700,7 @@ func PickLatestMessageUnboxed(conv chat1.ConversationLocal, typs []chat1.Message
 }
 
 func GetConvMtimeLocal(conv chat1.ConversationLocal) gregor1.Time {
-	timeTyps := []chat1.MessageType{
-		chat1.MessageType_TEXT,
-		chat1.MessageType_ATTACHMENT,
-		chat1.MessageType_SYSTEM,
-	}
-	msg, err := PickLatestMessageUnboxed(conv, timeTyps)
+	msg, err := PickLatestMessageUnboxed(conv, VisibleChatMessageTypes())
 	if err != nil {
 		return conv.ReaderInfo.Mtime
 	}
@@ -716,12 +708,7 @@ func GetConvMtimeLocal(conv chat1.ConversationLocal) gregor1.Time {
 }
 
 func GetConvSnippet(conv chat1.ConversationLocal) string {
-	timeTyps := []chat1.MessageType{
-		chat1.MessageType_TEXT,
-		chat1.MessageType_ATTACHMENT,
-		chat1.MessageType_SYSTEM,
-	}
-	msg, err := PickLatestMessageUnboxed(conv, timeTyps)
+	msg, err := PickLatestMessageUnboxed(conv, VisibleChatMessageTypes())
 	if err != nil {
 		return ""
 	}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -308,6 +308,10 @@ func MessageUnboxedDebugStrings(ms []MessageUnboxed) (res []string) {
 	return res
 }
 
+func MessageUnboxedDebugList(ms []MessageUnboxed) string {
+	return fmt.Sprintf("{ %v %v }", len(ms), strings.Join(MessageUnboxedDebugStrings(ms), ","))
+}
+
 func MessageUnboxedDebugLines(ms []MessageUnboxed) string {
 	return strings.Join(MessageUnboxedDebugStrings(ms), "\n")
 }


### PR DESCRIPTION
The goal is to make it so that nuking a conv doesn't push it to the top or bottom of the inbox but leaves it in the same place.
The client was filtering out deleted messages from maxmsgs in `PickLatestMessageUnboxed`, and in `localizeConversation` through `superXform.Run`. Now it passes them through so that `GetConvMtimeLocal` does what we want.

Tested manually.