### PR TITLE
Enable ephemeral support for whitelisted admins in mobile [CORE-6882]

### DIFF
--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -63,12 +63,6 @@ func (e *EKLib) checkLoginAndPUK(ctx context.Context) error {
 func (e *EKLib) ShouldRun(ctx context.Context) bool {
 	g := e.G()
 
-	// TODO -- when we launch, remove the feature flagging on Prod
-	willRun := g.Env.GetFeatureFlags().Admin() || g.Env.GetRunMode() == libkb.DevelRunMode || g.Env.RunningInCI()
-	if !willRun {
-		e.G().Log.CDebugf(ctx, "EKLib skipping run")
-		return false
-	}
 	oneshot, err := g.IsOneshot(ctx)
 	if err != nil {
 		e.G().Log.CDebugf(ctx, "EKLib#ShouldRun failed: %s", err)

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -12,6 +12,14 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
+// While  under development, this whitelist will allow ephemeral code to work
+// (useful for enabling on mobile builds)
+var adminWhitelist = map[keybase1.UID]bool{
+	"d1b3a5fa977ce53da2c2142a4511bc00": true, // joshblum
+	"41b1f75fb55046d370608425a3208100": true, // oconnor663
+	"95e88f2087e480cae28f08d81554bc00": true, // mikem
+}
+
 const cacheEntryLifetimeSecs = 60 * 5 // 5 minutes
 const lruSize = 200
 
@@ -63,9 +71,16 @@ func (e *EKLib) checkLoginAndPUK(ctx context.Context) error {
 func (e *EKLib) ShouldRun(ctx context.Context) bool {
 	g := e.G()
 
+	_, ok := adminWhitelist[e.G().Env.GetUID()]
+	willRun := ok || g.Env.GetFeatureFlags().Admin() || g.Env.GetRunMode() == libkb.DevelRunMode || g.Env.RunningInCI()
+	if !willRun {
+		e.G().Log.CDebugf(ctx, "EKLib skipping run")
+		return false
+	}
+
 	oneshot, err := g.IsOneshot(ctx)
 	if err != nil {
-		e.G().Log.CDebugf(ctx, "EKLib#ShouldRun failed: %s", err)
+		g.Log.CDebugf(ctx, "EKLib#ShouldRun failed: %s", err)
 		return false
 	}
 	return !oneshot


### PR DESCRIPTION
This will enable ephemeral support throughout, ~so we shouldn't merge it until we're comfortable~ for whitelisted admins. We can keep updating this branch with master and run our own mobile builds from it for testing though.

cc @oconnor663 @mmaxim 