### PR TITLE
Fix messagesWereDeleted reducer

### DIFF
--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -614,14 +614,6 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
           }
           return arr
         }, upToOrdinals)
-
-        const ordinals = state.messageOrdinals.get(conversationIDKey, I.SortedSet())
-        ordinals.reduce((arr, ordinal) => {
-          if (Types.ordinalToNumber(ordinal) < upToMessageID) {
-            arr.push(ordinal)
-          }
-          return arr
-        }, upToOrdinals)
       }
 
       const allOrdinals = I.Set(


### PR DESCRIPTION
@keybase/react-hackers 

b633984103 (@mmaxim) added support for `upToMessageID` to the `messagesWereDeleted` reducer (this is for "Delete History" and message retention deletions), but it (usually) deletes every message in the thread instead of just the `upTo` messages.  

I don't understand the point of the code section that this PR removes:

1) we already added the ordinals of the messages with IDs less than `upTo` to `upToOrdinals` just above here

2) this code compares ordinal values to `messageID` values, and they aren't comparable types -- ordinal values increase slower than `messageID` values, so the result is that any call to messagesWereDeleted with an `upTo` will find every ordinal value, and delete every message in the thread.

@mmaxim, want to take a look?