### PR TITLE
change the EK protocol, sign over existing keys

### DIFF
--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -14,6 +14,10 @@ const KeyLifetimeSecs = 60 * 60 * 24 * 7 // one week
 // Everyday we want to generate a new key if possible
 const KeyGenLifetimeSecs = 60 * 60 * 24 // one day
 
+func ctimeIsStale(ctime keybase1.Time, currentMerkleRoot libkb.MerkleRoot) bool {
+	return currentMerkleRoot.Ctime()-ctime.UnixSeconds() > KeyLifetimeSecs
+}
+
 // We should wrap any entry points to the library with this before we're ready
 // to fully release it.
 func ShouldRun(g *libkb.GlobalContext) bool {
@@ -29,13 +33,16 @@ func makeNewRandomSeed() (seed keybase1.Bytes32, err error) {
 
 }
 
-func deriveDHKey(k keybase1.Bytes32, reason libkb.DeriveReason) (key *libkb.NaclDHKeyPair, err error) {
+func deriveDHKey(k keybase1.Bytes32, reason libkb.DeriveReason) *libkb.NaclDHKeyPair {
 	derived, err := libkb.DeriveFromSecret(k, reason)
 	if err != nil {
-		return nil, err
+		panic("This should never fail: " + err.Error())
 	}
 	keypair, err := libkb.MakeNaclDHKeyPairFromSecret(derived)
-	return &keypair, err
+	if err != nil {
+		panic("This should never fail: " + err.Error())
+	}
+	return &keypair
 }
 
 func newEKSeedFromBytes(b []byte) (seed keybase1.Bytes32, err error) {

--- a/go/ephemeral/device_ek_test.go
+++ b/go/ephemeral/device_ek_test.go
@@ -25,7 +25,7 @@ func TestNewDeviceEK(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, deviceEK.Metadata, publishedMetadata)
 
-	fetchedDevices, err := getActiveDeviceEKMetadata(context.Background(), tc.G, merkleRoot)
+	fetchedDevices, err := getAllActiveDeviceEKMetadata(context.Background(), tc.G, merkleRoot)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(fetchedDevices))

--- a/go/ephemeral/user_ek_box_storage_test.go
+++ b/go/ephemeral/user_ek_box_storage_test.go
@@ -36,8 +36,7 @@ func TestUserEKBoxStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	seed := UserEKSeed(userEK.Seed)
-	keypair, err := seed.DeriveDHKey()
-	require.NoError(t, err)
+	keypair := seed.DeriveDHKey()
 	require.Equal(t, userEKMetadata.Kid, keypair.GetKID())
 
 	// Test MaxGeneration
@@ -57,8 +56,7 @@ func TestUserEKBoxStorage(t *testing.T) {
 	require.True(t, ok)
 
 	seed = UserEKSeed(userEK.Seed)
-	keypair, err = seed.DeriveDHKey()
-	require.NoError(t, err)
+	keypair = seed.DeriveDHKey()
 	require.Equal(t, userEKMetadata.Kid, keypair.GetKID())
 
 	// Let's delete our deviceEK and verify we can't unbox the userEK

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -616,6 +616,7 @@ type TeamLoader interface {
 type DeviceEKStorage interface {
 	Put(ctx context.Context, generation keybase1.EkGeneration, deviceEK keybase1.DeviceEk) (err error)
 	Get(ctx context.Context, generation keybase1.EkGeneration) (deviceEK keybase1.DeviceEk, err error)
+	GetAllActive(ctx context.Context, merkleRoot MerkleRoot) (metadatas []keybase1.DeviceEkMetadata, err error)
 	MaxGeneration(ctx context.Context) (maxGeneration keybase1.EkGeneration, err error)
 	DeleteExpired(ctx context.Context, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	ClearCache()

--- a/go/protocol/keybase1/ephemeral.go
+++ b/go/protocol/keybase1/ephemeral.go
@@ -13,6 +13,28 @@ func (o EkGeneration) DeepCopy() EkGeneration {
 	return o
 }
 
+type DeviceEkStatement struct {
+	CurrentDeviceEk   DeviceEkMetadata   `codec:"currentDeviceEk" json:"current_device_ek"`
+	ExistingDeviceEks []DeviceEkMetadata `codec:"existingDeviceEks" json:"existing_device_eks"`
+}
+
+func (o DeviceEkStatement) DeepCopy() DeviceEkStatement {
+	return DeviceEkStatement{
+		CurrentDeviceEk: o.CurrentDeviceEk.DeepCopy(),
+		ExistingDeviceEks: (func(x []DeviceEkMetadata) []DeviceEkMetadata {
+			if x == nil {
+				return nil
+			}
+			var ret []DeviceEkMetadata
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ExistingDeviceEks),
+	}
+}
+
 type DeviceEkMetadata struct {
 	Kid        KID          `codec:"kid" json:"device_ephemeral_dh_public"`
 	HashMeta   HashMeta     `codec:"hashMeta" json:"hash_meta"`
@@ -38,6 +60,28 @@ func (o DeviceEk) DeepCopy() DeviceEk {
 	return DeviceEk{
 		Seed:     o.Seed.DeepCopy(),
 		Metadata: o.Metadata.DeepCopy(),
+	}
+}
+
+type UserEkStatement struct {
+	CurrentUserEk   UserEkMetadata   `codec:"currentUserEk" json:"current_user_ek"`
+	ExistingUserEks []UserEkMetadata `codec:"existingUserEks" json:"existing_user_eks"`
+}
+
+func (o UserEkStatement) DeepCopy() UserEkStatement {
+	return UserEkStatement{
+		CurrentUserEk: o.CurrentUserEk.DeepCopy(),
+		ExistingUserEks: (func(x []UserEkMetadata) []UserEkMetadata {
+			if x == nil {
+				return nil
+			}
+			var ret []UserEkMetadata
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ExistingUserEks),
 	}
 }
 

--- a/protocol/avdl/keybase1/ephemeral.avdl
+++ b/protocol/avdl/keybase1/ephemeral.avdl
@@ -7,6 +7,19 @@ protocol ephemeral {
   @typedef("int64")
   record EkGeneration {}
 
+  // NOTE: The device/user/team structs are very similar here, so it might seem
+  // like a good idea to unify them. However! One thing we have to be careful
+  // with is that signatures of one type don't get confused for another type.
+  // Thus we use distinct field names like "device_ephemeral_dh_public" and
+  // "user_ephemeral_dh_public". If anyone ever tries to refactor all these
+  // structs, please be careful with this detail.
+  record DeviceEkStatement {
+    @jsonkey("current_device_ek")
+    DeviceEkMetadata currentDeviceEk;
+    @jsonkey("existing_device_eks")
+    array<DeviceEkMetadata> existingDeviceEks;
+  }
+
   record DeviceEkMetadata {
     @jsonkey("device_ephemeral_dh_public")
     KID kid;
@@ -19,6 +32,13 @@ protocol ephemeral {
   record DeviceEk {
     Bytes32 seed;
     DeviceEkMetadata metadata;
+  }
+
+  record UserEkStatement {
+    @jsonkey("current_user_ek")
+    UserEkMetadata currentUserEk;
+    @jsonkey("existing_user_eks")
+    array<UserEkMetadata> existingUserEks;
   }
 
   record UserEkMetadata {

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2201,6 +2201,8 @@ export type DeviceEk = $ReadOnly<{seed: Bytes32, metadata: DeviceEkMetadata}>
 
 export type DeviceEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation: EkGeneration, ctime: Time}>
 
+export type DeviceEkStatement = $ReadOnly<{currentDeviceEk: DeviceEkMetadata, existingDeviceEks?: ?Array<DeviceEkMetadata>}>
+
 export type DeviceID = String
 
 export type DeviceType =
@@ -3980,6 +3982,8 @@ export type UserEk = $ReadOnly<{seed: Bytes32, metadata: UserEkMetadata}>
 export type UserEkBoxed = $ReadOnly<{box: String, deviceEkGeneration: EkGeneration, metadata: UserEkMetadata}>
 
 export type UserEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation: EkGeneration, ctime: Time}>
+
+export type UserEkStatement = $ReadOnly<{currentUserEk: UserEkMetadata, existingUserEks?: ?Array<UserEkMetadata>}>
 
 export type UserGetUPAKRpcParam = $ReadOnly<{uid: UID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 

--- a/protocol/json/keybase1/ephemeral.json
+++ b/protocol/json/keybase1/ephemeral.json
@@ -16,6 +16,25 @@
     },
     {
       "type": "record",
+      "name": "DeviceEkStatement",
+      "fields": [
+        {
+          "type": "DeviceEkMetadata",
+          "name": "currentDeviceEk",
+          "jsonkey": "current_device_ek"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "DeviceEkMetadata"
+          },
+          "name": "existingDeviceEks",
+          "jsonkey": "existing_device_eks"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "DeviceEkMetadata",
       "fields": [
         {
@@ -49,6 +68,25 @@
         {
           "type": "DeviceEkMetadata",
           "name": "metadata"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "UserEkStatement",
+      "fields": [
+        {
+          "type": "UserEkMetadata",
+          "name": "currentUserEk",
+          "jsonkey": "current_user_ek"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "UserEkMetadata"
+          },
+          "name": "existingUserEks",
+          "jsonkey": "existing_user_eks"
         }
       ]
     },

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2201,6 +2201,8 @@ export type DeviceEk = $ReadOnly<{seed: Bytes32, metadata: DeviceEkMetadata}>
 
 export type DeviceEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation: EkGeneration, ctime: Time}>
 
+export type DeviceEkStatement = $ReadOnly<{currentDeviceEk: DeviceEkMetadata, existingDeviceEks?: ?Array<DeviceEkMetadata>}>
+
 export type DeviceID = String
 
 export type DeviceType =
@@ -3980,6 +3982,8 @@ export type UserEk = $ReadOnly<{seed: Bytes32, metadata: UserEkMetadata}>
 export type UserEkBoxed = $ReadOnly<{box: String, deviceEkGeneration: EkGeneration, metadata: UserEkMetadata}>
 
 export type UserEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation: EkGeneration, ctime: Time}>
+
+export type UserEkStatement = $ReadOnly<{currentUserEk: UserEkMetadata, existingUserEks?: ?Array<UserEkMetadata>}>
 
 export type UserGetUPAKRpcParam = $ReadOnly<{uid: UID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 


### PR DESCRIPTION
We're going to need to be able to verify teamEKs other than the most
recent one, when we start doing pairwise MAC'ing in chat. That means
the latest PTK needs to sign over all still-valid generations of the
teamEK, not just the most recent. So instead of this sig:

{
  team_ephemeral_dh_public: ...
  generation: ...
  hash_meta: ...
}

We now need this one:

{
  current_team_ek: {
    team_ephemeral_dh_public: ...
    generation: ...
    hash_meta: ...
    ctime: ...  # adding this in to save the client a fetch
  },
  existing_team_eks: [
    { ... older teamEK blob like the one above ... },
    ...
  ]
}

Make this change, and a similar change for userEKs and deviceEKs, for
consistency.

This depends on https://github.com/keybase/keybase/pull/2235, and tests
will be broken until both are landed.