### PR TITLE
Rebox teamek when adding members

### DIFF
--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -668,7 +668,8 @@ func (e *Kex2Provisionee) storeEKs(ctx context.Context, deviceEKStatement keybas
 	ekLib := e.G().GetEKLib()
 	if ekLib == nil || !ekLib.ShouldRun(ctx) {
 		return nil
-	} else if userEKBox == nil {
+	}
+	if userEKBox == nil {
 		e.G().Log.CWarningf(ctx, "userEKBox nil, no ephemeral keys to store")
 		return nil
 	}

--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -41,7 +41,7 @@ func newEKUnboxErr(boxType EKType, boxGeneration keybase1.EkGeneration, missingT
 }
 
 func (e *EKUnboxErr) Error() string {
-	return fmt.Sprintf("Error unboxing [%s]@generation%v missing [%s]@generation%v", e.boxType, e.boxGeneration, e.missingType, e.missingGeneration)
+	return fmt.Sprintf("Error unboxing %s@generation:%v missing %s@generation:%v", e.boxType, e.boxGeneration, e.missingType, e.missingGeneration)
 }
 
 func ctimeIsStale(ctime keybase1.Time, currentMerkleRoot libkb.MerkleRoot) bool {

--- a/go/ephemeral/handler.go
+++ b/go/ephemeral/handler.go
@@ -11,7 +11,7 @@ func HandleNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase
 	defer g.CTrace(ctx, "HandleNewTeamEK", func() error { return err })()
 
 	ekLib := g.GetEKLib()
-	ekLib.PurgeTeamEKGenCache(ctx, teamID, generation)
+	ekLib.PurgeTeamEKGenCache(teamID, generation)
 	g.NotifyRouter.HandleNewTeamEK(ctx, teamID, generation)
 	return nil
 }

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -118,7 +118,7 @@ func (e *EKLib) CleanupStaleUserAndDeviceEKs(ctx context.Context) (err error) {
 }
 
 func (e *EKLib) cleanupStaleUserAndDeviceEKs(ctx context.Context, merkleRoot libkb.MerkleRoot) (err error) {
-	defer e.G().CTrace(ctx, "CleanupStaleUserAndDeviceEKs", func() error { return err })()
+	defer e.G().CTrace(ctx, "cleanupStaleUserAndDeviceEKs", func() error { return err })()
 
 	epick := libkb.FirstErrorPicker{}
 
@@ -220,6 +220,8 @@ func (e *EKLib) NewTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID) (ne
 }
 
 func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot, statement *keybase1.TeamEkStatement) (needed bool, err error) {
+	defer e.G().CTrace(ctx, "newTeamEKNeeded", func() error { return err })()
+
 	// Let's see what the latest server statement is.
 	// No statement, so we need a teamEK
 	if statement == nil {
@@ -265,7 +267,8 @@ func (e *EKLib) isEntryValid(val interface{}) (*teamEKGenCacheEntry, bool) {
 	return cacheEntry, (keybase1.TimeFromSeconds(time.Now().Unix()) - cacheEntry.Ctime) < keybase1.TimeFromSeconds(cacheEntryLifetimeSecs)
 }
 
-func (e *EKLib) PurgeTeamEKGenCache(context context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) {
+func (e *EKLib) PurgeTeamEKGenCache(teamID keybase1.TeamID, generation keybase1.EkGeneration) {
+
 	key := e.cacheKey(teamID)
 	val, ok := e.teamEKGenCache.Get(teamID)
 	if ok {
@@ -276,6 +279,8 @@ func (e *EKLib) PurgeTeamEKGenCache(context context.Context, teamID keybase1.Tea
 }
 
 func (e *EKLib) GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (teamEK keybase1.TeamEk, err error) {
+	defer e.G().CTrace(ctx, "GetOrCreateLatestTeamEK", func() error { return err })()
+
 	e.Lock()
 	defer e.Unlock()
 
@@ -344,6 +349,8 @@ func (e *EKLib) DeriveDeviceDHKey(seed keybase1.Bytes32) *libkb.NaclDHKeyPair {
 }
 
 func (e *EKLib) SignedDeviceEKStatementFromSeed(ctx context.Context, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey libkb.GenericKey, existingMetadata []keybase1.DeviceEkMetadata) (statement keybase1.DeviceEkStatement, signedStatement string, err error) {
+	defer e.G().CTrace(ctx, "SignedDeviceEKStatementFromSeed", func() error { return err })()
+
 	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(ctx, libkb.EphemeralKeyMerkleFreshness)
 	if err != nil {
 		return statement, signedStatement, err
@@ -354,6 +361,8 @@ func (e *EKLib) SignedDeviceEKStatementFromSeed(ctx context.Context, generation 
 
 // For device provisioning
 func (e *EKLib) BoxLatestUserEK(ctx context.Context, receiverKey libkb.NaclDHKeyPair, deviceEKGeneration keybase1.EkGeneration) (userEKBox *keybase1.UserEkBoxed, err error) {
+	defer e.G().CTrace(ctx, "BoxLatestUserEK", func() error { return err })()
+
 	// TODO remove this when we want to release in the wild.
 	if !e.ShouldRun(ctx) {
 		return nil, nil
@@ -397,6 +406,8 @@ func (e *EKLib) PrepareNewUserEK(ctx context.Context, merkleRoot libkb.MerkleRoo
 }
 
 func (e *EKLib) BoxLatestTeamEK(ctx context.Context, teamID keybase1.TeamID, recipients []keybase1.UID) (teamEKBoxes *[]keybase1.TeamEkBoxMetadata, err error) {
+	defer e.G().CTrace(ctx, "BoxLatestTeamEK", func() error { return err })()
+
 	// TODO remove this when we want to release in the wild.
 	if !e.ShouldRun(ctx) {
 		return nil, nil

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -69,11 +69,11 @@ func prepareNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot li
 		return "", nil, newMetadata, nil, err
 	}
 	var generation keybase1.EkGeneration
-	statement, ok := prevStatements[g.Env.GetUID()]
-	if !ok || statement == nil {
+	prevStatement, ok := prevStatements[g.Env.GetUID()]
+	if !ok || prevStatement == nil {
 		generation = 1 // start at generation 1
 	} else {
-		generation = statement.CurrentUserEkMetadata.Generation + 1
+		generation = prevStatement.CurrentUserEkMetadata.Generation + 1
 	}
 
 	dhKeypair := seed.DeriveDHKey()
@@ -206,7 +206,7 @@ type userEKStatementResponse struct {
 // transitional thing, and eventually when all "reasonably up to date" clients
 // in the wild have EK support, we will make that case an error.
 func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []keybase1.UID) (statements map[keybase1.UID]*keybase1.UserEkStatement, err error) {
-	defer g.CTrace(ctx, "fetchUserEKStatement", func() error { return err })()
+	defer g.CTrace(ctx, "fetchUserEKStatements", func() error { return err })()
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "user/user_ek",

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -77,7 +77,12 @@ func TestDeviceRevokeNewUserEK(t *testing.T) {
 	require.NoError(t, err)
 
 	// Confirm that the user has a userEK.
-	firstStatement, err := fetchUserEKStatement(context.Background(), tc.G)
+	uid := tc.G.Env.GetUID()
+	uids := []keybase1.UID{uid}
+	statements, err := fetchUserEKStatements(context.Background(), tc.G, uids)
+	require.NoError(t, err)
+	firstStatement, ok := statements[uid]
+	require.True(t, ok)
 	require.EqualValues(t, firstStatement.CurrentUserEkMetadata.Generation, 1, "should start at userEK gen 1")
 
 	// Load the full user so that we can grab their devices.
@@ -98,8 +103,10 @@ func TestDeviceRevokeNewUserEK(t *testing.T) {
 	require.NoError(t, err)
 
 	// Finally, confirm that the revocation above rolled a new userEK.
-	secondStatement, err := fetchUserEKStatement(context.Background(), tc.G)
+	statements, err = fetchUserEKStatements(context.Background(), tc.G, uids)
 	require.NoError(t, err)
+	secondStatement, ok := statements[uid]
+	require.True(t, ok)
 	require.EqualValues(t, secondStatement.CurrentUserEkMetadata.Generation, 2, "after revoke, should have userEK gen 2")
 	userEK, err := tc.G.GetUserEKBoxStorage().Get(context.Background(), 2)
 	require.NoError(t, err)
@@ -120,7 +127,12 @@ func TestPukRollNewUserEK(t *testing.T) {
 	require.NoError(t, err)
 
 	// Confirm that the user has a userEK.
-	firstStatement, err := fetchUserEKStatement(context.Background(), tc.G)
+	uid := tc.G.Env.GetUID()
+	uids := []keybase1.UID{uid}
+	statements, err := fetchUserEKStatements(context.Background(), tc.G, uids)
+	require.NoError(t, err)
+	firstStatement, ok := statements[uid]
+	require.True(t, ok)
 	require.EqualValues(t, firstStatement.CurrentUserEkMetadata.Generation, 1, "should start at userEK gen 1")
 
 	// Do a PUK roll.
@@ -133,8 +145,10 @@ func TestPukRollNewUserEK(t *testing.T) {
 	require.NoError(t, err)
 
 	// Finally, confirm that the roll above also rolled a new userEK.
-	secondStatement, err := fetchUserEKStatement(context.Background(), tc.G)
+	statements, err = fetchUserEKStatements(context.Background(), tc.G, uids)
 	require.NoError(t, err)
+	secondStatement, ok := statements[uid]
+	require.True(t, ok)
 	require.EqualValues(t, secondStatement.CurrentUserEkMetadata.Generation, 2, "after PUK roll, should have userEK gen 2")
 	userEK, err := tc.G.GetUserEKBoxStorage().Get(context.Background(), 2)
 	require.NoError(t, err)

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +19,8 @@ func TestNewUserEK(t *testing.T) {
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 
-	prevStatement, err := fetchUserEKStatement(context.Background(), tc.G)
+	uids := []keybase1.UID{tc.G.Env.GetUID()}
+	prevStatement, err := fetchUserEKStatements(context.Background(), tc.G, uids)
 	require.NoError(t, err)
 	prevExisting := prevStatement.ExistingUserEkMetadata
 	prevExisting = append(prevExisting, prevStatement.CurrentUserEkMetadata)
@@ -31,7 +33,7 @@ func TestNewUserEK(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, userEK.Metadata, publishedMetadata)
 
-	statementPtr, err := fetchUserEKStatement(context.Background(), tc.G)
+	statementPtr, err := fetchUserEKStatement(context.Background(), tc.G, uids)
 	require.NoError(t, err)
 	require.NotNil(t, statementPtr)
 	statement := *statementPtr

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -19,9 +19,12 @@ func TestNewUserEK(t *testing.T) {
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 
-	uids := []keybase1.UID{tc.G.Env.GetUID()}
-	prevStatement, err := fetchUserEKStatements(context.Background(), tc.G, uids)
+	uid := tc.G.Env.GetUID()
+	uids := []keybase1.UID{uid}
+	prevStatements, err := fetchUserEKStatements(context.Background(), tc.G, uids)
 	require.NoError(t, err)
+	prevStatement, ok := prevStatements[uid]
+	require.True(t, ok)
 	prevExisting := prevStatement.ExistingUserEkMetadata
 	prevExisting = append(prevExisting, prevStatement.CurrentUserEkMetadata)
 
@@ -33,10 +36,11 @@ func TestNewUserEK(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, userEK.Metadata, publishedMetadata)
 
-	statementPtr, err := fetchUserEKStatement(context.Background(), tc.G, uids)
+	statements, err := fetchUserEKStatements(context.Background(), tc.G, uids)
 	require.NoError(t, err)
-	require.NotNil(t, statementPtr)
-	statement := *statementPtr
+	statement, ok := statements[uid]
+	require.True(t, ok)
+	require.NotNil(t, statement)
 	currentMetadata := statement.CurrentUserEkMetadata
 	require.Equal(t, currentMetadata, publishedMetadata)
 	require.Equal(t, statement.ExistingUserEkMetadata, prevExisting)

--- a/go/libkb/downgrade_leases.go
+++ b/go/libkb/downgrade_leases.go
@@ -4,9 +4,10 @@
 package libkb
 
 import (
+	"strings"
+
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
-	"strings"
 )
 
 func kidsToString(kids []keybase1.KID) string {
@@ -25,12 +26,12 @@ func sigIDsToString(sigIDs []keybase1.SigID) string {
 	return strings.Join(tmp, ",")
 }
 
-func uidsToString(uids []keybase1.UID) string {
-	var tmp []string
-	for _, u := range uids {
-		tmp = append(tmp, string(u))
+func UidsToString(uids []keybase1.UID) string {
+	s := make([]string, len(uids))
+	for i, uid := range uids {
+		s[i] = string(uid)
 	}
-	return strings.Join(tmp, ",")
+	return strings.Join(s, ",")
 }
 
 type Lease struct {
@@ -100,7 +101,7 @@ func RequestDowngradeLeaseByTeam(ctx context.Context, g *GlobalContext, teamID k
 		NetContext:  ctx,
 		Args: HTTPArgs{
 			"team_id":     S{string(teamID)},
-			"member_uids": S{uidsToString(uids)},
+			"member_uids": S{UidsToString(uids)},
 		},
 	}, &res)
 	if err != nil {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -647,7 +647,7 @@ type EKLib interface {
 	SignedDeviceEKStatementFromSeed(ctx context.Context, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey GenericKey, existingMetadata []keybase1.DeviceEkMetadata) (keybase1.DeviceEkStatement, string, error)
 	BoxLatestUserEK(ctx context.Context, receiverKey NaclDHKeyPair, deviceEKGeneration keybase1.EkGeneration) (*keybase1.UserEkBoxed, error)
 	PrepareNewUserEK(ctx context.Context, merkleRoot MerkleRoot, pukSeed PerUserKeySeed) (sig string, boxes []keybase1.UserEkBoxMetadata, newMetadata keybase1.UserEkMetadata, myBox *keybase1.UserEkBoxed, err error)
-	BoxLatestTeamEK(ctx context.Context) ([]*keybase1.TeamEkBoxMetadata, error)
+	BoxLatestTeamEK(ctx context.Context, teamID keybase1.TeamID, uids []keybase1.UID) (*[]keybase1.TeamEkBoxMetadata, error)
 	ShouldRun(ctx context.Context) bool
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -641,7 +641,7 @@ type TeamEKBoxStorage interface {
 type EKLib interface {
 	KeygenIfNeeded(ctx context.Context) error
 	GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (keybase1.TeamEk, error)
-	PurgeTeamEKGenCache(context context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration)
+	PurgeTeamEKGenCache(teamID keybase1.TeamID, generation keybase1.EkGeneration)
 	NewEphemeralSeed() (keybase1.Bytes32, error)
 	DeriveDeviceDHKey(seed keybase1.Bytes32) *NaclDHKeyPair
 	SignedDeviceEKStatementFromSeed(ctx context.Context, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey GenericKey, existingMetadata []keybase1.DeviceEkMetadata) (keybase1.DeviceEkStatement, string, error)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -647,6 +647,7 @@ type EKLib interface {
 	SignedDeviceEKStatementFromSeed(ctx context.Context, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey GenericKey, existingMetadata []keybase1.DeviceEkMetadata) (keybase1.DeviceEkStatement, string, error)
 	BoxLatestUserEK(ctx context.Context, receiverKey NaclDHKeyPair, deviceEKGeneration keybase1.EkGeneration) (*keybase1.UserEkBoxed, error)
 	PrepareNewUserEK(ctx context.Context, merkleRoot MerkleRoot, pukSeed PerUserKeySeed) (sig string, boxes []keybase1.UserEkBoxMetadata, newMetadata keybase1.UserEkMetadata, myBox *keybase1.UserEkBoxed, err error)
+	BoxLatestTeamEK(ctx context.Context) ([]*keybase1.TeamEkBoxMetadata, error)
 	ShouldRun(ctx context.Context) bool
 }
 

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -48,3 +48,64 @@ func checkNewTeamEKNotifications(tc *libkb.TestContext, notifications *teamNotif
 		}
 	}
 }
+
+func TestTeamTransactionWithTeamEK(t *testing.T) {
+	runTeamTransaction(t, true /* createTeamEK*/)
+}
+
+func TestTeamTransactionNoTeamEK(t *testing.T) {
+	runTeamTransaction(t, false /* createTeamEK*/)
+}
+
+func getTeamEK(g *libkb.GlobalContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) (keybase1.TeamEk, error) {
+	storage := g.GetTeamEKBoxStorage()
+	return storage.Get(context.Background(), teamID, generation)
+}
+
+func runTeamTransaction(t *testing.T, createTeamEK bool) {
+	ctx := newSMUContext(t)
+	defer ctx.cleanup()
+
+	ann := ctx.installKeybaseForUser("ann", 10)
+	ann.signup()
+	bob := ctx.installKeybaseForUser("bob", 10)
+	bob.signup()
+
+	annG := ann.getPrimaryGlobalContext()
+	ephemeral.ServiceInit(annG)
+	bobG := bob.getPrimaryGlobalContext()
+	ephemeral.ServiceInit(bobG)
+
+	team := ann.createTeam([]*smuUser{})
+	teamName, err := keybase1.TeamNameFromString(team.name)
+	require.NoError(t, err)
+	teamID := teamName.ToPrivateTeamID()
+
+	var expectedMetadata keybase1.TeamEkMetadata
+	var expectedGeneration keybase1.EkGeneration
+	if createTeamEK {
+		ekLib := annG.GetEKLib()
+		teamEK, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+		require.NoError(t, err)
+
+		expectedMetadata = teamEK.Metadata
+		expectedGeneration = expectedMetadata.Generation
+	} else {
+		expectedMetadata = keybase1.TeamEkMetadata{}
+		expectedGeneration = 1
+	}
+
+	ann.addTeamMember(team, bob, keybase1.TeamRole_WRITER)
+
+	annTeamEK, annErr := getTeamEK(annG, teamID, expectedGeneration)
+	bobTeamEK, bobErr := getTeamEK(bobG, teamID, expectedGeneration)
+	if createTeamEK {
+		require.NoError(t, annErr)
+		require.NoError(t, bobErr)
+	} else {
+		require.Error(t, annErr)
+		require.Error(t, bobErr)
+	}
+	require.Equal(t, bobTeamEK.Metadata, expectedMetadata)
+	require.Equal(t, annTeamEK.Metadata, expectedMetadata)
+}

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -13,6 +13,8 @@ type member struct {
 	perUserKey keybase1.PerUserKey
 }
 
+type MemberMap map[keybase1.UserVersion]keybase1.PerUserKey
+
 type memberSet struct {
 	Owners  []member
 	Admins  []member
@@ -21,11 +23,11 @@ type memberSet struct {
 	None    []member
 
 	// the per-user-keys of everyone in the lists above
-	recipients map[keybase1.UserVersion]keybase1.PerUserKey
+	recipients MemberMap
 }
 
 func newMemberSet() *memberSet {
-	return &memberSet{recipients: make(map[keybase1.UserVersion]keybase1.PerUserKey)}
+	return &memberSet{recipients: make(MemberMap)}
 }
 
 func newMemberSetChange(ctx context.Context, g *libkb.GlobalContext, req keybase1.TeamChangeReq) (*memberSet, error) {
@@ -55,8 +57,8 @@ func (m *memberSet) nonAdmins() []member {
 	return ret
 }
 
-func (m *memberSet) adminAndOwnerRecipients() map[keybase1.UserVersion]keybase1.PerUserKey {
-	ret := map[keybase1.UserVersion]keybase1.PerUserKey{}
+func (m *memberSet) adminAndOwnerRecipients() MemberMap {
+	ret := MemberMap{}
 	for _, owner := range m.Owners {
 		ret[owner.version] = owner.perUserKey
 	}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1351,6 +1351,7 @@ type sigPayloadArgs struct {
 	lease              *libkb.Lease
 	prePayload         libkb.JSONPayload
 	legacyTLFUpgrade   *keybase1.TeamGetLegacyTLFUpgrade
+	teamEKBoxes        []*keybase1.TeamEkBoxMetadata
 }
 
 func (t *Team) sigPayload(sigMultiItem libkb.SigMultiItem, args sigPayloadArgs) libkb.JSONPayload {
@@ -1371,6 +1372,9 @@ func (t *Team) sigPayload(sigMultiItem libkb.SigMultiItem, args sigPayloadArgs) 
 	}
 	if args.legacyTLFUpgrade != nil {
 		payload["legacy_tlf_upgrade"] = args.legacyTLFUpgrade
+	}
+	if args.teamEKBoxes != nil {
+		payload["team_ek_box"] = args.teamEKBoxes
 	}
 
 	if t.G().VDL.DumpPayload() {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -600,7 +600,7 @@ func (t *Team) deleteRoot(ctx context.Context, ui keybase1.TeamsUiInterface) err
 		return err
 	}
 
-	payload := t.sigPayload(sigMultiItem, sigPayloadArgs{})
+	payload := t.sigPayload([]libkb.SigMultiItem{sigMultiItem}, sigPayloadArgs{})
 	return t.postMulti(payload)
 }
 
@@ -986,12 +986,13 @@ func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error
 		return err
 	}
 
-	err = t.precheckLinksToPost(ctx, []libkb.SigMultiItem{sigMultiItem})
+	sigMulti := []libkb.SigMultiItem{sigMultiItem}
+	err = t.precheckLinksToPost(ctx, sigMulti)
 	if err != nil {
 		return err
 	}
 
-	payload := t.sigPayload(sigMultiItem, sigPayloadArgs{})
+	payload := t.sigPayload(sigMulti, sigPayloadArgs{})
 	err = t.postMulti(payload)
 	if err != nil {
 		return err
@@ -1113,13 +1114,14 @@ func (t *Team) postChangeItem(ctx context.Context, section SCTeamSection, linkTy
 		return err
 	}
 
-	err = t.precheckLinksToPost(ctx, []libkb.SigMultiItem{sigMultiItem})
+	sigMulti := []libkb.SigMultiItem{sigMultiItem}
+	err = t.precheckLinksToPost(ctx, sigMulti)
 	if err != nil {
 		return err
 	}
 
 	// make the payload
-	payload := t.sigPayload(sigMultiItem, sigPayloadArgs)
+	payload := t.sigPayload(sigMulti, sigPayloadArgs)
 
 	// send it to the server
 	return t.postMulti(payload)
@@ -1351,16 +1353,16 @@ type sigPayloadArgs struct {
 	lease              *libkb.Lease
 	prePayload         libkb.JSONPayload
 	legacyTLFUpgrade   *keybase1.TeamGetLegacyTLFUpgrade
-	teamEKBoxes        []*keybase1.TeamEkBoxMetadata
+	teamEKBoxes        *[]keybase1.TeamEkBoxMetadata
 }
 
-func (t *Team) sigPayload(sigMultiItem libkb.SigMultiItem, args sigPayloadArgs) libkb.JSONPayload {
+func (t *Team) sigPayload(sigMulti []libkb.SigMultiItem, args sigPayloadArgs) libkb.JSONPayload {
 	payload := libkb.JSONPayload{}
 	// copy the prepayload so we don't mutate it
 	for k, v := range args.prePayload {
 		payload[k] = v
 	}
-	payload["sigs"] = []interface{}{sigMultiItem}
+	payload["sigs"] = sigMulti
 	if args.secretBoxes != nil {
 		payload["per_team_key"] = args.secretBoxes
 	}
@@ -1666,7 +1668,7 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 		return err
 	}
 
-	payload := t.sigPayload(sigMultiItem, sigPayloadArgs{
+	payload := t.sigPayload([]libkb.SigMultiItem{sigMultiItem}, sigPayloadArgs{
 		legacyTLFUpgrade: &keybase1.TeamGetLegacyTLFUpgrade{
 			EncryptedKeyset:  encStr,
 			LegacyGeneration: cryptKeys[len(cryptKeys)-1].Generation(),
@@ -1704,7 +1706,7 @@ func (t *Team) AssociateWithTLFID(ctx context.Context, tlfID keybase1.TLFID) (er
 		return err
 	}
 
-	payload := t.sigPayload(sigMultiItem, sigPayloadArgs{})
+	payload := t.sigPayload([]libkb.SigMultiItem{sigMultiItem}, sigPayloadArgs{})
 	return t.postMulti(payload)
 }
 

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1376,7 +1376,10 @@ func (t *Team) sigPayload(sigMulti []libkb.SigMultiItem, args sigPayloadArgs) li
 		payload["legacy_tlf_upgrade"] = args.legacyTLFUpgrade
 	}
 	if args.teamEKBoxes != nil {
-		payload["team_ek_box"] = args.teamEKBoxes
+		payload["team_ek_rebox"] = libkb.JSONPayload{
+			"boxes":   args.teamEKBoxes,
+			"team_id": t.ID,
+		}
 	}
 
 	if t.G().VDL.DumpPayload() {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1375,7 +1375,7 @@ func (t *Team) sigPayload(sigMulti []libkb.SigMultiItem, args sigPayloadArgs) li
 	if args.legacyTLFUpgrade != nil {
 		payload["legacy_tlf_upgrade"] = args.legacyTLFUpgrade
 	}
-	if args.teamEKBoxes != nil {
+	if args.teamEKBoxes != nil && len(*args.teamEKBoxes) > 0 {
 		payload["team_ek_rebox"] = libkb.JSONPayload{
 			"boxes":   args.teamEKBoxes,
 			"team_id": t.ID,

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -646,8 +646,15 @@ func (tx *AddMemberTx) Post(ctx context.Context) (err error) {
 	} else { // If we didn't rotate the PTK, let's rebox the existing PTK for any of the new members
 		ekLib := g.GetEKLib()
 		if ekLib != nil {
+			// Only box up for the latest members
 			memSet.removeExistingMembers(ctx, team)
-			teamEKBoxes, err := ekLib.BoxLatestTeamEK(ctx, memSet.recipients)
+			i := 0
+			uids := make([]keybase1.UID, len(memSet.recipients))
+			for uv := range memSet.recipients {
+				uids[i] = uv.Uid
+				i++
+			}
+			teamEKBoxes, err = ekLib.BoxLatestTeamEK(ctx, team.ID, uids)
 			if err != nil {
 				return err
 			}

--- a/go/teams/transactions_test.go
+++ b/go/teams/transactions_test.go
@@ -55,6 +55,7 @@ func TestTransactions1(t *testing.T) {
 	require.Equal(t, owner.GetUserVersion(), members.Owners[0])
 	require.Equal(t, 0, len(members.Admins))
 	require.Equal(t, 1, len(members.Writers))
+	require.Equal(t, other.GetUserVersion(), members.Writers[0])
 	require.Equal(t, 0, len(members.Readers))
 
 	invites := team.GetActiveAndObsoleteInvites()

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -182,17 +182,9 @@ func (a *apiReply) GetAppStatus() *libkb.AppStatus {
 	return &a.Status
 }
 
-func uidsToString(uids []keybase1.UID) string {
-	s := make([]string, len(uids))
-	for i, uid := range uids {
-		s[i] = string(uid)
-	}
-	return strings.Join(s, ",")
-}
-
 func uidsToStringForLog(uids []keybase1.UID) string {
 	if len(uids) < 5 {
-		return uidsToString(uids)
+		return libkb.UidsToString(uids)
 	}
 
 	return fmt.Sprintf("%s,...,%s [%d total UIDs]", uids[0], uids[len(uids)-1], len(uids))
@@ -218,7 +210,7 @@ func (u *UIDMap) lookupFromServerBatch(ctx context.Context, g libkb.UIDMapperCon
 		g.GetLog().CDebugf(ctx, "user/names refreshers: %s", refreshers)
 	}
 	arg.Args = libkb.HTTPArgs{
-		"uids":       libkb.S{Val: uidsToString(uids)},
+		"uids":       libkb.S{Val: libkb.UidsToString(uids)},
 		"no_cache":   libkb.B{Val: noCache},
 		"refreshers": libkb.S{Val: refreshers},
 	}


### PR DESCRIPTION
When adding members to a team, rebox the current teamEK if it exists for the new members. Depends  on https://github.com/keybase/keybase/pull/2277

cc @mlsteele 