### PR TITLE
PGP select: better defaults, disclaimers, fixes to protected secret key import

### DIFF
--- a/go/client/cmd_pgp_select.go
+++ b/go/client/cmd_pgp_select.go
@@ -55,7 +55,7 @@ Learn more: keybase pgp help select
 `
 
 const importPrivDisclaimer = `You are selecting a PGP key to publish in your profile, and
-importing key to *local*, *encrypted* Keybase keyring.
+importing secret key to *local*, *encrypted* Keybase keyring.
 
 If your GPG key is encrypted, you will be asked for passphrase
 to unlock it. You may be asked *twice* - first by GPG, to export

--- a/go/client/cmd_pgp_select.go
+++ b/go/client/cmd_pgp_select.go
@@ -16,10 +16,10 @@ import (
 )
 
 type CmdPGPSelect struct {
-	query      string
-	multi      bool
-	skipImport bool
-	onlyImport bool
+	query        string
+	multi        bool
+	importSecret bool
+	noPublish    bool
 	libkb.Contextified
 }
 
@@ -31,14 +31,26 @@ func (v *CmdPGPSelect) ParseArgv(ctx *cli.Context) (err error) {
 	}
 	if err == nil {
 		v.multi = ctx.Bool("multi")
-		v.skipImport = ctx.Bool("no-import")
-		v.onlyImport = ctx.Bool("only-import")
-		if v.onlyImport && v.skipImport {
-			err = fmt.Errorf("Can specify only one of --no-import OR --only-import")
+		v.importSecret = ctx.Bool("import")
+		v.noPublish = ctx.Bool("no-publish")
+		if v.noPublish && !v.importSecret {
+			err = fmt.Errorf("Nothing to do - refused to publish with \"--no-publish\" but did not ask to import secret key (\"--import\")")
 		}
 	}
 	return err
 }
+
+const importDisclaimer = `You are selecting a PGP key to sign and publish a statement that you
+own said key, effectively making it part of your Keybase.io identity.
+
+You will be prompted by GPG to unlock your private key - it will be
+used to make a signature that you are the owner of said key.
+
+What you can also do, is importing the secret key to *local, encrypted*
+Keybase keyring, to be able to decrypt or sign using Keybase client.
+See more in documentation: "keybase pgp help select".
+
+`
 
 func (v *CmdPGPSelect) Run() error {
 	c, err := GetPGPClient(v.G())
@@ -53,11 +65,18 @@ func (v *CmdPGPSelect) Run() error {
 		return err
 	}
 
+	if !v.importSecret && !v.noPublish {
+		// The default setting - inform user what's going on and point
+		// to documentation for more options.
+		dui := v.G().UI.GetDumbOutputUI()
+		dui.Printf(importDisclaimer)
+	}
+
 	err = c.PGPSelect(context.TODO(), keybase1.PGPSelectArg{
 		FingerprintQuery: v.query,
 		AllowMulti:       v.multi,
-		SkipImport:       v.skipImport,
-		OnlyImport:       v.onlyImport,
+		SkipImport:       !v.importSecret,
+		OnlyImport:       v.noPublish,
 	})
 	err = AddPGPMultiInstructions(err)
 	return err
@@ -77,26 +96,31 @@ func NewCmdPGPSelect(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 				Usage: "Allow multiple PGP keys.",
 			},
 			cli.BoolFlag{
-				Name:  "no-import",
-				Usage: "Don't import private key to the local Keybase keyring.",
+				Name:  "import",
+				Usage: "Import private key to the local Keybase keyring.",
 			},
 			cli.BoolFlag{
-				Name:  "only-import",
-				Usage: "only import the secret key into the local Keybase keyring.",
+				Name:  "no-publish",
+				Usage: "Only import to Keybase keyring, do not publish on user profile.",
 			},
 		},
 		Description: `"keybase pgp select" looks at the local GnuPG keychain for all
    available secret keys. It then makes those keys available for use with keybase.
    The steps involved are: (1) sign a signature chain link with the selected PGP
    key and the existing device key; (2) push this signature and the public PGP
-   key to the server; (3) copy the PGP secret half into your local Keybase keyring;
-   and (4) encrypt this secret key with Keybase's local key security
-   mechanism.
+   key to the server; and if "--import" flag is passed: (3) copy the PGP secret half
+   into your local Keybase keyring; and (4) encrypt this secret key with Keybase's
+   local key security mechanism.
 
    By default, Keybase suggests only one PGP public key, but if you want to,
-   you can supply the "--multi" flag to override this restriction. If you don't
+   you can supply the "--multi" flag to override this restriction. If you
    want your secret key imported into the local Keybase keyring, then use
-   the "--no-import" flag.
+   the "--import" flag. Importing the secret key to Keybase keyring makes
+   it possible to use Keybase PGP like "pgp decrypt" or "pgp sign".
+
+   If you don't want to publish signature chain link to Keybase servers, use
+   "--no-publish" flag. It's only valid when both "--no-publish" and "--import"
+   flags are used.
 
    This operation will never push your secret key, encrypted or otherwise,
    to the Keybase server.`,

--- a/go/client/cmd_pgp_select.go
+++ b/go/client/cmd_pgp_select.go
@@ -46,9 +46,11 @@ own said key, effectively making it part of your Keybase.io identity.
 You will be prompted by GPG to unlock your private key - it will be
 used to make a signature that you are the owner of said key.
 
-What you can also do, is importing the secret key to *local, encrypted*
-Keybase keyring, to be able to decrypt or sign using Keybase client.
-See more in documentation: "keybase pgp help select".
+You can also import the secret key to *local*, *encrypted* Keybase
+keyring, to be able to decrypt or sign using Keybase client. To do
+that, use "--import" flag.
+
+Learn more: keybase pgp help select
 
 `
 

--- a/go/client/cmd_pgp_select.go
+++ b/go/client/cmd_pgp_select.go
@@ -40,7 +40,7 @@ func (v *CmdPGPSelect) ParseArgv(ctx *cli.Context) (err error) {
 	return err
 }
 
-const importDisclaimer = `You are selecting a PGP key to sign and publish a statement that you
+const selectDisclaimer = `You are selecting a PGP key to sign and publish a statement that you
 own said key, effectively making it part of your Keybase.io identity.
 
 You will be prompted by GPG to unlock your private key - it will be
@@ -51,6 +51,18 @@ keyring, to be able to decrypt or sign using Keybase client. To do
 that, use "--import" flag.
 
 Learn more: keybase pgp help select
+
+`
+
+const importPrivDisclaimer = `You are selecting a PGP key to publish in your profile, and
+importing key to *local*, *encrypted* Keybase keyring.
+
+If your GPG key is encrypted, you will be asked for passphrase
+to unlock it. You may be asked *twice* - first by GPG, to export
+encrypted key bundle, and then by Keybase, to unlock secret key.
+
+Please note that this will not work if your secret key lives on a
+hardware device (like smart cards).
 
 `
 
@@ -67,11 +79,13 @@ func (v *CmdPGPSelect) Run() error {
 		return err
 	}
 
+	dui := v.G().UI.GetDumbOutputUI()
 	if !v.importSecret && !v.noPublish {
 		// The default setting - inform user what's going on and point
 		// to documentation for more options.
-		dui := v.G().UI.GetDumbOutputUI()
-		dui.Printf(importDisclaimer)
+		dui.Printf(selectDisclaimer)
+	} else if v.importSecret {
+		dui.Printf(importPrivDisclaimer)
 	}
 
 	err = c.PGPSelect(context.TODO(), keybase1.PGPSelectArg{

--- a/go/client/cmd_pgp_select.go
+++ b/go/client/cmd_pgp_select.go
@@ -40,15 +40,15 @@ func (v *CmdPGPSelect) ParseArgv(ctx *cli.Context) (err error) {
 	return err
 }
 
-const selectDisclaimer = `You are selecting a PGP key to sign and publish a statement that you
-own said key, effectively making it part of your Keybase.io identity.
+const selectDisclaimer = `You are selecting a PGP key from your local GnuPG keychain, and
+will publish a statement signed with this key to make it part of 
+your Keybase.io identity.
 
-You will be prompted by GPG to unlock your private key - it will be
-used to make a signature that you are the owner of said key.
+Note that GnuPG will prompt you to perform this signature.
 
 You can also import the secret key to *local*, *encrypted* Keybase
-keyring, to be able to decrypt or sign using Keybase client. To do
-that, use "--import" flag.
+keyring, enabling decryption and signing with the Keybase client.
+To do that, use "--import" flag.
 
 Learn more: keybase pgp help select
 
@@ -57,12 +57,12 @@ Learn more: keybase pgp help select
 const importPrivDisclaimer = `You are selecting a PGP key to publish in your profile, and
 importing secret key to *local*, *encrypted* Keybase keyring.
 
-If your GPG key is encrypted, you will be asked for passphrase
-to unlock it. You may be asked *twice* - first by GPG, to export
-encrypted key bundle, and then by Keybase, to unlock secret key.
+If your GnuPG key is encrypted, you will be asked for passphrase
+to unlock it. You may be asked *twice* - first by GnuPG, to export
+encrypted key bundle, and then by Keybase, to unlock the secret key.
 
 Please note that this will not work if your secret key lives on a
-hardware device (like smart cards).
+hardware device (like a smart card or a Yubikey).
 
 `
 
@@ -122,17 +122,17 @@ func NewCmdPGPSelect(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 		},
 		Description: `"keybase pgp select" looks at the local GnuPG keychain for all
    available secret keys. It then makes those keys available for use with keybase.
-   The steps involved are: (1) sign a signature chain link with the selected PGP
-   key and the existing device key; (2) push this signature and the public PGP
-   key to the server; and if "--import" flag is passed: (3) copy the PGP secret half
-   into your local Keybase keyring; and (4) encrypt this secret key with Keybase's
+   The steps involved are: (1a) sign a signature chain link with the selected PGP
+   key and the existing device key; (1b) push this signature and the public PGP
+   key to the server; and if "--import" flag is passed: (2a) copy the PGP secret half
+   into your local Keybase keyring; and (2b) encrypt this secret key with Keybase's
    local key security mechanism.
 
    By default, Keybase suggests only one PGP public key, but if you want to,
    you can supply the "--multi" flag to override this restriction. If you
    want your secret key imported into the local Keybase keyring, then use
-   the "--import" flag. Importing the secret key to Keybase keyring makes
-   it possible to use Keybase PGP like "pgp decrypt" or "pgp sign".
+   the "--import" flag. Importing your secret key to Keybase keyring makes
+   it possible to use Keybase PGP commands like "pgp decrypt" or "pgp sign".
 
    If you don't want to publish signature chain link to Keybase servers, use
    "--no-publish" flag. It's only valid when both "--no-publish" and "--import"

--- a/go/client/cmd_stress.go
+++ b/go/client/cmd_stress.go
@@ -302,6 +302,9 @@ func (c *CmdStress) WantToAddGPGKey(_ context.Context, _ int) (bool, error) {
 func (c *CmdStress) ConfirmDuplicateKeyChosen(_ context.Context, _ int) (bool, error) {
 	return false, nil
 }
+func (c *CmdStress) ConfirmImportSecretToExistingKey(_ context.Context, _ int) (bool, error) {
+	return false, nil
+}
 
 func (c *CmdStress) secretUIProtocol() rpc.Protocol {
 	return keybase1.SecretUiProtocol(c)

--- a/go/client/gpg_ui.go
+++ b/go/client/gpg_ui.go
@@ -81,6 +81,13 @@ func (g GPGUI) ConfirmDuplicateKeyChosen(_ context.Context, _ int) (bool, error)
 	return g.parent.PromptYesNo(PromptDescriptorGPGConfirmDuplicateKey, "You've already selected this public key for use on Keybase. Would you like to update it on Keybase?", libkb.PromptDefaultYes)
 }
 
+func (g GPGUI) ConfirmImportSecretToExistingKey(_ context.Context, _ int) (bool, error) {
+	if g.noPrompt {
+		return false, nil
+	}
+	return g.parent.PromptYesNo(PromptDescriptorGPGConfirmDuplicateKey, "Do you want to import secret half of this key to local Keybase keyring?", libkb.PromptDefaultYes)
+}
+
 func (g GPGUI) GetTTY(_ context.Context) (string, error) {
 	return g.tty, nil
 }

--- a/go/engine/errors.go
+++ b/go/engine/errors.go
@@ -40,7 +40,7 @@ type PGPImportStubbedError struct {
 }
 
 func (e PGPImportStubbedError) Error() string {
-	return fmt.Sprintf("Key %s has private part stubbed - cannot import to Keybase keychain. Try again with --no-import.",
+	return fmt.Sprintf("Key %s has private part stubbed - cannot import to Keybase keychain. Try again without --import.",
 		e.KeyIDString)
 }
 

--- a/go/engine/errors.go
+++ b/go/engine/errors.go
@@ -40,7 +40,7 @@ type PGPImportStubbedError struct {
 }
 
 func (e PGPImportStubbedError) Error() string {
-	return fmt.Sprintf("Key %s has private part stubbed - cannot import to Keybase keychain. Try again without --import.",
+	return fmt.Sprintf("Key %s has a stubbed private key, so we can't import it to the Keybase keychain.",
 		e.KeyIDString)
 }
 

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -224,12 +224,12 @@ func (e *GPGImportKeyEngine) Run(m libkb.MetaContext) (err error) {
 			return fmt.Errorf("ImportKey (secret: true) error: %s", err)
 		}
 
-		if !libkb.FindPGPPrivateKey(bundle) {
-			return PGPImportStubbedError{KeyIDString: selected.GetFingerprint().ToKeyID()}
-		}
-
 		if err := bundle.Unlock(m, "Import of key into Keybase keyring", m.UIs().SecretUI); err != nil {
 			return err
+		}
+
+		if !libkb.FindPGPPrivateKey(bundle) {
+			return PGPImportStubbedError{KeyIDString: selected.GetFingerprint().ToKeyID()}
 		}
 	}
 

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -155,11 +155,9 @@ func (e *GPGImportKeyEngine) Run(m libkb.MetaContext) (err error) {
 
 	publicKeys := me.GetActivePGPKeys(false)
 	duplicate := false
-	hasSecret := false
 	for _, key := range publicKeys {
 		if key.GetFingerprint().Eq(*(selected.GetFingerprint())) {
 			duplicate = true
-			hasSecret = key.HasSecretKey()
 			break
 		}
 	}
@@ -182,7 +180,7 @@ func (e *GPGImportKeyEngine) Run(m libkb.MetaContext) (err error) {
 			return err
 		}
 
-		if !e.arg.SkipImport && !hasSecret {
+		if !e.arg.SkipImport {
 			// Key is duplicate, but caller wants to import secret
 			// half.
 			res, err := m.UIs().GPGUI.ConfirmImportSecretToExistingKey(m.Ctx(), 0)

--- a/go/engine/gpg_test.go
+++ b/go/engine/gpg_test.go
@@ -49,6 +49,10 @@ func (g *gpgtestui) ConfirmDuplicateKeyChosen(_ context.Context, _ int) (bool, e
 	return true, nil
 }
 
+func (g *gpgtestui) ConfirmImportSecretToExistingKey(_ context.Context, _ int) (bool, error) {
+	return false, nil
+}
+
 func (g *gpgtestui) Sign(_ context.Context, arg keybase1.SignArg) (string, error) {
 	fp, err := libkb.PGPFingerprintFromSlice(arg.Fingerprint)
 	if err != nil {

--- a/go/kbtest/ui.go
+++ b/go/kbtest/ui.go
@@ -47,6 +47,10 @@ func (g *gpgtestui) ConfirmDuplicateKeyChosen(_ context.Context, _ int) (bool, e
 	return true, nil
 }
 
+func (g *gpgtestui) ConfirmImportSecretToExistingKey(_ context.Context, _ int) (bool, error) {
+	return false, nil
+}
+
 func (g *gpgtestui) Sign(_ context.Context, _ keybase1.SignArg) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }

--- a/go/protocol/keybase1/gpg_ui.go
+++ b/go/protocol/keybase1/gpg_ui.go
@@ -28,6 +28,10 @@ type ConfirmDuplicateKeyChosenArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
 }
 
+type ConfirmImportSecretToExistingKeyArg struct {
+	SessionID int `codec:"sessionID" json:"sessionID"`
+}
+
 type SelectKeyAndPushOptionArg struct {
 	SessionID int      `codec:"sessionID" json:"sessionID"`
 	Keys      []GPGKey `codec:"keys" json:"keys"`
@@ -49,6 +53,7 @@ type GetTTYArg struct {
 type GpgUiInterface interface {
 	WantToAddGPGKey(context.Context, int) (bool, error)
 	ConfirmDuplicateKeyChosen(context.Context, int) (bool, error)
+	ConfirmImportSecretToExistingKey(context.Context, int) (bool, error)
 	SelectKeyAndPushOption(context.Context, SelectKeyAndPushOptionArg) (SelectKeyRes, error)
 	SelectKey(context.Context, SelectKeyArg) (string, error)
 	Sign(context.Context, SignArg) (string, error)
@@ -87,6 +92,22 @@ func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.ConfirmDuplicateKeyChosen(ctx, (*typedArgs)[0].SessionID)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"confirmImportSecretToExistingKey": {
+				MakeArg: func() interface{} {
+					ret := make([]ConfirmImportSecretToExistingKeyArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ConfirmImportSecretToExistingKeyArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ConfirmImportSecretToExistingKeyArg)(nil), args)
+						return
+					}
+					ret, err = i.ConfirmImportSecretToExistingKey(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -167,6 +188,12 @@ func (c GpgUiClient) WantToAddGPGKey(ctx context.Context, sessionID int) (res bo
 func (c GpgUiClient) ConfirmDuplicateKeyChosen(ctx context.Context, sessionID int) (res bool, err error) {
 	__arg := ConfirmDuplicateKeyChosenArg{SessionID: sessionID}
 	err = c.Cli.Call(ctx, "keybase.1.gpgUi.confirmDuplicateKeyChosen", []interface{}{__arg}, &res)
+	return
+}
+
+func (c GpgUiClient) ConfirmImportSecretToExistingKey(ctx context.Context, sessionID int) (res bool, err error) {
+	__arg := ConfirmImportSecretToExistingKeyArg{SessionID: sessionID}
+	err = c.Cli.Call(ctx, "keybase.1.gpgUi.confirmImportSecretToExistingKey", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/service/gpg.go
+++ b/go/service/gpg.go
@@ -38,6 +38,9 @@ func (r *RemoteGPGUI) WantToAddGPGKey(ctx context.Context, _ int) (bool, error) 
 func (r *RemoteGPGUI) ConfirmDuplicateKeyChosen(ctx context.Context, _ int) (bool, error) {
 	return r.uicli.ConfirmDuplicateKeyChosen(ctx, r.sessionID)
 }
+func (r *RemoteGPGUI) ConfirmImportSecretToExistingKey(ctx context.Context, _ int) (bool, error) {
+	return r.uicli.ConfirmImportSecretToExistingKey(ctx, r.sessionID)
+}
 func (r *RemoteGPGUI) Sign(ctx context.Context, arg keybase1.SignArg) (string, error) {
 	return r.uicli.Sign(ctx, arg)
 }

--- a/protocol/avdl/keybase1/gpg_ui.avdl
+++ b/protocol/avdl/keybase1/gpg_ui.avdl
@@ -11,6 +11,7 @@ protocol gpgUi {
 
   boolean wantToAddGPGKey(int sessionID);
   boolean confirmDuplicateKeyChosen(int sessionID);
+  boolean confirmImportSecretToExistingKey(int sessionID);
   SelectKeyRes selectKeyAndPushOption(int sessionID, array<GPGKey> keys);
   string selectKey(int sessionID, array<GPGKey> keys);
   string sign(bytes msg, bytes fingerprint);

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2496,6 +2496,8 @@ export type GitTeamRepoSettings = $ReadOnly<{channelName?: ?String, chatDisabled
 
 export type GpgUiConfirmDuplicateKeyChosenRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type GpgUiConfirmImportSecretToExistingKeyRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type GpgUiGetTTYRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type GpgUiSelectKeyAndPushOptionRpcParam = $ReadOnly<{keys?: ?Array<GPGKey>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -4218,6 +4220,7 @@ type GitGetAllGitMetadataResult = ?Array<GitRepoResult>
 type GitGetGitMetadataResult = ?Array<GitRepoResult>
 type GitGetTeamRepoSettingsResult = GitTeamRepoSettings
 type GpgUiConfirmDuplicateKeyChosenResult = Boolean
+type GpgUiConfirmImportSecretToExistingKeyResult = Boolean
 type GpgUiGetTTYResult = String
 type GpgUiSelectKeyAndPushOptionResult = SelectKeyRes
 type GpgUiSelectKeyResult = String
@@ -4371,6 +4374,7 @@ type UserSearchResult = ?Array<SearchResult>
 export type IncomingCallMapType = {|
   'keybase.1.gpgUi.wantToAddGPGKey'?: (params: $ReadOnly<{sessionID: Int}>, response: {error: RPCErrorHandler, result: (result: GpgUiWantToAddGPGKeyResult) => void}) => void,
   'keybase.1.gpgUi.confirmDuplicateKeyChosen'?: (params: $ReadOnly<{sessionID: Int}>, response: {error: RPCErrorHandler, result: (result: GpgUiConfirmDuplicateKeyChosenResult) => void}) => void,
+  'keybase.1.gpgUi.confirmImportSecretToExistingKey'?: (params: $ReadOnly<{sessionID: Int}>, response: {error: RPCErrorHandler, result: (result: GpgUiConfirmImportSecretToExistingKeyResult) => void}) => void,
   'keybase.1.gpgUi.selectKeyAndPushOption'?: (params: $ReadOnly<{sessionID: Int, keys?: ?Array<GPGKey>}>, response: {error: RPCErrorHandler, result: (result: GpgUiSelectKeyAndPushOptionResult) => void}) => void,
   'keybase.1.gpgUi.selectKey'?: (params: $ReadOnly<{sessionID: Int, keys?: ?Array<GPGKey>}>, response: {error: RPCErrorHandler, result: (result: GpgUiSelectKeyResult) => void}) => void,
   'keybase.1.gpgUi.sign'?: (params: $ReadOnly<{msg: Bytes, fingerprint: Bytes}>, response: {error: RPCErrorHandler, result: (result: GpgUiSignResult) => void}) => void,

--- a/protocol/json/keybase1/gpg_ui.json
+++ b/protocol/json/keybase1/gpg_ui.json
@@ -45,6 +45,15 @@
       ],
       "response": "boolean"
     },
+    "confirmImportSecretToExistingKey": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": "boolean"
+    },
     "selectKeyAndPushOption": {
       "request": [
         {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2496,6 +2496,8 @@ export type GitTeamRepoSettings = $ReadOnly<{channelName?: ?String, chatDisabled
 
 export type GpgUiConfirmDuplicateKeyChosenRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type GpgUiConfirmImportSecretToExistingKeyRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type GpgUiGetTTYRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type GpgUiSelectKeyAndPushOptionRpcParam = $ReadOnly<{keys?: ?Array<GPGKey>, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -4218,6 +4220,7 @@ type GitGetAllGitMetadataResult = ?Array<GitRepoResult>
 type GitGetGitMetadataResult = ?Array<GitRepoResult>
 type GitGetTeamRepoSettingsResult = GitTeamRepoSettings
 type GpgUiConfirmDuplicateKeyChosenResult = Boolean
+type GpgUiConfirmImportSecretToExistingKeyResult = Boolean
 type GpgUiGetTTYResult = String
 type GpgUiSelectKeyAndPushOptionResult = SelectKeyRes
 type GpgUiSelectKeyResult = String
@@ -4371,6 +4374,7 @@ type UserSearchResult = ?Array<SearchResult>
 export type IncomingCallMapType = {|
   'keybase.1.gpgUi.wantToAddGPGKey'?: (params: $ReadOnly<{sessionID: Int}>, response: {error: RPCErrorHandler, result: (result: GpgUiWantToAddGPGKeyResult) => void}) => void,
   'keybase.1.gpgUi.confirmDuplicateKeyChosen'?: (params: $ReadOnly<{sessionID: Int}>, response: {error: RPCErrorHandler, result: (result: GpgUiConfirmDuplicateKeyChosenResult) => void}) => void,
+  'keybase.1.gpgUi.confirmImportSecretToExistingKey'?: (params: $ReadOnly<{sessionID: Int}>, response: {error: RPCErrorHandler, result: (result: GpgUiConfirmImportSecretToExistingKeyResult) => void}) => void,
   'keybase.1.gpgUi.selectKeyAndPushOption'?: (params: $ReadOnly<{sessionID: Int, keys?: ?Array<GPGKey>}>, response: {error: RPCErrorHandler, result: (result: GpgUiSelectKeyAndPushOptionResult) => void}) => void,
   'keybase.1.gpgUi.selectKey'?: (params: $ReadOnly<{sessionID: Int, keys?: ?Array<GPGKey>}>, response: {error: RPCErrorHandler, result: (result: GpgUiSelectKeyResult) => void}) => void,
   'keybase.1.gpgUi.sign'?: (params: $ReadOnly<{msg: Bytes, fingerprint: Bytes}>, response: {error: RPCErrorHandler, result: (result: GpgUiSignResult) => void}) => void,

--- a/shared/profile/pgp/prove-pgp-import.desktop.js
+++ b/shared/profile/pgp/prove-pgp-import.desktop.js
@@ -13,14 +13,12 @@ class ProvePgpImport extends Component<Props> {
           Import a PGP key
         </Text>
         <Text style={styleBody} type="Body">
-          To upload your existing PGP key to Keybase, please run the following command from your terminal:
+          To register your existing PGP public key on Keybase, please run the following command from your
+          terminal:
         </Text>
         <Box style={styleTerminal}>
           <Text type="TerminalComment"># import a key from gpg's key chain</Text>
           <Text type="Terminal">keybase pgp select</Text>
-          <Text type="TerminalEmpty" />
-          <Text type="TerminalComment"># import from stdin and send the public half to Keybase</Text>
-          <Text type="Terminal">cat privkey.asc | keybase pgp import</Text>
           <Text type="TerminalEmpty" />
           <Text type="TerminalComment"># for more options</Text>
           <Text type="Terminal">keybase pgp help</Text>


### PR DESCRIPTION
Note: it's not necessarily what the ticket asked for. But maybe it could work.  Most importantly, it fixes encrypted key imports :slightly_frowning_face: 

1) `--no-import` is default now. If user wants to import key to KB keyring, they can use `--import` flag.
2) renamed `--only-import` to `--no-publish`. note that `--no-publish` only works with `--import`, otherwise there would be nothing to do.
3) added new gpg ui prompt for when user already has key published, but want to additionally import secret key. user is asked if they want to go ahead and import secret key. Previously this was possible by explicit `pgp select --only-import`, now this case is detected and implicit (but asked by prompt).
To summarise, this improves the following experience:
```
» keybase pgp select
... (key was published to keybase.io but not imported)
# oops, I wanted to import as well.
» keybase pgp select --import --multi
You've already selected this public key for use on Keybase. Would you like to update it on Keybase? [Y/n] y
▶ INFO Key was already up to date.
Do you want to import secret half of this key to local Keybase keyring? [y/N] y
```
4) Added disclaimers where only publishing and importing that explain the process behind the two paths.