### PR TITLE
Don't let atLeast exceed atMost

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -717,6 +717,9 @@ func (h *Server) GetInboxSummaryForCLILocal(ctx context.Context, arg chat1.GetIn
 		if arg.UnreadFirstLimit.AtMost <= 0 {
 			arg.UnreadFirstLimit.AtMost = int(^uint(0) >> 1) // maximum int
 		}
+		if arg.UnreadFirstLimit.AtMost < arg.UnreadFirstLimit.AtLeast {
+			arg.UnreadFirstLimit.AtMost = arg.UnreadFirstLimit.AtLeast
+		}
 		query := queryBase
 		query.UnreadOnly, query.ReadOnly = true, false
 		if gires, err = h.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
@@ -783,6 +786,9 @@ func (h *Server) GetConversationForCLILocal(ctx context.Context, arg chat1.GetCo
 
 	if arg.Limit.AtMost <= 0 {
 		arg.Limit.AtMost = int(^uint(0) >> 1) // maximum int
+	}
+	if arg.Limit.AtMost < arg.Limit.AtLeast {
+		arg.Limit.AtMost = arg.Limit.AtLeast
 	}
 
 	convLocal := arg.Conv


### PR DESCRIPTION
Previously if you did a `keybase chat search --at-least=1000`, `--at-most` would default to `100` you wouldn't get back at least 1000 results. You could specify both flags to get the desired behavior but I feel this is a little more intuitive.