### PR TITLE
Split chat input strings on `\n` in mention popup

### DIFF
--- a/shared/chat/conversation/input/mention-handler-hoc.desktop.js
+++ b/shared/chat/conversation/input/mention-handler-hoc.desktop.js
@@ -183,7 +183,7 @@ const mentionHoc = (InputComponent: React.ComponentType<Props>) => {
       const selections = this._inputRef && this._inputRef.selections()
       if (text && selections && selections.selectionStart === selections.selectionEnd) {
         const upToCursor = text.substring(0, selections.selectionStart)
-        const words = upToCursor.split(' ')
+        const words = upToCursor.split(/ |\n/)
         const lastWord = words[words.length - 1]
         if (includeWordAfterCursor) {
           const afterCursor = text.substring(selections.selectionStart)

--- a/shared/chat/conversation/input/mention-handler-hoc.native.js
+++ b/shared/chat/conversation/input/mention-handler-hoc.native.js
@@ -54,7 +54,7 @@ const mentionHoc = (InputComponent: React.ComponentType<Props>) => {
     _getWordAtCursor = (text: string) => {
       const {selectionStart} = this.state._selection
       const upToCursor = text.substring(0, selectionStart)
-      const words = upToCursor.split(' ')
+      const words = upToCursor.split(/ |\n/)
       return words[words.length - 1]
     }
 


### PR DESCRIPTION
Fixes a bug where the mention popup flickers open then closes immediately if you try to start a mention right after a newline. r? @keybase/react-hackers 