### PR TITLE
Add CLI command 'keybase wallet detail <txid>'

### DIFF
--- a/go/client/cmd_wallet.go
+++ b/go/client/cmd_wallet.go
@@ -9,6 +9,7 @@ import (
 func newCmdWallet(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	subcommands := []cli.Command{
 		newCmdWalletBalances(cl, g),
+		newCmdWalletDetail(cl, g),
 		newCmdWalletHistory(cl, g),
 		newCmdWalletImport(cl, g),
 		newCmdWalletSend(cl, g),

--- a/go/client/cmd_wallet_detail.go
+++ b/go/client/cmd_wallet_detail.go
@@ -1,0 +1,66 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"golang.org/x/net/context"
+)
+
+type cmdWalletDetail struct {
+	libkb.Contextified
+	TxID string
+}
+
+func newCmdWalletDetail(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	cmd := &cmdWalletDetail{
+		Contextified: libkb.NewContextified(g),
+	}
+	return cli.Command{
+		Name:         "detail",
+		Aliases:      []string{"details"},
+		Usage:        "Show payment details",
+		ArgumentHelp: "<transaction ID>",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(cmd, "detail", c)
+		},
+	}
+}
+
+func (c *cmdWalletDetail) ParseArgv(ctx *cli.Context) (err error) {
+	if len(ctx.Args()) == 0 {
+		return errors.New("expected a tx ID (run 'keybase wallet history -v' to find one)")
+	}
+	if len(ctx.Args()) != 1 {
+		return errors.New("expected one argument")
+	}
+	c.TxID = ctx.Args()[0]
+	return nil
+}
+
+func (c *cmdWalletDetail) Run() (err error) {
+	cli, err := GetWalletClient(c.G())
+	if err != nil {
+		return err
+	}
+	detail, err := cli.PaymentDetailCLILocal(context.TODO(), c.TxID)
+	if err != nil {
+		return err
+	}
+	dui := c.G().UI.GetDumbOutputUI()
+	printPayment(c.G(), detail, true, dui)
+	return nil
+}
+
+func (c *cmdWalletDetail) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/client/cmd_wallet_history.go
+++ b/go/client/cmd_wallet_history.go
@@ -5,7 +5,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/keybase/cli"
@@ -74,51 +73,8 @@ func (c *cmdWalletHistory) Run() (err error) {
 	line := func(format string, args ...interface{}) {
 		dui.Printf(format+"\n", args...)
 	}
-	for _, p := range payments {
-		timeStr := p.Time.Time().Format("2006/01/02 15:04")
-		line("%v", timeStr)
-		amount := fmt.Sprintf("%v XLM", libkb.StellarSimplifyAmount(p.Amount))
-		if !p.Asset.IsNativeXLM() {
-			amount = fmt.Sprintf("%v %v/%v", p.Amount, p.Asset.Code, p.Asset.Issuer)
-		}
-		if p.DisplayAmount != nil && p.DisplayCurrency != nil && len(*p.DisplayAmount) > 0 && len(*p.DisplayAmount) > 0 {
-			amount = fmt.Sprintf("%v %v (%v)", *p.DisplayAmount, *p.DisplayCurrency, amount)
-		}
-		line("%v", amount)
-		// Show sender and recipient. Prefer keybase form, fall back to stellar abbreviations.
-		from := p.FromStellar.LossyAbbreviation()
-		to := p.ToStellar.LossyAbbreviation()
-		if p.FromUsername != nil {
-			from = *p.FromUsername
-		}
-		if p.ToUsername != nil {
-			to = *p.ToUsername
-		}
-		showedAbbreviation := true
-		if p.FromUsername != nil && p.ToUsername != nil {
-			showedAbbreviation = false
-		}
-		line("%v -> %v", from, to)
-		// If an abbreviation was shown, show the full addresses
-		if showedAbbreviation || c.verbose {
-			line("From: %v", p.FromStellar.String())
-			line("To:   %v", p.ToStellar.String())
-		}
-		if len(p.Note) > 0 {
-			line("Note: %v", c.filterNote(p.Note))
-		}
-		if len(p.NoteErr) > 0 {
-			line("Note Error: %v", p.NoteErr)
-		}
-		if c.verbose {
-			line("Transaction Hash: %v", p.StellarTxID)
-		}
-		if len(p.Status) > 0 && p.Status != "completed" {
-			line("Status: %v", p.Status)
-			if c.verbose {
-				line("        %v", p.StatusDetail)
-			}
-		}
+	for i := len(payments) - 1; i >= 0; i-- {
+		printPayment(c.G(), payments[i], c.verbose, dui)
 		line("")
 	}
 	if len(payments) == 0 {

--- a/go/client/stellar_common.go
+++ b/go/client/stellar_common.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/stellar1"
+)
+
+func printPayment(g *libkb.GlobalContext, p stellar1.PaymentCLILocal, verbose bool, dui libkb.DumbOutputUI) {
+	line := func(format string, args ...interface{}) {
+		dui.Printf(format+"\n", args...)
+	}
+	timeStr := p.Time.Time().Format("2006/01/02 15:04")
+	line("%v", ColorString(g, "bold", timeStr))
+	amount := fmt.Sprintf("%v XLM", libkb.StellarSimplifyAmount(p.Amount))
+	if !p.Asset.IsNativeXLM() {
+		amount = fmt.Sprintf("%v %v/%v", p.Amount, p.Asset.Code, p.Asset.Issuer)
+	}
+	if p.DisplayAmount != nil && p.DisplayCurrency != nil && len(*p.DisplayAmount) > 0 && len(*p.DisplayAmount) > 0 {
+		amount = fmt.Sprintf("%v %v (%v)", *p.DisplayAmount, *p.DisplayCurrency, amount)
+	}
+	line("%v", ColorString(g, "green", amount))
+	// Show sender and recipient. Prefer keybase form, fall back to stellar abbreviations.
+	from := p.FromStellar.LossyAbbreviation()
+	to := p.ToStellar.LossyAbbreviation()
+	if p.FromUsername != nil {
+		from = *p.FromUsername
+	}
+	if p.ToUsername != nil {
+		to = *p.ToUsername
+	}
+	showedAbbreviation := true
+	if p.FromUsername != nil && p.ToUsername != nil {
+		showedAbbreviation = false
+	}
+	line("%v -> %v", from, to)
+	// If an abbreviation was shown, show the full addresses
+	if showedAbbreviation || verbose {
+		line("From: %v", p.FromStellar.String())
+		line("To:   %v", p.ToStellar.String())
+	}
+	if len(p.Note) > 0 {
+		line("Note: %v", ColorString(g, "yellow", printPaymentFilterNote(p.Note)))
+	}
+	if len(p.NoteErr) > 0 {
+		line("Note Error: %v", ColorString(g, "red", p.NoteErr))
+	}
+	if verbose {
+		line("Transaction Hash: %v", p.StellarTxID)
+	}
+	if len(p.Status) > 0 && p.Status != "completed" {
+		line("Status: %v", ColorString(g, "red", p.Status))
+		line("        %v", ColorString(g, "red", p.StatusDetail))
+	}
+}
+
+// printPaymentFilterNote: Pare down the note so that it's less likely to contain tricks.
+// Such as newlines and fake transactions.
+// Shows only the first line.
+func printPaymentFilterNote(note string) string {
+	lines := strings.Split(strings.TrimSpace(note), "\n")
+	if len(lines) < 1 {
+		return ""
+	}
+	return strings.TrimSpace(lines[0])
+}

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -286,7 +286,6 @@ type recentPaymentsResult struct {
 
 func RecentPayments(ctx context.Context, g *libkb.GlobalContext,
 	accountID stellar1.AccountID, limit int) (res []stellar1.PaymentSummary, err error) {
-	payload := make(libkb.JSONPayload)
 	apiArg := libkb.APIArg{
 		Endpoint:    "stellar/recentpayments",
 		SessionType: libkb.APISessionTypeREQUIRED,
@@ -294,10 +293,29 @@ func RecentPayments(ctx context.Context, g *libkb.GlobalContext,
 			"account_id": libkb.S{Val: accountID.String()},
 			"limit":      libkb.I{Val: limit},
 		},
-		JSONPayload: payload,
-		NetContext:  ctx,
+		NetContext: ctx,
 	}
 	var apiRes recentPaymentsResult
+	err = g.API.GetDecode(apiArg, &apiRes)
+	return apiRes.Result, err
+}
+
+type paymentDetailResult struct {
+	libkb.AppStatusEmbed
+	Result stellar1.PaymentSummary `json:"res"`
+}
+
+func PaymentDetail(ctx context.Context, g *libkb.GlobalContext,
+	txID string) (res stellar1.PaymentSummary, err error) {
+	apiArg := libkb.APIArg{
+		Endpoint:    "stellar/paymentdetail",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		Args: libkb.HTTPArgs{
+			"txID": libkb.S{Val: txID},
+		},
+		NetContext: ctx,
+	}
+	var apiRes paymentDetailResult
 	err = g.API.GetDecode(apiArg, &apiRes)
 	return apiRes.Result, err
 }

--- a/go/stellar/remote/remote_net.go
+++ b/go/stellar/remote/remote_net.go
@@ -2,7 +2,6 @@ package remote
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
@@ -35,5 +34,5 @@ func (r *RemoteNet) RecentPayments(ctx context.Context, accountID stellar1.Accou
 }
 
 func (r *RemoteNet) PaymentDetail(ctx context.Context, txID string) (res stellar1.PaymentSummary, err error) {
-	return res, fmt.Errorf("TODO (CORE-7554)")
+	return PaymentDetail(ctx, r.G(), txID)
 }

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -324,74 +324,82 @@ func RecentPaymentsCLILocal(ctx context.Context, g *libkb.GlobalContext, remoter
 	if err != nil {
 		return nil, err
 	}
-	for _, x := range payments {
-		y := stellar1.PaymentCLILocal{
-			StellarTxID: x.StellarTxID,
-			Status:      "pending",
-			Amount:      x.Amount,
-			Asset:       x.Asset,
-			FromStellar: x.From,
-			ToStellar:   x.To,
-		}
-		if x.Stellar != nil {
-			y.Status = "completed"
-		}
-		if x.Keybase != nil {
-			y.Time = x.Keybase.Ctime
-			switch x.Keybase.Status {
-			case stellar1.TransactionStatus_PENDING:
-				y.Status = "pending"
-			case stellar1.TransactionStatus_SUCCESS:
-				y.Status = "completed"
-			case stellar1.TransactionStatus_ERROR_TRANSIENT:
-				y.Status = "error"
-				y.StatusDetail = x.Keybase.SubmitErrMsg
-			case stellar1.TransactionStatus_ERROR_PERMANENT:
-				y.Status = "error"
-				y.StatusDetail = x.Keybase.SubmitErrMsg
-			default:
-				y.Status = "unknown"
-				y.StatusDetail = x.Keybase.SubmitErrMsg
-			}
-			y.DisplayAmount = x.Keybase.DisplayAmount
-			y.DisplayCurrency = x.Keybase.DisplayCurrency
-			fromUsername, err := g.GetUPAKLoader().LookupUsername(ctx, x.Keybase.From.Uid)
-			if err == nil {
-				tmp := fromUsername.String()
-				y.FromUsername = &tmp
-			}
-			if x.Keybase.To != nil {
-				toUsername, err := g.GetUPAKLoader().LookupUsername(ctx, x.Keybase.To.Uid)
-				if err == nil {
-					tmp := toUsername.String()
-					y.ToUsername = &tmp
-				}
-			}
-			if len(x.Keybase.NoteB64) > 0 {
-				note, err := NoteDecryptB64(ctx, g, x.Keybase.NoteB64)
-				if err != nil {
-					y.NoteErr = fmt.Sprintf("failed to decrypt payment note: %v", err)
-				} else {
-					if note.StellarID != x.StellarTxID {
-						y.NoteErr = "discarded note for wrong txid"
-					} else {
-						y.Note = note.Note
-					}
-				}
-				if len(y.NoteErr) > 0 {
-					g.Log.CWarningf(ctx, y.NoteErr)
-				}
-			}
-		}
-		if x.Stellar != nil {
-			y.Time = x.Stellar.Ctime
-		}
-		res = append(res, y)
+	for _, p := range payments {
+		res = append(res, localizePayment(ctx, g, p))
 	}
 	return res, nil
 }
 
 func PaymentDetailCLILocal(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter, txID string) (res stellar1.PaymentCLILocal, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.PaymentDetailCLILocal", func() error { return err })()
-	return res, fmt.Errorf("TODO (CORE-7554)")
+	payment, err := remoter.PaymentDetail(ctx, txID)
+	if err != nil {
+		return res, err
+	}
+	return localizePayment(ctx, g, payment), nil
+}
+
+func localizePayment(ctx context.Context, g *libkb.GlobalContext, x stellar1.PaymentSummary) stellar1.PaymentCLILocal {
+	y := stellar1.PaymentCLILocal{
+		StellarTxID: x.StellarTxID,
+		Status:      "pending",
+		Amount:      x.Amount,
+		Asset:       x.Asset,
+		FromStellar: x.From,
+		ToStellar:   x.To,
+	}
+	if x.Stellar != nil {
+		y.Status = "completed"
+	}
+	if x.Keybase != nil {
+		y.Time = x.Keybase.Ctime
+		switch x.Keybase.Status {
+		case stellar1.TransactionStatus_PENDING:
+			y.Status = "pending"
+		case stellar1.TransactionStatus_SUCCESS:
+			y.Status = "completed"
+		case stellar1.TransactionStatus_ERROR_TRANSIENT:
+			y.Status = "error"
+			y.StatusDetail = x.Keybase.SubmitErrMsg
+		case stellar1.TransactionStatus_ERROR_PERMANENT:
+			y.Status = "error"
+			y.StatusDetail = x.Keybase.SubmitErrMsg
+		default:
+			y.Status = "unknown"
+			y.StatusDetail = x.Keybase.SubmitErrMsg
+		}
+		y.DisplayAmount = x.Keybase.DisplayAmount
+		y.DisplayCurrency = x.Keybase.DisplayCurrency
+		fromUsername, err := g.GetUPAKLoader().LookupUsername(ctx, x.Keybase.From.Uid)
+		if err == nil {
+			tmp := fromUsername.String()
+			y.FromUsername = &tmp
+		}
+		if x.Keybase.To != nil {
+			toUsername, err := g.GetUPAKLoader().LookupUsername(ctx, x.Keybase.To.Uid)
+			if err == nil {
+				tmp := toUsername.String()
+				y.ToUsername = &tmp
+			}
+		}
+		if len(x.Keybase.NoteB64) > 0 {
+			note, err := NoteDecryptB64(ctx, g, x.Keybase.NoteB64)
+			if err != nil {
+				y.NoteErr = fmt.Sprintf("failed to decrypt payment note: %v", err)
+			} else {
+				if note.StellarID != x.StellarTxID {
+					y.NoteErr = "discarded note for wrong txid"
+				} else {
+					y.Note = note.Note
+				}
+			}
+			if len(y.NoteErr) > 0 {
+				g.Log.CWarningf(ctx, y.NoteErr)
+			}
+		}
+	}
+	if x.Stellar != nil {
+		y.Time = x.Stellar.Ctime
+	}
+	return y
 }

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -50,6 +50,18 @@ func (t *txlogger) Filter(accountID stellar1.AccountID, limit int) []stellar1.Pa
 	return res
 }
 
+func (t *txlogger) Find(txID string) *stellar1.PaymentSummary {
+	for _, tx := range t.transactions {
+		if tx.StellarTxID.String() == txID {
+			return &tx
+		}
+		if tx.Keybase != nil && tx.Keybase.KbTxID.String() == txID {
+			return &tx
+		}
+	}
+	return nil
+}
+
 var txLog *txlogger
 
 func init() {
@@ -192,7 +204,11 @@ func (r *RemoteMock) RecentPayments(ctx context.Context, accountID stellar1.Acco
 }
 
 func (r *RemoteMock) PaymentDetail(ctx context.Context, txID string) (res stellar1.PaymentSummary, err error) {
-	return res, fmt.Errorf("TODO (CORE-7554)")
+	p := txLog.Find(txID)
+	if p == nil {
+		return res, fmt.Errorf("RemoteMock: tx not found: '%v'", txID)
+	}
+	return *p, nil
 }
 
 func (r *RemoteMock) AddAccount(t *testing.T) stellar1.AccountID {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -316,6 +316,13 @@ func TestRecentPaymentsLocal(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recipPayments, 1)
 	checkPayment(recipPayments[0])
+
+	payment, err := srvSender.PaymentDetailCLILocal(context.Background(), senderPayments[0].StellarTxID.String())
+	require.NoError(t, err)
+	checkPayment(payment)
+	payment, err = srvRecip.PaymentDetailCLILocal(context.Background(), senderPayments[0].StellarTxID.String())
+	require.NoError(t, err)
+	checkPayment(payment)
 }
 
 // Create n TestContexts with logged in users


### PR DESCRIPTION
Add `keybase wallet detail` which shows the same info `keybase wallet history --verbose`.

Flip the ordering of `keybase wallet history` so that the latest transaction appears at the bottom of the list.

Add some color to spruce things up!

Needs https://github.com/keybase/keybase/pull/2368, but maybe not for CI because of the magic of mocks.

```
$ kbu wallet
...
COMMANDS:
...
   detail, details      Show payment details
...
```

```
$ kbu wallet detail
Error parsing command line arguments: expected a tx ID (run 'keybase wallet history -v' to find one)

NAME:
   keybase wallet detail - Show payment details

USAGE:
   keybase wallet detail <transaction ID>
```

```
$ kbu wallet detail 8cd2ed0f22e502a041c9ad4378d8a080f5f7b0cde8a041074b5e2afe2ada3e3d
2018/04/19 15:45
0.8231785 XLM
st10 -> st9
From: GADKGEK2DDUNBLGQB7HTSRKRIF2KVLCH3BMMX5BNA4XYGEMOGMXKMIGT
To:   GBO2GSJRJF7PRACIMJTKFN7DTXN3JX4ITU4SU2ETC6VCJBJTIMOQBE6X
Note: for lunch
Transaction Hash: 8cd2ed0f22e502a041c9ad4378d8a080f5f7b0cde8a041074b5e2afe2ada3e3d
```

A stranger's tx
```
$ kbu wallet detail 71931e8c49d5523debc39b4dea8cdbc4729a070ddce9f33575f4bed5fc30e1b3
▶ WARNING Running in devel mode
2018/03/12 14:23
4 XLM
GB...23UA -> GB...LLAO
From: GBGSPJUIK5W5S7QNSFLL5YJTLTPMWD6Q3GHTSLLB3Q6GMBWNC7ST23UA
To:   GBYMUO6SVZXDB7DAN432DIZYUQN33EWIC4QQCXHPUA3PM5YJ2AS5LLAO
Transaction Hash: 71931e8c49d5523debc39b4dea8cdbc4729a070ddce9f33575f4bed5fc30e1b3
```

A stranger's weird tx
```
$ kbu wallet detail d71541b3c8677e5250f4665469439605b270a955fa0e554c8a38a41cf7b312c5
▶ ERROR transaction included no payment operations
```