### PR TITLE
make Env.GetMountDir() return emtpy by default on windows

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -255,6 +255,9 @@ func (e *Env) GetMountDir() (string, error) {
 					"%s (%s)", runmodeName, user.Username))
 			case "linux":
 				return filepath.Join(e.GetRuntimeDir(), "kbfs")
+			// kbfsdokan depends on an empty default
+			case "windows":
+				return ""
 			default:
 				return filepath.Join(e.GetRuntimeDir(), "kbfs")
 			}


### PR DESCRIPTION
this broke fresh installs. Building a test installer now but I'm confident this will do it.