### PR TITLE
Make stellar link 'name' field optional

### DIFF
--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -915,9 +915,12 @@ func ParseWalletStellarChainLink(b GenericChainLink) (ret *WalletStellarChainLin
 	if err != nil {
 		return nil, mkErr("Can't get address network: %v", err)
 	}
-	ret.name, err = walletSection.AtKey("name").GetString()
-	if err != nil {
-		return nil, mkErr("Can't get account name: %v", err)
+	nameOption := walletSection.AtKey("name")
+	if !nameOption.IsNil() {
+		ret.name, err = nameOption.GetString()
+		if err != nil {
+			return nil, mkErr("Can't get account name: %v", err)
+		}
 	}
 
 	// Check the network and that the keys match.

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -805,7 +805,6 @@ func StellarProof(me *User, walletAddress stellar1.AccountID,
 	}
 
 	walletSection := jsonw.NewDictionary()
-	walletSection.SetKey("name", jsonw.NewString(""))
 	walletSection.SetKey("address", jsonw.NewString(walletAddress.String()))
 	walletSection.SetKey("network", jsonw.NewString(string(WalletNetworkStellar)))
 

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -60,6 +60,7 @@ func TestCreateWallet(t *testing.T) {
 	require.NoError(t, err)
 	addr := u0.StellarWalletAddress()
 	t.Logf("Found account: %v", addr)
+	require.NotNil(t, addr)
 	_, err = libkb.MakeNaclSigningKeyPairFromStellarAccountID(*addr)
 	require.NoError(t, err, "stellar key should be nacl pubable")
 	require.Equal(t, bundle.Accounts[0].AccountID.String(), addr.String(), "addr looked up should match secret bundle")


### PR DESCRIPTION
Don't post 'name' and don't complain if it's missing.

Clients before this patch will not be able to parse links created after this patch. They do recognize the type, though, so they do not fail to load the sigchain. Instead they fail to load the link, which means they issue a warning whenever parsing the sigchain and miss the fact that there's a stellar address in there.

```
$ kbu id st11
▶ WARNING Error in parsing chain Link: Can't get account name: <root>.body.wallet.name: no such key: name @uid=ff750b9880347da6d244c5dcae554b19, seq=6, link=efac615f23f387c60b9f01a67d63d5efa191fca97c39e509ffc5cc18c7bd2549 [tags:ID2
=s7DlV_4M7aZv,LU=7fbZAX4Fs4r7]
▶ INFO Identifying st11
```

```
$ kbu wallet send st11 0.001 USD
Current exchange rate: ~ 0.359039 USD / XLM
Send 0.0027852 XLM (~0.001 USD) to st11? (type 'YES' to confirm): YES
▶ WARNING Error in parsing chain Link: Can't get account name: <root>.body.wallet.name: no such key: name @uid=ff750b9880347da6d244c5dcae554b19, seq=6, link=efac615f23f387c60b9f01a67d63d5efa191fca97c39e509ffc5cc18c7bd2549 [tags:LU=
T5VV_2jkCMdm]
▶ WARNING not exportable error: keybase user st11 does not have a stellar wallet (*errors.errorString)
▶ ERROR keybase user st11 does not have a stellar wallet
client git:(master)
```