### PR TITLE
Retention policy hotfix

### DIFF
--- a/shared/teams/team/settings/retention/warning/index.js
+++ b/shared/teams/team/settings/retention/warning/index.js
@@ -36,7 +36,7 @@ const Wrapper = ({children, onBack}) =>
 const RetentionWarning = (props: Props) => {
   const policyString = daysToLabel(props.days)
   return (
-    <Wrapper onBack={props.onBack}>
+    <Wrapper onBack={props.onCancel}>
       <Box style={containerStyle}>
         <Icon type={iconType} style={iconStyle} />
         <Text type="Header" style={headerStyle}>


### PR DESCRIPTION
This fixes a bug where you could exit the retention warning in a way such that the info-panel dropdown wouldn't be reset to it's initial value. ~It also makes some minor wording changes to the warning dialog~. (moved to next PR) r? @keybase/react-hackers 
