### PR TITLE
Add support for local currency conversion in `keybase wallet send`

### DIFF
--- a/go/client/cmd_wallet_balances.go
+++ b/go/client/cmd_wallet_balances.go
@@ -85,9 +85,9 @@ func (c *cmdWalletBalances) runForUser(cli stellar1.LocalClient) error {
 			localAmountStr := ""
 			if balance.Asset.IsNativeXLM() {
 				if acc.LocalCurrency != "" {
-					localAmount, err := acc.LocalExchangeRate.ConvertXLM(balance.Amount)
+					localAmount, err := acc.LocalExchangeRate.ConvertXLMToLocal(balance.Amount)
 					if err == nil {
-						localAmountStr = fmt.Sprintf(" (%s %s)", localAmount, string(acc.LocalCurrency))
+						localAmountStr = fmt.Sprintf(" (~%s %s)", localAmount, string(acc.LocalCurrency))
 					} else {
 						c.G().Log.Warning("Unable to convert to local currency: %s", err)
 					}

--- a/go/client/cmd_wallet_balances.go
+++ b/go/client/cmd_wallet_balances.go
@@ -85,7 +85,7 @@ func (c *cmdWalletBalances) runForUser(cli stellar1.LocalClient) error {
 			localAmountStr := ""
 			if balance.Asset.IsNativeXLM() {
 				if acc.LocalCurrency != "" {
-					localAmount, err := acc.LocalExchangeRate.ConvertXLMToLocal(balance.Amount)
+					localAmount, err := acc.LocalExchangeRate.ConvertXLMToLocal(balance.Amount, 2)
 					if err == nil {
 						localAmountStr = fmt.Sprintf(" (~%s %s)", localAmount, string(acc.LocalCurrency))
 					} else {

--- a/go/client/cmd_wallet_send.go
+++ b/go/client/cmd_wallet_send.go
@@ -82,7 +82,7 @@ func (c *cmdWalletSend) Run() error {
 		}
 
 		ui.Printf("Current exchange rate for XLM%s is: ~%s\n", c.localCurrency, exchangeRate.Format('f', 3))
-		amountDesc = fmt.Sprintf("~%s %s (%s XLM)", c.amount, c.localCurrency, amount)
+		amountDesc = fmt.Sprintf("%s XLM (~%s %s)", amount, c.amount, c.localCurrency)
 	}
 
 	if err := ui.PromptForConfirmation(fmt.Sprintf("Send %s to %s?", ColorString(c.G(), "green", amountDesc), ColorString(c.G(), "yellow", c.recipient))); err != nil {

--- a/go/client/cmd_wallet_send.go
+++ b/go/client/cmd_wallet_send.go
@@ -51,6 +51,9 @@ func (c *cmdWalletSend) ParseArgv(ctx *cli.Context) error {
 	c.amount = ctx.Args()[1]
 	if len(ctx.Args()) == 3 {
 		c.localCurrency = strings.ToUpper(ctx.Args()[2])
+		if len(c.localCurrency) != 3 {
+			return errors.New("Invalid currency code")
+		}
 	}
 	c.note = ctx.String("message")
 	return nil

--- a/go/client/cmd_wallet_send.go
+++ b/go/client/cmd_wallet_send.go
@@ -76,12 +76,12 @@ func (c *cmdWalletSend) Run() error {
 			return fmt.Errorf("Unable to get exchange rate for %q: %s", c.localCurrency, err)
 		}
 
-		amount, err = exchangeRate.ConvertLocalToXLM(c.amount)
+		amount, err = exchangeRate.ConvertLocalToXLM(c.amount, 4)
 		if err != nil {
 			return err
 		}
 
-		ui.Printf("Current exchange rate for XLM%s is: ~%s\n", c.localCurrency, exchangeRate.Format('f', 3))
+		ui.Printf("Current exchange rate for XLM%s is: ~%s\n", c.localCurrency, exchangeRate.Format('f', 4))
 		amountDesc = fmt.Sprintf("%s XLM (~%s %s)", amount, c.amount, c.localCurrency)
 	}
 

--- a/go/client/cmd_wallet_send.go
+++ b/go/client/cmd_wallet_send.go
@@ -3,6 +3,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
@@ -13,9 +14,10 @@ import (
 
 type cmdWalletSend struct {
 	libkb.Contextified
-	recipient string
-	amount    string
-	note      string
+	recipient     string
+	amount        string
+	note          string
+	localCurrency string
 }
 
 func newCmdWalletSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -30,7 +32,7 @@ func newCmdWalletSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 	}
 	return cli.Command{
 		Name:         "send",
-		ArgumentHelp: "<recipient> <amount> [-m message]",
+		ArgumentHelp: "<recipient> <amount> <local currency> [-m message]",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(cmd, "send", c)
 		},
@@ -39,12 +41,17 @@ func newCmdWalletSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 }
 
 func (c *cmdWalletSend) ParseArgv(ctx *cli.Context) error {
-	if len(ctx.Args()) != 2 {
-		return errors.New("send expects exactly two arguments")
+	if len(ctx.Args()) > 3 {
+		return errors.New("send expects at most three arguments")
+	} else if len(ctx.Args()) < 2 {
+		return errors.New("send expects at least two arguments (recipient and amount)")
 	}
 
 	c.recipient = ctx.Args()[0]
 	c.amount = ctx.Args()[1]
+	if len(ctx.Args()) == 3 {
+		c.localCurrency = strings.ToUpper(ctx.Args()[2])
+	}
 	c.note = ctx.String("message")
 	return nil
 }
@@ -56,13 +63,32 @@ func (c *cmdWalletSend) Run() error {
 	}
 
 	ui := c.G().UI.GetTerminalUI()
-	if err := ui.PromptForConfirmation(fmt.Sprintf("Send %s XLM to %s?", ColorString(c.G(), "green", c.amount), ColorString(c.G(), "yellow", c.recipient))); err != nil {
+
+	amount := c.amount
+	amountDesc := fmt.Sprintf("%s XLM", amount)
+
+	if c.localCurrency != "" && c.localCurrency != "XLM" {
+		exchangeRate, err := cli.ExchangeRateLocal(context.Background(), stellar1.LocalCurrencyCode(c.localCurrency))
+		if err != nil {
+			return fmt.Errorf("Unable to get exchange rate for %q: %s", c.localCurrency, err)
+		}
+
+		amount, err = exchangeRate.ConvertLocalToXLM(c.amount)
+		if err != nil {
+			return err
+		}
+
+		ui.Printf("Current exchange rate for XLM%s is: ~%s\n", c.localCurrency, exchangeRate.Format('f', 3))
+		amountDesc = fmt.Sprintf("~%s %s (%s XLM)", c.amount, c.localCurrency, amount)
+	}
+
+	if err := ui.PromptForConfirmation(fmt.Sprintf("Send %s to %s?", ColorString(c.G(), "green", amountDesc), ColorString(c.G(), "yellow", c.recipient))); err != nil {
 		return err
 	}
 
 	arg := stellar1.SendLocalArg{
 		Recipient: c.recipient,
-		Amount:    c.amount,
+		Amount:    amount,
 		Asset:     stellar1.Asset{Type: "native"},
 		Note:      c.note,
 	}

--- a/go/protocol/stellar1/extras.go
+++ b/go/protocol/stellar1/extras.go
@@ -121,23 +121,23 @@ func AssetNative() Asset {
 	}
 }
 
-func (b LocalExchangeRate) ConvertXLMToLocal(XLMAmount string) (localAmount string, err error) {
+func (b LocalExchangeRate) ConvertXLMToLocal(XLMAmount string, precision int) (localAmount string, err error) {
 	local, err := strconv.ParseFloat(XLMAmount, 64)
 	if err != nil {
 		return "", err
 	}
 
-	localAmount = strconv.FormatFloat(local*float64(b), 'f', 2, 64)
+	localAmount = strconv.FormatFloat(local*float64(b), 'f', precision, 64)
 	return localAmount, nil
 }
 
-func (b LocalExchangeRate) ConvertLocalToXLM(localAmount string) (XLMAmount string, err error) {
+func (b LocalExchangeRate) ConvertLocalToXLM(localAmount string, precision int) (XLMAmount string, err error) {
 	local, err := strconv.ParseFloat(localAmount, 64)
 	if err != nil {
 		return "", err
 	}
 
-	XLMAmount = strconv.FormatFloat(local/float64(b), 'f', 2, 64)
+	XLMAmount = strconv.FormatFloat(local/float64(b), 'f', precision, 64)
 	return XLMAmount, nil
 }
 

--- a/go/protocol/stellar1/extras.go
+++ b/go/protocol/stellar1/extras.go
@@ -121,12 +121,26 @@ func AssetNative() Asset {
 	}
 }
 
-func (b LocalExchangeRate) ConvertXLM(XLMAmount string) (localAmount string, err error) {
+func (b LocalExchangeRate) ConvertXLMToLocal(XLMAmount string) (localAmount string, err error) {
 	local, err := strconv.ParseFloat(XLMAmount, 64)
 	if err != nil {
 		return "", err
 	}
 
-	localAmount = strconv.FormatFloat(float64(b)*local, 'f', 2, 64)
+	localAmount = strconv.FormatFloat(local*float64(b), 'f', 2, 64)
 	return localAmount, nil
+}
+
+func (b LocalExchangeRate) ConvertLocalToXLM(localAmount string) (XLMAmount string, err error) {
+	local, err := strconv.ParseFloat(localAmount, 64)
+	if err != nil {
+		return "", err
+	}
+
+	XLMAmount = strconv.FormatFloat(local/float64(b), 'f', 2, 64)
+	return XLMAmount, nil
+}
+
+func (b LocalExchangeRate) Format(fmt byte, precision int) string {
+	return strconv.FormatFloat(float64(b), fmt, precision, 32)
 }

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -252,6 +252,10 @@ func getLocalCurrencyAndExchangeRate(ctx context.Context, g *libkb.GlobalContext
 func (s *Server) WalletGetLocalAccounts(ctx context.Context) (ret []stellar1.LocalOwnAccount, err error) {
 	ctx = s.logTag(ctx)
 	defer s.G().CTraceTimed(ctx, "WalletGetLocalAccounts", func() error { return err })()
+	err = s.assertLoggedIn(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	dump, _, err := remote.Fetch(ctx, s.G())
 	if err != nil {
@@ -285,4 +289,14 @@ func (s *Server) WalletGetLocalAccounts(ctx context.Context) (ret []stellar1.Loc
 	}
 
 	return ret, accountError
+}
+
+func (s *Server) ExchangeRateLocal(ctx context.Context, currency stellar1.LocalCurrencyCode) (res stellar1.LocalExchangeRate, err error) {
+	ctx = s.logTag(ctx)
+	defer s.G().CTraceTimed(ctx, fmt.Sprintf("ExchangeRateLocal(%s)", string(currency)), func() error { return err })()
+	rate, err := remote.ExchangeRate(ctx, s.G(), string(currency))
+	if err != nil {
+		return res, err
+	}
+	return stellar1.LocalExchangeRate(rate.Price), nil
 }

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -48,4 +48,6 @@ protocol local {
   void importSecretKeyLocal(SecretKey secretKey, boolean makePrimary);
 
   void setDisplayCurrency(AccountID accountID, string currency);
+
+  LocalExchangeRate exchangeRateLocal(LocalCurrencyCode currency);
 }

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -217,6 +217,15 @@
         }
       ],
       "response": null
+    },
+    "exchangeRateLocal": {
+      "request": [
+        {
+          "name": "currency",
+          "type": "LocalCurrencyCode"
+        }
+      ],
+      "response": "LocalExchangeRate"
     }
   },
   "namespace": "stellar.1"


### PR DESCRIPTION
Example command and output:
```
 » keybase wallet send t_alice 0.5 USD
Current exchange rate for XLMUSD is: ~0.194
Send ~0.5 USD (2.58 XLM) to t_alice? (type 'YES' to confirm):
```

This might end up a bit confusing when we start supporting multiple asset types. E.g. someone would want to send `HUGS` - then `keybase wallet send t_bob 10 HUGS` makes a lot of sense. Something more explicit might be preferable. The command will be less straight forward to use but more clear to what will actually happen.