### PR TITLE
Fix copyToClipboard import for proofs

### DIFF
--- a/shared/profile/post-proof/index.desktop.js
+++ b/shared/profile/post-proof/index.desktop.js
@@ -3,7 +3,7 @@ import * as shared from './shared'
 import * as React from 'react'
 import {Box, Button, CopyableText, Icon, PlatformIcon, Text} from '../../common-adapters'
 import LinkWithIcon from '../link-with-icon'
-import {copyToClipboard} from 'electron'
+import {copyToClipboard} from '../../util/clipboard'
 import {globalStyles, globalColors, globalMargins, desktopStyles, collapseStyles} from '../../styles'
 import type {Props} from '.'
 


### PR DESCRIPTION
@keybase/react-hackers 

Commit 0f26f724f023c3 changed the import path for `copyToClipboard()` to an incorrect one while doing unrelated icon work, resulting in an undefined function crash when you copy from inside the proof box on desktop.