### PR TITLE
fix clicking on filtered inbox row

### DIFF
--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -77,36 +77,36 @@ const mapDispatchToProps = (dispatch: Dispatch): * => ({
   _sendTyping: (conversationIDKey: Types.ConversationIDKey, typing: boolean) =>
     // only valid conversations
     conversationIDKey && dispatch(Chat2Gen.createSendTyping({conversationIDKey, typing})),
+  clearInboxFilter: () => dispatch(Chat2Gen.createSetInboxFilter({filter: ''})),
 })
 
-const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
-  return {
-    _editingMessage: stateProps._editingMessage,
-    _onSubmit: (text: string) => {
-      const em = stateProps._editingMessage
-      if (em) {
-        if (em.type === 'text' && em.text.stringValue() === text) {
-          dispatchProps._onCancelEditing(stateProps.conversationIDKey)
-        } else {
-          dispatchProps._onEditMessage(em, text)
-        }
+const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => ({
+  _editingMessage: stateProps._editingMessage,
+  _onSubmit: (text: string) => {
+    const em = stateProps._editingMessage
+    if (em) {
+      if (em.type === 'text' && em.text.stringValue() === text) {
+        dispatchProps._onCancelEditing(stateProps.conversationIDKey)
       } else {
-        dispatchProps._onPostMessage(stateProps.conversationIDKey, text)
+        dispatchProps._onEditMessage(em, text)
       }
-      ownProps.onScrollDown()
-    },
-    channelName: stateProps._meta.channelname,
-    conversationIDKey: stateProps.conversationIDKey,
-    focusInputCounter: ownProps.focusInputCounter,
-    isEditing: !!stateProps._editingMessage,
-    isLoading: false,
-    onAttach: (paths: Array<string>) => dispatchProps._onAttach(stateProps.conversationIDKey, paths),
-    onCancelEditing: () => dispatchProps._onCancelEditing(stateProps.conversationIDKey),
-    onEditLastMessage: () => dispatchProps._onEditLastMessage(stateProps.conversationIDKey, stateProps._you),
-    sendTyping: (typing: boolean) => dispatchProps._sendTyping(stateProps.conversationIDKey, typing),
-    typing: stateProps.typing,
-  }
-}
+    } else {
+      dispatchProps._onPostMessage(stateProps.conversationIDKey, text)
+    }
+    ownProps.onScrollDown()
+  },
+  channelName: stateProps._meta.channelname,
+  clearInboxFilter: dispatchProps.clearInboxFilter,
+  conversationIDKey: stateProps.conversationIDKey,
+  focusInputCounter: ownProps.focusInputCounter,
+  isEditing: !!stateProps._editingMessage,
+  isLoading: false,
+  onAttach: (paths: Array<string>) => dispatchProps._onAttach(stateProps.conversationIDKey, paths),
+  onCancelEditing: () => dispatchProps._onCancelEditing(stateProps.conversationIDKey),
+  onEditLastMessage: () => dispatchProps._onEditLastMessage(stateProps.conversationIDKey, stateProps._you),
+  sendTyping: (typing: boolean) => dispatchProps._sendTyping(stateProps.conversationIDKey, typing),
+  typing: stateProps.typing,
+})
 
 // Standalone throttled function to ensure we never accidentally recreate it and break the throttling
 const throttled = throttle((f, param) => f(param), 1000)

--- a/shared/chat/conversation/input-area/normal/index.desktop.js
+++ b/shared/chat/conversation/input-area/normal/index.desktop.js
@@ -104,6 +104,10 @@ class ConversationInput extends Component<InputProps> {
     this.props.setChannelMentionPopupOpen(false)
   }
 
+  _onFocus = () => {
+    this.props.clearInboxFilter()
+  }
+
   render() {
     return (
       <Box
@@ -159,6 +163,7 @@ class ConversationInput extends Component<InputProps> {
             <Input
               className={'mousetrap' /* className needed so key handler doesn't ignore hotkeys */}
               autoFocus={false}
+              onFocus={this._onFocus}
               small={true}
               style={styleInput}
               ref={this.props.inputSetRef}

--- a/shared/chat/conversation/input-area/normal/index.js.flow
+++ b/shared/chat/conversation/input-area/normal/index.js.flow
@@ -54,6 +54,7 @@ export type MentionHocProps = {
   mentionFilter: string,
   mentionPopupOpen: boolean,
   setMentionPopupOpen: (setOpen: boolean) => void,
+  clearInboxFilter: () => void,
 }
 
 export type Props = PreMentionHocProps & MentionHocProps

--- a/shared/chat/conversation/input-area/normal/index.js.flow
+++ b/shared/chat/conversation/input-area/normal/index.js.flow
@@ -8,6 +8,7 @@ export type PreMentionHocProps = {
   channelName: ?string,
   isEditing: boolean,
   focusInputCounter: number,
+  clearInboxFilter: () => void,
   inputBlur: () => void,
   inputClear: () => void,
   inputFocus: () => void,
@@ -54,7 +55,6 @@ export type MentionHocProps = {
   mentionFilter: string,
   mentionPopupOpen: boolean,
   setMentionPopupOpen: (setOpen: boolean) => void,
-  clearInboxFilter: () => void,
 }
 
 export type Props = PreMentionHocProps & MentionHocProps

--- a/shared/chat/inbox/row/chat-filter-row.js
+++ b/shared/chat/inbox/row/chat-filter-row.js
@@ -39,11 +39,11 @@ class ChatFilterRow extends React.PureComponent<Props, State> {
 
   _stopEditing = () => {
     this.setState({isEditing: false})
-    this.props.onSetFilter('')
   }
 
   _onKeyDown = (e: SyntheticKeyboardEvent<>, isComposingIME: boolean) => {
     if (e.key === 'Escape' && !isComposingIME) {
+      this.props.onSetFilter('')
       this._stopEditing()
     } else if (e.key === 'ArrowDown') {
       e.preventDefault()
@@ -60,6 +60,7 @@ class ChatFilterRow extends React.PureComponent<Props, State> {
     if (!isMobile) {
       e.preventDefault()
       e.stopPropagation()
+      this.props.onSetFilter('')
       this._stopEditing()
       this._input && this._input.blur()
     }


### PR DESCRIPTION
@keybase/react-hackers clicking with the mouse on filtered inbox wasn't working

The root cause is when you're in the filtered mode and you're using the arrow keys we want to not 'select' the conversation. When the filter box loses focus we'd then clear the search and put you back into 'regular' chat mode. The problem is clicking actually makes the filter box lose focus, which then would reset stuff and your click would basically get thrown away.

 Instead: the filter is cleared when the chat input box itself gets focus (on desktop)

cc: @mmaxim 