### PR TITLE
sort participants and better scoring. include timestamp in sort a little bit

### DIFF
--- a/shared/chat/inbox/container/__tests__/container.test.js
+++ b/shared/chat/inbox/container/__tests__/container.test.js
@@ -17,7 +17,7 @@ describe('inbox container tests', () => {
     expect(_testing.score('nothing', 'myname', ['a', 'b', 'c'])).toBe(0)
   })
   it('searching for exact', () => {
-    const oneExactScore = 1 / 3
+    const oneExactScore = 100 / 3
     expect(_testing.score('exact', 'myname', ['exact', 'b', 'c'])).toBeCloseTo(oneExactScore)
     expect(_testing.score('exact', 'myname', ['a', 'exact', 'c'])).toBeCloseTo(oneExactScore)
     expect(_testing.score('exact', 'myname', ['a', 'b', 'exact'])).toBeCloseTo(oneExactScore)

--- a/shared/chat/inbox/container/filtered.js
+++ b/shared/chat/inbox/container/filtered.js
@@ -12,13 +12,13 @@ const score = (lcFilter: string, lcYou: string, names: Array<string>): number =>
   return (
     namesMinusYou.reduce((total, p) => {
       if (p === lcFilter) {
-        return total + 1 // exact match
+        return total + 100 // exact match
       } else {
         const idx = p.indexOf(lcFilter)
         if (idx === 0) {
-          return total + 0.8 // prefix match
+          return total + 75 // prefix match
         } else if (idx !== -1) {
-          return total + 0.5 // sub match
+          return total + 10 // sub match
         } else {
           return total
         }
@@ -47,10 +47,11 @@ const getFilteredRowsAndMetadata = createSelector(
             lcYou,
             [...(meta.teamname || '').split(','), ...meta.participants.toArray()].filter(Boolean)
           ),
+          timestamp: meta.timestamp,
         }
       })
       .filter(r => r.score > 0)
-      .sort((a, b) => b.score - a.score)
+      .sort((a, b) => (a.score === b.score ? b.timestamp - a.timestamp : b.score - a.score))
       .map(({conversationIDKey}) => ({conversationIDKey, type: 'small'}))
       .valueSeq()
       .toArray()

--- a/shared/chat/inbox/row/filter-small-team/container.js
+++ b/shared/chat/inbox/row/filter-small-team/container.js
@@ -11,6 +11,7 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   const conversationIDKey = ownProps.conversationIDKey
 
   return {
+    _filter: state.chat2.inboxFilter.toLowerCase(),
     _hasUnread: Constants.getHasUnread(state, conversationIDKey),
     _meta: Constants.getMeta(state, conversationIDKey),
     _username: state.config.username || '',
@@ -31,13 +32,32 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const youNeedToRekey = !participantNeedToRekey && stateProps._meta.rekeyers.has(stateProps._username)
   const isLocked = participantNeedToRekey || youNeedToRekey
 
+  // order participants by hit
+  const participants = Constants.getRowParticipants(stateProps._meta, stateProps._username)
+    .toArray()
+    .sort((a, b) => {
+      const ai = a.indexOf(stateProps._filter)
+      const bi = b.indexOf(stateProps._filter)
+
+      if (ai === -1) {
+        return bi === -1 ? -1 : 1
+      } else if (bi === -1) {
+        return -1
+      } else {
+        if (bi === 0) {
+          return 1
+        }
+        return -1
+      }
+    })
+
   return {
     backgroundColor: styles.backgroundColor,
     isLocked,
     isMuted: stateProps._meta.isMuted,
     isSelected,
     onSelectConversation: dispatchProps.onSelectConversation,
-    participants: Constants.getRowParticipants(stateProps._meta, stateProps._username).toArray(),
+    participants,
     showBold: styles.showBold,
     teamname: stateProps._meta.teamname,
     usernameColor: styles.usernameColor,


### PR DESCRIPTION
@keybase/react-hackers cc: @mmaxim 
this makes filter better. it changes the scoring to increase the power of a prefix/exact match and sorts participants