### PR TITLE
ptrace protection attempt 2

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -99,13 +99,15 @@ func main() {
 }
 
 func tryToDisableProcessTracing(log logger.Logger, e *libkb.Env) {
+	if e.GetRunMode() != libkb.ProductionRunMode || e.AllowPTrace() {
+		return
+	}
+
 	// We do our best but if it's not possible on some systems or
 	// configurations, it's not a fatal error. Also see documentation
 	// in ptrace_*.go files.
-	if e.GetRunMode() == libkb.ProductionRunMode {
-		if err := libkb.DisableProcessTracing(); err != nil {
-			log.Debug("Unable to disable process tracing: %v", err.Error())
-		}
+	if err := libkb.DisableProcessTracing(); err != nil {
+		log.Debug("Unable to disable process tracing: %v", err.Error())
 	}
 }
 

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -70,13 +70,11 @@ func main() {
 
 	// We do our best but if it's not possible on some systems or
 	// configurations, do not exit. Also see documentation in
-	// ptrace.go file.
+	// ptrace_*.go files.
 	if err := libkb.DisableProcessTracing(); err != nil {
 		startupErrors = append(startupErrors,
 			fmt.Errorf("Unable to disable process tracing: %v\n", err.Error()))
 	}
-
-	startupErrors = append(startupErrors, fmt.Errorf("Hello world"))
 
 	// Set our panel of external services.
 	g.SetServices(externals.GetServices())

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -63,6 +63,13 @@ func main() {
 		g.Log.Errorf("SaferDLLLoading error: %v", err.Error())
 	}
 
+	// We do our best but if it's not possible on some systems or
+	// configurations, do not exit. Also see documentation in
+	// ptrace.go file.
+	if err := libkb.DisableProcessTracing(); err != nil {
+		fmt.Printf("Unable to disable process tracing: %v\n", err.Error())
+	}
+
 	// Set our panel of external services.
 	g.SetServices(externals.GetServices())
 

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -104,7 +104,7 @@ func tryToDisableProcessTracing(log logger.Logger, e *libkb.Env) {
 	// in ptrace_*.go files.
 	if e.GetRunMode() == libkb.ProductionRunMode {
 		if err := libkb.DisableProcessTracing(); err != nil {
-			log.Debug("Unable to disable process tracing: %v\n", err.Error())
+			log.Debug("Unable to disable process tracing: %v", err.Error())
 		}
 	}
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1343,3 +1343,9 @@ func GetPlatformString() string {
 	}
 	return runtime.GOOS
 }
+
+func (e *Env) AllowPTrace() bool {
+	return e.GetBool(false,
+		func() (bool, bool) { return e.getEnvBool("KEYBASE_ALLOW_PTRACE") },
+	)
+}

--- a/go/libkb/ptrace_linux.go
+++ b/go/libkb/ptrace_linux.go
@@ -1,0 +1,31 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build linux,!android
+
+package libkb
+
+import (
+	"syscall"
+)
+
+// Disallow ptrace attachment on linux system by setting
+// PR_SET_DUMPABLE. This makes it impossible to e.g. attach gdb or use
+// gcore on keybase process. Modern linux system are already ptrace-
+// hardened by setting "restricted ptrace" using Yama
+// (https://www.kernel.org/doc/Documentation/security/Yama.txt).
+
+// Note that one can still attach ptrace as root, unless ptrace_scope
+// is set to 3, which locks ptrace completely.
+
+func prctl(option int, arg uint64) error {
+	_, _, errno := syscall.Syscall6(syscall.SYS_PRCTL, uintptr(option), uintptr(arg), 0, 0, 0, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func DisableProcessTracing() error {
+	return prctl(syscall.PR_SET_DUMPABLE, 0)
+}

--- a/go/libkb/ptrace_osx.go
+++ b/go/libkb/ptrace_osx.go
@@ -1,0 +1,29 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build darwin
+
+package libkb
+
+import (
+	"syscall"
+)
+
+// Disallow ptrace attachment by using MacOS specific PT_DENY_ATTACH
+// ptrace call. This blocks attempts at attaching ptrace to current
+// process and drops any other processes that are currently attaching
+// to current process.
+
+const PT_DENY_ATTACH = 31
+
+func ptrace(request, pid int, addr uintptr, data uintptr) error {
+	_, _, errno = syscall.Syscall6(syscall.SYS_PTRACE, uintptr(request), uintptr(pid), uintptr(addr), uintptr(data), 0, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func DisableProcessTracing() error {
+	return ptrace(PT_DENY_ATTACH, 0, 0, 0)
+}

--- a/go/libkb/ptrace_osx.go
+++ b/go/libkb/ptrace_osx.go
@@ -14,10 +14,10 @@ import (
 // process and drops any other processes that are currently attaching
 // to current process.
 
-const PT_DENY_ATTACH = 31
+const PtDenyAttach = 31
 
 func ptrace(request, pid int, addr uintptr, data uintptr) error {
-	_, _, errno = syscall.Syscall6(syscall.SYS_PTRACE, uintptr(request), uintptr(pid), uintptr(addr), uintptr(data), 0, 0)
+	_, _, errno := syscall.Syscall6(syscall.SYS_PTRACE, uintptr(request), uintptr(pid), uintptr(addr), uintptr(data), 0, 0)
 	if errno != 0 {
 		return errno
 	}
@@ -25,5 +25,5 @@ func ptrace(request, pid int, addr uintptr, data uintptr) error {
 }
 
 func DisableProcessTracing() error {
-	return ptrace(PT_DENY_ATTACH, 0, 0, 0)
+	return ptrace(PtDenyAttach, 0, 0, 0)
 }

--- a/go/libkb/ptrace_other.go
+++ b/go/libkb/ptrace_other.go
@@ -1,0 +1,10 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build !darwin,!linux
+
+package libkb
+
+func DisableTracing() error {
+	return nil
+}

--- a/go/libkb/ptrace_other.go
+++ b/go/libkb/ptrace_other.go
@@ -5,6 +5,6 @@
 
 package libkb
 
-func DisableTracing() error {
+func DisableProcessTracing() error {
 	return nil
 }

--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -86,8 +86,17 @@ build_one_architecture() {
   fakeroot dpkg-deb --build "$dest/build" "$dest/$name-$version-$debian_arch.deb"
 }
 
-export debian_arch=amd64
-build_one_architecture
+if [ -z "${KEYBASE_SKIP_64_BIT:-}" ] ; then
+  export debian_arch=amd64
+  build_one_architecture
+else
+  echo SKIPPING 64-bit deb package
+fi
 
-export debian_arch=i386
-build_one_architecture
+if [ -z "${KEYBASE_SKIP_32_BIT:-}" ] ; then
+  export debian_arch=i386
+  build_one_architecture
+else
+  echo SKIPPING 32-bit deb package
+fi
+

--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -32,7 +32,9 @@ elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/deb"
   # "psmisc" provides "killall", which is used in run_keybase and
   # post_install.sh.
-  dependencies="Depends: libappindicator1, fuse, libgconf-2-4, psmisc"
+  # "procps" provides "pkill", which is used when we can't use killall
+  # becuase of PR_SET_DUMPABLE.
+  dependencies="Depends: libappindicator1, fuse, libgconf-2-4, psmisc, procps"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean repo

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -111,7 +111,7 @@ if [ -z "${KEYBASE_SKIP_64_BIT:-}" ] ; then
   export debian_arch=amd64
   # Requiring "libXss.so" here installs the 32-bit version. See
   # https://github.com/keybase/client/pull/5226.
-  dependencies="Requires: at, fuse, libXss.so.1()(64bit), initscripts, psmisc"
+  dependencies="Requires: at, fuse, libXss.so.1()(64bit), initscripts, psmisc, procps"
   build_one_architecture
 else
   echo SKIPPING 64-bit rpm package
@@ -124,9 +124,10 @@ if [ -z "${KEYBASE_SKIP_32_BIT:-}" ] ; then
   # which provides libXss.so. Unfortunately that doesn't work on
   # OpenSUSE. This is the most compatible set of dependencies we've
   # found.  "psmisc" provides "killall", which is used in run_keybase.
+  # "procps" provides "pkill", which is also used in run_keybase.
   # "initscripts" provides "service", which is used to start atd in the
   # post-install.
-  dependencies="Requires: at, fuse, libXss.so.1, initscripts, psmisc"
+  dependencies="Requires: at, fuse, libXss.so.1, initscripts, psmisc, procps"
   build_one_architecture
 else
   echo SKIPPING 32-bit rpm package

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -106,20 +106,29 @@ build_one_architecture() {
   rpmbuild --define "_topdir $dest" --target "$rpm_arch" -bb "$spec"
 }
 
-export rpm_arch=i386
-export debian_arch=i386
-# On Fedora, it would be more correct to require "libXScrnSaver",
-# which provides libXss.so. Unfortunately that doesn't work on
-# OpenSUSE. This is the most compatible set of dependencies we've
-# found.  "psmisc" provides "killall", which is used in run_keybase.
-# "initscripts" provides "service", which is used to start atd in the
-# post-install.
-dependencies="Requires: at, fuse, libXss.so.1, initscripts, psmisc"
-build_one_architecture
+if [ -z "${KEYBASE_SKIP_64_BIT:-}" ] ; then
+  export rpm_arch=x86_64
+  export debian_arch=amd64
+  # Requiring "libXss.so" here installs the 32-bit version. See
+  # https://github.com/keybase/client/pull/5226.
+  dependencies="Requires: at, fuse, libXss.so.1()(64bit), initscripts, psmisc"
+  build_one_architecture
+else
+  echo SKIPPING 64-bit rpm package
+fi
 
-export rpm_arch=x86_64
-export debian_arch=amd64
-# Requiring "libXss.so" here installs the 32-bit version. See
-# https://github.com/keybase/client/pull/5226.
-dependencies="Requires: at, fuse, libXss.so.1()(64bit), initscripts, psmisc"
-build_one_architecture
+if [ -z "${KEYBASE_SKIP_32_BIT:-}" ] ; then
+  export rpm_arch=i386
+  export debian_arch=i386
+  # On Fedora, it would be more correct to require "libXScrnSaver",
+  # which provides libXss.so. Unfortunately that doesn't work on
+  # OpenSUSE. This is the most compatible set of dependencies we've
+  # found.  "psmisc" provides "killall", which is used in run_keybase.
+  # "initscripts" provides "service", which is used to start atd in the
+  # post-install.
+  dependencies="Requires: at, fuse, libXss.so.1, initscripts, psmisc"
+  build_one_architecture
+else
+  echo SKIPPING 32-bit rpm package
+fi
+

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -118,7 +118,11 @@ kill_all() {
   if killall kbfsfuse &> /dev/null ; then
     echo Shutting down kbfsfuse...
   fi
-  if killall keybase &> /dev/null ; then
+  # Use pkill instead of killall because service sets itself as non-
+  # dumpable, which changes ownership of /proc/[pid], giving killall
+  # trouble finding `keybase` process. Make sure to use regexp pattern
+  # here so we don't also kill "keybase-redirector".
+  if pkill "^keybase$" &> /dev/null ; then
     echo Shutting down keybase service...
   fi
 


### PR DESCRIPTION
1. Protect keybase service from other user's processes reads and debugging. 
1.1. On Linux it sets `PR_SET_DUMPABLE` to 0 by default, which disables any kind of reads into the process and disables core dumps. Neither `ptrace` nor `process_vm_readv` against Keybase service should be possible.
1.2. On MacOS it uses non-standard ptrace call `PT_DENY_ATTACH`. I've verified that attaching `lldb` is no longer possible after this call, and also current debuggers are immediately dropped.
2. `PR_SET_DUMPABLE=0` has a side effect where `/proc/[pid]` is now owned by root. This breaks some tools like `killall`. `killall keybase` in `run_keybase` has been replaced by `pkill "^keybase$"` which uses other method of finding processes to kill.
3. `pkill` seems to be standard in most distributions I tested on, as well as on MacOS Sierra and higher. On Linux it's in `procps` package, which I added as a dependency to deb and rpm builders.
4. `procps` is default on arch as well, but there is `procps-ng` package in AUR. `procps-ng` is a fork with improvements, and apparently what most distros install as `procps` is `procps-ng`.

TODO:
- [ ] Only call `DisableProcessTracing` for admins for now.
- [ ] Test Arch and Debian.

cc @oconnor663 how can we proceed with this? thanks