### PR TITLE
protocol: add `FindNextMD` metadata RPC and make accessor methods for KBFS merkle data

### DIFF
--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -313,6 +313,10 @@ type MerkleRootPayloadUnpacked struct {
 				Root    *string `json:"root"`
 				Version *int    `json:"version"`
 			} `json:"public"`
+			PrivateTeam struct {
+				Root    *string `json:"root"`
+				Version *int    `json:"version"`
+			} `json:"privateteam"`
 		} `json:"kbfs"`
 		LegacyUIDRoot NodeHashShort  `json:"legacy_uid_root"`
 		Prev          NodeHashLong   `json:"prev"`
@@ -1719,6 +1723,27 @@ func (mr *MerkleRoot) Fetched() time.Time {
 	return mr.fetched
 }
 
+func (mr *MerkleRoot) KBFSPrivate() (*string, *int) {
+	if mr == nil {
+		return nil, nil
+	}
+	return mr.payload.kbfsPrivate()
+}
+
+func (mr *MerkleRoot) KBFSPublic() (*string, *int) {
+	if mr == nil {
+		return nil, nil
+	}
+	return mr.payload.kbfsPublic()
+}
+
+func (mr *MerkleRoot) KBFSPrivateTeam() (*string, *int) {
+	if mr == nil {
+		return nil, nil
+	}
+	return mr.payload.kbfsPrivateTeam()
+}
+
 func (mrp MerkleRootPayload) skipToSeqno(s keybase1.Seqno) NodeHash {
 	if mrp.unpacked.Body.Skips == nil {
 		return nil
@@ -1731,3 +1756,12 @@ func (mrp MerkleRootPayload) rootHash() NodeHash          { return mrp.unpacked.
 func (mrp MerkleRootPayload) legacyUIDRootHash() NodeHash { return mrp.unpacked.Body.LegacyUIDRoot }
 func (mrp MerkleRootPayload) pvlHash() string             { return mrp.unpacked.Body.PvlHash }
 func (mrp MerkleRootPayload) ctime() int64                { return mrp.unpacked.Ctime }
+func (mrp MerkleRootPayload) kbfsPrivate() (*string, *int) {
+	return mrp.unpacked.Body.Kbfs.Private.Root, mrp.unpacked.Body.Kbfs.Private.Version
+}
+func (mrp MerkleRootPayload) kbfsPublic() (*string, *int) {
+	return mrp.unpacked.Body.Kbfs.Public.Root, mrp.unpacked.Body.Kbfs.Public.Version
+}
+func (mrp MerkleRootPayload) kbfsPrivateTeam() (*string, *int) {
+	return mrp.unpacked.Body.Kbfs.PrivateTeam.Root, mrp.unpacked.Body.Kbfs.PrivateTeam.Version
+}

--- a/go/protocol/keybase1/metadata.go
+++ b/go/protocol/keybase1/metadata.go
@@ -309,6 +309,9 @@ type SetImplicitTeamModeForTestArg struct {
 	ImplicitTeamMode string `codec:"implicitTeamMode" json:"implicitTeamMode"`
 }
 
+type ForceMerkleBuildForTestArg struct {
+}
+
 type MetadataInterface interface {
 	GetChallenge(context.Context) (ChallengeInfo, error)
 	Authenticate(context.Context, string) (int, error)
@@ -336,6 +339,7 @@ type MetadataInterface interface {
 	GetMerkleNode(context.Context, string) ([]byte, error)
 	FindNextMD(context.Context, FindNextMDArg) (FindNextMDResponse, error)
 	SetImplicitTeamModeForTest(context.Context, string) error
+	ForceMerkleBuildForTest(context.Context) error
 }
 
 func MetadataProtocol(i MetadataInterface) rpc.Protocol {
@@ -743,6 +747,17 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"forceMerkleBuildForTest": {
+				MakeArg: func() interface{} {
+					ret := make([]ForceMerkleBuildForTestArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					err = i.ForceMerkleBuildForTest(ctx)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -887,5 +902,10 @@ func (c MetadataClient) FindNextMD(ctx context.Context, __arg FindNextMDArg) (re
 func (c MetadataClient) SetImplicitTeamModeForTest(ctx context.Context, implicitTeamMode string) (err error) {
 	__arg := SetImplicitTeamModeForTestArg{ImplicitTeamMode: implicitTeamMode}
 	err = c.Cli.Call(ctx, "keybase.1.metadata.setImplicitTeamModeForTest", []interface{}{__arg}, nil)
+	return
+}
+
+func (c MetadataClient) ForceMerkleBuildForTest(ctx context.Context) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.metadata.forceMerkleBuildForTest", []interface{}{ForceMerkleBuildForTestArg{}}, nil)
 	return
 }

--- a/protocol/avdl/keybase1/metadata.avdl
+++ b/protocol/avdl/keybase1/metadata.avdl
@@ -52,6 +52,12 @@ protocol metadata {
     boolean releaseAfterSuccess;
   }
 
+  record FindNextMDResponse {
+     array<bytes> merkleNodes;
+     Seqno rootSeqno;
+     HashMeta rootHash;
+  }
+
   ChallengeInfo getChallenge();
   int authenticate(string signature);
   void putMetadata(MDBlock mdBlock, KeyBundle readerKeyBundle, KeyBundle writerKeyBundle, map<string> logTags, union{null, LockContext} lockContext, MDPriority priority);
@@ -80,6 +86,7 @@ protocol metadata {
   MerkleRoot getMerkleRootLatest(MerkleTreeID treeID);
   MerkleRoot getMerkleRootSince(MerkleTreeID treeID, Time when);
   bytes getMerkleNode(string hash);
+  FindNextMDResponse findNextMD(Seqno seqno, string folderID);
 
   // For testing.
   void setImplicitTeamModeForTest(string implicitTeamMode);

--- a/protocol/avdl/keybase1/metadata.avdl
+++ b/protocol/avdl/keybase1/metadata.avdl
@@ -90,4 +90,5 @@ protocol metadata {
 
   // For testing.
   void setImplicitTeamModeForTest(string implicitTeamMode);
+  void forceMerkleBuildForTest();
 }

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1080,6 +1080,10 @@ export const metadataFindNextMDRpcChannelMap = (configKeys: Array<string>, reque
 
 export const metadataFindNextMDRpcPromise = (request: MetadataFindNextMDRpcParam): Promise<MetadataFindNextMDResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.findNextMD', request, (error: RPCError, result: MetadataFindNextMDResult) => (error ? reject(error) : resolve(result))))
 
+export const metadataForceMerkleBuildForTestRpcChannelMap = (configKeys: Array<string>, request: MetadataForceMerkleBuildForTestRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.metadata.forceMerkleBuildForTest', request)
+
+export const metadataForceMerkleBuildForTestRpcPromise = (request: MetadataForceMerkleBuildForTestRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.forceMerkleBuildForTest', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
 export const metadataGetChallengeRpcChannelMap = (configKeys: Array<string>, request: MetadataGetChallengeRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.metadata.getChallenge', request)
 
 export const metadataGetChallengeRpcPromise = (request: MetadataGetChallengeRpcParam): Promise<MetadataGetChallengeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.getChallenge', request, (error: RPCError, result: MetadataGetChallengeResult) => (error ? reject(error) : resolve(result))))
@@ -2798,6 +2802,8 @@ export type MetadataAuthenticateRpcParam = $ReadOnly<{signature: String, incomin
 export type MetadataDeleteKeyRpcParam = $ReadOnly<{uid: UID, deviceKID: KID, keyHalfID: Bytes, logTags: {[key: string]: String}, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type MetadataFindNextMDRpcParam = $ReadOnly<{seqno: Seqno, folderID: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type MetadataForceMerkleBuildForTestRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type MetadataGetChallengeRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1076,6 +1076,10 @@ export const metadataDeleteKeyRpcChannelMap = (configKeys: Array<string>, reques
 
 export const metadataDeleteKeyRpcPromise = (request: MetadataDeleteKeyRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.deleteKey', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
 
+export const metadataFindNextMDRpcChannelMap = (configKeys: Array<string>, request: MetadataFindNextMDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.metadata.findNextMD', request)
+
+export const metadataFindNextMDRpcPromise = (request: MetadataFindNextMDRpcParam): Promise<MetadataFindNextMDResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.findNextMD', request, (error: RPCError, result: MetadataFindNextMDResult) => (error ? reject(error) : resolve(result))))
+
 export const metadataGetChallengeRpcChannelMap = (configKeys: Array<string>, request: MetadataGetChallengeRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.metadata.getChallenge', request)
 
 export const metadataGetChallengeRpcPromise = (request: MetadataGetChallengeRpcParam): Promise<MetadataGetChallengeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.getChallenge', request, (error: RPCError, result: MetadataGetChallengeResult) => (error ? reject(error) : resolve(result))))
@@ -2333,6 +2337,8 @@ export type FileType =
   | 1 // DIRECTORY_1
   | 2 // FILE_2
 
+export type FindNextMDResponse = $ReadOnly<{merkleNodes?: ?Array<Bytes>, rootSeqno: Seqno, rootHash: HashMeta}>
+
 export type FirstStepResult = $ReadOnly<{valPlusTwo: Int}>
 
 export type Folder = $ReadOnly<{name: String, private: Boolean, notificationsOn: Boolean, created: Boolean, folderType: FolderType}>
@@ -2790,6 +2796,8 @@ export type MerkleTreeLocation = $ReadOnly<{leaf: UserOrTeamID, loc: SigChainLoc
 export type MetadataAuthenticateRpcParam = $ReadOnly<{signature: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type MetadataDeleteKeyRpcParam = $ReadOnly<{uid: UID, deviceKID: KID, keyHalfID: Bytes, logTags: {[key: string]: String}, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type MetadataFindNextMDRpcParam = $ReadOnly<{seqno: Seqno, folderID: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type MetadataGetChallengeRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
@@ -4163,6 +4171,7 @@ type LoginUiGetEmailOrUsernameResult = String
 type LoginUiPromptRevokePaperKeysResult = Boolean
 type MerkleGetCurrentMerkleRootResult = MerkleRootAndTime
 type MetadataAuthenticateResult = Int
+type MetadataFindNextMDResult = FindNextMDResponse
 type MetadataGetChallengeResult = ChallengeInfo
 type MetadataGetFolderHandleResult = Bytes
 type MetadataGetKeyBundlesResult = KeyBundleResponse

--- a/protocol/json/keybase1/metadata.json
+++ b/protocol/json/keybase1/metadata.json
@@ -139,6 +139,27 @@
           "name": "releaseAfterSuccess"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "FindNextMDResponse",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "bytes"
+          },
+          "name": "merkleNodes"
+        },
+        {
+          "type": "Seqno",
+          "name": "rootSeqno"
+        },
+        {
+          "type": "HashMeta",
+          "name": "rootHash"
+        }
+      ]
     }
   ],
   "messages": {
@@ -492,6 +513,19 @@
         }
       ],
       "response": "bytes"
+    },
+    "findNextMD": {
+      "request": [
+        {
+          "name": "seqno",
+          "type": "Seqno"
+        },
+        {
+          "name": "folderID",
+          "type": "string"
+        }
+      ],
+      "response": "FindNextMDResponse"
     },
     "setImplicitTeamModeForTest": {
       "request": [

--- a/protocol/json/keybase1/metadata.json
+++ b/protocol/json/keybase1/metadata.json
@@ -535,6 +535,10 @@
         }
       ],
       "response": null
+    },
+    "forceMerkleBuildForTest": {
+      "request": [],
+      "response": null
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1080,6 +1080,10 @@ export const metadataFindNextMDRpcChannelMap = (configKeys: Array<string>, reque
 
 export const metadataFindNextMDRpcPromise = (request: MetadataFindNextMDRpcParam): Promise<MetadataFindNextMDResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.findNextMD', request, (error: RPCError, result: MetadataFindNextMDResult) => (error ? reject(error) : resolve(result))))
 
+export const metadataForceMerkleBuildForTestRpcChannelMap = (configKeys: Array<string>, request: MetadataForceMerkleBuildForTestRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.metadata.forceMerkleBuildForTest', request)
+
+export const metadataForceMerkleBuildForTestRpcPromise = (request: MetadataForceMerkleBuildForTestRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.forceMerkleBuildForTest', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
 export const metadataGetChallengeRpcChannelMap = (configKeys: Array<string>, request: MetadataGetChallengeRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.metadata.getChallenge', request)
 
 export const metadataGetChallengeRpcPromise = (request: MetadataGetChallengeRpcParam): Promise<MetadataGetChallengeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.getChallenge', request, (error: RPCError, result: MetadataGetChallengeResult) => (error ? reject(error) : resolve(result))))
@@ -2798,6 +2802,8 @@ export type MetadataAuthenticateRpcParam = $ReadOnly<{signature: String, incomin
 export type MetadataDeleteKeyRpcParam = $ReadOnly<{uid: UID, deviceKID: KID, keyHalfID: Bytes, logTags: {[key: string]: String}, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type MetadataFindNextMDRpcParam = $ReadOnly<{seqno: Seqno, folderID: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type MetadataForceMerkleBuildForTestRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type MetadataGetChallengeRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1076,6 +1076,10 @@ export const metadataDeleteKeyRpcChannelMap = (configKeys: Array<string>, reques
 
 export const metadataDeleteKeyRpcPromise = (request: MetadataDeleteKeyRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.deleteKey', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
 
+export const metadataFindNextMDRpcChannelMap = (configKeys: Array<string>, request: MetadataFindNextMDRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.metadata.findNextMD', request)
+
+export const metadataFindNextMDRpcPromise = (request: MetadataFindNextMDRpcParam): Promise<MetadataFindNextMDResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.findNextMD', request, (error: RPCError, result: MetadataFindNextMDResult) => (error ? reject(error) : resolve(result))))
+
 export const metadataGetChallengeRpcChannelMap = (configKeys: Array<string>, request: MetadataGetChallengeRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.metadata.getChallenge', request)
 
 export const metadataGetChallengeRpcPromise = (request: MetadataGetChallengeRpcParam): Promise<MetadataGetChallengeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.metadata.getChallenge', request, (error: RPCError, result: MetadataGetChallengeResult) => (error ? reject(error) : resolve(result))))
@@ -2333,6 +2337,8 @@ export type FileType =
   | 1 // DIRECTORY_1
   | 2 // FILE_2
 
+export type FindNextMDResponse = $ReadOnly<{merkleNodes?: ?Array<Bytes>, rootSeqno: Seqno, rootHash: HashMeta}>
+
 export type FirstStepResult = $ReadOnly<{valPlusTwo: Int}>
 
 export type Folder = $ReadOnly<{name: String, private: Boolean, notificationsOn: Boolean, created: Boolean, folderType: FolderType}>
@@ -2790,6 +2796,8 @@ export type MerkleTreeLocation = $ReadOnly<{leaf: UserOrTeamID, loc: SigChainLoc
 export type MetadataAuthenticateRpcParam = $ReadOnly<{signature: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type MetadataDeleteKeyRpcParam = $ReadOnly<{uid: UID, deviceKID: KID, keyHalfID: Bytes, logTags: {[key: string]: String}, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type MetadataFindNextMDRpcParam = $ReadOnly<{seqno: Seqno, folderID: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type MetadataGetChallengeRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
@@ -4163,6 +4171,7 @@ type LoginUiGetEmailOrUsernameResult = String
 type LoginUiPromptRevokePaperKeysResult = Boolean
 type MerkleGetCurrentMerkleRootResult = MerkleRootAndTime
 type MetadataAuthenticateResult = Int
+type MetadataFindNextMDResult = FindNextMDResponse
 type MetadataGetChallengeResult = ChallengeInfo
 type MetadataGetFolderHandleResult = Bytes
 type MetadataGetKeyBundlesResult = KeyBundleResponse


### PR DESCRIPTION
This adds a new RPC for the metadata protocol for finding the next MD for merkle checking. It also introduces access functions for KBFS-related merkle data in the global Merkle root.

Issue: KBFS-2903