### PR TITLE
Up arrow to edit a chat message should leave the cursor at the end of the message

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -67,7 +67,6 @@ class PlatformInput extends Component<PlatformInputProps, State> {
   }
 
   _onKeyDown = (e: SyntheticKeyboardEvent<>) => {
-    e.preventDefault()
     if (this.props.pendingWaiting) {
       return
     }
@@ -77,6 +76,7 @@ class PlatformInput extends Component<PlatformInputProps, State> {
 
     const text = this._getText()
     if (e.key === 'ArrowUp' && !this.props.isEditing && !text) {
+      e.preventDefault()
       this.props.onEditLastMessage()
     } else if (e.key === 'Escape' && this.props.isEditing) {
       this.props.onCancelEditing()

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -67,6 +67,7 @@ class PlatformInput extends Component<PlatformInputProps, State> {
   }
 
   _onKeyDown = (e: SyntheticKeyboardEvent<>) => {
+    e.preventDefault()
     if (this.props.pendingWaiting) {
       return
     }


### PR DESCRIPTION
@keybase/react-hackers 

Just as @buoyad guessed, the cursor being at the start of the message being edited instead of the end was due to the lack of a preventDefault, causing the up arrow to get processed a second time by the input field.