### PR TITLE
Follow prompt default-yes for no-proofs users

### DIFF
--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -214,7 +214,7 @@ func (ui IdentifyTrackUI) Confirm(o *keybase1.IdentifyOutcome) (result keybase1.
 	case keybase1.TrackStatus_NEW_ZERO_PROOFS:
 		prompt = "We found an account for " + username +
 			", but they haven't proven their identity. Still follow them?"
-		promptDefault = libkb.PromptDefaultNo
+		promptDefault = libkb.PromptDefaultYes
 	case keybase1.TrackStatus_NEW_FAIL_PROOFS:
 		verb := "follow"
 		if o.TrackOptions.ForPGPPull {

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -203,6 +203,10 @@ func (ui IdentifyTrackUI) Confirm(o *keybase1.IdentifyOutcome) (result keybase1.
 	trackChanged := true
 	switch o.TrackStatus {
 	case keybase1.TrackStatus_UPDATE_BROKEN_REVOKED, keybase1.TrackStatus_UPDATE_BROKEN_FAILED_PROOFS:
+		if o.TrackOptions.BypassConfirm {
+			ui.G().Log.Error("Some proofs failed. Try again without '-y'")
+			return
+		}
 		return ui.confirmFailedTrackProofs(o)
 	case keybase1.TrackStatus_UPDATE_NEW_PROOFS:
 		prompt = "Your view of " + username +
@@ -234,10 +238,15 @@ func (ui IdentifyTrackUI) Confirm(o *keybase1.IdentifyOutcome) (result keybase1.
 	}
 
 	// Tracking statement doesn't exist or changed, lets prompt them with the details
-	if o.TrackOptions.BypassConfirm && promptDefault == libkb.PromptDefaultYes {
-		result.IdentityConfirmed = true
-		result.AutoConfirmed = true
-		ui.G().Log.Info("Identity auto-confirmed via command-line flag")
+	if o.TrackOptions.BypassConfirm {
+		if promptDefault == libkb.PromptDefaultYes {
+			result.IdentityConfirmed = true
+			result.AutoConfirmed = true
+			ui.G().Log.Info("Identity auto-confirmed via command-line flag")
+		} else {
+			ui.G().Log.Error("Not auto-confirming. Try again without '-y'")
+			return
+		}
 	} else {
 		if result.IdentityConfirmed, err = ui.parent.PromptYesNo(PromptDescriptorTrackAction, prompt, promptDefault); err != nil {
 			return


### PR DESCRIPTION
Referencing https://github.com/keybase/client/issues/10553

_changed, see thread_

When following someone with `keybase follow` there is a `-y` option for the sure-footed to bypass prompts. Before this PR it bypassed
1. Is this the junderwood you wanted? [Y/n]

But did _not_ bypass

2. Some proofs failed; still follow junderwood? [y/N]
3. We found an account for junderwood, but they haven't proven their identity. Still follow them? [y/N]

There may be other prompts that I missed.

This change makes it so that case 3 defaults to yes `[Y/n]` and _is_ bypassed by `-y`. Case 2 is unchanged. The rationale here is that it if you are following a username with `-y` it's very likely ok with you that they have no proofs. Case 2 is more serious and it's helpful to encourage people to fix broken proofs.

cc @maxtaco in case you have an opinion