### PR TITLE
Add rn-prebuild script

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -34,6 +34,7 @@
     "start-cold": "yarn run _helper start-cold",
     "start-hot": "yarn run _helper start-hot",
     "start-prod": "yarn run _helper start-prod",
+    "rn-prebuild": "./react-native/packageAndBuild.sh",
     "rn-start": "./node_modules/react-native/scripts/packager.sh --resetCache",
     "rn-gobuild-ios": "./react-native/gobuild.sh ios",
     "rn-gobuild-android": "./react-native/gobuild.sh android",

--- a/shared/react-native/packageAndBuild.sh
+++ b/shared/react-native/packageAndBuild.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# starts up the RN packager & requests both ios and android bundles
+
+requestbundles ()
+{
+  printf "\nRequesting bundles...\n"
+  curl -s -o /dev/null localhost:8081/index.ios.bundle 2>&1 
+  curl -s -o /dev/null localhost:8081/index.android.bundle 2>&1
+}
+# give the packager time to start
+sleep 5 && requestbundles &
+yarn rn-start 


### PR DESCRIPTION
`rn-prebuild` does the same as `rn-start`, but requests the ios and android bundles after starting the packager so they're ready when they're requested for real. r? @keybase/react-hackers 