### PR TITLE
fix race in TestTeamRemoveAfterReset

### DIFF
--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -405,6 +405,7 @@ func TestTeamRemoveAfterReset(t *testing.T) {
 
 	bob.loginAfterReset(10)
 	divDebug(ctx, "Bob logged in after reset")
+	ann.pollForMembershipUpdate(team, keybase1.PerTeamKeyGeneration(2), nil)
 
 	joe.reset()
 	divDebug(ctx, "Reset joe (%s), not re-provisioning though!", joe.username)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -785,7 +785,7 @@ func (u *userPlusDevice) perUserKeyUpgrade() {
 }
 
 func kickTeamRekeyd(g *libkb.GlobalContext, t libkb.TestingTB) {
-	const workTimeSec = 3 // team_rekeyd delay before retrying job if it wasn't finished.
+	const workTimeSec = 1 // team_rekeyd delay before retrying job if it wasn't finished.
 	args := libkb.HTTPArgs{
 		"work_time_sec": libkb.I{Val: workTimeSec},
 	}


### PR DESCRIPTION
- the current configuration allowed for either 1 or 2 rotates, so the test got confused
- so therefore, it's a better idea to serialize the two resets and assert a rotate after each one
- this revealed a race on team_rekeyd, fixed by maxtaco/CORE-7509 on the server side