### PR TITLE
Dismiss dialog when leaving team via chat

### DIFF
--- a/shared/teams/really-leave-team/container-chat.js
+++ b/shared/teams/really-leave-team/container-chat.js
@@ -4,8 +4,6 @@ import * as TeamsGen from '../../actions/teams-gen'
 import {connect, type TypedState} from '../../util/container'
 import ReallyLeaveTeam, {Spinner, type Props as RenderProps} from '.'
 import LastOwnerDialog from './last-owner'
-import {navigateTo} from '../../actions/route-tree'
-import {chatTab} from '../../constants/tabs'
 import {getCanPerform, hasCanPerform} from '../../constants/teams'
 import {type Teamname} from '../../constants/types/teams'
 
@@ -31,7 +29,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
   onClose: () => dispatch(navigateUp()),
   onLeave: () => {
     dispatch(TeamsGen.createLeaveTeam({teamname: routeProps.get('teamname')}))
-    dispatch(navigateTo([chatTab]))
+    dispatch(navigateUp())
     dispatch(TeamsGen.createGetTeams())
   },
 })


### PR DESCRIPTION
This was mostly fixed by #11440, which dealt with deselecting the chat. The only other thing that was missing was dismissing the dialog. r? @keybase/react-hackers 