### PR TITLE
properly let generic setting win over @ metion CORE-7575

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -355,6 +355,10 @@ func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 		kind := chat1.NotificationKind_GENERIC
 		switch typ {
 		case chat1.MessageType_TEXT, chat1.MessageType_SYSTEM:
+			// Check for generic hit on desktop right off and return true if we hit
+			if conv.Notifications.Settings[apptype][kind] {
+				return true
+			}
 			for _, at := range msg.Valid().AtMentions {
 				if at.Eq(uid) {
 					kind = chat1.NotificationKind_ATMENTION

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2989,7 +2989,34 @@ func TestChatSrvSetAppNotificationSettings(t *testing.T) {
 
 		mustPostLocalForTest(t, ctc, users[1], conv,
 			chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello!"}))
-
+		select {
+		case info := <-listener0.newMessage:
+			require.Equal(t, chat1.MessageType_TEXT, info.Message.GetMessageType())
+			require.True(t, info.DisplayDesktopNotification)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no new message event")
+		}
+		setting := chat1.AppNotificationSettingLocal{
+			DeviceType: keybase1.DeviceType_DESKTOP,
+			Kind:       chat1.NotificationKind_ATMENTION,
+			Enabled:    false,
+		}
+		_, err = ctc.as(t, users[0]).chatLocalHandler().SetAppNotificationSettingsLocal(ctx,
+			chat1.SetAppNotificationSettingsLocalArg{
+				ConvID:   conv.Id,
+				Settings: []chat1.AppNotificationSettingLocal{setting},
+			})
+		require.NoError(t, err)
+		select {
+		case rsettings := <-listener0.appNotificationSettings:
+			require.Equal(t, gconv.GetConvID(), rsettings.ConvID)
+			require.Equal(t, 2, len(rsettings.Settings.Settings))
+			require.False(t, rsettings.Settings.ChannelWide)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no app notification received")
+		}
+		mustPostLocalForTest(t, ctc, users[1], conv,
+			chat1.NewMessageBodyWithText(chat1.MessageText{Body: fmt.Sprintf("@%s", users[0].Username)}))
 		select {
 		case info := <-listener0.newMessage:
 			require.Equal(t, chat1.MessageType_TEXT, info.Message.GetMessageType())
@@ -2998,15 +3025,20 @@ func TestChatSrvSetAppNotificationSettings(t *testing.T) {
 			require.Fail(t, "no new message event")
 		}
 
-		setting := chat1.AppNotificationSettingLocal{
+		setting = chat1.AppNotificationSettingLocal{
 			DeviceType: keybase1.DeviceType_DESKTOP,
 			Kind:       chat1.NotificationKind_GENERIC,
 			Enabled:    false,
 		}
+		setting2 := chat1.AppNotificationSettingLocal{
+			DeviceType: keybase1.DeviceType_DESKTOP,
+			Kind:       chat1.NotificationKind_ATMENTION,
+			Enabled:    true,
+		}
 		_, err = ctc.as(t, users[0]).chatLocalHandler().SetAppNotificationSettingsLocal(ctx,
 			chat1.SetAppNotificationSettingsLocalArg{
 				ConvID:   conv.Id,
-				Settings: []chat1.AppNotificationSettingLocal{setting},
+				Settings: []chat1.AppNotificationSettingLocal{setting, setting2},
 			})
 		require.NoError(t, err)
 		select {


### PR DESCRIPTION
We were treating notifications as an either/or thing with generic mentions, so if someone @ mentions you in a channel where you have all activity generating badges, you'd get no desktop notification. 

cc @buoyad 