### PR TITLE
deliver placeholders from cached response from GetThreadNonblock CORE-7745

### DIFF
--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -222,6 +222,9 @@ func (b *BackgroundConvLoader) Queue(ctx context.Context, job types.ConvLoaderJo
 func (b *BackgroundConvLoader) Suspend(ctx context.Context) (canceled bool) {
 	b.Lock()
 	defer b.Unlock()
+	if !b.started {
+		return false
+	}
 	if b.suspendCount == 0 {
 		b.resumeCh = make(chan struct{})
 		b.suspendCh <- b.resumeCh

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -611,7 +611,7 @@ func TestGetThreadHoleResolution(t *testing.T) {
 	}
 	doSync(t, syncer, ri, uid)
 
-	localThread, err := tc.Context().ConvSource.PullLocalOnly(ctx, convID, uid, nil, nil)
+	localThread, err := tc.Context().ConvSource.PullLocalOnly(ctx, convID, uid, nil, nil, 0)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(localThread.Messages))
 
@@ -882,7 +882,7 @@ func TestExpungeFromDelete(t *testing.T) {
 	require.NoError(t, hcs.storage.MaybeNuke(context.TODO(), true, nil, conv.GetConvID(), uid))
 	_, err = hcs.GetMessages(ctx, conv, uid, []chat1.MessageID{3, 2})
 	require.NoError(t, err)
-	tv, err := hcs.PullLocalOnly(ctx, conv.GetConvID(), uid, nil, nil)
+	tv, err := hcs.PullLocalOnly(ctx, conv.GetConvID(), uid, nil, nil, 0)
 	require.Error(t, err)
 	require.IsType(t, storage.MissError{}, err)
 
@@ -893,7 +893,7 @@ func TestExpungeFromDelete(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no conv loader")
 	}
-	tv, err = hcs.PullLocalOnly(ctx, conv.GetConvID(), uid, nil, nil)
+	tv, err = hcs.PullLocalOnly(ctx, conv.GetConvID(), uid, nil, nil, 0)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(tv.Messages))
 	require.Equal(t, chat1.MessageID(4), tv.Messages[0].GetMessageID())

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -396,7 +396,7 @@ func (h *Server) GetCachedThread(ctx context.Context, arg chat1.GetCachedThreadA
 	// Get messages from local disk only
 	uid := h.G().Env.GetUID()
 	thread, err := h.G().ConvSource.PullLocalOnly(ctx, arg.ConversationID,
-		gregor1.UID(uid.ToBytes()), arg.Query, arg.Pagination)
+		gregor1.UID(uid.ToBytes()), arg.Query, arg.Pagination, 0)
 	if err != nil {
 		return chat1.GetThreadLocalRes{}, err
 	}
@@ -548,7 +548,7 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 				h.clock.Sleep(*h.cachedThreadDelay)
 			}
 			localThread, err = h.G().ConvSource.PullLocalOnly(bctx, arg.ConversationID,
-				uid, arg.Query, pagination)
+				uid, arg.Query, pagination, 10)
 			ch <- err
 		}()
 		select {
@@ -1170,7 +1170,7 @@ func (h *Server) PostLocalNonblock(ctx context.Context, arg chat1.PostLocalNonbl
 	if arg.ClientPrev == 0 {
 		h.Debug(ctx, "PostLocalNonblock: ClientPrev not specified using local storage")
 		thread, err := h.G().ConvSource.PullLocalOnly(ctx, arg.ConversationID, uid.ToBytes(), nil,
-			&chat1.Pagination{Num: 1})
+			&chat1.Pagination{Num: 1}, 0)
 		if err != nil || len(thread.Messages) == 0 {
 			h.Debug(ctx, "PostLocalNonblock: unable to read local storage, setting ClientPrev to 1")
 			prevMsgID = 1

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -71,17 +71,15 @@ var _ chat1.LocalInterface = (*Server)(nil)
 
 func NewServer(g *globals.Context, store *attachments.Store, serverConn ServerConnection,
 	uiSource UISource) *Server {
-	delay := 10 * time.Second
 	return &Server{
-		Contextified:      globals.NewContextified(g),
-		DebugLabeler:      utils.NewDebugLabeler(g.GetLog(), "Server", false),
-		serverConn:        serverConn,
-		uiSource:          uiSource,
-		store:             store,
-		boxer:             NewBoxer(g),
-		identNotifier:     NewCachingIdentifyNotifier(g),
-		clock:             clockwork.NewRealClock(),
-		remoteThreadDelay: &delay,
+		Contextified:  globals.NewContextified(g),
+		DebugLabeler:  utils.NewDebugLabeler(g.GetLog(), "Server", false),
+		serverConn:    serverConn,
+		uiSource:      uiSource,
+		store:         store,
+		boxer:         NewBoxer(g),
+		identNotifier: NewCachingIdentifyNotifier(g),
+		clock:         clockwork.NewRealClock(),
 	}
 }
 
@@ -445,7 +443,7 @@ func (h *Server) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg
 func (h *Server) mergeLocalRemoteThread(ctx context.Context, remoteThread, localThread *chat1.ThreadView,
 	mode chat1.GetThreadNonblockCbMode) (res chat1.ThreadView, err error) {
 	defer func() {
-		if err != nil {
+		if err != nil || localThread == nil {
 			return
 		}
 		rm := make(map[chat1.MessageID]bool)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2343,6 +2343,89 @@ func TestChatSrvGetThreadNonblockIncremental(t *testing.T) {
 	})
 }
 
+func TestChatSrvGetThreadNonblockPlaceholders(t *testing.T) {
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetThreadNonblockPlaceholders", 1)
+		defer ctc.cleanup()
+		users := ctc.users()
+
+		editMsg := func(ctx context.Context, conv chat1.ConversationInfoLocal, msgID chat1.MessageID) chat1.MessageID {
+			postRes, err := ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, chat1.PostLocalArg{
+				ConversationID: conv.Id,
+				Msg: chat1.MessagePlaintext{
+					ClientHeader: chat1.MessageClientHeader{
+						Conv:        conv.Triple,
+						MessageType: chat1.MessageType_EDIT,
+						TlfName:     conv.TlfName,
+						Supersedes:  msgID,
+					},
+					MessageBody: chat1.NewMessageBodyWithEdit(chat1.MessageEdit{
+						MessageID: msgID,
+						Body:      "HI",
+					}),
+				},
+			})
+			require.NoError(t, err)
+			return postRes.MessageID
+		}
+
+		uid := gregor1.UID(users[0].GetUID().ToBytes())
+		inboxCb := make(chan kbtest.NonblockInboxResult, 100)
+		threadCb := make(chan kbtest.NonblockThreadResult, 100)
+		ui := kbtest.NewChatUI(inboxCb, threadCb, nil, nil)
+		ctc.as(t, users[0]).h.mockChatUI = ui
+		ctx := ctc.as(t, users[0]).startCtx
+		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt)
+		cs := ctc.world.Tcs[users[0].Username].ChatG.ConvSource
+		msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
+		msgID1 := mustPostLocalForTest(t, ctc, users[0], conv, msg)
+		editMsgID1 := editMsg(ctx, conv, msgID1)
+		msgID2 := mustPostLocalForTest(t, ctc, users[0], conv, msg)
+		editMsgID2 := editMsg(ctx, conv, msgID2)
+		msgID3 := mustPostLocalForTest(t, ctc, users[0], conv, msg)
+		msgRes, err := ctc.as(t, users[0]).chatLocalHandler().GetMessagesLocal(ctx, chat1.GetMessagesLocalArg{
+			ConversationID: conv.Id,
+			MessageIDs:     []chat1.MessageID{msgID3},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(msgRes.Messages))
+		msg3 := msgRes.Messages[0]
+		msgIDs := []chat1.MessageID{msgID3, editMsgID2, msgID2, editMsgID1, msgID1, 1}
+
+		require.NoError(t, cs.Clear(context.TODO(), conv.Id, uid))
+		_, err = cs.PushUnboxed(ctx, conv.Id, uid, msg3)
+		require.NoError(t, err)
+
+		delay := 10 * time.Minute
+		clock := clockwork.NewFakeClock()
+		ctc.as(t, users[0]).h.clock = clock
+		ctc.as(t, users[0]).h.remoteThreadDelay = &delay
+		cb := make(chan struct{})
+		query := chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}
+		go func() {
+			_, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(ctx,
+				chat1.GetThreadNonblockArg{
+					ConversationID: conv.Id,
+					Query:          &query,
+				},
+			)
+			require.NoError(t, err)
+			close(cb)
+		}()
+		select {
+		case res := <-threadCb:
+			require.False(t, res.Full)
+			require.Equal(t, len(msgIDs), len(res.Thread.Messages))
+			require.Equal(t, msgIDs, utils.PluckUIMessageIDs(res.Thread.Messages))
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no thread cb")
+		}
+
+	})
+}
+
 func TestChatSrvGetThreadNonblock(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetThreadNonblock", 1)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -66,7 +66,7 @@ type ConversationSource interface {
 	Pull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
 		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-		query *chat1.GetThreadQuery, p *chat1.Pagination) (chat1.ThreadView, error)
+		query *chat1.GetThreadQuery, p *chat1.Pagination, maxPlaceholders int) (chat1.ThreadView, error)
 	GetMessages(ctx context.Context, conv UnboxConversationInfo, uid gregor1.UID, msgIDs []chat1.MessageID) ([]chat1.MessageUnboxed, error)
 	GetMessagesWithRemotes(ctx context.Context, conv chat1.Conversation, uid gregor1.UID,
 		msgs []chat1.MessageBoxed) ([]chat1.MessageUnboxed, error)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -449,9 +449,14 @@ func FilterByType(msgs []chat1.MessageUnboxed, query *chat1.GetThreadQuery, incl
 			}
 			continue
 		}
-		if includeAllErrors && state == chat1.MessageUnboxedState_ERROR {
+		switch state {
+		case chat1.MessageUnboxedState_ERROR:
+			if includeAllErrors {
+				res = append(res, msg)
+			}
+		case chat1.MessageUnboxedState_PLACEHOLDER:
 			res = append(res, msg)
-		} else {
+		default:
 			_, match := typmap[msg.GetMessageType()]
 			if !useTypeFilter || match {
 				res = append(res, msg)
@@ -630,6 +635,13 @@ func PluckMessageIDs(msgs []chat1.MessageSummary) []chat1.MessageID {
 	res := make([]chat1.MessageID, len(msgs))
 	for i, m := range msgs {
 		res[i] = m.GetMessageID()
+	}
+	return res
+}
+
+func PluckUIMessageIDs(msgs []chat1.UIMessage) (res []chat1.MessageID) {
+	for _, m := range msgs {
+		res = append(res, m.GetMessageID())
 	}
 	return res
 }

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -455,6 +455,7 @@ func FilterByType(msgs []chat1.MessageUnboxed, query *chat1.GetThreadQuery, incl
 				res = append(res, msg)
 			}
 		case chat1.MessageUnboxedState_PLACEHOLDER:
+			// We don't know what the type is for these, so just include them
 			res = append(res, msg)
 		default:
 			_, match := typmap[msg.GetMessageType()]

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2275,11 +2275,13 @@ func (o MessageUnboxedError) DeepCopy() MessageUnboxedError {
 
 type MessageUnboxedPlaceholder struct {
 	MessageID MessageID `codec:"messageID" json:"messageID"`
+	Hidden    bool      `codec:"hidden" json:"hidden"`
 }
 
 func (o MessageUnboxedPlaceholder) DeepCopy() MessageUnboxedPlaceholder {
 	return MessageUnboxedPlaceholder{
 		MessageID: o.MessageID.DeepCopy(),
+		Hidden:    o.Hidden,
 	}
 }
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -350,14 +350,14 @@ func (d *Service) startChatModules() {
 		uid := d.G().Env.GetUID().ToBytes()
 		g := globals.NewContext(d.G(), d.ChatG())
 		g.MessageDeliverer.Start(context.Background(), uid)
-		g.ConvLoader.Start(context.Background(), uid)
+		//	g.ConvLoader.Start(context.Background(), uid)
 		g.FetchRetrier.Start(context.Background(), uid)
 	}
 }
 
 func (d *Service) stopChatModules() {
 	<-d.ChatG().MessageDeliverer.Stop(context.Background())
-	<-d.ChatG().ConvLoader.Stop(context.Background())
+	//<-d.ChatG().ConvLoader.Stop(context.Background())
 	<-d.ChatG().FetchRetrier.Stop(context.Background())
 }
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -350,14 +350,14 @@ func (d *Service) startChatModules() {
 		uid := d.G().Env.GetUID().ToBytes()
 		g := globals.NewContext(d.G(), d.ChatG())
 		g.MessageDeliverer.Start(context.Background(), uid)
-		//	g.ConvLoader.Start(context.Background(), uid)
+		g.ConvLoader.Start(context.Background(), uid)
 		g.FetchRetrier.Start(context.Background(), uid)
 	}
 }
 
 func (d *Service) stopChatModules() {
 	<-d.ChatG().MessageDeliverer.Stop(context.Background())
-	//<-d.ChatG().ConvLoader.Stop(context.Background())
+	<-d.ChatG().ConvLoader.Stop(context.Background())
 	<-d.ChatG().FetchRetrier.Stop(context.Background())
 }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -382,6 +382,7 @@ protocol local {
 
   record MessageUnboxedPlaceholder {
     MessageID messageID;
+    boolean hidden;
   }
 
   // If a new case is needed here, make sure to update UIMessage in chat_ui.avdl as well.

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -1073,7 +1073,7 @@ export type MessageUnboxedErrorType =
   | 2 // BADVERSION_2
   | 3 // IDENTIFY_3
 
-export type MessageUnboxedPlaceholder = $ReadOnly<{messageID: MessageID}>
+export type MessageUnboxedPlaceholder = $ReadOnly<{messageID: MessageID, hidden: Boolean}>
 
 export type MessageUnboxedState =
   | 1 // VALID_1

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1146,6 +1146,10 @@
         {
           "type": "MessageID",
           "name": "messageID"
+        },
+        {
+          "type": "boolean",
+          "name": "hidden"
         }
       ]
     },

--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -452,12 +452,18 @@ const placeholderUIMessageToMessage = (
   uiMessage: RPCChatTypes.UIMessage,
   p: RPCChatTypes.MessageUnboxedPlaceholder
 ) => {
-  return makeMessageText({
-    conversationIDKey,
-    errorReason: 'waiting for message from server...',
-    id: Types.numberToMessageID(p.messageID),
-    ordinal: Types.numberToOrdinal(p.messageID),
-  })
+  return !p.hidden
+    ? makeMessageText({
+        conversationIDKey,
+        errorReason: 'waiting for message from server...',
+        id: Types.numberToMessageID(p.messageID),
+        ordinal: Types.numberToOrdinal(p.messageID),
+      })
+    : makeMessageDeleted({
+        conversationIDKey,
+        id: Types.numberToMessageID(p.messageID),
+        ordinal: Types.numberToOrdinal(p.messageID),
+      })
 }
 
 const errorUIMessagetoMessage = (

--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -447,6 +447,19 @@ const outboxUIMessagetoMessage = (
   })
 }
 
+const placeholderUIMessageToMessage = (
+  conversationIDKey: Types.ConversationIDKey,
+  uiMessage: RPCChatTypes.UIMessage,
+  p: RPCChatTypes.MessageUnboxedPlaceholder
+) => {
+  return makeMessageText({
+    conversationIDKey,
+    errorReason: 'waiting for message from server...',
+    id: Types.numberToMessageID(p.messageID),
+    ordinal: Types.numberToOrdinal(p.messageID),
+  })
+}
+
 const errorUIMessagetoMessage = (
   conversationIDKey: Types.ConversationIDKey,
   uiMessage: RPCChatTypes.UIMessage,
@@ -484,7 +497,10 @@ export const uiMessageToMessage = (
       }
       break
     case RPCChatTypes.chatUiMessageUnboxedState.placeholder:
-      return null
+      if (uiMessage.placeholder) {
+        return placeholderUIMessageToMessage(conversationIDKey, uiMessage, uiMessage.placeholder)
+      }
+      break
     default:
       /*::
       declare var ifFlowErrorsHereItsCauseYouDidntHandleAllTypesAbove: (a: empty) => any

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -1073,7 +1073,7 @@ export type MessageUnboxedErrorType =
   | 2 // BADVERSION_2
   | 3 // IDENTIFY_3
 
-export type MessageUnboxedPlaceholder = $ReadOnly<{messageID: MessageID}>
+export type MessageUnboxedPlaceholder = $ReadOnly<{messageID: MessageID, hidden: Boolean}>
 
 export type MessageUnboxedState =
   | 1 // VALID_1


### PR DESCRIPTION
**Background**
A common problem on a spotty connection on mobile is that when tapping into a thread, we will show only the most recent message (the snippet message), and none of the cached messages we have stored. The main reason for this is we have no way to render a gap in the message from the snippet to the stored messages. This patch fixes this problem by transmitting back placeholder rows in the cached response from GetThreadNonblock, and clearing/replacing them when we get the full thread. 

cc @malgorithms Please let me know what you think.

**Go**
1.) Change `PullLocalOnly` to return placeholder messages if so instructed by the new `maxPlaceholders` argument. We already had a way to query the disk cache with "holes", so just re-use that mechanic.
2.) When returning the remote callback from `GetThreadNonblock`, we check to make sure we have replaced all of the placeholder messages we sent in the cached version. If we have not, then replace those with hidden placeholders so the UI can drop them. This happens if some of the placeholders represent invisible messages like edits.

**JS**
@keybase/react-hackers 
1.) Render placeholder messages with some red text. 

Here is what it looks like:
Loading:
![image](https://user-images.githubusercontent.com/1250314/39437016-a6e45594-4c6d-11e8-830b-b0ca280af10e.png)

Done:
![image](https://user-images.githubusercontent.com/1250314/39437028-ace8ffe4-4c6d-11e8-9f78-554cc09c654f.png)

