### PR TITLE
Force wallclock time for ephemeral calculations

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -555,7 +555,7 @@ func (b *Boxer) unboxV1(ctx context.Context, boxed chat1.MessageBoxed,
 			OutboxID:          hp.OutboxID,
 			OutboxInfo:        hp.OutboxInfo,
 			KbfsCryptKeysUsed: hp.KbfsCryptKeysUsed,
-			Rtime:             gregor1.ToTime(b.clock.Now()),
+			Rtime:             gregor1.ToTime(keybase1.ForceWallClock(b.clock.Now())),
 		}
 	default:
 		return nil,
@@ -792,7 +792,7 @@ func (b *Boxer) unversionHeaderMBV2(ctx context.Context, headerVersioned chat1.H
 			OutboxInfo:        hp.OutboxInfo,
 			KbfsCryptKeysUsed: hp.KbfsCryptKeysUsed,
 			EphemeralMetadata: hp.EphemeralMetadata,
-			Rtime:             gregor1.ToTime(b.clock.Now()),
+			Rtime:             gregor1.ToTime(keybase1.ForceWallClock(b.clock.Now())),
 		}, hp.BodyHash, nil
 	default:
 		return chat1.MessageClientHeaderVerified{}, nil,

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/keybase/client/go/erasablekv"
 	"github.com/keybase/client/go/libkb"
@@ -108,7 +107,7 @@ func (s *DeviceEKStorage) Put(ctx context.Context, generation keybase1.EkGenerat
 	}
 	// Fill in this puppy.
 	if deviceEK.Metadata.DeviceCtime == 0 {
-		deviceEK.Metadata.DeviceCtime = keybase1.ToTime(time.Now())
+		deviceEK.Metadata.DeviceCtime = keybase1.ToTime(libkb.WallClockNow())
 	}
 	err = s.storage.Put(ctx, key, deviceEK)
 	if err != nil {
@@ -293,7 +292,7 @@ func (s *DeviceEKStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.Me
 	// we can complete deletions offline.
 	var now keybase1.Time
 	if merkleRoot.IsNil() {
-		now = keybase1.ToTime(time.Now())
+		now = keybase1.ToTime(libkb.WallClockNow())
 	} else {
 		now = keybase1.TimeFromSeconds(merkleRoot.Ctime())
 	}

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -328,7 +328,7 @@ type teamEKGenCacheEntry struct {
 func (e *EKLib) newCacheEntry(generation keybase1.EkGeneration) *teamEKGenCacheEntry {
 	return &teamEKGenCacheEntry{
 		Generation: generation,
-		Ctime:      keybase1.TimeFromSeconds(time.Now().Unix()),
+		Ctime:      keybase1.ToTime(libkb.WallClockNow()),
 	}
 }
 
@@ -341,7 +341,7 @@ func (e *EKLib) isEntryValid(val interface{}) (*teamEKGenCacheEntry, bool) {
 	if !ok || cacheEntry == nil {
 		return nil, false
 	}
-	return cacheEntry, time.Now().Sub(cacheEntry.Ctime.Time()) < time.Duration(cacheEntryLifetimeSecs*time.Second)
+	return cacheEntry, libkb.WallClockNow().Sub(cacheEntry.Ctime.Time()) < time.Duration(cacheEntryLifetimeSecs*time.Second)
 }
 
 func (e *EKLib) PurgeTeamEKGenCache(teamID keybase1.TeamID, generation keybase1.EkGeneration) {

--- a/go/libkb/nist.go
+++ b/go/libkb/nist.go
@@ -5,10 +5,11 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
-	"github.com/keybase/client/go/protocol/keybase1"
-	context "golang.org/x/net/context"
 	"sync"
 	"time"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
 )
 
 //
@@ -122,7 +123,7 @@ func durationToSeconds(d time.Duration) int64 {
 func (n *NIST) IsStillValid() (bool, time.Duration) {
 	n.RLock()
 	defer n.RUnlock()
-	now := ForceWallClock(n.G().Clock().Now())
+	now := keybase1.ForceWallClock(n.G().Clock().Now())
 	diff := n.expiresAt.Sub(now) - nistExpirationMargin
 	return (diff > 0), diff
 }
@@ -293,7 +294,7 @@ func (n *NIST) generate(ctx context.Context, uid keybase1.UID, deviceID keybase1
 
 	n.long = longTmp
 	n.short = shortTmp
-	n.expiresAt = ForceWallClock(expires)
+	n.expiresAt = keybase1.ForceWallClock(expires)
 
 	return nil
 }

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -860,8 +860,6 @@ func NoiseXOR(secret [32]byte, noise NoiseBytes) ([]byte, error) {
 	return xor, nil
 }
 
-// ForceWallClock takes a multi-personality Go time and converts it to
-// a regular old WallClock time.
-func ForceWallClock(t time.Time) time.Time {
-	return t.Round(0)
+func WallClockNow() time.Time {
+	return keybase1.ForceWallClock(time.Now())
 }

--- a/go/libkb/util_test.go
+++ b/go/libkb/util_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -149,5 +150,5 @@ func hasMonotonicClock(t time.Time) bool {
 func TestForceWallClock(t *testing.T) {
 	n := time.Now()
 	require.True(t, hasMonotonicClock(n))
-	require.False(t, hasMonotonicClock(ForceWallClock(n)))
+	require.False(t, hasMonotonicClock(keybase1.ForceWallClock(n)))
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -420,6 +420,7 @@ func (m MessageUnboxedValid) Etime() gregor1.Time {
 }
 
 func (m MessageUnboxedValid) RemainingEphemeralLifetime(now time.Time) time.Duration {
+	now = keybase1.ForceWallClock(now)
 	remainingLifetime := m.Etime().Time().Sub(now).Round(time.Second)
 	return remainingLifetime
 }
@@ -428,6 +429,7 @@ func (m MessageUnboxedValid) IsEphemeralExpired(now time.Time) bool {
 	if !m.IsEphemeral() {
 		return false
 	}
+	now = keybase1.ForceWallClock(now)
 	etime := m.Etime().Time()
 	// There are a few ways a message could be considered expired
 	// 1. Our body is already nil (deleted from DELETEHISTORY or a server purge)
@@ -441,6 +443,7 @@ func (m MessageUnboxedValid) HideExplosion(now time.Time) bool {
 		return false
 	}
 	etime := m.Etime()
+	now = keybase1.ForceWallClock(now)
 	return etime.Time().Add(explosionLifetime).Before(now)
 }
 
@@ -536,13 +539,15 @@ func (m MessageBoxed) Etime() gregor1.Time {
 	if metadata == nil {
 		return 0
 	}
-	return Etime(metadata.Lifetime, m.ServerHeader.Ctime, gregor1.ToTime(time.Now()), m.ServerHeader.Now)
+	now := gregor1.ToTime(keybase1.ForceWallClock(time.Now()))
+	return Etime(metadata.Lifetime, m.ServerHeader.Ctime, now, m.ServerHeader.Now)
 }
 
 func (m MessageBoxed) IsEphemeralExpired(now time.Time) bool {
 	if !m.IsEphemeral() {
 		return false
 	}
+	now = keybase1.ForceWallClock(now)
 	etime := m.Etime().Time()
 	return m.EphemeralMetadata().ExplodedBy != nil || etime.Before(now) || etime.Equal(now)
 }
@@ -551,6 +556,7 @@ func (m MessageBoxed) HideExplosion(now time.Time) bool {
 	if !m.IsEphemeral() {
 		return false
 	}
+	now = keybase1.ForceWallClock(now)
 	etime := m.Etime()
 	return etime.Time().Add(explosionLifetime).Before(now)
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -693,6 +693,12 @@ func encode(b []byte) string {
 	return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "=")
 }
 
+// ForceWallClock takes a multi-personality Go time and converts it to
+// a regular old WallClock time.
+func ForceWallClock(t time.Time) time.Time {
+	return t.Round(0)
+}
+
 func FromTime(t Time) time.Time {
 	if t == 0 {
 		return time.Time{}


### PR DESCRIPTION
@buoyad noticed that an ephemeral message had reverted to the original lifetime on one of his devices after a few days had passed. After a db nuke, the remaining lifetime was calculated correctly. I _think_ that the issue was caused by his device having been asleep and then monotonic clock being off when he received the message, which looked like the server was trying to extend the lifetime so he defaulted to the original (signed) lifetime. 

we try to `ForceWallClock` time wherever we do ephemeral calculations (even if it's redundant in some places since we are deserializing/serializing a `time.Time`, it will hopefully prevent future bugs from happening) 