### PR TITLE
default more to load to false

### DIFF
--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -245,7 +245,7 @@ export const makeConversationMeta: I.RecordFactory<_ConversationMeta> = I.Record
   offline: false,
   orangeLineOrdinal: null,
   paginationKey: null,
-  paginationMoreToLoad: true,
+  paginationMoreToLoad: false,
   participants: I.OrderedSet(),
   rekeyers: I.Set(),
   resetParticipants: I.Set(),


### PR DESCRIPTION
@keybase/react-hackers this defaults the moreToLoad flag to false. This fixes when you make a new convo (therefore we don't load it) so it won't say 'digging ancient messages'. On a real load it'll correctly get the paginationMoreToLoad flag