### PR TITLE
Fix initscripts requirement

### DIFF
--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -114,12 +114,12 @@ export debian_arch=i386
 # found.  "psmisc" provides "killall", which is used in run_keybase.
 # "initscripts" provides "service", which is used to start atd in the
 # post-install.
-dependencies="Requires: at, fuse, libXss.so.1, initscripts, psmisc"
+dependencies="Requires: at, fuse, libXss.so.1, /sbin/service, psmisc"
 build_one_architecture
 
 export rpm_arch=x86_64
 export debian_arch=amd64
 # Requiring "libXss.so" here installs the 32-bit version. See
 # https://github.com/keybase/client/pull/5226.
-dependencies="Requires: at, fuse, libXss.so.1()(64bit), initscripts, psmisc"
+dependencies="Requires: at, fuse, libXss.so.1()(64bit), /sbin/service, psmisc"
 build_one_architecture


### PR DESCRIPTION
openSUSE and some others distributions uses a different name for package initscripts
This fix uses the name of the module provided by the package, this will make dependency independent of package name.

keybase/keybase-issues#3202

This PR is an internal version of https://github.com/keybase/client/pull/11414, to trigger CI.