### PR TITLE
Remove VersionErrors from storage when our client is able to understand them

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -406,6 +406,9 @@ func (b *Boxer) unbox(ctx context.Context, boxed chat1.MessageBoxed,
 			b.Debug(ctx, "error unboxing message version: %v", boxed.Version)
 		}
 		return res, err
+	// NOTE: When adding new versions here, you must also update
+	// chat1/extras.go so MessageUnboxedError.ParseableVersion understands the
+	// new max version
 	default:
 		return nil,
 			NewPermanentUnboxingError(NewMessageBoxedVersionError(boxed.Version))
@@ -557,6 +560,9 @@ func (b *Boxer) unboxV1(ctx context.Context, boxed chat1.MessageBoxed,
 			KbfsCryptKeysUsed: hp.KbfsCryptKeysUsed,
 			Rtime:             gregor1.ToTime(b.clock.Now()),
 		}
+	// NOTE: When adding new versions here, you must also update
+	// chat1/extras.go so MessageUnboxedError.ParseableVersion understands the
+	// new max version
 	default:
 		return nil,
 			NewPermanentUnboxingError(NewHeaderVersionError(headerVersion,
@@ -586,6 +592,9 @@ func (b *Boxer) unboxV1(ctx context.Context, boxed chat1.MessageBoxed,
 		switch bodyVersion {
 		case chat1.BodyPlaintextVersion_V1:
 			body = bodyVersioned.V1().MessageBody
+		// NOTE: When adding new versions here, you must also update
+		// chat1/extras.go so MessageUnboxedError.ParseableVersion understands the
+		// new max version
 		default:
 			return nil,
 				NewPermanentUnboxingError(NewBodyVersionError(bodyVersion,
@@ -794,6 +803,9 @@ func (b *Boxer) unversionHeaderMBV2(ctx context.Context, headerVersioned chat1.H
 			EphemeralMetadata: hp.EphemeralMetadata,
 			Rtime:             gregor1.ToTime(b.clock.Now()),
 		}, hp.BodyHash, nil
+	// NOTE: When adding new versions here, you must also update
+	// chat1/extras.go so MessageUnboxedError.ParseableVersion understands the
+	// new max version
 	default:
 		return chat1.MessageClientHeaderVerified{}, nil,
 			NewPermanentUnboxingError(NewHeaderVersionError(headerVersion,
@@ -809,6 +821,9 @@ func (b *Boxer) unversionBody(ctx context.Context, bodyVersioned chat1.BodyPlain
 	switch bodyVersion {
 	case chat1.BodyPlaintextVersion_V1:
 		return bodyVersioned.V1().MessageBody, nil
+	// NOTE: When adding new versions here, you must also update
+	// chat1/extras.go so MessageUnboxedError.ParseableVersion understands the
+	// new max version
 	default:
 		return chat1.MessageBody{},
 			NewPermanentUnboxingError(NewBodyVersionError(bodyVersion,
@@ -1560,6 +1575,9 @@ func (b *Boxer) verifyMessageV1(ctx context.Context, header chat1.HeaderPlaintex
 	switch headerVersion {
 	case chat1.HeaderPlaintextVersion_V1:
 		return b.verifyMessageHeaderV1(ctx, header.V1(), msg, skipBodyVerification)
+	// NOTE: When adding new versions here, you must also update
+	// chat1/extras.go so MessageUnboxedError.ParseableVersion understands the
+	// new max version
 	default:
 		return verifyMessageRes{},
 			NewPermanentUnboxingError(NewHeaderVersionError(headerVersion,

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -90,6 +90,9 @@ func (b *Boxer) makeErrorMessage(ctx context.Context, msg chat1.MessageBoxed, er
 	e := chat1.MessageUnboxedError{
 		ErrType:            err.ExportType(),
 		ErrMsg:             err.Error(),
+		VersionKind:        err.VersionKind(),
+		VersionNumber:      err.VersionNumber(),
+		IsCritical:         err.IsCritical(),
 		MessageID:          msg.GetMessageID(),
 		MessageType:        msg.GetMessageType(),
 		Ctime:              msg.ServerHeader.Ctime,

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -1569,3 +1569,72 @@ func TestExplodingMessageUnbox(t *testing.T) {
 	require.NotNil(t, unboxed.EphemeralMetadata())
 	require.Equal(t, msg.EphemeralMetadata().Lifetime, unboxed.EphemeralMetadata().Lifetime)
 }
+
+func TestVersionErrorBasic(t *testing.T) {
+	// Test basic functionality
+	maxMessageBoxedVersion := chat1.MaxMessageBoxedVersion
+	err := NewMessageBoxedVersionError(maxMessageBoxedVersion)
+	e := chat1.MessageUnboxedError{
+		ErrType: err.ExportType(),
+		ErrMsg:  err.Error(),
+	}
+	require.True(t, e.ParseableVersion())
+
+	// not recoverable until we bump the max
+	err = NewMessageBoxedVersionError(maxMessageBoxedVersion + 1)
+	e = chat1.MessageUnboxedError{
+		ErrType: err.ExportType(),
+		ErrMsg:  err.Error(),
+	}
+	require.False(t, e.ParseableVersion())
+
+	chat1.MaxMessageBoxedVersion = maxMessageBoxedVersion + 1
+	defer func() { chat1.MaxMessageBoxedVersion = maxMessageBoxedVersion }()
+	require.True(t, e.ParseableVersion())
+}
+
+func TestVersionError(t *testing.T) {
+	tc, boxer := setupChatTest(t, "box")
+	defer tc.Cleanup()
+
+	// These tests will fail when we update the boxer code to accept new
+	// maximums. This forces
+	// chat1/extras.go#MessageUnboxedError.ParseableVersion to stay up to date
+	// for it's max accepted versions. Vx__ will also have to be updated in the
+	// checks below
+	assertErr := func(err UnboxingError) {
+		require.Error(t, err)
+		typ := err.ExportType()
+		switch typ {
+		case chat1.MessageUnboxedErrorType_BADVERSION, chat1.MessageUnboxedErrorType_BADVERSION_CRITICAL:
+			// pass
+		default:
+			t.Fatal(t, "invalid error type: ", typ)
+		}
+
+		e := chat1.MessageUnboxedError{
+			ErrType: err.ExportType(),
+			ErrMsg:  err.Error(),
+		}
+		require.False(t, e.ParseableVersion())
+	}
+	maxMessageBoxedVersion := chat1.MaxMessageBoxedVersion + 1
+	maxHeaderVersion := chat1.MaxHeaderVersion + 1
+	maxBodyVersion := chat1.MaxBodyVersion + 1
+
+	key := cryptKey(t)
+	t.Logf("unbox")
+	_, err := boxer.unbox(context.Background(), chat1.MessageBoxed{Version: maxMessageBoxedVersion},
+		chat1.ConversationMembersType_TEAM, key, nil)
+	assertErr(err)
+
+	t.Logf("unversionHeaderMBV2")
+	hv2 := chat1.HeaderPlaintextUnsupported{}
+	_, _, err = boxer.unversionHeaderMBV2(context.Background(), chat1.HeaderPlaintext{Version__: maxHeaderVersion, V2__: &hv2})
+	assertErr(err)
+
+	t.Logf("unversionBody")
+	bv2 := chat1.BodyPlaintextUnsupported{}
+	_, err = boxer.unversionBody(context.Background(), chat1.BodyPlaintext{Version__: maxBodyVersion, V2__: &bv2})
+	assertErr(err)
+}

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -1571,7 +1571,8 @@ func TestExplodingMessageUnbox(t *testing.T) {
 }
 
 func TestVersionErrorBasic(t *testing.T) {
-	// Test basic functionality
+	// Test basic functionality for parsing the error message
+	// TODO remove this when we drop parsing
 	maxMessageBoxedVersion := chat1.MaxMessageBoxedVersion
 	err := NewMessageBoxedVersionError(maxMessageBoxedVersion)
 	e := chat1.MessageUnboxedError{
@@ -1579,6 +1580,16 @@ func TestVersionErrorBasic(t *testing.T) {
 		ErrMsg:  err.Error(),
 	}
 	require.True(t, e.ParseableVersion())
+
+	err2 := NewMessageBoxedVersionError(maxMessageBoxedVersion)
+	e2 := chat1.MessageUnboxedError{
+		ErrType:       err2.ExportType(),
+		ErrMsg:        err2.Error(),
+		VersionKind:   err2.VersionKind(),
+		VersionNumber: err2.VersionNumber(),
+		IsCritical:    err2.IsCritical(),
+	}
+	require.True(t, e2.ParseableVersion())
 
 	// not recoverable until we bump the max
 	err = NewMessageBoxedVersionError(maxMessageBoxedVersion + 1)

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -192,6 +192,8 @@ type VersionError struct {
 	Critical bool
 }
 
+// NOTE: If the error message here changes format,
+// chat1/extras.go#ParseableVersion must also be changed to match.
 func (e VersionError) Error() string {
 	return fmt.Sprintf("Unable to decrypt because current client is out of date. Please update your version of Keybase! Chat version error: [ unhandled: %s version: %d critical: %v ]", e.Kind, e.Version, e.Critical)
 }
@@ -205,7 +207,7 @@ func (e VersionError) ExportType() chat1.MessageUnboxedErrorType {
 
 func NewMessageBoxedVersionError(version chat1.MessageBoxedVersion) VersionError {
 	return VersionError{
-		Kind:     "messageboxed",
+		Kind:     chat1.VersionErrorMessageBoxed,
 		Version:  int(version),
 		Critical: true,
 	}
@@ -214,7 +216,7 @@ func NewMessageBoxedVersionError(version chat1.MessageBoxedVersion) VersionError
 func NewHeaderVersionError(version chat1.HeaderPlaintextVersion,
 	defaultHeader chat1.HeaderPlaintextUnsupported) VersionError {
 	return VersionError{
-		Kind:     "header",
+		Kind:     chat1.VersionErrorHeader,
 		Version:  int(version),
 		Critical: defaultHeader.Mi.Crit,
 	}
@@ -222,7 +224,7 @@ func NewHeaderVersionError(version chat1.HeaderPlaintextVersion,
 
 func NewBodyVersionError(version chat1.BodyPlaintextVersion, defaultBody chat1.BodyPlaintextUnsupported) VersionError {
 	return VersionError{
-		Kind:     "body",
+		Kind:     chat1.VersionErrorBody,
 		Version:  int(version),
 		Critical: defaultBody.Mi.Crit,
 	}

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -261,7 +261,7 @@ func (e VersionError) IsCritical() bool {
 
 func NewMessageBoxedVersionError(version chat1.MessageBoxedVersion) VersionError {
 	return VersionError{
-		Kind:     chat1.VersionErrorMessageBoxed,
+		Kind:     string(chat1.VersionErrorMessageBoxed),
 		Version:  int(version),
 		Critical: true,
 	}
@@ -270,7 +270,7 @@ func NewMessageBoxedVersionError(version chat1.MessageBoxedVersion) VersionError
 func NewHeaderVersionError(version chat1.HeaderPlaintextVersion,
 	defaultHeader chat1.HeaderPlaintextUnsupported) VersionError {
 	return VersionError{
-		Kind:     chat1.VersionErrorHeader,
+		Kind:     string(chat1.VersionErrorHeader),
 		Version:  int(version),
 		Critical: defaultHeader.Mi.Crit,
 	}
@@ -278,7 +278,7 @@ func NewHeaderVersionError(version chat1.HeaderPlaintextVersion,
 
 func NewBodyVersionError(version chat1.BodyPlaintextVersion, defaultBody chat1.BodyPlaintextUnsupported) VersionError {
 	return VersionError{
-		Kind:     chat1.VersionErrorBody,
+		Kind:     string(chat1.VersionErrorBody),
 		Version:  int(version),
 		Critical: defaultBody.Mi.Crit,
 	}

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -897,7 +897,14 @@ func (s *Storage) FetchMessages(ctx context.Context, convID chat1.ConversationID
 			}
 		}
 		sres = rc.Result()
-		res = append(res, &sres[0])
+		msg := &sres[0]
+
+		// If we have a versioning error but our client now understands the new
+		// version, don't return the error message
+		if msg.IsError() && msg.Error().ParseableVersion() {
+			msg = nil
+		}
+		res = append(res, msg)
 	}
 
 	return res, nil

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -339,12 +339,10 @@ func MessageUnboxedDebugLines(ms []MessageUnboxed) string {
 	return strings.Join(MessageUnboxedDebugStrings(ms), "\n")
 }
 
-type VersionKind string
-
 const (
 	VersionErrorMessageBoxed VersionKind = "messageboxed"
-	VersionErrorHeader                   = "header"
-	VersionErrorBody                     = "body"
+	VersionErrorHeader       VersionKind = "header"
+	VersionErrorBody         VersionKind = "body"
 )
 
 // NOTE: these values correspond to the maximum accepted values in
@@ -364,10 +362,10 @@ func (m MessageUnboxedError) ParseableVersion() bool {
 		return false
 	}
 
-	kind := m.VersionKind()
-	version := m.VersionNumber()
-
-	// This error was stored from an old client, we have parse out the info we need from the error message.
+	kind := m.VersionKind
+	version := m.VersionNumber
+	// This error was stored from an old client, we have parse out the info we
+	// need from the error message.
 	// TODO remove this check once it has be live for a few cycles.
 	if kind == "" && version == 0 {
 		re := regexp.MustCompile(`.* Chat version error: \[ unhandled: (\w+) version: (\d+) .*\]`)
@@ -376,6 +374,7 @@ func (m MessageUnboxedError) ParseableVersion() bool {
 			return false
 		}
 		kind = VersionKind(matches[1])
+		var err error
 		version, err = strconv.Atoi(matches[2])
 		if err != nil {
 			return false

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -339,10 +339,12 @@ func MessageUnboxedDebugLines(ms []MessageUnboxed) string {
 	return strings.Join(MessageUnboxedDebugStrings(ms), "\n")
 }
 
+type VersionKind string
+
 const (
-	VersionErrorMessageBoxed = "messageboxed"
-	VersionErrorHeader       = "header"
-	VersionErrorBody         = "body"
+	VersionErrorMessageBoxed VersionKind = "messageboxed"
+	VersionErrorHeader                   = "header"
+	VersionErrorBody                     = "body"
 )
 
 // NOTE: these values correspond to the maximum accepted values in
@@ -352,7 +354,8 @@ var MaxMessageBoxedVersion MessageBoxedVersion = MessageBoxedVersion_V3
 var MaxHeaderVersion HeaderPlaintextVersion = HeaderPlaintextVersion_V1
 var MaxBodyVersion BodyPlaintextVersion = BodyPlaintextVersion_V1
 
-// Check if this error has a version that is now able to be understood by our client.
+// ParseableVersion checks if this error has a version that is now able to be
+// understood by our client.
 func (m MessageUnboxedError) ParseableVersion() bool {
 	switch m.ErrType {
 	case MessageUnboxedErrorType_BADVERSION, MessageUnboxedErrorType_BADVERSION_CRITICAL:
@@ -361,16 +364,24 @@ func (m MessageUnboxedError) ParseableVersion() bool {
 		return false
 	}
 
-	re := regexp.MustCompile(`.* Chat version error: \[ unhandled: (\w+) version: (\d+) .*\]`)
-	matches := re.FindStringSubmatch(m.ErrMsg)
-	if len(matches) != 3 {
-		return false
+	kind := m.VersionKind()
+	version := m.VersionNumber()
+
+	// This error was stored from an old client, we have parse out the info we need from the error message.
+	// TODO remove this check once it has be live for a few cycles.
+	if kind == "" && version == 0 {
+		re := regexp.MustCompile(`.* Chat version error: \[ unhandled: (\w+) version: (\d+) .*\]`)
+		matches := re.FindStringSubmatch(m.ErrMsg)
+		if len(matches) != 3 {
+			return false
+		}
+		kind = VersionKind(matches[1])
+		version, err = strconv.Atoi(matches[2])
+		if err != nil {
+			return false
+		}
 	}
-	kind := matches[1]
-	version, err := strconv.Atoi(matches[2])
-	if err != nil {
-		return false
-	}
+
 	var maxVersion int
 	switch kind {
 	case VersionErrorMessageBoxed:

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -336,6 +337,52 @@ func MessageUnboxedDebugList(ms []MessageUnboxed) string {
 
 func MessageUnboxedDebugLines(ms []MessageUnboxed) string {
 	return strings.Join(MessageUnboxedDebugStrings(ms), "\n")
+}
+
+const (
+	VersionErrorMessageBoxed = "messageboxed"
+	VersionErrorHeader       = "header"
+	VersionErrorBody         = "body"
+)
+
+// NOTE: these values correspond to the maximum accepted values in
+// chat/boxer.go. If these values are changed, they must also be accepted
+// there.
+var MaxMessageBoxedVersion MessageBoxedVersion = MessageBoxedVersion_V3
+var MaxHeaderVersion HeaderPlaintextVersion = HeaderPlaintextVersion_V1
+var MaxBodyVersion BodyPlaintextVersion = BodyPlaintextVersion_V1
+
+// Check if this error has a version that is now able to be understood by our client.
+func (m MessageUnboxedError) ParseableVersion() bool {
+	switch m.ErrType {
+	case MessageUnboxedErrorType_BADVERSION, MessageUnboxedErrorType_BADVERSION_CRITICAL:
+		// only applies to these types
+	default:
+		return false
+	}
+
+	re := regexp.MustCompile(`.* Chat version error: \[ unhandled: (\w+) version: (\d+) .*\]`)
+	matches := re.FindStringSubmatch(m.ErrMsg)
+	if len(matches) != 3 {
+		return false
+	}
+	kind := matches[1]
+	version, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return false
+	}
+	var maxVersion int
+	switch kind {
+	case VersionErrorMessageBoxed:
+		maxVersion = int(MaxMessageBoxedVersion)
+	case VersionErrorHeader:
+		maxVersion = int(MaxHeaderVersion)
+	case VersionErrorBody:
+		maxVersion = int(MaxBodyVersion)
+	default:
+		return false
+	}
+	return maxVersion >= version
 }
 
 func (m MessageUnboxedValid) AsDeleteHistory() (res MessageDeleteHistory, err error) {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -11,6 +11,12 @@ import (
 	context "golang.org/x/net/context"
 )
 
+type VersionKind string
+
+func (o VersionKind) DeepCopy() VersionKind {
+	return o
+}
+
 type MessageText struct {
 	Body string `codec:"body" json:"body"`
 }
@@ -2351,6 +2357,9 @@ func (e MessageUnboxedErrorType) String() string {
 type MessageUnboxedError struct {
 	ErrType            MessageUnboxedErrorType `codec:"errType" json:"errType"`
 	ErrMsg             string                  `codec:"errMsg" json:"errMsg"`
+	VersionKind        VersionKind             `codec:"versionKind" json:"versionKind"`
+	VersionNumber      int                     `codec:"versionNumber" json:"versionNumber"`
+	IsCritical         bool                    `codec:"isCritical" json:"isCritical"`
 	SenderUsername     string                  `codec:"senderUsername" json:"senderUsername"`
 	SenderDeviceName   string                  `codec:"senderDeviceName" json:"senderDeviceName"`
 	SenderDeviceType   string                  `codec:"senderDeviceType" json:"senderDeviceType"`
@@ -2366,6 +2375,9 @@ func (o MessageUnboxedError) DeepCopy() MessageUnboxedError {
 	return MessageUnboxedError{
 		ErrType:            o.ErrType.DeepCopy(),
 		ErrMsg:             o.ErrMsg,
+		VersionKind:        o.VersionKind.DeepCopy(),
+		VersionNumber:      o.VersionNumber,
+		IsCritical:         o.IsCritical,
 		SenderUsername:     o.SenderUsername,
 		SenderDeviceName:   o.SenderDeviceName,
 		SenderDeviceType:   o.SenderDeviceType,

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -6,6 +6,8 @@ protocol local {
   import idl "common.avdl";
   import idl "chat_ui.avdl";
 
+  @typedef("string") record VersionKind {}
+
   record MessageText {
     string body;
   }
@@ -392,6 +394,9 @@ protocol local {
   record MessageUnboxedError {
     MessageUnboxedErrorType errType;
     string errMsg;
+    VersionKind versionKind;
+    int versionNumber;
+    boolean isCritical;
     string senderUsername;
     string senderDeviceName;
     string senderDeviceType;

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -616,7 +616,7 @@ export type MessageType =
   | 13 // REACTION_13
 
 export type MessageUnboxed = {state: 1, valid: ?MessageUnboxedValid} | {state: 2, error: ?MessageUnboxedError} | {state: 3, outbox: ?OutboxRecord} | {state: 4, placeholder: ?MessageUnboxedPlaceholder}
-export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, senderUsername: String, senderDeviceName: String, senderDeviceType: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time, isEphemeral: Boolean, isEphemeralExpired: Boolean, etime: Gregor1.Time}>
+export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, versionKind: VersionKind, versionNumber: Int, isCritical: Boolean, senderUsername: String, senderDeviceName: String, senderDeviceType: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time, isEphemeral: Boolean, isEphemeralExpired: Boolean, etime: Gregor1.Time}>
 export type MessageUnboxedErrorType =
   | 0 // MISC_0
   | 1 // BADVERSION_CRITICAL_1
@@ -808,6 +808,7 @@ export type UnverifiedInboxUIItem = $ReadOnly<{convID: String, name: String, vis
 export type UnverifiedInboxUIItemMetadata = $ReadOnly<{channelName: String, headline: String, snippet: String, writerNames?: ?Array<String>, resetParticipants?: ?Array<String>}>
 export type UnverifiedInboxUIItems = $ReadOnly<{items?: ?Array<UnverifiedInboxUIItem>, pagination?: ?UIPagination, offline: Boolean}>
 export type UpdateConversationMembership = $ReadOnly<{inboxVers: InboxVers, joined?: ?Array<ConversationMember>, removed?: ?Array<ConversationMember>, reset?: ?Array<ConversationMember>, previewed?: ?Array<ConversationID>, unreadUpdate?: ?UnreadUpdate, unreadUpdates?: ?Array<UnreadUpdate>}>
+export type VersionKind = String
 type ChatUiChatConfirmChannelDeleteResult = Boolean
 type LocalDeleteConversationLocalResult = DeleteConversationLocalRes
 type LocalDownloadAttachmentLocalResult = DownloadAttachmentLocalRes

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -23,6 +23,12 @@
   "types": [
     {
       "type": "record",
+      "name": "VersionKind",
+      "fields": [],
+      "typedef": "string"
+    },
+    {
+      "type": "record",
       "name": "MessageText",
       "fields": [
         {
@@ -1173,6 +1179,18 @@
         {
           "type": "string",
           "name": "errMsg"
+        },
+        {
+          "type": "VersionKind",
+          "name": "versionKind"
+        },
+        {
+          "type": "int",
+          "name": "versionNumber"
+        },
+        {
+          "type": "boolean",
+          "name": "isCritical"
         },
         {
           "type": "string",

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -616,7 +616,7 @@ export type MessageType =
   | 13 // REACTION_13
 
 export type MessageUnboxed = {state: 1, valid: ?MessageUnboxedValid} | {state: 2, error: ?MessageUnboxedError} | {state: 3, outbox: ?OutboxRecord} | {state: 4, placeholder: ?MessageUnboxedPlaceholder}
-export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, senderUsername: String, senderDeviceName: String, senderDeviceType: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time, isEphemeral: Boolean, isEphemeralExpired: Boolean, etime: Gregor1.Time}>
+export type MessageUnboxedError = $ReadOnly<{errType: MessageUnboxedErrorType, errMsg: String, versionKind: VersionKind, versionNumber: Int, isCritical: Boolean, senderUsername: String, senderDeviceName: String, senderDeviceType: String, messageID: MessageID, messageType: MessageType, ctime: Gregor1.Time, isEphemeral: Boolean, isEphemeralExpired: Boolean, etime: Gregor1.Time}>
 export type MessageUnboxedErrorType =
   | 0 // MISC_0
   | 1 // BADVERSION_CRITICAL_1
@@ -808,6 +808,7 @@ export type UnverifiedInboxUIItem = $ReadOnly<{convID: String, name: String, vis
 export type UnverifiedInboxUIItemMetadata = $ReadOnly<{channelName: String, headline: String, snippet: String, writerNames?: ?Array<String>, resetParticipants?: ?Array<String>}>
 export type UnverifiedInboxUIItems = $ReadOnly<{items?: ?Array<UnverifiedInboxUIItem>, pagination?: ?UIPagination, offline: Boolean}>
 export type UpdateConversationMembership = $ReadOnly<{inboxVers: InboxVers, joined?: ?Array<ConversationMember>, removed?: ?Array<ConversationMember>, reset?: ?Array<ConversationMember>, previewed?: ?Array<ConversationID>, unreadUpdate?: ?UnreadUpdate, unreadUpdates?: ?Array<UnreadUpdate>}>
+export type VersionKind = String
 type ChatUiChatConfirmChannelDeleteResult = Boolean
 type LocalDeleteConversationLocalResult = DeleteConversationLocalRes
 type LocalDownloadAttachmentLocalResult = DownloadAttachmentLocalRes


### PR DESCRIPTION
When we bump a `MessageBoxed`/`Header`/`Body` versions we store a `PermanentUnboxingError` on old clients since they cannot yet understand these messages. When these clients update, we want them to try to refetch the message from the server since they can now try to unboxed.