### PR TITLE
dont delete anything form outbox and fail all messages if one fails due to attempt exhaustion CORE-8046

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -684,7 +684,7 @@ func (e *Env) GetGregorPingInterval() time.Duration {
 }
 
 func (e *Env) GetGregorPingTimeout() time.Duration {
-	return e.GetDuration(5*time.Second,
+	return e.GetDuration(30*time.Second,
 		func() (time.Duration, bool) { return e.getEnvDuration("KEYBASE_PUSH_PING_TIMEOUT") },
 		func() (time.Duration, bool) { return e.GetConfig().GetGregorPingTimeout() },
 		func() (time.Duration, bool) { return e.cmd.GetGregorPingTimeout() },
@@ -692,7 +692,7 @@ func (e *Env) GetGregorPingTimeout() time.Duration {
 }
 
 func (e *Env) GetChatDelivererInterval() time.Duration {
-	return e.GetDuration(30*time.Second,
+	return e.GetDuration(5*time.Second,
 		func() (time.Duration, bool) { return e.getEnvDuration("KEYBASE_CHAT_DELIVERER_INTERVAL") },
 		func() (time.Duration, bool) { return e.GetConfig().GetChatDelivererInterval() },
 		func() (time.Duration, bool) { return e.cmd.GetChatDelivererInterval() },

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -684,7 +684,7 @@ func (e *Env) GetGregorPingInterval() time.Duration {
 }
 
 func (e *Env) GetGregorPingTimeout() time.Duration {
-	return e.GetDuration(30*time.Second,
+	return e.GetDuration(5*time.Second,
 		func() (time.Duration, bool) { return e.getEnvDuration("KEYBASE_PUSH_PING_TIMEOUT") },
 		func() (time.Duration, bool) { return e.GetConfig().GetGregorPingTimeout() },
 		func() (time.Duration, bool) { return e.cmd.GetGregorPingTimeout() },

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1198,23 +1198,25 @@ func (e OutboxStateType) String() string {
 type OutboxErrorType int
 
 const (
-	OutboxErrorType_MISC      OutboxErrorType = 0
-	OutboxErrorType_OFFLINE   OutboxErrorType = 1
-	OutboxErrorType_IDENTIFY  OutboxErrorType = 2
-	OutboxErrorType_TOOLONG   OutboxErrorType = 3
-	OutboxErrorType_DUPLICATE OutboxErrorType = 4
-	OutboxErrorType_EXPIRED   OutboxErrorType = 5
+	OutboxErrorType_MISC            OutboxErrorType = 0
+	OutboxErrorType_OFFLINE         OutboxErrorType = 1
+	OutboxErrorType_IDENTIFY        OutboxErrorType = 2
+	OutboxErrorType_TOOLONG         OutboxErrorType = 3
+	OutboxErrorType_DUPLICATE       OutboxErrorType = 4
+	OutboxErrorType_EXPIRED         OutboxErrorType = 5
+	OutboxErrorType_TOOMANYATTEMPTS OutboxErrorType = 6
 )
 
 func (o OutboxErrorType) DeepCopy() OutboxErrorType { return o }
 
 var OutboxErrorTypeMap = map[string]OutboxErrorType{
-	"MISC":      0,
-	"OFFLINE":   1,
-	"IDENTIFY":  2,
-	"TOOLONG":   3,
-	"DUPLICATE": 4,
-	"EXPIRED":   5,
+	"MISC":            0,
+	"OFFLINE":         1,
+	"IDENTIFY":        2,
+	"TOOLONG":         3,
+	"DUPLICATE":       4,
+	"EXPIRED":         5,
+	"TOOMANYATTEMPTS": 6,
 }
 
 var OutboxErrorTypeRevMap = map[OutboxErrorType]string{
@@ -1224,6 +1226,7 @@ var OutboxErrorTypeRevMap = map[OutboxErrorType]string{
 	3: "TOOLONG",
 	4: "DUPLICATE",
 	5: "EXPIRED",
+	6: "TOOMANYATTEMPTS",
 }
 
 func (e OutboxErrorType) String() string {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -195,7 +195,8 @@ protocol local {
     IDENTIFY_2,
     TOOLONG_3,
     DUPLICATE_4,
-    EXPIRED_5
+    EXPIRED_5,
+    TOOMANYATTEMPTS_6
   }
 
   record OutboxStateError {

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -295,6 +295,7 @@ export const localOutboxErrorType = {
   toolong: 3,
   duplicate: 4,
   expired: 5,
+  toomanyattempts: 6,
 }
 
 export const localOutboxStateType = {
@@ -1178,6 +1179,7 @@ export type OutboxErrorType =
   | 3 // TOOLONG_3
   | 4 // DUPLICATE_4
   | 5 // EXPIRED_5
+  | 6 // TOOMANYATTEMPTS_6
 
 export type OutboxID = Bytes
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -649,7 +649,8 @@
         "IDENTIFY_2",
         "TOOLONG_3",
         "DUPLICATE_4",
-        "EXPIRED_5"
+        "EXPIRED_5",
+        "TOOMANYATTEMPTS_6"
       ]
     },
     {

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -295,6 +295,7 @@ export const localOutboxErrorType = {
   toolong: 3,
   duplicate: 4,
   expired: 5,
+  toomanyattempts: 6,
 }
 
 export const localOutboxStateType = {
@@ -1178,6 +1179,7 @@ export type OutboxErrorType =
   | 3 // TOOLONG_3
   | 4 // DUPLICATE_4
   | 5 // EXPIRED_5
+  | 6 // TOOMANYATTEMPTS_6
 
 export type OutboxID = Bytes
 


### PR DESCRIPTION
Patch does the following:

1.) Stops removing everything from the on disk outbox when running the `Deliverer`  send loop. 
2.) Whenever we encounter an error sending, we abort the `Deliverer` send loop.
3.) A failure for "too many attempts" now fails everything in the outbox.
4.) We retry faster/ 