### PR TITLE
Stellar RPC: key exporting

### DIFF
--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -253,6 +253,16 @@ type ChangeDisplayCurrencyLocalArg struct {
 	Currency  OutsideCurrencyCode `codec:"currency" json:"currency"`
 }
 
+type GetWalletAccountPublicKeyLocalArg struct {
+	SessionID int       `codec:"sessionID" json:"sessionID"`
+	AccountID AccountID `codec:"accountID" json:"accountID"`
+}
+
+type GetWalletAccountPrivateKeyLocalArg struct {
+	SessionID int       `codec:"sessionID" json:"sessionID"`
+	AccountID AccountID `codec:"accountID" json:"accountID"`
+}
+
 type BalancesLocalArg struct {
 	AccountID AccountID `codec:"accountID" json:"accountID"`
 }
@@ -328,6 +338,8 @@ type LocalInterface interface {
 	DeleteWalletAccountLocal(context.Context, DeleteWalletAccountLocalArg) error
 	LinkNewWalletAccountLocal(context.Context, LinkNewWalletAccountLocalArg) (AccountID, error)
 	ChangeDisplayCurrencyLocal(context.Context, ChangeDisplayCurrencyLocalArg) error
+	GetWalletAccountPublicKeyLocal(context.Context, GetWalletAccountPublicKeyLocalArg) (string, error)
+	GetWalletAccountPrivateKeyLocal(context.Context, GetWalletAccountPrivateKeyLocalArg) (SecretKey, error)
 	BalancesLocal(context.Context, AccountID) ([]Balance, error)
 	SendCLILocal(context.Context, SendCLILocalArg) (SendResultCLILocal, error)
 	ClaimCLILocal(context.Context, ClaimCLILocalArg) (RelayClaimResult, error)
@@ -473,6 +485,38 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					err = i.ChangeDisplayCurrencyLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"getWalletAccountPublicKeyLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]GetWalletAccountPublicKeyLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]GetWalletAccountPublicKeyLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]GetWalletAccountPublicKeyLocalArg)(nil), args)
+						return
+					}
+					ret, err = i.GetWalletAccountPublicKeyLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"getWalletAccountPrivateKeyLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]GetWalletAccountPrivateKeyLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]GetWalletAccountPrivateKeyLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]GetWalletAccountPrivateKeyLocalArg)(nil), args)
+						return
+					}
+					ret, err = i.GetWalletAccountPrivateKeyLocal(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -744,6 +788,16 @@ func (c LocalClient) LinkNewWalletAccountLocal(ctx context.Context, __arg LinkNe
 
 func (c LocalClient) ChangeDisplayCurrencyLocal(ctx context.Context, __arg ChangeDisplayCurrencyLocalArg) (err error) {
 	err = c.Cli.Call(ctx, "stellar.1.local.changeDisplayCurrencyLocal", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) GetWalletAccountPublicKeyLocal(ctx context.Context, __arg GetWalletAccountPublicKeyLocalArg) (res string, err error) {
+	err = c.Cli.Call(ctx, "stellar.1.local.getWalletAccountPublicKeyLocal", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) GetWalletAccountPrivateKeyLocal(ctx context.Context, __arg GetWalletAccountPrivateKeyLocalArg) (res SecretKey, err error) {
+	err = c.Cli.Call(ctx, "stellar.1.local.getWalletAccountPrivateKeyLocal", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -279,3 +279,45 @@ func (s *Server) ChangeDisplayCurrencyLocal(ctx context.Context, arg stellar1.Ch
 	}
 	return remote.SetAccountDefaultCurrency(ctx, s.G(), arg.AccountID, string(arg.Currency))
 }
+
+func (s *Server) GetWalletAccountPublicKeyLocal(ctx context.Context, arg stellar1.GetWalletAccountPublicKeyLocalArg) (res string, err error) {
+	defer s.G().CTraceTimed(ctx, "GetWalletAccountPublicKeyLocal", func() error { return err })()
+	if arg.AccountID.IsNil() {
+		return res, errors.New("passed empty AccountID")
+	}
+	return arg.AccountID.String(), nil
+}
+
+func (s *Server) GetWalletAccountPrivateKeyLocal(ctx context.Context, arg stellar1.GetWalletAccountPrivateKeyLocalArg) (res stellar1.SecretKey, err error) {
+	mctx := libkb.NewMetaContext(s.logTag(ctx), s.G())
+	defer s.G().CTraceTimed(ctx, "GetWalletAccountPrivateKeyLocal", func() error { return err })()
+	if err = s.assertLoggedIn(ctx); err != nil {
+		return res, err
+	}
+	if arg.AccountID.IsNil() {
+		return res, errors.New("passed empty AccountID")
+	}
+
+	// Prompt for passphrase
+	username := s.G().GetEnv().GetUsername().String()
+	promptArg := libkb.DefaultPassphrasePromptArg(mctx, username)
+	promptArg.Prompt = fmt.Sprintf("%s to export Stellar secret keys for %q", promptArg.Prompt, arg.AccountID)
+	secretUI := s.uiSource.SecretUI(s.G(), 0)
+	ppRes, err := secretUI.GetPassphrase(promptArg, nil)
+	if err != nil {
+		return res, err
+	}
+	pwdOk := false
+	_, err = s.G().LoginState().VerifyPlaintextPassphrase(mctx, ppRes.Passphrase, func(lctx libkb.LoginContext) error {
+		pwdOk = true
+		return nil
+	})
+	if err != nil {
+		return res, err
+	}
+	if !pwdOk {
+		return res, libkb.PassphraseError{}
+	}
+
+	return stellar.ExportSecretKey(ctx, s.G(), arg.AccountID)
+}

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -289,34 +289,12 @@ func (s *Server) GetWalletAccountPublicKeyLocal(ctx context.Context, arg stellar
 }
 
 func (s *Server) GetWalletAccountPrivateKeyLocal(ctx context.Context, arg stellar1.GetWalletAccountPrivateKeyLocalArg) (res stellar1.SecretKey, err error) {
-	mctx := libkb.NewMetaContext(s.logTag(ctx), s.G())
 	defer s.G().CTraceTimed(ctx, "GetWalletAccountPrivateKeyLocal", func() error { return err })()
 	if err = s.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}
 	if arg.AccountID.IsNil() {
 		return res, errors.New("passed empty AccountID")
-	}
-
-	// Prompt for passphrase
-	username := s.G().GetEnv().GetUsername().String()
-	promptArg := libkb.DefaultPassphrasePromptArg(mctx, username)
-	promptArg.Prompt = fmt.Sprintf("%s to export Stellar secret keys for %q", promptArg.Prompt, arg.AccountID)
-	secretUI := s.uiSource.SecretUI(s.G(), 0)
-	ppRes, err := secretUI.GetPassphrase(promptArg, nil)
-	if err != nil {
-		return res, err
-	}
-	pwdOk := false
-	_, err = s.G().LoginState().VerifyPlaintextPassphrase(mctx, ppRes.Passphrase, func(lctx libkb.LoginContext) error {
-		pwdOk = true
-		return nil
-	})
-	if err != nil {
-		return res, err
-	}
-	if !pwdOk {
-		return res, libkb.PassphraseError{}
 	}
 
 	return stellar.ExportSecretKey(ctx, s.G(), arg.AccountID)

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -423,8 +423,7 @@ func TestPrivateKeyExporting(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	// Random account ID. Will still ask for password, and then
-	// discover it doesn't known this ID, and bail out.
+	// Try random account ID.
 	randomAccID, _ := randomStellarKeypair()
 	_, err = tcs[0].Srv.GetWalletAccountPrivateKeyLocal(context.Background(), stellar1.GetWalletAccountPrivateKeyLocalArg{
 		AccountID: randomAccID,

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -377,3 +377,64 @@ func TestChangeDisplayCurrency(t *testing.T) {
 	require.Len(t, balances, 1)
 	require.EqualValues(t, "EUR", balances[0].WorthCurrency)
 }
+
+func TestPublicKeyExporting(t *testing.T) {
+	tcs, cleanup := setupNTests(t, 1)
+	defer cleanup()
+
+	stellar.CreateWallet(context.Background(), tcs[0].G)
+	tcs[0].Backend.ImportAccountsForUser(tcs[0])
+	accID := getPrimaryAccountID(tcs[0])
+
+	// Try empty argument.
+	_, err := tcs[0].Srv.GetWalletAccountPublicKeyLocal(context.Background(), stellar1.GetWalletAccountPublicKeyLocalArg{
+		AccountID: stellar1.AccountID(""),
+	})
+	require.Error(t, err)
+
+	// Anything should work - even accounts that don't exist or are
+	// not ours.
+	randomAccID, _ := randomStellarKeypair()
+	pubKey, err := tcs[0].Srv.GetWalletAccountPublicKeyLocal(context.Background(), stellar1.GetWalletAccountPublicKeyLocalArg{
+		AccountID: randomAccID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, randomAccID, pubKey)
+
+	// Try account of our own.
+	pubKey, err = tcs[0].Srv.GetWalletAccountPublicKeyLocal(context.Background(), stellar1.GetWalletAccountPublicKeyLocalArg{
+		AccountID: accID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, accID, pubKey)
+}
+
+func TestPrivateKeyExporting(t *testing.T) {
+	tcs, cleanup := setupNTests(t, 1)
+	defer cleanup()
+
+	stellar.CreateWallet(context.Background(), tcs[0].G)
+	tcs[0].Backend.ImportAccountsForUser(tcs[0])
+	accID := getPrimaryAccountID(tcs[0])
+
+	// Try empty argument.
+	_, err := tcs[0].Srv.GetWalletAccountPrivateKeyLocal(context.Background(), stellar1.GetWalletAccountPrivateKeyLocalArg{
+		AccountID: stellar1.AccountID(""),
+	})
+	require.Error(t, err)
+
+	// Random account ID. Will still ask for password, and then
+	// discover it doesn't known this ID, and bail out.
+	randomAccID, _ := randomStellarKeypair()
+	_, err = tcs[0].Srv.GetWalletAccountPrivateKeyLocal(context.Background(), stellar1.GetWalletAccountPrivateKeyLocalArg{
+		AccountID: randomAccID,
+	})
+	require.Error(t, err)
+
+	// Happy path.
+	privKey, err := tcs[0].Srv.GetWalletAccountPrivateKeyLocal(context.Background(), stellar1.GetWalletAccountPrivateKeyLocalArg{
+		AccountID: accID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, tcs[0].Backend.SecretKey(accID), privKey)
+}

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -162,6 +162,20 @@ func TestImportExport(t *testing.T) {
 		require.Equal(t, s1, exported)
 	})
 
+	withWrongPassphrase := func(f func()) {
+		ui := &libkb.TestSecretUI{Passphrase: "notquite" + tcs[0].Fu.Passphrase}
+		tcs[0].Srv.uiSource.(*testUISource).secretUI = ui
+		f()
+		require.True(t, ui.CalledGetPassphrase, "operation should ask for passphrase")
+		tcs[0].Srv.uiSource.(*testUISource).secretUI = nullSecretUI{}
+	}
+
+	withWrongPassphrase(func() {
+		_, err := srv.ExportSecretKeyLocal(context.Background(), a1)
+		require.Error(t, err)
+		require.IsType(t, libkb.PassphraseError{}, err)
+	})
+
 	_, err = srv.ExportSecretKeyLocal(context.Background(), stellar1.AccountID(s1))
 	require.Error(t, err, "export confusing secret and public")
 

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -50,6 +50,9 @@ protocol local {
   // supported currencies, returned from getDisplayCurrenciesLocal.
   void changeDisplayCurrencyLocal(int sessionID, AccountID accountID, OutsideCurrencyCode currency);
 
+  string getWalletAccountPublicKeyLocal(int sessionID, AccountID accountID);
+  SecretKey getWalletAccountPrivateKeyLocal(int sessionID, AccountID accountID);
+
   // -------------------------------------------------------
   // CLI protocol
   // -------------------------------------------------------

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -370,6 +370,32 @@
       ],
       "response": null
     },
+    "getWalletAccountPublicKeyLocal": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "accountID",
+          "type": "AccountID"
+        }
+      ],
+      "response": "string"
+    },
+    "getWalletAccountPrivateKeyLocal": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "accountID",
+          "type": "AccountID"
+        }
+      ],
+      "response": "SecretKey"
+    },
     "balancesLocal": {
       "request": [
         {


### PR DESCRIPTION
Two new RPCs: one to export public key from AccountID, and another one to export secret key from AccountID. Most of the code is test code.

There is also addition to old test: `TestImportExport` which checks what happens if user provides wrong password.
