### PR TITLE
bring back notifications on Windows

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -183,7 +183,12 @@
                 Name="Keybase"
                 Description="Start GUI"
                 Target="[GuiDir]Keybase.exe"
-                WorkingDirectory="GuiDir"/>
+                WorkingDirectory="GuiDir">
+        <!-- Windows needs this for notifications to show on certain versions
+           https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
+           https://support.microsoft.com/en-us/help/2745126/warning-1946-message-when-you-install-a-windows-installer-package-in-w -->
+        <ShortcutProperty Key="{9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}, 5" Value="Keybase.Keybase.GUI" />
+      </Shortcut>
       <RegistryValue Root="HKCU" Key="Software\Keybase\Keybase" Name="ShortCutGUI" Type="integer" Value="1" KeyPath="yes"/>
     </Component>
   </Fragment>

--- a/shared/desktop/app/index.js
+++ b/shared/desktop/app/index.js
@@ -67,6 +67,10 @@ function start() {
     }
   }
 
+  // Windows needs this for notifications to show on certain versions
+  // https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
+  app.setAppUserModelId('Keybase.Keybase.GUI')
+
   // MUST do this else we get limited by simultaneous hot reload event streams
   app.commandLine.appendSwitch('ignore-connections-limit', 'localhost')
 


### PR DESCRIPTION
I have notifications again on Windows 10 version 1709, build 16299, and this also should make them work on Windows 8.x, where I don't think they did before.

https://keybase.atlassian.net/browse/DESKTOP-6394
https://github.com/keybase/client/issues/10453#issuecomment-378071020
