### PR TITLE
bring back missing methods

### DIFF
--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -32,6 +32,11 @@ class Input extends Component<Props, State> {
     }
   }
 
+  // Does nothing on mobile
+  select = () => {}
+  // Does nothing on mobile
+  moveCursorToEnd = () => {}
+
   // Needed to support wrapping with e.g. a ClickableBox. See
   // https://facebook.github.io/react-native/docs/direct-manipulation.html .
   setNativeProps = (nativeProps: Object) => {


### PR DESCRIPTION
input.js.flow claims we have select() in input but that was removed here:
https://github.com/keybase/client/commit/23a7700fbd106ad327e93f481e36a4915fadac9b#diff-5123e2ec6128a6a4cb1b681361bdf0c9L106

this fixes that (fixes the crash when adding atachments)
@keybase/react-hackers 
cc: @akalin 