### PR TITLE
Fix android crash

### DIFF
--- a/shared/chat/conversation/messages/wrapper/height-retainer/index.native.js
+++ b/shared/chat/conversation/messages/wrapper/height-retainer/index.native.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {Box, NativeImage} from '../../../../../common-adapters/mobile.native'
 import {collapseStyles} from '../../../../../styles'
+import {isAndroid} from '../../../../../constants/platform'
 import type {Props} from '.'
 
 const explodedUllustrationURL = require('../../../../../images/icons/pattern-ashes-mobile-400-80.png')
@@ -31,7 +32,7 @@ class HeightRetainer extends React.Component<Props, State> {
           <NativeImage
             source={explodedUllustrationURL}
             style={{width: '100%', height: '100%'}}
-            resizeMode="repeat"
+            resizeMode={isAndroid ? 'cover' : 'repeat'}
           />
         )}
         {!this.props.retainHeight && this.props.children}


### PR DESCRIPTION
`resizeMode="repeat"` is no good on android, sets it to cover instead. I have a separate TODO to figure out repeating on android. r? @keybase/react-hackers 