### PR TITLE
Better error when wallet send to nonexistant user

### DIFF
--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -227,6 +227,9 @@ func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput) (res 
 		social, err := expr.ToSocialAssertion()
 		if err != nil {
 			m.CDebugf("not a social assertion: %s (%s)", to, expr)
+			if _, ok := expr.(libkb.AssertionKeybase); ok {
+				return res, libkb.NotFoundError{Msg: fmt.Sprintf("user not found: %q", to)}
+			}
 			return res, fmt.Errorf("invalid recipient %q: %s", to, err)
 		}
 		res.Assertion = &social


### PR DESCRIPTION
After
```
$ kbu wallet send xxxxxxxx 0.0001 XLM
▶ WARNING Running in devel mode
Send 0.0001 XLM to xxxxxxxx? (type 'YES' to confirm): YES
▶ ERROR user not found: "xxxxxxxx"
```

Before
```
$ kbu wallet send xxxxxxxx 0.0001 XLM
▶ WARNING Running in devel mode
Send 0.0001 XLM to xxxxxxxx? (type 'YES' to confirm): YES
▶ WARNING not exportable error: invalid recipient "xxxxxxxx": cannot convert AssertionKeybase to social assertion (*errors.errorString)
▶ ERROR invalid recipient "xxxxxxxx": cannot convert AssertionKeybase to social assertion
```