### PR TITLE
team.change badge dismissal optimization

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1147,6 +1147,7 @@ type TeamChangeRow struct {
 	LatestSeqno       Seqno  `codec:"latestSeqno" json:"latest_seqno"`
 	ImplicitTeam      bool   `codec:"implicitTeam" json:"implicit_team"`
 	Misc              bool   `codec:"misc" json:"misc"`
+	RemovedResetUsers bool   `codec:"removedResetUsers" json:"removed_reset_users"`
 }
 
 func (o TeamChangeRow) DeepCopy() TeamChangeRow {
@@ -1158,6 +1159,7 @@ func (o TeamChangeRow) DeepCopy() TeamChangeRow {
 		LatestSeqno:       o.LatestSeqno.DeepCopy(),
 		ImplicitTeam:      o.ImplicitTeam,
 		Misc:              o.Misc,
+		RemovedResetUsers: o.RemovedResetUsers,
 	}
 }
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -389,6 +389,8 @@ protocol teams {
     boolean implicitTeam;
     @jsonkey("misc")
     boolean misc;
+    @jsonkey("removed_reset_users")
+    boolean removedResetUsers;
   }
 
   record TeamExitRow {

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -3774,7 +3774,7 @@ export type TeamCLKRResetUser = $ReadOnly<{uid: UID, userEldestSeqno: Seqno, mem
 
 export type TeamChangeReq = $ReadOnly<{owners?: ?Array<UserVersion>, admins?: ?Array<UserVersion>, writers?: ?Array<UserVersion>, readers?: ?Array<UserVersion>, none?: ?Array<UserVersion>, completedInvites: {[key: string]: UserVersionPercentForm}}>
 
-export type TeamChangeRow = $ReadOnly<{id: TeamID, name: String, keyRotated: Boolean, membershipChanged: Boolean, latestSeqno: Seqno, implicitTeam: Boolean, misc: Boolean}>
+export type TeamChangeRow = $ReadOnly<{id: TeamID, name: String, keyRotated: Boolean, membershipChanged: Boolean, latestSeqno: Seqno, implicitTeam: Boolean, misc: Boolean, removedResetUsers: Boolean}>
 
 export type TeamChangeSet = $ReadOnly<{membershipChanged: Boolean, keyRotated: Boolean, renamed: Boolean, misc: Boolean}>
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -954,6 +954,11 @@
           "type": "boolean",
           "name": "misc",
           "jsonkey": "misc"
+        },
+        {
+          "type": "boolean",
+          "name": "removedResetUsers",
+          "jsonkey": "removed_reset_users"
         }
       ]
     },

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -3774,7 +3774,7 @@ export type TeamCLKRResetUser = $ReadOnly<{uid: UID, userEldestSeqno: Seqno, mem
 
 export type TeamChangeReq = $ReadOnly<{owners?: ?Array<UserVersion>, admins?: ?Array<UserVersion>, writers?: ?Array<UserVersion>, readers?: ?Array<UserVersion>, none?: ?Array<UserVersion>, completedInvites: {[key: string]: UserVersionPercentForm}}>
 
-export type TeamChangeRow = $ReadOnly<{id: TeamID, name: String, keyRotated: Boolean, membershipChanged: Boolean, latestSeqno: Seqno, implicitTeam: Boolean, misc: Boolean}>
+export type TeamChangeRow = $ReadOnly<{id: TeamID, name: String, keyRotated: Boolean, membershipChanged: Boolean, latestSeqno: Seqno, implicitTeam: Boolean, misc: Boolean, removedResetUsers: Boolean}>
 
 export type TeamChangeSet = $ReadOnly<{membershipChanged: Boolean, keyRotated: Boolean, renamed: Boolean, misc: Boolean}>
 


### PR DESCRIPTION
Only look to dismiss reset user badges when server sends `RemovedResetUsers=true` in `team.change` message.

Expecting CI failure: https://github.com/keybase/keybase/pull/2518 has to land first.