### PR TITLE
reader support for new merkle-signing key

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -134,9 +134,11 @@ const RemoteIdentifyUITimeout = 5 * time.Second
 
 var MerkleProdKIDs = []string{
 	"010159baae6c7d43c66adf8fb7bb2b8b4cbe408c062cfc369e693ccb18f85631dbcd0a",
+	"01209ec31411b9b287f62630c2486005af27548ba62a59bbc802e656b888991a20230a",
 }
 var MerkleTestKIDs = []string{
 	"0101be58b6c82db64f6ccabb05088db443c69f87d5d48857d709ed6f73948dabe67d0a",
+	"0120328031cf9d2a6108036408aeb3646b8985f7f8ff1a8e635e829d248a48b1014d0a",
 }
 var MerkleStagingKIDs = []string{
 	"0101bed85ce72cc315828367c28b41af585b6b7d95646a62ca829691d70f49184fa70a",

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -312,10 +312,6 @@ type MerkleRootPayloadUnpacked struct {
 				Version *int    `json:"version"`
 			} `json:"public"`
 		} `json:"kbfs"`
-		Key struct {
-			Fingerprint PGPFingerprint `json:"fingerprint"`
-			KeyID       string         `json:"key_id"`
-		} `json:"key"`
 		LegacyUIDRoot NodeHashShort  `json:"legacy_uid_root"`
 		Prev          NodeHashLong   `json:"prev"`
 		Root          NodeHashLong   `json:"root"`


### PR DESCRIPTION
- new key is an EdDSA key
- therefore don't use the PGP-specific fields in the merkle root, they weren't checked anyways
- prepare current clients (test and prod) for the new keys, though it'll be a while before we roll this out