### PR TITLE
Reduce testing time for sigchain related actions

### DIFF
--- a/go/engine/bg_identifier_test.go
+++ b/go/engine/bg_identifier_test.go
@@ -16,15 +16,10 @@ const (
 )
 
 func TestBackgroundIdentifier(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testBackgroundIdentifier(t, sigVersion)
-	})
-}
-
-func _testBackgroundIdentifier(t *testing.T, sigVersion libkb.SigVersion) {
 	t.Skip()
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClockAt(time.Now())

--- a/go/engine/cryptocurrency_test.go
+++ b/go/engine/cryptocurrency_test.go
@@ -59,7 +59,6 @@ func _testCryptocurrency(t *testing.T, sigVersion libkb.SigVersion) {
 	}
 
 	// Now set a real address, but with the wrong family. This should fail
-	sv = keybase1.SigVersion(sigVersion)
 	e = NewCryptocurrencyEngine(tc.G, keybase1.RegisterAddressArg{Address: firstAddress, WantedFamily: "zcash", SigVersion: &sv})
 	err = RunEngine(e, ctx)
 	if err == nil {
@@ -70,7 +69,6 @@ func _testCryptocurrency(t *testing.T, sigVersion libkb.SigVersion) {
 	}
 
 	// Now set a real address; this should succeed.
-	sv = keybase1.SigVersion(sigVersion)
 	e = NewCryptocurrencyEngine(tc.G, keybase1.RegisterAddressArg{Address: firstAddress, WantedFamily: "bitcoin", SigVersion: &sv})
 	err = RunEngine(e, ctx)
 	if err != nil {
@@ -82,7 +80,6 @@ func _testCryptocurrency(t *testing.T, sigVersion libkb.SigVersion) {
 	}
 
 	// Test overwriting it without --force; should fail.
-	sv = keybase1.SigVersion(sigVersion)
 	e = NewCryptocurrencyEngine(tc.G, keybase1.RegisterAddressArg{Address: secondAddress, SigVersion: &sv})
 	err = RunEngine(e, ctx)
 	if err == nil {
@@ -96,7 +93,6 @@ func _testCryptocurrency(t *testing.T, sigVersion libkb.SigVersion) {
 	}
 
 	// Now test the overwrite with the --force flag; should succeed.
-	sv = keybase1.SigVersion(sigVersion)
 	e = NewCryptocurrencyEngine(tc.G, keybase1.RegisterAddressArg{Address: secondAddress, Force: true, SigVersion: &sv})
 	err = RunEngine(e, ctx)
 	if err != nil {
@@ -120,7 +116,6 @@ func _testCryptocurrency(t *testing.T, sigVersion libkb.SigVersion) {
 	}
 
 	// Check that we can also add a Zcash address
-	sv = keybase1.SigVersion(sigVersion)
 	e = NewCryptocurrencyEngine(tc.G, keybase1.RegisterAddressArg{Address: zcash1, SigVersion: &sv})
 	err = RunEngine(e, ctx)
 	if err != nil {
@@ -136,7 +131,6 @@ func _testCryptocurrency(t *testing.T, sigVersion libkb.SigVersion) {
 	}
 
 	// Check that we can't also add a second Zcash address
-	sv = keybase1.SigVersion(sigVersion)
 	e = NewCryptocurrencyEngine(tc.G, keybase1.RegisterAddressArg{Address: zcash2, SigVersion: &sv})
 	err = RunEngine(e, ctx)
 	if err == nil {
@@ -154,7 +148,6 @@ func _testCryptocurrency(t *testing.T, sigVersion libkb.SigVersion) {
 	}
 
 	// Check that we can't also add a second Zcash address
-	sv = keybase1.SigVersion(sigVersion)
 	e = NewCryptocurrencyEngine(tc.G, keybase1.RegisterAddressArg{Address: zcash2, Force: true, SigVersion: &sv})
 	err = RunEngine(e, ctx)
 	if err != nil {

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -387,14 +387,9 @@ func TestIdentify2WithUIDWithBrokenTrackWithSuppressUI(t *testing.T) {
 }
 
 func TestIdentify2WithUIDWithUntrackedFastPath(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testIdentify2WithUIDWithUntrackedFastPath(t, sigVersion)
-	})
-}
-
-func _testIdentify2WithUIDWithUntrackedFastPath(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "TestIdentify2WithUIDWithUntrackedFastPath")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	fu := CreateAndSignupFakeUser(tc, "track")
 
@@ -966,15 +961,9 @@ func TestIdentify2NoSigchain(t *testing.T) {
 
 // See CORE-4310
 func TestIdentifyAfterDbNuke(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testIdentifyAfterDbNuke(t, sigVersion)
-	})
-}
-
-func _testIdentifyAfterDbNuke(t *testing.T, sigVersion libkb.SigVersion) {
-
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	trackAlice(tc, fu, sigVersion)
@@ -1013,13 +1002,9 @@ func _testIdentifyAfterDbNuke(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestNoSelfHostedIdentifyInPassiveMode(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testNoSelfHostedIdentifyInPassiveMode(t, sigVersion)
-	})
-}
-func _testNoSelfHostedIdentifyInPassiveMode(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "id")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	eve := CreateAndSignupFakeUser(tc, "e")
 	_, _, err := proveRooter(tc.G, eve, sigVersion)

--- a/go/engine/list_tracking_test.go
+++ b/go/engine/list_tracking_test.go
@@ -61,14 +61,9 @@ func _testListTracking(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestListTrackingJSON(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testListTrackingJSON(t, sigVersion)
-	})
-}
-
-func _testListTrackingJSON(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 	fu.LoginOrBust(tc)
 
@@ -98,15 +93,10 @@ func _testListTrackingJSON(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestListTrackingLocal(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testListTrackingLocal(t, sigVersion)
-	})
-}
-
-func _testListTrackingLocal(t *testing.T, sigVersion libkb.SigVersion) {
 	t.Skip("Skipping test for local tracks in list tracking (milestone 2)")
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	trackAlice(tc, fu, sigVersion)

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -194,19 +194,23 @@ func TestUserEmails(t *testing.T) {
 }
 
 func TestProvisionDesktop(t *testing.T) {
-	testProvisionDesktop(t, false)
+	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
+		testProvisionDesktop(t, false, sigVersion)
+	})
 }
 
 func TestProvisionDesktopPUK(t *testing.T) {
-	testProvisionDesktop(t, true)
+	testProvisionDesktop(t, true, libkb.KeybaseNullSigVersion)
 }
 
-func testProvisionDesktop(t *testing.T, upgradePerUserKey bool) {
+func testProvisionDesktop(t *testing.T, upgradePerUserKey bool, sigVersion libkb.SigVersion) {
 	// device X (provisioner) context:
 	t.Logf("setup X")
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
-	sigVersion := libkb.GetDefaultSigVersion(tcX.G)
+	if sigVersion == libkb.KeybaseNullSigVersion {
+		sigVersion = libkb.GetDefaultSigVersion(tcX.G)
+	}
 	tcX.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
 
 	// device Y (provisionee) context:

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -194,22 +194,19 @@ func TestUserEmails(t *testing.T) {
 }
 
 func TestProvisionDesktop(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		testProvisionDesktop(t, false, sigVersion)
-	})
+	testProvisionDesktop(t, false)
 }
 
 func TestProvisionDesktopPUK(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		testProvisionDesktop(t, true, sigVersion)
-	})
+	testProvisionDesktop(t, true)
 }
 
-func testProvisionDesktop(t *testing.T, upgradePerUserKey bool, sigVersion libkb.SigVersion) {
+func testProvisionDesktop(t *testing.T, upgradePerUserKey bool) {
 	// device X (provisioner) context:
 	t.Logf("setup X")
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tcX.G)
 	tcX.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
 
 	// device Y (provisionee) context:
@@ -890,14 +887,9 @@ func testSign(t *testing.T, tc libkb.TestContext) {
 }
 
 func TestProvisionPaperOnly(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testProvisionPaperOnly(t, sigVersion)
-	})
-}
-
-func _testProvisionPaperOnly(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := NewFakeUserOrBust(t, "paper")
 	arg := MakeTestSignupEngineRunArg(fu)
 	arg.SkipPaper = false
@@ -1990,15 +1982,10 @@ func TestProvisionPaperFailures(t *testing.T) {
 // After kex provisioning, try using a synced pgp key to sign
 // something.
 func TestProvisionKexUseSyncPGP(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testProvisionKexUseSyncPGP(t, sigVersion)
-	})
-}
-
-func _testProvisionKexUseSyncPGP(t *testing.T, sigVersion libkb.SigVersion) {
 	// device X (provisioner) context:
 	tcX := SetupEngineTestRealTriplesec(t, "kex2provision")
 	defer tcX.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tcX.G)
 
 	// device Y (provisionee) context:
 	tcY := SetupEngineTestRealTriplesec(t, "template")
@@ -2357,14 +2344,9 @@ func TestResetAccountPaper(t *testing.T) {
 
 // After resetting account, try kex2 provisioning.
 func TestResetAccountKexProvision(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testResetAccountKexProvision(t, sigVersion)
-	})
-}
-
-func _testResetAccountKexProvision(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	u := CreateAndSignupFakeUser(tc, "login")
 
@@ -2526,14 +2508,9 @@ func TestResetThenPGPOnlyThenProvision(t *testing.T) {
 // Try to replicate @nistur sigchain.
 // github issue: https://github.com/keybase/client/issues/2356
 func TestResetAccountLikeNistur(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testResetAccountLikeNistur(t, sigVersion)
-	})
-}
-
-func _testResetAccountLikeNistur(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	// user with synced pgp key
 	u := createFakeUserWithPGPOnly(t, tc)
@@ -2742,15 +2719,10 @@ func TestResetMultipleDevices(t *testing.T) {
 // results in provisioning again...)
 // Seems to only happen w/ kex2.
 func TestProvisionWithBadConfig(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testProvisionWithBadConfig(t, sigVersion)
-	})
-}
-
-func _testProvisionWithBadConfig(t *testing.T, sigVersion libkb.SigVersion) {
 	// device X (provisioner) context:
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tcX.G)
 
 	// device Y (provisionee) context:
 	tcY := SetupEngineTest(t, "template")
@@ -2985,20 +2957,16 @@ func TestProvisionGPGMobile(t *testing.T) {
 }
 
 func TestProvisionEnsureNoPaperKey(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		testProvisionEnsureNoPaperKey(t, false, sigVersion)
-	})
+	testProvisionEnsureNoPaperKey(t, false)
 }
 
 func TestProvisionEnsureNoPaperKeyPUK(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		testProvisionEnsureNoPaperKey(t, true, sigVersion)
-	})
+	testProvisionEnsureNoPaperKey(t, true)
 }
 
 // Provisioning a new device when the user has no paper keys should work
 // and not generate a paper key.
-func testProvisionEnsureNoPaperKey(t *testing.T, upgradePerUserKey bool, sigVersion libkb.SigVersion) {
+func testProvisionEnsureNoPaperKey(t *testing.T, upgradePerUserKey bool) {
 	// This test is based on TestProvisionDesktop.
 
 	t.Logf("create 2 contexts")
@@ -3006,6 +2974,7 @@ func testProvisionEnsureNoPaperKey(t *testing.T, upgradePerUserKey bool, sigVers
 	// device X (provisioner) context:
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tcX.G)
 	tcX.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
 
 	// device Y (provisionee) context:
@@ -3136,12 +3105,6 @@ func testProvisionEnsureNoPaperKey(t *testing.T, upgradePerUserKey bool, sigVers
 
 // Device X provisions device Y, then device Y revokes X.
 func TestProvisionAndRevoke(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testProvisionAndRevoke(t, sigVersion)
-	})
-}
-
-func _testProvisionAndRevoke(t *testing.T, sigVersion libkb.SigVersion) {
 	// This test is based on TestProvisionDesktop.
 
 	t.Logf("create 2 contexts")
@@ -3149,6 +3112,7 @@ func _testProvisionAndRevoke(t *testing.T, sigVersion libkb.SigVersion) {
 	// device X (provisioner) context:
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tcX.G)
 
 	// device Y (provisionee) context:
 	tcY := SetupEngineTest(t, "template")

--- a/go/engine/merkle_client_historical_test.go
+++ b/go/engine/merkle_client_historical_test.go
@@ -9,12 +9,6 @@ import (
 )
 
 func TestMerkleClientHistorical(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testMerkleClientHistorical(t, sigVersion)
-	})
-}
-
-func _testMerkleClientHistorical(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
 	fu := CreateAndSignupFakeUser(tc, "track")
@@ -29,7 +23,14 @@ func _testMerkleClientHistorical(t *testing.T, sigVersion libkb.SigVersion) {
 	require.NotNil(t, leaf)
 	require.NotNil(t, root)
 
+	var sigVersion libkb.SigVersion
 	for i := 0; i < 5; i++ {
+		// Cover both v1 and v2 case
+		if i%2 == 0 {
+			sigVersion = libkb.KeybaseSignatureV2
+		} else {
+			sigVersion = libkb.KeybaseSignatureV1
+		}
 		trackAlice(tc, fu, sigVersion)
 		untrackAlice(tc, fu, sigVersion)
 	}

--- a/go/engine/pgp_keyfinder_test.go
+++ b/go/engine/pgp_keyfinder_test.go
@@ -12,14 +12,9 @@ import (
 )
 
 func TestPGPKeyfinder(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testPGPKeyfinder(t, sigVersion)
-	})
-}
-
-func _testPGPKeyfinder(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "PGPKeyfinder")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	u := CreateAndSignupFakeUser(tc, "login")
 	// track alice before starting so we have a user already tracked

--- a/go/engine/pgp_pull_test.go
+++ b/go/engine/pgp_pull_test.go
@@ -86,14 +86,9 @@ func runPGPPullExpectingError(tc libkb.TestContext, arg PGPPullEngineArg) {
 }
 
 func TestPGPPullAll(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testPGPPullAll(t, sigVersion)
-	})
-}
-
-func _testPGPPullAll(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "pgp_pull")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	users := []string{"t_alice", "t_bob"}
 	fu := createUserWhoTracks(tc, users, sigVersion)
@@ -108,14 +103,9 @@ func _testPGPPullAll(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestPGPPullOne(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testPGPPullOne(t, sigVersion)
-	})
-}
-
-func _testPGPPullOne(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "pgp_pull")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	users := []string{"t_alice", "t_bob"}
 	fu := createUserWhoTracks(tc, users, sigVersion)
@@ -134,14 +124,9 @@ func _testPGPPullOne(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestPGPPullBadIDs(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testPGPPullBadIDs(t, sigVersion)
-	})
-}
-
-func _testPGPPullBadIDs(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "pgp_pull")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	users := []string{"t_alice", "t_bob"}
 	fu := createUserWhoTracks(tc, users, sigVersion)

--- a/go/engine/prove_test.go
+++ b/go/engine/prove_test.go
@@ -59,14 +59,9 @@ func _testProveRooterWithSecretStore(t *testing.T, sigVersion libkb.SigVersion) 
 
 // When device keys are cached, proofs shouldn't require passphrase prompt.
 func TestProveRooterCachedKeys(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testProveRooterCachedKeys(t, sigVersion)
-	})
-}
-
-func _testProveRooterCachedKeys(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "prove")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	fu := CreateAndSignupFakeUser(tc, "prove")
 	tc.G.LoginState().Account(func(a *libkb.Account) {

--- a/go/engine/saltpack_decrypt_test.go
+++ b/go/engine/saltpack_decrypt_test.go
@@ -125,15 +125,9 @@ func (t *testDecryptSaltpackUI) SaltpackPromptForDecrypt(_ context.Context, arg 
 }
 
 func TestSaltpackDecryptBrokenTrack(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testSaltpackDecryptBrokenTrack(t, sigVersion)
-	})
-}
-
-func _testSaltpackDecryptBrokenTrack(t *testing.T, sigVersion libkb.SigVersion) {
-
 	tc := SetupEngineTest(t, "SaltpackDecrypt")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	// create a user to track the proofUser
 	trackUser := CreateAndSignupFakeUser(tc, "naclp")

--- a/go/engine/soft_snooze_test.go
+++ b/go/engine/soft_snooze_test.go
@@ -60,14 +60,9 @@ func (e *flakeyRooterAPI) PostHTML(arg libkb.APIArg) (res *libkb.ExternalHTMLRes
 }
 
 func TestSoftSnooze(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testSoftSnooze(t, sigVersion)
-	})
-}
-
-func _testSoftSnooze(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClockAt(time.Now())

--- a/go/engine/track_proof_test.go
+++ b/go/engine/track_proof_test.go
@@ -152,14 +152,9 @@ var sbtests = []sbtest{
 }
 
 func TestTrackProofServiceBlocks(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackProofServiceBlocks(t, sigVersion)
-	})
-}
-
-func _testTrackProofServiceBlocks(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	for _, test := range sbtests {
@@ -543,15 +538,10 @@ func _testTrackProofRooterRevoke(t *testing.T, sigVersion libkb.SigVersion) {
 // proofUser makes a user@rooter proof, then a user2@rooter proof.
 // trackUser tracks proofUser.  Verify the tracking statement.
 func TestTrackProofRooterOther(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackProofRooterOther(t, sigVersion)
-	})
-}
-
-func _testTrackProofRooterOther(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
 
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	// create a user with a rooter proof
 	proofUser := CreateAndSignupFakeUser(tc, "proof")
 	_, _, err := proveRooter(tc.G, proofUser, sigVersion)
@@ -592,14 +582,9 @@ func _testTrackProofRooterOther(t *testing.T, sigVersion libkb.SigVersion) {
 // proofUser.  proofUser makes a user2@rooter proof, trackUser
 // tracks proofUser again.  Test that the change is noticed.
 func TestTrackProofRooterChange(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackProofRooterChange(t, sigVersion)
-	})
-}
-
-func _testTrackProofRooterChange(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	// create a user with a rooter proof
 	proofUser := CreateAndSignupFakeUser(tc, "proof")

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -160,14 +160,9 @@ func _testTrack(t *testing.T, sigVersion libkb.SigVersion) {
 
 // tests tracking a user that doesn't have a public key (#386)
 func TestTrackNoPubKey(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackNoPubKey(t, sigVersion)
-	})
-}
-
-func _testTrackNoPubKey(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 	Logout(tc)
 
@@ -179,14 +174,9 @@ func _testTrackNoPubKey(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestTrackMultiple(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackMultiple(t, sigVersion)
-	})
-}
-
-func _testTrackMultiple(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	trackAlice(tc, fu, sigVersion)
@@ -196,14 +186,9 @@ func _testTrackMultiple(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestTrackNewUserWithPGP(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackNewUserWithPGP(t, sigVersion)
-	})
-}
-
-func _testTrackNewUserWithPGP(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := createFakeUserWithPGPSibkey(tc)
 	Logout(tc)
 
@@ -217,14 +202,9 @@ func _testTrackNewUserWithPGP(t *testing.T, sigVersion libkb.SigVersion) {
 
 // see issue #578
 func TestTrackRetrack(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackRetrack(t, sigVersion)
-	})
-}
-
-func _testTrackRetrack(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	tc.G.LoginState().Account(func(a *libkb.Account) {
@@ -438,13 +418,9 @@ func _testIdentifyTrackRaceDetection(t *testing.T, sigVersion libkb.SigVersion) 
 }
 
 func TestTrackNoKeys(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackNoKeys(t, sigVersion)
-	})
-}
-func _testTrackNoKeys(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	nk, pp := createFakeUserWithNoKeys(tc)
 	Logout(tc)
 

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -21,9 +21,14 @@ func doWithSigChainVersions(f func(libkb.SigVersion)) {
 }
 
 func TestTrackTokenIdentify2(t *testing.T) {
+	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
+		_testTrackTokenIdentify2(t, sigVersion)
+	})
+}
+
+func _testTrackTokenIdentify2(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
-	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	idUI := &FakeIdentifyUI{}
@@ -185,9 +190,14 @@ func TestTrackLocalThenLocalTemp(t *testing.T) {
 }
 
 func TestTrackRemoteThenLocalTemp(t *testing.T) {
+	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
+		_testTrackRemoteThenLocalTemp(t, sigVersion)
+	})
+}
+
+func _testTrackRemoteThenLocalTemp(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
-	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	// Tracking remote means we have to agree what time it is

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -21,13 +21,9 @@ func doWithSigChainVersions(f func(libkb.SigVersion)) {
 }
 
 func TestTrackTokenIdentify2(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackTokenIdentify2(t, sigVersion)
-	})
-}
-func _testTrackTokenIdentify2(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	idUI := &FakeIdentifyUI{}
@@ -61,13 +57,9 @@ func _testTrackTokenIdentify2(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestTrackLocalThenLocalTemp(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackLocalThenLocalTemp(t, sigVersion)
-	})
-}
-func _testTrackLocalThenLocalTemp(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClock()
@@ -193,13 +185,9 @@ func _testTrackLocalThenLocalTemp(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestTrackRemoteThenLocalTemp(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackRemoteThenLocalTemp(t, sigVersion)
-	})
-}
-func _testTrackRemoteThenLocalTemp(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	// Tracking remote means we have to agree what time it is
@@ -322,14 +310,9 @@ func _testTrackRemoteThenLocalTemp(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestTrackFailTempRecover(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackFailTempRecover(t, sigVersion)
-	})
-}
-
-func _testTrackFailTempRecover(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClock()
@@ -464,14 +447,9 @@ func (d *FakeGregorDismisser) LocalDismissItem(ctx context.Context, id gregor.Ms
 }
 
 func TestTrackWithTokenDismissesGregor(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testTrackWithTokenDismissesGregor(t, sigVersion)
-	})
-}
-
-func _testTrackWithTokenDismissesGregor(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	dismisser := &FakeGregorDismisser{}

--- a/go/engine/untrack_test.go
+++ b/go/engine/untrack_test.go
@@ -112,13 +112,9 @@ func _testUntrack(t *testing.T, sigVersion libkb.SigVersion) {
 }
 
 func TestUntrackRemoteOnly(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testUntrackRemoteOnly(t, sigVersion)
-	})
-}
-func _testUntrackRemoteOnly(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "untrack")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 	fu := CreateAndSignupFakeUser(tc, "untrk")
 
 	sv := keybase1.SigVersion(sigVersion)

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -179,14 +179,9 @@ func TestLoadDeviceKeyRevoked(t *testing.T) {
 }
 
 func TestFullSelfCacherFlushSingleMachine(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testFullSelfCacherFlushSingleMachine(t, sigVersion)
-	})
-}
-
-func _testFullSelfCacherFlushSingleMachine(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "fsc")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	fu := CreateAndSignupFakeUser(tc, "fsc")
 
@@ -446,14 +441,9 @@ func TestLoadAfterAcctReset2(t *testing.T) {
 // logins in a row, right on top of each other, previous subchains
 // would be dropped from the self UPAK.
 func TestLoadAfterAcctResetCORE6943(t *testing.T) {
-	doWithSigChainVersions(func(sigVersion libkb.SigVersion) {
-		_testLoadAfterAcctResetCORE6943(t, sigVersion)
-	})
-}
-
-func _testLoadAfterAcctResetCORE6943(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "clu")
 	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	t.Logf("create new user")
 	fu := CreateAndSignupFakeUser(tc, "res")


### PR DESCRIPTION
With the introduction of sigchain v2 we initially chained all sig chain related tests to test against both versions. This isn't necessary for tests where the sigchain action isn't the primary focus of the test so we try to remove the double testing in places it seemed redundant. 

Starting runtime:
```
$ go test
PASS
ok      github.com/keybase/client/go/engine     406.909s
```

Only V1:
```
$ go test
PASS
ok      github.com/keybase/client/go/engine     327.448s
```

Only V2:
```
$ go test
PASS
ok      github.com/keybase/client/go/engine     311.891s
```

After cherrypicking:
```
$ go test
PASS
ok      github.com/keybase/client/go/engine     335.090s
```

cc @mmaxim