### PR TITLE
fix oneshot bug where user was getting logged out via LogoutIfRevoked

### DIFF
--- a/go/engine/login_oneshot_test.go
+++ b/go/engine/login_oneshot_test.go
@@ -43,4 +43,7 @@ func TestLoginOneshot(t *testing.T) {
 	err = AssertProvisioned(tc2)
 	require.NoError(t, err)
 	testSign(t, tc2)
+	err = m.LogoutIfRevoked()
+	require.NoError(t, err)
+	testSign(t, tc2)
 }

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -368,7 +368,7 @@ func TestSignAfterRevoke(t *testing.T) {
 	}
 
 	// This should log out tc1:
-	if err := tc1.G.LogoutIfRevoked(); err != nil {
+	if err := NewMetaContextForTest(tc1).LogoutIfRevoked(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -395,7 +395,7 @@ func TestLogoutIfRevokedNoop(t *testing.T) {
 
 	AssertLoggedIn(tc)
 
-	if err := tc.G.LogoutIfRevoked(); err != nil {
+	if err := NewMetaContextForTest(tc).LogoutIfRevoked(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -966,7 +966,6 @@ func (g *GlobalContext) NewRPCLogFactory() *RPCLogFactory {
 	return &RPCLogFactory{Contextified: NewContextified(g)}
 }
 
-
 // LogoutSelfCheck checks with the API server to see if this uid+device pair should
 // logout.
 func (g *GlobalContext) LogoutSelfCheck() error {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -966,37 +966,6 @@ func (g *GlobalContext) NewRPCLogFactory() *RPCLogFactory {
 	return &RPCLogFactory{Contextified: NewContextified(g)}
 }
 
-// LogoutIfRevoked loads the user and checks if the current device keys
-// have been revoked.  If so, it calls Logout.
-func (g *GlobalContext) LogoutIfRevoked() error {
-	in, err := g.LoginState().LoggedInLoad()
-	if err != nil {
-		return err
-	}
-	if !in {
-		g.Log.Debug("LogoutIfRevoked: skipping check (not logged in)")
-		return nil
-	}
-
-	if g.Env.GetSkipLogoutIfRevokedCheck() {
-		g.Log.Debug("LogoutIfRevoked: skipping check (SkipLogoutIfRevokedCheck)")
-		return nil
-	}
-
-	me, err := LoadMe(NewLoadUserForceArg(g))
-	if err != nil {
-		return err
-	}
-
-	if !me.HasCurrentDeviceInCurrentInstall() {
-		g.Log.Debug("LogoutIfRevoked: current device revoked, calling logout")
-		return g.Logout()
-	}
-
-	g.Log.Debug("LogoutIfRevoked: current device ok")
-
-	return nil
-}
 
 // LogoutSelfCheck checks with the API server to see if this uid+device pair should
 // logout.

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -787,3 +787,21 @@ func (u *CachedUPAKLoader) removeMemCache(ctx context.Context, uid keybase1.UID)
 func (u *CachedUPAKLoader) purgeMemCache() {
 	u.cache.Purge()
 }
+
+func checkDeviceValidForUID(ctx context.Context, u UPAKLoader, uid keybase1.UID, did keybase1.DeviceID) error {
+	var nnu NormalizedUsername
+	return u.CheckDeviceForUIDAndUsername(ctx, uid, did, nnu)
+}
+
+func CheckCurrentUIDDeviceID(m MetaContext) (err error) {
+	defer m.CTrace("CheckCurrentUIDDeviceID", func() error { return err })()
+	uid := m.G().Env.GetUID()
+	if uid.IsNil() {
+		return NoUIDError{}
+	}
+	did := m.G().Env.GetDeviceIDForUID(uid)
+	if did.IsNil() {
+		return NoDeviceError{fmt.Sprintf("for UID %s", uid)}
+	}
+	return checkDeviceValidForUID(m.Ctx(), m.G().GetUPAKLoader(), uid, did)
+}

--- a/go/service/user_handler.go
+++ b/go/service/user_handler.go
@@ -26,25 +26,26 @@ func newUserHandler(g *libkb.GlobalContext) *userHandler {
 }
 
 func (r *userHandler) Create(ctx context.Context, cli gregor1.IncomingInterface, category string, item gregor.Item) (bool, error) {
+	m := libkb.NewMetaContext(ctx, r.G())
 	switch category {
 	case "user.key_change":
-		return true, r.keyChange()
+		return true, r.keyChange(m)
 	case "user.identity_change":
-		return true, r.identityChange()
+		return true, r.identityChange(m)
 	default:
 		return false, fmt.Errorf("unknown userHandler category: %q", category)
 	}
 }
 
-func (r *userHandler) keyChange() error {
-	r.G().KeyfamilyChanged(r.G().Env.GetUID())
+func (r *userHandler) keyChange(m libkb.MetaContext) error {
+	m.G().KeyfamilyChanged(m.G().Env.GetUID())
 
 	// check if this device was just revoked and if so, log out
-	return r.G().LogoutIfRevoked()
+	return m.LogoutIfRevoked()
 }
 
-func (r *userHandler) identityChange() error {
-	r.G().UserChanged(r.G().Env.GetUID())
+func (r *userHandler) identityChange(m libkb.MetaContext) error {
+	m.G().UserChanged(m.G().Env.GetUID())
 	return nil
 }
 


### PR DESCRIPTION
- it turns out that HasCurrentDeviceInCurrentInstall doesn't really work for paper-based keys
- but it also seems silly to be force reloading users just to answer this question, when a upak would work just as well
- so just use the UPAK-based check instead.
- master fails with current test, but patch fixes the test