### PR TITLE
send ibms injected locally from an on-disk queue CORE-7921

### DIFF
--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -397,7 +397,7 @@ func (c *Client) filterLocalDismissals(ctx context.Context, state gregor.State) 
 	return filteredState
 }
 
-func (c *Client) applyOutboxMessages(ctx context.Context, state gregor.State) gregor.State {
+func (c *Client) applyOutboxMessages(ctx context.Context, state gregor.State, t gregor.TimeOrOffset) gregor.State {
 	msgs, err := c.Sm.Outbox(ctx, c.User)
 	if err != nil {
 		c.Log.CDebugf(ctx, "applyOutboxMessages: failed to read outbox: %s", err)
@@ -411,7 +411,7 @@ func (c *Client) applyOutboxMessages(ctx context.Context, state gregor.State) gr
 			return state
 		}
 	}
-	astate, err := sm.State(ctx, c.User, c.Device, gregor1.TimeOrOffset{})
+	astate, err := sm.State(ctx, c.User, c.Device, t)
 	if err != nil {
 		c.Log.CDebugf(ctx, "applyOutboxMessages: failed to read state back out: %s", err)
 		return state
@@ -427,7 +427,7 @@ func (c *Client) StateMachineState(ctx context.Context, t gregor.TimeOrOffset,
 	}
 	if applyLocalState {
 		st = c.filterLocalDismissals(ctx, st)
-		st = c.applyOutboxMessages(ctx, st)
+		st = c.applyOutboxMessages(ctx, st, t)
 	}
 	return st, nil
 }

--- a/go/gregor/interface.go
+++ b/go/gregor/interface.go
@@ -211,6 +211,15 @@ type StateMachine interface {
 
 	// Consume a local dismissal in state machine storage
 	ConsumeLocalDismissal(context.Context, UID, MsgID) error
+
+	// Outbox gives all of the pending messages in the outbox
+	Outbox(context.Context, UID) ([]Message, error)
+
+	// InitOutbox sets the outbox for the give user
+	InitOutbox(context.Context, UID, []Message) error
+
+	// ConsumeOutboxMessage add a message to the outbox
+	ConsumeOutboxMessage(context.Context, UID, Message) error
 }
 
 type ObjFactory interface {

--- a/go/gregor/interface.go
+++ b/go/gregor/interface.go
@@ -126,6 +126,7 @@ type ProtocolState interface {
 type Message interface {
 	ToInBandMessage() InBandMessage
 	ToOutOfBandMessage() OutOfBandMessage
+	Marshal() ([]byte, error)
 }
 
 type ReminderSet interface {
@@ -243,6 +244,7 @@ type ObjFactory interface {
 	MakeTimeOrOffsetFromOffset(d time.Duration) (TimeOrOffset, error)
 	MakeReminderSetFromReminders([]Reminder, bool) (ReminderSet, error)
 	UnmarshalState([]byte) (State, error)
+	UnmarshalMessage([]byte) (Message, error)
 }
 
 type MainLoopServer interface {

--- a/go/gregor/storage/db.go
+++ b/go/gregor/storage/db.go
@@ -7,8 +7,9 @@ import (
 	"github.com/keybase/client/go/libkb"
 )
 
-type localDismissalsRecord struct {
+type localStorageRecord struct {
 	Dismissals [][]byte `json:"d"`
+	Outbox     [][]byte `json:"o"`
 }
 
 type LocalDb struct {
@@ -25,27 +26,28 @@ func dbKey(u gregor.UID) libkb.DbKey {
 	return libkb.DbKey{Typ: libkb.DBGregor, Key: hex.EncodeToString(u.Bytes())}
 }
 
-func dbKeyLocalDismiss(u gregor.UID) libkb.DbKey {
+func dbKeyLocal(u gregor.UID) libkb.DbKey {
 	return libkb.DbKey{Typ: libkb.DBGregor, Key: "_ld" + hex.EncodeToString(u.Bytes())}
 }
 
-func (db *LocalDb) Store(u gregor.UID, state []byte, localDismissals [][]byte) error {
+func (db *LocalDb) Store(u gregor.UID, state []byte, outbox [][]byte, localDismissals [][]byte) error {
 	if err := db.G().LocalDb.PutRaw(dbKey(u), state); err != nil {
 		return err
 	}
-	ldr := localDismissalsRecord{
+	ldr := localStorageRecord{
 		Dismissals: localDismissals,
+		Outbox:     outbox,
 	}
-	return db.G().LocalDb.PutObj(dbKeyLocalDismiss(u), nil, ldr)
+	return db.G().LocalDb.PutObj(dbKeyLocal(u), nil, ldr)
 }
 
-func (db *LocalDb) Load(u gregor.UID) (state []byte, localDismissals [][]byte, err error) {
+func (db *LocalDb) Load(u gregor.UID) (state []byte, outbox [][]byte, localDismissals [][]byte, err error) {
 	if state, _, err = db.G().LocalDb.GetRaw(dbKey(u)); err != nil {
-		return state, localDismissals, err
+		return state, outbox, localDismissals, err
 	}
-	var ldr localDismissalsRecord
-	if _, err = db.G().LocalDb.GetInto(&ldr, dbKeyLocalDismiss(u)); err != nil {
-		return state, localDismissals, err
+	var ldr localStorageRecord
+	if _, err = db.G().LocalDb.GetInto(&ldr, dbKeyLocal(u)); err != nil {
+		return state, outbox, localDismissals, err
 	}
-	return state, ldr.Dismissals, nil
+	return state, ldr.Outbox, ldr.Dismissals, nil
 }

--- a/go/protocol/gregor1/extras.go
+++ b/go/protocol/gregor1/extras.go
@@ -262,6 +262,12 @@ func (m Message) ToOutOfBandMessage() gregor.OutOfBandMessage {
 	return *m.Oobm_
 }
 
+func (m Message) Marshal() ([]byte, error) {
+	var b []byte
+	err := codec.NewEncoderBytes(&b, &codec.MsgpackHandle{WriteExt: true}).Encode(m)
+	return b, err
+}
+
 func (m *Message) SetCTime(ctime time.Time) {
 	if m.Ibm_ != nil && m.Ibm_.StateUpdate_ != nil {
 		m.Ibm_.StateUpdate_.Md_.Ctime_ = ToTime(ctime)

--- a/go/protocol/gregor1/factory.go
+++ b/go/protocol/gregor1/factory.go
@@ -240,6 +240,15 @@ func (o ObjFactory) UnmarshalState(b []byte) (gregor.State, error) {
 	return state, nil
 }
 
+func (o ObjFactory) UnmarshalMessage(b []byte) (gregor.Message, error) {
+	var message Message
+	err := codec.NewDecoderBytes(b, &codec.MsgpackHandle{WriteExt: true}).Decode(&message)
+	if err != nil {
+		return nil, err
+	}
+	return message, nil
+}
+
 func (o ObjFactory) MakeTimeOrOffsetFromTime(t time.Time) (gregor.TimeOrOffset, error) {
 	return timeToTimeOrOffset(&t), nil
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -316,7 +316,6 @@ func (g *gregorHandler) GetClient() chat1.RemoteInterface {
 func (g *gregorHandler) resetGregorClient(ctx context.Context) (err error) {
 	defer g.G().Trace("gregorHandler#newGregorClient", func() error { return err })()
 	of := gregor1.ObjFactory{}
-	sm := storage.NewMemEngine(of, clockwork.NewRealClock(), g.G().Log)
 
 	var guid gregor.UID
 	var gdid gregor.DeviceID
@@ -348,8 +347,9 @@ func (g *gregorHandler) resetGregorClient(ctx context.Context) (err error) {
 	}
 
 	// Create client object
-	gcli := grclient.NewClient(guid, gdid, sm, storage.NewLocalDB(g.G().ExternalG()),
-		g.G().Env.GetGregorSaveInterval(), g.G().Log)
+	gcli := grclient.NewClient(guid, gdid, func() gregor.StateMachine {
+		return storage.NewMemEngine(of, clockwork.NewRealClock(), g.G().Log)
+	}, storage.NewLocalDB(g.G().ExternalG()), g.GetIncomingClient, g.G().Log)
 
 	// Bring up local state
 	g.Debug(ctx, "restoring state from leveldb")
@@ -358,6 +358,9 @@ func (g *gregorHandler) resetGregorClient(ctx context.Context) (err error) {
 		g.Debug(ctx, "restore local state failed: %s", err)
 	}
 
+	if g.gregorCli != nil {
+		g.gregorCli.Stop()
+	}
 	g.gregorCli = gcli
 	return nil
 }
@@ -1625,12 +1628,11 @@ func (g *gregorHandler) DismissItem(ctx context.Context, cli gregor1.IncomingInt
 	dismissal.Ibm_.StateUpdate_.Dismissal_ = &gregor1.Dismissal{
 		MsgIDs_: []gregor1.MsgID{gregor1.MsgID(id.Bytes())},
 	}
-
-	if cli == nil {
-		cli = gregor1.IncomingClient{Cli: g.cli}
+	gcli, err := g.getGregorCli()
+	if err != nil {
+		return err
 	}
-	err = cli.ConsumeMessage(ctx, *dismissal)
-	return err
+	return gcli.ConsumeMessage(ctx, *dismissal)
 }
 
 func (g *gregorHandler) LocalDismissItem(ctx context.Context, id gregor.MsgID) (err error) {
@@ -1671,10 +1673,11 @@ func (g *gregorHandler) DismissCategory(ctx context.Context, category gregor1.Ca
 				},
 			}},
 	}
-
-	incomingClient := g.GetIncomingClient()
-	err = incomingClient.ConsumeMessage(ctx, *dismissal)
-	return err
+	gcli, err := g.getGregorCli()
+	if err != nil {
+		return err
+	}
+	return gcli.ConsumeMessage(ctx, *dismissal)
 }
 
 func (g *gregorHandler) InjectItem(ctx context.Context, cat string, body []byte, dtime gregor1.TimeOrOffset) (gregor1.MsgID, error) {
@@ -1693,9 +1696,11 @@ func (g *gregorHandler) InjectItem(ctx context.Context, cat string, body []byte,
 		Dtime_:    dtime,
 	}
 
-	incomingClient := gregor1.IncomingClient{Cli: g.cli}
-	err = incomingClient.ConsumeMessage(ctx, *creation)
-	return creation.Ibm_.StateUpdate_.Md_.MsgID_, err
+	gcli, err := g.getGregorCli()
+	if err != nil {
+		return err
+	}
+	return creation.Ibm_.StateUpdate_.Md_.MsgID_, gcli.ConsumeMessage(ctx, *creation)
 }
 
 func (g *gregorHandler) UpdateItem(ctx context.Context, msgID gregor1.MsgID, cat string, body []byte, dtime gregor1.TimeOrOffset) (gregor1.MsgID, error) {
@@ -1717,9 +1722,11 @@ func (g *gregorHandler) UpdateItem(ctx context.Context, msgID gregor1.MsgID, cat
 		MsgIDs_: []gregor1.MsgID{msgID},
 	}
 
-	incomingClient := gregor1.IncomingClient{Cli: g.cli}
-	err = incomingClient.ConsumeMessage(ctx, *msg)
-	return msg.Ibm_.StateUpdate_.Md_.MsgID_, err
+	gcli, err := g.getGregorCli()
+	if err != nil {
+		return err
+	}
+	return msg.Ibm_.StateUpdate_.Md_.MsgID_, gcli.ConsumeMessage(ctx, *msg)
 }
 
 func (g *gregorHandler) InjectOutOfBandMessage(system string, body []byte) error {
@@ -1730,8 +1737,7 @@ func (g *gregorHandler) InjectOutOfBandMessage(system string, body []byte) error
 
 	uid := g.G().Env.GetUID()
 	if uid.IsNil() {
-		err = fmt.Errorf("Can't create new gregor items without a current UID.")
-		return err
+		return libkb.LoggedInError{}
 	}
 	gregorUID := gregor1.UID(uid.ToBytes())
 
@@ -1743,10 +1749,11 @@ func (g *gregorHandler) InjectOutOfBandMessage(system string, body []byte) error
 		},
 	}
 
-	incomingClient := gregor1.IncomingClient{Cli: g.cli}
-	// TODO: Should the interface take a context from the caller?
-	err = incomingClient.ConsumeMessage(context.TODO(), msg)
-	return err
+	gcli, err := g.getGregorCli()
+	if err != nil {
+		return err
+	}
+	return gcli.ConsumeMessage(ctx, msg)
 }
 
 func (g *gregorHandler) simulateCrashForTesting() {
@@ -1775,7 +1782,7 @@ func (g *gregorHandler) getState(ctx context.Context) (res gregor1.State, err er
 		return res, errors.New("gregor service not available (are you in standalone?)")
 	}
 
-	s, err = g.gregorCli.StateMachineState(ctx, nil, false)
+	s, err = g.gregorCli.StateMachineState(ctx, nil, true, true)
 	if err != nil {
 		return res, err
 	}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1698,7 +1698,7 @@ func (g *gregorHandler) InjectItem(ctx context.Context, cat string, body []byte,
 
 	gcli, err := g.getGregorCli()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	return creation.Ibm_.StateUpdate_.Md_.MsgID_, gcli.ConsumeMessage(ctx, *creation)
 }
@@ -1724,14 +1724,14 @@ func (g *gregorHandler) UpdateItem(ctx context.Context, msgID gregor1.MsgID, cat
 
 	gcli, err := g.getGregorCli()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	return msg.Ibm_.StateUpdate_.Md_.MsgID_, gcli.ConsumeMessage(ctx, *msg)
 }
 
-func (g *gregorHandler) InjectOutOfBandMessage(system string, body []byte) error {
+func (g *gregorHandler) InjectOutOfBandMessage(ctx context.Context, system string, body []byte) error {
 	var err error
-	defer g.G().Trace(fmt.Sprintf("gregorHandler.InjectOutOfBandMessage(%s)", system),
+	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.InjectOutOfBandMessage(%s)", system),
 		func() error { return err },
 	)()
 
@@ -1782,7 +1782,7 @@ func (g *gregorHandler) getState(ctx context.Context) (res gregor1.State, err er
 		return res, errors.New("gregor service not available (are you in standalone?)")
 	}
 
-	s, err = g.gregorCli.StateMachineState(ctx, nil, true, true)
+	s, err = g.gregorCli.StateMachineState(ctx, nil, true)
 	if err != nil {
 		return res, err
 	}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1619,6 +1619,7 @@ func (g *gregorHandler) DismissItem(ctx context.Context, cli gregor1.IncomingInt
 	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.dismissItem(%s)", id.String()),
 		func() error { return err },
 	)()
+	defer g.pushState(keybase1.PushReason_NEW_DATA)
 
 	dismissal, err := g.templateMessage()
 	if err != nil {
@@ -1642,6 +1643,7 @@ func (g *gregorHandler) LocalDismissItem(ctx context.Context, id gregor.MsgID) (
 	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.localDismissItem(%s)", id.String()),
 		func() error { return err },
 	)()
+	defer g.pushState(keybase1.PushReason_NEW_DATA)
 
 	cli, err := g.getGregorCli()
 	if err != nil {
@@ -1655,6 +1657,7 @@ func (g *gregorHandler) DismissCategory(ctx context.Context, category gregor1.Ca
 	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.DismissCategory(%s)", category.String()),
 		func() error { return err },
 	)()
+	defer g.pushState(keybase1.PushReason_NEW_DATA)
 
 	dismissal, err := g.templateMessage()
 	if err != nil {
@@ -1685,6 +1688,7 @@ func (g *gregorHandler) InjectItem(ctx context.Context, cat string, body []byte,
 	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.InjectItem(%s)", cat),
 		func() error { return err },
 	)()
+	defer g.pushState(keybase1.PushReason_NEW_DATA)
 
 	creation, err := g.templateMessage()
 	if err != nil {
@@ -1708,6 +1712,7 @@ func (g *gregorHandler) UpdateItem(ctx context.Context, msgID gregor1.MsgID, cat
 	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.UpdateItem(%s,%s)", msgID.String(), cat),
 		func() error { return err },
 	)()
+	defer g.pushState(keybase1.PushReason_NEW_DATA)
 
 	msg, err := g.templateMessage()
 	if err != nil {

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -956,7 +956,7 @@ func TestOfflineConsume(t *testing.T) {
 	tc := libkb.SetupTest(t, "gregor", 2)
 	defer tc.Cleanup()
 	tc.G.SetService()
-	_, server, uid := setupSyncTests(t, tc)
+	h, server, uid := setupSyncTests(t, tc)
 
 	fclient := newFlakeyIncomingClient(func() gregor1.IncomingInterface { return server })
 	client := grclient.NewClient(uid, nil, func() gregor.StateMachine {
@@ -966,6 +966,7 @@ func TestOfflineConsume(t *testing.T) {
 	client.TestingEvents = tev
 	fc := clockwork.NewFakeClock()
 	client.Clock = fc
+	h.gregorCli = client
 
 	// Try to consume offline
 	t.Logf("offline")
@@ -1005,6 +1006,7 @@ func TestOfflineConsume(t *testing.T) {
 		Uid: uid,
 	})
 	require.NoError(t, err)
+	require.NoError(t, broadcastMessageTesting(t, h, msg))
 	require.Equal(t, 1, len(serverState.Items_))
 	require.Equal(t, msg.ToInBandMessage().Metadata().MsgID().String(),
 		serverState.Items_[0].Metadata().MsgID().String())

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -998,7 +998,7 @@ func TestOfflineConsume(t *testing.T) {
 	case msg := <-tev.OutboxSend:
 		require.Equal(t, msg.ToInBandMessage().Metadata().MsgID().String(),
 			items[0].Metadata().MsgID().String())
-	case <-time.After(2 * time.Second):
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no send")
 	}
 	serverState, err = server.State(context.TODO(), gregor1.StateArg{
@@ -1006,6 +1006,8 @@ func TestOfflineConsume(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(serverState.Items_))
+	require.Equal(t, msg.ToInBandMessage().Metadata().MsgID().String(),
+		serverState.Items_[0].Metadata().MsgID().String())
 	clientState, err = client.StateMachineState(context.TODO(), gregor1.TimeOrOffset{}, true)
 	require.NoError(t, err)
 	items, err = clientState.Items()

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -996,7 +996,7 @@ func (d *Service) GregorInjectOutOfBandMessage(sys string, body []byte) error {
 	if d.gregor == nil {
 		return errors.New("can't gregor inject without a gregor")
 	}
-	return d.gregor.InjectOutOfBandMessage(sys, body)
+	return d.gregor.InjectOutOfBandMessage(context.TODO(), sys, body)
 }
 
 func (d *Service) HasGregor() bool {

--- a/go/systests/gregor_test.go
+++ b/go/systests/gregor_test.go
@@ -163,14 +163,17 @@ func TestGregorForwardToElectron(t *testing.T) {
 		}
 	}
 
-	select {
-	case pushArg := <-em.stateCh:
-		checkState(pushArg.State)
-		if pushArg.Reason != keybase1.PushReason_NEW_DATA {
-			t.Errorf("wrong reason for push: %v", pushArg.Reason)
+	// We get two push states, one from the local send, and one from receiving broadcast
+	for i := 0; i < 2; i++ {
+		select {
+		case pushArg := <-em.stateCh:
+			checkState(pushArg.State)
+			if pushArg.Reason != keybase1.PushReason_NEW_DATA {
+				t.Errorf("wrong reason for push: %v", pushArg.Reason)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("never got an IBM")
 		}
-	case <-time.After(3 * time.Second):
-		t.Fatalf("never got an IBM")
 	}
 
 	pollForTrue(t, tc.G, func(i int) bool {


### PR DESCRIPTION
Patch does the following:

1.) Add a new "outbox" to be managed by the Gregor server client.
2.) The outbox is stored/restored in the normal `Save`/`Restore` flow for the Gregor state.
3.) Add `ConsumeMessage` to `Client` for use by `gregorHandler` to send new messages. For OOBMs, they go immediately to the server. For IBMs, they get put in the outbox and the send loop gets triggered.
4.) When calling `StateMachineState` on `Client`, it can optionally apply the messages in the outbox to yield the final version. The call the frontend makes will use this method.
5.) Throw up a `pushState` call to the frontend whenever they call one of the functions that can modify state. They only act on these messages, not the success of a call they make. 
6.) Some other random cleanup.

cc @buoyad (although you don't need to do anything here, the APIs don't change).