### PR TITLE
Use fork of react-native-image-picker

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -122,7 +122,7 @@
     "react-native-camera": "0.10.0",
     "react-native-contacts": "2.1.2",
     "react-native-fetch-blob": "0.10.8",
-    "react-native-image-picker": "0.26.7",
+    "react-native-image-picker": "git://github.com/keybase/react-native-image-picker#b70affdef548c355c4dc864cd72a2bc79666649e",
     "react-native-push-notification": "git://github.com/keybase/react-native-push-notification#keybase-fixes-off-302",
     "react-navigation": "git://github.com/keybase/react-navigation#keybase-fixes-off-beta-12",
     "react-redux": "5.0.7",

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -10547,9 +10547,9 @@ react-native-fetch-blob@0.10.8:
     base-64 "0.1.0"
     glob "7.0.6"
 
-react-native-image-picker@0.26.7:
+"react-native-image-picker@git://github.com/keybase/react-native-image-picker#b70affdef548c355c4dc864cd72a2bc79666649e":
   version "0.26.7"
-  resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-0.26.7.tgz#ad2ee957f7f6cc01396893ea03d84cb2adb2e376"
+  resolved "git://github.com/keybase/react-native-image-picker#b70affdef548c355c4dc864cd72a2bc79666649e"
 
 react-native-iphone-x-helper@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This switches our `react-native-image-picker` to a fork that changes two things:
- allows user to grant only one permission
- fixes crasher in permission-denied-retry flow

see [here](https://github.com/keybase/react-native-image-picker/commit/b70affdef548c355c4dc864cd72a2bc79666649e) for the diff. r? @keybase/react-hackers 