### PR TITLE
re-enable background conv loader on mobile, and control it during app state changes CORE-7440

### DIFF
--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -20,14 +20,12 @@ type identifyNotifierKey int
 type chatTrace int
 type identifyModeKey int
 type upakfinderKey int
-type bgOperationKey int
 
 var kfKey keyfinderKey
 var inKey identifyNotifierKey
 var chatTraceKey chatTrace
 var identModeKey identifyModeKey
 var upKey upakfinderKey
-var bgOpKey bgOperationKey
 
 type identModeData struct {
 	mode   keybase1.TLFIdentifyBehavior
@@ -81,14 +79,6 @@ func CtxUPAKFinder(ctx context.Context, g *globals.Context) types.UPAKFinder {
 	return NewCachingUPAKFinder(g)
 }
 
-func CtxIsBackgroundOperation(ctx context.Context) bool {
-	val := ctx.Value(bgOpKey)
-	if _, ok := val.(bool); ok {
-		return true
-	}
-	return false
-}
-
 func CtxModifyIdentifyNotifier(ctx context.Context, notifier types.IdentifyNotifier) context.Context {
 	return context.WithValue(ctx, inKey, notifier)
 }
@@ -120,10 +110,6 @@ func CtxAddLogTags(ctx context.Context, env appTypeSource) context.Context {
 	ctx = rpc.AddRpcTagsToContext(ctx, rpcTags)
 
 	return ctx
-}
-
-func CtxSetBackgroundOperation(ctx context.Context) context.Context {
-	return context.WithValue(ctx, bgOpKey, true)
 }
 
 func Context(ctx context.Context, g *globals.Context, mode keybase1.TLFIdentifyBehavior,

--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -20,12 +20,14 @@ type identifyNotifierKey int
 type chatTrace int
 type identifyModeKey int
 type upakfinderKey int
+type bgOperationKey int
 
 var kfKey keyfinderKey
 var inKey identifyNotifierKey
 var chatTraceKey chatTrace
 var identModeKey identifyModeKey
 var upKey upakfinderKey
+var bgOpKey bgOperationKey
 
 type identModeData struct {
 	mode   keybase1.TLFIdentifyBehavior
@@ -79,6 +81,14 @@ func CtxUPAKFinder(ctx context.Context, g *globals.Context) types.UPAKFinder {
 	return NewCachingUPAKFinder(g)
 }
 
+func CtxIsBackgroundOperation(ctx context.Context) bool {
+	val := ctx.Value(bgOpKey)
+	if _, ok := val.(bool); ok {
+		return true
+	}
+	return false
+}
+
 func CtxModifyIdentifyNotifier(ctx context.Context, notifier types.IdentifyNotifier) context.Context {
 	return context.WithValue(ctx, inKey, notifier)
 }
@@ -110,6 +120,10 @@ func CtxAddLogTags(ctx context.Context, env appTypeSource) context.Context {
 	ctx = rpc.AddRpcTagsToContext(ctx, rpcTags)
 
 	return ctx
+}
+
+func CtxSetBackgroundOperation(ctx context.Context) context.Context {
+	return context.WithValue(ctx, bgOpKey, true)
 }
 
 func Context(ctx context.Context, g *globals.Context, mode keybase1.TLFIdentifyBehavior,

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -110,10 +110,6 @@ func (b *BackgroundConvLoader) Start(ctx context.Context, uid gregor1.UID) {
 	b.newQueue()
 	b.started = true
 	b.uid = uid
-	// On mobile fresh start, apply the foreground wait
-	if b.G().GetAppType() == libkb.MobileAppType {
-		b.clock.Sleep(b.resumeWait)
-	}
 	go b.loop()
 }
 
@@ -209,6 +205,11 @@ func (b *BackgroundConvLoader) loop() {
 		<-ch
 		b.clock.Sleep(b.resumeWait)
 		b.Debug(bgctx, "waitForResume: resuming loop")
+	}
+	// On mobile fresh start, apply the foreground wait
+	if b.G().GetAppType() == libkb.MobileAppType {
+		b.Debug(bgctx, "loop: delaying startup since on mobile")
+		b.clock.Sleep(b.resumeWait)
 	}
 	for {
 		// get a convID from queue, or stop

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -62,7 +62,7 @@ func NewBackgroundConvLoader(g *globals.Context) *BackgroundConvLoader {
 	b := &BackgroundConvLoader{
 		Contextified:  globals.NewContextified(g),
 		DebugLabeler:  utils.NewDebugLabeler(g.GetLog(), "BackgroundConvLoader", false),
-		stopCh:        make(chan chan struct{}),
+		stopCh:        make(chan chan struct{}, 5),
 		suspendCh:     make(chan chan struct{}, 10),
 		identNotifier: NewCachingIdentifyNotifier(g),
 		clock:         clockwork.NewRealClock(),

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,13 +65,22 @@ func makeSlowestRemote() slowestRemote {
 	}
 }
 
-func (s slowestRemote) GetThreadRemote(ctx context.Context, arg chat1.GetThreadRemoteArg) (res chat1.GetThreadRemoteRes, err error) {
+func (s slowestRemote) delay(ctx context.Context) {
 	s.callCh <- struct{}{}
 	select {
 	case <-ctx.Done():
 	case <-time.After(24 * time.Hour):
 	}
-	return res, nil
+}
+
+func (s slowestRemote) GetThreadRemote(ctx context.Context, arg chat1.GetThreadRemoteArg) (res chat1.GetThreadRemoteRes, err error) {
+	s.delay(ctx)
+	return res, context.Canceled
+}
+
+func (s slowestRemote) GetMessagesRemote(ctx context.Context, arg chat1.GetMessagesRemoteArg) (res chat1.GetMessagesRemoteRes, err error) {
+	s.delay(ctx)
+	return res, context.Canceled
 }
 
 func TestConvLoaderSuspend(t *testing.T) {
@@ -108,4 +120,101 @@ func TestConvLoaderSuspend(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no event")
 	}
+}
+
+func TestConvLoaderAppState(t *testing.T) {
+	tc, world, listener, res := setupLoaderTest(t)
+	defer world.Cleanup()
+
+	clock := clockwork.NewFakeClock()
+	appStateCh := make(chan struct{})
+	tc.ChatG.ConvLoader.(*BackgroundConvLoader).clock = clock
+	tc.ChatG.ConvLoader.(*BackgroundConvLoader).appStateCh = appStateCh
+	ri := tc.ChatG.ConvSource.(*HybridConversationSource).ri
+	slowRi := makeSlowestRemote()
+	failDuration := 2 * time.Second
+	uid := gregor1.UID(tc.G.Env.GetUID().ToBytes())
+
+	// Test that a foreground with no background doesnt do anything
+	tc.ChatG.ConvSource.(*HybridConversationSource).ri = func() chat1.RemoteInterface {
+		return slowRi
+	}
+	tc.ChatG.ConvSource.(*HybridConversationSource).Clear(res.ConvID, uid)
+	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(), res.ConvID))
+	clock.BlockUntil(1)
+	clock.Advance(200 * time.Millisecond) // Get by small sleep
+	select {
+	case <-slowRi.callCh:
+	case <-time.After(failDuration):
+		require.Fail(t, "no remote call")
+	}
+	require.True(t, tc.Context().ConvLoader.Suspend(context.TODO()))
+	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
+	select {
+	case <-appStateCh:
+	case <-time.After(failDuration):
+		require.Fail(t, "no app state")
+	}
+	select {
+	case <-listener.bgConvLoads:
+		require.Fail(t, "no load yet")
+	default:
+	}
+	tc.ChatG.ConvSource.(*HybridConversationSource).ri = ri
+	require.True(t, tc.Context().ConvLoader.Resume(context.TODO()))
+	clock.BlockUntil(1)
+	clock.Advance(2 * time.Second) // Get by resume wait
+	clock.BlockUntil(1)
+	clock.Advance(time.Hour) // Get by small sleep
+	select {
+	case convID := <-listener.bgConvLoads:
+		require.Equal(t, res.ConvID, convID)
+	case <-time.After(failDuration):
+		require.Fail(t, "no event")
+	}
+
+	t.Logf("testing foreground/background")
+	// Test that background/foreground works
+	tc.ChatG.ConvSource.(*HybridConversationSource).Clear(res.ConvID, uid)
+	tc.ChatG.ConvSource.(*HybridConversationSource).ri = func() chat1.RemoteInterface {
+		return slowRi
+	}
+	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(), res.ConvID))
+	clock.BlockUntil(1)
+	clock.Advance(200 * time.Millisecond) // Get by small sleep
+	select {
+	case <-slowRi.callCh:
+	case <-time.After(failDuration):
+		require.Fail(t, "no remote call")
+	}
+	tc.G.AppState.Update(keybase1.AppState_BACKGROUND)
+	select {
+	case <-appStateCh:
+	case <-time.After(failDuration):
+		require.Fail(t, "no app state")
+	}
+	tc.ChatG.ConvSource.(*HybridConversationSource).ri = ri
+	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
+	select {
+	case <-appStateCh:
+	case <-time.After(failDuration):
+		require.Fail(t, "no app state")
+	}
+	// Need to advance clock
+	select {
+	case <-listener.bgConvLoads:
+		require.Fail(t, "no load yet")
+	default:
+	}
+	clock.BlockUntil(1)
+	clock.Advance(10 * time.Second)
+	clock.BlockUntil(1)
+	clock.Advance(time.Hour) // Get by small sleep
+	select {
+	case convID := <-listener.bgConvLoads:
+		require.Equal(t, res.ConvID, convID)
+	case <-time.After(failDuration):
+		require.Fail(t, "no event")
+	}
+
 }

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -725,6 +725,7 @@ func TestConversationLockingDeadlock(t *testing.T) {
 	tc := world.Tcs[u.Username]
 	syncer := NewSyncer(tc.Context())
 	syncer.isConnected = true
+	<-tc.Context().ConvLoader.Stop(context.TODO())
 	hcs := tc.Context().ConvSource.(*HybridConversationSource)
 	if hcs == nil {
 		t.Skip()

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -534,7 +534,8 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 		}
 
 		// Queue all these convs up to be loaded by the background loader (cap it at first 50)
-		if index < 50 {
+		// Also make sure we aren't here because of a background loader operation
+		if index < 50 && !CtxIsBackgroundOperation(ctx) {
 			if err := s.G().ConvLoader.Queue(ctx, conv.GetConvID()); err != nil {
 				s.Debug(ctx, "fetchRemoteInbox: failed to queue conversation load: %s", err)
 			}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -535,7 +535,7 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 
 		// Queue all these convs up to be loaded by the background loader (cap it at first 50)
 		// Also make sure we aren't here because of a background loader operation
-		if index < 50 && !CtxIsBackgroundOperation(ctx) {
+		if index < 50 {
 			if err := s.G().ConvLoader.Queue(ctx, conv.GetConvID()); err != nil {
 				s.Debug(ctx, "fetchRemoteInbox: failed to queue conversation load: %s", err)
 			}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -524,11 +524,20 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 	if err != nil {
 		return types.Inbox{}, ib.RateLimit, err
 	}
-	// Need to run expunge on anything we fetch from the server
-	for _, conv := range ib.Inbox.Full().Conversations {
+
+	// Run any tasks on the fetched conversations
+	for index, conv := range ib.Inbox.Full().Conversations {
+		// Need to run expunge on anything we fetch from the server
 		expunge := conv.GetExpunge()
 		if expunge != nil {
 			s.G().ConvSource.Expunge(ctx, conv.GetConvID(), uid, *expunge)
+		}
+
+		// Queue all these convs up to be loaded by the background loader (cap it at first 50)
+		if index < 50 {
+			if err := s.G().ConvLoader.Queue(ctx, conv.GetConvID()); err != nil {
+				s.Debug(ctx, "fetchRemoteInbox: failed to queue conversation load: %s", err)
+			}
 		}
 	}
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -278,7 +278,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	h := NewServer(g, nil, nil, testUISource{})
 	uid := gregor1.UID(user.User.GetUID().ToBytes())
 
-	var tlf kbtest.TlfMock
+	var tlf *kbtest.TlfMock
 	var ri chat1.RemoteInterface
 	if useRemoteMock {
 		mockRemote := kbtest.NewChatRemoteMock(c.world)

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -349,8 +349,8 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		}
 
 		// Queue background conversation loads
-		for _, convID := range utils.PluckConvIDs(incr.Convs) {
-			if err := s.G().ConvLoader.Queue(ctx, convID); err != nil {
+		for _, conv := range incr.Convs {
+			if err := s.G().ConvLoader.Queue(ctx, conv.GetConvID()); err != nil {
 				s.Debug(ctx, "Sync: failed to queue conversation load: %s", err)
 			}
 		}

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -8,7 +8,6 @@ import (
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -350,12 +349,9 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		}
 
 		// Queue background conversation loads
-		// MM: 12/03/2017 Let's not do this on mobile, it is too much load
-		if s.G().GetAppType() != libkb.MobileAppType {
-			for _, convID := range utils.PluckConvIDs(incr.Convs) {
-				if err := s.G().ConvLoader.Queue(ctx, convID); err != nil {
-					s.Debug(ctx, "Sync: failed to queue conversation load: %s", err)
-				}
+		for _, convID := range utils.PluckConvIDs(incr.Convs) {
+			if err := s.G().ConvLoader.Queue(ctx, convID); err != nil {
+				s.Debug(ctx, "Sync: failed to queue conversation load: %s", err)
 			}
 		}
 	}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -179,6 +179,8 @@ func (m *TlfMock) newTLFID() chat1.TLFID {
 }
 
 func (m *TlfMock) getTlfID(cname keybase1.CanonicalTlfName) (keybase1.TLFID, error) {
+	m.Lock()
+	defer m.Unlock()
 	tlfID, ok := m.world.tlfs[cname]
 	if !ok {
 		for _, n := range strings.Split(string(cname), ",") {
@@ -194,8 +196,6 @@ func (m *TlfMock) getTlfID(cname keybase1.CanonicalTlfName) (keybase1.TLFID, err
 }
 
 func (m *TlfMock) Lookup(ctx context.Context, tlfName string, public bool) (res *types.NameInfo, err error) {
-	m.Lock()
-	defer m.Unlock()
 	var tlfID keybase1.TLFID
 	res = types.NewNameInfo()
 	name := CanonicalTlfNameForTest(tlfName)
@@ -233,8 +233,6 @@ func (m *TlfMock) DecryptionKeys(ctx context.Context, tlfName string, tlfID chat
 }
 
 func (m *TlfMock) CryptKeys(ctx context.Context, tlfName string) (res keybase1.GetTLFCryptKeysRes, err error) {
-	m.Lock()
-	defer m.Unlock()
 	res.NameIDBreaks.CanonicalName = CanonicalTlfNameForTest(tlfName)
 	if res.NameIDBreaks.TlfID, err = m.getTlfID(res.NameIDBreaks.CanonicalName); err != nil {
 		return keybase1.GetTLFCryptKeysRes{}, err
@@ -248,8 +246,6 @@ func (m *TlfMock) CryptKeys(ctx context.Context, tlfName string) (res keybase1.G
 }
 
 func (m *TlfMock) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, tlfName string) (keybase1.CanonicalTLFNameAndIDWithBreaks, error) {
-	m.Lock()
-	defer m.Unlock()
 	var res keybase1.CanonicalTLFNameAndIDWithBreaks
 	res.CanonicalName = CanonicalTlfNameForTest(tlfName)
 	var err error

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -152,11 +153,12 @@ func mustGetRandCryptKeys(controlled byte) []keybase1.CryptKey {
 }
 
 type TlfMock struct {
+	sync.Mutex
 	world *ChatMockWorld
 }
 
-func NewTlfMock(world *ChatMockWorld) TlfMock {
-	return TlfMock{world}
+func NewTlfMock(world *ChatMockWorld) *TlfMock {
+	return &TlfMock{world: world}
 }
 
 func CanonicalTlfNameForTest(tlfName string) keybase1.CanonicalTlfName {
@@ -167,7 +169,7 @@ func CanonicalTlfNameForTest(tlfName string) keybase1.CanonicalTlfName {
 	return keybase1.CanonicalTlfName(strings.Join(names, ","))
 }
 
-func (m TlfMock) newTLFID() chat1.TLFID {
+func (m *TlfMock) newTLFID() chat1.TLFID {
 	suffix := byte(0x29)
 	idBytes, err := libkb.RandBytesWithSuffix(16, suffix)
 	if err != nil {
@@ -176,7 +178,7 @@ func (m TlfMock) newTLFID() chat1.TLFID {
 	return chat1.TLFID(idBytes)
 }
 
-func (m TlfMock) getTlfID(cname keybase1.CanonicalTlfName) (keybase1.TLFID, error) {
+func (m *TlfMock) getTlfID(cname keybase1.CanonicalTlfName) (keybase1.TLFID, error) {
 	tlfID, ok := m.world.tlfs[cname]
 	if !ok {
 		for _, n := range strings.Split(string(cname), ",") {
@@ -191,7 +193,9 @@ func (m TlfMock) getTlfID(cname keybase1.CanonicalTlfName) (keybase1.TLFID, erro
 	return keybase1.TLFID(hex.EncodeToString([]byte(tlfID))), nil
 }
 
-func (m TlfMock) Lookup(ctx context.Context, tlfName string, public bool) (res *types.NameInfo, err error) {
+func (m *TlfMock) Lookup(ctx context.Context, tlfName string, public bool) (res *types.NameInfo, err error) {
+	m.Lock()
+	defer m.Unlock()
 	var tlfID keybase1.TLFID
 	res = types.NewNameInfo()
 	name := CanonicalTlfNameForTest(tlfName)
@@ -217,18 +221,20 @@ func (m TlfMock) Lookup(ctx context.Context, tlfName string, public bool) (res *
 	return res, nil
 }
 
-func (m TlfMock) EncryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (m *TlfMock) EncryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (*types.NameInfo, error) {
 	return m.Lookup(ctx, tlfName, public)
 }
 
-func (m TlfMock) DecryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (m *TlfMock) DecryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
 	keyGeneration int, kbfsEncrypted bool) (*types.NameInfo, error) {
 	return m.Lookup(ctx, tlfName, public)
 }
 
-func (m TlfMock) CryptKeys(ctx context.Context, tlfName string) (res keybase1.GetTLFCryptKeysRes, err error) {
+func (m *TlfMock) CryptKeys(ctx context.Context, tlfName string) (res keybase1.GetTLFCryptKeysRes, err error) {
+	m.Lock()
+	defer m.Unlock()
 	res.NameIDBreaks.CanonicalName = CanonicalTlfNameForTest(tlfName)
 	if res.NameIDBreaks.TlfID, err = m.getTlfID(res.NameIDBreaks.CanonicalName); err != nil {
 		return keybase1.GetTLFCryptKeysRes{}, err
@@ -241,7 +247,9 @@ func (m TlfMock) CryptKeys(ctx context.Context, tlfName string) (res keybase1.Ge
 	return res, nil
 }
 
-func (m TlfMock) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, tlfName string) (keybase1.CanonicalTLFNameAndIDWithBreaks, error) {
+func (m *TlfMock) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, tlfName string) (keybase1.CanonicalTLFNameAndIDWithBreaks, error) {
+	m.Lock()
+	defer m.Unlock()
 	var res keybase1.CanonicalTLFNameAndIDWithBreaks
 	res.CanonicalName = CanonicalTlfNameForTest(tlfName)
 	var err error
@@ -252,7 +260,7 @@ func (m TlfMock) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, tlfN
 	return res, nil
 }
 
-func (m TlfMock) PublicCanonicalTLFNameAndID(ctx context.Context, tlfName string) (keybase1.CanonicalTLFNameAndIDWithBreaks, error) {
+func (m *TlfMock) PublicCanonicalTLFNameAndID(ctx context.Context, tlfName string) (keybase1.CanonicalTLFNameAndIDWithBreaks, error) {
 	res := keybase1.CanonicalTLFNameAndIDWithBreaks{
 		CanonicalName: keybase1.CanonicalTlfName(tlfName),
 		TlfID:         "abcdefg",


### PR DESCRIPTION
Patch does the following:

1.) Turns the background conv loader back on for mobile, triggering on incremental sync, as well as the first 50 conversations of a remote fetch. 
2.) Invoke a `Suspend` call when backgrounding the app, and delay the resume by a second on foreground. This is an attempt to try and reduce the churn on foreground. 
3.) Apply that same 1 second delay on a fresh start on mobile.
4.) Prevent the background conv loader from queuing any convos into itself during a load. 
