### PR TITLE
Fix chat button on reddit redesign

### DIFF
--- a/browser/js/inject.js
+++ b/browser/js/inject.js
@@ -51,7 +51,7 @@ const profileInject = {
   },
 
   "reddit": function redditInjectProfile(user) {
-    const container = document.querySelector("h1");
+    const container = document.querySelector("h1") || document.querySelector("h4").nextSibling;
     if (!container) return;
 
     const button = renderProfileChatButton(user);

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -2,7 +2,7 @@
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsc0yU3MTDhx+JC23YHwvWo/TD1Pynkdc9QekQ7S3jpl0isgro3I5K0ywANwBsZicIYhVq3OQTzV4jq53YoJSP9OFApMb3yzqzJ/QmcwpGvHjztD6I2zPoglMLnWj12VNqFqJtqVj5tT+/TQJ2MdY4eCQpuPweEwDLsR9mP2mxlpV1iCNzF2T61DAqnLmV8zeyjrwJ1QRZq/qd0lJR5JRI8+xBTTStOy2eQvnf8ngEXq2R+NXNq10MELtTpfAT0NPPS1lUbJwR9AYbm9f4wQWLxpeyl63WlmbBUsInM9jsfccDo0hULa59IWpgTdFVQFMBFlIEIN7St8QpF09OygMNQIDAQAB",
   "name": "Keybase",
   "short_name": "Keybase",
-  "version": "1.10.13",
+  "version": "1.10.14",
   "description": "A secure chat button for every profile.",
   "icons": {
     "48": "images/icon-keybase-logo-48.png",


### PR DESCRIPTION
Reddit is launching a redesign which breaks chat button injection, this fixes it to work for the old and new designs. We should keep an eye on this until it's fully stable to make sure we don't have to change it further

old design:
![screen shot 2018-04-25 at 11 44 19 am](https://user-images.githubusercontent.com/1144020/39257219-00f79908-487f-11e8-81b0-9e8abe059ab6.png)

new design:
![screen shot 2018-04-25 at 11 44 44 am](https://user-images.githubusercontent.com/1144020/39257220-01147212-487f-11e8-9f79-cacee8c6f8b2.png)




cc @shazow @mlsteele 