### PR TITLE
Send (or skip) chat message when setting avatar

### DIFF
--- a/go/avatars/fullcaching_test.go
+++ b/go/avatars/fullcaching_test.go
@@ -73,6 +73,7 @@ func TestAvatarsFullCaching(t *testing.T) {
 		path = convertPath(path)
 		file, err := os.Open(path)
 		require.NoError(t, err)
+		defer file.Close()
 		dat, err := ioutil.ReadAll(file)
 		require.NoError(t, err)
 		return string(dat)

--- a/go/avatars/upload.go
+++ b/go/avatars/upload.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/teams"
 )
 
 func addFile(mpart *multipart.Writer, param, filename string) error {
@@ -32,7 +31,7 @@ func addFile(mpart *multipart.Writer, param, filename string) error {
 	return err
 }
 
-func postAvatarImage(mctx libkb.MetaContext, filename string, teamID *keybase1.TeamID, crop *keybase1.ImageCropRect) (err error) {
+func UploadImage(mctx libkb.MetaContext, filename string, teamID *keybase1.TeamID, crop *keybase1.ImageCropRect) (err error) {
 	var body bytes.Buffer
 	mpart := multipart.NewWriter(&body)
 
@@ -85,22 +84,4 @@ func postAvatarImage(mctx libkb.MetaContext, filename string, teamID *keybase1.T
 	}
 
 	return nil
-}
-
-func UploadImage(mctx libkb.MetaContext, filename string, teamname *string, crop *keybase1.ImageCropRect) error {
-	var teamID *keybase1.TeamID
-	if teamname != nil {
-		team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
-			Name:        *teamname,
-			Public:      false,
-			ForceRepoll: false,
-			NeedAdmin:   true,
-		})
-		if err != nil {
-			return err
-		}
-		teamID = &team.ID
-	}
-
-	return postAvatarImage(mctx, filename, teamID, crop)
 }

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -781,6 +781,8 @@ func systemMessageSnippet(msg chat1.MessageSystem) string {
 		return fmt.Sprintf("%s added to team", msg.Inviteaddedtoteam().Invitee)
 	case chat1.MessageSystemType_GITPUSH:
 		return fmt.Sprintf("%s pushed to %s", msg.Gitpush().Pusher, msg.Gitpush().RepoName)
+	case chat1.MessageSystemType_CHANGEAVATAR:
+		return fmt.Sprintf("%s changed team avatar", msg.Changeavatar().User)
 	default:
 		return ""
 	}

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -461,6 +461,8 @@ func formatSystemMessage(body chat1.MessageSystem) string {
 			return fmt.Sprintf("[git (%s) %s pushed %d commits to %s]", body.Gitpush().RepoName,
 				body.Gitpush().Pusher, total, names)
 		}
+	case chat1.MessageSystemType_CHANGEAVATAR:
+		return fmt.Sprintf("[%s changed team avatar]", body.Changeavatar().User)
 	}
 	return "<unknown system message>"
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -81,6 +81,7 @@ const (
 	MessageSystemType_COMPLEXTEAM       MessageSystemType = 2
 	MessageSystemType_CREATETEAM        MessageSystemType = 3
 	MessageSystemType_GITPUSH           MessageSystemType = 4
+	MessageSystemType_CHANGEAVATAR      MessageSystemType = 5
 )
 
 func (o MessageSystemType) DeepCopy() MessageSystemType { return o }
@@ -91,6 +92,7 @@ var MessageSystemTypeMap = map[string]MessageSystemType{
 	"COMPLEXTEAM":       2,
 	"CREATETEAM":        3,
 	"GITPUSH":           4,
+	"CHANGEAVATAR":      5,
 }
 
 var MessageSystemTypeRevMap = map[MessageSystemType]string{
@@ -99,6 +101,7 @@ var MessageSystemTypeRevMap = map[MessageSystemType]string{
 	2: "COMPLEXTEAM",
 	3: "CREATETEAM",
 	4: "GITPUSH",
+	5: "CHANGEAVATAR",
 }
 
 func (e MessageSystemType) String() string {
@@ -242,6 +245,18 @@ func (o MessageSystemGitPush) DeepCopy() MessageSystemGitPush {
 	}
 }
 
+type MessageSystemChangeAvatar struct {
+	Team string `codec:"team" json:"team"`
+	User string `codec:"user" json:"user"`
+}
+
+func (o MessageSystemChangeAvatar) DeepCopy() MessageSystemChangeAvatar {
+	return MessageSystemChangeAvatar{
+		Team: o.Team,
+		User: o.User,
+	}
+}
+
 type MessageSystem struct {
 	SystemType__        MessageSystemType               `codec:"systemType" json:"systemType"`
 	Addedtoteam__       *MessageSystemAddedToTeam       `codec:"addedtoteam,omitempty" json:"addedtoteam,omitempty"`
@@ -249,6 +264,7 @@ type MessageSystem struct {
 	Complexteam__       *MessageSystemComplexTeam       `codec:"complexteam,omitempty" json:"complexteam,omitempty"`
 	Createteam__        *MessageSystemCreateTeam        `codec:"createteam,omitempty" json:"createteam,omitempty"`
 	Gitpush__           *MessageSystemGitPush           `codec:"gitpush,omitempty" json:"gitpush,omitempty"`
+	Changeavatar__      *MessageSystemChangeAvatar      `codec:"changeavatar,omitempty" json:"changeavatar,omitempty"`
 }
 
 func (o *MessageSystem) SystemType() (ret MessageSystemType, err error) {
@@ -276,6 +292,11 @@ func (o *MessageSystem) SystemType() (ret MessageSystemType, err error) {
 	case MessageSystemType_GITPUSH:
 		if o.Gitpush__ == nil {
 			err = errors.New("unexpected nil value for Gitpush__")
+			return ret, err
+		}
+	case MessageSystemType_CHANGEAVATAR:
+		if o.Changeavatar__ == nil {
+			err = errors.New("unexpected nil value for Changeavatar__")
 			return ret, err
 		}
 	}
@@ -332,6 +353,16 @@ func (o MessageSystem) Gitpush() (res MessageSystemGitPush) {
 	return *o.Gitpush__
 }
 
+func (o MessageSystem) Changeavatar() (res MessageSystemChangeAvatar) {
+	if o.SystemType__ != MessageSystemType_CHANGEAVATAR {
+		panic("wrong case accessed")
+	}
+	if o.Changeavatar__ == nil {
+		return
+	}
+	return *o.Changeavatar__
+}
+
 func NewMessageSystemWithAddedtoteam(v MessageSystemAddedToTeam) MessageSystem {
 	return MessageSystem{
 		SystemType__:  MessageSystemType_ADDEDTOTEAM,
@@ -364,6 +395,13 @@ func NewMessageSystemWithGitpush(v MessageSystemGitPush) MessageSystem {
 	return MessageSystem{
 		SystemType__: MessageSystemType_GITPUSH,
 		Gitpush__:    &v,
+	}
+}
+
+func NewMessageSystemWithChangeavatar(v MessageSystemChangeAvatar) MessageSystem {
+	return MessageSystem{
+		SystemType__:   MessageSystemType_CHANGEAVATAR,
+		Changeavatar__: &v,
 	}
 }
 
@@ -405,6 +443,13 @@ func (o MessageSystem) DeepCopy() MessageSystem {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Gitpush__),
+		Changeavatar__: (func(x *MessageSystemChangeAvatar) *MessageSystemChangeAvatar {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Changeavatar__),
 	}
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -2310,9 +2310,10 @@ type SetTarsDisabledArg struct {
 }
 
 type UploadTeamAvatarArg struct {
-	Teamname string         `codec:"teamname" json:"teamname"`
-	Filename string         `codec:"filename" json:"filename"`
-	Crop     *ImageCropRect `codec:"crop,omitempty" json:"crop,omitempty"`
+	Teamname             string         `codec:"teamname" json:"teamname"`
+	Filename             string         `codec:"filename" json:"filename"`
+	Crop                 *ImageCropRect `codec:"crop,omitempty" json:"crop,omitempty"`
+	SendChatNotification bool           `codec:"sendChatNotification" json:"sendChatNotification"`
 }
 
 type TeamsInterface interface {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -8,7 +8,6 @@ package service
 import (
 	"fmt"
 
-	"github.com/keybase/client/go/avatars"
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -507,5 +506,5 @@ func (h *TeamsHandler) UploadTeamAvatar(ctx context.Context, arg keybase1.Upload
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("UploadTeamAvatar(%s,%s)", arg.Teamname, arg.Filename), func() error { return err })()
 
 	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
-	return avatars.UploadImage(mctx, arg.Filename, &arg.Teamname, arg.Crop)
+	return teams.ChangeTeamAvatar(mctx, arg)
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1526,6 +1526,8 @@ func ChangeTeamAvatar(mctx libkb.MetaContext, arg keybase1.UploadTeamAvatarArg) 
 		return err
 	}
 
-	SendTeamChatChangeAvatar(mctx, team.Name().String(), mctx.G().Env.GetUsername().String())
+	if arg.SendChatNotification {
+		SendTeamChatChangeAvatar(mctx, team.Name().String(), mctx.G().Env.GetUsername().String())
+	}
 	return nil
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/keybase/client/go/avatars"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -1507,5 +1508,24 @@ func SetTarsDisabled(ctx context.Context, g *libkb.GlobalContext, teamname strin
 		return err
 	}
 	t.notify(ctx, keybase1.TeamChangeSet{Misc: true})
+	return nil
+}
+
+func ChangeTeamAvatar(mctx libkb.MetaContext, arg keybase1.UploadTeamAvatarArg) error {
+	team, err := Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
+		Name:        arg.Teamname,
+		Public:      false,
+		ForceRepoll: false,
+		NeedAdmin:   true,
+	})
+	if err != nil {
+		return fixupTeamGetError(mctx.Ctx(), mctx.G(), err, arg.Teamname, false /* public */)
+	}
+
+	if err := avatars.UploadImage(mctx, arg.Filename, &team.ID, arg.Crop); err != nil {
+		return err
+	}
+
+	SendTeamChatChangeAvatar(mctx, team.Name().String(), mctx.G().Env.GetUsername().String())
 	return nil
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -32,7 +32,8 @@ protocol local {
     INVITEADDEDTOTEAM_1,
     COMPLEXTEAM_2,
     CREATETEAM_3,
-    GITPUSH_4
+    GITPUSH_4,
+    CHANGEAVATAR_5
   }
 
   record MessageSystemAddedToTeam {
@@ -72,12 +73,18 @@ protocol local {
     string previousRepoName;
   }
 
+  record MessageSystemChangeAvatar {
+    string team;
+    string user;
+  }
+
   variant MessageSystem switch (MessageSystemType systemType) {
     case ADDEDTOTEAM: MessageSystemAddedToTeam;
     case INVITEADDEDTOTEAM: MessageSystemInviteAddedToTeam;
     case COMPLEXTEAM: MessageSystemComplexTeam;
     case CREATETEAM: MessageSystemCreateTeam;
     case GITPUSH: MessageSystemGitPush;
+    case CHANGEAVATAR: MessageSystemChangeAvatar;
   }
 
   record MessageDeleteHistory {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -838,5 +838,5 @@ protocol teams {
   boolean getTarsDisabled(string name);
   void setTarsDisabled(string name, boolean disabled);
 
-  void uploadTeamAvatar(string teamname, string filename, union { null, ImageCropRect } crop);
+  void uploadTeamAvatar(string teamname, string filename, union { null, ImageCropRect } crop, boolean sendChatNotification);
 }

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -266,6 +266,7 @@ export const localMessageSystemType = {
   complexteam: 2,
   createteam: 3,
   gitpush: 4,
+  changeavatar: 5,
 }
 
 export const localMessageUnboxedErrorType = {
@@ -1041,9 +1042,11 @@ export type MessageServerHeader = $ReadOnly<{messageID: MessageID, supersededBy:
 
 export type MessageSummary = $ReadOnly<{msgID: MessageID, messageType: MessageType, tlfName: String, tlfPublic: Boolean, ctime: Gregor1.Time}>
 
-export type MessageSystem = {systemType: 0, addedtoteam: ?MessageSystemAddedToTeam} | {systemType: 1, inviteaddedtoteam: ?MessageSystemInviteAddedToTeam} | {systemType: 2, complexteam: ?MessageSystemComplexTeam} | {systemType: 3, createteam: ?MessageSystemCreateTeam} | {systemType: 4, gitpush: ?MessageSystemGitPush}
+export type MessageSystem = {systemType: 0, addedtoteam: ?MessageSystemAddedToTeam} | {systemType: 1, inviteaddedtoteam: ?MessageSystemInviteAddedToTeam} | {systemType: 2, complexteam: ?MessageSystemComplexTeam} | {systemType: 3, createteam: ?MessageSystemCreateTeam} | {systemType: 4, gitpush: ?MessageSystemGitPush} | {systemType: 5, changeavatar: ?MessageSystemChangeAvatar}
 
 export type MessageSystemAddedToTeam = $ReadOnly<{team: String, adder: String, addee: String, owners?: ?Array<String>, admins?: ?Array<String>, writers?: ?Array<String>, readers?: ?Array<String>}>
+
+export type MessageSystemChangeAvatar = $ReadOnly<{team: String, user: String}>
 
 export type MessageSystemComplexTeam = $ReadOnly<{team: String}>
 
@@ -1059,6 +1062,7 @@ export type MessageSystemType =
   | 2 // COMPLEXTEAM_2
   | 3 // CREATETEAM_3
   | 4 // GITPUSH_4
+  | 5 // CHANGEAVATAR_5
 
 export type MessageText = $ReadOnly<{body: String}>
 

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3974,7 +3974,7 @@ export type TeamsUiConfirmRootTeamDeleteRpcParam = $ReadOnly<{teamName: String, 
 
 export type TeamsUiConfirmSubteamDeleteRpcParam = $ReadOnly<{teamName: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type TeamsUploadTeamAvatarRpcParam = $ReadOnly<{teamname: String, filename: String, crop?: ?ImageCropRect, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type TeamsUploadTeamAvatarRpcParam = $ReadOnly<{teamname: String, filename: String, crop?: ?ImageCropRect, sendChatNotification: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type Test = $ReadOnly<{reply: String}>
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -86,7 +86,8 @@
         "INVITEADDEDTOTEAM_1",
         "COMPLEXTEAM_2",
         "CREATETEAM_3",
-        "GITPUSH_4"
+        "GITPUSH_4",
+        "CHANGEAVATAR_5"
       ]
     },
     {
@@ -223,6 +224,20 @@
       ]
     },
     {
+      "type": "record",
+      "name": "MessageSystemChangeAvatar",
+      "fields": [
+        {
+          "type": "string",
+          "name": "team"
+        },
+        {
+          "type": "string",
+          "name": "user"
+        }
+      ]
+    },
+    {
       "type": "variant",
       "name": "MessageSystem",
       "switch": {
@@ -264,6 +279,13 @@
             "def": false
           },
           "body": "MessageSystemGitPush"
+        },
+        {
+          "label": {
+            "name": "CHANGEAVATAR",
+            "def": false
+          },
+          "body": "MessageSystemChangeAvatar"
         }
       ]
     },

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2546,6 +2546,10 @@
             null,
             "ImageCropRect"
           ]
+        },
+        {
+          "name": "sendChatNotification",
+          "type": "boolean"
         }
       ],
       "response": null

--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -258,6 +258,13 @@ const uiMessageToSystemMessage = (minimum, body): ?Types.Message => {
         team,
       })
     }
+    case RPCChatTypes.localMessageSystemType.changeavatar: {
+      const {user = '???'} = body.changeavatar || {}
+      return makeMessageSystemText({
+        text: new HiddenString(`${user} changed team avatar`),
+        ...minimum,
+      })
+    }
     default:
       /*::
       declare var ifFlowErrorsHereItsCauseYouDidntHandleAllTypesAbove: (a: empty) => any

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -266,6 +266,7 @@ export const localMessageSystemType = {
   complexteam: 2,
   createteam: 3,
   gitpush: 4,
+  changeavatar: 5,
 }
 
 export const localMessageUnboxedErrorType = {
@@ -1041,9 +1042,11 @@ export type MessageServerHeader = $ReadOnly<{messageID: MessageID, supersededBy:
 
 export type MessageSummary = $ReadOnly<{msgID: MessageID, messageType: MessageType, tlfName: String, tlfPublic: Boolean, ctime: Gregor1.Time}>
 
-export type MessageSystem = {systemType: 0, addedtoteam: ?MessageSystemAddedToTeam} | {systemType: 1, inviteaddedtoteam: ?MessageSystemInviteAddedToTeam} | {systemType: 2, complexteam: ?MessageSystemComplexTeam} | {systemType: 3, createteam: ?MessageSystemCreateTeam} | {systemType: 4, gitpush: ?MessageSystemGitPush}
+export type MessageSystem = {systemType: 0, addedtoteam: ?MessageSystemAddedToTeam} | {systemType: 1, inviteaddedtoteam: ?MessageSystemInviteAddedToTeam} | {systemType: 2, complexteam: ?MessageSystemComplexTeam} | {systemType: 3, createteam: ?MessageSystemCreateTeam} | {systemType: 4, gitpush: ?MessageSystemGitPush} | {systemType: 5, changeavatar: ?MessageSystemChangeAvatar}
 
 export type MessageSystemAddedToTeam = $ReadOnly<{team: String, adder: String, addee: String, owners?: ?Array<String>, admins?: ?Array<String>, writers?: ?Array<String>, readers?: ?Array<String>}>
+
+export type MessageSystemChangeAvatar = $ReadOnly<{team: String, user: String}>
 
 export type MessageSystemComplexTeam = $ReadOnly<{team: String}>
 
@@ -1059,6 +1062,7 @@ export type MessageSystemType =
   | 2 // COMPLEXTEAM_2
   | 3 // CREATETEAM_3
   | 4 // GITPUSH_4
+  | 5 // CHANGEAVATAR_5
 
 export type MessageText = $ReadOnly<{body: String}>
 

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3974,7 +3974,7 @@ export type TeamsUiConfirmRootTeamDeleteRpcParam = $ReadOnly<{teamName: String, 
 
 export type TeamsUiConfirmSubteamDeleteRpcParam = $ReadOnly<{teamName: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type TeamsUploadTeamAvatarRpcParam = $ReadOnly<{teamname: String, filename: String, crop?: ?ImageCropRect, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type TeamsUploadTeamAvatarRpcParam = $ReadOnly<{teamname: String, filename: String, crop?: ?ImageCropRect, sendChatNotification: Boolean, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type Test = $ReadOnly<{reply: String}>
 


### PR DESCRIPTION
Send `MessageSystemType_CHANGEAVATAR` when changing avatar, or choose not to with `--skip-chat-message`.

This might need more work if we decide that the message should somehow link old avatar or something like that.