### PR TITLE
bump to 220 and roll back targetsdk until push is fixed

### DIFF
--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -91,9 +91,9 @@ android {
     defaultConfig {
         applicationId "io.keybase.ossifrage"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 23
         versionCode timestamp()
-        versionName "2.1.0"
+        versionName "2.2.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
@keybase/react-hackers this bumps mobile versions again since the android release and rolls back the target sdk on master until we can fix mobile push on android to use channels