### PR TITLE
Tweak native attachment views

### DIFF
--- a/shared/chat/conversation/attachment-fullscreen/index.native.js
+++ b/shared/chat/conversation/attachment-fullscreen/index.native.js
@@ -13,6 +13,8 @@ import {globalColors, globalMargins, globalStyles, isIPhoneX} from '../../../sty
 
 import type {Props} from './'
 
+const {width: screenWidth, height: screenHeight} = NativeDimensions.get('window')
+
 class AutoMaxSizeImage extends Component<any, {width: number, height: number}> {
   state = {height: 0, width: 0}
   _mounted: boolean = false
@@ -30,7 +32,6 @@ class AutoMaxSizeImage extends Component<any, {width: number, height: number}> {
   }
 
   render() {
-    const {width: maxWidth, height: maxHeight} = NativeDimensions.get('window')
     return (
       <ZoomableBox
         contentContainerStyle={{flex: 1, position: 'relative'}}
@@ -44,8 +45,8 @@ class AutoMaxSizeImage extends Component<any, {width: number, height: number}> {
           resizeMode="contain"
           style={{
             flex: 1,
-            height: Math.min(this.state.height, maxHeight),
-            width: Math.min(this.state.width, maxWidth),
+            height: Math.min(this.state.height, screenHeight),
+            width: Math.min(this.state.width, screenWidth),
             alignSelf: 'center',
           }}
         />

--- a/shared/chat/conversation/attachment-fullscreen/index.native.js
+++ b/shared/chat/conversation/attachment-fullscreen/index.native.js
@@ -7,6 +7,7 @@ import {
   ProgressIndicator,
   NativeImage,
   ZoomableBox,
+  NativeDimensions,
 } from '../../../common-adapters/index.native'
 import {globalColors, globalMargins, globalStyles, isIPhoneX} from '../../../styles'
 
@@ -23,7 +24,8 @@ class AutoMaxSizeImage extends Component<any, {width: number, height: number}> {
     this._mounted = true
     NativeImage.getSize(this.props.source.uri, (width, height) => {
       if (this._mounted) {
-        this.setState({height, width})
+        const {width: maxWidth, height: maxHeight} = NativeDimensions.get('window')
+        this.setState({height: Math.min(height, maxHeight), width: Math.min(width, maxWidth)})
       }
     })
   }
@@ -37,7 +39,8 @@ class AutoMaxSizeImage extends Component<any, {width: number, height: number}> {
       >
         <NativeImage
           {...this.props}
-          style={{flex: 1, resizeMode: 'contain', maxHeight: this.state.height, maxWidth: this.state.width}}
+          resizeMode="contain"
+          style={{flex: 1, height: this.state.height, width: this.state.width, alignSelf: 'center'}}
         />
       </ZoomableBox>
     )

--- a/shared/chat/conversation/attachment-fullscreen/index.native.js
+++ b/shared/chat/conversation/attachment-fullscreen/index.native.js
@@ -24,23 +24,30 @@ class AutoMaxSizeImage extends Component<any, {width: number, height: number}> {
     this._mounted = true
     NativeImage.getSize(this.props.source.uri, (width, height) => {
       if (this._mounted) {
-        const {width: maxWidth, height: maxHeight} = NativeDimensions.get('window')
-        this.setState({height: Math.min(height, maxHeight), width: Math.min(width, maxWidth)})
+        this.setState({height, width})
       }
     })
   }
 
   render() {
+    const {width: maxWidth, height: maxHeight} = NativeDimensions.get('window')
     return (
       <ZoomableBox
         contentContainerStyle={{flex: 1, position: 'relative'}}
         maxZoom={10}
         style={{position: 'relative', overflow: 'hidden', width: '100%', height: '100%'}}
+        showsHorizontalScrollIndicator={false}
+        showsVerticalScrollIndicator={false}
       >
         <NativeImage
           {...this.props}
           resizeMode="contain"
-          style={{flex: 1, height: this.state.height, width: this.state.width, alignSelf: 'center'}}
+          style={{
+            flex: 1,
+            height: Math.min(this.state.height, maxHeight),
+            width: Math.min(this.state.width, maxWidth),
+            alignSelf: 'center',
+          }}
         />
       </ZoomableBox>
     )

--- a/shared/chat/conversation/messages/attachment/image/container.js
+++ b/shared/chat/conversation/messages/attachment/image/container.js
@@ -6,6 +6,7 @@ import * as Route from '../../../../../actions/route-tree'
 import {connect, type TypedState, type Dispatch, isMobile} from '../../../../../util/container'
 import {globalColors} from '../../../../../styles'
 import ImageAttachment from '.'
+import {imgMaxWidth} from './image-render'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -74,7 +75,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     progress: message.transferProgress,
     progressLabel,
     title: message.title || message.fileName,
-    width: message.previewWidth,
+    width: Math.min(message.previewWidth, imgMaxWidth()),
   }
 }
 

--- a/shared/chat/conversation/messages/attachment/image/image-render.native.js
+++ b/shared/chat/conversation/messages/attachment/image/image-render.native.js
@@ -6,7 +6,7 @@ import type {ImageRenderProps} from './image-render'
 
 export function ImageRender({style, src}: ImageRenderProps) {
   const source = typeof src === 'string' ? {uri: 'file://' + src} : src
-  return <NativeImage source={source} style={style} />
+  return <NativeImage source={source} style={style} resizeMode="contain" />
 }
 
 export function imgMaxWidth() {


### PR DESCRIPTION
- Tweaks attachment preview for small screens

before / after
<div style="display: flex; flex-direction: row">
<img width="300" alt="before" src="https://user-images.githubusercontent.com/11968340/38878594-4d5e04f4-422f-11e8-9394-38a3f9df6c52.png">
<img width="300" alt="after" src="https://user-images.githubusercontent.com/11968340/38878610-54e1f8a2-422f-11e8-950f-b4be801d7761.png">
</div>

- Centers fullscreen view for small images

before / after
<div style="display: flex; flex-direction: row">
<img width="300" alt="before-2" src="https://user-images.githubusercontent.com/11968340/38878764-ba984606-422f-11e8-8fe8-a4525e04cbac.png">
<img width="300" alt="after-2" src="https://user-images.githubusercontent.com/11968340/38878771-bcd640a8-422f-11e8-97fb-b61acd828389.png">
</div>

r? @keybase/react-hackers 