### PR TITLE
Add ChangeDisplayCurrencyLocal Stellar RPC

### DIFF
--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -247,6 +247,12 @@ type LinkNewWalletAccountLocalArg struct {
 	Name      string    `codec:"name" json:"name"`
 }
 
+type ChangeDisplayCurrencyLocalArg struct {
+	SessionID int                 `codec:"sessionID" json:"sessionID"`
+	AccountID AccountID           `codec:"accountID" json:"accountID"`
+	Currency  OutsideCurrencyCode `codec:"currency" json:"currency"`
+}
+
 type BalancesLocalArg struct {
 	AccountID AccountID `codec:"accountID" json:"accountID"`
 }
@@ -320,6 +326,7 @@ type LocalInterface interface {
 	SetWalletAccountAsDefaultLocal(context.Context, SetWalletAccountAsDefaultLocalArg) error
 	DeleteWalletAccountLocal(context.Context, DeleteWalletAccountLocalArg) error
 	LinkNewWalletAccountLocal(context.Context, LinkNewWalletAccountLocalArg) (AccountID, error)
+	ChangeDisplayCurrencyLocal(context.Context, ChangeDisplayCurrencyLocalArg) error
 	BalancesLocal(context.Context, AccountID) ([]Balance, error)
 	SendCLILocal(context.Context, SendCLILocalArg) (SendResultCLILocal, error)
 	ClaimCLILocal(context.Context, ClaimCLILocalArg) (RelayClaimResult, error)
@@ -449,6 +456,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.LinkNewWalletAccountLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"changeDisplayCurrencyLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]ChangeDisplayCurrencyLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChangeDisplayCurrencyLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChangeDisplayCurrencyLocalArg)(nil), args)
+						return
+					}
+					err = i.ChangeDisplayCurrencyLocal(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -715,6 +738,11 @@ func (c LocalClient) DeleteWalletAccountLocal(ctx context.Context, __arg DeleteW
 
 func (c LocalClient) LinkNewWalletAccountLocal(ctx context.Context, __arg LinkNewWalletAccountLocalArg) (res AccountID, err error) {
 	err = c.Cli.Call(ctx, "stellar.1.local.linkNewWalletAccountLocal", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) ChangeDisplayCurrencyLocal(ctx context.Context, __arg ChangeDisplayCurrencyLocalArg) (err error) {
+	err = c.Cli.Call(ctx, "stellar.1.local.changeDisplayCurrencyLocal", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/stellar/remote/interface.go
+++ b/go/stellar/remote/interface.go
@@ -15,6 +15,10 @@ type Remoter interface {
 	SubmitRelayClaim(context.Context, stellar1.RelayClaimPost) (stellar1.RelayClaimResult, error)
 	RecentPayments(ctx context.Context, accountID stellar1.AccountID, limit int) (res []stellar1.PaymentSummary, err error)
 	PaymentDetail(ctx context.Context, txID string) (res stellar1.PaymentSummary, err error)
+	// GetAccountDisplayCurrency is not used as a mock now - since this
+	// setting only lives in database table on the server, we can do full
+	// integration testing here. Otherwise, all what ChangeDisplayCurrency
+	// test would do is testing a mock.
 	GetAccountDisplayCurrency(ctx context.Context, accountID stellar1.AccountID) (string, error)
 	ExchangeRate(ctx context.Context, currency string) (stellar1.OutsideExchangeRate, error)
 }

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -314,3 +314,66 @@ func TestDeleteWallet(t *testing.T) {
 	require.Equal(t, accs[0].AccountID, accID2)
 	require.True(t, accs[0].IsPrimary)
 }
+
+func TestChangeDisplayCurrency(t *testing.T) {
+	tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	stellar.CreateWallet(context.Background(), tcs[0].G)
+	tcs[0].Backend.ImportAccountsForUser(tcs[0])
+	accID := getPrimaryAccountID(tcs[0])
+
+	// Try invalid currency first.
+	err := tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+		AccountID: accID,
+		Currency:  stellar1.OutsideCurrencyCode("ZZZ"),
+	})
+	require.Error(t, err)
+
+	// Try empty account id.
+	err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+		AccountID: stellar1.AccountID(""),
+		Currency:  stellar1.OutsideCurrencyCode("USD"),
+	})
+	require.Error(t, err)
+
+	// Try non-existant account id.
+	invalidAccID, _ := randomStellarKeypair()
+	err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+		AccountID: invalidAccID,
+		Currency:  stellar1.OutsideCurrencyCode("USD"),
+	})
+	require.Error(t, err)
+
+	// Make wallet as other user, and try to change the currency as
+	// first user.
+	stellar.CreateWallet(context.Background(), tcs[1].G)
+	tcs[1].Backend.ImportAccountsForUser(tcs[1])
+	accID2 := getPrimaryAccountID(tcs[1])
+	err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+		AccountID: accID2,
+		Currency:  stellar1.OutsideCurrencyCode("EUR"),
+	})
+	require.Error(t, err)
+
+	// Finally, a happy path.
+	err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+		AccountID: accID,
+		Currency:  stellar1.OutsideCurrencyCode("EUR"),
+	})
+	require.NoError(t, err)
+
+	// Check both CLI and Frontend RPCs.
+	accs, err := tcs[0].Srv.WalletGetAccountsCLILocal(context.Background())
+	require.NoError(t, err)
+	require.Len(t, accs, 1)
+	require.NotNil(t, accs[0].ExchangeRate)
+	require.EqualValues(t, "EUR", accs[0].ExchangeRate.Currency)
+
+	balances, err := tcs[0].Srv.GetAccountAssetsLocal(context.Background(), stellar1.GetAccountAssetsLocalArg{
+		AccountID: accID,
+	})
+	require.NoError(t, err)
+	require.Len(t, balances, 1)
+	require.EqualValues(t, "EUR", balances[0].WorthCurrency)
+}

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -341,7 +341,7 @@ func NewBackendMock(t testing.TB) *BackendMock {
 }
 
 func (r *BackendMock) trace(err *error, name string, format string, args ...interface{}) func() {
-	r.T.Logf("+ %s%s", name, fmt.Sprintf(format, args...))
+	r.T.Logf("+ %s %s", name, fmt.Sprintf(format, args...))
 	return func() {
 		errStr := "?"
 		if err != nil {

--- a/protocol/avdl/stellar1/common.avdl
+++ b/protocol/avdl/stellar1/common.avdl
@@ -87,6 +87,7 @@ protocol common {
     string note;
   }
 
+  // OutsideCurrencyCode examples: "USD", "EUR"
   @typedef("string") record OutsideCurrencyCode {}
 
   record OutsideExchangeRate {

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -46,6 +46,10 @@ protocol local {
 
   AccountID linkNewWalletAccountLocal(int sessionID, SecretKey secretKey, string name);
 
+  // OutsideCurrencyCode examples: "USD", "EUR". Has to be one of
+  // supported currencies, returned from getDisplayCurrenciesLocal.
+  void changeDisplayCurrencyLocal(int sessionID, AccountID accountID, OutsideCurrencyCode currency);
+
   // -------------------------------------------------------
   // CLI protocol
   // -------------------------------------------------------

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -353,6 +353,23 @@
       ],
       "response": "AccountID"
     },
+    "changeDisplayCurrencyLocal": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "accountID",
+          "type": "AccountID"
+        },
+        {
+          "name": "currency",
+          "type": "OutsideCurrencyCode"
+        }
+      ],
+      "response": null
+    },
     "balancesLocal": {
       "request": [
         {


### PR DESCRIPTION
Note: I did not remove `GetAccountDisplayCurrency` mock yet, even though it's not used by stellar code right now (calls `remote.GetAccountDisplayCurrency` instead of `s.remoter.`GetAccountDisplayCurrency). I suspect in the future some tests might be conducted in a way where kbweb doesn't even know about the account, so this mock could be brought back then.