### PR TITLE
Fix team green link retry

### DIFF
--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -292,6 +292,7 @@ func (l *TeamLoader) load2InnerLocked(ctx context.Context, arg load2ArgT) (res *
 		case GreenLinkError:
 			// Try again
 			l.G().Log.CDebugf(ctx, "TeamLoader retrying after green link")
+			arg.forceRepoll = true
 			continue
 		}
 		return res, err


### PR DESCRIPTION
When a GreenLinkError happens, retry with ForceRepoll. Otherwise you'll keep getting the same thing.

I think this is a bug that has always been here where a GreenLinkError will not get retried effectively if the fetch happened for any reason other than ForceRepoll. (NeedKeyGen, etc)

cc @strib 