### PR TITLE
Systests and AccelerateTeamRekeyd: change work_time_sec to 10 sec

### DIFF
--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -783,16 +783,20 @@ func (u *userPlusDevice) perUserKeyUpgrade() {
 }
 
 func kickTeamRekeyd(g *libkb.GlobalContext, t libkb.TestingTB) {
+	const workTimeSec = 10 // team_rekeyd delay before retrying job if it wasn't finished.
+	args := libkb.HTTPArgs{
+		"work_time_sec": libkb.I{Val: workTimeSec},
+	}
 	apiArg := libkb.APIArg{
 		Endpoint:    "test/accelerate_team_rekeyd",
-		Args:        libkb.HTTPArgs{},
+		Args:        args,
 		SessionType: libkb.APISessionTypeREQUIRED,
 	}
 
+	t.Logf("Calling accelerate_team_rekeyd, setting work_time_sec to %d", workTimeSec)
+
 	_, err := g.API.Post(apiArg)
-	if err != nil {
-		t.Fatalf("Failed to accelerate team rekeyd: %s", err)
-	}
+	require.NoError(t, err)
 }
 
 func GetTeamForTestByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*teams.Team, error) {

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -783,7 +783,7 @@ func (u *userPlusDevice) perUserKeyUpgrade() {
 }
 
 func kickTeamRekeyd(g *libkb.GlobalContext, t libkb.TestingTB) {
-	const workTimeSec = 10 // team_rekeyd delay before retrying job if it wasn't finished.
+	const workTimeSec = 3 // team_rekeyd delay before retrying job if it wasn't finished.
 	args := libkb.HTTPArgs{
 		"work_time_sec": libkb.I{Val: workTimeSec},
 	}


### PR DESCRIPTION
Despite team_rekeyd being accelerated in tests, it would still try to send one message and then postpone work for 60 seconds. So if for some reason it chooses wrong tribute or the gregor message does not go through, it's game over for the test. Changing this variable to 10 seconds make it possible for the work message to be retried few times before giving up.