### PR TITLE
fix FilePreview layout and hook up actions

### DIFF
--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -221,14 +221,13 @@ const itemStylesTeamTlf = memoize((teamName: string) => ({
   textType: folderTextType,
 }))
 
-export const humanReadableFileSize = (meta: Types.PathItemMetadata) => {
+export const humanReadableFileSize = (size: number) => {
   const kib = 1024
   const mib = kib * kib
   const gib = mib * kib
   const tib = gib * kib
 
-  if (!meta || !meta.size) return ''
-  const size = meta.size
+  if (!size) return ''
   if (size >= tib) return `${Math.round(size / tib)} TB`
   if (size >= gib) return `${Math.round(size / gib)} GB`
   if (size >= mib) return `${Math.round(size / mib)} MB`

--- a/shared/fs/common/path-item-info.js
+++ b/shared/fs/common/path-item-info.js
@@ -8,18 +8,19 @@ type Props = {
   lastModifiedTimestamp: number,
   lastWriter: string,
   wrap?: boolean,
+  startWithLastModified?: boolean,
 }
 
-const PathItemInfo = ({lastModifiedTimestamp, lastWriter, wrap}: Props) => (
-  <Box style={wrap ? timeWriterBoxStyleWithWrap : timeWriterBoxStyle}>
+const PathItemInfo = (props: Props) => (
+  <Box style={props.wrap ? timeWriterBoxStyleWithWrap : timeWriterBoxStyle}>
     <Text type="BodySmall" lineClamp={isMobile ? 1 : undefined}>
-      {formatTimeForFS(lastModifiedTimestamp)}
+      {(props.startWithLastModified ? 'Last modified ' : '') + formatTimeForFS(props.lastModifiedTimestamp)}
     </Text>
-    {lastWriter ? (
+    {props.lastWriter ? (
       <Text type="BodySmall" style={writerTextStyle} lineClamp={isMobile ? 1 : undefined}>
         &nbsp;by&nbsp;
         <Text type="BodySmall" style={writerStyle}>
-          {lastWriter}
+          {props.lastWriter}
         </Text>
       </Text>
     ) : (
@@ -34,8 +35,8 @@ const writerStyle = {
 
 const timeWriterBoxStyle = {
   ...globalStyles.flexBoxRow,
-  width: '100%',
 }
+
 const timeWriterBoxStyleWithWrap = {
   ...timeWriterBoxStyle,
   flexWrap: 'wrap',

--- a/shared/fs/filepreview/container.js
+++ b/shared/fs/filepreview/container.js
@@ -11,25 +11,65 @@ import FilePreview from '.'
 import * as FsGen from '../../actions/fs-gen'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
+import {navigateAppend, navigateUp} from '../../actions/route-tree'
 
 const mapStateToProps = (state: TypedState, {routeProps}) => {
   const path = Types.stringToPath(routeProps.get('path', Constants.defaultPath))
-  const meta = state.fs.pathItems.get(path)
+  const pathItem = state.fs.pathItems.get(path) || Constants.makeUnknownPathItem()
+  const _username = state.config.username || undefined
   return {
+    _username,
     path,
-    meta,
+    pathItem,
+    fileUIEnabled: state.favorite.fuseStatus ? state.favorite.fuseStatus.kextStarted : false,
   }
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   loadFilePreview: (path: Types.Path) => dispatch(FsGen.createFilePreviewLoad({path})),
+  onBack: () => dispatch(navigateUp()),
+  _download: (path: Types.Path) => dispatch(FsGen.createDownload({path, intent: 'none'})),
+  _showInFileUI: (path: Types.Path) => dispatch(FsGen.createOpenInFileUI({path: Types.pathToString(path)})),
+  _share: path => {
+    dispatch(
+      navigateAppend([
+        {
+          props: {path, isShare: true},
+          selected: 'pathItemAction',
+        },
+      ])
+    )
+  },
+  _save: (path: Types.Path) => {
+    dispatch(FsGen.createDownload({path, intent: 'camera-roll'}))
+    dispatch(
+      navigateAppend([
+        {
+          props: {path, isShare: true},
+          selected: 'transferPopup',
+        },
+      ])
+    )
+  },
 })
 
-const mergeProps = (stateProps, dispatchProps, ownProps) => ({
-  path: stateProps.path,
-  meta: stateProps.meta,
-  loadFilePreview: dispatchProps.loadFilePreview,
-})
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  const {fileUIEnabled, path, pathItem, _username} = stateProps
+  const {loadFilePreview, onBack, _download, _save, _share, _showInFileUI} = dispatchProps
+  const itemStyles = Constants.getItemStyles(Types.getPathElements(path), pathItem.type, _username)
+  return {
+    fileUIEnabled,
+    path,
+    pathItem,
+    loadFilePreview,
+    itemStyles,
+    onShare: () => _share(path),
+    onDownload: () => _download(path),
+    onShowInFileUI: () => _showInFileUI(path),
+    onSave: () => _save(path),
+    onBack,
+  }
+}
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),

--- a/shared/fs/index.stories.js
+++ b/shared/fs/index.stories.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
 import * as Types from '../constants/types/fs'
+import * as Constants from '../constants/fs'
 import {action, storiesOf, createPropProvider} from '../stories/storybook'
 import {globalColors} from '../styles'
 import Files from '.'
@@ -60,8 +61,6 @@ const provider = createPropProvider({
   }),
 })
 
-const previewPathName = '/keybase/private/foo/bar.img'
-
 const load = () => {
   storiesOf('Files', module)
     .addDecorator(provider)
@@ -78,15 +77,19 @@ const load = () => {
     ))
     .add('Preview', () => (
       <FilePreview
-        path={Types.stringToPath(previewPathName)}
-        meta={{
-          badgeCount: 0,
-          name: previewPathName,
-          lastModifiedTimestamp: 1518029754000,
-          size: 15000,
-          lastWriter: {uid: '', username: 'foobar'},
-          progress: 'pending',
-        }}
+        fileUIEnabled={true}
+        pathItem={Constants.makeFile({
+          name: 'bar.jpg',
+          size: 10240,
+          lastWriter: {uid: '', username: 'foo'},
+        })}
+        itemStyles={Constants.getItemStyles(['keybase', 'private', 'foo', 'bar.jpg'], 'file', 'foo')}
+        onAction={() => {}}
+        onBack={() => {}}
+        onDownload={() => {}}
+        onShowInFileUI={() => {}}
+        onShare={() => {}}
+        onSave={() => {}}
       />
     ))
 }

--- a/shared/fs/popups/row-action-popup-container.js
+++ b/shared/fs/popups/row-action-popup-container.js
@@ -64,7 +64,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
             navigateAppend([
               {
                 props: {path, isShare: true},
-                selected: 'rowAction',
+                selected: 'pathItemAction',
               },
             ])
           ),

--- a/shared/fs/popups/row-action-popup.js
+++ b/shared/fs/popups/row-action-popup.js
@@ -1,14 +1,12 @@
 // @flow
 import * as React from 'react'
 import * as Types from '../../constants/types/fs'
+import * as Constants from '../../constants/fs'
 import {globalStyles, globalMargins, isMobile} from '../../styles'
 import {Box, Text} from '../../common-adapters'
 import {ModalLessPopupMenu} from '../../common-adapters/popup-menu'
 import PathItemIcon from '../common/path-item-icon'
 import PathItemInfo from '../common/path-item-info'
-
-// TODO: use Constants.filesize after it's in.
-const filesize = s => `${(s / 1024).toString()} KB`
 
 type Props = {
   name: string,
@@ -35,7 +33,7 @@ const Popup = (props: Props) => {
         <Text type="BodySmallSemibold" style={{color: props.itemStyles.textColor}} lineClamp={1}>
           {props.name}
         </Text>
-        {props.type === 'file' && <Text type="BodySmall">{filesize(props.size)}</Text>}
+        {props.type === 'file' && <Text type="BodySmall">{Constants.humanReadableFileSize(props.size)}</Text>}
         {props.type === 'folder' && (
           <Text type="BodySmall">
             {props.childrenFolders

--- a/shared/fs/routes.js
+++ b/shared/fs/routes.js
@@ -10,12 +10,22 @@ import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import RowPopupMenu from './popups/row-action-popup-container'
 import TransferPopup from './popups/transfer-container.js'
 
+const _commonChildren = {
+  pathItemAction: {
+    component: RelativePopupHoc(RowPopupMenu),
+    tags: makeLeafTags({layerOnTop: true}),
+  },
+  transferPopup: {
+    component: RelativePopupHoc(TransferPopup),
+    tags: makeLeafTags({layerOnTop: true}),
+  },
+}
 const _folderRoute = {
   children: {
     folder: () => folderRoute,
     preview: {
       component: FilePreview,
-      initialState: {},
+      children: _commonChildren,
       tags: makeLeafTags({title: 'Preview'}),
     },
     breadcrumbAction: {
@@ -26,18 +36,11 @@ const _folderRoute = {
       component: RelativePopupHoc(SortBarPopupMenu),
       tags: makeLeafTags({layerOnTop: true}),
     },
-    rowAction: {
-      component: RelativePopupHoc(RowPopupMenu),
-      tags: makeLeafTags({layerOnTop: true}),
-    },
     finderAction: {
       component: RelativePopupHoc(FinderPopupMenu),
       tags: makeLeafTags({layerOnTop: true}),
     },
-    transferPopup: {
-      component: RelativePopupHoc(TransferPopup),
-      tags: makeLeafTags({layerOnTop: true}),
-    },
+    ..._commonChildren,
   },
   component: Files,
 }

--- a/shared/fs/row/container.js
+++ b/shared/fs/row/container.js
@@ -40,7 +40,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
             isShare: false,
             targetRect,
           },
-          selected: 'rowAction',
+          selected: 'pathItemAction',
         },
       ])
     )

--- a/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/shared/stories/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -30064,20 +30064,15 @@ exports[`Storyshots Edit team description Description unchanged 1`] = `
 exports[`Storyshots Files Preview 1`] = `
 .css-0,
 [data-css-0] {
-  font-size: 14px;
-  line-height: 18px;
-  color: rgba(0, 0, 0, 0.75);
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  font-family: OpenSans;
-  font-weight: 600;
+  color: rgba(0, 0, 0, 0.40);
 }
 
 .css-1,
 [data-css-1] {
-  font-size: 11px;
-  line-height: 15px;
-  color: rgba(0, 0, 0, 0.40);
+  font-size: 13px;
+  line-height: 17px;
+  color: #4C8EFF;
+  cursor: pointer;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   font-family: OpenSans;
@@ -30093,24 +30088,59 @@ exports[`Storyshots Files Preview 1`] = `
   text-rendering: optimizeLegibility;
   font-family: OpenSans;
   font-weight: 600;
-  margin-top: 16px;
 }
 
 .css-3,
 [data-css-3] {
-  font-size: 14px;
-  line-height: 18px;
-  color: #ffffff;
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.40);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   font-family: OpenSans;
-  font-weight: 600;
-  text-align: center;
-  white-space: pre;
+  font-weight: 400;
 }
 
 .css-4,
 [data-css-4] {
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.40);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 400;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.css-5,
+[data-css-5] {
+  font-size: 11px;
+  line-height: 15px;
+  color: rgba(0, 0, 0, 0.60);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 400;
+}
+
+.css-6,
+[data-css-6] {
+  font-size: 14px;
+  line-height: 18px;
+  color: #2645A3;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: OpenSans;
+  font-weight: 600;
+  margin-top: 16px;
+  margin-bottom: 8px;
+}
+
+.css-7,
+[data-css-7] {
   font-size: 14px;
   line-height: 18px;
   color: rgba(0, 0, 0, 0.75);
@@ -30140,6 +30170,8 @@ exports[`Storyshots Files Preview 1`] = `
     <div
       style={
         Object {
+          "display": "flex",
+          "flexDirection": "column",
           "height": "100%",
           "position": "relative",
         }
@@ -30149,26 +30181,190 @@ exports[`Storyshots Files Preview 1`] = `
         style={
           Object {
             "display": "flex",
+            "flexDirection": "row",
+          }
+        }
+      >
+        <div
+          onClick={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "cursor": "pointer",
+              "display": "flex",
+              "flexDirection": "row",
+              "marginLeft": 8,
+            }
+          }
+        >
+          <div>
+            <span
+              className="css-0"
+              onClick={null}
+              onMouseEnter={undefined}
+              onMouseLeave={undefined}
+              style={
+                Object {
+                  "WebkitFontSmoothing": "antialiased",
+                  "fontFamily": "kb",
+                  "fontSize": 16,
+                  "fontStyle": "normal",
+                  "fontVariant": "normal",
+                  "fontWeight": "normal",
+                  "lineHeight": 1,
+                  "marginRight": 6,
+                  "speak": "none",
+                  "textTransform": "none",
+                  "userSelect": "none",
+                }
+              }
+            >
+              
+            </span>
+          </div>
+          <span
+            className="css-1"
+            onClick={[Function]}
+            title={undefined}
+          >
+            Back
+          </span>
+        </div>
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "borderBottomColor": "rgba(0, 0, 0, 0.05)",
+              "borderBottomWidth": 0,
+              "display": "flex",
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "height": 48,
+              "justifyContent": "center",
+              "minHeight": 40,
+            }
+          }
+        >
+          <span
+            className="css-2"
+            onClick={undefined}
+            title={undefined}
+          >
+            bar.jpg
+          </span>
+          <div
+            style={
+              Object {
+                "display": "flex",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <span
+              className="css-3"
+              onClick={undefined}
+              title={undefined}
+            >
+              Last modified [mocked]
+            </span>
+            <span
+              className="css-4"
+              onClick={undefined}
+              title={undefined}
+            >
+               by 
+              <span
+                className="css-5"
+                onClick={undefined}
+                title={undefined}
+              >
+                foo
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F7F9FC",
+            "display": "flex",
+            "flex": 1,
             "flexDirection": "column",
+            "flexGrow": 1,
+            "justifyContent": "center",
+            "padding": 24,
           }
         }
       >
         <div
           style={
             Object {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
               "display": "flex",
+              "flex": 1,
               "flexDirection": "column",
+              "flexGrow": 1,
+              "justifyContent": "center",
+              "width": "100%",
             }
           }
         >
+          <img
+            className={undefined}
+            draggable="false"
+            onClick={null}
+            srcSet="icons/icon-file-private-32.png 1x, icons/icon-file-private-32@2x.png 2x"
+            style={
+              Object {
+                "color": "#3663EA",
+                "userSelect": "none",
+              }
+            }
+            title={undefined}
+          />
+          <span
+            className="css-6"
+            onClick={undefined}
+            title={undefined}
+          >
+            bar.jpg
+          </span>
+          <span
+            className="css-3"
+            onClick={undefined}
+            title={undefined}
+          >
+            10 KB
+          </span>
           <div
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={undefined}
+            onMouseLeave={undefined}
+            onMouseUp={[Function]}
             style={
               Object {
                 "alignItems": "center",
-                "display": "flex",
-                "flexDirection": "row",
+                "alignSelf": "center",
+                "backgroundColor": "#e6e6e6",
+                "borderRadius": 50,
+                "cursor": "pointer",
+                "display": "inline-block",
+                "flexDirection": "column",
+                "height": 32,
                 "justifyContent": "center",
-                "minHeight": 48,
+                "lineHeight": "inherit",
+                "marginTop": 16,
+                "minWidth": undefined,
+                "paddingLeft": 24,
+                "paddingRight": 24,
+                "position": "relative",
+                "textAlign": "left",
+                "transform": "none",
+                "transition": "none",
               }
             }
           >
@@ -30178,187 +30374,20 @@ exports[`Storyshots Files Preview 1`] = `
                   "alignItems": "center",
                   "display": "flex",
                   "flexDirection": "row",
+                  "height": "100%",
                   "justifyContent": "center",
+                  "position": "relative",
                 }
               }
             >
               <span
-                className="css-0"
+                className="css-7"
                 onClick={undefined}
                 title={undefined}
               >
-                Keybase Files
+                Show in Finder
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div>
-        <div
-          style={
-            Object {
-              "alignItems": "center",
-              "borderBottomColor": "rgba(0, 0, 0, 0.05)",
-              "borderBottomWidth": 0,
-              "display": "flex",
-              "flexDirection": "column",
-              "justifyContent": "center",
-              "minHeight": 40,
-            }
-          }
-        >
-          <span
-            className="css-0"
-            onClick={undefined}
-            title={undefined}
-          >
-            bar.img
-          </span>
-          <span
-            className="css-1"
-            onClick={undefined}
-            title={undefined}
-          >
-            Modified on [mocked] by foobar
-          </span>
-        </div>
-      </div>
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "display": "flex",
-            "flex": 1,
-            "flexDirection": "column",
-            "height": "100%",
-            "justifyContent": "center",
-          }
-        }
-      >
-        <img
-          className={undefined}
-          draggable="false"
-          onClick={null}
-          srcSet="icons/icon-folder-private-48.png 1x, icons/icon-folder-private-48@2x.png 2x"
-          style={
-            Object {
-              "userSelect": "none",
-            }
-          }
-          title={undefined}
-        />
-        <span
-          className="css-2"
-          onClick={undefined}
-          title={undefined}
-        >
-          bar.img
-        </span>
-        <span
-          className="css-1"
-          onClick={undefined}
-          title={undefined}
-        >
-          15 KB
-        </span>
-        <div
-          onClick={[Function]}
-          onMouseDown={[Function]}
-          onMouseEnter={undefined}
-          onMouseLeave={undefined}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "alignItems": "center",
-              "alignSelf": "center",
-              "backgroundColor": "#4C8EFF",
-              "borderRadius": 50,
-              "cursor": "pointer",
-              "display": "inline-block",
-              "flexDirection": "column",
-              "height": 32,
-              "justifyContent": "center",
-              "lineHeight": "inherit",
-              "marginTop": 24,
-              "minWidth": undefined,
-              "paddingLeft": 24,
-              "paddingRight": 24,
-              "position": "relative",
-              "textAlign": "left",
-              "transform": "none",
-              "transition": "none",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flexDirection": "row",
-                "height": "100%",
-                "justifyContent": "center",
-                "position": "relative",
-              }
-            }
-          >
-            <span
-              className="css-3"
-              onClick={undefined}
-              title={undefined}
-            >
-              Share
-            </span>
-          </div>
-        </div>
-        <div
-          onClick={[Function]}
-          onMouseDown={[Function]}
-          onMouseEnter={undefined}
-          onMouseLeave={undefined}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "alignItems": "center",
-              "alignSelf": "center",
-              "backgroundColor": "#e6e6e6",
-              "borderRadius": 50,
-              "cursor": "pointer",
-              "display": "inline-block",
-              "flexDirection": "column",
-              "height": 32,
-              "justifyContent": "center",
-              "lineHeight": "inherit",
-              "marginTop": 16,
-              "minWidth": undefined,
-              "paddingLeft": 24,
-              "paddingRight": 24,
-              "position": "relative",
-              "textAlign": "left",
-              "transform": "none",
-              "transition": "none",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flexDirection": "row",
-                "height": "100%",
-                "justifyContent": "center",
-                "position": "relative",
-              }
-            }
-          >
-            <span
-              className="css-4"
-              onClick={undefined}
-              title={undefined}
-            >
-              Open file
-            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
1) Changed the layout to match the design. It's still missing a few buttons in the header, which I've created KBFS-2888 to track.
2) Hooked up actions including share, download, show in Finder, save image; pretty much the same thing as in the action popup.

Screenshots:

<img width="971" alt="screen shot 2018-04-13 at 6 54 12 pm" src="https://user-images.githubusercontent.com/255797/38732458-cc08120e-3f50-11e8-928d-c696d19c410a.png">
<img width="971" alt="screen shot 2018-04-13 at 6 54 17 pm" src="https://user-images.githubusercontent.com/255797/38732469-d2b95964-3f50-11e8-9b31-450f95e5c8fd.png">
<img width="971" alt="screen shot 2018-04-13 at 6 55 58 pm" src="https://user-images.githubusercontent.com/255797/38732477-d799e9ee-3f50-11e8-8323-8f57cd81c2e7.png">
<img width="563" alt="screen shot 2018-04-13 at 6 54 20 pm" src="https://user-images.githubusercontent.com/255797/38732485-dbd373d6-3f50-11e8-89e6-45c9be872b72.png">
<img width="591" alt="screen shot 2018-04-13 at 6 54 23 pm" src="https://user-images.githubusercontent.com/255797/38732488-de21147c-3f50-11e8-9507-ce933149e11c.png">
<img width="591" alt="screen shot 2018-04-13 at 6 54 29 pm" src="https://user-images.githubusercontent.com/255797/38732492-e03ab88a-3f50-11e8-8086-a7f2816b4b00.png">
