### PR TITLE
Use` Admin` flag for ephemeral generation

### DIFF
--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -59,7 +59,7 @@ func (e *EKLib) ShouldRun(ctx context.Context) bool {
 	g := e.G()
 
 	// TODO -- when we launch, remove the feature flagging on Prod
-	willRun := g.Env.GetFeatureFlags().UseEphemeral() || g.Env.GetRunMode() == libkb.DevelRunMode || g.Env.RunningInCI()
+	willRun := g.Env.GetFeatureFlags().Admin() || g.Env.GetRunMode() == libkb.DevelRunMode || g.Env.RunningInCI()
 	if !willRun {
 		e.G().Log.CDebugf(ctx, "EKLib skipping run")
 		return false

--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -30,15 +30,6 @@ func (set FeatureFlags) Admin() bool {
 	return false
 }
 
-func (set FeatureFlags) UseEphemeral() bool {
-	for _, f := range set {
-		if f == Feature("use-ephemeral") {
-			return true
-		}
-	}
-	return false
-}
-
 func (set FeatureFlags) Empty() bool {
 	return len(set) == 0
 }


### PR DESCRIPTION
depends on #11480. This will turn on ephemeral stuff for anyone with the admin feature flag set, if we run into major issues we can revert this to disable it again.

cc @maxtaco @mmaxim @oconnor663 