### PR TITLE
 dont let Merge wipe out cache, just merge on per conv versions

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -141,7 +141,6 @@ func (b *NonblockingLocalizer) filterInboxRes(ctx context.Context, inbox types.I
 	var res []types.RemoteConversation
 	for _, conv := range inbox.ConvsUnverified {
 		if utils.IsConvEmpty(conv.Conv) {
-			b.Debug(ctx, "filterInboxRes: maxmsgs: %d", len(conv.Conv.MaxMsgSummaries))
 			b.Debug(ctx, "filterInboxRes: skipping because empty: convID: %s", conv.Conv.GetConvID())
 			continue
 		}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -141,6 +141,7 @@ func (b *NonblockingLocalizer) filterInboxRes(ctx context.Context, inbox types.I
 	var res []types.RemoteConversation
 	for _, conv := range inbox.ConvsUnverified {
 		if utils.IsConvEmpty(conv.Conv) {
+			b.Debug(ctx, "filterInboxRes: maxmsgs: %d", len(conv.Conv.MaxMsgSummaries))
 			b.Debug(ctx, "filterInboxRes: skipping because empty: convID: %s", conv.Conv.GetConvID())
 			continue
 		}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3643,9 +3643,10 @@ func TestChatSrvRetentionSweepTeam(t *testing.T) {
 		defer ctc.cleanup()
 		users := ctc.users()
 		ctx := ctc.as(t, users[0]).startCtx
-
+		_ = ctc.as(t, users[1]).startCtx
 		for i, u := range users {
 			t.Logf("user[%v] %v %v", i, u.Username, u.User.GetUID())
+			ctc.world.Tcs[u.Username].ChatG.Syncer.(*Syncer).isConnected = true
 		}
 
 		listener := newServerChatListener()

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -217,7 +217,7 @@ func (i *Inbox) mergeConvs(l []types.RemoteConversation, r []types.RemoteConvers
 	}
 	for _, conv := range r {
 		key := conv.GetConvID().String()
-		if m[key].GetVersion() < conv.GetVersion() {
+		if m[key].GetVersion() <= conv.GetVersion() {
 			res = append(res, conv)
 			delete(m, key)
 		}
@@ -308,10 +308,7 @@ func (i *Inbox) Merge(ctx context.Context, vers chat1.InboxVers, convsIn []chat1
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	i.Debug(ctx, "Merge: vers: %d convs: %d", vers, len(convsIn))
-	if len(convsIn) == 0 {
-		i.Debug(ctx, "Merge: empty list given, bailing")
-		return nil
-	} else if len(convsIn) == 1 {
+	if len(convsIn) == 1 {
 		i.Debug(ctx, "Merge: single conversation: %s", convsIn[0])
 	}
 
@@ -340,7 +337,7 @@ func (i *Inbox) Merge(ctx context.Context, vers chat1.InboxVers, convsIn []chat1
 	if ibox.InboxVersion != 0 {
 		vers = ibox.InboxVersion
 	} else {
-		i.Debug(ctx, "Merge: setting inbox version to: %d", vers)
+		i.Debug(ctx, "Merge: using given version: %d", vers)
 	}
 	i.Debug(ctx, "Merge: merging inbox: vers: %d", vers)
 	data = inboxDiskData{

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -211,15 +211,19 @@ func (i *Inbox) summarizeConvs(convs []types.RemoteConversation) (res []types.Re
 }
 
 func (i *Inbox) mergeConvs(l []types.RemoteConversation, r []types.RemoteConversation) (res []types.RemoteConversation) {
-	m := make(map[string]bool)
+	m := make(map[string]types.RemoteConversation)
 	for _, conv := range l {
-		m[conv.Conv.Metadata.ConversationID.String()] = true
-		res = append(res, conv)
+		m[conv.GetConvID().String()] = conv
 	}
 	for _, conv := range r {
-		if !m[conv.Conv.Metadata.ConversationID.String()] {
+		key := conv.GetConvID().String()
+		if m[key].GetVersion() < conv.GetVersion() {
 			res = append(res, conv)
+			delete(m, key)
 		}
+	}
+	for _, conv := range m {
+		res = append(res, conv)
 	}
 	return res
 }
@@ -293,6 +297,9 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, convs []chat1.Conversati
 	return i.writeDiskInbox(ctx, ibox)
 }
 
+// Merge add/updates conversations into the inbox. If a given conversation is either missing
+// from the inbox, or is of greater version than what is currently stored, we write it down. Otherwise,
+// we ignore it. If the inbox is currently blank, then we write down the given inbox version.
 func (i *Inbox) Merge(ctx context.Context, vers chat1.InboxVers, convsIn []chat1.Conversation,
 	query *chat1.GetInboxQuery, p *chat1.Pagination) (err Error) {
 	locks.Inbox.Lock()
@@ -300,7 +307,13 @@ func (i *Inbox) Merge(ctx context.Context, vers chat1.InboxVers, convsIn []chat1
 	defer i.Trace(ctx, func() error { return err }, "Merge")()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
-	i.Debug(ctx, "Merge: vers: %d", vers)
+	i.Debug(ctx, "Merge: vers: %d convs: %d", vers, len(convsIn))
+	if len(convsIn) == 0 {
+		i.Debug(ctx, "Merge: empty list given, bailing")
+		return nil
+	} else if len(convsIn) == 1 {
+		i.Debug(ctx, "Merge: single conversation: %s", convsIn[0])
+	}
 
 	convs := make([]chat1.Conversation, len(convsIn))
 	copy(convs, convsIn)
@@ -322,24 +335,19 @@ func (i *Inbox) Merge(ctx context.Context, vers chat1.InboxVers, convsIn []chat1
 	qp := inboxDiskQuery{QueryHash: hquery, Pagination: p}
 	var data inboxDiskData
 
-	// Replace the inbox under these conditions
-	if ibox.InboxVersion != vers || err != nil {
-		i.Debug(ctx, "Merge: replacing inbox: ibox.vers: %v vers: %v convs: %d", ibox.InboxVersion, vers,
-			len(convs))
-		data = inboxDiskData{
-			Version:       inboxVersion,
-			InboxVersion:  vers,
-			Conversations: utils.RemoteConvs(convs),
-			Queries:       []inboxDiskQuery{qp},
-		}
+	// Set inbox version if the current inbox is empty. Otherwise, we just use whatever the current
+	// value is.
+	if ibox.InboxVersion != 0 {
+		vers = ibox.InboxVersion
 	} else {
-		i.Debug(ctx, "Merge: merging inbox: version match")
-		data = inboxDiskData{
-			Version:       inboxVersion,
-			InboxVersion:  vers,
-			Conversations: i.mergeConvs(utils.RemoteConvs(convs), ibox.Conversations),
-			Queries:       append(ibox.Queries, qp),
-		}
+		i.Debug(ctx, "Merge: setting inbox version to: %d", vers)
+	}
+	i.Debug(ctx, "Merge: merging inbox: vers: %d", vers)
+	data = inboxDiskData{
+		Version:       inboxVersion,
+		InboxVersion:  vers,
+		Conversations: i.mergeConvs(utils.RemoteConvs(convs), ibox.Conversations),
+		Queries:       append(ibox.Queries, qp),
 	}
 
 	// Make sure that the inbox is in the write order before writing out

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -309,7 +309,7 @@ func (i *Inbox) Merge(ctx context.Context, vers chat1.InboxVers, convsIn []chat1
 
 	i.Debug(ctx, "Merge: vers: %d convs: %d", vers, len(convsIn))
 	if len(convsIn) == 1 {
-		i.Debug(ctx, "Merge: single conversation: %s", convsIn[0])
+		i.Debug(ctx, "Merge: single conversation: %s", convsIn[0].GetConvID())
 	}
 
 	convs := make([]chat1.Conversation, len(convsIn))

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -112,7 +112,8 @@ func TestInboxBasic(t *testing.T) {
 		Num: numConvs / 2,
 	})
 	require.NoError(t, err)
-	require.Equal(t, chat1.InboxVers(2), vers, "version mismatch")
+	// Merge in of 2 doesn't do anything, we still think we are at version 1 of the whole box
+	require.Equal(t, chat1.InboxVers(1), vers, "version mismatch")
 	convListCompare(t, convs[:numConvs/2], res, "half")
 }
 

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -74,6 +74,10 @@ func (rc RemoteConversation) GetConvID() chat1.ConversationID {
 	return rc.Conv.GetConvID()
 }
 
+func (rc RemoteConversation) GetVersion() chat1.ConversationVers {
+	return rc.Conv.Metadata.Version
+}
+
 type Inbox struct {
 	Version         chat1.InboxVers
 	ConvsUnverified []RemoteConversation

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -579,6 +579,7 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 	for _, m := range conv.MaxMsgs {
 		conv.MaxMsgSummaries = append(conv.MaxMsgSummaries, m.Summary())
 	}
+	conv.Metadata.Version++
 	sort.Sort(convByNewlyUpdated{mock: m})
 	res.MsgHeader = *inserted.ServerHeader
 	res.RateLimit = &chat1.RateLimit{}
@@ -643,6 +644,7 @@ func (m *ChatRemoteMock) NewConversationRemote2(ctx context.Context, arg chat1.N
 			ConversationID: res.ConvID,
 			Visibility:     vis,
 			MembersType:    arg.MembersType,
+			Version:        1,
 		},
 		MaxMsgs:         []chat1.MessageBoxed{first},
 		MaxMsgSummaries: []chat1.MessageSummary{first.Summary()},


### PR DESCRIPTION
We could get into the following problem situation:
1.) Some part of the service does a request for some conversation `A`. 
2.) We miss the local inbox cache (maybe because it is a hidden convo, or otherwise not included in the query used to populate the on disk inbox).
3.) We initiate a fetch from the server for the missing conversation.
4.) Before our remote call is realized, a bunch of stuff happens to the user's inbox, increasing the inbox version number.
5.) The remote call returns with an inbox version number that is greater than the stored inbox number (the client has not yet processed the Gregor messages about these changes). 
6.) We detect this in `Merge` and "replace" the inbox with what the server gave back (maybe for just 1 conversation) because we think there is a problem (since the inbox disk version is a mismatch from the server response). 

The key problem here is that explicitly fetching the inbox from the server doesn't really have any synchronization with the inbox version number on the server, and so this "replace" code could effectively clear the inbox. Note, this is much more likely with "active" inboxes; that is, inboxes where the version number is always changing (since we need to "lose" the race on the response from the get inbox remote call and processing Gregor messages that would sync up our inbox version). 

This patch solves this problem by never setting the inbox version in `Merge`, unless the inbox cache is just blank. We take advantage of the per conversation version numbers to know that we aren't blowing away any stored conversation with old data. This is the last place in the code where it is possible to clear the inbox (outside of an on-disk version schema change).

cc @maxtaco @malgorithms I hope this solves all your troubles. 
