### PR TITLE
Fix StripRevocations not stripping some revoked keys

### DIFF
--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -172,7 +172,7 @@ func (k *PGPKeyBundle) StripRevocations() (strippedKey *PGPKeyBundle) {
 	strippedKey.Subkeys = nil
 	for _, subkey := range oldSubkeys {
 		// Skip revoked subkeys
-		if subkey.Sig.SigType == packet.SigTypeSubkeyBinding {
+		if subkey.Sig.SigType == packet.SigTypeSubkeyBinding && subkey.Revocation == nil {
 			strippedKey.Subkeys = append(strippedKey.Subkeys, subkey)
 		}
 	}


### PR DESCRIPTION
In certain cases, depedning on the ordering of signatures, StripRevocations was not skipping subkeys that have revocation sigs. This only affected users who updated pgp key without pgp_update links.