### PR TITLE
Do not autologout in teams tests

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -161,6 +161,10 @@ type TestParameters struct {
 
 	// set to true to use production run mode in tests
 	UseProductionRunMode bool
+
+	// whether LogoutIfRevoked check should be skipped to avoid races
+	// during resets.
+	SkipLogoutIfRevokedCheck bool
 }
 
 func (tp TestParameters) GetDebug() (bool, bool) {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -689,6 +689,12 @@ func (e *Env) GetUpgradePerUserKey() bool {
 	return !e.Test.DisableUpgradePerUserKey
 }
 
+// If true, do not logout after user.key_change notification handler
+// decides that current device has been revoked.
+func (e *Env) GetSkipLogoutIfRevokedCheck() bool {
+	return e.Test.SkipLogoutIfRevokedCheck
+}
+
 func (e *Env) GetProxy() string {
 	return e.GetString(
 		func() string { return e.cmd.GetProxy() },

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -921,7 +921,7 @@ func (g *GlobalContext) LogoutIfRevoked() error {
 		return nil
 	}
 
-	if g.Env.Test.SkipLogoutIfRevokedCheck {
+	if g.Env.GetSkipLogoutIfRevokedCheck() {
 		g.Log.Debug("LogoutIfRevoked: skipping check (SkipLogoutIfRevokedCheck)")
 		return nil
 	}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -921,6 +921,11 @@ func (g *GlobalContext) LogoutIfRevoked() error {
 		return nil
 	}
 
+	if g.Env.Test.SkipLogoutIfRevokedCheck {
+		g.Log.Debug("LogoutIfRevoked: skipping check (SkipLogoutIfRevokedCheck)")
+		return nil
+	}
+
 	me, err := LoadMe(NewLoadUserForceArg(g))
 	if err != nil {
 		return err

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -150,6 +150,7 @@ func (tt *teamTester) addUserHelper(pre string, puk bool, paper bool) *userPlusD
 	if !puk {
 		tctx.Tp.DisableUpgradePerUserKey = true
 	}
+
 	var u userPlusDevice
 	u.device = &deviceWrapper{tctx: tctx}
 	u.device.start(0)
@@ -695,6 +696,7 @@ func (u *userPlusDevice) provisionNewDevice() *deviceWrapper {
 }
 
 func (u *userPlusDevice) reset() {
+	u.device.tctx.Tp.SkipLogoutIfRevokedCheck = true
 	uvBefore := u.userVersion()
 	err := u.device.userClient.ResetUser(context.TODO(), 0)
 	require.NoError(u.tc.T, err)


### PR DESCRIPTION
Current theory for CI failures like this one:
```
2018-03-14 13:56:39.91109 engine.go:67           : [I] - RunEngine(PerUserKeyUpgrade) -> ERROR: Login required
	assertions.go:239: 
                          
	Error Trace:	teams_test.go:782
			team_implicit_reset_test.go:281
			team_implicit_reset_test.go:319
		
	Error:      	Received unexpected error:
	            	Login required
		
	Messages:   	Run engine.NewPerUserKeyUpgrade
	test_logger.go:56: TEST FAILED: TestImplicitResetPUKtoNoPUK
```
is that during reset and reprovision, if user.key_change notification comes at the perfect time, it will log test user out immediately after logging in, leaving them in logged out state.

This PR adds ability to disable LogoutIfRevoked check in tests.