### PR TITLE
Try to load trusted conv meta if we find no participants in the mention hud

### DIFF
--- a/shared/chat/conversation/input-area/user-mention-hud/index.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.js
@@ -4,8 +4,10 @@ import {compose, withStateHandlers, lifecycle, withPropsOnChange, withProps} fro
 import {
   Avatar,
   Box,
+  Box2,
   ClickableBox,
   List,
+  ProgressIndicator,
   Text,
   ConnectedUsernames,
   Icon,
@@ -16,6 +18,7 @@ import {isSpecialMention} from '../../../../constants/chat2'
 type Props<D: {key: string, selected: boolean}> = {
   rowRenderer: (i: number, d: D) => React$Element<any>,
   data: Array<D>,
+  loading: boolean,
   style: Object,
   selectedIndex: number,
 }
@@ -66,10 +69,20 @@ const MentionRowRenderer = ({username, fullName, selected, onClick, onHover}: Me
 // We want to render Hud even if there's no data so we can still have lifecycle methods so we can still do things
 // This is important if you type a filter that gives you no results and you press enter for instance
 // $FlowIssue doens't like star now
-const Hud = ({style, data, rowRenderer, selectedIndex}: Props<*>) =>
+const Hud = ({style, data, loading, rowRenderer, selectedIndex}: Props<*>) =>
   data.length ? (
     <Box style={collapseStyles([hudStyle, style])}>
-      <List items={data} renderItem={rowRenderer} selectedIndex={selectedIndex} fixedHeight={40} />
+      {loading ? (
+        <Box2
+          direction="horizontal"
+          fullWidth={true}
+          style={{alignItems: 'center', justifyContent: 'center'}}
+        >
+          <ProgressIndicator style={{width: 40, height: 40}} />
+        </Box2>
+      ) : (
+        <List items={data} renderItem={rowRenderer} selectedIndex={selectedIndex} fixedHeight={40} />
+      )}
     </Box>
   ) : null
 

--- a/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
@@ -29,18 +29,22 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     if (m) {
       participants = m.participants
       _generalChannelConversationIDKey = m.conversationIDKey
+    } else {
+      logger.info(`MentionHUD: no meta found for general channel in team ${meta.teamname}`)
     }
   }
 
+  const users = participants
+    .map(p => ({fullName: stateProps._infoMap.getIn([p, 'fullname'], ''), username: p}))
+    .toArray()
   return {
     ...ownProps,
     _generalChannelConversationIDKey,
     _loadParticipants: dispatchProps._loadParticipants,
     conversationIDKey: stateProps.conversationIDKey,
     filter: stateProps._filter.toLowerCase(),
-    users: participants
-      .map(p => ({fullName: stateProps._infoMap.getIn([p, 'fullname'], ''), username: p}))
-      .toArray(),
+    loading: users.length === 0,
+    users,
   }
 }
 

--- a/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
@@ -1,7 +1,9 @@
 // @flow
 import {MentionHud} from '.'
-import {compose, connect, type TypedState, setDisplayName} from '../../../../util/container'
+import * as Chat2Gen from '../../../../actions/chat2-gen'
+import {compose, connect, lifecycle, type TypedState, setDisplayName} from '../../../../util/container'
 import * as I from 'immutable'
+import logger from '../../../../logger'
 
 const mapStateToProps = (state: TypedState, {filter, conversationIDKey}) => {
   return {
@@ -12,19 +14,28 @@ const mapStateToProps = (state: TypedState, {filter, conversationIDKey}) => {
   }
 }
 
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  _loadParticipants: conversationIDKey =>
+    dispatch(Chat2Gen.createMetaRequestTrusted({conversationIDKeys: [conversationIDKey], force: true})),
+})
+
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const meta = stateProps._metaMap.get(stateProps.conversationIDKey)
   let participants = meta ? meta.participants : I.Set()
+  let _generalChannelConversationIDKey = ''
   // Get the general channel participants instead
   if (meta && meta.teamType === 'big' && meta.channelname !== 'general') {
     const m = stateProps._metaMap.find(m => m.teamname === meta.teamname && m.channelname === 'general')
     if (m) {
       participants = m.participants
+      _generalChannelConversationIDKey = m.conversationIDKey
     }
   }
 
   return {
     ...ownProps,
+    _generalChannelConversationIDKey,
+    _loadParticipants: dispatchProps._loadParticipants,
     conversationIDKey: stateProps.conversationIDKey,
     filter: stateProps._filter.toLowerCase(),
     users: participants
@@ -33,6 +44,23 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   }
 }
 
-export default compose(connect(mapStateToProps, () => ({}), mergeProps), setDisplayName('UserMentionHud'))(
-  MentionHud
-)
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  setDisplayName('UserMentionHud'),
+  lifecycle({
+    componentDidMount() {
+      if (this.props.users.length === 0) {
+        // it can never be 0, we don't have a list of participants cached for the general channel or this channel
+        if (!this.props._generalChannelConversationIDKey) {
+          logger.warn(
+            'Mention HUD: no meta found for general channel, loading participants of current channel.'
+          )
+          this.props._loadParticipants(this.props.conversationIDKey)
+          return
+        }
+        logger.info('Mention HUD: no participants in general channel meta, requesting trusted inbox item.')
+        this.props._loadParticipants(this.props._generalChannelConversationIDKey)
+      }
+    },
+  })
+)(MentionHud)


### PR DESCRIPTION
Kind of already done. WIP because I may switch it to detect this case in `selectConversation` and request the trusted meta there. any thoughts @keybase/react-hackers?