### PR TITLE
fix clicking on list items requiring 2 taps

### DIFF
--- a/shared/chat/conversation/input-area/channel-mention-hud/index.js
+++ b/shared/chat/conversation/input-area/channel-mention-hud/index.js
@@ -47,7 +47,6 @@ const Hud = ({style, data, rowRenderer, selectedIndex}: Props<any>) =>
         renderItem={rowRenderer}
         selectedIndex={selectedIndex}
         fixedHeight={40}
-        keyboardShouldPersistTaps="always"
       />
     </Box>
   ) : null

--- a/shared/chat/conversation/input-area/user-mention-hud/index.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.js
@@ -69,13 +69,7 @@ const MentionRowRenderer = ({username, fullName, selected, onClick, onHover}: Me
 const Hud = ({style, data, rowRenderer, selectedIndex}: Props<*>) =>
   data.length ? (
     <Box style={collapseStyles([hudStyle, style])}>
-      <List
-        items={data}
-        renderItem={rowRenderer}
-        selectedIndex={selectedIndex}
-        fixedHeight={40}
-        keyboardShouldPersistTaps="always"
-      />
+      <List items={data} renderItem={rowRenderer} selectedIndex={selectedIndex} fixedHeight={40} />
     </Box>
   ) : null
 

--- a/shared/chat/conversation/list-area/waiting.js
+++ b/shared/chat/conversation/list-area/waiting.js
@@ -1,0 +1,20 @@
+// @flow
+import * as React from 'react'
+import {Box2, ProgressIndicator} from '../../../common-adapters'
+import {styleSheetCreate} from '../../../styles'
+
+const Waiting = () => (
+  <Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.container}>
+    <ProgressIndicator type="Small" style={styles.spinner} />
+  </Box2>
+)
+const styles = styleSheetCreate({
+  container: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  spinner: {width: 14},
+})
+
+export default Waiting

--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -201,6 +201,7 @@ class Inbox extends React.PureComponent<Props, State> {
             ref={this._setRef}
             onViewableItemsChanged={this._onViewChanged}
             windowSize={5}
+            keyboardShouldPersistTaps="handled"
             getItemLayout={this._getItemLayout}
             removeClippedSubviews={true}
           />

--- a/shared/common-adapters/list.native.js
+++ b/shared/common-adapters/list.native.js
@@ -6,6 +6,9 @@ import {globalStyles} from '../styles'
 import type {Props} from './list'
 
 class List extends PureComponent<Props<any>, void> {
+  static defaultProps = {
+    keyboardShouldPersistTaps: 'handled',
+  }
   _itemRender = ({item, index}) => {
     return this.props.renderItem(index, item)
   }

--- a/shared/search/results-list/index.native.js
+++ b/shared/search/results-list/index.native.js
@@ -44,6 +44,7 @@ class SearchResultsList extends Component<Props> {
           renderItem={this._renderItem}
           keyExtractor={this._keyExtractor}
           keyboardDismissMode={this.props.keyboardDismissMode}
+          keyboardShouldPersistTaps="handled"
         />
       </Box>
     )


### PR DESCRIPTION
@keybase/react-hackers we defaulted these props in common-adapters/list but things that use flatlist direction don't  have this. this causes you to have to tap twice in scrollable contents if you're in an input (like jump to chat or search)
