### PR TITLE
Fix prev pointers for exploding messages

### DIFF
--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -109,23 +109,20 @@ func (s *BlockingSender) addPrevPointersAndCheckConvID(ctx context.Context, msg 
 		return chat1.MessagePlaintext{}, err
 	}
 
-	var numPrev int
+	var hasPrev bool
 	if msg.IsEphemeral() {
 		prevs = newPrevsForExploding
-		numPrev = len(newPrevsForExploding)
+		hasPrev = len(newPrevsForExploding) > 0
 	} else {
 		prevs = newPrevsForRegular
 		// If we have only sent ephemeralMessages and are now sending a regular
 		// message, we may have an empty list for newPrevsForRegular. In this
 		// case we allow the `Prev` to be empty, so we don't want to abort in
 		// the check on numPrev below.
-		numPrev = len(newPrevsForRegular)
-		if numPrev == 0 {
-			numPrev = len(newPrevsForExploding)
-		}
+		hasPrev = len(newPrevsForRegular) > 0 || len(newPrevsForExploding) > 0
 	}
 
-	if numPrev == 0 {
+	if !hasPrev {
 		return chat1.MessagePlaintext{}, fmt.Errorf("Could not find previous messages for prev pointers (of %v)", len(res.Messages))
 	}
 

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -26,10 +26,10 @@ type BlockingSender struct {
 	globals.Contextified
 	utils.DebugLabeler
 
-	boxer          *Boxer
-	store          *attachments.Store
-	getRi          func() chat1.RemoteInterface
-	prevPagination *chat1.Pagination
+	boxer             *Boxer
+	store             *attachments.Store
+	getRi             func() chat1.RemoteInterface
+	prevPtrPagination *chat1.Pagination
 }
 
 var _ types.Sender = (*BlockingSender)(nil)
@@ -37,17 +37,17 @@ var _ types.Sender = (*BlockingSender)(nil)
 func NewBlockingSender(g *globals.Context, boxer *Boxer, store *attachments.Store,
 	getRi func() chat1.RemoteInterface) *BlockingSender {
 	return &BlockingSender{
-		Contextified:   globals.NewContextified(g),
-		DebugLabeler:   utils.NewDebugLabeler(g.GetLog(), "BlockingSender", false),
-		getRi:          getRi,
-		boxer:          boxer,
-		store:          store,
-		prevPagination: &chat1.Pagination{Num: 50},
+		Contextified:      globals.NewContextified(g),
+		DebugLabeler:      utils.NewDebugLabeler(g.GetLog(), "BlockingSender", false),
+		getRi:             getRi,
+		boxer:             boxer,
+		store:             store,
+		prevPtrPagination: &chat1.Pagination{Num: 50},
 	}
 }
 
 func (s *BlockingSender) setPrevPagination(p *chat1.Pagination) {
-	s.prevPagination = p
+	s.prevPtrPagination = p
 }
 
 func (s *BlockingSender) addSenderToMessage(msg chat1.MessagePlaintext) (chat1.MessagePlaintext, error) {
@@ -95,7 +95,7 @@ func (s *BlockingSender) addPrevPointersAndCheckConvID(ctx context.Context, msg 
 		&chat1.GetThreadQuery{
 			DisableResolveSupersedes: true,
 		},
-		s.prevPagination)
+		s.prevPtrPagination)
 	if err != nil {
 		return chat1.MessagePlaintext{}, err
 	}

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -185,6 +185,9 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	boxer.SetClock(world.Fc)
 	getRI := func() chat1.RemoteInterface { return ri }
 	baseSender := NewBlockingSender(g, boxer, nil, getRI)
+	// Force a small page size here to test prev pointer calculations for
+	// exploding and non exploding messages
+	baseSender.setPrevPagination(&chat1.Pagination{Num: 2})
 	sender := NewNonblockingSender(g, baseSender)
 	listener := chatListener{
 		incoming:       make(chan int, 100),
@@ -959,17 +962,48 @@ func TestKBFSCryptKeysBit(t *testing.T) {
 }
 
 func TestPrevPointerAddition(t *testing.T) {
-	ctx, world, ri, _, blockingSender, _ := setupTest(t, 1)
-	defer world.Cleanup()
+	mt := chat1.ConversationMembersType_TEAM
+	runWithEphemeral(t, mt, func(ephemeralLifetime *gregor1.DurationSec) {
+		ctx, world, ri, _, blockingSender, _ := setupTest(t, 1)
+		defer world.Cleanup()
 
-	u := world.GetUsers()[0]
-	uid := u.User.GetUID().ToBytes()
-	tc := userTc(t, world, u)
-	conv := newBlankConv(ctx, t, tc, uid, ri, blockingSender, u.Username)
+		var ephemeralMetadata *chat1.MsgEphemeralMetadata
+		if ephemeralLifetime != nil {
+			ephemeralMetadata = &chat1.MsgEphemeralMetadata{
+				Lifetime: *ephemeralLifetime,
+			}
+		}
+		u := world.GetUsers()[0]
+		uid := u.User.GetUID().ToBytes()
+		tc := userTc(t, world, u)
+		conv := newBlankConv(ctx, t, tc, uid, ri, blockingSender, u.Username)
 
-	// Send a bunch of messages on this convo
-	for i := 0; i < 10; i++ {
-		_, _, err := blockingSender.Send(ctx, conv.GetConvID(), chat1.MessagePlaintext{
+		// Send a bunch of messages on this convo
+		for i := 0; i < 10; i++ {
+			_, _, err := blockingSender.Send(ctx, conv.GetConvID(), chat1.MessagePlaintext{
+				ClientHeader: chat1.MessageClientHeader{
+					Conv:              conv.Metadata.IdTriple,
+					Sender:            uid,
+					TlfName:           u.Username,
+					MessageType:       chat1.MessageType_TEXT,
+					EphemeralMetadata: ephemeralMetadata,
+				},
+				MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
+			}, 0, nil)
+			require.NoError(t, err)
+		}
+
+		// Nuke the body cache
+		require.NoError(t, storage.New(tc.Context(), tc.ChatG.ConvSource).MaybeNuke(context.TODO(), true, nil, conv.GetConvID(), uid))
+
+		// Fetch a subset into the cache
+		_, err := tc.ChatG.ConvSource.Pull(ctx, conv.GetConvID(), uid, nil, &chat1.Pagination{
+			Num: 2,
+		})
+		require.NoError(t, err)
+
+		// Prepare a regular message and make sure it gets prev pointers
+		boxed, pendingAssetDeletes, _, _, _, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:        conv.Metadata.IdTriple,
 				Sender:      uid,
@@ -977,32 +1011,17 @@ func TestPrevPointerAddition(t *testing.T) {
 				MessageType: chat1.MessageType_TEXT,
 			},
 			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
-		}, 0, nil)
+		}, mt, &conv)
 		require.NoError(t, err)
-	}
-
-	// Nuke the body cache
-	require.NoError(t, storage.New(tc.Context(), tc.ChatG.ConvSource).MaybeNuke(context.TODO(), true, nil, conv.GetConvID(), uid))
-
-	// Fetch a subset into the cache
-	_, err := tc.ChatG.ConvSource.Pull(ctx, conv.GetConvID(), uid, nil, &chat1.Pagination{
-		Num: 2,
+		require.Empty(t, pendingAssetDeletes)
+		if ephemeralLifetime == nil {
+			require.NotEmpty(t, boxed.ClientHeader.Prev, "empty prev pointers")
+		} else {
+			// Since we only sent ephemeral messages previously, we won't have
+			// any prev pointers to regular messages here.
+			require.Empty(t, boxed.ClientHeader.Prev, "empty prev pointers")
+		}
 	})
-	require.NoError(t, err)
-
-	// Prepare a message and make sure it gets prev pointers
-	boxed, pendingAssetDeletes, _, _, _, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
-		ClientHeader: chat1.MessageClientHeader{
-			Conv:        conv.Metadata.IdTriple,
-			Sender:      uid,
-			TlfName:     u.Username,
-			MessageType: chat1.MessageType_TEXT,
-		},
-		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
-	}, chat1.ConversationMembersType_KBFS, &conv)
-	require.NoError(t, err)
-	require.Empty(t, pendingAssetDeletes)
-	require.NotEmpty(t, boxed.ClientHeader.Prev, "empty prev pointers")
 }
 
 // Test a DELETE attempts to delete all associated assets.


### PR DESCRIPTION
Addresses bug where prev pointers were not set properly for ephemeral messages and handles the case when we've only sent ephemeral messages and dont have a regular message to prev against. tests now cover both of these cases.

cc @buoyad  