### PR TITLE
Fix android image attachment view

### DIFF
--- a/shared/common-adapters/zoomable-box.android.js
+++ b/shared/common-adapters/zoomable-box.android.js
@@ -204,10 +204,11 @@ class ZoomableBox extends React.Component<Props, State> {
     )
 
   render() {
+    const panHandlers = this._panResponder ? this._panResponder.panHandlers : {}
     return (
       <Box
         {...this.props}
-        {...this._panResponder.panHandlers}
+        {...panHandlers}
         onLayout={this._onLayout}
         style={{
           ...this.props.style,


### PR DESCRIPTION
The `componentWillMount` -> `componentDidMount` change made it so `this._panResponder` could be null. r? @keybase/react-hackers 