### PR TITLE
Log error on ekbox failure instead of failing kex

### DIFF
--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -293,10 +293,14 @@ func (e *Kex2Provisioner) CounterSign2(input keybase1.Hello2Res) (output keybase
 
 	userEKBoxStorage := m.G().GetUserEKBoxStorage()
 	if len(string(input.DeviceEkKID)) != 0 && userEKBoxStorage != nil {
-		output.UserEkBox, err = e.makeUserEKBox(m, input.DeviceEkKID)
-		if err != nil {
-			return output, err
+		// If we error out here the provisionee will create it's own keys later
+		// but we shouldn't fail kex.
+		userEKBox, ekErr := e.makeUserEKBox(m, input.DeviceEkKID)
+		if ekErr != nil {
+			userEKBox = nil
+			m.CDebugf("Unable to makeUserEKBox %v", ekErr)
 		}
+		output.UserEkBox = userEKBox
 	} else {
 		m.CDebugf("Skipping userEKBox generation empty KID or storage. KID: %v, storage: %v", input.DeviceEkKID, userEKBoxStorage)
 	}


### PR DESCRIPTION
If we get an error when trying to box up our `userEK` during kex just log the error and continue, the provisioned device will have to generate their own keys after provisioning.

cc @oconnor663 