### PR TITLE
Revert "disable test that was failing"

### DIFF
--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -274,7 +274,6 @@ func TestRotateSkipTeamEKRoll(t *testing.T) {
 }
 
 func TestNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
-	t.Skip()
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 


### PR DESCRIPTION
This reverts commit 112ffc9e4fc7448fcf3d152d187a1df9d5606714.
    
Our hope is that https://github.com/keybase/keybase/pull/2466 has fixed
the flakiness.