### PR TITLE
Show provisioning errors in the GUI

### DIFF
--- a/shared/actions/login.js
+++ b/shared/actions/login.js
@@ -496,11 +496,17 @@ function* loginFlowSaga(usernameOrEmail, passphrase): Generator<any, void, any> 
 
   const loginSagas = kex2Sagas(cancelLogin, EngineRpc.passthroughResponseSaga, passphraseSaga)
 
-  const loginRpcCall = new EngineRpc.EngineRpcCall(loginSagas, RPCTypes.loginLoginRpcChannelMap, 'loginRpc', {
-    clientType: RPCTypes.commonClientType.guiMain,
-    deviceType,
-    usernameOrEmail,
-  })
+  const loginRpcCall = new EngineRpc.EngineRpcCall(
+    loginSagas,
+    RPCTypes.loginLoginRpcChannelMap,
+    'loginRpc',
+    {
+      clientType: RPCTypes.commonClientType.guiMain,
+      deviceType,
+      usernameOrEmail,
+    },
+    true // finished error should cancel
+  )
 
   try {
     const result = yield Saga.call(loginRpcCall.run)

--- a/shared/constants/engine.js
+++ b/shared/constants/engine.js
@@ -98,6 +98,7 @@ class EngineRpcCall {
     this._rpc = rpc
     this._cleanedUp = false
     this._request = request
+    this._finishedErrorShouldCancel = finishedErrorShouldCancel || false
     this._subSagaChannel = Saga.channel(Saga.buffers.expanding(10))
     this._waitingActionCreator = waitingActionCreator
     // $FlowIssue with this


### PR DESCRIPTION
@keybase/react-hackers CC @patrickxb 

A few things going on here.

If you change your system clock back a few hours and then try to provision a new device (as provisionee), the GUI will hang on the QR code display screen and never show you an error.

It won't show you an error because the loginRpcCall saga doesn't complete.

It won't complete because after we receive the finished response to the loginLogin RPC with an error, there are still subSagas active, and the EngineRpcCall waits on all subsagas to finish before returning a result.

I *think* the reason that subSagas are still active is that the service sends an RPC cancellation for them (e.g. displayAndPromptSecret), but node-framed-msgpack-rpc does not know anything about the RPC cancellation message type, so the RPC is still outstanding as far as we're concerned.

There is a "finishedErrorShouldCancel" argument to EngineRpcCall.  It wasn't being used here, but when you do use it here, it fixes the problem and cancels the remaining subsagas when the main call finishes with an error, which it does here.  So this PR fixes the reported bug.

But!  The finishedErrorShouldCancel argument is busted, before this PR.  The constructor takes the argument, but doesn't set `this._finishedErrorShouldCancel` to that argument, and that instance attr is what's actually tested against later (so it's always undefined, before this PR).  The device add RPC was attempting to use this argument -- but not actually using it since it's broken -- so this PR makes a change that will affect the device add RPC too.