### PR TITLE
Pluralize role name.

### DIFF
--- a/shared/teams/role-picker/controlled-container.js
+++ b/shared/teams/role-picker/controlled-container.js
@@ -13,12 +13,14 @@ import {type TeamRoleType} from '../../constants/types/teams'
   onComplete gets selected role
   selectedRole sets a default role for the component
   allowOwner specifies whether the user can choose the 'owner' option
+  pluralizeRoleName speficifies whether to pluralize the role name or not
 */
 export type ControlledRolePickerProps = {
   onComplete: (role: TeamRoleType, sendNotification: boolean) => void,
   selectedRole?: TeamRoleType,
   allowOwner?: boolean,
   allowAdmin?: boolean,
+  pluralizeRoleName?: boolean,
   showNotificationCheckbox?: boolean,
   sendNotificationChecked?: boolean,
 }
@@ -28,6 +30,7 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
   const _onComplete = routeProps.get('onComplete')
   const allowAdmin = routeProps.get('allowAdmin')
   const allowOwner = routeProps.get('allowOwner')
+  const pluralizeRoleName = routeProps.get('pluralizeRoleName')
   const sendNotificationChecked = routeProps.get('sendNotificationChecked')
   const showSendNotification = routeProps.get('showNotificationCheckbox')
   return {
@@ -37,6 +40,7 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
     confirm: false,
     controlled: true,
     currentType,
+    pluralizeRoleName,
     sendNotificationChecked,
     showSendNotification,
     username: '',

--- a/shared/teams/role-picker/index.js
+++ b/shared/teams/role-picker/index.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react'
-import pluralize from 'pluralize'
 import {
   Avatar,
   Box,
@@ -18,6 +17,7 @@ import {typeToLabel, isAdmin, isOwner} from '../../constants/teams'
 import {type TeamRoleType} from '../../constants/types/teams'
 import {globalColors, globalMargins, globalStyles, isMobile} from '../../styles'
 import {roleIconMap, roleIconColorMap, roleDescMap, permissionMap} from './index.meta'
+import {pluralize} from '../../util/string'
 
 export type RolePickerProps = {
   confirm: boolean,

--- a/shared/teams/role-picker/index.js
+++ b/shared/teams/role-picker/index.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react'
+import pluralize from 'pluralize'
 import {
   Avatar,
   Box,
@@ -25,6 +26,7 @@ export type RolePickerProps = {
   selectedRole: TeamRoleType,
   allowAdmin?: boolean,
   allowOwner?: boolean,
+  pluralizeRoleName?: boolean,
   sendNotification: boolean,
   teamname: string,
   sendNotificationChecked?: boolean,
@@ -41,6 +43,7 @@ const makeRoleOption = (
   role: TeamRoleType,
   selected: TeamRoleType,
   setSelected: TeamRoleType => void,
+  pluralizeRoleName?: boolean = false,
   disabled?: boolean = false
 ) => (
   <ClickableBox
@@ -71,7 +74,7 @@ const makeRoleOption = (
           />
         )}
         <Text style={{color: selected === role ? globalColors.white : globalColors.black_75}} type="BodyBig">
-          {typeToLabel[role]}
+          {pluralizeRoleName ? pluralize(typeToLabel[role]) : typeToLabel[role]}
         </Text>
       </Box>
       <Text style={{color: selected === role ? globalColors.white : globalColors.black_40}} type="BodySmall">
@@ -89,6 +92,7 @@ export const RoleOptions = ({
   setSelectedRole,
   allowAdmin = true,
   allowOwner = true,
+  pluralizeRoleName = false,
   setSendNotification,
   sendNotification,
   sendNotificationChecked,
@@ -107,10 +111,10 @@ export const RoleOptions = ({
     <Box style={{marginTop: globalMargins.small, marginBottom: globalMargins.small}}>
       <Text type="Header">{username ? `Select a role for ${username}:` : 'Select a role:'}</Text>
     </Box>
-    {allowOwner && makeRoleOption('owner', selectedRole, setSelectedRole)}
-    {allowAdmin && makeRoleOption('admin', selectedRole, setSelectedRole)}
-    {makeRoleOption('writer', selectedRole, setSelectedRole)}
-    {makeRoleOption('reader', selectedRole, setSelectedRole)}
+    {allowOwner && makeRoleOption('owner', selectedRole, setSelectedRole, pluralizeRoleName)}
+    {allowAdmin && makeRoleOption('admin', selectedRole, setSelectedRole, pluralizeRoleName)}
+    {makeRoleOption('writer', selectedRole, setSelectedRole, pluralizeRoleName)}
+    {makeRoleOption('reader', selectedRole, setSelectedRole, pluralizeRoleName)}
     {showSendNotification && (
       <Box style={{marginTop: globalMargins.small, marginBottom: globalMargins.tiny}}>
         <Checkbox label="Send chat notification" onCheck={setSendNotification} checked={sendNotification} />

--- a/shared/teams/team/settings-tab/container.js
+++ b/shared/teams/team/settings-tab/container.js
@@ -46,6 +46,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
             selectedRole: newOpenTeamRole,
             allowOwner: false,
             allowAdmin: false,
+            pluralizeRoleName: true,
           },
           selected: 'controlledRolePicker',
         },

--- a/shared/teams/team/settings-tab/index.js
+++ b/shared/teams/team/settings-tab/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import pluralize from 'pluralize'
 import * as Types from '../../../constants/types/teams'
 import {retentionPolicies} from '../../../constants/teams'
 import {Box, Button, Checkbox, Text} from '../../../common-adapters'
@@ -139,7 +140,7 @@ const OpenTeam = (props: SettingProps) =>
             type={props.newOpenTeam ? 'BodySmallPrimaryLink' : 'BodySmall'}
             onClick={props.newOpenTeam ? props.onSetOpenTeamRole : undefined}
           >
-            {props.newOpenTeamRole}
+            {pluralize(props.newOpenTeamRole)}
           </Text>
           .
         </Text>

--- a/shared/teams/team/settings-tab/index.js
+++ b/shared/teams/team/settings-tab/index.js
@@ -1,11 +1,11 @@
 // @flow
 import * as React from 'react'
-import pluralize from 'pluralize'
 import * as Types from '../../../constants/types/teams'
 import {retentionPolicies} from '../../../constants/teams'
 import {Box, Button, Checkbox, Text} from '../../../common-adapters'
 import {globalColors, globalMargins, globalStyles} from '../../../styles'
 import {isMobile} from '../../../constants/platform'
+import {pluralize} from '../../../util/string'
 import RetentionPicker from './retention/container'
 
 // initial settings (except retention policy)

--- a/shared/util/string.js
+++ b/shared/util/string.js
@@ -1,5 +1,10 @@
 // @flow
 
+// Add pluralization rules as necessary
+function pluralize(str: string): string {
+  return str.endsWith('s') ? str : `${str}s`
+}
+
 function toStringForLog(a: any): string {
   if (typeof a === 'string') {
     return a
@@ -11,4 +16,4 @@ function toStringForLog(a: any): string {
   return (a && a.toString && a.toString()) || 'Failed to turn item to string in toStringForLog'
 }
 
-export {toStringForLog}
+export {pluralize, toStringForLog}


### PR DESCRIPTION
Resolves DESKTOP-5664

This adds the ability to pluralize the role names on the role picker.

Why? Sometimes we're referring to more than one person. E.g., we're referring to multiple people when setting the permissions for an open team.