### PR TITLE
use a NEWACTIVITY stale message for retry success, and just have JS reload thread without clearing it

### DIFF
--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -63,7 +63,7 @@ func (c *ConversationRetry) RekeyFixable(ctx context.Context, tlfID chat1.TLFID)
 func (c *ConversationRetry) SendStale(ctx context.Context, uid gregor1.UID) {
 	supdates := []chat1.ConversationStaleUpdate{chat1.ConversationStaleUpdate{
 		ConvID:     c.convID,
-		UpdateType: chat1.StaleUpdateType_CLEAR,
+		UpdateType: chat1.StaleUpdateType_NEWACTIVITY,
 	}}
 	c.G().Syncer.SendChatStaleNotifications(ctx, uid, supdates, false)
 }

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -67,7 +67,7 @@ func TestFetchRetry(t *testing.T) {
 	select {
 	case updates := <-list.threadsStale:
 		require.Equal(t, 1, len(updates))
-		require.Equal(t, chat1.StaleUpdateType_CLEAR, updates[0].UpdateType)
+		require.Equal(t, chat1.StaleUpdateType_NEWACTIVITY, updates[0].UpdateType)
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "timeout on inbox stale")
 	}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2882,7 +2882,7 @@ func TestChatSrvGetThreadNonblockError(t *testing.T) {
 		select {
 		case updates := <-listener.threadsStale:
 			require.Equal(t, 1, len(updates))
-			require.Equal(t, chat1.StaleUpdateType_CLEAR, updates[0].UpdateType)
+			require.Equal(t, chat1.StaleUpdateType_NEWACTIVITY, updates[0].UpdateType)
 		case <-time.After(2 * time.Second):
 			require.Fail(t, "no threads stale message received")
 		}
@@ -2951,7 +2951,7 @@ func TestChatSrvGetInboxNonblockError(t *testing.T) {
 		select {
 		case updates := <-listener.threadsStale:
 			require.Equal(t, 1, len(updates))
-			require.Equal(t, chat1.StaleUpdateType_CLEAR, updates[0].UpdateType)
+			require.Equal(t, chat1.StaleUpdateType_NEWACTIVITY, updates[0].UpdateType)
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "no threads stale message received")
 		}

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -130,7 +130,10 @@ type _LeaveConversationPayload = $ReadOnly<{|
   dontNavigateToInbox?: boolean,
 |}>
 type _LoadOlderMessagesDueToScrollPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey|}>
-type _MarkConversationsStalePayload = $ReadOnly<{|conversationIDKeys: Array<Types.ConversationIDKey>|}>
+type _MarkConversationsStalePayload = $ReadOnly<{|
+  conversationIDKeys: Array<Types.ConversationIDKey>,
+  updateType: RPCChatTypes.StaleUpdateType,
+|}>
 type _MarkInitiallyLoadedThreadAsReadPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey|}>
 type _MessageAttachmentNativeSavePayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -456,6 +456,11 @@ const onChatThreadStale = updates => {
       return arr
     }, [])
     if (conversationIDKeys.length > 0) {
+      logger.info(
+        `onChatThreadStale: dispatching thread reload actions for ${
+          conversationIDKeys.length
+        } convs of type ${key}`
+      )
       actions.concat([
         Chat2Gen.createMarkConversationsStale({
           conversationIDKeys,

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -18,31 +18,31 @@
     // Select a conversation (or leave nothing selected)
     "selectConversation": {
       "conversationIDKey": "Types.ConversationIDKey",
-        // why this happened, sometimes there's different side effects
-        "reason": [
-          "'clearSelected'", // deselect
-          "'justCreated'", // just made one
-          "'desktopNotification'", // clicked notification
-          "'searching'", // searching and found one
-          "'sendingToPending'", // select the pending we sent into
-          "'createdMessagePrivately'", // messaging privately and maybe made it
-          "'findNewestConversation'", // find a new chat to select
-          "'inboxBig'", // inbox row
-          "'inboxFilterArrow'", // arrow keys in inbox filter
-          "'inboxFilterChanged'", // inbox filter made first one selected
-          "'inboxSmall'", // inbox row
-          "'inboxNewConversation'", // new conversation row
-          "'jumpFromReset'", // from older reset convo
-          "'jumpToReset'", // going to an older reset convo
-          "'justCreated'", // just made it and select it
-          "'manageView'", // clicked from manage screen
-          "'previewResolved'", // did a preview and are now selecting it
-          "'pendingModeChange'", // pending mode changed so we select the pending conversation id key
-          "'push'", // from a push
-          "'savedLastState'", // last seen chat tab
-          "'startFoundExisting'", // starting a conversation and found one already
-          "'teamChat'", // from team
-        ]
+      // why this happened, sometimes there's different side effects
+      "reason": [
+        "'clearSelected'", // deselect
+        "'justCreated'", // just made one
+        "'desktopNotification'", // clicked notification
+        "'searching'", // searching and found one
+        "'sendingToPending'", // select the pending we sent into
+        "'createdMessagePrivately'", // messaging privately and maybe made it
+        "'findNewestConversation'", // find a new chat to select
+        "'inboxBig'", // inbox row
+        "'inboxFilterArrow'", // arrow keys in inbox filter
+        "'inboxFilterChanged'", // inbox filter made first one selected
+        "'inboxSmall'", // inbox row
+        "'inboxNewConversation'", // new conversation row
+        "'jumpFromReset'", // from older reset convo
+        "'jumpToReset'", // going to an older reset convo
+        "'justCreated'", // just made it and select it
+        "'manageView'", // clicked from manage screen
+        "'previewResolved'", // did a preview and are now selecting it
+        "'pendingModeChange'", // pending mode changed so we select the pending conversation id key
+        "'push'", // from a push
+        "'savedLastState'", // last seen chat tab
+        "'startFoundExisting'", // starting a conversation and found one already
+        "'teamChat'" // from team
+      ]
     },
     // Select an existing conversation or setup an empty one. Can either be adhoc or a tlf (adhoc or team)
     // fromAReset means you were in a reset kbfs convo and you want to make a new one
@@ -67,12 +67,12 @@
         "'teamHeader'",
         "'convertAdHoc'",
         "'memberView'",
-        "'newChannel'",
+        "'newChannel'"
       ]
     },
     "createConversation": {
       "_description": "Actually start a conversation",
-      "participants": "Array<string>",
+      "participants": "Array<string>"
     },
     // Update our badges in the nav
     "badgesUpdated": {
@@ -156,8 +156,9 @@
       "outboxID": "Types.OutboxID"
     },
     "setPendingConversationExistingConversationIDKey": {
-      "_description": "When the search changes we need to find any existing conversations to stash into the metaMap",
-      "conversationIDKey": "Types.ConversationIDKey",
+      "_description":
+        "When the search changes we need to find any existing conversations to stash into the metaMap",
+      "conversationIDKey": "Types.ConversationIDKey"
     },
     // Start editing a message / or edit the last message / or clear editing
     "messageSetEditing": {
@@ -329,7 +330,8 @@
     },
     // Server told us a conversation is out of date
     "markConversationsStale": {
-      "conversationIDKeys": "Array<Types.ConversationIDKey>"
+      "conversationIDKeys": "Array<Types.ConversationIDKey>",
+      "updateType": "RPCChatTypes.StaleUpdateType"
     },
     // Navigation helpers. Nav is slightly different on mobile / desktop
     "navigateToInbox": {},

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -150,7 +150,9 @@ const metaMapReducer = (metaMap, action) => {
 const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
   switch (action.type) {
     case Chat2Gen.markConversationsStale:
-      return messageMap.deleteAll(action.payload.conversationIDKeys)
+      return action.payload.updateType === RPCChatTypes.notifyChatStaleUpdateType.clear
+        ? messageMap.deleteAll(action.payload.conversationIDKeys)
+        : messageMap
     case Chat2Gen.messageEdit: // fallthrough
     case Chat2Gen.messageDelete:
       return messageMap.updateIn(
@@ -283,7 +285,9 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
 const messageOrdinalsReducer = (messageOrdinals, action) => {
   switch (action.type) {
     case Chat2Gen.markConversationsStale:
-      return messageOrdinals.deleteAll(action.payload.conversationIDKeys)
+      return action.payload.updateType === RPCChatTypes.notifyChatStaleUpdateType.clear
+        ? messageOrdinals.deleteAll(action.payload.conversationIDKeys)
+        : messageOrdinals
     case Chat2Gen.metasReceived:
       const existingPending = messageOrdinals.get(Constants.pendingConversationIDKey)
       if (action.payload.clearExistingMessages) {


### PR DESCRIPTION
Should make it so we don't see as much flipping back and forth between blank and message state.