### PR TITLE
Delete deviceEKs on deprovision, deprovision on revoke

### DIFF
--- a/go/engine/deprovision.go
+++ b/go/engine/deprovision.go
@@ -4,8 +4,6 @@
 package engine
 
 import (
-	"fmt"
-
 	"github.com/keybase/client/go/libkb"
 )
 
@@ -100,44 +98,15 @@ func (e *DeprovisionEngine) Run(m libkb.MetaContext) (err error) {
 	//   a) Revoke all the current device's keys.
 	//   b) Log out.
 	// 2. Delete all the user's secret keys!!!
-	// 3. Delete the user from the config file.
-	// 4. Db nuke.
+	// 3. Delete the user's ephemeralKeys
+	// 4. Delete the user from the config file.
+	// 5. Db nuke.
 
 	if e.doRevoke {
-		err = e.attemptLoggedInRevoke(m)
-		if err != nil {
-			return
+		if err = e.attemptLoggedInRevoke(m); err != nil {
+			return err
 		}
 	}
 
-	logui := m.UIs().LogUI
-
-	if clearSecretErr := libkb.ClearStoredSecret(m.G(), e.username); clearSecretErr != nil {
-		m.CWarningf("ClearStoredSecret error: %s", clearSecretErr)
-	}
-
-	// XXX: Delete the user's secret keyring. It's very important that we never
-	// do this to the wrong user. Please do not copy this code :)
-	logui.Info("Deleting %s's secret keys file...", e.username.String())
-	filename := m.G().SKBFilenameForUser(e.username)
-	err = libkb.ShredFile(filename)
-	if err != nil {
-		return fmt.Errorf("Failed to delete secret key file: %s", err)
-	}
-
-	logui.Info("Deleting %s from config.json...", e.username.String())
-	if err = m.G().Env.GetConfigWriter().NukeUser(e.username); err != nil {
-		return
-	}
-
-	// The config entries we just nuked could still be in memory. Clear them.
-	m.G().Env.GetConfigWriter().SetUserConfig(nil, true /* overwrite; ignored */)
-
-	logui.Info("Clearing the local cache db...")
-	if _, err = m.G().LocalDb.Nuke(); err != nil {
-		return
-	}
-
-	logui.Info("Deprovision finished.")
-	return
+	return libkb.ClearSecretsOnDeprovision(m, e.username)
 }

--- a/go/engine/login_oneshot_test.go
+++ b/go/engine/login_oneshot_test.go
@@ -1,10 +1,11 @@
 package engine
 
 import (
+	"testing"
+
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestLoginOneshot(t *testing.T) {
@@ -44,7 +45,7 @@ func TestLoginOneshot(t *testing.T) {
 	require.NoError(t, err)
 	testSign(t, tc2)
 	trackAlice(tc2, fu, 2)
-	err = m.LogoutIfRevoked()
+	err = m.LogoutAndDeprovisionIfRevoked()
 	require.NoError(t, err)
 	testSign(t, tc2)
 }

--- a/go/engine/puk_roll.go
+++ b/go/engine/puk_roll.go
@@ -173,7 +173,7 @@ func (e *PerUserKeyRoll) inner(m libkb.MetaContext) error {
 			userEKSection["boxes"] = boxes
 			payload["user_ek"] = userEKSection
 		} else {
-			m.CWarningf("skipping userEK publishing, because there are no valid deviceEKs")
+			m.CDebugf("skipping userEK publishing, there are no valid deviceEKs")
 		}
 	}
 

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -285,7 +285,7 @@ func (e *RevokeEngine) Run(m libkb.MetaContext) error {
 			userEKSection["boxes"] = filteredBoxes
 			payload["user_ek"] = userEKSection
 		} else {
-			m.CWarningf("skipping userEK publishing, because there are no valid deviceEKs")
+			m.CDebugf("skipping userEK publishing, there are no valid deviceEKs")
 		}
 	}
 	m.CDebugf("RevokeEngine#Run pukBoxes:%v pukPrev:%v for generation %v, userEKBox: %v",

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -368,7 +368,7 @@ func TestSignAfterRevoke(t *testing.T) {
 	}
 
 	// This should log out tc1:
-	if err := NewMetaContextForTest(tc1).LogoutIfRevoked(); err != nil {
+	if err := NewMetaContextForTest(tc1).LogoutAndDeprovisionIfRevoked(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -379,15 +379,15 @@ func TestSignAfterRevoke(t *testing.T) {
 		Msg: msg,
 	})
 	if err == nil {
-		t.Fatal("nil error signing after LogoutIfRevoked")
+		t.Fatal("nil error signing after LogoutAndDeprovisionIfRevoked")
 	}
 	if _, ok := err.(libkb.LoginRequiredError); !ok {
 		t.Errorf("error type: %T, expected libkb.LoginRequiredError", err)
 	}
 }
 
-// Check that if not on a revoked device that LogoutIfRevoked doesn't do anything.
-func TestLogoutIfRevokedNoop(t *testing.T) {
+// Check that if not on a revoked device that LogoutAndDeprovisionIfRevoked doesn't do anything.
+func TestLogoutAndDeprovisionIfRevokedNoop(t *testing.T) {
 	tc := SetupEngineTest(t, "rev")
 	defer tc.Cleanup()
 
@@ -395,7 +395,7 @@ func TestLogoutIfRevokedNoop(t *testing.T) {
 
 	AssertLoggedIn(tc)
 
-	if err := NewMetaContextForTest(tc).LogoutIfRevoked(); err != nil {
+	if err := NewMetaContextForTest(tc).LogoutAndDeprovisionIfRevoked(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -35,13 +35,16 @@ func NewDeviceEKStorage(g *libkb.GlobalContext) *DeviceEKStorage {
 	}
 }
 
+func (s *DeviceEKStorage) keyPrefixFromUsername(username libkb.NormalizedUsername) string {
+	return fmt.Sprintf("%s-%s-", deviceEKPrefix, username)
+}
+
 func (s *DeviceEKStorage) keyPrefix(ctx context.Context) (prefix string, err error) {
 	uv, err := getCurrentUserUV(ctx, s.G())
 	if err != nil {
 		return prefix, err
 	}
-	return fmt.Sprintf("%s-%s-%s-", deviceEKPrefix, s.G().Env.GetUsername(), uv.EldestSeqno), nil
-
+	return fmt.Sprintf("%s-%s-", s.keyPrefixFromUsername(s.G().Env.GetUsername()), uv.EldestSeqno), nil
 }
 
 func (s *DeviceEKStorage) key(ctx context.Context, generation keybase1.EkGeneration) (key string, err error) {
@@ -207,6 +210,10 @@ func (s *DeviceEKStorage) getCache(ctx context.Context) (cache DeviceEKMap, err 
 func (s *DeviceEKStorage) ClearCache() {
 	s.Lock()
 	defer s.Unlock()
+	s.clearCache()
+}
+
+func (s *DeviceEKStorage) clearCache() {
 	s.cache = make(DeviceEKMap)
 	s.indexed = false
 }
@@ -314,5 +321,25 @@ func (s *DeviceEKStorage) deletedWrongEldestSeqno(ctx context.Context) (err erro
 			epick.Push(s.storage.Erase(ctx, key))
 		}
 	}
+	return epick.Error()
+}
+
+func (s *DeviceEKStorage) ForceDeleteAll(ctx context.Context, username libkb.NormalizedUsername) (err error) {
+	defer s.G().CTrace(ctx, "DeviceEKStorage#ForceDeleteAll", func() error { return err })()
+
+	keys, err := s.storage.AllKeys(ctx)
+	if err != nil {
+		return err
+	}
+	prefix := s.keyPrefixFromUsername(username)
+	epick := libkb.FirstErrorPicker{}
+	for _, key := range keys {
+		// only delete if the key is owned by the current user
+		if strings.HasPrefix(key, prefix) {
+			epick.Push(s.storage.Erase(ctx, key))
+		}
+	}
+
+	s.clearCache()
 	return epick.Error()
 }

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -24,7 +24,6 @@ func TestKeygenIfNeeded(t *testing.T) {
 		deviceEKNeeded, err := ekLib.NewDeviceEKNeeded(context.Background())
 		require.NoError(t, err)
 		require.True(t, deviceEKNeeded)
-
 	}
 
 	expectedUserEKGen, err := userEKBoxStorage.MaxGeneration(context.Background())
@@ -80,7 +79,13 @@ func TestKeygenIfNeeded(t *testing.T) {
 	deviceEKStorage.ClearCache()
 	expectedDeviceEKGen++
 	expectedUserEKGen++
-	keygen(expectedDeviceEKGen, expectedUserEKGen)
+
+	// Test ForceDeleteAll
+	err = deviceEKStorage.ForceDeleteAll(context.Background(), tc.G.Env.GetUsername())
+	require.NoError(t, err)
+	deviceEKs, err := rawDeviceEKStorage.GetAll(context.Background())
+	require.NoError(t, err)
+	require.Len(t, deviceEKs, 0)
 }
 
 func TestNewTeamEKNeeded(t *testing.T) {

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -269,9 +269,9 @@ func (s *TeamEKBoxStorage) DeleteExpired(ctx context.Context, teamID keybase1.Te
 		return nil, nil
 	}
 
-	for _, teamEKBox := range teamEKBoxes {
+	for gen, teamEKBox := range teamEKBoxes {
 		if ctimeIsStale(teamEKBox.Metadata.Ctime, merkleRoot) {
-			expired = append(expired, teamEKBox.Metadata.Generation)
+			expired = append(expired, gen)
 		}
 	}
 	return expired, s.deleteMany(ctx, teamID, expired)

--- a/go/libkb/deprovision.go
+++ b/go/libkb/deprovision.go
@@ -1,9 +1,5 @@
 package libkb
 
-import (
-	"fmt"
-)
-
 // XXX: THIS DELETES SECRET KEYS. Deleting the wrong secret keys can make you
 // lose all your data forever. We only run this in the DeprovisionEngine and if
 // we detect that our device was revoked in LogoutAndDeprovisionIfRevoked.
@@ -12,6 +8,8 @@ func ClearSecretsOnDeprovision(m MetaContext, username NormalizedUsername) error
 	// 2. Delete the user's ephemeralKeys
 	// 3. Delete the user from the config file.
 	// 4. Db nuke.
+
+	epick := FirstErrorPicker{}
 
 	var logger func(string, ...interface{})
 	if m.UIs().LogUI == nil {
@@ -28,35 +26,27 @@ func ClearSecretsOnDeprovision(m MetaContext, username NormalizedUsername) error
 	// do this to the wrong user. Please do not copy this code :)
 	logger("Deleting %s's secret keys file...", username.String())
 	filename := m.G().SKBFilenameForUser(username)
-	if err := ShredFile(filename); err != nil {
-		return fmt.Errorf("Failed to delete secret key file: %s", err)
-	}
+	epick.Push(ShredFile(filename))
 
 	logger("Deleting %s's ephemeralKeys...", username.String())
 	// NOTE: We only store userEK/teamEK boxes locally and these are removed in
 	// the LocalDb.Nuke() below so we just delete any deviceEKs here.
 	deviceEKStorage := m.G().GetDeviceEKStorage()
 	if deviceEKStorage != nil {
-		if err := deviceEKStorage.ForceDeleteAll(m.Ctx(), username); err != nil {
-			return err
-		}
+		epick.Push(deviceEKStorage.ForceDeleteAll(m.Ctx(), username))
 	}
 
 	logger("Deleting %s from config.json...", username.String())
-	if err := m.SwitchUserDeprovisionNukeConfig(username); err != nil {
-		return err
-	}
+	epick.Push(m.SwitchUserDeprovisionNukeConfig(username))
 
 	logger("Clearing the local cache db...")
-	if _, err := m.G().LocalDb.Nuke(); err != nil {
-		return err
-	}
+	_, err := m.G().LocalDb.Nuke()
+	epick.Push(err)
 
 	logger("Clearing the local cache chat db...")
-	if _, err := m.G().LocalChatDb.Nuke(); err != nil {
-		return err
-	}
+	_, err = m.G().LocalChatDb.Nuke()
+	epick.Push(err)
 
 	logger("Deprovision finished.")
-	return nil
+	return epick.Error()
 }

--- a/go/libkb/deprovision.go
+++ b/go/libkb/deprovision.go
@@ -1,0 +1,65 @@
+package libkb
+
+import (
+	"fmt"
+)
+
+// XXX: THIS DELETES SECRET KEYS. Deleting the wrong secret keys can make you
+// lose all your data forever. We only run this in the DeprovisionEngine and if
+// we detect that our device was revoked in LogoutAndDeprovisionIfRevoked.
+func ClearSecretsOnDeprovision(m MetaContext, username NormalizedUsername) error {
+	// 1. Delete all the user's secret keys!!!
+	// 2. Delete the user's ephemeralKeys
+	// 3. Delete the user from the config file.
+	// 4. Db nuke.
+
+	var logger func(string, ...interface{})
+	if m.UIs().LogUI == nil {
+		logger = m.CInfof
+	} else {
+		logger = m.UIs().LogUI.Info
+	}
+
+	if clearSecretErr := ClearStoredSecret(m.G(), username); clearSecretErr != nil {
+		m.CWarningf("ClearStoredSecret error: %s", clearSecretErr)
+	}
+
+	// XXX: Delete the user's secret keyring. It's very important that we never
+	// do this to the wrong user. Please do not copy this code :)
+	logger("Deleting %s's secret keys file...", username.String())
+	filename := m.G().SKBFilenameForUser(username)
+	if err := ShredFile(filename); err != nil {
+		return fmt.Errorf("Failed to delete secret key file: %s", err)
+	}
+
+	logger("Deleting %s's ephemeralKeys...", username.String())
+	// NOTE: We only store userEK/teamEK boxes locally and these are removed in
+	// the LocalDb.Nuke() below so we just delete any deviceEKs here.
+	deviceEKStorage := m.G().GetDeviceEKStorage()
+	if deviceEKStorage != nil {
+		if err := deviceEKStorage.ForceDeleteAll(m.Ctx(), username); err != nil {
+			return err
+		}
+	}
+
+	logger("Deleting %s from config.json...", username.String())
+	if err := m.G().Env.GetConfigWriter().NukeUser(username); err != nil {
+		return err
+	}
+
+	// The config entries we just nuked could still be in memory. Clear them.
+	m.G().Env.GetConfigWriter().SetUserConfig(nil, true /* overwrite; ignored */)
+
+	logger("Clearing the local cache db...")
+	if _, err := m.G().LocalDb.Nuke(); err != nil {
+		return err
+	}
+
+	logger("Clearing the local cache chat db...")
+	if _, err := m.G().LocalChatDb.Nuke(); err != nil {
+		return err
+	}
+
+	logger("Deprovision finished.")
+	return nil
+}

--- a/go/libkb/deprovision.go
+++ b/go/libkb/deprovision.go
@@ -43,12 +43,9 @@ func ClearSecretsOnDeprovision(m MetaContext, username NormalizedUsername) error
 	}
 
 	logger("Deleting %s from config.json...", username.String())
-	if err := m.G().Env.GetConfigWriter().NukeUser(username); err != nil {
+	if err := m.SwitchUserDeprovisionNukeConfig(username); err != nil {
 		return err
 	}
-
-	// The config entries we just nuked could still be in memory. Clear them.
-	m.G().Env.GetConfigWriter().SetUserConfig(nil, true /* overwrite; ignored */)
 
 	logger("Clearing the local cache db...")
 	if _, err := m.G().LocalDb.Nuke(); err != nil {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -634,6 +634,8 @@ type DeviceEKStorage interface {
 	MaxGeneration(ctx context.Context) (keybase1.EkGeneration, error)
 	DeleteExpired(ctx context.Context, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	ClearCache()
+	// Dangerous! Only for deprovisioning.
+	ForceDeleteAll(ctx context.Context, username NormalizedUsername) error
 }
 
 type UserEKBoxStorage interface {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -597,16 +597,16 @@ func (d *Service) hourlyChecks() {
 	})
 	go func() {
 		// do this quickly
-		if err := m.LogoutIfRevoked(); err != nil {
-			m.CDebugf("LogoutIfRevoked error: %s", err)
+		if err := m.LogoutAndDeprovisionIfRevoked(); err != nil {
+			m.CDebugf("LogoutAndDeprovisionIfRevoked error: %s", err)
 		}
 		ekLib := m.G().GetEKLib()
 		ekLib.KeygenIfNeeded(m.Ctx())
 		for {
 			<-ticker.C
 			m.CDebugf("| checking if current device revoked")
-			if err := m.LogoutIfRevoked(); err != nil {
-				m.CDebugf("LogoutIfRevoked error: %s", err)
+			if err := m.LogoutAndDeprovisionIfRevoked(); err != nil {
+				m.CDebugf("LogoutAndDeprovisionIfRevoked error: %s", err)
 			}
 
 			ekLib := m.G().GetEKLib()

--- a/go/service/user_handler.go
+++ b/go/service/user_handler.go
@@ -41,7 +41,7 @@ func (r *userHandler) keyChange(m libkb.MetaContext) error {
 	m.G().KeyfamilyChanged(m.G().Env.GetUID())
 
 	// check if this device was just revoked and if so, log out
-	return m.LogoutIfRevoked()
+	return m.LogoutAndDeprovisionIfRevoked()
 }
 
 func (r *userHandler) identityChange(m libkb.MetaContext) error {


### PR DESCRIPTION
Adds `ForceDeleteAll` to delete deviceEKs on deprovision and nukes the `LocalChatDb` as well. userEKs and teamEKs were already cleared when `LocalDb` is nuked.  Major change is that if we detect we've been revoked (`LogoutAndDeprovisionIfRevoked`), we now do the same secret clearing as deprovisioning. 

cc @patrickxb @maxtaco  