### PR TITLE
Move team channel gear icon to the left.

### DIFF
--- a/shared/chat/inbox/row/big-team-header/index.js
+++ b/shared/chat/inbox/row/big-team-header/index.js
@@ -39,7 +39,10 @@ class _BigTeamHeader extends React.PureComponent<Props> {
         <ClickableBox
           onClick={props.toggleShowingMenu}
           ref={props.setAttachmentRef}
-          style={collapseStyles([globalStyles.flexBoxRow, {position: 'relative'}])}
+          style={collapseStyles([
+            globalStyles.flexBoxRow,
+            {position: 'relative', right: globalMargins.xtiny},
+          ])}
         >
           <Icon className="icon" type="iconfont-gear" fontSize={iconFontSize} color={globalColors.black_20} />
           <Box

--- a/shared/chat/inbox/row/small-team/top-line.js
+++ b/shared/chat/inbox/row/small-team/top-line.js
@@ -4,7 +4,7 @@ import shallowEqual from 'shallowequal'
 import {Text, PlaintextUsernames, Box, Icon} from '../../../../common-adapters'
 import {FloatingMenuParentHOC, type FloatingMenuParentProps} from '../../../../common-adapters/floating-menu'
 import TeamMenu from '../../../conversation/info-panel/menu/container'
-import {globalStyles, globalColors, isMobile, platformStyles} from '../../../../styles'
+import {globalStyles, globalColors, globalMargins, isMobile, platformStyles} from '../../../../styles'
 
 type Props = {
   hasUnread: boolean,
@@ -106,6 +106,7 @@ class _SimpleTopLine extends React.Component<Props> {
             color={this.props.subColor}
             fontSize={14}
             hoverColor={this.props.iconHoverColor}
+            style={{position: 'relative', right: globalMargins.xtiny}}
           />
         )}
         {this.props.hasBadge ? <Box key="1" style={unreadDotStyle} /> : null}


### PR DESCRIPTION
The ephemeral scrollbars in macOS cause the majority of the team settings icon (the little gear in the inbox) to become un-tappable after they've disappeared. This moves the icons to the left enough to where the majority of the icon is tappable after the scrollbars have disappeared.