### PR TITLE
remove keyformat fix [CORE-7987]

### DIFF
--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -3,7 +3,6 @@ package ephemeral
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -146,33 +145,6 @@ func TestDeviceEKStorage(t *testing.T) {
 	err = erasableStorage.Get(context.Background(), badEldestSeqnoKey, &badEldestSeqnoDeviceEK)
 	require.Error(t, err)
 	require.Equal(t, badEldestSeqnoDeviceEK, keybase1.DeviceEk{})
-
-	// There was a bug in the deviceEK format introduced in
-	// https://github.com/keybase/client/pull/11911 where the key format went from
-	//  deviceEKPrefix-username-eldestSeqNo-generation.ek to
-	//  deviceEKPrefix-username--eldestSeqNo-generation.ek
-	// Test that we repair these keys
-	badKeyFormat := fmt.Sprintf("%s-%s--%s-0.ek", deviceEKPrefix, s.G().Env.GetUsername(), uv.EldestSeqno)
-	err = erasableStorage.Put(context.Background(), badKeyFormat, keybase1.DeviceEk{})
-	require.NoError(t, err)
-
-	goodKeyFormat := fmt.Sprintf("%s-%s-%s-1.ek", deviceEKPrefix, s.G().Env.GetUsername(), uv.EldestSeqno)
-	err = erasableStorage.Put(context.Background(), goodKeyFormat, keybase1.DeviceEk{})
-	require.NoError(t, err)
-
-	err = s.keyFormatRepair(context.Background())
-	require.NoError(t, err)
-
-	var badKeyFormatDeviceEK keybase1.DeviceEk
-	err = erasableStorage.Get(context.Background(), badKeyFormat, &badKeyFormatDeviceEK)
-	require.Error(t, err)
-
-	var goodKeyFormatDeviceEK keybase1.DeviceEk
-	err = erasableStorage.Get(context.Background(), goodKeyFormat, &goodKeyFormatDeviceEK)
-	require.NoError(t, err)
-
-	err = erasableStorage.Get(context.Background(), strings.Replace(badKeyFormat, "--", "-", 1), &goodKeyFormatDeviceEK)
-	require.NoError(t, err)
 }
 
 // If we change the key format intentionally, we have to introduce some form of


### PR DESCRIPTION
removes deviceEK storage format repair. This bug never made it out to a client in the wild with keygen enabled so it was intended for people who were testing things out. Since we did a full release of clients that have the fix i think it's safe to remove this and assume that affected devices/users are upgraded (it's good to remove it before launching fully so we don't have to needlessly run it)