### PR TITLE
New Stellar RPC: SetWalletAccountAsDefaultLocal

### DIFF
--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -230,6 +230,11 @@ type ChangeWalletAccountNameLocalArg struct {
 	NewName   string    `codec:"newName" json:"newName"`
 }
 
+type SetWalletAccountAsDefaultLocalArg struct {
+	SessionID int       `codec:"sessionID" json:"sessionID"`
+	AccountID AccountID `codec:"accountID" json:"accountID"`
+}
+
 type BalancesLocalArg struct {
 	AccountID AccountID `codec:"accountID" json:"accountID"`
 }
@@ -300,6 +305,7 @@ type LocalInterface interface {
 	GetAccountAssetsLocal(context.Context, GetAccountAssetsLocalArg) ([]AccountAssetLocal, error)
 	GetDisplayCurrenciesLocal(context.Context, int) ([]CurrencyLocal, error)
 	ChangeWalletAccountNameLocal(context.Context, ChangeWalletAccountNameLocalArg) error
+	SetWalletAccountAsDefaultLocal(context.Context, SetWalletAccountAsDefaultLocalArg) error
 	BalancesLocal(context.Context, AccountID) ([]Balance, error)
 	SendCLILocal(context.Context, SendCLILocalArg) (SendResultCLILocal, error)
 	ClaimCLILocal(context.Context, ClaimCLILocalArg) (RelayClaimResult, error)
@@ -381,6 +387,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					err = i.ChangeWalletAccountNameLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"setWalletAccountAsDefaultLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]SetWalletAccountAsDefaultLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SetWalletAccountAsDefaultLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SetWalletAccountAsDefaultLocalArg)(nil), args)
+						return
+					}
+					err = i.SetWalletAccountAsDefaultLocal(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -632,6 +654,11 @@ func (c LocalClient) GetDisplayCurrenciesLocal(ctx context.Context, sessionID in
 
 func (c LocalClient) ChangeWalletAccountNameLocal(ctx context.Context, __arg ChangeWalletAccountNameLocalArg) (err error) {
 	err = c.Cli.Call(ctx, "stellar.1.local.changeWalletAccountNameLocal", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) SetWalletAccountAsDefaultLocal(ctx context.Context, __arg SetWalletAccountAsDefaultLocalArg) (err error) {
+	err = c.Cli.Call(ctx, "stellar.1.local.setWalletAccountAsDefaultLocal", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -794,6 +794,9 @@ func ChangeAccountName(m libkb.MetaContext, accountID stellar1.AccountID, newNam
 }
 
 func SetAccountAsPrimary(m libkb.MetaContext, accountID stellar1.AccountID) (err error) {
+	if accountID.IsNil() {
+		return errors.New("passed empty AccountID")
+	}
 	prevBundle, _, err := remote.Fetch(m.Ctx(), m.G())
 	if err != nil {
 		return err

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -820,6 +820,5 @@ func SetAccountAsPrimary(m libkb.MetaContext, accountID stellar1.AccountID) (err
 	if !foundAccID {
 		return fmt.Errorf("account not found: %v", accountID)
 	}
-	//return remote.Post(m.Ctx(), m.G(), nextBundle)
 	return remote.PostWithChainlink(m.Ctx(), m.G(), nextBundle)
 }

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -194,6 +194,9 @@ func (a balanceList) nativeBalanceDescription() (string, error) {
 func (s *Server) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.ChangeWalletAccountNameLocalArg) (err error) {
 	m := libkb.NewMetaContext(s.logTag(ctx), s.G())
 	defer s.G().CTraceTimed(ctx, "ChangeWalletAccountNameLocal", func() error { return err })()
+	if err = s.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 
 	return stellar.ChangeAccountName(m, arg.AccountID, arg.NewName)
 }
@@ -201,6 +204,9 @@ func (s *Server) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.
 func (s *Server) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar1.SetWalletAccountAsDefaultLocalArg) (err error) {
 	m := libkb.NewMetaContext(s.logTag(ctx), s.G())
 	defer s.G().CTraceTimed(ctx, "SetWalletAccountAsDefaultLocal", func() error { return err })()
+	if err = s.assertLoggedIn(ctx); err != nil {
+		return err
+	}
 
 	return stellar.SetAccountAsPrimary(m, arg.AccountID)
 }

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -197,3 +197,10 @@ func (s *Server) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.
 
 	return stellar.ChangeAccountName(m, arg.AccountID, arg.NewName)
 }
+
+func (s *Server) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar1.SetWalletAccountAsDefaultLocalArg) (err error) {
+	m := libkb.NewMetaContext(s.logTag(ctx), s.G())
+	defer s.G().CTraceTimed(ctx, "SetWalletAccountAsDefaultLocal", func() error { return err })()
+
+	return stellar.SetAccountAsPrimary(m, arg.AccountID)
+}

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -156,7 +156,7 @@ func TestChangeWalletName(t *testing.T) {
 }
 
 func TestSetAccountAsDefault(t *testing.T) {
-	tcs, cleanup := setupNTests(t, 1)
+	tcs, cleanup := setupNTests(t, 2)
 	defer cleanup()
 
 	_, err := stellar.CreateWallet(context.Background(), tcs[0].G)
@@ -217,4 +217,12 @@ func TestSetAccountAsDefault(t *testing.T) {
 			require.Equal(t, acc.IsPrimary, acc.AccountID == v)
 		}
 	}
+
+	// Expecting additionalAccs[0] to be default account. Lookup
+	// public Stellar address as another user.
+	u0, err := tcs[1].G.LoadUserByUID(tcs[0].Fu.User.GetUID())
+	require.NoError(t, err)
+	u0addr := u0.StellarWalletAddress()
+	require.NotNil(t, u0addr)
+	require.Equal(t, additionalAccs[0], *u0addr)
 }

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -181,10 +181,15 @@ func TestSetAccountAsDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 1, bundle.Revision)
 
-	// Test invalid argument
+	// Test invalid arguments
 	invalidAccID, _ := randomStellarKeypair()
 	err = tcs[0].Srv.SetWalletAccountAsDefaultLocal(context.Background(), stellar1.SetWalletAccountAsDefaultLocalArg{
 		AccountID: invalidAccID,
+	})
+	require.Error(t, err)
+
+	err = tcs[0].Srv.SetWalletAccountAsDefaultLocal(context.Background(), stellar1.SetWalletAccountAsDefaultLocalArg{
+		AccountID: stellar1.AccountID(""),
 	})
 	require.Error(t, err)
 

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -202,7 +202,8 @@ func TestSetAccountAsDefault(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	for _, v := range additionalAccs {
+	for i := len(additionalAccs) - 1; i >= 0; i-- {
+		v := additionalAccs[i]
 		arg := stellar1.SetWalletAccountAsDefaultLocalArg{
 			AccountID: v,
 		}

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -35,6 +35,7 @@ protocol local {
   array<CurrencyLocal> getDisplayCurrenciesLocal(int sessionID);
 
   void changeWalletAccountNameLocal(int sessionID, AccountID accountID, string newName);
+  void setWalletAccountAsDefaultLocal(int sessionID, AccountID accountID);
 
   // -------------------------------------------------------
   // CLI protocol

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -306,6 +306,19 @@
       ],
       "response": null
     },
+    "setWalletAccountAsDefaultLocal": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "accountID",
+          "type": "AccountID"
+        }
+      ],
+      "response": null
+    },
     "balancesLocal": {
       "request": [
         {


### PR DESCRIPTION
This PR adds an RPC that changes primary account in a bundle and posts the bundle with user chain link.