### PR TITLE
Ban CompletedInvites section from team Invite links

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -1424,13 +1424,8 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		return res, nil
 	case libkb.LinkTypeInvite:
 		err = enforce(LinkRules{
-			Admin:   TristateOptional,
-			Invites: TristateRequire,
-			// TODO: CompletedInvites was historically optional but it is also not processed.
-			// We should ban or process it. In order to do this without breaking any teams
-			// we should make sure that no teams have CompletedInvites in an Invite link before
-			// making a change.
-			CompletedInvites:    TristateOptional,
+			Admin:               TristateOptional,
+			Invites:             TristateRequire,
 			AllowInImplicitTeam: true,
 		})
 		if err != nil {


### PR DESCRIPTION
In team Invite links the CompletedInvites section was historically allowed but not processed. From here on any teams with this banned behavior will not be loadable.

- [ ] check that there are no invite links in the db that have a completedinvites section.