### PR TITLE
allow iOS keychain to be accessible after first device unlock CORE-7443

### DIFF
--- a/go/libkb/secret_store_ios.go
+++ b/go/libkb/secret_store_ios.go
@@ -17,5 +17,5 @@ func (k KeychainSecretStore) synchronizable() keychain.Synchronizable {
 }
 
 func (k KeychainSecretStore) accessible() keychain.Accessible {
-	return keychain.AccessibleWhenUnlockedThisDeviceOnly
+	return keychain.AccessibleAfterFirstUnlockThisDeviceOnly
 }


### PR DESCRIPTION
This is the access control level that Signal [uses](https://github.com/signalapp/Signal-iOS/blob/6ccf93e9291c6d06abd956c9721cf756312cbb46/SignalServiceKit/src/Storage/OWSStorage.m#L824), so it is likely safe, and would make background operations succeed much more often. 

I also included some update code to try and fix old keychain entries.  