### PR TITLE
Add keybase script for arbitrary futzing

### DIFF
--- a/go/client/cmd_script.go
+++ b/go/client/cmd_script.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+type CmdScript struct {
+	libkb.Contextified
+	Script string
+	Args   []string
+}
+
+func newCmdScript(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "script",
+		ArgumentHelp: "<script> [<args>]",
+		Usage:        "Run a dev debug script",
+		Action: func(c *cli.Context) {
+			cmd := NewCmdScriptRunner(g)
+			cl.ChooseCommand(cmd, "script", c)
+		},
+		Flags: []cli.Flag{},
+	}
+}
+
+func NewCmdScriptRunner(g *libkb.GlobalContext) *CmdScript {
+	return &CmdScript{Contextified: libkb.NewContextified(g)}
+}
+
+func (c *CmdScript) ParseArgv(ctx *cli.Context) error {
+	args := ctx.Args()
+	if len(args) < 1 {
+		return fmt.Errorf("script name required")
+	}
+	c.Script = args[0]
+	c.Args = args[1:]
+	return nil
+}
+
+func (c *CmdScript) Run() error {
+	cli, err := GetDebuggingClient(c.G())
+	if err != nil {
+		return err
+	}
+	res, err := cli.Script(context.Background(), keybase1.ScriptArg{
+		Script: c.Script,
+		Args:   c.Args,
+	})
+	dui := c.G().UI.GetDumbOutputUI()
+	dui.Printf("%v", res)
+	return err
+}
+
+func (c *CmdScript) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -31,6 +31,7 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 		newCmdTeamGenerateSeitan(cl, g),
 		newCmdTeamRotateKey(cl, g),
 		newCmdTeamDebug(cl, g),
+		newCmdScript(cl, g),
 	}
 }
 

--- a/go/client/rpc.go
+++ b/go/client/rpc.go
@@ -280,6 +280,15 @@ func GetChatLocalClient(g *libkb.GlobalContext) (cli chat1.LocalClient, err erro
 	return cli, nil
 }
 
+func GetDebuggingClient(g *libkb.GlobalContext) (cli keybase1.DebuggingClient, err error) {
+	rcli, _, err := GetRPCClientWithContext(g)
+	if err != nil {
+		return cli, err
+	}
+	cli = keybase1.DebuggingClient{Cli: rcli}
+	return cli, nil
+}
+
 func introduceMyself(g *libkb.GlobalContext, xp rpc.Transporter) error {
 	cli := rpc.NewClient(xp, libkb.NewContextifiedErrorUnwrapper(g), nil)
 	ccli := keybase1.ConfigClient{Cli: cli}

--- a/go/service/debugging.go
+++ b/go/service/debugging.go
@@ -11,14 +11,18 @@ import (
 )
 
 type DebuggingHandler struct {
+	libkb.Contextified
 	*BaseHandler
 }
 
 func NewDebuggingHandler(xp rpc.Transporter, g *libkb.GlobalContext) *DebuggingHandler {
-	return &DebuggingHandler{BaseHandler: NewBaseHandler(g, xp)}
+	return &DebuggingHandler{
+		Contextified: libkb.NewContextified(g),
+		BaseHandler:  NewBaseHandler(g, xp),
+	}
 }
 
-func (t DebuggingHandler) FirstStep(ctx context.Context, arg keybase1.FirstStepArg) (result keybase1.FirstStepResult, err error) {
+func (t *DebuggingHandler) FirstStep(ctx context.Context, arg keybase1.FirstStepArg) (result keybase1.FirstStepResult, err error) {
 	client := t.rpcClient()
 	cbArg := keybase1.SecondStepArg{Val: arg.Val + 1, SessionID: arg.SessionID}
 	var cbReply int
@@ -31,12 +35,12 @@ func (t DebuggingHandler) FirstStep(ctx context.Context, arg keybase1.FirstStepA
 	return
 }
 
-func (t DebuggingHandler) SecondStep(_ context.Context, arg keybase1.SecondStepArg) (val int, err error) {
+func (t *DebuggingHandler) SecondStep(_ context.Context, arg keybase1.SecondStepArg) (val int, err error) {
 	val = arg.Val + 1
 	return
 }
 
-func (t DebuggingHandler) Increment(_ context.Context, arg keybase1.IncrementArg) (val int, err error) {
+func (t *DebuggingHandler) Increment(_ context.Context, arg keybase1.IncrementArg) (val int, err error) {
 	val = arg.Val + 1
 	return
 }

--- a/go/service/debugging_devel.go
+++ b/go/service/debugging_devel.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+//
+// +build !production
+
+package service
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (res string, err error) {
+	ctx = libkb.WithLogTag(ctx, "DG")
+	defer t.G().CTraceTimed(ctx, fmt.Sprintf("Script(%s)", arg.Script), func() error { return err })()
+	args := arg.Args
+	log := func(format string, args ...interface{}) {
+		t.G().Log.CInfof(ctx, format, args...)
+	}
+	defer time.Sleep(100 * time.Millisecond) // Without this CInfof often doesn't reach the CLI
+	switch arg.Script {
+	case "rid2":
+		if len(args) != 2 {
+			return "", fmt.Errorf("require 2 args: <mode:gui/kbfs> <assertion>")
+		}
+		idBehavior := keybase1.TLFIdentifyBehavior_CHAT_GUI
+		var iui libkb.IdentifyUI
+		switch args[0] {
+		case "gui":
+		case "kbfs":
+			idBehavior = keybase1.TLFIdentifyBehavior_CHAT_GUI
+			iui = t.NewRemoteIdentifyUI(0)
+		default:
+			return "", fmt.Errorf("unrecognized mode %v: use 'gui' or 'kbfs'", args[0])
+		}
+		eng := engine.NewResolveThenIdentify2(t.G(), &keybase1.Identify2Arg{
+			UserAssertion:    args[1],
+			UseDelegateUI:    false,
+			Reason:           keybase1.IdentifyReason{Reason: "debugging script"},
+			CanSuppressUI:    true,
+			IdentifyBehavior: idBehavior,
+		})
+		err := engine.RunEngine(eng, &engine.Context{
+			IdentifyUI: iui,
+			NetContext: ctx,
+		})
+		log("GetProofSet: %v", spew.Sdump(eng.GetProofSet()))
+		log("ConfirmResult: %v", spew.Sdump(eng.ConfirmResult()))
+		eres := eng.Result()
+		if eres != nil {
+			log("Result.Upk.Username: %v", spew.Sdump(eres.Upk.Username))
+			log("Result.IdentifiedAt: %v", spew.Sdump(eres.IdentifiedAt))
+			log("Result.TrackBreaks: %v", spew.Sdump(eres.TrackBreaks))
+		} else {
+			log("Result: %v", spew.Sdump(eres))
+		}
+		return "", err
+	case "":
+		return "", fmt.Errorf("empty script name")
+	default:
+		return "", fmt.Errorf("unknown script: %v", arg.Script)
+	}
+}
+
+func (t *DebuggingHandler) NewRemoteIdentifyUI(sessionID int) *RemoteIdentifyUI {
+	c := t.rpcClient()
+	return &RemoteIdentifyUI{
+		sessionID:    sessionID,
+		uicli:        keybase1.IdentifyUiClient{Cli: c},
+		logUI:        t.getLogUI(sessionID),
+		Contextified: libkb.NewContextified(t.G()),
+	}
+}

--- a/go/service/debugging_production.go
+++ b/go/service/debugging_production.go
@@ -1,0 +1,18 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+//
+// +build production
+
+package service
+
+import (
+	"fmt"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (string, error) {
+	defer t.G().CTraceTimed(ctx, "Script", func() error { return err })()
+	return "", fmt.Errorf("debugging script not supported in production builds")
+}

--- a/protocol/avdl/keybase1/debugging.avdl
+++ b/protocol/avdl/keybase1/debugging.avdl
@@ -15,4 +15,6 @@ protocol debugging {
 
   // Increment val
   int increment(int sessionID, int val);
+
+  string script(string script, array<string> args);
 }

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -630,6 +630,10 @@ export const debuggingIncrementRpcChannelMap = (configKeys: Array<string>, reque
 
 export const debuggingIncrementRpcPromise = (request: DebuggingIncrementRpcParam): Promise<DebuggingIncrementResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.debugging.increment', request, (error: RPCError, result: DebuggingIncrementResult) => (error ? reject(error) : resolve(result))))
 
+export const debuggingScriptRpcChannelMap = (configKeys: Array<string>, request: DebuggingScriptRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.debugging.script', request)
+
+export const debuggingScriptRpcPromise = (request: DebuggingScriptRpcParam): Promise<DebuggingScriptResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.debugging.script', request, (error: RPCError, result: DebuggingScriptResult) => (error ? reject(error) : resolve(result))))
+
 export const debuggingSecondStepRpcChannelMap = (configKeys: Array<string>, request: DebuggingSecondStepRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.debugging.secondStep', request)
 
 export const debuggingSecondStepRpcPromise = (request: DebuggingSecondStepRpcParam): Promise<DebuggingSecondStepResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.debugging.secondStep', request, (error: RPCError, result: DebuggingSecondStepResult) => (error ? reject(error) : resolve(result))))
@@ -2206,6 +2210,8 @@ export type DbValue = Bytes
 export type DebuggingFirstStepRpcParam = $ReadOnly<{val: Int, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type DebuggingIncrementRpcParam = $ReadOnly<{val: Int, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type DebuggingScriptRpcParam = $ReadOnly<{script: String, args?: ?Array<String>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type DebuggingSecondStepRpcParam = $ReadOnly<{val: Int, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
@@ -4160,6 +4166,7 @@ type CryptocurrencyRegisterAddressResult = RegisterAddressRes
 type CtlDbGetResult = ?DbValue
 type DebuggingFirstStepResult = FirstStepResult
 type DebuggingIncrementResult = Int
+type DebuggingScriptResult = String
 type DebuggingSecondStepResult = Int
 type DeviceCheckDeviceNameFormatResult = Boolean
 type DeviceDeviceHistoryListResult = ?Array<DeviceDetail>

--- a/protocol/json/keybase1/debugging.json
+++ b/protocol/json/keybase1/debugging.json
@@ -52,6 +52,22 @@
         }
       ],
       "response": "int"
+    },
+    "script": {
+      "request": [
+        {
+          "name": "script",
+          "type": "string"
+        },
+        {
+          "name": "args",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
+        }
+      ],
+      "response": "string"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -630,6 +630,10 @@ export const debuggingIncrementRpcChannelMap = (configKeys: Array<string>, reque
 
 export const debuggingIncrementRpcPromise = (request: DebuggingIncrementRpcParam): Promise<DebuggingIncrementResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.debugging.increment', request, (error: RPCError, result: DebuggingIncrementResult) => (error ? reject(error) : resolve(result))))
 
+export const debuggingScriptRpcChannelMap = (configKeys: Array<string>, request: DebuggingScriptRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.debugging.script', request)
+
+export const debuggingScriptRpcPromise = (request: DebuggingScriptRpcParam): Promise<DebuggingScriptResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.debugging.script', request, (error: RPCError, result: DebuggingScriptResult) => (error ? reject(error) : resolve(result))))
+
 export const debuggingSecondStepRpcChannelMap = (configKeys: Array<string>, request: DebuggingSecondStepRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.debugging.secondStep', request)
 
 export const debuggingSecondStepRpcPromise = (request: DebuggingSecondStepRpcParam): Promise<DebuggingSecondStepResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.debugging.secondStep', request, (error: RPCError, result: DebuggingSecondStepResult) => (error ? reject(error) : resolve(result))))
@@ -2206,6 +2210,8 @@ export type DbValue = Bytes
 export type DebuggingFirstStepRpcParam = $ReadOnly<{val: Int, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type DebuggingIncrementRpcParam = $ReadOnly<{val: Int, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
+export type DebuggingScriptRpcParam = $ReadOnly<{script: String, args?: ?Array<String>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type DebuggingSecondStepRpcParam = $ReadOnly<{val: Int, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
@@ -4160,6 +4166,7 @@ type CryptocurrencyRegisterAddressResult = RegisterAddressRes
 type CtlDbGetResult = ?DbValue
 type DebuggingFirstStepResult = FirstStepResult
 type DebuggingIncrementResult = Int
+type DebuggingScriptResult = String
 type DebuggingSecondStepResult = Int
 type DeviceCheckDeviceNameFormatResult = Boolean
 type DeviceDeviceHistoryListResult = ?Array<DeviceDetail>


### PR DESCRIPTION
`keybase script <scriptname> [<args>...]` is for running arbitrary junk in the service for debugging. Not compiled into prod builds.

`keybase script rid2 gui rook1@rooter` runs `ResolveThenIdentify2` and pretty prints the results.