### PR TITLE
Enable seitanv2 by default

### DIFF
--- a/go/client/cmd_team_generate_seitan.go
+++ b/go/client/cmd_team_generate_seitan.go
@@ -83,13 +83,13 @@ func (c *CmdTeamGenerateSeitan) Run() error {
 	labelSms.F = c.FullName
 	labelSms.N = c.Number
 
-	arg := keybase1.TeamCreateSeitanTokenArg{
+	arg := keybase1.TeamCreateSeitanTokenV2Arg{
 		Name:  c.Team,
 		Role:  c.Role,
 		Label: keybase1.NewSeitanKeyLabelWithSms(labelSms),
 	}
 
-	res, err := cli.TeamCreateSeitanToken(context.Background(), arg)
+	res, err := cli.TeamCreateSeitanTokenV2(context.Background(), arg)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (c *CmdTeamGenerateSeitan) GetUsage() libkb.Usage {
 	}
 }
 
-const teamGenerateSeitanDoc = `"keybase team generate-token" allows you to create a one-time use,
+const teamGenerateSeitanDoc = `"keybase generate-invite-token" allows you to create a one-time use,
 expiring, cryptographically secure token that someone can use to join
 a team.
 

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -215,7 +215,7 @@ const generateSMSBody = (teamname: string, seitan: string): string => {
 
 const _inviteToTeamByPhone = function*(action: TeamsGen.InviteToTeamByPhonePayload) {
   const {teamname, role, phoneNumber, fullName = ''} = action.payload
-  const seitan = yield Saga.call(RPCTypes.teamsTeamCreateSeitanTokenRpcPromise, {
+  const seitan = yield Saga.call(RPCTypes.teamsTeamCreateSeitanTokenV2RpcPromise, {
     name: teamname,
     role: (!!role && RPCTypes.teamsTeamRole[role]) || 0,
     label: {t: 1, sms: ({f: fullName || '', n: phoneNumber}: RPCTypes.SeitanKeyLabelSms)},


### PR DESCRIPTION
Enable seitan v2 invitations by default on CLI and the GUI. If we're no longer creating any v1 invites, should we cleanup some of the tests (slow systests)? 

cc @keybase/react-hackers @zapu 