### PR TITLE
modernize LKSec for MetaContext

### DIFF
--- a/go/engine/bug_3964_repairman_test.go
+++ b/go/engine/bug_3964_repairman_test.go
@@ -124,7 +124,7 @@ func corruptDevice2(dev1 libkb.TestContext, dev2 libkb.TestContext) (*libkb.Devi
 	if pps == nil {
 		return nil, errors.New("empty passphrase stream on m1, but expected one since we just signed up")
 	}
-	goodLksec := libkb.NewLKSec(pps, m2.CurrentUID(), m2.G())
+	goodLksec := libkb.NewLKSec(pps, m2.CurrentUID())
 
 	if err = goodLksec.LoadServerHalf(m2); err != nil {
 		return nil, err
@@ -138,7 +138,6 @@ func corruptDevice2(dev1 libkb.TestContext, dev2 libkb.TestContext) (*libkb.Devi
 	badLskec := libkb.NewLKSecWithFullSecret(
 		goodLksec.CorruptedFullSecretForBug3964Testing(dev1ServerHalf),
 		dev2.G.Env.GetUID(),
-		dev2.G,
 	)
 	var krf *libkb.SKBKeyringFile
 	krf, err = libkb.LoadSKBKeyringFromMetaContext(m2)

--- a/go/engine/fakeusers_test.go
+++ b/go/engine/fakeusers_test.go
@@ -336,6 +336,6 @@ func createFakeUserWithPGPSibkeyPushedPaper(tc libkb.TestContext) *FakeUser {
 // fakeLKS is used to create a lks that has the server half when
 // creating a fake user that doesn't have a device.
 func (s *SignupEngine) fakeLKS(m libkb.MetaContext) error {
-	s.lks = libkb.NewLKSec(s.ppStream, s.uid, m.G())
+	s.lks = libkb.NewLKSec(s.ppStream, s.uid)
 	return s.lks.GenerateServerHalf()
 }

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -570,7 +570,7 @@ func (e *Kex2Provisionee) pushLKSServerHalf(m libkb.MetaContext) (err error) {
 	// make new lks
 	ppstream := libkb.NewPassphraseStream(e.pps.PassphraseStream)
 	ppstream.SetGeneration(libkb.PassphraseGeneration(e.pps.Generation))
-	e.lks = libkb.NewLKSec(ppstream, e.uid, e.G())
+	e.lks = libkb.NewLKSec(ppstream, e.uid)
 	e.lks.GenerateServerHalf()
 
 	// make client half recovery

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -471,7 +471,7 @@ func (e *loginProvision) ensureLKSec(m libkb.MetaContext) error {
 		return err
 	}
 
-	e.lks = libkb.NewLKSec(pps, e.arg.User.GetUID(), m.G())
+	e.lks = libkb.NewLKSec(pps, e.arg.User.GetUID())
 	return nil
 }
 
@@ -1031,7 +1031,7 @@ func (e *loginProvision) fetchLKS(m libkb.MetaContext, encKey libkb.GenericKey) 
 	if err != nil {
 		return err
 	}
-	e.lks = libkb.NewLKSecWithClientHalf(clientLKS, gen, e.arg.User.GetUID(), m.G())
+	e.lks = libkb.NewLKSecWithClientHalf(clientLKS, gen, e.arg.User.GetUID())
 	return nil
 }
 

--- a/go/engine/login_with_paperkey.go
+++ b/go/engine/login_with_paperkey.go
@@ -77,7 +77,7 @@ func (e *LoginWithPaperKey) Run(m libkb.MetaContext) error {
 	if err != nil {
 		return err
 	}
-	lks := libkb.NewLKSecWithClientHalf(clientLKS, gen, me.GetUID(), m.G())
+	lks := libkb.NewLKSecWithClientHalf(clientLKS, gen, me.GetUID())
 	m.CDebugf("Got LKS client half")
 
 	// Get the LKS server half.

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -261,7 +261,7 @@ func (e *PaperKeyGen) push(m libkb.MetaContext) (err error) {
 		}
 	}
 
-	backupLks := libkb.NewLKSecWithClientHalf(clientHalf, ppgen, e.arg.Me.GetUID(), e.G())
+	backupLks := libkb.NewLKSecWithClientHalf(clientHalf, ppgen, e.arg.Me.GetUID())
 	backupLks.SetServerHalf(libkb.NewLKSecServerHalfZeros())
 
 	ctext, err := backupLks.EncryptClientHalfRecovery(e.encKey)

--- a/go/engine/paperprovision.go
+++ b/go/engine/paperprovision.go
@@ -185,7 +185,7 @@ func (e *PaperProvisionEngine) fetchLKS(m libkb.MetaContext, encKey libkb.Generi
 	if err != nil {
 		return err
 	}
-	e.lks = libkb.NewLKSecWithClientHalf(clientLKS, gen, e.User.GetUID(), e.G())
+	e.lks = libkb.NewLKSecWithClientHalf(clientLKS, gen, e.User.GetUID())
 	return nil
 }
 
@@ -241,7 +241,7 @@ func (e *PaperProvisionEngine) ensureLKSec(m libkb.MetaContext) error {
 		return err
 	}
 
-	e.lks = libkb.NewLKSec(pps, e.User.GetUID(), e.G())
+	e.lks = libkb.NewLKSec(pps, e.User.GetUID())
 	return nil
 }
 

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -204,7 +204,7 @@ func (s *SignupEngine) join(m libkb.MetaContext, username, email, inviteCode str
 
 func (s *SignupEngine) registerDevice(m libkb.MetaContext, deviceName string) error {
 	m.CDebugf("SignupEngine#registerDevice")
-	s.lks = libkb.NewLKSec(s.ppStream, s.uid, m.G())
+	s.lks = libkb.NewLKSec(s.ppStream, s.uid)
 	args := &DeviceWrapArgs{
 		Me:         s.me,
 		DeviceName: deviceName,

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -163,7 +163,7 @@ func TestLocalKeySecurity(t *testing.T) {
 	}
 
 	m := NewMetaContextForTest(tc)
-	lks := libkb.NewLKSec(s.ppStream, s.uid, tc.G)
+	lks := libkb.NewLKSec(s.ppStream, s.uid)
 	if err := lks.Load(m); err != nil {
 		t.Fatal(err)
 	}

--- a/go/libkb/bug_3964_repairman.go
+++ b/go/libkb/bug_3964_repairman.go
@@ -45,7 +45,7 @@ func (b *bug3964Repairman) loadLKSecServerDetails(m MetaContext, lksec *LKSec) (
 	if err != nil {
 		return nil, err
 	}
-	lksec.SetFullSecret()
+	lksec.SetFullSecret(m)
 	return ret, err
 }
 
@@ -188,7 +188,7 @@ func (b *bug3964Repairman) Run(m MetaContext) (err error) {
 	// This logline is asserted in testing in bug_3964_repairman_test
 	m.G().Log.CDebugf(m.Ctx(), "| Repairman wasn't short-circuited")
 
-	lksec, err = pps.ToLKSec(m.G(), lctx.GetUID())
+	lksec, err = pps.ToLKSec(lctx.GetUID())
 	if err != nil {
 		return err
 	}

--- a/go/libkb/lksec.go
+++ b/go/libkb/lksec.go
@@ -154,7 +154,6 @@ type LKSec struct {
 	ppGen      PassphraseGeneration
 	uid        keybase1.UID
 	deviceID   keybase1.DeviceID
-	Contextified
 }
 
 func xorBytes(x *[LKSecLen]byte, y *[LKSecLen]byte) *[LKSecLen]byte {
@@ -184,15 +183,14 @@ func (c LKSecClientHalf) ComputeMask(c2 LKSecClientHalf) LKSecMask {
 	return LKSecMask{m: xorBytes(c.c, c2.c)}
 }
 
-func NewLKSec(pps *PassphraseStream, uid keybase1.UID, gc *GlobalContext) *LKSec {
-	return NewLKSecWithDeviceID(pps, uid, keybase1.DeviceID(""), gc)
+func NewLKSec(pps *PassphraseStream, uid keybase1.UID) *LKSec {
+	return NewLKSecWithDeviceID(pps, uid, keybase1.DeviceID(""))
 }
 
-func NewLKSecWithDeviceID(pps *PassphraseStream, uid keybase1.UID, deviceID keybase1.DeviceID, gc *GlobalContext) *LKSec {
+func NewLKSecWithDeviceID(pps *PassphraseStream, uid keybase1.UID, deviceID keybase1.DeviceID) *LKSec {
 	res := &LKSec{
-		uid:          uid,
-		deviceID:     deviceID,
-		Contextified: NewContextified(gc),
+		uid:      uid,
+		deviceID: deviceID,
 	}
 
 	if pps != nil {
@@ -202,21 +200,19 @@ func NewLKSecWithDeviceID(pps *PassphraseStream, uid keybase1.UID, deviceID keyb
 	return res
 }
 
-func NewLKSecWithClientHalf(clientHalf LKSecClientHalf, ppgen PassphraseGeneration, uid keybase1.UID, gc *GlobalContext) *LKSec {
+func NewLKSecWithClientHalf(clientHalf LKSecClientHalf, ppgen PassphraseGeneration, uid keybase1.UID) *LKSec {
 	return &LKSec{
-		clientHalf:   clientHalf,
-		ppGen:        ppgen,
-		uid:          uid,
-		Contextified: NewContextified(gc),
+		clientHalf: clientHalf,
+		ppGen:      ppgen,
+		uid:        uid,
 	}
 }
 
-func NewLKSecWithFullSecret(secret LKSecFullSecret, uid keybase1.UID, gc *GlobalContext) *LKSec {
+func NewLKSecWithFullSecret(secret LKSecFullSecret, uid keybase1.UID) *LKSec {
 	return &LKSec{
-		secret:       secret,
-		ppGen:        PassphraseGeneration(-1),
-		uid:          uid,
-		Contextified: NewContextified(gc),
+		secret: secret,
+		ppGen:  PassphraseGeneration(-1),
+		uid:    uid,
 	}
 }
 
@@ -283,12 +279,12 @@ func (s *LKSec) Load(m MetaContext) (err error) {
 		return err
 	}
 
-	s.SetFullSecret()
+	s.SetFullSecret(m)
 	return nil
 }
 
-func (s *LKSec) SetFullSecret() {
-	s.G().Log.Debug("| Making XOR'ed secret key for Local Key Security (LKS)")
+func (s *LKSec) SetFullSecret(m MetaContext) {
+	m.CDebugf("| Making XOR'ed secret key for Local Key Security (LKS)")
 	s.secret = s.serverHalf.ComputeFullSecret(s.clientHalf)
 }
 
@@ -358,23 +354,23 @@ func (s *LKSec) attemptBug3964Recovery(m MetaContext, data []byte, nonce *[24]by
 		return nil, 0, LKSecServerHalf{}, err
 	}
 	devices := ss.AllDevices()
-	res, serverHalf, err := s.tryAllDevicesForBug3964Recovery(devices, data, nonce)
+	res, serverHalf, err := s.tryAllDevicesForBug3964Recovery(m, devices, data, nonce)
 	return res, s.ppGen, serverHalf, err
 }
 
-func (s *LKSec) tryAllDevicesForBug3964Recovery(devices DeviceKeyMap, data []byte, nonce *[24]byte) (res []byte, erroneousMask LKSecServerHalf, err error) {
+func (s *LKSec) tryAllDevicesForBug3964Recovery(m MetaContext, devices DeviceKeyMap, data []byte, nonce *[24]byte) (res []byte, erroneousMask LKSecServerHalf, err error) {
 
 	// This logline is asserted in testing in bug_3964_repairman_test
-	defer s.G().Trace("LKSec#tryAllDevicesForBug3964Recovery()", func() error { return err })()
+	defer m.CTrace("LKSec#tryAllDevicesForBug3964Recovery()", func() error { return err })()
 
 	for devid, dev := range devices {
 
 		// This logline is asserted in testing in bug_3964_repairman_test
-		s.G().Log.Debug("| Trying Bug 3964 Recovery w/ device %q {id: %s, lks: %s...}", dev.Description, devid, dev.LksServerHalf[0:8])
+		m.CDebugf("| Trying Bug 3964 Recovery w/ device %q {id: %s, lks: %s...}", dev.Description, devid, dev.LksServerHalf[0:8])
 
 		serverHalf, err := dev.ToLKSec()
 		if err != nil {
-			s.G().Log.Debug("| Failed with error: %s\n", err)
+			m.CDebugf("| Failed with error: %s\n", err)
 			continue
 		}
 		fs := s.secret.bug3964Remask(serverHalf)
@@ -382,7 +378,7 @@ func (s *LKSec) tryAllDevicesForBug3964Recovery(devices DeviceKeyMap, data []byt
 
 		if ok {
 			// This logline is asserted in testing in bug_3964_repairman_test
-			s.G().Log.Debug("| Success")
+			m.CDebugf("| Success")
 			return res, serverHalf, nil
 		}
 	}
@@ -416,15 +412,15 @@ func (s *LKSec) Decrypt(m MetaContext, src []byte) (res []byte, gen PassphraseGe
 	return res, s.ppGen, LKSecServerHalf{}, nil
 }
 
-func (s *LKSec) decryptForBug3964Repair(src []byte, dkm DeviceKeyMap) (res []byte, erroneousMask LKSecServerHalf, err error) {
-	defer s.G().Trace("LKSec#decryptForBug3964Repair()", func() error { return err })()
+func (s *LKSec) decryptForBug3964Repair(m MetaContext, src []byte, dkm DeviceKeyMap) (res []byte, erroneousMask LKSecServerHalf, err error) {
+	defer m.CTrace("LKSec#decryptForBug3964Repair()", func() error { return err })()
 	data, nonce := splitCiphertext(src)
 	res, ok := secretbox.Open(nil, data, nonce, s.secret.f)
 	if ok {
-		s.G().Log.Debug("| Succeeded with intended mask")
+		m.CDebugf("| Succeeded with intended mask")
 		return res, LKSecServerHalf{}, nil
 	}
-	return s.tryAllDevicesForBug3964Recovery(dkm, data, nonce)
+	return s.tryAllDevicesForBug3964Recovery(m, dkm, data, nonce)
 }
 
 func (s *LKSec) ComputeClientHalf() (ret LKSecClientHalf, err error) {
@@ -471,7 +467,7 @@ func NewLKSecForEncrypt(m MetaContext, ui SecretUI, uid keybase1.UID) (ret *LKSe
 	if err != nil {
 		return nil, err
 	}
-	ret = NewLKSec(pps, uid, m.G())
+	ret = NewLKSec(pps, uid)
 	return ret, nil
 }
 
@@ -492,7 +488,7 @@ func (s *LKSec) ToSKB(m MetaContext, key GenericKey) (ret *SKB, err error) {
 	if s == nil {
 		return nil, errors.New("nil lks")
 	}
-	ret = NewSKBWithGlobalContext(s.G())
+	ret = NewSKBWithGlobalContext(m.G())
 
 	var publicKey RawPublicKey
 	var privateKey RawPrivateKey

--- a/go/libkb/passphrase_login.go
+++ b/go/libkb/passphrase_login.go
@@ -217,7 +217,7 @@ func PassphraseLoginPrompt(m MetaContext, usernameOrEmail string, maxAttempts in
 
 func StoreSecretAfterLogin(m MetaContext, n NormalizedUsername, uid keybase1.UID, deviceID keybase1.DeviceID) (err error) {
 	defer m.CTrace("StoreSecretAfterLogin", func() error { return err })()
-	lksec := NewLKSecWithDeviceID(m.LoginContext().PassphraseStreamCache().PassphraseStream(), uid, deviceID, m.G())
+	lksec := NewLKSecWithDeviceID(m.LoginContext().PassphraseStreamCache().PassphraseStream(), uid, deviceID)
 	return StoreSecretAfterLoginWithLKS(m, n, lksec)
 }
 
@@ -281,7 +281,7 @@ func getStoredPassphraseStream(m MetaContext) (*PassphraseStream, error) {
 	if err != nil {
 		return nil, err
 	}
-	lks := NewLKSecWithFullSecret(fullSecret, m.CurrentUID(), m.G())
+	lks := NewLKSecWithFullSecret(fullSecret, m.CurrentUID())
 	if err = lks.LoadServerHalf(m); err != nil {
 		return nil, err
 	}

--- a/go/libkb/passphrase_stream.go
+++ b/go/libkb/passphrase_stream.go
@@ -104,16 +104,15 @@ func (ps PassphraseStream) LksClientHalf() LKSecClientHalf {
 	return ret
 }
 
-func (ps PassphraseStream) ToLKSec(g *GlobalContext, uid keybase1.UID) (*LKSec, error) {
+func (ps PassphraseStream) ToLKSec(uid keybase1.UID) (*LKSec, error) {
 	ch, err := NewLKSecClientHalfFromBytes(ps.stream[lksIndex:])
 	if err != nil {
 		return nil, err
 	}
 	return &LKSec{
-		Contextified: NewContextified(g),
-		clientHalf:   ch,
-		ppGen:        ps.Generation(),
-		uid:          uid,
+		clientHalf: ch,
+		ppGen:      ps.Generation(),
+		uid:        uid,
 	}, nil
 }
 

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -128,7 +128,7 @@ func (s *SKB) newLKSec(pps *PassphraseStream) *LKSec {
 	if s.uid.IsNil() {
 		panic("no uid set in skb")
 	}
-	return NewLKSec(pps, s.uid, s.G())
+	return NewLKSec(pps, s.uid)
 }
 
 func (s *SKB) ToPacket() (ret *KeybasePacket, err error) {
@@ -352,7 +352,7 @@ func (s *SKB) lksUnlockWithSecretRetriever(m MetaContext, secretRetriever Secret
 	if s.uid.IsNil() {
 		panic("no uid set in skb")
 	}
-	lks := NewLKSecWithFullSecret(secret, s.uid, m.G())
+	lks := NewLKSecWithFullSecret(secret, s.uid)
 	unlocked, _, _, err = lks.Decrypt(m, s.Priv.Data)
 
 	return

--- a/go/libkb/skb_keyring.go
+++ b/go/libkb/skb_keyring.go
@@ -364,7 +364,7 @@ func (k *SKBKeyringFile) Bug3964Repair(m MetaContext, lks *LKSec, dkm DeviceKeyM
 
 		var decryption, reencryption []byte
 		var badMask LKSecServerHalf
-		decryption, badMask, err = lks.decryptForBug3964Repair(b.Priv.Data, dkm)
+		decryption, badMask, err = lks.decryptForBug3964Repair(m, b.Priv.Data, dkm)
 		if err != nil {
 			m.CDebugf("| Decryption failed at block=%d; keeping as is (%s)", i, err)
 			newBlocks = append(newBlocks, b)

--- a/go/libkb/skb_test.go
+++ b/go/libkb/skb_test.go
@@ -74,7 +74,7 @@ func makeTestLKSec(t *testing.T, gc *GlobalContext) *LKSec {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lks := NewLKSec(pps, keybase1.UID("00000000000000000000000000000019"), gc)
+	lks := NewLKSec(pps, keybase1.UID("00000000000000000000000000000019"))
 	if err := lks.GenerateServerHalf(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- no need to contextify this object, use the m passed through