### PR TITLE
Make PGP Gen engine errors bubble up, navigate away on error

### DIFF
--- a/shared/actions/profile/pgp.js
+++ b/shared/actions/profile/pgp.js
@@ -102,6 +102,14 @@ function* _generatePgpSaga(): Saga.SagaGenerator<any, any> {
       return
     }
 
+    if (incoming.finished && incoming.finished.error) {
+      throw incoming.finished.error
+    }
+
+    if (!incoming['keybase.1.pgpUi.keyGenerated']) {
+      throw new Error('KeyGeneration failed')
+    }
+
     yield Saga.call([
       incoming['keybase.1.pgpUi.keyGenerated'].response,
       incoming['keybase.1.pgpUi.keyGenerated'].response.result,
@@ -126,6 +134,8 @@ function* _generatePgpSaga(): Saga.SagaGenerator<any, any> {
   } catch (e) {
     generatePgpKeyChanMap.close()
     logger.info('error in generating pgp key', e)
+    yield Saga.put(navigateTo([peopleTab, 'profile']))
+    throw e
   }
 }
 


### PR DESCRIPTION
There was a bug in how pgp gen engine errors were handled. On error, it would still go to
```
yield Saga.call([
       incoming['keybase.1.pgpUi.keyGenerated'].response,
       incoming['keybase.1.pgpUi.keyGenerated'].response.result,
```
but `incoming['keybase.1.pgpUi.keyGenerated']` was undefined, throwing an error. But the catch block would only log the error, so user would still see the PGP generation "loading" screen. 

Some determined users would leave it on for hours, even though pgp generation has long failed.

This PR attempts to extract and throw the "real" error from engine, navigate away form the generation screen, and rethrow the error so it ends up as black bar.

cc @keybase/react-hackers 