### PR TITLE
Vendor saltpack

### DIFF
--- a/go/vendor/github.com/keybase/saltpack/README.md
+++ b/go/vendor/github.com/keybase/saltpack/README.md
@@ -58,4 +58,4 @@ Ph/Hao4ZzCQDM76Jr/aCUJIbxyc2zco=
 ```
 The changes here are small: we've reduced our characters to base62 plus some period markers, and only at the ends of words. PGP messages often get mangled by different apps, websites, and smart text processors.
 
-Of course, **saltpack** can output binary, too. Either way, it's what's inside the format that matters. You can read the [spec](https://saltpack.org/encryption-format) for the details.
+Of course, **saltpack** can output binary, too. Either way, it's what's inside the format that matters. You can read the [spec](https://saltpack.org/encryption-format-v2) for the details.

--- a/go/vendor/github.com/keybase/saltpack/armor62_encrypt.go
+++ b/go/vendor/github.com/keybase/saltpack/armor62_encrypt.go
@@ -23,6 +23,18 @@ func (c closeForwarder) Close() error {
 	return nil
 }
 
+func newEncryptArmor62Stream(version Version, ciphertext io.Writer, sender BoxSecretKey, receivers []BoxPublicKey, ephemeralKeyCreator EphemeralKeyCreator, rng encryptRNG, brand string) (plaintext io.WriteCloser, err error) {
+	enc, err := NewArmor62EncoderStream(ciphertext, MessageTypeEncryption, brand)
+	if err != nil {
+		return nil, err
+	}
+	out, err := newEncryptStream(version, enc, sender, receivers, ephemeralKeyCreator, rng)
+	if err != nil {
+		return nil, err
+	}
+	return closeForwarder([]io.WriteCloser{out, enc}), nil
+}
+
 // NewEncryptArmor62Stream creates a stream that consumes plaintext data.
 // It will write out encrypted data to the io.Writer passed in as ciphertext.
 // The encryption is from the specified sender, and is encrypted for the
@@ -33,25 +45,20 @@ func (c closeForwarder) Close() error {
 //
 // The ciphertext is additionally armored with the recommended armor62-style format.
 //
-// Returns an io.WriteCloser that accepts plaintext data to be encrypted; and
-// also returns an error if initialization failed.
+// If initialization succeeds, returns an io.WriteCloser that accepts
+// plaintext data to be encrypted and a nil error. Otherwise, returns
+// nil and the initialization error.
 func NewEncryptArmor62Stream(version Version, ciphertext io.Writer, sender BoxSecretKey, receivers []BoxPublicKey, brand string) (plaintext io.WriteCloser, err error) {
-	enc, err := NewArmor62EncoderStream(ciphertext, MessageTypeEncryption, brand)
+	ephemeralKeyCreator, err := receiversToEphemeralKeyCreator(receivers)
 	if err != nil {
 		return nil, err
 	}
-	out, err := NewEncryptStream(version, enc, sender, receivers)
-	if err != nil {
-		return nil, err
-	}
-	return closeForwarder([]io.WriteCloser{out, enc}), nil
+	return newEncryptArmor62Stream(version, ciphertext, sender, receivers, ephemeralKeyCreator, defaultEncryptRNG{}, brand)
 }
 
-// EncryptArmor62Seal is the non-streaming version of NewEncryptArmor62Stream, which
-// inputs a plaintext (in bytes) and output a ciphertext (as a string).
-func EncryptArmor62Seal(version Version, plaintext []byte, sender BoxSecretKey, receivers []BoxPublicKey, brand string) (string, error) {
+func encryptArmor62Seal(version Version, plaintext []byte, sender BoxSecretKey, receivers []BoxPublicKey, ephemeralKeyCreator EphemeralKeyCreator, rng encryptRNG, brand string) (string, error) {
 	var buf bytes.Buffer
-	enc, err := NewEncryptArmor62Stream(version, &buf, sender, receivers, brand)
+	enc, err := newEncryptArmor62Stream(version, &buf, sender, receivers, ephemeralKeyCreator, rng, brand)
 	if err != nil {
 		return "", err
 	}
@@ -62,4 +69,14 @@ func EncryptArmor62Seal(version Version, plaintext []byte, sender BoxSecretKey, 
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+// EncryptArmor62Seal is the non-streaming version of NewEncryptArmor62Stream, which
+// inputs a plaintext (in bytes) and output a ciphertext (as a string).
+func EncryptArmor62Seal(version Version, plaintext []byte, sender BoxSecretKey, receivers []BoxPublicKey, brand string) (string, error) {
+	ephemeralKeyCreator, err := receiversToEphemeralKeyCreator(receivers)
+	if err != nil {
+		return "", err
+	}
+	return encryptArmor62Seal(version, plaintext, sender, receivers, ephemeralKeyCreator, defaultEncryptRNG{}, brand)
 }

--- a/go/vendor/github.com/keybase/saltpack/armor62_signcrypt.go
+++ b/go/vendor/github.com/keybase/saltpack/armor62_signcrypt.go
@@ -9,6 +9,19 @@ import (
 	"io/ioutil"
 )
 
+func newSigncryptArmor62SealStream(ciphertext io.Writer, sender SigningSecretKey, receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey, ephemeralKeyCreator EphemeralKeyCreator, rng signcryptRNG, brand string) (plaintext io.WriteCloser, err error) {
+	// Note: same "BEGIN SALTPACK ENCRYPTED" visible message type.
+	enc, err := NewArmor62EncoderStream(ciphertext, MessageTypeEncryption, brand)
+	if err != nil {
+		return nil, err
+	}
+	out, err := newSigncryptSealStream(enc, sender, receiverBoxKeys, receiverSymmetricKeys, ephemeralKeyCreator, rng)
+	if err != nil {
+		return nil, err
+	}
+	return closeForwarder([]io.WriteCloser{out, enc}), nil
+}
+
 // NewSigncryptArmor62SealStream creates a stream that consumes plaintext data.
 // It will write out signcrypted data to the io.Writer passed in as ciphertext.
 // The signcryption is from the specified sender, and is signcrypted for the
@@ -19,26 +32,19 @@ import (
 //
 // The ciphertext is additionally armored with the recommended armor62-style format.
 //
-// Returns an io.WriteCloser that accepts plaintext data to be signcrypted; and
-// also returns an error if initialization failed.
-func NewSigncryptArmor62SealStream(ciphertext io.Writer, keyring Keyring, sender SigningSecretKey, receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey, brand string) (plaintext io.WriteCloser, err error) {
-	// Note: same "BEGIN SALTPACK ENCRYPTED" visible message type.
-	enc, err := NewArmor62EncoderStream(ciphertext, MessageTypeEncryption, brand)
-	if err != nil {
-		return nil, err
-	}
-	out, err := NewSigncryptSealStream(enc, keyring, sender, receiverBoxKeys, receiverSymmetricKeys)
-	if err != nil {
-		return nil, err
-	}
-	return closeForwarder([]io.WriteCloser{out, enc}), nil
+// If initialization succeeds, returns an io.WriteCloser that accepts
+// plaintext data to be signcrypted and a nil error. Otherwise,
+// returns nil and the initialization error.
+//
+// ephemeralKeyCreator should be the last argument; it's the 2nd one
+// to preserve the public API.
+func NewSigncryptArmor62SealStream(ciphertext io.Writer, ephemeralKeyCreator EphemeralKeyCreator, sender SigningSecretKey, receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey, brand string) (plaintext io.WriteCloser, err error) {
+	return newSigncryptArmor62SealStream(ciphertext, sender, receiverBoxKeys, receiverSymmetricKeys, ephemeralKeyCreator, defaultSigncryptRNG{}, brand)
 }
 
-// SigncryptArmor62Seal is the non-streaming version of NewSigncryptArmor62SealStream, which
-// inputs a plaintext (in bytes) and output a ciphertext (as a string).
-func SigncryptArmor62Seal(plaintext []byte, keyring Keyring, sender SigningSecretKey, receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey, brand string) (string, error) {
+func signcryptArmor62Seal(plaintext []byte, sender SigningSecretKey, receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey, ephemeralKeyCreator EphemeralKeyCreator, rng signcryptRNG, brand string) (string, error) {
 	var buf bytes.Buffer
-	enc, err := NewSigncryptArmor62SealStream(&buf, keyring, sender, receiverBoxKeys, receiverSymmetricKeys, brand)
+	enc, err := newSigncryptArmor62SealStream(&buf, sender, receiverBoxKeys, receiverSymmetricKeys, ephemeralKeyCreator, rng, brand)
 	if err != nil {
 		return "", err
 	}
@@ -49,6 +55,15 @@ func SigncryptArmor62Seal(plaintext []byte, keyring Keyring, sender SigningSecre
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+// SigncryptArmor62Seal is the non-streaming version of NewSigncryptArmor62SealStream, which
+// inputs a plaintext (in bytes) and output a ciphertext (as a string).
+//
+// ephemeralKeyCreator should be the last argument; it's the 2nd one
+// to preserve the public API.
+func SigncryptArmor62Seal(plaintext []byte, ephemeralKeyCreator EphemeralKeyCreator, sender SigningSecretKey, receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey, brand string) (string, error) {
+	return signcryptArmor62Seal(plaintext, sender, receiverBoxKeys, receiverSymmetricKeys, ephemeralKeyCreator, defaultSigncryptRNG{}, brand)
 }
 
 // NewDearmor62SigncryptOpenStream makes a new stream that dearmors and decrypts the given

--- a/go/vendor/github.com/keybase/saltpack/const.go
+++ b/go/vendor/github.com/keybase/saltpack/const.go
@@ -28,17 +28,23 @@ const MessageTypeDetachedSignature MessageType = 2
 // signcrypted message.
 const MessageTypeSigncryption MessageType = 3
 
+// Version1 returns the Version for Saltpack V1.
 func Version1() Version {
 	return Version{Major: 1, Minor: 0}
 }
+
+// Version2 returns the Version for Saltpack V2.
 func Version2() Version {
 	return Version{Major: 2, Minor: 0}
 }
 
+// CurrentVersion returns the Version for the currently-used Saltpack
+// version.
 func CurrentVersion() Version {
-	return Version1()
+	return Version2()
 }
 
+// KnownVersions returns all known Saltpack versions.
 func KnownVersions() []Version {
 	return []Version{Version1(), Version2()}
 }

--- a/go/vendor/github.com/keybase/saltpack/encoding/basex/bases.go
+++ b/go/vendor/github.com/keybase/saltpack/encoding/basex/bases.go
@@ -14,7 +14,7 @@ const b58skipChars = "\t\n\r !\"#$%&'()*+,-./0:;<=>?@IOl[\\]^_`{|}~"
 // Bitcoin-style encoding
 const base58EncodeStd = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
-// Base58StdEncoding is the standard base58-encoding, with Strict mode enforcing
+// Base58StdEncodingStrict is the standard base58-encoding, with Strict mode enforcing
 // no foreign characters
 var Base58StdEncodingStrict = NewEncoding(base58EncodeStd, 19, "")
 
@@ -25,7 +25,7 @@ var Base58StdEncoding = NewEncoding(base58EncodeStd, 19, b58skipChars)
 // Unlike Base64, we put the digits first.
 const base62EncodeStd = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
-// Base62StdEncoding is the standard 62-encoding, with a 32-byte input block and, a
+// Base62StdEncodingStrict is the standard 62-encoding, with a 32-byte input block and, a
 // 43-byte output block. Strict mode is on, so no foreign characters.
 var Base62StdEncodingStrict = NewEncoding(base62EncodeStd, 32, "")
 

--- a/go/vendor/github.com/keybase/saltpack/key.go
+++ b/go/vendor/github.com/keybase/saltpack/key.go
@@ -24,6 +24,15 @@ func rawBoxKeyFromSlice(slice []byte) (*RawBoxKey, error) {
 // buffer. Used for NaCl SecretBox.
 type SymmetricKey [32]byte
 
+func newRandomSymmetricKey() (*SymmetricKey, error) {
+	var s SymmetricKey
+	err := csprngRead(s[:])
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
 func symmetricKeyFromSlice(slice []byte) (*SymmetricKey, error) {
 	var result SymmetricKey
 	if len(slice) != len(result) {
@@ -31,6 +40,13 @@ func symmetricKeyFromSlice(slice []byte) (*SymmetricKey, error) {
 	}
 	result = sliceToByte32(slice)
 	return &result, nil
+}
+
+// EphemeralKeyCreator is an interface for objects that can create
+// random ephemeral keys.
+type EphemeralKeyCreator interface {
+	// CreateEmphemeralKey creates a random ephemeral key.
+	CreateEphemeralKey() (BoxSecretKey, error)
 }
 
 // BasePublicKey types can output a key ID corresponding to the key.
@@ -44,15 +60,12 @@ type BasePublicKey interface {
 // BoxPublicKey is an generic interface to NaCl's public key Box function.
 type BoxPublicKey interface {
 	BasePublicKey
+	// Implement EphemeralKeyCreator to avoid breaking the public API.
+	EphemeralKeyCreator
 
 	// ToRawBoxKeyPointer returns this public key as a *[32]byte,
 	// for use with nacl.box.Seal
 	ToRawBoxKeyPointer() *RawBoxKey
-
-	// CreateEmphemeralKey creates an ephemeral key of the same type, but
-	// totally random. The BoxPublicKey and the Keyring interfaces both support
-	// this method, for convenience.
-	CreateEphemeralKey() (BoxSecretKey, error)
 
 	// HideIdentity returns true if we should hide the identity of this
 	// key in our output message format.
@@ -106,6 +119,9 @@ type SigningPublicKey interface {
 // recover public or private keys during the decryption process.
 // Calls can block on network action.
 type Keyring interface {
+	// Implement EphemeralKeyCreator to avoid breaking the public API.
+	EphemeralKeyCreator
+
 	// LookupBoxSecretKey looks in the Keyring for the secret key corresponding
 	// to one of the given Key IDs.  Returns the index and the key on success,
 	// or -1 and nil on failure.
@@ -123,11 +139,6 @@ type Keyring interface {
 	// BoxPublicKey format. This key has never been seen before, so
 	// will be ephemeral.
 	ImportBoxEphemeralKey(kid []byte) BoxPublicKey
-
-	// CreateEmphemeralKey creates a random ephemeral key. It is not added to
-	// the keyring. The BoxPublicKey and Keyring interfaces both support this
-	// method, for convenience.
-	CreateEphemeralKey() (BoxSecretKey, error)
 }
 
 // SigKeyring is an interface used during verification to find

--- a/go/vendor/github.com/keybase/saltpack/nonce.go
+++ b/go/vendor/github.com/keybase/saltpack/nonce.go
@@ -1,7 +1,6 @@
 package saltpack
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 )
 
@@ -89,7 +88,7 @@ type sigNonce [16]byte
 // newSigNonce creates a sigNonce with random bytes.
 func newSigNonce() (sigNonce, error) {
 	var n sigNonce
-	if _, err := rand.Read(n[:]); err != nil {
+	if err := csprngRead(n[:]); err != nil {
 		return sigNonce{}, err
 	}
 	return n, nil

--- a/go/vendor/github.com/keybase/saltpack/rand.go
+++ b/go/vendor/github.com/keybase/saltpack/rand.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// (Following the advice of
+// https://softwareengineering.stackexchange.com/a/264363 re. above
+// copyright notices.)
+
+package saltpack
+
+import (
+	cryptorand "crypto/rand"
+	"encoding/binary"
+	"io"
+)
+
+// csprngReadFull is a thin wrapper around io.ReadFull on a given
+// CSPRNG that also (paranoidly) checks the length.
+func csprngReadFull(csprng io.Reader, b []byte) error {
+	n, err := io.ReadFull(csprng, b)
+	if err != nil {
+		return err
+	}
+	if n != len(b) {
+		return ErrInsufficientRandomness
+	}
+	return nil
+}
+
+// csprngRead is like crypto/rand.Read, except it uses csprngReadFull
+// instead of io.ReadFull.
+func csprngRead(b []byte) error {
+	return csprngReadFull(cryptorand.Reader, b)
+}
+
+// csprngUint32, given a CSPRNG, returns a uniformly distributed
+// random number in [0, 2³²).
+func csprngUint32(csprng io.Reader) (uint32, error) {
+	var buf [4]byte
+	err := csprngReadFull(csprng, buf[:])
+	if err != nil {
+		return 0, err
+	}
+
+	return binary.BigEndian.Uint32(buf[:]), nil
+}
+
+// csprngUint32n, given a CSPRNG, returns, as a uint32, a uniformly
+// distributed random number in [0, n). It is adapted from
+// math/rand.int31n from go 1.10.
+//
+// For implementation details, see:
+// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
+// https://lemire.me/blog/2016/06/30/fast-random-shuffling
+func csprngUint32n(csprng io.Reader, n uint32) (uint32, error) {
+	v, err := csprngUint32(csprng)
+	if err != nil {
+		return 0, err
+	}
+	prod := uint64(v) * uint64(n)
+	low := uint32(prod)
+	if low < n {
+		thresh := -n % n
+		for low < thresh {
+			v, err = csprngUint32(csprng)
+			if err != nil {
+				return 0, err
+			}
+			prod = uint64(v) * uint64(n)
+			low = uint32(prod)
+		}
+	}
+	return uint32(prod >> 32), nil
+}
+
+// csprngShuffle randomizes the order of elements given a CSPRNG. n is
+// the number of elements, which must be >= 0 and < 2³¹. swap swaps
+// the elements with indexes i and j.
+//
+// This function implements
+// https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle , and is
+// adapted from math/rand.Shuffle from go 1.10.
+func csprngShuffle(csprng io.Reader, n int, swap func(i, j int)) error {
+	if n < 0 {
+		panic("csprngShuffle: n < 0")
+	}
+	if n > ((1 << 31) - 1) {
+		panic("csprngShuffle: n >= 2³¹")
+	}
+
+	for i := n - 1; i > 0; i-- {
+		j, err := csprngUint32n(csprng, uint32(i+1))
+		if err != nil {
+			return err
+		}
+		swap(i, int(j))
+	}
+	return nil
+}

--- a/go/vendor/github.com/keybase/saltpack/signcrypt_open.go
+++ b/go/vendor/github.com/keybase/saltpack/signcrypt_open.go
@@ -206,7 +206,7 @@ func (sos *signcryptOpenStream) processBlock(payloadCiphertext []byte, isFinal b
 		return nil, ErrBadCiphertext(seqno)
 	}
 
-	var detachedSig [ed25519.SignatureSize]byte = sliceToByte64(attachedSig[:ed25519.SignatureSize])
+	detachedSig := sliceToByte64(attachedSig[:ed25519.SignatureSize])
 	chunkPlaintext := attachedSig[ed25519.SignatureSize:]
 
 	// Handle anonymous sender mode by skipping signature verification. By
@@ -249,11 +249,12 @@ func NewSigncryptOpenStream(r io.Reader, keyring SigncryptKeyring, resolver Symm
 	return sos.signingPublicKey, newChunkReader(sos), nil
 }
 
+// SymmetricKeyResolver is an interface for resolving identifiers to keys.
 type SymmetricKeyResolver interface {
 	ResolveKeys(identifiers [][]byte) ([]*SymmetricKey, error)
 }
 
-// Open simply opens a ciphertext given the set of keys in the specified keyring.
+// SigncryptOpen simply opens a ciphertext given the set of keys in the specified keyring.
 // It returns a plaintext on sucess, and an error on failure. It returns the header's
 // MessageKeyInfo in either case.
 func SigncryptOpen(ciphertext []byte, keyring SigncryptKeyring, resolver SymmetricKeyResolver) (senderPub SigningPublicKey, plaintext []byte, err error) {
@@ -269,6 +270,8 @@ func SigncryptOpen(ciphertext []byte, keyring SigncryptKeyring, resolver Symmetr
 	return senderPub, ret, err
 }
 
+// SigncryptKeyring is a combination of the Keyring and SigKeyring
+// interfaces.
 type SigncryptKeyring interface {
 	Keyring
 	SigKeyring

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -389,22 +389,22 @@
 			"revision": ""
 		},
 		{
-			"checksumSHA1": "Duc20TmnXwW5yPF92LMOMKWuB0c=",
+			"checksumSHA1": "UT+c8olRWpXtZIw96rRFXYfBUzY=",
 			"path": "github.com/keybase/saltpack",
-			"revision": "a64888f73967e479064b4a80cc65ae4c3829ab07",
-			"revisionTime": "2017-05-01T17:44:31Z"
+			"revision": "282df2166aa71f1283de12d39a10addbb30bafb4",
+			"revisionTime": "2018-03-19T16:38:18Z"
 		},
 		{
-			"checksumSHA1": "Gdp9VlKETiubZjf25/zvKOs0hH0=",
+			"checksumSHA1": "D4hR7JGP+aNHyAfXjBumb6PU7IM=",
 			"path": "github.com/keybase/saltpack/basic",
-			"revision": "a64888f73967e479064b4a80cc65ae4c3829ab07",
-			"revisionTime": "2017-05-01T17:44:31Z"
+			"revision": "282df2166aa71f1283de12d39a10addbb30bafb4",
+			"revisionTime": "2018-03-19T16:38:18Z"
 		},
 		{
-			"checksumSHA1": "J5D2TJ+bjeSpUvJMPPvW3/BrOiY=",
+			"checksumSHA1": "LpuohLoTQEeJxurlZ5ruBJFWh8E=",
 			"path": "github.com/keybase/saltpack/encoding/basex",
-			"revision": "a64888f73967e479064b4a80cc65ae4c3829ab07",
-			"revisionTime": "2017-05-01T17:44:31Z"
+			"revision": "282df2166aa71f1283de12d39a10addbb30bafb4",
+			"revisionTime": "2018-03-19T16:38:18Z"
 		},
 		{
 			"path": "github.com/kr/pty",


### PR DESCRIPTION
Notable changes:

- Hardcodes field order for encryption, so that fixes to the codec
  library won't change it.
- Make receiver shuffling unbiased, even on go <1.10.
- Bump CurrentVersion to Version2 (although keybase already always uses
  Version2).