### PR TITLE
Center role picker

### DIFF
--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -43326,10 +43326,10 @@ exports[`Storyshots Team Roles ConfirmAdmin 1`] = `
         Object {
           "alignItems": "center",
           "display": "flex",
-          "flex": 1,
           "flexDirection": "column",
-          "minWidth": 480,
           "paddingBottom": 4,
+          "paddingLeft": 24,
+          "paddingRight": 24,
           "paddingTop": 4,
         }
       }
@@ -43986,10 +43986,10 @@ exports[`Storyshots Team Roles ConfirmOwner 1`] = `
         Object {
           "alignItems": "center",
           "display": "flex",
-          "flex": 1,
           "flexDirection": "column",
-          "minWidth": 480,
           "paddingBottom": 4,
+          "paddingLeft": 24,
+          "paddingRight": 24,
           "paddingTop": 4,
         }
       }
@@ -44624,10 +44624,10 @@ exports[`Storyshots Team Roles ConfirmReader 1`] = `
         Object {
           "alignItems": "center",
           "display": "flex",
-          "flex": 1,
           "flexDirection": "column",
-          "minWidth": 480,
           "paddingBottom": 4,
+          "paddingLeft": 24,
+          "paddingRight": 24,
           "paddingTop": 4,
         }
       }
@@ -45333,10 +45333,10 @@ exports[`Storyshots Team Roles ConfirmWriter 1`] = `
         Object {
           "alignItems": "center",
           "display": "flex",
-          "flex": 1,
           "flexDirection": "column",
-          "minWidth": 480,
           "paddingBottom": 4,
+          "paddingLeft": 24,
+          "paddingRight": 24,
           "paddingTop": 4,
         }
       }
@@ -45895,7 +45895,6 @@ exports[`Storyshots Team Roles Picker 1`] = `
   text-rendering: optimizeLegibility;
   font-family: OpenSans;
   font-weight: 400;
-  width: 267px;
 }
 
 .glamor-6,
@@ -45923,7 +45922,6 @@ exports[`Storyshots Team Roles Picker 1`] = `
   text-rendering: optimizeLegibility;
   font-family: OpenSans;
   font-weight: 400;
-  width: 267px;
 }
 
 .glamor-16,
@@ -45971,7 +45969,7 @@ exports[`Storyshots Team Roles Picker 1`] = `
           "alignItems": "center",
           "display": "flex",
           "flexDirection": "column",
-          "minWidth": 480,
+          "maxWidth": 400,
           "paddingBottom": 8,
           "paddingTop": 16,
         }
@@ -46009,7 +46007,7 @@ exports[`Storyshots Team Roles Picker 1`] = `
             "flexDirection": "row",
             "height": undefined,
             "lineHeight": 0,
-            "minWidth": 480,
+            "minWidth": undefined,
             "padding": 8,
             "paddingLeft": 16,
             "paddingRight": 40,
@@ -46017,6 +46015,7 @@ exports[`Storyshots Team Roles Picker 1`] = `
             "textAlign": "left",
             "transform": "none",
             "transition": "none",
+            "width": "100%",
           }
         }
       >
@@ -46120,7 +46119,7 @@ exports[`Storyshots Team Roles Picker 1`] = `
             "flexDirection": "row",
             "height": undefined,
             "lineHeight": 0,
-            "minWidth": 480,
+            "minWidth": undefined,
             "padding": 8,
             "paddingLeft": 16,
             "paddingRight": 40,
@@ -46128,6 +46127,7 @@ exports[`Storyshots Team Roles Picker 1`] = `
             "textAlign": "left",
             "transform": "none",
             "transition": "none",
+            "width": "100%",
           }
         }
       >
@@ -46231,7 +46231,7 @@ exports[`Storyshots Team Roles Picker 1`] = `
             "flexDirection": "row",
             "height": undefined,
             "lineHeight": 0,
-            "minWidth": 480,
+            "minWidth": undefined,
             "padding": 8,
             "paddingLeft": 16,
             "paddingRight": 40,
@@ -46239,6 +46239,7 @@ exports[`Storyshots Team Roles Picker 1`] = `
             "textAlign": "left",
             "transform": "none",
             "transition": "none",
+            "width": "100%",
           }
         }
       >
@@ -46317,7 +46318,7 @@ exports[`Storyshots Team Roles Picker 1`] = `
             "flexDirection": "row",
             "height": undefined,
             "lineHeight": 0,
-            "minWidth": 480,
+            "minWidth": undefined,
             "padding": 8,
             "paddingLeft": 16,
             "paddingRight": 40,
@@ -46325,6 +46326,7 @@ exports[`Storyshots Team Roles Picker 1`] = `
             "textAlign": "left",
             "transform": "none",
             "transition": "none",
+            "width": "100%",
           }
         }
       >

--- a/shared/teams/role-picker/index.js
+++ b/shared/teams/role-picker/index.js
@@ -50,7 +50,8 @@ const makeRoleOption = (
       ...globalStyles.flexBoxRow,
       alignItems: 'center',
       backgroundColor: selected === role ? globalColors.blue : globalColors.white,
-      minWidth: 480,
+      width: '100%',
+      borderRadius: 0,
       padding: globalMargins.tiny,
       paddingLeft: globalMargins.small,
       paddingRight: globalMargins.large,
@@ -74,10 +75,7 @@ const makeRoleOption = (
           {typeToLabel[role]}
         </Text>
       </Box>
-      <Text
-        style={{color: selected === role ? globalColors.white : globalColors.black_40, width: 267}}
-        type="BodySmall"
-      >
+      <Text style={{color: selected === role ? globalColors.white : globalColors.black_40}} type="BodySmall">
         {role && roleDescMap[role]}
       </Text>
     </Box>
@@ -103,7 +101,7 @@ export const RoleOptions = ({
     style={{
       ...globalStyles.flexBoxColumn,
       alignItems: 'center',
-      minWidth: 480,
+      maxWidth: 400,
       paddingTop: globalMargins.small,
       paddingBottom: globalMargins.tiny,
     }}
@@ -183,10 +181,10 @@ export const RoleConfirm = ({
       style={{
         ...globalStyles.flexBoxColumn,
         alignItems: 'center',
-        flex: 1,
-        minWidth: 480,
         paddingTop: globalMargins.xtiny,
         paddingBottom: globalMargins.xtiny,
+        paddingLeft: globalMargins.medium,
+        paddingRight: globalMargins.medium,
       }}
     >
       <Box


### PR DESCRIPTION
Shuffles some styles to re-center the role picker on mobile.

5S simulator:
<img src="https://user-images.githubusercontent.com/11968340/36814782-9e474e60-1ca6-11e8-9dec-c00244a00143.png" width="300px" />

desktop:
<img width="712" alt="image" src="https://user-images.githubusercontent.com/11968340/36814815-bba6db24-1ca6-11e8-9905-87e1b66e521f.png">