### PR TITLE
Fix '(still trying)' splash string

### DIFF
--- a/shared/login/forms/splash/container.js
+++ b/shared/login/forms/splash/container.js
@@ -5,7 +5,7 @@ import Splash from '.'
 import {connect, type TypedState, type Dispatch, isMobile} from '../../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({
-  _stillTrying: state.config.bootstrapTriesRemaining === Constants.maxBootstrapTries,
+  _stillTrying: state.config.bootstrapTriesRemaining !== Constants.maxBootstrapTries,
   failed: state.config.bootStatus === 'bootStatusFailure',
 })
 


### PR DESCRIPTION
@keybase/react-hackers 

Looks like the sign got switched as part of the refactor in #12028.