### PR TITLE
Tweak info sent in chat msg headers [CORE-6874]

### DIFF
--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -1049,6 +1049,18 @@ func (o OutboxInfo) DeepCopy() OutboxInfo {
 	}
 }
 
+type EphemeralMetadata struct {
+	EphemeralLifetime gregor1.DurationSec   `codec:"ephemeralLifetime" json:"ephemeralLifetime"`
+	Generation        keybase1.EkGeneration `codec:"generation" json:"generation"`
+}
+
+func (o EphemeralMetadata) DeepCopy() EphemeralMetadata {
+	return EphemeralMetadata{
+		EphemeralLifetime: o.EphemeralLifetime.DeepCopy(),
+		Generation:        o.Generation.DeepCopy(),
+	}
+}
+
 type MessageClientHeader struct {
 	Conv              ConversationIDTriple     `codec:"conv" json:"conv"`
 	TlfName           string                   `codec:"tlfName" json:"tlfName"`
@@ -1064,8 +1076,7 @@ type MessageClientHeader struct {
 	MerkleRoot        *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
 	OutboxID          *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	OutboxInfo        *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
-	IsEphemeral       bool                     `codec:"isEphemeral" json:"isEphemeral"`
-	EphemeralLifetime gregor1.DurationSec      `codec:"ephemeralLifetime" json:"ephemeralLifetime"`
+	EphemeralMetadata *EphemeralMetadata       `codec:"ephemeralMetadata,omitempty" json:"ephemeralMetadata,omitempty"`
 }
 
 func (o MessageClientHeader) DeepCopy() MessageClientHeader {
@@ -1134,8 +1145,13 @@ func (o MessageClientHeader) DeepCopy() MessageClientHeader {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.OutboxInfo),
-		IsEphemeral:       o.IsEphemeral,
-		EphemeralLifetime: o.EphemeralLifetime.DeepCopy(),
+		EphemeralMetadata: (func(x *EphemeralMetadata) *EphemeralMetadata {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.EphemeralMetadata),
 	}
 }
 
@@ -1151,8 +1167,7 @@ type MessageClientHeaderVerified struct {
 	MerkleRoot        *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
 	OutboxID          *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	OutboxInfo        *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
-	IsEphemeral       bool                     `codec:"isEphemeral" json:"isEphemeral"`
-	EphemeralLifetime gregor1.DurationSec      `codec:"ephemeralLifetime" json:"ephemeralLifetime"`
+	EphemeralMetadata *EphemeralMetadata       `codec:"ephemeralMetadata,omitempty" json:"ephemeralMetadata,omitempty"`
 }
 
 func (o MessageClientHeaderVerified) DeepCopy() MessageClientHeaderVerified {
@@ -1202,8 +1217,13 @@ func (o MessageClientHeaderVerified) DeepCopy() MessageClientHeaderVerified {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.OutboxInfo),
-		IsEphemeral:       o.IsEphemeral,
-		EphemeralLifetime: o.EphemeralLifetime.DeepCopy(),
+		EphemeralMetadata: (func(x *EphemeralMetadata) *EphemeralMetadata {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.EphemeralMetadata),
 	}
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -303,6 +303,11 @@
     gregor1.Time composeTime;
   }
 
+  record EphemeralMetadata {
+    gregor1.DurationSec ephemeralLifetime; // used to computed etime
+    keybase1.EkGeneration generation;
+  }
+
   // The Boxer's compareHeaders* functions checks each of these fields.
   // If we add a field here, that method needs to be updated.
   record MessageClientHeader {
@@ -335,8 +340,7 @@
     union { null, OutboxID } outboxID;
     union { null, OutboxInfo } outboxInfo;
 
-    boolean isEphemeral;
-    gregor1.DurationSec ephemeralLifetime; // used to computed etime
+    union { null, EphemeralMetadata } ephemeralMetadata;
   }
 
   record MessageClientHeaderVerified {
@@ -361,8 +365,7 @@
     union { null, OutboxID } outboxID;
     union { null, OutboxInfo } outboxInfo;
 
-    boolean isEphemeral;
-    gregor1.DurationSec ephemeralLifetime; // used to computed etime
+    union { null, EphemeralMetadata } ephemeralMetadata;
   }
 
   // The same format as in KBFS (see libkbfs/data_types.go)

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -751,6 +751,8 @@ export type DownloadAttachmentLocalRes = $ReadOnly<{offline: Boolean, rateLimits
 
 export type EncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
+export type EphemeralMetadata = $ReadOnly<{ephemeralLifetime: Gregor1.DurationSec, generation: Keybase1.EkGeneration}>
+
 export type Expunge = $ReadOnly<{upto: MessageID, basis: MessageID}>
 
 export type ExpungeInfo = $ReadOnly<{convID: ConversationID, expunge: Expunge}>
@@ -993,9 +995,9 @@ export type MessageBoxedVersion =
   | 1 // V1_1
   | 2 // V2_2
 
-export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, isEphemeral: Boolean, ephemeralLifetime: Gregor1.DurationSec}>
+export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?EphemeralMetadata}>
 
-export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, isEphemeral: Boolean, ephemeralLifetime: Gregor1.DurationSec}>
+export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?EphemeralMetadata}>
 
 export type MessageConversationMetadata = $ReadOnly<{conversationTitle: String}>
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -786,6 +786,20 @@
     },
     {
       "type": "record",
+      "name": "EphemeralMetadata",
+      "fields": [
+        {
+          "type": "gregor1.DurationSec",
+          "name": "ephemeralLifetime"
+        },
+        {
+          "type": "keybase1.EkGeneration",
+          "name": "generation"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "MessageClientHeader",
       "fields": [
         {
@@ -866,12 +880,11 @@
           "name": "outboxInfo"
         },
         {
-          "type": "boolean",
-          "name": "isEphemeral"
-        },
-        {
-          "type": "gregor1.DurationSec",
-          "name": "ephemeralLifetime"
+          "type": [
+            null,
+            "EphemeralMetadata"
+          ],
+          "name": "ephemeralMetadata"
         }
       ]
     },
@@ -939,12 +952,11 @@
           "name": "outboxInfo"
         },
         {
-          "type": "boolean",
-          "name": "isEphemeral"
-        },
-        {
-          "type": "gregor1.DurationSec",
-          "name": "ephemeralLifetime"
+          "type": [
+            null,
+            "EphemeralMetadata"
+          ],
+          "name": "ephemeralMetadata"
         }
       ]
     },

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -751,6 +751,8 @@ export type DownloadAttachmentLocalRes = $ReadOnly<{offline: Boolean, rateLimits
 
 export type EncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
+export type EphemeralMetadata = $ReadOnly<{ephemeralLifetime: Gregor1.DurationSec, generation: Keybase1.EkGeneration}>
+
 export type Expunge = $ReadOnly<{upto: MessageID, basis: MessageID}>
 
 export type ExpungeInfo = $ReadOnly<{convID: ConversationID, expunge: Expunge}>
@@ -993,9 +995,9 @@ export type MessageBoxedVersion =
   | 1 // V1_1
   | 2 // V2_2
 
-export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, isEphemeral: Boolean, ephemeralLifetime: Gregor1.DurationSec}>
+export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?EphemeralMetadata}>
 
-export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, isEphemeral: Boolean, ephemeralLifetime: Gregor1.DurationSec}>
+export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?EphemeralMetadata}>
 
 export type MessageConversationMetadata = $ReadOnly<{conversationTitle: String}>
 


### PR DESCRIPTION
Change the metadata format for ephemeral metadata in chat headers. We have to pass the generation info along so we know which teamEK was used to encrypt the body. 


cc @mmaxim 