### PR TITLE
Request push token more often

### DIFF
--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -213,8 +213,11 @@ function* checkIOSPushSaga(): Saga.SagaGenerator<any, any> {
     ])
   } else {
     // badge or alert permissions are enabled
-    logger.info('Badge or alert permissions are enabled')
-    yield Saga.put(PushGen.createSetHasPermissions({hasPermissions: true}))
+    logger.info('Badge or alert permissions are enabled. Getting token.')
+    yield Saga.all([
+      Saga.put(PushGen.createSetHasPermissions({hasPermissions: true})),
+      Saga.call(requestPushPermissions),
+    ])
   }
 }
 
@@ -250,10 +253,15 @@ function* mobileAppStateSaga(action: AppGen.MobileAppStatePayload) {
     console.log('Checking push permissions')
     const permissions = yield Saga.call(checkPermissions)
     if (permissions.alert || permissions.badge) {
-      console.log('Push permissions are ON')
+      logger.info('Found push permissions ENABLED on app focus')
+      const hasPermissions = yield Saga.select((state: TypedState) => state.push.hasPermissions)
+      if (!hasPermissions) {
+        logger.info('Had no permissions before, requesting permissions to get token')
+        yield Saga.call(requestPushPermissions)
+      }
       yield Saga.put(PushGen.createSetHasPermissions({hasPermissions: true}))
     } else {
-      console.log('Push permissions are OFF')
+      logger.info('Found push permissions DISABLED on app focus')
       yield Saga.put(PushGen.createSetHasPermissions({hasPermissions: false}))
     }
   }

--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -254,7 +254,8 @@ function* mobileAppStateSaga(action: AppGen.MobileAppStatePayload) {
     const permissions = yield Saga.call(checkPermissions)
     if (permissions.alert || permissions.badge) {
       logger.info('Found push permissions ENABLED on app focus')
-      const hasPermissions = yield Saga.select((state: TypedState) => state.push.hasPermissions)
+      const state: TypedState = yield Saga.select()
+      const hasPermissions = state.push.hasPermissions
       if (!hasPermissions) {
         logger.info('Had no permissions before, requesting permissions to get token')
         yield Saga.call(requestPushPermissions)


### PR DESCRIPTION
This adds some calls to `requestPermissions` to handle a flow on iOS that could skip requesting a push token after permissions are enabled. 

r? @keybase/react-hackers 