### PR TITLE
[WIP] Make Seqno uint64

### DIFF
--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -57,7 +57,7 @@ func (s *DeviceEKStorage) key(ctx context.Context, generation keybase1.EkGenerat
 
 func (s *DeviceEKStorage) keyToEldestSeqno(key string) (eldestSeqno keybase1.Seqno, err error) {
 	if !strings.HasPrefix(key, deviceEKPrefix) {
-		return -1, nil
+		return keybase1.InvalidSeqno(), nil
 	}
 	parts := strings.Split(key, "-")
 
@@ -67,7 +67,7 @@ func (s *DeviceEKStorage) keyToEldestSeqno(key string) (eldestSeqno keybase1.Seq
 	}
 	// Make sure this key is for our current user and not a different one.
 	if parts[1] != s.G().Env.GetUsername().String() {
-		return -1, nil
+		return keybase1.InvalidSeqno(), nil
 	}
 	e, err := strconv.ParseUint(parts[2], 10, 64)
 	if err != nil {

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -951,7 +951,7 @@ func (c *ChainLink) getSeqnoFromPayload() keybase1.Seqno {
 	if c.unpacked != nil {
 		return c.unpacked.seqno
 	}
-	return keybase1.Seqno(-1)
+	return keybase1.InvalidSeqno()
 }
 
 func (c *ChainLink) GetSeqno() keybase1.Seqno {

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -221,7 +221,7 @@ func (sc *SigChain) Bump(mt MerkleTriple) {
 
 func (sc *SigChain) LoadFromServer(ctx context.Context, t *MerkleTriple, selfUID keybase1.UID) (dirtyTail *MerkleTriple, err error) {
 	low := sc.GetLastLoadedSeqno()
-	sc.loadedFromLinkOne = (low == keybase1.Seqno(0) || low == keybase1.Seqno(-1))
+	sc.loadedFromLinkOne = (low == keybase1.Seqno(0) || low == keybase1.InvalidSeqno())
 
 	isSelf := selfUID.Equal(sc.uid)
 
@@ -1044,8 +1044,8 @@ func (sc *SigChain) CheckFreshness(srv *MerkleTriple) (current bool, err error) 
 	Efn := NewServerChainError
 	sc.G().Log.Debug("+ CheckFreshness")
 	defer sc.G().Log.Debug("- CheckFreshness (%s) -> (%v,%s)", sc.uid, current, ErrToOk(err))
-	a := keybase1.Seqno(-1)
-	b := keybase1.Seqno(-1)
+	a := keybase1.InvalidSeqno()
+	b := keybase1.InvalidSeqno()
 
 	if srv != nil {
 		sc.G().Log.Debug("| Server triple: %v", srv)

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -316,7 +316,7 @@ func (o TeamIDAndName) DeepCopy() TeamIDAndName {
 	}
 }
 
-type Seqno int64
+type Seqno uint64
 
 func (o Seqno) DeepCopy() Seqno {
 	return o

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -381,6 +381,8 @@ func (l LinkID) Eq(l2 LinkID) bool {
 	return l == l2
 }
 
+func InvalidSeqno() Seqno { return ^Seqno(0) }
+
 func (s Seqno) Eq(s2 Seqno) bool {
 	return s == s2
 }

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -99,7 +99,7 @@ protocol Common {
     TeamName name;
   }
 
-  @typedef("int64") @lint("ignore")
+  @typedef("uint64") @lint("ignore")
   record Seqno {}
 
   enum SeqType {

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3423,7 +3423,7 @@ export type SeqType =
   | 2 // PRIVATE_2
   | 3 // SEMIPRIVATE_3
 
-export type Seqno = Int64
+export type Seqno = Uint64
 
 export type ServiceStatus = $ReadOnly<{version: String, label: String, pid: String, lastExitStatus: String, bundleVersion: String, installStatus: InstallStatus, installAction: InstallAction, status: Status}>
 

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -219,7 +219,7 @@
       "type": "record",
       "name": "Seqno",
       "fields": [],
-      "typedef": "int64",
+      "typedef": "uint64",
       "lint": "ignore"
     },
     {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3423,7 +3423,7 @@ export type SeqType =
   | 2 // PRIVATE_2
   | 3 // SEMIPRIVATE_3
 
-export type Seqno = Int64
+export type Seqno = Uint64
 
 export type ServiceStatus = $ReadOnly<{version: String, label: String, pid: String, lastExitStatus: String, bundleVersion: String, installStatus: InstallStatus, installAction: InstallAction, status: Status}>
 


### PR DESCRIPTION
This is because KBFS's RootMetadata pulls in Seqno via MerkleRootV2, and so
the go-codec changes would affect its encoding.