### PR TITLE
Fix all settings tab showing up empty

### DIFF
--- a/shared/settings/index.js
+++ b/shared/settings/index.js
@@ -23,6 +23,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {routePath}: OwnProps) => ({
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   badgeNotifications: stateProps.badgeNotifications,
   badgeNumbers: stateProps._badgeNumbers.toObject(),
+  children: ownProps.children,
   isModal: stateProps.isModal,
   selectedTab: stateProps.selectedTab,
   ...dispatchProps,


### PR DESCRIPTION
@keybase/react-hackers 

This container was refactored by the webpack work to get its own mergeProps -- it was previously connected directly -- and in the process its downstream component lost access to ownProps.children, leading to a white screen for every tab.