### PR TITLE
Open teams - do not list reset members in TeamGet RPC

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1832,6 +1832,15 @@ func (t TeamMembersDetails) ActiveUsernames() map[string]bool {
 	return m
 }
 
+func FilterInactiveMembers(arg []TeamMemberDetails) (ret []TeamMemberDetails) {
+	for _, v := range arg {
+		if v.Active {
+			ret = append(ret, v)
+		}
+	}
+	return ret
+}
+
 func (t TeamName) IsNil() bool {
 	return len(t.Parts) == 0
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -121,7 +121,19 @@ func (h *TeamsHandler) TeamCreateWithSettings(ctx context.Context, arg keybase1.
 func (h *TeamsHandler) TeamGet(ctx context.Context, arg keybase1.TeamGetArg) (res keybase1.TeamDetails, err error) {
 	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamGet(%s)", arg.Name), func() error { return err })()
-	return teams.Details(ctx, h.G().ExternalG(), arg.Name, arg.ForceRepoll)
+
+	res, err = teams.Details(ctx, h.G().ExternalG(), arg.Name, arg.ForceRepoll)
+	if err != nil {
+		return res, err
+	}
+
+	if res.Settings.Open {
+		h.G().Log.CDebugf(ctx, "TeamGet: %q is an open team, filtering reset writers and readers", arg.Name)
+		res.Members.Writers = keybase1.FilterInactiveMembers(res.Members.Writers)
+		res.Members.Readers = keybase1.FilterInactiveMembers(res.Members.Readers)
+	}
+
+	return res, nil
 }
 
 func (h *TeamsHandler) TeamImplicitAdmins(ctx context.Context, arg keybase1.TeamImplicitAdminsArg) (res []keybase1.TeamMemberDetails, err error) {

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -282,16 +282,18 @@ func (u *userPlusDevice) teamSetSettings(teamName string, settings keybase1.Team
 		Settings: settings,
 	})
 	require.NoError(u.tc.T, err)
-	changeByID := false
-	for {
-		select {
-		case arg := <-u.notifications.changeCh:
-			changeByID = arg.Changes.Misc
-		case <-time.After(500 * time.Millisecond * libkb.CITimeMultiplier(u.tc.G)):
-			u.tc.T.Fatal("no notification on teamSetSettings")
-		}
-		if changeByID {
-			return
+	if u.notifications != nil {
+		changeByID := false
+		for {
+			select {
+			case arg := <-u.notifications.changeCh:
+				changeByID = arg.Changes.Misc
+			case <-time.After(500 * time.Millisecond * libkb.CITimeMultiplier(u.tc.G)):
+				u.tc.T.Fatal("no notification on teamSetSettings")
+			}
+			if changeByID {
+				return
+			}
 		}
 	}
 }

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -28,7 +28,11 @@ func HandleRotateRequest(ctx context.Context, g *libkb.GlobalContext, msg keybas
 		return err
 	}
 
-	if len(msg.ResetUsersUntrusted) > 0 && team.IsOpen() {
+	isAdmin := func() bool {
+		role, err := team.myRole(ctx)
+		return err == nil && role.IsOrAbove(keybase1.TeamRole_ADMIN)
+	}
+	if len(msg.ResetUsersUntrusted) > 0 && team.IsOpen() && isAdmin() {
 		if needRP, err := sweepOpenTeamResetMembers(ctx, g, team, msg.ResetUsersUntrusted); err == nil {
 			// If sweepOpenTeamResetMembers does not do anything to
 			// the team, do not load team again later.


### PR DESCRIPTION
This PR fixes two things:
1) When a writer got CLKR, they tried to remove reset members if CLKR provided any. This failed when posting sig. Client would still go to normal rotate_key route, so all was fine, but there is no reason to build change_membersip sig that will be rejected anyway.
2) Change TeamGet to filter reset members if team is open. This was done at RPC level in `service/teams.go` instead of in `service_helper.go : func Details`, because Details is used in other places and I decided that it's better if internal methods do not do this kind of presentation approximation / filtering. Note that it only filters writers and readers - we want to see that an admin needs help in getting back in, and they also don't get removed automatically in CLKR.
3) Added tests for both changes.