### PR TITLE
More visual QA and bugfixes for profile showcasing

### DIFF
--- a/shared/common-adapters/button.js
+++ b/shared/common-adapters/button.js
@@ -24,9 +24,9 @@ export type Props = {
   className?: string,
 }
 
-const Progress = ({small}) => (
+const Progress = ({small, white}) => (
   <Box style={progress}>
-    <ProgressIndicator style={progressStyle(small)} white={true} />
+    <ProgressIndicator style={progressStyle(small)} white={white} />
   </Box>
 )
 
@@ -81,6 +81,8 @@ class Button extends React.Component<Props> {
 
     const onClick = (!this.props.disabled && !this.props.waiting && this.props.onClick) || null
 
+    const whiteSpinner = this.props.type !== 'PrimaryGreenActive'
+
     return (
       <ClickableBox style={containerStyle} onClick={onClick}>
         <Box
@@ -100,7 +102,7 @@ class Button extends React.Component<Props> {
               {this.props.label}
             </Text>
           )}
-          {this.props.waiting && <Progress small={this.props.small} />}
+          {this.props.waiting && <Progress small={this.props.small} white={whiteSpinner} />}
         </Box>
       </ClickableBox>
     )

--- a/shared/profile/index.desktop.js
+++ b/shared/profile/index.desktop.js
@@ -44,20 +44,22 @@ type State = {
   },
 }
 
-const EditControl = ({onClickShowcaseOffer}: {onClickShowcaseOffer: () => void}) => (
+const EditControl = ({isYou, onClickShowcaseOffer}: {isYou: boolean, onClickShowcaseOffer: () => void}) => (
   <Box style={globalStyles.flexBoxRow}>
     <Text type="BodySmallSemibold">Teams</Text>
-    <Icon style={{marginLeft: globalMargins.xtiny}} type="iconfont-edit" onClick={onClickShowcaseOffer} />
+    {!!isYou && (
+      <Icon style={{marginLeft: globalMargins.xtiny}} type="iconfont-edit" onClick={onClickShowcaseOffer} />
+    )}
   </Box>
 )
 
 const ShowcaseTeamsOffer = ({onClickShowcaseOffer}: {onClickShowcaseOffer: () => void}) => (
   <Box onClick={onClickShowcaseOffer} style={styleShowcasedTeamContainer}>
     <Box style={styleShowcasedTeamAvatar}>
-      <Icon type="icon-team-placeholder-avatar-24" size={24} />
+      <Icon type="icon-team-placeholder-avatar-24" size={24} style={{borderRadius: 5}} />
     </Box>
     <Box style={styleShowcasedTeamName}>
-      <Text style={{color: globalColors.black_40}} type="BodyPrimaryLink">
+      <Text style={{color: globalColors.black_20}} type="BodyPrimaryLink">
         Publish the teams you're in
       </Text>
     </Box>
@@ -317,7 +319,7 @@ class ProfileRender extends PureComponent<Props, State> {
         : null
 
     const showEdit =
-      (this.props.userInfo && this.props.userInfo.showcasedTeams.length > 0) ||
+      (!this.props.isYou && this.props.userInfo && this.props.userInfo.showcasedTeams.length > 0) ||
       (this.props.isYou && this.props.youAreInTeams)
 
     const showShowcaseTeamsOffer = this.props.isYou && this.props.youAreInTeams
@@ -396,7 +398,12 @@ class ProfileRender extends PureComponent<Props, State> {
               <Box style={styleProofs}>
                 {!loading && (
                   <Box style={{...globalStyles.flexBoxColumn, paddingBottom: globalMargins.small}}>
-                    {showEdit && <EditControl onClickShowcaseOffer={this.props.onClickShowcaseOffer} />}
+                    {showEdit && (
+                      <EditControl
+                        isYou={this.props.isYou}
+                        onClickShowcaseOffer={this.props.onClickShowcaseOffer}
+                      />
+                    )}
                     {this.props.userInfo.showcasedTeams.length > 0
                       ? this.props.userInfo.showcasedTeams.map(team => (
                           <ShowcasedTeamRow

--- a/shared/profile/index.native.js
+++ b/shared/profile/index.native.js
@@ -42,20 +42,22 @@ type State = {
   activeMenuProof: ?Proof,
 }
 
-const EditControl = ({onClickShowcaseOffer}: {onClickShowcaseOffer: () => void}) => (
+const EditControl = ({isYou, onClickShowcaseOffer}: {isYou: boolean, onClickShowcaseOffer: () => void}) => (
   <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', marginBottom: globalMargins.tiny}}>
     <Text type="BodySmallSemibold">Teams</Text>
-    <Icon style={{marginLeft: 2}} type="iconfont-edit" onClick={onClickShowcaseOffer} />
+    {!!isYou && (
+      <Icon style={{margin: 2, width: 22, height: 22}} type="iconfont-edit" onClick={onClickShowcaseOffer} />
+    )}
   </Box>
 )
 
 const ShowcaseTeamsOffer = ({onClickShowcaseOffer}: {onClickShowcaseOffer: () => void}) => (
   <ClickableBox onClick={onClickShowcaseOffer} style={styleShowcasedTeamContainer}>
     <Box style={styleShowcasedTeamAvatar}>
-      <Icon type="icon-team-placeholder-avatar-32" size={32} />
+      <Icon type="icon-team-placeholder-avatar-32" size={32} style={{borderRadius: 5}} />
     </Box>
-    <Box style={{...globalStyles.flexBoxRow, padding: globalMargins.tiny}}>
-      <Text style={{color: globalColors.black_40}} type="BodySmallInlineLink">
+    <Box style={{...globalStyles.flexBoxRow, marginTop: 4}}>
+      <Text style={{color: globalColors.black_20}} type="BodyPrimaryLink">
         Publish the teams you're in
       </Text>
     </Box>
@@ -234,7 +236,7 @@ class Profile extends Component<Props, State> {
       : shared.missingProofs(this.props.proofs, this.props.onMissingProofClick)
 
     const showEdit =
-      (this.props.userInfo && this.props.userInfo.showcasedTeams.length > 0) ||
+      (!this.props.isYou && this.props.userInfo && this.props.userInfo.showcasedTeams.length > 0) ||
       (this.props.isYou && this.props.youAreInTeams)
 
     const showShowcaseTeamsOffer = this.props.isYou && this.props.youAreInTeams
@@ -287,7 +289,9 @@ class Profile extends Component<Props, State> {
             alignItems: 'flex-start',
           }}
         >
-          {showEdit && <EditControl onClickShowcaseOffer={this.props.onClickShowcaseOffer} />}
+          {showEdit && (
+            <EditControl isYou={this.props.isYou} onClickShowcaseOffer={this.props.onClickShowcaseOffer} />
+          )}
 
           {this.props.userInfo.showcasedTeams.length > 0
             ? this.props.userInfo.showcasedTeams.map(team => (
@@ -301,7 +305,7 @@ class Profile extends Component<Props, State> {
                 <ShowcaseTeamsOffer onClickShowcaseOffer={this.props.onClickShowcaseOffer} />
               )}
         </Box>
-        )}
+
         <Box style={styleProofsAndFolders}>
           <LoadingWrapper
             duration={500}

--- a/shared/profile/showcase-team-offer/container.js
+++ b/shared/profile/showcase-team-offer/container.js
@@ -37,7 +37,7 @@ const mergeProps = (stateProps, dispatchProps) => {
     teamNameToCanPerform: stateProps._teamNameToCanPerform.toObject(),
     teamNameToPublicitySettings: stateProps._teamNameToPublicitySettings.toObject(),
     teamnames,
-    title: 'Showcase teams',
+    title: 'Publish your teams',
     waiting: stateProps._waiting.toObject(),
   }
 }

--- a/shared/profile/showcase-team-offer/index.js
+++ b/shared/profile/showcase-team-offer/index.js
@@ -69,7 +69,7 @@ const ShowcaseTeamOffer = (props: Props) => (
     <Text style={{paddingBottom: globalMargins.small}} type="Header">
       Publish the teams you're in
     </Text>
-    <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', marginBottom: globalMargins.xtiny}}>
+    <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', marginBottom: globalMargins.tiny}}>
       <Box style={{backgroundColor: globalColors.black_05, height: 1, width: 24}} />
       <Icon
         style={{
@@ -82,41 +82,42 @@ const ShowcaseTeamOffer = (props: Props) => (
       <Box style={{backgroundColor: globalColors.black_05, height: 1, width: 24}} />
     </Box>
 
-    <Text
-      style={{color: globalColors.black_40, paddingTop: globalMargins.tiny, textAlign: 'center'}}
-      type="BodySmall"
-    >
-      Promoting a team will encourage others to ask to join.
-    </Text>
-    <Text
-      style={{
-        color: globalColors.black_40,
-        paddingTop: isMobile ? globalMargins.tiny : 0,
-        textAlign: 'center',
-      }}
-      type="BodySmall"
-    >
-      The team's description and number of members will be public.
-    </Text>
-
-    <ScrollView style={{flexShrink: 1, marginTop: globalMargins.medium, width: '100%'}}>
-      {props.teamnames &&
-        props.teamnames.map(name => (
-          <TeamRow
-            canShowcase={
-              props.teamNameToCanPerform[name] && props.teamNameToCanPerform[name].setMemberShowcase
-            }
-            key={name}
-            name={name}
-            isOpen={props.teamNameToIsOpen[name]}
-            membercount={props.teammembercounts[name]}
-            onPromote={promoted => props.onPromote(name, promoted)}
-            showcased={
-              props.teamNameToPublicitySettings[name] && props.teamNameToPublicitySettings[name].member
-            }
-            waiting={!!props.waiting[teamWaitingKey(name)]}
-          />
-        ))}
+    <ScrollView>
+      <Box style={{...globalStyles.flexBoxRow, flexShrink: 1, width: '100%'}}>
+        <Text
+          style={{
+            color: globalColors.black_40,
+            paddingBottom: globalMargins.small,
+            paddingLeft: globalMargins.large,
+            paddingRight: globalMargins.large,
+            paddingTop: globalMargins.tiny,
+            textAlign: 'center',
+          }}
+          type="BodySmall"
+        >
+          Promoting a team will encourage others to ask to join. The team's description and number of members
+          will be public.
+        </Text>
+      </Box>
+      <Box style={{flexShrink: 1, width: '100%'}}>
+        {props.teamnames &&
+          props.teamnames.map(name => (
+            <TeamRow
+              canShowcase={
+                props.teamNameToCanPerform[name] && props.teamNameToCanPerform[name].setMemberShowcase
+              }
+              key={name}
+              name={name}
+              isOpen={props.teamNameToIsOpen[name]}
+              membercount={props.teammembercounts[name]}
+              onPromote={promoted => props.onPromote(name, promoted)}
+              showcased={
+                props.teamNameToPublicitySettings[name] && props.teamNameToPublicitySettings[name].member
+              }
+              waiting={!!props.waiting[teamWaitingKey(name)]}
+            />
+          ))}
+      </Box>
     </ScrollView>
     <ClickableBox onClick={props.onBack} style={{flexGrow: 1}}>
       <Button style={{margin: globalMargins.small}} type="Secondary" onClick={props.onBack} label="Close" />


### PR DESCRIPTION
@keybase/react-hackers 

* fix a crash loading Profile on mobile due to an errant `)}`

* fix the logic around when to show the Edit pencil

* fix the (white) spinner being invisible on a PrimaryGreenActive button, which has a white background, by switching to grey for that button

* fix text size and opacity

* fix rounded corners on the placeholder Team icon

* put the helper text inside the scrollable view