### PR TITLE
app: record installer error text in a new file

### DIFF
--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -10,6 +10,7 @@ import {
   ExitCodeAuthCanceledError,
 } from '../../constants/favorite'
 import UserData from './user-data'
+import fs from 'fs'
 
 import type {InstallResult} from '../../constants/types/rpc-gen'
 
@@ -59,6 +60,8 @@ export default (callback: (err: any) => void): void => {
       hasFUSEError: false,
       hasKBNMError: false,
     }
+    let stdoutResult = stdout
+    let stderrResult = stderr
     if (err) {
       errorsResult.errors = [`There was an error trying to run the install (${err.code}).`]
     } else if (stdout !== '') {
@@ -77,6 +80,7 @@ export default (callback: (err: any) => void): void => {
     }
 
     if (errorsResult.errors.length > 0) {
+      fs.appendFileSync('/tmp/kbfs-install-error.txt', `Install errors: stdout=${stdoutResult}, stderr=${stderrResult}\n`)
       showError(errorsResult.errors, errorsResult.hasFUSEError || errorsResult.hasKBNMError, callback)
       return
     }


### PR DESCRIPTION
Neither `console.log()` and `logger.info()` seems to work for the install unless you start it from the command line, and this error text is needed to help debug a rare issue that can't be reproduced from the command line (I've tried in a script continuously for the past day).

So, until normal logging works in installer.js, write the errors (when they occur) to a temp file that we can ask users to send us separately from their `keybase log send`.  Hopefully an admin build user will find the error before we even need to make this public.