### PR TITLE
Fix crash on devices page on Android

### DIFF
--- a/shared/devices/device-page/index.js
+++ b/shared/devices/device-page/index.js
@@ -33,7 +33,7 @@ const TimelineMarker = ({first, last, closedCircle}) => (
 const TimelineLabel = ({desc, subDesc, subDescIsName, spacerOnBottom}) => (
   <Box2 direction="vertical" style={styles.timelineLabel}>
     <Text type="Body">{desc}</Text>
-    {subDesc &&
+    {!!subDesc &&
       subDescIsName && (
         <Text type="BodySmall">
           by{' '}
@@ -42,7 +42,7 @@ const TimelineLabel = ({desc, subDesc, subDescIsName, spacerOnBottom}) => (
           </Text>
         </Text>
       )}
-    {subDesc && !subDescIsName && <Text type="BodySmall">{subDesc}</Text>}
+    {!!subDesc && !subDescIsName && <Text type="BodySmall">{subDesc}</Text>}
     {spacerOnBottom && <Box style={{height: 15}} />}
   </Box2>
 )


### PR DESCRIPTION
@keybase/react-hackers 

I don't think this crash was a recent regression -- it's only the *first* device you ever provisioned that crashes, which is why I didn't see it during checklist.  (My first device is long revoked.)

`subDesc` usually contains the name of the device that provisioned the device in question.  And there's no such device for your first device, leading to an empty string and the standard Android YogaNode crash in that case.