### PR TITLE
protocol: add merkle root to FindNextMD response

### DIFF
--- a/go/protocol/keybase1/metadata.go
+++ b/go/protocol/keybase1/metadata.go
@@ -149,13 +149,15 @@ func (o LockContext) DeepCopy() LockContext {
 }
 
 type FindNextMDResponse struct {
-	MerkleNodes [][]byte `codec:"merkleNodes" json:"merkleNodes"`
-	RootSeqno   Seqno    `codec:"rootSeqno" json:"rootSeqno"`
-	RootHash    HashMeta `codec:"rootHash" json:"rootHash"`
+	KbfsRoot    MerkleRoot `codec:"kbfsRoot" json:"kbfsRoot"`
+	MerkleNodes [][]byte   `codec:"merkleNodes" json:"merkleNodes"`
+	RootSeqno   Seqno      `codec:"rootSeqno" json:"rootSeqno"`
+	RootHash    HashMeta   `codec:"rootHash" json:"rootHash"`
 }
 
 func (o FindNextMDResponse) DeepCopy() FindNextMDResponse {
 	return FindNextMDResponse{
+		KbfsRoot: o.KbfsRoot.DeepCopy(),
 		MerkleNodes: (func(x [][]byte) [][]byte {
 			if x == nil {
 				return nil

--- a/protocol/avdl/keybase1/metadata.avdl
+++ b/protocol/avdl/keybase1/metadata.avdl
@@ -53,6 +53,7 @@ protocol metadata {
   }
 
   record FindNextMDResponse {
+     MerkleRoot kbfsRoot;
      array<bytes> merkleNodes;
      Seqno rootSeqno;
      HashMeta rootHash;

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2345,7 +2345,7 @@ export type FileType =
   | 1 // DIRECTORY_1
   | 2 // FILE_2
 
-export type FindNextMDResponse = $ReadOnly<{merkleNodes?: ?Array<Bytes>, rootSeqno: Seqno, rootHash: HashMeta}>
+export type FindNextMDResponse = $ReadOnly<{kbfsRoot: MerkleRoot, merkleNodes?: ?Array<Bytes>, rootSeqno: Seqno, rootHash: HashMeta}>
 
 export type FirstStepResult = $ReadOnly<{valPlusTwo: Int}>
 

--- a/protocol/json/keybase1/metadata.json
+++ b/protocol/json/keybase1/metadata.json
@@ -145,6 +145,10 @@
       "name": "FindNextMDResponse",
       "fields": [
         {
+          "type": "MerkleRoot",
+          "name": "kbfsRoot"
+        },
+        {
           "type": {
             "type": "array",
             "items": "bytes"

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2345,7 +2345,7 @@ export type FileType =
   | 1 // DIRECTORY_1
   | 2 // FILE_2
 
-export type FindNextMDResponse = $ReadOnly<{merkleNodes?: ?Array<Bytes>, rootSeqno: Seqno, rootHash: HashMeta}>
+export type FindNextMDResponse = $ReadOnly<{kbfsRoot: MerkleRoot, merkleNodes?: ?Array<Bytes>, rootSeqno: Seqno, rootHash: HashMeta}>
 
 export type FirstStepResult = $ReadOnly<{valPlusTwo: Int}>
 


### PR DESCRIPTION
This will allow the caller to find the pubkey and nonce needed to decrypt encrypted leaves.

Issue: KBFS-2904