### PR TITLE
update rpc vendor that fixes a memory leak

### DIFF
--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
@@ -111,9 +111,6 @@ func (t *connTransport) Finalize() {
 		t.transport.Close()
 	}
 	t.transport = t.stagedTransport
-	if t.stagedTransport != nil {
-		t.stagedTransport.Close()
-	}
 	t.stagedTransport = nil
 }
 
@@ -283,9 +280,6 @@ func (ct *ConnectionTransportTLS) Finalize() {
 		ct.transport.Close()
 	}
 	ct.transport = ct.stagedTransport
-	if ct.stagedTransport != nil {
-		ct.stagedTransport.Close()
-	}
 	ct.stagedTransport = nil
 	ct.srvRemote.Reset()
 }

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -295,10 +295,10 @@
 			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
-			"checksumSHA1": "ZnAvhum5nZfQmxQgbVAcVFePehM=",
+			"checksumSHA1": "8NAR663YrcBLUjum4k16CBEvGtY=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "d5c3e33aacf1bccedc64b0a3965736e1f261bcdb",
-			"revisionTime": "2018-02-05T22:52:15Z"
+			"revision": "39d38af173756e1f14b5c9422093d407c63ea8b7",
+			"revisionTime": "2018-03-15T01:07:33Z"
 		},
 		{
 			"checksumSHA1": "RLs8GIV4e+D350pyzZh5RC3mgQg=",

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -297,8 +297,8 @@
 		{
 			"checksumSHA1": "X2BcPzXoodWwobqI+DYKXPPlT3I=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "c6756c2d667d65bacac3d18c77154b2bf46d57b2",
-			"revisionTime": "2018-03-15T22:59:32Z"
+			"revision": "a1a8266e43439a8704b7ce500d91888b6a9a1e2b",
+			"revisionTime": "2018-03-15T23:23:27Z"
 		},
 		{
 			"checksumSHA1": "RLs8GIV4e+D350pyzZh5RC3mgQg=",

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -295,10 +295,10 @@
 			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
-			"checksumSHA1": "8NAR663YrcBLUjum4k16CBEvGtY=",
+			"checksumSHA1": "X2BcPzXoodWwobqI+DYKXPPlT3I=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "39d38af173756e1f14b5c9422093d407c63ea8b7",
-			"revisionTime": "2018-03-15T01:07:33Z"
+			"revision": "c6756c2d667d65bacac3d18c77154b2bf46d57b2",
+			"revisionTime": "2018-03-15T22:59:32Z"
 		},
 		{
 			"checksumSHA1": "RLs8GIV4e+D350pyzZh5RC3mgQg=",


### PR DESCRIPTION
It probably doesn't matter as much for `client`, but just in case I'm vendoring it in here as well. 

Related:

https://github.com/keybase/go-framed-msgpack-rpc/pull/136

https://github.com/keybase/go-framed-msgpack-rpc/pull/137