### PR TITLE
more robust strategy for finding next merkle root after revokes

### DIFF
--- a/go/client/cmd_fnmr.go
+++ b/go/client/cmd_fnmr.go
@@ -1,0 +1,132 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+type modeFNMR int
+
+const (
+	modeFNMRNone   modeFNMR = 0
+	modeFNMRRevoke modeFNMR = 1
+)
+
+type cmdFNMR struct {
+	libkb.Contextified
+	mode  modeFNMR
+	uid   keybase1.UID
+	seqno keybase1.Seqno
+	upak  keybase1.UPAKVersioned
+}
+
+func NewCmdFNMR(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "fnmr",
+		Description:  "Find next merkle Root",
+		ArgumentHelp: "uid",
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  "revoke,k",
+				Usage: "sequence # of the revoke to query",
+			},
+		},
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&cmdFNMR{Contextified: libkb.NewContextified(g)}, "fnmr", c)
+		},
+	}
+}
+
+func (c *cmdFNMR) runRevoke(ctx context.Context, cli keybase1.UserClient) error {
+	v, err := c.upak.V()
+	if err != nil {
+		return err
+	}
+	if v != keybase1.UPAKVersion_V2 {
+		return fmt.Errorf("wanted V2 upak, got something else")
+	}
+	var devKey *keybase1.PublicKeyV2NaCl
+	for _, i := range c.upak.V2().AllIncarnations() {
+		for _, k := range i.DeviceKeys {
+			if k.Base.Revocation != nil && k.Base.IsSibkey && k.Base.Revocation.SigChainLocation.Seqno == c.seqno {
+				tmp := k
+				devKey = &tmp
+			}
+		}
+	}
+	if devKey == nil {
+		return fmt.Errorf("can't find device key for revocation")
+	}
+	c.G().Log.CDebugf(ctx, "Found device key: %+v", *devKey)
+	revk := devKey.Base.Revocation
+	res, err := cli.FindNextMerkleRootAfterRevoke(ctx, keybase1.FindNextMerkleRootAfterRevokeArg{
+		Uid:  c.uid,
+		Kid:  devKey.Base.Kid,
+		Loc:  revk.SigChainLocation,
+		Prev: revk.PrevMerkleRootSigned,
+	})
+	if err != nil {
+		return err
+	}
+	jsonOut, err := json.Marshal(res)
+	if err != nil {
+		return err
+	}
+	c.G().UI.GetTerminalUI().Output(string(jsonOut) + "\n")
+	return nil
+}
+
+func (c *cmdFNMR) Run() error {
+	userClient, err := GetUserClient(c.G())
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+
+	c.upak, err = userClient.GetUPAK(ctx, c.uid)
+	if err != nil {
+		return err
+	}
+
+	switch c.mode {
+	case modeFNMRRevoke:
+		return c.runRevoke(ctx, userClient)
+	default:
+		return fmt.Errorf("No operation mode found; try one of: {-r}")
+	}
+}
+
+func (c *cmdFNMR) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		return errors.New("need a UID argument")
+	}
+	var err error
+	c.uid, err = keybase1.UIDFromString(ctx.Args()[0])
+	if err != nil {
+		return err
+	}
+	i := ctx.Int("revoke")
+	if i > 0 {
+		c.mode = modeFNMRRevoke
+		c.seqno = keybase1.Seqno(i)
+	}
+	return nil
+}
+
+func (c *cmdFNMR) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -33,6 +33,7 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdDumpKeyfamily(cl, g),
 		NewCmdDumpPushNotifications(cl, g),
 		NewCmdEncrypt(cl, g),
+		NewCmdFNMR(cl, g),
 		NewCmdGit(cl, g),
 		NewCmdHome(cl, g),
 		NewCmdID(cl, g),

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -514,10 +514,15 @@ func (tmp *ChainLinkUnpacked) unpackPayloadJSON(g *GlobalContext, payload []byte
 		tmp.ignoreIfUnsupported = SigIgnoreIfUnsupported(ignore)
 	}
 
+	// Due to an earlier error, it's possible for the merkle root that we signed over
+	// to be in one of two places, so check both.
 	if i, err := jsonparser.GetInt(payload, "body", "merkle_root", "seqno"); err == nil {
+		tmp.merkleSeqno = keybase1.Seqno(i)
+	} else if i, err := jsonparser.GetInt(payload, "merkle_root", "seqno"); err == nil {
 		tmp.merkleSeqno = keybase1.Seqno(i)
 	}
 
+	// Hash meta was only ever in the correct place (within body)
 	if s, err := jsonparser.GetString(payload, "body", "merkle_root", "hash_meta"); err == nil {
 		tmp.merkleHashMeta, err = keybase1.HashMetaFromString(s)
 		if err != nil {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -613,6 +613,11 @@ var FirstProdMerkleSeqnoWithSkips = keybase1.Seqno(835903)
 // We didn't have valid signatures before 796, so don't try to load them.
 var FirstProdMerkleSeqnoWithSigs = keybase1.Seqno(796)
 
+// Before this merkle seqno, we had the other, more bushy shape. From this point
+// on, we have the modern shape. It's possible to tweak our clients to handle both
+// shapes, but it's not really worth it at this time.
+var FirstProdMerkleTreeWithModernShape = keybase1.Seqno(531408)
+
 type AppType string
 
 const (

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1161,6 +1161,8 @@ const (
 	merkleErrorAncientSeqno
 	merkleErrorKBFSBadTree
 	merkleErrorKBFSMismatch
+	merkleErrorBadRoot
+	merkleErrorOldTree
 )
 
 type MerkleClientError struct {

--- a/go/libkb/merkle_tools.go
+++ b/go/libkb/merkle_tools.go
@@ -71,9 +71,15 @@ func findFirstLeafWithChainSeqno(m MetaContext, id keybase1.UserOrTeamID, chainS
 		}
 		inc *= 2
 	}
+
 	if hi > last {
 		hi = last
 	}
+
+	if hi < chainSeqno {
+		return nil, nil, MerkleClientError{fmt.Sprintf("given chainSeqno %d is >= max root seqno %d", chainSeqno, hi), merkleErrorNotFound}
+	}
+
 	m.CDebugf("Stopped at hi bookend; binary searching in [%d,%d]", low, hi)
 
 	// Now binary search between prevRootSeqno and the hi we just got

--- a/go/libkb/merkle_tools.go
+++ b/go/libkb/merkle_tools.go
@@ -60,7 +60,7 @@ func findFirstLeafWithChainSeqno(m MetaContext, id keybase1.UserOrTeamID, chainS
 
 	// First bump the hi pointer up to a merkle root that overshoots (or is equal to)
 	// the request chainSeqno. Don't go any higher than the last known Merkle seqno.
-	for hi = low + 1; hi < last; hi += inc {
+	for hi = low + 1; hi <= last; hi += inc {
 		var tmpSeqno keybase1.Seqno
 		leaf, root, tmpSeqno, err = lookupLeafAtRootSeqno(m, id, hi, typ)
 		if err != nil {
@@ -73,11 +73,7 @@ func findFirstLeafWithChainSeqno(m MetaContext, id keybase1.UserOrTeamID, chainS
 	}
 
 	if hi > last {
-		hi = last
-	}
-
-	if hi < chainSeqno {
-		return nil, nil, MerkleClientError{fmt.Sprintf("given chainSeqno %d is >= max root seqno %d", chainSeqno, hi), merkleErrorNotFound}
+		return nil, nil, MerkleClientError{fmt.Sprintf("given chainSeqno %d can't be found even as high as Merkle Root %d", chainSeqno, hi), merkleErrorNotFound}
 	}
 
 	m.CDebugf("Stopped at hi bookend; binary searching in [%d,%d]", low, hi)

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1367,6 +1367,12 @@ func (u UserPlusKeysV2AllIncarnations) FindDevice(d DeviceID) *PublicKeyV2NaCl {
 	return nil
 }
 
+func (u UserPlusKeysV2AllIncarnations) AllIncarnations() (ret []UserPlusKeysV2) {
+	ret = append(ret, u.Current)
+	ret = append(ret, u.PastIncarnations...)
+	return ret
+}
+
 func (u UserPlusKeys) FindKID(needle KID) *PublicKey {
 	for _, k := range u.DeviceKeys {
 		if k.KID.Equal(needle) {


### PR DESCRIPTION
- handle bursts of merkle activity with two binary searches
- a new utility, `keybase fnmr`, to test this on prod data
- tested by hand, successfully, with:

```sh
$ ~/src/go/bin/keybase --run-mode=prod --home=/tmp/x --standalone fnmr -k 88 e0e2b660297259e41145c049c8d60d19  # the user who found this bug, in the problem spot of his sigchain
{"res":{"seqno":2105929,"hashMeta":"68bff3427d80ffed287c4a73bfdeda4c2f31581417320ee77a4691197a508ee7"}}
```

and:

```sh
$ ~/src/go/bin/keybase --run-mode=prod --home=/tmp/x --standalone fnmr -k 342 dbb165b7879fe7b1174df73bed0b9500 # normal revoke, should only take one step
{"res":{"seqno":1548866,"hashMeta":"556629a0569625bd1e0b778ca621acea7e26a0250857088efa519cdea2afe9b9"}}
```

- warning: it's not possible to use this function call on merkle roots older than:

```go
var FirstProdMerkleTreeWithModernShape = keybase1.Seqno(531408)
```