### PR TITLE
login_provision ported off of LoginState

### DIFF
--- a/go/engine/bug_3964_repairman_test.go
+++ b/go/engine/bug_3964_repairman_test.go
@@ -31,58 +31,58 @@ func (a *auditLog) ClearLines() {
 
 func (a *auditLog) Debug(format string, args ...interface{}) {
 	s := fmt.Sprintf(format, args...)
-	a.l.Debug(s)
+	a.l.CloneWithAddedDepth(1).Debug(s)
 	*a.lines = append(*a.lines, s)
 }
 func (a *auditLog) CDebugf(ctx context.Context, format string, args ...interface{}) {
 	s := fmt.Sprintf(format, args...)
-	a.l.CDebugf(ctx, s)
+	a.l.CloneWithAddedDepth(1).CDebugf(ctx, s)
 	*a.lines = append(*a.lines, s)
 }
 func (a *auditLog) Info(format string, args ...interface{}) {
-	a.l.Info(format, args...)
+	a.l.CloneWithAddedDepth(1).Info(format, args...)
 }
 func (a *auditLog) CInfof(ctx context.Context, format string, args ...interface{}) {
-	a.l.CInfof(ctx, format, args...)
+	a.l.CloneWithAddedDepth(1).CInfof(ctx, format, args...)
 }
 func (a *auditLog) Notice(format string, args ...interface{}) {
-	a.l.Notice(format, args...)
+	a.l.CloneWithAddedDepth(1).Notice(format, args...)
 }
 func (a *auditLog) CNoticef(ctx context.Context, format string, args ...interface{}) {
-	a.l.CNoticef(ctx, format, args...)
+	a.l.CloneWithAddedDepth(1).CNoticef(ctx, format, args...)
 }
 func (a *auditLog) Warning(format string, args ...interface{}) {
-	a.l.Warning(format, args...)
+	a.l.CloneWithAddedDepth(1).Warning(format, args...)
 }
 func (a *auditLog) CWarningf(ctx context.Context, format string, args ...interface{}) {
-	a.l.CWarningf(ctx, format, args...)
+	a.l.CloneWithAddedDepth(1).CWarningf(ctx, format, args...)
 }
 func (a *auditLog) Error(format string, args ...interface{}) {
-	a.l.Errorf(format, args...)
+	a.l.CloneWithAddedDepth(1).Errorf(format, args...)
 }
 func (a *auditLog) Errorf(format string, args ...interface{}) {
-	a.l.Errorf(format, args...)
+	a.l.CloneWithAddedDepth(1).Errorf(format, args...)
 }
 func (a *auditLog) CErrorf(ctx context.Context, format string, args ...interface{}) {
-	a.l.CErrorf(ctx, format, args...)
+	a.l.CloneWithAddedDepth(1).CErrorf(ctx, format, args...)
 }
 func (a *auditLog) Critical(format string, args ...interface{}) {
-	a.l.Critical(format, args...)
+	a.l.CloneWithAddedDepth(1).Critical(format, args...)
 }
 func (a *auditLog) CCriticalf(ctx context.Context, format string, args ...interface{}) {
-	a.l.CCriticalf(ctx, format, args...)
+	a.l.CloneWithAddedDepth(1).CCriticalf(ctx, format, args...)
 }
 func (a *auditLog) Fatalf(format string, args ...interface{}) {
-	a.l.Fatalf(format, args...)
+	a.l.CloneWithAddedDepth(1).Fatalf(format, args...)
 }
 func (a *auditLog) CFatalf(ctx context.Context, format string, args ...interface{}) {
-	a.l.CFatalf(ctx, format, args...)
+	a.l.CloneWithAddedDepth(1).CFatalf(ctx, format, args...)
 }
 func (a *auditLog) Profile(fmts string, args ...interface{}) {
-	a.l.Profile(fmts, args...)
+	a.l.CloneWithAddedDepth(1).Profile(fmts, args...)
 }
 func (a *auditLog) Configure(style string, debug bool, filename string) {
-	a.l.Configure(style, debug, filename)
+	a.l.CloneWithAddedDepth(1).Configure(style, debug, filename)
 }
 func (a *auditLog) RotateLogFile() error {
 	return a.l.RotateLogFile()
@@ -101,46 +101,29 @@ func (a *auditLog) SetExternalHandler(handler logger.ExternalHandler) {
 }
 
 func corruptDevice2(dev1 libkb.TestContext, dev2 libkb.TestContext) (*libkb.DeviceKey, error) {
-	ls1 := dev1.G.LoginState()
-	ls2 := dev2.G.LoginState()
-	m := NewMetaContextForTest(dev2)
+	m2 := NewMetaContextForTest(dev2)
+	m1 := NewMetaContextForTest(dev1)
 
-	err := ls1.RunSecretSyncer(dev1.G.Env.GetUID())
-	if err != nil {
-		return nil, err
-	}
-
-	var e2 error
 	var ret libkb.DeviceKey
 
-	err = ls1.SecretSyncer(func(s *libkb.SecretSyncer) {
-		ret, e2 = s.FindDevice(dev1.G.Env.GetDeviceID())
-	}, "corruptDevice2")
+	ss, err := m1.G().ActiveDevice.SyncSecrets(m1)
 	if err != nil {
 		return nil, err
 	}
-	if e2 != nil {
-		return nil, e2
+	ret, err = ss.FindDevice(m1.G().Env.GetDeviceID())
+	if err != nil {
+		return nil, err
 	}
-	var goodLksec *libkb.LKSec
 
 	// Dev1 has a passphrase cached, but dev2 doesn't (since it was provisioned).
 	// For this test though it's fine to take the passphrase from dev1.
-	err = ls1.PassphraseStreamCache(func(ppc *libkb.PassphraseStreamCache) {
-		if !ppc.Valid() {
-			e2 = errors.New("invalid stream cache")
-			return
-		}
-		goodLksec = libkb.NewLKSec(ppc.PassphraseStream(), dev2.G.Env.GetUID(), dev2.G)
-	}, "corruptDevice2")
+	pps := m1.ActiveDevice().PassphraseStream()
+	if pps == nil {
+		return nil, errors.New("empty passphrase stream on m1, but expected one since we just signed up")
+	}
+	goodLksec := libkb.NewLKSec(pps, m2.CurrentUID(), m2.G())
 
-	if err != nil {
-		return nil, err
-	}
-	if e2 != nil {
-		return nil, e2
-	}
-	if err = goodLksec.LoadServerHalf(m); err != nil {
+	if err = goodLksec.LoadServerHalf(m2); err != nil {
 		return nil, err
 	}
 
@@ -154,34 +137,27 @@ func corruptDevice2(dev1 libkb.TestContext, dev2 libkb.TestContext) (*libkb.Devi
 		dev2.G.Env.GetUID(),
 		dev2.G,
 	)
-
-	err = ls2.MutateKeyring(func(krf *libkb.SKBKeyringFile) *libkb.SKBKeyringFile {
-		for _, b := range krf.Blocks {
-			raw, _, erroneousMask, err := goodLksec.Decrypt(m, b.Priv.Data)
-			if err != nil {
-				e2 = err
-				return nil
-			}
-			if !erroneousMask.IsNil() {
-				e2 = errors.New("bad erroneousMask")
-				return nil
-			}
-			b.Priv.Data, e2 = badLskec.Encrypt(m, raw)
-			if e2 != nil {
-				return nil
-			}
-		}
-		krf.MarkDirty()
-		if e2 = krf.Save(); e2 != nil {
-			return nil
-		}
-		return krf
-	}, "corruptDevice2")
+	var krf *libkb.SKBKeyringFile
+	krf, err = libkb.LoadSKBKeyringFromMetaContext(m2)
 	if err != nil {
 		return nil, err
 	}
-	if e2 != nil {
-		return nil, e2
+	for _, b := range krf.Blocks {
+		raw, _, erroneousMask, err := goodLksec.Decrypt(m2, b.Priv.Data)
+		if err != nil {
+			return nil, err
+		}
+		if !erroneousMask.IsNil() {
+			return nil, errors.New("bad erroneousMask")
+		}
+		b.Priv.Data, err = badLskec.Encrypt(m2, raw)
+		if err != nil {
+			return nil, err
+		}
+	}
+	krf.MarkDirty()
+	if err = krf.Save(); err != nil {
+		return nil, err
 	}
 	return &ret, nil
 }
@@ -328,6 +304,7 @@ func TestBug3964Repairman(t *testing.T) {
 	})
 	defer cleanup()
 
+	t.Logf("-------------- Checkpoint 1 -----------------------")
 	dev1Key, err := corruptDevice2(dev1, dev2)
 	if err != nil {
 		t.Fatal(err)
@@ -335,17 +312,21 @@ func TestBug3964Repairman(t *testing.T) {
 
 	dev2.G.TestOptions.NoBug3964Repair = true
 	logoutLogin(t, user, dev2)
+	t.Logf("-------------- Checkpoint 2 -----------------------")
 	checkAuditLogForBug3964Recovery(t, log.GetLines(), dev1.G.Env.GetDeviceID(), dev1Key)
 	dev2.G.TestOptions.NoBug3964Repair = false
 
 	log.ClearLines()
 	logoutLogin(t, user, dev2)
+	t.Logf("-------------- Checkpoint 3 -----------------------")
 	checkAuditLogForBug3964Repair(t, log.GetLines(), dev1.G.Env.GetDeviceID(), dev1Key)
 
 	log.ClearLines()
 	logoutLogin(t, user, dev2)
+	t.Logf("-------------- Checkpoint 4 -----------------------")
 	checkAuditLogCleanLogin(t, log.GetLines())
 	checkAuditLogForRepairmanShortCircuit(t, log.GetLines())
 
+	t.Logf("-------------- Checkpoint 5 -----------------------")
 	checkLKSWorked(t, dev2, user)
 }

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -455,3 +455,7 @@ func getUserSeqno(tc *libkb.TestContext, uid keybase1.UID) keybase1.Seqno {
 func checkUserSeqno(tc *libkb.TestContext, uid keybase1.UID, expected keybase1.Seqno) {
 	require.Equal(tc.T, expected, getUserSeqno(tc, uid))
 }
+
+func fakeSalt() []byte {
+	return []byte("fakeSALTfakeSALT")
+}

--- a/go/engine/crypto_test.go
+++ b/go/engine/crypto_test.go
@@ -313,9 +313,8 @@ func TestCryptoUnboxBytes32AnyPaper(t *testing.T) {
 	if err := RunEngine2(m, peng); err != nil {
 		t.Fatal(err)
 	}
-	err := tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.SetUnlockedPaperKey(peng.SigKey(), peng.EncKey())
-	}, "TestCryptoUnboxBytes32AnyPaper")
+
+	m.ActiveDevice().CachePaperKey(m, libkb.NewDeviceWithKeysOnly(peng.SigKey(), peng.EncKey()))
 
 	key := peng.EncKey()
 	kp, ok := key.(libkb.NaclDHKeyPair)

--- a/go/engine/device_wrap.go
+++ b/go/engine/device_wrap.go
@@ -132,7 +132,7 @@ func (e *DeviceWrap) setActiveDevice(m libkb.MetaContext) (err error) {
 	// Sync down secrets for future offline login attempts to work.
 	// This will largely just download what we just uploaded, but it's
 	// easy to do this way.
-	w := m.ActiveDevice().SyncSecrets(m)
+	_, w := m.ActiveDevice().SyncSecrets(m)
 	if w != nil {
 		m.CWarningf("Error sync secrets: %s", w.Error())
 	}

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -71,9 +71,8 @@ func runPrereqs(m libkb.MetaContext, e Engine2) error {
 	prq := e.Prereqs()
 
 	if prq.TemporarySession {
-		err := m.G().AssertTemporarySession(m.LoginContext())
-		if err != nil {
-			return err
+		if !m.HasAnySession() {
+			return libkb.NewLoginRequiredError("need either a temporary session or a device")
 		}
 	}
 

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -36,6 +36,7 @@ type Kex2Provisionee struct {
 	lks          *libkb.LKSec
 	kex2Cancel   func()
 	mctx         libkb.MetaContext
+	salt         []byte
 	v1Only       bool // only support protocol v1 (for testing)
 }
 
@@ -46,12 +47,13 @@ var _ libkb.UserBasic = (*Kex2Provisionee)(nil)
 var _ libkb.SessionReader = (*Kex2Provisionee)(nil)
 
 // NewKex2Provisionee creates a Kex2Provisionee engine.
-func NewKex2Provisionee(g *libkb.GlobalContext, device *libkb.Device, secret kex2.Secret) *Kex2Provisionee {
+func NewKex2Provisionee(g *libkb.GlobalContext, device *libkb.Device, secret kex2.Secret, salt []byte) *Kex2Provisionee {
 	return &Kex2Provisionee{
 		Contextified: libkb.NewContextified(g),
 		device:       device,
 		secret:       secret,
 		secretCh:     make(chan kex2.Secret),
+		salt:         salt,
 	}
 }
 
@@ -293,8 +295,8 @@ func (e *Kex2Provisionee) handleDidCounterSign(m libkb.MetaContext, sig []byte, 
 		return err
 	}
 
-	// logged in, so save the login state to temporary config file
-	err = e.saveLoginState()
+	// logged in, so update our temporary session to say so
+	err = e.updateTemporarySession(m)
 	if err != nil {
 		return err
 	}
@@ -321,8 +323,8 @@ func (e *Kex2Provisionee) handleDidCounterSign(m libkb.MetaContext, sig []byte, 
 		return err
 	}
 
-	// cache the device keys in memory
-	if err = e.cacheKeys(m); err != nil {
+	// update the global active device, and also store the device keys in memory under ActiveDevice
+	if err = e.saveConfig(m); err != nil {
 		return err
 	}
 
@@ -333,15 +335,12 @@ func (e *Kex2Provisionee) handleDidCounterSign(m libkb.MetaContext, sig []byte, 
 	return e.storeEKs(m, deviceEKStatement, userEKBox)
 }
 
-// saveLoginState stores the user's login state. The user config
-// file is stored in a temporary location, since we're usually in a
-// "config file transaction" at this point.
-func (e *Kex2Provisionee) saveLoginState() error {
-	lctx := e.mctx.LoginContext()
-	if err := lctx.LoadLoginSession(e.username); err != nil {
-		return err
-	}
-	return lctx.SaveState(string(e.sessionToken), string(e.csrfToken), libkb.NewNormalizedUsername(e.username), e.uid, e.device.ID)
+// updateTemporarySession comits the session token and csrf token to our temporary session,
+// stored in our provisional login context. We'll need that to post successfully.
+func (e *Kex2Provisionee) updateTemporarySession(m libkb.MetaContext) (err error) {
+	defer m.CTrace("Kex2Provisionee#updateTemporarySession", func() error { return err })()
+	m.CDebugf("login context: %T %+v", m.LoginContext(), m.LoginContext())
+	return m.LoginContext().SaveState(string(e.sessionToken), string(e.csrfToken), libkb.NewNormalizedUsername(e.username), e.uid, e.device.ID)
 }
 
 type decodedSig struct {
@@ -565,7 +564,9 @@ func (e *Kex2Provisionee) dhKeyProof(dh libkb.GenericKey, eldestKID keybase1.KID
 
 }
 
-func (e *Kex2Provisionee) pushLKSServerHalf(m libkb.MetaContext) error {
+func (e *Kex2Provisionee) pushLKSServerHalf(m libkb.MetaContext) (err error) {
+	defer m.CTrace("Kex2Provisionee#pushLKSServerHalf", func() error { return err })()
+
 	// make new lks
 	ppstream := libkb.NewPassphraseStream(e.pps.PassphraseStream)
 	ppstream.SetGeneration(libkb.PassphraseGeneration(e.pps.Generation))
@@ -579,7 +580,7 @@ func (e *Kex2Provisionee) pushLKSServerHalf(m libkb.MetaContext) error {
 		return err
 	}
 
-	err = libkb.PostDeviceLKS(m.Ctx(), m.G(), e, e.device.ID, e.device.Type, e.lks.GetServerHalf(), e.lks.Generation(), chrText, chrKID)
+	err = libkb.PostDeviceLKS(m, e, e.device.ID, e.device.Type, e.lks.GetServerHalf(), e.lks.Generation(), chrText, chrKID)
 	if err != nil {
 		return err
 	}
@@ -648,8 +649,8 @@ func (e *Kex2Provisionee) ephemeralKeygen(m libkb.MetaContext, userEKBox *keybas
 }
 
 // cacheKeys caches the device keys in the Account object.
-func (e *Kex2Provisionee) cacheKeys(m libkb.MetaContext) (err error) {
-	defer m.CTrace("Kex2Provisionee.cacheKeys", func() error { return err })()
+func (e *Kex2Provisionee) saveConfig(m libkb.MetaContext) (err error) {
+	defer m.CTrace("Kex2Provisionee#saveConfig", func() error { return err })()
 	if e.eddsa == nil {
 		return errors.New("cacheKeys called, but eddsa key is nil")
 	}
@@ -657,11 +658,12 @@ func (e *Kex2Provisionee) cacheKeys(m libkb.MetaContext) (err error) {
 		return errors.New("cacheKeys called, but dh key is nil")
 	}
 
-	if err = m.LoginContext().SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType}, e.eddsa, e.device); err != nil {
-		return err
+	var deviceName string
+	if e.device.Description != nil {
+		deviceName = *e.device.Description
 	}
 
-	return m.LoginContext().SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType}, e.dh, e.device)
+	return m.SwitchUserNewConfigActiveDevice(e.uid, libkb.NewNormalizedUsername(e.username), e.salt, e.device.ID, e.eddsa, e.dh, deviceName)
 }
 
 func (e *Kex2Provisionee) storeEKs(m libkb.MetaContext, deviceEKStatement keybase1.DeviceEkStatement, userEKBox *keybase1.UserEkBoxed) (err error) {

--- a/go/engine/login_load_user.go
+++ b/go/engine/login_load_user.go
@@ -106,21 +106,12 @@ func (e *loginLoadUser) findUsername(m libkb.MetaContext) (string, error) {
 	// looks like an email address
 	m.CDebugf("%q looks like an email address, must get login session to get user", e.usernameOrEmail)
 
-	// need to login with it in order to get the username
-	m = m.WithNewProvisionalLoginContext()
-
 	if err := libkb.PassphraseLoginPromptThenSecretStore(m, e.usernameOrEmail, 3, false /* failOnStoreError */); err != nil {
 		return "", err
 	}
 
 	username := m.LoginContext().GetUsername().String()
 	m.CDebugf("VerifyEmailAddress %q => %q", e.usernameOrEmail, username)
-
-	// Save the provisional login information in case we want this verified passphrase
-	// downstream. Note that it probably makes sense to create this provisional login
-	// a few stack frames up, and propagate to other engines, but for now, do
-	// the simple thing.
-	m = m.CommitProvisionalLogin()
 
 	return username, nil
 }

--- a/go/engine/login_load_user_test.go
+++ b/go/engine/login_load_user_test.go
@@ -185,7 +185,7 @@ func testLoginLoadUserEmail(t *testing.T, fu *FakeUser, input string) (*libkb.Us
 		SecretUI: fu.NewSecretUI(),
 	}
 	eng := newLoginLoadUser(tc.G, input)
-	m := NewMetaContextForTest(tc).WithUIs(uis)
+	m := NewMetaContextForTest(tc).WithUIs(uis).WithNewProvisionalLoginContext()
 	if err := RunEngine2(m, eng); err != nil {
 		return nil, err
 	}

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -151,23 +151,20 @@ func (e *loginProvision) Run(m libkb.MetaContext) error {
 	return nil
 }
 
-func saveToSecretStore(m libkb.MetaContext, nun libkb.NormalizedUsername, lks *libkb.LKSec) (err error) {
+func (e *loginProvision) saveToSecretStore(m libkb.MetaContext) error {
+	return e.saveToSecretStoreWithLKS(m, e.lks)
+}
+
+func (e *loginProvision) saveToSecretStoreWithLKS(m libkb.MetaContext, lks *libkb.LKSec) (err error) {
+	nun := e.arg.User.GetNormalizedName()
 	defer m.CTrace(fmt.Sprintf("saveToSecretStore(%s)", nun), func() error { return err })()
-	var secret libkb.LKSecFullSecret
-	secretStore := libkb.NewSecretStore(m.G(), nun)
-	secret, err = lks.GetSecret(m)
-	if err == nil {
-		err = secretStore.StoreSecret(secret)
-	}
-	if err != nil {
-		m.CWarningf("saveToSecretStore(%s) failed: %s", nun, err)
-	}
-	return err
+	return libkb.StoreSecretAfterLoginWithLKS(m, nun, lks)
 }
 
 // deviceWithType provisions this device with an existing device using the
 // kex2 protocol.  provisionerType is the existing device type.
-func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType keybase1.DeviceType) error {
+func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType keybase1.DeviceType) (err error) {
+	defer m.CTrace("loginProvision#deviceWithType", func() error { return err })()
 
 	// make a new device:
 	deviceID, err := libkb.NewDeviceID()
@@ -197,7 +194,12 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 	}
 
 	// create provisionee engine
-	provisionee := NewKex2Provisionee(m.G(), device, secret.Secret())
+	salt, err := e.arg.User.GetSalt()
+	if err != nil {
+		m.CDebugf("Failed to get salt")
+		return err
+	}
+	provisionee := NewKex2Provisionee(m.G(), device, secret.Secret(), salt)
 
 	var canceler func()
 
@@ -256,36 +258,26 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 		}
 	}()
 
-	f := func(lctx libkb.LoginContext) error {
-		// run provisionee
-		m := m.WithLoginContext(lctx)
-		err := RunEngine2(m, provisionee)
-		if err != nil {
-			return err
-		}
-
-		// TODO this error is being ignored... k?
-		saveToSecretStore(m, e.arg.User.GetNormalizedName(), provisionee.GetLKSec())
-
-		e.signingKey, err = provisionee.SigningKey()
-		if err != nil {
-			return err
-		}
-		e.encryptionKey, err = provisionee.EncryptionKey()
-		if err != nil {
-			return err
-		}
-
-		// Load me again so that keys will be up to date.
-		loadArg := libkb.NewLoadUserArgWithMetaContext(m).WithSelf(true).WithUID(e.arg.User.GetUID())
-		e.arg.User, err = libkb.LoadUser(loadArg)
-		if err != nil {
-			return err
-		}
-
-		return nil
+	err = RunEngine2(m, provisionee)
+	if err != nil {
+		return err
 	}
-	if err := m.G().LoginState().ExternalFunc(f, "loginProvision.device - Run provisionee"); err != nil {
+
+	e.saveToSecretStoreWithLKS(m, provisionee.GetLKSec())
+
+	e.signingKey, err = provisionee.SigningKey()
+	if err != nil {
+		return err
+	}
+	e.encryptionKey, err = provisionee.EncryptionKey()
+	if err != nil {
+		return err
+	}
+
+	// Load me again so that keys will be up to date.
+	loadArg := libkb.NewLoadUserArgWithMetaContext(m).WithSelf(true).WithUID(e.arg.User.GetUID())
+	e.arg.User, err = libkb.LoadUser(loadArg)
+	if err != nil {
 		return err
 	}
 
@@ -304,131 +296,131 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 }
 
 // paper attempts to provision the device via a paper key.
-func (e *loginProvision) paper(m libkb.MetaContext, device *libkb.Device) error {
+func (e *loginProvision) paper(m libkb.MetaContext, device *libkb.Device) (err error) {
+	defer m.CTrace("loginProvision#paper", func() error { return err })()
 
 	// get the paper key from the user
-	kp, err := e.getValidPaperKey(m)
+	keys, err := e.getValidPaperKey(m)
 	if err != nil {
 		return err
 	}
 
-	m.CDebugf("paper signing key kid: %s", kp.sigKey.GetKID())
-	m.CDebugf("paper encryption key kid: %s", kp.encKey.GetKID())
+	m.CDebugf("paper signing key kid: %s", keys.SigningKey().GetKID())
+	m.CDebugf("paper encryption key kid: %s", keys.EncryptionKey().GetKID())
 
-	// After obtaining login session, this will be called before the login state is released.
-	// It signs this new device with the paper key.
-	var afterLogin = func(lctx libkb.LoginContext) error {
-		m = m.WithLoginContext(lctx)
+	u := e.arg.User
+	uid := u.GetUID()
+	nn := u.GetNormalizedName()
 
-		lctx.EnsureUsername(e.arg.User.GetNormalizedName())
+	// Set the active device to be a special paper key active device, which keeps
+	// a cached copy around for DeviceKeyGen, which requires it to be in memory.
+	// It also will establish a NIST so that API calls can proceed on behalf of the user.
+	m = m.WithPaperKeyActiveDevice(keys, uid)
+	m.LoginContext().SetUsernameUID(nn, uid)
 
-		// need lksec to store device keys locally
-		if err := e.fetchLKS(m, kp.encKey); err != nil {
-			return err
-		}
-
-		if err := e.makeDeviceKeysWithSigner(m, kp.sigKey); err != nil {
-			return err
-		}
-		if err := lctx.LocalSession().SetDeviceProvisioned(m.G().Env.GetDeviceIDForUsername(e.arg.User.GetNormalizedName())); err != nil {
-			// not a fatal error, session will stay in memory
-			m.CWarningf("error saving session file: %s", err)
-		}
-		saveToSecretStore(m, e.arg.User.GetNormalizedName(), e.lks)
-		return nil
+	// need lksec to store device keys locally
+	if err := e.fetchLKS(m, keys.EncryptionKey()); err != nil {
+		return err
 	}
 
-	// need a session to continue to provision, login with paper sigKey
-	return m.G().LoginState().LoginWithKey(m, e.arg.User, kp.sigKey, afterLogin)
+	if err := e.makeDeviceKeysWithSigner(m, keys.SigningKey()); err != nil {
+		return err
+	}
+
+	// The DeviceWrap engine (called via makeDeviceKeysWithSigner) sets
+	// the global ActiveDevice to be a valid device. So we're OK to remove
+	// our temporary thread-local paperkey device installed just above.
+	m = m.WithGlobalActiveDevice()
+
+	// Cache the paper keys globally now that we're logged in. Note we must call
+	// thie after the m.WithGlobalActiveDevice() above, since we want to cache
+	// the paper key on the global and not thread-local active device.
+	m.ActiveDevice().CachePaperKey(m, keys)
+
+	e.saveToSecretStore(m)
+	return nil
 }
 
 var paperKeyNotFound = libkb.NotFoundError{
 	Msg: "paper key not found, most likely due to a typo in one of the words in the phrase",
 }
 
-func (e *loginProvision) getValidPaperKey(m libkb.MetaContext) (*keypair, error) {
-	var lastErr error
+func (e *loginProvision) getValidPaperKey(m libkb.MetaContext) (keys *libkb.DeviceWithKeys, err error) {
+	defer m.CTrace("loginProvision#getValidPaperKey", func() error { return err })()
+
 	for i := 0; i < 10; i++ {
-		// get the paper key from the user
-		kp, prefix, err := getPaperKey(m, lastErr)
-		if err != nil {
-			m.CDebugf("getValidPaperKey attempt %d (%s): %s", i, prefix, err)
-			if _, ok := err.(libkb.InputCanceledError); ok {
-				return nil, err
-			}
-			lastErr = err
-			continue
+		keys, err = e.getValidPaperKeyOnce(m, i, err)
+		if err == nil {
+			return keys, err
 		}
-
-		// use the KID to find the uid
-		uid, err := e.uidByKID(m, kp.sigKey.GetKID())
-		if err != nil {
-			m.CDebugf("getValidPaperKey attempt %d (%s): %s", i, prefix, err)
-
-			switch err := err.(type) {
-			case libkb.NotFoundError:
-				lastErr = paperKeyNotFound
-			case libkb.AppStatusError:
-				if err.Code == libkb.SCNotFound {
-					lastErr = paperKeyNotFound
-				} else {
-					lastErr = err
-				}
-			default:
-				lastErr = err
-			}
-
-			continue
+		if _, ok := err.(libkb.InputCanceledError); ok {
+			return nil, err
 		}
+	}
+	m.CDebugf("getValidPaperKey retry attempts exhausted")
+	return nil, err
+}
 
-		if uid.NotEqual(e.arg.User.GetUID()) {
-			lastErr = paperKeyNotFound
-			continue
-		}
+func (e *loginProvision) getValidPaperKeyOnce(m libkb.MetaContext, i int, lastErr error) (keys *libkb.DeviceWithKeys, err error) {
+	defer m.CTrace("loginProvision#getValidPaperKeyOnce", func() error { return err })()
 
-		// found a paper key that can be used for signing
-		m.CDebugf("found paper key (%s) match for %s", prefix, e.arg.User.GetName())
-		return kp, nil
+	// get the paper key from the user
+	var prefix string
+	keys, prefix, err = getPaperKey(m, lastErr)
+	if err != nil {
+		m.CDebugf("getValidPaperKeyOnce attempt %d (%s): %s", i, prefix, err)
+		return nil, err
 	}
 
-	m.CDebugf("getValidPaperKey retry attempts exhausted")
-	return nil, lastErr
+	// use the KID to find the uid, deviceID and deviceName
+	var uid keybase1.UID
+	uid, err = keys.Populate(m)
+	if err != nil {
+		m.CDebugf("getValidPaperKeyOnce attempt %d (%s): %s", i, prefix, err)
+
+		switch err := err.(type) {
+		case libkb.NotFoundError:
+			return nil, paperKeyNotFound
+		case libkb.AppStatusError:
+			if err.Code == libkb.SCNotFound {
+				return nil, paperKeyNotFound
+			}
+		}
+		return nil, err
+	}
+
+	if uid.NotEqual(e.arg.User.GetUID()) {
+		return nil, paperKeyNotFound
+	}
+
+	// found a paper key that can be used for signing
+	m.CDebugf("found paper key (%s) match for %s", prefix, e.arg.User.GetName())
+	return keys, nil
 }
 
 // pgpProvision attempts to provision with a synced pgp key.  It
 // needs to get a session first to look for a synced pgp key.
-func (e *loginProvision) pgpProvision(m libkb.MetaContext) error {
-	// After obtaining login session, this will be called before the login state is released.
-	// It tries to get the pgp key and uses it to provision new device keys for this device.
-	var afterLogin = func(lctx libkb.LoginContext) error {
-		m = m.WithLoginContext(lctx)
+func (e *loginProvision) pgpProvision(m libkb.MetaContext) (err error) {
+	defer m.CTrace("loginProvision#pgpProvision", func() error { return err })()
 
-		lctx.EnsureUsername(e.arg.User.GetNormalizedName())
-
-		signer, err := e.syncedPGPKey(m)
-		if err != nil {
-			return err
-		}
-
-		if err := e.makeDeviceKeysWithSigner(m, signer); err != nil {
-			return err
-		}
-		if err := lctx.LocalSession().SetDeviceProvisioned(m.G().Env.GetDeviceIDForUsername(e.arg.User.GetNormalizedName())); err != nil {
-			// not a fatal error, session will stay in memory
-			m.CWarningf("error saving session file: %s", err)
-			return err
-		}
-
-		u := e.arg.User
-		tmpErr := saveToSecretStore(m, u.GetNormalizedName(), e.lks)
-		if tmpErr != nil {
-			m.CWarningf("pgpProvision: %s", tmpErr)
-		}
-		return nil
+	err = e.passphraseLogin(m)
+	if err != nil {
+		return err
 	}
 
-	// need a session to try to get synced private key
-	return m.G().LoginState().LoginWithPrompt(m, e.arg.User.GetName(), m.UIs().LoginUI, m.UIs().SecretUI, afterLogin)
+	// After obtaining login session, this will be called before the login state is released.
+	// It tries to get the pgp key and uses it to provision new device keys for this device.
+	signer, err := e.syncedPGPKey(m)
+	if err != nil {
+		return err
+	}
+
+	if err = e.makeDeviceKeysWithSigner(m, signer); err != nil {
+		return err
+	}
+
+	e.saveToSecretStore(m)
+	return nil
 }
 
 // makeDeviceKeysWithSigner creates device keys given a signing
@@ -485,15 +477,32 @@ func (e *loginProvision) ensureLKSec(m libkb.MetaContext) error {
 
 // ppStream gets the passphrase stream, either cached or via
 // SecretUI.
-func (e *loginProvision) ppStream(m libkb.MetaContext) (*libkb.PassphraseStream, error) {
-	if lctx := m.LoginContext(); lctx != nil {
-		cached := lctx.PassphraseStreamCache()
-		if cached == nil {
-			return nil, errors.New("loginProvision: ppStream() -> nil PassphraseStreamCache")
-		}
-		return cached.PassphraseStream(), nil
+func (e *loginProvision) ppStream(m libkb.MetaContext) (ret *libkb.PassphraseStream, err error) {
+	defer m.CTrace("loginProvision#ppStream", func() error { return err })()
+	if ret = m.PassphraseStream(); ret != nil {
+		return ret, nil
 	}
-	return m.G().LoginState().GetPassphraseStreamForUser(m, m.UIs().SecretUI, e.arg.User.GetName())
+	if err = e.passphraseLogin(m); err != nil {
+		return nil, err
+	}
+	if ret = m.PassphraseStream(); ret != nil {
+		return ret, nil
+	}
+	return nil, errors.New("no passphrase available")
+}
+
+func (e *loginProvision) passphraseLogin(m libkb.MetaContext) (err error) {
+	defer m.CTrace("loginProvision#passphraseLogin", func() error { return err })()
+
+	if m.LoginContext() != nil {
+		ok, _ := m.LoginContext().LoggedInLoad()
+		if ok {
+			m.CDebugf("already logged in")
+			return nil
+		}
+	}
+
+	return libkb.PassphraseLoginPromptThenSecretStore(m, e.arg.User.GetName(), 5, false)
 }
 
 // deviceName gets a new device name from the user.
@@ -555,7 +564,9 @@ func (e *loginProvision) makeDeviceKeys(m libkb.MetaContext, args *DeviceWrapArg
 
 // syncedPGPKey looks for a synced pgp key for e.user.  If found,
 // it unlocks it.
-func (e *loginProvision) syncedPGPKey(m libkb.MetaContext) (libkb.GenericKey, error) {
+func (e *loginProvision) syncedPGPKey(m libkb.MetaContext) (ret libkb.GenericKey, err error) {
+	defer m.CTrace("loginProvision#syncedPGPKey", func() error { return err })()
+
 	key, err := e.arg.User.SyncedSecretKey(m)
 	if err != nil {
 		return nil, err
@@ -629,7 +640,10 @@ func (e *loginProvision) checkArg() error {
 	return nil
 }
 
-func (e *loginProvision) route(m libkb.MetaContext) error {
+func (e *loginProvision) route(m libkb.MetaContext) (err error) {
+
+	defer m.CTrace("loginProvision#route", func() error { return err })()
+
 	// check if User has any pgp keys, active devices
 	ckf := e.arg.User.GetComputedKeyFamily()
 	if ckf != nil {
@@ -659,7 +673,9 @@ func (e *loginProvision) route(m libkb.MetaContext) error {
 	return e.makeEldestDevice(m)
 }
 
-func (e *loginProvision) chooseDevice(m libkb.MetaContext, pgp bool) error {
+func (e *loginProvision) chooseDevice(m libkb.MetaContext, pgp bool) (err error) {
+	defer m.CTrace("loginProvision#chooseDevice", func() error { return err })()
+
 	ckf := e.arg.User.GetComputedKeyFamily()
 	devices := partitionDeviceList(ckf.GetAllActiveDevices())
 	sort.Sort(devices)
@@ -725,8 +741,10 @@ func (e *loginProvision) chooseDevice(m libkb.MetaContext, pgp bool) error {
 	}
 }
 
-func (e *loginProvision) tryPGP(m libkb.MetaContext) error {
-	err := e.pgpProvision(m)
+func (e *loginProvision) tryPGP(m libkb.MetaContext) (err error) {
+	defer m.CTrace("loginProvision#tryPGP", func() error { return err })()
+
+	err = e.pgpProvision(m)
 	if err == nil {
 		return nil
 	}
@@ -741,7 +759,8 @@ func (e *loginProvision) tryPGP(m libkb.MetaContext) error {
 	return e.tryGPG(m)
 }
 
-func (e *loginProvision) tryGPG(m libkb.MetaContext) error {
+func (e *loginProvision) tryGPG(m libkb.MetaContext) (err error) {
+	defer m.CTrace("loginProvision#tryGPG", func() error { return err })()
 	key, method, err := e.chooseGPGKeyAndMethod(m)
 	if err != nil {
 		return err
@@ -771,43 +790,31 @@ func (e *loginProvision) tryGPG(m libkb.MetaContext) error {
 		return fmt.Errorf("invalid gpg provisioning method: %v", method)
 	}
 
-	// After obtaining login session, this will be called before the login state is released.
-	// It signs this new device with the selected gpg key.
-	var afterLogin = func(lctx libkb.LoginContext) error {
-		m = m.WithLoginContext(lctx)
-
-		lctx.EnsureUsername(e.arg.User.GetNormalizedName())
-
-		if err := e.makeDeviceKeysWithSigner(m, signingKey); err != nil {
-			if appErr, ok := err.(libkb.AppStatusError); ok && appErr.Code == libkb.SCKeyCorrupted {
-				// Propagate the error, but display a more descriptive message to the user.
-				m.G().Log.Error("during GPG provisioning.\nWe were able to generate a PGP signature " +
-					"with gpg client, but it was rejected by the server. This often means that this " +
-					"PGP key is expired or unusable. You can update your key on https://keybase.io")
-			}
-			return err
-		}
-		if err := lctx.LocalSession().SetDeviceProvisioned(m.G().Env.GetDeviceIDForUsername(e.arg.User.GetNormalizedName())); err != nil {
-			// not a fatal error, session will stay in memory
-			m.CWarningf("error saving session file: %s", err)
-		}
-
-		if method == keybase1.GPGMethod_GPG_IMPORT {
-			// store the key in lksec
-			_, err := libkb.WriteLksSKBToKeyring(m, signingKey, e.lks)
-			if err != nil {
-				m.CWarningf("error saving exported gpg key in lksec: %s", err)
-				return err
-			}
-		}
-
-		saveToSecretStore(m, e.arg.User.GetNormalizedName(), e.lks)
-
-		return nil
+	if err = e.passphraseLogin(m); err != nil {
+		return err
 	}
 
-	// need a session to continue to provision
-	return m.G().LoginState().LoginWithPrompt(m, e.arg.User.GetName(), m.UIs().LoginUI, m.UIs().SecretUI, afterLogin)
+	if err := e.makeDeviceKeysWithSigner(m, signingKey); err != nil {
+		if appErr, ok := err.(libkb.AppStatusError); ok && appErr.Code == libkb.SCKeyCorrupted {
+			// Propagate the error, but display a more descriptive message to the user.
+			m.G().Log.Error("during GPG provisioning.\nWe were able to generate a PGP signature " +
+				"with gpg client, but it was rejected by the server. This often means that this " +
+				"PGP key is expired or unusable. You can update your key on https://keybase.io")
+		}
+		return err
+	}
+	e.saveToSecretStore(m)
+
+	if method == keybase1.GPGMethod_GPG_IMPORT {
+		// store the key in lksec
+		_, err := libkb.WriteLksSKBToKeyring(m, signingKey, e.lks)
+		if err != nil {
+			m.CWarningf("error saving exported gpg key in lksec: %s", err)
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (e *loginProvision) chooseGPGKeyAndMethod(m libkb.MetaContext) (*libkb.GpgPrimaryKey, keybase1.GPGMethod, error) {
@@ -987,35 +994,15 @@ func (e *loginProvision) makeEldestDevice(m libkb.MetaContext) error {
 	}
 	args.IsEldest = true
 
-	aerr := m.G().LoginState().Account(func(a *libkb.Account) {
-		a.EnsureUsername(e.arg.User.GetNormalizedName())
-		m = m.WithLoginContext(a)
-
-		if err = e.makeDeviceKeys(m, args); err != nil {
-			return
-		}
-
-		// save provisioned device id in the session
-		err = a.LocalSession().SetDeviceProvisioned(m.G().Env.GetDeviceIDForUsername(e.arg.User.GetNormalizedName()))
-		if err != nil {
-			return
-		}
-
-		// Store the secret.
-		// It is not stored in login_state.go/passphraseLogin because there is no device id at that time.
-		saveToSecretStore(m, e.arg.User.GetNormalizedName(), e.lks)
-	}, "makeEldestDevice")
-	if err != nil {
+	if err = e.makeDeviceKeys(m, args); err != nil {
 		return err
 	}
-	if aerr != nil {
-		return aerr
-	}
+	e.saveToSecretStore(m)
 	return nil
 }
 
 // This is used by SaltpackDecrypt as well.
-func getPaperKey(m libkb.MetaContext, lastErr error) (pair *keypair, prefix string, err error) {
+func getPaperKey(m libkb.MetaContext, lastErr error) (keys *libkb.DeviceWithKeys, prefix string, err error) {
 	passphrase, err := libkb.GetPaperKeyPassphrase(m, m.UIs().SecretUI, "", lastErr)
 	if err != nil {
 		return nil, "", err
@@ -1035,34 +1022,8 @@ func getPaperKey(m libkb.MetaContext, lastErr error) (pair *keypair, prefix stri
 	if err := RunEngine2(m, bkeng); err != nil {
 		return nil, prefix, err
 	}
-
-	kp := &keypair{sigKey: bkeng.SigKey(), encKey: bkeng.EncKey()}
-	if err := m.G().LoginState().Account(func(a *libkb.Account) {
-		a.SetUnlockedPaperKey(kp.sigKey, kp.encKey)
-	}, "UnlockedPaperKey"); err != nil {
-		return nil, prefix, err
-	}
-
-	return kp, prefix, nil
-}
-
-func (e *loginProvision) uidByKID(m libkb.MetaContext, kid keybase1.KID) (keybase1.UID, error) {
-	var nilUID keybase1.UID
-	arg := libkb.APIArg{
-		Endpoint:    "key/owner",
-		SessionType: libkb.APISessionTypeNONE,
-		Args:        libkb.HTTPArgs{"kid": libkb.S{Val: kid.String()}},
-		NetContext:  m.Ctx(),
-	}
-	res, err := m.G().API.Get(arg)
-	if err != nil {
-		return nilUID, err
-	}
-	suid, err := res.Body.AtPath("uid").GetString()
-	if err != nil {
-		return nilUID, err
-	}
-	return keybase1.UIDFromString(suid)
+	keys = bkeng.DeviceWithKeys()
+	return keys, prefix, nil
 }
 
 func (e *loginProvision) fetchLKS(m libkb.MetaContext, encKey libkb.GenericKey) error {

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -80,6 +80,10 @@ func (e *PaperKeyGen) EncKey() libkb.NaclDHKeyPair {
 	return e.encKey
 }
 
+func (e *PaperKeyGen) DeviceWithKeys() *libkb.DeviceWithKeys {
+	return libkb.NewDeviceWithKeysOnly(e.sigKey, e.encKey)
+}
+
 // Run starts the engine.
 func (e *PaperKeyGen) Run(m libkb.MetaContext) error {
 	if !e.arg.SkipPush {
@@ -289,7 +293,7 @@ func (e *PaperKeyGen) push(m libkb.MetaContext) error {
 	if lctx := m.LoginContext(); lctx != nil {
 		sr = lctx.LocalSession()
 	}
-	if err := libkb.PostDeviceLKS(m.Ctx(), e.G(), sr, backupDev.ID, libkb.DeviceTypePaper, backupLks.GetServerHalf(), backupLks.Generation(), ctext, e.encKey.GetKID()); err != nil {
+	if err := libkb.PostDeviceLKS(m, sr, backupDev.ID, libkb.DeviceTypePaper, backupLks.GetServerHalf(), backupLks.Generation(), ctext, e.encKey.GetKID()); err != nil {
 		return err
 	}
 
@@ -321,7 +325,7 @@ func (e *PaperKeyGen) push(m libkb.MetaContext) error {
 	}
 
 	m.CDebugf("PaperKeyGen#push running delegators")
-	return libkb.DelegatorAggregator(m.LoginContext(), []libkb.Delegator{sigDel, sigEnc}, nil, pukBoxes, nil)
+	return libkb.DelegatorAggregator(m, []libkb.Delegator{sigDel, sigEnc}, nil, pukBoxes, nil)
 }
 
 func (e *PaperKeyGen) makePerUserKeyBoxes(m libkb.MetaContext) ([]keybase1.PerUserKeyBox, error) {

--- a/go/engine/paperprovision.go
+++ b/go/engine/paperprovision.go
@@ -61,11 +61,16 @@ func (e *PaperProvisionEngine) Run(m libkb.MetaContext) (err error) {
 		return err
 	}
 
+	m = m.WithNewProvisionalLoginContext()
+
 	// From this point on, if there's an error, we abort the
 	// transaction.
 	defer func() {
 		if tx != nil {
 			tx.Abort()
+		}
+		if err == nil {
+			m = m.CommitProvisionalLogin()
 		}
 	}()
 
@@ -93,11 +98,11 @@ func (e *PaperProvisionEngine) Run(m libkb.MetaContext) (err error) {
 		return err
 	}
 
-	kp := &keypair{sigKey: bkeng.SigKey(), encKey: bkeng.EncKey()}
+	keys := bkeng.DeviceWithKeys()
 
 	// Make sure the key matches the logged in user
 	// use the KID to find the uid
-	uid, err := e.uidByKID(kp.sigKey.GetKID())
+	uid, err := keys.Populate(m)
 	if err != nil {
 		return err
 	}
@@ -113,7 +118,7 @@ func (e *PaperProvisionEngine) Run(m libkb.MetaContext) (err error) {
 	}
 
 	// Make new device keys and sign them with this paper key
-	err = e.paper(m, kp)
+	err = e.paper(m, keys)
 	if err != nil {
 		return err
 	}
@@ -152,31 +157,33 @@ func (e *PaperProvisionEngine) uidByKID(kid keybase1.KID) (keybase1.UID, error) 
 }
 
 // copied more or less from loginProvision.paper()
-func (e *PaperProvisionEngine) paper(m libkb.MetaContext, kp *keypair) error {
+func (e *PaperProvisionEngine) paper(m libkb.MetaContext, keys *libkb.DeviceWithKeys) error {
 	// After obtaining login session, this will be called before the login state is released.
 	// It signs this new device with the paper key.
-	var afterLogin = func(lctx libkb.LoginContext) error {
-		m = m.WithLoginContext(lctx)
+	u := e.User
+	uid := u.GetUID()
+	nn := u.GetNormalizedName()
 
-		// need lksec to store device keys locally
-		if err := e.fetchLKS(m, kp.encKey); err != nil {
-			return err
-		}
+	// Set the active device to be a special paper key active device, which keeps
+	// a cached copy around for DeviceKeyGen, which requires it to be in memory.
+	// It also will establish a NIST so that API calls can proceed on behalf of the user.
+	m = m.WithPaperKeyActiveDevice(keys, uid)
+	m.LoginContext().SetUsernameUID(nn, uid)
 
-		lctx.SetUnlockedPaperKey(kp.sigKey, kp.encKey)
-
-		if err := e.makeDeviceKeysWithSigner(m, kp.sigKey); err != nil {
-			return err
-		}
-		if err := lctx.LocalSession().SetDeviceProvisioned(e.G().Env.GetDeviceID()); err != nil {
-			// not a fatal error, session will stay in memory
-			m.CWarningf("error saving session file: %s", err)
-		}
-		return nil
+	// need lksec to store device keys locally
+	if err := e.fetchLKS(m, keys.EncryptionKey()); err != nil {
+		return err
 	}
 
-	// need a session to continue to provision, login with paper sigKey
-	return e.G().LoginState().LoginWithKey(m, e.User, kp.sigKey, afterLogin)
+	if err := e.makeDeviceKeysWithSigner(m, keys.SigningKey()); err != nil {
+		return err
+	}
+
+	// Cache the paper keys globally now that we're logged in
+	m = m.WithGlobalActiveDevice()
+	m.ActiveDevice().CachePaperKey(m, keys)
+
+	return nil
 }
 
 func (e *PaperProvisionEngine) sendNotification() {

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -343,7 +343,7 @@ func (e *PGPKeyImportEngine) push(m libkb.MetaContext) (err error) {
 	}
 	e.del.NewKey = e.bundle
 	e.del.EncodedPrivateKey = e.epk
-	if err = e.del.Run(m.LoginContext()); err != nil {
+	if err = e.del.Run(m); err != nil {
 		return err
 	}
 

--- a/go/engine/pgp_keygen.go
+++ b/go/engine/pgp_keygen.go
@@ -139,5 +139,5 @@ func (e *PGPKeyGen) push(m libkb.MetaContext, bundle *libkb.PGPKeyBundle, pushPr
 		del.EncodedPrivateKey = armored
 	}
 
-	return del.Run(m.LoginContext())
+	return del.Run(m)
 }

--- a/go/engine/pgp_update.go
+++ b/go/engine/pgp_update.go
@@ -104,7 +104,7 @@ func (e *PGPUpdateEngine) Run(m libkb.MetaContext) error {
 		del.NewKey = bundle
 
 		m.UIs().LogUI.Info("Posting update for key %s.", fingerprint.String())
-		if err := del.Run(m.LoginContext()); err != nil {
+		if err := del.Run(m); err != nil {
 			if appStatusErr, ok := err.(libkb.AppStatusError); ok && appStatusErr.Code == libkb.SCKeyDuplicateUpdate {
 				m.UIs().LogUI.Info("Key was already up to date.")
 				e.duplicatedFingerprints = append(e.duplicatedFingerprints, fingerprint)

--- a/go/engine/saltpack_decrypt.go
+++ b/go/engine/saltpack_decrypt.go
@@ -128,7 +128,7 @@ func (e *SaltpackDecrypt) Run(m libkb.MetaContext) (err error) {
 		if err != nil {
 			return err
 		}
-		key = keypair.encKey
+		key = keypair.EncryptionKey()
 	} else {
 		// Load self so that we can get device keys. This does require you to
 		// be logged in.

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -280,7 +280,7 @@ func (a *Account) Keyring() (*SKBKeyringFile, error) {
 	unp := a.localSession.GetUsername()
 	// not sure how this could happen, but just in case:
 	if unp == nil {
-		return nil, NoUsernameError{}
+		return nil, NewNoUsernameError()
 	}
 
 	if a.skbKeyring != nil && a.skbKeyring.IsForUsername(*unp) {
@@ -531,26 +531,6 @@ func (a *Account) deviceNameLookup(device *Device, me *User, key GenericKey) str
 	return *device.Description
 }
 
-func (a *Account) SetUnlockedPaperKey(sig GenericKey, enc GenericKey) error {
-	a.paperSigKey = newTimedGenericKey(a.G(), sig, "paper signing key")
-	a.paperEncKey = newTimedGenericKey(a.G(), enc, "paper encryption key")
-	return nil
-}
-
-func (a *Account) GetUnlockedPaperSigKey() GenericKey {
-	if a.paperSigKey == nil {
-		return nil
-	}
-	return a.paperSigKey.getKey()
-}
-
-func (a *Account) GetUnlockedPaperEncKey() GenericKey {
-	if a.paperEncKey == nil {
-		return nil
-	}
-	return a.paperEncKey.getKey()
-}
-
 func (a *Account) ClearCachedSecretKeys() {
 	a.G().Log.Debug("clearing cached secret keys")
 	a.ClearPaperKeys()
@@ -604,4 +584,8 @@ func (a *Account) SecretPromptCanceled() {
 
 func (a *Account) SetDeviceName(name string) error {
 	return a.G().ActiveDevice.setDeviceName(a, a.G().Env.GetUID(), a.localSession.GetDeviceID(), name)
+}
+
+func (a *Account) SetUsernameUID(n NormalizedUsername, u keybase1.UID) error {
+	return errors.New("cannot call SetUsernameUID on legacy Account object")
 }

--- a/go/libkb/delegatekeyaggregator.go
+++ b/go/libkb/delegatekeyaggregator.go
@@ -16,7 +16,7 @@ type AggSigProducer func() (JSONPayload, error)
 
 // Run posts an array of delegations to the server. Keeping this simple as we don't need any state (yet)
 // `extra` is optional and adds an extra sig, produced by something other than a Delegator, after the others.
-func DelegatorAggregator(lctx LoginContext, ds []Delegator, extra AggSigProducer,
+func DelegatorAggregator(m MetaContext, ds []Delegator, extra AggSigProducer,
 	pukBoxes []keybase1.PerUserKeyBox, pukPrev *PerUserKeyPrev) (err error) {
 	if len(ds) == 0 {
 		return errors.New("Empty delegators to aggregator")
@@ -30,7 +30,7 @@ func DelegatorAggregator(lctx LoginContext, ds []Delegator, extra AggSigProducer
 		var d = &ds[i]
 
 		d.Aggregated = true
-		if err := d.Run(lctx); err != nil {
+		if err := d.Run(m); err != nil {
 			return err
 		}
 
@@ -62,8 +62,9 @@ func DelegatorAggregator(lctx LoginContext, ds []Delegator, extra AggSigProducer
 	apiArg.uArgs = nil
 	apiArg.Endpoint = "key/multi"
 	apiArg.JSONPayload = payload
+	apiArg.MetaContext = m
 
-	_, err = apiArgBase.G().API.PostJSON(apiArg)
+	_, err = m.G().API.PostJSON(apiArg)
 	return err
 }
 

--- a/go/libkb/device_with_keys.go
+++ b/go/libkb/device_with_keys.go
@@ -1,0 +1,109 @@
+package libkb
+
+import (
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"sync"
+	"time"
+)
+
+type DeviceWithKeys struct {
+	signingKey    GenericKey
+	encryptionKey GenericKey
+	deviceID      keybase1.DeviceID
+	deviceName    string
+}
+
+func NewDeviceWithKeys(s GenericKey, e GenericKey, d keybase1.DeviceID, n string) *DeviceWithKeys {
+	return &DeviceWithKeys{s, e, d, n}
+}
+func NewDeviceWithKeysOnly(e GenericKey, s GenericKey) *DeviceWithKeys {
+	return &DeviceWithKeys{e, s, keybase1.DeviceID(""), ""}
+}
+func (d DeviceWithKeys) EncryptionKey() GenericKey {
+	return d.encryptionKey
+}
+func (d DeviceWithKeys) SigningKey() GenericKey {
+	return d.signingKey
+}
+func (d DeviceWithKeys) DeviceID() keybase1.DeviceID {
+	return d.deviceID
+}
+func (d DeviceWithKeys) DeviceName() string {
+	return d.deviceName
+}
+
+func (d DeviceWithKeys) HasBothKeys() bool {
+	return d.signingKey != nil && d.encryptionKey != nil
+}
+
+type SelfDestructingDeviceWithKeys struct {
+	sync.Mutex
+	deviceWithKeys    *DeviceWithKeys
+	testPostCleanHook func()
+}
+
+func NewSelfDestructingDeviceWithKeys(m MetaContext, k *DeviceWithKeys, d time.Duration) *SelfDestructingDeviceWithKeys {
+	ret := &SelfDestructingDeviceWithKeys{
+		deviceWithKeys: k,
+	}
+	go ret.setFuse(m, d)
+	return ret
+}
+
+func (s *SelfDestructingDeviceWithKeys) setFuse(m MetaContext, d time.Duration) {
+	<-m.G().Clock().After(d)
+	s.Lock()
+	defer s.Unlock()
+	s.deviceWithKeys = nil
+	if s.testPostCleanHook != nil {
+		s.testPostCleanHook()
+	}
+}
+
+func (s *SelfDestructingDeviceWithKeys) SetTestPostCleanHook(f func()) {
+	s.Lock()
+	defer s.Unlock()
+	s.testPostCleanHook = f
+}
+
+func (s *SelfDestructingDeviceWithKeys) DeviceWithKeys() *DeviceWithKeys {
+	s.Lock()
+	defer s.Unlock()
+	if s.deviceWithKeys == nil {
+		return nil
+	}
+	ret := *s.deviceWithKeys
+	return &ret
+}
+
+type ownerDeviceReply struct {
+	Status     AppStatus         `json:"status"`
+	UID        keybase1.UID      `json:"uid"`
+	DeviceID   keybase1.DeviceID `json:"device_id"`
+	DeviceName string            `json:"device_name"`
+}
+
+func (o *ownerDeviceReply) GetAppStatus() *AppStatus {
+	return &o.Status
+}
+
+func (d *DeviceWithKeys) Populate(m MetaContext) (uid keybase1.UID, err error) {
+	arg := APIArg{
+		Endpoint:    "key/owner/device",
+		SessionType: APISessionTypeNONE,
+		Args:        HTTPArgs{"kid": S{Val: d.signingKey.GetKID().String()}},
+		NetContext:  m.Ctx(),
+	}
+	var res ownerDeviceReply
+	err = m.G().API.GetDecode(arg, &res)
+	if err != nil {
+		return uid, err
+	}
+	d.deviceID = res.DeviceID
+	d.deviceName = res.DeviceName
+	return res.UID, nil
+}
+
+func (d *DeviceWithKeys) ToPaperKeyActiveDevice(m MetaContext, u keybase1.UID) *ActiveDevice {
+	return NewPaperKeyActiveDevice(m, u, d)
+}

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -707,6 +707,8 @@ func (e NoUsernameError) Error() string {
 	return "No username known"
 }
 
+func NewNoUsernameError() NoUsernameError { return NoUsernameError{} }
+
 //=============================================================================
 
 type UnmarshalError struct {

--- a/go/libkb/generickey.go
+++ b/go/libkb/generickey.go
@@ -71,7 +71,8 @@ func CanEncrypt(key GenericKey) bool {
 	}
 }
 
-func skbPushAndSave(m MetaContext, skb *SKB) error {
+func skbPushAndSave(m MetaContext, skb *SKB) (err error) {
+	defer m.CTrace("skbPushAndSave", func() error { return err })()
 	if lctx := m.LoginContext(); lctx != nil {
 		kr, err := lctx.Keyring()
 		if err != nil {
@@ -79,7 +80,6 @@ func skbPushAndSave(m MetaContext, skb *SKB) error {
 		}
 		return kr.PushAndSave(skb)
 	}
-	var err error
 	kerr := m.G().LoginState().Keyring(func(ring *SKBKeyringFile) {
 		err = ring.PushAndSave(skb)
 	}, "PushAndSave")

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -47,7 +47,7 @@ func (g *GlobalContext) SKBFilenameForUser(un NormalizedUsername) string {
 
 func LoadSKBKeyring(un NormalizedUsername, g *GlobalContext) (*SKBKeyringFile, error) {
 	if un.IsNil() {
-		return nil, NoUsernameError{}
+		return nil, NewNoUsernameError()
 	}
 
 	skbfile := NewSKBKeyringFile(g, un)
@@ -58,9 +58,13 @@ func LoadSKBKeyring(un NormalizedUsername, g *GlobalContext) (*SKBKeyringFile, e
 	return skbfile, nil
 }
 
+func LoadSKBKeyringFromMetaContext(m MetaContext) (*SKBKeyringFile, error) {
+	return LoadSKBKeyring(m.CurrentUsername(), m.G())
+}
+
 func StatSKBKeyringMTime(un NormalizedUsername, g *GlobalContext) (mtime time.Time, err error) {
 	if un.IsNil() {
-		return mtime, NoUsernameError{}
+		return mtime, NewNoUsernameError()
 	}
 	return NewSKBKeyringFile(g, un).MTime()
 }
@@ -323,7 +327,7 @@ func (k *Keyrings) GetSecretKeyWithoutPrompt(m MetaContext, ska SecretKeyArg) (k
 
 	// not cached, so try to unlock without prompting
 	if ska.Me == nil {
-		err = NoUsernameError{}
+		err = NewNoUsernameError()
 		return nil, err
 	}
 	secretStore := NewSecretStore(m.G(), ska.Me.GetNormalizedName())

--- a/go/libkb/lksec.go
+++ b/go/libkb/lksec.go
@@ -502,6 +502,7 @@ func (s *LKSec) EncryptClientHalfRecovery(key GenericKey) (string, error) {
 // ToSKB exports a generic key with the given LKSec to a SecretKeyBundle,
 // performing all necessary encryption.
 func (s *LKSec) ToSKB(m MetaContext, key GenericKey) (ret *SKB, err error) {
+	defer m.CTrace("LKSec#ToSKB", func() error { return err })()
 	if s == nil {
 		return nil, errors.New("nil lks")
 	}
@@ -526,12 +527,13 @@ func (s *LKSec) ToSKB(m MetaContext, key GenericKey) (ret *SKB, err error) {
 	return ret, nil
 }
 
-func WriteLksSKBToKeyring(m MetaContext, k GenericKey, lks *LKSec) (*SKB, error) {
-	skb, err := lks.ToSKB(m, k)
+func WriteLksSKBToKeyring(m MetaContext, k GenericKey, lks *LKSec) (skb *SKB, err error) {
+	defer m.CTrace("WriteLksSKBToKeyring", func() error { return err })()
+	skb, err = lks.ToSKB(m, k)
 	if err != nil {
 		return nil, fmt.Errorf("k.ToLksSKB() error: %s", err)
 	}
-	if err := skbPushAndSave(m, skb); err != nil {
+	if err = skbPushAndSave(m, skb); err != nil {
 		return nil, err
 	}
 	return skb, nil

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -56,6 +56,7 @@ type LoginContext interface {
 	GetUsername() NormalizedUsername
 	EnsureUsername(username NormalizedUsername)
 	SaveState(sessionID, csrf string, username NormalizedUsername, uid keybase1.UID, deviceID keybase1.DeviceID) error
+	SetUsernameUID(username NormalizedUsername, uid keybase1.UID) error
 
 	Keyring() (*SKBKeyringFile, error)
 	ClearKeyring()
@@ -65,10 +66,6 @@ type LoginContext interface {
 	RunSecretSyncer(uid keybase1.UID) error
 
 	SetCachedSecretKey(ska SecretKeyArg, key GenericKey, device *Device) error
-	SetUnlockedPaperKey(sig GenericKey, enc GenericKey) error
-
-	GetUnlockedPaperEncKey() GenericKey
-	GetUnlockedPaperSigKey() GenericKey
 }
 
 type LoggedInHelper interface {
@@ -735,7 +732,7 @@ func (s *LoginState) getEmailOrUsername(m MetaContext, username *string, loginUI
 	}
 
 	if len(*username) == 0 {
-		err = NoUsernameError{}
+		err = NewNoUsernameError()
 	}
 
 	if err != nil {

--- a/go/libkb/naclgen.go
+++ b/go/libkb/naclgen.go
@@ -46,7 +46,7 @@ func (g *NaclKeyGen) SaveLKS(m MetaContext, lks *LKSec) error {
 	return err
 }
 
-func (g *NaclKeyGen) Push(lctx LoginContext, aggregated bool) (d Delegator, err error) {
+func (g *NaclKeyGen) Push(m MetaContext, aggregated bool) (d Delegator, err error) {
 	if g.pair == nil {
 		return Delegator{}, fmt.Errorf("cannot Push delegator before Generate")
 	}
@@ -65,7 +65,7 @@ func (g *NaclKeyGen) Push(lctx LoginContext, aggregated bool) (d Delegator, err 
 		return
 	}
 
-	err = d.Run(lctx)
+	err = d.Run(m)
 	return
 }
 

--- a/go/libkb/passphrase_login.go
+++ b/go/libkb/passphrase_login.go
@@ -30,7 +30,7 @@ func pplGetEmailOrUsername(m MetaContext, usernameOrEmail string) (string, error
 		return "", err
 	}
 	if len(usernameOrEmail) == 0 {
-		return "", NoUsernameError{}
+		return "", NewNoUsernameError()
 	}
 	return usernameOrEmail, nil
 }

--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -547,7 +547,7 @@ func (s *PerUserKeyring) fetchBoxesLocked(m MetaContext,
 		SessionType: APISessionTypeREQUIRED,
 		SessionR:    sessionR,
 		RetryCount:  5, // It's pretty bad to fail this, so retry.
-		NetContext:  m.Ctx(),
+		MetaContext: m,
 	}, &resp)
 	if err != nil {
 		return nil, nil, err

--- a/go/libkb/post.go
+++ b/go/libkb/post.go
@@ -187,15 +187,15 @@ func CheckPostedViaSigID(ctx context.Context, g *GlobalContext, sigID keybase1.S
 	return rfound, keybase1.ProofStatus(rstatus), keybase1.ProofState(rstate), rerr
 }
 
-func PostDeviceLKS(ctx context.Context, g *GlobalContext, sr SessionReader, deviceID keybase1.DeviceID, deviceType string, serverHalf LKSecServerHalf,
+func PostDeviceLKS(m MetaContext, sr SessionReader, deviceID keybase1.DeviceID, deviceType string, serverHalf LKSecServerHalf,
 	ppGen PassphraseGeneration,
 	clientHalfRecovery string, clientHalfRecoveryKID keybase1.KID) error {
-	g.Log.Debug("| PostDeviceLKS: %s", deviceID)
+	m.CDebugf("| PostDeviceLKS: %s", deviceID)
 	if serverHalf.IsNil() {
 		return fmt.Errorf("PostDeviceLKS: called with empty serverHalf")
 	}
 	if ppGen < 1 {
-		g.Log.Warning("PostDeviceLKS: ppGen < 1 (%d)", ppGen)
+		m.CWarningf("PostDeviceLKS: ppGen < 1 (%d)", ppGen)
 		debug.PrintStack()
 	}
 	arg := APIArg{
@@ -210,13 +210,13 @@ func PostDeviceLKS(ctx context.Context, g *GlobalContext, sr SessionReader, devi
 			"kid":             S{Val: clientHalfRecoveryKID.String()},
 			"platform":        S{Val: GetPlatformString()},
 		},
-		RetryCount: 10,
-		SessionR:   sr,
-		NetContext: ctx,
+		RetryCount:  10,
+		SessionR:    sr,
+		MetaContext: m,
 	}
-	_, err := g.API.Post(arg)
+	_, err := m.G().API.Post(arg)
 	if err != nil {
-		g.Log.Info("device/update(%+v) failed: %s", arg.Args, err)
+		m.CInfof("device/update(%+v) failed: %s", arg.Args, err)
 	}
 	return err
 }

--- a/go/libkb/sync_secret.go
+++ b/go/libkb/sync_secret.go
@@ -174,6 +174,9 @@ func (ss *SecretSyncer) store(uid keybase1.UID) (err error) {
 // FindActiveKey examines the synced keys, looking for one that's currently active.
 // Returns ret=nil if none was found.
 func (ss *SecretSyncer) FindActiveKey(ckf *ComputedKeyFamily) (ret *SKB, err error) {
+	ss.Lock()
+	defer ss.Unlock()
+
 	if ss.keys == nil {
 		return nil, nil
 	}
@@ -187,6 +190,8 @@ func (ss *SecretSyncer) FindActiveKey(ckf *ComputedKeyFamily) (ret *SKB, err err
 
 // AllActiveKeys returns all the active synced PGP keys.
 func (ss *SecretSyncer) AllActiveKeys(ckf *ComputedKeyFamily) []*SKB {
+	ss.Lock()
+	defer ss.Unlock()
 	var res []*SKB
 	for _, key := range ss.keys.PrivateKeys {
 		if ret, _ := key.FindActiveKey(ss.G(), ckf); ret != nil {
@@ -197,6 +202,8 @@ func (ss *SecretSyncer) AllActiveKeys(ckf *ComputedKeyFamily) []*SKB {
 }
 
 func (ss *SecretSyncer) FindPrivateKey(kid string) (ServerPrivateKey, bool) {
+	ss.Lock()
+	defer ss.Unlock()
 	k, ok := ss.keys.PrivateKeys[kid]
 	return k, ok
 }
@@ -219,6 +226,8 @@ func (k *ServerPrivateKey) FindActiveKey(g *GlobalContext, ckf *ComputedKeyFamil
 }
 
 func (ss *SecretSyncer) FindDevice(id keybase1.DeviceID) (DeviceKey, error) {
+	ss.Lock()
+	defer ss.Unlock()
 	if ss.keys == nil {
 		return DeviceKey{}, DeviceNotFoundError{"SecretSyncer", id, false}
 	}
@@ -230,6 +239,8 @@ func (ss *SecretSyncer) FindDevice(id keybase1.DeviceID) (DeviceKey, error) {
 }
 
 func (ss *SecretSyncer) AllDevices() DeviceKeyMap {
+	ss.Lock()
+	defer ss.Unlock()
 	if ss.keys == nil {
 		return nil
 	}
@@ -244,6 +255,8 @@ func (ss *SecretSyncer) HasDevices() bool {
 }
 
 func (ss *SecretSyncer) Devices() (DeviceKeyMap, error) {
+	ss.Lock()
+	defer ss.Unlock()
 	if ss.keys == nil {
 		return nil, fmt.Errorf("no keys")
 	}
@@ -251,6 +264,8 @@ func (ss *SecretSyncer) Devices() (DeviceKeyMap, error) {
 }
 
 func (ss *SecretSyncer) dumpDevices() {
+	ss.Lock()
+	defer ss.Unlock()
 	ss.G().Log.Warning("dumpDevices:")
 	if ss.keys == nil {
 		ss.G().Log.Warning("dumpDevices -- ss.keys == nil")
@@ -288,6 +303,8 @@ func (ss *SecretSyncer) HasActiveDevice(includeTypesSet DeviceTypeSet) (bool, er
 
 // ActiveDevices returns all the active desktop and mobile devices.
 func (ss *SecretSyncer) ActiveDevices(includeTypesSet DeviceTypeSet) (DeviceKeyMap, error) {
+	ss.Lock()
+	defer ss.Unlock()
 	if ss.keys == nil {
 		return nil, fmt.Errorf("no keys")
 	}
@@ -310,6 +327,8 @@ func (ss *SecretSyncer) ActiveDevices(includeTypesSet DeviceTypeSet) (DeviceKeyM
 }
 
 func (ss *SecretSyncer) DumpPrivateKeys() {
+	ss.Lock()
+	defer ss.Unlock()
 	for s, key := range ss.keys.PrivateKeys {
 		ss.G().Log.Info("Private key: %s", s)
 		ss.G().Log.Info("  -- kid: %s, keytype: %d, bits: %d, algo: %d", key.Kid, key.KeyType, key.KeyBits, key.KeyAlgo)

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -161,23 +161,24 @@ func (h ConfigHandler) GetExtendedStatus(ctx context.Context, sessionID int) (re
 	res.DeviceSigKeyCached = sk != nil
 	res.DeviceEncKeyCached = ek != nil
 
-	h.G().LoginState().Account(func(a *libkb.Account) {
-		res.PassphraseStreamCached = a.PassphraseStreamCache().ValidPassphraseStream()
-		res.TsecCached = a.PassphraseStreamCache().ValidTsec()
-
-		// cached paper key status
-		if a.GetUnlockedPaperSigKey() != nil {
-			res.PaperSigKeyCached = true
-		}
-		if a.GetUnlockedPaperEncKey() != nil {
+	m := libkb.NewMetaContext(ctx, h.G())
+	ad := m.ActiveDevice()
+	// cached paper key status
+	if pk := ad.PaperKey(m); pk != nil {
+		if pk.EncryptionKey() != nil {
 			res.PaperEncKeyCached = true
 		}
-
-		res.SecretPromptSkip = a.SkipSecretPrompt()
-
-		if a.LoginSession() != nil {
-			res.Session = a.LoginSession().Status()
+		if pk.SigningKey() != nil {
+			res.PaperSigKeyCached = true
 		}
+	}
+
+	psc := ad.PassphraseStreamCache()
+	res.PassphraseStreamCached = psc.ValidPassphraseStream()
+	res.TsecCached = psc.ValidTsec()
+
+	h.G().LoginState().Account(func(a *libkb.Account) {
+		res.SecretPromptSkip = a.SkipSecretPrompt()
 	}, "ConfigHandler::GetExtendedStatus")
 
 	current, all, err := h.G().GetAllUserNames()

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -312,7 +312,7 @@ func (h *PGPHandler) PGPPurge(ctx context.Context, arg keybase1.PGPPurgeArg) (ke
 func (h *PGPHandler) PGPStorageDismiss(ctx context.Context, sessionID int) error {
 	username := h.G().Env.GetUsername()
 	if username.IsNil() {
-		return libkb.NoUsernameError{}
+		return libkb.NewNoUsernameError()
 	}
 
 	key := libkb.DbKeyNotificationDismiss(libkb.NotificationDismissPGPPrefix, username)

--- a/go/systests/rekey_test.go
+++ b/go/systests/rekey_test.go
@@ -705,13 +705,8 @@ func (rkt *rekeyTester) provisionNewDevice() *deviceWrapper {
 
 	// Clear the paper key because we don't want it hanging around to
 	// solve the problems we're trying to induce.
-	err := dev2.tctx.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearPaperKeys()
-	}, "provisionNewDevice")
-
-	if err != nil {
-		rkt.t.Fatalf("failed to clear keys: %s", err)
-	}
+	m := libkb.NewMetaContextBackground(dev2.tctx.G)
+	m.ActiveDevice().ClearPaperKey(m)
 
 	return dev2
 }


### PR DESCRIPTION
- store passphrase stream cache and paperkey in the active device
- remove engine.keyring in favor of libkb.DeviceWithKeys