### PR TITLE
introduce two caching avatar sources CORE-7421

### DIFF
--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -1,0 +1,391 @@
+package avatars
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/lru"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type avatarLoadPair struct {
+	name   string
+	format keybase1.AvatarFormat
+	path   string
+}
+
+type avatarLoadSpec struct {
+	hits   []avatarLoadPair
+	misses []avatarLoadPair
+	stales []avatarLoadPair
+}
+
+func (a avatarLoadSpec) details(l []avatarLoadPair) (names []string, formats []keybase1.AvatarFormat) {
+	fmap := make(map[keybase1.AvatarFormat]bool)
+	umap := make(map[string]bool)
+	for _, m := range l {
+		umap[m.name] = true
+		fmap[m.format] = true
+	}
+	for u := range umap {
+		names = append(names, u)
+	}
+	for f := range fmap {
+		formats = append(formats, f)
+	}
+	return names, formats
+}
+
+func (a avatarLoadSpec) missDetails() ([]string, []keybase1.AvatarFormat) {
+	return a.details(a.misses)
+}
+
+func (a avatarLoadSpec) staleDetails() ([]string, []keybase1.AvatarFormat) {
+	return a.details(a.stales)
+}
+
+type populateArg struct {
+	name   string
+	format keybase1.AvatarFormat
+	url    keybase1.AvatarUrl
+}
+
+type FullCachingSource struct {
+	libkb.Contextified
+
+	diskLRU        *lru.DiskLRU
+	staleThreshold time.Duration
+	fallbackSource Source
+	simpleSource   Source
+	httpSrv        *libkb.HTTPSrv
+	fallbackMode   bool
+
+	populateCacheCh chan populateArg
+
+	// testing
+	populateSuccessCh chan struct{}
+	tempDir           string
+	forceHTTPSrv      bool
+}
+
+var _ Source = (*FullCachingSource)(nil)
+
+func NewFullCachingSource(g *libkb.GlobalContext, staleThreshold time.Duration, size int,
+	fallbackSource Source) *FullCachingSource {
+	return &FullCachingSource{
+		Contextified:   libkb.NewContextified(g),
+		diskLRU:        lru.NewDiskLRU("avatars", 1, size),
+		staleThreshold: staleThreshold,
+		fallbackSource: fallbackSource,
+		simpleSource:   NewSimpleSource(g),
+		httpSrv:        libkb.NewHTTPSrv(g, libkb.NewPortRangeListenerSource(7000, 8000)),
+	}
+}
+
+func (c *FullCachingSource) StartBackgroundTasks() {
+	c.fallbackSource.StartBackgroundTasks()
+	go c.monitorAppState()
+	c.populateCacheCh = make(chan populateArg, 100)
+	for i := 0; i < 10; i++ {
+		go c.populateCacheWorker()
+	}
+	// On mobile, using an HTTP interface is simpler so use it instead.
+	if c.httpServerMode() {
+		c.startHTTPServer(context.Background())
+	}
+}
+
+func (c *FullCachingSource) StopBackgroundTasks() {
+	c.fallbackSource.StopBackgroundTasks()
+	close(c.populateCacheCh)
+	c.fallbackMode = false
+	c.diskLRU.Flush(context.Background(), c.G())
+	if c.httpServerMode() {
+		c.httpSrv.Stop()
+	}
+}
+
+func (c *FullCachingSource) httpServerMode() bool {
+	return c.forceHTTPSrv || c.G().GetAppType() == libkb.MobileAppType
+}
+
+func (c *FullCachingSource) debug(ctx context.Context, msg string, args ...interface{}) {
+	c.G().Log.CDebugf(ctx, "Avatars.FullCachingSource: %s", fmt.Sprintf(msg, args...))
+}
+
+func (c *FullCachingSource) avatarKey(name string, format keybase1.AvatarFormat) string {
+	return fmt.Sprintf("%s:%s", name, format.String())
+}
+
+func (c *FullCachingSource) isStale(item lru.DiskLRUEntry) bool {
+	return c.G().GetClock().Now().Sub(item.Ctime) > c.staleThreshold
+}
+
+func (c *FullCachingSource) startHTTPServer(ctx context.Context) {
+	if err := c.httpSrv.Start(); err != nil {
+		c.debug(ctx, "failed to start local http server, defaulting to simple mode")
+		c.fallbackMode = true
+	} else {
+		c.fallbackMode = false
+		c.httpSrv.HandleFunc("/a", c.serveHTTPAvatar)
+	}
+}
+
+func (c *FullCachingSource) monitorAppState() {
+	c.debug(context.Background(), "monitorAppState: starting up")
+	for {
+		state := <-c.G().AppState.NextUpdate()
+		ctx := context.Background()
+		switch state {
+		case keybase1.AppState_FOREGROUND:
+			c.debug(ctx, "monitorAppState: foregrounded")
+			if c.httpServerMode() && !c.httpSrv.Active() {
+				c.debug(ctx, "monitorAppState: starting http server")
+				c.startHTTPServer(ctx)
+			}
+		case keybase1.AppState_BACKGROUND:
+			c.debug(ctx, "monitorAppState: backgrounded")
+			if c.httpServerMode() && c.httpSrv.Active() {
+				c.debug(ctx, "monitorAppState: backgrounded, stopping http server")
+				c.httpSrv.Stop()
+			}
+			c.diskLRU.Flush(ctx, c.G())
+		}
+	}
+}
+
+func (c *FullCachingSource) specLoad(ctx context.Context, names []string, formats []keybase1.AvatarFormat) (res avatarLoadSpec, err error) {
+	for _, name := range names {
+		for _, format := range formats {
+			key := c.avatarKey(name, format)
+			found, entry, err := c.diskLRU.Get(ctx, c.G(), key)
+			if err != nil {
+				return res, err
+			}
+			lp := avatarLoadPair{
+				name:   name,
+				format: format,
+			}
+
+			// If we found something in the index, let's make sure we have it on the disk as well.
+			if found {
+				lp.path = entry.Value.(string)
+				var file *os.File
+				if file, err = os.Open(lp.path); err != nil {
+					c.debug(ctx, "specLoad: error loading hit: file: %s err: %s", lp.path, err)
+					c.diskLRU.Remove(ctx, c.G(), key)
+					// Not a true hit if we don't have it on the disk as well
+					found = false
+				} else {
+					file.Close()
+				}
+			}
+			if found {
+				if c.isStale(entry) {
+					res.stales = append(res.stales, lp)
+				} else {
+					res.hits = append(res.hits, lp)
+				}
+			} else {
+				res.misses = append(res.misses, lp)
+			}
+		}
+	}
+	return res, nil
+}
+
+func (c *FullCachingSource) getCacheDir() string {
+	if len(c.tempDir) > 0 {
+		return c.tempDir
+	}
+	return c.G().GetCacheDir()
+}
+
+func (c *FullCachingSource) commitAvatarToDisk(ctx context.Context, data io.ReadCloser, previousPath string) (path string, err error) {
+	var file *os.File
+	if len(previousPath) > 0 {
+		// We already have the image, let's re-use the same file
+		c.debug(ctx, "commitAvatarToDisk: using previous path: %s", previousPath)
+		file, err = os.OpenFile(previousPath, os.O_RDWR, os.ModeAppend)
+	} else {
+		file, err = ioutil.TempFile(c.getCacheDir(), "avatar")
+	}
+	if err != nil {
+		return path, err
+	}
+	defer file.Close()
+	_, err = io.Copy(file, data)
+	if err != nil {
+		return path, err
+	}
+	path = file.Name()
+	return path, nil
+}
+
+func (c *FullCachingSource) removeFile(ctx context.Context, ent *lru.DiskLRUEntry) {
+	if ent != nil {
+		file := ent.Value.(string)
+		if err := os.Remove(file); err != nil {
+			c.debug(ctx, "removeFile: failed to remove: file: %s err: %s", file, err)
+		} else {
+			c.debug(ctx, "removeFile: successfully removed: %s", file)
+		}
+	}
+}
+
+func (c *FullCachingSource) populateCacheWorker() {
+	for arg := range c.populateCacheCh {
+		ctx := context.Background()
+		c.debug(ctx, "populateCacheWorker: fetching: name: %s format: %s url: %s", arg.name,
+			arg.format, arg.url)
+		// Grab image data first
+		resp, err := http.Get(arg.url.String())
+		if err != nil {
+			c.debug(ctx, "populateCacheWorker: failed to download avatar: %s", err)
+			continue
+		}
+		// Find any previous path we stored this image at on the disk
+		var previousPath string
+		key := c.avatarKey(arg.name, arg.format)
+		found, ent, err := c.diskLRU.Get(ctx, c.G(), key)
+		if err != nil {
+			c.debug(ctx, "populateCacheWorker: failed to read previous entry in LRU: %s", err)
+			continue
+		}
+		if found {
+			previousPath = ent.Value.(string)
+		}
+
+		// Save to disk
+		path, err := c.commitAvatarToDisk(ctx, resp.Body, previousPath)
+		if err != nil {
+			c.debug(ctx, "populateCacheWorker: failed to write to disk: %s", err)
+			continue
+		}
+		evicted, err := c.diskLRU.Put(ctx, c.G(), key, path)
+		if err != nil {
+			c.debug(ctx, "populateCacheWorker: failed to put into LRU: %s", err)
+			continue
+		}
+		// Remove any evicted file (if there is one)
+		c.removeFile(ctx, evicted)
+
+		if c.populateSuccessCh != nil {
+			c.populateSuccessCh <- struct{}{}
+		}
+	}
+}
+
+func (c *FullCachingSource) dispatchPopulateFromRes(ctx context.Context, res keybase1.LoadAvatarsRes) {
+	for name, rec := range res.Picmap {
+		for format, url := range rec {
+			if url != "" {
+				c.populateCacheCh <- populateArg{
+					name:   name,
+					format: format,
+					url:    url,
+				}
+			}
+		}
+	}
+}
+
+func (c *FullCachingSource) serveHTTPAvatar(w http.ResponseWriter, req *http.Request) {
+	path := req.URL.Query().Get("p")
+	// Check path prefix
+	file, err := os.Open(path)
+	if err != nil {
+		c.debug(context.Background(), "serveHTTPAvatar: failed to read: file: %s err: %s", path, err)
+		return
+	}
+	c.debug(context.Background(), "serveHTTPAvatar: successfully read file: %s", path)
+	w.Header().Add("Cache-Control", "no-cache")
+	io.Copy(w, file)
+	file.Close()
+}
+
+func (c *FullCachingSource) makeURL(path string) keybase1.AvatarUrl {
+	if c.httpServerMode() {
+		addr, _ := c.httpSrv.Addr()
+		return keybase1.MakeAvatarURL(fmt.Sprintf("http://%s/a?p=%s", addr, path))
+	}
+	return keybase1.MakeAvatarURL(fmt.Sprintf("file://%s", path))
+}
+
+func (c *FullCachingSource) mergeRes(res *keybase1.LoadAvatarsRes, m keybase1.LoadAvatarsRes) {
+	for username, rec := range m.Picmap {
+		for format, url := range rec {
+			res.Picmap[username][format] = url
+		}
+	}
+}
+
+func (c *FullCachingSource) loadNames(ctx context.Context, names []string, formats []keybase1.AvatarFormat,
+	remoteFetch func(context.Context, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)) (res keybase1.LoadAvatarsRes, err error) {
+	loadSpec, err := c.specLoad(ctx, names, formats)
+	if err != nil {
+		return res, err
+	}
+	c.debug(ctx, "loadNames: hits: %d stales: %d misses: %d", len(loadSpec.hits), len(loadSpec.stales),
+		len(loadSpec.misses))
+
+	// Fill in the hits
+	allocRes(&res, names)
+	for _, hit := range loadSpec.hits {
+		res.Picmap[hit.name][hit.format] = c.makeURL(hit.path)
+	}
+	// Fill in stales
+	for _, stale := range loadSpec.stales {
+		res.Picmap[stale.name][stale.format] = c.makeURL(stale.path)
+	}
+
+	// Go get the misses
+	missNames, missFormats := loadSpec.missDetails()
+	if len(missNames) > 0 {
+		loadRes, err := remoteFetch(ctx, missNames, missFormats)
+		if err == nil {
+			c.mergeRes(&res, loadRes)
+			c.dispatchPopulateFromRes(ctx, loadRes)
+		} else {
+			c.debug(ctx, "loadNames: failed to load server miss reqs: %s", err)
+		}
+	}
+	// Spawn off a goroutine to reload stales
+	staleNames, staleFormats := loadSpec.staleDetails()
+	if len(staleNames) > 0 {
+		go func() {
+			c.debug(context.Background(), "loadNames: spawning stale background load: names: %d",
+				len(staleNames))
+			loadRes, err := remoteFetch(context.Background(), staleNames, staleFormats)
+			if err == nil {
+				c.dispatchPopulateFromRes(ctx, loadRes)
+			} else {
+				c.debug(ctx, "loadNames: failed to load server stale reqs: %s", err)
+			}
+		}()
+	}
+	return res, nil
+}
+
+func (c *FullCachingSource) LoadUsers(ctx context.Context, usernames []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
+	defer c.G().Trace("FullCachingSource.LoadUsers", func() error { return err })()
+	// If we failed to startup our HTTP server, we just don't do any caching
+	if c.fallbackMode {
+		return c.fallbackSource.LoadUsers(ctx, usernames, formats)
+	}
+	return c.loadNames(ctx, usernames, formats, c.simpleSource.LoadUsers)
+}
+
+func (c *FullCachingSource) LoadTeams(ctx context.Context, teams []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
+	defer c.G().Trace("FullCachingSource.LoadTeams", func() error { return err })()
+	if c.fallbackMode {
+		return c.fallbackSource.LoadTeams(ctx, teams, formats)
+	}
+	return c.loadNames(ctx, teams, formats, c.simpleSource.LoadTeams)
+}

--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -62,7 +62,6 @@ type FullCachingSource struct {
 	diskLRU        *lru.DiskLRU
 	staleThreshold time.Duration
 	simpleSource   Source
-	httpSrv        *libkb.HTTPSrv
 
 	populateCacheCh chan populateArg
 
@@ -79,7 +78,6 @@ func NewFullCachingSource(g *libkb.GlobalContext, staleThreshold time.Duration, 
 		diskLRU:        lru.NewDiskLRU("avatars", 1, size),
 		staleThreshold: staleThreshold,
 		simpleSource:   NewSimpleSource(g),
-		httpSrv:        libkb.NewHTTPSrv(g, libkb.NewPortRangeListenerSource(7000, 8000)),
 	}
 }
 

--- a/go/avatars/fullcaching_test.go
+++ b/go/avatars/fullcaching_test.go
@@ -1,0 +1,119 @@
+package avatars
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAvatarsFullCaching(t *testing.T) {
+	tc := libkb.SetupTest(t, "TestAvatarsFullCaching", 1)
+	defer tc.Cleanup()
+	clock := clockwork.NewFakeClock()
+	tc.G.SetClock(clock)
+
+	testSrv := libkb.NewHTTPSrv(tc.G, libkb.NewPortRangeListenerSource(7000, 8000))
+	require.NoError(t, testSrv.Start())
+	testSrv.HandleFunc("/p", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "hi")
+	})
+	testSrv.HandleFunc("/p2", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "hi2")
+	})
+
+	ctx := context.TODO()
+	cb := make(chan struct{}, 5)
+	a, _ := testSrv.Addr()
+	testSrvAddr := fmt.Sprintf("http://%s/p", a)
+	tc.G.API = newAvatarMockAPI(makeHandler(testSrvAddr, cb))
+	source := NewFullCachingSource(tc.G, time.Hour, 10, NewURLCachingSource(tc.G, time.Hour, 10))
+	source.populateSuccessCh = make(chan struct{}, 5)
+	source.tempDir = os.TempDir()
+	source.forceHTTPSrv = true
+	source.StartBackgroundTasks()
+	defer source.StopBackgroundTasks()
+
+	t.Logf("first blood")
+	res, err := source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	require.NoError(t, err)
+	require.Equal(t, testSrvAddr, res.Picmap["mike"]["square"].String())
+	select {
+	case <-cb:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no API call")
+	}
+	select {
+	case <-source.populateSuccessCh:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no populate")
+	}
+
+	t.Log("cache hit")
+	getHTTP := func(addr string) string {
+		resp, err := http.Get(addr)
+		require.NoError(t, err)
+		dat, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return string(dat)
+	}
+	res, err = source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	require.NoError(t, err)
+	select {
+	case <-cb:
+		require.Fail(t, "no API call")
+	default:
+	}
+	select {
+	case <-source.populateSuccessCh:
+		require.Fail(t, "no populate")
+	default:
+	}
+	val := res.Picmap["mike"]["square"].String()
+	require.NotEqual(t, testSrvAddr, val)
+	require.True(t, strings.HasPrefix(val, "http://127.0.0.1"))
+	require.Equal(t, "hi", getHTTP(val))
+
+	t.Log("stale")
+	testSrvAddr = fmt.Sprintf("http://%s/p2", a)
+	tc.G.API = newAvatarMockAPI(makeHandler(testSrvAddr, cb))
+	clock.Advance(2 * time.Hour)
+	res, err = source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	require.NoError(t, err)
+	select {
+	case <-cb:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no API call")
+	}
+	select {
+	case <-source.populateSuccessCh:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no populate")
+	}
+	val2 := res.Picmap["mike"]["square"].String()
+	require.Equal(t, val, val2)
+	res, err = source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	require.NoError(t, err)
+	select {
+	case <-cb:
+		require.Fail(t, "no API call")
+	default:
+	}
+	select {
+	case <-source.populateSuccessCh:
+		require.Fail(t, "no populate")
+	default:
+	}
+	val2 = res.Picmap["mike"]["square"].String()
+	require.Equal(t, val2, val)
+	require.Equal(t, "hi2", getHTTP(val2))
+}

--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -28,7 +28,7 @@ func CreateSourceFromEnv(g *libkb.GlobalContext) (s Source) {
 		if g.GetAppType() == libkb.MobileAppType {
 			maxSize = 2000
 		}
-		s = NewFullCachingSource(g, time.Second, maxSize)
+		s = NewFullCachingSource(g, time.Hour, maxSize)
 	}
 	s.StartBackgroundTasks()
 	g.PushShutdownHook(func() error {

--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -28,8 +28,7 @@ func CreateSourceFromEnv(g *libkb.GlobalContext) (s Source) {
 		if g.GetAppType() == libkb.MobileAppType {
 			maxSize = 2000
 		}
-		ucs := NewURLCachingSource(g, time.Hour, 20000)
-		s = NewFullCachingSource(g, time.Hour, maxSize, ucs)
+		s = NewFullCachingSource(g, time.Second, maxSize)
 	}
 	s.StartBackgroundTasks()
 	g.PushShutdownHook(func() error {

--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -2,6 +2,7 @@ package avatars
 
 import (
 	"context"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -10,8 +11,37 @@ import (
 type Source interface {
 	LoadUsers(context.Context, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)
 	LoadTeams(context.Context, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)
+
+	StartBackgroundTasks()
+	StopBackgroundTasks()
 }
 
-func CreateSourceFromEnv(g *libkb.GlobalContext) Source {
-	return NewSimpleSource(g)
+func CreateSourceFromEnv(g *libkb.GlobalContext) (s Source) {
+	typ := g.Env.GetAvatarSource()
+	switch typ {
+	case "simple":
+		s = NewSimpleSource(g)
+	case "url":
+		s = NewURLCachingSource(g, time.Hour, 20000)
+	case "full":
+		maxSize := 10000
+		if g.GetAppType() == libkb.MobileAppType {
+			maxSize = 2000
+		}
+		ucs := NewURLCachingSource(g, time.Hour, 20000)
+		s = NewFullCachingSource(g, time.Hour, maxSize, ucs)
+	}
+	s.StartBackgroundTasks()
+	g.PushShutdownHook(func() error {
+		s.StopBackgroundTasks()
+		return nil
+	})
+	return s
+}
+
+func allocRes(res *keybase1.LoadAvatarsRes, usernames []string) {
+	res.Picmap = make(map[string]map[keybase1.AvatarFormat]keybase1.AvatarUrl)
+	for _, u := range usernames {
+		res.Picmap[u] = make(map[keybase1.AvatarFormat]keybase1.AvatarUrl)
+	}
 }

--- a/go/avatars/simple.go
+++ b/go/avatars/simple.go
@@ -28,6 +28,11 @@ func NewSimpleSource(g *libkb.GlobalContext) *SimpleSource {
 	}
 }
 
+var _ Source = (*SimpleSource)(nil)
+
+func (s *SimpleSource) StartBackgroundTasks() {}
+func (s *SimpleSource) StopBackgroundTasks()  {}
+
 func (s *SimpleSource) formatArg(formats []keybase1.AvatarFormat) string {
 	var strs []string
 	for _, f := range formats {
@@ -63,7 +68,7 @@ func (s *SimpleSource) makeRes(res *keybase1.LoadAvatarsRes, apiRes apiAvatarRes
 		return fmt.Errorf("invalid API server response, wrong number of users: %d != %d",
 			len(apiRes.Pictures), len(names))
 	}
-	s.allocRes(res, names)
+	allocRes(res, names)
 	for index, rec := range apiRes.Pictures {
 		u := names[index]
 		for format, url := range rec {
@@ -75,13 +80,6 @@ func (s *SimpleSource) makeRes(res *keybase1.LoadAvatarsRes, apiRes apiAvatarRes
 
 func (s *SimpleSource) debug(ctx context.Context, msg string, args ...interface{}) {
 	s.G().Log.CDebugf(ctx, "Avatars.SimpleSource: %s", fmt.Sprintf(msg, args...))
-}
-
-func (s *SimpleSource) allocRes(res *keybase1.LoadAvatarsRes, usernames []string) {
-	res.Picmap = make(map[string]map[keybase1.AvatarFormat]keybase1.AvatarUrl)
-	for _, u := range usernames {
-		res.Picmap[u] = make(map[keybase1.AvatarFormat]keybase1.AvatarUrl)
-	}
 }
 
 func (s *SimpleSource) LoadUsers(ctx context.Context, usernames []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {

--- a/go/avatars/urlcaching.go
+++ b/go/avatars/urlcaching.go
@@ -1,0 +1,165 @@
+package avatars
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/lru"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type URLCachingSource struct {
+	libkb.Contextified
+
+	diskLRU        *lru.DiskLRU
+	staleThreshold time.Duration
+	simpleSource   *SimpleSource
+}
+
+var _ Source = (*URLCachingSource)(nil)
+
+func NewURLCachingSource(g *libkb.GlobalContext, staleThreshold time.Duration, size int) *URLCachingSource {
+	return &URLCachingSource{
+		Contextified:   libkb.NewContextified(g),
+		diskLRU:        lru.NewDiskLRU("avatarurls", 1, size),
+		staleThreshold: staleThreshold,
+		simpleSource:   NewSimpleSource(g),
+	}
+}
+
+func (c *URLCachingSource) StartBackgroundTasks() {
+	go c.monitorAppState()
+}
+
+func (c *URLCachingSource) StopBackgroundTasks() {
+	c.diskLRU.Flush(context.Background(), c.G())
+}
+
+func (c *URLCachingSource) debug(ctx context.Context, msg string, args ...interface{}) {
+	c.G().Log.CDebugf(ctx, "Avatars.URLCachingSource: %s", fmt.Sprintf(msg, args...))
+}
+
+func (c *URLCachingSource) avatarKey(name string, format keybase1.AvatarFormat) string {
+	return fmt.Sprintf("%s:%s", name, format.String())
+}
+
+func (c *URLCachingSource) isStale(item lru.DiskLRUEntry) bool {
+	return c.G().GetClock().Now().Sub(item.Ctime) > c.staleThreshold
+}
+
+func (c *URLCachingSource) monitorAppState() {
+	c.debug(context.Background(), "monitorAppState: starting up")
+	for {
+		state := <-c.G().AppState.NextUpdate()
+		ctx := context.Background()
+		switch state {
+		case keybase1.AppState_BACKGROUND:
+			c.debug(ctx, "monitorAppState: backgrounded")
+			c.diskLRU.Flush(ctx, c.G())
+		}
+	}
+}
+
+func (c *URLCachingSource) specLoad(ctx context.Context, names []string, formats []keybase1.AvatarFormat) (res avatarLoadSpec, err error) {
+	for _, name := range names {
+		for _, format := range formats {
+			key := c.avatarKey(name, format)
+			found, entry, err := c.diskLRU.Get(ctx, c.G(), key)
+			if err != nil {
+				return res, err
+			}
+			lp := avatarLoadPair{
+				name:   name,
+				format: format,
+			}
+			if found {
+				lp.path = entry.Value.(string)
+				if c.isStale(entry) {
+					res.stales = append(res.stales, lp)
+				} else {
+					res.hits = append(res.hits, lp)
+				}
+			} else {
+				res.misses = append(res.misses, lp)
+			}
+		}
+	}
+	return res, nil
+}
+
+func (c *URLCachingSource) mergeRes(res *keybase1.LoadAvatarsRes, m keybase1.LoadAvatarsRes) {
+	for username, rec := range m.Picmap {
+		for format, url := range rec {
+			res.Picmap[username][format] = url
+		}
+	}
+}
+
+func (c *URLCachingSource) commitURLs(ctx context.Context, res keybase1.LoadAvatarsRes) {
+	for name, rec := range res.Picmap {
+		for format, url := range rec {
+			if _, err := c.diskLRU.Put(ctx, c.G(), c.avatarKey(name, format), url); err != nil {
+				c.debug(ctx, "commitURLs: failed to save URL: url: %s err: %s", url, err)
+			}
+		}
+	}
+}
+
+func (c *URLCachingSource) loadNames(ctx context.Context, names []string, formats []keybase1.AvatarFormat,
+	remoteFetch func(context.Context, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)) (res keybase1.LoadAvatarsRes, err error) {
+	loadSpec, err := c.specLoad(ctx, names, formats)
+	if err != nil {
+		return res, err
+	}
+	c.debug(ctx, "loadNames: hits: %d stales: %d misses: %d", len(loadSpec.hits), len(loadSpec.stales),
+		len(loadSpec.misses))
+
+	// Fill in the hits
+	allocRes(&res, names)
+	for _, hit := range loadSpec.hits {
+		res.Picmap[hit.name][hit.format] = keybase1.MakeAvatarURL(hit.path)
+	}
+	// Fill in stales
+	for _, stale := range loadSpec.stales {
+		res.Picmap[stale.name][stale.format] = keybase1.MakeAvatarURL(stale.path)
+	}
+
+	// Go get the misses
+	missNames, missFormats := loadSpec.missDetails()
+	if len(missNames) > 0 {
+		loadRes, err := remoteFetch(ctx, missNames, missFormats)
+		if err == nil {
+			c.commitURLs(ctx, loadRes)
+			c.mergeRes(&res, loadRes)
+		} else {
+			c.debug(ctx, "loadNames: failed to load server miss reqs: %s", err)
+		}
+	}
+	// Spawn off a goroutine to reload stales
+	staleNames, staleFormats := loadSpec.staleDetails()
+	if len(staleNames) > 0 {
+		go func() {
+			c.debug(context.Background(), "loadNames: spawning stale background load: names: %d",
+				len(staleNames))
+			loadRes, err := remoteFetch(context.Background(), staleNames, staleFormats)
+			if err != nil {
+				c.debug(ctx, "loadNames: failed to load server stale reqs: %s", err)
+			} else {
+				c.commitURLs(ctx, loadRes)
+			}
+		}()
+	}
+	return res, nil
+}
+
+func (c *URLCachingSource) LoadUsers(ctx context.Context, usernames []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
+	defer c.G().Trace("URLCachingSource.LoadUsers", func() error { return err })()
+	return c.loadNames(ctx, usernames, formats, c.simpleSource.LoadUsers)
+}
+
+func (c *URLCachingSource) LoadTeams(ctx context.Context, teams []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
+	defer c.G().Trace("URLCachingSource.LoadTeams", func() error { return err })()
+	return c.loadNames(ctx, teams, formats, c.simpleSource.LoadTeams)
+}

--- a/go/avatars/urlcaching_test.go
+++ b/go/avatars/urlcaching_test.go
@@ -1,0 +1,89 @@
+package avatars
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+type apiHandlerFn func(libkb.APIArg, libkb.APIResponseWrapper) error
+type avatarMockAPI struct {
+	libkb.API
+	handler apiHandlerFn
+}
+
+func (a *avatarMockAPI) GetDecode(arg libkb.APIArg, res libkb.APIResponseWrapper) error {
+	return a.handler(arg, res)
+}
+
+func newAvatarMockAPI(f apiHandlerFn) *avatarMockAPI {
+	return &avatarMockAPI{handler: f}
+}
+
+func makeHandler(url string, cb chan struct{}) apiHandlerFn {
+	return func(arg libkb.APIArg, res libkb.APIResponseWrapper) error {
+		m := make(map[keybase1.AvatarFormat]keybase1.AvatarUrl)
+		m["square"] = keybase1.MakeAvatarURL(url)
+		res.(*apiAvatarRes).Pictures = []map[keybase1.AvatarFormat]keybase1.AvatarUrl{m}
+		cb <- struct{}{}
+		return nil
+	}
+}
+
+func TestAvatarsURLCaching(t *testing.T) {
+	tc := libkb.SetupTest(t, "TestAvatarsURLCaching", 1)
+	defer tc.Cleanup()
+
+	clock := clockwork.NewFakeClock()
+	tc.G.SetClock(clock)
+
+	ctx := context.TODO()
+	cb := make(chan struct{}, 5)
+
+	tc.G.API = newAvatarMockAPI(makeHandler("url", cb))
+	source := NewURLCachingSource(tc.G, time.Hour, 10)
+
+	t.Logf("API server fetch")
+	res, err := source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	require.NoError(t, err)
+	require.Equal(t, "url", res.Picmap["mike"]["square"].String())
+	select {
+	case <-cb:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no API call")
+	}
+	t.Logf("cache fetch")
+	res, err = source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	require.NoError(t, err)
+	require.Equal(t, "url", res.Picmap["mike"]["square"].String())
+	select {
+	case <-cb:
+		require.Fail(t, "no API call")
+	default:
+	}
+
+	t.Logf("stale")
+	clock.Advance(2 * time.Hour)
+	tc.G.API = newAvatarMockAPI(makeHandler("url2", cb))
+	res, err = source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	require.NoError(t, err)
+	require.Equal(t, "url", res.Picmap["mike"]["square"].String())
+	select {
+	case <-cb:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no API call")
+	}
+	res, err = source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	require.NoError(t, err)
+	require.Equal(t, "url2", res.Picmap["mike"]["square"].String())
+	select {
+	case <-cb:
+		require.Fail(t, "no API call")
+	default:
+	}
+}

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1073,6 +1073,13 @@ func (e *Env) GetChatMemberType() string {
 	)
 }
 
+func (e *Env) GetAvatarSource() string {
+	return e.GetString(
+		func() string { return os.Getenv("KEYBASE_AVATAR_SOURCE") },
+		func() string { return "full" },
+	)
+}
+
 func (e *Env) GetDeviceID() keybase1.DeviceID {
 	return e.GetConfig().GetDeviceID()
 }

--- a/go/libkb/httpsrv.go
+++ b/go/libkb/httpsrv.go
@@ -8,40 +8,120 @@ import (
 	"sync"
 )
 
-// RandomPortHTTPSrv starts a simple HTTP server on a random port and and exposes all the methods
-// of http.ServeMux
-type RandomPortHTTPSrv struct {
-	sync.Mutex
-	server *http.Server
-	*http.ServeMux
+type HTTPSrvListenerSource interface {
+	GetListener() (net.Listener, string, error)
 }
 
-func NewRandomPortHTTPSrv() *RandomPortHTTPSrv {
-	return &RandomPortHTTPSrv{}
-}
+type RandomPortListenerSource struct{}
 
-func (h *RandomPortHTTPSrv) Start() (err error) {
-	h.Lock()
-	defer h.Unlock()
-	h.ServeMux = http.NewServeMux()
+func (r RandomPortListenerSource) GetListener() (net.Listener, string, error) {
 	localhost := "127.0.0.1"
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", localhost))
 	if err != nil {
-		return err
+		return nil, "", err
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
 	address := fmt.Sprintf("%s:%d", localhost, port)
+	return listener, address, nil
+}
+
+type PortRangeListenerSource struct {
+	sync.Mutex
+	pinnedPort int
+	low, high  int
+}
+
+func NewPortRangeListenerSource(low, high int) *PortRangeListenerSource {
+	return &PortRangeListenerSource{
+		low:  low,
+		high: high,
+	}
+}
+
+func (p *PortRangeListenerSource) GetListener() (listener net.Listener, address string, err error) {
+	p.Lock()
+	defer p.Unlock()
+	var errMsg string
+	localhost := "127.0.0.1"
+	if p.pinnedPort > 0 {
+		address = fmt.Sprintf("%s:%d", localhost, p.pinnedPort)
+		listener, err = net.Listen("tcp", address)
+		if err == nil {
+			return listener, address, nil
+		}
+		errMsg = fmt.Sprintf("failed to bind to pinned port: %d err: %s", p.pinnedPort, err)
+	} else {
+		for port := p.low; port < p.high; port++ {
+			address = fmt.Sprintf("%s:%d", localhost, port)
+			listener, err = net.Listen("tcp", address)
+			if err == nil {
+				p.pinnedPort = port
+				return listener, address, nil
+			}
+		}
+		errMsg = "failed to bind to port in range"
+	}
+	return listener, address, errors.New(errMsg)
+}
+
+// HTTPSrv starts a simple HTTP server with a parameter for a module to provide a listener source
+type HTTPSrv struct {
+	sync.Mutex
+	*http.ServeMux
+	Contextified
+
+	listenerSource HTTPSrvListenerSource
+	server         *http.Server
+	active         bool
+}
+
+func NewHTTPSrv(g *GlobalContext, listenerSource HTTPSrvListenerSource) *HTTPSrv {
+	return &HTTPSrv{
+		Contextified:   NewContextified(g),
+		listenerSource: listenerSource,
+	}
+}
+
+func (h *HTTPSrv) Start() (err error) {
+	h.Lock()
+	defer h.Unlock()
+	if h.active {
+		h.G().Log.Debug("HTTPSrv: already running, not starting again")
+		// Just bail out of this if we are already running
+		return nil
+	}
+	h.ServeMux = http.NewServeMux()
+	listener, address, err := h.listenerSource.GetListener()
+	if err != nil {
+		h.G().Log.Debug("HTTPSrv: failed to get a listener: %s", err)
+		return err
+	}
 	h.server = &http.Server{
 		Addr:    address,
 		Handler: h.ServeMux,
 	}
 	go func() {
-		h.server.Serve(listener)
+		h.Lock()
+		h.active = true
+		h.Unlock()
+		h.G().Log.Debug("HTTPSrv: server starting on: %s", address)
+		if err := h.server.Serve(listener); err != nil {
+			h.G().Log.Debug("HTTPSrv: server died: %s", err)
+		}
+		h.Lock()
+		h.active = false
+		h.Unlock()
 	}()
 	return nil
 }
 
-func (h *RandomPortHTTPSrv) Addr() (string, error) {
+func (h *HTTPSrv) Active() bool {
+	h.Lock()
+	defer h.Unlock()
+	return h.active
+}
+
+func (h *HTTPSrv) Addr() (string, error) {
 	h.Lock()
 	defer h.Unlock()
 	if h.server != nil {
@@ -50,7 +130,7 @@ func (h *RandomPortHTTPSrv) Addr() (string, error) {
 	return "", errors.New("server not running")
 }
 
-func (h *RandomPortHTTPSrv) Stop() {
+func (h *HTTPSrv) Stop() {
 	h.Lock()
 	defer h.Unlock()
 	if h.server != nil {

--- a/go/libkb/httpsrv.go
+++ b/go/libkb/httpsrv.go
@@ -25,6 +25,10 @@ func (r RandomPortListenerSource) GetListener() (net.Listener, string, error) {
 	return listener, address, nil
 }
 
+func NewRandomPortListenerSource() *RandomPortListenerSource {
+	return &RandomPortListenerSource{}
+}
+
 type PortRangeListenerSource struct {
 	sync.Mutex
 	pinnedPort int
@@ -36,6 +40,10 @@ func NewPortRangeListenerSource(low, high int) *PortRangeListenerSource {
 		low:  low,
 		high: high,
 	}
+}
+
+func NewFixedPortListenerSource(port int) *PortRangeListenerSource {
+	return NewPortRangeListenerSource(port, port)
 }
 
 func (p *PortRangeListenerSource) GetListener() (listener net.Listener, address string, err error) {
@@ -51,7 +59,7 @@ func (p *PortRangeListenerSource) GetListener() (listener net.Listener, address 
 		}
 		errMsg = fmt.Sprintf("failed to bind to pinned port: %d err: %s", p.pinnedPort, err)
 	} else {
-		for port := p.low; port < p.high; port++ {
+		for port := p.low; port <= p.high; port++ {
 			address = fmt.Sprintf("%s:%d", localhost, port)
 			listener, err = net.Listen("tcp", address)
 			if err == nil {

--- a/go/libkb/httpsrv_test.go
+++ b/go/libkb/httpsrv_test.go
@@ -9,20 +9,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRandomPortHTTPSrv(t *testing.T) {
-	srv := NewRandomPortHTTPSrv()
-	require.NoError(t, srv.Start())
-	srv.HandleFunc("/test", func(resp http.ResponseWriter, req *http.Request) {
-		fmt.Fprintf(resp, "success")
-	})
-	addr, err := srv.Addr()
-	require.NoError(t, err)
-	url := fmt.Sprintf("http://%s/test", addr)
-	t.Logf("url: %s", url)
-	resp, err := http.Get(url)
-	require.NoError(t, err)
-	out, err := ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, "success", string(out))
-	srv.Stop()
+func TestHTTPSrv(t *testing.T) {
+	tc := SetupTest(t, "TestAvatarsFullCaching", 1)
+	defer tc.Cleanup()
+
+	test := func(s HTTPSrvListenerSource) {
+		srv := NewHTTPSrv(tc.G, s)
+		require.NoError(t, srv.Start())
+		srv.HandleFunc("/test", func(resp http.ResponseWriter, req *http.Request) {
+			fmt.Fprintf(resp, "success")
+		})
+		addr, err := srv.Addr()
+		require.NoError(t, err)
+		url := fmt.Sprintf("http://%s/test", addr)
+		t.Logf("url: %s", url)
+		resp, err := http.Get(url)
+		require.NoError(t, err)
+		out, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "success", string(out))
+		srv.Stop()
+	}
+	test(NewRandomPortListenerSource())
+	test(NewPortRangeListenerSource(7000, 8000))
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2365,3 +2365,11 @@ func (s StellarBundle) CheckInvariants() error {
 func (f AvatarFormat) String() string {
 	return string(f)
 }
+
+func (u AvatarUrl) String() string {
+	return string(u)
+}
+
+func MakeAvatarURL(u string) AvatarUrl {
+	return AvatarUrl(u)
+}

--- a/shared/common-adapters/avatar.js
+++ b/shared/common-adapters/avatar.js
@@ -121,7 +121,6 @@ const mapStateToProps = (state: TypedState, ownProps: Props) => {
   }
 
   return {
-    _needAskForData: !state.config.avatars.hasOwnProperty(name),
     _urlMap,
   }
 }
@@ -187,19 +186,17 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     isPlaceholder = false
   }
 
-  if (!url && !stateProps._needAskForData) {
+  if (!url) {
     const placeholder = isTeam ? teamPlaceHolders : avatarPlaceHolders
     url = iconTypeToImgSet(placeholder[String(ownProps.size)], ownProps.size)
     isPlaceholder = true
   }
 
   let _askForUserData = null
-  if (stateProps._needAskForData) {
-    if (isTeam) {
-      _askForUserData = () => dispatchProps._askForTeamUserData(ownProps.teamname)
-    } else {
-      _askForUserData = () => dispatchProps._askForUserData(ownProps.username)
-    }
+  if (isTeam) {
+    _askForUserData = () => dispatchProps._askForTeamUserData(ownProps.teamname)
+  } else {
+    _askForUserData = () => dispatchProps._askForUserData(ownProps.username)
   }
 
   const _name = isTeam ? ownProps.teamname : ownProps.username
@@ -255,7 +252,7 @@ const realConnector = compose(
         if (this.props._name === this.props._stateName) {
           this.props._maybeLoadUserData()
         }
-      }, 700)
+      }, 200)
       this.props.setMounted(this.props._name, _timeoutID)
     },
     componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Patch does the following:

1.) Introduces two new avatar caching sources for possible use, `URLCachingSource` and `FullCachingSource`. 
2.) `URLCachingSource` uses the new `DiskLRU` to store avatar URLs in LevelDB. The URLs delivered to the frontend are S3 URLs, and so the effectiveness of this is dependent on the frontend caching the actual image files. 
3.) `FullCachingSource` uses `DiskLRU` to cache locations on the disk where we have downloaded avatars from S3. The URLs delivered to the frontend are either `file://` (for desktop), or to a local HTTP interface (for mobile). 
4.) Both new sources implement a mechanism for marking avatars in the cache as stale. They basically can be in the cache for up to whatever time limit is specified, at which time we download the new information for the avatar in the background. That is, we only block the frontend on a complete miss, not on these stale hits. Note this system could be expanded to use Gregor messages in the future for things like the current user's profile, or people in their inbox. 
5.) The patch makes `FullCachingSource` the default, since it is likely the most effective solution. It comes with the advantage of providing guaranteed avatars when offline, and not having a dependence on a frontend caching scheme we don't fully control. 
6.) Changed avatar.js to always ask the service for avatar URLs, and stop trying to limit the amount of times it calls out for new data. This is necessary for the LRU and stale mechanics to function properly.  cc @chrisnojima 

cc @malgorithms 
