### PR TITLE
Add ephemeral cell for unverified convs

### DIFF
--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -187,6 +187,10 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 					Content:   flexibletable.SingleCell{Item: "???"},
 				},
 				flexibletable.Cell{
+					Alignment: flexibletable.Center,
+					Content:   flexibletable.SingleCell{Item: "???"},
+				},
+				flexibletable.Cell{
 					Alignment: flexibletable.Left,
 					Content:   flexibletable.SingleCell{Item: conv.Error.Message},
 				},


### PR DESCRIPTION
fixes a bug where unverified convs got the following error:

`▶ ERROR rendering conversation list view error: existing rows have 5 cells but the new row has 6 cells`

cc @mmaxim @oconnor663 