### PR TITLE
reload upgrade team on anything but offline error

### DIFF
--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -375,7 +375,7 @@ func LoadTeam(ctx context.Context, g *libkb.GlobalContext, tlfID chat1.TLFID, tl
 			return nil
 		}
 		if err = loadAttempt(false); err != nil {
-			if _, ok := err.(ImpteamUpgradeBadteamError); ok {
+			if IsOfflineError(err) != OfflineErrorKindOnline {
 				// try again on bad team, might have had an old team cached
 				g.Log.CDebugf(ctx, "++Chat: LoadTeam: trying again: %s", err)
 				if err = loadAttempt(true); err != nil {


### PR DESCRIPTION
These teams can fail to load for a variety of reasons, just check for a non-network error and reload in that case. 