### PR TITLE
Shorten label text.

### DIFF
--- a/shared/teams/team/settings-tab/retention/index.js
+++ b/shared/teams/team/settings-tab/retention/index.js
@@ -294,7 +294,7 @@ const policyToLabel = (p: RetentionPolicy, parent: ?RetentionPolicy) => {
 }
 const policyToInheritLabel = (p: RetentionPolicy) => {
   const label = policyToLabel(p)
-  return `Use team default (${label})`
+  return `Team default (${label})`
 }
 // Use only for comparing policy durations
 const policyToComparable = (p: RetentionPolicy, parent: ?RetentionPolicy): number => {


### PR DESCRIPTION
@malgorithms pointed out that the label wraps when the inherited label is used in conjunction with “Never auto-delete”. The other option I was thinking was “Using default (Never auto-delete)”.