### PR TITLE
only need the one CA for api-0.core.keybaseapi.com, not both

### DIFF
--- a/go/libkb/ca.go
+++ b/go/libkb/ca.go
@@ -16,7 +16,7 @@ func GetBundledCAsFromHost(host string) (rootCA []byte, ok bool) {
 		realAPICA = apiCAOverrideForTest
 	}
 	switch {
-	case host == "api.keybase.io":
+	case (host == "api.keybase.io" || host == "api-0.core.keybaseapi.com"):
 		return []byte(realAPICA), true
 
 	// Staging CA.


### PR DESCRIPTION
It actually wouldn't have given a wrong answer before, but this is more correct.