### PR TITLE
add a test for rolling userEKs/teamEKs with a revoked device

### DIFF
--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -165,6 +165,10 @@ func publishNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybas
 	return metadata, nil
 }
 
+func ForcePublishNewTeamEKForTesting(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEkMetadata, err error) {
+	return publishNewTeamEK(ctx, g, teamID, merkleRoot)
+}
+
 func boxTeamEKForUsers(ctx context.Context, g *libkb.GlobalContext, usersMetadata map[keybase1.UID]keybase1.UserEkMetadata, teamEK keybase1.TeamEk) (teamBoxes *[]keybase1.TeamEkBoxMetadata, myTeamEKBoxed *keybase1.TeamEkBoxed, err error) {
 	defer g.CTrace(ctx, "boxTeamEKForUsers", func() error { return err })()
 

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -162,6 +162,10 @@ func publishNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot li
 	return newMetadata, err
 }
 
+func ForcePublishNewUserEKForTesting(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (metadata keybase1.UserEkMetadata, err error) {
+	return publishNewUserEK(ctx, g, merkleRoot)
+}
+
 func boxUserEKForDevices(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot, seed UserEKSeed, userMetadata keybase1.UserEkMetadata) (boxes []keybase1.UserEkBoxMetadata, myUserEKBoxed *keybase1.UserEkBoxed, err error) {
 	defer g.CTrace(ctx, "boxUserEKForDevices", func() error { return err })()
 

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/ephemeral"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -232,4 +233,47 @@ func runRotate(t *testing.T, createTeamEK bool) {
 	maxGeneration, err := storage.MaxGeneration(context.Background(), teamID)
 	require.NoError(t, err)
 	require.Equal(t, maxGeneration, expectedMaxGeneration)
+}
+
+func TestNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	alice := tt.addUserWithPaper("alice")
+
+	teamID, _ := alice.createTeam2()
+
+	ephemeral.ServiceInit(alice.tc.G)
+	ekLib := alice.tc.G.GetEKLib()
+
+	_, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	require.NoError(t, err)
+
+	// Provision a new device that we can revoke.
+	newDevice := alice.provisionNewDevice()
+
+	// Revoke it.
+	revokeEngine := engine.NewRevokeDeviceEngine(alice.tc.G, engine.RevokeDeviceEngineArgs{
+		ID:        newDevice.deviceKey.DeviceID,
+		ForceSelf: true,
+		ForceLast: false,
+	})
+	uis := libkb.UIs{
+		LogUI:    alice.tc.G.Log,
+		SecretUI: alice.newSecretUI(),
+	}
+	m := libkb.NewMetaContextForTest(*alice.tc).WithUIs(uis)
+	err = engine.RunEngine2(m, revokeEngine)
+	require.NoError(t, err)
+
+	// Now provision a new userEK. This makes sure that we don't get confused
+	// by the revoked device's deviceEKs.
+	merkleRoot, err := alice.tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
+	require.NoError(t, err)
+	_, err = ephemeral.ForcePublishNewUserEKForTesting(context.Background(), alice.tc.G, *merkleRoot)
+	require.NoError(t, err)
+
+	// And do the same for the teamEK, just to be sure.
+	_, err = ephemeral.ForcePublishNewTeamEKForTesting(context.Background(), alice.tc.G, teamID, *merkleRoot)
+	require.NoError(t, err)
 }

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -218,7 +218,7 @@ func (tt *teamTester) addUserHelper(pre string, puk bool, paper bool) *userPlusD
 	require.True(tt.t, u.device.deviceKey.KID.Exists())
 	if paper {
 		require.Len(tt.t, backups, 1, "backup keys")
-		u.backupKey = backups[0]
+		u.backupKey = &backups[0]
 		u.backupKey.secret = signupUI.info.displayedPaperKey
 	} else {
 		require.Len(tt.t, backups, 0, "backup keys")
@@ -239,7 +239,7 @@ type userPlusDevice struct {
 	username                 string
 	passphrase               string
 	userInfo                 *signupInfo
-	backupKey                backupKey
+	backupKey                *backupKey
 	device                   *deviceWrapper
 	tc                       *libkb.TestContext
 	deviceClient             keybase1.DeviceClient
@@ -665,7 +665,7 @@ func (u *userPlusDevice) provisionNewDevice() *deviceWrapper {
 	require.NotNil(t, u.backupKey, "Add user with paper key to use provisionNewDevice")
 
 	// ui for provisioning
-	ui := &rekeyProvisionUI{username: u.username, backupKey: u.backupKey}
+	ui := &rekeyProvisionUI{username: u.username, backupKey: *u.backupKey}
 	{
 		_, xp, err := client.GetRPCClientWithContext(g)
 		require.NoError(t, err)
@@ -695,6 +695,8 @@ func (u *userPlusDevice) provisionNewDevice() *deviceWrapper {
 	require.NoError(t, err)
 	device.deviceKey.KID = skey.GetKID()
 	require.True(t, device.deviceKey.KID.Exists())
+	device.deviceKey.DeviceID = g.ActiveDevice.DeviceID()
+	require.True(t, device.deviceKey.DeviceID.Exists())
 
 	return device
 }


### PR DESCRIPTION
Prior to keybase/keybase commit
7719b3fd2e6ad62836ee807605b48fa477061e95, the server would keep
returning revoked devices' deviceEKs, and the client would (correctly)
error out. This test covers that condition, and fails if you check out
the old server code.

r? @joshblum 