### PR TITLE
Fix resolver for public teams

### DIFF
--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -382,6 +382,9 @@ func (r *Resolver) resolveTeamViaServerLookup(ctx context.Context, au AssertionU
 	arg.Args = make(HTTPArgs)
 	arg.Args[key] = S{Val: val}
 	arg.Args["lookup_only"] = B{Val: true}
+	if res.queriedByTeamID && au.ToTeamID().IsPublic() {
+		arg.Args["public"] = B{Val: true}
+	}
 
 	var lookup teamLookup
 	if err := r.G().API.GetDecode(arg, &lookup); err != nil {

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -247,17 +247,20 @@ func TestTeamReInviteAfterReset(t *testing.T) {
 	require.Equal(t, details.Members.Admins[0].Username, bob.username)
 }
 
-func TestImpTeamWithRooter(t *testing.T) {
+func testImpTeamWithRooterParametrized(t *testing.T, public bool) {
+	t.Logf("testImpTeamWithRooterParametrized(public=%t)", public)
+
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
 	alice := tt.addUser("alice")
 	bob := tt.addUser("bob")
+	tt.logUserNames()
 
 	rooterUser := bob.username + "@rooter"
 	displayName := strings.Join([]string{alice.username, rooterUser}, ",")
 
-	team, err := alice.lookupImplicitTeam(true /*create*/, displayName, false /*isPublic*/)
+	team, err := alice.lookupImplicitTeam(true /*create*/, displayName, public)
 	require.NoError(t, err)
 
 	t.Logf("Created implicit team %v\n", team)
@@ -272,14 +275,35 @@ func TestImpTeamWithRooter(t *testing.T) {
 	// Poll for new team name, without the "@rooter"
 	newDisplayName := strings.Join([]string{alice.username, bob.username}, ",")
 
-	team2, err := alice.lookupImplicitTeam(false /*create*/, newDisplayName, false /*isPublic*/)
-	require.NoError(t, err)
-	require.Equal(t, team, team2)
+	lookupAs := func(u *userPlusDevice) {
+		team2, err := u.lookupImplicitTeam(false /*create*/, newDisplayName, public)
+		require.NoError(t, err)
+		require.Equal(t, team, team2)
 
-	// Lookup by old name should get the same result
-	team2, err = alice.lookupImplicitTeam(false /*create*/, displayName, false /*isPublic*/)
-	require.NoError(t, err)
-	require.Equal(t, team, team2)
+		// Lookup by old name should get the same result
+		team2, err = u.lookupImplicitTeam(false /*create*/, displayName, public)
+		require.NoError(t, err)
+		require.Equal(t, team, team2)
+
+		// Test resolver
+		_, err = teams.ResolveIDToName(context.Background(), u.tc.G, team)
+		require.NoError(t, err)
+	}
+
+	lookupAs(alice)
+	lookupAs(bob)
+
+	if public {
+		doug := tt.addUser("doug")
+		t.Logf("Signed up %s (%s) to test public access", doug.username, doug.uid)
+
+		lookupAs(doug)
+	}
+}
+
+func TestImpTeamWithRooter(t *testing.T) {
+	testImpTeamWithRooterParametrized(t, false /* public */)
+	testImpTeamWithRooterParametrized(t, true /* public */)
 }
 
 func TestImpTeamWithRooterConflict(t *testing.T) {

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -79,6 +79,11 @@ func TestLookupImplicitTeams(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, teamDisplay, formatName)
 		require.Equal(t, team.IsPublic(), public)
+
+		expr := fmt.Sprintf("tid:%s", createdTeam.ID)
+		rres := tc.G.Resolver.ResolveFullExpressionNeedUsername(context.Background(), expr)
+		require.NoError(t, rres.GetError())
+		require.True(t, rres.GetTeamID().Exists())
 	}
 
 	displayName := strings.Join(usernames, ",")


### PR DESCRIPTION
Resolver was failing with teams because it did not pass `public` argument to `team/get` endpoint. Added parametrised implicit teams tests to check both public and private teams, but I think this issue also affected non-impteams, so maybe more tests are needed.

PR also brings in attempt at fixing the resolver, but it works only for team id URLs because only from them we can derive whether team is public or not.