### PR TITLE
Stellar note decrypt use fast puk getter

### DIFF
--- a/go/stellar/note.go
+++ b/go/stellar/note.go
@@ -89,11 +89,7 @@ func noteSymmetricKeyForDecryption(ctx context.Context, g *libkb.GlobalContext, 
 	if err != nil {
 		return res, err
 	}
-	err = pukring.Sync(ctx)
-	if err != nil {
-		return res, err
-	}
-	pukSeed, err := pukring.GetSeedByGeneration(ctx, mePukGen)
+	pukSeed, err := pukring.GetSeedByGenerationOrSync(ctx, mePukGen)
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
Hook it up to note. `keybase wallet history` used to take 2 + n API calls, now takes 2 (rarely 3). What a savings!