### PR TITLE
use git rev-parse --short=8 on windows

### DIFF
--- a/packaging/windows/build_prerelease.cmd
+++ b/packaging/windows/build_prerelease.cmd
@@ -27,7 +27,7 @@ pushd %GOPATH%\src\github.com\keybase\kbfs\kbfsdokan
 :: Make sure the whole build fails if we can't build kbfsdokan
 del kbfsdokan.exe
 :: winresource invokes git to get the current revision
-for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\kbfs rev-parse --short HEAD') do set KBFS_HASH=%%i
+for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\kbfs rev-parse=8 --short HEAD') do set KBFS_HASH=%%i
 for /f "tokens=1 delims=+" %%i in ("%KEYBASE_BUILD%") do set KBFS_BUILD=%%i+%KBFS_HASH%
 echo KBFS_BUILD %KBFS_BUILD%
 set CGO_ENABLED=1

--- a/packaging/windows/dorelease.cmd
+++ b/packaging/windows/dorelease.cmd
@@ -157,8 +157,8 @@ goto:eof
 EXIT /B 1
 
 :check_ci 
-for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\client rev-parse --short HEAD') do set clientCommit=%%i
-for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\kbfs rev-parse --short HEAD') do set kbfsCommit=%%i
+for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\client rev-parse=8 --short HEAD') do set clientCommit=%%i
+for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\kbfs rev-parse=8 --short HEAD') do set kbfsCommit=%%i
 echo [%clientCommit%] [%kbfsCommit%]
 :: need GITHUB_TOKEN
 pushd %GOPATH%\src\github.com\keybase\release


### PR DESCRIPTION
Github suddenly stopped working with a commit hash of 7 chars, which seems to be the default short length on slightly older versions of Git. This seems to make CI pass again until we update the build machine(s).