### PR TITLE
installer: 60s timeout for helper RPCs

### DIFF
--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.60</string>
+	<string>1.1.61</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.60</string>
+	<string>1.1.61</string>
 	<key>KBFuseBuild</key>
 	<string>3.6.3</string>
 	<key>KBFuseVersion</key>

--- a/osx/KBKit/KBKit/Component/KBHelperTool.m
+++ b/osx/KBKit/KBKit/Component/KBHelperTool.m
@@ -46,7 +46,7 @@
   MPXPCClient *client = [[MPXPCClient alloc] initWithServiceName:@"keybase.Helper" privileged:YES readOptions:MPMessagePackReaderOptionsUseOrderedDictionary];
   client.retryMaxAttempts = 4;
   client.retryDelay = 0.5;
-  client.timeout = 10.0;
+  client.timeout = 60.0;
   return client;
 }
 

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -15,7 +15,7 @@ cd $dir
 client_dir="$dir/../.."
 fuse_dir="$client_dir/osx/Fuse"
 tmp_dir="/tmp/desktop-kbfuse"
-installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.60-darwin.tgz"
+installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.61-darwin.tgz"
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -97,7 +97,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.60-darwin.tgz"
+installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.61-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://prerelease.keybase.io/darwin-package/KeybaseUpdater-1.0.6-darwin.tgz"
 


### PR DESCRIPTION
Installing the redirector can take a while on slow machines, since it involves copying a binary and checking its signature.

A few people who had seen the error somewhat reliably say they no longer see it with this build.

Issue: #11197 
