### PR TITLE
Move UsernameTips above the username text input.

### DIFF
--- a/shared/profile/prove-enter-username.desktop.js
+++ b/shared/profile/prove-enter-username.desktop.js
@@ -72,6 +72,7 @@ class PrivateEnterUsernameRender extends Component<Props, State> {
           overlay={'icon-proof-unfinished'}
           overlayColor={globalColors.grey}
         />
+        <UsernameTips platform={this.props.platform} />
         <Input
           autoFocus={true}
           style={styleInput}
@@ -81,7 +82,6 @@ class PrivateEnterUsernameRender extends Component<Props, State> {
           onChangeText={username => this.handleUsernameChange(username)}
           onEnterKeyDown={() => this.handleContinue()}
         />
-        <UsernameTips platform={this.props.platform} />
         <Box style={{...globalStyles.flexBoxRow, marginTop: 32}}>
           <Button
             type="Secondary"
@@ -100,6 +100,8 @@ class PrivateEnterUsernameRender extends Component<Props, State> {
     )
   }
 }
+
+// FIXME: this is the old way (#styles)
 
 const styleErrorBanner = {
   ...globalStyles.flexBoxColumn,
@@ -142,10 +144,15 @@ const styleInput = {
 
 const styleInfoBanner = {
   ...globalStyles.flexBoxColumn,
-  alignSelf: 'stretch',
   alignItems: 'center',
   backgroundColor: globalColors.yellow,
-  padding: globalMargins.tiny,
+  marginTop: globalMargins.small,
+  marginBottom: -globalMargins.tiny,
+  paddingTop: globalMargins.xsmall,
+  paddingBottom: globalMargins.xsmall,
+  paddingLeft: globalMargins.small,
+  paddingRight: globalMargins.small,
+  borderRadius: 3,
 }
 
 export default PrivateEnterUsernameRender

--- a/shared/profile/prove-enter-username.native.js
+++ b/shared/profile/prove-enter-username.native.js
@@ -65,6 +65,7 @@ class PrivateEnterUsernameRender extends Component<Props, State> {
           overlay={'icon-proof-pending'}
           overlayColor={globalColors.grey}
         />
+        <UsernameTips platform={this.props.platform} />
         <Input
           style={styleInput}
           autoFocus={true}
@@ -74,7 +75,6 @@ class PrivateEnterUsernameRender extends Component<Props, State> {
           onChangeText={username => this.handleUsernameChange(username)}
           onEnterKeyDown={() => this.handleContinue()}
         />
-        <UsernameTips platform={this.props.platform} />
         <Button
           style={styleButton}
           type="Primary"
@@ -88,17 +88,20 @@ class PrivateEnterUsernameRender extends Component<Props, State> {
   }
 }
 
+// FIXME: this is the old way (#styles)
+
 const styleErrorBannerText = {
   color: globalColors.white,
 }
 
 const styleIcon = {
   alignSelf: 'center',
+  marginTop: globalMargins.mediumLarge,
 }
 
 const styleInput = {
   marginBottom: 0,
-  marginTop: globalMargins.large,
+  marginTop: globalMargins.mediumLarge,
 }
 
 const styleInfoBanner = {
@@ -110,6 +113,7 @@ const styleInfoBanner = {
   paddingLeft: globalMargins.medium,
   paddingRight: globalMargins.medium,
   marginTop: globalMargins.large,
+  marginBottom: -globalMargins.medium,
   marginLeft: -globalMargins.medium,
   marginRight: -globalMargins.medium,
 }

--- a/shared/styles/shared.js
+++ b/shared/styles/shared.js
@@ -6,8 +6,10 @@ import type {_StylesCrossPlatform, _StylesMobile, _StylesDesktop} from './css'
 export const globalMargins = {
   xtiny: 4,
   tiny: 8,
+  xsmall: 12,
   small: 16,
   medium: 24,
+  mediumLarge: 32,
   large: 40,
   xlarge: 64,
 }


### PR DESCRIPTION
Resolves DESKTOP-3339

I added some space around the icon, banner, and text input to give things a little more breathing space on native. I also resized the container to not span the entire width of the container on desktop, reference the images below.

**Before**
<img width="831" alt="screen shot 2018-04-24 at 11 41 41 am" src="https://user-images.githubusercontent.com/30595/39202614-6918ca1c-47c0-11e8-9e21-a6f3d6198f13.png">
<img width="831" alt="screen shot 2018-04-24 at 11 41 51 am" src="https://user-images.githubusercontent.com/30595/39202615-6926daa8-47c0-11e8-9c25-6a27371cea29.png">
<img width="432" alt="screen shot 2018-04-24 at 11 42 30 am" src="https://user-images.githubusercontent.com/30595/39202616-693038aa-47c0-11e8-8ef3-72fe742f6a16.png">
<img width="432" alt="screen shot 2018-04-24 at 11 42 44 am" src="https://user-images.githubusercontent.com/30595/39202617-693bb8ba-47c0-11e8-829d-ae4233307d1b.png">

**After**
<img width="831" alt="screen shot 2018-04-24 at 1 09 23 pm" src="https://user-images.githubusercontent.com/30595/39202819-18aa1b2a-47c1-11e8-81e3-52e6f08213bd.png">
<img width="831" alt="screen shot 2018-04-24 at 1 09 40 pm" src="https://user-images.githubusercontent.com/30595/39202820-18e4badc-47c1-11e8-8f4e-0703ae48c152.png">
<img width="432" alt="screen shot 2018-04-24 at 1 10 24 pm" src="https://user-images.githubusercontent.com/30595/39202821-1911ed5e-47c1-11e8-828a-6ca9e1d65ab0.png">
<img width="432" alt="screen shot 2018-04-24 at 1 10 35 pm" src="https://user-images.githubusercontent.com/30595/39202822-1933efda-47c1-11e8-80e7-85ec761d6b26.png">