### PR TITLE
Systest fixes

### DIFF
--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -561,17 +561,20 @@ func teamInviteRemoveIfHigherRole(t *testing.T, waitForRekeyd bool) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
+	userParams := standaloneUserArgs{
+		disableGregor:            true,
+		suppressTeamChatAnnounce: true,
+	}
+
 	var own *userPlusDevice
 	if waitForRekeyd {
 		own = tt.addUser("own")
 	} else {
-		own = makeUserStandalone(t, "own", standaloneUserArgs{
-			disableGregor:            true,
-			suppressTeamChatAnnounce: true,
-		})
+		own = makeUserStandalone(t, "own", userParams)
 		tt.users = append(tt.users, own)
 	}
-	roo := tt.addUser("roo")
+	roo := makeUserStandalone(t, "roo", userParams)
+	tt.users = append(tt.users, roo)
 	tt.logUserNames()
 
 	teamID, teamName := own.createTeam2()

--- a/go/systests/team_list_test.go
+++ b/go/systests/team_list_test.go
@@ -61,6 +61,8 @@ func TestTeamList(t *testing.T) {
 
 	teamCli := ann.getTeamsClient()
 
+	ann.setUIDMapperNoCachingMode(true)
+
 	rootername := randomUser("arbitrary").username
 	_, err := teamCli.TeamAddMember(context.TODO(), keybase1.TeamAddMemberArg{
 		Name:     team.name,

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -130,6 +130,7 @@ func TestTeamReset(t *testing.T) {
 	// Note that ann (the admin) has a UIDMapper that should get pubsub updates
 	// since she is an admin for the team in question. cam won't get those
 	// pubsub updates
+	ann.setUIDMapperNoCachingMode(true)
 	bob.setUIDMapperNoCachingMode(true)
 	cam.setUIDMapperNoCachingMode(true)
 


### PR DESCRIPTION
- In `TestTeamInviteRemoveIfHigherRole`, there was another user added as admin to the team. If he got drafted as a tribute, manual call to `HandleSBSRequest` would fail because invite was already completed.
- There were two more tests that I could get to fail consistently on one of my machines. I had to disable uidmapper cache for them because the underlying issue seems non-trivial