### PR TITLE
Return EKMissingBoxErr to use in KeygenIfNeeded

### DIFF
--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -44,6 +44,22 @@ func (e *EKUnboxErr) Error() string {
 	return fmt.Sprintf("Error unboxing %s@generation:%v missing %s@generation:%v", e.boxType, e.boxGeneration, e.missingType, e.missingGeneration)
 }
 
+type EKMissingBoxErr struct {
+	boxType       EKType
+	boxGeneration keybase1.EkGeneration
+}
+
+func newEKMissingBoxErr(boxType EKType, boxGeneration keybase1.EkGeneration) *EKMissingBoxErr {
+	return &EKMissingBoxErr{
+		boxType:       boxType,
+		boxGeneration: boxGeneration,
+	}
+}
+
+func (e *EKMissingBoxErr) Error() string {
+	return fmt.Sprintf("Missing box for %s@generation:%v", e.boxType, e.boxGeneration)
+}
+
 func ctimeIsStale(ctime keybase1.Time, currentMerkleRoot libkb.MerkleRoot) bool {
 	return currentMerkleRoot.Ctime()-ctime.UnixSeconds() >= KeyLifetimeSecs
 }

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -199,7 +199,7 @@ func (e *EKLib) newUserEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot
 	ek, err := s.Get(ctx, statement.CurrentUserEkMetadata.Generation)
 	if err != nil {
 		switch err.(type) {
-		case *EKUnboxErr:
+		case *EKUnboxErr, *EKMissingBoxErr:
 			e.G().Log.Debug(err.Error())
 			return true, nil
 		default:
@@ -238,7 +238,7 @@ func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, mer
 	ek, err := s.Get(ctx, teamID, statement.CurrentTeamEkMetadata.Generation)
 	if err != nil {
 		switch err.(type) {
-		case *EKUnboxErr:
+		case *EKUnboxErr, *EKMissingBoxErr:
 			e.G().Log.Debug(err.Error())
 			return true, nil
 		default:

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -123,7 +123,7 @@ func (s *TeamEKBoxStorage) fetchAndPut(ctx context.Context, teamID keybase1.Team
 	}
 
 	if result.Result == nil {
-		return teamEK, fmt.Errorf("server didn't return a box for teamEK generation %d", generation)
+		return teamEK, newEKMissingBoxErr(TeamEKStr, generation)
 	}
 
 	// Before we store anything, let's verify that the server returned

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -113,7 +113,7 @@ func (s *UserEKBoxStorage) fetchAndPut(ctx context.Context, generation keybase1.
 	}
 
 	if result.Result == nil {
-		return userEK, fmt.Errorf("server didn't return a box for userEK generation %d", generation)
+		return userEK, newEKMissingBoxErr(UserEKStr, generation)
 	}
 
 	// Before we store anything, let's verify that the server returned


### PR DESCRIPTION
Ran into an issue where deviceA had created a usedEK but did not box it for deviceB (stale) and deviceB couldn't make a new userEK since it errored out in the `newUserEKNeeded` check once it came back online