### PR TITLE
Fix some styling typos

### DIFF
--- a/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.native.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.native.js
@@ -61,7 +61,7 @@ class ExplodingHeightRetainer extends React.Component<Props, State> {
 const AshTower = (props: {numImages: number}) => {
   const children = []
   for (let i = 0; i < props.numImages; i++) {
-    children.push(<NativeImage key={i} source={explodedIllustrationURL} style={styles.image} />)
+    children.push(<NativeImage key={i} source={explodedIllustrationURL} style={styles.ashes} />)
   }
   return <React.Fragment>{children}</React.Fragment>
 }

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -35,7 +35,7 @@ const AssetInput = (props: Props) => (
       placeholder={props.inputPlaceholder}
     />
     <Box2 direction="horizontal" fullWidth={true} gap="xtiny">
-      <Text type="BodySmall" style={styles.label}>
+      <Text type="BodySmall" style={styles.labelMargin}>
         {props.bottomLabel}
       </Text>
       <Icon


### PR DESCRIPTION
I was working on typing `styleSheetCreate` to make sure we never use keys that we don't supply. The typing isn't done, but I found a couple places where we used nonexistent keys. r? @keybase/react-hackers 