### PR TITLE
refactor so that non-engines can access Bootstrap+LoginContext

### DIFF
--- a/go/engine/common.go
+++ b/go/engine/common.go
@@ -34,36 +34,8 @@ func IsLoggedIn(e Engine, ctx *Context) (ret bool, uid keybase1.UID) {
 	return ret, uid
 }
 
-// bootstrap will setup an ActiveDevice with a NIST Factory for the engine
-// that's calling us. The LoginContext passed through isn't really needed
-// for anything aside from assertions, but as we phase out LoginState, we'll
-// leave it here so that assertions in LoginState can still pass.
 func bootstrap(e Engine, ctx *Context) (ok bool, uid keybase1.UID, err error) {
-
-	run := func(a libkb.LoginContext) (keybase1.UID, error) {
-		return libkb.BootstrapActiveDeviceFromConfig(ctx.NetContext, e.G(), a, true)
-	}
-	a := ctx.LoginContext
-	nctx := ctx.NetContext
-	g := e.G()
-	if a == nil {
-		aerr := g.LoginState().Account(func(a *libkb.Account) {
-			uid, err = run(a)
-		}, "BootstrapActiveDevice")
-		if err == nil && aerr != nil {
-			g.Log.CDebugf(nctx, "LoginOffline: LoginState account error: %s", aerr)
-			err = aerr
-		}
-	} else {
-		uid, err = run(a)
-	}
-	ok = false
-	if err == nil {
-		ok = true
-	} else if _, isLRE := err.(libkb.LoginRequiredError); isLRE {
-		err = nil
-	}
-	return ok, uid, err
+	return libkb.BootstrapActiveDeviceWithLoginContext(ctx.GetNetContext(), e.G(), ctx.LoginContext)
 }
 
 type keypair struct {

--- a/go/libkb/bootstrap_active_device.go
+++ b/go/libkb/bootstrap_active_device.go
@@ -140,12 +140,12 @@ func bootstrapActiveDeviceReturnRawError(ctx context.Context, g *GlobalContext, 
 // for anything aside from assertions, but as we phase out LoginState, we'll
 // leave it here so that assertions in LoginState can still pass.
 func BootstrapActiveDeviceWithLoginContext(ctx context.Context, g *GlobalContext, lctx LoginContext) (ok bool, uid keybase1.UID, err error) {
-	run := func(a LoginContext) (keybase1.UID, error) {
+	run := func(lctx LoginContext) (keybase1.UID, error) {
 		return BootstrapActiveDeviceFromConfig(ctx, g, lctx, true)
 	}
 	if lctx == nil {
-		aerr := g.LoginState().Account(func(a *Account) {
-			uid, err = run(a)
+		aerr := g.LoginState().Account(func(lctx *Account) {
+			uid, err = run(lctx)
 		}, "BootstrapActiveDevice")
 		if err == nil && aerr != nil {
 			g.Log.CDebugf(ctx, "LoginOffline: LoginState account error: %s", aerr)

--- a/go/libkb/bootstrap_active_device.go
+++ b/go/libkb/bootstrap_active_device.go
@@ -134,3 +134,31 @@ func bootstrapActiveDeviceReturnRawError(ctx context.Context, g *GlobalContext, 
 	err = ad.Set(g, lctx, uid, deviceID, sib, sub, deviceName)
 	return err
 }
+
+// BootstrapActiveDeviceWithLoginConext will setup an ActiveDevice with a NIST Factory
+// for the caller. The LoginContext passed through isn't really needed
+// for anything aside from assertions, but as we phase out LoginState, we'll
+// leave it here so that assertions in LoginState can still pass.
+func BootstrapActiveDeviceWithLoginContext(ctx context.Context, g *GlobalContext, lctx LoginContext) (ok bool, uid keybase1.UID, err error) {
+	run := func(a LoginContext) (keybase1.UID, error) {
+		return BootstrapActiveDeviceFromConfig(ctx, g, lctx, true)
+	}
+	if lctx == nil {
+		aerr := g.LoginState().Account(func(a *Account) {
+			uid, err = run(a)
+		}, "BootstrapActiveDevice")
+		if err == nil && aerr != nil {
+			g.Log.CDebugf(ctx, "LoginOffline: LoginState account error: %s", aerr)
+			err = aerr
+		}
+	} else {
+		uid, err = run(lctx)
+	}
+	ok = false
+	if err == nil {
+		ok = true
+	} else if _, isLRE := err.(LoginRequiredError); isLRE {
+		err = nil
+	}
+	return ok, uid, err
+}


### PR DESCRIPTION
small refactor to show this function to go/ephemeral...