### PR TITLE
Exploding messages: timer to the right

### DIFF
--- a/shared/chat/conversation/messages/message-popup/exploding/index.js
+++ b/shared/chat/conversation/messages/message-popup/exploding/index.js
@@ -113,7 +113,7 @@ class ExplodingPopupHeader extends React.Component<PropsWithTimer<Props>, State>
           gapEnd={true}
           gapStart={true}
           style={{
-            backgroundColor: this.state.secondsLeft < oneHourInSecs ? globalColors.red : globalColors.black,
+            backgroundColor: this.state.secondsLeft < oneMinuteInS ? globalColors.red : globalColors.black,
             marginTop: globalMargins.tiny,
           }}
         >
@@ -166,7 +166,7 @@ const ExplodingPopupMenu = (props: PropsWithTimer<Props>) => {
   )
 }
 
-const oneHourInSecs = 60 * 60
+const oneMinuteInS = 60
 
 const stylePopup = platformStyles({
   common: {

--- a/shared/chat/conversation/messages/message-popup/exploding/index.js
+++ b/shared/chat/conversation/messages/message-popup/exploding/index.js
@@ -113,7 +113,7 @@ class ExplodingPopupHeader extends React.Component<PropsWithTimer<Props>, State>
           gapEnd={true}
           gapStart={true}
           style={{
-            backgroundColor: this.state.secondsLeft < oneMinuteInS ? globalColors.red : globalColors.black,
+            backgroundColor: this.state.secondsLeft < oneMinuteInS ? globalColors.red : globalColors.black_75,
             marginTop: globalMargins.tiny,
           }}
         >

--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -82,6 +82,7 @@ const mergeProps = (stateProps, dispatchProps) => {
 
   return {
     author: message.author,
+    exploded: message.exploded,
     explodesAt: message.explodingTime,
     exploding: message.exploding,
     failureDescription,

--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -82,6 +82,8 @@ const mergeProps = (stateProps, dispatchProps) => {
 
   return {
     author: message.author,
+    explodesAt: message.explodingTime,
+    exploding: message.exploding,
     failureDescription,
     includeHeader,
     innerClass: stateProps.innerClass,

--- a/shared/chat/conversation/messages/wrapper/exploding-meta.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta.js
@@ -56,7 +56,7 @@ class ExplodingMeta extends React.Component<Props, State> {
     switch (this.state.mode) {
       case 'countdown':
         return (
-          <Box2 direction="horizontal" gap="xtiny">
+          <Box2 direction="horizontal" gap="xtiny" style={styles.container}>
             <Box2
               direction="horizontal"
               style={collapseStyles([
@@ -74,7 +74,11 @@ class ExplodingMeta extends React.Component<Props, State> {
           </Box2>
         )
       case 'boom':
-        return <Icon type="iconfont-boom" fontSize={isMobile ? 44 : 22} color={globalColors.black_75} />
+        return (
+          <Box2 direction="horizontal" style={styles.container}>
+            <Icon type="iconfont-boom" fontSize={isMobile ? 44 : 22} color={globalColors.black_75} />
+          </Box2>
+        )
     }
     return null
   }
@@ -111,6 +115,9 @@ const formatTimeDifference = (d: number): string => {
 }
 
 const styles = styleSheetCreate({
+  container: {
+    alignSelf: 'flex-end',
+  },
   countdownContainer: {
     borderRadius: 2,
     paddingLeft: 4,

--- a/shared/chat/conversation/messages/wrapper/exploding-meta.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react'
 import {Box2, Text, Icon, HOCTimers, type PropsWithTimer} from '../../../../common-adapters'
-// import {} from '../../../../constants/types/chat2'
-import {collapseStyles, globalColors, isMobile, styleSheetCreate} from '../../../../styles'
+import {castPlatformStyles} from '../../../../common-adapters/icon'
+import {collapseStyles, globalColors, isMobile, platformStyles, styleSheetCreate} from '../../../../styles'
 
 const oneMinuteInMs = 60 * 1000
 const oneHourInMs = oneMinuteInMs * 60
@@ -53,10 +53,11 @@ class ExplodingMeta extends React.Component<Props, State> {
   render() {
     const backgroundColor =
       this.props.explodesAt - Date.now() < oneMinuteInMs ? globalColors.red : globalColors.black_75
+    let children
     switch (this.state.mode) {
       case 'countdown':
-        return (
-          <Box2 direction="horizontal" gap="xtiny" style={styles.container}>
+        children = (
+          <Box2 direction="horizontal" gap="xtiny">
             <Box2
               direction="horizontal"
               style={collapseStyles([
@@ -73,14 +74,24 @@ class ExplodingMeta extends React.Component<Props, State> {
             <Icon type="iconfont-bomb" fontSize={isMobile ? 22 : 16} color={globalColors.black_75} />
           </Box2>
         )
+        break
       case 'boom':
-        return (
-          <Box2 direction="horizontal" style={styles.container}>
-            <Icon type="iconfont-boom" fontSize={isMobile ? 44 : 22} color={globalColors.black_75} />
+        children = (
+          <Box2 direction="horizontal">
+            <Icon
+              type="iconfont-boom"
+              style={castPlatformStyles(styles.boomIcon)}
+              fontSize={isMobile ? 44 : 35}
+              color={globalColors.black_75}
+            />
           </Box2>
         )
     }
-    return null
+    return (
+      <Box2 direction="horizontal" style={styles.container}>
+        {children}
+      </Box2>
+    )
   }
 }
 
@@ -100,7 +111,7 @@ const getLoopInterval = (diff: number) => {
 
 const formatTimeDifference = (d: number): string => {
   if (d < 0) {
-    return 'now'
+    return '0'
   }
   if (d > oneDayInMs) {
     return `${Math.floor(d / oneDayInMs)}d`
@@ -115,8 +126,24 @@ const formatTimeDifference = (d: number): string => {
 }
 
 const styles = styleSheetCreate({
+  boomIcon: platformStyles({
+    common: {
+      position: 'absolute',
+    },
+    isElectron: {
+      top: -6,
+      left: 0,
+    },
+    isMobile: {
+      top: -22,
+      left: 0,
+    },
+  }),
   container: {
     alignSelf: 'flex-end',
+    position: 'relative',
+    width: isMobile ? 80 : 72,
+    height: isMobile ? 22 : 19,
   },
   countdownContainer: {
     borderRadius: 2,

--- a/shared/chat/conversation/messages/wrapper/exploding-meta.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta.js
@@ -84,15 +84,15 @@ class ExplodingMeta extends React.Component<Props, State> {
   }
 }
 
-const getLoopInterval = (d: number) => {
-  if (d > oneDayInMs) {
-    return d - Math.floor(d / oneDayInMs) * oneDayInMs
+const getLoopInterval = (diff: number) => {
+  if (diff > oneDayInMs) {
+    return diff - Math.floor(diff / oneDayInMs) * oneDayInMs
   }
-  if (d > oneHourInMs) {
-    return d - Math.floor(d / oneHourInMs) * oneHourInMs
+  if (diff > oneHourInMs) {
+    return diff - Math.floor(diff / oneHourInMs) * oneHourInMs
   }
-  if (d > oneMinuteInMs) {
-    return d - Math.floor(d / oneMinuteInMs) * oneMinuteInMs
+  if (diff > oneMinuteInMs) {
+    return diff - Math.floor(diff / oneMinuteInMs) * oneMinuteInMs
   }
   // less than a minute, check every second
   return 1000

--- a/shared/chat/conversation/messages/wrapper/exploding-meta.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import {Box2, Text, Icon, HOCTimers, type PropsWithTimer} from '../../../../common-adapters'
 import {castPlatformStyles} from '../../../../common-adapters/icon'
 import {collapseStyles, globalColors, isMobile, platformStyles, styleSheetCreate} from '../../../../styles'
+import {formatDurationShort} from '../../../../util/timestamp'
 
 const oneMinuteInMs = 60 * 1000
 const oneHourInMs = oneMinuteInMs * 60
@@ -68,7 +69,7 @@ class ExplodingMeta extends React.Component<Props, State> {
               ])}
             >
               <Text type="Body" style={{color: globalColors.white, fontSize: 10, fontWeight: 'bold'}}>
-                {formatTimeDifference(this.props.explodesAt - Date.now())}
+                {formatDurationShort(this.props.explodesAt - Date.now())}
               </Text>
             </Box2>
             <Icon type="iconfont-bomb" fontSize={isMobile ? 22 : 16} color={globalColors.black_75} />
@@ -107,22 +108,6 @@ const getLoopInterval = (diff: number) => {
   }
   // less than a minute, check every second
   return 1000
-}
-
-const formatTimeDifference = (d: number): string => {
-  if (d < 0) {
-    return '0'
-  }
-  if (d > oneDayInMs) {
-    return `${Math.floor(d / oneDayInMs)}d`
-  }
-  if (d > oneHourInMs) {
-    return `${Math.floor(d / oneHourInMs)}h`
-  }
-  if (d > oneMinuteInMs) {
-    return `${Math.floor(d / oneMinuteInMs)}m`
-  }
-  return `${Math.floor(d / 1000)}s`
 }
 
 const styles = styleSheetCreate({

--- a/shared/chat/conversation/messages/wrapper/exploding-meta.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta.js
@@ -51,6 +51,8 @@ class ExplodingMeta extends React.Component<Props, State> {
   }
 
   render() {
+    const backgroundColor =
+      this.props.explodesAt - Date.now() < oneMinuteInMs ? globalColors.red : globalColors.black_75
     switch (this.state.mode) {
       case 'countdown':
         return (
@@ -60,10 +62,7 @@ class ExplodingMeta extends React.Component<Props, State> {
               style={collapseStyles([
                 styles.countdownContainer,
                 {
-                  backgroundColor:
-                    this.props.explodesAt - Date.now() < oneMinuteInMs
-                      ? globalColors.red
-                      : globalColors.black,
+                  backgroundColor,
                 },
               ])}
             >
@@ -71,10 +70,11 @@ class ExplodingMeta extends React.Component<Props, State> {
                 {formatTimeDifference(this.props.explodesAt - Date.now())}
               </Text>
             </Box2>
+            <Icon type="iconfont-bomb" fontSize={isMobile ? 22 : 16} color={globalColors.black_75} />
           </Box2>
         )
       case 'boom':
-        return <Icon type="iconfont-boom" fontSize={isMobile ? 44 : 22} />
+        return <Icon type="iconfont-boom" fontSize={isMobile ? 44 : 22} color={globalColors.black_75} />
     }
     return null
   }

--- a/shared/chat/conversation/messages/wrapper/exploding-meta.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta.js
@@ -1,0 +1,121 @@
+// @flow
+import * as React from 'react'
+import {Box2, Text, Icon, HOCTimers, type PropsWithTimer} from '../../../../common-adapters'
+// import {} from '../../../../constants/types/chat2'
+import {collapseStyles, globalColors, isMobile, styleSheetCreate} from '../../../../styles'
+
+const oneMinuteInMs = 60 * 1000
+const oneHourInMs = oneMinuteInMs * 60
+const oneDayInMs = oneHourInMs * 24
+
+type Props = PropsWithTimer<{
+  explodesAt: number,
+}>
+
+// 'none' is functionally 'unset', used to detect a fresh mount
+// and hide self if the message already exploded
+type State = {
+  mode: 'none' | 'countdown' | 'boom' | 'hidden',
+}
+
+class ExplodingMeta extends React.Component<Props, State> {
+  state = {
+    mode: 'none',
+  }
+
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    if (prevState.mode === 'none' && Date.now() >= nextProps.explodesAt) {
+      return {mode: 'hidden'}
+    }
+    if (prevState.mode !== 'none') {
+      // never change away from anything set
+      return null
+    }
+    return {mode: 'countdown'}
+  }
+
+  componentDidMount() {
+    this.state.mode === 'countdown' && this._updateLoop()
+  }
+
+  _updateLoop = () => {
+    const difference = this.props.explodesAt - Date.now()
+    if (difference <= 0) {
+      this.setState({mode: 'boom'})
+      return
+    }
+    const interval = getLoopInterval(difference)
+    this.props.setTimeout(() => {
+      this.forceUpdate(this._updateLoop)
+    }, interval)
+  }
+
+  render() {
+    switch (this.state.mode) {
+      case 'countdown':
+        return (
+          <Box2 direction="horizontal" gap="xtiny">
+            <Box2
+              direction="horizontal"
+              style={collapseStyles([
+                styles.countdownContainer,
+                {
+                  backgroundColor:
+                    this.props.explodesAt - Date.now() < oneMinuteInMs
+                      ? globalColors.red
+                      : globalColors.black,
+                },
+              ])}
+            >
+              <Text type="Body" style={{color: globalColors.white, fontSize: 10, fontWeight: 'bold'}}>
+                {formatTimeDifference(this.props.explodesAt - Date.now())}
+              </Text>
+            </Box2>
+          </Box2>
+        )
+      case 'boom':
+        return <Icon type="iconfont-boom" fontSize={isMobile ? 44 : 22} />
+    }
+    return null
+  }
+}
+
+const getLoopInterval = (d: number) => {
+  if (d > oneDayInMs) {
+    return d - Math.floor(d / oneDayInMs) * oneDayInMs
+  }
+  if (d > oneHourInMs) {
+    return d - Math.floor(d / oneHourInMs) * oneHourInMs
+  }
+  if (d > oneMinuteInMs) {
+    return d - Math.floor(d / oneMinuteInMs) * oneMinuteInMs
+  }
+  // less than a minute, check every second
+  return 1000
+}
+
+const formatTimeDifference = (d: number): string => {
+  if (d < 0) {
+    return 'now'
+  }
+  if (d > oneDayInMs) {
+    return `${Math.floor(d / oneDayInMs)}d`
+  }
+  if (d > oneHourInMs) {
+    return `${Math.floor(d / oneHourInMs)}h`
+  }
+  if (d > oneMinuteInMs) {
+    return `${Math.floor(d / oneMinuteInMs)}m`
+  }
+  return `${Math.floor(d / 1000)}s`
+}
+
+const styles = styleSheetCreate({
+  countdownContainer: {
+    borderRadius: 2,
+    paddingLeft: 4,
+    paddingRight: 4,
+  },
+})
+
+export default HOCTimers(ExplodingMeta)

--- a/shared/chat/conversation/messages/wrapper/height-retainer/index.desktop.js
+++ b/shared/chat/conversation/messages/wrapper/height-retainer/index.desktop.js
@@ -39,6 +39,8 @@ class HeightRetainer extends React.Component<Props, State> {
               backgroundImage: explodedIllustrationUrl,
               backgroundRepeat: 'repeat',
               backgroundSize: '400px 68px',
+              maxWidth: 500,
+              marginRight: 60,
             },
         ])}
       >

--- a/shared/chat/conversation/messages/wrapper/index.js.flow
+++ b/shared/chat/conversation/messages/wrapper/index.js.flow
@@ -4,6 +4,8 @@ import * as Types from '../../../../constants/types/chat2'
 
 export type Props = {
   author: string,
+  explodesAt: number,
+  exploding: boolean,
   failureDescription: string,
   includeHeader: boolean,
   innerClass: React.ComponentType<any>,

--- a/shared/chat/conversation/messages/wrapper/index.js.flow
+++ b/shared/chat/conversation/messages/wrapper/index.js.flow
@@ -4,6 +4,7 @@ import * as Types from '../../../../constants/types/chat2'
 
 export type Props = {
   author: string,
+  exploded: boolean,
   explodesAt: number,
   exploding: boolean,
   failureDescription: string,

--- a/shared/chat/conversation/messages/wrapper/index.native.js
+++ b/shared/chat/conversation/messages/wrapper/index.native.js
@@ -13,7 +13,7 @@ const dismissKeyboard = () => {
 
 const _NativeWrapper = (props: Props & FloatingMenuParentProps) => (
   <NativeTouchableHighlight
-    onLongPress={props.message.exploded ? undefined : props.toggleShowingMenu}
+    onLongPress={props.exploded ? undefined : props.toggleShowingMenu}
     underlayColor={globalColors.white}
     onPress={dismissKeyboard}
   >

--- a/shared/chat/conversation/messages/wrapper/index.native.js
+++ b/shared/chat/conversation/messages/wrapper/index.native.js
@@ -13,7 +13,7 @@ const dismissKeyboard = () => {
 
 const _NativeWrapper = (props: Props & FloatingMenuParentProps) => (
   <NativeTouchableHighlight
-    onLongPress={props.toggleShowingMenu}
+    onLongPress={props.message.exploded ? undefined : props.toggleShowingMenu}
     underlayColor={globalColors.white}
     onPress={dismissKeyboard}
   >

--- a/shared/chat/conversation/messages/wrapper/shared.js
+++ b/shared/chat/conversation/messages/wrapper/shared.js
@@ -107,70 +107,75 @@ const LeftSide = props => (
 )
 
 const RightSide = props => (
-  <Box
-    style={collapseStyles([styles.rightSide, props.includeHeader && styles.hasHeader])}
-    className="message-wrapper"
-  >
-    {props.includeHeader && (
-      <Username
-        username={props.author}
-        isYou={props.isYou}
-        isFollowing={props.isFollowing}
-        isBroken={props.isBroken}
-        onClick={props.onAuthorClick}
-      />
-    )}
-    <Box style={styles.textContainer} className="message">
-      {/* TODO remove the `|| props.isExplodingUnreadable` when a fix for inadvertent error messages is in.
+  <Box style={styles.rightSideContainer}>
+    <Box
+      style={collapseStyles([styles.rightSide, props.includeHeader && styles.hasHeader])}
+      className="message-wrapper"
+    >
+      {props.includeHeader && (
+        <Username
+          username={props.author}
+          isYou={props.isYou}
+          isFollowing={props.isFollowing}
+          isBroken={props.isBroken}
+          onClick={props.onAuthorClick}
+        />
+      )}
+      <Box style={styles.textContainer} className="message">
+        {/* TODO remove the `|| props.isExplodingUnreadable` when a fix for inadvertent error messages is in.
           The problem is that `isExplodingUnreadable` is coming as true without `props.message.exploded` sometimes.  */}
-      <HeightRetainer
-        style={styles.flexOneColumn}
-        retainHeight={props.message.exploded || props.isExplodingUnreadable}
-      >
-        <props.innerClass
+        <HeightRetainer
+          style={styles.flexOneColumn}
+          retainHeight={props.message.exploded || props.isExplodingUnreadable}
+        >
+          <props.innerClass
+            message={props.message}
+            isEditing={props.isEditing}
+            toggleShowingMenu={props.toggleShowingMenu}
+          />
+          {props.isEdited && <EditedMark />}
+        </HeightRetainer>
+        {!isMobile &&
+          !props.message.exploded && (
+            <MenuButton setRef={props.setAttachmentRef} onClick={props.toggleShowingMenu} />
+          )}
+        <MessagePopup
+          attachTo={props.attachmentRef}
           message={props.message}
-          isEditing={props.isEditing}
-          toggleShowingMenu={props.toggleShowingMenu}
+          onHidden={props.toggleShowingMenu}
+          position="bottom left"
+          visible={props.showingMenu}
         />
-        {props.isEdited && <EditedMark />}
-      </HeightRetainer>
-      {!isMobile && <MenuButton setRef={props.setAttachmentRef} onClick={props.toggleShowingMenu} />}
-      <MessagePopup
-        attachTo={props.attachmentRef}
-        message={props.message}
-        onHidden={props.toggleShowingMenu}
-        position="bottom left"
-        visible={props.showingMenu}
-      />
-      {props.isRevoked && (
-        <Icon
-          type="iconfont-exclamation"
-          style={iconCastPlatformStyles(styles.exclamation)}
-          color={globalColors.blue}
-          fontSize={11}
-        />
-      )}
-      {props.exploding && <ExplodingMeta explodesAt={props.explodesAt} />}
-    </Box>
-    {!!props.failureDescription && (
-      <Failure
-        failureDescription={props.failureDescription}
-        isExplodingUnreadable={props.isExplodingUnreadable}
-        onRetry={props.onRetry}
-        onEdit={props.onEdit}
-        onCancel={props.onCancel}
-      />
-    )}
-    <Box style={styles.sendIndicatorContainer}>
-      {props.isYou && (
-        <SendIndicator
-          sent={props.messageSent}
-          failed={props.messageFailed}
-          style={{marginBottom: 2}}
-          id={props.message.timestamp}
+        {props.isRevoked && (
+          <Icon
+            type="iconfont-exclamation"
+            style={iconCastPlatformStyles(styles.exclamation)}
+            color={globalColors.blue}
+            fontSize={11}
+          />
+        )}
+      </Box>
+      {!!props.failureDescription && (
+        <Failure
+          failureDescription={props.failureDescription}
+          isExplodingUnreadable={props.isExplodingUnreadable}
+          onRetry={props.onRetry}
+          onEdit={props.onEdit}
+          onCancel={props.onCancel}
         />
       )}
+      <Box style={styles.sendIndicatorContainer}>
+        {props.isYou && (
+          <SendIndicator
+            sent={props.messageSent}
+            failed={props.messageFailed}
+            style={{marginBottom: 2}}
+            id={props.message.timestamp}
+          />
+        )}
+      </Box>
     </Box>
+    {props.exploding && <ExplodingMeta explodesAt={props.explodesAt} />}
   </Box>
 )
 
@@ -218,13 +223,19 @@ const styles = styleSheetCreate({
     common: {
       ...globalStyles.flexBoxColumn,
       flex: 1,
-      paddingBottom: 2,
       paddingRight: globalMargins.tiny,
+      position: 'relative',
     },
     isMobile: {
       marginRight: sendIndicatorWidth,
     },
   }),
+  rightSideContainer: {
+    ...globalStyles.flexBoxRow,
+    flex: 1,
+    paddingBottom: 2,
+    paddingRight: globalMargins.tiny,
+  },
   selected: {backgroundColor: globalColors.black_05},
   sendIndicator: {marginBottom: 2},
   sendIndicatorContainer: platformStyles({

--- a/shared/chat/conversation/messages/wrapper/shared.js
+++ b/shared/chat/conversation/messages/wrapper/shared.js
@@ -123,10 +123,10 @@ const RightSide = props => (
       )}
       <Box style={styles.textContainer} className="message">
         {/* TODO remove the `|| props.isExplodingUnreadable` when a fix for inadvertent error messages is in.
-          The problem is that `isExplodingUnreadable` is coming as true without `props.message.exploded` sometimes.  */}
+          The problem is that `isExplodingUnreadable` is coming as true without `props.exploded` sometimes.  */}
         <HeightRetainer
           style={styles.flexOneColumn}
-          retainHeight={props.message.exploded || props.isExplodingUnreadable}
+          retainHeight={props.exploded || props.isExplodingUnreadable}
         >
           <props.innerClass
             message={props.message}
@@ -136,9 +136,7 @@ const RightSide = props => (
           {props.isEdited && <EditedMark />}
         </HeightRetainer>
         {!isMobile &&
-          !props.message.exploded && (
-            <MenuButton setRef={props.setAttachmentRef} onClick={props.toggleShowingMenu} />
-          )}
+          !props.exploded && <MenuButton setRef={props.setAttachmentRef} onClick={props.toggleShowingMenu} />}
         <MessagePopup
           attachTo={props.attachmentRef}
           message={props.message}

--- a/shared/chat/conversation/messages/wrapper/shared.js
+++ b/shared/chat/conversation/messages/wrapper/shared.js
@@ -15,6 +15,7 @@ import Timestamp from './timestamp'
 import SendIndicator from './chat-send'
 import MessagePopup from '../message-popup'
 import HeightRetainer from './height-retainer'
+import ExplodingMeta from './exploding-meta'
 
 import type {Props} from '.'
 
@@ -149,6 +150,7 @@ const RightSide = props => (
           fontSize={11}
         />
       )}
+      {props.exploding && <ExplodingMeta explodesAt={props.explodesAt} />}
     </Box>
     {!!props.failureDescription && (
       <Failure

--- a/shared/util/__mocks__/timestamp.js
+++ b/shared/util/__mocks__/timestamp.js
@@ -32,3 +32,7 @@ export function daysToLabel(days: number): string {
 export function secondsToDHMS(seconds: number): string {
   return '[mocked]'
 }
+
+export function formatDurationShort(ms: number): string {
+  return '[mocked]'
+}

--- a/shared/util/timestamp.js
+++ b/shared/util/timestamp.js
@@ -105,3 +105,22 @@ export function secondsToDHMS(seconds: number): string {
 
   return `${days}d ${hours}h ${mins}m ${secs}s`
 }
+
+const oneMinuteInMs = 60 * 1000
+const oneHourInMs = oneMinuteInMs * 60
+const oneDayInMs = oneHourInMs * 24
+export function formatDurationShort(ms: number): string {
+  if (ms < 0) {
+    return '0'
+  }
+  if (ms > oneDayInMs) {
+    return `${Math.floor(ms / oneDayInMs)}d`
+  }
+  if (ms > oneHourInMs) {
+    return `${Math.floor(ms / oneHourInMs)}h`
+  }
+  if (ms > oneMinuteInMs) {
+    return `${Math.floor(ms / oneMinuteInMs)}m`
+  }
+  return `${Math.floor(ms / 1000)}s`
+}


### PR DESCRIPTION
The styling is still a little rough around the message container & send indicator. It'll probably be cleaned a little in a later PR, when the `EXPLODED` annotation is added. This is the timer counting down and the boom icon as things explode:

<img width="80" alt="image" src="https://user-images.githubusercontent.com/11968340/40492540-b28b9ea0-5f3e-11e8-9f98-3e6022e45687.png">


 r? @keybase/react-hackers 