### PR TITLE
add UpdateCategory RPC for dismissing an entire category and replacing with a new item CORE-8055

### DIFF
--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -425,6 +425,7 @@ func (c *Client) applyOutboxMessages(ctx context.Context, state gregor.State, t 
 	if len(msgs) == 0 {
 		return state
 	}
+	c.Log.CDebugf(ctx, "applyOutboxMessages: applying %d outbox messages", len(msgs))
 	sm := c.createSm()
 	sm.InitState(state)
 	for _, m := range msgs {

--- a/go/gregor/interface.go
+++ b/go/gregor/interface.go
@@ -101,6 +101,7 @@ type Reminder interface {
 type MsgRange interface {
 	EndTime() TimeOrOffset
 	Category() Category
+	SkipMsgIDs() []MsgID
 }
 
 type Dismissal interface {

--- a/go/gregor/interface.go
+++ b/go/gregor/interface.go
@@ -233,7 +233,8 @@ type ObjFactory interface {
 	MakeItem(u UID, msgid MsgID, deviceid DeviceID, ctime time.Time, c Category, dtime *time.Time, body Body) (Item, error)
 	MakeReminder(i Item, seqno int, t time.Time) (Reminder, error)
 	MakeReminderID(u UID, msgid MsgID, seqno int) (ReminderID, error)
-	MakeDismissalByRange(uid UID, msgid MsgID, devid DeviceID, ctime time.Time, c Category, d time.Time) (InBandMessage, error)
+	MakeDismissalByRange(uid UID, msgid MsgID, devid DeviceID, ctime time.Time, c Category, d time.Time,
+		skipMsgIDs []MsgID) (InBandMessage, error)
 	MakeDismissalByIDs(uid UID, msgid MsgID, devid DeviceID, ctime time.Time, d []MsgID) (InBandMessage, error)
 	MakeStateSyncMessage(uid UID, msgid MsgID, devid DeviceID, ctime time.Time) (InBandMessage, error)
 	MakeState(i []Item) (State, error)

--- a/go/gregor/storage/mem_sm.go
+++ b/go/gregor/storage/mem_sm.go
@@ -191,10 +191,20 @@ func toTime(now time.Time, t gregor.TimeOrOffset) time.Time {
 }
 
 func (u *user) dismissRanges(now time.Time, rs []gregor.MsgRange) {
+	isSkipped := func(i *item, r gregor.MsgRange) bool {
+		msgID := i.item.Metadata().MsgID()
+		for _, s := range r.SkipMsgIDs() {
+			if msgID.String() == s.String() {
+				return true
+			}
+		}
+		return false
+	}
 	for _, i := range u.items {
 		for _, r := range rs {
 			if r.Category().String() == i.item.Category().String() &&
-				isBeforeOrSame(i.ctime, toTime(now, r.EndTime())) {
+				isBeforeOrSame(i.ctime, toTime(now, r.EndTime())) &&
+				!isSkipped(i, r) {
 				i.dtime = &now
 				i.dismissedImmediate = true
 				u.removeLocalDismissal(i.item.Metadata().MsgID())

--- a/go/protocol/gregor1/common.go
+++ b/go/protocol/gregor1/common.go
@@ -118,14 +118,26 @@ func (o StateSyncMessage) DeepCopy() StateSyncMessage {
 }
 
 type MsgRange struct {
-	EndTime_  TimeOrOffset `codec:"endTime" json:"endTime"`
-	Category_ Category     `codec:"category" json:"category"`
+	EndTime_    TimeOrOffset `codec:"endTime" json:"endTime"`
+	Category_   Category     `codec:"category" json:"category"`
+	SkipMsgIDs_ []MsgID      `codec:"skipMsgIDs" json:"skipMsgIDs"`
 }
 
 func (o MsgRange) DeepCopy() MsgRange {
 	return MsgRange{
 		EndTime_:  o.EndTime_.DeepCopy(),
 		Category_: o.Category_.DeepCopy(),
+		SkipMsgIDs_: (func(x []MsgID) []MsgID {
+			if x == nil {
+				return nil
+			}
+			var ret []MsgID
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.SkipMsgIDs_),
 	}
 }
 

--- a/go/protocol/gregor1/extras.go
+++ b/go/protocol/gregor1/extras.go
@@ -27,6 +27,7 @@ func (d DeviceID) Eq(other DeviceID) bool {
 }
 func (m MsgID) Bytes() []byte                 { return []byte(m) }
 func (m MsgID) String() string                { return hex.EncodeToString(m) }
+func (m MsgID) Eq(n MsgID) bool               { return m.String() == n.String() }
 func (s System) String() string               { return string(s) }
 func (c Category) String() string             { return string(c) }
 func (b Body) Bytes() []byte                  { return []byte(b) }

--- a/go/protocol/gregor1/extras.go
+++ b/go/protocol/gregor1/extras.go
@@ -71,6 +71,12 @@ func (m MsgRange) EndTime() gregor.TimeOrOffset {
 func (m MsgRange) Category() gregor.Category {
 	return m.Category_
 }
+func (m MsgRange) SkipMsgIDs() (res []gregor.MsgID) {
+	for _, s := range m.SkipMsgIDs_ {
+		res = append(res, s)
+	}
+	return res
+}
 
 func (d Dismissal) RangesToDismiss() []gregor.MsgRange {
 	var ret []gregor.MsgRange

--- a/go/protocol/gregor1/factory.go
+++ b/go/protocol/gregor1/factory.go
@@ -114,7 +114,7 @@ func (o ObjFactory) MakeReminder(i gregor.Item, seqno int, t time.Time) (gregor.
 	}, nil
 }
 
-func (o ObjFactory) MakeDismissalByRange(uid gregor.UID, msgid gregor.MsgID, devid gregor.DeviceID, ctime time.Time, c gregor.Category, d time.Time) (gregor.InBandMessage, error) {
+func (o ObjFactory) MakeDismissalByRange(uid gregor.UID, msgid gregor.MsgID, devid gregor.DeviceID, ctime time.Time, c gregor.Category, d time.Time, skipMsgIDs []gregor.MsgID) (gregor.InBandMessage, error) {
 	md, err := o.makeMetadata(uid, msgid, devid, ctime, gregor.InBandMsgTypeUpdate)
 	if err != nil {
 		return nil, err

--- a/go/protocol/gregor1/factory.go
+++ b/go/protocol/gregor1/factory.go
@@ -119,13 +119,18 @@ func (o ObjFactory) MakeDismissalByRange(uid gregor.UID, msgid gregor.MsgID, dev
 	if err != nil {
 		return nil, err
 	}
+	var skips []MsgID
+	for _, s := range skipMsgIDs {
+		skips = append(skips, MsgID(s.Bytes()))
+	}
 	return InBandMessage{
 		StateUpdate_: &StateUpdateMessage{
 			Md_: md,
 			Dismissal_: &Dismissal{
 				Ranges_: []MsgRange{{
-					EndTime_:  timeToTimeOrOffset(&d),
-					Category_: Category(c.String()),
+					EndTime_:    timeToTimeOrOffset(&d),
+					Category_:   Category(c.String()),
+					SkipMsgIDs_: skips,
 				}},
 			},
 		},

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1762,6 +1762,7 @@ func (g *gregorHandler) UpdateCategory(ctx context.Context, cat string, body []b
 	if err != nil {
 		return nil, err
 	}
+	msgID := msg.Ibm_.StateUpdate_.Md_.MsgID_
 	msg.Ibm_.StateUpdate_.Creation_ = &gregor1.Item{
 		Category_: gregor1.Category(cat),
 		Body_:     gregor1.Body(body),
@@ -1771,7 +1772,7 @@ func (g *gregorHandler) UpdateCategory(ctx context.Context, cat string, body []b
 		Ranges_: []gregor1.MsgRange{
 			gregor1.MsgRange{
 				Category_:   gregor1.Category(cat),
-				SkipMsgIDs_: []gregor1.MsgID{msg.Ibm_.Metadata().MsgID().(gregor1.MsgID)},
+				SkipMsgIDs_: []gregor1.MsgID{msgID},
 			}},
 	}
 
@@ -1779,7 +1780,7 @@ func (g *gregorHandler) UpdateCategory(ctx context.Context, cat string, body []b
 	if err != nil {
 		return nil, err
 	}
-	return msg.Ibm_.StateUpdate_.Md_.MsgID_, gcli.ConsumeMessage(ctx, *msg)
+	return msgID, gcli.ConsumeMessage(ctx, *msg)
 }
 
 func (g *gregorHandler) InjectOutOfBandMessage(ctx context.Context, system string, body []byte) error {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1757,6 +1757,43 @@ func (g *gregorHandler) UpdateItem(ctx context.Context, msgID gregor1.MsgID, cat
 	return msg.Ibm_.StateUpdate_.Md_.MsgID_, gcli.ConsumeMessage(ctx, *msg)
 }
 
+func (g *gregorHandler) UpdateCategory(ctx context.Context, cat string, body []byte,
+	dtime gregor1.TimeOrOffset) (res gregor1.MsgID, err error) {
+	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.UpdateCategory(%s)", cat),
+		func() error { return err },
+	)()
+	defer g.pushState(keybase1.PushReason_NEW_DATA)
+
+	msg, err := g.templateMessage()
+	if err != nil {
+		return nil, err
+	}
+	msg.Ibm_.StateUpdate_.Creation_ = &gregor1.Item{
+		Category_: gregor1.Category(cat),
+		Body_:     gregor1.Body(body),
+		Dtime_:    dtime,
+	}
+	msg.Ibm_.StateUpdate_.Dismissal_ = &gregor1.Dismissal{
+		Ranges_: []gregor1.MsgRange{
+			gregor1.MsgRange{
+				Category_:   gregor1.Category(cat),
+				SkipMsgIDs_: []gregor1.MsgID{msg.Ibm_.Metadata().MsgID().(gregor1.MsgID)},
+				// A small non-zero offset that effectively means "now",
+				// because an actually-zero offset would be interpreted as "not
+				// an offset at all" by the SQL query builder.
+				EndTime_: gregor1.TimeOrOffset{
+					Offset_: gregor1.DurationMsec(1),
+				},
+			}},
+	}
+
+	gcli, err := g.getGregorCli()
+	if err != nil {
+		return nil, err
+	}
+	return msg.Ibm_.StateUpdate_.Md_.MsgID_, gcli.ConsumeMessage(ctx, *msg)
+}
+
 func (g *gregorHandler) InjectOutOfBandMessage(ctx context.Context, system string, body []byte) error {
 	var err error
 	defer g.G().CTrace(ctx, fmt.Sprintf("gregorHandler.InjectOutOfBandMessage(%s)", system),
@@ -1846,6 +1883,11 @@ func (g *gregorRPCHandler) InjectItem(ctx context.Context, arg keybase1.InjectIt
 func (g *gregorRPCHandler) UpdateItem(ctx context.Context, arg keybase1.UpdateItemArg) (res gregor1.MsgID, err error) {
 	defer g.G().CTraceTimed(ctx, "gregorRPCHandler#UpdateItem", func() error { return err })()
 	return g.gh.UpdateItem(ctx, arg.MsgID, arg.Cat, []byte(arg.Body), arg.Dtime)
+}
+
+func (g *gregorRPCHandler) UpdateCategory(ctx context.Context, arg keybase1.UpdateCategoryArg) (res gregor1.MsgID, err error) {
+	defer g.G().CTraceTimed(ctx, "gregorRPCHandler#UpdateCategory", func() error { return err })()
+	return g.gh.UpdateCategory(ctx, arg.Category, []byte(arg.Body), arg.Dtime)
 }
 
 func (g *gregorRPCHandler) DismissCategory(ctx context.Context, category gregor1.Category) (err error) {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1691,12 +1691,6 @@ func (g *gregorHandler) DismissCategory(ctx context.Context, category gregor1.Ca
 		Ranges_: []gregor1.MsgRange{
 			gregor1.MsgRange{
 				Category_: category,
-				// A small non-zero offset that effectively means "now",
-				// because an actually-zero offset would be interpreted as "not
-				// an offset at all" by the SQL query builder.
-				EndTime_: gregor1.TimeOrOffset{
-					Offset_: gregor1.DurationMsec(1),
-				},
 			}},
 	}
 	gcli, err := g.getGregorCli()
@@ -1778,12 +1772,6 @@ func (g *gregorHandler) UpdateCategory(ctx context.Context, cat string, body []b
 			gregor1.MsgRange{
 				Category_:   gregor1.Category(cat),
 				SkipMsgIDs_: []gregor1.MsgID{msg.Ibm_.Metadata().MsgID().(gregor1.MsgID)},
-				// A small non-zero offset that effectively means "now",
-				// because an actually-zero offset would be interpreted as "not
-				// an offset at all" by the SQL query builder.
-				EndTime_: gregor1.TimeOrOffset{
-					Offset_: gregor1.DurationMsec(1),
-				},
 			}},
 	}
 

--- a/protocol/avdl/gregor1/common.avdl
+++ b/protocol/avdl/gregor1/common.avdl
@@ -37,6 +37,7 @@ protocol common {
   record MsgRange {
     TimeOrOffset endTime;
     Category category;
+    array<MsgID> skipMsgIDs;
   }
 
   record Dismissal {

--- a/protocol/avdl/keybase1/gregor.avdl
+++ b/protocol/avdl/keybase1/gregor.avdl
@@ -7,4 +7,5 @@ protocol gregor {
   void dismissCategory(gregor1.Category category);
   void dismissItem(gregor1.MsgID id);
   gregor1.MsgID updateItem(gregor1.MsgID msgID, string cat, string body, gregor1.TimeOrOffset dtime);
+  gregor1.MsgID updateCategory(string category, string body, gregor1.TimeOrOffset dtime);
 }

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -794,6 +794,10 @@ export const gregorUIPushReason = {
   newData: 2,
 }
 
+export const gregorUpdateCategoryRpcChannelMap = (configKeys: Array<string>, request: GregorUpdateCategoryRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.updateCategory', request)
+
+export const gregorUpdateCategoryRpcPromise = (request: GregorUpdateCategoryRpcParam): Promise<GregorUpdateCategoryResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.gregor.updateCategory', request, (error: RPCError, result: GregorUpdateCategoryResult) => (error ? reject(error) : resolve(result))))
+
 export const gregorUpdateItemRpcChannelMap = (configKeys: Array<string>, request: GregorUpdateItemRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.updateItem', request)
 
 export const gregorUpdateItemRpcPromise = (request: GregorUpdateItemRpcParam): Promise<GregorUpdateItemResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.gregor.updateItem', request, (error: RPCError, result: GregorUpdateItemResult) => (error ? reject(error) : resolve(result))))
@@ -2528,6 +2532,8 @@ export type GregorUIPushOutOfBandMessagesRpcParam = $ReadOnly<{oobm?: ?Array<Gre
 
 export type GregorUIPushStateRpcParam = $ReadOnly<{state: Gregor1.State, reason: PushReason, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type GregorUpdateCategoryRpcParam = $ReadOnly<{category: String, body: String, dtime: Gregor1.TimeOrOffset, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type GregorUpdateItemRpcParam = $ReadOnly<{msgID: Gregor1.MsgID, cat: String, body: String, dtime: Gregor1.TimeOrOffset, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type HasServerKeysRes = $ReadOnly<{hasServerKeys: Boolean}>
@@ -4244,6 +4250,7 @@ type GpgUiSignResult = String
 type GpgUiWantToAddGPGKeyResult = Boolean
 type GregorGetStateResult = Gregor1.State
 type GregorInjectItemResult = Gregor1.MsgID
+type GregorUpdateCategoryResult = Gregor1.MsgID
 type GregorUpdateItemResult = Gregor1.MsgID
 type HomeHomeGetScreenResult = HomeScreen
 type IdentifyIdentify2Result = Identify2Res

--- a/protocol/js/rpc-gregor-gen.js
+++ b/protocol/js/rpc-gregor-gen.js
@@ -126,7 +126,7 @@ export type Metadata = $ReadOnly<{uid: UID, msgID: MsgID, ctime: Time, deviceID:
 
 export type MsgID = Bytes
 
-export type MsgRange = $ReadOnly<{endTime: TimeOrOffset, category: Category}>
+export type MsgRange = $ReadOnly<{endTime: TimeOrOffset, category: Category, skipMsgIDs?: ?Array<MsgID>}>
 
 export type OutOfBandMessage = $ReadOnly<{uid: UID, system: System, body: Body}>
 

--- a/protocol/json/gregor1/common.json
+++ b/protocol/json/gregor1/common.json
@@ -120,6 +120,13 @@
         {
           "type": "Category",
           "name": "category"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "MsgID"
+          },
+          "name": "skipMsgIDs"
         }
       ]
     },

--- a/protocol/json/keybase1/gregor.json
+++ b/protocol/json/keybase1/gregor.json
@@ -68,6 +68,23 @@
         }
       ],
       "response": "gregor1.MsgID"
+    },
+    "updateCategory": {
+      "request": [
+        {
+          "name": "category",
+          "type": "string"
+        },
+        {
+          "name": "body",
+          "type": "string"
+        },
+        {
+          "name": "dtime",
+          "type": "gregor1.TimeOrOffset"
+        }
+      ],
+      "response": "gregor1.MsgID"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -794,6 +794,10 @@ export const gregorUIPushReason = {
   newData: 2,
 }
 
+export const gregorUpdateCategoryRpcChannelMap = (configKeys: Array<string>, request: GregorUpdateCategoryRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.updateCategory', request)
+
+export const gregorUpdateCategoryRpcPromise = (request: GregorUpdateCategoryRpcParam): Promise<GregorUpdateCategoryResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.gregor.updateCategory', request, (error: RPCError, result: GregorUpdateCategoryResult) => (error ? reject(error) : resolve(result))))
+
 export const gregorUpdateItemRpcChannelMap = (configKeys: Array<string>, request: GregorUpdateItemRpcParam): EngineChannel => engine()._channelMapRpcHelper(configKeys, 'keybase.1.gregor.updateItem', request)
 
 export const gregorUpdateItemRpcPromise = (request: GregorUpdateItemRpcParam): Promise<GregorUpdateItemResult> => new Promise((resolve, reject) => engine()._rpcOutgoing('keybase.1.gregor.updateItem', request, (error: RPCError, result: GregorUpdateItemResult) => (error ? reject(error) : resolve(result))))
@@ -2528,6 +2532,8 @@ export type GregorUIPushOutOfBandMessagesRpcParam = $ReadOnly<{oobm?: ?Array<Gre
 
 export type GregorUIPushStateRpcParam = $ReadOnly<{state: Gregor1.State, reason: PushReason, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
+export type GregorUpdateCategoryRpcParam = $ReadOnly<{category: String, body: String, dtime: Gregor1.TimeOrOffset, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
+
 export type GregorUpdateItemRpcParam = $ReadOnly<{msgID: Gregor1.MsgID, cat: String, body: String, dtime: Gregor1.TimeOrOffset, incomingCallMap?: IncomingCallMapType, waitingHandler?: WaitingHandlerType}>
 
 export type HasServerKeysRes = $ReadOnly<{hasServerKeys: Boolean}>
@@ -4244,6 +4250,7 @@ type GpgUiSignResult = String
 type GpgUiWantToAddGPGKeyResult = Boolean
 type GregorGetStateResult = Gregor1.State
 type GregorInjectItemResult = Gregor1.MsgID
+type GregorUpdateCategoryResult = Gregor1.MsgID
 type GregorUpdateItemResult = Gregor1.MsgID
 type HomeHomeGetScreenResult = HomeScreen
 type IdentifyIdentify2Result = Identify2Res

--- a/shared/constants/types/rpc-gregor-gen.js
+++ b/shared/constants/types/rpc-gregor-gen.js
@@ -126,7 +126,7 @@ export type Metadata = $ReadOnly<{uid: UID, msgID: MsgID, ctime: Time, deviceID:
 
 export type MsgID = Bytes
 
-export type MsgRange = $ReadOnly<{endTime: TimeOrOffset, category: Category}>
+export type MsgRange = $ReadOnly<{endTime: TimeOrOffset, category: Category, skipMsgIDs?: ?Array<MsgID>}>
 
 export type OutOfBandMessage = $ReadOnly<{uid: UID, system: System, body: Body}>
 


### PR DESCRIPTION
Patch does the following:

1.) Adds `UpdateCategory` service RPC that dismisses the category and creates the new item.
2.) Get rid of small `EndTime_` on message range dismiss, since the server now handles them better. 

cc @buoyad 