### PR TITLE
use a HOC around Files to fix loading folders

### DIFF
--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -1,6 +1,14 @@
 // @flow
 import * as I from 'immutable'
-import {compose, connect, lifecycle, setDisplayName, type Dispatch, type TypedState} from '../util/container'
+import {
+  compose,
+  connect,
+  lifecycle,
+  mapProps,
+  setDisplayName,
+  type Dispatch,
+  type TypedState,
+} from '../util/container'
 import Files from '.'
 import * as FsGen from '../actions/fs-gen'
 import * as Types from '../constants/types/fs'
@@ -63,18 +71,11 @@ const ConnectedFiles = compose(
 )(Files)
 
 const FilesLoadingHoc = compose(
-  connect(
-    (state, {routeProps}) => ({
-      path: routeProps.get('path', Constants.defaultPath),
-    }),
-    (dispatch: Dispatch) => ({
-      loadFolderList: (path: Types.Path) => dispatch(FsGen.createFolderListLoad({path})),
-    }),
-    ({path}, {loadFolderList}) => ({
-      path,
-      loadFolderList,
-    })
-  ),
+  connect(), // provides `dispatch`
+  mapProps(({routeProps, dispatch}) => ({
+    path: routeProps.get('path', Constants.defaultPath),
+    loadFolderList: (path: Types.Path) => dispatch(FsGen.createFolderListLoad({path})),
+  })),
   lifecycle({
     componentWillMount() {
       this.props.loadFolderList(this.props.path)

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -84,6 +84,9 @@ const FilesLoadingHoc = compose(
     },
     componentWillReceiveProps(nextProps) {
       if (this.props.path === nextProps.path) {
+        // This check is needed since otherwise when e.g. user clicks a popup
+        // menu, we'd end up triggerring loadFolderList too even though we
+        // didn't navigate to a different path.
         return
       }
       this.props.loadFolderList(nextProps.path)

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -83,13 +83,12 @@ const FilesLoadingHoc = compose(
       this.props.loadFolderList(this.props.path)
     },
     componentWillReceiveProps(nextProps) {
-      if (this.props.path === nextProps.path) {
-        // This check is needed since otherwise when e.g. user clicks a popup
-        // menu, we'd end up triggerring loadFolderList too even though we
-        // didn't navigate to a different path.
-        return
+      // This check is needed since otherwise when e.g. user clicks a popup
+      // menu, we'd end up triggerring loadFolderList too even though we didn't
+      // navigate to a different path.
+      if (this.props.path !== nextProps.path) {
+        this.props.loadFolderList(nextProps.path)
       }
-      this.props.loadFolderList(nextProps.path)
     },
   }),
   setDisplayName('FilesLoadingHoc')

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -71,16 +71,21 @@ const ConnectedFiles = compose(
 )(Files)
 
 const FilesLoadingHoc = compose(
-  connect(), // provides `dispatch`
-  mapProps(({routeProps, dispatch}) => ({
-    path: routeProps.get('path', Constants.defaultPath),
+  connect(undefined, (dispatch: Dispatch) => ({
     loadFolderList: (path: Types.Path) => dispatch(FsGen.createFolderListLoad({path})),
+  })),
+  mapProps(({routeProps, loadFolderList}) => ({
+    path: routeProps.get('path', Constants.defaultPath),
+    loadFolderList,
   })),
   lifecycle({
     componentWillMount() {
       this.props.loadFolderList(this.props.path)
     },
-    componentWillUpdate(nextProps) {
+    componentWillReceiveProps(nextProps) {
+      if (this.props.path === nextProps.path) {
+        return
+      }
       this.props.loadFolderList(nextProps.path)
     },
   }),


### PR DESCRIPTION
With the new master `componentWillMount` doesn't fire after route changes anymore; I guess this is a performance improvement to reduce rendering (yay!), but happened to break folder loading. We can't just call trigger `loadFolderList` in a different lifecycle method (e.g. `componentWillUpdate`) since finishing folder listing updates the same component too. So this PR adds a HOC for the connected Files component that watches for `routeProps` changes, and fires `loadFolderList` in both `componentWillMount` and `componentWillUpdate`.