### PR TITLE
check the display name of the imp team for an upgraded convo against conv name CORE-7288

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -454,7 +454,7 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv types.U
 			case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE:
 				s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
 				tlfID := msg.Valid().ClientHeader.Conv.Tlfid
-				team, err := LoadTeam(ctx, s.G().ExternalG(), tlfID, conv.GetMembersType(),
+				team, err := LoadTeam(ctx, s.G().ExternalG(), tlfID, tlfName, conv.GetMembersType(),
 					msg.Valid().ClientHeader.TlfPublic, nil)
 				if err != nil {
 					return err

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -246,3 +246,13 @@ type DuplicateTopicNameError struct {
 func (e DuplicateTopicNameError) Error() string {
 	return fmt.Sprintf("channel name %s is already in use", e.TopicName)
 }
+
+//=============================================================================
+
+type ImpteamUpgradeBadteamError struct {
+	Msg string
+}
+
+func (e ImpteamUpgradeBadteamError) Error() string {
+	return fmt.Sprintf("bad iteam found in upgraded conv: %s", e.Msg)
+}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -1261,6 +1261,7 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		var errMsg string
 		s.Debug(ctx, "localizeConversation: trying to load team for %v chat", conversationLocal.Info.Visibility)
 		iteam, err := LoadTeam(ctx, s.G().ExternalG(), conversationLocal.Info.Triple.Tlfid,
+			conversationLocal.Info.TlfName,
 			conversationRemote.GetMembersType(),
 			conversationLocal.Info.Visibility == keybase1.TLFVisibility_PUBLIC, nil)
 		if err != nil {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -364,15 +364,19 @@ func LoadTeam(ctx context.Context, g *libkb.GlobalContext, tlfID chat1.TLFID, tl
 			return team, err
 		}
 		if !tlfID.EqString(team.KBFSTLFID()) {
-			return team, fmt.Errorf("mismatch TLFID to team: %s != %s", team.KBFSTLFID(), tlfID)
+			return team, ImpteamUpgradeBadteamError{
+				Msg: fmt.Sprintf("mismatch TLFID to team: %s != %s", team.KBFSTLFID(), tlfID),
+			}
 		}
 		impTeamName, err := team.ImplicitTeamDisplayNameString(ctx)
 		if err != nil {
 			return team, err
 		}
 		if impTeamName != tlfName {
-			return team, fmt.Errorf("mismatch TLF name to implicit team name: %s != %s", impTeamName,
-				tlfName)
+			return team, ImpteamUpgradeBadteamError{
+				Msg: fmt.Sprintf("mismatch TLF name to implicit team name: %s != %s", impTeamName,
+					tlfName),
+			}
 		}
 		return team, nil
 	}


### PR DESCRIPTION
Check the TLF name of the conversation against the display name of the implicit team we load for an upgraded conversation.