### PR TITLE
Show off-network accounts

### DIFF
--- a/go/client/cmd_wallet_balances.go
+++ b/go/client/cmd_wallet_balances.go
@@ -81,6 +81,15 @@ func (c *cmdWalletBalances) runForUser(cli stellar1.LocalClient) error {
 		}
 		dui.Printf("Balances for account %s:\n", accountName)
 
+		if len(acc.Balance) == 0 {
+			// If there are no balance entries the account is not on the network.
+			// Make a fake entry of 0 XLM to display.
+			acc.Balance = []stellar1.Balance{{
+				Asset:  stellar1.AssetNative(),
+				Amount: "0",
+				Limit:  "",
+			}}
+		}
 		for _, balance := range acc.Balance {
 			localAmountStr := ""
 			if balance.Asset.IsNativeXLM() {

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
@@ -238,6 +239,17 @@ func (s *Server) WalletGetLocalAccounts(ctx context.Context) (ret []stellar1.Loc
 
 		ret = append(ret, acc)
 	}
+
+	// Put the primary account first
+	sort.SliceStable(ret, func(i, j int) bool {
+		if ret[i].IsPrimary {
+			return true
+		}
+		if ret[j].IsPrimary {
+			return false
+		}
+		return i < j
+	})
 
 	return ret, accountError
 }


### PR DESCRIPTION
Deal with accounts that have no entries on the network. I just [changed stellard](https://github.com/keybase/keybase/pull/2339) to return no rows for these.

```
$ kbu wallet balances
Balances for account GADKGEK2DDUNBLGQB7HTSRKRIF2KVLCH3BMMX5BNA4XYGEMOGMXKMIGT (Primary):
XLM     0

Balances for account GDMJOZ4RU6LJHMIT73ADNHRC4TI5LN6R4GQCEDADMQPBID2HF5BFYBSV:
XLM     8.9987300

Balances for account GCE7UR3NRMAUE4CFEOFPRLLXFRVBY7EOBVV2UK5O2CJ3SMBBK3LKCS3E:
XLM     1.0000100

Balances for account GA34EWMWAHNA6KQ7LSNWWJZTWOZ3AY4X6UZQVWTNCX5ANV6G5PZDINHH:
XLM     0
```