### PR TITLE
don't generate full PGP keys to speed up tests (~10s savings)

### DIFF
--- a/go/engine/pgp_keygen.go
+++ b/go/engine/pgp_keygen.go
@@ -11,7 +11,8 @@ import (
 // PGPKeyGen is an engine.
 type PGPKeyGen struct {
 	libkb.Contextified
-	arg keybase1.PGPKeyGenDefaultArg
+	arg    keybase1.PGPKeyGenDefaultArg
+	genArg *libkb.PGPGenArg
 }
 
 // NewPGPKeyGen creates a PGPKeyGen engine.
@@ -53,11 +54,16 @@ func (e *PGPKeyGen) SubConsumers() []libkb.UIConsumer {
 func (e *PGPKeyGen) Run(ctx *Context) error {
 
 	// generate a new pgp key with defaults (and no push)
+	var genArg libkb.PGPGenArg
+	if e.genArg != nil {
+		genArg = *e.genArg
+	}
+	genArg.Ids = libkb.ImportPGPIdentities(e.arg.CreateUids.Ids)
 	arg := PGPKeyImportEngineArg{
 		Ctx:        e.G(),
 		AllowMulti: true,
 		OnlySave:   true,
-		Gen:        &libkb.PGPGenArg{Ids: libkb.ImportPGPIdentities(e.arg.CreateUids.Ids)},
+		Gen:        &genArg,
 	}
 	eng := NewPGPKeyImportEngine(arg)
 	if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/pgp_keygen_test.go
+++ b/go/engine/pgp_keygen_test.go
@@ -4,9 +4,9 @@
 package engine
 
 import (
-	"testing"
-
+	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"testing"
 )
 
 func TestPGPKeyGenPush(t *testing.T) {
@@ -29,6 +29,10 @@ func TestPGPKeyGenPush(t *testing.T) {
 		},
 	}
 	eng := NewPGPKeyGen(tc.G, arg)
+	eng.genArg = &libkb.PGPGenArg{
+		PrimaryBits: 768,
+		SubkeyBits:  768,
+	}
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -68,6 +72,10 @@ func TestPGPKeyGenNoPush(t *testing.T) {
 		},
 	}
 	eng := NewPGPKeyGen(tc.G, arg)
+	eng.genArg = &libkb.PGPGenArg{
+		PrimaryBits: 768,
+		SubkeyBits:  768,
+	}
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Before:

```
[max@piave ~/src/go/src/github.com/keybase/client/go/engine ] time ./engine.test -test.run TestPGPKeyGen
PASS

real	0m11.680s
user	0m10.348s
sys	0m0.147s
```


After:
```
[max@piave ~/src/go/src/github.com/keybase/client/go/engine ] time ./engine.test -test.run TestPGPKeyGen
PASS

real	0m0.985s
user	0m0.154s
sys	0m0.051s
```