### PR TITLE
Upload avatar RPC

### DIFF
--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -336,8 +336,15 @@ func (c *FullCachingSource) loadNames(ctx context.Context, names []string, forma
 func (c *FullCachingSource) clearName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
 	for _, format := range formats {
 		key := c.avatarKey(name, format)
-		if err := c.diskLRU.Remove(ctx, c.G(), key); err != nil {
+		found, ent, err := c.diskLRU.Get(ctx, c.G(), key)
+		if err != nil {
 			return err
+		}
+		if found {
+			c.removeFile(ctx, &ent)
+			if err := c.diskLRU.Remove(ctx, c.G(), key); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -354,6 +354,6 @@ func (c *FullCachingSource) LoadTeams(ctx context.Context, teams []string, forma
 }
 
 func (c *FullCachingSource) ClearCacheForName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
-	defer c.G().Trace("FullCachingSource.ClearCacheForUser", func() error { return err })()
+	defer c.G().Trace(fmt.Sprintf("FullCachingSource.ClearCacheForUser(%q,%v)", name, formats), func() error { return err })()
 	return c.clearName(ctx, name, formats)
 }

--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -333,6 +333,16 @@ func (c *FullCachingSource) loadNames(ctx context.Context, names []string, forma
 	return res, nil
 }
 
+func (c *FullCachingSource) clearName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
+	for _, format := range formats {
+		key := c.avatarKey(name, format)
+		if err := c.diskLRU.Remove(ctx, c.G(), key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (c *FullCachingSource) LoadUsers(ctx context.Context, usernames []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
 	defer c.G().Trace("FullCachingSource.LoadUsers", func() error { return err })()
 	return c.loadNames(ctx, usernames, formats, c.simpleSource.LoadUsers)
@@ -341,4 +351,9 @@ func (c *FullCachingSource) LoadUsers(ctx context.Context, usernames []string, f
 func (c *FullCachingSource) LoadTeams(ctx context.Context, teams []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
 	defer c.G().Trace("FullCachingSource.LoadTeams", func() error { return err })()
 	return c.loadNames(ctx, teams, formats, c.simpleSource.LoadTeams)
+}
+
+func (c *FullCachingSource) ClearCacheForName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
+	defer c.G().Trace("FullCachingSource.ClearCacheForUser", func() error { return err })()
+	return c.clearName(ctx, name, formats)
 }

--- a/go/avatars/fullcaching_test.go
+++ b/go/avatars/fullcaching_test.go
@@ -59,12 +59,18 @@ func TestAvatarsFullCaching(t *testing.T) {
 	}
 
 	t.Log("cache hit")
-	getFile := func(path string) string {
+
+	convertPath := func(path string) string {
 		path = strings.TrimPrefix(path, "file://")
 		if runtime.GOOS == "windows" {
 			path = strings.Replace(path, `/`, `\`, -1)
 			path = path[1:]
 		}
+		return path
+	}
+
+	getFile := func(path string) string {
+		path = convertPath(path)
 		file, err := os.Open(path)
 		require.NoError(t, err)
 		dat, err := ioutil.ReadAll(file)
@@ -121,4 +127,11 @@ func TestAvatarsFullCaching(t *testing.T) {
 	val2 = res.Picmap["mike"]["square"].String()
 	require.Equal(t, val2, val)
 	require.Equal(t, "hi2", getFile(val2))
+
+	err = source.ClearCacheForName(context.Background(), "mike", []keybase1.AvatarFormat{"square"})
+	require.NoError(t, err)
+
+	_, err = os.Stat(convertPath(val2))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
 }

--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -24,13 +24,15 @@ func CreateSourceFromEnv(g *libkb.GlobalContext) (s Source) {
 	case "simple":
 		s = NewSimpleSource(g)
 	case "url":
-		s = NewURLCachingSource(g, time.Hour, 20000)
+		s = NewURLCachingSource(g, time.Hour /* staleThreshold */, 20000)
 	case "full":
 		maxSize := 10000
 		if g.GetAppType() == libkb.MobileAppType {
 			maxSize = 2000
 		}
-		s = NewFullCachingSource(g, time.Hour, maxSize)
+		// When changing staleThreshold here, serverside avatar change
+		// notification dismiss time should be adjusted as well.
+		s = NewFullCachingSource(g, time.Hour /* staleThreshold */, maxSize)
 	}
 	s.StartBackgroundTasks()
 	g.PushShutdownHook(func() error {

--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -12,6 +12,8 @@ type Source interface {
 	LoadUsers(context.Context, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)
 	LoadTeams(context.Context, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)
 
+	ClearCacheForName(context.Context, string, []keybase1.AvatarFormat) error
+
 	StartBackgroundTasks()
 	StopBackgroundTasks()
 }

--- a/go/avatars/simple.go
+++ b/go/avatars/simple.go
@@ -105,3 +105,7 @@ func (s *SimpleSource) LoadTeams(ctx context.Context, teams []string, formats []
 	}
 	return res, nil
 }
+
+func (s *SimpleSource) ClearCacheForName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
+	return nil
+}

--- a/go/avatars/upload.go
+++ b/go/avatars/upload.go
@@ -1,0 +1,100 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package avatars
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"os"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
+)
+
+func addFile(mpart *multipart.Writer, param, filename string) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	part, err := mpart.CreateFormFile(param, filename)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(part, file)
+	return err
+}
+
+type imageCropParams struct {
+	x0, y0, x1, y1 int
+}
+
+func postAvatarImage(mctx libkb.MetaContext, filename string, crop *imageCropParams, teamID *keybase1.TeamID) (err error) {
+	var body bytes.Buffer
+	mpart := multipart.NewWriter(&body)
+
+	if err := addFile(mpart, "avatar", filename); err != nil {
+		mctx.CDebugf("addFile error: %s", err)
+		return err
+	}
+
+	if teamID != nil {
+		mpart.WriteField("team_id", string(*teamID))
+	}
+
+	if crop != nil {
+		mpart.WriteField("x0", fmt.Sprintf("%d", crop.x0))
+		mpart.WriteField("y0", fmt.Sprintf("%d", crop.y0))
+		mpart.WriteField("x1", fmt.Sprintf("%d", crop.x1))
+		mpart.WriteField("y1", fmt.Sprintf("%d", crop.y1))
+	}
+
+	if err := mpart.Close(); err != nil {
+		return err
+	}
+
+	var endpoint string
+	if teamID != nil {
+		endpoint = "image/upload_team_avatar"
+	} else {
+		endpoint = "image/upload_user_avatar"
+	}
+
+	mctx.CDebugf("Running POST to %s", endpoint)
+
+	arg := libkb.APIArg{
+		Endpoint:    endpoint,
+		SessionType: libkb.APISessionTypeREQUIRED,
+	}
+
+	_, err = mctx.G().API.PostRaw(arg, mpart.FormDataContentType(), &body)
+	if err != nil {
+		mctx.CDebugf("post error: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func UploadImage(mctx libkb.MetaContext, filename string, teamname *string) error {
+	var teamID *keybase1.TeamID
+	if teamname != nil {
+		team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
+			Name:        *teamname,
+			Public:      false,
+			ForceRepoll: false,
+			NeedAdmin:   true,
+		})
+		if err != nil {
+			return err
+		}
+		teamID = &team.ID
+	}
+	return postAvatarImage(mctx, filename, nil, teamID)
+}

--- a/go/avatars/upload.go
+++ b/go/avatars/upload.go
@@ -41,6 +41,13 @@ func postAvatarImage(mctx libkb.MetaContext, filename string, teamID *keybase1.T
 		return err
 	}
 
+	// Server checks upload size as well.
+	const maxUploadSize = 20 * 1024 * 1024
+	if bodyLen := body.Len(); bodyLen > maxUploadSize {
+		return fmt.Errorf("Image is too big: tried to upload %d bytes, max size is %d bytes.",
+			bodyLen, maxUploadSize)
+	}
+
 	if teamID != nil {
 		mpart.WriteField("team_id", string(*teamID))
 	}

--- a/go/avatars/upload.go
+++ b/go/avatars/upload.go
@@ -22,7 +22,8 @@ func addFile(mpart *multipart.Writer, param, filename string) error {
 	}
 	defer file.Close()
 
-	part, err := mpart.CreateFormFile(param, filename)
+	// do not disclose our filename to the server
+	part, err := mpart.CreateFormFile(param, "image" /* filename */)
 	if err != nil {
 		return err
 	}

--- a/go/avatars/upload.go
+++ b/go/avatars/upload.go
@@ -94,5 +94,6 @@ func UploadImage(mctx libkb.MetaContext, filename string, teamname *string, crop
 		}
 		teamID = &team.ID
 	}
+
 	return postAvatarImage(mctx, filename, teamID, crop)
 }

--- a/go/avatars/upload.go
+++ b/go/avatars/upload.go
@@ -31,11 +31,7 @@ func addFile(mpart *multipart.Writer, param, filename string) error {
 	return err
 }
 
-type imageCropParams struct {
-	x0, y0, x1, y1 int
-}
-
-func postAvatarImage(mctx libkb.MetaContext, filename string, crop *imageCropParams, teamID *keybase1.TeamID) (err error) {
+func postAvatarImage(mctx libkb.MetaContext, filename string, teamID *keybase1.TeamID, crop *keybase1.ImageCropRect) (err error) {
 	var body bytes.Buffer
 	mpart := multipart.NewWriter(&body)
 
@@ -49,10 +45,11 @@ func postAvatarImage(mctx libkb.MetaContext, filename string, crop *imageCropPar
 	}
 
 	if crop != nil {
-		mpart.WriteField("x0", fmt.Sprintf("%d", crop.x0))
-		mpart.WriteField("y0", fmt.Sprintf("%d", crop.y0))
-		mpart.WriteField("x1", fmt.Sprintf("%d", crop.x1))
-		mpart.WriteField("y1", fmt.Sprintf("%d", crop.y1))
+		mctx.CDebugf("Adding crop fields: %+v", crop)
+		mpart.WriteField("x0", fmt.Sprintf("%d", crop.X0))
+		mpart.WriteField("y0", fmt.Sprintf("%d", crop.Y0))
+		mpart.WriteField("x1", fmt.Sprintf("%d", crop.X1))
+		mpart.WriteField("y1", fmt.Sprintf("%d", crop.Y1))
 	}
 
 	if err := mpart.Close(); err != nil {
@@ -82,7 +79,7 @@ func postAvatarImage(mctx libkb.MetaContext, filename string, crop *imageCropPar
 	return nil
 }
 
-func UploadImage(mctx libkb.MetaContext, filename string, teamname *string) error {
+func UploadImage(mctx libkb.MetaContext, filename string, teamname *string, crop *keybase1.ImageCropRect) error {
 	var teamID *keybase1.TeamID
 	if teamname != nil {
 		team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
@@ -96,5 +93,5 @@ func UploadImage(mctx libkb.MetaContext, filename string, teamname *string) erro
 		}
 		teamID = &team.ID
 	}
-	return postAvatarImage(mctx, filename, nil, teamID)
+	return postAvatarImage(mctx, filename, teamID, crop)
 }

--- a/go/avatars/upload_test.go
+++ b/go/avatars/upload_test.go
@@ -1,0 +1,85 @@
+package avatars
+
+import (
+	"io"
+	"io/ioutil"
+	"mime"
+	"mime/multipart"
+	"os"
+	"testing"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+type uploadAvatarMockAPI struct {
+	libkb.API
+	Func func(map[string]string) error
+}
+
+func (a *uploadAvatarMockAPI) PostRaw(arg libkb.APIArg, contentType string, r io.Reader) (*libkb.APIRes, error) {
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, err
+	}
+
+	postForm := make(map[string]string)
+
+	mr := multipart.NewReader(r, params["boundary"])
+	for {
+		p, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		slurp, err := ioutil.ReadAll(p)
+		if err != nil {
+			return nil, err
+		}
+		postForm[p.Header.Get("Content-Disposition")] = string(slurp)
+	}
+
+	err = a.Func(postForm)
+	return nil, err
+}
+
+func TestUploadAvatar(t *testing.T) {
+	tc := libkb.SetupTest(t, "TestUploadAvatar", 1)
+	defer tc.Cleanup()
+
+	_, err := kbtest.CreateAndSignupFakeUser("avtr", tc.G)
+	require.NoError(t, err)
+
+	// Prepare test avatar file
+	tmpfile, err := ioutil.TempFile(os.TempDir(), "kbtest_avatar.png")
+	require.NoError(t, err)
+	tmpFileStr := "\x89PNGa somewhat goofy picture of a cat"
+	_, err = tmpfile.WriteString(tmpFileStr)
+	require.NoError(t, err)
+	tmpfile.Close()
+	t.Logf("Created a test avatar file: %s", tmpfile.Name())
+	defer os.Remove(tmpfile.Name())
+
+	mock := uploadAvatarMockAPI{}
+	mock.Func = func(post map[string]string) error {
+		require.Len(t, post, 5)
+		require.Equal(t, "1", post["form-data; name=\"x0\""])
+		require.Equal(t, "2", post["form-data; name=\"y0\""])
+		require.Equal(t, "3", post["form-data; name=\"x1\""])
+		require.Equal(t, "4", post["form-data; name=\"y1\""])
+		require.Equal(t, tmpFileStr, post["form-data; name=\"avatar\"; filename=\"image\""])
+		return nil
+	}
+	tc.G.API = &mock
+
+	crop := keybase1.ImageCropRect{
+		X0: 1, Y0: 2, X1: 3, Y1: 4,
+	}
+
+	mctx := libkb.NewMetaContextBackground(tc.G)
+	UploadImage(mctx, tmpfile.Name(), nil, &crop)
+}

--- a/go/avatars/urlcaching.go
+++ b/go/avatars/urlcaching.go
@@ -182,6 +182,6 @@ func (c *URLCachingSource) LoadTeams(ctx context.Context, teams []string, format
 }
 
 func (c *URLCachingSource) ClearCacheForName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
-	defer c.G().Trace("URLCachingSource.ClearCacheForUser", func() error { return err })()
+	defer c.G().Trace(fmt.Sprintf("URLCachingSource.ClearCacheForUser(%s,%v)", name, formats), func() error { return err })()
 	return c.clearName(ctx, name, formats)
 }

--- a/go/avatars/urlcaching.go
+++ b/go/avatars/urlcaching.go
@@ -161,6 +161,16 @@ func (c *URLCachingSource) loadNames(ctx context.Context, names []string, format
 	return res, nil
 }
 
+func (c *URLCachingSource) clearName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
+	for _, format := range formats {
+		key := c.avatarKey(name, format)
+		if err := c.diskLRU.Remove(ctx, c.G(), key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (c *URLCachingSource) LoadUsers(ctx context.Context, usernames []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
 	defer c.G().Trace("URLCachingSource.LoadUsers", func() error { return err })()
 	return c.loadNames(ctx, usernames, formats, c.simpleSource.LoadUsers)
@@ -169,4 +179,9 @@ func (c *URLCachingSource) LoadUsers(ctx context.Context, usernames []string, fo
 func (c *URLCachingSource) LoadTeams(ctx context.Context, teams []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
 	defer c.G().Trace("URLCachingSource.LoadTeams", func() error { return err })()
 	return c.loadNames(ctx, teams, formats, c.simpleSource.LoadTeams)
+}
+
+func (c *URLCachingSource) ClearCacheForName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
+	defer c.G().Trace("URLCachingSource.ClearCacheForUser", func() error { return err })()
+	return c.clearName(ctx, name, formats)
 }

--- a/go/client/cmd_upload_avatar.go
+++ b/go/client/cmd_upload_avatar.go
@@ -1,0 +1,86 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+type cmdUploadAvatar struct {
+	libkb.Contextified
+	filename string
+	teamname string
+}
+
+func newCmdUploadAvatar(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	cmd := &cmdUploadAvatar{
+		Contextified: libkb.NewContextified(g),
+	}
+	return cli.Command{
+		Name:         "upload-avatar",
+		ArgumentHelp: "[--team <teamname>] <filename>",
+		Usage:        "Upload avatar for user or team",
+		Description:  "Upload avatar for user or team",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "team",
+				Usage: "Uploads avatar for given team instead of user.",
+			},
+		},
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(cmd, "upload-avatar", c)
+		},
+	}
+}
+
+func (c *cmdUploadAvatar) ParseArgv(ctx *cli.Context) error {
+	args := ctx.Args()
+	if len(args) > 1 {
+		return errors.New("one filename required, multiple arguments found")
+	} else if len(args) == 0 {
+		return errors.New("filename argument not found")
+	}
+
+	c.filename = args[0]
+	c.teamname = ctx.String("team")
+	return nil
+}
+
+func (c *cmdUploadAvatar) Run() error {
+
+	// arg := keybase1.UploadUserAvatarArg{
+	// 	Filename: c.filename,
+	// }
+	if c.teamname != "" {
+		cli, err := GetTeamsClient(c.G())
+		if err != nil {
+			return err
+		}
+
+		arg := keybase1.UploadTeamAvatarArg{
+			Teamname: c.teamname,
+			Filename: c.filename,
+		}
+		return cli.UploadTeamAvatar(context.Background(), arg)
+	}
+
+	cli, err := GetUserClient(c.G())
+	if err != nil {
+		return err
+	}
+	return cli.UploadUserAvatar(context.Background(), c.filename)
+}
+
+func (c *cmdUploadAvatar) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/cmd_upload_avatar.go
+++ b/go/client/cmd_upload_avatar.go
@@ -54,10 +54,6 @@ func (c *cmdUploadAvatar) ParseArgv(ctx *cli.Context) error {
 }
 
 func (c *cmdUploadAvatar) Run() error {
-
-	// arg := keybase1.UploadUserAvatarArg{
-	// 	Filename: c.filename,
-	// }
 	if c.teamname != "" {
 		cli, err := GetTeamsClient(c.G())
 		if err != nil {

--- a/go/client/cmd_upload_avatar.go
+++ b/go/client/cmd_upload_avatar.go
@@ -75,7 +75,10 @@ func (c *cmdUploadAvatar) Run() error {
 	if err != nil {
 		return err
 	}
-	return cli.UploadUserAvatar(context.Background(), c.filename)
+	arg := keybase1.UploadUserAvatarArg{
+		Filename: c.filename,
+	}
+	return cli.UploadUserAvatar(context.Background(), arg)
 }
 
 func (c *cmdUploadAvatar) GetUsage() libkb.Usage {

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -32,6 +32,7 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 		newCmdTeamRotateKey(cl, g),
 		newCmdTeamDebug(cl, g),
 		newCmdScript(cl, g),
+		newCmdUploadAvatar(cl, g),
 	}
 }
 

--- a/go/protocol/keybase1/avatars.go
+++ b/go/protocol/keybase1/avatars.go
@@ -53,12 +53,24 @@ func (o LoadAvatarsRes) DeepCopy() LoadAvatarsRes {
 }
 
 type AvatarClearCacheMsg struct {
-	Name string `codec:"name" json:"name"`
+	Name    string         `codec:"name" json:"name"`
+	Formats []AvatarFormat `codec:"formats" json:"formats"`
 }
 
 func (o AvatarClearCacheMsg) DeepCopy() AvatarClearCacheMsg {
 	return AvatarClearCacheMsg{
 		Name: o.Name,
+		Formats: (func(x []AvatarFormat) []AvatarFormat {
+			if x == nil {
+				return nil
+			}
+			var ret []AvatarFormat
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Formats),
 	}
 }
 

--- a/go/protocol/keybase1/avatars.go
+++ b/go/protocol/keybase1/avatars.go
@@ -52,6 +52,16 @@ func (o LoadAvatarsRes) DeepCopy() LoadAvatarsRes {
 	}
 }
 
+type AvatarClearCacheMsg struct {
+	Name string `codec:"name" json:"name"`
+}
+
+func (o AvatarClearCacheMsg) DeepCopy() AvatarClearCacheMsg {
+	return AvatarClearCacheMsg{
+		Name: o.Name,
+	}
+}
+
 type LoadUserAvatarsArg struct {
 	Names   []string       `codec:"names" json:"names"`
 	Formats []AvatarFormat `codec:"formats" json:"formats"`

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -915,6 +915,22 @@ func (o FullNamePackage) DeepCopy() FullNamePackage {
 	}
 }
 
+type ImageCropRect struct {
+	X0 int `codec:"x0" json:"x0"`
+	Y0 int `codec:"y0" json:"y0"`
+	X1 int `codec:"x1" json:"x1"`
+	Y1 int `codec:"y1" json:"y1"`
+}
+
+func (o ImageCropRect) DeepCopy() ImageCropRect {
+	return ImageCropRect{
+		X0: o.X0,
+		Y0: o.Y0,
+		X1: o.X1,
+		Y1: o.Y1,
+	}
+}
+
 type CommonInterface interface {
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -2309,6 +2309,11 @@ type SetTarsDisabledArg struct {
 	Disabled bool   `codec:"disabled" json:"disabled"`
 }
 
+type UploadTeamAvatarArg struct {
+	Teamname string `codec:"teamname" json:"teamname"`
+	Filename string `codec:"filename" json:"filename"`
+}
+
 type TeamsInterface interface {
 	TeamCreate(context.Context, TeamCreateArg) (TeamCreateResult, error)
 	TeamCreateWithSettings(context.Context, TeamCreateWithSettingsArg) (TeamCreateResult, error)
@@ -2353,6 +2358,7 @@ type TeamsInterface interface {
 	TeamDebug(context.Context, TeamID) (TeamDebugRes, error)
 	GetTarsDisabled(context.Context, string) (bool, error)
 	SetTarsDisabled(context.Context, SetTarsDisabledArg) error
+	UploadTeamAvatar(context.Context, UploadTeamAvatarArg) error
 }
 
 func TeamsProtocol(i TeamsInterface) rpc.Protocol {
@@ -2999,6 +3005,22 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"uploadTeamAvatar": {
+				MakeArg: func() interface{} {
+					ret := make([]UploadTeamAvatarArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]UploadTeamAvatarArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]UploadTeamAvatarArg)(nil), args)
+						return
+					}
+					err = i.UploadTeamAvatar(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -3214,5 +3236,10 @@ func (c TeamsClient) GetTarsDisabled(ctx context.Context, name string) (res bool
 
 func (c TeamsClient) SetTarsDisabled(ctx context.Context, __arg SetTarsDisabledArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.setTarsDisabled", []interface{}{__arg}, nil)
+	return
+}
+
+func (c TeamsClient) UploadTeamAvatar(ctx context.Context, __arg UploadTeamAvatarArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.uploadTeamAvatar", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -2310,8 +2310,9 @@ type SetTarsDisabledArg struct {
 }
 
 type UploadTeamAvatarArg struct {
-	Teamname string `codec:"teamname" json:"teamname"`
-	Filename string `codec:"filename" json:"filename"`
+	Teamname string         `codec:"teamname" json:"teamname"`
+	Filename string         `codec:"filename" json:"filename"`
+	Crop     *ImageCropRect `codec:"crop,omitempty" json:"crop,omitempty"`
 }
 
 type TeamsInterface interface {

--- a/go/protocol/keybase1/user.go
+++ b/go/protocol/keybase1/user.go
@@ -363,6 +363,10 @@ type GetUPAKArg struct {
 	Uid UID `codec:"uid" json:"uid"`
 }
 
+type UploadUserAvatarArg struct {
+	Filename string `codec:"filename" json:"filename"`
+}
+
 type UserInterface interface {
 	ListTrackers(context.Context, ListTrackersArg) ([]Tracker, error)
 	ListTrackersByName(context.Context, ListTrackersByNameArg) ([]Tracker, error)
@@ -401,6 +405,7 @@ type UserInterface interface {
 	MeUserVersion(context.Context, MeUserVersionArg) (UserVersion, error)
 	// getUPAK returns a UPAK. Used mainly for debugging.
 	GetUPAK(context.Context, UID) (UPAKVersioned, error)
+	UploadUserAvatar(context.Context, string) error
 }
 
 func UserProtocol(i UserInterface) rpc.Protocol {
@@ -743,6 +748,22 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"uploadUserAvatar": {
+				MakeArg: func() interface{} {
+					ret := make([]UploadUserAvatarArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]UploadUserAvatarArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]UploadUserAvatarArg)(nil), args)
+						return
+					}
+					err = i.UploadUserAvatar(ctx, (*typedArgs)[0].Filename)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -875,5 +896,11 @@ func (c UserClient) MeUserVersion(ctx context.Context, __arg MeUserVersionArg) (
 func (c UserClient) GetUPAK(ctx context.Context, uid UID) (res UPAKVersioned, err error) {
 	__arg := GetUPAKArg{Uid: uid}
 	err = c.Cli.Call(ctx, "keybase.1.user.getUPAK", []interface{}{__arg}, &res)
+	return
+}
+
+func (c UserClient) UploadUserAvatar(ctx context.Context, filename string) (err error) {
+	__arg := UploadUserAvatarArg{Filename: filename}
+	err = c.Cli.Call(ctx, "keybase.1.user.uploadUserAvatar", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/keybase1/user.go
+++ b/go/protocol/keybase1/user.go
@@ -364,7 +364,8 @@ type GetUPAKArg struct {
 }
 
 type UploadUserAvatarArg struct {
-	Filename string `codec:"filename" json:"filename"`
+	Filename string         `codec:"filename" json:"filename"`
+	Crop     *ImageCropRect `codec:"crop,omitempty" json:"crop,omitempty"`
 }
 
 type UserInterface interface {
@@ -405,7 +406,7 @@ type UserInterface interface {
 	MeUserVersion(context.Context, MeUserVersionArg) (UserVersion, error)
 	// getUPAK returns a UPAK. Used mainly for debugging.
 	GetUPAK(context.Context, UID) (UPAKVersioned, error)
-	UploadUserAvatar(context.Context, string) error
+	UploadUserAvatar(context.Context, UploadUserAvatarArg) error
 }
 
 func UserProtocol(i UserInterface) rpc.Protocol {
@@ -759,7 +760,7 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]UploadUserAvatarArg)(nil), args)
 						return
 					}
-					err = i.UploadUserAvatar(ctx, (*typedArgs)[0].Filename)
+					err = i.UploadUserAvatar(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -899,8 +900,7 @@ func (c UserClient) GetUPAK(ctx context.Context, uid UID) (res UPAKVersioned, er
 	return
 }
 
-func (c UserClient) UploadUserAvatar(ctx context.Context, filename string) (err error) {
-	__arg := UploadUserAvatarArg{Filename: filename}
+func (c UserClient) UploadUserAvatar(ctx context.Context, __arg UploadUserAvatarArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.user.uploadUserAvatar", []interface{}{__arg}, nil)
 	return
 }

--- a/go/service/avatars.go
+++ b/go/service/avatars.go
@@ -76,20 +76,18 @@ func (r *avatarGregorHandler) Name() string {
 
 func (r *avatarGregorHandler) clearName(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
 	r.G().Log.CDebugf(ctx, "avatarGregorHandler: avatar.clear_cache_for_name received")
-	var msg keybase1.AvatarClearCacheMsg
-	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
+	var msgs []keybase1.AvatarClearCacheMsg
+	if err := json.Unmarshal(item.Body().Bytes(), &msgs); err != nil {
 		r.G().Log.CDebugf(ctx, "error unmarshaling avatar.clear_cache_for_name item: %s", err)
 		return err
 	}
 
-	r.G().Log.CDebugf(ctx, "avatar.clear_cache_for_name unmarshaled: %+v", msg)
+	r.G().Log.CDebugf(ctx, "avatar.clear_cache_for_name unmarshaled: %+v", msgs)
 
-	formats := []keybase1.AvatarFormat{
-		"square_200", "square_360", "square_40",
-	}
-
-	if err := r.source.ClearCacheForName(ctx, msg.Name, formats); err != nil {
-		return err
+	for _, msg := range msgs {
+		if err := r.source.ClearCacheForName(ctx, msg.Name, msg.Formats); err != nil {
+			return err
+		}
 	}
 
 	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -505,6 +505,7 @@ func (d *Service) startupGregor() {
 		d.gregor.PushHandler(newTeamHandler(d.G(), d.badger))
 		d.gregor.PushHandler(d.home)
 		d.gregor.PushHandler(newEKHandler(d.G()))
+		d.gregor.PushHandler(newAvatarGregorHandler(d.G(), d.avatarLoader))
 
 		// Connect to gregord
 		if gcErr := d.tryGregordConnect(); gcErr != nil {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -8,6 +8,7 @@ package service
 import (
 	"fmt"
 
+	"github.com/keybase/client/go/avatars"
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -499,4 +500,12 @@ func (h *TeamsHandler) SetTarsDisabled(ctx context.Context, arg keybase1.SetTars
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("SetTarsDisabled(%s,%t)", arg.Name, arg.Disabled), func() error { return err })()
 
 	return teams.SetTarsDisabled(ctx, h.G().ExternalG(), arg.Name, arg.Disabled)
+}
+
+func (h *TeamsHandler) UploadTeamAvatar(ctx context.Context, arg keybase1.UploadTeamAvatarArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("UploadTeamAvatar(%s,%s)", arg.Teamname, arg.Filename), func() error { return err })()
+
+	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
+	return avatars.UploadImage(mctx, arg.Filename, &arg.Teamname)
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -507,5 +507,5 @@ func (h *TeamsHandler) UploadTeamAvatar(ctx context.Context, arg keybase1.Upload
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("UploadTeamAvatar(%s,%s)", arg.Teamname, arg.Filename), func() error { return err })()
 
 	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
-	return avatars.UploadImage(mctx, arg.Filename, &arg.Teamname)
+	return avatars.UploadImage(mctx, arg.Filename, &arg.Teamname, arg.Crop)
 }

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -355,10 +355,10 @@ func (h *UserHandler) GetUPAK(ctx context.Context, uid keybase1.UID) (ret keybas
 	return ret, err
 }
 
-func (h *UserHandler) UploadUserAvatar(ctx context.Context, filename string) (err error) {
+func (h *UserHandler) UploadUserAvatar(ctx context.Context, arg keybase1.UploadUserAvatarArg) (err error) {
 	ctx = libkb.WithLogTag(ctx, "US")
-	defer h.G().CTraceTimed(ctx, fmt.Sprintf("UploadUserAvatar(%s)", filename), func() error { return err })()
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("UploadUserAvatar(%s)", arg.Filename), func() error { return err })()
 
 	mctx := libkb.NewMetaContext(ctx, h.G())
-	return avatars.UploadImage(mctx, filename, nil /* teamname */)
+	return avatars.UploadImage(mctx, arg.Filename, nil /* teamname */, arg.Crop)
 }

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/keybase/client/go/avatars"
 	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/engine"
@@ -352,4 +353,12 @@ func (h *UserHandler) GetUPAK(ctx context.Context, uid keybase1.UID) (ret keybas
 	}
 	ret = keybase1.NewUPAKVersionedWithV2(*upak)
 	return ret, err
+}
+
+func (h *UserHandler) UploadUserAvatar(ctx context.Context, filename string) (err error) {
+	ctx = libkb.WithLogTag(ctx, "US")
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("UploadUserAvatar(%s)", filename), func() error { return err })()
+
+	mctx := libkb.NewMetaContext(ctx, h.G())
+	return avatars.UploadImage(mctx, filename, nil /* teamname */)
 }

--- a/protocol/avdl/keybase1/avatars.avdl
+++ b/protocol/avdl/keybase1/avatars.avdl
@@ -15,5 +15,7 @@ protocol avatars {
     record AvatarClearCacheMsg {
         @jsonkey("name")
         string name;
+        @jsonkey("formats")
+        array<AvatarFormat> formats;
     }
 }

--- a/protocol/avdl/keybase1/avatars.avdl
+++ b/protocol/avdl/keybase1/avatars.avdl
@@ -11,4 +11,9 @@ protocol avatars {
 
     LoadAvatarsRes loadUserAvatars(array<string> names, array<AvatarFormat> formats);
     LoadAvatarsRes loadTeamAvatars(array<string> names, array<AvatarFormat> formats);
+
+    record AvatarClearCacheMsg {
+        @jsonkey("name")
+        string name;
+    }
 }

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -323,4 +323,10 @@ protocol Common {
     Time cachedAt;
   }
 
+  record ImageCropRect {
+    int x0;
+    int y0;
+    int x1;
+    int y1;
+  }
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -838,5 +838,5 @@ protocol teams {
   boolean getTarsDisabled(string name);
   void setTarsDisabled(string name, boolean disabled);
 
-  void uploadTeamAvatar(string teamname, string filename);
+  void uploadTeamAvatar(string teamname, string filename, union { null, ImageCropRect } crop);
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -837,4 +837,6 @@ protocol teams {
 
   boolean getTarsDisabled(string name);
   void setTarsDisabled(string name, boolean disabled);
+
+  void uploadTeamAvatar(string teamname, string filename);
 }

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -153,5 +153,5 @@ protocol user {
   @lint("ignore")
   UPAKVersioned getUPAK(UID uid);
 
-  void uploadUserAvatar(string filename);
+  void uploadUserAvatar(string filename, union { null, ImageCropRect } crop);
 }

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -152,4 +152,6 @@ protocol user {
   */
   @lint("ignore")
   UPAKVersioned getUPAK(UID uid);
+
+  void uploadUserAvatar(string filename);
 }

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2040,6 +2040,8 @@ export type AsyncOps =
   | 5 // MOVE_5
   | 6 // REMOVE_6
 
+export type AvatarClearCacheMsg = $ReadOnly<{name: String}>
+
 export type AvatarFormat = String
 
 export type AvatarUrl = String

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1805,6 +1805,10 @@ export const teamsTeamTreeRpcChannelMap = (configKeys: Array<string>, request: T
 
 export const teamsTeamTreeRpcPromise = (request: TeamsTeamTreeRpcParam): Promise<TeamsTeamTreeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamTree', request, (error: RPCError, result: TeamsTeamTreeResult) => (error ? reject(error) : resolve(result))))
 
+export const teamsUploadTeamAvatarRpcChannelMap = (configKeys: Array<string>, request: TeamsUploadTeamAvatarRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.uploadTeamAvatar', request)
+
+export const teamsUploadTeamAvatarRpcPromise = (request: TeamsUploadTeamAvatarRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.uploadTeamAvatar', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
 export const testPanicRpcChannelMap = (configKeys: Array<string>, request: TestPanicRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.test.panic', request)
 
 export const testPanicRpcPromise = (request: TestPanicRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.test.panic', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
@@ -1985,6 +1989,10 @@ export const userResetUserRpcPromise = (request: UserResetUserRpcParam): Promise
 export const userSearchRpcChannelMap = (configKeys: Array<string>, request: UserSearchRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.search', request)
 
 export const userSearchRpcPromise = (request: UserSearchRpcParam): Promise<UserSearchResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.search', request, (error: RPCError, result: UserSearchResult) => (error ? reject(error) : resolve(result))))
+
+export const userUploadUserAvatarRpcChannelMap = (configKeys: Array<string>, request: UserUploadUserAvatarRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.uploadUserAvatar', request)
+
+export const userUploadUserAvatarRpcPromise = (request: UserUploadUserAvatarRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.uploadUserAvatar', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
 
 export type APIRes = $ReadOnly<{status: String, body: String, httpStatus: Int, appStatus: String}>
 
@@ -3962,6 +3970,8 @@ export type TeamsUiConfirmRootTeamDeleteRpcParam = $ReadOnly<{teamName: String, 
 
 export type TeamsUiConfirmSubteamDeleteRpcParam = $ReadOnly<{teamName: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type TeamsUploadTeamAvatarRpcParam = $ReadOnly<{teamname: String, filename: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type Test = $ReadOnly<{reply: String}>
 
 export type TestPanicRpcParam = $ReadOnly<{message: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -4140,6 +4150,8 @@ export type UserSummary2 = $ReadOnly<{uid: UID, username: String, thumbnail: Str
 export type UserSummary2Set = $ReadOnly<{users?: ?Array<UserSummary2>, time: Time, version: Int}>
 
 export type UserTeamShowcase = $ReadOnly<{fqName: String, open: Boolean, teamIsShowcased: Boolean, description: String, role: TeamRole, publicAdmins?: ?Array<String>, numMembers: Int}>
+
+export type UserUploadUserAvatarRpcParam = $ReadOnly<{filename: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type UserVersion = $ReadOnly<{uid: UID, eldestSeqno: Seqno}>
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2040,7 +2040,7 @@ export type AsyncOps =
   | 5 // MOVE_5
   | 6 // REMOVE_6
 
-export type AvatarClearCacheMsg = $ReadOnly<{name: String}>
+export type AvatarClearCacheMsg = $ReadOnly<{name: String, formats?: ?Array<AvatarFormat>}>
 
 export type AvatarFormat = String
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2645,6 +2645,8 @@ export type IdentifyUiStartRpcParam = $ReadOnly<{username: String, reason: Ident
 
 export type Identity = $ReadOnly<{status?: ?Status, whenLastTracked: Time, proofs?: ?Array<IdentifyRow>, cryptocurrency?: ?Array<Cryptocurrency>, revoked?: ?Array<TrackDiff>, revokedDetails?: ?Array<RevokedProof>, breaksTracking: Boolean}>
 
+export type ImageCropRect = $ReadOnly<{x0: Int, y0: Int, x1: Int, y1: Int}>
+
 export type ImplicitRole = $ReadOnly<{role: TeamRole, ancestor: TeamID}>
 
 export type ImplicitTeamConflictInfo = $ReadOnly<{generation: ConflictGeneration, time: Time}>
@@ -3970,7 +3972,7 @@ export type TeamsUiConfirmRootTeamDeleteRpcParam = $ReadOnly<{teamName: String, 
 
 export type TeamsUiConfirmSubteamDeleteRpcParam = $ReadOnly<{teamName: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type TeamsUploadTeamAvatarRpcParam = $ReadOnly<{teamname: String, filename: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type TeamsUploadTeamAvatarRpcParam = $ReadOnly<{teamname: String, filename: String, crop?: ?ImageCropRect, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type Test = $ReadOnly<{reply: String}>
 
@@ -4151,7 +4153,7 @@ export type UserSummary2Set = $ReadOnly<{users?: ?Array<UserSummary2>, time: Tim
 
 export type UserTeamShowcase = $ReadOnly<{fqName: String, open: Boolean, teamIsShowcased: Boolean, description: String, role: TeamRole, publicAdmins?: ?Array<String>, numMembers: Int}>
 
-export type UserUploadUserAvatarRpcParam = $ReadOnly<{filename: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type UserUploadUserAvatarRpcParam = $ReadOnly<{filename: String, crop?: ?ImageCropRect, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type UserVersion = $ReadOnly<{uid: UID, eldestSeqno: Seqno}>
 

--- a/protocol/json/keybase1/avatars.json
+++ b/protocol/json/keybase1/avatars.json
@@ -45,6 +45,14 @@
           "type": "string",
           "name": "name",
           "jsonkey": "name"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "AvatarFormat"
+          },
+          "name": "formats",
+          "jsonkey": "formats"
         }
       ]
     }

--- a/protocol/json/keybase1/avatars.json
+++ b/protocol/json/keybase1/avatars.json
@@ -36,6 +36,17 @@
           "name": "picmap"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "AvatarClearCacheMsg",
+      "fields": [
+        {
+          "type": "string",
+          "name": "name",
+          "jsonkey": "name"
+        }
+      ]
     }
   ],
   "messages": {

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -729,6 +729,28 @@
           "name": "cachedAt"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "ImageCropRect",
+      "fields": [
+        {
+          "type": "int",
+          "name": "x0"
+        },
+        {
+          "type": "int",
+          "name": "y0"
+        },
+        {
+          "type": "int",
+          "name": "x1"
+        },
+        {
+          "type": "int",
+          "name": "y1"
+        }
+      ]
     }
   ],
   "messages": {},

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2529,6 +2529,19 @@
         }
       ],
       "response": null
+    },
+    "uploadTeamAvatar": {
+      "request": [
+        {
+          "name": "teamname",
+          "type": "string"
+        },
+        {
+          "name": "filename",
+          "type": "string"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2539,6 +2539,13 @@
         {
           "name": "filename",
           "type": "string"
+        },
+        {
+          "name": "crop",
+          "type": [
+            null,
+            "ImageCropRect"
+          ]
         }
       ],
       "response": null

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -590,6 +590,15 @@
       "response": "UPAKVersioned",
       "doc": "getUPAK returns a UPAK. Used mainly for debugging.",
       "lint": "ignore"
+    },
+    "uploadUserAvatar": {
+      "request": [
+        {
+          "name": "filename",
+          "type": "string"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -596,6 +596,13 @@
         {
           "name": "filename",
           "type": "string"
+        },
+        {
+          "name": "crop",
+          "type": [
+            null,
+            "ImageCropRect"
+          ]
         }
       ],
       "response": null

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2040,6 +2040,8 @@ export type AsyncOps =
   | 5 // MOVE_5
   | 6 // REMOVE_6
 
+export type AvatarClearCacheMsg = $ReadOnly<{name: String}>
+
 export type AvatarFormat = String
 
 export type AvatarUrl = String

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1805,6 +1805,10 @@ export const teamsTeamTreeRpcChannelMap = (configKeys: Array<string>, request: T
 
 export const teamsTeamTreeRpcPromise = (request: TeamsTeamTreeRpcParam): Promise<TeamsTeamTreeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.teamTree', request, (error: RPCError, result: TeamsTeamTreeResult) => (error ? reject(error) : resolve(result))))
 
+export const teamsUploadTeamAvatarRpcChannelMap = (configKeys: Array<string>, request: TeamsUploadTeamAvatarRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.uploadTeamAvatar', request)
+
+export const teamsUploadTeamAvatarRpcPromise = (request: TeamsUploadTeamAvatarRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.teams.uploadTeamAvatar', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
+
 export const testPanicRpcChannelMap = (configKeys: Array<string>, request: TestPanicRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.test.panic', request)
 
 export const testPanicRpcPromise = (request: TestPanicRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.test.panic', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
@@ -1985,6 +1989,10 @@ export const userResetUserRpcPromise = (request: UserResetUserRpcParam): Promise
 export const userSearchRpcChannelMap = (configKeys: Array<string>, request: UserSearchRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.search', request)
 
 export const userSearchRpcPromise = (request: UserSearchRpcParam): Promise<UserSearchResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.search', request, (error: RPCError, result: UserSearchResult) => (error ? reject(error) : resolve(result))))
+
+export const userUploadUserAvatarRpcChannelMap = (configKeys: Array<string>, request: UserUploadUserAvatarRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.uploadUserAvatar', request)
+
+export const userUploadUserAvatarRpcPromise = (request: UserUploadUserAvatarRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.uploadUserAvatar', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
 
 export type APIRes = $ReadOnly<{status: String, body: String, httpStatus: Int, appStatus: String}>
 
@@ -3962,6 +3970,8 @@ export type TeamsUiConfirmRootTeamDeleteRpcParam = $ReadOnly<{teamName: String, 
 
 export type TeamsUiConfirmSubteamDeleteRpcParam = $ReadOnly<{teamName: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type TeamsUploadTeamAvatarRpcParam = $ReadOnly<{teamname: String, filename: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type Test = $ReadOnly<{reply: String}>
 
 export type TestPanicRpcParam = $ReadOnly<{message: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -4140,6 +4150,8 @@ export type UserSummary2 = $ReadOnly<{uid: UID, username: String, thumbnail: Str
 export type UserSummary2Set = $ReadOnly<{users?: ?Array<UserSummary2>, time: Time, version: Int}>
 
 export type UserTeamShowcase = $ReadOnly<{fqName: String, open: Boolean, teamIsShowcased: Boolean, description: String, role: TeamRole, publicAdmins?: ?Array<String>, numMembers: Int}>
+
+export type UserUploadUserAvatarRpcParam = $ReadOnly<{filename: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type UserVersion = $ReadOnly<{uid: UID, eldestSeqno: Seqno}>
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2040,7 +2040,7 @@ export type AsyncOps =
   | 5 // MOVE_5
   | 6 // REMOVE_6
 
-export type AvatarClearCacheMsg = $ReadOnly<{name: String}>
+export type AvatarClearCacheMsg = $ReadOnly<{name: String, formats?: ?Array<AvatarFormat>}>
 
 export type AvatarFormat = String
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2645,6 +2645,8 @@ export type IdentifyUiStartRpcParam = $ReadOnly<{username: String, reason: Ident
 
 export type Identity = $ReadOnly<{status?: ?Status, whenLastTracked: Time, proofs?: ?Array<IdentifyRow>, cryptocurrency?: ?Array<Cryptocurrency>, revoked?: ?Array<TrackDiff>, revokedDetails?: ?Array<RevokedProof>, breaksTracking: Boolean}>
 
+export type ImageCropRect = $ReadOnly<{x0: Int, y0: Int, x1: Int, y1: Int}>
+
 export type ImplicitRole = $ReadOnly<{role: TeamRole, ancestor: TeamID}>
 
 export type ImplicitTeamConflictInfo = $ReadOnly<{generation: ConflictGeneration, time: Time}>
@@ -3970,7 +3972,7 @@ export type TeamsUiConfirmRootTeamDeleteRpcParam = $ReadOnly<{teamName: String, 
 
 export type TeamsUiConfirmSubteamDeleteRpcParam = $ReadOnly<{teamName: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type TeamsUploadTeamAvatarRpcParam = $ReadOnly<{teamname: String, filename: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type TeamsUploadTeamAvatarRpcParam = $ReadOnly<{teamname: String, filename: String, crop?: ?ImageCropRect, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type Test = $ReadOnly<{reply: String}>
 
@@ -4151,7 +4153,7 @@ export type UserSummary2Set = $ReadOnly<{users?: ?Array<UserSummary2>, time: Tim
 
 export type UserTeamShowcase = $ReadOnly<{fqName: String, open: Boolean, teamIsShowcased: Boolean, description: String, role: TeamRole, publicAdmins?: ?Array<String>, numMembers: Int}>
 
-export type UserUploadUserAvatarRpcParam = $ReadOnly<{filename: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type UserUploadUserAvatarRpcParam = $ReadOnly<{filename: String, crop?: ?ImageCropRect, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type UserVersion = $ReadOnly<{uid: UID, eldestSeqno: Seqno}>
 


### PR DESCRIPTION
This PR adds two new RPCs: `uploadTeamAvatar` and `uploadUserAvatar`. Given the filename, and optionally crop region, service will do a multipart POST request to `image/upload_team_avatar` or `image/upload_user_avatar`.

Avatars source got a `ClearCacheForName` method that will clear cache for name (both teams and user names share cache).

Introduced is also `avatarGregorHandler` which responds to `avatar.clear_cache_for_name` gregor messages by clearing avatar cache for name.

Because, even on local server, uploading an avatar creates a file on S3, there are no integration tests for this feature for now.