### PR TITLE
Search results tracker icon tweaks

### DIFF
--- a/shared/chat/conversation/list-area/container.js
+++ b/shared/chat/conversation/list-area/container.js
@@ -3,10 +3,11 @@ import * as React from 'react'
 import * as SearchConstants from '../../../constants/search'
 import * as Types from '../../../constants/types/chat2'
 import * as Constants from '../../../constants/chat2'
+import * as ProfileGen from '../../../actions/profile-gen'
 import * as TrackerGen from '../../../actions/tracker-gen'
 import Normal from './normal/container'
 import SearchResultsList from '../../../search/results-list/container'
-import {connect, type TypedState, type Dispatch} from '../../../util/container'
+import {connect, type TypedState, type Dispatch, isMobile} from '../../../util/container'
 import {desktopStyles} from '../../../styles'
 import StartConversation from './start-conversation/container'
 import Waiting from './waiting'
@@ -91,7 +92,9 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   onShowTracker: (username: string) =>
-    dispatch(TrackerGen.createGetProfile({forceDisplay: true, ignoreCache: false, username})),
+    isMobile
+      ? dispatch(ProfileGen.createShowUserProfile({username}))
+      : dispatch(TrackerGen.createGetProfile({forceDisplay: true, ignoreCache: false, username})),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {

--- a/shared/search/result-row/index.js
+++ b/shared/search/result-row/index.js
@@ -97,8 +97,9 @@ const Right = ({showTrackerButton, onShowTracker}) => {
       onClick={onShowTracker}
       style={{
         marginLeft: globalMargins.small,
-        marginRight: isMobile ? globalMargins.tiny : globalMargins.small,
+        marginRight: globalMargins.small,
       }}
+      fontSize={isMobile ? 22 : 16}
     />
   ) : null
 }


### PR DESCRIPTION
Fixes the dimensions on mobile & hooks up the action in the chat results list to go to the profile on mobile. On master it does nothing on mobile. r? @keybase/react-hackers 