### PR TITLE
Filter errors on already exploded messages

### DIFF
--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -477,10 +477,17 @@ func FilterExploded(msgs []chat1.MessageUnboxed) (res []chat1.MessageUnboxed) {
 			if mvalid.IsEphemeral() && mvalid.HideExplosion(now) {
 				continue
 			}
+		} else if msg.IsError() {
+			// If we had an error on an expired message, it's irrelevant now
+			// that the message has exploded so we hide it.
+			merr := msg.Error()
+			if merr.IsEphemeral && merr.IsEphemeralExpired {
+				continue
+			}
 		}
 		res = append(res, msg)
 	}
-	return msgs
+	return res
 }
 
 // GetSupersedes must be called with a valid msg

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -237,6 +237,13 @@ func (m MessageUnboxed) IsValid() bool {
 	return false
 }
 
+func (m MessageUnboxed) IsError() bool {
+	if state, err := m.State(); err == nil {
+		return state == MessageUnboxedState_ERROR
+	}
+	return false
+}
+
 // IsValidFull returns whether the message is both:
 // 1. Valid
 // 2. Has a non-deleted body with a type matching the header
@@ -355,6 +362,7 @@ func (m *MsgEphemeralMetadata) String() string {
 	}
 	return fmt.Sprintf("{ Lifetime: %v, Generation: %v, ExplodedBy: %v }", time.Second*time.Duration(m.Lifetime), m.Generation, explodedBy)
 }
+
 func (m MessagePlaintext) IsEphemeral() bool {
 	return m.EphemeralMetadata() != nil
 }


### PR DESCRIPTION
If we do a `db nuke` already exploded messages used to show up with errors about missing keys etc but we filter them now

cc @buoyad 