### PR TITLE
port device_add and kex2_provisioner off of LoginState

### DIFF
--- a/go/engine/device_add.go
+++ b/go/engine/device_add.go
@@ -71,7 +71,7 @@ func (e *DeviceAdd) Run(m libkb.MetaContext) (err error) {
 	// provisioner needs ppstream, and UI is confusing when it asks for
 	// it at the same time as asking for the secret, so get it first
 	// before prompting for the kex2 secret:
-	pps, err := m.G().LoginState().GetPassphraseStreamStored(m, m.UIs().SecretUI)
+	pps, err := libkb.GetPassphraseStreamStored(m)
 	if err != nil {
 		return err
 	}

--- a/go/engine/device_add_test.go
+++ b/go/engine/device_add_test.go
@@ -162,7 +162,7 @@ func TestDeviceAddStoredSecret(t *testing.T) {
 		ProvisionUI: &testXProvisionUI{secret: secretY},
 	}
 	eng := NewDeviceAdd(tcX.G)
-	m := NewMetaContextForTest(tcX).WithUIs(uis).WithNewProvisionalLoginContext()
+	m := NewMetaContextForTest(tcX).WithUIs(uis)
 	if err := RunEngine2(m, eng); err != nil {
 		t.Errorf("device add error: %s", err)
 	}

--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -86,7 +86,7 @@ func (e *Kex2Provisioner) Run(m libkb.MetaContext) error {
 	// get current passphrase stream if necessary:
 	if e.pps.PassphraseStream == nil {
 		m.CDebugf("kex2 provisioner needs passphrase stream, getting it from LoginState")
-		pps, err := m.G().LoginState().GetPassphraseStreamStored(m, m.UIs().SecretUI)
+		pps, err := libkb.GetPassphraseStreamStored(m)
 		if err != nil {
 			return err
 		}

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -185,50 +185,45 @@ func (e *PaperKeyGen) makeEncKey(seed []byte) error {
 	return nil
 }
 
-func (e *PaperKeyGen) getClientHalfFromSecretStore() (libkb.LKSecClientHalf, libkb.PassphraseGeneration, error) {
-	zeroGen := libkb.PassphraseGeneration(0)
-	var dummy libkb.LKSecClientHalf
+func (e *PaperKeyGen) getClientHalfFromSecretStore(m libkb.MetaContext) (clientHalf libkb.LKSecClientHalf, ppgen libkb.PassphraseGeneration, err error) {
+	defer m.CTrace("PaperKeyGen#getClientHalfFromSecretStore", func() error { return err })
 
 	secretStore := libkb.NewSecretStore(e.G(), e.arg.Me.GetNormalizedName())
 	if secretStore == nil {
-		return dummy, zeroGen, errors.New("No secret store available")
+		return clientHalf, ppgen, errors.New("No secret store available")
 	}
 
 	secret, err := secretStore.RetrieveSecret()
 	if err != nil {
-		return dummy, zeroGen, err
+		return clientHalf, ppgen, err
 	}
 
 	devid := e.G().Env.GetDeviceID()
 	if devid.IsNil() {
-		return dummy, zeroGen, fmt.Errorf("no device id set")
+		return clientHalf, ppgen, fmt.Errorf("no device id set")
 	}
-
-	var dev libkb.DeviceKey
-	aerr := e.G().LoginState().Account(func(a *libkb.Account) {
-		if err = libkb.RunSyncer(a.SecretSyncer(), e.arg.Me.GetUID(), a.LoggedIn(), a.LocalSession()); err != nil {
-			return
-		}
-		dev, err = a.SecretSyncer().FindDevice(devid)
-	}, "BackupKeygen.Run() -- retrieving passphrase generation)")
-	if aerr != nil {
-		return dummy, zeroGen, aerr
-	}
+	var ss *libkb.SecretSyncer
+	ss, err = m.ActiveDevice().SyncSecrets(m)
 	if err != nil {
-		return dummy, zeroGen, err
+		return clientHalf, ppgen, err
+	}
+	var dev libkb.DeviceKey
+	dev, err = ss.FindDevice(devid)
+	if err != nil {
+		return clientHalf, ppgen, err
 	}
 	serverHalf, err := libkb.NewLKSecServerHalfFromHex(dev.LksServerHalf)
 	if err != nil {
-		return dummy, zeroGen, err
+		return clientHalf, ppgen, err
 	}
 
-	clientHalf := serverHalf.ComputeClientHalf(secret)
+	clientHalf = serverHalf.ComputeClientHalf(secret)
 
 	return clientHalf, dev.PPGen, nil
 }
 
-func (e *PaperKeyGen) push(m libkb.MetaContext) error {
-	m.CDebugf("PaperKeyGen#push")
+func (e *PaperKeyGen) push(m libkb.MetaContext) (err error) {
+	defer m.CTrace("PaperKeyGen#push", func() error { return err })()
 	if e.arg.SkipPush {
 		return nil
 	}
@@ -248,33 +243,19 @@ func (e *PaperKeyGen) push(m libkb.MetaContext) error {
 	// create lks halves for this device.  Note that they aren't used for
 	// local, encrypted storage of the paper keys, but just for recovery
 	// purposes.
+	m.Dump()
 
-	foundStream := false
 	var ppgen libkb.PassphraseGeneration
 	var clientHalf libkb.LKSecClientHalf
-	if lctx := m.LoginContext(); lctx != nil {
-		stream := lctx.PassphraseStreamCache().PassphraseStream()
-		if stream != nil {
-			foundStream = true
-			ppgen = stream.Generation()
-			clientHalf = stream.LksClientHalf()
-		}
+	if stream := m.PassphraseStream(); stream != nil {
+		m.CDebugf("Got cached passphrase stream")
+		clientHalf = stream.LksClientHalf()
+		ppgen = stream.Generation()
 	} else {
-		m.G().LoginState().Account(func(a *libkb.Account) {
-			stream := a.PassphraseStream()
-			if stream == nil {
-				return
-			}
-			foundStream = true
-			ppgen = stream.Generation()
-			clientHalf = stream.LksClientHalf()
-		}, "BackupKeygen - push")
-	}
-
-	// stream was nil, so we must have loaded lks from the secret
-	// store.
-	if !foundStream {
-		clientHalf, ppgen, err = e.getClientHalfFromSecretStore()
+		m.CDebugf("Got nil passphrase stream; going to secret store")
+		// stream was nil, so we must have loaded lks from the secret
+		// store.
+		clientHalf, ppgen, err = e.getClientHalfFromSecretStore(m)
 		if err != nil {
 			return err
 		}

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -447,7 +447,7 @@ func (a *Account) saveUserConfig(username NormalizedUsername, uid keybase1.UID, 
 	return cw.SetUserConfig(NewUserConfig(uid, username, salt, deviceID), true /* overwrite */)
 }
 
-func (a *Account) Dump() {
+func (a *Account) Dump(m MetaContext, prefix string) {
 	fmt.Printf("Account dump:\n")
 	a.loginSession.Dump()
 	a.streamCache.Dump()

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -22,6 +22,21 @@ type ActiveDevice struct {
 	sync.RWMutex
 }
 
+func (a *ActiveDevice) Dump(m MetaContext, prefix string) {
+	m.CDebugf("%sUID: %s", prefix, a.uid)
+	m.CDebugf("%sUsername (via env): %s", prefix, a.Username(m))
+	m.CDebugf("%sDeviceID: %s", prefix, a.deviceID)
+	m.CDebugf("%sDeviceName: %s", prefix, a.deviceName)
+	if a.signingKey != nil {
+		m.CDebugf("%sSigKey: %s", prefix, a.signingKey.GetKID())
+	}
+	if a.encryptionKey != nil {
+		m.CDebugf("%sEncKey: %s", prefix, a.encryptionKey.GetKID())
+	}
+	m.CDebugf("%sPassphraseCache: %v", prefix, (a.passphrase != nil && a.passphrase.ValidPassphraseStream()))
+	m.CDebugf("%sPaperKeyCache: %v", prefix, (a.paperKey != nil && a.paperKey.DeviceWithKeys() != nil))
+}
+
 // NewProvisionalActiveDevice creates an ActiveDevice that is "provisional", in that it
 // should not be considered the global ActiveDevice. Instead, it should reside in thread-local
 // context, and can be weaved through the login machinery without trampling the actual global

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -491,13 +491,13 @@ func (m MetaContext) LogoutIfRevoked() (err error) {
 }
 
 func (m MetaContext) PassphraseStream() *PassphraseStream {
-	if m.LoginContext() == nil {
-		return nil
+	if m.LoginContext() != nil {
+		if m.LoginContext().PassphraseStreamCache() == nil {
+			return nil
+		}
+		return m.LoginContext().PassphraseStreamCache().PassphraseStream()
 	}
-	if m.LoginContext().PassphraseStreamCache() == nil {
-		return nil
-	}
-	return m.LoginContext().PassphraseStreamCache().PassphraseStream()
+	return m.ActiveDevice().PassphraseStream()
 }
 
 func (m MetaContext) CurrentUsername() NormalizedUsername {

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -15,6 +15,20 @@ type MetaContext struct {
 	uis          UIs
 }
 
+func (m MetaContext) Dump() {
+	m.CDebugf("MetaContext#Dump:")
+	if m.activeDevice != nil {
+		m.CDebugf("- Local ActiveDevice:")
+		m.activeDevice.Dump(m, "-- ")
+	}
+	m.CDebugf("- Global ActiveDevice:")
+	m.g.ActiveDevice.Dump(m, "-- ")
+	if m.loginContext != nil {
+		m.CDebugf("- Login Context:")
+		m.loginContext.Dump(m, "-- ")
+	}
+}
+
 func NewMetaContext(ctx context.Context, g *GlobalContext) MetaContext {
 	return MetaContext{ctx: ctx, g: g}
 }

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -67,6 +67,8 @@ type LoginContext interface {
 	RunSecretSyncer(uid keybase1.UID) error
 
 	SetCachedSecretKey(ska SecretKeyArg, key GenericKey, device *Device) error
+
+	Dump(m MetaContext, prefix string)
 }
 
 type LoggedInHelper interface {
@@ -314,65 +316,6 @@ func (s *LoginState) GetPassphraseStreamWithPassphrase(m MetaContext, passphrase
 	}
 	err = InternalError{"No cached keystream data after login attempt"}
 	return nil, err
-}
-
-func (s *LoginState) getStoredPassphraseStream(m MetaContext, username NormalizedUsername) (*PassphraseStream, error) {
-	fullSecret, err := m.G().SecretStore().RetrieveSecret(m.G().Env.GetUsername())
-	if err != nil {
-		return nil, err
-	}
-	lks := NewLKSecWithFullSecret(fullSecret, m.G().Env.GetUID(), s.G())
-	if err = lks.LoadServerHalf(m); err != nil {
-		return nil, err
-	}
-	stream, err := NewPassphraseStreamLKSecOnly(lks)
-	if err != nil {
-		return nil, err
-	}
-	return stream, nil
-}
-
-// GetPassphraseStreamStored either returns a cached, verified passphrase
-// stream from a previous login, the secret store, or generates a new one via
-// login.
-func (s *LoginState) GetPassphraseStreamStored(m MetaContext, ui SecretUI) (pps *PassphraseStream, err error) {
-	m.G().Log.CDebugf(m.Ctx(), "+ GetPassphraseStreamStored() called")
-	defer func() { m.G().Log.CDebugf(m.Ctx(), "- GetPassphraseStreamStored() -> %s", ErrToOk(err)) }()
-
-	// 1. try cached
-	m.G().Log.CDebugf(m.Ctx(), "| trying cached passphrase stream")
-	full, err := s.PassphraseStream()
-	if err != nil {
-		return pps, err
-	}
-	if full != nil {
-		m.G().Log.CDebugf(m.Ctx(), "| cached passphrase stream ok, using it")
-		return full, nil
-	}
-
-	// 2. try from secret store
-	if m.G().SecretStore() != nil {
-		m.G().Log.CDebugf(m.Ctx(), "| trying to get passphrase stream from secret store")
-		pps, err = s.getStoredPassphraseStream(m, s.G().Env.GetUsername())
-		if err == nil {
-			m.G().Log.CDebugf(m.Ctx(), "| got passphrase stream from secret store")
-			return pps, nil
-		}
-
-		m.G().Log.CDebugf(m.Ctx(), "| failed to get passphrase stream from secret store: %s", err)
-	}
-
-	// 3. login and get it
-	m.G().Log.CDebugf(m.Ctx(), "| using full GetPassphraseStream")
-	full, err = s.GetPassphraseStream(m, ui)
-	if err != nil {
-		return pps, err
-	}
-	if full != nil {
-		m.G().Log.CDebugf(m.Ctx(), "| success using full GetPassphraseStream")
-		return full, nil
-	}
-	return pps, nil
 }
 
 // GetVerifiedTripleSec either returns a cached, verified Triplesec
@@ -1264,7 +1207,7 @@ func (s *LoginState) PassphraseStreamGeneration() (PassphraseGeneration, error) 
 
 func (s *LoginState) AccountDump() {
 	err := s.Account(func(a *Account) {
-		a.Dump()
+		a.Dump(NewMetaContextBackground(s.G()), "")
 	}, "LoginState - AccountDump")
 	if err != nil {
 		s.G().Log.Warning("error getting account for AccountDump: %s", err)

--- a/go/libkb/provisional_login_context.go
+++ b/go/libkb/provisional_login_context.go
@@ -1,6 +1,7 @@
 package libkb
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -27,6 +28,17 @@ func newProvisionalLoginContext(m MetaContext) *ProvisionalLoginContext {
 		localSession:     newSession(m.G()),
 		secretSyncer:     NewSecretSyncer(m.G()),
 	}
+}
+
+func (p *ProvisionalLoginContext) Dump(m MetaContext, prefix string) {
+	m.CDebugf("%sUsername: %s", prefix, p.username)
+	m.CDebugf("%sUID: %s", prefix, p.uid)
+	if p.salt != nil {
+		m.CDebugf("%sSalt: %s", prefix, hex.EncodeToString(p.salt))
+	}
+	m.CDebugf("%sPassphraseCache: %v", prefix, (p.streamCache != nil))
+	m.CDebugf("%sLocalSession: %v", prefix, (p.localSession != nil))
+	m.CDebugf("%sLoginSession: %v", prefix, (p.loginSession != nil))
 }
 
 func plcErr(s string) error {
@@ -70,6 +82,9 @@ func (p *ProvisionalLoginContext) SetStreamGeneration(gen PassphraseGeneration, 
 	}
 }
 func (p *ProvisionalLoginContext) PassphraseStream() *PassphraseStream {
+	if p.PassphraseStreamCache() == nil {
+		return nil
+	}
 	return p.PassphraseStreamCache().PassphraseStream()
 }
 func (p *ProvisionalLoginContext) GetStreamGeneration() (ret PassphraseGeneration) {


### PR DESCRIPTION
- move GetPassphraseStreamStored out of LoginState
- introduce a new MetaContext#Dump feature, which is quite nice for debugging
- finish up device engines, like DeviceHistory and DeviceList