### PR TITLE
typo in 8 char rev-parse

### DIFF
--- a/packaging/windows/build_prerelease.cmd
+++ b/packaging/windows/build_prerelease.cmd
@@ -27,7 +27,7 @@ pushd %GOPATH%\src\github.com\keybase\kbfs\kbfsdokan
 :: Make sure the whole build fails if we can't build kbfsdokan
 del kbfsdokan.exe
 :: winresource invokes git to get the current revision
-for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\kbfs rev-parse=8 --short HEAD') do set KBFS_HASH=%%i
+for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\kbfs rev-parse --short=8 HEAD') do set KBFS_HASH=%%i
 for /f "tokens=1 delims=+" %%i in ("%KEYBASE_BUILD%") do set KBFS_BUILD=%%i+%KBFS_HASH%
 echo KBFS_BUILD %KBFS_BUILD%
 set CGO_ENABLED=1

--- a/packaging/windows/dorelease.cmd
+++ b/packaging/windows/dorelease.cmd
@@ -157,8 +157,8 @@ goto:eof
 EXIT /B 1
 
 :check_ci 
-for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\client rev-parse=8 --short HEAD') do set clientCommit=%%i
-for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\kbfs rev-parse=8 --short HEAD') do set kbfsCommit=%%i
+for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\client rev-parse --short=8 HEAD') do set clientCommit=%%i
+for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\kbfs rev-parse --short=8 HEAD') do set kbfsCommit=%%i
 echo [%clientCommit%] [%kbfsCommit%]
 :: need GITHUB_TOKEN
 pushd %GOPATH%\src\github.com\keybase\release


### PR DESCRIPTION
Sorry, team, I crossed my wires on which bot options build with CI. Previous branch was wrong - I had thought it passed CI when it hadn't. Looks like the winbot only does CI for smoke pairs right now, which I will change soon.