### PR TITLE
On-Demand TeamEK Generation

### DIFF
--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -9,6 +9,8 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
+// NOTE: If you change this value you should change it in web/ephemeral.iced
+// and go/ekreaperd/reaper.go as well.
 // Keys last at most one week
 const KeyLifetimeSecs = 60 * 60 * 24 * 7 // one week
 // Everyday we want to generate a new key if possible

--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -16,20 +16,22 @@ const KeyLifetimeSecs = 60 * 60 * 24 * 7 // one week
 // Everyday we want to generate a new key if possible
 const KeyGenLifetimeSecs = 60 * 60 * 24 // one day
 
+type EKType string
+
 const (
-	DEVICE_EK = "deviceEK"
-	USER_EK   = "userEK"
-	TEAM_EK   = "teamEK"
+	DeviceEKStr EKType = "deviceEK"
+	UserEKStr   EKType = "userEK"
+	TeamEKStr   EKType = "teamEK"
 )
 
 type EKUnboxErr struct {
-	boxType           string
+	boxType           EKType
 	boxGeneration     keybase1.EkGeneration
-	missingType       string // device/user/teamEK
+	missingType       EKType
 	missingGeneration keybase1.EkGeneration
 }
 
-func newEKUnboxErr(boxType string, boxGeneration keybase1.EkGeneration, missingType string, missingGeneration keybase1.EkGeneration) *EKUnboxErr {
+func newEKUnboxErr(boxType EKType, boxGeneration keybase1.EkGeneration, missingType EKType, missingGeneration keybase1.EkGeneration) *EKUnboxErr {
 	return &EKUnboxErr{
 		missingType:       missingType,
 		boxType:           boxType,
@@ -46,7 +48,7 @@ func ctimeIsStale(ctime keybase1.Time, currentMerkleRoot libkb.MerkleRoot) bool 
 	return currentMerkleRoot.Ctime()-ctime.UnixSeconds() >= KeyLifetimeSecs
 }
 
-func keygenExpired(ctime keybase1.Time, currentMerkleRoot libkb.MerkleRoot) bool {
+func keygenNeeded(ctime keybase1.Time, currentMerkleRoot libkb.MerkleRoot) bool {
 	return currentMerkleRoot.Ctime()-ctime.UnixSeconds() >= KeyGenLifetimeSecs
 }
 

--- a/go/ephemeral/device_ek.go
+++ b/go/ephemeral/device_ek.go
@@ -123,8 +123,7 @@ func signAndPublishDeviceEK(ctx context.Context, g *libkb.GlobalContext, generat
 		Ctime: keybase1.TimeFromSeconds(merkleRoot.Ctime()),
 	}
 	statement := keybase1.DeviceEkStatement{
-		CurrentDeviceEkMetadata: metadata,
-		// TODO: Make the server more forgiving if this list is wrong?
+		CurrentDeviceEkMetadata:  metadata,
 		ExistingDeviceEkMetadata: existingMetadata,
 	}
 

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -114,7 +114,7 @@ func (e *EKLib) newDeviceEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRo
 		return needed, err
 	}
 
-	return keygenExpired(ek.Metadata.Ctime, merkleRoot), nil
+	return keygenNeeded(ek.Metadata.Ctime, merkleRoot), nil
 }
 
 func (e *EKLib) NewUserEKNeeded(ctx context.Context) (needed bool, err error) {
@@ -153,7 +153,7 @@ func (e *EKLib) newUserEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot
 		}
 	}
 	// Ok we can access the ek, check lifetime.
-	return keygenExpired(ek.Metadata.Ctime, merkleRoot), nil
+	return keygenNeeded(ek.Metadata.Ctime, merkleRoot), nil
 }
 
 func (e *EKLib) NewTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID) (needed bool, err error) {
@@ -190,7 +190,7 @@ func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, mer
 		}
 	}
 	// Ok we can access the ek, check lifetime.
-	return keygenExpired(ek.Metadata.Ctime, merkleRoot), nil
+	return keygenNeeded(ek.Metadata.Ctime, merkleRoot), nil
 }
 
 func (e *EKLib) GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (teamEK keybase1.TeamEk, err error) {

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -21,7 +21,6 @@ func NewEKLib(g *libkb.GlobalContext) *EKLib {
 }
 
 func (e *EKLib) KeygenIfNeeded(ctx context.Context) (err error) {
-	defer e.G().CTrace(ctx, "KeygenIfNeeded", func() error { return err })()
 	e.Lock()
 	defer e.Unlock()
 
@@ -35,34 +34,44 @@ func (e *EKLib) KeygenIfNeeded(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	merkleRoot := *merkleRootPtr
+	return e.keygenIfNeeded(ctx, *merkleRootPtr)
+}
 
-	deviceEKNeeded, err := e.newDeviceEKNeeded(ctx, merkleRoot)
-	if err != nil {
+func (e *EKLib) keygenIfNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot) (err error) {
+	defer e.G().CTrace(ctx, "keygenIfNeeded", func() error { return err })()
+
+	if deviceEKNeeded, err := e.newDeviceEKNeeded(ctx, merkleRoot); err != nil {
 		return err
-	}
-	if deviceEKNeeded {
+	} else if deviceEKNeeded {
 		_, err = publishNewDeviceEK(ctx, e.G(), merkleRoot)
 		if err != nil {
 			return err
 		}
 	}
 
-	userEKNeeded, err := e.newUserEKNeeded(ctx, merkleRoot)
-	if err != nil {
+	if userEKNeeded, err := e.newUserEKNeeded(ctx, merkleRoot); err != nil {
 		return err
-	}
-
-	if userEKNeeded {
+	} else if userEKNeeded {
 		_, err = publishNewUserEK(ctx, e.G(), merkleRoot)
 		if err != nil {
 			return err
 		}
 	}
-	return e.CleanupStaleUserAndDeviceEKs(ctx, merkleRoot)
+	return e.cleanupStaleUserAndDeviceEKs(ctx, merkleRoot)
 }
 
-func (e *EKLib) CleanupStaleUserAndDeviceEKs(ctx context.Context, merkleRoot libkb.MerkleRoot) (err error) {
+func (e *EKLib) CleanupStaleUserAndDeviceEKs(ctx context.Context) (err error) {
+	e.Lock()
+	defer e.Unlock()
+
+	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(ctx, libkb.EphemeralKeyMerkleFreshness)
+	if err != nil {
+		return err
+	}
+	return e.cleanupStaleUserAndDeviceEKs(ctx, *merkleRootPtr)
+}
+
+func (e *EKLib) cleanupStaleUserAndDeviceEKs(ctx context.Context, merkleRoot libkb.MerkleRoot) (err error) {
 	defer e.G().CTrace(ctx, "CleanupStaleUserAndDeviceEKs", func() error { return err })()
 
 	epick := libkb.FirstErrorPicker{}
@@ -77,7 +86,20 @@ func (e *EKLib) CleanupStaleUserAndDeviceEKs(ctx context.Context, merkleRoot lib
 	return epick.Error()
 }
 
+func (e *EKLib) NewDeviceEKNeeded(ctx context.Context) (needed bool, err error) {
+	e.Lock()
+	defer e.Unlock()
+
+	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(ctx, libkb.EphemeralKeyMerkleFreshness)
+	if err != nil {
+		return false, err
+	}
+	return e.newDeviceEKNeeded(ctx, *merkleRootPtr)
+}
+
 func (e *EKLib) newDeviceEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
+	defer e.G().CTrace(ctx, "newDeviceEKNeeded", func() error { return err })()
+
 	s := e.G().GetDeviceEKStorage()
 	maxGeneration, err := s.MaxGeneration(ctx)
 	if err != nil {
@@ -92,25 +114,133 @@ func (e *EKLib) newDeviceEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRo
 		return needed, err
 	}
 
-	return keybase1.Time(merkleRoot.Ctime())-ek.Metadata.Ctime >= KeyGenLifetimeSecs, nil
+	return keygenExpired(ek.Metadata.Ctime, merkleRoot), nil
+}
+
+func (e *EKLib) NewUserEKNeeded(ctx context.Context) (needed bool, err error) {
+	e.Lock()
+	defer e.Unlock()
+
+	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(ctx, libkb.EphemeralKeyMerkleFreshness)
+	if err != nil {
+		return false, err
+	}
+	return e.newUserEKNeeded(ctx, *merkleRootPtr)
 }
 
 func (e *EKLib) newUserEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
-	s := e.G().GetUserEKBoxStorage()
-	maxGeneration, err := s.MaxGeneration(ctx)
+	defer e.G().CTrace(ctx, "newUserEKNeeded", func() error { return err })()
+
+	// Let's see what the latest server statement is.
+	statement, err := fetchUserEKStatement(ctx, e.G())
 	if err != nil {
-		return needed, err
+		return false, err
 	}
-	if maxGeneration < 0 {
+	// No statement, so we need a userEK
+	if statement == nil {
 		return true, nil
 	}
-
-	ek, err := s.Get(ctx, maxGeneration)
+	// Can we access this generation? If not, let's regenerate.
+	s := e.G().GetUserEKBoxStorage()
+	ek, err := s.Get(ctx, statement.CurrentUserEkMetadata.Generation)
 	if err != nil {
-		return needed, err
+		switch err.(type) {
+		case *EKUnboxErr:
+			e.G().Log.Debug(err.Error())
+			return true, nil
+		default:
+			return false, err
+		}
+	}
+	// Ok we can access the ek, check lifetime.
+	return keygenExpired(ek.Metadata.Ctime, merkleRoot), nil
+}
+
+func (e *EKLib) NewTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID) (needed bool, err error) {
+	e.Lock()
+	defer e.Unlock()
+
+	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(ctx, libkb.EphemeralKeyMerkleFreshness)
+	if err != nil {
+		return false, err
+	}
+	statement, err := fetchTeamEKStatement(ctx, e.G(), teamID)
+	if err != nil {
+		return false, err
+	}
+	return e.newTeamEKNeeded(ctx, teamID, *merkleRootPtr, statement)
+}
+
+func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot, statement *keybase1.TeamEkStatement) (needed bool, err error) {
+	// Let's see what the latest server statement is.
+	// No statement, so we need a teamEK
+	if statement == nil {
+		return true, nil
+	}
+	// Can we access this generation? If not, let's regenerate.
+	s := e.G().GetTeamEKBoxStorage()
+	ek, err := s.Get(ctx, teamID, statement.CurrentTeamEkMetadata.Generation)
+	if err != nil {
+		switch err.(type) {
+		case *EKUnboxErr:
+			e.G().Log.Debug(err.Error())
+			return true, nil
+		default:
+			return false, err
+		}
+	}
+	// Ok we can access the ek, check lifetime.
+	return keygenExpired(ek.Metadata.Ctime, merkleRoot), nil
+}
+
+func (e *EKLib) GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (teamEK keybase1.TeamEk, err error) {
+	// TODO put an LRU cache in front of this with a short lifetime so we don't
+	// hit the server ever time we want the latest key for a team.
+	e.Lock()
+	defer e.Unlock()
+
+	if loggedIn, err := e.G().LoginState().LoggedInLoad(); err != nil {
+		return teamEK, err
+	} else if !loggedIn {
+		return teamEK, fmt.Errorf("Aborting ephemeral key generation, user is not logged in!")
 	}
 
-	return keybase1.Time(merkleRoot.Ctime())-ek.Metadata.Ctime >= KeyGenLifetimeSecs, nil
+	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(ctx, libkb.EphemeralKeyMerkleFreshness)
+	if err != nil {
+		return teamEK, err
+	}
+	merkleRoot := *merkleRootPtr
+
+	// First publish new device or userEKs if we need to.
+	if err = e.keygenIfNeeded(ctx, merkleRoot); err != nil {
+		return teamEK, err
+	}
+
+	statement, err := fetchTeamEKStatement(ctx, e.G(), teamID)
+	if err != nil {
+		return teamEK, err
+	}
+
+	var publishedMetadata keybase1.TeamEkMetadata
+	if teamEKNeeded, err := e.newTeamEKNeeded(ctx, teamID, merkleRoot, statement); err != nil {
+		return teamEK, err
+	} else if teamEKNeeded {
+		publishedMetadata, err = publishNewTeamEK(ctx, e.G(), teamID, merkleRoot)
+		// TODO implement a gregor notification for other clients to clear
+		// their cache and fetch the latest teamEK
+		if err != nil {
+			return teamEK, err
+		}
+	} else {
+		publishedMetadata = statement.CurrentTeamEkMetadata
+	}
+
+	teamEKBoxStorage := e.G().GetTeamEKBoxStorage()
+	_, err = teamEKBoxStorage.DeleteExpired(ctx, teamID, merkleRoot)
+	if err != nil {
+		return teamEK, err
+	}
+	return teamEKBoxStorage.Get(ctx, teamID, publishedMetadata.Generation)
 }
 
 func (e *EKLib) OnLogin() error {

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
@@ -15,43 +14,171 @@ func TestKeygenIfNeeded(t *testing.T) {
 	defer tc.Cleanup()
 
 	ekLib := NewEKLib(tc.G)
-	userEKBoxStorage := NewUserEKBoxStorage(tc.G)
-	deviceEKStorage := NewDeviceEKStorage(tc.G)
-	keygen := func() {
+	deviceEKStorage := tc.G.GetDeviceEKStorage()
+	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
+
+	expectedDeviceEKGen, err := deviceEKStorage.MaxGeneration(context.Background())
+	require.NoError(t, err)
+	if expectedDeviceEKGen < 0 {
+		expectedDeviceEKGen = 1
+		deviceEKNeeded, err := ekLib.NewDeviceEKNeeded(context.Background())
+		require.NoError(t, err)
+		require.True(t, deviceEKNeeded)
+
+	}
+
+	expectedUserEKGen, err := userEKBoxStorage.MaxGeneration(context.Background())
+	require.NoError(t, err)
+	if expectedUserEKGen < 0 {
+		expectedUserEKGen = 1
+		userEKNeeded, err := ekLib.NewUserEKNeeded(context.Background())
+		require.NoError(t, err)
+		require.True(t, userEKNeeded)
+	}
+
+	keygen := func(expectedDeviceEKGen, expectedUserEKGen keybase1.EkGeneration) {
 		err := ekLib.KeygenIfNeeded(context.Background())
 		require.NoError(t, err)
 
-		deviceEKs, err := deviceEKStorage.GetAll(context.Background())
+		// verify deviceEK
+		deviceEKNeeded, err := ekLib.NewDeviceEKNeeded(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, 1, len(deviceEKs))
+		require.False(t, deviceEKNeeded)
 
-		userEKs, err := userEKBoxStorage.GetAll(context.Background())
+		deviceEKMaxGen, err := deviceEKStorage.MaxGeneration(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, 1, len(userEKs))
+		require.Equal(t, expectedDeviceEKGen, deviceEKMaxGen)
+
+		// verify userEK
+		userEKNeeded, err := ekLib.NewUserEKNeeded(context.Background())
+		require.NoError(t, err)
+		require.False(t, userEKNeeded)
+
+		userEKMaxGen, err := userEKBoxStorage.MaxGeneration(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expectedUserEKGen, userEKMaxGen)
 	}
 
 	// If we retry keygen, we don't regenerate keys
-	keygen()
-	keygen()
+	keygen(expectedDeviceEKGen, expectedUserEKGen)
+	keygen(expectedDeviceEKGen, expectedUserEKGen)
+
+	rawDeviceEKStorage := NewDeviceEKStorage(tc.G)
+	rawUserEKBoxStorage := NewUserEKBoxStorage(tc.G)
 
 	// Let's purge our local userEK store and make sure we don't regenerate
 	// (respecting the server max)
-	userEKs, err := userEKBoxStorage.GetAll(context.Background())
+	err = rawUserEKBoxStorage.Delete(context.Background(), expectedUserEKGen)
 	require.NoError(t, err)
-	for generation := range userEKs {
-		userEKBoxStorage.Delete(context.Background(), generation)
-	}
-	tc.G.GetUserEKBoxStorage().ClearCache()
-	keygen()
+	userEKBoxStorage.ClearCache()
+	keygen(expectedDeviceEKGen, expectedUserEKGen)
 
 	// Now let's kill our deviceEK as well, so we should regenerate a new
 	// userEK since we can't access the old one
-	deviceEKs, err := deviceEKStorage.GetAll(context.Background())
+	err = rawDeviceEKStorage.Delete(context.Background(), expectedDeviceEKGen)
 	require.NoError(t, err)
-	for generation := range deviceEKs {
-		deviceEKStorage.Delete(context.Background(), generation)
+	deviceEKStorage.ClearCache()
+	expectedDeviceEKGen++
+	expectedUserEKGen++
+	keygen(expectedDeviceEKGen, expectedUserEKGen)
+}
+
+func TestNewTeamEKNeeded(t *testing.T) {
+	tc := ephemeralKeyTestSetup(t)
+	defer tc.Cleanup()
+
+	teamID := createTeam(tc)
+	ekLib := NewEKLib(tc.G)
+	deviceEKStorage := tc.G.GetDeviceEKStorage()
+	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
+	teamEKBoxStorage := tc.G.GetTeamEKBoxStorage()
+
+	// We don't have any keys, so we should need a new teamEK
+	needed, err := ekLib.NewTeamEKNeeded(context.Background(), teamID)
+	require.NoError(t, err)
+	require.True(t, needed)
+
+	expectedTeamEKGen, err := teamEKBoxStorage.MaxGeneration(context.Background(), teamID)
+	require.NoError(t, err)
+	if expectedTeamEKGen < 0 {
+		expectedTeamEKGen = 1
 	}
-	keygen()
+
+	expectedDeviceEKGen, err := deviceEKStorage.MaxGeneration(context.Background())
+	require.NoError(t, err)
+	if expectedDeviceEKGen < 0 {
+		expectedDeviceEKGen = 1
+	}
+
+	expectedUserEKGen, err := userEKBoxStorage.MaxGeneration(context.Background())
+	require.NoError(t, err)
+	if expectedUserEKGen < 0 {
+		expectedUserEKGen = 1
+	}
+
+	keygen := func(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen keybase1.EkGeneration) {
+		teamEK, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+		require.NoError(t, err)
+
+		// verify deviceEK
+		deviceEKNeeded, err := ekLib.NewDeviceEKNeeded(context.Background())
+		require.NoError(t, err)
+		require.False(t, deviceEKNeeded)
+
+		deviceEKMaxGen, err := deviceEKStorage.MaxGeneration(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expectedDeviceEKGen, deviceEKMaxGen)
+
+		// verify userEK
+		userEKNeeded, err := ekLib.NewUserEKNeeded(context.Background())
+		require.NoError(t, err)
+		require.False(t, userEKNeeded)
+
+		userEKMaxGen, err := userEKBoxStorage.MaxGeneration(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expectedUserEKGen, userEKMaxGen)
+
+		// verify teamEK
+		teamEKGen, err := teamEKBoxStorage.MaxGeneration(context.Background(), teamID)
+		require.NoError(t, err)
+		require.Equal(t, expectedTeamEKGen, teamEKGen)
+		require.Equal(t, expectedTeamEKGen, teamEK.Metadata.Generation)
+
+		teamEKNeeded, err := ekLib.NewTeamEKNeeded(context.Background(), teamID)
+		require.NoError(t, err)
+		require.False(t, teamEKNeeded)
+	}
+
+	// If we retry keygen, we don't regenerate keys
+	keygen(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	keygen(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+
+	rawDeviceEKStorage := NewDeviceEKStorage(tc.G)
+	rawUserEKBoxStorage := NewUserEKBoxStorage(tc.G)
+	rawTeamEKBoxStorage := NewTeamEKBoxStorage(tc.G)
+
+	// Let's purge our local teamEK store and make sure we don't regenerate
+	// (respecting the server max)
+	err = rawTeamEKBoxStorage.Delete(context.Background(), teamID, expectedTeamEKGen)
+	require.NoError(t, err)
+	teamEKBoxStorage.ClearCache()
+	keygen(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+
+	// Now let's kill our userEK, we should gracefully not regenerate
+	// since we can still fetch the userEK from the server.
+	err = rawUserEKBoxStorage.Delete(context.Background(), expectedUserEKGen)
+	require.NoError(t, err)
+	tc.G.GetDeviceEKStorage().ClearCache()
+	keygen(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+
+	// Now let's kill our deviceEK as well, and we should generate all new keys
+	err = rawDeviceEKStorage.Delete(context.Background(), expectedDeviceEKGen)
+	require.NoError(t, err)
+	tc.G.GetDeviceEKStorage().ClearCache()
+	expectedDeviceEKGen++
+	expectedUserEKGen++
+	expectedTeamEKGen++
+	keygen(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
 }
 
 func TestCleanupStaleUserAndDeviceEKs(t *testing.T) {
@@ -70,18 +197,14 @@ func TestCleanupStaleUserAndDeviceEKs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
-	require.NoError(t, err)
-	merkleRoot := *merkleRootPtr
-
 	ekLib := NewEKLib(tc.G)
-	err = ekLib.CleanupStaleUserAndDeviceEKs(context.Background(), merkleRoot)
+	err = ekLib.CleanupStaleUserAndDeviceEKs(context.Background())
 	require.NoError(t, err)
 
 	deviceEK, err := s.Get(context.Background(), 0)
 	require.Error(t, err)
 	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 
-	err = ekLib.CleanupStaleUserAndDeviceEKs(context.Background(), merkleRoot)
+	err = ekLib.CleanupStaleUserAndDeviceEKs(context.Background())
 	require.NoError(t, err)
 }

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -150,7 +150,7 @@ func signAndPublishTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID ke
 		return metadata, nil, err
 	}
 
-	return metadata, nil, nil
+	return metadata, myTeamEKBoxed, nil
 }
 
 func boxTeamEKForMembers(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot, seed TeamEKSeed, teamMetadata keybase1.TeamEkMetadata) (boxes []TeamEKBoxMetadata, myTeamEKBoxed *keybase1.TeamEkBoxed, err error) {

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -173,7 +173,8 @@ func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.
 	userEKBoxStorage := s.G().GetUserEKBoxStorage()
 	userEK, err := userEKBoxStorage.Get(ctx, teamEKBoxed.UserEkGeneration)
 	if err != nil {
-		return teamEK, newEKUnboxErr(TEAM_EK, teamEKGeneration, USER_EK, teamEKBoxed.UserEkGeneration)
+		s.G().Log.CWarningf(ctx, "%v", err)
+		return teamEK, newEKUnboxErr(TeamEKStr, teamEKGeneration, UserEKStr, teamEKBoxed.UserEkGeneration)
 	}
 
 	userSeed := UserEKSeed(userEK.Seed)
@@ -181,7 +182,8 @@ func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.
 
 	msg, _, err := userKeypair.DecryptFromString(teamEKBoxed.Box)
 	if err != nil {
-		return teamEK, newEKUnboxErr(TEAM_EK, teamEKGeneration, USER_EK, teamEKBoxed.UserEkGeneration)
+		s.G().Log.CWarningf(ctx, "%v", err)
+		return teamEK, newEKUnboxErr(TeamEKStr, teamEKGeneration, UserEKStr, teamEKBoxed.UserEkGeneration)
 	}
 
 	seed, err := newTeamEKSeedFromBytes(msg)

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -65,7 +65,7 @@ func (s *TeamEKBoxStorage) Get(ctx context.Context, teamID keybase1.TeamID, gene
 		return s.fetchAndPut(ctx, teamID, generation)
 	}
 	defer s.Unlock() // release the lock after we unbox
-	return s.unbox(ctx, teamEKBoxed)
+	return s.unbox(ctx, generation, teamEKBoxed)
 }
 
 func (s *TeamEKBoxStorage) getMap(ctx context.Context, teamID keybase1.TeamID) (teamEKBoxes TeamEKBoxMap, found bool, err error) {
@@ -150,7 +150,7 @@ func (s *TeamEKBoxStorage) fetchAndPut(ctx context.Context, teamID keybase1.Team
 		Metadata:         teamEKMetadata,
 	}
 
-	teamEK, err = s.unbox(ctx, teamEKBoxed)
+	teamEK, err = s.unbox(ctx, generation, teamEKBoxed)
 	if err != nil {
 		return teamEK, err
 	}
@@ -167,14 +167,13 @@ func (s *TeamEKBoxStorage) fetchAndPut(ctx context.Context, teamID keybase1.Team
 	return teamEK, err
 }
 
-func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKBoxed keybase1.TeamEkBoxed) (teamEK keybase1.TeamEk, err error) {
+func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) (teamEK keybase1.TeamEk, err error) {
 	defer s.G().CTrace(ctx, "TeamEKBoxStorage#unbox", func() error { return err })()
 
 	userEKBoxStorage := s.G().GetUserEKBoxStorage()
 	userEK, err := userEKBoxStorage.Get(ctx, teamEKBoxed.UserEkGeneration)
-	// TODO return specific error
 	if err != nil {
-		return teamEK, err
+		return teamEK, newEKUnboxErr(TEAM_EK, teamEKGeneration, USER_EK, teamEKBoxed.UserEkGeneration)
 	}
 
 	userSeed := UserEKSeed(userEK.Seed)
@@ -182,7 +181,7 @@ func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKBoxed keybase1.TeamE
 
 	msg, _, err := userKeypair.DecryptFromString(teamEKBoxed.Box)
 	if err != nil {
-		return teamEK, err
+		return teamEK, newEKUnboxErr(TEAM_EK, teamEKGeneration, USER_EK, teamEKBoxed.UserEkGeneration)
 	}
 
 	seed, err := newTeamEKSeedFromBytes(msg)
@@ -287,7 +286,7 @@ func (s *TeamEKBoxStorage) GetAll(ctx context.Context, teamID keybase1.TeamID) (
 	}
 
 	for generation, teamEKBoxed := range teamEKBoxes {
-		teamEK, err := s.unbox(ctx, teamEKBoxed)
+		teamEK, err := s.unbox(ctx, generation, teamEKBoxed)
 		if err != nil {
 			return nil, err
 		}

--- a/go/ephemeral/team_ek_test.go
+++ b/go/ephemeral/team_ek_test.go
@@ -34,7 +34,7 @@ func TestNewTeamEK(t *testing.T) {
 
 	teamID := createTeam(tc)
 
-	// Before we've published any teamEK's, ActiveTeamEKMetadata should return nil.
+	// Before we've published any teamEK's, fetchTeamEKStatement should return nil.
 	nilStatement, err := fetchTeamEKStatement(context.Background(), tc.G, teamID)
 	require.NoError(t, err)
 	require.Nil(t, nilStatement)
@@ -56,6 +56,14 @@ func TestNewTeamEK(t *testing.T) {
 	require.Equal(t, currentMetadata, publishedMetadata)
 	require.EqualValues(t, 1, currentMetadata.Generation)
 	require.Equal(t, statement.ExistingTeamEkMetadata, []keybase1.TeamEkMetadata{})
+
+	// We've stored the result in local storage
+	teamEKBoxStorage := tc.G.GetTeamEKBoxStorage()
+	maxGeneration, err := teamEKBoxStorage.MaxGeneration(context.Background(), teamID)
+	require.NoError(t, err)
+	ek, err := teamEKBoxStorage.Get(context.Background(), teamID, maxGeneration)
+	require.NoError(t, err)
+	require.Equal(t, ek.Metadata, publishedMetadata)
 
 	s := NewTeamEKBoxStorage(tc.G)
 	// Put our storage in a bad state by deleting the maxGeneration

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -185,7 +185,8 @@ func (s *UserEKBoxStorage) unbox(ctx context.Context, userEKGeneration keybase1.
 	deviceEKStorage := s.G().GetDeviceEKStorage()
 	deviceEK, err := deviceEKStorage.Get(ctx, userEKBoxed.DeviceEkGeneration)
 	if err != nil {
-		return userEK, newEKUnboxErr(USER_EK, userEKGeneration, DEVICE_EK, userEKBoxed.DeviceEkGeneration)
+		s.G().Log.CWarningf(ctx, "%v", err)
+		return userEK, newEKUnboxErr(UserEKStr, userEKGeneration, DeviceEKStr, userEKBoxed.DeviceEkGeneration)
 	}
 
 	deviceSeed := DeviceEKSeed(deviceEK.Seed)
@@ -193,7 +194,8 @@ func (s *UserEKBoxStorage) unbox(ctx context.Context, userEKGeneration keybase1.
 
 	msg, _, err := deviceKeypair.DecryptFromString(userEKBoxed.Box)
 	if err != nil {
-		return userEK, newEKUnboxErr(USER_EK, userEKGeneration, DEVICE_EK, userEKBoxed.DeviceEkGeneration)
+		s.G().Log.CWarningf(ctx, "%v", err)
+		return userEK, newEKUnboxErr(UserEKStr, userEKGeneration, DeviceEKStr, userEKBoxed.DeviceEkGeneration)
 	}
 
 	seed, err := newUserEKSeedFromBytes(msg)

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -42,6 +42,13 @@ func TestNewUserEK(t *testing.T) {
 	require.EqualValues(t, 1, currentMetadata.Generation)
 	require.Equal(t, statement.ExistingUserEkMetadata, []keybase1.UserEkMetadata{})
 
+	// We've stored the result in local storage
+	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
+	maxGeneration, err := userEKBoxStorage.MaxGeneration(context.Background())
+	ek, err := userEKBoxStorage.Get(context.Background(), maxGeneration)
+	require.NoError(t, err)
+	require.Equal(t, ek.Metadata, publishedMetadata)
+
 	rawStorage := NewUserEKBoxStorage(tc.G)
 	// Put our storage in a bad state by deleting the maxGeneration
 	err = rawStorage.Delete(context.Background(), keybase1.EkGeneration(1))

--- a/go/kex2/transport.go
+++ b/go/kex2/transport.go
@@ -104,7 +104,7 @@ const sessionIDText = "Kex v2 Session ID"
 
 // NewConn establishes a Kex session based on the given secret. Will work for
 // both ends of the connection, regardless of which order the two started
-// their conntection. Will communicate with the other end via the given message router.
+// their connection. Will communicate with the other end via the given message router.
 // You can specify an optional timeout to cancel any reads longer than that timeout.
 func NewConn(ctx context.Context, lctx LogContext, r MessageRouter, s Secret, d DeviceID, readTimeout time.Duration) (con net.Conn, err error) {
 	mac := hmac.New(sha256.New, []byte(s[:]))

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -640,6 +640,7 @@ type TeamEKBoxStorage interface {
 
 type EKLib interface {
 	KeygenIfNeeded(ctx context.Context) error
+	GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (keybase1.TeamEk, error)
 }
 
 type ImplicitTeamConflictInfoCacher interface {


### PR DESCRIPTION
Fixes a bug where if the local store was out of date or had no data (i.e. after logout), we would incorrectly publish a new userEK.

Exposes `GetOrCreateLatestTeamEK`. We have to complete a few TODOs before this is fully ready to be used by chat

Depends on https://github.com/keybase/keybase/pull/2252 before tests will pass..