### PR TITLE
add public info to UnboxConversationInfo CORE-7383

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -237,6 +237,11 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv
 	defer b.Trace(ctx, func() error { return uberr }, "UnboxMessage(%s, %d)", conv.GetConvID(),
 		boxed.GetMessageID())()
 	tlfName := boxed.ClientHeader.TLFNameExpanded(conv.GetFinalizeInfo())
+	if conv.IsPublic() != boxed.ClientHeader.TlfPublic {
+		return b.makeErrorMessage(boxed,
+			NewPermanentUnboxingError(fmt.Errorf("visibility mismatch: %v != %v", conv.IsPublic(),
+				boxed.ClientHeader.TlfPublic))), nil
+	}
 	keyMembersType := b.getEffectiveMembersType(ctx, boxed, conv.GetMembersType())
 	nameInfo, err := CtxKeyFinder(ctx, b.G()).FindForDecryption(ctx,
 		tlfName, boxed.ClientHeader.Conv.Tlfid, conv.GetMembersType(),

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -678,6 +678,7 @@ func TestChatMessagePublic(t *testing.T) {
 		conv := chat1.Conversation{
 			Metadata: chat1.ConversationMetadata{
 				ConversationID: convID,
+				Visibility:     keybase1.TLFVisibility_PUBLIC,
 			},
 		}
 

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -673,7 +673,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	// Set up public inbox info if we don't have one with members type from remote call. Assume this is a
 	// public chat here, since it is the only chance we have to unbox it.
 	if unboxConv == nil {
-		unboxConv = newPublicUnboxConverstionInfo(convID, boxed.MembersType)
+		unboxConv = newExtraInboxUnboxConverstionInfo(convID, boxed.MembersType, boxed.Visibility)
 	}
 
 	// Unbox

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -908,8 +908,8 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 		if err != nil {
 			return res, rl, fmt.Errorf("error creating topic ID: %s", err)
 		}
-		n.Debug(ctx, "attempt: %v [tlfID: %s topicType: %d topicID: %s name: %s]", i, triple.Tlfid,
-			triple.TopicType, triple.TopicID, info.CanonicalName)
+		n.Debug(ctx, "attempt: %v [tlfID: %s topicType: %d topicID: %s name: %s public: %v]", i, triple.Tlfid,
+			triple.TopicType, triple.TopicID, info.CanonicalName, isPublic)
 		firstMessageBoxed, topicNameState, err := n.makeFirstMessage(ctx, triple, info.CanonicalName,
 			n.membersType, n.vis, n.topicName)
 		if err != nil {
@@ -973,7 +973,8 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 				fmt.Errorf("newly created conversation fetch error: found %d conversations", len(ib.Convs))
 		}
 		res = ib.Convs[0]
-		n.Debug(ctx, "fetched conv: %v", res.GetConvID())
+		n.Debug(ctx, "fetched conv: %v mt: %v public: %v", res.GetConvID(), res.GetMembersType(),
+			res.IsPublic())
 
 		// Update inbox cache
 		updateConv := ib.ConvsUnverified[0]

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2580,7 +2580,11 @@ func (h *Server) UnboxMobilePushNotification(ctx context.Context, arg chat1.Unbo
 	if err != nil {
 		h.Debug(ctx, "UnboxMobilePushNotification: failed to push message to conv source: %s", err.Error())
 		// Try to just unbox without pushing
-		unboxInfo := newBasicUnboxConversationInfo(convID, arg.MembersType, nil)
+		vis := keybase1.TLFVisibility_PRIVATE
+		if msgBoxed.ClientHeader.TlfPublic {
+			vis = keybase1.TLFVisibility_PUBLIC
+		}
+		unboxInfo := newBasicUnboxConversationInfo(convID, arg.MembersType, nil, vis)
 		if msgUnboxed, err = NewBoxer(h.G()).UnboxMessage(ctx, msgBoxed, unboxInfo); err != nil {
 			h.Debug(ctx, "UnboxMobilePushNotification: failed simple unbox as well, bailing: %s", err.Error())
 			return res, err

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2408,6 +2408,7 @@ func TestChatSrvGetThreadNonblockError(t *testing.T) {
 		}
 		require.NoError(t, ctc.world.Tcs[users[0].Username].ChatG.ConvSource.Clear(conv.Id, uid))
 		g := ctc.world.Tcs[users[0].Username].ChatG
+		ri := ctc.as(t, users[0]).ri
 		g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
 			return chat1.RemoteClient{Cli: errorClient{}}
 		})
@@ -2423,9 +2424,7 @@ func TestChatSrvGetThreadNonblockError(t *testing.T) {
 		require.Error(t, err)
 
 		// Advance clock and look for stale
-		g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
-			return kbtest.NewChatRemoteMock(ctc.world)
-		})
+		g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface { return ri })
 		ctc.world.Fc.Advance(time.Hour)
 
 		select {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -43,6 +43,7 @@ type UnboxConversationInfo interface {
 	GetMembersType() chat1.ConversationMembersType
 	GetFinalizeInfo() *chat1.ConversationFinalizeInfo
 	GetExpunge() *chat1.Expunge
+	IsPublic() bool
 }
 
 type ConversationSource interface {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -608,6 +608,10 @@ func (c ConversationLocal) GetExpunge() *Expunge {
 	return &c.Expunge
 }
 
+func (c ConversationLocal) IsPublic() bool {
+	return c.Info.Visibility == keybase1.TLFVisibility_PUBLIC
+}
+
 func (c ConversationLocal) GetMaxMessage(typ MessageType) (MessageUnboxed, error) {
 	for _, msg := range c.MaxMessages {
 		if msg.GetMessageType() == typ {
@@ -646,6 +650,10 @@ func (c Conversation) GetFinalizeInfo() *ConversationFinalizeInfo {
 
 func (c Conversation) GetExpunge() *Expunge {
 	return &c.Expunge
+}
+
+func (c Conversation) IsPublic() bool {
+	return c.Metadata.Visibility == keybase1.TLFVisibility_PUBLIC
 }
 
 func (c Conversation) GetMaxMessage(typ MessageType) (MessageSummary, error) {

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -150,6 +150,7 @@ func (o GetInboxByTLFIDRemoteRes) DeepCopy() GetInboxByTLFIDRemoteRes {
 type GetThreadRemoteRes struct {
 	Thread      ThreadViewBoxed         `codec:"thread" json:"thread"`
 	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
+	Visibility  keybase1.TLFVisibility  `codec:"visibility" json:"visibility"`
 	RateLimit   *RateLimit              `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
@@ -157,6 +158,7 @@ func (o GetThreadRemoteRes) DeepCopy() GetThreadRemoteRes {
 	return GetThreadRemoteRes{
 		Thread:      o.Thread.DeepCopy(),
 		MembersType: o.MembersType.DeepCopy(),
+		Visibility:  o.Visibility.DeepCopy(),
 		RateLimit: (func(x *RateLimit) *RateLimit {
 			if x == nil {
 				return nil

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -66,6 +66,7 @@ protocol remote {
   record GetThreadRemoteRes {
     ThreadViewBoxed thread;
     ConversationMembersType membersType;
+    keybase1.TLFVisibility visibility;
     union { null, RateLimit } rateLimit;
   }
 

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -807,7 +807,7 @@ export type GetThreadNonblockReason =
 
 export type GetThreadQuery = $ReadOnly<{markAsRead: Boolean, messageTypes?: ?Array<MessageType>, disableResolveSupersedes: Boolean, before?: ?Gregor1.Time, after?: ?Gregor1.Time, messageIDControl?: ?MessageIDControl}>
 
-export type GetThreadRemoteRes = $ReadOnly<{thread: ThreadViewBoxed, membersType: ConversationMembersType, rateLimit?: ?RateLimit}>
+export type GetThreadRemoteRes = $ReadOnly<{thread: ThreadViewBoxed, membersType: ConversationMembersType, visibility: Keybase1.TLFVisibility, rateLimit?: ?RateLimit}>
 
 export type GlobalAppNotificationSetting =
   | 0 // NEWMESSAGES_0

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -129,6 +129,10 @@
           "name": "membersType"
         },
         {
+          "type": "keybase1.TLFVisibility",
+          "name": "visibility"
+        },
+        {
           "type": [
             null,
             "RateLimit"

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -807,7 +807,7 @@ export type GetThreadNonblockReason =
 
 export type GetThreadQuery = $ReadOnly<{markAsRead: Boolean, messageTypes?: ?Array<MessageType>, disableResolveSupersedes: Boolean, before?: ?Gregor1.Time, after?: ?Gregor1.Time, messageIDControl?: ?MessageIDControl}>
 
-export type GetThreadRemoteRes = $ReadOnly<{thread: ThreadViewBoxed, membersType: ConversationMembersType, rateLimit?: ?RateLimit}>
+export type GetThreadRemoteRes = $ReadOnly<{thread: ThreadViewBoxed, membersType: ConversationMembersType, visibility: Keybase1.TLFVisibility, rateLimit?: ?RateLimit}>
 
 export type GlobalAppNotificationSetting =
   | 0 // NEWMESSAGES_0


### PR DESCRIPTION
We currently pull the public status of a conversation off of the message itself in `UnboxMessage`, but this can be wrong, and cause an error to propagate incorrectly. Change it to pull the public-ness from the conversation data itself, so that if a message has the wrong public bit set on the `ClientHeader`, that single message itself just gets marked as a failure. 

Needs: https://github.com/keybase/keybase/pull/2206