### PR TITLE
Split stellar bundle into secret and shared part

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2323,9 +2323,8 @@ func (r ResetLink) Summarize() ResetSummary {
 // CheckInvariants checks that the bundle satisfies
 // 1. No duplicate account IDs
 // 2. At most one primary account
-func (s StellarSecretBundle) CheckInvariants() error {
+func (s StellarBundle) CheckInvariants() error {
 	accountIDs := make(map[StellarAccountID]bool)
-	names := make(map[string]bool)
 	var foundPrimary bool
 	for _, entry := range s.Accounts {
 		_, found := accountIDs[entry.AccountID]
@@ -2333,11 +2332,6 @@ func (s StellarSecretBundle) CheckInvariants() error {
 			return fmt.Errorf("duplicate account ID: %v", entry.AccountID)
 		}
 		accountIDs[entry.AccountID] = true
-		_, found = names[entry.Name]
-		if found {
-			return fmt.Errorf("duplicate account name: %v", entry.Name)
-		}
-		names[entry.Name] = true
 		if entry.IsPrimary {
 			if foundPrimary {
 				return errors.New("multiple primary accounts")

--- a/go/protocol/keybase1/stellar.go
+++ b/go/protocol/keybase1/stellar.go
@@ -26,15 +26,26 @@ func (o StellarRevision) DeepCopy() StellarRevision {
 	return o
 }
 
-type EncryptedStellarSecretBundle struct {
+type Hash []byte
+
+func (o Hash) DeepCopy() Hash {
+	return (func(x []byte) []byte {
+		if x == nil {
+			return nil
+		}
+		return append([]byte{}, x...)
+	})(o)
+}
+
+type EncryptedStellarBundle struct {
 	V   int                  `codec:"v" json:"v"`
 	E   []byte               `codec:"e" json:"e"`
 	N   BoxNonce             `codec:"n" json:"n"`
 	Gen PerUserKeyGeneration `codec:"gen" json:"gen"`
 }
 
-func (o EncryptedStellarSecretBundle) DeepCopy() EncryptedStellarSecretBundle {
-	return EncryptedStellarSecretBundle{
+func (o EncryptedStellarBundle) DeepCopy() EncryptedStellarBundle {
+	return EncryptedStellarBundle{
 		V: o.V,
 		E: (func(x []byte) []byte {
 			if x == nil {
@@ -47,37 +58,37 @@ func (o EncryptedStellarSecretBundle) DeepCopy() EncryptedStellarSecretBundle {
 	}
 }
 
-type StellarSecretBundleVersion int
+type StellarBundleVersion int
 
 const (
-	StellarSecretBundleVersion_V1 StellarSecretBundleVersion = 1
+	StellarBundleVersion_V1 StellarBundleVersion = 1
 )
 
-func (o StellarSecretBundleVersion) DeepCopy() StellarSecretBundleVersion { return o }
+func (o StellarBundleVersion) DeepCopy() StellarBundleVersion { return o }
 
-var StellarSecretBundleVersionMap = map[string]StellarSecretBundleVersion{
+var StellarBundleVersionMap = map[string]StellarBundleVersion{
 	"V1": 1,
 }
 
-var StellarSecretBundleVersionRevMap = map[StellarSecretBundleVersion]string{
+var StellarBundleVersionRevMap = map[StellarBundleVersion]string{
 	1: "V1",
 }
 
-func (e StellarSecretBundleVersion) String() string {
-	if v, ok := StellarSecretBundleVersionRevMap[e]; ok {
+func (e StellarBundleVersion) String() string {
+	if v, ok := StellarBundleVersionRevMap[e]; ok {
 		return v
 	}
 	return ""
 }
 
-type StellarSecretBundleVersioned struct {
-	Version__ StellarSecretBundleVersion `codec:"version" json:"version"`
-	V1__      *StellarSecretBundleV1     `codec:"v1,omitempty" json:"v1,omitempty"`
+type StellarBundleSecretVersioned struct {
+	Version__ StellarBundleVersion   `codec:"version" json:"version"`
+	V1__      *StellarBundleSecretV1 `codec:"v1,omitempty" json:"v1,omitempty"`
 }
 
-func (o *StellarSecretBundleVersioned) Version() (ret StellarSecretBundleVersion, err error) {
+func (o *StellarBundleSecretVersioned) Version() (ret StellarBundleVersion, err error) {
 	switch o.Version__ {
-	case StellarSecretBundleVersion_V1:
+	case StellarBundleVersion_V1:
 		if o.V1__ == nil {
 			err = errors.New("unexpected nil value for V1__")
 			return ret, err
@@ -86,8 +97,8 @@ func (o *StellarSecretBundleVersioned) Version() (ret StellarSecretBundleVersion
 	return o.Version__, nil
 }
 
-func (o StellarSecretBundleVersioned) V1() (res StellarSecretBundleV1) {
-	if o.Version__ != StellarSecretBundleVersion_V1 {
+func (o StellarBundleSecretVersioned) V1() (res StellarBundleSecretV1) {
+	if o.Version__ != StellarBundleVersion_V1 {
 		panic("wrong case accessed")
 	}
 	if o.V1__ == nil {
@@ -96,17 +107,17 @@ func (o StellarSecretBundleVersioned) V1() (res StellarSecretBundleV1) {
 	return *o.V1__
 }
 
-func NewStellarSecretBundleVersionedWithV1(v StellarSecretBundleV1) StellarSecretBundleVersioned {
-	return StellarSecretBundleVersioned{
-		Version__: StellarSecretBundleVersion_V1,
+func NewStellarBundleSecretVersionedWithV1(v StellarBundleSecretV1) StellarBundleSecretVersioned {
+	return StellarBundleSecretVersioned{
+		Version__: StellarBundleVersion_V1,
 		V1__:      &v,
 	}
 }
 
-func (o StellarSecretBundleVersioned) DeepCopy() StellarSecretBundleVersioned {
-	return StellarSecretBundleVersioned{
+func (o StellarBundleSecretVersioned) DeepCopy() StellarBundleSecretVersioned {
+	return StellarBundleSecretVersioned{
 		Version__: o.Version__.DeepCopy(),
-		V1__: (func(x *StellarSecretBundleV1) *StellarSecretBundleV1 {
+		V1__: (func(x *StellarBundleSecretV1) *StellarBundleSecretV1 {
 			if x == nil {
 				return nil
 			}
@@ -116,19 +127,21 @@ func (o StellarSecretBundleVersioned) DeepCopy() StellarSecretBundleVersioned {
 	}
 }
 
-type StellarSecretBundleV1 struct {
-	Revision StellarRevision      `codec:"revision" json:"revision"`
-	Accounts []StellarSecretEntry `codec:"accounts" json:"accounts"`
+type StellarBundleVisibleV1 struct {
+	Revision StellarRevision       `codec:"revision" json:"revision"`
+	Prev     Hash                  `codec:"prev" json:"prev"`
+	Accounts []StellarVisibleEntry `codec:"accounts" json:"accounts"`
 }
 
-func (o StellarSecretBundleV1) DeepCopy() StellarSecretBundleV1 {
-	return StellarSecretBundleV1{
+func (o StellarBundleVisibleV1) DeepCopy() StellarBundleVisibleV1 {
+	return StellarBundleVisibleV1{
 		Revision: o.Revision.DeepCopy(),
-		Accounts: (func(x []StellarSecretEntry) []StellarSecretEntry {
+		Prev:     o.Prev.DeepCopy(),
+		Accounts: (func(x []StellarVisibleEntry) []StellarVisibleEntry {
 			if x == nil {
 				return nil
 			}
-			var ret []StellarSecretEntry
+			var ret []StellarVisibleEntry
 			for _, v := range x {
 				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
@@ -138,14 +151,14 @@ func (o StellarSecretBundleV1) DeepCopy() StellarSecretBundleV1 {
 	}
 }
 
-type StellarSecretBundle struct {
-	Revision StellarRevision      `codec:"revision" json:"revision"`
-	Accounts []StellarSecretEntry `codec:"accounts" json:"accounts"`
+type StellarBundleSecretV1 struct {
+	VisibleHash Hash                 `codec:"visibleHash" json:"visibleHash"`
+	Accounts    []StellarSecretEntry `codec:"accounts" json:"accounts"`
 }
 
-func (o StellarSecretBundle) DeepCopy() StellarSecretBundle {
-	return StellarSecretBundle{
-		Revision: o.Revision.DeepCopy(),
+func (o StellarBundleSecretV1) DeepCopy() StellarBundleSecretV1 {
+	return StellarBundleSecretV1{
+		VisibleHash: o.VisibleHash.DeepCopy(),
 		Accounts: (func(x []StellarSecretEntry) []StellarSecretEntry {
 			if x == nil {
 				return nil
@@ -183,18 +196,29 @@ func (e StellarAccountMode) String() string {
 	return ""
 }
 
-type StellarSecretEntry struct {
+type StellarVisibleEntry struct {
 	AccountID StellarAccountID   `codec:"accountID" json:"accountID"`
 	Mode      StellarAccountMode `codec:"mode" json:"mode"`
-	Signers   []StellarSecretKey `codec:"signers" json:"signers"`
 	IsPrimary bool               `codec:"isPrimary" json:"isPrimary"`
+}
+
+func (o StellarVisibleEntry) DeepCopy() StellarVisibleEntry {
+	return StellarVisibleEntry{
+		AccountID: o.AccountID.DeepCopy(),
+		Mode:      o.Mode.DeepCopy(),
+		IsPrimary: o.IsPrimary,
+	}
+}
+
+type StellarSecretEntry struct {
+	AccountID StellarAccountID   `codec:"accountID" json:"accountID"`
+	Signers   []StellarSecretKey `codec:"signers" json:"signers"`
 	Name      string             `codec:"name" json:"name"`
 }
 
 func (o StellarSecretEntry) DeepCopy() StellarSecretEntry {
 	return StellarSecretEntry{
 		AccountID: o.AccountID.DeepCopy(),
-		Mode:      o.Mode.DeepCopy(),
 		Signers: (func(x []StellarSecretKey) []StellarSecretKey {
 			if x == nil {
 				return nil
@@ -206,8 +230,61 @@ func (o StellarSecretEntry) DeepCopy() StellarSecretEntry {
 			}
 			return ret
 		})(o.Signers),
+		Name: o.Name,
+	}
+}
+
+type StellarBundle struct {
+	Revision StellarRevision `codec:"revision" json:"revision"`
+	Prev     Hash            `codec:"prev" json:"prev"`
+	OwnHash  Hash            `codec:"ownHash" json:"ownHash"`
+	Accounts []StellarEntry  `codec:"accounts" json:"accounts"`
+}
+
+func (o StellarBundle) DeepCopy() StellarBundle {
+	return StellarBundle{
+		Revision: o.Revision.DeepCopy(),
+		Prev:     o.Prev.DeepCopy(),
+		OwnHash:  o.OwnHash.DeepCopy(),
+		Accounts: (func(x []StellarEntry) []StellarEntry {
+			if x == nil {
+				return nil
+			}
+			var ret []StellarEntry
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Accounts),
+	}
+}
+
+type StellarEntry struct {
+	AccountID StellarAccountID   `codec:"accountID" json:"accountID"`
+	Mode      StellarAccountMode `codec:"mode" json:"mode"`
+	IsPrimary bool               `codec:"isPrimary" json:"isPrimary"`
+	Signers   []StellarSecretKey `codec:"signers" json:"signers"`
+	Name      string             `codec:"name" json:"name"`
+}
+
+func (o StellarEntry) DeepCopy() StellarEntry {
+	return StellarEntry{
+		AccountID: o.AccountID.DeepCopy(),
+		Mode:      o.Mode.DeepCopy(),
 		IsPrimary: o.IsPrimary,
-		Name:      o.Name,
+		Signers: (func(x []StellarSecretKey) []StellarSecretKey {
+			if x == nil {
+				return nil
+			}
+			var ret []StellarSecretKey
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Signers),
+		Name: o.Name,
 	}
 }
 

--- a/go/stellar/bundle/bundle.go
+++ b/go/stellar/bundle/bundle.go
@@ -1,6 +1,8 @@
 package bundle
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -11,32 +13,56 @@ import (
 )
 
 /*
-The box posted to the server is base64(msgpack(EncryptedStellarSecretBundle)).
-EncryptedStellarSecretBundle := secretbox(key, bundlepack, randomnonce).
+The client posts to the server the bundle in 3 parts:
+1. bundle_encrypted = b64(msgpack(EncryptedStellarBundle))
+2. bundle_visible = b64(msgpack(StellarBundleVisibleV1))
+3. format_version = StellarBundleSecretVersioned.Version
+
+EncryptedStellarBundle := secretbox(key, bundlepack, randomnonce).
 key := HMAC(PUKSeed[gen], "Derived-User-NaCl-SecretBox-StellarBundle-1")
-bundlepack := msgpack(StellarSecretBundleVersioned)
+bundlepack := msgpack(StellarBundleSecretVersioned)
 */
 
-// Box encrypts the stellar key bundle for the PUK.
-// Returns the encrypted struct and a base64 encoding for posting to the server.
-func Box(bundle keybase1.StellarSecretBundle, pukGen keybase1.PerUserKeyGeneration,
-	puk libkb.PerUserKeySeed) (res keybase1.EncryptedStellarSecretBundle, resB64 string, err error) {
+type BoxResult struct {
+	Enc           keybase1.EncryptedStellarBundle
+	EncB64        string // base64 msgpack'd Enc
+	VisB64        string // base64 msgpack'd Vis
+	FormatVersion keybase1.StellarBundleVersion
+}
+
+// Box encrypts a stellar key bundle for a PUK.
+func Box(bundle keybase1.StellarBundle, pukGen keybase1.PerUserKeyGeneration,
+	puk libkb.PerUserKeySeed) (res BoxResult, err error) {
 	err = bundle.CheckInvariants()
 	if err != nil {
-		return res, resB64, err
+		return res, err
 	}
-	versioned := keybase1.NewStellarSecretBundleVersionedWithV1(keybase1.StellarSecretBundleV1{
+	accountsVisible, accountsSecret := accountsSplit(bundle.Accounts)
+	res.FormatVersion = keybase1.StellarBundleVersion_V1
+	visibleV1 := keybase1.StellarBundleVisibleV1{
 		Revision: bundle.Revision,
-		Accounts: bundle.Accounts,
+		Prev:     bundle.Prev,
+		Accounts: accountsVisible,
+	}
+	visiblePack, err := libkb.MsgpackEncode(visibleV1)
+	if err != nil {
+		return res, err
+	}
+	res.VisB64 = base64.StdEncoding.EncodeToString(visiblePack)
+	visibleHash := sha256.Sum256(visiblePack)
+	versionedSecret := keybase1.NewStellarBundleSecretVersionedWithV1(keybase1.StellarBundleSecretV1{
+		VisibleHash: visibleHash[:],
+		Accounts:    accountsSecret,
 	})
-	return Encrypt(versioned, pukGen, puk)
+	res.Enc, res.EncB64, err = Encrypt(versionedSecret, pukGen, puk)
+	return res, err
 }
 
 // Encrypt encrypts the stellar key bundle for the PUK.
 // Returns the encrypted struct and a base64 encoding for posting to the server.
 // Does not check invariants.
-func Encrypt(bundle keybase1.StellarSecretBundleVersioned, pukGen keybase1.PerUserKeyGeneration,
-	puk libkb.PerUserKeySeed) (res keybase1.EncryptedStellarSecretBundle, resB64 string, err error) {
+func Encrypt(bundle keybase1.StellarBundleSecretVersioned, pukGen keybase1.PerUserKeyGeneration,
+	puk libkb.PerUserKeySeed) (res keybase1.EncryptedStellarBundle, resB64 string, err error) {
 	// Msgpack (inner)
 	clearpack, err := libkb.MsgpackEncode(bundle)
 	if err != nil {
@@ -58,14 +84,14 @@ func Encrypt(bundle keybase1.StellarSecretBundleVersioned, pukGen keybase1.PerUs
 	secbox := secretbox.Seal(nil, clearpack[:], &nonce, (*[libkb.NaclSecretBoxKeySize]byte)(&symmetricKey))
 
 	// Annotate
-	res = keybase1.EncryptedStellarSecretBundle{
+	res = keybase1.EncryptedStellarBundle{
 		V:   1,
 		E:   secbox,
 		N:   nonce,
 		Gen: pukGen,
 	}
 
-	// Msgpack (inner) + b64
+	// Msgpack (outer) + b64
 	cipherpack, err := libkb.MsgpackEncode(res)
 	if err != nil {
 		return res, resB64, err
@@ -74,21 +100,33 @@ func Encrypt(bundle keybase1.StellarSecretBundleVersioned, pukGen keybase1.PerUs
 	return res, resB64, nil
 }
 
+type DecodeResult struct {
+	Enc     keybase1.EncryptedStellarBundle
+	EncHash keybase1.Hash
+}
+
 // Decode decodes but does not decrypt the bundle.
-// Returns `res` which is need to decrypt and `res.Gen` specifies the decryption PUK.
-func Decode(encryptedBundleB64 string) (res keybase1.EncryptedStellarSecretBundle, err error) {
+// Returns `res` which is needed to decrypt and `res.Gen` specifies the decryption PUK.
+func Decode(encryptedBundleB64 string) (res DecodeResult, err error) {
 	cipherpack, err := base64.StdEncoding.DecodeString(encryptedBundleB64)
 	if err != nil {
 		return res, err
 	}
-	err = libkb.MsgpackDecode(&res, cipherpack)
-	return res, err
+	encHash := sha256.Sum256(cipherpack)
+	res.EncHash = encHash[:]
+	err = libkb.MsgpackDecode(&res.Enc, cipherpack)
+	if err != nil {
+		return res, fmt.Errorf("error unpacking encrypted bundle: %v", err)
+	}
+	return res, nil
 }
 
 // Unbox decrypts the stellar key bundle.
-func Unbox(encryptedBundle keybase1.EncryptedStellarSecretBundle,
-	puk libkb.PerUserKeySeed) (res keybase1.StellarSecretBundle, version keybase1.StellarSecretBundleVersion, err error) {
-	versioned, err := Decrypt(encryptedBundle, puk)
+// And decodes and verifies the visible bundle.
+// Does not check the prev hash.
+func Unbox(decodeRes DecodeResult, visibleBundleB64 string,
+	puk libkb.PerUserKeySeed) (res keybase1.StellarBundle, version keybase1.StellarBundleVersion, err error) {
+	versioned, err := Decrypt(decodeRes.Enc, puk)
 	if err != nil {
 		return res, version, err
 	}
@@ -97,14 +135,31 @@ func Unbox(encryptedBundle keybase1.EncryptedStellarSecretBundle,
 		return res, version, err
 	}
 	switch version {
-	case keybase1.StellarSecretBundleVersion_V1:
-		v1 := versioned.V1()
-		res = keybase1.StellarSecretBundle{
-			Revision: v1.Revision,
-			Accounts: v1.Accounts,
+	case keybase1.StellarBundleVersion_V1:
+		visiblePack, err := base64.StdEncoding.DecodeString(visibleBundleB64)
+		if err != nil {
+			return res, version, err
+		}
+		visibleHash := sha256.Sum256(visiblePack)
+		secretV1 := versioned.V1()
+		if !hmac.Equal(visibleHash[:], secretV1.VisibleHash) {
+			return res, version, errors.New("corrupted bundle: visible hash mismatch")
+		}
+		var visibleV1 keybase1.StellarBundleVisibleV1
+		err = libkb.MsgpackDecode(&visibleV1, visiblePack)
+		if err != nil {
+			return res, version, fmt.Errorf("error unpacking visible bundle: %v", err)
+		}
+		res, err = merge(secretV1, visibleV1)
+		if err != nil {
+			return res, version, err
 		}
 	default:
 		return res, version, fmt.Errorf("unsupported stellar secret bundle version: %v", version)
+	}
+	res.OwnHash = decodeRes.EncHash
+	if len(res.OwnHash) == 0 {
+		return res, version, fmt.Errorf("stellar bundle missing own hash")
 	}
 	err = res.CheckInvariants()
 	return res, version, err
@@ -112,8 +167,8 @@ func Unbox(encryptedBundle keybase1.EncryptedStellarSecretBundle,
 
 // Decrypt decrypts the stellar key bundle.
 // Does not check invariants.
-func Decrypt(encBundle keybase1.EncryptedStellarSecretBundle,
-	puk libkb.PerUserKeySeed) (res keybase1.StellarSecretBundleVersioned, err error) {
+func Decrypt(encBundle keybase1.EncryptedStellarBundle,
+	puk libkb.PerUserKeySeed) (res keybase1.StellarBundleSecretVersioned, err error) {
 	// Derive key
 	symmetricKey, err := puk.DeriveSymmetricKey(libkb.DeriveReasonPUKStellarBundle)
 	if err != nil {
@@ -134,4 +189,45 @@ func Decrypt(encBundle keybase1.EncryptedStellarSecretBundle,
 	// Msgpack (inner)
 	err = libkb.MsgpackDecode(&res, clearpack)
 	return res, err
+}
+
+func accountsSplit(accounts []keybase1.StellarEntry) (vis []keybase1.StellarVisibleEntry, sec []keybase1.StellarSecretEntry) {
+	for _, acc := range accounts {
+		vis = append(vis, keybase1.StellarVisibleEntry{
+			AccountID: acc.AccountID,
+			Mode:      acc.Mode,
+			IsPrimary: acc.IsPrimary,
+		})
+		sec = append(sec, keybase1.StellarSecretEntry{
+			AccountID: acc.AccountID,
+			Signers:   acc.Signers,
+			Name:      acc.Name,
+		})
+	}
+	return vis, sec
+}
+
+func merge(secret keybase1.StellarBundleSecretV1, visible keybase1.StellarBundleVisibleV1) (res keybase1.StellarBundle, err error) {
+	if len(secret.Accounts) != len(visible.Accounts) {
+		return res, fmt.Errorf("corrupted bundle: secret and visible have different counts")
+	}
+	var accounts []keybase1.StellarEntry
+	for i, sec := range secret.Accounts {
+		vis := visible.Accounts[i]
+		if sec.AccountID != vis.AccountID {
+			return res, fmt.Errorf("corrupted bundle: mismatched account ID")
+		}
+		accounts = append(accounts, keybase1.StellarEntry{
+			AccountID: vis.AccountID,
+			Mode:      vis.Mode,
+			IsPrimary: vis.IsPrimary,
+			Signers:   sec.Signers,
+			Name:      sec.Name,
+		})
+	}
+	return keybase1.StellarBundle{
+		Revision: visible.Revision,
+		Prev:     visible.Prev,
+		Accounts: accounts,
+	}, nil
 }

--- a/go/stellar/bundle/bundle_test.go
+++ b/go/stellar/bundle/bundle_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const v1 = keybase1.StellarSecretBundleVersion_V1
+const v1 = keybase1.StellarBundleVersion_V1
 
 type canned struct {
 	pukSeedB64 string
 	pukGen     int
-	outerB64   string
+	encB64     string
+	visB64     string
 }
 
 func (c *canned) puk(t *testing.T) (puk libkb.PerUserKeySeed) {
@@ -30,10 +31,12 @@ func (c *canned) gen() keybase1.PerUserKeyGeneration {
 }
 
 var cans = []canned{
-	{"sTwIOJ9nGIW1H+ruwX1yXwomu72JmmhMbORjhzEA1Is=", 3, "hKFlxNFm/UeXfI1g5p97qljKSb/slFsmAPgImHN74OlxgTseWKJ36sbREgWlqISAM2yvzR1d/2MqpfO9+6hvi3r1gaO1exEgBCMUddrpI+oFwuPLHqATa6Q5y0c/scfRcLJdUf+NHD+7QubB0Sb3fg9Ln6k4BLz3aUxxUZaoEnOF5JKfEd30M0Xcb/qC0GHwKzC2vYaajyBq7NTO46UJDji3eO+y61cHLQ56Ui4qc64P6HO/H78NFKHMijnxPtFZnBO/SitxVNRu7aWsTc0SEs6SM/zCsqNnZW4DoW7EGP+i1y3+JhzofplQXDzXGzs0aDC6zFkuU6F2AQ=="},
-	{"dO/t7WzeXmuQF+8vitbxrTZZcLasJDLiWre0j9E0WYY=", 3, "hKFlxNEGzWSdEAoPP0VUOFiGi+F4knwYPYiFBeQmZzdUaPOJ5j0F1hMxtPx0MV/6WOLWEBNs8MNIH7owuMyQMf6oVH2P8S8+r5dUXBrfoC37BYd/zoA/AheN2LGFwLNCOU4HZFtaUwSxqQNdkM/MRt9PvxPTWz+ivZwoV1zMj+f2Nx8+t/2FYBDLCGLui4g16cExl3PH5P+w9VQa/QjWUFHTBSr1fInudKTjxfcm2gN6Nsb6msook1VZwrfOAgAgsc889WK6com1WMsFFCvG12gLdzvuJqNnZW4DoW7EGBEEUn+mRL1bPTqf47dZiHspRiusRLv3Z6F2AQ=="},
+	{"BGYPk8x7VXMRvHzfaceTUks9W9Vx91BHJC5ukiI0xE8=", 3, "hKFlxORQo+AglN4EmjCZ7/0c/Lg/OMh0QOjkr86fMnYGFAL5yQVlQKb4KEzKwDQOkVY1nWnMCLqKY4z36KtdJ2Es09ae4QAluWLHbHYruAdzZjyCCR4yc/sF9XLahdHeqqivuKGjxfLLV+Al8ZXlcbZ+j+++E8E/szPyK4FzUrH4VK+RFWhNFDd5fl1r5jt7BDzzkfkZRTFxeaUlHgl8tB3Ks3uyrs6wsRA9H4QV3jYNPO4xDZ3YtrRbpTFuglui38B8z87sIkubNhy1XKH/kIGd7j62fGO5TGG7QHC0SwJz3OWAY2DlIhajZ2VuA6FuxBgkiHiy6QrIxBfjIiIV/CVXZPn/3uvEM8uhdgE=", "g6hhY2NvdW50c5GDqWFjY291bnRJRNk4R0RHUlVOTlRURUhGU0dHTk5FTklGQ1hMSEk1RkdDUk5CNTU0SEhZR0RQQlY1RDNPQ0taQlNaTzKpaXNQcmltYXJ5w6Rtb2RlAKRwcmV2wKhyZXZpc2lvbgE="},
+	{"B4r8s6QrEfgO/gJT5k2+x3fykfLQMZWJJVUakZmwsm4=", 3, "hKFlxOSL8f9p79FDdEs47rxZnwKfg+94pzF6GHFZpM+6z0n8PzNGg3cBeM+hpPlzhJoWBhTg1TKIHZ3WWK+91tTYvpA2xkrWXUZpzvQdqqsBGpTPAnb0O7Ob4jKrt2brjewdoJn7BxH6BmrlTau9tmtQj05Yb1VEEYMx35PrcSK3+bw4tQUhhRezr7wMixR0bdXwqpxdx7Yz9Ovupf90h7INw2CT+drWAFB1zTqLul1PVvwQsddj85qC2tuSdUCakbZ/gY03CHNpVh1a1W65tJxkoaXg2DuiIUcrIe+SeHXIlsNU5fIF2YyjZ2VuA6FuxBiUZpnIvcrLcWe34kDGfpQYVWEvZrEClvKhdgE=", "g6hhY2NvdW50c5GDqWFjY291bnRJRNk4R0FaN1VJT0xSQ1dYWFBHQkEzSjRQM1dDNjZHUlNWSVhQWERDRktLVDcyNlRWT1JNUjU3UU9QQUypaXNQcmltYXJ5w6Rtb2RlAKRwcmV2wKhyZXZpc2lvbgE="},
 	// this one has two primary accounts.
-	{"q/kPfnlbgK312LrI9xLtHPxXw66a4apEz6mgdM3J4WY=", 3, "hKFlxQF0Gopd0H+DTbHDr49361EXfyDWTVRfc1AzSwlP0DPUtOjbX0hedU9OyFAYSmr82FpTl8O8m+bKgk9GngT7Dm51pudCpuxANQ7LoOI5hlHJXWeDimS2Q/UzHt7nZxztsE9++RR5vE4tnsdSH0IbC8Br88OgNp+wIE7WzTehVCHyvU7QHmH7nbZTT8S78FMKO9MVRcpXUKA00fx35yLKcJ5XaXhS2sv+bVh4K4LL/iY1wdPyUQMhqQhstM+NZMBP8JzkSpYILg5bKF2u5Tmo01HA6LqbE/Jezw/iQ5I/rJ/sXX5ctxjKoH1IHeT7ObtuTtAopEk3XJsN8gL0sWAxc/IFAmHKMYPsMPq3hh3cAhwTwYxkdqRJGFk1l9X7ErhbOkQmLvjkLZwhzNPOGjf5TUbJLd4Wk0hQx+BOKegL299LHvIzBYFpMxVdL21IN+zDze56D7pwyXzBB1iHur+qGMthtepI9oHqEF66ToRQCvqMI/7bVl1Vo2dlbgOhbsQYrBSyc5ycfisWyYWdqMFKwahbYuwH7rbXoXYB"},
+	{"KHUq4YZME7s30g/R+cQkwONToYIoZxgDriV0C3Vn+Po=", 3, "hKFlxQF2oTmeYwShzWTA0m54gdPPdM77ZYpaWm7Y7I9NzDKSapG6AutL0Vc2620McAFo1KuK0IjEtX0xh3bfY0yBPcUjQSuX7B9nNlvm25NcNEUYY+s7vlcOvNcsolCsPzT3jgXcs9qkmnlJWqGFHvqmuxAfVjirSa1Tx7SpLdD1lS8T5kCN9yX8lxNwS1sQHj4XZ1s798v8Wklh5bIVlvqEuCWF3o84+KXAosrx4fu/pPO7TsvcPusKxe3MeVmZ/2cftZCufK3RkiBMKliF/6tLxnLtwdqi0KBpuhh9tj1jlWNFDIcrP2gC/faz9JZ6oh4Ve+lfwuyVcfOcWU7X3u6T+KAplLj0HwEWlANMoXXKYIa/IwFlAlxCWa4zkQHj7H6ymEwu5gI/jV4r4m9Z2b6/WEmg+DmIDiB0zSS3cvGZs0je6hURAwaoUIhSOXVEwtQ17k4U++iJIMxSOf+Ft/k3yP8X/ceJeW+zv9b2GSoCzi7aktnG/BVrcpmjZ2VuA6FuxBiGG3oFPJdO64/uvd1xb087GH0RIR2ZPGChdgE=", "g6hhY2NvdW50c5KDqWFjY291bnRJRNk4R0NRTDZHSE9NNllaQUlGUUE3T0VCS1JLWlFPU0NYUzVNV05NU1JXRFpZTFBMQ1pXR0hSQ1dLVjSpaXNQcmltYXJ5w6Rtb2RlAIOpYWNjb3VudElE2ThHQ1VIRUVCQ0JMSE9ZTVBaUEpWNFBMUkVSUlJRTFg0Q1dERkxUT0k0U0xERUlJVEZQRkRRV0xOWalpc1ByaW1hcnnDpG1vZGUApHByZXbAqHJldmlzaW9uAQ=="},
+	// this one has the accounts in different orders on the inside and outside
+	{"jLb/t4BwNkBOTnAyLUeHWkAxUQRG1Umnn50xNMlZVeI=", 3, "hKFlxQF2A+vdA4GJqi6u8Pvu/uhESSlauGGWFymRPEuCR3fKXl6Ms0X3kyw9mVAGzWXNOlht/h5qtf5WcyZYrV7PXK0yPcgyay3EnbzcSdPdKJwV9Srplv5IjlFQATYVVi9QDhNR+caPdh/KpG3sWQ6TK8dIKHEosgze6C4vk5MMqSYD4RHAaPzx3tk/QdrwMyebGCuOGa7u8WLl7bwWH2BwXc+AcqtlBN76FMv3BOEn0xzumeSeAwW9QuNAWvi30Rd+KTAnYCeUpOnjH0mEGBtcvxicNVknT/GOkgTU7Bcws0rLG8wCL6ky288SnKtcxOw7jQgyciL/AZyIEcPE/Z+RXjcKfgcHo+PWmaHmPXLGQiFbmCzdP2N+1m0lW0A8Ye3CYaW4FkVbFe7HggRty4k3xrbbR8GjE1A9AvHbyoa1vAjTHLm/QnqVslXNp3raYpAuYuANuwUUCELfUrug5647VokzTepKiEhQs0FGo5L6SpfAiPkmM3DOp1OjZ2VuA6FuxBjxuftzcissPIfzECF4AZ3kMnkLnBgQv9ahdgE=", "g6hhY2NvdW50c5KDqWFjY291bnRJRNk4R0NRTDZHSE9NNllaQUlGUUE3T0VCS1JLWlFPU0NYUzVNV05NU1JXRFpZTFBMQ1pXR0hSQ1dLVjSpaXNQcmltYXJ5wqRtb2RlAIOpYWNjb3VudElE2ThHQ1VIRUVCQ0JMSE9ZTVBaUEpWNFBMUkVSUlJRTFg0Q1dERkxUT0k0U0xERUlJVEZQRkRRV0xOWalpc1ByaW1hcnnCpG1vZGUApHByZXbAqHJldmlzaW9uAQ=="},
 }
 
 func TestBundleRoundtrip(t *testing.T) {
@@ -42,60 +45,130 @@ func TestBundleRoundtrip(t *testing.T) {
 	t.Logf("puk seed (hex): %v", base64.StdEncoding.EncodeToString(puk[:]))
 	t.Logf("puk gen: %v", pukGen)
 
-	enc, resB64, err := Box(bundle, pukGen, puk)
+	res, err := Box(bundle, pukGen, puk)
 	require.NoError(t, err)
-	t.Logf("outer b64: %v", resB64)
-	require.True(t, len(resB64) > 100)
-	require.Equal(t, 1, enc.V)
-	require.True(t, len(enc.E) > 100)
-	require.Equal(t, pukGen, enc.Gen)
+	t.Logf("outer enc b64: %v", res.EncB64)
+	t.Logf("outer vis b64: %v", res.VisB64)
+	t.Logf("enc.N b64: %v", base64.StdEncoding.EncodeToString(res.Enc.N[:]))
+	t.Logf("enc.E b64: %v", base64.StdEncoding.EncodeToString(res.Enc.E))
+	require.Equal(t, v1, res.FormatVersion)
+	require.True(t, len(res.EncB64) > 100)
+	require.Equal(t, 1, res.Enc.V)
+	require.True(t, len(res.Enc.E) > 100)
+	require.Equal(t, pukGen, res.Enc.Gen)
 
-	enc2, err := Decode(resB64)
+	dec2, err := Decode(res.EncB64)
 	require.NoError(t, err)
-	require.Equal(t, enc, enc2)
+	require.Equal(t, res.Enc, dec2.Enc)
 
-	bundle2, v, err := Unbox(enc2, puk)
+	bundle2, v, err := Unbox(dec2, res.VisB64, puk)
 	require.NoError(t, err)
-	require.Equal(t, bundle, bundle2)
+	bundle2ForComparison := bundle2.DeepCopy()
+	bundle2ForComparison.OwnHash = nil
+	require.Equal(t, bundle, bundle2ForComparison)
 	require.Equal(t, v1, v)
+	require.Nil(t, bundle2.Prev)
 }
 
-func TestBundleRoundtripCorruption(t *testing.T) {
-	bundle := sampleBundle()
-	puk, pukGen := mkPuk(t, 3)
+func TestBundlePrevs(t *testing.T) {
+	bundle1src := sampleBundle()
+	puk1, pukGen1 := mkPuk(t, 1)
+	puk2, pukGen2 := mkPuk(t, 2)
 
-	_, resB64, err := Box(bundle, pukGen, puk)
+	res1, err := Box(bundle1src, pukGen1, puk1)
+	require.NoError(t, err)
+
+	dec1, err := Decode(res1.EncB64)
+	require.NoError(t, err)
+	require.Equal(t, pukGen1, dec1.Enc.Gen)
+	bundle1, _, err := Unbox(dec1, res1.VisB64, puk1)
+	require.NoError(t, err)
+	require.Nil(t, bundle1.Prev, "first box should have no prev")
+
+	bundle2src := bundle1.DeepCopy()
+	bundle2src.Prev = bundle1.OwnHash
+	bundle2src.Accounts[0].Name = "squirrel fund"
+	res2, err := Box(bundle2src, pukGen2, puk2)
+	require.NoError(t, err)
+
+	dec2, err := Decode(res2.EncB64)
+	require.NoError(t, err)
+	bundle2, _, err := Unbox(dec2, res2.VisB64, puk2)
+	require.NoError(t, err)
+	require.Equal(t, "squirrel fund", bundle2.Accounts[0].Name, "account should be renamed")
+	require.Equal(t, bundle1.OwnHash, bundle2.Prev, "bundle 2 should prev bundle 1")
+	require.NotNil(t, bundle2.Prev)
+
+	bundle3src := bundle1.DeepCopy()
+	bundle3src.Prev = bundle2.OwnHash
+	bundle3src.Accounts[0].IsPrimary = false
+	res3, err := Box(bundle3src, pukGen2, puk2)
+	require.NoError(t, err)
+
+	enc3, err := Decode(res3.EncB64)
+	require.NoError(t, err)
+	bundle3, _, err := Unbox(enc3, res3.VisB64, puk2)
+	require.NoError(t, err)
+	require.False(t, bundle3.Accounts[0].IsPrimary, "account should not be primary")
+	require.Equal(t, bundle2.OwnHash, bundle3.Prev, "bundle 3 should prev bundle 2")
+}
+
+func TestBundleRoundtripCorruptionEnc(t *testing.T) {
+	bundle := sampleBundle()
+	puk, pukGen := mkPuk(t, 4)
+
+	res, err := Box(bundle, pukGen, puk)
 	require.NoError(t, err)
 	replaceWith := "a"
-	if resB64[85] == 'a' {
+	if res.EncB64[85] == 'a' {
 		replaceWith = "b"
 	}
-	resB64 = resB64[:85] + replaceWith + resB64[86:]
+	res.EncB64 = res.EncB64[:85] + replaceWith + res.EncB64[86:]
 
-	enc2, err := Decode(resB64)
+	dec2, err := Decode(res.EncB64)
 	require.NoError(t, err)
 
-	_, _, err = Unbox(enc2, puk)
+	_, _, err = Unbox(dec2, res.VisB64, puk)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "secret box open failed")
 }
 
+func TestBundleRoundtripCorruptionVis(t *testing.T) {
+	bundle := sampleBundle()
+	puk, pukGen := mkPuk(t, 3)
+
+	res, err := Box(bundle, pukGen, puk)
+	require.NoError(t, err)
+	replaceWith := "a"
+	if res.VisB64[85] == 'a' {
+		replaceWith = "b"
+	}
+	res.VisB64 = res.VisB64[:85] + replaceWith + res.VisB64[86:]
+
+	dec2, err := Decode(res.EncB64)
+	require.NoError(t, err)
+
+	_, _, err = Unbox(dec2, res.VisB64, puk)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "hash mismatch")
+}
+
 func TestCanned(t *testing.T) {
 	c := cans[0]
-	enc, err := Decode(c.outerB64)
+	dec, err := Decode(c.encB64)
 	require.NoError(t, err)
-	require.Equal(t, 1, enc.V)
-	require.Equal(t, c.gen(), enc.Gen)
-	require.Equal(t, "/6LXLf4mHOh+mVBcPNcbOzRoMLrMWS5T", base64.StdEncoding.EncodeToString(enc.N[:]))
-	b64EncE := "Zv1Hl3yNYOafe6pYykm/7JRbJgD4CJhze+DpcYE7Hliid+rG0RIFpaiEgDNsr80dXf9jKqXzvfuob4t69YGjtXsRIAQjFHXa6SPqBcLjyx6gE2ukOctHP7HH0XCyXVH/jRw/u0LmwdEm934PS5+pOAS892lMcVGWqBJzheSSnxHd9DNF3G/6gtBh8Cswtr2Gmo8gauzUzuOlCQ44t3jvsutXBy0OelIuKnOuD+hzvx+/DRShzIo58T7RWZwTv0orcVTUbu2lrE3NEhLOkjP8wrI="
-	require.Equal(t, b64EncE, base64.StdEncoding.EncodeToString(enc.E))
+	require.Equal(t, 1, dec.Enc.V)
+	require.Equal(t, c.gen(), dec.Enc.Gen)
+	require.Equal(t, "JIh4sukKyMQX4yIiFfwlV2T5/97rxDPL", base64.StdEncoding.EncodeToString(dec.Enc.N[:]))
+	b64EncE := "UKPgIJTeBJowme/9HPy4PzjIdEDo5K/OnzJ2BhQC+ckFZUCm+ChMysA0DpFWNZ1pzAi6imOM9+irXSdhLNPWnuEAJblix2x2K7gHc2Y8ggkeMnP7BfVy2oXR3qqor7iho8Xyy1fgJfGV5XG2fo/vvhPBP7Mz8iuBc1Kx+FSvkRVoTRQ3eX5da+Y7ewQ885H5GUUxcXmlJR4JfLQdyrN7sq7OsLEQPR+EFd42DTzuMQ2d2La0W6UxboJbot/AfM/O7CJLmzYctVyh/5CBne4+tnxjuUxhu0BwtEsCc9zlgGNg5SIW"
+	require.Equal(t, b64EncE, base64.StdEncoding.EncodeToString(dec.Enc.E))
 
-	bundle, v, err := Unbox(enc, c.puk(t))
+	bundle, v, err := Unbox(dec, c.visB64, c.puk(t))
 	require.NoError(t, err)
 	require.Equal(t, v1, v)
 	require.Equal(t, keybase1.StellarRevision(1), bundle.Revision)
 	require.Len(t, bundle.Accounts, 1)
-	refAccount := keybase1.StellarSecretEntry{
+	refAccount := keybase1.StellarEntry{
 		AccountID: "GDGRUNNTTEHFSGGNNENIFCXLHI5FGCRNB554HHYGDPBV5D3OCKZBSZO2",
 		Mode:      keybase1.StellarAccountMode_USER,
 		Signers:   []keybase1.StellarSecretKey{"SAGWDNEMLK2Z65NXQUGP6UMR4MDYZ3UQSUXLIEZU6KENJXEHEGIS23BT"},
@@ -109,35 +182,52 @@ func TestCannedWrongKey(t *testing.T) {
 	c := cans[1]
 	puk := c.puk(t)
 	puk[3] = byte(8)
-	enc, err := Decode(c.outerB64)
+	dec, err := Decode(c.encB64)
 	require.NoError(t, err)
-	_, _, err = Unbox(enc, puk)
+	_, err = Decrypt(dec.Enc, puk)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "secret box open failed")
+	_, _, err = Unbox(dec, c.visB64, puk)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "secret box open failed")
 }
 
-func TestCannedUnboxInvariantViolation(t *testing.T) {
+func TestCannedUnboxInvariantViolationMultiplePrimary(t *testing.T) {
 	c := cans[2]
-	enc, err := Decode(c.outerB64)
+	dec, err := Decode(c.encB64)
 	require.NoError(t, err)
-	_, _, err = Unbox(enc, c.puk(t))
+	_, err = Decrypt(dec.Enc, c.puk(t))
+	require.NoError(t, err)
+	_, _, err = Unbox(dec, c.visB64, c.puk(t))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "multiple primary accounts")
 }
 
-func TestBoxInvariantViolation(t *testing.T) {
+func TestCannedUnboxInvariantViolationOrderMismatch(t *testing.T) {
+	c := cans[3]
+	dec, err := Decode(c.encB64)
+	require.NoError(t, err)
+	_, err = Decrypt(dec.Enc, c.puk(t))
+	require.NoError(t, err)
+	_, _, err = Unbox(dec, c.visB64, c.puk(t))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mismatched account ID")
+}
+
+func TestBoxInvariantViolationDuplicateAccount(t *testing.T) {
 	bundle := bundleDuplicateAccountIDs()
 	puk, pukGen := mkPuk(t, 3)
 
-	_, _, err := Box(bundle, pukGen, puk)
+	_, err := Box(bundle, pukGen, puk)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "duplicate account ID")
 }
 
-func sampleBundle() keybase1.StellarSecretBundle {
-	return keybase1.StellarSecretBundle{
+func sampleBundle() keybase1.StellarBundle {
+	return keybase1.StellarBundle{
 		Revision: 1,
-		Accounts: []keybase1.StellarSecretEntry{{
+		Prev:     nil,
+		Accounts: []keybase1.StellarEntry{{
 			AccountID: "GDRDPWSPKOEUNYZMWKNEC3WZTEDPT6XYGDWNO4VIASTFFZYS5WII2762",
 			Mode:      keybase1.StellarAccountMode_USER,
 			Signers:   []keybase1.StellarSecretKey{"SDGCPMBQHYAIWM3PQOEKWICDMLVT7REJ24J26QEYJYGB6FJRPTKDULQX"},
@@ -147,10 +237,11 @@ func sampleBundle() keybase1.StellarSecretBundle {
 	}
 }
 
-func bundleDuplicateAccountIDs() keybase1.StellarSecretBundle {
-	return keybase1.StellarSecretBundle{
+func bundleDuplicateAccountIDs() keybase1.StellarBundle {
+	return keybase1.StellarBundle{
 		Revision: 1,
-		Accounts: []keybase1.StellarSecretEntry{{
+		Prev:     nil,
+		Accounts: []keybase1.StellarEntry{{
 			AccountID: "GDRDPWSPKOEUNYZMWKNEC3WZTEDPT6XYGDWNO4VIASTFFZYS5WII2762",
 			Mode:      keybase1.StellarAccountMode_USER,
 			Signers:   []keybase1.StellarSecretKey{"SDGCPMBQHYAIWM3PQOEKWICDMLVT7REJ24J26QEYJYGB6FJRPTKDULQX"},

--- a/protocol/avdl/keybase1/stellar.avdl
+++ b/protocol/avdl/keybase1/stellar.avdl
@@ -6,33 +6,34 @@ protocol stellar {
   @typedef("string") record StellarAccountID {}
   @typedef("string") record StellarSecretKey {}
   @typedef("uint64") @lint("ignore") record StellarRevision {}
+  @typedef("bytes")  record Hash {}
 
   // The same format as in chat1.EncryptedData (and KBFS, Git)
-  record EncryptedStellarSecretBundle {
+  record EncryptedStellarBundle {
     int   v;                  // version = 1
-    bytes e;                  // encrypted msgpacked StellarSecretBundleVersioned (output of secretbox)
+    bytes e;                  // encrypted msgpacked StellarBundleSecretVersioned (output of secretbox)
     BoxNonce n;               // nonce
     PerUserKeyGeneration gen; // PUK generation that was used
   }
 
-  enum StellarSecretBundleVersion {
+  enum StellarBundleVersion {
     V1_1
   }
 
-  variant StellarSecretBundleVersioned switch (StellarSecretBundleVersion version) {
-    case V1 : StellarSecretBundleV1;
+  variant StellarBundleSecretVersioned switch (StellarBundleVersion version) {
+    case V1 : StellarBundleSecretV1;
   }
 
-  record StellarSecretBundleV1 {
+  // There is no versioned form of BundleVisible because it is versioned
+  // by BundleSecret's version field.
+  record StellarBundleVisibleV1 {
     StellarRevision revision;
-    array<StellarSecretEntry> accounts;
+    Hash prev; // SHA256 of previous msgpack(EncryptedStellarBundle)
+    array<StellarVisibleEntry> accounts;
   }
 
-  // Unversioned struct for local use only.
-  record StellarSecretBundle {
-    StellarRevision revision;
-    // AccountID and name should be unique.
-    // At most one account should be primary.
+  record StellarBundleSecretV1 {
+    Hash visibleHash; // SHA256 of msgpack(StellarBundleVisibleV1)
     array<StellarSecretEntry> accounts;
   }
 
@@ -40,14 +41,38 @@ protocol stellar {
     USER_0 // Each of the user's devices has access to the keys
   }
 
-  // One stellar account.
-  // In both StellarSecretBundle{Versioned}, so may need to split
-  // when making protocol changes.
-  record StellarSecretEntry {
+  // Server-visible attributes of an account.
+  record StellarVisibleEntry {
     StellarAccountID accountID;
     StellarAccountMode mode;
-    array<StellarSecretKey> signers;
     boolean isPrimary; // whether this is the primary account (public)
+  }
+
+  // Secret attributes of an account.
+  record StellarSecretEntry {
+    StellarAccountID accountID;
+    array<StellarSecretKey> signers;
+    string name;
+  }
+
+  // Unversioned struct for local use only.
+  record StellarBundle {
+    StellarRevision revision;
+    Hash prev;
+    // SHA256 of this msgpack(EncryptedStellarBundle)
+    // Not serialized. Only set if this bundle was decrypted.
+    Hash ownHash;
+    // AccountID and name should be unique.
+    // At most one account should be primary.
+    array<StellarEntry> accounts;
+  }
+
+  // Combined stellar entry for local use only.
+  record StellarEntry {
+    StellarAccountID accountID;
+    StellarAccountMode mode;
+    boolean isPrimary; // whether this is the primary account
+    array<StellarSecretKey> signers;
     string name;
   }
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1536,7 +1536,7 @@ export const stellarStellarAccountMode = {
   user: 0,
 }
 
-export const stellarStellarSecretBundleVersion = {
+export const stellarStellarBundleVersion = {
   v1: 1,
 }
 
@@ -2209,7 +2209,7 @@ export type EncryptedBytes32 = any
 
 export type EncryptedGitMetadata = $ReadOnly<{v: Int, e: Bytes, n: BoxNonce, gen: PerTeamKeyGeneration}>
 
-export type EncryptedStellarSecretBundle = $ReadOnly<{v: Int, e: Bytes, n: BoxNonce, gen: PerUserKeyGeneration}>
+export type EncryptedStellarBundle = $ReadOnly<{v: Int, e: Bytes, n: BoxNonce, gen: PerUserKeyGeneration}>
 
 export type ErrorNum = Int
 
@@ -2419,6 +2419,8 @@ export type GregorUIPushOutOfBandMessagesRpcParam = $ReadOnly<{oobm?: ?Array<Gre
 export type GregorUIPushStateRpcParam = $ReadOnly<{state: Gregor1.State, reason: PushReason, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type HasServerKeysRes = $ReadOnly<{hasServerKeys: Boolean}>
+
+export type Hash = Bytes
 
 export type HashMeta = Bytes
 
@@ -3555,19 +3557,25 @@ export type StellarAccountID = String
 
 export type StellarAccountMode = 0 // USER_0
 
+export type StellarBundle = $ReadOnly<{revision: StellarRevision, prev: Hash, ownHash: Hash, accounts?: ?Array<StellarEntry>}>
+
+export type StellarBundleSecretV1 = $ReadOnly<{visibleHash: Hash, accounts?: ?Array<StellarSecretEntry>}>
+
+export type StellarBundleSecretVersioned = {version: 1, v1: ?StellarBundleSecretV1}
+
+export type StellarBundleVersion = 1 // V1_1
+
+export type StellarBundleVisibleV1 = $ReadOnly<{revision: StellarRevision, prev: Hash, accounts?: ?Array<StellarVisibleEntry>}>
+
+export type StellarEntry = $ReadOnly<{accountID: StellarAccountID, mode: StellarAccountMode, isPrimary: Boolean, signers?: ?Array<StellarSecretKey>, name: String}>
+
 export type StellarRevision = Uint64
 
-export type StellarSecretBundle = $ReadOnly<{revision: StellarRevision, accounts?: ?Array<StellarSecretEntry>}>
-
-export type StellarSecretBundleV1 = $ReadOnly<{revision: StellarRevision, accounts?: ?Array<StellarSecretEntry>}>
-
-export type StellarSecretBundleVersion = 1 // V1_1
-
-export type StellarSecretBundleVersioned = {version: 1, v1: ?StellarSecretBundleV1}
-
-export type StellarSecretEntry = $ReadOnly<{accountID: StellarAccountID, mode: StellarAccountMode, signers?: ?Array<StellarSecretKey>, isPrimary: Boolean, name: String}>
+export type StellarSecretEntry = $ReadOnly<{accountID: StellarAccountID, signers?: ?Array<StellarSecretKey>, name: String}>
 
 export type StellarSecretKey = String
+
+export type StellarVisibleEntry = $ReadOnly<{accountID: StellarAccountID, mode: StellarAccountMode, isPrimary: Boolean}>
 
 export type Stream = $ReadOnly<{fd: Int}>
 

--- a/protocol/json/keybase1/stellar.json
+++ b/protocol/json/keybase1/stellar.json
@@ -28,7 +28,13 @@
     },
     {
       "type": "record",
-      "name": "EncryptedStellarSecretBundle",
+      "name": "Hash",
+      "fields": [],
+      "typedef": "bytes"
+    },
+    {
+      "type": "record",
+      "name": "EncryptedStellarBundle",
       "fields": [
         {
           "type": "int",
@@ -50,16 +56,16 @@
     },
     {
       "type": "enum",
-      "name": "StellarSecretBundleVersion",
+      "name": "StellarBundleVersion",
       "symbols": [
         "V1_1"
       ]
     },
     {
       "type": "variant",
-      "name": "StellarSecretBundleVersioned",
+      "name": "StellarBundleSecretVersioned",
       "switch": {
-        "type": "StellarSecretBundleVersion",
+        "type": "StellarBundleVersion",
         "name": "version"
       },
       "cases": [
@@ -68,22 +74,26 @@
             "name": "V1",
             "def": false
           },
-          "body": "StellarSecretBundleV1"
+          "body": "StellarBundleSecretV1"
         }
       ]
     },
     {
       "type": "record",
-      "name": "StellarSecretBundleV1",
+      "name": "StellarBundleVisibleV1",
       "fields": [
         {
           "type": "StellarRevision",
           "name": "revision"
         },
         {
+          "type": "Hash",
+          "name": "prev"
+        },
+        {
           "type": {
             "type": "array",
-            "items": "StellarSecretEntry"
+            "items": "StellarVisibleEntry"
           },
           "name": "accounts"
         }
@@ -91,11 +101,11 @@
     },
     {
       "type": "record",
-      "name": "StellarSecretBundle",
+      "name": "StellarBundleSecretV1",
       "fields": [
         {
-          "type": "StellarRevision",
-          "name": "revision"
+          "type": "Hash",
+          "name": "visibleHash"
         },
         {
           "type": {
@@ -115,7 +125,7 @@
     },
     {
       "type": "record",
-      "name": "StellarSecretEntry",
+      "name": "StellarVisibleEntry",
       "fields": [
         {
           "type": "StellarAccountID",
@@ -126,6 +136,20 @@
           "name": "mode"
         },
         {
+          "type": "boolean",
+          "name": "isPrimary"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "StellarSecretEntry",
+      "fields": [
+        {
+          "type": "StellarAccountID",
+          "name": "accountID"
+        },
+        {
           "type": {
             "type": "array",
             "items": "StellarSecretKey"
@@ -133,8 +157,58 @@
           "name": "signers"
         },
         {
+          "type": "string",
+          "name": "name"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "StellarBundle",
+      "fields": [
+        {
+          "type": "StellarRevision",
+          "name": "revision"
+        },
+        {
+          "type": "Hash",
+          "name": "prev"
+        },
+        {
+          "type": "Hash",
+          "name": "ownHash"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "StellarEntry"
+          },
+          "name": "accounts"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "StellarEntry",
+      "fields": [
+        {
+          "type": "StellarAccountID",
+          "name": "accountID"
+        },
+        {
+          "type": "StellarAccountMode",
+          "name": "mode"
+        },
+        {
           "type": "boolean",
           "name": "isPrimary"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "StellarSecretKey"
+          },
+          "name": "signers"
         },
         {
           "type": "string",

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1536,7 +1536,7 @@ export const stellarStellarAccountMode = {
   user: 0,
 }
 
-export const stellarStellarSecretBundleVersion = {
+export const stellarStellarBundleVersion = {
   v1: 1,
 }
 
@@ -2209,7 +2209,7 @@ export type EncryptedBytes32 = any
 
 export type EncryptedGitMetadata = $ReadOnly<{v: Int, e: Bytes, n: BoxNonce, gen: PerTeamKeyGeneration}>
 
-export type EncryptedStellarSecretBundle = $ReadOnly<{v: Int, e: Bytes, n: BoxNonce, gen: PerUserKeyGeneration}>
+export type EncryptedStellarBundle = $ReadOnly<{v: Int, e: Bytes, n: BoxNonce, gen: PerUserKeyGeneration}>
 
 export type ErrorNum = Int
 
@@ -2419,6 +2419,8 @@ export type GregorUIPushOutOfBandMessagesRpcParam = $ReadOnly<{oobm?: ?Array<Gre
 export type GregorUIPushStateRpcParam = $ReadOnly<{state: Gregor1.State, reason: PushReason, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type HasServerKeysRes = $ReadOnly<{hasServerKeys: Boolean}>
+
+export type Hash = Bytes
 
 export type HashMeta = Bytes
 
@@ -3555,19 +3557,25 @@ export type StellarAccountID = String
 
 export type StellarAccountMode = 0 // USER_0
 
+export type StellarBundle = $ReadOnly<{revision: StellarRevision, prev: Hash, ownHash: Hash, accounts?: ?Array<StellarEntry>}>
+
+export type StellarBundleSecretV1 = $ReadOnly<{visibleHash: Hash, accounts?: ?Array<StellarSecretEntry>}>
+
+export type StellarBundleSecretVersioned = {version: 1, v1: ?StellarBundleSecretV1}
+
+export type StellarBundleVersion = 1 // V1_1
+
+export type StellarBundleVisibleV1 = $ReadOnly<{revision: StellarRevision, prev: Hash, accounts?: ?Array<StellarVisibleEntry>}>
+
+export type StellarEntry = $ReadOnly<{accountID: StellarAccountID, mode: StellarAccountMode, isPrimary: Boolean, signers?: ?Array<StellarSecretKey>, name: String}>
+
 export type StellarRevision = Uint64
 
-export type StellarSecretBundle = $ReadOnly<{revision: StellarRevision, accounts?: ?Array<StellarSecretEntry>}>
-
-export type StellarSecretBundleV1 = $ReadOnly<{revision: StellarRevision, accounts?: ?Array<StellarSecretEntry>}>
-
-export type StellarSecretBundleVersion = 1 // V1_1
-
-export type StellarSecretBundleVersioned = {version: 1, v1: ?StellarSecretBundleV1}
-
-export type StellarSecretEntry = $ReadOnly<{accountID: StellarAccountID, mode: StellarAccountMode, signers?: ?Array<StellarSecretKey>, isPrimary: Boolean, name: String}>
+export type StellarSecretEntry = $ReadOnly<{accountID: StellarAccountID, signers?: ?Array<StellarSecretKey>, name: String}>
 
 export type StellarSecretKey = String
+
+export type StellarVisibleEntry = $ReadOnly<{accountID: StellarAccountID, mode: StellarAccountMode, isPrimary: Boolean}>
 
 export type Stream = $ReadOnly<{fd: Int}>
 


### PR DESCRIPTION
Before this PR, the stellar bundle was a list of accounts encrypted for the user. But the server needs to know what the accounts are, so every time the client posts it would need to tell the server what changed. An ad-hoc protocol for that would be hard to get right. And the risk of desyncing the encrypted form and db representation would be bad.

This PR splits the stellar bundle into an encrypted list with the secrets and a list shared with the server. It will be easy for the client to always post both lists in sync. And the server can read the plaintext to update the db. To ensure the server can't munge the user data, the encrypted package contains the hash of the plaintext package. One additional db column will be needed for `b64(msgpack(StellarBundleVisibleV1))`.
​
For each account some of the info is shared with the server and some is secret:
- AccountID: shared
- IsPrimary: shared
- Mode: shared
- Signer secrets: secret
- Name: secret
​
After this PR and patrick's PR land the bundle records can be moved into stellar1.