### PR TITLE
implement BgTicker for background tasks

### DIFF
--- a/go/libkb/bgticker.go
+++ b/go/libkb/bgticker.go
@@ -1,0 +1,129 @@
+package libkb
+
+import (
+	"context"
+	"time"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+)
+
+const (
+	stateIdle = iota
+	stateActive
+	stateExpired
+)
+
+const defaultResumeWait = time.Second
+
+type BgTicker struct {
+	Contextified
+
+	C          <-chan time.Time
+	c          chan time.Time
+	duration   time.Duration
+	state      int
+	startedAt  time.Time
+	resumeWait time.Duration
+	t          *time.Timer
+	fn         func()
+
+	// For testing
+	clock      clockwork.Clock
+	appStateCh chan struct{}
+}
+
+func NewBgTicker(g *GlobalContext, d time.Duration) *BgTicker {
+	c := make(chan time.Time, 1)
+	t := &BgTicker{
+		Contextified: NewContextified(g),
+		duration:     d,
+		C:            c,
+		c:            c,
+		resumeWait:   defaultResumeWait,
+		clock:        clockwork.NewRealClock(),
+	}
+
+	t.fn = func() {
+		t.c <- t.clock.Now()
+		t.t = time.AfterFunc(t.duration, t.fn)
+	}
+	go t.monitorAppState()
+	return t
+}
+
+func (t *BgTicker) SetClock(clock clockwork.Clock) {
+	t.clock = clock
+}
+
+// Pause pauses current timer until Start method is be called.
+// Next Start call will wait rest of duration + resumeWait.
+func (t *BgTicker) Pause() bool {
+	if t.state != stateActive {
+		return false
+	}
+	if !t.t.Stop() {
+		t.state = stateExpired
+		return false
+	}
+	t.state = stateIdle
+	dur := time.Now().Sub(t.startedAt)
+	t.duration = t.duration - dur + t.resumeWait
+	return true
+}
+
+// Start starts BgTicker that will send the current time on its channel after
+// at least duration d.
+func (t *BgTicker) Start() bool {
+	if t.state != stateIdle {
+		return false
+	}
+	t.startedAt = t.clock.Now()
+	t.state = stateActive
+	t.t = time.AfterFunc(t.duration, t.fn)
+	return true
+}
+
+// Stop prevents the BgTicker from firing. It returns true if the call stops
+// the timer, false if the timer has already expired or been stopped.
+// Stop does not close the channel, to prevent a read from the channel
+// succeeding incorrectly.
+func (t *BgTicker) Stop() bool {
+	if t.state != stateActive {
+		return false
+	}
+	t.startedAt = t.clock.Now()
+	t.state = stateExpired
+	t.t.Stop()
+	return true
+}
+
+// Monitor the AppState and pause the ticker if the app goes to the background.
+func (t *BgTicker) monitorAppState() {
+	ctx := context.Background()
+	paused := false
+	t.G().Log.CDebugf(ctx, "monitorAppState: starting up")
+	state := keybase1.AppState_FOREGROUND
+	for {
+		state = <-t.G().AppState.NextUpdate(&state)
+		switch state {
+		case keybase1.AppState_FOREGROUND:
+			t.G().Log.CDebugf(ctx, "monitorAppState: foregrounded")
+			// Only resume if we had paused earlier (frontend can spam us with these)
+			if paused {
+				t.G().Log.CDebugf(ctx, "monitorAppState: resuming ticker")
+				t.Start()
+				paused = false
+			}
+		case keybase1.AppState_BACKGROUND:
+			t.G().Log.CDebugf(ctx, "monitorAppState: backgrounded, pausing ticker")
+			if !paused {
+				t.Pause()
+				paused = true
+			}
+		}
+		if t.appStateCh != nil {
+			t.appStateCh <- struct{}{}
+		}
+	}
+}

--- a/go/libkb/bgticker.go
+++ b/go/libkb/bgticker.go
@@ -46,6 +46,8 @@ func NewBgTicker(g *GlobalContext, d time.Duration) *BgTicker {
 
 	t.fn = func() {
 		t.c <- t.clock.Now()
+		// reset the duration in case we modified it when calling Pause
+		t.duration = d
 		t.t = time.AfterFunc(t.duration, t.fn)
 	}
 	go t.monitorAppState()

--- a/go/libkb/bgticker.go
+++ b/go/libkb/bgticker.go
@@ -1,131 +1,42 @@
 package libkb
 
 import (
-	"context"
 	"time"
-
-	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/clockwork"
 )
-
-const (
-	stateIdle = iota
-	stateActive
-	stateExpired
-)
-
-const defaultResumeWait = time.Second
 
 type BgTicker struct {
-	Contextified
-
 	C          <-chan time.Time
 	c          chan time.Time
-	duration   time.Duration
-	state      int
-	startedAt  time.Time
+	ticker     *time.Ticker
 	resumeWait time.Duration
-	t          *time.Timer
-	fn         func()
-
-	// For testing
-	clock      clockwork.Clock
-	appStateCh chan struct{}
 }
 
-func NewBgTicker(g *GlobalContext, d time.Duration) *BgTicker {
+func NewBgTicker(duration time.Duration, wait time.Duration) *BgTicker {
+	return NewBgTickerWithWait(duration, 10*time.Second)
+}
+
+func NewBgTickerWithWait(duration time.Duration, wait time.Duration) *BgTicker {
 	c := make(chan time.Time, 1)
 	t := &BgTicker{
-		Contextified: NewContextified(g),
-		duration:     d,
-		C:            c,
-		c:            c,
-		resumeWait:   defaultResumeWait,
-		clock:        clockwork.NewRealClock(),
+		C:          c,
+		c:          c,
+		ticker:     time.NewTicker(duration - wait),
+		resumeWait: wait,
 	}
-
-	t.fn = func() {
-		t.c <- t.clock.Now()
-		// reset the duration in case we modified it when calling Pause
-		t.duration = d
-		t.t = time.AfterFunc(t.duration, t.fn)
-	}
-	go t.monitorAppState()
+	go t.tick()
 	return t
 }
 
-func (t *BgTicker) SetClock(clock clockwork.Clock) {
-	t.clock = clock
-}
-
-// Pause pauses current timer until Start method is be called.
-// Next Start call will wait rest of duration + resumeWait.
-func (t *BgTicker) Pause() bool {
-	if t.state != stateActive {
-		return false
-	}
-	if !t.t.Stop() {
-		t.state = stateExpired
-		return false
-	}
-	t.state = stateIdle
-	dur := time.Now().Sub(t.startedAt)
-	t.duration = t.duration - dur + t.resumeWait
-	return true
-}
-
-// Start starts BgTicker that will send the current time on its channel after
-// at least duration d.
-func (t *BgTicker) Start() bool {
-	if t.state != stateIdle {
-		return false
-	}
-	t.startedAt = t.clock.Now()
-	t.state = stateActive
-	t.t = time.AfterFunc(t.duration, t.fn)
-	return true
-}
-
-// Stop prevents the BgTicker from firing. It returns true if the call stops
-// the timer, false if the timer has already expired or been stopped.
-// Stop does not close the channel, to prevent a read from the channel
-// succeeding incorrectly.
-func (t *BgTicker) Stop() bool {
-	if t.state != stateActive {
-		return false
-	}
-	t.startedAt = t.clock.Now()
-	t.state = stateExpired
-	t.t.Stop()
-	return true
-}
-
-// Monitor the AppState and pause the ticker if the app goes to the background.
-func (t *BgTicker) monitorAppState() {
-	ctx := context.Background()
-	paused := false
-	t.G().Log.CDebugf(ctx, "monitorAppState: starting up")
-	state := keybase1.AppState_FOREGROUND
+func (t *BgTicker) tick() {
 	for {
-		state = <-t.G().AppState.NextUpdate(&state)
-		switch state {
-		case keybase1.AppState_FOREGROUND:
-			t.G().Log.CDebugf(ctx, "monitorAppState: foregrounded")
-			// Only resume if we had paused earlier (frontend can spam us with these)
-			if paused {
-				t.G().Log.CDebugf(ctx, "monitorAppState: resuming ticker")
-				t.Start()
-				paused = false
-			}
-		case keybase1.AppState_BACKGROUND:
-			t.G().Log.CDebugf(ctx, "monitorAppState: backgrounded, pausing ticker")
-			if !paused {
-				t.Pause()
-				paused = true
-			}
-		}
-		if t.appStateCh != nil {
-			t.appStateCh <- struct{}{}
+		select {
+		case c := <-t.ticker.C:
+			time.Sleep(t.resumeWait)
+			t.c <- c
 		}
 	}
+}
+
+func (t *BgTicker) Stop() {
+	t.ticker.Stop()
 }

--- a/go/libkb/bgticker.go
+++ b/go/libkb/bgticker.go
@@ -11,7 +11,13 @@ type BgTicker struct {
 	resumeWait time.Duration
 }
 
-func NewBgTicker(duration time.Duration, wait time.Duration) *BgTicker {
+// This ticker wrap's Go's time.Ticker to wait a given time.Duration before
+// firing. This is helpful to not overload the mobile apps when they are
+// brought to the foreground and all have tasks that are ready to fire.
+
+// NewBgTicker will panic if wait > duration as time.Ticker does with a
+// negative duration.
+func NewBgTicker(duration time.Duration) *BgTicker {
 	return NewBgTickerWithWait(duration, 10*time.Second)
 }
 

--- a/go/libkb/bgticker_test.go
+++ b/go/libkb/bgticker_test.go
@@ -4,115 +4,23 @@ import (
 	"testing"
 	"time"
 
-	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
 )
 
 const chWait = 5 * time.Second
 
-func setupBgTickerTest(t *testing.T) (TestContext, *BgTicker, clockwork.FakeClock) {
-	tc := SetupTest(t, "ticker", 1)
-	fc := clockwork.NewFakeClock()
-	ticker := NewBgTicker(tc.G, time.Second)
-	ticker.SetClock(fc)
-	return tc, ticker, fc
-}
+func TestBgTicker(t *testing.T) {
+	duration := 2 * time.Millisecond
+	ticker := NewBgTickerWithWait(duration, time.Millisecond)
 
-func TestBgTickerStart(t *testing.T) {
-	_, ticker, clock := setupBgTickerTest(t)
-
-	start := clock.Now()
-	require.True(t, ticker.Start())
-	clock.Advance(ticker.duration)
-
+	start := time.Now()
 	// Test tick
 	for i := 0; i < 5; i++ {
 		select {
 		case <-ticker.C:
-			require.True(t, clock.Now().Sub(start) >= ticker.duration)
-			clock.Advance(ticker.duration)
+			require.True(t, time.Now().Sub(start) >= duration)
 		case <-time.After(chWait):
 			require.Fail(t, "ticker did not fire")
 		}
-	}
-}
-
-func TestBgTickerStop(t *testing.T) {
-	_, ticker, clock := setupBgTickerTest(t)
-
-	require.True(t, ticker.Start())
-	require.True(t, ticker.Stop())
-	clock.Advance(time.Second * 2)
-
-	select {
-	case <-ticker.C:
-		require.Fail(t, "stop is not working")
-	case <-time.After(ticker.duration):
-	}
-}
-
-func TestBgTickerPause(t *testing.T) {
-	_, ticker, clock := setupBgTickerTest(t)
-
-	start := clock.Now()
-	require.True(t, ticker.Start())
-	clock.Advance(time.Microsecond * 500)
-
-	require.True(t, ticker.Pause())
-	clock.Advance(time.Second)
-
-	require.True(t, ticker.Start())
-	clock.Advance(time.Second)
-
-	select {
-	case <-ticker.C:
-		require.True(t, clock.Now().Sub(start) >= ticker.duration)
-	case <-time.After(chWait):
-		require.Fail(t, "ticker did not fire")
-	}
-}
-
-func TestBgTickerBackgroundStateChanges(t *testing.T) {
-	tc, ticker, clock := setupBgTickerTest(t)
-
-	appStateCh := make(chan struct{})
-	ticker.appStateCh = appStateCh
-
-	start := clock.Now()
-	require.True(t, ticker.Start())
-
-	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
-	select {
-	case <-appStateCh:
-		require.Fail(t, "app state")
-	default:
-	}
-	require.Equal(t, ticker.state, stateActive)
-
-	// Set the background state and assert that we are paused
-	tc.G.AppState.Update(keybase1.AppState_BACKGROUND)
-	select {
-	case <-appStateCh:
-	case <-time.After(chWait):
-		require.Fail(t, "no app state")
-	}
-	require.Equal(t, ticker.state, stateIdle)
-	clock.Advance(time.Second)
-
-	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
-	select {
-	case <-appStateCh:
-	case <-time.After(chWait):
-		require.Fail(t, "no app state")
-	}
-	require.Equal(t, ticker.state, stateActive)
-	clock.Advance(time.Second)
-
-	select {
-	case <-ticker.C:
-		require.True(t, clock.Now().Sub(start) >= ticker.duration)
-	case <-time.After(chWait):
-		require.Fail(t, "ticker did not fire")
 	}
 }

--- a/go/libkb/bgticker_test.go
+++ b/go/libkb/bgticker_test.go
@@ -1,0 +1,118 @@
+package libkb
+
+import (
+	"testing"
+	"time"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+const chWait = 5 * time.Second
+
+func setupBgTickerTest(t *testing.T) (TestContext, *BgTicker, clockwork.FakeClock) {
+	tc := SetupTest(t, "ticker", 1)
+	fc := clockwork.NewFakeClock()
+	ticker := NewBgTicker(tc.G, time.Second)
+	ticker.SetClock(fc)
+	return tc, ticker, fc
+}
+
+func TestBgTickerStart(t *testing.T) {
+	_, ticker, clock := setupBgTickerTest(t)
+
+	start := clock.Now()
+	require.True(t, ticker.Start())
+	clock.Advance(ticker.duration)
+
+	// Test tick
+	for i := 0; i < 5; i++ {
+		select {
+		case <-ticker.C:
+			require.True(t, clock.Now().Sub(start) >= ticker.duration)
+			clock.Advance(ticker.duration)
+		case <-time.After(chWait):
+			require.Fail(t, "ticker did not fire")
+		}
+	}
+}
+
+func TestBgTickerStop(t *testing.T) {
+	_, ticker, clock := setupBgTickerTest(t)
+
+	require.True(t, ticker.Start())
+	require.True(t, ticker.Stop())
+	clock.Advance(time.Second * 2)
+
+	select {
+	case <-ticker.C:
+		require.Fail(t, "stop is not working")
+	case <-time.After(ticker.duration):
+	}
+}
+
+func TestBgTickerPause(t *testing.T) {
+	_, ticker, clock := setupBgTickerTest(t)
+
+	start := clock.Now()
+	require.True(t, ticker.Start())
+	clock.Advance(time.Microsecond * 500)
+
+	require.True(t, ticker.Pause())
+	clock.Advance(time.Second)
+
+	require.True(t, ticker.Start())
+	clock.Advance(time.Second)
+
+	select {
+	case <-ticker.C:
+		require.True(t, clock.Now().Sub(start) >= ticker.duration)
+	case <-time.After(chWait):
+		require.Fail(t, "ticker did not fire")
+	}
+}
+
+func TestBgTickerBackgroundStateChanges(t *testing.T) {
+	tc, ticker, clock := setupBgTickerTest(t)
+
+	appStateCh := make(chan struct{})
+	ticker.appStateCh = appStateCh
+
+	start := clock.Now()
+	require.True(t, ticker.Start())
+
+	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
+	select {
+	case <-appStateCh:
+		require.Fail(t, "app state")
+	default:
+	}
+	require.Equal(t, ticker.state, stateActive)
+
+	// Set the background state and assert that we are paused
+	tc.G.AppState.Update(keybase1.AppState_BACKGROUND)
+	select {
+	case <-appStateCh:
+	case <-time.After(chWait):
+		require.Fail(t, "no app state")
+	}
+	require.Equal(t, ticker.state, stateIdle)
+	clock.Advance(time.Second)
+
+	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
+	select {
+	case <-appStateCh:
+	case <-time.After(chWait):
+		require.Fail(t, "no app state")
+	}
+	require.Equal(t, ticker.state, stateActive)
+	clock.Advance(time.Second)
+
+	select {
+	case <-ticker.C:
+		require.True(t, clock.Now().Sub(start) >= ticker.duration)
+	case <-time.After(chWait):
+		require.Fail(t, "ticker did not fire")
+	}
+}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -556,7 +556,7 @@ func (d *Service) writeServiceInfo() error {
 }
 
 func (d *Service) chatEphemeralPurgeChecks() {
-	ticker := libkb.NewBgTicker(d.G(), 5*time.Minute)
+	ticker := libkb.NewBgTicker(5 * time.Minute)
 	d.G().PushShutdownHook(func() error {
 		d.G().Log.Debug("stopping chatEphemeralPurgeChecks loop")
 		ticker.Stop()
@@ -582,7 +582,7 @@ func (d *Service) chatEphemeralPurgeChecks() {
 }
 
 func (d *Service) hourlyChecks() {
-	ticker := libkb.NewBgTicker(d.G(), 1*time.Hour)
+	ticker := libkb.NewBgTicker(1 * time.Hour)
 	d.G().PushShutdownHook(func() error {
 		d.G().Log.Debug("stopping hourlyChecks loop")
 		ticker.Stop()
@@ -614,7 +614,7 @@ func (d *Service) hourlyChecks() {
 }
 
 func (d *Service) slowChecks() {
-	ticker := libkb.NewBgTicker(d.G(), 6*time.Hour)
+	ticker := libkb.NewBgTicker(6 * time.Hour)
 	d.G().PushShutdownHook(func() error {
 		d.G().Log.Debug("stopping slowChecks loop")
 		ticker.Stop()

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -556,7 +556,7 @@ func (d *Service) writeServiceInfo() error {
 }
 
 func (d *Service) chatEphemeralPurgeChecks() {
-	ticker := time.NewTicker(5 * time.Minute)
+	ticker := libkb.NewBgTicker(d.G(), 5*time.Minute)
 	d.G().PushShutdownHook(func() error {
 		d.G().Log.Debug("stopping chatEphemeralPurgeChecks loop")
 		ticker.Stop()
@@ -582,7 +582,7 @@ func (d *Service) chatEphemeralPurgeChecks() {
 }
 
 func (d *Service) hourlyChecks() {
-	ticker := time.NewTicker(1 * time.Hour)
+	ticker := libkb.NewBgTicker(d.G(), 1*time.Hour)
 	d.G().PushShutdownHook(func() error {
 		d.G().Log.Debug("stopping hourlyChecks loop")
 		ticker.Stop()
@@ -614,7 +614,7 @@ func (d *Service) hourlyChecks() {
 }
 
 func (d *Service) slowChecks() {
-	ticker := time.NewTicker(6 * time.Hour)
+	ticker := libkb.NewBgTicker(d.G(), 6*time.Hour)
 	d.G().PushShutdownHook(func() error {
 		d.G().Log.Debug("stopping slowChecks loop")
 		ticker.Stop()


### PR DESCRIPTION
To address:
```
There are a ton of things happening in hourlyChecks in the service, and they all basically fire at once 
when we foreground the mobile app. I think it is actually causing the app to potentially crash. Even if 
that theory is wrong, it is still a ton of wasted effort when foregrounding to be checking things new 
tracks, or EK generation, or device revoke.
```

`BgTicker` offers a `Pause` method to pause the ticker when the app is moved to the background. Once resumed (when the app is moved back to the foreground), the ticker will wait the remaining duration from when it was paused with an additional `resumeWait` so it doesn't overload the app.

based loosely on: https://github.com/ivahaev/timer 

cc @mmaxim 