### PR TITLE
Add wallet upkeep background task

### DIFF
--- a/go/engine/wallet_upkeep_background.go
+++ b/go/engine/wallet_upkeep_background.go
@@ -1,0 +1,104 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// WalletUpkeepBackground keeps the wallet bundle encrypted for the latest puk.
+
+package engine
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/stellar"
+)
+
+var WalletUpkeepBackgroundSettings = BackgroundTaskSettings{
+	// Wait after starting the app
+	Start: 40 * time.Second,
+	// When waking up on mobile lots of timers will go off at once. We wait an additional
+	// delay so as not to add to that herd and slow down the mobile experience when opening the app.
+	WakeUp: 20 * time.Second,
+	// Wait between checks
+	Interval: 24 * time.Hour,
+	// Time limit on each round
+	Limit: 10 * time.Minute,
+}
+
+// WalletUpkeepBackground is an engine.
+type WalletUpkeepBackground struct {
+	libkb.Contextified
+	sync.Mutex
+
+	args *WalletUpkeepBackgroundArgs
+	task *BackgroundTask
+}
+
+type WalletUpkeepBackgroundArgs struct {
+	// Channels used for testing. Normally nil.
+	testingMetaCh     chan<- string
+	testingRoundResCh chan<- error
+}
+
+// NewWalletUpkeepBackground creates a WalletUpkeepBackground engine.
+func NewWalletUpkeepBackground(g *libkb.GlobalContext, args *WalletUpkeepBackgroundArgs) *WalletUpkeepBackground {
+	task := NewBackgroundTask(g, &BackgroundTaskArgs{
+		Name:     "WalletUpkeepBackground",
+		F:        WalletUpkeepBackgroundRound,
+		Settings: WalletUpkeepBackgroundSettings,
+
+		testingMetaCh:     args.testingMetaCh,
+		testingRoundResCh: args.testingRoundResCh,
+	})
+	return &WalletUpkeepBackground{
+		Contextified: libkb.NewContextified(g),
+		args:         args,
+		// Install the task early so that Shutdown can be called before RunEngine.
+		task: task,
+	}
+}
+
+// Name is the unique engine name.
+func (e *WalletUpkeepBackground) Name() string {
+	return "WalletUpkeepBackground"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *WalletUpkeepBackground) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *WalletUpkeepBackground) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *WalletUpkeepBackground) SubConsumers() []libkb.UIConsumer {
+	return []libkb.UIConsumer{}
+}
+
+// Run starts the engine.
+// Returns immediately, kicks off a background goroutine.
+func (e *WalletUpkeepBackground) Run(ctx *Context) (err error) {
+	return RunEngine(e.task, ctx)
+}
+
+func (e *WalletUpkeepBackground) Shutdown() {
+	e.task.Shutdown()
+}
+
+func WalletUpkeepBackgroundRound(g *libkb.GlobalContext, ectx *Context) error {
+	if g.ConnectivityMonitor.IsConnected(ectx.GetNetContext()) == libkb.ConnectivityMonitorNo {
+		g.Log.CDebugf(ectx.GetNetContext(), "WalletUpkeepBackgroundRound giving up offline")
+		return nil
+	}
+
+	if !g.LocalSigchainGuard().IsAvailable(ectx.GetNetContext(), "WalletUpkeepBackgroundRound") {
+		g.Log.CDebugf(ectx.GetNetContext(), "WalletUpkeepBackgroundRound yielding to guard")
+		return nil
+	}
+
+	err := stellar.Upkeep(ectx.GetNetContext(), g)
+	return err
+}

--- a/go/libkb/stellar.go
+++ b/go/libkb/stellar.go
@@ -27,13 +27,3 @@ func MakeNaclSigningKeyPairFromStellarSecretKey(sec keybase1.StellarSecretKey) (
 	}
 	return MakeNaclSigningKeyPairFromSecretBytes(byteSlice)
 }
-
-// Make the "stellar" section of an API arg.
-// Modifies `serverArg`.
-func AddWalletServerArg(serverArg JSONPayload, bundleEncB64 string, bundleVisB64 string, formatVersion int) {
-	section := make(JSONPayload)
-	section["encrypted"] = bundleEncB64
-	section["visible"] = bundleVisB64
-	section["version"] = formatVersion
-	serverArg["stellar"] = section
-}

--- a/go/stellar/bundle/boxer.go
+++ b/go/stellar/bundle/boxer.go
@@ -191,6 +191,15 @@ func Decrypt(encBundle keybase1.EncryptedStellarBundle,
 	return res, err
 }
 
+// Create the next bundle given a decrypted bundle.
+func Advance(prevBundle keybase1.StellarBundle) keybase1.StellarBundle {
+	nextBundle := prevBundle.DeepCopy()
+	nextBundle.Prev = nextBundle.OwnHash
+	nextBundle.OwnHash = nil
+	nextBundle.Revision++
+	return nextBundle
+}
+
 func accountsSplit(accounts []keybase1.StellarEntry) (vis []keybase1.StellarVisibleEntry, sec []keybase1.StellarSecretEntry) {
 	for _, acc := range accounts {
 		vis = append(vis, keybase1.StellarVisibleEntry{

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -29,16 +29,15 @@ func ShouldCreate(ctx context.Context, g *libkb.GlobalContext) (should bool, err
 	return apiRes.ShouldCreate, err
 }
 
-// Post a bundle to the server
+// Post a bundle to the server with a chainlink.
 func PostWithChainlink(ctx context.Context, g *libkb.GlobalContext, clearBundle keybase1.StellarBundle) (err error) {
-	defer g.CTraceTimed(ctx, "Stellar.Post", func() error { return err })()
+	defer g.CTraceTimed(ctx, "Stellar.PostWithChainlink", func() error { return err })()
 
 	uid := g.ActiveDevice.UID()
 	if uid.IsNil() {
 		return libkb.NoUIDError{}
 	}
-
-	g.Log.CDebugf(ctx, "StellarPost load self")
+	g.Log.CDebugf(ctx, "Stellar.PostWithChainLink: load self")
 	loadMeArg := libkb.NewLoadUserArg(g).
 		WithNetContext(ctx).
 		WithUID(uid).
@@ -53,16 +52,7 @@ func PostWithChainlink(ctx context.Context, g *libkb.GlobalContext, clearBundle 
 	if err != nil {
 		return fmt.Errorf("signing key not found: (%v)", err)
 	}
-	pukring, err := g.GetPerUserKeyring()
-	if err != nil {
-		return err
-	}
-	err = pukring.Sync(ctx)
-	if err != nil {
-		return err
-	}
-	pukGen := pukring.CurrentGeneration()
-	pukSeed, err := pukring.GetSeedByGeneration(ctx, pukGen)
+	pukGen, pukSeed, err := getLatestPuk(ctx, g)
 	if err != nil {
 		return err
 	}
@@ -82,13 +72,13 @@ func PostWithChainlink(ctx context.Context, g *libkb.GlobalContext, clearBundle 
 	if !stellarAccount.IsPrimary {
 		return errors.New("initial stellar account is not primary")
 	}
-	g.Log.CDebugf(ctx, "StellarPost accountID:%v pukGen:%v", stellarAccount.AccountID, pukGen)
+	g.Log.CDebugf(ctx, "Stellar.PostWithChainLink: revision:%v accountID:%v pukGen:%v", clearBundle.Revision, stellarAccount.AccountID, pukGen)
 	boxed, err := bundle.Box(clearBundle, pukGen, pukSeed)
 	if err != nil {
 		return err
 	}
 
-	g.Log.CDebugf(ctx, "StellarPost make sigs")
+	g.Log.CDebugf(ctx, "Stellar.PostWithChainLink: make sigs")
 
 	sig, err := libkb.WalletProofReverseSigned(me, stellarAccount.AccountID, stellarAccount.Signers[0], sigKey)
 	if err != nil {
@@ -101,9 +91,9 @@ func PostWithChainlink(ctx context.Context, g *libkb.GlobalContext, clearBundle 
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = sigsList
 
-	libkb.AddWalletServerArg(payload, boxed.EncB64, boxed.VisB64, int(boxed.FormatVersion))
+	addWalletServerArg(payload, boxed.EncB64, boxed.VisB64, int(boxed.FormatVersion))
 
-	g.Log.CDebugf(ctx, "StellarPost post")
+	g.Log.CDebugf(ctx, "Stellar.PostWithChainLink: post")
 	_, err = g.API.PostJSON(libkb.APIArg{
 		Endpoint:    "key/multi",
 		SessionType: libkb.APISessionTypeREQUIRED,
@@ -117,6 +107,47 @@ func PostWithChainlink(ctx context.Context, g *libkb.GlobalContext, clearBundle 
 	return nil
 }
 
+// Post a bundle to the server.
+func Post(ctx context.Context, g *libkb.GlobalContext, clearBundle keybase1.StellarBundle) (err error) {
+	defer g.CTraceTimed(ctx, "Stellar.Post", func() error { return err })()
+	pukGen, pukSeed, err := getLatestPuk(ctx, g)
+	if err != nil {
+		return err
+	}
+	err = clearBundle.CheckInvariants()
+	if err != nil {
+		return err
+	}
+	g.Log.CDebugf(ctx, "Stellar.Post: revision:%v", clearBundle.Revision)
+	boxed, err := bundle.Box(clearBundle, pukGen, pukSeed)
+	if err != nil {
+		return err
+	}
+	payload := make(libkb.JSONPayload)
+	addWalletServerArg(payload, boxed.EncB64, boxed.VisB64, int(boxed.FormatVersion))
+	g.Log.CDebugf(ctx, "Stellar.Post: post")
+	_, err = g.API.PostJSON(libkb.APIArg{
+		Endpoint:    "stellar/bundle",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		JSONPayload: payload,
+	})
+	return err
+}
+
+func getLatestPuk(ctx context.Context, g *libkb.GlobalContext) (pukGen keybase1.PerUserKeyGeneration, pukSeed libkb.PerUserKeySeed, err error) {
+	pukring, err := g.GetPerUserKeyring()
+	if err != nil {
+		return pukGen, pukSeed, err
+	}
+	err = pukring.Sync(ctx)
+	if err != nil {
+		return pukGen, pukSeed, err
+	}
+	pukGen = pukring.CurrentGeneration()
+	pukSeed, err = pukring.GetSeedByGeneration(ctx, pukGen)
+	return pukGen, pukSeed, err
+}
+
 type fetchRes struct {
 	Status       libkb.AppStatus `json:"status"`
 	EncryptedB64 string          `json:"encrypted"`
@@ -128,31 +159,41 @@ func (r *fetchRes) GetAppStatus() *libkb.AppStatus {
 }
 
 // Fetch and unbox the latest bundle from the server.
-func Fetch(ctx context.Context, g *libkb.GlobalContext) (res keybase1.StellarBundle, err error) {
+func Fetch(ctx context.Context, g *libkb.GlobalContext) (res keybase1.StellarBundle, pukGen keybase1.PerUserKeyGeneration, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.Fetch", func() error { return err })()
 	arg := libkb.NewAPIArgWithNetContext(ctx, "stellar/bundle")
 	arg.SessionType = libkb.APISessionTypeREQUIRED
 	var apiRes fetchRes
 	err = g.API.GetDecode(arg, &apiRes)
 	if err != nil {
-		return res, err
+		return res, 0, err
 	}
 	decodeRes, err := bundle.Decode(apiRes.EncryptedB64)
 	if err != nil {
-		return res, err
+		return res, 0, err
 	}
 	pukring, err := g.GetPerUserKeyring()
 	if err != nil {
-		return res, err
+		return res, 0, err
 	}
 	err = pukring.Sync(ctx)
 	if err != nil {
-		return res, err
+		return res, 0, err
 	}
 	puk, err := pukring.GetSeedByGeneration(ctx, decodeRes.Enc.Gen)
 	if err != nil {
-		return res, err
+		return res, 0, err
 	}
 	res, _, err = bundle.Unbox(decodeRes, apiRes.VisibleB64, puk)
-	return res, err
+	return res, decodeRes.Enc.Gen, err
+}
+
+// Make the "stellar" section of an API arg.
+// Modifies `serverArg`.
+func addWalletServerArg(serverArg libkb.JSONPayload, bundleEncB64 string, bundleVisB64 string, formatVersion int) {
+	section := make(libkb.JSONPayload)
+	section["encrypted"] = bundleEncB64
+	section["visible"] = bundleVisB64
+	section["version"] = formatVersion
+	serverArg["stellar"] = section
 }


### PR DESCRIPTION
`Stellar.Upkeep` checks whether the user's bundle is encrypted with their latest PUK and if not re-encrypts and posts it.

`WalletUpkeepBackground` runs `Upkeep` in the background about a minute after startup and every 24 hours.