### PR TITLE
Do not return empty tx error in HandleOpenTeamAccessRequest

### DIFF
--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -269,6 +269,11 @@ func HandleOpenTeamAccessRequest(ctx context.Context, g *libkb.GlobalContext, ms
 			g.Log.CDebugf(ctx, "Open team request: adding %v, returned err: %v", uv, err)
 		}
 
+		if tx.IsEmpty() {
+			g.Log.CDebugf(ctx, "Nothing to do - transaction is empty")
+			return nil
+		}
+
 		return tx.Post(ctx)
 	})
 }


### PR DESCRIPTION
Something that came up when I was looking through SBS/OPENREQ code.

In an event when we get OPENREQ notification but all access requests are already granted, we would go through them but end up with empty transaction (because every `AddMemberByUV` would return `libkb.ExistsError`). `tx.Post` on empty tx is an error, but we do not consider this an error condition, so catch this beforehand and return with no error.

Note that even if we did return an error, next time server got around to sending this OPENREQ notification, it would notice that these tars are already granted in `_close_moot_tars`. So while it's a bug, it doesn't have any bad effects right now.