### PR TITLE
Add missing err check

### DIFF
--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -79,6 +79,9 @@ func Upkeep(ctx context.Context, g *libkb.GlobalContext) (err error) {
 		return err
 	}
 	prevBundle, prevPukGen, err := remote.Fetch(ctx, g)
+	if err != nil {
+		return err
+	}
 	pukGen := pukring.CurrentGeneration()
 	if pukGen <= prevPukGen {
 		g.Log.CDebugf(ctx, "Stellar.Upkeep: early out prevPukGen:%v < pukGen:%v", prevPukGen, pukGen)


### PR DESCRIPTION
So we'll have clients trying to post empty revision 1 bundles for a while. Which is annoying. They'll get blocked by the server since they have no primary accounts.