### PR TITLE
Show local file as preview when sending attachment

### DIFF
--- a/shared/chat/conversation/messages/message-popup/attachment/container.js
+++ b/shared/chat/conversation/messages/message-popup/attachment/container.js
@@ -27,6 +27,7 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   return {
     _canDeleteHistory,
     _you: state.config.username,
+    pending: !!message.transferState,
   }
 }
 
@@ -92,6 +93,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
       isMobile && message.attachmentType === 'image' ? () => dispatchProps._onSaveAttachment(message) : null,
     onShareAttachment: isIOS ? () => dispatchProps._onShareAttachment(message) : null,
     onShowInFinder: !isMobile && message.downloadPath ? () => dispatchProps._onShowInFinder(message) : null,
+    pending: stateProps.pending,
     position: ownProps.position,
     timestamp: message.timestamp,
     visible: ownProps.visible,

--- a/shared/chat/conversation/messages/message-popup/attachment/index.js
+++ b/shared/chat/conversation/messages/message-popup/attachment/index.js
@@ -19,6 +19,7 @@ type Props = {
   onSaveAttachment: null | (() => void),
   onShareAttachment: null | (() => void),
   onShowInFinder: null | (() => void),
+  pending: boolean,
   position: Position,
   style?: Object,
   timestamp: number,
@@ -52,9 +53,13 @@ const AttachmentPopupMenu = (props: Props) => {
       : []),
     'Divider',
     ...(props.onShowInFinder ? [{onClick: props.onShowInFinder, title: `Show in ${fileUIName}`}] : []),
-    ...(props.onSaveAttachment ? [{onClick: props.onSaveAttachment, title: 'Save'}] : []),
-    ...(props.onShareAttachment ? [{onClick: props.onShareAttachment, title: 'Share'}] : []),
-    ...(props.onDownload ? [{onClick: props.onDownload, title: 'Download'}] : []),
+    ...(props.onSaveAttachment
+      ? [{disabled: props.pending, onClick: props.onSaveAttachment, title: 'Save'}]
+      : []),
+    ...(props.onShareAttachment
+      ? [{disabled: props.pending, onClick: props.onShareAttachment, title: 'Share'}]
+      : []),
+    ...(props.onDownload ? [{disabled: props.pending, onClick: props.onDownload, title: 'Download'}] : []),
   ]
 
   const header = {

--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -616,9 +616,11 @@ export const upgradeMessage = (old: Types.Message, m: Types.Message) => {
     if (old.submitState === 'pending') {
       // we sent an attachment, service replied
       // with the real message. replace our placeholder but
-      // only hold on to the ordinal so it doesn't
+      // hold on to the ordinal so it doesn't
       // jump in the conversation view
-      return m.set('ordinal', old.ordinal)
+      // hold on to the previewURL so that we
+      // don't show the gray box.
+      return m.set('ordinal', old.ordinal).set('previewURL', old.previewURL)
     }
     // $ForceType
     return m.withMutations((ret: Types.MessageAttachment) => {

--- a/shared/constants/types/chat2/message.js
+++ b/shared/constants/types/chat2/message.js
@@ -127,7 +127,7 @@ export type _MessageAttachment = {
   timestamp: number,
   title: string,
   transferProgress: number, // 0-1 // only for the file
-  transferState: 'uploading' | 'downloading' | 'remoteUploading' | null, // only for file
+  transferState: 'uploading' | 'downloading' | 'remoteUploading' | null,
   previewTransferState: 'downloading' | null, // only for preview
   type: 'attachment',
 }


### PR DESCRIPTION
Saving & sharing on mobile were also busted when we're `uploading` the attachment, so I disabled those. r? @keybase/react-hackers 