### PR TITLE
fix getting placeholders for sent

### DIFF
--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -462,13 +462,13 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
               } else if (message.type === 'placeholder') {
                 // sometimes we send then get a placeholder for that send. Lets see if we already have the message id for the sent
                 // and ignore the placeholder in that instance
-                const existingOrdial = messageIDToOrdinal(
+                const existingOrdinal = messageIDToOrdinal(
                   messageMap,
                   pendingOutboxToOrdinal,
                   conversationIDKey,
                   message.id
                 )
-                if (!existingOrdial) {
+                if (!existingOrdinal) {
                   arr.push(message.ordinal)
                 }
               } else {

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -459,6 +459,18 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
                 if (!findExisting(conversationIDKey, m)) {
                   arr.push(m.ordinal)
                 }
+              } else if (message.type === 'placeholder') {
+                // sometimes we send then get a placeholder for that send. Lets see if we already have the message id for the sent
+                // and ignore the placeholder in that instance
+                const existingOrdial = messageIDToOrdinal(
+                  messageMap,
+                  pendingOutboxToOrdinal,
+                  conversationIDKey,
+                  message.id
+                )
+                if (!existingOrdial) {
+                  arr.push(message.ordinal)
+                }
               } else {
                 arr.push(message.ordinal)
               }


### PR DESCRIPTION
This fixes the problem where you can get a placeholder for a message you sent during this session.
To repro on master:

1. send a couple of messages
1. select another conversation
1. db nuke
1. send into that same conversation from a different user
1. click back into the conversation

You should see your send messages from step 1 and spinners for those messages

With this pr you just see the sent ones

@keybase/react-hackers 
@mmaxim 