### PR TITLE
Log app lifecycle on iOS

### DIFF
--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -258,19 +258,26 @@ const BOOL isDebug = NO;
 
 - (void) hideCover {
   // Always cancel outstanding animations else they can fight and the timing is very weird
+  NSLog(@"hideCover: cancelling outstanding animations...");
   [self.resignImageView.layer removeAllAnimations];
   [UIView animateWithDuration:0.3 delay:0.3 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
     self.resignImageView.alpha = 0;
-  } completion:nil];
+  } completion:^(BOOL finished){
+    NSLog(@"hideCover: hid keyz screen. Finished: %d", finished);
+  }];
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {
   // Always cancel outstanding animations else they can fight and the timing is very weird
+  NSLog(@"applicationWillResignActive: cancelling outstanding animations...");
   [self.resignImageView.layer removeAllAnimations];
   // Try a nice animation out
+  NSLog(@"applicationWillResignActive: rendering keyz screen...");
   [UIView animateWithDuration:0.3 delay:0.1 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
     self.resignImageView.alpha = 1;
-  } completion:nil];
+  } completion:^(BOOL finished){
+    NSLog(@"applicationWillResignActive: rendered keyz screen. Finished: %d", finished);
+  }];
   KeybaseSetAppStateInactive();
 }
 
@@ -278,8 +285,10 @@ const BOOL isDebug = NO;
   // Throw away any saved screenshot just in case anyways
   [application ignoreSnapshotOnNextApplicationLaunch];
   // Always cancel outstanding animations else they can fight and the timing is very weird
+  NSLog(@"applicationDidEnterBackground: cancelling outstanding animations...");
   [self.resignImageView.layer removeAllAnimations];
   // Snapshot happens right after this call, force alpha immediately w/o animation else you'll get a half animated overlay
+  NSLog(@"applicationDidEnterBackground: setting keyz screen alpha to 1.");
   self.resignImageView.alpha = 1;
 
   const bool requestTime = KeybaseAppDidEnterBackground();
@@ -295,20 +304,25 @@ const BOOL isDebug = NO;
 
 // Sometimes these lifecycle calls can be skipped so try and catch them all
 - (void)applicationDidBecomeActive:(UIApplication *)application {
+  NSLog(@"applicationDidBecomeActive: hiding keyz screen.");
   [self hideCover];
+  NSLog(@"applicationDidBecomeActive: notifying service.");
   [self notifyAppState:application];
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
+  NSLog(@"applicationWillEnterForeground: hiding keyz screen.");
   [self hideCover];
 }
 
 - (void)applicationDidFinishLaunching:(UIApplication *)application {
+  NSLog(@"applicationDidFinishLaunching: notifying service.");
   [self notifyAppState:application];
 }
 
 - (void)notifyAppState:(UIApplication *)application {
   const UIApplicationState state = application.applicationState;
+  NSLog(@"notifyAppState: notifying service with new appState: %ld", (long)state);
   switch (state) {
     case UIApplicationStateActive:
       KeybaseSetAppStateForeground();


### PR DESCRIPTION
This is to help debug crashes that @mlsteele sees on foregrounding the app. Here's how they look in the logs:

```
42884 2018-06-08 10:21:15.453 Keybase[10914:3793552] applicationWillResignActive: cancelling outstanding animations...
42885 2018-06-08 10:21:15.453 Keybase[10914:3793552] applicationWillResignActive: rendering keyz screen...
49589 2018-06-08 10:21:27.848 Keybase[10914:3793552] applicationDidEnterBackground: cancelling outstanding animations...
49590 2018-06-08 10:21:27.848 Keybase[10914:3793552] applicationDidEnterBackground: setting keyz screen alpha to 1.
49848 2018-06-08 10:21:29.523 Keybase[10915:3793916] applicationDidBecomeActive: hiding keyz screen.
49849 2018-06-08 10:21:29.524 Keybase[10915:3793916] hideCover: cancelling outstanding animations...
49850 2018-06-08 10:21:29.524 Keybase[10915:3793916] applicationDidBecomeActive: notifying service.
49851 2018-06-08 10:21:29.524 Keybase[10915:3793916] notifyAppState: notifying service with new appState: 0
49857 2018-06-08 10:21:29.526 Keybase[10915:3793916] hideCover: hid keyz screen. Finished: 1
```

r? @keybase/react-hackers 