### PR TITLE
add param to next update to immediately trigger update in case client out of date

### DIFF
--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -112,8 +112,9 @@ func (c *FullCachingSource) isStale(item lru.DiskLRUEntry) bool {
 
 func (c *FullCachingSource) monitorAppState() {
 	c.debug(context.Background(), "monitorAppState: starting up")
+	state := keybase1.AppState_FOREGROUND
 	for {
-		state := <-c.G().AppState.NextUpdate()
+		state := <-c.G().AppState.NextUpdate(&state)
 		ctx := context.Background()
 		switch state {
 		case keybase1.AppState_BACKGROUND:

--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -114,7 +114,7 @@ func (c *FullCachingSource) monitorAppState() {
 	c.debug(context.Background(), "monitorAppState: starting up")
 	state := keybase1.AppState_FOREGROUND
 	for {
-		state := <-c.G().AppState.NextUpdate(&state)
+		state = <-c.G().AppState.NextUpdate(&state)
 		ctx := context.Background()
 		switch state {
 		case keybase1.AppState_BACKGROUND:

--- a/go/avatars/urlcaching.go
+++ b/go/avatars/urlcaching.go
@@ -51,8 +51,9 @@ func (c *URLCachingSource) isStale(item lru.DiskLRUEntry) bool {
 
 func (c *URLCachingSource) monitorAppState() {
 	c.debug(context.Background(), "monitorAppState: starting up")
+	state := keybase1.AppState_FOREGROUND
 	for {
-		state := <-c.G().AppState.NextUpdate()
+		state := <-c.G().AppState.NextUpdate(&state)
 		ctx := context.Background()
 		switch state {
 		case keybase1.AppState_BACKGROUND:

--- a/go/avatars/urlcaching.go
+++ b/go/avatars/urlcaching.go
@@ -53,7 +53,7 @@ func (c *URLCachingSource) monitorAppState() {
 	c.debug(context.Background(), "monitorAppState: starting up")
 	state := keybase1.AppState_FOREGROUND
 	for {
-		state := <-c.G().AppState.NextUpdate(&state)
+		state = <-c.G().AppState.NextUpdate(&state)
 		ctx := context.Background()
 		switch state {
 		case keybase1.AppState_BACKGROUND:

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -79,8 +79,9 @@ func (b *BackgroundConvLoader) monitorAppState() {
 	ctx := context.Background()
 	suspended := false
 	b.Debug(ctx, "monitorAppState: starting up")
+	state := keybase1.AppState_FOREGROUND
 	for {
-		state := <-b.G().AppState.NextUpdate()
+		state := <-b.G().AppState.NextUpdate(&state)
 		switch state {
 		case keybase1.AppState_FOREGROUND:
 			b.Debug(ctx, "monitorAppState: foregrounded")

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -81,7 +81,7 @@ func (b *BackgroundConvLoader) monitorAppState() {
 	b.Debug(ctx, "monitorAppState: starting up")
 	state := keybase1.AppState_FOREGROUND
 	for {
-		state := <-b.G().AppState.NextUpdate(&state)
+		state = <-b.G().AppState.NextUpdate(&state)
 		switch state {
 		case keybase1.AppState_FOREGROUND:
 			b.Debug(ctx, "monitorAppState: foregrounded")

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -125,7 +125,7 @@ func (s *Syncer) sendNotificationLoop() {
 			s.sendNotificationsOnce()
 		case <-s.flushCh:
 			s.sendNotificationsOnce()
-		case state := <-s.G().AppState.NextUpdate():
+		case state := <-s.G().AppState.NextUpdate(nil):
 			// If we receive an update that app state has moved to the foreground, then trigger
 			// flushing these notifications
 			if state == keybase1.AppState_FOREGROUND {

--- a/go/libkb/appstate.go
+++ b/go/libkb/appstate.go
@@ -25,11 +25,15 @@ func NewAppState(g *GlobalContext) *AppState {
 }
 
 // NextUpdate returns a channel that triggers when the app state changes
-func (a *AppState) NextUpdate() chan keybase1.AppState {
+func (a *AppState) NextUpdate(lastState *keybase1.AppState) chan keybase1.AppState {
 	a.Lock()
 	defer a.Unlock()
 	ch := make(chan keybase1.AppState, 1)
-	a.updateChs = append(a.updateChs, ch)
+	if lastState != nil && *lastState != a.state {
+		ch <- a.state
+	} else {
+		a.updateChs = append(a.updateChs, ch)
+	}
 	return ch
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -219,8 +219,9 @@ func (g *gregorHandler) Init() {
 
 func (g *gregorHandler) monitorAppState() {
 	// Wait for state updates and react accordingly
+	state := keybase1.AppState_FOREGROUND
 	for {
-		state := <-g.G().AppState.NextUpdate()
+		state := <-g.G().AppState.NextUpdate(&state)
 		switch state {
 		case keybase1.AppState_BACKGROUNDACTIVE:
 			fallthrough

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -221,7 +221,7 @@ func (g *gregorHandler) monitorAppState() {
 	// Wait for state updates and react accordingly
 	state := keybase1.AppState_FOREGROUND
 	for {
-		state := <-g.G().AppState.NextUpdate(&state)
+		state = <-g.G().AppState.NextUpdate(&state)
 		switch state {
 		case keybase1.AppState_BACKGROUNDACTIVE:
 			fallthrough

--- a/go/tlfupgrade/tlfupgrade.go
+++ b/go/tlfupgrade/tlfupgrade.go
@@ -96,8 +96,9 @@ func (b *BackgroundTLFUpdater) Shutdown() error {
 func (b *BackgroundTLFUpdater) monitorAppState() {
 	ctx := context.Background()
 	b.debug(ctx, "monitorAppState: starting up")
+	state := keybase1.AppState_FOREGROUND
 	for {
-		state := <-b.G().AppState.NextUpdate()
+		state := <-b.G().AppState.NextUpdate(&state)
 		switch state {
 		case keybase1.AppState_FOREGROUND:
 			b.debug(ctx, "monitorAppState: foregrounded, running all after: %v", b.initialWait)

--- a/go/tlfupgrade/tlfupgrade.go
+++ b/go/tlfupgrade/tlfupgrade.go
@@ -98,7 +98,7 @@ func (b *BackgroundTLFUpdater) monitorAppState() {
 	b.debug(ctx, "monitorAppState: starting up")
 	state := keybase1.AppState_FOREGROUND
 	for {
-		state := <-b.G().AppState.NextUpdate(&state)
+		state = <-b.G().AppState.NextUpdate(&state)
 		switch state {
 		case keybase1.AppState_FOREGROUND:
 			b.debug(ctx, "monitorAppState: foregrounded, running all after: %v", b.initialWait)


### PR DESCRIPTION
It's possible these `monitorAppState` loops spread throughout the app can miss updates if they don't get back to receiving on the `NextUpdate()` channel they create. In order to mitigate, pass the previous known state to `NextUpdate()`, so that if it is different we can trigger the channel immediately. 