### PR TITLE
run background fetch on iOS CORE-7443

### DIFF
--- a/go/chat/push_test.go
+++ b/go/chat/push_test.go
@@ -158,23 +158,10 @@ func TestPushAppState(t *testing.T) {
 		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 1 })
 	select {
 	case <-list.incoming:
-		require.Fail(t, "not message should be sent")
-	default:
-	}
-
-	select {
-	case <-handler.orderer.WaitForTurn(context.TODO(), uid, 2):
 	case <-time.After(20 * time.Second):
-		require.Fail(t, "turn never happened")
+		require.Fail(t, "no message received")
 	}
-
 	tc.G.AppState.Update(keybase1.AppState_FOREGROUND)
-	select {
-	case <-list.threadsStale:
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no stale message")
-	}
-
 	sendSimple(ctx, t, tc, handler, sender, conv, u,
 		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 1 })
 	select {

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -71,7 +71,7 @@ const BOOL isDebug = NO;
 #endif
 
   BOOL securityAccessGroupOverride = isSimulator;
-  BOOL skipLogFile = true;
+  BOOL skipLogFile = false;
 
   NSString * home = NSHomeDirectory();
 

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -71,7 +71,7 @@ const BOOL isDebug = NO;
 #endif
 
   BOOL securityAccessGroupOverride = isSimulator;
-  BOOL skipLogFile = false;
+  BOOL skipLogFile = true;
 
   NSString * home = NSHomeDirectory();
 
@@ -158,8 +158,22 @@ const BOOL isDebug = NO;
   self.resignImageView.backgroundColor = [UIColor whiteColor];
   [self.resignImageView setImage:[UIImage imageNamed:@"LaunchImage"]];
   [self.window addSubview:self.resignImageView];
+  
+  [[UIApplication sharedApplication]
+   setMinimumBackgroundFetchInterval:
+   UIApplicationBackgroundFetchIntervalMinimum];
 
   return YES;
+}
+
+-(void) application:(UIApplication *)application performFetchWithCompletionHandler:
+(void (^)(UIBackgroundFetchResult))completionHandler {
+  NSLog(@"Background fetch started...");
+  dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+    KeybaseBackgroundSync();
+    completionHandler(UIBackgroundFetchResultNewData);
+    NSLog(@"Background fetch completed...");
+  });
 }
 
 // Required to register for notifications

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -169,7 +169,7 @@ const BOOL isDebug = NO;
 -(void) application:(UIApplication *)application performFetchWithCompletionHandler:
 (void (^)(UIBackgroundFetchResult))completionHandler {
   NSLog(@"Background fetch started...");
-  dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
     KeybaseBackgroundSync();
     completionHandler(UIBackgroundFetchResultNewData);
     NSLog(@"Background fetch completed...");

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -37,10 +37,10 @@
 	<string>Inviting contacts to Keybase</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Attaching images to chat messages</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Saving images from chat messages</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Attaching images to chat messages</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>OpenSans_bold.ttf</string>
@@ -55,6 +55,7 @@
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
**Go**

1.) Add a new mobile endpoint `BackgroundSync`, which puts the app into state `BACKGROUNDACTIVE` and waits for 10 seconds before putting the app back into `BACKGROUND` mode and exiting.
2.) Start up `BackgroundConvLoader` on `BACKGROUNDACTIVE` state update so we can get threads loaded on wakeup.
3.) Remove restriction on sending chat notifications if we aren't in the foreground, my testing shows this doesn't really matter. 
cc @oconnor663 @joshblum since I think this will probably be enough to do the EK stuff. 

**Native**
@keybase/react-hackers 
1.) Enable background fetch mode for the app, and request to be woken up as often as possible.
2.) On wakeup, dispatch a call to `BackgroundSync`.