### PR TITLE
Fix the Help/Doc link on desktop

### DIFF
--- a/shared/util/url-helper.js
+++ b/shared/util/url-helper.js
@@ -2,6 +2,7 @@
 import keybaseUrl from '../constants/urls'
 
 const linkFuncs = {
+  help: () => `${keybaseUrl}/getting-started`,
   home: () => keybaseUrl,
   user: ({username}) => `${keybaseUrl}/${username || ''}`,
 }


### PR DESCRIPTION
@keybase/react-hackers 

This broke when we decided to stop loading the Getting Started link on first run (and removed this url).