### PR TITLE
Add PaymentDetail RPC (protocol skeleton)

### DIFF
--- a/go/protocol/stellar1/extras.go
+++ b/go/protocol/stellar1/extras.go
@@ -28,6 +28,10 @@ func (k KeybaseTransactionID) String() string {
 	return string(k)
 }
 
+func (t TransactionID) String() string {
+	return string(t)
+}
+
 func ToTimeMs(t time.Time) TimeMs {
 	// the result of calling UnixNano on the zero Time is undefined.
 	// https://golang.org/pkg/time/#Time.UnixNano

--- a/go/protocol/stellar1/remote.go
+++ b/go/protocol/stellar1/remote.go
@@ -83,60 +83,6 @@ func (o Operation) DeepCopy() Operation {
 	}
 }
 
-type TransactionDetails struct {
-	StellarID             TransactionID        `codec:"stellarID" json:"stellarID"`
-	KeybaseID             KeybaseTransactionID `codec:"keybaseID" json:"keybaseID"`
-	Hash                  string               `codec:"Hash" json:"Hash"`
-	Ledger                int                  `codec:"ledger" json:"ledger"`
-	LedgerCloseTime       int                  `codec:"ledgerCloseTime" json:"ledgerCloseTime"`
-	SourceAccount         AccountID            `codec:"sourceAccount" json:"sourceAccount"`
-	SourceAccountSequence string               `codec:"sourceAccountSequence" json:"sourceAccountSequence"`
-	FeePaid               int                  `codec:"feePaid" json:"feePaid"`
-	Members               Members              `codec:"members" json:"members"`
-	NoteB64               string               `codec:"noteB64" json:"noteB64"`
-	Signatures            []string             `codec:"signatures" json:"signatures"`
-	Operations            []Operation          `codec:"operations" json:"operations"`
-	Ctime                 TimeMs               `codec:"ctime" json:"ctime"`
-}
-
-func (o TransactionDetails) DeepCopy() TransactionDetails {
-	return TransactionDetails{
-		StellarID:             o.StellarID.DeepCopy(),
-		KeybaseID:             o.KeybaseID.DeepCopy(),
-		Hash:                  o.Hash,
-		Ledger:                o.Ledger,
-		LedgerCloseTime:       o.LedgerCloseTime,
-		SourceAccount:         o.SourceAccount.DeepCopy(),
-		SourceAccountSequence: o.SourceAccountSequence,
-		FeePaid:               o.FeePaid,
-		Members:               o.Members.DeepCopy(),
-		NoteB64:               o.NoteB64,
-		Signatures: (func(x []string) []string {
-			if x == nil {
-				return nil
-			}
-			var ret []string
-			for _, v := range x {
-				vCopy := v
-				ret = append(ret, vCopy)
-			}
-			return ret
-		})(o.Signatures),
-		Operations: (func(x []Operation) []Operation {
-			if x == nil {
-				return nil
-			}
-			var ret []Operation
-			for _, v := range x {
-				vCopy := v.DeepCopy()
-				ret = append(ret, vCopy)
-			}
-			return ret
-		})(o.Operations),
-		Ctime: o.Ctime.DeepCopy(),
-	}
-}
-
 type PaymentPost struct {
 	StellarAccountSeqno uint64  `codec:"stellarAccountSeqno" json:"stellarAccountSeqno"`
 	Members             Members `codec:"members" json:"members"`
@@ -262,9 +208,9 @@ type RecentPaymentsArg struct {
 	Limit     int                  `codec:"limit" json:"limit"`
 }
 
-type TransactionArg struct {
+type PaymentDetailArg struct {
 	Caller keybase1.UserVersion `codec:"caller" json:"caller"`
-	Id     TransactionID        `codec:"id" json:"id"`
+	TxID   string               `codec:"txID" json:"txID"`
 }
 
 type AccountSeqnoArg struct {
@@ -285,7 +231,7 @@ type IsMasterKeyActiveArg struct {
 type RemoteInterface interface {
 	Balances(context.Context, BalancesArg) ([]Balance, error)
 	RecentPayments(context.Context, RecentPaymentsArg) ([]PaymentSummary, error)
-	Transaction(context.Context, TransactionArg) (TransactionDetails, error)
+	PaymentDetail(context.Context, PaymentDetailArg) (PaymentSummary, error)
 	AccountSeqno(context.Context, AccountSeqnoArg) (string, error)
 	SubmitPayment(context.Context, SubmitPaymentArg) (PaymentResult, error)
 	IsMasterKeyActive(context.Context, IsMasterKeyActiveArg) (bool, error)
@@ -327,18 +273,18 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"transaction": {
+			"paymentDetail": {
 				MakeArg: func() interface{} {
-					ret := make([]TransactionArg, 1)
+					ret := make([]PaymentDetailArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]TransactionArg)
+					typedArgs, ok := args.(*[]PaymentDetailArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]TransactionArg)(nil), args)
+						err = rpc.NewTypeError((*[]PaymentDetailArg)(nil), args)
 						return
 					}
-					ret, err = i.Transaction(ctx, (*typedArgs)[0])
+					ret, err = i.PaymentDetail(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -409,8 +355,8 @@ func (c RemoteClient) RecentPayments(ctx context.Context, __arg RecentPaymentsAr
 	return
 }
 
-func (c RemoteClient) Transaction(ctx context.Context, __arg TransactionArg) (res TransactionDetails, err error) {
-	err = c.Cli.Call(ctx, "stellar.1.remote.transaction", []interface{}{__arg}, &res)
+func (c RemoteClient) PaymentDetail(ctx context.Context, __arg PaymentDetailArg) (res PaymentSummary, err error) {
+	err = c.Cli.Call(ctx, "stellar.1.remote.paymentDetail", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/stellar/remote/interface.go
+++ b/go/stellar/remote/interface.go
@@ -12,4 +12,5 @@ type Remoter interface {
 	Balances(ctx context.Context, accountID stellar1.AccountID) ([]stellar1.Balance, error)
 	SubmitTransaction(ctx context.Context, payload libkb.JSONPayload) (stellar1.PaymentResult, error)
 	RecentPayments(ctx context.Context, accountID stellar1.AccountID, limit int) (res []stellar1.PaymentSummary, err error)
+	PaymentDetail(ctx context.Context, txID string) (res stellar1.PaymentSummary, err error)
 }

--- a/go/stellar/remote/remote_net.go
+++ b/go/stellar/remote/remote_net.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
@@ -10,6 +11,8 @@ import (
 type RemoteNet struct {
 	libkb.Contextified
 }
+
+var _ Remoter = (*RemoteNet)(nil)
 
 func NewRemoteNet(g *libkb.GlobalContext) *RemoteNet {
 	return &RemoteNet{Contextified: libkb.NewContextified(g)}
@@ -29,4 +32,8 @@ func (r *RemoteNet) SubmitTransaction(ctx context.Context, payload libkb.JSONPay
 
 func (r *RemoteNet) RecentPayments(ctx context.Context, accountID stellar1.AccountID, limit int) (res []stellar1.PaymentSummary, err error) {
 	return RecentPayments(ctx, r.G(), accountID, limit)
+}
+
+func (r *RemoteNet) PaymentDetail(ctx context.Context, txID string) (res stellar1.PaymentSummary, err error) {
+	return res, fmt.Errorf("TODO (CORE-7554)")
 }

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -318,14 +318,14 @@ func GetOwnPrimaryAccountID(ctx context.Context, g *libkb.GlobalContext) (res st
 	return primary.AccountID, nil
 }
 
-func RecentPaymentsCLILocal(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter, accountID stellar1.AccountID) (res []stellar1.RecentPaymentCLILocal, err error) {
+func RecentPaymentsCLILocal(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter, accountID stellar1.AccountID) (res []stellar1.PaymentCLILocal, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.RecentPaymentsCLILocal", func() error { return err })()
 	payments, err := remoter.RecentPayments(ctx, accountID, 0)
 	if err != nil {
 		return nil, err
 	}
 	for _, x := range payments {
-		y := stellar1.RecentPaymentCLILocal{
+		y := stellar1.PaymentCLILocal{
 			StellarTxID: x.StellarTxID,
 			Status:      "pending",
 			Amount:      x.Amount,
@@ -389,4 +389,9 @@ func RecentPaymentsCLILocal(ctx context.Context, g *libkb.GlobalContext, remoter
 		res = append(res, y)
 	}
 	return res, nil
+}
+
+func PaymentDetailCLILocal(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter, txID string) (res stellar1.PaymentCLILocal, err error) {
+	defer g.CTraceTimed(ctx, "Stellar.PaymentDetailCLILocal", func() error { return err })()
+	return res, fmt.Errorf("TODO (CORE-7554)")
 }

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -191,6 +191,10 @@ func (r *RemoteMock) RecentPayments(ctx context.Context, accountID stellar1.Acco
 	return txLog.Filter(accountID, limit), nil
 }
 
+func (r *RemoteMock) PaymentDetail(ctx context.Context, txID string) (res stellar1.PaymentSummary, err error) {
+	return res, fmt.Errorf("TODO (CORE-7554)")
+}
+
 func (r *RemoteMock) AddAccount(t *testing.T) stellar1.AccountID {
 	full, err := keypair.Random()
 	if err != nil {

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -86,7 +86,7 @@ func (s *Server) SendLocal(ctx context.Context, arg stellar1.SendLocalArg) (stel
 	return stellar.SendPayment(ctx, s.G(), s.remoter, stellar.RecipientInput(arg.Recipient), arg.Amount, arg.Note)
 }
 
-func (s *Server) RecentPaymentsCLILocal(ctx context.Context, accountID *stellar1.AccountID) (res []stellar1.RecentPaymentCLILocal, err error) {
+func (s *Server) RecentPaymentsCLILocal(ctx context.Context, accountID *stellar1.AccountID) (res []stellar1.PaymentCLILocal, err error) {
 	ctx = s.logTag(ctx)
 	defer s.G().CTraceTimed(ctx, "RecentPaymentsCLILocal", func() error { return err })()
 	if err = s.assertLoggedIn(ctx); err != nil {
@@ -102,6 +102,15 @@ func (s *Server) RecentPaymentsCLILocal(ctx context.Context, accountID *stellar1
 		selectAccountID = *accountID
 	}
 	return stellar.RecentPaymentsCLILocal(ctx, s.G(), s.remoter, selectAccountID)
+}
+
+func (s *Server) PaymentDetailCLILocal(ctx context.Context, txID string) (res stellar1.PaymentCLILocal, err error) {
+	ctx = s.logTag(ctx)
+	defer s.G().CTraceTimed(ctx, "PaymentDetailCLILocal", func() error { return err })()
+	if err = s.assertLoggedIn(ctx); err != nil {
+		return res, err
+	}
+	return stellar.PaymentDetailCLILocal(ctx, s.G(), s.remoter, txID)
 }
 
 func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.Bundle, err error) {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -300,7 +300,7 @@ func TestRecentPaymentsLocal(t *testing.T) {
 	_, err = srvSender.SendLocal(context.Background(), arg)
 	require.NoError(t, err)
 
-	checkPayment := func(payment stellar1.RecentPaymentCLILocal) {
+	checkPayment := func(payment stellar1.PaymentCLILocal) {
 		require.Equal(t, accountIDSender, payment.FromStellar)
 		require.Equal(t, accountIDRecip, payment.ToStellar)
 		require.NotNil(t, payment.ToUsername)

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -6,7 +6,7 @@ protocol local {
 
   PaymentResult sendLocal(string recipient, string amount, Asset asset, string note);
 
-  record RecentPaymentCLILocal {
+  record PaymentCLILocal {
     TransactionID stellarTxID;
     TimeMs time;
     string status;
@@ -23,7 +23,10 @@ protocol local {
     string note;
     string noteErr;
   }
-  array<RecentPaymentCLILocal> recentPaymentsCLILocal(union { null, AccountID } accountID);
+  array<PaymentCLILocal> recentPaymentsCLILocal(union { null, AccountID } accountID);
+
+  // txID can be either a keybase or stellar transaction ID.
+  PaymentCLILocal paymentDetailCLILocal(string txID);
 
   void walletInitLocal();
 

--- a/protocol/avdl/stellar1/remote.avdl
+++ b/protocol/avdl/stellar1/remote.avdl
@@ -43,24 +43,6 @@ protocol remote {
     string amount;
   }
 
-  record TransactionDetails {
-    TransactionID stellarID;
-    KeybaseTransactionID keybaseID;
-    string Hash;
-    int ledger;
-    int ledgerCloseTime;
-    AccountID sourceAccount;
-    string sourceAccountSequence;
-    int feePaid;
-
-    Members members;
-    string noteB64; // b64-encoded EncryptedNote or empty string.
-    array<string> signatures;
-    array<Operation> operations;
-
-    TimeMs ctime;
-  }
-
   record PaymentPost {
     uint64 stellarAccountSeqno;
 
@@ -107,11 +89,15 @@ protocol remote {
   }
 
   array<Balance> balances(keybase1.UserVersion caller, AccountID accountID);
+
   array<PaymentSummary> recentPayments(keybase1.UserVersion caller, AccountID accountID, int limit);
-  TransactionDetails transaction(keybase1.UserVersion caller, TransactionID id);
+
+  // txID can be either a keybase or stellar transaction ID.
+  PaymentSummary paymentDetail(keybase1.UserVersion caller, string txID);
 
   // js can't handle uint64, so returning a string
   string accountSeqno(keybase1.UserVersion caller, AccountID accountID);
+
   PaymentResult submitPayment(keybase1.UserVersion caller, PaymentPost payment);
 
   // ask the stellar network whether the master key for the account has power

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -9,7 +9,7 @@
   "types": [
     {
       "type": "record",
-      "name": "RecentPaymentCLILocal",
+      "name": "PaymentCLILocal",
       "fields": [
         {
           "type": "TransactionID",
@@ -160,8 +160,17 @@
       ],
       "response": {
         "type": "array",
-        "items": "RecentPaymentCLILocal"
+        "items": "PaymentCLILocal"
       }
+    },
+    "paymentDetailCLILocal": {
+      "request": [
+        {
+          "name": "txID",
+          "type": "string"
+        }
+      ],
+      "response": "PaymentCLILocal"
     },
     "walletInitLocal": {
       "request": [],

--- a/protocol/json/stellar1/remote.json
+++ b/protocol/json/stellar1/remote.json
@@ -132,70 +132,6 @@
     },
     {
       "type": "record",
-      "name": "TransactionDetails",
-      "fields": [
-        {
-          "type": "TransactionID",
-          "name": "stellarID"
-        },
-        {
-          "type": "KeybaseTransactionID",
-          "name": "keybaseID"
-        },
-        {
-          "type": "string",
-          "name": "Hash"
-        },
-        {
-          "type": "int",
-          "name": "ledger"
-        },
-        {
-          "type": "int",
-          "name": "ledgerCloseTime"
-        },
-        {
-          "type": "AccountID",
-          "name": "sourceAccount"
-        },
-        {
-          "type": "string",
-          "name": "sourceAccountSequence"
-        },
-        {
-          "type": "int",
-          "name": "feePaid"
-        },
-        {
-          "type": "Members",
-          "name": "members"
-        },
-        {
-          "type": "string",
-          "name": "noteB64"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "string"
-          },
-          "name": "signatures"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "Operation"
-          },
-          "name": "operations"
-        },
-        {
-          "type": "TimeMs",
-          "name": "ctime"
-        }
-      ]
-    },
-    {
-      "type": "record",
       "name": "PaymentPost",
       "fields": [
         {
@@ -375,18 +311,18 @@
         "items": "PaymentSummary"
       }
     },
-    "transaction": {
+    "paymentDetail": {
       "request": [
         {
           "name": "caller",
           "type": "keybase1.UserVersion"
         },
         {
-          "name": "id",
-          "type": "TransactionID"
+          "name": "txID",
+          "type": "string"
         }
       ],
-      "response": "TransactionDetails"
+      "response": "PaymentSummary"
     },
     "accountSeqno": {
       "request": [


### PR DESCRIPTION
Add new local and remote rpcs for getting payment details. Returns the same type as RecentPayments. This PR is enough to vendor into the server, but just returns TODO errors.