### PR TITLE
cleanup the cache flush story

### DIFF
--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -303,6 +303,11 @@ func (b *BackgroundConvLoader) loop() {
 		b.clock.Sleep(b.resumeWait)
 	}
 
+	// Only access stopCh under lock to avoid racing with b.stopCh = make(chan{}) above.
+	b.Lock()
+	stopCh := b.stopCh
+	b.Unlock()
+
 	// Main loop
 	for {
 		b.Debug(bgctx, "loop: waiting for job")
@@ -346,7 +351,7 @@ func (b *BackgroundConvLoader) loop() {
 			if !waitForResume(ch) {
 				return
 			}
-		case <-b.stopCh:
+		case <-stopCh:
 			b.Debug(bgctx, "loop: shutting down for %s", uid)
 			return
 		}
@@ -357,6 +362,11 @@ func (b *BackgroundConvLoader) loadLoop() {
 	bgctx := context.Background()
 	uid := b.uid
 	b.Debug(bgctx, "loadLoop: starting for uid: %s", uid)
+
+	b.Lock()
+	stopCh := b.stopCh
+	b.Unlock()
+
 	for {
 		select {
 		case task := <-b.loadCh:
@@ -367,7 +377,7 @@ func (b *BackgroundConvLoader) loadLoop() {
 					b.Debug(bgctx, "enqueue error %s", err)
 				}
 			}
-		case <-b.stopCh:
+		case <-stopCh:
 			return
 		}
 	}

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -807,19 +807,6 @@ func (a *InternalAPIEngine) Delete(arg APIArg) (*APIRes, error) {
 
 func (a *InternalAPIEngine) DoRequest(arg APIArg, req *http.Request) (*APIRes, error) {
 	m := arg.GetMetaContext(a.G())
-	res, reqErr := a.doRequest(m, arg, req)
-	if reqErr == nil {
-		return res, nil
-	}
-
-	if req.GetBody != nil {
-		// post request body consumed, need to get it back
-		var err error
-		req.Body, err = req.GetBody()
-		if err != nil {
-			return res, err
-		}
-	}
 	res, err := a.doRequest(m, arg, req)
 	return res, err
 }

--- a/go/service/ctl.go
+++ b/go/service/ctl.go
@@ -62,7 +62,8 @@ func (c *CtlHandler) DbNuke(ctx context.Context, sessionID int) error {
 		teamLoader.ClearMem()
 	}
 	// Now drop caches, since we had the DB's state in-memory too.
-	return c.G().ConfigureCaches()
+	c.G().FlushCaches()
+	return nil
 }
 
 func (c *CtlHandler) AppExit(_ context.Context, sessionID int) error {
@@ -88,7 +89,7 @@ func (c *CtlHandler) DbDelete(_ context.Context, arg keybase1.DbDeleteArg) (err 
 	}
 
 	c.G().Log.Debug("Clearing memory caches after DbDelete")
-	c.G().ConfigureMemCaches()
+	c.G().FlushCaches()
 
 	return nil
 }
@@ -133,7 +134,7 @@ func (c *CtlHandler) DbPut(_ context.Context, arg keybase1.DbPutArg) (err error)
 	}
 
 	c.G().Log.Debug("Clearing memory caches after DbPut")
-	c.G().ConfigureMemCaches()
+	c.G().FlushCaches()
 
 	return nil
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -376,6 +376,11 @@ func (g *gregorHandler) resetGregorClient(ctx context.Context) (err error) {
 }
 
 func (g *gregorHandler) getGregorCli() (*grclient.Client, error) {
+
+	if g == nil {
+		return nil, errors.New("gregorHandler client unset")
+	}
+
 	g.gregorCliMu.Lock()
 	ret := g.gregorCli
 	g.gregorCliMu.Unlock()
@@ -1797,12 +1802,9 @@ func newGregorRPCHandler(xp rpc.Transporter, g *libkb.GlobalContext, gh *gregorH
 func (g *gregorHandler) getState(ctx context.Context) (res gregor1.State, err error) {
 	var s gregor.State
 
-	g.gregorCliMu.Lock()
-	gcli := g.gregorCli
-	g.gregorCliMu.Unlock()
-
-	if g == nil || gcli == nil {
-		return res, errors.New("gregor service not available (are you in standalone?)")
+	gcli, err := g.getGregorCli()
+	if err != nil {
+		return res, err
 	}
 
 	s, err = gcli.StateMachineState(ctx, nil, true)

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -188,8 +188,13 @@ type gregorHandler struct {
 	// This lock is to protect ibmHandlers and gregorCli and firehoseHandlers. Only public methods
 	// should grab it.
 	sync.Mutex
-	ibmHandlers      []libkb.GregorInBandMessageHandler
-	gregorCli        *grclient.Client
+	ibmHandlers []libkb.GregorInBandMessageHandler
+
+	// gregorCliMu just protecs the gregorCli pointer, since it can be swapped out
+	// in one goroutine and accessed in another.
+	gregorCliMu sync.Mutex
+	gregorCli   *grclient.Client
+
 	firehoseHandlers []libkb.GregorFirehoseHandler
 	badger           *badges.Badger
 	reachability     *reachability
@@ -358,18 +363,27 @@ func (g *gregorHandler) resetGregorClient(ctx context.Context) (err error) {
 		g.Debug(ctx, "restore local state failed: %s", err)
 	}
 
-	if g.gregorCli != nil {
-		g.gregorCli.Stop()
-	}
+	g.gregorCliMu.Lock()
+	gcliOld := g.gregorCli
 	g.gregorCli = gcli
+	g.gregorCliMu.Unlock()
+
+	if gcliOld != nil {
+		gcliOld.Stop()
+	}
+
 	return nil
 }
 
 func (g *gregorHandler) getGregorCli() (*grclient.Client, error) {
-	if g.gregorCli == nil {
+	g.gregorCliMu.Lock()
+	ret := g.gregorCli
+	g.gregorCliMu.Unlock()
+
+	if ret == nil {
 		return nil, errors.New("client unset")
 	}
-	return g.gregorCli, nil
+	return ret, nil
 }
 
 func (g *gregorHandler) getRPCCli() rpc.GenericClient {
@@ -1783,11 +1797,15 @@ func newGregorRPCHandler(xp rpc.Transporter, g *libkb.GlobalContext, gh *gregorH
 func (g *gregorHandler) getState(ctx context.Context) (res gregor1.State, err error) {
 	var s gregor.State
 
-	if g == nil || g.gregorCli == nil {
+	g.gregorCliMu.Lock()
+	gcli := g.gregorCli
+	g.gregorCliMu.Unlock()
+
+	if g == nil || gcli == nil {
 		return res, errors.New("gregor service not available (are you in standalone?)")
 	}
 
-	s, err = g.gregorCli.StateMachineState(ctx, nil, true)
+	s, err = gcli.StateMachineState(ctx, nil, true)
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
- previously, we observed in CI, that it's possible to shut a cache down twice on logout
- this cleaner story should prevent that, and also cleans up the code a little bit.
- just watch out for certain tests that want reset caches while preserving cache properties