### PR TITLE
don't run os.Executable() on mobile

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1368,6 +1368,11 @@ func GetPlatformString() string {
 	return runtime.GOOS
 }
 
+func IsMobilePlatform() bool {
+	s := GetPlatformString()
+	return (s == "ios" || s == "android")
+}
+
 func (e *Env) AllowPTrace() bool {
 	return e.GetBool(false,
 		func() (bool, bool) { return e.getEnvBool("KEYBASE_ALLOW_PTRACE") },

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -718,6 +718,10 @@ func CanExec(p string) error {
 }
 
 func CurrentBinaryRealpath() (string, error) {
+	if IsMobilePlatform() {
+		return "mobile-binary-location-unknown", nil
+	}
+
 	executable, err := os.Executable()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
@chrisnojima  and @buoyad point out that it crashes.