### PR TITLE
set etime instead of lifetime

### DIFF
--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -327,8 +327,9 @@ func TestBackgroundPurge(t *testing.T) {
 	u := world.GetUsers()[0]
 	uid := gregor1.UID(u.GetUID().ToBytes())
 	trip := newConvTriple(ctx, t, tc, u.Username)
+	clock := world.Fc
 	chatStorage := storage.New(g)
-	chatStorage.SetClock(world.Fc)
+	chatStorage.SetClock(clock)
 
 	// setup a ticker since we don't run the service's fastChatChecks ticker here.
 	tickerLifetime := 500 * time.Millisecond
@@ -352,7 +353,7 @@ func TestBackgroundPurge(t *testing.T) {
 		}
 	}
 
-	sendEphemeral := func(lifetime gregor1.DurationSec) *chat1.MessageBoxed {
+	sendEphemeral := func(lifetime time.Duration) *chat1.MessageBoxed {
 		_, msgBoxed, _, err := baseSender.Send(ctx, res.ConvID, chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:              trip,
@@ -360,7 +361,7 @@ func TestBackgroundPurge(t *testing.T) {
 				TlfName:           u.Username,
 				TlfPublic:         false,
 				MessageType:       chat1.MessageType_TEXT,
-				EphemeralMetadata: &chat1.MsgEphemeralMetadata{Lifetime: lifetime},
+				EphemeralMetadata: &chat1.MsgEphemeralMetadata{Etime: gregor1.ToTime(clock.Now().Add(lifetime))},
 			},
 			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
 				Body: "hi",
@@ -394,7 +395,7 @@ func TestBackgroundPurge(t *testing.T) {
 	assertTrackerState(res.ConvID, expectedPurgeInfo)
 
 	// Send two ephemeral messages, and ensure both get purged
-	lifetime := gregor1.DurationSec(1)
+	lifetime := time.Second
 	msgBoxed1 := sendEphemeral(lifetime * 2)
 	msgBoxed2 := sendEphemeral(lifetime * 3)
 

--- a/go/chat/storage/outbox_test.go
+++ b/go/chat/storage/outbox_test.go
@@ -148,7 +148,7 @@ func TestChatOutboxEphemeralPurge(t *testing.T) {
 	conv := makeConvo(gregor1.Time(5), 1, 1)
 
 	prevOrdinal := 1
-	ephemeralMetadata := &chat1.MsgEphemeralMetadata{Lifetime: 0}
+	ephemeralMetadata := &chat1.MsgEphemeralMetadata{Etime: gregor1.ToTime(ob.clock.Now())}
 	for i := 0; i < 5; i++ {
 		obr, err := ob.PushMessage(context.TODO(), conv.GetConvID(), makeMsgPlaintextEphemeral("hi", uid, ephemeralMetadata),
 			nil, keybase1.TLFIdentifyBehavior_CHAT_CLI)

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -1042,13 +1042,13 @@ func (o OutboxInfo) DeepCopy() OutboxInfo {
 }
 
 type MsgEphemeralMetadata struct {
-	Lifetime   gregor1.DurationSec   `codec:"life" json:"life"`
-	Generation keybase1.EkGeneration `codec:"gen" json:"gen"`
+	Etime      gregor1.Time          `codec:"e" json:"e"`
+	Generation keybase1.EkGeneration `codec:"g" json:"g"`
 }
 
 func (o MsgEphemeralMetadata) DeepCopy() MsgEphemeralMetadata {
 	return MsgEphemeralMetadata{
-		Lifetime:   o.Lifetime.DeepCopy(),
+		Etime:      o.Etime.DeepCopy(),
 		Generation: o.Generation.DeepCopy(),
 	}
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -358,14 +358,6 @@ func (o *MsgEphemeralMetadata) Eq(r *MsgEphemeralMetadata) bool {
 	return (o == nil) && (r == nil)
 }
 
-func ETime(metadata *MsgEphemeralMetadata, header *MessageServerHeader) gregor1.Time {
-	if metadata == nil || header == nil {
-		return 0
-	}
-	etime := header.Ctime.Time().Add(time.Second * time.Duration(metadata.Lifetime))
-	return gregor1.ToTime(etime)
-}
-
 func (m MessageUnboxedValid) IsExploding() bool {
 	return m.EphemeralMetadata() != nil
 }
@@ -379,8 +371,7 @@ func (m MessageUnboxedValid) Etime() gregor1.Time {
 	if metadata == nil {
 		return 0
 	}
-	etime := m.ServerHeader.Ctime.Time().Add(time.Second * time.Duration(metadata.Lifetime))
-	return gregor1.ToTime(etime)
+	return metadata.Etime
 }
 
 func (m MessageUnboxedValid) IsEphemeralExpired(now time.Time) bool {
@@ -481,7 +472,10 @@ func (m MessageBoxed) EphemeralMetadata() *MsgEphemeralMetadata {
 
 func (m MessageBoxed) Etime() gregor1.Time {
 	metadata := m.EphemeralMetadata()
-	return ETime(metadata, m.ServerHeader)
+	if metadata == nil {
+		return 0
+	}
+	return metadata.Etime
 }
 
 func (m MessageBoxed) IsExploding() bool {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -305,9 +305,9 @@
 
   @mpackkey("em") @jsonkey("em")
   record MsgEphemeralMetadata {
-    @mpackkey("life") @jsonkey("life")
-    gregor1.DurationSec lifetime; // used to computed etime
-    @mpackkey("gen") @jsonkey("gen")
+    @mpackkey("e") @jsonkey("e")
+    gregor1.Time etime;
+    @mpackkey("g") @jsonkey("g")
     keybase1.EkGeneration generation;
   }
 

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -1081,7 +1081,7 @@ export type MessageUnboxedState =
 
 export type MessageUnboxedValid = $ReadOnly<{clientHeader: MessageClientHeaderVerified, serverHeader: MessageServerHeader, messageBody: MessageBody, senderUsername: String, senderDeviceName: String, senderDeviceType: String, bodyHash: Hash, headerHash: Hash, headerSignature?: ?SignatureInfo, verificationKey?: ?Bytes, senderDeviceRevokedAt?: ?Gregor1.Time, atMentionUsernames?: ?Array<String>, atMentions?: ?Array<Gregor1.UID>, channelMention: ChannelMention, channelNameMentions?: ?Array<ChannelNameMention>}>
 
-export type MsgEphemeralMetadata = $ReadOnly<{lifetime: Gregor1.DurationSec, generation: Keybase1.EkGeneration}>
+export type MsgEphemeralMetadata = $ReadOnly<{etime: Gregor1.Time, generation: Keybase1.EkGeneration}>
 
 export type NameQuery = $ReadOnly<{name: String, membersType: ConversationMembersType}>
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -784,16 +784,16 @@
       "name": "MsgEphemeralMetadata",
       "fields": [
         {
-          "type": "gregor1.DurationSec",
-          "name": "lifetime",
-          "mpackkey": "life",
-          "jsonkey": "life"
+          "type": "gregor1.Time",
+          "name": "etime",
+          "mpackkey": "e",
+          "jsonkey": "e"
         },
         {
           "type": "keybase1.EkGeneration",
           "name": "generation",
-          "mpackkey": "gen",
-          "jsonkey": "gen"
+          "mpackkey": "g",
+          "jsonkey": "g"
         }
       ],
       "mpackkey": "em",

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -1081,7 +1081,7 @@ export type MessageUnboxedState =
 
 export type MessageUnboxedValid = $ReadOnly<{clientHeader: MessageClientHeaderVerified, serverHeader: MessageServerHeader, messageBody: MessageBody, senderUsername: String, senderDeviceName: String, senderDeviceType: String, bodyHash: Hash, headerHash: Hash, headerSignature?: ?SignatureInfo, verificationKey?: ?Bytes, senderDeviceRevokedAt?: ?Gregor1.Time, atMentionUsernames?: ?Array<String>, atMentions?: ?Array<Gregor1.UID>, channelMention: ChannelMention, channelNameMentions?: ?Array<ChannelNameMention>}>
 
-export type MsgEphemeralMetadata = $ReadOnly<{lifetime: Gregor1.DurationSec, generation: Keybase1.EkGeneration}>
+export type MsgEphemeralMetadata = $ReadOnly<{etime: Gregor1.Time, generation: Keybase1.EkGeneration}>
 
 export type NameQuery = $ReadOnly<{name: String, membersType: ConversationMembersType}>
 


### PR DESCRIPTION
~depends on https://github.com/keybase/client/pull/11438~

Clients will now compute `etime` themselves and send this to the server for use instead of `lifetime` for an ephemeral message. This allows us to validate that any superseding message have the same (and client signed) `etime` as the message they supersede. In a subsequent PR the `lifetime` parameter will  be completely removed