### PR TITLE
New RPC to get team access request

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -2126,7 +2126,8 @@ type TeamAcceptInviteOrRequestAccessArg struct {
 }
 
 type TeamListRequestsArg struct {
-	SessionID int `codec:"sessionID" json:"sessionID"`
+	SessionID int     `codec:"sessionID" json:"sessionID"`
+	TeamName  *string `codec:"teamName,omitempty" json:"teamName,omitempty"`
 }
 
 type TeamListMyAccessRequestsArg struct {
@@ -2263,7 +2264,7 @@ type TeamsInterface interface {
 	TeamAcceptInvite(context.Context, TeamAcceptInviteArg) error
 	TeamRequestAccess(context.Context, TeamRequestAccessArg) (TeamRequestAccessResult, error)
 	TeamAcceptInviteOrRequestAccess(context.Context, TeamAcceptInviteOrRequestAccessArg) (TeamAcceptOrRequestResult, error)
-	TeamListRequests(context.Context, int) ([]TeamJoinRequest, error)
+	TeamListRequests(context.Context, TeamListRequestsArg) ([]TeamJoinRequest, error)
 	TeamListMyAccessRequests(context.Context, TeamListMyAccessRequestsArg) ([]TeamName, error)
 	TeamIgnoreRequest(context.Context, TeamIgnoreRequestArg) error
 	TeamTree(context.Context, TeamTreeArg) (TeamTreeResult, error)
@@ -2578,7 +2579,7 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]TeamListRequestsArg)(nil), args)
 						return
 					}
-					ret, err = i.TeamListRequests(ctx, (*typedArgs)[0].SessionID)
+					ret, err = i.TeamListRequests(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -3028,8 +3029,7 @@ func (c TeamsClient) TeamAcceptInviteOrRequestAccess(ctx context.Context, __arg 
 	return
 }
 
-func (c TeamsClient) TeamListRequests(ctx context.Context, sessionID int) (res []TeamJoinRequest, err error) {
-	__arg := TeamListRequestsArg{SessionID: sessionID}
+func (c TeamsClient) TeamListRequests(ctx context.Context, __arg TeamListRequestsArg) (res []TeamJoinRequest, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamListRequests", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -312,13 +312,13 @@ func (h *TeamsHandler) TeamAcceptInviteOrRequestAccess(ctx context.Context, arg 
 	return teams.TeamAcceptInviteOrRequestAccess(ctx, h.G().ExternalG(), arg.TokenOrName)
 }
 
-func (h *TeamsHandler) TeamListRequests(ctx context.Context, sessionID int) (res []keybase1.TeamJoinRequest, err error) {
+func (h *TeamsHandler) TeamListRequests(ctx context.Context, arg keybase1.TeamListRequestsArg) (res []keybase1.TeamJoinRequest, err error) {
 	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, "TeamListRequests", func() error { return err })()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return nil, err
 	}
-	return teams.ListRequests(ctx, h.G().ExternalG())
+	return teams.ListRequests(ctx, h.G().ExternalG(), arg.TeamName)
 }
 
 func (h *TeamsHandler) TeamListMyAccessRequests(ctx context.Context, arg keybase1.TeamListMyAccessRequestsArg) (res []keybase1.TeamName, err error) {

--- a/go/teams/request_test.go
+++ b/go/teams/request_test.go
@@ -39,7 +39,7 @@ func TestAccessRequestAccept(t *testing.T) {
 	err = owner.Login(tc.G)
 	require.NoError(t, err)
 
-	reqs, err := ListRequests(context.Background(), tc.G)
+	reqs, err := ListRequests(context.Background(), tc.G, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(reqs))
 	require.Equal(t, teamName, reqs[0].Name)
@@ -94,7 +94,7 @@ func TestAccessRequestIgnore(t *testing.T) {
 	if err := owner.Login(tc.G); err != nil {
 		t.Fatal(err)
 	}
-	reqs, err := ListRequests(context.Background(), tc.G)
+	reqs, err := ListRequests(context.Background(), tc.G, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +142,7 @@ func TestAccessRequestIgnore(t *testing.T) {
 }
 
 func assertNoRequests(tc libkb.TestContext) {
-	reqs, err := ListRequests(context.Background(), tc.G)
+	reqs, err := ListRequests(context.Background(), tc.G, nil)
 	if err != nil {
 		tc.T.Fatal(err)
 	}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -979,8 +979,14 @@ func (r *accessRequestList) GetAppStatus() *libkb.AppStatus {
 	return &r.Status
 }
 
-func ListRequests(ctx context.Context, g *libkb.GlobalContext) ([]keybase1.TeamJoinRequest, error) {
-	arg := apiArg(ctx, "team/laar")
+func ListRequests(ctx context.Context, g *libkb.GlobalContext, teamName *string) ([]keybase1.TeamJoinRequest, error) {
+	var arg libkb.APIArg
+	if teamName != nil {
+		arg = apiArg(ctx, "team/access_requests")
+		arg.Args.Add("team", libkb.S{Val: *teamName})
+	} else {
+		arg = apiArg(ctx, "team/laar")
+	}
 
 	var arList accessRequestList
 	if err := g.API.GetDecode(arg, &arList); err != nil {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -701,7 +701,7 @@ protocol teams {
   // Accept an invite or request to join a team, try both.
   TeamAcceptOrRequestResult teamAcceptInviteOrRequestAccess(int sessionID, string tokenOrName);
 
-  array<TeamJoinRequest> teamListRequests(int sessionID);
+  array<TeamJoinRequest> teamListRequests(int sessionID, union { null, string } teamName);
 
   // List TeamAccessRequests from current user. Optionally can provide
   // a teamname, and API server will only return request for that team,

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3859,7 +3859,7 @@ export type TeamsTeamLeaveRpcParam = $ReadOnly<{name: String, permanent: Boolean
 
 export type TeamsTeamListMyAccessRequestsRpcParam = $ReadOnly<{teamName?: ?String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type TeamsTeamListRequestsRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type TeamsTeamListRequestsRpcParam = $ReadOnly<{teamName?: ?String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type TeamsTeamListSubteamsRecursiveRpcParam = $ReadOnly<{parentTeamName: String, forceRepoll: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2146,6 +2146,13 @@
         {
           "name": "sessionID",
           "type": "int"
+        },
+        {
+          "name": "teamName",
+          "type": [
+            null,
+            "string"
+          ]
         }
       ],
       "response": {

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -393,7 +393,7 @@ const _getDetails = function*(action: TeamsGen.GetDetailsPayload): Saga.SagaGene
     }
 
     // Get requests to join
-    const requests: RPCTypes.TeamJoinRequest[] = yield Saga.call(RPCTypes.teamsTeamListRequestsRpcPromise)
+    const requests: RPCTypes.TeamJoinRequest[] = yield Saga.call(RPCTypes.teamsTeamListRequestsRpcPromise, {})
     requests.sort((a, b) => a.username.localeCompare(b.username))
 
     const requestMap = requests.reduce((reqMap, req) => {

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -393,7 +393,9 @@ const _getDetails = function*(action: TeamsGen.GetDetailsPayload): Saga.SagaGene
     }
 
     // Get requests to join
-    const requests: RPCTypes.TeamJoinRequest[] = yield Saga.call(RPCTypes.teamsTeamListRequestsRpcPromise, {})
+    const requests: RPCTypes.TeamJoinRequest[] = yield Saga.call(RPCTypes.teamsTeamListRequestsRpcPromise, {
+      teamName: teamname,
+    })
     requests.sort((a, b) => a.username.localeCompare(b.username))
 
     const requestMap = requests.reduce((reqMap, req) => {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3859,7 +3859,7 @@ export type TeamsTeamLeaveRpcParam = $ReadOnly<{name: String, permanent: Boolean
 
 export type TeamsTeamListMyAccessRequestsRpcParam = $ReadOnly<{teamName?: ?String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type TeamsTeamListRequestsRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type TeamsTeamListRequestsRpcParam = $ReadOnly<{teamName?: ?String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type TeamsTeamListSubteamsRecursiveRpcParam = $ReadOnly<{parentTeamName: String, forceRepoll: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 


### PR DESCRIPTION
- Added `teamName`  argument to `TeamListRequests` RPC which will call new API endpoint to get access requests for a team that is: faster than the previous endpoint, and also works for subteam impadmins.
- Added new argument to cli to benefit from new API as well.
- (minor change :lipstick:) Changed CLI to write additional info to stderr and only use stdout for actual list of requests.
- Make use of new argument in GUI. It probably needs further cleaning up, though.