### PR TITLE
Fix previewing channels

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -746,7 +746,7 @@ const loadMoreMessagesSuccess = (results: ?Array<any>) => {
 
 // If we're previewing a conversation we tell the service so it injects it into the inbox with a flag to tell us its a preview
 const previewConversation = (action: Chat2Gen.SelectConversationPayload) =>
-  action.payload.asAPreview
+  action.payload.reason === 'preview'
     ? Saga.call(RPCChatTypes.localPreviewConversationByIDLocalRpcPromise, {
         convID: Types.keyToConversationID(action.payload.conversationIDKey),
       })


### PR DESCRIPTION
Bit by that flow bug again; previewing channels was busted because we were predicating on a property that was removed in #10926. r? @keybase/react-hackers 