### PR TITLE
Log errors on ClearSecrets instead of returning them

### DIFF
--- a/go/engine/deprovision.go
+++ b/go/engine/deprovision.go
@@ -75,8 +75,7 @@ func (e *DeprovisionEngine) attemptLoggedInRevoke(m libkb.MetaContext) error {
 			ForceLast: true,
 		}
 		revokeEng := NewRevokeDeviceEngine(m.G(), revokeArg)
-		err = revokeEng.Run(m)
-		if err != nil {
+		if err = revokeEng.Run(m); err != nil {
 			m.CDebugf("DeprovisionEngine error during revoke: %s", err)
 			return err
 		}
@@ -108,5 +107,8 @@ func (e *DeprovisionEngine) Run(m libkb.MetaContext) (err error) {
 		}
 	}
 
-	return libkb.ClearSecretsOnDeprovision(m, e.username)
+	if err = libkb.ClearSecretsOnDeprovision(m, e.username); err != nil {
+		m.CDebugf("DeprovisionEngine error during clear secrets: %s", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Instead of returning an error from `ClearSecretsOnDeprovision` we log it. `ClearSecretsOnDeprovision` does best effort deletion, charging through the various things we nuke if there are any errors so if there are any it's probably more useful as informational than alerting the user.