### PR TITLE
Fix 'create subteam' on team page

### DIFF
--- a/shared/teams/new-team/container.js
+++ b/shared/teams/new-team/container.js
@@ -9,7 +9,7 @@ import {
   withHandlers,
   type TypedState,
 } from '../../util/container'
-import {validTeamname, baseTeamname} from '../../constants/teamname'
+import {baseTeamname} from '../../constants/teamname'
 import upperFirst from 'lodash/upperFirst'
 
 const mapStateToProps = (state: TypedState) => ({
@@ -31,9 +31,10 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath}) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const name = ownProps.routeProps.get('name')
-  const baseTeam = name && baseTeamname(name)
-  const isSubteam = baseTeam && validTeamname(baseTeam)
+  const isSubteam = ownProps.routeProps.get('makeSubteam') || false
+  const routeName = ownProps.routeProps.get('name') || ''
+  const name = routeName.concat(isSubteam ? '.' : '')
+  const baseTeam = baseTeamname(name)
   return {
     ...stateProps,
     ...dispatchProps,

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -53,7 +53,7 @@ const mapDispatchToProps = (
     onChat: () => dispatch(ChatGen.createOpenTeamConversation({teamname, channelname: 'general'})),
     onLeaveTeam: () => dispatch(navigateAppend([{props: {teamname}, selected: 'reallyLeaveTeam'}])),
     onCreateSubteam: () =>
-      dispatch(navigateAppend([{props: {name: `${teamname}.`}, selected: 'showNewTeamDialog'}])),
+      dispatch(navigateAppend([{props: {makeSubteam: true, name: teamname}, selected: 'showNewTeamDialog'}])),
     _loadTeam: teamname => dispatch(TeamsGen.createGetDetails({teamname})),
     onBack: () => dispatch(navigateUp()),
 

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -53,7 +53,7 @@ const mapDispatchToProps = (
     onChat: () => dispatch(ChatGen.createOpenTeamConversation({teamname, channelname: 'general'})),
     onLeaveTeam: () => dispatch(navigateAppend([{props: {teamname}, selected: 'reallyLeaveTeam'}])),
     onCreateSubteam: () =>
-      dispatch(navigateAppend([{props: {name: teamname}, selected: 'showNewTeamDialog'}])),
+      dispatch(navigateAppend([{props: {name: `${teamname}.`}, selected: 'showNewTeamDialog'}])),
     _loadTeam: teamname => dispatch(TeamsGen.createGetDetails({teamname})),
     onBack: () => dispatch(navigateUp()),
 

--- a/shared/teams/team/subteams/container.js
+++ b/shared/teams/team/subteams/container.js
@@ -20,7 +20,7 @@ const mapStateToProps = (state: TypedState, {teamname}: OwnProps) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch, {teamname}: OwnProps) => ({
   onCreateSubteam: () =>
-    dispatch(navigateAppend([{props: {name: `${teamname}.`}, selected: 'showNewTeamDialog'}])),
+    dispatch(navigateAppend([{props: {makeSubteam: true, name: teamname}, selected: 'showNewTeamDialog'}])),
   onHideSubteamsBanner: () =>
     dispatch(GregorGen.createInjectItem({body: 'true', category: 'sawSubteamsBanner'})),
   onReadMoreAboutSubteams: () => openURL('https://keybase.io/docs/teams/design'),


### PR DESCRIPTION
@keybase/react-hackers CC @buoyad 

The team page refactor looks to have removed a subtle but necessary `.` from the end of the teamname passed to the `showNewTeamDialog` route.  Seeing that there's a `.` in the team name is how that component identifies that you're creating a subteam rather than a team, so we were prompting the user as if they were creating a new team rather than a subteam.