### PR TITLE
Make proof message text un-selectable.

### DIFF
--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -31,7 +31,7 @@ function MissingProofRow({missingProof, style}: {missingProof: MissingProof, sty
         </Box>
         <Box style={styleProofNameSection}>
           <Box style={styleProofNameLabelContainer}>
-            <Text type="Body" selectable={true} style={{...styleProofName, color: missingColor}}>
+            <Text type="Body" style={{...styleProofName, color: missingColor}}>
               {missingProof.message}
             </Text>
           </Box>


### PR DESCRIPTION
This text doesn't really need to be selectable. It's selectability is interfering with the tap event.