### PR TITLE
queue up background load for old pages when loading first page CORE-7917

### DIFF
--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -263,7 +263,6 @@ func TestConvLoaderPageBack(t *testing.T) {
 		})
 		require.NoError(t, err)
 	}
-	// Send kicks off one of these when reading the conversation
 	select {
 	case <-listener.bgConvLoads:
 		require.Fail(t, "no loads here")

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -603,10 +603,11 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 		} else {
 			h.G().FetchRetrier.Success(ctx, uid,
 				NewConversationRetry(h.G(), arg.ConversationID, nil, ThreadLoad))
+			// Load old pages of this conversation on success
+			h.dispatchOldPagesJob(ctx, arg.ConversationID, uid, pagination, resultPagination)
 		}
 	}()
 	defer h.suspendConvLoader(ctx)()
-	defer func() { h.dispatchOldPagesJob(ctx, arg.ConversationID, uid, pagination, resultPagination) }()
 	// Lock conversation while this is running
 	if err := h.G().ConvSource.AcquireConversationLock(ctx, uid, arg.ConversationID); err != nil {
 		return res, err

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2696,6 +2696,68 @@ func TestChatSrvGetThreadNonblockPlaceholderFirst(t *testing.T) {
 	})
 }
 
+func TestChatSrvGetThreadNonblockOldPages(t *testing.T) {
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetThreadNonblock", 1)
+		defer ctc.cleanup()
+		users := ctc.users()
+		if mt == chat1.ConversationMembersType_KBFS {
+			return
+		}
+
+		uid := gregor1.UID(users[0].GetUID().ToBytes())
+		inboxCb := make(chan kbtest.NonblockInboxResult, 100)
+		threadCb := make(chan kbtest.NonblockThreadResult, 100)
+		ui := kbtest.NewChatUI(inboxCb, threadCb, nil, nil)
+		ctc.as(t, users[0]).h.mockChatUI = ui
+		ctx := ctc.as(t, users[0]).startCtx
+		bgConvLoads := make(chan chat1.ConversationID, 10)
+		ctc.as(t, users[0]).h.G().ConvLoader.Start(ctx, uid)
+		ctc.as(t, users[0]).h.G().ConvLoader.(*BackgroundConvLoader).loads = bgConvLoads
+
+		t.Logf("send a bunch of messages")
+		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt)
+		// need two for new conversation, plus the gregor message
+		for i := 0; i < 2; i++ {
+			select {
+			case <-bgConvLoads:
+			case <-time.After(20 * time.Second):
+				require.Fail(t, "no bkg load")
+			}
+		}
+		numMsgs := 20
+		msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
+		for i := 0; i < numMsgs; i++ {
+			mustPostLocalForTest(t, ctc, users[0], conv, msg)
+		}
+		select {
+		case <-bgConvLoads:
+			require.Fail(t, "no more bg loads")
+		default:
+		}
+		_, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(ctx,
+			chat1.GetThreadNonblockArg{
+				ConversationID:   conv.Id,
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+				Pagination:       utils.PresentPagination(&chat1.Pagination{Num: 1}),
+			},
+		)
+		require.NoError(t, err)
+		res := receiveThreadResult(t, threadCb)
+		require.Equal(t, 1, len(res.Messages))
+		select {
+		case <-bgConvLoads:
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no bkg load")
+		}
+		select {
+		case <-bgConvLoads:
+			require.Fail(t, "no more bg loads")
+		default:
+		}
+	})
+}
+
 func TestChatSrvGetThreadNonblock(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetThreadNonblock", 1)

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -51,18 +51,8 @@ func (q inboxDiskQuery) queryMatch(other inboxDiskQuery) bool {
 	return false
 }
 
-func (q inboxDiskQuery) paginationMatch(other inboxDiskQuery) bool {
-	if q.Pagination == nil && other.Pagination == nil {
-		return true
-	}
-	if q.Pagination != nil && other.Pagination != nil {
-		return q.Pagination.Eq(*other.Pagination)
-	}
-	return false
-}
-
 func (q inboxDiskQuery) match(other inboxDiskQuery) bool {
-	return q.queryMatch(other) && q.paginationMatch(other)
+	return q.queryMatch(other) && q.Pagination.Eq(other.Pagination)
 }
 
 type inboxDiskData struct {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -686,14 +686,25 @@ func (f *ConversationFinalizeInfo) BeforeSummary() string {
 	return fmt.Sprintf("(before %s account reset %s)", f.ResetUser, f.ResetDate)
 }
 
-func (p Pagination) Eq(other Pagination) bool {
-	return p.Last == other.Last && bytes.Equal(p.Next, other.Next) &&
-		bytes.Equal(p.Previous, other.Previous) && p.Num == other.Num
+func (p *Pagination) Eq(other *Pagination) bool {
+	if p == nil && other == nil {
+		return true
+	}
+	if p != nil && other != nil {
+		return p.Last == other.Last && bytes.Equal(p.Next, other.Next) &&
+			bytes.Equal(p.Previous, other.Previous) && p.Num == other.Num
+	}
+	return false
 }
 
-func (p Pagination) String() string {
+func (p *Pagination) String() string {
 	return fmt.Sprintf("[Num: %d n: %s p: %s last: %v]", p.Num, hex.EncodeToString(p.Next),
 		hex.EncodeToString(p.Previous), p.Last)
+}
+
+// FirstPage returns true if the pagination object is not pointing in any direction
+func (p *Pagination) FirstPage() bool {
+	return p == nil || (len(p.Next) == 0 && len(p.Previous) == 0)
 }
 
 func (c ConversationLocal) GetMtime() gregor1.Time {

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -41,11 +41,11 @@ let config = {
 }
 
 // Developer settings
-config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
+  config.isDevApplePushToken = true
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
   config.printOutstandingRPCs = true

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -45,9 +45,9 @@ if (__DEV__) {
   config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
-  config.isDevApplePushToken = true
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
+  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -41,13 +41,13 @@ let config = {
 }
 
 // Developer settings
+config.isDevApplePushToken = true
 if (__DEV__) {
   config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
-  config.isDevApplePushToken = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.reduxSagaLoggerMasked = false


### PR DESCRIPTION
If we click into a thread, dispatch background jobs to load the back pages of that thread with low priority. The purpose is if someone decides to scroll up and we don't yet have that part of the thread cached that we can pick it up in the background first. 