### PR TITLE
Don't show chat button for impadmins

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1975,6 +1975,7 @@ type TeamOperation struct {
 	ManageMembers          bool `codec:"manageMembers" json:"manageMembers"`
 	ManageSubteams         bool `codec:"manageSubteams" json:"manageSubteams"`
 	CreateChannel          bool `codec:"createChannel" json:"createChannel"`
+	Chat                   bool `codec:"chat" json:"chat"`
 	DeleteChannel          bool `codec:"deleteChannel" json:"deleteChannel"`
 	RenameChannel          bool `codec:"renameChannel" json:"renameChannel"`
 	EditChannelDescription bool `codec:"editChannelDescription" json:"editChannelDescription"`
@@ -1994,6 +1995,7 @@ func (o TeamOperation) DeepCopy() TeamOperation {
 		ManageMembers:          o.ManageMembers,
 		ManageSubteams:         o.ManageSubteams,
 		CreateChannel:          o.CreateChannel,
+		Chat:                   o.Chat,
 		DeleteChannel:          o.DeleteChannel,
 		RenameChannel:          o.RenameChannel,
 		EditChannelDescription: o.EditChannelDescription,

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1142,6 +1142,7 @@ func TestTeamCanUserPerform(t *testing.T) {
 	require.True(t, annPerms.SetPublicityAny)
 	require.True(t, annPerms.ChangeTarsDisabled)
 	require.True(t, annPerms.DeleteChatHistory)
+	require.True(t, annPerms.Chat)
 
 	require.True(t, bobPerms.ManageMembers)
 	require.True(t, bobPerms.ManageSubteams)
@@ -1158,6 +1159,7 @@ func TestTeamCanUserPerform(t *testing.T) {
 	require.True(t, bobPerms.SetPublicityAny)
 	require.True(t, bobPerms.ChangeTarsDisabled)
 	require.True(t, bobPerms.DeleteChatHistory)
+	require.True(t, bobPerms.Chat)
 
 	// Some ops are fine for writers
 	require.False(t, pamPerms.ManageMembers)
@@ -1175,8 +1177,9 @@ func TestTeamCanUserPerform(t *testing.T) {
 	require.False(t, pamPerms.SetPublicityAny)
 	require.False(t, pamPerms.ChangeTarsDisabled)
 	require.False(t, pamPerms.DeleteChatHistory)
+	require.True(t, pamPerms.Chat)
 
-	// Only SetMemberShowcase (by default) and LeaveTeam is available for readers
+	// Only SetMemberShowcase (by default), LeaveTeam, and Chat is available for readers
 	require.False(t, eddPerms.ManageMembers)
 	require.False(t, eddPerms.ManageSubteams)
 	require.False(t, eddPerms.CreateChannel)
@@ -1192,6 +1195,7 @@ func TestTeamCanUserPerform(t *testing.T) {
 	require.False(t, eddPerms.SetPublicityAny)
 	require.False(t, eddPerms.ChangeTarsDisabled)
 	require.False(t, eddPerms.DeleteChatHistory)
+	require.True(t, eddPerms.Chat)
 
 	annPerms = callCanPerform(ann, subteam)
 	bobPerms = callCanPerform(bob, subteam)
@@ -1211,6 +1215,7 @@ func TestTeamCanUserPerform(t *testing.T) {
 	require.True(t, annPerms.SetPublicityAny)
 	require.True(t, annPerms.ChangeTarsDisabled)
 	require.False(t, annPerms.DeleteChatHistory)
+	require.False(t, annPerms.Chat)
 
 	require.True(t, bobPerms.ManageMembers)
 	require.True(t, bobPerms.ManageSubteams)
@@ -1227,6 +1232,7 @@ func TestTeamCanUserPerform(t *testing.T) {
 	require.True(t, bobPerms.SetPublicityAny)
 	require.True(t, bobPerms.ChangeTarsDisabled)
 	require.False(t, bobPerms.DeleteChatHistory)
+	require.False(t, bobPerms.Chat)
 
 	// Invalid team for pam
 	_, err = teams.CanUserPerform(context.TODO(), pam.tc.G, subteam)
@@ -1250,4 +1256,5 @@ func TestTeamCanUserPerform(t *testing.T) {
 	// TBD: require.True(t, donnyPerms.JoinTeam)
 	require.False(t, donnyPerms.SetPublicityAny)
 	require.False(t, donnyPerms.DeleteChatHistory)
+	require.False(t, donnyPerms.Chat)
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1361,6 +1361,7 @@ func CanUserPerform(ctx context.Context, g *libkb.GlobalContext, teamname string
 	ret.RenameChannel = isWriter()
 	ret.EditChannelDescription = isWriter()
 	ret.DeleteChatHistory = admin
+	ret.Chat = isRoleOrAbove(keybase1.TeamRole_READER)
 
 	return ret, err
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -782,6 +782,7 @@ protocol teams {
     boolean manageMembers;
     boolean manageSubteams;
     boolean createChannel;
+    boolean chat;
     boolean deleteChannel;
     boolean renameChannel;
     boolean editChannelDescription;

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3780,7 +3780,7 @@ export type TeamNamePart = String
 
 export type TeamOpenReqMsg = $ReadOnly<{teamID: TeamID, tars?: ?Array<TeamAccessRequest>}>
 
-export type TeamOperation = $ReadOnly<{manageMembers: Boolean, manageSubteams: Boolean, createChannel: Boolean, deleteChannel: Boolean, renameChannel: Boolean, editChannelDescription: Boolean, setTeamShowcase: Boolean, setMemberShowcase: Boolean, changeOpenTeam: Boolean, leaveTeam: Boolean, joinTeam: Boolean, setPublicityAny: Boolean, listFirst: Boolean, changeTarsDisabled: Boolean, deleteChatHistory: Boolean}>
+export type TeamOperation = $ReadOnly<{manageMembers: Boolean, manageSubteams: Boolean, createChannel: Boolean, chat: Boolean, deleteChannel: Boolean, renameChannel: Boolean, editChannelDescription: Boolean, setTeamShowcase: Boolean, setMemberShowcase: Boolean, changeOpenTeam: Boolean, leaveTeam: Boolean, joinTeam: Boolean, setPublicityAny: Boolean, listFirst: Boolean, changeTarsDisabled: Boolean, deleteChatHistory: Boolean}>
 
 export type TeamPlusApplicationKeys = $ReadOnly<{id: TeamID, name: String, implicit: Boolean, public: Boolean, application: TeamApplication, writers?: ?Array<UserVersion>, onlyReaders?: ?Array<UserVersion>, applicationKeys?: ?Array<TeamApplicationKey>}>
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1760,6 +1760,10 @@
         },
         {
           "type": "boolean",
+          "name": "chat"
+        },
+        {
+          "type": "boolean",
           "name": "deleteChannel"
         },
         {

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -90,6 +90,7 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
 export const initialCanUserPerform: RPCTypes.TeamOperation = {
   manageMembers: false,
   manageSubteams: false,
+  chat: false,
   createChannel: false,
   deleteChannel: false,
   renameChannel: false,

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3780,7 +3780,7 @@ export type TeamNamePart = String
 
 export type TeamOpenReqMsg = $ReadOnly<{teamID: TeamID, tars?: ?Array<TeamAccessRequest>}>
 
-export type TeamOperation = $ReadOnly<{manageMembers: Boolean, manageSubteams: Boolean, createChannel: Boolean, deleteChannel: Boolean, renameChannel: Boolean, editChannelDescription: Boolean, setTeamShowcase: Boolean, setMemberShowcase: Boolean, changeOpenTeam: Boolean, leaveTeam: Boolean, joinTeam: Boolean, setPublicityAny: Boolean, listFirst: Boolean, changeTarsDisabled: Boolean, deleteChatHistory: Boolean}>
+export type TeamOperation = $ReadOnly<{manageMembers: Boolean, manageSubteams: Boolean, createChannel: Boolean, chat: Boolean, deleteChannel: Boolean, renameChannel: Boolean, editChannelDescription: Boolean, setTeamShowcase: Boolean, setMemberShowcase: Boolean, changeOpenTeam: Boolean, leaveTeam: Boolean, joinTeam: Boolean, setPublicityAny: Boolean, listFirst: Boolean, changeTarsDisabled: Boolean, deleteChatHistory: Boolean}>
 
 export type TeamPlusApplicationKeys = $ReadOnly<{id: TeamID, name: String, implicit: Boolean, public: Boolean, application: TeamApplication, writers?: ?Array<UserVersion>, onlyReaders?: ?Array<UserVersion>, applicationKeys?: ?Array<TeamApplicationKey>}>
 

--- a/shared/teams/team/header/container.js
+++ b/shared/teams/team/header/container.js
@@ -15,6 +15,7 @@ const mapStateToProps = (state: TypedState, {teamname}: OwnProps) => {
   const yourOperations = Constants.getCanPerform(state, teamname)
   return {
     _you: state.config.username,
+    canChat: yourOperations.chat,
     canEditDescription: yourOperations.editChannelDescription,
     canJoinTeam: yourOperations.joinTeam,
     canManageMembers: yourOperations.manageMembers,
@@ -47,6 +48,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {teamname}: OwnProps) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  canChat: stateProps.canChat,
   canEditDescription: stateProps.canEditDescription,
   canJoinTeam: stateProps.canJoinTeam,
   canManageMembers: stateProps.canManageMembers,

--- a/shared/teams/team/header/index.js
+++ b/shared/teams/team/header/index.js
@@ -6,6 +6,7 @@ import {Box, Button, ButtonBar, Icon, Meta, NameWithIcon, Text} from '../../../c
 import {globalColors, globalMargins, globalStyles, isMobile} from '../../../styles'
 
 export type Props = {
+  canChat: boolean,
   canEditDescription: boolean,
   canJoinTeam: boolean,
   canManageMembers: boolean,
@@ -73,15 +74,17 @@ const TeamHeader = (props: Props) => (
 
       {/* Actions */}
       <ButtonBar direction="row" style={isMobile ? {width: 'auto', marginBottom: -8} : undefined}>
-        <Button type="Primary" label="Chat" onClick={props.onChat}>
-          <Icon
-            type="iconfont-chat"
-            style={{
-              marginRight: 8,
-              color: globalColors.white,
-            }}
-          />
-        </Button>
+        {props.canChat && (
+          <Button type="Primary" label="Chat" onClick={props.onChat}>
+            <Icon
+              type="iconfont-chat"
+              style={{
+                marginRight: 8,
+                color: globalColors.white,
+              }}
+            />
+          </Button>
+        )}
         {props.canManageMembers && (
           <Button
             type="Secondary"


### PR DESCRIPTION
adds `chat` to `canUserPerform` and uses it on team header. r? @keybase/react-hackers 