### PR TITLE
Set xattr on eraseablekv files to exclude from osx backups

### DIFF
--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/keybase/client/go/erasablekv"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
@@ -18,7 +19,7 @@ type DeviceEKStorage struct {
 	libkb.Contextified
 	sync.Mutex
 	indexOnce *sync.Once
-	storage   ErasableKVStore
+	storage   erasablekv.ErasableKVStore
 	cache     map[keybase1.EkGeneration]keybase1.DeviceEk
 	keyPrefix string
 }
@@ -27,7 +28,7 @@ func NewDeviceEKStorage(g *libkb.GlobalContext) *DeviceEKStorage {
 	keyPrefix := fmt.Sprintf("%s-%s", deviceEKPrefix, g.Env.GetUsername().String())
 	return &DeviceEKStorage{
 		Contextified: libkb.NewContextified(g),
-		storage:      NewFileErasableKVStore(g),
+		storage:      erasablekv.NewFileErasableKVStore(g),
 		cache:        make(map[keybase1.EkGeneration]keybase1.DeviceEk),
 		indexOnce:    new(sync.Once),
 		keyPrefix:    keyPrefix,
@@ -121,11 +122,6 @@ func (s *DeviceEKStorage) index(ctx context.Context) (err error) {
 		}
 	})
 	return err
-}
-
-// Used for testing
-func (s *DeviceEKStorage) ClearCache() {
-	s.cache = make(map[keybase1.EkGeneration]keybase1.DeviceEk)
 }
 
 func (s *DeviceEKStorage) GetAll(ctx context.Context) (deviceEKs map[keybase1.EkGeneration]keybase1.DeviceEk, err error) {

--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -2,9 +2,6 @@ package ephemeral
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
-	"path/filepath"
 	"testing"
 
 	"github.com/keybase/client/go/kbtest"
@@ -84,22 +81,4 @@ func TestDeviceEKStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 2, maxGeneration)
 
-	// Test noise file corruption
-	generation := keybase1.EkGeneration(2)
-	username := tc.G.Env.GetUsername().String()
-	noiseName := fmt.Sprintf("%s-%s-%d.ek%s", deviceEKPrefix, username, generation, noiseSuffix)
-	noiseFilePath := filepath.Join(tc.G.Env.GetDataDir(), noiseName)
-	noise, err := ioutil.ReadFile(noiseFilePath)
-	require.NoError(t, err)
-
-	// flip one bit
-	noise[0] ^= 0x01
-
-	err = ioutil.WriteFile(noiseFilePath, noise, libkb.PermFile)
-	require.NoError(t, err)
-
-	s.ClearCache()
-	corrupt, err := s.Get(context.Background(), generation)
-	require.Error(t, err)
-	require.NotEqual(t, corrupt, tests[int(generation)])
 }

--- a/go/erasablekv/disable_backup_darwin.go
+++ b/go/erasablekv/disable_backup_darwin.go
@@ -1,0 +1,24 @@
+// +build darwin
+
+package erasablekv
+
+import (
+	"path/filepath"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/pkg/xattr"
+	"golang.org/x/net/context"
+)
+
+const noBackup = "com.apple.metadata:com_apple_backup_excludeItem com.apple.backupd"
+
+func SetDisableBackup(ctx context.Context, g *libkb.GlobalContext, name string) {
+	path := filepath.Dir(name)
+	filename := filepath.Base(name)
+	// CrashPlan respects this metadata flag as does TimeMachine.
+	// https://support.crashplan.com/Troubleshooting/CrashPlan_And_OS_X_Metadata
+	err := xattr.Set(path, filename, []byte(noBackup))
+	if err != nil {
+		g.Log.CDebugf(ctx, "Unable to write xattr %s", filepath.Join(path, filename))
+	}
+}

--- a/go/erasablekv/disable_backup_darwin_test.go
+++ b/go/erasablekv/disable_backup_darwin_test.go
@@ -1,0 +1,39 @@
+// +build darwin
+
+package erasablekv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/pkg/xattr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetDisableBackup(t *testing.T) {
+	tc := libkb.SetupTest(t, "erasable kv store disable backup", 1)
+	defer tc.Cleanup()
+
+	_, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
+	require.NoError(t, err)
+
+	s := NewFileErasableKVStore(tc.G)
+	key := "test-key"
+	value := "value"
+
+	err = s.Put(context.Background(), key, value)
+	require.NoError(t, err)
+
+	storageDir := getStorageDir(tc.G)
+	// Check that we set noBackup on the key
+	metadata, err := xattr.Get(storageDir, key)
+	require.NoError(t, err)
+	require.Equal(t, []byte(noBackup), metadata)
+
+	// Check that we set noBackup on the noise
+	metadata, err = xattr.Get(storageDir, key+noiseSuffix)
+	require.NoError(t, err)
+	require.Equal(t, []byte(noBackup), metadata)
+}

--- a/go/erasablekv/disable_backup_default.go
+++ b/go/erasablekv/disable_backup_default.go
@@ -1,0 +1,10 @@
+// +build !darwin
+
+package erasablekv
+
+import (
+	"github.com/keybase/client/go/libkb"
+	"golang.org/x/net/context"
+)
+
+func SetDisableBackup(ctx context.Context, g *libkb.GlobalContext, name string) {}

--- a/go/erasablekv/erasable_kv_store.go
+++ b/go/erasablekv/erasable_kv_store.go
@@ -1,4 +1,4 @@
-package ephemeral
+package erasablekv
 
 import (
 	"fmt"
@@ -27,6 +27,11 @@ type boxedData struct {
 // ***
 const cryptoVersion = 1
 const noiseSuffix = ".ns"
+const storageSubDir = "eraseablekvstore"
+
+func getStorageDir(g *libkb.GlobalContext) string {
+	return filepath.Join(g.Env.GetDataDir(), storageSubDir)
+}
 
 type ErasableKVStore interface {
 	Put(ctx context.Context, key string, val interface{}) error
@@ -43,7 +48,7 @@ type ErasableKVStore interface {
 type FileErasableKVStore struct {
 	libkb.Contextified
 	sync.Mutex
-	storagePath string
+	storageDir string
 }
 
 var _ ErasableKVStore = (*FileErasableKVStore)(nil)
@@ -51,12 +56,12 @@ var _ ErasableKVStore = (*FileErasableKVStore)(nil)
 func NewFileErasableKVStore(g *libkb.GlobalContext) *FileErasableKVStore {
 	return &FileErasableKVStore{
 		Contextified: libkb.NewContextified(g),
-		storagePath:  g.Env.GetDataDir(),
+		storageDir:   getStorageDir(g),
 	}
 }
 
 func (s *FileErasableKVStore) filepath(key string) string {
-	return filepath.Join(s.storagePath, key)
+	return filepath.Join(s.storageDir, key)
 }
 
 func (s *FileErasableKVStore) noiseKey(key string) string {
@@ -158,12 +163,14 @@ func (s *FileErasableKVStore) write(ctx context.Context, key string, data []byte
 		return err
 	}
 
-	tmp, err := ioutil.TempFile(s.storagePath, key)
+	tmp, err := ioutil.TempFile(s.storageDir, key)
 	if err != nil {
 		return err
 	}
 	// remove the temp file if it still exists at the end of this function
 	defer libkb.ShredFile(tmp.Name())
+
+	SetDisableBackup(ctx, s.G(), tmp.Name())
 
 	if runtime.GOOS != "windows" {
 		// os.Fchmod not supported on windows
@@ -192,6 +199,7 @@ func (s *FileErasableKVStore) write(ctx context.Context, key string, data []byte
 	if err := os.Rename(tmp.Name(), filepath); err != nil {
 		return err
 	}
+	SetDisableBackup(ctx, s.G(), filepath)
 
 	if runtime.GOOS != "windows" {
 		// os.Fchmod not supported on windows
@@ -267,7 +275,7 @@ func (s *FileErasableKVStore) AllKeys(ctx context.Context) (keys []string, err e
 	defer s.G().CTrace(ctx, "FileErasableKVStore#AllKeys", func() error { return err })()
 	s.Lock()
 	defer s.Unlock()
-	files, err := filepath.Glob(s.storagePath)
+	files, err := filepath.Glob(s.storageDir + "/*")
 	if err != nil {
 		return keys, err
 	}
@@ -275,7 +283,7 @@ func (s *FileErasableKVStore) AllKeys(ctx context.Context) (keys []string, err e
 		if strings.HasSuffix(file, noiseSuffix) {
 			continue
 		}
-		parts := strings.Split(file, s.storagePath)
+		parts := strings.Split(file, s.storageDir+"/")
 		keys = append(keys, parts[1])
 	}
 	return keys, nil

--- a/go/erasablekv/erasable_kv_store.go
+++ b/go/erasablekv/erasable_kv_store.go
@@ -275,7 +275,7 @@ func (s *FileErasableKVStore) AllKeys(ctx context.Context) (keys []string, err e
 	defer s.G().CTrace(ctx, "FileErasableKVStore#AllKeys", func() error { return err })()
 	s.Lock()
 	defer s.Unlock()
-	files, err := filepath.Glob(s.storageDir + "/*")
+	files, err := filepath.Glob(s.storageDir + string(os.PathSeparator) + "*")
 	if err != nil {
 		return keys, err
 	}
@@ -283,7 +283,7 @@ func (s *FileErasableKVStore) AllKeys(ctx context.Context) (keys []string, err e
 		if strings.HasSuffix(file, noiseSuffix) {
 			continue
 		}
-		parts := strings.Split(file, s.storageDir+"/")
+		parts := strings.Split(file, s.storageDir+string(os.PathSeparator))
 		keys = append(keys, parts[1])
 	}
 	return keys, nil

--- a/go/erasablekv/erasable_kv_store_test.go
+++ b/go/erasablekv/erasable_kv_store_test.go
@@ -1,0 +1,60 @@
+package erasablekv
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestErasableKVStore(t *testing.T) {
+	tc := libkb.SetupTest(t, "erasablekv store encryption", 1)
+	defer tc.Cleanup()
+
+	_, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
+	require.NoError(t, err)
+
+	s := NewFileErasableKVStore(tc.G)
+	key := "test-key"
+	value := "value"
+
+	err = s.Put(context.Background(), key, value)
+	require.NoError(t, err)
+
+	expected, err := s.Get(context.Background(), key)
+	require.Error(t, err)
+	require.NotEqual(t, expected, value)
+
+	keys, err := s.AllKeys(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{key}, keys)
+
+	// Test noise file corruption
+	noiseName := fmt.Sprintf("%s%s", key, noiseSuffix)
+	storageDir := getStorageDir(tc.G)
+	noiseFilePath := filepath.Join(storageDir, noiseName)
+	noise, err := ioutil.ReadFile(noiseFilePath)
+	require.NoError(t, err)
+
+	// flip one bit
+	noise[0] ^= 0x01
+
+	err = ioutil.WriteFile(noiseFilePath, noise, libkb.PermFile)
+	require.NoError(t, err)
+
+	corrupt, err := s.Get(context.Background(), key)
+	require.Error(t, err)
+	require.NotEqual(t, corrupt, value)
+
+	err = s.Erase(context.Background(), key)
+	require.NoError(t, err)
+
+	keys, err = s.AllKeys(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string(nil), keys)
+}

--- a/go/vendor/github.com/pkg/xattr/LICENSE
+++ b/go/vendor/github.com/pkg/xattr/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2012 Dave Cheney. All rights reserved.
+Copyright (c) 2014 Kuba Podgórski. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/go/vendor/github.com/pkg/xattr/README.md
+++ b/go/vendor/github.com/pkg/xattr/README.md
@@ -1,0 +1,34 @@
+[![GoDoc](https://godoc.org/github.com/pkg/xattr?status.svg)](http://godoc.org/github.com/pkg/xattr)
+[![Go Report Card](https://goreportcard.com/badge/github.com/pkg/xattr)](https://goreportcard.com/report/github.com/pkg/xattr)
+[![Build Status](https://travis-ci.org/pkg/xattr.svg?branch=master)](https://travis-ci.org/pkg/xattr)
+
+xattr
+=====
+Extended attribute support for Go (linux + darwin + freebsd).
+
+"Extended attributes are name:value pairs associated permanently with files and directories, similar to the environment strings associated with a process. An attribute may be defined or undefined. If it is defined, its value may be empty or non-empty." [See more...](https://en.wikipedia.org/wiki/Extended_file_attributes)
+
+
+### Example
+```
+  const path = "/tmp/myfile"
+  const prefix = "user."
+
+  if err := xattr.Set(path, prefix+"test", []byte("test-attr-value")); err != nil {
+  	log.Fatal(err)
+  }
+ 
+  var list []string
+  if list, err = xattr.List(path); err != nil {
+  	log.Fatal(err)
+  }
+  
+  var data []byte
+  if data, err = xattr.Get(path, prefix+"test"); err != nil {
+  	log.Fatal(err)
+  }
+
+  if err = xattr.Remove(path, prefix+"test"); err != nil {
+  	log.Fatal(err)
+  }
+```

--- a/go/vendor/github.com/pkg/xattr/go.mod
+++ b/go/vendor/github.com/pkg/xattr/go.mod
@@ -1,0 +1,1 @@
+module "github.com/pkg/xattr"

--- a/go/vendor/github.com/pkg/xattr/syscall_darwin.go
+++ b/go/vendor/github.com/pkg/xattr/syscall_darwin.go
@@ -1,0 +1,39 @@
+// +build darwin
+
+package xattr
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func getxattr(path string, name string, value *byte, size int, pos int, options int) (int, error) {
+
+	r0, _, e1 := syscall.Syscall6(syscall.SYS_GETXATTR, uintptr(unsafe.Pointer(syscall.StringBytePtr(path))), uintptr(unsafe.Pointer(syscall.StringBytePtr(name))), uintptr(unsafe.Pointer(value)), uintptr(size), uintptr(pos), uintptr(options))
+	if e1 != syscall.Errno(0) {
+		return int(r0), e1
+	}
+	return int(r0), nil
+}
+
+func listxattr(path string, namebuf *byte, size int, options int) (int, error) {
+	r0, _, e1 := syscall.Syscall6(syscall.SYS_LISTXATTR, uintptr(unsafe.Pointer(syscall.StringBytePtr(path))), uintptr(unsafe.Pointer(namebuf)), uintptr(size), uintptr(options), 0, 0)
+	if e1 != syscall.Errno(0) {
+		return int(r0), e1
+	}
+	return int(r0), nil
+}
+
+func setxattr(path string, name string, value *byte, size int, pos int, options int) error {
+	if _, _, e1 := syscall.Syscall6(syscall.SYS_SETXATTR, uintptr(unsafe.Pointer(syscall.StringBytePtr(path))), uintptr(unsafe.Pointer(syscall.StringBytePtr(name))), uintptr(unsafe.Pointer(value)), uintptr(size), uintptr(pos), uintptr(options)); e1 != syscall.Errno(0) {
+		return e1
+	}
+	return nil
+}
+
+func removexattr(path string, name string, options int) error {
+	if _, _, e1 := syscall.Syscall(syscall.SYS_REMOVEXATTR, uintptr(unsafe.Pointer(syscall.StringBytePtr(path))), uintptr(unsafe.Pointer(syscall.StringBytePtr(name))), uintptr(options)); e1 != syscall.Errno(0) {
+		return e1
+	}
+	return nil
+}

--- a/go/vendor/github.com/pkg/xattr/syscall_freebsd.go
+++ b/go/vendor/github.com/pkg/xattr/syscall_freebsd.go
@@ -1,0 +1,91 @@
+// +build freebsd
+
+package xattr
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+/*
+   ssize_t
+   extattr_get_file(const char *path, int attrnamespace,
+       const char *attrname, void *data, size_t nbytes);
+
+   ssize_t
+   extattr_set_file(const char *path, int attrnamespace,
+       const char *attrname, const void *data, size_t nbytes);
+
+   int
+   extattr_delete_file(const char *path, int attrnamespace,
+       const char *attrname);
+
+   ssize_t
+   extattr_list_file(const char *path, int attrnamespace, void *data,
+       size_t nbytes);
+*/
+
+func extattr_get_file(path string, attrnamespace int, attrname string, data *byte, nbytes int) (int, error) {
+	r, _, e := syscall.Syscall6(
+		syscall.SYS_EXTATTR_GET_FILE,
+		uintptr(unsafe.Pointer(syscall.StringBytePtr(path))),
+		uintptr(attrnamespace),
+		uintptr(unsafe.Pointer(syscall.StringBytePtr(attrname))),
+		uintptr(unsafe.Pointer(data)),
+		uintptr(nbytes),
+		0,
+	)
+	var err error
+	if e != 0 {
+		err = e
+	}
+	return int(r), err
+}
+
+func extattr_set_file(path string, attrnamespace int, attrname string, data *byte, nbytes int) (int, error) {
+	r, _, e := syscall.Syscall6(
+		syscall.SYS_EXTATTR_SET_FILE,
+		uintptr(unsafe.Pointer(syscall.StringBytePtr(path))),
+		uintptr(attrnamespace),
+		uintptr(unsafe.Pointer(syscall.StringBytePtr(attrname))),
+		uintptr(unsafe.Pointer(data)),
+		uintptr(nbytes),
+		0,
+	)
+	var err error
+	if e != 0 {
+		err = e
+	}
+	return int(r), err
+}
+
+func extattr_delete_file(path string, attrnamespace int, attrname string) error {
+	_, _, e := syscall.Syscall(
+		syscall.SYS_EXTATTR_DELETE_FILE,
+		uintptr(unsafe.Pointer(syscall.StringBytePtr(path))),
+		uintptr(attrnamespace),
+		uintptr(unsafe.Pointer(syscall.StringBytePtr(attrname))),
+	)
+	var err error
+	if e != 0 {
+		err = e
+	}
+	return err
+}
+
+func extattr_list_file(path string, attrnamespace int, data *byte, nbytes int) (int, error) {
+	r, _, e := syscall.Syscall6(
+		syscall.SYS_EXTATTR_LIST_FILE,
+		uintptr(unsafe.Pointer(syscall.StringBytePtr(path))),
+		uintptr(attrnamespace),
+		uintptr(unsafe.Pointer(data)),
+		uintptr(nbytes),
+		0,
+		0,
+	)
+	var err error
+	if e != 0 {
+		err = e
+	}
+	return int(r), err
+}

--- a/go/vendor/github.com/pkg/xattr/xattr.go
+++ b/go/vendor/github.com/pkg/xattr/xattr.go
@@ -1,0 +1,32 @@
+/*
+Package xattr provides support for extended attributes on linux, darwin and freebsd.
+Extended attributes are name:value pairs associated permanently with files and directories,
+similar to the environment strings associated with a process.
+An attribute may be defined or undefined. If it is defined, its value may be empty or non-empty.
+More details you can find here: https://en.wikipedia.org/wiki/Extended_file_attributes
+*/
+package xattr
+
+// Error records an error and the operation, file path and attribute that caused it.
+type Error struct {
+	Op   string
+	Path string
+	Name string
+	Err  error
+}
+
+func (e *Error) Error() string {
+	return e.Op + " " + e.Path + " " + e.Name + ": " + e.Err.Error()
+}
+
+// nullTermToStrings converts an array of NULL terminated UTF-8 strings to a []string.
+func nullTermToStrings(buf []byte) (result []string) {
+	offset := 0
+	for index, b := range buf {
+		if b == 0 {
+			result = append(result, string(buf[offset:index]))
+			offset = index + 1
+		}
+	}
+	return
+}

--- a/go/vendor/github.com/pkg/xattr/xattr_darwin.go
+++ b/go/vendor/github.com/pkg/xattr/xattr_darwin.go
@@ -1,0 +1,74 @@
+// +build darwin
+
+package xattr
+
+import "syscall"
+
+// Get retrieves extended attribute data associated with path.
+func Get(path, name string) ([]byte, error) {
+	// find size.
+	size, err := getxattr(path, name, nil, 0, 0, 0)
+	if err != nil {
+		return nil, &Error{"xattr.Get", path, name, err}
+	}
+	if size > 0 {
+		buf := make([]byte, size)
+		// Read into buffer of that size.
+		read, err := getxattr(path, name, &buf[0], size, 0, 0)
+		if err != nil {
+			return nil, &Error{"xattr.Get", path, name, err}
+		}
+		return buf[:read], nil
+	}
+	return []byte{}, nil
+}
+
+// List retrieves a list of names of extended attributes associated
+// with the given path in the file system.
+func List(path string) ([]string, error) {
+	// find size.
+	size, err := listxattr(path, nil, 0, 0)
+	if err != nil {
+		return nil, &Error{"xattr.List", path, "", err}
+	}
+	if size > 0 {
+
+		buf := make([]byte, size)
+		// Read into buffer of that size.
+		read, err := listxattr(path, &buf[0], size, 0)
+		if err != nil {
+			return nil, &Error{"xattr.List", path, "", err}
+		}
+		return nullTermToStrings(buf[:read]), nil
+	}
+	return []string{}, nil
+}
+
+// Set associates name and data together as an attribute of path.
+func Set(path, name string, data []byte) error {
+	var dataval *byte = nil
+	datalen := len(data)
+	if datalen > 0 {
+		dataval = &data[0]
+	}
+	if err := setxattr(path, name, dataval, datalen, 0, 0); err != nil {
+		return &Error{"xattr.Set", path, name, err}
+	}
+	return nil
+}
+
+// Remove removes the attribute associated with the given path.
+func Remove(path, name string) error {
+	if err := removexattr(path, name, 0); err != nil {
+		return &Error{"xattr.Remove", path, name, err}
+	}
+	return nil
+}
+
+// Supported checks if filesystem supports extended attributes
+func Supported(path string) bool {
+	if _, err := listxattr(path, nil, 0, 0); err != nil {
+		return err != syscall.ENOTSUP
+	}
+	return true
+}

--- a/go/vendor/github.com/pkg/xattr/xattr_freebsd.go
+++ b/go/vendor/github.com/pkg/xattr/xattr_freebsd.go
@@ -1,0 +1,98 @@
+// +build freebsd
+
+package xattr
+
+import (
+	"syscall"
+)
+
+const (
+	EXTATTR_NAMESPACE_USER = 1
+)
+
+// Get retrieves extended attribute data associated with path.
+func Get(path, name string) ([]byte, error) {
+	// find size.
+	size, err := extattr_get_file(path, EXTATTR_NAMESPACE_USER, name, nil, 0)
+	if err != nil {
+		return nil, &Error{"xattr.Get", path, name, err}
+	}
+	if size > 0 {
+		buf := make([]byte, size)
+		// Read into buffer of that size.
+		read, err := extattr_get_file(path, EXTATTR_NAMESPACE_USER, name, &buf[0], size)
+		if err != nil {
+			return nil, &Error{"xattr.Get", path, name, err}
+		}
+		return buf[:read], nil
+	}
+	return []byte{}, nil
+}
+
+// List retrieves a list of names of extended attributes associated
+// with the given path in the file system.
+func List(path string) ([]string, error) {
+	// find size.
+	size, err := extattr_list_file(path, EXTATTR_NAMESPACE_USER, nil, 0)
+	if err != nil {
+		return nil, &Error{"xattr.List", path, "", err}
+	}
+	if size > 0 {
+		buf := make([]byte, size)
+		// Read into buffer of that size.
+		read, err := extattr_list_file(path, EXTATTR_NAMESPACE_USER, &buf[0], size)
+		if err != nil {
+			return nil, &Error{"xattr.List", path, "", err}
+		}
+		return attrListToStrings(buf[:read]), nil
+	}
+	return []string{}, nil
+}
+
+// Set associates name and data together as an attribute of path.
+func Set(path, name string, data []byte) error {
+	var dataval *byte = nil
+	datalen := len(data)
+	if datalen > 0 {
+		dataval = &data[0]
+	}
+	written, err := extattr_set_file(path, EXTATTR_NAMESPACE_USER, name, dataval, datalen)
+	if err != nil {
+		return &Error{"xattr.Set", path, name, err}
+	}
+	if written != datalen {
+		return &Error{"xattr.Set", path, name, syscall.E2BIG}
+	}
+	return nil
+}
+
+// Remove removes the attribute associated with the given path.
+func Remove(path, name string) error {
+	if err := extattr_delete_file(path, EXTATTR_NAMESPACE_USER, name); err != nil {
+		return &Error{"xattr.Remove", path, name, err}
+	}
+	return nil
+}
+
+// Supported checks if filesystem supports extended attributes
+func Supported(path string) bool {
+	if _, err := extattr_list_file(path, EXTATTR_NAMESPACE_USER, nil, 0); err != nil {
+		return err != syscall.ENOTSUP
+	}
+	return true
+}
+
+// attrListToStrings converts a sequnce of attribute name entries to a []string.
+// Each entry consists of a single byte containing the length
+// of the attribute name, followed by the attribute name.
+// The name is _not_ terminated by NUL.
+func attrListToStrings(buf []byte) []string {
+	var result []string
+	index := 0
+	for index < len(buf) {
+		next := index + 1 + int(buf[index])
+		result = append(result, string(buf[index+1:next]))
+		index = next
+	}
+	return result
+}

--- a/go/vendor/github.com/pkg/xattr/xattr_linux.go
+++ b/go/vendor/github.com/pkg/xattr/xattr_linux.go
@@ -1,0 +1,69 @@
+// +build linux
+
+package xattr
+
+import "syscall"
+
+// Get retrieves extended attribute data associated with path.
+func Get(path, name string) ([]byte, error) {
+	// find size.
+	size, err := syscall.Getxattr(path, name, nil)
+	if err != nil {
+		return nil, &Error{"xattr.Get", path, name, err}
+	}
+	if size > 0 {
+		data := make([]byte, size)
+		// Read into buffer of that size.
+		read, err := syscall.Getxattr(path, name, data)
+		if err != nil {
+			return nil, &Error{"xattr.Get", path, name, err}
+		}
+		return data[:read], nil
+	}
+	return []byte{}, nil
+}
+
+// List retrieves a list of names of extended attributes associated
+// with the given path in the file system.
+func List(path string) ([]string, error) {
+	// find size.
+	size, err := syscall.Listxattr(path, nil)
+	if err != nil {
+		return nil, &Error{"xattr.List", path, "", err}
+	}
+	if size > 0 {
+		buf := make([]byte, size)
+		// Read into buffer of that size.
+		read, err := syscall.Listxattr(path, buf)
+		if err != nil {
+			return nil, &Error{"xattr.List", path, "", err}
+		}
+		return nullTermToStrings(buf[:read]), nil
+	}
+	return []string{}, nil
+}
+
+// Set associates name and data together as an attribute of path.
+func Set(path, name string, data []byte) error {
+	if err := syscall.Setxattr(path, name, data, 0); err != nil {
+		return &Error{"xattr.Set", path, name, err}
+	}
+	return nil
+}
+
+// Remove removes the attribute associated
+// with the given path.
+func Remove(path, name string) error {
+	if err := syscall.Removexattr(path, name); err != nil {
+		return &Error{"xattr.Remove", path, name, err}
+	}
+	return nil
+}
+
+// Supported checks if filesystem supports extended attributes
+func Supported(path string) bool {
+	if _, err := syscall.Listxattr(path, nil); err != nil {
+		return err != syscall.ENOTSUP
+	}
+	return true
+}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -446,6 +446,12 @@
 			"revisionTime": "2017-09-10T13:46:14Z"
 		},
 		{
+			"checksumSHA1": "Lm/IsrUTXFXtxwDQk+HQDRTitVc=",
+			"path": "github.com/pkg/xattr",
+			"revision": "bc67bfc801466b4b8e62df951397972652fa8414",
+			"revisionTime": "2018-02-23T11:29:58Z"
+		},
+		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",


### PR DESCRIPTION
Best effort to disable common backups for things in eraseablekv store on osx (crashplan + time machine)

cc @maxtaco 