### PR TITLE
Fix message popup

### DIFF
--- a/shared/chat/conversation/messages/wrapper/shared.js
+++ b/shared/chat/conversation/messages/wrapper/shared.js
@@ -46,8 +46,8 @@ const Username = ({username, isYou, isFollowing, isBroken, onClick}) => {
   )
 }
 
-const MenuButton = ({onClick}) => (
-  <Box className="menu-button">
+const MenuButton = ({onClick, setRef}) => (
+  <Box ref={setRef} className="menu-button">
     <Icon type="iconfont-ellipsis" style={styles.ellipsis} onClick={onClick} fontSize={16} />
   </Box>
 )
@@ -133,7 +133,9 @@ class MessageWrapper extends React.PureComponent<Props & FloatingMenuParentProps
                   />
                   {props.isEdited && <EditedMark />}
                 </Box>
-                {!isMobile && <MenuButton ref={props.setAttachmentRef} onClick={props.toggleShowingMenu} />}
+                {!isMobile && (
+                  <MenuButton setRef={props.setAttachmentRef} onClick={props.toggleShowingMenu} />
+                )}
                 <MessagePopup
                   attachTo={props.attachmentRef}
                   message={props.message}

--- a/shared/common-adapters/floating-menu.js
+++ b/shared/common-adapters/floating-menu.js
@@ -53,6 +53,8 @@ type State = {
 type Callbacks = {
   setShowingMenu: boolean => void,
   toggleShowingMenu: () => void,
+  // WARNING: Only use setAttachmentRef on class components. Otherwise the ref will be
+  // optimized out in production code!
   setAttachmentRef: ?(?React.Component<*, *>) => void,
 }
 


### PR DESCRIPTION
`setAttachmentRef` can get optimized out in production code when it's used on a functional components ([more info](https://reactjs.org/docs/refs-and-the-dom.html) and discussion https://github.com/facebook/react/issues/4936). I ticketed figuring out a reliable scheme for it, for now this adds a warning comment and pipes through the ref to the inner `Box`, which is stateful. r? @keybase/react-hackers 