### PR TITLE
deprecate LoginState, and eliminate almost all non-libkb callsites

### DIFF
--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -172,11 +172,12 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	if useRemoteMock {
 		ctx = newTestContextWithTlfMock(tc, tlf)
 	} else {
-		var sessionToken string
 		ctx = newTestContext(tc)
-		tc.G.LoginState().LocalSession(func(s *libkb.Session) {
-			sessionToken = s.GetToken()
-		}, "test session")
+		nist, err := tc.G.ActiveDevice.NIST(context.TODO())
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		sessionToken := nist.Token().String()
 		gh := newGregorTestConnection(tc.Context(), uid, sessionToken)
 		require.NoError(t, gh.Connect(ctx))
 		ri = gh.GetClient()

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -300,11 +300,12 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 		ri = mockRemote
 		ctx = newTestContextWithTlfMock(tc, tlf)
 	} else {
-		var sessionToken string
 		ctx = newTestContext(tc)
-		tc.G.LoginState().LocalSession(func(s *libkb.Session) {
-			sessionToken = s.GetToken()
-		}, "test session")
+		nist, err := tc.G.ActiveDevice.NIST(context.TODO())
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		sessionToken := nist.Token().String()
 		gh := newGregorTestConnection(tc.Context(), uid, sessionToken)
 		require.NoError(t, gh.Connect(ctx))
 		ri = gh.GetClient()

--- a/go/engine/bug_3964_repairman_test.go
+++ b/go/engine/bug_3964_repairman_test.go
@@ -266,7 +266,7 @@ func checkLKSWorked(t *testing.T, tctx libkb.TestContext, u *FakeUser) {
 	uis := libkb.UIs{
 		SecretUI: u.NewSecretUI(),
 	}
-	me, err := libkb.LoadMe(libkb.LoadUserArg{Contextified: libkb.NewContextified(tctx.G)})
+	me, err := libkb.LoadMe(libkb.NewLoadUserArgWithMetaContext(NewMetaContextForTest(tctx)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -459,7 +459,7 @@ func fakeSalt() []byte {
 
 func clearCaches(g *libkb.GlobalContext) {
 	g.ActiveDevice.ClearCaches()
-	g.LoginState().Account(func(a *libkb.Account) {
+	g.LoginStateDeprecated().Account(func(a *libkb.Account) {
 		a.ClearStreamCache()
 		a.ClearPaperKeys()
 	}, "account - clear")

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2513,7 +2513,6 @@ func TestResetThenPGPOnlyThenProvision(t *testing.T) {
 	m = m.WithNewProvisionalLoginContext()
 	err := libkb.PassphraseLoginNoPrompt(m, u.Username, u.Passphrase)
 	require.NoError(t, err, "passphrase login no prompt worked")
-	m = m.CommitProvisionalLogin()
 
 	// Generate a new test PGP key for the user, and specify the PushSecret
 	// flag so that their triplesec'ed key is pushed to the server.
@@ -2532,6 +2531,7 @@ func TestResetThenPGPOnlyThenProvision(t *testing.T) {
 		tc.T.Fatal(err)
 	}
 
+	m = m.CommitProvisionalLogin()
 	Logout(tc)
 
 	// Now finally try a login

--- a/go/engine/pgp_decrypt_test.go
+++ b/go/engine/pgp_decrypt_test.go
@@ -572,9 +572,7 @@ func TestPGPDecryptWithSyncedKey(t *testing.T) {
 	// No need to get a passphrase, since we just logged in.
 	require.False(t, decryptCalledPassphrase, "passphrase get wasn't called")
 
-	// Simulate a service restart
-	m.ActiveDevice().ClearCaches()
-	m.G().LoginState().Account(func(a *libkb.Account) { a.ClearStreamCache() }, "clear")
+	clearCaches(m.G())
 
 	decryptCalledPassphrase = decryptIt()
 	require.True(t, decryptCalledPassphrase, "passphrase get was called")

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -67,11 +67,11 @@ func NewPGPKeyImportEngineFromBytes(g *libkb.GlobalContext, key []byte, pushPriv
 	return
 }
 
-func (e *PGPKeyImportEngine) loadMe() (err error) {
+func (e *PGPKeyImportEngine) loadMe(m libkb.MetaContext) (err error) {
 	if e.me = e.arg.Me; e.me != nil {
 		return
 	}
-	e.me, err = libkb.LoadMe(libkb.NewLoadUserPubOptionalArg(e.G()))
+	e.me, err = libkb.LoadMe(libkb.NewLoadUserArgWithMetaContext(m).WithPublicKeyOptional())
 	return err
 }
 
@@ -155,7 +155,7 @@ func (e *PGPKeyImportEngine) Run(m libkb.MetaContext) (err error) {
 		return err
 	}
 
-	if err = e.loadMe(); err != nil {
+	if err = e.loadMe(m); err != nil {
 		return err
 	}
 

--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -416,7 +416,7 @@ func (e *ScanProofsEngine) CheckOne(m libkb.MetaContext, rec map[string]string, 
 
 // GetSigHint gets the SigHint. This can return (nil, nil) if nothing goes wrong but there is no hint.
 func (e *ScanProofsEngine) GetSigHint(m libkb.MetaContext, uid keybase1.UID, sigid keybase1.SigID) (*libkb.SigHint, error) {
-	sighints, err := libkb.LoadAndRefreshSigHints(m.Ctx(), uid, m.G())
+	sighints, err := libkb.LoadAndRefreshSigHints(m, uid)
 	if err != nil {
 		return nil, err
 	}

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -161,7 +161,7 @@ func TestLoadDeviceKeyRevoked(t *testing.T) {
 	assertNumDevicesAndKeys(tc, fu, 1, 2)
 
 	t.Logf("load revoked device")
-	upk, deviceKey, revoked, err := tc.G.GetUPAKLoader().LoadDeviceKey(nil, user.GetUID(), thisDevice.ID)
+	upk, deviceKey, revoked, err := tc.G.GetUPAKLoader().LoadDeviceKey(context.TODO(), user.GetUID(), thisDevice.ID)
 	require.NoError(t, err)
 	require.Equal(t, user.GetNormalizedName().String(), upk.Base.Username, "usernames must match")
 	require.Equal(t, thisDevice.ID, deviceKey.DeviceID, "deviceID must match")

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -58,7 +58,7 @@ func TestLoadDeviceKeyNew(t *testing.T) {
 	t.Logf("using device1:%+v", device1.ID)
 
 	t.Logf("load existing device key")
-	upk, deviceKey, revoked, err := tc.G.GetUPAKLoader().LoadDeviceKey(nil, user.GetUID(), device1.ID)
+	upk, deviceKey, revoked, err := tc.G.GetUPAKLoader().LoadDeviceKey(context.TODO(), user.GetUID(), device1.ID)
 	require.NoError(t, err)
 	require.Equal(t, user.GetNormalizedName().String(), upk.Base.Username, "usernames must match")
 	require.Equal(t, device1.ID, deviceKey.DeviceID, "deviceID must match")
@@ -115,7 +115,7 @@ func TestLoadDeviceKeyNew(t *testing.T) {
 	t.Logf("using device2:%+v", device2.ID)
 
 	t.Logf("load brand new device (while old is cached)")
-	upk, deviceKey, revoked, err = tc.G.GetUPAKLoader().LoadDeviceKey(nil, user.GetUID(), device2.ID)
+	upk, deviceKey, revoked, err = tc.G.GetUPAKLoader().LoadDeviceKey(context.TODO(), user.GetUID(), device2.ID)
 	require.NoError(t, err)
 	require.Equal(t, user.GetNormalizedName().String(), upk.Base.Username, "usernames must match")
 	require.Equal(t, device2.ID, deviceKey.DeviceID, "deviceID must match")

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -146,11 +146,7 @@ func Logout(tc libkb.TestContext) {
 }
 
 func AssertProvisioned(tc libkb.TestContext) error {
-	prov, err := tc.G.LoginState().LoggedInProvisioned(context.TODO())
-	if err != nil {
-		return err
-	}
-	if !prov {
+	if !tc.G.ActiveDevice.Valid() {
 		return libkb.LoginRequiredError{}
 	}
 	return nil

--- a/go/libkb/bootstrap_active_device.go
+++ b/go/libkb/bootstrap_active_device.go
@@ -152,7 +152,7 @@ func LoadProvisionalActiveDevice(m MetaContext, uid keybase1.UID, deviceID keyba
 	return ret, nil
 }
 
-// BootstrapActiveDeviceWithLoginConext will setup an ActiveDevice with a NIST Factory
+// BootstrapActiveDeviceWithMetaContext will setup an ActiveDevice with a NIST Factory
 // for the caller. The m.loginContext passed through isn't really needed
 // for anything aside from assertions, but as we phase out LoginState, we'll
 // leave it here so that assertions in LoginState can still pass.
@@ -161,7 +161,7 @@ func BootstrapActiveDeviceWithMetaContext(m MetaContext) (ok bool, uid keybase1.
 		return BootstrapActiveDeviceFromConfig(m.WithLoginContext(lctx), true)
 	}
 	if lctx := m.LoginContext(); lctx == nil {
-		aerr := m.G().LoginState().Account(func(lctx *Account) {
+		aerr := m.G().LoginStateDeprecated().Account(func(lctx *Account) {
 			uid, err = run(lctx)
 		}, "BootstrapActiveDevice")
 		if err == nil && aerr != nil {

--- a/go/libkb/full_self_cacher.go
+++ b/go/libkb/full_self_cacher.go
@@ -119,7 +119,7 @@ func (m *CachedFullSelf) maybeClearCache(ctx context.Context, arg *LoadUserArg) 
 	var sigHints *SigHints
 	var leaf *MerkleUserLeaf
 
-	sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(ctx, m.G(), arg.uid, true)
+	sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(NewMetaContext(ctx, m.G()), arg.uid, true)
 	if err != nil {
 		m.me = nil
 		return err
@@ -151,10 +151,7 @@ func (m *CachedFullSelf) maybeClearCache(ctx context.Context, arg *LoadUserArg) 
 // WithUser supports other so that code doesn't need to change if we're doing the
 // operation for the user or someone else.
 func (m *CachedFullSelf) WithUser(arg LoadUserArg, f func(u *User) error) (err error) {
-	ctx := arg.netContext
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx := arg.GetNetContext()
 	ctx = WithLogTag(ctx, "SELF")
 	arg = arg.WithNetContext(ctx)
 

--- a/go/libkb/generickey.go
+++ b/go/libkb/generickey.go
@@ -80,7 +80,7 @@ func skbPushAndSave(m MetaContext, skb *SKB) (err error) {
 		}
 		return kr.PushAndSave(skb)
 	}
-	kerr := m.G().LoginState().Keyring(func(ring *SKBKeyringFile) {
+	kerr := m.G().LoginStateDeprecated().Keyring(func(ring *SKBKeyringFile) {
 		err = ring.PushAndSave(skb)
 	}, "PushAndSave")
 	if kerr != nil {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -271,7 +271,7 @@ func (g *GlobalContext) createLoginState() {
 	g.createLoginStateLocked()
 }
 
-func (g *GlobalContext) LoginState() *LoginState {
+func (g *GlobalContext) LoginStateDeprecated() *LoginState {
 	g.loginStateMu.RLock()
 	defer g.loginStateMu.RUnlock()
 
@@ -763,7 +763,7 @@ func (g *GlobalContext) GetMyUID() keybase1.UID {
 		return uid
 	}
 
-	g.LoginState().LocalSession(func(s *Session) {
+	g.LoginStateDeprecated().LocalSession(func(s *Session) {
 		uid = s.GetUID()
 	}, "G - GetMyUID - GetUID")
 	if uid.Exists() {
@@ -1227,34 +1227,6 @@ func (g *GlobalContext) ReplaceSecretStore() error {
 	g.Log.Debug("ReplaceSecretStore success")
 
 	return nil
-}
-
-// AssertTemporarySession asserts that the user has an old-fashioned
-// session token. Should only be necessary on login/provisioning flow.
-func (g *GlobalContext) AssertTemporarySession(lctx LoginContext) error {
-
-	run := func(lctx LoginContext) error {
-		sess := lctx.LocalSession()
-		if sess == nil {
-			return LoginRequiredError{"no session object loaded"}
-		}
-		if !sess.IsValid() {
-			return LoginRequiredError{"session isn't valid"}
-		}
-		return nil
-	}
-
-	if lctx != nil {
-		return run(lctx)
-	}
-	var gerr error
-	aerr := g.LoginState().Account(func(a *Account) {
-		gerr = run(a)
-	}, "AssertTemporarySession")
-	if aerr != nil {
-		return aerr
-	}
-	return gerr
 }
 
 func (g *GlobalContext) IsOneshot(ctx context.Context) (bool, error) {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -1060,7 +1060,7 @@ func (g *GlobalContext) SetTeamEKBoxStorage(s TeamEKBoxStorage) {
 }
 
 func (g *GlobalContext) LoadUserByUID(uid keybase1.UID) (*User, error) {
-	arg := NewLoadUserByUIDArg(nil, g, uid).WithPublicKeyOptional()
+	arg := NewLoadUserArgWithMetaContext(NewMetaContextBackground(g)).WithUID(uid).WithPublicKeyOptional()
 	return LoadUser(arg)
 }
 

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -210,7 +210,7 @@ func (k *Keyrings) GetSecretKeyLocked(m MetaContext, ska SecretKeyArg) (ret *SKB
 			return ret, err
 		}
 	} else {
-		aerr := m.G().LoginState().Account(func(a *Account) {
+		aerr := m.G().LoginStateDeprecated().Account(func(a *Account) {
 			ret, err = a.LockedLocalSecretKey(ska)
 		}, "LockedLocalSecretKey")
 		if err != nil {
@@ -277,7 +277,7 @@ func (k *Keyrings) setCachedSecretKey(m MetaContext, ska SecretKeyArg, key Gener
 	if lctx := m.LoginContext(); lctx != nil {
 		setErr = lctx.SetCachedSecretKey(ska, key, nil)
 	} else {
-		aerr := m.G().LoginState().Account(func(a *Account) {
+		aerr := m.G().LoginStateDeprecated().Account(func(a *Account) {
 			setErr = a.SetCachedSecretKey(ska, key, nil)
 		}, "GetSecretKeyWithPrompt - SetCachedSecretKey")
 		if aerr != nil {
@@ -393,7 +393,7 @@ func (k *Keyrings) GetSecretKeyWithPassphrase(m MetaContext, me *User, passphras
 		tsec, _ = lctx.PassphraseStreamCache().TriplesecAndGeneration()
 		pps = lctx.PassphraseStreamCache().PassphraseStream()
 	} else {
-		m.G().LoginState().PassphraseStreamCache(func(sc *PassphraseStreamCache) {
+		m.G().LoginStateDeprecated().PassphraseStreamCache(func(sc *PassphraseStreamCache) {
 			tsec, _ = sc.TriplesecAndGeneration()
 			pps = sc.PassphraseStream()
 		}, "StreamCache - tsec, pps")

--- a/go/libkb/lksec.go
+++ b/go/libkb/lksec.go
@@ -447,7 +447,7 @@ func (s *LKSec) loadSecretSyncer(m MetaContext) (ss *SecretSyncer, err error) {
 		}
 		return lctx.SecretSyncer(), nil
 	}
-	aerr := m.G().LoginState().Account(func(a *Account) {
+	aerr := m.G().LoginStateDeprecated().Account(func(a *Account) {
 		if err = RunSyncer(m, a.SecretSyncer(), s.uid, a.LoggedIn(), a.LocalSession()); err != nil {
 			return
 		}
@@ -482,7 +482,7 @@ func (s *LKSec) apiServerHalf(m MetaContext, devid keybase1.DeviceID) (dkm Devic
 // an LKS that works for encryption.
 func NewLKSecForEncrypt(m MetaContext, ui SecretUI, uid keybase1.UID) (ret *LKSec, err error) {
 	var pps *PassphraseStream
-	if pps, err = m.G().LoginState().GetPassphraseStream(m, ui); err != nil {
+	if pps, err = m.G().LoginStateDeprecated().GetPassphraseStream(m, ui); err != nil {
 		return
 	}
 	ret = NewLKSec(pps, uid, m.G())

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -123,6 +123,11 @@ func (arg LoadUserArg) WithSelf(self bool) LoadUserArg {
 	return arg
 }
 
+func (arg LoadUserArg) EnsureCtxAndLogTag() LoadUserArg {
+	arg.m = arg.m.EnsureCtx().WithLogTag("LU")
+	return arg
+}
+
 func (arg LoadUserArg) WithCachedOnly() LoadUserArg {
 	arg.cachedOnly = true
 	return arg

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -18,7 +18,6 @@ type UIDer interface {
 }
 
 type LoadUserArg struct {
-	Contextified
 	uid                      keybase1.UID
 	name                     string // Can also be an assertion like foo@twitter
 	publicKeyOptional        bool
@@ -45,9 +44,7 @@ type LoadUserArg struct {
 	merkleLeaf *MerkleUserLeaf
 	sigHints   *SigHints
 
-	// NetContext is the context to build on top of.  We'll make a new
-	// Debug Tag for this LoadUser Operation.
-	netContext context.Context
+	m MetaContext
 }
 
 func (arg LoadUserArg) String() string {
@@ -56,22 +53,24 @@ func (arg LoadUserArg) String() string {
 		arg.forcePoll, arg.staleOK, arg.abortIfSigchainUnchanged, arg.cachedOnly)
 }
 
+func (arg LoadUserArg) MetaContext() MetaContext {
+	return arg.m
+}
+
 func NewLoadUserArg(g *GlobalContext) LoadUserArg {
-	return LoadUserArg{Contextified: NewContextified(g)}
+	return LoadUserArg{m: NewMetaContextBackground(g)}
 }
 
 func NewLoadUserArgWithMetaContext(m MetaContext) LoadUserArg {
 	return LoadUserArg{
-		Contextified: NewContextified(m.G()),
-		netContext:   m.Ctx(),
-		uider:        m.LoginContext(),
+		m:     m,
+		uider: m.LoginContext(),
 	}
 }
 
 func NewLoadUserArgWithContext(ctx context.Context, g *GlobalContext) LoadUserArg {
 	return LoadUserArg{
-		Contextified: NewContextified(g),
-		netContext:   ctx,
+		m: NewMetaContext(ctx, g),
 	}
 }
 
@@ -101,9 +100,8 @@ func NewLoadUserByNameArg(g *GlobalContext, name string) LoadUserArg {
 }
 
 func NewLoadUserByUIDArg(ctx context.Context, g *GlobalContext, uid keybase1.UID) LoadUserArg {
-	arg := NewLoadUserArg(g)
+	arg := NewLoadUserArgWithMetaContext(NewMetaContext(ctx, g))
 	arg.uid = uid
-	arg.netContext = ctx
 	return arg
 }
 
@@ -141,7 +139,7 @@ func (arg LoadUserArg) WithName(n string) LoadUserArg {
 }
 
 func (arg LoadUserArg) WithNetContext(ctx context.Context) LoadUserArg {
-	arg.netContext = ctx
+	arg.m = arg.m.WithCtx(ctx)
 	return arg
 }
 
@@ -166,10 +164,7 @@ func (arg LoadUserArg) WithStaleOK(b bool) LoadUserArg {
 }
 
 func (arg LoadUserArg) GetNetContext() context.Context {
-	if arg.netContext != nil {
-		return arg.netContext
-	}
-	if ctx := arg.G().NetContext; ctx != nil {
+	if ctx := arg.m.Ctx(); ctx != nil {
 		return ctx
 	}
 	return context.Background()
@@ -190,13 +185,6 @@ func (arg LoadUserArg) WithForceReload() LoadUserArg {
 	return arg
 }
 
-func (arg *LoadUserArg) WithLogTag() context.Context {
-	ctx := WithLogTag(arg.GetNetContext(), "LU")
-	arg.netContext = ctx
-	arg.SetGlobalContext(arg.G().CloneWithNetContextAndNewLogger(ctx))
-	return ctx
-}
-
 func (arg *LoadUserArg) checkUIDName() error {
 	if arg.uid.Exists() {
 		return nil
@@ -214,8 +202,8 @@ func (arg *LoadUserArg) checkUIDName() error {
 		return nil
 	}
 
-	if arg.uid = myUID(arg.G(), arg.uider); arg.uid.IsNil() {
-		arg.name = arg.G().Env.GetUsername().String()
+	if arg.uid = myUID(arg.m.G(), arg.uider); arg.uid.IsNil() {
+		arg.name = arg.m.G().Env.GetUsername().String()
 		if len(arg.name) == 0 {
 			return SelfNotFoundError{msg: "could not find UID or username for self"}
 		}
@@ -234,7 +222,7 @@ func (arg *LoadUserArg) resolveUID() (ResolveResult, error) {
 		return rres, fmt.Errorf("resolveUID: no uid or name")
 	}
 
-	if rres = arg.G().Resolver.ResolveWithBody(arg.name).FailOnDeleted(); rres.err != nil {
+	if rres = arg.m.G().Resolver.ResolveWithBody(arg.name).FailOnDeleted(); rres.err != nil {
 		return rres, rres.err
 	}
 
@@ -252,7 +240,7 @@ func (arg *LoadUserArg) checkSelf() {
 		return
 	}
 
-	myuid := myUID(arg.G(), arg.uider)
+	myuid := myUID(arg.m.G(), arg.uider)
 	if myuid.Exists() && arg.uid.Exists() && myuid.Equal(arg.uid) {
 		arg.self = true
 	}
@@ -272,21 +260,23 @@ func LoadMeByMetaContextAndUID(m MetaContext, uid keybase1.UID) (*User, error) {
 
 func LoadUser(arg LoadUserArg) (ret *User, err error) {
 
-	ctx := arg.WithLogTag()
-	defer arg.G().CTraceTimed(ctx, fmt.Sprintf("LoadUser(%s)", arg), func() error { return err })()
+	m := arg.MetaContext()
+
+	m = m.WithLogTag("LU")
+	defer m.CTraceTimed(fmt.Sprintf("LoadUser(%s)", arg), func() error { return err })()
 
 	var refresh bool
 
-	if arg.G().VDL.DumpSiteLoadUser() {
+	if m.G().VDL.DumpSiteLoadUser() {
 		debug.PrintStack()
 	}
 
 	// Whatever the reply is, pass along our desired global context
 	defer func() {
 		if ret != nil {
-			ret.SetGlobalContext(arg.G())
+			ret.SetGlobalContext(m.G())
 			if refresh {
-				arg.G().NotifyRouter.HandleUserChanged(ret.GetUID())
+				m.G().NotifyRouter.HandleUserChanged(ret.GetUID())
 			}
 		}
 	}()
@@ -296,7 +286,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 		return nil, err
 	}
 
-	arg.G().Log.CDebugf(ctx, "+ LoadUser(uid=%v, name=%v)", arg.uid, arg.name)
+	m.CDebugf("LoadUser(uid=%v, name=%v)", arg.uid, arg.name)
 
 	// resolve the uid from the name, if necessary
 	rres, err := arg.resolveUID()
@@ -307,7 +297,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	// check to see if this is a self load
 	arg.checkSelf()
 
-	arg.G().Log.CDebugf(ctx, "| resolved to %s", arg.uid)
+	m.CDebugf("| resolved to %s", arg.uid)
 
 	// We can get the user object's body from either the resolution result or
 	// if it was plumbed through as a parameter.
@@ -320,14 +310,14 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	// They might have already been loaded in.
 	var sigHints *SigHints
 	if sigHints = arg.sigHints; sigHints == nil {
-		sigHints, err = LoadSigHints(ctx, arg.uid, arg.G())
+		sigHints, err = LoadSigHints(m, arg.uid)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// load user from local, remote
-	ret, refresh, err = loadUser(ctx, arg.G(), arg.uid, resolveBody, sigHints, arg.forceReload, arg.merkleLeaf)
+	ret, refresh, err = loadUser(m, arg.uid, resolveBody, sigHints, arg.forceReload, arg.merkleLeaf)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +331,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 		return ret, err
 	}
 
-	if err = ret.LoadSigChains(ctx, &ret.leaf, arg.self); err != nil {
+	if err = ret.LoadSigChains(m, &ret.leaf, arg.self); err != nil {
 		return ret, err
 	}
 
@@ -354,8 +344,8 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	}
 
 	// Proactively cache fetches from remote server to local storage
-	if e2 := ret.Store(ctx); e2 != nil {
-		arg.G().Log.CWarningf(ctx, "Problem storing user %s: %s", ret.GetName(), e2)
+	if e2 := ret.Store(m); e2 != nil {
+		m.CWarningf("Problem storing user %s: %s", ret.GetName(), e2)
 	}
 
 	if ret.HasActiveKey() {
@@ -370,7 +360,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 		}
 
 	} else if !arg.publicKeyOptional {
-		arg.G().Log.CDebugf(ctx, "No active key for user: %s", ret.GetUID())
+		m.CDebugf("No active key for user: %s", ret.GetUID())
 
 		var emsg string
 		if arg.self {
@@ -382,15 +372,15 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	return ret, err
 }
 
-func loadUser(ctx context.Context, g *GlobalContext, uid keybase1.UID, resolveBody *jsonw.Wrapper, sigHints *SigHints, force bool, leaf *MerkleUserLeaf) (*User, bool, error) {
-	local, err := LoadUserFromLocalStorage(ctx, g, uid)
+func loadUser(m MetaContext, uid keybase1.UID, resolveBody *jsonw.Wrapper, sigHints *SigHints, force bool, leaf *MerkleUserLeaf) (*User, bool, error) {
+	local, err := LoadUserFromLocalStorage(m, uid)
 	var refresh bool
 	if err != nil {
-		g.Log.CWarningf(ctx, "Failed to load %s from storage: %s", uid, err)
+		m.CWarningf("Failed to load %s from storage: %s", uid, err)
 	}
 
 	if leaf == nil {
-		leaf, err = lookupMerkleLeaf(ctx, g, uid, (local != nil), sigHints)
+		leaf, err = lookupMerkleLeaf(m, uid, (local != nil), sigHints)
 		if err != nil {
 			return nil, refresh, err
 		}
@@ -399,7 +389,7 @@ func loadUser(ctx context.Context, g *GlobalContext, uid keybase1.UID, resolveBo
 	var f1, loadRemote bool
 
 	if local == nil {
-		g.Log.CDebugf(ctx, "| No local user stored for %s", uid)
+		m.CDebugf("| No local user stored for %s", uid)
 		loadRemote = true
 	} else if f1, err = local.CheckBasicsFreshness(leaf.idVersion); err != nil {
 		return nil, refresh, err
@@ -408,12 +398,12 @@ func loadUser(ctx context.Context, g *GlobalContext, uid keybase1.UID, resolveBo
 		refresh = loadRemote
 	}
 
-	g.Log.CDebugf(ctx, "| Freshness: basics=%v; for %s", f1, uid)
+	m.CDebugf("| Freshness: basics=%v; for %s", f1, uid)
 
 	var ret *User
 	if !loadRemote && !force {
 		ret = local
-	} else if ret, err = LoadUserFromServer(ctx, g, uid, resolveBody); err != nil {
+	} else if ret, err = LoadUserFromServer(m, uid, resolveBody); err != nil {
 		return nil, refresh, err
 	}
 
@@ -427,21 +417,21 @@ func loadUser(ctx context.Context, g *GlobalContext, uid keybase1.UID, resolveBo
 	return ret, refresh, nil
 }
 
-func LoadUserFromLocalStorage(ctx context.Context, g *GlobalContext, uid keybase1.UID) (u *User, err error) {
-	g.Log.CDebugf(ctx, "+ LoadUserFromLocalStorage(%s)", uid)
-	jw, err := g.LocalDb.Get(DbKeyUID(DBUser, uid))
+func LoadUserFromLocalStorage(m MetaContext, uid keybase1.UID) (u *User, err error) {
+	m.CDebugf("+ LoadUserFromLocalStorage(%s)", uid)
+	jw, err := m.G().LocalDb.Get(DbKeyUID(DBUser, uid))
 	if err != nil {
 		return nil, err
 	}
 
 	if jw == nil {
-		g.Log.CDebugf(ctx, "- loadUserFromLocalStorage(%s): Not found", uid)
+		m.CDebugf("- loadUserFromLocalStorage(%s): Not found", uid)
 		return nil, nil
 	}
 
-	g.Log.CDebugf(ctx, "| Loaded successfully")
+	m.CDebugf("| Loaded successfully")
 
-	if u, err = NewUserFromLocalStorage(g, jw); err != nil {
+	if u, err = NewUserFromLocalStorage(m.G(), jw); err != nil {
 		return nil, err
 	}
 
@@ -449,8 +439,8 @@ func LoadUserFromLocalStorage(ctx context.Context, g *GlobalContext, uid keybase
 		err = fmt.Errorf("Bad lookup; uid mismatch: %s != %s", uid, u.id)
 	}
 
-	g.Log.CDebugf(ctx, "| Loaded username %s (uid=%s)", u.name, uid)
-	g.Log.CDebugf(ctx, "- LoadUserFromLocalStorage(%s,%s)", u.name, uid)
+	m.CDebugf("| Loaded username %s (uid=%s)", u.name, uid)
+	m.CDebugf("- LoadUserFromLocalStorage(%s,%s)", u.name, uid)
 
 	return
 }
@@ -483,19 +473,19 @@ func LoadUserEmails(g *GlobalContext) (emails []keybase1.Email, err error) {
 	return
 }
 
-func LoadUserFromServer(ctx context.Context, g *GlobalContext, uid keybase1.UID, body *jsonw.Wrapper) (u *User, err error) {
-	g.Log.CDebugf(ctx, "+ Load User from server: %s", uid)
+func LoadUserFromServer(m MetaContext, uid keybase1.UID, body *jsonw.Wrapper) (u *User, err error) {
+	m.CDebugf("Load User from server: %s", uid)
 
 	// Res.body might already have been preloaded a a result of a Resolve call earlier.
 	if body == nil {
-		res, err := g.API.Get(APIArg{
+		res, err := m.G().API.Get(APIArg{
 			Endpoint:    "user/lookup",
 			SessionType: APISessionTypeNONE,
 			Args: HTTPArgs{
 				"uid":          UIDArg(uid),
 				"load_deleted": B{true},
 			},
-			NetContext: ctx,
+			MetaContext: m,
 		})
 
 		if err != nil {
@@ -503,13 +493,13 @@ func LoadUserFromServer(ctx context.Context, g *GlobalContext, uid keybase1.UID,
 		}
 		body = res.Body.AtKey("them")
 	} else {
-		g.Log.CDebugf(ctx, "| Skipped load; got user object previously")
+		m.CDebugf("| Skipped load; got user object previously")
 	}
 
-	if u, err = NewUserFromServer(g, body); err != nil {
+	if u, err = NewUserFromServer(m.G(), body); err != nil {
 		return u, err
 	}
-	g.Log.CDebugf(ctx, "- Load user from server: %s -> %s", uid, ErrToOk(err))
+	m.CDebugf("- Load user from server: %s -> %s", uid, ErrToOk(err))
 
 	return u, err
 }
@@ -521,7 +511,7 @@ func myUID(g *GlobalContext, uider UIDer) keybase1.UID {
 	return g.GetMyUID()
 }
 
-func lookupMerkleLeaf(ctx context.Context, g *GlobalContext, uid keybase1.UID, localExists bool, sigHints *SigHints) (f *MerkleUserLeaf, err error) {
+func lookupMerkleLeaf(m MetaContext, uid keybase1.UID, localExists bool, sigHints *SigHints) (f *MerkleUserLeaf, err error) {
 	if uid.IsNil() {
 		err = fmt.Errorf("uid parameter for lookupMerkleLeaf empty")
 		return
@@ -530,7 +520,7 @@ func lookupMerkleLeaf(ctx context.Context, g *GlobalContext, uid keybase1.UID, l
 	q := NewHTTPArgs()
 	q.Add("uid", UIDArg(uid))
 
-	f, err = g.MerkleClient.LookupUser(ctx, q, sigHints)
+	f, err = m.G().MerkleClient.LookupUser(m.Ctx(), q, sigHints)
 	if err == nil && f == nil && localExists {
 		err = fmt.Errorf("User not found in server Merkle tree")
 	}
@@ -538,14 +528,14 @@ func lookupMerkleLeaf(ctx context.Context, g *GlobalContext, uid keybase1.UID, l
 	return
 }
 
-func lookupSigHintsAndMerkleLeaf(ctx context.Context, g *GlobalContext, uid keybase1.UID, localExists bool) (sigHints *SigHints, leaf *MerkleUserLeaf, err error) {
-	defer g.CTrace(ctx, "lookupSigHintsAndMerkleLeaf", func() error { return err })()
-	sigHints, err = LoadSigHints(ctx, uid, g)
+func lookupSigHintsAndMerkleLeaf(m MetaContext, uid keybase1.UID, localExists bool) (sigHints *SigHints, leaf *MerkleUserLeaf, err error) {
+	defer m.CTrace("lookupSigHintsAndMerkleLeaf", func() error { return err })()
+	sigHints, err = LoadSigHints(m, uid)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	leaf, err = lookupMerkleLeaf(ctx, g, uid, true, sigHints)
+	leaf, err = lookupMerkleLeaf(m, uid, true, sigHints)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libkb/loaduser_test.go
+++ b/go/libkb/loaduser_test.go
@@ -12,10 +12,11 @@ import (
 func TestLoadUserPlusKeys(t *testing.T) {
 	tc := SetupTest(t, "user plus keys", 1)
 	defer tc.Cleanup()
+	m := NewMetaContextForTest(tc)
 
 	// this is kind of pointless as there is no cache anymore
 	for i := 0; i < 10; i++ {
-		u, err := LoadUserPlusKeys(nil, tc.G, "295a7eea607af32040647123732bc819", "")
+		u, err := LoadUserPlusKeys(m.Ctx(), tc.G, "295a7eea607af32040647123732bc819", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -28,7 +29,7 @@ func TestLoadUserPlusKeys(t *testing.T) {
 	}
 
 	for _, uid := range []keybase1.UID{"295a7eea607af32040647123732bc819", "afb5eda3154bc13c1df0189ce93ba119", "9d56bd0c02ac2711e142faf484ea9519", "c4c565570e7e87cafd077509abf5f619", "561247eb1cc3b0f5dc9d9bf299da5e19"} {
-		_, err := LoadUserPlusKeys(nil, tc.G, uid, "")
+		_, err := LoadUserPlusKeys(m.Ctx(), tc.G, uid, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -84,7 +85,7 @@ func BenchmarkLoadSigChains(b *testing.B) {
 	u.sigChainMem = nil
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err = u.LoadSigChains(nil, &u.leaf, false); err != nil {
+		if err = u.LoadSigChains(NewMetaContextForTest(tc), &u.leaf, false); err != nil {
 			b.Fatal(err)
 		}
 		u.sigChainMem = nil

--- a/go/libkb/log_send.go
+++ b/go/libkb/log_send.go
@@ -140,7 +140,7 @@ func (l *LogSendContext) post(status, feedback, kbfsLog, svcLog, desktopLog, upd
 	}
 
 	// Get the login session, if any
-	l.G().LoginState().LoggedInLoad()
+	l.G().LoginStateDeprecated().LoggedInLoad()
 
 	resp, err := l.G().API.PostRaw(arg, mpart.FormDataContentType(), &body)
 	if err != nil {

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -1192,17 +1192,6 @@ func (s *LoginState) SessionLoadAndCheck(force bool) (bool, error) {
 	return sessionValid, nil
 }
 
-func IsLoggedIn(g *GlobalContext, lih LoggedInHelper) (ret bool, uid keybase1.UID, err error) {
-	if lih == nil {
-		lih = g.LoginState()
-	}
-	ret, err = lih.LoggedInLoad()
-	if ret && err == nil {
-		uid = lih.GetUID()
-	}
-	return ret, uid, err
-}
-
 // UnverifiedPassphraseStream takes a passphrase as a parameter and
 // also the salt from the Account and computes a Triplesec and
 // a passphrase stream.  It's not verified through a Login.
@@ -1219,7 +1208,7 @@ func UnverifiedPassphraseStream(m MetaContext, passphrase string) (tsec Triplese
 		}
 		salt, err = lctx.LoginSession().Salt()
 	} else {
-		aerr := m.G().LoginState().Account(func(a *Account) {
+		aerr := m.G().LoginStateDeprecated().Account(func(a *Account) {
 			if len(username) > 0 {
 				err = a.LoadLoginSession(username)
 				if err != nil {

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -649,7 +649,7 @@ func (mc *MerkleClient) lookupPathAndSkipSequenceUser(ctx context.Context, q HTT
 	}
 
 	if sigHints != nil {
-		if err = sigHints.RefreshWith(ctx, apiRes.Body.AtKey("sigs")); err != nil {
+		if err = sigHints.RefreshWith(NewMetaContext(ctx, mc.G()), apiRes.Body.AtKey("sigs")); err != nil {
 			return nil, nil, nil, nil, err
 		}
 	}

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/buger/jsonparser"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	"golang.org/x/net/context"
 )
 
 type ChainLinks []*ChainLink
@@ -219,14 +218,14 @@ func (sc *SigChain) Bump(mt MerkleTriple) {
 	sc.localChainUpdateTime = sc.G().Clock().Now()
 }
 
-func (sc *SigChain) LoadFromServer(ctx context.Context, t *MerkleTriple, selfUID keybase1.UID) (dirtyTail *MerkleTriple, err error) {
+func (sc *SigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID keybase1.UID) (dirtyTail *MerkleTriple, err error) {
 	low := sc.GetLastLoadedSeqno()
 	sc.loadedFromLinkOne = (low == keybase1.Seqno(0) || low == keybase1.Seqno(-1))
 
 	isSelf := selfUID.Equal(sc.uid)
 
-	sc.G().Log.CDebugf(ctx, "+ Load SigChain from server (uid=%s, low=%d)", sc.uid, low)
-	defer func() { sc.G().Log.CDebugf(ctx, "- Loaded SigChain -> %s", ErrToOk(err)) }()
+	m.CDebugf("+ Load SigChain from server (uid=%s, low=%d)", sc.uid, low)
+	defer func() { m.CDebugf("- Loaded SigChain -> %s", ErrToOk(err)) }()
 
 	resp, finisher, err := sc.G().API.GetResp(APIArg{
 		Endpoint:    "sig/get",
@@ -237,7 +236,7 @@ func (sc *SigChain) LoadFromServer(ctx context.Context, t *MerkleTriple, selfUID
 			"v2_compressed": B{true},   // TODO: Change the server to honor this flag
 			"self":          B{isSelf}, // TODO: Change the server to honor this flag
 		},
-		NetContext: ctx,
+		MetaContext: m,
 	})
 	if err != nil {
 		return
@@ -250,10 +249,10 @@ func (sc *SigChain) LoadFromServer(ctx context.Context, t *MerkleTriple, selfUID
 	if err != nil {
 		return nil, err
 	}
-	return sc.LoadServerBody(ctx, body, low, t, selfUID)
+	return sc.LoadServerBody(m, body, low, t, selfUID)
 }
 
-func (sc *SigChain) LoadServerBody(ctx context.Context, body []byte, low keybase1.Seqno, t *MerkleTriple, selfUID keybase1.UID) (dirtyTail *MerkleTriple, err error) {
+func (sc *SigChain) LoadServerBody(m MetaContext, body []byte, low keybase1.Seqno, t *MerkleTriple, selfUID keybase1.UID) (dirtyTail *MerkleTriple, err error) {
 	if val, err := jsonparser.GetInt(body, "status", "code"); err == nil {
 		if keybase1.StatusCode(val) == keybase1.StatusCode_SCDeleted {
 			// Do not bother trying to read the sigchain - user is
@@ -273,14 +272,14 @@ func (sc *SigChain) LoadServerBody(ctx context.Context, body []byte, low keybase
 
 		var link *ChainLink
 		if link, err = ImportLinkFromServer(sc.G(), sc, value, selfUID); err != nil {
-			sc.G().Log.Debug("ImportLinkFromServer error: %s", err)
+			m.CDebugf("ImportLinkFromServer error: %s", err)
 			return
 		}
 		if link.GetSeqno() <= low {
 			return
 		}
 		if selfUID.Equal(link.GetUID()) {
-			sc.G().Log.CDebugf(ctx, "| Setting isOwnNewLinkFromServer=true for seqno %d", link.GetSeqno())
+			m.CDebugf("| Setting isOwnNewLinkFromServer=true for seqno %d", link.GetSeqno())
 			link.isOwnNewLinkFromServer = true
 		}
 		links = append(links, link)
@@ -298,7 +297,7 @@ func (sc *SigChain) LoadServerBody(ctx context.Context, body []byte, low keybase
 		return nil, err
 	}
 
-	sc.G().Log.CDebugf(ctx, "| Got back %d new entries", numEntries)
+	m.CDebugf("| Got back %d new entries", numEntries)
 
 	if t != nil && !foundTail {
 		err = NewServerChainError("Failed to reach (%s, %d) in server response",
@@ -312,7 +311,7 @@ func (sc *SigChain) LoadServerBody(ctx context.Context, body []byte, low keybase
 		// If we've stored a `last` and it's less than the one
 		// we just loaded, then nuke it.
 		if sc.localChainTail != nil && sc.localChainTail.Less(*dirtyTail) {
-			sc.G().Log.CDebugf(ctx, "| Clear cached last (%d < %d)", sc.localChainTail.Seqno, dirtyTail.Seqno)
+			m.CDebugf("| Clear cached last (%d < %d)", sc.localChainTail.Seqno, dirtyTail.Seqno)
 			sc.localChainTail = nil
 			sc.localCki = nil
 		}
@@ -334,16 +333,16 @@ func (sc *SigChain) getFirstSeqno() (ret keybase1.Seqno) {
 	return ret
 }
 
-func (sc *SigChain) VerifyChain(ctx context.Context) (err error) {
-	sc.G().Log.CDebugf(ctx, "+ SigChain#VerifyChain()")
+func (sc *SigChain) VerifyChain(m MetaContext) (err error) {
+	m.CDebugf("+ SigChain#VerifyChain()")
 	defer func() {
-		sc.G().Log.CDebugf(ctx, "- SigChain#VerifyChain() -> %s", ErrToOk(err))
+		m.CDebugf("- SigChain#VerifyChain() -> %s", ErrToOk(err))
 	}()
 	for i := len(sc.chainLinks) - 1; i >= 0; i-- {
 		curr := sc.chainLinks[i]
-		sc.G().VDL.CLogf(ctx, VLog1, "| verify link %d (%s)", i, curr.id)
+		m.G().VDL.CLogf(m.Ctx(), VLog1, "| verify link %d (%s)", i, curr.id)
 		if curr.chainVerified {
-			sc.G().Log.CDebugf(ctx, "| short-circuit at link %d", i)
+			m.CDebugf("| short-circuit at link %d", i)
 			break
 		}
 		if err = curr.VerifyLink(); err != nil {
@@ -426,7 +425,7 @@ func (sc SigChain) GetLastLoadedSeqno() (ret keybase1.Seqno) {
 	return
 }
 
-func (sc *SigChain) Store(ctx context.Context) (err error) {
+func (sc *SigChain) Store(m MetaContext) (err error) {
 	for i := len(sc.chainLinks) - 1; i >= 0; i-- {
 		link := sc.chainLinks[i]
 		var didStore bool
@@ -553,12 +552,12 @@ func (sc *SigChain) Dump(w io.Writer) {
 // verifySubchain verifies the given subchain and outputs a yes/no answer
 // on whether or not it's well-formed, and also yields ComputedKeyInfos for
 // all keys found in the process, including those that are now retired.
-func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links ChainLinks) (cached bool, cki *ComputedKeyInfos, err error) {
+func (sc *SigChain) verifySubchain(m MetaContext, kf KeyFamily, links ChainLinks) (cached bool, cki *ComputedKeyInfos, err error) {
 	un := sc.username
 
-	sc.G().Log.CDebugf(ctx, "+ verifySubchain")
+	m.CDebugf("+ verifySubchain")
 	defer func() {
-		sc.G().Log.CDebugf(ctx, "- verifySubchain -> %v, %s", cached, ErrToOk(err))
+		m.CDebugf("- verifySubchain -> %v, %s", cached, ErrToOk(err))
 	}()
 
 	if len(links) == 0 {
@@ -569,10 +568,10 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 	last := links[len(links)-1]
 	if cki = last.GetSigCheckCache(); cki != nil {
 		if cki.IsStaleVersion() {
-			sc.G().Log.CDebugf(ctx, "Ignoring cached CKI, since the version is old (%d < %d)", cki.Version, ComputedKeyInfosVersionCurrent)
+			m.CDebugf("Ignoring cached CKI, since the version is old (%d < %d)", cki.Version, ComputedKeyInfosVersionCurrent)
 		} else {
 			cached = true
-			sc.G().Log.CDebugf(ctx, "Skipped verification (cached): %s", last.id)
+			m.CDebugf("Skipped verification (cached): %s", last.id)
 			return cached, cki, err
 		}
 	}
@@ -585,7 +584,7 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 
 	for linkIndex, link := range links {
 		if isBad, reason := link.IsBad(); isBad {
-			sc.G().Log.CDebugf(ctx, "Ignoring bad chain link with sig ID %s: %s", link.GetSigID(), reason)
+			m.CDebugf("Ignoring bad chain link with sig ID %s: %s", link.GetSigID(), reason)
 			continue
 		}
 
@@ -637,7 +636,7 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 
 		if pgpcl, ok := tcl.(*PGPUpdateChainLink); ok {
 			if hash := pgpcl.GetPGPFullHash(); hash != "" {
-				sc.G().Log.CDebugf(ctx, "| Setting active PGP hash for %s: %s", pgpcl.kid, hash)
+				m.CDebugf("| Setting active PGP hash for %s: %s", pgpcl.kid, hash)
 				ckf.SetActivePGPHash(pgpcl.kid, hash)
 			}
 		}
@@ -645,7 +644,7 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 		if isModifyingKeys || isFinalLink || hasRevocations {
 			err = link.VerifySigWithKeyFamily(ckf)
 			if err != nil {
-				sc.G().Log.CDebugf(ctx, "| Failure in VerifySigWithKeyFamily: %s", err)
+				m.CDebugf("| Failure in VerifySigWithKeyFamily: %s", err)
 				return cached, cki, err
 			}
 		}
@@ -653,7 +652,7 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 		if isDelegating {
 			err = ckf.Delegate(tcl)
 			if err != nil {
-				sc.G().Log.CDebugf(ctx, "| Failure in Delegate: %s", err)
+				m.CDebugf("| Failure in Delegate: %s", err)
 				return cached, cki, err
 			}
 		}
@@ -675,7 +674,7 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 		}
 
 		if err = tcl.VerifyReverseSig(ckf); err != nil {
-			sc.G().Log.CDebugf(ctx, "| Failure in VerifyReverseSig: %s", err)
+			m.CDebugf("| Failure in VerifyReverseSig: %s", err)
 			return cached, cki, err
 		}
 
@@ -688,7 +687,7 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 		}
 
 		if err != nil {
-			sc.G().Log.CDebugf(ctx, "| bailing out on error: %s", err)
+			m.CDebugf("| bailing out on error: %s", err)
 			return cached, cki, err
 		}
 	}
@@ -697,15 +696,15 @@ func (sc *SigChain) verifySubchain(ctx context.Context, kf KeyFamily, links Chai
 	return cached, cki, err
 }
 
-func (sc *SigChain) verifySigsAndComputeKeysCurrent(ctx context.Context, eldest keybase1.KID, ckf *ComputedKeyFamily) (cached bool, linksConsumed int, err error) {
+func (sc *SigChain) verifySigsAndComputeKeysCurrent(m MetaContext, eldest keybase1.KID, ckf *ComputedKeyFamily) (cached bool, linksConsumed int, err error) {
 
 	cached = false
-	sc.G().Log.CDebugf(ctx, "+ verifySigsAndComputeKeysCurrent for user %s (eldest = %s)", sc.uid, eldest)
+	m.CDebugf("+ verifySigsAndComputeKeysCurrent for user %s (eldest = %s)", sc.uid, eldest)
 	defer func() {
-		sc.G().Log.CDebugf(ctx, "- verifySigsAndComputeKeysCurrent for user %s -> %s", sc.uid, ErrToOk(err))
+		m.CDebugf("- verifySigsAndComputeKeysCurrent for user %s -> %s", sc.uid, ErrToOk(err))
 	}()
 
-	if err = sc.VerifyChain(ctx); err != nil {
+	if err = sc.VerifyChain(m); err != nil {
 		return cached, 0, err
 	}
 
@@ -730,7 +729,7 @@ func (sc *SigChain) verifySigsAndComputeKeysCurrent(ctx context.Context, eldest 
 	sc.currentSubchainStart = 0
 
 	if ckf.kf == nil || eldest.IsNil() {
-		sc.G().Log.CDebugf(ctx, "| VerifyWithKey short-circuit, since no Key available")
+		m.CDebugf("| VerifyWithKey short-circuit, since no Key available")
 		sc.localCki = NewComputedKeyInfos(sc.G())
 		ckf.cki = sc.localCki
 		return cached, 0, err
@@ -747,7 +746,7 @@ func (sc *SigChain) verifySigsAndComputeKeysCurrent(ctx context.Context, eldest 
 	}
 
 	if len(links) == 0 {
-		sc.G().Log.CDebugf(ctx, "| Empty chain after we limited to eldest %s", eldest)
+		m.CDebugf("| Empty chain after we limited to eldest %s", eldest)
 		eldestKey, _ := ckf.FindKeyWithKIDUnsafe(eldest)
 		sc.localCki = NewComputedKeyInfos(sc.G())
 		err = sc.localCki.InsertServerEldestKey(eldestKey, sc.username)
@@ -755,7 +754,7 @@ func (sc *SigChain) verifySigsAndComputeKeysCurrent(ctx context.Context, eldest 
 		return cached, 0, err
 	}
 
-	if cached, ckf.cki, err = sc.verifySubchain(ctx, *ckf.kf, links); err != nil {
+	if cached, ckf.cki, err = sc.verifySubchain(m, *ckf.kf, links); err != nil {
 		return cached, len(links), err
 	}
 
@@ -780,9 +779,9 @@ func (c ChainLinks) omittingNRightmostLinks(n int) ChainLinks {
 
 // VerifySigsAndComputeKeys iterates over all potentially all incarnations of the user, trying to compute
 // multiple subchains. It returns (bool, error), where bool is true if the load hit the cache, and false otherwise.
-func (sc *SigChain) VerifySigsAndComputeKeys(ctx context.Context, eldest keybase1.KID, ckf *ComputedKeyFamily) (bool, error) {
+func (sc *SigChain) VerifySigsAndComputeKeys(m MetaContext, eldest keybase1.KID, ckf *ComputedKeyFamily) (bool, error) {
 	// First consume the currently active sigchain.
-	cached, numLinksConsumed, err := sc.verifySigsAndComputeKeysCurrent(ctx, eldest, ckf)
+	cached, numLinksConsumed, err := sc.verifySigsAndComputeKeysCurrent(m, eldest, ckf)
 	if err != nil || ckf.kf == nil {
 		return cached, err
 	}
@@ -793,11 +792,11 @@ func (sc *SigChain) VerifySigsAndComputeKeys(ctx context.Context, eldest keybase
 	historicalLinks := sc.chainLinks.omittingNRightmostLinks(numLinksConsumed)
 
 	if len(historicalLinks) > 0 {
-		sc.G().Log.CDebugf(ctx, "After consuming %d links, there are %d historical links left",
+		m.CDebugf("After consuming %d links, there are %d historical links left",
 			numLinksConsumed, len(historicalLinks))
 		// ignore error here, since it shouldn't kill the overall load if historical subchains don't run
 		// correctly.
-		cached, _ = sc.verifySigsAndComputeKeysHistorical(ctx, historicalLinks, *ckf.kf)
+		cached, _ = sc.verifySigsAndComputeKeysHistorical(m, historicalLinks, *ckf.kf)
 		if !cached {
 			allCached = false
 		}
@@ -806,37 +805,37 @@ func (sc *SigChain) VerifySigsAndComputeKeys(ctx context.Context, eldest keybase
 	return allCached, nil
 }
 
-func (sc *SigChain) verifySigsAndComputeKeysHistorical(ctx context.Context, allLinks ChainLinks, kf KeyFamily) (allCached bool, err error) {
+func (sc *SigChain) verifySigsAndComputeKeysHistorical(m MetaContext, allLinks ChainLinks, kf KeyFamily) (allCached bool, err error) {
 
-	defer sc.G().CTrace(ctx, "verifySigsAndComputeKeysHistorical", func() error { return err })()
+	defer m.CTrace("verifySigsAndComputeKeysHistorical", func() error { return err })()
 	var cached bool
 
 	var prevSubchains []ChainLinks
 
 	for {
 		if len(allLinks) == 0 {
-			sc.G().Log.CDebugf(ctx, "Ending iteration through previous subchains; no further links")
+			m.CDebugf("Ending iteration through previous subchains; no further links")
 			break
 		}
 
 		i := len(allLinks) - 1
 		eldest := allLinks[i].ToEldestKID()
 		if eldest.IsNil() {
-			sc.G().Log.CDebugf(ctx, "Ending iteration through previous subchains; saw a nil eldest (@%d)", i)
+			m.CDebugf("Ending iteration through previous subchains; saw a nil eldest (@%d)", i)
 			break
 		}
-		sc.G().Log.CDebugf(ctx, "Examining subchain that ends at %d with eldest %s", i, eldest)
+		m.CDebugf("Examining subchain that ends at %d with eldest %s", i, eldest)
 
 		var links ChainLinks
 		links, err = cropToRightmostSubchain(allLinks, eldest)
 		if err != nil {
-			sc.G().Log.CInfof(ctx, "Error backtracking all links from %d: %s", i, err)
+			m.CInfof("Error backtracking all links from %d: %s", i, err)
 			break
 		}
 
-		cached, _, err = sc.verifySubchain(ctx, kf, links)
+		cached, _, err = sc.verifySubchain(m, kf, links)
 		if err != nil {
-			sc.G().Log.CInfof(ctx, "Error verifying subchain from %d: %s", i, err)
+			m.CInfof("Error verifying subchain from %d: %s", i, err)
 			break
 		}
 		if !cached {
@@ -846,7 +845,7 @@ func (sc *SigChain) verifySigsAndComputeKeysHistorical(ctx context.Context, allL
 		allLinks = allLinks.omittingNRightmostLinks(len(links))
 	}
 	reverseListOfChainLinks(prevSubchains)
-	sc.G().Log.CDebugf(ctx, "Loaded %d additional historical subchains", len(prevSubchains))
+	m.CDebugf("Loaded %d additional historical subchains", len(prevSubchains))
 	sc.prevSubchains = prevSubchains
 	return allCached, nil
 }
@@ -899,6 +898,7 @@ var PublicChain = &ChainType{
 //========================================================================
 
 type SigChainLoader struct {
+	MetaContextified
 	user                 *User
 	self                 bool
 	leaf                 *MerkleUserLeaf
@@ -912,10 +912,6 @@ type SigChainLoader struct {
 	// The preloaded sigchain; maybe we're loading a user that already was
 	// loaded, and here's the existing sigchain.
 	preload *SigChain
-
-	ctx context.Context
-
-	Contextified
 }
 
 //========================================================================
@@ -951,17 +947,17 @@ func (l *SigChainLoader) LoadLinksFromStorage() (err error) {
 
 	uid := l.user.GetUID()
 
-	l.G().Log.CDebugf(l.ctx, "+ SigChainLoader.LoadFromStorage(%s)", uid)
-	defer func() { l.G().Log.CDebugf(l.ctx, "- SigChainLoader.LoadFromStorage(%s) -> %s", uid, ErrToOk(err)) }()
+	l.M().CDebugf("+ SigChainLoader.LoadFromStorage(%s)", uid)
+	defer func() { l.M().CDebugf("- SigChainLoader.LoadFromStorage(%s) -> %s", uid, ErrToOk(err)) }()
 
 	if mt, err = l.LoadLastLinkIDFromStorage(); err != nil || mt == nil || mt.LinkID == nil {
-		l.G().Log.CDebugf(l.ctx, "| Failed to load last link ID")
+		l.M().CDebugf("| Failed to load last link ID")
 		if err == nil {
-			l.G().Log.CDebugf(l.ctx, "| no error loading last link ID from storage")
+			l.M().CDebugf("| no error loading last link ID from storage")
 		} else if mt == nil {
-			l.G().Log.CDebugf(l.ctx, "| mt (MerkleTriple) nil result from load last link ID from storage")
+			l.M().CDebugf("| mt (MerkleTriple) nil result from load last link ID from storage")
 		} else if mt.LinkID == nil {
-			l.G().Log.CDebugf(l.ctx, "| mt (MerkleTriple) from storage has a nil link ID")
+			l.M().CDebugf("| mt (MerkleTriple) from storage has a nil link ID")
 		}
 		return
 	}
@@ -971,7 +967,7 @@ func (l *SigChainLoader) LoadLinksFromStorage() (err error) {
 		return err
 	}
 	if currentLink == nil {
-		l.G().Log.CDebugf(l.ctx, "tried to load previous link ID %s, but link not found", mt.LinkID.String())
+		l.M().CDebugf("tried to load previous link ID %s, but link not found", mt.LinkID.String())
 		return nil
 	}
 	links := ChainLinks{currentLink}
@@ -992,7 +988,7 @@ func (l *SigChainLoader) LoadLinksFromStorage() (err error) {
 			return err
 		}
 		if prevLink == nil {
-			l.G().Log.CDebugf(l.ctx, "tried to load previous link ID %s, but link not found", currentLink.GetPrev())
+			l.M().CDebugf("tried to load previous link ID %s, but link not found", currentLink.GetPrev())
 			return nil
 		}
 
@@ -1004,7 +1000,7 @@ func (l *SigChainLoader) LoadLinksFromStorage() (err error) {
 	}
 
 	reverse(links)
-	l.G().Log.CDebugf(l.ctx, "| Loaded %d links", len(links))
+	l.M().CDebugf("| Loaded %d links", len(links))
 
 	l.links = links
 	return
@@ -1018,7 +1014,7 @@ func (l *SigChainLoader) MakeSigChain() error {
 		username:             l.user.GetNormalizedName(),
 		chainLinks:           l.links,
 		currentSubchainStart: l.currentSubchainStart,
-		Contextified:         l.Contextified,
+		Contextified:         NewContextified(l.G()),
 	}
 	for _, link := range l.links {
 		link.SetParent(sc)
@@ -1130,18 +1126,18 @@ func (l *SigChainLoader) selfUID() (uid keybase1.UID) {
 
 func (l *SigChainLoader) LoadFromServer() (err error) {
 	srv := l.GetMerkleTriple()
-	l.dirtyTail, err = l.chain.LoadFromServer(l.ctx, srv, l.selfUID())
+	l.dirtyTail, err = l.chain.LoadFromServer(l.M(), srv, l.selfUID())
 	return
 }
 
 //========================================================================
 
 func (l *SigChainLoader) VerifySigsAndComputeKeys() (err error) {
-	l.G().Log.CDebugf(l.ctx, "VerifySigsAndComputeKeys(): l.leaf: %v, l.leaf.eldest: %v, l.ckf: %v", l.leaf, l.leaf.eldest, l.ckf)
+	l.M().CDebugf("VerifySigsAndComputeKeys(): l.leaf: %v, l.leaf.eldest: %v, l.ckf: %v", l.leaf, l.leaf.eldest, l.ckf)
 	if l.ckf.kf == nil {
 		return nil
 	}
-	_, err = l.chain.VerifySigsAndComputeKeys(l.ctx, l.leaf.eldest, &l.ckf)
+	_, err = l.chain.VerifySigsAndComputeKeys(l.M(), l.leaf.eldest, &l.ckf)
 	if err != nil {
 		return err
 	}
@@ -1159,7 +1155,7 @@ func (l *SigChainLoader) StoreTail() (err error) {
 		return nil
 	}
 	err = l.G().LocalDb.PutObj(l.dbKey(), nil, l.dirtyTail)
-	l.G().Log.CDebugf(l.ctx, "| Storing dirtyTail @ %d (%v)", l.dirtyTail.Seqno, l.dirtyTail)
+	l.M().CDebugf("| Storing dirtyTail @ %d (%v)", l.dirtyTail.Seqno, l.dirtyTail)
 	if err == nil {
 		l.dirtyTail = nil
 	}
@@ -1171,7 +1167,7 @@ func (l *SigChainLoader) StoreTail() (err error) {
 func (l *SigChainLoader) Store() (err error) {
 	err = l.StoreTail()
 	if err == nil {
-		err = l.chain.Store(l.ctx)
+		err = l.chain.Store(l.M())
 	}
 	return
 }
@@ -1194,13 +1190,13 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 
 	uid := l.user.GetUID()
 
-	l.G().Log.CDebugf(l.ctx, "+ SigChainLoader#Load(%s)", uid)
+	l.M().CDebugf("+ SigChainLoader#Load(%s)", uid)
 	defer func() {
-		l.G().Log.CDebugf(l.ctx, "- SigChainLoader#Load(%s) -> (%v, %s)", uid, (ret != nil), ErrToOk(err))
+		l.M().CDebugf("- SigChainLoader#Load(%s) -> (%v, %s)", uid, (ret != nil), ErrToOk(err))
 	}()
 
 	stage := func(s string) {
-		l.G().Log.CDebugf(l.ctx, "| SigChainLoader#Load(%s) %s", uid, s)
+		l.M().CDebugf("| SigChainLoader#Load(%s) %s", uid, s)
 	}
 
 	stage("GetFingerprint")
@@ -1224,7 +1220,7 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 	}
 	ret = l.chain
 	stage("VerifyChain")
-	if err = l.chain.VerifyChain(l.ctx); err != nil {
+	if err = l.chain.VerifyChain(l.M()); err != nil {
 		return nil, err
 	}
 	stage("CheckFreshness")
@@ -1239,16 +1235,16 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 	} else if l.chain.GetComputedKeyInfosWithVersionBust() == nil {
 		// The chain tip doesn't have a cached cki, probably because new
 		// signatures have shown up since the last time we loaded it.
-		l.G().Log.CDebugf(l.ctx, "| Need to reverify chain since we don't have ComputedKeyInfos")
+		l.M().CDebugf("| Need to reverify chain since we don't have ComputedKeyInfos")
 	} else if !l.merkleTreeEldestMatchesLastLinkEldest() {
 		// CheckFreshness above might've decided our chain tip hasn't moved,
 		// but we might still need to proceed with the rest of the load if the
 		// eldest KID has changed.
-		l.G().Log.CDebugf(l.ctx, "| Merkle leaf doesn't match the chain tip.")
+		l.M().CDebugf("| Merkle leaf doesn't match the chain tip.")
 	} else {
 		// The chain tip has a cached cki, AND the current eldest kid matches
 		// it. Use what's cached and short circuit.
-		l.G().Log.CDebugf(l.ctx, "| Sigchain was fully cached. Short-circuiting verification.")
+		l.M().CDebugf("| Sigchain was fully cached. Short-circuiting verification.")
 		ret.wasFullyCached = true
 		stage("VerifySig (in fully cached)")
 
@@ -1264,13 +1260,13 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 	}
 
 	stage("VerifyChain")
-	if err = l.chain.VerifyChain(l.ctx); err != nil {
+	if err = l.chain.VerifyChain(l.M()); err != nil {
 		return nil, err
 	}
 
 	stage("StoreChain")
-	if err = l.chain.Store(l.ctx); err != nil {
-		l.G().Log.CDebugf(l.ctx, "| continuing past error storing chain links: %s", err)
+	if err = l.chain.Store(l.M()); err != nil {
+		l.M().CDebugf("| continuing past error storing chain links: %s", err)
 	}
 	stage("VerifySig")
 	if err = l.VerifySigsAndComputeKeys(); err != nil {
@@ -1278,7 +1274,7 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 	}
 	stage("Store")
 	if err = l.Store(); err != nil {
-		l.G().Log.CDebugf(l.ctx, "| continuing past error storing chain: %s", err)
+		l.M().CDebugf("| continuing past error storing chain: %s", err)
 	}
 
 	return ret, nil

--- a/go/libkb/sig_chain_test.go
+++ b/go/libkb/sig_chain_test.go
@@ -15,7 +15,6 @@ import (
 	jsonw "github.com/keybase/go-jsonw"
 	testvectors "github.com/keybase/keybase-test-vectors/go"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 // Returns a map from error name strings to sets of Go error types. If a test
@@ -225,7 +224,7 @@ func doChainTest(t *testing.T, tc TestContext, testCase TestCase) {
 		sigchain.chainLinks = append(sigchain.chainLinks, link)
 	}
 	if sigchainErr == nil {
-		_, sigchainErr = sigchain.VerifySigsAndComputeKeys(nil, eldestKID, &ckf)
+		_, sigchainErr = sigchain.VerifySigsAndComputeKeys(NewMetaContextForTest(tc), eldestKID, &ckf)
 	}
 
 	// Some tests expect an error. If we get one, make sure it's the right
@@ -327,7 +326,7 @@ func doChainTest(t *testing.T, tc TestContext, testCase TestCase) {
 }
 
 func storeAndLoad(t *testing.T, tc TestContext, chain *SigChain) {
-	err := chain.Store(context.Background())
+	err := chain.Store(NewMetaContextForTest(tc))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -341,9 +340,8 @@ func storeAndLoad(t *testing.T, tc TestContext, chain *SigChain) {
 			public: chain.GetCurrentTailTriple(),
 			uid:    chain.uid,
 		},
-		chainType:    PublicChain,
-		Contextified: NewContextified(tc.G),
-		ctx:          context.Background(),
+		chainType:        PublicChain,
+		MetaContextified: NewMetaContextified(NewMetaContextForTest(tc)),
 	}
 	sgl.chain = chain
 	sgl.dirtyTail = chain.GetCurrentTailTriple()

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -260,7 +260,7 @@ func (s *SKB) UnlockSecretKey(m MetaContext, passphrase string, tsec Triplesec, 
 			if lctx := m.LoginContext(); lctx != nil {
 				lctx.CreateStreamCache(tsec, pps)
 			} else {
-				aerr := s.G().LoginState().Account(func(a *Account) {
+				aerr := s.G().LoginStateDeprecated().Account(func(a *Account) {
 					a.CreateStreamCache(tsec, pps)
 				}, "skb - UnlockSecretKey - CreateStreamCache")
 				if aerr != nil {
@@ -430,7 +430,7 @@ func (s *SKB) UnlockNoPrompt(m MetaContext, secretStore SecretStore) (GenericKey
 		tsec, _ = lctx.PassphraseStreamCache().TriplesecAndGeneration()
 		pps = lctx.PassphraseStreamCache().PassphraseStream()
 	} else {
-		s.G().LoginState().PassphraseStreamCache(func(sc *PassphraseStreamCache) {
+		s.G().LoginStateDeprecated().PassphraseStreamCache(func(sc *PassphraseStreamCache) {
 			tsec, _ = sc.TriplesecAndGeneration()
 			pps = sc.PassphraseStream()
 		}, "skb - UnlockNoPrompt - tsec, pps")
@@ -460,7 +460,7 @@ func (s *SKB) unlockPrompt(m MetaContext, arg SecretKeyPromptArg, secretStore Se
 	// if lctx != nil, then don't bother as any prompts during login should be shown.
 	if m.LoginContext() == nil && arg.UseCancelCache {
 		var skip bool
-		s.G().LoginState().Account(func(a *Account) {
+		s.G().LoginStateDeprecated().Account(func(a *Account) {
 			skip = a.SkipSecretPrompt()
 		}, "SKB - unlockPrompt")
 		if skip {
@@ -487,7 +487,7 @@ func (s *SKB) unlockPrompt(m MetaContext, arg SecretKeyPromptArg, secretStore Se
 	if err != nil {
 		if _, ok := err.(InputCanceledError); ok && arg.UseCancelCache {
 			// cache the cancel response in the account
-			s.G().LoginState().Account(func(a *Account) {
+			s.G().LoginStateDeprecated().Account(func(a *Account) {
 				a.SecretPromptCanceled()
 			}, "SKB - unlockPrompt - input canceled")
 		}

--- a/go/libkb/skb_test.go
+++ b/go/libkb/skb_test.go
@@ -103,7 +103,7 @@ func makeTestSKB(t *testing.T, lks *LKSec, g *GlobalContext) *SKB {
 		t.Fatal(err)
 	}
 	g.createLoginState()
-	err = g.LoginState().Account(func(a *Account) {
+	err = g.LoginStateDeprecated().Account(func(a *Account) {
 		a.CreateLoginSessionWithSalt(email, salt)
 	}, "makeTestSKB")
 	if err != nil {
@@ -195,7 +195,7 @@ func TestUnusedSecretStore(t *testing.T) {
 	skb := makeTestSKB(t, lks, tc.G)
 	// It doesn't matter what passphraseStream contains, as long
 	// as it's the right size.
-	err := tc.G.LoginState().Account(func(a *Account) {
+	err := tc.G.LoginStateDeprecated().Account(func(a *Account) {
 		a.CreateStreamCache(nil, NewPassphraseStream(make([]byte, extraLen)))
 	}, "TestUnusedSecretStore")
 	if err != nil {

--- a/go/libkb/status.go
+++ b/go/libkb/status.go
@@ -31,7 +31,7 @@ func GetCurrentStatus(ctx context.Context, g *GlobalContext) (res CurrentStatus,
 		res.Registered = true
 		res.User = NewUserThin(cr.GetUsername().String(), uid)
 	}
-	res.SessionIsValid, err = g.LoginState().LoggedInProvisioned(ctx)
+	res.SessionIsValid, err = g.LoginStateDeprecated().LoggedInProvisioned(ctx)
 	res.LoggedIn = res.SessionIsValid
 	return
 }

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -258,11 +258,11 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 
 	// Shorthand
 	g := u.G()
-
 	// Add a LU= tax to this context, for all subsequent debugging
-	ctx := arg.WithLogTag()
+	m := arg.MetaContext().WithLogTag("LU")
+	ctx := m.Ctx()
 
-	defer g.CVTrace(ctx, VLog0, culDebug(arg.uid), func() error { return err })()
+	defer m.CVTrace(VLog0, culDebug(arg.uid), func() error { return err })()
 
 	if arg.uid.IsNil() {
 		if len(arg.name) == 0 {
@@ -286,7 +286,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		if user != nil && err == nil {
 			// Update the full-self cacher after the lock is released, to avoid
 			// any circular locking.
-			if fs := u.G().GetFullSelfer(); fs != nil && arg.self {
+			if fs := g.GetFullSelfer(); fs != nil && arg.self {
 				fs.Update(ctx, user)
 			}
 		}
@@ -330,7 +330,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		var sigHints *SigHints
 		var leaf *MerkleUserLeaf
 
-		sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(ctx, u.G(), arg.uid, true)
+		sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(m, arg.uid, true)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -403,7 +403,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 	}
 
 	if err := u.putUPAKToCache(ctx, ret); err != nil {
-		u.G().Log.CDebugf(ctx, "continuing past error in putUPAKToCache: %s", err)
+		m.CDebugf("continuing past error in putUPAKToCache: %s", err)
 	}
 
 	if u.TestDeadlocker != nil {

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -260,8 +260,8 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 	arg = arg.EnsureCtxAndLogTag()
 
 	// Shorthands
-	g := u.G()
 	m := arg.MetaContext()
+	g := m.G()
 	ctx := m.Ctx()
 
 	defer m.CVTrace(VLog0, culDebug(arg.uid), func() error { return err })()

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -256,10 +256,12 @@ func (u *CachedUPAKLoader) PutUserToCache(ctx context.Context, user *User) error
 // be able to access it from inside the accessor with exclusion.
 func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInfo, accessor func(k *keybase1.UserPlusKeysV2AllIncarnations) error, shouldReturnFullUser bool) (ret *keybase1.UserPlusKeysV2AllIncarnations, user *User, err error) {
 
-	// Shorthand
-	g := u.G()
 	// Add a LU= tax to this context, for all subsequent debugging
-	m := arg.MetaContext().WithLogTag("LU")
+	arg = arg.EnsureCtxAndLogTag()
+
+	// Shorthands
+	g := u.G()
+	m := arg.MetaContext()
 	ctx := m.Ctx()
 
 	defer m.CVTrace(VLog0, culDebug(arg.uid), func() error { return err })()

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -177,7 +177,7 @@ func (h ConfigHandler) GetExtendedStatus(ctx context.Context, sessionID int) (re
 	res.PassphraseStreamCached = psc.ValidPassphraseStream()
 	res.TsecCached = psc.ValidTsec()
 
-	h.G().LoginState().Account(func(a *libkb.Account) {
+	h.G().LoginStateDeprecated().Account(func(a *libkb.Account) {
 		res.SecretPromptSkip = a.SkipSecretPrompt()
 	}, "ConfigHandler::GetExtendedStatus")
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -619,30 +619,12 @@ func (d *Service) slowChecks() {
 }
 
 func (d *Service) tryGregordConnect() error {
-	// If we're logged out, LoggedInLoad() will return false with no error,
-	// even if the network is down. However, if we're logged in and the network
-	// is down, it will still return false, along with the network error. We
-	// need to handle that case specifically, so that we still start the gregor
-	// connect loop.
-	loggedIn, err := d.G().LoginState().LoggedInProvisioned(context.Background())
-	if err != nil {
-		// A network error means we *think* we're logged in, and we tried to
-		// confirm with the API server. In that case we'll swallow the error
-		// and allow control to proceed to the gregor loop. We'll still
-		// short-circuit for any unexpected errors though.
-		switch err.(type) {
-		case libkb.LoginStateTimeoutError, libkb.APINetError:
-			d.G().Log.Debug("Network/timeout error received from LoginState, continuing onward: %s", err)
-		default:
-			d.G().Log.Debug("Unexpected non-network error in tryGregordConnect: %s", err)
-			return err
-		}
-	} else if !loggedIn {
+	loggedIn := d.G().ActiveDevice.Valid()
+	if !loggedIn {
 		// We only respect the loggedIn flag in the no-error case.
 		d.G().Log.Debug("not logged in, so not connecting to gregord")
 		return nil
 	}
-
 	return d.gregordConnect()
 }
 

--- a/go/service/rekey_master.go
+++ b/go/service/rekey_master.go
@@ -359,7 +359,7 @@ func (r *rekeyMaster) hasGregorTLFRekeyMessages() (ret bool, err error) {
 func (r *rekeyMaster) computeProblems() (nextWait time.Duration, problemsAndDevices *keybase1.ProblemSetDevices, event keybase1.RekeyEvent, err error) {
 	defer r.G().Trace("rekeyMaster#computeProblems", func() error { return err })()
 
-	if loggedIn, _, _ := libkb.IsLoggedIn(r.G(), nil); !loggedIn {
+	if !r.G().ActiveDevice.Valid() {
 		r.G().Log.Debug("| not logged in")
 		nextWait = rekeyTimeoutBackground
 		return nextWait, nil, keybase1.RekeyEvent{EventType: keybase1.RekeyEventType_NOT_LOGGED_IN}, err

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -209,7 +209,7 @@ func (h *UserHandler) loadPublicKeys(ctx context.Context, larg libkb.LoadUserArg
 func (h *UserHandler) LoadAllPublicKeysUnverified(ctx context.Context,
 	arg keybase1.LoadAllPublicKeysUnverifiedArg) (keys []keybase1.PublicKey, err error) {
 
-	u, err := libkb.LoadUserFromServer(ctx, h.G(), arg.Uid, nil)
+	u, err := libkb.LoadUserFromServer(libkb.NewMetaContext(ctx, h.G()), arg.Uid, nil)
 	if err != nil {
 		return
 	}

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -85,18 +85,10 @@ func (s *Server) ExportSecretKeyLocal(ctx context.Context, accountID stellar1.Ac
 	if err != nil {
 		return res, err
 	}
-	pwdOk := false
-	_, err = s.G().LoginState().VerifyPlaintextPassphrase(mctx, ppRes.Passphrase, func(lctx libkb.LoginContext) error {
-		pwdOk = true
-		return nil
-	})
+	_, err = libkb.VerifyPassphraseForLoggedInUser(mctx, ppRes.Passphrase)
 	if err != nil {
 		return res, err
 	}
-	if !pwdOk {
-		return res, libkb.PassphraseError{}
-	}
-
 	return stellar.ExportSecretKey(ctx, s.G(), accountID)
 }
 

--- a/go/stellar/stellarsvc/service_devel.go
+++ b/go/stellar/stellarsvc/service_devel.go
@@ -38,19 +38,10 @@ func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.Bundle, err
 	if err != nil {
 		return dump, err
 	}
-	pwdOk := false
-	_, err = s.G().LoginState().VerifyPlaintextPassphrase(mctx, res.Passphrase, func(lctx libkb.LoginContext) error {
-		pwdOk = true
-
-		return nil
-	})
+	_, err = libkb.VerifyPassphraseForLoggedInUser(mctx, res.Passphrase)
 	if err != nil {
 		return dump, err
 	}
-	if !pwdOk {
-		return dump, libkb.PassphraseError{}
-	}
-
 	dump, _, err = remote.Fetch(ctx, s.G())
 
 	return dump, err

--- a/go/systests/gregor_test.go
+++ b/go/systests/gregor_test.go
@@ -94,7 +94,6 @@ func TestGregorForwardToElectron(t *testing.T) {
 	if err := signup.Run(); err != nil {
 		t.Fatal(err)
 	}
-	tc.G.Log.Debug("Login State: %v", tc.G.LoginState())
 
 	var err error
 	check := func() {

--- a/go/systests/passphrase_test.go
+++ b/go/systests/passphrase_test.go
@@ -163,7 +163,7 @@ func TestPassphraseRecover(t *testing.T) {
 	m1 := libkb.NewMetaContextForTest(*tc1)
 
 	t.Logf("Verify on tc1")
-	_, err = tc1.G.LoginState().VerifyPlaintextPassphrase(m1, userInfo.passphrase, nil)
+	_, err = libkb.VerifyPassphraseForLoggedInUser(m1, userInfo.passphrase)
 	require.NoError(t, err)
 
 	oldPassphrase := userInfo.passphrase
@@ -189,15 +189,15 @@ func TestPassphraseRecover(t *testing.T) {
 
 	t.Logf("Verify new passphrase on tc2")
 	m2 := libkb.NewMetaContextForTest(*tc2)
-	_, err = tc2.G.LoginState().VerifyPlaintextPassphrase(m2, newPassphrase, nil)
+	_, err = libkb.VerifyPassphraseForLoggedInUser(m2, newPassphrase)
 	require.NoError(t, err)
 
 	t.Logf("Verify new passphrase on tc1")
-	_, err = tc2.G.LoginState().VerifyPlaintextPassphrase(m2, newPassphrase, nil)
+	_, err = libkb.VerifyPassphraseForLoggedInUser(m1, newPassphrase)
 	require.NoError(t, err)
 
 	t.Logf("Verify old passphrase on tc1")
-	_, err = tc1.G.LoginState().VerifyPlaintextPassphrase(m2, oldPassphrase, nil)
+	_, err = libkb.VerifyPassphraseForLoggedInUser(m1, oldPassphrase)
 	require.Error(t, err, "old passphrase passed verification after passphrase change")
 
 	t.Logf("Stop tc1")

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -689,10 +689,7 @@ func (u *userPlusDevice) provisionNewDevice() *deviceWrapper {
 	require.NoError(t, err, "login")
 
 	// Clear the paper key.
-	err = g.LoginState().Account(func(a *libkb.Account) {
-		a.ClearPaperKeys()
-	}, "provisionNewDevice")
-	require.NoError(t, err, "clear paper key")
+	g.ActiveDevice.ClearCaches()
 
 	skey, err := g.ActiveDevice.SigningKey()
 	require.NoError(t, err)

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -131,8 +131,6 @@ func TestTrackingNotifications(t *testing.T) {
 	if err := signup.Run(); err != nil {
 		t.Fatal(err)
 	}
-	tc2.G.Log.Debug("Login State: %v", tc2.G.LoginState())
-
 	nh := newTrackingNotifyHandler()
 
 	// Launch the server that will listen for tracking notifications.

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -299,7 +299,6 @@ func TestSignupLogout(t *testing.T) {
 	if err := signup.Run(); err != nil {
 		t.Fatal(err)
 	}
-	tc2.G.Log.Debug("Login State: %v", tc2.G.LoginState())
 	select {
 	case err := <-nh.errCh:
 		t.Fatalf("Error before notify: %v", err)

--- a/go/tools/sigchain/main.go
+++ b/go/tools/sigchain/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -97,19 +96,21 @@ func main() {
 		iterations = 10
 	}
 
+	m := libkb.NewMetaContextBackground(g)
+
 	for i := 0; i < iterations; i++ {
 		start := time.Now()
 		sc = &libkb.SigChain{Contextified: libkb.NewContextified(g)}
 		sc.SetUIDUsername(keybase1.UID(*uid), *username)
-		if _, err := sc.LoadServerBody(context.Background(), raw, 0, nil, ""); err != nil {
+		if _, err := sc.LoadServerBody(m, raw, 0, nil, ""); err != nil {
 			errout(err.Error())
 		}
 
-		if err := sc.VerifyChain(context.Background()); err != nil {
+		if err := sc.VerifyChain(m); err != nil {
 			errout(err.Error())
 		}
 
-		if err := sc.Store(context.Background()); err != nil {
+		if err := sc.Store(m); err != nil {
 			errout(err.Error())
 		}
 		elapsed := time.Since(start)


### PR DESCRIPTION
- never use old-style Account-based API args -- this fixes a horrible bug in engine tests, which slowed them way way down.
- make sure that it always works to use the new ones in the metacontext
- also, modernize, sort-of, loading users and sigchains, since we need to now plumb metacontexts all the way through