### PR TITLE
Add check for race in login flow

### DIFF
--- a/shared/actions/login.js
+++ b/shared/actions/login.js
@@ -152,6 +152,11 @@ function* navBasedOnLoginAndInitialState(): Saga.SagaGenerator<any, any> {
     yield Saga.put(switchRouteDef(loginRouteTree))
     yield Saga.put.resolve(getExtendedStatus())
     yield Saga.call(getAccounts)
+    // We may have logged successfully in by now, check before trying to navigate
+    const state = yield Saga.select()
+    if (state.config.loggedIn) {
+      return
+    }
     yield Saga.put(navigateTo(['login'], [loginTab]))
   } else if (loginError) {
     // show error on login screen


### PR DESCRIPTION
This was causing an exception on the logout/login flow. I think it was due to a race that's existed since before the routes got split up. One or more of the `yield`s that happens in the `registered && !loggedIn` flow were taking long enough that a login could have happened in the mean time. Since the routing changes this causes a more severe error than it did before. This adds a check for whether we've logged in before the route call and bails out if so. r? @keybase/react-hackers 