### PR TITLE
Show errors adding people to teams inside the add dialog

### DIFF
--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -57,9 +57,12 @@
       "participant": "string"
     },
     "addPeopleToTeam": {
-      "teamname": "string",
+      "destSubPath": "I.List<string>",
       "role": "string",
-      "sendChatNotification": "boolean"
+      "rootPath": "I.List<string>",
+      "sendChatNotification": "boolean",
+      "sourceSubPath": "I.List<string>",
+      "teamname": "string"
     },
     "inviteToTeamByEmail": {
       "teamname": "string",
@@ -122,6 +125,9 @@
     },
     "setTeamCreationPending": {
       "pending": "boolean"
+    },
+    "setTeamInviteError": {
+      "error": "string"
     },
     "setTeamJoinError": {
       "error": "string"

--- a/shared/actions/teams-gen.js
+++ b/shared/actions/teams-gen.js
@@ -51,6 +51,7 @@ export const setTeamCreationError = 'teams:setTeamCreationError'
 export const setTeamCreationPending = 'teams:setTeamCreationPending'
 export const setTeamDetails = 'teams:setTeamDetails'
 export const setTeamInfo = 'teams:setTeamInfo'
+export const setTeamInviteError = 'teams:setTeamInviteError'
 export const setTeamJoinError = 'teams:setTeamJoinError'
 export const setTeamJoinSuccess = 'teams:setTeamJoinSuccess'
 export const setTeamLoadingInvites = 'teams:setTeamLoadingInvites'
@@ -92,9 +93,12 @@ export const createAddParticipant = (
 ) => ({error: false, payload, type: addParticipant})
 export const createAddPeopleToTeam = (
   payload: $ReadOnly<{|
-    teamname: string,
+    destSubPath: I.List<string>,
     role: string,
+    rootPath: I.List<string>,
     sendChatNotification: boolean,
+    sourceSubPath: I.List<string>,
+    teamname: string,
   |}>
 ) => ({error: false, payload, type: addPeopleToTeam})
 export const createAddTeamWithChosenChannels = (payload: $ReadOnly<{|teamname: string|}>) => ({error: false, payload, type: addTeamWithChosenChannels})
@@ -272,6 +276,7 @@ export const createSetTeamInfo = (
     teamNameToID: I.Map<Types.Teamname, string>,
   |}>
 ) => ({error: false, payload, type: setTeamInfo})
+export const createSetTeamInviteError = (payload: $ReadOnly<{|error: string|}>) => ({error: false, payload, type: setTeamInviteError})
 export const createSetTeamJoinError = (payload: $ReadOnly<{|error: string|}>) => ({error: false, payload, type: setTeamJoinError})
 export const createSetTeamJoinSuccess = (
   payload: $ReadOnly<{|
@@ -373,6 +378,7 @@ export type SetTeamCreationErrorPayload = More.ReturnType<typeof createSetTeamCr
 export type SetTeamCreationPendingPayload = More.ReturnType<typeof createSetTeamCreationPending>
 export type SetTeamDetailsPayload = More.ReturnType<typeof createSetTeamDetails>
 export type SetTeamInfoPayload = More.ReturnType<typeof createSetTeamInfo>
+export type SetTeamInviteErrorPayload = More.ReturnType<typeof createSetTeamInviteError>
 export type SetTeamJoinErrorPayload = More.ReturnType<typeof createSetTeamJoinError>
 export type SetTeamJoinSuccessPayload = More.ReturnType<typeof createSetTeamJoinSuccess>
 export type SetTeamLoadingInvitesPayload = More.ReturnType<typeof createSetTeamLoadingInvites>
@@ -431,6 +437,7 @@ export type Actions =
   | More.ReturnType<typeof createSetTeamCreationPending>
   | More.ReturnType<typeof createSetTeamDetails>
   | More.ReturnType<typeof createSetTeamInfo>
+  | More.ReturnType<typeof createSetTeamInviteError>
   | More.ReturnType<typeof createSetTeamJoinError>
   | More.ReturnType<typeof createSetTeamJoinSuccess>
   | More.ReturnType<typeof createSetTeamLoadingInvites>

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -237,8 +237,7 @@ const _inviteByEmail = function*(action: TeamsGen.InviteToTeamByEmailPayload) {
 }
 
 const _addToTeam = function*(action: TeamsGen.AddToTeamPayload) {
-  const {role, sendChatNotification, teamname, username} = action.payload
-  yield Saga.all([Saga.put(TeamsGen.createSetTeamInviteError({error: ''}))])
+  const {teamname, username, role, sendChatNotification} = action.payload
   const waitingKeys = [Constants.teamWaitingKey(teamname), Constants.addMemberWaitingKey(teamname, username)]
   yield Saga.put(createIncrementWaiting({key: waitingKeys}))
   try {

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -1,7 +1,8 @@
 // @flow
 import logger from '../logger'
-import {map, last} from 'lodash-es'
+import {map, last, upperFirst} from 'lodash-es'
 import * as I from 'immutable'
+import * as SearchGen from './search-gen'
 import * as GregorGen from './gregor-gen'
 import * as TeamsGen from './teams-gen'
 import * as Types from '../constants/types/teams'
@@ -87,19 +88,45 @@ const _leaveTeam = function(action: TeamsGen.LeaveTeamPayload) {
 }
 
 const _addPeopleToTeam = function*(action: TeamsGen.AddPeopleToTeamPayload) {
-  const {role, teamname, sendChatNotification} = action.payload
+  const {destSubPath, role, rootPath, sendChatNotification, sourceSubPath, teamname} = action.payload
   yield Saga.put(createIncrementWaiting({key: Constants.teamWaitingKey(teamname)}))
   const state: TypedState = yield Saga.select()
   const ids = SearchConstants.getUserInputItemIds(state, {searchKey: 'addToTeamSearch'})
+  const collectedErrors = []
   for (const id of ids) {
-    yield Saga.call(RPCTypes.teamsTeamAddMemberRpcPromise, {
-      name: teamname,
-      email: '',
-      username: id,
-      role: role ? RPCTypes.teamsTeamRole[role] : RPCTypes.teamsTeamRole.none,
-      sendChatNotification,
-    })
+    try {
+      yield Saga.call(RPCTypes.teamsTeamAddMemberRpcPromise, {
+        name: teamname,
+        email: '',
+        username: id,
+        role: role ? RPCTypes.teamsTeamRole[role] : RPCTypes.teamsTeamRole.none,
+        sendChatNotification,
+      })
+    } catch (error) {
+      if (error.desc === 'You cannot invite an owner to a team.') {
+        // This error comes through as error code scgeneric, so if we want
+        // to rewrite it we have to match on the string itself.
+        const [username, service] = id.split('@')
+        collectedErrors.push(
+          `${upperFirst(
+            service
+          )} user @${username} doesn't have a Keybase account yet, so you can't add them as an owner; you can add them as reader or writer.`
+        )
+      } else {
+        collectedErrors.push(`Error adding ${id}: ${error.desc}`)
+      }
+    }
   }
+  if (collectedErrors.length === 0) {
+    // Success, dismiss the create team dialog.
+    yield Saga.put(
+      putActionIfOnPath(rootPath.concat(sourceSubPath), navigateTo(destSubPath, rootPath), rootPath)
+    )
+  } else {
+    yield Saga.put(TeamsGen.createSetTeamInviteError({error: collectedErrors.join('\n')}))
+  }
+  yield Saga.put(SearchGen.createClearSearchResults({searchKey: 'addToTeamSearch'}))
+  yield Saga.put(SearchGen.createSetUserInputItems({searchKey: 'addToTeamSearch', searchResults: []}))
   yield Saga.put(createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
 }
 
@@ -210,7 +237,8 @@ const _inviteByEmail = function*(action: TeamsGen.InviteToTeamByEmailPayload) {
 }
 
 const _addToTeam = function*(action: TeamsGen.AddToTeamPayload) {
-  const {teamname, username, role, sendChatNotification} = action.payload
+  const {role, sendChatNotification, teamname, username} = action.payload
+  yield Saga.all([Saga.put(TeamsGen.createSetTeamInviteError({error: ''}))])
   const waitingKeys = [Constants.teamWaitingKey(teamname), Constants.addMemberWaitingKey(teamname, username)]
   yield Saga.put(createIncrementWaiting({key: waitingKeys}))
   try {

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -87,6 +87,7 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   teamCreationError: '',
   teamCreationPending: false,
   teamAccessRequestsPending: I.Set(),
+  teamInviteError: '',
   teamJoinError: '',
   teamJoinSuccess: false,
   teamJoinSuccessTeamName: '',

--- a/shared/constants/types/teams.js
+++ b/shared/constants/types/teams.js
@@ -102,6 +102,7 @@ export type _State = {
   sawChatBanner: boolean,
   sawSubteamsBanner: boolean,
   teamAccessRequestsPending: I.Set<Teamname>,
+  teamInviteError: string,
   teamJoinError: string,
   teamJoinSuccess: boolean,
   teamJoinSuccessTeamName: string,

--- a/shared/reducers/teams.js
+++ b/shared/reducers/teams.js
@@ -20,6 +20,9 @@ const rootReducer = (state: Types.State = initialState, action: TeamsGen.Actions
     case TeamsGen.setTeamCreationPending:
       return state.set('teamCreationPending', action.payload.pending)
 
+    case TeamsGen.setTeamInviteError:
+      return state.set('teamInviteError', action.payload.error)
+
     case TeamsGen.setTeamJoinError:
       return state.set('teamJoinError', action.payload.error)
 

--- a/shared/teams/add-people/container.js
+++ b/shared/teams/add-people/container.js
@@ -2,10 +2,12 @@
 import * as TeamsGen from '../../actions/teams-gen'
 import * as SearchGen from '../../actions/search-gen'
 import * as SearchConstants from '../../constants/search'
-import {getRole, isOwner} from '../../constants/teams'
+import {getRole, isOwner, teamWaitingKey} from '../../constants/teams'
+import {upperFirst} from 'lodash-es'
 import AddPeople from '.'
 import {HeaderHoc} from '../../common-adapters'
 import {navigateAppend} from '../../actions/route-tree'
+import {anyWaiting} from '../../constants/waiting'
 import {
   connect,
   compose,
@@ -22,17 +24,28 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
     isEmpty: SearchConstants.getUserInputItemIds(state, {searchKey: 'addToTeamSearch'}).length === 0,
     name: teamname,
     _yourRole: getRole(state, teamname),
+    errorText: upperFirst(state.teams.teamInviteError),
+    loading: anyWaiting(state, teamWaitingKey(teamname)),
   }
 }
 
-const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
+const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routeProps}) => ({
   _getSuggestions: () => dispatch(SearchGen.createSearchSuggestions({searchKey: 'addToTeamSearch'})),
   onAddPeople: (role: string, sendChatNotification: boolean) => {
+    const teamname = routeProps.get('teamname')
+    const rootPath = routePath.take(1)
+    const sourceSubPath = routePath.rest()
+    const destSubPath = sourceSubPath.butLast()
     dispatch(
-      TeamsGen.createAddPeopleToTeam({teamname: routeProps.get('teamname'), role, sendChatNotification})
+      TeamsGen.createAddPeopleToTeam({
+        destSubPath,
+        role,
+        rootPath,
+        sendChatNotification,
+        sourceSubPath,
+        teamname,
+      })
     )
-    dispatch(navigateUp())
-    dispatch(TeamsGen.createGetTeams())
     dispatch(SearchGen.createClearSearchResults({searchKey: 'addToTeamSearch'}))
     dispatch(SearchGen.createSetUserInputItems({searchKey: 'addToTeamSearch', searchResults: []}))
   },
@@ -40,6 +53,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
     dispatch(navigateUp())
     dispatch(SearchGen.createClearSearchResults({searchKey: 'addToTeamSearch'}))
     dispatch(SearchGen.createSetUserInputItems({searchKey: 'addToTeamSearch', searchResults: []}))
+    dispatch(TeamsGen.createSetTeamInviteError({error: ''}))
   },
   onOpenRolePicker: (
     role: string,

--- a/shared/teams/add-people/index.js
+++ b/shared/teams/add-people/index.js
@@ -9,7 +9,14 @@ import {
   Text,
   PopupDialog,
 } from '../../common-adapters'
-import {globalStyles, globalMargins, globalColors, isMobile, desktopStyles} from '../../styles'
+import {
+  collapseStyles,
+  globalStyles,
+  globalMargins,
+  globalColors,
+  isMobile,
+  desktopStyles,
+} from '../../styles'
 import {capitalize} from 'lodash-es'
 import UserInput from '../../search/user-input/container'
 import SearchResultsList from '../../search/results-list/container'
@@ -31,7 +38,9 @@ const MaybePopup = isMobile
     )
 
 type Props = {
+  errorText: string,
   isEmpty: boolean,
+  loading: boolean,
   onAddPeople: () => void,
   onClose: () => void,
   onLeave: () => void,
@@ -88,6 +97,7 @@ const AddPeople = (props: Props) => (
           disabled={props.isEmpty}
           style={{margin: globalMargins.tiny}}
           type="Primary"
+          waiting={props.loading}
         />
       </Box>
 
@@ -100,8 +110,23 @@ const AddPeople = (props: Props) => (
           }}
         />
       )}
+      {!!props.errorText && (
+        <Box style={collapseStyles([globalStyles.flexBoxColumn, {backgroundColor: globalColors.red}])}>
+          {props.errorText.split('\n').map(line => (
+            <Box key={line} style={globalStyles.flexBoxRow}>
+              <Text
+                style={{margin: globalMargins.tiny, textAlign: 'center', width: '100%'}}
+                type="BodySemibold"
+                backgroundMode="HighRisk"
+              >
+                {line}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+      )}
 
-      <Box style={{...globalStyles.flexBoxColumn}}>
+      <Box style={globalStyles.flexBoxColumn}>
         <UserInput
           autoFocus={true}
           onExitSearch={props.onClose}


### PR DESCRIPTION
@keybase/react-hackers 

We were just black barring errors that show up when you're adding people to a team.

This new approach is:

* wait to decide whether to close the add dialog until we know whether the add succeeded, put a spinner on the Add button while we're waiting

* if it did, just close the dialog.  This close moves to the Saga instead of the container, since the Saga's what knows about the success/failure.

* if it failed, gather up the failures in an array (you can add more than one person at once, so you can have more than one error) and send it to the store as a `\n`-joined string.

* for a specific error (trying to add someone as owner using sharing-before-signup), rewrite it to be more friendly.

* at the top of the dialog, show each failure, let people try again.

I'm not very happy with the single string, and the way that we have a separate try call for each RPC, but changing how the saga's hooked up should probably be its own cleanup story.