### PR TITLE
Add CLI command 'wallet export'

### DIFF
--- a/go/client/cmd_wallet.go
+++ b/go/client/cmd_wallet.go
@@ -9,6 +9,7 @@ import (
 func newCmdWallet(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	subcommands := []cli.Command{
 		newCmdWalletBalances(cl, g),
+		newCmdWalletExport(cl, g),
 		newCmdWalletHistory(cl, g),
 		newCmdWalletImport(cl, g),
 		newCmdWalletSend(cl, g),

--- a/go/client/cmd_wallet_export.go
+++ b/go/client/cmd_wallet_export.go
@@ -1,0 +1,101 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"golang.org/x/net/context"
+)
+
+type cmdWalletExport struct {
+	libkb.Contextified
+	accountID string
+}
+
+func newCmdWalletExport(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	cmd := &cmdWalletExport{
+		Contextified: libkb.NewContextified(g),
+	}
+	return cli.Command{
+		Name:         "export",
+		Description:  "Export a stellar account's secret key",
+		Usage:        "Export a stellar account's secret key",
+		ArgumentHelp: "[<account ID>]",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(cmd, "export", c)
+		},
+		Flags: []cli.Flag{},
+	}
+}
+
+func (c *cmdWalletExport) ParseArgv(ctx *cli.Context) (err error) {
+	if len(ctx.Args()) > 1 {
+		return errors.New("expected zero or one arguments")
+	}
+	if len(ctx.Args()) > 0 {
+		c.accountID = ctx.Args()[0]
+	}
+	return nil
+}
+
+func (c *cmdWalletExport) Run() (err error) {
+	protocols := []rpc.Protocol{
+		NewSecretUIProtocol(c.G()),
+	}
+	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
+	dui := c.G().UI.GetDumbOutputUI()
+	cli, err := GetWalletClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	var accountID stellar1.AccountID
+	if len(c.accountID) > 0 {
+		accountID, err = libkb.ParseStellarAccountID(c.accountID)
+		if err != nil {
+			return err
+		}
+	}
+	if len(accountID) == 0 {
+		accounts, err := cli.WalletGetLocalAccounts(context.Background())
+		if err != nil {
+			return err
+		}
+		if len(accounts) == 1 {
+			accountID = accounts[0].AccountID
+		} else {
+			dui.Printf("You have multiple accounts.\n")
+			dui.Printf("Run 'keybase wallet balances' to list them.\n")
+			dui.Printf("Then run 'keybase wallet export <account ID>' to export one.\n")
+			return fmt.Errorf("account selection required")
+		}
+	}
+
+	dui.Printf("This secret key is used to send money and manage your stellar account.\n")
+	dui.Printf("Anyone with the secret will have full access to the account.\n")
+
+	secKey, err := cli.ExportSecretKeyLocal(context.TODO(), accountID)
+	if err != nil {
+		return err
+	}
+	dui.Printf("\nAccount ID: %s\n\nKeep it secret.\nSecret Key: %s\nKeep it safe.\n", accountID.String(), secKey.SecureNoLogString())
+	return
+}
+
+func (c *cmdWalletExport) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -109,6 +109,30 @@ func ImportSecretKey(ctx context.Context, g *libkb.GlobalContext, secretKey stel
 	return remote.Post(ctx, g, nextBundle)
 }
 
+func ExportSecretKey(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.AccountID) (res stellar1.SecretKey, err error) {
+	prevBundle, _, err := remote.Fetch(ctx, g)
+	if err != nil {
+		return res, err
+	}
+	for _, account := range prevBundle.Accounts {
+		if account.AccountID.Eq(accountID) && account.Mode == stellar1.AccountMode_USER {
+			if len(account.Signers) == 0 {
+				return res, fmt.Errorf("no secret keys found for account")
+			}
+			if len(account.Signers) != 1 {
+				return res, fmt.Errorf("expected 1 secret key but found %v", len(account.Signers))
+			}
+			return account.Signers[0], nil
+		}
+	}
+	_, _, parseSecErr := libkb.ParseStellarSecretKey(accountID.String())
+	if parseSecErr == nil {
+		// Just in case a secret key worked its way in here
+		return res, fmt.Errorf("account not found: unexpected secret key")
+	}
+	return res, fmt.Errorf("account not found: %v", accountID)
+}
+
 func BalanceXLM(ctx context.Context, remoter remote.Remoter, accountID stellar1.AccountID) (stellar1.Balance, error) {
 	balances, err := remoter.Balances(ctx, accountID)
 	if err != nil {

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -48,6 +48,9 @@ protocol local {
 
   void importSecretKeyLocal(SecretKey secretKey, boolean makePrimary);
 
+  // prompts for passphrase
+  SecretKey exportSecretKeyLocal(AccountID accountID);
+
   void setDisplayCurrency(AccountID accountID, string currency);
 
   OutsideExchangeRate exchangeRateLocal(OutsideCurrencyCode currency);

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -209,6 +209,15 @@
       ],
       "response": null
     },
+    "exportSecretKeyLocal": {
+      "request": [
+        {
+          "name": "accountID",
+          "type": "AccountID"
+        }
+      ],
+      "response": "SecretKey"
+    },
     "setDisplayCurrency": {
       "request": [
         {


### PR DESCRIPTION
Add a wallet export command that exports the secret key for one account. Defaults to your only account if you have only one. The RPC prompts for your passphrase.

```
$ kbu wallet export
This secret key is used to send money and manage your stellar account.
Anyone with the secret will have full access to the account.

Account ID: GBR5NOCHPYVN4FUMZ574XAEBSJQAWW7FNK5FIDEI7OAPW4SJLFKVSXZD

Keep it secret.
Secret Key: SDROKLQZOY3IBSVF6Y7BDPU52WYN4YAZKYRRQAPWIYXUJ46K5XKOU6SA
Keep it safe.
```

```
$ kbu wallet export
This secret key is used to send money and manage your stellar account.
Anyone with the secret will have full access to the account.
▶ ERROR Input canceled
```

```
$ kbu wallet export
You have multiple accounts.
Run 'keybase wallet balances' to list them.
Then run 'keybase wallet export <account ID>' to export one.
▶ ERROR account selection required
```

```
$ kbu wallet export GBJNGHJED3XOJXTB2KMZYMZYXRMWZHIJX5FXU2KA67JNRLJDYYC2GTNJ
This secret key is used to send money and manage your stellar account.
Anyone with the secret will have full access to the account.

Account ID: GBJNGHJED3XOJXTB2KMZYMZYXRMWZHIJX5FXU2KA67JNRLJDYYC2GTNJ

Keep it secret.
Secret Key: SBOWK4QVXKDSIPA23AVHJPORK2L7YZ3E2663CJJFXFOS2T5LNCA6GQWG
Keep it safe.
```

![image](https://user-images.githubusercontent.com/705646/39068051-f7d3905e-44a8-11e8-9517-2670e592ddcb.png)
