### PR TITLE
Autoclaim relay payments (client)

### DIFF
--- a/go/client/cmd_wallet_send.go
+++ b/go/client/cmd_wallet_send.go
@@ -14,13 +14,13 @@ import (
 	"golang.org/x/net/context"
 )
 
-type cmdWalletSend struct {
+type CmdWalletSend struct {
 	libkb.Contextified
-	recipient     string
-	amount        string
-	note          string
-	localCurrency string
-	forceRelay    bool
+	Recipient     string
+	Amount        string
+	Note          string
+	LocalCurrency string
+	ForceRelay    bool
 }
 
 func newCmdWalletSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -36,7 +36,7 @@ func newCmdWalletSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 			Usage: "Force a relay transfer (dev-only)",
 		})
 	}
-	cmd := &cmdWalletSend{
+	cmd := &CmdWalletSend{
 		Contextified: libkb.NewContextified(g),
 	}
 	return cli.Command{
@@ -50,27 +50,27 @@ func newCmdWalletSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 	}
 }
 
-func (c *cmdWalletSend) ParseArgv(ctx *cli.Context) error {
+func (c *CmdWalletSend) ParseArgv(ctx *cli.Context) error {
 	if len(ctx.Args()) > 3 {
 		return errors.New("send expects at most three arguments")
 	} else if len(ctx.Args()) < 2 {
 		return errors.New("send expects at least two arguments (recipient and amount)")
 	}
 
-	c.recipient = ctx.Args()[0]
-	c.amount = ctx.Args()[1]
+	c.Recipient = ctx.Args()[0]
+	c.Amount = ctx.Args()[1]
 	if len(ctx.Args()) == 3 {
-		c.localCurrency = strings.ToUpper(ctx.Args()[2])
-		if len(c.localCurrency) != 3 {
+		c.LocalCurrency = strings.ToUpper(ctx.Args()[2])
+		if len(c.LocalCurrency) != 3 {
 			return errors.New("Invalid currency code")
 		}
 	}
-	c.note = ctx.String("message")
-	c.forceRelay = ctx.Bool("relay")
+	c.Note = ctx.String("message")
+	c.ForceRelay = ctx.Bool("relay")
 	return nil
 }
 
-func (c *cmdWalletSend) Run() error {
+func (c *CmdWalletSend) Run() error {
 	cli, err := GetWalletClient(c.G())
 	if err != nil {
 		return err
@@ -85,40 +85,40 @@ func (c *cmdWalletSend) Run() error {
 
 	ui := c.G().UI.GetTerminalUI()
 
-	amount := c.amount
+	amount := c.Amount
 	amountDesc := fmt.Sprintf("%s XLM", amount)
 
 	var displayAmount, displayCurrency string
 
-	if c.localCurrency != "" && c.localCurrency != "XLM" {
-		exchangeRate, err := cli.ExchangeRateLocal(context.Background(), stellar1.OutsideCurrencyCode(c.localCurrency))
+	if c.LocalCurrency != "" && c.LocalCurrency != "XLM" {
+		exchangeRate, err := cli.ExchangeRateLocal(context.Background(), stellar1.OutsideCurrencyCode(c.LocalCurrency))
 		if err != nil {
-			return fmt.Errorf("Unable to get exchange rate for %q: %s", c.localCurrency, err)
+			return fmt.Errorf("Unable to get exchange rate for %q: %s", c.LocalCurrency, err)
 		}
 
-		amount, err = stellar.ConvertLocalToXLM(c.amount, exchangeRate)
+		amount, err = stellar.ConvertLocalToXLM(c.Amount, exchangeRate)
 		if err != nil {
 			return err
 		}
 
-		ui.Printf("Current exchange rate: ~ %s %s / XLM\n", exchangeRate.Rate, c.localCurrency)
-		amountDesc = fmt.Sprintf("%s XLM (~%s %s)", amount, c.amount, c.localCurrency)
-		displayAmount = c.amount
-		displayCurrency = c.localCurrency
+		ui.Printf("Current exchange rate: ~ %s %s / XLM\n", exchangeRate.Rate, c.LocalCurrency)
+		amountDesc = fmt.Sprintf("%s XLM (~%s %s)", amount, c.Amount, c.LocalCurrency)
+		displayAmount = c.Amount
+		displayCurrency = c.LocalCurrency
 	}
 
-	if err := ui.PromptForConfirmation(fmt.Sprintf("Send %s to %s?", ColorString(c.G(), "green", amountDesc), ColorString(c.G(), "yellow", c.recipient))); err != nil {
+	if err := ui.PromptForConfirmation(fmt.Sprintf("Send %s to %s?", ColorString(c.G(), "green", amountDesc), ColorString(c.G(), "yellow", c.Recipient))); err != nil {
 		return err
 	}
 
 	arg := stellar1.SendCLILocalArg{
-		Recipient:       c.recipient,
+		Recipient:       c.Recipient,
 		Amount:          amount,
 		Asset:           stellar1.AssetNative(),
-		Note:            c.note,
+		Note:            c.Note,
 		DisplayAmount:   displayAmount,
 		DisplayCurrency: displayCurrency,
-		ForceRelay:      c.forceRelay,
+		ForceRelay:      c.ForceRelay,
 	}
 	res, err := cli.SendCLILocal(context.Background(), arg)
 	if err != nil {
@@ -130,7 +130,7 @@ func (c *cmdWalletSend) Run() error {
 	return nil
 }
 
-func (c *cmdWalletSend) GetUsage() libkb.Usage {
+func (c *CmdWalletSend) GetUsage() libkb.Usage {
 	return libkb.Usage{
 		Config:    true,
 		API:       true,

--- a/go/client/stellar_common.go
+++ b/go/client/stellar_common.go
@@ -62,11 +62,12 @@ func printPayment(g *libkb.GlobalContext, p stellar1.PaymentCLILocal, verbose bo
 	if verbose {
 		line("Transaction Hash: %v", p.TxID)
 	}
-	switch p.Status {
-	case "", "completed":
+	switch {
+	case p.Status == "":
+	case cicmp(p.Status, "completed"):
 	default:
 		color := "red"
-		if p.Status == "claimable" {
+		if cicmp(p.Status, "claimable") {
 			color = "yellow"
 		}
 		line("Status: %v", ColorString(g, color, p.Status))
@@ -83,4 +84,8 @@ func printPaymentFilterNote(note string) string {
 		return ""
 	}
 	return strings.TrimSpace(lines[0])
+}
+
+func cicmp(a, b string) bool {
+	return strings.ToLower(a) == strings.ToLower(b)
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -619,12 +619,12 @@ type TeamLoader interface {
 }
 
 type Stellar interface {
+	OnLogout()
 	CreateWalletGated(context.Context) (bool, error)
 	CreateWalletSoft(context.Context)
 	Upkeep(context.Context) error
-	OnLogout()
-
 	GetServerDefinitions(context.Context) (stellar1.StellarServerDefinitions, error)
+	KickAutoClaimRunner(MetaContext, gregor.MsgID)
 }
 
 type DeviceEKStorage interface {

--- a/go/libkb/stellar_stub.go
+++ b/go/libkb/stellar_stub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keybase/client/go/gregor"
 	stellar1 "github.com/keybase/client/go/protocol/stellar1"
 )
 
@@ -17,6 +18,8 @@ func newNullStellar(g *GlobalContext) *nullStellar {
 	return &nullStellar{NewContextified(g)}
 }
 
+func (n *nullStellar) OnLogout() {}
+
 func (n *nullStellar) CreateWalletGated(ctx context.Context) (bool, error) {
 	return false, fmt.Errorf("null stellar impl")
 }
@@ -29,8 +32,8 @@ func (n *nullStellar) Upkeep(ctx context.Context) error {
 	return fmt.Errorf("null stellar impl")
 }
 
-func (n *nullStellar) OnLogout() {}
-
 func (n *nullStellar) GetServerDefinitions(ctx context.Context) (ret stellar1.StellarServerDefinitions, err error) {
 	return ret, fmt.Errorf("null stellar impl")
 }
+
+func (n *nullStellar) KickAutoClaimRunner(MetaContext, gregor.MsgID) {}

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -501,7 +501,7 @@ func (t TestUIDMapper) SetTestingNoCachingMode(enabled bool) {
 }
 
 func NewMetaContextForTest(tc TestContext) MetaContext {
-	return NewMetaContext(context.TODO(), tc.G)
+	return NewMetaContext(context.TODO(), tc.G).WithLogTag("TST")
 }
 
 func NewMetaContextForTestWithLogUI(tc TestContext) MetaContext {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -35,6 +35,8 @@ import (
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/pvlsource"
 	"github.com/keybase/client/go/stellar"
+	"github.com/keybase/client/go/stellar/remote"
+	"github.com/keybase/client/go/stellar/stellargregor"
 	"github.com/keybase/client/go/systemd"
 	"github.com/keybase/client/go/teams"
 	"github.com/keybase/client/go/tlfupgrade"
@@ -312,7 +314,7 @@ func (d *Service) setupTeams() error {
 }
 
 func (d *Service) setupStellar() error {
-	stellar.ServiceInit(d.G())
+	stellar.ServiceInit(d.G(), remote.NewRemoteNet(d.G()))
 	return nil
 }
 
@@ -505,6 +507,7 @@ func (d *Service) startupGregor() {
 		d.gregor.PushHandler(newRekeyLogHandler(d.G()))
 
 		d.gregor.PushHandler(newTeamHandler(d.G(), d.badger))
+		d.gregor.PushHandler(stellargregor.New(d.G(), remote.NewRemoteNet(d.G())))
 		d.gregor.PushHandler(d.home)
 		d.gregor.PushHandler(newEKHandler(d.G()))
 		d.gregor.PushHandler(newAvatarGregorHandler(d.G(), d.avatarLoader))

--- a/go/stellar/autoclaim.go
+++ b/go/stellar/autoclaim.go
@@ -1,0 +1,146 @@
+package stellar
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/gregor"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/keybase/client/go/stellar/remote"
+)
+
+// Claims relay payments in the background.
+// Threadsafe.
+type AutoClaimRunner struct {
+	startOnce  sync.Once
+	shutdownCh chan struct{}
+	kickCh     chan gregor.MsgID
+	remoter    remote.Remoter
+}
+
+func NewAutoClaimRunner(remoter remote.Remoter) *AutoClaimRunner {
+	return &AutoClaimRunner{
+		shutdownCh: make(chan struct{}, 1),
+		kickCh:     make(chan gregor.MsgID, 1),
+		remoter:    remoter,
+	}
+}
+
+// Kick the processor into gear.
+// It will run until all relays in the queue are claimed.
+// And then dismiss the gregor message.
+// `trigger` is of the gregor message that caused the kick.
+func (r *AutoClaimRunner) Kick(mctx libkb.MetaContext, trigger gregor.MsgID) {
+	mctx.CDebugf("AutoClaimRunner.Kick(trigger:%v)", trigger)
+	var onced bool
+	r.startOnce.Do(func() {
+		onced = true
+		go r.loop(libkb.NewMetaContextBackground(mctx.G()), trigger)
+	})
+	if !onced {
+		select {
+		case r.kickCh <- trigger:
+		default:
+		}
+	}
+}
+
+func (r *AutoClaimRunner) Shutdown(mctx libkb.MetaContext) {
+	mctx.CDebugf("AutoClaimRunner.Shutdown")
+	close(r.shutdownCh)
+}
+
+func (r *AutoClaimRunner) loop(mctx libkb.MetaContext, trigger gregor.MsgID) {
+	var i int
+	for {
+		i++
+		mctx := mctx.WithLogTag("ACR") // shadow mctx for this round with a log tag
+		log := func(format string, args ...interface{}) {
+			mctx.CDebugf(fmt.Sprintf("AutoClaimRunnner round[%v] ", i) + fmt.Sprintf(format, args...))
+		}
+		action, err := r.step(mctx, i, trigger)
+		if err != nil {
+			log("error: %v", err)
+		}
+		log("action: %v", action)
+		switch action {
+		case "fast":
+			// Go again
+		case "hibernate":
+			// Wait for a kick
+			select {
+			case trigger = <-r.kickCh:
+			case <-r.shutdownCh:
+				return
+			}
+		case "snooze":
+			fallthrough
+		default:
+			// Pause for a few minutes
+			select {
+			case <-time.After(2 * time.Minute):
+			case trigger = <-r.kickCh:
+			case <-r.shutdownCh:
+				return
+			}
+		}
+	}
+}
+
+func (r *AutoClaimRunner) step(mctx libkb.MetaContext, i int, trigger gregor.MsgID) (action string, err error) {
+	log := func(format string, args ...interface{}) {
+		mctx.CDebugf(fmt.Sprintf("AutoClaimRunnner round[%v] ", i) + fmt.Sprintf(format, args...))
+	}
+	log("step begin")
+	token, err := r.remoter.AcquireAutoClaimLock(mctx.Ctx())
+	if err != nil {
+		return "snooze", err
+	}
+	if len(token) == 0 {
+		log("autoclaim lock is busy")
+		return "snooze", nil
+	}
+	defer func() {
+		rerr := r.remoter.ReleaseAutoClaimLock(mctx.Ctx(), token)
+		if rerr != nil {
+			log("error releasing autoclaim lock: %v", rerr)
+		}
+	}()
+	ac, err := r.remoter.NextAutoClaim(mctx.Ctx())
+	if err != nil {
+		return "snooze", err
+	}
+	if ac == nil {
+		log("no more autoclaims")
+		log("dismissing kick: %v", trigger)
+		err = mctx.G().GregorDismisser.DismissItem(mctx.Ctx(), nil, trigger)
+		if err != nil {
+			log("error dismissing gregor kick: %v", err)
+		}
+		log("successfully dismissed kick")
+		return "hibernate", nil
+	}
+	log("got next autoclaim: %v", ac.KbTxID)
+	err = r.claim1(mctx, ac.KbTxID, token)
+	if err != nil {
+		return "snooze", err
+	}
+	log("successfully claimed: %v", ac.KbTxID)
+	return "fast", nil
+}
+
+func (r *AutoClaimRunner) claim1(mctx libkb.MetaContext, kbTxID stellar1.KeybaseTransactionID, token string) (err error) {
+	CreateWalletSoft(mctx.Ctx(), mctx.G())
+	into, err := GetOwnPrimaryAccountID(mctx.Ctx(), mctx.G())
+	if err != nil {
+		return err
+	}
+	// Explicitly CLAIM. We don't want to accidentally auto YANK.
+	dir := stellar1.RelayDirection_CLAIM
+	// Use the user's autoclaim lock that we acquired.
+	_, err = Claim(mctx.Ctx(), mctx.G(), r.remoter,
+		kbTxID.String(), into, &dir, &token)
+	return err
+}

--- a/go/stellar/remote/interface.go
+++ b/go/stellar/remote/interface.go
@@ -13,6 +13,9 @@ type Remoter interface {
 	SubmitPayment(ctx context.Context, post stellar1.PaymentDirectPost) (stellar1.PaymentResult, error)
 	SubmitRelayPayment(ctx context.Context, post stellar1.PaymentRelayPost) (stellar1.PaymentResult, error)
 	SubmitRelayClaim(context.Context, stellar1.RelayClaimPost) (stellar1.RelayClaimResult, error)
+	AcquireAutoClaimLock(context.Context) (string, error)
+	ReleaseAutoClaimLock(context.Context, string) error
+	NextAutoClaim(context.Context) (*stellar1.AutoClaim, error)
 	RecentPayments(ctx context.Context, accountID stellar1.AccountID, limit int) (res []stellar1.PaymentSummary, err error)
 	PaymentDetail(ctx context.Context, txID string) (res stellar1.PaymentSummary, err error)
 	// GetAccountDisplayCurrency is not used as a mock now - since this

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -335,6 +335,58 @@ func SubmitRelayClaim(ctx context.Context, g *libkb.GlobalContext, post stellar1
 	return res.RelayClaimResult, nil
 }
 
+type acquireAutoClaimLockResult struct {
+	libkb.AppStatusEmbed
+	Result string `json:"result"`
+}
+
+func AcquireAutoClaimLock(ctx context.Context, g *libkb.GlobalContext) (string, error) {
+	apiArg := libkb.APIArg{
+		Endpoint:    "stellar/acquireautoclaimlock",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		NetContext:  ctx,
+	}
+	var res acquireAutoClaimLockResult
+	if err := g.API.PostDecode(apiArg, &res); err != nil {
+		return "", err
+	}
+	return res.Result, nil
+}
+
+func ReleaseAutoClaimLock(ctx context.Context, g *libkb.GlobalContext, token string) error {
+	payload := make(libkb.JSONPayload)
+	payload["token"] = token
+	apiArg := libkb.APIArg{
+		Endpoint:    "stellar/releaseautoclaimlock",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		JSONPayload: payload,
+		NetContext:  ctx,
+	}
+	var res libkb.AppStatusEmbed
+	if err := g.API.PostDecode(apiArg, &res); err != nil {
+		return err
+	}
+	return nil
+}
+
+type nextAutoClaimResult struct {
+	libkb.AppStatusEmbed
+	Result *stellar1.AutoClaim `json:"result"`
+}
+
+func NextAutoClaim(ctx context.Context, g *libkb.GlobalContext) (*stellar1.AutoClaim, error) {
+	apiArg := libkb.APIArg{
+		Endpoint:    "stellar/nextautoclaim",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		NetContext:  ctx,
+	}
+	var res nextAutoClaimResult
+	if err := g.API.PostDecode(apiArg, &res); err != nil {
+		return nil, err
+	}
+	return res.Result, nil
+}
+
 type recentPaymentsResult struct {
 	libkb.AppStatusEmbed
 	Result []stellar1.PaymentSummary `json:"res"`

--- a/go/stellar/remote/remote_net.go
+++ b/go/stellar/remote/remote_net.go
@@ -42,6 +42,18 @@ func (r *RemoteNet) SubmitRelayClaim(ctx context.Context, post stellar1.RelayCla
 	return SubmitRelayClaim(ctx, r.G(), post)
 }
 
+func (r *RemoteNet) AcquireAutoClaimLock(ctx context.Context) (string, error) {
+	return AcquireAutoClaimLock(ctx, r.G())
+}
+
+func (r *RemoteNet) ReleaseAutoClaimLock(ctx context.Context, token string) error {
+	return ReleaseAutoClaimLock(ctx, r.G(), token)
+}
+
+func (r *RemoteNet) NextAutoClaim(ctx context.Context) (*stellar1.AutoClaim, error) {
+	return NextAutoClaim(ctx, r.G())
+}
+
 func (r *RemoteNet) RecentPayments(ctx context.Context, accountID stellar1.AccountID, limit int) (res []stellar1.PaymentSummary, err error) {
 	return RecentPayments(ctx, r.G(), accountID, limit)
 }

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -181,8 +181,9 @@ func LookupSenderPrimary(ctx context.Context, g *libkb.GlobalContext) (stellar1.
 }
 
 // TODO: handle stellar federation address rebecca*keybase.io (or rebecca*anything.wow)
-func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput) (stellarcommon.Recipient, error) {
-	res := stellarcommon.Recipient{
+func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput) (res stellarcommon.Recipient, err error) {
+	defer m.CTraceTimed("Stellar.LookupRecipient", func() error { return err })()
+	res = stellarcommon.Recipient{
 		Input: to,
 	}
 
@@ -235,7 +236,10 @@ func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput) (stel
 	username := idRes.User.Username
 
 	// load the user to get its wallet
-	user, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(m.G(), username).WithNetContext(m.Ctx()))
+	user, err := libkb.LoadUser(
+		libkb.NewLoadUserByNameArg(m.G(), username).
+			WithNetContext(m.Ctx()).
+			WithPublicKeyOptional())
 	if err != nil {
 		return res, err
 	}
@@ -395,9 +399,12 @@ func sendRelayPayment(m libkb.MetaContext, remoter remote.Remoter,
 }
 
 // Claim claims a waiting relay.
+// If `dir` is nil the direction is inferred.
 func Claim(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter,
-	txID string, into stellar1.AccountID) (res stellar1.RelayClaimResult, err error) {
-	defer g.CTraceTimed(ctx, "Stellar.ClaimPayment", func() error { return err })()
+	txID string, into stellar1.AccountID, dir *stellar1.RelayDirection,
+	autoClaimToken *string) (res stellar1.RelayClaimResult, err error) {
+	defer g.CTraceTimed(ctx, "Stellar.Claim", func() error { return err })()
+	g.Log.CDebugf(ctx, "Stellar.Claim(txID:%v, into:%v, dir:%v, autoClaimToken:%v)", txID, into, dir, autoClaimToken)
 	p, err := remoter.PaymentDetail(ctx, txID)
 	if err != nil {
 		return res, err
@@ -420,14 +427,15 @@ func Claim(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter,
 			return res, fmt.Errorf("Payment cannot be claimed. The payment failed anyway.")
 		}
 	case stellar1.PaymentSummaryType_RELAY:
-		return claimPaymentWithDetail(ctx, g, remoter, p.Relay(), into)
+		return claimPaymentWithDetail(ctx, g, remoter, p.Relay(), into, dir)
 	default:
 		return res, fmt.Errorf("unrecognized payment type: %v", typ)
 	}
 }
 
+// If `dir` is nil the direction is inferred.
 func claimPaymentWithDetail(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter,
-	p stellar1.PaymentSummaryRelay, into stellar1.AccountID) (res stellar1.RelayClaimResult, err error) {
+	p stellar1.PaymentSummaryRelay, into stellar1.AccountID, dir *stellar1.RelayDirection) (res stellar1.RelayClaimResult, err error) {
 	if p.Claim != nil && p.Claim.TxStatus == stellar1.TransactionStatus_SUCCESS {
 		recipient, _, err := g.GetUPAKLoader().Load(libkb.NewLoadUserByUIDArg(ctx, g, p.Claim.To.Uid))
 		if err != nil || recipient == nil {
@@ -447,9 +455,15 @@ func claimPaymentWithDetail(ctx context.Context, g *libkb.GlobalContext, remoter
 	if err != nil {
 		return res, err
 	}
-	dir := stellar1.RelayDirection_CLAIM
-	if p.From.Uid.Equal(g.ActiveDevice.UID()) {
-		dir = stellar1.RelayDirection_YANK
+	useDir := stellar1.RelayDirection_CLAIM
+	if dir == nil {
+		// Infer direction
+		if p.From.Uid.Equal(g.ActiveDevice.UID()) {
+			useDir = stellar1.RelayDirection_YANK
+		}
+	} else {
+		// Direction from caller
+		useDir = *dir
 	}
 	sp := NewSeqnoProvider(ctx, remoter)
 	sig, err := stellarnet.RelocateTransaction(stellarnet.SeedStr(skey.SecureNoLogString()),
@@ -459,7 +473,7 @@ func claimPaymentWithDetail(ctx context.Context, g *libkb.GlobalContext, remoter
 	}
 	return remoter.SubmitRelayClaim(ctx, stellar1.RelayClaimPost{
 		KeybaseID:         p.KbTxID,
-		Dir:               dir,
+		Dir:               useDir,
 		SignedTransaction: sig.Signed,
 	})
 }
@@ -545,7 +559,7 @@ func localizePayment(ctx context.Context, g *libkb.GlobalContext, p stellar1.Pay
 		return stellar1.PaymentCLILocal{
 			TxID:        p.TxID,
 			Time:        p.Ctime,
-			Status:      "completed",
+			Status:      "Completed",
 			Amount:      p.Amount,
 			Asset:       p.Asset,
 			FromStellar: p.From,
@@ -605,8 +619,8 @@ func localizePayment(ctx context.Context, g *libkb.GlobalContext, p stellar1.Pay
 			// If the funding tx is not complete
 			res.Status, res.StatusDetail = p.TxStatus.Details(p.TxErrMsg)
 		} else {
-			res.Status = "claimable"
-			res.StatusDetail = "Waiting for the recipient to open the app to claim, or the sender to yank."
+			res.Status = "Claimable"
+			res.StatusDetail = "Waiting for the recipient to open the app to claim, or the sender to cancel."
 		}
 		res.FromUsername, err = username(p.From.Uid)
 		if err != nil {
@@ -622,7 +636,7 @@ func localizePayment(ctx context.Context, g *libkb.GlobalContext, p stellar1.Pay
 		if p.Claim != nil {
 			if p.Claim.TxStatus == stellar1.TransactionStatus_SUCCESS {
 				// If the claim succeeded, the relay payment is done.
-				res.Status = "completed"
+				res.Status = "Completed"
 				res.ToStellar = &p.Claim.ToStellar
 				res.ToUsername, err = username(p.Claim.To.Uid)
 				if err != nil {
@@ -634,7 +648,7 @@ func localizePayment(ctx context.Context, g *libkb.GlobalContext, p stellar1.Pay
 					return res, err
 				}
 				res.Status, res.StatusDetail = p.Claim.TxStatus.Details(p.Claim.TxErrMsg)
-				res.Status = fmt.Sprintf("funded. Claim by %v is: %v", claimantUsername, res.Status)
+				res.Status = fmt.Sprintf("Funded. Claim by %v is: %v", claimantUsername, res.Status)
 			}
 		}
 		relaySecrets, err := relays.DecryptB64(ctx, g, p.TeamID, p.BoxB64)

--- a/go/stellar/stellargregor/stellargregor.go
+++ b/go/stellar/stellargregor/stellargregor.go
@@ -1,0 +1,58 @@
+package stellargregor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keybase/client/go/gregor"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/stellar/remote"
+)
+
+type handler struct {
+	libkb.Contextified
+	remoter remote.Remoter
+}
+
+var _ libkb.GregorInBandMessageHandler = (*handler)(nil)
+
+func New(g *libkb.GlobalContext, remoter remote.Remoter) *handler {
+	return &handler{
+		Contextified: libkb.NewContextified(g),
+		remoter:      remoter,
+	}
+}
+
+func (h *handler) Create(ctx context.Context, cli gregor1.IncomingInterface, category string, item gregor.Item) (bool, error) {
+	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("WGR")
+	switch category {
+	case "stellar.autoclaim":
+		return true, h.autoClaim(mctx, cli, category, item)
+	default:
+		if strings.HasPrefix(category, "stellar.") {
+			return false, fmt.Errorf("unknown handler category: %q", category)
+		}
+		return false, nil
+	}
+}
+
+func (h *handler) Dismiss(ctx context.Context, cli gregor1.IncomingInterface, category string, item gregor.Item) (bool, error) {
+	return false, nil
+}
+
+func (h *handler) IsAlive() bool {
+	return true
+}
+
+func (h *handler) Name() string {
+	return "stellarHandler"
+}
+
+// The server is telling the client to claim relay payments.
+func (h *handler) autoClaim(mctx libkb.MetaContext, cli gregor1.IncomingInterface, category string, item gregor.Item) error {
+	mctx.CDebugf("%v: %v received", h.Name(), category)
+	mctx.G().GetStellar().KickAutoClaimRunner(mctx, item.Metadata().MsgID())
+	return nil
+}

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -125,8 +125,6 @@ func TestChangeWalletName(t *testing.T) {
 	tcs, cleanup := setupNTests(t, 1)
 	defer cleanup()
 
-	stellar.ServiceInit(tcs[0].G)
-
 	_, err := stellar.CreateWallet(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -296,6 +296,18 @@ func (r *RemoteClientMock) SubmitRelayClaim(ctx context.Context, post stellar1.R
 	return r.Backend.SubmitRelayClaim(ctx, r.Tc, post)
 }
 
+func (r *RemoteClientMock) AcquireAutoClaimLock(ctx context.Context) (string, error) {
+	return "", fmt.Errorf("RemoteClientMock does not implement AcquireAutoClaimLock")
+}
+
+func (r *RemoteClientMock) ReleaseAutoClaimLock(ctx context.Context, token string) error {
+	return fmt.Errorf("RemoteClientMock does not implement ReleaseAutoClaimLock")
+}
+
+func (r *RemoteClientMock) NextAutoClaim(ctx context.Context) (*stellar1.AutoClaim, error) {
+	return nil, fmt.Errorf("RemoteClientMock does not implement NextAutoClaim")
+}
+
 func (r *RemoteClientMock) RecentPayments(ctx context.Context, accountID stellar1.AccountID, limit int) (res []stellar1.PaymentSummary, err error) {
 	return r.Backend.RecentPayments(ctx, r.Tc, accountID, limit)
 }

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -148,7 +148,7 @@ func (s *Server) ClaimCLILocal(ctx context.Context, arg stellar1.ClaimCLILocalAr
 			return res, err
 		}
 	}
-	return stellar.Claim(ctx, s.G(), s.remoter, arg.TxID, into)
+	return stellar.Claim(ctx, s.G(), s.remoter, arg.TxID, into, nil, nil)
 }
 
 func (s *Server) RecentPaymentsCLILocal(ctx context.Context, accountID *stellar1.AccountID) (res []stellar1.PaymentOrErrorCLILocal, err error) {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -24,7 +24,7 @@ import (
 
 func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
 	tc = externalstest.SetupTest(tb, name, depth+1)
-	stellar.ServiceInit(tc.G)
+	stellar.ServiceInit(tc.G, nil)
 	teams.ServiceInit(tc.G)
 	// use an insecure triplesec in tests
 	tc.G.NewTriplesec = func(passphrase []byte, salt []byte) (libkb.Triplesec, error) {
@@ -516,7 +516,7 @@ func testRelay(t *testing.T, yank bool) {
 	require.Len(t, history, 1)
 	require.Nil(t, history[0].Err)
 	require.NotNil(t, history[0].Payment)
-	require.Equal(t, "claimable", history[0].Payment.Status)
+	require.Equal(t, "Claimable", history[0].Payment.Status)
 	txID := history[0].Payment.TxID
 
 	fhistory, err := tcs[claimant].Srv.GetPaymentsLocal(context.Background(), stellar1.GetPaymentsLocalArg{AccountID: getPrimaryAccountID(tcs[claimant])})
@@ -557,7 +557,7 @@ func testRelay(t *testing.T, yank bool) {
 	require.Len(t, history, 1)
 	require.Nil(t, history[0].Err)
 	require.NotNil(t, history[0].Payment)
-	require.Equal(t, "completed", history[0].Payment.Status)
+	require.Equal(t, "Completed", history[0].Payment.Status)
 
 	fhistory, err = tcs[claimant].Srv.GetPaymentsLocal(context.Background(), stellar1.GetPaymentsLocalArg{AccountID: getPrimaryAccountID(tcs[claimant])})
 	require.NoError(t, err)
@@ -572,7 +572,7 @@ func testRelay(t *testing.T, yank bool) {
 	require.Len(t, history, 1)
 	require.Nil(t, history[0].Err)
 	require.NotNil(t, history[0].Payment)
-	require.Equal(t, "completed", history[0].Payment.Status)
+	require.Equal(t, "Completed", history[0].Payment.Status)
 
 	fhistory, err = tcs[0].Srv.GetPaymentsLocal(context.Background(), stellar1.GetPaymentsLocalArg{AccountID: getPrimaryAccountID(tcs[0])})
 	require.NoError(t, err)
@@ -592,7 +592,6 @@ func TestGetAvailableCurrencies(t *testing.T) {
 	tcs, cleanup := setupNTests(t, 1)
 	defer cleanup()
 
-	stellar.ServiceInit(tcs[0].G)
 	conf, err := tcs[0].G.GetStellar().GetServerDefinitions(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, conf.Currencies["USD"].Name, "US Dollar")

--- a/go/systests/common_test.go
+++ b/go/systests/common_test.go
@@ -4,11 +4,16 @@
 package systests
 
 import (
+	"fmt"
 	"path/filepath"
+	"testing"
+	"time"
 
 	"github.com/keybase/client/go/externalstest"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
 	context "golang.org/x/net/context"
 )
 
@@ -151,4 +156,38 @@ func getActiveDevicesAndKeys(tc *libkb.TestContext, username string) ([]*libkb.D
 		}
 	}
 	return activeDevices, append(sibkeys, subkeys...)
+}
+
+func pollFor(t *testing.T, label string, totalTime time.Duration, g *libkb.GlobalContext, poller func(i int) bool) {
+	t.Logf("pollFor '%s'", label)
+	totalTime *= libkb.CITimeMultiplier(g)
+	clock := clockwork.NewRealClock()
+	start := clock.Now()
+	endCh := clock.After(totalTime)
+	wait := 10 * time.Millisecond
+	var i int
+	for {
+		satisfied := poller(i)
+		since := clock.Since(start)
+		t.Logf("pollFor '%s' round:%v -> %v running:%v", label, i, satisfied, since)
+		if satisfied {
+			t.Logf("pollFor '%s' succeeded after %v attempts over %v", label, i, since)
+			return
+		}
+		if since > totalTime {
+			// Game over
+			msg := fmt.Sprintf("pollFor '%s' timed out after %v attempts over %v", label, i, since)
+			t.Logf(msg)
+			require.Fail(t, msg)
+			require.FailNow(t, msg)
+			return
+		}
+		t.Logf("pollFor '%s' wait:%v", label, wait)
+		select {
+		case <-endCh:
+		case <-clock.After(wait):
+		}
+		wait *= 2
+		i++
+	}
 }

--- a/go/systests/home_test.go
+++ b/go/systests/home_test.go
@@ -142,7 +142,7 @@ func pollForTrue(t *testing.T, g *libkb.GlobalContext, poller func(i int) bool) 
 		time.Sleep(wait)
 		wait = wait * 2
 	}
-	require.True(t, found, "found result after poll")
+	require.True(t, found, "whether condition was satisfied after polling ended")
 }
 
 func TestHome(t *testing.T) {

--- a/go/systests/stellar_test.go
+++ b/go/systests/stellar_test.go
@@ -180,14 +180,14 @@ func sampleNote() stellar1.NoteContents {
 // Friendbot sends someone XLM
 func gift(t testing.TB, accountID stellar1.AccountID) {
 	t.Logf("gift -> %v", accountID)
-	url := stellarnet.Client().URL + "/friendbot?addr=" + accountID.String()
+	url := "https://friendbot.stellar.org/?addr=" + accountID.String()
 	t.Logf("gift url: %v", url)
 	res, err := http.Get(url)
-	require.NoError(t, err)
+	require.NoError(t, err, "friendbot request error")
 	bodyBuf := new(bytes.Buffer)
 	bodyBuf.ReadFrom(res.Body)
 	t.Logf("gift res: %v", bodyBuf.String())
-	require.Equal(t, 200, res.StatusCode)
+	require.Equal(t, 200, res.StatusCode, "friendbot response status code")
 }
 
 func useStellarTestNet(t testing.TB) {

--- a/go/systests/stellar_test.go
+++ b/go/systests/stellar_test.go
@@ -1,12 +1,21 @@
 package systests
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
+	"github.com/keybase/client/go/client"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/stellar"
+	"github.com/keybase/client/go/teams"
+	"github.com/keybase/stellarnet"
+	"github.com/stellar/go/build"
+	"github.com/stellar/go/clients/horizon"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,9 +70,120 @@ func TestStellarNoteRoundtripAndResets(t *testing.T) {
 	require.Equal(t, sampleNote(), note)
 }
 
+// Part 1:
+// XLM is sent to a user before they have a PUK.
+// In the form of multiple relay payments.
+// They then get a PUK, add a wallet, and enter the impteam,
+// which all kick the autoclaim into gear.
+// Part 2:
+// A relay payment is sent to the user who already has a wallet.
+// The funds should be claimed asap.
+//
+// To debug this test use log filter "stellar_test|poll-|AutoClaim|stellar.claim|pollfor"
+//
+// Test took 35s with dev servers 2018-05-30
+func TestStellarRelayAutoClaims(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+	useStellarTestNet(t)
+
+	alice := tt.addUser("alice")
+	bob := tt.addPuklessUser("bob")
+	alice.kickTeamRekeyd()
+
+	t.Logf("alice gets funded")
+	res, err := alice.stellarClient.GetWalletAccountsLocal(context.Background(), 0)
+	require.NoError(t, err)
+	gift(t, res[0].AccountID)
+
+	t.Logf("alice sends a first relay payment to bob P1")
+	attachIdentifyUI(t, alice.tc.G, newSimpleIdentifyUI())
+	cmd := client.CmdWalletSend{
+		Contextified: libkb.NewContextified(alice.tc.G),
+		Recipient:    bob.username,
+		Amount:       "50",
+	}
+	require.NoError(t, cmd.Run())
+
+	t.Logf("alice sends a second relay payment to bob P2")
+	cmd = client.CmdWalletSend{
+		Contextified: libkb.NewContextified(alice.tc.G),
+		Recipient:    bob.username,
+		Amount:       "30",
+	}
+	require.NoError(t, cmd.Run())
+
+	t.Logf("get the impteam seqno to wait on later")
+	team, _, _, err := teams.LookupImplicitTeam(context.Background(), alice.tc.G, alice.username+","+bob.username, false)
+	require.NoError(t, err)
+	nextSeqno := team.NextSeqno()
+
+	t.Logf("bob gets a PUK and wallet")
+	bob.perUserKeyUpgrade()
+	bob.tc.G.GetStellar().CreateWalletSoft(context.Background())
+
+	t.Logf("wait for alice to add bob to their impteam")
+	alice.pollForTeamSeqnoLinkWithLoadArgs(keybase1.LoadTeamArg{ID: team.ID}, nextSeqno)
+
+	pollFor(t, "claims to complete", 10*time.Second, bob.tc.G, func(i int) bool {
+		res, err = bob.stellarClient.GetWalletAccountsLocal(context.Background(), 0)
+		require.NoError(t, err)
+		t.Logf("poll-1-%v: %v", i, res[0].BalanceDescription)
+		if res[0].BalanceDescription == "0 XLM" {
+			return false
+		}
+		if res[0].BalanceDescription == "49.9999800 XLM" {
+			t.Logf("poll-1-%v: received T1 but not T2", i)
+			return false
+		}
+		if res[0].BalanceDescription == "29.9999800 XLM" {
+			t.Logf("poll-1-%v: received T2 but not T1", i)
+			return false
+		}
+		t.Logf("poll-1-%v: received both payments", i)
+		require.Equal(t, "79.9999700 XLM", res[0].BalanceDescription)
+		return true
+	})
+
+	t.Logf("--------------------")
+	t.Logf("Part 2: Alice sends a relay payment to bob who now already has a wallet")
+	cmd = client.CmdWalletSend{
+		Contextified: libkb.NewContextified(alice.tc.G),
+		Recipient:    bob.username,
+		Amount:       "10",
+		ForceRelay:   true,
+	}
+	require.NoError(t, cmd.Run())
+
+	pollFor(t, "final claim to complete", 10*time.Second, bob.tc.G, func(i int) bool {
+		res, err = bob.stellarClient.GetWalletAccountsLocal(context.Background(), 0)
+		require.NoError(t, err)
+		t.Logf("poll-2-%v: %v", i, res[0].BalanceDescription)
+		if res[0].BalanceDescription == "79.9999700 XLM" {
+			return false
+		}
+		t.Logf("poll-1-%v: received final payment", i)
+		require.Equal(t, "89.9999600 XLM", res[0].BalanceDescription)
+		return true
+	})
+
+}
+
 func sampleNote() stellar1.NoteContents {
 	return stellar1.NoteContents{
 		Note:      "wizbang",
 		StellarID: stellar1.TransactionID("6653fc2fdbc42ad51ccbe77ee0a3c29e258a5513c62fdc532cbfff91ab101abf"),
 	}
+}
+
+// Friendbot sends someone XLM
+func gift(t testing.TB, accountID stellar1.AccountID) {
+	t.Logf("gift -> %v", accountID)
+	url := stellarnet.Client().URL + "/friendbot?addr=" + accountID.String()
+	_, err := http.Get(url)
+	require.NoError(t, err)
+}
+
+func useStellarTestNet(t testing.TB) {
+	stellarnet.SetClient(horizon.DefaultTestNetClient, build.TestNetwork)
 }

--- a/go/systests/stellar_test.go
+++ b/go/systests/stellar_test.go
@@ -1,6 +1,7 @@
 package systests
 
 import (
+	"bytes"
 	"net/http"
 	"testing"
 	"time"
@@ -180,8 +181,13 @@ func sampleNote() stellar1.NoteContents {
 func gift(t testing.TB, accountID stellar1.AccountID) {
 	t.Logf("gift -> %v", accountID)
 	url := stellarnet.Client().URL + "/friendbot?addr=" + accountID.String()
-	_, err := http.Get(url)
+	t.Logf("gift url: %v", url)
+	res, err := http.Get(url)
 	require.NoError(t, err)
+	bodyBuf := new(bytes.Buffer)
+	bodyBuf.ReadFrom(res.Body)
+	t.Logf("gift res: %v", bodyBuf.String())
+	require.Equal(t, 200, res.StatusCode)
 }
 
 func useStellarTestNet(t testing.TB) {

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/teams"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/stretchr/testify/require"
@@ -210,6 +211,7 @@ func (tt *teamTester) addUserHelper(pre string, puk bool, paper bool) *userPlusD
 	}
 
 	u.teamsClient = keybase1.TeamsClient{Cli: cli}
+	u.stellarClient = stellar1.LocalClient{Cli: cli}
 
 	g.ConfigureConfig()
 
@@ -245,6 +247,7 @@ type userPlusDevice struct {
 	tc                       *libkb.TestContext
 	deviceClient             keybase1.DeviceClient
 	teamsClient              keybase1.TeamsClient
+	stellarClient            stellar1.LocalClient
 	notifications            *teamNotifyHandler
 	suppressTeamChatAnnounce bool
 }


### PR DESCRIPTION
Relay payments are claimed automatically by the recipient's clients.

[Here's a doc](https://github.com/keybase/keybase/blob/miles/CORE-7720-autoclaim/docs/stellar_autoclaim.md)

There's a systest, and tested manually.

Also in this PR: Clients use the stellar test network whenever RunMode != prod

If you accidentally interact with a stellard that uses the wrong network you will get tx_bad_auth when posting transactions.

Requires https://github.com/keybase/keybase/pull/2517