### PR TITLE
Badge gear icon in inbox for teamnames you haven't selected channels for

### DIFF
--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -118,12 +118,9 @@ function* handleTLFUpdate(items: Array<Types.NonNullGregorItem>): Saga.SagaGener
 }
 
 function* handleBannersAndBadges(items: Array<Types.NonNullGregorItem>): Saga.SagaGenerator<any, any> {
-  console.warn('in handleBannersAndBadges', items)
   const sawChatBanner = items.find(i => i.item && i.item.category === 'sawChatBanner')
   const sawSubteamsBanner = items.find(i => i.item && i.item.category === 'sawSubteamsBanner')
   const chosenChannels = items.find(i => i.item && i.item.category === 'chosenChannelsForTeam')
-  // Right now we're getting the oldest one..
-  console.warn('chosenChannels is', chosenChannels)
   const chosenChannelsForTeam =
     (chosenChannels &&
       chosenChannels.item &&
@@ -136,14 +133,12 @@ function* handleBannersAndBadges(items: Array<Types.NonNullGregorItem>): Saga.Sa
   if (sawSubteamsBanner) {
     yield Saga.put(TeamsGen.createSetTeamSawSubteamsBanner())
   }
-  console.warn('set is', chosenChannelsForTeam)
   yield Saga.put(TeamsGen.createSetChosenChannelsForTeam({chosenChannelsForTeam}))
 }
 
 function _handlePushState(pushAction: GregorGen.PushStatePayload) {
   if (!pushAction.error) {
     const {payload: {state}} = pushAction
-    console.warn('in handlePushState', state)
     const nonNullItems = toNonNullGregorItems(state)
     if (nonNullItems.length !== (state.items || []).length) {
       logger.warn('Lost some messages in filtering out nonNull gregor items')

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -8,7 +8,6 @@ import * as GregorGen from './gregor-gen'
 import * as TeamsGen from './teams-gen'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import * as Saga from '../util/saga'
-import * as I from 'immutable'
 import engine from '../engine'
 import {folderFromPath} from '../constants/favorite.js'
 import {nativeReachabilityEvents} from '../util/reachability'
@@ -125,7 +124,12 @@ function* handleBannersAndBadges(items: Array<Types.NonNullGregorItem>): Saga.Sa
   const chosenChannels = items.find(i => i.item && i.item.category === 'chosenChannelsForTeam')
   // Right now we're getting the oldest one..
   console.warn('chosenChannels is', chosenChannels)
-  const chosenChannelsForTeam = (chosenChannels && chosenChannels.item && chosenChannels.item.body && chosenChannels.item.body.toString())|| JSON.stringify([])
+  const chosenChannelsForTeam =
+    (chosenChannels &&
+      chosenChannels.item &&
+      chosenChannels.item.body &&
+      chosenChannels.item.body.toString()) ||
+    JSON.stringify([])
   if (sawChatBanner) {
     yield Saga.put(TeamsGen.createSetTeamSawChatBanner())
   }

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -90,6 +90,9 @@
       "teamname": "string",
       "username": "string"
     },
+    "setLoadingChosenChannels": {
+      "loading": "boolean"
+    },
     "setMemberPublicity": {
       "teamname": "string",
       "showcase": "boolean"

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -36,6 +36,9 @@
     "getTeamPublicity": {
       "teamname": "string"
     },
+    "haveChosenChannelsForTeam": {
+      "teamname": "string"
+    },
     "saveChannelMembership": {
       "teamname": "string",
       "channelState": "Types.ChannelMembershipState"
@@ -97,6 +100,9 @@
     },
     "setChannelCreationError": {
       "error": "string"
+    },
+    "setChosenChannelsForTeam": {
+      "chosenChannelsForTeam": "string"
     },
     "setTeamCreationError": {
       "error": "string"

--- a/shared/actions/teams-gen.js
+++ b/shared/actions/teams-gen.js
@@ -39,6 +39,7 @@ export const saveTeamRetentionPolicy = 'teams:saveTeamRetentionPolicy'
 export const setChannelCreationError = 'teams:setChannelCreationError'
 export const setChosenChannelsForTeam = 'teams:setChosenChannelsForTeam'
 export const setLoaded = 'teams:setLoaded'
+export const setLoadingChosenChannels = 'teams:setLoadingChosenChannels'
 export const setMemberPublicity = 'teams:setMemberPublicity'
 export const setNewTeamInfo = 'teams:setNewTeamInfo'
 export const setPublicity = 'teams:setPublicity'
@@ -183,6 +184,7 @@ export const createSaveChannelMembership = (
 export const createSetChannelCreationError = (payload: $ReadOnly<{|error: string|}>) => ({error: false, payload, type: setChannelCreationError})
 export const createSetChosenChannelsForTeam = (payload: $ReadOnly<{|chosenChannelsForTeam: string|}>) => ({error: false, payload, type: setChosenChannelsForTeam})
 export const createSetLoaded = (payload: $ReadOnly<{|loaded: boolean|}>) => ({error: false, payload, type: setLoaded})
+export const createSetLoadingChosenChannels = (payload: $ReadOnly<{|loading: boolean|}>) => ({error: false, payload, type: setLoadingChosenChannels})
 export const createSetMemberPublicity = (
   payload: $ReadOnly<{|
     teamname: string,
@@ -311,6 +313,7 @@ export type SaveTeamRetentionPolicyPayload = More.ReturnType<typeof createSaveTe
 export type SetChannelCreationErrorPayload = More.ReturnType<typeof createSetChannelCreationError>
 export type SetChosenChannelsForTeamPayload = More.ReturnType<typeof createSetChosenChannelsForTeam>
 export type SetLoadedPayload = More.ReturnType<typeof createSetLoaded>
+export type SetLoadingChosenChannelsPayload = More.ReturnType<typeof createSetLoadingChosenChannels>
 export type SetMemberPublicityPayload = More.ReturnType<typeof createSetMemberPublicity>
 export type SetNewTeamInfoPayload = More.ReturnType<typeof createSetNewTeamInfo>
 export type SetPublicityPayload = More.ReturnType<typeof createSetPublicity>
@@ -364,6 +367,7 @@ export type Actions =
   | More.ReturnType<typeof createSetChannelCreationError>
   | More.ReturnType<typeof createSetChosenChannelsForTeam>
   | More.ReturnType<typeof createSetLoaded>
+  | More.ReturnType<typeof createSetLoadingChosenChannels>
   | More.ReturnType<typeof createSetMemberPublicity>
   | More.ReturnType<typeof createSetNewTeamInfo>
   | More.ReturnType<typeof createSetPublicity>

--- a/shared/actions/teams-gen.js
+++ b/shared/actions/teams-gen.js
@@ -27,6 +27,7 @@ export const getTeamOperations = 'teams:getTeamOperations'
 export const getTeamPublicity = 'teams:getTeamPublicity'
 export const getTeamRetentionPolicy = 'teams:getTeamRetentionPolicy'
 export const getTeams = 'teams:getTeams'
+export const haveChosenChannelsForTeam = 'teams:haveChosenChannelsForTeam'
 export const ignoreRequest = 'teams:ignoreRequest'
 export const inviteToTeamByEmail = 'teams:inviteToTeamByEmail'
 export const inviteToTeamByPhone = 'teams:inviteToTeamByPhone'
@@ -36,6 +37,7 @@ export const removeMemberOrPendingInvite = 'teams:removeMemberOrPendingInvite'
 export const saveChannelMembership = 'teams:saveChannelMembership'
 export const saveTeamRetentionPolicy = 'teams:saveTeamRetentionPolicy'
 export const setChannelCreationError = 'teams:setChannelCreationError'
+export const setChosenChannelsForTeam = 'teams:setChosenChannelsForTeam'
 export const setLoaded = 'teams:setLoaded'
 export const setMemberPublicity = 'teams:setMemberPublicity'
 export const setNewTeamInfo = 'teams:setNewTeamInfo'
@@ -140,6 +142,7 @@ export const createGetDetails = (payload: $ReadOnly<{|teamname: string|}>) => ({
 export const createGetTeamOperations = (payload: $ReadOnly<{|teamname: string|}>) => ({error: false, payload, type: getTeamOperations})
 export const createGetTeamPublicity = (payload: $ReadOnly<{|teamname: string|}>) => ({error: false, payload, type: getTeamPublicity})
 export const createGetTeams = () => ({error: false, payload: undefined, type: getTeams})
+export const createHaveChosenChannelsForTeam = (payload: $ReadOnly<{|teamname: string|}>) => ({error: false, payload, type: haveChosenChannelsForTeam})
 export const createIgnoreRequest = (
   payload: $ReadOnly<{|
     teamname: string,
@@ -178,6 +181,7 @@ export const createSaveChannelMembership = (
   |}>
 ) => ({error: false, payload, type: saveChannelMembership})
 export const createSetChannelCreationError = (payload: $ReadOnly<{|error: string|}>) => ({error: false, payload, type: setChannelCreationError})
+export const createSetChosenChannelsForTeam = (payload: $ReadOnly<{|chosenChannelsForTeam: string|}>) => ({error: false, payload, type: setChosenChannelsForTeam})
 export const createSetLoaded = (payload: $ReadOnly<{|loaded: boolean|}>) => ({error: false, payload, type: setLoaded})
 export const createSetMemberPublicity = (
   payload: $ReadOnly<{|
@@ -295,6 +299,7 @@ export type GetTeamOperationsPayload = More.ReturnType<typeof createGetTeamOpera
 export type GetTeamPublicityPayload = More.ReturnType<typeof createGetTeamPublicity>
 export type GetTeamRetentionPolicyPayload = More.ReturnType<typeof createGetTeamRetentionPolicy>
 export type GetTeamsPayload = More.ReturnType<typeof createGetTeams>
+export type HaveChosenChannelsForTeamPayload = More.ReturnType<typeof createHaveChosenChannelsForTeam>
 export type IgnoreRequestPayload = More.ReturnType<typeof createIgnoreRequest>
 export type InviteToTeamByEmailPayload = More.ReturnType<typeof createInviteToTeamByEmail>
 export type InviteToTeamByPhonePayload = More.ReturnType<typeof createInviteToTeamByPhone>
@@ -304,6 +309,7 @@ export type RemoveMemberOrPendingInvitePayload = More.ReturnType<typeof createRe
 export type SaveChannelMembershipPayload = More.ReturnType<typeof createSaveChannelMembership>
 export type SaveTeamRetentionPolicyPayload = More.ReturnType<typeof createSaveTeamRetentionPolicy>
 export type SetChannelCreationErrorPayload = More.ReturnType<typeof createSetChannelCreationError>
+export type SetChosenChannelsForTeamPayload = More.ReturnType<typeof createSetChosenChannelsForTeam>
 export type SetLoadedPayload = More.ReturnType<typeof createSetLoaded>
 export type SetMemberPublicityPayload = More.ReturnType<typeof createSetMemberPublicity>
 export type SetNewTeamInfoPayload = More.ReturnType<typeof createSetNewTeamInfo>
@@ -346,6 +352,7 @@ export type Actions =
   | More.ReturnType<typeof createGetTeamPublicity>
   | More.ReturnType<typeof createGetTeamRetentionPolicy>
   | More.ReturnType<typeof createGetTeams>
+  | More.ReturnType<typeof createHaveChosenChannelsForTeam>
   | More.ReturnType<typeof createIgnoreRequest>
   | More.ReturnType<typeof createInviteToTeamByEmail>
   | More.ReturnType<typeof createInviteToTeamByPhone>
@@ -355,6 +362,7 @@ export type Actions =
   | More.ReturnType<typeof createSaveChannelMembership>
   | More.ReturnType<typeof createSaveTeamRetentionPolicy>
   | More.ReturnType<typeof createSetChannelCreationError>
+  | More.ReturnType<typeof createSetChosenChannelsForTeam>
   | More.ReturnType<typeof createSetLoaded>
   | More.ReturnType<typeof createSetMemberPublicity>
   | More.ReturnType<typeof createSetNewTeamInfo>

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -922,12 +922,16 @@ function _updateTopic(action: TeamsGen.UpdateTopicPayload, state: TypedState) {
 function _haveChosenChannelsForTeam(action: TeamsGen.HaveChosenChannelsForTeamPayload, state: TypedState) {
   const teamname = action.payload
   const teamList = state.teams.chosenChannelsForTeam.add(teamname)
-  console.warn('teamList', teamList.toJS(), teamList.toJSON())
+  // We'd actually like to do this in one message to avoid having the UI glitch
+  // momentarily inbetween the dismiss (and therefore thinking no teams have
+  // had channels selected) and the re-inject.  This is CORE-7663.
   return Saga.sequentially([
     Saga.call(RPCTypes.gregorDismissCategoryRpcPromise, {
       category: 'chosenChannelsForTeam',
     }),
-    Saga.put(GregorGen.createInjectItem({body: JSON.stringify(teamList.toJSON()), category: 'chosenChannelsForTeam'}))
+    Saga.put(
+      GregorGen.createInjectItem({body: JSON.stringify(teamList.toJSON()), category: 'chosenChannelsForTeam'})
+    ),
   ])
 }
 

--- a/shared/chat/conversation/info-panel/menu/container.js
+++ b/shared/chat/conversation/info-panel/menu/container.js
@@ -1,6 +1,6 @@
 // @flow
 import * as Constants from '../../../../constants/teams'
-import {createGetTeamOperations} from '../../../../actions/teams-gen'
+import {createGetTeamOperations, createHaveChosenChannelsForTeam} from '../../../../actions/teams-gen'
 import {compose, connect, isMobile, lifecycle, type TypedState} from '../../../../util/container'
 import {InfoPanelMenu} from '.'
 import {navigateAppend, navigateTo, switchTo} from '../../../../actions/route-tree'
@@ -12,12 +12,14 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
   const yourOperations = Constants.getCanPerform(state, teamname)
   // We can get here without loading canPerform
   const _hasCanPerform = Constants.hasCanPerform(state, teamname)
+  const badgeSubscribe = Constants.getBadgeSubscribe(state, teamname)
   return {
     _hasCanPerform,
+    badgeSubscribe,
     canAddPeople: yourOperations.manageMembers,
     isSmallTeam,
-    teamname,
     memberCount: Constants.getTeamMemberCount(state, teamname),
+    teamname,
   }
 }
 
@@ -55,6 +57,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {routeProps, navigateUp}) => {
     onManageChannels: () => {
       !isMobile && dispatch(navigateUp())
       dispatch(navigateAppend([{selected: 'manageChannels', props: {teamname}}]))
+      dispatch(createHaveChosenChannelsForTeam(teamname))
     },
     onViewTeam: () => {
       !isMobile && dispatch(navigateUp())

--- a/shared/chat/conversation/info-panel/menu/index.js
+++ b/shared/chat/conversation/info-panel/menu/index.js
@@ -2,9 +2,10 @@
 import * as React from 'react'
 import PopupMenu, {ModalLessPopupMenu} from '../../../../common-adapters/popup-menu'
 import {Avatar, Box, Text} from '../../../../common-adapters'
-import {globalStyles, isMobile} from '../../../../styles'
+import {globalColors, globalStyles, isMobile} from '../../../../styles'
 
 type Props = {
+  badgeSubscribe: boolean,
   canAddPeople: boolean,
   isSmallTeam: boolean,
   memberCount: number,
@@ -38,11 +39,23 @@ const InfoPanelMenu = (props: Props) => {
       onClick: props.onInvite,
     },
   ]
-  const channelItem = {
-    title: props.isSmallTeam ? 'Make chat channels...' : 'Manage chat channels',
-    onClick: props.onManageChannels,
-    subTitle: props.isSmallTeam ? 'Turns this into a big team' : undefined,
-  }
+  const channelItem = props.isSmallTeam
+    ? {
+        onClick: props.onManageChannels,
+        subTitle: 'Turns this into a big team',
+        title: 'Make chat channels...',
+      }
+    : {
+        onClick: props.onManageChannels,
+        title: 'Subscribe to channels...',
+        view: (
+          <Box style={globalStyles.flexBoxRow}>
+            {props.badgeSubscribe && <Box style={styleBadge} />}
+            <Text style={isMobile ? styleText : {}} type={isMobile ? 'BodyBig' : 'Body'}>Subscribe to channels..</Text>
+          </Box>
+        ),
+      }
+
   const items = [
     ...(props.canAddPeople ? addPeopleItems : []),
     {title: 'View team', onClick: props.onViewTeam, style: {borderTopWidth: 0}},
@@ -65,6 +78,18 @@ const InfoPanelMenu = (props: Props) => {
       items={items}
     />
   )
+}
+
+const styleBadge = {
+  backgroundColor: globalColors.orange,
+  borderRadius: 6,
+  height: 8,
+  margin: isMobile ? 6 : 4,
+  width: 8,
+}
+
+const styleText = {
+  color: globalColors.blue,
 }
 
 export {InfoPanelMenu}

--- a/shared/chat/conversation/info-panel/menu/index.js
+++ b/shared/chat/conversation/info-panel/menu/index.js
@@ -51,7 +51,9 @@ const InfoPanelMenu = (props: Props) => {
         view: (
           <Box style={globalStyles.flexBoxRow}>
             {props.badgeSubscribe && <Box style={styleBadge} />}
-            <Text style={isMobile ? styleText : {}} type={isMobile ? 'BodyBig' : 'Body'}>Subscribe to channels..</Text>
+            <Text style={isMobile ? styleText : {}} type={isMobile ? 'BodyBig' : 'Body'}>
+              Subscribe to channels...
+            </Text>
           </Box>
         ),
       }

--- a/shared/chat/inbox/row/big-team-header/container.js
+++ b/shared/chat/inbox/row/big-team-header/container.js
@@ -1,6 +1,6 @@
 // @flow
 import {connect, type TypedState} from '../../../../util/container'
-import {getTeamMemberCount} from '../../../../constants/teams'
+import {getBadgeSubscribe, getTeamMemberCount} from '../../../../constants/teams'
 import {BigTeamHeader} from '.'
 // Typically you'd use the navigateAppend from the routeable component but this is a child* of that
 // and I'd prefer not to plumb through anything that could cause render thrashing so using the
@@ -8,6 +8,7 @@ import {BigTeamHeader} from '.'
 import {navigateAppend} from '../../../../actions/route-tree'
 
 const mapStateToProps = (state: TypedState, {teamname}) => ({
+  badgeSubscribe: getBadgeSubscribe(state, teamname),
   memberCount: getTeamMemberCount(state, teamname),
   teamname,
 })
@@ -31,6 +32,7 @@ const mapDispatchToProps = (dispatch, {teamname}) => ({
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   ...dispatchProps,
+  badgeSubscribe: stateProps.badgeSubscribe,
   memberCount: stateProps.memberCount,
   teamname: stateProps.teamname,
 })

--- a/shared/chat/inbox/row/big-team-header/index.js
+++ b/shared/chat/inbox/row/big-team-header/index.js
@@ -2,15 +2,15 @@
 import React from 'react'
 import {Avatar, Box, Text, Icon} from '../../../../common-adapters'
 import {
+  desktopStyles,
   globalStyles,
   globalColors,
   globalMargins,
-  glamorous,
   isMobile,
-  desktopStyles,
 } from '../../../../styles'
 
 type Props = {
+  badgeSubscribe: boolean,
   onClickGear: (evt?: SyntheticEvent<Element>) => void,
   memberCount: number,
   teamname: string,
@@ -21,7 +21,7 @@ class BigTeamHeader extends React.PureComponent<Props> {
     const props = this.props
 
     return (
-      <HeaderBox>
+      <Box style={teamRowContainerStyle}>
         <Avatar teamname={props.teamname} size={isMobile ? 24 : 16} />
         <Text type="BodySmallSemibold" style={teamStyle}>
           {props.teamname}
@@ -32,22 +32,10 @@ class BigTeamHeader extends React.PureComponent<Props> {
           onClick={isMobile ? () => props.onClickGear() : props.onClickGear}
           style={iconStyle}
         />
-      </HeaderBox>
+        {props.badgeSubscribe && <Box style={badgeStyle} />}
+      </Box>
     )
   }
-}
-
-const iconStyle = {
-  color: globalColors.black_20,
-  fontSize: isMobile ? 20 : 16,
-  padding: 4,
-  ...(isMobile
-    ? {
-        backgroundColor: globalColors.fastBlank,
-      }
-    : {
-        hoverColor: globalColors.black_75,
-      }),
 }
 
 const teamRowContainerStyle = {
@@ -61,19 +49,10 @@ const teamRowContainerStyle = {
   paddingRight: isMobile ? 0 : globalMargins.xtiny,
 }
 
-const HeaderBox = glamorous(Box)({
-  ...teamRowContainerStyle,
-  ...(isMobile
-    ? {}
-    : {
-        '& .icon': {
-          display: 'none !important',
-        },
-        ':hover .icon': {
-          display: 'inherit !important',
-        },
-      }),
-})
+const iconStyle = {
+  color: globalColors.black_20,
+  fontSize: isMobile ? 20 : 16,
+}
 
 const teamStyle = {
   color: globalColors.darkBlue,
@@ -85,6 +64,15 @@ const teamStyle = {
         backgroundColor: globalColors.fastBlank,
       }
     : {}),
+}
+
+const badgeStyle = {
+  backgroundColor: globalColors.orange,
+  borderRadius: 6,
+  height: 8,
+  marginTop: 4,
+  marginRight: 4,
+  width: 8,
 }
 
 export {BigTeamHeader}

--- a/shared/chat/inbox/row/big-team-header/index.js
+++ b/shared/chat/inbox/row/big-team-header/index.js
@@ -1,13 +1,7 @@
 // @flow
 import React from 'react'
 import {Avatar, Box, Text, Icon} from '../../../../common-adapters'
-import {
-  desktopStyles,
-  globalStyles,
-  globalColors,
-  globalMargins,
-  isMobile,
-} from '../../../../styles'
+import {desktopStyles, globalStyles, globalColors, globalMargins, isMobile} from '../../../../styles'
 
 type Props = {
   badgeSubscribe: boolean,
@@ -32,7 +26,9 @@ class BigTeamHeader extends React.PureComponent<Props> {
           onClick={isMobile ? () => props.onClickGear() : props.onClickGear}
           style={iconStyle}
         />
-        {props.badgeSubscribe && <Box style={badgeStyle} />}
+        <Box
+          style={{...badgeStyle, backgroundColor: props.badgeSubscribe ? globalColors.orange : undefined}}
+        />
       </Box>
     )
   }
@@ -67,7 +63,6 @@ const teamStyle = {
 }
 
 const badgeStyle = {
-  backgroundColor: globalColors.orange,
   borderRadius: 6,
   height: 8,
   marginTop: 4,

--- a/shared/chat/inbox/row/index.stories.js
+++ b/shared/chat/inbox/row/index.stories.js
@@ -120,7 +120,12 @@ const load = () => {
     ))
     .add('Team', () => (
       <Box style={{borderColor: 'black', borderStyle: 'solid', borderWidth: 1, width: 240}}>
-        <BigTeamHeader memberCount={30} onClickGear={action('onClickGear')} teamname="Keybase" />
+        <BigTeamHeader
+          badgeSubscribe={false}
+          memberCount={30}
+          onClickGear={action('onClickGear')}
+          teamname="Keybase"
+        />
         <BigTeamChannel {...commonChannel} teamname="Keybase" channelname="#general" />
         <BigTeamChannel {...commonChannel} teamname="Keybase" channelname="#random" showBold={true} />
         <BigTeamChannel
@@ -131,7 +136,12 @@ const load = () => {
           hasUnread={true}
         />
         <BigTeamChannel {...commonChannel} teamname="Keybase" channelname="#video-games" isMuted={true} />
-        <BigTeamHeader memberCount={30} onClickGear={action('onClickGear')} teamname="techtonica" />
+        <BigTeamHeader
+          badgeSubscribe={false}
+          memberCount={30}
+          onClickGear={action('onClickGear')}
+          teamname="techtonica"
+        />
         <BigTeamChannel {...commonChannel} teamname="techtonica" channelname="#general" isSelected={true} />
         <BigTeamChannel {...commonChannel} teamname="techtonica" channelname="#ignore-selected-below" />
         <BigTeamChannel

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -79,6 +79,7 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   chosenChannelsForTeam: I.Set(),
   convIDToChannelInfo: I.Map(),
   loaded: false,
+  loadingChosenChannels: false,
   sawChatBanner: false,
   sawSubteamsBanner: false,
   teamCreationError: '',

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -76,6 +76,7 @@ export const makeRetentionPolicy: I.RecordFactory<Types._RetentionPolicy> = I.Re
 
 export const makeState: I.RecordFactory<Types._State> = I.Record({
   channelCreationError: '',
+  chosenChannelsForTeam: I.Set(),
   convIDToChannelInfo: I.Map(),
   loaded: false,
   sawChatBanner: false,
@@ -175,6 +176,9 @@ const userIsActiveInTeamHelper = (
 
 const getConvIdsFromTeamName = (state: TypedState, teamname: string): I.Set<ChatTypes.ConversationIDKey> =>
   state.teams.teamNameToConvIDs.get(teamname, I.Set())
+
+const getBadgeSubscribe = (state: TypedState, teamname: string): boolean =>
+  !state.teams.chosenChannelsForTeam.has(teamname)
 
 const getTeamNameFromConvID = (state: TypedState, conversationIDKey: ChatTypes.ConversationIDKey) =>
   state.teams.teamNameToConvIDs.findKey(i => i.has(conversationIDKey))
@@ -364,6 +368,7 @@ export const makeResetUser: I.RecordFactory<Types._ResetUser> = I.Record({
 })
 
 export {
+  getBadgeSubscribe,
   getConvIdsFromTeamName,
   getRole,
   getCanPerform,

--- a/shared/constants/types/teams.js
+++ b/shared/constants/types/teams.js
@@ -98,6 +98,7 @@ export type ResetUser = I.RecordOf<_ResetUser>
 
 export type _State = {
   channelCreationError: string,
+  chosenChannelsForTeam: I.Set<Teamname>,
   convIDToChannelInfo: I.Map<ConversationIDKey, ChannelInfo>,
   sawChatBanner: boolean,
   sawSubteamsBanner: boolean,

--- a/shared/constants/types/teams.js
+++ b/shared/constants/types/teams.js
@@ -100,6 +100,7 @@ export type _State = {
   channelCreationError: string,
   chosenChannelsForTeam: I.Set<Teamname>,
   convIDToChannelInfo: I.Map<ConversationIDKey, ChannelInfo>,
+  loadingChosenChannels: boolean,
   sawChatBanner: boolean,
   sawSubteamsBanner: boolean,
   teamAccessRequestsPending: I.Set<Teamname>,

--- a/shared/people/item/index.js
+++ b/shared/people/item/index.js
@@ -83,8 +83,8 @@ const childrenContainerStyle = {
 
 const timestampContainerStyle = {
   ...globalStyles.flexBoxRow,
-  position: 'absolute',
   alignItems: 'center',
+  position: 'absolute',
   right: 8,
   top: 12,
 }

--- a/shared/reducers/teams.js
+++ b/shared/reducers/teams.js
@@ -96,11 +96,6 @@ const rootReducer = (state: Types.State = initialState, action: TeamsGen.Actions
       return state.set('sawSubteamsBanner', true)
 
     case TeamsGen.setChosenChannelsForTeam:
-      console.warn(
-        'in setChosenChannels with',
-        JSON.parse(action.payload.chosenChannelsForTeam),
-        state.get('loadingChosenChannels')
-      )
       return state.get('loadingChosenChannels')
         ? state
         : state.set('chosenChannelsForTeam', I.Set(JSON.parse(action.payload.chosenChannelsForTeam)))

--- a/shared/reducers/teams.js
+++ b/shared/reducers/teams.js
@@ -96,7 +96,17 @@ const rootReducer = (state: Types.State = initialState, action: TeamsGen.Actions
       return state.set('sawSubteamsBanner', true)
 
     case TeamsGen.setChosenChannelsForTeam:
-      return state.set('chosenChannelsForTeam', I.Set(JSON.parse(action.payload.chosenChannelsForTeam)))
+      console.warn(
+        'in setChosenChannels with',
+        JSON.parse(action.payload.chosenChannelsForTeam),
+        state.get('loadingChosenChannels')
+      )
+      return state.get('loadingChosenChannels')
+        ? state
+        : state.set('chosenChannelsForTeam', I.Set(JSON.parse(action.payload.chosenChannelsForTeam)))
+
+    case TeamsGen.setLoadingChosenChannels:
+      return state.set('loadingChosenChannels', action.payload.loading)
 
     // Saga-only actions
     case TeamsGen.addPeopleToTeam:

--- a/shared/reducers/teams.js
+++ b/shared/reducers/teams.js
@@ -115,6 +115,7 @@ const rootReducer = (state: Types.State = initialState, action: TeamsGen.Actions
     case TeamsGen.getTeamPublicity:
     case TeamsGen.getTeamRetentionPolicy:
     case TeamsGen.getTeams:
+    case TeamsGen.haveChosenChannelsForTeam:
     case TeamsGen.ignoreRequest:
     case TeamsGen.inviteToTeamByEmail:
     case TeamsGen.inviteToTeamByPhone:

--- a/shared/reducers/teams.js
+++ b/shared/reducers/teams.js
@@ -95,6 +95,9 @@ const rootReducer = (state: Types.State = initialState, action: TeamsGen.Actions
     case TeamsGen.setTeamSawSubteamsBanner:
       return state.set('sawSubteamsBanner', true)
 
+    case TeamsGen.setChosenChannelsForTeam:
+      return state.set('chosenChannelsForTeam', I.Set(JSON.parse(action.payload.chosenChannelsForTeam)))
+
     // Saga-only actions
     case TeamsGen.addPeopleToTeam:
     case TeamsGen.addToTeam:

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -82,13 +82,14 @@ const errorCatching = store => next => action => {
 }
 
 let middlewares = [errorCatching, createSagaMiddleware(crashHandler), thunkMiddleware]
-
+/*
 if (enableStoreLogging) {
   middlewares.push(loggerMiddleware)
 } else if (enableActionLogging) {
   middlewares.push(actionLogger)
 }
-
+*/
+middlewares.push(createLogger())
 if (__DEV__ && typeof window !== 'undefined') {
   window.debugActionLoop = () => {
     setInterval(() => {

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -82,6 +82,7 @@ const errorCatching = store => next => action => {
 }
 
 let middlewares = [errorCatching, createSagaMiddleware(crashHandler), thunkMiddleware]
+
 if (enableStoreLogging) {
   middlewares.push(loggerMiddleware)
 } else if (enableActionLogging) {

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -82,14 +82,12 @@ const errorCatching = store => next => action => {
 }
 
 let middlewares = [errorCatching, createSagaMiddleware(crashHandler), thunkMiddleware]
-/*
 if (enableStoreLogging) {
   middlewares.push(loggerMiddleware)
 } else if (enableActionLogging) {
   middlewares.push(actionLogger)
 }
-*/
-middlewares.push(createLogger())
+
 if (__DEV__ && typeof window !== 'undefined') {
   window.debugActionLoop = () => {
     setInterval(() => {


### PR DESCRIPTION
@keybase/react-hackers 

Changes:

* The gear icon next to big teams in the inbox is now always present, rather than only on hover
* If you haven't chosen "Subscribe to channels..." (manage channels) in that menu yet, the gear icon is badged, and there's a badge next to the menu item too
* When you do select it, we create a JSON string representing the set of teams you've selected channels for and send it to Gregor as a `chosenChannelsForTeam` category.
* When Gregor sends us back this update to the category, it goes into the store as an `I.Set<Teamname>` and that's what the containers use to decide whether to badge.

So we're serializing a set into a JSON string and having Gregor keep track of it as JSON.

There's some complication around using Gregor in this way.  It doesn't expose an update RPC, just dismiss and create.  So when we want to update, we first dismiss everything in the `chosenChannelsForTeam` category, and then we push our new version with an extra team (that you just clicked on) added.

But doing just this would lead to jank, as the UI updates to reflect the change inbetween the dismiss and the push.  So there's also a loading flag that's used to ignore the update that comes in as a result of the dismiss.  There's a CORE ticket for removing the need to have this loading flag, should be done next sprint.  That'll allow us to remove and action and use an `update` RPC directly, which would do the update in one message instead of two.