### PR TITLE
Use bigrat for currency conversions

### DIFF
--- a/go/client/cmd_wallet_balances.go
+++ b/go/client/cmd_wallet_balances.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/keybase/client/go/stellar"
 	"golang.org/x/net/context"
 )
 
@@ -93,10 +94,10 @@ func (c *cmdWalletBalances) runForUser(cli stellar1.LocalClient) error {
 		for _, balance := range acc.Balance {
 			localAmountStr := ""
 			if balance.Asset.IsNativeXLM() {
-				if acc.LocalCurrency != "" {
-					localAmount, err := acc.LocalExchangeRate.ConvertXLMToLocal(balance.Amount, 2)
+				if acc.ExchangeRate != nil {
+					localAmount, err := stellar.ConvertXLMToOutside(balance.Amount, *acc.ExchangeRate)
 					if err == nil {
-						localAmountStr = fmt.Sprintf(" (~%s %s)", localAmount, string(acc.LocalCurrency))
+						localAmountStr = fmt.Sprintf(" (~%s %s)", localAmount, string(acc.ExchangeRate.Currency))
 					} else {
 						c.G().Log.Warning("Unable to convert to local currency: %s", err)
 					}

--- a/go/client/cmd_wallet_send.go
+++ b/go/client/cmd_wallet_send.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/keybase/client/go/stellar"
 	"golang.org/x/net/context"
 )
 
@@ -71,17 +72,17 @@ func (c *cmdWalletSend) Run() error {
 	amountDesc := fmt.Sprintf("%s XLM", amount)
 
 	if c.localCurrency != "" && c.localCurrency != "XLM" {
-		exchangeRate, err := cli.ExchangeRateLocal(context.Background(), stellar1.LocalCurrencyCode(c.localCurrency))
+		exchangeRate, err := cli.ExchangeRateLocal(context.Background(), stellar1.OutsideCurrencyCode(c.localCurrency))
 		if err != nil {
 			return fmt.Errorf("Unable to get exchange rate for %q: %s", c.localCurrency, err)
 		}
 
-		amount, err = exchangeRate.ConvertLocalToXLM(c.amount, 4)
+		amount, err = stellar.ConvertLocalToXLM(c.amount, exchangeRate)
 		if err != nil {
 			return err
 		}
 
-		ui.Printf("Current exchange rate for XLM%s is: ~%s\n", c.localCurrency, exchangeRate.Format('f', 4))
+		ui.Printf("Current exchange rate: ~ %s %s / XLM\n", exchangeRate.Rate, c.localCurrency)
 		amountDesc = fmt.Sprintf("%s XLM (~%s %s)", amount, c.amount, c.localCurrency)
 	}
 

--- a/go/protocol/stellar1/common.go
+++ b/go/protocol/stellar1/common.go
@@ -181,6 +181,24 @@ func (o NoteContents) DeepCopy() NoteContents {
 	}
 }
 
+type OutsideCurrencyCode string
+
+func (o OutsideCurrencyCode) DeepCopy() OutsideCurrencyCode {
+	return o
+}
+
+type OutsideExchangeRate struct {
+	Currency OutsideCurrencyCode `codec:"currency" json:"currency"`
+	Rate     string              `codec:"rate" json:"rate"`
+}
+
+func (o OutsideExchangeRate) DeepCopy() OutsideExchangeRate {
+	return OutsideExchangeRate{
+		Currency: o.Currency.DeepCopy(),
+		Rate:     o.Rate,
+	}
+}
+
 type CommonInterface interface {
 }
 

--- a/go/protocol/stellar1/extras.go
+++ b/go/protocol/stellar1/extras.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 )
 
@@ -119,28 +118,4 @@ func AssetNative() Asset {
 		Code:   "",
 		Issuer: "",
 	}
-}
-
-func (b LocalExchangeRate) ConvertXLMToLocal(XLMAmount string, precision int) (localAmount string, err error) {
-	local, err := strconv.ParseFloat(XLMAmount, 64)
-	if err != nil {
-		return "", err
-	}
-
-	localAmount = strconv.FormatFloat(local*float64(b), 'f', precision, 64)
-	return localAmount, nil
-}
-
-func (b LocalExchangeRate) ConvertLocalToXLM(localAmount string, precision int) (XLMAmount string, err error) {
-	local, err := strconv.ParseFloat(localAmount, 64)
-	if err != nil {
-		return "", err
-	}
-
-	XLMAmount = strconv.FormatFloat(local/float64(b), 'f', precision, 64)
-	return XLMAmount, nil
-}
-
-func (b LocalExchangeRate) Format(fmt byte, precision int) string {
-	return strconv.FormatFloat(float64(b), fmt, precision, 32)
 }

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -68,25 +68,12 @@ func (o RecentPaymentCLILocal) DeepCopy() RecentPaymentCLILocal {
 	}
 }
 
-type LocalCurrencyCode string
-
-func (o LocalCurrencyCode) DeepCopy() LocalCurrencyCode {
-	return o
-}
-
-type LocalExchangeRate float32
-
-func (o LocalExchangeRate) DeepCopy() LocalExchangeRate {
-	return o
-}
-
 type LocalOwnAccount struct {
-	AccountID         AccountID         `codec:"accountID" json:"accountID"`
-	IsPrimary         bool              `codec:"isPrimary" json:"isPrimary"`
-	Name              string            `codec:"name" json:"name"`
-	Balance           []Balance         `codec:"balance" json:"balance"`
-	LocalCurrency     LocalCurrencyCode `codec:"localCurrency" json:"localCurrency"`
-	LocalExchangeRate LocalExchangeRate `codec:"localExchangeRate" json:"localExchangeRate"`
+	AccountID    AccountID            `codec:"accountID" json:"accountID"`
+	IsPrimary    bool                 `codec:"isPrimary" json:"isPrimary"`
+	Name         string               `codec:"name" json:"name"`
+	Balance      []Balance            `codec:"balance" json:"balance"`
+	ExchangeRate *OutsideExchangeRate `codec:"exchangeRate,omitempty" json:"exchangeRate,omitempty"`
 }
 
 func (o LocalOwnAccount) DeepCopy() LocalOwnAccount {
@@ -105,8 +92,13 @@ func (o LocalOwnAccount) DeepCopy() LocalOwnAccount {
 			}
 			return ret
 		})(o.Balance),
-		LocalCurrency:     o.LocalCurrency.DeepCopy(),
-		LocalExchangeRate: o.LocalExchangeRate.DeepCopy(),
+		ExchangeRate: (func(x *OutsideExchangeRate) *OutsideExchangeRate {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.ExchangeRate),
 	}
 }
 
@@ -149,7 +141,7 @@ type SetDisplayCurrencyArg struct {
 }
 
 type ExchangeRateLocalArg struct {
-	Currency LocalCurrencyCode `codec:"currency" json:"currency"`
+	Currency OutsideCurrencyCode `codec:"currency" json:"currency"`
 }
 
 type LocalInterface interface {
@@ -162,7 +154,7 @@ type LocalInterface interface {
 	OwnAccountLocal(context.Context, AccountID) (bool, error)
 	ImportSecretKeyLocal(context.Context, ImportSecretKeyLocalArg) error
 	SetDisplayCurrency(context.Context, SetDisplayCurrencyArg) error
-	ExchangeRateLocal(context.Context, LocalCurrencyCode) (LocalExchangeRate, error)
+	ExchangeRateLocal(context.Context, OutsideCurrencyCode) (OutsideExchangeRate, error)
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -370,7 +362,7 @@ func (c LocalClient) SetDisplayCurrency(ctx context.Context, __arg SetDisplayCur
 	return
 }
 
-func (c LocalClient) ExchangeRateLocal(ctx context.Context, currency LocalCurrencyCode) (res LocalExchangeRate, err error) {
+func (c LocalClient) ExchangeRateLocal(ctx context.Context, currency OutsideCurrencyCode) (res OutsideExchangeRate, err error) {
 	__arg := ExchangeRateLocalArg{Currency: currency}
 	err = c.Cli.Call(ctx, "stellar.1.local.exchangeRateLocal", []interface{}{__arg}, &res)
 	return

--- a/go/stellar/exchange.go
+++ b/go/stellar/exchange.go
@@ -1,0 +1,47 @@
+package stellar
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/stellar/go/amount"
+)
+
+func ConvertXLMToOutside(XLMAmount string, rate stellar1.OutsideExchangeRate) (localAmount string, err error) {
+	var zero big.Rat
+	rateRat := new(big.Rat)
+	_, ok := rateRat.SetString(rate.Rate)
+	if !ok {
+		return "", fmt.Errorf("error parsing exchange rate: %v", rate.Rate)
+	}
+	if rateRat.Cmp(&zero) == 0 {
+		return "", fmt.Errorf("zero-value exchange rate")
+	}
+	amountInt64, err := amount.ParseInt64(XLMAmount)
+	if err != nil {
+		return "", fmt.Errorf("parsing amount to convert: %v", err)
+	}
+	acc := big.NewRat(amountInt64, amount.One)
+	acc.Mul(acc, rateRat)
+	return acc.FloatString(7), nil
+}
+
+func ConvertLocalToXLM(localAmount string, rate stellar1.OutsideExchangeRate) (XLMAmount string, err error) {
+	var zero big.Rat
+	rateRat := new(big.Rat)
+	_, ok := rateRat.SetString(rate.Rate)
+	if !ok {
+		return "", fmt.Errorf("error parsing exchange rate: %v", rate.Rate)
+	}
+	if rateRat.Cmp(&zero) == 0 {
+		return "", fmt.Errorf("zero-value exchange rate")
+	}
+	amountInt64, err := amount.ParseInt64(localAmount)
+	if err != nil {
+		return "", fmt.Errorf("parsing amount to convert: %v", err)
+	}
+	acc := big.NewRat(amountInt64, amount.One)
+	acc.Quo(acc, rateRat)
+	return acc.FloatString(7), nil
+}

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"strconv"
 
 	"github.com/keybase/client/go/libkb"
@@ -314,12 +313,6 @@ type tickerResult struct {
 
 func (b *tickerResult) GetAppStatus() *libkb.AppStatus {
 	return &b.Status
-}
-
-type XLMExchangeRate struct {
-	Currency   string
-	PriceFloat float64
-	PriceRat   big.Rat
 }
 
 func ExchangeRate(ctx context.Context, g *libkb.GlobalContext, currency string) (stellar1.OutsideExchangeRate, error) {

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"strconv"
 
 	"github.com/keybase/client/go/libkb"
@@ -304,8 +305,8 @@ func RecentPayments(ctx context.Context, g *libkb.GlobalContext,
 
 type tickerResult struct {
 	Status     libkb.AppStatus `json:"status"`
-	Price      float64         `json:"price"`
-	PriceInBTC float64         `json:"xlm_btc"`
+	Price      string          `json:"price"`
+	PriceInBTC string          `json:"xlm_btc"`
 	CachedAt   keybase1.Time   `json:"cached_at"`
 	URL        string          `json:"url"`
 	Currency   string          `json:"currency"`
@@ -316,11 +317,12 @@ func (b *tickerResult) GetAppStatus() *libkb.AppStatus {
 }
 
 type XLMExchangeRate struct {
-	Price    float64
-	Currency string
+	Currency   string
+	PriceFloat float64
+	PriceRat   big.Rat
 }
 
-func ExchangeRate(ctx context.Context, g *libkb.GlobalContext, currency string) (XLMExchangeRate, error) {
+func ExchangeRate(ctx context.Context, g *libkb.GlobalContext, currency string) (stellar1.OutsideExchangeRate, error) {
 	apiArg := libkb.APIArg{
 		Endpoint:    "stellar/ticker",
 		SessionType: libkb.APISessionTypeREQUIRED,
@@ -331,9 +333,12 @@ func ExchangeRate(ctx context.Context, g *libkb.GlobalContext, currency string) 
 	}
 	var apiRes tickerResult
 	if err := g.API.GetDecode(apiArg, &apiRes); err != nil {
-		return XLMExchangeRate{}, err
+		return stellar1.OutsideExchangeRate{}, err
 	}
-	return XLMExchangeRate{Price: apiRes.Price, Currency: apiRes.Currency}, nil
+	return stellar1.OutsideExchangeRate{
+		Currency: stellar1.OutsideCurrencyCode(apiRes.Currency),
+		Rate:     apiRes.Price,
+	}, nil
 }
 
 type accountCurrencyResult struct {

--- a/protocol/avdl/stellar1/common.avdl
+++ b/protocol/avdl/stellar1/common.avdl
@@ -56,4 +56,11 @@ protocol common {
     TransactionID stellarID;
   }
 
+  @typedef("string") record OutsideCurrencyCode {}
+
+  record OutsideExchangeRate {
+    OutsideCurrencyCode currency; // Example: PLN
+    string rate; // Example: "0.9389014463" = PLN / XLM
+  }
+
 }

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -29,17 +29,13 @@ protocol local {
 
   Bundle walletDumpLocal();
 
-  @typedef("string") record LocalCurrencyCode {}
-  @typedef("float") record LocalExchangeRate {}
-
   // Account balance and its current value in selected currency.
   record LocalOwnAccount {
     AccountID accountID;
     boolean isPrimary;
     string name;
     array<Balance> balance;
-    LocalCurrencyCode localCurrency;
-    LocalExchangeRate localExchangeRate;
+    union { null, OutsideExchangeRate } exchangeRate;
   }
 
   array<LocalOwnAccount> walletGetLocalAccounts();
@@ -51,5 +47,5 @@ protocol local {
 
   void setDisplayCurrency(AccountID accountID, string currency);
 
-  LocalExchangeRate exchangeRateLocal(LocalCurrencyCode currency);
+  OutsideExchangeRate exchangeRateLocal(OutsideCurrencyCode currency);
 }

--- a/protocol/json/stellar1/common.json
+++ b/protocol/json/stellar1/common.json
@@ -169,6 +169,26 @@
           "name": "stellarID"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "OutsideCurrencyCode",
+      "fields": [],
+      "typedef": "string"
+    },
+    {
+      "type": "record",
+      "name": "OutsideExchangeRate",
+      "fields": [
+        {
+          "type": "OutsideCurrencyCode",
+          "name": "currency"
+        },
+        {
+          "type": "string",
+          "name": "rate"
+        }
+      ]
     }
   ],
   "messages": {},

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -83,18 +83,6 @@
     },
     {
       "type": "record",
-      "name": "LocalCurrencyCode",
-      "fields": [],
-      "typedef": "string"
-    },
-    {
-      "type": "record",
-      "name": "LocalExchangeRate",
-      "fields": [],
-      "typedef": "float"
-    },
-    {
-      "type": "record",
       "name": "LocalOwnAccount",
       "fields": [
         {
@@ -117,12 +105,11 @@
           "name": "balance"
         },
         {
-          "type": "LocalCurrencyCode",
-          "name": "localCurrency"
-        },
-        {
-          "type": "LocalExchangeRate",
-          "name": "localExchangeRate"
+          "type": [
+            null,
+            "OutsideExchangeRate"
+          ],
+          "name": "exchangeRate"
         }
       ]
     }
@@ -230,10 +217,10 @@
       "request": [
         {
           "name": "currency",
-          "type": "LocalCurrencyCode"
+          "type": "OutsideCurrencyCode"
         }
       ],
-      "response": "LocalExchangeRate"
+      "response": "OutsideExchangeRate"
     }
   },
   "namespace": "stellar.1"


### PR DESCRIPTION
Pass strings around for conversion rates and use big rationals for calculations. Round to 7 decimal places past the point after calculating.

I am not sure whether this actually matters, as I'm pretty unpracticed in thinking about precision. But I do think this way has less potential pitfalls.

Requires https://github.com/keybase/keybase/pull/2353