### PR TITLE
purge ephemeral messages periodically in the background

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -752,6 +752,7 @@ func (b *Boxer) unversionHeaderMBV2(ctx context.Context, headerVersioned chat1.H
 			OutboxID:          hp.OutboxID,
 			OutboxInfo:        hp.OutboxInfo,
 			KbfsCryptKeysUsed: hp.KbfsCryptKeysUsed,
+			EphemeralMetadata: hp.EphemeralMetadata, // TODO only for v3
 		}, hp.BodyHash, nil
 	default:
 		return chat1.MessageClientHeaderVerified{}, nil,
@@ -862,6 +863,12 @@ func (b *Boxer) compareHeadersMBV2(ctx context.Context, hServer chat1.MessageCli
 	// OutboxInfo
 	if !hServer.OutboxInfo.Eq(hSigned.OutboxInfo) {
 		return NewPermanentUnboxingError(NewHeaderMismatchError("OutboxInfo"))
+	}
+
+	// TODO only enforce this for v3
+	// EphemeralMetadata
+	if !hServer.EphemeralMetadata.Eq(hSigned.EphemeralMetadata) {
+		return NewPermanentUnboxingError(NewHeaderMismatchError("EphemeralMetadata"))
 	}
 
 	return nil
@@ -1289,6 +1296,7 @@ func (b *Boxer) boxV2(messagePlaintext chat1.MessagePlaintext, baseEncryptionKey
 		OutboxInfo:        messagePlaintext.ClientHeader.OutboxInfo,
 		OutboxID:          messagePlaintext.ClientHeader.OutboxID,
 		KbfsCryptKeysUsed: messagePlaintext.ClientHeader.KbfsCryptKeysUsed,
+		EphemeralMetadata: messagePlaintext.ClientHeader.EphemeralMetadata, // TODO only for v3
 		// In MessageBoxed.V2 HeaderSignature is nil.
 		HeaderSignature: nil,
 	})

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -113,17 +113,16 @@ type BackgroundConvLoader struct {
 	activeLoadCtx      context.Context
 	activeLoadCancelFn context.CancelFunc
 	suspendCount       int
-	storage            *storage.Storage
 
 	// for testing, make this and can check conv load successes
-	loadTestCh            chan chat1.ConversationID
+	loads                 chan chat1.ConversationID
 	testingNameInfoSource types.NameInfoSource
 	appStateCh            chan struct{}
 }
 
 var _ types.ConvLoader = (*BackgroundConvLoader)(nil)
 
-func NewBackgroundConvLoader(g *globals.Context, storage *storage.Storage) *BackgroundConvLoader {
+func NewBackgroundConvLoader(g *globals.Context) *BackgroundConvLoader {
 	b := &BackgroundConvLoader{
 		Contextified:  globals.NewContextified(g),
 		DebugLabeler:  utils.NewDebugLabeler(g.GetLog(), "BackgroundConvLoader", false),
@@ -132,7 +131,6 @@ func NewBackgroundConvLoader(g *globals.Context, storage *storage.Storage) *Back
 		identNotifier: NewCachingIdentifyNotifier(g),
 		clock:         clockwork.NewRealClock(),
 		resumeWait:    time.Second,
-		storage:       storage,
 	}
 	b.identNotifier.ResetOnGUIConnect()
 	b.newQueue()
@@ -453,44 +451,13 @@ func (b *BackgroundConvLoader) load(ictx context.Context, task clTask, uid grego
 		b.Debug(ctx, "load: invoking post load hook on job: %s", job)
 		job.PostLoadHook(ctx, tv, job)
 	}
-	// if testing, put the convID on the loadTestCh
-	if b.loadTestCh != nil {
-		b.Debug(ctx, "load: putting convID %s on loadTestCh", job.ConvID)
-		b.loadTestCh <- job.ConvID
-	}
 
+	// if testing, put the convID on the loads channel
+	if b.loads != nil {
+		b.Debug(ctx, "load: putting convID %s on loads chan", job.ConvID)
+		b.loads <- job.ConvID
+	}
 	return nil
-}
-
-// Called periodically by the fastChatChecks ticker in service/main
-func (b *BackgroundConvLoader) QueueEphemeralPurges(ctx context.Context) {
-	expiredConvs, err := b.storage.ConvsForEphemeralPurge(ctx, b.uid)
-	if err != nil {
-		b.Debug(ctx, "QueueEphemeralPurges error: %s", err)
-		return
-	}
-	for convIDStr, purgeInfo := range expiredConvs {
-		convID, err := chat1.MakeConvID(convIDStr)
-		if err != nil {
-			b.Debug(ctx, "invalid convID: %v, error: %s", convIDStr, err)
-			continue
-		}
-		job := types.NewConvLoaderJob(convID, nil, types.ConvLoaderPriorityHigh,
-			newConvLoaderEphemeralPurgeHook(b.G(), b.storage, b.uid, &purgeInfo))
-		task := clTask{job: job}
-		if err := b.enqueue(ctx, task); err != nil {
-			b.Debug(ctx, "enqueue error %s", err)
-		}
-	}
-}
-
-func newConvLoaderEphemeralPurgeHook(g *globals.Context, chatStorage *storage.Storage, uid gregor1.UID, purgeInfo *chat1.EphemeralPurgeInfo) func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
-	return func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
-		_, err := chatStorage.EphemeralPurge(ctx, job.ConvID, uid, purgeInfo)
-		if err != nil {
-			g.GetLog().CDebugf(ctx, "ephemeralPurge error: %s", err)
-		}
-	}
 }
 
 func newConvLoaderPagebackHook(g *globals.Context, curCalls, maxCalls int) func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -315,4 +317,104 @@ func TestConvLoaderJobQueue(t *testing.T) {
 	require.NoError(t, j.Push(newTask(types.ConvLoaderPriorityLow)))
 	require.NoError(t, j.Push(newTask(types.ConvLoaderPriorityLow)))
 	require.Error(t, j.Push(newTask(types.ConvLoaderPriorityLow)))
+}
+
+func TestBackgroundPurge(t *testing.T) {
+	ctx, tc, world, _, baseSender, listener, res := setupLoaderTest(t)
+	defer world.Cleanup()
+
+	// setup a ticker since we don't run the service's fastChatChecks ticker here.
+	tickerLifetime := 500 * time.Millisecond
+	ticker := time.NewTicker(tickerLifetime)
+	defer ticker.Stop()
+	go func() {
+		for {
+			<-ticker.C
+			world.Fc.Advance(tickerLifetime)
+			tc.Context().ConvLoader.QueueEphemeralPurges(context.Background())
+		}
+	}()
+
+	assertListener := func(convID chat1.ConversationID) {
+		select {
+		case convID := <-listener.bgConvLoads:
+			require.Equal(t, res.ConvID, convID)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for conversation load")
+		}
+	}
+
+	u := world.GetUsers()[0]
+	uid := gregor1.UID(u.GetUID().ToBytes())
+	trip := newConvTriple(ctx, t, tc, u.Username)
+	sendEphemeral := func(lifetime gregor1.DurationSec) *chat1.MessageBoxed {
+		_, msgBoxed, _, err := baseSender.Send(ctx, res.ConvID, chat1.MessagePlaintext{
+			ClientHeader: chat1.MessageClientHeader{
+				Conv:              trip,
+				Sender:            uid,
+				TlfName:           u.Username,
+				TlfPublic:         false,
+				MessageType:       chat1.MessageType_TEXT,
+				EphemeralMetadata: &chat1.MsgEphemeralMetadata{Lifetime: lifetime},
+			},
+			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+				Body: "hi",
+			}),
+		}, 0, nil)
+		require.NoError(t, err)
+		return msgBoxed
+	}
+
+	g := globals.NewContext(tc.G, tc.ChatG)
+	storage := storage.New(g)
+	storage.SetClock(world.Fc)
+
+	assertTrackerState := func(convID chat1.ConversationID, expectedPurgeInfo chat1.EphemeralPurgeInfo) {
+		allPurgeInfo, err := storage.GetAllPurgeInfo(ctx, uid)
+		require.NoError(t, err)
+		require.Len(t, allPurgeInfo, 1)
+		purgeInfo, ok := allPurgeInfo[convID.String()]
+		require.True(t, ok)
+		require.Equal(t, expectedPurgeInfo, purgeInfo)
+	}
+
+	// Load our conv with the initial tlf msg
+	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(),
+		types.NewConvLoaderJob(res.ConvID, &chat1.Pagination{Num: 3}, types.ConvLoaderPriorityHigh, nil)))
+	assertListener(res.ConvID)
+
+	// Nothing is up for purging yet
+	expectedPurgeInfo := chat1.EphemeralPurgeInfo{
+		MinUnexplodedID: 1,
+		NextPurgeTime:   0,
+		IsActive:        false,
+	}
+	assertTrackerState(res.ConvID, expectedPurgeInfo)
+
+	// Send two ephemeral messages, and ensure both get purged
+	lifetime := gregor1.DurationSec(1)
+	msgBoxed1 := sendEphemeral(lifetime * 2)
+	msgBoxed2 := sendEphemeral(lifetime * 3)
+
+	// Make sure we can queue up a task and execute it, setting our initial tracker state
+	assertListener(res.ConvID)
+	assertTrackerState(res.ConvID, chat1.EphemeralPurgeInfo{
+		MinUnexplodedID: msgBoxed1.GetMessageID(),
+		NextPurgeTime:   msgBoxed1.Etime(),
+		IsActive:        true,
+	})
+
+	assertListener(res.ConvID)
+	assertTrackerState(res.ConvID, chat1.EphemeralPurgeInfo{
+		MinUnexplodedID: msgBoxed2.GetMessageID(),
+		NextPurgeTime:   msgBoxed2.Etime(),
+		IsActive:        true,
+	})
+
+	assertListener(res.ConvID)
+	assertTrackerState(res.ConvID, chat1.EphemeralPurgeInfo{
+		MinUnexplodedID: msgBoxed2.GetMessageID(),
+		NextPurgeTime:   0,
+		IsActive:        false,
+	})
 }

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -188,8 +188,8 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	g.FetchRetrier.(*FetchRetrier).SetClock(world.Fc)
 	g.FetchRetrier.Connected(context.TODO())
 	g.FetchRetrier.Start(context.TODO(), u.User.GetUID().ToBytes())
-	convLoader := NewBackgroundConvLoader(g, chatStorage)
-	convLoader.loadTestCh = listener.bgConvLoads
+	convLoader := NewBackgroundConvLoader(g)
+	convLoader.loads = listener.bgConvLoads
 	convLoader.setTestingNameInfoSource(tlf)
 	g.ConvLoader = convLoader
 	g.ConvLoader.Start(context.TODO(), u.User.GetUID().ToBytes())

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -328,7 +328,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	g.FetchRetrier.Connected(context.TODO())
 	g.FetchRetrier.Start(context.TODO(), uid)
 
-	g.ConvLoader = NewBackgroundConvLoader(g)
+	g.ConvLoader = NewBackgroundConvLoader(g, chatStorage)
 
 	pushHandler := NewPushHandler(g)
 	pushHandler.SetClock(c.world.Fc)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -300,6 +300,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	h.boxer = NewBoxer(g)
 
 	chatStorage := storage.New(g)
+	chatStorage.SetClock(c.world.Fc)
 	g.ConvSource = NewHybridConversationSource(g, h.boxer, chatStorage,
 		func() chat1.RemoteInterface { return ri })
 	g.InboxSource = NewHybridInboxSource(g, func() chat1.RemoteInterface { return ri })
@@ -328,7 +329,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	g.FetchRetrier.Connected(context.TODO())
 	g.FetchRetrier.Start(context.TODO(), uid)
 
-	g.ConvLoader = NewBackgroundConvLoader(g, chatStorage)
+	g.ConvLoader = NewBackgroundConvLoader(g)
 
 	pushHandler := NewPushHandler(g)
 	pushHandler.SetClock(c.world.Fc)

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
 	"github.com/keybase/go-codec/codec"
 	"golang.org/x/net/context"
 )
@@ -36,6 +37,7 @@ type Storage struct {
 	breakTracker     *breakTracker
 	delhTracker      *delhTracker
 	ephemeralTracker *ephemeralTracker
+	clock            clockwork.Clock
 }
 
 type storageEngine interface {
@@ -55,12 +57,17 @@ func New(g *globals.Context) *Storage {
 		breakTracker:     newBreakTracker(g),
 		delhTracker:      newDelhTracker(g),
 		ephemeralTracker: newEphemeralTracker(g),
+		clock:            clockwork.NewRealClock(),
 		DebugLabeler:     utils.NewDebugLabeler(g.GetLog(), "Storage", false),
 	}
 }
 
 func (s *Storage) setEngine(engine storageEngine) {
 	s.engine = engine
+}
+
+func (s *Storage) SetClock(clock clockwork.Clock) {
+	s.clock = clock
 }
 
 func makeBlockIndexKey(convID chat1.ConversationID, uid gregor1.UID) libkb.DbKey {

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -6,10 +6,34 @@ import (
 	context "golang.org/x/net/context"
 )
 
+// For testing
+func (s *Storage) GetAllPurgeInfo(ctx context.Context, uid gregor1.UID) (info allPurgeInfo, err error) {
+	defer s.Trace(ctx, func() error { return err }, "GetAllPurgeInfo")()
+	return s.ephemeralTracker.getAllPurgeInfo(ctx, uid)
+}
+
+func (s *Storage) ConvsForEphemeralPurge(ctx context.Context, uid gregor1.UID) (expiredConvs map[string]chat1.EphemeralPurgeInfo, err Error) {
+	defer s.Trace(ctx, func() error { return err }, "ConvsForEphemeralPurge")()
+
+	allPurgeInfo, err := s.ephemeralTracker.getAllPurgeInfo(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	expiredConvs = make(map[string]chat1.EphemeralPurgeInfo)
+	now := s.clock.Now()
+	for convID, purgeInfo := range allPurgeInfo {
+		nextPurgeTime := purgeInfo.NextPurgeTime.Time()
+		if purgeInfo.IsActive && (nextPurgeTime.Before(now) || nextPurgeTime.Equal(now)) {
+			expiredConvs[convID] = purgeInfo
+		}
+	}
+	return expiredConvs, nil
+}
+
 // For a given conversation, purge all ephemeral messages from
 // purgeInfo.MinUnexplodedID to the present, updating bookkeeping for the next
 // time we need to purge this conv.
-func (s *Storage) EphemeralPurge(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, purgeInfo *EphemeralPurgeInfo) (newPurgeInfo *EphemeralPurgeInfo, err Error) {
+func (s *Storage) EphemeralPurge(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, purgeInfo *chat1.EphemeralPurgeInfo) (newPurgeInfo *chat1.EphemeralPurgeInfo, err Error) {
 	defer s.Trace(ctx, func() error { return err }, "EphemeralPurge")()
 
 	locks.Storage.Lock()
@@ -52,18 +76,13 @@ func (s *Storage) EphemeralPurge(ctx context.Context, convID chat1.ConversationI
 		s.Debug(ctx, "record-only ephemeralTracker: no local messages")
 		// We don't have these messages in cache, so don't retry this
 		// conversation until further notice.
-		err := s.ephemeralTracker.deletePurgeInfo(ctx, convID, uid)
+		err := s.ephemeralTracker.inactivatePurgeInfo(ctx, convID, uid)
 		return nil, err
 	default:
 		return nil, err
 	}
 	newPurgeInfo, err = s.ephemeralPurgeHelper(ctx, convID, uid, rc.Result())
 	if err != nil {
-		return nil, err
-	}
-	// End of the line
-	if newPurgeInfo.MinUnexplodedID == maxMsgID {
-		err = s.ephemeralTracker.deletePurgeInfo(ctx, convID, uid)
 		return nil, err
 	}
 	err = s.ephemeralTracker.setPurgeInfo(ctx, convID, uid, newPurgeInfo)
@@ -87,7 +106,7 @@ func (s *Storage) explodeExpiredMessages(ctx context.Context, convID chat1.Conve
 // give info for our bookkeeping for the next time we have to purge.
 // requires msgs to be sorted by descending message ID
 func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, msgs []chat1.MessageUnboxed) (purgeInfo *EphemeralPurgeInfo, err Error) {
+	uid gregor1.UID, msgs []chat1.MessageUnboxed) (purgeInfo *chat1.EphemeralPurgeInfo, err Error) {
 	defer s.Trace(ctx, func() error { return err }, "ephemeralPurgeHelper convID: %v, uid: %v, numMessages %v", convID, uid, len(msgs))()
 
 	if msgs == nil || len(msgs) == 0 {
@@ -97,6 +116,7 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 	nextPurgeTime := gregor1.Time(0)
 	minUnexplodedID := msgs[0].GetMessageID()
 	var exploded []chat1.MessageUnboxed
+	var hasExploding bool
 	for i, msg := range msgs {
 		if !msg.IsValid() {
 			s.Debug(ctx, "skipping invalid msg: %v", msg.GetMessageID())
@@ -104,7 +124,8 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 		}
 		mvalid := msg.Valid()
 		if mvalid.IsExploding() {
-			if !mvalid.IsEphemeralExpired() {
+			if !mvalid.IsEphemeralExpired(s.clock.Now()) {
+				hasExploding = true
 				// Keep track of the minimum ephemeral message that is not yet
 				// exploded.
 				if msg.GetMessageID() < minUnexplodedID {
@@ -132,9 +153,9 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 		s.Debug(ctx, "write messages failed: %v", err)
 		return nil, err
 	}
-
-	return &EphemeralPurgeInfo{
+	return &chat1.EphemeralPurgeInfo{
 		MinUnexplodedID: minUnexplodedID,
 		NextPurgeTime:   nextPurgeTime,
+		IsActive:        hasExploding,
 	}, nil
 }

--- a/go/chat/storage/storage_ephemeral_purge_test.go
+++ b/go/chat/storage/storage_ephemeral_purge_test.go
@@ -22,7 +22,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 	// G delete --^    ___  deletes F     <not deletable>
 	// H text           |                 <ephemeral with 1 "lifetime">
 
-	_, storage, uid := setupStorageTest(t, "delh")
+	_, storage, uid := setupStorageTest(t, "ephemeral purge")
 
 	convID := makeConvID()
 
@@ -84,7 +84,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 		}
 	}
 
-	verifyTrackerState := func(expectedPurgeInfo *EphemeralPurgeInfo) {
+	verifyTrackerState := func(expectedPurgeInfo *chat1.EphemeralPurgeInfo) {
 		purgeInfo, err := storage.ephemeralTracker.getPurgeInfo(context.Background(), convID, uid)
 		if expectedPurgeInfo == nil {
 			require.Error(t, err)
@@ -95,7 +95,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 		require.Equal(t, expectedPurgeInfo, purgeInfo)
 	}
 
-	ephemeralPurgeAndVerify := func(expectedPurgeInfo *EphemeralPurgeInfo) {
+	ephemeralPurgeAndVerify := func(expectedPurgeInfo *chat1.EphemeralPurgeInfo) {
 		purgeInfo, _ := storage.ephemeralTracker.getPurgeInfo(context.Background(), convID, uid)
 		newPurgeInfo, err := storage.EphemeralPurge(context.Background(), convID, uid, purgeInfo)
 		require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 	t.Logf("initial merge")
 	mustMerge(t, storage, convID, uid, sortMessagesDesc([]chat1.MessageUnboxed{msgA, msgB, msgC, msgD, msgE, msgF, msgG}))
 	// We set the initial tracker info when we merge in
-	expectedPurgeInfo := &EphemeralPurgeInfo{
+	expectedPurgeInfo := &chat1.EphemeralPurgeInfo{
 		NextPurgeTime:   msgC.Valid().Etime(),
 		MinUnexplodedID: msgC.GetMessageID(),
 	}
@@ -147,7 +147,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 	verifyTrackerState(expectedPurgeInfo)
 	// Once we run EphemeralPurge and sweep all messages, we update our tracker
 	// state
-	expectedPurgeInfo = &EphemeralPurgeInfo{
+	expectedPurgeInfo = &chat1.EphemeralPurgeInfo{
 		NextPurgeTime:   msgF.Valid().Etime(),
 		MinUnexplodedID: msgE.GetMessageID(),
 	}
@@ -166,7 +166,7 @@ func TestStorageEphemeralPurge(t *testing.T) {
 
 	// we've slept for ~ lifetime*2, F's lifetime is up
 	time.Sleep(sleepLifetime)
-	expectedPurgeInfo = &EphemeralPurgeInfo{
+	expectedPurgeInfo = &chat1.EphemeralPurgeInfo{
 		NextPurgeTime:   msgE.Valid().Etime(),
 		MinUnexplodedID: msgE.GetMessageID(),
 	}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -178,6 +178,7 @@ type ConvLoader interface {
 	Resumable
 
 	Queue(ctx context.Context, job ConvLoaderJob) error
+	QueueEphemeralPurges(ctx context.Context)
 	Suspend(ctx context.Context) bool
 	Resume(ctx context.Context) bool
 }

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -178,7 +178,6 @@ type ConvLoader interface {
 	Resumable
 
 	Queue(ctx context.Context, job ConvLoaderJob) error
-	QueueEphemeralPurges(ctx context.Context)
 	Suspend(ctx context.Context) bool
 	Resume(ctx context.Context) bool
 }

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -464,10 +464,11 @@ func FilterByType(msgs []chat1.MessageUnboxed, query *chat1.GetThreadQuery, incl
 // Filter messages that are both exploded that are no longer shown in the GUI
 // (as ash lines)
 func FilterExploded(msgs []chat1.MessageUnboxed) (res []chat1.MessageUnboxed) {
+	now := time.Now()
 	for _, msg := range msgs {
 		if msg.IsValid() {
 			mvalid := msg.Valid()
-			if mvalid.IsExploding() && mvalid.HideExplosion() {
+			if mvalid.IsExploding() && mvalid.HideExplosion(now) {
 				continue
 			}
 		}

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -1053,6 +1053,20 @@ func (o MsgEphemeralMetadata) DeepCopy() MsgEphemeralMetadata {
 	}
 }
 
+type EphemeralPurgeInfo struct {
+	IsActive        bool         `codec:"a" json:"a"`
+	NextPurgeTime   gregor1.Time `codec:"n" json:"n"`
+	MinUnexplodedID MessageID    `codec:"e" json:"e"`
+}
+
+func (o EphemeralPurgeInfo) DeepCopy() EphemeralPurgeInfo {
+	return EphemeralPurgeInfo{
+		IsActive:        o.IsActive,
+		NextPurgeTime:   o.NextPurgeTime.DeepCopy(),
+		MinUnexplodedID: o.MinUnexplodedID.DeepCopy(),
+	}
+}
+
 type MessageClientHeader struct {
 	Conv              ConversationIDTriple     `codec:"conv" json:"conv"`
 	TlfName           string                   `codec:"tlfName" json:"tlfName"`

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1340,6 +1340,7 @@ type HeaderPlaintextV1 struct {
 	OutboxID          *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	HeaderSignature   *SignatureInfo           `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
 	MerkleRoot        *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
+	EphemeralMetadata *MsgEphemeralMetadata    `codec:"em,omitempty" json:"em,omitempty"`
 }
 
 func (o HeaderPlaintextV1) DeepCopy() HeaderPlaintextV1 {
@@ -1397,6 +1398,13 @@ func (o HeaderPlaintextV1) DeepCopy() HeaderPlaintextV1 {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.MerkleRoot),
+		EphemeralMetadata: (func(x *MsgEphemeralMetadata) *MsgEphemeralMetadata {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.EphemeralMetadata),
 	}
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -311,6 +311,16 @@
     keybase1.EkGeneration generation;
   }
 
+  @mpackkey("pi") @jsonkey("pi")
+  record EphemeralPurgeInfo {
+    @mpackkey("a") @jsonkey("a")
+    boolean isActive;
+    @mpackkey("n") @jsonkey("n")
+    gregor1.Time nextPurgeTime;
+    @mpackkey("e") @jsonkey("e")
+    MessageID minUnexplodedID;
+  }
+
   // The Boxer's compareHeaders* functions checks each of these fields.
   // If we add a field here, that method needs to be updated.
   record MessageClientHeader {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -256,6 +256,9 @@ protocol local {
     // Latest merkle root when sent.
     // Nil in MBv1 messages. Non-nil in MBv2 messages.
     union { null, MerkleRoot } merkleRoot;
+
+    @mpackkey("em") @jsonkey("em")
+    union { null, MsgEphemeralMetadata } ephemeralMetadata;
   }
 
   // HeaderPlaintext is a variant container for all the

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -751,6 +751,8 @@ export type DownloadAttachmentLocalRes = $ReadOnly<{offline: Boolean, rateLimits
 
 export type EncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
+export type EphemeralPurgeInfo = $ReadOnly<{isActive: Boolean, nextPurgeTime: Gregor1.Time, minUnexplodedID: MessageID}>
+
 export type Expunge = $ReadOnly<{upto: MessageID, basis: MessageID}>
 
 export type ExpungeInfo = $ReadOnly<{convID: ConversationID, expunge: Expunge}>
@@ -828,7 +830,7 @@ export type HeaderPlaintextMetaInfo = $ReadOnly<{crit: Boolean}>
 
 export type HeaderPlaintextUnsupported = $ReadOnly<{mi: HeaderPlaintextMetaInfo}>
 
-export type HeaderPlaintextV1 = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, bodyHash: Hash, outboxInfo?: ?OutboxInfo, outboxID?: ?OutboxID, headerSignature?: ?SignatureInfo, merkleRoot?: ?MerkleRoot}>
+export type HeaderPlaintextV1 = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, bodyHash: Hash, outboxInfo?: ?OutboxInfo, outboxID?: ?OutboxID, headerSignature?: ?SignatureInfo, merkleRoot?: ?MerkleRoot, ephemeralMetadata?: ?MsgEphemeralMetadata}>
 
 export type HeaderPlaintextVersion =
   | 1 // V1_1

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -801,6 +801,32 @@
     },
     {
       "type": "record",
+      "name": "EphemeralPurgeInfo",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "isActive",
+          "mpackkey": "a",
+          "jsonkey": "a"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "nextPurgeTime",
+          "mpackkey": "n",
+          "jsonkey": "n"
+        },
+        {
+          "type": "MessageID",
+          "name": "minUnexplodedID",
+          "mpackkey": "e",
+          "jsonkey": "e"
+        }
+      ],
+      "mpackkey": "pi",
+      "jsonkey": "pi"
+    },
+    {
+      "type": "record",
       "name": "MessageClientHeader",
       "fields": [
         {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -787,6 +787,15 @@
             "MerkleRoot"
           ],
           "name": "merkleRoot"
+        },
+        {
+          "type": [
+            null,
+            "MsgEphemeralMetadata"
+          ],
+          "name": "ephemeralMetadata",
+          "mpackkey": "em",
+          "jsonkey": "em"
         }
       ]
     },

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -751,6 +751,8 @@ export type DownloadAttachmentLocalRes = $ReadOnly<{offline: Boolean, rateLimits
 
 export type EncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 
+export type EphemeralPurgeInfo = $ReadOnly<{isActive: Boolean, nextPurgeTime: Gregor1.Time, minUnexplodedID: MessageID}>
+
 export type Expunge = $ReadOnly<{upto: MessageID, basis: MessageID}>
 
 export type ExpungeInfo = $ReadOnly<{convID: ConversationID, expunge: Expunge}>
@@ -828,7 +830,7 @@ export type HeaderPlaintextMetaInfo = $ReadOnly<{crit: Boolean}>
 
 export type HeaderPlaintextUnsupported = $ReadOnly<{mi: HeaderPlaintextMetaInfo}>
 
-export type HeaderPlaintextV1 = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, bodyHash: Hash, outboxInfo?: ?OutboxInfo, outboxID?: ?OutboxID, headerSignature?: ?SignatureInfo, merkleRoot?: ?MerkleRoot}>
+export type HeaderPlaintextV1 = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, bodyHash: Hash, outboxInfo?: ?OutboxInfo, outboxID?: ?OutboxID, headerSignature?: ?SignatureInfo, merkleRoot?: ?MerkleRoot, ephemeralMetadata?: ?MsgEphemeralMetadata}>
 
 export type HeaderPlaintextVersion =
   | 1 // V1_1


### PR DESCRIPTION
depends on https://github.com/keybase/client/pull/11388

This is part 2 of purging ephemeral messages. A timer is added to the background conversation loader to periodically purge any conversations that have ephemeral messages that have exploded