### PR TITLE
Add -A, -B, -C flags for chat search.

### DIFF
--- a/go/chat/searcher.go
+++ b/go/chat/searcher.go
@@ -25,58 +25,121 @@ func NewSearcher(g *globals.Context) *Searcher {
 	}
 }
 
-func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchHit, conversationID chat1.ConversationID, re *regexp.Regexp, maxHits int, maxMessages int) (hits []chat1.ChatSearchHit, rlimits []chat1.RateLimit, err error) {
+func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchHit, conversationID chat1.ConversationID, re *regexp.Regexp,
+	maxHits, maxMessages, beforeContext, afterContext int) (hits []chat1.ChatSearchHit, rlimits []chat1.RateLimit, err error) {
 	uid := gregor1.UID(s.G().Env.GetUID().ToBytes())
 	pagination := &chat1.Pagination{Num: pageSize}
-	typs := []chat1.MessageType{chat1.MessageType_TEXT}
-	getThreadQuery := &chat1.GetThreadQuery{MessageTypes: typs}
 
-	var prev *chat1.MessageUnboxed
-	var next *chat1.MessageUnboxed
-	var searchHit chat1.ChatSearchHit
-	var rlimitsp []*chat1.RateLimit
-	numHits := 0
-	numMessages := 0
-	getPresentMsg := func(msg *chat1.MessageUnboxed) *chat1.UIMessage {
-		if msg != nil {
-			uiMsg := utils.PresentMessageUnboxed(ctx, s.G(), *msg, uid, conversationID)
-			return &uiMsg
-		}
-		return nil
+	if beforeContext >= pageSize {
+		beforeContext = pageSize - 1
 	}
-	for !pagination.Last && numHits < maxHits && numMessages < maxMessages {
-		thread, rl, err := s.G().ConvSource.Pull(ctx, conversationID, uid, getThreadQuery, pagination)
+	if afterContext >= pageSize {
+		afterContext = pageSize - 1
+	}
+
+	var rlimitsp []*chat1.RateLimit
+	// If we have to gather search result context around a pagination boundary
+	// we may have to fetch a thread and need to prevent refetching after this.
+	var prevThread, curThread *chat1.ThreadView
+	fetchThread := true
+
+	getThread := func() error {
+		prevThread = curThread
+		thread, rl, err := s.G().ConvSource.Pull(ctx, conversationID, uid, &chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}, pagination)
 		if err != nil {
-			return hits, rlimits, err
+			return err
 		}
-		pagination = thread.Pagination
+		curThread = &thread
+		pagination = curThread.Pagination
 		pagination.Num = pageSize
 		pagination.Previous = nil
 		rlimitsp = append(rlimitsp, rl...)
+		return nil
+	}
 
-		for i, msg := range thread.Messages {
-			msg := msg
+	getBeforeMsgs := func(i int) ([]chat1.MessageUnboxed, error) {
+		// Return context from the current thread only
+		if i+beforeContext < len(curThread.Messages) {
+			return curThread.Messages[i+1 : i+beforeContext+1], nil
+		}
+		hitContext := curThread.Messages[i+1:]
+		if prevThread != nil {
+			err := getThread()
+			if err != nil {
+				return nil, err
+			}
+			fetchThread = false
+			// Get the remaining context from the new current page  of the thread.
+			hitContext = append(curThread.Messages[:beforeContext-len(hitContext)], hitContext...)
+		}
+		return hitContext, nil
+	}
+
+	getAfterMsgs := func(i int) []chat1.MessageUnboxed {
+		// Return context from the current thread only
+		if afterContext < i {
+			return curThread.Messages[i-afterContext : i]
+		}
+		hitContext := curThread.Messages[:i]
+		if prevThread != nil {
+			// Get the remaining context from the previous page of the thread.
+			hitContext = append(prevThread.Messages[len(prevThread.Messages)-afterContext+i:], hitContext...)
+		}
+		return hitContext
+	}
+
+	// Order messages ascending by ID for presentation
+	getUIMsgs := func(msgs []chat1.MessageUnboxed) (uiMsgs []chat1.UIMessage) {
+		for i := len(msgs) - 1; i >= 0; i-- {
+			msg := msgs[i]
+			uiMsg := utils.PresentMessageUnboxed(ctx, s.G(), msg, uid, conversationID)
+			uiMsgs = append(uiMsgs, uiMsg)
+		}
+		return uiMsgs
+	}
+
+	numHits := 0
+	numMessages := 0
+	for !pagination.Last && numHits < maxHits && numMessages < maxMessages {
+		if fetchThread {
+			err := getThread()
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		// Reset this since we want to fetch on the next iteration.
+		fetchThread = true
+
+		for i, msg := range curThread.Messages {
 			if msg.IsValid() && msg.GetMessageType() == chat1.MessageType_TEXT {
 				numMessages++
-
-				if i+1 < len(thread.Messages) {
-					prev = &thread.Messages[i+1]
-				} else {
-					// Clear prev
-					prev = nil
+				if msg.Valid().MessageBody.IsNil() {
+					continue
 				}
-
 				msgText := msg.Valid().MessageBody.Text().Body
 				matches := re.FindAllString(msgText, -1)
 
 				if matches != nil {
 					numHits++
 
-					searchHit = chat1.ChatSearchHit{
-						PrevMessage: getPresentMsg(prev),
-						HitMessage:  getPresentMsg(&msg),
-						NextMessage: getPresentMsg(next),
-						Matches:     matches,
+					// First we fetch the msgs after the search hit, possibly
+					// using prevThread if we are at a pagination boundary
+					// (since msgs are ordered last to first).
+					afterMsgs := getAfterMsgs(i)
+					// Now we fetch the msgs before the search hit, possibly
+					// fetching a new page of results if we are at a pagination
+					// boundary.
+					beforeMsgs, err := getBeforeMsgs(i)
+					if err != nil {
+						return nil, nil, err
+					}
+					searchHit := chat1.ChatSearchHit{
+						BeforeMessages: getUIMsgs(beforeMsgs),
+						HitMessage:     utils.PresentMessageUnboxed(ctx, s.G(), msg, uid, conversationID),
+						AfterMessages:  getUIMsgs(afterMsgs),
+						Matches:        matches,
 					}
 					if uiCh != nil {
 						// Stream search hits back to the UI
@@ -85,9 +148,6 @@ func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchH
 					}
 					hits = append(hits, searchHit)
 				}
-				// Threads are ordered newest to oldest, so the current msg
-				// becomes the next msg for search context
-				next = &msg
 			}
 			if numHits >= maxHits || numMessages >= maxMessages {
 				break

--- a/go/chat/searcher.go
+++ b/go/chat/searcher.go
@@ -10,11 +10,13 @@ import (
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
-const pageSize = 300
+const defaultPageSize = 300
 
 type Searcher struct {
 	globals.Contextified
 	utils.DebugLabeler
+
+	pageSize int
 }
 
 func NewSearcher(g *globals.Context) *Searcher {
@@ -22,70 +24,92 @@ func NewSearcher(g *globals.Context) *Searcher {
 	return &Searcher{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: labeler,
+		pageSize:     defaultPageSize,
 	}
 }
 
 func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchHit, conversationID chat1.ConversationID, re *regexp.Regexp,
 	maxHits, maxMessages, beforeContext, afterContext int) (hits []chat1.ChatSearchHit, rlimits []chat1.RateLimit, err error) {
 	uid := gregor1.UID(s.G().Env.GetUID().ToBytes())
-	pagination := &chat1.Pagination{Num: pageSize}
+	pagination := &chat1.Pagination{Num: s.pageSize}
 
-	if beforeContext >= pageSize {
-		beforeContext = pageSize - 1
+	// Context cannot exceed the page size.
+	if beforeContext >= s.pageSize {
+		beforeContext = s.pageSize - 1
 	}
-	if afterContext >= pageSize {
-		afterContext = pageSize - 1
+	if afterContext >= s.pageSize {
+		afterContext = s.pageSize - 1
 	}
 
 	var rlimitsp []*chat1.RateLimit
-	// If we have to gather search result context around a pagination boundary
-	// we may have to fetch a thread and need to prevent refetching after this.
-	var prevThread, curThread *chat1.ThreadView
-	fetchThread := true
+	// If we have to gather search result context around a pagination boundary,
+	// we may have to fetch the next page of the thread
+	var prevPage, curPage, nextPage *chat1.ThreadView
 
-	getThread := func() error {
-		prevThread = curThread
+	getNextPage := func() (*chat1.ThreadView, error) {
 		thread, rl, err := s.G().ConvSource.Pull(ctx, conversationID, uid, &chat1.GetThreadQuery{
 			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
 		}, pagination)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		curThread = &thread
-		pagination = curThread.Pagination
-		pagination.Num = pageSize
+		filteredMsgs := []chat1.MessageUnboxed{}
+		// Filter out invalid/exploded messages so our search context is
+		// correct.
+		for _, msg := range thread.Messages {
+			if msg.IsValid() && msg.GetMessageType() == chat1.MessageType_TEXT && !msg.Valid().MessageBody.IsNil() {
+				filteredMsgs = append(filteredMsgs, msg)
+			}
+		}
+		thread.Messages = filteredMsgs
+		pagination = thread.Pagination
+		pagination.Num = s.pageSize
 		pagination.Previous = nil
 		rlimitsp = append(rlimitsp, rl...)
-		return nil
+		return &thread, nil
 	}
 
-	getBeforeMsgs := func(i int) ([]chat1.MessageUnboxed, error) {
-		// Return context from the current thread only
-		if i+beforeContext < len(curThread.Messages) {
-			return curThread.Messages[i+1 : i+beforeContext+1], nil
+	// Returns search context before the search hit, at position `i` in
+	// `cur.Messages` possibly fetching and returning a new page of results if
+	// we are at a pagination boundary.
+	getBeforeMsgs := func(i int, cur, next *chat1.ThreadView) (*chat1.ThreadView, []chat1.MessageUnboxed, error) {
+		// context is contained entirely in this page of the thread.
+		if i+beforeContext < len(cur.Messages) {
+			return next, cur.Messages[i+1 : i+beforeContext+1], nil
 		}
-		hitContext := curThread.Messages[i+1:]
-		if prevThread != nil {
-			err := getThread()
+		// Get all of the context after our hit index of the current page and fetch a new page if available.
+		hitContext := cur.Messages[i+1:]
+		if next == nil {
+			next, err = getNextPage()
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			fetchThread = false
-			// Get the remaining context from the new current page  of the thread.
-			hitContext = append(curThread.Messages[:beforeContext-len(hitContext)], hitContext...)
 		}
-		return hitContext, nil
+		// Get the remaining context from the new current page of the thread.
+		remainingContext := beforeContext - len(hitContext)
+		if remainingContext > len(next.Messages) {
+			remainingContext = len(next.Messages)
+		}
+		hitContext = append(next.Messages[:remainingContext], hitContext...)
+		return next, hitContext, nil
 	}
 
-	getAfterMsgs := func(i int) []chat1.MessageUnboxed {
+	// Returns the search context surrounding a search result at index `i` in
+	// `cur.Messages`, possibly using prev if we are at a
+	// pagination boundary (since msgs are ordered last to first).
+	getAfterMsgs := func(i int, prev, cur *chat1.ThreadView) []chat1.MessageUnboxed {
 		// Return context from the current thread only
 		if afterContext < i {
-			return curThread.Messages[i-afterContext : i]
+			return cur.Messages[i-afterContext : i]
 		}
-		hitContext := curThread.Messages[:i]
-		if prevThread != nil {
+		hitContext := cur.Messages[:i]
+		if prev != nil {
 			// Get the remaining context from the previous page of the thread.
-			hitContext = append(prevThread.Messages[len(prevThread.Messages)-afterContext+i:], hitContext...)
+			remainingContext := len(prev.Messages) - (afterContext - len(hitContext))
+			if remainingContext < 0 {
+				remainingContext = 0
+			}
+			hitContext = append(hitContext, prev.Messages[remainingContext:]...)
 		}
 		return hitContext
 	}
@@ -103,51 +127,43 @@ func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchH
 	numHits := 0
 	numMessages := 0
 	for !pagination.Last && numHits < maxHits && numMessages < maxMessages {
-		if fetchThread {
-			err := getThread()
+		prevPage = curPage
+		if nextPage == nil {
+			curPage, err = getNextPage()
 			if err != nil {
 				return nil, nil, err
 			}
+		} else { // we pre-fetched the next page when retrieving context
+			curPage = nextPage
+			nextPage = nil
 		}
-		// Reset this since we want to fetch on the next iteration.
-		fetchThread = true
 
-		for i, msg := range curThread.Messages {
-			if msg.IsValid() && msg.GetMessageType() == chat1.MessageType_TEXT {
-				numMessages++
-				if msg.Valid().MessageBody.IsNil() {
-					continue
+		for i, msg := range curPage.Messages {
+			numMessages++
+			msgText := msg.Valid().MessageBody.Text().Body
+			matches := re.FindAllString(msgText, -1)
+
+			if matches != nil {
+				numHits++
+
+				afterMsgs := getAfterMsgs(i, prevPage, curPage)
+				newThread, beforeMsgs, err := getBeforeMsgs(i, curPage, nextPage)
+				if err != nil {
+					return nil, nil, err
 				}
-				msgText := msg.Valid().MessageBody.Text().Body
-				matches := re.FindAllString(msgText, -1)
-
-				if matches != nil {
-					numHits++
-
-					// First we fetch the msgs after the search hit, possibly
-					// using prevThread if we are at a pagination boundary
-					// (since msgs are ordered last to first).
-					afterMsgs := getAfterMsgs(i)
-					// Now we fetch the msgs before the search hit, possibly
-					// fetching a new page of results if we are at a pagination
-					// boundary.
-					beforeMsgs, err := getBeforeMsgs(i)
-					if err != nil {
-						return nil, nil, err
-					}
-					searchHit := chat1.ChatSearchHit{
-						BeforeMessages: getUIMsgs(beforeMsgs),
-						HitMessage:     utils.PresentMessageUnboxed(ctx, s.G(), msg, uid, conversationID),
-						AfterMessages:  getUIMsgs(afterMsgs),
-						Matches:        matches,
-					}
-					if uiCh != nil {
-						// Stream search hits back to the UI
-						// channel
-						uiCh <- searchHit
-					}
-					hits = append(hits, searchHit)
+				nextPage = newThread
+				searchHit := chat1.ChatSearchHit{
+					BeforeMessages: getUIMsgs(beforeMsgs),
+					HitMessage:     utils.PresentMessageUnboxed(ctx, s.G(), msg, uid, conversationID),
+					AfterMessages:  getUIMsgs(afterMsgs),
+					Matches:        matches,
 				}
+				if uiCh != nil {
+					// Stream search hits back to the UI
+					// channel
+					uiCh <- searchHit
+				}
+				hits = append(hits, searchHit)
 			}
 			if numHits >= maxHits || numMessages >= maxMessages {
 				break

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -227,7 +227,10 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	g.PushHandler = pushHandler
 	g.ChatHelper = NewHelper(g, getRI)
 	g.TeamChannelSource = NewCachingTeamChannelSource(g, getRI)
-	g.Searcher = NewSearcher(g)
+	searcher := NewSearcher(g)
+	// Force small pages during tests to ensure we fetch context from new pages
+	searcher.pageSize = 2
+	g.Searcher = searcher
 	g.AttachmentURLSrv = DummyAttachmentHTTPSrv{}
 
 	return ctx, world, ri, sender, baseSender, &listener

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2716,7 +2716,7 @@ func (h *Server) GetSearchRegexp(ctx context.Context, arg chat1.GetSearchRegexpA
 		close(ch)
 	}()
 	hits, rlimits, err := h.G().Searcher.SearchRegexp(ctx, uiCh, arg.ConversationID, re, arg.MaxHits,
-		arg.MaxMessages)
+		arg.MaxMessages, arg.BeforeContext, arg.AfterContext)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -92,7 +92,7 @@ type MessageDeliverer interface {
 }
 
 type Searcher interface {
-	SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchHit, conversationID chat1.ConversationID, re *regexp.Regexp, maxHits int, maxMessages int) (hits []chat1.ChatSearchHit, rlimits []chat1.RateLimit, err error)
+	SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchHit, conversationID chat1.ConversationID, re *regexp.Regexp, maxHits, maxMessages, beforeContext, afterContext int) (hits []chat1.ChatSearchHit, rlimits []chat1.RateLimit, err error)
 }
 
 type Sender interface {

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -307,6 +307,8 @@ type searchRegexpOptionsV1 struct {
 	IsRegex        bool   `json:"is_regex"`
 	MaxHits        int    `json:"max_hits"`
 	MaxMessages    int    `json:"max_messages"`
+	BeforeContext  int    `json:"before_context"`
+	AfterContext   int    `json:"after_context"`
 }
 
 func (o searchRegexpOptionsV1) Check() error {

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -681,6 +681,8 @@ func (c *chatServiceHandler) SearchRegexpV1(ctx context.Context, opts searchRege
 		IsRegex:          opts.IsRegex,
 		MaxHits:          opts.MaxHits,
 		MaxMessages:      opts.MaxMessages,
+		BeforeContext:    opts.BeforeContext,
+		AfterContext:     opts.AfterContext,
 	}
 
 	res, err := client.GetSearchRegexp(ctx, arg)

--- a/go/client/cmd_chat_search.go
+++ b/go/client/cmd_chat_search.go
@@ -24,6 +24,8 @@ type CmdChatSearch struct {
 	query            string
 	maxHits          int
 	maxMessages      int
+	beforeContext    int
+	afterContext     int
 	isRegex          bool
 	hasTTY           bool
 }
@@ -55,13 +57,29 @@ func newCmdChatSearch(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 			cli.IntFlag{
 				Name:  "max-hits",
 				Value: 10,
-				Usage: "Specify the maximum number of search hits to get. Default is 10",
+				Usage: "Specify the maximum number of search hits to get.",
 			},
 			cli.IntFlag{
 				Name:  "max-messages",
 				Value: 10000,
-				Usage: "Specify the maximum number of messages to search. Default is 10000",
-			}),
+				Usage: "Specify the maximum number of messages to search.",
+			},
+			cli.IntFlag{
+				Name:  "B, before-context",
+				Value: 0,
+				Usage: "Print number messages of leading context before each match.",
+			},
+			cli.IntFlag{
+				Name:  "A, after-context",
+				Value: 0,
+				Usage: "Print number of messages of trailing context after each match.",
+			},
+			cli.IntFlag{
+				Name:  "C, context",
+				Value: 2,
+				Usage: "Print number of messages of leading and trailing context surrounding each match.",
+			},
+		),
 	}
 }
 
@@ -121,6 +139,8 @@ func (c *CmdChatSearch) Run() (err error) {
 		IsRegex:          c.isRegex,
 		MaxHits:          c.maxHits,
 		MaxMessages:      c.maxMessages,
+		BeforeContext:    c.beforeContext,
+		AfterContext:     c.afterContext,
 	}
 
 	_, err = resolver.ChatClient.GetSearchRegexp(ctx, arg)
@@ -142,6 +162,15 @@ func (c *CmdChatSearch) ParseArgv(ctx *cli.Context) (err error) {
 	c.query = ctx.Args().Get(1)
 	c.maxHits = ctx.Int("max-hits")
 	c.maxMessages = ctx.Int("max-messages")
+
+	c.afterContext = ctx.Int("after-context")
+	c.beforeContext = ctx.Int("before-context")
+	if c.afterContext == 0 && c.beforeContext == 0 {
+		context := ctx.Int("context")
+		c.beforeContext = context
+		c.afterContext = context
+	}
+
 	c.isRegex = ctx.Bool("regex")
 	query := c.query
 	if !c.isRegex {

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -683,35 +683,37 @@ func (o UIMessages) DeepCopy() UIMessages {
 }
 
 type ChatSearchHit struct {
-	PrevMessage *UIMessage `codec:"prevMessage,omitempty" json:"prevMessage,omitempty"`
-	HitMessage  *UIMessage `codec:"hitMessage,omitempty" json:"hitMessage,omitempty"`
-	NextMessage *UIMessage `codec:"nextMessage,omitempty" json:"nextMessage,omitempty"`
-	Matches     []string   `codec:"matches" json:"matches"`
+	BeforeMessages []UIMessage `codec:"beforeMessages" json:"beforeMessages"`
+	HitMessage     UIMessage   `codec:"hitMessage" json:"hitMessage"`
+	AfterMessages  []UIMessage `codec:"afterMessages" json:"afterMessages"`
+	Matches        []string    `codec:"matches" json:"matches"`
 }
 
 func (o ChatSearchHit) DeepCopy() ChatSearchHit {
 	return ChatSearchHit{
-		PrevMessage: (func(x *UIMessage) *UIMessage {
+		BeforeMessages: (func(x []UIMessage) []UIMessage {
 			if x == nil {
 				return nil
 			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.PrevMessage),
-		HitMessage: (func(x *UIMessage) *UIMessage {
+			var ret []UIMessage
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.BeforeMessages),
+		HitMessage: o.HitMessage.DeepCopy(),
+		AfterMessages: (func(x []UIMessage) []UIMessage {
 			if x == nil {
 				return nil
 			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.HitMessage),
-		NextMessage: (func(x *UIMessage) *UIMessage {
-			if x == nil {
-				return nil
+			var ret []UIMessage
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
 			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.NextMessage),
+			return ret
+		})(o.AfterMessages),
 		Matches: (func(x []string) []string {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -4230,6 +4230,8 @@ type GetSearchRegexpArg struct {
 	IsRegex          bool                         `codec:"isRegex" json:"isRegex"`
 	MaxHits          int                          `codec:"maxHits" json:"maxHits"`
 	MaxMessages      int                          `codec:"maxMessages" json:"maxMessages"`
+	BeforeContext    int                          `codec:"beforeContext" json:"beforeContext"`
+	AfterContext     int                          `codec:"afterContext" json:"afterContext"`
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -171,9 +171,9 @@ protocol chatUi {
   void chatThreadFull(int sessionID, string thread) oneway;
 
   record ChatSearchHit {
-    union{ null, UIMessage } prevMessage;
-    union{ null, UIMessage } hitMessage;
-    union{ null, UIMessage } nextMessage;
+    array<UIMessage> beforeMessages;
+    UIMessage hitMessage;
+    array<UIMessage> afterMessages;
     array<string>  matches;
   }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -854,5 +854,5 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  GetSearchRegexpRes getSearchRegexp(int sessionID, ConversationID conversationID, string query, boolean isRegex, int maxHits, int maxMessages, keybase1.TLFIdentifyBehavior identifyBehavior);
+  GetSearchRegexpRes getSearchRegexp(int sessionID, ConversationID conversationID, string query, boolean isRegex, int maxHits, int maxMessages, int beforeContext, int afterContext, keybase1.TLFIdentifyBehavior identifyBehavior);
 }

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -635,7 +635,7 @@ export type ChatActivityType =
   | 9 // EXPUNGE_9
   | 10 // EPHEMERAL_PURGE_10
 
-export type ChatSearchHit = $ReadOnly<{prevMessage?: ?UIMessage, hitMessage?: ?UIMessage, nextMessage?: ?UIMessage, matches?: ?Array<String>}>
+export type ChatSearchHit = $ReadOnly<{beforeMessages?: ?Array<UIMessage>, hitMessage: UIMessage, afterMessages?: ?Array<UIMessage>, matches?: ?Array<String>}>
 
 export type ChatSyncIncrementalInfo = $ReadOnly<{items?: ?Array<UnverifiedInboxUIItem>}>
 
@@ -916,7 +916,7 @@ export type LocalGetInboxSummaryForCLILocalRpcParam = $ReadOnly<{query: GetInbox
 
 export type LocalGetMessagesLocalRpcParam = $ReadOnly<{conversationID: ConversationID, messageIDs?: ?Array<MessageID>, disableResolveSupersedes: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type LocalGetSearchRegexpRpcParam = $ReadOnly<{conversationID: ConversationID, query: String, isRegex: Boolean, maxHits: Int, maxMessages: Int, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type LocalGetSearchRegexpRpcParam = $ReadOnly<{conversationID: ConversationID, query: String, isRegex: Boolean, maxHits: Int, maxMessages: Int, beforeContext: Int, afterContext: Int, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalGetTLFConversationsLocalRpcParam = $ReadOnly<{tlfName: String, topicType: TopicType, membersType: ConversationMembersType, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -588,25 +588,22 @@
       "name": "ChatSearchHit",
       "fields": [
         {
-          "type": [
-            null,
-            "UIMessage"
-          ],
-          "name": "prevMessage"
+          "type": {
+            "type": "array",
+            "items": "UIMessage"
+          },
+          "name": "beforeMessages"
         },
         {
-          "type": [
-            null,
-            "UIMessage"
-          ],
+          "type": "UIMessage",
           "name": "hitMessage"
         },
         {
-          "type": [
-            null,
-            "UIMessage"
-          ],
-          "name": "nextMessage"
+          "type": {
+            "type": "array",
+            "items": "UIMessage"
+          },
+          "name": "afterMessages"
         },
         {
           "type": {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -3492,6 +3492,14 @@
           "type": "int"
         },
         {
+          "name": "beforeContext",
+          "type": "int"
+        },
+        {
+          "name": "afterContext",
+          "type": "int"
+        },
+        {
           "name": "identifyBehavior",
           "type": "keybase1.TLFIdentifyBehavior"
         }

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -635,7 +635,7 @@ export type ChatActivityType =
   | 9 // EXPUNGE_9
   | 10 // EPHEMERAL_PURGE_10
 
-export type ChatSearchHit = $ReadOnly<{prevMessage?: ?UIMessage, hitMessage?: ?UIMessage, nextMessage?: ?UIMessage, matches?: ?Array<String>}>
+export type ChatSearchHit = $ReadOnly<{beforeMessages?: ?Array<UIMessage>, hitMessage: UIMessage, afterMessages?: ?Array<UIMessage>, matches?: ?Array<String>}>
 
 export type ChatSyncIncrementalInfo = $ReadOnly<{items?: ?Array<UnverifiedInboxUIItem>}>
 
@@ -916,7 +916,7 @@ export type LocalGetInboxSummaryForCLILocalRpcParam = $ReadOnly<{query: GetInbox
 
 export type LocalGetMessagesLocalRpcParam = $ReadOnly<{conversationID: ConversationID, messageIDs?: ?Array<MessageID>, disableResolveSupersedes: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type LocalGetSearchRegexpRpcParam = $ReadOnly<{conversationID: ConversationID, query: String, isRegex: Boolean, maxHits: Int, maxMessages: Int, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type LocalGetSearchRegexpRpcParam = $ReadOnly<{conversationID: ConversationID, query: String, isRegex: Boolean, maxHits: Int, maxMessages: Int, beforeContext: Int, afterContext: Int, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalGetTLFConversationsLocalRpcParam = $ReadOnly<{tlfName: String, topicType: TopicType, membersType: ConversationMembersType, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 


### PR DESCRIPTION
Add grep like context flags to search to allow controlling context surrounding a hit as proposed in https://github.com/keybase/client/issues/8523#issuecomment-386037704

cc @zapu 


```
$ kb chat search --help
Running `go install github.com/keybase/client/go/keybase`... Done.
NAME:
   keybase chat search - Search via regex within a conversation

USAGE:
   keybase chat search [command options] <conversation> <query>

OPTIONS:
   --topic-type "chat"          Specify topic type of the conversation. Has to be chat or dev
   --channel                    Specify the conversation channel.
   --public                     Only select public conversations. Exclusive to --private
   --private                    Only select private conversations. Exclusive to --public. If both --public and --private are present, --private takes priority.
   -r, --regex                  Make the given query a regex
   --max-hits "10"              Specify the maximum number of search hits to get.
   --max-messages "10000"       Specify the maximum number of messages to search.
   -B, --before-context "0"     Print number messages of leading context before each match.
   -A, --after-context "0"      Print number of messages of trailing context after each match.
   -C, --context "2"            Print number of messages of leading and trailing context surrounding each match.
````