### PR TITLE
Navigate to inbox after leaving channel via the info pane

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -171,7 +171,7 @@ export const createJoinConversation = (payload: $ReadOnly<{conversationIDKey: Ty
 export const createLeaveConversation = (
   payload: $ReadOnly<{
     conversationIDKey: Types.ConversationIDKey,
-    navigateToInbox?: boolean,
+    dontNavigateToInbox?: boolean,
   }>
 ) => ({error: false, payload, type: leaveConversation})
 export const createLoadOlderMessagesDueToScroll = (payload: $ReadOnly<{conversationIDKey: Types.ConversationIDKey}>) => ({error: false, payload, type: loadOlderMessagesDueToScroll})

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -168,7 +168,12 @@ export const createDesktopNotification = (
 export const createExitSearch = (payload: $ReadOnly<{canceled: boolean}>) => ({error: false, payload, type: exitSearch})
 export const createInboxRefresh = (payload: $ReadOnly<{reason: 'bootstrap' | 'componentNeverLoaded' | 'inboxStale' | 'inboxSyncedClear' | 'inboxSyncedUnknown' | 'joinedAConversation' | 'leftAConversation' | 'teamTypeChanged'}>) => ({error: false, payload, type: inboxRefresh})
 export const createJoinConversation = (payload: $ReadOnly<{conversationIDKey: Types.ConversationIDKey}>) => ({error: false, payload, type: joinConversation})
-export const createLeaveConversation = (payload: $ReadOnly<{conversationIDKey: Types.ConversationIDKey}>) => ({error: false, payload, type: leaveConversation})
+export const createLeaveConversation = (
+  payload: $ReadOnly<{
+    conversationIDKey: Types.ConversationIDKey,
+    navigateToInbox?: boolean,
+  }>
+) => ({error: false, payload, type: leaveConversation})
 export const createLoadOlderMessagesDueToScroll = (payload: $ReadOnly<{conversationIDKey: Types.ConversationIDKey}>) => ({error: false, payload, type: loadOlderMessagesDueToScroll})
 export const createMarkConversationsStale = (payload: $ReadOnly<{conversationIDKeys: Array<Types.ConversationIDKey>}>) => ({error: false, payload, type: markConversationsStale})
 export const createMarkInitiallyLoadedThreadAsRead = (payload: $ReadOnly<{conversationIDKey: Types.ConversationIDKey}>) => ({error: false, payload, type: markInitiallyLoadedThreadAsRead})

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1629,7 +1629,7 @@ const loadCanUserPerform = (action: Chat2Gen.SelectConversationPayload, state: T
 
 // Helpers to nav you to the right place
 const navigateToInbox = (action: Chat2Gen.NavigateToInboxPayload | Chat2Gen.LeaveConversationPayload) => {
-  if (action.type === Chat2Gen.leaveConversation && !action.payload.navigateToInbox) {
+  if (action.type === Chat2Gen.leaveConversation && action.payload.dontNavigateToInbox) {
     return
   }
   return Saga.put(Route.navigateTo([{props: {}, selected: chatTab}, {props: {}, selected: null}]))

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1628,8 +1628,12 @@ const loadCanUserPerform = (action: Chat2Gen.SelectConversationPayload, state: T
 }
 
 // Helpers to nav you to the right place
-const navigateToInbox = () =>
-  Saga.put(Route.navigateTo([{props: {}, selected: chatTab}, {props: {}, selected: null}]))
+const navigateToInbox = (action: Chat2Gen.NavigateToInboxPayload | Chat2Gen.LeaveConversationPayload) => {
+  if (action.type === Chat2Gen.leaveConversation && !action.payload.navigateToInbox) {
+    return
+  }
+  return Saga.put(Route.navigateTo([{props: {}, selected: chatTab}, {props: {}, selected: null}]))
+}
 const navigateToThread = (_: any, state: TypedState) => {
   if (state.chat2.selectedConversation) {
     return Saga.put(
@@ -1874,7 +1878,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
     markThreadAsRead
   )
 
-  yield Saga.safeTakeEveryPure(Chat2Gen.navigateToInbox, navigateToInbox)
+  yield Saga.safeTakeEveryPure([Chat2Gen.navigateToInbox, Chat2Gen.leaveConversation], navigateToInbox)
   yield Saga.safeTakeEveryPure(Chat2Gen.navigateToThread, navigateToThread)
 
   yield Saga.safeTakeEveryPure(Chat2Gen.joinConversation, joinConversation)

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1792,7 +1792,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
   }
 
   // Refresh the inbox
-  yield Saga.safeTakeEveryPure([Chat2Gen.inboxRefresh, Chat2Gen.leaveConversation], inboxRefresh)
+  yield Saga.safeTakeEveryPure(Chat2Gen.inboxRefresh, inboxRefresh)
   // Load teams
   yield Saga.safeTakeEveryPure(Chat2Gen.metasReceived, requestTeamsUnboxing)
   // We've scrolled some new inbox rows into view, queue them up

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -198,7 +198,7 @@
     },
     "leaveConversation": {
       "conversationIDKey": "Types.ConversationIDKey",
-      "navigateToInbox?": "boolean",
+      "dontNavigateToInbox?": "boolean",
     },
     "muteConversation": {
       "conversationIDKey": "Types.ConversationIDKey",

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -198,6 +198,7 @@
     },
     "leaveConversation": {
       "conversationIDKey": "Types.ConversationIDKey",
+      "navigateToInbox?": "boolean",
     },
     "muteConversation": {
       "conversationIDKey": "Types.ConversationIDKey",

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -74,10 +74,8 @@ const mapDispatchToProps = (dispatch: Dispatch, {conversationIDKey, navigateUp})
     ),
   _onBack: () => dispatch(navigateUp && navigateUp()),
   _navToRootChat: () => dispatch(Chat2Gen.createNavigateToInbox()),
-  onLeaveConversation: () => {
-    dispatch(Chat2Gen.createLeaveConversation({conversationIDKey}))
-    dispatch(Chat2Gen.createNavigateToInbox())
-  },
+  onLeaveConversation: () =>
+    dispatch(Chat2Gen.createLeaveConversation({conversationIDKey, navigateToInbox: true})),
   onJoinChannel: () => dispatch(Chat2Gen.createJoinConversation({conversationIDKey})),
   onShowBlockConversationDialog: () => {
     dispatch(

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -74,7 +74,10 @@ const mapDispatchToProps = (dispatch: Dispatch, {conversationIDKey, navigateUp})
     ),
   _onBack: () => dispatch(navigateUp && navigateUp()),
   _navToRootChat: () => dispatch(Chat2Gen.createNavigateToInbox()),
-  onLeaveConversation: () => dispatch(Chat2Gen.createLeaveConversation({conversationIDKey})),
+  onLeaveConversation: () => {
+    dispatch(Chat2Gen.createLeaveConversation({conversationIDKey}))
+    dispatch(Chat2Gen.createNavigateToInbox())
+  },
   onJoinChannel: () => dispatch(Chat2Gen.createJoinConversation({conversationIDKey})),
   onShowBlockConversationDialog: () => {
     dispatch(

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -74,8 +74,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {conversationIDKey, navigateUp})
     ),
   _onBack: () => dispatch(navigateUp && navigateUp()),
   _navToRootChat: () => dispatch(Chat2Gen.createNavigateToInbox()),
-  onLeaveConversation: () =>
-    dispatch(Chat2Gen.createLeaveConversation({conversationIDKey, navigateToInbox: true})),
+  onLeaveConversation: () => dispatch(Chat2Gen.createLeaveConversation({conversationIDKey})),
   onJoinChannel: () => dispatch(Chat2Gen.createJoinConversation({conversationIDKey})),
   onShowBlockConversationDialog: () => {
     dispatch(


### PR DESCRIPTION
Also addresses some weird behavior where the conversation would remain in the inbox on mobile. I didn't look deeply into the issue, but we were refreshing the inbox twice (once on our own & once on service notification). Removing our manual refresh gets rid of the issue. r? @keybase/react-hackers 