### PR TITLE
mock out timestamp functions

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -188,7 +188,6 @@
     "json5": "0.5.1",
     "klaw-sync": "3.0.2",
     "minimist": "1.2.0",
-    "moment-timezone": "^0.5.14",
     "null-loader": "0.1.1",
     "pegjs": "0.10.0",
     "raf": "3.4.0",

--- a/shared/stories/__tests__/Storyshots.test.js
+++ b/shared/stories/__tests__/Storyshots.test.js
@@ -2,12 +2,5 @@
 /* eslint-env jest */
 // eslint-disable-next-line
 import initStoryshots from '@storybook/addon-storyshots'
-import 'jest'
-
-jest.mock('moment', () => {
-  const moment = jest.requireActual('moment-timezone')
-  moment.tz.setDefault('UTC')
-  return moment
-})
-
+jest.mock('../../util/timestamp')
 initStoryshots()

--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -28527,7 +28527,7 @@ exports[`Storyshots Files Preview 1`] = `
             onClick={undefined}
             title={undefined}
           >
-            Modified on Feb 07 10:55 AM by foobar
+            Modified on [mocked] by foobar
           </span>
         </div>
       </div>

--- a/shared/util/__mocks__/timestamp.js
+++ b/shared/util/__mocks__/timestamp.js
@@ -1,0 +1,19 @@
+// @flow
+
+export function formatTimeForConversationList(time: number, nowOverride?: ?number): string {
+  return '[mocked]'
+}
+
+export function formatTimeForMessages(time: number, nowOverride?: number): string {
+  return '[mocked]'
+}
+
+export const formatTimeForFS = (time: number): string => '[mocked]'
+
+export function formatTimeForPopup(time: number): string {
+  return '[mocked]'
+}
+
+export function formatTimeForRevoked(time: number): string {
+  return '[mocked]'
+}

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -7382,13 +7382,7 @@ mksnapshot@^0.3.0:
     fs-extra "0.26.7"
     request "^2.79.0"
 
-moment-timezone@^0.5.14:
-  version "0.5.14"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.14.tgz#4eb38ff9538b80108ba467a458f3ed4268ccfcb1"
-  dependencies:
-    moment ">= 2.9.0"
-
-moment@2.21.0, "moment@>= 2.9.0":
+moment@2.21.0:
   version "2.21.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 


### PR DESCRIPTION
@keybase/react-hackers cc: @jzila 
Just mocking out our timestamp functions
moment is kinda messed up in the jest world due to packaging issues. This is the easiest fix i could find 2nite