### PR TITLE
Parse wallet sigchain links

### DIFF
--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -1077,6 +1077,16 @@ func (c *ChainLink) GetSigchainV2Type() (SigchainV2Type, error) {
 	return SigchainV2TypeFromV1TypeAndRevocations(c.unpacked.typ, SigHasRevokes(c.HasRevocations()))
 }
 
+func (c *ChainLink) GetSigchainV2TypeFromV2Shell() (SigchainV2Type, error) {
+	if c.unpacked == nil {
+		return SigchainV2TypeNone, errors.New("GetSigchainV2TypeFromV2Shell: chain link not unpacked")
+	}
+	if c.unpacked.outerLinkV2 == nil {
+		return SigchainV2TypeNone, errors.New("GetSigchainV2TypeFromV2Shell: chain link has no v2 shell")
+	}
+	return c.unpacked.outerLinkV2.LinkType, nil
+}
+
 func (c *ChainLink) checkServerSignatureMetadata(ckf ComputedKeyFamily) (ret keybase1.KID, err error) {
 	var serverKID, linkKID, verifyKID keybase1.KID
 

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -494,7 +494,6 @@ const (
 	DLGNone KeyRole = iota
 	DLGSibkey
 	DLGSubkey
-	DLGPerUserKey
 )
 
 const (

--- a/go/libkb/cryptocurrency.go
+++ b/go/libkb/cryptocurrency.go
@@ -27,6 +27,17 @@ const (
 	CryptocurrencyFamilyZCash   CryptocurrencyFamily = "zcash"
 )
 
+// Wallet and cryptocurrency are separate systems.
+// Wallet links have reverse signatures, and the control secrets are in keybase.
+// Whereas Cryptocurrency links are generally are public only and have no reverse sigs.
+// CryptocurrencyFamily and WalletNetwork are defined next to each other so that
+// someone will notice if they start to overlap.
+type WalletNetwork string
+
+const (
+	WalletNetworkStellar WalletNetwork = "stellar"
+)
+
 type CryptocurrencyPrefix struct {
 	Type   CryptocurrencyType
 	Prefix []byte

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1046,6 +1046,12 @@ func (s SigchainV2MismatchedHashError) Error() string {
 	return "Sigchain V2 hash mismatch error"
 }
 
+type SigchainV2StubbedDisallowed struct{}
+
+func (s SigchainV2StubbedDisallowed) Error() string {
+	return "Link was stubbed but required"
+}
+
 //=============================================================================
 
 type ReverseSigError struct {

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1052,6 +1052,12 @@ func (s SigchainV2StubbedDisallowed) Error() string {
 	return "Link was stubbed but required"
 }
 
+type SigchainV2Required struct{}
+
+func (s SigchainV2Required) Error() string {
+	return "Link must use sig v2"
+}
+
 //=============================================================================
 
 type ReverseSigError struct {

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -760,6 +760,7 @@ func WalletProof(me *User, walletAddress keybase1.StellarAccountID,
 		Me:         me,
 		LinkType:   LinkTypeWallet,
 		SigningKey: signingKey,
+		SigVersion: KeybaseSignatureV2,
 	}.ToJSON(me.G())
 	if err != nil {
 		return nil, err
@@ -804,7 +805,20 @@ func WalletProofReverseSigned(me *User, walletAddress keybase1.StellarAccountID,
 	// Make sig
 	jw := jwRev
 	jw.SetValueAtPath("body.wallet_key.reverse_sig", jsonw.NewString(reverseSig))
-	sig, sigID, linkID, err := SignJSON(jw, signer)
+	innerJSON, err := jw.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	sig, sigID, linkID, err := MakeSig(
+		signer,
+		LinkTypeWallet,
+		innerJSON,
+		SigHasRevokes(false),
+		keybase1.SeqType_PUBLIC,
+		SigIgnoreIfUnsupported(false),
+		me,
+		KeybaseSignatureV2,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -815,6 +829,7 @@ func WalletProofReverseSigned(me *User, walletAddress keybase1.StellarAccountID,
 
 	res := make(JSONPayload)
 	res["sig"] = sig
+	res["sig_inner"] = string(innerJSON)
 	res["signing_kid"] = signer.GetKID().String()
 	res["public_key"] = walletSignerKey.GetKID().String()
 	res["type"] = LinkTypeWallet

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -768,7 +768,7 @@ func WalletProof(me *User, walletAddress keybase1.StellarAccountID,
 	walletSection := jsonw.NewDictionary()
 	walletSection.SetKey("name", jsonw.NewString(""))
 	walletSection.SetKey("address", jsonw.NewString(walletAddress.String()))
-	walletSection.SetKey("network", jsonw.NewString("stellar"))
+	walletSection.SetKey("network", jsonw.NewString(string(WalletNetworkStellar)))
 
 	walletKeySection := jsonw.NewDictionary()
 	walletKeySection.SetKey("kid", jsonw.NewString(walletKID.String()))

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -658,8 +658,11 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 		}
 
 		if _, ok := tcl.(*WalletChainLink); ok {
-			// TODO CORE-7499: Assert that wallet chain links are be v2.
+			// Assert that wallet chain links are be >= v2.
 			// They must be v2 in order to be stubbable later for privacy.
+			if link.unpacked.sigVersion < 2 {
+				return cached, cki, SigchainV2Required{}
+			}
 			seenInflatedWalletLink = true
 		}
 

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -573,6 +573,7 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 	ckf := ComputedKeyFamily{kf: &kf, cki: cki, Contextified: sc.Contextified}
 
 	first := true
+	seenInflatedWalletLink := false
 
 	for linkIndex, link := range links {
 		if isBad, reason := link.IsBad(); isBad {
@@ -586,6 +587,15 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 			}
 			if link.NeedsSignature() {
 				return cached, cki, SigchainV2StubbedSignatureNeededError{}
+			}
+			linkTypeV2, err := link.GetSigchainV2TypeFromV2Shell()
+			if err != nil {
+				return cached, cki, err
+			}
+			if linkTypeV2 == SigchainV2TypeWallet && seenInflatedWalletLink {
+				// There may not be stubbed wallet links following an unstubbed wallet links (for a given network).
+				// So that the server can't roll back someone's active wallet address.
+				return cached, cki, SigchainV2StubbedDisallowed{}
 			}
 			sc.G().VDL.Log(VLog1, "| Skipping over stubbed-out link: %s", link.id)
 			continue
@@ -645,6 +655,12 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 			if err != nil {
 				return cached, cki, err
 			}
+		}
+
+		if _, ok := tcl.(*WalletChainLink); ok {
+			// TODO CORE-7499: Assert that wallet chain links are be v2.
+			// They must be v2 in order to be stubbable later for privacy.
+			seenInflatedWalletLink = true
 		}
 
 		if err = tcl.VerifyReverseSig(ckf); err != nil {

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -460,6 +460,12 @@ func (u *User) IDTable() *IdentityTable {
 	return u.idTable
 }
 
+// Return the active stellar public address for a user.
+// Returns nil if there is none or it has not been loaded.
+func (u *User) StellarWalletAddress() *keybase1.StellarAccountID {
+	return u.idTable.StellarWalletAddress()
+}
+
 func (u *User) sigChain() *SigChain {
 	return u.sigChainMem
 }

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -27,21 +27,22 @@ func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
 }
 
 func TestCreateWallet(t *testing.T) {
-	tc := SetupTest(t, "wallet", 1)
-	defer tc.Cleanup()
+	_, tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
 
-	_, err := kbtest.CreateAndSignupFakeUser("wall", tc.G)
+	_, err := kbtest.CreateAndSignupFakeUser("wall", tcs[0].G)
 	require.NoError(t, err)
 
-	created, err := CreateWallet(context.Background(), tc.G)
+	created, err := CreateWallet(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	require.True(t, created)
 
-	created, err = CreateWallet(context.Background(), tc.G)
+	created, err = CreateWallet(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	require.False(t, created)
 
-	bundle, err := remote.Fetch(context.Background(), tc.G)
+	t.Logf("Fetch the bundle")
+	bundle, err := remote.Fetch(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	require.Equal(t, keybase1.StellarRevision(1), bundle.Revision)
 	require.Nil(t, bundle.Prev)
@@ -52,4 +53,46 @@ func TestCreateWallet(t *testing.T) {
 	require.True(t, bundle.Accounts[0].IsPrimary)
 	require.Len(t, bundle.Accounts[0].Signers, 1)
 	require.Equal(t, "", bundle.Accounts[0].Name)
+
+	t.Logf("Lookup the public stellar address as another user")
+	u0, err := tcs[1].G.LoadUserByUID(tcs[0].G.ActiveDevice.UID())
+	require.NoError(t, err)
+	addr := u0.StellarWalletAddress()
+	require.NoError(t, err)
+	t.Logf("Found account: %v", addr)
+	_, err = libkb.MakeNaclSigningKeyPairFromStellarAccountID(*addr)
+	require.NoError(t, err, "stellar key should be nacl pubable")
+	require.Equal(t, bundle.Accounts[0].AccountID.String(), addr.String(), "addr looked up should match secret bundle")
+}
+
+// Create n TestContexts with logged in users
+// Returns (FakeUsers, TestContexts, CleanupFunction)
+func setupNTests(t *testing.T, n int) ([]*kbtest.FakeUser, []*libkb.TestContext, func()) {
+	return setupNTestsWithPukless(t, n, 0)
+}
+
+func setupNTestsWithPukless(t *testing.T, n, nPukless int) ([]*kbtest.FakeUser, []*libkb.TestContext, func()) {
+	require.True(t, n > 0, "must create at least 1 tc")
+	require.True(t, n >= nPukless, "more pukless users than total users requested")
+	var fus []*kbtest.FakeUser
+	var tcs []*libkb.TestContext
+	for i := 0; i < n; i++ {
+		tc := SetupTest(t, "team", 1)
+		tcs = append(tcs, &tc)
+		if i >= n-nPukless {
+			tc.Tp.DisableUpgradePerUserKey = true
+		}
+		fu, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+		require.NoError(t, err)
+		fus = append(fus, fu)
+	}
+	cleanup := func() {
+		for _, tc := range tcs {
+			tc.Cleanup()
+		}
+	}
+	for i, fu := range fus {
+		t.Logf("U%d: %v %v", i, fu.Username, fu.GetUserVersion())
+	}
+	return fus, tcs, cleanup
 }


### PR DESCRIPTION
Parse wallet sigchain links.
Add `libkb.User.StellarWalletAddress() -> *keybase1.StellarAccountID`.

~~On top of https://github.com/keybase/client/pull/11044~~

When links that were stubbed get unstubbed, what happens? This must be happening for v2 track links. I want to make sure no paths can sneak past my modifications to `verifySubchain`.

What should I do in terms of tests? `github.com/keybase/keybase-test-vectors/go`?