### PR TITLE
Hooks for device/user ek generation

### DIFF
--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -154,7 +154,6 @@ func (e *Login) notProvisionedErr(err error) bool {
 	}
 
 	e.G().Log.Debug("notProvisioned, not handling error %s (err type: %T)", err, err)
-
 	return false
 }
 

--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -17,7 +17,7 @@ const KeyGenLifetimeSecs = keybase1.Time(60 * 60 * 24) // one day
 // We should wrap any entry points to the library with this before we're ready
 // to fully release it.
 func ShouldRun(g *libkb.GlobalContext) bool {
-	return g.Env.GetFeatureFlags().Admin() || g.Env.GetRunMode() == libkb.DevelRunMode || g.Env.RunningInCI()
+	return g.Env.GetFeatureFlags().UseEphemeral() || g.Env.GetRunMode() == libkb.DevelRunMode || g.Env.RunningInCI()
 }
 
 func makeNewRandomSeed() (seed keybase1.Bytes32, err error) {

--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -4,16 +4,15 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 // Keys last at most one week
-const KeyLifetimeSecs = keybase1.Time(time.Hour * 24 * 7) // one week
+const KeyLifetimeSecs = keybase1.Time(60 * 60 * 24 * 7) // one week
 // Everyday we want to generate a new key if possible
-const KeyGenLifetimeSecs = keybase1.Time(time.Hour * 24) // one day
+const KeyGenLifetimeSecs = keybase1.Time(60 * 60 * 24) // one day
 
 func makeNewRandomSeed() (seed keybase1.Bytes32, err error) {
 	bs, err := libkb.RandBytes(libkb.NaclDHKeysize)

--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -10,9 +10,9 @@ import (
 )
 
 // Keys last at most one week
-const KeyLifetimeSecs = keybase1.Time(60 * 60 * 24 * 7) // one week
+const KeyLifetimeSecs = 60 * 60 * 24 * 7 // one week
 // Everyday we want to generate a new key if possible
-const KeyGenLifetimeSecs = keybase1.Time(60 * 60 * 24) // one day
+const KeyGenLifetimeSecs = 60 * 60 * 24 // one day
 
 // We should wrap any entry points to the library with this before we're ready
 // to fully release it.
@@ -89,7 +89,7 @@ func getExpiredGenerations(keyMap keyExpiryMap, nowCTime keybase1.Time) (expired
 			expiryOffset = KeyLifetimeSecs
 		}
 		// Keys can live for as long as KeyLifetimeSecs + expiryOffset
-		if (nowCTime - currentCTime) >= (KeyLifetimeSecs + expiryOffset) {
+		if (nowCTime - currentCTime) >= (keybase1.TimeFromSeconds(KeyLifetimeSecs) + expiryOffset) {
 			expired = append(expired, generation)
 		}
 	}

--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -10,7 +10,10 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
+// Keys last at most one week
 const KeyLifetimeSecs = keybase1.Time(time.Hour * 24 * 7) // one week
+// Everyday we want to generate a new key if possible
+const KeyGenLifetimeSecs = keybase1.Time(time.Hour * 24) // one day
 
 func makeNewRandomSeed() (seed keybase1.Bytes32, err error) {
 	bs, err := libkb.RandBytes(libkb.NaclDHKeysize)

--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -14,6 +14,12 @@ const KeyLifetimeSecs = keybase1.Time(60 * 60 * 24 * 7) // one week
 // Everyday we want to generate a new key if possible
 const KeyGenLifetimeSecs = keybase1.Time(60 * 60 * 24) // one day
 
+// We should wrap any entry points to the library with this before we're ready
+// to fully release it.
+func ShouldRun(g *libkb.GlobalContext) bool {
+	return g.Env.GetFeatureFlags().Admin() || g.Env.GetRunMode() == libkb.DevelRunMode || g.Env.RunningInCI()
+}
+
 func makeNewRandomSeed() (seed keybase1.Bytes32, err error) {
 	bs, err := libkb.RandBytes(libkb.NaclDHKeysize)
 	if err != nil {

--- a/go/ephemeral/common_test.go
+++ b/go/ephemeral/common_test.go
@@ -37,7 +37,7 @@ func TestTimeConversions(t *testing.T) {
 }
 
 func TestDeleteExpiredKeys(t *testing.T) {
-	now := keybase1.Time(time.Now().Unix())
+	now := keybase1.TimeFromSeconds(time.Now().Unix())
 
 	// Test empty
 	expired := getExpiredGenerations(make(keyExpiryMap), now)
@@ -54,12 +54,12 @@ func TestDeleteExpiredKeys(t *testing.T) {
 
 	// Test with a single key that is stale but not expired
 	keyMap = keyExpiryMap{
-		0: now - KeyLifetimeSecs,
+		0: now - keybase1.TimeFromSeconds(KeyLifetimeSecs),
 	}
 
 	// Test with a single key that is expired
 	keyMap = keyExpiryMap{
-		0: now - KeyLifetimeSecs*2,
+		0: now - keybase1.TimeFromSeconds(KeyLifetimeSecs*2),
 	}
 	expired = getExpiredGenerations(keyMap, now)
 	expected = []keybase1.EkGeneration{0}
@@ -67,7 +67,7 @@ func TestDeleteExpiredKeys(t *testing.T) {
 
 	// Test with a 6 day gap, but no expiry
 	keyMap = keyExpiryMap{
-		0: now - keybase1.Time(60*60*24*6),
+		0: now - keybase1.TimeFromSeconds(60*60*24*6),
 		1: now,
 	}
 	expired = getExpiredGenerations(keyMap, now)
@@ -78,7 +78,7 @@ func TestDeleteExpiredKeys(t *testing.T) {
 	keyMap = make(keyExpiryMap)
 	numKeys := 5
 	for i := 0; i < numKeys; i++ {
-		keyMap[keybase1.EkGeneration((numKeys - i - 1))] = now - KeyLifetimeSecs*keybase1.Time(i)
+		keyMap[keybase1.EkGeneration((numKeys - i - 1))] = now - keybase1.TimeFromSeconds(int64(KeyLifetimeSecs*i))
 	}
 	expired = getExpiredGenerations(keyMap, now)
 	expected = []keybase1.EkGeneration{0, 1, 2}

--- a/go/ephemeral/common_test.go
+++ b/go/ephemeral/common_test.go
@@ -67,7 +67,7 @@ func TestDeleteExpiredKeys(t *testing.T) {
 
 	// Test with a 6 day gap, but no expiry
 	keyMap = keyExpiryMap{
-		0: now - keybase1.Time(time.Hour*24*6),
+		0: now - keybase1.Time(60*60*24*6),
 		1: now,
 	}
 	expired = getExpiredGenerations(keyMap, now)

--- a/go/ephemeral/device_ek.go
+++ b/go/ephemeral/device_ek.go
@@ -72,7 +72,7 @@ func publishNewDeviceEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot 
 
 	storage := g.GetDeviceEKStorage()
 	generation, err := storage.MaxGeneration(ctx)
-	if err != nil && generation >= 0 {
+	if err != nil {
 		// Let's try to get the max from the server
 		g.Log.CDebugf(ctx, "Error getting maxGeneration from storage")
 		generation, err = getServerMaxDeviceEK(ctx, g, merkleRoot)

--- a/go/ephemeral/device_ek.go
+++ b/go/ephemeral/device_ek.go
@@ -224,7 +224,7 @@ func getActiveDeviceEKMetadata(ctx context.Context, g *libkb.GlobalContext, merk
 		// Check whether the key is stale. This isn't considered an error,
 		// since the server doesn't do this check for us. We log these cases
 		// and skip them.
-		ageSecs := keybase1.Time(merkleRoot.Ctime() - signedMerkleRoot.Ctime)
+		ageSecs := keybase1.TimeFromSeconds(merkleRoot.Ctime() - signedMerkleRoot.Ctime)
 		if ageSecs > KeyLifetimeSecs {
 			g.Log.CDebugf(ctx, "skipping stale deviceEK %s for device KID %s", verifiedMetadata.Kid, matchingDevice.KID)
 			continue

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -202,6 +202,7 @@ func (s *DeviceEKStorage) MaxGeneration(ctx context.Context) (maxGeneration keyb
 	s.Lock()
 	defer s.Unlock()
 
+	maxGeneration = -1
 	cache, err := s.getCache(ctx)
 	if err != nil {
 		return maxGeneration, err

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -230,7 +230,7 @@ func (s *DeviceEKStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.Me
 		keyMap[generation] = deviceEK.Metadata.Ctime
 	}
 
-	expired = getExpiredGenerations(keyMap, keybase1.Time(merkleRoot.Ctime()))
+	expired = getExpiredGenerations(keyMap, keybase1.TimeFromSeconds(merkleRoot.Ctime()))
 	epick := libkb.FirstErrorPicker{}
 	for _, generation := range expired {
 		epick.Push(s.delete(ctx, generation))

--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -17,43 +17,44 @@ func TestDeviceEKStorage(t *testing.T) {
 	defer tc.Cleanup()
 
 	now := keybase1.Time(time.Now().Unix())
-	merkleRoot, err := tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
+	merkleRoot := *merkleRootPtr
 
 	tests := []keybase1.DeviceEk{
 		{
 			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic0"))),
 			Metadata: keybase1.DeviceEkMetadata{
-				Generation: keybase1.EkGeneration(0),
+				Generation: 0,
 				HashMeta:   keybase1.HashMeta("fakeHashMeta0"),
-				Kid:        keybase1.KID(""),
+				Kid:        "",
 				Ctime:      now - KeyLifetimeSecs*3,
 			},
 		},
 		{
 			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic1"))),
 			Metadata: keybase1.DeviceEkMetadata{
-				Generation: keybase1.EkGeneration(1),
+				Generation: 1,
 				HashMeta:   keybase1.HashMeta("fakeHashMeta1"),
-				Kid:        keybase1.KID(""),
+				Kid:        "",
 				Ctime:      now - KeyLifetimeSecs*3,
 			},
 		},
 		{
 			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic2"))),
 			Metadata: keybase1.DeviceEkMetadata{
-				Generation: keybase1.EkGeneration(2),
+				Generation: 2,
 				HashMeta:   keybase1.HashMeta("fakeHashMeta2"),
-				Kid:        keybase1.KID(""),
+				Kid:        "",
 				Ctime:      now,
 			},
 		},
 		{
 			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic3"))),
 			Metadata: keybase1.DeviceEkMetadata{
-				Generation: keybase1.EkGeneration(3),
+				Generation: 3,
 				HashMeta:   keybase1.HashMeta("fakeHashMeta3"),
-				Kid:        keybase1.KID(""),
+				Kid:        "",
 				Ctime:      now,
 			},
 		},
@@ -75,6 +76,7 @@ func TestDeviceEKStorage(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 
+	s.ClearCache()
 	// Test GetAll
 	deviceEKs, err := s.GetAll(context.Background())
 	require.NoError(t, err)
@@ -87,9 +89,9 @@ func TestDeviceEKStorage(t *testing.T) {
 	}
 
 	// Test Delete
-	require.NoError(t, s.Delete(context.Background(), keybase1.EkGeneration(2)))
+	require.NoError(t, s.Delete(context.Background(), 2))
 
-	deviceEK, err = s.Get(context.Background(), keybase1.EkGeneration(2))
+	deviceEK, err = s.Get(context.Background(), 2)
 	require.Error(t, err)
 	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 
@@ -98,7 +100,7 @@ func TestDeviceEKStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 3, maxGeneration)
 
-	require.NoError(t, s.Delete(context.Background(), keybase1.EkGeneration(3)))
+	require.NoError(t, s.Delete(context.Background(), 3))
 
 	maxGeneration, err = s.MaxGeneration(context.Background())
 	require.NoError(t, err)
@@ -120,7 +122,7 @@ func TestDeviceEKStorage(t *testing.T) {
 	err = erasableStorage.Put(context.Background(), badEldestSeqnoKey, keybase1.DeviceEk{})
 	require.NoError(t, err)
 
-	expired, err := s.DeleteExpired(context.Background(), *merkleRoot)
+	expired, err := s.DeleteExpired(context.Background(), merkleRoot)
 	expected := []keybase1.EkGeneration{0, 1}
 	require.NoError(t, err)
 	require.Equal(t, expected, expired)

--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -16,7 +16,7 @@ func TestDeviceEKStorage(t *testing.T) {
 	tc := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	now := keybase1.Time(time.Now().Unix())
+	now := keybase1.TimeFromSeconds(time.Now().Unix())
 	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
@@ -28,7 +28,7 @@ func TestDeviceEKStorage(t *testing.T) {
 				Generation: 0,
 				HashMeta:   keybase1.HashMeta("fakeHashMeta0"),
 				Kid:        "",
-				Ctime:      now - KeyLifetimeSecs*3,
+				Ctime:      now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
 			},
 		},
 		{
@@ -37,7 +37,7 @@ func TestDeviceEKStorage(t *testing.T) {
 				Generation: 1,
 				HashMeta:   keybase1.HashMeta("fakeHashMeta1"),
 				Kid:        "",
-				Ctime:      now - KeyLifetimeSecs*3,
+				Ctime:      now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
 			},
 		},
 		{

--- a/go/ephemeral/device_ek_test.go
+++ b/go/ephemeral/device_ek_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
@@ -13,36 +13,45 @@ func TestNewDeviceEK(t *testing.T) {
 	tc := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	_, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
+	require.NoError(t, err)
+	merkleRoot := *merkleRootPtr
+
+	publishedMetadata, err := publishNewDeviceEK(context.Background(), tc.G, merkleRoot)
 	require.NoError(t, err)
 
-	publishedMetadata, err := PublishNewDeviceEK(context.Background(), tc.G)
+	s := tc.G.GetDeviceEKStorage()
+	deviceEK, err := s.Get(context.Background(), publishedMetadata.Generation)
 	require.NoError(t, err)
+	require.Equal(t, deviceEK.Metadata, publishedMetadata)
 
-	fetchedDevices, err := GetActiveDeviceEKMetadata(context.Background(), tc.G)
+	fetchedDevices, err := getActiveDeviceEKMetadata(context.Background(), tc.G, merkleRoot)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(fetchedDevices))
 	for _, fetchedDeviceMetadata := range fetchedDevices {
 		require.Equal(t, publishedMetadata, fetchedDeviceMetadata)
 	}
-	require.EqualValues(t, 1, publishedMetadata.Generation)
+	maxGeneration, err := s.MaxGeneration(context.Background())
+	require.NoError(t, err)
+
+	require.EqualValues(t, maxGeneration, publishedMetadata.Generation)
 
 	// If we publish again, we increase the generation
-	publishedMetadata2, err := PublishNewDeviceEK(context.Background(), tc.G)
+	publishedMetadata2, err := publishNewDeviceEK(context.Background(), tc.G, merkleRoot)
 	require.NoError(t, err)
-	require.EqualValues(t, 2, publishedMetadata2.Generation)
+	require.EqualValues(t, maxGeneration+1, publishedMetadata2.Generation)
 
-	s := NewDeviceEKStorage(tc.G)
+	rawStorage := NewDeviceEKStorage(tc.G)
 	// Put our storage in a bad state by deleting the maxGeneration
-	err = s.Delete(context.Background(), keybase1.EkGeneration(2))
+	err = rawStorage.Delete(context.Background(), keybase1.EkGeneration(maxGeneration+1))
 	require.NoError(t, err)
 
 	// If we publish in a bad local state, we can successfully get the
 	// maxGeneration from the server and continue
-	publishedMetadata3, err := PublishNewDeviceEK(context.Background(), tc.G)
+	publishedMetadata3, err := publishNewDeviceEK(context.Background(), tc.G, merkleRoot)
 	require.NoError(t, err)
-	require.EqualValues(t, 3, publishedMetadata3.Generation)
+	require.EqualValues(t, maxGeneration+2, publishedMetadata3.Generation)
 }
 
 // TODO: test cases chat verify we can detect invalid signatures and bad metadata

--- a/go/ephemeral/init.go
+++ b/go/ephemeral/init.go
@@ -11,8 +11,11 @@ func NewEphemeralStorageAndInstall(g *libkb.GlobalContext) {
 	g.SetUserEKBoxStorage(NewUserEKBoxStorage(g))
 	ekLib := NewEKLib(g)
 	g.SetEKLib(ekLib)
-	g.AddLoginHook(ekLib)
-	g.AddLogoutHook(ekLib)
+	// TODO remove this when we want to release in the wild.
+	if ShouldRun(g) {
+		g.AddLoginHook(ekLib)
+		g.AddLogoutHook(ekLib)
+	}
 }
 
 func ServiceInit(g *libkb.GlobalContext) {

--- a/go/ephemeral/init.go
+++ b/go/ephemeral/init.go
@@ -12,6 +12,7 @@ func NewEphemeralStorageAndInstall(g *libkb.GlobalContext) {
 	ekLib := NewEKLib(g)
 	g.SetEKLib(ekLib)
 	g.AddLoginHook(ekLib)
+	g.AddLogoutHook(ekLib)
 }
 
 func ServiceInit(g *libkb.GlobalContext) {

--- a/go/ephemeral/init.go
+++ b/go/ephemeral/init.go
@@ -1,12 +1,17 @@
 package ephemeral
 
-import "github.com/keybase/client/go/libkb"
+import (
+	"github.com/keybase/client/go/libkb"
+)
 
 // Creates a ephemeral key storage and installs it into G.
 func NewEphemeralStorageAndInstall(g *libkb.GlobalContext) {
 	// TODO add TeamEk storage
 	g.SetDeviceEKStorage(NewDeviceEKStorage(g))
 	g.SetUserEKBoxStorage(NewUserEKBoxStorage(g))
+	ekLib := NewEKLib(g)
+	g.SetEKLib(ekLib)
+	g.AddLoginHook(ekLib)
 }
 
 func ServiceInit(g *libkb.GlobalContext) {

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -1,0 +1,111 @@
+package ephemeral
+
+import (
+	"context"
+	"sync"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type EKLib struct {
+	libkb.Contextified
+	sync.Mutex
+}
+
+func NewEKLib(g *libkb.GlobalContext) *EKLib {
+	return &EKLib{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func (e *EKLib) KeygenIfNeeded(ctx context.Context) (err error) {
+	defer e.G().CTrace(ctx, "KeygenIfNeeded", func() error { return err })()
+	e.Lock()
+	defer e.Unlock()
+
+	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(ctx, libkb.EphemeralKeyMerkleFreshness)
+	if err != nil {
+		return err
+	}
+	merkleRoot := *merkleRootPtr
+
+	deviceEKNeeded, err := e.newDeviceEKNeeded(ctx, merkleRoot)
+	if err != nil {
+		return err
+	}
+	if deviceEKNeeded {
+		_, err = publishNewDeviceEK(ctx, e.G(), merkleRoot)
+		if err != nil {
+			return err
+		}
+	}
+
+	userEKNeeded, err := e.newUserEKNeeded(ctx, merkleRoot)
+	if err != nil {
+		return err
+	}
+
+	if userEKNeeded {
+		_, err = publishNewUserEK(ctx, e.G(), merkleRoot)
+		if err != nil {
+			return err
+		}
+	}
+	return e.CleanupStaleUserAndDeviceEKs(ctx, merkleRoot)
+}
+
+func (e *EKLib) CleanupStaleUserAndDeviceEKs(ctx context.Context, merkleRoot libkb.MerkleRoot) (err error) {
+	defer e.G().CTrace(ctx, "CleanupStaleUserAndDeviceEKs", func() error { return err })()
+
+	deviceEKStorage := e.G().GetDeviceEKStorage()
+
+	epick := libkb.FirstErrorPicker{}
+	_, err = deviceEKStorage.DeleteExpired(ctx, merkleRoot)
+	epick.Push(err)
+
+	userEKBoxStorage := e.G().GetUserEKBoxStorage()
+	_, err = userEKBoxStorage.DeleteExpired(ctx, merkleRoot)
+	epick.Push(err)
+	return epick.Error()
+}
+
+func (e *EKLib) newDeviceEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
+	s := e.G().GetDeviceEKStorage()
+	maxGeneration, err := s.MaxGeneration(ctx)
+	if err != nil {
+		return needed, err
+	}
+	if maxGeneration < 0 {
+		return true, nil
+	}
+
+	ek, err := s.Get(ctx, maxGeneration)
+	if err != nil {
+		return needed, err
+	}
+
+	return keybase1.Time(merkleRoot.Ctime())-ek.Metadata.Ctime > KeyGenLifetimeSecs, nil
+}
+
+func (e *EKLib) newUserEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
+	s := e.G().GetUserEKBoxStorage()
+	maxGeneration, err := s.MaxGeneration(ctx)
+	if err != nil {
+		return needed, err
+	}
+	if maxGeneration < 0 {
+		return true, nil
+	}
+
+	ek, err := s.Get(ctx, maxGeneration)
+	if err != nil {
+		return needed, err
+	}
+
+	return keybase1.Time(merkleRoot.Ctime())-ek.Metadata.Ctime > KeyGenLifetimeSecs, nil
+}
+
+func (e *EKLib) OnLogin() error {
+	return e.KeygenIfNeeded(context.Background())
+}

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -1,0 +1,68 @@
+package ephemeral
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeygenIfNeeded(t *testing.T) {
+	tc := ephemeralKeyTestSetup(t)
+	defer tc.Cleanup()
+
+	ekLib := NewEKLib(tc.G)
+	keygen := func() {
+		err := ekLib.KeygenIfNeeded(context.Background())
+		require.NoError(t, err)
+
+		deviceEKStorage := NewDeviceEKStorage(tc.G)
+		deviceEKs, err := deviceEKStorage.GetAll(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, 1, len(deviceEKs))
+
+		userEKBoxStorage := NewUserEKBoxStorage(tc.G)
+		userEKs, err := userEKBoxStorage.GetAll(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, 1, len(userEKs))
+	}
+
+	// If we retry keygen, we don't regenerate keys
+	keygen()
+	keygen()
+}
+
+func TestCleanupStaleUserAndDeviceEKs(t *testing.T) {
+	tc := ephemeralKeyTestSetup(t)
+	defer tc.Cleanup()
+
+	seed, err := newDeviceEphemeralSeed()
+	require.NoError(t, err)
+	s := tc.G.GetDeviceEKStorage()
+	ctimeExpired := keybase1.Time(time.Now().Unix()) - KeyLifetimeSecs*3
+	err = s.Put(context.Background(), 0, keybase1.DeviceEk{
+		Seed: keybase1.Bytes32(seed),
+		Metadata: keybase1.DeviceEkMetadata{
+			Ctime: ctimeExpired,
+		},
+	})
+	require.NoError(t, err)
+
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
+	require.NoError(t, err)
+	merkleRoot := *merkleRootPtr
+
+	ekLib := NewEKLib(tc.G)
+	err = ekLib.CleanupStaleUserAndDeviceEKs(context.Background(), merkleRoot)
+	require.NoError(t, err)
+
+	deviceEK, err := s.Get(context.Background(), 0)
+	require.Error(t, err)
+	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
+
+	err = ekLib.CleanupStaleUserAndDeviceEKs(context.Background(), merkleRoot)
+	require.NoError(t, err)
+}

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -42,7 +42,7 @@ func TestCleanupStaleUserAndDeviceEKs(t *testing.T) {
 	seed, err := newDeviceEphemeralSeed()
 	require.NoError(t, err)
 	s := tc.G.GetDeviceEKStorage()
-	ctimeExpired := keybase1.Time(time.Now().Unix()) - KeyLifetimeSecs*3
+	ctimeExpired := keybase1.TimeFromSeconds(time.Now().Unix() - KeyLifetimeSecs*3)
 	err = s.Put(context.Background(), 0, keybase1.DeviceEk{
 		Seed: keybase1.Bytes32(seed),
 		Metadata: keybase1.DeviceEkMetadata{

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -315,7 +315,7 @@ func getActiveUserEKMetadata(ctx context.Context, g *libkb.GlobalContext, merkle
 	// since the server doesn't do this check for us. We log these cases
 	// and return nil.
 	ageSecs := merkleRoot.Ctime() - metadata.Ctime.UnixSeconds()
-	if keybase1.Time(ageSecs) > KeyLifetimeSecs {
+	if ageSecs > KeyLifetimeSecs {
 		g.Log.CDebugf(ctx, "found stale userEK %s", metadata.Kid)
 		return nil, nil
 	}

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -37,7 +37,8 @@ type UserEKBoxMetadata struct {
 	Box                 string                `json:"box"`
 }
 
-func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxes []UserEKBoxMetadata) error {
+func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxes []UserEKBoxMetadata) (err error) {
+	defer g.CTrace(ctx, "postNewUserEK", func() error { return err })()
 	boxesJSON, err := json.Marshal(boxes)
 	if err != nil {
 		return err
@@ -55,13 +56,8 @@ func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxe
 	return err
 }
 
-func PublishNewUserEK(ctx context.Context, g *libkb.GlobalContext) (metadata keybase1.UserEkMetadata, err error) {
-	defer g.CTrace(ctx, "PublishNewUserEK", func() error { return err })()
-
-	currentMerkleRoot, err := g.GetMerkleClient().FetchRootFromServer(ctx, libkb.EphemeralKeyMerkleFreshness)
-	if err != nil {
-		return metadata, err
-	}
+func publishNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (metadata keybase1.UserEkMetadata, err error) {
+	defer g.CTrace(ctx, "publishNewUserEK", func() error { return err })()
 
 	seed, err := newUserEphemeralSeed()
 	if err != nil {
@@ -70,28 +66,36 @@ func PublishNewUserEK(ctx context.Context, g *libkb.GlobalContext) (metadata key
 
 	storage := g.GetUserEKBoxStorage()
 	generation, err := storage.MaxGeneration(ctx)
-	if err != nil {
+	if err != nil && generation >= 0 {
 		// Let's try to get the max from the server
 		g.Log.CDebugf(ctx, "Error getting maxGeneration from storage")
-		activeMetadata, err := GetLatestUserEKMetadataMaybeStale(ctx, g)
+		activeMetadata, err := getLatestUserEKMetadataMaybeStale(ctx, g)
 		if err != nil {
 			return metadata, err
 		}
-		generation = activeMetadata.Generation
+		if activeMetadata == nil {
+			generation = 0
+		} else {
+			generation = activeMetadata.Generation
+		}
 	}
 	generation++
 
-	metadata, myUserEKBoxed, err := signAndPublishUserEK(ctx, g, generation, seed, currentMerkleRoot)
+	metadata, myUserEKBoxed, err := signAndPublishUserEK(ctx, g, generation, seed, merkleRoot)
 	if err != nil {
 		g.Log.CDebugf(ctx, "Error posting deviceEK, retrying with server maxGeneration")
 		// Let's retry posting with the server given max
-		activeMetadata, err := GetLatestUserEKMetadataMaybeStale(ctx, g)
+		activeMetadata, err := getLatestUserEKMetadataMaybeStale(ctx, g)
 		if err != nil {
 			return metadata, err
 		}
-		generation = activeMetadata.Generation
+		if activeMetadata == nil {
+			generation = 0
+		} else {
+			generation = activeMetadata.Generation
+		}
 		generation++
-		metadata, myUserEKBoxed, err = signAndPublishUserEK(ctx, g, generation, seed, currentMerkleRoot)
+		metadata, myUserEKBoxed, err = signAndPublishUserEK(ctx, g, generation, seed, merkleRoot)
 		if err != nil {
 			return metadata, err
 		}
@@ -105,7 +109,7 @@ func PublishNewUserEK(ctx context.Context, g *libkb.GlobalContext) (metadata key
 	return metadata, err
 }
 
-func signAndPublishUserEK(ctx context.Context, g *libkb.GlobalContext, generation keybase1.EkGeneration, seed UserEKSeed, currentMerkleRoot *libkb.MerkleRoot) (metadata keybase1.UserEkMetadata, myUserEKBoxed *keybase1.UserEkBoxed, err error) {
+func signAndPublishUserEK(ctx context.Context, g *libkb.GlobalContext, generation keybase1.EkGeneration, seed UserEKSeed, merkleRoot libkb.MerkleRoot) (metadata keybase1.UserEkMetadata, myUserEKBoxed *keybase1.UserEkBoxed, err error) {
 
 	dhKeypair, err := seed.DeriveDHKey()
 	if err != nil {
@@ -115,11 +119,11 @@ func signAndPublishUserEK(ctx context.Context, g *libkb.GlobalContext, generatio
 	metadata = keybase1.UserEkMetadata{
 		Kid:        dhKeypair.GetKID(),
 		Generation: generation,
-		HashMeta:   currentMerkleRoot.HashMeta(),
+		HashMeta:   merkleRoot.HashMeta(),
 		// The ctime is derivable from the hash meta, by fetching the hashed
 		// root from the server, but including it saves readers a potential
 		// extra round trip.
-		Ctime: keybase1.TimeFromSeconds(currentMerkleRoot.Ctime()),
+		Ctime: keybase1.TimeFromSeconds(merkleRoot.Ctime()),
 	}
 	metadataJSON, err := json.Marshal(metadata)
 	if err != nil {
@@ -141,7 +145,7 @@ func signAndPublishUserEK(ctx context.Context, g *libkb.GlobalContext, generatio
 	}
 
 	// Box the seed up for each active deviceEK.
-	deviceEKs, err := GetActiveDeviceEKMetadata(ctx, g)
+	deviceEKs, err := getActiveDeviceEKMetadata(ctx, g, merkleRoot)
 	if err != nil {
 		return metadata, myUserEKBoxed, err
 	}
@@ -182,15 +186,12 @@ func signAndPublishUserEK(ctx context.Context, g *libkb.GlobalContext, generatio
 	return metadata, myUserEKBoxed, nil
 }
 
-type UserEKResponse struct {
+type userEKResponse struct {
 	Result *struct {
 		MerklePayload string `json:"merkle_payload"`
 		Sig           string `json:"sig"`
 	} `json:"result"`
 }
-
-// TODO let's go back and see which of these methods we can make private to the
-// package since some of this stuff is probably just internal
 
 // Verify that the blob is validly signed, and that the signing key is the
 // given user's latest PUK, then parse its contents. If the blob is signed by
@@ -198,7 +199,7 @@ type UserEKResponse struct {
 // `wrongKID` flag. As a transitional measure while we wait for all clients in
 // the wild to have EK support, callers will treat that case as "there is no
 // key" and convert the error to a warning.
-func VerifySigWithLatestPUK(ctx context.Context, g *libkb.GlobalContext, sig string) (metadata *keybase1.UserEkMetadata, wrongKID bool, err error) {
+func verifySigWithLatestPUK(ctx context.Context, g *libkb.GlobalContext, sig string) (metadata *keybase1.UserEkMetadata, wrongKID bool, err error) {
 	// Verify the sig.
 	signerKey, payload, _, err := libkb.NaclVerifyAndExtract(sig)
 	if err != nil {
@@ -248,8 +249,8 @@ func VerifySigWithLatestPUK(ctx context.Context, g *libkb.GlobalContext, sig str
 // one, this function will also return nil and log a warning. This is a
 // transitional thing, and eventually when all "reasonably up to date" clients
 // in the wild have EK support, we will make that case an error.
-func GetLatestUserEKMetadataMaybeStale(ctx context.Context, g *libkb.GlobalContext) (metadata *keybase1.UserEkMetadata, err error) {
-	defer g.CTrace(ctx, "GetLatestUserEKMetadataMaybeStale", func() error { return err })()
+func getLatestUserEKMetadataMaybeStale(ctx context.Context, g *libkb.GlobalContext) (metadata *keybase1.UserEkMetadata, err error) {
+	defer g.CTrace(ctx, "getLatestUserEKMetadataMaybeStale", func() error { return err })()
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "user/user_ek",
@@ -262,7 +263,7 @@ func GetLatestUserEKMetadataMaybeStale(ctx context.Context, g *libkb.GlobalConte
 		return nil, err
 	}
 
-	parsedResponse := UserEKResponse{}
+	parsedResponse := userEKResponse{}
 	err = res.Body.UnmarshalAgain(&parsedResponse)
 	if err != nil {
 		return nil, err
@@ -275,7 +276,7 @@ func GetLatestUserEKMetadataMaybeStale(ctx context.Context, g *libkb.GlobalConte
 		return nil, nil
 	}
 
-	metadata, wrongKID, err := VerifySigWithLatestPUK(ctx, g, parsedResponse.Result.Sig)
+	metadata, wrongKID, err := verifySigWithLatestPUK(ctx, g, parsedResponse.Result.Sig)
 	// Check the wrongKID condition before checking the error, since an error
 	// is still returned in this case. TODO: Turn this warning into an error
 	// after EK support is sufficiently widespread.
@@ -290,18 +291,18 @@ func GetLatestUserEKMetadataMaybeStale(ctx context.Context, g *libkb.GlobalConte
 	return metadata, nil
 }
 
-// As with GetLatestUserEKMetadataMaybeStale, but returns nil if the latest
+// As with getLatestUserEKMetadataMaybeStale, but returns nil if the latest
 // metadata is stale. This checks several things:
 // 1) The metadata blob is validly signed.
 // 2) The signing key is the user's latest PUK.
-// 3) The key hasn't expired. That is, the Merkle root it was delegated
+// 3) The key isn't stale . That is, the Merkle root it was delegated
 //    with is within one week of the current root. The server deliberately
-//    avoids doing this filtering for us, and finding expired keys in the
+//    avoids doing this filtering for us, and finding stale keys in the
 //    results here is expected. We silently drop them.
-func GetActiveUserEKMetadata(ctx context.Context, g *libkb.GlobalContext) (metadata *keybase1.UserEkMetadata, err error) {
+func getActiveUserEKMetadata(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (metadata *keybase1.UserEkMetadata, err error) {
 	defer g.CTrace(ctx, "GetActiveUserEKMetadata", func() error { return err })()
 
-	metadata, err = GetLatestUserEKMetadataMaybeStale(ctx, g)
+	metadata, err = getLatestUserEKMetadataMaybeStale(ctx, g)
 	if err != nil {
 		return nil, err
 	}
@@ -310,11 +311,10 @@ func GetActiveUserEKMetadata(ctx context.Context, g *libkb.GlobalContext) (metad
 		return nil, nil
 	}
 
-	// Check whether the key is expired. This isn't considered an error,
+	// Check whether the key is stale. This isn't considered an error,
 	// since the server doesn't do this check for us. We log these cases
 	// and return nil.
-	currentMerkleRoot, err := g.GetMerkleClient().FetchRootFromServer(ctx, libkb.EphemeralKeyMerkleFreshness)
-	ageSecs := currentMerkleRoot.Ctime() - metadata.Ctime.UnixSeconds()
+	ageSecs := merkleRoot.Ctime() - metadata.Ctime.UnixSeconds()
 	if keybase1.Time(ageSecs) > KeyLifetimeSecs {
 		g.Log.CDebugf(ctx, "found stale userEK %s", metadata.Kid)
 		return nil, nil

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -66,7 +66,7 @@ func publishNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot li
 
 	storage := g.GetUserEKBoxStorage()
 	generation, err := storage.MaxGeneration(ctx)
-	if err != nil && generation >= 0 {
+	if err != nil {
 		// Let's try to get the max from the server
 		g.Log.CDebugf(ctx, "Error getting maxGeneration from storage")
 		activeMetadata, err := getLatestUserEKMetadataMaybeStale(ctx, g)

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -110,7 +110,7 @@ func (s *UserEKBoxStorage) fetchAndPut(ctx context.Context, generation keybase1.
 	// Before we store anything, let's verify that the server returned
 	// signature is valid and the KID it has signed matches the boxed seed.
 	// Otherwise something's fishy..
-	userEKMetadata, wrongKID, err := VerifySigWithLatestPUK(ctx, s.G(), result.Result.Sig)
+	userEKMetadata, wrongKID, err := verifySigWithLatestPUK(ctx, s.G(), result.Result.Sig)
 
 	// Check the wrongKID condition before checking the error, since an error
 	// is still returned in this case. TODO: Turn this warning into an error
@@ -263,6 +263,8 @@ func (s *UserEKBoxStorage) MaxGeneration(ctx context.Context) (maxGeneration key
 	defer s.G().CTrace(ctx, "UserEKBoxStorage#MaxGeneration", func() error { return err })()
 	s.Lock()
 	defer s.Unlock()
+
+	maxGeneration = -1
 	cache, err := s.getCache(ctx)
 	if err != nil {
 		return maxGeneration, err

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -293,7 +293,7 @@ func (s *UserEKBoxStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.M
 		keyMap[generation] = userEKBoxed.Metadata.Ctime
 	}
 
-	expired = getExpiredGenerations(keyMap, keybase1.Time(merkleRoot.Ctime()))
+	expired = getExpiredGenerations(keyMap, keybase1.TimeFromSeconds(merkleRoot.Ctime()))
 	err = s.deleteMany(ctx, expired)
 	return expired, err
 }

--- a/go/ephemeral/user_ek_box_storage_test.go
+++ b/go/ephemeral/user_ek_box_storage_test.go
@@ -13,10 +13,14 @@ func TestUserEKBoxStorage(t *testing.T) {
 	tc := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	deviceEKMetadata, err := PublishNewDeviceEK(context.Background(), tc.G)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
+	require.NoError(t, err)
+	merkleRoot := *merkleRootPtr
+
+	deviceEKMetadata, err := publishNewDeviceEK(context.Background(), tc.G, merkleRoot)
 	require.NoError(t, err)
 
-	userEKMetadata, err := PublishNewUserEK(context.Background(), tc.G)
+	userEKMetadata, err := publishNewUserEK(context.Background(), tc.G, merkleRoot)
 	require.NoError(t, err)
 
 	s := tc.G.GetUserEKBoxStorage()
@@ -27,6 +31,7 @@ func TestUserEKBoxStorage(t *testing.T) {
 	require.Equal(t, keybase1.UserEk{}, nonexistent)
 
 	// Test get valid & unbox
+	s.ClearCache()
 	userEK, err := s.Get(context.Background(), userEKMetadata.Generation)
 	require.NoError(t, err)
 
@@ -83,11 +88,9 @@ func TestUserEKBoxStorage(t *testing.T) {
 
 	maxGeneration, err = s.MaxGeneration(context.Background())
 	require.NoError(t, err)
-	require.EqualValues(t, 0, maxGeneration)
+	require.EqualValues(t, -1, maxGeneration)
 
-	merkleRoot, err := tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
-	require.NoError(t, err)
-	expired, err := s.DeleteExpired(context.Background(), *merkleRoot)
+	expired, err := s.DeleteExpired(context.Background(), merkleRoot)
 	expected := []keybase1.EkGeneration(nil)
 	require.NoError(t, err)
 	require.Equal(t, expected, expired)

--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -30,6 +30,15 @@ func (set FeatureFlags) Admin() bool {
 	return false
 }
 
+func (set FeatureFlags) UseEphemeral() bool {
+	for _, f := range set {
+		if f == Feature("use-ephemeral") {
+			return true
+		}
+	}
+	return false
+}
+
 func (set FeatureFlags) Empty() bool {
 	return len(set) == 0
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -329,10 +329,6 @@ func (g *GlobalContext) Logout() error {
 			g.Log.Debug("Failed to nuke DB: %s", err)
 		}
 	}
-
-	if g.deviceEKStorage != nil {
-		g.deviceEKStorage.ClearCache()
-	}
 	g.cacheMu.Unlock()
 
 	// reload config to clear anything in memory

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -74,6 +74,7 @@ type GlobalContext struct {
 	teamLoader       TeamLoader       // Play back teams for id/name properties
 	deviceEKStorage  DeviceEKStorage  // Store device ephemeral keys
 	userEKBoxStorage UserEKBoxStorage // Store user ephemeral key boxes
+	ekLib            EKLib            // Wrapper to call ephemeral key methods
 	itciCacher       LRUer            // Cacher for implicit team conflict info
 	CardCache        *UserCardCache   // cache of keybase1.UserCard objects
 	fullSelfer       FullSelfer       // a loader that gets the full self object
@@ -156,6 +157,7 @@ func (g *GlobalContext) GetEnv() *Env                                  { return 
 func (g *GlobalContext) GetDNSNameServerFetcher() DNSNameServerFetcher { return g.DNSNSFetcher }
 func (g *GlobalContext) GetKVStore() KVStorer                          { return g.LocalDb }
 func (g *GlobalContext) GetClock() clockwork.Clock                     { return g.Clock() }
+func (g *GlobalContext) GetEKLib() EKLib                               { return g.ekLib }
 
 type LogGetter func() logger.Logger
 
@@ -206,6 +208,8 @@ func init() {
 func (g *GlobalContext) SetCommandLine(cmd CommandLine) { g.Env.SetCommandLine(cmd) }
 
 func (g *GlobalContext) SetUI(u UI) { g.UI = u }
+
+func (g *GlobalContext) SetEKLib(ekLib EKLib) { g.ekLib = ekLib }
 
 func (g *GlobalContext) Init() *GlobalContext {
 	g.Env = NewEnv(nil, nil, g.GetLog)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -629,6 +629,10 @@ type UserEKBoxStorage interface {
 	ClearCache()
 }
 
+type EKLib interface {
+	KeygenIfNeeded(ctx context.Context) error
+}
+
 type ImplicitTeamConflictInfoCacher interface {
 	Get(context.Context, bool, keybase1.TeamID) *keybase1.ImplicitTeamConflictInfo
 	Put(context.Context, bool, keybase1.TeamID, keybase1.ImplicitTeamConflictInfo) error

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -556,6 +556,9 @@ func (d *Service) hourlyChecks() {
 			d.G().Log.Debug("+ hourly check loop")
 			d.G().Log.Debug("| checking tracks on an hour timer")
 			libkb.CheckTracking(d.G())
+			d.G().Log.Debug("| checking if ephemeral keys need to be created or deleted")
+			ekLib := d.G().GetEKLib()
+			ekLib.KeygenIfNeeded(context.Background())
 			d.G().Log.Debug("| checking if current device revoked")
 			if err := d.G().LogoutIfRevoked(); err != nil {
 				d.G().Log.Debug("LogoutIfRevoked error: %s", err)

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -551,15 +551,23 @@ func (d *Service) hourlyChecks() {
 		if err := d.G().LogoutIfRevoked(); err != nil {
 			d.G().Log.Debug("LogoutIfRevoked error: %s", err)
 		}
-		ekLib := d.G().GetEKLib()
-		ekLib.KeygenIfNeeded(context.Background())
+		// TODO remove this when we want to release in the wild.
+		if ephemeral.ShouldRun(d.G()) {
+			ekLib := d.G().GetEKLib()
+			ekLib.KeygenIfNeeded(context.Background())
+		}
 		for {
 			<-ticker.C
 			d.G().Log.Debug("+ hourly check loop")
 			d.G().Log.Debug("| checking tracks on an hour timer")
 			libkb.CheckTracking(d.G())
-			d.G().Log.Debug("| checking if ephemeral keys need to be created or deleted")
-			ekLib.KeygenIfNeeded(context.Background())
+
+			// TODO remove this when we want to release in the wild.
+			if ephemeral.ShouldRun(d.G()) {
+				ekLib := d.G().GetEKLib()
+				d.G().Log.Debug("| checking if ephemeral keys need to be created or deleted")
+				ekLib.KeygenIfNeeded(context.Background())
+			}
 			d.G().Log.Debug("| checking if current device revoked")
 			if err := d.G().LogoutIfRevoked(); err != nil {
 				d.G().Log.Debug("LogoutIfRevoked error: %s", err)

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -551,13 +551,14 @@ func (d *Service) hourlyChecks() {
 		if err := d.G().LogoutIfRevoked(); err != nil {
 			d.G().Log.Debug("LogoutIfRevoked error: %s", err)
 		}
+		ekLib := d.G().GetEKLib()
+		ekLib.KeygenIfNeeded(context.Background())
 		for {
 			<-ticker.C
 			d.G().Log.Debug("+ hourly check loop")
 			d.G().Log.Debug("| checking tracks on an hour timer")
 			libkb.CheckTracking(d.G())
 			d.G().Log.Debug("| checking if ephemeral keys need to be created or deleted")
-			ekLib := d.G().GetEKLib()
 			ekLib.KeygenIfNeeded(context.Background())
 			d.G().Log.Debug("| checking if current device revoked")
 			if err := d.G().LogoutIfRevoked(); err != nil {


### PR DESCRIPTION
depends on #10914 and #10923 

We generation keys once a day and check during login/hourly if we need to regenerate. during these checks we also cleanup any stale keys.