### PR TITLE
Change PacketTag to uint for compatibility with new codec

### DIFF
--- a/go/engine/device_history.go
+++ b/go/engine/device_history.go
@@ -160,7 +160,7 @@ func (e *DeviceHistory) loadDevices(m libkb.MetaContext, user *libkb.User) error
 
 func (e *DeviceHistory) provisioner(m libkb.MetaContext, d *libkb.Device, ckis *libkb.ComputedKeyInfos, info *libkb.ComputedKeyInfo) (*libkb.Device, error) {
 	for _, v := range info.Delegations {
-		if v.GetKeyType() != libkb.KIDNaclEddsa {
+		if libkb.AlgoType(v.GetKeyType()) != libkb.KIDNaclEddsa {
 			// only concerned with device history, not pgp provisioners
 			continue
 		}

--- a/go/engine/saltpack_decrypt.go
+++ b/go/engine/saltpack_decrypt.go
@@ -102,7 +102,7 @@ func (e *SaltpackDecrypt) makeMessageInfo(me *libkb.User, mki *saltpack.MessageK
 	}
 	ckf := me.GetComputedKeyFamily()
 	for _, nr := range mki.NamedReceivers {
-		kid := keybase1.KIDFromRawKey(nr, libkb.KIDNaclDH)
+		kid := keybase1.KIDFromRawKey(nr, byte(libkb.KIDNaclDH))
 		if dev, _ := ckf.GetDeviceForKID(kid); dev != nil {
 			edev := dev.ProtExport()
 			edev.EncryptKey = kid

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -439,9 +439,11 @@ const (
 	KeybasePacketV1 PacketVersion = 1
 )
 
-type PacketTag int
+// PacketTag are tags for OpenPGP and Keybase packets. It is a uint to
+// be backwards compatible with older versions of codec that encoded
+// positive ints as uints.
+type PacketTag uint
 
-// Packet tags for OpenPGP and also Keybase packets
 const (
 	TagP3skb      PacketTag = 513
 	TagSignature  PacketTag = 514

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -444,20 +444,20 @@ type PacketTag int
 // Packet tags for OpenPGP and also Keybase packets
 const (
 	TagP3skb      PacketTag = 513
-	TagSignature            = 514
-	TagEncryption           = 515
+	TagSignature  PacketTag = 514
+	TagEncryption PacketTag = 515
 )
 
 const (
 	KIDPGPBase    AlgoType = 0x00
-	KIDPGPRsa              = 0x1
-	KIDPGPElgamal          = 0x10
-	KIDPGPDsa              = 0x11
-	KIDPGPEcdh             = 0x12
-	KIDPGPEcdsa            = 0x13
-	KIDPGPEddsa            = 0x16
-	KIDNaclEddsa           = 0x20
-	KIDNaclDH              = 0x21
+	KIDPGPRsa     AlgoType = 0x1
+	KIDPGPElgamal AlgoType = 0x10
+	KIDPGPDsa     AlgoType = 0x11
+	KIDPGPEcdh    AlgoType = 0x12
+	KIDPGPEcdsa   AlgoType = 0x13
+	KIDPGPEddsa   AlgoType = 0x16
+	KIDNaclEddsa  AlgoType = 0x20
+	KIDNaclDH     AlgoType = 0x21
 )
 
 // OpenPGP hash IDs, taken from http://tools.ietf.org/html/rfc4880#section-9.4

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -433,12 +433,19 @@ const (
 	HTTPRetryCount          = 6
 )
 
+type PacketVersion int
+
+const (
+	KeybasePacketV1 PacketVersion = 1
+)
+
+type PacketTag int
+
 // Packet tags for OpenPGP and also Keybase packets
 const (
-	KeybasePacketV1 = 1
-	TagP3skb        = 513
-	TagSignature    = 514
-	TagEncryption   = 515
+	TagP3skb      PacketTag = 513
+	TagSignature            = 514
+	TagEncryption           = 515
 )
 
 const (

--- a/go/libkb/kbpackets.go
+++ b/go/libkb/kbpackets.go
@@ -212,7 +212,7 @@ func (p *KeybasePacket) unpackBody(ch *codec.MsgpackHandle) error {
 			copy(si.Sig[:], sig)
 		}
 		if st, ok := mb["sig_type"].(int64); ok {
-			si.SigType = int(st)
+			si.SigType = AlgoType(st)
 		}
 		if v, ok := mb["version"].(int64); ok {
 			si.Version = int(v)

--- a/go/libkb/kbpackets.go
+++ b/go/libkb/kbpackets.go
@@ -45,13 +45,13 @@ type KeybasePacketHash struct {
 type KeybasePacket struct {
 	Body    interface{}        `codec:"body"`
 	Hash    *KeybasePacketHash `codec:"hash,omitempty"`
-	Tag     int                `codec:"tag"`
-	Version int                `codec:"version"`
+	Tag     PacketTag          `codec:"tag"`
+	Version PacketVersion      `codec:"version"`
 }
 
 type KeybasePackets []*KeybasePacket
 
-func NewKeybasePacket(body interface{}, tag int, version int) (*KeybasePacket, error) {
+func NewKeybasePacket(body interface{}, tag PacketTag, version PacketVersion) (*KeybasePacket, error) {
 	ret := KeybasePacket{
 		Body:    body,
 		Tag:     tag,

--- a/go/libkb/kbpackets_test.go
+++ b/go/libkb/kbpackets_test.go
@@ -64,6 +64,22 @@ tuX4LPcEa+72KyrsweuAJravU8SjgL/gAKhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B
 	require.IsType(t, err, FishyMsgpackError{}, "p=%+v", p)
 }
 
+// Guard against unexpected codec encoding changes, in particular for
+// ints.
+func TestHardcodedPacketEncode(t *testing.T) {
+	p, err := NewKeybasePacket(nil, TagSignature, KeybasePacketV1)
+	require.NoError(t, err)
+
+	p.Hash = nil
+
+	bytes, err := p.Encode()
+	require.NoError(t, err)
+	// In particular, {0xcd, 0x2, 0x2} shouldn't change to
+	// {0xd1, 0x2, 0x2}.
+	expectedBytes := []byte{0x83, 0xa4, 0x62, 0x6f, 0x64, 0x79, 0xc0, 0xa3, 0x74, 0x61, 0x67, 0xcd, 0x2, 0x2, 0xa7, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x1}
+	require.Equal(t, expectedBytes, bytes)
+}
+
 // This is a regression test for
 // https://github.com/ugorji/go/issues/237 .
 func TestMsgpackReencodeNilHash(t *testing.T) {

--- a/go/libkb/kid.go
+++ b/go/libkb/kid.go
@@ -19,11 +19,11 @@ func GetKID(w *jsonw.Wrapper) (kid keybase1.KID, err error) {
 }
 
 func KIDIsDeviceVerify(kid keybase1.KID) bool {
-	return kid.GetKeyType() == KIDNaclEddsa
+	return AlgoType(kid.GetKeyType()) == KIDNaclEddsa
 }
 
 func KIDIsDeviceEncrypt(kid keybase1.KID) bool {
-	return kid.GetKeyType() == KIDNaclDH
+	return AlgoType(kid.GetKeyType()) == KIDNaclDH
 }
 
 func KIDIsPGP(kid keybase1.KID) bool {

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -23,7 +23,7 @@ type NaclSigInfo struct {
 	Kid      keybase1.BinaryKID `codec:"key"`
 	Payload  []byte             `codec:"payload,omitempty"`
 	Sig      NaclSignature      `codec:"sig"`
-	SigType  int                `codec:"sig_type"`
+	SigType  AlgoType           `codec:"sig_type"`
 	HashType int                `codec:"hash_type"`
 	Detached bool               `codec:"detached"`
 	Version  int                `codec:"version,omitempty"`
@@ -31,11 +31,11 @@ type NaclSigInfo struct {
 }
 
 type NaclEncryptionInfo struct {
-	Ciphertext     []byte `codec:"ciphertext"`
-	EncryptionType int    `codec:"enc_type"`
-	Nonce          []byte `codec:"nonce"`
-	Receiver       []byte `codec:"receiver_key"`
-	Sender         []byte `codec:"sender_key"`
+	Ciphertext     []byte   `codec:"ciphertext"`
+	EncryptionType AlgoType `codec:"enc_type"`
+	Nonce          []byte   `codec:"nonce"`
+	Receiver       []byte   `codec:"receiver_key"`
+	Sender         []byte   `codec:"sender_key"`
 }
 
 const NaclDHKeysize = 32

--- a/go/libkb/saltpack.go
+++ b/go/libkb/saltpack.go
@@ -207,7 +207,7 @@ func BoxPublicKeyToKeybaseKID(k saltpack.BoxPublicKey) (ret keybase1.KID) {
 		return ret
 	}
 	p := k.ToKID()
-	return keybase1.KIDFromRawKey(p, KIDNaclDH)
+	return keybase1.KIDFromRawKey(p, byte(KIDNaclDH))
 }
 
 func checkSaltpackBrand(b string) error {

--- a/go/libkb/saltpack_sign.go
+++ b/go/libkb/saltpack_sign.go
@@ -105,5 +105,5 @@ func SigningPublicKeyToKeybaseKID(k saltpack.SigningPublicKey) (ret keybase1.KID
 		return ret
 	}
 	p := k.ToKID()
-	return keybase1.KIDFromRawKey(p, KIDNaclEddsa)
+	return keybase1.KIDFromRawKey(p, byte(KIDNaclEddsa))
 }


### PR DESCRIPTION
There's ambiguity in the MessagePack spec with regards to how ints
are encoded. Newer versions of ugorji/codec encode numbers of type
int that are > 127 as int{16,32,64}, whereas old versions (like the one we use)
encode them as uint{16,32,64}.

Change the type of PacketTag to uint to be forward-compatible, and add tests.