### PR TITLE
FindNexMerkleRootAfterReset

### DIFF
--- a/go/engine/upak2_test.go
+++ b/go/engine/upak2_test.go
@@ -112,6 +112,19 @@ func TestExportAllIncarnationsAfterReset(t *testing.T) {
 	require.Equal(t, reset.Type, keybase1.ResetType_RESET)
 	require.Equal(t, reset.EldestSeqno, keybase1.Seqno(1))
 
+	// Test libkb.FindNextMerkleRootAfterReset --- in this case, the next merkle root
+	// in the sequence should be the right one.
+	m := NewMetaContextForTest(tc)
+	fnmrArg := keybase1.FindNextMerkleRootAfterResetArg{
+		Uid:        u.GetUID(),
+		ResetSeqno: keybase1.Seqno(1),
+		Prev:       reset.MerkleRoot,
+	}
+	res, err := libkb.FindNextMerkleRootAfterReset(m, fnmrArg)
+	require.NoError(t, err)
+	require.NotNil(t, res.Res)
+	require.True(t, res.Res.Seqno > reset.MerkleRoot.Seqno)
+
 	// While we're here, also check that UPK v1 has the right reset summaries.
 	upk1, err := libkb.LoadUserPlusKeys(context.TODO(), tc.G, fu.UID(), keybase1.KID(""))
 	require.NoError(t, err)

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -257,6 +257,10 @@ type MerkleGenericLeaf struct {
 	LeafID  keybase1.UserOrTeamID
 	Public  *MerkleTriple
 	Private *MerkleTriple
+
+	// if the leaf is a User leaf, we'll have extra information here, like
+	// reset chain and eldest key. On a team leaf, this will be nil.
+	userExtras *MerkleUserLeaf
 }
 
 func (l MerkleTeamLeaf) MerkleGenericLeaf() *MerkleGenericLeaf {
@@ -269,9 +273,10 @@ func (l MerkleTeamLeaf) MerkleGenericLeaf() *MerkleGenericLeaf {
 
 func (mul MerkleUserLeaf) MerkleGenericLeaf() *MerkleGenericLeaf {
 	return &MerkleGenericLeaf{
-		LeafID:  mul.uid.AsUserOrTeam(),
-		Public:  mul.public,
-		Private: mul.private,
+		LeafID:     mul.uid.AsUserOrTeam(),
+		Public:     mul.public,
+		Private:    mul.private,
+		userExtras: &mul,
 	}
 }
 

--- a/go/libkb/merkle_tools.go
+++ b/go/libkb/merkle_tools.go
@@ -2,12 +2,13 @@ package libkb
 
 import (
 	"fmt"
+	"time"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-// leafPart is a simple accessor that takes the given leaf, and the private/public type,
+// leafSlot is a simple accessor that takes the given leaf, and the private/public type,
 // and returns the corresponding object.
-func leafPart(leaf *MerkleGenericLeaf, typ keybase1.SeqType) *MerkleTriple {
+func leafSlot(leaf *MerkleGenericLeaf, typ keybase1.SeqType) *MerkleTriple {
 	if leaf == nil {
 		return nil
 	}
@@ -21,28 +22,36 @@ func leafPart(leaf *MerkleGenericLeaf, typ keybase1.SeqType) *MerkleTriple {
 	}
 }
 
-// lookupLeafAtRootSeqno queries the server for the merkle root at rootSeqno, and then descends the tree to the
-// leaf for the supplied id. It returns the leaf, the root, and the leaf part determed by SeqType.
-func lookupLeafAtRootSeqno(m MetaContext, id keybase1.UserOrTeamID, rootSeqno keybase1.Seqno, typ keybase1.SeqType) (leaf *MerkleGenericLeaf, root *MerkleRoot, userChainSeqno keybase1.Seqno, err error) {
-	m.CDebugf("lookupLeafAtRootSeqno(%s,%d)", id, rootSeqno)
-	leaf, root, err = m.G().GetMerkleClient().LookupLeafAtSeqno(m.Ctx(), id, rootSeqno)
+// merkleSearchComparator is a comparator used to determine if the given leaf/root has overshot
+// the mark, or no. If overshoot, then return a true, otherwrise return a false. And error will
+// abort the attempt
+type merkleSearchComparator func(leaf *MerkleGenericLeaf, root *MerkleRoot) (bool, error)
+
+// lookup the max merkle root seqno from the server, or use a cached version if
+// possible (and it's less than a minute old).
+func lookupMaxMerkleSeqno(m MetaContext) (ret keybase1.Seqno, err error) {
+	defer m.CTrace("lookupMaxMerkleSeqno", func() error { return err })()
+	cli := m.G().GetMerkleClient()
+	mr, err := cli.FetchRootFromServer(m.Ctx(), time.Minute)
 	if err != nil {
-		return nil, nil, 0, err
+		return ret, err
 	}
-	part := leafPart(leaf, typ)
-	if part == nil {
-		return nil, nil, 0, MerkleClientError{fmt.Sprintf("leaf at root %d returned with nil %v part", rootSeqno, typ), merkleErrorBadLeaf}
+	lastp := mr.Seqno()
+	if lastp == nil {
+		return ret, MerkleClientError{"unexpected nil max merkle seqno", merkleErrorBadRoot}
 	}
-	return leaf, root, part.Seqno, nil
+	return *lastp, nil
 }
 
-// findFirstLeafWithChainSeqno finds the first chronological leaf in the merkle tree that contains the given
-// chainSeqno for the given UID. Start this search from the given prevRootSeqno, not from merkle position 1.
+// findFirstLeafWithComparer finds the first chronological leaf in the merkle tree for which
+// comparer(leaf, root) is true, where (leaf, root) is an historical (leaf,root) pair for this
+// id. It's assumed that that false values are all earlier in history than the true values. We're
+// looking for the point of transition. Start this search from the given prevRootSeqno, not from merkle seqno 1.
 // The algorithm is to jump forward, in exponentially larger jumps, until we find a root that has a leaf
-// that is >= the given chainSeqno. Then, to binary search to find the exact [a,b] pair in which a doesn't
-// contain the leaf seqno, and b does. The leaf and root that correspond to be are returned.
-func findFirstLeafWithChainSeqno(m MetaContext, id keybase1.UserOrTeamID, chainSeqno keybase1.Seqno, typ keybase1.SeqType, prevRootSeqno keybase1.Seqno) (leaf *MerkleGenericLeaf, root *MerkleRoot, err error) {
-	defer m.CTrace(fmt.Sprintf("findFirstLeafWithChainSeqno(%s,%d,%d)", id, chainSeqno, prevRootSeqno), func() error { return err })()
+// that makes comparer true. Then, to binary search to find the exact [a,b] pair in which a makes the
+// comparer false, and b makes it true. The leaf and root that correspond to be are returned.
+func findFirstLeafWithComparer(m MetaContext, id keybase1.UserOrTeamID, comparator merkleSearchComparator, prevRootSeqno keybase1.Seqno) (leaf *MerkleGenericLeaf, root *MerkleRoot, err error) {
+	defer m.CTrace(fmt.Sprintf("findFirstLeafWithComparer(%s,%d)", id, prevRootSeqno), func() error { return err })()
 
 	if m.G().Env.GetRunMode() == ProductionRunMode && prevRootSeqno < FirstProdMerkleTreeWithModernShape {
 		return nil, nil, MerkleClientError{"can't operate on old merkle sequence number", merkleErrorOldTree}
@@ -50,33 +59,38 @@ func findFirstLeafWithChainSeqno(m MetaContext, id keybase1.UserOrTeamID, chainS
 
 	cli := m.G().GetMerkleClient()
 	low := prevRootSeqno
-	lastp := cli.LastRoot().Seqno()
-	if lastp == nil {
-		return nil, nil, MerkleClientError{"unexpected nil high seqno", merkleErrorBadRoot}
+	last, err := lookupMaxMerkleSeqno(m)
+	if err != nil {
+		return nil, nil, err
 	}
-	last := *lastp
+	m.CDebugf("found max merkle root: %d", last)
 	var hi keybase1.Seqno
 	inc := keybase1.Seqno(1)
 
 	// First bump the hi pointer up to a merkle root that overshoots (or is equal to)
 	// the request chainSeqno. Don't go any higher than the last known Merkle seqno.
 	for hi = low + 1; hi <= last; hi += inc {
-		var tmpSeqno keybase1.Seqno
-		leaf, root, tmpSeqno, err = lookupLeafAtRootSeqno(m, id, hi, typ)
+		m.CDebugf("FFLWC: Expontential forward jump: trying %d", hi)
+		var found bool
+		leaf, root, err = cli.LookupLeafAtSeqno(m.Ctx(), id, hi)
 		if err != nil {
 			return nil, nil, err
 		}
-		if tmpSeqno >= chainSeqno {
+		found, err = comparator(leaf, root)
+		if err != nil {
+			return nil, nil, err
+		}
+		if found {
 			break
 		}
 		inc *= 2
 	}
 
 	if hi > last {
-		return nil, nil, MerkleClientError{fmt.Sprintf("given chainSeqno %d can't be found even as high as Merkle Root %d", chainSeqno, hi), merkleErrorNotFound}
+		return nil, nil, MerkleClientError{fmt.Sprintf("given link can't be found even as high as Merkle Root %d", hi), merkleErrorNotFound}
 	}
 
-	m.CDebugf("Stopped at hi bookend; binary searching in [%d,%d]", low, hi)
+	m.CDebugf("FFLWC: Stopped at hi bookend; binary searching in [%d,%d]", low, hi)
 
 	// Now binary search between prevRootSeqno and the hi we just got
 	// to find the exact transition. Note that if we never enter this loop,
@@ -86,20 +100,24 @@ func findFirstLeafWithChainSeqno(m MetaContext, id keybase1.UserOrTeamID, chainS
 	// (since hi = low + 1).
 	for hi-low > 1 {
 		mid := (hi + low) / 2
-		tmpLeaf, tmpRoot, tmpSeqno, err := lookupLeafAtRootSeqno(m, id, mid, typ)
+		tmpLeaf, tmpRoot, err := cli.LookupLeafAtSeqno(m.Ctx(), id, mid)
 		if err != nil {
 			return nil, nil, err
 		}
-		if tmpSeqno >= chainSeqno {
+		found, err := comparator(tmpLeaf, tmpRoot)
+		if err != nil {
+			return nil, nil, err
+		}
+		if found {
 			hi = mid
 			leaf = tmpLeaf
 			root = tmpRoot
 		} else {
 			low = mid
 		}
-		m.CDebugf("Found user seqno %d; after update: [%d,%d]", tmpSeqno, low, hi)
+		m.CDebugf("FFLWC: Binary search: after update range is [%d,%d]", low, hi)
 	}
-	m.CDebugf("settling at final seqno: %d", hi)
+	m.CDebugf("FFLWC: settling at final seqno: %d", hi)
 
 	return leaf, root, nil
 }
@@ -117,7 +135,16 @@ func FindNextMerkleRootAfterRevoke(m MetaContext, arg keybase1.FindNextMerkleRoo
 		return res, err
 	}
 
-	leaf, root, err := findFirstLeafWithChainSeqno(m, arg.Uid.AsUserOrTeam(), arg.Loc.Seqno, keybase1.SeqType_PUBLIC, arg.Prev.Seqno)
+	comparator := func(leaf *MerkleGenericLeaf, root *MerkleRoot) (bool, error) {
+		slot := leafSlot(leaf, keybase1.SeqType_PUBLIC)
+		if slot == nil {
+			return false, MerkleClientError{fmt.Sprintf("leaf at root %d returned with nil public part", *root.Seqno()), merkleErrorBadLeaf}
+		}
+		m.CDebugf("Comprator at Merkle root %d: found chain location is %d; searching for %d", *root.Seqno(), slot.Seqno, arg.Loc.Seqno)
+		return (slot.Seqno >= arg.Loc.Seqno), nil
+	}
+
+	leaf, root, err := findFirstLeafWithComparer(m, arg.Uid.AsUserOrTeam(), comparator, arg.Prev.Seqno)
 	if err != nil {
 		return res, err
 	}
@@ -135,7 +162,35 @@ func FindNextMerkleRootAfterRevoke(m MetaContext, arg keybase1.FindNextMerkleRoo
 		HashMeta: root.HashMeta(),
 		Seqno:    *root.Seqno(),
 	}
-	m.CDebugf("| res.Res: %+v", *res.Res)
+	m.CDebugf("res.Res: %+v", *res.Res)
+	return res, nil
+}
+
+func FindNextMerkleRootAfterReset(m MetaContext, arg keybase1.FindNextMerkleRootAfterResetArg) (res keybase1.NextMerkleRootRes, err error) {
+	defer m.CTrace(fmt.Sprintf("FindNextMerkleRootAfterReset(%+v)", arg), func() error { return err })()
+
+	comparator := func(leaf *MerkleGenericLeaf, root *MerkleRoot) (bool, error) {
+		user := leaf.userExtras
+		if user == nil {
+			return false, MerkleClientError{fmt.Sprintf("for root %d, expected a user leaf, didn't get one", *root.Seqno()), merkleErrorBadLeaf}
+		}
+		if user.resets == nil {
+			return false, nil
+		}
+		return (user.resets.chainTail.Seqno >= arg.ResetSeqno), nil
+	}
+	leaf, root, err := findFirstLeafWithComparer(m, arg.Uid.AsUserOrTeam(), comparator, arg.Prev.Seqno)
+	if err != nil {
+		return res, err
+	}
+	if leaf == nil || root == nil {
+		return res, MerkleClientError{"no suitable leaf found", merkleErrorNoUpdates}
+	}
+	res.Res = &keybase1.MerkleRootV2{
+		HashMeta: root.HashMeta(),
+		Seqno:    *root.Seqno(),
+	}
+	m.CDebugf("res.Res: %+v", *res.Res)
 	return res, nil
 }
 

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -353,3 +353,10 @@ func (h *UserHandler) FindNextMerkleRootAfterRevoke(ctx context.Context, arg key
 	defer m.CTraceTimed("UserHandler#FindNextMerkleRootAfterRevoke", func() error { return err })()
 	return libkb.FindNextMerkleRootAfterRevoke(m, arg)
 }
+
+func (h *UserHandler) FindNextMerkleRootAfterReset(ctx context.Context, arg keybase1.FindNextMerkleRootAfterResetArg) (ret keybase1.NextMerkleRootRes, err error) {
+	m := libkb.NewMetaContext(ctx, h.G())
+	m = m.WithLogTag("FNMR")
+	defer m.CTraceTimed("UserHandler#FindNextMerkleRootAfterReset", func() error { return err })()
+	return libkb.FindNextMerkleRootAfterReset(m, arg)
+}

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -163,4 +163,11 @@ protocol user {
    we'll start our search. Usually it's the next one, but not always
   */
   NextMerkleRootRes findNextMerkleRootAfterRevoke(UID uid, KID kid, SigChainLocation loc, MerkleRootV2 prev);
+
+  /**
+   FindNextMerkleRootAfterRest finds the first Merkle root that contains the UID reset
+   at resetSeqno. You should pass it prev, which was the last known Merkle root at the time of
+   the reset. Usually, we'll just turn up the next Merkle root, but not always.
+  */
+  NextMerkleRootRes findNextMerkleRootAfterReset(UID uid, Seqno resetSeqno, ResetMerkleRoot prev);
 }

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1910,6 +1910,10 @@ export const uiPromptDefault = {
   no: 2,
 }
 
+export const userFindNextMerkleRootAfterResetRpcChannelMap = (configKeys: Array<string>, request: UserFindNextMerkleRootAfterResetRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.findNextMerkleRootAfterReset', request)
+
+export const userFindNextMerkleRootAfterResetRpcPromise = (request: UserFindNextMerkleRootAfterResetRpcParam): Promise<UserFindNextMerkleRootAfterResetResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.findNextMerkleRootAfterReset', request, (error: RPCError, result: UserFindNextMerkleRootAfterResetResult) => (error ? reject(error) : resolve(result))))
+
 export const userFindNextMerkleRootAfterRevokeRpcChannelMap = (configKeys: Array<string>, request: UserFindNextMerkleRootAfterRevokeRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.findNextMerkleRootAfterRevoke', request)
 
 export const userFindNextMerkleRootAfterRevokeRpcPromise = (request: UserFindNextMerkleRootAfterRevokeRpcParam): Promise<UserFindNextMerkleRootAfterRevokeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.findNextMerkleRootAfterRevoke', request, (error: RPCError, result: UserFindNextMerkleRootAfterRevokeResult) => (error ? reject(error) : resolve(result))))
@@ -4097,6 +4101,8 @@ export type UserEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation
 
 export type UserEkStatement = $ReadOnly<{currentUserEkMetadata: UserEkMetadata, existingUserEkMetadata?: ?Array<UserEkMetadata>}>
 
+export type UserFindNextMerkleRootAfterResetRpcParam = $ReadOnly<{uid: UID, resetSeqno: Seqno, prev: ResetMerkleRoot, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type UserFindNextMerkleRootAfterRevokeRpcParam = $ReadOnly<{uid: UID, kid: KID, loc: SigChainLocation, prev: MerkleRootV2, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type UserGetUPAKRpcParam = $ReadOnly<{uid: UID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -4360,6 +4366,7 @@ type TlfKeysGetTLFCryptKeysResult = GetTLFCryptKeysRes
 type TlfPublicCanonicalTLFNameAndIDResult = CanonicalTLFNameAndIDWithBreaks
 type TrackTrackResult = ConfirmResult
 type UiPromptYesNoResult = Boolean
+type UserFindNextMerkleRootAfterResetResult = NextMerkleRootRes
 type UserFindNextMerkleRootAfterRevokeResult = NextMerkleRootRes
 type UserGetUPAKResult = UPAKVersioned
 type UserInterestingPeopleResult = ?Array<InterestingPerson>

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -632,6 +632,24 @@
       ],
       "response": "NextMerkleRootRes",
       "doc": "FindNextMerkleRootAfterRevoke finds the first Merkle Root that contains the UID/KID\n   revocation at the given SigChainLocataion. The MerkleRootV2 prev is a hint as to where\n   we'll start our search. Usually it's the next one, but not always"
+    },
+    "findNextMerkleRootAfterReset": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "UID"
+        },
+        {
+          "name": "resetSeqno",
+          "type": "Seqno"
+        },
+        {
+          "name": "prev",
+          "type": "ResetMerkleRoot"
+        }
+      ],
+      "response": "NextMerkleRootRes",
+      "doc": "FindNextMerkleRootAfterRest finds the first Merkle root that contains the UID reset\n   at resetSeqno. You should pass it prev, which was the last known Merkle root at the time of\n   the reset. Usually, we'll just turn up the next Merkle root, but not always."
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1910,6 +1910,10 @@ export const uiPromptDefault = {
   no: 2,
 }
 
+export const userFindNextMerkleRootAfterResetRpcChannelMap = (configKeys: Array<string>, request: UserFindNextMerkleRootAfterResetRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.findNextMerkleRootAfterReset', request)
+
+export const userFindNextMerkleRootAfterResetRpcPromise = (request: UserFindNextMerkleRootAfterResetRpcParam): Promise<UserFindNextMerkleRootAfterResetResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.findNextMerkleRootAfterReset', request, (error: RPCError, result: UserFindNextMerkleRootAfterResetResult) => (error ? reject(error) : resolve(result))))
+
 export const userFindNextMerkleRootAfterRevokeRpcChannelMap = (configKeys: Array<string>, request: UserFindNextMerkleRootAfterRevokeRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.user.findNextMerkleRootAfterRevoke', request)
 
 export const userFindNextMerkleRootAfterRevokeRpcPromise = (request: UserFindNextMerkleRootAfterRevokeRpcParam): Promise<UserFindNextMerkleRootAfterRevokeResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.user.findNextMerkleRootAfterRevoke', request, (error: RPCError, result: UserFindNextMerkleRootAfterRevokeResult) => (error ? reject(error) : resolve(result))))
@@ -4097,6 +4101,8 @@ export type UserEkMetadata = $ReadOnly<{kid: KID, hashMeta: HashMeta, generation
 
 export type UserEkStatement = $ReadOnly<{currentUserEkMetadata: UserEkMetadata, existingUserEkMetadata?: ?Array<UserEkMetadata>}>
 
+export type UserFindNextMerkleRootAfterResetRpcParam = $ReadOnly<{uid: UID, resetSeqno: Seqno, prev: ResetMerkleRoot, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type UserFindNextMerkleRootAfterRevokeRpcParam = $ReadOnly<{uid: UID, kid: KID, loc: SigChainLocation, prev: MerkleRootV2, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type UserGetUPAKRpcParam = $ReadOnly<{uid: UID, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
@@ -4360,6 +4366,7 @@ type TlfKeysGetTLFCryptKeysResult = GetTLFCryptKeysRes
 type TlfPublicCanonicalTLFNameAndIDResult = CanonicalTLFNameAndIDWithBreaks
 type TrackTrackResult = ConfirmResult
 type UiPromptYesNoResult = Boolean
+type UserFindNextMerkleRootAfterResetResult = NextMerkleRootRes
 type UserFindNextMerkleRootAfterRevokeResult = NextMerkleRootRes
 type UserGetUPAKResult = UPAKVersioned
 type UserInterestingPeopleResult = ?Array<InterestingPerson>


### PR DESCRIPTION
- an RPC that given an Reset seqno and the prev merkle signed into the reset record, find the next merkle root that contains the reset