### PR TITLE
Fix deleting attachments

### DIFF
--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -573,6 +573,7 @@ export const upgradeMessage = (old: Types.Message, m: Types.Message) => {
   if (old.type === 'attachment' && m.type === 'attachment') {
     // $ForceType
     return m.withMutations((ret: Types.MessageAttachment) => {
+      ret.set('id', old.id)
       ret.set('ordinal', old.ordinal)
       ret.set('downloadPath', old.downloadPath)
       if (old.previewURL && !m.previewURL) {


### PR DESCRIPTION
This fixes deleting attachments by holding on to the first message ID in place of the second one. This means we never hold the second ID. This fixes the issue, and I imagine this might have been how it worked before the refactor. @chrisnojima or @mmaxim should probably look this over. r? @keybase/react-hackers 