### PR TITLE
Show loading in thread if inbox sync is happening

### DIFF
--- a/shared/chat/conversation/normal/container.js
+++ b/shared/chat/conversation/normal/container.js
@@ -8,7 +8,9 @@ import {compose, connect, withStateHandlers, type TypedState} from '../../../uti
 import {chatTab} from '../../../constants/tabs'
 
 const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
-  const showLoader = !!state.chat2.loadingMap.get(`loadingThread:${conversationIDKey}`)
+  const loadingMap = state.chat2.loadingMap
+  const showLoader =
+    !!loadingMap.get(`loadingThread:${conversationIDKey}`) || !!loadingMap.get('inboxSyncStarted')
   const meta = Constants.getMeta(state, conversationIDKey)
   const infoPanelOpen = Constants.isInfoPanelOpen(state)
   return {conversationIDKey, infoPanelOpen, showLoader, threadLoadedOffline: meta.offline}


### PR DESCRIPTION
@keybase/react-hackers this shows the loader in the thread if the inbox sync is happening, which is a precursor for us to know if we need more messages in the thread itself

cc: @mmaxim 