### PR TITLE
packaging: hardcode root's redirector log path

### DIFF
--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -44,7 +44,7 @@ run_redirector() {
   if redirector_enabled ; then
     # Hardcode the logdir instead of using $HOME, because `sudo` on
     # Ubuntu preserves the user's $HOME for some reason.
-    logdir="/root/.cache/keybase"
+    logdir="/var/log/keybase"
     mkdir -p "$logdir"
     echo Starting root redirector at $rootmount.
     nohup "$krbin" "$rootmount" >> "$logdir/keybase.redirector.log" 2>&1 &

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -42,7 +42,9 @@ run_redirector() {
 
   # Only start the root redirector if it hasn't been explicitly disabled.
   if redirector_enabled ; then
-    logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
+    # Hardcode the logdir instead of using $HOME, because `sudo` on
+    # Ubuntu preserves the user's $HOME for some reason.
+    logdir="/root/.cache/keybase"
     mkdir -p "$logdir"
     echo Starting root redirector at $rootmount.
     nohup "$krbin" "$rootmount" >> "$logdir/keybase.redirector.log" 2>&1 &

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -157,11 +157,14 @@ run_redirector() {
 
   # Only start the root redirector if it hasn't been explicitly disabled.
   if [ "$disable" != "true" ]; then
-    # There's no good place to put logs as a user, since this binary
-    # will suid to root and be unable to write to ~/.cache/keybase.
-    # But I think it would also race to write to /root/.cache/keybase
-    # if it doesn't suid fast enough.
-    nohup keybase-redirector /keybase &> /dev/null &
+    log="${XDG_CACHE_HOME:-$HOME/.cache}/keybase/keybase.redirector.log"
+    # An older version of post_install.sh could have made a redirector log
+    # here that's owned by root.  If we can't write to it, then just nuke it
+    # and overwrite.
+    if [ -e "$log" -a ! -w "$log" ]; then
+      rm -f "$log" &> /dev/null
+    fi
+    nohup keybase-redirector /keybase >> "$log" 2>&1 &
   fi
 }
 

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -157,8 +157,11 @@ run_redirector() {
 
   # Only start the root redirector if it hasn't been explicitly disabled.
   if [ "$disable" != "true" ]; then
-    logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
-    nohup keybase-redirector /keybase >> "$logdir/keybase.redirector.log" 2>&1 &
+    # There's no good place to put logs as a user, since this binary
+    # will suid to root and be unable to write to ~/.cache/keybase.
+    # But I think it would also race to write to /root/.cache/keybase
+    # if it doesn't suid fast enough.
+    nohup keybase-redirector /keybase &> /dev/null &
   fi
 }
 

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -162,7 +162,7 @@ run_redirector() {
     # here that's owned by root.  If we can't write to it, then just nuke it
     # and overwrite.
     if [ -e "$log" -a ! -w "$log" ]; then
-      rm -f "$log" &> /dev/null
+      rm -f "$log"
     fi
     nohup keybase-redirector /keybase >> "$log" 2>&1 &
   fi


### PR DESCRIPTION
Because sudo on Ubuntu preserves HOME, so the root user would end up writing to the user's home directory, making the file unwritable by future `run_keybase` calls.

Issue: KBFS-2824