### PR TITLE
only send updates if the appstate changes

### DIFF
--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -93,8 +93,10 @@ func (b *BackgroundConvLoader) monitorAppState() {
 			}
 		case keybase1.AppState_BACKGROUND:
 			b.Debug(ctx, "monitorAppState: backgrounded, suspending load thread")
-			b.Suspend(ctx)
-			suspended = true
+			if !suspended {
+				b.Suspend(ctx)
+				suspended = true
+			}
 		}
 		if b.appStateCh != nil {
 			b.appStateCh <- struct{}{}

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -152,8 +152,8 @@ func TestConvLoaderAppState(t *testing.T) {
 	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
 	select {
 	case <-appStateCh:
-	case <-time.After(failDuration):
 		require.Fail(t, "no app state")
+	default:
 	}
 	select {
 	case <-listener.bgConvLoads:

--- a/go/libkb/appstate.go
+++ b/go/libkb/appstate.go
@@ -43,9 +43,14 @@ func (a *AppState) Update(state keybase1.AppState) {
 	a.Lock()
 	defer a.Unlock()
 	defer a.G().Trace(fmt.Sprintf("AppState.Update(%v)", state), func() error { return nil })()
-	a.state = state
-	for _, ch := range a.updateChs {
-		ch <- state
+	if a.state != state {
+		a.state = state
+		for _, ch := range a.updateChs {
+			ch <- state
+		}
+	} else {
+		a.G().Log.Debug("AppState.Update: ignoring update: %v, we are currently in state: %v",
+			state, a.state)
 	}
 	a.updateChs = nil
 }

--- a/go/libkb/appstate.go
+++ b/go/libkb/appstate.go
@@ -44,15 +44,17 @@ func (a *AppState) Update(state keybase1.AppState) {
 	defer a.Unlock()
 	defer a.G().Trace(fmt.Sprintf("AppState.Update(%v)", state), func() error { return nil })()
 	if a.state != state {
+		a.G().Log.Debug("AppState.Update: useful update: %v, we are currently in state: %v",
+			state, a.state)
 		a.state = state
 		for _, ch := range a.updateChs {
 			ch <- state
 		}
+		a.updateChs = nil
 	} else {
 		a.G().Log.Debug("AppState.Update: ignoring update: %v, we are currently in state: %v",
 			state, a.state)
 	}
-	a.updateChs = nil
 }
 
 // State returns the current app state


### PR DESCRIPTION
I think it is possible we get more notifications we are in the background with the new style of alerts coming from the native code. Don't send any updates to listeners if the state doesn't actually change. 

cc @buoyad 