### PR TITLE
stop blocking Linux builds on CircleCI

### DIFF
--- a/packaging/linux/build_and_push_packages.sh
+++ b/packaging/linux/build_and_push_packages.sh
@@ -45,7 +45,7 @@ export GITHUB_TOKEN="$(cat ~/.github_token)"
 # NB: This is duplicated in packaging/prerelease/build_app.sh.
 if [ ! "${NOWAIT:-}" = "1" ]; then
   echo "Checking client CI"
-  "$release_bin" wait-ci --repo="client" --commit="$(git -C $client_dir rev-parse HEAD)" --context="continuous-integration/jenkins/branch" --context="ci/circleci"
+  "$release_bin" wait-ci --repo="client" --commit="$(git -C $client_dir rev-parse HEAD)" --context="continuous-integration/jenkins/branch"
   if [ "$mode" != "production" ] ; then
     echo "Checking kbfs CI"
     "$release_bin" wait-ci --repo="kbfs" --commit="$(git -C $kbfs_dir rev-parse HEAD)" --context="continuous-integration/jenkins/branch"


### PR DESCRIPTION
This seems to be causing us some trouble, and @mmaxim suggests it doesn't have much value. (Just blocking on an Android build, rather than testing anything directly Linux-related?)

r? @cjb @strib