### PR TITLE
Set icon height in chat retention notice

### DIFF
--- a/shared/chat/conversation/messages/retention-notice/index.js
+++ b/shared/chat/conversation/messages/retention-notice/index.js
@@ -36,4 +36,6 @@ const containerStyle = {
 
 const iconStyle = {
   marginBottom: globalMargins.tiny,
+  height: isMobile ? 48 : 32,
+  width: isMobile ? 48 : 32,
 }


### PR DESCRIPTION
Improves the consistency of measuring the height of the message. r? @keybase/react-hackers 