### PR TITLE
dont use a background task and bypass JS for iOS plaintext notifications CORE-7494

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -357,7 +357,7 @@ func HandleBackgroundNotification(strConvID string, intMembersType int, intMessa
 		return err
 	}
 
-	// Send up the local notification with out message
+	// Send up the local notification with our message
 	id := fmt.Sprintf("%s:%d", strConvID, intMessageID)
 	pusher.LocalNotification(id, msg, badgeCount, "keybasemessage.wav", strConvID, "chat.newmessage")
 	// Hit the remote server to let it know we succeeded in showing something useful

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -312,6 +312,14 @@ func BackgroundSync() {
 	<-doneCh
 }
 
+func HandleBackgroundNotification(strConvID string, intMembersType int, intMessageID int,
+	strPushID string, badgeCount int, unixTime int, body string) (res string, err error) {
+	defer kbCtx.Trace(fmt.Sprintf("HandleBackgroundNotification(%s,%d,%d,%s,%d,%d)",
+		strConvID, intMembersType, intMessageID, strPushID, badgeCount, unixTime),
+		func() error { return err })()
+	return "HI MIKE", nil
+}
+
 // AppWillExit is called reliably on iOS when the app is about to terminate
 // not as reliably on android
 func AppWillExit() {

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -332,6 +332,12 @@ func HandleBackgroundNotification(strConvID string, intMembersType int, intMessa
 	if !kbCtx.ActiveDevice.HaveKeys() {
 		return "", libkb.LoginRequiredError{}
 	}
+	age := time.Now().Sub(time.Unix(int64(unixTime), 0))
+	if age >= 15*time.Second {
+		kbCtx.Log.CDebugf(ctx, "HandleBackgroundNotification: stale notification: %v", age)
+		return "", errors.New("stale notification")
+	}
+
 	bConvID, err := hex.DecodeString(strConvID)
 	if err != nil {
 		kbCtx.Log.CDebugf(ctx, "HandleBackgroundNotification: invalid convID: %s msg: %s", strConvID,

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -336,7 +336,7 @@ func HandleBackgroundNotification(strConvID string, intMembersType int, intMessa
 	if !kbCtx.ActiveDevice.HaveKeys() {
 		return libkb.LoginRequiredError{}
 	}
-	age := time.Now().Sub(time.Unix(int64(unixTime), 0))
+	age := time.Since(time.Unix(int64(unixTime), 0))
 	if age >= 15*time.Second {
 		kbCtx.Log.CDebugf(ctx, "HandleBackgroundNotification: stale notification: %v", age)
 		return errors.New("stale notification")

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -13,10 +14,13 @@ import (
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
+	"github.com/keybase/go-codec/codec"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"golang.org/x/net/context"
 )
 
@@ -231,6 +235,144 @@ func (h *Helper) GetMessages(ctx context.Context, uid gregor1.UID, convID chat1.
 		}
 	}
 	return messages, nil
+}
+
+func (h *Helper) sendRemoteNotificationSuccessful(ctx context.Context, pushIDs []string) {
+	// Get session token
+	nist, _, err := h.G().ActiveDevice.NISTAndUID(ctx)
+	if nist == nil {
+		h.Debug(ctx, "sendRemoteNotificationSuccessful: got a nil NIST, is the user logged out?")
+		return
+	}
+	if err != nil {
+		h.Debug(ctx, "sendRemoteNotificationSuccessful: failed to get logged in session: %s", err.Error())
+		return
+	}
+
+	// Make an ad hoc connection to gregor
+	uri, err := rpc.ParseFMPURI(h.G().Env.GetGregorURI())
+	if err != nil {
+		h.Debug(ctx, "sendRemoteNotificationSuccessful: failed to parse chat server UR: %s", err.Error())
+		return
+	}
+
+	var conn *rpc.Connection
+	if uri.UseTLS() {
+		rawCA := h.G().Env.GetBundledCA(uri.Host)
+		if len(rawCA) == 0 {
+			h.Debug(ctx, "sendRemoteNotificationSuccessful: failed to parse CAs: %s", err.Error())
+			return
+		}
+		conn = rpc.NewTLSConnection(rpc.NewFixedRemote(uri.HostPort),
+			[]byte(rawCA), libkb.NewContextifiedErrorUnwrapper(h.G().ExternalG()),
+			&remoteNotificationSuccessHandler{}, libkb.NewRPCLogFactory(h.G().ExternalG()),
+			logger.LogOutputWithDepthAdder{Logger: h.G().Log}, rpc.ConnectionOpts{})
+	} else {
+		t := rpc.NewConnectionTransport(uri, nil, libkb.MakeWrapError(h.G().ExternalG()))
+		conn = rpc.NewConnectionWithTransport(&remoteNotificationSuccessHandler{}, t,
+			libkb.NewContextifiedErrorUnwrapper(h.G().ExternalG()),
+			logger.LogOutputWithDepthAdder{Logger: h.G().Log}, rpc.ConnectionOpts{})
+	}
+	defer conn.Shutdown()
+
+	// Make remote successful call on our ad hoc conn
+	cli := chat1.RemoteClient{Cli: NewRemoteClient(h.G(), conn.GetClient())}
+	if err = cli.RemoteNotificationSuccessful(ctx,
+		chat1.RemoteNotificationSuccessfulArg{
+			AuthToken:        gregor1.SessionToken(nist.Token().String()),
+			CompanionPushIDs: pushIDs,
+		}); err != nil {
+		h.Debug(ctx, "UnboxMobilePushNotification: failed to invoke remote notification success: %",
+			err.Error())
+	}
+}
+
+func (h *Helper) formatPushText(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
+	membersType chat1.ConversationMembersType, msg chat1.MessageUnboxed) string {
+	switch membersType {
+	case chat1.ConversationMembersType_TEAM:
+		// Try to get the channel name
+		ib, _, err := h.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
+			ConvIDs: []chat1.ConversationID{convID},
+		}, nil)
+		if err != nil || len(ib.Convs) == 0 {
+			// Don't give up here, just display the team name only
+			h.Debug(ctx, "formatPushText: failed to unbox convo, using team only")
+			return fmt.Sprintf("%s (%s): %s", msg.Valid().SenderUsername, msg.Valid().ClientHeader.TlfName,
+				msg.Valid().MessageBody.Text().Body)
+		}
+		return fmt.Sprintf("%s (%s#%s): %s", msg.Valid().SenderUsername, msg.Valid().ClientHeader.TlfName,
+			utils.GetTopicName(ib.Convs[0]), msg.Valid().MessageBody.Text().Body)
+	default:
+		return fmt.Sprintf("%s: %s", msg.Valid().SenderUsername, msg.Valid().MessageBody.Text().Body)
+	}
+}
+
+func (h *Helper) UnboxMobilePushNotification(ctx context.Context, uid gregor1.UID,
+	convID chat1.ConversationID, membersType chat1.ConversationMembersType, pushIDs []string, payload string) (res string, err error) {
+	defer func() {
+		if err == nil {
+			// If we have succeeded, let us let the server know that it can abort the push notification
+			// associated with this silent one
+			h.sendRemoteNotificationSuccessful(ctx, pushIDs)
+		}
+	}()
+
+	// Parse the message payload
+	bMsg, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		h.Debug(ctx, "UnboxMobilePushNotification: invalid message payload: %s", err.Error())
+		return res, err
+	}
+	var msgBoxed chat1.MessageBoxed
+	mh := codec.MsgpackHandle{WriteExt: true}
+	if err = codec.NewDecoderBytes(bMsg, &mh).Decode(&msgBoxed); err != nil {
+		h.Debug(ctx, "UnboxMobilePushNotification: failed to msgpack decode payload: %s", err.Error())
+		return res, err
+	}
+
+	// Unbox first
+	vis := keybase1.TLFVisibility_PRIVATE
+	if msgBoxed.ClientHeader.TlfPublic {
+		vis = keybase1.TLFVisibility_PUBLIC
+	}
+	unboxInfo := newBasicUnboxConversationInfo(convID, membersType, nil, vis)
+	msgUnboxed, err := NewBoxer(h.G()).UnboxMessage(ctx, msgBoxed, unboxInfo)
+	if err != nil {
+		h.Debug(ctx, "UnboxMobilePushNotification: unbox failed, bailing: %s", err.Error())
+		return res, err
+	}
+
+	// Check to see if this will be a strict append before adding to the body cache
+	if err := h.G().ConvSource.AcquireConversationLock(ctx, uid, convID); err != nil {
+		return res, err
+	}
+	maxMsgID, err := storage.New(h.G()).GetMaxMsgID(ctx, convID, uid)
+	if err == nil {
+		if msgUnboxed.GetMessageID() > maxMsgID {
+			if _, err = h.G().ConvSource.PushUnboxed(ctx, convID, uid, msgUnboxed); err != nil {
+				h.Debug(ctx, "UnboxMobilePushNotification: failed to push message to conv source: %s",
+					err.Error())
+			}
+		} else {
+			h.Debug(ctx, "UnboxMobilePushNotification: message from the past, skipping insert: msgID: %d maxMsgID: %d", msgUnboxed.GetMessageID(), maxMsgID)
+
+		}
+	} else {
+		h.Debug(ctx, "UnboxMobilePushNotification: failed to fetch max msg ID: %s", err)
+	}
+	h.G().ConvSource.ReleaseConversationLock(ctx, uid, convID)
+
+	// Form the push notification message
+	if msgUnboxed.IsValid() && msgUnboxed.GetMessageType() == chat1.MessageType_TEXT {
+		res = h.formatPushText(ctx, uid, convID, membersType, msgUnboxed)
+		h.Debug(ctx, "UnboxMobilePushNotification: successful unbox")
+		return res, nil
+	}
+
+	h.Debug(ctx, "UnboxMobilePushNotification: invalid message received: typ: %v",
+		msgUnboxed.GetMessageType())
+	return "", errors.New("invalid message")
 }
 
 type sendHelper struct {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2494,8 +2494,12 @@ func (h *Server) UnboxMobilePushNotification(ctx context.Context, arg chat1.Unbo
 		return res, err
 	}
 	convID := chat1.ConversationID(bConvID)
-	return h.G().ChatHelper.UnboxMobilePushNotification(ctx, uid, convID, arg.MembersType, arg.PushIDs,
-		arg.Payload)
+	if res, err = h.G().ChatHelper.UnboxMobilePushNotification(ctx, uid, convID, arg.MembersType, arg.PushIDs,
+		arg.Payload); err != nil {
+		return res, err
+	}
+	h.G().ChatHelper.AckMobileNotificationSuccess(ctx, arg.PushIDs)
+	return res, nil
 }
 
 func (h *Server) SetGlobalAppNotificationSettingsLocal(ctx context.Context,

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -17,10 +17,8 @@ import (
 
 	"github.com/keybase/clockwork"
 
-	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/teams"
 
-	"encoding/base64"
 	"encoding/hex"
 
 	"github.com/keybase/client/go/chat/attachments"
@@ -33,7 +31,6 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
@@ -2482,77 +2479,6 @@ func (g *remoteNotificationSuccessHandler) ShouldRetryOnConnect(err error) bool 
 	return false
 }
 
-func (h *Server) sendRemoteNotificationSuccessful(ctx context.Context, pushIDs []string) {
-	// Get session token
-	nist, _, err := h.G().ActiveDevice.NISTAndUID(ctx)
-	if nist == nil {
-		h.Debug(ctx, "sendRemoteNotificationSuccessful: got a nil NIST, is the user logged out?")
-		return
-	}
-	if err != nil {
-		h.Debug(ctx, "sendRemoteNotificationSuccessful: failed to get logged in session: %s", err.Error())
-		return
-	}
-
-	// Make an ad hoc connection to gregor
-	uri, err := rpc.ParseFMPURI(h.G().Env.GetGregorURI())
-	if err != nil {
-		h.Debug(ctx, "sendRemoteNotificationSuccessful: failed to parse chat server UR: %s", err.Error())
-		return
-	}
-
-	var conn *rpc.Connection
-	if uri.UseTLS() {
-		rawCA := h.G().Env.GetBundledCA(uri.Host)
-		if len(rawCA) == 0 {
-			h.Debug(ctx, "sendRemoteNotificationSuccessful: failed to parse CAs: %s", err.Error())
-			return
-		}
-		conn = rpc.NewTLSConnection(rpc.NewFixedRemote(uri.HostPort),
-			[]byte(rawCA), libkb.NewContextifiedErrorUnwrapper(h.G().ExternalG()),
-			&remoteNotificationSuccessHandler{}, libkb.NewRPCLogFactory(h.G().ExternalG()),
-			logger.LogOutputWithDepthAdder{Logger: h.G().Log}, rpc.ConnectionOpts{})
-	} else {
-		t := rpc.NewConnectionTransport(uri, nil, libkb.MakeWrapError(h.G().ExternalG()))
-		conn = rpc.NewConnectionWithTransport(&remoteNotificationSuccessHandler{}, t,
-			libkb.NewContextifiedErrorUnwrapper(h.G().ExternalG()),
-			logger.LogOutputWithDepthAdder{Logger: h.G().Log}, rpc.ConnectionOpts{})
-	}
-	defer conn.Shutdown()
-
-	// Make remote successful call on our ad hoc conn
-	cli := chat1.RemoteClient{Cli: NewRemoteClient(h.G(), conn.GetClient())}
-	if err = cli.RemoteNotificationSuccessful(ctx,
-		chat1.RemoteNotificationSuccessfulArg{
-			AuthToken:        gregor1.SessionToken(nist.Token().String()),
-			CompanionPushIDs: pushIDs,
-		}); err != nil {
-		h.Debug(ctx, "UnboxMobilePushNotification: failed to invoke remote notification success: %",
-			err.Error())
-	}
-}
-
-func (h *Server) formatPushText(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
-	membersType chat1.ConversationMembersType, msg chat1.MessageUnboxed) string {
-	switch membersType {
-	case chat1.ConversationMembersType_TEAM:
-		// Try to get the channel name
-		ib, _, err := h.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
-			ConvIDs: []chat1.ConversationID{convID},
-		}, nil)
-		if err != nil || len(ib.Convs) == 0 {
-			// Don't give up here, just display the team name only
-			h.Debug(ctx, "formatPushText: failed to unbox convo, using team only")
-			return fmt.Sprintf("%s (%s): %s", msg.Valid().SenderUsername, msg.Valid().ClientHeader.TlfName,
-				msg.Valid().MessageBody.Text().Body)
-		}
-		return fmt.Sprintf("%s (%s#%s): %s", msg.Valid().SenderUsername, msg.Valid().ClientHeader.TlfName,
-			utils.GetTopicName(ib.Convs[0]), msg.Valid().MessageBody.Text().Body)
-	default:
-		return fmt.Sprintf("%s: %s", msg.Valid().SenderUsername, msg.Valid().MessageBody.Text().Body)
-	}
-}
-
 func (h *Server) UnboxMobilePushNotification(ctx context.Context, arg chat1.UnboxMobilePushNotificationArg) (res string, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks, h.identNotifier)
@@ -2562,75 +2488,14 @@ func (h *Server) UnboxMobilePushNotification(ctx context.Context, arg chat1.Unbo
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}
-	defer func() {
-		if err == nil {
-			// If we have succeeded, let us let the server know that it can abort the push notification
-			// associated with this silent one
-			h.sendRemoteNotificationSuccessful(ctx, arg.PushIDs)
-		}
-	}()
-
-	// Parse the message payload and convID
 	bConvID, err := hex.DecodeString(arg.ConvID)
 	if err != nil {
 		h.Debug(ctx, "UnboxMobilePushNotification: invalid convID: %s msg: %s", arg.ConvID, err.Error())
 		return res, err
 	}
 	convID := chat1.ConversationID(bConvID)
-	bMsg, err := base64.StdEncoding.DecodeString(arg.Payload)
-	if err != nil {
-		h.Debug(ctx, "UnboxMobilePushNotification: invalid message payload: %s", err.Error())
-		return res, err
-	}
-	var msgBoxed chat1.MessageBoxed
-	mh := codec.MsgpackHandle{WriteExt: true}
-	if err = codec.NewDecoderBytes(bMsg, &mh).Decode(&msgBoxed); err != nil {
-		h.Debug(ctx, "UnboxMobilePushNotification: failed to msgpack decode payload: %s", err.Error())
-		return res, err
-	}
-
-	// Unbox first
-	vis := keybase1.TLFVisibility_PRIVATE
-	if msgBoxed.ClientHeader.TlfPublic {
-		vis = keybase1.TLFVisibility_PUBLIC
-	}
-	unboxInfo := newBasicUnboxConversationInfo(convID, arg.MembersType, nil, vis)
-	msgUnboxed, err := NewBoxer(h.G()).UnboxMessage(ctx, msgBoxed, unboxInfo)
-	if err != nil {
-		h.Debug(ctx, "UnboxMobilePushNotification: unbox failed, bailing: %s", err.Error())
-		return res, err
-	}
-
-	// Check to see if this will be a strict append before adding to the body cache
-	if err := h.G().ConvSource.AcquireConversationLock(ctx, uid, convID); err != nil {
-		return res, err
-	}
-	maxMsgID, err := storage.New(h.G()).GetMaxMsgID(ctx, convID, uid)
-	if err == nil {
-		if msgUnboxed.GetMessageID() > maxMsgID {
-			if _, err = h.G().ConvSource.PushUnboxed(ctx, convID, uid, msgUnboxed); err != nil {
-				h.Debug(ctx, "UnboxMobilePushNotification: failed to push message to conv source: %s",
-					err.Error())
-			}
-		} else {
-			h.Debug(ctx, "UnboxMobilePushNotification: message from the past, skipping insert: msgID: %d maxMsgID: %d", msgUnboxed.GetMessageID(), maxMsgID)
-
-		}
-	} else {
-		h.Debug(ctx, "UnboxMobilePushNotification: failed to fetch max msg ID: %s", err)
-	}
-	h.G().ConvSource.ReleaseConversationLock(ctx, uid, convID)
-
-	// Form the push notification message
-	if msgUnboxed.IsValid() && msgUnboxed.GetMessageType() == chat1.MessageType_TEXT {
-		res = h.formatPushText(ctx, uid, convID, arg.MembersType, msgUnboxed)
-		h.Debug(ctx, "UnboxMobilePushNotification: successful unbox")
-		return res, nil
-	}
-
-	h.Debug(ctx, "UnboxMobilePushNotification: invalid message received: typ: %v",
-		msgUnboxed.GetMessageType())
-	return "", errors.New("invalid message")
+	return h.G().ChatHelper.UnboxMobilePushNotification(ctx, uid, convID, arg.MembersType, arg.PushIDs,
+		arg.Payload)
 }
 
 func (h *Server) SetGlobalAppNotificationSettingsLocal(ctx context.Context,

--- a/go/git/common_test.go
+++ b/go/git/common_test.go
@@ -174,6 +174,14 @@ func (m *mockChatHelper) GetMessages(ctx context.Context, uid gregor1.UID, convI
 	return nil, nil
 }
 
+func (m *mockChatHelper) AckMobileNotificationSuccess(ctx context.Context, pushIDs []string) {
+}
+
+func (m *mockChatHelper) UnboxMobilePushNotification(ctx context.Context, uid gregor1.UID,
+	convID chat1.ConversationID, membersType chat1.ConversationMembersType, pushIDs []string, payload string) (string, error) {
+	return "", nil
+}
+
 func (m *mockChatHelper) convKey(name string, topicName *string) string {
 	if topicName == nil {
 		return name + ":general"

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -771,4 +771,6 @@ type ChatHelper interface {
 	GetMessages(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
 		msgIDs []chat1.MessageID, resolveSupersedes bool) ([]chat1.MessageUnboxed, error)
 	UpgradeKBFSToImpteam(ctx context.Context, tlfName string, tlfID chat1.TLFID, public bool) error
+	UnboxMobilePushNotification(ctx context.Context, uid gregor1.UID,
+		convID chat1.ConversationID, membersType chat1.ConversationMembersType, pushIDs []string, payload string) (string, error)
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -773,4 +773,5 @@ type ChatHelper interface {
 	UpgradeKBFSToImpteam(ctx context.Context, tlfName string, tlfID chat1.TLFID, public bool) error
 	UnboxMobilePushNotification(ctx context.Context, uid gregor1.UID,
 		convID chat1.ConversationID, membersType chat1.ConversationMembersType, pushIDs []string, payload string) (string, error)
+	AckMobileNotificationSuccess(ctx context.Context, pushIDs []string)
 }

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -41,13 +41,13 @@ let config = {
 }
 
 // Developer settings
-config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
+  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -41,13 +41,13 @@ let config = {
 }
 
 // Developer settings
+config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
-  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false

--- a/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		272DA236209C3D9F002CE7A6 /* OpenSans-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 272DA208209C3D9F002CE7A6 /* OpenSans-ExtraBold.ttf */; };
 		272DA237209C3D9F002CE7A6 /* OpenSans-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 272DA208209C3D9F002CE7A6 /* OpenSans-ExtraBold.ttf */; };
 		2746CFFA1E9884BD00E579B0 /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 274AFB721E972F5300615A64 /* libresolv.tbd */; };
+		27EE26A820A140EF00F92CD1 /* Pusher.m in Sources */ = {isa = PBXBuildFile; fileRef = 27EE26A720A140EF00F92CD1 /* Pusher.m */; };
 		370EFC8E1FB3BDE1004DB3BB /* MessageUIManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 370EFC8D1FB3BDE1004DB3BB /* MessageUIManager.m */; };
 		375CA6651FFD40D300210B11 /* Storybook.m in Sources */ = {isa = PBXBuildFile; fileRef = 375CA6641FFD40D300210B11 /* Storybook.m */; };
 		A90CD4A81FCE1D0B00F97901 /* NativeLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = A90CD4A61FCE1D0A00F97901 /* NativeLogger.m */; };
@@ -401,6 +402,8 @@
 		272DA208209C3D9F002CE7A6 /* OpenSans-ExtraBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "OpenSans-ExtraBold.ttf"; sourceTree = "<group>"; };
 		274AFB721E972F5300615A64 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
 		27DDEEF0AE72483E8BF08ED2 /* RNFetchBlob.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFetchBlob.xcodeproj; path = "../../node_modules/react-native-fetch-blob/ios/RNFetchBlob.xcodeproj"; sourceTree = "<group>"; };
+		27EE26A720A140EF00F92CD1 /* Pusher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Pusher.m; sourceTree = "<group>"; };
+		27EE26A920A1466300F92CD1 /* Pusher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Pusher.h; sourceTree = "<group>"; };
 		370EFC8D1FB3BDE1004DB3BB /* MessageUIManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MessageUIManager.m; sourceTree = "<group>"; };
 		3724B72A1FB491F000A12CE6 /* MessageUIManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MessageUIManager.h; sourceTree = "<group>"; };
 		375CA6641FFD40D300210B11 /* Storybook.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Storybook.m; sourceTree = "<group>"; };
@@ -825,6 +828,8 @@
 				DBDCF3441B8D04FC00BA95D8 /* Keybase-Bridging-Header.h */,
 				DB7539311D77753600AFA61B /* Keybase_For_Tests-Bridging-Header.h */,
 				0044E59C1BCD7CEA008EF7EE /* LaunchScreen.storyboard */,
+				27EE26A720A140EF00F92CD1 /* Pusher.m */,
+				27EE26A920A1466300F92CD1 /* Pusher.h */,
 			);
 			path = Keybase;
 			sourceTree = "<group>";
@@ -1475,6 +1480,7 @@
 				DBEE30821FE8511F0020EBA5 /* DDASLLogger.m in Sources */,
 				DBEE30831FE8511F0020EBA5 /* DDLog.m in Sources */,
 				DBEE30811FE8511F0020EBA5 /* DDOSLogger.m in Sources */,
+				27EE26A820A140EF00F92CD1 /* Pusher.m in Sources */,
 				A90CD4A81FCE1D0B00F97901 /* NativeLogger.m in Sources */,
 				370EFC8E1FB3BDE1004DB3BB /* MessageUIManager.m in Sources */,
 				DBCE36251B90F14800ECADDE /* Engine.m in Sources */,

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -200,6 +200,7 @@ const BOOL isDebug = NO;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
   NSLog(@"Remote notification handle started...");
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+    NSString* convID = notification[@"c"];
     int membersType = [[notification objectForKey:@"t"] intValue];
     int messageID = [[notification objectForKey:@"d"] intValue];
     int badgeCount = [[notification objectForKey:@"b"] intValue];
@@ -208,12 +209,16 @@ const BOOL isDebug = NO;
     NSString* body = [notification objectForKey:@"m"];
     
     NSError *err = nil;
-    NSString* pushMessage = KeybaseHandleBackgroundNotification(notification[@"c"], membersType, messageID,
-                                        pushID, badgeCount, unixTime, body, &err);
+    NSString* pushMessage = KeybaseHandleBackgroundNotification(convID, membersType, messageID,
+                                                                pushID, badgeCount, unixTime, body, &err);
     if (err == nil) {
       UILocalNotification* localNotification = [[UILocalNotification alloc] init];
       localNotification.fireDate = [NSDate dateWithTimeIntervalSinceNow:0];
       localNotification.alertBody = pushMessage;
+      localNotification.applicationIconBadgeNumber = badgeCount;
+      localNotification.soundName = @"keybasemessage.wav";
+      NSDictionary *userInfo = @{ @"convID" : convID, @"type" : @"chat.newmessage"};
+      localNotification.userInfo = userInfo;
       dispatch_async(dispatch_get_main_queue(), ^{
         [application scheduleLocalNotification:localNotification];
       });

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -202,7 +202,7 @@ const BOOL isDebug = NO;
   NSLog(@"Remote notification handle started...");
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
     NSString* type = notification[@"type"];
-    if ([type isEqualToString:@"chat.newmessageSilent_2"]) {
+    if (type != nil && [type isEqualToString:@"chat.newmessageSilent_2"]) {
       NSString* convID = notification[@"c"];
       int membersType = [notification[@"t"] intValue];
       int messageID = [notification[@"d"] intValue];

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -72,7 +72,7 @@ const BOOL isDebug = NO;
 #endif
 
   BOOL securityAccessGroupOverride = isSimulator;
-  BOOL skipLogFile = true;
+  BOOL skipLogFile = false;
 
   NSString * home = NSHomeDirectory();
 

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -224,7 +224,7 @@ const BOOL isDebug = NO;
       });
     }
     completionHandler(UIBackgroundFetchResultNewData);
-    NSLog(@"Background fetch completed...");
+    NSLog(@"Remote notification handle finished...");
   });
 }
   

--- a/shared/react-native/ios/Keybase/Pusher.h
+++ b/shared/react-native/ios/Keybase/Pusher.h
@@ -1,0 +1,17 @@
+//
+//  Pusher.h
+//  Keybase
+//
+//  Created by Michael Maxim on 5/7/18.
+//  Copyright © 2018 Keybase. All rights reserved.
+//
+
+#ifndef Pusher_h
+#define Pusher_h
+#import <keybase/keybase.h>
+
+@interface PushNotifier : NSObject<KeybasePushNotifier> {
+}
+@end
+
+#endif /* Pusher_h */

--- a/shared/react-native/ios/Keybase/Pusher.m
+++ b/shared/react-native/ios/Keybase/Pusher.m
@@ -1,0 +1,33 @@
+//
+//  Pusher.m
+//  Keybase
+//
+//  Created by Michael Maxim on 5/7/18.
+//  Copyright © 2018 Keybase. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Pusher.h"
+@import UserNotifications;
+
+@implementation PushNotifier {
+}
+- (void)localNotification:(NSString*)ident msg:(NSString*)msg badgeCount:(long)badgeCount soundName:(NSString*)soundName convID:(NSString*)convID typ:(NSString*)typ {
+  UNMutableNotificationContent *localNotification = [UNMutableNotificationContent new];
+  localNotification.sound = [UNNotificationSound soundNamed:soundName];
+  localNotification.badge = [NSNumber numberWithLong:badgeCount];
+  localNotification.body = msg;
+  localNotification.userInfo  =@{ @"convID" : convID, @"type" : typ};
+  UNTimeIntervalNotificationTrigger *trigger = [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:0 repeats:NO];
+  UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:ident
+                                                                        content:localNotification trigger:trigger];
+  UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
+  [center addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
+    if (error != nil) {
+      NSLog(@"local notification failed: %@",error);
+    }
+  }];
+}
+
+@end
+

--- a/shared/react-native/ios/Keybase/Pusher.m
+++ b/shared/react-native/ios/Keybase/Pusher.m
@@ -17,10 +17,8 @@
   localNotification.sound = [UNNotificationSound soundNamed:soundName];
   localNotification.badge = [NSNumber numberWithLong:badgeCount];
   localNotification.body = msg;
-  localNotification.userInfo  =@{ @"convID" : convID, @"type" : typ};
-  UNTimeIntervalNotificationTrigger *trigger = [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:0 repeats:NO];
-  UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:ident
-                                                                        content:localNotification trigger:trigger];
+  localNotification.userInfo = @{ @"convID" : convID, @"type" : typ};
+  UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:ident content:localNotification trigger:nil];
   UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
   [center addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
     if (error != nil) {


### PR DESCRIPTION
**Go**
1.) Factor out `UnboxMobilePushNotification` into `ChatHelper` to make it more accessible. 
2.) Add an interface for native to implement, `PushNotifier` that allows us to send local notifications from Go.
3.) Add an entrypoint in `bind` called `HandleBackgroundNotification` that native can call to handle a background notification.
4.) Use new local push ability in Go to send local notification before we ack the server letting it know we have displayed something. This improves the chances of getting something on the screen quicker.

**Native**
@keybase/react-hackers 
1.) Skip calling into JS when receiving a background notification, and instead call the Go handler directly.
2.) Implement `PushNotifier` using the new local notification center API. 
