### PR TITLE
Fix attachment send

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1453,7 +1453,10 @@ function* downloadAttachment(fileName: string, conversationIDKey: any, message: 
 
 // Download an attachment to your device
 function* attachmentDownload(action: Chat2Gen.AttachmentDownloadPayload) {
-  const {conversationIDKey, ordinal} = action.payload
+  const {conversationIDKey, forShare, ordinal} = action.payload
+  if (forShare) {
+    return
+  }
   const state: TypedState = yield Saga.select()
   let message = Constants.getMessageMap(state, conversationIDKey).get(ordinal)
 

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1458,6 +1458,7 @@ function* attachmentDownload(action: Chat2Gen.AttachmentDownloadPayload) {
     // We are sharing an attachment on mobile,
     // the reducer handles setting the appropriate
     // flags in this case
+    // TODO DESKTOP-6562 refactor this logic
     return
   }
   const state: TypedState = yield Saga.select()

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1455,6 +1455,9 @@ function* downloadAttachment(fileName: string, conversationIDKey: any, message: 
 function* attachmentDownload(action: Chat2Gen.AttachmentDownloadPayload) {
   const {conversationIDKey, forShare, ordinal} = action.payload
   if (forShare) {
+    // We are sharing an attachment on mobile,
+    // the reducer handles setting the appropriate
+    // flags in this case
     return
   }
   const state: TypedState = yield Saga.select()

--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -610,6 +610,13 @@ export const upgradeMessage = (old: Types.Message, m: Types.Message) => {
     })
   }
   if (old.type === 'attachment' && m.type === 'attachment') {
+    if (old.submitState === 'pending') {
+      // we sent an attachment, service replied
+      // with the real message. replace our placeholder but
+      // only hold on to the ordinal so it doesn't
+      // jump in the conversation view
+      return m.set('ordinal', old.ordinal)
+    }
     // $ForceType
     return m.withMutations((ret: Types.MessageAttachment) => {
       // We got an attachment-uploaded message. Hold on to the old ID


### PR DESCRIPTION
Gets rid of our placeholder message when the service replies with the real one. r? @keybase/react-hackers 