### PR TITLE
Prioritize EK checking in hourly loop, reduce bgtimer wait

### DIFF
--- a/go/libkb/bgticker.go
+++ b/go/libkb/bgticker.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+const defaultWait = 5 * time.Second
+
 type BgTicker struct {
 	C          <-chan time.Time
 	c          chan time.Time
@@ -18,7 +20,7 @@ type BgTicker struct {
 // NewBgTicker will panic if wait > duration as time.Ticker does with a
 // negative duration.
 func NewBgTicker(duration time.Duration) *BgTicker {
-	return NewBgTickerWithWait(duration, 10*time.Second)
+	return NewBgTickerWithWait(duration, defaultWait)
 }
 
 func NewBgTickerWithWait(duration time.Duration, wait time.Duration) *BgTicker {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -604,17 +604,19 @@ func (d *Service) hourlyChecks() {
 		ekLib.KeygenIfNeeded(m.Ctx())
 		for {
 			<-ticker.C
-			m.CDebugf("+ hourly check loop")
-			m.CDebugf("| checking tracks on an hour timer")
-			libkb.CheckTracking(m.G())
-
-			ekLib := m.G().GetEKLib()
-			m.CDebugf("| checking if ephemeral keys need to be created or deleted")
-			ekLib.KeygenIfNeeded(m.Ctx())
 			m.CDebugf("| checking if current device revoked")
 			if err := m.LogoutIfRevoked(); err != nil {
 				m.CDebugf("LogoutIfRevoked error: %s", err)
 			}
+
+			ekLib := m.G().GetEKLib()
+			m.CDebugf("| checking if ephemeral keys need to be created or deleted")
+			ekLib.KeygenIfNeeded(m.Ctx())
+
+			m.CDebugf("+ hourly check loop")
+			m.CDebugf("| checking tracks on an hour timer")
+			libkb.CheckTracking(m.G())
+
 			m.CDebugf("- hourly check loop")
 		}
 	}()


### PR DESCRIPTION
The hourly check on ios either isn't running during the `BackgroundSync` or the sync was getting cut off before it got to ek generation steps. decreasing the `bgTimer` wait and moving the ek gen step above tracking should help. we could also give the `BackgroundSync` a few more seconds before we kill it, but i'd rather try this first for battery performance reason. thoughts?

cc @oconnor663 