### PR TITLE
Print chat search results to stdout instead of stderr

### DIFF
--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -172,7 +172,7 @@ func (c *ChatUI) ChatSearchHit(ctx context.Context, arg chat1.ChatSearchHitArg) 
 	// to refactor for UIMessage
 	hitText := highlightHits(searchHit.HitMessage, searchHit.Matches)
 	if hitText != "" {
-		w := c.terminal.ErrorWriter()
+		w := c.terminal.OutputWriter()
 		fmt.Fprintf(w, getContext(searchHit.PrevMessage))
 		fmt.Fprintln(w, hitText)
 		fmt.Fprintf(w, getContext(searchHit.NextMessage))


### PR DESCRIPTION
Let me know if there was a reason to use ErrorWriter instead.