### PR TITLE
Show all user's accounts in `keybase wallet balances`

### DIFF
--- a/go/client/cmd_wallet_balances.go
+++ b/go/client/cmd_wallet_balances.go
@@ -70,9 +70,9 @@ func (c *cmdWalletBalances) runForUser(cli stellar1.LocalClient) error {
 		if acc.Name != "" {
 			var isPrimary string
 			if acc.IsPrimary {
-				isPrimary = ", Primary"
+				isPrimary = ", primary"
 			}
-			accountName = fmt.Sprintf("%s (%q%s)", acc.Name, acc.AccountID.String(), isPrimary)
+			accountName = fmt.Sprintf("%s (%s%s)", acc.Name, acc.AccountID.String(), isPrimary)
 		} else {
 			accountName = acc.AccountID.String()
 			if acc.IsPrimary {

--- a/go/protocol/stellar1/extras.go
+++ b/go/protocol/stellar1/extras.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -118,4 +119,14 @@ func AssetNative() Asset {
 		Code:   "",
 		Issuer: "",
 	}
+}
+
+func (b LocalExchangeRate) ConvertXLM(XLMAmount string) (localAmount string, err error) {
+	local, err := strconv.ParseFloat(XLMAmount, 64)
+	if err != nil {
+		return "", err
+	}
+
+	localAmount = strconv.FormatFloat(float64(b)*local, 'f', 2, 64)
+	return localAmount, nil
 }

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -99,6 +99,9 @@ type WalletInitLocalArg struct {
 type WalletDumpLocalArg struct {
 }
 
+type WalletGetPublicKeysArg struct {
+}
+
 type OwnAccountLocalArg struct {
 	AccountID AccountID `codec:"accountID" json:"accountID"`
 }
@@ -119,6 +122,7 @@ type LocalInterface interface {
 	RecentPaymentsCLILocal(context.Context, *AccountID) ([]RecentPaymentCLILocal, error)
 	WalletInitLocal(context.Context) error
 	WalletDumpLocal(context.Context) (Bundle, error)
+	WalletGetPublicKeys(context.Context) ([]BundleEntry, error)
 	OwnAccountLocal(context.Context, AccountID) (bool, error)
 	ImportSecretKeyLocal(context.Context, ImportSecretKeyLocalArg) error
 	SetDisplayCurrency(context.Context, SetDisplayCurrencyArg) error
@@ -194,6 +198,17 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
 					ret, err = i.WalletDumpLocal(ctx)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"walletGetPublicKeys": {
+				MakeArg: func() interface{} {
+					ret := make([]WalletGetPublicKeysArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.WalletGetPublicKeys(ctx)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -278,6 +293,11 @@ func (c LocalClient) WalletInitLocal(ctx context.Context) (err error) {
 
 func (c LocalClient) WalletDumpLocal(ctx context.Context) (res Bundle, err error) {
 	err = c.Cli.Call(ctx, "stellar.1.local.walletDumpLocal", []interface{}{WalletDumpLocalArg{}}, &res)
+	return
+}
+
+func (c LocalClient) WalletGetPublicKeys(ctx context.Context) (res []BundleEntry, err error) {
+	err = c.Cli.Call(ctx, "stellar.1.local.walletGetPublicKeys", []interface{}{WalletGetPublicKeysArg{}}, &res)
 	return
 }
 

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -324,16 +324,6 @@ type XLMExchangeRate struct {
 	Currency string
 }
 
-func (b *XLMExchangeRate) ConvertXLM(XLMAmount string) (localAmount string, err error) {
-	local, err := strconv.ParseFloat(XLMAmount, 64)
-	if err != nil {
-		return "", err
-	}
-
-	localAmount = strconv.FormatFloat(b.Price*local, 'f', 2, 64)
-	return localAmount, nil
-}
-
 func ExchangeRate(ctx context.Context, g *libkb.GlobalContext, currency string) (XLMExchangeRate, error) {
 	apiArg := libkb.APIArg{
 		Endpoint:    "stellar/ticker",

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -113,7 +113,7 @@ func BalanceXLM(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.
 	}
 
 	for _, b := range balances {
-		if b.Asset.Type == "native" {
+		if b.Asset.IsNativeXLM() {
 			return b, nil
 		}
 	}

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -39,51 +39,14 @@ func (s *Server) logTag(ctx context.Context) context.Context {
 	return libkb.WithLogTag(ctx, "WA")
 }
 
-func (s *Server) BalancesLocal(ctx context.Context, accountID stellar1.AccountID) (ret []stellar1.LocalBalance, err error) {
+func (s *Server) BalancesLocal(ctx context.Context, accountID stellar1.AccountID) (ret []stellar1.Balance, err error) {
 	ctx = s.logTag(ctx)
 	defer s.G().CTraceTimed(ctx, "BalancesLocal", func() error { return err })()
 	if err = s.assertLoggedIn(ctx); err != nil {
 		return nil, err
 	}
 
-	balances, err := remote.Balances(ctx, s.G(), accountID)
-	if err != nil {
-		return nil, err
-	}
-
-	displayCurrency, err := remote.GetAccountDisplayCurrency(ctx, s.G(), accountID)
-	if err != nil {
-		s.G().Log.Warning("Could not get default currency for account %q: %s", accountID, err)
-		err = nil
-	}
-
-	var exchangeRateAvailable bool
-	var rate remote.XLMExchangeRate
-	if displayCurrency != "" {
-		rate, err = remote.ExchangeRate(ctx, s.G(), displayCurrency)
-		if err == nil {
-			exchangeRateAvailable = true
-		} else {
-			s.G().Log.Warning("Could not obtain exchange rate: %s", err)
-			err = nil
-		}
-	}
-
-	for _, b := range balances {
-		local := stellar1.LocalBalance{Balance: b}
-		if exchangeRateAvailable && local.Balance.Asset.Type == "native" {
-			converted, err := rate.ConvertXLM(local.Balance.Amount)
-			if err == nil {
-				local.Currency = rate.Currency
-				local.Value = converted
-			} else {
-				s.G().Log.Warning("Could not convert XLM balance to local currency: %s", err)
-			}
-
-		}
-		ret = append(ret, local)
-	}
-	return ret, err
+	return remote.Balances(ctx, s.G(), accountID)
 }
 
 func (s *Server) ImportSecretKeyLocal(ctx context.Context, arg stellar1.ImportSecretKeyLocalArg) (err error) {
@@ -255,20 +218,59 @@ func (s *Server) SetDisplayCurrency(ctx context.Context, arg stellar1.SetDisplay
 	return remote.SetAccountDefaultCurrency(ctx, s.G(), arg.AccountID, arg.Currency)
 }
 
-func (s *Server) WalletGetPublicKeys(ctx context.Context) (ret []stellar1.BundleEntry, err error) {
+func getLocalCurrencyAndExchangeRate(ctx context.Context, g *libkb.GlobalContext, account *stellar1.LocalOwnAccount) error {
+	displayCurrency, err := remote.GetAccountDisplayCurrency(ctx, g, account.AccountID)
+	if err != nil {
+		return err
+	}
+
+	if displayCurrency == "" {
+		return nil
+	}
+
+	rate, err := remote.ExchangeRate(ctx, g, displayCurrency)
+	if err != nil {
+		return err
+	}
+
+	account.LocalCurrency = stellar1.LocalCurrencyCode(rate.Currency)
+	account.LocalExchangeRate = stellar1.LocalExchangeRate(rate.Price)
+	return nil
+}
+
+func (s *Server) WalletGetLocalAccounts(ctx context.Context) (ret []stellar1.LocalOwnAccount, err error) {
 	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "WalletGetPublicKeys", func() error { return err })()
+	defer s.G().CTraceTimed(ctx, "WalletGetLocalAccounts", func() error { return err })()
 
 	dump, _, err := remote.Fetch(ctx, s.G())
 	if err != nil {
 		return nil, err
 	}
 
-	for _, entry := range dump.Accounts {
-		// Clear private part of BundleEntry before returning to the
-		// caller.
-		entry.Signers = []stellar1.SecretKey{}
-		ret = append(ret, entry)
+	var accountError error
+	for _, account := range dump.Accounts {
+		accID := account.AccountID
+		acc := stellar1.LocalOwnAccount{
+			AccountID: accID,
+			IsPrimary: account.IsPrimary,
+			Name:      account.Name,
+		}
+
+		balances, err := remote.Balances(ctx, s.G(), accID)
+		if err != nil {
+			accountError = err
+			s.G().Log.Warning("Could not load balance for %q", accID)
+			continue
+		}
+
+		acc.Balance = balances
+
+		if err := getLocalCurrencyAndExchangeRate(ctx, s.G(), &acc); err != nil {
+			s.G().Log.Warning("Could not load local currency exchange rate for %q", accID)
+		}
+
+		ret = append(ret, acc)
 	}
-	return ret, nil
+
+	return ret, accountError
 }

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -254,3 +254,21 @@ func (s *Server) SetDisplayCurrency(ctx context.Context, arg stellar1.SetDisplay
 	}
 	return remote.SetAccountDefaultCurrency(ctx, s.G(), arg.AccountID, arg.Currency)
 }
+
+func (s *Server) WalletGetPublicKeys(ctx context.Context) (ret []stellar1.BundleEntry, err error) {
+	ctx = s.logTag(ctx)
+	defer s.G().CTraceTimed(ctx, "WalletGetPublicKeys", func() error { return err })()
+
+	dump, _, err := remote.Fetch(ctx, s.G())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range dump.Accounts {
+		// Clear private part of BundleEntry before returning to the
+		// caller.
+		entry.Signers = []stellar1.SecretKey{}
+		ret = append(ret, entry)
+	}
+	return ret, nil
+}

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -220,7 +220,11 @@ func (s *Server) SetDisplayCurrency(ctx context.Context, arg stellar1.SetDisplay
 
 type exchangeRateMap map[string]remote.XLMExchangeRate
 
-func getLocalCurrencyAndExchangeRate(ctx context.Context, g *libkb.GlobalContext, account *stellar1.LocalOwnAccount, rates exchangeRateMap) error {
+// getLocalCurrencyAndExchangeRate gets display currency setting
+// for accountID and fetches exchange rate is set.
+//
+// Arguments `account` and `exchangeRates` may end up mutated.
+func getLocalCurrencyAndExchangeRate(ctx context.Context, g *libkb.GlobalContext, account *stellar1.LocalOwnAccount, exchangeRates exchangeRateMap) error {
 	displayCurrency, err := remote.GetAccountDisplayCurrency(ctx, g, account.AccountID)
 	if err != nil {
 		return err
@@ -230,14 +234,14 @@ func getLocalCurrencyAndExchangeRate(ctx context.Context, g *libkb.GlobalContext
 		return nil
 	}
 
-	rate, ok := rates[displayCurrency]
+	rate, ok := exchangeRates[displayCurrency]
 	if !ok {
 		var err error
 		rate, err = remote.ExchangeRate(ctx, g, displayCurrency)
 		if err != nil {
 			return err
 		}
-		rates[displayCurrency] = rate
+		exchangeRates[displayCurrency] = rate
 	}
 
 	account.LocalCurrency = stellar1.LocalCurrencyCode(rate.Currency)

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -33,6 +33,7 @@ protocol local {
   void walletInitLocal();
 
   Bundle walletDumpLocal();
+  array<BundleEntry> walletGetPublicKeys();
 
   // Whether this account is one of this user's.
   boolean ownAccountLocal(AccountID accountID);

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -2,14 +2,7 @@
 protocol local {
   import idl "common.avdl";
 
-  // Account balance and its current value in selected currency.
-  record LocalBalance {
-    Balance balance;
-    string currency;
-    string value;
-  }
-
-  array<LocalBalance> balancesLocal(AccountID accountID);
+  array<Balance> balancesLocal(AccountID accountID);
 
   PaymentResult sendLocal(string recipient, string amount, Asset asset, string note);
 
@@ -33,7 +26,21 @@ protocol local {
   void walletInitLocal();
 
   Bundle walletDumpLocal();
-  array<BundleEntry> walletGetPublicKeys();
+
+  @typedef("string") record LocalCurrencyCode {}
+  @typedef("float") record LocalExchangeRate {}
+
+  // Account balance and its current value in selected currency.
+  record LocalOwnAccount {
+    AccountID accountID;
+    boolean isPrimary;
+    string name;
+    array<Balance> balance;
+    LocalCurrencyCode localCurrency;
+    LocalExchangeRate localExchangeRate;
+  }
+
+  array<LocalOwnAccount> walletGetLocalAccounts();
 
   // Whether this account is one of this user's.
   boolean ownAccountLocal(AccountID accountID);

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -149,6 +149,13 @@
       "request": [],
       "response": "Bundle"
     },
+    "walletGetPublicKeys": {
+      "request": [],
+      "response": {
+        "type": "array",
+        "items": "BundleEntry"
+      }
+    },
     "ownAccountLocal": {
       "request": [
         {

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -9,24 +9,6 @@
   "types": [
     {
       "type": "record",
-      "name": "LocalBalance",
-      "fields": [
-        {
-          "type": "Balance",
-          "name": "balance"
-        },
-        {
-          "type": "string",
-          "name": "currency"
-        },
-        {
-          "type": "string",
-          "name": "value"
-        }
-      ]
-    },
-    {
-      "type": "record",
       "name": "RecentPaymentCLILocal",
       "fields": [
         {
@@ -90,6 +72,51 @@
           "name": "toUsername"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "LocalCurrencyCode",
+      "fields": [],
+      "typedef": "string"
+    },
+    {
+      "type": "record",
+      "name": "LocalExchangeRate",
+      "fields": [],
+      "typedef": "float"
+    },
+    {
+      "type": "record",
+      "name": "LocalOwnAccount",
+      "fields": [
+        {
+          "type": "AccountID",
+          "name": "accountID"
+        },
+        {
+          "type": "boolean",
+          "name": "isPrimary"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "Balance"
+          },
+          "name": "balance"
+        },
+        {
+          "type": "LocalCurrencyCode",
+          "name": "localCurrency"
+        },
+        {
+          "type": "LocalExchangeRate",
+          "name": "localExchangeRate"
+        }
+      ]
     }
   ],
   "messages": {
@@ -102,7 +129,7 @@
       ],
       "response": {
         "type": "array",
-        "items": "LocalBalance"
+        "items": "Balance"
       }
     },
     "sendLocal": {
@@ -149,11 +176,11 @@
       "request": [],
       "response": "Bundle"
     },
-    "walletGetPublicKeys": {
+    "walletGetLocalAccounts": {
       "request": [],
       "response": {
         "type": "array",
-        "items": "BundleEntry"
+        "items": "LocalOwnAccount"
       }
     },
     "ownAccountLocal": {


### PR DESCRIPTION
It's a bit outside of our current roadmap but I convinced myself (and @mlsteele ) that this could be useful.

But I'm not sure it's the right way to do this. I went with fetching and decrypting the entire stellar bundle because I recalled that we may want to offer a possibility of private (hidden) accounts, and even if it's not implemented right now, I'd like `wallet balances` to show them as well.

This PR is a bit conflicted with my other one, so please do not look too much into this one before the other one is merged. Also I'm fine if this one is rejected if there's another thing planned for this command.

Example run:
```
» kbs wallet balances
▶ WARNING Could not load local currency exchange rate for "GBCLXO4QB4PSRKXJM5Z3YIUDR32XWWGNXH54FUKARZB3WUKJG4MDQCSK"
Balances for account GB6BRS2WFYPPI4PQNYAWYZ3CRNJHIHWNZ67T5GTSZXQYV2DC3BGGJD2G (Primary):
XLM	4.3199900 (2.89 PLN)

Balances for account GBCLXO4QB4PSRKXJM5Z3YIUDR32XWWGNXH54FUKARZB3WUKJG4MDQCSK:
XLM	2.0000000
```

cc @patrickxb 