### PR TITLE
run the refactor show using context instead of explicitly tracking it CORE-7652

### DIFF
--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -437,7 +437,7 @@ func (b *BackgroundConvLoader) load(ictx context.Context, task clTask, uid grego
 	if pagination == nil {
 		pagination = &chat1.Pagination{Num: 50}
 	}
-	tv, _, err := b.G().ConvSource.Pull(ctx, job.ConvID, uid, query, pagination)
+	tv, err := b.G().ConvSource.Pull(ctx, job.ConvID, uid, query, pagination)
 	if err != nil {
 		b.Debug(ctx, "load: ConvSource.Pull error: %s (%T)", err, err)
 		if b.retriableError(err) && task.attempt+1 < bgLoaderMaxAttempts {

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -58,7 +58,7 @@ func (h *Helper) SendMsgByID(ctx context.Context, convID chat1.ConversationID,
 		},
 		MessageBody: body,
 	}
-	_, _, _, err := sender.Send(ctx, convID, msg, 0, nil)
+	_, _, err := sender.Send(ctx, convID, msg, 0, nil)
 	return err
 }
 
@@ -82,7 +82,7 @@ func (h *Helper) SendMsgByIDNonblock(ctx context.Context, convID chat1.Conversat
 		},
 		MessageBody: body,
 	}
-	_, _, _, err := sender.Send(ctx, convID, msg, 0, nil)
+	_, _, err := sender.Send(ctx, convID, msg, 0, nil)
 	return err
 }
 
@@ -134,7 +134,8 @@ func (h *Helper) FindConversations(ctx context.Context, name string, topicName *
 	if topicName != nil {
 		tname = *topicName
 	}
-	convs, _, err := FindConversations(ctx, h.G(), h.DebugLabeler, h.ri, uid, name, topicType, membersType, vis, tname, &oneChat)
+	convs, err := FindConversations(ctx, h.G(), h.DebugLabeler, h.ri, uid, name, topicType, membersType, vis,
+		tname, &oneChat)
 	return convs, err
 }
 
@@ -147,7 +148,7 @@ func (h *Helper) FindConversationsByID(ctx context.Context, convIDs []chat1.Conv
 	query := &chat1.GetInboxLocalQuery{
 		ConvIDs: convIDs,
 	}
-	inbox, _, err := h.G().InboxSource.Read(ctx, uid, nil, true, query, nil)
+	inbox, err := h.G().InboxSource.Read(ctx, uid, nil, true, query, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +175,7 @@ func (h *Helper) GetChannelTopicName(ctx context.Context, teamID keybase1.TeamID
 		ConvIDs:   []chat1.ConversationID{convID},
 		TopicType: &topicType,
 	}
-	inbox, _, err := h.G().InboxSource.Read(ctx, uid, nil, true, query, nil)
+	inbox, err := h.G().InboxSource.Read(ctx, uid, nil, true, query, nil)
 	if err != nil {
 		return topicName, err
 	}
@@ -187,7 +188,7 @@ func (h *Helper) GetChannelTopicName(ctx context.Context, teamID keybase1.TeamID
 
 	// Fallback to TeamChannelSource
 	h.Debug(ctx, "using TeamChannelSource")
-	topicName, _, err = h.G().TeamChannelSource.GetChannelTopicName(ctx, uid, tlfID, topicType, convID)
+	topicName, err = h.G().TeamChannelSource.GetChannelTopicName(ctx, uid, tlfID, topicType, convID)
 	return topicName, err
 }
 
@@ -216,7 +217,7 @@ func (h *Helper) UpgradeKBFSToImpteam(ctx context.Context, tlfName string, tlfID
 
 func (h *Helper) GetMessages(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
 	msgIDs []chat1.MessageID, resolveSupersedes bool) ([]chat1.MessageUnboxed, error) {
-	conv, _, err := GetUnverifiedConv(ctx, h.G(), uid, convID, true)
+	conv, err := GetUnverifiedConv(ctx, h.G(), uid, convID, true)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +294,7 @@ func (h *Helper) formatPushText(ctx context.Context, uid gregor1.UID, convID cha
 	switch membersType {
 	case chat1.ConversationMembersType_TEAM:
 		// Try to get the channel name
-		ib, _, err := h.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
+		ib, err := h.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
 			ConvIDs: []chat1.ConversationID{convID},
 		}, nil)
 		if err != nil || len(ib.Convs) == 0 {
@@ -437,7 +438,7 @@ func (s *sendHelper) conversation(ctx context.Context) error {
 		return err
 	}
 	uid := gregor1.UID(kuid.ToBytes())
-	conv, _, err := NewConversation(ctx, s.G(), uid, s.canonicalName, s.topicName,
+	conv, err := NewConversation(ctx, s.G(), uid, s.canonicalName, s.topicName,
 		chat1.TopicType_CHAT, s.membersType, keybase1.TLFVisibility_PRIVATE, s.remoteInterface)
 	if err != nil {
 		return err
@@ -500,7 +501,7 @@ func (s *sendHelper) deliver(ctx context.Context, body chat1.MessageBody, mtype 
 		},
 		MessageBody: body,
 	}
-	_, _, _, err := s.sender.Send(ctx, s.convID, msg, 0, nil)
+	_, _, err := s.sender.Send(ctx, s.convID, msg, 0, nil)
 	return err
 }
 
@@ -579,22 +580,22 @@ func RecentConversationParticipants(ctx context.Context, g *globals.Context, myU
 var errGetUnverifiedConvNotFound = errors.New("GetUnverifiedConv: conversation not found")
 
 func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
-	convID chat1.ConversationID, useLocalData bool) (chat1.Conversation, *chat1.RateLimit, error) {
+	convID chat1.ConversationID, useLocalData bool) (chat1.Conversation, error) {
 
-	inbox, ratelim, err := g.InboxSource.ReadUnverified(ctx, uid, useLocalData, &chat1.GetInboxQuery{
+	inbox, err := g.InboxSource.ReadUnverified(ctx, uid, useLocalData, &chat1.GetInboxQuery{
 		ConvIDs: []chat1.ConversationID{convID},
 	}, nil)
 	if err != nil {
-		return chat1.Conversation{}, ratelim, fmt.Errorf("GetUnverifiedConv: %s", err.Error())
+		return chat1.Conversation{}, fmt.Errorf("GetUnverifiedConv: %s", err.Error())
 	}
 	if len(inbox.ConvsUnverified) == 0 {
-		return chat1.Conversation{}, ratelim, errGetUnverifiedConvNotFound
+		return chat1.Conversation{}, errGetUnverifiedConvNotFound
 	}
 	if !inbox.ConvsUnverified[0].GetConvID().Eq(convID) {
-		return chat1.Conversation{}, ratelim, fmt.Errorf("GetUnverifiedConv: convID mismatch: %s != %s",
+		return chat1.Conversation{}, fmt.Errorf("GetUnverifiedConv: convID mismatch: %s != %s",
 			inbox.ConvsUnverified[0].GetConvID(), convID)
 	}
-	return inbox.ConvsUnverified[0].Conv, ratelim, nil
+	return inbox.ConvsUnverified[0].Conv, nil
 }
 
 func GetTopicNameState(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
@@ -633,9 +634,9 @@ func GetTopicNameState(ctx context.Context, g *globals.Context, debugger utils.D
 func FindConversations(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
 	ri func() chat1.RemoteInterface, uid gregor1.UID, tlfName string, topicType chat1.TopicType,
 	membersTypeIn chat1.ConversationMembersType, vis keybase1.TLFVisibility, topicName string,
-	oneChatPerTLF *bool) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
+	oneChatPerTLF *bool) (res []chat1.ConversationLocal, err error) {
 
-	findConvosWithMembersType := func(membersType chat1.ConversationMembersType) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
+	findConvosWithMembersType := func(membersType chat1.ConversationMembersType) (res []chat1.ConversationLocal, err error) {
 
 		query := &chat1.GetInboxLocalQuery{
 			Name: &chat1.NameQuery{
@@ -648,12 +649,9 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 			OneChatTypePerTLF: oneChatPerTLF,
 		}
 
-		inbox, irl, err := g.InboxSource.Read(ctx, uid, nil, true, query, nil)
+		inbox, err := g.InboxSource.Read(ctx, uid, nil, true, query, nil)
 		if err != nil {
-			return res, rl, err
-		}
-		if irl != nil {
-			rl = append(rl, *irl)
+			return res, err
 		}
 
 		// If we have inbox hits, return those
@@ -671,14 +669,13 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 			nameInfo, err := CtxKeyFinder(ctx, g).Find(ctx, tlfName, membersType, false)
 			if err != nil {
 				debugger.Debug(ctx, "FindConversations: failed to get TLFID from name: %s", err.Error())
-				return res, rl, err
+				return res, err
 			}
-			tlfConvs, irl, err := g.TeamChannelSource.GetChannelsFull(ctx, uid, nameInfo.ID, topicType)
+			tlfConvs, err := g.TeamChannelSource.GetChannelsFull(ctx, uid, nameInfo.ID, topicType)
 			if err != nil {
 				debugger.Debug(ctx, "FindConversations: failed to list TLF conversations: %s", err.Error())
-				return res, rl, err
+				return res, err
 			}
-			rl = append(rl, irl...)
 
 			for _, tlfConv := range tlfConvs {
 				if utils.GetTopicName(tlfConv) == topicName {
@@ -693,14 +690,14 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 
 			// Check for offline and return an error
 			if g.InboxSource.IsOffline(ctx) {
-				return res, rl, OfflineError{}
+				return res, OfflineError{}
 			}
 
 			// If we miss the inbox, and we are looking for a public TLF, let's try and find
 			// any conversation that matches
 			nameInfo, err := GetInboxQueryNameInfo(ctx, g, query)
 			if err != nil {
-				return res, rl, err
+				return res, err
 			}
 
 			// Call into gregor to try and find some public convs
@@ -710,10 +707,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 				SummarizeMaxMsgs: true,
 			})
 			if err != nil {
-				return res, rl, err
-			}
-			if pubConvs.RateLimit != nil {
-				rl = append(rl, *pubConvs.RateLimit)
+				return res, err
 			}
 
 			// Localize the convs (if any)
@@ -723,7 +717,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 					ConvsUnverified: utils.RemoteConvs(pubConvs.Conversations),
 				})
 				if err != nil {
-					return res, rl, err
+					return res, err
 				}
 
 				// Search for conversations that match the topic name
@@ -742,18 +736,16 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 			}
 
 		}
-		return res, rl, nil
+		return res, nil
 	}
 
-	var irl []chat1.RateLimit
 	attempts := make(map[chat1.ConversationMembersType]bool)
 	mt := membersTypeIn
 L:
 	for {
 		var ierr error
 		attempts[mt] = true
-		res, irl, ierr = findConvosWithMembersType(mt)
-		rl = append(rl, irl...)
+		res, ierr = findConvosWithMembersType(mt)
 		if ierr != nil || len(res) == 0 {
 			if ierr != nil {
 				debugger.Debug(ctx, "FindConversations: fail reason: %s mt: %v", ierr, mt)
@@ -799,35 +791,33 @@ L:
 			break L
 		}
 	}
-	return res, utils.AggRateLimits(rl), err
+	return res, err
 }
 
 // Post a join or leave message. Must be called when the user is in the conv.
 // Uses a blocking sender.
 func postJoinLeave(ctx context.Context, g *globals.Context, ri func() chat1.RemoteInterface, uid gregor1.UID,
-	convID chat1.ConversationID, body chat1.MessageBody) (rl []chat1.RateLimit, err error) {
+	convID chat1.ConversationID, body chat1.MessageBody) (err error) {
 	typ, err := body.MessageType()
 	if err != nil {
-		return nil, fmt.Errorf("message type for postJoinLeave: %v", err)
+		return fmt.Errorf("message type for postJoinLeave: %v", err)
 	}
 	switch typ {
 	case chat1.MessageType_JOIN, chat1.MessageType_LEAVE:
 	// good
 	default:
-		return nil, fmt.Errorf("invalid message type for postJoinLeave: %v", typ)
+		return fmt.Errorf("invalid message type for postJoinLeave: %v", typ)
 	}
 
 	// Get the conversation from the inbox.
 	query := chat1.GetInboxLocalQuery{
 		ConvIDs: []chat1.ConversationID{convID},
 	}
-	ib, irl, err := g.InboxSource.Read(ctx, uid, nil, true, &query, nil)
+	ib, err := g.InboxSource.Read(ctx, uid, nil, true, &query, nil)
 	if len(ib.Convs) != 1 {
-		return rl, fmt.Errorf("post join/leave: found %d conversations", len(ib.Convs))
+		return fmt.Errorf("post join/leave: found %d conversations", len(ib.Convs))
 	}
-	if irl != nil {
-		rl = append(rl, *irl)
-	}
+
 	conv := ib.Convs[0]
 
 	plaintext := chat1.MessagePlaintext{
@@ -850,33 +840,24 @@ func postJoinLeave(ctx context.Context, g *globals.Context, ri func() chat1.Remo
 
 	// Send with a blocking sender
 	sender := NewBlockingSender(g, NewBoxer(g), nil, ri)
-	_, _, irl, err = sender.Send(ctx, convID, plaintext, 0, nil)
-	if irl != nil {
-		rl = append(rl, *irl)
-	}
-	return rl, err
+	_, _, err = sender.Send(ctx, convID, plaintext, 0, nil)
+	return err
 }
 
 func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
-	ri func() chat1.RemoteInterface, uid gregor1.UID, convID chat1.ConversationID) (rl []chat1.RateLimit, err error) {
-	alreadyIn, irl, err := g.InboxSource.IsMember(ctx, uid, convID)
+	ri func() chat1.RemoteInterface, uid gregor1.UID, convID chat1.ConversationID) (err error) {
+	alreadyIn, err := g.InboxSource.IsMember(ctx, uid, convID)
 	if err != nil {
 		debugger.Debug(ctx, "JoinConversation: IsMember err: %s", err.Error())
 		// Assume we're not in.
 		alreadyIn = false
 	}
-	if irl != nil {
-		rl = append(rl, *irl)
-	}
 
 	// Send the join command even if we're in.
-	joinRes, err := ri().JoinConversation(ctx, convID)
+	_, err = ri().JoinConversation(ctx, convID)
 	if err != nil {
 		debugger.Debug(ctx, "JoinConversation: failed to join conversation: %s", err.Error())
-		return rl, err
-	}
-	if joinRes.RateLimit != nil {
-		rl = append(rl, *joinRes.RateLimit)
+		return err
 	}
 
 	if _, err = g.InboxSource.MembershipUpdate(ctx, uid, 0, []chat1.ConversationMember{
@@ -892,82 +873,67 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 		// Send a message to the channel after joining.
 		joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
 		debugger.Debug(ctx, "JoinConversation: sending join message to: %s", convID)
-		irl, err := postJoinLeave(ctx, g, ri, uid, convID, joinMessageBody)
+		err := postJoinLeave(ctx, g, ri, uid, convID, joinMessageBody)
 		if err != nil {
 			debugger.Debug(ctx, "JoinConversation: posting join-conv message failed: %v", err)
 			// ignore the error
 		}
-		rl = append(rl, irl...)
 	}
-	return rl, nil
+	return nil
 }
 
 func LeaveConversation(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
-	ri func() chat1.RemoteInterface, uid gregor1.UID, convID chat1.ConversationID) (rl []chat1.RateLimit, err error) {
-	alreadyIn, irl, err := g.InboxSource.IsMember(ctx, uid, convID)
+	ri func() chat1.RemoteInterface, uid gregor1.UID, convID chat1.ConversationID) (err error) {
+	alreadyIn, err := g.InboxSource.IsMember(ctx, uid, convID)
 	if err != nil {
 		debugger.Debug(ctx, "LeaveConversation: IsMember err: %s", err.Error())
 		// Pretend we're in.
 		alreadyIn = true
 	}
-	if irl != nil {
-		rl = append(rl, *irl)
-	}
 
 	// Send a message to the channel to leave the conversation
 	if alreadyIn {
 		leaveMessageBody := chat1.NewMessageBodyWithLeave(chat1.MessageLeave{})
-		irl, err := postJoinLeave(ctx, g, ri, uid, convID, leaveMessageBody)
+		err := postJoinLeave(ctx, g, ri, uid, convID, leaveMessageBody)
 		if err != nil {
 			debugger.Debug(ctx, "LeaveConversation: posting leave-conv message failed: %v", err)
-			return rl, err
+			return err
 		}
-		rl = append(rl, irl...)
 	} else {
-		lres, err := ri().LeaveConversation(ctx, convID)
+		_, err = ri().LeaveConversation(ctx, convID)
 		if err != nil {
 			debugger.Debug(ctx, "LeaveConversation: failed to leave conversation as a non-member: %s", err)
-			return rl, err
-		}
-		if lres.RateLimit != nil {
-			rl = append(rl, *lres.RateLimit)
+			return err
 		}
 	}
 
-	return rl, nil
+	return nil
 }
 
 func PreviewConversation(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
-	ri func() chat1.RemoteInterface, uid gregor1.UID, convID chat1.ConversationID) (rl []chat1.RateLimit, err error) {
-	alreadyIn, irl, err := g.InboxSource.IsMember(ctx, uid, convID)
+	ri func() chat1.RemoteInterface, uid gregor1.UID, convID chat1.ConversationID) (err error) {
+	alreadyIn, err := g.InboxSource.IsMember(ctx, uid, convID)
 	if err != nil {
 		debugger.Debug(ctx, "PreviewConversation: IsMember err: %s", err.Error())
 		// Assume we aren't in, server will reject us otherwise.
 		alreadyIn = false
 	}
-	if irl != nil {
-		rl = append(rl, *irl)
-	}
 	if alreadyIn {
 		debugger.Debug(ctx, "PreviewConversation: already in the conversation, no need to preview")
-		return nil, nil
+		return nil
 	}
 
-	previewRes, err := ri().PreviewConversation(ctx, convID)
+	_, err = ri().PreviewConversation(ctx, convID)
 	if err != nil {
 		debugger.Debug(ctx, "PreviewConversation: failed to preview conversation: %s", err.Error())
-		return rl, err
+		return err
 	}
-	if previewRes.RateLimit != nil {
-		rl = append(rl, *previewRes.RateLimit)
-	}
-
-	return rl, nil
+	return nil
 }
 
 func NewConversation(ctx context.Context, g *globals.Context, uid gregor1.UID, tlfName string, topicName *string,
 	topicType chat1.TopicType, membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility,
-	ri func() chat1.RemoteInterface) (chat1.ConversationLocal, []chat1.RateLimit, error) {
+	ri func() chat1.RemoteInterface) (chat1.ConversationLocal, error) {
 	helper := newNewConversationHelper(g, uid, tlfName, topicName, topicType, membersType, vis, ri)
 	return helper.create(ctx)
 }
@@ -1001,17 +967,19 @@ func newNewConversationHelper(g *globals.Context, uid gregor1.UID, tlfName strin
 	}
 }
 
-func (n *newConversationHelper) findConversations(ctx context.Context, membersType chat1.ConversationMembersType, topicName string) ([]chat1.ConversationLocal, []chat1.RateLimit, error) {
+func (n *newConversationHelper) findConversations(ctx context.Context,
+	membersType chat1.ConversationMembersType, topicName string) ([]chat1.ConversationLocal, error) {
 	onechatpertlf := true
-	return FindConversations(ctx, n.G(), n.DebugLabeler, n.ri, n.uid, n.tlfName, n.topicType, membersType, n.vis, topicName, &onechatpertlf)
+	return FindConversations(ctx, n.G(), n.DebugLabeler, n.ri, n.uid, n.tlfName, n.topicType, membersType,
+		n.vis, topicName, &onechatpertlf)
 }
 
-func (n *newConversationHelper) findExisting(ctx context.Context, topicName string) (res []chat1.ConversationLocal, rl []chat1.RateLimit, err error) {
+func (n *newConversationHelper) findExisting(ctx context.Context, topicName string) (res []chat1.ConversationLocal, err error) {
 	// proceed to findConversations for requested member type
 	return n.findConversations(ctx, n.membersType, topicName)
 }
 
-func (n *newConversationHelper) create(ctx context.Context) (res chat1.ConversationLocal, rl []chat1.RateLimit, reserr error) {
+func (n *newConversationHelper) create(ctx context.Context) (res chat1.ConversationLocal, reserr error) {
 	defer n.Trace(ctx, func() error { return reserr }, "newConversationHelper")()
 	// Handle a nil topic name with default values for the members type specified
 	if n.topicName == nil {
@@ -1035,13 +1003,12 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 	// user and such. For the most part, the CLI just uses FindConversationsLocal though, so it
 	// should hopefully just result in a bunch of cache hits on the second invocation.
 
-	convs, irl, err := n.findExisting(ctx, findConvsTopicName)
+	convs, err := n.findExisting(ctx, findConvsTopicName)
 
 	// If we find one conversation, then just return it as if we created it.
-	rl = append(rl, irl...)
 	if len(convs) == 1 {
 		n.Debug(ctx, "found previous conversation that matches, returning")
-		return convs[0], rl, err
+		return convs[0], err
 	}
 
 	if n.G().ExternalG().Env.GetChatMemberType() == "impteam" {
@@ -1061,21 +1028,21 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 	info, err := CtxKeyFinder(ctx, n.G()).Find(ctx, n.tlfName, n.membersType, isPublic)
 	if err != nil {
 		if n.membersType != chat1.ConversationMembersType_IMPTEAMNATIVE {
-			return res, rl, err
+			return res, err
 		}
 		if _, ok := err.(teams.TeamDoesNotExistError); !ok {
-			return res, rl, err
+			return res, err
 		}
 
 		// couldn't find implicit team, so make one
 		n.Debug(ctx, "making new implicit team %q", n.tlfName)
 		_, _, _, err = teams.LookupOrCreateImplicitTeam(ctx, n.G().ExternalG(), n.tlfName, isPublic)
 		if err != nil {
-			return res, rl, err
+			return res, err
 		}
 		info, err = CtxKeyFinder(ctx, n.G()).Find(ctx, n.tlfName, n.membersType, isPublic)
 		if err != nil {
-			return res, rl, err
+			return res, err
 		}
 	}
 
@@ -1088,14 +1055,14 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 	for i := 0; i < 5; i++ {
 		triple.TopicID, err = utils.NewChatTopicID()
 		if err != nil {
-			return res, rl, fmt.Errorf("error creating topic ID: %s", err)
+			return res, fmt.Errorf("error creating topic ID: %s", err)
 		}
 		n.Debug(ctx, "attempt: %v [tlfID: %s topicType: %d topicID: %s name: %s public: %v]", i, triple.Tlfid,
 			triple.TopicType, triple.TopicID, info.CanonicalName, isPublic)
 		firstMessageBoxed, topicNameState, err := n.makeFirstMessage(ctx, triple, info.CanonicalName,
 			n.membersType, n.vis, n.topicName)
 		if err != nil {
-			return res, rl, fmt.Errorf("error preparing message: %s", err)
+			return res, fmt.Errorf("error preparing message: %s", err)
 		}
 
 		var ncrres chat1.NewConversationRemoteRes
@@ -1105,9 +1072,6 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 			MembersType:    n.membersType,
 			TopicNameState: topicNameState,
 		})
-		if ncrres.RateLimit != nil {
-			rl = append(rl, *ncrres.RateLimit)
-		}
 		convID := ncrres.ConvID
 		if reserr != nil {
 			switch cerr := reserr.(type) {
@@ -1132,26 +1096,23 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 				n.Debug(ctx, "collision: %v", reserr)
 				continue
 			default:
-				return res, rl, fmt.Errorf("error creating conversation: %s", reserr)
+				return res, fmt.Errorf("error creating conversation: %s", reserr)
 			}
 		}
 
 		n.Debug(ctx, "established conv: %v", convID)
 
 		// create succeeded; grabbing the conversation and returning
-		ib, irl, err := n.G().InboxSource.Read(ctx, n.uid, nil, false,
+		ib, err := n.G().InboxSource.Read(ctx, n.uid, nil, false,
 			&chat1.GetInboxLocalQuery{
 				ConvIDs: []chat1.ConversationID{convID},
 			}, nil)
 		if err != nil {
-			return res, rl, err
-		}
-		if rl != nil {
-			rl = append(rl, *irl)
+			return res, err
 		}
 
 		if len(ib.Convs) != 1 {
-			return res, rl,
+			return res,
 				fmt.Errorf("newly created conversation fetch error: found %d conversations", len(ib.Convs))
 		}
 		res = ib.Convs[0]
@@ -1161,14 +1122,14 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 		// Update inbox cache
 		updateConv := ib.ConvsUnverified[0]
 		if err = n.G().InboxSource.NewConversation(ctx, n.uid, 0, updateConv.Conv); err != nil {
-			return res, rl, err
+			return res, err
 		}
 
 		// Clear team channel source
 		n.G().TeamChannelSource.ChannelsChanged(ctx, updateConv.Conv.Metadata.IdTriple.Tlfid)
 
 		if res.Error != nil {
-			return res, rl, errors.New(res.Error.Message)
+			return res, errors.New(res.Error.Message)
 		}
 
 		// Send a message to the channel after joining.
@@ -1177,12 +1138,11 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 			// don't send join messages to #general
 			if findConvsTopicName != globals.DefaultTeamTopic {
 				joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
-				irl, err := postJoinLeave(ctx, n.G(), n.ri, n.uid, convID, joinMessageBody)
+				err := postJoinLeave(ctx, n.G(), n.ri, n.uid, convID, joinMessageBody)
 				if err != nil {
 					n.Debug(ctx, "posting join-conv message failed: %v", err)
 					// ignore the error
 				}
-				rl = append(rl, irl...)
 			}
 		default:
 			// pass
@@ -1201,11 +1161,9 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 				n.Debug(ctx, "failed to send complex team intro message: %s", err)
 			}
 		}
-
-		return res, rl, nil
+		return res, nil
 	}
-
-	return res, rl, reserr
+	return res, reserr
 }
 
 func (n *newConversationHelper) makeFirstMessage(ctx context.Context, triple chat1.ConversationIDTriple,

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -300,22 +300,22 @@ func (b *baseInboxSource) GetInboxQueryLocalToRemote(ctx context.Context,
 	return rquery, info, nil
 }
 
-func (b *baseInboxSource) IsMember(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (bool, *chat1.RateLimit, error) {
-	ib, rl, err := b.ReadUnverified(ctx, uid, true, &chat1.GetInboxQuery{
+func (b *baseInboxSource) IsMember(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (bool, error) {
+	ib, err := b.ReadUnverified(ctx, uid, true, &chat1.GetInboxQuery{
 		ConvID: &convID,
 	}, nil)
 	if err != nil {
-		return false, rl, err
+		return false, err
 	}
 	if len(ib.ConvsUnverified) == 0 {
-		return false, rl, fmt.Errorf("conversation not found: %s", convID)
+		return false, fmt.Errorf("conversation not found: %s", convID)
 	}
 	conv := ib.ConvsUnverified[0]
 	switch conv.Conv.ReaderInfo.Status {
 	case chat1.ConversationMemberStatus_ACTIVE, chat1.ConversationMemberStatus_RESET:
-		return true, rl, nil
+		return true, nil
 	default:
-		return false, rl, nil
+		return false, nil
 	}
 }
 
@@ -350,7 +350,7 @@ func NewRemoteInboxSource(g *globals.Context, ri func() chat1.RemoteInterface) *
 
 func (s *RemoteInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	localizer types.ChatLocalizer, useLocalData bool, query *chat1.GetInboxLocalQuery,
-	p *chat1.Pagination) (types.Inbox, *chat1.RateLimit, error) {
+	p *chat1.Pagination) (types.Inbox, error) {
 
 	if localizer == nil {
 		localizer = NewBlockingLocalizer(s.G())
@@ -362,21 +362,21 @@ func (s *RemoteInboxSource) Read(ctx context.Context, uid gregor1.UID,
 
 	rquery, tlfInfo, err := s.GetInboxQueryLocalToRemote(ctx, query)
 	if err != nil {
-		return types.Inbox{}, nil, err
+		return types.Inbox{}, err
 	}
-	inbox, rl, err := s.ReadUnverified(ctx, uid, useLocalData, rquery, p)
+	inbox, err := s.ReadUnverified(ctx, uid, useLocalData, rquery, p)
 	if err != nil {
-		return types.Inbox{}, rl, err
+		return types.Inbox{}, err
 	}
 
 	res, err := localizer.Localize(ctx, uid, inbox)
 	if err != nil {
-		return types.Inbox{}, rl, err
+		return types.Inbox{}, err
 	}
 
 	res, err = filterConvLocals(res, rquery, query, tlfInfo)
 	if err != nil {
-		return types.Inbox{}, rl, err
+		return types.Inbox{}, err
 	}
 
 	return types.Inbox{
@@ -384,14 +384,14 @@ func (s *RemoteInboxSource) Read(ctx context.Context, uid gregor1.UID,
 		Convs:           res,
 		ConvsUnverified: inbox.ConvsUnverified,
 		Pagination:      inbox.Pagination,
-	}, rl, nil
+	}, nil
 }
 
 func (s *RemoteInboxSource) ReadUnverified(ctx context.Context, uid gregor1.UID, useLocalData bool,
-	rquery *chat1.GetInboxQuery, p *chat1.Pagination) (types.Inbox, *chat1.RateLimit, error) {
+	rquery *chat1.GetInboxQuery, p *chat1.Pagination) (types.Inbox, error) {
 
 	if s.IsOffline(ctx) {
-		return types.Inbox{}, nil, OfflineError{}
+		return types.Inbox{}, OfflineError{}
 	}
 
 	ib, err := s.getChatInterface().GetInboxRemote(ctx, chat1.GetInboxRemoteArg{
@@ -399,14 +399,14 @@ func (s *RemoteInboxSource) ReadUnverified(ctx context.Context, uid gregor1.UID,
 		Pagination: p,
 	})
 	if err != nil {
-		return types.Inbox{}, ib.RateLimit, err
+		return types.Inbox{}, err
 	}
 
 	return types.Inbox{
 		Version:         ib.Inbox.Full().Vers,
 		ConvsUnverified: utils.RemoteConvs(ib.Inbox.Full().Conversations),
 		Pagination:      ib.Inbox.Full().Pagination,
-	}, ib.RateLimit, nil
+	}, nil
 }
 
 func (s *RemoteInboxSource) NewConversation(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
@@ -494,11 +494,11 @@ func NewHybridInboxSource(g *globals.Context,
 }
 
 func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UID, query *chat1.GetInboxQuery,
-	p *chat1.Pagination) (types.Inbox, *chat1.RateLimit, error) {
+	p *chat1.Pagination) (types.Inbox, error) {
 
 	// Insta fail if we are offline
 	if s.IsOffline(ctx) {
-		return types.Inbox{}, nil, OfflineError{}
+		return types.Inbox{}, OfflineError{}
 	}
 
 	// We always want this on for fetches to fill the local inbox, otherwise we never get the
@@ -522,7 +522,7 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 		Pagination: p,
 	})
 	if err != nil {
-		return types.Inbox{}, ib.RateLimit, err
+		return types.Inbox{}, err
 	}
 
 	for index, conv := range ib.Inbox.Full().Conversations {
@@ -546,12 +546,12 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 		Version:         ib.Inbox.Full().Vers,
 		ConvsUnverified: utils.RemoteConvs(ib.Inbox.Full().Conversations),
 		Pagination:      ib.Inbox.Full().Pagination,
-	}, ib.RateLimit, nil
+	}, nil
 }
 
 func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	localizer types.ChatLocalizer, useLocalData bool, query *chat1.GetInboxLocalQuery,
-	p *chat1.Pagination) (inbox types.Inbox, rl *chat1.RateLimit, err error) {
+	p *chat1.Pagination) (inbox types.Inbox, err error) {
 
 	defer s.Trace(ctx, func() error { return err }, "Read")()
 	if localizer == nil {
@@ -565,23 +565,23 @@ func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	// Read unverified inbox
 	rquery, tlfInfo, err := s.GetInboxQueryLocalToRemote(ctx, query)
 	if err != nil {
-		return inbox, rl, err
+		return inbox, err
 	}
-	inbox, rl, err = s.ReadUnverified(ctx, uid, useLocalData, rquery, p)
+	inbox, err = s.ReadUnverified(ctx, uid, useLocalData, rquery, p)
 	if err != nil {
-		return inbox, rl, err
+		return inbox, err
 	}
 
 	// Localize
 	inbox.Convs, err = localizer.Localize(ctx, uid, inbox)
 	if err != nil {
-		return inbox, rl, err
+		return inbox, err
 	}
 
 	// Run post filters
 	inbox.Convs, err = filterConvLocals(inbox.Convs, rquery, query, tlfInfo)
 	if err != nil {
-		return inbox, rl, err
+		return inbox, err
 	}
 
 	// Write metadata to the inbox cache
@@ -590,11 +590,11 @@ func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,
 		s.Debug(ctx, "Read: unable to write inbox local metadata: %s", err)
 	}
 
-	return inbox, rl, nil
+	return inbox, nil
 }
 
 func (s *HybridInboxSource) ReadUnverified(ctx context.Context, uid gregor1.UID, useLocalData bool,
-	query *chat1.GetInboxQuery, p *chat1.Pagination) (res types.Inbox, rl *chat1.RateLimit, err error) {
+	query *chat1.GetInboxQuery, p *chat1.Pagination) (res types.Inbox, err error) {
 	defer s.Trace(ctx, func() error { return err }, "ReadUnverified")()
 
 	var cerr storage.Error
@@ -627,9 +627,9 @@ func (s *HybridInboxSource) ReadUnverified(ctx context.Context, uid gregor1.UID,
 		}
 
 		// Go to the remote on miss
-		res, rl, err = s.fetchRemoteInbox(ctx, uid, query, p)
+		res, err = s.fetchRemoteInbox(ctx, uid, query, p)
 		if err != nil {
-			return res, rl, err
+			return res, err
 		}
 
 		// Write out to local storage only if we are using local data
@@ -640,7 +640,7 @@ func (s *HybridInboxSource) ReadUnverified(ctx context.Context, uid gregor1.UID,
 		}
 	}
 
-	return res, rl, err
+	return res, err
 }
 
 func (s *HybridInboxSource) handleInboxError(ctx context.Context, err error, uid gregor1.UID) (ferr error) {
@@ -677,7 +677,7 @@ func (s *HybridInboxSource) NewConversation(ctx context.Context, uid gregor1.UID
 func (s *HybridInboxSource) getConvLocal(ctx context.Context, uid gregor1.UID,
 	convID chat1.ConversationID) (conv *chat1.ConversationLocal, err error) {
 	// Read back affected conversation so we can send it to the frontend
-	ib, _, err := s.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
+	ib, err := s.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
 		ConvIDs: []chat1.ConversationID{convID},
 	}, nil)
 	if err != nil {
@@ -696,7 +696,7 @@ func (s *HybridInboxSource) getConvLocal(ctx context.Context, uid gregor1.UID,
 func (s *HybridInboxSource) getConvsLocal(ctx context.Context, uid gregor1.UID,
 	convIDs []chat1.ConversationID) ([]chat1.ConversationLocal, error) {
 	// Read back affected conversation so we can send it to the frontend
-	ib, _, err := s.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
+	ib, err := s.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
 		ConvIDs: convIDs,
 	}, nil)
 	return ib.Convs, err
@@ -766,7 +766,7 @@ func (s *HybridInboxSource) TeamTypeChanged(ctx context.Context, uid gregor1.UID
 	defer s.Trace(ctx, func() error { return err }, "TeamTypeChanged")()
 
 	// Read the remote conversation so we can get the notification settings changes
-	remoteConv, _, err := GetUnverifiedConv(ctx, s.G(), uid, convID, false)
+	remoteConv, err := GetUnverifiedConv(ctx, s.G(), uid, convID, false)
 	if err != nil {
 		s.Debug(ctx, "TeamTypeChanged: failed to read team type conv: %s", err.Error())
 		return nil, err
@@ -854,7 +854,7 @@ func (s *HybridInboxSource) MembershipUpdate(ctx context.Context, uid gregor1.UI
 	var userJoinedConvs []chat1.Conversation
 	if len(userJoined) > 0 {
 		var ibox types.Inbox
-		ibox, _, err = s.Read(ctx, uid, nil, false, &chat1.GetInboxLocalQuery{
+		ibox, err = s.Read(ctx, uid, nil, false, &chat1.GetInboxLocalQuery{
 			ConvIDs: userJoined,
 		}, nil)
 		if err != nil {

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -284,7 +284,7 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 		defer g.Unlock()
 		defer g.orderer.CompleteTurn(ctx, uid, update.InboxVers)
 		// Get and localize the conversation to get the new tlfname.
-		inbox, _, err := g.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
+		inbox, err := g.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
 			ConvIDs: []chat1.ConversationID{update.ConvID},
 		}, nil)
 		if err != nil {
@@ -564,7 +564,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 
 			// We need to get this conversation and then localize it
 			var inbox types.Inbox
-			if inbox, _, err = g.G().InboxSource.Read(ctx, uid, nil, false, &chat1.GetInboxLocalQuery{
+			if inbox, err = g.G().InboxSource.Read(ctx, uid, nil, false, &chat1.GetInboxLocalQuery{
 				ConvIDs: []chat1.ConversationID{nm.ConvID},
 			}, nil); err != nil {
 				g.Debug(ctx, "chat activity: unable to read conversation: %s", err.Error())

--- a/go/chat/remoteclient.go
+++ b/go/chat/remoteclient.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"golang.org/x/net/context"
@@ -22,7 +23,13 @@ func NewRemoteClient(g *globals.Context, cli rpc.GenericClient) *RemoteClient {
 
 func (c *RemoteClient) Call(ctx context.Context, method string, arg interface{}, res interface{}) (err error) {
 	defer c.Trace(ctx, func() error { return err }, method)()
-	return c.cli.Call(ctx, method, arg, res)
+	err = c.cli.Call(ctx, method, arg, res)
+	if err == nil {
+		if rlRes, ok := res.(types.RateLimitedResult); ok {
+			CtxAddRateLimit(ctx, rlRes.GetRateLimit())
+		}
+	}
+	return err
 }
 
 func (c *RemoteClient) Notify(ctx context.Context, method string, arg interface{}) (err error) {

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -79,7 +79,7 @@ func (c *ConversationRetry) fixInboxFetch(ctx context.Context, uid gregor1.UID) 
 	c.Debug(ctx, "fixInboxFetch: retrying conversation")
 
 	// Reload this conversation and hope it works
-	inbox, _, err := c.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
+	inbox, err := c.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
 		ConvIDs: []chat1.ConversationID{c.convID},
 	}, nil)
 	if err != nil {
@@ -106,7 +106,7 @@ func (c *ConversationRetry) fixThreadFetch(ctx context.Context, uid gregor1.UID)
 	c.Debug(ctx, "fixThreadFetch: retrying conversation")
 	// Attempt a pull of 50 messages to simulate whatever request got the
 	// conversation in this queue.
-	_, _, err := c.G().ConvSource.Pull(ctx, c.convID, uid, nil, &chat1.Pagination{
+	_, err := c.G().ConvSource.Pull(ctx, c.convID, uid, nil, &chat1.Pagination{
 		Num: 50,
 	})
 	if err == nil {
@@ -167,7 +167,7 @@ func (f FullInboxRetry) Fix(ctx context.Context, uid gregor1.UID) error {
 		f.Debug(ctx, "Fix: failed to convert query: %s", err.Error())
 		return err
 	}
-	_, _, err = f.G().InboxSource.ReadUnverified(ctx, uid, true, query, f.pagination)
+	_, err = f.G().InboxSource.ReadUnverified(ctx, uid, true, query, f.pagination)
 	if err != nil {
 		f.Debug(ctx, "Fix: failed to load again: %d", err.Error())
 	}

--- a/go/chat/searcher.go
+++ b/go/chat/searcher.go
@@ -29,7 +29,7 @@ func NewSearcher(g *globals.Context) *Searcher {
 }
 
 func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchHit, conversationID chat1.ConversationID, re *regexp.Regexp,
-	maxHits, maxMessages, beforeContext, afterContext int) (hits []chat1.ChatSearchHit, rlimits []chat1.RateLimit, err error) {
+	maxHits, maxMessages, beforeContext, afterContext int) (hits []chat1.ChatSearchHit, err error) {
 	uid := gregor1.UID(s.G().Env.GetUID().ToBytes())
 	pagination := &chat1.Pagination{Num: s.pageSize}
 
@@ -41,13 +41,12 @@ func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchH
 		afterContext = s.pageSize - 1
 	}
 
-	var rlimitsp []*chat1.RateLimit
 	// If we have to gather search result context around a pagination boundary,
 	// we may have to fetch the next page of the thread
 	var prevPage, curPage, nextPage *chat1.ThreadView
 
 	getNextPage := func() (*chat1.ThreadView, error) {
-		thread, rl, err := s.G().ConvSource.Pull(ctx, conversationID, uid, &chat1.GetThreadQuery{
+		thread, err := s.G().ConvSource.Pull(ctx, conversationID, uid, &chat1.GetThreadQuery{
 			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
 		}, pagination)
 		if err != nil {
@@ -65,7 +64,6 @@ func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchH
 		pagination = thread.Pagination
 		pagination.Num = s.pageSize
 		pagination.Previous = nil
-		rlimitsp = append(rlimitsp, rl...)
 		return &thread, nil
 	}
 
@@ -131,7 +129,7 @@ func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchH
 		if nextPage == nil {
 			curPage, err = getNextPage()
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 		} else { // we pre-fetched the next page when retrieving context
 			curPage = nextPage
@@ -149,7 +147,7 @@ func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchH
 				afterMsgs := getAfterMsgs(i, prevPage, curPage)
 				newThread, beforeMsgs, err := getBeforeMsgs(i, curPage, nextPage)
 				if err != nil {
-					return nil, nil, err
+					return nil, err
 				}
 				nextPage = newThread
 				searchHit := chat1.ChatSearchHit{
@@ -173,5 +171,5 @@ func (s *Searcher) SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchH
 	if uiCh != nil {
 		close(uiCh)
 	}
-	return hits, utils.AggRateLimitsP(rlimitsp), nil
+	return hits, nil
 }

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -87,7 +87,7 @@ func (s *BlockingSender) addPrevPointersAndCheckConvID(ctx context.Context, msg 
 
 	var prevs []chat1.MessagePreviousPointer
 
-	res, _, err := s.G().ConvSource.Pull(ctx, conv.GetConvID(), msg.ClientHeader.Sender,
+	res, err := s.G().ConvSource.Pull(ctx, conv.GetConvID(), msg.ClientHeader.Sender,
 		&chat1.GetThreadQuery{
 			DisableResolveSupersedes: true,
 		},
@@ -237,7 +237,7 @@ func (s *BlockingSender) getAllDeletedEdits(ctx context.Context, msg chat1.Messa
 	// Use ConvSource with an `After` which query. Fetches from a combination of local cache
 	// and the server. This is an opportunity for the server to retain messages that should
 	// have been deleted without getting caught.
-	tv, _, err := s.G().ConvSource.Pull(ctx, conv.GetConvID(), msg.ClientHeader.Sender,
+	tv, err := s.G().ConvSource.Pull(ctx, conv.GetConvID(), msg.ClientHeader.Sender,
 		&chat1.GetThreadQuery{
 			MarkAsRead:   false,
 			MessageTypes: []chat1.MessageType{chat1.MessageType_EDIT, chat1.MessageType_ATTACHMENTUPLOADED},
@@ -296,7 +296,7 @@ func (s *BlockingSender) checkTopicNameAndGetState(ctx context.Context, msg chat
 		tlfID := msg.ClientHeader.Conv.Tlfid
 		topicType := msg.ClientHeader.Conv.TopicType
 		newTopicName := msg.MessageBody.Metadata().ConversationTitle
-		convs, _, err := s.G().TeamChannelSource.GetChannelsFull(ctx, msg.ClientHeader.Sender, tlfID,
+		convs, err := s.G().TeamChannelSource.GetChannelsFull(ctx, msg.ClientHeader.Sender, tlfID,
 			topicType)
 		if err != nil {
 			return topicNameState, err
@@ -492,7 +492,7 @@ func (s *BlockingSender) presentUIItem(conv *chat1.ConversationLocal) (res *chat
 }
 
 func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
-	msg chat1.MessagePlaintext, clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (obid chat1.OutboxID, boxed *chat1.MessageBoxed, rl *chat1.RateLimit, err error) {
+	msg chat1.MessagePlaintext, clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (obid chat1.OutboxID, boxed *chat1.MessageBoxed, err error) {
 	defer s.Trace(ctx, func() error { return err }, fmt.Sprintf("Send(%s)", convID))()
 
 	// Record that this user is "active in chat", which we use to determine
@@ -504,30 +504,30 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	// otherwise we give up and return an error.
 	var conv chat1.Conversation
 	sender := gregor1.UID(s.G().Env.GetUID().ToBytes())
-	conv, _, err = GetUnverifiedConv(ctx, s.G(), sender, convID, true)
+	conv, err = GetUnverifiedConv(ctx, s.G(), sender, convID, true)
 	if err != nil {
 		if err == errGetUnverifiedConvNotFound {
 			// If we didn't find it, then just attempt to join it and see what happens
 			switch msg.ClientHeader.MessageType {
 			case chat1.MessageType_JOIN, chat1.MessageType_LEAVE:
-				return chat1.OutboxID{}, nil, nil, err
+				return chat1.OutboxID{}, nil, err
 			default:
 				s.Debug(ctx, "conversation not found, attempting to join the conversation and try again")
-				if _, err = JoinConversation(ctx, s.G(), s.DebugLabeler, s.getRi, sender,
+				if err = JoinConversation(ctx, s.G(), s.DebugLabeler, s.getRi, sender,
 					convID); err != nil {
-					return chat1.OutboxID{}, nil, nil, err
+					return chat1.OutboxID{}, nil, err
 				}
 				// Force hit the remote here, so there is no race condition against the local
 				// inbox
-				conv, _, err = GetUnverifiedConv(ctx, s.G(), sender, convID, false)
+				conv, err = GetUnverifiedConv(ctx, s.G(), sender, convID, false)
 				if err != nil {
 					s.Debug(ctx, "failed to get conversation again, giving up: %s", err.Error())
-					return chat1.OutboxID{}, nil, nil, err
+					return chat1.OutboxID{}, nil, err
 				}
 			}
 		} else {
 			s.Debug(ctx, "error getting conversation metadata: %s", err.Error())
-			return chat1.OutboxID{}, nil, nil, err
+			return chat1.OutboxID{}, nil, err
 		}
 	} else {
 		s.Debug(ctx, "uid: %s in conversation %s with status: %v", sender,
@@ -542,8 +542,8 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 			// pass so we don't loop between Send and Join/Leave.
 		default:
 			s.Debug(ctx, "user is in preview mode, joining conversation")
-			if _, err = JoinConversation(ctx, s.G(), s.DebugLabeler, s.getRi, sender, convID); err != nil {
-				return chat1.OutboxID{}, nil, nil, err
+			if err = JoinConversation(ctx, s.G(), s.DebugLabeler, s.getRi, sender, convID); err != nil {
+				return chat1.OutboxID{}, nil, err
 			}
 		}
 	default:
@@ -559,7 +559,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 			conv.GetMembersType(), &conv)
 		if err != nil {
 			s.Debug(ctx, "error in Prepare: %s", err.Error())
-			return chat1.OutboxID{}, nil, nil, err
+			return chat1.OutboxID{}, nil, err
 		}
 		boxed = b
 
@@ -597,7 +597,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 				continue
 			default:
 				s.Debug(ctx, "failed to PostRemote, bailing: %s", err.Error())
-				return chat1.OutboxID{}, nil, nil, err
+				return chat1.OutboxID{}, nil, err
 			}
 		}
 		boxed.ServerHeader = &plres.MsgHeader
@@ -628,7 +628,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 		s.G().NotifyRouter.HandleNewChatActivity(ctx, keybase1.UID(boxed.ClientHeader.Sender.String()),
 			&activity)
 	}
-	return []byte{}, boxed, plres.RateLimit, nil
+	return []byte{}, boxed, nil
 }
 
 const deliverMaxAttempts = 5
@@ -893,7 +893,7 @@ func (s *Deliverer) deliverLoop() {
 					obr.OutboxID, s.clock.Now().Sub(obr.Ctime.Time()))
 				err = delivererExpireError{}
 			} else {
-				_, _, _, err = s.sender.Send(bctx, obr.ConvID, obr.Msg, 0, nil)
+				_, _, err = s.sender.Send(bctx, obr.ConvID, obr.Msg, 0, nil)
 			}
 			if err != nil {
 				s.Debug(bgctx, "failed to send msg: uid: %s convID: %s obid: %s err: %s attempts: %d",
@@ -946,12 +946,12 @@ func (s *NonblockingSender) Prepare(ctx context.Context, msg chat1.MessagePlaint
 }
 
 func (s *NonblockingSender) Send(ctx context.Context, convID chat1.ConversationID,
-	msg chat1.MessagePlaintext, clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (chat1.OutboxID, *chat1.MessageBoxed, *chat1.RateLimit, error) {
+	msg chat1.MessagePlaintext, clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (chat1.OutboxID, *chat1.MessageBoxed, error) {
 	msg.ClientHeader.OutboxInfo = &chat1.OutboxInfo{
 		Prev:        clientPrev,
 		ComposeTime: gregor1.ToTime(time.Now()),
 	}
 	identifyBehavior, _, _ := IdentifyMode(ctx)
 	obr, err := s.G().MessageDeliverer.Queue(ctx, convID, msg, outboxID, identifyBehavior)
-	return obr.OutboxID, nil, &chat1.RateLimit{}, err
+	return obr.OutboxID, nil, err
 }

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -17,7 +17,7 @@ func newConvLoaderEphemeralPurgeHook(g *globals.Context, chatStorage *Storage, u
 			g.GetLog().CDebugf(ctx, "ephemeralPurge: %s", err)
 		} else {
 			if len(explodedMsgs) > 0 {
-				ib, _, err := g.InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
+				ib, err := g.InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
 					ConvIDs: []chat1.ConversationID{job.ConvID},
 				}, nil)
 				if err != nil || len(ib.Convs) != 1 {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -64,7 +64,7 @@ type ConversationSource interface {
 	PushUnboxed(ctx context.Context, convID chat1.ConversationID,
 		uid gregor1.UID, msg chat1.MessageUnboxed) (continuousUpdate bool, err error)
 	Pull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
-		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
+		pagination *chat1.Pagination) (chat1.ThreadView, error)
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 		query *chat1.GetThreadQuery, p *chat1.Pagination, maxPlaceholders int) (chat1.ThreadView, error)
 	GetMessages(ctx context.Context, conv UnboxConversationInfo, uid gregor1.UID, msgIDs []chat1.MessageID) ([]chat1.MessageUnboxed, error)
@@ -92,12 +92,12 @@ type MessageDeliverer interface {
 }
 
 type Searcher interface {
-	SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchHit, conversationID chat1.ConversationID, re *regexp.Regexp, maxHits, maxMessages, beforeContext, afterContext int) (hits []chat1.ChatSearchHit, rlimits []chat1.RateLimit, err error)
+	SearchRegexp(ctx context.Context, uiCh chan chat1.ChatSearchHit, conversationID chat1.ConversationID, re *regexp.Regexp, maxHits, maxMessages, beforeContext, afterContext int) (hits []chat1.ChatSearchHit, err error)
 }
 
 type Sender interface {
 	Send(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext,
-		clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (chat1.OutboxID, *chat1.MessageBoxed, *chat1.RateLimit, error)
+		clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (chat1.OutboxID, *chat1.MessageBoxed, error)
 	Prepare(ctx context.Context, msg chat1.MessagePlaintext, membersType chat1.ConversationMembersType,
 		conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, chat1.ChannelMention, *chat1.TopicNameState, error)
 }
@@ -112,10 +112,10 @@ type InboxSource interface {
 	Offlinable
 
 	Read(ctx context.Context, uid gregor1.UID, localizer ChatLocalizer, useLocalData bool,
-		query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (Inbox, *chat1.RateLimit, error)
+		query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (Inbox, error)
 	ReadUnverified(ctx context.Context, uid gregor1.UID, useLocalData bool,
-		query *chat1.GetInboxQuery, p *chat1.Pagination) (Inbox, *chat1.RateLimit, error)
-	IsMember(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (bool, *chat1.RateLimit, error)
+		query *chat1.GetInboxQuery, p *chat1.Pagination) (Inbox, error)
+	IsMember(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (bool, error)
 
 	NewConversation(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		conv chat1.Conversation) error
@@ -213,9 +213,9 @@ type AppState interface {
 type TeamChannelSource interface {
 	Offlinable
 
-	GetChannelsFull(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType) ([]chat1.ConversationLocal, []chat1.RateLimit, error)
-	GetChannelsTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType) ([]chat1.ChannelNameMention, []chat1.RateLimit, error)
-	GetChannelTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType, chat1.ConversationID) (string, []chat1.RateLimit, error)
+	GetChannelsFull(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType) ([]chat1.ConversationLocal, error)
+	GetChannelsTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType) ([]chat1.ChannelNameMention, error)
+	GetChannelTopicName(context.Context, gregor1.UID, chat1.TLFID, chat1.TopicType, chat1.ConversationID) (string, error)
 	ChannelsChanged(context.Context, chat1.TLFID)
 }
 
@@ -242,4 +242,9 @@ type AttachmentURLSrv interface {
 	GetURL(ctx context.Context, convID chat1.ConversationID, msgID chat1.MessageID,
 		preview bool) string
 	GetAttachmentFetcher() AttachmentFetcher
+}
+
+type RateLimitedResult interface {
+	GetRateLimit() []chat1.RateLimit
+	SetRateLimits(rl []chat1.RateLimit)
 }

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -515,7 +515,7 @@ func ParseChannelNameMentions(ctx context.Context, body string, uid gregor1.UID,
 	if len(names) == 0 {
 		return nil
 	}
-	chanResponse, _, err := ts.GetChannelsTopicName(ctx, uid, teamID, chat1.TopicType_CHAT)
+	chanResponse, err := ts.GetChannelsTopicName(ctx, uid, teamID, chat1.TopicType_CHAT)
 	if err != nil {
 		return nil
 	}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1180,3 +1180,14 @@ func (r *GetSearchRegexpRes) GetRateLimit() []RateLimit {
 func (r *GetSearchRegexpRes) SetRateLimits(rl []RateLimit) {
 	r.RateLimits = rl
 }
+
+func (r *GetInboxRemoteRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *GetInboxRemoteRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1191,3 +1191,168 @@ func (r *GetInboxRemoteRes) GetRateLimit() (res []RateLimit) {
 func (r *GetInboxRemoteRes) SetRateLimits(rl []RateLimit) {
 	r.RateLimit = &rl[0]
 }
+
+func (r *GetInboxByTLFIDRemoteRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *GetInboxByTLFIDRemoteRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *GetThreadRemoteRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *GetThreadRemoteRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *GetConversationMetadataRemoteRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *GetConversationMetadataRemoteRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *PostRemoteRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *PostRemoteRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *NewConversationRemoteRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *NewConversationRemoteRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *GetMessagesRemoteRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *GetMessagesRemoteRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *MarkAsReadRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *MarkAsReadRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *SetConversationStatusRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *SetConversationStatusRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *GetPublicConversationsRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *GetPublicConversationsRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *JoinLeaveConversationRemoteRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *JoinLeaveConversationRemoteRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *DeleteConversationRemoteRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *DeleteConversationRemoteRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *GetMessageBeforeRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *GetMessageBeforeRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *GetTLFConversationsRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *GetTLFConversationsRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *SetAppNotificationSettingsRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *SetAppNotificationSettingsRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}
+
+func (r *SetRetentionRes) GetRateLimit() (res []RateLimit) {
+	if r.RateLimit != nil {
+		res = []RateLimit{*r.RateLimit}
+	}
+	return res
+}
+
+func (r *SetRetentionRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimit = &rl[0]
+}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1036,3 +1036,147 @@ func (p RetentionPolicy) Summary() string {
 func TeamIDToTLFID(teamID keybase1.TeamID) (TLFID, error) {
 	return MakeTLFID(teamID.String())
 }
+
+func (r *NonblockFetchRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *NonblockFetchRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *MarkAsReadLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *MarkAsReadLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *GetInboxAndUnboxLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *GetInboxAndUnboxLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *GetThreadLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *GetThreadLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *NewConversationLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *NewConversationLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *GetInboxSummaryForCLILocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *GetInboxSummaryForCLILocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *GetMessagesLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *GetMessagesLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *SetConversationStatusLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *SetConversationStatusLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *PostLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *PostLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *GetConversationForCLILocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *GetConversationForCLILocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *PostLocalNonblockRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *PostLocalNonblockRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *DownloadAttachmentLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *DownloadAttachmentLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *FindConversationsLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *FindConversationsLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *JoinLeaveConversationLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *JoinLeaveConversationLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *DeleteConversationLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *DeleteConversationLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *GetTLFConversationsLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *GetTLFConversationsLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *SetAppNotificationSettingsLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *SetAppNotificationSettingsLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *GetSearchRegexpRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *GetSearchRegexpRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}


### PR DESCRIPTION
This cleans up the code a lot, and is probably better too.