### PR TITLE
Explicitely clear API server uidmap cache to avoid cache race flake

### DIFF
--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -180,6 +180,9 @@ func (r *teamHandler) changeTeam(ctx context.Context, cli gregor1.IncomingInterf
 			continue
 		}
 
+		r.G().Log.CDebugf(ctx, "Checking reset badges: got total %d badges for team %q",
+			len(badges), row.Name)
+
 		// load this team and see if any of the badge users are active members
 		details, err := teams.Details(ctx, r.G(), row.Name, false)
 		if err != nil {

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -680,10 +680,7 @@ func TestTeamAfterDeleteUser(t *testing.T) {
 	bob.readChats(team, 1)
 }
 
-// TestTeamResetBadges checks that badges show up for admins
-// when a member of the team resets, and that they are dismissed
-// when the reset user is added.
-func TestTeamResetBadgesOnAdd(t *testing.T) {
+func testTeamResetBadgesAndDismiss(t *testing.T, readd bool) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
@@ -712,9 +709,17 @@ func TestTeamResetBadgesOnAdd(t *testing.T) {
 
 	// users[1] logs in after reset
 	tt.users[1].loginAfterReset()
+	clearServerUIDMapCache(tt.users[1].tc.G, t, []keybase1.UID{tt.users[1].uid})
 
-	// users[0] adds users[1] back to the team
-	tt.users[0].addTeamMember(teamName.String(), tt.users[1].username, keybase1.TeamRole_WRITER)
+	// Either re-adding or removing user from the team should clear
+	// the reset badge.
+	if readd {
+		// users[0] adds users[1] back to the team
+		tt.users[0].addTeamMember(teamName.String(), tt.users[1].username, keybase1.TeamRole_WRITER)
+	} else {
+		// users[0] removes users[1] from the team
+		tt.users[0].removeTeamMember(teamName.String(), tt.users[1].username)
+	}
 
 	// wait for badge state to have no teams w/ reset member
 	badgeState = tt.users[0].waitForBadgeStateWithReset(0)
@@ -725,44 +730,16 @@ func TestTeamResetBadgesOnAdd(t *testing.T) {
 	}
 }
 
+// TestTeamResetBadges checks that badges show up for admins
+// when a member of the team resets, and that they are dismissed
+// when the reset user is added.
+func TestTeamResetBadgesOnAdd(t *testing.T) {
+	testTeamResetBadgesAndDismiss(t, true)
+}
+
 // TestTeamResetBadgesOnRemove checks that badges show up for admins
 // when a member of the team resets, and that they are dismissed
 // when the reset user is removed.
 func TestTeamResetBadgesOnRemove(t *testing.T) {
-	tt := newTeamTester(t)
-	defer tt.cleanup()
-
-	tt.addUser("own")
-	tt.addUser("roo")
-
-	teamID, teamName := tt.users[0].createTeam2()
-	tt.users[0].kickTeamRekeyd()
-	tt.users[0].addTeamMember(teamName.String(), tt.users[1].username, keybase1.TeamRole_WRITER)
-	tt.users[1].reset()
-	tt.users[0].waitForTeamChangedGregor(teamID, keybase1.Seqno(2))
-	// wait for badge state to have 1 team w/ reset member
-	badgeState := tt.users[0].waitForBadgeStateWithReset(1)
-
-	// users[0] should be badged since users[1] reset
-	if len(badgeState.TeamsWithResetUsers) == 0 {
-		t.Fatal("TeamsWithResetUsers is empty after reset")
-	}
-	out := badgeState.TeamsWithResetUsers[0]
-	if out.Teamname != teamName.String() {
-		t.Errorf("badged team name: %s, expected %s", out.Teamname, teamName)
-	}
-	if out.Username != tt.users[1].username {
-		t.Errorf("badged user: %s, expected %s", out.Username, tt.users[1].username)
-	}
-
-	// users[0] removes users[1] from the team
-	tt.users[0].removeTeamMember(teamName.String(), tt.users[1].username)
-
-	// wait for badge state to have no teams w/ reset member
-	badgeState = tt.users[0].waitForBadgeStateWithReset(0)
-
-	// badge state should be cleared
-	if len(badgeState.TeamsWithResetUsers) != 0 {
-		t.Errorf("badge state for TeamsWithResetUsers not empty: %d", len(badgeState.TeamsWithResetUsers))
-	}
+	testTeamResetBadgesAndDismiss(t, false)
 }

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -818,6 +818,18 @@ func kickTeamRekeyd(g *libkb.GlobalContext, t libkb.TestingTB) {
 	require.NoError(t, err)
 }
 
+func clearServerUIDMapCache(g *libkb.GlobalContext, t libkb.TestingTB, uids []keybase1.UID) {
+	arg := libkb.NewAPIArg("user/names")
+	arg.SessionType = libkb.APISessionTypeNONE
+	arg.Args = libkb.HTTPArgs{
+		"uids":     libkb.S{Val: libkb.UidsToString(uids)},
+		"no_cache": libkb.B{Val: true},
+	}
+	t.Logf("Calling user/names with uids: %v and no_cache: true to clear serverside uidmap cache", uids)
+	_, err := g.API.Post(arg)
+	require.NoError(t, err)
+}
+
 func GetTeamForTestByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*teams.Team, error) {
 	return teams.Load(ctx, g, keybase1.LoadTeamArg{
 		Name:        name,


### PR DESCRIPTION
The race happens during the following (or similar) path:
1) user A does something that changes their eldest_seqno: e.g. resets or reprovisions after reset,
2) user B queries `user/names` endpoint *immediately* after.

Even though API request in (1) finishes (be it `key/multi` for reprovisioning, or the reset API), the serverside uidmap cache is still in flux because pubsub fire-and-forget is used to propagate the change across API server fleet - even if it's just one server on CI. So if a request to `user/names` is made quickly enough, server will still return the old value, also poisoning the clientside cache.

I went through several attempts at fixing this "properly" but considering that: 
1) it's a relatively obscure bug, and
2) it only affects CI, because any real operations on client don't trust uidmap.


I decided that ultimately forcing server to clear its cache during tests is the way to go. Serverside cache clearing is a side effect of calling `user/names` with `no-cache` parameter. Not only will the server always pull the latest value from the DB, but will also update its own cache while on it. So any subsequent `user/names` call from any context will be able to get proper data.

This `clearServerUIDMapCache` should probably be added in test user functions like `loginAfterReset`, but I'm still investigating which tests are affected. In some, I went nuclear and disabled uidmap cache entirely, where a more subtle fix like this one would be more adequate.