### PR TITLE
Don't use closeOnSelect here.

### DIFF
--- a/shared/profile/user-actions.js
+++ b/shared/profile/user-actions.js
@@ -151,7 +151,6 @@ class _DropdownButton extends React.PureComponent<DropdownProps & FloatingMenuPa
         </Box2>
         <FloatingMenu
           attachTo={this.props.attachmentRef}
-          closeOnSelect={true}
           containerStyle={styles.floatingMenu}
           items={this._menuItems}
           onHidden={this.props.toggleShowingMenu}


### PR DESCRIPTION
This and `toggleShowingMenu` are toggling the `showingMenu` state twice, leaving the user actions menu open.