### PR TITLE
Call previewConversation for messageLink as well

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -802,7 +802,7 @@ const loadMoreMessagesSuccess = (results: ?Array<any>) => {
 
 // If we're previewing a conversation we tell the service so it injects it into the inbox with a flag to tell us its a preview
 const previewConversation = (action: Chat2Gen.SelectConversationPayload) =>
-  action.payload.reason === 'preview'
+  action.payload.reason === 'preview' || action.payload.reason === 'messageLink'
     ? Saga.call(RPCChatTypes.localPreviewConversationByIDLocalRpcPromise, {
         convID: Types.keyToConversationID(action.payload.conversationIDKey),
       })


### PR DESCRIPTION
Fixes channel mentions behaving weirdly for channels you're not in. r? @keybase/react-hackers 