### PR TITLE
Only run codecov if there were changes to the shared dir

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -95,5 +95,5 @@ test:
     # copy the test results to the test results directory.
     # - cp -r android/app/build/outputs/androidTest-results/* $CIRCLE_TEST_REPORTS
   post:
-    - yarn coverage-report-helper -t json -o $CIRCLE_TEST_REPORTS/flow-coverage
-    - bash <(curl -s https://codecov.io/bash) -f $CIRCLE_TEST_REPORTS/flow-coverage/flow-coverage.json
+      # Only run coverage if there were changes to the shared folder
+    - if [ $(git rev-parse HEAD) == $(git log -1 --format=format:%H --full-diff .) ]; yarn coverage-report-helper -t json -o $CIRCLE_TEST_REPORTS/flow-coverage && bash <(curl -s https://codecov.io/bash) -f $CIRCLE_TEST_REPORTS/flow-coverage/flow-coverage.json; fi


### PR DESCRIPTION
The codecov change takes quite a bit of time to run, can we disable it for PRs that don't have changes to the shared folder?

![screen shot 2018-05-11 at 4 03 49 pm](https://user-images.githubusercontent.com/1144020/39944500-e9e1c5e6-5534-11e8-9bb0-638a5bfd970e.png)

we could also look into the `--concurrent-files` flag but i couldn't find great docs on if that will help with performance

```
$ flow-coverage-report --help
Usage: /usr/local/bin/flow-coverage-report COMMAND PROJECTDIR [...globs]

Options:
  -h, --help               Show help                                   [boolean]
  --flow-command-path, -f  path to the flow executable (defaults to "flow")
                                                                        [string]
  --type, -t               format of the generated reports (defaults to "text")
                                      [choices: "html", "json", "text", "badge"]
  --project-dir, -p        select the project dir path (defaults to
                           "/Users/joshblum")                           [string]
  --include-glob, -i       include the files selected by the specified glob
                                                                        [string]
  --exclude-glob, -x       exclude the files selected by the specified glob
                           (defaults to "node_modules/**")              [string]
  --threshold              the minimum coverage percent requested (defaults to
                           80)                                          [number]
  --output-dir, -o         output html or json files to this folder relative to
                           project-dir (defaults to "./flow-coverage")  [string]
  --concurrent-files, -c   the maximum number of files concurrently submitted to
                           flow (defaults to 1)                         [number]
  --strict-coverage        non annotated and flow weak files are considered as
                           completely uncovered. Default behavior is for flow to
                           best-guess coverage on all the files included in the
                           report.                                     [boolean]
  --no-config              do not load any config file from the project dir
                                                                       [boolean]
  --config                 file path of the config file to load         [string]
  -v, --version            Show version number                         [boolean]
```

cc @keybase/react-hackers 