### PR TITLE
Remove TestSubteamChats, add better test

### DIFF
--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -93,6 +93,7 @@ func (h *TeamsHandler) TeamCreateWithSettings(ctx context.Context, arg keybase1.
 		h.G().Log.CDebugf(ctx, "TeamCreate: created subteam %s with self in as %v", arg.Name, addSelfAs)
 		username := h.G().Env.GetUsername().String()
 		res.ChatSent = teams.SendTeamChatCreateMessage(ctx, h.G().ExternalG(), teamName.String(), username)
+		res.CreatorAdded = true
 
 		if !arg.JoinSubteam {
 			h.G().Log.CDebugf(ctx, "TeamCreate: leaving just-created subteam %s", arg.Name)

--- a/go/systests/team_create_test.go
+++ b/go/systests/team_create_test.go
@@ -5,7 +5,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	client "github.com/keybase/client/go/client"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 
 	"github.com/stretchr/testify/require"
@@ -23,13 +22,14 @@ func testSubteamCreate(t *testing.T, joinSubteam bool) {
 	parentName := ann.createTeam()
 	subteamName := parentName + ".test"
 
-	var err error
-	create := client.NewCmdTeamCreateRunner(ann.tc.G)
-	create.TeamName, err = keybase1.TeamNameFromString(subteamName)
+	cli := ann.teamsClient
+	res, err := cli.TeamCreate(context.Background(), keybase1.TeamCreateArg{
+		Name:        subteamName,
+		JoinSubteam: joinSubteam,
+	})
 	require.NoError(t, err)
-	create.JoinSubteam = joinSubteam
-	err = create.Run()
-	require.NoError(t, err)
+	require.Equal(t, joinSubteam, res.CreatorAdded)
+	require.True(t, res.ChatSent)
 
 	t.Logf("Created subteam %s", subteamName)
 


### PR DESCRIPTION
1. Remove TestSubteamChats in current form, do not try to create subteam and try to chat in it because it's very flaky. Systests is not a good place for chat testing.
2. New test tests both outcomes of `JoinSubteam` argument.
3. Fix a bug that I introduced where `CreatorAdded` return value was not being set properly.