### PR TITLE
Add wallet rpc preamble with RequireWallet

### DIFF
--- a/go/client/cmd_wallet_export.go
+++ b/go/client/cmd_wallet_export.go
@@ -81,13 +81,12 @@ func (c *cmdWalletExport) Run() (err error) {
 		}
 	}
 
-	dui.Printf("This secret key is used to send money and manage your stellar account.\n")
-	dui.Printf("Anyone with the secret will have full access to the account.\n")
-
 	secKey, err := cli.ExportSecretKeyLocal(context.TODO(), accountID)
 	if err != nil {
 		return err
 	}
+	dui.Printf("This secret key is used to send money and manage your stellar account.\n")
+	dui.Printf("Anyone with the secret will have full access to the account.\n")
 	dui.Printf("\nAccount ID: %s\n\nKeep it secret.\nSecret Key: %s\nKeep it safe.\n", accountID.String(), secKey.SecureNoLogString())
 	return
 }

--- a/go/engine/wallet_init_background.go
+++ b/go/engine/wallet_init_background.go
@@ -105,6 +105,5 @@ func WalletInitBackgroundRound(m libkb.MetaContext) error {
 		return nil
 	}
 
-	_, err := g.GetStellar().CreateWalletGated(context.Background())
-	return err
+	return g.GetStellar().CreateWalletGated(context.Background())
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -1184,13 +1184,15 @@ func (g *GlobalContext) IsOneshot(ctx context.Context) (bool, error) {
 }
 
 func (g *GlobalContext) GetMeUV(ctx context.Context) (res keybase1.UserVersion, err error) {
+	defer g.CTraceTimed(ctx, "GlobalContext.GetMeUV", func() error { return err })()
 	meUID := g.ActiveDevice.UID()
 	if meUID.IsNil() {
 		return res, LoginRequiredError{}
 	}
 	loadMeArg := NewLoadUserArgWithContext(ctx, g).
 		WithUID(meUID).
-		WithSelf(true)
+		WithSelf(true).
+		WithPublicKeyOptional()
 	upkv2, _, err := g.GetUPAKLoader().LoadV2(loadMeArg)
 	if err != nil {
 		return res, err

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -620,7 +620,7 @@ type TeamLoader interface {
 
 type Stellar interface {
 	OnLogout()
-	CreateWalletGated(context.Context) (bool, error)
+	CreateWalletGated(context.Context) error
 	CreateWalletSoft(context.Context)
 	Upkeep(context.Context) error
 	GetServerDefinitions(context.Context) (stellar1.StellarServerDefinitions, error)

--- a/go/libkb/stellar_stub.go
+++ b/go/libkb/stellar_stub.go
@@ -20,8 +20,8 @@ func newNullStellar(g *GlobalContext) *nullStellar {
 
 func (n *nullStellar) OnLogout() {}
 
-func (n *nullStellar) CreateWalletGated(ctx context.Context) (bool, error) {
-	return false, fmt.Errorf("null stellar impl")
+func (n *nullStellar) CreateWalletGated(ctx context.Context) error {
+	return fmt.Errorf("null stellar impl")
 }
 
 func (n *nullStellar) CreateWalletSoft(ctx context.Context) {

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -15,16 +15,17 @@ import (
 type shouldCreateRes struct {
 	libkb.AppStatusEmbed
 	ShouldCreate bool `json:"shouldcreate"`
+	HasWallet    bool `json:"haswallet"`
 }
 
 // ShouldCreate asks the server whether to create this user's initial wallet.
-func ShouldCreate(ctx context.Context, g *libkb.GlobalContext) (should bool, err error) {
+func ShouldCreate(ctx context.Context, g *libkb.GlobalContext) (shouldCreate, hasWallet bool, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.ShouldCreate", func() error { return err })()
 	arg := libkb.NewAPIArgWithNetContext(ctx, "stellar/shouldcreate")
 	arg.SessionType = libkb.APISessionTypeREQUIRED
 	var apiRes shouldCreateRes
 	err = g.API.GetDecode(arg, &apiRes)
-	return apiRes.ShouldCreate, err
+	return apiRes.ShouldCreate, apiRes.HasWallet, err
 }
 
 // Post a bundle to the server with a chainlink.

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -23,9 +23,12 @@ const ParticipantTypeStellar = "stellar"
 const ParticipantTypeSBS = "sbs"
 
 func (s *Server) GetWalletAccountsLocal(ctx context.Context, sessionID int) (accts []stellar1.WalletAccountLocal, err error) {
-	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "GetWalletAccountsLocal", func() error { return err })()
-	err = s.assertLoggedIn(ctx)
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:       "GetWalletAccountsLocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
 	if err != nil {
 		return nil, err
 	}
@@ -70,9 +73,11 @@ func (s *Server) GetWalletAccountsLocal(ctx context.Context, sessionID int) (acc
 }
 
 func (s *Server) GetAccountAssetsLocal(ctx context.Context, arg stellar1.GetAccountAssetsLocalArg) (assets []stellar1.AccountAssetLocal, err error) {
-	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "GetAccountAssetsLocal", func() error { return err })()
-	err = s.assertLoggedIn(ctx)
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName: "GetAccountAssetsLocal",
+		Err:     &err,
+	})
+	defer fin()
 	if err != nil {
 		return nil, err
 	}
@@ -164,9 +169,11 @@ func (s *Server) GetAccountAssetsLocal(ctx context.Context, arg stellar1.GetAcco
 }
 
 func (s *Server) GetDisplayCurrenciesLocal(ctx context.Context, sessionID int) (currencies []stellar1.CurrencyLocal, err error) {
-	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "GetDisplayCurrenciesLocal", func() error { return err })()
-	err = s.assertLoggedIn(ctx)
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName: "GetDisplayCurrenciesLocal",
+		Err:     &err,
+	})
+	defer fin()
 	if err != nil {
 		return nil, err
 	}
@@ -199,9 +206,12 @@ func (s *Server) GetDisplayCurrenciesLocal(ctx context.Context, sessionID int) (
 }
 
 func (s *Server) GetUserSettingsLocal(ctx context.Context, sessionID int) (userSettings stellar1.UserSettings, err error) {
-	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "GetUserSettingsLocal", func() error { return err })()
-	err = s.assertLoggedIn(ctx)
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:       "GetUserSettingsLocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
 	if err != nil {
 		return userSettings, err
 	}
@@ -214,9 +224,12 @@ func (s *Server) GetUserSettingsLocal(ctx context.Context, sessionID int) (userS
 }
 
 func (s *Server) SetAcceptedDisclaimerLocal(ctx context.Context, sessionID int) (err error) {
-	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "SetAcceptedDisclaimerLocal", func() error { return err })()
-	err = s.assertLoggedIn(ctx)
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:       "SetAcceptedDisclaimerLocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
 	if err != nil {
 		return err
 	}
@@ -225,9 +238,12 @@ func (s *Server) SetAcceptedDisclaimerLocal(ctx context.Context, sessionID int) 
 }
 
 func (s *Server) LinkNewWalletAccountLocal(ctx context.Context, arg stellar1.LinkNewWalletAccountLocalArg) (accountID stellar1.AccountID, err error) {
-	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "LinkNewWalletAccountLocal", func() error { return err })()
-	err = s.assertLoggedIn(ctx)
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:       "LinkNewWalletAccountLocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
 	if err != nil {
 		return "", err
 	}
@@ -246,9 +262,12 @@ func (s *Server) LinkNewWalletAccountLocal(ctx context.Context, arg stellar1.Lin
 }
 
 func (s *Server) GetPaymentsLocal(ctx context.Context, arg stellar1.GetPaymentsLocalArg) (payments []stellar1.PaymentOrErrorLocal, err error) {
-	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "GetPaymentsLocal", func() error { return err })()
-	err = s.assertLoggedIn(ctx)
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:       "GetPaymentsLocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
 	if err != nil {
 		return nil, err
 	}
@@ -467,29 +486,41 @@ func (a balanceList) nativeBalanceDescription() (string, error) {
 }
 
 func (s *Server) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.ChangeWalletAccountNameLocalArg) (err error) {
-	m := libkb.NewMetaContext(s.logTag(ctx), s.G())
-	defer s.G().CTraceTimed(ctx, "ChangeWalletAccountNameLocal", func() error { return err })()
-	if err = s.assertLoggedIn(ctx); err != nil {
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:       "ChangeWalletAccountNameLocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
+	if err != nil {
 		return err
 	}
 
-	return stellar.ChangeAccountName(m, arg.AccountID, arg.NewName)
+	return stellar.ChangeAccountName(s.mctx(ctx), arg.AccountID, arg.NewName)
 }
 
 func (s *Server) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar1.SetWalletAccountAsDefaultLocalArg) (err error) {
-	m := libkb.NewMetaContext(s.logTag(ctx), s.G())
-	defer s.G().CTraceTimed(ctx, "SetWalletAccountAsDefaultLocal", func() error { return err })()
-	if err = s.assertLoggedIn(ctx); err != nil {
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:       "SetWalletAccountAsDefaultLocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
+	if err != nil {
 		return err
 	}
 
-	return stellar.SetAccountAsPrimary(m, arg.AccountID)
+	return stellar.SetAccountAsPrimary(s.mctx(ctx), arg.AccountID)
 }
 
 func (s *Server) DeleteWalletAccountLocal(ctx context.Context, arg stellar1.DeleteWalletAccountLocalArg) (err error) {
-	m := libkb.NewMetaContext(s.logTag(ctx), s.G())
-	defer s.G().CTraceTimed(ctx, "DeleteWalletAccountLocal", func() error { return err })()
-	if err = s.assertLoggedIn(ctx); err != nil {
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:       "DeleteWalletAccountLocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
+	if err != nil {
 		return err
 	}
 
@@ -497,14 +528,20 @@ func (s *Server) DeleteWalletAccountLocal(ctx context.Context, arg stellar1.Dele
 		return errors.New("User did not acknowledge")
 	}
 
-	return stellar.DeleteAccount(m, arg.AccountID)
+	return stellar.DeleteAccount(s.mctx(ctx), arg.AccountID)
 }
 
 func (s *Server) ChangeDisplayCurrencyLocal(ctx context.Context, arg stellar1.ChangeDisplayCurrencyLocalArg) (err error) {
-	defer s.G().CTraceTimed(ctx, "ChangeDisplayCurrencyLocal", func() error { return err })()
-	if err = s.assertLoggedIn(ctx); err != nil {
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:       "ChangeDisplayCurrencyLocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
+	if err != nil {
 		return err
 	}
+
 	if arg.AccountID.IsNil() {
 		return errors.New("passed empty AccountID")
 	}
@@ -519,7 +556,16 @@ func (s *Server) ChangeDisplayCurrencyLocal(ctx context.Context, arg stellar1.Ch
 }
 
 func (s *Server) GetWalletAccountPublicKeyLocal(ctx context.Context, arg stellar1.GetWalletAccountPublicKeyLocalArg) (res string, err error) {
-	defer s.G().CTraceTimed(ctx, "GetWalletAccountPublicKeyLocal", func() error { return err })()
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:        "GetWalletAccountPublicKeyLocal",
+		Err:            &err,
+		AllowLoggedOut: true,
+	})
+	defer fin()
+	if err != nil {
+		return res, err
+	}
+
 	if arg.AccountID.IsNil() {
 		return res, errors.New("passed empty AccountID")
 	}
@@ -527,14 +573,19 @@ func (s *Server) GetWalletAccountPublicKeyLocal(ctx context.Context, arg stellar
 }
 
 func (s *Server) GetWalletAccountSecretKeyLocal(ctx context.Context, arg stellar1.GetWalletAccountSecretKeyLocalArg) (res stellar1.SecretKey, err error) {
-	defer s.G().CTraceTimed(ctx, "GetWalletAccountSecretKeyLocal", func() error { return err })()
-	if err = s.assertLoggedIn(ctx); err != nil {
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:       "GetWalletAccountSecretKeyLocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
+	if err != nil {
 		return res, err
 	}
+
 	if arg.AccountID.IsNil() {
 		return res, errors.New("passed empty AccountID")
 	}
-
 	return stellar.ExportSecretKey(ctx, s.G(), arg.AccountID)
 }
 

--- a/go/stellar/stellarsvc/service_devel.go
+++ b/go/stellar/stellarsvc/service_devel.go
@@ -15,18 +15,19 @@ import (
 )
 
 func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.Bundle, err error) {
-	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "WalletDumpLocal", func() error { return err })()
 	if s.G().Env.GetRunMode() != libkb.DevelRunMode {
 		return dump, errors.New("WalletDump only supported in devel run mode")
 	}
 
-	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "WalletDump", func() error { return err })()
-	err = s.assertLoggedIn(ctx)
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName: "WalletDumpLocal",
+		Err:     &err,
+	})
+	defer fin()
 	if err != nil {
 		return dump, err
 	}
+
 	mctx := libkb.NewMetaContext(ctx, s.G())
 
 	// verify passphrase

--- a/go/stellar/stellarsvc/service_production.go
+++ b/go/stellar/stellarsvc/service_production.go
@@ -13,7 +13,15 @@ import (
 )
 
 func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.Bundle, err error) {
-	ctx = s.logTag(ctx)
-	defer s.G().CTraceTimed(ctx, "WalletDumpLocal", func() error { return err })()
+	ctx, err, fin := s.Preamble(ctx, preambleArg{
+		RpcName:        "WalletDumpLocal",
+		Err:            &err,
+		AllowLoggedOut: true,
+	})
+	defer fin()
+	if err != nil {
+		return dump, err
+	}
+
 	return dump, fmt.Errorf("WalletDumpLocal is disabled in prod mode")
 }


### PR DESCRIPTION
Make the error `logged-in user has no wallet accounts` harder to get (if stellar is enabled for you). With this PR, when an RPC that has RequireWallet is called, it checks if the user has a wallet and if not tries to make one and if that fails errors out. Quickly in the common success case (<1ms locally).

Previously running `wallet list` wouldn't even try to get you a wallet. So you could race with the background maker for example by waiting more than 15 seconds to login on a logged-out device. Or by having stellar enabled for you while your service was running. I'm not sure how often to expect that sort of scenario, but with this PR it no longer matters.
