### PR TITLE
Purge attachments on message delete

### DIFF
--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -395,16 +395,16 @@ func (c *CachingAttachmentFetcher) DeleteAssets(ctx context.Context,
 		return nil
 	}
 
+	// Delete the assets locally
+	for _, asset := range assets {
+		c.diskLRU.Remove(ctx, c.G(), c.cacheKey(asset))
+	}
+
 	// get s3 params from server
 	s3params, err := ri().GetS3Params(ctx, convID)
 	if err != nil {
 		c.Debug(ctx, "error getting s3params: %s", err)
 		return err
-	}
-
-	// Delete the assets locally
-	for _, asset := range assets {
-		c.diskLRU.Remove(ctx, c.G(), c.cacheKey(asset))
 	}
 
 	// Try to delete the assets remotely

--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -397,6 +397,7 @@ func (c *CachingAttachmentFetcher) DeleteAssets(ctx context.Context,
 
 	// Delete the assets locally
 	for _, asset := range assets {
+		os.Remove(asset.Path)
 		c.diskLRU.Remove(ctx, c.G(), c.cacheKey(asset))
 	}
 

--- a/go/chat/attachment_httpsrv_test.go
+++ b/go/chat/attachment_httpsrv_test.go
@@ -41,6 +41,10 @@ func (m mockAttachmentRemoteStore) DecryptAsset(ctx context.Context, w io.Writer
 	return nil
 }
 
+func (m mockAttachmentRemoteStore) DeleteAssets(ctx context.Context, params chat1.S3Params, signer s3.Signer, assets []chat1.Asset) error {
+	return nil
+}
+
 func (m mockAttachmentRemoteStore) GetAssetReader(ctx context.Context, params chat1.S3Params, asset chat1.Asset,
 	signer s3.Signer) (io.ReadCloser, error) {
 	if m.assetReaderCh != nil {
@@ -53,7 +57,7 @@ type mockSigningRemote struct {
 	chat1.RemoteInterface
 }
 
-func (m mockSigningRemote) S3Sign(ctx context.Context, arg chat1.S3SignArg) ([]byte, error) {
+func (m mockSigningRemote) Sign(payload []byte) ([]byte, error) {
 	return nil, nil
 }
 
@@ -146,4 +150,10 @@ func TestChatSrvAttachmentHTTPSrv(t *testing.T) {
 	require.NoError(t, os.RemoveAll(fetcher.tempDir))
 	readAsset(uiMsg, false)
 	readAsset(uiMsg, true)
+
+	assets := utils.AssetsForMessage(tc.Context(), tv.Messages[0].Valid().MessageBody)
+	require.Len(t, assets, 1)
+	err = fetcher.DeleteAssets(context.TODO(), conv.Id, assets,
+		func() chat1.RemoteInterface { return mockSigningRemote{} }, mockSigningRemote{})
+	require.NoError(t, err)
 }

--- a/go/chat/attachment_httpsrv_test.go
+++ b/go/chat/attachment_httpsrv_test.go
@@ -153,7 +153,18 @@ func TestChatSrvAttachmentHTTPSrv(t *testing.T) {
 
 	assets := utils.AssetsForMessage(tc.Context(), tv.Messages[0].Valid().MessageBody)
 	require.Len(t, assets, 1)
+
+	found, localPath, err := fetcher.localAssetPath(context.TODO(), assets[0])
+	require.NoError(t, err)
+	require.True(t, found)
+	_, err = os.Stat(localPath)
+	require.False(t, os.IsNotExist(err))
+
 	err = fetcher.DeleteAssets(context.TODO(), conv.Id, assets,
 		func() chat1.RemoteInterface { return mockSigningRemote{} }, mockSigningRemote{})
 	require.NoError(t, err)
+
+	// make sure we have purged the attachment from disk as well
+	_, err = os.Stat(localPath)
+	require.True(t, os.IsNotExist(err))
 }

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -328,7 +328,7 @@ func TestBackgroundPurge(t *testing.T) {
 	uid := gregor1.UID(u.GetUID().ToBytes())
 	trip := newConvTriple(ctx, t, tc, u.Username)
 	clock := world.Fc
-	chatStorage := storage.New(g)
+	chatStorage := storage.New(g, tc.ChatG.ConvSource)
 	chatStorage.SetClock(clock)
 
 	// setup a ticker since we don't run the service's fastChatChecks ticker here.

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -51,6 +51,7 @@ func (s *baseConversationSource) Sign(payload []byte) ([]byte, error) {
 	return s.ri().S3Sign(context.Background(), arg)
 }
 
+// DeleteAssets implements github.com/keybase/go/chat/storage/storage.AssetDeleter interface.
 func (s *baseConversationSource) DeleteAssets(ctx context.Context, uid gregor1.UID,
 	convID chat1.ConversationID, assets []chat1.Asset) {
 	defer s.Trace(ctx, func() error { return nil }, "DeleteAssets", assets)()
@@ -816,7 +817,7 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 			superXform := newBasicSupersedesTransform(s.G())
 			superXform.SetMessagesFunc(func(ctx context.Context, conv types.UnboxConversationInfo,
 				uid gregor1.UID, msgIDs []chat1.MessageID) (res []chat1.MessageUnboxed, err error) {
-				msgs, err := storage.New(s.G()).FetchMessages(ctx, conv.GetConvID(), uid, msgIDs)
+				msgs, err := storage.New(s.G(), s).FetchMessages(ctx, conv.GetConvID(), uid, msgIDs)
 				if err != nil {
 					return nil, err
 				}

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -341,7 +341,7 @@ func (h *Helper) UnboxMobilePushNotification(ctx context.Context, uid gregor1.UI
 	if err := h.G().ConvSource.AcquireConversationLock(ctx, uid, convID); err != nil {
 		return res, err
 	}
-	maxMsgID, err := storage.New(h.G()).GetMaxMsgID(ctx, convID, uid)
+	maxMsgID, err := storage.New(h.G(), h.G().ConvSource).GetMaxMsgID(ctx, convID, uid)
 	if err == nil {
 		if msgUnboxed.GetMessageID() > maxMsgID {
 			if _, err = h.G().ConvSource.PushUnboxed(ctx, convID, uid, msgUnboxed); err != nil {

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -36,7 +36,7 @@ func NewSimpleIdentifyNotifier(g *globals.Context) *SimpleIdentifyNotifier {
 	return &SimpleIdentifyNotifier{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "SimpleIdentifyNotifier", false),
-		storage:      storage.New(g),
+		storage:      storage.New(g, g.ConvSource),
 	}
 }
 
@@ -65,7 +65,7 @@ func NewCachingIdentifyNotifier(g *globals.Context) *CachingIdentifyNotifier {
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "CachingIdentifyNotifier", false),
 		identCache:   make(map[string]keybase1.CanonicalTLFNameAndIDWithBreaks),
-		storage:      storage.New(g),
+		storage:      storage.New(g, g.ConvSource),
 	}
 }
 

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -1049,7 +1049,7 @@ func getUnverifiedTlfNameForErrors(conversationRemote chat1.Conversation) string
 func (s *localizerPipeline) getMessagesOffline(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, msgs []chat1.MessageSummary, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, chat1.ConversationErrorType, error) {
 
-	st := storage.New(s.G())
+	st := storage.New(s.G(), s.G().ConvSource)
 	res, err := st.FetchMessages(ctx, convID, uid, utils.PluckMessageIDs(msgs))
 	if err != nil {
 		// Just say we didn't find it in this case

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -34,7 +34,7 @@ func TestFetchRetry(t *testing.T) {
 	u2 := world.GetUsers()[2]
 	uid := u.User.GetUID().ToBytes()
 	tc := world.Tcs[u.Username]
-	store := storage.New(globals.NewContext(tc.G, tc.ChatG))
+	store := storage.New(globals.NewContext(tc.G, tc.ChatG), tc.ChatG.ConvSource)
 
 	var convIDs []chat1.ConversationID
 	var convs []chat1.Conversation

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -196,9 +196,10 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 		inboxSynced:    make(chan chat1.ChatSyncResult, 10),
 		ephemeralPurge: make(chan chat1.EphemeralPurgeNotifInfo, 10),
 	}
-	chatStorage := storage.New(g)
+	chatStorage := storage.New(g, nil)
 	chatStorage.SetClock(world.Fc)
 	g.ConvSource = NewHybridConversationSource(g, boxer, chatStorage, getRI)
+	chatStorage.SetAssetDeleter(g.ConvSource)
 	g.InboxSource = NewHybridInboxSource(g, getRI)
 	g.ServerCacheVersions = storage.NewServerVersions(g)
 	g.NotifyRouter.SetListener(&listener)
@@ -966,7 +967,7 @@ func TestPrevPointerAddition(t *testing.T) {
 	}
 
 	// Nuke the body cache
-	require.NoError(t, storage.New(tc.Context()).MaybeNuke(context.TODO(), true, nil, conv.GetConvID(), uid))
+	require.NoError(t, storage.New(tc.Context(), tc.ChatG.ConvSource).MaybeNuke(context.TODO(), true, nil, conv.GetConvID(), uid))
 
 	// Fetch a subset into the cache
 	_, _, err := tc.ChatG.ConvSource.Pull(ctx, conv.GetConvID(), uid, nil, &chat1.Pagination{

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2115,30 +2115,6 @@ func (h *Server) uploadAsset(ctx context.Context, sessionID int, params chat1.S3
 	return h.store.UploadAsset(ctx, &task)
 }
 
-func (h *Server) deleteAssets(ctx context.Context, conversationID chat1.ConversationID, assets []chat1.Asset) {
-	if len(assets) == 0 {
-		return
-	}
-
-	// get s3 params from server
-	params, err := h.remoteClient().GetS3Params(ctx, conversationID)
-	if err != nil {
-		h.Debug(ctx, "error getting s3 params: %s", err)
-		return
-	}
-
-	if err := h.store.DeleteAssets(ctx, params, h, assets); err != nil {
-		h.Debug(ctx, "error deleting assets: %s", err)
-
-		// there's no way to get asset information after this point.
-		// any assets not deleted will be stranded on s3.
-
-		return
-	}
-
-	h.Debug(ctx, "deleted %d assets", len(assets))
-}
-
 func (h *Server) FindConversationsLocal(ctx context.Context,
 	arg chat1.FindConversationsLocalArg) (res chat1.FindConversationsLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -312,10 +312,11 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 
 	h.boxer = NewBoxer(g)
 
-	chatStorage := storage.New(g)
+	chatStorage := storage.New(g, nil)
 	chatStorage.SetClock(c.world.Fc)
 	g.ConvSource = NewHybridConversationSource(g, h.boxer, chatStorage,
 		func() chat1.RemoteInterface { return ri })
+	chatStorage.SetAssetDeleter(g.ConvSource)
 	g.InboxSource = NewHybridInboxSource(g, func() chat1.RemoteInterface { return ri })
 	g.ServerCacheVersions = storage.NewServerVersions(g)
 	chatSyncer := NewSyncer(g)

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -388,6 +388,7 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 
 	s.Debug(ctx, "updateSupersededBy: num msgs: %d", len(msgs))
 	// Do a pass over all the messages and update supersededBy pointers
+	var allAssets []chat1.Asset
 	for _, msg := range msgs {
 
 		msgid := msg.GetMessageID()
@@ -430,10 +431,12 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 				mvalid := superMsg.Valid()
 				mvalid.ServerHeader.SupersededBy = msgid
 				if msg.GetMessageType() == chat1.MessageType_DELETE {
-					var emptyBody chat1.MessageBody
-					mvalid.MessageBody = emptyBody
+					msgPurged, assets := s.purgeMessage(mvalid)
+					allAssets = append(allAssets, assets...)
+					superMsgs[0] = msgPurged
+				} else {
+					superMsgs[0] = chat1.NewMessageUnboxedWithValid(mvalid)
 				}
-				superMsgs[0] = chat1.NewMessageUnboxedWithValid(mvalid)
 				if err = s.engine.WriteMessages(ctx, convID, uid, superMsgs); err != nil {
 					return err
 				}
@@ -442,6 +445,11 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 					superMsg.GetMessageID())
 			}
 		}
+	}
+
+	// conv source will queue asset deletions in the background
+	if convSource := s.G().ConvSource; convSource != nil {
+		convSource.DeleteAssets(ctx, uid, convID, allAssets)
 	}
 
 	return nil
@@ -608,6 +616,7 @@ func (s *Storage) applyExpunge(ctx context.Context, convID chat1.ConversationID,
 		return nil, err
 	}
 
+	var allAssets []chat1.Asset
 	var writeback []chat1.MessageUnboxed
 	for _, msg := range rc.Result() {
 		if !chat1.IsDeletableByDeleteHistory(msg.GetMessageType()) {
@@ -624,14 +633,17 @@ func (s *Storage) applyExpunge(ctx context.Context, convID chat1.ConversationID,
 			continue
 		}
 		mvalid.ServerHeader.SupersededBy = expunge.Basis // Can be 0
-		var emptyBody chat1.MessageBody
-		mvalid.MessageBody = emptyBody
-		writeback = append(writeback, chat1.NewMessageUnboxedWithValid(mvalid))
+		msgPurged, assets := s.purgeMessage(mvalid)
+		allAssets = append(allAssets, assets...)
+		writeback = append(writeback, msgPurged)
 	}
-	de("deleting %v messages", len(writeback))
+	// conv source will queue asset deletions in the background
+	if convSource := s.G().ConvSource; convSource != nil {
+		convSource.DeleteAssets(ctx, uid, convID, allAssets)
+	}
 
-	err = s.engine.WriteMessages(ctx, convID, uid, writeback)
-	if err != nil {
+	de("deleting %v messages", len(writeback))
+	if err = s.engine.WriteMessages(ctx, convID, uid, writeback); err != nil {
 		de("write messages failed: %v", err)
 		return nil, err
 	}
@@ -863,4 +875,12 @@ func (s *Storage) IsTLFIdentifyBroken(ctx context.Context, tlfID chat1.TLFID) bo
 		return true
 	}
 	return idBroken
+}
+
+// Clears the body of a message and returns any assets to be deleted.
+func (s *Storage) purgeMessage(mvalid chat1.MessageUnboxedValid) (chat1.MessageUnboxed, []chat1.Asset) {
+	assets := utils.AssetsForMessage(s.G(), mvalid.MessageBody)
+	var emptyBody chat1.MessageBody
+	mvalid.MessageBody = emptyBody
+	return chat1.NewMessageUnboxedWithValid(mvalid), assets
 }

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -189,8 +189,8 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 	// queue asset deletions in the background
 	s.assetDeleter.DeleteAssets(ctx, uid, convID, allAssets)
 
-	s.Debug(ctx, "purging %v ephemeral messages", len(exploded))
-	if err = s.engine.WriteMessages(ctx, convID, uid, exploded); err != nil {
+	s.Debug(ctx, "purging %v ephemeral messages", len(explodedMsgs))
+	if err = s.engine.WriteMessages(ctx, convID, uid, explodedMsgs); err != nil {
 		s.Debug(ctx, "write messages failed: %v", err)
 		return nil, nil, err
 	}

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -186,6 +186,9 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 		}
 	}
 
+	// queue asset deletions in the background
+	s.assetDeleter.DeleteAssets(ctx, uid, convID, allAssets)
+
 	s.Debug(ctx, "purging %v ephemeral messages", len(exploded))
 	if err = s.engine.WriteMessages(ctx, convID, uid, exploded); err != nil {
 		s.Debug(ctx, "write messages failed: %v", err)

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -153,6 +153,7 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 
 	nextPurgeTime := gregor1.Time(0)
 	minUnexplodedID := msgs[0].GetMessageID()
+	var allAssets []chat1.Asset
 	var hasExploding bool
 	for i, msg := range msgs {
 		if !msg.IsValid() {
@@ -176,20 +177,21 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 			} else if mvalid.MessageBody.IsNil() {
 				s.Debug(ctx, "skipping already exploded message: %v", msg.GetMessageID())
 			} else {
-				var emptyBody chat1.MessageBody
-				mvalid.MessageBody = emptyBody
-				newMsg := chat1.NewMessageUnboxedWithValid(mvalid)
-				explodedMsgs = append(explodedMsgs, newMsg)
-				msgs[i] = newMsg
+				msgPurged, assets := s.purgeMessage(mvalid)
+				allAssets = append(allAssets, assets...)
+				explodedMsgs = append(explodedMsgs, msgPurged)
+				msgs[i] = msgPurged
+				s.Debug(ctx, "purging ephemeral msg: %v", msgPurged.GetMessageID())
 			}
 		}
 	}
-	s.Debug(ctx, "purging %v ephemeral messages", len(explodedMsgs))
-	err = s.engine.WriteMessages(ctx, convID, uid, explodedMsgs)
-	if err != nil {
+
+	s.Debug(ctx, "purging %v ephemeral messages", len(exploded))
+	if err = s.engine.WriteMessages(ctx, convID, uid, exploded); err != nil {
 		s.Debug(ctx, "write messages failed: %v", err)
 		return nil, nil, err
 	}
+
 	return &chat1.EphemeralPurgeInfo{
 		MinUnexplodedID: minUnexplodedID,
 		NextPurgeTime:   nextPurgeTime,

--- a/go/chat/storage/storage_test.go
+++ b/go/chat/storage/storage_test.go
@@ -25,7 +25,7 @@ func setupStorageTest(t testing.TB, name string) (kbtest.ChatTestContext, *Stora
 	}
 	tc.Context().ServerCacheVersions = NewServerVersions(tc.Context())
 	require.NoError(t, err)
-	return tc, New(tc.Context()), gregor1.UID(u.User.GetUID().ToBytes())
+	return tc, New(tc.Context(), kbtest.NewDummyAssetDeleter()), gregor1.UID(u.User.GetUID().ToBytes())
 }
 
 func randBytes(n int) []byte {

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -101,7 +101,7 @@ func TestSyncerConnected(t *testing.T) {
 	syncer := NewSyncer(tc.Context())
 	syncer.isConnected = true
 	ibox := storage.NewInbox(tc.Context(), uid)
-	store := storage.New(tc.Context())
+	store := storage.New(tc.Context(), tc.ChatG.ConvSource)
 
 	var convs []chat1.Conversation
 	convs = append(convs, newConv(ctx, t, tc, uid, ri, sender, u.Username+","+u1.Username))
@@ -362,7 +362,7 @@ func TestSyncerMembersTypeChanged(t *testing.T) {
 		}),
 	}, 0, nil)
 	require.NoError(t, err)
-	s := storage.New(tc.Context())
+	s := storage.New(tc.Context(), tc.ChatG.ConvSource)
 	storedMsgs, err := s.FetchMessages(ctx, convID, uid, []chat1.MessageID{msg.GetMessageID()})
 	require.NoError(t, err)
 	require.Len(t, storedMsgs, 1)
@@ -460,7 +460,7 @@ func TestSyncerRetentionExpunge(t *testing.T) {
 	syncer := NewSyncer(tc.Context())
 	syncer.isConnected = true
 	ibox := storage.NewInbox(tc.Context(), uid)
-	store := storage.New(tc.Context())
+	store := storage.New(tc.Context(), tc.ChatG.ConvSource)
 
 	mconv := newConv(ctx, t, tc, uid, ri, sender, u.Username+","+u1.Username)
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -79,6 +79,7 @@ type ConversationSource interface {
 		convID chat1.ConversationID, deleteID chat1.MessageID)
 
 	SetRemoteInterface(func() chat1.RemoteInterface)
+	DeleteAssets(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, assets []chat1.Asset)
 }
 
 type MessageDeliverer interface {
@@ -231,6 +232,8 @@ type UPAKFinder interface {
 type ProgressReporter func(bytesCompleted, bytesTotal int64)
 
 type AttachmentFetcher interface {
+	DeleteAssets(ctx context.Context, convID chat1.ConversationID, assets []chat1.Asset,
+		ri func() chat1.RemoteInterface, signer s3.Signer) error
 	FetchAttachment(ctx context.Context, w io.Writer, convID chat1.ConversationID, asset chat1.Asset,
 		ri func() chat1.RemoteInterface, signer s3.Signer, progress ProgressReporter) error
 }

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1220,3 +1220,31 @@ func XlateMessageIDControlToPagination(control *chat1.MessageIDControl) (res *ch
 	}
 	return res
 }
+
+// assetsForMessage gathers all assets on a message
+func AssetsForMessage(g *globals.Context, msgBody chat1.MessageBody) (assets []chat1.Asset) {
+	typ, err := msgBody.MessageType()
+	if err != nil {
+		// Log and drop the error for a malformed MessageBody.
+		g.Log.Warning("error getting assets for message: %s", err)
+		return assets
+	}
+	switch typ {
+	case chat1.MessageType_ATTACHMENT:
+		body := msgBody.Attachment()
+		if body.Object.Path != "" {
+			assets = append(assets, body.Object)
+		}
+		if body.Preview != nil {
+			assets = append(assets, *body.Preview)
+		}
+		assets = append(assets, body.Previews...)
+	case chat1.MessageType_ATTACHMENTUPLOADED:
+		body := msgBody.Attachmentuploaded()
+		if body.Object.Path != "" {
+			assets = append(assets, body.Object)
+		}
+		assets = append(assets, body.Previews...)
+	}
+	return assets
+}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -1009,3 +1009,13 @@ func (c *ChatUI) ChatSearchDone(ctx context.Context, arg chat1.ChatSearchDoneArg
 	c.searchDoneCb <- arg
 	return nil
 }
+
+type DummyAssetDeleter struct{}
+
+func NewDummyAssetDeleter() DummyAssetDeleter {
+	return DummyAssetDeleter{}
+}
+
+// DeleteAssets implements github.com/keybase/go/chat/storage/storage.AssetDeleter interface.
+func (d DummyAssetDeleter) DeleteAssets(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, assets []chat1.Asset) {
+}

--- a/go/lru/disk_lru.go
+++ b/go/lru/disk_lru.go
@@ -352,8 +352,7 @@ func (d *DiskLRU) Remove(ctx context.Context, lctx libkb.LRUContext, key string)
 	if err != nil {
 		return err
 	}
-	index.Remove(key)
-	return nil
+	return d.removeEntry(ctx, lctx, index, key)
 }
 
 func (d *DiskLRU) ClearMemory(ctx context.Context, lctx libkb.LRUContext) {

--- a/go/lru/disk_lru_test.go
+++ b/go/lru/disk_lru_test.go
@@ -21,15 +21,24 @@ func TestDiskLRUBasic(t *testing.T) {
 	v := "Library/Caches/473847384738.jpg"
 	_, err := l.Put(ctx, tc.G, k, v)
 	require.NoError(t, err)
+
 	found, getRes, err := l.Get(ctx, tc.G, k)
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Equal(t, v, getRes.Value.(string))
+
 	l.ClearMemory(ctx, tc.G)
 	found, getRes, err = l.Get(ctx, tc.G, k)
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Equal(t, v, getRes.Value.(string))
+
+	err = l.Remove(ctx, tc.G, k)
+	require.NoError(t, err)
+	found, getRes, err = l.Get(ctx, tc.G, k)
+	require.NoError(t, err)
+	require.False(t, found)
+
 	found, getRes, err = l.Get(ctx, tc.G, "missing")
 	require.NoError(t, err)
 	require.False(t, found)

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -368,10 +368,11 @@ func (d *Service) createChatModules() {
 
 	// Set up main chat data sources
 	boxer := chat.NewBoxer(g)
-	chatStorage := storage.New(g)
+	chatStorage := storage.New(g, nil)
 	g.InboxSource = chat.NewInboxSource(g, g.Env.GetInboxSourceType(), ri)
 	g.ConvSource = chat.NewConversationSource(g, g.Env.GetConvSourceType(),
 		boxer, chatStorage, ri)
+	chatStorage.SetAssetDeleter(g.ConvSource)
 	g.Searcher = chat.NewSearcher(g)
 	g.ServerCacheVersions = storage.NewServerVersions(g)
 
@@ -577,7 +578,7 @@ func (d *Service) chatEphemeralPurgeChecks() {
 			d.G().Log.Debug("+ chat ephemeral purge loop")
 			g := globals.NewContext(d.G(), d.ChatG())
 			// Purge any conversations that have expired ephemeral messages
-			storage.New(g).QueueEphemeralBackgroundPurges(context.Background(), gregorUID)
+			storage.New(g, g.ConvSource).QueueEphemeralBackgroundPurges(context.Background(), gregorUID)
 			// Check the outbox for stuck ephemeral messages that need purging
 			storage.NewOutbox(g, gregorUID).EphemeralPurge(context.Background())
 			d.G().Log.Debug("- chat ephemeral chat loop")


### PR DESCRIPTION
When a message explodes or is deleted with an attachment we would like to purge the attachment from local caches and attempt remote deletion.

