### PR TITLE
Set pendingMode to fixedSetOfUsers on pending send

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -977,6 +977,8 @@ const sendToPendingConversation = (action: Chat2Gen.SendToPendingConversationPay
   return Saga.sequentially([
     // Disable sending more into a pending conversation
     Saga.put(Chat2Gen.createSetPendingStatus({pendingStatus: 'waiting'})),
+    // Disable searching for more people once you've tried to send
+    Saga.put(Chat2Gen.createSetPendingMode({pendingMode: 'fixedSetOfUsers'})),
     // Try to make the conversation
     Saga.call(RPCChatTypes.localNewConversationLocalRpcPromise, {
       identifyBehavior: RPCTypes.tlfKeysTLFIdentifyBehavior.chatGui,


### PR DESCRIPTION
Stops users from trying to search for users after attempting to send into a pending conversation. r? @keybase/react-hackers 