### PR TITLE
make privacy screen go away faster on foreground on iOS

### DIFF
--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -210,7 +210,7 @@ const BOOL isDebug = NO;
 - (void) hideCover {
   // Always cancel outstanding animations else they can fight and the timing is very weird
   [self.resignImageView.layer removeAllAnimations];
-  [UIView animateWithDuration:0.3 delay:0.3 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
+  [UIView animateWithDuration:0.2 delay:0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
     self.resignImageView.alpha = 0;
   } completion:nil];
 }


### PR DESCRIPTION
@keybase/react-hackers 

The privacy screen currently is up for like 600ms, which I think makes the app feel slower than it actually is. Drop it down to 200ms animation with no delay of the privacy screen just showing.

cc @cecileboucheron @malgorithms in case you had any opinions.