### PR TITLE
Make sigchain v2 default for cryptocurrency, track, untrack, and prove links

### DIFF
--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -469,10 +469,7 @@ func SignJSON(jw *jsonw.Wrapper, key GenericKey) (out string, id keybase1.SigID,
 }
 
 func GetDefaultSigVersion(g *GlobalContext) SigVersion {
-	if g.Env.GetFeatureFlags().Admin() {
-		return KeybaseSignatureV2
-	}
-	return KeybaseSignatureV1
+	return KeybaseSignatureV2
 }
 
 func MakeSig(

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -37,12 +37,12 @@ type KeySection struct {
 	PerUserKeyGeneration keybase1.PerUserKeyGeneration
 }
 
-func linkEntropy() (*jsonw.Wrapper, error) {
+func LinkEntropy() (string, error) {
 	entropyBytes, err := RandBytes(18)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate entropy bytes: %v", err)
+		return "", fmt.Errorf("failed to generate entropy bytes: %v", err)
 	}
-	return jsonw.NewString(base64.StdEncoding.EncodeToString(entropyBytes)), nil
+	return base64.StdEncoding.EncodeToString(entropyBytes), nil
 }
 
 func (arg KeySection) ToJSON() (*jsonw.Wrapper, error) {
@@ -176,11 +176,11 @@ func (u *User) ToTrackingStatement(w *jsonw.Wrapper, outcome *IdentifyOutcome) (
 		return err
 	}
 
-	entropy, err := linkEntropy()
+	entropy, err := LinkEntropy()
 	if err != nil {
 		return err
 	}
-	track.SetKey("entropy", entropy)
+	track.SetKey("entropy", jsonw.NewString(entropy))
 
 	w.SetKey("track", track)
 	return err
@@ -197,11 +197,11 @@ func (u *User) ToUntrackingStatement(w *jsonw.Wrapper) (err error) {
 	untrack.SetKey("basics", u.ToUntrackingStatementBasics())
 	untrack.SetKey("id", UIDWrapper(u.GetUID()))
 
-	entropy, err := linkEntropy()
+	entropy, err := LinkEntropy()
 	if err != nil {
 		return err
 	}
-	untrack.SetKey("entropy", entropy)
+	untrack.SetKey("entropy", jsonw.NewString(entropy))
 
 	w.SetKey("untrack", untrack)
 	return err
@@ -475,11 +475,11 @@ func (u *User) ServiceProof(signingKey GenericKey, typ ServiceType, remotename s
 		return nil, err
 	}
 	service := typ.ToServiceJSON(remotename)
-	entropy, err := linkEntropy()
+	entropy, err := LinkEntropy()
 	if err != nil {
 		return nil, err
 	}
-	service.SetKey("entropy", entropy)
+	service.SetKey("entropy", jsonw.NewString(entropy))
 
 	ret.AtKey("body").SetKey("service", service)
 	return ret, err
@@ -621,11 +621,11 @@ func (u *User) CryptocurrencySig(key GenericKey, address string, typ Cryptocurre
 	currencySection := jsonw.NewDictionary()
 	currencySection.SetKey("address", jsonw.NewString(address))
 	currencySection.SetKey("type", jsonw.NewString(typ.String()))
-	entropy, err := linkEntropy()
+	entropy, err := LinkEntropy()
 	if err != nil {
 		return nil, err
 	}
-	currencySection.SetKey("entropy", entropy)
+	currencySection.SetKey("entropy", jsonw.NewString(entropy))
 	body.SetKey("cryptocurrency", currencySection)
 	if len(sigToRevoke) > 0 {
 		revokeSection := jsonw.NewDictionary()
@@ -804,11 +804,11 @@ func WalletProof(me *User, walletAddress keybase1.StellarAccountID,
 
 	// Inner links can be hidden. To prevent an attacker from figuring out the
 	// contents from the hash of the inner link, add 18 random bytes.
-	entropy, err := linkEntropy()
+	entropy, err := LinkEntropy()
 	if err != nil {
 		return nil, err
 	}
-	walletSection.SetKey("entropy", entropy)
+	walletSection.SetKey("entropy", jsonw.NewString(entropy))
 
 	walletKeySection := jsonw.NewDictionary()
 	walletKeySection.SetKey("kid", jsonw.NewString(walletKID.String()))

--- a/go/teams/sig.go
+++ b/go/teams/sig.go
@@ -7,7 +7,6 @@
 package teams
 
 import (
-	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -234,11 +233,11 @@ func ChangeSig(me *libkb.User, prev libkb.LinkID, seqno keybase1.Seqno, key libk
 }
 
 func makeSCTeamEntropy() (SCTeamEntropy, error) {
-	rb, err := libkb.RandBytes(18)
+	entropy, err := libkb.LinkEntropy()
 	if err != nil {
 		return SCTeamEntropy(""), err
 	}
-	return SCTeamEntropy(base64.StdEncoding.EncodeToString(rb)), nil
+	return SCTeamEntropy(entropy), nil
 }
 
 func seqTypeForTeamPublicness(public bool) keybase1.SeqType {


### PR DESCRIPTION
```
$ git grep GetDefaultSigVersion | grep -v test
engine/cryptocurrency.go:21:            tmp := keybase1.SigVersion(libkb.GetDefaultSigVersion(g))
engine/prove.go:37:             tmp := keybase1.SigVersion(libkb.GetDefaultSigVersion(g))
engine/track_token.go:33:               tmp := keybase1.SigVersion(libkb.GetDefaultSigVersion(g))
engine/untrack.go:27:           arg.SigVersion = libkb.GetDefaultSigVersion(g)
libkb/kbsig.go:470:func GetDefaultSigVersion(g *GlobalContext) SigVersion {
```