### PR TITLE
Rebox UserEK for new device during provisioning

### DIFF
--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -195,7 +195,7 @@ func (e *Kex2Provisionee) handleHello(uid keybase1.UID, token keybase1.SessionTo
 
 	ekLib := e.G().GetEKLib()
 	if ekLib != nil {
-		e.deviceEKSeed, err = ekLib.NewDeviceEphemeralSeed()
+		e.deviceEKSeed, err = ekLib.NewEphemeralSeed()
 		if err != nil {
 			return res, err
 		}

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -312,6 +312,9 @@ func (e *Kex2Provisionee) handleDidCounterSign(sig []byte, perUserKeyBox *keybas
 	// Finish the ephemeral key generation -- create a deviceEKStatement and
 	// prepare the boxMetadata for posting if we received a valid userEKBox
 	deviceEKStatement, signedDeviceEKStatement, userEKBoxMetadata, err := e.ephemeralKeygen(e.ctx.NetContext, userEKBox)
+	if err != nil {
+		return err
+	}
 
 	// post the key sigs to the api server
 	if err = e.postSigs(eddsaArgs, dhArgs, perUserKeyBox, userEKBoxMetadata, signedDeviceEKStatement); err != nil {

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -311,13 +311,13 @@ func (e *Kex2Provisionee) handleDidCounterSign(sig []byte, perUserKeyBox *keybas
 
 	// Finish the ephemeral key generation -- create a deviceEKStatement and
 	// prepare the boxMetadata for posting if we received a valid userEKBox
-	deviceEKStatement, signedDeviceEKStatement, userEKBoxMetadata, err := e.ephemeralKeygen(e.ctx.NetContext, userEKBox)
+	deviceEKStatement, deviceEKStatementSig, userEKBoxMetadata, err := e.ephemeralKeygen(e.ctx.NetContext, userEKBox)
 	if err != nil {
 		return err
 	}
 
 	// post the key sigs to the api server
-	if err = e.postSigs(eddsaArgs, dhArgs, perUserKeyBox, userEKBoxMetadata, signedDeviceEKStatement); err != nil {
+	if err = e.postSigs(eddsaArgs, dhArgs, perUserKeyBox, userEKBoxMetadata, deviceEKStatementSig); err != nil {
 		return err
 	}
 
@@ -488,7 +488,7 @@ func (e *Kex2Provisionee) reverseSig(jw *jsonw.Wrapper) error {
 // postSigs takes the HTTP args for the signing key and encrypt
 // key and posts them to the api server.
 func (e *Kex2Provisionee) postSigs(signingArgs, encryptArgs *libkb.HTTPArgs, perUserKeyBox *keybase1.PerUserKeyBox,
-	userEKBoxMetadata *keybase1.UserEkBoxMetadata, signedDeviceEKStatement string) error {
+	userEKBoxMetadata *keybase1.UserEkBoxMetadata, deviceEKStatementSig string) error {
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = []map[string]string{firstValues(signingArgs.ToValues()), firstValues(encryptArgs.ToValues())}
 
@@ -498,8 +498,8 @@ func (e *Kex2Provisionee) postSigs(signingArgs, encryptArgs *libkb.HTTPArgs, per
 	}
 
 	if userEKBoxMetadata != nil { // if we don't have a userEKBox, we won't make a deviceEKStatement
-		// TODO add deviceEKStatement to server args
-		// TODO add userEkBoxMetadata to server args
+		payload["device_eks"] = map[string]string{string(e.device.ID): deviceEKStatementSig}
+		payload["user_ek_rebox"] = *userEKBoxMetadata
 	}
 
 	arg := libkb.APIArg{
@@ -610,29 +610,29 @@ func (e *Kex2Provisionee) saveKeys() error {
 	return nil
 }
 
-func (e *Kex2Provisionee) ephemeralKeygen(ctx context.Context, userEKBox *keybase1.UserEkBoxed) (deviceEKStatement keybase1.DeviceEkStatement, signedDeviceEKStatement string, userEKBoxMetadata *keybase1.UserEkBoxMetadata, err error) {
+func (e *Kex2Provisionee) ephemeralKeygen(ctx context.Context, userEKBox *keybase1.UserEkBoxed) (deviceEKStatement keybase1.DeviceEkStatement, deviceEKStatementSig string, userEKBoxMetadata *keybase1.UserEkBoxMetadata, err error) {
 	// TODO is this the return signature we want? need to see what we need on the server side..
 	defer e.G().CTrace(ctx, "ephemeralKeygen", func() error { return err })()
 
 	if userEKBox == nil { // We will create EKs after provisioning in the normal way
 		e.G().Log.CWarningf(ctx, "userEKBox nil, no ephemeral keys created during provisioning")
-		return deviceEKStatement, signedDeviceEKStatement, nil, nil
+		return deviceEKStatement, deviceEKStatementSig, nil, nil
 	}
 
 	ekLib := e.G().GetEKLib()
 	if ekLib == nil {
 		e.G().Log.CWarningf(ctx, "ekLib missing from G. Aborting ephemeralKeygen")
-		return deviceEKStatement, signedDeviceEKStatement, nil, nil
+		return deviceEKStatement, deviceEKStatementSig, nil, nil
 	}
 
 	signingKey, err := e.SigningKey()
 	if err != nil {
-		return deviceEKStatement, signedDeviceEKStatement, nil, err
+		return deviceEKStatement, deviceEKStatementSig, nil, err
 	}
 
-	deviceEKStatement, signedDeviceEKStatement, err = ekLib.SignedDeviceEKStatementFromSeed(ctx, userEKBox.DeviceEkGeneration, e.deviceEKSeed, signingKey, []keybase1.DeviceEkMetadata{})
+	deviceEKStatement, deviceEKStatementSig, err = ekLib.SignedDeviceEKStatementFromSeed(ctx, userEKBox.DeviceEkGeneration, e.deviceEKSeed, signingKey, []keybase1.DeviceEkMetadata{})
 	if err != nil {
-		return deviceEKStatement, signedDeviceEKStatement, nil, err
+		return deviceEKStatement, deviceEKStatementSig, nil, err
 	}
 
 	userEKBoxMetadata = &keybase1.UserEkBoxMetadata{
@@ -641,7 +641,7 @@ func (e *Kex2Provisionee) ephemeralKeygen(ctx context.Context, userEKBox *keybas
 		RecipientGeneration: userEKBox.DeviceEkGeneration,
 	}
 
-	return deviceEKStatement, signedDeviceEKStatement, userEKBoxMetadata, err
+	return deviceEKStatement, deviceEKStatementSig, userEKBoxMetadata, err
 }
 
 // cacheKeys caches the device keys in the Account object.

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -326,7 +326,10 @@ func (e *Kex2Provisionee) handleDidCounterSign(sig []byte, perUserKeyBox *keybas
 		return err
 	}
 
-	// store the ephemeralkeys, if any
+	// store the ephemeralkeys, if any. If this fails after we have posted the
+	// client will no not have access to the userEK it was just reboxed for
+	// unfortunately. Without any EKs, the normal generation machinery will
+	// take over and they will make a new userEK
 	return e.storeEKs(e.ctx.NetContext, deviceEKStatement, userEKBox)
 }
 

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -611,7 +611,6 @@ func (e *Kex2Provisionee) saveKeys() error {
 }
 
 func (e *Kex2Provisionee) ephemeralKeygen(ctx context.Context, userEKBox *keybase1.UserEkBoxed) (deviceEKStatement keybase1.DeviceEkStatement, deviceEKStatementSig string, userEKBoxMetadata *keybase1.UserEkBoxMetadata, err error) {
-	// TODO is this the return signature we want? need to see what we need on the server side..
 	defer e.G().CTrace(ctx, "ephemeralKeygen", func() error { return err })()
 
 	if userEKBox == nil { // We will create EKs after provisioning in the normal way
@@ -663,7 +662,10 @@ func (e *Kex2Provisionee) cacheKeys() (err error) {
 
 func (e *Kex2Provisionee) storeEKs(ctx context.Context, deviceEKStatement keybase1.DeviceEkStatement, userEKBox *keybase1.UserEkBoxed) (err error) {
 	defer e.G().Trace("Kex2Provisionee.storeEKs", func() error { return err })()
-	if userEKBox == nil {
+	ekLib := e.G().GetEKLib()
+	if ekLib == nil || !ekLib.ShouldRun(ctx) {
+		return nil
+	} else if userEKBox == nil {
 		e.G().Log.CWarningf(ctx, "userEKBox nil, no ephemeral keys to store")
 		return nil
 	}

--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -272,7 +272,7 @@ func (e *Kex2Provisioner) CounterSign2(input keybase1.Hello2Res) (output keybase
 	}
 	output.PpsEncrypted, err = key.EncryptToString(ppsPacked, nil)
 
-	// Sync the puk, if the pukring is nil, we don't have a puk and have
+	// Sync the PUK, if the pukring is nil, we don't have a PUK and have
 	// nothing to box. We also can't make a userEKBox which is signed by the
 	// PUK.
 	pukring, err := e.syncPUK()

--- a/go/engine/kex2_test.go
+++ b/go/engine/kex2_test.go
@@ -25,6 +25,7 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	// device X (provisioner) context:
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
+
 	tcX.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
 
 	// provisioner needs to be logged in
@@ -33,6 +34,7 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	// device Y (provisionee) context:
 	tcY := SetupEngineTest(t, "kex2provision")
 	defer tcY.Cleanup()
+
 	tcY.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
 
 	var secretX kex2.Secret

--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -52,12 +52,6 @@ func keygenNeeded(ctime keybase1.Time, currentMerkleRoot libkb.MerkleRoot) bool 
 	return currentMerkleRoot.Ctime()-ctime.UnixSeconds() >= KeyGenLifetimeSecs
 }
 
-// We should wrap any entry points to the library with this before we're ready
-// to fully release it.
-func ShouldRun(g *libkb.GlobalContext) bool {
-	return g.Env.GetFeatureFlags().UseEphemeral() || g.Env.GetRunMode() == libkb.DevelRunMode || g.Env.RunningInCI()
-}
-
 func makeNewRandomSeed() (seed keybase1.Bytes32, err error) {
 	bs, err := libkb.RandBytes(libkb.NaclDHKeysize)
 	if err != nil {

--- a/go/ephemeral/common_test.go
+++ b/go/ephemeral/common_test.go
@@ -12,6 +12,7 @@ import (
 
 func ephemeralKeyTestSetup(t *testing.T) libkb.TestContext {
 	tc := libkb.SetupTest(t, "ephemeral", 2)
+	defer tc.Cleanup()
 
 	NewEphemeralStorageAndInstall(tc.G)
 

--- a/go/ephemeral/common_test.go
+++ b/go/ephemeral/common_test.go
@@ -12,7 +12,6 @@ import (
 
 func ephemeralKeyTestSetup(t *testing.T) libkb.TestContext {
 	tc := libkb.SetupTest(t, "ephemeral", 2)
-	defer tc.Cleanup()
 
 	NewEphemeralStorageAndInstall(tc.G)
 

--- a/go/ephemeral/init.go
+++ b/go/ephemeral/init.go
@@ -11,11 +11,8 @@ func NewEphemeralStorageAndInstall(g *libkb.GlobalContext) {
 	g.SetTeamEKBoxStorage(NewTeamEKBoxStorage(g))
 	ekLib := NewEKLib(g)
 	g.SetEKLib(ekLib)
-	// TODO remove this when we want to release in the wild.
-	if ShouldRun(g) {
-		g.AddLoginHook(ekLib)
-		g.AddLogoutHook(ekLib)
-	}
+	g.AddLoginHook(ekLib)
+	g.AddLogoutHook(ekLib)
 }
 
 func ServiceInit(g *libkb.GlobalContext) {

--- a/go/ephemeral/kex2_test.go
+++ b/go/ephemeral/kex2_test.go
@@ -1,0 +1,148 @@
+package ephemeral
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/kex2"
+	"github.com/keybase/client/go/libkb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKex2Provision(t *testing.T) {
+	subTestKex2Provision(t, false)
+}
+
+func TestKex2ProvisionPUK(t *testing.T) {
+	subTestKex2Provision(t, true)
+}
+
+func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
+	// device X (provisioner) context:
+	tcX := libkb.SetupTest(t, "kex2provision", 2)
+	defer tcX.Cleanup()
+	tcX.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
+	NewEphemeralStorageAndInstall(tcX.G)
+
+	// provisioner needs to be logged in
+	userX, err := kbtest.CreateAndSignupFakeUser("X", tcX.G)
+	require.NoError(t, err)
+
+	// The test user has a PUK, but it's not automatically loaded. We have to
+	// explicitly sync it.
+	keyring, err := tcX.G.GetPerUserKeyring()
+	require.NoError(t, err)
+	err = keyring.Sync(context.Background())
+	require.NoError(t, err)
+
+	// provisioner needs to be logged in
+	err = userX.Login(tcX.G)
+	require.NoError(t, err)
+
+	ekLib := tcX.G.GetEKLib()
+	err = ekLib.KeygenIfNeeded(context.Background())
+	require.NoError(t, err)
+
+	// After the provision, Y should have access to this userEK generation
+	userEKBoxStorageX := tcX.G.GetUserEKBoxStorage()
+	expectedUserEKGen, err := userEKBoxStorageX.MaxGeneration(context.Background())
+	require.NoError(t, err)
+	require.True(t, expectedUserEKGen > 0)
+	userEKX, err := userEKBoxStorageX.Get(context.Background(), expectedUserEKGen)
+	require.NoError(t, err)
+
+	// device Y (provisionee) context:
+	tcY := libkb.SetupTest(t, "kex2provision", 2)
+	defer tcY.Cleanup()
+	tcY.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
+	NewEphemeralStorageAndInstall(tcY.G)
+
+	var secretX kex2.Secret
+	_, err = rand.Read(secretX[:])
+	require.NoError(t, err)
+
+	var secretY kex2.Secret
+	_, err = rand.Read(secretY[:])
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	// start provisionee
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		f := func(lctx libkb.LoginContext) error {
+
+			ctx := &engine.Context{
+				ProvisionUI:  &kbtest.TestProvisionUI{SecretCh: make(chan kex2.Secret, 1)},
+				LoginContext: lctx,
+			}
+			deviceID, err := libkb.NewDeviceID()
+			if err != nil {
+				t.Errorf("provisionee device id error: %s", err)
+				return err
+			}
+			suffix, err := libkb.RandBytes(5)
+			if err != nil {
+				t.Errorf("provisionee device suffix error: %s", err)
+				return err
+			}
+			dname := fmt.Sprintf("device_%x", suffix)
+			device := &libkb.Device{
+				ID:          deviceID,
+				Description: &dname,
+				Type:        libkb.DeviceTypeDesktop,
+			}
+			provisionee := engine.NewKex2Provisionee(tcY.G, device, secretY)
+			if err := engine.RunEngine(provisionee, ctx); err != nil {
+				t.Errorf("provisionee error: %s", err)
+				return err
+			}
+			return nil
+		}
+
+		if err := tcY.G.LoginState().ExternalFunc(f, "Test - Kex2Provision"); err != nil {
+			t.Errorf("kex2 provisionee error: %s", err)
+		}
+	}()
+
+	// start provisioner
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ctx := &engine.Context{
+			SecretUI:    userX.NewSecretUI(),
+			ProvisionUI: &kbtest.TestProvisionUI{},
+		}
+		provisioner := engine.NewKex2Provisioner(tcX.G, secretX, nil)
+		go provisioner.AddSecret(secretY)
+		if err := engine.RunEngine(provisioner, ctx); err != nil {
+			t.Errorf("provisioner error: %s", err)
+			return
+		}
+	}()
+
+	wg.Wait()
+
+	// Confirm that Y has a deviceEK.
+	deviceEKStorageY := tcY.G.GetDeviceEKStorage()
+	maxDeviceEKGenerationY, err := deviceEKStorageY.MaxGeneration(context.Background())
+	require.NoError(t, err)
+	require.True(t, maxDeviceEKGenerationY > 0)
+	_, err = deviceEKStorageY.Get(context.Background(), maxDeviceEKGenerationY)
+	require.NoError(t, err)
+
+	// Confirm Y has a userEK at the same generation as X.
+	userEKBoxStorageY := tcY.G.GetUserEKBoxStorage()
+	maxUserEKGenerationY, err := userEKBoxStorageY.MaxGeneration(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expectedUserEKGen, maxUserEKGenerationY)
+	userEKY, err := userEKBoxStorageY.Get(context.Background(), maxUserEKGenerationY)
+	require.Equal(t, userEKY, userEKX)
+}

--- a/go/ephemeral/kex2_test.go
+++ b/go/ephemeral/kex2_test.go
@@ -156,8 +156,19 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	userEKGenY, err := userEKBoxStorageY.MaxGeneration(context.Background())
 	require.NoError(t, err)
 	require.EqualValues(t, userEKGenX, userEKGenY)
-	userEKY, err := userEKBoxStorageY.Get(context.Background(), userEKGenY)
-	require.Equal(t, userEKY, userEKX)
 
-	// TODO clear cache on storage and verify we can fetch the userekbox from the server.
+	if upgradePerUserKey {
+		userEKY, err := userEKBoxStorageY.Get(context.Background(), userEKGenY)
+		require.NoError(t, err)
+		require.Equal(t, userEKX, userEKY)
+
+		// Now clear local store and make sure the server has reboxed userEK.
+		rawUserEKBoxStorage := NewUserEKBoxStorage(tcY.G)
+		rawUserEKBoxStorage.Delete(context.Background(), userEKGenY)
+		userEKBoxStorageY.ClearCache()
+
+		userEKYFetched, err := userEKBoxStorageY.Get(context.Background(), userEKGenY)
+		require.NoError(t, err)
+		require.Equal(t, userEKX, userEKYFetched)
+	}
 }

--- a/go/ephemeral/kex2_test.go
+++ b/go/ephemeral/kex2_test.go
@@ -158,4 +158,6 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	require.EqualValues(t, userEKGenX, userEKGenY)
 	userEKY, err := userEKBoxStorageY.Get(context.Background(), userEKGenY)
 	require.Equal(t, userEKY, userEKX)
+
+	// TODO clear cache on storage and verify we can fetch the userekbox from the server.
 }

--- a/go/ephemeral/kex2_test.go
+++ b/go/ephemeral/kex2_test.go
@@ -145,8 +145,20 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	if upgradePerUserKey {
 		// Confirm that Y has a deviceEK.
 		require.True(t, maxDeviceEKGenerationY > 0)
-		_, err = deviceEKStorageY.Get(context.Background(), maxDeviceEKGenerationY)
+		deviceEKY, err := deviceEKStorageY.Get(context.Background(), maxDeviceEKGenerationY)
 		require.NoError(t, err)
+
+		// Make sure the server knows about our device_ek
+		merkleRootPtr, err := tcY.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
+		require.NoError(t, err)
+
+		fetchedDevices, err := allActiveDeviceEKMetadata(context.Background(), tcY.G, *merkleRootPtr)
+		require.NoError(t, err)
+
+		deviceEKMetatdata, ok := fetchedDevices[tcY.G.ActiveDevice.DeviceID()]
+		require.True(t, ok)
+		require.Equal(t, deviceEKY.Metadata, deviceEKMetatdata)
+
 	} else {
 		require.EqualValues(t, -1, maxDeviceEKGenerationY)
 	}

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -317,7 +317,7 @@ func (e *EKLib) GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.Tea
 	return teamEK, nil
 }
 
-func (e *EKLib) NewDeviceEphemeralSeed() (seed keybase1.Bytes32, err error) {
+func (e *EKLib) NewEphemeralSeed() (seed keybase1.Bytes32, err error) {
 	return makeNewRandomSeed()
 }
 

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -318,11 +318,7 @@ func (e *EKLib) GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.Tea
 }
 
 func (e *EKLib) NewDeviceEphemeralSeed() (seed keybase1.Bytes32, err error) {
-	deviceEKSeed, err := newDeviceEphemeralSeed()
-	if err != nil {
-		return seed, nil
-	}
-	return keybase1.Bytes32(deviceEKSeed), nil
+	return makeNewRandomSeed()
 }
 
 func (e *EKLib) DeriveDeviceDHKey(seed keybase1.Bytes32) *libkb.NaclDHKeyPair {

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -32,13 +32,7 @@ func (s *TeamEKSeed) DeriveDHKey() *libkb.NaclDHKeyPair {
 	return deriveDHKey(keybase1.Bytes32(*s), libkb.DeriveReasonTeamEKEncryption)
 }
 
-type TeamEKBoxMetadata struct {
-	RecipientUID        keybase1.UID          `json:"recipient_uid"`
-	RecipientGeneration keybase1.EkGeneration `json:"recipient_generation"`
-	Box                 string                `json:"box"`
-}
-
-func postNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, sig string, boxes []TeamEKBoxMetadata) (err error) {
+func postNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, sig string, boxes []keybase1.TeamEkBoxMetadata) (err error) {
 	defer g.CTrace(ctx, "postNewTeamEK", func() error { return err })()
 
 	boxesJSON, err := json.Marshal(boxes)
@@ -153,7 +147,7 @@ func signAndPublishTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID ke
 	return metadata, myTeamEKBoxed, nil
 }
 
-func boxTeamEKForMembers(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot, seed TeamEKSeed, teamMetadata keybase1.TeamEkMetadata) (boxes []TeamEKBoxMetadata, myTeamEKBoxed *keybase1.TeamEkBoxed, err error) {
+func boxTeamEKForMembers(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot, seed TeamEKSeed, teamMetadata keybase1.TeamEkMetadata) (boxes []keybase1.TeamEkBoxMetadata, myTeamEKBoxed *keybase1.TeamEkBoxed, err error) {
 	defer g.CTrace(ctx, "boxTeamEKForMembers", func() error { return err })()
 
 	membersMetadata, err := activeMemberEKMetadata(ctx, g, teamID, merkleRoot)
@@ -172,7 +166,7 @@ func boxTeamEKForMembers(ctx context.Context, g *libkb.GlobalContext, teamID key
 		if err != nil {
 			return nil, nil, err
 		}
-		boxMetadata := TeamEKBoxMetadata{
+		boxMetadata := keybase1.TeamEkBoxMetadata{
 			RecipientUID:        uid,
 			RecipientGeneration: memberMetadata.Generation,
 			Box:                 box,

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -46,7 +46,7 @@ func (s *TeamEKBoxStorage) dbKey(ctx context.Context, teamID keybase1.TeamID) (d
 }
 
 func (s *TeamEKBoxStorage) Get(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
-	defer s.G().CTrace(ctx, "TeamEKBoxStorage#Get", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("TeamEKBoxStorage#Get: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
 
 	s.Lock()
 
@@ -69,7 +69,7 @@ func (s *TeamEKBoxStorage) Get(ctx context.Context, teamID keybase1.TeamID, gene
 }
 
 func (s *TeamEKBoxStorage) getMap(ctx context.Context, teamID keybase1.TeamID) (teamEKBoxes TeamEKBoxMap, found bool, err error) {
-	defer s.G().CTrace(ctx, "TeamEKBoxStorage#getMap", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("TeamEKBoxStorage#getMap: teamID:%v", teamID), func() error { return err })()
 
 	teamEKBoxes, found = s.cache.GetMap(teamID)
 	if found {
@@ -99,7 +99,7 @@ type TeamEKBoxedResponse struct {
 }
 
 func (s *TeamEKBoxStorage) fetchAndPut(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
-	defer s.G().CTrace(ctx, "TeamEKBoxStorage#fetchAndPut", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("TeamEKBoxStorage#fetchAndPut: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "team/team_ek_box",
@@ -168,7 +168,7 @@ func (s *TeamEKBoxStorage) fetchAndPut(ctx context.Context, teamID keybase1.Team
 }
 
 func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) (teamEK keybase1.TeamEk, err error) {
-	defer s.G().CTrace(ctx, "TeamEKBoxStorage#unbox", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("TeamEKBoxStorage#unbox: teamEKGeneration: %v", teamEKGeneration), func() error { return err })()
 
 	userEKBoxStorage := s.G().GetUserEKBoxStorage()
 	userEK, err := userEKBoxStorage.Get(ctx, teamEKBoxed.UserEkGeneration)
@@ -198,7 +198,7 @@ func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.
 }
 
 func (s *TeamEKBoxStorage) Put(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) (err error) {
-	defer s.G().CTrace(ctx, "TeamEKBoxStorage#Put", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("TeamEKBoxStorage#Put: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
@@ -227,7 +227,7 @@ func (s *TeamEKBoxStorage) Delete(ctx context.Context, teamID keybase1.TeamID, g
 }
 
 func (s *TeamEKBoxStorage) deleteMany(ctx context.Context, teamID keybase1.TeamID, generations []keybase1.EkGeneration) (err error) {
-	defer s.G().CTrace(ctx, "TeamEKBoxStorage#delete", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("TeamEKBoxStorage#delete: teamID:%v, generations:%v", teamID, generations), func() error { return err })()
 
 	teamEKBoxes, found, err := s.getMap(ctx, teamID)
 	if err != nil {
@@ -253,7 +253,7 @@ func (s *TeamEKBoxStorage) deleteMany(ctx context.Context, teamID keybase1.TeamI
 }
 
 func (s *TeamEKBoxStorage) DeleteExpired(ctx context.Context, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (expired []keybase1.EkGeneration, err error) {
-	defer s.G().CTrace(ctx, "TeamEKBoxStorage#DeleteExpired", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("TeamEKBoxStorage#DeleteExpired: teamID:%v", teamID), func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
@@ -274,7 +274,7 @@ func (s *TeamEKBoxStorage) DeleteExpired(ctx context.Context, teamID keybase1.Te
 }
 
 func (s *TeamEKBoxStorage) GetAll(ctx context.Context, teamID keybase1.TeamID) (teamEKs TeamEKMap, err error) {
-	defer s.G().CTrace(ctx, "TeamEKBoxStorage#GetAll", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("TeamEKBoxStorage#GetAll: teamID:%v", teamID), func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
@@ -304,7 +304,7 @@ func (s *TeamEKBoxStorage) ClearCache() {
 }
 
 func (s *TeamEKBoxStorage) MaxGeneration(ctx context.Context, teamID keybase1.TeamID) (maxGeneration keybase1.EkGeneration, err error) {
-	defer s.G().CTrace(ctx, "TeamEKBoxStorage#MaxGeneration", func() error { return nil })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("TeamEKBoxStorage#MaxGeneration: teamID:%v", teamID), func() error { return nil })()
 
 	s.Lock()
 	defer s.Unlock()

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -31,13 +31,7 @@ func (s *UserEKSeed) DeriveDHKey() *libkb.NaclDHKeyPair {
 	return deriveDHKey(keybase1.Bytes32(*s), libkb.DeriveReasonUserEKEncryption)
 }
 
-type UserEKBoxMetadata struct {
-	RecipientDeviceID   keybase1.DeviceID     `json:"recipient_device_id"`
-	RecipientGeneration keybase1.EkGeneration `json:"recipient_generation"`
-	Box                 string                `json:"box"`
-}
-
-func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxes []UserEKBoxMetadata) (err error) {
+func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxes []keybase1.UserEkBoxMetadata) (err error) {
 	defer g.CTrace(ctx, "postNewUserEK", func() error { return err })()
 
 	boxesJSON, err := json.Marshal(boxes)
@@ -152,7 +146,7 @@ func signAndPublishUserEK(ctx context.Context, g *libkb.GlobalContext, generatio
 	return metadata, myUserEKBoxed, nil
 }
 
-func boxUserEKForDevices(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot, seed UserEKSeed, userMetadata keybase1.UserEkMetadata) (boxes []UserEKBoxMetadata, myUserEKBoxed *keybase1.UserEkBoxed, err error) {
+func boxUserEKForDevices(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot, seed UserEKSeed, userMetadata keybase1.UserEkMetadata) (boxes []keybase1.UserEkBoxMetadata, myUserEKBoxed *keybase1.UserEkBoxed, err error) {
 	defer g.CTrace(ctx, "boxUserEKForDevices", func() error { return err })()
 
 	devicesMetadata, err := allActiveDeviceEKMetadata(ctx, g, merkleRoot)
@@ -171,7 +165,7 @@ func boxUserEKForDevices(ctx context.Context, g *libkb.GlobalContext, merkleRoot
 		if err != nil {
 			return nil, nil, err
 		}
-		boxMetadata := UserEKBoxMetadata{
+		boxMetadata := keybase1.UserEkBoxMetadata{
 			RecipientDeviceID:   deviceID,
 			RecipientGeneration: deviceMetadata.Generation,
 			Box:                 box,

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -41,8 +41,8 @@ func (s *UserEKBoxStorage) dbKey(ctx context.Context) (dbKey libkb.DbKey, err er
 }
 
 func (s *UserEKBoxStorage) getCache(ctx context.Context) (cache UserEKBoxMap, err error) {
+	defer s.G().CTrace(ctx, "UserEKBoxStorage#getCache", func() error { return err })()
 	if !s.indexed {
-		defer s.G().CTrace(ctx, "UserEKBoxStorage#indexInner", func() error { return err })()
 
 		key, err := s.dbKey(ctx)
 		if err != nil {
@@ -58,7 +58,7 @@ func (s *UserEKBoxStorage) getCache(ctx context.Context) (cache UserEKBoxMap, er
 }
 
 func (s *UserEKBoxStorage) Get(ctx context.Context, generation keybase1.EkGeneration) (userEK keybase1.UserEk, err error) {
-	defer s.G().CTrace(ctx, "UserEKBoxStorage#Get", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("UserEKBoxStorage#Get: generation:%v", generation), func() error { return err })()
 
 	s.Lock()
 
@@ -89,7 +89,7 @@ type UserEKBoxedResponse struct {
 }
 
 func (s *UserEKBoxStorage) fetchAndPut(ctx context.Context, generation keybase1.EkGeneration) (userEK keybase1.UserEk, err error) {
-	defer s.G().CTrace(ctx, "UserEKBoxStorage#fetchAndPut", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("UserEKBoxStorage#fetchAndPut: generation: %v", generation), func() error { return err })()
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "user/user_ek_box",
@@ -158,7 +158,7 @@ func (s *UserEKBoxStorage) fetchAndPut(ctx context.Context, generation keybase1.
 }
 
 func (s *UserEKBoxStorage) Put(ctx context.Context, generation keybase1.EkGeneration, userEKBoxed keybase1.UserEkBoxed) (err error) {
-	defer s.G().CTrace(ctx, "UserEKBoxStorage#Put", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("UserEKBoxStorage#Put: generation:%v", generation), func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
@@ -180,7 +180,7 @@ func (s *UserEKBoxStorage) Put(ctx context.Context, generation keybase1.EkGenera
 }
 
 func (s *UserEKBoxStorage) unbox(ctx context.Context, userEKGeneration keybase1.EkGeneration, userEKBoxed keybase1.UserEkBoxed) (userEK keybase1.UserEk, err error) {
-	defer s.G().CTrace(ctx, "UserEKBoxStorage#unbox", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("UserEKBoxStorage#unbox: generation:%v", userEKGeneration), func() error { return err })()
 
 	deviceEKStorage := s.G().GetDeviceEKStorage()
 	deviceEK, err := deviceEKStorage.Get(ctx, userEKBoxed.DeviceEkGeneration)
@@ -216,7 +216,7 @@ func (s *UserEKBoxStorage) Delete(ctx context.Context, generation keybase1.EkGen
 }
 
 func (s *UserEKBoxStorage) deleteMany(ctx context.Context, generations []keybase1.EkGeneration) (err error) {
-	defer s.G().CTrace(ctx, "UserEKBoxStorage#delete", func() error { return err })()
+	defer s.G().CTrace(ctx, fmt.Sprintf("UserEKBoxStorage#deleteMany: generations:%v", generations), func() error { return err })()
 
 	cache, err := s.getCache(ctx)
 	if err != nil {

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/kex2"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -60,7 +61,7 @@ func (fu *FakeUser) GetUserVersion() keybase1.UserVersion {
 
 func (fu *FakeUser) Login(g *libkb.GlobalContext) error {
 	ctx := &engine.Context{
-		ProvisionUI: &testProvisionUI{},
+		ProvisionUI: &TestProvisionUI{},
 		LogUI:       g.UI.GetLogUI(),
 		GPGUI:       &gpgtestui{},
 		SecretUI:    fu.NewSecretUI(),
@@ -138,47 +139,51 @@ func AssertProvisioned(tc libkb.TestContext) error {
 	return nil
 }
 
-type testProvisionUI struct {
+type TestProvisionUI struct {
+	SecretCh chan kex2.Secret
 }
 
-func (u *testProvisionUI) ChooseProvisioningMethod(_ context.Context, _ keybase1.ChooseProvisioningMethodArg) (keybase1.ProvisionMethod, error) {
+func (u *TestProvisionUI) ChooseProvisioningMethod(_ context.Context, _ keybase1.ChooseProvisioningMethodArg) (keybase1.ProvisionMethod, error) {
 	panic("ChooseProvisioningMethod deprecated")
 }
 
-func (u *testProvisionUI) ChooseGPGMethod(_ context.Context, _ keybase1.ChooseGPGMethodArg) (keybase1.GPGMethod, error) {
+func (u *TestProvisionUI) ChooseGPGMethod(_ context.Context, _ keybase1.ChooseGPGMethodArg) (keybase1.GPGMethod, error) {
 	return keybase1.GPGMethod_GPG_NONE, nil
 }
 
-func (u *testProvisionUI) SwitchToGPGSignOK(ctx context.Context, arg keybase1.SwitchToGPGSignOKArg) (bool, error) {
+func (u *TestProvisionUI) SwitchToGPGSignOK(ctx context.Context, arg keybase1.SwitchToGPGSignOKArg) (bool, error) {
 	return true, nil
 }
 
-func (u *testProvisionUI) ChooseDevice(_ context.Context, arg keybase1.ChooseDeviceArg) (keybase1.DeviceID, error) {
+func (u *TestProvisionUI) ChooseDevice(_ context.Context, arg keybase1.ChooseDeviceArg) (keybase1.DeviceID, error) {
 	return "", nil
 }
 
-func (u *testProvisionUI) ChooseDeviceType(_ context.Context, _ keybase1.ChooseDeviceTypeArg) (keybase1.DeviceType, error) {
+func (u *TestProvisionUI) ChooseDeviceType(_ context.Context, _ keybase1.ChooseDeviceTypeArg) (keybase1.DeviceType, error) {
 	return keybase1.DeviceType_DESKTOP, nil
 }
 
-func (u *testProvisionUI) DisplayAndPromptSecret(_ context.Context, arg keybase1.DisplayAndPromptSecretArg) (keybase1.SecretResponse, error) {
+func (u *TestProvisionUI) DisplayAndPromptSecret(_ context.Context, arg keybase1.DisplayAndPromptSecretArg) (keybase1.SecretResponse, error) {
+	var ks kex2.Secret
+	copy(ks[:], arg.Secret)
+	u.SecretCh <- ks
 	var sr keybase1.SecretResponse
 	return sr, nil
 }
 
-func (u *testProvisionUI) PromptNewDeviceName(_ context.Context, arg keybase1.PromptNewDeviceNameArg) (string, error) {
+func (u *TestProvisionUI) PromptNewDeviceName(_ context.Context, arg keybase1.PromptNewDeviceNameArg) (string, error) {
 	return libkb.RandString("device", 5)
 }
 
-func (u *testProvisionUI) DisplaySecretExchanged(_ context.Context, _ int) error {
+func (u *TestProvisionUI) DisplaySecretExchanged(_ context.Context, _ int) error {
 	return nil
 }
 
-func (u *testProvisionUI) ProvisioneeSuccess(_ context.Context, _ keybase1.ProvisioneeSuccessArg) error {
+func (u *TestProvisionUI) ProvisioneeSuccess(_ context.Context, _ keybase1.ProvisioneeSuccessArg) error {
 	return nil
 }
 
-func (u *testProvisionUI) ProvisionerSuccess(_ context.Context, _ keybase1.ProvisionerSuccessArg) error {
+func (u *TestProvisionUI) ProvisionerSuccess(_ context.Context, _ keybase1.ProvisionerSuccessArg) error {
 	return nil
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -642,6 +642,9 @@ type EKLib interface {
 	KeygenIfNeeded(ctx context.Context) error
 	GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (keybase1.TeamEk, error)
 	PurgeTeamEKGenCache(context context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration)
+	NewDeviceEphemeralSeed() (keybase1.Bytes32, error)
+	DeriveDeviceDHKey(seed keybase1.Bytes32) *NaclDHKeyPair
+	SignedDeviceEKStatementFromSeed(ctx context.Context, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey GenericKey, existingMetadata []keybase1.DeviceEkMetadata) (keybase1.DeviceEkStatement, string, error)
 }
 
 type ImplicitTeamConflictInfoCacher interface {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -642,7 +642,7 @@ type EKLib interface {
 	KeygenIfNeeded(ctx context.Context) error
 	GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (keybase1.TeamEk, error)
 	PurgeTeamEKGenCache(context context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration)
-	NewDeviceEphemeralSeed() (keybase1.Bytes32, error)
+	NewEphemeralSeed() (keybase1.Bytes32, error)
 	DeriveDeviceDHKey(seed keybase1.Bytes32) *NaclDHKeyPair
 	SignedDeviceEKStatementFromSeed(ctx context.Context, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey GenericKey, existingMetadata []keybase1.DeviceEkMetadata) (keybase1.DeviceEkStatement, string, error)
 	BoxLatestUserEK(ctx context.Context, receiverKey NaclDHKeyPair, deviceEKGeneration keybase1.EkGeneration) (*keybase1.UserEkBoxed, error)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -645,6 +645,7 @@ type EKLib interface {
 	NewDeviceEphemeralSeed() (keybase1.Bytes32, error)
 	DeriveDeviceDHKey(seed keybase1.Bytes32) *NaclDHKeyPair
 	SignedDeviceEKStatementFromSeed(ctx context.Context, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey GenericKey, existingMetadata []keybase1.DeviceEkMetadata) (keybase1.DeviceEkStatement, string, error)
+	BoxLatestUserEK(ctx context.Context, receiverKey NaclDHKeyPair, deviceEKGeneration keybase1.EkGeneration) (*keybase1.UserEkBoxed, error)
 }
 
 type ImplicitTeamConflictInfoCacher interface {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -646,6 +646,7 @@ type EKLib interface {
 	DeriveDeviceDHKey(seed keybase1.Bytes32) *NaclDHKeyPair
 	SignedDeviceEKStatementFromSeed(ctx context.Context, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey GenericKey, existingMetadata []keybase1.DeviceEkMetadata) (keybase1.DeviceEkStatement, string, error)
 	BoxLatestUserEK(ctx context.Context, receiverKey NaclDHKeyPair, deviceEKGeneration keybase1.EkGeneration) (*keybase1.UserEkBoxed, error)
+	ShouldRun(ctx context.Context) bool
 }
 
 type ImplicitTeamConflictInfoCacher interface {

--- a/go/protocol/keybase1/ephemeral.go
+++ b/go/protocol/keybase1/ephemeral.go
@@ -115,6 +115,20 @@ func (o UserEkBoxed) DeepCopy() UserEkBoxed {
 	}
 }
 
+type UserEkBoxMetadata struct {
+	Box                 string       `codec:"box" json:"box"`
+	RecipientGeneration EkGeneration `codec:"recipientGeneration" json:"recipient_generation"`
+	RecipientDeviceID   DeviceID     `codec:"recipientDeviceID" json:"recipient_device_id"`
+}
+
+func (o UserEkBoxMetadata) DeepCopy() UserEkBoxMetadata {
+	return UserEkBoxMetadata{
+		Box:                 o.Box,
+		RecipientGeneration: o.RecipientGeneration.DeepCopy(),
+		RecipientDeviceID:   o.RecipientDeviceID.DeepCopy(),
+	}
+}
+
 type UserEk struct {
 	Seed     Bytes32        `codec:"seed" json:"seed"`
 	Metadata UserEkMetadata `codec:"metadata" json:"metadata"`
@@ -176,6 +190,20 @@ func (o TeamEkBoxed) DeepCopy() TeamEkBoxed {
 		Box:              o.Box,
 		UserEkGeneration: o.UserEkGeneration.DeepCopy(),
 		Metadata:         o.Metadata.DeepCopy(),
+	}
+}
+
+type TeamEkBoxMetadata struct {
+	Box                 string       `codec:"box" json:"box"`
+	RecipientGeneration EkGeneration `codec:"recipientGeneration" json:"recipient_generation"`
+	RecipientUID        UID          `codec:"recipientUID" json:"recipient_uid"`
+}
+
+func (o TeamEkBoxMetadata) DeepCopy() TeamEkBoxMetadata {
+	return TeamEkBoxMetadata{
+		Box:                 o.Box,
+		RecipientGeneration: o.RecipientGeneration.DeepCopy(),
+		RecipientUID:        o.RecipientUID.DeepCopy(),
 	}
 }
 

--- a/go/protocol/keybase1/kex2provisionee2.go
+++ b/go/protocol/keybase1/kex2provisionee2.go
@@ -11,12 +11,14 @@ import (
 type Hello2Res struct {
 	EncryptionKey KID      `codec:"encryptionKey" json:"encryptionKey"`
 	SigPayload    HelloRes `codec:"sigPayload" json:"sigPayload"`
+	DeviceEkKID   KID      `codec:"deviceEkKID" json:"deviceEkKID"`
 }
 
 func (o Hello2Res) DeepCopy() Hello2Res {
 	return Hello2Res{
 		EncryptionKey: o.EncryptionKey.DeepCopy(),
 		SigPayload:    o.SigPayload.DeepCopy(),
+		DeviceEkKID:   o.DeviceEkKID.DeepCopy(),
 	}
 }
 
@@ -45,6 +47,7 @@ type DidCounterSign2Arg struct {
 	Sig          []byte         `codec:"sig" json:"sig"`
 	PpsEncrypted string         `codec:"ppsEncrypted" json:"ppsEncrypted"`
 	PukBox       *PerUserKeyBox `codec:"pukBox,omitempty" json:"pukBox,omitempty"`
+	UserEkBox    *UserEkBoxed   `codec:"userEkBox,omitempty" json:"userEkBox,omitempty"`
 }
 
 type Kex2Provisionee2Interface interface {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -554,23 +554,17 @@ func (d *Service) hourlyChecks() {
 		if err := d.G().LogoutIfRevoked(); err != nil {
 			d.G().Log.Debug("LogoutIfRevoked error: %s", err)
 		}
-		// TODO remove this when we want to release in the wild.
-		if ephemeral.ShouldRun(d.G()) {
-			ekLib := d.G().GetEKLib()
-			ekLib.KeygenIfNeeded(context.Background())
-		}
+		ekLib := d.G().GetEKLib()
+		ekLib.KeygenIfNeeded(context.Background())
 		for {
 			<-ticker.C
 			d.G().Log.Debug("+ hourly check loop")
 			d.G().Log.Debug("| checking tracks on an hour timer")
 			libkb.CheckTracking(d.G())
 
-			// TODO remove this when we want to release in the wild.
-			if ephemeral.ShouldRun(d.G()) {
-				ekLib := d.G().GetEKLib()
-				d.G().Log.Debug("| checking if ephemeral keys need to be created or deleted")
-				ekLib.KeygenIfNeeded(context.Background())
-			}
+			ekLib := d.G().GetEKLib()
+			d.G().Log.Debug("| checking if ephemeral keys need to be created or deleted")
+			ekLib.KeygenIfNeeded(context.Background())
 			d.G().Log.Debug("| checking if current device revoked")
 			if err := d.G().LogoutIfRevoked(); err != nil {
 				d.G().Log.Debug("LogoutIfRevoked error: %s", err)

--- a/protocol/avdl/keybase1/ephemeral.avdl
+++ b/protocol/avdl/keybase1/ephemeral.avdl
@@ -61,6 +61,14 @@ protocol ephemeral {
     UserEkMetadata metadata;
   }
 
+  record UserEkBoxMetadata {
+    string box;
+    @jsonkey("recipient_generation")
+    EkGeneration recipientGeneration;
+    @jsonkey("recipient_device_id")
+    DeviceID recipientDeviceID;
+  }
+
   record UserEk {
     Bytes32 seed;
     UserEkMetadata metadata;
@@ -89,6 +97,14 @@ protocol ephemeral {
     @jsonkey("user_ek_generation")
     EkGeneration userEkGeneration;
     TeamEkMetadata metadata;
+  }
+
+  record TeamEkBoxMetadata {
+    string box;
+    @jsonkey("recipient_generation")
+    EkGeneration recipientGeneration;
+    @jsonkey("recipient_uid")
+    UID recipientUID;
   }
 
   record TeamEk {

--- a/protocol/avdl/keybase1/kex2provisionee2.avdl
+++ b/protocol/avdl/keybase1/kex2provisionee2.avdl
@@ -2,18 +2,22 @@
 @namespace("keybase.1")
 protocol Kex2Provisionee2 {
   import idl "common.avdl";
+  import idl "ephemeral.avdl";
 
   record Hello2Res {
     KID encryptionKey;
     HelloRes sigPayload;
+    KID deviceEkKID;
   }
 
   Hello2Res hello2(UID uid, SessionToken token, CsrfToken csrf, string sigBody);
+
   void didCounterSign2(
     bytes sig,
     string ppsEncrypted,
     // Current generation per-user-secret boxed for the new device
-    union { null, PerUserKeyBox } pukBox
+    union { null, PerUserKeyBox } pukBox,
+    union { null, UserEkBoxed } userEkBox
   );
 
   @lint("ignore")

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2450,7 +2450,7 @@ export type HasServerKeysRes = $ReadOnly<{hasServerKeys: Boolean}>
 
 export type HashMeta = Bytes
 
-export type Hello2Res = $ReadOnly<{encryptionKey: KID, sigPayload: HelloRes}>
+export type Hello2Res = $ReadOnly<{encryptionKey: KID, sigPayload: HelloRes, deviceEkKID: KID}>
 
 export type HelloRes = String
 
@@ -2638,7 +2638,7 @@ export type KbfsMountGetCurrentMountDirRpcParam = ?$ReadOnly<{incomingCallMap?: 
 
 export type KbfsMountSetCurrentMountDirRpcParam = $ReadOnly<{dir: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type Kex2Provisionee2DidCounterSign2RpcParam = $ReadOnly<{sig: Bytes, ppsEncrypted: String, pukBox?: ?PerUserKeyBox, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type Kex2Provisionee2DidCounterSign2RpcParam = $ReadOnly<{sig: Bytes, ppsEncrypted: String, pukBox?: ?PerUserKeyBox, userEkBox?: ?UserEkBoxed, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type Kex2Provisionee2Hello2RpcParam = $ReadOnly<{uid: UID, token: SessionToken, csrf: CsrfToken, sigBody: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
@@ -3675,6 +3675,8 @@ export type TeamDetails = $ReadOnly<{members: TeamMembersDetails, keyGeneration:
 
 export type TeamEk = $ReadOnly<{seed: Bytes32, metadata: TeamEkMetadata}>
 
+export type TeamEkBoxMetadata = $ReadOnly<{box: String, recipientGeneration: EkGeneration, recipientUID: UID}>
+
 export type TeamEkBoxed = $ReadOnly<{box: String, userEkGeneration: EkGeneration, metadata: TeamEkMetadata}>
 
 export type TeamEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation: EkGeneration, ctime: Time}>
@@ -3963,6 +3965,8 @@ export type User = $ReadOnly<{uid: UID, username: String}>
 export type UserCard = $ReadOnly<{following: Int, followers: Int, uid: UID, fullName: String, location: String, bio: String, website: String, twitter: String, youFollowThem: Boolean, theyFollowYou: Boolean, teamShowcase?: ?Array<UserTeamShowcase>}>
 
 export type UserEk = $ReadOnly<{seed: Bytes32, metadata: UserEkMetadata}>
+
+export type UserEkBoxMetadata = $ReadOnly<{box: String, recipientGeneration: EkGeneration, recipientDeviceID: DeviceID}>
 
 export type UserEkBoxed = $ReadOnly<{box: String, deviceEkGeneration: EkGeneration, metadata: UserEkMetadata}>
 

--- a/protocol/json/keybase1/ephemeral.json
+++ b/protocol/json/keybase1/ephemeral.json
@@ -135,6 +135,26 @@
     },
     {
       "type": "record",
+      "name": "UserEkBoxMetadata",
+      "fields": [
+        {
+          "type": "string",
+          "name": "box"
+        },
+        {
+          "type": "EkGeneration",
+          "name": "recipientGeneration",
+          "jsonkey": "recipient_generation"
+        },
+        {
+          "type": "DeviceID",
+          "name": "recipientDeviceID",
+          "jsonkey": "recipient_device_id"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "UserEk",
       "fields": [
         {
@@ -206,6 +226,26 @@
         {
           "type": "TeamEkMetadata",
           "name": "metadata"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "TeamEkBoxMetadata",
+      "fields": [
+        {
+          "type": "string",
+          "name": "box"
+        },
+        {
+          "type": "EkGeneration",
+          "name": "recipientGeneration",
+          "jsonkey": "recipient_generation"
+        },
+        {
+          "type": "UID",
+          "name": "recipientUID",
+          "jsonkey": "recipient_uid"
         }
       ]
     },

--- a/protocol/json/keybase1/kex2provisionee2.json
+++ b/protocol/json/keybase1/kex2provisionee2.json
@@ -4,6 +4,10 @@
     {
       "path": "common.avdl",
       "type": "idl"
+    },
+    {
+      "path": "ephemeral.avdl",
+      "type": "idl"
     }
   ],
   "types": [
@@ -18,6 +22,10 @@
         {
           "type": "HelloRes",
           "name": "sigPayload"
+        },
+        {
+          "type": "KID",
+          "name": "deviceEkKID"
         }
       ]
     },
@@ -79,6 +87,13 @@
           "type": [
             null,
             "PerUserKeyBox"
+          ]
+        },
+        {
+          "name": "userEkBox",
+          "type": [
+            null,
+            "UserEkBoxed"
           ]
         }
       ],

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2450,7 +2450,7 @@ export type HasServerKeysRes = $ReadOnly<{hasServerKeys: Boolean}>
 
 export type HashMeta = Bytes
 
-export type Hello2Res = $ReadOnly<{encryptionKey: KID, sigPayload: HelloRes}>
+export type Hello2Res = $ReadOnly<{encryptionKey: KID, sigPayload: HelloRes, deviceEkKID: KID}>
 
 export type HelloRes = String
 
@@ -2638,7 +2638,7 @@ export type KbfsMountGetCurrentMountDirRpcParam = ?$ReadOnly<{incomingCallMap?: 
 
 export type KbfsMountSetCurrentMountDirRpcParam = $ReadOnly<{dir: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type Kex2Provisionee2DidCounterSign2RpcParam = $ReadOnly<{sig: Bytes, ppsEncrypted: String, pukBox?: ?PerUserKeyBox, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type Kex2Provisionee2DidCounterSign2RpcParam = $ReadOnly<{sig: Bytes, ppsEncrypted: String, pukBox?: ?PerUserKeyBox, userEkBox?: ?UserEkBoxed, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type Kex2Provisionee2Hello2RpcParam = $ReadOnly<{uid: UID, token: SessionToken, csrf: CsrfToken, sigBody: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
@@ -3675,6 +3675,8 @@ export type TeamDetails = $ReadOnly<{members: TeamMembersDetails, keyGeneration:
 
 export type TeamEk = $ReadOnly<{seed: Bytes32, metadata: TeamEkMetadata}>
 
+export type TeamEkBoxMetadata = $ReadOnly<{box: String, recipientGeneration: EkGeneration, recipientUID: UID}>
+
 export type TeamEkBoxed = $ReadOnly<{box: String, userEkGeneration: EkGeneration, metadata: TeamEkMetadata}>
 
 export type TeamEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation: EkGeneration, ctime: Time}>
@@ -3963,6 +3965,8 @@ export type User = $ReadOnly<{uid: UID, username: String}>
 export type UserCard = $ReadOnly<{following: Int, followers: Int, uid: UID, fullName: String, location: String, bio: String, website: String, twitter: String, youFollowThem: Boolean, theyFollowYou: Boolean, teamShowcase?: ?Array<UserTeamShowcase>}>
 
 export type UserEk = $ReadOnly<{seed: Bytes32, metadata: UserEkMetadata}>
+
+export type UserEkBoxMetadata = $ReadOnly<{box: String, recipientGeneration: EkGeneration, recipientDeviceID: DeviceID}>
 
 export type UserEkBoxed = $ReadOnly<{box: String, deviceEkGeneration: EkGeneration, metadata: UserEkMetadata}>
 


### PR DESCRIPTION
WIP -- need to update `key/multi` endpoint to accept the new args.  When a device is provisioned we rebox the current userEK (if any) for the new device so they will have access to teamEKs encrypted with this latest userEK. If we aren't able to rebox, the newly provisioned device will generate a new device/userEK once they're logged in. We might fail reboxing because provisioner/provisionee is on the old version of the protocol, the user has no PUK, or the provisioner has no userEK

@oconnor663 we should review together and see if there are other test cases we want to drag in from engine. 

cc @patrickxb 