### PR TITLE
Clear login error when switching users.

### DIFF
--- a/shared/actions/login.js
+++ b/shared/actions/login.js
@@ -577,6 +577,7 @@ function* initalizeMyCodeStateForAddingADevice(): Generator<any, void, any> {
 function* _startLogin() {
   yield Saga.put(LoginGen.createSetRevokedSelf({revoked: ''}))
   yield Saga.put(LoginGen.createSetDeletedSelf({deletedUsername: ''}))
+  yield Saga.put(LoginGen.createLoginError({error: ''}))
   yield Saga.put(navigateTo(['login', 'usernameOrEmail'], [loginTab]))
 
   yield Saga.call(initalizeMyCodeStateForLogin)
@@ -600,6 +601,7 @@ function* _startLogin() {
 
 function _relogin({payload: {usernameOrEmail, passphrase}}: LoginGen.ReloginPayload) {
   return Saga.call(Saga.sequentially, [
+    Saga.put(LoginGen.createLoginError({error: ''})),
     Saga.put(LoginGen.createSetRevokedSelf({revoked: ''})),
     Saga.put(LoginGen.createSetDeletedSelf({deletedUsername: ''})),
     Saga.call(Saga.sequentially, [

--- a/shared/constants/login.js
+++ b/shared/constants/login.js
@@ -74,7 +74,7 @@ const makeState: I.RecordFactory<Types._State> = I.Record({
   forgotPasswordSuccess: false,
   justDeletedSelf: null,
   justRevokedSelf: null,
-  loginError: null,
+  loginError: '',
   registerUserPassError: null,
   registerUserPassLoading: false,
   waitingForResponse: false,

--- a/shared/constants/types/login.js
+++ b/shared/constants/types/login.js
@@ -40,7 +40,7 @@ export type _State = {
   forgotPasswordSuccess: boolean,
   justDeletedSelf: ?string,
   justRevokedSelf: ?string,
-  loginError: ?string,
+  loginError: string,
   registerUserPassError: ?string,
   registerUserPassLoading: boolean,
   waitingForResponse: boolean,

--- a/shared/login/login/container.js
+++ b/shared/login/login/container.js
@@ -18,6 +18,7 @@ const mapStateToProps = (state: TypedState) => {
 }
 
 const mapDispatchToProps = (dispatch: any, {navigateAppend}) => ({
+  _resetError: () => dispatch(LoginGen.createLoginError({error: ''})),
   onFeedback: () => dispatch(navigateAppend(['feedback'])),
   onForgotPassphrase: () => dispatch(LoginGen.createOpenAccountResetPage()),
   onLogin: (user: string, passphrase: string) =>
@@ -53,6 +54,13 @@ export default compose(
         props.onLogin(props.selectedUser, props.passphrase)
       }
     },
-    selectedUserChange: props => user => props.setSelectedUser(user),
+    selectedUserChange: props => user => {
+      // Clear the error and reset the passphrase input when they switch users
+      if (props.error && user !== props.selectedUser) {
+        props._resetError()
+        props.passphraseChange()
+      }
+      props.setSelectedUser(user)
+    },
   })
 )(Login)

--- a/shared/login/login/container.js
+++ b/shared/login/login/container.js
@@ -61,9 +61,7 @@ export default compose(
         props.onLogin(props.selectedUser, props.passphrase)
       }
     },
-    selectedUserChange: props => user => {
-      props.setSelectedUser(user)
-    },
+    selectedUserChange: props => user => props.setSelectedUser(user),
   }),
   lifecycle({
     componentDidUpdate(prevProps: Props) {

--- a/shared/login/login/container.js
+++ b/shared/login/login/container.js
@@ -1,8 +1,15 @@
 // @flow
 import * as LoginGen from '../../actions/login-gen'
 import HiddenString from '../../util/hidden-string'
-import Login from '.'
-import {compose, withStateHandlers, withHandlers, connect, type TypedState} from '../../util/container'
+import Login, {type Props} from '.'
+import {
+  compose,
+  lifecycle,
+  withStateHandlers,
+  withHandlers,
+  connect,
+  type TypedState,
+} from '../../util/container'
 import {requestAutoInvite} from '../../actions/signup'
 
 const mapStateToProps = (state: TypedState) => {
@@ -55,12 +62,21 @@ export default compose(
       }
     },
     selectedUserChange: props => user => {
-      // Clear the error and reset the passphrase input when they switch users
-      if (props.error && user !== props.selectedUser) {
-        props._resetError()
-        props.passphraseChange()
-      }
       props.setSelectedUser(user)
+    },
+  }),
+  lifecycle({
+    componentDidUpdate(prevProps: Props) {
+      // Clear the passphrase when there's an error.
+      // We’re doing this here because passphrase isn’t in the store.
+      // Otherwise, we’d use a saga.
+      if (this.props.error !== prevProps.error) {
+        this.props.passphraseChange()
+      }
+      // Same here but for clearing the error.
+      if (this.props.selectedUser !== prevProps.selectedUser) {
+        this.props._resetError()
+      }
     },
   })
 )(Login)

--- a/shared/login/login/index.js.flow
+++ b/shared/login/login/index.js.flow
@@ -6,7 +6,7 @@ export type Props = {
   onForgotPassphrase: () => void,
   onSignup: () => void,
   onSomeoneElse: () => void,
-  error: ?string,
+  error: string,
   waitingForResponse: boolean,
   passphrase: string,
   showTyping: boolean,

--- a/shared/login/login/index.stories.js
+++ b/shared/login/login/index.stories.js
@@ -4,7 +4,7 @@ import Login, {type Props} from '.'
 import {action, storiesOf} from '../../stories/storybook'
 
 const commonProps: Props = {
-  error: null,
+  error: '',
   onBack: action('onBack'),
   onFeedback: action('onFeedback'),
   onForgotPassphrase: action('onForgotPassphrase'),


### PR DESCRIPTION
Resolves DESKTOP-4269

This clears the login error after switching user accounts and empties the passphrase input.

I've created DESKTOP-6641 to track the work on focusing the passphrase input after switching user accounts in the user dropdown menu.

@keybase/react-hackers, this is ready for review.