### PR TITLE
Display retention policies to non-admins

### DIFF
--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -403,22 +403,6 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
       }
       if (props.smallTeam) {
         // Small team.
-        const retentionRows = props.canSetRetention
-          ? [
-              {
-                type: 'divider',
-                key: nextKey(),
-                marginBottom: 0,
-              },
-              {
-                type: 'retention',
-                key: 'retention',
-                teamname: props.teamname || '',
-                entityType: 'small team',
-              },
-            ]
-          : []
-
         headerRows = [
           {type: 'spacer', key: nextKey(), height: globalMargins.small},
           smallTeamHeaderRow,
@@ -432,7 +416,17 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
             type: 'notifications',
             key: 'notifications',
           },
-          ...retentionRows,
+          {
+            type: 'divider',
+            key: nextKey(),
+            marginBottom: 0,
+          },
+          {
+            type: 'retention',
+            key: 'retention',
+            teamname: props.teamname || '',
+            entityType: 'small team',
+          },
           {
             type: 'divider',
             key: nextKey(),
@@ -493,22 +487,6 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
           ]
         } else {
           // Big team, no preview.
-          const retentionRows = props.canSetRetention
-            ? [
-                {
-                  type: 'divider',
-                  key: nextKey(),
-                  marginBottom: 0,
-                },
-                {
-                  type: 'retention',
-                  key: 'retention',
-                  entityType: 'channel',
-                  teamname: props.teamname || '',
-                },
-              ]
-            : []
-
           headerRows = [
             headerRow,
             {
@@ -540,7 +518,17 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
               type: 'notifications',
               key: 'notifications',
             },
-            ...retentionRows,
+            {
+              type: 'divider',
+              key: nextKey(),
+              marginBottom: 0,
+            },
+            {
+              type: 'retention',
+              key: 'retention',
+              entityType: 'channel',
+              teamname: props.teamname || '',
+            },
             {
               type: 'divider',
               key: nextKey(),

--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -50974,6 +50974,494 @@ exports[`Storyshots Teams/Retention Channel inheriting 1`] = `
 </div>
 `;
 
+exports[`Storyshots Teams/Retention Non-admin channel 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.40);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 600;
+}
+
+.glamor-1,
+[data-glamor-1] {
+  color: rgba(0, 0, 0, 0.40);
+}
+
+.glamor-2,
+[data-glamor-2] {
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.40);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 400;
+}
+
+<div
+  style={
+    Object {
+      "flex": 1,
+      "overflow": "auto",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "height": "100%",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "flexDirection": "column",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": "row",
+              "marginBottom": 2,
+              "marginTop": 16,
+            }
+          }
+        >
+          <span
+            className="glamor-0"
+            onClick={undefined}
+            title={undefined}
+          >
+            Message deletion
+          </span>
+          <div>
+            <span
+              className="glamor-1"
+              onClick={null}
+              onMouseEnter={undefined}
+              onMouseLeave={undefined}
+              style={
+                Object {
+                  "WebkitFontSmoothing": "antialiased",
+                  "fontFamily": "kb",
+                  "fontSize": 16,
+                  "fontStyle": "normal",
+                  "fontVariant": "normal",
+                  "fontWeight": "normal",
+                  "lineHeight": 1,
+                  "marginLeft": 4,
+                  "speak": "none",
+                  "textTransform": "none",
+                  "userSelect": "none",
+                }
+              }
+            >
+              
+            </span>
+          </div>
+        </div>
+        <span
+          className="glamor-2"
+          onClick={undefined}
+          title={undefined}
+        >
+          Admins have set this channel to auto-delete messages after [mocked]
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Teams/Retention Non-admin channel inherit 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.40);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 600;
+}
+
+.glamor-1,
+[data-glamor-1] {
+  color: rgba(0, 0, 0, 0.40);
+}
+
+.glamor-2,
+[data-glamor-2] {
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.40);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 400;
+}
+
+<div
+  style={
+    Object {
+      "flex": 1,
+      "overflow": "auto",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "height": "100%",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "flexDirection": "column",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": "row",
+              "marginBottom": 2,
+              "marginTop": 16,
+            }
+          }
+        >
+          <span
+            className="glamor-0"
+            onClick={undefined}
+            title={undefined}
+          >
+            Message deletion
+          </span>
+          <div>
+            <span
+              className="glamor-1"
+              onClick={null}
+              onMouseEnter={undefined}
+              onMouseLeave={undefined}
+              style={
+                Object {
+                  "WebkitFontSmoothing": "antialiased",
+                  "fontFamily": "kb",
+                  "fontSize": 16,
+                  "fontStyle": "normal",
+                  "fontVariant": "normal",
+                  "fontWeight": "normal",
+                  "lineHeight": 1,
+                  "marginLeft": 4,
+                  "speak": "none",
+                  "textTransform": "none",
+                  "userSelect": "none",
+                }
+              }
+            >
+              
+            </span>
+          </div>
+        </div>
+        <span
+          className="glamor-2"
+          onClick={undefined}
+          title={undefined}
+        >
+          Messages in this channel will expire after [mocked], which is the team default.
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Teams/Retention Non-admin small team 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.40);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 600;
+}
+
+.glamor-1,
+[data-glamor-1] {
+  color: rgba(0, 0, 0, 0.40);
+}
+
+.glamor-2,
+[data-glamor-2] {
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.40);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 400;
+}
+
+<div
+  style={
+    Object {
+      "flex": 1,
+      "overflow": "auto",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "height": "100%",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "flexDirection": "column",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": "row",
+              "marginBottom": 2,
+              "marginTop": 16,
+            }
+          }
+        >
+          <span
+            className="glamor-0"
+            onClick={undefined}
+            title={undefined}
+          >
+            Message deletion
+          </span>
+          <div>
+            <span
+              className="glamor-1"
+              onClick={null}
+              onMouseEnter={undefined}
+              onMouseLeave={undefined}
+              style={
+                Object {
+                  "WebkitFontSmoothing": "antialiased",
+                  "fontFamily": "kb",
+                  "fontSize": 16,
+                  "fontStyle": "normal",
+                  "fontVariant": "normal",
+                  "fontWeight": "normal",
+                  "lineHeight": 1,
+                  "marginLeft": 4,
+                  "speak": "none",
+                  "textTransform": "none",
+                  "userSelect": "none",
+                }
+              }
+            >
+              
+            </span>
+          </div>
+        </div>
+        <span
+          className="glamor-2"
+          onClick={undefined}
+          title={undefined}
+        >
+          Admins have set this chat to auto-delete messages after [mocked]
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Teams/Retention Non-admin team-wide 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.40);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 600;
+}
+
+.glamor-1,
+[data-glamor-1] {
+  color: rgba(0, 0, 0, 0.40);
+}
+
+.glamor-2,
+[data-glamor-2] {
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.40);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 400;
+}
+
+<div
+  style={
+    Object {
+      "flex": 1,
+      "overflow": "auto",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "height": "100%",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "display": "flex",
+            "flexDirection": "column",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": "row",
+              "marginBottom": 2,
+              "marginTop": 16,
+            }
+          }
+        >
+          <span
+            className="glamor-0"
+            onClick={undefined}
+            title={undefined}
+          >
+            Message deletion
+          </span>
+          <div>
+            <span
+              className="glamor-1"
+              onClick={null}
+              onMouseEnter={undefined}
+              onMouseLeave={undefined}
+              style={
+                Object {
+                  "WebkitFontSmoothing": "antialiased",
+                  "fontFamily": "kb",
+                  "fontSize": 16,
+                  "fontStyle": "normal",
+                  "fontVariant": "normal",
+                  "fontWeight": "normal",
+                  "lineHeight": 1,
+                  "marginLeft": 4,
+                  "speak": "none",
+                  "textTransform": "none",
+                  "userSelect": "none",
+                }
+              }
+            >
+              
+            </span>
+          </div>
+        </div>
+        <span
+          className="glamor-2"
+          onClick={undefined}
+          title={undefined}
+        >
+          Admins have set this team to auto-delete messages after [mocked]
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Teams/Retention Small team 1`] = `
 .glamor-0,
 [data-glamor-0] {

--- a/shared/teams/team/settings/index.js
+++ b/shared/teams/team/settings/index.js
@@ -274,7 +274,7 @@ export class Settings extends React.Component<Props, State> {
             <IgnoreAccessRequests {...this.props} {...this.state} setBoolSettings={this.setBoolSettings} />
           </React.Fragment>
         )}
-        {this.props.yourOperations.setRetentionPolicy && (
+        {this.props.yourOperations.chat && (
           <RetentionPicker
             type="simple"
             onSelect={this._onSelectRetentionPolicy}

--- a/shared/teams/team/settings/retention/container.js
+++ b/shared/teams/team/settings/retention/container.js
@@ -117,6 +117,7 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
     _path,
     _permissionsLoaded,
     canSetPolicy,
+    entityType, // used only to display policy to non-admins
     loading,
     policy,
     showInheritOption,

--- a/shared/teams/team/settings/retention/index.js
+++ b/shared/teams/team/settings/retention/index.js
@@ -16,6 +16,7 @@ import {retentionPolicies, baseRetentionPolicies} from '../../../../constants/te
 import {daysToLabel} from '../../../../util/timestamp'
 
 export type Props = {
+  canSetPolicy: boolean,
   containerStyle?: StylesCrossPlatform,
   dropdownStyle?: StylesCrossPlatform,
   policy: RetentionPolicy,

--- a/shared/teams/team/settings/retention/index.js
+++ b/shared/teams/team/settings/retention/index.js
@@ -14,6 +14,7 @@ import {type MenuItem} from '../../../../common-adapters/popup-menu'
 import {type RetentionPolicy} from '../../../../constants/types/teams'
 import {retentionPolicies, baseRetentionPolicies} from '../../../../constants/teams'
 import {daysToLabel} from '../../../../util/timestamp'
+import {type RetentionEntityType} from './container'
 
 export type Props = {
   canSetPolicy: boolean,
@@ -158,14 +159,45 @@ class RetentionPicker extends React.Component<Props, State> {
   }
 }
 
-const headingStyle = platformStyles({
-  common: {
-    ...globalStyles.flexBoxRow,
-    alignItems: 'center',
-    marginTop: globalMargins.small,
-    marginBottom: globalMargins.tiny,
-  },
-})
+const RetentionDisplay = (props: Props & {entityType: RetentionEntityType}) => {
+  let convType = ''
+  switch (props.entityType) {
+    case 'big team':
+      convType = 'team'
+      break
+    case 'small team':
+      convType = 'chat'
+      break
+    case 'channel':
+      convType = 'channel'
+      break
+    case 'chat':
+    default:
+      throw new Error(`Bad entityType encountered in RetentionDisplay: ${props.entityType}`)
+  }
+  const text = policyToExplanation(convType, props.policy, props.teamPolicy)
+  return (
+    <Box style={collapseStyles([globalStyles.flexBoxColumn, props.containerStyle])}>
+      <Box style={displayHeadingStyle}>
+        <Text type="BodySmallSemibold">Message deletion</Text>
+        <Icon type="iconfont-timer" style={{fontSize: 16, marginLeft: globalMargins.xtiny}} />
+      </Box>
+      <Text type="BodySmall">{text}</Text>
+    </Box>
+  )
+}
+
+const headingStyle = {
+  ...globalStyles.flexBoxRow,
+  alignItems: 'center',
+  marginTop: globalMargins.small,
+  marginBottom: globalMargins.tiny,
+}
+
+const displayHeadingStyle = {
+  ...headingStyle,
+  marginBottom: 2,
+}
 
 const dropdownStyle = platformStyles({
   common: {
@@ -183,21 +215,17 @@ const dropdownStyle = platformStyles({
   },
 })
 
-const labelStyle = platformStyles({
-  common: {
-    ...globalStyles.flexBoxCenter,
-    minHeight: isMobile ? 40 : 32,
-    width: '100%',
-  },
-})
+const labelStyle = {
+  ...globalStyles.flexBoxCenter,
+  minHeight: isMobile ? 40 : 32,
+  width: '100%',
+}
 
-const progressIndicatorStyle = platformStyles({
-  common: {
-    width: 30,
-    height: 30,
-    marginTop: globalMargins.small,
-  },
-})
+const progressIndicatorStyle = {
+  width: 30,
+  height: 30,
+  marginTop: globalMargins.small,
+}
 
 // Utilities for transforming retention policies <-> labels
 const policyToLabel = (p: RetentionPolicy, parent: ?RetentionPolicy) => {
@@ -262,9 +290,46 @@ const policyEquals = (p1?: RetentionPolicy, p2?: RetentionPolicy): boolean => {
   }
   return p1 === p2
 }
+const policyToExplanation = (convType: string, p: RetentionPolicy, parent?: RetentionPolicy) => {
+  let exp = ''
+  switch (p.type) {
+    case 'inherit':
+      if (!parent) {
+        throw new Error(`Got policy of type 'inherit' with no inheritable policy`)
+      }
+      let behavior = ''
+      switch (parent.type) {
+        case 'inherit':
+          throw new Error(`Got invalid type 'inherit' for team-wide policy`)
+        case 'retain':
+          behavior = 'be retained indefinitely'
+          break
+        case 'expire':
+          behavior = `expire after ${daysToLabel(parent.days)}`
+          break
+        default:
+          throw new Error(`Impossible policy type encountered: ${parent.type}`)
+      }
+      exp = `Messages in this ${convType} will ${behavior}, which is the team default.`
+      break
+    case 'retain':
+      exp = `Admins have set this ${convType} to retain messages indefinitely.`
+      break
+    case 'expire':
+      exp = `Admins have set this ${convType} to auto-delete messages after ${daysToLabel(p.days)}`
+      break
+    default:
+      throw new Error(`Impossible policy type encountered: ${p.type}`)
+  }
+  return exp
+}
 
 // Switcher to avoid having RetentionPicker try to process nonexistent data
-const RetentionSwitcher = (props: Props) =>
-  props.loading ? <ProgressIndicator style={progressIndicatorStyle} /> : <RetentionPicker {...props} />
+const RetentionSwitcher = (props: Props & {entityType: RetentionEntityType}) => {
+  if (props.loading) {
+    return <ProgressIndicator style={progressIndicatorStyle} />
+  }
+  return props.canSetPolicy ? <RetentionPicker {...props} /> : <RetentionDisplay {...props} />
+}
 
 export default RetentionSwitcher

--- a/shared/teams/team/settings/retention/index.stories.js
+++ b/shared/teams/team/settings/retention/index.stories.js
@@ -37,6 +37,7 @@ const load = () => {
     ))
     .add('Channel', () => (
       <RetentionPicker
+        entityType="channel"
         canSetPolicy={true}
         policy={policy30Days}
         teamPolicy={policyRetain}
@@ -49,6 +50,7 @@ const load = () => {
     ))
     .add('Big team', () => (
       <RetentionPicker
+        entityType="big team"
         canSetPolicy={true}
         policy={policy30Days}
         loading={false}
@@ -60,6 +62,7 @@ const load = () => {
     ))
     .add('Small team', () => (
       <RetentionPicker
+        entityType="small team"
         canSetPolicy={true}
         policy={policyRetain}
         loading={false}
@@ -71,6 +74,7 @@ const load = () => {
     ))
     .add('Adhoc', () => (
       <RetentionPicker
+        entityType="adhoc"
         canSetPolicy={true}
         policy={policy30Days}
         loading={false}
@@ -82,6 +86,7 @@ const load = () => {
     ))
     .add('Channel inheriting', () => (
       <RetentionPicker
+        entityType="channel"
         canSetPolicy={true}
         policy={policyInherit}
         teamPolicy={policy30Days}
@@ -94,6 +99,7 @@ const load = () => {
     ))
     .add('Automatically show warning / set policy', () => (
       <RetentionPicker
+        entityType="channel"
         canSetPolicy={true}
         policy={policyInherit}
         teamPolicy={policy30Days}

--- a/shared/teams/team/settings/retention/index.stories.js
+++ b/shared/teams/team/settings/retention/index.stories.js
@@ -10,6 +10,7 @@ import {RetentionDropdownView} from './dropdown'
 const policyRetain = makeRetentionPolicy({type: 'retain'})
 const policyInherit = makeRetentionPolicy({type: 'inherit'})
 const policy30Days = makeRetentionPolicy({type: 'expire', days: 30})
+const policy7Days = makeRetentionPolicy({type: 'expire', days: 7})
 
 const actions = {
   setRetentionPolicy: action('setRetentionPolicy'),
@@ -107,6 +108,56 @@ const load = () => {
         showInheritOption={true}
         showOverrideNotice={false}
         type="auto"
+        {...actions}
+      />
+    ))
+    .add('Non-admin team-wide', () => (
+      <RetentionPicker
+        entityType="big team"
+        canSetPolicy={false}
+        policy={policy30Days}
+        loading={false}
+        showInheritOption={false}
+        showOverrideNotice={true}
+        type="simple"
+        {...actions}
+      />
+    ))
+    .add('Non-admin channel', () => (
+      <RetentionPicker
+        entityType="channel"
+        canSetPolicy={false}
+        policy={policy30Days}
+        teamPolicy={policyRetain}
+        loading={false}
+        showInheritOption={true}
+        showOverrideNotice={false}
+        type="simple"
+        {...actions}
+      />
+    ))
+    .add('Non-admin channel inherit', () => (
+      <RetentionPicker
+        entityType="channel"
+        canSetPolicy={false}
+        policy={policyInherit}
+        teamPolicy={policy7Days}
+        loading={false}
+        showInheritOption={true}
+        showOverrideNotice={false}
+        type="simple"
+        {...actions}
+      />
+    ))
+    .add('Non-admin small team', () => (
+      <RetentionPicker
+        entityType="small team"
+        canSetPolicy={false}
+        policy={policy7Days}
+        loading={false}
+        showInheritOption={false}
+        showOverrideNotice={false}
+        type="simple"
         {...actions}
       />
     ))

--- a/shared/teams/team/settings/retention/index.stories.js
+++ b/shared/teams/team/settings/retention/index.stories.js
@@ -37,6 +37,7 @@ const load = () => {
     ))
     .add('Channel', () => (
       <RetentionPicker
+        canSetPolicy={true}
         policy={policy30Days}
         teamPolicy={policyRetain}
         loading={false}
@@ -48,6 +49,7 @@ const load = () => {
     ))
     .add('Big team', () => (
       <RetentionPicker
+        canSetPolicy={true}
         policy={policy30Days}
         loading={false}
         showInheritOption={false}
@@ -58,6 +60,7 @@ const load = () => {
     ))
     .add('Small team', () => (
       <RetentionPicker
+        canSetPolicy={true}
         policy={policyRetain}
         loading={false}
         showInheritOption={false}
@@ -68,6 +71,7 @@ const load = () => {
     ))
     .add('Adhoc', () => (
       <RetentionPicker
+        canSetPolicy={true}
         policy={policy30Days}
         loading={false}
         showInheritOption={false}
@@ -78,6 +82,7 @@ const load = () => {
     ))
     .add('Channel inheriting', () => (
       <RetentionPicker
+        canSetPolicy={true}
         policy={policyInherit}
         teamPolicy={policy30Days}
         loading={false}
@@ -89,6 +94,7 @@ const load = () => {
     ))
     .add('Automatically show warning / set policy', () => (
       <RetentionPicker
+        canSetPolicy={true}
         policy={policyInherit}
         teamPolicy={policy30Days}
         loading={false}


### PR DESCRIPTION
Adds permissions checks to the retention picker so it automatically switches views depending on whether you're an admin or not.
Admin:
<img width="315" alt="image" src="https://user-images.githubusercontent.com/11968340/38150788-b2667890-342e-11e8-8798-969623c8d93e.png">

Non-admin:
<img width="316" alt="image" src="https://user-images.githubusercontent.com/11968340/38150751-8a855274-342e-11e8-975b-7d87e36507fd.png">
(see storybook for variations)
r? @keybase/react-hackers 