### PR TITLE
Add optional comments to action creators

### DIFF
--- a/shared/desktop/yarn-helper/action-creator-creator.js
+++ b/shared/desktop/yarn-helper/action-creator-creator.js
@@ -23,6 +23,8 @@ type FileDesc = {
 
 type CompileActionFn = (ns: ActionNS, actionName: ActionName, desc: ActionDesc) => string
 
+const reservedPayloadKeys = ['_description']
+
 function compile(ns: ActionNS, {prelude, actions}: FileDesc): string {
   return `// @flow
 // NOTE: This file is GENERATED from json files in actions/json. Run 'yarn build-actions' to regenerate
@@ -79,7 +81,7 @@ function actionReduxTypeName(ns: ActionNS, actionName: ActionName): string {
 }
 
 function payloadKeys(p: Object) {
-  return Object.keys(p).filter(key => !['_description'].includes(key))
+  return Object.keys(p).filter(key => !reservedPayloadKeys.includes(key))
 }
 
 function printPayload(p: Object) {

--- a/shared/desktop/yarn-helper/action-creator-creator.js
+++ b/shared/desktop/yarn-helper/action-creator-creator.js
@@ -78,10 +78,14 @@ function actionReduxTypeName(ns: ActionNS, actionName: ActionName): string {
   return `'${ns}:${actionName}'`
 }
 
+function payloadKeys(p: Object) {
+  return Object.keys(p).filter(key => !['_description'].includes(key))
+}
+
 function printPayload(p: Object) {
-  return Object.keys(p).length
+  return payloadKeys(p).length
     ? '(payload: $ReadOnly<{' +
-        Object.keys(p)
+        payloadKeys(p)
           .map(key => `${key}: ${p[key]}`)
           .join(',\n') +
         '}>)'
@@ -98,13 +102,19 @@ function compileActionCreator(ns: ActionNS, actionName: ActionName, desc: Action
   const {canError, ...noErrorPayload} = desc
 
   return (
+    (noErrorPayload._description
+      ? `/**
+     * ${noErrorPayload._description}
+     */
+    `
+      : '') +
     `export const create${capitalize(actionName)} = ${printPayload(noErrorPayload)} => (
-  { error: false, payload${Object.keys(noErrorPayload).length ? '' : ': undefined'}, type: ${actionName}, }
+  { error: false, payload${payloadKeys(noErrorPayload).length ? '' : ': undefined'}, type: ${actionName}, }
 )` +
     (canError
       ? `
   export const create${capitalize(actionName)}Error = ${printPayload(canError)} => (
-    { error: true, payload${Object.keys(canError).length ? '' : ': undefined'}, type: ${actionName}, }
+    { error: true, payload${payloadKeys(canError).length ? '' : ': undefined'}, type: ${actionName}, }
   )`
       : '')
   )


### PR DESCRIPTION
This adds an optional field `_description` the action creator will look for in action payloads. The contents get added as a function comment on the action creator.

example output:
```
/**
 * Removes a member or pending invite from a team. Only call with one of {`teamname`, `username`, `inviteID`}
 */
export const createRemoveMemberOrPendingInvite = (
  payload: $ReadOnly<{
    email: string,
    teamname: string,
    username: string,
    inviteID: string,
  }>
) => ({error: false, payload, type: removeMemberOrPendingInvite})
```

and being picked up by vscode autocomplete:
<img width="551" alt="screen shot 2018-02-26 at 6 07 10 pm" src="https://user-images.githubusercontent.com/11968340/36734187-bce0f27e-1ba0-11e8-942d-f3b407e108a6.png">

I thought this would be nice to have in general and especially for some of our semantically ambiguous actions, like the one above. Open for discussion!

r? @keybase/react-hackers 