### PR TITLE
Fix subteams tab

### DIFF
--- a/shared/teams/team/subteams/container.js
+++ b/shared/teams/team/subteams/container.js
@@ -60,7 +60,7 @@ const listMergeProps = (stateProps, dispatchProps, ownProps) => {
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   listItems: listMergeProps(stateProps, dispatchProps, ownProps).listItems,
-  teamname: ownProps.teamname,
+  ...ownProps,
 })
 
 export const subteamsListItemsConnector = connect(mapStateToProps, mapDispatchToProps, mergeProps)


### PR DESCRIPTION
Subteams tab was busted because it wasn't passing ownProps back to the parent. r? @keybase/react-hackers 