### PR TITLE
Make info panel a route on desktop & partially consolidate chat routes

### DIFF
--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -15,8 +15,7 @@ import {Box} from '../../../common-adapters'
 
 type OwnProps = {
   conversationIDKey: Types.ConversationIDKey,
-  // ? because this isn't a route on desktop, and headerHoc is mobile only
-  navigateUp?: typeof Route.navigateUp,
+  onBack: () => void,
 }
 
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
@@ -48,8 +47,7 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   }
 }
 
-const mapDispatchToProps = (dispatch: Dispatch, {conversationIDKey, navigateUp}) => ({
-  _onBack: () => dispatch(navigateUp && navigateUp()),
+const mapDispatchToProps = (dispatch: Dispatch, {conversationIDKey, onBack}) => ({
   _navToRootChat: () => dispatch(Chat2Gen.createNavigateToInbox()),
   onLeaveConversation: () => dispatch(Chat2Gen.createLeaveConversation({conversationIDKey})),
   onJoinChannel: () => dispatch(Chat2Gen.createJoinConversation({conversationIDKey})),

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -8,9 +8,10 @@ import * as TeamTypes from '../../../constants/types/teams'
 import * as Types from '../../../constants/types/chat2'
 import {InfoPanel} from '.'
 import {teamsTab} from '../../../constants/tabs'
-import {connect, type TypedState} from '../../../util/container'
+import {connect, type TypedState, isMobile} from '../../../util/container'
 import {createShowUserProfile} from '../../../actions/profile-gen'
 import {getCanPerform} from '../../../constants/teams'
+import {Box} from '../../../common-adapters'
 
 type OwnProps = {
   conversationIDKey: Types.ConversationIDKey,
@@ -104,14 +105,12 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
 const ConnectedInfoPanel = connect(mapStateToProps, mapDispatchToProps, mergeProps)(InfoPanel)
 
 type SelectorOwnProps = {
-  conversationIDKey: ?Types.ConversationIDKey,
-  routeProps?: I.RecordOf<{conversationIDKey: Types.ConversationIDKey}>, // on mobile it's a route
-  navigateUp?: typeof Route.navigateUp,
+  routeProps: I.RecordOf<{conversationIDKey: Types.ConversationIDKey}>,
+  navigateUp: typeof Route.navigateUp,
 }
 
 const mapStateToSelectorProps = (state: TypedState, ownProps: SelectorOwnProps) => {
-  const conversationIDKey =
-    ownProps.conversationIDKey || (ownProps.routeProps ? ownProps.routeProps.get('conversationIDKey') : null)
+  const conversationIDKey = ownProps.routeProps.get('conversationIDKey')
   return {
     conversationIDKey,
   }
@@ -136,8 +135,27 @@ class InfoPanelSelector extends React.PureComponent<Props> {
       return null
     }
 
-    return <ConnectedInfoPanel onBack={this.props.onBack} conversationIDKey={this.props.conversationIDKey} />
+    return isMobile ? (
+      <ConnectedInfoPanel onBack={this.props.onBack} conversationIDKey={this.props.conversationIDKey} />
+    ) : (
+      <Box onClick={this.props.onBack} style={clickCatcherStyle}>
+        <Box style={panelContainerStyle} onClick={evt => evt.stopPropagation()}>
+          <ConnectedInfoPanel onBack={this.props.onBack} conversationIDKey={this.props.conversationIDKey} />
+        </Box>
+      </Box>
+    )
   }
+}
+
+const clickCatcherStyle = {position: 'absolute', top: 35, right: 0, bottom: 0, left: 80}
+const panelContainerStyle = {
+  position: 'absolute',
+  right: 0,
+  top: 0,
+  bottom: 0,
+  width: 320,
+  display: 'flex',
+  flexDirection: 'column',
 }
 
 export default connect(mapStateToSelectorProps, mapDispatchToSelectorProps)(InfoPanelSelector)

--- a/shared/chat/conversation/list-area/container.js
+++ b/shared/chat/conversation/list-area/container.js
@@ -14,8 +14,6 @@ type Props = {
   onFocusInput: () => void,
   onShowTracker: (user: string) => void,
   showSearchResults: boolean,
-  // TODO DESKTOP-6256 get rid of this
-  onToggleInfoPanel: () => void,
 }
 
 class ListArea extends React.PureComponent<Props> {
@@ -33,7 +31,6 @@ class ListArea extends React.PureComponent<Props> {
         <Normal
           listScrollDownCounter={this.props.listScrollDownCounter}
           onFocusInput={this.props.onFocusInput}
-          onToggleInfoPanel={this.props.onToggleInfoPanel}
           conversationIDKey={this.props.conversationIDKey}
         />
       )

--- a/shared/chat/conversation/list-area/normal/container.js
+++ b/shared/chat/conversation/list-area/normal/container.js
@@ -15,8 +15,6 @@ import {
 type OwnProps = {
   conversationIDKey: Types.ConversationIDKey,
   onFocusInput: () => void,
-  // TODO DESKTOP-6256 get rid of this
-  onToggleInfoPanel: () => void,
 }
 
 const mapStateToProps = (state: TypedState, {conversationIDKey}: OwnProps) => ({
@@ -39,7 +37,6 @@ const mergeProps = (stateProps, dispatchProps: DispatchProps, ownProps: OwnProps
   _loadMoreMessages: dispatchProps._loadMoreMessages,
   conversationIDKey: stateProps.conversationIDKey,
   editingOrdinal: stateProps.editingOrdinal,
-  onToggleInfoPanel: ownProps.onToggleInfoPanel,
   markInitiallyLoadedThreadAsRead: dispatchProps._markInitiallyLoadedThreadAsRead,
   messageOrdinals: stateProps.messageOrdinals.toList(),
   onFocusInput: ownProps.onFocusInput,

--- a/shared/chat/conversation/list-area/normal/index.desktop.js
+++ b/shared/chat/conversation/list-area/normal/index.desktop.js
@@ -122,13 +122,7 @@ class Thread extends React.Component<Props, State> {
               <SpecialBottomMessage conversationIDKey={this.props.conversationIDKey} measure={measure} />
             )
           } else if (index === 0) {
-            content = (
-              <SpecialTopMessage
-                onToggleInfoPanel={this.props.onToggleInfoPanel}
-                conversationIDKey={this.props.conversationIDKey}
-                measure={measure}
-              />
-            )
+            content = <SpecialTopMessage conversationIDKey={this.props.conversationIDKey} measure={measure} />
           } else {
             const ordinalIndex = index - 1
             const ordinal = this.props.messageOrdinals.get(ordinalIndex)

--- a/shared/chat/conversation/list-area/normal/index.native.js
+++ b/shared/chat/conversation/list-area/normal/index.native.js
@@ -10,13 +10,7 @@ import type {Props} from '.'
 class ConversationList extends React.PureComponent<Props> {
   _renderItem = ({index, item}) => {
     if (item === 'specialTop') {
-      return (
-        <SpecialTopMessage
-          onToggleInfoPanel={this.props.onToggleInfoPanel}
-          conversationIDKey={this.props.conversationIDKey}
-          measure={null}
-        />
-      )
+      return <SpecialTopMessage conversationIDKey={this.props.conversationIDKey} measure={null} />
     } else if (item === 'specialBottom') {
       return <SpecialBottomMessage conversationIDKey={this.props.conversationIDKey} measure={null} />
     } else {

--- a/shared/chat/conversation/messages/retention-notice/container.js
+++ b/shared/chat/conversation/messages/retention-notice/container.js
@@ -6,10 +6,10 @@ import {makeRetentionNotice} from '../../../../util/teams'
 import {getCanPerform, hasCanPerform} from '../../../../constants/teams'
 import {createGetTeamOperations} from '../../../../actions/teams-gen'
 import RetentionNotice from '.'
+import {navigateAppend} from '../../../../actions/route-tree'
 
 type OwnProps = {
   conversationIDKey: ChatTypes.ConversationIDKey,
-  onToggleInfoPanel: () => void,
   measure: ?() => void,
 }
 
@@ -37,8 +37,10 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
 
 const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
   _loadPermissions: (teamname: string) => dispatch(createGetTeamOperations({teamname})),
-  // TODO DESKTOP-6256 have this do a navigateAppend
-  onChange: ownProps.onToggleInfoPanel,
+  onChange: () =>
+    dispatch(
+      navigateAppend([{selected: 'infoPanel', props: {conversationIDKey: ownProps.conversationIDKey}}])
+    ),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {

--- a/shared/chat/conversation/messages/special-top-message.js
+++ b/shared/chat/conversation/messages/special-top-message.js
@@ -14,7 +14,6 @@ type Props = {
   hasOlderResetConversation: boolean,
   showRetentionNotice: boolean,
   loadMoreType: 'moreToLoad' | 'noMoreToLoad',
-  onToggleInfoPanel: () => void,
   showTeamOffer: boolean,
   // $FlowIssue "null or undefined is incompatible with null or undefined"
   measure: ?() => void,
@@ -37,11 +36,7 @@ class TopMessage extends React.PureComponent<Props> {
       <Box>
         {this.props.loadMoreType === 'noMoreToLoad' &&
           this.props.showRetentionNotice && (
-            <RetentionNotice
-              onToggleInfoPanel={this.props.onToggleInfoPanel}
-              conversationIDKey={this.props.conversationIDKey}
-              measure={this.props.measure}
-            />
+            <RetentionNotice conversationIDKey={this.props.conversationIDKey} measure={this.props.measure} />
           )}
         <Box style={spacerStyle} />
         {this.props.hasOlderResetConversation && (
@@ -85,8 +80,6 @@ const moreStyle = {
 
 type OwnProps = {
   conversationIDKey: Types.ConversationIDKey,
-  // TODO DESKTOP-6256 get rid of this
-  onToggleInfoPanel: () => void,
   measure: ?() => void,
 }
 
@@ -102,7 +95,6 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   return {
     conversationIDKey: ownProps.conversationIDKey,
     hasOlderResetConversation,
-    onToggleInfoPanel: ownProps.onToggleInfoPanel,
     showRetentionNotice,
     loadMoreType,
     showTeamOffer,

--- a/shared/chat/conversation/normal/container.js
+++ b/shared/chat/conversation/normal/container.js
@@ -5,11 +5,13 @@ import * as TrackerGen from '../../../actions/tracker-gen'
 import * as RouteTree from '../../../actions/route-tree'
 import Normal from '.'
 import {compose, connect, withStateHandlers, type TypedState} from '../../../util/container'
+import {chatTab} from '../../../constants/tabs'
 
 const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
   const showLoader = !!state.chat2.loadingMap.get(`loadingThread:${conversationIDKey}`)
   const meta = Constants.getMeta(state, conversationIDKey)
-  return {conversationIDKey, showLoader, threadLoadedOffline: meta.offline}
+  const infoPanelOpen = Constants.isInfoPanelOpen(state)
+  return {conversationIDKey, infoPanelOpen, showLoader, threadLoadedOffline: meta.offline}
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -17,8 +19,13 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(
       RouteTree.navigateAppend([{props: {conversationIDKey, paths}, selected: 'attachmentGetTitles'}])
     ),
-  _onOpenInfoPanelMobile: (conversationIDKey: Types.ConversationIDKey) =>
-    dispatch(RouteTree.navigateAppend([{props: {conversationIDKey}, selected: 'infoPanel'}])),
+  _onToggleInfoPanel: (isOpen: boolean, conversationIDKey: Types.ConversationIDKey) => {
+    if (isOpen) {
+      dispatch(RouteTree.navigateTo(['conversation'], [chatTab]))
+    } else {
+      dispatch(RouteTree.navigateAppend([{props: {conversationIDKey}, selected: 'infoPanel'}]))
+    }
+  },
   onShowTracker: (username: string) =>
     dispatch(TrackerGen.createGetProfile({forceDisplay: true, ignoreCache: false, username})),
 })
@@ -26,8 +33,10 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 const mergeProps = (stateProps, dispatchProps) => {
   return {
     conversationIDKey: stateProps.conversationIDKey,
+    infoPanelOpen: stateProps.infoPanelOpen,
     onAttach: (paths: Array<string>) => dispatchProps._onAttach(stateProps.conversationIDKey, paths),
-    onOpenInfoPanelMobile: () => dispatchProps._onOpenInfoPanelMobile(stateProps.conversationIDKey),
+    onToggleInfoPanel: () =>
+      dispatchProps._onToggleInfoPanel(stateProps.infoPanelOpen, stateProps.conversationIDKey),
     onShowTracker: dispatchProps.onShowTracker,
     showLoader: stateProps.showLoader,
     threadLoadedOffline: stateProps.threadLoadedOffline,

--- a/shared/chat/conversation/normal/index.desktop.js
+++ b/shared/chat/conversation/normal/index.desktop.js
@@ -39,21 +39,6 @@ const Offline = () => (
   </Box>
 )
 
-// const InfoPaneWrapper = ({onToggle, conversationIDKey}) => (
-//   <div
-//     style={{
-//       ...globalStyles.flexBoxColumn,
-//       bottom: 0,
-//       position: 'absolute',
-//       right: 0,
-//       top: 35,
-//       width: 320,
-//     }}
-//   >
-//     <InfoPanel onToggleInfoPanel={onToggle} conversationIDKey={conversationIDKey} />
-//   </div>
-// )
-
 class Conversation extends React.PureComponent<Props, State> {
   _mounted = false
   state = {

--- a/shared/chat/conversation/normal/index.desktop.js
+++ b/shared/chat/conversation/normal/index.desktop.js
@@ -137,8 +137,6 @@ class Conversation extends React.PureComponent<Props, State> {
         {this.props.showLoader && <LoadingLine />}
         <ListArea
           listScrollDownCounter={this.props.listScrollDownCounter}
-          // TODO DESKTOP-6256 get rid of this
-          onToggleInfoPanel={this.props.onToggleInfoPanel}
           onFocusInput={this.props.onFocusInput}
           conversationIDKey={this.props.conversationIDKey}
         />

--- a/shared/chat/conversation/normal/index.desktop.js
+++ b/shared/chat/conversation/normal/index.desktop.js
@@ -6,7 +6,6 @@ import Banner from '../bottom-banner/container'
 import HeaderArea from '../header-area/container'
 import InputArea from '../input-area/container'
 import ListArea from '../list-area/container'
-import InfoPanel from '../info-panel/container'
 import logger from '../../../logger'
 import {Box, Icon, LoadingLine, Text} from '../../../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../../../styles'
@@ -15,7 +14,6 @@ import {readImageFromClipboard} from '../../../util/clipboard.desktop'
 import type {Props} from '.'
 
 type State = {
-  infoPanelOpen: boolean,
   showDropOverlay: boolean,
   conversationIDKey: ?Types.ConversationIDKey,
 }
@@ -41,20 +39,20 @@ const Offline = () => (
   </Box>
 )
 
-const InfoPaneWrapper = ({onToggle, conversationIDKey}) => (
-  <div
-    style={{
-      ...globalStyles.flexBoxColumn,
-      bottom: 0,
-      position: 'absolute',
-      right: 0,
-      top: 35,
-      width: 320,
-    }}
-  >
-    <InfoPanel onToggleInfoPanel={onToggle} conversationIDKey={conversationIDKey} />
-  </div>
-)
+// const InfoPaneWrapper = ({onToggle, conversationIDKey}) => (
+//   <div
+//     style={{
+//       ...globalStyles.flexBoxColumn,
+//       bottom: 0,
+//       position: 'absolute',
+//       right: 0,
+//       top: 35,
+//       width: 320,
+//     }}
+//   >
+//     <InfoPanel onToggleInfoPanel={onToggle} conversationIDKey={conversationIDKey} />
+//   </div>
+// )
 
 class Conversation extends React.PureComponent<Props, State> {
   _mounted = false
@@ -137,10 +135,6 @@ class Conversation extends React.PureComponent<Props, State> {
     })
   }
 
-  _onToggleInfoPanel = () => {
-    this.setState(prevState => ({infoPanelOpen: !prevState.infoPanelOpen}))
-  }
-
   render() {
     return (
       <Box
@@ -151,15 +145,15 @@ class Conversation extends React.PureComponent<Props, State> {
       >
         {this.props.threadLoadedOffline && <Offline />}
         <HeaderArea
-          onToggleInfoPanel={this._onToggleInfoPanel}
-          infoPanelOpen={this.state.infoPanelOpen}
+          onToggleInfoPanel={this.props.onToggleInfoPanel}
+          infoPanelOpen={this.props.infoPanelOpen}
           conversationIDKey={this.props.conversationIDKey}
         />
         {this.props.showLoader && <LoadingLine />}
         <ListArea
           listScrollDownCounter={this.props.listScrollDownCounter}
           // TODO DESKTOP-6256 get rid of this
-          onToggleInfoPanel={this._onToggleInfoPanel}
+          onToggleInfoPanel={this.props.onToggleInfoPanel}
           onFocusInput={this.props.onFocusInput}
           conversationIDKey={this.props.conversationIDKey}
         />
@@ -169,12 +163,6 @@ class Conversation extends React.PureComponent<Props, State> {
           onScrollDown={this.props.onScrollDown}
           conversationIDKey={this.props.conversationIDKey}
         />
-        {this.state.infoPanelOpen && (
-          <InfoPaneWrapper
-            onToggle={this._onToggleInfoPanel}
-            conversationIDKey={this.props.conversationIDKey}
-          />
-        )}
         {this.state.showDropOverlay && <DropOverlay onDragLeave={this._onDragLeave} onDrop={this._onDrop} />}
       </Box>
     )

--- a/shared/chat/conversation/normal/index.js.flow
+++ b/shared/chat/conversation/normal/index.js.flow
@@ -5,13 +5,14 @@ import * as Types from '../../../constants/types/chat2'
 export type Props = {
   conversationIDKey: Types.ConversationIDKey,
   focusInputCounter: number,
+  infoPanelOpen: boolean,
   listScrollDownCounter: number,
   showLoader: boolean,
   onAttach: (paths: Array<string>) => void,
   onFocusInput: () => void,
   onScrollDown: () => void,
   onShowTracker: (username: string) => void,
-  onOpenInfoPanelMobile: () => void,
+  onToggleInfoPanel: () => void,
   threadLoadedOffline: boolean,
 }
 

--- a/shared/chat/conversation/normal/index.native.js
+++ b/shared/chat/conversation/normal/index.native.js
@@ -33,13 +33,13 @@ class Conversation extends React.PureComponent<Props> {
       <Box style={containerStyle}>
         {this.props.threadLoadedOffline && <Offline />}
         <HeaderArea
-          onToggleInfoPanel={this.props.onOpenInfoPanelMobile}
+          onToggleInfoPanel={this.props.onToggleInfoPanel}
           infoPanelOpen={false}
           conversationIDKey={this.props.conversationIDKey}
         />
         {this.props.showLoader && <LoadingLine />}
         <ListArea
-          onToggleInfoPanel={this.props.onOpenInfoPanelMobile}
+          onToggleInfoPanel={this.props.onToggleInfoPanel}
           listScrollDownCounter={this.props.listScrollDownCounter}
           onFocusInput={this.props.onFocusInput}
           conversationIDKey={this.props.conversationIDKey}

--- a/shared/chat/manage-channels/edit-channel.js
+++ b/shared/chat/manage-channels/edit-channel.js
@@ -82,11 +82,12 @@ const EditChannelBare = (props: Props & TextState) => (
       </ButtonBar>
     </Box>
     {isMobile &&
-      props.showDelete && (
+      props.showDelete &&
+      !props.deleteRenameDisabled && (
         <DeleteChannel
           channelName={props.channelName}
           onConfirmedDelete={props.onConfirmedDelete}
-          disabled={props.deleteRenameDisabled}
+          disabled={false}
         />
       )}
   </Box>

--- a/shared/chat/routes.js
+++ b/shared/chat/routes.js
@@ -18,90 +18,73 @@ import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import DeleteHistoryWarning from './delete-history-warning/container'
 import RetentionWarning from '../teams/team/settings-tab/retention/warning/container'
 
-const editChannel = {
-  component: MaybePopupHoc(isMobile)(EditChannel),
-  tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
-  children: {},
-}
-
-const createChannel = {
-  component: CreateChannel,
-  tags: makeLeafTags({hideStatusBar: true}),
-  children: {},
-}
-
-// These are routes that can be children of the inbox,
-// conversation, or the info panel. If you're adding a
-// component that will be routeable from the inbox or info
-// panel, add it here
 const chatChildren = {
-  createChannel,
-  editChannel,
+  createChannel: {
+    component: CreateChannel,
+    tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
+    children: key => makeRouteDefNode(chatChildren[key]),
+  },
+  editChannel: {
+    component: MaybePopupHoc(isMobile)(EditChannel),
+    tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
+    children: key => makeRouteDefNode(chatChildren[key]),
+  },
   manageChannels: {
     component: ManageChannels,
     tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
-    children: {
-      createChannel,
-      editChannel,
-    },
+    children: key => makeRouteDefNode(chatChildren[key]),
   },
   reallyLeaveTeam: {
-    children: {},
+    children: key => makeRouteDefNode(chatChildren[key]),
     component: ReallyLeaveTeam,
     tags: makeLeafTags({layerOnTop: !isMobile}),
   },
   retentionWarning: {
     component: RetentionWarning,
-    children: {},
+    children: key => makeRouteDefNode(chatChildren[key]),
     tags: makeLeafTags({layerOnTop: !isMobile}),
   },
   showBlockConversationDialog: {
     component: BlockConversationWarning,
     tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
-    children: {},
+    children: key => makeRouteDefNode(chatChildren[key]),
   },
   showNewTeamDialog: {
     component: NewTeamDialogFromChat,
     tags: makeLeafTags({layerOnTop: !isMobile}),
-    children: {},
+    children: key => makeRouteDefNode(chatChildren[key]),
+  },
+  attachmentFullscreen: {
+    component: AttachmentFullscreen,
+    tags: makeLeafTags(isMobile ? {hideStatusBar: true, fullscreen: true} : {layerOnTop: true}),
+    children: key => makeRouteDefNode(chatChildren[key]),
+  },
+  attachmentGetTitles: {
+    component: AttachmentGetTitles,
+    tags: makeLeafTags({layerOnTop: true}),
+    children: key => makeRouteDefNode(chatChildren[key]),
+  },
+  infoPanel: {
+    component: InfoPanel,
+    children: key => makeRouteDefNode(chatChildren[key]),
+    tags: makeLeafTags({layerOnTop: !isMobile}),
+  },
+  deleteHistoryWarning: {
+    component: DeleteHistoryWarning,
+    tags: makeLeafTags({layerOnTop: !isMobile}),
+    children: key => makeRouteDefNode(chatChildren[key]),
+  },
+  enterPaperkey: {
+    component: EnterPaperkey,
   },
 }
-
-const chatChildRoutes = {}
-Object.keys(chatChildren).forEach(key => {
-  chatChildRoutes[key] = makeRouteDefNode(chatChildren[key])
-})
 
 // Routes accessible from an action coming from within the
 // actual conversation view (info panel and routes coming
 // from message menu or special messages)
 const conversationRoute = makeRouteDefNode({
   component: Conversation,
-  children: {
-    attachmentFullscreen: {
-      component: AttachmentFullscreen,
-      tags: makeLeafTags(isMobile ? {hideStatusBar: true, fullscreen: true} : {layerOnTop: true}),
-      children: {},
-    },
-    attachmentGetTitles: {
-      component: AttachmentGetTitles,
-      tags: makeLeafTags({layerOnTop: true}),
-      children: {},
-    },
-    infoPanel: {
-      component: InfoPanel,
-      children: chatChildren,
-      tags: makeLeafTags({layerOnTop: !isMobile}),
-    },
-    deleteHistoryWarning: {
-      component: DeleteHistoryWarning,
-      tags: makeLeafTags({layerOnTop: false}),
-      children: {},
-    },
-    enterPaperkey: {
-      component: EnterPaperkey,
-    },
-  },
+  children: chatChildren,
 })
 
 const routeTree = isMobile
@@ -109,7 +92,7 @@ const routeTree = isMobile
       component: Inbox,
       children: key => {
         if (key !== 'conversation') {
-          return chatChildRoutes[key]
+          return makeRouteDefNode(chatChildren[key])
         }
         return conversationRoute
       },

--- a/shared/chat/routes.js
+++ b/shared/chat/routes.js
@@ -18,6 +18,7 @@ import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import DeleteHistoryWarning from './delete-history-warning/container'
 import RetentionWarning from '../teams/team/settings-tab/retention/warning/container'
 
+// Arbitrarily stackable routes from the chat tab
 const chatChildren = {
   createChannel: {
     component: CreateChannel,
@@ -71,7 +72,7 @@ const chatChildren = {
   },
   deleteHistoryWarning: {
     component: DeleteHistoryWarning,
-    tags: makeLeafTags({layerOnTop: !isMobile}),
+    tags: makeLeafTags({layerOnTop: false}),
     children: key => makeRouteDefNode(chatChildren[key]),
   },
   enterPaperkey: {
@@ -79,9 +80,6 @@ const chatChildren = {
   },
 }
 
-// Routes accessible from an action coming from within the
-// actual conversation view (info panel and routes coming
-// from message menu or special messages)
 const conversationRoute = makeRouteDefNode({
   component: Conversation,
   children: chatChildren,

--- a/shared/chat/routes.js
+++ b/shared/chat/routes.js
@@ -83,6 +83,7 @@ const conversationRoute = makeRouteDefNode({
     infoPanel: {
       component: InfoPanel,
       children: infoPanelChildren,
+      tags: makeLeafTags({layerOnTop: !isMobile}),
     },
     // We should consolidate these as only info panel children once it's changed to a route on desktop
     ...infoPanelChildren,

--- a/shared/common-adapters/header-hoc.js.flow
+++ b/shared/common-adapters/header-hoc.js.flow
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {type StylesCrossPlatform} from '../styles'
 
 export type Props = {
-  title?: ?string,
+  title?: string,
   onBack?: ?() => void,
   onCancel?: ?() => void,
   headerStyle?: StylesCrossPlatform,

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -61,6 +61,10 @@ export const isUserActivelyLookingAtThisThread = (
     conversationIDKey === selectedConversationIDKey // looking at the selected thread?
   )
 }
+export const isInfoPanelOpen = (state: TypedState) => {
+  const routePath = getPath(state.routeTree.routeState, [chatTab])
+  return routePath.size === 3 && routePath.get(2) === 'infoPanel'
+}
 export const pendingConversationIDKey = Types.stringToConversationIDKey('')
 
 export {

--- a/shared/teams/really-leave-team/container-chat.js
+++ b/shared/teams/really-leave-team/container-chat.js
@@ -21,12 +21,13 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
     _canLeaveTeam,
     _loaded: hasCanPerform(state, name),
     name,
+    title: 'Confirmation',
   }
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
   _loadOperations: teamname => dispatch(TeamsGen.createGetTeamOperations({teamname})),
-  onClose: () => dispatch(navigateUp()),
+  onBack: () => dispatch(navigateUp()),
   onLeave: () => {
     dispatch(TeamsGen.createLeaveTeam({teamname: routeProps.get('teamname')}))
     dispatch(navigateUp())

--- a/shared/teams/really-leave-team/container.js
+++ b/shared/teams/really-leave-team/container.js
@@ -15,11 +15,12 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
   return {
     _lastOwner,
     name,
+    title: 'Confirmation',
   }
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
-  onClose: () => dispatch(navigateUp()),
+  onBack: () => dispatch(navigateUp()),
   onLeave: () => {
     dispatch(TeamsGen.createLeaveTeam({teamname: routeProps.get('teamname')}))
     dispatch(navigateTo([teamsTab]))

--- a/shared/teams/really-leave-team/index.js
+++ b/shared/teams/really-leave-team/index.js
@@ -8,18 +8,20 @@ import {
   Icon,
   MaybePopup,
   ProgressIndicator,
+  HeaderHoc,
   Text,
 } from '../../common-adapters'
 import {globalStyles, globalMargins, isMobile} from '../../styles'
 
 export type Props = {
-  onClose: () => void,
+  onBack: () => void,
   onLeave: () => void,
   name: string,
+  title: string,
 }
 
-const Spinner = (props: Props) => (
-  <MaybePopup onClose={props.onClose}>
+const _Spinner = (props: Props) => (
+  <MaybePopup onClose={props.onBack}>
     <Box
       style={{...globalStyles.flexBoxColumn, alignItems: 'center', flex: 1, padding: globalMargins.xlarge}}
     >
@@ -27,9 +29,10 @@ const Spinner = (props: Props) => (
     </Box>
   </MaybePopup>
 )
+const Spinner = isMobile ? HeaderHoc(_Spinner) : _Spinner
 
-const ReallyLeaveTeam = (props: Props) => (
-  <MaybePopup onClose={props.onClose}>
+const _ReallyLeaveTeam = (props: Props) => (
+  <MaybePopup onClose={props.onBack}>
     <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', flex: 1, padding: globalMargins.large}}>
       <Avatar teamname={props.name} size={64} />
       <Icon type="icon-team-leave-28" style={{marginRight: -60, marginTop: -20, zIndex: 1}} />
@@ -41,12 +44,13 @@ const ReallyLeaveTeam = (props: Props) => (
         unless an admin invites you.
       </Text>
       <ButtonBar direction={isMobile ? 'column' : 'row'} fullWidth={isMobile}>
-        <Button type="Secondary" onClick={props.onClose} label="Cancel" />
+        <Button type="Secondary" onClick={props.onBack} label="Cancel" />
         <Button type="Danger" onClick={props.onLeave} label={`Yes, leave ${props.name}`} fullWidth={true} />
       </ButtonBar>
     </Box>
   </MaybePopup>
 )
+const ReallyLeaveTeam = isMobile ? HeaderHoc(_ReallyLeaveTeam) : _ReallyLeaveTeam
 
 export default ReallyLeaveTeam
 export {Spinner}

--- a/shared/teams/really-leave-team/last-owner.js
+++ b/shared/teams/really-leave-team/last-owner.js
@@ -1,17 +1,18 @@
 // @flow
 import * as React from 'react'
-import {Avatar, Box, Text, Icon, Button, MaybePopup, ButtonBar} from '../../common-adapters'
-import {globalStyles, globalMargins} from '../../styles'
+import {Avatar, Box, Text, Icon, Button, HeaderHoc, MaybePopup, ButtonBar} from '../../common-adapters'
+import {globalStyles, globalMargins, isMobile} from '../../styles'
 
 type Props = {
-  onClose: () => void,
+  onBack: () => void,
   onLeave: () => void,
   name: string,
+  title: string,
 }
 
-const ReallyLeaveTeam = (props: Props) => (
+const _ReallyLeaveTeam = (props: Props) => (
   <MaybePopup
-    onClose={props.onClose}
+    onClose={props.onBack}
     styleContainer={{height: 'auto'}}
     styleCover={{justifyContent: 'center', alignItems: 'center'}}
   >
@@ -32,7 +33,7 @@ const ReallyLeaveTeam = (props: Props) => (
         style={{
           margin: globalMargins.medium,
           marginBottom: globalMargins.small,
-          width: 380,
+          maxWidth: 380,
           textAlign: 'center',
         }}
       >
@@ -51,10 +52,11 @@ const ReallyLeaveTeam = (props: Props) => (
         You'll have to add another user as an owner before you can leave {props.name}.
       </Text>
       <ButtonBar>
-        <Button type="Primary" onClick={props.onClose} label="Got it" />
+        <Button type="Primary" onClick={props.onBack} label="Got it" />
       </ButtonBar>
     </Box>
   </MaybePopup>
 )
+const ReallyLeaveTeam = isMobile ? HeaderHoc(_ReallyLeaveTeam) : _ReallyLeaveTeam
 
 export default ReallyLeaveTeam


### PR DESCRIPTION
Makes the info panel a route on desktop by changing `InfoPanelSelector` to wrap the info panel in a click catcher and position it correctly. Also makes some changes around how routes are special-cased on mobile. r? @keybase/react-hackers 