### PR TITLE
dummy test [ignore this PR]

### DIFF
--- a/go/ephemeral/device_ek_test.go
+++ b/go/ephemeral/device_ek_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestJackDummy(t *testing.T) {
+	panic("deliberate failure to test CI")
+}
+
 func TestNewDeviceEK(t *testing.T) {
 	tc := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()


### PR DESCRIPTION
I want to make sure failing an ephemeral key test fails CI. It's a new module in the client repo, and I'm not 100% sure we don't need to whitelist it somewhere.