### PR TITLE
don't search KBFS conversations anymore when finding by name

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -672,6 +672,11 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 	oneChatPerTLF *bool) (res []chat1.ConversationLocal, err error) {
 
 	findConvosWithMembersType := func(membersType chat1.ConversationMembersType) (res []chat1.ConversationLocal, err error) {
+		// Don't look for KBFS conversations anymore, they have mostly been converted, and it is better
+		// to just not search for them than to create a double conversation.
+		if membersType == chat1.ConversationMembersType_KBFS {
+			return nil, nil
+		}
 
 		query := &chat1.GetInboxLocalQuery{
 			Name: &chat1.NameQuery{

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -1097,8 +1097,8 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 		if err != nil {
 			return res, fmt.Errorf("error creating topic ID: %s", err)
 		}
-		n.Debug(ctx, "attempt: %v [tlfID: %s topicType: %d topicID: %s name: %s public: %v]", i, triple.Tlfid,
-			triple.TopicType, triple.TopicID, info.CanonicalName, isPublic)
+		n.Debug(ctx, "attempt: %v [tlfID: %s topicType: %d topicID: %s name: %s public: %v mt: %v]", i,
+			triple.Tlfid, triple.TopicType, triple.TopicID, info.CanonicalName, isPublic, n.membersType)
 		firstMessageBoxed, topicNameState, err := n.makeFirstMessage(ctx, triple, info.CanonicalName,
 			n.membersType, n.vis, n.topicName)
 		if err != nil {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -690,6 +690,9 @@ func TestChatSrvNewConversationMultiTeam(t *testing.T) {
 		_, err = tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
 		require.Error(t, err)
 		topicName = ""
+		if mt == chat1.ConversationMembersType_KBFS {
+			arg.TopicName = nil
+		}
 		_, err = tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
 		switch mt {
 		case chat1.ConversationMembersType_KBFS:
@@ -697,6 +700,7 @@ func TestChatSrvNewConversationMultiTeam(t *testing.T) {
 		case chat1.ConversationMembersType_TEAM:
 			require.Error(t, err)
 		}
+		arg.TopicName = &topicName
 		topicName = "dskjdskdjskdjskdjskdjskdjskdjskjdskjdskdskdjksdjks"
 		_, err = tc.chatLocalHandler().NewConversationLocal(tc.startCtx, arg)
 		require.Error(t, err)
@@ -2145,8 +2149,8 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 
 func TestChatSrvFindConversations(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
-		// XXX: Public chats can't work with teams yet
-		if mt == chat1.ConversationMembersType_TEAM {
+		switch mt {
+		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_KBFS:
 			return
 		}
 
@@ -3950,7 +3954,6 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Conversations), "conv found")
 		consumeIdentify(ctx, listener0) // impteam
-		consumeIdentify(ctx, listener0) // kbfs
 
 		// create a new conversation
 		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
@@ -3963,7 +3966,6 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			})
 		require.NoError(t, err)
 		consumeIdentify(ctx, listener0) //impteam
-		consumeIdentify(ctx, listener0) //kbfs
 		consumeIdentify(ctx, listener0) //encrypt for first message
 
 		uid := users[0].User.GetUID().ToBytes()


### PR DESCRIPTION
We make the decision to not lookup names -> TLF ID anymore for finding chat conversations. Most chat conversations have been converted to implicit teams, and there are performance problems when hitting the KBFS daemon. The downside is that if someone does have a KBFS chat straggler, then this will cause them to get two conversations in their inbox (if they go through the new conversation flow at all). 

cc @maxtaco @malgorithms @chrisnojima 