### PR TITLE
Storybook - add prop provider to send form story

### DIFF
--- a/shared/wallets/index.stories.js
+++ b/shared/wallets/index.stories.js
@@ -5,12 +5,15 @@ import {storiesOf} from '../stories/storybook'
 import asset from './asset/index.stories'
 import walletList from './wallet-list/index.stories'
 import wallet from './wallet/index.stories'
+import sendForm from './send-form/index.stories'
 
 const load = () => {
   asset()
-  // these should actually be implemented in their own files Aka walletlist/index. Stories. Js
+  sendForm()
   walletList()
   wallet()
+
+  /* Still TODO */
   storiesOf('Wallets', module).add('Wallet Onboarding', () => (
     <Text type="BodyBig">Wallet Onboarding TBD</Text>
   ))

--- a/shared/wallets/send-form/asset-input/container.js
+++ b/shared/wallets/send-form/asset-input/container.js
@@ -1,6 +1,6 @@
 // @flow
 import AssetInput from '.'
-import {connect, type TypedState, type Dispatch} from '../../../util/container'
+import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -8,4 +8,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 const mergeProps = (stateProps, dispatchProps) => ({})
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(AssetInput)
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  setDisplayName('AssetInput')
+)(AssetInput)

--- a/shared/wallets/send-form/available/container.js
+++ b/shared/wallets/send-form/available/container.js
@@ -1,6 +1,6 @@
 // @flow
 import Available from '.'
-import {connect, type TypedState, type Dispatch} from '../../../util/container'
+import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -8,4 +8,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 const mergeProps = (stateProps, dispatchProps) => ({})
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Available)
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps), setDisplayName('Available'))(
+  Available
+)

--- a/shared/wallets/send-form/banner/container.js
+++ b/shared/wallets/send-form/banner/container.js
@@ -1,6 +1,6 @@
 // @flow
 import Banner from '.'
-import {connect, type TypedState, type Dispatch} from '../../../util/container'
+import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -8,4 +8,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 const mergeProps = (stateProps, dispatchProps) => ({})
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Banner)
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps), setDisplayName('Banner'))(
+  Banner
+)

--- a/shared/wallets/send-form/body/container.js
+++ b/shared/wallets/send-form/body/container.js
@@ -1,6 +1,6 @@
 // @flow
 import Body from '.'
-import {connect, type TypedState, type Dispatch} from '../../../util/container'
+import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -8,4 +8,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 const mergeProps = (stateProps, dispatchProps) => ({})
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Body)
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps), setDisplayName('Body'))(Body)

--- a/shared/wallets/send-form/body/index.js
+++ b/shared/wallets/send-form/body/index.js
@@ -23,11 +23,8 @@ const Spinner = () => (
 
 const Body = ({bannerInfo, isProcessing, onClick}: Props) => (
   <Box2 direction="vertical">
-    (isProcessing ?
-    <Spinner />
-    : null) (bannerInfo ?
-    <Banner />
-    : null)
+    {isProcessing && <Spinner />}
+    {bannerInfo && <Banner />}
     <Participants />
     <Divider />
     <AssetInput />

--- a/shared/wallets/send-form/footer/container.js
+++ b/shared/wallets/send-form/footer/container.js
@@ -1,6 +1,6 @@
 // @flow
 import Footer from '.'
-import {connect, type TypedState, type Dispatch} from '../../../util/container'
+import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -8,4 +8,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 const mergeProps = (stateProps, dispatchProps) => ({})
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Footer)
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps), setDisplayName('Footer'))(
+  Footer
+)

--- a/shared/wallets/send-form/header/container.js
+++ b/shared/wallets/send-form/header/container.js
@@ -1,6 +1,6 @@
 // @flow
 import Header from '.'
-import {connect, type TypedState, type Dispatch} from '../../../util/container'
+import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -8,4 +8,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 const mergeProps = (stateProps, dispatchProps) => ({})
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Header)
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps), setDisplayName('Header'))(
+  Header
+)

--- a/shared/wallets/send-form/index.stories.js
+++ b/shared/wallets/send-form/index.stories.js
@@ -1,10 +1,28 @@
 // @flow
 import React from 'react'
-import {action, storiesOf} from '../../stories/storybook'
+import {action, createPropProvider, storiesOf} from '../../stories/storybook'
 import SendForm from '.'
 
+// TODO some of the state of these child components
+// may be held completely by the parent form. Figure out a
+// good level of connected granularity while implementing
+// TODO fill these out
+const provider = createPropProvider({
+  AssetInput: props => ({}),
+  Available: props => ({}),
+  Banner: props => ({}),
+  Body: props => ({}),
+  Footer: props => ({}),
+  Header: props => ({}),
+  Memo: props => ({}),
+  Note: props => ({}),
+  Participants: props => ({}),
+})
+
 const load = () => {
-  storiesOf('Wallets/SendForm', module).add('Send', () => <SendForm onClick={action('onClick')} />)
+  storiesOf('Wallets/SendForm', module)
+    .addDecorator(provider)
+    .add('Send', () => <SendForm onClick={action('onClick')} />)
 }
 
 export default load

--- a/shared/wallets/send-form/memo/container.js
+++ b/shared/wallets/send-form/memo/container.js
@@ -1,6 +1,6 @@
 // @flow
 import Memo from '.'
-import {connect, type TypedState, type Dispatch} from '../../../util/container'
+import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -8,4 +8,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 const mergeProps = (stateProps, dispatchProps) => ({})
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Memo)
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps), setDisplayName('Memo'))(Memo)

--- a/shared/wallets/send-form/note/container.js
+++ b/shared/wallets/send-form/note/container.js
@@ -1,6 +1,6 @@
 // @flow
 import Note from '.'
-import {connect, type TypedState, type Dispatch} from '../../../util/container'
+import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -8,4 +8,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 const mergeProps = (stateProps, dispatchProps) => ({})
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Note)
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps), setDisplayName('Note'))(Note)

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -1,6 +1,6 @@
 // @flow
 import Participants from '.'
-import {connect, type TypedState, type Dispatch} from '../../../util/container'
+import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -8,4 +8,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 const mergeProps = (stateProps, dispatchProps) => ({})
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Participants)
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  setDisplayName('Participants')
+)(Participants)


### PR DESCRIPTION
The send form story has connected children; this adds a prop provider and corresponding `setDisplayName`s to allow it to render in storybook. r? @keybase/react-hackers 