### PR TITLE
Add notify teamNameUpdate

### DIFF
--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -833,6 +833,10 @@ func (n *teamNotifyHandler) TeamChangedByName(ctx context.Context, arg keybase1.
 	return nil
 }
 
+func (n *teamNotifyHandler) TeamNameUpdate(ctx context.Context, arg keybase1.TeamNameUpdateArg) error {
+	return nil
+}
+
 func (n *teamNotifyHandler) TeamDeleted(ctx context.Context, teamID keybase1.TeamID) error {
 	return nil
 }

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -314,10 +314,14 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 
 	// Fetch from cache
 	tracer.Stage("cache load")
-	var ret *keybase1.TeamData
-	if !arg.forceFullReload {
-		// Load from cache
-		ret = l.storage.Get(ctx, arg.teamID, arg.public)
+	ret := l.storage.Get(ctx, arg.teamID, arg.public)
+	var cachedName *keybase1.TeamName
+	if ret != nil && !ret.Name.IsNil() {
+		cachedName = &ret.Name
+	}
+	if arg.forceFullReload {
+		// Don't use the cache
+		ret = nil
 	}
 
 	if ret != nil && !ret.Chain.Reader.Eq(arg.me) {
@@ -326,11 +330,6 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		l.G().Log.CWarningf(ctx, "TeamLoader discarding snapshot for wrong user: (%v, %v) != (%v, %v)",
 			arg.me.Uid, arg.me.EldestSeqno, ret.Chain.Reader.Uid, ret.Chain.Reader.EldestSeqno)
 		ret = nil
-	}
-
-	var cachedName *keybase1.TeamName
-	if ret != nil && !ret.Name.IsNil() {
-		cachedName = &ret.Name
 	}
 
 	// Determine whether to repoll merkle.
@@ -576,15 +575,16 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 
 	tracer.Stage("notify")
 	if cachedName != nil && !cachedName.Eq(newName) {
-		chain := TeamSigChainState{inner: ret.Chain}
 		// Send a notification if we used to have the name cached and it has changed at all.
-		changeSet := keybase1.TeamChangeSet{Renamed: true}
-		go l.G().NotifyRouter.HandleTeamChangedByID(context.Background(),
-			chain.GetID(), chain.GetLatestSeqno(), chain.IsImplicit(), changeSet)
-		go l.G().NotifyRouter.HandleTeamChangedByName(context.Background(),
-			cachedName.String(), chain.GetLatestSeqno(), chain.IsImplicit(), changeSet)
-		go l.G().NotifyRouter.HandleTeamChangedByName(context.Background(),
-			newName.String(), chain.GetLatestSeqno(), chain.IsImplicit(), changeSet)
+		chain := TeamSigChainState{inner: ret.Chain}
+		oldName := cachedName.String()
+		go l.G().NotifyRouter.HandleTeamNameUpdate(context.Background(), keybase1.TeamNameUpdateArg{
+			TeamID:       chain.GetID(),
+			TeamName:     newName.String(),
+			OldTeamName:  &oldName,
+			LatestSeqno:  chain.GetLatestSeqno(),
+			ImplicitTeam: chain.IsImplicit(),
+		})
 	}
 
 	// Check request constraints

--- a/protocol/avdl/keybase1/notify_team.avdl
+++ b/protocol/avdl/keybase1/notify_team.avdl
@@ -33,6 +33,14 @@ protocol NotifyTeam {
     TeamChangeSet changes
   ) oneway;
 
+  void teamNameUpdate(
+    TeamID teamID,
+    string teamName,
+    union { null, string} oldTeamName,
+    Seqno latestSeqno,
+    boolean implicitTeam
+  ) oneway;
+
   void teamDeleted(TeamID teamID) oneway;
 
   void teamAbandoned(TeamID teamID) oneway;

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2850,6 +2850,8 @@ export type NotifyTeamTeamDeletedRpcParam = $ReadOnly<{teamID: TeamID, incomingC
 
 export type NotifyTeamTeamExitRpcParam = $ReadOnly<{teamID: TeamID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type NotifyTeamTeamNameUpdateRpcParam = $ReadOnly<{teamID: TeamID, teamName: String, oldTeamName?: ?String, latestSeqno: Seqno, implicitTeam: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type NotifyTrackingTrackingChangedRpcParam = $ReadOnly<{uid: UID, username: String, isTracking: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type NotifyUsersUserChangedRpcParam = $ReadOnly<{uid: UID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -4266,6 +4268,7 @@ export type IncomingCallMapType = {
   'keybase.1.NotifySession.clientOutOfDate'?: (params: $ReadOnly<{upgradeTo: String, upgradeURI: String, upgradeMsg: String}>, response: CommonResponseHandler) => void,
   'keybase.1.NotifyTeam.teamChangedByID'?: (params: $ReadOnly<{teamID: TeamID, latestSeqno: Seqno, implicitTeam: Boolean, changes: TeamChangeSet}>, response: CommonResponseHandler) => void,
   'keybase.1.NotifyTeam.teamChangedByName'?: (params: $ReadOnly<{teamName: String, latestSeqno: Seqno, implicitTeam: Boolean, changes: TeamChangeSet}>, response: CommonResponseHandler) => void,
+  'keybase.1.NotifyTeam.teamNameUpdate'?: (params: $ReadOnly<{teamID: TeamID, teamName: String, oldTeamName?: ?String, latestSeqno: Seqno, implicitTeam: Boolean}>, response: CommonResponseHandler) => void,
   'keybase.1.NotifyTeam.teamDeleted'?: (params: $ReadOnly<{teamID: TeamID}>, response: CommonResponseHandler) => void,
   'keybase.1.NotifyTeam.teamAbandoned'?: (params: $ReadOnly<{teamID: TeamID}>, response: CommonResponseHandler) => void,
   'keybase.1.NotifyTeam.teamExit'?: (params: $ReadOnly<{teamID: TeamID}>, response: CommonResponseHandler) => void,

--- a/protocol/json/keybase1/notify_team.json
+++ b/protocol/json/keybase1/notify_team.json
@@ -75,6 +75,35 @@
       "response": null,
       "oneway": true
     },
+    "teamNameUpdate": {
+      "request": [
+        {
+          "name": "teamID",
+          "type": "TeamID"
+        },
+        {
+          "name": "teamName",
+          "type": "string"
+        },
+        {
+          "name": "oldTeamName",
+          "type": [
+            null,
+            "string"
+          ]
+        },
+        {
+          "name": "latestSeqno",
+          "type": "Seqno"
+        },
+        {
+          "name": "implicitTeam",
+          "type": "boolean"
+        }
+      ],
+      "response": null,
+      "oneway": true
+    },
     "teamDeleted": {
       "request": [
         {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2850,6 +2850,8 @@ export type NotifyTeamTeamDeletedRpcParam = $ReadOnly<{teamID: TeamID, incomingC
 
 export type NotifyTeamTeamExitRpcParam = $ReadOnly<{teamID: TeamID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type NotifyTeamTeamNameUpdateRpcParam = $ReadOnly<{teamID: TeamID, teamName: String, oldTeamName?: ?String, latestSeqno: Seqno, implicitTeam: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type NotifyTrackingTrackingChangedRpcParam = $ReadOnly<{uid: UID, username: String, isTracking: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type NotifyUsersUserChangedRpcParam = $ReadOnly<{uid: UID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -4266,6 +4268,7 @@ export type IncomingCallMapType = {
   'keybase.1.NotifySession.clientOutOfDate'?: (params: $ReadOnly<{upgradeTo: String, upgradeURI: String, upgradeMsg: String}>, response: CommonResponseHandler) => void,
   'keybase.1.NotifyTeam.teamChangedByID'?: (params: $ReadOnly<{teamID: TeamID, latestSeqno: Seqno, implicitTeam: Boolean, changes: TeamChangeSet}>, response: CommonResponseHandler) => void,
   'keybase.1.NotifyTeam.teamChangedByName'?: (params: $ReadOnly<{teamName: String, latestSeqno: Seqno, implicitTeam: Boolean, changes: TeamChangeSet}>, response: CommonResponseHandler) => void,
+  'keybase.1.NotifyTeam.teamNameUpdate'?: (params: $ReadOnly<{teamID: TeamID, teamName: String, oldTeamName?: ?String, latestSeqno: Seqno, implicitTeam: Boolean}>, response: CommonResponseHandler) => void,
   'keybase.1.NotifyTeam.teamDeleted'?: (params: $ReadOnly<{teamID: TeamID}>, response: CommonResponseHandler) => void,
   'keybase.1.NotifyTeam.teamAbandoned'?: (params: $ReadOnly<{teamID: TeamID}>, response: CommonResponseHandler) => void,
   'keybase.1.NotifyTeam.teamExit'?: (params: $ReadOnly<{teamID: TeamID}>, response: CommonResponseHandler) => void,


### PR DESCRIPTION
Add a notification `teamNameUpdate` for when a team name changes compared to what we last had on file. Fires very lazily, only when the team is loaded. There are other notifications that fire fast but do not have trusted TeamID<->TeamName bindings.

Base branch. Shouldn't merge this until GUI handles the new notification.

`TeamNameUpdate` now fires at a site where previously 3 notifications were fired. They have been removed from that site.
- `TeamChangedByID`
- `TeamChangedByName` for the old name
- `TeamChangedByName` for the new name

Before merging:
- [ ] gui work
- [ ] Make KBFS PR to process new notification. Merge in tandem.