### PR TITLE
Fix native inspector

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -257,6 +257,14 @@ See [this
 link](https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers)
 for how to increase the watch limit; I set mine to 65536.
 
+#### Native inspector
+
+If you get this error message on trying to open the inspector:
+
+`Expected to find exactly one React Native renderer on DevTools hook.`
+
+It might be because you're importing a library that attaches itself as a renderer, such as `react-dom`. If that's the case, you should make sure not to import any such module outside of a `.desktop.js` file, and if you have to, it should be predicated on `!isMobile` and use `require` to access the library.
+
 ### Dependency forks
 
 We have some custom forks of dependencies. This is usually a temporary fix and is something we want to avoid long term.

--- a/shared/chat/manage-channels/delete-channel.js
+++ b/shared/chat/manage-channels/delete-channel.js
@@ -1,8 +1,7 @@
 // @flow
 import * as React from 'react'
-import ReactDOM from 'react-dom'
 import {Text, Box, Icon, PopupMenu} from '../../common-adapters'
-import {globalStyles, globalColors, globalMargins} from '../../styles'
+import {globalStyles, globalColors, globalMargins, isMobile} from '../../styles'
 
 const PopupHeader = ({channelName}: {channelName: string}) => {
   return (
@@ -45,7 +44,10 @@ class DeleteChannel extends React.Component<Props, State> {
   // anyway.
 
   _hidePopup = () => {
-    ReactDOM.unmountComponentAtNode(document.getElementById('popupContainer'))
+    if (!isMobile) {
+      const ReactDOM = require('react-dom')
+      ReactDOM.unmountComponentAtNode(document.getElementById('popupContainer'))
+    }
   }
 
   _onClick(event: SyntheticEvent<>) {
@@ -78,8 +80,11 @@ class DeleteChannel extends React.Component<Props, State> {
       />
     )
     const container = document.getElementById('popupContainer')
-    // FIXME: this is the right way to render portals retaining context for now, though it will change in the future.
-    ReactDOM.unstable_renderSubtreeIntoContainer(this, popupComponent, container)
+    if (!isMobile) {
+      const ReactDOM = require('react-dom')
+      // FIXME: this is the right way to render portals retaining context for now, though it will change in the future.
+      ReactDOM.unstable_renderSubtreeIntoContainer(this, popupComponent, container)
+    }
   }
 
   render() {


### PR DESCRIPTION
It was broken because we imported `react-dom` on a module that was imported on native. Added a note to the readme about it. r? @keybase/react-hackers 