### PR TITLE
lock GetThreadNonblock at top level so frontend can only do one fetch per conversation at a time CORE-7647

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -133,6 +133,15 @@ func NewRemoteConversationSource(g *globals.Context, b *Boxer, ri func() chat1.R
 	}
 }
 
+func (s *RemoteConversationSource) AcquireConversationLock(ctx context.Context, uid gregor1.UID,
+	convID chat1.ConversationID) error {
+	return nil
+}
+
+func (s *RemoteConversationSource) ReleaseConversationLock(ctx context.Context, uid gregor1.UID,
+	convID chat1.ConversationID) {
+}
+
 func (s *RemoteConversationSource) Push(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, msg chat1.MessageBoxed) (chat1.MessageUnboxed, bool, error) {
 	// Do nothing here, we don't care about pushed messages
@@ -413,6 +422,17 @@ func NewHybridConversationSource(g *globals.Context, b *Boxer, storage *storage.
 		lockTab:                newConversationLockTab(g),
 		numExpungeReload:       100,
 	}
+}
+
+func (s *HybridConversationSource) AcquireConversationLock(ctx context.Context, uid gregor1.UID,
+	convID chat1.ConversationID) error {
+	_, err := s.lockTab.Acquire(ctx, uid, convID)
+	return err
+}
+
+func (s *HybridConversationSource) ReleaseConversationLock(ctx context.Context, uid gregor1.UID,
+	convID chat1.ConversationID) {
+	s.lockTab.Release(ctx, uid, convID)
 }
 
 func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.ConversationID,

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -489,6 +489,14 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 			h.Debug(ctx, "GetThreadNonblock: result obtained offline")
 		}
 	}()
+
+	// Lock conversation while this is running
+	if err := h.G().ConvSource.AcquireConversationLock(ctx, uid, arg.ConversationID); err != nil {
+		return res, err
+	}
+	defer h.G().ConvSource.ReleaseConversationLock(ctx, uid, arg.ConversationID)
+	h.Debug(ctx, "GetThreadNonblock: conversation lock obtained")
+
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -54,6 +54,9 @@ type UnboxConversationInfo interface {
 type ConversationSource interface {
 	Offlinable
 
+	AcquireConversationLock(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) error
+	ReleaseConversationLock(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID)
+
 	Push(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 		msg chat1.MessageBoxed) (chat1.MessageUnboxed, bool, error)
 	Pull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,


### PR DESCRIPTION
The goal here is to make it so if you are scrolling up quickly, that the JS doesn't get confused by the cached and full payloads coming back intermixed. 

cc @maxtaco 