### PR TITLE
service: change install timeouts from 120ns to 120s

### DIFF
--- a/go/service/install.go
+++ b/go/service/install.go
@@ -4,6 +4,8 @@
 package service
 
 import (
+	"time"
+
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/install"
@@ -31,13 +33,15 @@ func (h *InstallHandler) FuseStatus(_ context.Context, arg keybase1.FuseStatusAr
 
 func (h *InstallHandler) InstallFuse(context.Context) (keybase1.InstallResult, error) {
 	components := []string{"helper", "fuse"}
-	result := install.Install(h.G(), "", "", components, false, 120, h.G().Log)
+	result := install.Install(
+		h.G(), "", "", components, false, 120*time.Second, h.G().Log)
 	return result, nil
 }
 
 func (h *InstallHandler) InstallKBFS(context.Context) (keybase1.InstallResult, error) {
 	components := []string{"mountdir", "kbfs", "redirector"}
-	result := install.Install(h.G(), "", "", components, false, 120, h.G().Log)
+	result := install.Install(
+		h.G(), "", "", components, false, 120*time.Second, h.G().Log)
 	return result, nil
 }
 
@@ -54,6 +58,7 @@ func (h *InstallHandler) UninstallKBFS(context.Context) (keybase1.UninstallResul
 
 func (h *InstallHandler) InstallCommandLinePrivileged(context.Context) (keybase1.InstallResult, error) {
 	components := []string{"clipaths"}
-	result := install.Install(h.G(), "", "", components, false, 120, h.G().Log)
+	result := install.Install(
+		h.G(), "", "", components, false, 120*time.Second, h.G().Log)
 	return result, nil
 }


### PR DESCRIPTION
This was causing two copies of KBFS to run when launchd didn't report a status within 120ns.  In turn, this caused an KBFS error popup because the disk cache can't be used by two processes at once.

Issue: KBFS-2818