### PR TITLE
get full caching avatar system working on windows CORE-7556

### DIFF
--- a/go/avatars/fileurilze_nix.go
+++ b/go/avatars/fileurilze_nix.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package avatars
+
+func fileUrlize(path string) string {
+	return path
+}

--- a/go/avatars/fileurlize_windows.go
+++ b/go/avatars/fileurlize_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package avatars
+
+import (
+	"strings"
+)
+
+func fileUrlize(path string) string {
+	return `/` + strings.Replace(path, `\`, `/`, -1)
+}

--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -275,7 +275,7 @@ func (c *FullCachingSource) dispatchPopulateFromRes(ctx context.Context, res key
 }
 
 func (c *FullCachingSource) makeURL(path string) keybase1.AvatarUrl {
-	return keybase1.MakeAvatarURL(fmt.Sprintf("file://%s", path))
+	return keybase1.MakeAvatarURL(fmt.Sprintf("file://%s", fileUrlize(path)))
 }
 
 func (c *FullCachingSource) mergeRes(res *keybase1.LoadAvatarsRes, m keybase1.LoadAvatarsRes) {

--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -18,10 +18,6 @@ type Source interface {
 
 func CreateSourceFromEnv(g *libkb.GlobalContext) (s Source) {
 	typ := g.Env.GetAvatarSource()
-	if libkb.GetPlatformString() == "windows" {
-		// Force Windows to use the simpler source
-		typ = "simple"
-	}
 	switch typ {
 	case "simple":
 		s = NewSimpleSource(g)


### PR DESCRIPTION
Tested manually on Windows, and it works. 

cc @zanderz you should pay special attention to avatars after this goes in if you are running the Windows admin builds.