### PR TITLE
Add pukring getter that only calls sync when it doesn't find key

### DIFF
--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -357,6 +357,17 @@ func (s *PerUserKeyring) GetSeedByGeneration(ctx context.Context, gen keybase1.P
 	return key.seed, nil
 }
 
+func (s *PerUserKeyring) GetSeedByGenerationOrSync(ctx context.Context, gen keybase1.PerUserKeyGeneration) (res PerUserKeySeed, err error) {
+	if seed, err := s.GetSeedByGeneration(ctx, gen); err == nil {
+		return seed, nil
+	}
+	// Generation was not available, try to sync.
+	if err := s.Sync(ctx); err != nil {
+		return res, err
+	}
+	return s.GetSeedByGeneration(ctx, gen)
+}
+
 // Get the encryption key of a generation.
 func (s *PerUserKeyring) GetEncryptionKeyByGeneration(ctx context.Context, gen keybase1.PerUserKeyGeneration) (*NaclDHKeyPair, error) {
 	s.Lock()
@@ -386,6 +397,17 @@ func (s *PerUserKeyring) GetEncryptionKeyBySeqno(ctx context.Context, seqno keyb
 		return nil, fmt.Errorf("no encrypted key for seqno %v", seqno)
 	}
 	return s.getEncryptionKeyByGenerationLocked(ctx, gen)
+}
+
+func (s *PerUserKeyring) GetEncryptionKeyBySeqnoOrSync(ctx context.Context, seqno keybase1.Seqno) (*NaclDHKeyPair, error) {
+	if key, err := s.GetEncryptionKeyBySeqno(ctx, seqno); err == nil {
+		return key, nil
+	}
+	// Key at generation from seqno was not available, try to sync.
+	if err := s.Sync(ctx); err != nil {
+		return nil, err
+	}
+	return s.GetEncryptionKeyBySeqno(ctx, seqno)
 }
 
 // GetEncryptionKeyByKID finds an encryption key that matches kid.

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -181,11 +181,7 @@ func Fetch(ctx context.Context, g *libkb.GlobalContext) (res stellar1.Bundle, pu
 	if err != nil {
 		return res, 0, err
 	}
-	err = pukring.Sync(ctx)
-	if err != nil {
-		return res, 0, err
-	}
-	puk, err := pukring.GetSeedByGeneration(ctx, decodeRes.Enc.Gen)
+	puk, err := pukring.GetSeedByGenerationOrSync(ctx, decodeRes.Enc.Gen)
 	if err != nil {
 		return res, 0, err
 	}

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -137,16 +137,7 @@ func (l *LoaderContextG) perUserEncryptionKey(ctx context.Context, userSeqno key
 	if err != nil {
 		return nil, err
 	}
-	// Try to get it locally, if that fails try again after syncing.
-	encKey, err := kr.GetEncryptionKeyBySeqno(ctx, userSeqno)
-	if err == nil {
-		return encKey, err
-	}
-	if err := kr.Sync(ctx); err != nil {
-		return nil, err
-	}
-	encKey, err = kr.GetEncryptionKeyBySeqno(ctx, userSeqno)
-	return encKey, err
+	return kr.GetEncryptionKeyBySeqnoOrSync(ctx, userSeqno)
 }
 
 func (l *LoaderContextG) merkleLookup(ctx context.Context, teamID keybase1.TeamID, public bool) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error) {


### PR DESCRIPTION
The locking situation in these new functions is not ideal there but I did not want to refactor all of the locking in `per_user_key.go`. Should we spend more time on this?