### PR TITLE
Mock floating box in storyshots

### DIFF
--- a/shared/chat/conversation/messages/set-explode-popup/index.stories.js
+++ b/shared/chat/conversation/messages/set-explode-popup/index.stories.js
@@ -12,7 +12,7 @@ const common = {
   onSelect: action('onSelect'),
   selected: null,
   items,
-  visible: false, // TODO (for storyshots, see DESKTOP-6620)
+  visible: true,
 }
 
 const load = () => {

--- a/shared/common-adapters/__mocks__/floating-box.desktop.js
+++ b/shared/common-adapters/__mocks__/floating-box.desktop.js
@@ -4,7 +4,7 @@ import Box from '../box'
 import type {Props} from '../floating-box'
 
 export default class FloatingBox extends React.Component<Props, {}> {
-  static getDerivedStateFromProps = (props: Props) => ({})
+  state = {}
   render() {
     return <Box style={this.props.containerStyle}>{this.props.children}</Box>
   }

--- a/shared/common-adapters/__mocks__/floating-box.desktop.js
+++ b/shared/common-adapters/__mocks__/floating-box.desktop.js
@@ -1,0 +1,11 @@
+// @flow
+import * as React from 'react'
+import Box from '../box'
+import type {Props} from '../floating-box'
+
+export default class FloatingBox extends React.Component<Props, {}> {
+  static getDerivedStateFromProps = (props: Props) => ({})
+  render() {
+    return <Box style={this.props.containerStyle}>{this.props.children}</Box>
+  }
+}

--- a/shared/stories/__tests__/Storyshots.test.js
+++ b/shared/stories/__tests__/Storyshots.test.js
@@ -3,6 +3,7 @@
 // eslint-disable-next-line
 import initStoryshots from '@storybook/addon-storyshots'
 jest.mock('../../util/timestamp')
+jest.mock('../../common-adapters/floating-box.desktop')
 initStoryshots({
   configPath: '.storybook',
 })


### PR DESCRIPTION
Allows us to take storyshots of bare 'floating' stuff with `visible: true` set initially. r? @keybase/react-hackers cc @cjb 