### PR TITLE
Split PreviewConversation action

### DIFF
--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -338,7 +338,7 @@ func TestChangeDisplayCurrency(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	// Try non-existant account id.
+	// Try non-existent account id.
 	invalidAccID, _ := randomStellarKeypair()
 	err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
 		AccountID: invalidAccID,

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -22,7 +22,6 @@ export const blockConversation = 'chat2:blockConversation'
 export const clearLoading = 'chat2:clearLoading'
 export const createConversation = 'chat2:createConversation'
 export const desktopNotification = 'chat2:desktopNotification'
-export const findAndPreviewConversation = 'chat2:findAndPreviewConversation'
 export const findAndSelectTeamGeneral = 'chat2:findAndSelectTeamGeneral'
 export const handleSeeingExplodingMessages = 'chat2:handleSeeingExplodingMessages'
 export const inboxRefresh = 'chat2:inboxRefresh'
@@ -75,6 +74,7 @@ export const setPendingConversationExistingConversationIDKey = 'chat2:setPending
 export const setPendingConversationUsers = 'chat2:setPendingConversationUsers'
 export const setPendingMode = 'chat2:setPendingMode'
 export const setupChatHandlers = 'chat2:setupChatHandlers'
+export const startPendingConversation = 'chat2:startPendingConversation'
 export const updateConvExplodingModes = 'chat2:updateConvExplodingModes'
 export const updateConvRetentionPolicy = 'chat2:updateConvRetentionPolicy'
 export const updateMoreToLoad = 'chat2:updateMoreToLoad'
@@ -125,10 +125,6 @@ type _DesktopNotificationPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
   author: string,
   body: string,
-|}>
-type _FindAndPreviewConversationPayload = $ReadOnly<{|
-  participants: Array<string>,
-  reason: 'resetChatWithoutThem' | 'tracker' | 'teamHeader' | 'files' | 'teamInvite' | 'fromAReset' | 'profile' | 'teamMember' | 'memberView',
 |}>
 type _FindAndSelectTeamGeneralPayload = $ReadOnly<{|
   teamname: string,
@@ -310,6 +306,10 @@ type _SetPendingConversationUsersPayload = $ReadOnly<{|
 |}>
 type _SetPendingModePayload = $ReadOnly<{|pendingMode: Types.PendingMode|}>
 type _SetupChatHandlersPayload = void
+type _StartPendingConversationPayload = $ReadOnly<{|
+  participants: Array<string>,
+  reason: 'resetChatWithoutThem' | 'tracker' | 'teamHeader' | 'files' | 'teamInvite' | 'fromAReset' | 'profile' | 'teamMember' | 'memberView',
+|}>
 type _UpdateConvExplodingModesPayload = $ReadOnly<{|modes: Array<{conversationIDKey: Types.ConversationIDKey, seconds: number}>|}>
 type _UpdateConvRetentionPolicyPayload = $ReadOnly<{|conv: RPCChatTypes.InboxUIItem|}>
 type _UpdateMoreToLoadPayload = $ReadOnly<{|
@@ -375,6 +375,10 @@ export const createSetConvRetentionPolicy = (payload: _SetConvRetentionPolicyPay
  */
 export const createHandleSeeingExplodingMessages = (payload: _HandleSeeingExplodingMessagesPayload) => ({error: false, payload, type: handleSeeingExplodingMessages})
 /**
+ * Start a pending conversation with the given participants. fromAReset means you were in a reset kbfs convo and you want to make a new one. Chatting from external places in the app should usually call this.
+ */
+export const createStartPendingConversation = (payload: _StartPendingConversationPayload) => ({error: false, payload, type: startPendingConversation})
+/**
  * When the search changes we need to find any existing conversations to stash into the metaMap
  */
 export const createSetPendingConversationExistingConversationIDKey = (payload: _SetPendingConversationExistingConversationIDKeyPayload) => ({error: false, payload, type: setPendingConversationExistingConversationIDKey})
@@ -388,7 +392,6 @@ export const createBadgesUpdated = (payload: _BadgesUpdatedPayload) => ({error: 
 export const createBlockConversation = (payload: _BlockConversationPayload) => ({error: false, payload, type: blockConversation})
 export const createClearLoading = (payload: _ClearLoadingPayload) => ({error: false, payload, type: clearLoading})
 export const createDesktopNotification = (payload: _DesktopNotificationPayload) => ({error: false, payload, type: desktopNotification})
-export const createFindAndPreviewConversation = (payload: _FindAndPreviewConversationPayload) => ({error: false, payload, type: findAndPreviewConversation})
 export const createInboxRefresh = (payload: _InboxRefreshPayload) => ({error: false, payload, type: inboxRefresh})
 export const createJoinConversation = (payload: _JoinConversationPayload) => ({error: false, payload, type: joinConversation})
 export const createLeaveConversation = (payload: _LeaveConversationPayload) => ({error: false, payload, type: leaveConversation})
@@ -448,7 +451,6 @@ export type BlockConversationPayload = $Call<typeof createBlockConversation, _Bl
 export type ClearLoadingPayload = $Call<typeof createClearLoading, _ClearLoadingPayload>
 export type CreateConversationPayload = $Call<typeof createCreateConversation, _CreateConversationPayload>
 export type DesktopNotificationPayload = $Call<typeof createDesktopNotification, _DesktopNotificationPayload>
-export type FindAndPreviewConversationPayload = $Call<typeof createFindAndPreviewConversation, _FindAndPreviewConversationPayload>
 export type FindAndSelectTeamGeneralPayload = $Call<typeof createFindAndSelectTeamGeneral, _FindAndSelectTeamGeneralPayload>
 export type HandleSeeingExplodingMessagesPayload = $Call<typeof createHandleSeeingExplodingMessages, _HandleSeeingExplodingMessagesPayload>
 export type InboxRefreshPayload = $Call<typeof createInboxRefresh, _InboxRefreshPayload>
@@ -501,6 +503,7 @@ export type SetPendingConversationExistingConversationIDKeyPayload = $Call<typeo
 export type SetPendingConversationUsersPayload = $Call<typeof createSetPendingConversationUsers, _SetPendingConversationUsersPayload>
 export type SetPendingModePayload = $Call<typeof createSetPendingMode, _SetPendingModePayload>
 export type SetupChatHandlersPayload = $Call<typeof createSetupChatHandlers, _SetupChatHandlersPayload>
+export type StartPendingConversationPayload = $Call<typeof createStartPendingConversation, _StartPendingConversationPayload>
 export type UpdateConvExplodingModesPayload = $Call<typeof createUpdateConvExplodingModes, _UpdateConvExplodingModesPayload>
 export type UpdateConvRetentionPolicyPayload = $Call<typeof createUpdateConvRetentionPolicy, _UpdateConvRetentionPolicyPayload>
 export type UpdateMoreToLoadPayload = $Call<typeof createUpdateMoreToLoad, _UpdateMoreToLoadPayload>
@@ -522,7 +525,6 @@ export type Actions =
   | ClearLoadingPayload
   | CreateConversationPayload
   | DesktopNotificationPayload
-  | FindAndPreviewConversationPayload
   | FindAndSelectTeamGeneralPayload
   | HandleSeeingExplodingMessagesPayload
   | InboxRefreshPayload
@@ -575,6 +577,7 @@ export type Actions =
   | SetPendingConversationUsersPayload
   | SetPendingModePayload
   | SetupChatHandlersPayload
+  | StartPendingConversationPayload
   | UpdateConvExplodingModesPayload
   | UpdateConvRetentionPolicyPayload
   | UpdateMoreToLoadPayload

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -22,6 +22,7 @@ export const blockConversation = 'chat2:blockConversation'
 export const clearLoading = 'chat2:clearLoading'
 export const createConversation = 'chat2:createConversation'
 export const desktopNotification = 'chat2:desktopNotification'
+export const findAndPreviewConversation = 'chat2:findAndPreviewConversation'
 export const handleSeeingExplodingMessages = 'chat2:handleSeeingExplodingMessages'
 export const inboxRefresh = 'chat2:inboxRefresh'
 export const joinConversation = 'chat2:joinConversation'
@@ -57,7 +58,7 @@ export const navigateToInbox = 'chat2:navigateToInbox'
 export const navigateToThread = 'chat2:navigateToThread'
 export const notificationSettingsUpdated = 'chat2:notificationSettingsUpdated'
 export const openFolder = 'chat2:openFolder'
-export const previewConversation = 'chat2:previewConversation'
+export const previewKnownTeamConversation = 'chat2:previewKnownTeamConversation'
 export const resetChatWithoutThem = 'chat2:resetChatWithoutThem'
 export const resetLetThemIn = 'chat2:resetLetThemIn'
 export const selectConversation = 'chat2:selectConversation'
@@ -123,6 +124,12 @@ type _DesktopNotificationPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
   author: string,
   body: string,
+|}>
+type _FindAndPreviewConversationPayload = $ReadOnly<{|
+  participants?: Array<string>,
+  teamname?: string,
+  channelname?: string,
+  reason: 'resetChatWithoutThem' | 'tracker' | 'teamHeader' | 'files' | 'teamInvite' | 'fromAReset' | 'profile' | 'teamMember' | 'teamHeader' | 'convertAdHoc' | 'memberView',
 |}>
 type _HandleSeeingExplodingMessagesPayload = void
 type _InboxRefreshPayload = $ReadOnly<{|reason: 'bootstrap' | 'componentNeverLoaded' | 'inboxStale' | 'inboxSyncedClear' | 'inboxSyncedUnknown' | 'joinedAConversation' | 'leftAConversation' | 'teamTypeChanged'|}>
@@ -252,12 +259,11 @@ type _NotificationSettingsUpdatedPayload = $ReadOnly<{|
   settings: RPCChatTypes.ConversationNotificationInfo,
 |}>
 type _OpenFolderPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey|}>
-type _PreviewConversationPayload = $ReadOnly<{|
-  participants?: Array<string>,
+type _PreviewKnownTeamConversationPayload = $ReadOnly<{|
+  channelname: string,
+  conversationIDKey: Types.ConversationIDKey,
   teamname?: string,
-  channelname?: string,
-  conversationIDKey?: Types.ConversationIDKey,
-  reason: 'manageView' | 'messageLink' | 'resetChatWithoutThem' | 'tracker' | 'teamHeader' | 'files' | 'teamInvite' | 'fromAReset' | 'profile' | 'teamMember' | 'teamHeader' | 'convertAdHoc' | 'memberView' | 'newChannel',
+  reason: 'manageView' | 'messageLink' | 'newChannel' | 'previewResolved',
 |}>
 type _ResetChatWithoutThemPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey|}>
 type _ResetLetThemInPayload = $ReadOnly<{|
@@ -338,6 +344,10 @@ export const createMessagesExploded = (payload: _MessagesExplodedPayload) => ({e
  */
 export const createUpdateConvExplodingModes = (payload: _UpdateConvExplodingModesPayload) => ({error: false, payload, type: updateConvExplodingModes})
 /**
+ * Select or preview an existing team conversation.
+ */
+export const createPreviewKnownTeamConversation = (payload: _PreviewKnownTeamConversationPayload) => ({error: false, payload, type: previewKnownTeamConversation})
+/**
  * Set a lock on the exploding mode for a conversation.
  */
 export const createSetExplodingModeLock = (payload: _SetExplodingModeLockPayload) => ({error: false, payload, type: setExplodingModeLock})
@@ -371,6 +381,7 @@ export const createBadgesUpdated = (payload: _BadgesUpdatedPayload) => ({error: 
 export const createBlockConversation = (payload: _BlockConversationPayload) => ({error: false, payload, type: blockConversation})
 export const createClearLoading = (payload: _ClearLoadingPayload) => ({error: false, payload, type: clearLoading})
 export const createDesktopNotification = (payload: _DesktopNotificationPayload) => ({error: false, payload, type: desktopNotification})
+export const createFindAndPreviewConversation = (payload: _FindAndPreviewConversationPayload) => ({error: false, payload, type: findAndPreviewConversation})
 export const createInboxRefresh = (payload: _InboxRefreshPayload) => ({error: false, payload, type: inboxRefresh})
 export const createJoinConversation = (payload: _JoinConversationPayload) => ({error: false, payload, type: joinConversation})
 export const createLeaveConversation = (payload: _LeaveConversationPayload) => ({error: false, payload, type: leaveConversation})
@@ -404,7 +415,6 @@ export const createNavigateToInbox = (payload: _NavigateToInboxPayload) => ({err
 export const createNavigateToThread = (payload: _NavigateToThreadPayload) => ({error: false, payload, type: navigateToThread})
 export const createNotificationSettingsUpdated = (payload: _NotificationSettingsUpdatedPayload) => ({error: false, payload, type: notificationSettingsUpdated})
 export const createOpenFolder = (payload: _OpenFolderPayload) => ({error: false, payload, type: openFolder})
-export const createPreviewConversation = (payload: _PreviewConversationPayload) => ({error: false, payload, type: previewConversation})
 export const createResetChatWithoutThem = (payload: _ResetChatWithoutThemPayload) => ({error: false, payload, type: resetChatWithoutThem})
 export const createResetLetThemIn = (payload: _ResetLetThemInPayload) => ({error: false, payload, type: resetLetThemIn})
 export const createSelectConversation = (payload: _SelectConversationPayload) => ({error: false, payload, type: selectConversation})
@@ -431,6 +441,7 @@ export type BlockConversationPayload = $Call<typeof createBlockConversation, _Bl
 export type ClearLoadingPayload = $Call<typeof createClearLoading, _ClearLoadingPayload>
 export type CreateConversationPayload = $Call<typeof createCreateConversation, _CreateConversationPayload>
 export type DesktopNotificationPayload = $Call<typeof createDesktopNotification, _DesktopNotificationPayload>
+export type FindAndPreviewConversationPayload = $Call<typeof createFindAndPreviewConversation, _FindAndPreviewConversationPayload>
 export type HandleSeeingExplodingMessagesPayload = $Call<typeof createHandleSeeingExplodingMessages, _HandleSeeingExplodingMessagesPayload>
 export type InboxRefreshPayload = $Call<typeof createInboxRefresh, _InboxRefreshPayload>
 export type JoinConversationPayload = $Call<typeof createJoinConversation, _JoinConversationPayload>
@@ -466,7 +477,7 @@ export type NavigateToInboxPayload = $Call<typeof createNavigateToInbox, _Naviga
 export type NavigateToThreadPayload = $Call<typeof createNavigateToThread, _NavigateToThreadPayload>
 export type NotificationSettingsUpdatedPayload = $Call<typeof createNotificationSettingsUpdated, _NotificationSettingsUpdatedPayload>
 export type OpenFolderPayload = $Call<typeof createOpenFolder, _OpenFolderPayload>
-export type PreviewConversationPayload = $Call<typeof createPreviewConversation, _PreviewConversationPayload>
+export type PreviewKnownTeamConversationPayload = $Call<typeof createPreviewKnownTeamConversation, _PreviewKnownTeamConversationPayload>
 export type ResetChatWithoutThemPayload = $Call<typeof createResetChatWithoutThem, _ResetChatWithoutThemPayload>
 export type ResetLetThemInPayload = $Call<typeof createResetLetThemIn, _ResetLetThemInPayload>
 export type SelectConversationPayload = $Call<typeof createSelectConversation, _SelectConversationPayload>
@@ -503,6 +514,7 @@ export type Actions =
   | ClearLoadingPayload
   | CreateConversationPayload
   | DesktopNotificationPayload
+  | FindAndPreviewConversationPayload
   | HandleSeeingExplodingMessagesPayload
   | InboxRefreshPayload
   | JoinConversationPayload
@@ -538,7 +550,7 @@ export type Actions =
   | NavigateToThreadPayload
   | NotificationSettingsUpdatedPayload
   | OpenFolderPayload
-  | PreviewConversationPayload
+  | PreviewKnownTeamConversationPayload
   | ResetChatWithoutThemPayload
   | ResetLetThemInPayload
   | SelectConversationPayload

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -265,7 +265,7 @@ type _ResetLetThemInPayload = $ReadOnly<{|
 |}>
 type _SelectConversationPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
-  reason: 'clearSelected' | 'justCreated' | 'desktopNotification' | 'setPendingMode' | 'sendingToPending' | 'createdMessagePrivately' | 'findNewestConversation' | 'inboxBig' | 'inboxFilterArrow' | 'inboxFilterChanged' | 'inboxSmall' | 'inboxNewConversation' | 'jumpFromReset' | 'jumpToReset' | 'justCreated' | 'manageView' | 'previewResolved' | 'pendingModeChange' | 'push' | 'savedLastState' | 'startFoundExisting' | 'teamChat',
+  reason: 'clearSelected' | 'justCreated' | 'desktopNotification' | 'setPendingMode' | 'sendingToPending' | 'createdMessagePrivately' | 'findNewestConversation' | 'inboxBig' | 'inboxFilterArrow' | 'inboxFilterChanged' | 'inboxSmall' | 'inboxNewConversation' | 'jumpFromReset' | 'jumpToReset' | 'justCreated' | 'selectOrPreview' | 'pendingModeChange' | 'push' | 'savedLastState' | 'startFoundExisting' | 'teamChat' | 'manageView' | 'messageLink' | 'newChannel' | 'previewResolved',
 |}>
 type _SelectOrPreviewTeamConversationPayload = $ReadOnly<{|
   channelname: string,

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -269,13 +269,13 @@ type _ResetLetThemInPayload = $ReadOnly<{|
 |}>
 type _SelectConversationPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
-  reason: 'clearSelected' | 'justCreated' | 'desktopNotification' | 'setPendingMode' | 'sendingToPending' | 'createdMessagePrivately' | 'findNewestConversation' | 'inboxBig' | 'inboxFilterArrow' | 'inboxFilterChanged' | 'inboxSmall' | 'inboxNewConversation' | 'jumpFromReset' | 'jumpToReset' | 'justCreated' | 'selectOrPreview' | 'pendingModeChange' | 'push' | 'savedLastState' | 'startFoundExisting' | 'teamChat' | 'manageView' | 'messageLink' | 'newChannel' | 'previewResolved',
+  reason: 'clearSelected' | 'justCreated' | 'desktopNotification' | 'setPendingMode' | 'sendingToPending' | 'createdMessagePrivately' | 'findNewestConversation' | 'inboxBig' | 'inboxFilterArrow' | 'inboxFilterChanged' | 'inboxSmall' | 'inboxNewConversation' | 'jumpFromReset' | 'jumpToReset' | 'justCreated' | 'selectOrPreview' | 'pendingModeChange' | 'push' | 'savedLastState' | 'startFoundExisting' | 'teamChat' | 'manageView' | 'messageLink' | 'newChannel' | 'teamGeneral',
 |}>
 type _SelectOrPreviewTeamConversationPayload = $ReadOnly<{|
   channelname: string,
   conversationIDKey: Types.ConversationIDKey,
   teamname?: string,
-  reason: 'manageView' | 'messageLink' | 'newChannel' | 'previewResolved',
+  reason: 'manageView' | 'messageLink' | 'newChannel' | 'teamGeneral',
 |}>
 type _SendTypingPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -128,7 +128,6 @@ type _DesktopNotificationPayload = $ReadOnly<{|
 type _FindAndPreviewConversationPayload = $ReadOnly<{|
   participants?: Array<string>,
   teamname?: string,
-  channelname?: string,
   reason: 'resetChatWithoutThem' | 'tracker' | 'teamHeader' | 'files' | 'teamInvite' | 'fromAReset' | 'profile' | 'teamMember' | 'teamHeader' | 'convertAdHoc' | 'memberView',
 |}>
 type _HandleSeeingExplodingMessagesPayload = void

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -23,6 +23,7 @@ export const clearLoading = 'chat2:clearLoading'
 export const createConversation = 'chat2:createConversation'
 export const desktopNotification = 'chat2:desktopNotification'
 export const findAndPreviewConversation = 'chat2:findAndPreviewConversation'
+export const findAndSelectTeamGeneral = 'chat2:findAndSelectTeamGeneral'
 export const handleSeeingExplodingMessages = 'chat2:handleSeeingExplodingMessages'
 export const inboxRefresh = 'chat2:inboxRefresh'
 export const joinConversation = 'chat2:joinConversation'
@@ -126,9 +127,12 @@ type _DesktopNotificationPayload = $ReadOnly<{|
   body: string,
 |}>
 type _FindAndPreviewConversationPayload = $ReadOnly<{|
-  participants?: Array<string>,
-  teamname?: string,
-  reason: 'resetChatWithoutThem' | 'tracker' | 'teamHeader' | 'files' | 'teamInvite' | 'fromAReset' | 'profile' | 'teamMember' | 'teamHeader' | 'convertAdHoc' | 'memberView',
+  participants: Array<string>,
+  reason: 'resetChatWithoutThem' | 'tracker' | 'teamHeader' | 'files' | 'teamInvite' | 'fromAReset' | 'profile' | 'teamMember' | 'memberView',
+|}>
+type _FindAndSelectTeamGeneralPayload = $ReadOnly<{|
+  teamname: string,
+  reason: 'files' | 'teamHeader' | 'convertAdHoc',
 |}>
 type _HandleSeeingExplodingMessagesPayload = void
 type _InboxRefreshPayload = $ReadOnly<{|reason: 'bootstrap' | 'componentNeverLoaded' | 'inboxStale' | 'inboxSyncedClear' | 'inboxSyncedUnknown' | 'joinedAConversation' | 'leftAConversation' | 'teamTypeChanged'|}>
@@ -339,6 +343,10 @@ export const createUpdateTeamRetentionPolicy = (payload: _UpdateTeamRetentionPol
  */
 export const createMessagesExploded = (payload: _MessagesExplodedPayload) => ({error: false, payload, type: messagesExploded})
 /**
+ * Find the #general channel for the given team, then select it.
+ */
+export const createFindAndSelectTeamGeneral = (payload: _FindAndSelectTeamGeneralPayload) => ({error: false, payload, type: findAndSelectTeamGeneral})
+/**
  * Handle an update to our conversation exploding modes.
  */
 export const createUpdateConvExplodingModes = (payload: _UpdateConvExplodingModesPayload) => ({error: false, payload, type: updateConvExplodingModes})
@@ -441,6 +449,7 @@ export type ClearLoadingPayload = $Call<typeof createClearLoading, _ClearLoading
 export type CreateConversationPayload = $Call<typeof createCreateConversation, _CreateConversationPayload>
 export type DesktopNotificationPayload = $Call<typeof createDesktopNotification, _DesktopNotificationPayload>
 export type FindAndPreviewConversationPayload = $Call<typeof createFindAndPreviewConversation, _FindAndPreviewConversationPayload>
+export type FindAndSelectTeamGeneralPayload = $Call<typeof createFindAndSelectTeamGeneral, _FindAndSelectTeamGeneralPayload>
 export type HandleSeeingExplodingMessagesPayload = $Call<typeof createHandleSeeingExplodingMessages, _HandleSeeingExplodingMessagesPayload>
 export type InboxRefreshPayload = $Call<typeof createInboxRefresh, _InboxRefreshPayload>
 export type JoinConversationPayload = $Call<typeof createJoinConversation, _JoinConversationPayload>
@@ -514,6 +523,7 @@ export type Actions =
   | CreateConversationPayload
   | DesktopNotificationPayload
   | FindAndPreviewConversationPayload
+  | FindAndSelectTeamGeneralPayload
   | HandleSeeingExplodingMessagesPayload
   | InboxRefreshPayload
   | JoinConversationPayload

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -58,10 +58,10 @@ export const navigateToInbox = 'chat2:navigateToInbox'
 export const navigateToThread = 'chat2:navigateToThread'
 export const notificationSettingsUpdated = 'chat2:notificationSettingsUpdated'
 export const openFolder = 'chat2:openFolder'
-export const previewKnownTeamConversation = 'chat2:previewKnownTeamConversation'
 export const resetChatWithoutThem = 'chat2:resetChatWithoutThem'
 export const resetLetThemIn = 'chat2:resetLetThemIn'
 export const selectConversation = 'chat2:selectConversation'
+export const selectOrPreviewTeamConversation = 'chat2:selectOrPreviewTeamConversation'
 export const sendTyping = 'chat2:sendTyping'
 export const setConvExplodingMode = 'chat2:setConvExplodingMode'
 export const setConvRetentionPolicy = 'chat2:setConvRetentionPolicy'
@@ -259,12 +259,6 @@ type _NotificationSettingsUpdatedPayload = $ReadOnly<{|
   settings: RPCChatTypes.ConversationNotificationInfo,
 |}>
 type _OpenFolderPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey|}>
-type _PreviewKnownTeamConversationPayload = $ReadOnly<{|
-  channelname: string,
-  conversationIDKey: Types.ConversationIDKey,
-  teamname?: string,
-  reason: 'manageView' | 'messageLink' | 'newChannel' | 'previewResolved',
-|}>
 type _ResetChatWithoutThemPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey|}>
 type _ResetLetThemInPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
@@ -273,6 +267,12 @@ type _ResetLetThemInPayload = $ReadOnly<{|
 type _SelectConversationPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
   reason: 'clearSelected' | 'justCreated' | 'desktopNotification' | 'setPendingMode' | 'sendingToPending' | 'createdMessagePrivately' | 'findNewestConversation' | 'inboxBig' | 'inboxFilterArrow' | 'inboxFilterChanged' | 'inboxSmall' | 'inboxNewConversation' | 'jumpFromReset' | 'jumpToReset' | 'justCreated' | 'manageView' | 'previewResolved' | 'pendingModeChange' | 'push' | 'savedLastState' | 'startFoundExisting' | 'teamChat',
+|}>
+type _SelectOrPreviewTeamConversationPayload = $ReadOnly<{|
+  channelname: string,
+  conversationIDKey: Types.ConversationIDKey,
+  teamname?: string,
+  reason: 'manageView' | 'messageLink' | 'newChannel' | 'previewResolved',
 |}>
 type _SendTypingPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
@@ -346,7 +346,7 @@ export const createUpdateConvExplodingModes = (payload: _UpdateConvExplodingMode
 /**
  * Select or preview an existing team conversation.
  */
-export const createPreviewKnownTeamConversation = (payload: _PreviewKnownTeamConversationPayload) => ({error: false, payload, type: previewKnownTeamConversation})
+export const createSelectOrPreviewTeamConversation = (payload: _SelectOrPreviewTeamConversationPayload) => ({error: false, payload, type: selectOrPreviewTeamConversation})
 /**
  * Set a lock on the exploding mode for a conversation.
  */
@@ -477,10 +477,10 @@ export type NavigateToInboxPayload = $Call<typeof createNavigateToInbox, _Naviga
 export type NavigateToThreadPayload = $Call<typeof createNavigateToThread, _NavigateToThreadPayload>
 export type NotificationSettingsUpdatedPayload = $Call<typeof createNotificationSettingsUpdated, _NotificationSettingsUpdatedPayload>
 export type OpenFolderPayload = $Call<typeof createOpenFolder, _OpenFolderPayload>
-export type PreviewKnownTeamConversationPayload = $Call<typeof createPreviewKnownTeamConversation, _PreviewKnownTeamConversationPayload>
 export type ResetChatWithoutThemPayload = $Call<typeof createResetChatWithoutThem, _ResetChatWithoutThemPayload>
 export type ResetLetThemInPayload = $Call<typeof createResetLetThemIn, _ResetLetThemInPayload>
 export type SelectConversationPayload = $Call<typeof createSelectConversation, _SelectConversationPayload>
+export type SelectOrPreviewTeamConversationPayload = $Call<typeof createSelectOrPreviewTeamConversation, _SelectOrPreviewTeamConversationPayload>
 export type SendTypingPayload = $Call<typeof createSendTyping, _SendTypingPayload>
 export type SetConvExplodingModePayload = $Call<typeof createSetConvExplodingMode, _SetConvExplodingModePayload>
 export type SetConvRetentionPolicyPayload = $Call<typeof createSetConvRetentionPolicy, _SetConvRetentionPolicyPayload>
@@ -550,10 +550,10 @@ export type Actions =
   | NavigateToThreadPayload
   | NotificationSettingsUpdatedPayload
   | OpenFolderPayload
-  | PreviewKnownTeamConversationPayload
   | ResetChatWithoutThemPayload
   | ResetLetThemInPayload
   | SelectConversationPayload
+  | SelectOrPreviewTeamConversationPayload
   | SendTypingPayload
   | SetConvExplodingModePayload
   | SetConvRetentionPolicyPayload

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1173,9 +1173,7 @@ const previewConversationAfterFindExisting = (
 
   let existingConversationIDKey = Constants.noConversationIDKey
 
-  const isTeam =
-    action.type === Chat2Gen.findAndPreviewConversation &&
-    (action.payload.teamname || action.payload.channelname)
+  const isTeam = action.type === Chat2Gen.findAndPreviewConversation && action.payload.teamname
   if (results && results.conversations && results.conversations.length > 0) {
     // Even if we find an existing conversation lets put it into the pending state so its on top always, makes the UX simpler and better to see it selected
     // and allows quoting privately to work nicely
@@ -1195,7 +1193,7 @@ const previewConversationAfterFindExisting = (
   if (isTeam) {
     return Saga.put(
       Chat2Gen.createSelectOrPreviewTeamConversation({
-        channelname: action.payload.channelname || '',
+        channelname: 'general',
         conversationIDKey: existingConversationIDKey,
         teamname: action.payload.teamname || '',
         reason: 'previewResolved',
@@ -1221,12 +1219,10 @@ const previewConversationFindExisting = (
 ) => {
   let participants
   let teamname
-  let channelname
   let conversationIDKey
   if (action.type === Chat2Gen.findAndPreviewConversation) {
     participants = action.payload.participants
     teamname = action.payload.teamname
-    channelname = action.payload.channelname || 'general'
   } else if (action.type === Chat2Gen.setPendingConversationUsers) {
     if (!action.payload.fromSearch) {
       return
@@ -1258,7 +1254,7 @@ const previewConversationFindExisting = (
     params = {
       membersType: RPCChatTypes.commonConversationMembersType.team,
       tlfName: teamname,
-      topicName: channelname,
+      topicName: 'general',
     }
   } else if (conversationIDKey) {
     // we can skip the call if we have a conversationid already

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -962,7 +962,7 @@ const messageDelete = (action: Chat2Gen.MessageDeletePayload, state: TypedState)
   const {conversationIDKey, ordinal} = action.payload
   const message = state.chat2.messageMap.getIn([conversationIDKey, ordinal])
   if (!message || (message.type !== 'text' && message.type !== 'attachment')) {
-    logger.warn('Deleting non-existent or, non-text non-attachment message')
+    logger.warn('Deleting non-existent or non-text non-attachment message')
     logger.debug('Deleting invalid message:', message)
     return
   }

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1173,12 +1173,12 @@ const previewConversationAfterFindExisting = (
 
   let existingConversationIDKey = Constants.noConversationIDKey
 
-  const isTeam = action.type === Chat2Gen.findAndPreviewConversation && action.payload.teamname
   if (results && results.conversations && results.conversations.length > 0) {
     // Even if we find an existing conversation lets put it into the pending state so its on top always, makes the UX simpler and better to see it selected
     // and allows quoting privately to work nicely
     existingConversationIDKey = Types.conversationIDToKey(results.conversations[0].info.id)
 
+    const isTeam = action.type === Chat2Gen.findAndPreviewConversation && action.payload.teamname
     // If we get a conversationIDKey we don't know about (maybe an empty convo) lets treat it as not being found so we can go through the create flow
     // if it's a team avoid the flow and just preview & select the channel
     if (
@@ -1190,12 +1190,12 @@ const previewConversationAfterFindExisting = (
   }
 
   // If we're previewing a team conversation we want to actually make an rpc call and add it to the inbox
-  if (isTeam) {
+  if (action.type === Chat2Gen.findAndPreviewConversation && action.payload.teamname) {
     return Saga.put(
       Chat2Gen.createSelectOrPreviewTeamConversation({
         channelname: 'general',
         conversationIDKey: existingConversationIDKey,
-        teamname: action.payload.teamname || '',
+        teamname: action.payload.teamname,
         reason: 'previewResolved',
       })
     )

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -962,7 +962,7 @@ const messageDelete = (action: Chat2Gen.MessageDeletePayload, state: TypedState)
   const {conversationIDKey, ordinal} = action.payload
   const message = state.chat2.messageMap.getIn([conversationIDKey, ordinal])
   if (!message || (message.type !== 'text' && message.type !== 'attachment')) {
-    logger.warn('Deleting non-existant or, non-text non-attachment message')
+    logger.warn('Deleting non-existent or, non-text non-attachment message')
     logger.debug('Deleting invalid message:', message)
     return
   }
@@ -1285,7 +1285,7 @@ const selectOrPreviewTeamConversation = (
 ) => {
   const {conversationIDKey} = action.payload
   if (conversationIDKey === Constants.noConversationIDKey) {
-    throw new Error('Tried to preview a non-existant channel?')
+    throw new Error('Tried to preview a non-existent channel?')
   }
   // TODO: Skip RPC if we already have a row for the channel.
   return Saga.sequentially([

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1194,7 +1194,7 @@ const previewConversationAfterFindExisting = (
   // If we're previewing a team conversation we want to actually make an rpc call and add it to the inbox
   if (isTeam) {
     return Saga.put(
-      Chat2Gen.createPreviewKnownTeamConversation({
+      Chat2Gen.createSelectOrPreviewTeamConversation({
         channelname: action.payload.channelname || '',
         conversationIDKey: existingConversationIDKey,
         teamname: action.payload.teamname || '',
@@ -1289,8 +1289,8 @@ const previewConversationFindExisting = (
   return Saga.sequentially([markPendingWaiting, setUsers, makeCall, passUsersDown])
 }
 
-const previewKnownTeamConversation = (
-  action: Chat2Gen.PreviewKnownTeamConversationPayload,
+const selectOrPreviewTeamConversation = (
+  action: Chat2Gen.SelectOrPreviewTeamConversationPayload,
   state: TypedState
 ) => {
   const {conversationIDKey} = action.payload
@@ -1929,7 +1929,7 @@ const changePendingMode = (
   action:
     | Chat2Gen.SelectConversationPayload
     | Chat2Gen.FindAndPreviewConversationPayload
-    | Chat2Gen.PreviewKnownTeamConversationPayload,
+    | Chat2Gen.SelectOrPreviewTeamConversationPayload,
   state: TypedState
 ) => {
   switch (action.type) {
@@ -1944,7 +1944,7 @@ const changePendingMode = (
           pendingMode: action.payload.reason === 'fromAReset' ? 'startingFromAReset' : 'fixedSetOfUsers',
         })
       )
-    case Chat2Gen.previewKnownTeamConversation:
+    case Chat2Gen.selectOrPreviewTeamConversation:
       // We're selecting a team so we never want to show the row.
       return Saga.put(Chat2Gen.createSetPendingMode({pendingMode: 'none'}))
     case Chat2Gen.selectConversation: {
@@ -2169,7 +2169,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
     previewConversationFindExisting,
     previewConversationAfterFindExisting
   )
-  yield Saga.safeTakeEveryPure(Chat2Gen.previewKnownTeamConversation, previewKnownTeamConversation)
+  yield Saga.safeTakeEveryPure(Chat2Gen.selectOrPreviewTeamConversation, selectOrPreviewTeamConversation)
   yield Saga.safeTakeEveryPure(Chat2Gen.openFolder, openFolder)
 
   // On bootstrap lets load the untrusted inbox. This helps make some flows easier
@@ -2222,7 +2222,11 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
   )
   yield Saga.safeTakeEveryPure(Chat2Gen.createConversation, createConversation, createConversationSelectIt)
   yield Saga.safeTakeEveryPure(
-    [Chat2Gen.selectConversation, Chat2Gen.findAndPreviewConversation, Chat2Gen.previewKnownTeamConversation],
+    [
+      Chat2Gen.selectConversation,
+      Chat2Gen.findAndPreviewConversation,
+      Chat2Gen.selectOrPreviewTeamConversation,
+    ],
     changePendingMode
   )
 

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1295,7 +1295,7 @@ const selectOrPreviewTeamConversation = (
     Saga.put(
       Chat2Gen.createSelectConversation({
         conversationIDKey: conversationIDKey,
-        reason: 'previewResolved',
+        reason: action.payload.reason,
       })
     ),
     Saga.put(Chat2Gen.createNavigateToThread()),

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1184,11 +1184,10 @@ const previewConversationFindExisting = (
     identifyBehavior: RPCTypes.tlfKeysTLFIdentifyBehavior.chatGui,
     membersType: RPCChatTypes.commonConversationMembersType.impteamnative,
     oneChatPerTLF: true,
+    tlfName: toFind.join(','),
     topicName: '',
     topicType: RPCChatTypes.commonTopicType.chat,
     visibility: RPCTypes.commonTLFVisibility.private,
-
-    tlfName: toFind.join(','),
   })
 
   const passUsersDown = Saga.identity(users)
@@ -1230,7 +1229,6 @@ const previewConversationAfterFindExisting = (
     existingConversationIDKey = Types.conversationIDToKey(results.conversations[0].info.id)
 
     // If we get a conversationIDKey we don't know about (maybe an empty convo) lets treat it as not being found so we can go through the create flow
-    // if it's a team avoid the flow and just preview & select the channel
     if (!Constants.maybeGetMeta(state, existingConversationIDKey)) {
       existingConversationIDKey = Constants.noConversationIDKey
     }
@@ -1252,11 +1250,10 @@ const findTeamGeneral = (action: Chat2Gen.FindAndSelectTeamGeneralPayload, state
     identifyBehavior: RPCTypes.tlfKeysTLFIdentifyBehavior.chatGui,
     membersType: RPCChatTypes.commonConversationMembersType.team,
     oneChatPerTLF: true,
-    topicType: RPCChatTypes.commonTopicType.chat,
-    visibility: RPCTypes.commonTLFVisibility.private,
-
     tlfName: action.payload.teamname,
     topicName: 'general',
+    topicType: RPCChatTypes.commonTopicType.chat,
+    visibility: RPCTypes.commonTLFVisibility.private,
   })
 
 const selectTeamGeneral = (
@@ -1266,8 +1263,6 @@ const selectTeamGeneral = (
   let existingConversationIDKey = Constants.noConversationIDKey
 
   if (results && results.conversations && results.conversations.length > 0) {
-    // Even if we find an existing conversation lets put it into the pending state so its on top always, makes the UX simpler and better to see it selected
-    // and allows quoting privately to work nicely
     existingConversationIDKey = Types.conversationIDToKey(results.conversations[0].info.id)
   }
 
@@ -1276,7 +1271,7 @@ const selectTeamGeneral = (
       channelname: 'general',
       conversationIDKey: existingConversationIDKey,
       teamname: action.payload.teamname,
-      reason: 'previewResolved',
+      reason: 'teamGeneral',
     })
   )
 }

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1925,10 +1925,6 @@ const changePendingMode = (
 ) => {
   switch (action.type) {
     case Chat2Gen.startPendingConversation:
-      // We decided to make a team instead of start a convo, so no resolution will take place
-      if (action.payload.reason === 'convertAdHoc') {
-        return Saga.put(Chat2Gen.createSetPendingMode({pendingMode: 'none'}))
-      }
       // Otherwise, we're starting a chat with some users.
       return Saga.put(
         Chat2Gen.createSetPendingMode({

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1203,7 +1203,7 @@ const previewConversationAfterFindExisting = (
     return Saga.sequentially([
       Saga.put(
         Chat2Gen.createSetPendingConversationExistingConversationIDKey({
-          conversationIDKey: existingConversationIDKey || Constants.noConversationIDKey,
+          conversationIDKey: existingConversationIDKey,
         })
       ),
       Saga.put(Chat2Gen.createSetPendingConversationUsers({fromSearch: false, users})),

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1260,20 +1260,19 @@ const selectTeamGeneral = (
   results: ?RPCChatTypes.FindConversationsLocalRes,
   action: Chat2Gen.FindAndSelectTeamGeneralPayload
 ) => {
-  let existingConversationIDKey = Constants.noConversationIDKey
-
   if (results && results.conversations && results.conversations.length > 0) {
-    existingConversationIDKey = Types.conversationIDToKey(results.conversations[0].info.id)
+    const conversationIDKey = Types.conversationIDToKey(results.conversations[0].info.id)
+    return Saga.put(
+      Chat2Gen.createSelectOrPreviewTeamConversation({
+        channelname: 'general',
+        conversationIDKey,
+        teamname: action.payload.teamname,
+        reason: 'teamGeneral',
+      })
+    )
   }
 
-  return Saga.put(
-    Chat2Gen.createSelectOrPreviewTeamConversation({
-      channelname: 'general',
-      conversationIDKey: existingConversationIDKey,
-      teamname: action.payload.teamname,
-      reason: 'teamGeneral',
-    })
-  )
+  throw new Error(`Couldn't find #general for ${action.payload.teamname}`)
 }
 
 const selectOrPreviewTeamConversation = (

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1219,7 +1219,6 @@ const previewConversationFindExisting = (
 ) => {
   let participants
   let teamname
-  let conversationIDKey
   if (action.type === Chat2Gen.findAndPreviewConversation) {
     participants = action.payload.participants
     teamname = action.payload.teamname
@@ -1256,8 +1255,6 @@ const previewConversationFindExisting = (
       tlfName: teamname,
       topicName: 'general',
     }
-  } else if (conversationIDKey) {
-    // we can skip the call if we have a conversationid already
   } else {
     throw new Error('Start conversation called w/ no participants or teamname')
   }
@@ -1268,17 +1265,15 @@ const previewConversationFindExisting = (
     })
   )
 
-  const makeCall = conversationIDKey
-    ? null
-    : Saga.call(RPCChatTypes.localFindConversationsLocalRpcPromise, {
-        identifyBehavior: RPCTypes.tlfKeysTLFIdentifyBehavior.chatGui,
-        membersType: RPCChatTypes.commonConversationMembersType.impteamnative,
-        oneChatPerTLF: true,
-        topicName: '',
-        topicType: RPCChatTypes.commonTopicType.chat,
-        visibility: RPCTypes.commonTLFVisibility.private,
-        ...params,
-      })
+  const makeCall = Saga.call(RPCChatTypes.localFindConversationsLocalRpcPromise, {
+    identifyBehavior: RPCTypes.tlfKeysTLFIdentifyBehavior.chatGui,
+    membersType: RPCChatTypes.commonConversationMembersType.impteamnative,
+    oneChatPerTLF: true,
+    topicName: '',
+    topicType: RPCChatTypes.commonTopicType.chat,
+    visibility: RPCTypes.commonTLFVisibility.private,
+    ...params,
+  })
 
   const passUsersDown = Saga.identity(users)
 

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1235,14 +1235,13 @@ const previewConversationFindExisting = (
       )
     }
   }
-  const you = state.config.username || ''
-
   let params
   let users
   let setUsers
 
   // we handled participants or teams
   if (participants) {
+    const you = state.config.username || ''
     const toFind = I.Set(participants).add(you)
     params = {tlfName: toFind.join(',')}
     users = I.Set(participants)

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -49,11 +49,8 @@
         "'teamGeneral'"
       ]
     },
-    // Find a existing conversation and preview it, or setup an empty one. Can either be adhoc or a tlf (adhoc or team)
-    // fromAReset means you were in a reset kbfs convo and you want to make a new one
-    // Chatting from external places in the app should usually call this
-    // If you already know the conversationID for a team channel, use previewKnownTeamConversation instead.
-    "findAndPreviewConversation": {
+    "startPendingConversation": {
+      "_description": "Start a pending conversation with the given participants. fromAReset means you were in a reset kbfs convo and you want to make a new one. Chatting from external places in the app should usually call this.",
       "participants": "Array<string>",
       "reason": [
         "'resetChatWithoutThem'",

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -35,13 +35,18 @@
         "'jumpFromReset'", // from older reset convo
         "'jumpToReset'", // going to an older reset convo
         "'justCreated'", // just made it and select it
-        "'manageView'", // clicked from manage screen
-        "'previewResolved'", // did a preview and are now selecting it
+        "'selectOrPreview'", // did a preview and are now selecting it
         "'pendingModeChange'", // pending mode changed so we select the pending conversation id key
         "'push'", // from a push
         "'savedLastState'", // last seen chat tab
         "'startFoundExisting'", // starting a conversation and found one already
-        "'teamChat'" // from team
+        "'teamChat'", // from team
+
+        // From selectOrPreviewTeamConversation (see below).
+        "'manageView'",
+        "'messageLink'",
+        "'newChannel'",
+        "'previewResolved'"
       ]
     },
     // Find a existing conversation and preview it, or setup an empty one. Can either be adhoc or a tlf (adhoc or team)
@@ -75,10 +80,10 @@
       // e.g. for messageLink.
       "teamname?": "string",
       "reason": [
-        "'manageView'",
-        "'messageLink'",
-        "'newChannel'",
-        "'previewResolved'"
+        "'manageView'", // clicked from manage screen
+        "'messageLink'", // clicked channel mention
+        "'newChannel'", // created a new channel
+        "'previewResolved'" // did a preview and are now selecting it
       ]
     },
     "createConversation": {

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -46,7 +46,7 @@
         "'manageView'",
         "'messageLink'",
         "'newChannel'",
-        "'previewResolved'"
+        "'teamGeneral'"
       ]
     },
     // Find a existing conversation and preview it, or setup an empty one. Can either be adhoc or a tlf (adhoc or team)
@@ -88,7 +88,7 @@
         "'manageView'", // clicked from manage screen
         "'messageLink'", // clicked channel mention
         "'newChannel'", // created a new channel
-        "'previewResolved'" // did a preview and are now selecting it
+        "'teamGeneral'" // selecting #general for a team
       ]
     },
     "createConversation": {

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -51,7 +51,6 @@
     "findAndPreviewConversation": {
       "participants?": "Array<string>",
       "teamname?": "string",
-      "channelname?": "string",
       "reason": [
         "'resetChatWithoutThem'",
         "'tracker'",

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -67,12 +67,13 @@
       ]
     },
     
-    "previewKnownTeamConversation": {
+    "selectOrPreviewTeamConversation": {
       "_description": "Select or preview an existing team conversation.",
       // Not strictly needed, but convenient to know when debugging.
       "channelname": "string",
       "conversationIDKey": "Types.ConversationIDKey",
-      // Also not strictly needed, and may not be known by the caller.
+      // Also not strictly needed, and may not be known by the caller,
+      // e.g. for messageLink.
       "teamname?": "string",
       "reason": [
         "'manageView'",

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -44,18 +44,15 @@
         "'teamChat'" // from team
       ]
     },
-    // Select an existing conversation or setup an empty one. Can either be adhoc or a tlf (adhoc or team)
+    // Find a existing conversation and preview it, or setup an empty one. Can either be adhoc or a tlf (adhoc or team)
     // fromAReset means you were in a reset kbfs convo and you want to make a new one
     // Chatting from external places in the app should usually call this
-    // if you want to preview a team chat (and add it to the inbox use selectConversation instead)
-    "previewConversation": {
+    // If you already know the conversationID for a team channel, use previewKnownTeamConversation instead.
+    "findAndPreviewConversation": {
       "participants?": "Array<string>",
       "teamname?": "string",
       "channelname?": "string",
-      "conversationIDKey?": "Types.ConversationIDKey", // we only use this when we click on channel mentions. we could maybe change that plumbing but keeping it for now
       "reason": [
-        "'manageView'",
-        "'messageLink'",
         "'resetChatWithoutThem'",
         "'tracker'",
         "'teamHeader'",
@@ -66,8 +63,22 @@
         "'teamMember'",
         "'teamHeader'",
         "'convertAdHoc'",
-        "'memberView'",
-        "'newChannel'"
+        "'memberView'"
+      ]
+    },
+    
+    "previewKnownTeamConversation": {
+      "_description": "Select or preview an existing team conversation.",
+      // Not strictly needed, but convenient to know when debugging.
+      "channelname": "string",
+      "conversationIDKey": "Types.ConversationIDKey",
+      // Also not strictly needed, and may not be known by the caller.
+      "teamname?": "string",
+      "reason": [
+        "'manageView'",
+        "'messageLink'",
+        "'newChannel'",
+        "'previewResolved'"
       ]
     },
     "createConversation": {

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -54,8 +54,7 @@
     // Chatting from external places in the app should usually call this
     // If you already know the conversationID for a team channel, use previewKnownTeamConversation instead.
     "findAndPreviewConversation": {
-      "participants?": "Array<string>",
-      "teamname?": "string",
+      "participants": "Array<string>",
       "reason": [
         "'resetChatWithoutThem'",
         "'tracker'",
@@ -65,12 +64,18 @@
         "'fromAReset'",
         "'profile'",
         "'teamMember'",
-        "'teamHeader'",
-        "'convertAdHoc'",
         "'memberView'"
       ]
     },
-    
+    "findAndSelectTeamGeneral": {
+      "_description": "Find the #general channel for the given team, then select it.",
+      "teamname": "string",
+      "reason": [
+        "'files'",
+        "'teamHeader'",
+        "'convertAdHoc'"
+      ]
+    },    
     "selectOrPreviewTeamConversation": {
       "_description": "Select or preview an existing team conversation.",
       // Not strictly needed, but convenient to know when debugging.

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -383,7 +383,7 @@ const _createNewTeamFromConversation = function*(
           })
         }
       }
-      yield Saga.put(Chat2Gen.createPreviewConversation({teamname, reason: 'convertAdHoc'}))
+      yield Saga.put(Chat2Gen.createFindAndPreviewConversation({teamname, reason: 'convertAdHoc'}))
     } catch (error) {
       yield Saga.put(TeamsGen.createSetTeamCreationError({error: error.desc}))
     } finally {
@@ -877,7 +877,7 @@ function* _createChannel(action: TeamsGen.CreateChannelPayload) {
 
     // Select the new channel, and switch to the chat tab.
     yield Saga.put(
-      Chat2Gen.createPreviewConversation({
+      Chat2Gen.createPreviewKnownTeamConversation({
         channelname,
         conversationIDKey: newConversationIDKey,
         reason: 'newChannel',

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -383,7 +383,7 @@ const _createNewTeamFromConversation = function*(
           })
         }
       }
-      yield Saga.put(Chat2Gen.createFindAndPreviewConversation({teamname, reason: 'convertAdHoc'}))
+      yield Saga.put(Chat2Gen.createFindAndSelectTeamGeneral({teamname, reason: 'convertAdHoc'}))
     } catch (error) {
       yield Saga.put(TeamsGen.createSetTeamCreationError({error: error.desc}))
     } finally {

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -877,7 +877,7 @@ function* _createChannel(action: TeamsGen.CreateChannelPayload) {
 
     // Select the new channel, and switch to the chat tab.
     yield Saga.put(
-      Chat2Gen.createPreviewKnownTeamConversation({
+      Chat2Gen.createSelectOrPreviewTeamConversation({
         channelname,
         conversationIDKey: newConversationIDKey,
         reason: 'newChannel',

--- a/shared/chat/conversation/messages/system-old-profile-reset-notice/container.js
+++ b/shared/chat/conversation/messages/system-old-profile-reset-notice/container.js
@@ -18,7 +18,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onOpenConversation: (conversationIDKey: Types.ConversationIDKey) =>
     dispatch(Chat2Gen.createSelectConversation({conversationIDKey, reason: 'jumpFromReset'})),
   startConversation: (participants: Array<string>) =>
-    dispatch(Chat2Gen.createPreviewConversation({participants, reason: 'fromAReset'})),
+    dispatch(Chat2Gen.createFindAndPreviewConversation({participants, reason: 'fromAReset'})),
 })
 
 const mergeProps = (stateProps, dispatchProps) => {

--- a/shared/chat/conversation/messages/system-old-profile-reset-notice/container.js
+++ b/shared/chat/conversation/messages/system-old-profile-reset-notice/container.js
@@ -18,7 +18,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onOpenConversation: (conversationIDKey: Types.ConversationIDKey) =>
     dispatch(Chat2Gen.createSelectConversation({conversationIDKey, reason: 'jumpFromReset'})),
   startConversation: (participants: Array<string>) =>
-    dispatch(Chat2Gen.createFindAndPreviewConversation({participants, reason: 'fromAReset'})),
+    dispatch(Chat2Gen.createStartPendingConversation({participants, reason: 'fromAReset'})),
 })
 
 const mergeProps = (stateProps, dispatchProps) => {

--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -95,7 +95,8 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
         })
       )
       dispatch(navigateUp())
-      dispatch(Chat2Gen.createPreviewConversation({teamname, channelname, reason: 'manageView'}))
+      // TODO: Use findKnownTeamConversation, use manageView.
+      dispatch(Chat2Gen.createFindAndPreviewConversation({teamname, channelname, reason: 'memberView'}))
     },
   }
 }

--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -84,6 +84,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
       oldChannelState: ChannelMembershipState,
       nextChannelState: ChannelMembershipState,
       you: string,
+      convID: ChatTypes.ConversationIDKey,
       channelname: string
     ) => {
       dispatch(
@@ -95,8 +96,14 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
         })
       )
       dispatch(navigateUp())
-      // TODO: Use findKnownTeamConversation, use manageView.
-      dispatch(Chat2Gen.createFindAndPreviewConversation({teamname, channelname, reason: 'memberView'}))
+      dispatch(
+        Chat2Gen.createSelectOrPreviewTeamConversation({
+          conversationIDKey: convID,
+          teamname,
+          channelname,
+          reason: 'manageView',
+        })
+      )
     },
   }
 }
@@ -125,8 +132,8 @@ export default compose(
       }),
     onSaveSubscriptions: props => () =>
       props._saveSubscriptions(props.oldChannelState, props.nextChannelState, props._you),
-    onClickChannel: props => (channelname: string) => {
-      props._onView(props.oldChannelState, props.nextChannelState, props._you, channelname)
+    onClickChannel: props => (convID: ChatTypes.ConversationIDKey, channelname: string) => {
+      props._onView(props.oldChannelState, props.nextChannelState, props._you, convID, channelname)
     },
   }),
   lifecycle({

--- a/shared/chat/manage-channels/index.desktop.js
+++ b/shared/chat/manage-channels/index.desktop.js
@@ -124,7 +124,7 @@ const ManageChannels = (props: Props) => {
               onToggle={() => props.onToggle(c.convID)}
               showEdit={!props.unsavedSubscriptions}
               onEdit={() => props.onEdit(c.convID)}
-              onClickChannel={() => props.onClickChannel(c.name)}
+              onClickChannel={() => props.onClickChannel(c.convID, c.name)}
             />
           ))}
         </ScrollView>

--- a/shared/chat/manage-channels/index.js.flow
+++ b/shared/chat/manage-channels/index.js.flow
@@ -16,7 +16,7 @@ export type Props = {
   onToggle: (convID: ConversationIDKey) => void,
   onEdit: (convID: ConversationIDKey) => void,
   onClose: () => void,
-  onClickChannel: (channelname: string) => void,
+  onClickChannel: (convID: ConversationIDKey, channelname: string) => void,
   teamname: string,
   unsavedSubscriptions: boolean,
   onSaveSubscriptions: () => void,

--- a/shared/chat/manage-channels/index.native.js
+++ b/shared/chat/manage-channels/index.native.js
@@ -100,7 +100,7 @@ const ManageChannels = (props: Props) => (
           onToggle={() => props.onToggle(c.convID)}
           showEdit={!props.unsavedSubscriptions}
           onEdit={() => props.onEdit(c.convID)}
-          onClickChannel={() => props.onClickChannel(c.name)}
+          onClickChannel={() => props.onClickChannel(c.convID, c.name)}
         />
       ))}
     </ScrollView>

--- a/shared/common-adapters/channel-container.js
+++ b/shared/common-adapters/channel-container.js
@@ -8,7 +8,7 @@ const mapStateToProps = (state: TypedState) => ({})
 const mapDispatchToProps = (dispatch: Dispatch, {convID, name}) => ({
   onClick: () =>
     dispatch(
-      Chat2Gen.createPreviewKnownTeamConversation({
+      Chat2Gen.createSelectOrPreviewTeamConversation({
         conversationIDKey: convID,
         channelname: name,
         reason: 'messageLink',

--- a/shared/common-adapters/channel-container.js
+++ b/shared/common-adapters/channel-container.js
@@ -8,7 +8,7 @@ const mapStateToProps = (state: TypedState) => ({})
 const mapDispatchToProps = (dispatch: Dispatch, {convID, name}) => ({
   onClick: () =>
     dispatch(
-      Chat2Gen.createPreviewConversation({
+      Chat2Gen.createPreviewKnownTeamConversation({
         conversationIDKey: convID,
         channelname: name,
         reason: 'messageLink',

--- a/shared/common-adapters/channel-container.js
+++ b/shared/common-adapters/channel-container.js
@@ -12,6 +12,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {convID, name}) => ({
         conversationIDKey: convID,
         channelname: name,
         reason: 'messageLink',
+        // We don't know the teamname here.
       })
     ),
 })

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -165,6 +165,7 @@ export const makeInboxQuery = (
 
 export {
   getConversationIDKeyMetasToLoad,
+  maybeGetMeta,
   getMeta,
   getRowParticipants,
   getRowStyles,

--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -281,6 +281,8 @@ export const makeConversationMeta: I.RecordFactory<_ConversationMeta> = I.Record
   wasFinalizedBy: '',
 })
 
+export const maybeGetMeta = (state: TypedState, id: Types.ConversationIDKey) => state.chat2.metaMap.get(id)
+
 const emptyMeta = makeConversationMeta()
 export const getMeta = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.metaMap.get(id, emptyMeta)

--- a/shared/folders/container.desktop.js
+++ b/shared/folders/container.desktop.js
@@ -29,7 +29,7 @@ const mapDispatchToProps = (dispatch: any, {routePath, routeState, setRouteState
     if (participants) {
       dispatch(Chat2Gen.createFindAndPreviewConversation({participants, reason: 'files'}))
     } else if (teamname) {
-      dispatch(Chat2Gen.createFindAndPreviewConversation({teamname, reason: 'files'}))
+      dispatch(Chat2Gen.createFindAndSelectTeamGeneral({teamname, reason: 'files'}))
     }
   },
   onClick: path => dispatch(navigateAppend([{props: {path}, selected: 'files'}])),

--- a/shared/folders/container.desktop.js
+++ b/shared/folders/container.desktop.js
@@ -27,9 +27,9 @@ const mapDispatchToProps = (dispatch: any, {routePath, routeState, setRouteState
   onChat: tlf => {
     const {participants, teamname} = tlfToParticipantsOrTeamname(tlf)
     if (participants) {
-      dispatch(Chat2Gen.createPreviewConversation({participants, reason: 'files'}))
+      dispatch(Chat2Gen.createFindAndPreviewConversation({participants, reason: 'files'}))
     } else if (teamname) {
-      dispatch(Chat2Gen.createPreviewConversation({teamname, reason: 'files'}))
+      dispatch(Chat2Gen.createFindAndPreviewConversation({teamname, reason: 'files'}))
     }
   },
   onClick: path => dispatch(navigateAppend([{props: {path}, selected: 'files'}])),

--- a/shared/folders/container.desktop.js
+++ b/shared/folders/container.desktop.js
@@ -27,7 +27,7 @@ const mapDispatchToProps = (dispatch: any, {routePath, routeState, setRouteState
   onChat: tlf => {
     const {participants, teamname} = tlfToParticipantsOrTeamname(tlf)
     if (participants) {
-      dispatch(Chat2Gen.createFindAndPreviewConversation({participants, reason: 'files'}))
+      dispatch(Chat2Gen.createStartPendingConversation({participants, reason: 'files'}))
     } else if (teamname) {
       dispatch(Chat2Gen.createFindAndSelectTeamGeneral({teamname, reason: 'files'}))
     }

--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -78,7 +78,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {setRouteState}: OwnProps) => ({
     ),
   onChangeFriendshipsTab: currentFriendshipsTab => setRouteState({currentFriendshipsTab}),
   onChat: username =>
-    dispatch(Chat2Gen.createFindAndPreviewConversation({participants: [username], reason: 'profile'})),
+    dispatch(Chat2Gen.createStartPendingConversation({participants: [username], reason: 'profile'})),
   onClearAddUserToTeamsResults: () => dispatch(TeamsGen.createSetAddUserToTeamsResults({results: ''})),
   onClickAvatar: (username: string) => dispatch(ProfileGen.createOnClickAvatar({username})),
   onClickFollowers: (username: string) => dispatch(ProfileGen.createOnClickFollowers({username})),

--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -78,7 +78,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {setRouteState}: OwnProps) => ({
     ),
   onChangeFriendshipsTab: currentFriendshipsTab => setRouteState({currentFriendshipsTab}),
   onChat: username =>
-    dispatch(Chat2Gen.createPreviewConversation({participants: [username], reason: 'profile'})),
+    dispatch(Chat2Gen.createFindAndPreviewConversation({participants: [username], reason: 'profile'})),
   onClearAddUserToTeamsResults: () => dispatch(TeamsGen.createSetAddUserToTeamsResults({results: ''})),
   onClickAvatar: (username: string) => dispatch(ProfileGen.createOnClickAvatar({username})),
   onClickFollowers: (username: string) => dispatch(ProfileGen.createOnClickFollowers({username})),

--- a/shared/profile/non-user-profile/container.js
+++ b/shared/profile/non-user-profile/container.js
@@ -21,7 +21,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
   },
   onStartChat: (username: string) => {
     if (username) {
-      dispatch(Chat2Gen.createFindAndPreviewConversation({participants: [username], reason: 'profile'}))
+      dispatch(Chat2Gen.createStartPendingConversation({participants: [username], reason: 'profile'}))
     }
   },
 })

--- a/shared/profile/non-user-profile/container.js
+++ b/shared/profile/non-user-profile/container.js
@@ -21,7 +21,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
   },
   onStartChat: (username: string) => {
     if (username) {
-      dispatch(Chat2Gen.createPreviewConversation({participants: [username], reason: 'profile'}))
+      dispatch(Chat2Gen.createFindAndPreviewConversation({participants: [username], reason: 'profile'}))
     }
   },
 })

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -742,7 +742,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     case Chat2Gen.updateNotificationSettings:
     case Chat2Gen.blockConversation:
     case Chat2Gen.findAndPreviewConversation:
-    case Chat2Gen.previewKnownTeamConversation:
+    case Chat2Gen.selectOrPreviewTeamConversation:
     case Chat2Gen.createConversation:
     case Chat2Gen.setConvExplodingMode:
     case Chat2Gen.handleSeeingExplodingMessages:

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -742,6 +742,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     case Chat2Gen.updateNotificationSettings:
     case Chat2Gen.blockConversation:
     case Chat2Gen.findAndPreviewConversation:
+    case Chat2Gen.findAndSelectTeamGeneral:
     case Chat2Gen.selectOrPreviewTeamConversation:
     case Chat2Gen.createConversation:
     case Chat2Gen.setConvExplodingMode:

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -741,7 +741,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     case Chat2Gen.messageAttachmentNativeSave:
     case Chat2Gen.updateNotificationSettings:
     case Chat2Gen.blockConversation:
-    case Chat2Gen.findAndPreviewConversation:
+    case Chat2Gen.startPendingConversation:
     case Chat2Gen.findAndSelectTeamGeneral:
     case Chat2Gen.selectOrPreviewTeamConversation:
     case Chat2Gen.createConversation:

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -741,7 +741,8 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     case Chat2Gen.messageAttachmentNativeSave:
     case Chat2Gen.updateNotificationSettings:
     case Chat2Gen.blockConversation:
-    case Chat2Gen.previewConversation:
+    case Chat2Gen.findAndPreviewConversation:
+    case Chat2Gen.previewKnownTeamConversation:
     case Chat2Gen.createConversation:
     case Chat2Gen.setConvExplodingMode:
     case Chat2Gen.handleSeeingExplodingMessages:

--- a/shared/teams/team/custom-title/container.js
+++ b/shared/teams/team/custom-title/container.js
@@ -14,7 +14,7 @@ const mapStateToProps = (state: TypedState, {teamname}) => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {teamname}) => ({
-  onChat: () => dispatch(Chat2Gen.createFindAndPreviewConversation({teamname, reason: 'teamHeader'})),
+  onChat: () => dispatch(Chat2Gen.createFindAndSelectTeamGeneral({teamname, reason: 'teamHeader'})),
   onOpenFolder: () => dispatch(KBFSGen.createOpen({path: `/keybase/team/${teamname}`})),
 })
 

--- a/shared/teams/team/custom-title/container.js
+++ b/shared/teams/team/custom-title/container.js
@@ -14,7 +14,8 @@ const mapStateToProps = (state: TypedState, {teamname}) => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {teamname}) => ({
-  onChat: () => dispatch(Chat2Gen.createPreviewConversation({teamname, reason: 'teamHeader'})),
+  // TODO: Should probably use previewKnownTeamConversation.
+  onChat: () => dispatch(Chat2Gen.createFindAndPreviewConversation({teamname, reason: 'teamHeader'})),
   onOpenFolder: () => dispatch(KBFSGen.createOpen({path: `/keybase/team/${teamname}`})),
 })
 

--- a/shared/teams/team/custom-title/container.js
+++ b/shared/teams/team/custom-title/container.js
@@ -14,7 +14,6 @@ const mapStateToProps = (state: TypedState, {teamname}) => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {teamname}) => ({
-  // TODO: Should probably use previewKnownTeamConversation.
   onChat: () => dispatch(Chat2Gen.createFindAndPreviewConversation({teamname, reason: 'teamHeader'})),
   onOpenFolder: () => dispatch(KBFSGen.createOpen({path: `/keybase/team/${teamname}`})),
 })

--- a/shared/teams/team/header/container.js
+++ b/shared/teams/team/header/container.js
@@ -34,7 +34,8 @@ const mapDispatchToProps = (dispatch: Dispatch, {teamname}: OwnProps) => ({
     dispatch(navigateAppend([{props: {teamname}, selected: 'addPeople'}]))
     dispatch(createAddResultsToUserInput({searchKey: 'addToTeamSearch', searchResults: [you]}))
   },
-  onChat: () => dispatch(Chat2Gen.createPreviewConversation({teamname, reason: 'teamHeader'})),
+  // TODO: Should probably use previewKnownTeamConversation.
+  onChat: () => dispatch(Chat2Gen.createFindAndPreviewConversation({teamname, reason: 'teamHeader'})),
   onEditDescription: () => dispatch(navigateAppend([{props: {teamname}, selected: 'editTeamDescription'}])),
 })
 

--- a/shared/teams/team/header/container.js
+++ b/shared/teams/team/header/container.js
@@ -34,7 +34,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {teamname}: OwnProps) => ({
     dispatch(navigateAppend([{props: {teamname}, selected: 'addPeople'}]))
     dispatch(createAddResultsToUserInput({searchKey: 'addToTeamSearch', searchResults: [you]}))
   },
-  onChat: () => dispatch(Chat2Gen.createFindAndPreviewConversation({teamname, reason: 'teamHeader'})),
+  onChat: () => dispatch(Chat2Gen.createFindAndSelectTeamGeneral({teamname, reason: 'teamHeader'})),
   onEditDescription: () => dispatch(navigateAppend([{props: {teamname}, selected: 'editTeamDescription'}])),
 })
 

--- a/shared/teams/team/header/container.js
+++ b/shared/teams/team/header/container.js
@@ -34,7 +34,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {teamname}: OwnProps) => ({
     dispatch(navigateAppend([{props: {teamname}, selected: 'addPeople'}]))
     dispatch(createAddResultsToUserInput({searchKey: 'addToTeamSearch', searchResults: [you]}))
   },
-  // TODO: Should probably use previewKnownTeamConversation.
   onChat: () => dispatch(Chat2Gen.createFindAndPreviewConversation({teamname, reason: 'teamHeader'})),
   onEditDescription: () => dispatch(navigateAppend([{props: {teamname}, selected: 'editTeamDescription'}])),
 })

--- a/shared/teams/team/invites-tab/request-row/container.js
+++ b/shared/teams/team/invites-tab/request-row/container.js
@@ -24,7 +24,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       ])
     ),
   _onChat: username => {
-    username && dispatch(Chat2Gen.createPreviewConversation({participants: [username], reason: 'teamInvite'}))
+    username &&
+      dispatch(Chat2Gen.createFindAndPreviewConversation({participants: [username], reason: 'teamInvite'}))
   },
   _onIgnoreRequest: (teamname: string, username: string) =>
     dispatch(TeamsGen.createIgnoreRequest({teamname, username})),

--- a/shared/teams/team/invites-tab/request-row/container.js
+++ b/shared/teams/team/invites-tab/request-row/container.js
@@ -25,7 +25,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     ),
   _onChat: username => {
     username &&
-      dispatch(Chat2Gen.createFindAndPreviewConversation({participants: [username], reason: 'teamInvite'}))
+      dispatch(Chat2Gen.createStartPendingConversation({participants: [username], reason: 'teamInvite'}))
   },
   _onIgnoreRequest: (teamname: string, username: string) =>
     dispatch(TeamsGen.createIgnoreRequest({teamname, username})),

--- a/shared/teams/team/member/container.js
+++ b/shared/teams/team/member/container.js
@@ -69,7 +69,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {routeProps, navigateAppend, nav
   },
   _onChat: username => {
     username &&
-      dispatch(Chat2Gen.createFindAndPreviewConversation({participants: [username], reason: 'memberView'}))
+      dispatch(Chat2Gen.createStartPendingConversation({participants: [username], reason: 'memberView'}))
   },
   onBack: () => dispatch(navigateUp()),
 })

--- a/shared/teams/team/member/container.js
+++ b/shared/teams/team/member/container.js
@@ -68,7 +68,8 @@ const mapDispatchToProps = (dispatch: Dispatch, {routeProps, navigateAppend, nav
     dispatch(navigateAppend([{props: {teamname}, selected: 'reallyLeaveTeam'}]))
   },
   _onChat: username => {
-    username && dispatch(Chat2Gen.createPreviewConversation({participants: [username], reason: 'memberView'}))
+    username &&
+      dispatch(Chat2Gen.createFindAndPreviewConversation({participants: [username], reason: 'memberView'}))
   },
   onBack: () => dispatch(navigateUp()),
 })

--- a/shared/teams/team/members-tab/member-row/container.js
+++ b/shared/teams/team/members-tab/member-row/container.js
@@ -61,7 +61,9 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps): DispatchPro
   },
   onChat: () => {
     ownProps.username &&
-      dispatch(Chat2Gen.createPreviewConversation({participants: [ownProps.username], reason: 'teamMember'}))
+      dispatch(
+        Chat2Gen.createFindAndPreviewConversation({participants: [ownProps.username], reason: 'teamMember'})
+      )
   },
   onClick: () => dispatch(navigateAppend([{props: ownProps, selected: 'member'}])),
 })

--- a/shared/teams/team/members-tab/member-row/container.js
+++ b/shared/teams/team/members-tab/member-row/container.js
@@ -62,7 +62,7 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps): DispatchPro
   onChat: () => {
     ownProps.username &&
       dispatch(
-        Chat2Gen.createFindAndPreviewConversation({participants: [ownProps.username], reason: 'teamMember'})
+        Chat2Gen.createStartPendingConversation({participants: [ownProps.username], reason: 'teamMember'})
       )
   },
   onClick: () => dispatch(navigateAppend([{props: ownProps, selected: 'member'}])),

--- a/shared/tracker/remote-container.desktop.js
+++ b/shared/tracker/remote-container.desktop.js
@@ -23,7 +23,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {teamname}) => ({
   _loadTeams: () => dispatch(TeamsGen.createGetTeams()),
   _onChat: (username: string) => {
     dispatch(AppGen.createShowMain())
-    dispatch(Chat2Gen.createPreviewConversation({participants: [username], reason: 'tracker'}))
+    dispatch(Chat2Gen.createFindAndPreviewConversation({participants: [username], reason: 'tracker'}))
   },
   _onClickAvatar: (username: string) =>
     dispatch(ProfileGen.createOnClickAvatar({openWebsite: true, username})),

--- a/shared/tracker/remote-container.desktop.js
+++ b/shared/tracker/remote-container.desktop.js
@@ -23,7 +23,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {teamname}) => ({
   _loadTeams: () => dispatch(TeamsGen.createGetTeams()),
   _onChat: (username: string) => {
     dispatch(AppGen.createShowMain())
-    dispatch(Chat2Gen.createFindAndPreviewConversation({participants: [username], reason: 'tracker'}))
+    dispatch(Chat2Gen.createStartPendingConversation({participants: [username], reason: 'tracker'}))
   },
   _onClickAvatar: (username: string) =>
     dispatch(ProfileGen.createOnClickAvatar({openWebsite: true, username})),


### PR DESCRIPTION
...into one for finding conversations for a list of people,
one for finding the general channel for a team, and one for
selecting a team channel with a known ID.

Fix clicking on a channel from the manage channel screen to
just select the conversation.