### PR TITLE
tweak ephemeral snippets, show sender when more than 2 participants

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -853,8 +853,7 @@ func TestChatSrvGetInboxNonblockLocalMetadata(t *testing.T) {
 						continue
 					}
 					require.Equal(t, fmt.Sprintf("%d", numconvs-index-1), conv.LocalMetadata.ChannelName)
-					require.Equal(t, fmt.Sprintf("%s: %d", users[numconvs-index-1].Username, numconvs-index-1),
-						conv.LocalMetadata.Snippet)
+					require.Equal(t, fmt.Sprintf("%d", numconvs-index-1), conv.LocalMetadata.Snippet)
 					require.Zero(t, len(conv.LocalMetadata.WriterNames))
 				default:
 					require.Equal(t, fmt.Sprintf("%d", numconvs-index), conv.LocalMetadata.Snippet)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -853,7 +853,8 @@ func TestChatSrvGetInboxNonblockLocalMetadata(t *testing.T) {
 						continue
 					}
 					require.Equal(t, fmt.Sprintf("%d", numconvs-index-1), conv.LocalMetadata.ChannelName)
-					require.Equal(t, fmt.Sprintf("%d", numconvs-index-1), conv.LocalMetadata.Snippet)
+					require.Equal(t, fmt.Sprintf("%s: %d", users[numconvs-index-1].Username, numconvs-index-1),
+						conv.LocalMetadata.Snippet)
 					require.Zero(t, len(conv.LocalMetadata.WriterNames))
 				default:
 					require.Equal(t, fmt.Sprintf("%d", numconvs-index), conv.LocalMetadata.Snippet)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -795,14 +795,16 @@ func systemMessageSnippet(msg chat1.MessageSystem) string {
 	}
 }
 
-func GetMsgSnippet(msg chat1.MessageUnboxed, conv chat1.ConversationLocal, currentUsername string) string {
-	if !msg.IsValid() {
-		return ""
+// Sender prefix for msg snippets. Will show if a conversation has > 2 members
+// or is of type TEAM
+func getSenderPrefix(mvalid chat1.MessageUnboxedValid, conv chat1.ConversationLocal, currentUsername string) (senderPrefix string) {
+	var showPrefix bool
+	switch conv.GetMembersType() {
+	case chat1.ConversationMembersType_TEAM:
+		showPrefix = true
 	}
 
-	mvalid := msg.Valid()
-	var senderPrefix string
-	if len(conv.Names()) > 2 {
+	if showPrefix || len(conv.Names()) > 2 {
 		sender := mvalid.SenderUsername
 		if sender == currentUsername {
 			senderPrefix = "You: "
@@ -810,6 +812,16 @@ func GetMsgSnippet(msg chat1.MessageUnboxed, conv chat1.ConversationLocal, curre
 			senderPrefix = fmt.Sprintf("%s: ", sender)
 		}
 	}
+	return senderPrefix
+}
+
+func GetMsgSnippet(msg chat1.MessageUnboxed, conv chat1.ConversationLocal, currentUsername string) string {
+	if !msg.IsValid() {
+		return ""
+	}
+
+	mvalid := msg.Valid()
+	senderPrefix := getSenderPrefix(mvalid, conv, currentUsername)
 
 	if !msg.IsValidFull() {
 		if mvalid.IsEphemeral() && mvalid.IsEphemeralExpired(time.Now()) {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -802,9 +802,11 @@ func getSenderPrefix(mvalid chat1.MessageUnboxedValid, conv chat1.ConversationLo
 	switch conv.GetMembersType() {
 	case chat1.ConversationMembersType_TEAM:
 		showPrefix = true
+	default:
+		showPrefix = len(conv.Names()) > 2
 	}
 
-	if showPrefix || len(conv.Names()) > 2 {
+	if showPrefix {
 		sender := mvalid.SenderUsername
 		if sender == currentUsername {
 			senderPrefix = "You: "


### PR DESCRIPTION
cc @buoyad @malgorithms 

PR addresses two things:

1. Tweaks how ephemeral messages are displayed in inbox snippets in exploded/unexploded state:
<img width="244" alt="screen shot 2018-05-31 at 10 18 35 am" src="https://user-images.githubusercontent.com/1144020/40787756-612bd510-64bc-11e8-9b29-8ade190d3574.png">
<img width="232" alt="screen shot 2018-05-31 at 10 19 05 am" src="https://user-images.githubusercontent.com/1144020/40787757-613eff8c-64bc-11e8-8c8b-00dac3c8279a.png">
note: the number of dashes shown may get truncated (as in the screenshot) depending on the length of the username. is that ok?

2. Shows the sender information for conversations with more than two participants. This means for a TEAM with <=2 people sender info is now hidden, we could always display this for TEAMs and check the number of participants otherwise but i think it's more consistent as is. 

