### PR TITLE
libkb.HTTPSrv: fix a potential race; idempotent EnsureActive(); reuse ServeMux

### DIFF
--- a/go/avatars/fullcaching_test.go
+++ b/go/avatars/fullcaching_test.go
@@ -24,13 +24,15 @@ func TestAvatarsFullCaching(t *testing.T) {
 	tc.G.SetClock(clock)
 
 	testSrv := libkb.NewHTTPSrv(tc.G, libkb.NewPortRangeListenerSource(7000, 8000))
-	require.NoError(t, testSrv.Start())
-	testSrv.HandleFunc("/p", func(w http.ResponseWriter, req *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/p", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "hi")
 	})
-	testSrv.HandleFunc("/p2", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/p2", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "hi2")
 	})
+	_, err := testSrv.EnsureActive(mux)
+	require.NoError(t, err)
 
 	ctx := context.TODO()
 	cb := make(chan struct{}, 5)

--- a/go/libkb/httpsrv_test.go
+++ b/go/libkb/httpsrv_test.go
@@ -15,10 +15,12 @@ func TestHTTPSrv(t *testing.T) {
 
 	test := func(s HTTPSrvListenerSource) {
 		srv := NewHTTPSrv(tc.G, s)
-		require.NoError(t, srv.Start())
-		srv.HandleFunc("/test", func(resp http.ResponseWriter, req *http.Request) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/test", func(resp http.ResponseWriter, req *http.Request) {
 			fmt.Fprintf(resp, "success")
 		})
+		_, err := srv.EnsureActive(mux)
+		require.NoError(t, err)
 		addr, err := srv.Addr()
 		require.NoError(t, err)
 		url := fmt.Sprintf("http://%s/test", addr)


### PR DESCRIPTION
If `Addr()` is called immediately after `Start()` is called, it's possible that `Addr()` grabs lock before the goroutine spawned in `Start()` does, and it'd find `active` to be false, and returns an error. So this PR sets `active` to true before releasing the lock in `Start()`. (I don't have proof from the logs to show this is indeed what happened for Patrick and Miles, but this is the likely cause that I suspect.)

Also changing `Start()` into an idempotent `EnsureActive()`.