### PR TITLE
Fix up edit channel name/desc

### DIFF
--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -34,10 +34,10 @@ const mapStateToProps = (state: TypedState, {routeProps, routeState}) => {
 
   const channels = channelInfos
     .map((info, convID) => ({
-      description: info.description,
+      description: info.description || '',
       convID,
-      name: info.channelname,
-      selected: you && info.participants.has(you),
+      name: info.channelname || '',
+      selected: you && info.participants && info.participants.has(you),
     }))
     .valueSeq()
     .toArray()

--- a/shared/chat/manage-channels/edit-channel-container.js
+++ b/shared/chat/manage-channels/edit-channel-container.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import * as I from 'immutable'
 import * as Constants from '../../constants/teams'
-import {getMeta} from '../../constants/chat2'
 import * as TeamsGen from '../../actions/teams-gen'
 import {type ConversationIDKey} from '../../constants/types/chat2'
 import EditChannel, {type Props} from './edit-channel'
@@ -19,25 +18,15 @@ const mapStateToProps = (state: TypedState, {navigateUp, routePath, routeProps})
     throw new Error('teamname unexpectedly empty')
   }
 
-  // If we're being loaded from the manage channels page, then
-  // getChannelInfoFromConvID should return a non-null ChannelInfo
-  // object. Otherwise, we're being loaded from the info pane of a
-  // channel we belong to, so fetch the meta from the chat store
-  // instead.
-  const channelInfo =
-    Constants.getChannelInfoFromConvID(state, teamname, conversationIDKey) ||
-    getMeta(state, conversationIDKey)
-
-  const channelName = channelInfo ? channelInfo.channelname : ''
-  const topic = channelInfo ? channelInfo.description : ''
+  const {channelName, topic} = Constants.getChannelNameAndTopicFromConvID(state, teamname, conversationIDKey)
   const yourRole = Constants.getRole(state, teamname)
   const canDelete = Constants.isAdmin(yourRole) || Constants.isOwner(yourRole)
   return {
+    canDelete,
+    channelName,
     conversationIDKey,
     teamname,
-    channelName,
     topic,
-    canDelete,
   }
 }
 


### PR DESCRIPTION
@keybase/react-hackers CC @akalin-keybase 

Commit da00b48248bb introduced a new algorithm for finding the channel name and description for a conversationID, described in a comment inside the commit.  The motivation is to allow the edit-channel component to be used from two different places: the info pane (channel is in inbox) and the manage channels page of a team (channel isn't in inbox, but is in teams store).  Here's the comment:

```js
  // If we're being loaded from the manage channels page, then
  // getChannelInfoFromConvID should return a non-null ChannelInfo
  // object. Otherwise, we're being loaded from the info pane of a
  // channel we belong to, so fetch the meta from the chat store
  // instead.
  const channelInfo =
    Constants.getChannelInfoFromConvID(state, teamname, conversationIDKey) ||
    getMeta(state, conversationIDKey)
```
This doesn't quite work, for two reasons.

1) If you have a channel that's only in your inbox, and you edit it through the info pane, the act of editing it writes a non-null ChannelInfo object into the teams store.  So if you go back to the edit channel dialog again from the info pane, we'll now use the teams store version.  But that ChannelInfo object is incomplete: if you change the name but not the description, then we don't record the description there at all.

2) If the teams store object exists in that case, it'll be an `I.Map()`, and you need to convert to an object or `channelInfo.description` (as opposed to `channelInfo.get('description')` will return undefined and the dialog will show up empty, which is what's happening on master.  It looks like it's usually an `I.Record()` in the case where you didn't just write it, so perhaps the use of `I.Map()` there is a bug?

So, this algorithm doesn't work.  How about if we reverse it -- prefer the inbox if it exists, then fall back to the teams store?

That *almost* works.  If the inbox row exists but is not yet unboxed, then the `description` will be blank -- we don't know what it is until we've unboxed.  Seems like we actually want "prefer the inbox if it exists and is unboxed, else fall back to the teams store", and that seems to cover every case.  That's what this PR does.