### PR TITLE
only delay offline check when in foreground CORE-7583

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -34,7 +34,7 @@ func newBaseConversationSource(g *globals.Context, ri func() chat1.RemoteInterfa
 		DebugLabeler:     labeler,
 		ri:               ri,
 		boxer:            boxer,
-		sourceOfflinable: newSourceOfflinable(labeler),
+		sourceOfflinable: newSourceOfflinable(g, labeler),
 	}
 }
 

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -342,7 +342,7 @@ func NewRemoteInboxSource(g *globals.Context, ri func() chat1.RemoteInterface) *
 	s := &RemoteInboxSource{
 		Contextified:     globals.NewContextified(g),
 		DebugLabeler:     labeler,
-		sourceOfflinable: newSourceOfflinable(labeler),
+		sourceOfflinable: newSourceOfflinable(g, labeler),
 	}
 	s.baseInboxSource = newBaseInboxSource(g, s, ri)
 	return s
@@ -487,7 +487,7 @@ func NewHybridInboxSource(g *globals.Context,
 	s := &HybridInboxSource{
 		Contextified:     globals.NewContextified(g),
 		DebugLabeler:     labeler,
-		sourceOfflinable: newSourceOfflinable(labeler),
+		sourceOfflinable: newSourceOfflinable(g, labeler),
 	}
 	s.baseInboxSource = newBaseInboxSource(g, s, getChatInterface)
 	return s

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -492,6 +492,10 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}
+	// If this is from a push, set us into the foreground
+	if arg.Reason == chat1.GetThreadNonblockReason_PUSH {
+		h.G().AppState.Update(keybase1.AppState_FOREGROUND)
+	}
 
 	// Set last select conversation on syncer
 	h.G().Syncer.SelectConversation(ctx, arg.ConversationID)

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -494,6 +494,11 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 	}
 	// If this is from a push, set us into the foreground
 	if arg.Reason == chat1.GetThreadNonblockReason_PUSH {
+		// Also if we get here and we claim to not be in the foreground yet, then hit disconnect
+		// to reset any delay checks or timers
+		if h.G().AppState.State() != keybase1.AppState_FOREGROUND {
+			h.G().Syncer.Disconnected(ctx)
+		}
 		h.G().AppState.Update(keybase1.AppState_FOREGROUND)
 	}
 

--- a/go/chat/sourceofflinable.go
+++ b/go/chat/sourceofflinable.go
@@ -65,7 +65,7 @@ func (s *sourceOfflinable) IsOffline(ctx context.Context) bool {
 	s.Unlock()
 
 	if offline {
-		if !delayed {
+		if delayed {
 			s.Debug(ctx, "IsOffline: offline, but skipping delay since we already did it")
 			return offline
 		}


### PR DESCRIPTION
Patch does the following:

1.) Does not delay and wait for connection in `IsOffline` if the app is not in the foreground. Otherwise we would get a bad interaction with `UnboxMobilePushNotification` where we would run `IsOffline` get delayed 4 seconds (which would hurt the plaintext notification), and then on foreground would not do the wait since we thought we already did (the `!delayed` check). After this change, we won't set this variable in the background, and the delay will happen once foregrounded.
2.) Change `GetThreadNonblock` to use the new `Reason` parameter to set itself into the foreground if the reason is `PUSH`. The frontend will call this function so fast that it will beat the normal foreground notification we get from the native code. So if we get a `PUSH` get thread call, just set ourselves into the foreground. cc @chrisnojima since this will be the first use of this parameter. 