### PR TITLE
Show passphrase errors on the main login form

### DIFF
--- a/shared/actions/json/login.json
+++ b/shared/actions/json/login.json
@@ -52,6 +52,9 @@
     "setOtherDeviceCodeState": {
       "codePageOtherDeviceRole": "Types.DeviceRole"
     },
+    "loginError": {
+      "error": "string"
+    },
     "provisioningError": {
       "error": "Error"
     },

--- a/shared/actions/login-gen.js
+++ b/shared/actions/login-gen.js
@@ -14,6 +14,7 @@ export const addNewDevice = 'login:addNewDevice'
 export const chooseGPGMethod = 'login:chooseGPGMethod'
 export const clearQRCode = 'login:clearQRCode'
 export const configuredAccounts = 'login:configuredAccounts'
+export const loginError = 'login:loginError'
 export const logout = 'login:logout'
 export const logoutDone = 'login:logoutDone'
 export const navBasedOnLoginAndInitialState = 'login:navBasedOnLoginAndInitialState'
@@ -47,6 +48,7 @@ export const createChooseGPGMethod = (payload: $ReadOnly<{exportKey: boolean}>) 
 export const createClearQRCode = () => ({error: false, payload: undefined, type: clearQRCode})
 export const createConfiguredAccounts = (payload: $ReadOnly<{accounts: ?Array<{|hasStoredSecret: boolean, username: string|}>}>) => ({error: false, payload, type: configuredAccounts})
 export const createConfiguredAccountsError = (payload: $ReadOnly<{error: Error}>) => ({error: true, payload, type: configuredAccounts})
+export const createLoginError = (payload: $ReadOnly<{error: string}>) => ({error: false, payload, type: loginError})
 export const createLogout = () => ({error: false, payload: undefined, type: logout})
 export const createLogoutDone = () => ({error: false, payload: undefined, type: logoutDone})
 export const createNavBasedOnLoginAndInitialState = () => ({error: false, payload: undefined, type: navBasedOnLoginAndInitialState})
@@ -94,6 +96,7 @@ export type AddNewDevicePayload = More.ReturnType<typeof createAddNewDevice>
 export type ChooseGPGMethodPayload = More.ReturnType<typeof createChooseGPGMethod>
 export type ClearQRCodePayload = More.ReturnType<typeof createClearQRCode>
 export type ConfiguredAccountsPayload = More.ReturnType<typeof createConfiguredAccounts>
+export type LoginErrorPayload = More.ReturnType<typeof createLoginError>
 export type LogoutDonePayload = More.ReturnType<typeof createLogoutDone>
 export type LogoutPayload = More.ReturnType<typeof createLogout>
 export type NavBasedOnLoginAndInitialStatePayload = More.ReturnType<typeof createNavBasedOnLoginAndInitialState>
@@ -129,6 +132,7 @@ export type Actions =
   | More.ReturnType<typeof createClearQRCode>
   | More.ReturnType<typeof createConfiguredAccounts>
   | More.ReturnType<typeof createConfiguredAccountsError>
+  | More.ReturnType<typeof createLoginError>
   | More.ReturnType<typeof createLogout>
   | More.ReturnType<typeof createLogoutDone>
   | More.ReturnType<typeof createNavBasedOnLoginAndInitialState>

--- a/shared/actions/login.js
+++ b/shared/actions/login.js
@@ -509,7 +509,13 @@ function* loginFlowSaga(usernameOrEmail, passphrase): Generator<any, void, any> 
 
       if (error) {
         logger.debug('login call error', error)
-        yield Saga.call(handleProvisioningError, error)
+        if (error.code === RPCTypes.constantsStatusCode.scbadloginpassword) {
+          // Stay on the login form
+          yield Saga.put(LoginGen.createLoginError({error: 'Looks like a bad passphrase.'}))
+        } else {
+          // Show the error on the error page
+          yield Saga.call(handleProvisioningError, error)
+        }
       } else {
         yield Saga.call(navBasedOnLoginAndInitialState)
       }

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -39,6 +39,8 @@ export default function(state: Types.State = initialState, action: LoginGen.Acti
           )
     case LoginGen.waitingForResponse:
       return state.set('waitingForResponse', action.payload.waiting)
+    case LoginGen.loginError:
+      return state.set('loginError', action.payload.error)
     case LoginGen.provisioningError:
     case LoginGen.resetQRCodeScanned: // fallthrough
       return state.set('codePageQrCodeScanned', false)


### PR DESCRIPTION
@keybase/react-hackers 

The main login page takes an errorText prop from `state.login.loginError`, but after our various login saga refactors nothing was ever setting that store entry.  So this PR special cases passphrase errors to set that entry.