### PR TITLE
Make the feedback button full-width.

### DIFF
--- a/shared/settings/feedback.native.js
+++ b/shared/settings/feedback.native.js
@@ -133,7 +133,13 @@ class Feedback extends Component<Props> {
             </Box>
           </Box>
           <ButtonBar>
-            <Button label="Send" type="Primary" onClick={this._onSubmit} waiting={sending} />
+            <Button
+              label="Send"
+              type="Primary"
+              onClick={this._onSubmit}
+              waiting={sending}
+              style={{width: '100%'}}
+            />
           </ButtonBar>
           {sendError && (
             <Box style={{...globalStyles.flexBoxColumn, marginTop: globalMargins.small}}>

--- a/shared/settings/feedback.native.js
+++ b/shared/settings/feedback.native.js
@@ -137,6 +137,7 @@ class Feedback extends Component<Props> {
               fullWidth={true}
               label="Send"
               onClick={this._onSubmit}
+              // TODO: Remove this style when fullWidth does it.
               style={{width: '100%'}}
               type="Primary"
               waiting={sending}

--- a/shared/settings/feedback.native.js
+++ b/shared/settings/feedback.native.js
@@ -134,11 +134,12 @@ class Feedback extends Component<Props> {
           </Box>
           <ButtonBar>
             <Button
+              fullWidth={true}
               label="Send"
-              type="Primary"
               onClick={this._onSubmit}
-              waiting={sending}
               style={{width: '100%'}}
+              type="Primary"
+              waiting={sending}
             />
           </ButtonBar>
           {sendError && (


### PR DESCRIPTION
@cecileboucheron requested this change.

@keybase/react-hackers, this is ready for review. It makes the “Send” button on the feedback view full-width. Also, is there a reason we wouldn't want the `fullWidth` attribute to also set the width to 100%?