### PR TITLE
Fix can delete history on adhoc/imp teams

### DIFF
--- a/shared/chat/conversation/messages/message-popup/attachment/container.js
+++ b/shared/chat/conversation/messages/message-popup/attachment/container.js
@@ -19,7 +19,8 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   const message = ownProps.message
   const meta = Constants.getMeta(state, message.conversationIDKey)
   const yourOperations = getCanPerform(state, meta.teamname)
-  const _canDeleteHistory = flags.deleteChatHistory && yourOperations && yourOperations.deleteChatHistory
+  const _canDeleteHistory =
+    meta.teamType !== 'big' || (flags.deleteChatHistory && yourOperations && yourOperations.deleteChatHistory)
   return {
     _canDeleteHistory,
     _you: state.config.username,

--- a/shared/chat/conversation/messages/message-popup/text/container.js
+++ b/shared/chat/conversation/messages/message-popup/text/container.js
@@ -18,7 +18,8 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   const message = ownProps.message
   const meta = Constants.getMeta(state, message.conversationIDKey)
   const yourOperations = getCanPerform(state, meta.teamname)
-  const _canDeleteHistory = flags.deleteChatHistory && yourOperations && yourOperations.deleteChatHistory
+  const _canDeleteHistory =
+    meta.teamType !== 'big' || (flags.deleteChatHistory && yourOperations && yourOperations.deleteChatHistory)
   return {
     _canDeleteHistory,
     _you: state.config.username,


### PR DESCRIPTION
@keybase/react-hackers CC @mmaxim @zapu 

Delete chat history was only working on big teams, because it was only checking canUserPerform, which is undefined for imp teams and kbfs chats.