### PR TITLE
Fix 'prompt attempts exhausted' error in GUI login/provisioning

### DIFF
--- a/shared/actions/login.js
+++ b/shared/actions/login.js
@@ -484,7 +484,8 @@ function* handleProvisioningError(error): Generator<any, void, any> {
 
 function* loginFlowSaga(usernameOrEmail, passphrase): Generator<any, void, any> {
   // If there is passphrase, use that.
-  const passphraseSaga = passphrase
+  const passphraseEntered = passphrase && passphrase.stringValue && passphrase.stringValue() !== ''
+  const passphraseSaga = passphraseEntered
     ? onBackSaga => () =>
         EngineRpc.rpcResult({
           passphrase: passphrase ? passphrase.stringValue() : 'NEVER HAPPENS',


### PR DESCRIPTION
@keybase/react-hackers 

After a login saga refactor, we decide whether to register a secretUi handler depending on whether we think we already know a passphrase, but the test we use is invalid because it treats having `HiddenString("")` as already knowing a passphrase.  This change fixes these cases:

1:
* logout in gui
* in gui login screen where there is a dropdown with usernames, don't enter a passphrase
* press login button

2:
* provision two devices for a user, a and b, and a paper key
* on device a, revoke device b
* on device b, logout if not already
* gui login screen will show you a dropdown with usernames. select the username you are using. don't enter a passphrase
* you'll get to the device select screen, choose the paper key
* you'll see prompt attempts exhausted err