### PR TITLE
fix mobile

### DIFF
--- a/shared/chat/conversation/messages/wrapper/shared.js
+++ b/shared/chat/conversation/messages/wrapper/shared.js
@@ -266,7 +266,7 @@ const styles = styleSheetCreate({
     },
     isElectron: {pointerEvents: 'none'},
     isMobile: {
-      right: -sendIndicatorWidth,
+      right: -18,
     },
   }),
   textContainer: {

--- a/shared/common-adapters/meta.js
+++ b/shared/common-adapters/meta.js
@@ -39,7 +39,7 @@ const Meta = (props: Props) => (
       style={collapseStyles([
         styles.text,
         props.color ? {color: props.color} : null,
-        props.size === 'Small' ? {fontSize: 10, lineHeight: '12px'} : null,
+        props.size === 'Small' ? platformStyles({common: {fontSize: 10, lineHeight: 12}}) : null,
       ])}
     >
       {props.noUppercase ? props.title : props.title.toUpperCase()}


### PR DESCRIPTION
1. Red box on mobile due to lineheight
1. Send animation totally offscreen

@keybase/react-hackers 
cc: @cecileboucheron this was broken in your styling changes.
you can't pass a lineheight string to react native. use platformStyles to do this automatically