### PR TITLE
 check for strict append before inserting anything into body cache on silent notification CORE-7674

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -452,7 +452,7 @@ func (s *HybridConversationSource) isContinuousPush(ctx context.Context, convID 
 	default:
 		return false, err
 	}
-	return true, nil
+	return continuousUpdate, nil
 }
 
 func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.ConversationID,

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -89,9 +89,10 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 	return nil
 }
 
-func (s *baseConversationSource) TransformSupersedes(ctx context.Context, conv chat1.Conversation, uid gregor1.UID, msgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error) {
+func (s *baseConversationSource) TransformSupersedes(ctx context.Context,
+	unboxInfo types.UnboxConversationInfo, uid gregor1.UID, msgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error) {
 	transform := newBasicSupersedesTransform(s.G())
-	return transform.Run(ctx, conv, uid, msgs)
+	return transform.Run(ctx, unboxInfo, uid, msgs)
 }
 
 // patchPaginationLast turns on page.Last if the messages are before InboxSource's view of Expunge.

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2580,23 +2580,39 @@ func (h *Server) UnboxMobilePushNotification(ctx context.Context, arg chat1.Unbo
 		return res, err
 	}
 
-	// Let's just take this whole message and add it to the message body cache. Alternatively,
-	// we can try to just unbox if this fails, since it will need the convo in cache.
-	msgUnboxed, _, err := h.G().ConvSource.Push(ctx, convID, uid, msgBoxed)
+	// Unbox first
+	vis := keybase1.TLFVisibility_PRIVATE
+	if msgBoxed.ClientHeader.TlfPublic {
+		vis = keybase1.TLFVisibility_PUBLIC
+	}
+	unboxInfo := newBasicUnboxConversationInfo(convID, arg.MembersType, nil, vis)
+	msgUnboxed, err := NewBoxer(h.G()).UnboxMessage(ctx, msgBoxed, unboxInfo)
 	if err != nil {
-		h.Debug(ctx, "UnboxMobilePushNotification: failed to push message to conv source: %s", err.Error())
-		// Try to just unbox without pushing
-		vis := keybase1.TLFVisibility_PRIVATE
-		if msgBoxed.ClientHeader.TlfPublic {
-			vis = keybase1.TLFVisibility_PUBLIC
-		}
-		unboxInfo := newBasicUnboxConversationInfo(convID, arg.MembersType, nil, vis)
-		if msgUnboxed, err = NewBoxer(h.G()).UnboxMessage(ctx, msgBoxed, unboxInfo); err != nil {
-			h.Debug(ctx, "UnboxMobilePushNotification: failed simple unbox as well, bailing: %s", err.Error())
-			return res, err
-		}
+		h.Debug(ctx, "UnboxMobilePushNotification: unbox failed, bailing: %s", err.Error())
+		return res, err
 	}
 
+	// Check to see if this will be a strict append before adding to the body cache
+	if err := h.G().ConvSource.AcquireConversationLock(ctx, uid, convID); err != nil {
+		return res, err
+	}
+	maxMsgID, err := storage.New(h.G()).GetMaxMsgID(ctx, convID, uid)
+	if err == nil {
+		if msgUnboxed.GetMessageID() > maxMsgID {
+			if _, err = h.G().ConvSource.PushUnboxed(ctx, convID, uid, msgUnboxed); err != nil {
+				h.Debug(ctx, "UnboxMobilePushNotification: failed to push message to conv source: %s",
+					err.Error())
+			}
+		} else {
+			h.Debug(ctx, "UnboxMobilePushNotification: message from the past, skipping insert: msgID: %d maxMsgID: %d", msgUnboxed.GetMessageID(), maxMsgID)
+
+		}
+	} else {
+		h.Debug(ctx, "UnboxMobilePushNotification: failed to fetch max msg ID: %s", err)
+	}
+	h.G().ConvSource.ReleaseConversationLock(ctx, uid, convID)
+
+	// Form the push notification message
 	if msgUnboxed.IsValid() && msgUnboxed.GetMessageType() == chat1.MessageType_TEXT {
 		res = h.formatPushText(ctx, uid, convID, arg.MembersType, msgUnboxed)
 		h.Debug(ctx, "UnboxMobilePushNotification: successful unbox")

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -59,6 +59,8 @@ type ConversationSource interface {
 
 	Push(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 		msg chat1.MessageBoxed) (chat1.MessageUnboxed, bool, error)
+	PushUnboxed(ctx context.Context, convID chat1.ConversationID,
+		uid gregor1.UID, msg chat1.MessageUnboxed) (continuousUpdate bool, err error)
 	Pull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
 		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -69,7 +69,7 @@ type ConversationSource interface {
 	GetMessagesWithRemotes(ctx context.Context, conv chat1.Conversation, uid gregor1.UID,
 		msgs []chat1.MessageBoxed) ([]chat1.MessageUnboxed, error)
 	Clear(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) error
-	TransformSupersedes(ctx context.Context, conv chat1.Conversation, uid gregor1.UID,
+	TransformSupersedes(ctx context.Context, unboxInfo UnboxConversationInfo, uid gregor1.UID,
 		msgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error)
 	Expunge(ctx context.Context, convID chat1.ConversationID,
 		uid gregor1.UID, expunge chat1.Expunge) error


### PR DESCRIPTION
If we don't check for a strict append, the out of order nature of the silent notifications can undo the superseded nature of a message already in the body cache. 