### PR TITLE
run a background process to upgrade KBFS chats to implicit team CORE-7013

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -8,7 +8,7 @@ vet:
 	go vet ./...
 
 lint:
-	golint ./... | grep -v ^vendor | grep -v ^protocol | grep -v comment | grep -v KeysById | grep -v "error should be the last type" | grep -v stutters | grep -v "error strings should not be capitalized" || echo "Lint-free!"
+	golint ./... | grep -v ^vendor | grep -v ^protocol | grep -v comment | grep -v KeysById | grep -v "error should be the last type" | grep -v stutters | grep -v "error strings should not be capitalized" || echo "Lint-free!" | grep -v prot.go
 
 # to run splint, first do this:  go get stathat.com/c/splint
 splint:

--- a/go/Makefile
+++ b/go/Makefile
@@ -8,7 +8,7 @@ vet:
 	go vet ./...
 
 lint:
-	golint ./... | grep -v ^vendor | grep -v ^protocol | grep -v comment | grep -v KeysById | grep -v "error should be the last type" | grep -v stutters | grep -v "error strings should not be capitalized" || echo "Lint-free!" | grep -v prot.go
+	golint ./... | grep -v ^vendor | grep -v ^protocol | grep -v comment | grep -v KeysById | grep -v "error should be the last type" | grep -v stutters | grep -v "error strings should not be capitalized" | grep -v prot.go || echo "Lint-free!"
 
 # to run splint, first do this:  go get stathat.com/c/splint
 splint:

--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -117,7 +117,11 @@ func Context(ctx context.Context, g *globals.Context, mode keybase1.TLFIdentifyB
 	if breaks == nil {
 		breaks = new([]keybase1.TLFIdentifyFailure)
 	}
-	res := IdentifyModeCtx(ctx, mode, breaks)
+	res := ctx
+	_, _, ok := IdentifyMode(res)
+	if !ok {
+		res = IdentifyModeCtx(res, mode, breaks)
+	}
 	val := res.Value(kfKey)
 	if _, ok := val.(KeyFinder); !ok {
 		res = context.WithValue(res, kfKey, NewKeyFinder(g))
@@ -130,7 +134,9 @@ func Context(ctx context.Context, g *globals.Context, mode keybase1.TLFIdentifyB
 	if _, ok := val.(types.UPAKFinder); !ok {
 		res = context.WithValue(res, upKey, NewCachingUPAKFinder(g))
 	}
-	res = CtxAddLogTags(res, g.GetEnv())
+	if _, ok = CtxTrace(res); !ok {
+		res = CtxAddLogTags(res, g.GetEnv())
+	}
 	return res
 }
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -187,7 +187,10 @@ func (h *Helper) GetChannelTopicName(ctx context.Context, teamID keybase1.TeamID
 	return topicName, err
 }
 
-func (h *Helper) UpgradeKBFSToImpteam(ctx context.Context, tlfName string, tlfID chat1.TLFID, public bool) error {
+func (h *Helper) UpgradeKBFSToImpteam(ctx context.Context, tlfName string, tlfID chat1.TLFID, public bool) (err error) {
+	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, nil, NewCachingIdentifyNotifier(h.G()))
+	defer h.Trace(ctx, func() error { return err }, "ChatHelper.UpgradeKBFSToImpteam(%s,%s,%v)",
+		tlfID, tlfName, public)()
 	var cryptKeys []keybase1.CryptKey
 	ni, err := CtxKeyFinder(ctx, h.G()).FindForEncryption(ctx, tlfName, tlfID,
 		chat1.ConversationMembersType_KBFS, public)

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -187,6 +187,26 @@ func (h *Helper) GetChannelTopicName(ctx context.Context, teamID keybase1.TeamID
 	return topicName, err
 }
 
+func (h *Helper) UpgradeKBFSToImpteam(ctx context.Context, tlfName string, tlfID chat1.TLFID, public bool) error {
+	var cryptKeys []keybase1.CryptKey
+	ni, err := CtxKeyFinder(ctx, h.G()).FindForEncryption(ctx, tlfName, tlfID,
+		chat1.ConversationMembersType_KBFS, public)
+	if err != nil {
+		return err
+	}
+	for _, key := range ni.CryptKeys[chat1.ConversationMembersType_KBFS] {
+		cryptKeys = append(cryptKeys, keybase1.CryptKey{
+			KeyGeneration: key.Generation(),
+			Key:           key.Material(),
+		})
+	}
+	tlfName = ni.CanonicalName
+	h.Debug(ctx, "UpgradeKBFSToImpteam: upgrading: TlfName: %s TLFID: %s public: %v keys: %d",
+		tlfName, tlfID, public, len(cryptKeys))
+	return teams.UpgradeTLFIDToImpteam(ctx, h.G().ExternalG(), tlfName, keybase1.TLFID(tlfID.String()),
+		public, keybase1.TeamApplication_CHAT, cryptKeys)
+}
+
 type sendHelper struct {
 	utils.DebugLabeler
 

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2707,27 +2707,10 @@ func (h *Server) UpgradeKBFSConversationToImpteam(ctx context.Context, convID ch
 	if conv.GetMembersType() != chat1.ConversationMembersType_KBFS {
 		return fmt.Errorf("cannot upgrade %v conversation", conv.GetMembersType())
 	}
-
-	var cryptKeys []keybase1.CryptKey
 	tlfID := conv.Info.Triple.Tlfid
 	tlfName := conv.Info.TlfName
 	public := conv.Info.Visibility == keybase1.TLFVisibility_PUBLIC
-	ni, err := CtxKeyFinder(ctx, h.G()).Find(ctx, tlfName, conv.GetMembersType(), public)
-	if err != nil {
-		return err
-	}
-	for _, key := range ni.CryptKeys[chat1.ConversationMembersType_KBFS] {
-		cryptKeys = append(cryptKeys, keybase1.CryptKey{
-			KeyGeneration: key.Generation(),
-			Key:           key.Material(),
-		})
-	}
-	tlfName = ni.CanonicalName
-	h.Debug(ctx, "UpgradeKBFSConversationToImpteam: upgrading: TlfName: %s TLFID: %s public: %v keys: %d",
-		tlfName, tlfID, public, len(cryptKeys))
-
-	return teams.UpgradeTLFIDToImpteam(ctx, h.G().ExternalG(), tlfName, keybase1.TLFID(tlfID.String()),
-		public, keybase1.TeamApplication_CHAT, cryptKeys)
+	return h.G().ChatHelper.UpgradeKBFSToImpteam(ctx, tlfName, tlfID, public)
 }
 
 func (h *Server) GetSearchRegexp(ctx context.Context, arg chat1.GetSearchRegexpArg) (res chat1.GetSearchRegexpRes, err error) {

--- a/go/git/common_test.go
+++ b/go/git/common_test.go
@@ -163,6 +163,11 @@ func (m *mockChatHelper) GetChannelTopicName(ctx context.Context, teamID keybase
 	return "", fmt.Errorf("mockChatHelper.GetChannelTopicName conv not found %v", convID)
 }
 
+func (m *mockChatHelper) UpgradeKBFSToImpteam(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	public bool) error {
+	return nil
+}
+
 func (m *mockChatHelper) convKey(name string, topicName *string) string {
 	if topicName == nil {
 		return name + ":general"

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -720,4 +720,5 @@ type ChatHelper interface {
 		membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility) ([]chat1.ConversationLocal, error)
 	FindConversationsByID(ctx context.Context, convIDs []chat1.ConversationID) ([]chat1.ConversationLocal, error)
 	GetChannelTopicName(context.Context, keybase1.TeamID, chat1.TopicType, chat1.ConversationID) (string, error)
+	UpgradeKBFSToImpteam(ctx context.Context, tlfName string, tlfID chat1.TLFID, public bool) error
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/keybase/client/go/pvlsource"
 	"github.com/keybase/client/go/systemd"
 	"github.com/keybase/client/go/teams"
+	"github.com/keybase/client/go/tlfupgrade"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
@@ -314,6 +315,7 @@ func (d *Service) RunBackgroundOperations(uir *UIRouter) {
 	d.runBackgroundIdentifier()
 	d.runBackgroundPerUserKeyUpgrade()
 	d.runBackgroundPerUserKeyUpkeep()
+	d.runTLFUpgrade()
 	go d.identifySelf()
 }
 
@@ -429,6 +431,11 @@ func (d *Service) identifySelf() {
 			d.G().Log.Debug("identifySelf: updated full self cache for: %s", self.GetName())
 		}
 	}
+}
+
+func (d *Service) runTLFUpgrade() {
+	upgrader := tlfupgrade.NewBackgroundTLFUpdater(d.G())
+	upgrader.Run()
 }
 
 func (d *Service) runBackgroundIdentifier() {

--- a/go/tlfupgrade/prot.go
+++ b/go/tlfupgrade/prot.go
@@ -1,0 +1,250 @@
+package tlfupgrade
+
+import (
+	"errors"
+
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type GetTLFForUpgradeResType int
+
+const (
+	GetTLFForUpgradeResType_TLFAVAILABLE GetTLFForUpgradeResType = 0
+	GetTLFForUpgradeResType_DELAY        GetTLFForUpgradeResType = 1
+	GetTLFForUpgradeResType_ERR          GetTLFForUpgradeResType = 2
+	GetTLFForUpgradeResType_DISABLED     GetTLFForUpgradeResType = 3
+)
+
+func (o GetTLFForUpgradeResType) DeepCopy() GetTLFForUpgradeResType { return o }
+
+var GetTLFForUpgradeResTypeMap = map[string]GetTLFForUpgradeResType{
+	"TLFAVAILABLE": 0,
+	"DELAY":        1,
+	"ERR":          2,
+	"DISABLED":     3,
+}
+
+var GetTLFForUpgradeResTypeRevMap = map[GetTLFForUpgradeResType]string{
+	0: "TLFAVAILABLE",
+	1: "DELAY",
+	2: "ERR",
+	3: "DISABLED",
+}
+
+func (e GetTLFForUpgradeResType) String() string {
+	if v, ok := GetTLFForUpgradeResTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type DelayReason int
+
+const (
+	DelayReason_MISS     DelayReason = 0
+	DelayReason_INFLIGHT DelayReason = 1
+)
+
+func (o DelayReason) DeepCopy() DelayReason { return o }
+
+var DelayReasonMap = map[string]DelayReason{
+	"MISS":     0,
+	"INFLIGHT": 1,
+}
+
+var DelayReasonRevMap = map[DelayReason]string{
+	0: "MISS",
+	1: "INFLIGHT",
+}
+
+func (e DelayReason) String() string {
+	if v, ok := DelayReasonRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type GetTLFForUpgradeAvailableRes struct {
+	TlfID    keybase1.TLFID `codec:"tlfID" json:"tlfID"`
+	TlfName  string         `codec:"tlfName" json:"tlfName"`
+	IsPublic bool           `codec:"isPublic" json:"isPublic"`
+}
+
+func (o GetTLFForUpgradeAvailableRes) DeepCopy() GetTLFForUpgradeAvailableRes {
+	return GetTLFForUpgradeAvailableRes{
+		TlfID:    o.TlfID.DeepCopy(),
+		TlfName:  o.TlfName,
+		IsPublic: o.IsPublic,
+	}
+}
+
+type GetTLFForUpgradeDelayRes struct {
+	Delay  gregor1.Time `codec:"delay" json:"delay"`
+	Reason DelayReason  `codec:"reason" json:"reason"`
+}
+
+func (o GetTLFForUpgradeDelayRes) DeepCopy() GetTLFForUpgradeDelayRes {
+	return GetTLFForUpgradeDelayRes{
+		Delay:  o.Delay.DeepCopy(),
+		Reason: o.Reason.DeepCopy(),
+	}
+}
+
+type GetTLFForUpgradeErrRes struct {
+	Error string       `codec:"error" json:"error"`
+	Delay gregor1.Time `codec:"delay" json:"delay"`
+}
+
+func (o GetTLFForUpgradeErrRes) DeepCopy() GetTLFForUpgradeErrRes {
+	return GetTLFForUpgradeErrRes{
+		Error: o.Error,
+		Delay: o.Delay.DeepCopy(),
+	}
+}
+
+type GetTLFForUpgradeDisabledRes struct {
+	Delay gregor1.Time `codec:"delay" json:"delay"`
+}
+
+func (o GetTLFForUpgradeDisabledRes) DeepCopy() GetTLFForUpgradeDisabledRes {
+	return GetTLFForUpgradeDisabledRes{
+		Delay: o.Delay.DeepCopy(),
+	}
+}
+
+type GetTLFForUpgradeRes struct {
+	Typ__          GetTLFForUpgradeResType       `codec:"typ" json:"typ"`
+	Tlfavailable__ *GetTLFForUpgradeAvailableRes `codec:"tlfavailable,omitempty" json:"tlfavailable,omitempty"`
+	Delay__        *GetTLFForUpgradeDelayRes     `codec:"delay,omitempty" json:"delay,omitempty"`
+	Err__          *GetTLFForUpgradeErrRes       `codec:"err,omitempty" json:"err,omitempty"`
+	Disabled__     *GetTLFForUpgradeDisabledRes  `codec:"disabled,omitempty" json:"disabled,omitempty"`
+}
+
+func (o *GetTLFForUpgradeRes) Typ() (ret GetTLFForUpgradeResType, err error) {
+	switch o.Typ__ {
+	case GetTLFForUpgradeResType_TLFAVAILABLE:
+		if o.Tlfavailable__ == nil {
+			err = errors.New("unexpected nil value for Tlfavailable__")
+			return ret, err
+		}
+	case GetTLFForUpgradeResType_DELAY:
+		if o.Delay__ == nil {
+			err = errors.New("unexpected nil value for Delay__")
+			return ret, err
+		}
+	case GetTLFForUpgradeResType_ERR:
+		if o.Err__ == nil {
+			err = errors.New("unexpected nil value for Err__")
+			return ret, err
+		}
+	case GetTLFForUpgradeResType_DISABLED:
+		if o.Disabled__ == nil {
+			err = errors.New("unexpected nil value for Disabled__")
+			return ret, err
+		}
+	}
+	return o.Typ__, nil
+}
+
+func (o GetTLFForUpgradeRes) Tlfavailable() (res GetTLFForUpgradeAvailableRes) {
+	if o.Typ__ != GetTLFForUpgradeResType_TLFAVAILABLE {
+		panic("wrong case accessed")
+	}
+	if o.Tlfavailable__ == nil {
+		return
+	}
+	return *o.Tlfavailable__
+}
+
+func (o GetTLFForUpgradeRes) Delay() (res GetTLFForUpgradeDelayRes) {
+	if o.Typ__ != GetTLFForUpgradeResType_DELAY {
+		panic("wrong case accessed")
+	}
+	if o.Delay__ == nil {
+		return
+	}
+	return *o.Delay__
+}
+
+func (o GetTLFForUpgradeRes) Err() (res GetTLFForUpgradeErrRes) {
+	if o.Typ__ != GetTLFForUpgradeResType_ERR {
+		panic("wrong case accessed")
+	}
+	if o.Err__ == nil {
+		return
+	}
+	return *o.Err__
+}
+
+func (o GetTLFForUpgradeRes) Disabled() (res GetTLFForUpgradeDisabledRes) {
+	if o.Typ__ != GetTLFForUpgradeResType_DISABLED {
+		panic("wrong case accessed")
+	}
+	if o.Disabled__ == nil {
+		return
+	}
+	return *o.Disabled__
+}
+
+func NewGetTLFForUpgradeResWithTlfavailable(v GetTLFForUpgradeAvailableRes) GetTLFForUpgradeRes {
+	return GetTLFForUpgradeRes{
+		Typ__:          GetTLFForUpgradeResType_TLFAVAILABLE,
+		Tlfavailable__: &v,
+	}
+}
+
+func NewGetTLFForUpgradeResWithDelay(v GetTLFForUpgradeDelayRes) GetTLFForUpgradeRes {
+	return GetTLFForUpgradeRes{
+		Typ__:   GetTLFForUpgradeResType_DELAY,
+		Delay__: &v,
+	}
+}
+
+func NewGetTLFForUpgradeResWithErr(v GetTLFForUpgradeErrRes) GetTLFForUpgradeRes {
+	return GetTLFForUpgradeRes{
+		Typ__: GetTLFForUpgradeResType_ERR,
+		Err__: &v,
+	}
+}
+
+func NewGetTLFForUpgradeResWithDisabled(v GetTLFForUpgradeDisabledRes) GetTLFForUpgradeRes {
+	return GetTLFForUpgradeRes{
+		Typ__:      GetTLFForUpgradeResType_DISABLED,
+		Disabled__: &v,
+	}
+}
+
+func (o GetTLFForUpgradeRes) DeepCopy() GetTLFForUpgradeRes {
+	return GetTLFForUpgradeRes{
+		Typ__: o.Typ__.DeepCopy(),
+		Tlfavailable__: (func(x *GetTLFForUpgradeAvailableRes) *GetTLFForUpgradeAvailableRes {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Tlfavailable__),
+		Delay__: (func(x *GetTLFForUpgradeDelayRes) *GetTLFForUpgradeDelayRes {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Delay__),
+		Err__: (func(x *GetTLFForUpgradeErrRes) *GetTLFForUpgradeErrRes {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Err__),
+		Disabled__: (func(x *GetTLFForUpgradeDisabledRes) *GetTLFForUpgradeDisabledRes {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Disabled__),
+	}
+}

--- a/go/tlfupgrade/tlfupgrade.go
+++ b/go/tlfupgrade/tlfupgrade.go
@@ -1,0 +1,63 @@
+package tlfupgrade
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+)
+
+type BackgroundTLFUpdater struct {
+	libkb.Contextified
+
+	initialWait time.Duration
+	clock       clockwork.Clock
+	shutdownCh  chan struct{}
+	suspendCh   chan struct{}
+}
+
+func NewBackgroundTLFUpdater(g *libkb.GlobalContext) *BackgroundTLFUpdater {
+	return &BackgroundTLFUpdater{
+		Contextified: libkb.NewContextified(g),
+		initialWait:  10 * time.Second,
+		shutdownCh:   make(chan struct{}),
+		suspendCh:    make(chan struct{}),
+		clock:        clockwork.NewRealClock(),
+	}
+}
+
+func (b *BackgroundTLFUpdater) debug(msg string, args ...interface{}) {
+	b.G().Log.Debug("BackgroundTLFUpdater: %s", fmt.Sprintf(msg, args...))
+}
+
+func (b *BackgroundTLFUpdater) Run() {
+	go b.monitorAppState()
+}
+
+func (b *BackgroundTLFUpdater) Shutdown() {
+
+}
+
+func (b *BackgroundTLFUpdater) monitorAppState() {
+	for {
+		state := <-b.G().AppState.NextUpdate()
+		switch state {
+		case keybase1.AppState_FOREGROUND:
+			// wait for the initial wait time before waking up the upgrade threads
+			b.clock.Sleep(b.initialWait)
+			b.
+		case keybase1.AppState_BACKGROUND:
+			b.debug("backgrounded, suspending upgrade thread")
+			b.suspendCh <- struct{}{}
+		}
+	}
+}
+
+func (b *BackgroundTLFUpdater) runAppType(appType keybase1.TeamApplication) {
+	b.clock.Sleep(b.initialWait)
+	for {
+		select {}
+	}
+}

--- a/go/tlfupgrade/tlfupgrade.go
+++ b/go/tlfupgrade/tlfupgrade.go
@@ -31,7 +31,7 @@ func NewBackgroundTLFUpdater(g *libkb.GlobalContext) *BackgroundTLFUpdater {
 		Contextified: libkb.NewContextified(g),
 		initialWait:  10 * time.Second,
 		errWait:      20 * time.Second,
-		successWait:  15 * time.Second,
+		successWait:  time.Minute,
 		shutdownCh:   make(chan struct{}),
 		clock:        clockwork.NewRealClock(),
 	}

--- a/go/tlfupgrade/tlfupgrade.go
+++ b/go/tlfupgrade/tlfupgrade.go
@@ -6,10 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
-
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/clockwork"
 )

--- a/go/tlfupgrade/tlfupgrade_test.go
+++ b/go/tlfupgrade/tlfupgrade_test.go
@@ -1,0 +1,70 @@
+package tlfupgrade
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+type testAPIServer struct {
+	libkb.API
+	responseFn func() getUpgradeRes
+}
+
+func (t *testAPIServer) GetDecode(arg libkb.APIArg, resp libkb.APIResponseWrapper) error {
+	*(resp.(*getUpgradeRes)) = t.responseFn()
+	return nil
+}
+
+type testChatHelper struct {
+	libkb.ChatHelper
+}
+
+func (t *testChatHelper) UpgradeKBFSToImpteam(context.Context, string, chat1.TLFID, bool) error {
+	return nil
+}
+
+func TestBackgroundTLFUpdater(t *testing.T) {
+	tc := libkb.SetupTest(t, "TestBackgroundTLFUpdater", 1)
+	defer tc.Cleanup()
+
+	api := &testAPIServer{}
+	u := NewBackgroundTLFUpdater(tc.G)
+	u.testingAPIServer = api
+	u.testingChatHelper = &testChatHelper{}
+	upgradeCh := make(chan keybase1.TLFID, 5)
+	u.upgradeCh = &upgradeCh
+
+	refTLFID := keybase1.TLFID("hi")
+	f := func() getUpgradeRes {
+		return getUpgradeRes{
+			GetTLFForUpgradeRes: NewGetTLFForUpgradeResWithTlfavailable(GetTLFForUpgradeAvailableRes{
+				TlfID: refTLFID,
+			})}
+	}
+	api.responseFn = f
+	clock := clockwork.NewFakeClock()
+	u.clock = clock
+	u.Run()
+
+	attempt := func() {
+		clock.BlockUntil(1)
+		clock.Advance(time.Hour)
+		select {
+		case tlfID := <-upgradeCh:
+			require.Equal(t, refTLFID, tlfID)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no upgrade")
+		}
+	}
+	attempt()
+	tc.G.AppState.Update(keybase1.AppState_BACKGROUND)
+	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
+	attempt()
+}

--- a/go/tlfupgrade/tlfupgrade_test.go
+++ b/go/tlfupgrade/tlfupgrade_test.go
@@ -52,7 +52,6 @@ func TestBackgroundTLFUpdater(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	u.clock = clock
 	u.Run()
-
 	attempt := func() {
 		clock.BlockUntil(1)
 		clock.Advance(time.Hour)
@@ -67,4 +66,5 @@ func TestBackgroundTLFUpdater(t *testing.T) {
 	tc.G.AppState.Update(keybase1.AppState_BACKGROUND)
 	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
 	attempt()
+	u.Shutdown()
 }


### PR DESCRIPTION
The idea here is we run a background loop which asks for TLFs to upgrade, and uses the server response to know how often to loop around. We also try to be smart about not running an upgrade right after an foreground on the mobile app. 