### PR TITLE
hack around electron limitations detecting start menu placement

### DIFF
--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -17,7 +17,8 @@ type State = {
   promptedForCLI: boolean,
 }
 class InstallerData extends UserData<State> {}
-const installerState = new InstallerData('installer.json', {promptedForCLI: false})
+// prevent error spewage on windows
+const installerState = isWindows ? null : new InstallerData('installer.json', {promptedForCLI: false})
 
 type CheckErrorsResult = {
   errors: Array<string>,

--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -17,8 +17,16 @@ type State = {
   promptedForCLI: boolean,
 }
 class InstallerData extends UserData<State> {}
-// prevent error spewage on windows
-const installerState = isWindows ? null : new InstallerData('installer.json', {promptedForCLI: false})
+// prevent error spewage on windows by not instantiating
+// InstallerData. Flow seems to require this fake stub.
+const installerState = isWindows
+  ? {
+      save: () => {},
+      state: {
+        promptedForCLI: false,
+      },
+    }
+  : new InstallerData('installer.json', {promptedForCLI: false})
 
 type CheckErrorsResult = {
   errors: Array<string>,

--- a/shared/desktop/app/menu-bar.js
+++ b/shared/desktop/app/menu-bar.js
@@ -91,7 +91,7 @@ export default function(menubarWindowIDCallback: (id: number) => void) {
 
     mb.on('show', () => {
       // Account for different taskbar positions on Windows
-      if (isWindows) {
+      if (isWindows && mb.window && mb.tray) {
         const cursorPoint = electronScreen.getCursorScreenPoint()
         const screenSize = electronScreen.getDisplayNearestPoint(cursorPoint).workArea
         let menuBounds = mb.window.getBounds()


### PR DESCRIPTION
and fix the console startup error on Windows while I'm at it.

Electron seems to have stopped registering a different work area than the desktop area, which is how our previous hack detected start menu position.