### PR TITLE
proposal: oneshot login

### DIFF
--- a/go/client/cmd_oneshot.go
+++ b/go/client/cmd_oneshot.go
@@ -56,7 +56,7 @@ users can examine each other's processes. But it might be a good fit for
 Docker deployments.
 
 Also note that by default keybase shouldn't be run as root, but in Docker (or
-other containers), root is the best option, so you can use "keybase oneshot"
+other containers), root can be the best option, so you can use "keybase oneshot"
 in concert with the KEYBASE_ALLOW_ROOT=1 environment variable.
 
 Some features won't work in oneshot mode, such as: (1) ephemeral messaging;

--- a/go/client/cmd_oneshot.go
+++ b/go/client/cmd_oneshot.go
@@ -56,8 +56,11 @@ users can examine each other's processes. But it might be a good fit for
 Docker deployments.
 
 Also note that by default keybase shouldn't be run as root, but in Docker (or
-other containers), root is the only option, so you can use "keybase oneshot"
-in concert with the KEYBASE_ALLOW_ROOT=1 environment variable.`,
+other containers), root is the best option, so you can use "keybase oneshot"
+in concert with the KEYBASE_ALLOW_ROOT=1 environment variable.
+
+Some features won't work in oneshot mode, such as: (1) ephemeral messaging;
+and (2) cryptocurrency integrations.`,
 	}
 	return cmd
 }

--- a/go/client/cmd_oneshot.go
+++ b/go/client/cmd_oneshot.go
@@ -43,7 +43,7 @@ running keybase in a Docker container.
 
 It won't write any credential information out disk, and it won't make any
 changes to the user's sigchain. It will rather hold the given paperkey in
-memory for as long as the service is running (or until "keybsae logout" is
+memory for as long as the service is running (or until "keybase logout" is
 called) and then will disappear.
 
 It needs a username and a paperkey to work, either passed in via command-line

--- a/go/client/cmd_oneshot.go
+++ b/go/client/cmd_oneshot.go
@@ -6,9 +6,9 @@ package client
 import (
 	"errors"
 	"fmt"
+	"golang.org/x/net/context"
 	"os"
 	"strings"
-	"golang.org/x/net/context"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
@@ -20,17 +20,17 @@ import (
 func NewCmdOneshot(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	flags := []cli.Flag{
 		cli.StringFlag{
-			Name : "p, paperkey",
-			Usage : "specify a paper key (or try the KEYBASE_PAPERKEY environment variable)",
+			Name:  "p, paperkey",
+			Usage: "specify a paper key (or try the KEYBASE_PAPERKEY environment variable)",
 		},
 		cli.StringFlag{
-			Name : "u,username",
-			Usage : "specify a username (or try the KEYBASE_USERNAME environment variable)",
+			Name:  "u,username",
+			Usage: "specify a username (or try the KEYBASE_USERNAME environment variable)",
 		},
 	}
 	cmd := cli.Command{
-		Name:         "oneshot",
-		Usage:        "Establish a oneshot device, as in logging into keybase from a disposable docker",
+		Name:  "oneshot",
+		Usage: "Establish a oneshot device, as in logging into keybase from a disposable docker",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdOneshotRunner(g), "oneshot", c)
 			cl.SetNoStandalone()
@@ -42,8 +42,8 @@ func NewCmdOneshot(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 
 type CmdOneshot struct {
 	libkb.Contextified
-	Username   string
-	PaperKey   string
+	Username string
+	PaperKey string
 }
 
 func NewCmdOneshotRunner(g *libkb.GlobalContext) *CmdOneshot {
@@ -62,7 +62,7 @@ func (c *CmdOneshot) Run() error {
 		return err
 	}
 
-	err = client.LoginOneshot(context.Background(), keybase1.LoginOneshotArg{SessionID : 0, Username : c.Username, PaperKey : c.PaperKey })
+	err = client.LoginOneshot(context.Background(), keybase1.LoginOneshotArg{SessionID: 0, Username: c.Username, PaperKey: c.PaperKey})
 	return err
 }
 

--- a/go/client/cmd_oneshot.go
+++ b/go/client/cmd_oneshot.go
@@ -1,0 +1,104 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+)
+
+func NewCmdOneshot(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	flags := []cli.Flag{
+		cli.StringFlag{
+			Name : "p, paperkey",
+			Usage : "specify a paper key (or try the KEYBASE_PAPERKEY environment variable)",
+		},
+		cli.StringFlag{
+			Name : "u,username",
+			Usage : "specify a username (or try the KEYBASE_USERNAME environment variable)",
+		},
+	}
+	cmd := cli.Command{
+		Name:         "oneshot",
+		Usage:        "Establish a oneshot device, as in logging into keybase from a disposable docker",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdOneshotRunner(g), "oneshot", c)
+			cl.SetNoStandalone()
+		},
+		Flags: flags,
+	}
+	return cmd
+}
+
+type CmdOneshot struct {
+	libkb.Contextified
+	Username   string
+	PaperKey   string
+}
+
+func NewCmdOneshotRunner(g *libkb.GlobalContext) *CmdOneshot {
+	return &CmdOneshot{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func (c *CmdOneshot) Run() error {
+	protocols := []rpc.Protocol{}
+	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
+	client, err := GetLoginClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	err = client.LoginOneshot(context.Background(), keybase1.LoginOneshotArg{SessionID : 0, Username : c.Username, PaperKey : c.PaperKey })
+	return err
+}
+
+func (c *CmdOneshot) ParseArgv(ctx *cli.Context) (err error) {
+	nargs := len(ctx.Args())
+	if nargs != 0 {
+		return errors.New("didn't expect any arguments")
+	}
+	c.Username, err = c.getOption(ctx, "username")
+	if err != nil {
+		return err
+	}
+	c.PaperKey, err = c.getOption(ctx, "paperkey")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CmdOneshot) getOption(ctx *cli.Context, s string) (string, error) {
+	v := ctx.String(s)
+	if len(v) > 0 {
+		return v, nil
+	}
+	envVarName := fmt.Sprintf("KEYBASE_%s", strings.ToUpper(s))
+	v = os.Getenv(envVarName)
+	if len(v) > 0 {
+		return v, nil
+	}
+	return "", fmt.Errorf("Need a --%s option or a %s environment variable", s, envVarName)
+}
+
+func (c *CmdOneshot) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    false,
+		KbKeyring: false,
+		API:       false,
+	}
+}

--- a/go/client/cmd_oneshot.go
+++ b/go/client/cmd_oneshot.go
@@ -36,6 +36,28 @@ func NewCmdOneshot(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 			cl.SetNoStandalone()
 		},
 		Flags: flags,
+		Description: `"keybase oneshot" is used to establish a temporary device that will
+be thrown away after the corresponding "keybase service" process exits (or
+logout is called). For instance, you can use this, instead of login, for
+running keybase in a Docker container.
+
+It won't write any credential information out disk, and it won't make any
+changes to the user's sigchain. It will rather hold the given paperkey in
+memory for as long as the service is running (or until "keybsae logout" is
+called) and then will disappear.
+
+It needs a username and a paperkey to work, either passed in via command-line
+flags or the environment.
+
+Passing a paperkey via the environment or via command line flags is
+potentially unsafe. Other processes running on the machine can inspect these
+data, so "oneshot" is strongly advised against on a multi-tenant system where
+users can examine each other's processes. But it might be a good fit for
+Docker deployments.
+
+Also note that by default keybase shouldn't be run as root, but in Docker (or
+other containers), root is the only option, so you can use "keybase oneshot"
+in concert with the KEYBASE_ALLOW_ROOT=1 environment variable.`,
 	}
 	return cmd
 }

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -42,6 +42,7 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdLog(cl, g),
 		NewCmdLogin(cl, g),
 		NewCmdLogout(cl, g),
+		NewCmdOneshot(cl, g),
 		NewCmdPaperKey(cl, g),
 		NewCmdPassphrase(cl, g),
 		NewCmdPGP(cl, g),

--- a/go/engine/login_oneshot.go
+++ b/go/engine/login_oneshot.go
@@ -14,18 +14,18 @@ import (
 // but the existence of the login won't hit the user's sigchain.
 type LoginOneshot struct {
 	libkb.Contextified
-	arg      keybase1.LoginOneshotArg
-	upak     keybase1.UserPlusKeysV2
-	sigKey   libkb.GenericKey
-	encKey   libkb.NaclDHKeyPair
-	deviceID keybase1.DeviceID
+	arg        keybase1.LoginOneshotArg
+	upak       keybase1.UserPlusKeysV2
+	sigKey     libkb.GenericKey
+	encKey     libkb.NaclDHKeyPair
+	deviceID   keybase1.DeviceID
 	deviceName string
 }
 
 func NewLoginOneshot(g *libkb.GlobalContext, arg keybase1.LoginOneshotArg) *LoginOneshot {
 	return &LoginOneshot{
-		Contextified : libkb.NewContextified(g),
-		arg : arg,
+		Contextified: libkb.NewContextified(g),
+		arg:          arg,
 	}
 }
 
@@ -89,7 +89,7 @@ func (e *LoginOneshot) checkLogin(ctx context.Context) (err error) {
 func (e *LoginOneshot) makeLoginChanges(ctx context.Context) (err error) {
 	defer e.G().CTrace(ctx, "LoginOneshot#makeLoginChanges", func() error { return err })()
 	var gerr error
-	err = e.G().LoginState().Account(func (a *libkb.Account) {
+	err = e.G().LoginState().Account(func(a *libkb.Account) {
 		gerr = e.G().ActiveDevice.Set(e.G(), a, e.upak.GetUID(), e.deviceID, e.sigKey, e.encKey, e.deviceName)
 	}, "LoginOneshot#makeLoginChanges")
 	if err != nil {
@@ -115,7 +115,7 @@ func (e *LoginOneshot) commitLoginChanges(ctx context.Context) (err error) {
 func (e *LoginOneshot) rollbackLoginChanges(ctx context.Context) (err error) {
 	defer e.G().CTrace(ctx, "LoginOneshot#rollbackLoginChanges", func() error { return err })()
 	var gerr error
-	err = e.G().LoginState().Account(func (a *libkb.Account) {
+	err = e.G().LoginState().Account(func(a *libkb.Account) {
 		gerr = e.G().ActiveDevice.Clear(a)
 	}, "LoginOneshot#rollbackLoginChanges")
 	if err != nil {

--- a/go/engine/login_oneshot.go
+++ b/go/engine/login_oneshot.go
@@ -167,8 +167,6 @@ func (e *LoginOneshot) Run(ectx *Context) (err error) {
 	if err = e.loadKey(ectx); err != nil {
 		return err
 	}
-	if err = e.finish(ctx); err != nil {
-		return err
-	}
-	return nil
+	err = e.finish(ctx)
+	return err
 }

--- a/go/engine/login_oneshot.go
+++ b/go/engine/login_oneshot.go
@@ -1,0 +1,174 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+// "Oneshot login" is a login that works only once, say in an ephemeral
+// context like a docker image. Bootstrap such a session with a paperkey,
+// but the existence of the login won't hit the user's sigchain.
+type LoginOneshot struct {
+	libkb.Contextified
+	arg      keybase1.LoginOneshotArg
+	upak     keybase1.UserPlusKeysV2
+	sigKey   libkb.GenericKey
+	encKey   libkb.NaclDHKeyPair
+	deviceID keybase1.DeviceID
+	deviceName string
+}
+
+func NewLoginOneshot(g *libkb.GlobalContext, arg keybase1.LoginOneshotArg) *LoginOneshot {
+	return &LoginOneshot{
+		Contextified : libkb.NewContextified(g),
+		arg : arg,
+	}
+}
+
+func (e *LoginOneshot) Name() string {
+	return "LoginOneshot"
+}
+
+func (e *LoginOneshot) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+func (e *LoginOneshot) RequiredUIs() []libkb.UIKind      { return []libkb.UIKind{} }
+func (e *LoginOneshot) SubConsumers() []libkb.UIConsumer { return []libkb.UIConsumer{} }
+
+func (e *LoginOneshot) loadUser(ctx context.Context) (err error) {
+	defer e.G().CTrace(ctx, "LoginOneshot#loadUser", func() error { return err })()
+	arg := libkb.NewLoadUserArgWithContext(ctx, e.G()).WithName(e.arg.Username)
+	var upak *keybase1.UserPlusKeysV2AllIncarnations
+	upak, _, err = e.G().GetUPAKLoader().LoadV2(arg)
+	if err != nil {
+		return err
+	}
+	e.upak = upak.Current
+	return nil
+}
+func (e *LoginOneshot) loadKey(ectx *Context) (err error) {
+	ctx := ectx.GetNetContext()
+	defer e.G().CTrace(ctx, "LoginOneshot#loadKey", func() error { return err })()
+	arg := PaperKeyGenArg{
+		Passphrase: libkb.NewPaperKeyPhrase(e.arg.PaperKey),
+		SkipPush:   true,
+		UID:        e.upak.GetUID(),
+	}
+	eng := NewPaperKeyGen(&arg, e.G())
+	err = RunEngine(eng, ectx)
+	if err != nil {
+		return err
+	}
+	e.sigKey = eng.SigKey()
+	e.encKey = eng.EncKey()
+	device := e.upak.FindDeviceKey(e.sigKey.GetKID())
+	if device == nil {
+		return libkb.NewNoDeviceError("no device found for paper key")
+	}
+	if device.Base.Revocation != nil {
+		return libkb.NewKeyRevokedError(e.sigKey.GetKID().String())
+	}
+	e.deviceID = device.DeviceID
+	e.deviceName = device.DeviceDescription
+	return nil
+}
+
+func (e *LoginOneshot) checkLogin(ctx context.Context) (err error) {
+	defer e.G().CTrace(ctx, "LoginOneshot#checkLogin", func() error { return err })()
+	arg := libkb.NewRetryAPIArg("sesscheck")
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	_, err = e.G().API.Get(arg)
+	return err
+}
+
+func (e *LoginOneshot) makeLoginChanges(ctx context.Context) (err error) {
+	defer e.G().CTrace(ctx, "LoginOneshot#makeLoginChanges", func() error { return err })()
+	var gerr error
+	err = e.G().LoginState().Account(func (a *libkb.Account) {
+		gerr = e.G().ActiveDevice.Set(e.G(), a, e.upak.GetUID(), e.deviceID, e.sigKey, e.encKey, e.deviceName)
+	}, "LoginOneshot#makeLoginChanges")
+	if err != nil {
+		return err
+	}
+	err = gerr
+	if err != nil {
+		return err
+	}
+	uc := libkb.NewOneshotUserConfig(e.upak.GetUID(), libkb.NewNormalizedUsername(e.upak.GetName()), nil, e.deviceID)
+	e.G().Env.GetConfigWriter().SetUserConfig(uc, false)
+
+	return nil
+}
+
+func (e *LoginOneshot) commitLoginChanges(ctx context.Context) (err error) {
+	defer e.G().CTrace(ctx, "LoginOneshot#commitLoginChanges", func() error { return err })()
+	e.G().NotifyRouter.HandleLogin(e.arg.Username)
+	e.G().CallLoginHooks()
+	return nil
+}
+
+func (e *LoginOneshot) rollbackLoginChanges(ctx context.Context) (err error) {
+	defer e.G().CTrace(ctx, "LoginOneshot#rollbackLoginChanges", func() error { return err })()
+	var gerr error
+	err = e.G().LoginState().Account(func (a *libkb.Account) {
+		gerr = e.G().ActiveDevice.Clear(a)
+	}, "LoginOneshot#rollbackLoginChanges")
+	if err != nil {
+		return err
+	}
+	err = gerr
+	if err != nil {
+		return err
+	}
+	e.G().Env.GetConfigWriter().SetUserConfig(nil, false)
+	return nil
+}
+
+func (e *LoginOneshot) finish(ctx context.Context) (err error) {
+	defer e.G().CTrace(ctx, "LoginOneshot#commit", func() error { return err })()
+
+	err = e.makeLoginChanges(ctx)
+	if err != nil {
+		return err
+	}
+	err = e.checkLogin(ctx)
+	if err == nil {
+		err = e.commitLoginChanges(ctx)
+	} else {
+		e.rollbackLoginChanges(ctx)
+	}
+	return err
+}
+
+func (e *LoginOneshot) checkPreconditions(ctx context.Context) (err error) {
+	defer e.G().CTrace(ctx, "LoginOneshot#checkPreconditions", func() error { return err })()
+	if e.G().ActiveDevice.Valid() {
+		return libkb.LoggedInError{}
+	}
+	return nil
+}
+
+func (e *LoginOneshot) Run(ectx *Context) (err error) {
+	ctx := ectx.GetNetContext()
+	defer e.G().CTrace(ctx, "LoginOneshot#run", func() error { return err })()
+
+	if err = e.checkPreconditions(ctx); err != nil {
+		return err
+	}
+
+	if err = e.loadUser(ctx); err != nil {
+		return err
+	}
+	if err = e.loadKey(ectx); err != nil {
+		return err
+	}
+	if err = e.finish(ctx); err != nil {
+		return err
+	}
+	return nil
+}

--- a/go/engine/login_oneshot_test.go
+++ b/go/engine/login_oneshot_test.go
@@ -1,0 +1,43 @@
+package engine
+
+import (
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestLoginOneshot(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+	fu := NewFakeUserOrBust(t, "paper")
+	arg := MakeTestSignupEngineRunArg(fu)
+	arg.SkipPaper = false
+	loginUI := &paperLoginUI{Username: fu.Username}
+	ctx := &Context{
+		LogUI:    tc.G.UI.GetLogUI(),
+		GPGUI:    &gpgtestui{},
+		SecretUI: fu.NewSecretUI(),
+		LoginUI:  loginUI,
+	}
+	s := NewSignupEngine(&arg, tc.G)
+	err := RunEngine(s, ctx)
+	require.NoError(t, err)
+	require.True(t, len(loginUI.PaperPhrase) > 0)
+
+	assertNumDevicesAndKeys(tc, fu, 2, 4)
+	Logout(tc)
+
+	tc2 := SetupEngineTest(t, "login")
+	defer tc2.Cleanup()
+
+	eng := NewLoginOneshot(tc2.G, keybase1.LoginOneshotArg{
+		Username: fu.NormalizedUsername().String(),
+		PaperKey: loginUI.PaperPhrase,
+	})
+	err = RunEngine(eng, &Context{})
+	require.NoError(t, err)
+	assertNumDevicesAndKeys(tc, fu, 2, 4)
+	err = AssertProvisioned(tc2)
+	require.NoError(t, err)
+	testSign(t, tc2)
+}

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -64,20 +64,12 @@ func (e *EKLib) ShouldRun(ctx context.Context) bool {
 		e.G().Log.CDebugf(ctx, "EKLib skipping run")
 		return false
 	}
-	uc, err := g.Env.GetConfig().GetUserConfig()
+	oneshot, err := g.IsOneshot(ctx)
 	if err != nil {
-		e.G().Log.CDebugf(ctx, "Error getting a user config: %s", err)
+		e.G().Log.CWarningf(ctx, "EKLib#ShouldRun failed: %s", err)
 		return false
 	}
-	if uc == nil {
-		e.G().Log.CDebugf(ctx, "Null userconfig, not running EK tasks")
-		return false
-	}
-	if uc.IsOneshot() {
-		e.G().Log.CDebugf(ctx, "Not running EK tasks in oneshot login mode")
-		return false
-	}
-	return true
+	return !oneshot
 }
 
 func (e *EKLib) KeygenIfNeeded(ctx context.Context) (err error) {

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -57,18 +57,33 @@ func (e *EKLib) checkLoginAndPUK(ctx context.Context) error {
 // to fully release it.
 func (e *EKLib) ShouldRun(ctx context.Context) bool {
 	g := e.G()
+
+	// TODO -- when we launch, remove the feature flagging on Prod
 	willRun := g.Env.GetFeatureFlags().UseEphemeral() || g.Env.GetRunMode() == libkb.DevelRunMode || g.Env.RunningInCI()
 	if !willRun {
 		e.G().Log.CDebugf(ctx, "EKLib skipping run")
+		return false
 	}
-	return willRun
+	uc, err := g.Env.GetConfig().GetUserConfig()
+	if err != nil {
+		e.G().Log.CDebugf(ctx, "Error getting a user config: %s", err)
+		return false
+	}
+	if uc == nil {
+		e.G().Log.CDebugf(ctx, "Null userconfig, not running EK tasks")
+		return false
+	}
+	if uc.IsOneshot() {
+		e.G().Log.CDebugf(ctx, "Not running EK tasks in oneshot login mode")
+		return false
+	}
+	return true
 }
 
 func (e *EKLib) KeygenIfNeeded(ctx context.Context) (err error) {
 	e.Lock()
 	defer e.Unlock()
 
-	// TODO remove this when we want to release in the wild.
 	if !e.ShouldRun(ctx) {
 		return nil
 	}
@@ -361,7 +376,6 @@ func (e *EKLib) SignedDeviceEKStatementFromSeed(ctx context.Context, generation 
 func (e *EKLib) BoxLatestUserEK(ctx context.Context, receiverKey libkb.NaclDHKeyPair, deviceEKGeneration keybase1.EkGeneration) (userEKBox *keybase1.UserEkBoxed, err error) {
 	defer e.G().CTrace(ctx, "BoxLatestUserEK", func() error { return err })()
 
-	// TODO remove this when we want to release in the wild.
 	if !e.ShouldRun(ctx) {
 		return nil, nil
 	}
@@ -469,7 +483,6 @@ func (e *EKLib) PrepareNewTeamEK(ctx context.Context, teamID keybase1.TeamID, si
 }
 
 func (e *EKLib) OnLogin() error {
-	// TODO remove this when we want to release in the wild.
 	if !e.ShouldRun(context.Background()) {
 		return nil
 	}
@@ -477,7 +490,6 @@ func (e *EKLib) OnLogin() error {
 }
 
 func (e *EKLib) OnLogout() error {
-	// TODO remove this when we want to release in the wild.
 	if !e.ShouldRun(context.Background()) {
 		return nil
 	}

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -128,7 +128,7 @@ func mainInner(g *libkb.GlobalContext) error {
 		return nil
 	}
 
-	if !cmd.GetUsage().AllowRoot {
+	if !cmd.GetUsage().AllowRoot && !g.Env.GetAllowRoot() {
 		checkSystemUser(g.Log)
 	}
 

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -22,7 +22,7 @@ type ActiveDevice struct {
 // Set acquires the write lock and sets all the fields in ActiveDevice.
 // The acct parameter is not used for anything except to help ensure
 // that this is called from inside a LogingState account request.
-func (a *ActiveDevice) set(g *GlobalContext, lctx LoginContext, uid keybase1.UID, deviceID keybase1.DeviceID, sigKey, encKey GenericKey, deviceName string) error {
+func (a *ActiveDevice) Set(g *GlobalContext, lctx LoginContext, uid keybase1.UID, deviceID keybase1.DeviceID, sigKey, encKey GenericKey, deviceName string) error {
 	a.Lock()
 	defer a.Unlock()
 
@@ -110,6 +110,10 @@ func (a *ActiveDevice) internalUpdateUIDDeviceID(lctx LoginContext, uid keybase1
 	}
 
 	return nil
+}
+
+func (a *ActiveDevice) Clear(acct *Account) error {
+	return a.clear(acct)
 }
 
 // clear acquires the write lock and resets all the fields to zero values.

--- a/go/libkb/bootstrap_active_device.go
+++ b/go/libkb/bootstrap_active_device.go
@@ -131,6 +131,6 @@ func bootstrapActiveDeviceReturnRawError(ctx context.Context, g *GlobalContext, 
 		return err
 	}
 
-	err = ad.set(g, lctx, uid, deviceID, sib, sub, deviceName)
+	err = ad.Set(g, lctx, uid, deviceID, sib, sub, deviceName)
 	return err
 }

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -572,7 +572,6 @@ func (f JSONConfigFile) GetLogFormat() string {
 func (f JSONConfigFile) GetStandalone() (bool, bool) {
 	return f.GetTopLevelBool("standalone")
 }
-
 func (f JSONConfigFile) GetGregorURI() string {
 	s, _ := f.GetStringAtPath("push.server_uri")
 	return s

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -292,8 +292,21 @@ func (f JSONConfigFile) GetUserConfigForUsername(nu NormalizedUsername) (*UserCo
 	return ImportUserConfigFromJSONWrapper(f.jw.AtKey("users").AtKey(nu.String()))
 }
 
+func (f JSONConfigFile) copyUserConfigIfForUID(u keybase1.UID) (*UserConfig) {
+	if f.userConfigWrapper.userConfig.GetUID().Equal(u) {
+		tmp := *f.userConfigWrapper.userConfig
+		return &tmp
+	}
+	return nil
+}
+
 // GetUserConfigForUID sees if there's a UserConfig object for the given UIDs previously stored.
 func (f JSONConfigFile) GetUserConfigForUID(u keybase1.UID) (*UserConfig, error) {
+
+	if uc := f.copyUserConfigIfForUID(u); uc != nil {
+		return uc, nil
+	}
+
 	d := f.jw.AtKey("users")
 	keys, _ := d.Keys()
 	for _, key := range keys {
@@ -374,6 +387,11 @@ func (f *JSONConfigFile) setUserConfigWithLock(u *UserConfig, overwrite bool) er
 		f.jw.DeleteKey("current_user")
 		f.userConfigWrapper.userConfig = nil
 		return f.Save()
+	}
+
+	if u.IsOneshot() {
+		f.userConfigWrapper.userConfig = u
+		return nil
 	}
 
 	parent := f.jw.AtKey("users")

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -293,7 +293,7 @@ func (f JSONConfigFile) GetUserConfigForUsername(nu NormalizedUsername) (*UserCo
 }
 
 func (f JSONConfigFile) copyUserConfigIfForUID(u keybase1.UID) *UserConfig {
-	if f.userConfigWrapper == nil {
+	if f.userConfigWrapper == nil || f.userConfigWrapper.userConfig == nil {
 		return nil
 	}
 	if f.userConfigWrapper.userConfig.GetUID().IsNil() {

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -292,7 +292,13 @@ func (f JSONConfigFile) GetUserConfigForUsername(nu NormalizedUsername) (*UserCo
 	return ImportUserConfigFromJSONWrapper(f.jw.AtKey("users").AtKey(nu.String()))
 }
 
-func (f JSONConfigFile) copyUserConfigIfForUID(u keybase1.UID) (*UserConfig) {
+func (f JSONConfigFile) copyUserConfigIfForUID(u keybase1.UID) *UserConfig {
+	if f.userConfigWrapper == nil {
+		return nil
+	}
+	if f.userConfigWrapper.userConfig.GetUID().IsNil() {
+		return nil
+	}
 	if f.userConfigWrapper.userConfig.GetUID().Equal(u) {
 		tmp := *f.userConfigWrapper.userConfig
 		return &tmp

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -583,6 +583,12 @@ func (e *Env) GetAPIDump() bool {
 	)
 }
 
+func (e *Env) GetAllowRoot() bool {
+	return e.GetBool(false,
+		func() (bool, bool) { return e.getEnvBool("KEYBASE_ALLOW_ROOT") },
+	)
+}
+
 func (e *Env) GetUsername() NormalizedUsername {
 	return e.GetConfig().GetUsername()
 }

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -970,6 +970,10 @@ type KeyRevokedError struct {
 	msg string
 }
 
+func NewKeyRevokedError(m string) KeyRevokedError {
+	return KeyRevokedError{m}
+}
+
 func (r KeyRevokedError) Error() string {
 	return fmt.Sprintf("Key revoked: %s", r.msg)
 }
@@ -1190,6 +1194,10 @@ func (e SkipSecretPromptError) Error() string {
 
 type NoDeviceError struct {
 	Reason string
+}
+
+func NewNoDeviceError(s string) NoDeviceError {
+	return NoDeviceError{s}
 }
 
 func (e NoDeviceError) Error() string {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -1292,3 +1292,16 @@ func (g *GlobalContext) AssertTemporarySession(lctx LoginContext) error {
 	}
 	return gerr
 }
+
+func (g *GlobalContext) IsOneshot(ctx context.Context) (bool, error) {
+	uc, err := g.Env.GetConfig().GetUserConfig()
+	if err != nil {
+		g.Log.CDebugf(ctx, "IsOneshot: Error getting a user config: %s", err)
+		return false, err
+	}
+	if uc == nil {
+		g.Log.CDebugf(ctx, "IsOneshot: nil user config")
+		return false, nil
+	}
+	return uc.IsOneshot(), nil
+}

--- a/go/libkb/userconfig.go
+++ b/go/libkb/userconfig.go
@@ -53,6 +53,8 @@ type UserConfig struct {
 	importedID       keybase1.UID
 	importedSalt     []byte
 	importedDeviceID keybase1.DeviceID
+
+	isOneshot bool
 }
 
 //==================================================================
@@ -61,6 +63,7 @@ func (u UserConfig) GetUID() keybase1.UID            { return u.importedID }
 func (u UserConfig) GetUsername() NormalizedUsername { return u.Name }
 func (u UserConfig) GetSalt() []byte                 { return u.importedSalt }
 func (u UserConfig) GetDeviceID() keybase1.DeviceID  { return u.importedDeviceID }
+func (u UserConfig) IsOneshot() bool { return u.isOneshot }
 
 //==================================================================
 
@@ -78,6 +81,12 @@ func NewUserConfig(id keybase1.UID, name NormalizedUsername, salt []byte, dev ke
 		tmp := dev.String()
 		ret.Device = &tmp
 	}
+	return ret
+}
+
+func NewOneshotUserConfig(id keybase1.UID, name NormalizedUsername, salt []byte, dev keybase1.DeviceID) *UserConfig {
+	ret := NewUserConfig(id, name, salt, dev)
+	ret.isOneshot = true
 	return ret
 }
 

--- a/go/libkb/userconfig.go
+++ b/go/libkb/userconfig.go
@@ -63,7 +63,7 @@ func (u UserConfig) GetUID() keybase1.UID            { return u.importedID }
 func (u UserConfig) GetUsername() NormalizedUsername { return u.Name }
 func (u UserConfig) GetSalt() []byte                 { return u.importedSalt }
 func (u UserConfig) GetDeviceID() keybase1.DeviceID  { return u.importedDeviceID }
-func (u UserConfig) IsOneshot() bool { return u.isOneshot }
+func (u UserConfig) IsOneshot() bool                 { return u.isOneshot }
 
 //==================================================================
 

--- a/go/protocol/keybase1/login.go
+++ b/go/protocol/keybase1/login.go
@@ -89,6 +89,12 @@ type AccountDeleteArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
 }
 
+type LoginOneshotArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Username  string `codec:"username" json:"username"`
+	PaperKey  string `codec:"paperKey" json:"paperKey"`
+}
+
 type LoginInterface interface {
 	// Returns an array of information about accounts configured on the local
 	// machine. Currently configured accounts are defined as those that have stored
@@ -131,6 +137,10 @@ type LoginInterface interface {
 	PGPProvision(context.Context, PGPProvisionArg) error
 	// accountDelete is for devel/testing to delete the current user's account.
 	AccountDelete(context.Context, int) error
+	// loginOnetime allows a service to have a "onetime login", without
+	// provisioning a device. It bootstraps credentials with the given
+	// paperkey
+	LoginOneshot(context.Context, LoginOneshotArg) error
 }
 
 func LoginProtocol(i LoginInterface) rpc.Protocol {
@@ -361,6 +371,22 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"loginOneshot": {
+				MakeArg: func() interface{} {
+					ret := make([]LoginOneshotArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]LoginOneshotArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]LoginOneshotArg)(nil), args)
+						return
+					}
+					err = i.LoginOneshot(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -470,5 +496,13 @@ func (c LoginClient) PGPProvision(ctx context.Context, __arg PGPProvisionArg) (e
 func (c LoginClient) AccountDelete(ctx context.Context, sessionID int) (err error) {
 	__arg := AccountDeleteArg{SessionID: sessionID}
 	err = c.Cli.Call(ctx, "keybase.1.login.accountDelete", []interface{}{__arg}, nil)
+	return
+}
+
+// loginOnetime allows a service to have a "onetime login", without
+// provisioning a device. It bootstraps credentials with the given
+// paperkey
+func (c LoginClient) LoginOneshot(ctx context.Context, __arg LoginOneshotArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.login.loginOneshot", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/keybase1/login.go
+++ b/go/protocol/keybase1/login.go
@@ -137,7 +137,7 @@ type LoginInterface interface {
 	PGPProvision(context.Context, PGPProvisionArg) error
 	// accountDelete is for devel/testing to delete the current user's account.
 	AccountDelete(context.Context, int) error
-	// loginOnetime allows a service to have a "onetime login", without
+	// loginOneshot allows a service to have a "onetime login", without
 	// provisioning a device. It bootstraps credentials with the given
 	// paperkey
 	LoginOneshot(context.Context, LoginOneshotArg) error
@@ -499,7 +499,7 @@ func (c LoginClient) AccountDelete(ctx context.Context, sessionID int) (err erro
 	return
 }
 
-// loginOnetime allows a service to have a "onetime login", without
+// loginOneshot allows a service to have a "onetime login", without
 // provisioning a device. It bootstraps credentials with the given
 // paperkey
 func (c LoginClient) LoginOneshot(ctx context.Context, __arg LoginOneshotArg) (err error) {

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -176,3 +176,13 @@ func (h *LoginHandler) AccountDelete(ctx context.Context, sessionID int) error {
 	eng := engine.NewAccountDelete(h.G())
 	return engine.RunEngine(eng, ectx)
 }
+
+func (h *LoginHandler) LoginOneshot(ctx context.Context, arg keybase1.LoginOneshotArg) error {
+	ectx := &engine.Context{
+		LogUI:      h.getLogUI(arg.SessionID),
+		NetContext: ctx,
+		SessionID:  arg.SessionID,
+	}
+	eng := engine.NewLoginOneshot(h.G(), arg)
+	return engine.RunEngine(eng, ectx)
+}

--- a/protocol/avdl/keybase1/login.avdl
+++ b/protocol/avdl/keybase1/login.avdl
@@ -27,12 +27,12 @@ protocol login {
     via email address does not work.
     */
   void login(int sessionID, string deviceType, string usernameOrEmail, ClientType clientType);
- 
+
   /**
     Login a user only if the user is on a provisioned device.  Username is optional.
     If noPassphrasePrompt is set, then only a stored secret will be used to unlock
     the device keys.
-    */ 
+    */
   void loginProvisionedDevice(int sessionID, string username, boolean noPassphrasePrompt);
 
   /**
@@ -81,4 +81,11 @@ protocol login {
     accountDelete is for devel/testing to delete the current user's account.
     */
   void accountDelete(int sessionID);
+
+  /**
+   loginOnetime allows a service to have a "onetime login", without
+   provisioning a device. It bootstraps credentials with the given
+   paperkey
+   */
+  void loginOneshot(int sessionID, string username, string paperKey);
 }

--- a/protocol/avdl/keybase1/login.avdl
+++ b/protocol/avdl/keybase1/login.avdl
@@ -83,7 +83,7 @@ protocol login {
   void accountDelete(int sessionID);
 
   /**
-   loginOnetime allows a service to have a "onetime login", without
+   loginOneshot allows a service to have a "onetime login", without
    provisioning a device. It bootstraps credentials with the given
    paperkey
    */

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1020,6 +1020,10 @@ export const loginGetConfiguredAccountsRpcChannelMap = (configKeys: Array<string
 
 export const loginGetConfiguredAccountsRpcPromise = (request: LoginGetConfiguredAccountsRpcParam): Promise<LoginGetConfiguredAccountsResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.login.getConfiguredAccounts', request, (error: RPCError, result: LoginGetConfiguredAccountsResult) => (error ? reject(error) : resolve(result))))
 
+export const loginLoginOneshotRpcChannelMap = (configKeys: Array<string>, request: LoginLoginOneshotRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.login.loginOneshot', request)
+
+export const loginLoginOneshotRpcPromise = (request: LoginLoginOneshotRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.login.loginOneshot', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
 export const loginLoginProvisionedDeviceRpcChannelMap = (configKeys: Array<string>, request: LoginLoginProvisionedDeviceRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.login.loginProvisionedDevice', request)
 
 export const loginLoginProvisionedDeviceRpcPromise = (request: LoginLoginProvisionedDeviceRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.login.loginProvisionedDevice', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
@@ -2724,6 +2728,8 @@ export type LoginClearStoredSecretRpcParam = $ReadOnly<{username: String, incomi
 export type LoginDeprovisionRpcParam = $ReadOnly<{username: String, doRevoke: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LoginGetConfiguredAccountsRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type LoginLoginOneshotRpcParam = $ReadOnly<{username: String, paperKey: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LoginLoginProvisionedDeviceRpcParam = $ReadOnly<{username: String, noPassphrasePrompt: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 

--- a/protocol/json/keybase1/login.json
+++ b/protocol/json/keybase1/login.json
@@ -213,6 +213,24 @@
       ],
       "response": null,
       "doc": "accountDelete is for devel/testing to delete the current user's account."
+    },
+    "loginOneshot": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "paperKey",
+          "type": "string"
+        }
+      ],
+      "response": null,
+      "doc": "loginOnetime allows a service to have a \"onetime login\", without\n   provisioning a device. It bootstraps credentials with the given\n   paperkey"
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/keybase1/login.json
+++ b/protocol/json/keybase1/login.json
@@ -230,7 +230,7 @@
         }
       ],
       "response": null,
-      "doc": "loginOnetime allows a service to have a \"onetime login\", without\n   provisioning a device. It bootstraps credentials with the given\n   paperkey"
+      "doc": "loginOneshot allows a service to have a \"onetime login\", without\n   provisioning a device. It bootstraps credentials with the given\n   paperkey"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1020,6 +1020,10 @@ export const loginGetConfiguredAccountsRpcChannelMap = (configKeys: Array<string
 
 export const loginGetConfiguredAccountsRpcPromise = (request: LoginGetConfiguredAccountsRpcParam): Promise<LoginGetConfiguredAccountsResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.login.getConfiguredAccounts', request, (error: RPCError, result: LoginGetConfiguredAccountsResult) => (error ? reject(error) : resolve(result))))
 
+export const loginLoginOneshotRpcChannelMap = (configKeys: Array<string>, request: LoginLoginOneshotRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.login.loginOneshot', request)
+
+export const loginLoginOneshotRpcPromise = (request: LoginLoginOneshotRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.login.loginOneshot', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
 export const loginLoginProvisionedDeviceRpcChannelMap = (configKeys: Array<string>, request: LoginLoginProvisionedDeviceRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.login.loginProvisionedDevice', request)
 
 export const loginLoginProvisionedDeviceRpcPromise = (request: LoginLoginProvisionedDeviceRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.login.loginProvisionedDevice', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
@@ -2724,6 +2728,8 @@ export type LoginClearStoredSecretRpcParam = $ReadOnly<{username: String, incomi
 export type LoginDeprovisionRpcParam = $ReadOnly<{username: String, doRevoke: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LoginGetConfiguredAccountsRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type LoginLoginOneshotRpcParam = $ReadOnly<{username: String, paperKey: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LoginLoginProvisionedDeviceRpcParam = $ReadOnly<{username: String, noPassphrasePrompt: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 


### PR DESCRIPTION
- allow a "oneshot" login for keybase, which means that you can specify a username and a paperkey, and the service in question will act on behalf of that user for the duration of its run, acting like a full keybase node
- it's a little bit a hack, in that the device will be the "paper key", but it appears to work in preliminary tests
- we had a request for such a feature to power kbfsgit from inside of short-lived dockers, and it doesn't make sense to provision them as a full keybase devices