### PR TITLE
show a placeholder for the most recent message if we know via inbox CORE-7809

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 -   repo: local
     hooks:
     -   id: eslint
@@ -15,7 +16,7 @@
         files: \.(js|flow)$
         args: [-c, cd shared && node_modules/.bin/flow]
 -   repo: https://github.com/keybase/pre-commit-golang.git
-    sha: 06cb541d5ec2ec6adc218f7862098c55b5b24fc1
+    sha: b3408a42cc77ece991924d5f477ee3ae94371f9a
     hooks:
     -   id: go-fmt
     -   id: go-vet

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -839,15 +839,13 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 	// if the caller is ok with receiving placeholders
 	var iboxMaxMsgID chat1.MessageID
 	if maxPlaceholders > 0 {
-		_, iboxRes, _, err := storage.NewInbox(s.G(), uid).Read(ctx, &chat1.GetInboxQuery{
-			ConvID: &convID,
-		}, nil)
+		iboxRes, err := storage.NewInbox(s.G(), uid).GetConversation(ctx, convID)
 		if err != nil {
 			s.Debug(ctx, "PullLocalOnly: failed to read inbox for conv, not using: %s", err)
-		} else if len(iboxRes) != 1 || iboxRes[0].Conv.ReaderInfo == nil {
-			s.Debug(ctx, "PullLocalOnly: no conv returned for conv, not using")
+		} else if iboxRes.Conv.ReaderInfo == nil {
+			s.Debug(ctx, "PullLocalOnly: no reader infoconv returned for conv, not using")
 		} else {
-			iboxMaxMsgID = iboxRes[0].Conv.ReaderInfo.MaxMsgid
+			iboxMaxMsgID = iboxRes.Conv.ReaderInfo.MaxMsgid
 			s.Debug(ctx, "PullLocalOnly: found ibox max msgid: %d", iboxMaxMsgID)
 		}
 	}

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -835,6 +835,23 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 		}
 	}()
 
+	// Fetch the inbox max message ID as well to compare against the local stored max messages
+	// if the caller is ok with receiving placeholders
+	var iboxMaxMsgID chat1.MessageID
+	if maxPlaceholders > 0 {
+		_, iboxRes, _, err := storage.NewInbox(s.G(), uid).Read(ctx, &chat1.GetInboxQuery{
+			ConvID: &convID,
+		}, nil)
+		if err != nil {
+			s.Debug(ctx, "PullLocalOnly: failed to read inbox for conv, not using: %s", err)
+		} else if len(iboxRes) != 1 || iboxRes[0].Conv.ReaderInfo == nil {
+			s.Debug(ctx, "PullLocalOnly: no conv returned for conv, not using")
+		} else {
+			iboxMaxMsgID = iboxRes[0].Conv.ReaderInfo.MaxMsgid
+			s.Debug(ctx, "PullLocalOnly: found ibox max msgid: %d", iboxMaxMsgID)
+		}
+	}
+
 	// A number < 0 means it will fetch until it hits the end of the local copy. Our special
 	// result collector will suppress any miss errors
 	num := -1
@@ -842,7 +859,7 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 		num = pagination.Num
 	}
 	rc := storage.NewHoleyResultCollector(maxPlaceholders, newPullLocalResultCollector(num))
-	tv, err = s.storage.FetchUpToLocalMaxMsgID(ctx, convID, uid, rc, query, pagination)
+	tv, err = s.storage.FetchUpToLocalMaxMsgID(ctx, convID, uid, rc, iboxMaxMsgID, query, pagination)
 	if err != nil {
 		s.Debug(ctx, "PullLocalOnly: failed to fetch local messages: %s", err.Error())
 		return chat1.ThreadView{}, err

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
@@ -883,8 +882,8 @@ func TestClearFromDelete(t *testing.T) {
 	_, err = hcs.GetMessages(ctx, conv, uid, []chat1.MessageID{3, 2})
 	require.NoError(t, err)
 	tv, err := hcs.PullLocalOnly(ctx, conv.GetConvID(), uid, nil, nil, 0)
-	require.Error(t, err)
-	require.IsType(t, storage.MissError{}, err)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(tv.Messages))
 
 	hcs.numExpungeReload = 1
 	hcs.ClearFromDelete(ctx, uid, conv.GetConvID(), 4)

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -323,11 +323,10 @@ func (h *Server) MarkAsReadLocal(ctx context.Context, arg chat1.MarkAsReadLocalA
 	}
 
 	// Check local copy to see if we have this convo, and have fully read it. If so, we skip the remote call
-	_, readRes, _, err := storage.NewInbox(h.G(), uid).Read(ctx, &chat1.GetInboxQuery{
-		ConvID: &arg.ConversationID,
-	}, nil)
-	if err == nil && len(readRes) > 0 && readRes[0].GetConvID().Eq(arg.ConversationID) &&
-		readRes[0].Conv.ReaderInfo.ReadMsgid == readRes[0].Conv.ReaderInfo.MaxMsgid {
+
+	readRes, err := storage.NewInbox(h.G(), uid).GetConversation(ctx, arg.ConversationID)
+	if err == nil && readRes.GetConvID().Eq(arg.ConversationID) &&
+		readRes.Conv.ReaderInfo.ReadMsgid == readRes.Conv.ReaderInfo.MaxMsgid {
 		h.Debug(ctx, "MarkAsReadLocal: conversation fully read: %s, not sending remote call",
 			arg.ConversationID)
 		return chat1.MarkAsReadLocalRes{

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2357,6 +2357,25 @@ func TestChatSrvGetThreadNonblockIncremental(t *testing.T) {
 	})
 }
 
+func msgState(t *testing.T, msg chat1.UIMessage) chat1.MessageUnboxedState {
+	state, err := msg.State()
+	require.NoError(t, err)
+	return state
+}
+
+func confirmIsPlaceholder(t *testing.T, msgID chat1.MessageID, msg chat1.UIMessage, hidden bool) {
+	require.Equal(t, msgID, msg.GetMessageID())
+	require.Equal(t, chat1.MessageUnboxedState_PLACEHOLDER, msgState(t, msg))
+	require.Equal(t, hidden, msg.Placeholder().Hidden)
+}
+
+func confirmIsText(t *testing.T, msgID chat1.MessageID, msg chat1.UIMessage, text string) {
+	require.Equal(t, msgID, msg.GetMessageID())
+	require.Equal(t, chat1.MessageUnboxedState_VALID, msgState(t, msg))
+	require.Equal(t, chat1.MessageType_TEXT, msg.GetMessageType())
+	require.Equal(t, text, msg.Valid().MessageBody.Text().Body)
+}
+
 func TestChatSrvGetThreadNonblockPlaceholders(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetThreadNonblockPlaceholders", 1)
@@ -2443,33 +2462,17 @@ func TestChatSrvGetThreadNonblockPlaceholders(t *testing.T) {
 			require.NoError(t, err)
 			close(cb)
 		}()
-		msgState := func(msg chat1.UIMessage) chat1.MessageUnboxedState {
-			state, err := msg.State()
-			require.NoError(t, err)
-			return state
-		}
-		confirmPlaceholder := func(msgID chat1.MessageID, msg chat1.UIMessage, hidden bool) {
-			require.Equal(t, msgID, msg.GetMessageID())
-			require.Equal(t, chat1.MessageUnboxedState_PLACEHOLDER, msgState(msg))
-			require.Equal(t, hidden, msg.Placeholder().Hidden)
-		}
-		confirmText := func(msgID chat1.MessageID, msg chat1.UIMessage, text string) {
-			require.Equal(t, msgID, msg.GetMessageID())
-			require.Equal(t, chat1.MessageUnboxedState_VALID, msgState(msg))
-			require.Equal(t, chat1.MessageType_TEXT, msg.GetMessageType())
-			require.Equal(t, text, msg.Valid().MessageBody.Text().Body)
-		}
 		select {
 		case res := <-threadCb:
 			require.False(t, res.Full)
 			require.Equal(t, len(msgIDs), len(res.Thread.Messages))
 			require.Equal(t, msgIDs, utils.PluckUIMessageIDs(res.Thread.Messages))
-			confirmText(msgID3, res.Thread.Messages[0], "hi")
-			confirmPlaceholder(editMsgID2, res.Thread.Messages[1], false)
-			confirmPlaceholder(msgID2, res.Thread.Messages[2], false)
-			confirmPlaceholder(editMsgID1, res.Thread.Messages[3], false)
-			confirmPlaceholder(msgID1, res.Thread.Messages[4], false)
-			confirmPlaceholder(1, res.Thread.Messages[5], false)
+			confirmIsText(t, msgID3, res.Thread.Messages[0], "hi")
+			confirmIsPlaceholder(t, editMsgID2, res.Thread.Messages[1], false)
+			confirmIsPlaceholder(t, msgID2, res.Thread.Messages[2], false)
+			confirmIsPlaceholder(t, editMsgID1, res.Thread.Messages[3], false)
+			confirmIsPlaceholder(t, msgID1, res.Thread.Messages[4], false)
+			confirmIsPlaceholder(t, 1, res.Thread.Messages[5], false)
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no thread cb")
 		}
@@ -2478,11 +2481,98 @@ func TestChatSrvGetThreadNonblockPlaceholders(t *testing.T) {
 		case res := <-threadCb:
 			require.True(t, res.Full)
 			require.Equal(t, len(msgIDs)-1, len(res.Thread.Messages))
-			confirmPlaceholder(editMsgID2, res.Thread.Messages[0], true)
-			confirmText(msgID2, res.Thread.Messages[1], "HI")
-			confirmPlaceholder(editMsgID1, res.Thread.Messages[2], true)
-			confirmText(msgID1, res.Thread.Messages[3], "HI")
-			confirmPlaceholder(1, res.Thread.Messages[4], true)
+			confirmIsPlaceholder(t, editMsgID2, res.Thread.Messages[0], true)
+			confirmIsText(t, msgID2, res.Thread.Messages[1], "HI")
+			confirmIsPlaceholder(t, editMsgID1, res.Thread.Messages[2], true)
+			confirmIsText(t, msgID1, res.Thread.Messages[3], "HI")
+			confirmIsPlaceholder(t, 1, res.Thread.Messages[4], true)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no thread cb")
+		}
+		select {
+		case <-cb:
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "GetThread never finished")
+		}
+	})
+}
+
+func TestChatSrvGetThreadNonblockPlaceholderFirst(t *testing.T) {
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetThreadNonblockPlaceholdersFirst", 1)
+		defer ctc.cleanup()
+		users := ctc.users()
+
+		uid := gregor1.UID(users[0].GetUID().ToBytes())
+		inboxCb := make(chan kbtest.NonblockInboxResult, 100)
+		threadCb := make(chan kbtest.NonblockThreadResult, 100)
+		ui := kbtest.NewChatUI(inboxCb, threadCb, nil, nil)
+		ctc.as(t, users[0]).h.mockChatUI = ui
+		ctx := ctc.as(t, users[0]).startCtx
+		<-ctc.as(t, users[0]).h.G().ConvLoader.Stop(ctx)
+		listener := newServerChatListener()
+		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
+
+		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt)
+		tc := ctc.world.Tcs[users[0].Username]
+		cs := tc.ChatG.ConvSource
+		msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
+		msgID1 := mustPostLocalForTest(t, ctc, users[0], conv, msg)
+		consumeNewMsg(t, listener, chat1.MessageType_TEXT)
+		consumeNewMsg(t, listener, chat1.MessageType_TEXT)
+		msgID2 := mustPostLocalForTest(t, ctc, users[0], conv, msg)
+		consumeNewMsg(t, listener, chat1.MessageType_TEXT)
+		consumeNewMsg(t, listener, chat1.MessageType_TEXT)
+		msgRes, err := ctc.as(t, users[0]).chatLocalHandler().GetMessagesLocal(ctx, chat1.GetMessagesLocalArg{
+			ConversationID: conv.Id,
+			MessageIDs:     []chat1.MessageID{msgID1},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(msgRes.Messages))
+		msg1 := msgRes.Messages[0]
+		msgIDs := []chat1.MessageID{msgID2, msgID1, 1}
+
+		require.NoError(t, cs.Clear(context.TODO(), conv.Id, uid))
+		_, err = cs.PushUnboxed(ctx, conv.Id, uid, msg1)
+		require.NoError(t, err)
+
+		delay := 10 * time.Minute
+		clock := clockwork.NewFakeClock()
+		ctc.as(t, users[0]).h.clock = clock
+		ctc.as(t, users[0]).h.remoteThreadDelay = &delay
+		cb := make(chan struct{})
+		query := chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}
+		go func() {
+			_, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(ctx,
+				chat1.GetThreadNonblockArg{
+					ConversationID: conv.Id,
+					Query:          &query,
+					CbMode:         chat1.GetThreadNonblockCbMode_INCREMENTAL,
+				},
+			)
+			require.NoError(t, err)
+			close(cb)
+		}()
+		select {
+		case res := <-threadCb:
+			require.False(t, res.Full)
+			require.Equal(t, len(msgIDs), len(res.Thread.Messages))
+			require.Equal(t, msgIDs, utils.PluckUIMessageIDs(res.Thread.Messages))
+			confirmIsPlaceholder(t, msgID2, res.Thread.Messages[0], false)
+			confirmIsText(t, msgID1, res.Thread.Messages[1], "hi")
+			confirmIsPlaceholder(t, 1, res.Thread.Messages[2], false)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no thread cb")
+		}
+		clock.Advance(20 * time.Minute)
+		select {
+		case res := <-threadCb:
+			require.True(t, res.Full)
+			require.Equal(t, len(msgIDs)-1, len(res.Thread.Messages))
+			confirmIsText(t, msgID2, res.Thread.Messages[0], "hi")
+			confirmIsPlaceholder(t, 1, res.Thread.Messages[1], true)
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no thread cb")
 		}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -602,6 +602,20 @@ func (i *Inbox) ReadAll(ctx context.Context) (vers chat1.InboxVers, res []types.
 	return ibox.InboxVersion, ibox.Conversations, nil
 }
 
+func (i *Inbox) GetConversation(ctx context.Context, convID chat1.ConversationID) (res types.RemoteConversation, err Error) {
+	defer i.Trace(ctx, func() error { return err }, fmt.Sprintf("GetConversation(%s,%s)", i.uid, convID))()
+	_, iboxRes, _, err := i.Read(ctx, &chat1.GetInboxQuery{
+		ConvID: &convID,
+	}, nil)
+	if err != nil {
+		return res, err
+	}
+	if len(iboxRes) != 1 {
+		return res, MissError{}
+	}
+	return iboxRes[0], nil
+}
+
 func (i *Inbox) Read(ctx context.Context, query *chat1.GetInboxQuery, p *chat1.Pagination) (vers chat1.InboxVers, res []types.RemoteConversation, pagination *chat1.Pagination, err Error) {
 	locks.Inbox.Lock()
 	defer locks.Inbox.Unlock()

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -56,6 +56,13 @@ type AssetDeleter interface {
 	DeleteAssets(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, assets []chat1.Asset)
 }
 
+type DummyAssetDeleter struct{}
+
+func (d DummyAssetDeleter) DeleteAssets(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
+	assets []chat1.Asset) {
+
+}
+
 func New(g *globals.Context, assetDeleter AssetDeleter) *Storage {
 	return &Storage{
 		Contextified:     globals.NewContextified(g),
@@ -300,6 +307,9 @@ func (s *Storage) MaybeNuke(ctx context.Context, force bool, err Error, convID c
 			if _, err = s.G().LocalChatDb.Nuke(); err != nil {
 				s.Debug(ctx, "failed to delete chat local storage: %s", err)
 			}
+		}
+		if err := s.idtracker.clear(convID, uid); err != nil {
+			s.Debug(ctx, "failed to clear max message storage: %s", err)
 		}
 	}
 	return err

--- a/go/chat/storage/storage_msgid_tracker.go
+++ b/go/chat/storage/storage_msgid_tracker.go
@@ -82,3 +82,7 @@ func (t *msgIDTracker) getMaxMessageID(
 
 	return maxMsgID, nil
 }
+
+func (t *msgIDTracker) clear(convID chat1.ConversationID, uid gregor1.UID) error {
+	return t.G().LocalChatDb.Delete(t.makeDbKey(convID, uid))
+}

--- a/go/chat/storage/storage_test.go
+++ b/go/chat/storage/storage_test.go
@@ -798,12 +798,14 @@ func TestStorageLocalMax(t *testing.T) {
 	msgs := makeMsgRange(10)
 	conv := makeConversation(15)
 
-	_, err := storage.FetchUpToLocalMaxMsgID(context.TODO(), conv.Metadata.ConversationID, uid, nil, nil, nil)
+	_, err := storage.FetchUpToLocalMaxMsgID(context.TODO(), conv.Metadata.ConversationID, uid, nil, 0,
+		nil, nil)
 	require.Error(t, err)
 	require.IsType(t, MissError{}, err, "wrong error type")
 
 	mustMerge(t, storage, conv.Metadata.ConversationID, uid, msgs)
-	tv, err := storage.FetchUpToLocalMaxMsgID(context.TODO(), conv.Metadata.ConversationID, uid, nil, nil, nil)
+	tv, err := storage.FetchUpToLocalMaxMsgID(context.TODO(), conv.Metadata.ConversationID, uid, nil, 0,
+		nil, nil)
 	require.NoError(t, err)
 	require.Len(t, tv.Messages, 10)
 }


### PR DESCRIPTION
If we somehow know about the presence of a newer message from the inbox cache, then render a placeholder in that spot instead of just going blank. 