### PR TITLE
set a 10 second dial timeout on gregor conn

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1513,6 +1513,7 @@ func (g *gregorHandler) connectTLS() error {
 		WrapErrorFunc:                 libkb.MakeWrapError(g.G().ExternalG()),
 		InitialReconnectBackoffWindow: func() time.Duration { return g.chatAwareInitialReconnectBackoffWindow(ctx) },
 		ReconnectBackoff:              func() backoff.BackOff { return g.chatAwareReconnectBackoff(ctx) },
+		DialerTimeout:                 10 * time.Second,
 		// We deliberately avoid ForceInitialBackoff here, becuase we don't
 		// want to penalize mobile, which tears down its connection frequently.
 	}


### PR DESCRIPTION
It seems like a `Dial` can just go out to lunch, even if the connection seems ok. Just blowing up the attempt and retrying would likely get us back online. Thankfully, the RPC library already has a feature that lets us set a timeout on `Dial` attempts, so let's try setting it to 10 seconds for the Gregor connection. 