### PR TITLE
Fix bug in deviceEK storage key format

### DIFF
--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -28,11 +28,17 @@ type DeviceEKStorage struct {
 }
 
 func NewDeviceEKStorage(g *libkb.GlobalContext) *DeviceEKStorage {
-	return &DeviceEKStorage{
+	s := &DeviceEKStorage{
 		Contextified: libkb.NewContextified(g),
 		storage:      erasablekv.NewFileErasableKVStore(g, deviceEKSubDir),
 		cache:        make(DeviceEKMap),
 	}
+	// TODO remove this once the fix is propagated
+	err := s.keyFormatRepair(context.TODO())
+	if err != nil {
+		s.G().Log.CWarningf(context.TODO(), "keyFormatRepair failed: %v", err)
+	}
+	return s
 }
 
 func (s *DeviceEKStorage) keyPrefixFromUsername(username libkb.NormalizedUsername) string {
@@ -44,7 +50,7 @@ func (s *DeviceEKStorage) keyPrefix(ctx context.Context) (prefix string, err err
 	if err != nil {
 		return prefix, err
 	}
-	return fmt.Sprintf("%s-%s-", s.keyPrefixFromUsername(s.G().Env.GetUsername()), uv.EldestSeqno), nil
+	return fmt.Sprintf("%s%s-", s.keyPrefixFromUsername(s.G().Env.GetUsername()), uv.EldestSeqno), nil
 }
 
 func (s *DeviceEKStorage) key(ctx context.Context, generation keybase1.EkGeneration) (key string, err error) {
@@ -336,6 +342,45 @@ func (s *DeviceEKStorage) ForceDeleteAll(ctx context.Context, username libkb.Nor
 	for _, key := range keys {
 		// only delete if the key is owned by the current user
 		if strings.HasPrefix(key, prefix) {
+			epick.Push(s.storage.Erase(ctx, key))
+		}
+	}
+
+	s.clearCache()
+	return epick.Error()
+}
+
+// There was a bug in the deviceEK format introduced in
+// https://github.com/keybase/client/pull/11911 where the key format went from
+//  deviceEKPrefix-username-eldestSeqNo-generation.ek to
+//  deviceEKPrefix-username--eldestSeqNo-generation.ek
+// We repair these keys on startup to fix this.
+func (s *DeviceEKStorage) keyFormatRepair(ctx context.Context) (err error) {
+	defer s.G().CTraceTimed(ctx, "DeviceEKStorage#fixKeyFormat", func() error { return err })()
+
+	s.Lock()
+	defer s.Unlock()
+
+	keys, err := s.storage.AllKeys(ctx)
+	if err != nil {
+		return err
+	}
+	epick := libkb.FirstErrorPicker{}
+	prefix := fmt.Sprintf("%s-%s--", deviceEKPrefix, s.G().Env.GetUsername())
+	for _, key := range keys {
+		if strings.HasPrefix(key, prefix) {
+			deviceEK := keybase1.DeviceEk{}
+			s.storage.Get(ctx, key, &deviceEK)
+			if err != nil {
+				epick.Push(err)
+				continue
+			}
+			newKey := strings.Replace(key, "--", "-", 1)
+			err = s.storage.Put(ctx, newKey, deviceEK)
+			if err != nil {
+				epick.Push(err)
+				continue
+			}
 			epick.Push(s.storage.Erase(ctx, key))
 		}
 	}

--- a/go/ephemeral/user_ek_box_storage_test.go
+++ b/go/ephemeral/user_ek_box_storage_test.go
@@ -1,6 +1,7 @@
 package ephemeral
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
@@ -92,4 +93,21 @@ func TestUserEKBoxStorage(t *testing.T) {
 	expected := []keybase1.EkGeneration(nil)
 	require.NoError(t, err)
 	require.Equal(t, expected, expired)
+}
+
+// If we change the key format intentionally, we have to introduce some form of
+// migration or versioning between the keys. This test should blow up if we
+// break it unintentionally.
+func TestUserEKStorageKeyFormat(t *testing.T) {
+	tc, _ := ephemeralKeyTestSetup(t)
+	defer tc.Cleanup()
+
+	s := NewUserEKBoxStorage(tc.G)
+	uv, err := getCurrentUserUV(context.Background(), tc.G)
+	require.NoError(t, err)
+
+	key, err := s.dbKey(context.Background())
+	require.NoError(t, err)
+	expected := fmt.Sprintf("userEphemeralKeyBox-%s-%s", s.G().Env.GetUsername(), uv.EldestSeqno)
+	require.Equal(t, expected, key.Key)
 }


### PR DESCRIPTION
Noticed this in the logs:

```
deletedWrongEldestSeqno: skipping delete, invalid keyToEldestSeqno: deviceEphemeralKey-joshblum--1-20.ek -> 0, error: Invalid key format for deviceEK: deviceEphemeralKey-joshblum--1-20.ek 
```

in https://github.com/keybase/client/pull/11911 i had an error in string formatting that introduced an extra `-` in the disk key format for deviceEKs. tests didn't catch it since we didn't have a test for key format changing and we can read/write/delete w/o problem otherwise. I added a little migrator that will bring back the old format and tests that will fail so we can't burn ourselves with something similar again. 