### PR TITLE
remove LoginState from engine *_test.go

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4331,7 +4331,7 @@ func TestChatSrvUserReset(t *testing.T) {
 
 		t.Logf("reset user 1")
 		ctcForUser := ctc.as(t, users[1])
-		require.NoError(t, ctcForUser.h.G().LoginState().ResetAccount(ctcForUser.m, users[1].Username))
+		require.NoError(t, libkb.ResetAccount(ctcForUser.m, users[1].NormalizedUsername(), users[1].Passphrase))
 		select {
 		case act := <-listener0.membersUpdate:
 			require.Equal(t, act.ConvID, conv.Id)
@@ -4392,7 +4392,7 @@ func TestChatSrvUserReset(t *testing.T) {
 
 		t.Logf("reset user 2")
 		ctcForUser2 := ctc.as(t, users[2])
-		require.NoError(t, ctcForUser2.h.G().LoginState().ResetAccount(ctcForUser2.m, users[2].Username))
+		require.NoError(t, libkb.ResetAccount(ctcForUser2.m, users[2].NormalizedUsername(), users[2].Passphrase))
 		select {
 		case act := <-listener0.membersUpdate:
 			require.Equal(t, act.ConvID, conv.Id)

--- a/go/client/cmd_account_reset.go
+++ b/go/client/cmd_account_reset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
@@ -51,7 +52,7 @@ func (c *CmdAccountReset) Run() error {
 	if err != nil {
 		return err
 	}
-	return cli.ResetAccount(context.Background(), 0)
+	return cli.ResetAccount(context.Background(), keybase1.ResetAccountArg{})
 }
 
 func (c *CmdAccountReset) GetUsage() libkb.Usage {

--- a/go/engine/account_delete.go
+++ b/go/engine/account_delete.go
@@ -45,22 +45,16 @@ func (e *AccountDelete) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *AccountDelete) Run(m libkb.MetaContext) error {
-	username := m.G().GetEnv().GetUsername().String()
-	arg := libkb.DefaultPassphrasePromptArg(m, username)
+	username := m.G().GetEnv().GetUsername()
+	arg := libkb.DefaultPassphrasePromptArg(m, username.String())
 	res, err := m.UIs().SecretUI.GetPassphrase(arg, nil)
 	if err != nil {
 		return err
 	}
-	m = m.WithNewProvisionalLoginContext()
-	err = libkb.PassphraseLoginNoPrompt(m, username, res.Passphrase)
+	err = libkb.DeleteAccount(m, username, res.Passphrase)
 	if err != nil {
 		return err
 	}
-	err = libkb.DeleteAccountWithContext(m, username)
-	if err != nil {
-		return err
-	}
-
 	m.CDebugf("account deleted, logging out")
 	m.G().Logout()
 

--- a/go/engine/bg_identifier_test.go
+++ b/go/engine/bg_identifier_test.go
@@ -24,8 +24,6 @@ func TestBackgroundIdentifier(t *testing.T) {
 
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc.G.SetClock(fakeClock)
-	// to pick up the new clock...
-	tc.G.ResetLoginState()
 
 	_, tracy, err := runTrack(tc, fu, "t_tracy", sigVersion)
 	if err != nil {

--- a/go/engine/bootstrap_test.go
+++ b/go/engine/bootstrap_test.go
@@ -28,10 +28,7 @@ func TestBootstrap(t *testing.T) {
 
 	// Simulate restarting the service by wiping out the
 	// passphrase stream cache and cached secret keys
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-		a.ClearCachedSecretKeys()
-	}, "account - clear")
+	clearCaches(tc.G)
 	tc.G.GetUPAKLoader().ClearMemory()
 
 	// set server uri to nonexistent ip so api calls will fail

--- a/go/engine/bug_3964_repairman_test.go
+++ b/go/engine/bug_3964_repairman_test.go
@@ -117,7 +117,10 @@ func corruptDevice2(dev1 libkb.TestContext, dev2 libkb.TestContext) (*libkb.Devi
 
 	// Dev1 has a passphrase cached, but dev2 doesn't (since it was provisioned).
 	// For this test though it's fine to take the passphrase from dev1.
-	pps := m1.ActiveDevice().PassphraseStream()
+	pps, err := libkb.GetPassphraseStreamStored(m1)
+	if err != nil {
+		return nil, err
+	}
 	if pps == nil {
 		return nil, errors.New("empty passphrase stream on m1, but expected one since we just signed up")
 	}
@@ -285,9 +288,12 @@ func checkLKSWorked(t *testing.T, tctx libkb.TestContext, u *FakeUser) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pps, err := tctx.G.LoginState().GetPassphraseStream(m, m.UIs().SecretUI)
+	pps, err := libkb.GetPassphraseStreamStored(m)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if pps == nil {
+		t.Fatal("failed to get passphrase stream")
 	}
 	clientHalfExpected := pps.LksClientHalf()
 	if !clientHalf.Equal(clientHalfExpected) {

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	insecureTriplesec "github.com/keybase/go-triplesec-insecure"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func SetupEngineTest(tb libkb.TestingTB, name string) libkb.TestContext {
@@ -257,7 +256,8 @@ func (fu *FakeUser) NewCountSecretUI() *libkb.TestCountSecretUI {
 }
 
 func AssertProvisioned(tc libkb.TestContext) error {
-	prov, err := tc.G.LoginState().LoggedInProvisioned(context.TODO())
+	m := NewMetaContextForTest(tc)
+	prov, err := isLoggedInWithError(m)
 	if err != nil {
 		return err
 	}
@@ -268,12 +268,13 @@ func AssertProvisioned(tc libkb.TestContext) error {
 }
 
 func AssertNotProvisioned(tc libkb.TestContext) error {
-	prov, err := tc.G.LoginState().LoggedInProvisioned(context.TODO())
+	m := NewMetaContextForTest(tc)
+	prov, err := isLoggedInWithError(m)
 	if err != nil {
 		return err
 	}
 	if prov {
-		return errors.New("AssertNotProvisioned failed:  user is provisioned")
+		return errors.New("AssertNotProvisioned failed: user is provisioned")
 	}
 	return nil
 }
@@ -293,8 +294,7 @@ func AssertLoggedOut(tc libkb.TestContext) error {
 }
 
 func LoggedIn(tc libkb.TestContext) bool {
-	lin, _ := tc.G.LoginState().LoggedInLoad()
-	return lin
+	return tc.G.ActiveDevice.Valid()
 }
 
 func Logout(tc libkb.TestContext) {
@@ -317,7 +317,7 @@ func testEngineWithSecretStore(
 	defer tc.Cleanup()
 
 	fu := SignupFakeUserStoreSecret(tc, "wss")
-	tc.ResetLoginState()
+	tc.SimulateServiceRestart()
 
 	testSecretUI := libkb.TestSecretUI{
 		Passphrase:  fu.Passphrase,
@@ -411,16 +411,13 @@ func NewMetaContextForTestWithLogUI(tc libkb.TestContext) libkb.MetaContext {
 }
 
 func ResetAccount(tc libkb.TestContext, u *FakeUser) {
-	err := tc.G.LoginState().ResetAccount(NewMetaContextForTest(tc), u.Username)
-	if err != nil {
-		tc.T.Fatalf("In account reset: %s", err)
-	}
-	tc.T.Logf("Account reset for user %s", u.Username)
+	ResetAccountNoLogout(tc, u)
 	Logout(tc)
 }
 
 func ResetAccountNoLogout(tc libkb.TestContext, u *FakeUser) {
-	err := tc.G.LoginState().ResetAccount(NewMetaContextForTest(tc), u.Username)
+	m := NewMetaContextForTest(tc)
+	err := libkb.ResetAccount(m, u.NormalizedUsername(), u.Passphrase)
 	if err != nil {
 		tc.T.Fatalf("In account reset: %s", err)
 	}
@@ -458,4 +455,12 @@ func checkUserSeqno(tc *libkb.TestContext, uid keybase1.UID, expected keybase1.S
 
 func fakeSalt() []byte {
 	return []byte("fakeSALTfakeSALT")
+}
+
+func clearCaches(g *libkb.GlobalContext) {
+	g.ActiveDevice.ClearCaches()
+	g.LoginState().Account(func(a *libkb.Account) {
+		a.ClearStreamCache()
+		a.ClearPaperKeys()
+	}, "account - clear")
 }

--- a/go/engine/concurrency_test.go
+++ b/go/engine/concurrency_test.go
@@ -11,13 +11,11 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	context "golang.org/x/net/context"
 )
 
 var runConc = flag.Bool("conc", false, "run (expensive) concurrency tests")
 
-// TestConcurrentLogin tries calling logout, login, and many of
-// the exposed methods in LoginState concurrently.  Use the
-// -race flag to test it.
 func TestConcurrentLogin(t *testing.T) {
 	if !*runConc {
 		t.Skip("Skipping ConcurrentLogin test")
@@ -52,18 +50,9 @@ func TestConcurrentLogin(t *testing.T) {
 					fmt.Printf("func caller %d done\n", index)
 					return
 				default:
-					tc.G.LoginState().LocalSession(func(s *libkb.Session) {
-						s.APIArgs()
-					}, "APIArgs")
-					tc.G.LoginState().Account(func(a *libkb.Account) {
-						a.UserInfo()
-					}, "UserInfo")
-					tc.G.LoginState().LocalSession(func(s *libkb.Session) {
-						s.GetUID()
-					}, "GetUID")
-					tc.G.LoginState().LoggedIn()
-					tc.G.LoginState().LoggedInLoad()
-					// tc.G.LoginState.Shutdown()
+					tc.G.ActiveDevice.NIST(context.Background())
+					tc.G.ActiveDevice.UID()
+					tc.G.ActiveDevice.Valid()
 				}
 			}
 		}(i)
@@ -111,10 +100,7 @@ func TestConcurrentGetPassphraseStream(t *testing.T) {
 					fmt.Printf("func caller %d done\n", index)
 					return
 				default:
-					_, err := tc.G.LoginState().GetPassphraseStream(NewMetaContextForTest(tc), u.NewSecretUI())
-					if err != nil {
-						tc.G.Log.Warning("GetPassphraseStream err: %s", err)
-					}
+					tc.G.ActiveDevice.PassphraseStream()
 				}
 			}
 		}(i)
@@ -126,7 +112,7 @@ func TestConcurrentGetPassphraseStream(t *testing.T) {
 }
 
 // TestConcurrentLogin tries calling logout, login, and many of
-// the exposed methods in LoginState concurrently.  Use the
+// the exposed methods in ActiveDevice concurrently.  Use the
 // -race flag to test it.
 func TestConcurrentSignup(t *testing.T) {
 	if !*runConc {

--- a/go/engine/crypto_test.go
+++ b/go/engine/crypto_test.go
@@ -380,9 +380,7 @@ func TestCryptoUnboxBytes32AnyPaper(t *testing.T) {
 	}
 
 	// clear the paper key cache to test getting a paper key via UI
-	err = tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearCachedSecretKeys()
-	}, "TestCryptoUnboxBytes32AnyPaper")
+	clearCaches(tc.G)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -85,7 +85,7 @@ func (e *Kex2Provisioner) Run(m libkb.MetaContext) error {
 
 	// get current passphrase stream if necessary:
 	if e.pps.PassphraseStream == nil {
-		m.CDebugf("kex2 provisioner needs passphrase stream, getting it from LoginState")
+		m.CDebugf("kex2 provisioner needs passphrase stream, getting it via GetPassphraseStreamStored")
 		pps, err := libkb.GetPassphraseStreamStored(m)
 		if err != nil {
 			return err

--- a/go/engine/login_offline_test.go
+++ b/go/engine/login_offline_test.go
@@ -25,11 +25,7 @@ func TestLoginOffline(t *testing.T) {
 
 	// Simulate restarting the service by wiping out the
 	// passphrase stream cache and cached secret keys
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-		a.ClearCachedSecretKeys()
-		a.UnloadLocalSession()
-	}, "account - clear")
+	clearCaches(tc.G)
 	tc.G.GetUPAKLoader().ClearMemory()
 
 	// set server uri to nonexistent ip so api calls will fail
@@ -91,11 +87,7 @@ func TestLoginOfflineDelay(t *testing.T) {
 
 	// Simulate restarting the service by wiping out the
 	// passphrase stream cache and cached secret keys
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-		a.ClearCachedSecretKeys()
-		a.UnloadLocalSession()
-	}, "account - clear")
+	clearCaches(tc.G)
 	tc.G.GetUPAKLoader().ClearMemory()
 
 	// set server uri to nonexistent ip so api calls will fail
@@ -148,11 +140,7 @@ func TestLoginOfflineNoUpak(t *testing.T) {
 
 	// Simulate restarting the service by wiping out the
 	// passphrase stream cache and cached secret keys
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-		a.ClearCachedSecretKeys()
-		a.UnloadLocalSession()
-	}, "account - clear")
+	tc.SimulateServiceRestart()
 	tc.G.GetUPAKLoader().ClearMemory()
 
 	// invalidate the cache for uid

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -7,10 +7,10 @@ import (
 	"errors"
 	"testing"
 
-	"golang.org/x/net/context"
-
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 // TODO: These tests should really be in libkb/. However, any test
@@ -51,45 +51,30 @@ func TestLoginWhileAlreadyLoggedIn(t *testing.T) {
 	fu := CreateAndSignupFakeUser(tc, "li")
 
 	// These should all work, since the username matches.
-
 	mctx := NewMetaContextForTest(tc)
 
-	if err := tc.G.LoginState().LoginWithPrompt(mctx, "", nil, nil, nil); err != nil {
-		t.Error(err)
-	}
-
-	if err := tc.G.LoginState().LoginWithPrompt(mctx, fu.Username, nil, nil, nil); err != nil {
-		t.Error(err)
-	}
-
-	if err := tc.G.LoginState().LoginWithStoredSecret(mctx, fu.Username, nil); err != nil {
-		t.Error(err)
-	}
-
-	if err := tc.G.LoginState().LoginWithPassphrase(mctx, fu.Username, "", false, nil); err != nil {
-		t.Error(err)
-	}
-
-	// This should fail.
-	if _, ok := tc.G.LoginState().LoginWithPrompt(mctx, "other", nil, nil, nil).(libkb.LoggedInWrongUserError); !ok {
-		t.Fatal("Did not get expected LoggedIn error")
-	}
+	_, err := libkb.GetPassphraseStreamStored(mctx)
+	require.NoError(t, err, "PassphraseLoginPrompt")
+	mctx = mctx.WithNewProvisionalLoginContext()
+	err = libkb.PassphraseLoginNoPrompt(mctx, fu.Username, fu.Passphrase)
+	mctx = mctx.CommitProvisionalLogin()
+	require.NoError(t, err, "PassphraseLoginNoPrompt")
+	_, err = libkb.GetPassphraseStreamStored(mctx)
+	require.NoError(t, err, "PassphraseLoginPrompt")
 }
 
 // Test that login works while already logged in and after a login
-// state reset.
-func TestLoginAfterLoginStateReset(t *testing.T) {
+// state reset (via service restart).
+func TestLoginAfterServiceRestart(t *testing.T) {
 	tc := SetupEngineTest(t, "login while already logged in")
 	defer tc.Cleanup()
 
 	// Logs the user in.
 	_ = SignupFakeUserStoreSecret(tc, "li")
 
-	tc.ResetLoginState()
-
-	if err := tc.G.LoginState().LoginWithPrompt(NewMetaContextForTest(tc), "", nil, nil, nil); err != nil {
-		t.Error(err)
-	}
+	tc.SimulateServiceRestart()
+	ok, _ := isLoggedIn(NewMetaContextForTest(tc))
+	require.True(t, ok, "we are logged in after a service restart")
 }
 
 // Test that login fails with a nonexistent user.
@@ -102,7 +87,9 @@ func TestLoginNonexistent(t *testing.T) {
 	Logout(tc)
 
 	secretUI := &libkb.TestSecretUI{Passphrase: "XXXXXXXXXXXX"}
-	err := tc.G.LoginState().LoginWithPrompt(NewMetaContextForTest(tc), "nonexistent", nil, secretUI, nil)
+	m := NewMetaContextForTest(tc)
+	m = m.WithNewProvisionalLoginContext().WithUIs(libkb.UIs{SecretUI: secretUI})
+	err := libkb.PassphraseLoginPrompt(m, "nonexistent", 1)
 	if _, ok := err.(libkb.NotFoundError); !ok {
 		t.Errorf("error type: %T, expected libkb.NotFoundError", err)
 	}
@@ -155,26 +142,12 @@ func TestLoginWithPromptPassphrase(t *testing.T) {
 		Passphrase: fu.Passphrase,
 	}
 
-	mctx := NewMetaContextForTest(tc)
-	if err := tc.G.LoginState().LoginWithPrompt(mctx, "", nil, mockGetKeybasePassphrase, nil); err != nil {
-		t.Error(err)
-	}
-
-	if !mockGetKeybasePassphrase.Called {
-		t.Errorf("secretUI.GetKeybasePassphrase() unexpectedly not called")
-	}
-
-	Logout(tc)
-
-	mockGetKeybasePassphrase.Called = false
-	if err := tc.G.LoginState().LoginWithPrompt(mctx, fu.Username, nil, mockGetKeybasePassphrase, nil); err != nil {
-		t.Error(err)
-	}
-
+	mctx := NewMetaContextForTest(tc).WithNewProvisionalLoginContext().WithUIs(libkb.UIs{SecretUI: mockGetKeybasePassphrase})
+	err := libkb.PassphraseLoginPrompt(mctx, fu.Username, 1)
+	require.NoError(t, err, "prompt with username")
 	mockGetKeybasePassphrase.CheckLastErr(t)
-
 	if !mockGetKeybasePassphrase.Called {
-		t.Errorf("secretUI.GetKeybasePassphrase() unexpectedly not called")
+		t.Fatalf("secretUI.GetKeybasePassphrase() unexpectedly not called")
 	}
 
 	Logout(tc)
@@ -185,20 +158,19 @@ func TestLoginWithPromptPassphrase(t *testing.T) {
 	mockGetUsername := &GetUsernameMock{
 		Username: fu.Username,
 	}
+	mctx = mctx.WithNewProvisionalLoginContext().WithUIs(libkb.UIs{SecretUI: mockGetKeybasePassphrase, LoginUI: mockGetUsername})
 	mockGetKeybasePassphrase.Called = false
-	if err := tc.G.LoginState().LoginWithPrompt(mctx, "", mockGetUsername, mockGetKeybasePassphrase, nil); err != nil {
-		t.Error(err)
-	}
+	err = libkb.PassphraseLoginPrompt(mctx, "", 1)
+	require.NoError(t, err, "prompt with username")
 
 	mockGetUsername.CheckLastErr(t)
 	mockGetKeybasePassphrase.CheckLastErr(t)
 
 	if !mockGetUsername.Called {
-		t.Errorf("loginUI.GetEmailOrUsername() unexpectedly not called")
+		t.Fatalf("loginUI.GetEmailOrUsername() unexpectedly not called")
 	}
-
 	if !mockGetKeybasePassphrase.Called {
-		t.Errorf("secretUI.GetKeybasePassphrase() unexpectedly not called")
+		t.Fatalf("secretUI.GetKeybasePassphrase() unexpectedly not called")
 	}
 }
 
@@ -250,10 +222,9 @@ func TestLoginWithStoredSecret(t *testing.T) {
 		Passphrase:  fu.Passphrase,
 		StoreSecret: true,
 	}
-	mctx := NewMetaContextForTest(tc)
-	if err := tc.G.LoginState().LoginWithPrompt(mctx, "", nil, mockGetPassphrase, nil); err != nil {
-		t.Fatal(err)
-	}
+	mctx := NewMetaContextForTest(tc).WithNewProvisionalLoginContext().WithUIs(libkb.UIs{SecretUI: mockGetPassphrase})
+	err := libkb.PassphraseLoginPromptThenSecretStore(mctx, fu.Username, 1, true)
+	require.NoError(t, err, "no error after prompt")
 
 	mockGetPassphrase.CheckLastErr(t)
 
@@ -265,11 +236,11 @@ func TestLoginWithStoredSecret(t *testing.T) {
 		t.Errorf("User %s unexpectedly does not have a stored secret", fu.Username)
 	}
 
-	// TODO: Mock out the SecretStore and make sure that it's
-	// actually consulted.
-	if err := tc.G.LoginState().LoginWithStoredSecret(mctx, fu.Username, nil); err != nil {
-		t.Error(err)
-	}
+	mctx = mctx.CommitProvisionalLogin()
+
+	clearCaches(tc.G)
+	ili, _ := isLoggedIn(mctx)
+	require.True(t, ili, "still logged in after caches are cleared (via secret store)")
 
 	Logout(tc)
 
@@ -281,20 +252,14 @@ func TestLoginWithStoredSecret(t *testing.T) {
 		t.Errorf("User %s unexpectedly has a stored secret", fu.Username)
 	}
 
-	if err := tc.G.LoginState().LoginWithStoredSecret(mctx, fu.Username, nil); err == nil {
-		t.Error("Did not get expected error")
-	}
-
-	if err := tc.G.LoginState().LoginWithStoredSecret(mctx, "", nil); err == nil {
-		t.Error("Did not get expected error")
-	}
+	ili, _ = isLoggedIn(mctx)
+	require.False(t, ili, "cannot finagle a login")
 
 	fu = CreateAndSignupFakeUser(tc, "lwss")
 	Logout(tc)
 
-	if err := tc.G.LoginState().LoginWithStoredSecret(mctx, fu.Username, nil); err == nil {
-		t.Error("Did not get expected error")
-	}
+	ili, _ = isLoggedIn(mctx)
+	require.False(t, ili, "cannot finagle a login")
 }
 
 // Test that the login flow with passphrase correctly denies bad
@@ -306,13 +271,13 @@ func TestLoginWithPassphraseErrors(t *testing.T) {
 	fu := CreateAndSignupFakeUser(tc, "lwpe")
 	Logout(tc)
 
-	mctx := NewMetaContextForTest(tc)
-	err := tc.G.LoginState().LoginWithPassphrase(mctx, "", "", false, nil)
+	mctx := NewMetaContextForTest(tc).WithNewProvisionalLoginContext()
+	err := libkb.PassphraseLoginNoPrompt(mctx, "", "")
 	if _, ok := err.(libkb.AppStatusError); !ok {
 		t.Error("Did not get expected AppStatusError")
 	}
-
-	err = tc.G.LoginState().LoginWithPassphrase(mctx, fu.Username, "wrong passphrase", false, nil)
+	mctx = mctx.WithNewProvisionalLoginContext()
+	err = libkb.PassphraseLoginNoPrompt(mctx, fu.Username, fu.Passphrase+"x")
 	if _, ok := err.(libkb.PassphraseError); !ok {
 		t.Error("Did not get expected PassphraseError")
 	}
@@ -328,20 +293,15 @@ func TestLoginWithPassphraseNoStore(t *testing.T) {
 	fu := CreateAndSignupFakeUser(tc, "lwpns")
 	Logout(tc)
 
-	mctx := NewMetaContextForTest(tc)
-	if err := tc.G.LoginState().LoginWithPassphrase(mctx, fu.Username, fu.Passphrase, false, nil); err != nil {
-		t.Error(err)
-	}
-
+	mctx := NewMetaContextForTest(tc).WithNewProvisionalLoginContext()
+	err := libkb.PassphraseLoginNoPrompt(mctx, fu.Username, fu.Passphrase)
+	require.NoError(t, err, "login with passphrase worked")
+	mctx = mctx.CommitProvisionalLogin()
+	require.False(t, userHasStoredSecret(&tc, fu.Username), "no stored secret")
 	Logout(tc)
-
-	if err := tc.G.LoginState().LoginWithStoredSecret(mctx, fu.Username, nil); err == nil {
-		t.Error("Did not get expected error")
-	}
-
-	if userHasStoredSecret(&tc, fu.Username) {
-		t.Errorf("User %s unexpectedly has a stored secret", fu.Username)
-	}
+	ili, _ := isLoggedIn(mctx)
+	require.False(t, ili, "not logged in, since no store")
+	require.False(t, userHasStoredSecret(&tc, fu.Username), "no stored secret")
 }
 
 // TODO: Test LoginWithPassphrase with pubkey login failing.

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -157,28 +157,6 @@ func testUserHasDeviceKey(tc libkb.TestContext) {
 	}
 }
 
-func TestUserInfo(t *testing.T) {
-	t.Skip()
-	tc := SetupEngineTest(t, "login")
-	defer tc.Cleanup()
-
-	u := CreateAndSignupFakeUser(tc, "login")
-	var username libkb.NormalizedUsername
-	var err error
-	aerr := tc.G.LoginState().Account(func(a *libkb.Account) {
-		_, username, _, _, _, err = a.UserInfo()
-	}, "TestUserInfo")
-	if aerr != nil {
-		t.Fatal(err)
-	}
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !username.Eq(libkb.NewNormalizedUsername(u.Username)) {
-		t.Errorf("userinfo username: %q, expected %q", username, u.Username)
-	}
-}
-
 func TestUserEmails(t *testing.T) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
@@ -949,7 +927,6 @@ func TestProvisionPaperOnly(t *testing.T) {
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc2.G.SetClock(fakeClock)
 	// to pick up the new clock...
-	tc2.G.ResetLoginState()
 	defer tc2.Cleanup()
 
 	secUI := fu.NewSecretUI()
@@ -1044,11 +1021,7 @@ func simulateServiceRestart(t *testing.T, tc libkb.TestContext, fu *FakeUser) {
 
 	// Simulate restarting the service by wiping out the
 	// passphrase stream cache and cached secret keys
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-		a.ClearCachedSecretKeys()
-		a.ClearLoginSession()
-	}, "account - clear")
+	tc.SimulateServiceRestart()
 
 	// now assert we can login without a passphrase
 	uis := libkb.UIs{
@@ -1796,26 +1769,24 @@ func TestLoginStreamCache(t *testing.T) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
 
-	u1 := CreateAndSignupFakeUser(tc, "login")
+	u1 := SignupFakeUserStoreSecret(tc, "login")
+	assertSecretStored(tc, u1.Username)
 
 	if !assertStreamCache(tc, true) {
 		t.Fatal("expected valid stream cache after signup")
 	}
 
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-		a.ClearCachedSecretKeys()
-	}, "clear stream cache")
+	clearCaches(tc.G)
 
 	if !assertStreamCache(tc, false) {
 		t.Fatal("expected invalid stream cache after clear")
 	}
 
-	// This should now unlock the stream cache too
+	// This should not unlock the stream cache
 	u1.LoginOrBust(tc)
 
-	if !assertStreamCache(tc, true) {
-		t.Fatal("expected valid stream cache after login")
+	if !assertStreamCache(tc, false) {
+		t.Fatal("expected no valid stream cache after login")
 	}
 	assertDeviceKeysCached(tc)
 	assertSecretStored(tc, u1.Username)
@@ -2539,16 +2510,16 @@ func TestResetThenPGPOnlyThenProvision(t *testing.T) {
 	ResetAccount(tc, u)
 
 	// Now login again so we can post a PGP key
-	err := tc.G.LoginState().LoginWithPassphrase(m, u.Username, u.Passphrase, false, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	m = m.WithNewProvisionalLoginContext()
+	err := libkb.PassphraseLoginNoPrompt(m, u.Username, u.Passphrase)
+	require.NoError(t, err, "passphrase login no prompt worked")
+	m = m.CommitProvisionalLogin()
 
 	// Generate a new test PGP key for the user, and specify the PushSecret
 	// flag so that their triplesec'ed key is pushed to the server.
 	gen := libkb.PGPGenArg{
-		PrimaryBits: 1024,
-		SubkeyBits:  1024,
+		PrimaryBits: 768,
+		SubkeyBits:  768,
 	}
 	gen.AddDefaultUID(tc.G)
 	peng := NewPGPKeyImportEngine(tc.G, PGPKeyImportEngineArg{
@@ -2557,8 +2528,6 @@ func TestResetThenPGPOnlyThenProvision(t *testing.T) {
 		NoSave:     true,
 	})
 
-	// Reset LoginContext to be `nil`, so that way we get the tc.G.LoginState
-	// session token, rather than the old one in ctx.LoginContext.
 	if err := RunEngine2(m, peng); err != nil {
 		tc.T.Fatal(err)
 	}
@@ -2923,10 +2892,7 @@ func TestProvisionerSecretStore(t *testing.T) {
 	if _, err := rand.Read(secretX[:]); err != nil {
 		t.Fatal(err)
 	}
-	tcX.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-		a.ClearCachedSecretKeys()
-	}, "clear stream cache")
+	clearCaches(tcX.G)
 
 	secretCh := make(chan kex2.Secret)
 
@@ -3392,11 +3358,7 @@ func TestBootstrapAfterGPGSign(t *testing.T) {
 
 		// Simulate restarting the service by wiping out the
 		// passphrase stream cache and cached secret keys
-		tc2.G.LoginState().Account(func(a *libkb.Account) {
-			a.ClearStreamCache()
-			a.ClearCachedSecretKeys()
-			a.UnloadLocalSession()
-		}, "account - clear")
+		tc2.SimulateServiceRestart()
 		tc2.G.GetUPAKLoader().ClearMemory()
 
 		// LoginOffline will run when service restarts.
@@ -3792,10 +3754,9 @@ func assertDeviceKeysCached(tc libkb.TestContext) {
 
 func assertPassphraseStreamCache(tc libkb.TestContext) {
 	var ppsValid bool
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		ppsValid = a.PassphraseStreamCache().ValidPassphraseStream()
-	}, "assertPassphraseStreamCache")
-
+	if ppsc := tc.G.ActiveDevice.PassphraseStreamCache(); ppsc != nil {
+		ppsValid = ppsc.ValidPassphraseStream()
+	}
 	if !ppsValid {
 		tc.T.Fatal("passphrase stream not cached")
 	}
@@ -3803,10 +3764,6 @@ func assertPassphraseStreamCache(tc libkb.TestContext) {
 
 func assertSecretStored(tc libkb.TestContext, username string) {
 	secret, err := tc.G.SecretStore().RetrieveSecret(libkb.NewNormalizedUsername(username))
-	if err != nil {
-		tc.T.Fatal(err)
-	}
-	if secret.IsNil() {
-		tc.T.Fatal("secret in secret store was nil")
-	}
+	require.NoError(tc.T, err, "no error fetching secret")
+	require.False(tc.T, secret.IsNil(), "secret was non-nil")
 }

--- a/go/engine/login_with_paperkey_test.go
+++ b/go/engine/login_with_paperkey_test.go
@@ -92,12 +92,8 @@ func TestLoginWithPaperKeyLoggedInAndLocked(t *testing.T) {
 	u, paperkey := CreateAndSigunpLPK(tc, "login")
 
 	t.Logf("locking keys")
-	err := tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearCachedSecretKeys()
-		a.ClearStreamCache()
-	}, "test")
-	require.NoError(t, err)
-	err = tc.G.SecretStore().ClearSecret(libkb.NormalizedUsername(u.Username))
+	tc.SimulateServiceRestart()
+	err := tc.G.SecretStore().ClearSecret(libkb.NormalizedUsername(u.Username))
 	require.NoError(t, err)
 
 	t.Logf("checking logged in status [before]")

--- a/go/engine/nist_test.go
+++ b/go/engine/nist_test.go
@@ -15,7 +15,6 @@ func TestNIST(t *testing.T) {
 
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc.G.SetClock(fakeClock)
-	tc.G.ResetLoginState()
 
 	// Need to set active devices
 	Logout(tc)

--- a/go/engine/paperkey_test.go
+++ b/go/engine/paperkey_test.go
@@ -90,11 +90,10 @@ func TestPaperKey(t *testing.T) {
 	Logout(tc)
 
 	// make sure the passphrase authentication didn't change:
-
-	_, err := tc.G.LoginState().VerifyPlaintextPassphrase(NewMetaContextForTest(tc), fu.Passphrase, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	m = m.WithNewProvisionalLoginContext()
+	err := libkb.PassphraseLoginNoPrompt(m, fu.Username, fu.Passphrase)
+	require.NoError(t, err, "passphrase login still worked")
+	m = m.CommitProvisionalLogin()
 
 	// make sure the backup key device id is different than the actual device id
 	// and that the actual device id didn't change.

--- a/go/engine/passphrase_change_test.go
+++ b/go/engine/passphrase_change_test.go
@@ -158,9 +158,7 @@ func TestPassphraseChangeKnownPrompt(t *testing.T) {
 
 	// clear the passphrase stream cache to force a prompt
 	// for the existing passphrase.
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-	}, "clear stream cache")
+	clearCaches(tc.G)
 
 	// Test changing passphrase 3 times; so that old passphrase
 	// cache is properly busted.
@@ -236,7 +234,8 @@ func TestPassphraseChangeKnownPromptRepeatOld(t *testing.T) {
 		// the bug fix that we're actually trying to test by doing multiple
 		// passphrase changes.
 		if i == numChanges-1 {
-			_, err := tc.G.LoginState().VerifyPlaintextPassphrase(NewMetaContextForTest(tc), newPassphrase, nil)
+			m := NewMetaContextForTest(tc)
+			_, err := libkb.VerifyPassphraseForLoggedInUser(m, newPassphrase)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -362,10 +361,7 @@ func TestPassphraseChangeUnknownNoPSCache(t *testing.T) {
 
 	u, _, _ := CreateAndSignupFakeUserCustomArg(tc, "paper", f)
 
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-		a.ClearCachedSecretKeys()
-	}, "clear stream cache")
+	tc.SimulateServiceRestart()
 
 	newPassphrase := "password1234"
 	arg := &keybase1.PassphraseChangeArg{
@@ -486,7 +482,7 @@ func TestPassphraseChangeLoggedOutBackupKeySecretStore(t *testing.T) {
 	// this call will cause the login state to be reloaded.
 	assertLoadSecretKeys(tc, u, "logged out w/ backup key, before passphrase change")
 
-	tc.ResetLoginState()
+	tc.SimulateServiceRestart()
 
 	secretUI := libkb.TestSecretUI{}
 	uis := libkb.UIs{
@@ -535,9 +531,7 @@ func TestPassphraseChangePGPUsage(t *testing.T) {
 
 	// clear the passphrase stream cache to force a prompt
 	// for the existing passphrase.
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-	}, "clear stream cache")
+	clearCaches(tc.G)
 
 	newPassphrase := "password1234"
 	arg := &keybase1.PassphraseChangeArg{
@@ -574,9 +568,7 @@ func TestPassphraseChangePGP3Sec(t *testing.T) {
 
 	// clear the passphrase stream cache to force a prompt
 	// for the existing passphrase.
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-	}, "clear stream cache")
+	clearCaches(tc.G)
 
 	newPassphrase := "password1234"
 	arg := &keybase1.PassphraseChangeArg{
@@ -682,7 +674,7 @@ func TestPassphraseChangeLoggedOutBackupKeySecretStorePGP(t *testing.T) {
 	// this call will cause the login state to be reloaded.
 	assertLoadSecretKeys(tc, u, "logged out w/ backup key, before passphrase change")
 
-	tc.ResetLoginState()
+	tc.SimulateServiceRestart()
 
 	secretUI := libkb.TestSecretUI{}
 	uis = libkb.UIs{
@@ -753,9 +745,7 @@ func TestPassphraseChangePGP3SecMultiple(t *testing.T) {
 
 	// clear the passphrase stream cache to force a prompt
 	// for the existing passphrase.
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-	}, "clear stream cache")
+	clearCaches(tc.G)
 
 	newPassphrase := "password1234"
 	arg := &keybase1.PassphraseChangeArg{

--- a/go/engine/prove_test.go
+++ b/go/engine/prove_test.go
@@ -64,9 +64,7 @@ func TestProveRooterCachedKeys(t *testing.T) {
 	sigVersion := libkb.GetDefaultSigVersion(tc.G)
 
 	fu := CreateAndSignupFakeUser(tc, "prove")
-	tc.G.LoginState().Account(func(a *libkb.Account) {
-		a.ClearStreamCache()
-	}, "clear stream cache")
+	clearCaches(tc.G)
 
 	_, _, err := proveRooterWithSecretUI(tc.G, fu, &libkb.TestSecretUI{}, sigVersion)
 	if err != nil {

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -118,8 +118,6 @@ func (s *SignupEngine) Run(m libkb.MetaContext) (err error) {
 	m = m.CommitProvisionalLogin()
 
 	// signup complete, notify anyone interested.
-	// (and don't notify inside a LoginState action to avoid
-	// a chance of timing out)
 	m.G().NotifyRouter.HandleLogin(s.arg.Username)
 
 	// For instance, setup gregor and friends...

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -54,6 +54,10 @@ func subTestSignupEngine(t *testing.T, upgradePerUserKey bool) {
 		t.Fatal(err)
 	}
 
+	if err := AssertLoggedOut(tc); err != nil {
+		t.Fatal(err)
+	}
+
 	fu.LoginOrBust(tc)
 
 	if err = AssertDeviceID(tc.G); err != nil {
@@ -75,16 +79,13 @@ func subTestSignupEngine(t *testing.T, upgradePerUserKey bool) {
 		t.Fatal(err)
 	}
 
-	mockGetPassphrase := &GetPassphraseMock{
-		Passphrase: fu.Passphrase,
-	}
-	if err = tc.G.LoginState().LoginWithPrompt(NewMetaContextForTest(tc), fu.Username, nil, mockGetPassphrase, nil); err != nil {
+	secretUI := fu.NewSecretUI()
+	err = fu.LoginWithSecretUI(secretUI, tc.G)
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	mockGetPassphrase.CheckLastErr(t)
-
-	if !mockGetPassphrase.Called {
+	if !secretUI.CalledGetPassphrase {
 		t.Errorf("secretUI.GetKeybasePassphrase() not called")
 	}
 

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -206,7 +206,6 @@ func TestFullSelfCacherFlushTwoMachines(t *testing.T) {
 	defer tc.Cleanup()
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc.G.SetClock(fakeClock)
-	tc.G.ResetLoginState()
 
 	t.Logf("create new user")
 	fu := NewFakeUserOrBust(t, "paper")

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -52,6 +52,10 @@ func (fu *FakeUser) GetUID() keybase1.UID {
 	return libkb.UsernameToUID(fu.Username)
 }
 
+func (fu FakeUser) NormalizedUsername() libkb.NormalizedUsername {
+	return libkb.NewNormalizedUsername(fu.Username)
+}
+
 func (fu *FakeUser) GetUserVersion() keybase1.UserVersion {
 	return keybase1.UserVersion{
 		Uid:         fu.GetUID(),
@@ -115,7 +119,8 @@ func createAndSignupFakeUser(prefix string, g *libkb.GlobalContext, skipPaper bo
 
 // copied from engine/common_test.go
 func ResetAccount(tc libkb.TestContext, u *FakeUser) {
-	err := tc.G.LoginState().ResetAccount(libkb.NewMetaContextForTest(tc), u.Username)
+	m := libkb.NewMetaContextForTest(tc)
+	err := libkb.ResetAccount(m, u.NormalizedUsername(), u.Passphrase)
 	if err != nil {
 		tc.T.Fatalf("In account reset: %s", err)
 	}
@@ -124,11 +129,12 @@ func ResetAccount(tc libkb.TestContext, u *FakeUser) {
 }
 
 func DeleteAccount(tc libkb.TestContext, u *FakeUser) {
-	err := tc.G.LoginState().DeleteAccount(libkb.NewMetaContextForTest(tc), u.Username)
+	m := libkb.NewMetaContextForTest(tc)
+	err := libkb.DeleteAccount(m, u.NormalizedUsername(), u.Passphrase)
 	if err != nil {
-		tc.T.Fatalf("In delete: %s", err)
+		tc.T.Fatalf("In account reset: %s", err)
 	}
-	tc.T.Logf("Account deleted for user %s", u.Username)
+	tc.T.Logf("Account reset for user %s", u.Username)
 	Logout(tc)
 }
 

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -403,33 +403,6 @@ func (a *Account) EnsureUsername(username NormalizedUsername) {
 
 }
 
-func (a *Account) UserInfo() (uid keybase1.UID, username NormalizedUsername,
-	token string, deviceSubkey, deviceSibkey GenericKey, err error) {
-	if !a.LoggedIn() {
-		err = LoginRequiredError{}
-		return
-	}
-
-	arg := NewLoadUserArg(a.G()).WithLoginContext(a).WithSelf(true)
-	err = a.G().GetFullSelfer().WithUser(arg, func(user *User) error {
-		var err error
-		deviceSubkey, err = user.GetDeviceSubkey()
-		if err != nil {
-			return err
-		}
-		deviceSibkey, err = user.GetDeviceSibkey()
-		if err != nil {
-			return err
-		}
-		uid = user.GetUID()
-		username = user.GetNormalizedName()
-		return nil
-
-	})
-	token = a.localSession.GetToken()
-	return
-}
-
 // SaveState saves the logins state to memory, and to the user
 // config file.
 func (a *Account) SaveState(sessionID, csrf string, username NormalizedUsername, uid keybase1.UID, deviceID keybase1.DeviceID) error {

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -377,49 +377,6 @@ func ComputeLoginPackage(m MetaContext, username string) (ret PDPKALoginPackage,
 	return computeLoginPackageFromEmailOrUsername(username, ps, loginSession)
 }
 
-func (s *LoginState) ResetAccount(m MetaContext, username string) (err error) {
-	return s.resetOrDelete(m, username, "nuke")
-}
-
-func (s *LoginState) DeleteAccount(m MetaContext, username string) (err error) {
-	return s.resetOrDelete(m, username, "delete")
-}
-
-func ResetAccountWithContext(m MetaContext, username string) error {
-	return ResetOrDeleteWithContext(m, username, "nuke")
-}
-
-func DeleteAccountWithContext(m MetaContext, username string) error {
-	return ResetOrDeleteWithContext(m, username, "delete")
-}
-
-func ResetOrDeleteWithContext(m MetaContext, username string, endpoint string) (err error) {
-	lctx := m.LoginContext()
-	err = lctx.LoadLoginSession(username)
-	if err != nil {
-		return err
-	}
-	pdpka, err := ComputeLoginPackage(m, username)
-	if err != nil {
-		return err
-	}
-	arg := APIArg{
-		Endpoint:    endpoint,
-		SessionType: APISessionTypeREQUIRED,
-		Args:        NewHTTPArgs(),
-		SessionR:    lctx.LocalSession(),
-	}
-	pdpka.PopulateArgs(&arg.Args)
-	_, err = m.G().API.Post(arg)
-	return err
-}
-
-func (s *LoginState) resetOrDelete(m MetaContext, username string, endpoint string) (err error) {
-	return s.loginHandle(func(lctx LoginContext) error {
-		return ResetOrDeleteWithContext(m.WithLoginContext(lctx), username, endpoint)
-	}, nil, ("ResetAccount: " + endpoint))
-}
-
 func (s *LoginState) postLoginToServer(m MetaContext, eOu string, lp PDPKALoginPackage) (*loginAPIResult, error) {
 
 	arg := APIArg{

--- a/go/libkb/passphrase_login.go
+++ b/go/libkb/passphrase_login.go
@@ -426,15 +426,15 @@ func VerifyPassphraseGetStreamInLoginContext(m MetaContext, passphrase string) (
 // VerifyPassphraseForLoggedInUser verifies that the current passphrase is correct for the logged
 // in user, returning nil if correct, and an error if not. Only used in tests right now, but
 // it's fine to use in production code if it seems appropriate.
-func VerifyPassphraseForLoggedInUser(m MetaContext, pp string) (err error) {
+func VerifyPassphraseForLoggedInUser(m MetaContext, pp string) (pps *PassphraseStream, err error) {
 	defer m.CTrace("VerifyPassphraseForLoggedInUser", func() error { return err })()
 	uid, un := m.ActiveDevice().GetUsernameAndUIDIfValid(m)
 	if uid.IsNil() {
-		return NewLoginRequiredError("for VerifyPassphraseForLoggedInUser")
+		return nil, NewLoginRequiredError("for VerifyPassphraseForLoggedInUser")
 	}
 	m = m.WithNewProvisionalLoginContextForUIDAndUsername(uid, un)
-	_, err = VerifyPassphraseGetStreamInLoginContext(m, pp)
-	return err
+	pps, err = VerifyPassphraseGetStreamInLoginContext(m, pp)
+	return pps, err
 }
 
 // ComputeLoginPackage2 computes the login package for the given UID as dictated by

--- a/go/libkb/reset_delete.go
+++ b/go/libkb/reset_delete.go
@@ -1,0 +1,44 @@
+package libkb
+
+import (
+	"errors"
+)
+
+func ResetAccount(m MetaContext, username NormalizedUsername, passphrase string) (err error) {
+	defer m.CTrace("ResetAccount", func() error { return err })()
+	return resetOrDeleteAccount(m, username, passphrase, "nuke")
+}
+
+func DeleteAccount(m MetaContext, username NormalizedUsername, passphrase string) (err error) {
+	defer m.CTrace("DeleteAccount", func() error { return err })()
+	return resetOrDeleteAccount(m, username, passphrase, "delete")
+}
+
+func resetOrDeleteAccount(m MetaContext, username NormalizedUsername, passphrase string, endpoint string) (err error) {
+	defer m.CTrace("resetOrDeleteAccount", func() error { return err })()
+
+	m = m.WithNewProvisionalLoginContext()
+	err = PassphraseLoginNoPrompt(m, username.String(), passphrase)
+	if err != nil {
+		return err
+	}
+	pps := m.PassphraseStream()
+	if pps == nil {
+		return errors.New("unexpected nil passphrase stream")
+	}
+
+	pdpka, err := ComputeLoginPackage2(m, pps)
+	if err != nil {
+		return err
+	}
+
+	arg := APIArg{
+		Endpoint:    endpoint,
+		SessionType: APISessionTypeREQUIRED,
+		Args:        NewHTTPArgs(),
+		MetaContext: m,
+	}
+	pdpka.PopulateArgs(&arg.Args)
+	_, err = m.G().API.Post(arg)
+	return err
+}

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -166,10 +166,10 @@ func (tc *TestContext) MakePGPKey(id string) (*PGPKeyBundle, error) {
 	return GeneratePGPKeyBundle(tc.G, arg, tc.G.UI.GetLogUI())
 }
 
-// ResetLoginStateForTest simulates a shutdown and restart (for client
+// SimulatServiceRestart simulates a shutdown and restart (for client
 // state). Used by tests that need to clear out cached login state
 // without logging out.
-func (tc *TestContext) ResetLoginState() {
+func (tc *TestContext) SimulateServiceRestart() {
 	tc.G.createLoginState()
 }
 

--- a/go/protocol/keybase1/account.go
+++ b/go/protocol/keybase1/account.go
@@ -40,7 +40,8 @@ type HasServerKeysArg struct {
 }
 
 type ResetAccountArg struct {
-	SessionID int `codec:"sessionID" json:"sessionID"`
+	SessionID  int    `codec:"sessionID" json:"sessionID"`
+	Passphrase string `codec:"passphrase" json:"passphrase"`
 }
 
 type AccountInterface interface {
@@ -54,7 +55,9 @@ type AccountInterface interface {
 	// * Whether the logged-in user has uploaded private keys
 	// * Will error if not logged in.
 	HasServerKeys(context.Context, int) (HasServerKeysRes, error)
-	ResetAccount(context.Context, int) error
+	// resetAccount resets the user's account; it's meant only for devel and tests.
+	// passphrase is optional and will be prompted for if not supplied.
+	ResetAccount(context.Context, ResetAccountArg) error
 }
 
 func AccountProtocol(i AccountInterface) rpc.Protocol {
@@ -136,7 +139,7 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]ResetAccountArg)(nil), args)
 						return
 					}
-					err = i.ResetAccount(ctx, (*typedArgs)[0].SessionID)
+					err = i.ResetAccount(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -176,8 +179,9 @@ func (c AccountClient) HasServerKeys(ctx context.Context, sessionID int) (res Ha
 	return
 }
 
-func (c AccountClient) ResetAccount(ctx context.Context, sessionID int) (err error) {
-	__arg := ResetAccountArg{SessionID: sessionID}
+// resetAccount resets the user's account; it's meant only for devel and tests.
+// passphrase is optional and will be prompted for if not supplied.
+func (c AccountClient) ResetAccount(ctx context.Context, __arg ResetAccountArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.account.resetAccount", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/keybase1/user.go
+++ b/go/protocol/keybase1/user.go
@@ -350,10 +350,6 @@ type InterestingPeopleArg struct {
 	MaxUsers int `codec:"maxUsers" json:"maxUsers"`
 }
 
-type ResetUserArg struct {
-	SessionID int `codec:"sessionID" json:"sessionID"`
-}
-
 type MeUserVersionArg struct {
 	SessionID int  `codec:"sessionID" json:"sessionID"`
 	ForcePoll bool `codec:"forcePoll" json:"forcePoll"`
@@ -402,7 +398,6 @@ type UserInterface interface {
 	ListTrackers2(context.Context, ListTrackers2Arg) (UserSummary2Set, error)
 	ProfileEdit(context.Context, ProfileEditArg) error
 	InterestingPeople(context.Context, int) ([]InterestingPerson, error)
-	ResetUser(context.Context, int) error
 	MeUserVersion(context.Context, MeUserVersionArg) (UserVersion, error)
 	// getUPAK returns a UPAK. Used mainly for debugging.
 	GetUPAK(context.Context, UID) (UPAKVersioned, error)
@@ -701,22 +696,6 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"resetUser": {
-				MakeArg: func() interface{} {
-					ret := make([]ResetUserArg, 1)
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]ResetUserArg)
-					if !ok {
-						err = rpc.NewTypeError((*[]ResetUserArg)(nil), args)
-						return
-					}
-					err = i.ResetUser(ctx, (*typedArgs)[0].SessionID)
-					return
-				},
-				MethodType: rpc.MethodCall,
-			},
 			"meUserVersion": {
 				MakeArg: func() interface{} {
 					ret := make([]MeUserVersionArg, 1)
@@ -879,12 +858,6 @@ func (c UserClient) ProfileEdit(ctx context.Context, __arg ProfileEditArg) (err 
 func (c UserClient) InterestingPeople(ctx context.Context, maxUsers int) (res []InterestingPerson, err error) {
 	__arg := InterestingPeopleArg{MaxUsers: maxUsers}
 	err = c.Cli.Call(ctx, "keybase.1.user.interestingPeople", []interface{}{__arg}, &res)
-	return
-}
-
-func (c UserClient) ResetUser(ctx context.Context, sessionID int) (err error) {
-	__arg := ResetUserArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.user.resetUser", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -4,7 +4,6 @@
 package service
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/keybase/client/go/avatars"
@@ -236,21 +235,6 @@ func (h *UserHandler) ListTrackers2(ctx context.Context, arg keybase1.ListTracke
 		res = eng.GetResults()
 	}
 	return res, err
-}
-
-func (h *UserHandler) ResetUser(ctx context.Context, sessionID int) error {
-	if h.G().Env.GetRunMode() != libkb.DevelRunMode {
-		return errors.New("can only reset user via service RPC in dev mode")
-	}
-	err := h.G().LoginState().ResetAccount(libkb.NewMetaContext(ctx, h.G()), h.G().Env.GetUsername().String())
-	if err != nil {
-		return err
-	}
-	err = h.G().Logout()
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func (h *UserHandler) ProfileEdit(nctx context.Context, arg keybase1.ProfileEditArg) error {

--- a/go/systests/passphrase_test.go
+++ b/go/systests/passphrase_test.go
@@ -50,7 +50,7 @@ func TestPassphraseChange(t *testing.T) {
 	}
 
 	m := libkb.NewMetaContextForTest(*tc)
-	err := libkb.VerifyPassphraseForLoggedInUser(m, userInfo.passphrase)
+	_, err := libkb.VerifyPassphraseForLoggedInUser(m, userInfo.passphrase)
 	require.NoError(t, err, "verified passphrase")
 
 	oldPassphrase := userInfo.passphrase
@@ -62,9 +62,9 @@ func TestPassphraseChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = libkb.VerifyPassphraseForLoggedInUser(m, newPassphrase)
+	_, err = libkb.VerifyPassphraseForLoggedInUser(m, newPassphrase)
 	require.NoError(t, err, "verified passphrase")
-	err = libkb.VerifyPassphraseForLoggedInUser(m, oldPassphrase)
+	_, err = libkb.VerifyPassphraseForLoggedInUser(m, oldPassphrase)
 	require.Error(t, err, "old passphrase failed to verify")
 
 	if err := client.CtlServiceStop(tc2.G); err != nil {

--- a/go/systests/rekey_test.go
+++ b/go/systests/rekey_test.go
@@ -20,15 +20,16 @@ import (
 // deviceWrapper wraps a mock "device", meaning an independent running service and
 // some connected clients.
 type deviceWrapper struct {
-	tctx         *libkb.TestContext
-	clones       []*libkb.TestContext
-	stopCh       chan error
-	service      *service.Service
-	rekeyUI      *testRekeyUI
-	deviceKey    keybase1.PublicKey
-	rekeyClient  keybase1.RekeyClient
-	userClient   keybase1.UserClient
-	gregorClient keybase1.GregorClient
+	tctx          *libkb.TestContext
+	clones        []*libkb.TestContext
+	stopCh        chan error
+	service       *service.Service
+	rekeyUI       *testRekeyUI
+	deviceKey     keybase1.PublicKey
+	rekeyClient   keybase1.RekeyClient
+	userClient    keybase1.UserClient
+	accountClient keybase1.AccountClient
+	gregorClient  keybase1.GregorClient
 }
 
 func (d *deviceWrapper) KID() keybase1.KID {
@@ -238,6 +239,7 @@ func (rkt *rekeyTester) startUIsAndClients(dw *deviceWrapper) {
 		dw.rekeyClient = keybase1.RekeyClient{Cli: cli}
 		dw.userClient = keybase1.UserClient{Cli: cli}
 		dw.gregorClient = keybase1.GregorClient{Cli: cli}
+		dw.accountClient = keybase1.AccountClient{Cli: cli}
 		return nil
 	}
 

--- a/go/systests/standalone_test.go
+++ b/go/systests/standalone_test.go
@@ -75,6 +75,7 @@ func makeUserStandalone(t *testing.T, pre string, opts standaloneUserArgs) *user
 	u.teamsClient = keybase1.TeamsClient{Cli: cli}
 
 	u.device.userClient = keybase1.UserClient{Cli: cli}
+	u.device.accountClient = keybase1.AccountClient{Cli: cli}
 
 	return &u
 }

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -186,6 +186,7 @@ func (tt *teamTester) addUserHelper(pre string, puk bool, paper bool) *userPlusD
 
 	u.deviceClient = keybase1.DeviceClient{Cli: cli}
 	u.device.userClient = keybase1.UserClient{Cli: cli}
+	u.device.accountClient = keybase1.AccountClient{Cli: cli}
 
 	// register for notifications
 	u.notifications = newTeamNotifyHandler()
@@ -706,7 +707,7 @@ func (u *userPlusDevice) provisionNewDevice() *deviceWrapper {
 func (u *userPlusDevice) reset() {
 	u.device.tctx.Tp.SkipLogoutIfRevokedCheck = true
 	uvBefore := u.userVersion()
-	err := u.device.userClient.ResetUser(context.TODO(), 0)
+	err := u.device.accountClient.ResetAccount(context.TODO(), keybase1.ResetAccountArg{Passphrase: u.passphrase})
 	require.NoError(u.tc.T, err)
 	uvAfter := u.userVersion()
 	require.NotEqual(u.tc.T, uvBefore.EldestSeqno, uvAfter.EldestSeqno,

--- a/go/test/run_tests.sh
+++ b/go/test/run_tests.sh
@@ -25,7 +25,7 @@ for i in $DIRS; do
   fi
 
   echo -n "$i......."
-  if ! (cd $i && go test -timeout 50m -ldflags -s) ; then
+  if ! (cd $i && go test -timeout 50m -ldflags -s ) ; then
     failures+=("$i")
   fi
 done

--- a/protocol/avdl/keybase1/account.avdl
+++ b/protocol/avdl/keybase1/account.avdl
@@ -26,5 +26,9 @@ protocol account {
     boolean hasServerKeys;
   }
 
-  void resetAccount(int sessionID);
+  /**
+   resetAccount resets the user's account; it's meant only for devel and tests.
+   passphrase is optional and will be prompted for if not supplied.
+  */
+  void resetAccount(int sessionID, string passphrase);
 }

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -142,9 +142,6 @@ protocol user {
   }
   array<InterestingPerson> interestingPeople(int maxUsers);
 
-  // resetUser resets the user. Only works in Dev mode since it's so dangerous
-  void resetUser(int sessionID);
-
   UserVersion meUserVersion(int sessionID, boolean forcePoll);
 
   /**

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1982,10 +1982,6 @@ export const userProfileEditRpcChannelMap = (configKeys: Array<string>, request:
 
 export const userProfileEditRpcPromise = (request: UserProfileEditRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.profileEdit', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
 
-export const userResetUserRpcChannelMap = (configKeys: Array<string>, request: UserResetUserRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.resetUser', request)
-
-export const userResetUserRpcPromise = (request: UserResetUserRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.resetUser', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
-
 export const userSearchRpcChannelMap = (configKeys: Array<string>, request: UserSearchRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.search', request)
 
 export const userSearchRpcPromise = (request: UserSearchRpcParam): Promise<UserSearchResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.search', request, (error: RPCError, result: UserSearchResult) => (error ? reject(error) : resolve(result))))
@@ -2004,7 +2000,7 @@ export type AccountPassphraseChangeRpcParam = $ReadOnly<{oldPassphrase: String, 
 
 export type AccountPassphrasePromptRpcParam = $ReadOnly<{guiArg: GUIEntryArg, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type AccountResetAccountRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type AccountResetAccountRpcParam = $ReadOnly<{passphrase: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type AnnotatedMemberInfo = $ReadOnly<{userID: UID, teamID: TeamID, username: String, fullName: String, fqName: String, isImplicitTeam: Boolean, isOpenTeam: Boolean, role: TeamRole, implicit?: ?ImplicitRole, needsPUK: Boolean, memberCount: Int, eldestSeqno: Seqno, active: Boolean, allowProfilePromote: Boolean, isMemberShowcased: Boolean}>
 
@@ -4138,8 +4134,6 @@ export type UserPlusKeysV2 = $ReadOnly<{uid: UID, username: String, eldestSeqno:
 export type UserPlusKeysV2AllIncarnations = $ReadOnly<{current: UserPlusKeysV2, pastIncarnations?: ?Array<UserPlusKeysV2>, uvv: UserVersionVector, seqnoLinkIDs: {[key: string]: LinkID}, minorVersion: UPK2MinorVersion}>
 
 export type UserProfileEditRpcParam = $ReadOnly<{fullName: String, location: String, bio: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
-
-export type UserResetUserRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type UserResolution = $ReadOnly<{assertion: SocialAssertion, userID: UID}>
 

--- a/protocol/json/keybase1/account.json
+++ b/protocol/json/keybase1/account.json
@@ -83,9 +83,14 @@
         {
           "name": "sessionID",
           "type": "int"
+        },
+        {
+          "name": "passphrase",
+          "type": "string"
         }
       ],
-      "response": null
+      "response": null,
+      "doc": "resetAccount resets the user's account; it's meant only for devel and tests.\n   passphrase is optional and will be prompted for if not supplied."
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -558,15 +558,6 @@
         "items": "InterestingPerson"
       }
     },
-    "resetUser": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        }
-      ],
-      "response": null
-    },
     "meUserVersion": {
       "request": [
         {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1982,10 +1982,6 @@ export const userProfileEditRpcChannelMap = (configKeys: Array<string>, request:
 
 export const userProfileEditRpcPromise = (request: UserProfileEditRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.profileEdit', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
 
-export const userResetUserRpcChannelMap = (configKeys: Array<string>, request: UserResetUserRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.resetUser', request)
-
-export const userResetUserRpcPromise = (request: UserResetUserRpcParam): Promise<void> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.resetUser', request, (error: RPCError, result: void) => (error ? reject(error) : resolve())))
-
 export const userSearchRpcChannelMap = (configKeys: Array<string>, request: UserSearchRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.search', request)
 
 export const userSearchRpcPromise = (request: UserSearchRpcParam): Promise<UserSearchResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.search', request, (error: RPCError, result: UserSearchResult) => (error ? reject(error) : resolve(result))))
@@ -2004,7 +2000,7 @@ export type AccountPassphraseChangeRpcParam = $ReadOnly<{oldPassphrase: String, 
 
 export type AccountPassphrasePromptRpcParam = $ReadOnly<{guiArg: GUIEntryArg, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
-export type AccountResetAccountRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+export type AccountResetAccountRpcParam = $ReadOnly<{passphrase: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type AnnotatedMemberInfo = $ReadOnly<{userID: UID, teamID: TeamID, username: String, fullName: String, fqName: String, isImplicitTeam: Boolean, isOpenTeam: Boolean, role: TeamRole, implicit?: ?ImplicitRole, needsPUK: Boolean, memberCount: Int, eldestSeqno: Seqno, active: Boolean, allowProfilePromote: Boolean, isMemberShowcased: Boolean}>
 
@@ -4138,8 +4134,6 @@ export type UserPlusKeysV2 = $ReadOnly<{uid: UID, username: String, eldestSeqno:
 export type UserPlusKeysV2AllIncarnations = $ReadOnly<{current: UserPlusKeysV2, pastIncarnations?: ?Array<UserPlusKeysV2>, uvv: UserVersionVector, seqnoLinkIDs: {[key: string]: LinkID}, minorVersion: UPK2MinorVersion}>
 
 export type UserProfileEditRpcParam = $ReadOnly<{fullName: String, location: String, bio: String, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
-
-export type UserResetUserRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type UserResolution = $ReadOnly<{assertion: SocialAssertion, userID: UID}>
 


### PR DESCRIPTION
- there is still one more instance in common_test.go, which we should go and rip out once LoginState is actually ripped out of libkb (and G)
- try to keep the tests as much as possible, but some changes to tests had to be made since the login of what "being logged in" is now different