### PR TITLE
make search use the correct helper for looking up convos by participants

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1096,7 +1096,7 @@ const startConversation = (action: Chat2Gen.StartConversationPayload, state: Typ
             : parseFolderNameToUsers('', names)
                 .map(u => u.username)
                 .filter(u => u !== you)
-        conversationIDKey = Constants.getExistingConversationWithUsers(I.Set(users), you, state.chat2.metaMap)
+        conversationIDKey = Constants.findConversationFromParticipants(state, I.Set(users))
       } else if (type === 'team') {
         // Actually a team, find general channel
         const meta = state.chat2.metaMap.find(

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -659,7 +659,7 @@ const loadMoreMessages = (
   }
 
   // Update bookkeeping
-  _loadingMessagesWithPaginationKey[conversationIDKey] = paginationKey
+  _loadingMessagesWithPaginationKey[Types.conversationIDKeyToString(conversationIDKey)] = paginationKey
 
   // we clear on the first callback. we sometimes don't get a cached context
   let calledClear = false
@@ -683,7 +683,10 @@ const loadMoreMessages = (
       }, [])
 
       // Still loading this conversation w/ this paginationKey?
-      if (_loadingMessagesWithPaginationKey[conversationIDKey] === paginationKey) {
+      if (
+        _loadingMessagesWithPaginationKey[Types.conversationIDKeyToString(conversationIDKey)] ===
+        paginationKey
+      ) {
         let newPaginationKey = Types.stringToPaginationKey(
           (uiMessages.pagination && uiMessages.pagination.next) || ''
         )

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -39,21 +39,23 @@ class Conversation extends React.PureComponent<SwitchProps> {
 const mapStateToProps = (state: TypedState): * => {
   let _conversationIDKey
   let _pendingConversationUsers
-  let _findExisting = false
 
   if (state.chat2.pendingSelected) {
     _pendingConversationUsers = state.chat2.pendingConversationUsers
-    _findExisting = state.chat2.pendingMode !== 'startingFromAReset'
+    if (state.chat2.pendingMode !== 'startingFromAReset') {
+      _conversationIDKey = Constants.findConversationFromParticipants(
+        state,
+        state.chat2.pendingConversationUsers
+      )
+    }
   } else {
     _conversationIDKey = Constants.getSelectedConversation(state)
   }
 
   return {
     _conversationIDKey,
-    _findExisting,
     _metaMap: state.chat2.metaMap,
     _pendingConversationUsers,
-    _you: state.config.username || '',
   }
 }
 
@@ -72,13 +74,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       type = 'normal'
     }
   } else if (stateProps._pendingConversationUsers) {
-    conversationIDKey = stateProps._findExisting
-      ? Constants.getExistingConversationWithUsers(
-          stateProps._pendingConversationUsers,
-          stateProps._you,
-          stateProps._metaMap
-        )
-      : undefined
     type = 'normal'
   } else {
     type = 'noConvo'

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -37,14 +37,6 @@ export const getEditingOrdinal = (state: TypedState, id: Types.ConversationIDKey
 export const getTyping = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.typingMap.get(id, I.Set())
 export const generateOutboxID = () => Buffer.from([...Array(8)].map(() => Math.floor(Math.random() * 256)))
-export const getExistingConversationWithUsers = (
-  users: I.Set<string>,
-  you: string,
-  metaMap: I.Map<Types.ConversationIDKey, Types.ConversationMeta>
-) => {
-  const toFind = I.Set(users.concat([you]))
-  return metaMap.findKey(meta => meta.participants.toSet().equals(toFind)) || ''
-}
 export const isUserActivelyLookingAtThisThread = (
   state: TypedState,
   conversationIDKey: Types.ConversationIDKey

--- a/shared/logger/action-transformer.js
+++ b/shared/logger/action-transformer.js
@@ -72,7 +72,24 @@ const actionTransformMap: {[key: string]: ActionTransformer<*, *>} = {
   [Chat2Gen.selectConversation]: fullOutput,
   [Chat2Gen.metaNeedsUpdating]: fullOutput,
   [Chat2Gen.metaUpdatePagination]: fullOutput,
+  [Chat2Gen.setConversationOffline]: fullOutput,
   [ConfigGen.globalError]: fullOutput,
+  [Chat2Gen.setPendingSelected]: fullOutput,
+  [Chat2Gen.setPendingMode]: fullOutput,
+  [Chat2Gen.setPendingConversationUsers]: fullOutput,
+
+  [Chat2Gen.sendToPendingConversation]: a => ({
+    payload: {users: a.payload.users},
+    type: a.type,
+  }),
+  [Chat2Gen.messageSend]: a => ({
+    payload: {conversationIDKey: a.payload.conversationIDKey},
+    type: a.type,
+  }),
+  [Chat2Gen.messagesAdd]: a => ({
+    payload: {context: a.context},
+    type: a.type,
+  }),
 }
 
 const transformActionForLog: ActionTransformer<*, *> = (action, state) =>

--- a/shared/settings/feedback-container.native.js
+++ b/shared/settings/feedback-container.native.js
@@ -137,6 +137,7 @@ const extraChatLogs = (state: TypedState) => {
       metaMap: {
         ...chat.metaMap.get(c, I.Map()).toJS(),
         channelname: 'X',
+        description: 'X',
         snippet: 'X',
       },
       pendingMode: chat.pendingMode,


### PR DESCRIPTION
@keybase/react-hackers there were 2 functions to find an existing conversation but one was looser than the other. 

To repro @malgorithms 's issue you'd have to disable inbox refresh, get a convo from a team, then do a search for the participants of that team and you'd get the wrong convo