### PR TITLE
Disallow --public and --exploding-lifetime

### DIFF
--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -80,6 +80,18 @@ func (e EphemeralUnboxingError) Error() string {
 
 //=============================================================================
 
+type EphemeralKeyError struct{}
+
+func NewEphemeralKeyError() EphemeralKeyError {
+	return EphemeralKeyError{}
+}
+
+func (e EphemeralKeyError) Error() string {
+	return "Cannot use ephemeral messages for a public team."
+}
+
+//=============================================================================
+
 type ConsistencyErrorCode int
 
 const (

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -80,13 +80,13 @@ func (e EphemeralUnboxingError) Error() string {
 
 //=============================================================================
 
-type EphemeralKeyError struct{}
+type PublicTeamEphemeralKeyError struct{}
 
-func NewEphemeralKeyError() EphemeralKeyError {
-	return EphemeralKeyError{}
+func NewPublicTeamEphemeralKeyError() PublicTeamEphemeralKeyError {
+	return PublicTeamEphemeralKeyError{}
 }
 
-func (e EphemeralKeyError) Error() string {
+func (e PublicTeamEphemeralKeyError) Error() string {
 	return "Cannot use ephemeral messages for a public team."
 }
 

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -239,6 +239,10 @@ func (t *TeamsNameInfoSource) DecryptionKeys(ctx context.Context, name string, t
 
 func (t *TeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (teamEK keybase1.TeamEk, err error) {
+	if public {
+		return teamEK, NewEphemeralKeyError()
+	}
+
 	teamID, err := keybase1.TeamIDFromString(tlfID.String())
 	if err != nil {
 		return teamEK, err
@@ -248,6 +252,10 @@ func (t *TeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfNam
 
 func (t *TeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool, generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
+	if public {
+		return teamEK, NewEphemeralKeyError()
+	}
+
 	teamID, err := keybase1.TeamIDFromString(tlfID.String())
 	if err != nil {
 		return teamEK, err
@@ -387,6 +395,10 @@ func (t *ImplicitTeamsNameInfoSource) DecryptionKeys(ctx context.Context, name s
 
 func (t *ImplicitTeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (teamEK keybase1.TeamEk, err error) {
+	if public {
+		return teamEK, NewEphemeralKeyError()
+	}
+
 	// The native case is the same as regular teams.
 	if membersType == chat1.ConversationMembersType_IMPTEAMNATIVE {
 		teamID, err := keybase1.TeamIDFromString(tlfID.String())
@@ -406,6 +418,10 @@ func (t *ImplicitTeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context
 func (t *ImplicitTeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
 	generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
+	if public {
+		return teamEK, NewEphemeralKeyError()
+	}
+
 	// The native case is the same as regular teams.
 	if membersType == chat1.ConversationMembersType_IMPTEAMNATIVE {
 		teamID, err := keybase1.TeamIDFromString(tlfID.String())

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -240,7 +240,7 @@ func (t *TeamsNameInfoSource) DecryptionKeys(ctx context.Context, name string, t
 func (t *TeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (teamEK keybase1.TeamEk, err error) {
 	if public {
-		return teamEK, NewEphemeralKeyError()
+		return teamEK, NewPublicTeamEphemeralKeyError()
 	}
 
 	teamID, err := keybase1.TeamIDFromString(tlfID.String())
@@ -253,7 +253,7 @@ func (t *TeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfNam
 func (t *TeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool, generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
 	if public {
-		return teamEK, NewEphemeralKeyError()
+		return teamEK, NewPublicTeamEphemeralKeyError()
 	}
 
 	teamID, err := keybase1.TeamIDFromString(tlfID.String())
@@ -396,7 +396,7 @@ func (t *ImplicitTeamsNameInfoSource) DecryptionKeys(ctx context.Context, name s
 func (t *ImplicitTeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (teamEK keybase1.TeamEk, err error) {
 	if public {
-		return teamEK, NewEphemeralKeyError()
+		return teamEK, NewPublicTeamEphemeralKeyError()
 	}
 
 	// The native case is the same as regular teams.
@@ -419,7 +419,7 @@ func (t *ImplicitTeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context
 	membersType chat1.ConversationMembersType, public bool,
 	generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
 	if public {
-		return teamEK, NewEphemeralKeyError()
+		return teamEK, NewPublicTeamEphemeralKeyError()
 	}
 
 	// The native case is the same as regular teams.

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -97,7 +97,7 @@ var chatFlags = map[string]cli.Flag{
 	"exploding-lifetime": cli.DurationFlag{
 		Name: "exploding-lifetime",
 		Usage: fmt.Sprintf(`Make this message an exploding message and set the lifetime for the given duration.
-	The maximum lifetime is %v (one week) and the minimum lifetime is %v.`,
+	The maximum lifetime is %v (one week) and the minimum lifetime is %v. Cannot be used in conjunction with --public.`,
 			libkb.MaxEphemeralLifetime, libkb.MinEphemeralLifetime),
 	},
 }

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -79,14 +79,25 @@ func newCmdChatSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 
 func (c *CmdChatSend) Run() (err error) {
 	if c.resolvingRequest.TlfName != "" {
-		err = annotateResolvingRequest(c.G(), &c.resolvingRequest)
-		if err != nil {
+		if err = annotateResolvingRequest(c.G(), &c.resolvingRequest); err != nil {
 			return err
 		}
 	}
 	// TLFVisibility_ANY doesn't make any sense for send, so switch that to PRIVATE:
 	if c.resolvingRequest.Visibility == keybase1.TLFVisibility_ANY {
 		c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
+	}
+
+	// Verify we can continue with the current options, this will return an
+	// error if you try to send to a KBFS chat or have --public set and
+	// ephemeralLifetime.
+	if c.ephemeralLifetime > 0 {
+		if c.resolvingRequest.Visibility == keybase1.TLFVisibility_PUBLIC {
+			return fmt.Errorf("Cannot send ephemeral messages with --public set.")
+		}
+		if c.resolvingRequest.MembersType == chat1.ConversationMembersType_KBFS {
+			return fmt.Errorf("Cannot send ephemeral messages to a KBFS type chat.")
+		}
 	}
 
 	// TODO: Right now this command cannot be run in standalone at
@@ -98,8 +109,7 @@ func (c *CmdChatSend) Run() (err error) {
 			chat1.ConversationMembersType_IMPTEAMUPGRADE:
 			c.G().StartStandaloneChat()
 		default:
-			err = CantRunInStandaloneError{}
-			return err
+			return CantRunInStandaloneError{}
 		}
 	}
 

--- a/go/client/cmd_chat_upload.go
+++ b/go/client/cmd_chat_upload.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/keybase/cli"
@@ -66,6 +67,12 @@ func (c *CmdChatUpload) ParseArgv(ctx *cli.Context) error {
 }
 
 func (c *CmdChatUpload) Run() error {
+	// Verify that we are not trying to send an ephemeral message to a public
+	// chat.
+	if c.ephemeralLifetime.Duration > 0 && c.public {
+		return fmt.Errorf("Cannot send ephemeral messages with --public set.")
+	}
+
 	opts := attachOptionsV1{
 		Channel: ChatChannel{
 			Name:   c.tlf,


### PR DESCRIPTION
fixes error if you tried to send an ephemeral message with `--public` set for `keybase chat send` and `keybase chat upload`

Help:

```
$ kb chat send --help
Running `go install github.com/keybase/client/go/keybase`... Done.
NAME:
   keybase chat send - Send a message to a conversation

USAGE:
   keybase chat send [command options] [conversation [message]]

OPTIONS:
   --topic-type "chat"          Specify topic type of the conversation. Has to be chat or dev
   --channel                    Specify the conversation channel.
   --public                     Only select public conversations. Exclusive to --private
   --private                    Only select private conversations. Exclusive to --public. If both --public and --private are present, --private takes priority.
   --set-headline               Set the headline for the conversation
   --clear-headline             Clear the headline for the conversation
   --nonblock                   Send message without success confirmation
   --exploding-lifetime "0s"    Make this message an exploding message and set the lifetime for the given duration.
                                The maximum lifetime is 168h0m0s (one week) and the minimum lifetime is 30s. Cannot be used in conjunction with --public.
 ```
error handling:
```
$ kb chat send --exploding-lifetime=30s --public test3 hi
Running `go install github.com/keybase/client/go/keybase`... Done.
▶ WARNING Running in devel mode
▶ ERROR Cannot send ephemeral messages with --public set.
```