### PR TITLE
hold onto tsec'ed passphrase as input for PGP synced key decryption

### DIFF
--- a/go/engine/passphrase_change.go
+++ b/go/engine/passphrase_change.go
@@ -299,6 +299,11 @@ func (c *PassphraseChange) runStandardUpdate(m libkb.MetaContext) (err error) {
 		return err
 	}
 
+	// Reset the passphrase stream cache on the global Active Device, since if it exists,
+	// it was for a previous version of the passphrase.
+	m = m.WithGlobalActiveDevice()
+	m.ActiveDevice().ClearCaches()
+
 	return nil
 }
 

--- a/go/engine/pgp_decrypt_test.go
+++ b/go/engine/pgp_decrypt_test.go
@@ -577,9 +577,7 @@ func TestPGPDecryptWithSyncedKey(t *testing.T) {
 	decryptCalledPassphrase = decryptIt()
 	require.True(t, decryptCalledPassphrase, "passphrase get was called")
 
-	// See CORE-7929, we shouldn't really need a passphrase here, but for now,
-	// assert the buggy behavior.
 	decryptCalledPassphrase = decryptIt()
-	require.True(t, decryptCalledPassphrase, "passphrase get was called")
+	require.False(t, decryptCalledPassphrase, "passphrase get wasn't called")
 
 }

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -550,8 +550,7 @@ func (m MetaContext) PassphraseStreamAndTriplesec() (*PassphraseStream, Triplese
 	if ppsc == nil {
 		return nil, nil
 	}
-	tsec, _ := ppsc.TriplesecAndGeneration()
-	return ppsc.PassphraseStream(), tsec
+	return ppsc.PassphraseStreamAndTriplesec()
 }
 
 func (m MetaContext) TriplesecAndGeneration() (ret Triplesec, ppgen PassphraseGeneration) {

--- a/go/libkb/passphrase_stream_cache.go
+++ b/go/libkb/passphrase_stream_cache.go
@@ -86,6 +86,27 @@ func (s *PassphraseStreamCache) TriplesecAndGeneration() (Triplesec, PassphraseG
 	return s.tsec, ppgen
 }
 
+func (s *PassphraseStreamCache) PassphraseStreamAndTriplesec() (pps *PassphraseStream, tsec Triplesec) {
+
+	if s == nil {
+		return nil, nil
+	}
+
+	s.Lock()
+	defer s.Unlock()
+
+	// Beware the classic Go `nil` interface bug...
+	if s.tsec != nil {
+		tsec = s.tsec
+	}
+
+	if s.passphraseStream != nil {
+		pps = s.passphraseStream.Clone()
+	}
+
+	return pps, tsec
+}
+
 // PassphraseStream returns a copy of the currently cached passphrase stream,
 // or nil if none exists.
 func (s *PassphraseStreamCache) PassphraseStream() *PassphraseStream {

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -249,6 +249,10 @@ func (s *SKB) UnlockSecretKey(m MetaContext, passphrase string, tsec Triplesec, 
 			}
 		}
 		unlocked, err = s.tsecUnlock(tsec)
+		if err == nil {
+			m.CDebugf("Caching passphrase stream: tsec=%v, pps=%v", (tsec != nil), (pps != nil))
+			m.ActiveDevice().CachePassphraseStream(NewPassphraseStreamCache(tsec, pps))
+		}
 	case LKSecVersion:
 		m.CDebugf("case: LKSec")
 		ppsIn := pps
@@ -400,7 +404,8 @@ func (s *SKB) UnlockWithStoredSecret(m MetaContext, secretRetriever SecretRetrie
 
 var ErrUnlockNotPossible = errors.New("unlock not possible")
 
-func (s *SKB) UnlockNoPrompt(m MetaContext, secretStore SecretStore) (GenericKey, error) {
+func (s *SKB) UnlockNoPrompt(m MetaContext, secretStore SecretStore) (ret GenericKey, err error) {
+	defer m.CTrace("SKB#UnlockNoPrompt", func() error { return err })()
 	// already have decrypted secret?
 	if s.decryptedSecret != nil {
 		return s.decryptedSecret, nil


### PR DESCRIPTION
- there are two ways we could have handled this
  - the first is when decrypting a synced PGP key, to ask for a salt and generate a full passphrase stream,
    since we can read the salt out of the P3SKB blob and therefore don't need to ask the server for it.
  - the second is just to handle the case of a partial passphrase stream cache (with a tsec but with a passphraseStream)
- we opted for the second option here, since it's slightly less disruptive, but we might revisit this idea later on