### PR TITLE
Move exploding-lifetime flag to shared code

### DIFF
--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -94,6 +94,12 @@ var chatFlags = map[string]cli.Flag{
 		Name:  "u, unmute",
 		Usage: "Unmute the conversation",
 	},
+	"exploding-lifetime": cli.DurationFlag{
+		Name: "exploding-lifetime",
+		Usage: fmt.Sprintf(`Make this message an exploding message and set the lifetime for the given duration.
+	The maximum lifetime is %v (one week) and the minimum lifetime is %v.`,
+			libkb.MaxEphemeralLifetime, libkb.MinEphemeralLifetime),
+	},
 }
 
 func mustGetChatFlags(keys ...string) (flags []cli.Flag) {

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -61,15 +61,9 @@ func newCmdChatSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 	flags := append(getConversationResolverFlags(),
 		mustGetChatFlags("set-headline", "clear-headline", "nonblock")...,
 	)
-	// TODO move this to mustGetChatFlags once we release
-	ekLib := ephemeral.NewEKLib(g)
-	if ekLib.ShouldRun(context.TODO()) {
-		flags = append(flags, cli.DurationFlag{
-			Name: "exploding-lifetime",
-			Usage: fmt.Sprintf(`Make this message an exploding message and set the lifetime for the given duration.
-	The maximum lifetime is %v (one week) and the minimum lifetime is %v.`,
-				libkb.MaxEphemeralLifetime, libkb.MinEphemeralLifetime),
-		})
+	// TODO remove this check for release.
+	if ephemeral.NewEKLib(g).ShouldRun(context.TODO()) {
+		flags = append(flags, mustGetChatFlags("exploding-lifetime")...)
 	}
 	return cli.Command{
 		Name:         "send",

--- a/go/client/cmd_chat_upload.go
+++ b/go/client/cmd_chat_upload.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/keybase/cli"
@@ -34,16 +33,9 @@ func newCmdChatUpload(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 			Usage: "Title of attachment (defaults to filename)",
 		},
 	}
-	// TODO move this to mustGetChatFlags once we release
-	ekLib := ephemeral.NewEKLib(g)
-	if ekLib.ShouldRun(context.TODO()) {
-		flags = append(flags,
-			cli.DurationFlag{
-				Name: "exploding-lifetime",
-				Usage: fmt.Sprintf(`Make this message an exploding message and set the lifetime for the given duration.
-	The maximum lifetime is %v (one week) and the minimum lifetime is %v.`,
-					libkb.MaxEphemeralLifetime, libkb.MinEphemeralLifetime),
-			})
+	// TODO remove this check for release.
+	if ephemeral.NewEKLib(g).ShouldRun(context.TODO()) {
+		flags = append(flags, mustGetChatFlags("exploding-lifetime")...)
 	}
 	return cli.Command{
 		Name:         "upload",


### PR DESCRIPTION
Just some cleanup so we don't duplicate the flag for `exploding-lifetime` to make the final release easier 