### PR TITLE
Don't show the edit option for other people's messages.

### DIFF
--- a/shared/chat/conversation/messages/message-popup/exploding/index.js
+++ b/shared/chat/conversation/messages/message-popup/exploding/index.js
@@ -119,7 +119,14 @@ class ExplodingPopupHeader extends React.Component<Props & TimerProps, State> {
 
 const ExplodingPopupMenu = (props: Props & TimerProps) => {
   const items = [
-    {disabled: !props.onEdit, onClick: props.onEdit, title: 'Edit'},
+    ...(props.onEdit
+      ? [
+          {
+            onClick: props.onEdit,
+            title: 'Edit',
+          },
+        ]
+      : []),
     ...(props.yourMessage
       ? [
           {

--- a/shared/chat/conversation/messages/message-popup/text/index.js
+++ b/shared/chat/conversation/messages/message-popup/text/index.js
@@ -55,7 +55,6 @@ const TextPopupMenu = (props: Props) => {
     ...(props.onEdit
       ? [
           {
-            disabled: !props.onEdit,
             onClick: props.onEdit,
             title: 'Edit',
           },

--- a/shared/chat/conversation/messages/message-popup/text/index.js
+++ b/shared/chat/conversation/messages/message-popup/text/index.js
@@ -52,7 +52,15 @@ const TextPopupMenu = (props: Props) => {
         ]
       : []),
     ...(props.yourMessage || props.onDeleteMessageHistory ? ['Divider'] : []),
-    {disabled: !props.onEdit, onClick: props.onEdit, title: 'Edit'},
+    ...(props.onEdit
+      ? [
+          {
+            disabled: !props.onEdit,
+            onClick: props.onEdit,
+            title: 'Edit',
+          },
+        ]
+      : []),
     {onClick: props.onCopy, title: 'Copy Text'},
     {onClick: props.onQuote, title: 'Quote'},
     {onClick: props.onReplyPrivately, title: 'Reply Privately'},


### PR DESCRIPTION
Is there ever a time when we'd show someone the edit option and it would be inactive? If so, I'll need to add the `disabled` prop back.

@keybase/react-hackers, this is ready for review.