### PR TITLE
When creating a new subteam, don't strip away the last segment

### DIFF
--- a/shared/constants/__test__/teamname.test.js
+++ b/shared/constants/__test__/teamname.test.js
@@ -1,6 +1,6 @@
 // @noflow
 /* eslint-env jest */
-import {validTeamname, baseTeamname} from '../teamname'
+import {validTeamname} from '../teamname'
 
 describe('teamname', () => {
   describe('validTeamname', () => {
@@ -19,11 +19,5 @@ describe('teamname', () => {
         expect(validTeamname(validName)).toBe(false)
       }
     })
-  })
-
-  it('baseTeamname', () => {
-    expect(baseTeamname('team')).toBe('team')
-    expect(baseTeamname('team.sub')).toBe('team')
-    expect(baseTeamname('team.sub.sub')).toBe('team.sub')
   })
 })

--- a/shared/constants/teamname.js
+++ b/shared/constants/teamname.js
@@ -14,18 +14,4 @@ const validTeamname = (s: string): boolean => {
   return s.split('.').every(validTeamnamePart)
 }
 
-// The type below is copied from ..teams. Can't import it because
-// doing so yields an error, possibly because of an import cycle.
-
-type Teamname = string
-
-const baseTeamname = (teamname: Teamname): ?Teamname => {
-  const i = teamname.lastIndexOf('.')
-  if (i < 0) {
-    return teamname
-  }
-
-  return teamname.substring(0, i)
-}
-
-export {validTeamnamePart, validTeamname, baseTeamname}
+export {validTeamnamePart, validTeamname}

--- a/shared/teams/new-team/container.js
+++ b/shared/teams/new-team/container.js
@@ -10,7 +10,6 @@ import {
   withHandlers,
   type TypedState,
 } from '../../util/container'
-import {baseTeamname} from '../../constants/teamname'
 
 const mapStateToProps = (state: TypedState) => ({
   errorText: upperFirst(state.teams.teamCreationError),
@@ -32,8 +31,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath}) => ({
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const isSubteam = ownProps.routeProps.get('makeSubteam') || false
-  const routeName = ownProps.routeProps.get('name') || ''
-  const baseTeam = baseTeamname(routeName)
+  const baseTeam = ownProps.routeProps.get('name') || ''
   return {
     ...stateProps,
     ...dispatchProps,


### PR DESCRIPTION
@keybase/react-hackers 

@buoyad, seems like this baseTeamname() function doesn't need to exist at all, do you agree?