### PR TITLE
Fix scrollback issues

### DIFF
--- a/go/libkb/sig_chain_test.go
+++ b/go/libkb/sig_chain_test.go
@@ -348,6 +348,8 @@ func storeAndLoad(t *testing.T, tc TestContext, chain *SigChain) {
 	sgl.chain = nil
 	sgl.dirtyTail = nil
 	var sc2 *SigChain
+	// Reset the link cache so that we're sure our loads hits storage.
+	tc.G.LinkCache = NewLinkCache(1000, time.Hour)
 	sc2, err = sgl.Load()
 	if err != nil {
 		t.Fatal(err)

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -306,8 +306,7 @@ export const createMetaRequestingTrusted = (payload: $ReadOnly<{|conversationIDK
 export const createMetaUpdatePagination = (
   payload: $ReadOnly<{|
     conversationIDKey: Types.ConversationIDKey,
-    paginationKey: Types.PaginationKey,
-    paginationMoreToLoad: boolean,
+    paginationKey: ?Types.PaginationKey,
   |}>
 ) => ({error: false, payload, type: metaUpdatePagination})
 export const createMetasReceived = (

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -583,6 +583,8 @@ const loadThreadMessageTypes = Object.keys(RPCChatTypes.commonMessageType).reduc
   return arr
 }, [])
 
+// We bookkeep the current request's paginationkey in case we get very slow callbacks so we we can ignore new paginationKeys that are too old
+const _loadingMessagesWithPaginationKey = {}
 // Load new messages on a thread. We call this when you select a conversation, we get a thread-is-stale notification, or when you scroll up and want more messages
 const loadMoreMessages = (
   action:
@@ -656,6 +658,9 @@ const loadMoreMessages = (
     numberOfMessagesToLoad = numMessagesOnInitialLoad
   }
 
+  // Update bookkeeping
+  _loadingMessagesWithPaginationKey[Types.conversationIDKeyToString(conversationIDKey)] = paginationKey
+
   // we clear on the first callback. we sometimes don't get a cached context
   let calledClear = false
   const onGotThread = function*({thread}: {thread: string}, context: 'full' | 'cached') {
@@ -677,16 +682,24 @@ const loadMoreMessages = (
         return arr
       }, [])
 
-      let paginationKey = Types.stringToPaginationKey(
-        (uiMessages.pagination && uiMessages.pagination.next) || ''
-      )
+      // Still loading this conversation w/ this paginationKey?
+      if (
+        _loadingMessagesWithPaginationKey[Types.conversationIDKeyToString(conversationIDKey)] ===
+        paginationKey
+      ) {
+        let newPaginationKey = Types.stringToPaginationKey(
+          (uiMessages.pagination && uiMessages.pagination.next) || ''
+        )
 
-      if (context === 'full') {
-        const paginationMoreToLoad = uiMessages.pagination ? !uiMessages.pagination.last : true
-        // if last is true we ignore paginationkey
-        paginationKey = paginationMoreToLoad ? paginationKey : Types.stringToPaginationKey('')
+        if (context === 'full') {
+          const paginationMoreToLoad = uiMessages.pagination ? !uiMessages.pagination.last : true
+          // if last is true on the full payload we blow away paginationKey
+          newPaginationKey = paginationMoreToLoad ? newPaginationKey : Types.stringToPaginationKey('')
+        }
+        yield Saga.put(
+          Chat2Gen.createMetaUpdatePagination({conversationIDKey, paginationKey: newPaginationKey})
+        )
       }
-      yield Saga.put(Chat2Gen.createMetaUpdatePagination({conversationIDKey, paginationKey}))
 
       // If we're loading the thread clean lets clear
       if (!calledClear && action.type !== Chat2Gen.loadOlderMessagesDueToScroll) {
@@ -1086,7 +1099,7 @@ const startConversation = (action: Chat2Gen.StartConversationPayload, state: Typ
             : parseFolderNameToUsers('', names)
                 .map(u => u.username)
                 .filter(u => u !== you)
-        conversationIDKey = Constants.getExistingConversationWithUsers(I.Set(users), you, state.chat2.metaMap)
+        conversationIDKey = Constants.findConversationFromParticipants(state, I.Set(users))
       } else if (type === 'team') {
         // Actually a team, find general channel
         const meta = state.chat2.metaMap.find(

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -677,17 +677,16 @@ const loadMoreMessages = (
         return arr
       }, [])
 
-      if (context === 'cached') {
-        yield Saga.put(
-          Chat2Gen.createMetaUpdatePagination({
-            conversationIDKey,
-            paginationKey: Types.stringToPaginationKey(
-              (uiMessages.pagination && uiMessages.pagination.next) || ''
-            ),
-            paginationMoreToLoad: uiMessages.pagination ? !uiMessages.pagination.last : true,
-          })
-        )
+      let paginationKey = Types.stringToPaginationKey(
+        (uiMessages.pagination && uiMessages.pagination.next) || ''
+      )
+
+      if (context === 'full') {
+        const paginationMoreToLoad = uiMessages.pagination ? !uiMessages.pagination.last : true
+        // if last is true we ignore paginationkey
+        paginationKey = paginationMoreToLoad ? paginationKey : Types.stringToPaginationKey('')
       }
+      yield Saga.put(Chat2Gen.createMetaUpdatePagination({conversationIDKey, paginationKey}))
 
       // If we're loading the thread clean lets clear
       if (!calledClear && action.type !== Chat2Gen.loadOlderMessagesDueToScroll) {

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -108,8 +108,7 @@
     // We updated our view of a thread
     "metaUpdatePagination": {
       "conversationIDKey": "Types.ConversationIDKey",
-      "paginationKey": "Types.PaginationKey",
-      "paginationMoreToLoad": "boolean",
+      "paginationKey": "?Types.PaginationKey",
     },
     // Add a new message
     "messagesAdd": {

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -39,21 +39,23 @@ class Conversation extends React.PureComponent<SwitchProps> {
 const mapStateToProps = (state: TypedState): * => {
   let _conversationIDKey
   let _pendingConversationUsers
-  let _findExisting = false
 
   if (state.chat2.pendingSelected) {
     _pendingConversationUsers = state.chat2.pendingConversationUsers
-    _findExisting = state.chat2.pendingMode !== 'startingFromAReset'
+    if (state.chat2.pendingMode !== 'startingFromAReset') {
+      _conversationIDKey = Constants.findConversationFromParticipants(
+        state,
+        state.chat2.pendingConversationUsers
+      )
+    }
   } else {
     _conversationIDKey = Constants.getSelectedConversation(state)
   }
 
   return {
     _conversationIDKey,
-    _findExisting,
     _metaMap: state.chat2.metaMap,
     _pendingConversationUsers,
-    _you: state.config.username || '',
   }
 }
 
@@ -72,13 +74,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       type = 'normal'
     }
   } else if (stateProps._pendingConversationUsers) {
-    conversationIDKey = stateProps._findExisting
-      ? Constants.getExistingConversationWithUsers(
-          stateProps._pendingConversationUsers,
-          stateProps._you,
-          stateProps._metaMap
-        )
-      : undefined
     type = 'normal'
   } else {
     type = 'noConvo'

--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -25,7 +25,7 @@ const mapStateToProps = (state: TypedState, {message, previous, innerClass, isSe
 
   let loadMoreType = null
   if (!previous) {
-    loadMoreType = meta.paginationMoreToLoad ? 'moreToLoad' : 'noMoreToLoad'
+    loadMoreType = meta.paginationKey ? 'moreToLoad' : 'noMoreToLoad'
   }
 
   return {

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -37,14 +37,6 @@ export const getEditingOrdinal = (state: TypedState, id: Types.ConversationIDKey
 export const getTyping = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.typingMap.get(id, I.Set())
 export const generateOutboxID = () => Buffer.from([...Array(8)].map(() => Math.floor(Math.random() * 256)))
-export const getExistingConversationWithUsers = (
-  users: I.Set<string>,
-  you: string,
-  metaMap: I.Map<Types.ConversationIDKey, Types.ConversationMeta>
-) => {
-  const toFind = I.Set(users.concat([you]))
-  return metaMap.findKey(meta => meta.participants.toSet().equals(toFind)) || ''
-}
 export const isUserActivelyLookingAtThisThread = (
   state: TypedState,
   conversationIDKey: Types.ConversationIDKey

--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -100,7 +100,7 @@ const getTeamType = ({teamType, membersType}) => {
   }
 }
 
-// Upgrade a meta, try and keep exising values if possible to reduce render thrashing in components
+// Upgrade a meta, try and keep existing values if possible to reduce render thrashing in components
 // Enforce the verions only increase and we only go from untrusted to trusted, etc
 export const updateMeta = (
   old: Types.ConversationMeta,
@@ -120,7 +120,6 @@ export const updateMeta = (
   return meta.withMutations(m => {
     m.set('channelname', meta.channelname || old.channelname)
     m.set('paginationKey', old.paginationKey)
-    m.set('paginationMoreToLoad', old.paginationMoreToLoad)
     m.set('orangeLineOrdinal', old.orangeLineOrdinal)
     m.set('participants', participants)
     m.set('rekeyers', rekeyers)
@@ -258,7 +257,6 @@ export const makeConversationMeta: I.RecordFactory<_ConversationMeta> = I.Record
   offline: false,
   orangeLineOrdinal: null,
   paginationKey: null,
-  paginationMoreToLoad: false,
   participants: I.OrderedSet(),
   rekeyers: I.Set(),
   resetParticipants: I.Set(),

--- a/shared/constants/types/chat2/meta.js
+++ b/shared/constants/types/chat2/meta.js
@@ -29,7 +29,6 @@ export type _ConversationMeta = {
   offline: boolean,
   orangeLineOrdinal: ?Ordinal,
   paginationKey: ?PaginationKey,
-  paginationMoreToLoad: boolean,
   participants: I.OrderedSet<string>,
   rekeyers: I.Set<string>,
   resetParticipants: I.Set<string>,

--- a/shared/logger/action-transformer.js
+++ b/shared/logger/action-transformer.js
@@ -43,6 +43,7 @@ const entityTransformer = (action: Entity.Actions) => ({
 })
 
 const defaultTransformer: ActionTransformer<*, *> = ({type}) => ({type})
+const fullOutput = a => a
 
 const actionTransformMap: {[key: string]: ActionTransformer<*, *>} = {
   [RouteTreeConstants.switchTo]: pathActionTransformer,
@@ -55,6 +56,7 @@ const actionTransformMap: {[key: string]: ActionTransformer<*, *>} = {
   'entity:merge': entityTransformer,
   'entity:replace': entityTransformer,
   'entity:subtract': entityTransformer,
+
   _loadAvatarHelper: nullTransform,
   [ConfigGen.loadAvatars]: nullTransform,
   [ConfigGen.loadTeamAvatars]: nullTransform,
@@ -63,12 +65,14 @@ const actionTransformMap: {[key: string]: ActionTransformer<*, *>} = {
   [EngineGen.waitingForRpc]: nullTransform,
   [GregorGen.pushOOBM]: nullTransform,
   [AppGen.changedFocus]: nullTransform,
-  [Chat2Gen.setLoading]: a => a,
-  [Chat2Gen.clearLoading]: a => a,
-  [Chat2Gen.selectConversation]: a => a,
-  [Chat2Gen.metaNeedsUpdating]: a => a,
   [Chat2Gen.updateTypers]: nullTransform,
-  [ConfigGen.globalError]: a => a,
+
+  [Chat2Gen.setLoading]: fullOutput,
+  [Chat2Gen.clearLoading]: fullOutput,
+  [Chat2Gen.selectConversation]: fullOutput,
+  [Chat2Gen.metaNeedsUpdating]: fullOutput,
+  [Chat2Gen.metaUpdatePagination]: fullOutput,
+  [ConfigGen.globalError]: fullOutput,
 }
 
 const transformActionForLog: ActionTransformer<*, *> = (action, state) =>

--- a/shared/logger/action-transformer.js
+++ b/shared/logger/action-transformer.js
@@ -72,7 +72,24 @@ const actionTransformMap: {[key: string]: ActionTransformer<*, *>} = {
   [Chat2Gen.selectConversation]: fullOutput,
   [Chat2Gen.metaNeedsUpdating]: fullOutput,
   [Chat2Gen.metaUpdatePagination]: fullOutput,
+  [Chat2Gen.setConversationOffline]: fullOutput,
   [ConfigGen.globalError]: fullOutput,
+  [Chat2Gen.setPendingSelected]: fullOutput,
+  [Chat2Gen.setPendingMode]: fullOutput,
+  [Chat2Gen.setPendingConversationUsers]: fullOutput,
+
+  [Chat2Gen.sendToPendingConversation]: a => ({
+    payload: {users: a.payload.users},
+    type: a.type,
+  }),
+  [Chat2Gen.messageSend]: a => ({
+    payload: {conversationIDKey: a.payload.conversationIDKey},
+    type: a.type,
+  }),
+  [Chat2Gen.messagesAdd]: a => ({
+    payload: {context: a.context},
+    type: a.type,
+  }),
 }
 
 const transformActionForLog: ActionTransformer<*, *> = (action, state) =>

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -42,12 +42,7 @@ const metaMapReducer = (metaMap, action) => {
     case Chat2Gen.metaUpdatePagination:
       return metaMap.update(
         action.payload.conversationIDKey,
-        meta =>
-          meta
-            ? meta
-                .set('paginationKey', action.payload.paginationKey)
-                .set('paginationMoreToLoad', action.payload.paginationMoreToLoad)
-            : meta
+        meta => (meta ? meta.set('paginationKey', action.payload.paginationKey) : meta)
       )
     case Chat2Gen.metaDelete:
       return metaMap.delete(action.payload.conversationIDKey)

--- a/shared/settings/feedback-container.native.js
+++ b/shared/settings/feedback-container.native.js
@@ -137,6 +137,7 @@ const extraChatLogs = (state: TypedState) => {
       metaMap: {
         ...chat.metaMap.get(c, I.Map()).toJS(),
         channelname: 'X',
+        description: 'X',
         snippet: 'X',
       },
       pendingMode: chat.pendingMode,


### PR DESCRIPTION
@keybase/react-hackers 

The old code took the pagination value from the cached phase. Before we plumbed through 'last' and the paginationKey. Turns out the last value from cached can be incorrect (set to true) even though there are more values.

The new code takes the paginationKey from full and cached callbacks, but in the full one (where last is correct) it can blow away the paginationKey if last is true

Additionally we no longer expose last to the rest of the app. if last is true we just remove the paginationKey