### PR TITLE
CLI: move examples below options

### DIFF
--- a/go/client/help.go
+++ b/go/client/help.go
@@ -199,10 +199,7 @@ USAGE:
    keybase {{.FullName}}{{ if .Subcommands }} <command>{{ end }}{{if .Flags}} [command options]{{end}} {{ .ArgumentHelp }}{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}{{ if .Examples }}
-
-EXAMPLES:
-{{.ExamplesFormatted}}{{ end }}{{ if .Subcommands }}
+   {{.Description}}{{end}}{{ if .Subcommands }}
 
 COMMANDS:
    {{range .Subcommands}}{{if .Usage }}{{join .Names ", "}}{{ "\t" }}{{.Usage}}{{ end }}
@@ -210,7 +207,10 @@ COMMANDS:
 
 OPTIONS:
    {{range .Flags}}{{.}}
-   {{end}}{{ end }}
+   {{end}}{{ end }}{{ if .Examples }}
+EXAMPLES:
+{{.ExamplesFormatted}}{{ end }}
+
 `
 
 // SubcommandHelpTemplate is used for `keybase cmd` with no

--- a/go/vendor/github.com/keybase/cli/help.go
+++ b/go/vendor/github.com/keybase/cli/help.go
@@ -44,14 +44,14 @@ USAGE:
    command {{.FullName}}{{if .Flags}} [command options]{{end}} [arguments...]{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}{{if .Examples}}
-
-EXAMPLES:
-{{.ExamplesFormatted}}{{end}}{{if .Flags}}
+   {{.Description}}{{end}}{{if .Flags}}
 
 OPTIONS:
    {{range .Flags}}{{.}}
-   {{end}}{{ end }}
+   {{end}}{{ end }}{{if .Examples}}
+
+EXAMPLES:
+{{.ExamplesFormatted}}{{end}}
 `
 
 // The text template for the subcommand help topic.

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -189,10 +189,10 @@
 			"revisionTime": "2016-05-17T06:10:00Z"
 		},
 		{
-			"checksumSHA1": "As/C2CDekxCEGyFN5sOcrEt/r0Q=",
+			"checksumSHA1": "XfwkOvXS532Ei4UDa5jhBZIEsuY=",
 			"path": "github.com/keybase/cli",
-			"revision": "f7d0b25da714078d8c84ac64afe8d88794d587e3",
-			"revisionTime": "2017-11-10T20:24:45Z"
+			"revision": "fc02402bde61f4341e79f9a7186fbe966d435800",
+			"revisionTime": "2018-02-28T16:13:57Z"
 		},
 		{
 			"path": "github.com/keybase/clockwork",


### PR DESCRIPTION
Move `EXAMPLES` below `OPTIONS` in cli commands.

For example it now looks like:
```
$ keybase team remove-member
Error parsing command line arguments: team name argument required

NAME:
   keybase team remove-member - Remove a user from a team.

USAGE:
   keybase team remove-member [command options] <team name> --user=<username>

OPTIONS:
   -u, --user   username
   --email      cancel a pending invite by email address
   --invite-id  cancel a pending invite by ID
   -f, --force  don't ask for confirmation

EXAMPLES:
   Remove a user from the team:
       keybase team remove-member acme --user roadrunner
   Cancel an email invite:
       keybase team remove-member acme --email roadrunner@acme.com
   Cancel a secret token invite (like sms):
       keybase team list-members acme --show-invite-id # to get the invite ID
       keybase team remove-member acme --invite-id 9cfd13f927bcd1f6832fefa084bb2127

$
```

Where it used to be:
```
$ keybase team remove-member
Error parsing command line arguments: team name argument required

NAME:
   keybase team remove-member - Remove a user from a team.

USAGE:
   keybase team remove-member [command options] <team name> --user=<username>

EXAMPLES:
   Remove a user from the team:
       keybase team remove-member acme --user roadrunner
   Cancel an email invite:
       keybase team remove-member acme --email roadrunner@acme.com
   Cancel a secret token invite (like sms):
       keybase team list-members acme --show-invite-id # to get the invite ID
       keybase team remove-member acme --invite-id 9cfd13f927bcd1f6832fefa084bb2127

OPTIONS:
   -u, --user   username
   --email      cancel a pending invite by email address
   --invite-id  cancel a pending invite by ID
   -f, --force  don't ask for confirmation

$
```