### PR TITLE
don't do anything on reception of transient errors CORE-7833

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -206,23 +206,18 @@ const unboxRows = (
   }
   const onFailed = function*({convID, error}: RPCChatTypes.ChatUiChatInboxFailedRpcParam) {
     const state: TypedState = yield Saga.select()
+    const conversationIDKey = Types.conversationIDToKey(convID)
     switch (error.typ) {
       case RPCChatTypes.localConversationErrorType.transient:
         logger.info(
-          `onFailed: ignoring transient error for convID: ${Types.conversationIDToKey(convID)} error: ${
-            error.message
-          }`
+          `onFailed: ignoring transient error for convID: ${conversationIDKey} error: ${error.message}`
         )
         break
       default:
-        logger.info(
-          `onFailed: displaying error for convID: ${Types.conversationIDToKey(convID)} error: ${
-            error.message
-          }`
-        )
+        logger.info(`onFailed: displaying error for convID: ${conversationIDKey} error: ${error.message}`)
         yield Saga.put(
           Chat2Gen.createMetaReceivedError({
-            conversationIDKey: Types.conversationIDToKey(convID),
+            conversationIDKey: conversationIDKey,
             error,
             username: state.config.username || '',
           })

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -206,13 +206,28 @@ const unboxRows = (
   }
   const onFailed = function*({convID, error}: RPCChatTypes.ChatUiChatInboxFailedRpcParam) {
     const state: TypedState = yield Saga.select()
-    yield Saga.put(
-      Chat2Gen.createMetaReceivedError({
-        conversationIDKey: Types.conversationIDToKey(convID),
-        error,
-        username: state.config.username || '',
-      })
-    )
+    switch (error.typ) {
+      case RPCChatTypes.localConversationErrorType.transient:
+        logger.info(
+          `onFailed: ignoring transient error for convID: ${Types.conversationIDToKey(convID)} error: ${
+            error.message
+          }`
+        )
+        break
+      default:
+        logger.info(
+          `onFailed: displaying error for convID: ${Types.conversationIDToKey(convID)} error: ${
+            error.message
+          }`
+        )
+        yield Saga.put(
+          Chat2Gen.createMetaReceivedError({
+            conversationIDKey: Types.conversationIDToKey(convID),
+            error,
+            username: state.config.username || '',
+          })
+        )
+    }
     return EngineRpc.rpcResult()
   }
   const loadInboxRpc = new EngineRpc.EngineRpcCall(


### PR DESCRIPTION
@keybase/react-hackers 
Transient inbox errors (things like network failures) can get generated in a variety of circumstances, but we don't ever want to show them in the UI, so let's just ignore them.

cc @malgorithms since you get this a lot.