### PR TITLE
Fix `keybase git create` option order

### DIFF
--- a/go/client/cmd_git_create.go
+++ b/go/client/cmd_git_create.go
@@ -22,9 +22,9 @@ type CmdGitCreate struct {
 func newCmdGitCreate(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "create",
-		ArgumentHelp: "<repo name> [--team=<team name>]",
+		ArgumentHelp: "[--team=<team name>] <repo name>",
 		Usage:        "Create a personal or team git repository.",
-		Description:  "`keybase git create reponame` will create a personal git repo.\n   `keybase git create reponame --team=treehouse` will create a\n   team git repo for the `treehouse` team.",
+		Description:  "`keybase git create reponame` will create a personal git repo.\n   `keybase git create --team=treehouse reponame` will create a\n   team git repo for the `treehouse` team.",
 		Action: func(c *cli.Context) {
 			cmd := NewCmdGitCreateRunner(g)
 			cl.ChooseCommand(cmd, "create", c)


### PR DESCRIPTION
The help text suggests an order of options that does not work as specified if used with other command options (i.e.`--skip-notify`), e.g.:

 - `keybase git create --skip-notify reponame --team=treehouse` creates a private personal repo instead of a team repo.
 - `keybase git create --skip-notify --team=treehouse reponame` does create a team repo.

Therefore, I've changed the order of the help/usage text.