### PR TITLE
nuke session.json

### DIFF
--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -62,7 +62,6 @@ type fstatus struct {
 	StoredSecret           bool
 	SecretPromptSkip       bool
 	SessionIsValid         bool
-	SessionStatus          string
 	ConfigPath             string
 
 	Client struct {
@@ -165,7 +164,6 @@ func (c *CmdStatus) load() (*fstatus, error) {
 		status.Service.Log = filepath.Join(extStatus.LogDir, libkb.ServiceLogFileName)
 	}
 
-	status.SessionStatus = c.sessionStatus(extStatus.Session)
 	status.PassphraseStreamCached = extStatus.PassphraseStreamCached
 	status.TsecCached = extStatus.TsecCached
 	status.DeviceSigKeyCached = extStatus.DeviceSigKeyCached
@@ -247,7 +245,7 @@ func (c *CmdStatus) outputTerminal(status *fstatus) error {
 		dui.Printf("    ID:        %s\n", status.Device.DeviceID)
 		dui.Printf("    status:    %s\n\n", libkb.DeviceStatusToString(&status.Device.Status))
 	}
-	dui.Printf("Session:       %s\n", status.SessionStatus)
+	dui.Printf("Session:\n")
 	dui.Printf("    is valid:  %s\n", BoolString(status.SessionIsValid, "yes", "no"))
 
 	var deviceKeysLockStatus string
@@ -338,17 +336,6 @@ func (c *CmdStatus) GetUsage() libkb.Usage {
 		Config: true,
 		API:    true,
 	}
-}
-
-func (c *CmdStatus) sessionStatus(s *keybase1.SessionStatus) string {
-	if s == nil {
-		return "no session"
-	}
-	if s.SaltOnly {
-		return fmt.Sprintf("%s [salt only]", s.SessionFor)
-	}
-
-	return fmt.Sprintf("%s [loaded: %s, cleared: %s, expired: %s]", s.SessionFor, BoolString(s.Loaded, "yes", "no"), BoolString(s.Cleared, "yes", "no"), BoolString(s.Expired, "yes", "no"))
 }
 
 // execToString returns the space-trimmed output of a command or an error.

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -307,22 +307,13 @@ func testEngineWithSecretStore(
 	tc := SetupEngineTest(t, "wss")
 	defer tc.Cleanup()
 
-	fu := CreateAndSignupFakeUser(tc, "wss")
+	fu := SignupFakeUserStoreSecret(tc, "wss")
 	tc.ResetLoginState()
 
 	testSecretUI := libkb.TestSecretUI{
 		Passphrase:  fu.Passphrase,
 		StoreSecret: true,
 	}
-	runEngine(tc, fu, &testSecretUI)
-
-	if !testSecretUI.CalledGetPassphrase {
-		t.Fatal("GetPassphrase() unexpectedly not called")
-	}
-
-	tc.ResetLoginState()
-
-	testSecretUI = libkb.TestSecretUI{}
 	runEngine(tc, fu, &testSecretUI)
 
 	if testSecretUI.CalledGetPassphrase {

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	insecureTriplesec "github.com/keybase/go-triplesec-insecure"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func SetupEngineTest(tb libkb.TestingTB, name string) libkb.TestContext {
@@ -248,7 +249,7 @@ func (fu *FakeUser) NewCountSecretUI() *libkb.TestCountSecretUI {
 }
 
 func AssertProvisioned(tc libkb.TestContext) error {
-	prov, err := tc.G.LoginState().LoggedInProvisionedCheck()
+	prov, err := tc.G.LoginState().LoggedInProvisioned(context.TODO())
 	if err != nil {
 		return err
 	}
@@ -259,7 +260,7 @@ func AssertProvisioned(tc libkb.TestContext) error {
 }
 
 func AssertNotProvisioned(tc libkb.TestContext) error {
-	prov, err := tc.G.LoginState().LoggedInProvisionedCheck()
+	prov, err := tc.G.LoginState().LoggedInProvisioned(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/go/engine/concurrency_test.go
+++ b/go/engine/concurrency_test.go
@@ -61,9 +61,6 @@ func TestConcurrentLogin(t *testing.T) {
 					tc.G.LoginState().LocalSession(func(s *libkb.Session) {
 						s.GetUID()
 					}, "GetUID")
-					tc.G.LoginState().LocalSession(func(s *libkb.Session) {
-						s.Load()
-					}, "session Load")
 					tc.G.LoginState().LoggedIn()
 					tc.G.LoginState().LoggedInLoad()
 					// tc.G.LoginState.Shutdown()

--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -83,13 +83,11 @@ func assertDeprovisionWithSetup(tc libkb.TestContext, targ assertDeprovisionWith
 	}
 
 	dbPath := tc.G.Env.GetDbFilename()
-	sessionPath := tc.G.Env.GetSessionFilename()
 	secretKeysPath := tc.G.SKBFilenameForUser(fu.NormalizedUsername())
 	numKeys := getNumKeys(tc, *fu)
 	expectedNumKeys := numKeys
 
 	assertFileExists(tc.T, dbPath)
-	assertFileExists(tc.T, sessionPath)
 	assertFileExists(tc.T, secretKeysPath)
 	if !isUserInConfigFile(tc, *fu) {
 		tc.T.Fatalf("User %s is not in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
@@ -147,7 +145,6 @@ func assertDeprovisionWithSetup(tc libkb.TestContext, targ assertDeprovisionWith
 	}
 
 	assertFileDoesNotExist(tc.T, dbPath)
-	assertFileDoesNotExist(tc.T, sessionPath)
 	assertFileDoesNotExist(tc.T, secretKeysPath)
 	if isUserInConfigFile(tc, *fu) {
 		tc.T.Fatalf("User %s is still in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
@@ -239,12 +236,10 @@ func assertDeprovisionLoggedOut(tc libkb.TestContext) {
 	}
 
 	dbPath := tc.G.Env.GetDbFilename()
-	sessionPath := tc.G.Env.GetSessionFilename()
 	secretKeysPath := tc.G.SKBFilenameForUser(fu.NormalizedUsername())
 	numKeys := getNumKeys(tc, *fu)
 
 	assertFileExists(tc.T, dbPath)
-	assertFileExists(tc.T, sessionPath)
 	assertFileExists(tc.T, secretKeysPath)
 	if !isUserInConfigFile(tc, *fu) {
 		tc.T.Fatalf("User %s is not in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
@@ -284,7 +279,6 @@ func assertDeprovisionLoggedOut(tc libkb.TestContext) {
 	}
 
 	assertFileDoesNotExist(tc.T, dbPath)
-	assertFileDoesNotExist(tc.T, sessionPath)
 	assertFileDoesNotExist(tc.T, secretKeysPath)
 	if isUserInConfigFile(tc, *fu) {
 		tc.T.Fatalf("User %s is still in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
@@ -341,12 +335,10 @@ func assertCurrentDeviceRevoked(tc libkb.TestContext) {
 	}
 
 	dbPath := tc.G.Env.GetDbFilename()
-	sessionPath := tc.G.Env.GetSessionFilename()
 	secretKeysPath := tc.G.SKBFilenameForUser(fu.NormalizedUsername())
 	numKeys := getNumKeys(tc, *fu)
 
 	assertFileExists(tc.T, dbPath)
-	assertFileExists(tc.T, sessionPath)
 	assertFileExists(tc.T, secretKeysPath)
 	if !isUserInConfigFile(tc, *fu) {
 		tc.T.Fatalf("User %s is not in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
@@ -388,7 +380,6 @@ func assertCurrentDeviceRevoked(tc libkb.TestContext) {
 	}
 
 	assertFileDoesNotExist(tc.T, dbPath)
-	assertFileDoesNotExist(tc.T, sessionPath)
 	assertFileDoesNotExist(tc.T, secretKeysPath)
 	if isUserInConfigFile(tc, *fu) {
 		tc.T.Fatalf("User %s is still in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())

--- a/go/engine/devlist.go
+++ b/go/engine/devlist.go
@@ -29,7 +29,7 @@ func (d *DevList) Name() string {
 }
 
 func (d *DevList) Prereqs() Prereqs {
-	return Prereqs{Session: true}
+	return Prereqs{Device: true}
 }
 
 func (d *DevList) RequiredUIs() []libkb.UIKind {

--- a/go/engine/login_offline.go
+++ b/go/engine/login_offline.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 type LoginOffline struct {
@@ -51,138 +50,11 @@ func (e *LoginOffline) Run(ctx *Context) error {
 func (e *LoginOffline) run(ctx *Context) error {
 	var gerr error
 	aerr := e.G().LoginState().Account(func(a *libkb.Account) {
-		var in bool
-		in, gerr = a.LoggedInProvisioned()
-		if gerr != nil {
-			e.G().Log.Debug("LoginOffline: LoggedInProvisioned error: %s", gerr)
-			return
-		}
-		if !in {
-			e.G().Log.Debug("LoginOffline: LoggedInProvisioned says not logged in")
-			gerr = libkb.LoginRequiredError{}
-			return
-		}
-
-		// current user has a valid session file
-		e.G().Log.Debug("LoginOffline: current user has a valid session file")
-
-		// check ActiveDevice cache
-		uid, deviceID, _, sigKey, encKey := e.G().ActiveDevice.AllFields()
-		if sigKey != nil && encKey != nil {
-			if uid.Equal(a.GetUID()) && deviceID.Eq(a.GetDeviceID()) {
-				// since they match, good to go
-				e.G().Log.Debug("LoginOffline: found cached device keys in ActiveDevice")
-				return
-			}
-		}
-
-		// nothing cached, so need to load the locked keys and unlock them
-		// with secret store
-
-		uid = e.G().Env.GetUID()
-		deviceID = e.G().Env.GetDeviceIDForUID(uid)
-
-		// use the UPAKLoader with StaleOK, CachedOnly in order to get cached upak
-		arg := libkb.NewLoadUserByUIDArg(ctx.NetContext, e.G(), uid).WithPublicKeyOptional().WithStaleOK(true).WithCachedOnly().WithLoginContext(a)
-		upak, _, err := e.G().GetUPAKLoader().Load(arg)
+		_, err := libkb.BootstrapActiveDeviceFromConfig(ctx.NetContext, e.G(), a, false)
 		if err != nil {
-			e.G().Log.Debug("LoginOffline: upak.Load err: %s", err)
-			// if user load fails, login required
-			gerr = libkb.LoginRequiredError{}
-			return
+			gerr = libkb.NewLoginRequiredError(err.Error())
 		}
-
-		// find the sibkey
-		var sibkey *keybase1.PublicKey
-		for _, key := range upak.Base.DeviceKeys {
-			if key.DeviceID.Eq(deviceID) && key.IsSibkey == true {
-				e.G().Log.Debug("LoginOffline: device sibkey match: %+v", key)
-				sibkey = &key
-				break
-			}
-		}
-		if sibkey == nil {
-			e.G().Log.Debug("LoginOffline: no sibkey found in upak.Base.DeviceKeys")
-			gerr = libkb.NewLoginOfflineError("no sibkey found")
-			return
-		}
-
-		// find the subkey
-		var subkey *keybase1.PublicKey
-		for _, key := range upak.Base.DeviceKeys {
-			if !key.IsSibkey && key.ParentID == sibkey.KID.String() {
-				e.G().Log.Debug("LoginOffline: subkey match: %+v", key)
-				subkey = &key
-				break
-			}
-		}
-		if subkey == nil {
-			e.G().Log.Debug("LoginOffline: no subkey found in upak.Base.DeviceKeys")
-			gerr = libkb.NewLoginOfflineError("no subkey found")
-			return
-		}
-
-		// load the keyring file
-		username := libkb.NewNormalizedUsername(upak.Base.Username)
-		kr, err := libkb.LoadSKBKeyring(username, e.G())
-		if err != nil {
-			e.G().Log.Debug("LoginOffline: error loading keyring for %s: %s", username, err)
-			gerr = err
-			return
-		}
-
-		// get the locked keys out of the keyring
-		lockedSibkey := kr.LookupByKid(sibkey.KID)
-		if lockedSibkey == nil {
-			e.G().Log.Debug("LoginOffline: no locked sibkey with KID %s", sibkey.KID)
-			gerr = libkb.NewLoginOfflineError("no locked sibkey found in keyring")
-			return
-		}
-		lockedSibkey.SetUID(uid)
-
-		lockedSubkey := kr.LookupByKid(subkey.KID)
-		if lockedSubkey == nil {
-			e.G().Log.Debug("LoginOffline: no locked subkey with KID %s", subkey.KID)
-			gerr = libkb.NewLoginOfflineError("no locked subkey found in keyring")
-			return
-		}
-		lockedSubkey.SetUID(uid)
-
-		// unlock the keys with the secret store
-		secretStore := libkb.NewSecretStore(e.G(), username)
-		unlockedSibkey, err := lockedSibkey.UnlockNoPrompt(a, secretStore)
-		if err != nil {
-			e.G().Log.Debug("LoginOffline: failed to unlock sibkey: %s", err)
-			gerr = err
-			return
-		}
-
-		unlockedSubkey, err := lockedSubkey.UnlockNoPrompt(a, secretStore)
-		if err != nil {
-			e.G().Log.Debug("LoginOffline: failed to unlock subkey: %s", err)
-			gerr = err
-			return
-		}
-
-		device := &libkb.Device{
-			ID:          deviceID,
-			Kid:         sibkey.KID,
-			Description: &sibkey.DeviceDescription,
-		}
-
-		// cache the unlocked secret keys
-		ska := libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType}
-		if err := a.SetCachedSecretKey(ska, unlockedSibkey, device); err != nil {
-			e.G().Log.Debug("LoginOffline: failed to cache sibkey: %s", err)
-			gerr = err
-			return
-		}
-		ska = libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType}
-		if err := a.SetCachedSecretKey(ska, unlockedSubkey, device); err != nil {
-			e.G().Log.Debug("LoginOffline: failed to cache subkey: %s", err)
-			gerr = err
-			return
-		}
+		return
 	}, "LoginOffline")
 
 	if aerr != nil {

--- a/go/engine/login_provisioned_device.go
+++ b/go/engine/login_provisioned_device.go
@@ -65,7 +65,7 @@ func (e *LoginProvisionedDevice) Run(ctx *Context) error {
 
 func (e *LoginProvisionedDevice) run(ctx *Context) error {
 	// already logged in?
-	in, err := e.G().LoginState().LoggedInProvisionedCheck()
+	in, err := e.G().LoginState().LoggedInProvisioned(ctx.GetNetContext())
 	if err == nil && in {
 		if len(e.username) == 0 || e.G().Env.GetUsername() == libkb.NewNormalizedUsername(e.username) {
 			// already logged in, make sure to unlock device keys

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -81,7 +81,7 @@ func TestLoginAfterLoginStateReset(t *testing.T) {
 	defer tc.Cleanup()
 
 	// Logs the user in.
-	_ = CreateAndSignupFakeUser(tc, "li")
+	_ = SignupFakeUserStoreSecret(tc, "li")
 
 	tc.ResetLoginState()
 

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2493,6 +2493,9 @@ func TestResetThenPGPOnlyThenProvision(t *testing.T) {
 		NoSave:     true,
 	})
 
+	// Reset LoginContext to be `nil`, so that way we get the tc.G.LoginState
+	// session token, rather than the old one in ctx.LoginContext.
+	ctx.LoginContext = nil
 	if err := RunEngine(peng, ctx); err != nil {
 		tc.T.Fatal(err)
 	}

--- a/go/engine/login_with_paperkey_test.go
+++ b/go/engine/login_with_paperkey_test.go
@@ -92,13 +92,14 @@ func TestLoginWithPaperKeyLoggedInAndLocked(t *testing.T) {
 	t.Logf("locking keys")
 	err := tc.G.LoginState().Account(func(a *libkb.Account) {
 		a.ClearCachedSecretKeys()
+		a.ClearStreamCache()
 	}, "test")
 	require.NoError(t, err)
 	err = tc.G.SecretStore().ClearSecret(libkb.NormalizedUsername(u.Username))
 	require.NoError(t, err)
 
 	t.Logf("checking logged in status [before]")
-	AssertLoggedInLPK(&tc, true)
+	AssertLoggedInLPK(&tc, false)
 	t.Logf("checking unlocked status [before]")
 	AssertDeviceKeysLock(&tc, false)
 
@@ -141,13 +142,13 @@ func CreateAndSigunpLPK(tc libkb.TestContext, prefix string) (*FakeUser, string)
 }
 
 func AssertLoggedInLPK(tc *libkb.TestContext, shouldBeLoggedIn bool) {
-	sessionIsValid, err := tc.G.LoginState().LoggedInProvisionedCheck()
+
+	activeDeviceIsValid := tc.G.ActiveDevice.Valid()
 	t := tc.T
-	require.NoError(t, err)
 	if shouldBeLoggedIn {
-		require.Equal(t, true, sessionIsValid, "user should be logged in")
+		require.Equal(t, true, activeDeviceIsValid, "user should be logged in")
 	} else {
-		require.Equal(t, false, sessionIsValid, "user should not be logged in")
+		require.Equal(t, false, activeDeviceIsValid, "user should not be logged in")
 	}
 }
 

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -53,9 +53,9 @@ func (e *PaperKeyGen) Name() string {
 
 // GetPrereqs returns the engine prereqs.
 func (e *PaperKeyGen) Prereqs() Prereqs {
-	// only need session if pushing keys
+	// only need a device if pushing keys
 	return Prereqs{
-		Session: !e.arg.SkipPush,
+		Device: !e.arg.SkipPush,
 	}
 }
 

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -129,9 +129,7 @@ func (e *PGPKeyImportEngine) Name() string {
 }
 
 func (e *PGPKeyImportEngine) Prereqs() Prereqs {
-	return Prereqs{
-		Session: true,
-	}
+	return Prereqs{}
 }
 
 func (e *PGPKeyImportEngine) RequiredUIs() []libkb.UIKind {
@@ -194,7 +192,6 @@ func (e *PGPKeyImportEngine) Run(ctx *Context) error {
 		if err := e.testExisting(); err != nil {
 			return err
 		}
-
 		if err := e.loadDelegator(ctx); err != nil {
 			return err
 		}
@@ -212,7 +209,6 @@ func (e *PGPKeyImportEngine) Run(ctx *Context) error {
 		if err := e.push(ctx); err != nil {
 			return err
 		}
-
 		if err := e.exportToGPG(ctx); err != nil {
 			return GPGExportingError{err, true /* inPGPGen */}
 		}

--- a/go/engine/signup_join.go
+++ b/go/engine/signup_join.go
@@ -136,9 +136,6 @@ func (s *SignupJoinEngine) Run(lctx libkb.LoginContext, arg SignupJoinEngineRunA
 }
 
 func (s *SignupJoinEngine) WriteOut(lctx libkb.LoginContext, salt []byte) error {
-	if err := lctx.LocalSession().Load(); err != nil {
-		return err
-	}
 	if err := lctx.CreateLoginSessionWithSalt(s.username.String(), salt); err != nil {
 		return err
 	}

--- a/go/engine/soft_snooze_test.go
+++ b/go/engine/soft_snooze_test.go
@@ -63,12 +63,10 @@ func TestSoftSnooze(t *testing.T) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
 	sigVersion := libkb.GetDefaultSigVersion(tc.G)
-	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc.G.SetClock(fakeClock)
-	// to pick up the new clock...
-	tc.G.ResetLoginState()
+	fu := CreateAndSignupFakeUser(tc, "track")
 
 	flakeyAPI := flakeyRooterAPI{orig: tc.G.XAPI, flakeOut: false, G: tc.G}
 	tc.G.XAPI = &flakeyAPI

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -202,6 +202,10 @@ func TestTrackNewUserWithPGP(t *testing.T) {
 
 // see issue #578
 func TestTrackRetrack(t *testing.T) {
+
+	// XXX - can this test be salvaged?
+	t.Skip()
+
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
 	sigVersion := libkb.GetDefaultSigVersion(tc.G)

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -203,18 +203,10 @@ func TestTrackNewUserWithPGP(t *testing.T) {
 // see issue #578
 func TestTrackRetrack(t *testing.T) {
 
-	// XXX - can this test be salvaged?
-	t.Skip()
-
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
 	sigVersion := libkb.GetDefaultSigVersion(tc.G)
-	fu := CreateAndSignupFakeUser(tc, "track")
-
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-		a.ClearCachedSecretKeys()
-	}, "clear stream cache")
+	fu := createFakeUserWithPGPSibkey(tc)
 
 	idUI := &FakeIdentifyUI{}
 	secretUI := fu.NewSecretUI()
@@ -243,10 +235,6 @@ func TestTrackRetrack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !secretUI.CalledGetPassphrase {
-		t.Errorf("expected get passphrase call")
-	}
-
 	fu.User, err = libkb.LoadMe(libkb.NewLoadUserPubOptionalArg(tc.G))
 	if err != nil {
 		t.Fatal(err)
@@ -257,25 +245,10 @@ func TestTrackRetrack(t *testing.T) {
 		t.Errorf("seqno after track: %d, expected > %d", seqnoAfter, seqnoBefore)
 	}
 
-	Logout(tc)
-	fu.LoginOrBust(tc)
-	// clear out the passphrase cache
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-		a.ClearCachedSecretKeys()
-	}, "clear stream cache")
-
-	// reset the flag
-	secretUI.CalledGetPassphrase = false
-
 	eng = NewTrackEngine(arg, tc.G)
 	err = RunEngine(eng, ctx)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	if secretUI.CalledGetPassphrase {
-		t.Errorf("get secret called on retrack")
 	}
 
 	fu.User, err = libkb.LoadMe(libkb.NewLoadUserPubOptionalArg(tc.G))

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -48,7 +48,7 @@ func (e *TrackToken) Name() string {
 // GetPrereqs returns the engine prereqs.
 func (e *TrackToken) Prereqs() Prereqs {
 	return Prereqs{
-		Session: true,
+		Device: true,
 	}
 }
 

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -65,12 +65,10 @@ func TestTrackLocalThenLocalTemp(t *testing.T) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
 	sigVersion := libkb.GetDefaultSigVersion(tc.G)
-	fu := CreateAndSignupFakeUser(tc, "track")
 
-	fakeClock := clockwork.NewFakeClock()
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc.G.SetClock(fakeClock)
-	// to pick up the new clock...
-	tc.G.ResetLoginState()
+	fu := CreateAndSignupFakeUser(tc, "track")
 
 	flakeyAPI := flakeyRooterAPI{orig: tc.G.XAPI, flakeOut: false, G: tc.G}
 	tc.G.XAPI = &flakeyAPI
@@ -198,13 +196,11 @@ func TestTrackRemoteThenLocalTemp(t *testing.T) {
 func _testTrackRemoteThenLocalTemp(t *testing.T, sigVersion libkb.SigVersion) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
-	fu := CreateAndSignupFakeUser(tc, "track")
 
 	// Tracking remote means we have to agree what time it is
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc.G.SetClock(fakeClock)
-	// to pick up the new clock...
-	tc.G.ResetLoginState()
+	fu := CreateAndSignupFakeUser(tc, "track")
 
 	flakeyAPI := flakeyRooterAPI{orig: tc.G.XAPI, flakeOut: false, G: tc.G}
 	tc.G.XAPI = &flakeyAPI
@@ -323,12 +319,10 @@ func TestTrackFailTempRecover(t *testing.T) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
 	sigVersion := libkb.GetDefaultSigVersion(tc.G)
-	fu := CreateAndSignupFakeUser(tc, "track")
 
-	fakeClock := clockwork.NewFakeClock()
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc.G.SetClock(fakeClock)
-	// to pick up the new clock...
-	tc.G.ResetLoginState()
+	fu := CreateAndSignupFakeUser(tc, "track")
 
 	flakeyAPI := flakeyRooterAPI{orig: tc.G.XAPI, flakeOut: false, G: tc.G}
 	tc.G.XAPI = &flakeyAPI

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -129,7 +129,7 @@ func Logout(tc libkb.TestContext) {
 }
 
 func AssertProvisioned(tc libkb.TestContext) error {
-	prov, err := tc.G.LoginState().LoggedInProvisionedCheck()
+	prov, err := tc.G.LoginState().LoggedInProvisioned(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -109,9 +109,6 @@ func (a *Account) LoggedInProvisionedCheck() (bool, error) {
 // LoggedInProvisioned will load the session file if necessary and return true if the
 // device is provisioned.  It will *not* check the session with the api server.
 func (a *Account) LoggedInProvisioned() (bool, error) {
-	if err := a.LocalSession().Load(); err != nil {
-		return false, err
-	}
 	return a.LocalSession().IsLoggedInAndProvisioned(), nil
 }
 
@@ -144,7 +141,6 @@ func (a *Account) setLoginSession(ls *LoginSession) {
 		// But it probably signifies an error.
 		a.G().Log.Debug("Account: overwriting loginSession")
 	}
-
 	a.loginSession = ls
 }
 

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
 )
 
 type timedGenericKey struct {
@@ -101,15 +102,17 @@ func (a *Account) LoggedInLoad() (bool, error) {
 	return a.LocalSession().loadAndCheck()
 }
 
-// LoggedInProvisionedCheck will load and check the session with the api server if necessary.
-func (a *Account) LoggedInProvisionedCheck() (bool, error) {
-	return a.LocalSession().loadAndCheckProvisioned()
-}
-
-// LoggedInProvisioned will load the session file if necessary and return true if the
-// device is provisioned.  It will *not* check the session with the api server.
-func (a *Account) LoggedInProvisioned() (bool, error) {
-	return a.LocalSession().IsLoggedInAndProvisioned(), nil
+// LoggedInProvisioned will check if the user is logged in and provisioned on this
+// device. It will do so by bootstrapping the ActiveDevice.
+func (a *Account) LoggedInProvisioned(ctx context.Context) (bool, error) {
+	_, err := BootstrapActiveDeviceFromConfig(context.TODO(), a.G(), a, true)
+	if err == nil {
+		return true, nil
+	}
+	if _, isLRE := err.(LoginRequiredError); isLRE {
+		return false, nil
+	}
+	return false, err
 }
 
 func (a *Account) LoadLoginSession(emailOrUsername string) error {

--- a/go/libkb/bootstrap_active_device.go
+++ b/go/libkb/bootstrap_active_device.go
@@ -1,0 +1,125 @@
+package libkb
+
+import (
+	"fmt"
+	"github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
+)
+
+func loadAndUnlockKey(ctx context.Context, g *GlobalContext, lctx LoginContext, kr *SKBKeyringFile, secretStore SecretStore, uid keybase1.UID, kid keybase1.KID) (key GenericKey, err error) {
+	defer g.CTrace(ctx, fmt.Sprintf("loadAndUnlockKey(%s)", kid), func() error { return err })()
+
+	locked := kr.LookupByKid(kid)
+	if locked == nil {
+		g.Log.CDebugf(ctx, "loadAndUnlockKey: no locked key for %s", kid)
+		return nil, NoKeyError{fmt.Sprintf("no key for %s", kid)}
+	}
+	locked.SetUID(uid)
+	unlocked, err := locked.UnlockNoPrompt(lctx, secretStore)
+	if err != nil {
+		g.Log.CDebugf(ctx, "Failed to unlock key %s: %s", kid, err)
+		return nil, err
+	}
+	return unlocked, err
+}
+
+func BootstrapActiveDeviceFromConfig(ctx context.Context, g *GlobalContext, lctx LoginContext, online bool) (uid keybase1.UID, err error) {
+	uid = g.Env.GetUID()
+	if uid.IsNil() {
+		return uid, NoUIDError{}
+	}
+	deviceID := g.Env.GetDeviceIDForUID(uid)
+	if deviceID.IsNil() {
+		return uid, NoDeviceError{fmt.Sprintf("no device in config for UID=%s", uid)}
+	}
+	err = BootstrapActiveDevice(ctx, g, lctx, uid, deviceID, online)
+	return uid, err
+}
+
+func isBootstrapLoggedOutError(err error) bool {
+	if _, ok := err.(NoUIDError); ok {
+		return true
+	}
+	if err == ErrUnlockNotPossible {
+		return true
+	}
+	return false
+}
+
+func fixupBootstrapError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if isBootstrapLoggedOutError(err) {
+		return LoginRequiredError{err.Error()}
+	}
+	return err
+}
+
+// BootstrapActiveDevice takes the user's config.json, keys.mpack file and
+// secret store to populate ActiveDevice, and to have all credentials necessary
+// to sign NIST tokens, allowing the user to act as if "logged in". Will return
+// nil if everything work, LoginRequiredError if a real "login" in required to
+// make the app work, and various errors on unexpected failures.
+func BootstrapActiveDevice(ctx context.Context, g *GlobalContext, lctx LoginContext, uid keybase1.UID, deviceID keybase1.DeviceID, online bool) error {
+	err := bootstrapActiveDeviceWithRawError(ctx, g, lctx, uid, deviceID, online)
+	return fixupBootstrapError(err)
+}
+
+func bootstrapActiveDeviceWithRawError(ctx context.Context, g *GlobalContext, lctx LoginContext, uid keybase1.UID, deviceID keybase1.DeviceID, online bool) (err error) {
+	defer g.CTrace(ctx, "BootstrapActiveDevice", func() error { return err })()
+
+	ad := g.ActiveDevice
+
+	if ad.IsValidFor(uid, deviceID) {
+		g.Log.CDebugf(ctx, "active device is current")
+		return nil
+	}
+	// use the UPAKLoader with StaleOK, CachedOnly in order to get cached upak
+	arg := NewLoadUserByUIDArg(ctx, g, uid).WithPublicKeyOptional()
+	if !online {
+		arg = arg.WithStaleOK(true).WithCachedOnly()
+	}
+	if lctx != nil {
+		arg = arg.WithLoginContext(lctx)
+	}
+	upak, _, err := g.GetUPAKLoader().LoadV2(arg)
+	if err != nil {
+		g.Log.CDebugf(ctx, "BootstrapActiveDevice: upak.Load err: %s", err)
+		return err
+	}
+
+	// find the sibkey
+	sibkeyKID, deviceName := upak.Current.FindSigningDeviceKID(deviceID)
+	if sibkeyKID.IsNil() {
+		g.Log.CDebugf(ctx, "BootstrapActiveDevice: no sibkey found for device %s", deviceID)
+		return NoKeyError{"no signing device key found for user"}
+	}
+
+	subkeyKID := upak.Current.FindEncryptionDeviceKID(sibkeyKID)
+	if subkeyKID.IsNil() {
+		g.Log.CDebugf(ctx, "BootstrapActiveDevice: no subkey found for device: %s", deviceID)
+		return NoKeyError{"no encryption device key found for user"}
+	}
+
+	// load the keyring file
+	username := NewNormalizedUsername(upak.Current.Username)
+	kr, err := LoadSKBKeyring(username, g)
+	if err != nil {
+		g.Log.CDebugf(ctx, "BootstrapActiveDevice: error loading keyring for %s: %s", username, err)
+		return err
+	}
+
+	secretStore := NewSecretStore(g, username)
+	sib, err := loadAndUnlockKey(ctx, g, lctx, kr, secretStore, uid, sibkeyKID)
+	if err != nil {
+		return err
+	}
+	sub, err := loadAndUnlockKey(ctx, g, lctx, kr, secretStore, uid, subkeyKID)
+	if err != nil {
+		return err
+	}
+
+	err = ad.set(g, lctx, uid, deviceID, sib, sub, deviceName)
+	return err
+}

--- a/go/libkb/bootstrap_active_device.go
+++ b/go/libkb/bootstrap_active_device.go
@@ -24,6 +24,12 @@ func loadAndUnlockKey(ctx context.Context, g *GlobalContext, lctx LoginContext, 
 }
 
 func BootstrapActiveDeviceFromConfig(ctx context.Context, g *GlobalContext, lctx LoginContext, online bool) (uid keybase1.UID, err error) {
+	uid, err = bootstrapActiveDeviceFromConfigReturnRawError(ctx, g, lctx, online)
+	err = fixupBootstrapError(err)
+	return uid, err
+}
+
+func bootstrapActiveDeviceFromConfigReturnRawError(ctx context.Context, g *GlobalContext, lctx LoginContext, online bool) (uid keybase1.UID, err error) {
 	uid = g.Env.GetUID()
 	if uid.IsNil() {
 		return uid, NoUIDError{}
@@ -62,11 +68,11 @@ func fixupBootstrapError(err error) error {
 // nil if everything work, LoginRequiredError if a real "login" in required to
 // make the app work, and various errors on unexpected failures.
 func BootstrapActiveDevice(ctx context.Context, g *GlobalContext, lctx LoginContext, uid keybase1.UID, deviceID keybase1.DeviceID, online bool) error {
-	err := bootstrapActiveDeviceWithRawError(ctx, g, lctx, uid, deviceID, online)
+	err := bootstrapActiveDeviceReturnRawError(ctx, g, lctx, uid, deviceID, online)
 	return fixupBootstrapError(err)
 }
 
-func bootstrapActiveDeviceWithRawError(ctx context.Context, g *GlobalContext, lctx LoginContext, uid keybase1.UID, deviceID keybase1.DeviceID, online bool) (err error) {
+func bootstrapActiveDeviceReturnRawError(ctx context.Context, g *GlobalContext, lctx LoginContext, uid keybase1.UID, deviceID keybase1.DeviceID, online bool) (err error) {
 	defer g.CTrace(ctx, "BootstrapActiveDevice", func() error { return err })()
 
 	ad := g.ActiveDevice

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -1150,11 +1150,6 @@ func (s *LoginState) LoginSession(h func(*LoginSession), name string) error {
 func (s *LoginState) SecretSyncer(h func(*SecretSyncer), name string) error {
 	var err error
 	aerr := s.Account(func(a *Account) {
-		// SecretSyncer needs session loaded:
-		err = a.localSession.Load()
-		if err != nil {
-			return
-		}
 		h(a.SecretSyncer())
 	}, name)
 	if aerr != nil {

--- a/go/libkb/session.go
+++ b/go/libkb/session.go
@@ -4,13 +4,9 @@
 package libkb
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"time"
-
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	jsonw "github.com/keybase/go-jsonw"
+	"time"
 )
 
 type SessionReader interface {
@@ -21,7 +17,6 @@ type SessionReader interface {
 
 type Session struct {
 	Contextified
-	file     *JSONFile
 	token    string
 	csrf     string
 	inFile   bool
@@ -106,140 +101,21 @@ func (s *Session) SetLoggedIn(sessionID, csrfToken string, username NormalizedUs
 	s.uid = uid
 	s.username = &username
 	s.token = sessionID
-	if s.file == nil {
-		if err := s.Load(); err != nil {
-			return err
-		}
-	}
-	if s.GetDictionary() == nil {
-		s.G().Log.Warning("s.GetDict() == nil")
-	}
-	s.GetDictionary().SetKey("session", jsonw.NewString(sessionID))
-
-	s.SetCsrf(csrfToken)
-
+	s.csrf = csrfToken
 	s.deviceID = deviceID
-	if s.file == nil {
-		return errors.New("no session file")
-	}
-	s.GetDictionary().SetKey("device_provisioned", jsonw.NewString(deviceID.String()))
-
-	return s.save()
-}
-
-func (s *Session) save() error {
-	mtime := time.Now()
-	s.GetDictionary().SetKey("mtime", jsonw.NewInt64(mtime.Unix()))
-	if err := s.file.Save(); err != nil {
-		return err
-	}
-	s.mtime = mtime
+	s.mtime = time.Now()
 	return nil
 }
 
-func (s *Session) SetCsrf(t string) {
-	s.csrf = t
-	if s.file == nil {
-		return
-	}
-	s.GetDictionary().SetKey("csrf", jsonw.NewString(t))
-}
-
 func (s *Session) SetDeviceProvisioned(devid keybase1.DeviceID) error {
-	s.G().Log.Debug("Local Session:  setting provisioned device id: %s", devid)
+	s.G().Log.Debug("Local Session: setting provisioned device id: %s", devid)
 	s.deviceID = devid
-	if s.file == nil {
-		return errors.New("no session file")
-	}
-	s.GetDictionary().SetKey("device_provisioned", jsonw.NewString(devid.String()))
-	return s.save()
+	return nil
 }
 
 func (s *Session) isConfigLoggedIn() bool {
 	reader := s.G().Env.GetConfig()
 	return reader.GetUsername() != "" && reader.GetDeviceID().Exists() && reader.GetUID().Exists()
-}
-
-// The session file can be out of sync with the config file, particularly when
-// switching between the node and go clients.
-func (s *Session) nukeSessionFileIfOutOfSync() error {
-	sessionFile := s.G().Env.GetSessionFilename()
-	// Use stat to check existence.
-	_, statErr := os.Lstat(sessionFile)
-	if statErr == nil && !s.isConfigLoggedIn() {
-		s.G().Log.Warning("Session file found but user is not logged in. Deleting session file.")
-		return os.Remove(sessionFile)
-	}
-	return nil
-}
-
-func (s *Session) Load() error {
-	s.G().Log.Debug("+ Loading session")
-	if s.loaded {
-		s.G().Log.Debug("- Skipped; already loaded")
-		return nil
-	}
-
-	err := s.nukeSessionFileIfOutOfSync()
-	if err != nil {
-		return err
-	}
-
-	s.file = NewJSONFile(s.G(), s.G().Env.GetSessionFilename(), "session")
-	err = s.file.Load(false)
-	s.loaded = true
-
-	if err != nil {
-		s.G().Log.Error("Failed to load session file")
-		return err
-	}
-
-	if s.file.Exists() {
-		var tmp error
-		var token, csrf, devid string
-		ok := true
-		s.file.jw.AtKey("session").GetStringVoid(&token, &tmp)
-		if tmp != nil {
-			s.G().Log.Warning("Bad 'session' value in session file %s: %s",
-				s.file.filename, tmp)
-			ok = false
-		}
-		s.file.jw.AtKey("csrf").GetStringVoid(&csrf, &tmp)
-		if tmp != nil {
-			s.G().Log.Warning("Bad 'csrf' value in session file %s: %s",
-				s.file.filename, tmp)
-			ok = false
-		}
-		var did keybase1.DeviceID
-		s.file.jw.AtKey("device_provisioned").GetStringVoid(&devid, &tmp)
-		if tmp != nil {
-			s.G().Log.Debug("Bad 'device_provisioned' value in session file %s: %s", s.file.filename, tmp)
-			ok = false
-		} else {
-			var err error
-			did, err = keybase1.DeviceIDFromString(devid)
-			if err != nil {
-				s.G().Log.Debug("Bad 'device_provisioned' value in session file %s: %s (%s)", s.file.filename, err, devid)
-				ok = false
-
-			}
-		}
-		mtime, _ := s.file.jw.AtKey("mtime").GetInt64()
-		if ok {
-			s.token = token
-			s.csrf = csrf
-			s.inFile = true
-			s.deviceID = did
-			s.mtime = time.Unix(mtime, 0)
-			s.valid = true
-		}
-	}
-	s.G().Log.Debug("- Loaded session")
-	return nil
-}
-
-func (s *Session) GetDictionary() *jsonw.Wrapper {
-	return s.file.jw
 }
 
 func (s *Session) IsRecent() bool {
@@ -289,10 +165,8 @@ func (s *Session) checkWithServer() error {
 		s.uid = uid
 		nu := NewNormalizedUsername(username)
 		s.username = &nu
-		s.SetCsrf(csrf)
-		if err = s.save(); err != nil {
-			return err
-		}
+		s.csrf = csrf
+		s.mtime = time.Now()
 	} else {
 		s.G().Log.Notice("Stored session expired")
 		s.Invalidate()
@@ -348,14 +222,9 @@ func (s *Session) postLogout() error {
 }
 
 func (s *Session) Logout() error {
-	err := s.Load()
-	var e2 error
-	if err == nil && s.HasSessionToken() {
+	var err, e2 error
+	if s.HasSessionToken() {
 		e2 = s.postLogout()
-		if e3 := s.file.Nuke(); e3 != nil {
-			s.inFile = false
-			s.G().Log.Warning("Failed to remove session file: %s", e3)
-		}
 	}
 	if err == nil && e2 != nil {
 		err = e2
@@ -364,10 +233,7 @@ func (s *Session) Logout() error {
 }
 
 func (s *Session) loadAndCheck() (bool, error) {
-	err := s.Load()
-	if err != nil {
-		return false, err
-	}
+	var err error
 	if s.HasSessionToken() {
 		err = s.check()
 	}
@@ -390,10 +256,7 @@ func (s *Session) LoadAndCheckIfStale() (bool, error) {
 }
 
 func (s *Session) LoadAndForceCheck() (bool, error) {
-	err := s.Load()
-	if err != nil {
-		return false, err
-	}
+	var err error
 	if s.HasSessionToken() {
 		err = s.checkWithServer()
 	}

--- a/go/libkb/status.go
+++ b/go/libkb/status.go
@@ -5,6 +5,7 @@ package libkb
 
 import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
 )
 
 type UserInfo struct {
@@ -20,7 +21,7 @@ type CurrentStatus struct {
 	User           *User
 }
 
-func GetCurrentStatus(g *GlobalContext) (res CurrentStatus, err error) {
+func GetCurrentStatus(ctx context.Context, g *GlobalContext) (res CurrentStatus, err error) {
 	cr := g.Env.GetConfig()
 	if cr == nil {
 		return
@@ -30,7 +31,7 @@ func GetCurrentStatus(g *GlobalContext) (res CurrentStatus, err error) {
 		res.Registered = true
 		res.User = NewUserThin(cr.GetUsername().String(), uid)
 	}
-	res.SessionIsValid, err = g.LoginState().LoggedInProvisionedCheck()
+	res.SessionIsValid, err = g.LoginState().LoggedInProvisioned(ctx)
 	res.LoggedIn = res.SessionIsValid
 	return
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1367,6 +1367,40 @@ func (u UserPlusKeysV2) FindDeviceKey(needle KID) *PublicKeyV2NaCl {
 	return nil
 }
 
+func (u UserPlusKeysV2) FindSigningDeviceKey(d DeviceID) (*PublicKeyV2NaCl, string) {
+	for _, k := range u.DeviceKeys {
+		if k.DeviceID.Eq(d) && k.Base.IsSibkey {
+			return &k, k.DeviceDescription
+		}
+	}
+	return nil, ""
+}
+
+func (u UserPlusKeysV2) FindSigningDeviceKID(d DeviceID) (KID, string) {
+	key, name := u.FindSigningDeviceKey(d)
+	if key == nil {
+		return KID(""), name
+	}
+	return key.Base.Kid, name
+}
+
+func (u UserPlusKeysV2) FindEncryptionDeviceKey(parent KID) *PublicKeyV2NaCl {
+	for _, k := range u.DeviceKeys {
+		if !k.Base.IsSibkey && k.Parent != nil && k.Parent.Equal(parent) {
+			return &k
+		}
+	}
+	return nil
+}
+
+func (u UserPlusKeysV2) FindEncryptionDeviceKID(parent KID) KID {
+	key := u.FindEncryptionDeviceKey(parent)
+	if key == nil {
+		return KID("")
+	}
+	return key.Base.Kid
+}
+
 func (s ChatConversationID) String() string {
 	return hex.EncodeToString(s)
 }

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -39,9 +39,9 @@ func NewConfigHandler(xp rpc.Transporter, i libkb.ConnectionID, g *libkb.GlobalC
 	}
 }
 
-func (h ConfigHandler) GetCurrentStatus(_ context.Context, sessionID int) (res keybase1.GetCurrentStatusRes, err error) {
+func (h ConfigHandler) GetCurrentStatus(ctx context.Context, sessionID int) (res keybase1.GetCurrentStatusRes, err error) {
 	var cs libkb.CurrentStatus
-	if cs, err = libkb.GetCurrentStatus(h.G()); err == nil {
+	if cs, err = libkb.GetCurrentStatus(ctx, h.G()); err == nil {
 		res = cs.Export()
 	}
 	return

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -635,7 +635,7 @@ func (d *Service) tryGregordConnect() error {
 	// is down, it will still return false, along with the network error. We
 	// need to handle that case specifically, so that we still start the gregor
 	// connect loop.
-	loggedIn, err := d.G().LoginState().LoggedInProvisioned()
+	loggedIn, err := d.G().LoginState().LoggedInProvisioned(context.Background())
 	if err != nil {
 		// A network error means we *think* we're logged in, and we tried to
 		// confirm with the API server. In that case we'll swallow the error


### PR DESCRIPTION
- with NIST tokens, there's no good reason to keep session.json's around, since you can always cook up a new session
- factor out bootstrapping code from LoginOfflineEngine and move to a new library function
- LoginOfflineEngine now calls into our new bootstrap code
- Lots of small changes to engine tests to get everything working again.
- This stategy does hose standalone users who don't store secrets. Such is life. We previously popped up random pinentries, but we're getting away from that.