### PR TITLE
Put trace button behind a secret handshake

### DIFF
--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -68,6 +68,8 @@ type DeveloperState = {
   clickCount: number,
 }
 
+const clickThreshold = 7
+
 class Developer extends React.Component<Props, DeveloperState> {
   constructor(props: Props) {
     super(props)
@@ -78,13 +80,19 @@ class Developer extends React.Component<Props, DeveloperState> {
   }
 
   _onLabelClick = () => {
-    this.setState(state => ({
-      clickCount: state.clickCount + 1,
-    }))
+    this.setState(state => {
+      const clickCount = state.clickCount + 1
+      if (clickCount < clickThreshold) {
+        console.log(
+          `clickCount = ${clickCount} (${clickThreshold - clickCount} away from showing developer controls)`
+        )
+      }
+      return {clickCount}
+    })
   }
 
   _showTrace = () => {
-    return this.state.clickCount >= 7
+    return this.state.clickCount >= clickThreshold
   }
 
   render() {

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -102,7 +102,7 @@ class Developer extends React.Component<Props, DeveloperState> {
         <Text
           type="BodySmallSemibold"
           onClick={this._onLabelClick}
-          style={{textAlign: 'center', cursor: 'default'}}
+          style={{...(isMobile ? {} : {cursor: 'default'}), textAlign: 'center'}}
         >
           {isMobile
             ? `Please don't do anything here unless instructed to by a developer.`

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -64,7 +64,25 @@ class TraceButton extends React.Component<TraceButtonProps> {
   }
 }
 
-class Developer extends React.Component<Props> {
+type DeveloperState = {
+  clickCount: number,
+}
+
+class Developer extends React.Component<Props, DeveloperState> {
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {
+      clickCount: 0,
+    }
+  }
+
+  _onLabelClick = () => {
+    this.setState(state => ({
+      clickCount: state.clickCount + 1,
+    }))
+  }
+
   render() {
     const props = this.props
     return (
@@ -77,7 +95,7 @@ class Developer extends React.Component<Props> {
           flex: 1,
         }}
       >
-        <Text type="BodySmallSemibold" style={{textAlign: 'center'}}>
+        <Text type="BodySmallSemibold" onClick={this._onLabelClick} style={{textAlign: 'center'}}>
           {isMobile
             ? `Please don't do anything here unless instructed to by a developer.`
             : `Please don't do anything below here unless instructed to by a developer.`}

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -64,36 +64,39 @@ class TraceButton extends React.Component<TraceButtonProps> {
   }
 }
 
-function Developer(props: Props) {
-  return (
-    <Box
-      style={{
-        ...globalStyles.flexBoxColumn,
-        alignItems: 'center',
-        paddingTop: globalMargins.xlarge,
-        paddingBottom: globalMargins.medium,
-        flex: 1,
-      }}
-    >
-      <Text type="BodySmallSemibold" style={{textAlign: 'center'}}>
-        {isMobile
-          ? `Please don't do anything here unless instructed to by a developer.`
-          : `Please don't do anything below here unless instructed to by a developer.`}
-      </Text>
-      <Box style={{width: '100%', height: 2, backgroundColor: globalColors.grey}} />
-      <Button
-        style={{marginTop: globalMargins.small}}
-        type="Danger"
-        label="DB Nuke"
-        onClick={props.onDBNuke}
-      />
-      <TraceButton durationSeconds={30} onTrace={props.onTrace} traceInProgress={props.traceInProgress} />
-      <Text type="BodySmallSemibold" style={{textAlign: 'center'}}>
-        Trace files are included in logs sent with feedback.
-      </Text>
-      <Box style={{flex: 1}} />
-    </Box>
-  )
+class Developer extends React.Component<Props> {
+  render() {
+    const props = this.props
+    return (
+      <Box
+        style={{
+          ...globalStyles.flexBoxColumn,
+          alignItems: 'center',
+          paddingTop: globalMargins.xlarge,
+          paddingBottom: globalMargins.medium,
+          flex: 1,
+        }}
+      >
+        <Text type="BodySmallSemibold" style={{textAlign: 'center'}}>
+          {isMobile
+            ? `Please don't do anything here unless instructed to by a developer.`
+            : `Please don't do anything below here unless instructed to by a developer.`}
+        </Text>
+        <Box style={{width: '100%', height: 2, backgroundColor: globalColors.grey}} />
+        <Button
+          style={{marginTop: globalMargins.small}}
+          type="Danger"
+          label="DB Nuke"
+          onClick={props.onDBNuke}
+        />
+        <TraceButton durationSeconds={30} onTrace={props.onTrace} traceInProgress={props.traceInProgress} />
+        <Text type="BodySmallSemibold" style={{textAlign: 'center'}}>
+          Trace files are included in logs sent with feedback.
+        </Text>
+        <Box style={{flex: 1}} />
+      </Box>
+    )
+  }
 }
 
 export default Advanced

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -83,6 +83,10 @@ class Developer extends React.Component<Props, DeveloperState> {
     }))
   }
 
+  _showTrace = () => {
+    return this.state.clickCount >= 7
+  }
+
   render() {
     const props = this.props
     return (
@@ -107,10 +111,14 @@ class Developer extends React.Component<Props, DeveloperState> {
           label="DB Nuke"
           onClick={props.onDBNuke}
         />
-        <TraceButton durationSeconds={30} onTrace={props.onTrace} traceInProgress={props.traceInProgress} />
-        <Text type="BodySmallSemibold" style={{textAlign: 'center'}}>
-          Trace files are included in logs sent with feedback.
-        </Text>
+        {this._showTrace() && (
+          <TraceButton durationSeconds={30} onTrace={props.onTrace} traceInProgress={props.traceInProgress} />
+        )}
+        {this._showTrace() && (
+          <Text type="BodySmallSemibold" style={{textAlign: 'center'}}>
+            Trace files are included in logs sent with feedback.
+          </Text>
+        )}
         <Box style={{flex: 1}} />
       </Box>
     )

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -99,7 +99,11 @@ class Developer extends React.Component<Props, DeveloperState> {
           flex: 1,
         }}
       >
-        <Text type="BodySmallSemibold" onClick={this._onLabelClick} style={{textAlign: 'center'}}>
+        <Text
+          type="BodySmallSemibold"
+          onClick={this._onLabelClick}
+          style={{textAlign: 'center', cursor: 'default'}}
+        >
           {isMobile
             ? `Please don't do anything here unless instructed to by a developer.`
             : `Please don't do anything below here unless instructed to by a developer.`}


### PR DESCRIPTION
One would have to click the developer warning 7 times (a la Android)
to show the trace button.

Ideally, we'd know whether we're an admin build or not, and just use that,
but that's currently not easy, so going with this for now. This should deter
casual users.