### PR TITLE
Explain team name being invalid on team join screen

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -69,7 +69,11 @@ const _joinTeam = function*(action: TeamsGen.JoinTeamPayload) {
       })
     )
   } catch (error) {
-    yield Saga.put(TeamsGen.createSetTeamJoinError({error: error.desc}))
+    const desc =
+      error.code === RPCTypes.constantsStatusCode.scteaminvitebadtoken
+        ? 'Sorry, that team name or token is not valid.'
+        : error.desc
+    yield Saga.put(TeamsGen.createSetTeamJoinError({error: desc}))
   }
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

When the error joining a team is TEAM_INVITE_BAD_TOKEN, it comes through with no error.desc, so we don't have a description string to send the user.

If we prefer, I could try to get this string sent back from the server instead of hardcoding it here.