### PR TITLE
Fix TeamResetBadges* tests

### DIFF
--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -675,7 +675,6 @@ func TestTeamAfterDeleteUser(t *testing.T) {
 // when a member of the team resets, and that they are dismissed
 // when the reset user is added.
 func TestTeamResetBadgesOnAdd(t *testing.T) {
-	t.Skip()
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
@@ -688,10 +687,9 @@ func TestTeamResetBadgesOnAdd(t *testing.T) {
 	tt.users[1].reset()
 	tt.users[0].waitForTeamChangedGregor(teamID, keybase1.Seqno(2))
 	// wait for badge state to have 1 team w/ reset member
-	tt.users[0].waitForBadgeStateWithReset(1)
+	badgeState := tt.users[0].waitForBadgeStateWithReset(1)
 
 	// users[0] should be badged since users[1] reset
-	badgeState := getBadgeState(t, tt.users[0])
 	if len(badgeState.TeamsWithResetUsers) == 0 {
 		t.Fatal("TeamsWithResetUsers is empty after reset")
 	}
@@ -710,10 +708,9 @@ func TestTeamResetBadgesOnAdd(t *testing.T) {
 	tt.users[0].addTeamMember(teamName.String(), tt.users[1].username, keybase1.TeamRole_WRITER)
 
 	// wait for badge state to have no teams w/ reset member
-	tt.users[0].waitForBadgeStateWithReset(0)
+	badgeState = tt.users[0].waitForBadgeStateWithReset(0)
 
 	// badge state should be cleared
-	badgeState = getBadgeState(t, tt.users[0])
 	if len(badgeState.TeamsWithResetUsers) != 0 {
 		t.Errorf("badge state for TeamsWithResetUsers not empty: %d", len(badgeState.TeamsWithResetUsers))
 	}
@@ -723,7 +720,6 @@ func TestTeamResetBadgesOnAdd(t *testing.T) {
 // when a member of the team resets, and that they are dismissed
 // when the reset user is removed.
 func TestTeamResetBadgesOnRemove(t *testing.T) {
-	t.Skip()
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
@@ -736,10 +732,9 @@ func TestTeamResetBadgesOnRemove(t *testing.T) {
 	tt.users[1].reset()
 	tt.users[0].waitForTeamChangedGregor(teamID, keybase1.Seqno(2))
 	// wait for badge state to have 1 team w/ reset member
-	tt.users[0].waitForBadgeStateWithReset(1)
+	badgeState := tt.users[0].waitForBadgeStateWithReset(1)
 
 	// users[0] should be badged since users[1] reset
-	badgeState := getBadgeState(t, tt.users[0])
 	if len(badgeState.TeamsWithResetUsers) == 0 {
 		t.Fatal("TeamsWithResetUsers is empty after reset")
 	}
@@ -755,10 +750,9 @@ func TestTeamResetBadgesOnRemove(t *testing.T) {
 	tt.users[0].removeTeamMember(teamName.String(), tt.users[1].username)
 
 	// wait for badge state to have no teams w/ reset member
-	tt.users[0].waitForBadgeStateWithReset(0)
+	badgeState = tt.users[0].waitForBadgeStateWithReset(0)
 
 	// badge state should be cleared
-	badgeState = getBadgeState(t, tt.users[0])
 	if len(badgeState.TeamsWithResetUsers) != 0 {
 		t.Errorf("badge state for TeamsWithResetUsers not empty: %d", len(badgeState.TeamsWithResetUsers))
 	}

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -491,19 +491,20 @@ func (u *userPlusDevice) waitForTeamChangedGregor(teamID keybase1.TeamID, toSeqn
 	u.tc.T.Fatalf("timed out waiting for team rotate %s", teamID)
 }
 
-func (u *userPlusDevice) waitForBadgeStateWithReset(numReset int) {
+func (u *userPlusDevice) waitForBadgeStateWithReset(numReset int) keybase1.BadgeState {
 	for i := 0; i < 10; i++ {
 		select {
 		case arg := <-u.notifications.badgeCh:
 			u.tc.T.Logf("badge state received: %+v", arg.TeamsWithResetUsers)
 			if len(arg.TeamsWithResetUsers) == numReset {
 				u.tc.T.Logf("badge state length match")
-				return
+				return arg
 			}
 		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
 		}
 	}
 	u.tc.T.Fatal("timed out waiting for badge state")
+	return keybase1.BadgeState{}
 }
 
 func (u *userPlusDevice) drainGregor() {


### PR DESCRIPTION
There was a race here because one (test) notification recipient had a different badge state than the other.

This just uses the badge state from `waitForBadgeStateWithReset` instead of then getting it from `getBadgeState`.

