### PR TITLE
ignore native files on webpack so errors are easier to understand

### DIFF
--- a/shared/desktop/webpack.config.babel.js
+++ b/shared/desktop/webpack.config.babel.js
@@ -26,6 +26,7 @@ const config = (_, {mode}) => {
       loader: 'babel-loader',
       options: {
         cacheDirectory: true,
+        ignore: [/\.(native|ios|android)\.js$/],
         plugins: [...(isHot ? ['react-hot-loader/babel'] : [])],
         presets: [['@babel/preset-env', {debug: false, modules: false, targets: {electron: '1.8.4'}}]],
       },


### PR DESCRIPTION
@keybase/react-hackers should help debug errors easier when including native in desktop paths

cc: @adamjspooner 

Before:
<img width="997" alt="screen shot 2018-05-25 at 10 09 04 am" src="https://user-images.githubusercontent.com/516435/40548787-b03996be-6003-11e8-9d51-91c038043e4e.png">

After:
<img width="999" alt="screen shot 2018-05-25 at 10 08 20 am" src="https://user-images.githubusercontent.com/516435/40548747-97821d3a-6003-11e8-923f-7c4613c4dcea.png">

