### PR TITLE
Fix for new chat selected the second one

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -281,7 +281,12 @@ export const createMessagesWereDeleted = (
     ordinals?: Array<Types.Ordinal>,
   |}>
 ) => ({error: false, payload, type: messagesWereDeleted})
-export const createMetaDelete = (payload: $ReadOnly<{|conversationIDKey: Types.ConversationIDKey|}>) => ({error: false, payload, type: metaDelete})
+export const createMetaDelete = (
+  payload: $ReadOnly<{|
+    conversationIDKey: Types.ConversationIDKey,
+    selectSomethingElse: boolean,
+  |}>
+) => ({error: false, payload, type: metaDelete})
 export const createMetaHandleQueue = () => ({error: false, payload: undefined, type: metaHandleQueue})
 export const createMetaNeedsUpdating = (
   payload: $ReadOnly<{|

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -317,14 +317,20 @@ const chatActivityToMetasAction = (payload: ?{+conv?: ?RPCChatTypes.InboxUIItem}
       RPCChatTypes.commonConversationStatus.reported,
     ].includes(conv.status) ||
       conv.isEmpty)
+
+  // We want to select a different convo if its cause we ignored/blocked/reported. Otherwise sometimes we get that a convo
+  // is empty which we don't want to select something else as sometimes we're in the middle of making it!
+  const selectSomethingElse = isADelete && !conv.isEmpty
   return meta
     ? [
         isADelete
-          ? Chat2Gen.createMetaDelete({conversationIDKey: meta.conversationIDKey})
+          ? Chat2Gen.createMetaDelete({conversationIDKey: meta.conversationIDKey, selectSomethingElse})
           : Chat2Gen.createMetasReceived({metas: [meta]}),
         UsersGen.createUpdateFullnames({usernameToFullname}),
       ]
-    : conversationIDKey && isADelete ? [Chat2Gen.createMetaDelete({conversationIDKey})] : []
+    : conversationIDKey && isADelete
+      ? [Chat2Gen.createMetaDelete({conversationIDKey, selectSomethingElse})]
+      : []
 }
 
 // We got errors from the service
@@ -1146,6 +1152,9 @@ const selectTheNewestConversation = (
   state: TypedState
 ) => {
   if (action.type === Chat2Gen.metaDelete) {
+    if (!action.payload.selectSomethingElse) {
+      return
+    }
     // only do this if we blocked the current conversation
     if (Constants.getSelectedConversation(state) !== action.payload.conversationIDKey) {
       return

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -104,6 +104,7 @@
     // We got a status update saying it was blocked or ignored
     "metaDelete": {
       "conversationIDKey": "Types.ConversationIDKey",
+      "selectSomethingElse": "boolean",
     },
     // We updated our view of a thread
     "metaUpdatePagination": {


### PR DESCRIPTION
@keybase/react-hackers there was a race where:

1. You create  new conversation
2. We make it and wait to get the conversationidkey back
3. We post to it

Additionally we have some logic to ensure you have a selected conversation on desktop. This is so if you have a selected conversation and you block it or were blocked or leave the team or etc we'd select the newest conversation. 
In this flow after step 1 happens we get an incoming message about the new inbox item, but its isEmpty flag is true, so we went through this flow.

Instead I added a new flag to say we want this reselect behavior  and only do it when its due to blocking / ignoring etc and not due to isEmpty