### PR TITLE
Add retention to the ad-hoc info panel

### DIFF
--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -97,9 +97,9 @@ const getDividerStyle = (row: DividerRow) => ({
 type RetentionRow = {
   type: 'retention',
   key: 'retention',
-  teamname: string,
-  isTeamWide: boolean,
-  isSmallTeam: boolean,
+  teamname?: string,
+  isTeamWide?: boolean,
+  isSmallTeam?: boolean,
 }
 
 const retentionStyles = {
@@ -414,6 +414,7 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
                 conversationIDKey: props.selectedConversationIDKey,
                 teamname: props.teamname || '',
                 isTeamWide: props.smallTeam,
+                isTeam: true,
                 isSmallTeam: props.smallTeam,
               },
             ]
@@ -506,6 +507,7 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
                   conversationIDKey: props.selectedConversationIDKey,
                   teamname: props.teamname || '',
                   isTeamWide: props.smallTeam,
+                  isTeam: true,
                   isSmallTeam: props.smallTeam,
                 },
               ]
@@ -578,6 +580,18 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
           type: 'notifications',
           key: 'notifications',
         },
+        {
+          type: 'divider',
+          key: nextKey(),
+          marginBottom: 0,
+        },
+        {
+          type: 'retention',
+          key: 'retention',
+          conversationIDKey: props.selectedConversationIDKey,
+          isTeam: false,
+        },
+
         {
           type: 'divider',
           key: nextKey(),

--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -209,15 +209,11 @@ export const inboxUIItemToConversationMeta = (i: RPCChatTypes.InboxUIItem) => {
     notificationsMobile,
   } = parseNotificationSettings(i.notifications)
 
-  let retentionPolicy
-  if (isTeam) {
-    // default for team channels is 'inherit'
-    retentionPolicy = i.convRetention
-      ? serviceRetentionPolicyToRetentionPolicy(i.convRetention)
-      : makeRetentionPolicy({type: 'inherit'})
-  } else {
-    // default for ad-hoc is 'retain'
-    retentionPolicy = makeRetentionPolicy()
+  // default inherit for teams, retain for ad-hoc
+  let retentionPolicy = isTeam ? makeRetentionPolicy({type: 'inherit'}) : makeRetentionPolicy()
+  if (i.convRetention) {
+    // it has been set for this conversation
+    retentionPolicy = serviceRetentionPolicyToRetentionPolicy(i.convRetention)
   }
 
   return makeConversationMeta({

--- a/shared/teams/team/settings/container.js
+++ b/shared/teams/team/settings/container.js
@@ -40,7 +40,11 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   _saveRetentionPolicy: (teamname: Types.Teamname, policy: Types.RetentionPolicy) =>
     dispatch(TeamsGen.createSetTeamRetentionPolicy({teamname, policy})),
   _showRetentionWarning: (days: number, onConfirm: () => void) =>
-    dispatch(navigateAppend([{selected: 'retentionWarning', props: {days, onConfirm}}])),
+    dispatch(
+      navigateAppend([
+        {selected: 'retentionWarning', props: {days, onConfirm, isTeamWide: true, isTeam: true}},
+      ])
+    ),
   setOpenTeamRole: (newOpenTeamRole: Types.TeamRoleType, setNewOpenTeamRole: Types.TeamRoleType => void) => {
     dispatch(
       navigateAppend([

--- a/shared/teams/team/settings/retention/container.js
+++ b/shared/teams/team/settings/retention/container.js
@@ -19,7 +19,7 @@ import type {ConversationIDKey} from '../../../../constants/types/chat2'
 import RetentionPicker from './'
 
 // TODO make this typing tighter to guarantee the team properties if `isTeam` is true
-// and we should also derive some of these props (isSmallTeam, )
+// and we should also derive some of these props (isSmallTeam, more if possible)
 export type OwnProps = {
   conversationIDKey?: ConversationIDKey,
   teamname?: string,
@@ -31,13 +31,14 @@ export type OwnProps = {
 
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   const isTeam = !!ownProps.teamname
-  const teamPolicy = isTeam && getTeamRetentionPolicy(state, ownProps.teamname)
+  const teamPolicy = ownProps.teamname && getTeamRetentionPolicy(state, ownProps.teamname)
   // we need to show a spinner, but only if it's a team
   const loading = isTeam && !teamPolicy
   if (!isTeam && !ownProps.conversationIDKey) {
     throw new Error('RetentionPicker got no conversationIDKey for ad-hoc conversation!')
   }
-  const policy = getConversationRetentionPolicy(state, ownProps.conversationIDKey)
+  const policy =
+    !!ownProps.conversationIDKey && getConversationRetentionPolicy(state, ownProps.conversationIDKey)
   if (!ownProps.isTeamWide && !policy) {
     throw new Error('Conv retpolicy not present in metaMap')
   }
@@ -83,7 +84,7 @@ const mapDispatchToProps = (
   },
   setRetentionPolicy: (policy: RetentionPolicy) => {
     if (isTeamWide) {
-      dispatch(TeamsGen.createSetTeamRetentionPolicy({policy, teamname}))
+      teamname && dispatch(TeamsGen.createSetTeamRetentionPolicy({policy, teamname}))
     } else {
       if (!conversationIDKey) {
         throw new Error('Tried to set conv retention policy with no ConversationIDKey')

--- a/shared/teams/team/settings/retention/container.js
+++ b/shared/teams/team/settings/retention/container.js
@@ -69,7 +69,7 @@ const mapDispatchToProps = (
         [
           {
             selected: 'retentionWarning',
-            props: {days, onCancel, onConfirm},
+            props: {days, onCancel, onConfirm, isTeamWide},
           },
         ],
         parentPath

--- a/shared/teams/team/settings/retention/index.js
+++ b/shared/teams/team/settings/retention/index.js
@@ -21,7 +21,8 @@ export type Props = {
   policy: RetentionPolicy,
   teamPolicy?: RetentionPolicy,
   loading: boolean,
-  isTeamWide: boolean,
+  isTeam: boolean,
+  isTeamWide?: boolean,
   isSmallTeam?: boolean,
   type: 'simple' | 'auto',
   setRetentionPolicy: (policy: RetentionPolicy) => void,
@@ -76,7 +77,8 @@ class RetentionPicker extends React.Component<Props, State> {
   }
 
   _makeItems = () => {
-    if (this.props.isTeamWide) {
+    if (this.props.isTeamWide || !this.props.isTeam) {
+      // same items for team-wide policies and ad-hoc conversations
       const items = teamRetentionPolicies.map(policy => {
         if (policy.type === 'expire') {
           return {title: daysToLabel(policy.days), onClick: () => this._onSelect(policy)}

--- a/shared/teams/team/settings/retention/index.stories.js
+++ b/shared/teams/team/settings/retention/index.stories.js
@@ -39,6 +39,7 @@ const load = () => {
       <RetentionPicker
         loading={false}
         isTeamWide={false}
+        isTeam={true}
         policy={policyRetain}
         teamPolicy={policy30Days}
         type="simple"
@@ -52,6 +53,7 @@ const load = () => {
       <RetentionPicker
         loading={false}
         isTeamWide={false}
+        isTeam={true}
         policy={policyInherit}
         teamPolicy={policy30Days}
         type="simple"
@@ -62,6 +64,7 @@ const load = () => {
       <RetentionPicker
         loading={false}
         isTeamWide={false}
+        isTeam={true}
         policy={policyInherit}
         teamPolicy={policy30Days}
         type="auto"

--- a/shared/teams/team/settings/retention/index.stories.js
+++ b/shared/teams/team/settings/retention/index.stories.js
@@ -47,7 +47,14 @@ const load = () => {
       />
     ))
     .add('Team-wide', () => (
-      <RetentionPicker loading={false} isTeamWide={true} policy={policy30Days} type="simple" {...actions} />
+      <RetentionPicker
+        loading={false}
+        isTeamWide={true}
+        isTeam={true}
+        policy={policy30Days}
+        type="simple"
+        {...actions}
+      />
     ))
     .add('Channel inheriting from team', () => (
       <RetentionPicker

--- a/shared/teams/team/settings/retention/warning/container.js
+++ b/shared/teams/team/settings/retention/warning/container.js
@@ -5,6 +5,9 @@ import RetentionWarning from '.'
 const mapStateToProps = (state: TypedState, {routeProps}) => {
   return {
     days: routeProps.get('days'),
+    isTeam: routeProps.get('isTeam'),
+    isTeamWide: routeProps.get('isTeamWide'),
+    isSmallTeam: routeProps.get('isSmallTeam'),
   }
 }
 

--- a/shared/teams/team/settings/retention/warning/index.js
+++ b/shared/teams/team/settings/retention/warning/index.js
@@ -17,7 +17,8 @@ import {globalMargins, globalStyles, isMobile, platformStyles} from '../../../..
 type Props = {
   days: number,
   enabled: boolean,
-  isBigTeam: boolean,
+  isBigTeam: boolean, // TODO DESKTOP-6376 use this in conjunction with isTeamWide to decide on wording
+  isTeamWide: boolean,
   setEnabled: boolean => void,
   onConfirm: () => void,
   onCancel: () => void,
@@ -43,9 +44,13 @@ const RetentionWarning = (props: Props) => {
           Destroy chat messages after {policyString}?
         </Text>
         <Text type="Body" style={bodyStyle}>
-          You are about to set the message deletion policy in this team's chats to{' '}
-          <Text type="BodySemibold">{policyString}.</Text> This will affect all the team's channels, except
-          the ones you've set manually.
+          You are about to set the message deletion policy in this {props.isTeamWide ? "team's" : "channel's"}{' '}
+          chats to <Text type="BodySemibold">{policyString}.</Text>{' '}
+          {props.isTeamWide && (
+            <Text type="Body">
+              This will affect all the team's channels, except the ones you've set manually.
+            </Text>
+          )}
         </Text>
         <Checkbox
           checked={props.enabled}
@@ -56,7 +61,9 @@ const RetentionWarning = (props: Props) => {
               <Text type="Body">
                 I understand that messages older than {policyString} will be deleted for everyone.
               </Text>
-              <Text type="BodySmall">Channels you've set manually will not be affected.</Text>
+              {props.isTeamWide && (
+                <Text type="BodySmall">Channels you've set manually will not be affected.</Text>
+              )}
             </Box>
           }
         />

--- a/shared/teams/team/settings/retention/warning/index.js
+++ b/shared/teams/team/settings/retention/warning/index.js
@@ -17,8 +17,9 @@ import {globalMargins, globalStyles, isMobile, platformStyles} from '../../../..
 type Props = {
   days: number,
   enabled: boolean,
-  isBigTeam: boolean, // TODO DESKTOP-6376 use this in conjunction with isTeamWide to decide on wording
+  isSmallTeam: boolean, // TODO DESKTOP-6376 use this in conjunction with isTeamWide to decide on wording
   isTeamWide: boolean,
+  isTeam: boolean,
   setEnabled: boolean => void,
   onConfirm: () => void,
   onCancel: () => void,
@@ -36,6 +37,14 @@ const Wrapper = ({children, onBack}) =>
 
 const RetentionWarning = (props: Props) => {
   const policyString = daysToLabel(props.days)
+  let convType = "team's channels"
+  if (!props.isTeam) {
+    convType = 'conversation'
+  } else if (!props.isTeamWide) {
+    convType = 'channel'
+  } else if (props.isTeam) {
+    convType = 'team'
+  }
   return (
     <Wrapper onBack={props.onCancel}>
       <Box style={containerStyle}>
@@ -44,13 +53,14 @@ const RetentionWarning = (props: Props) => {
           Destroy chat messages after {policyString}?
         </Text>
         <Text type="Body" style={bodyStyle}>
-          You are about to set the message deletion policy in this {props.isTeamWide ? "team's" : "channel's"}{' '}
-          chats to <Text type="BodySemibold">{policyString}.</Text>{' '}
-          {props.isTeamWide && (
-            <Text type="Body">
-              This will affect all the team's channels, except the ones you've set manually.
-            </Text>
-          )}
+          You are about to set the message deletion policy in this {convType} to{' '}
+          <Text type="BodySemibold">{policyString}.</Text>{' '}
+          {props.isTeamWide &&
+            !props.isSmallTeam && (
+              <Text type="Body">
+                This will affect all the team's channels, except the ones you've set manually.
+              </Text>
+            )}
         </Text>
         <Checkbox
           checked={props.enabled}
@@ -61,9 +71,10 @@ const RetentionWarning = (props: Props) => {
               <Text type="Body">
                 I understand that messages older than {policyString} will be deleted for everyone.
               </Text>
-              {props.isTeamWide && (
-                <Text type="BodySmall">Channels you've set manually will not be affected.</Text>
-              )}
+              {props.isTeamWide &&
+                !props.isSmallTeam && (
+                  <Text type="BodySmall">Channels you've set manually will not be affected.</Text>
+                )}
             </Box>
           }
         />

--- a/shared/teams/team/settings/retention/warning/index.js
+++ b/shared/teams/team/settings/retention/warning/index.js
@@ -36,7 +36,7 @@ const Wrapper = ({children, onBack}) =>
 const RetentionWarning = (props: Props) => {
   const policyString = daysToLabel(props.days)
   return (
-    <Wrapper onBack={props.onBack}>
+    <Wrapper onBack={props.onCancel}>
       <Box style={containerStyle}>
         <Icon type={iconType} style={iconStyle} />
         <Text type="Header" style={headerStyle}>


### PR DESCRIPTION
`retention/container` is a bit messier than I'd like because of the new optional props, I can take a pass at cleaning it up soon. Thought I'd get this out there ASAP just in case.
r? @keybase/react-hackers 