### PR TITLE
Make the editing marker on mobile fit from top to bottom as it does on desktop.

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -204,7 +204,7 @@ const styles = styleSheetCreate({
     ...globalStyles.flexBoxColumn,
     alignItems: 'center',
     justifyContent: 'center',
-    paddingBottom: 6,
+    paddingBottom: 12,
     paddingLeft: globalMargins.tiny,
     paddingRight: globalMargins.tiny,
   },
@@ -216,20 +216,19 @@ const styles = styleSheetCreate({
     borderTopWidth: 1,
     flexShrink: 0,
     minHeight: 48,
-    paddingBottom: 6,
     paddingRight: 6,
-    paddingTop: 6,
   },
   editingTabStyle: {
     ...globalStyles.flexBoxColumn,
     alignItems: 'flex-start',
     backgroundColor: globalColors.yellow_60,
     height: '100%',
+    padding: 3,
   },
   input: {
     marginLeft: globalMargins.tiny,
-    paddingBottom: 6,
-    paddingTop: 6,
+    paddingBottom: 12,
+    paddingTop: 12,
     ...(isIOS
       ? {}
       : {


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review.