### PR TITLE
Bring back types inheriting from Error

### DIFF
--- a/shared/actions/search.js
+++ b/shared/actions/search.js
@@ -11,6 +11,7 @@ import * as Selectors from '../constants/selectors'
 import isEqual from 'lodash/isEqual'
 import keyBy from 'lodash/keyBy'
 import trim from 'lodash/trim'
+import {SearchError} from '../util/errors'
 import {onIdlePromise} from '../util/idle-callback'
 import {serviceIdToIcon, serviceIdToLogo24} from '../util/platforms'
 
@@ -91,7 +92,7 @@ function _parseKeybaseRawResult(result: RawResult): Types.SearchResult {
     }
   }
 
-  throw new Error(`Invalid raw result for keybase. Missing result.keybase ${JSON.stringify(result)}`)
+  throw new SearchError(`Invalid raw result for keybase. Missing result.keybase ${JSON.stringify(result)}`)
 }
 
 function _parseThirdPartyRawResult(result: RawResult): Types.SearchResult {
@@ -125,7 +126,9 @@ function _parseThirdPartyRawResult(result: RawResult): Types.SearchResult {
     }
   }
 
-  throw new Error(`Invalid raw result for service search. Missing result.service ${JSON.stringify(result)}`)
+  throw new SearchError(
+    `Invalid raw result for service search. Missing result.service ${JSON.stringify(result)}`
+  )
 }
 
 function _parseRawResultToRow(result: RawResult, service: Types.Service) {

--- a/shared/constants/engine.js
+++ b/shared/constants/engine.js
@@ -9,6 +9,7 @@ import * as SagaTypes from './types/saga'
 import type {Channel} from 'redux-saga'
 import {getEngine, EngineChannel} from '../engine'
 import mapValues from 'lodash/mapValues'
+import {RPCTimeoutError} from '../util/errors'
 
 // If a sub saga returns bail early, then the rpc will bail early
 const BailedEarly = {type: '@@engineRPCCall:bailedEarly', payload: undefined}
@@ -168,9 +169,7 @@ class EngineRpcCall {
 
         if (incoming.timeout) {
           yield Saga.call([this, this._cleanup], subSagaTasks)
-          throw new Error(
-            `RPC timeout error on ${this._rpcNameKey}. Had a ttl of: ${timeout || 'Undefined ttl'}`
-          )
+          throw new RPCTimeoutError(this._rpcNameKey, timeout)
         }
 
         if (incoming.finished) {

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -166,6 +166,8 @@ export function dataToRouteState(data: Object): RouteStateNode {
   )
 }
 
+export class InvalidRouteError extends Error {}
+
 // Explicit list of iterable types to accept. We don't want to allow strings
 // since navigateTo('foo') instead of navigateTo(['foo']) is an easy mistake to
 // make.
@@ -206,7 +208,7 @@ function _routeSet(
     // $FlowIssue
     const childDef = routeDef.getChild(childName)
     if (!childDef) {
-      throw new Error(`RT: Invalid route child: ${childName}`)
+      throw new InvalidRouteError(`Invalid route child: ${childName}`)
     }
 
     newRouteState = newRouteState.updateChild(childName, childState => {
@@ -267,7 +269,7 @@ export function routeSetState(
   // $FlowIssue
   return routeState.updateChild(name, childState => {
     if (!childState) {
-      throw new Error(`RT: Missing state child: ${name || 'undefined'}`)
+      throw new InvalidRouteError(`Missing state child: ${name || 'undefined'}`)
     }
     return routeSetState(routeDef, childState, pathSeq.skip(1), partialState)
   })

--- a/shared/util/errors.js
+++ b/shared/util/errors.js
@@ -1,6 +1,6 @@
 // @flow
 
-export class RPCError {
+export class RPCError extends Error {
   message: string
   code: number // Consult type StatusCode in rpc-gen.js for what this means
   fields: any
@@ -9,7 +9,7 @@ export class RPCError {
   details: string // Details w/ error code & method if it's present
 
   constructor(message: string, code: number, fields: any, name: ?string, method: ?string) {
-    this.message = paramsToErrorMsg(message, code, fields, name, method)
+    super(paramsToErrorMsg(message, code, fields, name, method))
     this.code = code // Consult type StatusCode in rpc-gen.js for what this means
     this.fields = fields
     this.desc = message
@@ -53,12 +53,8 @@ export function convertToError(err: Object, method?: string): Error {
     return err
   }
 
-  if (err instanceof RPCError) {
-    return new Error(err.message)
-  }
-
   if (err.hasOwnProperty('desc') && err.hasOwnProperty('code')) {
-    return new Error(convertToRPCError(err, method).message)
+    return convertToRPCError(err, method)
   }
 
   return new Error(`Unknown error: ${JSON.stringify(err)}`)

--- a/shared/util/errors.js
+++ b/shared/util/errors.js
@@ -29,6 +29,10 @@ export class RPCTimeoutError extends Error {
   }
 }
 
+export class ValidationError extends Error {}
+
+export class SearchError extends Error {}
+
 const paramsToErrorDetails = (code: number, name: ?string, method: ?string) => {
   let res = `Error code ${code}`
   if (name) {

--- a/shared/util/errors.js
+++ b/shared/util/errors.js
@@ -18,6 +18,17 @@ export class RPCError extends Error {
   }
 }
 
+export class RPCTimeoutError extends Error {
+  ttl: ?number
+  rpcName: string
+
+  constructor(rpcName: string, ttl: ?number) {
+    super(`RPC timeout error on ${rpcName}. Had a ttl of: ${ttl || 'Undefined ttl'}`)
+    this.ttl = ttl
+    this.rpcName = rpcName
+  }
+}
+
 const paramsToErrorDetails = (code: number, name: ?string, method: ?string) => {
   let res = `Error code ${code}`
   if (name) {

--- a/shared/util/simple-validators.js
+++ b/shared/util/simple-validators.js
@@ -1,5 +1,6 @@
 // @flow
 import trim from 'lodash/trim'
+import {ValidationError} from './errors'
 
 function isBlank(s: string): boolean {
   return trim(s).length === 0
@@ -26,8 +27,8 @@ function isEmptyOrBlank(thing: ?string): boolean {
 
 // Returns an error string if not valid
 function isValidCommon(thing: ?string): ?Error {
-  if (isEmptyOrBlank(thing)) return new Error('Cannot be blank')
-  if (thing && hasSpaces(thing)) return new Error('No spaces allowed')
+  if (isEmptyOrBlank(thing)) return new ValidationError('Cannot be blank')
+  if (thing && hasSpaces(thing)) return new ValidationError('No spaces allowed')
 }
 
 // Returns an error string if not valid
@@ -37,7 +38,7 @@ function isValidUsername(username: ?string): ?Error {
     return commonError
   }
   if (username && hasPeriod(username)) {
-    return new Error("Usernames can't contain periods.")
+    return new ValidationError("Usernames can't contain periods.")
   }
 }
 
@@ -49,13 +50,13 @@ function isValidEmail(email: ?string): ?Error {
   }
 
   if (email && !hasAtSign(email)) {
-    return new Error('Invalid email address.')
+    return new ValidationError('Invalid email address.')
   }
 }
 
 // Returns an error string if not valid
 function isValidName(name: ?string): ?Error {
-  if (isEmptyOrBlank(name)) return new Error('Please provide your name.')
+  if (isEmptyOrBlank(name)) return new ValidationError('Please provide your name.')
 }
 
 export {isValidUsername, isValidEmail, isValidName}


### PR DESCRIPTION
In particular, make RPCError inherit from Error and throw those around.

This fixes all the places that expect RPC errors to have the desc field and others.