### PR TITLE
login_with_paperkey no longer needs LoginState

### DIFF
--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -39,6 +39,20 @@ func requiresUI(c libkb.UIConsumer, kind libkb.UIKind) bool {
 	return false
 }
 
+// isLoggedInWithUIDAndError conveys if the user is in a logged-in state or not.
+// If this function returns `true`, it's because the user is logged in,
+// is on a provisioned device, and has an unlocked device key, If this
+// function returns `false`, it's because either no one has ever logged onto
+// this device, or someone has, and then clicked `logout`. If the return
+// value is `false`, and `err` is `nil`, then the service is in one of
+// those expected "logged out" states.  If the return value is `false`
+// and `err` is non-`nil`, then something went wrong, and the app is in some
+// sort of unexpected state. If `ret` is `true`, then `uid` will convey
+// which user is logged in.
+//
+// Under the hood, IsLoggedIn is going through the BootstrapActiveDevice
+// flow and therefore will try its best to unlocked locked keys if it can
+// without user interaction.
 func isLoggedInWithUIDAndError(m libkb.MetaContext) (ret bool, uid keybase1.UID, err error) {
 	ret, uid, err = libkb.BootstrapActiveDeviceWithMetaContext(m)
 	return ret, uid, err

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -20,6 +20,22 @@ type ActiveDevice struct {
 	sync.RWMutex
 }
 
+// NewProvisionalActiveDevice creates an ActiveDevice that is "provisional", in that it
+// should not be considered the global ActiveDevice. Instead, it should reside in thread-local
+// context, and can be weaved through the login machinery without trampling the actual global
+// ActiveDevice.
+func NewProvisionalActiveDevice(m MetaContext, u keybase1.UID, d keybase1.DeviceID, sigKey GenericKey, encKey GenericKey, deviceName string) *ActiveDevice {
+	return &ActiveDevice{
+		uid:           u,
+		deviceID:      d,
+		deviceName:    deviceName,
+		signingKey:    sigKey,
+		encryptionKey: encKey,
+		nistFactory:   NewNISTFactory(m.G(), u, d, sigKey),
+		secretSyncer:  NewSecretSyncer(m.G()),
+	}
+}
+
 // Set acquires the write lock and sets all the fields in ActiveDevice.
 // The acct parameter is not used for anything except to help ensure
 // that this is called from inside a LogingState account request.

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -51,10 +51,9 @@ func (s *AppStatusEmbed) GetAppStatus() *AppStatus {
 // Internal and External APIs both implement these methods,
 // allowing us to share the request-making code below in doRequest
 type Requester interface {
-	Contextifier
-	fixHeaders(ctx context.Context, arg APIArg, req *http.Request, nist *NIST) error
+	fixHeaders(m MetaContext, arg APIArg, req *http.Request, nist *NIST) error
 	getCli(needSession bool) *Client
-	consumeHeaders(ctx context.Context, resp *http.Response, nist *NIST) error
+	consumeHeaders(m MetaContext, resp *http.Response, nist *NIST) error
 	isExternal() bool
 }
 
@@ -217,23 +216,23 @@ func (c *countingReader) numRead() int {
 
 func noopFinisher() {}
 
-func getNIST(ctx context.Context, g *GlobalContext, sessType APISessionType) *NIST {
+func getNIST(m MetaContext, sessType APISessionType) *NIST {
 	if sessType == APISessionTypeNONE {
 		return nil
 	}
 
-	if !g.Env.GetTorMode().UseSession() {
+	if !m.G().Env.GetTorMode().UseSession() {
 		return nil
 	}
 
-	nist, err := g.ActiveDevice.NIST(ctx)
+	nist, err := m.ActiveDevice().NIST(m.Ctx())
 	if nist == nil {
-		g.Log.CDebugf(ctx, "active device couldn't generate a NIST")
+		m.CDebugf("active device couldn't generate a NIST")
 		return nil
 	}
 
 	if err != nil {
-		g.Log.CDebugf(ctx, "Error generating NIST: %s", err)
+		m.CDebugf("Error generating NIST: %s", err)
 		return nil
 	}
 	return nist
@@ -244,27 +243,20 @@ func getNIST(ctx context.Context, g *GlobalContext, sessType APISessionType) *NI
 // a `finisher func()` that *must always be called* after the response is no longer
 // needed. This finisher is always non-nil (and just a noop in some cases),
 // so therefore it's fine to call it without checking for nil-ness.
-func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes bool) (_ *http.Response, finisher func(), jw *jsonw.Wrapper, err error) {
-	if !api.G().Env.GetTorMode().UseSession() && arg.SessionType == APISessionTypeREQUIRED {
+func doRequestShared(m MetaContext, api Requester, arg APIArg, req *http.Request, wantJSONRes bool) (_ *http.Response, finisher func(), jw *jsonw.Wrapper, err error) {
+	if !m.G().Env.GetTorMode().UseSession() && arg.SessionType == APISessionTypeREQUIRED {
 		err = TorSessionRequiredError{}
 		return
 	}
 
+	m = m.EnsureCtx().WithLogTag("API")
+
 	finisher = noopFinisher
 
-	ctx := arg.NetContext
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	ctx = WithLogTag(ctx, "API")
-	arg.NetContext = ctx
+	nist := getNIST(m, arg.SessionType)
 
-	api.G().Log.CDebugf(ctx, "+ API %s %s", req.Method, req.URL)
-
-	nist := getNIST(ctx, api.G(), arg.SessionType)
-
-	if err = api.fixHeaders(ctx, arg, req, nist); err != nil {
-		api.G().Log.CDebugf(ctx, "- API %s %s: fixHeaders error: %s", req.Method, req.URL, err)
+	if err = api.fixHeaders(m, arg, req, nist); err != nil {
+		m.CDebugf("- API %s %s: fixHeaders error: %s", req.Method, req.URL, err)
 		return
 	}
 	needSession := false
@@ -282,18 +274,17 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	var jsonBytes int
 	var status string
 	defer func() {
-		api.G().Log.CDebugf(ctx, "- API %s %s: err=%s, status=%q, jsonwBytes=%d", req.Method, req.URL,
-			ErrToOk(err), status, jsonBytes)
+		m.CDebugf("- API %s %s: err=%s, status=%q, jsonwBytes=%d", req.Method, req.URL, ErrToOk(err), status, jsonBytes)
 	}()
 
-	if api.G().Env.GetAPIDump() {
+	if m.G().Env.GetAPIDump() {
 		jpStr, _ := json.MarshalIndent(arg.JSONPayload, "", "  ")
 		argStr, _ := json.MarshalIndent(arg.getHTTPArgs(), "", "  ")
-		api.G().Log.CDebugf(ctx, "| full request: json:%s querystring:%s", jpStr, argStr)
+		m.CDebugf("| full request: json:%s querystring:%s", jpStr, argStr)
 	}
 
-	timer := api.G().Timers.Start(timerType)
-	internalResp, canc, err := doRetry(ctx, api, arg, cli, req)
+	timer := m.G().Timers.Start(timerType)
+	internalResp, canc, err := doRetry(m, arg, cli, req)
 
 	finisher = func() {
 		if internalResp != nil {
@@ -324,7 +315,7 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	// headers. If the client is *really* out of date, the request status will
 	// be a 400 error, but these headers will still be present. So we need to
 	// handle headers *before* we abort based on status below.
-	err = api.consumeHeaders(ctx, internalResp, nist)
+	err = api.consumeHeaders(m, internalResp, nist)
 	if err != nil {
 		return nil, finisher, nil, err
 	}
@@ -348,9 +339,9 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 		}
 
 		jw = jsonw.NewWrapper(obj)
-		if api.G().Env.GetAPIDump() {
+		if m.G().Env.GetAPIDump() {
 			b, _ := json.MarshalIndent(obj, "", "  ")
-			api.G().Log.CDebugf(ctx, "| full reply: %s", b)
+			m.CDebugf("| full reply: %s", b)
 		}
 	}
 
@@ -362,19 +353,19 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 // retry them arg.RetryCount times. It returns 3 values: the HTTP response, if all goes
 // well; a canceler function func() that the caller should call after all work is completed
 // on this request; and an error. The canceler function is to clean up the timeout.
-func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *http.Request) (*http.Response, func(), error) {
+func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (*http.Response, func(), error) {
 
 	// This serves as a proxy for checking the status of the Gregor connection. If we are not
 	// connected to Gregor, then it is likely the case we are totally offline, or on a very bad
 	// connection. If that is the case, let's make these timeouts very aggressive, so we don't
 	// block up everything trying to succeed when we probably will not.
-	if ConnectivityMonitorNo == g.G().ConnectivityMonitor.IsConnected(ctx) {
+	if ConnectivityMonitorNo == m.G().ConnectivityMonitor.IsConnected(m.Ctx()) {
 		arg.InitialTimeout = HTTPFastTimeout
 		arg.RetryCount = 0
 	}
 
 	if arg.InitialTimeout == 0 && arg.RetryCount == 0 {
-		resp, err := ctxhttp.Do(ctx, cli.cli, req)
+		resp, err := ctxhttp.Do(m.Ctx(), cli.cli, req)
 		return resp, nil, err
 	}
 
@@ -396,9 +387,9 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 	var lastErr error
 	for i := 0; i < retries; i++ {
 		if i > 0 {
-			g.G().Log.CDebugf(ctx, "retry attempt %d of %d for %s", i, retries, arg.Endpoint)
+			m.CDebugf("retry attempt %d of %d for %s", i, retries, arg.Endpoint)
 		}
-		resp, canc, err := doTimeout(ctx, g, cli, req, timeout)
+		resp, canc, err := doTimeout(m, cli, req, timeout)
 		if err == nil {
 			return resp, canc, nil
 		}
@@ -406,8 +397,8 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 		timeout = time.Duration(float64(timeout) * multiplier)
 
 		// If chat goes offline during this retry loop, then let's bail out early
-		if ConnectivityMonitorNo == g.G().ConnectivityMonitor.IsConnected(ctx) {
-			g.G().Log.CDebugf(ctx, "retry loop aborting since chat went offline")
+		if ConnectivityMonitorNo == m.G().ConnectivityMonitor.IsConnected(m.Ctx()) {
+			m.CDebugf("retry loop aborting since chat went offline")
 			break
 		}
 
@@ -427,8 +418,8 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 // doTimeout does the http request with a timeout. It returns the response from making the HTTP request,
 // a canceler, and an error. The canceler ought to be called before the caller (or its caller) is done
 // with this request.
-func doTimeout(origCtx context.Context, g Contextifier, cli *Client, req *http.Request, timeout time.Duration) (*http.Response, func(), error) {
-	ctx, cancel := context.WithTimeout(origCtx, timeout*CITimeMultiplier(g.G()))
+func doTimeout(m MetaContext, cli *Client, req *http.Request, timeout time.Duration) (*http.Response, func(), error) {
+	ctx, cancel := context.WithTimeout(m.Ctx(), timeout*CITimeMultiplier(m.G()))
 	resp, err := ctxhttp.Do(ctx, cli.cli, req)
 	return resp, cancel, err
 }
@@ -550,7 +541,7 @@ func (a *InternalAPIEngine) updateCriticalClockSkewWarning(resp *http.Response) 
 	}
 }
 
-func (a *InternalAPIEngine) consumeHeaders(ctx context.Context, resp *http.Response, nist *NIST) (err error) {
+func (a *InternalAPIEngine) consumeHeaders(m MetaContext, resp *http.Response, nist *NIST) (err error) {
 	upgradeTo := resp.Header.Get("X-Keybase-Client-Upgrade-To")
 	upgradeURI := resp.Header.Get("X-Keybase-Upgrade-URI")
 	customMessage := resp.Header.Get("X-Keybase-Upgrade-Message")
@@ -560,7 +551,7 @@ func (a *InternalAPIEngine) consumeHeaders(ctx context.Context, resp *http.Respo
 			customMessage = string(decoded)
 		} else {
 			// If base64-decode fails, just log the error and skip decoding.
-			a.G().Log.CErrorf(ctx, "Failed to decode X-Keybase-Upgrade-Message header: %s", err)
+			m.CErrorf("Failed to decode X-Keybase-Upgrade-Message header: %s", err)
 		}
 	}
 
@@ -572,9 +563,9 @@ func (a *InternalAPIEngine) consumeHeaders(ctx context.Context, resp *http.Respo
 			nist.MarkSuccess()
 		case "failed":
 			nist.MarkFailure()
-			a.G().Log.CWarningf(ctx, "NIST token failed to verify")
+			m.CWarningf("NIST token failed to verify")
 		default:
-			a.G().Log.CNoticef(ctx, "Unexpected 'X-Keybase-Auth-NIST' state: %s", nistReply)
+			m.CInfof("Unexpected 'X-Keybase-Auth-NIST' state: %s", nistReply)
 		}
 	}
 
@@ -582,14 +573,14 @@ func (a *InternalAPIEngine) consumeHeaders(ctx context.Context, resp *http.Respo
 
 	if len(upgradeTo) > 0 || len(customMessage) > 0 {
 		now := time.Now()
-		g := a.G()
+		g := m.G()
 		g.oodiMu.Lock()
 		g.outOfDateInfo.UpgradeTo = upgradeTo
 		g.outOfDateInfo.UpgradeURI = upgradeURI
 		g.outOfDateInfo.CustomMessage = customMessage
 		if g.lastUpgradeWarning.IsZero() || now.Sub(*g.lastUpgradeWarning) > 3*time.Minute {
 			// Send the notification after we unlock
-			defer a.G().NotifyRouter.HandleClientOutOfDate(upgradeTo, upgradeURI, customMessage)
+			defer g.NotifyRouter.HandleClientOutOfDate(upgradeTo, upgradeURI, customMessage)
 			*g.lastUpgradeWarning = now
 		}
 		g.oodiMu.Unlock()
@@ -598,7 +589,7 @@ func (a *InternalAPIEngine) consumeHeaders(ctx context.Context, resp *http.Respo
 		// of date, but now it doesn't. (Maybe a bad config got pushed and then
 		// later fixed.) If so, we need to clear the global outOfDateInfo, so
 		// that the client stops printing warnings.
-		g := a.G()
+		g := m.G()
 		g.oodiMu.Lock()
 		g.outOfDateInfo.UpgradeTo = ""
 		g.outOfDateInfo.UpgradeURI = ""
@@ -608,51 +599,51 @@ func (a *InternalAPIEngine) consumeHeaders(ctx context.Context, resp *http.Respo
 	return
 }
 
-func (a *InternalAPIEngine) fixHeaders(ctx context.Context, arg APIArg, req *http.Request, nist *NIST) error {
+func (a *InternalAPIEngine) fixHeaders(m MetaContext, arg APIArg, req *http.Request, nist *NIST) error {
 
 	if nist != nil {
 		req.Header.Set("X-Keybase-Session", nist.Token().String())
 
 	} else if arg.SessionType != APISessionTypeNONE {
-		a.G().Log.CDebugf(ctx, "fixHeaders: falling back to legacy session management")
+		m.CDebugf("fixHeaders: falling back to legacy session management")
 		tok, csrf, err := a.sessionArgs(arg)
 		if err != nil {
 			if arg.SessionType == APISessionTypeREQUIRED {
-				a.G().Log.CWarningf(ctx, "fixHeaders: session required, but error getting sessionArgs: %s", err)
+				m.CWarningf("fixHeaders: session required, but error getting sessionArgs: %s", err)
 				return err
 			}
-			a.G().Log.CDebugf(ctx, "fixHeaders: session optional, error getting sessionArgs: %s", err)
+			m.CDebugf("fixHeaders: session optional, error getting sessionArgs: %s", err)
 		}
 
-		if a.G().Env.GetTorMode().UseSession() {
+		if m.G().Env.GetTorMode().UseSession() {
 			if len(tok) > 0 {
 				req.Header.Set("X-Keybase-Session", tok)
 			} else if arg.SessionType == APISessionTypeREQUIRED {
-				a.G().Log.CWarningf(ctx, "fixHeaders: need session, but session token empty")
+				m.CWarningf("fixHeaders: need session, but session token empty")
 				return InternalError{Msg: "API request requires session, but session token empty"}
 			}
 		}
-		if a.G().Env.GetTorMode().UseCSRF() {
+		if m.G().Env.GetTorMode().UseCSRF() {
 			if len(csrf) > 0 {
 				req.Header.Set("X-CSRF-Token", csrf)
 			} else if arg.SessionType == APISessionTypeREQUIRED {
-				a.G().Log.CWarningf(ctx, "fixHeaders: need session, but session csrf empty")
+				m.CWarningf("fixHeaders: need session, but session csrf empty")
 				return InternalError{Msg: "API request requires session, but session csrf empty"}
 			}
 		}
 	}
 
-	if a.G().Env.GetTorMode().UseHeaders() {
+	if m.G().Env.GetTorMode().UseHeaders() {
 		req.Header.Set("User-Agent", UserAgent)
 		identifyAs := GoClientID + " v" + VersionString() + " " + GetPlatformString()
 		req.Header.Set("X-Keybase-Client", identifyAs)
-		if a.G().Env.GetDeviceID().Exists() {
+		if m.G().Env.GetDeviceID().Exists() {
 			req.Header.Set("X-Keybase-Device-ID", a.G().Env.GetDeviceID().String())
 		}
-		if i := a.G().Env.GetInstallID(); i.Exists() {
+		if i := m.G().Env.GetInstallID(); i.Exists() {
 			req.Header.Set("X-Keybase-Install-ID", i.String())
 		}
-		if tags := LogTagsToString(arg.NetContext); tags != "" {
+		if tags := LogTagsToString(m.Ctx()); tags != "" {
 			req.Header.Set("X-Keybase-Log-Tags", tags)
 		}
 	}
@@ -733,13 +724,15 @@ func (a *InternalAPIEngine) Get(arg APIArg) (*APIRes, error) {
 // GetResp performs a GET request and returns the http response. The finisher
 // second arg should be called whenever we're done with the response (if it's non-nil).
 func (a *InternalAPIEngine) GetResp(arg APIArg) (*http.Response, func(), error) {
+	m := arg.GetMetaContext(a.G())
+
 	url1 := a.getURL(arg)
 	req, err := a.PrepareGet(url1, arg)
 	if err != nil {
 		return nil, noopFinisher, err
 	}
 
-	resp, finisher, _, err := doRequestShared(a, arg, req, false)
+	resp, finisher, _, err := doRequestShared(m, a, arg, req, false)
 	if err != nil {
 		return nil, finisher, err
 	}
@@ -750,35 +743,37 @@ func (a *InternalAPIEngine) GetResp(arg APIArg) (*http.Response, func(), error) 
 // GetDecode performs a GET request and decodes the response via
 // JSON into the value pointed to by v.
 func (a *InternalAPIEngine) GetDecode(arg APIArg, v APIResponseWrapper) error {
-	reqErr := a.getDecode(arg, v)
+	m := arg.GetMetaContext(a.G())
+	reqErr := a.getDecode(m, arg, v)
 	if reqErr == nil {
 		return nil
 	}
 
-	if err := a.refreshSession(arg, reqErr); err != nil {
+	if err := a.refreshSession(m, arg, reqErr); err != nil {
 		return err
 	}
 
-	a.G().Log.CDebugf(arg.NetContext, "| API GetDecode %s session refreshed, trying again", arg.Endpoint)
+	m.CDebugf("| API GetDecode %s session refreshed, trying again", arg.Endpoint)
 
-	reqErr = a.getDecode(arg, v)
+	reqErr = a.getDecode(m, arg, v)
 	if reqErr == nil {
-		a.G().Log.CDebugf(arg.NetContext, "| API GetDecode %s success after refresh", arg.Endpoint)
+		m.CDebugf("| API GetDecode %s success after refresh", arg.Endpoint)
 		return nil
 	}
 	if _, relogin := reqErr.(ReloginRequiredError); relogin {
-		a.G().Log.CDebugf(arg.NetContext, "| API GetDecode %s retry after refresh still asking for new session, bailing out", arg.Endpoint)
+		m.CDebugf("| API GetDecode %s retry after refresh still asking for new session, bailing out", arg.Endpoint)
 		return LoginRequiredError{Context: "your session has expired"}
 	}
 
-	a.G().Log.CDebugf(arg.NetContext, "| API GetDecode %s error after refresh: %s", arg.Endpoint, reqErr)
+	m.CDebugf("| API GetDecode %s error after refresh: %s", arg.Endpoint, reqErr)
 	return reqErr
 }
 
-func (a *InternalAPIEngine) getDecode(arg APIArg, v APIResponseWrapper) error {
+func (a *InternalAPIEngine) getDecode(m MetaContext, arg APIArg, v APIResponseWrapper) error {
+	arg.MetaContext = m
 	resp, finisher, err := a.GetResp(arg)
 	if err != nil {
-		a.G().Log.CDebugf(arg.NetContext, "| API GetDecode, GetResp error: %s", err)
+		m.CDebugf("| API GetDecode, GetResp error: %s", err)
 		return err
 	}
 	defer finisher()
@@ -790,17 +785,17 @@ func (a *InternalAPIEngine) getDecode(arg APIArg, v APIResponseWrapper) error {
 		if err != nil {
 			return err
 		}
-		a.G().Log.CDebugf(arg.NetContext, "| response body: %s", string(body))
+		m.CDebugf("| response body: %s", string(body))
 		reader = bytes.NewReader(body)
 	}
 
 	dec := json.NewDecoder(reader)
 	if err = dec.Decode(&v); err != nil {
-		a.G().Log.CDebugf(arg.NetContext, "| API GetDecode, Decode error: %s", err)
+		m.CDebugf("| API GetDecode, Decode error: %s", err)
 		return err
 	}
 	if err = a.checkAppStatus(arg, v.GetAppStatus()); err != nil {
-		a.G().Log.CDebugf(arg.NetContext, "| API GetDecode, checkAppStatus error: %s", err)
+		m.CDebugf("| API GetDecode, checkAppStatus error: %s", err)
 		return err
 	}
 
@@ -824,14 +819,14 @@ func (a *InternalAPIEngine) PostJSON(arg APIArg) (*APIRes, error) {
 
 // postResp performs a POST request and returns the http response.
 // The finisher() should be called after the response is no longer needed.
-func (a *InternalAPIEngine) postResp(arg APIArg) (*http.Response, func(), error) {
+func (a *InternalAPIEngine) postResp(m MetaContext, arg APIArg) (*http.Response, func(), error) {
 	url1 := a.getURL(arg)
 	req, err := a.PrepareMethodWithBody("POST", url1, arg)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	resp, finisher, _, err := doRequestShared(a, arg, req, false)
+	resp, finisher, _, err := doRequestShared(m, a, arg, req, false)
 	if err != nil {
 		return nil, finisher, err
 	}
@@ -840,32 +835,33 @@ func (a *InternalAPIEngine) postResp(arg APIArg) (*http.Response, func(), error)
 }
 
 func (a *InternalAPIEngine) PostDecode(arg APIArg, v APIResponseWrapper) error {
-	reqErr := a.postDecode(arg, v)
+	m := arg.GetMetaContext(a.G())
+	reqErr := a.postDecode(m, arg, v)
 	if reqErr == nil {
 		return nil
 	}
 
-	if err := a.refreshSession(arg, reqErr); err != nil {
+	if err := a.refreshSession(m, arg, reqErr); err != nil {
 		return err
 	}
 
-	a.G().Log.CDebugf(arg.NetContext, "| API PostDecode %s session refreshed, trying again", arg.Endpoint)
-	reqErr = a.postDecode(arg, v)
+	m.CDebugf("| API PostDecode %s session refreshed, trying again", arg.Endpoint)
+	reqErr = a.postDecode(m, arg, v)
 	if reqErr == nil {
-		a.G().Log.CDebugf(arg.NetContext, "| API PostDecode %s success after refresh", arg.Endpoint)
+		m.CDebugf("| API PostDecode %s success after refresh", arg.Endpoint)
 		return nil
 	}
 	if _, relogin := reqErr.(ReloginRequiredError); relogin {
-		a.G().Log.CDebugf(arg.NetContext, "| API PostDecode %s retry after refresh still asking for new session, bailing out", arg.Endpoint)
+		m.CDebugf("| API PostDecode %s retry after refresh still asking for new session, bailing out", arg.Endpoint)
 		return LoginRequiredError{Context: "your session has expired"}
 	}
 
-	a.G().Log.CDebugf(arg.NetContext, "| API PostDecode %s error after refresh: %s", arg.Endpoint, reqErr)
+	m.CDebugf("| API PostDecode %s error after refresh: %s", arg.Endpoint, reqErr)
 	return reqErr
 }
 
-func (a *InternalAPIEngine) postDecode(arg APIArg, v APIResponseWrapper) error {
-	resp, finisher, err := a.postResp(arg)
+func (a *InternalAPIEngine) postDecode(m MetaContext, arg APIArg, v APIResponseWrapper) error {
+	resp, finisher, err := a.postResp(m, arg)
 	if err != nil {
 		return err
 	}
@@ -899,16 +895,17 @@ func (a *InternalAPIEngine) Delete(arg APIArg) (*APIRes, error) {
 }
 
 func (a *InternalAPIEngine) DoRequest(arg APIArg, req *http.Request) (*APIRes, error) {
-	res, reqErr := a.doRequest(arg, req)
+	m := arg.GetMetaContext(a.G())
+	res, reqErr := a.doRequest(m, arg, req)
 	if reqErr == nil {
 		return res, nil
 	}
 
-	if err := a.refreshSession(arg, reqErr); err != nil {
+	if err := a.refreshSession(m, arg, reqErr); err != nil {
 		return res, err
 	}
 
-	a.G().Log.CDebugf(arg.NetContext, "| API call %s session refreshed, trying again", arg.Endpoint)
+	m.CDebugf("| API call %s session refreshed, trying again", arg.Endpoint)
 
 	if req.GetBody != nil {
 		// post request body consumed, need to get it back
@@ -919,50 +916,49 @@ func (a *InternalAPIEngine) DoRequest(arg APIArg, req *http.Request) (*APIRes, e
 		}
 	}
 
-	res, err := a.doRequest(arg, req)
+	res, err := a.doRequest(m, arg, req)
 	if err == nil {
-		a.G().Log.CDebugf(arg.NetContext, "| API call %s success after refresh", arg.Endpoint)
+		m.CDebugf("| API call %s success after refresh", arg.Endpoint)
 		return res, nil
 	}
 
 	if _, relogin := err.(ReloginRequiredError); relogin {
-		a.G().Log.CDebugf(arg.NetContext, "| API call %s retry after refresh still asking for new session, bailing out", arg.Endpoint)
+		m.CDebugf("| API call %s retry after refresh still asking for new session, bailing out", arg.Endpoint)
 		return res, LoginRequiredError{Context: "your session has expired"}
 	}
 
-	a.G().Log.CDebugf(arg.NetContext, "| API call %s error after refresh: %s", arg.Endpoint, err)
+	m.CDebugf("| API call %s error after refresh: %s", arg.Endpoint, err)
 
 	return res, err
 }
 
-func (a *InternalAPIEngine) refreshSession(arg APIArg, reqErr error) error {
+func (a *InternalAPIEngine) refreshSession(m MetaContext, arg APIArg, reqErr error) error {
 	_, relogin := reqErr.(ReloginRequiredError)
 	if !relogin {
 		return reqErr
 	}
 
-	a.G().Log.CDebugf(arg.NetContext, "| API call %s session expired, trying to refresh", arg.Endpoint)
+	m.CDebugf("| API call %s session expired, trying to refresh", arg.Endpoint)
 
 	if arg.SessionR != nil {
 		// can't re-login with a SessionR
 		return LoginRequiredError{Context: "your session has expired"}
-
 	}
 
-	username := a.G().Env.GetUsername()
-	if err := a.G().LoginState().LoginWithStoredSecret(NewMetaContext(arg.NetContext, a.G()), username.String(), nil); err != nil {
-		a.G().Log.CDebugf(arg.NetContext, "| API call %s session refresh error: %s", arg.Endpoint, err)
+	username := m.G().Env.GetUsername()
+	if err := m.G().LoginState().LoginWithStoredSecret(m, username.String(), nil); err != nil {
+		m.CDebugf("| API call %s session refresh error: %s", arg.Endpoint, err)
 		return LoginRequiredError{Context: "your session has expired"}
 
 	}
 
-	a.G().Log.CDebugf(arg.NetContext, "| API call %s session refreshed", arg.Endpoint)
+	m.CDebugf("| API call %s session refreshed", arg.Endpoint)
 	return nil
 
 }
 
-func (a *InternalAPIEngine) doRequest(arg APIArg, req *http.Request) (*APIRes, error) {
-	resp, finisher, jw, err := doRequestShared(a, arg, req, true)
+func (a *InternalAPIEngine) doRequest(m MetaContext, arg APIArg, req *http.Request) (*APIRes, error) {
+	resp, finisher, jw, err := doRequestShared(m, a, arg, req, true)
 	if err != nil {
 		return nil, err
 	}
@@ -978,12 +974,12 @@ func (a *InternalAPIEngine) doRequest(arg APIArg, req *http.Request) (*APIRes, e
 	// http.AppStatus
 	appStatus, err := a.checkAppStatusFromJSONWrapper(arg, status)
 	if err != nil {
-		a.G().Log.CDebugf(arg.NetContext, "- API call %s error: %s", arg.Endpoint, err)
+		m.CDebugf("- API call %s error: %s", arg.Endpoint, err)
 		return nil, err
 	}
 
 	body := jw
-	a.G().Log.CDebugf(arg.NetContext, "- API call %s success", arg.Endpoint)
+	m.CDebugf("- API call %s success", arg.Endpoint)
 	return &APIRes{status, body, resp.StatusCode, appStatus}, err
 }
 
@@ -1001,7 +997,7 @@ const (
 	XAPIResText
 )
 
-func (api *ExternalAPIEngine) fixHeaders(ctx context.Context, arg APIArg, req *http.Request, nist *NIST) error {
+func (api *ExternalAPIEngine) fixHeaders(m MetaContext, arg APIArg, req *http.Request, nist *NIST) error {
 	// TODO (here and in the internal API engine implementation): If we don't
 	// set the User-Agent, it will default to http.defaultUserAgent
 	// ("Go-http-client/1.1"). We should think about whether that's what we
@@ -1018,7 +1014,7 @@ func (api *ExternalAPIEngine) fixHeaders(ctx context.Context, arg APIArg, req *h
 			userAgent = strings.Replace(userAgent, "android", "linux", 1)
 		}
 	}
-	if api.G().Env.GetTorMode().UseHeaders() {
+	if m.G().Env.GetTorMode().UseHeaders() {
 		req.Header.Set("User-Agent", userAgent)
 	}
 
@@ -1030,7 +1026,7 @@ func isReddit(req *http.Request) bool {
 	return host == "reddit.com" || strings.HasSuffix(host, ".reddit.com")
 }
 
-func (api *ExternalAPIEngine) consumeHeaders(ctx context.Context, resp *http.Response, nist *NIST) error {
+func (api *ExternalAPIEngine) consumeHeaders(m MetaContext, resp *http.Response, nist *NIST) error {
 	return nil
 }
 
@@ -1040,11 +1036,13 @@ func (api *ExternalAPIEngine) DoRequest(
 	arg APIArg, req *http.Request, restype XAPIResType) (
 	ar *ExternalAPIRes, hr *ExternalHTMLRes, tr *ExternalTextRes, err error) {
 
+	m := arg.GetMetaContext(api.G())
+
 	var resp *http.Response
 	var jw *jsonw.Wrapper
 	var finisher func()
 
-	resp, finisher, jw, err = doRequestShared(api, arg, req, (restype == XAPIResJSON))
+	resp, finisher, jw, err = doRequestShared(m, api, arg, req, (restype == XAPIResJSON))
 	if err != nil {
 		return
 	}

--- a/go/libkb/apiarg.go
+++ b/go/libkb/apiarg.go
@@ -28,6 +28,14 @@ type APIArg struct {
 	RetryMultiplier float64       // optional
 	RetryCount      int           // optional
 	NetContext      context.Context
+	MetaContext     MetaContext
+}
+
+func (a APIArg) GetMetaContext(g *GlobalContext) MetaContext {
+	if a.MetaContext.g != nil {
+		return a.MetaContext
+	}
+	return NewMetaContext(a.NetContext, g)
 }
 
 // NewAPIArg creates a standard APIArg that will result

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -257,8 +257,8 @@ type ExternalAPIRes struct {
 
 type API interface {
 	Get(APIArg) (*APIRes, error)
-	GetResp(APIArg) (*http.Response, func(), error)
 	GetDecode(APIArg, APIResponseWrapper) error
+	GetResp(APIArg) (*http.Response, func(), error)
 	Post(APIArg) (*APIRes, error)
 	PostJSON(APIArg) (*APIRes, error)
 	PostDecode(APIArg, APIResponseWrapper) error


### PR DESCRIPTION
- we change the strategy here; taking a page out of oneshot's book, we're installing a provisional ActiveDevice in the MetaContext, and then using it to fetch recovery information from the server
- change BootstrapActiveDevice code to also hold the switchUserMu when finishing up (and also ensuring that the config file didn't change out from underneath us).
- start to weave `MetaContext` through `API`, but stop at the public interface. It'll be a huge patch to force callers to pass it in, so just make it an optional element of `APIArg`. If not specified, then we'll cook one up based on the given `GlobalContext`, and the optional `NetContext` in `APIArg`.