### PR TITLE
fix two bugs with NIST generation

### DIFF
--- a/go/libkb/nist.go
+++ b/go/libkb/nist.go
@@ -23,9 +23,9 @@ import (
 // we're more responsive when we come back from backgrounding, etc.
 //
 
-// If we're within 1 hour of expiration, generate a new NIST;
-const nistExpirationMargin = time.Hour
-const nistLifetime = 28 * time.Hour
+// If we're within 26 hours of expiration, generate a new NIST;
+const nistExpirationMargin = 26 * time.Hour // I.e., half of the lifetime
+const nistLifetime = 52 * time.Hour         // A little longer than 2 days.
 const nistSessionIDLength = 16
 const nistShortHashLen = 19
 
@@ -115,10 +115,15 @@ func (f *NISTFactory) NIST(ctx context.Context) (ret *NIST, err error) {
 	return f.nist, nil
 }
 
+func durationToSeconds(d time.Duration) int64 {
+	return int64(d / time.Second)
+}
+
 func (n *NIST) IsStillValid() (bool, time.Duration) {
 	n.RLock()
 	defer n.RUnlock()
-	diff := n.expiresAt.Sub(n.G().Clock().Now()) - nistExpirationMargin
+	now := ForceWallClock(n.G().Clock().Now())
+	diff := n.expiresAt.Sub(now) - nistExpirationMargin
 	return (diff > 0), diff
 }
 
@@ -242,7 +247,7 @@ func (n *NIST) generate(ctx context.Context, uid keybase1.UID, deviceID keybase1
 		Hostname:  CanonicalHost,
 		UID:       uid.ToBytes(),
 		Generated: generated.Unix(),
-		Lifetime:  nistLifetime.Nanoseconds() / 1000000000,
+		Lifetime:  durationToSeconds(nistLifetime),
 		KID:       key.GetBinaryKID(),
 	}
 	payload.DeviceID, err = hex.DecodeString(string(deviceID))
@@ -287,7 +292,7 @@ func (n *NIST) generate(ctx context.Context, uid keybase1.UID, deviceID keybase1
 
 	n.long = longTmp
 	n.short = shortTmp
-	n.expiresAt = expires
+	n.expiresAt = ForceWallClock(expires)
 
 	return nil
 }

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -857,3 +857,9 @@ func NoiseXOR(secret [32]byte, noise NoiseBytes) ([]byte, error) {
 
 	return xor, nil
 }
+
+// ForceWallClock takes a multi-personality Go time and converts it to
+// a regular old WallClock time.
+func ForceWallClock(t time.Time) time.Time {
+	return t.Round(0)
+}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -731,7 +731,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 		if _, ok := err.(libkb.BadSessionError); ok {
 			g.chatLog.Debug(ctx, "bad session from SyncAll(): forcing session check on next attempt")
 			g.forceSessionCheck = true
-			nist.DidFail()
+			nist.MarkFailure()
 		}
 		return fmt.Errorf("error running SyncAll: %s", err.Error())
 	}


### PR DESCRIPTION
- When computing IsStillValid, don't use monotonic clock, use wallclock, since monotonic can be totally wrong if the computer went to sleep for a while
- Actually nuke the session token on failure, rather than just asking if it was nuked and throwing away the answer :(