### PR TITLE
use NIST sessions wherever possible

### DIFF
--- a/go/engine/nist_test.go
+++ b/go/engine/nist_test.go
@@ -1,0 +1,76 @@
+package engine
+
+import (
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	"testing"
+	"time"
+)
+
+func TestNIST(t *testing.T) {
+	tc := SetupEngineTest(t, "nist")
+	defer tc.Cleanup()
+	fu := CreateAndSignupFakeUser(tc, "nst")
+
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+	tc.G.ResetLoginState()
+
+	// Need to set active devices
+	Logout(tc)
+
+	ctx := context.Background()
+
+	// If you're logged out, it's not an error to grab a NIST,
+	// you just won't get one back
+	nist, err := tc.G.ActiveDevice.NIST(ctx)
+	require.NoError(t, err)
+	require.Nil(t, nist)
+
+	fu.LoginOrBust(tc)
+
+	// First stab, generate the NIST, and make sure it's a long NIST
+	nist, err = tc.G.ActiveDevice.NIST(ctx)
+	require.NoError(t, err, "no nist error")
+	require.NotNil(t, nist, "nist came back")
+	require.False(t, nist.IsExpired(), "nist is not expired")
+	longTok := nist.Token().String()
+	require.True(t, len(longTok) > 60, "should be a long token")
+
+	// If we call into the same codepath again, make sure that we get
+	// the same NIST back out
+	nist, err = tc.G.ActiveDevice.NIST(ctx)
+	require.NoError(t, err, "no nist error")
+	longTok2 := nist.Token().String()
+	require.Equal(t, longTok, longTok2, "same token if done twice")
+
+	// Once we've "marked success" for the NIST, then we're OK to switch over
+	// to a "short NIST"
+	nist.MarkSuccess()
+	nist, err = tc.G.ActiveDevice.NIST(ctx)
+	require.NoError(t, err, "no nist error")
+	shortTok1 := nist.Token().String()
+	require.True(t, len(shortTok1) < 60, "should be a short token")
+	require.NotEqual(t, longTok2, shortTok1, "and yes, it's a different token")
+
+	// After 100 hours, it should be an expired token
+	fakeClock.Advance(100 * time.Hour)
+	require.True(t, nist.IsExpired(), "nist should be expired now")
+	nist, err = tc.G.ActiveDevice.NIST(ctx)
+	require.NoError(t, err, "no nist error")
+
+	// Easy to make a new token, but we have to make sure that it's
+	// a different one.
+	longTok3 := nist.Token().String()
+	require.True(t, len(longTok3) > 60, "should be a long token")
+	require.NotEqual(t, longTok, longTok3, "after expiration, should get a new token")
+
+	// As before, once it's successful, then, as above, we get a short NIST token.
+	nist.MarkSuccess()
+	nist, err = tc.G.ActiveDevice.NIST(ctx)
+	require.NoError(t, err, "no nist error")
+	shortTok2 := nist.Token().String()
+	require.True(t, len(shortTok2) < 60, "should be a short token")
+	require.NotEqual(t, shortTok1, shortTok2, "the short tok changed")
+}

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -490,7 +490,7 @@ func (a *Account) SetCachedSecretKey(ska SecretKeyArg, key GenericKey, device *D
 	case DeviceSigningKeyType:
 		a.G().Log.Debug("caching secret device signing key")
 
-		if err := a.G().ActiveDevice.setSigningKey(a, uid, deviceID, key); err != nil {
+		if err := a.G().ActiveDevice.setSigningKey(a.G(), a, uid, deviceID, key); err != nil {
 			return err
 		}
 

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -221,3 +221,10 @@ func (a *ActiveDevice) NIST(ctx context.Context) (*NIST, error) {
 	defer a.RUnlock()
 	return a.nistFactory.NIST(ctx)
 }
+
+func (a *ActiveDevice) NISTAndUID(ctx context.Context) (*NIST, keybase1.UID, error) {
+	a.RLock()
+	defer a.RUnlock()
+	nist, err := a.nistFactory.NIST(ctx)
+	return nist, a.uid, err
+}

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -222,12 +222,6 @@ func getNIST(ctx context.Context, g *GlobalContext, sessType APISessionType) *NI
 		return nil
 	}
 
-	// We're almost always using NISTs, unless we're some whacky tests like
-	// TestRekey.
-	if g.Env.DisableNISTs() {
-		return nil
-	}
-
 	if !g.Env.GetTorMode().UseSession() {
 		return nil
 	}

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -52,9 +52,9 @@ func (s *AppStatusEmbed) GetAppStatus() *AppStatus {
 // allowing us to share the request-making code below in doRequest
 type Requester interface {
 	Contextifier
-	fixHeaders(arg APIArg, req *http.Request) error
+	fixHeaders(ctx context.Context, arg APIArg, req *http.Request, nist *NIST) error
 	getCli(needSession bool) *Client
-	consumeHeaders(resp *http.Response) error
+	consumeHeaders(ctx context.Context, resp *http.Response, nist *NIST) error
 	isExternal() bool
 }
 
@@ -217,6 +217,34 @@ func (c *countingReader) numRead() int {
 
 func noopFinisher() {}
 
+func getNIST(ctx context.Context, g *GlobalContext, sessType APISessionType) *NIST {
+	if sessType == APISessionTypeNONE {
+		return nil
+	}
+
+	// We're almost always using NISTs, unless we're some whacky tests like
+	// TestRekey.
+	if g.Env.DisableNISTs() {
+		return nil
+	}
+
+	if !g.Env.GetTorMode().UseSession() {
+		return nil
+	}
+
+	nist, err := g.ActiveDevice.NIST(ctx)
+	if nist == nil {
+		g.Log.CDebugf(ctx, "active device couldn't generate a NIST")
+		return nil
+	}
+
+	if err != nil {
+		g.Log.CDebugf(ctx, "Error generating NIST: %s", err)
+		return nil
+	}
+	return nist
+}
+
 // doRequestShared returns an http.Response, which is a live streaming object that
 // escapes the function in which it was created.  It therefore also returns
 // a `finisher func()` that *must always be called* after the response is no longer
@@ -239,7 +267,9 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 
 	api.G().Log.CDebugf(ctx, "+ API %s %s", req.Method, req.URL)
 
-	if err = api.fixHeaders(arg, req); err != nil {
+	nist := getNIST(ctx, api.G(), arg.SessionType)
+
+	if err = api.fixHeaders(ctx, arg, req, nist); err != nil {
 		api.G().Log.CDebugf(ctx, "- API %s %s: fixHeaders error: %s", req.Method, req.URL, err)
 		return
 	}
@@ -300,7 +330,7 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	// headers. If the client is *really* out of date, the request status will
 	// be a 400 error, but these headers will still be present. So we need to
 	// handle headers *before* we abort based on status below.
-	err = api.consumeHeaders(internalResp)
+	err = api.consumeHeaders(ctx, internalResp, nist)
 	if err != nil {
 		return nil, finisher, nil, err
 	}
@@ -526,7 +556,7 @@ func (a *InternalAPIEngine) updateCriticalClockSkewWarning(resp *http.Response) 
 	}
 }
 
-func (a *InternalAPIEngine) consumeHeaders(resp *http.Response) (err error) {
+func (a *InternalAPIEngine) consumeHeaders(ctx context.Context, resp *http.Response, nist *NIST) (err error) {
 	upgradeTo := resp.Header.Get("X-Keybase-Client-Upgrade-To")
 	upgradeURI := resp.Header.Get("X-Keybase-Upgrade-URI")
 	customMessage := resp.Header.Get("X-Keybase-Upgrade-Message")
@@ -536,7 +566,21 @@ func (a *InternalAPIEngine) consumeHeaders(resp *http.Response) (err error) {
 			customMessage = string(decoded)
 		} else {
 			// If base64-decode fails, just log the error and skip decoding.
-			a.G().Log.Errorf("Failed to decode X-Keybase-Upgrade-Message header: %s", err)
+			a.G().Log.CErrorf(ctx, "Failed to decode X-Keybase-Upgrade-Message header: %s", err)
+		}
+	}
+
+	if nist != nil {
+		nistReply := resp.Header.Get("X-Keybase-Auth-NIST")
+		switch nistReply {
+		case "":
+		case "verified":
+			nist.MarkSuccess()
+		case "failed":
+			nist.MarkFailure()
+			a.G().Log.CWarningf(ctx, "NIST token failed to verify")
+		default:
+			a.G().Log.CNoticef(ctx, "Unexpected 'X-Keybase-Auth-NIST' state: %s", nistReply)
 		}
 	}
 
@@ -570,22 +614,27 @@ func (a *InternalAPIEngine) consumeHeaders(resp *http.Response) (err error) {
 	return
 }
 
-func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) error {
-	if arg.SessionType != APISessionTypeNONE {
+func (a *InternalAPIEngine) fixHeaders(ctx context.Context, arg APIArg, req *http.Request, nist *NIST) error {
+
+	if nist != nil {
+		req.Header.Set("X-Keybase-Session", nist.Token().String())
+
+	} else if arg.SessionType != APISessionTypeNONE {
+		a.G().Log.CDebugf(ctx, "fixHeaders: falling back to legacy session management")
 		tok, csrf, err := a.sessionArgs(arg)
 		if err != nil {
 			if arg.SessionType == APISessionTypeREQUIRED {
-				a.G().Log.Warning("fixHeaders: session required, but error getting sessionArgs: %s", err)
+				a.G().Log.CWarningf(ctx, "fixHeaders: session required, but error getting sessionArgs: %s", err)
 				return err
 			}
-			a.G().Log.Debug("fixHeaders: session optional, error getting sessionArgs: %s", err)
+			a.G().Log.CDebugf(ctx, "fixHeaders: session optional, error getting sessionArgs: %s", err)
 		}
 
 		if a.G().Env.GetTorMode().UseSession() {
 			if len(tok) > 0 {
 				req.Header.Set("X-Keybase-Session", tok)
 			} else if arg.SessionType == APISessionTypeREQUIRED {
-				a.G().Log.Warning("fixHeaders: need session, but session token empty")
+				a.G().Log.CWarningf(ctx, "fixHeaders: need session, but session token empty")
 				return InternalError{Msg: "API request requires session, but session token empty"}
 			}
 		}
@@ -593,7 +642,7 @@ func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) error {
 			if len(csrf) > 0 {
 				req.Header.Set("X-CSRF-Token", csrf)
 			} else if arg.SessionType == APISessionTypeREQUIRED {
-				a.G().Log.Warning("fixHeaders: need session, but session csrf empty")
+				a.G().Log.CWarningf(ctx, "fixHeaders: need session, but session csrf empty")
 				return InternalError{Msg: "API request requires session, but session csrf empty"}
 			}
 		}
@@ -958,7 +1007,7 @@ const (
 	XAPIResText
 )
 
-func (api *ExternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) error {
+func (api *ExternalAPIEngine) fixHeaders(ctx context.Context, arg APIArg, req *http.Request, nist *NIST) error {
 	// TODO (here and in the internal API engine implementation): If we don't
 	// set the User-Agent, it will default to http.defaultUserAgent
 	// ("Go-http-client/1.1"). We should think about whether that's what we
@@ -987,7 +1036,7 @@ func isReddit(req *http.Request) bool {
 	return host == "reddit.com" || strings.HasSuffix(host, ".reddit.com")
 }
 
-func (api *ExternalAPIEngine) consumeHeaders(resp *http.Response) error {
+func (api *ExternalAPIEngine) consumeHeaders(ctx context.Context, resp *http.Response, nist *NIST) error {
 	return nil
 }
 

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -569,6 +569,7 @@ const (
 	SignaturePrefixSigchain       SignaturePrefix = "Keybase-Sigchain-1"
 	SignaturePrefixChatAttachment SignaturePrefix = "Keybase-Chat-Attachment-1"
 	SignaturePrefixTesting        SignaturePrefix = "Keybase-Testing-1"
+	SignaturePrefixNIST           SignaturePrefix = "Keybase-Auth-NIST-1"
 	// Chat prefixes for each MessageBoxedVersion.
 	SignaturePrefixChatMBv1 SignaturePrefix = "Keybase-Chat-1"
 	SignaturePrefixChatMBv2 SignaturePrefix = "Keybase-Chat-2"

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -168,6 +168,11 @@ type TestParameters struct {
 
 	// On if, in test, we want to skip sending system chat messages
 	SkipSendingSystemChatMessages bool
+
+	// On if we can't use NIST-style sessions. Mainly in tests that aggressively
+	// push the clock forward (since the server will start to reject NISTs for
+	// clocks too far broken).
+	DisableNISTs bool
 }
 
 func (tp TestParameters) GetDebug() (bool, bool) {
@@ -306,6 +311,10 @@ func (e *Env) GetLogDir() string          { return e.HomeFinder.LogDir() }
 
 func (e *Env) SendSystemChatMessages() bool {
 	return !e.Test.SkipSendingSystemChatMessages
+}
+
+func (e *Env) DisableNISTs() bool {
+	return e.Test.DisableNISTs
 }
 
 func (e *Env) GetRuntimeDir() string {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -169,10 +169,9 @@ type TestParameters struct {
 	// On if, in test, we want to skip sending system chat messages
 	SkipSendingSystemChatMessages bool
 
-	// On if we can't use NIST-style sessions. Mainly in tests that aggressively
-	// push the clock forward (since the server will start to reject NISTs for
-	// clocks too far broken).
-	DisableNISTs bool
+	// If we need to use the real clock for NIST generation (as in really
+	// whacky tests liks TestRekey).
+	UseTimeClockForNISTs bool
 }
 
 func (tp TestParameters) GetDebug() (bool, bool) {
@@ -313,8 +312,8 @@ func (e *Env) SendSystemChatMessages() bool {
 	return !e.Test.SkipSendingSystemChatMessages
 }
 
-func (e *Env) DisableNISTs() bool {
-	return e.Test.DisableNISTs
+func (e *Env) UseTimeClockForNISTs() bool {
+	return e.Test.UseTimeClockForNISTs
 }
 
 func (e *Env) GetRuntimeDir() string {

--- a/go/libkb/nist.go
+++ b/go/libkb/nist.go
@@ -27,6 +27,7 @@ import (
 const nistExpirationMargin = time.Minute * 5
 const nistLifetime = 28 * time.Hour
 const nistSessionIDLength = 16
+const nistShortHashLen = 19
 
 type nistMode int
 type sessionVersion int
@@ -53,6 +54,9 @@ func (n NISTToken) String() string { return base64.StdEncoding.EncodeToString(n.
 func (n NISTToken) Hash() []byte {
 	tmp := sha256.Sum256(n.Bytes())
 	return tmp[:]
+}
+func (n NISTToken) ShortHash() []byte {
+	return n.Hash()[0:nistShortHashLen]
 }
 
 type NIST struct {
@@ -243,7 +247,7 @@ func (n *NIST) generate(ctx context.Context, uid keybase1.UID, deviceID keybase1
 	shortTmp, err = (nistHash{
 		Version: nistVersion,
 		Mode:    nistModeHash,
-		Hash:    longTmp.Hash(),
+		Hash:    longTmp.ShortHash(),
 	}).pack()
 	if err != nil {
 		return err

--- a/go/libkb/nist.go
+++ b/go/libkb/nist.go
@@ -1,0 +1,266 @@
+package libkb
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
+	"sync"
+	"time"
+)
+
+//
+// NIST = "Non-Interactive Session Token"
+//
+// If a client has an unlocked device key, it's able to sign a statement
+// of its own creation, and present it to the server as a session key.
+// Or, to save bandwidth, can just present the hash of a previously-accepted
+// NIST token.
+//
+// Use NIST tokens rather than the prior generation of session tokens so that
+// we're more responsive when we come back from backgrounding, etc.
+//
+
+// If we're within 5 minutes of expiration, generate a new NIST
+const nistExpirationMargin = time.Minute * 5
+const nistLifetime = 28 * time.Hour
+const nistSessionIDLength = 16
+
+type nistMode int
+type sessionVersion int
+
+const (
+	nistVersion       sessionVersion = 34
+	nistModeSignature nistMode       = 1
+	nistModeHash      nistMode       = 2
+)
+
+type NISTFactory struct {
+	Contextified
+	sync.Mutex
+	uid      keybase1.UID
+	deviceID keybase1.DeviceID
+	key      GenericKey // cached secret signing key
+	nist     *NIST
+}
+
+type NISTToken []byte
+
+func (n NISTToken) Bytes() []byte  { return []byte(n) }
+func (n NISTToken) String() string { return base64.StdEncoding.EncodeToString(n.Bytes()) }
+func (n NISTToken) Hash() []byte {
+	tmp := sha256.Sum256(n.Bytes())
+	return tmp[:]
+}
+
+type NIST struct {
+	Contextified
+	sync.RWMutex
+	expiresAt time.Time
+	failed    bool
+	succeeded bool
+	long      NISTToken
+	short     NISTToken
+}
+
+func NewNISTFactory(g *GlobalContext, uid keybase1.UID, deviceID keybase1.DeviceID, key GenericKey) *NISTFactory {
+	return &NISTFactory{
+		Contextified: NewContextified(g),
+		uid:          uid,
+		deviceID:     deviceID,
+		key:          key,
+	}
+}
+
+func (f *NISTFactory) NIST(ctx context.Context) (ret *NIST, err error) {
+	if f == nil {
+		return nil, nil
+	}
+
+	f.Lock()
+	defer f.Unlock()
+
+	if f.nist == nil || f.nist.IsExpired() || f.nist.DidFail() {
+		ret = newNIST(f.G())
+		err = ret.generate(ctx, f.uid, f.deviceID, f.key)
+		if err != nil {
+			return nil, err
+		}
+		f.nist = ret
+	}
+
+	return f.nist, nil
+}
+
+func (n *NIST) IsExpired() bool {
+	n.RLock()
+	defer n.RUnlock()
+	conservativeExpiration := n.expiresAt.Add(-nistExpirationMargin)
+	return !conservativeExpiration.After(n.G().Clock().Now())
+}
+
+func (n *NIST) DidFail() bool {
+	n.RLock()
+	defer n.RUnlock()
+	return n.failed
+}
+
+func (n *NIST) MarkFailure() {
+	n.Lock()
+	defer n.Unlock()
+	n.failed = true
+}
+
+func (n *NIST) MarkSuccess() {
+	n.Lock()
+	defer n.Unlock()
+	n.succeeded = true
+}
+
+func newNIST(g *GlobalContext) *NIST {
+	return &NIST{Contextified: NewContextified(g)}
+}
+
+type nistPayload struct {
+	_struct   bool `codec:",toarray"`
+	Version   sessionVersion
+	Mode      nistMode
+	Hostname  string
+	UID       []byte
+	DeviceID  []byte
+	KID       []byte
+	Generated int64
+	Lifetime  int64
+	SessionID []byte
+}
+
+type nistSig struct {
+	_struct bool `codec:",toarray"`
+	Version sessionVersion
+	Mode    nistMode
+	Sig     []byte
+	Payload nistPayloadShort
+}
+
+type nistPayloadShort struct {
+	_struct   bool `codec:",toarray"`
+	UID       []byte
+	DeviceID  []byte
+	Generated int64
+	Lifetime  int64
+	SessionID []byte
+}
+
+type nistHash struct {
+	_struct bool `codec:",toarray"`
+	Version sessionVersion
+	Mode    nistMode
+	Hash    []byte
+}
+
+func (h nistSig) pack() (NISTToken, error) {
+	b, err := MsgpackEncode(h)
+	if err != nil {
+		return nil, err
+	}
+	return NISTToken(b), nil
+}
+
+func (h nistHash) pack() (NISTToken, error) {
+	b, err := MsgpackEncode(h)
+	if err != nil {
+		return nil, err
+	}
+	return NISTToken(b), nil
+}
+
+func (n nistPayload) abbreviate() nistPayloadShort {
+	return nistPayloadShort{
+		UID:       n.UID,
+		DeviceID:  n.DeviceID,
+		Generated: n.Generated,
+		Lifetime:  n.Lifetime,
+		SessionID: n.SessionID,
+	}
+}
+
+func (n *NIST) generate(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID, key GenericKey) (err error) {
+	defer n.G().CTrace(ctx, "NIST#generate", func() error { return err })()
+
+	n.Lock()
+	defer n.Unlock()
+
+	naclKey, ok := (key).(NaclSigningKeyPair)
+	if !ok {
+		return errors.New("cannot generate a NIST without a NaCl key")
+	}
+
+	generated := n.G().Clock().Now()
+	expires := generated.Add(nistLifetime)
+
+	payload := nistPayload{
+		Version:   nistVersion,
+		Mode:      nistModeSignature,
+		Hostname:  CanonicalHost,
+		UID:       uid.ToBytes(),
+		Generated: generated.Unix(),
+		Lifetime:  nistLifetime.Nanoseconds() / 1000000000,
+		KID:       key.GetBinaryKID(),
+	}
+	payload.DeviceID, err = hex.DecodeString(string(deviceID))
+	if err != nil {
+		return err
+	}
+	payload.SessionID, err = RandBytes(nistSessionIDLength)
+	if err != nil {
+		return err
+	}
+	var sigInfo *NaclSigInfo
+	var payloadPacked []byte
+	payloadPacked, err = MsgpackEncode(payload)
+	if err != nil {
+		return err
+	}
+	sigInfo, err = naclKey.SignV2(payloadPacked, SignaturePrefixNIST)
+	if err != nil {
+		return err
+	}
+
+	var longTmp, shortTmp NISTToken
+
+	longTmp, err = (nistSig{
+		Version: nistVersion,
+		Mode:    nistModeSignature,
+		Sig:     sigInfo.Sig[:],
+		Payload: payload.abbreviate(),
+	}).pack()
+	if err != nil {
+		return err
+	}
+
+	shortTmp, err = (nistHash{
+		Version: nistVersion,
+		Mode:    nistModeHash,
+		Hash:    longTmp.Hash(),
+	}).pack()
+	if err != nil {
+		return err
+	}
+
+	n.long = longTmp
+	n.short = shortTmp
+	n.expiresAt = expires
+
+	return nil
+}
+
+func (n *NIST) Token() NISTToken {
+	n.RLock()
+	defer n.RUnlock()
+	if n.succeeded {
+		return n.short
+	}
+	return n.long
+}

--- a/go/libkb/nist.go
+++ b/go/libkb/nist.go
@@ -201,7 +201,17 @@ func (n *NIST) generate(ctx context.Context, uid keybase1.UID, deviceID keybase1
 		return errors.New("cannot generate a NIST without a NaCl key")
 	}
 
-	generated := n.G().Clock().Now()
+	var generated time.Time
+
+	// For some tests we ignore the clock in n.G().Clock() and just use the standard
+	// time.Now() clock, because otherwise, the server would start to reject our
+	// NISTs.
+	if n.G().Env.UseTimeClockForNISTs() {
+		generated = time.Now()
+	} else {
+		generated = n.G().Clock().Now()
+	}
+
 	expires := generated.Add(nistLifetime)
 
 	payload := nistPayload{

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1229,7 +1229,7 @@ func (g *gregorHandler) loggedIn(ctx context.Context) (uid keybase1.UID, token s
 	}
 	if err != nil {
 		g.G().Log.CDebugf(ctx, "gregorHandler: error in generating NIST: %s", err.Error())
-		return uid, token, loggedInNo
+		return uid, token, loggedInMaybe
 	}
 
 	return uid, nist.Token().String(), loggedInYes

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1224,14 +1224,13 @@ func (g *gregorHandler) loggedIn(ctx context.Context) (uid keybase1.UID, token s
 
 	nist, uid, err := g.G().ActiveDevice.NISTAndUID(ctx)
 	if nist == nil {
-		g.G().Log.CDebugf(ctx, "no NIST for login; user isn't logged in")
+		g.G().Log.CDebugf(ctx, "gregorHandler: no NIST for login; user isn't logged in")
 		return uid, token, loggedInNo
 	}
 	if err != nil {
-		g.G().Log.CDebugf(ctx, "error in generating NIST: %s", err.Error())
+		g.G().Log.CDebugf(ctx, "gregorHandler: error in generating NIST: %s", err.Error())
 		return uid, token, loggedInNo
 	}
-	g.G().Log.CDebugf(ctx, "NIST %s", nist.Token().String())
 
 	return uid, nist.Token().String(), loggedInYes
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1222,26 +1222,18 @@ func (g *gregorHandler) loggedIn(ctx context.Context) (uid keybase1.UID, token s
 		// if we were going to block, then that means we are still alive
 	}
 
-	// Continue on and authenticate
-	g.G().Log.Debug("gregorHandler forceSessionCheck: %v", g.forceSessionCheck)
-	status, err := g.G().LoginState().APIServerSession(g.forceSessionCheck)
-	if err != nil {
-		switch err.(type) {
-		case libkb.LoginRequiredError:
-			return uid, token, loggedInNo
-		case libkb.NoSessionError:
-			return uid, token, loggedInNo
-		default:
-			g.G().Log.Debug("gregorHandler APIServerSessionStatus error (%T): %s", err, err)
-		}
-		g.G().Log.Debug("gregorHandler APIServerSessionStatus error: %s (returning loggedInMaybe)", err)
-		return uid, token, loggedInMaybe
-	}
-	if status == nil {
+	nist, uid, err := g.G().ActiveDevice.NISTAndUID(ctx)
+	if nist == nil {
+		g.G().Log.CDebugf(ctx, "no NIST for login; user isn't logged in")
 		return uid, token, loggedInNo
 	}
+	if err != nil {
+		g.G().Log.CDebugf(ctx, "error in generating NIST: %s", err.Error())
+		return uid, token, loggedInNo
+	}
+	g.G().Log.CDebugf(ctx, "NIST %s", nist.Token().String())
 
-	return status.UID, status.SessionToken, loggedInYes
+	return uid, nist.Token().String(), loggedInYes
 }
 
 func (g *gregorHandler) auth(ctx context.Context, cli rpc.GenericClient, auth *gregor1.AuthResult) (err error) {

--- a/go/systests/rekey_test.go
+++ b/go/systests/rekey_test.go
@@ -132,7 +132,7 @@ func (rkt *rekeyTester) setup(nm string) *deviceWrapper {
 func (rkt *rekeyTester) setupDevice(nm string) *deviceWrapper {
 	tctx := setupTest(rkt.t, nm)
 	tctx.G.SetClock(rkt.fakeClock)
-	tctx.G.Env.Test.DisableNISTs = true
+	tctx.G.Env.Test.UseTimeClockForNISTs = true
 	ret := &deviceWrapper{tctx: tctx}
 	rkt.devices = append(rkt.devices, ret)
 	return ret

--- a/go/systests/rekey_test.go
+++ b/go/systests/rekey_test.go
@@ -132,6 +132,7 @@ func (rkt *rekeyTester) setup(nm string) *deviceWrapper {
 func (rkt *rekeyTester) setupDevice(nm string) *deviceWrapper {
 	tctx := setupTest(rkt.t, nm)
 	tctx.G.SetClock(rkt.fakeClock)
+	tctx.G.Env.Test.DisableNISTs = true
 	ret := &deviceWrapper{tctx: tctx}
 	rkt.devices = append(rkt.devices, ret)
 	return ret

--- a/go/systests/team_list_test.go
+++ b/go/systests/team_list_test.go
@@ -1,7 +1,6 @@
 package systests
 
 import (
-	"fmt"
 	"testing"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -203,30 +202,20 @@ func TestTeamDuplicateUIDList(t *testing.T) {
 	team := ann.createTeam()
 	t.Logf("Team created (%s)", team)
 
-	fmt.Printf("-- TestTeamDuplicateUIDList A\n")
-
 	ann.addTeamMember(team, bob.username, keybase1.TeamRole_WRITER)
-	fmt.Printf("-- TestTeamDuplicateUIDList A.1\n")
-
 	bob.reset()
-	fmt.Printf("-- TestTeamDuplicateUIDList A.2\n")
 	bob.loginAfterReset()
-	fmt.Printf("-- TestTeamDuplicateUIDList A.3\n")
 
 	t.Logf("Bob (%s) resets and reprovisions", bob.username)
-	fmt.Printf("-- TestTeamDuplicateUIDList A.4\n")
 
 	ann.addTeamMember(team, bob.username, keybase1.TeamRole_WRITER)
-	fmt.Printf("-- TestTeamDuplicateUIDList A.5\n")
 
 	teamCli := ann.teamsClient
-	fmt.Printf("-- TestTeamDuplicateUIDList A.6\n")
 	details, err := teamCli.TeamGet(context.TODO(), keybase1.TeamGetArg{
 		Name:        team,
 		ForceRepoll: true,
 	})
 	require.NoError(t, err)
-	fmt.Printf("-- TestTeamDuplicateUIDList B\n")
 
 	// Expecting just the active writer here, and not inactive
 	// (because of reset) invite.
@@ -255,14 +244,12 @@ func TestTeamDuplicateUIDList(t *testing.T) {
 	require.NoError(t, err)
 
 	check(&list)
-	fmt.Printf("-- TestTeamDuplicateUIDList C\n")
 
 	t.Logf("Calling TeamList")
 	list, err = teamCli.TeamListUnverified(context.TODO(), keybase1.TeamListUnverifiedArg{})
 	require.NoError(t, err)
 
 	check(&list)
-	fmt.Printf("-- TestTeamDuplicateUIDList D\n")
 }
 
 func TestTeamTree(t *testing.T) {
@@ -290,18 +277,15 @@ func TestTeamTree(t *testing.T) {
 	}
 
 	subTeam1 := createSubteam(team, "staff")
-	fmt.Printf("-- TestTeamTree A\n")
 
 	sub1SubTeam1 := createSubteam(subTeam1, "legal")
 	sub1SubTeam2 := createSubteam(subTeam1, "hr")
 
 	subTeam2 := createSubteam(team, "offtopic")
-	fmt.Printf("-- TestTeamTree B\n")
 
 	sub2SubTeam1 := createSubteam(subTeam2, "games")
 	sub2SubTeam2 := createSubteam(subTeam2, "crypto")
 	sub2SubTeam3 := createSubteam(subTeam2, "cryptocurrency")
-	fmt.Printf("-- TestTeamTree C\n")
 
 	checkTeamTree := func(teamName string, expectedTree ...string) {
 		set := make(map[string]bool)
@@ -328,10 +312,8 @@ func TestTeamTree(t *testing.T) {
 	checkTeamTree(team, subTeam1, subTeam2, sub1SubTeam1, sub1SubTeam2, sub2SubTeam1, sub2SubTeam2, sub2SubTeam3)
 	checkTeamTree(subTeam1, sub1SubTeam1, sub1SubTeam2)
 	checkTeamTree(subTeam2, sub2SubTeam1, sub2SubTeam2, sub2SubTeam3)
-	fmt.Printf("-- TestTeamTree D\n")
 
 	checkTeamTree(sub2SubTeam1)
 	checkTeamTree(sub2SubTeam2)
 	checkTeamTree(sub2SubTeam3)
-	fmt.Printf("-- TestTeamTree E\n")
 }


### PR DESCRIPTION
- NIST = **N**on-**I**nteractive **S**ession **T**oken
- all engine tests now work
- add a nist test
- sytests all work too:
  - TestRekey is aggressive with playing with the clock, so it can't work with NISTs
  - TestAccountDeadlock needs a csrf_token from sesscheck, so fix that on the server side