### PR TITLE
unselect the current conversation when going back to the inbox on mobile

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1612,7 +1612,7 @@ const navigateToThread = (_: any, state: TypedState) => {
   }
 }
 
-const mobileClearSelectedConversation = (a: any, state: TypedState) => {
+const mobileClearSelectedConversation = (_: any, state: TypedState) => {
   const routePath = getPath(state.routeTree.routeState)
   const inboxSelected = routePath.size === 1 && routePath.get(0) === chatTab
   if (inboxSelected) {
@@ -1754,7 +1754,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
     yield Saga.safeTakeEvery(Chat2Gen.messageAttachmentNativeSave, messageAttachmentNativeSave)
     // Unselect the conversation when we go to the inbox
     yield Saga.safeTakeEveryPure(
-      [a => typeof a.type === 'string' && a.type.startsWith('routeTree:')],
+      a => typeof a.type === 'string' && a.type.startsWith('routeTree:'),
       mobileClearSelectedConversation
     )
   } else {


### PR DESCRIPTION
@keybase/react-hackers This is to fix the orange bar logic not working on mobile.
When you click into a convo and back out the selected conversation would still be considered selected. This broke the orange bar convo as the its possible the old convo and the new convo are the same so you'd set / unset the orange bar marker in the reducer. It makes sense if you go back to the inbox for there to be no selected conversation ion mobile as that could likely have other things be incorrect