### PR TITLE
implement backwards compatible pairwise MACs for exploding messages

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -725,6 +725,11 @@ func (f failingTlf) EphemeralDecryptionKey(ctx context.Context, tlfName string, 
 	panic("unimplemented")
 }
 
+func (f failingTlf) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (bool, []keybase1.KID, error) {
+	panic("unimplemented")
+}
+
 type failingUpak struct {
 	t *testing.T
 }
@@ -764,6 +769,10 @@ func (f failingUpak) Invalidate(ctx context.Context, uid keybase1.UID) {
 func (f failingUpak) LoadDeviceKey(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (upk *keybase1.UserPlusAllKeys, deviceKey *keybase1.PublicKey, revoked *keybase1.RevokedKey, err error) {
 	require.Fail(f.t, "LoadDeviceKey call")
 	return nil, nil, nil, nil
+}
+func (f failingUpak) LoadUPAKWithDeviceID(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (*keybase1.UserPlusKeysV2AllIncarnations, error) {
+	require.Fail(f.t, "LoadUPAKWithDeviceID call")
+	return nil, nil
 }
 func (f failingUpak) LookupUsername(ctx context.Context, uid keybase1.UID) (libkb.NormalizedUsername, error) {
 	require.Fail(f.t, "LookupUsername call")

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -136,6 +136,30 @@ func (e PublicTeamEphemeralKeyError) Error() string {
 
 //=============================================================================
 
+type NotAuthenticatedForThisDeviceError struct{}
+
+func NewNotAuthenticatedForThisDeviceError() NotAuthenticatedForThisDeviceError {
+	return NotAuthenticatedForThisDeviceError{}
+}
+
+func (e NotAuthenticatedForThisDeviceError) Error() string {
+	return "this message is not authenticated for this device"
+}
+
+//=============================================================================
+
+type InvalidMACError struct{}
+
+func NewInvalidMACError() InvalidMACError {
+	return InvalidMACError{}
+}
+
+func (e InvalidMACError) Error() string {
+	return "invalid MAC"
+}
+
+//=============================================================================
+
 type ConsistencyErrorCode int
 
 const (

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -24,6 +24,8 @@ type KeyFinder interface {
 		membersType chat1.ConversationMembersType, public bool) (keybase1.TeamEk, error)
 	EphemeralKeyForDecryption(ctx context.Context, tlfName string, teamID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool, generation keybase1.EkGeneration) (keybase1.TeamEk, error)
+	ShouldPairwiseMAC(ctx context.Context, tlfName string, teamID chat1.TLFID,
+		membersType chat1.ConversationMembersType, public bool) (bool, []keybase1.KID, error)
 	Reset()
 	SetNameInfoSourceOverride(types.NameInfoSource)
 }
@@ -193,6 +195,11 @@ func (k *KeyFinderImpl) EphemeralKeyForEncryption(ctx context.Context, tlfName s
 func (k *KeyFinderImpl) EphemeralKeyForDecryption(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool, generation keybase1.EkGeneration) (keybase1.TeamEk, error) {
 	return k.createNameInfoSource(ctx, membersType).EphemeralDecryptionKey(ctx, tlfName, tlfID, membersType, public, generation)
+}
+
+func (k *KeyFinderImpl) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (bool, []keybase1.KID, error) {
+	return k.createNameInfoSource(ctx, membersType).ShouldPairwiseMAC(ctx, tlfName, tlfID, membersType, public)
 }
 
 func (k *KeyFinderImpl) SetNameInfoSourceOverride(ni types.NameInfoSource) {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -263,6 +263,58 @@ func (t *TeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfNam
 	return t.G().GetEKLib().GetTeamEK(ctx, teamID, generation)
 }
 
+func (t *TeamsNameInfoSource) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (bool, []keybase1.KID, error) {
+	return shouldPairwiseMAC(ctx, t.G(), t.loader, tlfName, tlfID, membersType, public)
+}
+
+func shouldPairwiseMAC(ctx context.Context, g *globals.Context, loader *TeamLoader, tlfName string,
+	tlfID chat1.TLFID, membersType chat1.ConversationMembersType, public bool) (should bool, kids []keybase1.KID, err error) {
+	defer g.CTraceTimed(ctx, fmt.Sprintf("shouldPairwiseMAC teamID %s", tlfID.String()), func() error { return err })()
+
+	team, err := loader.loadTeam(ctx, tlfID, tlfName, membersType, public, nil)
+	if err != nil {
+		return false, nil, err
+	}
+	members, err := team.Members()
+	if err != nil {
+		return false, nil, err
+	}
+	memberUVs := members.AllUserVersions()
+
+	// For performance reasons, we don't try to pairwise MAC any messages in
+	// large teams.
+	if len(memberUVs) > libkb.MaxTeamMembersForPairwiseMAC {
+		return false, nil, nil
+	}
+
+	unrevokedKIDs := []keybase1.KID{}
+	for _, member := range memberUVs {
+		upak, _, err := g.GetUPAKLoader().LoadV2(libkb.NewLoadUserByUIDArg(ctx, g.GlobalContext, member.Uid))
+		if err != nil {
+			return false, nil, err
+		}
+		for _, key := range upak.Current.DeviceKeys {
+			// Include only unrevoked encryption keys.
+			if !key.Base.IsSibkey && key.Base.Revocation == nil {
+				unrevokedKIDs = append(unrevokedKIDs, key.Base.Kid)
+			}
+		}
+	}
+	if len(unrevokedKIDs) > 10*libkb.MaxTeamMembersForPairwiseMAC {
+		// If someone on the team has a ton of devices, it could break our "100
+		// members" heuristic and lead to bad performance. We don't want to
+		// silently fall back to the non-repudiable mode, because that would
+		// create an opening for downgrade attacks, and we'd need to document
+		// this exception everywhere we talk about repudiability. But if this
+		// turns out to be a performance issue in practice, we might want to
+		// add some workaround. (For example, we could choose to omit
+		// recipients with an unreasonable number of devices.)
+		g.Log.CWarningf(ctx, "unreasonable number of devices (%d) in recipients list", len(unrevokedKIDs))
+	}
+	return true, unrevokedKIDs, nil
+}
+
 type ImplicitTeamsNameInfoSource struct {
 	globals.Contextified
 	utils.DebugLabeler
@@ -436,6 +488,11 @@ func (t *ImplicitTeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context
 		return teamEK, err
 	}
 	return t.G().GetEKLib().GetTeamEK(ctx, team.ID, generation)
+}
+
+func (t *ImplicitTeamsNameInfoSource) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (bool, []keybase1.KID, error) {
+	return shouldPairwiseMAC(ctx, t.G(), t.loader, tlfName, tlfID, membersType, public)
 }
 
 func (t *ImplicitTeamsNameInfoSource) lookupInternalName(ctx context.Context, name string, public bool) (res *types.NameInfo, err error) {

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -111,6 +111,11 @@ func (t *KBFSNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName
 	return teamEK, fmt.Errorf("KBFSNameInfoSource doesn't support ephemeral keys")
 }
 
+func (t *KBFSNameInfoSource) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (bool, []keybase1.KID, error) {
+	return false, nil, nil
+}
+
 func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res keybase1.GetTLFCryptKeysRes, ferr error) {
 	identBehavior, _, ok := IdentifyMode(ctx)
 	if !ok {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -43,6 +43,8 @@ type NameInfoSource interface {
 	EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool,
 		generation keybase1.EkGeneration) (keybase1.TeamEk, error)
+	ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+		membersType chat1.ConversationMembersType, public bool) (bool, []keybase1.KID, error)
 }
 
 type UnboxConversationInfo interface {

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -255,6 +255,11 @@ func (m *TlfMock) EphemeralDecryptionKey(ctx context.Context, tlfName string, tl
 	return keybase1.TeamEk{}, nil
 }
 
+func (m *TlfMock) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (bool, []keybase1.KID, error) {
+	return false, nil, nil
+}
+
 func (m *TlfMock) CryptKeys(ctx context.Context, tlfName string) (res keybase1.GetTLFCryptKeysRes, err error) {
 	res.NameIDBreaks.CanonicalName = CanonicalTlfNameForTest(tlfName)
 	if res.NameIDBreaks.TlfID, err = m.getTlfID(res.NameIDBreaks.CanonicalName); err != nil {

--- a/go/libkb/bootstrap_active_device.go
+++ b/go/libkb/bootstrap_active_device.go
@@ -2,6 +2,7 @@ package libkb
 
 import (
 	"fmt"
+
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -115,7 +116,7 @@ func LoadUnlockedDeviceKeys(m MetaContext, uid keybase1.UID, deviceID keybase1.D
 	sibkeyKID := device.Base.Kid
 	deviceName = device.DeviceDescription
 
-	subkeyKID := upak.Current.FindEncryptionDeviceKID(sibkeyKID)
+	subkeyKID := upak.Current.FindEncryptionKIDFromSigningKID(sibkeyKID)
 	if subkeyKID.IsNil() {
 		m.CDebugf("BootstrapActiveDevice: no subkey found for device: %s", deviceID)
 		return nil, nil, deviceName, NoKeyError{"no encryption device key found for user"}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -610,6 +610,8 @@ const (
 	DeriveReasonUserEKEncryption    DeriveReason = "Derived-Ephemeral-User-NaCl-DH-1"
 	DeriveReasonTeamEKEncryption    DeriveReason = "Derived-Ephemeral-Team-NaCl-DH-1"
 	DeriveReasonTeamEKExplodingChat DeriveReason = "Derived-Ephemeral-Team-NaCl-SecretBox-ExplodingChat-1"
+
+	DeriveReasonChatPairwiseMAC DeriveReason = "Derived-Chat-Pairwise-HMAC-SHA256-1"
 )
 
 // Not a DeriveReason because it is not used in the same way.
@@ -695,3 +697,5 @@ const noiseFileLen = 1024 * 1024 * 2
 // go/chatbase/storage/ephemeral.go as well.
 const MaxEphemeralLifetime = time.Hour * 24 * 7
 const MinEphemeralLifetime = time.Second * 30
+
+const MaxTeamMembersForPairwiseMAC = 100

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -168,6 +168,18 @@ func ImportKeypairFromKID(k keybase1.KID) (key GenericKey, err error) {
 	return
 }
 
+func ImportDHKeypairFromKID(k keybase1.KID) (*NaclDHKeyPair, error) {
+	genericKey, err := ImportKeypairFromKID(k)
+	if err != nil {
+		return nil, err
+	}
+	naclKey, ok := genericKey.(NaclDHKeyPair)
+	if !ok {
+		return nil, fmt.Errorf("expected NaclDHKeyPair, got %T", genericKey)
+	}
+	return &naclKey, nil
+}
+
 func ImportNaclSigningKeyPairFromHex(s string) (ret NaclSigningKeyPair, err error) {
 	var body []byte
 	if body, err = importNaclHex(s, byte(KIDNaclEddsa), ed25519.PublicKeySize); err != nil {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -351,7 +351,7 @@ const (
 // NOTE: these values correspond to the maximum accepted values in
 // chat/boxer.go. If these values are changed, they must also be accepted
 // there.
-var MaxMessageBoxedVersion MessageBoxedVersion = MessageBoxedVersion_V3
+var MaxMessageBoxedVersion MessageBoxedVersion = MessageBoxedVersion_V4
 var MaxHeaderVersion HeaderPlaintextVersion = HeaderPlaintextVersion_V1
 var MaxBodyVersion BodyPlaintextVersion = BodyPlaintextVersion_V1
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -12,13 +12,14 @@ import (
 )
 
 type MessageBoxed struct {
-	Version          MessageBoxedVersion  `codec:"version" json:"version"`
-	ServerHeader     *MessageServerHeader `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
-	ClientHeader     MessageClientHeader  `codec:"clientHeader" json:"clientHeader"`
-	HeaderCiphertext SealedData           `codec:"headerCiphertext" json:"headerCiphertext"`
-	BodyCiphertext   EncryptedData        `codec:"bodyCiphertext" json:"bodyCiphertext"`
-	VerifyKey        []byte               `codec:"verifyKey" json:"verifyKey"`
-	KeyGeneration    int                  `codec:"keyGeneration" json:"keyGeneration"`
+	Version          MessageBoxedVersion     `codec:"version" json:"version"`
+	ServerHeader     *MessageServerHeader    `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
+	ClientHeader     MessageClientHeader     `codec:"clientHeader" json:"clientHeader"`
+	HeaderCiphertext SealedData              `codec:"headerCiphertext" json:"headerCiphertext"`
+	BodyCiphertext   EncryptedData           `codec:"bodyCiphertext" json:"bodyCiphertext"`
+	VerifyKey        []byte                  `codec:"verifyKey" json:"verifyKey"`
+	KeyGeneration    int                     `codec:"keyGeneration" json:"keyGeneration"`
+	PairwiseMacs     map[keybase1.KID][]byte `codec:"pairwiseMacs" json:"pairwiseMacs"`
 }
 
 func (o MessageBoxed) DeepCopy() MessageBoxed {
@@ -41,6 +42,23 @@ func (o MessageBoxed) DeepCopy() MessageBoxed {
 			return append([]byte{}, x...)
 		})(o.VerifyKey),
 		KeyGeneration: o.KeyGeneration,
+		PairwiseMacs: (func(x map[keybase1.KID][]byte) map[keybase1.KID][]byte {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[keybase1.KID][]byte)
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := (func(x []byte) []byte {
+					if x == nil {
+						return nil
+					}
+					return append([]byte{}, x...)
+				})(v)
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.PairwiseMacs),
 	}
 }
 
@@ -51,6 +69,7 @@ const (
 	MessageBoxedVersion_V1    MessageBoxedVersion = 1
 	MessageBoxedVersion_V2    MessageBoxedVersion = 2
 	MessageBoxedVersion_V3    MessageBoxedVersion = 3
+	MessageBoxedVersion_V4    MessageBoxedVersion = 4
 )
 
 func (o MessageBoxedVersion) DeepCopy() MessageBoxedVersion { return o }
@@ -60,6 +79,7 @@ var MessageBoxedVersionMap = map[string]MessageBoxedVersion{
 	"V1":    1,
 	"V2":    2,
 	"V3":    3,
+	"V4":    4,
 }
 
 var MessageBoxedVersionRevMap = map[MessageBoxedVersion]string{
@@ -67,6 +87,7 @@ var MessageBoxedVersionRevMap = map[MessageBoxedVersion]string{
 	1: "V1",
 	2: "V2",
 	3: "V3",
+	4: "V4",
 }
 
 func (e MessageBoxedVersion) String() string {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -428,6 +428,10 @@ func UIDFromString(s string) (UID, error) {
 	return UID(s), nil
 }
 
+func UIDFromSlice(b []byte) (UID, error) {
+	return UIDFromString(hex.EncodeToString(b))
+}
+
 // Used by unit tests.
 func MakeTestUID(n uint32) UID {
 	b := make([]byte, 8)
@@ -1435,7 +1439,7 @@ func (u UserPlusKeysV2) FindSigningDeviceKID(d DeviceID) (KID, string) {
 	return key.Base.Kid, key.DeviceDescription
 }
 
-func (u UserPlusKeysV2) FindEncryptionDeviceKey(parent KID) *PublicKeyV2NaCl {
+func (u UserPlusKeysV2) FindEncryptionDeviceKeyFromSigningKID(parent KID) *PublicKeyV2NaCl {
 	for _, k := range u.DeviceKeys {
 		if !k.Base.IsSibkey && k.Parent != nil && k.Parent.Equal(parent) {
 			return &k
@@ -1444,12 +1448,20 @@ func (u UserPlusKeysV2) FindEncryptionDeviceKey(parent KID) *PublicKeyV2NaCl {
 	return nil
 }
 
-func (u UserPlusKeysV2) FindEncryptionDeviceKID(parent KID) KID {
-	key := u.FindEncryptionDeviceKey(parent)
+func (u UserPlusKeysV2) FindEncryptionKIDFromSigningKID(parent KID) KID {
+	key := u.FindEncryptionDeviceKeyFromSigningKID(parent)
 	if key == nil {
 		return KID("")
 	}
 	return key.Base.Kid
+}
+
+func (u UserPlusKeysV2) FindEncryptionKIDFromDeviceID(deviceID DeviceID) KID {
+	signingKID, _ := u.FindSigningDeviceKID(deviceID)
+	if signingKID.IsNil() {
+		return KID("")
+	}
+	return u.FindEncryptionKIDFromSigningKID(signingKID)
 }
 
 func (s ChatConversationID) String() string {

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -32,6 +32,12 @@ protocol remote {
 
     // [V1, V2]: Key generation of the encryption key
     int keyGeneration;
+
+    // [V1, V2, V3]: Missing
+    // V4: Optional map of pairwise MACs, for repudiable messages. These cover
+    // both the headerCiphertext and the verifyKey, though in the repudiable
+    // case the verifyKey is usually a public constant.
+    map<keybase1.KID, bytes> pairwiseMacs;
   }
 
   enum MessageBoxedVersion {
@@ -50,7 +56,11 @@ protocol remote {
     // V3: Exactly as V2, except that the message
     // may be exploding, meaning the body is
     // encrypted with a separate ephemeral key.
-    V3_3
+    V3_3,
+
+    // V4: Exactly as V3, except if pairwise MACs are included,
+    // then the sender signing key is a dummy.
+    V4_4
   }
 
   record ThreadViewBoxed {

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -238,6 +238,7 @@ export const remoteMessageBoxedVersion = {
   v1: 1,
   v2: 2,
   v3: 3,
+  v4: 4,
 }
 
 export const remoteSyncAllNotificationType = {
@@ -560,12 +561,13 @@ export type MerkleRoot = $ReadOnly<{seqno: Long, hash: Bytes}>
 export type MessageAttachment = $ReadOnly<{object: Asset, preview?: ?Asset, previews?: ?Array<Asset>, metadata: Bytes, uploaded: Boolean}>
 export type MessageAttachmentUploaded = $ReadOnly<{messageID: MessageID, object: Asset, previews?: ?Array<Asset>, metadata: Bytes}>
 export type MessageBody = {messageType: 1, text: ?MessageText} | {messageType: 2, attachment: ?MessageAttachment} | {messageType: 3, edit: ?MessageEdit} | {messageType: 4, delete: ?MessageDelete} | {messageType: 5, metadata: ?MessageConversationMetadata} | {messageType: 7, headline: ?MessageHeadline} | {messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded} | {messageType: 9, join: ?MessageJoin} | {messageType: 10, leave: ?MessageLeave} | {messageType: 11, system: ?MessageSystem} | {messageType: 12, deletehistory: ?MessageDeleteHistory} | {messageType: 13, reaction: ?MessageReaction}
-export type MessageBoxed = $ReadOnly<{version: MessageBoxedVersion, serverHeader?: ?MessageServerHeader, clientHeader: MessageClientHeader, headerCiphertext: SealedData, bodyCiphertext: EncryptedData, verifyKey: Bytes, keyGeneration: Int}>
+export type MessageBoxed = $ReadOnly<{version: MessageBoxedVersion, serverHeader?: ?MessageServerHeader, clientHeader: MessageClientHeader, headerCiphertext: SealedData, bodyCiphertext: EncryptedData, verifyKey: Bytes, keyGeneration: Int, pairwiseMacs: {[key: string]: Bytes}}>
 export type MessageBoxedVersion =
   | 0 // VNONE_0
   | 1 // V1_1
   | 2 // V2_2
   | 3 // V3_3
+  | 4 // V4_4
 
 export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?MsgEphemeralMetadata}>
 export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?MsgEphemeralMetadata, rtime: Gregor1.Time}>

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -47,6 +47,14 @@
         {
           "type": "int",
           "name": "keyGeneration"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "bytes",
+            "keys": "keybase1.KID"
+          },
+          "name": "pairwiseMacs"
         }
       ]
     },
@@ -57,7 +65,8 @@
         "VNONE_0",
         "V1_1",
         "V2_2",
-        "V3_3"
+        "V3_3",
+        "V4_4"
       ]
     },
     {

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -238,6 +238,7 @@ export const remoteMessageBoxedVersion = {
   v1: 1,
   v2: 2,
   v3: 3,
+  v4: 4,
 }
 
 export const remoteSyncAllNotificationType = {
@@ -560,12 +561,13 @@ export type MerkleRoot = $ReadOnly<{seqno: Long, hash: Bytes}>
 export type MessageAttachment = $ReadOnly<{object: Asset, preview?: ?Asset, previews?: ?Array<Asset>, metadata: Bytes, uploaded: Boolean}>
 export type MessageAttachmentUploaded = $ReadOnly<{messageID: MessageID, object: Asset, previews?: ?Array<Asset>, metadata: Bytes}>
 export type MessageBody = {messageType: 1, text: ?MessageText} | {messageType: 2, attachment: ?MessageAttachment} | {messageType: 3, edit: ?MessageEdit} | {messageType: 4, delete: ?MessageDelete} | {messageType: 5, metadata: ?MessageConversationMetadata} | {messageType: 7, headline: ?MessageHeadline} | {messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded} | {messageType: 9, join: ?MessageJoin} | {messageType: 10, leave: ?MessageLeave} | {messageType: 11, system: ?MessageSystem} | {messageType: 12, deletehistory: ?MessageDeleteHistory} | {messageType: 13, reaction: ?MessageReaction}
-export type MessageBoxed = $ReadOnly<{version: MessageBoxedVersion, serverHeader?: ?MessageServerHeader, clientHeader: MessageClientHeader, headerCiphertext: SealedData, bodyCiphertext: EncryptedData, verifyKey: Bytes, keyGeneration: Int}>
+export type MessageBoxed = $ReadOnly<{version: MessageBoxedVersion, serverHeader?: ?MessageServerHeader, clientHeader: MessageClientHeader, headerCiphertext: SealedData, bodyCiphertext: EncryptedData, verifyKey: Bytes, keyGeneration: Int, pairwiseMacs: {[key: string]: Bytes}}>
 export type MessageBoxedVersion =
   | 0 // VNONE_0
   | 1 // V1_1
   | 2 // V2_2
   | 3 // V3_3
+  | 4 // V4_4
 
 export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?MsgEphemeralMetadata}>
 export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?MsgEphemeralMetadata, rtime: Gregor1.Time}>


### PR DESCRIPTION
For exploding messages on small teams, include pairwise MACs in the
header. Clients with no pairwise MAC support will ignore these, and
we'll keep signing with the regular key, so there should be no breakage.
Define message boxed V4, which will be when we stop signing with the
regular key, but don't emit those messages yet.

r? @maxtaco @joshblum @mmaxim 

So far I've only added some very low level test to sanity check the MAC'ing, but
I will expand the test cases to include unboxing a corrupted message.