### PR TITLE
fix bug in hash computation for 2015-era badWhitespaceChainLinks

### DIFF
--- a/go/libkb/sig_chain_test.go
+++ b/go/libkb/sig_chain_test.go
@@ -348,6 +348,8 @@ func storeAndLoad(t *testing.T, tc TestContext, chain *SigChain) {
 	sgl.chain = nil
 	sgl.dirtyTail = nil
 	var sc2 *SigChain
+	// Reset the link cache so that we're sure our loads hits storage.
+	tc.G.LinkCache = NewLinkCache(1000, time.Hour)
 	sc2, err = sgl.Load()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
It turned out that after recent sigchain optimizations, we were using the sig payload to compute
chain link IDs. This is almost always correct, except for the ~30 links from badWhitespaceChainLinks.
In those cases, perform the "fix" operation which is just to strip off the trailing newline.