### PR TITLE
Make channel join/leave system message smaller

### DIFF
--- a/shared/chat/conversation/messages/system-joined/index.js
+++ b/shared/chat/conversation/messages/system-joined/index.js
@@ -22,39 +22,48 @@ class Joined extends React.PureComponent<Props> {
     return (
       <Box
         style={{
-          marginTop: 2,
-          marginBottom: 2,
-          marginLeft: globalMargins.xtiny,
+          marginTop: 3,
+          marginBottom: 3,
+          marginLeft: globalMargins.tiny,
           ...globalStyles.flexBoxRow,
           alignItems: 'center',
           justifyContent: 'flex-start',
         }}
       >
-        <Avatar size={12} username={author} style={{marginRight: globalMargins.xtiny}} />
-        <Text title={formatTimeForMessages(timestamp)} type="BodySmall">
-          {you === author ? (
-            <Text type="BodySmallSemibold" style={{color: globalColors.black_40}}>
-              You
-            </Text>
-          ) : (
-            <ConnectedUsernames
-              inline={true}
-              type="BodySmall"
-              onUsernameClicked={onUsernameClicked}
-              colorFollowing={true}
-              underline={true}
-              usernames={[author]}
-            />
-          )}{' '}
-          joined {isBigTeam ? `#${channelname}` : teamname}
-          {'. '}
-          {author === you &&
-            isBigTeam && (
-              <Text title="" onClick={onManageChannels} style={{color: globalColors.blue}} type="BodySmall">
-                Manage channel subscriptions.
+        <Avatar size={24} username={author} style={{marginRight: globalMargins.tiny}} />
+        <Box style={globalStyles.flexBoxColumn}>
+          <Text title={formatTimeForMessages(timestamp)} type="BodySmallSemibold">
+            {you === author ? (
+              <Text type="BodySmallSemibold" style={{color: globalColors.black_40}}>
+                You
               </Text>
-            )}
-        </Text>
+            ) : (
+              <ConnectedUsernames
+                inline={true}
+                type="BodySmallSemibold"
+                onUsernameClicked={onUsernameClicked}
+                colorFollowing={true}
+                underline={true}
+                usernames={[author]}
+              />
+            )}{' '}
+          </Text>
+          <Text type="BodySmallSemibold">
+            joined {isBigTeam ? `#${channelname}` : teamname}
+            {'. '}
+            {author === you &&
+              isBigTeam && (
+                <Text
+                  title=""
+                  onClick={onManageChannels}
+                  style={{color: globalColors.blue}}
+                  type="BodySmallSemibold"
+                >
+                  Manage channel subscriptions.
+                </Text>
+              )}
+          </Text>
+        </Box>
       </Box>
     )
   }

--- a/shared/chat/conversation/messages/system-joined/index.js
+++ b/shared/chat/conversation/messages/system-joined/index.js
@@ -30,7 +30,12 @@ class Joined extends React.PureComponent<Props> {
           justifyContent: 'flex-start',
         }}
       >
-        <Avatar size={24} username={author} style={{marginRight: globalMargins.tiny}} />
+        <Avatar
+          onClick={() => onUsernameClicked(author)}
+          size={24}
+          username={author}
+          style={{marginRight: globalMargins.tiny}}
+        />
         <Box style={globalStyles.flexBoxColumn}>
           <Text title={formatTimeForMessages(timestamp)} type="BodySmallSemibold">
             {you === author ? (
@@ -48,17 +53,12 @@ class Joined extends React.PureComponent<Props> {
               />
             )}{' '}
           </Text>
-          <Text type="BodySmallSemibold">
+          <Text type="BodySmall">
             joined {isBigTeam ? `#${channelname}` : teamname}
             {'. '}
             {author === you &&
               isBigTeam && (
-                <Text
-                  title=""
-                  onClick={onManageChannels}
-                  style={{color: globalColors.blue}}
-                  type="BodySmallSemibold"
-                >
+                <Text title="" onClick={onManageChannels} style={{color: globalColors.blue}} type="BodySmall">
                   Manage channel subscriptions.
                 </Text>
               )}

--- a/shared/chat/conversation/messages/system-joined/index.js
+++ b/shared/chat/conversation/messages/system-joined/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
+import UserNotice from '../user-notice'
 import {Avatar, Box, Text, ConnectedUsernames} from '../../../../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../../../../styles'
 import {formatTimeForMessages} from '../../../../util/timestamp'
@@ -19,6 +20,10 @@ class Joined extends React.PureComponent<Props> {
   render() {
     const {channelname, isBigTeam, onManageChannels, you, teamname, onUsernameClicked} = this.props
     const {author, timestamp} = this.props.message
+    if (author === you) {
+      // Bring more attention to the current user joining
+      return <JoinedUserNotice {...this.props} />
+    }
     return (
       <Box
         style={{
@@ -37,22 +42,14 @@ class Joined extends React.PureComponent<Props> {
           style={{marginRight: globalMargins.tiny}}
         />
         <Box style={globalStyles.flexBoxColumn}>
-          <Text type="BodySmallSemibold">
-            {you === author ? (
-              <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
-                You
-              </Text>
-            ) : (
-              <ConnectedUsernames
-                inline={true}
-                type="BodySmallSemibold"
-                onUsernameClicked={onUsernameClicked}
-                colorFollowing={true}
-                underline={true}
-                usernames={[author]}
-              />
-            )}{' '}
-          </Text>
+          <ConnectedUsernames
+            inline={true}
+            type="BodySmallSemibold"
+            onUsernameClicked={onUsernameClicked}
+            colorFollowing={true}
+            underline={true}
+            usernames={[author]}
+          />
           <Text title={formatTimeForMessages(timestamp)} type="BodySmall">
             joined {isBigTeam ? `#${channelname}` : teamname}
             {'. '}
@@ -65,6 +62,53 @@ class Joined extends React.PureComponent<Props> {
           </Text>
         </Box>
       </Box>
+    )
+  }
+}
+
+class JoinedUserNotice extends React.PureComponent<Props> {
+  render() {
+    const {channelname, isBigTeam, onManageChannels, you, teamname, onUsernameClicked} = this.props
+    const {author, timestamp} = this.props.message
+    return (
+      <UserNotice style={{marginTop: globalMargins.small}} username={author} bgColor={globalColors.blue4}>
+        <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
+          {formatTimeForMessages(timestamp)}
+        </Text>
+        <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
+          {you === author ? (
+            'You'
+          ) : (
+            <ConnectedUsernames
+              inline={true}
+              type="BodySmallSemibold"
+              onUsernameClicked={onUsernameClicked}
+              colorFollowing={true}
+              underline={true}
+              usernames={[author]}
+            />
+          )}{' '}
+          joined{' '}
+          {isBigTeam ? (
+            `#${channelname}`
+          ) : (
+            <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
+              {teamname}
+            </Text>
+          )}.
+        </Text>
+        {author === you &&
+          isBigTeam && (
+            <Text
+              backgroundMode="Announcements"
+              onClick={onManageChannels}
+              style={{color: globalColors.blue}}
+              type="BodySmallSemibold"
+            >
+              Manage channel subscriptions.
+            </Text>
+          )}
+      </UserNotice>
     )
   }
 }

--- a/shared/chat/conversation/messages/system-joined/index.js
+++ b/shared/chat/conversation/messages/system-joined/index.js
@@ -2,8 +2,7 @@
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
 import {Box, Text, ConnectedUsernames} from '../../../../common-adapters'
-import UserNotice from '../user-notice'
-import {globalColors, globalMargins, globalStyles} from '../../../../styles'
+import {globalColors, globalMargins} from '../../../../styles'
 import {formatTimeForMessages} from '../../../../util/timestamp'
 
 type Props = {
@@ -26,13 +25,13 @@ class Joined extends React.PureComponent<Props> {
           marginLeft: globalMargins.xtiny,
           marginTop: 2,
           marginBottom: 2,
-          // ...globalStyles.flexBoxColumn,
-          // alignItems: 'center',
         }}
       >
-        <Text type="BodySmallItalic">
+        <Text title={formatTimeForMessages(timestamp)} type="BodySmallItalic">
           {you === author ? (
-            'You'
+            <Text type="BodySmallSemiboldItalic" style={{color: globalColors.black_40}}>
+              You
+            </Text>
           ) : (
             <ConnectedUsernames
               inline={true}
@@ -47,50 +46,17 @@ class Joined extends React.PureComponent<Props> {
           {'. '}
           {author === you &&
             isBigTeam && (
-              <Text onClick={onManageChannels} style={{color: globalColors.blue}} type="BodySmallItalic">
+              <Text
+                title=""
+                onClick={onManageChannels}
+                style={{color: globalColors.blue}}
+                type="BodySmallItalic"
+              >
                 Manage channel subscriptions.
               </Text>
             )}
         </Text>
       </Box>
-      // <UserNotice style={{marginTop: globalMargins.small}} username={author} bgColor={globalColors.blue4}>
-      //   <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
-      //     {formatTimeForMessages(timestamp)}
-      //   </Text>
-      //   <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
-      //     {you === author ? (
-      //       'You'
-      //     ) : (
-      //       <ConnectedUsernames
-      //         inline={true}
-      //         type="BodySmallSemibold"
-      //         onUsernameClicked={onUsernameClicked}
-      //         colorFollowing={true}
-      //         underline={true}
-      //         usernames={[author]}
-      //       />
-      //     )}{' '}
-      //     joined{' '}
-      //     {isBigTeam ? (
-      //       `#${channelname}`
-      //     ) : (
-      //       <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
-      //         {teamname}
-      //       </Text>
-      //     )}.
-      //   </Text>
-      //   {author === you &&
-      //     isBigTeam && (
-      //       <Text
-      //         backgroundMode="Announcements"
-      //         onClick={onManageChannels}
-      //         style={{color: globalColors.blue}}
-      //         type="BodySmallSemibold"
-      //       >
-      //         Manage channel subscriptions.
-      //       </Text>
-      //     )}
-      // </UserNotice>
     )
   }
 }

--- a/shared/chat/conversation/messages/system-joined/index.js
+++ b/shared/chat/conversation/messages/system-joined/index.js
@@ -37,9 +37,9 @@ class Joined extends React.PureComponent<Props> {
           style={{marginRight: globalMargins.tiny}}
         />
         <Box style={globalStyles.flexBoxColumn}>
-          <Text title={formatTimeForMessages(timestamp)} type="BodySmallSemibold">
+          <Text type="BodySmallSemibold">
             {you === author ? (
-              <Text type="BodySmallSemibold" style={{color: globalColors.black_40}}>
+              <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
                 You
               </Text>
             ) : (
@@ -53,7 +53,7 @@ class Joined extends React.PureComponent<Props> {
               />
             )}{' '}
           </Text>
-          <Text type="BodySmall">
+          <Text title={formatTimeForMessages(timestamp)} type="BodySmall">
             joined {isBigTeam ? `#${channelname}` : teamname}
             {'. '}
             {author === you &&

--- a/shared/chat/conversation/messages/system-joined/index.js
+++ b/shared/chat/conversation/messages/system-joined/index.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
-import {Box, Text, ConnectedUsernames} from '../../../../common-adapters'
-import {globalColors, globalMargins} from '../../../../styles'
+import {Avatar, Box, Text, ConnectedUsernames} from '../../../../common-adapters'
+import {globalStyles, globalColors, globalMargins} from '../../../../styles'
 import {formatTimeForMessages} from '../../../../util/timestamp'
 
 type Props = {
@@ -22,20 +22,24 @@ class Joined extends React.PureComponent<Props> {
     return (
       <Box
         style={{
-          marginLeft: globalMargins.xtiny,
           marginTop: 2,
           marginBottom: 2,
+          marginLeft: globalMargins.xtiny,
+          ...globalStyles.flexBoxRow,
+          alignItems: 'center',
+          justifyContent: 'flex-start',
         }}
       >
-        <Text title={formatTimeForMessages(timestamp)} type="BodySmallItalic">
+        <Avatar size={12} username={author} style={{marginRight: globalMargins.xtiny}} />
+        <Text title={formatTimeForMessages(timestamp)} type="BodySmall">
           {you === author ? (
-            <Text type="BodySmallSemiboldItalic" style={{color: globalColors.black_40}}>
+            <Text type="BodySmallSemibold" style={{color: globalColors.black_40}}>
               You
             </Text>
           ) : (
             <ConnectedUsernames
               inline={true}
-              type="BodySmallItalic"
+              type="BodySmall"
               onUsernameClicked={onUsernameClicked}
               colorFollowing={true}
               underline={true}
@@ -46,12 +50,7 @@ class Joined extends React.PureComponent<Props> {
           {'. '}
           {author === you &&
             isBigTeam && (
-              <Text
-                title=""
-                onClick={onManageChannels}
-                style={{color: globalColors.blue}}
-                type="BodySmallItalic"
-              >
+              <Text title="" onClick={onManageChannels} style={{color: globalColors.blue}} type="BodySmall">
                 Manage channel subscriptions.
               </Text>
             )}

--- a/shared/chat/conversation/messages/system-joined/index.js
+++ b/shared/chat/conversation/messages/system-joined/index.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
-import {Text, ConnectedUsernames} from '../../../../common-adapters'
+import {Box, Text, ConnectedUsernames} from '../../../../common-adapters'
 import UserNotice from '../user-notice'
-import {globalColors, globalMargins} from '../../../../styles'
+import {globalColors, globalMargins, globalStyles} from '../../../../styles'
 import {formatTimeForMessages} from '../../../../util/timestamp'
 
 type Props = {
@@ -21,44 +21,76 @@ class Joined extends React.PureComponent<Props> {
     const {channelname, isBigTeam, onManageChannels, you, teamname, onUsernameClicked} = this.props
     const {author, timestamp} = this.props.message
     return (
-      <UserNotice style={{marginTop: globalMargins.small}} username={author} bgColor={globalColors.blue4}>
-        <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
-          {formatTimeForMessages(timestamp)}
-        </Text>
-        <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
+      <Box
+        style={{
+          marginLeft: globalMargins.xtiny,
+          marginTop: 2,
+          marginBottom: 2,
+          // ...globalStyles.flexBoxColumn,
+          // alignItems: 'center',
+        }}
+      >
+        <Text type="BodySmallItalic">
           {you === author ? (
             'You'
           ) : (
             <ConnectedUsernames
               inline={true}
-              type="BodySmallSemibold"
+              type="BodySmallItalic"
               onUsernameClicked={onUsernameClicked}
               colorFollowing={true}
               underline={true}
               usernames={[author]}
             />
           )}{' '}
-          joined{' '}
-          {isBigTeam ? (
-            `#${channelname}`
-          ) : (
-            <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
-              {teamname}
-            </Text>
-          )}.
+          joined {isBigTeam ? `#${channelname}` : teamname}
+          {'. '}
+          {author === you &&
+            isBigTeam && (
+              <Text onClick={onManageChannels} style={{color: globalColors.blue}} type="BodySmallItalic">
+                Manage channel subscriptions.
+              </Text>
+            )}
         </Text>
-        {author === you &&
-          isBigTeam && (
-            <Text
-              backgroundMode="Announcements"
-              onClick={onManageChannels}
-              style={{color: globalColors.blue}}
-              type="BodySmallSemibold"
-            >
-              Manage channel subscriptions.
-            </Text>
-          )}
-      </UserNotice>
+      </Box>
+      // <UserNotice style={{marginTop: globalMargins.small}} username={author} bgColor={globalColors.blue4}>
+      //   <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
+      //     {formatTimeForMessages(timestamp)}
+      //   </Text>
+      //   <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
+      //     {you === author ? (
+      //       'You'
+      //     ) : (
+      //       <ConnectedUsernames
+      //         inline={true}
+      //         type="BodySmallSemibold"
+      //         onUsernameClicked={onUsernameClicked}
+      //         colorFollowing={true}
+      //         underline={true}
+      //         usernames={[author]}
+      //       />
+      //     )}{' '}
+      //     joined{' '}
+      //     {isBigTeam ? (
+      //       `#${channelname}`
+      //     ) : (
+      //       <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
+      //         {teamname}
+      //       </Text>
+      //     )}.
+      //   </Text>
+      //   {author === you &&
+      //     isBigTeam && (
+      //       <Text
+      //         backgroundMode="Announcements"
+      //         onClick={onManageChannels}
+      //         style={{color: globalColors.blue}}
+      //         type="BodySmallSemibold"
+      //       >
+      //         Manage channel subscriptions.
+      //       </Text>
+      //     )}
+      // </UserNotice>
     )
   }
 }

--- a/shared/chat/conversation/messages/system-left/container.js
+++ b/shared/chat/conversation/messages/system-left/container.js
@@ -7,6 +7,7 @@ import {createGetProfile} from '../../../../actions/tracker-gen'
 
 const mapStateToProps = (state: TypedState, {message}) => ({
   _meta: Constants.getMeta(state, message.conversationIDKey),
+  you: state.config.username,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -25,6 +26,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     message: ownProps.message,
     onUsernameClicked: dispatchProps.onUsernameClicked,
     teamname: _meta.teamname,
+    you: stateProps.you,
   }
 }
 

--- a/shared/chat/conversation/messages/system-left/index.js
+++ b/shared/chat/conversation/messages/system-left/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
 import {Avatar, Box, Text, ConnectedUsernames} from '../../../../common-adapters'
-import {globalMargins, globalStyles} from '../../../../styles'
+import {globalColors, globalMargins, globalStyles} from '../../../../styles'
 import {formatTimeForMessages} from '../../../../util/timestamp'
 
 type Props = {
@@ -11,11 +11,12 @@ type Props = {
   message: Types.MessageSystemLeft,
   onUsernameClicked: (username: string) => void,
   teamname: string,
+  you: string,
 }
 
 class Left extends React.PureComponent<Props> {
   render() {
-    const {channelname, isBigTeam, teamname, onUsernameClicked} = this.props
+    const {channelname, isBigTeam, teamname, onUsernameClicked, you} = this.props
     const {author, timestamp} = this.props.message
     return (
       <Box
@@ -36,14 +37,20 @@ class Left extends React.PureComponent<Props> {
         />
         <Box style={globalStyles.flexBoxColumn}>
           <Text type="BodySmallSemibold">
-            <ConnectedUsernames
-              inline={true}
-              type="BodySmallSemibold"
-              onUsernameClicked={onUsernameClicked}
-              colorFollowing={true}
-              underline={true}
-              usernames={[author]}
-            />
+            {you === author ? (
+              <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
+                You
+              </Text>
+            ) : (
+              <ConnectedUsernames
+                inline={true}
+                type="BodySmallSemibold"
+                onUsernameClicked={onUsernameClicked}
+                colorFollowing={true}
+                underline={true}
+                usernames={[author]}
+              />
+            )}{' '}
           </Text>
           <Text title={formatTimeForMessages(timestamp)} type="BodySmall">
             left {isBigTeam ? `#${channelname}` : teamname}.

--- a/shared/chat/conversation/messages/system-left/index.js
+++ b/shared/chat/conversation/messages/system-left/index.js
@@ -2,8 +2,7 @@
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
 import {Box, Text, ConnectedUsernames} from '../../../../common-adapters'
-import UserNotice from '../user-notice'
-import {globalColors, globalMargins, globalStyles} from '../../../../styles'
+import {globalMargins} from '../../../../styles'
 import {formatTimeForMessages} from '../../../../util/timestamp'
 
 type Props = {
@@ -24,11 +23,9 @@ class Left extends React.PureComponent<Props> {
           marginLeft: globalMargins.xtiny,
           marginTop: 2,
           marginBottom: 2,
-          // ...globalStyles.flexBoxColumn,
-          // alignItems: 'center',
         }}
       >
-        <Text type="BodySmallItalic">
+        <Text title={formatTimeForMessages(timestamp)} type="BodySmallItalic">
           <ConnectedUsernames
             inline={true}
             type="BodySmallItalic"
@@ -40,29 +37,6 @@ class Left extends React.PureComponent<Props> {
           left {isBigTeam ? `#${channelname}` : teamname}
         </Text>
       </Box>
-      // <UserNotice style={{marginTop: globalMargins.small}} username={author} bgColor={globalColors.blue4}>
-      //   <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
-      //     {formatTimeForMessages(timestamp)}
-      //   </Text>
-      //   <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
-      //     <ConnectedUsernames
-      //       inline={true}
-      //       type="BodySmallSemibold"
-      //       onUsernameClicked={onUsernameClicked}
-      //       colorFollowing={true}
-      //       underline={true}
-      //       usernames={[author]}
-      //     />{' '}
-      //     left
-      //     {isBigTeam ? (
-      //       `#${channelname}`
-      //     ) : (
-      //       <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
-      //         {teamname}
-      //       </Text>
-      //     )}.
-      //   </Text>
-      // </UserNotice>
     )
   }
 }

--- a/shared/chat/conversation/messages/system-left/index.js
+++ b/shared/chat/conversation/messages/system-left/index.js
@@ -35,7 +35,7 @@ class Left extends React.PureComponent<Props> {
           style={{marginRight: globalMargins.tiny}}
         />
         <Box style={globalStyles.flexBoxColumn}>
-          <Text title={formatTimeForMessages(timestamp)} type="BodySmallSemibold">
+          <Text type="BodySmallSemibold">
             <ConnectedUsernames
               inline={true}
               type="BodySmallSemibold"
@@ -45,7 +45,9 @@ class Left extends React.PureComponent<Props> {
               usernames={[author]}
             />
           </Text>
-          <Text type="BodySmallSemibold">left {isBigTeam ? `#${channelname}` : teamname}</Text>
+          <Text title={formatTimeForMessages(timestamp)} type="BodySmall">
+            left {isBigTeam ? `#${channelname}` : teamname}.
+          </Text>
         </Box>
       </Box>
     )

--- a/shared/chat/conversation/messages/system-left/index.js
+++ b/shared/chat/conversation/messages/system-left/index.js
@@ -20,26 +20,28 @@ class Left extends React.PureComponent<Props> {
     return (
       <Box
         style={{
-          marginTop: 2,
-          marginBottom: 2,
-          marginLeft: globalMargins.xtiny,
+          marginTop: 3,
+          marginBottom: 3,
+          marginLeft: globalMargins.tiny,
           ...globalStyles.flexBoxRow,
           alignItems: 'center',
           justifyContent: 'flex-start',
         }}
       >
-        <Avatar size={12} username={author} style={{marginRight: globalMargins.xtiny}} />
-        <Text title={formatTimeForMessages(timestamp)} type="BodySmall">
-          <ConnectedUsernames
-            inline={true}
-            type="BodySmall"
-            onUsernameClicked={onUsernameClicked}
-            colorFollowing={true}
-            underline={true}
-            usernames={[author]}
-          />{' '}
-          left {isBigTeam ? `#${channelname}` : teamname}
-        </Text>
+        <Avatar size={24} username={author} style={{marginRight: globalMargins.tiny}} />
+        <Box style={globalStyles.flexBoxColumn}>
+          <Text title={formatTimeForMessages(timestamp)} type="BodySmallSemibold">
+            <ConnectedUsernames
+              inline={true}
+              type="BodySmallSemibold"
+              onUsernameClicked={onUsernameClicked}
+              colorFollowing={true}
+              underline={true}
+              usernames={[author]}
+            />
+          </Text>
+          <Text type="BodySmallSemibold">left {isBigTeam ? `#${channelname}` : teamname}</Text>
+        </Box>
       </Box>
     )
   }

--- a/shared/chat/conversation/messages/system-left/index.js
+++ b/shared/chat/conversation/messages/system-left/index.js
@@ -28,7 +28,12 @@ class Left extends React.PureComponent<Props> {
           justifyContent: 'flex-start',
         }}
       >
-        <Avatar size={24} username={author} style={{marginRight: globalMargins.tiny}} />
+        <Avatar
+          onClick={() => onUsernameClicked(author)}
+          size={24}
+          username={author}
+          style={{marginRight: globalMargins.tiny}}
+        />
         <Box style={globalStyles.flexBoxColumn}>
           <Text title={formatTimeForMessages(timestamp)} type="BodySmallSemibold">
             <ConnectedUsernames

--- a/shared/chat/conversation/messages/system-left/index.js
+++ b/shared/chat/conversation/messages/system-left/index.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
-import {Text, ConnectedUsernames} from '../../../../common-adapters'
+import {Box, Text, ConnectedUsernames} from '../../../../common-adapters'
 import UserNotice from '../user-notice'
-import {globalColors, globalMargins} from '../../../../styles'
+import {globalColors, globalMargins, globalStyles} from '../../../../styles'
 import {formatTimeForMessages} from '../../../../util/timestamp'
 
 type Props = {
@@ -19,29 +19,50 @@ class Left extends React.PureComponent<Props> {
     const {channelname, isBigTeam, teamname, onUsernameClicked} = this.props
     const {author, timestamp} = this.props.message
     return (
-      <UserNotice style={{marginTop: globalMargins.small}} username={author} bgColor={globalColors.blue4}>
-        <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
-          {formatTimeForMessages(timestamp)}
-        </Text>
-        <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
+      <Box
+        style={{
+          marginLeft: globalMargins.xtiny,
+          marginTop: 2,
+          marginBottom: 2,
+          // ...globalStyles.flexBoxColumn,
+          // alignItems: 'center',
+        }}
+      >
+        <Text type="BodySmallItalic">
           <ConnectedUsernames
             inline={true}
-            type="BodySmallSemibold"
+            type="BodySmallItalic"
             onUsernameClicked={onUsernameClicked}
             colorFollowing={true}
             underline={true}
             usernames={[author]}
           />{' '}
-          left
-          {isBigTeam ? (
-            `#${channelname}`
-          ) : (
-            <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
-              {teamname}
-            </Text>
-          )}.
+          left {isBigTeam ? `#${channelname}` : teamname}
         </Text>
-      </UserNotice>
+      </Box>
+      // <UserNotice style={{marginTop: globalMargins.small}} username={author} bgColor={globalColors.blue4}>
+      //   <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
+      //     {formatTimeForMessages(timestamp)}
+      //   </Text>
+      //   <Text type="BodySmallSemibold" backgroundMode="Announcements" style={{color: globalColors.black_40}}>
+      //     <ConnectedUsernames
+      //       inline={true}
+      //       type="BodySmallSemibold"
+      //       onUsernameClicked={onUsernameClicked}
+      //       colorFollowing={true}
+      //       underline={true}
+      //       usernames={[author]}
+      //     />{' '}
+      //     left
+      //     {isBigTeam ? (
+      //       `#${channelname}`
+      //     ) : (
+      //       <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
+      //         {teamname}
+      //       </Text>
+      //     )}.
+      //   </Text>
+      // </UserNotice>
     )
   }
 }

--- a/shared/chat/conversation/messages/system-left/index.js
+++ b/shared/chat/conversation/messages/system-left/index.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
-import {Box, Text, ConnectedUsernames} from '../../../../common-adapters'
-import {globalMargins} from '../../../../styles'
+import {Avatar, Box, Text, ConnectedUsernames} from '../../../../common-adapters'
+import {globalMargins, globalStyles} from '../../../../styles'
 import {formatTimeForMessages} from '../../../../util/timestamp'
 
 type Props = {
@@ -20,15 +20,19 @@ class Left extends React.PureComponent<Props> {
     return (
       <Box
         style={{
-          marginLeft: globalMargins.xtiny,
           marginTop: 2,
           marginBottom: 2,
+          marginLeft: globalMargins.xtiny,
+          ...globalStyles.flexBoxRow,
+          alignItems: 'center',
+          justifyContent: 'flex-start',
         }}
       >
-        <Text title={formatTimeForMessages(timestamp)} type="BodySmallItalic">
+        <Avatar size={12} username={author} style={{marginRight: globalMargins.xtiny}} />
+        <Text title={formatTimeForMessages(timestamp)} type="BodySmall">
           <ConnectedUsernames
             inline={true}
-            type="BodySmallItalic"
+            type="BodySmall"
             onUsernameClicked={onUsernameClicked}
             colorFollowing={true}
             underline={true}

--- a/shared/chat/conversation/messages/system-left/index.js
+++ b/shared/chat/conversation/messages/system-left/index.js
@@ -38,7 +38,7 @@ class Left extends React.PureComponent<Props> {
         <Box style={globalStyles.flexBoxColumn}>
           <Text type="BodySmallSemibold">
             {you === author ? (
-              <Text type="BodySmallSemibold" style={{color: globalColors.black_60}}>
+              <Text type="BodySmallSemiboldItalic" style={{color: globalColors.black_60}}>
                 You
               </Text>
             ) : (

--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -74,15 +74,18 @@ const mergeProps = (stateProps, dispatchProps) => {
     previous.author === message.author &&
     (previous.type === 'text' || previous.type === 'deleted')
 
-  const oldEnough =
-    !!previous &&
-    !!previous.timestamp &&
-    !!message.timestamp &&
+  const oldEnough = !!(
+    previous &&
+    previous.timestamp &&
+    message.timestamp &&
     message.timestamp - previous.timestamp > howLongBetweenTimestampsMs
+  )
 
   // Always show a timestamp if the previous message is a concise joined/left message
-  const previousIsJoinedLeft =
-    !!previous && (previous.type === 'systemJoined' || previous.type === 'systemLeft')
+  const previousIsJoinedLeft = !!(
+    previous &&
+    (previous.type === 'systemJoined' || previous.type === 'systemLeft')
+  )
 
   const timestamp =
     stateProps.orangeLineAbove || !previous || oldEnough || previousIsJoinedLeft

--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -75,13 +75,19 @@ const mergeProps = (stateProps, dispatchProps) => {
     (previous.type === 'text' || previous.type === 'deleted')
 
   const oldEnough =
-    previous &&
-    previous.timestamp &&
-    message.timestamp &&
+    !!previous &&
+    !!previous.timestamp &&
+    !!message.timestamp &&
     message.timestamp - previous.timestamp > howLongBetweenTimestampsMs
 
+  // Always show a timestamp if the previous message is a concise joined/left message
+  const previousIsJoinedLeft =
+    !!previous && (previous.type === 'systemJoined' || previous.type === 'systemLeft')
+
   const timestamp =
-    stateProps.orangeLineAbove || !previous || oldEnough ? formatTimeForMessages(message.timestamp) : null
+    stateProps.orangeLineAbove || !previous || oldEnough || previousIsJoinedLeft
+      ? formatTimeForMessages(message.timestamp)
+      : null
   const includeHeader = !previous || !continuingTextBlock || !!timestamp
   let failureDescription = null
   if ((message.type === 'text' || message.type === 'attachment') && message.errorReason) {


### PR DESCRIPTION
Styles the system message to look more like a regular message, with some custom styles to set them apart:

<img width="911" alt="image" src="https://user-images.githubusercontent.com/11968340/37484674-99982870-285f-11e8-927e-8216a3a38964.png">

also special-cases the Leave system message to replace the username with `You`, which we only had for the join before.

r? @keybase/react-hackers cc @cecileboucheron 

EDIT: after taking another pass, we'll keep the larger notice for the current user joining to bring their attention to `Manage channel subscriptions`

<img width="798" alt="image" src="https://user-images.githubusercontent.com/11968340/37486734-bff7fa08-2865-11e8-92a9-e69e5460a933.png">

