### PR TITLE
Get ephemeralMetadata for EDIT and ATTACHMENTUPLOADED msgs

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -217,7 +217,7 @@ func (h *Helper) UpgradeKBFSToImpteam(ctx context.Context, tlfName string, tlfID
 
 func (h *Helper) GetMessages(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
 	msgIDs []chat1.MessageID, resolveSupersedes bool) ([]chat1.MessageUnboxed, error) {
-	conv, err := GetUnverifiedConv(ctx, h.G(), uid, convID, true)
+	conv, err := GetUnverifiedConv(ctx, h.G(), uid, convID, true /* useLocalData */)
 	if err != nil {
 		return nil, err
 	}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2024,14 +2024,14 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			consumeNewMsg(t, listener, chat1.MessageType_TEXT)
 
 			t.Logf("edit the message")
+			// An ephemeralLifetime is added if we are editing an ephemeral message
 			earg := chat1.PostEditNonblockArg{
-				ConversationID:    created.Id,
-				TlfName:           created.TlfName,
-				TlfPublic:         created.Visibility == keybase1.TLFVisibility_PUBLIC,
-				Supersedes:        unboxed.GetMessageID(),
-				Body:              "hi2",
-				IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
-				EphemeralLifetime: ephemeralLifetime,
+				ConversationID:   created.Id,
+				TlfName:          created.TlfName,
+				TlfPublic:        created.Visibility == keybase1.TLFVisibility_PUBLIC,
+				Supersedes:       unboxed.GetMessageID(),
+				Body:             "hi2",
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 			}
 			res, err = ctc.as(t, users[0]).chatLocalHandler().PostEditNonblock(tc.startCtx, earg)
 			require.NoError(t, err)

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -143,7 +143,7 @@ func (l ephemeralLifetime) Valid() bool {
 	if d == 0 {
 		return true // nil val
 	}
-	return d <= maxEphemeralLifetime && d >= minEphemeralLifetime
+	return d <= libkb.MaxEphemeralLifetime && d >= libkb.MinEphemeralLifetime
 }
 
 type sendOptionsV1 struct {
@@ -182,11 +182,10 @@ func (r readOptionsV1) Check() error {
 }
 
 type editOptionsV1 struct {
-	Channel           ChatChannel
-	ConversationID    string          `json:"conversation_id"`
-	MessageID         chat1.MessageID `json:"message_id"`
-	Message           ChatMessage
-	EphemeralLifetime ephemeralLifetime `json:"exploding_lifetime"`
+	Channel        ChatChannel
+	ConversationID string          `json:"conversation_id"`
+	MessageID      chat1.MessageID `json:"message_id"`
+	Message        ChatMessage
 }
 
 func (e editOptionsV1) Check() error {
@@ -200,9 +199,6 @@ func (e editOptionsV1) Check() error {
 
 	if !e.Message.Valid() {
 		return ErrInvalidOptions{version: 1, method: methodEdit, err: errors.New("invalid message")}
-	}
-	if !e.EphemeralLifetime.Valid() {
-		return ErrInvalidOptions{version: 1, method: methodEdit, err: errors.New("invalid ephemeral lifetime")}
 	}
 
 	return nil

--- a/go/client/chat_api_test.go
+++ b/go/client/chat_api_test.go
@@ -334,13 +334,6 @@ var optTests = []optTest{
 		input: `{"id": 30, "method": "edit", "params":{"version": 1, "options": {"conversation_id": "333", "message_id": 123, "message": {"body": "edited"}}}}`,
 	},
 	{
-		input: `{"id": 30, "method": "edit", "params":{"version": 1, "options": {"conversation_id": "333", "message_id": 123, "message": {"body": "edited"}, "exploding_lifetime": "5m"}}}`,
-	},
-	{
-		input: `{"id": 30, "method": "edit", "params":{"version": 1, "options": {"conversation_id": "333", "message_id": 123, "message": {"body": "edited"}, "exploding_lifetime": "1s"}}}`,
-		err:   ErrInvalidOptions{},
-	},
-	{
 		input: `{"id": 30, "method": "delete", "params":{"version": 1, "options": {}}}`,
 		err:   ErrInvalidOptions{},
 	},

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -542,7 +542,7 @@ func newMessageViewValid(g *libkb.GlobalContext, conversationID chat1.Conversati
 		m.SenderUsername, possiblyRevokedMark, m.SenderDeviceName, shortDurationFromNow(t))
 
 	if m.IsEphemeral() {
-		remainingLifetime := m.RemainingLifetime()
+		remainingLifetime := m.RemainingLifetime(time.Now())
 		if remainingLifetime <= 0 {
 			mv.Body = "[exploded]"
 			for i := 0; i < 40; i++ {

--- a/go/client/chat_send_common.go
+++ b/go/client/chat_send_common.go
@@ -96,7 +96,7 @@ func chatSend(ctx context.Context, g *libkb.GlobalContext, c ChatSendArg) error 
 			confirmed = true
 		}
 		if c.ephemeralLifetime != 0 {
-			lifetime := gregor1.DurationSec(c.ephemeralLifetime / time.Second)
+			lifetime := gregor1.ToDurationSec(c.ephemeralLifetime)
 			msg.ClientHeader.EphemeralMetadata = &chat1.MsgEphemeralMetadata{Lifetime: lifetime}
 		}
 

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -300,13 +300,12 @@ func (c *chatServiceHandler) EditV1(ctx context.Context, opts editOptionsV1) Rep
 		return c.errReply(fmt.Errorf("invalid conv ID: %s", opts.ConversationID))
 	}
 	arg := sendArgV1{
-		conversationID:    convID,
-		channel:           opts.Channel,
-		body:              chat1.NewMessageBodyWithEdit(chat1.MessageEdit{MessageID: opts.MessageID, Body: opts.Message.Body}),
-		mtype:             chat1.MessageType_EDIT,
-		supersedes:        opts.MessageID,
-		response:          "message edited",
-		ephemeralLifetime: opts.EphemeralLifetime,
+		conversationID: convID,
+		channel:        opts.Channel,
+		body:           chat1.NewMessageBodyWithEdit(chat1.MessageEdit{MessageID: opts.MessageID, Body: opts.Message.Body}),
+		mtype:          chat1.MessageType_EDIT,
+		supersedes:     opts.MessageID,
+		response:       "message edited",
 	}
 	return c.sendV1(ctx, arg)
 }
@@ -831,7 +830,7 @@ func (c *chatServiceHandler) makePostHeader(ctx context.Context, arg sendArgV1, 
 	}
 	var ephemeralMetadata *chat1.MsgEphemeralMetadata
 	if arg.ephemeralLifetime.Duration != 0 && membersType != chat1.ConversationMembersType_KBFS {
-		ephemeralLifetime := gregor1.DurationSec(time.Duration(arg.ephemeralLifetime.Duration) / time.Second)
+		ephemeralLifetime := gregor1.ToDurationSec(time.Duration(arg.ephemeralLifetime.Duration))
 		ephemeralMetadata = &chat1.MsgEphemeralMetadata{Lifetime: ephemeralLifetime}
 	}
 

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -23,11 +23,6 @@ import (
 	isatty "github.com/mattn/go-isatty"
 )
 
-// NOTE if you change these values you should change them in
-// go/chatbase/storage/ephemeral.go as well.
-const maxEphemeralLifetime = time.Hour * 24 * 7
-const minEphemeralLifetime = time.Second * 30
-
 type CmdChatSend struct {
 	libkb.Contextified
 	resolvingRequest chatConversationResolvingRequest
@@ -72,7 +67,7 @@ func newCmdChatSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 			Name: "exploding-lifetime",
 			Usage: fmt.Sprintf(`Make this message an exploding message and set the lifetime for the given duration.
 	The maximum lifetime is %v (one week) and the minimum lifetime is %v.`,
-				maxEphemeralLifetime, minEphemeralLifetime),
+				libkb.MaxEphemeralLifetime, libkb.MinEphemeralLifetime),
 		})
 	}
 	return cli.Command{
@@ -164,11 +159,11 @@ func (c *CmdChatSend) ParseArgv(ctx *cli.Context) (err error) {
 	}
 
 	if c.ephemeralLifetime != 0 {
-		if c.ephemeralLifetime > maxEphemeralLifetime {
-			return fmt.Errorf("ephemeral lifetime cannot exceed %v", maxEphemeralLifetime)
+		if c.ephemeralLifetime > libkb.MaxEphemeralLifetime {
+			return fmt.Errorf("ephemeral lifetime cannot exceed %v", libkb.MaxEphemeralLifetime)
 		}
-		if c.ephemeralLifetime < minEphemeralLifetime {
-			return fmt.Errorf("ephemeral lifetime must be at least %v", minEphemeralLifetime)
+		if c.ephemeralLifetime < libkb.MinEphemeralLifetime {
+			return fmt.Errorf("ephemeral lifetime must be at least %v", libkb.MinEphemeralLifetime)
 		}
 	}
 

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -673,3 +673,8 @@ const CurrentGitMetadataEncryptionVersion = 1
 // The secret_store_file and erasable_kv_store use a random noise file of this
 // size when encrypting secrets for disk.
 const noiseFileLen = 1024 * 1024 * 2
+
+// NOTE if you change these values you should change them in
+// go/chatbase/storage/ephemeral.go as well.
+const MaxEphemeralLifetime = time.Hour * 24 * 7
+const MinEphemeralLifetime = time.Second * 30

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -391,8 +391,8 @@ func (m MessageUnboxedValid) Etime() gregor1.Time {
 	return Etime(metadata.Lifetime, header.Ctime, m.ClientHeader.Rtime, header.Now)
 }
 
-func (m MessageUnboxedValid) RemainingLifetime() time.Duration {
-	remainingLifetime := m.Etime().Time().Sub(time.Now()).Round(time.Second)
+func (m MessageUnboxedValid) RemainingLifetime(now time.Time) time.Duration {
+	remainingLifetime := m.Etime().Time().Sub(now).Round(time.Second)
 	return remainingLifetime
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3965,15 +3965,14 @@ type PostDeleteNonblockArg struct {
 }
 
 type PostEditNonblockArg struct {
-	ConversationID    ConversationID               `codec:"conversationID" json:"conversationID"`
-	TlfName           string                       `codec:"tlfName" json:"tlfName"`
-	TlfPublic         bool                         `codec:"tlfPublic" json:"tlfPublic"`
-	Supersedes        MessageID                    `codec:"supersedes" json:"supersedes"`
-	Body              string                       `codec:"body" json:"body"`
-	OutboxID          *OutboxID                    `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
-	ClientPrev        MessageID                    `codec:"clientPrev" json:"clientPrev"`
-	IdentifyBehavior  keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
-	EphemeralLifetime *gregor1.DurationSec         `codec:"ephemeralLifetime,omitempty" json:"ephemeralLifetime,omitempty"`
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
+	Supersedes       MessageID                    `codec:"supersedes" json:"supersedes"`
+	Body             string                       `codec:"body" json:"body"`
+	OutboxID         *OutboxID                    `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	ClientPrev       MessageID                    `codec:"clientPrev" json:"clientPrev"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type PostHeadlineNonblockArg struct {

--- a/go/protocol/gregor1/extras.go
+++ b/go/protocol/gregor1/extras.go
@@ -418,6 +418,14 @@ func FormatTime(t Time) string {
 	return FromTime(t).Format(layout)
 }
 
+func ToDurationMsec(d time.Duration) DurationMsec {
+	return DurationMsec(d / time.Millisecond)
+}
+
+func ToDurationSec(d time.Duration) DurationSec {
+	return DurationSec(d / time.Second)
+}
+
 // DeviceID returns the deviceID in a SyncArc, or interface nil
 // (and not gregor1.DeviceID(nil)) if not was specified.
 func (s SyncArg) DeviceID() gregor.DeviceID {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -628,9 +628,9 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  PostLocalNonblockRes postTextNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, string body, MessageID clientPrev, union { null, OutboxID } outboxID,  keybase1.TLFIdentifyBehavior identifyBehavior, union {null, gregor1.DurationSec} ephemeralLifetime);
+  PostLocalNonblockRes postTextNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, string body, MessageID clientPrev, union { null, OutboxID } outboxID, keybase1.TLFIdentifyBehavior identifyBehavior, union {null, gregor1.DurationSec} ephemeralLifetime);
   PostLocalNonblockRes postDeleteNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, MessageID supersedes,MessageID clientPrev, union { null, OutboxID } outboxID,  keybase1.TLFIdentifyBehavior identifyBehavior);
-  PostLocalNonblockRes postEditNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, MessageID supersedes, string body, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior, union {null, gregor1.DurationSec} ephemeralLifetime);
+  PostLocalNonblockRes postEditNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, MessageID supersedes, string body, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalNonblockRes postHeadlineNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic,  string headline, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalRes postHeadline(ConversationID conversationID, string tlfName, boolean tlfPublic, string headline, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalNonblockRes postMetadataNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic,  string channelName, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
@@ -732,7 +732,8 @@ protocol local {
     bytes metadata,
     keybase1.TLFIdentifyBehavior identifyBehavior,
     union { null, OutboxID } outboxID,
-    union {null, gregor1.DurationSec} ephemeralLifetime);
+    union {null, gregor1.DurationSec} ephemeralLifetime
+    );
 
   // LocalFileSource is a file attachment source.  Filename must be readable
   // by the service for the duration of the attachment upload.
@@ -750,7 +751,8 @@ protocol local {
     bytes metadata,
     keybase1.TLFIdentifyBehavior identifyBehavior,
     union { null, OutboxID } outboxID,
-    union {null, gregor1.DurationSec} ephemeralLifetime);
+    union {null, gregor1.DurationSec} ephemeralLifetime
+    );
 
   record DownloadAttachmentLocalRes {
     boolean offline;

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -948,7 +948,7 @@ export type LocalPostDeleteHistoryUptoRpcParam = $ReadOnly<{conversationID: Conv
 
 export type LocalPostDeleteNonblockRpcParam = $ReadOnly<{conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, clientPrev: MessageID, outboxID?: ?OutboxID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type LocalPostEditNonblockRpcParam = $ReadOnly<{conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, body: String, outboxID?: ?OutboxID, clientPrev: MessageID, identifyBehavior: Keybase1.TLFIdentifyBehavior, ephemeralLifetime?: ?Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type LocalPostEditNonblockRpcParam = $ReadOnly<{conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, body: String, outboxID?: ?OutboxID, clientPrev: MessageID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalPostFileAttachmentLocalRpcParam = $ReadOnly<{conversationID: ConversationID, tlfName: String, visibility: Keybase1.TLFVisibility, attachment: LocalFileSource, preview?: ?MakePreviewRes, title: String, metadata: Bytes, identifyBehavior: Keybase1.TLFIdentifyBehavior, outboxID?: ?OutboxID, ephemeralLifetime?: ?Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2671,13 +2671,6 @@
         {
           "name": "identifyBehavior",
           "type": "keybase1.TLFIdentifyBehavior"
-        },
-        {
-          "name": "ephemeralLifetime",
-          "type": [
-            null,
-            "gregor1.DurationSec"
-          ]
         }
       ],
       "response": "PostLocalNonblockRes"

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -948,7 +948,7 @@ export type LocalPostDeleteHistoryUptoRpcParam = $ReadOnly<{conversationID: Conv
 
 export type LocalPostDeleteNonblockRpcParam = $ReadOnly<{conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, clientPrev: MessageID, outboxID?: ?OutboxID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type LocalPostEditNonblockRpcParam = $ReadOnly<{conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, body: String, outboxID?: ?OutboxID, clientPrev: MessageID, identifyBehavior: Keybase1.TLFIdentifyBehavior, ephemeralLifetime?: ?Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type LocalPostEditNonblockRpcParam = $ReadOnly<{conversationID: ConversationID, tlfName: String, tlfPublic: Boolean, supersedes: MessageID, body: String, outboxID?: ?OutboxID, clientPrev: MessageID, identifyBehavior: Keybase1.TLFIdentifyBehavior, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type LocalPostFileAttachmentLocalRpcParam = $ReadOnly<{conversationID: ConversationID, tlfName: String, visibility: Keybase1.TLFVisibility, attachment: LocalFileSource, preview?: ?MakePreviewRes, title: String, metadata: Bytes, identifyBehavior: Keybase1.TLFIdentifyBehavior, outboxID?: ?OutboxID, ephemeralLifetime?: ?Gregor1.DurationSec, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 


### PR DESCRIPTION
The service now handles creating `MsgEphemeralMetadata` for messages that supersede and ephemeral one. So if you edit an ephemeral message the edit is also made ephemeral with whatever the remaining lifetime is 

cc @buoyad  @oconnor663 