### PR TITLE
move loginLoadUser off of LoginState

### DIFF
--- a/go/engine/device_wrap.go
+++ b/go/engine/device_wrap.go
@@ -62,8 +62,8 @@ func (e *DeviceWrap) SubConsumers() []libkb.UIConsumer {
 }
 
 func (e *DeviceWrap) registerDevice(m libkb.MetaContext) (err error) {
-
 	defer m.CTrace("DeviceWrap#registerDevice", func() error { return err })()
+	var salt []byte
 
 	if e.args.Me.HasCurrentDeviceInCurrentInstall() {
 		return libkb.DeviceAlreadyProvisionedError{}
@@ -81,7 +81,10 @@ func (e *DeviceWrap) registerDevice(m libkb.MetaContext) (err error) {
 	m.CDebugf("Device ID: %s", e.deviceID)
 
 	m.UIs().LogUI.Debug("Setting Device ID to %s", e.deviceID)
-	if err = m.SetDeviceIDWithinRegistration(e.deviceID); err != nil {
+	if salt, err = e.args.Me.GetSalt(); err != nil {
+		return err
+	}
+	if err = m.SwitchUserNewConfig(e.args.Me.GetUID(), e.args.Me.GetNormalizedName(), salt, e.deviceID); err != nil {
 		return err
 	}
 	return nil

--- a/go/engine/login_load_user.go
+++ b/go/engine/login_load_user.go
@@ -55,15 +55,20 @@ func (e *loginLoadUser) SubConsumers() []libkb.UIConsumer {
 }
 
 // Run starts the engine.
-func (e *loginLoadUser) Run(m libkb.MetaContext) error {
-	username, err := e.findUsername(m)
+func (e *loginLoadUser) Run(m libkb.MetaContext) (err error) {
+	defer m.CTrace("loginLoadUser#Run", func() error { return err })()
+
+	var username string
+	username, err = e.findUsername(m)
 	if err != nil {
 		return err
 	}
 
 	m.CDebugf("loginLoadUser: found username %q", username)
 
-	arg := libkb.NewLoadUserArgWithMetaContext(m).WithName(username).WithPublicKeyOptional()
+	// NOTE(max) 2018-05-09: ForceReload since older versions of cached users don't
+	// have salt stored, ad we need it in DeviceWrap to write out the config file.
+	arg := libkb.NewLoadUserArgWithMetaContext(m).WithName(username).WithPublicKeyOptional().WithForceReload()
 	user, err := libkb.LoadUser(arg)
 	if err != nil {
 		return err
@@ -100,17 +105,22 @@ func (e *loginLoadUser) findUsername(m libkb.MetaContext) (string, error) {
 
 	// looks like an email address
 	m.CDebugf("%q looks like an email address, must get login session to get user", e.usernameOrEmail)
+
 	// need to login with it in order to get the username
-	var username string
-	var afterLogin = func(lctx libkb.LoginContext) error {
-		username = lctx.LocalSession().GetUsername().String()
-		return nil
-	}
-	if err := m.G().LoginState().VerifyEmailAddress(m, e.usernameOrEmail, m.UIs().SecretUI, afterLogin); err != nil {
+	m = m.WithNewProvisionalLoginContext()
+
+	if err := libkb.PassphraseLoginPromptThenSecretStore(m, e.usernameOrEmail, 3, false /* failOnStoreError */); err != nil {
 		return "", err
 	}
 
+	username := m.LoginContext().GetUsername().String()
 	m.CDebugf("VerifyEmailAddress %q => %q", e.usernameOrEmail, username)
+
+	// Save the provisional login information in case we want this verified passphrase
+	// downstream. Note that it probably makes sense to create this provisional login
+	// a few stack frames up, and propagate to other engines, but for now, do
+	// the simple thing.
+	m = m.CommitProvisionalLogin()
 
 	return username, nil
 }

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -79,6 +79,17 @@ func (a *Account) GetUID() (ret keybase1.UID) {
 	return ret
 }
 
+func (a *Account) GetUsername() (ret NormalizedUsername) {
+	if a.localSession == nil {
+		return ret
+	}
+	if a.localSession.username == nil {
+		return ret
+	}
+	ret = *a.localSession.username
+	return ret
+}
+
 func (a *Account) GetDeviceID() (ret keybase1.DeviceID) {
 	if a.localSession != nil {
 		ret = a.localSession.GetDeviceID()

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -542,12 +542,6 @@ func (f JSONConfigFile) GetUsername() (ret NormalizedUsername) {
 	}
 	return ret
 }
-func (f JSONConfigFile) GetSalt() (ret []byte) {
-	if uc, _ := f.GetUserConfig(); uc != nil {
-		ret = uc.GetSalt()
-	}
-	return ret
-}
 func (f JSONConfigFile) GetUID() (ret keybase1.UID) {
 	if uc, _ := f.GetUserConfig(); uc != nil {
 		ret = uc.GetUID()

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -344,25 +344,6 @@ func (m MetaContext) SwitchUserToActiveDevice(n NormalizedUsername, ad *ActiveDe
 	return nil
 }
 
-// SetDeviceIDWithRegistration sets the DeviceID for a user's config section during
-// device registration. It atomically clears out the global ActiveDevice, since the ActiveDevice
-// should be nil if the deviceID for the current user is unset (as it was jus before the call).
-func (m MetaContext) SetDeviceIDWithinRegistration(d keybase1.DeviceID) error {
-	g := m.G()
-	g.switchUserMu.Lock()
-	defer g.switchUserMu.Unlock()
-	cw := g.Env.GetConfigWriter()
-	if cw == nil {
-		return NoConfigWriterError{}
-	}
-	err := cw.SetDeviceID(d)
-	if err != nil {
-		return err
-	}
-	g.ActiveDevice.Clear(nil)
-	return nil
-}
-
 // SetActiveDevice sets the active device to have the UID, deviceID, sigKey, encKey and deviceName
 // as specified, and does so while grabbing the global switchUser lock, since it should be sycnhronized
 // with attempts to switch the global logged in user. It does not, however, change the `current_user`

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1055,10 +1055,6 @@ func (e *Env) GetSecretKeyringTemplate() string {
 	)
 }
 
-func (e *Env) GetSalt() []byte {
-	return e.GetConfig().GetSalt()
-}
-
 func (e *Env) GetLocalRPCDebug() string {
 	return e.GetString(
 		func() string { return e.cmd.GetLocalRPCDebug() },

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -154,7 +154,6 @@ type ConfigReader interface {
 	GetProofCacheShortDur() (time.Duration, bool)
 	GetLinkCacheCleanDur() (time.Duration, bool)
 	GetNoPinentry() (bool, bool)
-	GetSalt() []byte
 	GetDeviceID() keybase1.DeviceID
 	GetDeviceIDForUsername(nu NormalizedUsername) keybase1.DeviceID
 	GetDeviceIDForUID(u keybase1.UID) keybase1.DeviceID

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -53,6 +53,7 @@ type LoginContext interface {
 
 	LocalSession() *Session
 	GetUID() keybase1.UID
+	GetUsername() NormalizedUsername
 	EnsureUsername(username NormalizedUsername)
 	SaveState(sessionID, csrf string, username NormalizedUsername, uid keybase1.UID, deviceID keybase1.DeviceID) error
 

--- a/go/libkb/provisional_login_context.go
+++ b/go/libkb/provisional_login_context.go
@@ -93,7 +93,9 @@ func (p *ProvisionalLoginContext) LocalSession() *Session {
 }
 func (p *ProvisionalLoginContext) GetUID() keybase1.UID {
 	return p.uid
-
+}
+func (p *ProvisionalLoginContext) GetUsername() NormalizedUsername {
+	return p.username
 }
 func (p *ProvisionalLoginContext) EnsureUsername(username NormalizedUsername) {
 }

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -4,6 +4,7 @@
 package libkb
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -109,6 +110,18 @@ func (u *User) GetNormalizedName() NormalizedUsername { return NewNormalizedUser
 func (u *User) GetName() string                       { return u.name }
 func (u *User) GetUID() keybase1.UID                  { return u.id }
 func (u *User) GetStatus() keybase1.StatusCode        { return u.status }
+
+func (u *User) GetSalt() (salt []byte, err error) {
+	saltHex, err := u.basics.AtKey("salt").GetString()
+	if err != nil {
+		return nil, err
+	}
+	salt, err = hex.DecodeString(saltHex)
+	if err != nil {
+		return nil, err
+	}
+	return salt, nil
+}
 
 func (u *User) GetIDVersion() (int64, error) {
 	return u.basics.AtKey("id_version").GetInt64()

--- a/go/libkb/userconfig.go
+++ b/go/libkb/userconfig.go
@@ -69,7 +69,6 @@ type UserConfig struct {
 
 func (u UserConfig) GetUID() keybase1.UID            { return u.importedID }
 func (u UserConfig) GetUsername() NormalizedUsername { return u.Name }
-func (u UserConfig) GetSalt() []byte                 { return u.importedSalt }
 func (u UserConfig) GetDeviceID() keybase1.DeviceID  { return u.importedDeviceID }
 func (u UserConfig) IsOneshot() bool                 { return u.isOneshot }
 


### PR DESCRIPTION
- as a side effect, redo the config-writing strategy in DeviceWrap, since that broke with these changes;
  - Just write the whole file in DeviceWrap, which required us to plumb salt through LoadUser
  - ForceReload since cached versions don't have salt