### PR TITLE
Fix removing pukless members

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2238,6 +2238,11 @@ func (t TLFVisibility) Eq(r TLFVisibility) bool {
 func ParseUserVersion(s UserVersionPercentForm) (res UserVersion, err error) {
 	parts := strings.Split(string(s), "%")
 	if len(parts) == 1 {
+		// NOTE: We have to keep it the way it is, even though we
+		// never save UIDs without EldestSeqno anywhere. There may be
+		// team chain which have UVs encoded with assumed default=1 in
+		// the wild.
+
 		// default to seqno 1
 		parts = append(parts, "1")
 	}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2240,7 +2240,7 @@ func ParseUserVersion(s UserVersionPercentForm) (res UserVersion, err error) {
 	if len(parts) == 1 {
 		// NOTE: We have to keep it the way it is, even though we
 		// never save UIDs without EldestSeqno anywhere. There may be
-		// team chain which have UVs encoded with assumed default=1 in
+		// team chain which have UVs encoded with default eldest=1 in
 		// the wild.
 
 		// default to seqno 1

--- a/go/teams/invite_test.go
+++ b/go/teams/invite_test.go
@@ -121,8 +121,10 @@ func TestKeybaseInviteMalformed(t *testing.T) {
 	tc, owner, other, teamname := setupPuklessInviteTest(t)
 	defer tc.Cleanup()
 
+	// Pretend it's an old client.
 	invite := SCTeamInvite{
 		Type: "keybase",
+		// Use name that is not "uid%seqno" but just "uid" instead.
 		Name: keybase1.TeamInviteName(other.User.GetUID()),
 		ID:   NewInviteID(),
 	}

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -153,7 +153,8 @@ func (tx *AddMemberTx) sweepCryptoMembersOlderThan(uv keybase1.UserVersion) {
 // invites (PUKless members) for given UID.
 func (tx *AddMemberTx) sweepKeybaseInvites(uid keybase1.UID) {
 	team := tx.team
-	for _, invite := range team.chain().inner.ActiveInvites {
+	allInvites := team.GetActiveAndObsoleteInvites()
+	for _, invite := range allInvites {
 		if inviteUv, err := invite.KeybaseUserVersion(); err == nil {
 			if inviteUv.Uid.Equal(uid) && !tx.completedInvites[invite.Id] {
 				tx.CancelInvite(invite.Id)


### PR DESCRIPTION
- Add new function `removeKeybaseTypeInviteForUID` that will remove PUKless members same way we remove crypto members - by only matching UID.
- Use new function in `RemoveMember` code path for removing PUKless members.
- Add test for mikem bug and another one for PUKless reset user member removal bug.
- Unrelated minor change: AddMemberTx will sweep all keybase invites, even if decided obsolete by team player.