### PR TITLE
Run CreateWalletSoft synchronously on signup

### DIFF
--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -9,7 +9,6 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	triplesec "github.com/keybase/go-triplesec"
-	context "golang.org/x/net/context"
 )
 
 type SignupEngine struct {
@@ -125,9 +124,7 @@ func (s *SignupEngine) Run(m libkb.MetaContext) (err error) {
 	// For instance, setup gregor and friends...
 	m.G().CallLoginHooks()
 
-	go func() {
-		m.G().GetStellar().CreateWalletSoft(context.Background())
-	}()
+	m.G().GetStellar().CreateWalletSoft(m.Ctx())
 
 	return nil
 }


### PR DESCRIPTION
Fix CI when autowallet is on.

The races were between two different Gs. On tests that involve multiple users. I can't think of a better way to fix this and this seems fine.

Simpler than https://github.com/keybase/client/pull/11908