### PR TITLE
better printing of error details

### DIFF
--- a/shared/logger/action-transformer.js
+++ b/shared/logger/action-transformer.js
@@ -74,10 +74,10 @@ const actionTransformMap: {[key: string]: ActionTransformer<*, *>} = {
   [Chat2Gen.metaUpdatePagination]: fullOutput,
   [Chat2Gen.setConversationOffline]: fullOutput,
   [ConfigGen.globalError]: a => {
-    let err
+    let err = {}
     const ge = a.payload.globalError
     if (ge) {
-      err = `Global Error: ${ge.message} ${ge.stack || ''}`
+      err = {err: `Global Error: ${ge.message} ${ge.stack || ''}`}
     }
 
     return {

--- a/shared/logger/action-transformer.js
+++ b/shared/logger/action-transformer.js
@@ -73,7 +73,18 @@ const actionTransformMap: {[key: string]: ActionTransformer<*, *>} = {
   [Chat2Gen.metaNeedsUpdating]: fullOutput,
   [Chat2Gen.metaUpdatePagination]: fullOutput,
   [Chat2Gen.setConversationOffline]: fullOutput,
-  [ConfigGen.globalError]: fullOutput,
+  [ConfigGen.globalError]: a => {
+    let err
+    const ge = a.payload.globalError
+    if (ge) {
+      err = `Global Error: ${ge.message} ${ge.stack || ''}`
+    }
+
+    return {
+      payload: err,
+      type: a.type,
+    }
+  },
   [Chat2Gen.setPendingSelected]: fullOutput,
   [Chat2Gen.setPendingMode]: fullOutput,
   [Chat2Gen.setPendingConversationUsers]: fullOutput,


### PR DESCRIPTION
@keybase/react-hackers the old flow sent error down the error.toString() route which just prints the message but not the stack