### PR TITLE
Generate stellar relay transfer for recipients without wallets

### DIFF
--- a/go/client/cmd_wallet_import.go
+++ b/go/client/cmd_wallet_import.go
@@ -98,7 +98,8 @@ func (c *cmdWalletImport) promptSecretKey() (stellar1.SecretKey, stellar1.Accoun
 	if len(secStr) == 0 {
 		return "", "", libkb.InputCanceledError{}
 	}
-	return libkb.ParseStellarSecretKey(secStr)
+	secKey, accountID, _, err := libkb.ParseStellarSecretKey(secStr)
+	return secKey, accountID, err
 }
 
 func (c *cmdWalletImport) confirm(accountID stellar1.AccountID) error {

--- a/go/engine/wallet_init_background.go
+++ b/go/engine/wallet_init_background.go
@@ -90,17 +90,17 @@ func (e *WalletInitBackground) Shutdown() {
 
 func WalletInitBackgroundRound(g *libkb.GlobalContext, ectx *Context) error {
 	if g.ConnectivityMonitor.IsConnected(ectx.GetNetContext()) == libkb.ConnectivityMonitorNo {
-		g.Log.CDebugf(ectx.GetNetContext(), "WalletInitBackgroundRound giving up offline")
+		g.Log.CDebugf(ectx.GetNetContext(), "WalletInitBackground giving up offline")
 		return nil
 	}
 
 	if !g.ActiveDevice.Valid() {
-		g.Log.CDebugf(ectx.GetNetContext(), "WalletInitBackgroundRound not logged in")
+		g.Log.CDebugf(ectx.GetNetContext(), "WalletInitBackground not logged in")
 		return nil
 	}
 
-	if !g.LocalSigchainGuard().IsAvailable(ectx.GetNetContext(), "WalletInitBackgroundRound") {
-		g.Log.CDebugf(ectx.GetNetContext(), "WalletInitBackgroundRound yielding to guard")
+	if !g.LocalSigchainGuard().IsAvailable(ectx.GetNetContext(), "WalletInitBackground") {
+		g.Log.CDebugf(ectx.GetNetContext(), "WalletInitBackground yielding to guard")
 		return nil
 	}
 

--- a/go/git/crypto.go
+++ b/go/git/crypto.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"crypto/rand"
 	"fmt"
 
 	"golang.org/x/crypto/nacl/secretbox"
@@ -56,14 +55,13 @@ func (c *Crypto) Box(ctx context.Context, plaintext []byte, teamSpec keybase1.Te
 		}
 	}
 
-	var nonce keybase1.BoxNonce
-	if _, err := rand.Read(nonce[:]); err != nil {
+	nonce, err := libkb.RandomNaclDHNonce()
+	if err != nil {
 		return nil, err
 	}
 
 	var encKey [libkb.NaclSecretBoxKeySize]byte = key.Key
-	var naclNonce [libkb.NaclDHNonceSize]byte = nonce
-	sealed := secretbox.Seal(nil, plaintext, &naclNonce, &encKey)
+	sealed := secretbox.Seal(nil, plaintext, &nonce, &encKey)
 
 	return &keybase1.EncryptedGitMetadata{
 		V:   libkb.CurrentGitMetadataEncryptionVersion,

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -102,6 +102,9 @@ func (p CommandLine) GetVDebugSetting() string {
 func (p CommandLine) GetUpgradePerUserKey() (bool, bool) {
 	return p.GetBool("upgrade-per-user-key", true)
 }
+func (p CommandLine) GetAutoWallet() (bool, bool) {
+	return p.GetBool("auto-wallet", true)
+}
 func (p CommandLine) GetPGPFingerprint() *libkb.PGPFingerprint {
 	return libkb.PGPFingerprintFromHexNoError(p.GetGString("fingerprint"))
 }

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -117,6 +117,10 @@ func (f JSONConfigFile) GetUpgradePerUserKey() (bool, bool) {
 	return false, false
 }
 
+func (f JSONConfigFile) GetAutoWallet() (bool, bool) {
+	return false, false
+}
+
 func (f JSONConfigFile) GetTopLevelString(s string) (ret string) {
 	var e error
 	f.jw.AtKey(s).GetStringVoid(&ret, &e)

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -657,6 +657,7 @@ const (
 	TeamPrevKeySecretBoxDerivationString = "Keybase-Derived-Team-NaCl-SecretBox-1"
 	TeamGitMetadataDerivationString      = "Keybase-Derived-Team-NaCl-GitMetadata-1"
 	TeamSeitanTokenDerivationString      = "Keybase-Derived-Team-NaCl-SeitanInviteToken-1"
+	TeamStellarRelayDerivationString     = "Keybase-Derived-Team-NaCl-StellarRelay-1"
 )
 
 func CurrentSaltpackVersion() saltpack.Version {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -31,6 +31,7 @@ func (n NullConfiguration) GetPvlKitFilename() string                           
 func (n NullConfiguration) GetUsername() NormalizedUsername                                { return NormalizedUsername("") }
 func (n NullConfiguration) GetEmail() string                                               { return "" }
 func (n NullConfiguration) GetUpgradePerUserKey() (bool, bool)                             { return false, false }
+func (n NullConfiguration) GetAutoWallet() (bool, bool)                                    { return false, false }
 func (n NullConfiguration) GetProxy() string                                               { return "" }
 func (n NullConfiguration) GetGpgHome() string                                             { return "" }
 func (n NullConfiguration) GetBundledCA(h string) string                                   { return "" }
@@ -158,6 +159,7 @@ type TestParameters struct {
 	DevelName                string
 	RuntimeDir               string
 	DisableUpgradePerUserKey bool
+	DisableAutoWallet        bool
 
 	// set to true to use production run mode in tests
 	UseProductionRunMode bool
@@ -711,6 +713,11 @@ func (e *Env) GetEmail() string {
 // Upgrade sigchains to contain per-user-keys.
 func (e *Env) GetUpgradePerUserKey() bool {
 	return !e.Test.DisableUpgradePerUserKey
+}
+
+// Automatically create a wallet for the logged-in user.
+func (e *Env) GetAutoWallet() bool {
+	return !e.Test.DisableAutoWallet
 }
 
 // If true, do not logout after user.key_change notification handler

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -815,10 +815,19 @@ func (d DecryptWrongReceiverError) Error() string {
 	return "Bad receiver key"
 }
 
-type DecryptOpenError struct{}
+type DecryptOpenError struct {
+	What string
+}
+
+func NewDecryptOpenError(what string) DecryptOpenError {
+	return DecryptOpenError{What: what}
+}
 
 func (d DecryptOpenError) Error() string {
-	return "box.Open failure; ciphertext was corrupted or wrong key"
+	if len(d.What) == 0 {
+		return "box.Open failure; ciphertext was corrupted or wrong key"
+	}
+	return fmt.Sprintf("failed to decrypt '%s'; ciphertext was corrupted or wrong key", d.What)
 }
 
 //=============================================================================

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -41,6 +41,7 @@ type configGetter interface {
 	GetDbFilename() string
 	GetDebug() (bool, bool)
 	GetUpgradePerUserKey() (bool, bool)
+	GetAutoWallet() (bool, bool)
 	GetGpg() string
 	GetGpgHome() string
 	GetGpgOptions() []string

--- a/go/libkb/stellar.go
+++ b/go/libkb/stellar.go
@@ -36,26 +36,26 @@ func MakeNaclSigningKeyPairFromStellarSecretKey(sec stellar1.SecretKey) (res Nac
 
 // ParseStellarSecretKey parses a secret key and returns it and the AccountID it is the master key of.
 // Returns helpful error messages than can be shown to users.
-func ParseStellarSecretKey(secStr string) (stellar1.SecretKey, stellar1.AccountID, error) {
+func ParseStellarSecretKey(secStr string) (stellar1.SecretKey, stellar1.AccountID, *keypair.Full, error) {
 	secStr = strings.ToUpper(secStr)
 	if len(secStr) != 56 {
-		return "", "", fmt.Errorf("stellar secret key must be 56 chars long: was %v", len(secStr))
+		return "", "", nil, fmt.Errorf("stellar secret key must be 56 chars long: was %v", len(secStr))
 	}
 	_, err := base32.StdEncoding.DecodeString(secStr)
 	if err != nil {
-		return "", "", fmt.Errorf("invalid characters in stellar secret key")
+		return "", "", nil, fmt.Errorf("invalid characters in stellar secret key")
 	}
 	kp, err := keypair.Parse(secStr)
 	if err != nil {
-		return "", "", fmt.Errorf("invalid stellar secret key: %v", err)
+		return "", "", nil, fmt.Errorf("invalid stellar secret key: %v", err)
 	}
 	switch kp := kp.(type) {
 	case *keypair.FromAddress:
-		return "", "", errors.New("unexpected stellar account ID, expected secret key")
+		return "", "", nil, errors.New("unexpected stellar account ID, expected secret key")
 	case *keypair.Full:
-		return stellar1.SecretKey(kp.Seed()), stellar1.AccountID(kp.Address()), nil
+		return stellar1.SecretKey(kp.Seed()), stellar1.AccountID(kp.Address()), kp, nil
 	default:
-		return "", "", fmt.Errorf("invalid stellar secret key")
+		return "", "", nil, fmt.Errorf("invalid stellar secret key")
 	}
 }
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -8,6 +8,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/sha512"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -2412,4 +2413,9 @@ func (u AvatarUrl) String() string {
 
 func MakeAvatarURL(u string) AvatarUrl {
 	return AvatarUrl(u)
+}
+
+func (b Bytes32) IsBlank() bool {
+	var blank Bytes32
+	return (subtle.ConstantTimeCompare(b[:], blank[:]) == 1)
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -52,6 +52,7 @@ const (
 	TeamApplication_SALTPACK            TeamApplication = 3
 	TeamApplication_GIT_METADATA        TeamApplication = 4
 	TeamApplication_SEITAN_INVITE_TOKEN TeamApplication = 5
+	TeamApplication_STELLAR_RELAY       TeamApplication = 6
 )
 
 func (o TeamApplication) DeepCopy() TeamApplication { return o }
@@ -62,6 +63,7 @@ var TeamApplicationMap = map[string]TeamApplication{
 	"SALTPACK":            3,
 	"GIT_METADATA":        4,
 	"SEITAN_INVITE_TOKEN": 5,
+	"STELLAR_RELAY":       6,
 }
 
 var TeamApplicationRevMap = map[TeamApplication]string{
@@ -70,6 +72,7 @@ var TeamApplicationRevMap = map[TeamApplication]string{
 	3: "SALTPACK",
 	4: "GIT_METADATA",
 	5: "SEITAN_INVITE_TOKEN",
+	6: "STELLAR_RELAY",
 }
 
 func (e TeamApplication) String() string {

--- a/go/protocol/stellar1/common.go
+++ b/go/protocol/stellar1/common.go
@@ -181,6 +181,27 @@ func (o NoteContents) DeepCopy() NoteContents {
 	}
 }
 
+type EncryptedRelaySecret struct {
+	V   int                           `codec:"v" json:"v"`
+	E   []byte                        `codec:"e" json:"e"`
+	N   keybase1.BoxNonce             `codec:"n" json:"n"`
+	Gen keybase1.PerTeamKeyGeneration `codec:"gen" json:"gen"`
+}
+
+func (o EncryptedRelaySecret) DeepCopy() EncryptedRelaySecret {
+	return EncryptedRelaySecret{
+		V: o.V,
+		E: (func(x []byte) []byte {
+			if x == nil {
+				return nil
+			}
+			return append([]byte{}, x...)
+		})(o.E),
+		N:   o.N.DeepCopy(),
+		Gen: o.Gen.DeepCopy(),
+	}
+}
+
 type OutsideCurrencyCode string
 
 func (o OutsideCurrencyCode) DeepCopy() OutsideCurrencyCode {

--- a/go/protocol/stellar1/common.go
+++ b/go/protocol/stellar1/common.go
@@ -168,14 +168,12 @@ func (o NoteRecipient) DeepCopy() NoteRecipient {
 }
 
 type NoteContents struct {
-	Version   int           `codec:"version" json:"version"`
 	Note      string        `codec:"note" json:"note"`
 	StellarID TransactionID `codec:"stellarID" json:"stellarID"`
 }
 
 func (o NoteContents) DeepCopy() NoteContents {
 	return NoteContents{
-		Version:   o.Version,
 		Note:      o.Note,
 		StellarID: o.StellarID.DeepCopy(),
 	}
@@ -199,6 +197,20 @@ func (o EncryptedRelaySecret) DeepCopy() EncryptedRelaySecret {
 		})(o.E),
 		N:   o.N.DeepCopy(),
 		Gen: o.Gen.DeepCopy(),
+	}
+}
+
+type RelayContents struct {
+	StellarID TransactionID `codec:"stellarID" json:"stellarID"`
+	Sk        SecretKey     `codec:"sk" json:"sk"`
+	Note      string        `codec:"note" json:"note"`
+}
+
+func (o RelayContents) DeepCopy() RelayContents {
+	return RelayContents{
+		StellarID: o.StellarID.DeepCopy(),
+		Sk:        o.Sk.DeepCopy(),
+		Note:      o.Note,
 	}
 }
 

--- a/go/stellar/bundle/main.go
+++ b/go/stellar/bundle/main.go
@@ -42,7 +42,7 @@ func AddAccount(bundle *stellar1.Bundle, secretKey stellar1.SecretKey, name stri
 	if bundle == nil {
 		return fmt.Errorf("nil bundle")
 	}
-	secretKey, accountID, err := libkb.ParseStellarSecretKey(string(secretKey))
+	secretKey, accountID, _, err := libkb.ParseStellarSecretKey(string(secretKey))
 	if err != nil {
 		return err
 	}

--- a/go/stellar/note_test.go
+++ b/go/stellar/note_test.go
@@ -60,7 +60,6 @@ func randomSymmetricKey(t testing.TB) libkb.NaclSecretBoxKey {
 
 func sampleNote() stellar1.NoteContents {
 	return stellar1.NoteContents{
-		Version:   1,
 		Note:      "wizbang",
 		StellarID: stellar1.TransactionID("6653fc2fdbc42ad51ccbe77ee0a3c29e258a5513c62fdc532cbfff91ab101abf"),
 	}

--- a/go/stellar/relay.go
+++ b/go/stellar/relay.go
@@ -1,0 +1,123 @@
+package stellar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/keybase/client/go/stellar/remote"
+	"github.com/keybase/client/go/teams"
+	"github.com/keybase/stellarnet"
+	"github.com/stellar/go/build"
+	"github.com/stellar/go/keypair"
+	"golang.org/x/crypto/nacl/secretbox"
+)
+
+// Get the key used to encrypted the key for a relay transfer
+// A key from the implicit team betwen the logged-in user and `to`.
+// If `generation` is nil, gets the latest key.
+// TODO CORE-7718 make this private
+func KeyForRelayTransfer(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter,
+	other *libkb.User, generation *keybase1.PerTeamKeyGeneration) (res keybase1.TeamApplicationKey, err error) {
+	if other == nil {
+		return res, fmt.Errorf("missing other user")
+	}
+	meUsername, err := g.GetUPAKLoader().LookupUsername(ctx, g.ActiveDevice.UID())
+	if err != nil {
+		return res, err
+	}
+	impTeamDisplayName := fmt.Sprintf("%s,%s", meUsername.String(), other.GetNormalizedName().String())
+	team, _, _, err := teams.LookupOrCreateImplicitTeam(ctx, g, impTeamDisplayName, false /*public*/)
+	if err != nil {
+		return res, err
+	}
+	if generation == nil {
+		return team.ApplicationKey(ctx, keybase1.TeamApplication_STELLAR_RELAY)
+	}
+	return team.ApplicationKeyAtGeneration(keybase1.TeamApplication_STELLAR_RELAY, *generation)
+}
+
+// TODO CORE-7718 make this private
+type RelayPaymentInput struct {
+	From      stellar1.SecretKey
+	AmountXLM string
+	// Implicit-team key to encrypt for
+	EncryptFor    keybase1.TeamApplicationKey
+	SeqnoProvider build.SequenceProvider
+}
+
+// TODO CORE-7718 make this private
+type RelayPaymentOutput struct {
+	// Account ID of the shared account.
+	RelayAccountID stellar1.AccountID
+	// Encrypted box containing the secret key to the account.
+	EncryptedSeed stellar1.EncryptedRelaySecret
+	FundTx        stellarnet.SignResult
+}
+
+// createRelayTransfer generates a stellar account, encrypts its key, and signs a transaction funding it.
+// TODO CORE-7718 make this private
+func CreateRelayTransfer(in RelayPaymentInput) (res RelayPaymentOutput, err error) {
+	_, _, senderKp, err := libkb.ParseStellarSecretKey(string(in.From))
+	if err != nil {
+		return res, err
+	}
+	senderSeed, err := stellarnet.NewSeedStr(senderKp.Seed())
+	if err != nil {
+		return res, err
+	}
+	relayKp, err := keypair.Random()
+	if err != nil {
+		return res, err
+	}
+	relayAccountID, err := stellarnet.NewAddressStr(relayKp.Address())
+	if err != nil {
+		return res, err
+	}
+	sig, err := stellarnet.CreateAccountXLMTransaction(
+		senderSeed, relayAccountID, in.AmountXLM, in.SeqnoProvider)
+	if err != nil {
+		return res, err
+	}
+	encSeed, err := encryptRelaySecret(stellar1.SecretKey(relayKp.Seed()), in.EncryptFor)
+	return RelayPaymentOutput{
+		RelayAccountID: stellar1.AccountID(relayKp.Address()),
+		EncryptedSeed:  encSeed,
+		FundTx:         sig,
+	}, nil
+}
+
+func encryptRelaySecret(secret stellar1.SecretKey, encryptFor keybase1.TeamApplicationKey) (res stellar1.EncryptedRelaySecret, err error) {
+	if encryptFor.Key.IsBlank() {
+		return res, errors.New("attempt to use blank team application key")
+	}
+	nonce, err := libkb.RandomNaclDHNonce()
+	if err != nil {
+		return res, err
+	}
+	secbox := secretbox.Seal(
+		nil, []byte(secret), &nonce, (*[32]byte)(&encryptFor.Key))
+	return stellar1.EncryptedRelaySecret{
+		V:   1,
+		E:   secbox,
+		N:   nonce,
+		Gen: encryptFor.KeyGeneration,
+	}, nil
+}
+
+// TODO CORE-7718 make this private
+func DecryptRelaySecret(box stellar1.EncryptedRelaySecret, key keybase1.TeamApplicationKey) (res stellar1.SecretKey, err error) {
+	if box.V != 1 {
+		return res, fmt.Errorf("unsupported relay secret box version: %v", box.V)
+	}
+	msg, ok := secretbox.Open(
+		nil, box.E, (*[24]byte)(&box.N), (*[32]byte)(&key.Key))
+	if !ok {
+		return res, libkb.NewDecryptOpenError("relay payment secretbox")
+	}
+	res, _, _, err = libkb.ParseStellarSecretKey(string(msg))
+	return res, err
+}

--- a/go/stellar/seqno.go
+++ b/go/stellar/seqno.go
@@ -3,7 +3,6 @@ package stellar
 import (
 	"golang.org/x/net/context"
 
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/stellar/remote"
 	"github.com/stellar/go/xdr"
@@ -13,15 +12,13 @@ import (
 // wrapper and shouldn't be reused after the transaction is built.
 type SeqnoProvider struct {
 	ctx     context.Context
-	g       *libkb.GlobalContext
 	remoter remote.Remoter
 }
 
 // NewSeqnoProvider creates a SeqnoProvider.
-func NewSeqnoProvider(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter) *SeqnoProvider {
+func NewSeqnoProvider(ctx context.Context, remoter remote.Remoter) *SeqnoProvider {
 	return &SeqnoProvider{
 		ctx:     ctx,
-		g:       g,
 		remoter: remoter,
 	}
 }

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -46,6 +46,10 @@ func CreateWallet(ctx context.Context, g *libkb.GlobalContext) (created bool, er
 func CreateWalletGated(ctx context.Context, g *libkb.GlobalContext) (created bool, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.CreateWalletGated", func() error { return err })()
 	// TODO: short-circuit if the user has a bundle already
+	if !g.Env.GetAutoWallet() {
+		g.Log.CDebugf(ctx, "CreateWalletGated disabled by env setting")
+		return false, nil
+	}
 	should, err := remote.ShouldCreate(ctx, g)
 	if err != nil {
 		return false, err
@@ -73,15 +77,15 @@ func CreateWalletSoft(ctx context.Context, g *libkb.GlobalContext) {
 // Upkeep makes sure the bundle is encrypted for the user's latest PUK.
 func Upkeep(ctx context.Context, g *libkb.GlobalContext) (err error) {
 	defer g.CTraceTimed(ctx, "Stellar.Upkeep", func() error { return err })()
+	prevBundle, prevPukGen, err := remote.Fetch(ctx, g)
+	if err != nil {
+		return err
+	}
 	pukring, err := g.GetPerUserKeyring()
 	if err != nil {
 		return err
 	}
 	err = pukring.Sync(ctx)
-	if err != nil {
-		return err
-	}
-	prevBundle, prevPukGen, err := remote.Fetch(ctx, g)
 	if err != nil {
 		return err
 	}
@@ -126,7 +130,7 @@ func ExportSecretKey(ctx context.Context, g *libkb.GlobalContext, accountID stel
 			return account.Signers[0], nil
 		}
 	}
-	_, _, parseSecErr := libkb.ParseStellarSecretKey(accountID.String())
+	_, _, _, parseSecErr := libkb.ParseStellarSecretKey(accountID.String())
 	if parseSecErr == nil {
 		// Just in case a secret key worked its way in here
 		return res, fmt.Errorf("account not found: unexpected secret key")
@@ -172,45 +176,49 @@ func LookupSenderPrimary(ctx context.Context, g *libkb.GlobalContext) (stellar1.
 type RecipientInput string
 
 type Recipient struct {
-	Input     RecipientInput
-	User      *libkb.User
-	AccountID stellarnet.AddressStr
+	Input RecipientInput
+	User  *libkb.User
+	// Recipient may not have a stellar wallet ready to receive
+	AccountID *stellarnet.AddressStr
 }
 
 // TODO: handle stellar federation address rebecca*keybase.io (or rebecca*anything.wow)
-func LookupRecipient(ctx context.Context, g *libkb.GlobalContext, to RecipientInput) (*Recipient, error) {
-	r := Recipient{
+func LookupRecipient(ctx context.Context, g *libkb.GlobalContext, to RecipientInput) (Recipient, error) {
+	res := Recipient{
 		Input: to,
 	}
 
-	if to[0] == 'G' && len(to) > 16 {
-		var err error
-		r.AccountID, err = stellarnet.NewAddressStr(string(to))
+	storeAddress := func(address string) error {
+		accountID, err := stellarnet.NewAddressStr(address)
 		if err != nil {
-			return nil, err
+			return err
 		}
+		res.AccountID = &accountID
+		return nil
+	}
 
-		return &r, nil
+	if to[0] == 'G' && len(to) > 16 {
+		err := storeAddress(string(to))
+		if err != nil {
+			return res, err
+		}
+		return res, nil
 	}
 
 	user, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(g, string(to)).WithNetContext(ctx))
 	if err != nil {
-		return nil, err
+		return res, err
 	}
+	res.User = user
 	accountID := user.StellarWalletAddress()
 	if accountID == nil {
-		return nil, fmt.Errorf("keybase user %s does not have a stellar wallet", to)
+		return res, nil
 	}
-	r.AccountID, err = stellarnet.NewAddressStr(accountID.String())
-	if err != nil {
-		return nil, err
-	}
-	r.User = user
-
-	return &r, nil
+	err = storeAddress(accountID.String())
+	return res, err
 }
 
-func makePostFromCurrentUser(ctx context.Context, g *libkb.GlobalContext, acctID stellarnet.AddressStr, recipient *Recipient) (stellar1.PaymentPost, error) {
+func makePostFromCurrentUser(ctx context.Context, g *libkb.GlobalContext, acctID stellarnet.AddressStr, recipient Recipient) (stellar1.PaymentPost, error) {
 	meUpk, err := loadMeUpk(ctx, g)
 	if err != nil {
 		return stellar1.PaymentPost{}, err
@@ -226,11 +234,12 @@ func makePostFromCurrentUser(ctx context.Context, g *libkb.GlobalContext, acctID
 			FromDeviceID: deviceID,
 		},
 	}
-	if recipient != nil {
-		post.Members.ToStellar = stellar1.AccountID(recipient.AccountID.String())
-		if recipient.User != nil {
-			post.Members.To = recipient.User.ToUserVersion()
-		}
+	if recipient.AccountID == nil {
+		return stellar1.PaymentPost{}, fmt.Errorf("no stellar account for recipient")
+	}
+	post.Members.ToStellar = stellar1.AccountID(recipient.AccountID.String())
+	if recipient.User != nil {
+		post.Members.To = recipient.User.ToUserVersion()
 	}
 	return post, nil
 }
@@ -238,6 +247,8 @@ func makePostFromCurrentUser(ctx context.Context, g *libkb.GlobalContext, acctID
 // SendPayment sends XLM
 // `note` is optional. An empty string will not attach a note.
 func SendPayment(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter, to RecipientInput, amount string, note string) (stellar1.PaymentResult, error) {
+	var err error
+	defer g.CTraceTimed(ctx, "Stellar.SendPayment", func() error { return err })()
 	// look up sender wallet
 	primary, err := LookupSenderPrimary(ctx, g)
 	if err != nil {
@@ -247,14 +258,18 @@ func SendPayment(ctx context.Context, g *libkb.GlobalContext, remoter remote.Rem
 	if err != nil {
 		return stellar1.PaymentResult{}, err
 	}
-	primarySeed, err := stellarnet.NewSeedStr(primary.Signers[0].SecureNoLogString())
+	primarySeed := primary.Signers[0]
+	// look up recipient
+	recipient, err := LookupRecipient(ctx, g, to)
 	if err != nil {
 		return stellar1.PaymentResult{}, err
 	}
-	senderAcct := stellarnet.NewAccount(primaryAccountID)
 
-	// look up recipient
-	recipient, err := LookupRecipient(ctx, g, to)
+	if recipient.AccountID == nil {
+		return sendRelayPayment(ctx, g, remoter, primarySeed, recipient, amount)
+	}
+
+	primarySeed2, err := stellarnet.NewSeedStr(primarySeed.SecureNoLogString())
 	if err != nil {
 		return stellar1.PaymentResult{}, err
 	}
@@ -264,7 +279,7 @@ func SendPayment(ctx context.Context, g *libkb.GlobalContext, remoter remote.Rem
 		return stellar1.PaymentResult{}, err
 	}
 
-	sp := NewSeqnoProvider(ctx, g, remoter)
+	sp := NewSeqnoProvider(ctx, remoter)
 
 	// check if recipient account exists
 	var txID string
@@ -276,7 +291,7 @@ func SendPayment(ctx context.Context, g *libkb.GlobalContext, remoter remote.Rem
 		// if no balance, create_account operation
 		// we could check here to make sure that amount is at least 1XLM
 		// but for now, just let stellar-core tell us there was an error
-		sig, err := senderAcct.CreateAccountXLMTransaction(primarySeed, recipient.AccountID, amount, sp)
+		sig, err := stellarnet.CreateAccountXLMTransaction(primarySeed2, *recipient.AccountID, amount, sp)
 		if err != nil {
 			return stellar1.PaymentResult{}, err
 		}
@@ -285,7 +300,7 @@ func SendPayment(ctx context.Context, g *libkb.GlobalContext, remoter remote.Rem
 		txID = sig.TxHash
 	} else {
 		// if balance, payment operation
-		sig, err := senderAcct.PaymentXLMTransaction(primarySeed, recipient.AccountID, amount, sp)
+		sig, err := stellarnet.PaymentXLMTransaction(primarySeed2, *recipient.AccountID, amount, sp)
 		if err != nil {
 			return stellar1.PaymentResult{}, err
 		}
@@ -315,6 +330,32 @@ func SendPayment(ctx context.Context, g *libkb.GlobalContext, remoter remote.Rem
 	payload := make(libkb.JSONPayload)
 	payload["payment"] = post
 	return remoter.SubmitTransaction(ctx, payload)
+}
+
+// sendRelayPayment sends XLM through a relay account.
+// The balance of the relay account can be claimed by either party.
+func sendRelayPayment(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter,
+	from stellar1.SecretKey, recipient Recipient, amount string) (res stellar1.PaymentResult, err error) {
+	defer g.CTraceTimed(ctx, "Stellar.sendRelayPayment", func() error { return err })()
+	if recipient.User == nil {
+		// TODO support SBS assertions?
+		return res, fmt.Errorf("no user in recipient")
+	}
+	appKey, err := KeyForRelayTransfer(ctx, g, remoter, recipient.User, nil)
+	if err != nil {
+		return res, err
+	}
+	_, err = CreateRelayTransfer(RelayPaymentInput{
+		From:          from,
+		AmountXLM:     amount,
+		EncryptFor:    appKey,
+		SeqnoProvider: NewSeqnoProvider(ctx, remoter),
+	})
+	if err != nil {
+		return res, err
+	}
+	// TODO CORE-7718
+	return res, fmt.Errorf("keybase user %s does not have a wallet", recipient.User.GetNormalizedName().String())
 }
 
 func isAccountFunded(ctx context.Context, remoter remote.Remoter, accountID stellar1.AccountID) (funded bool, err error) {

--- a/go/systests/stellar_test.go
+++ b/go/systests/stellar_test.go
@@ -63,7 +63,6 @@ func TestStellarNoteRoundtripAndResets(t *testing.T) {
 
 func sampleNote() stellar1.NoteContents {
 	return stellar1.NoteContents{
-		Version:   1,
 		Note:      "wizbang",
 		StellarID: stellar1.TransactionID("6653fc2fdbc42ad51ccbe77ee0a3c29e258a5513c62fdc532cbfff91ab101abf"),
 	}

--- a/go/teams/appkeys.go
+++ b/go/teams/appkeys.go
@@ -77,6 +77,8 @@ func applicationKeyForMask(mask keybase1.ReaderKeyMask, secret keybase1.PerTeamK
 		derivationString = libkb.TeamGitMetadataDerivationString
 	case keybase1.TeamApplication_SEITAN_INVITE_TOKEN:
 		derivationString = libkb.TeamSeitanTokenDerivationString
+	case keybase1.TeamApplication_STELLAR_RELAY:
+		derivationString = libkb.TeamStellarRelayDerivationString
 	default:
 		return keybase1.TeamApplicationKey{}, fmt.Errorf("unrecognized application id: %v", mask.Application)
 	}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -745,6 +745,11 @@ func (l *TeamLoader) checkReaderKeyMaskCoverage(ctx context.Context,
 	state *keybase1.TeamData, gen keybase1.PerTeamKeyGeneration) error {
 
 	for _, app := range keybase1.TeamApplicationMap {
+		if app == keybase1.TeamApplication_STELLAR_RELAY {
+			// TODO CORE-7718 Allow clients to be missing these RKMs for now.
+			//                Will need a team cache bust to repair.
+			continue
+		}
 		if _, ok := state.ReaderKeyMasks[app]; !ok {
 			return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
 		}

--- a/go/vendor/github.com/keybase/stellarnet/account.go
+++ b/go/vendor/github.com/keybase/stellarnet/account.go
@@ -239,14 +239,14 @@ func isOpNoDestination(inErr error) bool {
 
 // SendXLM sends 'amount' lumens from 'from' account to 'to' account.
 // If the recipient has no account yet, this will create it.
-func (a *Account) SendXLM(from SeedStr, to AddressStr, amount string) (ledger int32, txid string, err error) {
+func SendXLM(from SeedStr, to AddressStr, amount string) (ledger int32, txid string, err error) {
 	// this is checked in build.Transaction, but can't hurt to break out early
 	if _, err = samount.Parse(amount); err != nil {
 		return 0, "", err
 	}
 
 	// try payment first
-	ledger, txid, err = a.paymentXLM(from, to, amount)
+	ledger, txid, err = paymentXLM(from, to, amount)
 
 	if err != nil {
 		if err != ErrAccountNotFound {
@@ -255,15 +255,15 @@ func (a *Account) SendXLM(from SeedStr, to AddressStr, amount string) (ledger in
 
 		// if payment failed due to op_no_destination, then
 		// should try createAccount instead
-		return a.createAccountXLM(from, to, amount)
+		return createAccountXLM(from, to, amount)
 	}
 
 	return ledger, txid, nil
 }
 
 // paymentXLM creates a payment transaction from 'from' to 'to' for 'amount' lumens.
-func (a *Account) paymentXLM(from SeedStr, to AddressStr, amount string) (ledger int32, txid string, err error) {
-	sig, err := a.PaymentXLMTransaction(from, to, amount, client)
+func paymentXLM(from SeedStr, to AddressStr, amount string) (ledger int32, txid string, err error) {
+	sig, err := PaymentXLMTransaction(from, to, amount, client)
 	if err != nil {
 		return 0, "", err
 	}
@@ -271,7 +271,7 @@ func (a *Account) paymentXLM(from SeedStr, to AddressStr, amount string) (ledger
 }
 
 // PaymentXLMTransaction creates a signed transaction to send a payment from 'from' to 'to' for 'amount' lumens.
-func (a *Account) PaymentXLMTransaction(from SeedStr, to AddressStr, amount string,
+func PaymentXLMTransaction(from SeedStr, to AddressStr, amount string,
 	seqnoProvider build.SequenceProvider) (res SignResult, err error) {
 	tx, err := build.Transaction(
 		build.SourceAccount{AddressOrSeed: from.SecureNoLogString()},
@@ -286,12 +286,12 @@ func (a *Account) PaymentXLMTransaction(from SeedStr, to AddressStr, amount stri
 	if err != nil {
 		return res, err
 	}
-	return a.sign(from, tx)
+	return sign(from, tx)
 }
 
 // createAccountXLM funds an new account 'to' from 'from' with a starting balance of 'amount'.
-func (a *Account) createAccountXLM(from SeedStr, to AddressStr, amount string) (ledger int32, txid string, err error) {
-	sig, err := a.CreateAccountXLMTransaction(from, to, amount, client)
+func createAccountXLM(from SeedStr, to AddressStr, amount string) (ledger int32, txid string, err error) {
+	sig, err := CreateAccountXLMTransaction(from, to, amount, client)
 	if err != nil {
 		return 0, "", err
 	}
@@ -300,7 +300,7 @@ func (a *Account) createAccountXLM(from SeedStr, to AddressStr, amount string) (
 
 // CreateAccountXLMTransaction creates a signed transaction to fund an new account 'to' from 'from'
 // with a starting balance of 'amount'.
-func (a *Account) CreateAccountXLMTransaction(from SeedStr, to AddressStr, amount string,
+func CreateAccountXLMTransaction(from SeedStr, to AddressStr, amount string,
 	seqnoProvider build.SequenceProvider) (res SignResult, err error) {
 	tx, err := build.Transaction(
 		build.SourceAccount{AddressOrSeed: from.SecureNoLogString()},
@@ -315,7 +315,7 @@ func (a *Account) CreateAccountXLMTransaction(from SeedStr, to AddressStr, amoun
 	if err != nil {
 		return res, err
 	}
-	return a.sign(from, tx)
+	return sign(from, tx)
 }
 
 type SignResult struct {
@@ -325,7 +325,7 @@ type SignResult struct {
 }
 
 // sign signs and base64-encodes a transaction.
-func (a *Account) sign(from SeedStr, tx *build.TransactionBuilder) (res SignResult, err error) {
+func sign(from SeedStr, tx *build.TransactionBuilder) (res SignResult, err error) {
 	txe, err := tx.Sign(from.SecureNoLogString())
 	if err != nil {
 		return res, err

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -420,10 +420,10 @@
 			"revisionTime": "2018-03-22T21:11:54Z"
 		},
 		{
-			"checksumSHA1": "Hue44d2YvZ/5Sd+oyxW93A/hFeQ=",
+			"checksumSHA1": "9bzqMvSXr8Lr+Na6YXvMyN6QqjI=",
 			"path": "github.com/keybase/stellarnet",
-			"revision": "f76ab41facf34d915dece0604a7d6c6d4d489424",
-			"revisionTime": "2018-04-19T18:32:21Z"
+			"revision": "da171d2552e171473bca077282694b83051304a9",
+			"revisionTime": "2018-04-25T21:28:23Z"
 		},
 		{
 			"path": "github.com/kr/pty",

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -19,7 +19,8 @@ protocol teams {
     CHAT_2,
     SALTPACK_3,
     GIT_METADATA_4,
-    SEITAN_INVITE_TOKEN_5
+    SEITAN_INVITE_TOKEN_5,
+    STELLAR_RELAY_6
   }
 
   // PerTeamKeyGeneration describes the generation of the secret.

--- a/protocol/avdl/stellar1/common.avdl
+++ b/protocol/avdl/stellar1/common.avdl
@@ -51,7 +51,6 @@ protocol common {
   }
 
   record NoteContents {
-    int version;
     string note;
     TransactionID stellarID;
   }
@@ -63,6 +62,12 @@ protocol common {
     bytes e;             // encrypted data
     keybase1.BoxNonce n; // nonce
     keybase1.PerTeamKeyGeneration gen; // key generation that was used
+  }
+
+  record RelayContents {
+    TransactionID stellarID;
+    SecretKey sk;
+    string note;
   }
 
   @typedef("string") record OutsideCurrencyCode {}

--- a/protocol/avdl/stellar1/common.avdl
+++ b/protocol/avdl/stellar1/common.avdl
@@ -56,6 +56,15 @@ protocol common {
     TransactionID stellarID;
   }
 
+  // A stellar secret key encrypted for an iteam.
+  // Decrypts to a stellar1.SecretKey.
+  record EncryptedRelaySecret {
+    int v;               // version
+    bytes e;             // encrypted data
+    keybase1.BoxNonce n; // nonce
+    keybase1.PerTeamKeyGeneration gen; // key generation that was used
+  }
+
   @typedef("string") record OutsideCurrencyCode {}
 
   record OutsideExchangeRate {

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1670,6 +1670,7 @@ export const teamsTeamApplication = {
   saltpack: 3,
   gitMetadata: 4,
   seitanInviteToken: 5,
+  stellarRelay: 6,
 }
 
 export const teamsTeamChangeMembershipRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamChangeMembershipRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamChangeMembership', request)
@@ -3720,6 +3721,7 @@ export type TeamApplication =
   | 3 // SALTPACK_3
   | 4 // GIT_METADATA_4
   | 5 // SEITAN_INVITE_TOKEN_5
+  | 6 // STELLAR_RELAY_6
 
 export type TeamApplicationKey = $ReadOnly<{application: TeamApplication, keyGeneration: PerTeamKeyGeneration, key: Bytes32}>
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -21,7 +21,8 @@
         "CHAT_2",
         "SALTPACK_3",
         "GIT_METADATA_4",
-        "SEITAN_INVITE_TOKEN_5"
+        "SEITAN_INVITE_TOKEN_5",
+        "STELLAR_RELAY_6"
       ]
     },
     {

--- a/protocol/json/stellar1/common.json
+++ b/protocol/json/stellar1/common.json
@@ -157,10 +157,6 @@
       "name": "NoteContents",
       "fields": [
         {
-          "type": "int",
-          "name": "version"
-        },
-        {
           "type": "string",
           "name": "note"
         },
@@ -189,6 +185,24 @@
         {
           "type": "keybase1.PerTeamKeyGeneration",
           "name": "gen"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "RelayContents",
+      "fields": [
+        {
+          "type": "TransactionID",
+          "name": "stellarID"
+        },
+        {
+          "type": "SecretKey",
+          "name": "sk"
+        },
+        {
+          "type": "string",
+          "name": "note"
         }
       ]
     },

--- a/protocol/json/stellar1/common.json
+++ b/protocol/json/stellar1/common.json
@@ -172,6 +172,28 @@
     },
     {
       "type": "record",
+      "name": "EncryptedRelaySecret",
+      "fields": [
+        {
+          "type": "int",
+          "name": "v"
+        },
+        {
+          "type": "bytes",
+          "name": "e"
+        },
+        {
+          "type": "keybase1.BoxNonce",
+          "name": "n"
+        },
+        {
+          "type": "keybase1.PerTeamKeyGeneration",
+          "name": "gen"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "OutsideCurrencyCode",
       "fields": [],
       "typedef": "string"

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1670,6 +1670,7 @@ export const teamsTeamApplication = {
   saltpack: 3,
   gitMetadata: 4,
   seitanInviteToken: 5,
+  stellarRelay: 6,
 }
 
 export const teamsTeamChangeMembershipRpcChannelMap = (configKeys: Array<string>, request: TeamsTeamChangeMembershipRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.teamChangeMembership', request)
@@ -3720,6 +3721,7 @@ export type TeamApplication =
   | 3 // SALTPACK_3
   | 4 // GIT_METADATA_4
   | 5 // SEITAN_INVITE_TOKEN_5
+  | 6 // STELLAR_RELAY_6
 
 export type TeamApplicationKey = $ReadOnly<{application: TeamApplication, keyGeneration: PerTeamKeyGeneration, key: Bytes32}>
 


### PR DESCRIPTION
For sending to users without wallets use a 'relay' payment where the money goes into a shared account. The key for the shared account is keyed for the implicit of the sender and recipient.

- [x] _do not merge_ until the RKM situation is figured out and `add_new_team_app` is run on the server. Clients check that all RKMs are covered. Also probably need to bust the team cache to backfill RKMs before really using the key.
- A handful of functions are exported from `stellar` that ideally won't be. There are TODOs for that. I think they can be made private again once more of the sending machinery is implemented.
- I haven't decided what to do with the shared note. Since the current strategy won't work for relay payments. Maybe stick it in the same `EncryptedRelaySecret`. Maybe give it its own box, but then it might need another RKM.