### PR TITLE
clean up cleanLoggedInAndNotRevoked in engine.Login

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -456,6 +456,10 @@ func (f failingUpak) LoadV2WithKID(ctx context.Context, uid keybase1.UID, kid ke
 	require.Fail(f.t, "LoadV2WithKID call")
 	return nil, nil
 }
+func (f failingUpak) CheckDeviceForUIDAndUsername(ctx context.Context, uid keybase1.UID, did keybase1.DeviceID, n libkb.NormalizedUsername) error {
+	require.Fail(f.t, "CheckDeviceForUIDAndUsername call")
+	return nil
+}
 
 func TestGetThreadCaching(t *testing.T) {
 	ctx, world, ri, _, sender, _ := setupTest(t, 1)

--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -199,11 +199,11 @@ func (e *Login) checkLoggedInAndNotRevoked(m libkb.MetaContext) (bool, error) {
 			m.CDebugf("logout error: %s", err)
 		}
 		return false, err
-	case libkb.BadUsernameError:
+	case libkb.LoggedInWrongUserError:
 		if libkb.CheckEmail.F(e.usernameOrEmail) {
 			m.CDebugf("Login: already logged in, but %q email address provided. Can't determine if that is current user without further work, so just returning LoggedInError", e.usernameOrEmail)
 		} else {
-			m.CDebugf("User already logged in as different user (%s)", err.Error())
+			m.CDebugf(err.Error())
 		}
 		return true, libkb.LoggedInError{}
 	default:

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -566,7 +566,7 @@ type LoggedInWrongUserError struct {
 }
 
 func (e LoggedInWrongUserError) Error() string {
-	return fmt.Sprintf("Logged in as %q, attempting to log in as %q:  try logout first", e.ExistingName, e.AttemptedName)
+	return fmt.Sprintf("Logged in as %q, attempting to log in as %q: try logout first", e.ExistingName, e.AttemptedName)
 }
 
 //=============================================================================

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2321,3 +2321,9 @@ func NewTeamProvisionalError(canKey bool, isPublic bool, dn string) error {
 }
 
 //=============================================================================
+
+type NoActiveDeviceError struct{}
+
+func (e NoActiveDeviceError) Error() string { return "no active device" }
+
+//=============================================================================

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -704,7 +704,7 @@ func (u *CachedUPAKLoader) CheckDeviceForUIDAndUsername(ctx context.Context, uid
 		return NewKeyRevokedError(did.String())
 	}
 	if !n.IsNil() && !foundUsername.Eq(n) {
-		return NewBadUsernameError(fmt.Sprintf("expected %q not %q", foundUsername.String(), n.String()))
+		return LoggedInWrongUserError{ExistingName: foundUsername, AttemptedName: foundUsername}
 	}
 	return nil
 }


### PR DESCRIPTION
- previously there was racy behavior, between when we checked ActiveDevice is Valid() and when we checked the UID() fields
- Use UPAKs to check the current UID/device, rather than a full user load.