### PR TITLE
fetch participants correctly for imp team chats CORE-7491

### DIFF
--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const inboxVersion = 19
+const inboxVersion = 20
 
 type queryHash []byte
 


### PR DESCRIPTION
The code that was there before I think was leftover from when imp team chats were using the internal name for TLF name (the `__keybase_implict_team_XXX` name). That's not true anymore, so there is no reason to try and load the team here. 

Also bump the inbox version since these blank participant lists were working their way into the inbox cache as well. 

cc @chrisnojima 