### PR TITLE
packaging: update Linux and macOS mount points

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -6,6 +6,7 @@ package libkb
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -229,20 +230,28 @@ func (e *Env) GetMountDir() (string, error) {
 		func() string {
 			switch runtime.GOOS {
 			case "darwin":
+				volumes := "/Volumes"
+				user, err := user.Current()
+				if err != nil {
+					panic(fmt.Sprintf("Couldn't get current user: %+v", err))
+				}
+				var runmodeName string
 				switch e.GetRunMode() {
 				case DevelRunMode:
-					return filepath.Join(e.GetHome(), "keybase.devel")
+					runmodeName = "KeybaseDevel"
 				case StagingRunMode:
-					return filepath.Join(e.GetHome(), "keybase.staging")
+					runmodeName = "KeybaseStaging"
 				case ProductionRunMode:
-					return filepath.Join(e.GetHome(), "keybase")
+					runmodeName = "Keybase"
 				default:
 					panic("Invalid run mode")
 				}
+				return filepath.Join(volumes, fmt.Sprintf(
+					"%s's %s", user.Username, runmodeName))
 			case "linux":
-				return filepath.Join(e.GetDataDir(), "fs")
+				return filepath.Join(e.GetRuntimeDir(), "kbfs")
 			default:
-				return filepath.Join(e.GetDataDir(), "fs")
+				return filepath.Join(e.GetRuntimeDir(), "kbfs")
 			}
 		},
 	), nil

--- a/osx/KBKit/KBKit/Component/KBHelperTool.m
+++ b/osx/KBKit/KBKit/Component/KBHelperTool.m
@@ -85,7 +85,9 @@
   NSString *infoText = @"";
   if ([bundleVersion isOrderedSame:[KBSemVersion version:@"1.0.31"]]) {
     alertText = @"New Keybase feature: multiple users in macOS";
-    infoText = @"Previously, only one user of this computer could find their Keybase files at /keybase. With this update, /keybase will now support multiple users on the same computer by redirecting to user-specific Keybase directories in /Volumes.\n\nYou may need to enter your password for this update.";  }
+    // Use a division slash instead of a regular / to avoid weird line breaks.
+    infoText = @"Previously, only one user of this computer could find their Keybase files at \u2215keybase. With this update, \u2215keybase will now support multiple users on the same computer by linking to user-specific Keybase directories in \u2215Volumes.\n\nYou may need to enter your password for this update.";
+  }
   NSAlert *alert = [[NSAlert alloc] init];
   [alert setMessageText:alertText];
   [alert setInformativeText:infoText];

--- a/osx/KBKit/KBKit/Component/KBHelperTool.m
+++ b/osx/KBKit/KBKit/Component/KBHelperTool.m
@@ -85,7 +85,7 @@
   NSString *infoText = @"";
   if ([bundleVersion isOrderedSame:[KBSemVersion version:@"1.0.31"]]) {
     alertText = @"New Keybase feature: multiple users in macOS";
-    infoText = @"Previously, only one user of this computer could find their Keybase files at /keybase. With this update, /keybase will now support multiple users on the same computer by redirecting to keybase/ in your home directory, where most apps put files.\n\nYou may need to enter your password for this update.";  }
+    infoText = @"Previously, only one user of this computer could find their Keybase files at /keybase. With this update, /keybase will now support multiple users on the same computer by redirecting to user-specific Keybase directories in /Volumes.\n\nYou may need to enter your password for this update.";  }
   NSAlert *alert = [[NSAlert alloc] init];
   [alert setMessageText:alertText];
   [alert setInformativeText:infoText];

--- a/osx/KBKit/KBKit/Component/KBMountDir.m
+++ b/osx/KBKit/KBKit/Component/KBMountDir.m
@@ -63,15 +63,14 @@
 }
 
 - (void)createMountDir:(KBCompletion)completion {
-  DDLogDebug(@"Creating mount directory: %@", self.config.mountDir);
-
-  NSError *err = nil;
-  if (![NSFileManager.defaultManager createDirectoryAtPath:self.config.mountDir withIntermediateDirectories:NO attributes:nil error:&err]) {
+  uid_t uid = getuid();
+  gid_t gid = getgid();
+  NSNumber *permissions = [NSNumber numberWithShort:0600];
+  NSDictionary *params = @{@"directory": self.config.mountDir, @"uid": @(uid), @"gid": @(gid), @"permissions": permissions, @"excludeFromBackup": @(YES)};
+  DDLogDebug(@"Creating mount directory: %@", params);
+  [self.helperTool.helper sendRequest:@"createDirectory" params:@[params] completion:^(NSError *err, id value) {
     completion(err);
-    return;
-  }
-
-  completion(nil);
+  }];
 }
 
 - (void)install:(KBCompletion)completion {

--- a/osx/KBKit/KBKit/System/KBEnvConfig.h
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.h
@@ -60,7 +60,6 @@ typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
 
 - (NSString *)logFile:(NSString *)label;
 
-- (NSString *)defaultMountDir:(KBPathOptions)options;
 - (NSString *)homePath:(NSString *)filename options:(KBPathOptions)options;
 - (NSString *)dataPath:(NSString *)filename options:(KBPathOptions)options;
 - (NSString *)runtimePath:(NSString *)filename options:(KBPathOptions)options;

--- a/osx/KBKit/KBKit/System/KBEnvConfig.h
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.h
@@ -60,6 +60,7 @@ typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
 
 - (NSString *)logFile:(NSString *)label;
 
+- (NSString *)defaultMountDir:(KBPathOptions)options;
 - (NSString *)homePath:(NSString *)filename options:(KBPathOptions)options;
 - (NSString *)dataPath:(NSString *)filename options:(KBPathOptions)options;
 - (NSString *)runtimePath:(NSString *)filename options:(KBPathOptions)options;

--- a/osx/KBKit/KBKit/System/KBEnvConfig.m
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.m
@@ -38,10 +38,8 @@
   if ((self = [super init])) {
     _runMode = runMode;
 
-    // Read the mount point from the config file if possible.  NOTE:
-    // if you change this default, you must also change the default
-    // for darwin in the `GetMountDir` function of `libkb/env.go`.
-    NSString *mountDir = [self defaultMountDir:(KBPathOptions)0];
+    // Read the mount point from the config file if possible.
+    NSString *mountDir = [self defaultMountDir];
     NSData *data = [NSData dataWithContentsOfFile:[self dataPath:@"config.json" options:0]];
     if (data) {
       NSError *err = nil;
@@ -132,11 +130,13 @@
   else return NSStringWithFormat(@"Keybase.%@", NSStringFromKBRunMode(_runMode, NO));
 }
 
-- (NSString *)defaultMountdir:(KBPathOptions)options {
+- (NSString *)defaultMountDir {
+  // NOTE: if you change this default, you must also change the default
+  // for darwin in the `GetMountDir` function of `libkb/env.go`.
   NSString *appName = [self appName];
   NSString *userName = NSUserName();
   NSString *mount = NSStringWithFormat(@"%@'s %@", userName, appName);
-  return [KBPath pathInDir:@"/Volumes" path:mount options:options];
+  return [KBPath pathInDir:@"/Volumes" path:mount options:0];
 }
 
 - (NSString *)homePath:(NSString *)filename options:(KBPathOptions)options {

--- a/osx/KBKit/KBKit/System/KBEnvConfig.m
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.m
@@ -41,8 +41,7 @@
     // Read the mount point from the config file if possible.  NOTE:
     // if you change this default, you must also change the default
     // for darwin in the `GetMountDir` function of `libkb/env.go`.
-    NSString *defaultMountDir = [self homePath:[[self appNameWithDot] lowercaseString] options:0];
-    NSString *mountDir = defaultMountDir;
+    NSString *mountDir = [self defaultMountDir:(KBPathOptions)0];
     NSData *data = [NSData dataWithContentsOfFile:[self dataPath:@"config.json" options:0]];
     if (data) {
       NSError *err = nil;
@@ -131,6 +130,13 @@
 - (NSString *)appNameWithDot {
   if (_runMode == KBRunModeProd) return @"Keybase";
   else return NSStringWithFormat(@"Keybase.%@", NSStringFromKBRunMode(_runMode, NO));
+}
+
+- (NSString *)defaultMountdir:(KBPathOptions)options {
+  NSString *appName = [self appName];
+  NSString *userName = NSUserName();
+  NSString *mount = NSStringWithFormat(@"%@'s %@", userName, appName);
+  return [KBPath pathInDir:@"/Volumes" path:mount options:options];
 }
 
 - (NSString *)homePath:(NSString *)filename options:(KBPathOptions)options {

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -117,7 +117,7 @@ build_one_architecture() {
   # Build the root redirector binary.
   echo "Building keybase-redirector for $GOARCH..."
   go build -tags "$go_tags" -ldflags "$ldflags_client" -o \
-    "$layout_dir/usr/bin/keybase-redirector" github.com/keybase/kbfs/redirector/go
+    "$layout_dir/usr/bin/keybase-redirector" github.com/keybase/kbfs/redirector
 
   # Build the kbnm binary
   echo "Building kbnm for $GOARCH..."

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -13,18 +13,47 @@ set -e -u -o pipefail
 runtime_dir="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase"
 mkdir -p "$runtime_dir"
 startup_token="$runtime_dir/startup_mode"
-# Use -d to avoid starting up the keybase background daemon here.
-if keybase config get -d -b mountdir &> /dev/null ; then
-    mountdir="$(keybase config get -d -b mountdir 2> /dev/null)"
-else
-    # The user has no mountpoint configured yet, so pick a default one
-    # and record the default setting in a separate config field, so
-    # later we can tell whether the user changed it away from the
-    # default or not.
-    mountdir="${XDG_DATA_HOME:-$HOME/.local/share}/keybase/fs"
-    keybase config set mountdir "$mountdir"
-    keybase config set mountdirdefault "$mountdir"
-fi
+
+set_empty_mountdir_to_default() {
+    # Set the mount point to a default value if a) nothing is set yet,
+    # or b) both are set to the old default.
+    default=""
+    # Use -d to avoid starting up the keybase background daemon here.
+    if keybase config get -d -b mountdirdefault &> /dev/null ; then
+        # If the current mount directory is still the old default, force
+        # an update to the new default.
+        default="$(keybase config get -d -b mountdirdefault 2> /dev/null)"
+        oldDefault="${XDG_DATA_HOME:-$HOME/.local/share}/keybase/fs"
+        # For the new default mountpoint, use
+        # /run/user/$UID/keybase/kbfs if at all possible, but if the
+        # system doesn't have $XDG_RUNTIME_DIR defined, we'll have to
+        # fall back to something in the home directory (putting the
+        # user at risk of things like du and find crawling KBFS...).
+        newDefault="${XDG_RUNTIME_DIR:-$HOME/.local/share}/keybase/kbfs"
+        if [ "$default" = "$oldDefault" ]; then
+            mountdir="$(keybase config get -d -b mountdir 2> /dev/null)"
+            if [ "$mountdir" = "$default" ]; then
+                if fusermount -uz "$mountdir" &> /dev/null ; then
+                    echo "Updating mount directory from $default to $newDefault"
+                fi
+                default=""
+            fi
+        fi
+    fi
+
+    if [ -z "$default" ]; then
+        # The user has no mountpoint configured yet, so pick a default one
+        # and record the default setting in a separate config field, so
+        # later we can tell whether the user changed it away from the
+        # default or not.
+        mountdir="$newDefault"
+        keybase config set mountdir "$mountdir"
+        keybase config set mountdirdefault "$mountdir"
+    fi
+}
+
+set_empty_mountdir_to_default
+mountdir="$(keybase config get -d -b mountdir 2> /dev/null)"
 export KEYBASE_MOUNTDIR=$mountdir
 
 # Don't make the mountpoint until after unmounting/killing the

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -29,7 +29,7 @@ set_empty_mountdir_to_default() {
         # system doesn't have $XDG_RUNTIME_DIR defined, we'll have to
         # fall back to something in the home directory (putting the
         # user at risk of things like du and find crawling KBFS...).
-        newDefault="${XDG_RUNTIME_DIR:-$HOME/.local/share}/keybase/kbfs"
+        newDefault="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase/kbfs"
         if [ "$default" = "$oldDefault" ]; then
             mountdir="$(keybase config get -d -b mountdir 2> /dev/null)"
             if [ "$mountdir" = "$default" ]; then

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -18,18 +18,18 @@ set_empty_mountdir_to_default() {
     # Set the mount point to a default value if a) nothing is set yet,
     # or b) both are set to the old default.
     default=""
+    oldDefault="${XDG_DATA_HOME:-$HOME/.local/share}/keybase/fs"
     # Use -d to avoid starting up the keybase background daemon here.
+    # For the new default mountpoint, use /run/user/$UID/keybase/kbfs
+    # if at all possible, but if the system doesn't have
+    # $XDG_RUNTIME_DIR defined, we'll have to fall back to something
+    # in the home directory (putting the user at risk of things like
+    # du and find crawling KBFS...).
+    newDefault="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase/kbfs"
     if keybase config get -d -b mountdirdefault &> /dev/null ; then
         # If the current mount directory is still the old default, force
         # an update to the new default.
         default="$(keybase config get -d -b mountdirdefault 2> /dev/null)"
-        oldDefault="${XDG_DATA_HOME:-$HOME/.local/share}/keybase/fs"
-        # For the new default mountpoint, use
-        # /run/user/$UID/keybase/kbfs if at all possible, but if the
-        # system doesn't have $XDG_RUNTIME_DIR defined, we'll have to
-        # fall back to something in the home directory (putting the
-        # user at risk of things like du and find crawling KBFS...).
-        newDefault="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase/kbfs"
         if [ "$default" = "$oldDefault" ]; then
             mountdir="$(keybase config get -d -b mountdir 2> /dev/null)"
             if [ "$mountdir" = "$default" ]; then

--- a/packaging/prerelease/build_kbfs.sh
+++ b/packaging/prerelease/build_kbfs.sh
@@ -21,7 +21,7 @@ tags=${TAGS:-"prerelease production"}
 ldflags="-X github.com/keybase/kbfs/libkbfs.PrereleaseBuild=$kbfs_build"
 pkg="github.com/keybase/kbfs/kbfsfuse"
 git_remote_helper_pkg="github.com/keybase/kbfs/kbfsgit/git-remote-keybase"
-redirector_pkg="github.com/keybase/kbfs/redirector/go"
+redirector_pkg="github.com/keybase/kbfs/redirector"
 
 if [ "$PLATFORM" = "windows" ]; then
   pkg="github.com/keybase/kbfs/kbfsdokan"


### PR DESCRIPTION
New mount points:
* Linux: `/run/user/$UID/keybase/kbfs` if `$XDG_RUNTIME_DIR` is set, `~/.config/keybase/kbfs` otherwise
* macOS: `/Volumes/$username's Keybase`

This is to meant to both a) support multiple local users on the same machine using KBFS, and b) pulling the mount out of the home directory of the user if possible, to avoid `du`/`find`/backup issues that have been popping up on Linux.

Here's what the new dialogue looks like when upgrading Keybase:
<img width="504" alt="screen shot 2018-03-06 at 4 30 35 pm" src="https://user-images.githubusercontent.com/8516691/37067673-c5f62356-215f-11e8-9955-6aba28a279a1.png">
(I have no idea how to force the alert box to not split the lines after a slash, sigh.  I'm still working on that.)

Issue: KBFS-2814