### PR TITLE
Fix error message

### DIFF
--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -75,7 +75,7 @@ func NewEphemeralUnboxingError() EphemeralUnboxingError {
 }
 
 func (e EphemeralUnboxingError) Error() string {
-	return "Unable to decrypt exploding message. Missing keys."
+	return "Unable to decrypt exploding message. Missing keys"
 }
 
 //=============================================================================


### PR DESCRIPTION
when the message is rendered an extra `.` is added