### PR TITLE
modernize engine prereqs

### DIFF
--- a/go/engine/common.go
+++ b/go/engine/common.go
@@ -10,7 +10,7 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-// IsLoggedIn conveys if the user is in a logged-in state or not.
+// IsLoggedInWithError conveys if the user is in a logged-in state or not.
 // If this function returns `true`, it's because the user is logged in,
 // is on a provisioned device, and has an unlocked device key, If this
 // function returns `false`, it's because either no one has ever logged onto
@@ -24,9 +24,14 @@ import (
 // Under the hood, IsLoggedIn is going through the BootstrapActiveDevice
 // flow and therefore will try its best to unlocked locked keys if it can
 // without user interaction.
-func IsLoggedIn(e Engine, ctx *Context) (ret bool, uid keybase1.UID, err error) {
+func IsLoggedInWithError(e Engine, ctx *Context) (ret bool, uid keybase1.UID, err error) {
 	ret, uid, err = bootstrap(e, ctx)
 	return ret, uid, err
+}
+
+func IsLoggedIn(e Engine, ctx *Context) (ret bool, uid keybase1.UID) {
+	ret, uid, _ = IsLoggedInWithError(e, ctx)
+	return ret, uid
 }
 
 // bootstrap will setup an ActiveDevice with a NIST Factory for the engine
@@ -69,7 +74,7 @@ type keypair struct {
 // findDeviceKeys looks for device keys and unlocks them.
 func findDeviceKeys(ctx *Context, e Engine, me *libkb.User) (*keypair, error) {
 	// need to be logged in to get a device key (unlocked)
-	lin, _, _ := IsLoggedIn(e, ctx)
+	lin, _ := IsLoggedIn(e, ctx)
 	if !lin {
 		return nil, libkb.LoginRequiredError{}
 	}

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -68,6 +68,12 @@ func (fu FakeUser) NormalizedUsername() libkb.NormalizedUsername {
 	return libkb.NewNormalizedUsername(fu.Username)
 }
 
+func (fu *FakeUser) LoadUser(tc libkb.TestContext) error {
+	var err error
+	fu.User, err = libkb.LoadMe(libkb.NewLoadUserArg(tc.G))
+	return err
+}
+
 func (fu FakeUser) UID() keybase1.UID {
 	// All new-style names will have a 1-to-1 mapping
 	return libkb.UsernameToUID(fu.Username)

--- a/go/engine/device_history.go
+++ b/go/engine/device_history.go
@@ -46,7 +46,7 @@ func (e *DeviceHistory) Prereqs() Prereqs {
 	if len(e.username) > 0 {
 		return Prereqs{}
 	}
-	return Prereqs{Session: true}
+	return Prereqs{Device: true}
 }
 
 // RequiredUIs returns the required UIs.

--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -77,7 +77,7 @@ func (e *DeviceKeygen) Name() string {
 
 // GetPrereqs returns the engine prereqs.
 func (e *DeviceKeygen) Prereqs() Prereqs {
-	return Prereqs{Session: true}
+	return Prereqs{TemporarySession: true}
 }
 
 // RequiredUIs returns the required UIs.

--- a/go/engine/email_change.go
+++ b/go/engine/email_change.go
@@ -31,7 +31,7 @@ func (c *EmailChange) Name() string {
 
 // Prereqs returns engine prereqs
 func (c *EmailChange) Prereqs() Prereqs {
-	return Prereqs{Session: true}
+	return Prereqs{Device: true}
 }
 
 // RequiredUIs returns the required UIs.

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -5,15 +5,13 @@ package engine
 
 import (
 	"fmt"
-	"net/url"
-	"runtime/debug"
-
 	"github.com/keybase/client/go/libkb"
+	"runtime/debug"
 )
 
 type Prereqs struct {
-	Session bool
-	Device  bool
+	TemporarySession bool
+	Device           bool
 }
 
 type Engine interface {
@@ -30,17 +28,8 @@ type UIDelegateWanter interface {
 func runPrereqs(e Engine, ctx *Context) (err error) {
 	prq := e.Prereqs()
 
-	if prq.Session {
-		var ok bool
-		ok, _, err = IsLoggedIn(e, ctx)
-		if !ok {
-			urlError, isURLError := err.(*url.Error)
-			context := ""
-			if isURLError {
-				context = fmt.Sprintf("Encountered a network error: %s", urlError.Err)
-			}
-			err = libkb.LoginRequiredError{Context: context}
-		}
+	if prq.TemporarySession {
+		err := e.G().AssertTemporarySession(ctx.LoginContext)
 		if err != nil {
 			return err
 		}

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -36,7 +36,7 @@ func runPrereqs(e Engine, ctx *Context) error {
 	}
 
 	if prq.Device {
-		ok, _, err := IsLoggedIn(e, ctx)
+		ok, _, err := IsLoggedInWithError(e, ctx)
 		if err != nil {
 			return err
 		}

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -25,7 +25,7 @@ type UIDelegateWanter interface {
 	WantDelegate(libkb.UIKind) bool
 }
 
-func runPrereqs(e Engine, ctx *Context) (err error) {
+func runPrereqs(e Engine, ctx *Context) error {
 	prq := e.Prereqs()
 
 	if prq.TemporarySession {
@@ -36,18 +36,16 @@ func runPrereqs(e Engine, ctx *Context) (err error) {
 	}
 
 	if prq.Device {
-		var ok bool
-		ok, err = IsProvisioned(e, ctx)
+		ok, _, err := IsLoggedIn(e, ctx)
 		if err != nil {
 			return err
 		}
 		if !ok {
-			err = libkb.DeviceRequiredError{}
-			return err
+			return libkb.DeviceRequiredError{}
 		}
 	}
 
-	return
+	return nil
 
 }
 

--- a/go/engine/fakeusers_test.go
+++ b/go/engine/fakeusers_test.go
@@ -117,7 +117,7 @@ func createFakeUserWithPGPPubOnly(t *testing.T, tc libkb.TestContext) *FakeUser 
 			return err
 		}
 
-		return s.addGPG(a, ctx, false)
+		return s.addGPG(a, ctx, false, false)
 	}
 	if err := s.G().LoginState().ExternalFunc(f, "createFakeUserWithPGPPubOnly"); err != nil {
 		t.Fatal(err)
@@ -158,13 +158,13 @@ func createFakeUserWithPGPMult(t *testing.T, tc libkb.TestContext) *FakeUser {
 			return err
 		}
 
-		if err := s.addGPG(a, ctx, false); err != nil {
+		if err := s.addGPG(a, ctx, false, false); err != nil {
 			return err
 		}
 
 		// hack the gpg ui to select a different key:
 		ctx.GPGUI = &gpgtestui{index: 1}
-		return s.addGPG(a, ctx, true)
+		return s.addGPG(a, ctx, true, false)
 	}
 
 	if err := s.G().LoginState().ExternalFunc(f, "createFakeUserWithPGPPubMult"); err != nil {
@@ -209,7 +209,7 @@ func createFakeUserWithPGPMultSubset(t *testing.T, tc libkb.TestContext, alterna
 		}
 
 		// this will add the GPG key for fu.Email to their account
-		return s.addGPG(a, ctx, false)
+		return s.addGPG(a, ctx, false, false)
 	}
 
 	if err := s.G().LoginState().ExternalFunc(f, "createFakeUserWithPGPMultSubset"); err != nil {

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -20,13 +20,14 @@ import (
 )
 
 type GPGImportKeyArg struct {
-	Query      string
-	Signer     libkb.GenericKey
-	AllowMulti bool
-	SkipImport bool
-	OnlyImport bool
-	Me         *libkb.User
-	Lks        *libkb.LKSec
+	Query                string
+	Signer               libkb.GenericKey
+	AllowMulti           bool
+	SkipImport           bool
+	OnlyImport           bool
+	HasProvisionedDevice bool
+	Me                   *libkb.User
+	Lks                  *libkb.LKSec
 }
 
 type GPGImportKeyEngine struct {
@@ -44,9 +45,10 @@ func NewGPGImportKeyEngine(arg *GPGImportKeyArg, g *libkb.GlobalContext) *GPGImp
 }
 
 func (e *GPGImportKeyEngine) Prereqs() Prereqs {
-	return Prereqs{
-		Session: true,
+	if !e.arg.HasProvisionedDevice {
+		return Prereqs{TemporarySession: true}
 	}
+	return Prereqs{Device: true}
 }
 
 func (e *GPGImportKeyEngine) Name() string {

--- a/go/engine/hasserverkeys.go
+++ b/go/engine/hasserverkeys.go
@@ -29,7 +29,7 @@ func (e *HasServerKeys) Name() string {
 // Prereqs returns the engine prereqs.
 func (e *HasServerKeys) Prereqs() Prereqs {
 	return Prereqs{
-		Session: true,
+		Device: true,
 	}
 }
 

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -889,7 +889,7 @@ func (e *Identify2WithUID) loadUsers(ctx *Context) error {
 	var loadMeErr, loadThemErr error
 
 	var selfLoad bool
-	loggedIn, myUID, _ := IsLoggedIn(e, ctx)
+	loggedIn, myUID := IsLoggedIn(e, ctx)
 
 	var wg sync.WaitGroup
 	if loggedIn {

--- a/go/engine/list_trackers.go
+++ b/go/engine/list_trackers.go
@@ -46,7 +46,7 @@ func (e *ListTrackersEngine) Prereqs() Prereqs {
 	if e.uid.IsNil() && len(e.username) == 0 {
 		session = true
 	}
-	return Prereqs{Session: session}
+	return Prereqs{Device: session}
 }
 
 // RequiredUIs returns the required UIs.

--- a/go/engine/list_trackers2.go
+++ b/go/engine/list_trackers2.go
@@ -33,7 +33,7 @@ func (e *ListTrackers2Engine) Prereqs() Prereqs {
 	if len(e.arg.Assertion) == 0 {
 		session = true
 	}
-	return Prereqs{Session: session}
+	return Prereqs{Device: session}
 }
 
 func (e *ListTrackers2Engine) RequiredUIs() []libkb.UIKind {

--- a/go/engine/paperkey_primary.go
+++ b/go/engine/paperkey_primary.go
@@ -45,7 +45,7 @@ func (e *PaperKeyPrimary) Name() string {
 // GetPrereqs returns the engine prereqs.
 func (e *PaperKeyPrimary) Prereqs() Prereqs {
 	return Prereqs{
-		Session: true,
+		Device: true,
 	}
 }
 

--- a/go/engine/passphrase_change.go
+++ b/go/engine/passphrase_change.go
@@ -42,7 +42,7 @@ func (c *PassphraseChange) Prereqs() Prereqs {
 		return Prereqs{}
 	}
 
-	return Prereqs{Session: true}
+	return Prereqs{Device: true}
 }
 
 // RequiredUIs returns the required UIs.

--- a/go/engine/pgp_decrypt_test.go
+++ b/go/engine/pgp_decrypt_test.go
@@ -27,7 +27,7 @@ func decengctx(fu *FakeUser, tc libkb.TestContext) *Context {
 func TestPGPDecrypt(t *testing.T) {
 	tc := SetupEngineTest(t, "PGPDecrypt")
 	defer tc.Cleanup()
-	fu := createFakeUserWithPGPOnly(t, tc)
+	fu := createFakeUserWithPGPSibkeyPushed(tc)
 
 	// encrypt a message
 	msg := "10 days in Japan"
@@ -70,7 +70,7 @@ func TestPGPDecrypt(t *testing.T) {
 func TestPGPDecryptArmored(t *testing.T) {
 	tc := SetupEngineTest(t, "PGPDecrypt")
 	defer tc.Cleanup()
-	fu := createFakeUserWithPGPOnly(t, tc)
+	fu := createFakeUserWithPGPSibkeyPushed(tc)
 
 	// encrypt a message
 	msg := "10 days in Japan"
@@ -130,7 +130,7 @@ END KEYBASE SALTPACK ENCRYPTED MESSAGE.`
 func TestPGPDecryptSignedSelf(t *testing.T) {
 	tc := SetupEngineTest(t, "PGPDecrypt")
 	defer tc.Cleanup()
-	fu := createFakeUserWithPGPOnly(t, tc)
+	fu := createFakeUserWithPGPSibkeyPushed(tc)
 
 	// encrypt a message
 	msg := "We pride ourselves on being meticulous; no issue is too small."

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -65,7 +65,7 @@ func (e *PGPEncrypt) SubConsumers() []libkb.UIConsumer {
 // Run starts the engine.
 func (e *PGPEncrypt) Run(ctx *Context) error {
 	// verify valid options based on logged in state:
-	ok, uid, _ := IsLoggedIn(e, ctx)
+	ok, uid := IsLoggedIn(e, ctx)
 
 	if !ok {
 		// not logged in.  this is fine, unless they requested signing the message.

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -65,10 +65,7 @@ func (e *PGPEncrypt) SubConsumers() []libkb.UIConsumer {
 // Run starts the engine.
 func (e *PGPEncrypt) Run(ctx *Context) error {
 	// verify valid options based on logged in state:
-	ok, uid, err := IsLoggedIn(e, ctx)
-	if err != nil {
-		return err
-	}
+	ok, uid, _ := IsLoggedIn(e, ctx)
 
 	if !ok {
 		// not logged in.  this is fine, unless they requested signing the message.

--- a/go/engine/pgp_export_key.go
+++ b/go/engine/pgp_export_key.go
@@ -37,7 +37,7 @@ type PGPKeyExportEngine struct {
 
 func (e *PGPKeyExportEngine) Prereqs() Prereqs {
 	return Prereqs{
-		Session: true,
+		Device: true,
 	}
 }
 

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -188,7 +188,7 @@ func (e *PGPPullEngine) Run(ctx *Context) error {
 		return err
 	}
 
-	if ok, _, _ := IsLoggedIn(e, ctx); !ok {
+	if ok, _ := IsLoggedIn(e, ctx); !ok {
 		return e.runLoggedOut(ctx)
 	}
 

--- a/go/engine/pgp_sign.go
+++ b/go/engine/pgp_sign.go
@@ -27,7 +27,7 @@ type PGPSignArg struct {
 
 func (p *PGPSignEngine) Prereqs() Prereqs {
 	return Prereqs{
-		Session: true,
+		Device: true,
 	}
 }
 

--- a/go/engine/pgp_sign_test.go
+++ b/go/engine/pgp_sign_test.go
@@ -26,7 +26,15 @@ var signTests = []signTest{
 func TestPGPSign(t *testing.T) {
 	tc := SetupEngineTest(t, "pgp_sign")
 	defer tc.Cleanup()
-	fu := createFakeUserWithPGPOnly(t, tc)
+	fu := createFakeUserWithPGPSibkeyPushed(tc)
+
+	if err := fu.LoadUser(tc); err != nil {
+		t.Fatal(err)
+	}
+
+	if fu.User == nil {
+		t.Fatal("got a nil User")
+	}
 
 	skb, err := fu.User.GetSyncedSecretKey()
 	if err != nil {

--- a/go/engine/pgp_update.go
+++ b/go/engine/pgp_update.go
@@ -35,7 +35,7 @@ func (e *PGPUpdateEngine) Name() string {
 
 func (e *PGPUpdateEngine) Prereqs() Prereqs {
 	return Prereqs{
-		Session: true,
+		Device: true,
 	}
 }
 

--- a/go/engine/prove_check.go
+++ b/go/engine/prove_check.go
@@ -38,7 +38,7 @@ func (e *ProveCheck) Name() string {
 
 // GetPrereqs returns the engine prereqs.
 func (e *ProveCheck) Prereqs() Prereqs {
-	return Prereqs{Session: true}
+	return Prereqs{Device: true}
 }
 
 // RequiredUIs returns the required UIs.

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -70,13 +70,10 @@ func (e *ResolveThenIdentify2) resolveUID(ctx *Context) (err error) {
 
 	// if no uid and no assertion, then if logged in use self uid:
 	if len(e.arg.UserAssertion) == 0 && e.arg.AllowEmptySelfID {
-		ok, uid, err := IsLoggedIn(e, ctx)
+		ok, uid, _ := IsLoggedIn(e, ctx)
 		if ok {
 			e.arg.Uid = uid
 			return nil
-		}
-		if err != nil {
-			return err
 		}
 		return libkb.LoginRequiredError{Context: "to identify without specifying a user assertion"}
 	}

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -70,7 +70,7 @@ func (e *ResolveThenIdentify2) resolveUID(ctx *Context) (err error) {
 
 	// if no uid and no assertion, then if logged in use self uid:
 	if len(e.arg.UserAssertion) == 0 && e.arg.AllowEmptySelfID {
-		ok, uid, _ := IsLoggedIn(e, ctx)
+		ok, uid := IsLoggedIn(e, ctx)
 		if ok {
 			e.arg.Uid = uid
 			return nil

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -93,7 +93,7 @@ func (e *SaltpackEncrypt) loadMyPublicKeys() ([]libkb.NaclDHKeyPublic, error) {
 }
 
 func (e *SaltpackEncrypt) loadMe(ctx *Context) error {
-	loggedIn, uid, err := IsLoggedIn(e, ctx)
+	loggedIn, uid, err := IsLoggedInWithError(e, ctx)
 	if err != nil && !e.arg.Opts.NoSelfEncrypt {
 		return err
 	}

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -94,8 +94,11 @@ func (e *SaltpackEncrypt) loadMyPublicKeys() ([]libkb.NaclDHKeyPublic, error) {
 
 func (e *SaltpackEncrypt) loadMe(ctx *Context) error {
 	loggedIn, uid, err := IsLoggedIn(e, ctx)
-	if err != nil || !loggedIn {
+	if err != nil && !e.arg.Opts.NoSelfEncrypt {
 		return err
+	}
+	if !loggedIn {
+		return nil
 	}
 	e.me, err = libkb.LoadMeByUID(ctx.GetNetContext(), e.G(), uid)
 	return err

--- a/go/engine/saltpack_encrypt_test.go
+++ b/go/engine/saltpack_encrypt_test.go
@@ -331,8 +331,8 @@ func TestSaltpackEncryptSelfNoKey(t *testing.T) {
 	eng := NewSaltpackEncrypt(arg, tc.G)
 	eng.skipTLFKeysForTesting = true
 	err := RunEngine(eng, ctx)
-	if _, ok := err.(libkb.NoKeyError); !ok {
-		t.Fatalf("expected error type libkb.NoKeyError, got %T (%s)", err, err)
+	if _, ok := err.(libkb.NoDeviceError); !ok {
+		t.Fatalf("expected error type libkb.NoDeviceError, got %T (%s)", err, err)
 	}
 }
 

--- a/go/engine/saltpack_sender_identify.go
+++ b/go/engine/saltpack_sender_identify.go
@@ -126,7 +126,7 @@ func (e *SaltpackSenderIdentify) identifySender(ctx *Context) (err error) {
 
 	var lin bool
 	var uid keybase1.UID
-	if lin, uid, _ = IsLoggedIn(e, ctx); lin && uid.Equal(e.res.Uid) {
+	if lin, uid = IsLoggedIn(e, ctx); lin && uid.Equal(e.res.Uid) {
 		e.res.SenderType = keybase1.SaltpackSenderType_SELF
 		if len(e.arg.userAssertion) == 0 {
 			e.G().Log.Debug("| Sender is self")

--- a/go/engine/saltpack_sender_identify.go
+++ b/go/engine/saltpack_sender_identify.go
@@ -126,7 +126,7 @@ func (e *SaltpackSenderIdentify) identifySender(ctx *Context) (err error) {
 
 	var lin bool
 	var uid keybase1.UID
-	if lin, uid, err = IsLoggedIn(e, ctx); err == nil && lin && uid.Equal(e.res.Uid) {
+	if lin, uid, _ = IsLoggedIn(e, ctx); lin && uid.Equal(e.res.Uid) {
 		e.res.SenderType = keybase1.SaltpackSenderType_SELF
 		if len(e.arg.userAssertion) == 0 {
 			e.G().Log.Debug("| Sender is self")

--- a/go/engine/user_config.go
+++ b/go/engine/user_config.go
@@ -32,9 +32,7 @@ func (e *UserConfigEngine) Name() string {
 }
 
 func (e *UserConfigEngine) Prereqs() Prereqs {
-	return Prereqs{
-		Session: true,
-	}
+	return Prereqs{Device: true}
 }
 
 func (e *UserConfigEngine) RequiredUIs() []libkb.UIKind {

--- a/go/libkb/bootstrap_active_device.go
+++ b/go/libkb/bootstrap_active_device.go
@@ -95,6 +95,11 @@ func bootstrapActiveDeviceReturnRawError(ctx context.Context, g *GlobalContext, 
 		return err
 	}
 
+	if upak.Current.Status == keybase1.StatusCode_SCDeleted {
+		g.Log.CDebugf(ctx, "User %s was deleted", uid)
+		return UserDeletedError{}
+	}
+
 	// find the sibkey
 	sibkeyKID, deviceName := upak.Current.FindSigningDeviceKID(deviceID)
 	if sibkeyKID.IsNil() {


### PR DESCRIPTION
- there used to be 2 prereqs: Session and Device. They are now treated the same, and we introduce a new Prereq, which is TemporarySession, only useful during signup/login
- change IsLoggedIn to just plug into the bootstrap active device stuff
- fix lots and lots of tests