### PR TITLE
osx: ignore unmount errors for the redirector

### DIFF
--- a/osx/Helper/KBHelper.m
+++ b/osx/Helper/KBHelper.m
@@ -198,8 +198,7 @@
   NSError *error = nil;
   [self unmount:directory error:&error];
   if (error) {
-    completion(error, nil);
-    return;
+    KBLog(@"Ignoring unmount error: %@", error);
   }
 
   // First create the directory.
@@ -240,8 +239,7 @@
   NSError *error = nil;
   [self unmount:directory error:&error];
   if (error) {
-    completion(error, nil);
-    return;
+    KBLog(@"Ignoring unmount error: %@", error);
   }
 
   if (self.redirector) {


### PR DESCRIPTION
If nothing is mounted at /keybase when startRedirector is called, then the NSTask.waitUntilExit may call or may not throw an exception, depending on whether the task is finished or not before the call is made.  This might explain the few errors people have seen installing the redirector at startup. Most of the time the NSTask would finish quickly enough that there would be no error, and the startRedirector command would succeed, but once in a while it would fail.

So instead just log the error and ignore it, since it doesn't really matter.