### PR TITLE
improve imp team handling

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -476,24 +476,12 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv types.U
 			var names []string
 			tlfID := msg.Valid().ClientHeader.Conv.Tlfid
 			switch conv.GetMembersType() {
-			case chat1.ConversationMembersType_KBFS:
+			case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAMNATIVE,
+				chat1.ConversationMembersType_IMPTEAMUPGRADE:
 				names = utils.SplitTLFName(tlfName)
 			case chat1.ConversationMembersType_TEAM:
 				// early out of team convs
 				return nil
-			case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE:
-				s.Debug(ctx, "identifyTLF: implicit team TLF, looking up display name for %s", tlfName)
-				tlfID := msg.Valid().ClientHeader.Conv.Tlfid
-				team, err := LoadTeam(ctx, s.G().ExternalG(), tlfID, tlfName, conv.GetMembersType(),
-					msg.Valid().ClientHeader.TlfPublic, nil)
-				if err != nil {
-					return err
-				}
-				display, err := team.ImplicitTeamDisplayName(ctx)
-				if err != nil {
-					return err
-				}
-				names = utils.SplitTLFName(display.String())
 			}
 
 			s.Debug(ctx, "identifyTLF: identifying from msg ID: %d names: %v convID: %s",

--- a/go/chat/upgrade_test.go
+++ b/go/chat/upgrade_test.go
@@ -116,7 +116,8 @@ func TestChatKBFSUpgradeBadteam(t *testing.T) {
 	}, keybase1.TeamApplication_CHAT))
 
 	// Should fail because the name of the imp team doesn't match the conversation name
-	_, err = LoadTeam(context.TODO(), tc0.Context().ExternalG(), chat1.TLFID(tlfID.ToBytes()), conv.TlfName,
+	loader := NewTeamLoader(tc0.Context().ExternalG())
+	_, err = loader.loadTeam(context.TODO(), chat1.TLFID(tlfID.ToBytes()), conv.TlfName,
 		chat1.ConversationMembersType_IMPTEAMUPGRADE, false, nil)
 	require.Error(t, err)
 	require.IsType(t, ImpteamUpgradeBadteamError{}, err)


### PR DESCRIPTION
Patch does the following:

1.) Don't load team when loading a conv hit from cache for imp team chats, also leftover code from when the TLF name was the internal name.
2.) Add more debugging to the `loadTeam` functionality. 
3.) Fix botched error case handling for upgraded teams.