### PR TITLE
Add ephemeral messaging test for sbs case [CORE-8036]

### DIFF
--- a/go/chat/sbs_test.go
+++ b/go/chat/sbs_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
@@ -84,95 +85,113 @@ func proveRooter(t *testing.T, g *libkb.GlobalContext, fu *kbtest.FakeUser) {
 
 func TestChatSrvSBS(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
-		ctc := makeChatTestContext(t, "TestChatSrvSBS", 2)
-		defer ctc.cleanup()
-		users := ctc.users()
+		runWithEphemeral(t, mt, func(ephemeralLifetime *gregor1.DurationSec) {
+			ctc := makeChatTestContext(t, "TestChatSrvSBS", 2)
+			defer ctc.cleanup()
+			users := ctc.users()
 
-		// Only run this test for imp teams
-		switch mt {
-		case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE:
-		default:
-			return
-		}
+			// Only run this test for imp teams
+			switch mt {
+			case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE:
+			default:
+				return
+			}
+			// If we are sending ephemeral messages make sure both users have
+			// user/device EKs
+			if ephemeralLifetime != nil {
+				ctc.as(t, users[0]).h.G().GetEKLib().KeygenIfNeeded(context.Background())
+				ctc.as(t, users[1]).h.G().GetEKLib().KeygenIfNeeded(context.Background())
+			}
 
-		tc0 := ctc.world.Tcs[users[0].Username]
-		tc1 := ctc.world.Tcs[users[1].Username]
-		ctx := ctc.as(t, users[0]).startCtx
-		listener0 := newServerChatListener()
-		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
-		listener1 := newServerChatListener()
-		ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener1)
-		kickTeamRekeyd(tc0.Context().ExternalG(), t)
-		name := users[0].Username + "," + users[1].Username + "@rooter"
-		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
-			chat1.NewConversationLocalArg{
-				TlfName:          name,
-				TopicType:        chat1.TopicType_CHAT,
-				TlfVisibility:    keybase1.TLFVisibility_PRIVATE,
-				MembersType:      chat1.ConversationMembersType_IMPTEAMNATIVE,
-				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-			})
-		require.NoError(t, err)
+			tc0 := ctc.world.Tcs[users[0].Username]
+			tc1 := ctc.world.Tcs[users[1].Username]
+			ctx := ctc.as(t, users[0]).startCtx
+			listener0 := newServerChatListener()
+			ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
+			listener1 := newServerChatListener()
+			ctc.as(t, users[1]).h.G().NotifyRouter.SetListener(listener1)
+			kickTeamRekeyd(tc0.Context().ExternalG(), t)
+			name := users[0].Username + "," + users[1].Username + "@rooter"
+			ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
+				chat1.NewConversationLocalArg{
+					TlfName:          name,
+					TopicType:        chat1.TopicType_CHAT,
+					TlfVisibility:    keybase1.TLFVisibility_PRIVATE,
+					MembersType:      chat1.ConversationMembersType_IMPTEAMNATIVE,
+					IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+				})
+			require.NoError(t, err)
 
-		mustPostLocalForTest(t, ctc, users[0], ncres.Conv.Info,
-			chat1.NewMessageBodyWithText(chat1.MessageText{
-				Body: "HI",
-			}))
-		consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
-		consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
+			mustPostLocalEphemeralForTest(t, ctc, users[0], ncres.Conv.Info,
+				chat1.NewMessageBodyWithText(chat1.MessageText{
+					Body: "HI",
+				}), ephemeralLifetime)
+			require.NoError(t, err)
+			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
+			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
 
-		_, err = postLocalForTest(t, ctc, users[1], ncres.Conv.Info,
-			chat1.NewMessageBodyWithText(chat1.MessageText{
-				Body: "HI",
-			}))
-		require.Error(t, err)
-		require.IsType(t, libkb.ChatNotInTeamError{}, err)
+			_, err = postLocalEphemeralForTest(t, ctc, users[1], ncres.Conv.Info,
+				chat1.NewMessageBodyWithText(chat1.MessageText{
+					Body: "HI",
+				}), ephemeralLifetime)
+			require.Error(t, err)
+			require.IsType(t, libkb.ChatNotInTeamError{}, err)
 
-		t.Logf("proving rooter now")
-		proveRooter(t, tc1.Context().ExternalG(), users[1])
-		t.Logf("uid1: %s", users[1].User.GetUID())
-		t.Logf("teamID: %s", ncres.Conv.Info.Triple.Tlfid)
-		t.Logf("convID: %x", ncres.Conv.GetConvID().DbShortForm())
+			t.Logf("proving rooter now")
+			proveRooter(t, tc1.Context().ExternalG(), users[1])
+			t.Logf("uid1: %s", users[1].User.GetUID())
+			t.Logf("teamID: %s", ncres.Conv.Info.Triple.Tlfid)
+			t.Logf("convID: %x", ncres.Conv.GetConvID().DbShortForm())
 
-		select {
-		case rres := <-listener0.membersUpdate:
-			require.Equal(t, ncres.Conv.GetConvID(), rres.ConvID)
-			require.Equal(t, 1, len(rres.Members))
-			require.Equal(t, users[1].Username, rres.Members[0].Member)
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "no resolve")
-		}
-		select {
-		case rres := <-listener1.joinedConv:
-			require.Equal(t, ncres.Conv.GetConvID().String(), rres.ConvID)
-			require.Equal(t, 2, len(rres.Participants))
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "no resolve")
-		}
+			select {
+			case rres := <-listener0.membersUpdate:
+				require.Equal(t, ncres.Conv.GetConvID(), rres.ConvID)
+				require.Equal(t, 1, len(rres.Members))
+				require.Equal(t, users[1].Username, rres.Members[0].Member)
+			case <-time.After(20 * time.Second):
+				require.Fail(t, "no resolve")
+			}
+			select {
+			case rres := <-listener1.joinedConv:
+				require.Equal(t, ncres.Conv.GetConvID().String(), rres.ConvID)
+				require.Equal(t, 2, len(rres.Participants))
+			case <-time.After(20 * time.Second):
+				require.Fail(t, "no resolve")
+			}
 
-		mustPostLocalForTest(t, ctc, users[0], ncres.Conv.Info,
-			chat1.NewMessageBodyWithText(chat1.MessageText{
-				Body: "HI",
-			}))
-		consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
-		consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
-		consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
-		mustPostLocalForTest(t, ctc, users[1], ncres.Conv.Info,
-			chat1.NewMessageBodyWithText(chat1.MessageText{
-				Body: "HI",
-			}))
-		consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
-		consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
-		consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
-		tvres, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
-			ConversationID: ncres.Conv.GetConvID(),
-			Query: &chat1.GetThreadQuery{
-				MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
-			},
+			mustPostLocalEphemeralForTest(t, ctc, users[0], ncres.Conv.Info,
+				chat1.NewMessageBodyWithText(chat1.MessageText{
+					Body: "HI",
+				}), ephemeralLifetime)
+			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
+			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
+			consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
+
+			mustPostLocalEphemeralForTest(t, ctc, users[1], ncres.Conv.Info,
+				chat1.NewMessageBodyWithText(chat1.MessageText{
+					Body: "HI",
+				}), ephemeralLifetime)
+			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
+			consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
+			consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
+			verifyThread := func(user *kbtest.FakeUser) {
+				tvres, err := ctc.as(t, user).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
+					ConversationID: ncres.Conv.GetConvID(),
+					Query: &chat1.GetThreadQuery{
+						MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+					},
+				})
+				require.NoError(t, err)
+				require.Equal(t, 3, len(tvres.Thread.Messages))
+
+				for _, msg := range tvres.Thread.Messages {
+					require.True(t, msg.IsValid())
+				}
+			}
+
+			verifyThread(users[0])
+			verifyThread(users[1])
 		})
-		require.NoError(t, err)
-		require.Equal(t, 3, len(tvres.Thread.Messages))
-
 	})
 
 }

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -217,7 +217,7 @@ type userEKStatementResponse struct {
 // transitional thing, and eventually when all "reasonably up to date" clients
 // in the wild have EK support, we will make that case an error.
 func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []keybase1.UID) (statements map[keybase1.UID]*keybase1.UserEkStatement, err error) {
-	defer g.CTraceTimed(ctx, "fetchUserEKStatements", func() error { return err })()
+	defer g.CTraceTimed(ctx, fmt.Sprintf("fetchUserEKStatements: numUids: %v", len(uids)), func() error { return err })()
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "user/user_ek",
@@ -374,7 +374,7 @@ func verifySigWithLatestPUK(ctx context.Context, g *libkb.GlobalContext, uid key
 }
 
 func filterStaleUserEKStatements(ctx context.Context, g *libkb.GlobalContext, statementMap map[keybase1.UID]*keybase1.UserEkStatement, merkleRoot libkb.MerkleRoot) (activeMap map[keybase1.UID]keybase1.UserEkStatement, err error) {
-	defer g.CTraceTimed(ctx, "filterStaleUserEKStatements", func() error { return err })()
+	defer g.CTraceTimed(ctx, fmt.Sprintf("filterStaleUserEKStatements: numStatements: %v", len(statementMap)), func() error { return err })()
 
 	activeMap = make(map[keybase1.UID]keybase1.UserEkStatement)
 	for uid, statement := range statementMap {


### PR DESCRIPTION
Verify that ephemeral messages work for SBS chats (assuming that the sbs user has device/user ephemeral keys before they prove the account)