### PR TITLE
Attach sender info to error message

### DIFF
--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -489,7 +489,10 @@ const errorUIMessagetoMessage = (
   o: RPCChatTypes.MessageUnboxedError
 ) => {
   return makeMessageText({
+    author: o.senderUsername,
     conversationIDKey,
+    deviceName: o.senderDeviceName,
+    deviceType: DeviceTypes.stringToDeviceType(o.senderDeviceType),
     errorReason: o.errMsg,
     id: Types.numberToMessageID(o.messageID),
     ordinal: Types.numberToOrdinal(o.messageID),


### PR DESCRIPTION
This attaches the author, deviceName, and deviceType. We don't get `senderDeviceRevokedAt` with this message, so it's possible for us to show `Encrypted and signed by {devicename}` without noting that it's been revoked. cc @mmaxim r? @keybase/react-hackers 