### PR TITLE
Fix error messaging display for ephemeral chats

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -88,14 +88,14 @@ func (b *Boxer) log() logger.Logger {
 
 func (b *Boxer) makeErrorMessage(msg chat1.MessageBoxed, err UnboxingError) chat1.MessageUnboxed {
 	return chat1.NewMessageUnboxedWithError(chat1.MessageUnboxedError{
-		ErrType:           err.ExportType(),
-		ErrMsg:            err.Error(),
-		MessageID:         msg.GetMessageID(),
-		MessageType:       msg.GetMessageType(),
-		Ctime:             msg.ServerHeader.Ctime,
-		Now:               msg.ServerHeader.Now,
-		Rtime:             gregor1.ToTime(b.clock.Now()),
-		EphemeralMetadata: msg.ClientHeader.EphemeralMetadata,
+		ErrType:            err.ExportType(),
+		ErrMsg:             err.Error(),
+		MessageID:          msg.GetMessageID(),
+		MessageType:        msg.GetMessageType(),
+		Ctime:              msg.ServerHeader.Ctime,
+		IsEphemeral:        msg.IsEphemeral(),
+		IsEphemeralExpired: msg.IsEphemeralExpired(b.clock.Now()),
+		Etime:              msg.Etime(),
 	})
 }
 
@@ -283,13 +283,13 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv
 
 	// If the message is exploding, load the ephemeral key.
 	var ephemeralSeed *keybase1.TeamEk
-	if boxed.IsExploding() {
+	if boxed.IsEphemeral() {
 		ek, ekErr := CtxKeyFinder(ctx, b.G()).EphemeralKeyForDecryption(
 			ctx, tlfName, boxed.ClientHeader.Conv.Tlfid, conv.GetMembersType(), boxed.ClientHeader.TlfPublic,
 			boxed.EphemeralMetadata().Generation)
 		if ekErr != nil {
 			b.Debug(ctx, "failed to get a key for ephemeral message: msgID: %d err: %s", boxed.ServerHeader.MessageID, ekErr.Error())
-			return b.makeErrorMessage(boxed, NewPermanentUnboxingError(fmt.Errorf("Unable to decrypt exploding message. Missing keys."))), nil
+			return b.makeErrorMessage(boxed, NewPermanentUnboxingError(NewEphemeralUnboxingError())), nil
 		}
 		ephemeralSeed = &ek
 	}
@@ -399,7 +399,7 @@ func (b *Boxer) unbox(ctx context.Context, boxed chat1.MessageBoxed,
 	// V3 is the same as V2, except that it indicates exploding message support.
 	case chat1.MessageBoxedVersion_V2, chat1.MessageBoxedVersion_V3:
 		// Disable reading exploding messages until fully we release support
-		if boxed.IsExploding() {
+		if boxed.Version == chat1.MessageBoxedVersion_V3 {
 			if ekLib := b.G().GetEKLib(); ekLib != nil && !ekLib.ShouldRun(ctx) {
 				return nil, NewPermanentUnboxingError(NewMessageBoxedVersionError(boxed.Version))
 			}
@@ -640,7 +640,7 @@ func (b *Boxer) unboxV2orV3(ctx context.Context, boxed chat1.MessageBoxed,
 		return nil, NewPermanentUnboxingError(err)
 	}
 	bodyEncryptionKey := headerEncryptionKey
-	if boxed.IsExploding() {
+	if boxed.IsEphemeral() {
 		bodyEncryptionKey, err = libkb.DeriveFromSecret(ephemeralSeed.Seed, libkb.DeriveReasonTeamEKExplodingChat)
 		if err != nil {
 			return nil, NewPermanentUnboxingError(err)
@@ -1124,7 +1124,7 @@ func (b *Boxer) BoxMessage(ctx context.Context, msg chat1.MessagePlaintext,
 		version = *b.boxVersionForTesting
 	}
 
-	if msg.IsExploding() && version == chat1.MessageBoxedVersion_V1 {
+	if msg.IsEphemeral() && version == chat1.MessageBoxedVersion_V1 {
 		return nil, fmt.Errorf("cannot use exploding messages with V1")
 	}
 
@@ -1155,7 +1155,7 @@ func (b *Boxer) BoxMessage(ctx context.Context, msg chat1.MessagePlaintext,
 	// version. Make sure we're not using MessageBoxedVersion_V1, since that
 	// doesn't support exploding messages.
 	var ephemeralSeed *keybase1.TeamEk
-	if msg.IsExploding() {
+	if msg.IsEphemeral() {
 		ek, err := CtxKeyFinder(ctx, b.G()).EphemeralKeyForEncryption(
 			ctx, tlfName, msg.ClientHeader.Conv.Tlfid, membersType, msg.ClientHeader.TlfPublic)
 		if err != nil {
@@ -1347,7 +1347,7 @@ func (b *Boxer) boxV2orV3(messagePlaintext chat1.MessagePlaintext, baseEncryptio
 	// Regular messages use the same encryption key for the header and for the
 	// body. Exploding messages use a derived ephemeral key for the body.
 	bodyEncryptionKey := headerEncryptionKey
-	if messagePlaintext.IsExploding() {
+	if messagePlaintext.IsEphemeral() {
 		bodyEncryptionKey, err = libkb.DeriveFromSecret(ephemeralSeed.Seed, libkb.DeriveReasonTeamEKExplodingChat)
 		if err != nil {
 			return nil, err

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -1564,7 +1564,7 @@ func TestExplodingMessageUnbox(t *testing.T) {
 	}
 	require.Nil(t, unboxed.SenderDeviceRevokedAt, "message should not be from revoked device")
 	require.NotNil(t, unboxed.BodyHash)
-	require.True(t, unboxed.IsExploding())
+	require.True(t, unboxed.IsEphemeral())
 	require.NotNil(t, unboxed.EphemeralMetadata())
 	require.Equal(t, msg.EphemeralMetadata().Lifetime, unboxed.EphemeralMetadata().Lifetime)
 }

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -41,6 +41,8 @@ func (e PermanentUnboxingError) ExportType() chat1.MessageUnboxedErrorType {
 	switch err := e.inner.(type) {
 	case VersionError:
 		return err.ExportType()
+	case EphemeralUnboxingError:
+		return chat1.MessageUnboxedErrorType_EPHEMERAL
 	default:
 		return chat1.MessageUnboxedErrorType_MISC
 	}
@@ -62,6 +64,18 @@ func (e TransientUnboxingError) Inner() error { return e.inner }
 
 func (e TransientUnboxingError) ExportType() chat1.MessageUnboxedErrorType {
 	return chat1.MessageUnboxedErrorType_MISC
+}
+
+//=============================================================================
+
+type EphemeralUnboxingError struct{}
+
+func NewEphemeralUnboxingError() EphemeralUnboxingError {
+	return EphemeralUnboxingError{}
+}
+
+func (e EphemeralUnboxingError) Error() string {
+	return "Unable to decrypt exploding message. Missing keys."
 }
 
 //=============================================================================

--- a/go/chat/prev.go
+++ b/go/chat/prev.go
@@ -58,7 +58,7 @@ func CheckPrevPointersAndGetUnpreved(thread *chat1.ThreadView) (newPrevsForRegul
 			knownMessages[id] = msg
 			unprevedIDsForExploding[id] = struct{}{}
 			// The regular prev view only sees regular messages.
-			if !msg.IsExploding() {
+			if !msg.IsEphemeral() {
 				unprevedIDsForRegular[id] = struct{}{}
 			}
 		}
@@ -100,7 +100,7 @@ func CheckPrevPointersAndGetUnpreved(thread *chat1.ThreadView) (newPrevsForRegul
 				// to".
 				delete(unprevedIDsForExploding, prev.Id)
 				// The regular prev view doesn't respect exploding prevs.
-				if !msg.IsExploding() {
+				if !msg.IsEphemeral() {
 					delete(unprevedIDsForRegular, prev.Id)
 				}
 			}

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -469,7 +469,7 @@ func (o *Outbox) EphemeralPurge(ctx context.Context) (err error) {
 	var purged, recs []chat1.OutboxRecord
 	now := o.clock.Now()
 	for _, obr := range obox.Records {
-		if obr.Msg.IsExploding() {
+		if obr.Msg.IsEphemeral() {
 			st, err := obr.State.State()
 			if err != nil {
 				o.Debug(ctx, "purging ephemeral message from outbox with error getting state: %s", err)

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -147,7 +147,7 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 			continue
 		}
 		mvalid := msg.Valid()
-		if mvalid.IsExploding() {
+		if mvalid.IsEphemeral() {
 			if !mvalid.IsEphemeralExpired(s.clock.Now()) {
 				hasExploding = true
 				// Keep track of the minimum ephemeral message that is not yet

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -180,20 +180,13 @@ func (t *basicSupersedesTransform) Run(ctx context.Context,
 				continue
 			}
 			if !newMsg.IsValidFull() {
-				// Drop the message. It has been deleted locally but not
-				// superseded by anything.  Could have been deleted by a
-				// delete-history, retention expunge, or was an exploding
-				// message.
-				if newMsg.IsValid() {
-					// If we want to show the GUI that the message is exploded,
-					// don't hide these yet
-					mvalid := newMsg.Valid()
-					if !mvalid.IsExploding() || mvalid.HideExplosion(time.Now()) {
-						t.Debug(ctx, "skipping: %d because not valid full", msg.GetMessageID())
-						continue
-					}
-				} else {
-					t.Debug(ctx, "skipping: %d because it is not valid", msg.GetMessageID())
+				// Drop the message unless it is ephemeral. It has been deleted
+				// locally but not superseded by anything.  Could have been
+				// deleted by a delete-history, retention expunge, or was an
+				// exploding message.
+				mvalid := newMsg.Valid()
+				if !mvalid.IsExploding() || mvalid.HideExplosion(time.Now()) {
+					t.Debug(ctx, "skipping: %d because not valid full", msg.GetMessageID())
 					continue
 				}
 			}

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -185,7 +185,7 @@ func (t *basicSupersedesTransform) Run(ctx context.Context,
 				// deleted by a delete-history, retention expunge, or was an
 				// exploding message.
 				mvalid := newMsg.Valid()
-				if !mvalid.IsExploding() || mvalid.HideExplosion(time.Now()) {
+				if !mvalid.IsEphemeral() || mvalid.HideExplosion(time.Now()) {
 					t.Debug(ctx, "skipping: %d because not valid full", msg.GetMessageID())
 					continue
 				}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -962,16 +962,13 @@ func PresentMessageUnboxed(ctx context.Context, g *globals.Context, rawMsg chat1
 	}
 	switch state {
 	case chat1.MessageUnboxedState_VALID:
-		var valid chat1.MessageUnboxedValid
+		valid := rawMsg.Valid()
 		if !rawMsg.IsValidFull() {
 			showErr := true
-			if rawMsg.IsValid() {
-				valid = rawMsg.Valid()
-				// If we have an expired ephemeral message, don't show an error
-				// message.
-				if valid.IsExploding() && valid.IsEphemeralExpired(time.Now()) {
-					showErr = false
-				}
+			// If we have an expired ephemeral message, don't show an error
+			// message.
+			if valid.IsExploding() && valid.IsEphemeralExpired(time.Now()) {
+				showErr = false
 			}
 			if showErr {
 				return miscErr(fmt.Errorf("unexpected deleted %v message",
@@ -979,7 +976,6 @@ func PresentMessageUnboxed(ctx context.Context, g *globals.Context, rawMsg chat1
 			}
 		}
 		var strOutboxID *string
-		valid = rawMsg.Valid()
 		if valid.ClientHeader.OutboxID != nil {
 			so := valid.ClientHeader.OutboxID.String()
 			strOutboxID = &so

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -474,7 +474,7 @@ func FilterExploded(msgs []chat1.MessageUnboxed) (res []chat1.MessageUnboxed) {
 	for _, msg := range msgs {
 		if msg.IsValid() {
 			mvalid := msg.Valid()
-			if mvalid.IsExploding() && mvalid.HideExplosion(now) {
+			if mvalid.IsEphemeral() && mvalid.HideExplosion(now) {
 				continue
 			}
 		}
@@ -967,7 +967,7 @@ func PresentMessageUnboxed(ctx context.Context, g *globals.Context, rawMsg chat1
 			showErr := true
 			// If we have an expired ephemeral message, don't show an error
 			// message.
-			if valid.IsExploding() && valid.IsEphemeralExpired(time.Now()) {
+			if valid.IsEphemeral() && valid.IsEphemeralExpired(time.Now()) {
 				showErr = false
 			}
 			if showErr {
@@ -983,8 +983,6 @@ func PresentMessageUnboxed(ctx context.Context, g *globals.Context, rawMsg chat1
 		res = chat1.NewUIMessageWithValid(chat1.UIMessageValid{
 			MessageID:             rawMsg.GetMessageID(),
 			Ctime:                 valid.ServerHeader.Ctime,
-			Now:                   valid.ServerHeader.Now,
-			Rtime:                 valid.ClientHeader.Rtime,
 			OutboxID:              strOutboxID,
 			MessageBody:           valid.MessageBody,
 			SenderUsername:        valid.SenderUsername,
@@ -996,7 +994,9 @@ func PresentMessageUnboxed(ctx context.Context, g *globals.Context, rawMsg chat1
 			ChannelMention:        valid.ChannelMention,
 			ChannelNameMentions:   presentChannelNameMentions(ctx, valid.ChannelNameMentions),
 			AssetUrlInfo:          presentAttachmentAssetInfo(ctx, g, rawMsg, convID),
-			EphemeralMetadata:     valid.EphemeralMetadata(),
+			IsEphemeral:           valid.IsEphemeral(),
+			IsEphemeralExpired:    valid.IsEphemeralExpired(time.Now()),
+			Etime:                 valid.Etime(),
 		})
 	case chat1.MessageUnboxedState_OUTBOX:
 		var body string

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -539,7 +539,7 @@ func newMessageViewValid(g *libkb.GlobalContext, conversationID chat1.Conversati
 	mv.AuthorAndTimeWithDeviceName = fmt.Sprintf("%s%s <%s> %s",
 		m.SenderUsername, possiblyRevokedMark, m.SenderDeviceName, shortDurationFromNow(t))
 
-	if m.IsExploding() {
+	if m.IsEphemeral() {
 		remainingLifetime := m.RemainingLifetime()
 		if remainingLifetime <= 0 {
 			mv.Body = "[exploded]"

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -391,6 +391,8 @@ func (o UIAssetUrlInfo) DeepCopy() UIAssetUrlInfo {
 type UIMessageValid struct {
 	MessageID             MessageID              `codec:"messageID" json:"messageID"`
 	Ctime                 gregor1.Time           `codec:"ctime" json:"ctime"`
+	Now                   gregor1.Time           `codec:"now" json:"now"`
+	Rtime                 gregor1.Time           `codec:"rtime" json:"rtime"`
 	OutboxID              *string                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	MessageBody           MessageBody            `codec:"messageBody" json:"messageBody"`
 	SenderUsername        string                 `codec:"senderUsername" json:"senderUsername"`
@@ -409,6 +411,8 @@ func (o UIMessageValid) DeepCopy() UIMessageValid {
 	return UIMessageValid{
 		MessageID: o.MessageID.DeepCopy(),
 		Ctime:     o.Ctime.DeepCopy(),
+		Now:       o.Now.DeepCopy(),
+		Rtime:     o.Rtime.DeepCopy(),
 		OutboxID: (func(x *string) *string {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -391,8 +391,6 @@ func (o UIAssetUrlInfo) DeepCopy() UIAssetUrlInfo {
 type UIMessageValid struct {
 	MessageID             MessageID              `codec:"messageID" json:"messageID"`
 	Ctime                 gregor1.Time           `codec:"ctime" json:"ctime"`
-	Now                   gregor1.Time           `codec:"now" json:"now"`
-	Rtime                 gregor1.Time           `codec:"rtime" json:"rtime"`
 	OutboxID              *string                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	MessageBody           MessageBody            `codec:"messageBody" json:"messageBody"`
 	SenderUsername        string                 `codec:"senderUsername" json:"senderUsername"`
@@ -404,15 +402,15 @@ type UIMessageValid struct {
 	AtMentions            []string               `codec:"atMentions" json:"atMentions"`
 	ChannelMention        ChannelMention         `codec:"channelMention" json:"channelMention"`
 	ChannelNameMentions   []UIChannelNameMention `codec:"channelNameMentions" json:"channelNameMentions"`
-	EphemeralMetadata     *MsgEphemeralMetadata  `codec:"ephemeralMetadata,omitempty" json:"ephemeralMetadata,omitempty"`
+	IsEphemeral           bool                   `codec:"ie" json:"ie"`
+	IsEphemeralExpired    bool                   `codec:"iex" json:"iex"`
+	Etime                 gregor1.Time           `codec:"e" json:"e"`
 }
 
 func (o UIMessageValid) DeepCopy() UIMessageValid {
 	return UIMessageValid{
 		MessageID: o.MessageID.DeepCopy(),
 		Ctime:     o.Ctime.DeepCopy(),
-		Now:       o.Now.DeepCopy(),
-		Rtime:     o.Rtime.DeepCopy(),
 		OutboxID: (func(x *string) *string {
 			if x == nil {
 				return nil
@@ -462,13 +460,9 @@ func (o UIMessageValid) DeepCopy() UIMessageValid {
 			}
 			return ret
 		})(o.ChannelNameMentions),
-		EphemeralMetadata: (func(x *MsgEphemeralMetadata) *MsgEphemeralMetadata {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.EphemeralMetadata),
+		IsEphemeral:        o.IsEphemeral,
+		IsEphemeralExpired: o.IsEphemeralExpired,
+		Etime:              o.Etime.DeepCopy(),
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2256,11 +2256,14 @@ func (e MessageUnboxedErrorType) String() string {
 }
 
 type MessageUnboxedError struct {
-	ErrType     MessageUnboxedErrorType `codec:"errType" json:"errType"`
-	ErrMsg      string                  `codec:"errMsg" json:"errMsg"`
-	MessageID   MessageID               `codec:"messageID" json:"messageID"`
-	MessageType MessageType             `codec:"messageType" json:"messageType"`
-	Ctime       gregor1.Time            `codec:"ctime" json:"ctime"`
+	ErrType           MessageUnboxedErrorType `codec:"errType" json:"errType"`
+	ErrMsg            string                  `codec:"errMsg" json:"errMsg"`
+	MessageID         MessageID               `codec:"messageID" json:"messageID"`
+	MessageType       MessageType             `codec:"messageType" json:"messageType"`
+	Ctime             gregor1.Time            `codec:"ctime" json:"ctime"`
+	Rtime             gregor1.Time            `codec:"rtime" json:"rtime"`
+	Now               gregor1.Time            `codec:"now" json:"now"`
+	EphemeralMetadata *MsgEphemeralMetadata   `codec:"em,omitempty" json:"em,omitempty"`
 }
 
 func (o MessageUnboxedError) DeepCopy() MessageUnboxedError {
@@ -2270,6 +2273,15 @@ func (o MessageUnboxedError) DeepCopy() MessageUnboxedError {
 		MessageID:   o.MessageID.DeepCopy(),
 		MessageType: o.MessageType.DeepCopy(),
 		Ctime:       o.Ctime.DeepCopy(),
+		Rtime:       o.Rtime.DeepCopy(),
+		Now:         o.Now.DeepCopy(),
+		EphemeralMetadata: (func(x *MsgEphemeralMetadata) *MsgEphemeralMetadata {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.EphemeralMetadata),
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2230,6 +2230,7 @@ const (
 	MessageUnboxedErrorType_BADVERSION_CRITICAL MessageUnboxedErrorType = 1
 	MessageUnboxedErrorType_BADVERSION          MessageUnboxedErrorType = 2
 	MessageUnboxedErrorType_IDENTIFY            MessageUnboxedErrorType = 3
+	MessageUnboxedErrorType_EPHEMERAL           MessageUnboxedErrorType = 4
 )
 
 func (o MessageUnboxedErrorType) DeepCopy() MessageUnboxedErrorType { return o }
@@ -2239,6 +2240,7 @@ var MessageUnboxedErrorTypeMap = map[string]MessageUnboxedErrorType{
 	"BADVERSION_CRITICAL": 1,
 	"BADVERSION":          2,
 	"IDENTIFY":            3,
+	"EPHEMERAL":           4,
 }
 
 var MessageUnboxedErrorTypeRevMap = map[MessageUnboxedErrorType]string{
@@ -2246,6 +2248,7 @@ var MessageUnboxedErrorTypeRevMap = map[MessageUnboxedErrorType]string{
 	1: "BADVERSION_CRITICAL",
 	2: "BADVERSION",
 	3: "IDENTIFY",
+	4: "EPHEMERAL",
 }
 
 func (e MessageUnboxedErrorType) String() string {
@@ -2256,32 +2259,26 @@ func (e MessageUnboxedErrorType) String() string {
 }
 
 type MessageUnboxedError struct {
-	ErrType           MessageUnboxedErrorType `codec:"errType" json:"errType"`
-	ErrMsg            string                  `codec:"errMsg" json:"errMsg"`
-	MessageID         MessageID               `codec:"messageID" json:"messageID"`
-	MessageType       MessageType             `codec:"messageType" json:"messageType"`
-	Ctime             gregor1.Time            `codec:"ctime" json:"ctime"`
-	Rtime             gregor1.Time            `codec:"rtime" json:"rtime"`
-	Now               gregor1.Time            `codec:"now" json:"now"`
-	EphemeralMetadata *MsgEphemeralMetadata   `codec:"em,omitempty" json:"em,omitempty"`
+	ErrType            MessageUnboxedErrorType `codec:"errType" json:"errType"`
+	ErrMsg             string                  `codec:"errMsg" json:"errMsg"`
+	MessageID          MessageID               `codec:"messageID" json:"messageID"`
+	MessageType        MessageType             `codec:"messageType" json:"messageType"`
+	Ctime              gregor1.Time            `codec:"ctime" json:"ctime"`
+	IsEphemeral        bool                    `codec:"ie" json:"ie"`
+	IsEphemeralExpired bool                    `codec:"iex" json:"iex"`
+	Etime              gregor1.Time            `codec:"e" json:"e"`
 }
 
 func (o MessageUnboxedError) DeepCopy() MessageUnboxedError {
 	return MessageUnboxedError{
-		ErrType:     o.ErrType.DeepCopy(),
-		ErrMsg:      o.ErrMsg,
-		MessageID:   o.MessageID.DeepCopy(),
-		MessageType: o.MessageType.DeepCopy(),
-		Ctime:       o.Ctime.DeepCopy(),
-		Rtime:       o.Rtime.DeepCopy(),
-		Now:         o.Now.DeepCopy(),
-		EphemeralMetadata: (func(x *MsgEphemeralMetadata) *MsgEphemeralMetadata {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.EphemeralMetadata),
+		ErrType:            o.ErrType.DeepCopy(),
+		ErrMsg:             o.ErrMsg,
+		MessageID:          o.MessageID.DeepCopy(),
+		MessageType:        o.MessageType.DeepCopy(),
+		Ctime:              o.Ctime.DeepCopy(),
+		IsEphemeral:        o.IsEphemeral,
+		IsEphemeralExpired: o.IsEphemeralExpired,
+		Etime:              o.Etime.DeepCopy(),
 	}
 }
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -104,6 +104,8 @@ protocol chatUi {
   record UIMessageValid {
     MessageID messageID;
     gregor1.Time ctime;
+    gregor1.Time now;
+    gregor1.Time rtime;
     union { null, string } outboxID;
     MessageBody messageBody;
     string senderUsername;

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -104,8 +104,6 @@ protocol chatUi {
   record UIMessageValid {
     MessageID messageID;
     gregor1.Time ctime;
-    gregor1.Time now;
-    gregor1.Time rtime;
     union { null, string } outboxID;
     MessageBody messageBody;
     string senderUsername;
@@ -117,7 +115,12 @@ protocol chatUi {
     array<string> atMentions;
     ChannelMention channelMention;
     array<UIChannelNameMention> channelNameMentions;
-    union { null, MsgEphemeralMetadata } ephemeralMetadata;
+    @mpackkey("ie") @jsonkey("ie")
+    boolean isEphemeral;
+    @mpackkey("iex") @jsonkey("iex")
+    boolean isEphemeralExpired;
+    @mpackkey("e") @jsonkey("e")
+    gregor1.Time etime;
   }
 
   record UIMessageOutbox {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -378,6 +378,10 @@ protocol local {
     MessageID messageID;
     MessageType messageType;
     gregor1.Time ctime;
+    gregor1.Time rtime;
+    gregor1.Time now;
+    @mpackkey("em") @jsonkey("em")
+    union { null, MsgEphemeralMetadata } ephemeralMetadata;
   }
 
   record MessageUnboxedPlaceholder {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -369,7 +369,8 @@ protocol local {
     MISC_0,
     BADVERSION_CRITICAL_1,
     BADVERSION_2,
-    IDENTIFY_3
+    IDENTIFY_3,
+    EPHEMERAL_4
   }
 
   record MessageUnboxedError {
@@ -378,10 +379,12 @@ protocol local {
     MessageID messageID;
     MessageType messageType;
     gregor1.Time ctime;
-    gregor1.Time rtime;
-    gregor1.Time now;
-    @mpackkey("em") @jsonkey("em")
-    union { null, MsgEphemeralMetadata } ephemeralMetadata;
+    @mpackkey("ie") @jsonkey("ie")
+    boolean isEphemeral;
+    @mpackkey("iex") @jsonkey("iex")
+    boolean isEphemeralExpired;
+    @mpackkey("e") @jsonkey("e")
+    gregor1.Time etime;
   }
 
   record MessageUnboxedPlaceholder {

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -1065,7 +1065,7 @@ export type MessageType =
 
 export type MessageUnboxed = {state: 1, valid: ?MessageUnboxedValid} | {state: 2, error: ?MessageUnboxedError} | {state: 3, outbox: ?OutboxRecord} | {state: 4, placeholder: ?MessageUnboxedPlaceholder}
 
-export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time}>
+export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time, rtime: Gregor1.Time, now: Gregor1.Time, ephemeralMetadata?: ?MsgEphemeralMetadata}>
 
 export type MessageUnboxedErrorType =
   | 0 // MISC_0
@@ -1360,7 +1360,7 @@ export type UIMessage = {state: 1, valid: ?UIMessageValid} | {state: 2, error: ?
 
 export type UIMessageOutbox = $ReadOnly<{state: OutboxState, outboxID: String, messageType: MessageType, body: String, ctime: Gregor1.Time, ordinal: Double}>
 
-export type UIMessageValid = $ReadOnly<{messageID: MessageID, ctime: Gregor1.Time, outboxID?: ?String, messageBody: MessageBody, senderUsername: String, senderDeviceName: String, senderDeviceType: String, superseded: Boolean, assetUrlInfo?: ?UIAssetUrlInfo, senderDeviceRevokedAt?: ?Gregor1.Time, atMentions?: ?Array<String>, channelMention: ChannelMention, channelNameMentions?: ?Array<UIChannelNameMention>, ephemeralMetadata?: ?MsgEphemeralMetadata}>
+export type UIMessageValid = $ReadOnly<{messageID: MessageID, ctime: Gregor1.Time, now: Gregor1.Time, rtime: Gregor1.Time, outboxID?: ?String, messageBody: MessageBody, senderUsername: String, senderDeviceName: String, senderDeviceType: String, superseded: Boolean, assetUrlInfo?: ?UIAssetUrlInfo, senderDeviceRevokedAt?: ?Gregor1.Time, atMentions?: ?Array<String>, channelMention: ChannelMention, channelNameMentions?: ?Array<UIChannelNameMention>, ephemeralMetadata?: ?MsgEphemeralMetadata}>
 
 export type UIMessages = $ReadOnly<{messages?: ?Array<UIMessage>, pagination?: ?UIPagination}>
 

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -268,6 +268,7 @@ export const localMessageUnboxedErrorType = {
   badversionCritical: 1,
   badversion: 2,
   identify: 3,
+  ephemeral: 4,
 }
 
 export const localNewConversationLocalRpcChannelMap = (configKeys: Array<string>, request: LocalNewConversationLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.newConversationLocal', request)
@@ -1065,13 +1066,14 @@ export type MessageType =
 
 export type MessageUnboxed = {state: 1, valid: ?MessageUnboxedValid} | {state: 2, error: ?MessageUnboxedError} | {state: 3, outbox: ?OutboxRecord} | {state: 4, placeholder: ?MessageUnboxedPlaceholder}
 
-export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time, rtime: Gregor1.Time, now: Gregor1.Time, ephemeralMetadata?: ?MsgEphemeralMetadata}>
+export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time, isEphemeral: Boolean, isEphemeralExpired: Boolean, etime: Gregor1.Time}>
 
 export type MessageUnboxedErrorType =
   | 0 // MISC_0
   | 1 // BADVERSION_CRITICAL_1
   | 2 // BADVERSION_2
   | 3 // IDENTIFY_3
+  | 4 // EPHEMERAL_4
 
 export type MessageUnboxedPlaceholder = $ReadOnly<{messageID: MessageID, hidden: Boolean}>
 
@@ -1360,7 +1362,7 @@ export type UIMessage = {state: 1, valid: ?UIMessageValid} | {state: 2, error: ?
 
 export type UIMessageOutbox = $ReadOnly<{state: OutboxState, outboxID: String, messageType: MessageType, body: String, ctime: Gregor1.Time, ordinal: Double}>
 
-export type UIMessageValid = $ReadOnly<{messageID: MessageID, ctime: Gregor1.Time, now: Gregor1.Time, rtime: Gregor1.Time, outboxID?: ?String, messageBody: MessageBody, senderUsername: String, senderDeviceName: String, senderDeviceType: String, superseded: Boolean, assetUrlInfo?: ?UIAssetUrlInfo, senderDeviceRevokedAt?: ?Gregor1.Time, atMentions?: ?Array<String>, channelMention: ChannelMention, channelNameMentions?: ?Array<UIChannelNameMention>, ephemeralMetadata?: ?MsgEphemeralMetadata}>
+export type UIMessageValid = $ReadOnly<{messageID: MessageID, ctime: Gregor1.Time, outboxID?: ?String, messageBody: MessageBody, senderUsername: String, senderDeviceName: String, senderDeviceType: String, superseded: Boolean, assetUrlInfo?: ?UIAssetUrlInfo, senderDeviceRevokedAt?: ?Gregor1.Time, atMentions?: ?Array<String>, channelMention: ChannelMention, channelNameMentions?: ?Array<UIChannelNameMention>, isEphemeral: Boolean, isEphemeralExpired: Boolean, etime: Gregor1.Time}>
 
 export type UIMessages = $ReadOnly<{messages?: ?Array<UIMessage>, pagination?: ?UIPagination}>
 

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -407,6 +407,14 @@
           "name": "ctime"
         },
         {
+          "type": "gregor1.Time",
+          "name": "now"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "rtime"
+        },
+        {
           "type": [
             null,
             "string"

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -407,14 +407,6 @@
           "name": "ctime"
         },
         {
-          "type": "gregor1.Time",
-          "name": "now"
-        },
-        {
-          "type": "gregor1.Time",
-          "name": "rtime"
-        },
-        {
           "type": [
             null,
             "string"
@@ -474,11 +466,22 @@
           "name": "channelNameMentions"
         },
         {
-          "type": [
-            null,
-            "MsgEphemeralMetadata"
-          ],
-          "name": "ephemeralMetadata"
+          "type": "boolean",
+          "name": "isEphemeral",
+          "mpackkey": "ie",
+          "jsonkey": "ie"
+        },
+        {
+          "type": "boolean",
+          "name": "isEphemeralExpired",
+          "mpackkey": "iex",
+          "jsonkey": "iex"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "etime",
+          "mpackkey": "e",
+          "jsonkey": "e"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1136,6 +1136,23 @@
         {
           "type": "gregor1.Time",
           "name": "ctime"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "rtime"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "now"
+        },
+        {
+          "type": [
+            null,
+            "MsgEphemeralMetadata"
+          ],
+          "name": "ephemeralMetadata",
+          "mpackkey": "em",
+          "jsonkey": "em"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1110,7 +1110,8 @@
         "MISC_0",
         "BADVERSION_CRITICAL_1",
         "BADVERSION_2",
-        "IDENTIFY_3"
+        "IDENTIFY_3",
+        "EPHEMERAL_4"
       ]
     },
     {
@@ -1138,21 +1139,22 @@
           "name": "ctime"
         },
         {
-          "type": "gregor1.Time",
-          "name": "rtime"
+          "type": "boolean",
+          "name": "isEphemeral",
+          "mpackkey": "ie",
+          "jsonkey": "ie"
+        },
+        {
+          "type": "boolean",
+          "name": "isEphemeralExpired",
+          "mpackkey": "iex",
+          "jsonkey": "iex"
         },
         {
           "type": "gregor1.Time",
-          "name": "now"
-        },
-        {
-          "type": [
-            null,
-            "MsgEphemeralMetadata"
-          ],
-          "name": "ephemeralMetadata",
-          "mpackkey": "em",
-          "jsonkey": "em"
+          "name": "etime",
+          "mpackkey": "e",
+          "jsonkey": "e"
         }
       ]
     },

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -1065,7 +1065,7 @@ export type MessageType =
 
 export type MessageUnboxed = {state: 1, valid: ?MessageUnboxedValid} | {state: 2, error: ?MessageUnboxedError} | {state: 3, outbox: ?OutboxRecord} | {state: 4, placeholder: ?MessageUnboxedPlaceholder}
 
-export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time}>
+export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time, rtime: Gregor1.Time, now: Gregor1.Time, ephemeralMetadata?: ?MsgEphemeralMetadata}>
 
 export type MessageUnboxedErrorType =
   | 0 // MISC_0
@@ -1360,7 +1360,7 @@ export type UIMessage = {state: 1, valid: ?UIMessageValid} | {state: 2, error: ?
 
 export type UIMessageOutbox = $ReadOnly<{state: OutboxState, outboxID: String, messageType: MessageType, body: String, ctime: Gregor1.Time, ordinal: Double}>
 
-export type UIMessageValid = $ReadOnly<{messageID: MessageID, ctime: Gregor1.Time, outboxID?: ?String, messageBody: MessageBody, senderUsername: String, senderDeviceName: String, senderDeviceType: String, superseded: Boolean, assetUrlInfo?: ?UIAssetUrlInfo, senderDeviceRevokedAt?: ?Gregor1.Time, atMentions?: ?Array<String>, channelMention: ChannelMention, channelNameMentions?: ?Array<UIChannelNameMention>, ephemeralMetadata?: ?MsgEphemeralMetadata}>
+export type UIMessageValid = $ReadOnly<{messageID: MessageID, ctime: Gregor1.Time, now: Gregor1.Time, rtime: Gregor1.Time, outboxID?: ?String, messageBody: MessageBody, senderUsername: String, senderDeviceName: String, senderDeviceType: String, superseded: Boolean, assetUrlInfo?: ?UIAssetUrlInfo, senderDeviceRevokedAt?: ?Gregor1.Time, atMentions?: ?Array<String>, channelMention: ChannelMention, channelNameMentions?: ?Array<UIChannelNameMention>, ephemeralMetadata?: ?MsgEphemeralMetadata}>
 
 export type UIMessages = $ReadOnly<{messages?: ?Array<UIMessage>, pagination?: ?UIPagination}>
 

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -268,6 +268,7 @@ export const localMessageUnboxedErrorType = {
   badversionCritical: 1,
   badversion: 2,
   identify: 3,
+  ephemeral: 4,
 }
 
 export const localNewConversationLocalRpcChannelMap = (configKeys: Array<string>, request: LocalNewConversationLocalRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'chat.1.local.newConversationLocal', request)
@@ -1065,13 +1066,14 @@ export type MessageType =
 
 export type MessageUnboxed = {state: 1, valid: ?MessageUnboxedValid} | {state: 2, error: ?MessageUnboxedError} | {state: 3, outbox: ?OutboxRecord} | {state: 4, placeholder: ?MessageUnboxedPlaceholder}
 
-export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time, rtime: Gregor1.Time, now: Gregor1.Time, ephemeralMetadata?: ?MsgEphemeralMetadata}>
+export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time, isEphemeral: Boolean, isEphemeralExpired: Boolean, etime: Gregor1.Time}>
 
 export type MessageUnboxedErrorType =
   | 0 // MISC_0
   | 1 // BADVERSION_CRITICAL_1
   | 2 // BADVERSION_2
   | 3 // IDENTIFY_3
+  | 4 // EPHEMERAL_4
 
 export type MessageUnboxedPlaceholder = $ReadOnly<{messageID: MessageID, hidden: Boolean}>
 
@@ -1360,7 +1362,7 @@ export type UIMessage = {state: 1, valid: ?UIMessageValid} | {state: 2, error: ?
 
 export type UIMessageOutbox = $ReadOnly<{state: OutboxState, outboxID: String, messageType: MessageType, body: String, ctime: Gregor1.Time, ordinal: Double}>
 
-export type UIMessageValid = $ReadOnly<{messageID: MessageID, ctime: Gregor1.Time, now: Gregor1.Time, rtime: Gregor1.Time, outboxID?: ?String, messageBody: MessageBody, senderUsername: String, senderDeviceName: String, senderDeviceType: String, superseded: Boolean, assetUrlInfo?: ?UIAssetUrlInfo, senderDeviceRevokedAt?: ?Gregor1.Time, atMentions?: ?Array<String>, channelMention: ChannelMention, channelNameMentions?: ?Array<UIChannelNameMention>, ephemeralMetadata?: ?MsgEphemeralMetadata}>
+export type UIMessageValid = $ReadOnly<{messageID: MessageID, ctime: Gregor1.Time, outboxID?: ?String, messageBody: MessageBody, senderUsername: String, senderDeviceName: String, senderDeviceType: String, superseded: Boolean, assetUrlInfo?: ?UIAssetUrlInfo, senderDeviceRevokedAt?: ?Gregor1.Time, atMentions?: ?Array<String>, channelMention: ChannelMention, channelNameMentions?: ?Array<UIChannelNameMention>, isEphemeral: Boolean, isEphemeralExpired: Boolean, etime: Gregor1.Time}>
 
 export type UIMessages = $ReadOnly<{messages?: ?Array<UIMessage>, pagination?: ?UIPagination}>
 


### PR DESCRIPTION
Fixes:

1. If a device isn't boxed for a message it can show a better error message (we may want to customize further) and display ash lines once the message is deleted since some ephemeral state is copied to the`UIMessage` type (cc @buoyad)

2. If an ephemeral message is expired we no longer show "unexpected deleted text message" since it's expected. ie: 

<img width="600" alt="screen shot 2018-05-07 at 11 43 44 am" src="https://user-images.githubusercontent.com/1144020/39711556-0ea3a614-51ee-11e8-8611-d5bf6cfbba15.png">
no longer appears

cc @oconnor663