### PR TITLE
Enable wallet command

### DIFF
--- a/go/client/cmd_wallet.go
+++ b/go/client/cmd_wallet.go
@@ -9,6 +9,7 @@ import (
 func newCmdWallet(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	subcommands := []cli.Command{
 		newCmdWalletBalances(cl, g),
+		newCmdWalletDump(cl, g),
 		newCmdWalletHistory(cl, g),
 		newCmdWalletImport(cl, g),
 		newCmdWalletSend(cl, g),

--- a/go/client/cmd_wallet.go
+++ b/go/client/cmd_wallet.go
@@ -9,7 +9,6 @@ import (
 func newCmdWallet(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	subcommands := []cli.Command{
 		newCmdWalletBalances(cl, g),
-		newCmdWalletDump(cl, g),
 		newCmdWalletHistory(cl, g),
 		newCmdWalletImport(cl, g),
 		newCmdWalletSend(cl, g),

--- a/go/client/cmd_wallet_balances.go
+++ b/go/client/cmd_wallet_balances.go
@@ -23,6 +23,7 @@ func newCmdWalletBalances(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cl
 	}
 	return cli.Command{
 		Name:        "balances",
+		Usage:       "Show account balances",
 		Description: "Show account balances",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(cmd, "balances", c)

--- a/go/client/cmd_wallet_dump.go
+++ b/go/client/cmd_wallet_dump.go
@@ -20,7 +20,8 @@ func newCmdWalletDump(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 		Contextified: libkb.NewContextified(g),
 	}
 	return cli.Command{
-		Name: "dump",
+		Name:  "dump",
+		Usage: "Display wallet account keys",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(cmd, "dump", c)
 		},

--- a/go/client/cmd_wallet_import.go
+++ b/go/client/cmd_wallet_import.go
@@ -26,7 +26,7 @@ func newCmdWalletImport(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 	return cli.Command{
 		Name:         "import",
 		Description:  "Import a stellar account",
-		Usage:        "Import keys of a Stellar account",
+		Usage:        "Import stellar account keys",
 		ArgumentHelp: "[--primary]",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(cmd, "import", c)

--- a/go/client/cmd_wallet_send.go
+++ b/go/client/cmd_wallet_send.go
@@ -33,6 +33,7 @@ func newCmdWalletSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 	}
 	return cli.Command{
 		Name:         "send",
+		Usage:        "Send XLM to a keybase user or stellar address",
 		ArgumentHelp: "<recipient> <amount> <local currency> [-m message]",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(cmd, "send", c)

--- a/go/client/cmd_wallet_set_currency.go
+++ b/go/client/cmd_wallet_set_currency.go
@@ -23,7 +23,7 @@ func newCmdWalletSetCurrency(cl *libcmdline.CommandLine, g *libkb.GlobalContext)
 	}
 	return cli.Command{
 		Name:  "set-currency",
-		Usage: "Sets default display currency of Stellar account.",
+		Usage: "Set stellar account display currency",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(cmd, "set-currency", c)
 		},

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -64,6 +64,7 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdUPAK(cl, g),
 		NewCmdVerify(cl, g),
 		NewCmdVersion(cl, g),
+		newCmdWallet(cl, g),
 	}
 	ret = append(ret, getBuildSpecificCommands(cl, g)...)
 	ret = append(ret, getPlatformSpecificCommands(cl, g)...)

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -50,6 +50,7 @@ func getBuildSpecificAccountCommands(cl *libcmdline.CommandLine, g *libkb.Global
 
 func getBuildSpecificWalletCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
 	return []cli.Command{
+		newCmdWalletDump(cl, g),
 		newCmdWalletInit(cl, g),
 	}
 }

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -31,7 +31,6 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 		newCmdTeamGenerateSeitan(cl, g),
 		newCmdTeamRotateKey(cl, g),
 		newCmdTeamDebug(cl, g),
-		newCmdWallet(cl, g),
 	}
 }
 
@@ -52,7 +51,6 @@ func getBuildSpecificAccountCommands(cl *libcmdline.CommandLine, g *libkb.Global
 func getBuildSpecificWalletCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
 	return []cli.Command{
 		newCmdWalletInit(cl, g),
-		newCmdWalletDump(cl, g),
 	}
 }
 


### PR DESCRIPTION
1. Move wallet command from devel to common
2. Add Usage for subcommands that didn't have any
3. Standardize usage across wallet subcommands


