### PR TITLE
Skip key rotation clientside

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -817,6 +817,7 @@ type TeamSigChainState struct {
 	UserLog          map[UserVersion][]UserLogPoint                    `codec:"userLog" json:"userLog"`
 	SubteamLog       map[TeamID][]SubteamLogPoint                      `codec:"subteamLog" json:"subteamLog"`
 	PerTeamKeys      map[PerTeamKeyGeneration]PerTeamKey               `codec:"perTeamKeys" json:"perTeamKeys"`
+	PerTeamKeyCTime  UnixTime                                          `codec:"perTeamKeyCTime" json:"perTeamKeyCTime"`
 	LinkIDs          map[Seqno]LinkID                                  `codec:"linkIDs" json:"linkIDs"`
 	StubbedLinks     map[Seqno]bool                                    `codec:"stubbedLinks" json:"stubbedLinks"`
 	ActiveInvites    map[TeamInviteID]TeamInvite                       `codec:"activeInvites" json:"activeInvites"`
@@ -911,6 +912,7 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 			}
 			return ret
 		})(o.PerTeamKeys),
+		PerTeamKeyCTime: o.PerTeamKeyCTime.DeepCopy(),
 		LinkIDs: (func(x map[Seqno]LinkID) map[Seqno]LinkID {
 			if x == nil {
 				return nil

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -287,6 +287,10 @@ func (t TeamSigChainState) GetLatestPerTeamKey() (keybase1.PerTeamKey, error) {
 	return res, nil
 }
 
+func (t *TeamSigChainState) GetLatestPerTeamKeyCTime() keybase1.UnixTime {
+	return t.inner.PerTeamKeyCTime
+}
+
 func (t TeamSigChainState) GetPerTeamKeyAtGeneration(gen keybase1.PerTeamKeyGeneration) (keybase1.PerTeamKey, error) {
 	res, ok := t.inner.PerTeamKeys[gen]
 	if !ok {
@@ -922,6 +926,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 				UserLog:          make(map[keybase1.UserVersion][]keybase1.UserLogPoint),
 				SubteamLog:       make(map[keybase1.TeamID][]keybase1.SubteamLogPoint),
 				PerTeamKeys:      perTeamKeys,
+				PerTeamKeyCTime:  keybase1.UnixTime(payload.Ctime),
 				LinkIDs:          make(map[keybase1.Seqno]keybase1.LinkID),
 				StubbedLinks:     make(map[keybase1.Seqno]bool),
 				ActiveInvites:    make(map[keybase1.TeamInviteID]keybase1.TeamInvite),
@@ -1112,6 +1117,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 				return res, err
 			}
 			res.newState.inner.PerTeamKeys[newKey.Gen] = newKey
+			res.newState.inner.PerTeamKeyCTime = keybase1.UnixTime(payload.Ctime)
 		}
 
 		return res, nil
@@ -1150,6 +1156,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 
 		res.newState = prevState.DeepCopy()
 		res.newState.inner.PerTeamKeys[newKey.Gen] = newKey
+		res.newState.inner.PerTeamKeyCTime = keybase1.UnixTime(payload.Ctime)
 
 		return res, nil
 	case libkb.LinkTypeLeave:

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -718,7 +718,6 @@ func (t *TeamSigChainPlayer) addInnerLink(
 	}
 
 	// completely ignore these fields
-	_ = payload.Ctime
 	_ = payload.ExpireIn
 	_ = payload.SeqType
 
@@ -1297,6 +1296,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 				UserLog:         make(map[keybase1.UserVersion][]keybase1.UserLogPoint),
 				SubteamLog:      make(map[keybase1.TeamID][]keybase1.SubteamLogPoint),
 				PerTeamKeys:     perTeamKeys,
+				PerTeamKeyCTime: keybase1.UnixTime(payload.Ctime),
 				LinkIDs:         make(map[keybase1.Seqno]keybase1.LinkID),
 				StubbedLinks:    make(map[keybase1.Seqno]bool),
 				ActiveInvites:   make(map[keybase1.TeamInviteID]keybase1.TeamInvite),

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -155,7 +155,7 @@ func sweepOpenTeamResetMembers(ctx context.Context, g *libkb.GlobalContext,
 			// Make it possible for user to come back in once they reprovision.
 			Permanent: false,
 			// Coming from CLKR, we want to ensure team key is rotated.
-			DontRotateKey: false,
+			SkipKeyRotation: false,
 		}
 		if err := team.ChangeMembershipWithOptions(ctx, changeReq, opts); err != nil {
 			return err

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
@@ -392,7 +391,6 @@ func HandleOpenTeamAccessRequest(ctx context.Context, g *libkb.GlobalContext, ms
 		}
 
 		tx := CreateAddMemberTx(team)
-		tx.DontRotateKey = team.CanSkipKeyRotation(time.Now())
 		for _, tar := range msg.Tars {
 			uv := NewUserVersion(tar.Uid, tar.EldestSeqno)
 			err := tx.AddMemberByUV(ctx, uv, joinAsRole)

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -49,6 +49,7 @@ func memberSetupMultiple(t *testing.T) (tc libkb.TestContext, owner, otherA, oth
 	}
 
 	name = createTeam(tc)
+	t.Logf("Created team %q", name)
 
 	return tc, owner, otherA, otherB, name
 }

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -219,7 +219,7 @@ func TestMemberAddHasBoxes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, true /* rotateIfHasRemoval */)
+	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, false /* dontRotateKey */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func TestMemberChangeRoleNoBoxes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, true /* rotateIfHasRemoval */)
+	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, false /* dontRotateKey */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -219,7 +219,7 @@ func TestMemberAddHasBoxes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req)
+	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, true /* rotateIfHasRemoval */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func TestMemberChangeRoleNoBoxes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req)
+	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, true /* rotateIfHasRemoval */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -220,7 +220,7 @@ func TestMemberAddHasBoxes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, false /* dontRotateKey */)
+	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, false /* skipKeyRotation */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,7 +253,7 @@ func TestMemberChangeRoleNoBoxes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, false /* dontRotateKey */)
+	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, false /* skipKeyRotation */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/teams/rotate_test.go
+++ b/go/teams/rotate_test.go
@@ -527,7 +527,7 @@ func TestRotateResetMultipleUsers(t *testing.T) {
 }
 
 func TestRemoveWithoutRotation(t *testing.T) {
-	tc, _, otherA, _, name := memberSetupMultiple(t)
+	tc, _, otherA, otherB, name := memberSetupMultiple(t)
 	defer tc.Cleanup()
 
 	require.NoError(t, SetRoleWriter(context.Background(), tc.G, name, otherA.Username))
@@ -535,8 +535,14 @@ func TestRemoveWithoutRotation(t *testing.T) {
 	team, err := GetForTestByStringName(context.Background(), tc.G, name)
 	require.NoError(t, err)
 
-	uv := keybase1.NewUserVersion(otherA.User.GetUID(), otherA.EldestSeqno)
-	req := keybase1.TeamChangeReq{None: []keybase1.UserVersion{uv}}
+	req := keybase1.TeamChangeReq{
+		Writers: []keybase1.UserVersion{
+			keybase1.NewUserVersion(otherB.User.GetUID(), otherB.EldestSeqno),
+		},
+		None: []keybase1.UserVersion{
+			keybase1.NewUserVersion(otherA.User.GetUID(), otherA.EldestSeqno),
+		},
+	}
 
 	opts := ChangeMembershipOptions{
 		DontRotateKey: true,

--- a/go/teams/rotate_test.go
+++ b/go/teams/rotate_test.go
@@ -545,7 +545,7 @@ func TestRemoveWithoutRotation(t *testing.T) {
 	}
 
 	opts := ChangeMembershipOptions{
-		DontRotateKey: true,
+		SkipKeyRotation: true,
 	}
 	err = team.ChangeMembershipWithOptions(context.Background(), req, opts)
 	require.NoError(t, err)

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -521,7 +521,7 @@ func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 
 		opts := ChangeMembershipOptions{
 			Permanent:     t.IsOpen(), // Ban for open teams only.
-			DontRotateKey: t.CanSkipKeyRotation(time.Now()),
+			DontRotateKey: t.CanSkipKeyRotation(g.Clock().Now()),
 		}
 		return t.ChangeMembershipWithOptions(ctx, req, opts)
 	})

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -521,7 +521,7 @@ func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 
 		opts := ChangeMembershipOptions{
 			Permanent:     t.IsOpen(), // Ban for open teams only.
-			DontRotateKey: t.CanSkipKeyRotation(g.Clock().Now()),
+			DontRotateKey: t.CanSkipKeyRotation(),
 		}
 		return t.ChangeMembershipWithOptions(ctx, req, opts)
 	})

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -519,9 +519,11 @@ func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 		}
 		req := keybase1.TeamChangeReq{None: []keybase1.UserVersion{existingUV}}
 
-		// Ban for open teams only.
-		permanent := t.IsOpen()
-		return t.ChangeMembershipPermanent(ctx, req, permanent)
+		opts := ChangeMembershipOptions{
+			Permanent:     t.IsOpen(), // Ban for open teams only.
+			DontRotateKey: t.CanSkipKeyRotation(time.Now()),
+		}
+		return t.ChangeMembershipWithOptions(ctx, req, opts)
 	})
 }
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -520,8 +520,8 @@ func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 		req := keybase1.TeamChangeReq{None: []keybase1.UserVersion{existingUV}}
 
 		opts := ChangeMembershipOptions{
-			Permanent:     t.IsOpen(), // Ban for open teams only.
-			DontRotateKey: t.CanSkipKeyRotation(),
+			Permanent:       t.IsOpen(), // Ban for open teams only.
+			SkipKeyRotation: t.CanSkipKeyRotation(),
 		}
 		return t.ChangeMembershipWithOptions(ctx, req, opts)
 	})

--- a/go/teams/storage.go
+++ b/go/teams/storage.go
@@ -89,7 +89,7 @@ type DiskStorage struct {
 }
 
 // Increment to invalidate the disk cache.
-const diskStorageVersion = 9
+const diskStorageVersion = 10
 
 type DiskStorageItem struct {
 	Version int                `codec:"V"`

--- a/go/teams/storage.go
+++ b/go/teams/storage.go
@@ -89,7 +89,7 @@ type DiskStorage struct {
 }
 
 // Increment to invalidate the disk cache.
-const diskStorageVersion = 10
+const diskStorageVersion = 9
 
 type DiskStorageItem struct {
 	Version int                `codec:"V"`

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -49,12 +49,12 @@ func (t *Team) CanSkipKeyRotation(now time.Time) bool {
 		// Do not do this optimization for implicit teams.
 		return false
 	}
+
 	// If cannot decide because of an error, return default false.
 	members, err := t.UsersWithRoleOrAbove(keybase1.TeamRole_READER)
 	if err != nil {
 		return false
 	}
-
 	if len(members) < 50 {
 		// Not a big team
 		return false
@@ -65,7 +65,6 @@ func (t *Team) CanSkipKeyRotation(now time.Time) bool {
 		// Last key rotation was more than 24 hours ago.
 		return false
 	}
-
 	// Time is big and key was rotated recently - can skip rotation.
 	return true
 }

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -44,7 +44,7 @@ func NewTeam(ctx context.Context, g *libkb.GlobalContext, teamData *keybase1.Tea
 	}
 }
 
-func (t *Team) CanSkipKeyRotation(now time.Time) bool {
+func (t *Team) CanSkipKeyRotation() bool {
 	// Only applies for >=50 member teams.
 	const MinTeamSize = 50
 	// Aim for one rotation every 24h.
@@ -65,6 +65,7 @@ func (t *Team) CanSkipKeyRotation(now time.Time) bool {
 		return false
 	}
 
+	now := t.G().Clock().Now()
 	duration := now.Sub(time.Unix(int64(t.chain().GetLatestPerTeamKeyCTime()), 0))
 	if duration > KeyRotateInterval {
 		// Last key rotation was more than predefined interval.

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1332,13 +1332,18 @@ func (t *Team) recipientBoxes(ctx context.Context, memSet *memberSet, dontRotate
 	// if there are any removals happening, need to rotate the
 	// team key, and recipients will be all the users in the team
 	// after the removal.
-	if memSet.HasRemoval() && !dontRotateKey {
-		// key is rotating, so recipients needs to be all the remaining members
-		// of the team after the removal (and including any new members in this
-		// change)
-		t.G().Log.Debug("team change request contains removal, rotating team key")
-		boxes, perTeamKey, teamEKPayload, err := t.rotateBoxes(ctx, memSet)
-		return boxes, implicitAdminBoxes, perTeamKey, teamEKPayload, err
+	if memSet.HasRemoval() {
+		if !dontRotateKey {
+			// key is rotating, so recipients needs to be all the remaining members
+			// of the team after the removal (and including any new members in this
+			// change)
+			t.G().Log.Debug("recipientBoxes: Team change request contains removal, rotating team key")
+			boxes, perTeamKey, teamEKPayload, err := t.rotateBoxes(ctx, memSet)
+			return boxes, implicitAdminBoxes, perTeamKey, teamEKPayload, err
+		}
+
+		// If we don't rotate key, continue with the usual boxing.
+		t.G().Log.Debug("recipientBoxes: Skipping key rotation")
 	}
 
 	// don't need keys for existing members, so remove them from the set

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -70,7 +70,7 @@ func (t *Team) CanSkipKeyRotation(now time.Time) bool {
 		// Last key rotation was more than predefined interval.
 		return false
 	}
-	// Time is big and key was rotated recently - can skip rotation.
+	// Team is big and key was rotated recently - can skip rotation.
 	return true
 }
 
@@ -463,11 +463,12 @@ func (t *Team) getDowngradedUsers(ctx context.Context, ms *memberSet) (uids []ke
 }
 
 type ChangeMembershipOptions struct {
-	// Pass "permanent" flag, user will be requiest access back to the
-	// team (useful for open teams).
+	// Pass "permanent" flag, user will not be able to request access
+	// to the team again, admin will have to add them back.
 	Permanent bool
 
-	// Do not rotate team key, even on member removals.
+	// Do not rotate team key, even on member removals. Server will
+	// queue CLKR if client sends removals without rotation.
 	DontRotateKey bool
 }
 

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -631,7 +631,7 @@ func (tx *AddMemberTx) Post(ctx context.Context) (err error) {
 	if tx.DontRotateKey != nil {
 		dontRotate = *tx.DontRotateKey
 	} else {
-		dontRotate = team.CanSkipKeyRotation(team.G().Clock().Now())
+		dontRotate = team.CanSkipKeyRotation()
 	}
 	secretBoxes, implicitAdminBoxes, perTeamKeySection, teamEKPayload, err := team.recipientBoxes(ctx, memSet, dontRotate)
 	if err != nil {

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -6,7 +6,6 @@ package teams
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -19,6 +18,9 @@ type AddMemberTx struct {
 	payloads []interface{} // *SCTeamInvites or *keybase1.TeamChangeReq
 
 	completedInvites map[keybase1.TeamInviteID]bool
+
+	// Do not rotate team key, even on member removals.
+	DontRotateKey bool
 }
 
 func CreateAddMemberTx(t *Team) *AddMemberTx {
@@ -625,8 +627,7 @@ func (tx *AddMemberTx) Post(ctx context.Context) (err error) {
 		}()
 	}
 
-	shouldRotate := team.shouldRotateOnRemoval(time.Now())
-	secretBoxes, implicitAdminBoxes, perTeamKeySection, teamEKPayload, err := team.recipientBoxes(ctx, memSet, shouldRotate)
+	secretBoxes, implicitAdminBoxes, perTeamKeySection, teamEKPayload, err := team.recipientBoxes(ctx, memSet, tx.DontRotateKey)
 	if err != nil {
 		return err
 	}

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -20,7 +20,7 @@ type AddMemberTx struct {
 	completedInvites map[keybase1.TeamInviteID]bool
 
 	// Do not rotate team key, even on member removals.
-	DontRotateKey *bool
+	SkipKeyRotation *bool
 }
 
 func CreateAddMemberTx(t *Team) *AddMemberTx {
@@ -627,13 +627,13 @@ func (tx *AddMemberTx) Post(ctx context.Context) (err error) {
 		}()
 	}
 
-	var dontRotate bool
-	if tx.DontRotateKey != nil {
-		dontRotate = *tx.DontRotateKey
+	var skipKeyRotation bool
+	if tx.SkipKeyRotation != nil {
+		skipKeyRotation = *tx.SkipKeyRotation
 	} else {
-		dontRotate = team.CanSkipKeyRotation()
+		skipKeyRotation = team.CanSkipKeyRotation()
 	}
-	secretBoxes, implicitAdminBoxes, perTeamKeySection, teamEKPayload, err := team.recipientBoxes(ctx, memSet, dontRotate)
+	secretBoxes, implicitAdminBoxes, perTeamKeySection, teamEKPayload, err := team.recipientBoxes(ctx, memSet, skipKeyRotation)
 	if err != nil {
 		return err
 	}

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -6,6 +6,7 @@ package teams
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -624,7 +625,8 @@ func (tx *AddMemberTx) Post(ctx context.Context) (err error) {
 		}()
 	}
 
-	secretBoxes, implicitAdminBoxes, perTeamKeySection, teamEKPayload, err := team.recipientBoxes(ctx, memSet)
+	shouldRotate := team.shouldRotateOnRemoval(time.Now())
+	secretBoxes, implicitAdminBoxes, perTeamKeySection, teamEKPayload, err := team.recipientBoxes(ctx, memSet, shouldRotate)
 	if err != nil {
 		return err
 	}

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -270,6 +270,10 @@ protocol teams {
     // Keyed by per-team-key generation
     map<PerTeamKeyGeneration, PerTeamKey> perTeamKeys;
 
+    // Creation time of latest PerTeamKey, based on CTime from the
+    // link key appeared in.
+    UnixTime perTeamKeyCTime;
+
     // This is filled up to lastSeqno.
     map<Seqno, LinkID> linkIDs;
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3848,7 +3848,7 @@ export type TeamSettings = $ReadOnly<{open: Boolean, joinAs: TeamRole}>
 
 export type TeamShowcase = $ReadOnly<{isShowcased: Boolean, description?: ?String, setByUID?: ?UID, anyMemberShowcase: Boolean}>
 
-export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfLegacyUpgrade: {[key: string]: TeamLegacyTLFUpgradeChainInfo}}>
+export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, perTeamKeyCTime: UnixTime, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfLegacyUpgrade: {[key: string]: TeamLegacyTLFUpgradeChainInfo}}>
 
 export type TeamTreeEntry = $ReadOnly<{name: TeamName, admin: Boolean}>
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -706,6 +706,10 @@
           "name": "perTeamKeys"
         },
         {
+          "type": "UnixTime",
+          "name": "perTeamKeyCTime"
+        },
+        {
           "type": {
             "type": "map",
             "values": "LinkID",

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3848,7 +3848,7 @@ export type TeamSettings = $ReadOnly<{open: Boolean, joinAs: TeamRole}>
 
 export type TeamShowcase = $ReadOnly<{isShowcased: Boolean, description?: ?String, setByUID?: ?UID, anyMemberShowcase: Boolean}>
 
-export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfLegacyUpgrade: {[key: string]: TeamLegacyTLFUpgradeChainInfo}}>
+export type TeamSigChainState = $ReadOnly<{reader: UserVersion, id: TeamID, implicit: Boolean, public: Boolean, rootAncestor: TeamName, nameDepth: Int, nameLog?: ?Array<TeamNameLogPoint>, lastSeqno: Seqno, lastLinkID: LinkID, parentID?: ?TeamID, userLog: {[key: string]: ?Array<UserLogPoint>}, subteamLog: {[key: string]: ?Array<SubteamLogPoint>}, perTeamKeys: {[key: string]: PerTeamKey}, perTeamKeyCTime: UnixTime, linkIDs: {[key: string]: LinkID}, stubbedLinks: {[key: string]: Boolean}, activeInvites: {[key: string]: TeamInvite}, obsoleteInvites: {[key: string]: TeamInvite}, open: Boolean, openTeamJoinAs: TeamRole, tlfID: TLFID, tlfLegacyUpgrade: {[key: string]: TeamLegacyTLFUpgradeChainInfo}}>
 
 export type TeamTreeEntry = $ReadOnly<{name: TeamName, admin: Boolean}>
 


### PR DESCRIPTION
This PR makes it so client does not always rotate key when member is removed from the team. For this to happen, team has to:
1) be bigger than 50 members,
2) be rotated less than 24 hours ago.

New boolean argument `DontRotateKey` is plumbed all the way to `team.recipientBoxes`, and if it's true, it will not rotate key even when memberSet has removals.

`ChangeMembershipPermanent` function was changed to `ChangeMembershipWithOptions` and it now takes option struct `{ DontRotateKey, Permanent }`. `ChangeMembership` still does the default thing of passing permanent=false and always rotating key.

To decide if key rotation can be skipped, API consumers use `team.CanSkipKeyRotation`, passing current time from `g.Clock()`. To be able to tell when the key was last rotated, `TeamSigChainState` now holds `PerTeamKeyCTime` field, which is set to `payload.ctime` whenever the key is changed in sigchain.