### PR TITLE
add ability to cancel/lock background conv loader CORE-7439

### DIFF
--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -116,15 +116,17 @@ func (b *BackgroundConvLoader) Suspend(ctx context.Context) (canceled bool) {
 	return canceled
 }
 
-func (b *BackgroundConvLoader) Resume(ctx context.Context) {
+func (b *BackgroundConvLoader) Resume(ctx context.Context) bool {
 	b.Lock()
 	defer b.Unlock()
 	if b.suspendCount > 0 {
 		b.suspendCount--
 		if b.suspendCount == 0 && b.resumeCh != nil {
 			close(b.resumeCh)
+			return true
 		}
 	}
+	return false
 }
 
 func (b *BackgroundConvLoader) enqueue(ctx context.Context, task clTask) error {

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	bgLoaderMaxAttempts = 4
+	bgLoaderMaxAttempts = 10
 	bgLoaderInitDelay   = 100 * time.Millisecond
 	bgLoaderErrDelay    = 300 * time.Millisecond
 )
@@ -199,12 +199,10 @@ func (b *BackgroundConvLoader) newQueue() {
 }
 
 func (b *BackgroundConvLoader) retriableError(err error) bool {
-	if err == context.Canceled {
+	if IsOfflineError(err) != OfflineErrorKindOnline {
 		return true
 	}
-	switch lerr := err.(type) {
-	case UnboxingError:
-		return !lerr.IsPermanent()
+	switch err.(type) {
 	case storage.AbortedError:
 		return true
 	}

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -40,10 +40,7 @@ func TestConvLoader(t *testing.T) {
 	tc, world, listener, res := setupLoaderTest(t)
 	defer world.Cleanup()
 
-	if err := tc.Context().ConvLoader.Queue(context.TODO(), res.ConvID); err != nil {
-		t.Fatal(err)
-	}
-
+	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(), res.ConvID))
 	select {
 	case convID := <-listener.bgConvLoads:
 		if !convID.Eq(res.ConvID) {
@@ -51,5 +48,52 @@ func TestConvLoader(t *testing.T) {
 		}
 	case <-time.After(20 * time.Second):
 		t.Fatal("timeout waiting for conversation load")
+	}
+}
+
+type slowestRemote struct {
+	chat1.RemoteInterface
+	callCh chan struct{}
+}
+
+func makeSlowestRemote() slowestRemote {
+	return slowestRemote{
+		callCh: make(chan struct{}, 5),
+	}
+}
+
+func (s slowestRemote) GetThreadRemote(ctx context.Context, arg chat1.GetThreadRemoteArg) (res chat1.GetThreadRemoteRes, err error) {
+	s.callCh <- struct{}{}
+	select {
+	case <-ctx.Done():
+	case <-time.After(24 * time.Hour):
+	}
+	return res, nil
+}
+
+func TestConvLoaderSuspend(t *testing.T) {
+	tc, world, listener, res := setupLoaderTest(t)
+	defer world.Cleanup()
+
+	ri := tc.ChatG.ConvSource.(*HybridConversationSource).ri
+	slowRi := makeSlowestRemote()
+	tc.ChatG.ConvSource.(*HybridConversationSource).ri = func() chat1.RemoteInterface {
+		return slowRi
+	}
+	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(), res.ConvID))
+	select {
+	case <-slowRi.callCh:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no remote call")
+	}
+	require.True(t, tc.Context().ConvLoader.Suspend(context.TODO()))
+
+	tc.ChatG.ConvSource.(*HybridConversationSource).ri = ri
+	tc.Context().ConvLoader.Resume(context.TODO())
+	select {
+	case convID := <-listener.bgConvLoads:
+		require.Equal(t, res.ConvID, convID)
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no event")
 	}
 }

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -87,9 +87,21 @@ func TestConvLoaderSuspend(t *testing.T) {
 		require.Fail(t, "no remote call")
 	}
 	require.True(t, tc.Context().ConvLoader.Suspend(context.TODO()))
+	select {
+	case <-listener.bgConvLoads:
+		require.Fail(t, "no load yet")
+	default:
+	}
+	require.True(t, tc.Context().ConvLoader.Suspend(context.TODO()))
 
 	tc.ChatG.ConvSource.(*HybridConversationSource).ri = ri
-	tc.Context().ConvLoader.Resume(context.TODO())
+	require.False(t, tc.Context().ConvLoader.Resume(context.TODO()))
+	select {
+	case <-listener.bgConvLoads:
+		require.Fail(t, "no load yet")
+	default:
+	}
+	require.True(t, tc.Context().ConvLoader.Resume(context.TODO()))
 	select {
 	case convID := <-listener.bgConvLoads:
 		require.Equal(t, res.ConvID, convID)

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -134,6 +134,9 @@ func (h *Server) presentUnverifiedInbox(ctx context.Context, convs []types.Remot
 	return res, err
 }
 
+// suspendConvLoader will suspend the global ConvLoader until the return function is called. This allows
+// a succinct call like defer suspendConvLoader(ctx)() in RPC handlers wishing to lock out the
+// conv loader.
 func (h *Server) suspendConvLoader(ctx context.Context) func() {
 	if canceled := h.G().ConvLoader.Suspend(ctx); canceled {
 		h.Debug(ctx, "suspendConvLoader: canceled background task")

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -171,10 +171,11 @@ func (h *Server) presentUnverifiedInbox(ctx context.Context, convs []types.Remot
 }
 
 func (h *Server) suspendConvLoader(ctx context.Context) func() {
-	h.G().ConvLoader.CancelActiveLoad(ctx)
-	h.G().ConvLoader.Stop(ctx)
+	if canceled := h.G().ConvLoader.Suspend(ctx); canceled {
+		h.Debug(ctx, "suspendConvLoader: canceled background task")
+	}
 	return func() {
-		h.G().ConvLoader.Start(ctx, h.getUID())
+		h.G().ConvLoader.Resume(ctx)
 	}
 }
 

--- a/go/chat/storage/errors.go
+++ b/go/chat/storage/errors.go
@@ -108,3 +108,31 @@ func (e VersionMismatchError) ShouldClear() bool {
 func (e VersionMismatchError) Message() string {
 	return e.Error()
 }
+
+type AbortedError struct{}
+
+func NewAbortedError() AbortedError {
+	return AbortedError{}
+}
+
+func (e AbortedError) Error() string {
+	return "request aborted"
+}
+
+func (e AbortedError) ShouldClear() bool {
+	return false
+}
+
+func (e AbortedError) Message() string {
+	return e.Error()
+}
+
+func isAbortedRequest(ctx context.Context) Error {
+	// Check context for aborted request
+	select {
+	case <-ctx.Done():
+		return NewAbortedError()
+	default:
+	}
+	return nil
+}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -109,9 +109,11 @@ func (i *Inbox) dbKey() libkb.DbKey {
 }
 
 func (i *Inbox) readDiskInbox(ctx context.Context) (inboxDiskData, Error) {
-
 	var ibox inboxDiskData
-
+	// Check context for an aborted request
+	if err := isAbortedRequest(ctx); err != nil {
+		return ibox, err
+	}
 	// Check in memory cache first
 	if memibox := inboxMemCache.Get(i.uid); memibox != nil {
 		i.Debug(ctx, "hit in memory cache")
@@ -127,7 +129,6 @@ func (i *Inbox) readDiskInbox(ctx context.Context) (inboxDiskData, Error) {
 		}
 		inboxMemCache.Put(i.uid, &ibox)
 	}
-
 	// Check on disk server version against known server version
 	if _, err := i.G().ServerCacheVersions.MatchInbox(ctx, ibox.ServerVersion); err != nil {
 		i.Debug(ctx, "server version match error, clearing: %s", err.Error())

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -175,6 +175,7 @@ type ConvLoader interface {
 	Resumable
 
 	Queue(ctx context.Context, convID chat1.ConversationID) error
+	CancelActiveLoad(ctx context.Context)
 }
 
 type PushHandler interface {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -175,7 +175,8 @@ type ConvLoader interface {
 	Resumable
 
 	Queue(ctx context.Context, convID chat1.ConversationID) error
-	CancelActiveLoad(ctx context.Context)
+	Suspend(ctx context.Context) bool
+	Resume(ctx context.Context)
 }
 
 type PushHandler interface {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -176,7 +176,7 @@ type ConvLoader interface {
 
 	Queue(ctx context.Context, convID chat1.ConversationID) error
 	Suspend(ctx context.Context) bool
-	Resume(ctx context.Context)
+	Resume(ctx context.Context) bool
 }
 
 type PushHandler interface {


### PR DESCRIPTION
Patch does the following:

1.) Add two new functions to `ConvLoader`, `Suspend` and `Resume` which are intended to preempt the background conv loader in the case of foreground activity. 
2.) Implement `Suspend` to cancel any oustanding background load, and then place a lock on any further attempts.
3.) `Resume` will only restart if it has cleared all previous `Suspend` calls.
4.) Have all UI relevant service endpoints suspend the conv loader.
5.) Expand set of errors conv loaders retries on, and extends the number of attempts each task gets. 