### PR TITLE
Move one shot check to checkLoginAndPUK, it was removed when we lifted ShouldRun

### DIFF
--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -58,7 +58,7 @@ func (e *EKLib) NewMetaContext(ctx context.Context) libkb.MetaContext {
 func (e *EKLib) checkLoginAndPUK(ctx context.Context) (loggedIn bool, err error) {
 	m := e.NewMetaContext(ctx)
 	if oneshot, err := e.G().IsOneshot(ctx); err != nil || oneshot {
-		e.G().Log.CDebugf(ctx, "EKLib#ShouldRun failed: %s, isOneshot: %v", err, oneshot)
+		e.G().Log.CDebugf(ctx, "EKLib#checkLoginAndPUK error: %s, isOneshot: %v", err, oneshot)
 		return false, err
 	}
 


### PR DESCRIPTION
When we enabled key generation by removing `ShouldRun` checks this also skipped the check if we were running in `oneshot` mode. This brings back the check before we attempt keygen