### PR TITLE
Add Stellar RPC: DeleteWalletAccountLocal

### DIFF
--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -235,6 +235,12 @@ type SetWalletAccountAsDefaultLocalArg struct {
 	AccountID AccountID `codec:"accountID" json:"accountID"`
 }
 
+type DeleteWalletAccountLocalArg struct {
+	SessionID        int       `codec:"sessionID" json:"sessionID"`
+	AccountID        AccountID `codec:"accountID" json:"accountID"`
+	UserAcknowledged string    `codec:"userAcknowledged" json:"userAcknowledged"`
+}
+
 type LinkNewWalletAccountLocalArg struct {
 	SessionID int       `codec:"sessionID" json:"sessionID"`
 	SecretKey SecretKey `codec:"secretKey" json:"secretKey"`
@@ -312,6 +318,7 @@ type LocalInterface interface {
 	GetDisplayCurrenciesLocal(context.Context, int) ([]CurrencyLocal, error)
 	ChangeWalletAccountNameLocal(context.Context, ChangeWalletAccountNameLocalArg) error
 	SetWalletAccountAsDefaultLocal(context.Context, SetWalletAccountAsDefaultLocalArg) error
+	DeleteWalletAccountLocal(context.Context, DeleteWalletAccountLocalArg) error
 	LinkNewWalletAccountLocal(context.Context, LinkNewWalletAccountLocalArg) (AccountID, error)
 	BalancesLocal(context.Context, AccountID) ([]Balance, error)
 	SendCLILocal(context.Context, SendCLILocalArg) (SendResultCLILocal, error)
@@ -410,6 +417,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					err = i.SetWalletAccountAsDefaultLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"deleteWalletAccountLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]DeleteWalletAccountLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]DeleteWalletAccountLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]DeleteWalletAccountLocalArg)(nil), args)
+						return
+					}
+					err = i.DeleteWalletAccountLocal(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -682,6 +705,11 @@ func (c LocalClient) ChangeWalletAccountNameLocal(ctx context.Context, __arg Cha
 
 func (c LocalClient) SetWalletAccountAsDefaultLocal(ctx context.Context, __arg SetWalletAccountAsDefaultLocalArg) (err error) {
 	err = c.Cli.Call(ctx, "stellar.1.local.setWalletAccountAsDefaultLocal", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) DeleteWalletAccountLocal(ctx context.Context, __arg DeleteWalletAccountLocalArg) (err error) {
+	err = c.Cli.Call(ctx, "stellar.1.local.deleteWalletAccountLocal", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -825,3 +825,30 @@ func SetAccountAsPrimary(m libkb.MetaContext, accountID stellar1.AccountID) (err
 	}
 	return remote.PostWithChainlink(m.Ctx(), m.G(), nextBundle)
 }
+
+func DeleteAccount(m libkb.MetaContext, accountID stellar1.AccountID) error {
+	if accountID.IsNil() {
+		return errors.New("passed empty AccountID")
+	}
+	prevBundle, _, err := remote.Fetch(m.Ctx(), m.G())
+	if err != nil {
+		return err
+	}
+	nextBundle := bundle.Advance(prevBundle)
+	var found bool
+	for i, acc := range nextBundle.Accounts {
+		if acc.AccountID.Eq(accountID) {
+			if acc.IsPrimary {
+				return fmt.Errorf("cannot delete primary account %v", accountID)
+			}
+
+			nextBundle.Accounts = append(nextBundle.Accounts[:i], nextBundle.Accounts[i+1:]...)
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("account not found: %v", accountID)
+	}
+	return remote.Post(m.Ctx(), m.G(), nextBundle)
+}

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -4,6 +4,7 @@ package stellarsvc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -243,4 +244,18 @@ func (s *Server) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar
 	}
 
 	return stellar.SetAccountAsPrimary(m, arg.AccountID)
+}
+
+func (s *Server) DeleteWalletAccountLocal(ctx context.Context, arg stellar1.DeleteWalletAccountLocalArg) (err error) {
+	m := libkb.NewMetaContext(s.logTag(ctx), s.G())
+	defer s.G().CTraceTimed(ctx, "DeleteWalletAccountLocal", func() error { return err })()
+	if err = s.assertLoggedIn(ctx); err != nil {
+		return err
+	}
+
+	if arg.UserAcknowledged != "yes" {
+		return errors.New("User did not acknowledge")
+	}
+
+	return stellar.DeleteAccount(m, arg.AccountID)
 }

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -37,6 +37,13 @@ protocol local {
   void changeWalletAccountNameLocal(int sessionID, AccountID accountID, string newName);
   void setWalletAccountAsDefaultLocal(int sessionID, AccountID accountID);
 
+  // Deleting an account is irreversible, even with Keybase, Inc. help.
+  // Consumer of this API should always prompt the user and warn that if
+  // their secret key is not backed up, they will not be able to access
+  // funds on that account.
+  // This RPC checks if `userAcknowledged` string is equal to "yes".
+  void deleteWalletAccountLocal(int sessionID, AccountID accountID, string userAcknowledged);
+
   AccountID linkNewWalletAccountLocal(int sessionID, SecretKey secretKey, string name);
 
   // -------------------------------------------------------

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -319,6 +319,23 @@
       ],
       "response": null
     },
+    "deleteWalletAccountLocal": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "accountID",
+          "type": "AccountID"
+        },
+        {
+          "name": "userAcknowledged",
+          "type": "string"
+        }
+      ],
+      "response": null
+    },
     "linkNewWalletAccountLocal": {
       "request": [
         {


### PR DESCRIPTION
This PR adds a new RPC and test for it that deletes account from a bundle and posts that bundle. It bails out if account requested to delete is a primary account. We can change this behaviour, but we will have to decide which other account to set as primary.