### PR TITLE
Fix CI Flake [CORE-7841]

### DIFF
--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -254,8 +254,6 @@ func (e *RevokeEngine) Run(m libkb.MetaContext) error {
 	payload["sigs"] = sigsList
 	payload["downgrade_lease_id"] = lease.LeaseID
 
-	m.CDebugf("RevokeEngine#Run pukBoxes:%v pukPrev:%v for generation %v",
-		len(pukBoxes), pukPrev != nil, newPukGeneration)
 	if addingNewPUK {
 		libkb.AddPerUserKeyServerArg(payload, newPukGeneration, pukBoxes, pukPrev)
 	}
@@ -290,6 +288,8 @@ func (e *RevokeEngine) Run(m libkb.MetaContext) error {
 			m.CWarningf("skipping userEK publishing, because there are no valid deviceEKs")
 		}
 	}
+	m.CDebugf("RevokeEngine#Run pukBoxes:%v pukPrev:%v for generation %v, userEKBox: %v",
+		len(pukBoxes), pukPrev != nil, newPukGeneration, myUserEKBox != nil)
 
 	_, err = m.G().API.PostJSON(libkb.APIArg{
 		Endpoint:    "key/multi",

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -299,35 +299,12 @@ func (e *EKLib) PurgeTeamEKGenCache(teamID keybase1.TeamID, generation keybase1.
 }
 
 func (e *EKLib) GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (teamEK keybase1.TeamEk, err error) {
-	// There are plenty of race conditions where the PTK or teamEK or
-	// membership list can change out from under us while we're in the middle
-	// of posting a new key, causing the post to fail. Detect these conditions
-	// and retry.
 	defer e.G().CTrace(ctx, "GetOrCreateLatestTeamEK", func() error { return err })()
-	tries := 0
-	maxTries := 3
-	knownRaceConditions := []keybase1.StatusCode{
-		keybase1.StatusCode_SCSigWrongKey,
-		keybase1.StatusCode_SCSigOldSeqno,
-		keybase1.StatusCode_SCEphemeralKeyBadGeneration,
-		keybase1.StatusCode_SCEphemeralKeyUnexpectedBox,
-		keybase1.StatusCode_SCEphemeralKeyMissingBox,
-		keybase1.StatusCode_SCEphemeralKeyWrongNumberOfKeys,
-	}
-	for {
-		tries++
+	err = teamEKRetryWrapper(ctx, e.G(), func() error {
 		teamEK, err = e.getOrCreateLatestTeamEKInner(ctx, teamID)
-		retryableError := false
-		for _, code := range knownRaceConditions {
-			if libkb.IsAppStatusCode(err, code) {
-				e.G().Log.CDebugf(ctx, "GetOrCreateLatestTeamEK found a retryable error on try %d: %s", tries, err)
-				retryableError = true
-			}
-		}
-		if err == nil || !retryableError || tries >= maxTries {
-			return teamEK, err
-		}
-	}
+		return err
+	})
+	return teamEK, err
 }
 
 func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase1.TeamID) (teamEK keybase1.TeamEk, err error) {

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -166,6 +166,7 @@ func publishNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybas
 }
 
 func ForcePublishNewTeamEKForTesting(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEkMetadata, err error) {
+	defer g.CTrace(ctx, "ForcePublishNewTeamEKForTesting", func() error { return err })()
 	return publishNewTeamEK(ctx, g, teamID, merkleRoot)
 }
 

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -59,6 +59,8 @@ func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxe
 // userEK with the new PUK to upload both together. This helper covers the
 // steps common to both cases.
 func prepareNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot, pukSigning *libkb.NaclSigningKeyPair) (sig string, boxes []keybase1.UserEkBoxMetadata, newMetadata keybase1.UserEkMetadata, myBox *keybase1.UserEkBoxed, err error) {
+	defer g.CTrace(ctx, "prepareNewUserEK", func() error { return err })()
+
 	seed, err := newUserEphemeralSeed()
 	if err != nil {
 		return "", nil, newMetadata, nil, err
@@ -163,6 +165,7 @@ func publishNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot li
 }
 
 func ForcePublishNewUserEKForTesting(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (metadata keybase1.UserEkMetadata, err error) {
+	defer g.CTrace(ctx, "ForcePublishNewUserEKForTesting", func() error { return err })()
 	return publishNewUserEK(ctx, g, merkleRoot)
 }
 

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -254,9 +254,10 @@ func TestNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 
 	// Revoke it.
 	revokeEngine := engine.NewRevokeDeviceEngine(alice.tc.G, engine.RevokeDeviceEngineArgs{
-		ID:        newDevice.deviceKey.DeviceID,
-		ForceSelf: true,
-		ForceLast: false,
+		ID:                   newDevice.deviceKey.DeviceID,
+		ForceSelf:            true,
+		ForceLast:            false,
+		SkipUserEKForTesting: true,
 	})
 	uis := libkb.UIs{
 		LogUI:    alice.tc.G.Log,

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -254,9 +254,10 @@ func TestNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 
 	// Revoke it.
 	revokeEngine := engine.NewRevokeDeviceEngine(alice.tc.G, engine.RevokeDeviceEngineArgs{
-		ID:                   newDevice.deviceKey.DeviceID,
-		ForceSelf:            true,
-		ForceLast:            false,
+		ID:        newDevice.deviceKey.DeviceID,
+		ForceSelf: true,
+		ForceLast: false,
+		// We don't need a UserEK here since we force generate it below
 		SkipUserEKForTesting: true,
 	})
 	uis := libkb.UIs{


### PR DESCRIPTION
This error has been popping up in CI, i think there's a some race between the revoke trying to make new keys and us forcing a new key to be made but will probably have to dig deeper if this doesn't fix
```
	ephemeral_test.go:278: 
			Error Trace:	ephemeral_test.go:278
			Error:      	Received unexpected error:
			            	Error: ER_DUP_ENTRY: Duplicate entry '49a6cfd87a4c009540597442be720424-2' for key 'PRIMARY' (error 505)
			Test:       	TestNewUserEKAndTeamEKAfterRevokes
	test_logger.go:56: TEST FAILED: TestNewUserEKAndTeamEKAfterRevokes
```

cc @oconnor663 @maxtaco 