### PR TITLE
Allow desktop notifications

### DIFF
--- a/shared/desktop/app/main-window.desktop.js
+++ b/shared/desktop/app/main-window.desktop.js
@@ -15,9 +15,13 @@ export default function() {
   // download for webviews. If we decide to start using partitions for
   // webviews, we should make sure to attach this to those partitions too.
   SafeElectron.getSession().defaultSession.on('will-download', event => event.preventDefault())
-  // Disallow any permissions requests
+  // Disallow any permissions requests except for notifications
   SafeElectron.getSession().defaultSession.setPermissionRequestHandler(
     (webContents, permission, callback) => {
+      if (permission === 'notifications') {
+        // Allow notifications
+        return callback(true)
+      }
       return callback(false)
     }
   )


### PR DESCRIPTION
It'd be nice to do an additional check here, but I'm not sure how to do it in a foolproof way. The docs switch on `webContents.fileURL()`, which for us is `file:///.../{GOPATH stuff}/shared/desktop/renderer/renderer.dev.html?mainWindow&react_perf`. r? @keybase/react-hackers 