### PR TITLE
make passphrase stream cache thread safe

### DIFF
--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -188,13 +188,11 @@ func (a *Account) CreateStreamCache(tsec Triplesec, pps *PassphraseStream) {
 // SetStreamGeneration sets the passphrase generation on the cached stream
 // if it exists, and otherwise will wind up warning of a problem.
 func (a *Account) SetStreamGeneration(gen PassphraseGeneration, nilPPStreamOK bool) {
-	ps := a.PassphraseStreamRef()
-	if ps == nil {
-		if !nilPPStreamOK {
-			a.G().Log.Warning("Passphrase stream was nil; unexpected")
-		}
-	} else {
+	found := a.PassphraseStreamCache().MutatePassphraseStream(func(ps *PassphraseStream) {
 		ps.SetGeneration(gen)
+	})
+	if !found && !nilPPStreamOK {
+		a.G().Log.Warning("Passphrase stream was nil; unexpected")
 	}
 }
 
@@ -235,12 +233,6 @@ func (a *Account) PassphraseStreamCache() *PassphraseStreamCache {
 // or nil if none is there.
 func (a *Account) PassphraseStream() *PassphraseStream {
 	return a.PassphraseStreamCache().PassphraseStream()
-}
-
-// PassphraseStreamRef returns a reference to the actual passphrase stream, or
-// nil if none is there.
-func (a *Account) PassphraseStreamRef() *PassphraseStream {
-	return a.PassphraseStreamCache().PassphraseStreamRef()
 }
 
 func (a *Account) ClearStreamCache() {

--- a/go/libkb/passphrase_stream_cache.go
+++ b/go/libkb/passphrase_stream_cache.go
@@ -5,16 +5,60 @@ package libkb
 
 import (
 	"fmt"
+	"sync"
 )
 
 type PassphraseStreamCache struct {
-	tsec             Triplesec
+	sync.Mutex
+	tsec             *LockedTriplesec
 	passphraseStream *PassphraseStream
 }
 
+// LockedTriplesec is a wrapper around a Triplesec interface,
+// which allows multiple goroutines to handle the same underlying
+// Triplesec at the same time. The mechanism is simply a mutex
+// wrapping all accesses.
+type LockedTriplesec struct {
+	sync.Mutex
+	t Triplesec
+}
+
+func (t *LockedTriplesec) DeriveKey(l int) ([]byte, []byte, error) {
+	t.Lock()
+	defer t.Unlock()
+	return t.t.DeriveKey(l)
+}
+
+func (t *LockedTriplesec) Decrypt(b []byte) ([]byte, error) {
+	t.Lock()
+	defer t.Unlock()
+	return t.t.Decrypt(b)
+}
+
+func (t *LockedTriplesec) Encrypt(b []byte) ([]byte, error) {
+	t.Lock()
+	defer t.Unlock()
+	return t.t.Encrypt(b)
+}
+
+func (t *LockedTriplesec) Scrub() {
+	t.Lock()
+	defer t.Unlock()
+	t.t.Scrub()
+}
+
+func NewLockedTriplesec(t Triplesec) *LockedTriplesec {
+	if t == nil {
+		return nil
+	}
+	return &LockedTriplesec{t: t}
+}
+
+var _ Triplesec = (*LockedTriplesec)(nil)
+
 func NewPassphraseStreamCache(tsec Triplesec, ps *PassphraseStream) *PassphraseStreamCache {
 	return &PassphraseStreamCache{
-		tsec:             tsec,
+		tsec:             NewLockedTriplesec(tsec),
 		passphraseStream: ps,
 	}
 }
@@ -23,6 +67,14 @@ func (s *PassphraseStreamCache) Triplesec() Triplesec {
 	if s == nil {
 		return nil
 	}
+	s.Lock()
+	defer s.Unlock()
+
+	// Beware the classic Go `nil` interface bug...
+	if s.tsec == nil {
+		return nil
+	}
+
 	return s.tsec
 }
 
@@ -32,26 +84,39 @@ func (s *PassphraseStreamCache) PassphraseStream() *PassphraseStream {
 	if s == nil {
 		return nil
 	}
+	s.Lock()
+	defer s.Unlock()
 	return s.passphraseStream.Clone()
 }
 
-// PassphraseStream returns a reference to the currently cached passphrase stream,
-// or nil if none exists.
-func (s *PassphraseStreamCache) PassphraseStreamRef() *PassphraseStream {
+func (s *PassphraseStreamCache) MutatePassphraseStream(f func(*PassphraseStream)) bool {
 	if s == nil {
-		return nil
+		return false
 	}
-	return s.passphraseStream
+	s.Lock()
+	defer s.Unlock()
+	if s.passphraseStream == nil {
+		return false
+	}
+	f(s.passphraseStream)
+	return true
 }
 
 func (s *PassphraseStreamCache) Valid() bool {
-	return s.ValidPassphraseStream() && s.ValidTsec()
+	if s == nil {
+		return false
+	}
+	s.Lock()
+	defer s.Unlock()
+	return s.passphraseStream != nil && s.tsec != nil
 }
 
 func (s *PassphraseStreamCache) ValidPassphraseStream() bool {
 	if s == nil {
 		return false
 	}
+	s.Lock()
+	defer s.Unlock()
 	return s.passphraseStream != nil
 }
 
@@ -59,6 +124,8 @@ func (s *PassphraseStreamCache) ValidTsec() bool {
 	if s == nil {
 		return false
 	}
+	s.Lock()
+	defer s.Unlock()
 	return s.tsec != nil
 }
 
@@ -66,6 +133,8 @@ func (s *PassphraseStreamCache) Clear() {
 	if s == nil {
 		return
 	}
+	s.Lock()
+	defer s.Unlock()
 	if s.tsec != nil {
 		s.tsec.Scrub()
 		s.tsec = nil
@@ -79,6 +148,8 @@ func (s *PassphraseStreamCache) Dump() {
 		fmt.Printf("nil\n")
 		return
 	}
+	s.Lock()
+	defer s.Unlock()
 	fmt.Printf("PassphraseStreamCache:\n")
 	fmt.Printf("Valid: %v\n", s.Valid())
 	fmt.Printf("\n")


### PR DESCRIPTION
- we don't need it to be safe now, but we will once we move passphrase stream out of Account