### PR TITLE
Move relay to its own package

### DIFF
--- a/go/stellar/stellarcommon/common.go
+++ b/go/stellar/stellarcommon/common.go
@@ -1,0 +1,18 @@
+package stellarcommon
+
+import (
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/stellarnet"
+)
+
+type RecipientInput string
+
+type Recipient struct {
+	Input RecipientInput
+	// These 3 fields are nullable.
+	User      *libkb.User
+	Assertion *keybase1.SocialAssertion
+	// Recipient may not have a stellar wallet ready to receive
+	AccountID *stellarnet.AddressStr // User entered G... OR target has receiving address
+}

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/stellar"
 	"github.com/keybase/client/go/stellar/remote"
+	"github.com/keybase/client/go/stellar/stellarcommon"
 	"github.com/stellar/go/amount"
 )
 
@@ -136,7 +137,7 @@ func (s *Server) SendLocal(ctx context.Context, arg stellar1.SendLocalArg) (stel
 	}
 	m := libkb.NewMetaContext(ctx, s.G()).WithUIs(uis)
 
-	return stellar.SendPayment(m, s.remoter, stellar.RecipientInput(arg.Recipient), arg.Amount, arg.Note, displayBalance)
+	return stellar.SendPayment(m, s.remoter, stellarcommon.RecipientInput(arg.Recipient), arg.Amount, arg.Note, displayBalance)
 }
 
 func (s *Server) RecentPaymentsCLILocal(ctx context.Context, accountID *stellar1.AccountID) (res []stellar1.PaymentCLIOptionLocal, err error) {


### PR DESCRIPTION
Instead of making some relay methods private, move relay keying code to its own package under `stellar/relays`. `stellar/stellarcommon` is collateral damage.