### PR TITLE
Move typing notification throttle back to 2s

### DIFF
--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -6,7 +6,7 @@ import {type InputProps} from './types'
 import {throttle} from 'lodash-es'
 
 // Standalone throttled function to ensure we never accidentally recreate it and break the throttling
-const throttled = throttle((f, param) => f(param), 1000)
+const throttled = throttle((f, param) => f(param), 2000)
 
 class Input extends React.Component<InputProps> {
   _lastQuote: number


### PR DESCRIPTION
@mmaxim @chrisnojima 

Mike noticed that the server-side setTyping notification multiplied in March 2018 and asked for an explanation.  I checked that the throttle's still working, and discovered that the chat refactor in 93298a3c39c40 (merged March 8) lowered the throttle from every two seconds to every one second.

We don't have to merge this PR to move it back -- maybe the explanation of what happened is sufficient.  @mmaxim can decide.