### PR TITLE
Rework edit message and quote message flow

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -188,7 +188,7 @@ type _MessageSetEditingPayload = $ReadOnly<{|
 type _MessageSetQuotingPayload = $ReadOnly<{|
   sourceConversationIDKey: Types.ConversationIDKey,
   targetConversationIDKey: Types.ConversationIDKey,
-  ordinal: ?Types.Ordinal,
+  ordinal: Types.Ordinal,
 |}>
 type _MessageWasEditedPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -981,7 +981,7 @@ const getIdentifyBehavior = (state: TypedState, conversationIDKey: Types.Convers
 
 const messageReplyPrivately = (action: Chat2Gen.MessageReplyPrivatelyPayload, state: TypedState) => {
   const {sourceConversationIDKey, ordinal} = action.payload
-  const message = Constants.getMessageMap(state, sourceConversationIDKey).get(ordinal)
+  const message = Constants.getMessage(state, sourceConversationIDKey, ordinal)
   if (!message) {
     logger.warn("Can't find message to reply to", ordinal)
     return
@@ -1007,7 +1007,7 @@ const messageReplyPrivatelySuccess = (results: Array<any>, action: Chat2Gen.Mess
 
 const messageEdit = (action: Chat2Gen.MessageEditPayload, state: TypedState) => {
   const {conversationIDKey, text, ordinal} = action.payload
-  const message = Constants.getMessageMap(state, conversationIDKey).get(ordinal)
+  const message = Constants.getMessage(state, conversationIDKey, ordinal)
   if (!message) {
     logger.warn("Can't find message to edit", ordinal)
     return
@@ -1451,7 +1451,7 @@ function* attachmentDownload(action: Chat2Gen.AttachmentDownloadPayload) {
     return
   }
   const state: TypedState = yield Saga.select()
-  let message = Constants.getMessageMap(state, conversationIDKey).get(ordinal)
+  let message = Constants.getMessage(state, conversationIDKey, ordinal)
 
   if (!message || message.type !== 'attachment') {
     throw new Error('Trying to download missing / incorrect message?')
@@ -1659,7 +1659,7 @@ const markThreadAsRead = (
 const deleteMessageHistory = (action: Chat2Gen.MessageDeletePayload, state: TypedState) => {
   const {conversationIDKey, ordinal} = action.payload
   const meta = Constants.getMeta(state, conversationIDKey)
-  const message = Constants.getMessageMap(state, conversationIDKey).get(ordinal)
+  const message = Constants.getMessage(state, conversationIDKey, ordinal)
   if (!message) {
     throw new Error('Deleting message history with no message?')
   }
@@ -1739,7 +1739,7 @@ const mobileChangeSelection = (_: any, state: TypedState) => {
 function* mobileMessageAttachmentShare(action: Chat2Gen.MessageAttachmentNativeSharePayload) {
   const {conversationIDKey, ordinal} = action.payload
   let state: TypedState = yield Saga.select()
-  let message = Constants.getMessageMap(state, conversationIDKey).get(ordinal)
+  let message = Constants.getMessage(state, conversationIDKey, ordinal)
   if (!message || message.type !== 'attachment') {
     throw new Error('Invalid share message')
   }
@@ -1754,7 +1754,7 @@ function* mobileMessageAttachmentShare(action: Chat2Gen.MessageAttachmentNativeS
 function* mobileMessageAttachmentSave(action: Chat2Gen.MessageAttachmentNativeSavePayload) {
   const {conversationIDKey, ordinal} = action.payload
   let state: TypedState = yield Saga.select()
-  let message = Constants.getMessageMap(state, conversationIDKey).get(ordinal)
+  let message = Constants.getMessage(state, conversationIDKey, ordinal)
   if (!message || message.type !== 'attachment') {
     throw new Error('Invalid share message')
   }

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -169,7 +169,7 @@
     "messageSetQuoting": {
       "sourceConversationIDKey": "Types.ConversationIDKey",
       "targetConversationIDKey": "Types.ConversationIDKey",
-      "ordinal": "?Types.Ordinal"
+      "ordinal": "Types.Ordinal"
     },
     // Reply privately to a message with quoting
     "messageReplyPrivately": {

--- a/shared/chat/conversation/attachment-fullscreen/container.js
+++ b/shared/chat/conversation/attachment-fullscreen/container.js
@@ -14,7 +14,7 @@ const blankMessage = Constants.makeMessageAttachment({})
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   const conversationIDKey = ownProps.routeProps.get('conversationIDKey')
   const ordinal = ownProps.routeProps.get('ordinal')
-  const message = Constants.getMessageMap(state, conversationIDKey).get(ordinal, blankMessage)
+  const message = Constants.getMessage(state, conversationIDKey, ordinal) || blankMessage
   return {
     message: message.type === 'attachment' ? message : blankMessage,
   }

--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -30,10 +30,10 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
   const _you = state.config.username || ''
 
   return {
-    _editText: editInfo ? editInfo.text : '',
+    editText: editInfo ? editInfo.text : '',
     _editOrdinal: editInfo ? editInfo.ordinal : null,
-    _quoteCounter: quoteInfo ? quoteInfo.counter : 0,
-    _quoteText: quoteInfo ? quoteInfo.text : '',
+    quoteCounter: quoteInfo ? quoteInfo.counter : 0,
+    quoteText: quoteInfo ? quoteInfo.text : '',
     _you,
     conversationIDKey,
     typing: Constants.getTyping(state, conversationIDKey),
@@ -89,9 +89,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
   },
   typing: stateProps.typing,
 
-  _editText: stateProps._editText,
-  _quoteCounter: stateProps._quoteCounter,
-  _quoteText: stateProps._quoteText,
+  editText: stateProps.editText,
+  quoteCounter: stateProps.quoteCounter,
+  quoteText: stateProps.quoteText,
 
   getUnsentText: () => getUnsentText(stateProps.conversationIDKey),
   setUnsentText: (text: string) => setUnsentText(stateProps.conversationIDKey, text),

--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -24,7 +24,6 @@ const setUnsentText = (conversationIDKey: Types.ConversationIDKey, text: string)
 }
 
 const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
-  const meta = Constants.getMeta(state, conversationIDKey)
   const editInfo = Constants.getEditInfo(state, conversationIDKey)
   const quoteInfo = Constants.getQuoteInfo(state, conversationIDKey)
 
@@ -36,7 +35,6 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
     _quoteCounter: quoteInfo ? quoteInfo.counter : 0,
     _quoteText: quoteInfo ? quoteInfo.text : '',
     _you,
-    channelName: meta.channelname,
     conversationIDKey,
     typing: Constants.getTyping(state, conversationIDKey),
   }
@@ -75,7 +73,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 
 const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
   conversationIDKey: stateProps.conversationIDKey,
-  channelName: stateProps.channelName,
   isEditing: !!stateProps._editOrdinal,
   focusInputCounter: ownProps.focusInputCounter,
   clearInboxFilter: dispatchProps.clearInboxFilter,

--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -29,11 +29,12 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
   const _editingMessage: ?Types.Message = editingState
     ? Constants.getMessageMap(state, conversationIDKey).get(editingState.ordinal)
     : null
-  const quotingState = Constants.getQuotingState(
-    state, conversationIDKey)
+  const quotingState = Constants.getQuotingState(state)
   let _quotingMessage: ?Types.Message = quotingState
     ? Constants.getMessageMap(state, quotingState.sourceConversationIDKey).get(quotingState.ordinal)
     : null
+
+  const _quoteTarget = quotingState ? quotingState.targetConversationIDKey : null
 
   const _you = state.config.username || ''
   const injectedInputMessage: ?Types.Message = _editingMessage || _quotingMessage || null
@@ -47,6 +48,7 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
     _editingMessage,
     _quotingCounter: quotingState ? quotingState.counter : 0,
     _quotingMessage,
+    _quoteTarget,
     _you,
     channelName: meta.channelname,
     conversationIDKey,
@@ -114,6 +116,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
   _editingMessage: stateProps._editingMessage,
   _quotingCounter: stateProps._quotingCounter,
   _quotingMessage: stateProps._quotingMessage,
+  _quoteTarget: stateProps._quoteTarget,
   injectedInput: stateProps.injectedInput,
 
   getUnsentText: () => getUnsentText(stateProps.conversationIDKey),

--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -25,9 +25,9 @@ const setUnsentText = (conversationIDKey: Types.ConversationIDKey, text: string)
 
 const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
-  const editingState = Constants.getEditingState(state, conversationIDKey)
-  const _editingMessage: ?Types.Message = editingState
-    ? Constants.getMessageMap(state, conversationIDKey).get(editingState.ordinal)
+  const editingOrdinal = Constants.getEditingOrdinal(state, conversationIDKey)
+  const _editingMessage: ?Types.Message = editingOrdinal
+    ? Constants.getMessageMap(state, conversationIDKey).get(editingOrdinal)
     : null
   const quotingState = Constants.getQuotingState(state)
   let _quotingMessage: ?Types.Message = quotingState
@@ -44,7 +44,6 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
       : ''
 
   return {
-    _editingCounter: editingState ? editingState.counter : 0,
     _editingMessage,
     _quotingCounter: quotingState ? quotingState.counter : 0,
     _quotingMessage,
@@ -112,7 +111,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
   },
   typing: stateProps.typing,
 
-  _editingCounter: stateProps._editingCounter,
   _editingMessage: stateProps._editingMessage,
   _quotingCounter: stateProps._quotingCounter,
   _quotingMessage: stateProps._quotingMessage,

--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -26,30 +26,18 @@ const setUnsentText = (conversationIDKey: Types.ConversationIDKey, text: string)
 const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
   const editInfo = Constants.getEditInfo(state, conversationIDKey)
-  const quotingState = Constants.getQuotingState(state)
-  let _quotingMessage: ?Types.Message = quotingState
-    ? Constants.getMessageMap(state, quotingState.sourceConversationIDKey).get(quotingState.ordinal)
-    : null
-
-  const _quoteTarget = quotingState ? quotingState.targetConversationIDKey : null
+  const quoteInfo = Constants.getQuoteInfo(state, conversationIDKey)
 
   const _you = state.config.username || ''
-  const injectedInputMessage: ?Types.Message = _quotingMessage || null
-  const injectedInput: string =
-    injectedInputMessage && injectedInputMessage.type === 'text'
-      ? injectedInputMessage.text.stringValue()
-      : ''
 
   return {
     _editText: editInfo ? editInfo.text : '',
     _editOrdinal: editInfo ? editInfo.ordinal : null,
-    _quotingCounter: quotingState ? quotingState.counter : 0,
-    _quotingMessage,
-    _quoteTarget,
+    _quoteCounter: quoteInfo ? quoteInfo.counter : 0,
+    _quoteText: quoteInfo ? quoteInfo.text : '',
     _you,
     channelName: meta.channelname,
     conversationIDKey,
-    injectedInput,
     typing: Constants.getTyping(state, conversationIDKey),
   }
 }
@@ -105,10 +93,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
   typing: stateProps.typing,
 
   _editText: stateProps._editText,
-  _quotingCounter: stateProps._quotingCounter,
-  _quotingMessage: stateProps._quotingMessage,
-  _quoteTarget: stateProps._quoteTarget,
-  injectedInput: stateProps.injectedInput,
+  _quoteCounter: stateProps._quoteCounter,
+  _quoteText: stateProps._quoteText,
 
   getUnsentText: () => getUnsentText(stateProps.conversationIDKey),
   setUnsentText: (text: string) => setUnsentText(stateProps.conversationIDKey, text),

--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -25,16 +25,15 @@ const setUnsentText = (conversationIDKey: Types.ConversationIDKey, text: string)
 
 const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
-  const editingOrdinal = Constants.getEditingOrdinal(state, conversationIDKey)
-  const _editingMessage: ?Types.Message = editingOrdinal
-    ? Constants.getMessageMap(state, conversationIDKey).get(editingOrdinal)
+  const editingState = Constants.getEditingState(state, conversationIDKey)
+  const _editingMessage: ?Types.Message = editingState
+    ? Constants.getMessageMap(state, conversationIDKey).get(editingState.ordinal)
     : null
-  const quote = Constants.getQuotingOrdinalAndSource(state, conversationIDKey)
-  let _quotingMessage: ?Types.Message = null
-  if (quote) {
-    const {ordinal, sourceConversationIDKey} = quote
-    _quotingMessage = ordinal ? Constants.getMessageMap(state, sourceConversationIDKey).get(ordinal) : null
-  }
+  const quotingState = Constants.getQuotingState(
+    state, conversationIDKey)
+  let _quotingMessage: ?Types.Message = quotingState
+    ? Constants.getMessageMap(state, quotingState.sourceConversationIDKey).get(quotingState.ordinal)
+    : null
 
   const _you = state.config.username || ''
   const injectedInputMessage: ?Types.Message = _editingMessage || _quotingMessage || null
@@ -44,10 +43,12 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
       : ''
 
   return {
+    _editingCounter: editingState ? editingState.counter : 0,
     _editingMessage,
-    _meta: meta,
+    _quotingCounter: quotingState ? quotingState.counter : 0,
     _quotingMessage,
     _you,
+    channelName: meta.channelname,
     conversationIDKey,
     injectedInput,
     typing: Constants.getTyping(state, conversationIDKey),
@@ -95,7 +96,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 
 const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
   conversationIDKey: stateProps.conversationIDKey,
-  channelName: stateProps._meta.channelname,
+  channelName: stateProps.channelName,
   isEditing: !!stateProps._editingMessage,
   focusInputCounter: ownProps.focusInputCounter,
   clearInboxFilter: dispatchProps.clearInboxFilter,
@@ -121,8 +122,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
   },
   typing: stateProps.typing,
 
-  _quotingMessage: stateProps._quotingMessage,
+  _editingCounter: stateProps._editingCounter,
   _editingMessage: stateProps._editingMessage,
+  _quotingCounter: stateProps._quotingCounter,
+  _quotingMessage: stateProps._quotingMessage,
   injectedInput: stateProps.injectedInput,
 
   getUnsentText: () => getUnsentText(stateProps.conversationIDKey),

--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -62,14 +62,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     ),
   _onCancelEditing: (conversationIDKey: Types.ConversationIDKey) =>
     dispatch(Chat2Gen.createMessageSetEditing({conversationIDKey, ordinal: null})),
-  _onCancelQuoting: (conversationIDKey: Types.ConversationIDKey) =>
-    dispatch(
-      Chat2Gen.createMessageSetQuoting({
-        ordinal: null,
-        sourceConversationIDKey: conversationIDKey,
-        targetConversationIDKey: conversationIDKey,
-      })
-    ),
   _onEditLastMessage: (conversationIDKey: Types.ConversationIDKey, you: string) =>
     dispatch(
       Chat2Gen.createMessageSetEditing({
@@ -102,11 +94,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
   clearInboxFilter: dispatchProps.clearInboxFilter,
   onAttach: (paths: Array<string>) => dispatchProps._onAttach(stateProps.conversationIDKey, paths),
   onEditLastMessage: () => dispatchProps._onEditLastMessage(stateProps.conversationIDKey, stateProps._you),
-  onCancelEditing: () => {
-    dispatchProps._onCancelQuoting(stateProps.conversationIDKey)
-    dispatchProps._onCancelEditing(stateProps.conversationIDKey)
-  },
-  onCancelQuoting: () => dispatchProps._onCancelQuoting(stateProps.conversationIDKey),
+  onCancelEditing: () => dispatchProps._onCancelEditing(stateProps.conversationIDKey),
   onSubmit: (text: string) => {
     const em = stateProps._editingMessage
     if (em) {

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -20,15 +20,6 @@ class Input extends React.Component<InputProps> {
     this._input && this._input.focus()
   }
 
-  _inputMoveToEnd = () => {
-    if (this._input) {
-      this._input.transformText(({text, selection}) => ({
-        text,
-        selection: {start: text.length, end: text.length},
-      }))
-    }
-  }
-
   _onCancelQuoting = () => {
     this.props._quotingMessage && this.props.onCancelQuoting()
   }

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -4,7 +4,6 @@ import {Input as TextInput} from '../../../../common-adapters'
 import MentionInput from './mention-input'
 import {type InputProps} from './types'
 import {throttle} from 'lodash-es'
-import {formatTextForQuoting} from '../../../../util/chat'
 
 // Standalone throttled function to ensure we never accidentally recreate it and break the throttling
 const throttled = throttle((f, param) => f(param), 1000)
@@ -57,8 +56,7 @@ class Input extends React.Component<InputProps> {
     }
 
     if (!prevProps.isEditing && this.props.isEditing) {
-      const injectedInput = this.props.injectedInput
-      this._setText(injectedInput)
+      this._setText(this.props._editText)
       this._inputFocus()
       return
     }
@@ -68,13 +66,9 @@ class Input extends React.Component<InputProps> {
       return
     }
 
-    if (
-      this.props._quotingCounter !== this._lastQuote &&
-      this.props._quoteTarget === this.props.conversationIDKey
-    ) {
-      this._lastQuote = this.props._quotingCounter
-      const injectedInput = this.props.injectedInput
-      this._setText(formatTextForQuoting(injectedInput))
+    if (this.props._quoteCounter && this.props._quoteCounter !== this._lastQuote) {
+      this._lastQuote = this.props._quoteCounter
+      this._setText(this.props._quoteText)
       this._inputFocus()
       return
     }

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -9,6 +9,8 @@ import {throttle} from 'lodash-es'
 const throttled = throttle((f, param) => f(param), 1000)
 
 class Input extends React.Component<InputProps> {
+  _lastQuote: ?number
+
   _input: ?TextInput
 
   _inputSetRef = (input: ?TextInput) => {
@@ -67,7 +69,7 @@ class Input extends React.Component<InputProps> {
       }
     }
 
-    if (this.props._quoteCounter && this.props._quoteCounter > prevProps._quoteCounter) {
+    if (this.props._quoteCounter && this.props._quoteCounter !== this._lastQuote) {
       this._setText(this.props._quoteText)
       this._inputFocus()
       return

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -9,9 +9,13 @@ import {throttle} from 'lodash-es'
 const throttled = throttle((f, param) => f(param), 1000)
 
 class Input extends React.Component<InputProps> {
-  _lastQuote: ?number
-
+  _lastQuote: number
   _input: ?TextInput
+
+  constructor(props: InputProps) {
+    super(props)
+    this._lastQuote = 0
+  }
 
   _inputSetRef = (input: ?TextInput) => {
     this._input = input
@@ -69,7 +73,8 @@ class Input extends React.Component<InputProps> {
       }
     }
 
-    if (this.props._quoteCounter && this.props._quoteCounter !== this._lastQuote) {
+    if (this.props._quoteCounter > this._lastQuote) {
+      this._lastQuote = this.props._quoteCounter
       this._setText(this.props._quoteText)
       this._inputFocus()
       return

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 import {Input as TextInput} from '../../../../common-adapters'
-import {isMobile} from '../../../../util/container'
 import MentionInput from './mention-input'
 import {type InputProps} from './types'
 import {throttle} from 'lodash-es'
@@ -66,28 +65,26 @@ class Input extends React.Component<InputProps> {
   componentWillReceiveProps = (nextProps: InputProps) => {
     const props: InputProps = this.props
 
-    // Fill in the input with an edit, quote, or unsent text
-    if (
-      (nextProps._quotingMessage && nextProps._quotingMessage !== props._quotingMessage) ||
-      nextProps._editingMessage !== props._editingMessage
-    ) {
-      this._setText('') // blow away any unset stuff if we go into an edit/quote, else you edit / cancel / switch tabs and come back and you see the unsent value
+    if (nextProps._editingCounter !== this.props._editingCounter) {
+      // blow away any unset stuff if we go into an edit/quote, else you edit / cancel / switch tabs and come back and you see the unsent value
+      this._setText('')
       const injectedInput = nextProps.injectedInput
-      this._setText(
-        nextProps._quotingMessage && !nextProps._editingMessage
-          ? formatTextForQuoting(injectedInput)
-          : injectedInput,
-        true
-      )
-      !isMobile && this._inputMoveToEnd()
+      this._setText(injectedInput, true)
       this._inputFocus()
-    } else if (props.conversationIDKey !== nextProps.conversationIDKey && !nextProps.injectedInput) {
-      const text = nextProps.getUnsentText()
-      this._setText(text, true)
+      return
     }
 
-    if (nextProps.isEditing && !props.isEditing) {
+    if (nextProps._quotingCounter !== this.props._quotingCounter) {
+      this._setText('')
+      const injectedInput = nextProps.injectedInput
+      this._setText(formatTextForQuoting(injectedInput), true)
       this._inputFocus()
+      return
+    }
+
+    if (props.conversationIDKey !== nextProps.conversationIDKey) {
+      const text = nextProps.getUnsentText()
+      this._setText(text, true)
     }
   }
 

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -50,6 +50,8 @@ class Input extends React.Component<InputProps> {
   }
 
   componentDidMount = () => {
+    this._lastQuote = this.props._quoteCounter
+
     const text = this.props.getUnsentText()
     this._setText(text, true)
   }

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -56,13 +56,15 @@ class Input extends React.Component<InputProps> {
       this._inputFocus()
     }
 
-    if (
-      prevProps.conversationIDKey === this.props.conversationIDKey &&
-      this.props._editingCounter !== prevProps._editingCounter
-    ) {
+    if (!prevProps.isEditing && this.props.isEditing) {
       const injectedInput = this.props.injectedInput
       this._setText(injectedInput)
       this._inputFocus()
+      return
+    }
+
+    if (prevProps.isEditing && !this.props.isEditing) {
+      this._setText('')
       return
     }
 

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -50,6 +50,7 @@ class Input extends React.Component<InputProps> {
   }
 
   componentDidMount = () => {
+    // Set lastQuote so we only inject quoted text after we mount.
     this._lastQuote = this.props._quoteCounter
 
     const text = this.props.getUnsentText()

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -21,7 +21,7 @@ class Input extends React.Component<InputProps> {
   }
 
   _onCancelQuoting = () => {
-    this.props._quotingMessage && this.props.onCancelQuoting()
+    // this.props._quotingMessage && this.props.onCancelQuoting()
   }
 
   _onSubmit = (text: string) => {
@@ -54,26 +54,17 @@ class Input extends React.Component<InputProps> {
   }
 
   componentWillReceiveProps = (nextProps: InputProps) => {
-    const props: InputProps = this.props
-
-    if (nextProps._editingCounter !== this.props._editingCounter) {
-      // blow away any unset stuff if we go into an edit/quote, else you edit / cancel / switch tabs and come back and you see the unsent value
-      this._setText('')
-      const injectedInput = nextProps.injectedInput
-      this._setText(injectedInput, true)
-      this._inputFocus()
-      return
-    }
-
-    if (nextProps._quotingCounter !== this.props._quotingCounter) {
-      this._setText('')
-      const injectedInput = nextProps.injectedInput
-      this._setText(formatTextForQuoting(injectedInput), true)
-      this._inputFocus()
-      return
-    }
-
-    if (props.conversationIDKey !== nextProps.conversationIDKey) {
+    if (this.props.conversationIDKey === nextProps.conversationIDKey) {
+      if (nextProps._editingCounter !== this.props._editingCounter) {
+        const injectedInput = nextProps.injectedInput
+        this._setText(injectedInput)
+        this._inputFocus()
+      } else if (nextProps._quotingCounter !== this.props._quotingCounter) {
+        const injectedInput = nextProps.injectedInput
+        this._setText(formatTextForQuoting(injectedInput))
+        this._inputFocus()
+      }
+    } else {
       const text = nextProps.getUnsentText()
       this._setText(text, true)
     }

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -20,10 +20,6 @@ class Input extends React.Component<InputProps> {
     this._input && this._input.focus()
   }
 
-  _onCancelQuoting = () => {
-    // this.props._quotingMessage && this.props.onCancelQuoting()
-  }
-
   _onSubmit = (text: string) => {
     this.props.onSubmit(text)
     this._setText('')
@@ -80,7 +76,6 @@ class Input extends React.Component<InputProps> {
     return (
       <MentionInput
         {...this.props}
-        onCancelQuoting={this._onCancelQuoting}
         onSubmit={this._onSubmit}
         inputSetRef={this._inputSetRef}
         onChangeText={this._onChangeText}

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -9,8 +9,6 @@ import {throttle} from 'lodash-es'
 const throttled = throttle((f, param) => f(param), 1000)
 
 class Input extends React.Component<InputProps> {
-  _lastQuote: ?number
-
   _input: ?TextInput
 
   _inputSetRef = (input: ?TextInput) => {
@@ -55,19 +53,21 @@ class Input extends React.Component<InputProps> {
       this._inputFocus()
     }
 
-    if (!prevProps.isEditing && this.props.isEditing) {
-      this._setText(this.props._editText)
-      this._inputFocus()
-      return
+    // Only trigger edit changes when on the same conversation.
+    if (prevProps.conversationIDKey === this.props.conversationIDKey) {
+      if (!prevProps.isEditing && this.props.isEditing) {
+        this._setText(this.props._editText)
+        this._inputFocus()
+        return
+      }
+
+      if (prevProps.isEditing && !this.props.isEditing) {
+        this._setText('')
+        return
+      }
     }
 
-    if (prevProps.isEditing && !this.props.isEditing) {
-      this._setText('')
-      return
-    }
-
-    if (this.props._quoteCounter && this.props._quoteCounter !== this._lastQuote) {
-      this._lastQuote = this.props._quoteCounter
+    if (this.props._quoteCounter && this.props._quoteCounter > prevProps._quoteCounter) {
       this._setText(this.props._quoteText)
       this._inputFocus()
       return

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -10,6 +10,8 @@ import {formatTextForQuoting} from '../../../../util/chat'
 const throttled = throttle((f, param) => f(param), 1000)
 
 class Input extends React.Component<InputProps> {
+  _lastQuote: ?number
+
   _input: ?TextInput
 
   _inputSetRef = (input: ?TextInput) => {
@@ -49,26 +51,35 @@ class Input extends React.Component<InputProps> {
     this._setText(text, true)
   }
 
-  componentWillReceiveProps = (nextProps: InputProps) => {
-    if (this.props.conversationIDKey === nextProps.conversationIDKey) {
-      if (nextProps._editingCounter !== this.props._editingCounter) {
-        const injectedInput = nextProps.injectedInput
-        this._setText(injectedInput)
-        this._inputFocus()
-      } else if (nextProps._quotingCounter !== this.props._quotingCounter) {
-        const injectedInput = nextProps.injectedInput
-        this._setText(formatTextForQuoting(injectedInput))
-        this._inputFocus()
-      }
-    } else {
-      const text = nextProps.getUnsentText()
-      this._setText(text, true)
-    }
-  }
-
   componentDidUpdate = (prevProps: InputProps) => {
     if (this.props.focusInputCounter !== prevProps.focusInputCounter) {
       this._inputFocus()
+    }
+
+    if (
+      prevProps.conversationIDKey === this.props.conversationIDKey &&
+      this.props._editingCounter !== prevProps._editingCounter
+    ) {
+      const injectedInput = this.props.injectedInput
+      this._setText(injectedInput)
+      this._inputFocus()
+      return
+    }
+
+    if (
+      this.props._quotingCounter !== this._lastQuote &&
+      this.props._quoteTarget === this.props.conversationIDKey
+    ) {
+      this._lastQuote = this.props._quotingCounter
+      const injectedInput = this.props.injectedInput
+      this._setText(formatTextForQuoting(injectedInput))
+      this._inputFocus()
+      return
+    }
+
+    if (prevProps.conversationIDKey !== this.props.conversationIDKey) {
+      const text = this.props.getUnsentText()
+      this._setText(text, true)
     }
   }
 

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -61,7 +61,10 @@ class Input extends React.Component<InputProps> {
       this._inputFocus()
     }
 
-    // Only trigger edit changes when on the same conversation.
+    // Inject the appropriate text when entering or existing edit
+    // mode, but only when on the same conversation; otherwise we'd
+    // incorrectly inject when switching to/from a conversation with
+    // an unsent edit.
     if (prevProps.conversationIDKey === this.props.conversationIDKey) {
       if (!prevProps.isEditing && this.props.isEditing) {
         this._setText(this.props._editText)
@@ -75,6 +78,8 @@ class Input extends React.Component<InputProps> {
       }
     }
 
+    // Inject the appropriate text when quoting. Keep track of the
+    // last quote we did so as to inject exactly once.
     if (this.props._quoteCounter > this._lastQuote) {
       this._lastQuote = this.props._quoteCounter
       this._setText(this.props._quoteText)
@@ -82,6 +87,8 @@ class Input extends React.Component<InputProps> {
       return
     }
 
+    // Otherwise, inject unsent text. This must come after quote
+    // handling, so as to handle the 'Reply Privately' case.
     if (prevProps.conversationIDKey !== this.props.conversationIDKey) {
       const text = this.props.getUnsentText()
       this._setText(text, true)

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -51,7 +51,7 @@ class Input extends React.Component<InputProps> {
 
   componentDidMount = () => {
     // Set lastQuote so we only inject quoted text after we mount.
-    this._lastQuote = this.props._quoteCounter
+    this._lastQuote = this.props.quoteCounter
 
     const text = this.props.getUnsentText()
     this._setText(text, true)
@@ -68,7 +68,7 @@ class Input extends React.Component<InputProps> {
     // an unsent edit.
     if (prevProps.conversationIDKey === this.props.conversationIDKey) {
       if (!prevProps.isEditing && this.props.isEditing) {
-        this._setText(this.props._editText)
+        this._setText(this.props.editText)
         this._inputFocus()
         return
       }
@@ -81,9 +81,9 @@ class Input extends React.Component<InputProps> {
 
     // Inject the appropriate text when quoting. Keep track of the
     // last quote we did so as to inject exactly once.
-    if (this.props._quoteCounter > this._lastQuote) {
-      this._lastQuote = this.props._quoteCounter
-      this._setText(this.props._quoteText)
+    if (this.props.quoteCounter > this._lastQuote) {
+      this._lastQuote = this.props.quoteCounter
+      this._setText(this.props.quoteText)
       this._inputFocus()
       return
     }

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -73,11 +73,8 @@ const InputContainer = (props: Props) => {
     typing: props.typing,
 
     _editText: '',
-    _quotingCounter: 0,
-    _quotingMessage: null,
-    _quoteTarget: null,
-
-    injectedInput: '',
+    _quoteCounter: 0,
+    _quoteText: '',
 
     getUnsentText: () => {
       action('getUnsentText')()

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -72,7 +72,7 @@ const InputContainer = (props: Props) => {
     pendingWaiting: props.pendingWaiting,
     typing: props.typing,
 
-    _editingMessage: null,
+    _editText: '',
     _quotingCounter: 0,
     _quotingMessage: null,
     _quoteTarget: null,

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -72,7 +72,6 @@ const InputContainer = (props: Props) => {
     pendingWaiting: props.pendingWaiting,
     typing: props.typing,
 
-    _editingCounter: 0,
     _editingMessage: null,
     _quotingCounter: 0,
     _quotingMessage: null,

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -76,6 +76,7 @@ const InputContainer = (props: Props) => {
     _editingMessage: null,
     _quotingCounter: 0,
     _quotingMessage: null,
+    _quoteTarget: null,
 
     injectedInput: '',
 

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -72,8 +72,10 @@ const InputContainer = (props: Props) => {
     pendingWaiting: props.pendingWaiting,
     typing: props.typing,
 
-    _quotingMessage: null,
+    _editingCounter: 0,
     _editingMessage: null,
+    _quotingCounter: 0,
+    _quotingMessage: null,
 
     injectedInput: '',
 

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -53,7 +53,6 @@ const boxProps = {
 const InputContainer = (props: Props) => {
   const inputProps: InputProps = {
     conversationIDKey: stringToConversationIDKey('fake conversation id key'),
-    channelName: 'somechannel',
     isEditing: props.isEditing,
     isExploding: props.isExploding,
     focusInputCounter: 0,

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -71,9 +71,9 @@ const InputContainer = (props: Props) => {
     pendingWaiting: props.pendingWaiting,
     typing: props.typing,
 
-    _editText: '',
-    _quoteCounter: 0,
-    _quoteText: '',
+    editText: '',
+    quoteCounter: 0,
+    quoteText: '',
 
     getUnsentText: () => {
       action('getUnsentText')()

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -70,9 +70,6 @@ class PlatformInput extends Component<PlatformInputProps, State> {
   }
 
   _onKeyDown = (e: SyntheticKeyboardEvent<>) => {
-    // TODO: Also call onCancelQuoting on mobile.
-    this.props.onCancelQuoting()
-
     const text = this._getText()
     if (e.key === 'ArrowUp' && !this.props.isEditing && !text) {
       e.preventDefault()

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -28,6 +28,7 @@ type InputProps = CommonProps & {
   _editingMessage: ?Types.Message,
   _quotingCounter: number,
   _quotingMessage: ?Types.Message,
+  _quoteTarget: ?Types.ConversationIDKey,
   injectedInput: string,
 
   getUnsentText: () => string,

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -25,8 +25,10 @@ type CommonProps = {
 }
 
 type InputProps = CommonProps & {
-  _quotingMessage: ?Types.Message,
+  _editingCounter: number,
   _editingMessage: ?Types.Message,
+  _quotingCounter: number,
+  _quotingMessage: ?Types.Message,
   injectedInput: string,
 
   getUnsentText: () => string,

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -23,9 +23,9 @@ type CommonProps = {
 }
 
 type InputProps = CommonProps & {
-  _editText: string,
-  _quoteCounter: number,
-  _quoteText: string,
+  editText: string,
+  quoteCounter: number,
+  quoteText: string,
 
   getUnsentText: () => string,
   setUnsentText: (text: string) => void,

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -25,10 +25,8 @@ type CommonProps = {
 
 type InputProps = CommonProps & {
   _editText: string,
-  _quotingCounter: number,
-  _quotingMessage: ?Types.Message,
-  _quoteTarget: ?Types.ConversationIDKey,
-  injectedInput: string,
+  _quoteCounter: number,
+  _quoteText: string,
 
   getUnsentText: () => string,
   setUnsentText: (text: string) => void,

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -24,7 +24,6 @@ type CommonProps = {
 }
 
 type InputProps = CommonProps & {
-  _editingCounter: number,
   _editingMessage: ?Types.Message,
   _quotingCounter: number,
   _quotingMessage: ?Types.Message,

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -19,7 +19,6 @@ type CommonProps = {
   onAttach: (paths: Array<string>) => void,
   onEditLastMessage: () => void,
   onCancelEditing: () => void,
-  onCancelQuoting: () => void,
   onSubmit: (text: string) => void,
   typing: I.Set<string>,
 }

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -24,7 +24,7 @@ type CommonProps = {
 }
 
 type InputProps = CommonProps & {
-  _editingMessage: ?Types.Message,
+  _editText: string,
   _quotingCounter: number,
   _quotingMessage: ?Types.Message,
   _quoteTarget: ?Types.ConversationIDKey,

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -11,7 +11,6 @@ import {Input as TextInput} from '../../../../common-adapters'
 
 type CommonProps = {
   conversationIDKey: Types.ConversationIDKey,
-  channelName: string,
   isEditing: boolean,
   isExploding?: boolean,
   focusInputCounter: number,

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -84,9 +84,9 @@ class MessageFactory extends React.PureComponent<Props> {
 const mapStateToProps = (state: TypedState, {ordinal, previous, conversationIDKey}) => {
   const messageMap = Constants.getMessageMap(state, conversationIDKey)
   const message = messageMap.get(ordinal)
-  const editingOrdinal = Constants.getEditingOrdinal(state, conversationIDKey)
+  const editInfo = Constants.getEditInfo(state, conversationIDKey)
   return {
-    isEditing: message && conversationIDKey && editingOrdinal === message.ordinal,
+    isEditing: message && conversationIDKey && editInfo && editInfo.ordinal === message.ordinal,
     message,
     previous: previous ? messageMap.get(previous) : null,
   }

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -84,11 +84,9 @@ class MessageFactory extends React.PureComponent<Props> {
 const mapStateToProps = (state: TypedState, {ordinal, previous, conversationIDKey}) => {
   const messageMap = Constants.getMessageMap(state, conversationIDKey)
   const message = messageMap.get(ordinal)
+  const editingState = Constants.getEditingState(state, conversationIDKey)
   return {
-    isEditing:
-      message &&
-      conversationIDKey &&
-      Constants.getEditingOrdinal(state, conversationIDKey) === message.ordinal,
+    isEditing: message && conversationIDKey && editingState && editingState.ordinal === message.ordinal,
     message,
     previous: previous ? messageMap.get(previous) : null,
   }

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -84,9 +84,9 @@ class MessageFactory extends React.PureComponent<Props> {
 const mapStateToProps = (state: TypedState, {ordinal, previous, conversationIDKey}) => {
   const messageMap = Constants.getMessageMap(state, conversationIDKey)
   const message = messageMap.get(ordinal)
-  const editingState = Constants.getEditingState(state, conversationIDKey)
+  const editingOrdinal = Constants.getEditingOrdinal(state, conversationIDKey)
   return {
-    isEditing: message && conversationIDKey && editingState && editingState.ordinal === message.ordinal,
+    isEditing: message && conversationIDKey && editingOrdinal === message.ordinal,
     message,
     previous: previous ? messageMap.get(previous) : null,
   }

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -82,13 +82,14 @@ class MessageFactory extends React.PureComponent<Props> {
 }
 
 const mapStateToProps = (state: TypedState, {ordinal, previous, conversationIDKey}) => {
-  const messageMap = Constants.getMessageMap(state, conversationIDKey)
-  const message = messageMap.get(ordinal)
+  const message: ?Types.Message = Constants.getMessage(state, conversationIDKey, ordinal)
   const editInfo = Constants.getEditInfo(state, conversationIDKey)
+  const isEditing = !!(message && editInfo && editInfo.ordinal === message.ordinal)
+  const previousMessage = previous ? Constants.getMessage(state, conversationIDKey, previous) : null
   return {
-    isEditing: message && conversationIDKey && editInfo && editInfo.ordinal === message.ordinal,
+    isEditing,
     message,
-    previous: previous ? messageMap.get(previous) : null,
+    previous: previousMessage,
   }
 }
 

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -55,8 +55,8 @@ export const makeQuoteInfo: I.RecordFactory<Types._QuoteInfo> = I.Record({
 
 export const getMessageOrdinals = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.messageOrdinals.get(id, I.SortedSet())
-export const getMessageMap = (state: TypedState, id: Types.ConversationIDKey) =>
-  state.chat2.messageMap.get(id, I.Map())
+export const getMessage = (state: TypedState, id: Types.ConversationIDKey, ordinal: Types.Ordinal) =>
+  state.chat2.messageMap.getIn([id, ordinal])
 export const getHasBadge = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.badgeMap.get(id, 0) > 0
 export const getHasUnread = (state: TypedState, id: Types.ConversationIDKey) =>
@@ -68,7 +68,7 @@ export const getEditInfo = (state: TypedState, id: Types.ConversationIDKey) => {
     return null
   }
 
-  const message = getMessageMap(state, id).get(ordinal)
+  const message = getMessage(state, id, ordinal)
   if (!message || message.type !== 'text') {
     return null
   }
@@ -81,7 +81,7 @@ export const getQuoteInfo = (state: TypedState, id: Types.ConversationIDKey) => 
     return null
   }
 
-  const message = getMessageMap(state, quote.sourceConversationIDKey).get(quote.ordinal)
+  const message = getMessage(state, quote.sourceConversationIDKey, quote.ordinal)
   if (!message || message.type !== 'text') {
     return null
   }

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -62,6 +62,7 @@ export const getHasBadge = (state: TypedState, id: Types.ConversationIDKey) =>
 export const getHasUnread = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.unreadMap.get(id, 0) > 0
 export const getSelectedConversation = (state: TypedState) => state.chat2.selectedConversation
+
 export const getEditInfo = (state: TypedState, id: Types.ConversationIDKey) => {
   const ordinal = state.chat2.editingMap.get(id)
   if (!ordinal) {
@@ -75,8 +76,10 @@ export const getEditInfo = (state: TypedState, id: Types.ConversationIDKey) => {
 
   return {text: message.text.stringValue(), ordinal}
 }
+
 export const getQuoteInfo = (state: TypedState, id: Types.ConversationIDKey) => {
   const quote = state.chat2.quote
+  // Return null if we're not on the target conversation.
   if (!quote || quote.targetConversationIDKey !== id) {
     return null
   }
@@ -88,6 +91,7 @@ export const getQuoteInfo = (state: TypedState, id: Types.ConversationIDKey) => 
 
   return {counter: quote.counter, text: formatTextForQuoting(message.text.stringValue())}
 }
+
 export const getTyping = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.typingMap.get(id, I.Set())
 export const generateOutboxID = () => Buffer.from([...Array(8)].map(() => Math.floor(Math.random() * 256)))

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -50,8 +50,10 @@ export const getHasBadge = (state: TypedState, id: Types.ConversationIDKey) =>
 export const getHasUnread = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.unreadMap.get(id, 0) > 0
 export const getSelectedConversation = (state: TypedState) => state.chat2.selectedConversation
-export const getEditingOrdinal = (state: TypedState, id: Types.ConversationIDKey) =>
-  state.chat2.editingMap.get(id)
+export const getEditingOrdinal = (state: TypedState, id: Types.ConversationIDKey) => {
+  const editingState = state.chat2.editingMap.get(id)
+  return editingState ? editingState.ordinal : null
+}
 export const getQuotingOrdinalAndSource = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.quotingMap.get(id)
 export const getTyping = (state: TypedState, id: Types.ConversationIDKey) =>

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -51,7 +51,7 @@ export const getHasBadge = (state: TypedState, id: Types.ConversationIDKey) =>
 export const getHasUnread = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.unreadMap.get(id, 0) > 0
 export const getSelectedConversation = (state: TypedState) => state.chat2.selectedConversation
-export const getEditingState = (state: TypedState, id: Types.ConversationIDKey) =>
+export const getEditingOrdinal = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.editingMap.get(id)
 export const getQuotingState = (state: TypedState) => state.chat2.quote
 export const getTyping = (state: TypedState, id: Types.ConversationIDKey) =>

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -2,12 +2,11 @@
 import * as I from 'immutable'
 import * as Types from '../types/chat2'
 import * as RPCChatTypes from '../types/rpc-chat-gen'
+import * as Constants from '../../constants/chat2'
 import * as RPCTypes from '../../constants/types/rpc-gen'
 import {chatTab} from '../tabs'
 import type {TypedState} from '../reducer'
 import {getPath} from '../../route-tree'
-import logger from '../../logger'
-import {isEqual} from 'lodash-es'
 import {isMobile} from '../platform'
 import {
   pendingConversationIDKey,
@@ -49,8 +48,8 @@ export const isValidConversationIDKey = (id: Types.ConversationIDKey) =>
 export const makeQuoteInfo: I.RecordFactory<Types._QuoteInfo> = I.Record({
   counter: 0,
   ordinal: Types.numberToOrdinal(0),
-  sourceConversationIDKey: Types.stringToConversationIDKey(''),
-  targetConversationIDKey: Types.stringToConversationIDKey(''),
+  sourceConversationIDKey: Constants.noConversationIDKey,
+  targetConversationIDKey: Constants.noConversationIDKey,
 })
 
 export const getMessageOrdinals = (state: TypedState, id: Types.ConversationIDKey) =>

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -30,7 +30,6 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   pendingMode: 'none',
   pendingOutboxToOrdinal: I.Map(),
   quote: null,
-  quotingMap: I.Map(),
   selectedConversation: noConversationIDKey,
   typingMap: I.Map(),
   unreadMap: I.Map(),

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -27,6 +27,7 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   ]),
   pendingMode: 'none',
   pendingOutboxToOrdinal: I.Map(),
+  quote: null,
   quotingMap: I.Map(),
   selectedConversation: noConversationIDKey,
   typingMap: I.Map(),
@@ -52,7 +53,7 @@ export const getHasUnread = (state: TypedState, id: Types.ConversationIDKey) =>
 export const getSelectedConversation = (state: TypedState) => state.chat2.selectedConversation
 export const getEditingState = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.editingMap.get(id)
-export const getQuotingState = (state: TypedState, id: Types.ConversationIDKey) => state.chat2.quotingMap.get(id)
+export const getQuotingState = (state: TypedState) => state.chat2.quote
 export const getTyping = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.typingMap.get(id, I.Set())
 export const generateOutboxID = () => Buffer.from([...Array(8)].map(() => Math.floor(Math.random() * 256)))

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -50,12 +50,9 @@ export const getHasBadge = (state: TypedState, id: Types.ConversationIDKey) =>
 export const getHasUnread = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.unreadMap.get(id, 0) > 0
 export const getSelectedConversation = (state: TypedState) => state.chat2.selectedConversation
-export const getEditingOrdinal = (state: TypedState, id: Types.ConversationIDKey) => {
-  const editingState = state.chat2.editingMap.get(id)
-  return editingState ? editingState.ordinal : null
-}
-export const getQuotingOrdinalAndSource = (state: TypedState, id: Types.ConversationIDKey) =>
-  state.chat2.quotingMap.get(id)
+export const getEditingState = (state: TypedState, id: Types.ConversationIDKey) =>
+  state.chat2.editingMap.get(id)
+export const getQuotingState = (state: TypedState, id: Types.ConversationIDKey) => state.chat2.quotingMap.get(id)
 export const getTyping = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.typingMap.get(id, I.Set())
 export const generateOutboxID = () => Buffer.from([...Array(8)].map(() => Math.floor(Math.random() * 256)))

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -81,7 +81,7 @@ export const getQuoteInfo = (state: TypedState, id: Types.ConversationIDKey) => 
     return null
   }
 
-  const message = getMessageMap(state, id).get(quote.ordinal)
+  const message = getMessageMap(state, quote.sourceConversationIDKey).get(quote.ordinal)
   if (!message || message.type !== 'text') {
     return null
   }

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -59,8 +59,17 @@ export const getHasBadge = (state: TypedState, id: Types.ConversationIDKey) =>
 export const getHasUnread = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.unreadMap.get(id, 0) > 0
 export const getSelectedConversation = (state: TypedState) => state.chat2.selectedConversation
-export const getEditingOrdinal = (state: TypedState, id: Types.ConversationIDKey) =>
-  state.chat2.editingMap.get(id)
+export const getEditInfo = (state: TypedState, id: Types.ConversationIDKey) => {
+  const ordinal = state.chat2.editingMap.get(id)
+  if (!ordinal) {
+    return null
+  }
+  const message = getMessageMap(state, id).get(ordinal)
+  if (!message || message.type !== 'text') {
+    return null
+  }
+  return {text: message.text.stringValue(), ordinal}
+}
 export const getQuotingState = (state: TypedState) => state.chat2.quote
 export const getTyping = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.typingMap.get(id, I.Set())

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -42,6 +42,14 @@ export const isValidConversationIDKey = (id: Types.ConversationIDKey) =>
   id !== pendingConversationIDKey &&
   id !== noConversationIDKey &&
   id !== pendingWaitingConversationIDKey
+
+export const makeQuoteInfo: I.RecordFactory<Types._QuoteInfo> = I.Record({
+  counter: 0,
+  ordinal: Types.numberToOrdinal(0),
+  sourceConversationIDKey: Types.stringToConversationIDKey(''),
+  targetConversationIDKey: Types.stringToConversationIDKey(''),
+})
+
 export const getMessageOrdinals = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.messageOrdinals.get(id, I.SortedSet())
 export const getMessageMap = (state: TypedState, id: Types.ConversationIDKey) =>

--- a/shared/constants/types/chat2/index.js
+++ b/shared/constants/types/chat2/index.js
@@ -16,11 +16,6 @@ export type PendingStatus =
   | 'waiting' // attempting to create conversation
   | 'failed' // creating conversation failed
 
-type _editingState = {
-  counter: number,
-  ordinal: Message.Ordinal,
-}
-
 type _quoteState = {
   counter: number,
   ordinal: Message.Ordinal,
@@ -30,7 +25,7 @@ type _quoteState = {
 
 export type _State = {
   badgeMap: I.Map<Common.ConversationIDKey, number>, // id to the badge count
-  editingMap: I.Map<Common.ConversationIDKey, _editingState>, // current message being edited
+  editingMap: I.Map<Common.ConversationIDKey, Message.Ordinal>, // current message being edited
   inboxFilter: string, // filters 'jump to chat'
   loadingMap: I.Map<string, number>, // reasons why we're loading
   messageMap: I.Map<Common.ConversationIDKey, I.Map<Message.Ordinal, Message.Message>>, // messages in a thread

--- a/shared/constants/types/chat2/index.js
+++ b/shared/constants/types/chat2/index.js
@@ -17,7 +17,7 @@ export type PendingStatus =
   | 'failed' // creating conversation failed
 
 export type _QuoteInfo = {
-  // Always positive.
+  // Always positive and monotonically increasing.
   counter: number,
   ordinal: Message.Ordinal,
   sourceConversationIDKey: Common.ConversationIDKey,
@@ -36,7 +36,7 @@ export type _State = {
   metaMap: I.Map<Common.ConversationIDKey, Meta.ConversationMeta>, // metadata about a thread, There is a special node for the pending conversation
   quotingMap: I.Map<Common.ConversationIDKey, QuoteInfo>, // current message being quoted
   explodingModes: I.Map<Common.ConversationIDKey, number>, // seconds to exploding message expiration
-  quote: ?QuoteInfo, // current message being quoted
+  quote: ?QuoteInfo, // last quoted message
   selectedConversation: Common.ConversationIDKey, // the selected conversation, if any
   typingMap: I.Map<Common.ConversationIDKey, I.Set<string>>, // who's typing currently
   unreadMap: I.Map<Common.ConversationIDKey, number>, // how many unread messages there are

--- a/shared/constants/types/chat2/index.js
+++ b/shared/constants/types/chat2/index.js
@@ -34,7 +34,6 @@ export type _State = {
   messageMap: I.Map<Common.ConversationIDKey, I.Map<Message.Ordinal, Message.Message>>, // messages in a thread
   messageOrdinals: I.Map<Common.ConversationIDKey, I.SortedSet<Message.Ordinal>>, // ordered ordinals in a thread
   metaMap: I.Map<Common.ConversationIDKey, Meta.ConversationMeta>, // metadata about a thread, There is a special node for the pending conversation
-  quotingMap: I.Map<Common.ConversationIDKey, QuoteInfo>, // current message being quoted
   explodingModes: I.Map<Common.ConversationIDKey, number>, // seconds to exploding message expiration
   quote: ?QuoteInfo, // last quoted message
   selectedConversation: Common.ConversationIDKey, // the selected conversation, if any

--- a/shared/constants/types/chat2/index.js
+++ b/shared/constants/types/chat2/index.js
@@ -11,14 +11,25 @@ export type PendingMode =
   | 'fixedSetOfUsers' // selected a set of users externally
   | 'startingFromAReset' // fixedSet but our intention is to restart a reset conversation
 
-export type QuotedOrdConv = {
+export type PendingStatus =
+  | 'none' // no pending
+  | 'waiting' // attempting to create conversation
+  | 'failed' // creating conversation failed
+
+type _editingState = {
+  counter: number,
+  ordinal: Message.Ordinal,
+}
+
+type QuotedOrdConv = {
+  counter: number,
   ordinal: Message.Ordinal,
   sourceConversationIDKey: Common.ConversationIDKey,
 }
 
 export type _State = {
   badgeMap: I.Map<Common.ConversationIDKey, number>, // id to the badge count
-  editingMap: I.Map<Common.ConversationIDKey, Message.Ordinal>, // current message being edited
+  editingMap: I.Map<Common.ConversationIDKey, _editingState>, // current message being edited
   inboxFilter: string, // filters 'jump to chat'
   loadingMap: I.Map<string, number>, // reasons why we're loading
   messageMap: I.Map<Common.ConversationIDKey, I.Map<Message.Ordinal, Message.Message>>, // messages in a thread

--- a/shared/constants/types/chat2/index.js
+++ b/shared/constants/types/chat2/index.js
@@ -16,12 +16,15 @@ export type PendingStatus =
   | 'waiting' // attempting to create conversation
   | 'failed' // creating conversation failed
 
-type _quoteState = {
+export type _QuoteInfo = {
+  // Always positive.
   counter: number,
   ordinal: Message.Ordinal,
   sourceConversationIDKey: Common.ConversationIDKey,
   targetConversationIDKey: Common.ConversationIDKey,
 }
+
+export type QuoteInfo = I.RecordOf<_QuoteInfo>
 
 export type _State = {
   badgeMap: I.Map<Common.ConversationIDKey, number>, // id to the badge count
@@ -31,9 +34,9 @@ export type _State = {
   messageMap: I.Map<Common.ConversationIDKey, I.Map<Message.Ordinal, Message.Message>>, // messages in a thread
   messageOrdinals: I.Map<Common.ConversationIDKey, I.SortedSet<Message.Ordinal>>, // ordered ordinals in a thread
   metaMap: I.Map<Common.ConversationIDKey, Meta.ConversationMeta>, // metadata about a thread, There is a special node for the pending conversation
-  quotingMap: I.Map<Common.ConversationIDKey, _quoteState>, // current message being quoted
+  quotingMap: I.Map<Common.ConversationIDKey, QuoteInfo>, // current message being quoted
   explodingModes: I.Map<Common.ConversationIDKey, number>, // seconds to exploding message expiration
-  quote: ?_quoteState, // current message being quoted
+  quote: ?QuoteInfo, // current message being quoted
   selectedConversation: Common.ConversationIDKey, // the selected conversation, if any
   typingMap: I.Map<Common.ConversationIDKey, I.Set<string>>, // who's typing currently
   unreadMap: I.Map<Common.ConversationIDKey, number>, // how many unread messages there are

--- a/shared/constants/types/chat2/index.js
+++ b/shared/constants/types/chat2/index.js
@@ -21,10 +21,11 @@ type _editingState = {
   ordinal: Message.Ordinal,
 }
 
-type QuotedOrdConv = {
+type _quoteState = {
   counter: number,
   ordinal: Message.Ordinal,
   sourceConversationIDKey: Common.ConversationIDKey,
+  targetConversationIDKey: Common.ConversationIDKey,
 }
 
 export type _State = {
@@ -35,8 +36,9 @@ export type _State = {
   messageMap: I.Map<Common.ConversationIDKey, I.Map<Message.Ordinal, Message.Message>>, // messages in a thread
   messageOrdinals: I.Map<Common.ConversationIDKey, I.SortedSet<Message.Ordinal>>, // ordered ordinals in a thread
   metaMap: I.Map<Common.ConversationIDKey, Meta.ConversationMeta>, // metadata about a thread, There is a special node for the pending conversation
-  quotingMap: I.Map<Common.ConversationIDKey, QuotedOrdConv>, // current message being quoted
+  quotingMap: I.Map<Common.ConversationIDKey, _quoteState>, // current message being quoted
   explodingModes: I.Map<Common.ConversationIDKey, number>, // seconds to exploding message expiration
+  quote: ?_quoteState, // current message being quoted
   selectedConversation: Common.ConversationIDKey, // the selected conversation, if any
   typingMap: I.Map<Common.ConversationIDKey, I.Set<string>>, // who's typing currently
   unreadMap: I.Map<Common.ConversationIDKey, number>, // how many unread messages there are

--- a/shared/reducers/__tests__/chat2.js
+++ b/shared/reducers/__tests__/chat2.js
@@ -114,14 +114,6 @@ describe('chat2 reducer', () => {
         ordinal: Types.numberToOrdinal(1),
         sourceConversationIDKey: conversationIDKey,
       })
-
-      const clearAction = Chat2Gen.createMessageSetQuoting({
-        ordinal: null,
-        sourceConversationIDKey: conversationIDKey,
-        targetConversationIDKey: conversationIDKey,
-      })
-      const state2 = reducer(state1, clearAction)
-      expect(state2.quotingMap.get(conversationIDKey)).toEqual(undefined)
     })
   })
 })

--- a/shared/reducers/__tests__/chat2.js
+++ b/shared/reducers/__tests__/chat2.js
@@ -102,7 +102,7 @@ describe('chat2 reducer', () => {
   })
 
   describe('messageSetQuoting action', () => {
-    it('set and clear quoted message works', () => {
+    it('set quoted message works', () => {
       const setAction = Chat2Gen.createMessageSetQuoting({
         ordinal: Types.numberToOrdinal(1),
         sourceConversationIDKey: conversationIDKey,
@@ -110,10 +110,24 @@ describe('chat2 reducer', () => {
       })
 
       const state1 = reducer(initialState, setAction)
-      /*      expect(state1.quotingMap.get(conversationIDKey)).toEqual({
-        ordinal: Types.numberToOrdinal(1),
-        sourceConversationIDKey: conversationIDKey,
-      })*/
+      expect(state1.quote).toEqual(
+        Constants.makeQuoteInfo({
+          counter: 1,
+          ordinal: Types.numberToOrdinal(1),
+          sourceConversationIDKey: conversationIDKey,
+          targetConversationIDKey: conversationIDKey,
+        })
+      )
+
+      const state2 = reducer(state1, setAction)
+      expect(state2.quote).toEqual(
+        Constants.makeQuoteInfo({
+          counter: 2,
+          ordinal: Types.numberToOrdinal(1),
+          sourceConversationIDKey: conversationIDKey,
+          targetConversationIDKey: conversationIDKey,
+        })
+      )
     })
   })
 })

--- a/shared/reducers/__tests__/chat2.js
+++ b/shared/reducers/__tests__/chat2.js
@@ -110,10 +110,10 @@ describe('chat2 reducer', () => {
       })
 
       const state1 = reducer(initialState, setAction)
-      expect(state1.quotingMap.get(conversationIDKey)).toEqual({
+      /*      expect(state1.quotingMap.get(conversationIDKey)).toEqual({
         ordinal: Types.numberToOrdinal(1),
         sourceConversationIDKey: conversationIDKey,
-      })
+      })*/
     })
   })
 })

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -428,11 +428,9 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
         return editingMap
       })
     case Chat2Gen.messageSetQuoting:
-      return state.update('quotingMap', quotingMap => {
-        const {ordinal, sourceConversationIDKey, targetConversationIDKey} = action.payload
-        const counter = quotingMap.getIn([targetConversationIDKey, 'counter'], 0) + 1
-        return quotingMap.set(targetConversationIDKey, {counter, ordinal, sourceConversationIDKey})
-      })
+      const {ordinal, sourceConversationIDKey, targetConversationIDKey} = action.payload
+      const counter = (state.quote ? state.quote.counter : 0) + 1
+      return state.set('quote', {counter, ordinal, sourceConversationIDKey, targetConversationIDKey})
     case Chat2Gen.messagesAdd: {
       const {messages, context} = action.payload
 

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -408,7 +408,8 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
         if (ordinal) {
           const message = messageMap.get(ordinal)
           if (message && message.type === 'text') {
-            return editingMap.set(conversationIDKey, ordinal)
+            const counter = editingMap.getIn([conversationIDKey, 'counter'], 0) + 1
+            return editingMap.set(conversationIDKey, {counter, ordinal})
           } else {
             return editingMap
           }
@@ -421,7 +422,8 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
           return message && message.type === 'text' && message.author === editLastUser
         })
         if (found) {
-          return editingMap.set(conversationIDKey, found)
+          const counter = editingMap.getIn([conversationIDKey, 'counter'], 0) + 1
+          return editingMap.set(conversationIDKey, {counter, ordinal: found})
         }
         return editingMap
       })
@@ -433,7 +435,8 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
           return quotingMap.delete(targetConversationIDKey)
         }
         // quoting a specific message
-        return quotingMap.set(targetConversationIDKey, {ordinal, sourceConversationIDKey})
+        const counter = quotingMap.getIn([targetConversationIDKey, 'counter'], 0) + 1
+        return quotingMap.set(targetConversationIDKey, {counter, ordinal, sourceConversationIDKey})
       })
     case Chat2Gen.messagesAdd: {
       const {messages, context} = action.payload

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -430,11 +430,6 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     case Chat2Gen.messageSetQuoting:
       return state.update('quotingMap', quotingMap => {
         const {ordinal, sourceConversationIDKey, targetConversationIDKey} = action.payload
-        // clearing
-        if (!ordinal) {
-          return quotingMap.delete(targetConversationIDKey)
-        }
-        // quoting a specific message
         const counter = quotingMap.getIn([targetConversationIDKey, 'counter'], 0) + 1
         return quotingMap.set(targetConversationIDKey, {counter, ordinal, sourceConversationIDKey})
       })

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -408,8 +408,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
         if (ordinal) {
           const message = messageMap.get(ordinal)
           if (message && message.type === 'text') {
-            const counter = editingMap.getIn([conversationIDKey, 'counter'], 0) + 1
-            return editingMap.set(conversationIDKey, {counter, ordinal})
+            return editingMap.set(conversationIDKey, ordinal)
           } else {
             return editingMap
           }
@@ -422,8 +421,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
           return message && message.type === 'text' && message.author === editLastUser
         })
         if (found) {
-          const counter = editingMap.getIn([conversationIDKey, 'counter'], 0) + 1
-          return editingMap.set(conversationIDKey, {counter, ordinal: found})
+          return editingMap.set(conversationIDKey, found)
         }
         return editingMap
       })

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -428,7 +428,10 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     case Chat2Gen.messageSetQuoting:
       const {ordinal, sourceConversationIDKey, targetConversationIDKey} = action.payload
       const counter = (state.quote ? state.quote.counter : 0) + 1
-      return state.set('quote', {counter, ordinal, sourceConversationIDKey, targetConversationIDKey})
+      return state.set(
+        'quote',
+        Constants.makeQuoteInfo({counter, ordinal, sourceConversationIDKey, targetConversationIDKey})
+      )
     case Chat2Gen.messagesAdd: {
       const {messages, context} = action.payload
 

--- a/shared/settings/feedback-container.native.js
+++ b/shared/settings/feedback-container.native.js
@@ -143,7 +143,7 @@ const extraChatLogs = (state: TypedState) => {
       },
       pendingMode: chat.pendingMode,
       pendingOutboxToOrdinal: chat.pendingOutboxToOrdinal.get(c),
-      quotingMap: chat.quotingMap.get(c),
+      quote: chat.quote,
       unreadMap: chat.unreadMap.get(c),
     }).toJS()
   }


### PR DESCRIPTION
Remove need for onCancelQuoting, and change edit/quote text injection\
to be edge-triggered. Also save injected text as unsent, so that one can
switch away from a conversation that's editing / quoting without losing text.

Move edit/quote logic out of chat input mapStateToProps.

Also change getMessageMap to getMessage.