### PR TITLE
Swap out metamap atomically on certain notifications

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -348,7 +348,8 @@ export const createMetasReceived = (
   payload: $ReadOnly<{|
     metas: Array<Types.ConversationMeta>,
     neverCreate?: boolean,
-    clearExisting?: boolean,
+    clearExistingMetas?: boolean,
+    clearExistingMessages?: boolean,
   |}>
 ) => ({error: false, payload, type: metasReceived})
 export const createMuteConversation = (

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -348,6 +348,7 @@ export const createMetasReceived = (
   payload: $ReadOnly<{|
     metas: Array<Types.ConversationMeta>,
     neverCreate?: boolean,
+    clearExisting?: boolean,
   |}>
 ) => ({error: false, payload, type: metasReceived})
 export const createMuteConversation = (

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -641,7 +641,7 @@ const loadMoreMessages = (
     reason = action.payload.reason || 'selected'
   } else if (action.type === Chat2Gen.metasReceived) {
     if (!action.payload.clearExistingMessages) {
-      logger.info("Load thread bail: metas received but haven't cleared the existing messages")
+      // we didn't clear anything out, we don't need to fetch anything
       return
     }
     key = Constants.getSelectedConversation(state)

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -59,10 +59,12 @@ const inboxRefresh = (
           .map(item => Constants.unverifiedInboxUIItemToConversationMeta(item, username))
           .filter(Boolean)
         // Check if some of our existing stored metas might no longer be valid
-        const clearExisting =
+        const clearExistingMetas =
           action.type === Chat2Gen.inboxRefresh &&
           ['inboxSyncedClear', 'leftAConversation'].includes(action.payload.reason)
-        yield Saga.put(Chat2Gen.createMetasReceived({metas, clearExisting}))
+        const clearExistingMessages =
+          action.type === Chat2Gen.inboxRefresh && action.payload.reason === 'inboxSyncedClear'
+        yield Saga.put(Chat2Gen.createMetasReceived({metas, clearExistingMessages, clearExistingMetas}))
         return EngineRpc.rpcResult()
       },
     },

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -613,7 +613,8 @@ const loadMoreMessages = (
     | Chat2Gen.SelectConversationPayload
     | Chat2Gen.LoadOlderMessagesDueToScrollPayload
     | Chat2Gen.SetPendingConversationUsersPayload
-    | Chat2Gen.MarkConversationsStalePayload,
+    | Chat2Gen.MarkConversationsStalePayload
+    | Chat2Gen.MetasReceivedPayload,
   state: TypedState
 ) => {
   const numMessagesOnInitialLoad = isMobile ? 20 : 50
@@ -638,6 +639,12 @@ const loadMoreMessages = (
   } else if (action.type === Chat2Gen.selectConversation) {
     key = action.payload.conversationIDKey
     reason = action.payload.reason || 'selected'
+  } else if (action.type === Chat2Gen.metasReceived) {
+    if (!action.payload.clearExistingMessages) {
+      logger.info("Load thread bail: metas received but haven't cleared the existing messages")
+      return
+    }
+    key = Constants.getSelectedConversation(state)
   } else {
     key = action.payload.conversationIDKey
   }
@@ -1998,6 +2005,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
       Chat2Gen.loadOlderMessagesDueToScroll,
       Chat2Gen.setPendingConversationUsers,
       Chat2Gen.markConversationsStale,
+      Chat2Gen.metasReceived,
     ],
     loadMoreMessages,
     loadMoreMessagesSuccess

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -58,8 +58,11 @@ const inboxRefresh = (
         const metas = items
           .map(item => Constants.unverifiedInboxUIItemToConversationMeta(item, username))
           .filter(Boolean)
-
-        yield Saga.put(Chat2Gen.createMetasReceived({metas}))
+        // Check if some of our existing stored metas might no longer be valid
+        const clearExisting =
+          action.type === Chat2Gen.inboxRefresh &&
+          ['inboxSyncedClear', 'leftAConversation'].includes(action.payload.reason)
+        yield Saga.put(Chat2Gen.createMetasReceived({metas, clearExisting}))
         return EngineRpc.rpcResult()
       },
     },

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1047,7 +1047,7 @@ const cancelPendingConversation = (action: Chat2Gen.CancelPendingConversationPay
   ])
 
 const retryPendingConversation = (action: Chat2Gen.RetryPendingConversationPayload, state: TypedState) => {
-  const pendingMessages = state.chat2.messageMap.get(Types.stringToConversationIDKey(''))
+  const pendingMessages = state.chat2.messageMap.get(Constants.pendingConversationIDKey)
   if (!(pendingMessages && !pendingMessages.isEmpty())) {
     logger.warn('retryPendingConversation: found no pending messages; aborting')
     return

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -94,7 +94,8 @@
     "metasReceived": {
       "metas": "Array<Types.ConversationMeta>",
       "neverCreate?": "boolean", // If true never create a brand new meta, only update
-      "clearExisting?": "boolean", // If true, clear out the existing metaMap before inserting
+      "clearExistingMetas?": "boolean", // If true, clear out the existing metaMap before inserting
+      "clearExistingMessages?": "boolean", // If true, clear out any message data we already have.
     },
     // Got some inbox errors
     "metaReceivedError": {

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -94,6 +94,7 @@
     "metasReceived": {
       "metas": "Array<Types.ConversationMeta>",
       "neverCreate?": "boolean", // If true never create a brand new meta, only update
+      "clearExisting?": "boolean", // If true, clear out the existing metaMap before inserting
     },
     // Got some inbox errors
     "metaReceivedError": {

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -59,6 +59,7 @@ export const isUserActivelyLookingAtThisThread = (
     conversationIDKey === selectedConversationIDKey // looking at the selected thread?
   )
 }
+export const pendingConversationIDKey = Types.stringToConversationIDKey('')
 
 export {
   findConversationFromParticipants,

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -139,7 +139,6 @@ const metaMapReducer = (metaMap, action) => {
         return updated
       }, {})
       return metaMap.merge(newMetas)
-    case Chat2Gen.inboxRefresh: // fallthrough
     default:
       return metaMap
   }
@@ -158,8 +157,6 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
             ? message.set('submitState', action.type === Chat2Gen.messageDelete ? 'deleting' : 'editing')
             : message
       )
-    case Chat2Gen.inboxRefresh:
-      return action.payload.reason === 'inboxSyncedClear' ? messageMap.clear() : messageMap
     case Chat2Gen.messageAttachmentUploaded: {
       const {conversationIDKey, message, placeholderID} = action.payload
       const ordinal = messageIDToOrdinal(messageMap, pendingOutboxToOrdinal, conversationIDKey, placeholderID)
@@ -245,6 +242,13 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
         const path = action.error ? '' : action.payload.path
         return message.set('downloadPath', path)
       })
+    case Chat2Gen.metasReceived:
+      if (action.payload.clearExisting) {
+        // clear out what we have
+        // retain info pertaining to pending conversation
+        return messageMap.filter((_, k) => k !== Constants.pendingConversationIDKey)
+      }
+      return messageMap
     default:
       return messageMap
   }
@@ -252,10 +256,15 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
 
 const messageOrdinalsReducer = (messageOrdinals, action) => {
   switch (action.type) {
-    case Chat2Gen.inboxRefresh:
-      return action.payload.reason === 'inboxSyncedClear' ? messageOrdinals.clear() : messageOrdinals
     case Chat2Gen.markConversationsStale:
       return messageOrdinals.deleteAll(action.payload.conversationIDKeys)
+    case Chat2Gen.metasReceived:
+      if (action.payload.clearExisting) {
+        // clear out what we have
+        // retain info pertaining to pending conversation
+        return messageOrdinals.filter((_, k) => k !== Constants.pendingConversationIDKey)
+      }
+      return messageOrdinals
     default:
       return messageOrdinals
   }
@@ -521,7 +530,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     case Chat2Gen.setPendingMessageSubmitState: {
       const {reason, submitState} = action.payload
       logger.warn(`Got setPendingMessageSubmitState to '${submitState}' with reason: ${reason}`)
-      const conversationIDKey = Types.stringToConversationIDKey('')
+      const conversationIDKey = Constants.pendingConversationIDKey
       // We don't need to get the ordinals here, but we might as well check our state is kept internally consistent
       const ordinalMap = state.pendingOutboxToOrdinal.get(conversationIDKey)
       if (!ordinalMap) {
@@ -555,7 +564,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     }
     case Chat2Gen.clearPendingConversation: {
       return state.withMutations(s => {
-        const conversationIDKey = Types.stringToConversationIDKey('')
+        const conversationIDKey = Constants.pendingConversationIDKey
         s.deleteIn(['messageOrdinals', conversationIDKey])
         s.deleteIn(['pendingOutboxToOrdinal', conversationIDKey])
         s.deleteIn(['messageMap', conversationIDKey])
@@ -627,7 +636,6 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
       })
     }
     // metaMap/messageMap/messageOrdinalsList only actions
-    case Chat2Gen.inboxRefresh:
     case Chat2Gen.messageDelete:
     case Chat2Gen.messageEdit:
     case Chat2Gen.messageWasEdited:
@@ -660,6 +668,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     case Chat2Gen.attachmentUpload:
     case Chat2Gen.desktopNotification:
     case Chat2Gen.exitSearch:
+    case Chat2Gen.inboxRefresh:
     case Chat2Gen.joinConversation:
     case Chat2Gen.leaveConversation:
     case Chat2Gen.loadOlderMessagesDueToScroll:

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -243,9 +243,13 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
         return message.set('downloadPath', path)
       })
     case Chat2Gen.metasReceived:
-      return action.payload.clearExistingMessages
-        ? messageMap.filter((_, k) => k !== Constants.pendingConversationIDKey)
-        : messageMap
+      const existingPending = messageMap.get(Constants.pendingConversationIDKey)
+      if (action.payload.clearExistingMessages) {
+        return existingPending
+          ? messageMap.clear().set(Constants.pendingConversationIDKey, existingPending)
+          : messageMap.clear()
+      }
+      return messageMap
     default:
       return messageMap
   }
@@ -256,9 +260,13 @@ const messageOrdinalsReducer = (messageOrdinals, action) => {
     case Chat2Gen.markConversationsStale:
       return messageOrdinals.deleteAll(action.payload.conversationIDKeys)
     case Chat2Gen.metasReceived:
-      return action.payload.clearExistingMessages
-        ? messageOrdinals.filter((_, k) => k !== Constants.pendingConversationIDKey)
-        : messageOrdinals
+      const existingPending = messageOrdinals.get(Constants.pendingConversationIDKey)
+      if (action.payload.clearExistingMessages) {
+        return existingPending
+          ? messageOrdinals.clear().set(Constants.pendingConversationIDKey, existingPending)
+          : messageOrdinals.clear()
+      }
+      return messageOrdinals
     default:
       return messageOrdinals
   }

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -107,6 +107,9 @@ const metaMapReducer = (metaMap, action) => {
     }
     case Chat2Gen.metasReceived:
       return metaMap.withMutations(map => {
+        if (action.payload.clearExisting) {
+          map.clear()
+        }
         const neverCreate = !!action.payload.neverCreate
         action.payload.metas.forEach(meta => {
           map.update(meta.conversationIDKey, old => {
@@ -118,10 +121,6 @@ const metaMapReducer = (metaMap, action) => {
           })
         })
       })
-    case Chat2Gen.inboxRefresh:
-      return ['inboxSyncedClear', 'leftAConversation'].includes(action.payload.reason)
-        ? metaMap.clear()
-        : metaMap
     case Chat2Gen.updateConvRetentionPolicy:
       const {conv} = action.payload
       const newMeta = Constants.inboxUIItemToConversationMeta(conv)
@@ -140,6 +139,7 @@ const metaMapReducer = (metaMap, action) => {
         return updated
       }, {})
       return metaMap.merge(newMetas)
+    case Chat2Gen.inboxRefresh: // fallthrough
     default:
       return metaMap
   }


### PR DESCRIPTION
Fixes a race Chris ran into: when we get a `leaveConversation` notification from the service, we were handling it in the reducer by clearing out the `metaMap` while a request for the new metas was inflight. There was a short time when we didn't have a `metaMap` in the store because of this. If you tried to do anything that depends on `metaMap` in the meantime (e.g. sending a message), we could end up sending malformed RPCs.

This PR gets rid of that timing issue and makes the clear -> replace atomic by adding a flag `clearExisting` to the `metasReceived` action.

- [x] Retain pending conversation data on metasReceived w/ clearExisting