### PR TITLE
Disambiguate prompt confirmation text

### DIFF
--- a/go/client/chat_common.go
+++ b/go/client/chat_common.go
@@ -51,12 +51,12 @@ func postRetentionPolicy(ctx context.Context, lcli chat1.LocalClient, tui libkb.
 	teamWide := teamInvolved && !setChannel
 
 	if doPrompt {
-		promptText := fmt.Sprintf("Set the conversation retention policy?\nHit Enter, or Ctrl-C to cancel.")
+		promptText := fmt.Sprintf("Set the conversation retention policy?\nHit Enter to confirm, or Ctrl-C to cancel.")
 		if teamInvolved {
-			promptText = fmt.Sprintf("Set the channel retention policy?\nHit Enter, or Ctrl-C to cancel.")
+			promptText = fmt.Sprintf("Set the channel retention policy?\nHit Enter to confirm, or Ctrl-C to cancel.")
 		}
 		if teamWide {
-			promptText = fmt.Sprintf("Set the team-wide retention policy?\nHit Enter, or Ctrl-C to cancel.")
+			promptText = fmt.Sprintf("Set the team-wide retention policy?\nHit Enter to confirm, or Ctrl-C to cancel.")
 		}
 		_, err = tui.Prompt(PromptDescriptorChatSetRetention, promptText)
 		if err != nil {

--- a/go/client/cmd_chat_delete_history.go
+++ b/go/client/cmd_chat_delete_history.go
@@ -185,9 +185,9 @@ func (c *CmdChatDeleteHistory) chatSendDeleteHistory(ctx context.Context) error 
 	}
 
 	// Ask for confirmation on this destructive operation.
-	promptText := fmt.Sprintf("Permanently delete ALL chat history of [%s]?\nHit Enter, or Ctrl-C to cancel.", chatFullName)
+	promptText := fmt.Sprintf("Permanently delete ALL chat history of [%s]?\nHit Enter to confirm, or Ctrl-C to cancel.", chatFullName)
 	if c.age != gregor1.DurationSec(0) {
-		promptText = fmt.Sprintf("Permanently delete all chat messages in [%s] older than %v?\nHit Enter, or Ctrl-C to cancel.",
+		promptText = fmt.Sprintf("Permanently delete all chat messages in [%s] older than %v?\nHit Enter to confirm, or Ctrl-C to cancel.",
 			chatFullName, c.ageDesc)
 	}
 	_, err = c.G().UI.GetTerminalUI().Prompt(PromptDescriptorChatDeleteHistory, promptText)


### PR DESCRIPTION
```
$ keybase chat delete-history cn10
Found PRIVATE CHAT conversation: cn10,cn8
Permanently delete ALL chat history of [cn10,cn8]?
Hit Enter to confirm, or Ctrl-C to cancel.
```
