### PR TITLE
introduce a cache for subteamname->ID lookups for short bursts

### DIFF
--- a/go/libkb/burst_cache.go
+++ b/go/libkb/burst_cache.go
@@ -1,0 +1,96 @@
+package libkb
+
+import (
+	"fmt"
+	lru "github.com/hashicorp/golang-lru"
+	"golang.org/x/net/context"
+	"time"
+)
+
+// BurstCachce is an LRU+SingleFlighter useful for absorbing short-lived bursts
+// of lookups. If multiple goroutines are fetching resource A, they all will block on
+// the first fetch, and can (if the fetch returns without error) share the answer
+// of the first request.
+type BurstCache struct {
+	Contextified
+	locktab   LockTable
+	lru       *lru.Cache
+	cacheLife time.Duration
+	name      string
+}
+
+// BurstCacheKey is a key for a burst cache resource. Needs to implement the one
+// method --- String() --- used for turning the key into an LRU and LockTab key.
+type BurstCacheKey interface {
+	String() string
+}
+
+// NewBurstCache makes a new burst cache with the given size and cacheLife.
+// name is for debugging purposes.
+func NewBurstCache(g *GlobalContext, sz int, dur time.Duration, name string) *BurstCache {
+	lru, err := lru.New(sz)
+	if err != nil {
+		g.Log.Fatalf("Bad LRU Constructor: %s", err.Error())
+	}
+	return &BurstCache{
+		Contextified: NewContextified(g),
+		lru:          lru,
+		cacheLife:    dur,
+		name:         name,
+	}
+}
+
+type burstCacheObj struct {
+	obj      interface{}
+	cachedAt time.Time
+}
+
+// BurstCacherLoader is a function that loads an item (from network or whatnot).
+// On success, its result will be cached into the burst cache. Maps a key
+// to an object as an interface{}. The caller to Load() should wrap into the
+// closure all parameters needed to actually fetch the object. They called
+// Load(), so they likely have them handy.
+type BurstCacheLoader func() (obj interface{}, err error)
+
+// Load item key from the burst cache. On a cache miss, load with the given loader function.
+// Return the object as an interface{}, so the caller needs to cast out of this burst cache.
+func (b *BurstCache) Load(ctx context.Context, key BurstCacheKey, loader BurstCacheLoader) (ret interface{}, err error) {
+	ctx = WithLogTag(ctx, "BC")
+
+	defer b.G().CVTrace(ctx, VLog0, fmt.Sprintf("BurstCache(%s)#Load(%s)", b.name, key.String()), func() error { return err })()
+
+	lock := b.locktab.AcquireOnName(ctx, b.G(), key.String())
+	defer lock.Release(ctx)
+
+	b.G().VDL.CLogf(ctx, VLog0, "| past single-flight lock")
+
+	found := false
+	if val, ok := b.lru.Get(key.String()); ok {
+		b.G().VDL.CLogf(ctx, VLog0, "| found in LRU cache")
+		if tmp, ok := val.(*burstCacheObj); ok {
+			age := b.G().GetClock().Now().Sub(tmp.cachedAt)
+			if age < b.cacheLife {
+				b.G().VDL.CLogf(ctx, VLog0, "| cached object was fresh (loaded %v ago)", age)
+				ret = tmp.obj
+				found = true
+			} else {
+				b.G().VDL.CLogf(ctx, VLog0, "| cached object expired %v ago", (age - b.cacheLife))
+				b.lru.Remove(key.String())
+			}
+		} else {
+			b.G().Log.CErrorf(ctx, "| object in LRU was of wrong type")
+		}
+	} else {
+		b.G().VDL.CLogf(ctx, VLog0, "| object cache miss")
+	}
+
+	if !found {
+		ret, err = loader()
+		if err == nil {
+			b.G().VDL.CLogf(ctx, VLog0, "| caching object after successful fetch")
+			b.lru.Add(key.String(), &burstCacheObj{ret, b.G().GetClock().Now()})
+		}
+	}
+
+	return ret, err
+}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -608,6 +608,7 @@ type TeamLoader interface {
 	Delete(ctx context.Context, teamID keybase1.TeamID) error
 	// Untrusted hint of what a team's latest seqno is
 	HintLatestSeqno(ctx context.Context, id keybase1.TeamID, seqno keybase1.Seqno) error
+	ResolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName, public bool, allowCache bool) (id keybase1.TeamID, err error)
 	OnLogout()
 	// Clear the in-memory cache. Does not affect the disk cache.
 	ClearMem()

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -53,6 +53,10 @@ func (n *nullTeamLoader) HintLatestSeqno(ctx context.Context, id keybase1.TeamID
 	return nil
 }
 
+func (n *nullTeamLoader) ResolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName, public bool, allowCache bool) (id keybase1.TeamID, err error) {
+	return id, fmt.Errorf("null team loader")
+}
+
 func (n nullTeamLoader) OnLogout() {}
 
 func (n nullTeamLoader) ClearMem() {}

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1520,28 +1520,30 @@ func (o TeamRefreshers) DeepCopy() TeamRefreshers {
 }
 
 type LoadTeamArg struct {
-	ID               TeamID         `codec:"ID" json:"ID"`
-	Name             string         `codec:"name" json:"name"`
-	Public           bool           `codec:"public" json:"public"`
-	NeedAdmin        bool           `codec:"needAdmin" json:"needAdmin"`
-	RefreshUIDMapper bool           `codec:"refreshUIDMapper" json:"refreshUIDMapper"`
-	Refreshers       TeamRefreshers `codec:"refreshers" json:"refreshers"`
-	ForceFullReload  bool           `codec:"forceFullReload" json:"forceFullReload"`
-	ForceRepoll      bool           `codec:"forceRepoll" json:"forceRepoll"`
-	StaleOK          bool           `codec:"staleOK" json:"staleOK"`
+	ID                        TeamID         `codec:"ID" json:"ID"`
+	Name                      string         `codec:"name" json:"name"`
+	Public                    bool           `codec:"public" json:"public"`
+	NeedAdmin                 bool           `codec:"needAdmin" json:"needAdmin"`
+	RefreshUIDMapper          bool           `codec:"refreshUIDMapper" json:"refreshUIDMapper"`
+	Refreshers                TeamRefreshers `codec:"refreshers" json:"refreshers"`
+	ForceFullReload           bool           `codec:"forceFullReload" json:"forceFullReload"`
+	ForceRepoll               bool           `codec:"forceRepoll" json:"forceRepoll"`
+	StaleOK                   bool           `codec:"staleOK" json:"staleOK"`
+	AllowNameLookupBurstCache bool           `codec:"allowNameLookupBurstCache" json:"allowNameLookupBurstCache"`
 }
 
 func (o LoadTeamArg) DeepCopy() LoadTeamArg {
 	return LoadTeamArg{
-		ID:               o.ID.DeepCopy(),
-		Name:             o.Name,
-		Public:           o.Public,
-		NeedAdmin:        o.NeedAdmin,
-		RefreshUIDMapper: o.RefreshUIDMapper,
-		Refreshers:       o.Refreshers.DeepCopy(),
-		ForceFullReload:  o.ForceFullReload,
-		ForceRepoll:      o.ForceRepoll,
-		StaleOK:          o.StaleOK,
+		ID:                        o.ID.DeepCopy(),
+		Name:                      o.Name,
+		Public:                    o.Public,
+		NeedAdmin:                 o.NeedAdmin,
+		RefreshUIDMapper:          o.RefreshUIDMapper,
+		Refreshers:                o.Refreshers.DeepCopy(),
+		ForceFullReload:           o.ForceFullReload,
+		ForceRepoll:               o.ForceRepoll,
+		StaleOK:                   o.StaleOK,
+		AllowNameLookupBurstCache: o.AllowNameLookupBurstCache,
 	}
 }
 

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -144,7 +144,7 @@ func (l *TeamLoader) ResolveNameToIDUntrusted(ctx context.Context, teamName keyb
 	if err != nil {
 		return keybase1.TeamID(""), err
 	}
-	if idPointer, ok := idVoidPointer.(*keybase1.TeamID); ok {
+	if idPointer, ok := idVoidPointer.(*keybase1.TeamID); ok && idPointer != nil {
 		id = *idPointer
 	} else {
 		return keybase1.TeamID(""), errors.New("bad cast out of nameLookupBurstCache")

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -1,6 +1,7 @@
 package teams
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -44,15 +45,20 @@ type TeamLoader struct {
 	// Single-flight locks per team ID.
 	// (Private and public loads of the same ID will block each other, should be fine)
 	locktab libkb.LockTable
+
+	// Cache lookups of team name -> ID for a few seconds, to absorb bursts of lookups
+	// from the frontend
+	nameLookupBurstCache *libkb.BurstCache
 }
 
 var _ libkb.TeamLoader = (*TeamLoader)(nil)
 
 func NewTeamLoader(g *libkb.GlobalContext, world LoaderContext, storage *Storage) *TeamLoader {
 	return &TeamLoader{
-		Contextified: libkb.NewContextified(g),
-		world:        world,
-		storage:      storage,
+		Contextified:         libkb.NewContextified(g),
+		world:                world,
+		storage:              storage,
+		nameLookupBurstCache: libkb.NewBurstCache(g, 100, 10*time.Second, "SubteamNameToID"),
 	}
 }
 
@@ -108,6 +114,74 @@ func (l *TeamLoader) HintLatestSeqno(ctx context.Context, teamID keybase1.TeamID
 	return nil
 }
 
+type nameLookupBurstCacheKey struct {
+	teamName keybase1.TeamName
+	public   bool
+}
+
+func (n nameLookupBurstCacheKey) String() string {
+	return fmt.Sprintf("%s:%v", n.teamName.String(), n.public)
+}
+
+// Resolve a team name to a team ID.
+// Will always hit the server for subteams. The server can lie in this return value.
+func (l *TeamLoader) ResolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName, public bool, allowCache bool) (id keybase1.TeamID, err error) {
+
+	defer l.G().CVTrace(ctx, libkb.VLog0, fmt.Sprintf("resolveNameToUIDUntrusted(%s,%v,%v)", teamName.String(), public, allowCache), func() error { return err })()
+
+	// For root team names, just hash.
+	if teamName.IsRootTeam() {
+		return teamName.ToTeamID(public), nil
+	}
+
+	if !allowCache {
+		return resolveNameToIDUntrustedAPICall(ctx, l.G(), teamName, public)
+	}
+
+	var idVoidPointer interface{}
+	key := nameLookupBurstCacheKey{teamName, public}
+	idVoidPointer, err = l.nameLookupBurstCache.Load(ctx, key, l.makeNameLookupBurstCacheLoader(ctx, l.G(), key))
+	if err != nil {
+		return keybase1.TeamID(""), err
+	}
+	if idPointer, ok := idVoidPointer.(*keybase1.TeamID); ok {
+		id = *idPointer
+	} else {
+		return keybase1.TeamID(""), errors.New("bad cast out of nameLookupBurstCache")
+	}
+	return id, nil
+}
+
+func resolveNameToIDUntrustedAPICall(ctx context.Context, g *libkb.GlobalContext, teamName keybase1.TeamName, public bool) (id keybase1.TeamID, err error) {
+	arg := libkb.NewAPIArgWithNetContext(ctx, "team/get")
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	arg.Args = libkb.HTTPArgs{
+		"name":        libkb.S{Val: teamName.String()},
+		"lookup_only": libkb.B{Val: true},
+		"public":      libkb.B{Val: public},
+	}
+
+	var rt rawTeam
+	if err := g.API.GetDecode(arg, &rt); err != nil {
+		return id, err
+	}
+	id = rt.ID
+	if !id.Exists() {
+		return id, fmt.Errorf("could not resolve team name: %v", teamName.String())
+	}
+	return id, nil
+}
+
+func (l *TeamLoader) makeNameLookupBurstCacheLoader(ctx context.Context, g *libkb.GlobalContext, key nameLookupBurstCacheKey) libkb.BurstCacheLoader {
+	return func() (obj interface{}, err error) {
+		id, err := resolveNameToIDUntrustedAPICall(ctx, g, key.teamName, key.public)
+		if err != nil {
+			return nil, err
+		}
+		return &id, nil
+	}
+}
+
 // Load1 unpacks the loadArg, calls load2, and does some final checks.
 // The key difference between load1 and load2 is that load2 is recursive (for subteams).
 func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg keybase1.LoadTeamArg) (*keybase1.TeamData, error) {
@@ -130,7 +204,7 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 	// It is safe for the answer to be wrong because the name is checked on the way out,
 	// and the merkle tree check guarantees one sigchain per team id.
 	if !teamID.Exists() {
-		teamID, err = l.world.resolveNameToIDUntrusted(ctx, *teamName, lArg.Public)
+		teamID, err = l.ResolveNameToIDUntrusted(ctx, *teamName, lArg.Public, lArg.AllowNameLookupBurstCache)
 		if err != nil {
 			l.G().Log.CDebugf(ctx, "TeamLoader looking up team by name failed: %v -> %v", *teamName, err)
 			return nil, err

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -23,7 +23,6 @@ type LoaderContext interface {
 	getMe(context.Context) (keybase1.UserVersion, error)
 	// Lookup the eldest seqno of a user. Can use the cache.
 	lookupEldestSeqno(context.Context, keybase1.UID) (keybase1.Seqno, error)
-	resolveNameToIDUntrusted(context.Context, keybase1.TeamName, bool) (keybase1.TeamID, error)
 	// Get the current user's per-user-key's derived encryption key (full).
 	perUserEncryptionKey(ctx context.Context, userSeqno keybase1.Seqno) (*libkb.NaclDHKeyPair, error)
 	merkleLookup(ctx context.Context, teamID keybase1.TeamID, public bool) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error)
@@ -135,7 +134,7 @@ func (l *LoaderContextG) lookupEldestSeqno(ctx context.Context, uid keybase1.UID
 
 // Resolve a team name to a team ID.
 // Will always hit the server for subteams. The server can lie in this return value.
-func (l *LoaderContextG) resolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName,
+func (l *LoaderContextG) resolveNameToIDUntrusted(ctx context.Context, g *libkb.GlobalContext, teamName keybase1.TeamName,
 	public bool) (id keybase1.TeamID, err error) {
 	// For root team names, just hash.
 	if teamName.IsRootTeam() {

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -132,34 +132,6 @@ func (l *LoaderContextG) lookupEldestSeqno(ctx context.Context, uid keybase1.UID
 	return upak.Current.EldestSeqno, nil
 }
 
-// Resolve a team name to a team ID.
-// Will always hit the server for subteams. The server can lie in this return value.
-func (l *LoaderContextG) resolveNameToIDUntrusted(ctx context.Context, g *libkb.GlobalContext, teamName keybase1.TeamName,
-	public bool) (id keybase1.TeamID, err error) {
-	// For root team names, just hash.
-	if teamName.IsRootTeam() {
-		return teamName.ToTeamID(public), nil
-	}
-
-	arg := libkb.NewAPIArgWithNetContext(ctx, "team/get")
-	arg.SessionType = libkb.APISessionTypeREQUIRED
-	arg.Args = libkb.HTTPArgs{
-		"name":        libkb.S{Val: teamName.String()},
-		"lookup_only": libkb.B{Val: true},
-		"public":      libkb.B{Val: public},
-	}
-
-	var rt rawTeam
-	if err := l.G().API.GetDecode(arg, &rt); err != nil {
-		return id, err
-	}
-	id = rt.ID
-	if !id.Exists() {
-		return id, fmt.Errorf("could not resolve team name: %v", teamName.String())
-	}
-	return id, nil
-}
-
 func (l *LoaderContextG) perUserEncryptionKey(ctx context.Context, userSeqno keybase1.Seqno) (*libkb.NaclDHKeyPair, error) {
 	kr, err := l.G().GetPerUserKeyring()
 	if err != nil {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -245,7 +245,8 @@ func AddMemberByID(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.
 
 func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string, role keybase1.TeamRole) (res keybase1.TeamAddMemberResult, err error) {
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
-		Name: teamname,
+		Name:        teamname,
+		ForceRepoll: true,
 	})
 	if err != nil {
 		return res, err
@@ -1247,6 +1248,7 @@ func CanUserPerform(ctx context.Context, g *libkb.GlobalContext, teamname string
 		Name:    teamname,
 		StaleOK: true,
 		Public:  false, // assume private team
+		AllowNameLookupBurstCache: true,
 	})
 	if err != nil {
 		// Note: we eat the error here, assuming it meant this user
@@ -1435,13 +1437,19 @@ func (c *disableTARsRes) GetAppStatus() *libkb.AppStatus {
 }
 
 func GetTarsDisabled(ctx context.Context, g *libkb.GlobalContext, teamname string) (bool, error) {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
+
+	nameParsed, err := keybase1.TeamNameFromString(teamname)
+	if err != nil {
+		return false, err
+	}
+
+	id, err := g.GetTeamLoader().ResolveNameToIDUntrusted(ctx, nameParsed, false, true)
 	if err != nil {
 		return false, err
 	}
 
 	arg := apiArg(ctx, "team/disable_tars")
-	arg.Args.Add("tid", libkb.S{Val: t.ID.String()})
+	arg.Args.Add("tid", libkb.S{Val: id.String()})
 	var ret disableTARsRes
 	if err := g.API.GetDecode(arg, &ret); err != nil {
 		return false, err

--- a/go/teams/showcase_helper.go
+++ b/go/teams/showcase_helper.go
@@ -35,7 +35,7 @@ func (c *memberShowcaseRes) GetAppStatus() *libkb.AppStatus {
 }
 
 func GetTeamAndMemberShowcase(ctx context.Context, g *libkb.GlobalContext, teamname string) (ret keybase1.TeamAndMemberShowcase, err error) {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname, false)
+	t, err := GetForDisplayByStringName(ctx, g, teamname)
 	if err != nil {
 		return ret, err
 	}

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -528,9 +528,10 @@ protocol teams {
 
     TeamRefreshers refreshers;
 
-    boolean forceFullReload;      // Ignore local data and fetch from the server.
-    boolean forceRepoll;          // Force a sync with merkle.
-    boolean staleOK;              // If a very stale cache hit is OK.
+    boolean forceFullReload;           // Ignore local data and fetch from the server.
+    boolean forceRepoll;               // Force a sync with merkle.
+    boolean staleOK;                   // If a very stale cache hit is OK.
+    boolean allowNameLookupBurstCache; // If it's ok to hit the nameLookup burst cache
   }
 
   record ImplicitRole {

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2683,7 +2683,7 @@ export type LoadAvatarsRes = $ReadOnly<{picmap: {[key: string]: {[key: string]: 
 
 export type LoadDeviceErr = $ReadOnly<{where: String, desc: String}>
 
-export type LoadTeamArg = $ReadOnly<{ID: TeamID, name: String, public: Boolean, needAdmin: Boolean, refreshUIDMapper: Boolean, refreshers: TeamRefreshers, forceFullReload: Boolean, forceRepoll: Boolean, staleOK: Boolean}>
+export type LoadTeamArg = $ReadOnly<{ID: TeamID, name: String, public: Boolean, needAdmin: Boolean, refreshUIDMapper: Boolean, refreshers: TeamRefreshers, forceFullReload: Boolean, forceRepoll: Boolean, staleOK: Boolean, allowNameLookupBurstCache: Boolean}>
 
 export type LockContext = $ReadOnly<{requireLockID: LockID, releaseAfterSuccess: Boolean}>
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1284,6 +1284,10 @@
         {
           "type": "boolean",
           "name": "staleOK"
+        },
+        {
+          "type": "boolean",
+          "name": "allowNameLookupBurstCache"
         }
       ]
     },

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2683,7 +2683,7 @@ export type LoadAvatarsRes = $ReadOnly<{picmap: {[key: string]: {[key: string]: 
 
 export type LoadDeviceErr = $ReadOnly<{where: String, desc: String}>
 
-export type LoadTeamArg = $ReadOnly<{ID: TeamID, name: String, public: Boolean, needAdmin: Boolean, refreshUIDMapper: Boolean, refreshers: TeamRefreshers, forceFullReload: Boolean, forceRepoll: Boolean, staleOK: Boolean}>
+export type LoadTeamArg = $ReadOnly<{ID: TeamID, name: String, public: Boolean, needAdmin: Boolean, refreshUIDMapper: Boolean, refreshers: TeamRefreshers, forceFullReload: Boolean, forceRepoll: Boolean, staleOK: Boolean, allowNameLookupBurstCache: Boolean}>
 
 export type LockContext = $ReadOnly<{requireLockID: LockID, releaseAfterSuccess: Boolean}>
 


### PR DESCRIPTION
- you have to explicit opt into this cache, via new teamLoader parameter `AllowNameLookupBurstCache`