### PR TITLE
Use markdown for channel descriptions in info panels

### DIFF
--- a/shared/chat/conversation/info-panel/header.js
+++ b/shared/chat/conversation/info-panel/header.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {Box, ClickableBox, Icon, NameWithIcon, Text} from '../../../common-adapters'
+import {Box, ClickableBox, Icon, Markdown, NameWithIcon, Text} from '../../../common-adapters'
 import {type FloatingMenuParentProps, FloatingMenuParentHOC} from '../../../common-adapters/floating-menu'
 import InfoPanelMenu from './menu/container'
 import {
@@ -23,13 +23,7 @@ const gearIconSize = isMobile ? 24 : 16
 
 const _SmallTeamHeader = (props: SmallProps) => {
   return (
-    <Box
-      style={{
-        ...globalStyles.flexBoxRow,
-        alignItems: 'center',
-        marginLeft: globalMargins.small,
-      }}
-    >
+    <Box style={styles.smallContainer}>
       <InfoPanelMenu
         attachTo={props.attachmentRef}
         onHidden={props.toggleShowingMenu}
@@ -38,7 +32,7 @@ const _SmallTeamHeader = (props: SmallProps) => {
         visible={props.showingMenu}
       />
       <NameWithIcon
-        containerStyle={{flex: 1}}
+        containerStyle={styles.flexOne}
         horizontal={true}
         teamname={props.teamname}
         onClick={props.onClick}
@@ -49,26 +43,12 @@ const _SmallTeamHeader = (props: SmallProps) => {
         type="iconfont-gear"
         onClick={props.toggleShowingMenu}
         ref={props.setAttachmentRef}
-        style={iconStyle}
+        style={styles.gear}
         fontSize={gearIconSize}
       />
     </Box>
   )
 }
-
-const iconStyle = platformStyles({
-  common: {
-    paddingRight: 16,
-    paddingLeft: 16,
-    width: gearIconSize,
-    height: gearIconSize,
-  },
-  isMobile: {
-    marginRight: 16,
-    width: gearIconSize + 32,
-  },
-})
-
 const SmallTeamHeader = FloatingMenuParentHOC(_SmallTeamHeader)
 
 // TODO probably factor this out into a connected component
@@ -92,48 +72,61 @@ const EditBox = isMobile
 
 const BigTeamHeader = (props: BigProps) => {
   return (
-    <Box className="header-row" style={{...globalStyles.flexBoxColumn, alignItems: 'stretch'}}>
-      <Box
-        style={{alignSelf: 'center', marginTop: globalMargins.medium, marginBottom: 2, position: 'relative'}}
-      >
+    <Box className="header-row" style={styles.bigContainer}>
+      <Box style={styles.channelnameContainer}>
         <Text type="BodyBig">#{props.channelname}</Text>
         {props.canEditChannel && (
-          <EditBox
-            style={{
-              ...globalStyles.flexBoxRow,
-              position: 'absolute',
-              right: -50,
-              top: isMobile ? 2 : 1,
-            }}
-            onClick={props.onEditChannel}
-          >
-            <Icon style={{marginRight: globalMargins.xtiny}} type="iconfont-edit" />
+          <EditBox style={styles.editBox} onClick={props.onEditChannel}>
+            <Icon style={styles.editIcon} type="iconfont-edit" />
             <Text type="BodySmallPrimaryLink" className="hover-underline">
               Edit
             </Text>
           </EditBox>
         )}
       </Box>
-      {!!props.description && (
-        <Text style={styles.description} type="Body">
-          {props.description}
-        </Text>
-      )}
+      {!!props.description && <Markdown style={styles.description}>{props.description}</Markdown>}
     </Box>
   )
 }
 
 const styles = styleSheetCreate({
-  description: platformStyles({
+  bigContainer: {...globalStyles.flexBoxColumn, alignItems: 'stretch'},
+  channelnameContainer: {
+    alignSelf: 'center',
+    marginTop: globalMargins.medium,
+    marginBottom: 2,
+    position: 'relative',
+  },
+  description: {
+    paddingLeft: 4,
+    paddingRight: 4,
+    textAlign: 'center',
+  },
+  editBox: {
+    ...globalStyles.flexBoxRow,
+    position: 'absolute',
+    right: -50,
+    top: isMobile ? 2 : 1,
+  },
+  editIcon: {marginRight: globalMargins.xtiny},
+  flexOne: {flex: 1},
+  gear: platformStyles({
     common: {
-      paddingLeft: 4,
-      paddingRight: 4,
-      textAlign: 'center',
+      paddingRight: 16,
+      paddingLeft: 16,
+      width: gearIconSize,
+      height: gearIconSize,
     },
-    isElectron: {
-      wordWrap: 'break-word',
+    isMobile: {
+      marginRight: 16,
+      width: gearIconSize + 32,
     },
   }),
+  smallContainer: {
+    ...globalStyles.flexBoxRow,
+    alignItems: 'center',
+    marginLeft: globalMargins.small,
+  },
 })
 
 export {SmallTeamHeader, BigTeamHeader}

--- a/shared/chat/conversation/info-panel/header.js
+++ b/shared/chat/conversation/info-panel/header.js
@@ -3,7 +3,14 @@ import * as React from 'react'
 import {Box, ClickableBox, Icon, NameWithIcon, Text} from '../../../common-adapters'
 import {type FloatingMenuParentProps, FloatingMenuParentHOC} from '../../../common-adapters/floating-menu'
 import InfoPanelMenu from './menu/container'
-import {glamorous, globalMargins, globalStyles, isMobile, platformStyles} from '../../../styles'
+import {
+  glamorous,
+  globalMargins,
+  globalStyles,
+  isMobile,
+  platformStyles,
+  styleSheetCreate,
+} from '../../../styles'
 
 type SmallProps = {
   teamname: string,
@@ -108,19 +115,25 @@ const BigTeamHeader = (props: BigProps) => {
         )}
       </Box>
       {!!props.description && (
-        <Text
-          style={{
-            paddingLeft: 4,
-            paddingRight: 4,
-            textAlign: 'center',
-          }}
-          type="Body"
-        >
+        <Text style={styles.description} type="Body">
           {props.description}
         </Text>
       )}
     </Box>
   )
 }
+
+const styles = styleSheetCreate({
+  description: platformStyles({
+    common: {
+      paddingLeft: 4,
+      paddingRight: 4,
+      textAlign: 'center',
+    },
+    isElectron: {
+      wordWrap: 'break-word',
+    },
+  }),
+})
 
 export {SmallTeamHeader, BigTeamHeader}


### PR DESCRIPTION
Solves the wrapping problem and buys us emoji and clickable links! Examples:

<img width="370" alt="image" src="https://user-images.githubusercontent.com/11968340/40085722-78550eaa-5869-11e8-8b94-adb8839334f2.png">

r? @keybase/react-hackers 