### PR TITLE
don't queue up background loads for conversations that are not actually in the inbox CORE-7808

### DIFF
--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -1267,6 +1267,7 @@ func (i *Inbox) ServerVersion(ctx context.Context) (vers int, err Error) {
 }
 
 type InboxSyncRes struct {
+	FilteredConvs      []types.RemoteConversation
 	TeamTypeChanged    bool
 	MembersTypeChanged []chat1.ConversationID
 	Expunges           []InboxSyncResExpunge
@@ -1349,6 +1350,11 @@ func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Co
 	if err = i.writeDiskInbox(ctx, ibox); err != nil {
 		return res, err
 	}
+
+	// Filter the conversations for the result
+	res.FilteredConvs = i.applyQuery(ctx, &chat1.GetInboxQuery{
+		ConvIDs: utils.PluckConvIDs(convs),
+	}, utils.RemoteConvs(convs))
 
 	return res, nil
 }

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -383,7 +383,8 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		}
 
 		// Dispatch background jobs
-		for _, conv := range incr.Convs {
+		for _, rc := range iboxSyncRes.FilteredConvs {
+			conv := rc.Conv
 			if delMsg, err := conv.GetMaxMessage(chat1.MessageType_DELETE); err == nil {
 				// Any conversation with a delete in it needs to be checked for expunge
 				if s.G().ConvSource.ClearFromDelete(ctx, uid, conv.GetConvID(), delMsg.GetMessageID()) {

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -658,3 +658,52 @@ func TestSyncerBackgroundLoader(t *testing.T) {
 	default:
 	}
 }
+
+func TestSyncerBackgroundLoaderRemoved(t *testing.T) {
+	ctx, world, ri2, _, sender, list := setupTest(t, 2)
+	defer world.Cleanup()
+
+	ri := ri2.(*kbtest.ChatRemoteMock)
+	u := world.GetUsers()[0]
+	uid := u.User.GetUID().ToBytes()
+	tc := world.Tcs[u.Username]
+	syncer := NewSyncer(tc.Context())
+	syncer.isConnected = true
+
+	conv := newConv(ctx, t, tc, uid, ri, sender, u.Username)
+	select {
+	case <-list.bgConvLoads:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no conv load on sync")
+	}
+	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
+		sconv := conv.DeepCopy()
+		sconv.ReaderInfo.Status = chat1.ConversationMemberStatus_REMOVED
+		return chat1.NewSyncInboxResWithIncremental(chat1.SyncIncrementalRes{
+			Vers:  100,
+			Convs: []chat1.Conversation{sconv},
+		}), nil
+	}
+	doSync(t, syncer, ri, uid)
+	time.Sleep(400 * time.Millisecond)
+	select {
+	case <-list.bgConvLoads:
+		require.Fail(t, "no sync should happen")
+	default:
+	}
+	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
+		sconv := conv.DeepCopy()
+		sconv.Metadata.Existence = chat1.ConversationExistence_ARCHIVED
+		return chat1.NewSyncInboxResWithIncremental(chat1.SyncIncrementalRes{
+			Vers:  100,
+			Convs: []chat1.Conversation{sconv},
+		}), nil
+	}
+	doSync(t, syncer, ri, uid)
+	time.Sleep(400 * time.Millisecond)
+	select {
+	case <-list.bgConvLoads:
+		require.Fail(t, "no sync should happen")
+	default:
+	}
+}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -675,6 +675,13 @@ func PluckConvIDs(convs []chat1.Conversation) (res []chat1.ConversationID) {
 	return res
 }
 
+func PluckConvIDsRC(convs []types.RemoteConversation) (res []chat1.ConversationID) {
+	for _, conv := range convs {
+		res = append(res, conv.GetConvID())
+	}
+	return res
+}
+
 func SanitizeTopicName(topicName string) string {
 	return strings.TrimPrefix(topicName, "#")
 }


### PR DESCRIPTION
Previously we were queuing up conversations on the background loader from sync that we were removed from (or if they were deleted).