### PR TITLE
Team rotation in background

### DIFF
--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -29,19 +29,6 @@ func HandleRotateRequest(ctx context.Context, g *libkb.GlobalContext, msg keybas
 	}
 
 	if len(msg.ResetUsersUntrusted) > 0 && team.IsOpen() {
-		for _, uv := range msg.ResetUsersUntrusted {
-			// We don't use UIDMapper in sweepOpenTeamResetMembers, but
-			// since server just told us that these users have reset, we
-			// might as well use that knowledge to refresh cache.
-
-			// Use ClearUIDAtEldestSeqno instead of InformOfEldestSeqno
-			// because usually uv.UserEldestSeqno (the "new EldestSeqno")
-			// will be 0, because user has just reset and hasn't
-			// reprovisioned yet
-
-			g.UIDMapper.ClearUIDAtEldestSeqno(ctx, g, uv.Uid, uv.MemberEldestSeqno)
-		}
-
 		if needRP, err := sweepOpenTeamResetMembers(ctx, g, team, msg.ResetUsersUntrusted); err == nil {
 			// If sweepOpenTeamResetMembers does not do anything to
 			// the team, do not load team again later.


### PR DESCRIPTION
- Move `ClearUIDAtEldestSeqno` using server provided `ResetUsersUntrusted` to `teamHandler.rotateTeam` - this is rather quick so it can be done right there in gregor thread.
- Run `teams.HandleRotateRequest` in a goroutine. Add a lock to `teamHandler` so there can be only one rotate request being processed at a time.
- Move msg dismissal to the new goroutine as well. This makes `teamHandler.rotateTeam` always return nil error, I don't know if it's a problem.

It would be also great to make these background rotations cancellable. But I think this would better be done somewhere on a gregor layer. However right now I don't know enough about how contexts work to be able to propose a solution.

Also there might be an issue where a team is being rotated and then another rotation request comes for the same team. But we have similar issue right now as well, where I believe client would just keep itself busy churning on these requests one after another. So nothing changes apart from that it will churn in the background.