### PR TITLE
Fix bug when pagination.Num = 0

### DIFF
--- a/go/chat/pager/pager.go
+++ b/go/chat/pager/pager.go
@@ -88,7 +88,7 @@ func (p Pager) MakePage(length, reqed int, next interface{}, prev interface{}) (
 		Num:      length,
 		Next:     nextEncoded,
 		Previous: prevEncoded,
-		Last:     (length < reqed),
+		Last:     (length < reqed) || length == 0,
 	}, nil
 }
 
@@ -137,7 +137,7 @@ func NewThreadPager() ThreadPager {
 
 func (p ThreadPager) MakePage(res []Message, reqed int) (*chat1.Pagination, error) {
 	if len(res) == 0 {
-		return &chat1.Pagination{Num: 0}, nil
+		return &chat1.Pagination{Num: 0, Last: true}, nil
 	}
 
 	// Get first and last message IDs to encode in the result

--- a/go/chat/searcher.go
+++ b/go/chat/searcher.go
@@ -50,6 +50,7 @@ func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchH
 			return hits, rlimits, err
 		}
 		pagination = thread.Pagination
+		pagination.Num = pageSize
 		pagination.Previous = nil
 		rlimitsp = append(rlimitsp, rl...)
 


### PR DESCRIPTION
Fixes a bug in `keybase chat search` where the returned pagination object had `Num=0` resulting in an infinite search loop.