### PR TITLE
Handle multiple teamsWithChosenChannels in pushstate

### DIFF
--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -158,6 +158,7 @@ function handleTeamsWithChosenChannels(items: Array<Types.NonNullGregorItem>) {
     arrays = chosenChannelItems.reduce((res, i) => {
       try {
         const arr = JSON.parse(i.item.body.toString())
+        // this has to be an array
         if (!(arr instanceof Array)) {
           throw new Error(
             `Found invalid teamsWithChosenChannels item with ctime ${
@@ -167,8 +168,9 @@ function handleTeamsWithChosenChannels(items: Array<Types.NonNullGregorItem>) {
         }
         res.push(arr)
       } catch (e) {
-        logger.error(`Error in parsing teamsWithChosenChannels: ${e.message}; dismissing bad item`)
-        actions.push(Saga.call(RPCTypes.gregorDismissItemRpcPromise, {id: i.md.msgID}))
+        logger.error(`Error in parsing teamsWithChosenChannels: ${e.message}; skipping`)
+        // no need to dismiss the bad item, it will be excluded from the union
+        // and updateCategory will dismiss all existing ones
       }
       return res
     }, [])
@@ -201,6 +203,7 @@ function handleTeamsWithChosenChannels(items: Array<Types.NonNullGregorItem>) {
     let array = []
     try {
       array = JSON.parse(i.item.body.toString())
+      // this has to be an array
       if (!(array instanceof Array)) {
         throw new Error(
           `Found invalid teamsWithChosenChannels item with ctime ${
@@ -211,7 +214,8 @@ function handleTeamsWithChosenChannels(items: Array<Types.NonNullGregorItem>) {
     } catch (e) {
       logger.error(`Error in parsing teamsWithChosenChannels: ${e.message}; dismissing bad item`)
       actions.push(Saga.call(RPCTypes.gregorDismissItemRpcPromise, {id: i.md.msgID}))
-      return actions
+      // just return the one dismiss action
+      return Saga.all(actions)
     }
     const ctime = i.md.ctime
     logger.info(


### PR DESCRIPTION
@mlsteele had his `teamsWithChosenChannels` reset twice in the last week. It's because his client doesn't know about the existing `teamsWithChosenChannels`, and injects a new empty one so he ends up with two. This PR adds detection for multiple `teamsWithChosenChannels` arrays. We take the union of any valid items we find, and dismiss any invalid ones along the way. It's a little dangerous to modify the gregor state in its own receiver, but actions returned from `handleTeamsWithChosenChannels` monotonically decrease the number of `teamsWithChosenChannels` in the gregor state, so as long as we're not passing an invalid array in L192, we shouldn't get into a loop here. r? @keybase/react-hackers 