### PR TITLE
Fix 'delete this + above' not showing up on messages you didn't write

### DIFF
--- a/shared/chat/conversation/messages/message-popup/text/index.js
+++ b/shared/chat/conversation/messages/message-popup/text/index.js
@@ -21,37 +21,36 @@ type Props = {
 }
 
 const TextPopupMenu = (props: Props) => {
-  const commonItems = [
+  const items = [
+    ...(props.showDivider ? ['Divider'] : []),
     {onClick: props.onCopy, title: 'Copy Text'},
     {onClick: props.onQuote, title: 'Quote'},
     {onClick: props.onReplyPrivately, title: 'Reply Privately'},
     {onClick: props.onViewProfile, title: 'View Profile'},
+    ...(props.yourMessage
+      ? [
+          {disabled: !props.onEdit, onClick: props.onEdit, title: 'Edit'},
+          'Divider',
+          {
+            danger: true,
+            disabled: !props.onDelete,
+            onClick: props.onDelete,
+            subTitle: 'Deletes this message for everyone',
+            title: 'Delete',
+          },
+        ]
+      : []),
+    ...(props.onDeleteMessageHistory
+      ? [
+          'Divider',
+          {
+            danger: true,
+            onClick: props.onDeleteMessageHistory,
+            title: 'Delete this + everything above',
+          },
+        ]
+      : []),
   ]
-  const items = props.yourMessage
-    ? [
-        ...(props.showDivider ? ['Divider'] : []),
-        ...commonItems,
-        {disabled: !props.onEdit, onClick: props.onEdit, title: 'Edit'},
-        {
-          danger: true,
-          disabled: !props.onDelete,
-          onClick: props.onDelete,
-          subTitle: 'Deletes this message for everyone',
-          title: 'Delete',
-        },
-        ...(props.onDeleteMessageHistory
-          ? [
-              'Divider',
-              {
-                danger: true,
-                onClick: props.onDeleteMessageHistory,
-                title: 'Delete this + everything above',
-              },
-            ]
-          : []),
-      ]
-    : commonItems
-
   const header = {
     title: 'header',
     view: (


### PR DESCRIPTION
@keybase/react-hackers 

The `deleteMessageHistory` item was incorrectly inside a `props.yourMessage`.

While I was in there, took the opportunity to simplify the code.