### PR TITLE
ignore results from rpc that don't apply anymore

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1147,6 +1147,16 @@ const previewConversationAfterFindExisting = (
   const results: ?RPCChatTypes.FindConversationsLocalRes = _fromPreviewConversation[1]
   const users: Array<string> = _fromPreviewConversation[2]
 
+  // still looking for this result?
+  if (
+    !Constants.getMeta(state, Constants.pendingConversationIDKey)
+      .participants.toSet()
+      .equals(I.Set(users))
+  ) {
+    console.log('Ignorning old preview find due to participant mismatch')
+    return
+  }
+
   let existingConversationIDKey
 
   const isTeam =


### PR DESCRIPTION
this solves the case where you search for multiple users and get older results
can cause you to start a convo with a subset of people you're searching for
@keybase/react-hackers 