### PR TITLE
Create a new teamEK if you can't access the latest one

### DIFF
--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -252,7 +252,7 @@ func (t *TeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfNam
 	if err != nil {
 		return teamEK, err
 	}
-	return t.G().GetEKLib().GetMaybeCreateNewTeamEK(ctx, teamID, generation)
+	return t.G().GetEKLib().GetTeamEK(ctx, teamID, generation)
 }
 
 type ImplicitTeamsNameInfoSource struct {
@@ -412,14 +412,14 @@ func (t *ImplicitTeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context
 		if err != nil {
 			return teamEK, err
 		}
-		return t.G().GetEKLib().GetMaybeCreateNewTeamEK(ctx, teamID, generation)
+		return t.G().GetEKLib().GetTeamEK(ctx, teamID, generation)
 	}
 	// Otherwise for implicit teams, we have to load the team to get its ID.
 	team, err := t.loader.loadTeam(ctx, tlfID, tlfName, membersType, public, nil)
 	if err != nil {
 		return teamEK, err
 	}
-	return t.G().GetEKLib().GetMaybeCreateNewTeamEK(ctx, team.ID, generation)
+	return t.G().GetEKLib().GetTeamEK(ctx, team.ID, generation)
 }
 
 func (t *ImplicitTeamsNameInfoSource) lookupInternalName(ctx context.Context, name string, public bool) (res *types.NameInfo, err error) {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -252,7 +252,7 @@ func (t *TeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfNam
 	if err != nil {
 		return teamEK, err
 	}
-	return t.G().GetTeamEKBoxStorage().Get(ctx, teamID, generation)
+	return t.G().GetEKLib().GetMaybeCreateNewTeamEK(ctx, teamID, generation)
 }
 
 type ImplicitTeamsNameInfoSource struct {
@@ -412,14 +412,14 @@ func (t *ImplicitTeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context
 		if err != nil {
 			return teamEK, err
 		}
-		return t.G().GetTeamEKBoxStorage().Get(ctx, teamID, generation)
+		return t.G().GetEKLib().GetMaybeCreateNewTeamEK(ctx, teamID, generation)
 	}
 	// Otherwise for implicit teams, we have to load the team to get its ID.
 	team, err := t.loader.loadTeam(ctx, tlfID, tlfName, membersType, public, nil)
 	if err != nil {
 		return teamEK, err
 	}
-	return t.G().GetTeamEKBoxStorage().Get(ctx, team.ID, generation)
+	return t.G().GetEKLib().GetMaybeCreateNewTeamEK(ctx, team.ID, generation)
 }
 
 func (t *ImplicitTeamsNameInfoSource) lookupInternalName(ctx context.Context, name string, public bool) (res *types.NameInfo, err error) {

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -390,8 +390,8 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 
 // Try to get the TeamEK for the given `generation`. If this fails and the
 // `generation` is also the current maxGeneration, create a new teamEK.
-func (e *EKLib) GetMaybeCreateNewTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
-	defer e.G().CTrace(ctx, "GetMaybeCreateNewTeamEK", func() error { return err })()
+func (e *EKLib) GetTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
+	defer e.G().CTrace(ctx, "GetTeamEK", func() error { return err })()
 
 	teamEK, err = e.G().GetTeamEKBoxStorage().Get(ctx, teamID, generation)
 	if err != nil {

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -395,8 +395,11 @@ func (e *EKLib) GetMaybeCreateNewTeamEK(ctx context.Context, teamID keybase1.Tea
 
 	teamEK, err = e.G().GetTeamEKBoxStorage().Get(ctx, teamID, generation)
 	if err != nil {
-		if _, cerr := e.GetOrCreateLatestTeamEK(ctx, teamID); cerr != nil {
-			e.G().Log.CDebugf(ctx, "Unable to GetOrCreateLatestTeamEK: %v", cerr)
+		switch err.(type) {
+		case *EKUnboxErr, *EKMissingBoxErr:
+			if _, cerr := e.GetOrCreateLatestTeamEK(ctx, teamID); cerr != nil {
+				e.G().Log.CDebugf(ctx, "Unable to GetOrCreateLatestTeamEK: %v", cerr)
+			}
 		}
 	}
 	return teamEK, err

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -388,6 +388,20 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 	return teamEK, nil
 }
 
+// Try to get the TeamEK for the given `generation`. If this fails and the
+// `generation` is also the current maxGeneration, create a new teamEK.
+func (e *EKLib) GetMaybeCreateNewTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
+	defer e.G().CTrace(ctx, "GetMaybeCreateNewTeamEK", func() error { return err })()
+
+	teamEK, err = e.G().GetTeamEKBoxStorage().Get(ctx, teamID, generation)
+	if err != nil {
+		if _, cerr := e.GetOrCreateLatestTeamEK(ctx, teamID); cerr != nil {
+			e.G().Log.CDebugf(ctx, "Unable to GetOrCreateLatestTeamEK: %v", cerr)
+		}
+	}
+	return teamEK, err
+}
+
 func (e *EKLib) NewEphemeralSeed() (seed keybase1.Bytes32, err error) {
 	return makeNewRandomSeed()
 }

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -182,7 +182,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 
 	// If we try to access an older teamEK that we cannot access, we don't
 	// create a new teamEK
-	teamEK, err := ekLib.GetMaybeCreateNewTeamEK(context.Background(), teamID, expectedTeamEKGen-1)
+	teamEK, err := ekLib.GetTeamEK(context.Background(), teamID, expectedTeamEKGen-1)
 	require.Error(t, err)
 	require.Equal(t, teamEK, keybase1.TeamEk{})
 	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
@@ -193,7 +193,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	require.NoError(t, err)
 	tc.G.GetDeviceEKStorage().ClearCache()
 
-	teamEK, err = ekLib.GetMaybeCreateNewTeamEK(context.Background(), teamID, expectedTeamEKGen)
+	teamEK, err = ekLib.GetTeamEK(context.Background(), teamID, expectedTeamEKGen)
 	require.Error(t, err)
 	require.Equal(t, teamEK, keybase1.TeamEk{})
 

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -116,7 +116,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 		expectedUserEKGen = 1
 	}
 
-	keygen := func(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen keybase1.EkGeneration) {
+	assertKeyGenerations := func(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen keybase1.EkGeneration) {
 		teamEK, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 		require.NoError(t, err)
 
@@ -150,8 +150,8 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	}
 
 	// If we retry keygen, we don't regenerate keys
-	keygen(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
-	keygen(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
 
 	rawDeviceEKStorage := NewDeviceEKStorage(tc.G)
 	rawUserEKBoxStorage := NewUserEKBoxStorage(tc.G)
@@ -162,14 +162,14 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	err = rawTeamEKBoxStorage.Delete(context.Background(), teamID, expectedTeamEKGen)
 	require.NoError(t, err)
 	teamEKBoxStorage.ClearCache()
-	keygen(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
 
 	// Now let's kill our userEK, we should gracefully not regenerate
 	// since we can still fetch the userEK from the server.
 	err = rawUserEKBoxStorage.Delete(context.Background(), expectedUserEKGen)
 	require.NoError(t, err)
 	tc.G.GetDeviceEKStorage().ClearCache()
-	keygen(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
 
 	// Now let's kill our deviceEK as well, and we should generate all new keys
 	err = rawDeviceEKStorage.Delete(context.Background(), expectedDeviceEKGen)
@@ -178,7 +178,29 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	expectedDeviceEKGen++
 	expectedUserEKGen++
 	expectedTeamEKGen++
-	keygen(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+
+	// If we try to access an older teamEK that we cannot access, we don't
+	// create a new teamEK
+	teamEK, err := ekLib.GetMaybeCreateNewTeamEK(context.Background(), teamID, expectedTeamEKGen-1)
+	require.Error(t, err)
+	require.Equal(t, teamEK, keybase1.TeamEk{})
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+
+	// Now let's kill our deviceEK, so we can no longer access the latest teamEK
+	// and will generate a new one and verify it is the new valid max.
+	err = rawDeviceEKStorage.Delete(context.Background(), expectedDeviceEKGen)
+	require.NoError(t, err)
+	tc.G.GetDeviceEKStorage().ClearCache()
+
+	teamEK, err = ekLib.GetMaybeCreateNewTeamEK(context.Background(), teamID, expectedTeamEKGen)
+	require.Error(t, err)
+	require.Equal(t, teamEK, keybase1.TeamEk{})
+
+	expectedDeviceEKGen++
+	expectedUserEKGen++
+	expectedTeamEKGen++
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
 }
 
 func TestCleanupStaleUserAndDeviceEKs(t *testing.T) {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -652,6 +652,7 @@ type TeamEKBoxStorage interface {
 type EKLib interface {
 	KeygenIfNeeded(ctx context.Context) error
 	GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (keybase1.TeamEk, error)
+	GetMaybeCreateNewTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (keybase1.TeamEk, error)
 	PurgeTeamEKGenCache(teamID keybase1.TeamID, generation keybase1.EkGeneration)
 	NewEphemeralSeed() (keybase1.Bytes32, error)
 	DeriveDeviceDHKey(seed keybase1.Bytes32) *NaclDHKeyPair

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -652,7 +652,7 @@ type TeamEKBoxStorage interface {
 type EKLib interface {
 	KeygenIfNeeded(ctx context.Context) error
 	GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (keybase1.TeamEk, error)
-	GetMaybeCreateNewTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (keybase1.TeamEk, error)
+	GetTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (keybase1.TeamEk, error)
 	PurgeTeamEKGenCache(teamID keybase1.TeamID, generation keybase1.EkGeneration)
 	NewEphemeralSeed() (keybase1.Bytes32, error)
 	DeriveDeviceDHKey(seed keybase1.Bytes32) *NaclDHKeyPair


### PR DESCRIPTION
If you receive a message encrypted with the latest teamEK but can't decrypt it, you should force a new teamEK to be created so you can read new messages