### PR TITLE
Change PaymentSummary to be a variant

### DIFF
--- a/go/client/cmd_wallet_history.go
+++ b/go/client/cmd_wallet_history.go
@@ -76,7 +76,12 @@ func (c *cmdWalletHistory) Run() (err error) {
 	// `payments` is sorted most recent first.
 	// Print most recent at the bottom.
 	for i := len(payments) - 1; i >= 0; i-- {
-		printPayment(c.G(), payments[i], c.verbose, dui)
+		p := payments[i]
+		if p.Payment != nil {
+			printPayment(c.G(), *p.Payment, c.verbose, dui)
+		} else {
+			line(ColorString(c.G(), "red", "error in payment: %v", p.Err))
+		}
 		line("")
 	}
 	if len(payments) == 0 {

--- a/go/client/color.go
+++ b/go/client/color.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"fmt"
+
 	"github.com/keybase/client/go/libkb"
 )
 
@@ -145,6 +146,6 @@ func ColorBytes(g *libkb.GlobalContext, which string, text []byte) []byte {
 	}
 }
 
-func ColorString(g *libkb.GlobalContext, which, text string) string {
-	return string(ColorBytes(g, which, []byte(text)))
+func ColorString(g *libkb.GlobalContext, which, format string, args ...interface{}) string {
+	return string(ColorBytes(g, which, []byte(fmt.Sprintf(format, args...))))
 }

--- a/go/client/stellar_common.go
+++ b/go/client/stellar_common.go
@@ -23,17 +23,25 @@ func printPayment(g *libkb.GlobalContext, p stellar1.PaymentCLILocal, verbose bo
 	}
 	line("%v", ColorString(g, "green", amount))
 	// Show sender and recipient. Prefer keybase form, fall back to stellar abbreviations.
-	from := p.FromStellar.LossyAbbreviation()
-	to := p.ToStellar.LossyAbbreviation()
-	if p.FromUsername != nil {
-		from = *p.FromUsername
-	}
-	if p.ToUsername != nil {
-		to = *p.ToUsername
-	}
 	showedAbbreviation := true
-	if p.FromUsername != nil && p.ToUsername != nil {
-		showedAbbreviation = false
+	var from string
+	switch {
+	case p.FromUsername != nil:
+		from = *p.FromUsername
+	default:
+		from = p.FromStellar.LossyAbbreviation()
+		showedAbbreviation = true
+	}
+	var to string
+	switch {
+	case p.ToUsername != nil:
+		to = *p.ToUsername
+	case p.ToStellar != nil:
+		to = p.ToStellar.LossyAbbreviation()
+		showedAbbreviation = true
+	default:
+		// This should never happen
+		line("%v", ColorString(g, "red", "missing recipient info"))
 	}
 	line("%v -> %v", from, to)
 	// If an abbreviation was shown, show the full addresses
@@ -48,11 +56,17 @@ func printPayment(g *libkb.GlobalContext, p stellar1.PaymentCLILocal, verbose bo
 		line("Note Error: %v", ColorString(g, "red", p.NoteErr))
 	}
 	if verbose {
-		line("Transaction Hash: %v", p.StellarTxID)
+		line("Transaction Hash: %v", p.TxID)
 	}
-	if len(p.Status) > 0 && p.Status != "completed" {
-		line("Status: %v", ColorString(g, "red", p.Status))
-		line("        %v", ColorString(g, "red", p.StatusDetail))
+	switch p.Status {
+	case "", "completed":
+	default:
+		color := "red"
+		if p.Status == "claimable" {
+			color = "yellow"
+		}
+		line("Status: %v", ColorString(g, color, p.Status))
+		line("        %v", ColorString(g, color, p.StatusDetail))
 	}
 }
 

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -8,8 +8,26 @@ import (
 	context "golang.org/x/net/context"
 )
 
+type PaymentCLIOptionLocal struct {
+	Payment *PaymentCLILocal `codec:"payment,omitempty" json:"payment,omitempty"`
+	Err     string           `codec:"err" json:"err"`
+}
+
+func (o PaymentCLIOptionLocal) DeepCopy() PaymentCLIOptionLocal {
+	return PaymentCLIOptionLocal{
+		Payment: (func(x *PaymentCLILocal) *PaymentCLILocal {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Payment),
+		Err: o.Err,
+	}
+}
+
 type PaymentCLILocal struct {
-	StellarTxID     TransactionID `codec:"stellarTxID" json:"stellarTxID"`
+	TxID            TransactionID `codec:"txID" json:"txID"`
 	Time            TimeMs        `codec:"time" json:"time"`
 	Status          string        `codec:"status" json:"status"`
 	StatusDetail    string        `codec:"statusDetail" json:"statusDetail"`
@@ -18,7 +36,7 @@ type PaymentCLILocal struct {
 	DisplayAmount   *string       `codec:"displayAmount,omitempty" json:"displayAmount,omitempty"`
 	DisplayCurrency *string       `codec:"displayCurrency,omitempty" json:"displayCurrency,omitempty"`
 	FromStellar     AccountID     `codec:"fromStellar" json:"fromStellar"`
-	ToStellar       AccountID     `codec:"toStellar" json:"toStellar"`
+	ToStellar       *AccountID    `codec:"toStellar,omitempty" json:"toStellar,omitempty"`
 	FromUsername    *string       `codec:"fromUsername,omitempty" json:"fromUsername,omitempty"`
 	ToUsername      *string       `codec:"toUsername,omitempty" json:"toUsername,omitempty"`
 	Note            string        `codec:"note" json:"note"`
@@ -27,7 +45,7 @@ type PaymentCLILocal struct {
 
 func (o PaymentCLILocal) DeepCopy() PaymentCLILocal {
 	return PaymentCLILocal{
-		StellarTxID:  o.StellarTxID.DeepCopy(),
+		TxID:         o.TxID.DeepCopy(),
 		Time:         o.Time.DeepCopy(),
 		Status:       o.Status,
 		StatusDetail: o.StatusDetail,
@@ -48,7 +66,13 @@ func (o PaymentCLILocal) DeepCopy() PaymentCLILocal {
 			return &tmp
 		})(o.DisplayCurrency),
 		FromStellar: o.FromStellar.DeepCopy(),
-		ToStellar:   o.ToStellar.DeepCopy(),
+		ToStellar: (func(x *AccountID) *AccountID {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.ToStellar),
 		FromUsername: (func(x *string) *string {
 			if x == nil {
 				return nil
@@ -163,7 +187,7 @@ type FormatLocalCurrencyStringArg struct {
 type LocalInterface interface {
 	BalancesLocal(context.Context, AccountID) ([]Balance, error)
 	SendLocal(context.Context, SendLocalArg) (PaymentResult, error)
-	RecentPaymentsCLILocal(context.Context, *AccountID) ([]PaymentCLILocal, error)
+	RecentPaymentsCLILocal(context.Context, *AccountID) ([]PaymentCLIOptionLocal, error)
 	PaymentDetailCLILocal(context.Context, string) (PaymentCLILocal, error)
 	WalletInitLocal(context.Context) error
 	WalletDumpLocal(context.Context) (Bundle, error)
@@ -404,7 +428,7 @@ func (c LocalClient) SendLocal(ctx context.Context, __arg SendLocalArg) (res Pay
 	return
 }
 
-func (c LocalClient) RecentPaymentsCLILocal(ctx context.Context, accountID *AccountID) (res []PaymentCLILocal, err error) {
+func (c LocalClient) RecentPaymentsCLILocal(ctx context.Context, accountID *AccountID) (res []PaymentCLIOptionLocal, err error) {
 	__arg := RecentPaymentsCLILocalArg{AccountID: accountID}
 	err = c.Cli.Call(ctx, "stellar.1.local.recentPaymentsCLILocal", []interface{}{__arg}, &res)
 	return

--- a/go/protocol/stellar1/remote.go
+++ b/go/protocol/stellar1/remote.go
@@ -4,6 +4,7 @@
 package stellar1
 
 import (
+	"errors"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
@@ -81,63 +82,195 @@ func (o RelayClaimPost) DeepCopy() RelayClaimPost {
 	}
 }
 
+type PaymentSummaryType int
+
+const (
+	PaymentSummaryType_NONE    PaymentSummaryType = 0
+	PaymentSummaryType_STELLAR PaymentSummaryType = 1
+	PaymentSummaryType_DIRECT  PaymentSummaryType = 2
+	PaymentSummaryType_RELAY   PaymentSummaryType = 3
+)
+
+func (o PaymentSummaryType) DeepCopy() PaymentSummaryType { return o }
+
+var PaymentSummaryTypeMap = map[string]PaymentSummaryType{
+	"NONE":    0,
+	"STELLAR": 1,
+	"DIRECT":  2,
+	"RELAY":   3,
+}
+
+var PaymentSummaryTypeRevMap = map[PaymentSummaryType]string{
+	0: "NONE",
+	1: "STELLAR",
+	2: "DIRECT",
+	3: "RELAY",
+}
+
+func (e PaymentSummaryType) String() string {
+	if v, ok := PaymentSummaryTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type PaymentSummary struct {
-	Stellar     *PaymentSummaryStellar `codec:"stellar,omitempty" json:"stellar,omitempty"`
-	Keybase     *PaymentSummaryKeybase `codec:"keybase,omitempty" json:"keybase,omitempty"`
-	StellarTxID TransactionID          `codec:"stellarTxID" json:"stellarTxID"`
-	From        AccountID              `codec:"from" json:"from"`
-	To          AccountID              `codec:"to" json:"to"`
-	Amount      string                 `codec:"amount" json:"amount"`
-	Asset       Asset                  `codec:"asset" json:"asset"`
+	Typ__     PaymentSummaryType     `codec:"typ" json:"typ"`
+	Stellar__ *PaymentSummaryStellar `codec:"stellar,omitempty" json:"stellar,omitempty"`
+	Direct__  *PaymentSummaryDirect  `codec:"direct,omitempty" json:"direct,omitempty"`
+	Relay__   *PaymentSummaryRelay   `codec:"relay,omitempty" json:"relay,omitempty"`
+}
+
+func (o *PaymentSummary) Typ() (ret PaymentSummaryType, err error) {
+	switch o.Typ__ {
+	case PaymentSummaryType_STELLAR:
+		if o.Stellar__ == nil {
+			err = errors.New("unexpected nil value for Stellar__")
+			return ret, err
+		}
+	case PaymentSummaryType_DIRECT:
+		if o.Direct__ == nil {
+			err = errors.New("unexpected nil value for Direct__")
+			return ret, err
+		}
+	case PaymentSummaryType_RELAY:
+		if o.Relay__ == nil {
+			err = errors.New("unexpected nil value for Relay__")
+			return ret, err
+		}
+	}
+	return o.Typ__, nil
+}
+
+func (o PaymentSummary) Stellar() (res PaymentSummaryStellar) {
+	if o.Typ__ != PaymentSummaryType_STELLAR {
+		panic("wrong case accessed")
+	}
+	if o.Stellar__ == nil {
+		return
+	}
+	return *o.Stellar__
+}
+
+func (o PaymentSummary) Direct() (res PaymentSummaryDirect) {
+	if o.Typ__ != PaymentSummaryType_DIRECT {
+		panic("wrong case accessed")
+	}
+	if o.Direct__ == nil {
+		return
+	}
+	return *o.Direct__
+}
+
+func (o PaymentSummary) Relay() (res PaymentSummaryRelay) {
+	if o.Typ__ != PaymentSummaryType_RELAY {
+		panic("wrong case accessed")
+	}
+	if o.Relay__ == nil {
+		return
+	}
+	return *o.Relay__
+}
+
+func NewPaymentSummaryWithStellar(v PaymentSummaryStellar) PaymentSummary {
+	return PaymentSummary{
+		Typ__:     PaymentSummaryType_STELLAR,
+		Stellar__: &v,
+	}
+}
+
+func NewPaymentSummaryWithDirect(v PaymentSummaryDirect) PaymentSummary {
+	return PaymentSummary{
+		Typ__:    PaymentSummaryType_DIRECT,
+		Direct__: &v,
+	}
+}
+
+func NewPaymentSummaryWithRelay(v PaymentSummaryRelay) PaymentSummary {
+	return PaymentSummary{
+		Typ__:   PaymentSummaryType_RELAY,
+		Relay__: &v,
+	}
 }
 
 func (o PaymentSummary) DeepCopy() PaymentSummary {
 	return PaymentSummary{
-		Stellar: (func(x *PaymentSummaryStellar) *PaymentSummaryStellar {
+		Typ__: o.Typ__.DeepCopy(),
+		Stellar__: (func(x *PaymentSummaryStellar) *PaymentSummaryStellar {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
-		})(o.Stellar),
-		Keybase: (func(x *PaymentSummaryKeybase) *PaymentSummaryKeybase {
+		})(o.Stellar__),
+		Direct__: (func(x *PaymentSummaryDirect) *PaymentSummaryDirect {
 			if x == nil {
 				return nil
 			}
 			tmp := (*x).DeepCopy()
 			return &tmp
-		})(o.Keybase),
-		StellarTxID: o.StellarTxID.DeepCopy(),
+		})(o.Direct__),
+		Relay__: (func(x *PaymentSummaryRelay) *PaymentSummaryRelay {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Relay__),
+	}
+}
+
+type PaymentSummaryStellar struct {
+	TxID        TransactionID `codec:"txID" json:"txID"`
+	From        AccountID     `codec:"from" json:"from"`
+	To          AccountID     `codec:"to" json:"to"`
+	Amount      string        `codec:"amount" json:"amount"`
+	Asset       Asset         `codec:"asset" json:"asset"`
+	OperationID uint64        `codec:"operationID" json:"operationID"`
+	Ctime       TimeMs        `codec:"ctime" json:"ctime"`
+}
+
+func (o PaymentSummaryStellar) DeepCopy() PaymentSummaryStellar {
+	return PaymentSummaryStellar{
+		TxID:        o.TxID.DeepCopy(),
 		From:        o.From.DeepCopy(),
 		To:          o.To.DeepCopy(),
 		Amount:      o.Amount,
 		Asset:       o.Asset.DeepCopy(),
+		OperationID: o.OperationID,
+		Ctime:       o.Ctime.DeepCopy(),
 	}
 }
 
-type PaymentSummaryKeybase struct {
+type PaymentSummaryDirect struct {
 	KbTxID          KeybaseTransactionID  `codec:"kbTxID" json:"kbTxID"`
-	Status          TransactionStatus     `codec:"status" json:"status"`
-	SubmitErrMsg    string                `codec:"submitErrMsg" json:"submitErrMsg"`
-	Ctime           TimeMs                `codec:"ctime" json:"ctime"`
-	Rtime           TimeMs                `codec:"rtime" json:"rtime"`
+	TxID            TransactionID         `codec:"txID" json:"txID"`
+	TxStatus        TransactionStatus     `codec:"txStatus" json:"txStatus"`
+	TxErrMsg        string                `codec:"txErrMsg" json:"txErrMsg"`
+	FromStellar     AccountID             `codec:"fromStellar" json:"fromStellar"`
 	From            keybase1.UserVersion  `codec:"from" json:"from"`
 	FromDeviceID    keybase1.DeviceID     `codec:"fromDeviceID" json:"fromDeviceID"`
+	ToStellar       AccountID             `codec:"toStellar" json:"toStellar"`
 	To              *keybase1.UserVersion `codec:"to,omitempty" json:"to,omitempty"`
+	Amount          string                `codec:"amount" json:"amount"`
+	Asset           Asset                 `codec:"asset" json:"asset"`
 	DisplayAmount   *string               `codec:"displayAmount,omitempty" json:"displayAmount,omitempty"`
 	DisplayCurrency *string               `codec:"displayCurrency,omitempty" json:"displayCurrency,omitempty"`
 	NoteB64         string                `codec:"noteB64" json:"noteB64"`
+	Ctime           TimeMs                `codec:"ctime" json:"ctime"`
+	Rtime           TimeMs                `codec:"rtime" json:"rtime"`
 }
 
-func (o PaymentSummaryKeybase) DeepCopy() PaymentSummaryKeybase {
-	return PaymentSummaryKeybase{
+func (o PaymentSummaryDirect) DeepCopy() PaymentSummaryDirect {
+	return PaymentSummaryDirect{
 		KbTxID:       o.KbTxID.DeepCopy(),
-		Status:       o.Status.DeepCopy(),
-		SubmitErrMsg: o.SubmitErrMsg,
-		Ctime:        o.Ctime.DeepCopy(),
-		Rtime:        o.Rtime.DeepCopy(),
+		TxID:         o.TxID.DeepCopy(),
+		TxStatus:     o.TxStatus.DeepCopy(),
+		TxErrMsg:     o.TxErrMsg,
+		FromStellar:  o.FromStellar.DeepCopy(),
 		From:         o.From.DeepCopy(),
 		FromDeviceID: o.FromDeviceID.DeepCopy(),
+		ToStellar:    o.ToStellar.DeepCopy(),
 		To: (func(x *keybase1.UserVersion) *keybase1.UserVersion {
 			if x == nil {
 				return nil
@@ -145,6 +278,8 @@ func (o PaymentSummaryKeybase) DeepCopy() PaymentSummaryKeybase {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.To),
+		Amount: o.Amount,
+		Asset:  o.Asset.DeepCopy(),
 		DisplayAmount: (func(x *string) *string {
 			if x == nil {
 				return nil
@@ -160,18 +295,94 @@ func (o PaymentSummaryKeybase) DeepCopy() PaymentSummaryKeybase {
 			return &tmp
 		})(o.DisplayCurrency),
 		NoteB64: o.NoteB64,
+		Ctime:   o.Ctime.DeepCopy(),
+		Rtime:   o.Rtime.DeepCopy(),
 	}
 }
 
-type PaymentSummaryStellar struct {
-	OperationID uint64 `codec:"operationID" json:"operationID"`
-	Ctime       TimeMs `codec:"ctime" json:"ctime"`
+type PaymentSummaryRelay struct {
+	KbTxID          KeybaseTransactionID  `codec:"kbTxID" json:"kbTxID"`
+	TxID            TransactionID         `codec:"txID" json:"txID"`
+	TxStatus        TransactionStatus     `codec:"txStatus" json:"txStatus"`
+	TxErrMsg        string                `codec:"txErrMsg" json:"txErrMsg"`
+	FromStellar     AccountID             `codec:"fromStellar" json:"fromStellar"`
+	From            keybase1.UserVersion  `codec:"from" json:"from"`
+	FromDeviceID    keybase1.DeviceID     `codec:"fromDeviceID" json:"fromDeviceID"`
+	To              *keybase1.UserVersion `codec:"to,omitempty" json:"to,omitempty"`
+	RelayAccount    AccountID             `codec:"relayAccount" json:"relayAccount"`
+	Amount          string                `codec:"amount" json:"amount"`
+	DisplayAmount   *string               `codec:"displayAmount,omitempty" json:"displayAmount,omitempty"`
+	DisplayCurrency *string               `codec:"displayCurrency,omitempty" json:"displayCurrency,omitempty"`
+	Ctime           TimeMs                `codec:"ctime" json:"ctime"`
+	Rtime           TimeMs                `codec:"rtime" json:"rtime"`
+	BoxB64          string                `codec:"boxB64" json:"boxB64"`
+	TeamID          keybase1.TeamID       `codec:"teamID" json:"teamID"`
+	Claim           *ClaimSummary         `codec:"claim,omitempty" json:"claim,omitempty"`
 }
 
-func (o PaymentSummaryStellar) DeepCopy() PaymentSummaryStellar {
-	return PaymentSummaryStellar{
-		OperationID: o.OperationID,
-		Ctime:       o.Ctime.DeepCopy(),
+func (o PaymentSummaryRelay) DeepCopy() PaymentSummaryRelay {
+	return PaymentSummaryRelay{
+		KbTxID:       o.KbTxID.DeepCopy(),
+		TxID:         o.TxID.DeepCopy(),
+		TxStatus:     o.TxStatus.DeepCopy(),
+		TxErrMsg:     o.TxErrMsg,
+		FromStellar:  o.FromStellar.DeepCopy(),
+		From:         o.From.DeepCopy(),
+		FromDeviceID: o.FromDeviceID.DeepCopy(),
+		To: (func(x *keybase1.UserVersion) *keybase1.UserVersion {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.To),
+		RelayAccount: o.RelayAccount.DeepCopy(),
+		Amount:       o.Amount,
+		DisplayAmount: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.DisplayAmount),
+		DisplayCurrency: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.DisplayCurrency),
+		Ctime:  o.Ctime.DeepCopy(),
+		Rtime:  o.Rtime.DeepCopy(),
+		BoxB64: o.BoxB64,
+		TeamID: o.TeamID.DeepCopy(),
+		Claim: (func(x *ClaimSummary) *ClaimSummary {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Claim),
+	}
+}
+
+type ClaimSummary struct {
+	TxID      TransactionID        `codec:"txID" json:"txID"`
+	TxStatus  TransactionStatus    `codec:"txStatus" json:"txStatus"`
+	TxErrMsg  string               `codec:"txErrMsg" json:"txErrMsg"`
+	Dir       RelayDirection       `codec:"dir" json:"dir"`
+	ToStellar AccountID            `codec:"toStellar" json:"toStellar"`
+	To        keybase1.UserVersion `codec:"to" json:"to"`
+}
+
+func (o ClaimSummary) DeepCopy() ClaimSummary {
+	return ClaimSummary{
+		TxID:      o.TxID.DeepCopy(),
+		TxStatus:  o.TxStatus.DeepCopy(),
+		TxErrMsg:  o.TxErrMsg,
+		Dir:       o.Dir.DeepCopy(),
+		ToStellar: o.ToStellar.DeepCopy(),
+		To:        o.To.DeepCopy(),
 	}
 }
 

--- a/go/stellar/relay.go
+++ b/go/stellar/relay.go
@@ -114,6 +114,9 @@ func CreateRelayTransfer(in RelayPaymentInput) (res RelayPaymentOutput, err erro
 		Sk:        stellar1.SecretKey(relayKp.Seed()),
 		Note:      in.Note,
 	}, in.EncryptFor)
+	if err != nil {
+		return res, err
+	}
 	pack, err := libkb.MsgpackEncode(enc)
 	if err != nil {
 		return res, err

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -119,7 +119,7 @@ func (s *Server) SendLocal(ctx context.Context, arg stellar1.SendLocalArg) (stel
 	return stellar.SendPayment(ctx, s.G(), s.remoter, stellar.RecipientInput(arg.Recipient), arg.Amount, arg.Note)
 }
 
-func (s *Server) RecentPaymentsCLILocal(ctx context.Context, accountID *stellar1.AccountID) (res []stellar1.PaymentCLILocal, err error) {
+func (s *Server) RecentPaymentsCLILocal(ctx context.Context, accountID *stellar1.AccountID) (res []stellar1.PaymentCLIOptionLocal, err error) {
 	ctx = s.logTag(ctx)
 	defer s.G().CTraceTimed(ctx, "RecentPaymentsCLILocal", func() error { return err })()
 	if err = s.assertLoggedIn(ctx); err != nil {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -424,6 +424,7 @@ func TestRelayTransferInnards(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, err = libkb.ParseStellarAccountID(out.RelayAccountID.String())
+	require.NoError(t, err)
 	require.True(t, len(out.FundTx.Signed) > 100)
 
 	t.Logf("decrypt")

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -6,8 +6,13 @@ protocol local {
 
   PaymentResult sendLocal(string recipient, string amount, Asset asset, string note);
 
+  record PaymentCLIOptionLocal {
+    // Pointer or error
+    union { null, PaymentCLILocal } payment;
+    string err;
+  }
   record PaymentCLILocal {
-    TransactionID stellarTxID;
+    TransactionID txID; // For relay payments, the funding tx.
     TimeMs time;
     string status;
     string statusDetail;
@@ -17,13 +22,13 @@ protocol local {
     union { null, string } displayCurrency;
 
     AccountID fromStellar;
-    AccountID toStellar;
+    union { null, AccountID } toStellar;
     union { null, string } fromUsername;
     union { null, string } toUsername;
     string note;
     string noteErr;
   }
-  array<PaymentCLILocal> recentPaymentsCLILocal(union { null, AccountID } accountID);
+  array<PaymentCLIOptionLocal> recentPaymentsCLILocal(union { null, AccountID } accountID);
 
   // txID can be either a keybase or stellar transaction ID.
   PaymentCLILocal paymentDetailCLILocal(string txID);

--- a/protocol/avdl/stellar1/remote.avdl
+++ b/protocol/avdl/stellar1/remote.avdl
@@ -31,36 +31,80 @@ protocol remote {
     string signedTransaction; // Claim or yank tx
   }
 
-  record PaymentSummary {
-    // One or the other or both.
-    union { null, PaymentSummaryStellar } stellar; // Info from stellar network
-    union { null, PaymentSummaryKeybase } keybase; // Info from keybase storage
-
-    // Common values
-    TransactionID stellarTxID;
-    AccountID from;
-    AccountID to;
-    string amount; // amount of asset transfered
-    Asset asset;
+  enum PaymentSummaryType {
+    NONE_0,
+    STELLAR_1,
+    DIRECT_2,
+    RELAY_3
   }
 
-  record PaymentSummaryKeybase {
+  variant PaymentSummary switch (PaymentSummaryType typ) {
+    case STELLAR: PaymentSummaryStellar; // The only record of this tx is from horizon
+    case DIRECT: PaymentSummaryDirect;
+    case RELAY: PaymentSummaryRelay;
+  }
+
+  // Info from horizon
+  record PaymentSummaryStellar {
+    TransactionID txID;
+    AccountID from;
+    AccountID to;
+    string amount; // amount of asset
+    Asset asset;
+    uint64 operationID;
+    TimeMs ctime; // time on the network
+  }
+
+  record PaymentSummaryDirect {
     KeybaseTransactionID kbTxID;
-    TransactionStatus status;
-    string submitErrMsg;
-    TimeMs ctime;
-    TimeMs rtime; // time of last status update
+    TransactionID txID;
+    TransactionStatus txStatus;
+    string txErrMsg;
+    AccountID fromStellar;
     keybase1.UserVersion from;
     keybase1.DeviceID fromDeviceID;
+    AccountID toStellar;
     union { null, keybase1.UserVersion } to;
+    string amount; // amount of asset
+    Asset asset;
     union { null, string } displayAmount;
     union { null, string } displayCurrency;
     string noteB64; // b64-encoded EncryptedNote or empty string.
+    TimeMs ctime; // ctime in keybase db
+    TimeMs rtime; // time of last status update
   }
 
-  record PaymentSummaryStellar {
-    uint64 operationID;
-    TimeMs ctime;
+  record PaymentSummaryRelay {
+    KeybaseTransactionID kbTxID;
+
+    // Funding tx info.
+    TransactionID txID;
+    TransactionStatus txStatus;
+    string txErrMsg;
+
+    AccountID fromStellar;
+    keybase1.UserVersion from;
+    keybase1.DeviceID fromDeviceID;
+    union { null, keybase1.UserVersion } to;
+    AccountID relayAccount;
+    string amount; // amount of XLM
+    union { null, string } displayAmount;
+    union { null, string } displayCurrency;
+    TimeMs ctime; // ctime in keybase db
+    TimeMs rtime; // time of last status update of fund tx
+    string boxB64; // b64-encoded EncryptedRelaySecret
+    keybase1.TeamID teamID; // Impteam ID
+    // Summary of the most relevant claim. Either the successful one or latest pending.
+    union { null, ClaimSummary } claim;
+  }
+
+  record ClaimSummary {
+    TransactionID txID;
+    TransactionStatus txStatus;
+    string txErrMsg;
+    RelayDirection dir;
+    AccountID toStellar;
+    keybase1.UserVersion to; // who claimed it
   }
 
   array<Balance> balances(keybase1.UserVersion caller, AccountID accountID);

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -9,11 +9,28 @@
   "types": [
     {
       "type": "record",
+      "name": "PaymentCLIOptionLocal",
+      "fields": [
+        {
+          "type": [
+            null,
+            "PaymentCLILocal"
+          ],
+          "name": "payment"
+        },
+        {
+          "type": "string",
+          "name": "err"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "PaymentCLILocal",
       "fields": [
         {
           "type": "TransactionID",
-          "name": "stellarTxID"
+          "name": "txID"
         },
         {
           "type": "TimeMs",
@@ -54,7 +71,10 @@
           "name": "fromStellar"
         },
         {
-          "type": "AccountID",
+          "type": [
+            null,
+            "AccountID"
+          ],
           "name": "toStellar"
         },
         {
@@ -160,7 +180,7 @@
       ],
       "response": {
         "type": "array",
-        "items": "PaymentCLILocal"
+        "items": "PaymentCLIOptionLocal"
       }
     },
     "paymentDetailCLILocal": {

--- a/protocol/json/stellar1/remote.json
+++ b/protocol/json/stellar1/remote.json
@@ -109,26 +109,53 @@
       ]
     },
     {
-      "type": "record",
+      "type": "enum",
+      "name": "PaymentSummaryType",
+      "symbols": [
+        "NONE_0",
+        "STELLAR_1",
+        "DIRECT_2",
+        "RELAY_3"
+      ]
+    },
+    {
+      "type": "variant",
       "name": "PaymentSummary",
+      "switch": {
+        "type": "PaymentSummaryType",
+        "name": "typ"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "STELLAR",
+            "def": false
+          },
+          "body": "PaymentSummaryStellar"
+        },
+        {
+          "label": {
+            "name": "DIRECT",
+            "def": false
+          },
+          "body": "PaymentSummaryDirect"
+        },
+        {
+          "label": {
+            "name": "RELAY",
+            "def": false
+          },
+          "body": "PaymentSummaryRelay"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "PaymentSummaryStellar",
       "fields": [
         {
-          "type": [
-            null,
-            "PaymentSummaryStellar"
-          ],
-          "name": "stellar"
-        },
-        {
-          "type": [
-            null,
-            "PaymentSummaryKeybase"
-          ],
-          "name": "keybase"
-        },
-        {
           "type": "TransactionID",
-          "name": "stellarTxID"
+          "name": "txID"
         },
         {
           "type": "AccountID",
@@ -145,32 +172,40 @@
         {
           "type": "Asset",
           "name": "asset"
+        },
+        {
+          "type": "uint64",
+          "name": "operationID"
+        },
+        {
+          "type": "TimeMs",
+          "name": "ctime"
         }
       ]
     },
     {
       "type": "record",
-      "name": "PaymentSummaryKeybase",
+      "name": "PaymentSummaryDirect",
       "fields": [
         {
           "type": "KeybaseTransactionID",
           "name": "kbTxID"
         },
         {
+          "type": "TransactionID",
+          "name": "txID"
+        },
+        {
           "type": "TransactionStatus",
-          "name": "status"
+          "name": "txStatus"
         },
         {
           "type": "string",
-          "name": "submitErrMsg"
+          "name": "txErrMsg"
         },
         {
-          "type": "TimeMs",
-          "name": "ctime"
-        },
-        {
-          "type": "TimeMs",
-          "name": "rtime"
+          "type": "AccountID",
+          "name": "fromStellar"
         },
         {
           "type": "keybase1.UserVersion",
@@ -181,11 +216,23 @@
           "name": "fromDeviceID"
         },
         {
+          "type": "AccountID",
+          "name": "toStellar"
+        },
+        {
           "type": [
             null,
             "keybase1.UserVersion"
           ],
           "name": "to"
+        },
+        {
+          "type": "string",
+          "name": "amount"
+        },
+        {
+          "type": "Asset",
+          "name": "asset"
         },
         {
           "type": [
@@ -204,20 +251,130 @@
         {
           "type": "string",
           "name": "noteB64"
+        },
+        {
+          "type": "TimeMs",
+          "name": "ctime"
+        },
+        {
+          "type": "TimeMs",
+          "name": "rtime"
         }
       ]
     },
     {
       "type": "record",
-      "name": "PaymentSummaryStellar",
+      "name": "PaymentSummaryRelay",
       "fields": [
         {
-          "type": "uint64",
-          "name": "operationID"
+          "type": "KeybaseTransactionID",
+          "name": "kbTxID"
+        },
+        {
+          "type": "TransactionID",
+          "name": "txID"
+        },
+        {
+          "type": "TransactionStatus",
+          "name": "txStatus"
+        },
+        {
+          "type": "string",
+          "name": "txErrMsg"
+        },
+        {
+          "type": "AccountID",
+          "name": "fromStellar"
+        },
+        {
+          "type": "keybase1.UserVersion",
+          "name": "from"
+        },
+        {
+          "type": "keybase1.DeviceID",
+          "name": "fromDeviceID"
+        },
+        {
+          "type": [
+            null,
+            "keybase1.UserVersion"
+          ],
+          "name": "to"
+        },
+        {
+          "type": "AccountID",
+          "name": "relayAccount"
+        },
+        {
+          "type": "string",
+          "name": "amount"
+        },
+        {
+          "type": [
+            null,
+            "string"
+          ],
+          "name": "displayAmount"
+        },
+        {
+          "type": [
+            null,
+            "string"
+          ],
+          "name": "displayCurrency"
         },
         {
           "type": "TimeMs",
           "name": "ctime"
+        },
+        {
+          "type": "TimeMs",
+          "name": "rtime"
+        },
+        {
+          "type": "string",
+          "name": "boxB64"
+        },
+        {
+          "type": "keybase1.TeamID",
+          "name": "teamID"
+        },
+        {
+          "type": [
+            null,
+            "ClaimSummary"
+          ],
+          "name": "claim"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "ClaimSummary",
+      "fields": [
+        {
+          "type": "TransactionID",
+          "name": "txID"
+        },
+        {
+          "type": "TransactionStatus",
+          "name": "txStatus"
+        },
+        {
+          "type": "string",
+          "name": "txErrMsg"
+        },
+        {
+          "type": "RelayDirection",
+          "name": "dir"
+        },
+        {
+          "type": "AccountID",
+          "name": "toStellar"
+        },
+        {
+          "type": "keybase1.UserVersion",
+          "name": "to"
         }
       ]
     }


### PR DESCRIPTION
Make `PaymentSummary` a variant. It is returned by `RecentPayments` and `PaymentDetail`.
```
variant PaymentSummary switch (PaymentSummaryType typ) {
  case STELLAR: PaymentSummaryStellar; // The only record of this tx is from horizon
  case DIRECT: PaymentSummaryDirect;
  case RELAY: PaymentSummaryRelay;
}
```

This PR goes hand-in-hand with https://github.com/keybase/keybase/pull/2449. Skewing the client and server across these PRs will render `wallet history` and `wallet detail` inoperative on the client.

