### PR TITLE
Allow DeviceEK deletion offline

### DIFF
--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -17,53 +17,57 @@ func TestDeviceEKStorage(t *testing.T) {
 	tc, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	now := keybase1.TimeFromSeconds(time.Now().Unix())
-	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
-	require.NoError(t, err)
-	merkleRoot := *merkleRootPtr
-
-	tests := []keybase1.DeviceEk{
+	now := keybase1.ToTime(time.Now())
+	testKeys := []keybase1.DeviceEk{
 		{
 			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic0"))),
 			Metadata: keybase1.DeviceEkMetadata{
-				Generation: 0,
-				HashMeta:   keybase1.HashMeta("fakeHashMeta0"),
-				Kid:        "",
-				Ctime:      now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
+				Generation:  0,
+				HashMeta:    keybase1.HashMeta("fakeHashMeta0"),
+				Kid:         "",
+				Ctime:       now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
+				DeviceCtime: now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
 			},
 		},
 		{
 			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic1"))),
 			Metadata: keybase1.DeviceEkMetadata{
-				Generation: 1,
-				HashMeta:   keybase1.HashMeta("fakeHashMeta1"),
-				Kid:        "",
-				Ctime:      now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
+				Generation:  1,
+				HashMeta:    keybase1.HashMeta("fakeHashMeta1"),
+				Kid:         "",
+				Ctime:       now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
+				DeviceCtime: now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
 			},
 		},
 		{
 			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic2"))),
 			Metadata: keybase1.DeviceEkMetadata{
-				Generation: 2,
-				HashMeta:   keybase1.HashMeta("fakeHashMeta2"),
-				Kid:        "",
-				Ctime:      now,
+				Generation:  2,
+				HashMeta:    keybase1.HashMeta("fakeHashMeta2"),
+				Kid:         "",
+				Ctime:       now,
+				DeviceCtime: now,
 			},
 		},
 		{
 			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic3"))),
 			Metadata: keybase1.DeviceEkMetadata{
-				Generation: 3,
-				HashMeta:   keybase1.HashMeta("fakeHashMeta3"),
-				Kid:        "",
-				Ctime:      now,
+				Generation:  3,
+				HashMeta:    keybase1.HashMeta("fakeHashMeta3"),
+				Kid:         "",
+				Ctime:       now,
+				DeviceCtime: now,
 			},
 		},
 	}
 
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
+	require.NoError(t, err)
+	merkleRoot := *merkleRootPtr
+
 	s := NewDeviceEKStorage(tc.G)
 
-	for _, test := range tests {
+	for _, test := range testKeys {
 		err := s.Put(context.Background(), test.Metadata.Generation, test)
 		require.NoError(t, err)
 
@@ -83,7 +87,7 @@ func TestDeviceEKStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, len(deviceEKs), 4)
-	for _, test := range tests {
+	for _, test := range testKeys {
 		deviceEK, ok := deviceEKs[test.Metadata.Generation]
 		require.True(t, ok)
 		require.Equal(t, deviceEK, test)
@@ -123,8 +127,8 @@ func TestDeviceEKStorage(t *testing.T) {
 	err = erasableStorage.Put(context.Background(), badEldestSeqnoKey, keybase1.DeviceEk{})
 	require.NoError(t, err)
 
-	expired, err := s.DeleteExpired(context.Background(), merkleRoot)
 	expected := []keybase1.EkGeneration{0, 1}
+	expired, err := s.DeleteExpired(context.Background(), merkleRoot)
 	require.NoError(t, err)
 	require.Equal(t, expected, expired)
 
@@ -187,4 +191,62 @@ func TestDeviceEKStorageKeyFormat(t *testing.T) {
 	require.NoError(t, err)
 	expected := fmt.Sprintf("deviceEphemeralKey-%s-%s-%d.ek", s.G().Env.GetUsername(), uv.EldestSeqno, generation)
 	require.Equal(t, expected, key)
+}
+
+func TestDeleteExpiredOffline(t *testing.T) {
+	tc, _ := ephemeralKeyTestSetup(t)
+	defer tc.Cleanup()
+
+	now := keybase1.ToTime(time.Now())
+	expiredTestKeys := []keybase1.DeviceEk{
+		{
+			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic0"))),
+			Metadata: keybase1.DeviceEkMetadata{
+				Generation: 0,
+				HashMeta:   keybase1.HashMeta("fakeHashMeta0"),
+				Kid:        "",
+				Ctime:      now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
+				// Although we are 'offline' and can't get a merkleRoot, we
+				// correctly delete this key since we fall back to the Ctime
+				DeviceCtime: -1,
+			},
+		},
+		{
+			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic1"))),
+			Metadata: keybase1.DeviceEkMetadata{
+				Generation:  1,
+				HashMeta:    keybase1.HashMeta("fakeHashMeta1"),
+				Kid:         "",
+				Ctime:       now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
+				DeviceCtime: now - keybase1.TimeFromSeconds(KeyLifetimeSecs*3),
+			},
+		},
+		{
+			Seed: keybase1.Bytes32(libkb.MakeByte32([]byte("deviceekseed-deviceekseed-devic2"))),
+			Metadata: keybase1.DeviceEkMetadata{
+				Generation:  2,
+				HashMeta:    keybase1.HashMeta("fakeHashMeta2"),
+				Kid:         "",
+				Ctime:       now,
+				DeviceCtime: now,
+			},
+		},
+	}
+
+	s := NewDeviceEKStorage(tc.G)
+
+	for _, test := range expiredTestKeys {
+		err := s.Put(context.Background(), test.Metadata.Generation, test)
+		require.NoError(t, err)
+	}
+
+	expected := []keybase1.EkGeneration{0, 1}
+	expired, err := s.DeleteExpired(context.Background(), libkb.MerkleRoot{})
+	require.NoError(t, err)
+	require.Equal(t, expected, expired)
+
+	deviceEKsAfterDeleteExpired, err := s.GetAll(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, deviceEKsAfterDeleteExpired, 1)
 }

--- a/go/ephemeral/device_ek_test.go
+++ b/go/ephemeral/device_ek_test.go
@@ -23,6 +23,10 @@ func TestNewDeviceEK(t *testing.T) {
 	s := tc.G.GetDeviceEKStorage()
 	deviceEK, err := s.Get(context.Background(), publishedMetadata.Generation)
 	require.NoError(t, err)
+	// Clear out DeviceCtime since it won't be present in fetched data, it's
+	// only known locally.
+	require.NotEqual(t, 0, deviceEK.Metadata.DeviceCtime)
+	deviceEK.Metadata.DeviceCtime = 0
 	require.Equal(t, deviceEK.Metadata, publishedMetadata)
 
 	fetchedDevices, err := allActiveDeviceEKMetadata(context.Background(), tc.G, merkleRoot)

--- a/go/ephemeral/kex2_test.go
+++ b/go/ephemeral/kex2_test.go
@@ -110,10 +110,7 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 			}
 			provisionee := engine.NewKex2Provisionee(tcY.G, device, secretY, fakeSalt())
 			m := libkb.NewMetaContextForTest(tcY).WithUIs(uis).WithNewProvisionalLoginContext()
-			if err := engine.RunEngine2(m, provisionee); err != nil {
-				return err
-			}
-			return nil
+			return engine.RunEngine2(m, provisionee)
 		})()
 		require.NoError(t, err, "provisionee")
 	}()
@@ -145,6 +142,10 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 		require.True(t, maxDeviceEKGenerationY > 0)
 		deviceEKY, err := deviceEKStorageY.Get(context.Background(), maxDeviceEKGenerationY)
 		require.NoError(t, err)
+		// Clear out DeviceCtime since it won't be present in fetched data,
+		// it's only known locally.
+		require.NotEqual(t, 0, deviceEKY.Metadata.DeviceCtime)
+		deviceEKY.Metadata.DeviceCtime = 0
 
 		// Make sure the server knows about our device_ek
 		merkleRootPtr, err := tcY.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
@@ -234,4 +235,37 @@ func TestCleanupStaleUserAndDeviceEKs(t *testing.T) {
 
 	err = ekLib.CleanupStaleUserAndDeviceEKs(context.Background())
 	require.NoError(t, err)
+}
+
+func TestCleanupStaleUserAndDeviceEKsOffline(t *testing.T) {
+	tc, _ := ephemeralKeyTestSetup(t)
+	defer tc.Cleanup()
+
+	seed, err := newDeviceEphemeralSeed()
+	require.NoError(t, err)
+	s := tc.G.GetDeviceEKStorage()
+	ctimeExpired := keybase1.TimeFromSeconds(time.Now().Unix() - KeyLifetimeSecs*3)
+	err = s.Put(context.Background(), 0, keybase1.DeviceEk{
+		Seed: keybase1.Bytes32(seed),
+		Metadata: keybase1.DeviceEkMetadata{
+			Ctime:       ctimeExpired,
+			DeviceCtime: ctimeExpired,
+		},
+	})
+	require.NoError(t, err)
+
+	ekLib := NewEKLib(tc.G)
+	err = ekLib.keygenIfNeeded(context.Background(), libkb.MerkleRoot{})
+	require.Error(t, err)
+	require.Equal(t, SkipKeygenNilMerkleRoot, err.Error())
+
+	// Even though we return an error, we charge through on the deletion
+	// successfully.
+	deviceEK, err := s.Get(context.Background(), 0)
+	require.Error(t, err)
+	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
+
+	err = ekLib.keygenIfNeeded(context.Background(), libkb.MerkleRoot{})
+	require.Error(t, err)
+	require.Equal(t, SkipKeygenNilMerkleRoot, err.Error())
 }

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -225,6 +225,10 @@ func (mr MerkleRoot) HashMeta() keybase1.HashMeta {
 	return mr.ShortHash().ExportToHashMeta()
 }
 
+func (mr MerkleRoot) IsNil() bool {
+	return mr == MerkleRoot{}
+}
+
 type SkipSequence []MerkleRootPayload
 
 type MerkleTriple struct {

--- a/go/protocol/keybase1/ephemeral.go
+++ b/go/protocol/keybase1/ephemeral.go
@@ -14,18 +14,20 @@ func (o EkGeneration) DeepCopy() EkGeneration {
 }
 
 type DeviceEkMetadata struct {
-	Kid        KID          `codec:"kid" json:"device_ephemeral_dh_public"`
-	HashMeta   HashMeta     `codec:"hashMeta" json:"hash_meta"`
-	Generation EkGeneration `codec:"generation" json:"generation"`
-	Ctime      Time         `codec:"ctime" json:"ctime"`
+	Kid         KID          `codec:"kid" json:"device_ephemeral_dh_public"`
+	HashMeta    HashMeta     `codec:"hashMeta" json:"hash_meta"`
+	Generation  EkGeneration `codec:"generation" json:"generation"`
+	Ctime       Time         `codec:"ctime" json:"ctime"`
+	DeviceCtime Time         `codec:"deviceCtime" json:"deviceCtime"`
 }
 
 func (o DeviceEkMetadata) DeepCopy() DeviceEkMetadata {
 	return DeviceEkMetadata{
-		Kid:        o.Kid.DeepCopy(),
-		HashMeta:   o.HashMeta.DeepCopy(),
-		Generation: o.Generation.DeepCopy(),
-		Ctime:      o.Ctime.DeepCopy(),
+		Kid:         o.Kid.DeepCopy(),
+		HashMeta:    o.HashMeta.DeepCopy(),
+		Generation:  o.Generation.DeepCopy(),
+		Ctime:       o.Ctime.DeepCopy(),
+		DeviceCtime: o.DeviceCtime.DeepCopy(),
 	}
 }
 

--- a/protocol/avdl/keybase1/ephemeral.avdl
+++ b/protocol/avdl/keybase1/ephemeral.avdl
@@ -16,6 +16,7 @@ protocol ephemeral {
     HashMeta hashMeta;
     EkGeneration generation;
     Time ctime;
+    Time deviceCtime;
   }
 
   // NOTE: The device/user/team structs are very similar here, so it might seem

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2263,7 +2263,7 @@ export type DeviceDeviceListRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCal
 
 export type DeviceEk = $ReadOnly<{seed: Bytes32, metadata: DeviceEkMetadata}>
 
-export type DeviceEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation: EkGeneration, ctime: Time}>
+export type DeviceEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation: EkGeneration, ctime: Time, deviceCtime: Time}>
 
 export type DeviceEkStatement = $ReadOnly<{currentDeviceEkMetadata: DeviceEkMetadata, existingDeviceEkMetadata?: ?Array<DeviceEkMetadata>}>
 

--- a/protocol/json/keybase1/ephemeral.json
+++ b/protocol/json/keybase1/ephemeral.json
@@ -35,6 +35,10 @@
         {
           "type": "Time",
           "name": "ctime"
+        },
+        {
+          "type": "Time",
+          "name": "deviceCtime"
         }
       ]
     },

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2263,7 +2263,7 @@ export type DeviceDeviceListRpcParam = ?$ReadOnly<{incomingCallMap?: IncomingCal
 
 export type DeviceEk = $ReadOnly<{seed: Bytes32, metadata: DeviceEkMetadata}>
 
-export type DeviceEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation: EkGeneration, ctime: Time}>
+export type DeviceEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation: EkGeneration, ctime: Time, deviceCtime: Time}>
 
 export type DeviceEkStatement = $ReadOnly<{currentDeviceEkMetadata: DeviceEkMetadata, existingDeviceEkMetadata?: ?Array<DeviceEkMetadata>}>
 


### PR DESCRIPTION
We would like deviceEK deletion to proceed even when clients can't access the net/receive a merkleRoot (to check the key's expiry time) We add a local device time which we fall back on during deletion and ensure deletion proceeds even when offline.