### PR TITLE
keybase log profile command

### DIFF
--- a/go/client/cmd_log.go
+++ b/go/client/cmd_log.go
@@ -10,12 +10,14 @@ import (
 )
 
 func NewCmdLog(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	subcommands := []cli.Command{
+		NewCmdLogSend(cl, g),
+	}
+	subcommands = append(subcommands, getBuildSpecificLogCommands(cl, g)...)
 	return cli.Command{
 		Name:         "log",
 		Usage:        "Manage keybase logs",
 		ArgumentHelp: "[arguments...]",
-		Subcommands: []cli.Command{
-			NewCmdLogSend(cl, g),
-		},
+		Subcommands:  subcommands,
 	}
 }

--- a/go/client/cmd_log_profile.go
+++ b/go/client/cmd_log_profile.go
@@ -1,0 +1,69 @@
+// +build !production
+
+package client
+
+import (
+	"errors"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+// This is a devel-only cmd which can be used to see how long different
+// g.CTraceTimed calls are taking.
+func NewCmdLogProfile(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "profile",
+		Usage: "Analyze timed traces from logs.",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdLogProfile{Contextified: libkb.NewContextified(g)}, "profile", c)
+		},
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "p, path",
+				Usage: "Path of logfile to process.",
+			},
+		},
+	}
+}
+
+type CmdLogProfile struct {
+	libkb.Contextified
+	path string
+}
+
+func (c *CmdLogProfile) Run() error {
+	logProfileContext := libkb.LogProfileContext{
+		Contextified: libkb.NewContextified(c.G()),
+		Path:         c.path,
+	}
+
+	profileData, err := logProfileContext.LogProfile(c.path)
+	if err != nil {
+		return err
+	}
+
+	ui := c.G().UI.GetTerminalUI()
+	for _, profStr := range profileData {
+		ui.Printf("%v\n", profStr)
+	}
+
+	return nil
+}
+
+func (c *CmdLogProfile) ParseArgv(ctx *cli.Context) error {
+	c.path = ctx.String("path")
+	if len(c.path) == 0 {
+		return errors.New("path must be set")
+	}
+
+	return nil
+}
+
+func (c *CmdLogProfile) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -56,6 +56,12 @@ func getBuildSpecificWalletCommands(cl *libcmdline.CommandLine, g *libkb.GlobalC
 	}
 }
 
+func getBuildSpecificLogCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
+	return []cli.Command{
+		NewCmdLogProfile(cl, g),
+	}
+}
+
 var restrictedSignupFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "p, passphrase",

--- a/go/client/commands_production.go
+++ b/go/client/commands_production.go
@@ -29,6 +29,10 @@ func getBuildSpecificWalletCommands(cl *libcmdline.CommandLine, g *libkb.GlobalC
 	return []cli.Command{}
 }
 
+func getBuildSpecificLogCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
+	return []cli.Command{}
+}
+
 const develUsage = false
 
 var restrictedSignupFlags = []cli.Flag{}

--- a/go/libkb/log_profile.go
+++ b/go/libkb/log_profile.go
@@ -1,0 +1,101 @@
+package libkb
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// LogProfileContext for LogProfile
+type LogProfileContext struct {
+	Contextified
+	Path string
+}
+
+func maxDuration(durations []time.Duration) time.Duration {
+	max := time.Duration(0)
+	for _, d := range durations {
+		if d > max {
+			max = d
+		}
+	}
+	return max
+}
+
+func minDuration(durations []time.Duration) time.Duration {
+	if len(durations) == 0 {
+		return 0
+	}
+	min := durations[0]
+	for _, d := range durations {
+		if d < min {
+			min = d
+		}
+	}
+	return min
+}
+
+func avgDuration(durations []time.Duration) time.Duration {
+	if len(durations) == 0 {
+		return 0
+	}
+	var total int64
+	for _, d := range durations {
+		total += d.Nanoseconds()
+	}
+	return time.Duration(total / int64(len(durations)))
+}
+
+func format(fn string, durations []time.Duration) string {
+	return fmt.Sprintf(`%v:
+		max: %v
+		avg: %v
+		min: %v
+		len: %v`,
+		fn, maxDuration(durations), avgDuration(durations), minDuration(durations), len(durations))
+}
+
+func (l *LogProfileContext) LogProfile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	defer f.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	re := regexp.MustCompile("- (.*) -> .* \\[time=(.*)\\]( \\[tags)*")
+	data := map[string][]time.Duration{}
+	scanner := bufio.NewScanner(f)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		// We expect two groups, the function name and a duration
+		matches := re.FindAllStringSubmatch(scanner.Text(), -1)
+		if len(matches) == 0 {
+			continue
+		}
+		// Some log calls have fnName: args so we want to strip that.
+		fn := strings.Split(matches[0][1], ":")[0]
+		d, err := time.ParseDuration(matches[0][2])
+		if err != nil {
+			l.G().Log.CDebugf(context.TODO(), "Unable to parse duration: %s", err)
+			continue
+		}
+
+		durations, ok := data[fn]
+		if ok {
+			durations = append(durations, d)
+		} else {
+			durations = []time.Duration{d}
+		}
+		data[fn] = durations
+	}
+	res := []string{}
+	for fn, durations := range data {
+		res = append(res, format(fn, durations))
+	}
+	return res, nil
+}

--- a/go/libkb/log_profile.go
+++ b/go/libkb/log_profile.go
@@ -17,7 +17,7 @@ type LogProfileContext struct {
 	Path string
 }
 
-func maxDuration(durations []time.Duration) time.Duration {
+func (l *LogProfileContext) maxDuration(durations []time.Duration) time.Duration {
 	max := time.Duration(0)
 	for _, d := range durations {
 		if d > max {
@@ -27,7 +27,7 @@ func maxDuration(durations []time.Duration) time.Duration {
 	return max
 }
 
-func minDuration(durations []time.Duration) time.Duration {
+func (l *LogProfileContext) minDuration(durations []time.Duration) time.Duration {
 	if len(durations) == 0 {
 		return 0
 	}
@@ -40,7 +40,7 @@ func minDuration(durations []time.Duration) time.Duration {
 	return min
 }
 
-func avgDuration(durations []time.Duration) time.Duration {
+func (l *LogProfileContext) avgDuration(durations []time.Duration) time.Duration {
 	if len(durations) == 0 {
 		return 0
 	}
@@ -51,14 +51,14 @@ func avgDuration(durations []time.Duration) time.Duration {
 	return time.Duration(total / int64(len(durations)))
 }
 
-func format(fn string, durations []time.Duration) string {
+func (l *LogProfileContext) format(fn string, durations []time.Duration) string {
 	return fmt.Sprintf(`
 		%v:
 			max: %v
 			avg: %v
 			min: %v
 			len: %v`,
-		fn, maxDuration(durations), avgDuration(durations), minDuration(durations), len(durations))
+		fn, l.maxDuration(durations), l.avgDuration(durations), l.minDuration(durations), len(durations))
 }
 
 func (l *LogProfileContext) parseMatch(matches []string) (filename, fnName string, d time.Duration) {
@@ -119,7 +119,7 @@ func (l *LogProfileContext) LogProfile(path string) ([]string, error) {
 	for filename, data := range profiles {
 		res = append(res, filename)
 		for fnName, durations := range data {
-			res = append(res, format(fnName, durations))
+			res = append(res, l.format(fnName, durations))
 		}
 	}
 	return res, nil

--- a/go/libkb/log_profile.go
+++ b/go/libkb/log_profile.go
@@ -67,7 +67,7 @@ func (l *LogProfileContext) LogProfile(path string) ([]string, error) {
 		return nil, err
 	}
 
-	re := regexp.MustCompile("- (.*) -> .* \\[time=(.*)\\]( \\[tags)*")
+	re := regexp.MustCompile("- (.*) -> .* \\[time=(\\d+\\.\\w+)\\]")
 	data := map[string][]time.Duration{}
 	scanner := bufio.NewScanner(f)
 	scanner.Split(bufio.ScanLines)
@@ -77,8 +77,11 @@ func (l *LogProfileContext) LogProfile(path string) ([]string, error) {
 		if len(matches) == 0 {
 			continue
 		}
+		fn := matches[0][1]
 		// Some log calls have fnName: args so we want to strip that.
-		fn := strings.Split(matches[0][1], ":")[0]
+		fn = strings.Split(fn, ":")[0]
+		// Some log calls have fnName(args) so we want to strip that.
+		fn = strings.Split(fn, "(")[0]
 		d, err := time.ParseDuration(matches[0][2])
 		if err != nil {
 			l.G().Log.CDebugf(context.TODO(), "Unable to parse duration: %s", err)


### PR DESCRIPTION
get a sense for how long timed traces are taking on a log file quick and dirty.

Currently very basic but we can extended as needed. Possible ideas:
- add include/exclude filters so you only get traces you're interested in. (or make the output more grep friendly)
- include in `LogSend` by default so we can keep an eye on these numbers high level when logs come in

looks like this:
```
$ kb log profile
Running `go install github.com/keybase/client/go/keybase`... Done.
Error parsing command line arguments: path must be set

NAME:
   keybase log profile - Analyze timed traces from logs.

USAGE:
   keybase log profile [command options]

OPTIONS:
   -p, --path   Path of logfile to process.


joshblum@joshblum|[16:59:26] ~/go/src/github.com/keybase/client/go(joshblum/logprof)*$ kb log profile -p=/tmp/keybase.service.log
Running `go install github.com/keybase/client/go/keybase`... Done.
▶ WARNING Running in devel mode
newDeviceEKNeeded:
                max: 588.014984ms
                avg: 473.840189ms
                min: 359.665395ms
                len: 2
UserEKBoxStorage#getCache:
                max: 1.054702ms
                avg: 308.115µs
                min: 394ns
                len: 6
DeviceEKStorage#DeleteExpired:
                max: 1.439306ms
                avg: 889.42µs
                min: 539.833µs
                len: 4
Stellar.ShouldCreate:
                max: 25.641701ms
                avg: 25.641701ms
                min: 25.641701ms
                len: 1
...
```