### PR TITLE
flag to never create a meta

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -289,7 +289,12 @@ export const createMetaUpdatePagination = (
     paginationMoreToLoad: boolean,
   }>
 ) => ({error: false, payload, type: metaUpdatePagination})
-export const createMetasReceived = (payload: $ReadOnly<{metas: Array<Types.ConversationMeta>}>) => ({error: false, payload, type: metasReceived})
+export const createMetasReceived = (
+  payload: $ReadOnly<{
+    metas: Array<Types.ConversationMeta>,
+    neverCreate?: boolean,
+  }>
+) => ({error: false, payload, type: metasReceived})
 export const createMuteConversation = (
   payload: $ReadOnly<{
     conversationIDKey: Types.ConversationIDKey,

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -165,7 +165,7 @@ const unboxRows = (
     const inboxUIItem: RPCChatTypes.InboxUIItem = JSON.parse(conv)
     const meta = Constants.inboxUIItemToConversationMeta(inboxUIItem)
     if (meta) {
-      yield Saga.put(Chat2Gen.createMetasReceived({metas: [meta]}))
+      yield Saga.put(Chat2Gen.createMetasReceived({metas: [meta], neverCreate: true}))
     } else {
       yield Saga.put(
         Chat2Gen.createMetaReceivedError({

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -91,13 +91,14 @@
     },
     // Got some new inbox rows
     "metasReceived": {
-      "metas": "Array<Types.ConversationMeta>"
+      "metas": "Array<Types.ConversationMeta>",
+      "neverCreate?": "boolean", // If true never create a brand new meta, only update
     },
     // Got some inbox errors
     "metaReceivedError": {
       "conversationIDKey": "Types.ConversationIDKey",
       "error": "?RPCChatTypes.InboxUIItemError",
-      "username": "?string"
+      "username": "?string",
     },
     // We got a status update saying it was blocked or ignored
     "metaDelete": {

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -96,13 +96,13 @@ const metaMapReducer = (metaMap, action) => {
           default:
             return metaMap.update(
               action.payload.conversationIDKey,
-              meta =>
-                meta
-                  ? meta.withMutations(m => {
+              old =>
+                old
+                  ? old.withMutations(m => {
                       m.set('trustedState', 'error')
                       m.set('snippet', error.message)
                     })
-                  : meta
+                  : old
             )
         }
       } else {
@@ -111,9 +111,15 @@ const metaMapReducer = (metaMap, action) => {
     }
     case Chat2Gen.metasReceived:
       return metaMap.withMutations(map => {
+        const neverCreate = !!action.payload.neverCreate
         action.payload.metas.forEach(meta => {
-          const old = map.get(meta.conversationIDKey)
-          map.set(meta.conversationIDKey, old ? Constants.updateMeta(old, meta) : meta)
+          map.update(meta.conversationIDKey, old => {
+            if (old) {
+              return Constants.updateMeta(old, meta)
+            } else {
+              return neverCreate ? old : meta
+            }
+          })
         })
       })
     case Chat2Gen.inboxRefresh:


### PR DESCRIPTION
This fixes the race @buoyad found. 
The flow is
1. Mutate the inbox somehow (leave a channel)
2. Get a couple inbox refreshes close to each other (kinda hard before dannys changes)
3. We get a new inbox and start unboxing the visible rows
4. We get another new inbox with a different set of visible rows
5. Rows from step 3 start getting unboxed
6. We update the metas and create them if they're missing

with this code we now mark the 'unbox due to scrolling' actions as never creating metas