### PR TITLE
Add WalletInitBackground task

### DIFF
--- a/go/engine/wallet_init_background.go
+++ b/go/engine/wallet_init_background.go
@@ -1,0 +1,104 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// WalletInitBackground creates the initial wallet for a user the the background.
+
+package engine
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/stellar"
+)
+
+var WalletInitBackgroundSettings = BackgroundTaskSettings{
+	// Wait after starting the app
+	Start: 15 * time.Second,
+	// When waking up on mobile lots of timers will go off at once. We wait an additional
+	// delay so as not to add to that herd and slow down the mobile experience when opening the app.
+	WakeUp: 12 * time.Second,
+	// Wait between checks
+	Interval: 6 * time.Hour,
+	// Time limit on each round
+	Limit: 5 * time.Minute,
+}
+
+// WalletInitBackground is an engine.
+type WalletInitBackground struct {
+	libkb.Contextified
+	sync.Mutex
+
+	args *WalletInitBackgroundArgs
+	task *BackgroundTask
+}
+
+type WalletInitBackgroundArgs struct {
+	// Channels used for testing. Normally nil.
+	testingMetaCh     chan<- string
+	testingRoundResCh chan<- error
+}
+
+// NewWalletInitBackground creates a WalletInitBackground engine.
+func NewWalletInitBackground(g *libkb.GlobalContext, args *WalletInitBackgroundArgs) *WalletInitBackground {
+	task := NewBackgroundTask(g, &BackgroundTaskArgs{
+		Name:     "WalletInitBackground",
+		F:        WalletInitBackgroundRound,
+		Settings: WalletInitBackgroundSettings,
+
+		testingMetaCh:     args.testingMetaCh,
+		testingRoundResCh: args.testingRoundResCh,
+	})
+	return &WalletInitBackground{
+		Contextified: libkb.NewContextified(g),
+		args:         args,
+		// Install the task early so that Shutdown can be called before RunEngine.
+		task: task,
+	}
+}
+
+// Name is the unique engine name.
+func (e *WalletInitBackground) Name() string {
+	return "WalletInitBackground"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *WalletInitBackground) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *WalletInitBackground) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *WalletInitBackground) SubConsumers() []libkb.UIConsumer {
+	return []libkb.UIConsumer{}
+}
+
+// Run starts the engine.
+// Returns immediately, kicks off a background goroutine.
+func (e *WalletInitBackground) Run(ctx *Context) (err error) {
+	return RunEngine(e.task, ctx)
+}
+
+func (e *WalletInitBackground) Shutdown() {
+	e.task.Shutdown()
+}
+
+func WalletInitBackgroundRound(g *libkb.GlobalContext, ectx *Context) error {
+	if g.ConnectivityMonitor.IsConnected(ectx.GetNetContext()) == libkb.ConnectivityMonitorNo {
+		g.Log.CDebugf(ectx.GetNetContext(), "WalletInitBackgroundRound giving up offline")
+		return nil
+	}
+
+	if !g.LocalSigchainGuard().IsAvailable(ectx.GetNetContext(), "WalletInitBackgroundRound") {
+		g.Log.CDebugf(ectx.GetNetContext(), "WalletInitBackgroundRound yielding to guard")
+		return nil
+	}
+
+	_, err := stellar.CreateWalletGated(ectx.GetNetContext(), g)
+	return err
+}

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -10,6 +10,25 @@ import (
 	"github.com/keybase/client/go/stellar/bundle"
 )
 
+type shouldCreateRes struct {
+	Status       libkb.AppStatus `json:"status"`
+	ShouldCreate bool            `json:"shouldcreate"`
+}
+
+func (r *shouldCreateRes) GetAppStatus() *libkb.AppStatus {
+	return &r.Status
+}
+
+// ShouldCreate asks the server whether to create this user's initial wallet.
+func ShouldCreate(ctx context.Context, g *libkb.GlobalContext) (should bool, err error) {
+	defer g.CTraceTimed(ctx, "Stellar.ShouldCreate", func() error { return err })()
+	arg := libkb.NewAPIArgWithNetContext(ctx, "stellar/shouldcreate")
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	var apiRes shouldCreateRes
+	err = g.API.GetDecode(arg, &apiRes)
+	return apiRes.ShouldCreate, err
+}
+
 // Post a bundle to the server
 func PostWithChainlink(ctx context.Context, g *libkb.GlobalContext, clearBundle keybase1.StellarBundle) (err error) {
 	defer g.CTraceTimed(ctx, "Stellar.Post", func() error { return err })()

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1,0 +1,53 @@
+package stellar
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/stellar/bundle"
+	"github.com/keybase/client/go/stellar/remote"
+)
+
+// CreateWallet creates and posts an initial stellar bundle for a user.
+// Only succeeds if they do not already have one.
+// Safe to call even if the user has a bundle already.
+func CreateWallet(ctx context.Context, g *libkb.GlobalContext) (created bool, err error) {
+	defer g.CTraceTimed(ctx, "Stellar.CreateWallet", func() error { return err })()
+	// TODO: short-circuit if the user has a bundle already
+	clearBundle, err := bundle.NewInitialBundle()
+	if err != nil {
+		return created, err
+	}
+	err = remote.PostWithChainlink(ctx, g, clearBundle)
+	switch e := err.(type) {
+	case nil:
+		// ok
+	case libkb.AppStatusError:
+		switch keybase1.StatusCode(e.Code) {
+		case keybase1.StatusCode_SCStellarWrongRevision:
+			// Assume this happened because a bundle already existed.
+			// And suppress the error.
+			g.Log.CDebugf(ctx, "suppressing error: %v", err)
+			return false, nil
+		}
+		return false, err
+	default:
+		return false, err
+	}
+	return true, err
+}
+
+func CreateWalletGated(ctx context.Context, g *libkb.GlobalContext) (created bool, err error) {
+	defer g.CTraceTimed(ctx, "Stellar.CreateWalletGated", func() error { return err })()
+	// TODO: short-circuit if the user has a bundle already
+	should, err := remote.ShouldCreate(ctx, g)
+	if err != nil {
+		return false, err
+	}
+	if !should {
+		g.Log.CDebugf(ctx, "server did not recommend wallet creation")
+		return false, nil
+	}
+	return CreateWallet(ctx, g)
+}

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -4,9 +4,7 @@ import (
 	"context"
 
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/stellar/bundle"
-	"github.com/keybase/client/go/stellar/remote"
+	"github.com/keybase/client/go/stellar"
 )
 
 // Service handlers
@@ -15,28 +13,5 @@ import (
 // Only succeeds if they do not already have one.
 // Safe to call even if the user has a bundle already.
 func CreateWallet(ctx context.Context, g *libkb.GlobalContext) (created bool, err error) {
-	defer g.CTraceTimed(ctx, "Stellar.CreateWallet", func() error { return err })()
-	// TODO: short-circuit if the user has a bundle already
-
-	clearBundle, err := bundle.NewInitialBundle()
-	if err != nil {
-		return created, err
-	}
-	err = remote.PostWithChainlink(ctx, g, clearBundle)
-	switch e := err.(type) {
-	case nil:
-		// ok
-	case libkb.AppStatusError:
-		switch keybase1.StatusCode(e.Code) {
-		case keybase1.StatusCode_SCStellarWrongRevision:
-			// Assume this happened because a bundle already existed.
-			// And suppress the error.
-			g.Log.CDebugf(ctx, "suppressing error: %v", err)
-			return false, nil
-		}
-		return false, err
-	default:
-		return false, err
-	}
-	return true, err
+	return stellar.CreateWallet(ctx, g)
 }


### PR DESCRIPTION
Add a background task that creates a user's initial wallet. The background task aspect is the same as `PerUserKeyUpkeepBackground` and `PerUserKeyUpgradeBackground`. The creation is gated by first hitting the server's `stellar/shouldcreate` endpoint (https://github.com/keybase/keybase/pull/2253).

Moved the body of `CreateWallet` from `stellar/service` into `stellar`.
The deps are like this
`stellar/service` depends on `stellar/`.
`stellar/` can depend on `stellar/*` (with the exception of service).

~~On top of https://github.com/keybase/client/pull/11040~~