### PR TITLE
add an http server that starts on a random port

### DIFF
--- a/go/libkb/httpsrv.go
+++ b/go/libkb/httpsrv.go
@@ -1,0 +1,60 @@
+package libkb
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+)
+
+// RandomPortHTTPSrv starts a simple HTTP server on a random port and and exposes all the methods
+// of http.ServeMux
+type RandomPortHTTPSrv struct {
+	sync.Mutex
+	server *http.Server
+	*http.ServeMux
+}
+
+func NewRandomPortHTTPSrv() *RandomPortHTTPSrv {
+	return &RandomPortHTTPSrv{}
+}
+
+func (h *RandomPortHTTPSrv) Start() (err error) {
+	h.Lock()
+	defer h.Unlock()
+	h.ServeMux = http.NewServeMux()
+	localhost := "127.0.0.1"
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", localhost))
+	if err != nil {
+		return err
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	address := fmt.Sprintf("%s:%d", localhost, port)
+	h.server = &http.Server{
+		Addr:    address,
+		Handler: h.ServeMux,
+	}
+	go func() {
+		h.server.Serve(listener)
+	}()
+	return nil
+}
+
+func (h *RandomPortHTTPSrv) Addr() (string, error) {
+	h.Lock()
+	defer h.Unlock()
+	if h.server != nil {
+		return h.server.Addr, nil
+	}
+	return "", errors.New("server not running")
+}
+
+func (h *RandomPortHTTPSrv) Stop() {
+	h.Lock()
+	defer h.Unlock()
+	if h.server != nil {
+		h.server.Close()
+		h.server = nil
+	}
+}

--- a/go/libkb/httpsrv_test.go
+++ b/go/libkb/httpsrv_test.go
@@ -1,0 +1,28 @@
+package libkb
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandomPortHTTPSrv(t *testing.T) {
+	srv := NewRandomPortHTTPSrv()
+	require.NoError(t, srv.Start())
+	srv.HandleFunc("/test", func(resp http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(resp, "success")
+	})
+	addr, err := srv.Addr()
+	require.NoError(t, err)
+	url := fmt.Sprintf("http://%s/test", addr)
+	t.Logf("url: %s", url)
+	resp, err := http.Get(url)
+	require.NoError(t, err)
+	out, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "success", string(out))
+	srv.Stop()
+}


### PR DESCRIPTION
Patch introduces a new type `RandomPortHTTPSrv` which starts an HTTP server on a random port starting from 7000. The purpose of it is to serve some limited API to the frontend over `localhost`, such as serving locally stored avatars or chat attachment previews. 