### PR TITLE
Be a little smarter about refreshing teams

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -849,7 +849,7 @@ function _setupTeamHandlers() {
       const state = getState()
       logger.info(`Got teamChanged for ${args.teamName} from service`)
       const selectedTeamName = Constants.getSelectedTeamName(state)
-      if (!!selectedTeamName && selectedTeamName === args.teamName) {
+      if (selectedTeamName && selectedTeamName === args.teamName) {
         // only reload if that team is selected
         return getLoadCalls(selectedTeamName)
       }
@@ -862,7 +862,7 @@ function _setupTeamHandlers() {
       const state = getState()
       const {teamID} = args
       const selectedTeamName = Constants.getSelectedTeamName(state)
-      if (teamID === state.teams.teamNameToID.get(selectedTeamName)) {
+      if (selectedTeamName && teamID === Constants.getTeamID(state, selectedTeamName)) {
         return [navigateTo([], [teamsTab]), ...getLoadCalls()]
       }
     }
@@ -873,7 +873,7 @@ function _setupTeamHandlers() {
       const state = getState()
       const {teamID} = args
       const selectedTeamName = Constants.getSelectedTeamName(state)
-      if (teamID === state.teams.teamNameToID.get(selectedTeamName)) {
+      if (selectedTeamName && teamID === Constants.getTeamID(state, selectedTeamName)) {
         return [navigateTo([], [teamsTab]), ...getLoadCalls()]
       }
     }

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -865,6 +865,7 @@ function _setupTeamHandlers() {
       if (selectedTeamName && teamID === Constants.getTeamID(state, selectedTeamName)) {
         return [navigateTo([], [teamsTab]), ...getLoadCalls()]
       }
+      return getLoadCalls()
     }
   )
   engine().setIncomingActionCreators(
@@ -876,6 +877,7 @@ function _setupTeamHandlers() {
       if (selectedTeamName && teamID === Constants.getTeamID(state, selectedTeamName)) {
         return [navigateTo([], [teamsTab]), ...getLoadCalls()]
       }
+      return getLoadCalls()
     }
   )
 }

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -848,10 +848,10 @@ function _setupTeamHandlers() {
     (args: RPCTypes.NotifyTeamTeamChangedByNameRpcParam, _, __, getState) => {
       const state = getState()
       logger.info(`Got teamChanged for ${args.teamName} from service`)
-      const selectedTeamName = Constants.getSelectedTeamName(state)
-      if (selectedTeamName && selectedTeamName === args.teamName) {
+      const selectedTeamNames = Constants.getSelectedTeamNames(state)
+      if (selectedTeamNames.includes(args.teamName)) {
         // only reload if that team is selected
-        return getLoadCalls(selectedTeamName)
+        return getLoadCalls(args.teamName)
       }
       return getLoadCalls()
     }
@@ -861,8 +861,8 @@ function _setupTeamHandlers() {
     (args: RPCTypes.NotifyTeamTeamDeletedRpcParam, _, __, getState) => {
       const state = getState()
       const {teamID} = args
-      const selectedTeamName = Constants.getSelectedTeamName(state)
-      if (selectedTeamName && teamID === Constants.getTeamID(state, selectedTeamName)) {
+      const selectedTeamNames = Constants.getSelectedTeamNames(state)
+      if (selectedTeamNames.includes(Constants.getTeamNameFromID(state, teamID))) {
         return [navigateTo([], [teamsTab]), ...getLoadCalls()]
       }
       return getLoadCalls()
@@ -873,8 +873,8 @@ function _setupTeamHandlers() {
     (args: RPCTypes.NotifyTeamTeamExitRpcParam, _, __, getState) => {
       const state = getState()
       const {teamID} = args
-      const selectedTeamName = Constants.getSelectedTeamName(state)
-      if (selectedTeamName && teamID === Constants.getTeamID(state, selectedTeamName)) {
+      const selectedTeamNames = Constants.getSelectedTeamNames(state)
+      if (selectedTeamNames.includes(Constants.getTeamNameFromID(state, teamID))) {
         return [navigateTo([], [teamsTab]), ...getLoadCalls()]
       }
       return getLoadCalls()

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -205,13 +205,21 @@ const getTeamMemberCount = (state: TypedState, teamname: Types.Teamname): number
 const getTeamID = (state: TypedState, teamname: Types.Teamname): string =>
   state.teams.getIn(['teamNameToID', teamname], '')
 
+const getTeamNameFromID = (state: TypedState, teamID: string): ?Types.Teamname =>
+  state.teams.teamNameToID.findKey(value => value === teamID)
+
 const getTeamRetentionPolicy = (state: TypedState, teamname: Types.Teamname): ?Types.RetentionPolicy =>
   state.teams.getIn(['teamNameToRetentionPolicy', teamname], null)
 
-const getSelectedTeamName = (state: TypedState): ?Types.Teamname => {
+const getSelectedTeamNames = (state: TypedState): Types.Teamname[] => {
   const pathProps = getPathProps(state.routeTree.routeState, [teamsTab])
-  const lastNode = pathProps.last()
-  return (lastNode && lastNode.props.get('teamname')) || null
+  return pathProps.reduce((res, val) => {
+    const teamname = val.props.get('teamname')
+    if (val.node === 'team' && teamname) {
+      return res.concat(teamname)
+    }
+    return res
+  }, [])
 }
 
 /**
@@ -384,12 +392,13 @@ export {
   getTeamID,
   getTeamRetentionPolicy,
   getTeamMembers,
+  getTeamNameFromID,
   getTeamPublicitySettings,
   getTeamInvites,
   isInTeam,
   isInSomeTeam,
   isAccessRequestPending,
-  getSelectedTeamName,
+  getSelectedTeamNames,
   getTeamSubteams,
   getTeamSettings,
   getTeamResetUsers,

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -4,6 +4,8 @@ import * as ChatTypes from './types/chat2'
 import * as Types from './types/teams'
 import * as RPCTypes from './types/rpc-gen'
 import * as RPCChatTypes from './types/rpc-chat-gen'
+import {getPathProps} from '../route-tree'
+import {teamsTab} from './tabs'
 
 import type {Service} from './types/search'
 import {type TypedState} from './reducer'
@@ -206,6 +208,12 @@ const getTeamID = (state: TypedState, teamname: Types.Teamname): string =>
 const getTeamRetentionPolicy = (state: TypedState, teamname: Types.Teamname): ?Types.RetentionPolicy =>
   state.teams.getIn(['teamNameToRetentionPolicy', teamname], null)
 
+const getSelectedTeamName = (state: TypedState): ?Types.Teamname => {
+  const pathProps = getPathProps(state.routeTree.routeState, [teamsTab])
+  const lastNode = pathProps.last()
+  return (lastNode && lastNode.props.get('teamname')) || null
+}
+
 /**
  * Gets whether the team is big or small for teams you are a member of
  */
@@ -381,6 +389,7 @@ export {
   isInTeam,
   isInSomeTeam,
   isAccessRequestPending,
+  getSelectedTeamName,
   getTeamSubteams,
   getTeamSettings,
   getTeamResetUsers,

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -405,7 +405,7 @@ class Engine {
     this._incomingActionCreators[method] = actionCreator
   }
 
-  // DEPRECATED - use setIncomingActionCreator instead
+  // DEPRECATED - use setIncomingActionCreators instead
   setIncomingHandler(method: MethodKey, handler: (param: Object, response: ?Object) => void) {
     if (this._incomingHandler[method]) {
       rpcLog('engineInternal', "duplicate incoming handler!!! this isn't allowed", {method})


### PR DESCRIPTION
Adds predicates on whether you're actually on the _team page_ before we assault the service with load calls we might not be allowed to make. Gets rid of the black bars on leaving a team via the teams tab. If you're currently on a team page and someone else deletes it / removes you you'll be navigated up to the teams tab root. r? @keybase/react-hackers