### PR TITLE
[KBFS-2910] Fix Android Downloads

### DIFF
--- a/shared/actions/fs-gen.js
+++ b/shared/actions/fs-gen.js
@@ -41,7 +41,6 @@ export const createDismissTransfer = (payload: $ReadOnly<{|key: string|}>) => ({
 export const createDownload = (
   payload: $ReadOnly<{|
     intent: Types.TransferIntent,
-    mimeType?: string,
     path: Types.Path,
     localPath?: string,
   |}>

--- a/shared/actions/fs-platform-specific.android.js
+++ b/shared/actions/fs-platform-specific.android.js
@@ -36,8 +36,8 @@ export function copyToDownloadDir(path: string, mime: string): Promise<*> {
     .then(() => unlink(path))
     .then(() =>
       RNFetchBlob.android.addCompleteDownload({
-        title: 'Keybase Download',
-        description: 'Keybase Download',
+        title: fileName,
+        description: `Keybase downloaded ${fileName}`,
         mime,
         path: downloadPath,
         showNotification: true,

--- a/shared/actions/fs-platform-specific.android.js
+++ b/shared/actions/fs-platform-specific.android.js
@@ -1,0 +1,51 @@
+// @flow
+import * as FsGen from './fs-gen'
+import * as Saga from '../util/saga'
+import * as RPCTypes from '../constants/types/rpc-gen'
+import type {TypedState} from '../constants/reducer'
+import RNFetchBlob from 'react-native-fetch-blob'
+import {copy, unlink} from '../util/file'
+import {PermissionsAndroid} from 'react-native'
+
+export function openInFileUISaga(payload: FsGen.OpenInFileUIPayload, state: TypedState) {}
+export function* fuseStatusSaga(): Saga.SagaGenerator<any, any> {}
+export function fuseStatusResultSaga() {}
+export function* installFuseSaga(): Saga.SagaGenerator<any, any> {}
+export function installDokanSaga() {}
+export function installKBFS() {}
+export function installKBFSSuccess(payload: RPCTypes.InstallResult) {}
+export function openSecurityPreferences() {}
+export function uninstallKBFSConfirmSaga(): Promise<*> {
+  return new Promise((resolve, reject) => reject(new Error('unimplemented')))
+}
+export function uninstallKBFSSaga() {}
+export function uninstallKBFSSagaSuccess(result: RPCTypes.UninstallResult) {}
+export function copyToDownloadDir(path: string, mime: string): Promise<*> {
+  const fileName = path.substring(path.lastIndexOf('/') + 1)
+  const downloadPath = `${RNFetchBlob.fs.dirs.DownloadDir}/${fileName}`
+  return PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE, {
+    title: 'Keybase Storage Permission',
+    message: 'Keybase needs access to your storage so we can download a file to it',
+  })
+    .then(permissionStatus => {
+      if (permissionStatus !== 'granted') {
+        throw new Error('Unable to acquire storage permissions')
+      }
+      return copy(path, downloadPath)
+    })
+    .then(() => unlink(path))
+    .then(() =>
+      RNFetchBlob.android.addCompleteDownload({
+        title: 'Keybase Download',
+        description: 'Keybase Download',
+        mime,
+        path: downloadPath,
+        showNotification: true,
+      })
+    )
+    .catch(err => {
+      console.log('Error completing download')
+      console.log(err)
+      throw err
+    })
+}

--- a/shared/actions/fs-platform-specific.desktop.js
+++ b/shared/actions/fs-platform-specific.desktop.js
@@ -261,3 +261,7 @@ function installCachedDokan(): Promise<*> {
 export function installDokanSaga() {
   return Saga.call(installCachedDokan)
 }
+
+export function copyToDownloadDir(path: string): Promise<*> {
+  return new Promise((resolve, reject) => reject(new Error('unimplemented')))
+}

--- a/shared/actions/fs-platform-specific.desktop.js
+++ b/shared/actions/fs-platform-specific.desktop.js
@@ -265,7 +265,3 @@ export function installDokanSaga() {
 export function copyToDownloadDir(path: string): Promise<*> {
   return new Promise((resolve, reject) => reject(new Error('unimplemented')))
 }
-
-export function requestStoragePermissions(): Promise<*> {
-  return new Promise((resolve, reject) => reject(new Error('unimplemented')))
-}

--- a/shared/actions/fs-platform-specific.desktop.js
+++ b/shared/actions/fs-platform-specific.desktop.js
@@ -265,3 +265,7 @@ export function installDokanSaga() {
 export function copyToDownloadDir(path: string): Promise<*> {
   return new Promise((resolve, reject) => reject(new Error('unimplemented')))
 }
+
+export function requestStoragePermissions(): Promise<*> {
+  return new Promise((resolve, reject) => reject(new Error('unimplemented')))
+}

--- a/shared/actions/fs-platform-specific.ios.js
+++ b/shared/actions/fs-platform-specific.ios.js
@@ -21,19 +21,5 @@ export function uninstallKBFSConfirmSaga(): Promise<*> {
 export function uninstallKBFSSaga() {}
 export function uninstallKBFSSagaSuccess(result: RPCTypes.UninstallResult) {}
 export function copyToDownloadDir(path: string, mime: string): Promise<*> {
-  if (isAndroid) {
-    const downloadDir = RNFetchBlob.fs.dirs.DownloadDir
-    const fileName = path.substring(path.lastIndexOf('/'))
-    const downloadPath = `${downloadDir}/${fileName}`
-    copy(path, downloadPath).then(() =>
-      RNFetchBlob.android.addCompleteDownload({
-        title: 'Keybase Download',
-        description: 'Keybase Download',
-        mime,
-        downloadPath,
-        showNotification: true,
-      })
-    )
-  }
-  return new Promise((resolve, reject) => resolve())
+  return new Promise((resolve, reject) => reject(new Error('unimplemented')))
 }

--- a/shared/actions/fs-platform-specific.ios.js
+++ b/shared/actions/fs-platform-specific.ios.js
@@ -3,9 +3,6 @@ import * as FsGen from './fs-gen'
 import * as Saga from '../util/saga'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import type {TypedState} from '../constants/reducer'
-import RNFetchBlob from 'react-native-fetch-blob'
-import {isAndroid} from '../constants/platform'
-import {copy} from '../util/file'
 
 export function openInFileUISaga(payload: FsGen.OpenInFileUIPayload, state: TypedState) {}
 export function* fuseStatusSaga(): Saga.SagaGenerator<any, any> {}

--- a/shared/actions/fs-platform-specific.js.flow
+++ b/shared/actions/fs-platform-specific.js.flow
@@ -15,3 +15,4 @@ declare export function uninstallKBFSConfirmSaga(): Promise<*>
 declare export function uninstallKBFS(): void
 declare export function uninstallKBFSSuccess(result: RPCTypes.UninstallResult): void
 declare export function openSecurityPreferences(): Saga.SagaGenerator<any, any>
+declare export function copyToDownloadDir(path: string): Promise<*>

--- a/shared/actions/fs-platform-specific.native.js
+++ b/shared/actions/fs-platform-specific.native.js
@@ -3,6 +3,8 @@ import * as FsGen from './fs-gen'
 import * as Saga from '../util/saga'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import type {TypedState} from '../constants/reducer'
+import RNFetchBlob from 'react-native-fetch-blob'
+import {isAndroid} from '../constants/platform'
 
 export function openInFileUISaga(payload: FsGen.OpenInFileUIPayload, state: TypedState) {}
 export function* fuseStatusSaga(): Saga.SagaGenerator<any, any> {}
@@ -17,3 +19,15 @@ export function uninstallKBFSConfirmSaga(): Promise<*> {
 }
 export function uninstallKBFSSaga() {}
 export function uninstallKBFSSagaSuccess(result: RPCTypes.UninstallResult) {}
+export function copyToDownloadDir(path: string, mime: string): Promise<*> {
+  if (isAndroid) {
+    return RNFetchBlob.android.addCompleteDownload({
+      title: 'Keybase Download',
+      description: 'Keybase Download',
+      mime,
+      path,
+      showNotification: true,
+    })
+  }
+  return new Promise((resolve, reject) => resolve())
+}

--- a/shared/actions/fs-platform-specific.native.js
+++ b/shared/actions/fs-platform-specific.native.js
@@ -5,6 +5,7 @@ import * as RPCTypes from '../constants/types/rpc-gen'
 import type {TypedState} from '../constants/reducer'
 import RNFetchBlob from 'react-native-fetch-blob'
 import {isAndroid} from '../constants/platform'
+import {copy} from '../util/file'
 
 export function openInFileUISaga(payload: FsGen.OpenInFileUIPayload, state: TypedState) {}
 export function* fuseStatusSaga(): Saga.SagaGenerator<any, any> {}
@@ -21,13 +22,18 @@ export function uninstallKBFSSaga() {}
 export function uninstallKBFSSagaSuccess(result: RPCTypes.UninstallResult) {}
 export function copyToDownloadDir(path: string, mime: string): Promise<*> {
   if (isAndroid) {
-    return RNFetchBlob.android.addCompleteDownload({
-      title: 'Keybase Download',
-      description: 'Keybase Download',
-      mime,
-      path,
-      showNotification: true,
-    })
+    const downloadDir = RNFetchBlob.fs.dirs.DownloadDir
+    const fileName = path.substring(path.lastIndexOf('/'))
+    const downloadPath = `${downloadDir}/${fileName}`
+    copy(path, downloadPath).then(() =>
+      RNFetchBlob.android.addCompleteDownload({
+        title: 'Keybase Download',
+        description: 'Keybase Download',
+        mime,
+        downloadPath,
+        showNotification: true,
+      })
+    )
   }
   return new Promise((resolve, reject) => resolve())
 }

--- a/shared/actions/fs.js
+++ b/shared/actions/fs.js
@@ -20,6 +20,7 @@ import {
   uninstallKBFSConfirmSaga,
   uninstallKBFS,
   uninstallKBFSSuccess,
+  copyToDownloadDir,
 } from './fs-platform-specific'
 import {isMobile, isWindows} from '../constants/platform'
 import {saveAttachmentDialog, showShareActionSheet} from './platform-specific'
@@ -198,6 +199,7 @@ function* download(action: FsGen.DownloadPayload): Saga.SagaGenerator<any, any> 
     // that the file is available locally.
     switch (intent) {
       case 'none':
+        yield Saga.call(copyToDownloadDir, localPath, action.payload.mimeType)
         break
       case 'camera-roll':
         yield Saga.call(saveAttachmentDialog, localPath)

--- a/shared/actions/fs.js
+++ b/shared/actions/fs.js
@@ -195,17 +195,18 @@ function* download(action: FsGen.DownloadPayload): Saga.SagaGenerator<any, any> 
     // completePortion to 1.
     yield Saga.put(FsGen.createTransferProgress({key, completePortion: 1}))
 
-    // If this is for anyting other than a simple download, kick that off now
-    // that the file is available locally.
+    const mimeType = Constants.mimeTypeFromPathName(Types.getPathName(path))
+
+    // Kick off any post-download actions, now that the file is available locally.
     switch (intent) {
       case 'none':
-        yield Saga.call(copyToDownloadDir, localPath, action.payload.mimeType)
+        yield Saga.call(copyToDownloadDir, localPath, mimeType)
         break
       case 'camera-roll':
         yield Saga.call(saveAttachmentDialog, localPath)
         break
       case 'share':
-        yield Saga.call(showShareActionSheet, {url: localPath, mimeType: action.payload.mimeType})
+        yield Saga.call(showShareActionSheet, {url: localPath, mimeType})
         break
       case 'web-view':
       case 'web-view-text':

--- a/shared/actions/json/fs.json
+++ b/shared/actions/json/fs.json
@@ -27,7 +27,6 @@
     },
     "download": {
       "intent": "Types.TransferIntent",
-      "mimeType?": "string",
       "path": "Types.Path",
       "localPath?": "string"
     },

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -440,7 +440,7 @@ export const folderToFavoriteItems = (
   )
 }
 
-export const mimeTypeFromPathItem = (p: Types.PathItem): string => mime.lookup(p.name) || ''
+export const mimeTypeFromPathName = (name: string): string => mime.lookup(name) || ''
 
 export const viewTypeFromPath = (p: Types.Path): Types.FileViewType => {
   const name = Types.getPathName(p)

--- a/shared/fs/popups/row-action-popup-container.js
+++ b/shared/fs/popups/row-action-popup-container.js
@@ -33,7 +33,7 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
         )
 
   return {
-    _mimeType: Constants.mimeTypeFromPathItem(pathItem),
+    _fileName: pathItem.name,
     path,
     pathItem,
     isShare,
@@ -69,8 +69,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
               },
             ])
           ),
-        shareNative: (path: Types.Path, mimeType: string) => {
-          dispatch(FSGen.createDownload({intent: 'share', mimeType, path}))
+        shareNative: (path: Types.Path) => {
+          dispatch(FSGen.createDownload({intent: 'share', path}))
           dispatch(
             navigateAppend([
               {
@@ -123,12 +123,12 @@ const getRootMenuItems = (stateProps, dispatchProps) => {
   return menuItems
 }
 
-const getShareMenuItems = ({path, _mimeType}, {shareNative}) =>
+const getShareMenuItems = ({path}, {shareNative}) =>
   isMobile
     ? [
         {
           title: 'Send to other app',
-          onClick: () => shareNative(path, _mimeType),
+          onClick: () => shareNative(path),
         },
       ]
     : []

--- a/shared/react-native/android/app/src/main/AndroidManifest.xml
+++ b/shared/react-native/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <permission
         android:name="${applicationId}.permission.C2D_MESSAGE"


### PR DESCRIPTION
This fixes downloads on Android. We do that by:
1. Requesting permissions to access external storage
2. Copying the file from our cache folder to the external downloads folder (and removing it from cache if it copied successfully)
3. Marking the file as having completed a download, which allows it to appear in the Android Downloads app. It also sets a notification, allowing the user to view the download.