### PR TITLE
Move SBS handler to AddMemberTx, add more SBS tests

### DIFF
--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -616,11 +616,10 @@ func testTeamInviteSweepOldMembers(t *testing.T, startPUKless bool) {
 
 	roo.proveRooter()
 
-	if startPUKless {
-		own.pollForTeamSeqnoLink(teamName.String(), keybase1.Seqno(5))
-	} else {
-		own.pollForTeamSeqnoLink(teamName.String(), keybase1.Seqno(5))
-	}
+	// 3 links to created team, add roo, and add roo@rooter.
+	// + 2 links (rotate, change_membership) to add roo in startPUKless=false case;
+	// or +2 links (change_membersip, cancel invite) to add roo in startPUKless=true case.
+	own.pollForTeamSeqnoLink(teamName.String(), keybase1.Seqno(5))
 
 	teamObj := own.loadTeamByID(teamID, true /* admin */)
 	// 0 total invites: rooter invite was completed, and keybase invite was sweeped
@@ -637,5 +636,5 @@ func testTeamInviteSweepOldMembers(t *testing.T, startPUKless bool) {
 
 func TestTeamInviteSweepOldMembers(t *testing.T) {
 	testTeamInviteSweepOldMembers(t, false)
-	//testTeamInviteSweepOldMembers(t, true)
+	testTeamInviteSweepOldMembers(t, true)
 }

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -528,3 +528,114 @@ func TestSweepObsoleteKeybaseInvites(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, keybase1.TeamRole_NONE, role)
 }
+
+func TestTeamInviteRemoveIfHigherRole(t *testing.T) {
+	// NOTE: This code path is essentially dead because server  will
+	// not send SBS requests to admin for invitees that already are
+	// team members, and internally set invite status to MOOTED. See
+	// serverside _close_raced_sbs_invites.
+
+	// We are going to make standalone user and call HandleSBSRequest
+	// manually to test this.
+
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	own := makeUserStandalone(t, "own", standaloneUserArgs{
+		disableGregor:            true,
+		suppressTeamChatAnnounce: true,
+	})
+	tt.users = append(tt.users, own)
+	roo := tt.addUser("roo")
+	tt.logUserNames()
+
+	teamID, teamName := own.createTeam2()
+	own.addTeamMember(teamName.String(), roo.username, keybase1.TeamRole_ADMIN)
+	own.addTeamMember(teamName.String(), roo.username+"@rooter", keybase1.TeamRole_WRITER)
+
+	t.Logf("Created team %s", teamName.String())
+
+	roo.proveRooter()
+
+	teamObj := own.loadTeamByID(teamID, true /* admin */)
+	var invite keybase1.TeamInvite
+	invites := teamObj.GetActiveAndObsoleteInvites()
+	require.Len(t, invites, 1)
+	for _, invite = range invites {
+		// Get (only) invite from the map to local variable
+	}
+
+	rooUv := roo.userVersion()
+
+	err := teams.HandleSBSRequest(context.Background(), own.tc.G, keybase1.TeamSBSMsg{
+		TeamID: teamID,
+		Score:  0,
+		Invitees: []keybase1.TeamInvitee{
+			keybase1.TeamInvitee{
+				InviteID:    invite.Id,
+				Uid:         rooUv.Uid,
+				EldestSeqno: rooUv.EldestSeqno,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// SBS handler should have canceled the invite after discovering roo is
+	// already a member with higher role.
+	teamObj = own.loadTeamByID(teamID, true /* admin */)
+	require.Len(t, teamObj.GetActiveAndObsoleteInvites(), 0)
+	role, err := teamObj.MemberRole(context.Background(), roo.userVersion())
+	require.NoError(t, err)
+	require.Equal(t, keybase1.TeamRole_ADMIN, role)
+}
+
+func testTeamInviteSweepOldMembers(t *testing.T, startPUKless bool) {
+	t.Logf(":: testTeamInviteSweepOldMembers(startPUKless: %t)", startPUKless)
+
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	own := tt.addUser("own")
+	var roo *userPlusDevice
+	if startPUKless {
+		roo = tt.addPuklessUser("roo")
+	} else {
+		roo = tt.addUser("roo")
+	}
+	tt.logUserNames()
+
+	teamID, teamName := own.createTeam2()
+	own.addTeamMember(teamName.String(), roo.username, keybase1.TeamRole_WRITER)
+	own.addTeamMember(teamName.String(), roo.username+"@rooter", keybase1.TeamRole_ADMIN)
+
+	t.Logf("Created team %s", teamName.String())
+
+	roo.kickTeamRekeyd()
+	roo.reset()
+	roo.loginAfterReset()
+
+	roo.proveRooter()
+
+	if startPUKless {
+		own.pollForTeamSeqnoLink(teamName.String(), keybase1.Seqno(5))
+	} else {
+		own.pollForTeamSeqnoLink(teamName.String(), keybase1.Seqno(5))
+	}
+
+	teamObj := own.loadTeamByID(teamID, true /* admin */)
+	// 0 total invites: rooter invite was completed, and keybase invite was sweeped
+	require.Len(t, teamObj.GetActiveAndObsoleteInvites(), 0)
+	role, err := teamObj.MemberRole(context.Background(), roo.userVersion())
+	require.NoError(t, err)
+	require.Equal(t, keybase1.TeamRole_ADMIN, role)
+
+	members, err := teamObj.Members()
+	require.NoError(t, err)
+	require.Len(t, members.Owners, 1)
+	require.Len(t, members.Admins, 1)
+}
+
+func TestTeamInviteSweepOldMembers(t *testing.T) {
+	testTeamInviteSweepOldMembers(t, false)
+	//testTeamInviteSweepOldMembers(t, true)
+}

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -187,44 +187,22 @@ func handleSBSSingle(ctx context.Context, g *libkb.GlobalContext, teamID keybase
 
 		if currentRole.IsOrAbove(invite.Role) {
 			if team.IsImplicit() {
-				g.Log.CDebugf(ctx, "This is implicit team SBS resolution, mooting invite.")
+				g.Log.CDebugf(ctx, "This is implicit team SBS resolution, mooting invite %s", invite.Id)
 				req := keybase1.TeamChangeReq{}
 				req.CompletedInvites = make(SCMapInviteIDToUV)
 				req.CompletedInvites[invite.Id] = uv.PercentForm()
 				return team.ChangeMembership(ctx, req)
 			}
 
-			g.Log.CDebugf(ctx, "User already has same or higher role, canceling invite.")
+			g.Log.CDebugf(ctx, "User already has same or higher role, canceling invite %s", invite.Id)
 			return removeInviteID(ctx, team, invite.Id)
 		}
 
-		req, err := reqFromRole(uv, invite.Role)
-		if err != nil {
-			g.Log.CDebugf(ctx, "Failed to compute reqForRole for %+v, role=%s", uv, invite.Role)
+		tx := CreateAddMemberTx(team)
+		if err := tx.AddMemberBySBS(ctx, verifiedInvitee, invite.Role); err != nil {
 			return err
 		}
-		req.CompletedInvites = make(SCMapInviteIDToUV)
-		req.CompletedInvites[invite.Id] = uv.PercentForm()
-
-		// Check to see if the user is already in the team with a lower eldest seqno, if so, we need
-		// to remove that entry
-		existingUV, err := team.UserVersionByUID(ctx, verifiedInvitee.Uid)
-		if err == nil {
-			if existingUV.EldestSeqno > verifiedInvitee.EldestSeqno {
-				return fmt.Errorf("newer version of user %s already exists in team %q (%v > %v)",
-					verifiedInvitee.Uid, team.Name(), existingUV.EldestSeqno,
-					verifiedInvitee.EldestSeqno)
-			} else if existingUV.EldestSeqno < verifiedInvitee.EldestSeqno {
-				g.Log.CDebugf(ctx, "removing old version of user: %s (%v -> %v)", verifiedInvitee.Uid,
-					existingUV.EldestSeqno, verifiedInvitee.EldestSeqno)
-				req.None = []keybase1.UserVersion{existingUV}
-			}
-			// If EldestSeqnos are equal - it means it's an SBS promotion.
-		}
-
-		g.Log.CDebugf(ctx, "checks passed, proceeding with team.ChangeMembership, req = %+v", req)
-
-		if err = team.ChangeMembership(ctx, req); err != nil {
+		if err := tx.Post(ctx); err != nil {
 			return err
 		}
 

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -440,7 +440,9 @@ func (tx *AddMemberTx) ReAddMemberToImplicitTeam(ctx context.Context, uv keybase
 // AddMemberBySBS is very similar in what it does to addMemberByUPAKV2
 // (or AddMemberBy* family of functions), but it has easier job
 // because it only adds cryptomembers and fails on PUKless users. It
-// also completed inviteID for given invitee.
+// also sets invite referenced by `invitee.InviteID` as Completed by
+// UserVersion from `invitee` in the same ChangeMembership link that
+// adds the user to the team.
 //
 // AddMemberBySBS assumes that member role is already checked by the
 // caller, so it might generate invalid signature if invitee is

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -16,10 +16,15 @@ import (
 type AddMemberTx struct {
 	team     *Team
 	payloads []interface{} // *SCTeamInvites or *keybase1.TeamChangeReq
+
+	completedInvites map[keybase1.TeamInviteID]bool
 }
 
 func CreateAddMemberTx(t *Team) *AddMemberTx {
-	return &AddMemberTx{team: t}
+	return &AddMemberTx{
+		team:             t,
+		completedInvites: make(map[keybase1.TeamInviteID]bool),
+	}
 }
 
 func (tx *AddMemberTx) DebugPayloads() []interface{} {
@@ -127,7 +132,7 @@ func (tx *AddMemberTx) sweepKeybaseInvites(uid keybase1.UID) {
 	team := tx.team
 	for _, invite := range team.chain().inner.ActiveInvites {
 		if inviteUv, err := invite.KeybaseUserVersion(); err == nil {
-			if inviteUv.Uid.Equal(uid) {
+			if inviteUv.Uid.Equal(uid) && !tx.completedInvites[invite.Id] {
 				tx.CancelInvite(invite.Id)
 			}
 		}
@@ -173,7 +178,7 @@ func (tx *AddMemberTx) addMemberByUPKV2(ctx context.Context, user keybase1.UserP
 		g.Log.CDebugf(ctx, "Invite required for %v", uv)
 	}
 
-	normalizedUsername := libkb.NormalizedUsername(user.Username)
+	normalizedUsername := libkb.NewNormalizedUsername(user.Username)
 
 	if team.IsMember(ctx, uv) {
 		if !hasPUK {
@@ -231,7 +236,7 @@ func (tx *AddMemberTx) AddMemberByUV(ctx context.Context, uv keybase1.UserVersio
 	g := team.G()
 
 	defer g.CTrace(ctx, fmt.Sprintf("AddMemberTx.AddMemberByUV(%v,%v) to team %q", uv, role, team.Name()), func() error { return err })()
-	upak, err := loadUPAK2(ctx, g, uv.Uid, true /*forcePoll */)
+	upak, err := loadUPAK2(ctx, g, uv.Uid, true /* forcePoll */)
 	if err != nil {
 		return err
 	}
@@ -277,6 +282,7 @@ func (tx *AddMemberTx) CompleteInviteByID(ctx context.Context, inviteID keybase1
 		payload.CompletedInvites = make(map[keybase1.TeamInviteID]keybase1.UserVersionPercentForm)
 	}
 	payload.CompletedInvites[inviteID] = uv.PercentForm()
+	tx.completedInvites[inviteID] = true // mark id completed so sweeping will not cancel.
 	return nil
 }
 
@@ -417,6 +423,59 @@ func (tx *AddMemberTx) ReAddMemberToImplicitTeam(ctx context.Context, uv keybase
 		return errors.New("ReAddMemberToImplicitTeam tried to create more than one link")
 	}
 
+	return nil
+}
+
+// AddMemberBySBS is very similar in what it does to addMemberByUPAKV2
+// (or AddMemberBy* family of functions), but it has easier job
+// because it only adds cryptomembers and fails on PUKless users. It
+// also completed inviteID for given invitee.
+//
+// AddMemberBySBS assumes that member role is already checked by the
+// caller, so it might generate invalid signature if invitee is
+// already a member with same role.
+func (tx *AddMemberTx) AddMemberBySBS(ctx context.Context, invitee keybase1.TeamInvitee) (err error) {
+	team := tx.team
+	g := team.G()
+
+	defer g.CTrace(ctx, fmt.Sprintf("AddMemberTx.AddMemberBySBS(%v) to team: %q",
+		invitee, team.Name()), func() error { return err })()
+
+	uv := NewUserVersion(invitee.Uid, invitee.EldestSeqno)
+	upak, err := loadUPAK2(ctx, g, uv.Uid, true /* forcePoll */)
+	if err != nil {
+		return err
+	}
+
+	user := upak.Current
+	if uv.EldestSeqno != user.EldestSeqno {
+		return fmt.Errorf("Bad eldestseqno for %s: expected %d, got %d", uv.Uid, user.EldestSeqno, uv.EldestSeqno)
+	}
+
+	if len(user.PerUserKeys) == 0 {
+		return fmt.Errorf("Cannot add PUKless user %q (%s) for SBS", user.Username, uv.Uid)
+	}
+
+	if user.Status == keybase1.StatusCode_SCDeleted {
+		return fmt.Errorf("User %q (%s) is deleted", user.Username, uv.Uid)
+	}
+
+	if invitee.Role == keybase1.TeamRole_OWNER && team.IsSubteam() {
+		return NewSubteamOwnersError()
+	}
+
+	//normalizedUsername := libkb.NewNormalizedUsername(user.Username)
+
+	if err := tx.addMember(uv, invitee.Role); err != nil {
+		return err
+	}
+
+	if err := tx.CompleteInviteByID(ctx, invitee.InviteID, uv); err != nil {
+		return err
+	}
+
+	tx.sweepKeybaseInvites(uv.Uid)
+	tx.sweepCryptoMembers(uv.Uid)
 	return nil
 }
 


### PR DESCRIPTION
1. Increase SBS handler test coverage. New tests exercise SBS canceling mooted invite code path (see 2), and also sweeping old versions of members when adding users through SBS.
2. Discover dead code path where SBS handler cancels social invite for which the user is already member of the team with same role or higher. This does not trigger anymore because server will automatically set invite status to MOOTED and not trigger SBS handler in clients.
3. Use AddMemberTx in SBS handler. This required a new function in `transactions.go`: `AddMemberBySBS` which is specific to team invite resolution.
4. Changes to `AddMemberTx.sweepKeybaseInvites` were needed so it could work with `CompleteInviteByID` and not try to cancel already completed invite.