### PR TITLE
packaging: allow a global config.json file that can turn off the root redirector

### DIFF
--- a/go/client/cmd_config.go
+++ b/go/client/cmd_config.go
@@ -314,6 +314,9 @@ func NewCmdConfigInfo(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 func (v *CmdConfigGet) GetUsage() libkb.Usage {
 	return libkb.Usage{
 		Config: true,
+		// The root user may use the "config get -d" command to read
+		// config files.
+		AllowRoot: v.Direct,
 	}
 }
 

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -134,7 +134,9 @@ func mainInner(g *libkb.GlobalContext) error {
 		return nil
 	}
 
-	checkSystemUser(g.Log)
+	if !cmd.GetUsage().AllowRoot {
+		checkSystemUser(g.Log)
+	}
 
 	if cl.IsService() {
 		startProfile(g)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -210,6 +210,7 @@ type Usage struct {
 	KbKeyring  bool
 	API        bool
 	Socket     bool
+	AllowRoot  bool
 }
 
 type Command interface {

--- a/osx/KBKit/KBKit/Component/KBMountDir.m
+++ b/osx/KBKit/KBKit/Component/KBMountDir.m
@@ -163,7 +163,7 @@
   return YES;
 }
 
-- (BOOL)linkExists:(NSString *)linkPath {
++ (BOOL)linkExists:(NSString *)linkPath {
   NSDictionary *attributes = [NSFileManager.defaultManager attributesOfItemAtPath:linkPath error:nil];
   if (!attributes) {
     return NO;
@@ -171,7 +171,7 @@
   return [attributes[NSFileType] isEqual:NSFileTypeSymbolicLink];
 }
 
-- (NSString *)resolveLinkPath:(NSString *)linkPath {
++ (NSString *)resolveLinkPath:(NSString *)linkPath {
   if (![self linkExists:linkPath]) {
     return nil;
   }
@@ -193,7 +193,7 @@
   NSString *currPath = [self resolveLinkPath:symPath];
   if (currPath && ![config.mountDir isEqualToString:currPath]) {
     DDLogDebug(@"Removing old favorite: %@", currPath);
-    if ([[NSFileManager defaultManager] removeItemAtPath:symPath]) {
+    if (![[NSFileManager defaultManager] removeItemAtPath:symPath error:error]) {
       return NO;
     }
   }

--- a/osx/KBKit/KBKit/Component/KBMountDir.m
+++ b/osx/KBKit/KBKit/Component/KBMountDir.m
@@ -199,7 +199,7 @@
   }
 
   if (![[NSFileManager defaultManager] fileExistsAtPath:symPath]) {
-    if ([[NSFileManager defaultManager] createSymbolicLinkAtPath:symPath withDestinationPath:config.mountDir error:error]) {
+    if (![[NSFileManager defaultManager] createSymbolicLinkAtPath:symPath withDestinationPath:config.mountDir error:error]) {
       return NO;
     }
   }

--- a/osx/KBKit/KBKit/Component/KBRedirector.m
+++ b/osx/KBKit/KBKit/Component/KBRedirector.m
@@ -30,7 +30,7 @@
 }
 
 - (void)install:(KBCompletion)completion {
-  if ([self.config.redirectorDisabled]) {
+  if ([self.config redirectorDisabled]) {
     DDLogDebug(@"The redirector is disabled; ignoring");
     completion(nil);
     return;

--- a/osx/KBKit/KBKit/Component/KBRedirector.m
+++ b/osx/KBKit/KBKit/Component/KBRedirector.m
@@ -30,6 +30,12 @@
 }
 
 - (void)install:(KBCompletion)completion {
+  if ([self.config.redirectorDisabled]) {
+    DDLogDebug(@"The redirector is disabled; ignoring");
+    completion(nil);
+    return;
+  }
+
   uid_t uid = 0;
   gid_t gid = 0;
   NSNumber *permissions = [NSNumber numberWithShort:0600];

--- a/osx/KBKit/KBKit/System/KBEnvConfig.h
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.h
@@ -73,6 +73,7 @@ typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
 - (NSString *)gitRemoteHelperName;
 - (NSString *)redirectorBinName;
 - (NSString *)redirectorMount;
+- (BOOL)redirectorDisabled;
 
 - (BOOL)validate:(NSError **)error;
 

--- a/osx/KBKit/KBKit/System/KBEnvConfig.m
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.m
@@ -195,6 +195,22 @@
   }
 }
 
+- (BOOL)redirectorDisabled {
+  NSString *rootConfigPath = NSStringWithFormat(@"/etc/%@/config.json", [self appNameWithDot]);
+  NSData *data = [NSData dataWithContentsOfFile:rootConfigPath];
+  if (data) {
+    NSError *err = nil;
+    NSDictionary *appConfig = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&err];
+    if (!err) {
+      id obj = [appConfig valueForKeyPath:@"disable-root-redirector"];
+      if (obj) {
+        return (BOOL)obj;
+      }
+    }
+  }
+  return NO;
+}
+
 - (NSString *)kbfsBinName {
   switch(_runMode) {
     case KBRunModeDevel: return @"kbfsdev";

--- a/osx/KBKit/KBKit/System/KBEnvConfig.m
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.m
@@ -204,7 +204,8 @@
     if (!err) {
       id obj = [appConfig valueForKeyPath:@"disable-root-redirector"];
       if (obj) {
-        return (BOOL)obj;
+        NSNumber *val = (NSNumber *)obj;
+        return [val boolValue];
       }
     }
   }

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -117,7 +117,7 @@ build_one_architecture() {
   # Build the root redirector binary.
   echo "Building keybase-redirector for $GOARCH..."
   go build -tags "$go_tags" -ldflags "$ldflags_client" -o \
-    "$layout_dir/usr/bin/keybase-redirector" github.com/keybase/kbfs/redirector
+    "$layout_dir/usr/bin/keybase-redirector" github.com/keybase/kbfs/redirector/go
 
   # Build the kbnm binary
   echo "Building kbnm for $GOARCH..."

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -40,7 +40,7 @@ make_mountpoint() {
 run_redirector() {
   make_mountpoint
 
-  # Only start the root redirector if it hasn't been explicit disabled.
+  # Only start the root redirector if it hasn't been explicitly disabled.
   if [ "$disableRedirector" != "true" ]; then
     logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
     mkdir -p "$logdir"

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -65,7 +65,7 @@ if redirector_enabled ; then
   chmod 4755 "$krbin"
 else
   # Turn off suid if root has been turned off.
-  chmod 0755 "$krbin"
+  chmod a-s "$krbin"
 fi
 
 currlink="$(readlink "$rootmount")"

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -17,9 +17,6 @@ khuserDeprecated="keybasehelper"
 khbinDeprecated="/usr/bin/keybase-mount-helper"
 optDeprecated="/opt/keybase/mount-readme"
 
-chown root:root "$krbin"
-chmod 4755 "$krbin"
-
 redirector_enabled() {
   disableRedirector="false"
   if [ -r "$rootConfigFile" ] ; then
@@ -62,6 +59,14 @@ run_redirector() {
     echo "Killing root redirector"
   fi
 }
+
+if redirector_enabled ; then
+  chown root:root "$krbin"
+  chmod 4755 "$krbin"
+else
+  # Turn off suid if root has been turned off.
+  chmod 0755 "$krbin"
+fi
 
 currlink="$(readlink "$rootmount")"
 if [ -n "$currlink" ] ; then

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -49,6 +49,15 @@ run_redirector() {
     mkdir -p "$logdir"
     echo Starting root redirector at $rootmount.
     nohup "$krbin" "$rootmount" >> "$logdir/keybase.redirector.log" 2>&1 &
+    t=5
+    while ! mountpoint "$rootmount" &> /dev/null; do
+        sleep 1
+        t=$[t-1]
+        if [ $t -eq 0 ]; then
+            echo "Redirector hasn't started yet."
+            break
+        fi
+    done
   elif killall `basename "$krbin"` &> /dev/null ; then
     echo "Killing root redirector"
   fi

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -130,7 +130,7 @@ run_redirector() {
     fi
   fi
 
-  # Only start the root redirector if it hasn't been explicit disabled.
+  # Only start the root redirector if it hasn't been explicitly disabled.
   if [ "$disable" != "true" ]; then
     logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
     nohup keybase-redirector /keybase >> "$logdir/keybase.redirector.log" 2>&1 &

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -13,8 +13,9 @@ set -e -u -o pipefail
 runtime_dir="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase"
 mkdir -p "$runtime_dir"
 startup_token="$runtime_dir/startup_mode"
-if keybase config get mountdir &> /dev/null ; then
-    mountdir="$(keybase config get mountdir 2> /dev/null | sed -e s/\"//g)"
+# Use -d to avoid starting up the keybase background daemon here.
+if keybase config get -d -b mountdir &> /dev/null ; then
+    mountdir="$(keybase config get -d -b mountdir 2> /dev/null)"
 else
     # The user has no mountpoint configured yet, so pick a default one
     # and record the default setting in a separate config field, so
@@ -119,8 +120,21 @@ forward_vars() {
 }
 
 run_redirector() {
-  logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
-  nohup keybase-redirector /keybase >> "$logdir/keybase.redirector.log" 2>&1 &
+  rootConfigFile="/etc/keybase/config.json"
+  disableConfigKey="disable-root-redirector"
+
+  disable="false"
+  if [ -r "$rootConfigFile" ] ; then
+    if keybase -c "$rootConfigFile" config get -d "$disableConfigKey" &> /dev/null ; then
+      disable="$(keybase -c "$rootConfigFile" config get -d "$disableConfigKey" 2> /dev/null)"
+    fi
+  fi
+
+  # Only start the root redirector if it hasn't been explicit disabled.
+  if [ "$disable" != "true" ]; then
+    logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
+    nohup keybase-redirector /keybase >> "$logdir/keybase.redirector.log" 2>&1 &
+  fi
 }
 
 start_systemd() {

--- a/packaging/prerelease/build_kbfs.sh
+++ b/packaging/prerelease/build_kbfs.sh
@@ -21,7 +21,7 @@ tags=${TAGS:-"prerelease production"}
 ldflags="-X github.com/keybase/kbfs/libkbfs.PrereleaseBuild=$kbfs_build"
 pkg="github.com/keybase/kbfs/kbfsfuse"
 git_remote_helper_pkg="github.com/keybase/kbfs/kbfsgit/git-remote-keybase"
-redirector_pkg="github.com/keybase/kbfs/redirector"
+redirector_pkg="github.com/keybase/kbfs/redirector/go"
 
 if [ "$PLATFORM" = "windows" ]; then
   pkg="github.com/keybase/kbfs/kbfsdokan"


### PR DESCRIPTION
Once we turn on the root redirector, we'll probably face some detractors who don't like us using a mountpoint in /.  I think it makes sense to give them a way to turn it off if they don't want it.

Since the root redirector runs as root, we can't just use a config value in the normal user-based config.json, since there might be multiple users on the machine all using keybase.  So the idea here is to allow the user to optionally create a file at `/etc/keybase/config.json` as root, and populate it thusly:

```json
{
  "disable-root-redirector": true
}
```

Then, we'll post instructions in the docs on how to stop the root redirector and delete `/keybase`, and when things get restarted, we won't try to start it up again.

To make that happen, this PR:
* Adds new flags to `keybase config get` for:
  * "d, direct": read a value directly from the config file, rather than relying on the Keybase service (and without launching a service, if one isn't already running).
  * "b, bare": read a string from the config file without putting quotes around it.  (Not really needed for this PR, but helpful to avoid some sed-hacking in the scripts.)
* Check the root config file in `run_keybase` and the Linux post-installer, and not starting the redirector if needed.
* Check the root config file in OSX before starting the redirector.

cc: @maxtaco for the `keybase config get` changes.

Issue: KBFS-2798i