### PR TITLE
Default wallet OutsideCurrency

### DIFF
--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -171,6 +171,8 @@ func (s *Server) SetDisplayCurrency(ctx context.Context, arg stellar1.SetDisplay
 
 type exchangeRateMap map[string]stellar1.OutsideExchangeRate
 
+const defaultOutsideCurrency = "USD"
+
 // getLocalCurrencyAndExchangeRate gets display currency setting
 // for accountID and fetches exchange rate is set.
 //
@@ -181,7 +183,9 @@ func getLocalCurrencyAndExchangeRate(ctx context.Context, g *libkb.GlobalContext
 		return err
 	}
 	if displayCurrency == "" {
-		return nil
+		displayCurrency = defaultOutsideCurrency
+		g.Log.CDebugf(ctx, "Setting default display currency %s for account %s",
+			displayCurrency, account.AccountID)
 	}
 	rate, ok := exchangeRates[displayCurrency]
 	if !ok {
@@ -219,7 +223,7 @@ func (s *Server) WalletGetLocalAccounts(ctx context.Context) (ret []stellar1.Loc
 			Name:      account.Name,
 		}
 
-		balances, err := remote.Balances(ctx, s.G(), accID)
+		balances, err := s.remoter.Balances(ctx, accID)
 		if err != nil {
 			accountError = err
 			s.G().Log.Warning("Could not load balance for %q", accID)

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -214,6 +214,8 @@ func TestBalances(t *testing.T) {
 	require.Len(t, balances, 1)
 	require.Equal(t, balances[0].Asset.Type, "native")
 	require.Equal(t, balances[0].Amount, "10000")
+
+	tcs[0].Srv.WalletGetLocalAccounts(context.Background())
 }
 
 func TestSendLocalStellarAddress(t *testing.T) {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -214,8 +214,29 @@ func TestBalances(t *testing.T) {
 	require.Len(t, balances, 1)
 	require.Equal(t, balances[0].Asset.Type, "native")
 	require.Equal(t, balances[0].Amount, "10000")
+}
 
-	tcs[0].Srv.WalletGetLocalAccounts(context.Background())
+func TestGetLocalAccounts(t *testing.T) {
+	tcs, cleanup := setupNTests(t, 1)
+	defer cleanup()
+
+	created, err := stellar.CreateWallet(context.Background(), tcs[0].G)
+	require.True(t, created)
+	require.NoError(t, err)
+
+	tcs[0].Remote.ImportAccountsForUser(t, tcs[0].G)
+
+	accs, err := tcs[0].Srv.WalletGetLocalAccounts(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, accs, 1)
+	account := accs[0]
+	require.Len(t, account.Balance, 1)
+	require.Equal(t, account.Balance[0].Asset.Type, "native")
+	require.Equal(t, account.Balance[0].Amount, "0")
+	require.True(t, account.IsPrimary)
+	require.NotNil(t, account.ExchangeRate)
+	require.EqualValues(t, defaultOutsideCurrency, account.ExchangeRate.Currency)
 }
 
 func TestSendLocalStellarAddress(t *testing.T) {


### PR DESCRIPTION
`WalletGetLocalAccounts` API will return default outside/local currency=USD when currency is not set for the account. `wallet balances` command still understands nil-currency though, in case we want to go back.

Change `WalletGetLocalAccounts` to use `s.remoter` so it can be tested. In tests, added `ImportAccountsForUser` function, that will fetch and add accounts to the local mock account table. `TestGetLocalAccounts` is a new test that will create wallet using AP, then call `WalletGetLocalAccounts`, and inspect the result, also checking if default currency is returned.

TODO: If we decide to, change ExchangeRate to use mock as well. Right now it relies on *real* exchange rate API in keybase/keybase, which in turn relies in coinmarketcap.