### PR TITLE
Add a basic bash-completion file.

### DIFF
--- a/completion/bash
+++ b/completion/bash
@@ -1,0 +1,9 @@
+_keybase()
+{
+    COMPREPLY=()
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    completions=$(${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion)
+    COMPREPLY=( $(compgen -W "$completions" -- "$cur") )
+    return 0
+}
+complete -F _keybase keybase


### PR DESCRIPTION
This uses the --generate-bash completion flag to complete commands and
subcommands.

Resolves #4004.

Also see:
https://github.com/keybase/keybase-issues/issues/147

Let me know if there is a preferred place for a file like this.