### PR TITLE
Guard against field ordering issue

### DIFF
--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -678,7 +678,7 @@ func (c *ChainLink) Unpack(trusted bool, selfUID keybase1.UID, packed []byte) er
 			ol2.SeqType = keybase1.SeqType_PUBLIC
 		}
 		tmp.outerLinkV2 = ol2
-		sigKID = ol2.KID
+		sigKID = ol2.kid
 	}
 
 	payloadKID = tmp.kid

--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -2,9 +2,11 @@ package libkb
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
 )
 
 // See comment at top of sig_chain.go for a description of V1, V2 and
@@ -151,6 +153,10 @@ type OuterLinkV2 struct {
 	IgnoreIfUnsupported bool `codec:"ignore_if_unsupported"`
 }
 
+func (o OuterLinkV2) Encode() ([]byte, error) {
+	return MsgpackEncode(o)
+}
+
 type OuterLinkV2WithMetadata struct {
 	OuterLinkV2
 	raw   []byte
@@ -159,8 +165,17 @@ type OuterLinkV2WithMetadata struct {
 	kid   keybase1.KID
 }
 
-func (o OuterLinkV2) Encode() ([]byte, error) {
-	return MsgpackEncode(o)
+var _ codec.Selfer = (*OuterLinkV2WithMetadata)(nil)
+
+var errCodecEncodeSelf = errors.New("Unexpected call to OuterLinkV2WithMetadata.CodecEncodeSelf")
+var errCodecDecodeSelf = errors.New("Unexpected call to OuterLinkV2WithMetadata.CodecDecodeSelf")
+
+func (o *OuterLinkV2WithMetadata) CodecEncodeSelf(e *codec.Encoder) {
+	panic(errCodecEncodeSelf)
+}
+
+func (o *OuterLinkV2WithMetadata) CodecDecodeSelf(d *codec.Decoder) {
+	panic(errCodecDecodeSelf)
 }
 
 type SigIgnoreIfUnsupported bool

--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -165,6 +165,10 @@ type OuterLinkV2WithMetadata struct {
 	kid   keybase1.KID
 }
 
+// An OuterLinkV2WithMetadata should never be encoded/decoded
+// directly. This is to avoid problems like
+// https://github.com/keybase/saltpack/pull/43 .
+
 var _ codec.Selfer = (*OuterLinkV2WithMetadata)(nil)
 
 var errCodecEncodeSelf = errors.New("Unexpected call to OuterLinkV2WithMetadata.CodecEncodeSelf")

--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -156,7 +156,7 @@ type OuterLinkV2WithMetadata struct {
 	raw   []byte
 	sigID keybase1.SigID
 	sig   string
-	KID   keybase1.KID
+	kid   keybase1.KID
 }
 
 func (o OuterLinkV2) Encode() ([]byte, error) {
@@ -232,7 +232,7 @@ func (o OuterLinkV2WithMetadata) Raw() []byte {
 }
 
 func (o OuterLinkV2WithMetadata) Verify(ctx VerifyContext) (kid keybase1.KID, err error) {
-	key, err := ImportKeypairFromKID(o.KID)
+	key, err := ImportKeypairFromKID(o.kid)
 	if err != nil {
 		return kid, err
 	}
@@ -240,7 +240,7 @@ func (o OuterLinkV2WithMetadata) Verify(ctx VerifyContext) (kid keybase1.KID, er
 	if err != nil {
 		return kid, err
 	}
-	return o.KID, nil
+	return o.kid, nil
 }
 
 func DecodeOuterLinkV2(armored string) (*OuterLinkV2WithMetadata, error) {
@@ -257,7 +257,7 @@ func DecodeOuterLinkV2(armored string) (*OuterLinkV2WithMetadata, error) {
 		OuterLinkV2: ol,
 		sigID:       sigID,
 		raw:         payload,
-		KID:         kid,
+		kid:         kid,
 		sig:         armored,
 	}
 	return &ret, nil

--- a/go/libkb/chain_link_v2_test.go
+++ b/go/libkb/chain_link_v2_test.go
@@ -52,6 +52,22 @@ func TestOuterLinkV2WithMetadataPointerEmbedderDecode(t *testing.T) {
 	require.Equal(t, errCodecDecodeSelf, err)
 }
 
+type outerLinkV2WithMetadataContainer struct {
+	o OuterLinkV2WithMetadata
+}
+
+func TestOuterLinkV2WithMetadataContainerEncode(t *testing.T) {
+	var o outerLinkV2WithMetadataContainer
+	_, err := MsgpackEncode(o)
+	require.Equal(t, errCodecEncodeSelf, err)
+}
+
+func TestOuterLinkV2WithMetadataContainerDecode(t *testing.T) {
+	var o outerLinkV2WithMetadataContainer
+	err := MsgpackDecode(&o, []byte{0x1, 0x2})
+	require.Equal(t, errCodecDecodeSelf, err)
+}
+
 type withMetadataContainer struct {
 	o OuterLinkV2WithMetadata
 }

--- a/go/libkb/chain_link_v2_test.go
+++ b/go/libkb/chain_link_v2_test.go
@@ -53,7 +53,7 @@ func TestOuterLinkV2WithMetadataPointerEmbedderDecode(t *testing.T) {
 }
 
 type outerLinkV2WithMetadataContainer struct {
-	o OuterLinkV2WithMetadata
+	O OuterLinkV2WithMetadata
 }
 
 func TestOuterLinkV2WithMetadataContainerEncode(t *testing.T) {
@@ -63,27 +63,35 @@ func TestOuterLinkV2WithMetadataContainerEncode(t *testing.T) {
 }
 
 func TestOuterLinkV2WithMetadataContainerDecode(t *testing.T) {
+	bytes, err := MsgpackEncode(map[string]interface{}{
+		"O": []byte{0x01, 0x02},
+	})
+	require.NoError(t, err)
+
 	var o outerLinkV2WithMetadataContainer
-	err := MsgpackDecode(&o, []byte{0x1, 0x2})
+	err = MsgpackDecode(&o, bytes)
 	require.Equal(t, errCodecDecodeSelf, err)
 }
 
-type withMetadataContainer struct {
-	o OuterLinkV2WithMetadata
+type outerLinkV2WithMetadataPointerContainer struct {
+	O *OuterLinkV2WithMetadata
 }
 
-type withMetadataPointerContainer struct {
-	o *OuterLinkV2WithMetadata
-}
-
-func TestOuterLinkV2ContainerCodec(t *testing.T) {
-	var c1 withMetadataContainer
-	_, err := MsgpackEncode(c1)
-	require.NoError(t, err)
-
-	c2 := withMetadataPointerContainer{
-		o: &OuterLinkV2WithMetadata{},
+func TestOuterLinkV2WithMetadataPointerContainerEncode(t *testing.T) {
+	o := outerLinkV2WithMetadataPointerContainer{
+		O: &OuterLinkV2WithMetadata{},
 	}
-	_, err = MsgpackEncode(c2)
+	_, err := MsgpackEncode(o)
+	require.Equal(t, errCodecEncodeSelf, err)
+}
+
+func TestOuterLinkV2WithMetadataPointerContainerDecode(t *testing.T) {
+	bytes, err := MsgpackEncode(map[string]interface{}{
+		"O": []byte{0x01, 0x02},
+	})
 	require.NoError(t, err)
+
+	var o outerLinkV2WithMetadataPointerContainer
+	err = MsgpackDecode(&o, bytes)
+	require.Equal(t, errCodecDecodeSelf, err)
 }

--- a/go/libkb/chain_link_v2_test.go
+++ b/go/libkb/chain_link_v2_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOuterLinkV2Encode(t *testing.T) {
+func TestOuterLinkV2WithMetadataEncode(t *testing.T) {
 	var o OuterLinkV2WithMetadata
 	_, err := MsgpackEncode(o)
 	require.Equal(t, errCodecEncodeSelf, err)
@@ -14,8 +14,40 @@ func TestOuterLinkV2Encode(t *testing.T) {
 	require.Equal(t, errCodecEncodeSelf, err)
 }
 
-func TestOuterLinkV2Decode(t *testing.T) {
+func TestOuterLinkV2WithMetadataDecode(t *testing.T) {
 	var o OuterLinkV2WithMetadata
+	err := MsgpackDecode(&o, []byte{0x1, 0x2})
+	require.Equal(t, errCodecDecodeSelf, err)
+}
+
+type outerLinkV2WithMetadataEmbedder struct {
+	OuterLinkV2WithMetadata
+}
+
+func TestOuterLinkV2WithMetadataEmbedderEncode(t *testing.T) {
+	var o outerLinkV2WithMetadataEmbedder
+	_, err := MsgpackEncode(o)
+	require.Equal(t, errCodecEncodeSelf, err)
+}
+
+func TestOuterLinkV2WithMetadataEmbedderDecode(t *testing.T) {
+	var o outerLinkV2WithMetadataEmbedder
+	err := MsgpackDecode(&o, []byte{0x1, 0x2})
+	require.Equal(t, errCodecDecodeSelf, err)
+}
+
+type outerLinkV2WithMetadataPointerEmbedder struct {
+	*OuterLinkV2WithMetadata
+}
+
+func TestOuterLinkV2WithMetadataPointerEmbedderEncode(t *testing.T) {
+	var o outerLinkV2WithMetadataPointerEmbedder
+	_, err := MsgpackEncode(o)
+	require.Equal(t, errCodecEncodeSelf, err)
+}
+
+func TestOuterLinkV2WithMetadataPointerEmbedderDecode(t *testing.T) {
+	var o outerLinkV2WithMetadataPointerEmbedder
 	err := MsgpackDecode(&o, []byte{0x1, 0x2})
 	require.Equal(t, errCodecDecodeSelf, err)
 }

--- a/go/libkb/chain_link_v2_test.go
+++ b/go/libkb/chain_link_v2_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test that various ways in which OuterLinkV2WithMetadata may be
+// encoded/decoded all fail.
+
 func TestOuterLinkV2WithMetadataEncode(t *testing.T) {
 	var o OuterLinkV2WithMetadata
 	_, err := MsgpackEncode(o)

--- a/go/libkb/chain_link_v2_test.go
+++ b/go/libkb/chain_link_v2_test.go
@@ -1,0 +1,41 @@
+package libkb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOuterLinkV2Encode(t *testing.T) {
+	var o OuterLinkV2WithMetadata
+	_, err := MsgpackEncode(o)
+	require.Equal(t, errCodecEncodeSelf, err)
+	_, err = MsgpackEncode(&o)
+	require.Equal(t, errCodecEncodeSelf, err)
+}
+
+func TestOuterLinkV2Decode(t *testing.T) {
+	var o OuterLinkV2WithMetadata
+	err := MsgpackDecode(&o, []byte{0x1, 0x2})
+	require.Equal(t, errCodecDecodeSelf, err)
+}
+
+type withMetadataContainer struct {
+	o OuterLinkV2WithMetadata
+}
+
+type withMetadataPointerContainer struct {
+	o *OuterLinkV2WithMetadata
+}
+
+func TestOuterLinkV2ContainerCodec(t *testing.T) {
+	var c1 withMetadataContainer
+	_, err := MsgpackEncode(c1)
+	require.NoError(t, err)
+
+	c2 := withMetadataPointerContainer{
+		o: &OuterLinkV2WithMetadata{},
+	}
+	_, err = MsgpackEncode(c2)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
The OuterLinkV2WithMetadata type embeds a type that has `toarray`, which is
susceptible to https://github.com/keybase/saltpack/pull/43 . Add code and tests
to make sure that objects of that type aren't actually encoded/decoded.

Also make KID field unexported.