### PR TITLE
Do not try to import stubbed keys to kb pgp keychain

### DIFF
--- a/go/engine/errors.go
+++ b/go/engine/errors.go
@@ -31,3 +31,14 @@ func (e GPGExportingError) Error() string {
 	}
 	return e.err.Error()
 }
+
+//=============================================================================
+
+type PGPImportStubbedError struct {
+	KeyIDString string
+}
+
+func (e PGPImportStubbedError) Error() string {
+	return fmt.Sprintf("Key %s has private part stubbed - cannot import to Keybase keychain. Try again with --no-import.",
+		e.KeyIDString)
+}

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -202,6 +202,10 @@ func (e *GPGImportKeyEngine) Run(ctx *Context) (err error) {
 			return fmt.Errorf("ImportKey (secret: true) error: %s", err)
 		}
 
+		if !libkb.FindPGPPrivateKey(bundle) {
+			return PGPImportStubbedError{KeyIDString: selected.GetFingerprint().ToKeyID()}
+		}
+
 		if err := bundle.Unlock(e.G(), "Import of key into Keybase keyring", ctx.SecretUI); err != nil {
 			return err
 		}

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -558,14 +558,17 @@ func (k PGPKeyBundle) GetPrimaryUID() string {
 	return s
 }
 
+// HasSecretKey checks if the PGPKeyBundle contains secret key. This
+// function returning true does not indicate that the key is
+// functional - it may also be a key stub.
 func (k *PGPKeyBundle) HasSecretKey() bool {
 	return k.PrivateKey != nil
 }
 
-// findPGPPrivateKey checks if supposed secret key PGPKeyBundle
+// FindPGPPrivateKey checks if supposed secret key PGPKeyBundle
 // contains any valid PrivateKey entities. Sometimes primary private
 // key is stupped out but there are subkeys with secret keys.
-func findPGPPrivateKey(k *PGPKeyBundle) bool {
+func FindPGPPrivateKey(k *PGPKeyBundle) bool {
 	if k.PrivateKey.PrivateKey != nil {
 		return true
 	}
@@ -584,7 +587,7 @@ func (k *PGPKeyBundle) CheckSecretKey() (err error) {
 		err = NoSecretKeyError{}
 	} else if k.PrivateKey.Encrypted {
 		err = BadKeyError{"PGP key material should be unencrypted"}
-	} else if !findPGPPrivateKey(k) && k.GPGFallbackKey == nil {
+	} else if !FindPGPPrivateKey(k) && k.GPGFallbackKey == nil {
 		err = BadKeyError{"no private key material or GPGKey"}
 	}
 	return


### PR DESCRIPTION
Do not let user to get into a situation when they have a private key imported that is unable to decrypt/sign anything because it's a stub.