### PR TITLE
fix relogin crash

### DIFF
--- a/shared/common-adapters/input.js.flow
+++ b/shared/common-adapters/input.js.flow
@@ -62,6 +62,10 @@ export type Props = {
   keyboardType?: KeyboardType,
   returnKeyType?: 'done' | 'go' | 'next' | 'search' | 'send',
   selectTextOnFocus?: boolean,
+  // TODO this is a short term hack to have this be uncontrolled. I think likely by default we would want this to be uncontrolled but
+  // i'm afraid of touching this now while I'm fixing a crash.
+  // If true it won't use its internal value to drive its rendering
+  uncontrolled?: boolean,
 }
 
 declare export default class Input extends Component<Props> {

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -262,6 +262,10 @@ class Input extends Component<Props, State> {
       ...(this.props.maxLength ? {maxlength: this.props.maxLength} : null),
     }
 
+    if (this.props.uncontrolled) {
+      delete commonProps['value']
+    }
+
     const singlelineProps = {
       ...commonProps,
       multiline: false,

--- a/shared/login/login/index.native.js
+++ b/shared/login/login/index.native.js
@@ -24,7 +24,7 @@ class LoginRender extends Component<Props> {
       onEnterKeyDown: () => this.props.onSubmit(),
       errorText: this.props.error,
       autoFocus: true,
-      // There is a weird but with RN 0.54+ where if this is controlled it somehow causes a race which causes a crash
+      // There is a weird bug with RN 0.54+ where if this is controlled it somehow causes a race which causes a crash
       // making this uncontrolled fixes this
       uncontrolled: true,
     }

--- a/shared/login/login/index.native.js
+++ b/shared/login/login/index.native.js
@@ -24,6 +24,9 @@ class LoginRender extends Component<Props> {
       onEnterKeyDown: () => this.props.onSubmit(),
       errorText: this.props.error,
       autoFocus: true,
+      // There is a weird but with RN 0.54+ where if this is controlled it somehow causes a race which causes a crash
+      // making this uncontrolled fixes this
+      uncontrolled: true,
     }
 
     const checkboxProps = [


### PR DESCRIPTION
This took awhile to figure out (git bisect etc).

There is a bug in the last release where under some circumstances if you logout / login on ios you'll crash out. I can 100% repro and I think its related to password length.

The crash you get in is deep in UIKit when its trying to measure layout of the RN tree. After a bunch of debugging there are a couple of fixes. (all applied to the password input)

1. Turning off the SemiBold font on the input fixes it
2. Turning off the password masking fixes it
3. Turning off it being controlled fixes it

Since this doesn't actually need to be controlled I implemented #3 to fix it. Since i wanted to minimally fix it I just added a new flag which only login uses and only implemented this on mobile.

The core issue is react native but it's controlled by these variables (and maybe others). With this fix I can't repro this crash anymore.

Longer term I think we could move our Input to be uncontrolled (or if you do control it you have to do it externally). Currently its 100% controlled

@keybase/react-hackers 