### PR TITLE
use MetaContext instead of LoginContext in libkb, and branch out

### DIFF
--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -95,7 +95,7 @@ func getSigningKeyPairForTest(t *testing.T, tc *kbtest.ChatTestContext, u *kbtes
 			t.Fatal(err)
 		}
 	}
-	kp, err := tc.G.Keyrings.GetSecretKeyWithPassphrase(nil, u.User, u.Passphrase, nil)
+	kp, err := tc.G.Keyrings.GetSecretKeyWithPassphrase(kbtest.NewMetaContextForTest(*tc), u.User, u.Passphrase, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -242,6 +242,7 @@ type chatTestUserContext struct {
 	u        *kbtest.FakeUser
 	h        *Server
 	ri       chat1.RemoteInterface
+	m        libkb.MetaContext
 }
 
 func (tuc *chatTestUserContext) user() *kbtest.FakeUser {
@@ -355,6 +356,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 		u:        user,
 		startCtx: ctx,
 		ri:       ri,
+		m:        libkb.NewMetaContext(ctx, tc.G),
 	}
 	c.userContextCache[user.Username] = tuc
 	return tuc
@@ -3894,7 +3896,8 @@ func TestChatSrvUserReset(t *testing.T) {
 			ctc.as(t, users[1]).user(), ctc.as(t, users[2]).user())
 
 		t.Logf("reset user 1")
-		require.NoError(t, ctc.as(t, users[1]).h.G().LoginState().ResetAccount(users[1].Username))
+		ctcForUser := ctc.as(t, users[1])
+		require.NoError(t, ctcForUser.h.G().LoginState().ResetAccount(ctcForUser.m, users[1].Username))
 		select {
 		case act := <-listener0.membersUpdate:
 			require.Equal(t, act.ConvID, conv.Id)
@@ -3954,7 +3957,8 @@ func TestChatSrvUserReset(t *testing.T) {
 		require.Error(t, err)
 
 		t.Logf("reset user 2")
-		require.NoError(t, ctc.as(t, users[2]).h.G().LoginState().ResetAccount(users[2].Username))
+		ctcForUser2 := ctc.as(t, users[2])
+		require.NoError(t, ctcForUser2.h.G().LoginState().ResetAccount(ctcForUser2.m, users[2].Username))
 		select {
 		case act := <-listener0.membersUpdate:
 			require.Equal(t, act.ConvID, conv.Id)

--- a/go/client/cmd_test_passphrase.go
+++ b/go/client/cmd_test_passphrase.go
@@ -47,10 +47,12 @@ func (s *CmdTestPassphrase) Run() (err error) {
 		return err
 	}
 
+	ctx := context.Background()
+
 	arg := keybase1.PassphrasePromptArg{
-		GuiArg: libkb.DefaultPassphraseArg(s.G()),
+		GuiArg: libkb.DefaultPassphraseArg(libkb.NewMetaContext(ctx, s.G())),
 	}
-	res, err := cli.PassphrasePrompt(context.TODO(), arg)
+	res, err := cli.PassphrasePrompt(ctx, arg)
 	if err != nil {
 		return err
 	}

--- a/go/client/passphrase_prompt.go
+++ b/go/client/passphrase_prompt.go
@@ -15,7 +15,7 @@ import (
 // promptPassphrase asks the user for a passphrase.
 // Used during signup.
 func PromptPassphrase(g *libkb.GlobalContext) (keybase1.GetPassphraseRes, error) {
-	arg := libkb.DefaultPassphraseArg(g)
+	arg := libkb.DefaultPassphraseArg(libkb.NewMetaContextTODO(g))
 	arg.WindowTitle = "Passphrase"
 	arg.Prompt = fmt.Sprintf("Pick a strong passphrase (%d+ characters)", libkb.MinPassphraseLength)
 	arg.Type = keybase1.PassphraseType_PASS_PHRASE
@@ -25,7 +25,7 @@ func PromptPassphrase(g *libkb.GlobalContext) (keybase1.GetPassphraseRes, error)
 // promptNewPassphrase asks the user for a new passphrase.
 // Used when changing passphrases.
 func PromptNewPassphrase(g *libkb.GlobalContext) (string, error) {
-	arg := libkb.DefaultPassphraseArg(g)
+	arg := libkb.DefaultPassphraseArg(libkb.NewMetaContextTODO(g))
 	arg.WindowTitle = "Pick a new passphrase"
 	arg.Prompt = fmt.Sprintf("Pick a new strong passphrase (%d+ characters)", libkb.MinPassphraseLength)
 	arg.Type = keybase1.PassphraseType_VERIFY_PASS_PHRASE
@@ -39,7 +39,8 @@ func PromptNewPassphrase(g *libkb.GlobalContext) (string, error) {
 // PromptPaperPhrase asks the user to enter a paper key phrase.
 // Used in `rekey paper` command.
 func PromptPaperPhrase(g *libkb.GlobalContext) (string, error) {
-	arg := libkb.DefaultPassphraseArg(g)
+	m := libkb.NewMetaContextTODO(g)
+	arg := libkb.DefaultPassphraseArg(m)
 	arg.WindowTitle = "Enter a paper key"
 	arg.Prompt = "Enter a paper key"
 	arg.Type = keybase1.PassphraseType_PAPER_KEY
@@ -47,7 +48,7 @@ func PromptPaperPhrase(g *libkb.GlobalContext) (string, error) {
 	arg.Features.ShowTyping.DefaultValue = true
 
 	prompter := newClientPrompter(g)
-	res, err := libkb.GetPassphraseUntilCheck(g, arg, prompter, &libkb.PaperChecker{})
+	res, err := libkb.GetPassphraseUntilCheck(m, arg, prompter, &libkb.PaperChecker{})
 	if err != nil {
 		return "", err
 	}
@@ -56,12 +57,13 @@ func PromptPaperPhrase(g *libkb.GlobalContext) (string, error) {
 
 func promptPassphraseWithArg(g *libkb.GlobalContext, arg keybase1.GUIEntryArg, promptConfirm string) (keybase1.GetPassphraseRes, error) {
 	prompter := newClientPrompter(g)
+	m := libkb.NewMetaContextTODO(g)
 
 	firstPrompt := arg.Prompt
 
 	for i := 0; i < 10; i++ {
 		// get the first passphrase
-		res, err := libkb.GetPassphraseUntilCheckWithChecker(g, arg, prompter, &libkb.CheckPassphraseNew)
+		res, err := libkb.GetPassphraseUntilCheckWithChecker(m, arg, prompter, &libkb.CheckPassphraseNew)
 		if err != nil {
 			return keybase1.GetPassphraseRes{}, err
 		}
@@ -69,7 +71,7 @@ func promptPassphraseWithArg(g *libkb.GlobalContext, arg keybase1.GUIEntryArg, p
 		// get confirmation passphrase
 		arg.RetryLabel = ""
 		arg.Prompt = promptConfirm
-		confirm, err := libkb.GetPassphraseUntilCheckWithChecker(g, arg, prompter, &libkb.CheckPassphraseNew)
+		confirm, err := libkb.GetPassphraseUntilCheckWithChecker(m, arg, prompter, &libkb.CheckPassphraseNew)
 		if err != nil {
 			return keybase1.GetPassphraseRes{}, err
 		}

--- a/go/doc/context.md
+++ b/go/doc/context.md
@@ -1,0 +1,105 @@
+
+# A Note On The Various "Contexts" and "LoginState"
+
+We are in the midst of wide and slow-moving code reorgnization with two major goals:
+
+1. To standardize as much code as possible to take one of three "context" objects, always
+as a first argument: (a) Go's standard `context.Context`; (b) our rollup `libkb.MetaContext`;
+or (c) our chat-specific context `chat.ChatContext`. We want to eliminate all cases
+of functions taking multiple contexts, or contexts not in the first parameter slot, etc.
+2. To retire `libkb.LoginState`, `libkb.LoginContext`, and `libkb.Session`, and to migrate
+their roles into `libkb.ActiveDevice`.
+
+The goal of `libkb.MetaContext` is to provide both thread-local (see `.Ctx` and `.activeDevice`) and global context (see `.g`). During signup, login or provisioning, we can store a thread local
+version of the `ActiveDevice` in the `MetaContext` so that the various login and provisioning
+routines can act upon it before exposing it to the rest of the program, since it's still provisional
+until login completes. Once the `ActiveDevice` becomes official, then all threads can access it
+via `GlobalContext`.
+
+There's a ton of changes we'd have to make in the code to achieve these goals, and
+we'd like to proceed in small piecemeal steps so that we can shake out any bugs
+as we go.
+
+# History
+
+We have a long and sordid history here, and it might be worth explaining a little bit
+of what happened before we describe the strategy for going forward. When we first
+started this project, the Go standard `context.Context` hadn't fully formed yet,
+so we did incorporate it. Instead, we had a notion of `GlobalContext` which applied to
+all threads. At first, all threads accessed this global context via a global variable `G`,
+but that strategy was terrible for many reasons, and made testing multiple instances of
+Keybase in the same address space near-impossible.  Thus, we embarked upon a length crusade
+to retire to `G` variable and use a combination of dependency-injection and just passing `G`
+wherever we could.
+
+Around the same time, we started to adopt the `context.Context` standard, especially
+for logging with request-specific tags (useful for debugging). These attempts were sometimes
+at odds, so we would up with an inconsistent ordering and placement of these contexts
+when passed to function. Also, though were finally able to retire `G`, we did not succeed
+in fully threading `context.Context`s through the code; nor did we finish the project to always
+use `context.Context`-aware versions of logging functions.
+
+In addition, we've long had the LoginState/Account/LoginContext/Session family of objects
+to manage the user's logged-in state, and to shepherd the user through signup and device
+provisioning. We've experience growing pains and bugs around the current configuration
+and long for a simplification. In particular, we're not happy with the Go-channel-based
+synchronization primitives at the heart of the state maintenance here, since it's easy
+to code deadlocks hidden behind layers of abstraction.  Instead, we want a simple lock-based
+model, where those locks are only held briefly, never during a network request (let's say).
+
+# Migration Strategy
+
+## Step 1: Use NIST Tokens for Session Establishment
+
+Status: **completed**
+
+It used to be the case we needed the exclusive lock over Account/LoginContext to make an
+API call, since it needed the user's session cookie (and CSRF token), and it was stored there.
+This setup made it very easy for API calls to fight over this locked resource and to stall,
+especially on application foregrounding or resumption from a long sleep. So the solution
+here is to authenticate a client to the server just based on a signature that the user can
+cook up with just her/his public key. Now, API calls are no longer dependent on
+Account/LoginContext, with the exception of provisioning and signup (i.e., before
+proper device keys are established).
+
+## Step 2: Propagate MetaContext from libkb outward
+
+Status: **ongoing**
+
+### Step 2a: Replace LoginContext with a wrapper MetaContext (Part 1)
+
+- Start with `LoginState`-related functions and propagate outwards. Cover `ActiveDevice`,
+`PerUserKey`, and bubble up into `engine/` too, but only as necessary.
+
+### Step 2b: Replace LoginContext with a wrapper MetaContext (Part 2)
+
+- Continue with `stellar/` and `ephemeral/` to replace those functions that take
+both `context.Context` and `*GlobalContext` to take only `libkb.MetaContext`.
+
+### Step 2c: Move `engine.Context` into `libkb.MetaContext`
+
+- And then change all `engine/` code to take only the `libkb.MetaContext`
+
+## Step 3: Retire LoginState
+
+Once we get to this point, things are a little less clear. The advantage of having
+done step 2 first is that a lot of times, we check for a thread-local `LoginContext`
+and then fallback to one that we grab from the global state. A lot of code is
+duplicated to handle these two cases, since the access pattern is different.
+One strategy here might be to move to a `LoginContext`-like object that can be safely
+copied, so it's no longer necessary to operate on it from outside of a closure.
+
+### Step 3a: Move LoginSession into ActiveDevice
+
+### Step 3b: Move PassphraseStream into ActiveDevice
+
+### Step 3c: Kill LoginContext
+
+### Step 3d: Kill LoginState
+
+
+
+
+
+
+

--- a/go/engine/account_delete.go
+++ b/go/engine/account_delete.go
@@ -46,13 +46,14 @@ func (e *AccountDelete) SubConsumers() []libkb.UIConsumer {
 // Run starts the engine.
 func (e *AccountDelete) Run(ctx *Context) error {
 	username := e.G().GetEnv().GetUsername().String()
-	arg := libkb.DefaultPassphrasePromptArg(e.G(), username)
+	mctx := NewMetaContext(e, ctx)
+	arg := libkb.DefaultPassphrasePromptArg(mctx, username)
 	res, err := ctx.SecretUI.GetPassphrase(arg, nil)
 	if err != nil {
 		return err
 	}
-	_, err = e.G().LoginState().VerifyPlaintextPassphrase(res.Passphrase, func(lctx libkb.LoginContext) error {
-		return libkb.DeleteAccountWithContext(e.G(), lctx, username)
+	_, err = e.G().LoginState().VerifyPlaintextPassphrase(mctx, res.Passphrase, func(lctx libkb.LoginContext) error {
+		return libkb.DeleteAccountWithContext(mctx.WithLoginContext(lctx), username)
 	})
 
 	if err != nil {

--- a/go/engine/bug_3964_repairman_test.go
+++ b/go/engine/bug_3964_repairman_test.go
@@ -35,7 +35,9 @@ func (a *auditLog) Debug(format string, args ...interface{}) {
 	*a.lines = append(*a.lines, s)
 }
 func (a *auditLog) CDebugf(ctx context.Context, format string, args ...interface{}) {
-	a.l.CDebugf(ctx, format, args...)
+	s := fmt.Sprintf(format, args...)
+	a.l.CDebugf(ctx, s)
+	*a.lines = append(*a.lines, s)
 }
 func (a *auditLog) Info(format string, args ...interface{}) {
 	a.l.Info(format, args...)
@@ -101,11 +103,13 @@ func (a *auditLog) SetExternalHandler(handler logger.ExternalHandler) {
 func corruptDevice2(dev1 libkb.TestContext, dev2 libkb.TestContext) (*libkb.DeviceKey, error) {
 	ls1 := dev1.G.LoginState()
 	ls2 := dev2.G.LoginState()
+	m := NewMetaContextForTest(dev2)
 
 	err := ls1.RunSecretSyncer(dev1.G.Env.GetUID())
 	if err != nil {
 		return nil, err
 	}
+
 	var e2 error
 	var ret libkb.DeviceKey
 
@@ -136,7 +140,7 @@ func corruptDevice2(dev1 libkb.TestContext, dev2 libkb.TestContext) (*libkb.Devi
 	if e2 != nil {
 		return nil, e2
 	}
-	if err = goodLksec.LoadServerHalf(nil); err != nil {
+	if err = goodLksec.LoadServerHalf(m); err != nil {
 		return nil, err
 	}
 
@@ -153,7 +157,7 @@ func corruptDevice2(dev1 libkb.TestContext, dev2 libkb.TestContext) (*libkb.Devi
 
 	err = ls2.MutateKeyring(func(krf *libkb.SKBKeyringFile) *libkb.SKBKeyringFile {
 		for _, b := range krf.Blocks {
-			raw, _, erroneousMask, err := goodLksec.Decrypt(nil, b.Priv.Data)
+			raw, _, erroneousMask, err := goodLksec.Decrypt(m, b.Priv.Data)
 			if err != nil {
 				e2 = err
 				return nil
@@ -162,7 +166,7 @@ func corruptDevice2(dev1 libkb.TestContext, dev2 libkb.TestContext) (*libkb.Devi
 				e2 = errors.New("bad erroneousMask")
 				return nil
 			}
-			b.Priv.Data, e2 = badLskec.Encrypt(raw)
+			b.Priv.Data, e2 = badLskec.Encrypt(m, raw)
 			if e2 != nil {
 				return nil
 			}
@@ -292,7 +296,7 @@ func checkLKSWorked(t *testing.T, tctx libkb.TestContext, u *FakeUser) {
 		KeyType: libkb.DeviceEncryptionKeyType,
 	}
 	arg := ctx.SecretKeyPromptArg(ska, "tracking signature")
-	encKey, err := tctx.G.Keyrings.GetSecretKeyWithPrompt(arg)
+	encKey, err := tctx.G.Keyrings.GetSecretKeyWithPrompt(NewMetaContextForTest(tctx), arg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +307,7 @@ func checkLKSWorked(t *testing.T, tctx libkb.TestContext, u *FakeUser) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pps, err := tctx.G.LoginState().GetPassphraseStream(ctx.SecretUI)
+	pps, err := tctx.G.LoginState().GetPassphraseStream(NewMetaContextForTest(tctx), ctx.SecretUI)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -400,8 +400,12 @@ func SetupTwoDevicesWithHook(t *testing.T, nm string, hook func(tc *libkb.TestCo
 	return user, dev1, dev2, cleanup
 }
 
+func NewMetaContextForTest(tc libkb.TestContext) libkb.MetaContext {
+	return libkb.NewMetaContextForTest(tc)
+}
+
 func ResetAccount(tc libkb.TestContext, u *FakeUser) {
-	err := tc.G.LoginState().ResetAccount(u.Username)
+	err := tc.G.LoginState().ResetAccount(NewMetaContextForTest(tc), u.Username)
 	if err != nil {
 		tc.T.Fatalf("In account reset: %s", err)
 	}
@@ -410,7 +414,7 @@ func ResetAccount(tc libkb.TestContext, u *FakeUser) {
 }
 
 func ResetAccountNoLogout(tc libkb.TestContext, u *FakeUser) {
-	err := tc.G.LoginState().ResetAccount(u.Username)
+	err := tc.G.LoginState().ResetAccount(NewMetaContextForTest(tc), u.Username)
 	if err != nil {
 		tc.T.Fatalf("In account reset: %s", err)
 	}

--- a/go/engine/concurrency_test.go
+++ b/go/engine/concurrency_test.go
@@ -111,7 +111,7 @@ func TestConcurrentGetPassphraseStream(t *testing.T) {
 					fmt.Printf("func caller %d done\n", index)
 					return
 				default:
-					_, err := tc.G.LoginState().GetPassphraseStream(u.NewSecretUI())
+					_, err := tc.G.LoginState().GetPassphraseStream(NewMetaContextForTest(tc), u.NewSecretUI())
 					if err != nil {
 						tc.G.Log.Warning("GetPassphraseStream err: %s", err)
 					}

--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -93,10 +93,9 @@ func (c *Context) WithTimeout(timeout time.Duration) (*Context, context.CancelFu
 
 func (c *Context) SecretKeyPromptArg(ska libkb.SecretKeyArg, reason string) libkb.SecretKeyPromptArg {
 	return libkb.SecretKeyPromptArg{
-		LoginContext: c.LoginContext,
-		SecretUI:     c.SecretUI,
-		Ska:          ska,
-		Reason:       reason,
+		SecretUI: c.SecretUI,
+		Ska:      ska,
+		Reason:   reason,
 	}
 }
 
@@ -104,4 +103,8 @@ func (c *Context) CloneGlobalContextWithLogTags(g *libkb.GlobalContext, k string
 	netCtx := libkb.WithLogTag(c.GetNetContext(), k)
 	c.NetContext = netCtx
 	return g.CloneWithNetContextAndNewLogger(netCtx)
+}
+
+func NewMetaContext(e Engine, c *Context) libkb.MetaContext {
+	return libkb.NewMetaContext(c.GetNetContext(), e.G()).WithLoginContext(c.LoginContext)
 }

--- a/go/engine/crypto.go
+++ b/go/engine/crypto.go
@@ -120,11 +120,11 @@ func UnboxBytes32(ctx context.Context, g *libkb.GlobalContext, getSecretUI func(
 // bundles in arg.Bundles.  Key preference order:  cached device keys,
 // cached paper keys, local device key, user-entered paper key.
 // It returns the KID and bundle index along with the plaintext.
-func UnboxBytes32Any(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI, arg keybase1.UnboxBytes32AnyArg) (res keybase1.UnboxAnyRes, err error) {
-	defer g.CTrace(ctx, "UnboxBytes32Any", func() error { return err })()
+func UnboxBytes32Any(m libkb.MetaContext, getSecretUI func() libkb.SecretUI, arg keybase1.UnboxBytes32AnyArg) (res keybase1.UnboxAnyRes, err error) {
+	defer m.CTrace("UnboxBytes32Any", func() error { return err })()
 
 	// find a matching secret key for a bundle in arg.Bundles
-	key, index, err := getMatchingSecretKey(ctx, g, getSecretUI, arg)
+	key, index, err := getMatchingSecretKey(m, getSecretUI, arg)
 	if err != nil {
 		return res, err
 	}
@@ -170,9 +170,9 @@ func unboxBytes32(encryptionKey libkb.GenericKey, ciphertext keybase1.EncryptedB
 
 }
 
-func getMatchingSecretKey(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI, arg keybase1.UnboxBytes32AnyArg) (key libkb.GenericKey, index int, err error) {
+func getMatchingSecretKey(m libkb.MetaContext, getSecretUI func() libkb.SecretUI, arg keybase1.UnboxBytes32AnyArg) (key libkb.GenericKey, index int, err error) {
 	// first check cached keys
-	key, index, err = matchingCachedKey(g, arg)
+	key, index, err = matchingCachedKey(m, arg)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -180,26 +180,26 @@ func getMatchingSecretKey(ctx context.Context, g *libkb.GlobalContext, getSecret
 		return key, index, nil
 	}
 
-	g.Log.CDebugf(ctx, "getMatchingSecretKey: acquiring lock")
+	m.CDebugf("getMatchingSecretKey: acquiring lock")
 	getKeyMu.Lock()
 	defer func() {
 		getKeyMu.Unlock()
-		g.Log.CDebugf(ctx, "getMatchingSecretKey: lock released")
+		m.CDebugf("getMatchingSecretKey: lock released")
 	}()
-	g.Log.CDebugf(ctx, "getMatchingSecretKey: lock acquired")
+	m.CDebugf("getMatchingSecretKey: lock acquired")
 
 	// check cache after acquiring lock
-	key, index, err = matchingCachedKey(g, arg)
+	key, index, err = matchingCachedKey(m, arg)
 	if err != nil {
 		return nil, 0, err
 	}
 	if key != nil {
 		return key, index, nil
 	}
-	g.Log.CDebugf(ctx, "getMatchingSecretKey: no matching cached device key found")
+	m.CDebugf("getMatchingSecretKey: no matching cached device key found")
 
 	// load the user
-	me, err := libkb.LoadMe(libkb.NewLoadUserArg(g))
+	me, err := libkb.LoadMe(libkb.NewLoadUserArgWithMetaContext(m))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -208,22 +208,22 @@ func getMatchingSecretKey(ctx context.Context, g *libkb.GlobalContext, getSecret
 	secretUI := getSecretUI()
 
 	// check the device key for this user
-	key, index, err = matchingDeviceKey(g, secretUI, arg, me)
+	key, index, err = matchingDeviceKey(m, secretUI, arg, me)
 	if err != nil {
 		return nil, 0, err
 	}
 	if key != nil {
 		return key, index, nil
 	}
-	g.Log.CDebugf(ctx, "getMatchingSecretKey: no matching device key found")
+	m.CDebugf("getMatchingSecretKey: no matching device key found")
 
 	if !arg.PromptPaper {
-		g.Log.CDebugf(ctx, "UnboxBytes32Any/getMatchingSecretKey: not checking paper keys (promptPaper == false)")
+		m.CDebugf("UnboxBytes32Any/getMatchingSecretKey: not checking paper keys (promptPaper == false)")
 		return nil, 0, libkb.NoSecretKeyError{}
 	}
 
 	// check the paper keys for this user
-	key, index, err = matchingPaperKey(g, secretUI, arg, me)
+	key, index, err = matchingPaperKey(m, secretUI, arg, me)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -235,16 +235,16 @@ func getMatchingSecretKey(ctx context.Context, g *libkb.GlobalContext, getSecret
 }
 
 // check cached keys for arg.Bundles match.
-func matchingCachedKey(g *libkb.GlobalContext, arg keybase1.UnboxBytes32AnyArg) (key libkb.GenericKey, index int, err error) {
+func matchingCachedKey(m libkb.MetaContext, arg keybase1.UnboxBytes32AnyArg) (key libkb.GenericKey, index int, err error) {
 	// check device key first
-	dkey, err := g.ActiveDevice.EncryptionKey()
+	dkey, err := m.ActiveDevice().EncryptionKey()
 	if err == nil && dkey != nil {
 		if n, ok := kidMatch(dkey, arg.Bundles); ok {
 			return dkey, n, nil
 		}
 	}
 
-	err = g.LoginState().Account(func(a *libkb.Account) {
+	err = m.G().LoginState().Account(func(a *libkb.Account) {
 		// check paper key
 		pkey := a.GetUnlockedPaperEncKey()
 		if n, ok := kidMatch(pkey, arg.Bundles); ok {
@@ -264,7 +264,7 @@ func matchingCachedKey(g *libkb.GlobalContext, arg keybase1.UnboxBytes32AnyArg) 
 }
 
 // check device key for arg.Bundles match.
-func matchingDeviceKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg keybase1.UnboxBytes32AnyArg, me *libkb.User) (key libkb.GenericKey, index int, err error) {
+func matchingDeviceKey(m libkb.MetaContext, secretUI libkb.SecretUI, arg keybase1.UnboxBytes32AnyArg, me *libkb.User) (key libkb.GenericKey, index int, err error) {
 	ekey, err := me.GetDeviceSubkey()
 	if err == nil {
 		if n, ok := kidMatch(ekey, arg.Bundles); ok {
@@ -278,24 +278,24 @@ func matchingDeviceKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg keyb
 				Reason:         arg.Reason,
 				UseCancelCache: true,
 			}
-			key, err := g.Keyrings.GetSecretKeyWithPrompt(parg)
+			key, err := m.G().Keyrings.GetSecretKeyWithPrompt(m, parg)
 			if err != nil {
 				return nil, 0, err
 			}
 			return key, n, nil
 		}
 
-		g.Log.Debug("matchingDeviceKey: no match found for ekey in arg.Bundles")
-		logNoMatch(g, ekey, arg.Bundles)
+		m.CDebugf("matchingDeviceKey: no match found for ekey in arg.Bundles")
+		logNoMatch(m, ekey, arg.Bundles)
 	} else {
-		g.Log.Debug("matchingDeviceKey: ignoring error getting device subkey: %s", err)
+		m.CDebugf("matchingDeviceKey: ignoring error getting device subkey: %s", err)
 	}
 
 	return nil, 0, nil
 }
 
 // check all the user's paper keys for arg.Bundles match
-func matchingPaperKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg keybase1.UnboxBytes32AnyArg, me *libkb.User) (key libkb.GenericKey, index int, err error) {
+func matchingPaperKey(m libkb.MetaContext, secretUI libkb.SecretUI, arg keybase1.UnboxBytes32AnyArg, me *libkb.User) (key libkb.GenericKey, index int, err error) {
 	cki := me.GetComputedKeyInfos()
 	if cki == nil {
 		return nil, 0, nil
@@ -307,20 +307,20 @@ func matchingPaperKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg keyba
 			return nil, 0, err
 		}
 		if _, ok := kidMatch(enckey, arg.Bundles); ok {
-			g.Log.Debug("matching paper key: %s", *pdev.Description)
+			m.CDebugf("matching paper key: %s", *pdev.Description)
 			matchingPaper = append(matchingPaper, pdev)
 		}
 	}
 	if len(matchingPaper) == 0 {
-		g.Log.Debug("no matching paper keys found")
+		m.CDebugf("no matching paper keys found")
 		return nil, 0, nil
 	}
 
-	phrase, err := libkb.GetPaperKeyForCryptoPassphrase(g, secretUI, arg.Reason, matchingPaper)
+	phrase, err := libkb.GetPaperKeyForCryptoPassphrase(m, secretUI, arg.Reason, matchingPaper)
 	if err != nil {
 		return nil, 0, err
 	}
-	paperPhrase, err := libkb.NewPaperKeyPhraseCheckVersion(g, phrase)
+	paperPhrase, err := libkb.NewPaperKeyPhraseCheckVersion(m, phrase)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -329,7 +329,7 @@ func matchingPaperKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg keyba
 		Passphrase: paperPhrase,
 		SkipPush:   true,
 	}
-	bkeng := NewPaperKeyGen(bkarg, g)
+	bkeng := NewPaperKeyGen(bkarg, m.G())
 	if err := RunEngine(bkeng, &Context{}); err != nil {
 		return nil, 0, err
 	}
@@ -338,7 +338,7 @@ func matchingPaperKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg keyba
 	if n, ok := kidMatch(bkeng.EncKey(), arg.Bundles); ok {
 
 		// this key matches, so cache this paper key
-		if err := g.LoginState().Account(func(a *libkb.Account) {
+		if err := m.G().LoginState().Account(func(a *libkb.Account) {
 			a.SetUnlockedPaperKey(bkeng.SigKey(), bkeng.EncKey())
 		}, "UnboxBytes32Any - cache paper key"); err != nil {
 			return nil, 0, err
@@ -363,14 +363,14 @@ func kidMatch(key libkb.GenericKey, bundles []keybase1.CiphertextBundle) (int, b
 	return -1, false
 }
 
-func logNoMatch(g *libkb.GlobalContext, key libkb.GenericKey, bundles []keybase1.CiphertextBundle) {
+func logNoMatch(m libkb.MetaContext, key libkb.GenericKey, bundles []keybase1.CiphertextBundle) {
 	if key == nil {
-		g.Log.Debug("logNoMatch: key is nil")
+		m.CDebugf("logNoMatch: key is nil")
 		return
 	}
 	kid := key.GetKID()
-	g.Log.Debug("logNoMatch: desired kid: %s", kid)
+	m.CDebugf("logNoMatch: desired kid: %s", kid)
 	for i, bundle := range bundles {
-		g.Log.Debug("logNoMatch: kid %d: %s (%v)", i, bundle.Kid, kid.Equal(bundle.Kid))
+		m.CDebugf("logNoMatch: kid %d: %s (%v)", i, bundle.Kid, kid.Equal(bundle.Kid))
 	}
 }

--- a/go/engine/crypto_test.go
+++ b/go/engine/crypto_test.go
@@ -173,7 +173,7 @@ func TestCryptoUnboxBytes32(t *testing.T) {
 			{Kid: kp.GetKID(), Ciphertext: encryptedBytes32, Nonce: nonce, PublicKey: peersPublicKey},
 		},
 	}
-	res, err := UnboxBytes32Any(context.TODO(), tc.G, f, arg)
+	res, err := UnboxBytes32Any(NewMetaContextForTest(tc), f, arg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -368,7 +368,7 @@ func TestCryptoUnboxBytes32AnyPaper(t *testing.T) {
 		},
 		PromptPaper: true,
 	}
-	res, err := UnboxBytes32Any(context.TODO(), tc.G, f, arg)
+	res, err := UnboxBytes32Any(NewMetaContextForTest(tc), f, arg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,7 +394,7 @@ func TestCryptoUnboxBytes32AnyPaper(t *testing.T) {
 		return secretUI
 	}
 
-	res, err = UnboxBytes32Any(context.TODO(), tc.G, f, arg)
+	res, err = UnboxBytes32Any(NewMetaContextForTest(tc), f, arg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/cryptocurrency.go
+++ b/go/engine/cryptocurrency.go
@@ -52,7 +52,8 @@ func (e *CryptocurrencyEngine) Run(ctx *Context) (err error) {
 	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "CryptocurrencyEngine")
 	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "CryptocurrencyEngine")
 
-	defer e.G().Trace("CryptocurrencyEngine", func() error { return err })()
+	mctx := NewMetaContext(e, ctx)
+	defer mctx.CTrace("CryptocurrencyEngine", func() error { return err })()
 
 	var typ libkb.CryptocurrencyType
 	typ, _, err = libkb.CryptocurrencyParseAndCheck(e.arg.Address)
@@ -90,7 +91,7 @@ func (e *CryptocurrencyEngine) Run(ctx *Context) (err error) {
 		Me:      me,
 		KeyType: libkb.DeviceSigningKeyType,
 	}
-	sigKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "to register a cryptocurrency address"))
+	sigKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(mctx, ctx.SecretKeyPromptArg(ska, "to register a cryptocurrency address"))
 	if err != nil {
 		return err
 	}

--- a/go/engine/device_add.go
+++ b/go/engine/device_add.go
@@ -72,7 +72,7 @@ func (e *DeviceAdd) Run(ctx *Context) (err error) {
 	// provisioner needs ppstream, and UI is confusing when it asks for
 	// it at the same time as asking for the secret, so get it first
 	// before prompting for the kex2 secret:
-	pps, err := e.G().LoginState().GetPassphraseStreamStored(ctx.SecretUI)
+	pps, err := e.G().LoginState().GetPassphraseStreamStored(NewMetaContext(e, ctx), ctx.SecretUI)
 	if err != nil {
 		return err
 	}

--- a/go/engine/device_wrap.go
+++ b/go/engine/device_wrap.go
@@ -68,6 +68,7 @@ func (e *DeviceWrap) Run(ctx *Context) error {
 		Name: e.args.DeviceName,
 		Lks:  e.args.Lks,
 	}
+	m := NewMetaContext(e, ctx)
 	regEng := NewDeviceRegister(regArgs, e.G())
 	if err := RunEngine(regEng, ctx); err != nil {
 		return err
@@ -93,7 +94,7 @@ func (e *DeviceWrap) Run(ctx *Context) error {
 		Signer:    e.args.Signer,
 		EldestKID: e.args.EldestKID,
 	}
-	if err := kgEng.Push(ctx, pargs); err != nil {
+	if err := kgEng.Push(m, ctx, pargs); err != nil {
 		return err
 	}
 

--- a/go/engine/email_change.go
+++ b/go/engine/email_change.go
@@ -48,7 +48,8 @@ func (c *EmailChange) SubConsumers() []libkb.UIConsumer {
 
 // Run the engine
 func (c *EmailChange) Run(ctx *Context) (err error) {
-	defer c.G().Trace("EmailChange#Run", func() error { return err })()
+	mctx := NewMetaContext(c, ctx)
+	defer mctx.CTrace("EmailChange#Run", func() error { return err })()
 
 	if !libkb.CheckEmail.F(c.arg.NewEmail) {
 		return libkb.BadEmailError{}
@@ -66,7 +67,7 @@ func (c *EmailChange) Run(ctx *Context) (err error) {
 		KeyType: libkb.DeviceSigningKeyType,
 	}
 	arg := ctx.SecretKeyPromptArg(ska, "tracking signature")
-	signingKey, err := c.G().Keyrings.GetSecretKeyWithPrompt(arg)
+	signingKey, err := c.G().Keyrings.GetSecretKeyWithPrompt(mctx, arg)
 	if err != nil {
 		return err
 	}

--- a/go/engine/login_load_user.go
+++ b/go/engine/login_load_user.go
@@ -106,7 +106,7 @@ func (e *loginLoadUser) findUsername(ctx *Context) (string, error) {
 		username = lctx.LocalSession().GetUsername().String()
 		return nil
 	}
-	if err := e.G().LoginState().VerifyEmailAddress(e.usernameOrEmail, ctx.SecretUI, afterLogin); err != nil {
+	if err := e.G().LoginState().VerifyEmailAddress(NewMetaContext(e, ctx), e.usernameOrEmail, ctx.SecretUI, afterLogin); err != nil {
 		return "", err
 	}
 

--- a/go/engine/login_offline.go
+++ b/go/engine/login_offline.go
@@ -50,7 +50,7 @@ func (e *LoginOffline) Run(ctx *Context) error {
 func (e *LoginOffline) run(ctx *Context) error {
 	var gerr error
 	aerr := e.G().LoginState().Account(func(a *libkb.Account) {
-		_, err := libkb.BootstrapActiveDeviceFromConfig(ctx.NetContext, e.G(), a, false)
+		_, err := libkb.BootstrapActiveDeviceFromConfig(NewMetaContext(e, ctx).WithLoginContext(a), false)
 		if err != nil {
 			gerr = libkb.NewLoginRequiredError(err.Error())
 		}

--- a/go/engine/login_oneshot.go
+++ b/go/engine/login_oneshot.go
@@ -90,7 +90,7 @@ func (e *LoginOneshot) makeLoginChanges(ctx context.Context) (err error) {
 	defer e.G().CTrace(ctx, "LoginOneshot#makeLoginChanges", func() error { return err })()
 	var gerr error
 	err = e.G().LoginState().Account(func(a *libkb.Account) {
-		gerr = e.G().ActiveDevice.Set(e.G(), a, e.upak.GetUID(), e.deviceID, e.sigKey, e.encKey, e.deviceName)
+		gerr = e.G().ActiveDevice.Set(libkb.NewMetaContext(ctx, e.G()).WithLoginContext(a), e.upak.GetUID(), e.deviceID, e.sigKey, e.encKey, e.deviceName)
 	}, "LoginOneshot#makeLoginChanges")
 	if err != nil {
 		return err

--- a/go/engine/login_provisioned_device.go
+++ b/go/engine/login_provisioned_device.go
@@ -51,26 +51,27 @@ func (e *LoginProvisionedDevice) SubConsumers() []libkb.UIConsumer {
 }
 
 func (e *LoginProvisionedDevice) Run(ctx *Context) error {
-	if err := e.run(ctx); err != nil {
+	m := NewMetaContext(e, ctx)
+	if err := e.run(m, ctx); err != nil {
 		return err
 	}
 
-	e.G().Log.Debug("LoginProvisionedDevice success, sending login notification")
+	m.CDebugf("LoginProvisionedDevice success, sending login notification")
 	e.G().NotifyRouter.HandleLogin(string(e.G().Env.GetUsername()))
-	e.G().Log.Debug("LoginProvisionedDevice success, calling login hooks")
+	m.CDebugf("LoginProvisionedDevice success, calling login hooks")
 	e.G().CallLoginHooks()
 
 	return nil
 }
 
-func (e *LoginProvisionedDevice) run(ctx *Context) error {
+func (e *LoginProvisionedDevice) run(m libkb.MetaContext, ctx *Context) error {
 	// already logged in?
-	in, err := e.G().LoginState().LoggedInProvisioned(ctx.GetNetContext())
+	in, err := m.G().LoginState().LoggedInProvisioned(ctx.GetNetContext())
 	if err == nil && in {
 		if len(e.username) == 0 || e.G().Env.GetUsername() == libkb.NewNormalizedUsername(e.username) {
 			// already logged in, make sure to unlock device keys
 			var partialCopy *libkb.User
-			err = e.G().GetFullSelfer().WithSelf(ctx.NetContext, func(user *libkb.User) error {
+			err = m.G().GetFullSelfer().WithSelf(m.Ctx(), func(user *libkb.User) error {
 
 				// We don't want to hold onto the full cached user during
 				// the whole `unlockDeviceKey` run below, which touches
@@ -83,7 +84,7 @@ func (e *LoginProvisionedDevice) run(ctx *Context) error {
 			if err != nil {
 				return err
 			}
-			return e.unlockDeviceKeys(ctx, partialCopy)
+			return e.unlockDeviceKeys(m, ctx, partialCopy)
 		}
 	}
 
@@ -91,45 +92,45 @@ func (e *LoginProvisionedDevice) run(ctx *Context) error {
 	loadUserArg := libkb.NewLoadUserArg(e.G()).WithPublicKeyOptional().WithForceReload()
 	var nu libkb.NormalizedUsername
 	if len(e.username) == 0 {
-		e.G().Log.Debug("| using current username")
+		m.CDebugf("| using current username")
 		config, err = e.G().Env.GetConfig().GetUserConfig()
 		loadUserArg = loadUserArg.WithSelf(true)
 	} else {
-		e.G().Log.Debug("| using new username %s", e.username)
+		m.CDebugf("| using new username %s", e.username)
 		nu = libkb.NewNormalizedUsername(e.username)
 		config, err = e.G().Env.GetConfig().GetUserConfigForUsername(nu)
 		loadUserArg = loadUserArg.WithName(e.username)
 	}
 	if err != nil {
-		e.G().Log.Debug("error getting user config: %s (%T)", err, err)
+		m.CDebugf("error getting user config: %s (%T)", err, err)
 		return errNoConfig
 	}
 	if config == nil {
-		e.G().Log.Debug("user config is nil")
+		m.CDebugf("user config is nil")
 		return errNoConfig
 	}
 	deviceID := config.GetDeviceID()
 	if deviceID.IsNil() {
-		e.G().Log.Debug("no device in user config")
+		m.CDebugf("no device in user config")
 		return errNoDevice
 	}
 
 	// Make sure the device ID is still valid.
 	me, err := libkb.LoadUser(loadUserArg)
 	if err != nil {
-		e.G().Log.Debug("error loading user profile: %#v", err)
+		m.CDebugf("error loading user profile: %#v", err)
 		return err
 	}
 	if !me.HasDeviceInCurrentInstall(deviceID) {
-		e.G().Log.Debug("current device is not valid")
+		m.CDebugf("current device is not valid")
 
 		// If our config file is showing that we have a bogus
 		// deviceID (maybe from our account before an account reset),
 		// then we'll delete it from the config file here, so later parts
 		// of provisioning aren't confused by this device ID.
-		err := e.G().Env.GetConfigWriter().NukeUser(nu)
+		err := m.G().Env.GetConfigWriter().NukeUser(nu)
 		if err != nil {
-			e.G().Log.Warning("Error clearing user config: %s", err)
+			m.CWarningf("Error clearing user config: %s", err)
 		}
 		return errNoDevice
 	}
@@ -144,42 +145,42 @@ func (e *LoginProvisionedDevice) run(ctx *Context) error {
 	var afterLogin = func(lctx libkb.LoginContext) error {
 		if err := lctx.LocalSession().SetDeviceProvisioned(e.G().Env.GetDeviceID()); err != nil {
 			// not a fatal error, session will stay in memory
-			e.G().Log.Warning("error saving session file: %s", err)
+			m.CWarningf("error saving session file: %s", err)
 		}
 		return nil
 	}
 
 	if e.SecretStoreOnly {
-		if err := e.G().LoginState().LoginWithStoredSecret(e.username, afterLogin); err != nil {
+		if err := m.G().LoginState().LoginWithStoredSecret(m, e.username, afterLogin); err != nil {
 			return err
 		}
 
 	} else {
-		if err := e.G().LoginState().LoginWithPrompt(e.username, ctx.LoginUI, ctx.SecretUI, afterLogin); err != nil {
+		if err := m.G().LoginState().LoginWithPrompt(m, e.username, ctx.LoginUI, ctx.SecretUI, afterLogin); err != nil {
 			return err
 		}
 	}
 
 	// login was successful, unlock the device keys
-	err = e.unlockDeviceKeys(ctx, me)
+	err = e.unlockDeviceKeys(m, ctx, me)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (e *LoginProvisionedDevice) unlockDeviceKeys(ctx *Context, me *libkb.User) error {
+func (e *LoginProvisionedDevice) unlockDeviceKeys(m libkb.MetaContext, ctx *Context, me *libkb.User) error {
 
 	// CORE-5876 idea that lksec will be unusable if reachability state is NO
 	// and the user changed passphrase with a different device since it won't
 	// be able to sync the new server half.
-	if e.G().ConnectivityMonitor.IsConnected(ctx.NetContext) != libkb.ConnectivityMonitorYes {
-		e.G().Log.Debug("LoginProvisionedDevice: in unlockDeviceKeys, ConnectivityMonitor says not reachable, check to make sure")
+	if m.G().ConnectivityMonitor.IsConnected(ctx.NetContext) != libkb.ConnectivityMonitorYes {
+		m.CDebugf("LoginProvisionedDevice: in unlockDeviceKeys, ConnectivityMonitor says not reachable, check to make sure")
 		if err := e.G().ConnectivityMonitor.CheckReachability(ctx.NetContext); err != nil {
-			e.G().Log.Debug("error checking reachability: %s", err)
+			m.CDebugf("error checking reachability: %s", err)
 		} else {
 			connected := e.G().ConnectivityMonitor.IsConnected(ctx.NetContext)
-			e.G().Log.Debug("after CheckReachability(), IsConnected() => %v (connected? %v)", connected, connected == libkb.ConnectivityMonitorYes)
+			m.CDebugf("after CheckReachability(), IsConnected() => %v (connected? %v)", connected, connected == libkb.ConnectivityMonitorYes)
 		}
 	}
 
@@ -187,12 +188,12 @@ func (e *LoginProvisionedDevice) unlockDeviceKeys(ctx *Context, me *libkb.User) 
 		Me:      me,
 		KeyType: libkb.DeviceSigningKeyType,
 	}
-	_, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "unlock device keys"))
+	_, err := e.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska, "unlock device keys"))
 	if err != nil {
 		return err
 	}
 	ska.KeyType = libkb.DeviceEncryptionKeyType
-	_, err = e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "unlock device keys"))
+	_, err = e.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska, "unlock device keys"))
 	if err != nil {
 		return err
 	}

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2474,7 +2474,7 @@ func TestResetThenPGPOnlyThenProvision(t *testing.T) {
 	ResetAccount(tc, u)
 
 	// Now login again so we can post a PGP key
-	err := tc.G.LoginState().LoginWithPassphrase(u.Username, u.Passphrase, false, nil)
+	err := tc.G.LoginState().LoginWithPassphrase(NewMetaContextForTest(tc), u.Username, u.Passphrase, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/paperkey.go
+++ b/go/engine/paperkey.go
@@ -60,6 +60,7 @@ func (e *PaperKey) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *PaperKey) Run(ctx *Context) error {
+	m := NewMetaContext(e, ctx)
 	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "PaperKey")
 	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "PaperKey")
 
@@ -83,7 +84,7 @@ func (e *PaperKey) Run(ctx *Context) error {
 				Index:  i,
 			})
 		if err != nil {
-			e.G().Log.Warning("prompt error: %s", err)
+			m.CWarningf("prompt error: %s", err)
 			return err
 		}
 		if revoke {
@@ -113,7 +114,7 @@ func (e *PaperKey) Run(ctx *Context) error {
 		Me:      me,
 		KeyType: libkb.DeviceSigningKeyType,
 	}
-	signingKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska1, "You must sign your new paper key"))
+	signingKey, err := m.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska1, "You must sign your new paper key"))
 	if err != nil {
 		return err
 	}
@@ -122,7 +123,7 @@ func (e *PaperKey) Run(ctx *Context) error {
 		Me:      me,
 		KeyType: libkb.DeviceEncryptionKeyType,
 	}
-	encryptionKeyGeneric, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska2, "You must encrypt for your new paper key"))
+	encryptionKeyGeneric, err := m.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska2, "You must encrypt for your new paper key"))
 	if err != nil {
 		return err
 	}
@@ -149,7 +150,7 @@ func (e *PaperKey) Run(ctx *Context) error {
 		return err
 	}
 
-	return ctx.LoginUI.DisplayPaperKeyPhrase(context.TODO(), keybase1.DisplayPaperKeyPhraseArg{Phrase: e.passphrase.String()})
+	return ctx.LoginUI.DisplayPaperKeyPhrase(m.Ctx(), keybase1.DisplayPaperKeyPhraseArg{Phrase: e.passphrase.String()})
 
 }
 

--- a/go/engine/paperkey_submit.go
+++ b/go/engine/paperkey_submit.go
@@ -46,12 +46,13 @@ func (e *PaperKeySubmit) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *PaperKeySubmit) Run(ctx *Context) error {
+	m := NewMetaContext(e, ctx)
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
 	if err != nil {
 		return err
 	}
 
-	e.pair, err = matchPaperKey(ctx, e.G(), me, e.paperPhrase)
+	e.pair, err = matchPaperKey(m, ctx, me, e.paperPhrase)
 	if err != nil {
 		return err
 	}

--- a/go/engine/paperkey_test.go
+++ b/go/engine/paperkey_test.go
@@ -90,7 +90,7 @@ func TestPaperKey(t *testing.T) {
 
 	// make sure the passphrase authentication didn't change:
 
-	_, err := tc.G.LoginState().VerifyPlaintextPassphrase(fu.Passphrase, nil)
+	_, err := tc.G.LoginState().VerifyPlaintextPassphrase(NewMetaContextForTest(tc), fu.Passphrase, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/paperprovision.go
+++ b/go/engine/paperprovision.go
@@ -178,7 +178,7 @@ func (e *PaperProvisionEngine) paper(ctx *Context, kp *keypair) error {
 	}
 
 	// need a session to continue to provision, login with paper sigKey
-	return e.G().LoginState().LoginWithKey(ctx.LoginContext, e.User, kp.sigKey, afterLogin)
+	return e.G().LoginState().LoginWithKey(NewMetaContext(e, ctx), e.User, kp.sigKey, afterLogin)
 }
 
 func (e *PaperProvisionEngine) sendNotification() {

--- a/go/engine/passphrase_change.go
+++ b/go/engine/passphrase_change.go
@@ -61,13 +61,14 @@ func (c *PassphraseChange) SubConsumers() []libkb.UIConsumer {
 
 // Run the engine
 func (c *PassphraseChange) Run(ctx *Context) (err error) {
-	c.G().Log.Debug("+ PassphraseChange.Run")
+	m := NewMetaContext(c, ctx)
+
+	defer m.CTrace("PassphraseChange#Run", func() error { return err })()
 	defer func() {
-		c.G().Log.Debug("- PassphraseChange.Run -> %s", libkb.ErrToOk(err))
 		c.G().SKBKeyringMu.Unlock()
 	}()
 	c.G().SKBKeyringMu.Lock()
-	c.G().Log.Debug("| Acquired SKBKeyringMu mutex")
+	m.CDebugf("| Acquired SKBKeyringMu mutex")
 
 	if len(c.arg.Passphrase) < libkb.MinPassphraseLength {
 		return libkb.PassphraseError{Msg: "too short"}
@@ -80,9 +81,9 @@ func (c *PassphraseChange) Run(ctx *Context) (err error) {
 	c.G().LoginState().RunSecretSyncer(c.me.GetUID())
 
 	if c.arg.Force {
-		err = c.runForcedUpdate(ctx)
+		err = c.runForcedUpdate(m, ctx)
 	} else {
-		err = c.runStandardUpdate(ctx)
+		err = c.runStandardUpdate(m, ctx)
 	}
 
 	if err == nil {
@@ -101,13 +102,13 @@ func (c *PassphraseChange) findDeviceKeys(ctx *Context) (*keypair, error) {
 // does, it prompts for a paper key phrase.  This is used to
 // regenerate paper keys, which are then matched against the
 // paper keys found in the keyfamily.
-func (c *PassphraseChange) findPaperKeys(ctx *Context) (*keypair, error) {
-	kp, err := findPaperKeys(ctx, c.G(), c.me)
+func (c *PassphraseChange) findPaperKeys(m libkb.MetaContext, ctx *Context) (*keypair, error) {
+	kp, err := findPaperKeys(m, ctx, c.me)
 	if err != nil {
-		c.G().Log.Debug("findPaperKeys error: %s", err)
+		m.CDebugf("findPaperKeys error: %s", err)
 		return nil, err
 	}
-	c.G().Log.Debug("findPaperKeys success")
+	m.CDebugf("findPaperKeys success")
 	c.usingPaper = true
 	return kp, nil
 }
@@ -116,19 +117,19 @@ func (c *PassphraseChange) findPaperKeys(ctx *Context) (*keypair, error) {
 // The first choice is device keys.  If that fails, it will look
 // for backup keys.  If backup keys are necessary, then it will
 // also log the user in with the backup keys.
-func (c *PassphraseChange) findUpdateKeys(ctx *Context) (*keypair, error) {
+func (c *PassphraseChange) findUpdateKeys(m libkb.MetaContext, ctx *Context) (*keypair, error) {
 	kp, err := c.findDeviceKeys(ctx)
 	if err == nil {
 		return kp, nil
 	}
 
-	kp, err = c.findPaperKeys(ctx)
+	kp, err = c.findPaperKeys(m, ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// log in with backup keys
-	err = c.G().LoginState().LoginWithKey(ctx.LoginContext, c.me, kp.sigKey, nil)
+	err = c.G().LoginState().LoginWithKey(NewMetaContext(c, ctx), c.me, kp.sigKey, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -136,22 +137,23 @@ func (c *PassphraseChange) findUpdateKeys(ctx *Context) (*keypair, error) {
 	return kp, nil
 }
 
-func (c *PassphraseChange) forceUpdatePassphrase(ctx *Context, sigKey libkb.GenericKey, ppGen libkb.PassphraseGeneration, oldClientHalf libkb.LKSecClientHalf) error {
+func (c *PassphraseChange) forceUpdatePassphrase(m libkb.MetaContext, ctx *Context, sigKey libkb.GenericKey, ppGen libkb.PassphraseGeneration, oldClientHalf libkb.LKSecClientHalf) error {
 	// Don't update server-synced pgp keys when recovering.
 	// This will render any server-synced pgp keys unrecoverable from the server.
 	// TODO would it responsible to ask the server to delete them?
-	pgpKeys, nPgpKeysLost, err := c.findAndDecryptPrivatePGPKeysLossy(ctx)
+	pgpKeys, nPgpKeysLost, err := c.findAndDecryptPrivatePGPKeysLossy(m, ctx)
 	if err != nil {
 		return err
 	}
 
 	if nPgpKeysLost > 0 {
-		c.G().Log.Debug("PassphraseChange.runForcedUpdate: Losing %v synced keys", nPgpKeysLost)
+		m.CDebugf("PassphraseChange.runForcedUpdate: Losing %v synced keys", nPgpKeysLost)
 	}
 
 	var acctErr error
 	c.G().LoginState().Account(func(a *libkb.Account) {
 		// Ready the update argument; almost done, but we need some more stuff.
+		m = m.WithLoginContext(a)
 		payload, err := c.commonArgs(a, oldClientHalf, pgpKeys, ppGen)
 		if err != nil {
 			acctErr = err
@@ -215,13 +217,10 @@ func (c *PassphraseChange) forceUpdatePassphrase(ctx *Context, sigKey libkb.Gene
 // 2. If necessary, log in with backup keys
 // 3. Get lks client half from server
 // 4. Post an update passphrase proof
-func (c *PassphraseChange) runForcedUpdate(ctx *Context) (err error) {
-	c.G().Log.Debug("+ PassphraseChange.runForcedUpdate")
-	defer func() {
-		c.G().Log.Debug("- PassphraseChange.runForcedUpdate -> %s", libkb.ErrToOk(err))
-	}()
+func (c *PassphraseChange) runForcedUpdate(m libkb.MetaContext, ctx *Context) (err error) {
+	defer m.CTrace("PassphraseChange#runForcedUpdate", func() error { return err })()
 
-	kp, err := c.findUpdateKeys(ctx)
+	kp, err := c.findUpdateKeys(m, ctx)
 	if err != nil {
 		return
 	}
@@ -233,33 +232,31 @@ func (c *PassphraseChange) runForcedUpdate(ctx *Context) (err error) {
 		return
 	}
 
-	return c.forceUpdatePassphrase(ctx, kp.sigKey, ppGen, oldClientHalf)
+	return c.forceUpdatePassphrase(m, ctx, kp.sigKey, ppGen, oldClientHalf)
 }
 
 // runStandardUpdate is for when the user knows the current password.
-func (c *PassphraseChange) runStandardUpdate(ctx *Context) (err error) {
+func (c *PassphraseChange) runStandardUpdate(m libkb.MetaContext, ctx *Context) (err error) {
 
-	c.G().Log.Debug("+ PassphraseChange.runStandardUpdate")
-	defer func() {
-		c.G().Log.Debug("- PassphraseChange.runStandardUpdate -> %s", libkb.ErrToOk(err))
-	}()
+	defer m.CTrace("PassphraseChange.runStandardUpdate", func() error { return err })()
 
 	if len(c.arg.OldPassphrase) == 0 {
-		err = c.getVerifiedPassphraseHash(ctx)
+		err = c.getVerifiedPassphraseHash(m, ctx)
 	} else {
-		err = c.verifySuppliedPassphrase(ctx)
+		err = c.verifySuppliedPassphrase(m, ctx)
 	}
 	if err != nil {
 		return err
 	}
 
-	pgpKeys, err := c.findAndDecryptPrivatePGPKeys(ctx)
+	pgpKeys, err := c.findAndDecryptPrivatePGPKeys(m, ctx)
 	if err != nil {
 		return err
 	}
 
 	var acctErr error
 	c.G().LoginState().Account(func(a *libkb.Account) {
+		m = m.WithLoginContext(a)
 		gen := a.PassphraseStreamCache().PassphraseStream().Generation()
 		oldClientHalf := a.PassphraseStreamCache().PassphraseStream().LksClientHalf()
 
@@ -269,7 +266,7 @@ func (c *PassphraseChange) runStandardUpdate(ctx *Context) (err error) {
 			return
 		}
 
-		lp, err := libkb.ComputeLoginPackage(a, "")
+		lp, err := libkb.ComputeLoginPackage(m, "")
 		if err != nil {
 			acctErr = err
 			return
@@ -371,24 +368,24 @@ func (c *PassphraseChange) loadMe() (err error) {
 	return
 }
 
-func (c *PassphraseChange) getVerifiedPassphraseHash(ctx *Context) (err error) {
-	c.ppStream, err = c.G().LoginState().GetPassphraseStream(ctx.SecretUI)
+func (c *PassphraseChange) getVerifiedPassphraseHash(m libkb.MetaContext, ctx *Context) (err error) {
+	c.ppStream, err = c.G().LoginState().GetPassphraseStream(m, ctx.SecretUI)
 	return
 }
 
-func (c *PassphraseChange) verifySuppliedPassphrase(ctx *Context) (err error) {
-	c.ppStream, err = c.G().LoginState().VerifyPlaintextPassphrase(c.arg.OldPassphrase, nil)
+func (c *PassphraseChange) verifySuppliedPassphrase(m libkb.MetaContext, ctx *Context) (err error) {
+	c.ppStream, err = c.G().LoginState().VerifyPlaintextPassphrase(m, c.arg.OldPassphrase, nil)
 	return
 }
 
 // findAndDecryptPrivatePGPKeys gets the user's private pgp keys if any exist and decrypts them.
-func (c *PassphraseChange) findAndDecryptPrivatePGPKeys(ctx *Context) ([]libkb.GenericKey, error) {
+func (c *PassphraseChange) findAndDecryptPrivatePGPKeys(m libkb.MetaContext, ctx *Context) ([]libkb.GenericKey, error) {
 
 	var keyList []libkb.GenericKey
 
 	// Using a paper key makes TripleSec-synced keys unrecoverable
 	if c.usingPaper {
-		c.G().Log.Debug("using a paper key, thus TripleSec-synced keys are unrecoverable")
+		m.CDebugf("using a paper key, thus TripleSec-synced keys are unrecoverable")
 		return keyList, nil
 	}
 
@@ -402,7 +399,7 @@ func (c *PassphraseChange) findAndDecryptPrivatePGPKeys(ctx *Context) ([]libkb.G
 
 	for _, block := range blocks {
 		parg := ctx.SecretKeyPromptArg(libkb.SecretKeyArg{}, "passphrase change")
-		key, err := block.PromptAndUnlock(parg, secretRetriever, c.me)
+		key, err := block.PromptAndUnlock(m, parg, secretRetriever, c.me)
 		if err != nil {
 			return nil, err
 		}
@@ -415,13 +412,13 @@ func (c *PassphraseChange) findAndDecryptPrivatePGPKeys(ctx *Context) ([]libkb.G
 // findAndDecryptPrivatePGPKeysLossy gets the user's private pgp keys if any exist and attempts
 // to decrypt them without prompting the user. If any fail to decrypt, they are silently not returned.
 // The second return value is the number of keys which were not decrypted.
-func (c *PassphraseChange) findAndDecryptPrivatePGPKeysLossy(ctx *Context) ([]libkb.GenericKey, int, error) {
+func (c *PassphraseChange) findAndDecryptPrivatePGPKeysLossy(m libkb.MetaContext, ctx *Context) ([]libkb.GenericKey, int, error) {
 
 	var keyList []libkb.GenericKey
 	nLost := 0
 
 	// Only use the synced secret keys:
-	blocks, err := c.me.AllSyncedSecretKeys(ctx.LoginContext)
+	blocks, err := c.me.AllSyncedSecretKeys(m.LoginContext())
 	if err != nil {
 		return nil, 0, err
 	}
@@ -429,7 +426,7 @@ func (c *PassphraseChange) findAndDecryptPrivatePGPKeysLossy(ctx *Context) ([]li
 	secretRetriever := libkb.NewSecretStore(c.G(), c.me.GetNormalizedName())
 
 	for _, block := range blocks {
-		key, err := block.UnlockNoPrompt(ctx.LoginContext, secretRetriever)
+		key, err := block.UnlockNoPrompt(m, secretRetriever)
 		if err == nil {
 			keyList = append(keyList, key)
 		} else {
@@ -437,7 +434,7 @@ func (c *PassphraseChange) findAndDecryptPrivatePGPKeysLossy(ctx *Context) ([]li
 				return nil, 0, err
 			}
 			nLost++
-			c.G().Log.Debug("findAndDecryptPrivatePGPKeysLossy: ignoring failure to decrypt key without prompt")
+			m.CDebugf("findAndDecryptPrivatePGPKeysLossy: ignoring failure to decrypt key without prompt")
 		}
 	}
 

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -66,6 +66,7 @@ func (e *PGPEncrypt) SubConsumers() []libkb.UIConsumer {
 func (e *PGPEncrypt) Run(ctx *Context) error {
 	// verify valid options based on logged in state:
 	ok, uid := IsLoggedIn(e, ctx)
+	m := NewMetaContext(e, ctx)
 
 	if !ok {
 		// not logged in.  this is fine, unless they requested signing the message.
@@ -78,7 +79,7 @@ func (e *PGPEncrypt) Run(ctx *Context) error {
 			return libkb.LoginRequiredError{Context: "you must be logged in to encrypt for yourself (or use --no-self flag)"}
 		}
 	} else {
-		me, err := libkb.LoadMeByUID(ctx.GetNetContext(), e.G(), uid)
+		me, err := libkb.LoadMeByMetaContextAndUID(m, uid)
 		if err != nil {
 			return err
 		}
@@ -93,7 +94,7 @@ func (e *PGPEncrypt) Run(ctx *Context) error {
 			KeyType:  libkb.PGPKeyType,
 			KeyQuery: e.arg.KeyQuery,
 		}
-		key, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "command-line signature"))
+		key, err := e.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska, "command-line signature"))
 		if err != nil {
 			return err
 		}

--- a/go/engine/pgp_export_key.go
+++ b/go/engine/pgp_export_key.go
@@ -128,14 +128,14 @@ func (e *PGPKeyExportEngine) exportPublic() (err error) {
 	return
 }
 
-func (e *PGPKeyExportEngine) exportSecret(ctx *Context) error {
+func (e *PGPKeyExportEngine) exportSecret(m libkb.MetaContext, ctx *Context) error {
 	ska := libkb.SecretKeyArg{
 		Me:         e.me,
 		KeyType:    libkb.PGPKeyType,
 		KeyQuery:   e.arg.Query,
 		ExactMatch: e.arg.ExactMatch,
 	}
-	key, skb, err := e.G().Keyrings.GetSecretKeyAndSKBWithPrompt(ctx.SecretKeyPromptArg(ska, "key export"))
+	key, skb, err := m.G().Keyrings.GetSecretKeyAndSKBWithPrompt(m, ctx.SecretKeyPromptArg(ska, "key export"))
 	if err != nil {
 		if _, ok := err.(libkb.NoSecretKeyError); ok {
 			// if no secret key found, don't return an error, just let
@@ -165,7 +165,7 @@ func (e *PGPKeyExportEngine) exportSecret(ctx *Context) error {
 	if e.encrypted {
 		// Make encrypted PGP key bundle using provided passphrase.
 		// Key will be reimported from bytes so we don't mutate SKB.
-		raw, err = e.encryptKey(ctx, raw)
+		raw, err = e.encryptKey(m, ctx, raw)
 		if err != nil {
 			return err
 		}
@@ -181,14 +181,14 @@ func (e *PGPKeyExportEngine) exportSecret(ctx *Context) error {
 	return nil
 }
 
-func GetPGPExportPassphrase(g *libkb.GlobalContext, ui libkb.SecretUI, desc string) (keybase1.GetPassphraseRes, error) {
-	pRes, err := libkb.GetSecret(g, ui, "PGP key passphrase", desc, "", false)
+func GetPGPExportPassphrase(m libkb.MetaContext, ui libkb.SecretUI, desc string) (keybase1.GetPassphraseRes, error) {
+	pRes, err := libkb.GetSecret(m, ui, "PGP key passphrase", desc, "", false)
 	if err != nil {
 		return keybase1.GetPassphraseRes{}, err
 	}
 
 	desc = "Please reenter your passphrase for confirmation"
-	pRes2, err := libkb.GetSecret(g, ui, "PGP key passphrase", desc, "", false)
+	pRes2, err := libkb.GetSecret(m, ui, "PGP key passphrase", desc, "", false)
 	if pRes.Passphrase != pRes2.Passphrase {
 		return keybase1.GetPassphraseRes{}, errors.New("Passphrase mismatch")
 	}
@@ -196,7 +196,7 @@ func GetPGPExportPassphrase(g *libkb.GlobalContext, ui libkb.SecretUI, desc stri
 	return pRes, nil
 }
 
-func (e *PGPKeyExportEngine) encryptKey(ctx *Context, raw []byte) ([]byte, error) {
+func (e *PGPKeyExportEngine) encryptKey(m libkb.MetaContext, ctx *Context, raw []byte) ([]byte, error) {
 	entity, _, err := libkb.ReadOneKeyFromBytes(raw)
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ func (e *PGPKeyExportEngine) encryptKey(ctx *Context, raw []byte) ([]byte, error
 	}
 
 	desc := "Enter passphrase to protect your PGP key. Secure passphrases have at least 8 characters."
-	pRes, err := GetPGPExportPassphrase(e.G(), ctx.SecretUI, desc)
+	pRes, err := GetPGPExportPassphrase(m, ctx.SecretUI, desc)
 	if err != nil {
 		return nil, err
 	}
@@ -231,10 +231,8 @@ func (e *PGPKeyExportEngine) loadMe() (err error) {
 
 func (e *PGPKeyExportEngine) Run(ctx *Context) (err error) {
 
-	e.G().Log.Debug("+ PGPKeyExportEngine::Run")
-	defer func() {
-		e.G().Log.Debug("- PGPKeyExportEngine::Run -> %s", libkb.ErrToOk(err))
-	}()
+	m := NewMetaContext(e, ctx)
+	defer m.CTrace("PGPKeyExportEngine::Run", func() error { return err })()
 
 	if e.qtype == unset {
 		return fmt.Errorf("PGPKeyExportEngine: query type not set")
@@ -245,7 +243,7 @@ func (e *PGPKeyExportEngine) Run(ctx *Context) (err error) {
 	}
 
 	if e.arg.Secret {
-		err = e.exportSecret(ctx)
+		err = e.exportSecret(m, ctx)
 	} else {
 		err = e.exportPublic()
 	}

--- a/go/engine/pgp_sign.go
+++ b/go/engine/pgp_sign.go
@@ -59,6 +59,8 @@ func (p *PGPSignEngine) Run(ctx *Context) (err error) {
 	var dumpTo io.WriteCloser
 	var written int64
 
+	m := NewMetaContext(p, ctx)
+
 	defer func() {
 		if dumpTo != nil {
 			if e := dumpTo.Close(); e != nil {
@@ -83,7 +85,7 @@ func (p *PGPSignEngine) Run(ctx *Context) (err error) {
 		KeyType:  libkb.PGPKeyType,
 		KeyQuery: p.arg.Opts.KeyQuery,
 	}
-	key, err = p.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "command-line signature"))
+	key, err = p.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska, "command-line signature"))
 	if err != nil {
 		return
 	} else if pgp, ok = key.(*libkb.PGPKeyBundle); !ok {

--- a/go/engine/pgp_update.go
+++ b/go/engine/pgp_update.go
@@ -51,6 +51,7 @@ func (e *PGPUpdateEngine) SubConsumers() []libkb.UIConsumer {
 }
 
 func (e *PGPUpdateEngine) Run(ctx *Context) error {
+	m := NewMetaContext(e, ctx)
 	if e.all && len(e.selectedFingerprints) > 0 {
 		return fmt.Errorf("Cannot use explicit fingerprints with --all.")
 	}
@@ -77,7 +78,7 @@ func (e *PGPUpdateEngine) Run(ctx *Context) error {
 		Contextified:   libkb.NewContextified(e.G()),
 	}
 
-	err = del.LoadSigningKey(ctx.LoginContext, ctx.SecretUI)
+	err = del.LoadSigningKey(m, ctx.SecretUI)
 	if err != nil {
 		return err
 	}

--- a/go/engine/puk_test.go
+++ b/go/engine/puk_test.go
@@ -29,30 +29,32 @@ func TestPerUserKeySignupAndPullKeys(t *testing.T) {
 
 	kr, err := libkb.NewPerUserKeyring(tc.G, fu.UID())
 	require.NoError(t, err)
-	err = kr.Sync(context.Background())
+	ctx := context.Background()
+	mctx := libkb.NewMetaContext(ctx, tc.G)
+	err = kr.Sync(mctx)
 	require.NoError(t, err)
 	gen := keybase1.PerUserKeyGeneration(1)
 	require.Equal(t, kr.CurrentGeneration(), gen)
 
-	sigKey, err := kr.GetLatestSigningKey(context.TODO())
+	sigKey, err := kr.GetLatestSigningKey(mctx)
 	require.NoError(t, err)
 	require.NotNil(t, sigKey)
 	require.NotNil(t, sigKey.Private)
 
-	encKey, err := kr.GetEncryptionKeyByGeneration(context.TODO(), keybase1.PerUserKeyGeneration(1))
+	encKey, err := kr.GetEncryptionKeyByGeneration(mctx, keybase1.PerUserKeyGeneration(1))
 	require.NoError(t, err)
 	require.NotNil(t, encKey)
 	require.NotNil(t, encKey.Private)
 
-	encKey, err = kr.GetEncryptionKeyBySeqno(context.TODO(), keybase1.Seqno(3))
+	encKey, err = kr.GetEncryptionKeyBySeqno(mctx, keybase1.Seqno(3))
 	require.NoError(t, err)
 	require.NotNil(t, encKey)
 	require.NotNil(t, encKey.Private)
 
-	_, err = kr.GetEncryptionKeyByGeneration(context.TODO(), keybase1.PerUserKeyGeneration(2))
+	_, err = kr.GetEncryptionKeyByGeneration(mctx, keybase1.PerUserKeyGeneration(2))
 	require.Error(t, err)
 
-	err = kr.Sync(context.Background())
+	err = kr.Sync(mctx)
 	require.Nil(t, err)
 	require.Equal(t, kr.CurrentGeneration(), gen)
 }
@@ -70,31 +72,33 @@ func TestPerUserKeySignupPlusPaper(t *testing.T) {
 
 	kr, err := libkb.NewPerUserKeyring(tc.G, fu.UID())
 	require.NoError(t, err)
-	err = kr.Sync(context.Background())
+	ctx := context.Background()
+	mctx := libkb.NewMetaContext(ctx, tc.G)
+	err = kr.Sync(mctx)
 	require.NoError(t, err)
 
 	gen := keybase1.PerUserKeyGeneration(1)
 	require.Equal(t, kr.CurrentGeneration(), gen)
 
-	sigKey, err := kr.GetLatestSigningKey(context.TODO())
+	sigKey, err := kr.GetLatestSigningKey(mctx)
 	require.NoError(t, err)
 	require.NotNil(t, sigKey)
 	require.NotNil(t, sigKey.Private)
 
-	encKey, err := kr.GetEncryptionKeyByGeneration(context.TODO(), keybase1.PerUserKeyGeneration(1))
+	encKey, err := kr.GetEncryptionKeyByGeneration(mctx, keybase1.PerUserKeyGeneration(1))
 	require.NoError(t, err)
 	require.NotNil(t, encKey)
 	require.NotNil(t, encKey.Private)
 
-	encKey, err = kr.GetEncryptionKeyBySeqno(context.TODO(), keybase1.Seqno(3))
+	encKey, err = kr.GetEncryptionKeyBySeqno(mctx, keybase1.Seqno(3))
 	require.NoError(t, err)
 	require.NotNil(t, encKey)
 	require.NotNil(t, encKey.Private)
 
-	_, err = kr.GetEncryptionKeyByGeneration(context.TODO(), keybase1.PerUserKeyGeneration(2))
+	_, err = kr.GetEncryptionKeyByGeneration(mctx, keybase1.PerUserKeyGeneration(2))
 	require.Error(t, err)
 
-	err = kr.Sync(context.Background())
+	err = kr.Sync(mctx)
 	require.Nil(t, err)
 	require.Equal(t, kr.CurrentGeneration(), gen)
 }

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -116,7 +116,8 @@ func (e *RevokeEngine) explicitOrImplicitDeviceID(me *libkb.User) keybase1.Devic
 }
 
 func (e *RevokeEngine) Run(ctx *Context) error {
-	e.G().Log.CDebugf(ctx.NetContext, "RevokeEngine#Run (mode:%v)", e.mode)
+	m := NewMetaContext(e, ctx)
+	m.CDebugf("RevokeEngine#Run (mode:%v)", e.mode)
 
 	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "RevokeEngine")
 	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "RevokeEngine")
@@ -165,7 +166,7 @@ func (e *RevokeEngine) Run(ctx *Context) error {
 		ctx.LogUI.Info("  %s", kid)
 	}
 
-	sigKey, encKey, err := e.getDeviceSecretKeys(ctx, me)
+	sigKey, encKey, err := e.getDeviceSecretKeys(m, ctx, me)
 	if err != nil {
 		return err
 	}
@@ -188,7 +189,7 @@ func (e *RevokeEngine) Run(ctx *Context) error {
 	if err != nil {
 		return err
 	}
-	err = pukring.Sync(ctx.NetContext)
+	err = pukring.Sync(m)
 	if err != nil {
 		return err
 	}
@@ -204,7 +205,7 @@ func (e *RevokeEngine) Run(ctx *Context) error {
 		newPukSeed = &newPukSeedInner
 
 		// Create a prev secretbox containing the previous generation seed
-		pukPrevInner, err := pukring.PreparePrev(ctx.NetContext, *newPukSeed, newPukGeneration)
+		pukPrevInner, err := pukring.PreparePrev(m, *newPukSeed, newPukGeneration)
 		if err != nil {
 			return err
 		}
@@ -217,7 +218,7 @@ func (e *RevokeEngine) Run(ctx *Context) error {
 		}
 
 		// Create boxes of the new per-user-key
-		pukBoxesInner, err := pukring.PrepareBoxesForDevices(ctx.NetContext,
+		pukBoxesInner, err := pukring.PrepareBoxesForDevices(m,
 			*newPukSeed, newPukGeneration, pukReceivers, encKey)
 		if err != nil {
 			return err
@@ -298,7 +299,7 @@ func (e *RevokeEngine) Run(ctx *Context) error {
 	}
 
 	if addingNewPUK {
-		err = pukring.AddKey(ctx.NetContext, newPukGeneration, newPukSeqno, *newPukSeed)
+		err = pukring.AddKey(m, newPukGeneration, newPukSeqno, *newPukSeed)
 		if err != nil {
 			return err
 		}
@@ -319,12 +320,12 @@ func (e *RevokeEngine) Run(ctx *Context) error {
 
 // Get the full keys for this device.
 // Returns (sigKey, encKey, err)
-func (e *RevokeEngine) getDeviceSecretKeys(ctx *Context, me *libkb.User) (libkb.GenericKey, libkb.GenericKey, error) {
+func (e *RevokeEngine) getDeviceSecretKeys(m libkb.MetaContext, ctx *Context, me *libkb.User) (libkb.GenericKey, libkb.GenericKey, error) {
 	skaSig := libkb.SecretKeyArg{
 		Me:      me,
 		KeyType: libkb.DeviceSigningKeyType,
 	}
-	sigKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(skaSig, "to revoke another key"))
+	sigKey, err := m.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(skaSig, "to revoke another key"))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -336,7 +337,7 @@ func (e *RevokeEngine) getDeviceSecretKeys(ctx *Context, me *libkb.User) (libkb.
 		Me:      me,
 		KeyType: libkb.DeviceEncryptionKeyType,
 	}
-	encKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(skaEnc, "to revoke another key"))
+	encKey, err := m.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(skaEnc, "to revoke another key"))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/engine/revoke_sigs.go
+++ b/go/engine/revoke_sigs.go
@@ -63,6 +63,8 @@ func (e *RevokeSigsEngine) Run(ctx *Context) error {
 	e.G().LocalSigchainGuard().Set(ctx.GetNetContext(), "RevokeSigsEngine")
 	defer e.G().LocalSigchainGuard().Clear(ctx.GetNetContext(), "RevokeSigsEngine")
 
+	m := NewMetaContext(e, ctx)
+
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
 	if err != nil {
 		return err
@@ -82,7 +84,7 @@ func (e *RevokeSigsEngine) Run(ctx *Context) error {
 		Me:      me,
 		KeyType: libkb.DeviceSigningKeyType,
 	}
-	sigKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "to revoke a signature"))
+	sigKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska, "to revoke a signature"))
 	if err != nil {
 		return err
 	}

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -200,7 +200,7 @@ func checkPerUserKeyring(t *testing.T, g *libkb.GlobalContext, expectedCurrentGe
 	g.ClearPerUserKeyring()
 	pukring, err = g.GetPerUserKeyring()
 	require.NoError(t, err)
-	require.NoError(t, pukring.Sync(context.TODO()))
+	require.NoError(t, pukring.Sync(libkb.NewMetaContextTODO(g)))
 	require.Equal(t, keybase1.PerUserKeyGeneration(expectedCurrentGeneration), pukring.CurrentGeneration())
 }
 

--- a/go/engine/saltpack_decrypt.go
+++ b/go/engine/saltpack_decrypt.go
@@ -116,7 +116,8 @@ func (e *SaltpackDecrypt) makeMessageInfo(me *libkb.User, mki *saltpack.MessageK
 
 // Run starts the engine.
 func (e *SaltpackDecrypt) Run(ctx *Context) (err error) {
-	defer e.G().Trace("SaltpackDecrypt::Run", func() error { return err })()
+	m := NewMetaContext(e, ctx)
+	defer m.CTrace("SaltpackDecrypt::Run", func() error { return err })()
 
 	// We don't load this in the --paperkey case.
 	var me *libkb.User
@@ -125,7 +126,7 @@ func (e *SaltpackDecrypt) Run(ctx *Context) (err error) {
 	if e.arg.Opts.UsePaperKey {
 		// Prompt the user for a paper key. This doesn't require you to be
 		// logged in.
-		keypair, _, err := getPaperKey(e.G(), ctx, nil)
+		keypair, _, err := getPaperKey(m, ctx, nil)
 		if err != nil {
 			return err
 		}
@@ -142,8 +143,8 @@ func (e *SaltpackDecrypt) Run(ctx *Context) (err error) {
 			Me:      me,
 			KeyType: libkb.DeviceEncryptionKeyType,
 		}
-		e.G().Log.Debug("| GetSecretKeyWithPrompt")
-		key, err = e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "decrypting a message/file"))
+		m.CDebugf("| GetSecretKeyWithPrompt")
+		key, err = e.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska, "decrypting a message/file"))
 		if err != nil {
 			return err
 		}

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -106,10 +106,8 @@ func (e *SaltpackEncrypt) loadMe(ctx *Context) error {
 
 // Run starts the engine.
 func (e *SaltpackEncrypt) Run(ctx *Context) (err error) {
-	e.G().Log.Debug("+ SaltpackEncrypt::Run")
-	defer func() {
-		e.G().Log.Debug("- SaltpackEncrypt::Run -> %v", err)
-	}()
+	m := NewMetaContext(e, ctx)
+	defer m.CTrace("SaltpackEncrypt::Run", func() error { return err })()
 
 	var receivers []libkb.NaclDHKeyPublic
 
@@ -155,7 +153,7 @@ func (e *SaltpackEncrypt) Run(ctx *Context) (err error) {
 			Me:      e.me,
 			KeyType: libkb.DeviceEncryptionKeyType,
 		}
-		dhKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(secretKeyArgDH, "encrypting a message/file"))
+		dhKey, err := m.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(secretKeyArgDH, "encrypting a message/file"))
 		if err != nil {
 			return err
 		}
@@ -172,7 +170,7 @@ func (e *SaltpackEncrypt) Run(ctx *Context) (err error) {
 			Me:      e.me,
 			KeyType: libkb.DeviceSigningKeyType,
 		}
-		signingKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(secretKeyArgSigning, "signing a message/file"))
+		signingKey, err := m.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(secretKeyArgSigning, "signing a message/file"))
 		if err != nil {
 			return err
 		}

--- a/go/engine/saltpack_sign.go
+++ b/go/engine/saltpack_sign.go
@@ -57,7 +57,8 @@ func (e *SaltpackSign) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *SaltpackSign) Run(ctx *Context) error {
-	if err := e.loadKey(ctx); err != nil {
+	m := NewMetaContext(e, ctx)
+	if err := e.loadKey(m, ctx); err != nil {
 		return err
 	}
 
@@ -73,7 +74,7 @@ func (e *SaltpackSign) Run(ctx *Context) error {
 	return libkb.SaltpackSign(e.G(), e.arg.Source, e.arg.Sink, e.key, e.arg.Opts.Binary, saltpackVersion)
 }
 
-func (e *SaltpackSign) loadKey(ctx *Context) error {
+func (e *SaltpackSign) loadKey(m libkb.MetaContext, ctx *Context) error {
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
 	if err != nil {
 		return err
@@ -82,7 +83,7 @@ func (e *SaltpackSign) loadKey(ctx *Context) error {
 		Me:      me,
 		KeyType: libkb.DeviceSigningKeyType,
 	}
-	key, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "signing a message/file"))
+	key, err := m.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska, "signing a message/file"))
 	if err != nil {
 		return err
 	}

--- a/go/engine/scankeys.go
+++ b/go/engine/scankeys.go
@@ -296,10 +296,11 @@ func (s *ScanKeys) publicByID(id uint64) openpgp.EntityList {
 
 func (s *ScanKeys) unlockByID(id uint64) openpgp.EntityList {
 	var list openpgp.EntityList
+	m := libkb.NewMetaContextTODO(s.G())
 	for _, skb := range s.skbs {
 		pubkey, err := skb.GetPubKey()
 		if err != nil {
-			s.G().Log.Warning("error getting pub key from skb: %s", err)
+			m.CWarningf("error getting pub key from skb: %s", err)
 			continue
 		}
 		bundle, ok := pubkey.(*libkb.PGPKeyBundle)
@@ -316,14 +317,14 @@ func (s *ScanKeys) unlockByID(id uint64) openpgp.EntityList {
 			Reason:   unlockReason,
 			SecretUI: s.secui,
 		}
-		unlocked, err := skb.PromptAndUnlock(parg, nil, s.me)
+		unlocked, err := skb.PromptAndUnlock(m, parg, nil, s.me)
 		if err != nil {
-			s.G().Log.Warning("error unlocking key: %s", err)
+			m.CWarningf("error unlocking key: %s", err)
 			continue
 		}
 		unlockedBundle, ok := unlocked.(*libkb.PGPKeyBundle)
 		if !ok {
-			s.G().Log.Warning("could not convert unlocked key to PGPKeyBundle")
+			m.CWarningf("could not convert unlocked key to PGPKeyBundle")
 			continue
 		}
 		list = append(list, unlockedBundle.Entity)
@@ -332,20 +333,21 @@ func (s *ScanKeys) unlockByID(id uint64) openpgp.EntityList {
 }
 
 func (s *ScanKeys) unlockAll() openpgp.EntityList {
+	m := libkb.NewMetaContextTODO(s.G())
 	var list openpgp.EntityList
 	for _, skb := range s.skbs {
 		parg := libkb.SecretKeyPromptArg{
 			Reason:   unlockReason,
 			SecretUI: s.secui,
 		}
-		unlocked, err := skb.PromptAndUnlock(parg, nil, s.me)
+		unlocked, err := skb.PromptAndUnlock(m, parg, nil, s.me)
 		if err != nil {
-			s.G().Log.Warning("error unlocking key: %s", err)
+			m.CWarningf("error unlocking key: %s", err)
 			continue
 		}
 		unlockedBundle, ok := unlocked.(*libkb.PGPKeyBundle)
 		if !ok {
-			s.G().Log.Warning("could not convert unlocked key to PGPKeyBundle")
+			m.CWarningf("could not convert unlocked key to PGPKeyBundle")
 			continue
 		}
 		list = append(list, unlockedBundle.Entity)

--- a/go/engine/secretkeys.go
+++ b/go/engine/secretkeys.go
@@ -43,7 +43,8 @@ func (e *SecretKeysEngine) SubConsumers() []libkb.UIConsumer {
 }
 
 func (e *SecretKeysEngine) Run(ctx *Context) (err error) {
-	e.G().Log.Debug("+ SecretKeysEngine Run")
+	m := NewMetaContext(e, ctx)
+	defer m.CTrace("SecretKeysEngine#Run", func() error { return err })()
 
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
 	if err != nil {
@@ -62,7 +63,7 @@ func (e *SecretKeysEngine) Run(ctx *Context) (err error) {
 		Me:      me,
 		KeyType: libkb.DeviceSigningKeyType,
 	}
-	sigKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "to revoke another key"))
+	sigKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska, "to revoke another key"))
 	if err != nil {
 		return err
 	}
@@ -73,10 +74,10 @@ func (e *SecretKeysEngine) Run(ctx *Context) (err error) {
 	if !ok {
 		return fmt.Errorf("Expected a NaCl signing key.")
 	}
-	e.G().Log.Debug("| got signing key")
+	m.CDebugf("| got signing key")
 
 	ska.KeyType = libkb.DeviceEncryptionKeyType
-	encKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "to revoke another key"))
+	encKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(m, ctx.SecretKeyPromptArg(ska, "to revoke another key"))
 	if err != nil {
 		return err
 	}
@@ -87,7 +88,7 @@ func (e *SecretKeysEngine) Run(ctx *Context) (err error) {
 	if !ok {
 		return fmt.Errorf("Expected a NaCl encryption key.")
 	}
-	e.G().Log.Debug("| got encryption key")
+	m.CDebugf("| got encryption key")
 
 	e.result.Signing = [64]byte(*sigNaclKey.Private)
 	e.result.Encryption = [32]byte(*encNaclKey.Private)

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -78,7 +78,7 @@ func subTestSignupEngine(t *testing.T, upgradePerUserKey bool) {
 	mockGetPassphrase := &GetPassphraseMock{
 		Passphrase: fu.Passphrase,
 	}
-	if err = tc.G.LoginState().LoginWithPrompt(fu.Username, nil, mockGetPassphrase, nil); err != nil {
+	if err = tc.G.LoginState().LoginWithPrompt(NewMetaContextForTest(tc), fu.Username, nil, mockGetPassphrase, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -161,18 +161,19 @@ func TestLocalKeySecurity(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	m := NewMetaContextForTest(tc)
 	lks := libkb.NewLKSec(s.ppStream, s.uid, tc.G)
-	if err := lks.Load(nil); err != nil {
+	if err := lks.Load(m); err != nil {
 		t.Fatal(err)
 	}
 
 	text := "the people on the bus go up and down, up and down, up and down"
-	enc, err := lks.Encrypt([]byte(text))
+	enc, err := lks.Encrypt(m, []byte(text))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	dec, _, _, err := lks.Decrypt(nil, enc)
+	dec, _, _, err := lks.Decrypt(m, enc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +203,8 @@ func TestLocalKeySecurityStoreSecret(t *testing.T) {
 	arg.StoreSecret = true
 	s := SignupFakeUserWithArg(tc, fu, arg)
 
-	secret, err := s.lks.GetSecret(nil)
+	m := NewMetaContextForTest(tc)
+	secret, err := s.lks.GetSecret(m)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/unlock.go
+++ b/go/engine/unlock.go
@@ -53,10 +53,11 @@ func (e *Unlock) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *Unlock) Run(ctx *Context) error {
+	mctx := NewMetaContext(e, ctx)
 	if e.passphrase != "" {
-		_, err := e.G().LoginState().GetPassphraseStreamWithPassphrase(e.passphrase)
+		_, err := e.G().LoginState().GetPassphraseStreamWithPassphrase(mctx, e.passphrase)
 		return err
 	}
-	_, err := e.G().LoginState().GetPassphraseStream(ctx.SecretUI)
+	_, err := e.G().LoginState().GetPassphraseStream(mctx, ctx.SecretUI)
 	return err
 }

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -33,6 +33,10 @@ func NewEKLib(g *libkb.GlobalContext) *EKLib {
 	}
 }
 
+func (e *EKLib) NewMetaContext(ctx context.Context) libkb.MetaContext {
+	return libkb.NewMetaContext(ctx, e.G())
+}
+
 func (e *EKLib) checkLoginAndPUK(ctx context.Context) error {
 	if loggedIn, err := e.G().LoginState().LoggedInLoad(); err != nil {
 		return err
@@ -44,7 +48,7 @@ func (e *EKLib) checkLoginAndPUK(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := pukring.Sync(ctx); err != nil {
+	if err := pukring.Sync(e.NewMetaContext(ctx)); err != nil {
 		return err
 	}
 	if !pukring.HasAnyKeys() {

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -134,7 +134,7 @@ func publishNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot li
 	if err != nil {
 		return metadata, err
 	}
-	pukSigning, err := pukKeyring.GetLatestSigningKey(ctx)
+	pukSigning, err := pukKeyring.GetLatestSigningKey(libkb.NewMetaContext(ctx, g))
 	if err != nil {
 		return metadata, err
 	}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -30,6 +30,10 @@ type ChatTestContext struct {
 	ChatG *globals.ChatContext
 }
 
+func NewMetaContextForTest(c ChatTestContext) libkb.MetaContext {
+	return libkb.NewMetaContextForTest(c.TestContext)
+}
+
 func (c ChatTestContext) Context() *globals.Context {
 	return globals.NewContext(c.G, c.ChatG)
 }

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -113,7 +113,7 @@ func createAndSignupFakeUser(prefix string, g *libkb.GlobalContext, skipPaper bo
 
 // copied from engine/common_test.go
 func ResetAccount(tc libkb.TestContext, u *FakeUser) {
-	err := tc.G.LoginState().ResetAccount(u.Username)
+	err := tc.G.LoginState().ResetAccount(libkb.NewMetaContextForTest(tc), u.Username)
 	if err != nil {
 		tc.T.Fatalf("In account reset: %s", err)
 	}
@@ -122,7 +122,7 @@ func ResetAccount(tc libkb.TestContext, u *FakeUser) {
 }
 
 func DeleteAccount(tc libkb.TestContext, u *FakeUser) {
-	err := tc.G.LoginState().DeleteAccount(u.Username)
+	err := tc.G.LoginState().DeleteAccount(libkb.NewMetaContextForTest(tc), u.Username)
 	if err != nil {
 		tc.T.Fatalf("In delete: %s", err)
 	}

--- a/go/kex2/provisionee.go
+++ b/go/kex2/provisionee.go
@@ -26,10 +26,10 @@ type provisionee struct {
 // management that a provisionee needs to do as part of the protocol.
 type Provisionee interface {
 	GetLogFactory() rpc.LogFactory
-	HandleHello(keybase1.HelloArg) (keybase1.HelloRes, error)
-	HandleHello2(keybase1.Hello2Arg) (keybase1.Hello2Res, error)
-	HandleDidCounterSign([]byte) error
-	HandleDidCounterSign2(keybase1.DidCounterSign2Arg) error
+	HandleHello(ctx context.Context, a keybase1.HelloArg) (keybase1.HelloRes, error)
+	HandleHello2(ctx context.Context, a keybase1.Hello2Arg) (keybase1.Hello2Res, error)
+	HandleDidCounterSign(ctx context.Context, b []byte) error
+	HandleDidCounterSign2(ctx context.Context, a keybase1.DidCounterSign2Arg) error
 }
 
 // ProvisioneeArg provides the details that a provisionee needs in order
@@ -60,9 +60,9 @@ func RunProvisionee(arg ProvisioneeArg) error {
 // Hello is called via the RPC server interface by the remote client.
 // It in turn delegates the work to the passed in Provisionee interface,
 // calling HandleHello()
-func (p *provisionee) Hello(_ context.Context, arg keybase1.HelloArg) (res keybase1.HelloRes, err error) {
+func (p *provisionee) Hello(ctx context.Context, arg keybase1.HelloArg) (res keybase1.HelloRes, err error) {
 	close(p.start)
-	res, err = p.arg.Provisionee.HandleHello(arg)
+	res, err = p.arg.Provisionee.HandleHello(ctx, arg)
 	if err != nil {
 		p.done <- err
 	}
@@ -72,9 +72,9 @@ func (p *provisionee) Hello(_ context.Context, arg keybase1.HelloArg) (res keyba
 // Hello2 is called via the RPC server interface by the remote client.
 // It in turn delegates the work to the passed in Provisionee interface,
 // calling HandleHello()
-func (p *provisionee) Hello2(_ context.Context, arg keybase1.Hello2Arg) (res keybase1.Hello2Res, err error) {
+func (p *provisionee) Hello2(ctx context.Context, arg keybase1.Hello2Arg) (res keybase1.Hello2Res, err error) {
 	close(p.start)
-	res, err = p.arg.Provisionee.HandleHello2(arg)
+	res, err = p.arg.Provisionee.HandleHello2(ctx, arg)
 	if err != nil {
 		p.done <- err
 	}
@@ -84,9 +84,9 @@ func (p *provisionee) Hello2(_ context.Context, arg keybase1.Hello2Arg) (res key
 // DidCounterSign is called via the RPC server interface by the remote client.
 // It in turn delegates the work to the passed in Provisionee interface,
 // calling HandleDidCounterSign()
-func (p *provisionee) DidCounterSign(_ context.Context, sig []byte) (err error) {
+func (p *provisionee) DidCounterSign(ctx context.Context, sig []byte) (err error) {
 	p.startedCounterSign <- struct{}{}
-	err = p.arg.Provisionee.HandleDidCounterSign(sig)
+	err = p.arg.Provisionee.HandleDidCounterSign(ctx, sig)
 	p.done <- err
 	return err
 }
@@ -94,9 +94,9 @@ func (p *provisionee) DidCounterSign(_ context.Context, sig []byte) (err error) 
 // DidCounterSign2 is called via the RPC server interface by the remote client.
 // It in turn delegates the work to the passed in Provisionee interface,
 // calling HandleDidCounterSign()
-func (p *provisionee) DidCounterSign2(_ context.Context, arg keybase1.DidCounterSign2Arg) (err error) {
+func (p *provisionee) DidCounterSign2(ctx context.Context, arg keybase1.DidCounterSign2Arg) (err error) {
 	p.startedCounterSign <- struct{}{}
-	err = p.arg.Provisionee.HandleDidCounterSign2(arg)
+	err = p.arg.Provisionee.HandleDidCounterSign2(ctx, arg)
 	p.done <- err
 	return err
 }

--- a/go/kex2/rpc_test.go
+++ b/go/kex2/rpc_test.go
@@ -108,16 +108,16 @@ var ErrHandleHello = errors.New("handle hello failure")
 var ErrHandleDidCounterSign = errors.New("handle didCounterSign failure")
 var testTimeout = time.Duration(500) * time.Millisecond
 
-func (mp *mockProvisionee) HandleHello2(arg2 keybase1.Hello2Arg) (res keybase1.Hello2Res, err error) {
+func (mp *mockProvisionee) HandleHello2(ctx context.Context, arg2 keybase1.Hello2Arg) (res keybase1.Hello2Res, err error) {
 	arg1 := keybase1.HelloArg{
 		Uid:     arg2.Uid,
 		SigBody: arg2.SigBody,
 	}
-	res.SigPayload, err = mp.HandleHello(arg1)
+	res.SigPayload, err = mp.HandleHello(ctx, arg1)
 	return res, err
 }
 
-func (mp *mockProvisionee) HandleHello(arg keybase1.HelloArg) (res keybase1.HelloRes, err error) {
+func (mp *mockProvisionee) HandleHello(_ context.Context, arg keybase1.HelloArg) (res keybase1.HelloRes, err error) {
 	if (mp.behavior & BadProvisioneeSlowHello) != 0 {
 		time.Sleep(testTimeout * 8)
 	}
@@ -129,7 +129,7 @@ func (mp *mockProvisionee) HandleHello(arg keybase1.HelloArg) (res keybase1.Hell
 	return
 }
 
-func (mp *mockProvisionee) HandleDidCounterSign([]byte) error {
+func (mp *mockProvisionee) HandleDidCounterSign(_ context.Context, _ []byte) error {
 	if (mp.behavior & BadProvisioneeSlowDidCounterSign) != 0 {
 		time.Sleep(testTimeout * 8)
 	}
@@ -139,8 +139,8 @@ func (mp *mockProvisionee) HandleDidCounterSign([]byte) error {
 	return nil
 }
 
-func (mp *mockProvisionee) HandleDidCounterSign2(arg keybase1.DidCounterSign2Arg) error {
-	return mp.HandleDidCounterSign(arg.Sig)
+func (mp *mockProvisionee) HandleDidCounterSign2(ctx context.Context, arg keybase1.DidCounterSign2Arg) error {
+	return mp.HandleDidCounterSign(ctx, arg.Sig)
 }
 
 func testProtocolXWithBehavior(t *testing.T, provisioneeBehavior int) (results [2]error) {

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -104,7 +104,7 @@ func (a *Account) LoggedInLoad() (bool, error) {
 // LoggedInProvisioned will check if the user is logged in and provisioned on this
 // device. It will do so by bootstrapping the ActiveDevice.
 func (a *Account) LoggedInProvisioned(ctx context.Context) (bool, error) {
-	_, err := BootstrapActiveDeviceFromConfig(context.TODO(), a.G(), a, true)
+	_, err := BootstrapActiveDeviceFromConfig(NewMetaContext(ctx, a.G()).WithLoginContext(a), true)
 	if err == nil {
 		return true, nil
 	}

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -22,18 +22,18 @@ type ActiveDevice struct {
 // Set acquires the write lock and sets all the fields in ActiveDevice.
 // The acct parameter is not used for anything except to help ensure
 // that this is called from inside a LogingState account request.
-func (a *ActiveDevice) Set(g *GlobalContext, lctx LoginContext, uid keybase1.UID, deviceID keybase1.DeviceID, sigKey, encKey GenericKey, deviceName string) error {
+func (a *ActiveDevice) Set(m MetaContext, uid keybase1.UID, deviceID keybase1.DeviceID, sigKey, encKey GenericKey, deviceName string) error {
 	a.Lock()
 	defer a.Unlock()
 
-	if err := a.internalUpdateUIDDeviceID(lctx, uid, deviceID); err != nil {
+	if err := a.internalUpdateUIDDeviceID(m.LoginContext(), uid, deviceID); err != nil {
 		return err
 	}
 
 	a.signingKey = sigKey
 	a.encryptionKey = encKey
 	a.deviceName = deviceName
-	a.nistFactory = NewNISTFactory(g, uid, deviceID, sigKey)
+	a.nistFactory = NewNISTFactory(m.G(), uid, deviceID, sigKey)
 
 	return nil
 }

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -950,7 +950,7 @@ func (a *InternalAPIEngine) refreshSession(arg APIArg, reqErr error) error {
 	}
 
 	username := a.G().Env.GetUsername()
-	if err := a.G().LoginState().LoginWithStoredSecret(username.String(), nil); err != nil {
+	if err := a.G().LoginState().LoginWithStoredSecret(NewMetaContext(arg.NetContext, a.G()), username.String(), nil); err != nil {
 		a.G().Log.CDebugf(arg.NetContext, "| API call %s session refresh error: %s", arg.Endpoint, err)
 		return LoginRequiredError{Context: "your session has expired"}
 

--- a/go/libkb/bootstrap_active_device.go
+++ b/go/libkb/bootstrap_active_device.go
@@ -3,42 +3,41 @@ package libkb
 import (
 	"fmt"
 	"github.com/keybase/client/go/protocol/keybase1"
-	context "golang.org/x/net/context"
 )
 
-func loadAndUnlockKey(ctx context.Context, g *GlobalContext, lctx LoginContext, kr *SKBKeyringFile, secretStore SecretStore, uid keybase1.UID, kid keybase1.KID) (key GenericKey, err error) {
-	defer g.CTrace(ctx, fmt.Sprintf("loadAndUnlockKey(%s)", kid), func() error { return err })()
+func loadAndUnlockKey(m MetaContext, kr *SKBKeyringFile, secretStore SecretStore, uid keybase1.UID, kid keybase1.KID) (key GenericKey, err error) {
+	defer m.CTrace(fmt.Sprintf("loadAndUnlockKey(%s)", kid), func() error { return err })()
 
 	locked := kr.LookupByKid(kid)
 	if locked == nil {
-		g.Log.CDebugf(ctx, "loadAndUnlockKey: no locked key for %s", kid)
+		m.CDebugf("loadAndUnlockKey: no locked key for %s", kid)
 		return nil, NoKeyError{fmt.Sprintf("no key for %s", kid)}
 	}
 	locked.SetUID(uid)
-	unlocked, err := locked.UnlockNoPrompt(lctx, secretStore)
+	unlocked, err := locked.UnlockNoPrompt(m, secretStore)
 	if err != nil {
-		g.Log.CDebugf(ctx, "Failed to unlock key %s: %s", kid, err)
+		m.CDebugf("Failed to unlock key %s: %s", kid, err)
 		return nil, err
 	}
 	return unlocked, err
 }
 
-func BootstrapActiveDeviceFromConfig(ctx context.Context, g *GlobalContext, lctx LoginContext, online bool) (uid keybase1.UID, err error) {
-	uid, err = bootstrapActiveDeviceFromConfigReturnRawError(ctx, g, lctx, online)
+func BootstrapActiveDeviceFromConfig(m MetaContext, online bool) (uid keybase1.UID, err error) {
+	uid, err = bootstrapActiveDeviceFromConfigReturnRawError(m, online)
 	err = fixupBootstrapError(err)
 	return uid, err
 }
 
-func bootstrapActiveDeviceFromConfigReturnRawError(ctx context.Context, g *GlobalContext, lctx LoginContext, online bool) (uid keybase1.UID, err error) {
-	uid = g.Env.GetUID()
+func bootstrapActiveDeviceFromConfigReturnRawError(m MetaContext, online bool) (uid keybase1.UID, err error) {
+	uid = m.G().Env.GetUID()
 	if uid.IsNil() {
 		return uid, NoUIDError{}
 	}
-	deviceID := g.Env.GetDeviceIDForUID(uid)
+	deviceID := m.G().Env.GetDeviceIDForUID(uid)
 	if deviceID.IsNil() {
 		return uid, NoDeviceError{fmt.Sprintf("no device in config for UID=%s", uid)}
 	}
-	err = BootstrapActiveDevice(ctx, g, lctx, uid, deviceID, online)
+	err = BootstrapActiveDevice(m, uid, deviceID, online)
 	return uid, err
 }
 
@@ -67,88 +66,85 @@ func fixupBootstrapError(err error) error {
 // to sign NIST tokens, allowing the user to act as if "logged in". Will return
 // nil if everything work, LoginRequiredError if a real "login" in required to
 // make the app work, and various errors on unexpected failures.
-func BootstrapActiveDevice(ctx context.Context, g *GlobalContext, lctx LoginContext, uid keybase1.UID, deviceID keybase1.DeviceID, online bool) error {
-	err := bootstrapActiveDeviceReturnRawError(ctx, g, lctx, uid, deviceID, online)
+func BootstrapActiveDevice(m MetaContext, uid keybase1.UID, deviceID keybase1.DeviceID, online bool) error {
+	err := bootstrapActiveDeviceReturnRawError(m, uid, deviceID, online)
 	return fixupBootstrapError(err)
 }
 
-func bootstrapActiveDeviceReturnRawError(ctx context.Context, g *GlobalContext, lctx LoginContext, uid keybase1.UID, deviceID keybase1.DeviceID, online bool) (err error) {
-	defer g.CTrace(ctx, "BootstrapActiveDevice", func() error { return err })()
+func bootstrapActiveDeviceReturnRawError(m MetaContext, uid keybase1.UID, deviceID keybase1.DeviceID, online bool) (err error) {
+	defer m.CTrace("BootstrapActiveDevice", func() error { return err })()
 
-	ad := g.ActiveDevice
+	ad := m.ActiveDevice()
 
 	if ad.IsValidFor(uid, deviceID) {
-		g.Log.CDebugf(ctx, "active device is current")
+		m.CDebugf("active device is current")
 		return nil
 	}
 	// use the UPAKLoader with StaleOK, CachedOnly in order to get cached upak
-	arg := NewLoadUserByUIDArg(ctx, g, uid).WithPublicKeyOptional()
+	arg := NewLoadUserArgWithMetaContext(m).WithUID(uid).WithPublicKeyOptional()
 	if !online {
 		arg = arg.WithStaleOK(true).WithCachedOnly()
 	}
-	if lctx != nil {
-		arg = arg.WithLoginContext(lctx)
-	}
-	upak, _, err := g.GetUPAKLoader().LoadV2(arg)
+	upak, _, err := m.G().GetUPAKLoader().LoadV2(arg)
 	if err != nil {
-		g.Log.CDebugf(ctx, "BootstrapActiveDevice: upak.Load err: %s", err)
+		m.CDebugf("BootstrapActiveDevice: upak.Load err: %s", err)
 		return err
 	}
 
 	if upak.Current.Status == keybase1.StatusCode_SCDeleted {
-		g.Log.CDebugf(ctx, "User %s was deleted", uid)
+		m.CDebugf("User %s was deleted", uid)
 		return UserDeletedError{}
 	}
 
 	// find the sibkey
 	sibkeyKID, deviceName := upak.Current.FindSigningDeviceKID(deviceID)
 	if sibkeyKID.IsNil() {
-		g.Log.CDebugf(ctx, "BootstrapActiveDevice: no sibkey found for device %s", deviceID)
+		m.CDebugf("BootstrapActiveDevice: no sibkey found for device %s", deviceID)
 		return NoKeyError{"no signing device key found for user"}
 	}
 
 	subkeyKID := upak.Current.FindEncryptionDeviceKID(sibkeyKID)
 	if subkeyKID.IsNil() {
-		g.Log.CDebugf(ctx, "BootstrapActiveDevice: no subkey found for device: %s", deviceID)
+		m.CDebugf("BootstrapActiveDevice: no subkey found for device: %s", deviceID)
 		return NoKeyError{"no encryption device key found for user"}
 	}
 
 	// load the keyring file
 	username := NewNormalizedUsername(upak.Current.Username)
-	kr, err := LoadSKBKeyring(username, g)
+	kr, err := LoadSKBKeyring(username, m.G())
 	if err != nil {
-		g.Log.CDebugf(ctx, "BootstrapActiveDevice: error loading keyring for %s: %s", username, err)
+		m.CDebugf("BootstrapActiveDevice: error loading keyring for %s: %s", username, err)
 		return err
 	}
 
-	secretStore := NewSecretStore(g, username)
-	sib, err := loadAndUnlockKey(ctx, g, lctx, kr, secretStore, uid, sibkeyKID)
+	secretStore := NewSecretStore(m.G(), username)
+	sib, err := loadAndUnlockKey(m, kr, secretStore, uid, sibkeyKID)
 	if err != nil {
 		return err
 	}
-	sub, err := loadAndUnlockKey(ctx, g, lctx, kr, secretStore, uid, subkeyKID)
+	sub, err := loadAndUnlockKey(m, kr, secretStore, uid, subkeyKID)
 	if err != nil {
 		return err
 	}
 
-	err = ad.Set(g, lctx, uid, deviceID, sib, sub, deviceName)
+	err = ad.Set(m, uid, deviceID, sib, sub, deviceName)
 	return err
 }
 
 // BootstrapActiveDeviceWithLoginConext will setup an ActiveDevice with a NIST Factory
-// for the caller. The LoginContext passed through isn't really needed
+// for the caller. The m.loginContext passed through isn't really needed
 // for anything aside from assertions, but as we phase out LoginState, we'll
 // leave it here so that assertions in LoginState can still pass.
-func BootstrapActiveDeviceWithLoginContext(ctx context.Context, g *GlobalContext, lctx LoginContext) (ok bool, uid keybase1.UID, err error) {
+func BootstrapActiveDeviceWithMetaContext(m MetaContext) (ok bool, uid keybase1.UID, err error) {
 	run := func(lctx LoginContext) (keybase1.UID, error) {
-		return BootstrapActiveDeviceFromConfig(ctx, g, lctx, true)
+		return BootstrapActiveDeviceFromConfig(m.WithLoginContext(lctx), true)
 	}
-	if lctx == nil {
-		aerr := g.LoginState().Account(func(lctx *Account) {
+	if lctx := m.LoginContext(); lctx == nil {
+		aerr := m.G().LoginState().Account(func(lctx *Account) {
 			uid, err = run(lctx)
 		}, "BootstrapActiveDevice")
 		if err == nil && aerr != nil {
-			g.Log.CDebugf(ctx, "LoginOffline: LoginState account error: %s", aerr)
+			m.CDebugf("LoginOffline: LoginState account error: %s", aerr)
 			err = aerr
 		}
 	} else {

--- a/go/libkb/bug_3964_repairman.go
+++ b/go/libkb/bug_3964_repairman.go
@@ -16,14 +16,15 @@ func newBug3964Repairman(g *GlobalContext) *bug3964Repairman {
 	return &bug3964Repairman{Contextified: NewContextified(g)}
 }
 
-func (b *bug3964Repairman) attemptRepair(lctx LoginContext, lksec *LKSec, dkm DeviceKeyMap) (ran bool, serverHalfSet *LKSecServerHalfSet, err error) {
-	defer b.G().Trace("bug3964Repairman#attemptRepair", func() error { return err })()
+func (b *bug3964Repairman) attemptRepair(m MetaContext, lksec *LKSec, dkm DeviceKeyMap) (ran bool, serverHalfSet *LKSecServerHalfSet, err error) {
+	defer m.CTrace("bug3964Repairman#attemptRepair", func() error { return err })()
 	var oldKeyring, newKeyring *SKBKeyringFile
+	lctx := m.LoginContext()
 	oldKeyring, err = lctx.Keyring()
 	if err != nil {
 		return false, nil, err
 	}
-	newKeyring, serverHalfSet, err = oldKeyring.Bug3964Repair(lctx, lksec, dkm)
+	newKeyring, serverHalfSet, err = oldKeyring.Bug3964Repair(m, lksec, dkm)
 	if err != nil {
 		return false, nil, err
 	}
@@ -31,16 +32,16 @@ func (b *bug3964Repairman) attemptRepair(lctx LoginContext, lksec *LKSec, dkm De
 		return false, nil, nil
 	}
 	if err = newKeyring.Save(); err != nil {
-		b.G().Log.Debug("Error saving new keyring: %s", err)
+		m.CDebugf("Error saving new keyring: %s", err)
 		return false, nil, err
 	}
 	lctx.ClearKeyring()
 	return true, serverHalfSet, err
 }
 
-func (b *bug3964Repairman) loadLKSecServerDetails(lctx LoginContext, lksec *LKSec) (ret DeviceKeyMap, err error) {
-	defer b.G().Trace("bug3964Repairman#loadLKSecServerDetails", func() error { return err })()
-	ret, err = lksec.LoadServerDetails(lctx)
+func (b *bug3964Repairman) loadLKSecServerDetails(m MetaContext, lksec *LKSec) (ret DeviceKeyMap, err error) {
+	defer m.CTrace("bug3964Repairman#loadLKSecServerDetails", func() error { return err })()
+	ret, err = lksec.LoadServerDetails(m)
 	if err != nil {
 		return nil, err
 	}
@@ -74,20 +75,21 @@ func (b *bug3964Repairman) saveRepairmanVisit(nun NormalizedUsername) (err error
 	return err
 }
 
-func (b *bug3964Repairman) postToServer(lctx LoginContext, serverHalfSet *LKSecServerHalfSet, ppgen PassphraseGeneration, nun NormalizedUsername) (err error) {
-	defer b.G().Trace("bug3964Repairman#postToServer", func() error { return err })()
+func (b *bug3964Repairman) postToServer(m MetaContext, serverHalfSet *LKSecServerHalfSet, ppgen PassphraseGeneration, nun NormalizedUsername) (err error) {
+	defer m.G().CTrace(m.Ctx(), "bug3964Repairman#postToServer", func() error { return err })()
 	if serverHalfSet == nil {
 		return errors.New("internal error --- had nil server half set")
 	}
-	_, err = b.G().API.Post(APIArg{
+	_, err = m.G().API.Post(APIArg{
 		Endpoint:    "user/bug_3964_repair",
 		SessionType: APISessionTypeREQUIRED,
 		Args: HTTPArgs{
-			"device_id":         S{Val: b.G().Env.GetDeviceIDForUsername(nun).String()},
+			"device_id":         S{Val: m.G().Env.GetDeviceIDForUsername(nun).String()},
 			"ppgen":             I{Val: int(ppgen)},
 			"lks_server_halves": S{Val: serverHalfSet.EncodeToHexList()},
 		},
-		SessionR: lctx.LocalSession(),
+		SessionR:   m.LoginContext().LocalSession(),
+		NetContext: m.Ctx(),
 	})
 	return err
 }
@@ -151,23 +153,25 @@ func (b *bug3964Repairman) fixLKSClientHalf(lctx LoginContext, lksec *LKSec, ppg
 }
 
 // Run the engine
-func (b *bug3964Repairman) Run(lctx LoginContext, pps *PassphraseStream) (err error) {
-	defer b.G().Trace("bug3964Repairman#Run", func() error { return err })()
+func (b *bug3964Repairman) Run(m MetaContext) (err error) {
+	defer m.G().CTrace(m.Ctx(), "bug3964Repairman#Run", func() error { return err })()
+	lctx := m.LoginContext()
+	pps := lctx.PassphraseStreamCache().PassphraseStream()
 
 	var lksec *LKSec
 	var ran bool
 	var dkm DeviceKeyMap
 	var ss bool
 	var serverHalfSet *LKSecServerHalfSet
-	nun := b.G().Env.GetUsername()
+	nun := m.G().Env.GetUsername()
 
-	if b.G().TestOptions.NoBug3964Repair {
-		b.G().Log.Debug("| short circuit due to test options")
+	if m.G().TestOptions.NoBug3964Repair {
+		m.G().Log.CDebugf(m.Ctx(), "| short circuit due to test options")
 		return nil
 	}
 
 	if pps == nil {
-		b.G().Log.Debug("| Can't run repairman without a passphrase stream")
+		m.G().Log.CDebugf(m.Ctx(), "| Can't run repairman without a passphrase stream")
 		return nil
 	}
 
@@ -177,23 +181,23 @@ func (b *bug3964Repairman) Run(lctx LoginContext, pps *PassphraseStream) (err er
 
 	if ss {
 		// This logline is asserted in testing in bug_3964_repairman_test
-		b.G().Log.Debug("| Repairman already visited after file update; bailing out")
+		m.G().Log.CDebugf(m.Ctx(), "| Repairman already visited after file update; bailing out")
 		return nil
 	}
 
 	// This logline is asserted in testing in bug_3964_repairman_test
-	b.G().Log.Debug("| Repairman wasn't short-circuited")
+	m.G().Log.CDebugf(m.Ctx(), "| Repairman wasn't short-circuited")
 
-	lksec, err = pps.ToLKSec(b.G(), lctx.GetUID())
+	lksec, err = pps.ToLKSec(m.G(), lctx.GetUID())
 	if err != nil {
 		return err
 	}
 
-	if dkm, err = b.loadLKSecServerDetails(lctx, lksec); err != nil {
+	if dkm, err = b.loadLKSecServerDetails(m, lksec); err != nil {
 		return err
 	}
 
-	if ran, serverHalfSet, err = b.attemptRepair(lctx, lksec, dkm); err != nil {
+	if ran, serverHalfSet, err = b.attemptRepair(m, lksec, dkm); err != nil {
 		return err
 	}
 
@@ -201,7 +205,7 @@ func (b *bug3964Repairman) Run(lctx LoginContext, pps *PassphraseStream) (err er
 		return err
 	}
 
-	b.G().Log.Debug("| SKB keyring repair completed; edits=%v", ran)
+	m.G().Log.CDebugf(m.Ctx(), "| SKB keyring repair completed; edits=%v", ran)
 
 	if !ran {
 		b.saveRepairmanVisit(nun)
@@ -213,20 +217,20 @@ func (b *bug3964Repairman) Run(lctx LoginContext, pps *PassphraseStream) (err er
 	}
 
 	if ussErr := b.updateSecretStore(nun, lksec); ussErr != nil {
-		b.G().Log.Warning("Error in secret store manipulation: %s", ussErr)
+		m.G().Log.CWarningf(m.Ctx(), "Error in secret store manipulation: %s", ussErr)
 	} else {
 		b.saveRepairmanVisit(nun)
 	}
 
-	err = b.postToServer(lctx, serverHalfSet, pps.Generation(), nun)
+	err = b.postToServer(m, serverHalfSet, pps.Generation(), nun)
 
 	return err
 }
 
-func RunBug3964Repairman(g *GlobalContext, lctx LoginContext, pps *PassphraseStream) error {
-	err := newBug3964Repairman(g).Run(lctx, pps)
+func RunBug3964Repairman(m MetaContext) error {
+	err := newBug3964Repairman(m.G()).Run(m)
 	if err != nil {
-		g.Log.Debug("Error running Bug 3964 repairman: %s", err)
+		m.G().Log.CDebugf(m.Ctx(), "Error running Bug 3964 repairman: %s", err)
 	}
 	return err
 }

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -1,0 +1,60 @@
+package libkb
+
+import (
+	context "golang.org/x/net/context"
+)
+
+type MetaContext struct {
+	ctx          context.Context
+	g            *GlobalContext
+	loginContext LoginContext
+	activeDevice *ActiveDevice
+}
+
+func NewMetaContext(ctx context.Context, g *GlobalContext) MetaContext {
+	return MetaContext{ctx: ctx, g: g}
+}
+
+func (m MetaContext) WithLoginContext(l LoginContext) MetaContext {
+	m.loginContext = l
+	return m
+}
+
+func (m MetaContext) WithActiveDevice(a *ActiveDevice) MetaContext {
+	m.activeDevice = a
+	return m
+}
+
+func (m MetaContext) G() *GlobalContext {
+	return m.g
+}
+
+func (m MetaContext) Ctx() context.Context {
+	return m.ctx
+}
+
+func (m MetaContext) LoginContext() LoginContext {
+	return m.loginContext
+}
+
+func (m MetaContext) CTrace(msg string, f func() error) func() {
+	return CTrace(m.ctx, m.g.Log.CloneWithAddedDepth(1), msg, f)
+}
+
+func (m MetaContext) CDebugf(f string, args ...interface{}) {
+	m.g.Log.CloneWithAddedDepth(1).CDebugf(m.ctx, f, args...)
+}
+func (m MetaContext) CWarningf(f string, args ...interface{}) {
+	m.g.Log.CloneWithAddedDepth(1).CWarningf(m.ctx, f, args...)
+}
+
+func (m MetaContext) ActiveDevice() *ActiveDevice {
+	if m.activeDevice != nil {
+		return m.activeDevice
+	}
+	return m.G().ActiveDevice
+}
+
+func NewMetaContextTODO(g *GlobalContext) MetaContext {
+	return MetaContext{ctx: context.TODO(), g: g}
+}

--- a/go/libkb/generickey.go
+++ b/go/libkb/generickey.go
@@ -71,8 +71,8 @@ func CanEncrypt(key GenericKey) bool {
 	}
 }
 
-func skbPushAndSave(g *GlobalContext, skb *SKB, lctx LoginContext) error {
-	if lctx != nil {
+func skbPushAndSave(m MetaContext, skb *SKB) error {
+	if lctx := m.LoginContext(); lctx != nil {
 		kr, err := lctx.Keyring()
 		if err != nil {
 			return err
@@ -80,7 +80,7 @@ func skbPushAndSave(g *GlobalContext, skb *SKB, lctx LoginContext) error {
 		return kr.PushAndSave(skb)
 	}
 	var err error
-	kerr := g.LoginState().Keyring(func(ring *SKBKeyringFile) {
+	kerr := m.G().LoginState().Keyring(func(ring *SKBKeyringFile) {
 		err = ring.PushAndSave(skb)
 	}, "PushAndSave")
 	if kerr != nil {

--- a/go/libkb/keylock.go
+++ b/go/libkb/keylock.go
@@ -15,7 +15,6 @@ const (
 type UnlockerFunc func(pw string, storeSecret bool) (ret GenericKey, err error)
 
 type KeyUnlocker struct {
-	Contextified
 	tries          int
 	reason         string
 	keyDesc        string
@@ -25,9 +24,8 @@ type KeyUnlocker struct {
 	unlocker       UnlockerFunc
 }
 
-func NewKeyUnlocker(g *GlobalContext, tries int, reason string, keyDesc string, which PassphraseType, useSecretStore bool, ui SecretUI, unlocker UnlockerFunc) KeyUnlocker {
+func NewKeyUnlocker(tries int, reason string, keyDesc string, which PassphraseType, useSecretStore bool, ui SecretUI, unlocker UnlockerFunc) KeyUnlocker {
 	return KeyUnlocker{
-		Contextified:   NewContextified(g),
 		tries:          tries,
 		reason:         reason,
 		keyDesc:        keyDesc,
@@ -38,7 +36,7 @@ func NewKeyUnlocker(g *GlobalContext, tries int, reason string, keyDesc string, 
 	}
 }
 
-func (arg KeyUnlocker) Run() (ret GenericKey, err error) {
+func (arg KeyUnlocker) Run(m MetaContext) (ret GenericKey, err error) {
 	var emsg string
 
 	if arg.ui == nil {
@@ -55,7 +53,7 @@ func (arg KeyUnlocker) Run() (ret GenericKey, err error) {
 	title := "Your " + string(arg.which) + " passphrase"
 
 	for i := 0; arg.tries <= 0 || i < arg.tries; i++ {
-		res, err := GetSecret(arg.G(), arg.ui, title, prompt, emsg, arg.useSecretStore)
+		res, err := GetSecret(m, arg.ui, title, prompt, emsg, arg.useSecretStore)
 		if err != nil {
 			// probably canceled
 			return nil, err

--- a/go/libkb/lksec.go
+++ b/go/libkb/lksec.go
@@ -260,14 +260,11 @@ func (s *LKSec) GetServerHalf() LKSecServerHalf {
 	return s.serverHalf
 }
 
-func (s *LKSec) Load(lctx LoginContext) (err error) {
-	s.G().Log.Debug("+ LKSec::Load()")
-	defer func() {
-		s.G().Log.Debug("- LKSec::Load() -> %s", ErrToOk(err))
-	}()
+func (s *LKSec) Load(m MetaContext) (err error) {
+	defer m.CTrace("LKSec::Load()", func() error { return err })()
 
 	if !s.secret.IsNil() {
-		s.G().Log.Debug("| Short-circuit; we already know the full secret")
+		m.CDebugf("| Short-circuit; we already know the full secret")
 		return nil
 	}
 
@@ -276,7 +273,7 @@ func (s *LKSec) Load(lctx LoginContext) (err error) {
 		return err
 	}
 
-	if err = s.LoadServerHalf(lctx); err != nil {
+	if err = s.LoadServerHalf(m); err != nil {
 		return err
 	}
 
@@ -289,30 +286,27 @@ func (s *LKSec) SetFullSecret() {
 	s.secret = s.serverHalf.ComputeFullSecret(s.clientHalf)
 }
 
-func (s *LKSec) LoadServerHalf(lctx LoginContext) (err error) {
-	s.G().Log.Debug("+ LKSec::LoadServerHalf()")
-	defer func() {
-		s.G().Log.Debug("- LKSec::LoadServerHalf() -> %s", ErrToOk(err))
-	}()
+func (s *LKSec) LoadServerHalf(m MetaContext) (err error) {
+	defer m.CTrace("LKSec::LoadServerHalf()", func() error { return err })()
 
 	if !s.serverHalf.IsNil() {
-		s.G().Log.Debug("| short-circuit: already have serverHalf")
+		m.CDebugf("| short-circuit: already have serverHalf")
 		return nil
 	}
-	_, err = s.LoadServerDetails(lctx)
+	_, err = s.LoadServerDetails(m)
 	return err
 }
 
-func (s *LKSec) LoadServerDetails(lctx LoginContext) (ret DeviceKeyMap, err error) {
-	defer s.G().Trace("LKSec#LoadServerDetails", func() error { return err })()
+func (s *LKSec) LoadServerDetails(m MetaContext) (ret DeviceKeyMap, err error) {
+	defer m.CTrace("LKSec#LoadServerDetails", func() error { return err })()
 
-	devid := s.G().Env.GetDeviceIDForUID(s.uid)
+	devid := m.G().Env.GetDeviceIDForUID(s.uid)
 	if devid.IsNil() {
 		return ret, fmt.Errorf("lksec load: no device id set, thus can't fetch server half")
 	}
 
-	if ret, err = s.apiServerHalf(lctx, devid); err != nil {
-		s.G().Log.Debug("apiServerHalf(%s) error: %s", devid, err)
+	if ret, err = s.apiServerHalf(m, devid); err != nil {
+		m.CDebugf("apiServerHalf(%s) error: %s", devid, err)
 		return ret, err
 	}
 	if s.serverHalf.IsNil() {
@@ -322,27 +316,18 @@ func (s *LKSec) LoadServerDetails(lctx LoginContext) (ret DeviceKeyMap, err erro
 	return ret, nil
 }
 
-func (s *LKSec) GetSecret(lctx LoginContext) (secret LKSecFullSecret, err error) {
-	s.G().Log.Debug("+ LKsec:GetSecret()")
-	defer func() {
-		s.G().Log.Debug("- LKSec::GetSecret() -> %s", ErrToOk(err))
-	}()
-
-	if err = s.Load(lctx); err != nil {
-		return
+func (s *LKSec) GetSecret(m MetaContext) (secret LKSecFullSecret, err error) {
+	defer m.CTrace("LKsec:GetSecret()", func() error { return err })()
+	if err = s.Load(m); err != nil {
+		return secret, err
 	}
-
 	secret = s.secret
-	return
+	return secret, nil
 }
 
-func (s *LKSec) Encrypt(src []byte) (res []byte, err error) {
-	s.G().Log.Debug("+ LKsec:Encrypt()")
-	defer func() {
-		s.G().Log.Debug("- LKSec::Encrypt() -> %s", ErrToOk(err))
-	}()
-
-	if err = s.Load(nil); err != nil {
+func (s *LKSec) Encrypt(m MetaContext, src []byte) (res []byte, err error) {
+	defer m.CTrace("LKsec:Encrypt()", func() error { return err })()
+	if err = s.Load(m); err != nil {
 		return nil, err
 	}
 	var nonce []byte
@@ -358,8 +343,8 @@ func (s *LKSec) Encrypt(src []byte) (res []byte, err error) {
 	return ret, nil
 }
 
-func (s *LKSec) attemptBug3964Recovery(lctx LoginContext, data []byte, nonce *[24]byte) (res []byte, gen PassphraseGeneration, erroneousMask LKSecServerHalf, err error) {
-	ss, err := s.loadSecretSyncer(lctx)
+func (s *LKSec) attemptBug3964Recovery(m MetaContext, data []byte, nonce *[24]byte) (res []byte, gen PassphraseGeneration, erroneousMask LKSecServerHalf, err error) {
+	ss, err := s.loadSecretSyncer(m)
 	if err != nil {
 		return nil, 0, LKSecServerHalf{}, err
 	}
@@ -404,18 +389,19 @@ func splitCiphertext(src []byte) ([]byte, *[24]byte) {
 	return data, &nonce
 }
 
-func (s *LKSec) Decrypt(lctx LoginContext, src []byte) (res []byte, gen PassphraseGeneration, erroneousMask LKSecServerHalf, err error) {
+func (s *LKSec) Decrypt(m MetaContext, src []byte) (res []byte, gen PassphraseGeneration, erroneousMask LKSecServerHalf, err error) {
 	// This logline is asserted in testing in bug_3964_repairman_test
-	defer s.G().Trace("LKSec#Decrypt()", func() error { return err })()
+	defer m.CTrace("LKSec#Decrypt()", func() error { return err })()
 
-	if err = s.Load(lctx); err != nil {
+	if err = s.Load(m); err != nil {
 		return nil, 0, LKSecServerHalf{}, err
 	}
 	var ok bool
 	data, nonce := splitCiphertext(src)
 	res, ok = secretbox.Open(nil, data, nonce, s.secret.f)
 	if !ok {
-		return s.attemptBug3964Recovery(lctx, data, nonce)
+		m.CDebugf("secretbox.Open failed: attempting recovery")
+		return s.attemptBug3964Recovery(m, data, nonce)
 	}
 
 	return res, s.ppGen, LKSecServerHalf{}, nil
@@ -445,14 +431,14 @@ func (s *LKSec) ComputeClientHalf() (ret LKSecClientHalf, err error) {
 	return s.serverHalf.ComputeClientHalf(s.secret), nil
 }
 
-func (s *LKSec) loadSecretSyncer(lctx LoginContext) (ss *SecretSyncer, err error) {
-	if lctx != nil {
+func (s *LKSec) loadSecretSyncer(m MetaContext) (ss *SecretSyncer, err error) {
+	if lctx := m.LoginContext(); lctx != nil {
 		if err := lctx.RunSecretSyncer(s.uid); err != nil {
 			return nil, err
 		}
 		return lctx.SecretSyncer(), nil
 	}
-	aerr := s.G().LoginState().Account(func(a *Account) {
+	aerr := m.G().LoginState().Account(func(a *Account) {
 		if err = RunSyncer(a.SecretSyncer(), s.uid, a.LoggedIn(), a.LocalSession()); err != nil {
 			return
 		}
@@ -464,9 +450,9 @@ func (s *LKSec) loadSecretSyncer(lctx LoginContext) (ss *SecretSyncer, err error
 	return ss, err
 }
 
-func (s *LKSec) apiServerHalf(lctx LoginContext, devid keybase1.DeviceID) (dkm DeviceKeyMap, err error) {
+func (s *LKSec) apiServerHalf(m MetaContext, devid keybase1.DeviceID) (dkm DeviceKeyMap, err error) {
 	var dev DeviceKey
-	ss, err := s.loadSecretSyncer(lctx)
+	ss, err := s.loadSecretSyncer(m)
 	if err != nil {
 		return dkm, err
 	}
@@ -485,12 +471,12 @@ func (s *LKSec) apiServerHalf(lctx LoginContext, devid keybase1.DeviceID) (dkm D
 
 // NewLKSForEncrypt gets a verified passphrase stream, and returns
 // an LKS that works for encryption.
-func NewLKSecForEncrypt(ui SecretUI, uid keybase1.UID, gc *GlobalContext) (ret *LKSec, err error) {
+func NewLKSecForEncrypt(m MetaContext, ui SecretUI, uid keybase1.UID) (ret *LKSec, err error) {
 	var pps *PassphraseStream
-	if pps, err = gc.LoginState().GetPassphraseStream(ui); err != nil {
+	if pps, err = m.G().LoginState().GetPassphraseStream(m, ui); err != nil {
 		return
 	}
-	ret = NewLKSec(pps, uid, gc)
+	ret = NewLKSec(pps, uid, m.G())
 	return
 }
 
@@ -506,7 +492,7 @@ func (s *LKSec) EncryptClientHalfRecovery(key GenericKey) (string, error) {
 
 // ToSKB exports a generic key with the given LKSec to a SecretKeyBundle,
 // performing all necessary encryption.
-func (s *LKSec) ToSKB(key GenericKey) (ret *SKB, err error) {
+func (s *LKSec) ToSKB(m MetaContext, key GenericKey) (ret *SKB, err error) {
 	if s == nil {
 		return nil, errors.New("nil lks")
 	}
@@ -520,7 +506,7 @@ func (s *LKSec) ToSKB(key GenericKey) (ret *SKB, err error) {
 		return nil, err
 	}
 
-	ret.Priv.Data, err = s.Encrypt([]byte(privateKey))
+	ret.Priv.Data, err = s.Encrypt(m, []byte(privateKey))
 	if err != nil {
 		return nil, err
 	}
@@ -531,12 +517,12 @@ func (s *LKSec) ToSKB(key GenericKey) (ret *SKB, err error) {
 	return ret, nil
 }
 
-func WriteLksSKBToKeyring(g *GlobalContext, k GenericKey, lks *LKSec, lctx LoginContext) (*SKB, error) {
-	skb, err := lks.ToSKB(k)
+func WriteLksSKBToKeyring(m MetaContext, k GenericKey, lks *LKSec) (*SKB, error) {
+	skb, err := lks.ToSKB(m, k)
 	if err != nil {
 		return nil, fmt.Errorf("k.ToLksSKB() error: %s", err)
 	}
-	if err := skbPushAndSave(g, skb, lctx); err != nil {
+	if err := skbPushAndSave(m, skb); err != nil {
 		return nil, err
 	}
 	return skb, nil

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -56,6 +56,14 @@ func NewLoadUserArg(g *GlobalContext) LoadUserArg {
 	return LoadUserArg{Contextified: NewContextified(g)}
 }
 
+func NewLoadUserArgWithMetaContext(m MetaContext) LoadUserArg {
+	return LoadUserArg{
+		Contextified: NewContextified(m.G()),
+		netContext:   m.Ctx(),
+		loginContext: m.LoginContext(),
+	}
+}
+
 func NewLoadUserArgWithContext(ctx context.Context, g *GlobalContext) LoadUserArg {
 	return LoadUserArg{
 		Contextified: NewContextified(g),
@@ -253,6 +261,9 @@ func LoadMe(arg LoadUserArg) (*User, error) {
 
 func LoadMeByUID(ctx context.Context, g *GlobalContext, uid keybase1.UID) (*User, error) {
 	return LoadMe(NewLoadUserByUIDArg(ctx, g, uid))
+}
+func LoadMeByMetaContextAndUID(m MetaContext, uid keybase1.UID) (*User, error) {
+	return LoadMe(NewLoadUserArgWithMetaContext(m).WithUID(uid))
 }
 
 func LoadUser(arg LoadUserArg) (ret *User, err error) {

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -158,42 +158,42 @@ func NewLoginState(g *GlobalContext) *LoginState {
 	return res
 }
 
-func (s *LoginState) LoginWithPrompt(username string, loginUI LoginUI, secretUI SecretUI, after afterFn) (err error) {
-	s.G().Log.Debug("+ LoginWithPrompt(%s) called", username)
-	defer func() { s.G().Log.Debug("- LoginWithPrompt -> %s", ErrToOk(err)) }()
+func (s *LoginState) LoginWithPrompt(m MetaContext, username string, loginUI LoginUI, secretUI SecretUI, after afterFn) (err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ LoginWithPrompt(%s) called", username)
+	defer func() { m.G().Log.CDebugf(m.Ctx(), "- LoginWithPrompt -> %s", ErrToOk(err)) }()
 
 	err = s.loginHandle(func(lctx LoginContext) error {
-		return s.loginWithPromptHelper(lctx, username, loginUI, secretUI, false)
+		return s.loginWithPromptHelper(m.WithLoginContext(lctx), username, loginUI, secretUI, false)
 	}, after, "loginWithPromptHelper")
 	return
 }
 
-func (s *LoginState) LoginWithStoredSecret(username string, after afterFn) (err error) {
-	s.G().Log.Debug("+ LoginWithStoredSecret(%s) called", username)
-	defer func() { s.G().Log.Debug("- LoginWithStoredSecret -> %s", ErrToOk(err)) }()
+func (s *LoginState) LoginWithStoredSecret(m MetaContext, username string, after afterFn) (err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ LoginWithStoredSecret(%s) called", username)
+	defer func() { m.G().Log.CDebugf(m.Ctx(), "- LoginWithStoredSecret -> %s", ErrToOk(err)) }()
 
 	err = s.loginHandle(func(lctx LoginContext) error {
-		return s.loginWithStoredSecret(lctx, username)
+		return s.loginWithStoredSecret(m.WithLoginContext(lctx), username)
 	}, after, "loginWithStoredSecret")
 	return
 }
 
-func (s *LoginState) LoginWithPassphrase(username, passphrase string, storeSecret bool, after afterFn) (err error) {
-	s.G().Log.Debug("+ LoginWithPassphrase(%s) called", username)
-	defer func() { s.G().Log.Debug("- LoginWithPassphrase -> %s", ErrToOk(err)) }()
+func (s *LoginState) LoginWithPassphrase(m MetaContext, username, passphrase string, storeSecret bool, after afterFn) (err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ LoginWithPassphrase(%s) called", username)
+	defer func() { m.G().Log.CDebugf(m.Ctx(), "- LoginWithPassphrase -> %s", ErrToOk(err)) }()
 
 	err = s.loginHandle(func(lctx LoginContext) error {
-		return s.loginWithPassphrase(lctx, username, passphrase, storeSecret)
+		return s.loginWithPassphrase(m.WithLoginContext(lctx), username, passphrase, storeSecret)
 	}, after, "loginWithPassphrase")
 	return
 }
 
-func (s *LoginState) LoginWithKey(lctx LoginContext, user *User, key GenericKey, after afterFn) (err error) {
-	s.G().Log.Debug("+ LoginWithKey(%s) called", user.GetName())
-	defer func() { s.G().Log.Debug("- LoginWithKey -> %s", ErrToOk(err)) }()
+func (s *LoginState) LoginWithKey(m MetaContext, user *User, key GenericKey, after afterFn) (err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ LoginWithKey(%s) called", user.GetName())
+	defer func() { m.G().Log.CDebugf(m.Ctx(), "- LoginWithKey -> %s", ErrToOk(err)) }()
 
 	err = s.loginHandle(func(lctx LoginContext) error {
-		return s.loginWithKey(lctx, user, key)
+		return s.loginWithKey(m.WithLoginContext(lctx), user, key)
 	}, after, "loginWithKey")
 	return
 }
@@ -213,11 +213,11 @@ func (s *LoginState) ExternalFunc(f loginHandler, name string) error {
 	return s.loginHandle(f, nil, name)
 }
 
-func (s *LoginState) VerifyEmailAddress(email string, secretUI SecretUI, after afterFn) (err error) {
-	defer Trace(s.G().Log, "VerifyEmailAddress", func() error { return err })()
+func (s *LoginState) VerifyEmailAddress(m MetaContext, email string, secretUI SecretUI, after afterFn) (err error) {
+	defer m.G().CTrace(m.Ctx(), "VerifyEmailAddress", func() error { return err })()
 
 	err = s.loginHandle(func(lctx LoginContext) error {
-		return s.tryPassphrasePromptLogin(lctx, email, secretUI)
+		return s.tryPassphrasePromptLogin(m.WithLoginContext(lctx), email, secretUI)
 	}, after, "loginWithPassphrase")
 	return err
 }
@@ -241,20 +241,20 @@ func (s *LoginState) Shutdown() error {
 // GetPassphraseStream either returns a cached, verified passphrase stream
 // (maybe from a previous login) or generates a new one via Login. It will
 // return the current Passphrase stream on success or an error on failure.
-func (s *LoginState) GetPassphraseStream(ui SecretUI) (pps *PassphraseStream, err error) {
-	s.G().Log.Debug("+ GetPassphraseStream() called")
-	defer func() { s.G().Log.Debug("- GetPassphraseStream() -> %s", ErrToOk(err)) }()
+func (s *LoginState) GetPassphraseStream(m MetaContext, ui SecretUI) (pps *PassphraseStream, err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ GetPassphraseStream() called")
+	defer func() { m.G().Log.CDebugf(m.Ctx(), "- GetPassphraseStream() -> %s", ErrToOk(err)) }()
 
-	pps, err = s.GetPassphraseStreamForUser(ui, s.G().Env.GetUsername().String())
+	pps, err = s.GetPassphraseStreamForUser(m, ui, m.G().Env.GetUsername().String())
 	return
 }
 
 // GetPassphraseStreamForUser either returns a cached, verified passphrase stream
 // (maybe from a previous login) or generates a new one via Login. It will
 // return the current Passphrase stream on success or an error on failure.
-func (s *LoginState) GetPassphraseStreamForUser(ui SecretUI, username string) (pps *PassphraseStream, err error) {
-	s.G().Log.Debug("+ GetPassphraseStreamForUser() called")
-	defer func() { s.G().Log.Debug("- GetPassphraseStreamForUser() -> %s", ErrToOk(err)) }()
+func (s *LoginState) GetPassphraseStreamForUser(m MetaContext, ui SecretUI, username string) (pps *PassphraseStream, err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ GetPassphraseStreamForUser() called")
+	defer func() { m.G().Log.CDebugf(m.Ctx(), "- GetPassphraseStreamForUser() -> %s", ErrToOk(err)) }()
 
 	pps, err = s.PassphraseStream()
 	if err != nil {
@@ -264,7 +264,7 @@ func (s *LoginState) GetPassphraseStreamForUser(ui SecretUI, username string) (p
 		return pps, nil
 	}
 	err = s.loginHandle(func(lctx LoginContext) error {
-		return s.loginWithPromptHelper(lctx, username, nil, ui, true)
+		return s.loginWithPromptHelper(m.WithLoginContext(lctx), username, nil, ui, true)
 	}, nil, "LoginState - GetPassphraseStreamForUser")
 	if err != nil {
 		return nil, err
@@ -284,11 +284,11 @@ func (s *LoginState) GetPassphraseStreamForUser(ui SecretUI, username string) (p
 // passphrase stream (maybe from a previous login) or generates a new one via
 // Login. It will return the current Passphrase stream on success or an error
 // on failure.
-func (s *LoginState) GetPassphraseStreamWithPassphrase(passphrase string) (pps *PassphraseStream, err error) {
-	s.G().Log.Debug("+ GetPassphraseStreamWithPassphrase() called")
-	defer func() { s.G().Log.Debug("- GetPassphraseStreamWithPassphrase() -> %s", ErrToOk(err)) }()
+func (s *LoginState) GetPassphraseStreamWithPassphrase(m MetaContext, passphrase string) (pps *PassphraseStream, err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ GetPassphraseStreamWithPassphrase() called")
+	defer func() { m.G().Log.CDebugf(m.Ctx(), "- GetPassphraseStreamWithPassphrase() -> %s", ErrToOk(err)) }()
 
-	username := string(s.G().Env.GetUsername())
+	username := string(m.G().Env.GetUsername())
 	if username == "" {
 		return nil, fmt.Errorf("No current user to unlock.")
 	}
@@ -301,7 +301,7 @@ func (s *LoginState) GetPassphraseStreamWithPassphrase(passphrase string) (pps *
 		return pps, nil
 	}
 	err = s.loginHandle(func(lctx LoginContext) error {
-		return s.passphraseLogin(lctx, username, passphrase, nil, "")
+		return s.passphraseLogin(m.WithLoginContext(lctx), username, passphrase, nil, "")
 	}, nil, "LoginState - GetPassphraseStreamWithPassphrase")
 	if err != nil {
 		return nil, err
@@ -317,13 +317,13 @@ func (s *LoginState) GetPassphraseStreamWithPassphrase(passphrase string) (pps *
 	return nil, err
 }
 
-func (s *LoginState) getStoredPassphraseStream(username NormalizedUsername) (*PassphraseStream, error) {
-	fullSecret, err := s.G().SecretStore().RetrieveSecret(s.G().Env.GetUsername())
+func (s *LoginState) getStoredPassphraseStream(m MetaContext, username NormalizedUsername) (*PassphraseStream, error) {
+	fullSecret, err := m.G().SecretStore().RetrieveSecret(m.G().Env.GetUsername())
 	if err != nil {
 		return nil, err
 	}
-	lks := NewLKSecWithFullSecret(fullSecret, s.G().Env.GetUID(), s.G())
-	if err = lks.LoadServerHalf(nil); err != nil {
+	lks := NewLKSecWithFullSecret(fullSecret, m.G().Env.GetUID(), s.G())
+	if err = lks.LoadServerHalf(m); err != nil {
 		return nil, err
 	}
 	stream, err := NewPassphraseStreamLKSecOnly(lks)
@@ -336,41 +336,41 @@ func (s *LoginState) getStoredPassphraseStream(username NormalizedUsername) (*Pa
 // GetPassphraseStreamStored either returns a cached, verified passphrase
 // stream from a previous login, the secret store, or generates a new one via
 // login.
-func (s *LoginState) GetPassphraseStreamStored(ui SecretUI) (pps *PassphraseStream, err error) {
-	s.G().Log.Debug("+ GetPassphraseStreamStored() called")
-	defer func() { s.G().Log.Debug("- GetPassphraseStreamStored() -> %s", ErrToOk(err)) }()
+func (s *LoginState) GetPassphraseStreamStored(m MetaContext, ui SecretUI) (pps *PassphraseStream, err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ GetPassphraseStreamStored() called")
+	defer func() { m.G().Log.CDebugf(m.Ctx(), "- GetPassphraseStreamStored() -> %s", ErrToOk(err)) }()
 
 	// 1. try cached
-	s.G().Log.Debug("| trying cached passphrase stream")
+	m.G().Log.CDebugf(m.Ctx(), "| trying cached passphrase stream")
 	full, err := s.PassphraseStream()
 	if err != nil {
 		return pps, err
 	}
 	if full != nil {
-		s.G().Log.Debug("| cached passphrase stream ok, using it")
+		m.G().Log.CDebugf(m.Ctx(), "| cached passphrase stream ok, using it")
 		return full, nil
 	}
 
 	// 2. try from secret store
-	if s.G().SecretStore() != nil {
-		s.G().Log.Debug("| trying to get passphrase stream from secret store")
-		pps, err = s.getStoredPassphraseStream(s.G().Env.GetUsername())
+	if m.G().SecretStore() != nil {
+		m.G().Log.CDebugf(m.Ctx(), "| trying to get passphrase stream from secret store")
+		pps, err = s.getStoredPassphraseStream(m, s.G().Env.GetUsername())
 		if err == nil {
-			s.G().Log.Debug("| got passphrase stream from secret store")
+			m.G().Log.CDebugf(m.Ctx(), "| got passphrase stream from secret store")
 			return pps, nil
 		}
 
-		s.G().Log.Debug("| failed to get passphrase stream from secret store: %s", err)
+		m.G().Log.CDebugf(m.Ctx(), "| failed to get passphrase stream from secret store: %s", err)
 	}
 
 	// 3. login and get it
-	s.G().Log.Debug("| using full GetPassphraseStream")
-	full, err = s.GetPassphraseStream(ui)
+	m.G().Log.CDebugf(m.Ctx(), "| using full GetPassphraseStream")
+	full, err = s.GetPassphraseStream(m, ui)
 	if err != nil {
 		return pps, err
 	}
 	if full != nil {
-		s.G().Log.Debug("| success using full GetPassphraseStream")
+		m.G().Log.CDebugf(m.Ctx(), "| success using full GetPassphraseStream")
 		return full, nil
 	}
 	return pps, nil
@@ -378,7 +378,7 @@ func (s *LoginState) GetPassphraseStreamStored(ui SecretUI) (pps *PassphraseStre
 
 // GetVerifiedTripleSec either returns a cached, verified Triplesec
 // or generates a new one that's verified via Login.
-func (s *LoginState) GetVerifiedTriplesec(ui SecretUI) (ret Triplesec, gen PassphraseGeneration, err error) {
+func (s *LoginState) GetVerifiedTriplesec(m MetaContext, ui SecretUI) (ret Triplesec, gen PassphraseGeneration, err error) {
 	err = s.Account(func(a *Account) {
 		ret = a.PassphraseStreamCache().Triplesec()
 		gen = a.GetStreamGeneration()
@@ -387,7 +387,7 @@ func (s *LoginState) GetVerifiedTriplesec(ui SecretUI) (ret Triplesec, gen Passp
 		return
 	}
 
-	if err = s.verifyPassphraseWithServer(ui); err != nil {
+	if err = s.verifyPassphraseWithServer(m, ui); err != nil {
 		return
 	}
 
@@ -406,9 +406,9 @@ func (s *LoginState) GetVerifiedTriplesec(ui SecretUI) (ret Triplesec, gen Passp
 // is indeed the correct passphrase for the logged in user.  This is accomplished
 // via a login request.  The side effect will be that we'll retrieve the
 // correct generation number of the current passphrase from the server.
-func (s *LoginState) VerifyPlaintextPassphrase(pp string, after afterFn) (ppStream *PassphraseStream, err error) {
+func (s *LoginState) VerifyPlaintextPassphrase(m MetaContext, pp string, after afterFn) (ppStream *PassphraseStream, err error) {
 	err = s.loginHandle(func(lctx LoginContext) error {
-		err := s.verifyPlaintextPassphraseForLoggedInUser(lctx, pp)
+		err := s.verifyPlaintextPassphraseForLoggedInUser(m.WithLoginContext(lctx), pp)
 		if err == nil {
 			ppStream = lctx.PassphraseStreamCache().PassphraseStream()
 		}
@@ -417,7 +417,8 @@ func (s *LoginState) VerifyPlaintextPassphrase(pp string, after afterFn) (ppStre
 	return
 }
 
-func ComputeLoginPackage(lctx LoginContext, username string) (ret PDPKALoginPackage, err error) {
+func ComputeLoginPackage(m MetaContext, username string) (ret PDPKALoginPackage, err error) {
+	lctx := m.LoginContext()
 	loginSession, err := lctx.LoginSession().Session()
 	if err != nil {
 		return ret, err
@@ -432,28 +433,29 @@ func ComputeLoginPackage(lctx LoginContext, username string) (ret PDPKALoginPack
 	return computeLoginPackageFromEmailOrUsername(username, ps, loginSession)
 }
 
-func (s *LoginState) ResetAccount(username string) (err error) {
-	return s.resetOrDelete(username, "nuke")
+func (s *LoginState) ResetAccount(m MetaContext, username string) (err error) {
+	return s.resetOrDelete(m, username, "nuke")
 }
 
-func (s *LoginState) DeleteAccount(username string) (err error) {
-	return s.resetOrDelete(username, "delete")
+func (s *LoginState) DeleteAccount(m MetaContext, username string) (err error) {
+	return s.resetOrDelete(m, username, "delete")
 }
 
-func ResetAccountWithContext(g *GlobalContext, lctx LoginContext, username string) error {
-	return ResetOrDeleteWithContext(g, lctx, username, "nuke")
+func ResetAccountWithContext(m MetaContext, username string) error {
+	return ResetOrDeleteWithContext(m, username, "nuke")
 }
 
-func DeleteAccountWithContext(g *GlobalContext, lctx LoginContext, username string) error {
-	return ResetOrDeleteWithContext(g, lctx, username, "delete")
+func DeleteAccountWithContext(m MetaContext, username string) error {
+	return ResetOrDeleteWithContext(m, username, "delete")
 }
 
-func ResetOrDeleteWithContext(g *GlobalContext, lctx LoginContext, username string, endpoint string) (err error) {
+func ResetOrDeleteWithContext(m MetaContext, username string, endpoint string) (err error) {
+	lctx := m.LoginContext()
 	err = lctx.LoadLoginSession(username)
 	if err != nil {
 		return err
 	}
-	pdpka, err := ComputeLoginPackage(lctx, username)
+	pdpka, err := ComputeLoginPackage(m, username)
 	if err != nil {
 		return err
 	}
@@ -464,17 +466,17 @@ func ResetOrDeleteWithContext(g *GlobalContext, lctx LoginContext, username stri
 		SessionR:    lctx.LocalSession(),
 	}
 	pdpka.PopulateArgs(&arg.Args)
-	_, err = g.API.Post(arg)
+	_, err = m.G().API.Post(arg)
 	return err
 }
 
-func (s *LoginState) resetOrDelete(username string, endpoint string) (err error) {
+func (s *LoginState) resetOrDelete(m MetaContext, username string, endpoint string) (err error) {
 	return s.loginHandle(func(lctx LoginContext) error {
-		return ResetOrDeleteWithContext(s.G(), lctx, username, endpoint)
+		return ResetOrDeleteWithContext(m.WithLoginContext(lctx), username, endpoint)
 	}, nil, ("ResetAccount: " + endpoint))
 }
 
-func (s *LoginState) postLoginToServer(lctx LoginContext, eOu string, lp PDPKALoginPackage) (*loginAPIResult, error) {
+func (s *LoginState) postLoginToServer(m MetaContext, eOu string, lp PDPKALoginPackage) (*loginAPIResult, error) {
 
 	arg := APIArg{
 		Endpoint:    "login",
@@ -482,10 +484,11 @@ func (s *LoginState) postLoginToServer(lctx LoginContext, eOu string, lp PDPKALo
 		Args: HTTPArgs{
 			"email_or_username": S{eOu},
 		},
+		NetContext:     m.Ctx(),
 		AppStatusCodes: []int{SCOk, SCBadLoginPassword, SCBadLoginUserNotFound},
 	}
 	lp.PopulateArgs(&arg.Args)
-	res, err := s.G().API.Post(arg)
+	res, err := m.G().API.Post(arg)
 	if err != nil {
 		return nil, err
 	}
@@ -522,9 +525,10 @@ func (s *LoginState) postLoginToServer(lctx LoginContext, eOu string, lp PDPKALo
 	return &loginAPIResult{sessionID, csrfToken, uid, uname, PassphraseGeneration(ppGen)}, nil
 }
 
-func (s *LoginState) saveLoginState(lctx LoginContext, res *loginAPIResult, nilPPStreamOK bool) error {
+func (s *LoginState) saveLoginState(m MetaContext, res *loginAPIResult, nilPPStreamOK bool) error {
+	lctx := m.LoginContext()
 	lctx.SetStreamGeneration(res.ppGen, nilPPStreamOK)
-	return lctx.SaveState(res.sessionID, res.csrfToken, NewNormalizedUsername(res.username), res.uid, s.G().Env.GetDeviceIDForUsername(NewNormalizedUsername(res.username)))
+	return lctx.SaveState(res.sessionID, res.csrfToken, NewNormalizedUsername(res.username), res.uid, m.G().Env.GetDeviceIDForUsername(NewNormalizedUsername(res.username)))
 }
 
 func (r PostAuthProofRes) loginResult() (*loginAPIResult, error) {
@@ -548,45 +552,47 @@ type getSecretKeyFn func(*Keyrings, *User) (GenericKey, error)
 
 // pubkeyLoginHelper looks for a locally available private key and
 // tries to establish a session via public key signature.
-func (s *LoginState) pubkeyLoginHelper(lctx LoginContext, username string, getSecretKeyFn getSecretKeyFn) (err error) {
-	s.G().Log.Debug("+ pubkeyLoginHelper()")
+func (s *LoginState) pubkeyLoginHelper(m MetaContext, username string, getSecretKeyFn getSecretKeyFn) (err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ pubkeyLoginHelper()")
+	lctx := m.LoginContext()
 	defer func() {
 		if err != nil {
 			if e := lctx.SecretSyncer().Clear(); e != nil {
-				s.G().Log.Info("error clearing secret syncer: %s", e)
+				m.G().Log.CInfof(m.Ctx(), "error clearing secret syncer: %s", e)
 			}
 		}
-		s.G().Log.Debug("- pubkeyLoginHelper() -> %s", ErrToOk(err))
+		m.G().Log.CDebugf(m.Ctx(), "- pubkeyLoginHelper() -> %s", ErrToOk(err))
 	}()
 
 	nu := NewNormalizedUsername(username)
 
-	if _, err = s.G().Env.GetConfig().GetUserConfigForUsername(nu); err != nil {
-		s.G().Log.Debug("| No Userconfig for %s: %s", username, err)
+	if _, err = m.G().Env.GetConfig().GetUserConfigForUsername(nu); err != nil {
+		m.G().Log.CDebugf(m.Ctx(), "| No Userconfig for %s: %s", username, err)
 		return
 	}
 
 	var me *User
-	if me, err = LoadUser(NewLoadUserByNameArg(s.G(), username).WithLoginContext(lctx)); err != nil {
+	if me, err = LoadUser(NewLoadUserByNameArg(s.G(), username).WithLoginContext(lctx).WithNetContext(m.Ctx())); err != nil {
 		return
 	}
 
 	lctx.RunSecretSyncer(me.GetUID())
 	if !lctx.SecretSyncer().HasDevices() {
-		s.G().Log.Debug("| No synced devices, pubkey login impossible.")
+		m.G().Log.CDebugf(m.Ctx(), "| No synced devices, pubkey login impossible.")
 		err = NoDeviceError{Reason: "no synced devices during pubkey login"}
 		return err
 	}
 
 	var key GenericKey
-	if key, err = getSecretKeyFn(s.G().Keyrings, me); err != nil {
+	if key, err = getSecretKeyFn(m.G().Keyrings, me); err != nil {
 		return err
 	}
 
-	return s.pubkeyLoginWithKey(lctx, me, key)
+	return s.pubkeyLoginWithKey(m, me, key)
 }
 
-func (s *LoginState) pubkeyLoginWithKey(lctx LoginContext, me *User, key GenericKey) error {
+func (s *LoginState) pubkeyLoginWithKey(m MetaContext, me *User, key GenericKey) error {
+	lctx := m.LoginContext()
 	if err := lctx.LoadLoginSession(me.GetName()); err != nil {
 		return err
 	}
@@ -611,7 +617,7 @@ func (s *LoginState) pubkeyLoginWithKey(lctx LoginContext, me *User, key Generic
 		sig: sig,
 		key: key,
 	}
-	pres, err := PostAuthProof(context.TODO(), s.G(), arg)
+	pres, err := PostAuthProof(m.Ctx(), m.G(), arg)
 	if err != nil {
 		return err
 	}
@@ -621,17 +627,18 @@ func (s *LoginState) pubkeyLoginWithKey(lctx LoginContext, me *User, key Generic
 		return err
 	}
 
-	return s.saveLoginState(lctx, res, true)
+	return s.saveLoginState(m, res, true)
 }
 
-func (s *LoginState) checkLoggedIn(lctx LoginContext, username string, force bool) (loggedIn bool, err error) {
-	s.G().Log.Debug("+ checkedLoggedIn()")
-	defer func() { s.G().Log.Debug("- checkedLoggedIn() -> %t, %s", loggedIn, ErrToOk(err)) }()
+func (s *LoginState) checkLoggedIn(m MetaContext, username string, force bool) (loggedIn bool, err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ checkedLoggedIn()")
+	defer func() { m.G().Log.CDebugf(m.Ctx(), "- checkedLoggedIn() -> %t, %s", loggedIn, ErrToOk(err)) }()
+	lctx := m.LoginContext()
 
 	var loggedInTmp bool
 	if loggedInTmp, err = lctx.LoggedInLoad(); err != nil {
-		s.G().Log.Debug("| Session failed to load")
-		return
+		m.G().Log.CDebugf(m.Ctx(), "| Session failed to load")
+		return loggedIn, err
 	}
 
 	nu1 := lctx.LocalSession().GetUsername()
@@ -642,13 +649,13 @@ func (s *LoginState) checkLoggedIn(lctx LoginContext, username string, force boo
 	}
 
 	if !force && loggedInTmp {
-		s.G().Log.Debug("| Our session token is still valid; we're logged in")
+		s.G().Log.CDebugf(m.Ctx(), "| Our session token is still valid; we're logged in")
 		loggedIn = true
 	}
-	return
+	return loggedIn, err
 }
 
-func (s *LoginState) switchUser(lctx LoginContext, username string) error {
+func (s *LoginState) switchUser(m MetaContext, username string) error {
 	if len(username) == 0 {
 		// this isn't an error
 		return nil
@@ -657,44 +664,44 @@ func (s *LoginState) switchUser(lctx LoginContext, username string) error {
 		return errors.New("invalid username provided to switchUser")
 	}
 	nu := NewNormalizedUsername(username)
-	if err := s.G().Env.GetConfigWriter().SwitchUser(nu); err != nil {
+	if err := m.G().Env.GetConfigWriter().SwitchUser(nu); err != nil {
 		if _, ok := err.(UserNotFoundError); ok {
-			s.G().Log.Debug("| No user %s found; clearing out config", username)
+			m.G().Log.Debug("| No user %s found; clearing out config", username)
 			return nil
 		}
-		s.G().Log.Debug("| Can't switch user to %s: %s", username, err)
+		m.G().Log.Debug("| Can't switch user to %s: %s", username, err)
 		return err
 	}
 
-	lctx.EnsureUsername(nu)
+	m.LoginContext().EnsureUsername(nu)
 
-	s.G().Log.Debug("| Successfully switched user to %s", username)
+	m.G().Log.CDebugf(m.Ctx(), "| Successfully switched user to %s", username)
 	return nil
 }
 
 // Like pubkeyLoginHelper, but ignores most errors.
-func (s *LoginState) tryPubkeyLoginHelper(lctx LoginContext, username string, getSecretKeyFn getSecretKeyFn) (loggedIn bool, err error) {
-	if err = s.pubkeyLoginHelper(lctx, username, getSecretKeyFn); err == nil {
-		s.G().Log.Debug("| Pubkey login succeeded")
+func (s *LoginState) tryPubkeyLoginHelper(m MetaContext, username string, getSecretKeyFn getSecretKeyFn) (loggedIn bool, err error) {
+	if err = s.pubkeyLoginHelper(m, username, getSecretKeyFn); err == nil {
+		m.G().Log.CDebugf(m.Ctx(), "| Pubkey login succeeded")
 		loggedIn = true
-		return
+		return loggedIn, err
 	}
 
 	if _, ok := err.(CanceledError); ok {
-		s.G().Log.Debug("| Canceled pubkey login, so cancel login")
-		return
+		m.G().Log.CDebugf(m.Ctx(), "| Canceled pubkey login, so cancel login")
+		return loggedIn, err
 	}
 
-	s.G().Log.Debug("| Public key login failed, falling back: %s", err)
+	m.G().Log.CDebugf(m.Ctx(), "| Public key login failed, falling back: %s", err)
 	err = nil
-	return
+	return loggedIn, err
 }
 
-func (s *LoginState) tryPassphrasePromptLogin(lctx LoginContext, username string, secretUI SecretUI) (err error) {
+func (s *LoginState) tryPassphrasePromptLogin(m MetaContext, username string, secretUI SecretUI) (err error) {
 	retryMsg := ""
 	retryCount := 3
 	for i := 0; i < retryCount; i++ {
-		err = s.passphraseLogin(lctx, username, "", secretUI, retryMsg)
+		err = s.passphraseLogin(m, username, "", secretUI, retryMsg)
 
 		if err == nil {
 			return
@@ -709,18 +716,18 @@ func (s *LoginState) tryPassphrasePromptLogin(lctx LoginContext, username string
 	return
 }
 
-func (s *LoginState) getEmailOrUsername(lctx LoginContext, username *string, loginUI LoginUI) (err error) {
+func (s *LoginState) getEmailOrUsername(m MetaContext, username *string, loginUI LoginUI) (err error) {
 	if len(*username) != 0 {
 		return
 	}
 
-	*username = s.G().Env.GetEmailOrUsername()
+	*username = m.G().Env.GetEmailOrUsername()
 	if len(*username) != 0 {
 		return
 	}
 
 	if loginUI != nil {
-		if *username, err = loginUI.GetEmailOrUsername(context.TODO(), 0); err != nil {
+		if *username, err = loginUI.GetEmailOrUsername(m.Ctx(), 0); err != nil {
 			*username = ""
 			return
 		}
@@ -735,22 +742,24 @@ func (s *LoginState) getEmailOrUsername(lctx LoginContext, username *string, log
 	}
 
 	// username set, so redo config
-	if err = s.G().ConfigureConfig(); err != nil {
+	if err = m.G().ConfigureConfig(); err != nil {
 		return
 	}
-	return s.switchUser(lctx, *username)
+	return s.switchUser(m, *username)
 }
 
-func (s *LoginState) verifyPlaintextPassphraseForLoggedInUser(lctx LoginContext, passphrase string) (err error) {
-	s.G().Log.Debug("+ LoginState.verifyPlaintextPassphraseForLoggedInUser")
+func (s *LoginState) verifyPlaintextPassphraseForLoggedInUser(m MetaContext, passphrase string) (err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ LoginState.verifyPlaintextPassphraseForLoggedInUser")
 	defer func() {
-		s.G().Log.Debug("- LoginState.verifyPlaintextPassphraseForLoggedInUser -> %s", ErrToOk(err))
+		m.G().Log.CDebugf(m.Ctx(), "- LoginState.verifyPlaintextPassphraseForLoggedInUser -> %s", ErrToOk(err))
 	}()
 
 	var username string
-	if err = s.getEmailOrUsername(lctx, &username, nil); err != nil {
+	if err = s.getEmailOrUsername(m, &username, nil); err != nil {
 		return
 	}
+
+	lctx := m.LoginContext()
 
 	// For a login reattempt
 	lctx.ClearStreamCache()
@@ -760,42 +769,44 @@ func (s *LoginState) verifyPlaintextPassphraseForLoggedInUser(lctx LoginContext,
 
 	// Pass nil SecretUI (since we don't want to trigger the UI)
 	// and also no retry message.
-	err = s.passphraseLogin(lctx, username, passphrase, nil, "")
+	err = s.passphraseLogin(m, username, passphrase, nil, "")
 
 	return
 }
 
-func (s *LoginState) passphraseLogin(lctx LoginContext, username, passphrase string, secretUI SecretUI, retryMsg string) (err error) {
-	s.G().Log.Debug("+ LoginState#passphraseLogin (username=%s)", username)
+func (s *LoginState) passphraseLogin(m MetaContext, username, passphrase string, secretUI SecretUI, retryMsg string) (err error) {
+	m.G().Log.CDebugf(m.Ctx(), "+ LoginState#passphraseLogin (username=%s)", username)
 	defer func() {
-		s.G().Log.Debug("- LoginState#passphraseLogin -> %s", ErrToOk(err))
+		m.G().Log.CDebugf(m.Ctx(), "- LoginState#passphraseLogin -> %s", ErrToOk(err))
 	}()
+
+	lctx := m.LoginContext()
 
 	if err = lctx.LoadLoginSession(username); err != nil {
 		return
 	}
 
-	storeSecret, err := s.stretchPassphraseIfNecessary(lctx, username, passphrase, secretUI, retryMsg)
+	storeSecret, err := s.stretchPassphraseIfNecessary(m, username, passphrase, secretUI, retryMsg)
 	if err != nil {
 		return err
 	}
 
-	lp, err := ComputeLoginPackage(lctx, username)
+	lp, err := ComputeLoginPackage(m, username)
 	if err != nil {
 		return err
 	}
 
-	res, err := s.postLoginToServer(lctx, username, lp)
+	res, err := s.postLoginToServer(m, username, lp)
 	if err != nil {
 		lctx.ClearStreamCache()
 		return err
 	}
 
-	if err := s.saveLoginState(lctx, res, false); err != nil {
+	if err := s.saveLoginState(m, res, false); err != nil {
 		return err
 	}
 
-	s.G().Log.Debug("passphraseLogin success")
+	m.G().Log.CDebugf(m.Ctx(), "passphraseLogin success")
 
 	// If storeSecret is set and there is a device ID, then try to store the secret.
 	//
@@ -803,66 +814,68 @@ func (s *LoginState) passphraseLogin(lctx LoginContext, username, passphrase str
 	//
 	// Can get here without a device ID during device provisioning as this is used to establish a login
 	// session before the device keys are generated.
-	if storeSecret && !s.G().Env.GetDeviceIDForUsername(NewNormalizedUsername(res.username)).IsNil() {
+	if storeSecret && !m.G().Env.GetDeviceIDForUsername(NewNormalizedUsername(res.username)).IsNil() {
 
-		err = s.doStoreSecret(lctx, res)
+		err = s.doStoreSecret(m, res)
 		if err != nil {
-			s.G().Log.Debug("| LoginState#passphraseLogin: emergency logout")
+			m.G().Log.CDebugf(m.Ctx(), "| LoginState#passphraseLogin: emergency logout")
 			tmpErr := lctx.Logout()
 			if tmpErr != nil {
-				s.G().Log.Debug("error in emergency logout: %s", tmpErr)
+				m.G().Log.CDebugf(m.Ctx(), "error in emergency logout: %s", tmpErr)
 			}
 			return err
 		}
 	} else if !storeSecret {
-		s.G().Log.Debug("| LoginState#passphraseLogin: not storing secret because storeSecret false")
-	} else if s.G().Env.GetDeviceIDForUsername(NewNormalizedUsername(res.username)).IsNil() {
-		s.G().Log.Debug("| LoginState#passphraseLogin: not storing secret because no device id for username %q", res.username)
+		m.G().Log.CDebugf(m.Ctx(), "| LoginState#passphraseLogin: not storing secret because storeSecret false")
+	} else if m.G().Env.GetDeviceIDForUsername(NewNormalizedUsername(res.username)).IsNil() {
+		m.G().Log.CDebugf(m.Ctx(), "| LoginState#passphraseLogin: not storing secret because no device id for username %q", res.username)
 	}
 
-	if repairErr := RunBug3964Repairman(s.G(), lctx, lctx.PassphraseStreamCache().PassphraseStream()); repairErr != nil {
-		s.G().Log.Debug("In Bug 3964 repair: %s", repairErr)
+	if repairErr := RunBug3964Repairman(m); repairErr != nil {
+		m.G().Log.CDebugf(m.Ctx(), "In Bug 3964 repair: %s", repairErr)
 	}
 
 	return nil
 }
 
-func (s *LoginState) doStoreSecret(lctx LoginContext, res *loginAPIResult) (err error) {
+func (s *LoginState) doStoreSecret(m MetaContext, res *loginAPIResult) (err error) {
 
-	defer s.G().Trace("LoginState#doStoreSecret", func() error { return err })()
+	defer m.G().CTrace(m.Ctx(), "LoginState#doStoreSecret", func() error { return err })()
+	lctx := m.LoginContext()
 	pps := lctx.PassphraseStreamCache().PassphraseStream()
 	if pps == nil {
 		return errors.New("nil passphrase stream")
 	}
-	lks := NewLKSec(pps, res.uid, s.G())
-	secret, err := lks.GetSecret(lctx)
+	lks := NewLKSec(pps, res.uid, m.G())
+	secret, err := lks.GetSecret(m)
 	if err != nil {
-		s.G().Log.Debug("error getting lksec secret for SecretStore: %s", err)
+		m.G().Log.CDebugf(m.Ctx(), "error getting lksec secret for SecretStore: %s", err)
 		return err
 	}
 
-	secretStore := NewSecretStore(s.G(), NewNormalizedUsername(res.username))
+	secretStore := NewSecretStore(m.G(), NewNormalizedUsername(res.username))
 	if secretStore == nil {
-		s.G().Log.Debug("secret store requested, but unable to create one")
+		m.G().Log.CDebugf(m.Ctx(), "secret store requested, but unable to create one")
 		return nil
 	}
 	storeSecretErr := secretStore.StoreSecret(secret)
 	if storeSecretErr != nil {
 		// Ignore any errors storing the secret.
-		s.G().Log.Debug("(ignoring) StoreSecret error: %s", storeSecretErr)
+		m.G().Log.CDebugf(m.Ctx(), "(ignoring) StoreSecret error: %s", storeSecretErr)
 		return nil
 	}
 
 	return nil
 }
 
-func (s *LoginState) stretchPassphraseIfNecessary(lctx LoginContext, un string, pp string, ui SecretUI, retry string) (storeSecret bool, err error) {
-	s.G().Log.Debug("+ stretchPassphraseIfNecessary (%s)", un)
+func (s *LoginState) stretchPassphraseIfNecessary(m MetaContext, un string, pp string, ui SecretUI, retry string) (storeSecret bool, err error) {
+	s.G().Log.CDebugf(m.Ctx(), "+ stretchPassphraseIfNecessary (%s)", un)
 	defer func() {
-		s.G().Log.Debug("- stretchPassphraseIfNecessary -> %s", ErrToOk(err))
+		s.G().Log.CDebugf(m.Ctx(), "- stretchPassphraseIfNecessary -> %s", ErrToOk(err))
 	}()
+	lctx := m.LoginContext()
 	if lctx.PassphraseStreamCache().Valid() {
-		s.G().Log.Debug("| stretchPassphraseIfNecessary: passphrase stream cached")
+		m.G().Log.CDebugf(m.Ctx(), "| stretchPassphraseIfNecessary: passphrase stream cached")
 		// already have stretched passphrase cached
 		return false, nil
 	}
@@ -872,8 +885,8 @@ func (s *LoginState) stretchPassphraseIfNecessary(lctx LoginContext, un string, 
 			return false, NoUIError{"secret"}
 		}
 
-		s.G().Log.Debug("| stretchPassphraseIfNecessary: getting keybase passphrase via ui")
-		res, err := GetKeybasePassphrase(s.G(), ui, un, retry)
+		m.G().Log.CDebugf(m.Ctx(), "| stretchPassphraseIfNecessary: getting keybase passphrase via ui")
+		res, err := GetKeybasePassphrase(m, ui, un, retry)
 		if err != nil {
 			return false, err
 		}
@@ -889,23 +902,23 @@ func (s *LoginState) stretchPassphraseIfNecessary(lctx LoginContext, un string, 
 	return storeSecret, nil
 }
 
-func (s *LoginState) verifyPassphraseWithServer(ui SecretUI) error {
+func (s *LoginState) verifyPassphraseWithServer(m MetaContext, ui SecretUI) error {
 	return s.loginHandle(func(lctx LoginContext) error {
-		return s.loginWithPromptHelper(lctx, s.G().Env.GetUsername().String(), nil, ui, true)
+		return s.loginWithPromptHelper(m.WithLoginContext(lctx), m.G().Env.GetUsername().String(), nil, ui, true)
 	}, nil, "LoginState - verifyPassphrase")
 }
 
-func (s *LoginState) loginWithPromptHelper(lctx LoginContext, username string, loginUI LoginUI, secretUI SecretUI, force bool) (err error) {
+func (s *LoginState) loginWithPromptHelper(m MetaContext, username string, loginUI LoginUI, secretUI SecretUI, force bool) (err error) {
 	var loggedIn bool
-	if loggedIn, err = s.checkLoggedIn(lctx, username, force); err != nil || loggedIn {
+	if loggedIn, err = s.checkLoggedIn(m, username, force); err != nil || loggedIn {
 		return
 	}
 
-	if err = s.switchUser(lctx, username); err != nil {
+	if err = s.switchUser(m, username); err != nil {
 		return
 	}
 
-	if err = s.getEmailOrUsername(lctx, &username, loginUI); err != nil {
+	if err = s.getEmailOrUsername(m, &username, loginUI); err != nil {
 		return
 	}
 
@@ -914,17 +927,17 @@ func (s *LoginState) loginWithPromptHelper(lctx LoginContext, username string, l
 			Me:      me,
 			KeyType: DeviceSigningKeyType,
 		}
-		return keyrings.GetSecretKeyWithoutPrompt(lctx, ska)
+		return keyrings.GetSecretKeyWithoutPrompt(m, ska)
 	}
 
 	// If we're forcing a login to check our passphrase (as in when we're called
 	// from verifyPassphraseWithServer), then don't use public key login at all. See issue #510.
 	if !force {
-		if loggedIn, err = s.tryPubkeyLoginHelper(lctx, username, getSecretKeyFn); err != nil || loggedIn {
+		if loggedIn, err = s.tryPubkeyLoginHelper(m, username, getSecretKeyFn); err != nil || loggedIn {
 			return
 		}
 	}
-	return s.tryPassphrasePromptLogin(lctx, username, secretUI)
+	return s.tryPassphrasePromptLogin(m, username, secretUI)
 }
 
 // loginHandle creates a loginReq from a loginHandler and puts it
@@ -1021,75 +1034,75 @@ func (s *LoginState) requests() {
 	}
 }
 
-func (s *LoginState) loginWithStoredSecret(lctx LoginContext, username string) error {
-	if loggedIn, err := s.checkLoggedIn(lctx, username, false); err != nil {
+func (s *LoginState) loginWithStoredSecret(m MetaContext, username string) error {
+	if loggedIn, err := s.checkLoggedIn(m, username, false); err != nil {
 		return err
 	} else if loggedIn {
 		return nil
 	}
 
-	if err := s.switchUser(lctx, username); err != nil {
+	if err := s.switchUser(m, username); err != nil {
 		return err
 	}
 
 	getSecretKeyFn := func(keyrings *Keyrings, me *User) (GenericKey, error) {
-		secretRetriever := NewSecretStore(s.G(), me.GetNormalizedName())
+		secretRetriever := NewSecretStore(m.G(), me.GetNormalizedName())
 		ska := SecretKeyArg{
 			Me:      me,
 			KeyType: DeviceSigningKeyType,
 		}
-		key, err := keyrings.GetSecretKeyWithStoredSecret(lctx, ska, me, secretRetriever)
+		key, err := keyrings.GetSecretKeyWithStoredSecret(m, ska, me, secretRetriever)
 		if err != nil {
 			return nil, SecretStoreError{Msg: err.Error()}
 		}
 		return key, nil
 	}
-	return s.pubkeyLoginHelper(lctx, username, getSecretKeyFn)
+	return s.pubkeyLoginHelper(m, username, getSecretKeyFn)
 }
 
-func (s *LoginState) loginWithPassphrase(lctx LoginContext, username, passphrase string, storeSecret bool) error {
-	if loggedIn, err := s.checkLoggedIn(lctx, username, false); err != nil {
+func (s *LoginState) loginWithPassphrase(m MetaContext, username, passphrase string, storeSecret bool) error {
+	if loggedIn, err := s.checkLoggedIn(m, username, false); err != nil {
 		return err
 	} else if loggedIn {
 		return nil
 	}
 
-	if err := s.switchUser(lctx, username); err != nil {
+	if err := s.switchUser(m, username); err != nil {
 		return err
 	}
 
 	getSecretKeyFn := func(keyrings *Keyrings, me *User) (GenericKey, error) {
 		var secretStorer SecretStorer
 		if storeSecret {
-			secretStorer = NewSecretStore(s.G(), me.GetNormalizedName())
+			secretStorer = NewSecretStore(m.G(), me.GetNormalizedName())
 		}
-		key, err := keyrings.GetSecretKeyWithPassphrase(lctx, me, passphrase, secretStorer)
+		key, err := keyrings.GetSecretKeyWithPassphrase(m, me, passphrase, secretStorer)
 		if err != nil {
 			return nil, SecretStoreError{Msg: err.Error()}
 		}
 		return key, nil
 	}
-	if loggedIn, err := s.tryPubkeyLoginHelper(lctx, username, getSecretKeyFn); err != nil {
+	if loggedIn, err := s.tryPubkeyLoginHelper(m, username, getSecretKeyFn); err != nil {
 		return err
 	} else if loggedIn {
 		return nil
 	}
 
-	return s.passphraseLogin(lctx, username, passphrase, nil, "")
+	return s.passphraseLogin(m, username, passphrase, nil, "")
 }
 
-func (s *LoginState) loginWithKey(lctx LoginContext, user *User, key GenericKey) error {
-	if loggedIn, err := s.checkLoggedIn(lctx, user.GetName(), false); err != nil {
+func (s *LoginState) loginWithKey(m MetaContext, user *User, key GenericKey) error {
+	if loggedIn, err := s.checkLoggedIn(m, user.GetName(), false); err != nil {
 		return err
 	} else if loggedIn {
 		return nil
 	}
 
-	if err := s.switchUser(lctx, user.GetName()); err != nil {
+	if err := s.switchUser(m, user.GetName()); err != nil {
 		return err
 	}
 
-	return s.pubkeyLoginWithKey(lctx, user, key)
+	return s.pubkeyLoginWithKey(m, user, key)
 }
 
 func (s *LoginState) logout(a LoginContext) error {
@@ -1287,4 +1300,39 @@ func IsLoggedIn(g *GlobalContext, lih LoggedInHelper) (ret bool, uid keybase1.UI
 		uid = lih.GetUID()
 	}
 	return ret, uid, err
+}
+
+// UnverifiedPassphraseStream takes a passphrase as a parameter and
+// also the salt from the Account and computes a Triplesec and
+// a passphrase stream.  It's not verified through a Login.
+func UnverifiedPassphraseStream(m MetaContext, passphrase string) (tsec Triplesec, ret *PassphraseStream, err error) {
+	username := m.G().Env.GetUsername().String()
+	lctx := m.LoginContext()
+	var salt []byte
+	if lctx != nil {
+		if len(username) > 0 {
+			err = lctx.LoadLoginSession(username)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		salt, err = lctx.LoginSession().Salt()
+	} else {
+		aerr := m.G().LoginState().Account(func(a *Account) {
+			if len(username) > 0 {
+				err = a.LoadLoginSession(username)
+				if err != nil {
+					return
+				}
+			}
+			salt, err = a.LoginSession().Salt()
+		}, "skb - salt")
+		if aerr != nil {
+			return nil, nil, aerr
+		}
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return StretchPassphrase(m.G(), passphrase, salt)
 }

--- a/go/libkb/naclgen.go
+++ b/go/libkb/naclgen.go
@@ -41,8 +41,8 @@ func (g *NaclKeyGen) Generate() (err error) {
 	return
 }
 
-func (g *NaclKeyGen) SaveLKS(gc *GlobalContext, lks *LKSec, lctx LoginContext) error {
-	_, err := WriteLksSKBToKeyring(gc, g.pair, lks, lctx)
+func (g *NaclKeyGen) SaveLKS(m MetaContext, lks *LKSec) error {
+	_, err := WriteLksSKBToKeyring(m, g.pair, lks)
 	return err
 }
 

--- a/go/libkb/paperkey_phrase.go
+++ b/go/libkb/paperkey_phrase.go
@@ -92,14 +92,14 @@ func wordVersion(word string) uint8 {
 	return h[len(h)-1] & ((1 << PaperKeyVersionBits) - 1)
 }
 
-func NewPaperKeyPhraseCheckVersion(g *GlobalContext, passphrase string) (ret PaperKeyPhrase, err error) {
+func NewPaperKeyPhraseCheckVersion(m MetaContext, passphrase string) (ret PaperKeyPhrase, err error) {
 	paperPhrase := NewPaperKeyPhrase(passphrase)
 	version, err := paperPhrase.Version()
 	if err != nil {
 		return ret, err
 	}
 	if version != PaperKeyVersion {
-		g.Log.Debug("paper version mismatch: generated paper key version = %d, libkb version = %d", version, PaperKeyVersion)
+		m.CDebugf("paper version mismatch: generated paper key version = %d, libkb version = %d", version, PaperKeyVersion)
 		return ret, KeyVersionError{}
 	}
 	return paperPhrase, nil

--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -12,7 +12,6 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
 	"golang.org/x/crypto/nacl/secretbox"
-	context "golang.org/x/net/context"
 )
 
 const PerUserKeySeedSize = 32
@@ -203,7 +202,7 @@ func (s *PerUserKeyring) GetUID() keybase1.UID {
 
 // PrepareBoxForNewDevice encrypts the latest shared key seed for a new device.
 // The returned box should be pushed to the server.
-func (s *PerUserKeyring) PrepareBoxForNewDevice(ctx context.Context, receiverKey NaclDHKeyPair,
+func (s *PerUserKeyring) PrepareBoxForNewDevice(m MetaContext, receiverKey NaclDHKeyPair,
 	senderKey NaclDHKeyPair) (box keybase1.PerUserKeyBox, err error) {
 	s.Lock()
 	defer s.Unlock()
@@ -223,7 +222,7 @@ func (s *PerUserKeyring) PrepareBoxForNewDevice(ctx context.Context, receiverKey
 // Encrypt seed for receiverKeys. Use senderKey to encrypt.
 // Does not use the keyring at all. Attached for organizational purposes.
 // Used when creating a new seed.
-func (s *PerUserKeyring) PrepareBoxesForDevices(ctx context.Context, contents PerUserKeySeed,
+func (s *PerUserKeyring) PrepareBoxesForDevices(m MetaContext, contents PerUserKeySeed,
 	generation keybase1.PerUserKeyGeneration, receiverKeys []NaclDHKeyPair,
 	senderKey GenericKey) (boxes []keybase1.PerUserKeyBox, err error) {
 	// Do not lock self because we do not use self.
@@ -250,7 +249,7 @@ func (s *PerUserKeyring) PrepareBoxesForDevices(ctx context.Context, contents Pe
 // Prepares a prev secretbox containing generation n-1 encrypted for generation n.
 // Asserts that the current generation is n-1.
 // The `generation` parameter is n.
-func (s *PerUserKeyring) PreparePrev(ctx context.Context, newSeed PerUserKeySeed,
+func (s *PerUserKeyring) PreparePrev(m MetaContext, newSeed PerUserKeySeed,
 	newGeneration keybase1.PerUserKeyGeneration) (PerUserKeyPrev, error) {
 	s.Lock()
 	defer s.Unlock()
@@ -278,11 +277,11 @@ func (s *PerUserKeyring) PreparePrev(ctx context.Context, newSeed PerUserKeySeed
 }
 
 // AddKey registers a full key locally.
-func (s *PerUserKeyring) AddKey(ctx context.Context, generation keybase1.PerUserKeyGeneration,
+func (s *PerUserKeyring) AddKey(m MetaContext, generation keybase1.PerUserKeyGeneration,
 	seqno keybase1.Seqno, seed PerUserKeySeed) error {
 	s.Lock()
 	defer s.Unlock()
-	s.G().Log.CDebugf(ctx, "PerUserKeyring#AddKey(generation: %v, seqno:%v)", generation, seqno)
+	m.CDebugf("PerUserKeyring#AddKey(generation: %v, seqno:%v)", generation, seqno)
 
 	if seed.IsBlank() {
 		return errors.New("attempt to add blank per-user-key")
@@ -327,7 +326,7 @@ func (s *PerUserKeyring) currentGenerationLocked() keybase1.PerUserKeyGeneration
 	return keybase1.PerUserKeyGeneration(len(s.generations))
 }
 
-func (s *PerUserKeyring) GetLatestSigningKey(ctx context.Context) (*NaclSigningKeyPair, error) {
+func (s *PerUserKeyring) GetLatestSigningKey(m MetaContext) (*NaclSigningKeyPair, error) {
 	s.Lock()
 	defer s.Unlock()
 	gen := s.currentGenerationLocked()
@@ -341,7 +340,7 @@ func (s *PerUserKeyring) GetLatestSigningKey(ctx context.Context) (*NaclSigningK
 	return key.sigKey, nil
 }
 
-func (s *PerUserKeyring) GetSeedByGeneration(ctx context.Context, gen keybase1.PerUserKeyGeneration) (res PerUserKeySeed, err error) {
+func (s *PerUserKeyring) GetSeedByGeneration(m MetaContext, gen keybase1.PerUserKeyGeneration) (res PerUserKeySeed, err error) {
 	s.Lock()
 	defer s.Unlock()
 	if gen < 1 {
@@ -357,26 +356,26 @@ func (s *PerUserKeyring) GetSeedByGeneration(ctx context.Context, gen keybase1.P
 	return key.seed, nil
 }
 
-func (s *PerUserKeyring) GetSeedByGenerationOrSync(ctx context.Context, gen keybase1.PerUserKeyGeneration) (res PerUserKeySeed, err error) {
-	if seed, err := s.GetSeedByGeneration(ctx, gen); err == nil {
+func (s *PerUserKeyring) GetSeedByGenerationOrSync(m MetaContext, gen keybase1.PerUserKeyGeneration) (res PerUserKeySeed, err error) {
+	if seed, err := s.GetSeedByGeneration(m, gen); err == nil {
 		return seed, nil
 	}
 	// Generation was not available, try to sync.
-	if err := s.Sync(ctx); err != nil {
+	if err := s.Sync(m); err != nil {
 		return res, err
 	}
-	return s.GetSeedByGeneration(ctx, gen)
+	return s.GetSeedByGeneration(m, gen)
 }
 
 // Get the encryption key of a generation.
-func (s *PerUserKeyring) GetEncryptionKeyByGeneration(ctx context.Context, gen keybase1.PerUserKeyGeneration) (*NaclDHKeyPair, error) {
+func (s *PerUserKeyring) GetEncryptionKeyByGeneration(m MetaContext, gen keybase1.PerUserKeyGeneration) (*NaclDHKeyPair, error) {
 	s.Lock()
 	defer s.Unlock()
 
-	return s.getEncryptionKeyByGenerationLocked(ctx, gen)
+	return s.getEncryptionKeyByGenerationLocked(m, gen)
 }
 
-func (s *PerUserKeyring) getEncryptionKeyByGenerationLocked(ctx context.Context, gen keybase1.PerUserKeyGeneration) (*NaclDHKeyPair, error) {
+func (s *PerUserKeyring) getEncryptionKeyByGenerationLocked(m MetaContext, gen keybase1.PerUserKeyGeneration) (*NaclDHKeyPair, error) {
 	if gen < 1 {
 		return nil, fmt.Errorf("PerUserKeyring#GetEncryptionKey bad generation: %v", gen)
 	}
@@ -388,7 +387,7 @@ func (s *PerUserKeyring) getEncryptionKeyByGenerationLocked(ctx context.Context,
 }
 
 // Get the encryption key at the user sigchain seqno.
-func (s *PerUserKeyring) GetEncryptionKeyBySeqno(ctx context.Context, seqno keybase1.Seqno) (*NaclDHKeyPair, error) {
+func (s *PerUserKeyring) GetEncryptionKeyBySeqno(m MetaContext, seqno keybase1.Seqno) (*NaclDHKeyPair, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -396,22 +395,22 @@ func (s *PerUserKeyring) GetEncryptionKeyBySeqno(ctx context.Context, seqno keyb
 	if !ok {
 		return nil, fmt.Errorf("no encrypted key for seqno %v", seqno)
 	}
-	return s.getEncryptionKeyByGenerationLocked(ctx, gen)
+	return s.getEncryptionKeyByGenerationLocked(m, gen)
 }
 
-func (s *PerUserKeyring) GetEncryptionKeyBySeqnoOrSync(ctx context.Context, seqno keybase1.Seqno) (*NaclDHKeyPair, error) {
-	if key, err := s.GetEncryptionKeyBySeqno(ctx, seqno); err == nil {
+func (s *PerUserKeyring) GetEncryptionKeyBySeqnoOrSync(m MetaContext, seqno keybase1.Seqno) (*NaclDHKeyPair, error) {
+	if key, err := s.GetEncryptionKeyBySeqno(m, seqno); err == nil {
 		return key, nil
 	}
 	// Key at generation from seqno was not available, try to sync.
-	if err := s.Sync(ctx); err != nil {
+	if err := s.Sync(m); err != nil {
 		return nil, err
 	}
-	return s.GetEncryptionKeyBySeqno(ctx, seqno)
+	return s.GetEncryptionKeyBySeqno(m, seqno)
 }
 
 // GetEncryptionKeyByKID finds an encryption key that matches kid.
-func (s *PerUserKeyring) GetEncryptionKeyByKID(ctx context.Context, kid keybase1.KID) (*NaclDHKeyPair, error) {
+func (s *PerUserKeyring) GetEncryptionKeyByKID(m MetaContext, kid keybase1.KID) (*NaclDHKeyPair, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -426,29 +425,29 @@ func (s *PerUserKeyring) GetEncryptionKeyByKID(ctx context.Context, kid keybase1
 // Sync our PerUserKeyring with the server. It will either add all new
 // keys since our last update, or not at all if there was an error.
 // Pass it a standard Go network context.
-func (s *PerUserKeyring) Sync(ctx context.Context) (err error) {
-	return s.syncAsConfiguredDevice(ctx, nil, nil)
+func (s *PerUserKeyring) Sync(m MetaContext) (err error) {
+	return s.syncAsConfiguredDevice(m, nil)
 }
 
-// `lctx` and `upak` are optional
-func (s *PerUserKeyring) SyncWithExtras(ctx context.Context, lctx LoginContext, upak *keybase1.UserPlusAllKeys) (err error) {
-	return s.syncAsConfiguredDevice(ctx, lctx, upak)
+// `m.LoginContext` and `upak` are optional
+func (s *PerUserKeyring) SyncWithExtras(m MetaContext, upak *keybase1.UserPlusAllKeys) (err error) {
+	return s.syncAsConfiguredDevice(m, upak)
 }
 
-// `lctx` and `upak` are optional
-func (s *PerUserKeyring) syncAsConfiguredDevice(ctx context.Context, lctx LoginContext, upak *keybase1.UserPlusAllKeys) (err error) {
-	uid, deviceID, _, _, activeDecryptionKey := s.G().ActiveDevice.AllFields()
+// `m.LoginContext` and `upak` are optional
+func (s *PerUserKeyring) syncAsConfiguredDevice(m MetaContext, upak *keybase1.UserPlusAllKeys) (err error) {
+	uid, deviceID, _, _, activeDecryptionKey := m.ActiveDevice().AllFields()
 	if !s.uid.Equal(uid) {
 		return fmt.Errorf("UID changed on PerUserKeyring")
 	}
 	if deviceID.IsNil() {
 		return fmt.Errorf("missing configured deviceID")
 	}
-	return s.sync(ctx, lctx, upak, deviceID, activeDecryptionKey)
+	return s.sync(m, upak, deviceID, activeDecryptionKey)
 }
 
-// `lctx` and `upak` are optional
-func (s *PerUserKeyring) SyncAsPaperKey(ctx context.Context, lctx LoginContext, upak *keybase1.UserPlusAllKeys, deviceID keybase1.DeviceID, decryptionKey GenericKey) (err error) {
+// `m.LoginContext` and `upak` are optional
+func (s *PerUserKeyring) SyncAsPaperKey(m MetaContext, upak *keybase1.UserPlusAllKeys, deviceID keybase1.DeviceID, decryptionKey GenericKey) (err error) {
 	if deviceID.IsNil() {
 		return fmt.Errorf("missing deviceID")
 	}
@@ -456,32 +455,32 @@ func (s *PerUserKeyring) SyncAsPaperKey(ctx context.Context, lctx LoginContext, 
 	if decryptionKey == nil {
 		return fmt.Errorf("missing decryption key")
 	}
-	return s.sync(ctx, lctx, upak, deviceID, decryptionKey)
+	return s.sync(m, upak, deviceID, decryptionKey)
 }
 
-// `lctx` and `upak` are optional
-func (s *PerUserKeyring) sync(ctx context.Context, lctx LoginContext, upak *keybase1.UserPlusAllKeys, deviceID keybase1.DeviceID, decryptionKey GenericKey) (err error) {
-	defer s.G().CTrace(ctx, "PerUserKeyring#sync", func() error { return err })()
+// `m.LoginContext` and `upak` are optional
+func (s *PerUserKeyring) sync(m MetaContext, upak *keybase1.UserPlusAllKeys, deviceID keybase1.DeviceID, decryptionKey GenericKey) (err error) {
+	defer m.CTrace("PerUserKeyring#sync", func() error { return err })()
 
-	s.G().Log.CDebugf(ctx, "PerUserKeyring#sync(%v, %v)", lctx != nil, upak != nil)
+	m.CDebugf("PerUserKeyring#sync(%v, %v)", m.LoginContext() != nil, upak != nil)
 
 	s.Lock()
 	defer s.Unlock()
 
-	box, prevs, err := s.fetchBoxesLocked(ctx, lctx, deviceID)
+	box, prevs, err := s.fetchBoxesLocked(m, deviceID)
 	if err != nil {
 		return err
 	}
 
 	if upak == nil {
-		upak, err = s.getUPAK(ctx, lctx, upak)
+		upak, err = s.getUPAK(m, upak)
 		if err != nil {
 			return err
 		}
 	}
 
 	checker := newPerUserKeyChecker(upak)
-	newKeys, err := s.importLocked(ctx, box, prevs, decryptionKey, checker)
+	newKeys, err := s.importLocked(m, box, prevs, decryptionKey, checker)
 	if err != nil {
 		return err
 
@@ -490,12 +489,12 @@ func (s *PerUserKeyring) sync(ctx context.Context, lctx LoginContext, upak *keyb
 	return nil
 }
 
-func (s *PerUserKeyring) getUPAK(ctx context.Context, lctx LoginContext, upak *keybase1.UserPlusAllKeys) (*keybase1.UserPlusAllKeys, error) {
+func (s *PerUserKeyring) getUPAK(m MetaContext, upak *keybase1.UserPlusAllKeys) (*keybase1.UserPlusAllKeys, error) {
 	if upak != nil {
 		return upak, nil
 	}
-	upakArg := NewLoadUserByUIDArg(ctx, s.G(), s.uid).WithLoginContext(lctx)
-	upak, _, err := s.G().GetUPAKLoader().Load(upakArg)
+	upakArg := NewLoadUserArgWithMetaContext(m).WithUID(s.uid)
+	upak, _, err := m.G().GetUPAKLoader().Load(upakArg)
 	return upak, err
 }
 
@@ -528,18 +527,18 @@ func (m byGeneration) Len() int           { return len(m) }
 func (m byGeneration) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 func (m byGeneration) Less(i, j int) bool { return m[i].Generation < m[j].Generation }
 
-func (s *PerUserKeyring) fetchBoxesLocked(ctx context.Context, lctx LoginContext,
+func (s *PerUserKeyring) fetchBoxesLocked(m MetaContext,
 	deviceID keybase1.DeviceID) (box *keybase1.PerUserKeyBox, prevs []perUserKeyPrevResp, err error) {
 
-	defer s.G().CTrace(ctx, "PerUserKeyring#fetchBoxesLocked", func() error { return err })()
+	defer m.CTrace("PerUserKeyring#fetchBoxesLocked", func() error { return err })()
 
 	var sessionR SessionReader
-	if lctx != nil {
+	if lctx := m.LoginContext(); lctx != nil {
 		sessionR = lctx.LocalSession()
 	}
 
 	var resp perUserKeySyncResp
-	err = s.G().API.GetDecode(APIArg{
+	err = m.G().API.GetDecode(APIArg{
 		Endpoint: "key/fetch_per_user_key_secrets",
 		Args: HTTPArgs{
 			"generation": I{int(s.currentGenerationLocked())},
@@ -548,12 +547,12 @@ func (s *PerUserKeyring) fetchBoxesLocked(ctx context.Context, lctx LoginContext
 		SessionType: APISessionTypeREQUIRED,
 		SessionR:    sessionR,
 		RetryCount:  5, // It's pretty bad to fail this, so retry.
-		NetContext:  ctx,
+		NetContext:  m.Ctx(),
 	}, &resp)
 	if err != nil {
 		return nil, nil, err
 	}
-	s.G().Log.CDebugf(ctx, "| Got back box:%v and prevs:%d from server", resp.Box != nil, len(resp.Prevs))
+	m.CDebugf("| Got back box:%v and prevs:%d from server", resp.Box != nil, len(resp.Prevs))
 
 	return resp.Box, resp.Prevs, nil
 }
@@ -628,11 +627,11 @@ func (c *perUserKeyChecker) checkPublic(key importedPerUserKey, generation keyba
 	return nil
 }
 
-func (s *PerUserKeyring) importLocked(ctx context.Context,
+func (s *PerUserKeyring) importLocked(m MetaContext,
 	box *keybase1.PerUserKeyBox, prevs []perUserKeyPrevResp,
 	decryptionKey GenericKey, checker *perUserKeyChecker) (ret perUserKeyMap, err error) {
 
-	defer s.G().CTrace(ctx, "PerUserKeyring#importLocked", func() error { return err })()
+	defer m.CTrace("PerUserKeyring#importLocked", func() error { return err })()
 
 	if box == nil && len(prevs) == 0 {
 		// No new stuff, this keyring is up to date.
@@ -654,7 +653,7 @@ func (s *PerUserKeyring) importLocked(ctx context.Context,
 		debugPrevGenList = append(debugPrevGenList, fmt.Sprintf("%d", prev.Generation))
 	}
 	if len(debugPrevGenList) > 0 {
-		s.G().Log.CDebugf(ctx, "PerUserKeyring#importLocked prevs:(%s)", strings.Join(debugPrevGenList, ","))
+		m.CDebugf("PerUserKeyring#importLocked prevs:(%s)", strings.Join(debugPrevGenList, ","))
 	}
 
 	ret = make(perUserKeyMap)

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -707,9 +707,9 @@ func (k *PGPKeyBundle) unlockAllPrivateKeys(pw string) error {
 	return nil
 }
 
-func (k *PGPKeyBundle) Unlock(g *GlobalContext, reason string, secretUI SecretUI) error {
+func (k *PGPKeyBundle) Unlock(m MetaContext, reason string, secretUI SecretUI) error {
 	if !k.isAnyKeyEncrypted() {
-		g.Log.Debug("Key is not encrypted, skipping Unlock.")
+		m.CDebugf("Key is not encrypted, skipping Unlock.")
 		return nil
 	}
 
@@ -720,7 +720,7 @@ func (k *PGPKeyBundle) Unlock(g *GlobalContext, reason string, secretUI SecretUI
 		return k, nil
 	}
 
-	_, err := NewKeyUnlocker(g, 5, reason, k.VerboseDescription(), PassphraseTypePGP, false, secretUI, unlocker).Run()
+	_, err := NewKeyUnlocker(5, reason, k.VerboseDescription(), PassphraseTypePGP, false, secretUI, unlocker).Run(m)
 	return err
 }
 

--- a/go/libkb/skb_test.go
+++ b/go/libkb/skb_test.go
@@ -88,7 +88,7 @@ func makeTestSKB(t *testing.T, lks *LKSec, g *GlobalContext) *SKB {
 		t.Fatal(err)
 	}
 
-	skb, err := lks.ToSKB(NewGeneratedPGPKeyBundle(entity))
+	skb, err := lks.ToSKB(NewMetaContextTODO(g), NewGeneratedPGPKeyBundle(entity))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func testPromptAndUnlock(t *testing.T, skb *SKB) {
 	if ss == nil {
 		t.Fatal("NewSecretStore returned nil")
 	}
-	key, err := skb.PromptAndUnlock(parg, ss, nil)
+	key, err := skb.PromptAndUnlock(NewMetaContextTODO(skb.G()), parg, ss, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestBasicSecretStore(t *testing.T) {
 	defer tc.Cleanup()
 
 	lks := makeTestLKSec(t, tc.G)
-	expectedSecret, err := lks.GetSecret(nil)
+	expectedSecret, err := lks.GetSecret(NewMetaContextTODO(tc.G))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestCorruptSecretStore(t *testing.T) {
 	defer tc.Cleanup()
 
 	lks := makeTestLKSec(t, tc.G)
-	expectedSecret, err := lks.GetSecret(nil)
+	expectedSecret, err := lks.GetSecret(NewMetaContextTODO(tc.G))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +268,7 @@ func TestPromptCancelCache(t *testing.T) {
 		Reason:   "test reason",
 		SecretUI: &TestSecretUI{Passphrase: "passphrase"},
 	}
-	key, err := skb.PromptAndUnlock(parg, NewSecretStore(tc.G, "testusername"), nil)
+	key, err := skb.PromptAndUnlock(NewMetaContextTODO(tc.G), parg, NewSecretStore(tc.G, "testusername"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +283,7 @@ func testErrUnlock(t *testing.T, skb *SKB, ui *TestCancelSecretUI) error {
 		SecretUI:       ui,
 		UseCancelCache: true,
 	}
-	key, err := skb.PromptAndUnlock(parg, NewSecretStore(skb.G(), "testusername"), nil)
+	key, err := skb.PromptAndUnlock(NewMetaContextTODO(skb.G()), parg, NewSecretStore(skb.G(), "testusername"), nil)
 	if err == nil {
 		t.Fatal("PromptAndUnlock returned nil error")
 	}

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -505,3 +505,7 @@ func (t TestUIDMapper) MapUIDsToUsernamePackages(ctx context.Context, g UIDMappe
 func (t TestUIDMapper) SetTestingNoCachingMode(enabled bool) {
 
 }
+
+func NewMetaContextForTest(tc TestContext) MetaContext {
+	return NewMetaContext(context.TODO(), tc.G)
+}

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -349,8 +349,8 @@ func (u *User) StoreTopLevel(ctx context.Context) error {
 	return err
 }
 
-func (u *User) SyncedSecretKey(lctx LoginContext) (ret *SKB, err error) {
-	if lctx != nil {
+func (u *User) SyncedSecretKey(m MetaContext) (ret *SKB, err error) {
+	if lctx := m.LoginContext(); lctx != nil {
 		return u.getSyncedSecretKeyLogin(lctx)
 	}
 	return u.GetSyncedSecretKey()
@@ -715,7 +715,7 @@ func (u *User) SigningKeyPub() (GenericKey, error) {
 		Me:      u,
 		KeyType: DeviceSigningKeyType,
 	}
-	lockedKey, err := u.G().Keyrings.GetSecretKeyLocked(nil, arg)
+	lockedKey, err := u.G().Keyrings.GetSecretKeyLocked(NewMetaContextTODO(u.G()), arg)
 	if err != nil {
 		return nil, err
 	}

--- a/go/service/crypto.go
+++ b/go/service/crypto.go
@@ -87,5 +87,5 @@ func (c *CryptoHandler) UnboxBytes32(ctx context.Context, arg keybase1.UnboxByte
 }
 
 func (c *CryptoHandler) UnboxBytes32Any(ctx context.Context, arg keybase1.UnboxBytes32AnyArg) (keybase1.UnboxAnyRes, error) {
-	return engine.UnboxBytes32Any(ctx, c.G(), c.secretUIMaker(arg.SessionID, arg.Reason), arg)
+	return engine.UnboxBytes32Any(libkb.NewMetaContext(ctx, c.G()), c.secretUIMaker(arg.SessionID, arg.Reason), arg)
 }

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -235,7 +235,7 @@ func (h *UserHandler) ResetUser(ctx context.Context, sessionID int) error {
 	if h.G().Env.GetRunMode() != libkb.DevelRunMode {
 		return errors.New("can only reset user via service RPC in dev mode")
 	}
-	err := h.G().LoginState().ResetAccount(h.G().Env.GetUsername().String())
+	err := h.G().LoginState().ResetAccount(libkb.NewMetaContext(ctx, h.G()), h.G().Env.GetUsername().String())
 	if err != nil {
 		return err
 	}

--- a/go/stellar/note.go
+++ b/go/stellar/note.go
@@ -89,7 +89,8 @@ func noteSymmetricKeyForDecryption(ctx context.Context, g *libkb.GlobalContext, 
 	if err != nil {
 		return res, err
 	}
-	pukSeed, err := pukring.GetSeedByGenerationOrSync(ctx, mePukGen)
+	m := libkb.NewMetaContext(ctx, g)
+	pukSeed, err := pukring.GetSeedByGenerationOrSync(m, mePukGen)
 	if err != nil {
 		return res, err
 	}

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -140,12 +140,13 @@ func getLatestPuk(ctx context.Context, g *libkb.GlobalContext) (pukGen keybase1.
 	if err != nil {
 		return pukGen, pukSeed, err
 	}
-	err = pukring.Sync(ctx)
+	m := libkb.NewMetaContext(ctx, g)
+	err = pukring.Sync(m)
 	if err != nil {
 		return pukGen, pukSeed, err
 	}
 	pukGen = pukring.CurrentGeneration()
-	pukSeed, err = pukring.GetSeedByGeneration(ctx, pukGen)
+	pukSeed, err = pukring.GetSeedByGeneration(m, pukGen)
 	return pukGen, pukSeed, err
 }
 
@@ -181,7 +182,8 @@ func Fetch(ctx context.Context, g *libkb.GlobalContext) (res stellar1.Bundle, pu
 	if err != nil {
 		return res, 0, err
 	}
-	puk, err := pukring.GetSeedByGenerationOrSync(ctx, decodeRes.Enc.Gen)
+	m := libkb.NewMetaContext(ctx, g)
+	puk, err := pukring.GetSeedByGenerationOrSync(m, decodeRes.Enc.Gen)
 	if err != nil {
 		return res, 0, err
 	}

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -77,7 +77,7 @@ func Upkeep(ctx context.Context, g *libkb.GlobalContext) (err error) {
 	if err != nil {
 		return err
 	}
-	err = pukring.Sync(ctx)
+	err = pukring.Sync(libkb.NewMetaContext(ctx, g))
 	if err != nil {
 		return err
 	}

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -69,9 +69,11 @@ func (s *Server) ExportSecretKeyLocal(ctx context.Context, accountID stellar1.Ac
 		return res, err
 	}
 
+	mctx := libkb.NewMetaContext(ctx, s.G())
+
 	// Prompt for passphrase
 	username := s.G().GetEnv().GetUsername().String()
-	arg := libkb.DefaultPassphrasePromptArg(s.G(), username)
+	arg := libkb.DefaultPassphrasePromptArg(mctx, username)
 	arg.Prompt = arg.Prompt + " to export Stellar secret keys"
 	secretUI := s.uiSource.SecretUI(s.G(), 0)
 	ppRes, err := secretUI.GetPassphrase(arg, nil)
@@ -79,7 +81,7 @@ func (s *Server) ExportSecretKeyLocal(ctx context.Context, accountID stellar1.Ac
 		return res, err
 	}
 	pwdOk := false
-	_, err = s.G().LoginState().VerifyPlaintextPassphrase(ppRes.Passphrase, func(lctx libkb.LoginContext) error {
+	_, err = s.G().LoginState().VerifyPlaintextPassphrase(mctx, ppRes.Passphrase, func(lctx libkb.LoginContext) error {
 		pwdOk = true
 		return nil
 	})

--- a/go/stellar/stellarsvc/service_devel.go
+++ b/go/stellar/stellarsvc/service_devel.go
@@ -27,18 +27,19 @@ func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.Bundle, err
 	if err != nil {
 		return dump, err
 	}
+	mctx := libkb.NewMetaContext(ctx, s.G())
 
 	// verify passphrase
 	username := s.G().GetEnv().GetUsername().String()
 
-	arg := libkb.DefaultPassphrasePromptArg(s.G(), username)
+	arg := libkb.DefaultPassphrasePromptArg(mctx, username)
 	secretUI := s.uiSource.SecretUI(s.G(), 0)
 	res, err := secretUI.GetPassphrase(arg, nil)
 	if err != nil {
 		return dump, err
 	}
 	pwdOk := false
-	_, err = s.G().LoginState().VerifyPlaintextPassphrase(res.Passphrase, func(lctx libkb.LoginContext) error {
+	_, err = s.G().LoginState().VerifyPlaintextPassphrase(mctx, res.Passphrase, func(lctx libkb.LoginContext) error {
 		pwdOk = true
 
 		return nil

--- a/go/stellar/util.go
+++ b/go/stellar/util.go
@@ -47,11 +47,12 @@ func loadOwnLatestPuk(ctx context.Context, g *libkb.GlobalContext) (gen keybase1
 	if err != nil {
 		return 0, seed, err
 	}
-	err = pukring.Sync(ctx)
+	m := libkb.NewMetaContext(ctx, g)
+	err = pukring.Sync(m)
 	if err != nil {
 		return 0, seed, err
 	}
 	gen = pukring.CurrentGeneration()
-	seed, err = pukring.GetSeedByGeneration(ctx, gen)
+	seed, err = pukring.GetSeedByGeneration(m, gen)
 	return gen, seed, err
 }

--- a/go/systests/passphrase_test.go
+++ b/go/systests/passphrase_test.go
@@ -49,7 +49,8 @@ func TestPassphraseChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := tc.G.LoginState().VerifyPlaintextPassphrase(userInfo.passphrase, nil); err != nil {
+	m := libkb.NewMetaContextForTest(*tc)
+	if _, err := tc.G.LoginState().VerifyPlaintextPassphrase(m, userInfo.passphrase, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -62,11 +63,11 @@ func TestPassphraseChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := tc.G.LoginState().VerifyPlaintextPassphrase(newPassphrase, nil); err != nil {
+	if _, err := tc.G.LoginState().VerifyPlaintextPassphrase(m, newPassphrase, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := tc.G.LoginState().VerifyPlaintextPassphrase(oldPassphrase, nil); err == nil {
+	if _, err := tc.G.LoginState().VerifyPlaintextPassphrase(m, oldPassphrase, nil); err == nil {
 		t.Fatal("old passphrase passed verification after passphrase change")
 	}
 
@@ -163,8 +164,10 @@ func TestPassphraseRecover(t *testing.T) {
 	require.NoError(t, err)
 	tcClient = nil
 
+	m1 := libkb.NewMetaContextForTest(*tc1)
+
 	t.Logf("Verify on tc1")
-	_, err = tc1.G.LoginState().VerifyPlaintextPassphrase(userInfo.passphrase, nil)
+	_, err = tc1.G.LoginState().VerifyPlaintextPassphrase(m1, userInfo.passphrase, nil)
 	require.NoError(t, err)
 
 	oldPassphrase := userInfo.passphrase
@@ -189,15 +192,16 @@ func TestPassphraseRecover(t *testing.T) {
 	tcClient = nil
 
 	t.Logf("Verify new passphrase on tc2")
-	_, err = tc2.G.LoginState().VerifyPlaintextPassphrase(newPassphrase, nil)
+	m2 := libkb.NewMetaContextForTest(*tc2)
+	_, err = tc2.G.LoginState().VerifyPlaintextPassphrase(m2, newPassphrase, nil)
 	require.NoError(t, err)
 
 	t.Logf("Verify new passphrase on tc1")
-	_, err = tc2.G.LoginState().VerifyPlaintextPassphrase(newPassphrase, nil)
+	_, err = tc2.G.LoginState().VerifyPlaintextPassphrase(m2, newPassphrase, nil)
 	require.NoError(t, err)
 
 	t.Logf("Verify old passphrase on tc1")
-	_, err = tc1.G.LoginState().VerifyPlaintextPassphrase(oldPassphrase, nil)
+	_, err = tc1.G.LoginState().VerifyPlaintextPassphrase(m2, oldPassphrase, nil)
 	require.Error(t, err, "old passphrase passed verification after passphrase change")
 
 	t.Logf("Stop tc1")

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -36,6 +36,10 @@ type LoaderContextG struct {
 	libkb.Contextified
 }
 
+func (l *LoaderContextG) NewMetaContext(ctx context.Context) libkb.MetaContext {
+	return libkb.NewMetaContext(ctx, l.G())
+}
+
 var _ LoaderContext = (*LoaderContextG)(nil)
 
 func NewLoaderContextFromG(g *libkb.GlobalContext) LoaderContext {
@@ -137,7 +141,7 @@ func (l *LoaderContextG) perUserEncryptionKey(ctx context.Context, userSeqno key
 	if err != nil {
 		return nil, err
 	}
-	return kr.GetEncryptionKeyBySeqnoOrSync(ctx, userSeqno)
+	return kr.GetEncryptionKeyBySeqnoOrSync(l.NewMetaContext(ctx), userSeqno)
 }
 
 func (l *LoaderContextG) merkleLookup(ctx context.Context, teamID keybase1.TeamID, public bool) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error) {


### PR DESCRIPTION
- This is the first refactor (of maybe many) to try to standardize our use of contexts passed accross functions
- The main goal was to migrate those functions that take a LoginContext as a parameter and migrate them over
  to MetaContext instead, which can have a LoginContext in addition to other thread-local and global context.
- Migrate ActiveDevice, PerUserKey to the new MetaContext system
- Make light changes to engine/ but leave some more work TODO, like pushing engine.Context into libkb.MetaContext
- Document what's going on in context.md
- All code compiles and tests