### PR TITLE
credential authority can now support deleted users

### DIFF
--- a/go/auth/credential_authority_test.go
+++ b/go/auth/credential_authority_test.go
@@ -103,15 +103,15 @@ func (e userNotFoundError) Error() string {
 }
 
 func (ts *testState) GetUser(_ context.Context, uid keybase1.UID) (
-	un libkb.NormalizedUsername, sibkeys, subkeys []keybase1.KID, err error) {
+	un libkb.NormalizedUsername, sibkeys, subkeys []keybase1.KID, isDeleted bool, err error) {
 	ts.Lock()
 	defer ts.Unlock()
 	u := ts.users[uid]
 	if u == nil {
-		return libkb.NormalizedUsername(""), nil, nil, userNotFoundError{}
+		return libkb.NormalizedUsername(""), nil, nil, false, userNotFoundError{}
 	}
 	ts.numGets++
-	return u.username, u.sibkeys, u.subkeys, nil
+	return u.username, u.sibkeys, u.subkeys, false, nil
 }
 
 func (ts *testState) PollForChanges(_ context.Context) ([]keybase1.UID, error) {
@@ -163,14 +163,14 @@ func TestSimple(t *testing.T) {
 		t.Fatal("expected 0 gets")
 	}
 
-	err := credentialAuthority.CheckUserKey(context.TODO(), u0.uid, &u0.username, &key0)
+	err := credentialAuthority.CheckUserKey(context.TODO(), u0.uid, &u0.username, &key0, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if state.numGets != 1 {
 		t.Fatal("expected 1 get")
 	}
-	err = credentialAuthority.CheckUserKey(context.TODO(), u0.uid, &u0.username, &key0)
+	err = credentialAuthority.CheckUserKey(context.TODO(), u0.uid, &u0.username, &key0, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestSimple(t *testing.T) {
 		t.Fatalf("Wrong UID on eviction: %s != %s\n", uid, u0.uid)
 	}
 
-	err = credentialAuthority.CheckUserKey(context.TODO(), u0.uid, &u0.username, &key0)
+	err = credentialAuthority.CheckUserKey(context.TODO(), u0.uid, &u0.username, &key0, false)
 	if err == nil {
 		t.Fatal("Expected an error")
 	} else if bke, ok := err.(BadKeyError); !ok {
@@ -203,7 +203,7 @@ func TestSimple(t *testing.T) {
 		t.Fatalf("Expected a bad key error on key %s (not %s)", key0, bke.kid)
 	}
 
-	err = credentialAuthority.CheckUserKey(context.TODO(), u0.uid, &u0.username, &key1)
+	err = credentialAuthority.CheckUserKey(context.TODO(), u0.uid, &u0.username, &key1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestSimple(t *testing.T) {
 		t.Fatal("expected 2 gets")
 	}
 	state.tick(userTimeout + time.Millisecond)
-	err = credentialAuthority.CheckUserKey(context.TODO(), u0.uid, &u0.username, &key1)
+	err = credentialAuthority.CheckUserKey(context.TODO(), u0.uid, &u0.username, &key1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,7 +232,7 @@ func TestSimple(t *testing.T) {
 
 	ng := 3
 	for i := 0; i < 10; i++ {
-		err = credentialAuthority.CheckUserKey(context.TODO(), u1.uid, &u1.username, &u1.sibkeys[0])
+		err = credentialAuthority.CheckUserKey(context.TODO(), u1.uid, &u1.username, &u1.sibkeys[0], false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -257,7 +257,7 @@ func TestSimple(t *testing.T) {
 
 	// Make a new user -- u2!
 	u2 := state.newTestUser(4)
-	err = credentialAuthority.CheckUserKey(context.TODO(), u2.uid, &u2.username, &u2.sibkeys[0])
+	err = credentialAuthority.CheckUserKey(context.TODO(), u2.uid, &u2.username, &u2.sibkeys[0], false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -335,18 +335,14 @@ func TestCompareKeys(t *testing.T) {
 
 	missingSibkey := u.sibkeys[1:]
 	err = credentialAuthority.CompareUserKeys(context.TODO(), u.uid, missingSibkey, u.subkeys)
-	if err == nil {
-		t.Fatal("Expected an error")
-	} else if _, ok := err.(KeysNotEqualError); !ok {
-		t.Fatal("Expected keys not equal error")
+	if err != ErrKeysNotEqual {
+		t.Fatal("Expected an ErrKeysNotEqual")
 	}
 
 	missingSubkey := u.subkeys[1:]
 	err = credentialAuthority.CompareUserKeys(context.TODO(), u.uid, u.sibkeys, missingSubkey)
-	if err == nil {
-		t.Fatal("Expected an error")
-	} else if _, ok := err.(KeysNotEqualError); !ok {
-		t.Fatal("Expected keys not equal error")
+	if err != ErrKeysNotEqual {
+		t.Fatal("Expected an ErrKeysNotEqual")
 	}
 	credentialAuthority.Shutdown()
 }

--- a/go/auth/errors.go
+++ b/go/auth/errors.go
@@ -10,6 +10,9 @@ import (
 // ErrShutdown is raised when an operation is pending but the CA is shutting down
 var ErrShutdown = errors.New("shutting down")
 
+// ErrUserDeleted is raised when a user is deleted, but was loaded without the loadDeleted flag
+var ErrUserDeleted = errors.New("user was deleted")
+
 // BadUsernameError is raised when the given username disagreeds with the expected
 // username
 type BadUsernameError struct {
@@ -31,13 +34,8 @@ func (e BadKeyError) Error() string {
 	return fmt.Sprintf("Bad key error: %s not active for %s", e.kid, e.uid)
 }
 
-// KeysNotEqualError is raised when compared keys sets aren't equal.
-type KeysNotEqualError struct {
-}
-
-func (e KeysNotEqualError) Error() string {
-	return "Keys not equal"
-}
+// ErrKeysNotEqual is raised when compared keys sets aren't equal.
+var ErrKeysNotEqual = errors.New("keys not equal")
 
 // InvalidTokenTypeError is raised when the given token is not of the expected type.
 type InvalidTokenTypeError struct {

--- a/go/client/cmd_ca.go
+++ b/go/client/cmd_ca.go
@@ -45,8 +45,8 @@ func (c *CmdCA) runPromptLoop() error {
 			break
 		}
 		v := re.Split(s, -1)
-		if len(v) != 3 {
-			c.G().Log.Errorf("Need a triple: [<uid>,<username>,<kid>]")
+		if len(v) != 4 {
+			c.G().Log.Errorf("Need a quad: [<uid>,<username>,<loadDeleted>,<kid>]")
 			continue
 		}
 
@@ -58,13 +58,22 @@ func (c *CmdCA) runPromptLoop() error {
 
 		un := libkb.NewNormalizedUsername(v[1])
 
-		kid, e2 := keybase1.KIDFromStringChecked(v[2])
+		kid, e2 := keybase1.KIDFromStringChecked(v[3])
 		if e2 != nil {
-			c.G().Log.Errorf("Bad KID %s: %s", v[2], e2)
+			c.G().Log.Errorf("Bad KID %s: %s", v[3], e2)
 			continue
 		}
+		loadDeleted := false
+		switch v[2] {
+		case "1", "true":
+			loadDeleted = true
+		case "0", "false":
+		default:
+			c.G().Log.Errorf("Bad loadDeleted value: %s", v[2])
 
-		if e2 := ca.CheckUserKey(context.TODO(), uid, &un, &kid); e2 != nil {
+		}
+
+		if e2 := ca.CheckUserKey(context.TODO(), uid, &un, &kid, loadDeleted); e2 != nil {
 			c.G().Log.Errorf("Bad check: %s", e2)
 		}
 


### PR DESCRIPTION
- pass `loadDeleted` to `CheckUserKeys`, and if true, we'll load deleted users, and report them as being deleted if they load