### PR TITLE
Iterate on the actions row in the teams page

### DIFF
--- a/shared/common-adapters/button.js
+++ b/shared/common-adapters/button.js
@@ -86,6 +86,7 @@ class Button extends Component<Props> {
         <Box
           style={{
             ...globalStyles.flexBoxCenter,
+            ...globalStyles.flexBoxRow,
             position: 'relative',
             height: '100%',
           }}

--- a/shared/common-adapters/button.js
+++ b/shared/common-adapters/button.js
@@ -2,16 +2,17 @@
 import Box from './box'
 import ClickableBox from './clickable-box'
 import ProgressIndicator from './progress-indicator'
-import React, {Component} from 'react'
+import React, {Component, type Node} from 'react'
 import Text from './text'
 import {globalColors, globalStyles, globalMargins, isMobile} from '../styles'
 
 export type Props = {
+  children?: Node,
   onClick: ?(event: SyntheticEvent<>) => void,
   onPress?: void,
   onMouseEnter?: Function,
   onMouseLeave?: Function,
-  label: ?string,
+  label?: ?string,
   style?: ?Object,
   labelStyle?: ?Object,
   type: 'Primary' | 'PrimaryPrivate' | 'Secondary' | 'Danger' | 'PrimaryGreen' | 'PrimaryGreenActive',
@@ -89,12 +90,15 @@ class Button extends Component<Props> {
             height: '100%',
           }}
         >
-          <Text
-            type={this.props.small ? 'BodySemibold' : 'BodyBig'}
-            style={{...labelStyle, ...this.props.labelStyle}}
-          >
-            {this.props.label}
-          </Text>
+          {this.props.children}
+          {!this.props.children && (
+            <Text
+              type={this.props.small ? 'BodySemibold' : 'BodyBig'}
+              style={{...labelStyle, ...this.props.labelStyle}}
+            >
+              {this.props.label}
+            </Text>
+          )}
           {this.props.waiting && <Progress small={this.props.small} />}
         </Box>
       </ClickableBox>

--- a/shared/common-adapters/button.js
+++ b/shared/common-adapters/button.js
@@ -2,17 +2,17 @@
 import Box from './box'
 import ClickableBox from './clickable-box'
 import ProgressIndicator from './progress-indicator'
-import React, {Component, type Node} from 'react'
+import * as React from 'react'
 import Text from './text'
 import {globalColors, globalStyles, globalMargins, isMobile} from '../styles'
 
 export type Props = {
-  children?: Node,
+  children?: React.Node,
   onClick: ?(event: SyntheticEvent<>) => void,
   onPress?: void,
   onMouseEnter?: Function,
   onMouseLeave?: Function,
-  label?: ?string,
+  label: ?string,
   style?: ?Object,
   labelStyle?: ?Object,
   type: 'Primary' | 'PrimaryPrivate' | 'Secondary' | 'Danger' | 'PrimaryGreen' | 'PrimaryGreenActive',
@@ -30,7 +30,7 @@ const Progress = ({small}) => (
   </Box>
 )
 
-class Button extends Component<Props> {
+class Button extends React.Component<Props> {
   render() {
     const backgroundModeName = this.props.backgroundMode
       ? {
@@ -92,14 +92,12 @@ class Button extends Component<Props> {
           }}
         >
           {this.props.children}
-          {!this.props.children && (
-            <Text
-              type={this.props.small ? 'BodySemibold' : 'BodyBig'}
-              style={{...labelStyle, ...this.props.labelStyle}}
-            >
-              {this.props.label}
-            </Text>
-          )}
+          <Text
+            type={this.props.small ? 'BodySemibold' : 'BodyBig'}
+            style={{...labelStyle, ...this.props.labelStyle}}
+          >
+            {this.props.label}
+          </Text>
           {this.props.waiting && <Progress small={this.props.small} />}
         </Box>
       </ClickableBox>

--- a/shared/common-adapters/button.js
+++ b/shared/common-adapters/button.js
@@ -85,19 +85,21 @@ class Button extends React.Component<Props> {
       <ClickableBox style={containerStyle} onClick={onClick}>
         <Box
           style={{
-            ...globalStyles.flexBoxCenter,
             ...globalStyles.flexBoxRow,
+            ...globalStyles.flexBoxCenter,
             position: 'relative',
             height: '100%',
           }}
         >
-          {this.props.children}
-          <Text
-            type={this.props.small ? 'BodySemibold' : 'BodyBig'}
-            style={{...labelStyle, ...this.props.labelStyle}}
-          >
-            {this.props.label}
-          </Text>
+          {!this.props.waiting && this.props.children}
+          {!this.props.waiting && (
+            <Text
+              type={this.props.small ? 'BodySemibold' : 'BodyBig'}
+              style={{...labelStyle, ...this.props.labelStyle}}
+            >
+              {this.props.label}
+            </Text>
+          )}
           {this.props.waiting && <Progress small={this.props.small} />}
         </Box>
       </ClickableBox>
@@ -172,8 +174,6 @@ const DangerLabel = commonLabel
 const Custom = {}
 const CustomLabel = {color: globalColors.black_75, textAlign: 'center'}
 const progressStyle = small => (isMobile ? undefined : {height: small ? 20 : 20})
-const progress = isMobile
-  ? {marginTop: -regularHeight / 2}
-  : {...globalStyles.fillAbsolute, ...globalStyles.flexBoxCenter}
+const progress = isMobile ? null : {...globalStyles.fillAbsolute, ...globalStyles.flexBoxCenter}
 
 export default Button

--- a/shared/common-adapters/popup-menu.native.js
+++ b/shared/common-adapters/popup-menu.native.js
@@ -19,8 +19,8 @@ const MenuRow = (props: MenuItemProps) => (
   <TouchableOpacity
     disabled={!props.onClick}
     onPress={() => {
+      props.onHidden() // auto hide when making a selection
       props.onClick && props.onClick()
-      props.onHidden() // auto hide after a selection
     }}
     style={{...styleRow(props), ...props.style}}
   >

--- a/shared/common-adapters/user-actions.js
+++ b/shared/common-adapters/user-actions.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import type {Props} from './user-actions'
-import {Button, FollowButton, ButtonBar, Icon, Text} from '../common-adapters'
+import {Button, FollowButton, ButtonBar, Icon} from '../common-adapters'
 import {normal as proofNormal} from '../constants/tracker'
 import {globalColors} from '../styles'
 
@@ -20,7 +20,7 @@ function UserActions({
       return (
         <ButtonBar style={style}>
           <FollowButton following={true} onUnfollow={onUnfollow} waiting={waiting} />
-          <Button type="Primary" onClick={onChat} style={{marginRight: 0}}>
+          <Button type="Primary" label="Chat" onClick={onChat} style={{marginRight: 0}}>
             <Icon
               type="iconfont-chat"
               style={{
@@ -28,9 +28,6 @@ function UserActions({
                 color: globalColors.white,
               }}
             />
-            <Text type="BodyBig" backgroundMode="Announcements">
-              Chat
-            </Text>
           </Button>
         </ButtonBar>
       )
@@ -46,7 +43,7 @@ function UserActions({
     return (
       <ButtonBar style={style}>
         <FollowButton following={false} onFollow={onFollow} waiting={waiting} />
-        <Button type="Primary" onClick={onChat} style={{marginRight: 0}}>
+        <Button label="Chat" type="Primary" onClick={onChat} style={{marginRight: 0}}>
           <Icon
             type="iconfont-chat"
             style={{
@@ -54,9 +51,6 @@ function UserActions({
               color: globalColors.white,
             }}
           />
-          <Text type="BodyBig" backgroundMode="Announcements">
-            Chat
-          </Text>
         </Button>
       </ButtonBar>
     )

--- a/shared/common-adapters/user-actions.js
+++ b/shared/common-adapters/user-actions.js
@@ -1,8 +1,9 @@
 // @flow
 import * as React from 'react'
 import type {Props} from './user-actions'
-import {Button, FollowButton, ButtonBar} from '../common-adapters'
+import {Button, FollowButton, ButtonBar, Icon, Text} from '../common-adapters'
 import {normal as proofNormal} from '../constants/tracker'
+import {globalColors} from '../styles'
 
 function UserActions({
   trackerState,
@@ -19,7 +20,18 @@ function UserActions({
       return (
         <ButtonBar style={style}>
           <FollowButton following={true} onUnfollow={onUnfollow} waiting={waiting} />
-          <Button type="Primary" label="Start a Chat" onClick={onChat} style={{marginRight: 0}} />
+          <Button type="Primary" onClick={onChat} style={{marginRight: 0}}>
+            <Icon
+              type="iconfont-chat"
+              style={{
+                marginRight: 8,
+                color: globalColors.white,
+              }}
+            />
+            <Text type="BodyBig" backgroundMode="Announcements">
+              Chat
+            </Text>
+          </Button>
         </ButtonBar>
       )
     } else {
@@ -34,7 +46,18 @@ function UserActions({
     return (
       <ButtonBar style={style}>
         <FollowButton following={false} onFollow={onFollow} waiting={waiting} />
-        <Button type="Primary" label="Start a Chat" onClick={onChat} style={{marginRight: 0}} />
+        <Button type="Primary" onClick={onChat} style={{marginRight: 0}}>
+          <Icon
+            type="iconfont-chat"
+            style={{
+              marginRight: 8,
+              color: globalColors.white,
+            }}
+          />
+          <Text type="BodyBig" backgroundMode="Announcements">
+            Chat
+          </Text>
+        </Button>
       </ButtonBar>
     )
   }

--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -148,6 +148,7 @@ exports[`Storyshots Chat/Channel Heads up Display Mention Hud 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -204,6 +205,7 @@ exports[`Storyshots Chat/Channel Heads up Display Mention Hud 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -2878,6 +2880,7 @@ exports[`Storyshots Chat/Heads up Display Mention Hud 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -2934,6 +2937,7 @@ exports[`Storyshots Chat/Heads up Display Mention Hud 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -6705,6 +6709,7 @@ exports[`Storyshots Chat/Teams CreateChannel 1`] = `
                       Object {
                         "alignItems": "center",
                         "display": "flex",
+                        "flexDirection": "row",
                         "height": "100%",
                         "justifyContent": "center",
                         "position": "relative",
@@ -6761,6 +6766,7 @@ exports[`Storyshots Chat/Teams CreateChannel 1`] = `
                       Object {
                         "alignItems": "center",
                         "display": "flex",
+                        "flexDirection": "row",
                         "height": "100%",
                         "justifyContent": "center",
                         "position": "relative",
@@ -7215,6 +7221,7 @@ exports[`Storyshots Chat/Teams EditChannel - general 1`] = `
                   Object {
                     "alignItems": "center",
                     "display": "flex",
+                    "flexDirection": "row",
                     "height": "100%",
                     "justifyContent": "center",
                     "position": "relative",
@@ -7272,6 +7279,7 @@ exports[`Storyshots Chat/Teams EditChannel - general 1`] = `
                   Object {
                     "alignItems": "center",
                     "display": "flex",
+                    "flexDirection": "row",
                     "height": "100%",
                     "justifyContent": "center",
                     "position": "relative",
@@ -7702,6 +7710,7 @@ exports[`Storyshots Chat/Teams EditChannel 1`] = `
                   Object {
                     "alignItems": "center",
                     "display": "flex",
+                    "flexDirection": "row",
                     "height": "100%",
                     "justifyContent": "center",
                     "position": "relative",
@@ -7759,6 +7768,7 @@ exports[`Storyshots Chat/Teams EditChannel 1`] = `
                   Object {
                     "alignItems": "center",
                     "display": "flex",
+                    "flexDirection": "row",
                     "height": "100%",
                     "justifyContent": "center",
                     "position": "relative",
@@ -9171,6 +9181,7 @@ exports[`Storyshots Chat/Teams ManageChannels - Unsaved Subscription 1`] = `
                         Object {
                           "alignItems": "center",
                           "display": "flex",
+                          "flexDirection": "row",
                           "height": "100%",
                           "justifyContent": "center",
                           "position": "relative",
@@ -9228,6 +9239,7 @@ exports[`Storyshots Chat/Teams ManageChannels - Unsaved Subscription 1`] = `
                         Object {
                           "alignItems": "center",
                           "display": "flex",
+                          "flexDirection": "row",
                           "height": "100%",
                           "justifyContent": "center",
                           "position": "relative",
@@ -10992,6 +11004,7 @@ exports[`Storyshots Chat/Teams ManageChannels 1`] = `
                         Object {
                           "alignItems": "center",
                           "display": "flex",
+                          "flexDirection": "row",
                           "height": "100%",
                           "justifyContent": "center",
                           "position": "relative",
@@ -11049,6 +11062,7 @@ exports[`Storyshots Chat/Teams ManageChannels 1`] = `
                         Object {
                           "alignItems": "center",
                           "display": "flex",
+                          "flexDirection": "row",
                           "height": "100%",
                           "justifyContent": "center",
                           "position": "relative",
@@ -13957,6 +13971,7 @@ exports[`Storyshots Common Button 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -14013,6 +14028,7 @@ exports[`Storyshots Common Button 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -14080,6 +14096,7 @@ exports[`Storyshots Common Button 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -14136,6 +14153,7 @@ exports[`Storyshots Common Button 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -14203,6 +14221,7 @@ exports[`Storyshots Common Button 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -14259,6 +14278,7 @@ exports[`Storyshots Common Button 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -14326,6 +14346,7 @@ exports[`Storyshots Common Button 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -14382,6 +14403,7 @@ exports[`Storyshots Common Button 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -14452,6 +14474,7 @@ exports[`Storyshots Common Button 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -14511,6 +14534,7 @@ exports[`Storyshots Common Button 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -14572,6 +14596,7 @@ exports[`Storyshots Common Button 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -14627,6 +14652,7 @@ exports[`Storyshots Common Button 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -14682,6 +14708,7 @@ exports[`Storyshots Common Button 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -14737,6 +14764,7 @@ exports[`Storyshots Common Button 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -14795,6 +14823,7 @@ exports[`Storyshots Common Button 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -14944,6 +14973,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15008,6 +15038,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15064,6 +15095,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15134,6 +15166,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15212,6 +15245,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15268,6 +15302,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15340,6 +15375,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15404,6 +15440,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15468,6 +15505,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15532,6 +15570,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15588,6 +15627,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -15658,6 +15698,7 @@ exports[`Storyshots Common ButtonBar 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -26282,6 +26323,7 @@ exports[`Storyshots Edit team description Description changed 1`] = `
                       Object {
                         "alignItems": "center",
                         "display": "flex",
+                        "flexDirection": "row",
                         "height": "100%",
                         "justifyContent": "center",
                         "position": "relative",
@@ -26338,6 +26380,7 @@ exports[`Storyshots Edit team description Description changed 1`] = `
                       Object {
                         "alignItems": "center",
                         "display": "flex",
+                        "flexDirection": "row",
                         "height": "100%",
                         "justifyContent": "center",
                         "position": "relative",
@@ -26717,6 +26760,7 @@ exports[`Storyshots Edit team description Description unchanged 1`] = `
                       Object {
                         "alignItems": "center",
                         "display": "flex",
+                        "flexDirection": "row",
                         "height": "100%",
                         "justifyContent": "center",
                         "position": "relative",
@@ -26773,6 +26817,7 @@ exports[`Storyshots Edit team description Description unchanged 1`] = `
                       Object {
                         "alignItems": "center",
                         "display": "flex",
+                        "flexDirection": "row",
                         "height": "100%",
                         "justifyContent": "center",
                         "position": "relative",
@@ -27190,6 +27235,7 @@ exports[`Storyshots Git DeleteRepo 1`] = `
                     Object {
                       "alignItems": "center",
                       "display": "flex",
+                      "flexDirection": "row",
                       "height": "100%",
                       "justifyContent": "center",
                       "position": "relative",
@@ -27238,6 +27284,7 @@ exports[`Storyshots Git DeleteRepo 1`] = `
                     Object {
                       "alignItems": "center",
                       "display": "flex",
+                      "flexDirection": "row",
                       "height": "100%",
                       "justifyContent": "center",
                       "position": "relative",
@@ -27683,6 +27730,7 @@ exports[`Storyshots Git DeleteTeamRepo 1`] = `
                     Object {
                       "alignItems": "center",
                       "display": "flex",
+                      "flexDirection": "row",
                       "height": "100%",
                       "justifyContent": "center",
                       "position": "relative",
@@ -27731,6 +27779,7 @@ exports[`Storyshots Git DeleteTeamRepo 1`] = `
                     Object {
                       "alignItems": "center",
                       "display": "flex",
+                      "flexDirection": "row",
                       "height": "100%",
                       "justifyContent": "center",
                       "position": "relative",
@@ -27999,6 +28048,7 @@ exports[`Storyshots Git NewPersonalRepo 1`] = `
                     Object {
                       "alignItems": "center",
                       "display": "flex",
+                      "flexDirection": "row",
                       "height": "100%",
                       "justifyContent": "center",
                       "position": "relative",
@@ -28047,6 +28097,7 @@ exports[`Storyshots Git NewPersonalRepo 1`] = `
                     Object {
                       "alignItems": "center",
                       "display": "flex",
+                      "flexDirection": "row",
                       "height": "100%",
                       "justifyContent": "center",
                       "position": "relative",
@@ -28508,6 +28559,7 @@ exports[`Storyshots Git NewTeamRepo 1`] = `
                     Object {
                       "alignItems": "center",
                       "display": "flex",
+                      "flexDirection": "row",
                       "height": "100%",
                       "justifyContent": "center",
                       "position": "relative",
@@ -28556,6 +28608,7 @@ exports[`Storyshots Git NewTeamRepo 1`] = `
                     Object {
                       "alignItems": "center",
                       "display": "flex",
+                      "flexDirection": "row",
                       "height": "100%",
                       "justifyContent": "center",
                       "position": "relative",
@@ -32599,6 +32652,7 @@ exports[`Storyshots People/Todos Chat 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -32796,6 +32850,7 @@ exports[`Storyshots People/Todos Fill out bio 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -32998,6 +33053,7 @@ exports[`Storyshots People/Todos Follow someone 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -33207,6 +33263,7 @@ exports[`Storyshots People/Todos Install on phone 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -33416,6 +33473,7 @@ exports[`Storyshots People/Todos Make a folder 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -33625,6 +33683,7 @@ exports[`Storyshots People/Todos Make a git 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -33822,6 +33881,7 @@ exports[`Storyshots People/Todos Make a paper key 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -34024,6 +34084,7 @@ exports[`Storyshots People/Todos Make a team 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -34233,6 +34294,7 @@ exports[`Storyshots People/Todos Prove something 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -34442,6 +34504,7 @@ exports[`Storyshots People/Todos Set publicity 1`] = `
                 Object {
                   "alignItems": "center",
                   "display": "flex",
+                  "flexDirection": "row",
                   "height": "100%",
                   "justifyContent": "center",
                   "position": "relative",
@@ -43769,6 +43832,7 @@ exports[`Storyshots Team Roles ConfirmAdmin 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -43825,6 +43889,7 @@ exports[`Storyshots Team Roles ConfirmAdmin 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -44402,6 +44467,7 @@ exports[`Storyshots Team Roles ConfirmOwner 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -44458,6 +44524,7 @@ exports[`Storyshots Team Roles ConfirmOwner 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -45111,6 +45178,7 @@ exports[`Storyshots Team Roles ConfirmReader 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -45167,6 +45235,7 @@ exports[`Storyshots Team Roles ConfirmReader 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -45776,6 +45845,7 @@ exports[`Storyshots Team Roles ConfirmWriter 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -45832,6 +45902,7 @@ exports[`Storyshots Team Roles ConfirmWriter 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",
@@ -46502,6 +46573,7 @@ exports[`Storyshots Team Roles Picker 1`] = `
               Object {
                 "alignItems": "center",
                 "display": "flex",
+                "flexDirection": "row",
                 "height": "100%",
                 "justifyContent": "center",
                 "position": "relative",

--- a/shared/teams/routes.js
+++ b/shared/teams/routes.js
@@ -3,6 +3,7 @@ import TeamsContainer from './container'
 import {MaybePopupHoc} from '../common-adapters'
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import AddPeopleDialog from './add-people/container'
+import AddPeopleHow from './team/header/add-people-how/container'
 import InviteByEmailDialog from './invite-by-email/container'
 import NewTeamDialog from './new-team/container'
 import JoinTeamDialog from './join-team/container'
@@ -16,6 +17,7 @@ import ControlledRolePicker from './role-picker/controlled-container'
 import Member from './team/member/container'
 import ReallyRemoveMember from './team/really-remove-member/container'
 import Team from './team/container'
+import RelativePopupHoc from '../common-adapters/relative-popup-hoc'
 import {isMobile} from '../constants/platform'
 
 const makeManageChannels = {
@@ -64,6 +66,19 @@ const showNewTeamDialog = {
   tags: makeLeafTags({layerOnTop: !isMobile}),
 }
 
+const addPeopleOptions = {
+  addPeople: {
+    children: {controlledRolePicker},
+    component: AddPeopleDialog,
+    tags: makeLeafTags({layerOnTop: !isMobile}),
+  },
+  inviteByEmail: {
+    children: {controlledRolePicker},
+    component: InviteByEmailDialog,
+    tags: makeLeafTags({layerOnTop: !isMobile}),
+  },
+}
+
 const teamRoute = makeRouteDefNode({
   children: {
     ...makeManageChannels,
@@ -80,6 +95,11 @@ const teamRoute = makeRouteDefNode({
         reallyRemoveMember,
       },
       component: Member,
+    },
+    addPeopleHow: {
+      children: addPeopleOptions,
+      component: isMobile ? AddPeopleHow : RelativePopupHoc(AddPeopleHow),
+      tags: makeLeafTags({layerOnTop: true}),
     },
     addPeople: {
       children: {controlledRolePicker},

--- a/shared/teams/routes.js
+++ b/shared/teams/routes.js
@@ -66,7 +66,7 @@ const showNewTeamDialog = {
   tags: makeLeafTags({layerOnTop: !isMobile}),
 }
 
-const addPeopleOptions = {
+const makeAddPeopleOptions = {
   addPeople: {
     children: {controlledRolePicker},
     component: AddPeopleDialog,
@@ -82,6 +82,7 @@ const addPeopleOptions = {
 const teamRoute = makeRouteDefNode({
   children: {
     ...makeManageChannels,
+    ...makeAddPeopleOptions,
     controlledRolePicker,
     rolePicker,
     reallyLeaveTeam,
@@ -97,19 +98,9 @@ const teamRoute = makeRouteDefNode({
       component: Member,
     },
     addPeopleHow: {
-      children: addPeopleOptions,
+      children: {},
       component: isMobile ? AddPeopleHow : RelativePopupHoc(AddPeopleHow),
       tags: makeLeafTags({layerOnTop: true}),
-    },
-    addPeople: {
-      children: {controlledRolePicker},
-      component: AddPeopleDialog,
-      tags: makeLeafTags({layerOnTop: !isMobile}),
-    },
-    inviteByEmail: {
-      children: {controlledRolePicker},
-      component: InviteByEmailDialog,
-      tags: makeLeafTags({layerOnTop: !isMobile}),
     },
     editTeamDescription: {
       children: {},

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -4,6 +4,7 @@ import * as I from 'immutable'
 import * as React from 'react'
 import * as TeamsGen from '../../actions/teams-gen'
 import * as KBFSGen from '../../actions/kbfs-gen'
+import * as ChatGen from '../../actions/chat-gen'
 import Team, {CustomComponent} from '.'
 import {HeaderHoc} from '../../common-adapters'
 import {branch, connect, withStateHandlers, lifecycle, compose, type TypedState} from '../../util/container'
@@ -49,6 +50,7 @@ const mapDispatchToProps = (
   return {
     setSelectedTab: selectedTab => setRouteState({selectedTab}),
     onManageChat: () => dispatch(navigateAppend([{props: {teamname}, selected: 'manageChannels'}])),
+    onChat: () => dispatch(ChatGen.createOpenTeamConversation({teamname, channelname: 'general'})),
     onLeaveTeam: () => dispatch(navigateAppend([{props: {teamname}, selected: 'reallyLeaveTeam'}])),
     onCreateSubteam: () =>
       dispatch(navigateAppend([{props: {name: teamname}, selected: 'showNewTeamDialog'}])),
@@ -63,9 +65,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const customComponent = (
     <CustomComponent
       onOpenFolder={dispatchProps.onOpenFolder}
-      onManageChat={dispatchProps.onManageChat}
+      onChat={dispatchProps.onChat}
       onShowMenu={() => ownProps.setShowMenu(!ownProps.showMenu)}
-      canManageChat={stateProps.yourOperations.createChannel}
+      canChat={!stateProps.yourOperations.joinTeam}
       canViewFolder={!stateProps.yourOperations.joinTeam}
     />
   )

--- a/shared/teams/team/header/add-people-how/container.js
+++ b/shared/teams/team/header/add-people-how/container.js
@@ -1,12 +1,19 @@
 // @flow
 import {connect} from '../../../../util/container'
 import {AddPeopleHow} from '.'
-import {navigateUp} from '../../../../actions/route-tree'
+import {navigateTo, navigateUp} from '../../../../actions/route-tree'
+import {teamsTab} from '../../../../constants/tabs'
 
-const mapStateToProps = () => ({})
+const mapDispatchToProps = (dispatch: Dispatch, {routeProps}) => {
+  const teamname = routeProps.get('teamname')
+  return {
+    onAddPeople: () => dispatch(navigateTo([{selected: 'addPeople', props: {teamname}}], [teamsTab, 'team'])),
+    onClose: () => {
+      dispatch(navigateUp())
+    },
+    onInvite: () =>
+      dispatch(navigateTo([{selected: 'inviteByEmail', props: {teamname}}], [teamsTab, 'team'])),
+  }
+}
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  onClose: () => dispatch(navigateUp()),
-})
-
-export default connect(mapStateToProps, mapDispatchToProps)(AddPeopleHow)
+export default connect(undefined, mapDispatchToProps)(AddPeopleHow)

--- a/shared/teams/team/header/add-people-how/container.js
+++ b/shared/teams/team/header/add-people-how/container.js
@@ -1,0 +1,12 @@
+// @flow
+import {connect} from '../../../../util/container'
+import {AddPeopleHow} from '.'
+import {navigateUp} from '../../../../actions/route-tree'
+
+const mapStateToProps = () => ({})
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onClose: () => dispatch(navigateUp()),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(AddPeopleHow)

--- a/shared/teams/team/header/add-people-how/index.js
+++ b/shared/teams/team/header/add-people-how/index.js
@@ -1,16 +1,19 @@
 // @flow
 import * as React from 'react'
-import {Text} from '../../../../common-adapters'
 import PopupMenu, {ModalLessPopupMenu} from '../../../../common-adapters/popup-menu'
 import {isMobile} from '../../../../styles'
 
 type Props = {
-  label: string,
+  onAddPeople: () => void,
   onClose: () => void,
+  onInvite: () => void,
 }
 
 const AddPeopleHow = (props: Props) => {
-  const items = [{title: 'thing', view: <Text type="BodySemibold">Hi!</Text>}]
+  const items = [
+    {title: 'By username', subTitle: 'Keybase, Twitter, etc.', onClick: props.onAddPeople},
+    {title: isMobile ? 'From address book' : 'By email', onClick: props.onInvite},
+  ]
 
   return isMobile ? (
     <PopupMenu onHidden={props.onClose} style={{overflow: 'visible'}} items={items} />

--- a/shared/teams/team/header/add-people-how/index.js
+++ b/shared/teams/team/header/add-people-how/index.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from 'react'
+import {Text} from '../../../../common-adapters'
+import PopupMenu, {ModalLessPopupMenu} from '../../../../common-adapters/popup-menu'
+import {isMobile} from '../../../../styles'
+
+type Props = {
+  label: string,
+  onClose: () => void,
+}
+
+const AddPeopleHow = (props: Props) => {
+  const items = [{title: 'thing', view: <Text type="BodySemibold">Hi!</Text>}]
+
+  return isMobile ? (
+    <PopupMenu onHidden={props.onClose} style={{overflow: 'visible'}} items={items} />
+  ) : (
+    <ModalLessPopupMenu onHidden={() => {}} style={{overflow: 'visible', width: 200}} items={items} />
+  )
+}
+
+export {AddPeopleHow}

--- a/shared/teams/team/header/container.js
+++ b/shared/teams/team/header/container.js
@@ -33,7 +33,15 @@ const mapDispatchToProps = (dispatch: Dispatch, {teamname}: OwnProps) => ({
     dispatch(navigateAppend([{props: {teamname}, selected: 'addPeople'}]))
     dispatch(createAddResultsToUserInput({searchKey: 'addToTeamSearch', searchResults: [you]}))
   },
-  onAddPeople: () => dispatch(navigateAppend([{props: {teamname}, selected: 'addPeople'}])),
+  onAddPeople: target =>
+    dispatch(
+      navigateAppend([
+        {
+          props: {teamname, position: 'bottom left', targetRect: target && target.getBoundingClientRect()},
+          selected: 'addPeopleHow',
+        },
+      ])
+    ),
   onChat: () => dispatch(createOpenTeamConversation({teamname, channelname: 'general'})),
   onEditDescription: () => dispatch(navigateAppend([{props: {teamname}, selected: 'editTeamDescription'}])),
   onInviteByEmail: () => dispatch(navigateAppend([{props: {teamname}, selected: 'inviteByEmail'}])),

--- a/shared/teams/team/header/container.js
+++ b/shared/teams/team/header/container.js
@@ -44,7 +44,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {teamname}: OwnProps) => ({
     ),
   onChat: () => dispatch(createOpenTeamConversation({teamname, channelname: 'general'})),
   onEditDescription: () => dispatch(navigateAppend([{props: {teamname}, selected: 'editTeamDescription'}])),
-  onInviteByEmail: () => dispatch(navigateAppend([{props: {teamname}, selected: 'inviteByEmail'}])),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({

--- a/shared/teams/team/header/index.js
+++ b/shared/teams/team/header/index.js
@@ -73,7 +73,7 @@ const TeamHeader = (props: Props) => (
 
       {/* Actions */}
       <ButtonBar direction="row" style={isMobile ? {width: 'auto', marginBottom: -8} : undefined}>
-        <Button type="Primary" onClick={props.onChat}>
+        <Button type="Primary" label="Chat" onClick={props.onChat}>
           <Icon
             type="iconfont-chat"
             style={{
@@ -81,9 +81,6 @@ const TeamHeader = (props: Props) => (
               color: globalColors.white,
             }}
           />
-          <Text type="BodyBig" backgroundMode="Announcements">
-            Chat
-          </Text>
         </Button>
         {props.canManageMembers && (
           <Button

--- a/shared/teams/team/header/index.js
+++ b/shared/teams/team/header/index.js
@@ -4,7 +4,6 @@ import * as Constants from '../../../constants/teams'
 import * as Types from '../../../constants/types/teams'
 import {Avatar, Box, Button, ButtonBar, Icon, Meta, Text} from '../../../common-adapters'
 import {globalColors, globalMargins, globalStyles, isMobile} from '../../../styles'
-import {isLargeScreen} from '../../../constants/platform'
 
 export type Props = {
   canEditDescription: boolean,
@@ -20,7 +19,6 @@ export type Props = {
   onAddSelf: () => void,
   onChat: () => void,
   onEditDescription: () => void,
-  onInviteByEmail: () => void,
 }
 
 const TeamHeader = (props: Props) => (
@@ -90,14 +88,7 @@ const TeamHeader = (props: Props) => (
         <Button
           type="Primary"
           label={'Add people'}
-          small={isMobile && !isLargeScreen}
           onClick={event => props.onAddPeople(isMobile ? undefined : event.target)}
-        />
-        <Button
-          type="Secondary"
-          label={isMobile ? 'Invite contacts' : 'Invite by email'}
-          small={isMobile && !isLargeScreen}
-          onClick={props.onInviteByEmail}
         />
       </ButtonBar>
 

--- a/shared/teams/team/header/index.js
+++ b/shared/teams/team/header/index.js
@@ -16,7 +16,7 @@ export type Props = {
   role: ?Types.TeamRoleType,
   teamname: string,
 
-  onAddPeople: () => void,
+  onAddPeople: (target?: any) => void,
   onAddSelf: () => void,
   onChat: () => void,
   onEditDescription: () => void,
@@ -75,11 +75,23 @@ const TeamHeader = (props: Props) => (
 
       {/* Actions */}
       <ButtonBar direction="row" style={isMobile ? {width: 'auto', marginBottom: -8} : undefined}>
+        <Button type="Primary" onClick={props.onChat}>
+          <Icon
+            type="iconfont-chat"
+            style={{
+              marginRight: 8,
+              color: globalColors.white,
+            }}
+          />
+          <Text type="BodyBig" backgroundMode="Announcements">
+            Chat
+          </Text>
+        </Button>
         <Button
           type="Primary"
           label={'Add people'}
           small={isMobile && !isLargeScreen}
-          onClick={props.onAddPeople}
+          onClick={event => props.onAddPeople(isMobile ? undefined : event.target)}
         />
         <Button
           type="Secondary"
@@ -87,15 +99,6 @@ const TeamHeader = (props: Props) => (
           small={isMobile && !isLargeScreen}
           onClick={props.onInviteByEmail}
         />
-        {!isMobile && <Button type="Secondary" label="Chat" onClick={props.onChat} />}
-        {isMobile &&
-          !props.canJoinTeam && (
-            <Icon
-              type="iconfont-chat"
-              style={{width: isLargeScreen ? 24 : 20, height: isLargeScreen ? 24 : 20}}
-              onClick={props.onChat}
-            />
-          )}
       </ButtonBar>
 
       {/* CLI hint */}

--- a/shared/teams/team/header/index.js
+++ b/shared/teams/team/header/index.js
@@ -55,15 +55,15 @@ const TeamHeader = (props: Props) => (
       </Text>
 
       {/* Description */}
-      {!props.loading && (props.canEdit || props.description) ? (
+      {!props.loading && (props.canEditDescription || props.description) ? (
         <Text
           style={{
             paddingTop: globalMargins.tiny,
             color: props.description ? globalColors.black_75 : globalColors.black_20,
             maxWidth: 560,
           }}
-          onClick={props.canEdit ? props.onEditDescription : null}
-          type={props.canEdit ? 'BodySecondaryLink' : 'Body'}
+          onClick={props.canEditDescription ? props.onEditDescription : null}
+          type={props.canEditDescription ? 'BodySecondaryLink' : 'Body'}
         >
           {props.description || (props.canEditDescription && 'Write a brief description')}
         </Text>
@@ -85,11 +85,13 @@ const TeamHeader = (props: Props) => (
             Chat
           </Text>
         </Button>
-        <Button
-          type="Primary"
-          label={'Add people'}
-          onClick={event => props.onAddPeople(isMobile ? undefined : event.target)}
-        />
+        {props.canManageMembers && (
+          <Button
+            type="Secondary"
+            label={'Add people...'}
+            onClick={event => props.onAddPeople(isMobile ? undefined : event.target)}
+          />
+        )}
       </ButtonBar>
 
       {/* CLI hint */}

--- a/shared/teams/team/index.js
+++ b/shared/teams/team/index.js
@@ -91,28 +91,21 @@ export default Team
 
 type CustomProps = {
   onOpenFolder: () => void,
-  onManageChat: () => void,
+  onChat: () => void,
   onShowMenu: () => void,
-  canManageChat: boolean,
+  canChat: boolean,
   canViewFolder: boolean,
 }
 
-const CustomComponent = ({
-  onOpenFolder,
-  onManageChat,
-  onShowMenu,
-  canManageChat,
-  canViewFolder,
-}: CustomProps) => (
-  <Box style={{...globalStyles.flexBoxRow, position: 'absolute', right: 0}}>
-    {!isMobile &&
-      canManageChat && (
-        <Icon
-          onClick={onManageChat}
-          style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
-          type="iconfont-chat"
-        />
-      )}
+const CustomComponent = ({onOpenFolder, onChat, onShowMenu, canChat, canViewFolder}: CustomProps) => (
+  <Box style={{...globalStyles.flexBoxRow, position: 'absolute', alignItems: 'center', right: 0}}>
+    {canChat && (
+      <Icon
+        onClick={onChat}
+        style={{fontSize: isMobile ? 20 : 16, marginRight: globalMargins.tiny}}
+        type="iconfont-chat"
+      />
+    )}
     {!isMobile &&
       canViewFolder && (
         <Icon
@@ -126,8 +119,7 @@ const CustomComponent = ({
       type="iconfont-ellipsis"
       style={{
         fontSize: isMobile ? 20 : 16,
-        marginRight: isMobile ? globalMargins.xtiny : globalMargins.tiny,
-        padding: isMobile ? globalMargins.xtiny : 0,
+        marginRight: globalMargins.tiny,
       }}
     />
   </Box>

--- a/shared/teams/team/member/index.js
+++ b/shared/teams/team/member/index.js
@@ -11,7 +11,7 @@ import {
   Usernames,
   ButtonBar,
 } from '../../../common-adapters'
-import {globalStyles, globalMargins, isMobile} from '../../../styles'
+import {globalColors, globalStyles, globalMargins, isMobile} from '../../../styles'
 import {roleIconMap} from '../../role-picker/index.meta'
 
 export type Props = {
@@ -102,7 +102,18 @@ export const TeamMember = (props: Props) => {
         </Text>
       </Box>
       <ButtonBar direction={isMobile ? 'column' : 'row'}>
-        <Button type="Primary" label="Chat" onClick={onChat} />
+        <Button type="Primary" onClick={onChat}>
+          <Icon
+            type="iconfont-chat"
+            style={{
+              marginRight: 8,
+              color: globalColors.white,
+            }}
+          />
+          <Text type="BodyBig" backgroundMode="Announcements">
+            Chat
+          </Text>
+        </Button>
         {admin && <Button type="Secondary" label="Edit role" onClick={onEditMembership} />}
         {admin && (
           <Button

--- a/shared/teams/team/member/index.js
+++ b/shared/teams/team/member/index.js
@@ -102,7 +102,7 @@ export const TeamMember = (props: Props) => {
         </Text>
       </Box>
       <ButtonBar direction={isMobile ? 'column' : 'row'}>
-        <Button type="Primary" onClick={onChat}>
+        <Button label="Chat" type="Primary" onClick={onChat}>
           <Icon
             type="iconfont-chat"
             style={{
@@ -110,9 +110,6 @@ export const TeamMember = (props: Props) => {
               color: globalColors.white,
             }}
           />
-          <Text type="BodyBig" backgroundMode="Announcements">
-            Chat
-          </Text>
         </Button>
         {admin && <Button type="Secondary" label="Edit role" onClick={onEditMembership} />}
         {admin && (

--- a/shared/tracker/action.render.desktop.js
+++ b/shared/tracker/action.render.desktop.js
@@ -85,7 +85,7 @@ export default class ActionRender extends PureComponent<ActionProps> {
             onClick={() => this.props.onClose()}
           />
         )}
-        <Button style={styleChatButton} type="Primary" onClick={() => this.props.onChat()}>
+        <Button style={styleChatButton} label="Chat" type="Primary" onClick={() => this.props.onChat()}>
           <Icon
             type="iconfont-chat"
             style={{
@@ -93,9 +93,6 @@ export default class ActionRender extends PureComponent<ActionProps> {
               color: globalColors.white,
             }}
           />
-          <Text type="BodyBig" backgroundMode="Announcements">
-            Chat
-          </Text>
         </Button>
       </div>
     )

--- a/shared/tracker/action.render.desktop.js
+++ b/shared/tracker/action.render.desktop.js
@@ -85,12 +85,18 @@ export default class ActionRender extends PureComponent<ActionProps> {
             onClick={() => this.props.onClose()}
           />
         )}
-        <Button
-          style={styleChatButton}
-          type="Primary"
-          label="Start a Chat"
-          onClick={() => this.props.onChat()}
-        />
+        <Button style={styleChatButton} type="Primary" onClick={() => this.props.onChat()}>
+          <Icon
+            type="iconfont-chat"
+            style={{
+              marginRight: 8,
+              color: globalColors.white,
+            }}
+          />
+          <Text type="BodyBig" backgroundMode="Announcements">
+            Chat
+          </Text>
+        </Button>
       </div>
     )
   }


### PR DESCRIPTION
- Merges the two add buttons into one that triggers a menu
- Adds a fancy chat button to the team, member, and profile pages as well as tracker popup
  - It might be nice to make it a common adapter; I didn't want to get into trying to supertype the existing button
- Fixes a bug where team descriptions weren't showing up in the right conditions (cc @cecileboucheron)
- Makes header chat icon visible on mobile & navigate to team conversation on all platforms

r? @keybase/react-hackers 