### PR TITLE
Purge client msg cache of ephemeral msgs

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -74,6 +74,9 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 
 	// Run type filter if it exists
 	thread.Messages = utils.FilterByType(thread.Messages, q, true)
+	// If we have exploded any messages while fetching them from cache, remove
+	// them now.
+	thread.Messages = utils.FilterExploded(thread.Messages)
 
 	// Fetch outbox and tack onto the result
 	outbox := storage.NewOutbox(s.G(), uid)

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -31,10 +31,11 @@ type Storage struct {
 	globals.Contextified
 	utils.DebugLabeler
 
-	engine       storageEngine
-	idtracker    *msgIDTracker
-	breakTracker *breakTracker
-	delhTracker  *delhTracker
+	engine           storageEngine
+	idtracker        *msgIDTracker
+	breakTracker     *breakTracker
+	delhTracker      *delhTracker
+	ephemeralTracker *ephemeralTracker
 }
 
 type storageEngine interface {
@@ -48,12 +49,13 @@ type storageEngine interface {
 
 func New(g *globals.Context) *Storage {
 	return &Storage{
-		Contextified: globals.NewContextified(g),
-		engine:       newBlockEngine(g),
-		idtracker:    newMsgIDTracker(g),
-		breakTracker: newBreakTracker(g),
-		delhTracker:  newDelhTracker(g),
-		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "Storage", false),
+		Contextified:     globals.NewContextified(g),
+		engine:           newBlockEngine(g),
+		idtracker:        newMsgIDTracker(g),
+		breakTracker:     newBreakTracker(g),
+		delhTracker:      newDelhTracker(g),
+		ephemeralTracker: newEphemeralTracker(g),
+		DebugLabeler:     utils.NewDebugLabeler(g.GetLog(), "Storage", false),
 	}
 }
 
@@ -315,10 +317,7 @@ func (s *Storage) Expunge(ctx context.Context,
 // MergeHelper requires msgs to be sorted by descending message ID
 // expunge is optional
 func (s *Storage) MergeHelper(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed, expunge *chat1.Expunge) (MergeResult, Error) {
-
-	var res MergeResult
-	var err Error
+	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed, expunge *chat1.Expunge) (res MergeResult, err Error) {
 
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functions.
@@ -358,6 +357,17 @@ func (s *Storage) MergeHelper(ctx context.Context,
 		return res, s.MaybeNuke(false, err, convID, uid)
 	}
 	res.Expunged = expunged
+
+	purgeInfo, _, err := s.filterEphemeralMessages(ctx, convID, uid, msgs)
+	if err != nil {
+		return res, s.MaybeNuke(false, err, convID, uid)
+	}
+	// We may only be merging in some subset of messages, we only update if the
+	// info we get is more restrictive that what we have already
+	err = s.ephemeralTracker.maybeUpdatePurgeInfo(ctx, convID, uid, purgeInfo)
+	if err != nil {
+		s.Debug(ctx, "failed to update ephemeralTracker")
+	}
 
 	// Update max msg ID if needed
 	if len(msgs) > 0 {
@@ -703,11 +713,17 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, rc ResultCollector,
 	s.Debug(ctx, "Fetch: using result collector: %s", rc)
 
 	// Run seek looking for all the messages
-	var res []chat1.MessageUnboxed
 	if err = s.engine.ReadMessages(ctx, rc, convID, uid, maxID); err != nil {
 		return chat1.ThreadView{}, err
 	}
-	res = rc.Result()
+	msgs := rc.Result()
+
+	// Clear out any ephemeral messages that have exploded before we hand these
+	// messages out.
+	_, validMsgs, err := s.filterEphemeralMessages(ctx, convID, uid, msgs)
+	if err != nil {
+		return chat1.ThreadView{}, err
+	}
 
 	// Get the stored latest point upto which has been deleted.
 	// `maxDeletedUpto` can be behind the times, so the pager is patched later in ConvSource.
@@ -725,16 +741,16 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, rc ResultCollector,
 	// Form paged result
 	var tres chat1.ThreadView
 	var pmsgs []pager.Message
-	for _, m := range res {
+	for _, m := range validMsgs {
 		pmsgs = append(pmsgs, m)
 	}
 	if tres.Pagination, ierr = pager.NewThreadPager().MakePage(pmsgs, num, maxDeletedUpto); ierr != nil {
 		return chat1.ThreadView{},
 			NewInternalError(ctx, s.DebugLabeler, "Fetch: failed to encode pager: %s", ierr.Error())
 	}
-	tres.Messages = res
+	tres.Messages = validMsgs
 
-	s.Debug(ctx, "Fetch: cache hit: num: %d", len(res))
+	s.Debug(ctx, "Fetch: cache hit: num: %d", len(validMsgs))
 	return tres, nil
 }
 

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -1,0 +1,125 @@
+package storage
+
+import (
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	context "golang.org/x/net/context"
+)
+
+// For a given conversation, purge all ephemeral messages from
+// purgeInfo.MinUnexplodedID to the present, updating bookkeeping for the next
+// time we need to purge this conv.
+func (s *Storage) EphemeralPurge(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, purgeInfo *ephemeralPurgeInfo) (*ephemeralPurgeInfo, Error) {
+	locks.Storage.Lock()
+	defer locks.Storage.Unlock()
+
+	if purgeInfo == nil {
+		return nil, nil
+	}
+
+	// Fetch secret key
+	key, ierr := getSecretBoxKey(ctx, s.G().ExternalG(), DefaultSecretUI)
+	if ierr != nil {
+		return nil, MiscError{Msg: "unable to get secret key: " + ierr.Error()}
+	}
+
+	ctx, err := s.engine.Init(ctx, key, convID, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	maxMsgID, err := s.idtracker.getMaxMessageID(ctx, convID, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	var target int
+	if purgeInfo.MinUnexplodedID == 0 {
+		target = -1 // we need to traverse the whole conversation
+	} else {
+		target = int(maxMsgID-purgeInfo.MinUnexplodedID) + 1
+	}
+	rc := NewSimpleResultCollector(target)
+	err = s.engine.ReadMessages(ctx, rc, convID, uid, maxMsgID)
+	var newPurgeInfo *ephemeralPurgeInfo
+	switch err.(type) {
+	case nil:
+		// ok
+	case MissError:
+		s.Debug(ctx, "record-only ephemeralTracker: no local messages")
+		// We don't have these messages in cache, so don't retry this
+		// conversation until further notice.
+		err := s.ephemeralTracker.deletePurgeInfo(ctx, convID, uid)
+		return nil, err
+	default:
+		return nil, err
+	}
+	newPurgeInfo, _, err = s.filterEphemeralMessages(ctx, convID, uid, rc.Result())
+	if err != nil {
+		return nil, err
+	}
+	// End of the line
+	if newPurgeInfo.MinUnexplodedID == maxMsgID {
+		err = s.ephemeralTracker.deletePurgeInfo(ctx, convID, uid)
+		return nil, err
+	}
+	err = s.ephemeralTracker.setPurgeInfo(ctx, convID, uid, newPurgeInfo)
+	return newPurgeInfo, err
+}
+
+// Before adding or removing messages from storage, filter them and give info
+// for our bookkeeping for the next time we have to purge.
+// requires msgs to be sorted by descending message ID
+func (s *Storage) filterEphemeralMessages(ctx context.Context, convID chat1.ConversationID,
+	uid gregor1.UID, msgs []chat1.MessageUnboxed) (*ephemeralPurgeInfo, []chat1.MessageUnboxed, Error) {
+	s.Debug(ctx, "filterEphemeralMessages convID: %v, uid: %v, numMessages %v", convID, uid, len(msgs))
+
+	if msgs == nil || len(msgs) == 0 {
+		return nil, msgs, nil
+	}
+
+	nextPurgeTime := gregor1.Time(0)
+	minUnexplodedID := msgs[0].GetMessageID()
+	var unexploded, exploded []chat1.MessageUnboxed
+	for _, msg := range msgs {
+		if !msg.IsValid() {
+			s.Debug(ctx, "skipping invalid msg: %v", msg.GetMessageID())
+			unexploded = append(unexploded, msg)
+			continue
+		}
+		mvalid := msg.Valid()
+		if mvalid.IsExploding() {
+			if !mvalid.IsEphemeralExpired() {
+				// Keep track of the minimum ephemeral message that is not yet
+				// exploded.
+				if msg.GetMessageID() < minUnexplodedID {
+					minUnexplodedID = msg.GetMessageID()
+				}
+				// Keep track of the next time we'll have purge this conv.
+				if nextPurgeTime == 0 || mvalid.Etime() < nextPurgeTime {
+					nextPurgeTime = mvalid.Etime()
+				}
+				s.Debug(ctx, "skipping unexpired ephemeral msg: %v", msg.GetMessageID())
+			} else {
+				var emptyBody chat1.MessageBody
+				mvalid.MessageBody = emptyBody
+				exploded = append(exploded, chat1.NewMessageUnboxedWithValid(mvalid))
+				s.Debug(ctx, "purging ephemeral msg: %v", msg.GetMessageID())
+				continue
+			}
+		}
+
+		unexploded = append(unexploded, msg)
+	}
+	s.Debug(ctx, "purging %v ephemeral messages", len(exploded))
+	err := s.engine.WriteMessages(ctx, convID, uid, exploded)
+	if err != nil {
+		s.Debug(ctx, "write messages failed: %v", err)
+		return nil, nil, err
+	}
+
+	return &ephemeralPurgeInfo{
+		MinUnexplodedID: minUnexplodedID,
+		NextPurgeTime:   nextPurgeTime,
+	}, unexploded, nil
+}

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -9,7 +9,7 @@ import (
 // For a given conversation, purge all ephemeral messages from
 // purgeInfo.MinUnexplodedID to the present, updating bookkeeping for the next
 // time we need to purge this conv.
-func (s *Storage) EphemeralPurge(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, purgeInfo *ephemeralPurgeInfo) (*ephemeralPurgeInfo, Error) {
+func (s *Storage) EphemeralPurge(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, purgeInfo *EphemeralPurgeInfo) (*EphemeralPurgeInfo, Error) {
 	locks.Storage.Lock()
 	defer locks.Storage.Unlock()
 
@@ -41,7 +41,7 @@ func (s *Storage) EphemeralPurge(ctx context.Context, convID chat1.ConversationI
 	}
 	rc := NewSimpleResultCollector(target)
 	err = s.engine.ReadMessages(ctx, rc, convID, uid, maxMsgID)
-	var newPurgeInfo *ephemeralPurgeInfo
+	var newPurgeInfo *EphemeralPurgeInfo
 	switch err.(type) {
 	case nil:
 		// ok
@@ -85,7 +85,7 @@ func (s *Storage) filterEphemeralMessages(ctx context.Context, convID chat1.Conv
 // for our bookkeeping for the next time we have to purge.
 // requires msgs to be sorted by descending message ID
 func (s *Storage) _filterEphemeralMessages(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, msgs []chat1.MessageUnboxed) (*ephemeralPurgeInfo, []chat1.MessageUnboxed, Error) {
+	uid gregor1.UID, msgs []chat1.MessageUnboxed) (*EphemeralPurgeInfo, []chat1.MessageUnboxed, Error) {
 	s.Debug(ctx, "_filterEphemeralMessages convID: %v, uid: %v, numMessages %v", convID, uid, len(msgs))
 
 	if msgs == nil || len(msgs) == 0 {
@@ -132,7 +132,7 @@ func (s *Storage) _filterEphemeralMessages(ctx context.Context, convID chat1.Con
 		return nil, nil, err
 	}
 
-	return &ephemeralPurgeInfo{
+	return &EphemeralPurgeInfo{
 		MinUnexplodedID: minUnexplodedID,
 		NextPurgeTime:   nextPurgeTime,
 	}, unexploded, nil

--- a/go/chat/storage/storage_ephemeral_purge_test.go
+++ b/go/chat/storage/storage_ephemeral_purge_test.go
@@ -1,0 +1,197 @@
+package storage
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageEphemeralPurge(t *testing.T) {
+	// Uses this conversation:
+	// A start                            <not deletable>
+	// B text                             <not ephemeral>
+	// C text <----\        edited by E   <ephemeral with 1 "lifetime">
+	// D headline  |                      <not deletable>
+	// E edit -----^        edits C       <ephemeral with 3 "lifetime"s>
+	// F text <---\         deleted by G  <ephemeral with 2 "lifetime"s>
+	// G delete --^    ___  deletes F     <not deletable>
+	// H text           |                 <ephemeral with 1 "lifetime">
+
+	_, storage, uid := setupStorageTest(t, "delh")
+
+	convID := makeConvID()
+
+	type expectedM struct {
+		Name         string // letter label
+		MsgID        chat1.MessageID
+		BodyPresent  bool
+		SupersededBy chat1.MessageID
+	}
+	dontCare := chat1.MessageID(12341234)
+
+	var expectedState []expectedM // expectations sorted by ID ascending
+	setExpected := func(name string, msg chat1.MessageUnboxed, bodyPresent bool, supersededBy chat1.MessageID) {
+		xset := expectedM{name, msg.GetMessageID(), bodyPresent, supersededBy}
+		var found bool
+		for i, x := range expectedState {
+			if x.Name == name {
+				found = true
+				expectedState[i] = xset
+			}
+		}
+		if !found {
+			expectedState = append(expectedState, xset)
+		}
+		sort.Slice(expectedState, func(i, j int) bool {
+			return expectedState[i].MsgID < expectedState[j].MsgID
+		})
+	}
+
+	unsetExpected := func(name string) {
+		var idx int
+		for i, x := range expectedState {
+			if x.Name == name {
+				idx = i
+				break
+			}
+		}
+		expectedState = append(expectedState[:idx], expectedState[idx+1:]...)
+	}
+
+	assertState := func(maxMsgID chat1.MessageID) {
+		var rc ResultCollector
+		res, err := storage.Fetch(context.Background(), makeConversationAt(convID, maxMsgID), uid, rc, nil, nil)
+		require.NoError(t, err)
+		if len(res.Messages) != len(expectedState) {
+			t.Logf("wrong number of messages")
+			for _, m := range res.Messages {
+				t.Logf("msgid:%v type:%v", m.GetMessageID(), m.GetMessageType())
+			}
+			require.Equal(t, len(expectedState), len(res.Messages), "wrong number of messages")
+		}
+		for i, x := range expectedState {
+			t.Logf("[%v] checking msgID:%v supersededBy:%v", x.Name, x.MsgID, x.SupersededBy)
+			m := res.Messages[len(res.Messages)-1-i]
+			require.True(t, m.IsValid(), "[%v] message should be valid", x.Name)
+			require.Equal(t, x.MsgID, m.Valid().ServerHeader.MessageID, "[%v] message ID", x.Name)
+			if m.GetMessageType() != chat1.MessageType_TLFNAME {
+				if !x.BodyPresent && x.SupersededBy == 0 {
+					t.Fatalf("You expected the body to be deleted but the message not to be superseded. Are you sure?")
+				}
+			}
+			if x.SupersededBy != dontCare {
+				require.Equal(t, x.SupersededBy, m.Valid().ServerHeader.SupersededBy, "[%v] superseded by", x.Name)
+			}
+			if x.BodyPresent {
+				require.False(t, m.Valid().MessageBody.IsNil(), "[%v] message body should not be deleted", x.Name)
+			} else {
+				require.True(t, m.Valid().MessageBody.IsNil(), "[%v] message body should be deleted", x.Name)
+			}
+		}
+	}
+
+	verifyTrackerState := func(expectedPurgeInfo *ephemeralPurgeInfo) {
+		purgeInfo, err := storage.ephemeralTracker.getPurgeInfo(context.Background(), convID, uid)
+		if expectedPurgeInfo == nil {
+			require.Error(t, err)
+			require.IsType(t, MissError{}, err, "wrong error type")
+		} else {
+			require.NoError(t, err)
+		}
+		require.Equal(t, expectedPurgeInfo, purgeInfo)
+	}
+
+	ephemeralPurgeAndVerify := func(expectedPurgeInfo *ephemeralPurgeInfo) {
+		purgeInfo, _ := storage.ephemeralTracker.getPurgeInfo(context.Background(), convID, uid)
+		newPurgeInfo, err := storage.EphemeralPurge(context.Background(), convID, uid, purgeInfo)
+		require.NoError(t, err)
+		require.Equal(t, expectedPurgeInfo, newPurgeInfo)
+		verifyTrackerState(expectedPurgeInfo)
+	}
+
+	lifetime := gregor1.DurationSec(1)
+	sleepLifetime := time.Second * time.Duration(lifetime)
+	msgA := makeMsgWithType(1, chat1.MessageType_TLFNAME)
+	msgB := makeText(2, "some text")
+	msgC := makeEphemeralText(3, "some text", &chat1.MsgEphemeralMetadata{Lifetime: lifetime})
+	msgD := makeHeadlineMessage(4)
+	msgE := makeEphemeralEdit(5, msgC.GetMessageID(), &chat1.MsgEphemeralMetadata{Lifetime: lifetime * 3})
+	msgF := makeEphemeralText(6, "some text", &chat1.MsgEphemeralMetadata{Lifetime: lifetime * 2})
+	msgG := makeDelete(7, msgF.GetMessageID(), nil)
+	msgH := makeEphemeralText(8, "some text", &chat1.MsgEphemeralMetadata{Lifetime: lifetime})
+
+	t.Logf("initial merge")
+	mustMerge(t, storage, convID, uid, sortMessagesDesc([]chat1.MessageUnboxed{msgA, msgB, msgC, msgD, msgE, msgF, msgG}))
+	// We set the purge time on the merge since we have no tracker data, but no IDs
+	verifyTrackerState(&ephemeralPurgeInfo{
+		NextPurgeTime:   msgC.Valid().Etime(),
+		MinUnexplodedID: 0,
+	})
+	// We keep the purge time since it's the minimum, but can now set the
+	// minUnexplodedID
+	expectedPurgeInfo := &ephemeralPurgeInfo{
+		NextPurgeTime:   msgC.Valid().Etime(),
+		MinUnexplodedID: msgC.GetMessageID(),
+	}
+	ephemeralPurgeAndVerify(expectedPurgeInfo)
+
+	setExpected("A", msgA, false, 0) // TLFNAME messages have no body
+	setExpected("B", msgB, true, 0)
+	setExpected("C", msgC, true, msgE.GetMessageID())
+	setExpected("D", msgD, true, 0)
+	setExpected("E", msgE, true, 0)
+	setExpected("F", msgF, false, msgG.GetMessageID())
+	setExpected("G", msgG, true, 0)
+	assertState(msgG.GetMessageID())
+
+	t.Logf("sleep and fetch")
+	// We sleep for `lifetime`, so we expect C to get purged on fetch (msg H is not get merged in)
+	// The tracker will not update though until EphemeralPurge runs again
+	time.Sleep(sleepLifetime)
+	unsetExpected("C")
+	assertState(msgG.GetMessageID())
+	verifyTrackerState(expectedPurgeInfo)
+	expectedPurgeInfo = &ephemeralPurgeInfo{
+		NextPurgeTime:   msgF.Valid().Etime(),
+		MinUnexplodedID: msgE.GetMessageID(),
+	}
+	ephemeralPurgeAndVerify(expectedPurgeInfo)
+
+	t.Logf("mergeH")
+	// We add msgH, which is already expired, so it should get purged on entry,
+	// but our nextPurgeTime should be unchanged
+	mustMerge(t, storage, convID, uid, sortMessagesDesc([]chat1.MessageUnboxed{msgH}))
+	verifyTrackerState(expectedPurgeInfo)
+	// We never set H in expected, since it's already gone..
+	assertState(msgH.GetMessageID())
+	verifyTrackerState(expectedPurgeInfo)
+
+	// we've slept for ~ lifetime*2, F's lifetime is up
+	time.Sleep(sleepLifetime)
+	expectedPurgeInfo = &ephemeralPurgeInfo{
+		NextPurgeTime:   msgE.Valid().Etime(),
+		MinUnexplodedID: msgE.GetMessageID(),
+	}
+	ephemeralPurgeAndVerify(expectedPurgeInfo)
+	unsetExpected("F")
+	assertState(msgH.GetMessageID())
+
+	// we've slept for ~ lifetime*3, E's lifetime is up
+	time.Sleep(sleepLifetime)
+	ephemeralPurgeAndVerify(nil)
+	unsetExpected("E")
+	assertState(msgH.GetMessageID())
+
+	t.Logf("purge with no effect")
+	ephemeralPurgeAndVerify(nil)
+	assertState(msgH.GetMessageID())
+
+	t.Logf("another purge with no effect")
+	ephemeralPurgeAndVerify(nil)
+	assertState(msgH.GetMessageID())
+}

--- a/go/chat/storage/storage_ephemeral_purge_test.go
+++ b/go/chat/storage/storage_ephemeral_purge_test.go
@@ -95,7 +95,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 		}
 	}
 
-	verifyTrackerState := func(expectedPurgeInfo *ephemeralPurgeInfo) {
+	verifyTrackerState := func(expectedPurgeInfo *EphemeralPurgeInfo) {
 		purgeInfo, err := storage.ephemeralTracker.getPurgeInfo(context.Background(), convID, uid)
 		if expectedPurgeInfo == nil {
 			require.Error(t, err)
@@ -106,7 +106,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 		require.Equal(t, expectedPurgeInfo, purgeInfo)
 	}
 
-	ephemeralPurgeAndVerify := func(expectedPurgeInfo *ephemeralPurgeInfo) {
+	ephemeralPurgeAndVerify := func(expectedPurgeInfo *EphemeralPurgeInfo) {
 		purgeInfo, _ := storage.ephemeralTracker.getPurgeInfo(context.Background(), convID, uid)
 		newPurgeInfo, err := storage.EphemeralPurge(context.Background(), convID, uid, purgeInfo)
 		require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 	t.Logf("initial merge")
 	mustMerge(t, storage, convID, uid, sortMessagesDesc([]chat1.MessageUnboxed{msgA, msgB, msgC, msgD, msgE, msgF, msgG}))
 	// We set the initial tracker info when we merge in
-	expectedPurgeInfo := &ephemeralPurgeInfo{
+	expectedPurgeInfo := &EphemeralPurgeInfo{
 		NextPurgeTime:   msgC.Valid().Etime(),
 		MinUnexplodedID: msgC.GetMessageID(),
 	}
@@ -158,7 +158,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 	verifyTrackerState(expectedPurgeInfo)
 	// Once we run EphemeralPurge and sweep all messages, we update our tracker
 	// state
-	expectedPurgeInfo = &ephemeralPurgeInfo{
+	expectedPurgeInfo = &EphemeralPurgeInfo{
 		NextPurgeTime:   msgF.Valid().Etime(),
 		MinUnexplodedID: msgE.GetMessageID(),
 	}
@@ -176,7 +176,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 
 	// we've slept for ~ lifetime*2, F's lifetime is up
 	time.Sleep(sleepLifetime)
-	expectedPurgeInfo = &ephemeralPurgeInfo{
+	expectedPurgeInfo = &EphemeralPurgeInfo{
 		NextPurgeTime:   msgE.Valid().Etime(),
 		MinUnexplodedID: msgE.GetMessageID(),
 	}

--- a/go/chat/storage/storage_ephemeral_purge_tracker.go
+++ b/go/chat/storage/storage_ephemeral_purge_tracker.go
@@ -18,9 +18,9 @@ type ephemeralTracker struct {
 	sync.Mutex
 }
 
-type allPurgeInfo map[string]ephemeralPurgeInfo
+type allPurgeInfo map[string]EphemeralPurgeInfo
 
-type ephemeralPurgeInfo struct {
+type EphemeralPurgeInfo struct {
 	NextPurgeTime   gregor1.Time    `codec:"n"`
 	MinUnexplodedID chat1.MessageID `codec:"e"`
 }
@@ -92,7 +92,7 @@ func (t *ephemeralTracker) dbSet(ctx context.Context, uid gregor1.UID, newInfo a
 }
 
 func (t *ephemeralTracker) getPurgeInfo(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID) (*ephemeralPurgeInfo, Error) {
+	convID chat1.ConversationID, uid gregor1.UID) (*EphemeralPurgeInfo, Error) {
 	t.Debug(ctx, "getPurgeInfo")
 
 	t.Lock()
@@ -119,7 +119,7 @@ func (t *ephemeralTracker) getAllPurgeInfo(ctx context.Context, uid gregor1.UID)
 }
 
 func (t *ephemeralTracker) setPurgeInfo(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID, purgeInfo *ephemeralPurgeInfo) Error {
+	convID chat1.ConversationID, uid gregor1.UID, purgeInfo *EphemeralPurgeInfo) Error {
 	t.Debug(ctx, "setPurgeInfo %v", purgeInfo)
 
 	t.Lock()
@@ -136,7 +136,7 @@ func (t *ephemeralTracker) setPurgeInfo(ctx context.Context,
 // When we are filtering new messages coming in/out of storage, we maybe update
 // if they tell us about something older we should be purging.
 func (t *ephemeralTracker) maybeUpdatePurgeInfo(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID, purgeInfo *ephemeralPurgeInfo) Error {
+	convID chat1.ConversationID, uid gregor1.UID, purgeInfo *EphemeralPurgeInfo) Error {
 	t.Debug(ctx, "maybeUpdatePurgeInfo")
 
 	t.Lock()

--- a/go/chat/storage/storage_ephemeral_purge_tracker.go
+++ b/go/chat/storage/storage_ephemeral_purge_tracker.go
@@ -1,0 +1,187 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"golang.org/x/net/context"
+)
+
+type ephemeralTracker struct {
+	globals.Contextified
+	utils.DebugLabeler
+	sync.Mutex
+}
+
+type allPurgeInfo map[string]ephemeralPurgeInfo
+
+type ephemeralPurgeInfo struct {
+	NextPurgeTime   gregor1.Time    `codec:"n"`
+	MinUnexplodedID chat1.MessageID `codec:"e"`
+}
+
+type ephemeralTrackerEntry struct {
+	StorageVersion int `codec:"v"`
+	// convID -> purgeInfo
+	AllPurgeInfo allPurgeInfo `codec:"p"`
+}
+
+const ephemeralTrackerDiskVersion = 1
+
+func newEphemeralTracker(g *globals.Context) *ephemeralTracker {
+	return &ephemeralTracker{Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "ephemeralTracker", false),
+	}
+}
+
+func (t *ephemeralTracker) makeDbKey(uid gregor1.UID) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatBlocks,
+		Key: fmt.Sprintf("ephemeralTracker:%s", uid),
+	}
+}
+
+func (t *ephemeralTracker) dbGet(ctx context.Context, uid gregor1.UID) (allPurgeInfo, Error) {
+	t.Debug(ctx, "dbGet")
+
+	dbKey := t.makeDbKey(uid)
+	raw, found, err := t.G().LocalChatDb.GetRaw(dbKey)
+	if err != nil {
+		return nil, NewInternalError(ctx, t.DebugLabeler, "GetRaw error: %s", err.Error())
+	}
+	if !found {
+		return make(allPurgeInfo), nil
+	}
+
+	var dbRes ephemeralTrackerEntry
+	err = decode(raw, &dbRes)
+	if err != nil {
+		return nil, NewInternalError(ctx, t.DebugLabeler, "decode error: %s", err.Error())
+	}
+	switch dbRes.StorageVersion {
+	case ephemeralTrackerDiskVersion:
+		return dbRes.AllPurgeInfo, nil
+	default:
+		// ignore other versions
+		return make(allPurgeInfo), nil
+	}
+}
+
+func (t *ephemeralTracker) dbSet(ctx context.Context, uid gregor1.UID, newInfo allPurgeInfo) Error {
+	t.Debug(ctx, "dbSet")
+
+	var entry ephemeralTrackerEntry
+	entry.StorageVersion = ephemeralTrackerDiskVersion
+	entry.AllPurgeInfo = newInfo
+	data, err := encode(entry)
+	if err != nil {
+		return NewInternalError(ctx, t.DebugLabeler, "encode error: %s", err.Error())
+	}
+
+	dbKey := t.makeDbKey(uid)
+	err = t.G().LocalChatDb.PutRaw(dbKey, data)
+	if err != nil {
+		return NewInternalError(ctx, t.DebugLabeler, "PutRaw error: %s", err.Error())
+	}
+	return nil
+}
+
+func (t *ephemeralTracker) getPurgeInfo(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID) (*ephemeralPurgeInfo, Error) {
+	t.Debug(ctx, "getPurgeInfo")
+
+	t.Lock()
+	defer t.Unlock()
+
+	allPurgeInfo, err := t.dbGet(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	purgeInfo, ok := allPurgeInfo[convID.String()]
+	if !ok {
+		return nil, MissError{}
+	}
+	return &purgeInfo, nil
+}
+
+func (t *ephemeralTracker) getAllPurgeInfo(ctx context.Context, uid gregor1.UID) (allPurgeInfo, Error) {
+	t.Debug(ctx, "getAllPurgeInfo")
+
+	t.Lock()
+	defer t.Unlock()
+
+	return t.dbGet(ctx, uid)
+}
+
+func (t *ephemeralTracker) setPurgeInfo(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID, purgeInfo *ephemeralPurgeInfo) Error {
+	t.Debug(ctx, "setPurgeInfo %v", purgeInfo)
+
+	t.Lock()
+	defer t.Unlock()
+
+	allPurgeInfo, err := t.dbGet(ctx, uid)
+	if err != nil {
+		return err
+	}
+	allPurgeInfo[convID.String()] = *purgeInfo
+	return t.dbSet(ctx, uid, allPurgeInfo)
+}
+
+// When we are filtering new messages coming in/out of storage, we maybe update
+// if they tell us about something older we should be purging.
+func (t *ephemeralTracker) maybeUpdatePurgeInfo(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID, purgeInfo *ephemeralPurgeInfo) Error {
+	t.Debug(ctx, "maybeUpdatePurgeInfo")
+
+	t.Lock()
+	defer t.Unlock()
+
+	if purgeInfo == nil {
+		return nil
+	}
+
+	allPurgeInfo, err := t.dbGet(ctx, uid)
+	if err != nil {
+		return err
+	}
+	curPurgeInfo, ok := allPurgeInfo[convID.String()]
+	t.Debug(ctx, "maybeUpdatePurgeInfo old: %v, ok: %v, new: %v", curPurgeInfo, ok, purgeInfo)
+	if !ok {
+		// we can only set the NextPurgeTime, but know nothing about the
+		// minUnexplodedID, so we clear that value.
+		purgeInfo.MinUnexplodedID = 0
+	} else { // Throw away our update info if what we already have is more restrictive.
+		if purgeInfo.MinUnexplodedID == 0 || curPurgeInfo.MinUnexplodedID < purgeInfo.MinUnexplodedID {
+			purgeInfo.MinUnexplodedID = curPurgeInfo.MinUnexplodedID
+		}
+		if purgeInfo.NextPurgeTime == 0 || curPurgeInfo.NextPurgeTime < purgeInfo.NextPurgeTime {
+			purgeInfo.NextPurgeTime = curPurgeInfo.NextPurgeTime
+		}
+	}
+	t.Debug(ctx, "maybeUpdatePurgeInfo setting info: %v", purgeInfo)
+	allPurgeInfo[convID.String()] = *purgeInfo
+	return t.dbSet(ctx, uid, allPurgeInfo)
+}
+
+// If we run an EphemeralPurge and have nothing in our cache, we remove the
+// tracker.
+func (t *ephemeralTracker) deletePurgeInfo(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID) Error {
+	t.Debug(ctx, "deletePurgeInfo")
+
+	t.Lock()
+	defer t.Unlock()
+
+	allPurgeInfo, err := t.dbGet(ctx, uid)
+	if err != nil {
+		return err
+	}
+	delete(allPurgeInfo, convID.String())
+	return t.dbSet(ctx, uid, allPurgeInfo)
+}

--- a/go/chat/storage/storage_ephemeral_purge_tracker.go
+++ b/go/chat/storage/storage_ephemeral_purge_tracker.go
@@ -152,11 +152,7 @@ func (t *ephemeralTracker) maybeUpdatePurgeInfo(ctx context.Context,
 	}
 	curPurgeInfo, ok := allPurgeInfo[convID.String()]
 	t.Debug(ctx, "maybeUpdatePurgeInfo old: %v, ok: %v, new: %v", curPurgeInfo, ok, purgeInfo)
-	if !ok {
-		// we can only set the NextPurgeTime, but know nothing about the
-		// minUnexplodedID, so we clear that value.
-		purgeInfo.MinUnexplodedID = 0
-	} else { // Throw away our update info if what we already have is more restrictive.
+	if ok { // Throw away our update info if what we already have is more restrictive.
 		if purgeInfo.MinUnexplodedID == 0 || curPurgeInfo.MinUnexplodedID < purgeInfo.MinUnexplodedID {
 			purgeInfo.MinUnexplodedID = curPurgeInfo.MinUnexplodedID
 		}

--- a/go/chat/storage/storage_test.go
+++ b/go/chat/storage/storage_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/pager"
@@ -38,6 +39,7 @@ func makeEdit(id chat1.MessageID, supersedes chat1.MessageID) chat1.MessageUnbox
 	msg := chat1.MessageUnboxedValid{
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
+			Ctime:     gregor1.ToTime(time.Now()),
 		},
 		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: chat1.MessageType_EDIT,
@@ -50,10 +52,18 @@ func makeEdit(id chat1.MessageID, supersedes chat1.MessageID) chat1.MessageUnbox
 	return chat1.NewMessageUnboxedWithValid(msg)
 }
 
+func makeEphemeralEdit(id chat1.MessageID, supersedes chat1.MessageID, ephemeralMetadata *chat1.MsgEphemeralMetadata) chat1.MessageUnboxed {
+	msg := makeEdit(id, supersedes)
+	mvalid := msg.Valid()
+	mvalid.ClientHeader.EphemeralMetadata = ephemeralMetadata
+	return chat1.NewMessageUnboxedWithValid(mvalid)
+}
+
 func makeDelete(id chat1.MessageID, originalMessage chat1.MessageID, allEdits []chat1.MessageID) chat1.MessageUnboxed {
 	msg := chat1.MessageUnboxedValid{
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
+			Ctime:     gregor1.ToTime(time.Now()),
 		},
 		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: chat1.MessageType_DELETE,
@@ -69,6 +79,7 @@ func makeText(id chat1.MessageID, text string) chat1.MessageUnboxed {
 	msg := chat1.MessageUnboxedValid{
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
+			Ctime:     gregor1.ToTime(time.Now()),
 		},
 		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: chat1.MessageType_TEXT,
@@ -80,10 +91,18 @@ func makeText(id chat1.MessageID, text string) chat1.MessageUnboxed {
 	return chat1.NewMessageUnboxedWithValid(msg)
 }
 
+func makeEphemeralText(id chat1.MessageID, text string, ephemeralMetadata *chat1.MsgEphemeralMetadata) chat1.MessageUnboxed {
+	msg := makeText(id, text)
+	mvalid := msg.Valid()
+	mvalid.ClientHeader.EphemeralMetadata = ephemeralMetadata
+	return chat1.NewMessageUnboxedWithValid(mvalid)
+}
+
 func makeSystemMessage(id chat1.MessageID) chat1.MessageUnboxed {
 	msg := chat1.MessageUnboxedValid{
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
+			Ctime:     gregor1.ToTime(time.Now()),
 		},
 		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: chat1.MessageType_SYSTEM,
@@ -101,6 +120,7 @@ func makeHeadlineMessage(id chat1.MessageID) chat1.MessageUnboxed {
 	msg := chat1.MessageUnboxedValid{
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
+			Ctime:     gregor1.ToTime(time.Now()),
 		},
 		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: chat1.MessageType_HEADLINE,
@@ -116,6 +136,7 @@ func makeDeleteHistory(id chat1.MessageID, upto chat1.MessageID) chat1.MessageUn
 	msg := chat1.MessageUnboxedValid{
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
+			Ctime:     gregor1.ToTime(time.Now()),
 		},
 		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: chat1.MessageType_DELETEHISTORY,
@@ -131,6 +152,7 @@ func makeMsgWithType(id chat1.MessageID, typ chat1.MessageType) chat1.MessageUnb
 	msg := chat1.MessageUnboxedValid{
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
+			Ctime:     gregor1.ToTime(time.Now()),
 		},
 		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: typ,

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -174,8 +174,10 @@ func (t *basicSupersedesTransform) Run(ctx context.Context,
 				continue
 			}
 			if !newMsg.IsValidFull() {
-				// Drop the message. It has been deleted locally but not superseded by anything.
-				// Could have been deleted by a delete-history or retention expunge.
+				// Drop the message. It has been deleted locally but not
+				// superseded by anything.  Could have been deleted by a
+				// delete-history, retention expunge, or was an exploding
+				// message.
 				continue
 			}
 			newMsgs = append(newMsgs, *newMsg)

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -16,7 +16,6 @@ var ActionSetStatus = "setStatus"
 var ActionSetAppNotificationSettings = "setAppNotificationSettings"
 var ActionTeamType = "teamType"
 var ActionExpunge = "expunge"
-var ActionEphemeralPurge = "ephemeralPurge"
 
 var PushActivity = "chat.activity"
 var PushTyping = "chat.typing"

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -461,6 +461,22 @@ func FilterByType(msgs []chat1.MessageUnboxed, query *chat1.GetThreadQuery, incl
 	return res
 }
 
+// Filter messages that are both exploded that are no longer shown in the GUI
+// (as ash lines)
+func FilterExploded(msgs []chat1.MessageUnboxed) (res []chat1.MessageUnboxed) {
+	for _, msg := range msgs {
+		if !msg.IsValid() {
+			continue
+		}
+		mvalid := msg.Valid()
+		if mvalid.IsExploding() && mvalid.HideExplosion() {
+			continue
+		}
+		res = append(res, msg)
+	}
+	return msgs
+}
+
 // GetSupersedes must be called with a valid msg
 func GetSupersedes(msg chat1.MessageUnboxed) ([]chat1.MessageID, error) {
 	if !msg.IsValidFull() {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -465,12 +465,11 @@ func FilterByType(msgs []chat1.MessageUnboxed, query *chat1.GetThreadQuery, incl
 // (as ash lines)
 func FilterExploded(msgs []chat1.MessageUnboxed) (res []chat1.MessageUnboxed) {
 	for _, msg := range msgs {
-		if !msg.IsValid() {
-			continue
-		}
-		mvalid := msg.Valid()
-		if mvalid.IsExploding() && mvalid.HideExplosion() {
-			continue
+		if msg.IsValid() {
+			mvalid := msg.Valid()
+			if mvalid.IsExploding() && mvalid.HideExplosion() {
+				continue
+			}
 		}
 		res = append(res, msg)
 	}

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -743,16 +743,6 @@ func (o Expunge) DeepCopy() Expunge {
 	}
 }
 
-type ConvEphemeralMetadata struct {
-	LastKtime gregor1.Time `codec:"lastKtime" json:"lastKtime"`
-}
-
-func (o ConvEphemeralMetadata) DeepCopy() ConvEphemeralMetadata {
-	return ConvEphemeralMetadata{
-		LastKtime: o.LastKtime.DeepCopy(),
-	}
-}
-
 type ConversationMetadata struct {
 	IdTriple       ConversationIDTriple      `codec:"idTriple" json:"idTriple"`
 	ConversationID ConversationID            `codec:"conversationID" json:"conversationID"`
@@ -920,16 +910,15 @@ func (o ConversationCreatorInfoLocal) DeepCopy() ConversationCreatorInfoLocal {
 }
 
 type Conversation struct {
-	Metadata          ConversationMetadata          `codec:"metadata" json:"metadata"`
-	ReaderInfo        *ConversationReaderInfo       `codec:"readerInfo,omitempty" json:"readerInfo,omitempty"`
-	Notifications     *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
-	MaxMsgs           []MessageBoxed                `codec:"maxMsgs" json:"maxMsgs"`
-	MaxMsgSummaries   []MessageSummary              `codec:"maxMsgSummaries" json:"maxMsgSummaries"`
-	CreatorInfo       *ConversationCreatorInfo      `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
-	Expunge           Expunge                       `codec:"expunge" json:"expunge"`
-	ConvRetention     *RetentionPolicy              `codec:"convRetention,omitempty" json:"convRetention,omitempty"`
-	TeamRetention     *RetentionPolicy              `codec:"teamRetention,omitempty" json:"teamRetention,omitempty"`
-	EphemeralMetadata *ConvEphemeralMetadata        `codec:"em,omitempty" json:"em,omitempty"`
+	Metadata        ConversationMetadata          `codec:"metadata" json:"metadata"`
+	ReaderInfo      *ConversationReaderInfo       `codec:"readerInfo,omitempty" json:"readerInfo,omitempty"`
+	Notifications   *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
+	MaxMsgs         []MessageBoxed                `codec:"maxMsgs" json:"maxMsgs"`
+	MaxMsgSummaries []MessageSummary              `codec:"maxMsgSummaries" json:"maxMsgSummaries"`
+	CreatorInfo     *ConversationCreatorInfo      `codec:"creatorInfo,omitempty" json:"creatorInfo,omitempty"`
+	Expunge         Expunge                       `codec:"expunge" json:"expunge"`
+	ConvRetention   *RetentionPolicy              `codec:"convRetention,omitempty" json:"convRetention,omitempty"`
+	TeamRetention   *RetentionPolicy              `codec:"teamRetention,omitempty" json:"teamRetention,omitempty"`
 }
 
 func (o Conversation) DeepCopy() Conversation {
@@ -993,13 +982,6 @@ func (o Conversation) DeepCopy() Conversation {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.TeamRetention),
-		EphemeralMetadata: (func(x *ConvEphemeralMetadata) *ConvEphemeralMetadata {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.EphemeralMetadata),
 	}
 }
 

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -1004,10 +1004,9 @@ func (o MessageSummary) DeepCopy() MessageSummary {
 }
 
 type MessageServerHeader struct {
-	MessageID     MessageID    `codec:"messageID" json:"messageID"`
-	SupersededBy  MessageID    `codec:"supersededBy" json:"supersededBy"`
-	Ctime         gregor1.Time `codec:"ctime" json:"ctime"`
-	ExplodedByUID *gregor1.UID `codec:"explodedByUID,omitempty" json:"explodedByUID,omitempty"`
+	MessageID    MessageID    `codec:"messageID" json:"messageID"`
+	SupersededBy MessageID    `codec:"supersededBy" json:"supersededBy"`
+	Ctime        gregor1.Time `codec:"ctime" json:"ctime"`
 }
 
 func (o MessageServerHeader) DeepCopy() MessageServerHeader {
@@ -1015,13 +1014,6 @@ func (o MessageServerHeader) DeepCopy() MessageServerHeader {
 		MessageID:    o.MessageID.DeepCopy(),
 		SupersededBy: o.SupersededBy.DeepCopy(),
 		Ctime:        o.Ctime.DeepCopy(),
-		ExplodedByUID: (func(x *gregor1.UID) *gregor1.UID {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.ExplodedByUID),
 	}
 }
 

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -14,8 +14,10 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-type ByUID []gregor1.UID
+// we will show some representation of an exploded message in the UI for a week
+const explosionLifetime = time.Hour * 24 * 7
 
+type ByUID []gregor1.UID
 type ConvIDShort = []byte
 
 func (b ByUID) Len() int      { return len(b) }
@@ -347,14 +349,29 @@ func (m MessageUnboxedValid) EphemeralMetadata() *MsgEphemeralMetadata {
 
 func (m MessageUnboxedValid) Etime() gregor1.Time {
 	metadata := m.EphemeralMetadata()
+	if metadata == nil {
+		return 0
+	}
 	etime := m.ServerHeader.Ctime.Time().Add(time.Second * time.Duration(metadata.Lifetime))
 	return gregor1.ToTime(etime)
 }
 
 func (m MessageUnboxedValid) IsEphemeralExpired() bool {
+	if !m.IsExploding() {
+		return false
+	}
 	etime := m.Etime().Time()
 	now := time.Now()
-	return etime.Before(now) || etime.Equal(now) || m.ServerHeader.ExplodedByUID != nil
+	return etime.Before(now) || etime.Equal(now)
+}
+
+func (m MessageUnboxedValid) HideExplosion() bool {
+	if !m.IsExploding() {
+		return false
+	}
+	now := time.Now()
+	etime := m.Etime()
+	return etime.Time().Add(explosionLifetime).Before(now)
 }
 
 func (m MessageUnboxedValid) IsExploding() bool {

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -221,31 +221,6 @@ func (o ExpungePayload) DeepCopy() ExpungePayload {
 	}
 }
 
-type EphemeralPurgePayload struct {
-	Action       string                           `codec:"Action" json:"Action"`
-	ConvMetadata map[string]ConvEphemeralMetadata `codec:"convMetadata" json:"convMetadata"`
-	InboxVers    InboxVers                        `codec:"inboxVers" json:"inboxVers"`
-}
-
-func (o EphemeralPurgePayload) DeepCopy() EphemeralPurgePayload {
-	return EphemeralPurgePayload{
-		Action: o.Action,
-		ConvMetadata: (func(x map[string]ConvEphemeralMetadata) map[string]ConvEphemeralMetadata {
-			if x == nil {
-				return nil
-			}
-			ret := make(map[string]ConvEphemeralMetadata)
-			for k, v := range x {
-				kCopy := k
-				vCopy := v.DeepCopy()
-				ret[kCopy] = vCopy
-			}
-			return ret
-		})(o.ConvMetadata),
-		InboxVers: o.InboxVers.DeepCopy(),
-	}
-}
-
 type UnreadUpdate struct {
 	ConvID                  ConversationID              `codec:"convID" json:"convID"`
 	UnreadMessages          int                         `codec:"unreadMessages" json:"unreadMessages"`

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -210,10 +210,6 @@
   }
 
   @mpackkey("em") @jsonkey("em")
-  record ConvEphemeralMetadata {
-    gregor1.Time lastKtime;
-  }
-
   record ConversationMetadata  {
     ConversationIDTriple idTriple;
     ConversationID conversationID;
@@ -281,10 +277,6 @@
     Expunge expunge;
     union { null, RetentionPolicy } convRetention;
     union { null, RetentionPolicy } teamRetention;
-
-    // The last message id that was exploded.
-    @mpackkey("em") @jsonkey("em")
-    union { null, ConvEphemeralMetadata } ephemeralMetadata;
   }
 
   record MessageSummary {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -291,7 +291,6 @@
     MessageID messageID;
     MessageID supersededBy;
     gregor1.Time ctime;
-    union { null, gregor1.UID } explodedByUID;
   }
 
   record MessagePreviousPointer {

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -78,14 +78,6 @@ protocol gregor {
         union { null, UnreadUpdate } unreadUpdate;
     }
 
-    record EphemeralPurgePayload {
-        @lint("ignore")
-        string Action;
-        // ConverstionID
-        map<string, ConvEphemeralMetadata> convMetadata;
-        InboxVers inboxVers;
-    }
-
     record UnreadUpdate {
         ConversationID convID;
         // The count of unread messages to display

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -665,11 +665,9 @@ export type ChatUiChatThreadCachedRpcParam = $ReadOnly<{thread?: ?String, incomi
 
 export type ChatUiChatThreadFullRpcParam = $ReadOnly<{thread: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type ConvEphemeralMetadata = $ReadOnly<{lastKtime: Gregor1.Time}>
-
 export type ConvTypingUpdate = $ReadOnly<{convID: ConversationID, typers?: ?Array<TyperInfo>}>
 
-export type Conversation = $ReadOnly<{metadata: ConversationMetadata, readerInfo?: ?ConversationReaderInfo, notifications?: ?ConversationNotificationInfo, maxMsgs?: ?Array<MessageBoxed>, maxMsgSummaries?: ?Array<MessageSummary>, creatorInfo?: ?ConversationCreatorInfo, expunge: Expunge, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy, ephemeralMetadata?: ?ConvEphemeralMetadata}>
+export type Conversation = $ReadOnly<{metadata: ConversationMetadata, readerInfo?: ?ConversationReaderInfo, notifications?: ?ConversationNotificationInfo, maxMsgs?: ?Array<MessageBoxed>, maxMsgSummaries?: ?Array<MessageSummary>, creatorInfo?: ?ConversationCreatorInfo, expunge: Expunge, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy}>
 
 export type ConversationCreatorInfo = $ReadOnly<{ctime: Gregor1.Time, uid: Gregor1.UID}>
 
@@ -752,8 +750,6 @@ export type DeleteConversationRemoteRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 export type DownloadAttachmentLocalRes = $ReadOnly<{offline: Boolean, rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 
 export type EncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
-
-export type EphemeralPurgePayload = $ReadOnly<{Action: String, convMetadata: {[key: string]: ConvEphemeralMetadata}, inboxVers: InboxVers}>
 
 export type Expunge = $ReadOnly<{upto: MessageID, basis: MessageID}>
 

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -1019,7 +1019,7 @@ export type MessagePlaintext = $ReadOnly<{clientHeader: MessageClientHeader, mes
 
 export type MessagePreviousPointer = $ReadOnly<{id: MessageID, hash: Hash}>
 
-export type MessageServerHeader = $ReadOnly<{messageID: MessageID, supersededBy: MessageID, ctime: Gregor1.Time, explodedByUID?: ?Gregor1.UID}>
+export type MessageServerHeader = $ReadOnly<{messageID: MessageID, supersededBy: MessageID, ctime: Gregor1.Time}>
 
 export type MessageSummary = $ReadOnly<{msgID: MessageID, messageType: MessageType, tlfName: String, tlfPublic: Boolean, ctime: Gregor1.Time}>
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -492,18 +492,6 @@
     },
     {
       "type": "record",
-      "name": "ConvEphemeralMetadata",
-      "fields": [
-        {
-          "type": "gregor1.Time",
-          "name": "lastKtime"
-        }
-      ],
-      "mpackkey": "em",
-      "jsonkey": "em"
-    },
-    {
-      "type": "record",
       "name": "ConversationMetadata",
       "fields": [
         {
@@ -580,7 +568,9 @@
           },
           "name": "resetList"
         }
-      ]
+      ],
+      "mpackkey": "em",
+      "jsonkey": "em"
     },
     {
       "type": "record",
@@ -714,15 +704,6 @@
             "RetentionPolicy"
           ],
           "name": "teamRetention"
-        },
-        {
-          "type": [
-            null,
-            "ConvEphemeralMetadata"
-          ],
-          "name": "ephemeralMetadata",
-          "mpackkey": "em",
-          "jsonkey": "em"
         }
       ]
     },

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -748,13 +748,6 @@
         {
           "type": "gregor1.Time",
           "name": "ctime"
-        },
-        {
-          "type": [
-            null,
-            "gregor1.UID"
-          ],
-          "name": "explodedByUID"
         }
       ]
     },

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -261,29 +261,6 @@
     },
     {
       "type": "record",
-      "name": "EphemeralPurgePayload",
-      "fields": [
-        {
-          "type": "string",
-          "name": "Action",
-          "lint": "ignore"
-        },
-        {
-          "type": {
-            "type": "map",
-            "values": "ConvEphemeralMetadata",
-            "keys": "string"
-          },
-          "name": "convMetadata"
-        },
-        {
-          "type": "InboxVers",
-          "name": "inboxVers"
-        }
-      ]
-    },
-    {
-      "type": "record",
       "name": "UnreadUpdate",
       "fields": [
         {

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -665,11 +665,9 @@ export type ChatUiChatThreadCachedRpcParam = $ReadOnly<{thread?: ?String, incomi
 
 export type ChatUiChatThreadFullRpcParam = $ReadOnly<{thread: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type ConvEphemeralMetadata = $ReadOnly<{lastKtime: Gregor1.Time}>
-
 export type ConvTypingUpdate = $ReadOnly<{convID: ConversationID, typers?: ?Array<TyperInfo>}>
 
-export type Conversation = $ReadOnly<{metadata: ConversationMetadata, readerInfo?: ?ConversationReaderInfo, notifications?: ?ConversationNotificationInfo, maxMsgs?: ?Array<MessageBoxed>, maxMsgSummaries?: ?Array<MessageSummary>, creatorInfo?: ?ConversationCreatorInfo, expunge: Expunge, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy, ephemeralMetadata?: ?ConvEphemeralMetadata}>
+export type Conversation = $ReadOnly<{metadata: ConversationMetadata, readerInfo?: ?ConversationReaderInfo, notifications?: ?ConversationNotificationInfo, maxMsgs?: ?Array<MessageBoxed>, maxMsgSummaries?: ?Array<MessageSummary>, creatorInfo?: ?ConversationCreatorInfo, expunge: Expunge, convRetention?: ?RetentionPolicy, teamRetention?: ?RetentionPolicy}>
 
 export type ConversationCreatorInfo = $ReadOnly<{ctime: Gregor1.Time, uid: Gregor1.UID}>
 
@@ -752,8 +750,6 @@ export type DeleteConversationRemoteRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 export type DownloadAttachmentLocalRes = $ReadOnly<{offline: Boolean, rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 
 export type EncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
-
-export type EphemeralPurgePayload = $ReadOnly<{Action: String, convMetadata: {[key: string]: ConvEphemeralMetadata}, inboxVers: InboxVers}>
 
 export type Expunge = $ReadOnly<{upto: MessageID, basis: MessageID}>
 

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -1019,7 +1019,7 @@ export type MessagePlaintext = $ReadOnly<{clientHeader: MessageClientHeader, mes
 
 export type MessagePreviousPointer = $ReadOnly<{id: MessageID, hash: Hash}>
 
-export type MessageServerHeader = $ReadOnly<{messageID: MessageID, supersededBy: MessageID, ctime: Gregor1.Time, explodedByUID?: ?Gregor1.UID}>
+export type MessageServerHeader = $ReadOnly<{messageID: MessageID, supersededBy: MessageID, ctime: Gregor1.Time}>
 
 export type MessageSummary = $ReadOnly<{msgID: MessageID, messageType: MessageType, tlfName: String, tlfPublic: Boolean, ctime: Gregor1.Time}>
 


### PR DESCRIPTION
part I for client side cache purging. Whenever we read or write to msg cache storage, we try to purge exploded messages and (maybe) update some bookkeeping of what is stored. in a subsequent PR the purging will be attached to a background timer to periodically purge conversations that need it