### PR TITLE
Return error on wrongKID in storage

### DIFF
--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -234,10 +234,12 @@ func (e *EKLib) newUserEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot
 
 	// Let's see what the latest server statement is.
 	statement, _, wrongKID, err := fetchUserEKStatement(ctx, e.G(), e.G().Env.GetUID())
-	if err != nil {
+	if wrongKID {
+		return true, nil
+	} else if err != nil {
 		return false, err
 	}
-	if statement == nil || wrongKID {
+	if statement == nil {
 		return true, nil
 	}
 	// Can we access this generation? If not, let's regenerate.
@@ -265,20 +267,24 @@ func (e *EKLib) NewTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID) (ne
 	if err != nil {
 		return false, err
 	}
-	statement, _, _, err := fetchTeamEKStatement(ctx, e.G(), teamID)
-	if err != nil {
-		return false, err
-	}
-	return e.newTeamEKNeeded(ctx, teamID, *merkleRootPtr, statement)
+	needed, _, err = e.newTeamEKNeeded(ctx, teamID, *merkleRootPtr)
+	return needed, err
 }
 
-func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot, statement *keybase1.TeamEkStatement) (needed bool, err error) {
+func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (needed bool, latestGenerationk keybase1.EkGeneration, err error) {
 	defer e.G().CTraceTimed(ctx, fmt.Sprintf("newTeamEKNeeded: %v", needed), func() error { return err })()
+
+	statement, latestGeneration, wrongKID, err := fetchTeamEKStatement(ctx, e.G(), teamID)
+	if wrongKID {
+		return true, latestGeneration, nil
+	} else if err != nil {
+		return false, latestGeneration, err
+	}
 
 	// Let's see what the latest server statement is.
 	// No statement, so we need a teamEK
 	if statement == nil {
-		return true, nil
+		return true, latestGeneration, nil
 	}
 	// Can we access this generation? If not, let's regenerate.
 	s := e.G().GetTeamEKBoxStorage()
@@ -287,14 +293,14 @@ func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, mer
 		switch err.(type) {
 		case *EKUnboxErr, *EKMissingBoxErr:
 			e.G().Log.Debug(err.Error())
-			return true, nil
+			return true, latestGeneration, nil
 		default:
-			return false, err
+			return false, latestGeneration, err
 		}
 	}
 	// Ok we can access the ek, check lifetime.
 	e.G().Log.CDebugf(ctx, "nextTeamEKNeeded at: %v", nextKeygenTime(ek.Metadata.Ctime))
-	return keygenNeeded(ek.Metadata.Ctime, merkleRoot), nil
+	return keygenNeeded(ek.Metadata.Ctime, merkleRoot), latestGeneration, nil
 }
 
 type teamEKGenCacheEntry struct {
@@ -373,29 +379,23 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 		return teamEK, err
 	}
 
-	statement, _, _, err := fetchTeamEKStatement(ctx, e.G(), teamID)
+	teamEKNeeded, latestGeneration, err := e.newTeamEKNeeded(ctx, teamID, merkleRoot)
 	if err != nil {
 		return teamEK, err
-	}
-
-	var publishedMetadata keybase1.TeamEkMetadata
-	if teamEKNeeded, err := e.newTeamEKNeeded(ctx, teamID, merkleRoot, statement); err != nil {
-		return teamEK, err
 	} else if teamEKNeeded {
-		publishedMetadata, err = publishNewTeamEK(ctx, e.G(), teamID, merkleRoot)
+		publishedMetadata, err := publishNewTeamEK(ctx, e.G(), teamID, merkleRoot)
 		if err != nil {
 			return teamEK, err
 		}
-	} else {
-		publishedMetadata = statement.CurrentTeamEkMetadata
+		latestGeneration = publishedMetadata.Generation
 	}
 
-	teamEK, err = teamEKBoxStorage.Get(ctx, teamID, publishedMetadata.Generation)
+	teamEK, err = teamEKBoxStorage.Get(ctx, teamID, latestGeneration)
 	if err != nil {
 		return teamEK, err
 	}
 	// Cache the latest generation
-	e.teamEKGenCache.Add(key, e.newCacheEntry(publishedMetadata.Generation))
+	e.teamEKGenCache.Add(key, e.newCacheEntry(latestGeneration))
 	return teamEK, nil
 }
 

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -232,7 +232,9 @@ func (e *EKLib) NewUserEKNeeded(ctx context.Context) (needed bool, err error) {
 func (e *EKLib) newUserEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
 	defer e.G().CTraceTimed(ctx, fmt.Sprintf("newUserEKNeeded: %v", needed), func() error { return err })()
 
-	// Let's see what the latest server statement is.
+	// Let's see what the latest server statement is. This verifies that the
+	// latest statement was signed by the latest PUK and otherwise fails with
+	// wrongKID set.
 	statement, _, wrongKID, err := fetchUserEKStatement(ctx, e.G(), e.G().Env.GetUID())
 	if wrongKID {
 		return true, nil
@@ -274,6 +276,9 @@ func (e *EKLib) NewTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID) (ne
 func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (needed bool, latestGenerationk keybase1.EkGeneration, err error) {
 	defer e.G().CTraceTimed(ctx, fmt.Sprintf("newTeamEKNeeded: %v", needed), func() error { return err })()
 
+	// Let's see what the latest server statement is. This verifies that the
+	// latest statement was signed by the latest PTK and otherwise fails with
+	// wrongKID set.
 	statement, latestGeneration, wrongKID, err := fetchTeamEKStatement(ctx, e.G(), teamID)
 	if wrongKID {
 		return true, latestGeneration, nil

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -142,6 +142,11 @@ func (e *EKLib) keygenIfNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot)
 		}
 	}
 
+	// newUserEKNeeded checks that the current userEKStatement is signed by our
+	// latest PUK, is accessible to a deviceEK we have access to and that the
+	// key is not expired. It's crucial that this verifies that the latest PUK
+	// was used since we don't want to use a key signed by an old PUK for
+	// encryption.
 	if userEKNeeded, err := e.newUserEKNeeded(ctx, merkleRoot); err != nil {
 		return err
 	} else if userEKNeeded {
@@ -384,6 +389,11 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 		return teamEK, err
 	}
 
+	// newTeamEKNeeded checks that the current teamEKStatement is signed by the
+	// latest PTK, is accessible to a userEK we have access to and that the key
+	// is not expired. It's crucial that this verifies that the latest PTK was
+	// used since we don't want to use a key signed by an old PTK for
+	// encryption.
 	teamEKNeeded, latestGeneration, err := e.newTeamEKNeeded(ctx, teamID, merkleRoot)
 	if err != nil {
 		return teamEK, err

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -68,7 +68,7 @@ func prepareNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybas
 	var generation keybase1.EkGeneration
 	if prevStatement == nil {
 		// Even if the teamEK statement was signed by the wrong key (this can
-		// happen when legacy clients roll the PTK, fetchTeamEKStatement will
+		// happen when legacy clients roll the PTK), fetchTeamEKStatement will
 		// return the generation number from the last (unverifiable) statement.
 		// If there was never any statement, latestGeneration will be 0, so
 		// adding one is correct in all cases.

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -61,8 +61,8 @@ func prepareNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybas
 		return "", nil, metadata, nil, err
 	}
 
-	prevStatement, latestGeneration, _, err := fetchTeamEKStatement(ctx, g, teamID)
-	if err != nil {
+	prevStatement, latestGeneration, wrongKID, err := fetchTeamEKStatement(ctx, g, teamID)
+	if !wrongKID && err != nil {
 		return "", nil, metadata, nil, err
 	}
 	var generation keybase1.EkGeneration
@@ -293,8 +293,7 @@ func fetchTeamEKStatement(ctx context.Context, g *libkb.GlobalContext, teamID ke
 	if wrongKID {
 		g.Log.CDebugf(ctx, "It looks like someone rolled the PTK without generating new ephemeral keys. They might be on an old version.")
 		return nil, latestGeneration, true, nil
-	}
-	if err != nil {
+	} else if err != nil {
 		return nil, latestGeneration, false, err
 	}
 
@@ -437,8 +436,7 @@ func fetchTeamMemberStatements(ctx context.Context, g *libkb.GlobalContext, team
 			g.Log.CDebugf(ctx, "Member %v revoked a device without generating new ephemeral keys. They might be running an old version?", uid)
 			// Don't box for this member since they have no valid userEK
 			continue
-		}
-		if err != nil {
+		} else if err != nil {
 			return nil, err
 		}
 		statementMap[uid] = memberStatement

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -126,6 +126,12 @@ func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.Te
 		return teamEK, newEKMissingBoxErr(TeamEKStr, generation)
 	}
 
+	// Although we verify the signature is valid, it's possible that this key
+	// was signed with a PTK that is not our latest and greatest. We allow this
+	// when we are using this ek for *decryption*. When getting a key for
+	// *encryption* callers are responsible for verifying the signature is
+	// signed by the latest PTK or generating a new EK. This logic currently
+	// lives in ephemeral/lib.go#GetOrCreateLatestTeamEK (#newTeamEKNeeded)
 	_, teamEKStatement, err := extractTeamEKStatementFromSig(result.Result.Sig)
 	if err != nil {
 		return teamEK, err

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -129,15 +129,7 @@ func (s *TeamEKBoxStorage) fetchAndPut(ctx context.Context, teamID keybase1.Team
 	// Before we store anything, let's verify that the server returned
 	// signature is valid and the KID it has signed matches the boxed seed.
 	// Otherwise something's fishy..
-	teamEKStatement, _, wrongKID, err := verifySigWithLatestPTK(ctx, s.G(), teamID, result.Result.Sig)
-
-	// Check the wrongKID condition before checking the error, since an error
-	// is still returned in this case. TODO: Turn this warning into an error
-	// after EK support is sufficiently widespread.
-	if wrongKID {
-		s.G().Log.CDebugf(ctx, "It looks like you revoked a team key without generating new ephemeral keys. Are you running an old version?")
-		return teamEK, nil
-	}
+	teamEKStatement, _, _, err := verifySigWithLatestPTK(ctx, s.G(), teamID, result.Result.Sig)
 	if err != nil {
 		return teamEK, err
 	}

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -74,7 +74,7 @@ func prepareNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot li
 	var existingMaybeStaleMetadata []keybase1.UserEkMetadata
 	if prevStatement == nil {
 		// Even if the userEK statement was signed by the wrong key (this can
-		// happen when legacy clients roll the PUK, fetchUserEKStatement will
+		// happen when legacy clients roll the PUK), fetchUserEKStatement will
 		// return the generation number from the last (unverifiable) statement.
 		// If there was never any statement, latestGeneration will be 0, so
 		// adding one is correct in all cases.

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -116,6 +116,12 @@ func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase
 		return userEK, newEKMissingBoxErr(UserEKStr, generation)
 	}
 
+	// Although we verify the signature is valid, it's possible that this key
+	// was signed with a PUK that is not our latest and greatest. We allow this
+	// when we are using this ek for *decryption*. When getting a key for
+	// *encryption* callers are responsible for verifying the signature is
+	// signed by the latest PUK or generating a new EK. This logic currently
+	// lives in ephemeral/lib.go#KeygenIfNeeded (#newUserEKNeeded)
 	_, userEKStatement, err := extractUserEKStatementFromSig(result.Result.Sig)
 	if err != nil {
 		return userEK, err

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -119,15 +119,7 @@ func (s *UserEKBoxStorage) fetchAndPut(ctx context.Context, generation keybase1.
 	// Before we store anything, let's verify that the server returned
 	// signature is valid and the KID it has signed matches the boxed seed.
 	// Otherwise something's fishy..
-	userEKStatement, _, wrongKID, err := verifySigWithLatestPUK(ctx, s.G(), s.G().Env.GetUID(), result.Result.Sig)
-
-	// Check the wrongKID condition before checking the error, since an error
-	// is still returned in this case. TODO: Turn this warning into an error
-	// after EK support is sufficiently widespread.
-	if wrongKID {
-		s.G().Log.CDebugf(ctx, "It looks like you revoked a device without generating new ephemeral keys. Are you running an old version?")
-		return userEK, nil
-	}
+	userEKStatement, _, _, err := verifySigWithLatestPUK(ctx, s.G(), s.G().Env.GetUID(), result.Result.Sig)
 	if err != nil {
 		return userEK, err
 	}

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -153,9 +153,14 @@ func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 	var existingMetadata []keybase1.UserEkMetadata
+	ekLib := NewEKLib(tc.G)
+	needed, err := ekLib.NewUserEKNeeded(context.Background())
+	require.NoError(t, err)
 	if skipUserEKForTesting {
+		require.True(t, needed)
 		existingMetadata = []keybase1.UserEkMetadata{}
 	} else {
+		require.False(t, needed)
 		existingMetadata = statement.ExistingUserEkMetadata
 		existingMetadata = append(existingMetadata, statement.CurrentUserEkMetadata)
 	}
@@ -163,12 +168,8 @@ func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 }
 
 func TestPukRollNewUserEK(t *testing.T) {
-	tc := libkb.SetupTest(t, "kex2provision", 2)
+	tc, user := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
-	NewEphemeralStorageAndInstall(tc.G)
-
-	user, err := kbtest.CreateAndSignupFakeUser("e", tc.G)
-	require.NoError(t, err)
 
 	// Confirm that the user has a userEK.
 	uid := tc.G.Env.GetUID()

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -667,6 +667,8 @@ type EKLib interface {
 	BoxLatestTeamEK(ctx context.Context, teamID keybase1.TeamID, uids []keybase1.UID) (*[]keybase1.TeamEkBoxMetadata, error)
 	PrepareNewTeamEK(ctx context.Context, teamID keybase1.TeamID, signingKey NaclSigningKeyPair, uids []keybase1.UID) (string, *[]keybase1.TeamEkBoxMetadata, keybase1.TeamEkMetadata, *keybase1.TeamEkBoxed, error)
 	ShouldRun(ctx context.Context) bool
+	// For testing
+	NewTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID) (bool, error)
 }
 
 type ImplicitTeamConflictInfoCacher interface {

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -266,6 +266,9 @@ func TestRotateSkipTeamEKRoll(t *testing.T) {
 	annG.SetEKLib(ekLib)
 
 	// After rotating, ensure we can create a new TeamEK without issue.
+	needed, err := ekLib.NewTeamEKNeeded(context.Background(), teamID)
+	require.NoError(t, err)
+	require.True(t, needed)
 	merkleRoot, err := ann.tc.G.GetMerkleClient().FetchRootFromServer(context.Background(), libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	metadata, err := ephemeral.ForcePublishNewTeamEKForTesting(context.Background(), ann.tc.G, teamID, *merkleRoot)


### PR DESCRIPTION
From checking out the logs it seems we got a `wrongKID` set for an old key (probably because not all admin had keygen running) in which case we didn't return an error but an empty `keybase1.TeamEk`.

I think this was just wrong since we pass up the empty key and fail to decrypt: `error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key`. instead we should just return the error since storage can't access the key