### PR TITLE
Ability to pgp pull untracked users

### DIFF
--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -179,7 +179,6 @@ type FakeIdentifyUI struct {
 	Proofs          map[string]string
 	ProofResults    map[string]keybase1.LinkCheckResult
 	User            *keybase1.User
-	Confirmed       bool
 	Keys            map[libkb.PGPFingerprint]*keybase1.TrackDiff
 	DisplayKeyCalls int
 	DisplayKeyDiffs []*keybase1.TrackDiff
@@ -189,6 +188,7 @@ type FakeIdentifyUI struct {
 	BrokenTracking  bool
 	DisplayTLFArg   keybase1.DisplayTLFCreateWithInviteArg
 	DisplayTLFCount int
+	FakeConfirm     bool
 	sync.Mutex
 }
 
@@ -238,8 +238,9 @@ func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result key
 	time.Sleep(100 * time.Millisecond)
 
 	ui.Outcome = outcome
-	result.IdentityConfirmed = outcome.TrackOptions.BypassConfirm
-	result.RemoteConfirmed = outcome.TrackOptions.BypassConfirm && !outcome.TrackOptions.ExpiringLocal
+	bypass := ui.FakeConfirm || outcome.TrackOptions.BypassConfirm
+	result.IdentityConfirmed = bypass
+	result.RemoteConfirmed = bypass && !outcome.TrackOptions.ExpiringLocal
 	return
 }
 func (ui *FakeIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) error {

--- a/go/engine/pgp_pull_test.go
+++ b/go/engine/pgp_pull_test.go
@@ -169,7 +169,7 @@ func TestPGPPullNotTracked(t *testing.T) {
 	}
 
 	if fui.StartCount != 1 {
-		tc.T.Fatal("Expected 1 ID UI prompt, got %d", fui.StartCount)
+		tc.T.Fatalf("Expected 1 ID UI prompt, got %d", fui.StartCount)
 	}
 
 	assertKeysPresent(t, gpgClient, []string{bobFp, aliceFp})
@@ -199,7 +199,7 @@ func TestPGPPullNotLoggedIn(t *testing.T) {
 	}
 
 	if fui.StartCount != 2 {
-		tc.T.Fatal("Expected 2 ID UI prompts, got %d", fui.StartCount)
+		tc.T.Fatalf("Expected 2 ID UI prompts, got %d", fui.StartCount)
 	}
 
 	assertKeysPresent(t, gpgClient, []string{aliceFp, bobFp})

--- a/go/engine/pgp_pull_test.go
+++ b/go/engine/pgp_pull_test.go
@@ -132,9 +132,75 @@ func TestPGPPullBadIDs(t *testing.T) {
 	assertKeysMissing(t, gpgClient, []string{aliceFp, bobFp})
 
 	runPGPPullExpectingError(tc, PGPPullEngineArg{
-		// ID'ing a nonexistent/untracked user should fail the pull.
+		// ID'ing invalid user should fail the pull.
 		UserAsserts: []string{"t_bob", "t_NOT_TRACKED_BY_ME"},
 	})
 
 	assertKeysMissing(t, gpgClient, []string{aliceFp, bobFp})
+}
+
+func TestPGPPullNotTracked(t *testing.T) {
+	tc := SetupEngineTest(t, "pgp_pull")
+	defer tc.Cleanup()
+	sigVersion := libkb.GetDefaultSigVersion(tc.G)
+
+	// Only tracking alice
+	users := []string{"t_alice"}
+	fu := createUserWhoTracks(tc, users, sigVersion)
+	defer untrackUserList(tc, fu, users, sigVersion)
+	gpgClient := createGpgClient(tc)
+
+	// But want to pull bot alice and bob.
+	assertKeysMissing(t, gpgClient, []string{aliceFp, bobFp})
+
+	fui := &FakeIdentifyUI{FakeConfirm: true}
+	uis := libkb.UIs{
+		LogUI:      tc.G.UI.GetLogUI(),
+		GPGUI:      &gpgtestui{},
+		IdentifyUI: fui,
+	}
+	eng := NewPGPPullEngine(tc.G, &PGPPullEngineArg{
+		UserAsserts: []string{"t_bob", "t_alice"},
+	})
+	m := NewMetaContextForTest(tc).WithUIs(uis)
+	err := RunEngine2(m, eng)
+	if err != nil {
+		tc.T.Fatal("Error in PGPPullEngine:", err)
+	}
+
+	if fui.StartCount != 1 {
+		tc.T.Fatal("Expected 1 ID UI prompt, got %d", fui.StartCount)
+	}
+
+	assertKeysPresent(t, gpgClient, []string{bobFp, aliceFp})
+}
+
+func TestPGPPullNotLoggedIn(t *testing.T) {
+	tc := SetupEngineTest(t, "track")
+	defer tc.Cleanup()
+
+	gpgClient := createGpgClient(tc)
+
+	assertKeysMissing(t, gpgClient, []string{aliceFp, bobFp})
+
+	fui := &FakeIdentifyUI{FakeConfirm: true}
+	uis := libkb.UIs{
+		LogUI:      tc.G.UI.GetLogUI(),
+		GPGUI:      &gpgtestui{},
+		IdentifyUI: fui,
+	}
+	eng := NewPGPPullEngine(tc.G, &PGPPullEngineArg{
+		UserAsserts: []string{"t_bob", "t_alice"},
+	})
+	m := NewMetaContextForTest(tc).WithUIs(uis)
+	err := RunEngine2(m, eng)
+	if err != nil {
+		tc.T.Fatal("Error in PGPPullEngine:", err)
+	}
+
+	if fui.StartCount != 2 {
+		tc.T.Fatal("Expected 2 ID UI prompts, got %d", fui.StartCount)
+	}
+
+	assertKeysPresent(t, gpgClient, []string{aliceFp, bobFp})
 }


### PR DESCRIPTION
All the pieces for pulling untracked users were in there, because the engine also worked in not-logged-in mode, where it ran identify to confirm that user's key should be pulled. So that command used to have 3 modes of operation
1. `keybase pgp pull` (no arguments), would pull PGP keys for all tracked users.
2. `keybase pgp pull user_assertion` would look through tracked users and only pull PGP key for *user_assertion*. It was an error if *user_assertion* was not among tracked users.
3. When not logged in: `keybase pgp pull user_assertion` run Identify2 and confirm using IdentifyUI that user wants to pull PGP key of *user_assertion*.

This PR extends the 2nd option, by first going through tracked users to find passed *user_assertion*, and if it's not there, it re-uses machinery of option 3 to run Identify and confirm PGP pull.

This PR also adds a test for the change above, and also for unlogged pgp pull.