### PR TITLE
fix syncing gregor state

### DIFF
--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -232,7 +232,7 @@ func (c *Client) freshSync(ctx context.Context, cli gregor1.IncomingInterface, s
 
 	if state == nil {
 		state = new(gregor.State)
-		*state, err = c.State(cli)
+		*state, err = c.State(ctx, cli)
 		if err != nil {
 			return msgs, err
 		}
@@ -311,8 +311,7 @@ func (c *Client) InBandMessagesFromState(s gregor.State) ([]gregor.InBandMessage
 	return res, nil
 }
 
-func (c *Client) State(cli gregor1.IncomingInterface) (res gregor.State, err error) {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+func (c *Client) State(ctx context.Context, cli gregor1.IncomingInterface) (res gregor.State, err error) {
 	arg := gregor1.StateArg{
 		Uid:          gregor1.UID(c.User.Bytes()),
 		Deviceid:     gregor1.DeviceID(c.Device.Bytes()),

--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -230,7 +230,6 @@ func (c *Client) freshSync(ctx context.Context, cli gregor1.IncomingInterface, s
 	var msgs []gregor.InBandMessage
 	var err error
 
-	c.Sm.Clear()
 	if state == nil {
 		state = new(gregor.State)
 		*state, err = c.State(cli)
@@ -244,6 +243,7 @@ func (c *Client) freshSync(ctx context.Context, cli gregor1.IncomingInterface, s
 	if msgs, err = c.InBandMessagesFromState(*state); err != nil {
 		return msgs, err
 	}
+	c.Sm.Clear()
 	if err = c.Sm.InitState(*state); err != nil {
 		return msgs, err
 	}
@@ -288,7 +288,7 @@ func (c *Client) Sync(ctx context.Context, cli gregor1.IncomingInterface,
 	msgs, err := c.SyncFromTime(ctx, cli, c.Sm.LatestCTime(ctx, c.User, c.Device), syncResult)
 	if err != nil {
 		if _, ok := err.(ErrHashMismatch); ok {
-			c.Log.Debug("Sync(): hash check failure: %v", err)
+			c.Log.CDebugf(ctx, "Sync(): hash check failure: %v", err)
 			return c.freshSync(ctx, cli, nil)
 		}
 		return msgs, err

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -758,30 +758,31 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 			g.forceSessionCheck = true
 			nist.MarkFailure()
 		}
-		return fmt.Errorf("error running SyncAll: %s", err.Error())
+		return fmt.Errorf("error running SyncAll: %s", err)
 	}
 
 	// Use the client parameter instead of conn.GetClient(), since we can get stuck
 	// in a recursive loop if we keep retrying on reconnect.
 	if err := g.auth(ctx, timeoutCli, &syncAllRes.Auth); err != nil {
-		return fmt.Errorf("error authenticating: %s", err.Error())
+		return fmt.Errorf("error authenticating: %s", err)
 	}
 
 	// Sync chat data using a Syncer object
 	if err := g.G().Syncer.Connected(ctx, chatCli, uid, &syncAllRes.Chat); err != nil {
-		return fmt.Errorf("error running chat sync: %s", err.Error())
+		return fmt.Errorf("error running chat sync: %s", err)
 	}
 
 	// Sync down events since we have been dead
 	if _, err := g.serverSync(ctx, gregor1.IncomingClient{Cli: timeoutCli}, gcli,
 		&syncAllRes.Notification); err != nil {
-		g.chatLog.Debug(ctx, "serverSync: failure: %s", err.Error())
+		g.chatLog.Debug(ctx, "serverSync: failure: %s", err)
+		return fmt.Errorf("error running state sync: %s", err)
 	}
 
 	// Sync badge state in the background
 	if g.badger != nil {
 		if err := g.badger.Resync(ctx, g.GetClient, gcli, &syncAllRes.Badge); err != nil {
-			g.chatLog.Debug(ctx, "badger failure: %s", err.Error())
+			g.chatLog.Debug(ctx, "badger failure: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Fix syncing Gregor state, this could cause us to think we have a blank Gregor state locally in the following circumstance:

1.) Initiate restart of Gregor.
2.) Desktop clients all re-connect and re-sync state.
3.) There is another bug which causes us to miss the hash check for some reason (we can deal with this separately), causing the client to sync down the entire Gregor state fresh. Since Gregor is restarting, it is very slow to respond to this request.
4.) We had some bogus timeout set on this call of 5 seconds, and so it could easily miss this timeout in the restart scenario.
5.) `freshSync` clears the local state before hearing back from the server, so if the server call returns an error then we are left with a blank local state. 
6.) `OnConnect` did not fail out if the Gregor state sync routine returns an error, and so we are left fully connected to Gregor with a blank local state. This would only be fixable on a Gregor restart or local client restart.

Patch fixes this by doing the following:

1.) Failing out `OnConnect` if Gregor state sync fails.
2.) Increasing timeout on the call after a local state hash failure to the default of 30 seconds.
3.) Doesn't really affect anything after the first two, but we also don't clear the local state until hearing back from the server with no error. 

cc @buoyad @chrisnojima I think this should address the problems with getting a blank Gregor state back from `GetState`. 