### PR TITLE
 keybase-mount-helper: use suid to root instead of suid to keybasehelper

### DIFF
--- a/go/mounter/keybase-mount-helper/main.go
+++ b/go/mounter/keybase-mount-helper/main.go
@@ -16,10 +16,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"syscall"
 )
 
@@ -195,22 +193,10 @@ func checkAndSwitchMount(
 func main() {
 	flag.Parse()
 
-	// Figure out the helper UID.
-	khUser, err := user.Lookup(kbUsername)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot get %s user: %+v\n", kbUsername, err)
-		os.Exit(1)
-	}
-	khUID, err := strconv.Atoi(khUser.Uid)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Bad UID for %s user: %+v\n", kbUsername, err)
-		os.Exit(1)
-	}
-
 	// Lock the thread (because SYS_SETUID only sets the UID of the
 	// current OS thread) and switch to the helper user.
 	runtime.LockOSThread()
-	_, _, errNo := syscall.Syscall(syscall.SYS_SETUID, uintptr(khUID), 0, 0)
+	_, _, errNo := syscall.Syscall(syscall.SYS_SETUID, 0, 0, 0)
 	if errNo != 0 {
 		fmt.Fprintf(os.Stderr, "Can't setuid: %+v\n", errNo)
 		os.Exit(1)

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -16,13 +16,8 @@ rootlink="/keybase"
 vardir="/var/lib/keybase"
 mount1="$vardir/mount1"
 sample="/opt/keybase/mount-readme"
-khuser="keybasehelper"
+khuser="root"
 khbin="/usr/bin/keybase-mount-helper"
-
-# Create the keybasehelper system user, without login privileges.
-if useradd --system -s /bin/false -U -M $khuser &> /dev/null ; then
-    echo Created $khuser system user for managing mountpoints.
-fi
 
 chown "$khuser":"$khuser" "$khbin"
 chmod 4755 "$khbin"

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -17,6 +17,7 @@ vardir="/var/lib/keybase"
 mount1="$vardir/mount1"
 sample="/opt/keybase/mount-readme"
 khuser="root"
+khuserDeprecated="keybasehelper"
 khbin="/usr/bin/keybase-mount-helper"
 
 chown "$khuser":"$khuser" "$khbin"
@@ -46,6 +47,15 @@ if [ -z "$currlink" ] ; then
     if ln -s -T "$mount1" "$rootlink" &> /dev/null ; then
         chown "$khuser":"$khuser" "$rootlink"
     fi
+fi
+
+# Delete the keybasehelper system user, to clean up after older
+# versions.  TODO: remove this once sufficient time has passed since
+# those old releases.
+if userdel $khuserDeprecated &> /dev/null ; then
+    echo Removing $khuserDeprecated system user, as it is no longer needed.
+    # Switch /var/lib/keybase to be owned by root.
+    chown -R "$khuser":"$khuser" "$vardir"
 fi
 
 # Update the GTK icon cache, if possible.

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -83,7 +83,7 @@ kill_all() {
     # Remove any existing legacy mount.  This should never happen
     # because it should have already been done by post_install.sh.
     # Just in case, let the user know how to fix it.
-    echo Unmounting /keybase.  Run `sudo rmdir /keybase; sudo ln -s /opt/keybase/mount-readme /keybase; sudo chown keybasehelper:keybasehelper /keybase` and then run this command again.
+    echo Unmounting /keybase.  Run `sudo rmdir /keybase; sudo ln -s /opt/keybase/mount-readme /keybase; sudo chown root:root /keybase` and then run this command again.
     exit -1
   fi
   if fusermount -uz $mountdir &> /dev/null ; then


### PR DESCRIPTION
It turns out some Linux kernels have a problem letting a Go problem suid to a non-root user.  The exact cause isn't clear, even after extension user debugging in #10487.

It seems that using suid to root just fixes the problem.  It's a little less secure but the mount helper program is simple enough, and it's better than a nasty segfault that prevents startup.
