### PR TITLE
fix new chat w/ reset participants

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -165,9 +165,7 @@ const unboxRows = (
 
   const onUnboxed = function*({conv}: RPCChatTypes.ChatUiChatInboxConversationRpcParam) {
     const inboxUIItem: RPCChatTypes.InboxUIItem = JSON.parse(conv)
-    // We allow empty conversations now since we create them and they're empty now
-    const allowEmpty = action.type === Chat2Gen.selectConversation
-    const meta = Constants.inboxUIItemToConversationMeta(inboxUIItem, allowEmpty)
+    const meta = Constants.inboxUIItemToConversationMeta(inboxUIItem, true)
     if (meta) {
       yield Saga.put(
         Chat2Gen.createMetasReceived({

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1103,7 +1103,8 @@ const messageSend = (action: Chat2Gen.MessageSendPayload, state: TypedState) => 
 
 const previewConversationAfterFindExisting = (
   _fromPreviewConversation,
-  action: Chat2Gen.PreviewConversationPayload | Chat2Gen.SetPendingConversationUsersPayload
+  action: Chat2Gen.PreviewConversationPayload | Chat2Gen.SetPendingConversationUsersPayload,
+  state: TypedState
 ) => {
   // TODO make a sequentially that uses an object map and not all this array nonsense
   if (!_fromPreviewConversation || _fromPreviewConversation.length !== 4) {
@@ -1120,6 +1121,14 @@ const previewConversationAfterFindExisting = (
     // Even if we find an existing conversation lets put it into the pending state so its on top always, makes the UX simpler and better to see it selected
     // and allows quoting privately to work nicely
     existingConversationIDKey = Types.conversationIDToKey(results.conversations[0].info.id)
+
+    // If we get a conversationIDKey we don't know about (maybe an empty convo) lets treat it as not being found so we can go through the create flow
+    if (
+      existingConversationIDKey &&
+      Constants.getMeta(state, existingConversationIDKey).conversationIDKey === Constants.noConversationIDKey
+    ) {
+      existingConversationIDKey = Constants.noConversationIDKey
+    }
   }
 
   // If we're previewing a team conversation we want to actually make an rpc call and add it to the inbox

--- a/shared/chat/conversation/messages/special-bottom-message.js
+++ b/shared/chat/conversation/messages/special-bottom-message.js
@@ -35,6 +35,7 @@ class BottomMessage extends React.PureComponent<Props> {
 
 type OwnProps = {
   conversationIDKey: Types.ConversationIDKey,
+  measure: ?() => void,
 }
 
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
@@ -46,6 +47,7 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
       : null
 
   return {
+    measure: ownProps.measure,
     showResetParticipants,
     showSuperseded,
   }

--- a/shared/util/saga.js
+++ b/shared/util/saga.js
@@ -126,7 +126,7 @@ function* sequentially(effects: Array<any>): Generator<any, Array<any>, any> {
 function safeTakeEveryPure<A, R, FinalAction, FinalActionError>(
   pattern: string | Array<any> | Function,
   pureWorker: ((action: A, state: TypedState) => any) | ((action: A) => any),
-  actionCreatorsWithResult?: ?(result: R, action: A, updatedState?: TypedState) => FinalAction,
+  actionCreatorsWithResult?: ?(result: R, action: A, updatedState: TypedState) => FinalAction,
   actionCreatorsWithError?: ?(result: R, action: A) => FinalActionError
 ) {
   return safeTakeEvery(pattern, function* safeTakeEveryPureWorker(action: A) {
@@ -148,7 +148,8 @@ function safeTakeEveryPure<A, R, FinalAction, FinalActionError>(
           const state: TypedState = yield select()
           yield actionCreatorsWithResult(result, action, state)
         } else {
-          yield actionCreatorsWithResult(result, action)
+          // $FlowIssue we pass undefined if they don't use it
+          yield actionCreatorsWithResult(result, action, undefined)
         }
       }
     } catch (e) {

--- a/shared/util/saga.js
+++ b/shared/util/saga.js
@@ -126,7 +126,7 @@ function* sequentially(effects: Array<any>): Generator<any, Array<any>, any> {
 function safeTakeEveryPure<A, R, FinalAction, FinalActionError>(
   pattern: string | Array<any> | Function,
   pureWorker: ((action: A, state: TypedState) => any) | ((action: A) => any),
-  actionCreatorsWithResult?: ?(result: R, action: A) => FinalAction,
+  actionCreatorsWithResult?: ?(result: R, action: A, updatedState?: TypedState) => FinalAction,
   actionCreatorsWithError?: ?(result: R, action: A) => FinalActionError
 ) {
   return safeTakeEvery(pattern, function* safeTakeEveryPureWorker(action: A) {
@@ -143,7 +143,13 @@ function safeTakeEveryPure<A, R, FinalAction, FinalActionError>(
       }
 
       if (actionCreatorsWithResult) {
-        yield actionCreatorsWithResult(result, action)
+        if (actionCreatorsWithResult.length === 3) {
+          // add a way to get the updated state
+          const state: TypedState = yield select()
+          yield actionCreatorsWithResult(result, action, state)
+        } else {
+          yield actionCreatorsWithResult(result, action)
+        }
       }
     } catch (e) {
       if (actionCreatorsWithError) {


### PR DESCRIPTION
Fixes a bug, heres the repro

1. Make an account on the web (`new`)
1. Add a pgp key
1. With another account (`other`) share some files in kbfs (`/keybase/private/new,other/hello.txt`)
1. Reset the `new` account
1. Start a chat convo `new,other`
1. You should see the red banner w/ skull and crossbones
1. Click `add them` button
1. Send to new chat

This should fail with a blackbar no tlfname specific error

