### PR TITLE
parse the teamEK generation even with the signing PTK is bad [CORE-7841] 

### DIFF
--- a/go/ephemeral/handler.go
+++ b/go/ephemeral/handler.go
@@ -10,8 +10,9 @@ import (
 func HandleNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) (err error) {
 	defer g.CTrace(ctx, "HandleNewTeamEK", func() error { return err })()
 
-	ekLib := g.GetEKLib()
-	ekLib.PurgeTeamEKGenCache(teamID, generation)
+	if ekLib := g.GetEKLib(); ekLib != nil {
+		ekLib.PurgeTeamEKGenCache(teamID, generation)
+	}
 	g.NotifyRouter.HandleNewTeamEK(ctx, teamID, generation)
 	return nil
 }

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -232,7 +232,7 @@ func (e *EKLib) NewTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID) (ne
 	if err != nil {
 		return false, err
 	}
-	statement, err := fetchTeamEKStatement(ctx, e.G(), teamID)
+	statement, _, _, err := fetchTeamEKStatement(ctx, e.G(), teamID)
 	if err != nil {
 		return false, err
 	}
@@ -362,7 +362,7 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 		return teamEK, err
 	}
 
-	statement, err := fetchTeamEKStatement(ctx, e.G(), teamID)
+	statement, _, _, err := fetchTeamEKStatement(ctx, e.G(), teamID)
 	if err != nil {
 		return teamEK, err
 	}

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -129,7 +129,7 @@ func (s *TeamEKBoxStorage) fetchAndPut(ctx context.Context, teamID keybase1.Team
 	// Before we store anything, let's verify that the server returned
 	// signature is valid and the KID it has signed matches the boxed seed.
 	// Otherwise something's fishy..
-	teamEKStatement, wrongKID, err := verifySigWithLatestPTK(ctx, s.G(), teamID, result.Result.Sig)
+	teamEKStatement, _, wrongKID, err := verifySigWithLatestPTK(ctx, s.G(), teamID, result.Result.Sig)
 
 	// Check the wrongKID condition before checking the error, since an error
 	// is still returned in this case. TODO: Turn this warning into an error

--- a/go/ephemeral/team_ek_test.go
+++ b/go/ephemeral/team_ek_test.go
@@ -35,14 +35,14 @@ func TestNewTeamEK(t *testing.T) {
 	teamID := createTeam(tc)
 
 	// Before we've published any teamEK's, fetchTeamEKStatement should return nil.
-	nilStatement, err := fetchTeamEKStatement(context.Background(), tc.G, teamID)
+	nilStatement, _, _, err := fetchTeamEKStatement(context.Background(), tc.G, teamID)
 	require.NoError(t, err)
 	require.Nil(t, nilStatement)
 
 	publishedMetadata, err := publishNewTeamEK(context.Background(), tc.G, teamID, merkleRoot)
 	require.NoError(t, err)
 
-	statementPtr, err := fetchTeamEKStatement(context.Background(), tc.G, teamID)
+	statementPtr, _, _, err := fetchTeamEKStatement(context.Background(), tc.G, teamID)
 	require.NoError(t, err)
 	require.NotNil(t, statementPtr)
 	statement := *statementPtr

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -158,7 +158,7 @@ func TestResetMember(t *testing.T) {
 	ann.addWriter(team, bob)
 	ann.addWriter(team, joe)
 
-	// Ann now makes a new teamEk which joe can access but bob cannot
+	// ann now makes a new teamEk which joe can access but bob cannot
 	teamEK2, err := annEkLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 	require.NoError(t, err)
 
@@ -235,45 +235,83 @@ func runRotate(t *testing.T, createTeamEK bool) {
 	require.Equal(t, maxGeneration, expectedMaxGeneration)
 }
 
+func TestRotateSkipTeamEKRoll(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	ann := tt.addUser("ann")
+	bob := tt.addUserWithPaper("bob")
+
+	annG := ann.tc.G
+	ephemeral.ServiceInit(annG)
+	bobG := bob.tc.G
+	ephemeral.ServiceInit(bobG)
+
+	teamID, teamName := ann.createTeam2()
+
+	// After rotate, we should have rolled the teamEK if one existed.
+	ekLib := annG.GetEKLib()
+	teamEK, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	require.NoError(t, err)
+
+	// This is a hack to skip the teamEK generation during the PTK roll.
+	// We want to validate that we can create a new teamEK after this roll even
+	// though our existing teamEK is signed by a (now) invalid PTK
+	annG.SetEKLib(nil)
+
+	ann.addTeamMember(teamName.String(), bob.username, keybase1.TeamRole_WRITER)
+
+	bob.revokePaperKey()
+	ann.waitForRotateByID(teamID, keybase1.Seqno(3))
+	annG.SetEKLib(ekLib)
+
+	// After rotating, ensure we can create a new TeamEK without issue.
+	merkleRoot, err := ann.tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
+	require.NoError(t, err)
+	metadata, err := ephemeral.ForcePublishNewTeamEKForTesting(context.Background(), ann.tc.G, teamID, *merkleRoot)
+	require.NoError(t, err)
+	require.Equal(t, teamEK.Metadata.Generation+1, metadata.Generation)
+}
+
 func TestNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
-	alice := tt.addUserWithPaper("alice")
+	ann := tt.addUserWithPaper("ann")
 
-	teamID, _ := alice.createTeam2()
+	teamID, _ := ann.createTeam2()
 
-	ephemeral.ServiceInit(alice.tc.G)
-	ekLib := alice.tc.G.GetEKLib()
+	ephemeral.ServiceInit(ann.tc.G)
+	ekLib := ann.tc.G.GetEKLib()
 
 	_, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 	require.NoError(t, err)
 
 	// Provision a new device that we can revoke.
-	newDevice := alice.provisionNewDevice()
+	newDevice := ann.provisionNewDevice()
 
 	// Revoke it.
-	revokeEngine := engine.NewRevokeDeviceEngine(alice.tc.G, engine.RevokeDeviceEngineArgs{
+	revokeEngine := engine.NewRevokeDeviceEngine(ann.tc.G, engine.RevokeDeviceEngineArgs{
 		ID:        newDevice.deviceKey.DeviceID,
 		ForceSelf: true,
 		ForceLast: false,
 	})
 	uis := libkb.UIs{
-		LogUI:    alice.tc.G.Log,
-		SecretUI: alice.newSecretUI(),
+		LogUI:    ann.tc.G.Log,
+		SecretUI: ann.newSecretUI(),
 	}
-	m := libkb.NewMetaContextForTest(*alice.tc).WithUIs(uis)
+	m := libkb.NewMetaContextForTest(*ann.tc).WithUIs(uis)
 	err = engine.RunEngine2(m, revokeEngine)
 	require.NoError(t, err)
 
 	// Now provision a new userEK. This makes sure that we don't get confused
 	// by the revoked device's deviceEKs.
-	merkleRoot, err := alice.tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
+	merkleRoot, err := ann.tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
-	_, err = ephemeral.ForcePublishNewUserEKForTesting(context.Background(), alice.tc.G, *merkleRoot)
+	_, err = ephemeral.ForcePublishNewUserEKForTesting(context.Background(), ann.tc.G, *merkleRoot)
 	require.NoError(t, err)
 
 	// And do the same for the teamEK, just to be sure.
-	_, err = ephemeral.ForcePublishNewTeamEKForTesting(context.Background(), alice.tc.G, teamID, *merkleRoot)
+	_, err = ephemeral.ForcePublishNewTeamEKForTesting(context.Background(), ann.tc.G, teamID, *merkleRoot)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
We had to make a similar fix in userEKs. This takes care of the
situation where someone legacy-rolls the PTK and trashes the existing
keys. Previously that would cause clients to issue new teamEKs with
generation 1, which the server would reject.

r? @joshblum 

I will need to add a test before landing this.