### PR TITLE
fix styling on team invites page

### DIFF
--- a/shared/teams/team/invites/index.js
+++ b/shared/teams/team/invites/index.js
@@ -17,7 +17,6 @@ const DividerRow = (index, {key}) => (
       ...globalStyles.flexBoxRow,
       alignItems: 'center',
       flexShrink: 0,
-      height: globalMargins.medium,
       padding: globalMargins.tiny,
       width: '100%',
     }}

--- a/shared/teams/team/invites/invite-row/index.js
+++ b/shared/teams/team/invites/invite-row/index.js
@@ -25,20 +25,37 @@ export const TeamInviteRow = (props: Props) => {
         width: '100%',
       }}
     >
-      <Box style={{...globalStyles.flexBoxRow, flexGrow: 1, alignItems: 'center'}}>
+      <Box
+        style={{
+          ...globalStyles.flexBoxRow,
+          alignItems: 'center',
+          flexGrow: 1,
+          height: '100%',
+        }}
+      >
         <Avatar username={label} size={isMobile ? 48 : 32} />
-        <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.small}}>
-          <Usernames
-            type="BodySemibold"
-            colorFollowing={true}
-            users={[{following, username: label, you: you === label}]}
-          />
-          <Box style={globalStyles.flexBoxRow}>
-            <Text type="BodySmall">{role && typeToLabel[role]}</Text>
+        <Box style={{...globalStyles.flexBoxRow, flexGrow: 1, height: '100%', position: 'relative'}}>
+          <Box
+            style={{
+              ...globalStyles.fillAbsolute,
+              ...globalStyles.flexBoxRow,
+            }}
+          >
+            <Box style={{...globalStyles.flexBoxColumn, flexGrow: 1, marginLeft: globalMargins.small}}>
+              <Usernames
+                type="BodySemibold"
+                colorFollowing={true}
+                inline={true}
+                users={[{following, username: label, you: you === label}]}
+              />
+              <Box style={globalStyles.flexBoxRow}>
+                <Text type="BodySmall">{role && typeToLabel[role]}</Text>
+              </Box>
+            </Box>
           </Box>
         </Box>
       </Box>
-      <Box style={{...globalStyles.flexBoxRow, flexShrink: 1}}>
+      <Box style={{...globalStyles.flexBoxRow, marginLeft: globalMargins.xtiny}}>
         <Button
           small={true}
           label={isMobile ? 'Cancel' : 'Cancel invite'}

--- a/shared/teams/team/subteams/index.js
+++ b/shared/teams/team/subteams/index.js
@@ -53,7 +53,6 @@ const NoSubteams = ({row}) => (
       ...globalStyles.flexBoxRow,
       alignItems: 'center',
       flexShrink: 0,
-      height: globalMargins.medium,
       padding: globalMargins.tiny,
       width: '100%',
     }}


### PR DESCRIPTION
@keybase/react-hackers this fixes the styling on the team invites page

1. Dunno why we're using these explicit heights, that just clips things
2. This makes the names not push the cancel button off screen. We need to do the thing where we have a box that grows to take the empty space but won't push past that thing
