### PR TITLE
Sort out retention notification story

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -81,6 +81,7 @@ export const setupChatHandlers = 'chat2:setupChatHandlers'
 export const startConversation = 'chat2:startConversation'
 export const updateConvRetentionPolicy = 'chat2:updateConvRetentionPolicy'
 export const updateNotificationSettings = 'chat2:updateNotificationSettings'
+export const updateTeamRetentionPolicy = 'chat2:updateTeamRetentionPolicy'
 export const updateTypers = 'chat2:updateTypers'
 
 // Action Creators
@@ -92,6 +93,10 @@ export const createCancelPendingConversation = () => ({error: false, payload: un
  * Consume a service notification that a conversation's retention policy has been updated and update the conversation metaMap
  */
 export const createUpdateConvRetentionPolicy = (payload: $ReadOnly<{|conv: RPCChatTypes.InboxUIItem|}>) => ({error: false, payload, type: updateConvRetentionPolicy})
+/**
+ * Consume a service notification that a team retention policy was updated, and update all the associated conversations in the metaMap
+ */
+export const createUpdateTeamRetentionPolicy = (payload: $ReadOnly<{|convs: Array<RPCChatTypes.InboxUIItem>|}>) => ({error: false, payload, type: updateTeamRetentionPolicy})
 /**
  * Retries sending the pending message that is currently stored in the metaMap
  */
@@ -494,6 +499,7 @@ export type SetupChatHandlersPayload = More.ReturnType<typeof createSetupChatHan
 export type StartConversationPayload = More.ReturnType<typeof createStartConversation>
 export type UpdateConvRetentionPolicyPayload = More.ReturnType<typeof createUpdateConvRetentionPolicy>
 export type UpdateNotificationSettingsPayload = More.ReturnType<typeof createUpdateNotificationSettings>
+export type UpdateTeamRetentionPolicyPayload = More.ReturnType<typeof createUpdateTeamRetentionPolicy>
 export type UpdateTypersPayload = More.ReturnType<typeof createUpdateTypers>
 
 // All Actions
@@ -569,5 +575,6 @@ export type Actions =
   | More.ReturnType<typeof createStartConversation>
   | More.ReturnType<typeof createUpdateConvRetentionPolicy>
   | More.ReturnType<typeof createUpdateNotificationSettings>
+  | More.ReturnType<typeof createUpdateTeamRetentionPolicy>
   | More.ReturnType<typeof createUpdateTypers>
   | {type: 'common:resetStore', payload: void}

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -90,11 +90,11 @@ export const updateTypers = 'chat2:updateTypers'
  */
 export const createCancelPendingConversation = () => ({error: false, payload: undefined, type: cancelPendingConversation})
 /**
- * Consume a service notification that a conversation's retention policy has been updated and update the conversation metaMap
+ * Consume a service notification that a conversation's retention policy has been updated
  */
 export const createUpdateConvRetentionPolicy = (payload: $ReadOnly<{|conv: RPCChatTypes.InboxUIItem|}>) => ({error: false, payload, type: updateConvRetentionPolicy})
 /**
- * Consume a service notification that a team retention policy was updated, and update all the associated conversations in the metaMap
+ * Consume a service notification that a team retention policy was updated
  */
 export const createUpdateTeamRetentionPolicy = (payload: $ReadOnly<{|convs: Array<RPCChatTypes.InboxUIItem>|}>) => ({error: false, payload, type: updateTeamRetentionPolicy})
 /**
@@ -115,7 +115,7 @@ export const createSetPendingMessageSubmitState = (
  */
 export const createSetPendingStatus = (payload: $ReadOnly<{|pendingStatus: Types.PendingStatus|}>) => ({error: false, payload, type: setPendingStatus})
 /**
- * Sets the retention policy for a conversation. Valid operation for big team channels only.
+ * Sets the retention policy for a conversation.
  */
 export const createSetConvRetentionPolicy = (
   payload: $ReadOnly<{|

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -579,7 +579,8 @@ const setupChatHandlers = () => {
     if (update.convs) {
       return [Chat2Gen.createUpdateTeamRetentionPolicy({convs: update.convs})]
     }
-    logger.warn(
+    // this is a more serious problem, but we don't need to bug the user about it
+    logger.error(
       'ChatHandler: got NotifyChat.ChatSetTeamRetention with no attached InboxUIItems. The local version may be out of date'
     )
   })

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -564,6 +564,9 @@ const setupChatHandlers = () => {
     if (update.conv) {
       return [Chat2Gen.createUpdateConvRetentionPolicy({conv: update.conv})]
     }
+    logger.warn(
+      'ChatHandler: got NotifyChat.ChatSetConvRetention with no attached InboxUIItem. Forcing update.'
+    )
     // force to get the new retention policy
     return [
       Chat2Gen.createMetaRequestTrusted({
@@ -571,6 +574,14 @@ const setupChatHandlers = () => {
         force: true,
       }),
     ]
+  })
+  engine().setIncomingActionCreators('chat.1.NotifyChat.ChatSetTeamRetention', update => {
+    if (update.convs) {
+      return [Chat2Gen.createUpdateTeamRetentionPolicy({convs: update.convs})]
+    }
+    logger.warn(
+      'ChatHandler: got NotifyChat.ChatSetTeamRetention with no attached InboxUIItems. The local version may be out of date'
+    )
   })
 }
 

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -379,11 +379,11 @@
       "policy": "RetentionPolicy",
     },
     "updateConvRetentionPolicy": {
-      "_description": "Consume a service notification that a conversation's retention policy has been updated and update the conversation metaMap",
+      "_description": "Consume a service notification that a conversation's retention policy has been updated",
       "conv": "RPCChatTypes.InboxUIItem",
     },
     "updateTeamRetentionPolicy": {
-      "_description": "Consume a service notification that a team retention policy was updated, and update all the associated conversations in the metaMap",
+      "_description": "Consume a service notification that a team retention policy was updated",
       "convs": "Array<RPCChatTypes.InboxUIItem>",
     },
   }

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -374,13 +374,17 @@
       "offline": "boolean",
     },
     "setConvRetentionPolicy": {
-      "_description": "Sets the retention policy for a conversation. Valid operation for big team channels only.",
+      "_description": "Sets the retention policy for a conversation.",
       "conversationIDKey": "Types.ConversationIDKey",
       "policy": "RetentionPolicy",
     },
     "updateConvRetentionPolicy": {
       "_description": "Consume a service notification that a conversation's retention policy has been updated and update the conversation metaMap",
       "conv": "RPCChatTypes.InboxUIItem",
+    },
+    "updateTeamRetentionPolicy": {
+      "_description": "Consume a service notification that a team retention policy was updated, and update all the associated conversations in the metaMap",
+      "convs": "Array<RPCChatTypes.InboxUIItem>",
     },
   }
 }

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -160,6 +160,38 @@ const _setTeamRetentionPolicy = function(action: TeamsGen.SetTeamRetentionPolicy
   ])
 }
 
+const _updateTeamRetentionPolicy = function(
+  action: Chat2Gen.UpdateTeamRetentionPolicyPayload,
+  state: TypedState
+) {
+  const {convs} = action.payload
+  if (convs.length === 0) {
+    logger.warn('Got updateTeamRetentionPolicy with no convs; aborting. Local copy may be out of date')
+    return
+  }
+  const {teamRetention, name} = convs[0]
+  try {
+    const newPolicy = Constants.serviceRetentionPolicyToRetentionPolicy(teamRetention)
+    // increment / decrement waiting here to signify we got an update in case we didn't do it
+    return Saga.sequentially([
+      Saga.put(
+        createIncrementWaiting({
+          key: [Constants.teamWaitingKey(name), Constants.retentionWaitingKey(name)],
+        })
+      ),
+      Saga.put(replaceEntity(['teams', 'teamNameToRetentionPolicy'], I.Map([[name, newPolicy]]))),
+      Saga.put(
+        createDecrementWaiting({
+          key: [Constants.teamWaitingKey(name), Constants.retentionWaitingKey(name)],
+        })
+      ),
+    ])
+  } catch (err) {
+    logger.error(err.message)
+    throw err
+  }
+}
+
 const _inviteByEmail = function*(action: TeamsGen.InviteToTeamByEmailPayload) {
   const {invitees, role, teamname} = action.payload
   yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
@@ -853,18 +885,6 @@ function _setupTeamHandlers() {
       }
       actions.forEach(dispatch)
     })
-    engine().setIncomingHandler('chat.1.NotifyChat.ChatSetTeamRetention', args => {
-      logger.info('Got setTeamRetention from service')
-      const {convs, teamID} = args
-      if (convs.length === 0) {
-        logger.warn(`Teamhandler: Got setTeamRetention for team with no conversations: ${teamID}`)
-        return
-      }
-      const conv = convs[0]
-      const teamname = conv.name
-      const newPolicy = Constants.serviceRetentionPolicyToRetentionPolicy(conv.teamRetention)
-      dispatch(replaceEntity(['teams', 'teamNameToRetentionPolicy'], I.Map([[teamname, newPolicy]])))
-    })
   })
 }
 
@@ -1083,6 +1103,7 @@ const teamsSaga = function*(): Saga.SagaGenerator<any, any> {
   )
   yield Saga.safeTakeEvery(TeamsGen.getTeamRetentionPolicy, _getTeamRetentionPolicy)
   yield Saga.safeTakeEveryPure(TeamsGen.setTeamRetentionPolicy, _setTeamRetentionPolicy)
+  yield Saga.safeTakeEveryPure(Chat2Gen.updateTeamRetentionPolicy, _updateTeamRetentionPolicy)
 }
 
 export default teamsSaga

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -172,20 +172,7 @@ const _updateTeamRetentionPolicy = function(
   const {teamRetention, name} = convs[0]
   try {
     const newPolicy = Constants.serviceRetentionPolicyToRetentionPolicy(teamRetention)
-    // increment / decrement waiting here to signify we got an update in case we didn't do it
-    return Saga.sequentially([
-      Saga.put(
-        createIncrementWaiting({
-          key: [Constants.teamWaitingKey(name), Constants.retentionWaitingKey(name)],
-        })
-      ),
-      Saga.put(replaceEntity(['teams', 'teamNameToRetentionPolicy'], I.Map([[name, newPolicy]]))),
-      Saga.put(
-        createDecrementWaiting({
-          key: [Constants.teamWaitingKey(name), Constants.retentionWaitingKey(name)],
-        })
-      ),
-    ])
+    return Saga.put(replaceEntity(['teams', 'teamNameToRetentionPolicy'], I.Map([[name, newPolicy]])))
   } catch (err) {
     logger.error(err.message)
     throw err

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -405,6 +405,7 @@ class Engine {
     this._incomingActionCreators[method] = actionCreator
   }
 
+  // DEPRECATED - use setIncomingActionCreator instead
   setIncomingHandler(method: MethodKey, handler: (param: Object, response: ?Object) => void) {
     if (this._incomingHandler[method]) {
       rpcLog('engineInternal', "duplicate incoming handler!!! this isn't allowed", {method})

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -130,6 +130,16 @@ const metaMapReducer = (metaMap, action) => {
         return metaMap
       }
       return metaMap.set(newMeta.conversationIDKey, newMeta)
+    case Chat2Gen.updateTeamRetentionPolicy:
+      const {convs} = action.payload
+      const newMetas = convs.reduce((updated, conv) => {
+        const newMeta = Constants.inboxUIItemToConversationMeta(conv)
+        if (newMeta) {
+          updated[Types.conversationIDKeyToString(newMeta.conversationIDKey)] = newMeta
+        }
+        return updated
+      }, {})
+      return metaMap.merge(newMetas)
     default:
       return metaMap
   }
@@ -636,6 +646,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     case Chat2Gen.metaUpdatePagination:
     case Chat2Gen.setConversationOffline:
     case Chat2Gen.updateConvRetentionPolicy:
+    case Chat2Gen.updateTeamRetentionPolicy:
       return state.withMutations(s => {
         s.set('metaMap', metaMapReducer(state.metaMap, action))
         s.set('messageMap', messageMapReducer(state.messageMap, action, state.pendingOutboxToOrdinal))

--- a/shared/util/teams.js
+++ b/shared/util/teams.js
@@ -54,11 +54,11 @@ function makeRetentionNotice(
   let explanation = ''
   switch (policy.type) {
     case 'expire':
-      explanation = `are destroyed after ${policy.days} days.`
+      explanation = `are destroyed after ${policy.days} day${policy.days !== 1 ? 's' : ''}.`
       break
     case 'inherit':
       // teamPolicy can't be retain
-      explanation = `are destroyed after ${teamPolicy.days} days`
+      explanation = `are destroyed after ${teamPolicy.days} day${teamPolicy.days !== 1 ? 's' : ''}`
       explanation += teamType === 'small' ? '.' : ', the team default.'
       break
   }


### PR DESCRIPTION
Adds an `incomingActionCreator` to dispatch an action that updates both the chat & team store's versions of the team retention policy. Also does a tiny wording fix in the retention notice. r? @keybase/react-hackers 