### PR TITLE
Expose 'keybase chat retention-policy' on prod builds

### DIFF
--- a/go/client/cmd_chat.go
+++ b/go/client/cmd_chat.go
@@ -27,6 +27,7 @@ func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 		newCmdChatMute(cl, g),
 		newCmdChatRead(cl, g),
 		newCmdChatReport(cl, g),
+		newCmdChatSetRetention(cl, g),
 		newCmdChatSearch(cl, g),
 		newCmdChatSend(cl, g),
 		newCmdChatUpload(cl, g),

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -37,7 +37,6 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 func getBuildSpecificChatCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
 	return []cli.Command{
 		newCmdChatDeleteHistoryDev(cl, g),
-		newCmdChatSetRetention(cl, g),
 		newCmdChatSetRetentionDev(cl, g),
 		newCmdChatKBFSUpgrade(cl, g),
 	}


### PR DESCRIPTION
It's time. https://github.com/keybase/keybase/pull/2208 just greylisted clients before a commit after of https://github.com/keybase/client/pull/10526.

So by the next release hopefully they will all have upgraded. And we could blacklist them if that's not interested.

Git history:
old ...
`9e76db5`: https://github.com/keybase/client/pull/10360
`2e50fdf ` https://github.com/keybase/client/pull/10526
`7de6437` (minimum recommended by https://github.com/keybase/keybase/pull/2208)
... new
