### PR TITLE
bump Linux build Go version to 1.10.2

### DIFF
--- a/packaging/linux/Dockerfile
+++ b/packaging/linux/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update
 RUN apt-get install -y nodejs yarn
 
 # Install Go directly from Google, because the Debian repos tend to be behind.
-RUN wget "https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz" -O /root/go.tar
+RUN wget "https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz" -O /root/go.tar
 RUN tar -C /usr/local -xzf /root/go.tar
 RUN rm /root/go.tar
 ENV PATH "$PATH:/usr/local/go/bin"

--- a/packaging/linux/docker_build.sh
+++ b/packaging/linux/docker_build.sh
@@ -59,7 +59,7 @@ gpg_tempfile="$gpg_tempdir/code_signing_key"
 gpg --export-secret-key --armor "$code_signing_fingerprint" > "$gpg_tempfile"
 
 # Make sure the Docker image is built.
-image=keybase_packaging_v15
+image=keybase_packaging_v16
 if [ -z "$(docker images -q "$image")" ] ; then
   echo "Docker image '$image' not yet built. Building..."
   docker build -t "$image" "$clientdir/packaging/linux"


### PR DESCRIPTION
r? @mmaxim 

You were right, we were already on 1.10. This is a patch version bump.