### PR TITLE
dont clear inbox on network sync error

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4131,6 +4131,8 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 		ui := kbtest.NewChatUI(inboxCb, threadCb, nil, nil)
 		ctc.as(t, users[0]).h.mockChatUI = ui
 		ctc.as(t, users[1]).h.mockChatUI = ui
+		ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
+		ctc.world.Tcs[users[1].Username].ChatG.Syncer.(*Syncer).isConnected = true
 
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
 			ctc.as(t, users[1]).user())


### PR DESCRIPTION
I found that we were dumping the on-disk inbox cache for no reason in a lot of cases, one being that if we get a version mismatch error and then fail to `Sync` because of a network error we would dump the entire inbox. Instead, let's just do nothing, since if we are offline we will be calling `Sync` again anyway. 