### PR TITLE
Start on sendRelayPayment, proto changes

### DIFF
--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -1305,3 +1305,21 @@ func (g *GlobalContext) IsOneshot(ctx context.Context) (bool, error) {
 	}
 	return uc.IsOneshot(), nil
 }
+
+func (g *GlobalContext) GetMeUV(ctx context.Context) (res keybase1.UserVersion, err error) {
+	meUID := g.ActiveDevice.UID()
+	if meUID.IsNil() {
+		return res, LoginRequiredError{}
+	}
+	loadMeArg := NewLoadUserArgWithContext(ctx, g).
+		WithUID(meUID).
+		WithSelf(true)
+	upkv2, _, err := g.GetUPAKLoader().LoadV2(loadMeArg)
+	if err != nil {
+		return res, err
+	}
+	if upkv2 == nil {
+		return res, fmt.Errorf("could not load logged-in user")
+	}
+	return upkv2.Current.ToUserVersion(), nil
+}

--- a/go/protocol/stellar1/common.go
+++ b/go/protocol/stellar1/common.go
@@ -112,17 +112,70 @@ func (e TransactionStatus) String() string {
 	return ""
 }
 
+type PaymentStrategy int
+
+const (
+	PaymentStrategy_NONE   PaymentStrategy = 0
+	PaymentStrategy_DIRECT PaymentStrategy = 1
+	PaymentStrategy_RELAY  PaymentStrategy = 2
+)
+
+func (o PaymentStrategy) DeepCopy() PaymentStrategy { return o }
+
+var PaymentStrategyMap = map[string]PaymentStrategy{
+	"NONE":   0,
+	"DIRECT": 1,
+	"RELAY":  2,
+}
+
+var PaymentStrategyRevMap = map[PaymentStrategy]string{
+	0: "NONE",
+	1: "DIRECT",
+	2: "RELAY",
+}
+
+func (e PaymentStrategy) String() string {
+	if v, ok := PaymentStrategyRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type RelayDirection int
+
+const (
+	RelayDirection_CLAIM RelayDirection = 0
+	RelayDirection_YANK  RelayDirection = 1
+)
+
+func (o RelayDirection) DeepCopy() RelayDirection { return o }
+
+var RelayDirectionMap = map[string]RelayDirection{
+	"CLAIM": 0,
+	"YANK":  1,
+}
+
+var RelayDirectionRevMap = map[RelayDirection]string{
+	0: "CLAIM",
+	1: "YANK",
+}
+
+func (e RelayDirection) String() string {
+	if v, ok := RelayDirectionRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type PaymentResult struct {
-	StellarID TransactionID        `codec:"stellarID" json:"stellarID"`
 	KeybaseID KeybaseTransactionID `codec:"keybaseID" json:"keybaseID"`
-	Ledger    int                  `codec:"Ledger" json:"Ledger"`
+	StellarID TransactionID        `codec:"stellarID" json:"stellarID"`
 }
 
 func (o PaymentResult) DeepCopy() PaymentResult {
 	return PaymentResult{
-		StellarID: o.StellarID.DeepCopy(),
 		KeybaseID: o.KeybaseID.DeepCopy(),
-		Ledger:    o.Ledger,
+		StellarID: o.StellarID.DeepCopy(),
 	}
 }
 

--- a/go/stellar/relay.go
+++ b/go/stellar/relay.go
@@ -2,6 +2,7 @@ package stellar
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -80,8 +81,9 @@ type RelayPaymentOutput struct {
 	// Account ID of the shared account.
 	RelayAccountID stellar1.AccountID
 	// Encrypted box containing the secret key to the account.
-	Encrypted stellar1.EncryptedRelaySecret
-	FundTx    stellarnet.SignResult
+	Encrypted    stellar1.EncryptedRelaySecret
+	EncryptedB64 string
+	FundTx       stellarnet.SignResult
 }
 
 // createRelayTransfer generates a stellar account, encrypts its key, and signs a transaction funding it.
@@ -113,9 +115,14 @@ func CreateRelayTransfer(in RelayPaymentInput) (res RelayPaymentOutput, err erro
 		Sk:        stellar1.SecretKey(relayKp.Seed()),
 		Note:      in.Note,
 	}, in.EncryptFor)
+	pack, err := libkb.MsgpackEncode(enc)
+	if err != nil {
+		return res, err
+	}
 	return RelayPaymentOutput{
 		RelayAccountID: stellar1.AccountID(relayKp.Address()),
 		Encrypted:      enc,
+		EncryptedB64:   base64.StdEncoding.EncodeToString(pack),
 		FundTx:         sig,
 	}, nil
 }

--- a/go/stellar/relay.go
+++ b/go/stellar/relay.go
@@ -148,7 +148,21 @@ func encryptRelaySecret(relay stellar1.RelayContents, encryptFor keybase1.TeamAp
 }
 
 // TODO CORE-7718 make this private
-func DecryptRelaySecret(box stellar1.EncryptedRelaySecret, key keybase1.TeamApplicationKey) (res stellar1.RelayContents, err error) {
+// `box` should be a stellar1.EncryptedRelaySecret
+func DecryptRelaySecretB64(boxB64 string, key keybase1.TeamApplicationKey) (res stellar1.RelayContents, err error) {
+	pack, err := base64.StdEncoding.DecodeString(boxB64)
+	if err != nil {
+		return res, err
+	}
+	var box stellar1.EncryptedRelaySecret
+	err = libkb.MsgpackDecode(&box, pack)
+	if err != nil {
+		return res, err
+	}
+	return decryptRelaySecret(box, key)
+}
+
+func decryptRelaySecret(box stellar1.EncryptedRelaySecret, key keybase1.TeamApplicationKey) (res stellar1.RelayContents, err error) {
 	if box.V != 1 {
 		return res, fmt.Errorf("unsupported relay secret box version: %v", box.V)
 	}

--- a/go/stellar/relay.go
+++ b/go/stellar/relay.go
@@ -81,7 +81,6 @@ type RelayPaymentOutput struct {
 	// Account ID of the shared account.
 	RelayAccountID stellar1.AccountID
 	// Encrypted box containing the secret key to the account.
-	Encrypted    stellar1.EncryptedRelaySecret
 	EncryptedB64 string
 	FundTx       stellarnet.SignResult
 }
@@ -121,7 +120,6 @@ func CreateRelayTransfer(in RelayPaymentInput) (res RelayPaymentOutput, err erro
 	}
 	return RelayPaymentOutput{
 		RelayAccountID: stellar1.AccountID(relayKp.Address()),
-		Encrypted:      enc,
 		EncryptedB64:   base64.StdEncoding.EncodeToString(pack),
 		FundTx:         sig,
 	}, nil

--- a/go/stellar/remote/interface.go
+++ b/go/stellar/remote/interface.go
@@ -3,14 +3,14 @@ package remote
 import (
 	"context"
 
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
 )
 
 type Remoter interface {
 	AccountSeqno(ctx context.Context, accountID stellar1.AccountID) (uint64, error)
 	Balances(ctx context.Context, accountID stellar1.AccountID) ([]stellar1.Balance, error)
-	SubmitTransaction(ctx context.Context, payload libkb.JSONPayload) (stellar1.PaymentResult, error)
+	SubmitPayment(ctx context.Context, post stellar1.PaymentDirectPost) (stellar1.PaymentResult, error)
+	SubmitRelayPayment(ctx context.Context, post stellar1.PaymentRelayPost) (stellar1.PaymentResult, error)
 	RecentPayments(ctx context.Context, accountID stellar1.AccountID, limit int) (res []stellar1.PaymentSummary, err error)
 	PaymentDetail(ctx context.Context, txID string) (res stellar1.PaymentSummary, err error)
 }

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -282,12 +282,12 @@ func SubmitPayment(ctx context.Context, g *libkb.GlobalContext, post stellar1.Pa
 func SubmitRelayPayment(ctx context.Context, g *libkb.GlobalContext, post stellar1.PaymentRelayPost) (stellar1.PaymentResult, error) {
 	if true {
 		// TODO CORE-7718 re-enable this outgoing RPC
-		return stellar1.PaymentResult{}, fmt.Errorf("relay payments not implemented in this version")
+		return stellar1.PaymentResult{}, fmt.Errorf("relay payments not implemented in this version (you may need to update keybase)")
 	}
 	payload := make(libkb.JSONPayload)
 	payload["payment"] = post
 	apiArg := libkb.APIArg{
-		Endpoint:    "stellar/submitpayment",
+		Endpoint:    "stellar/submitrelaypayment",
 		SessionType: libkb.APISessionTypeREQUIRED,
 		JSONPayload: payload,
 		NetContext:  ctx,

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -263,19 +263,39 @@ func (s *submitResult) GetAppStatus() *libkb.AppStatus {
 	return &s.Status
 }
 
-func SubmitTransaction(ctx context.Context, g *libkb.GlobalContext, payload libkb.JSONPayload) (stellar1.PaymentResult, error) {
+func SubmitPayment(ctx context.Context, g *libkb.GlobalContext, post stellar1.PaymentDirectPost) (stellar1.PaymentResult, error) {
+	payload := make(libkb.JSONPayload)
+	payload["payment"] = post
 	apiArg := libkb.APIArg{
 		Endpoint:    "stellar/submitpayment",
 		SessionType: libkb.APISessionTypeREQUIRED,
 		JSONPayload: payload,
 		NetContext:  ctx,
 	}
-
 	var res submitResult
 	if err := g.API.PostDecode(apiArg, &res); err != nil {
 		return stellar1.PaymentResult{}, err
 	}
+	return res.PaymentResult, nil
+}
 
+func SubmitRelayPayment(ctx context.Context, g *libkb.GlobalContext, post stellar1.PaymentRelayPost) (stellar1.PaymentResult, error) {
+	if true {
+		// TODO CORE-7718 re-enable this outgoing RPC
+		return stellar1.PaymentResult{}, fmt.Errorf("relay payments not implemented in this version")
+	}
+	payload := make(libkb.JSONPayload)
+	payload["payment"] = post
+	apiArg := libkb.APIArg{
+		Endpoint:    "stellar/submitpayment",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		JSONPayload: payload,
+		NetContext:  ctx,
+	}
+	var res submitResult
+	if err := g.API.PostDecode(apiArg, &res); err != nil {
+		return stellar1.PaymentResult{}, err
+	}
 	return res.PaymentResult, nil
 }
 

--- a/go/stellar/remote/remote_net.go
+++ b/go/stellar/remote/remote_net.go
@@ -25,8 +25,12 @@ func (r *RemoteNet) Balances(ctx context.Context, accountID stellar1.AccountID) 
 	return Balances(ctx, r.G(), accountID)
 }
 
-func (r *RemoteNet) SubmitTransaction(ctx context.Context, payload libkb.JSONPayload) (stellar1.PaymentResult, error) {
-	return SubmitTransaction(ctx, r.G(), payload)
+func (r *RemoteNet) SubmitPayment(ctx context.Context, post stellar1.PaymentDirectPost) (stellar1.PaymentResult, error) {
+	return SubmitPayment(ctx, r.G(), post)
+}
+
+func (r *RemoteNet) SubmitRelayPayment(ctx context.Context, post stellar1.PaymentRelayPost) (stellar1.PaymentResult, error) {
+	return SubmitRelayPayment(ctx, r.G(), post)
 }
 
 func (r *RemoteNet) RecentPayments(ctx context.Context, accountID stellar1.AccountID, limit int) (res []stellar1.PaymentSummary, err error) {

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -281,9 +281,8 @@ func SendPayment(ctx context.Context, g *libkb.GlobalContext, remoter remote.Rem
 		return stellar1.PaymentResult{}, err
 	}
 
-	_, deviceID, _, _, _ := g.ActiveDevice.AllFields()
 	post := stellar1.PaymentDirectPost{
-		FromDeviceID: deviceID,
+		FromDeviceID: g.ActiveDevice.DeviceID(),
 	}
 	if recipient.User != nil {
 		tmp := recipient.User.ToUserVersion()
@@ -357,9 +356,8 @@ func sendRelayPayment(ctx context.Context, g *libkb.GlobalContext, remoter remot
 	if err != nil {
 		return res, err
 	}
-	_, deviceID, _, _, _ := g.ActiveDevice.AllFields()
 	post := stellar1.PaymentRelayPost{
-		FromDeviceID:      deviceID,
+		FromDeviceID:      g.ActiveDevice.DeviceID(),
 		ToAssertion:       string(recipient.Input),
 		RelayAccount:      relay.RelayAccountID,
 		TeamID:            teamID,

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -475,7 +475,7 @@ func setupTestsWithSettings(t *testing.T, settings []usetting) ([]*TestContext, 
 		}
 		fu, err := kbtest.CreateAndSignupFakeUser("wall", tc.G)
 		require.NoError(t, err)
-		srv, rm := newTestServer(tc.G)
+		srv, rm := newTestServer(t, tc.G)
 		tcs = append(tcs, &TestContext{
 			TestContext: tc,
 			Fu:          fu,
@@ -516,7 +516,7 @@ func (t *testUISource) SecretUI(g *libkb.GlobalContext, sessionID int) libkb.Sec
 	return t.secret
 }
 
-func newTestServer(g *libkb.GlobalContext) (*Server, *RemoteMock) {
-	m := NewRemoteMock(g)
+func newTestServer(t testing.TB, g *libkb.GlobalContext) (*Server, *RemoteMock) {
+	m := NewRemoteMock(t, g)
 	return New(g, &testUISource{nullSecretUI{}}, m), m
 }

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -427,7 +427,7 @@ func TestRelayTransferInnards(t *testing.T) {
 	t.Logf("decrypt")
 	appKey, err = stellar.RelayTransferKeyForDecryption(context.Background(), tcs[0].G, teamID, appKey.KeyGeneration)
 	require.NoError(t, err)
-	relaySecrets, err := stellar.DecryptRelaySecret(out.Encrypted, appKey)
+	relaySecrets, err := stellar.DecryptRelaySecretB64(out.EncryptedB64, appKey)
 	require.NoError(t, err)
 	_, accountID, _, err := libkb.ParseStellarSecretKey(relaySecrets.Sk.SecureNoLogString())
 	require.NoError(t, err)

--- a/go/stellar/util.go
+++ b/go/stellar/util.go
@@ -8,20 +8,6 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func loadMeUpk(ctx context.Context, g *libkb.GlobalContext) (res *keybase1.UserPlusKeysV2, err error) {
-	loadMeArg := libkb.NewLoadUserArgWithContext(ctx, g).
-		WithUID(g.ActiveDevice.UID()).
-		WithSelf(true)
-	upkv2, _, err := g.GetUPAKLoader().LoadV2(loadMeArg)
-	if err != nil {
-		return res, err
-	}
-	if upkv2 == nil {
-		return res, fmt.Errorf("could not load logged-in user")
-	}
-	return &upkv2.Current, nil
-}
-
 func loadUvUpk(ctx context.Context, g *libkb.GlobalContext, uv keybase1.UserVersion) (res *keybase1.UserPlusKeysV2, err error) {
 	loadArg := libkb.NewLoadUserArgWithContext(ctx, g).WithUID(uv.Uid)
 	upkv2, _, err := g.GetUPAKLoader().LoadV2(loadArg)

--- a/protocol/avdl/stellar1/common.avdl
+++ b/protocol/avdl/stellar1/common.avdl
@@ -29,10 +29,22 @@ protocol common {
     ERROR_PERMANENT_4
   }
 
+  enum PaymentStrategy {
+    NONE_0,
+    DIRECT_1,
+    RELAY_2
+  }
+
+  enum RelayDirection {
+    CLAIM_0,
+    YANK_1
+  }
+
   record PaymentResult {
-    TransactionID stellarID;
     KeybaseTransactionID keybaseID;
-    int Ledger;
+    // Direct: tx ID of the payment tx
+    // Relay : tx ID of the funding payment tx
+    TransactionID stellarID;
   }
 
   // A note encrypted for one or two keybase users.

--- a/protocol/avdl/stellar1/remote.avdl
+++ b/protocol/avdl/stellar1/remote.avdl
@@ -4,35 +4,25 @@ protocol remote {
   import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
   import idl "common.avdl";
 
-  record Members {
-    AccountID fromStellar;
-    keybase1.UserVersion from;
+  record PaymentDirectPost {
     keybase1.DeviceID fromDeviceID;
-    AccountID toStellar;
-    keybase1.UserVersion to;
-  }
-
-  record Operation {
-    string ID;
-    string opType;
-    int createdAt;
-    string TransactionHash;
-
-    Asset asset;
-    string amount;
-  }
-
-  record PaymentPost {
-    uint64 stellarAccountSeqno;
-
-    Members members;
-
+    union { null, keybase1.UserVersion } to; // Nil for payments to stellar addresses
     string displayAmount;
     string displayCurrency;
-
     string noteB64; // b64-encoded EncryptedNote or empty string.
-
     string signedTransaction;
+  }
+
+  record PaymentRelayPost {
+    keybase1.DeviceID fromDeviceID;
+    union { null, keybase1.UserVersion } to; // Nil for SBS
+    string toAssertion; // Ex: 'mlsteele' or 'maxtaco@reddit'
+    AccountID relayAccount; // Address where the funds will be held
+    keybase1.TeamID teamID; // Impteam ID
+    string displayAmount;
+    string displayCurrency;
+    string boxB64; // b64-encoded EncryptedRelaySecret
+    string signedTransaction; // Funding tx
   }
 
   record PaymentSummary {
@@ -77,7 +67,9 @@ protocol remote {
   // js can't handle uint64, so returning a string
   string accountSeqno(keybase1.UserVersion caller, AccountID accountID);
 
-  PaymentResult submitPayment(keybase1.UserVersion caller, PaymentPost payment);
+  PaymentResult submitPayment(keybase1.UserVersion caller, PaymentDirectPost payment);
+
+  PaymentResult submitRelayPayment(keybase1.UserVersion caller, PaymentRelayPost payment);
 
   // ask the stellar network whether the master key for the account has power
   boolean isMasterKeyActive(keybase1.UserVersion caller, AccountID accountID);

--- a/protocol/json/stellar1/common.json
+++ b/protocol/json/stellar1/common.json
@@ -92,20 +92,33 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "PaymentStrategy",
+      "symbols": [
+        "NONE_0",
+        "DIRECT_1",
+        "RELAY_2"
+      ]
+    },
+    {
+      "type": "enum",
+      "name": "RelayDirection",
+      "symbols": [
+        "CLAIM_0",
+        "YANK_1"
+      ]
+    },
+    {
       "type": "record",
       "name": "PaymentResult",
       "fields": [
-        {
-          "type": "TransactionID",
-          "name": "stellarID"
-        },
         {
           "type": "KeybaseTransactionID",
           "name": "keybaseID"
         },
         {
-          "type": "int",
-          "name": "Ledger"
+          "type": "TransactionID",
+          "name": "stellarID"
         }
       ]
     },

--- a/protocol/json/stellar1/remote.json
+++ b/protocol/json/stellar1/remote.json
@@ -14,71 +14,18 @@
   "types": [
     {
       "type": "record",
-      "name": "Members",
+      "name": "PaymentDirectPost",
       "fields": [
-        {
-          "type": "AccountID",
-          "name": "fromStellar"
-        },
-        {
-          "type": "keybase1.UserVersion",
-          "name": "from"
-        },
         {
           "type": "keybase1.DeviceID",
           "name": "fromDeviceID"
         },
         {
-          "type": "AccountID",
-          "name": "toStellar"
-        },
-        {
-          "type": "keybase1.UserVersion",
+          "type": [
+            null,
+            "keybase1.UserVersion"
+          ],
           "name": "to"
-        }
-      ]
-    },
-    {
-      "type": "record",
-      "name": "Operation",
-      "fields": [
-        {
-          "type": "string",
-          "name": "ID"
-        },
-        {
-          "type": "string",
-          "name": "opType"
-        },
-        {
-          "type": "int",
-          "name": "createdAt"
-        },
-        {
-          "type": "string",
-          "name": "TransactionHash"
-        },
-        {
-          "type": "Asset",
-          "name": "asset"
-        },
-        {
-          "type": "string",
-          "name": "amount"
-        }
-      ]
-    },
-    {
-      "type": "record",
-      "name": "PaymentPost",
-      "fields": [
-        {
-          "type": "uint64",
-          "name": "stellarAccountSeqno"
-        },
-        {
-          "type": "Members",
-          "name": "members"
         },
         {
           "type": "string",
@@ -91,6 +38,51 @@
         {
           "type": "string",
           "name": "noteB64"
+        },
+        {
+          "type": "string",
+          "name": "signedTransaction"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "PaymentRelayPost",
+      "fields": [
+        {
+          "type": "keybase1.DeviceID",
+          "name": "fromDeviceID"
+        },
+        {
+          "type": [
+            null,
+            "keybase1.UserVersion"
+          ],
+          "name": "to"
+        },
+        {
+          "type": "string",
+          "name": "toAssertion"
+        },
+        {
+          "type": "AccountID",
+          "name": "relayAccount"
+        },
+        {
+          "type": "keybase1.TeamID",
+          "name": "teamID"
+        },
+        {
+          "type": "string",
+          "name": "displayAmount"
+        },
+        {
+          "type": "string",
+          "name": "displayCurrency"
+        },
+        {
+          "type": "string",
+          "name": "boxB64"
         },
         {
           "type": "string",
@@ -283,7 +275,20 @@
         },
         {
           "name": "payment",
-          "type": "PaymentPost"
+          "type": "PaymentDirectPost"
+        }
+      ],
+      "response": "PaymentResult"
+    },
+    "submitRelayPayment": {
+      "request": [
+        {
+          "name": "caller",
+          "type": "keybase1.UserVersion"
+        },
+        {
+          "name": "payment",
+          "type": "PaymentRelayPost"
         }
       ],
       "response": "PaymentResult"


### PR DESCRIPTION
Implement some of sendRelayPayment. This PR doesn't have tests yet and the final remote call gets cut off by an `if true return error`. 

There are protocol changes to the normal SubmitPayment, which is why I think it makes sense to get this in before fully implementing relay submitting.

The server side vendors in this protocol but should be deployed first https://github.com/keybase/keybase/pull/2423