### PR TITLE
Animate exploding messages on desktop

### DIFF
--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -100,9 +100,9 @@ const mergeProps = (stateProps, dispatchProps, {measure}) => {
     measure,
     message,
     messageFailed: stateProps.messageFailed,
-    // `messageKey` must always be unique and immutable for the message
-    // or else it will wreak havoc on the conversation list view
-    messageKey: `${message.conversationIDKey}:${message.id}`,
+    // `messageKey` should be unique for the message as long
+    // as threads aren't switched
+    messageKey: `${message.conversationIDKey}:${Types.ordinalToNumber(message.ordinal)}`,
     messagePending: stateProps.messagePending,
     messageSent: stateProps.messageSent,
     onAuthorClick: () => dispatchProps._onAuthorClick(message.author),

--- a/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.desktop.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.desktop.js
@@ -39,7 +39,7 @@ class ExplodingHeightRetainer extends React.Component<Props, State> {
   }
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
-    return {children: copyChildren(nextProps.children)}
+    return nextProps.retainHeight ? null : {children: copyChildren(nextProps.children)}
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -131,7 +131,7 @@ const Ashes = (props: {doneExploding: boolean, exploded: boolean, explodedBy: ?s
   )
 }
 
-const maxFlameWidth = 50
+const maxFlameWidth = 20
 const FlameFront = (props: {height: number, stop: boolean}) => {
   const numBoxes = Math.ceil(props.height / 17)
   const children = []

--- a/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.desktop.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.desktop.js
@@ -46,7 +46,11 @@ class ExplodingHeightRetainer extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Props) {
     if (this.props.retainHeight) {
-      if (!prevProps.retainHeight && !this.timeoutID) {
+      if (!prevProps.retainHeight) {
+        if (this.timeoutID) {
+          clearTimeout(this.timeoutID)
+          this.timeoutID = null
+        }
         // destroy local copy of children when animation finishes
         this.setState({animating: true}, () => {
           this.timeoutID = setTimeout(

--- a/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.desktop.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.desktop.js
@@ -19,7 +19,7 @@ const explodedIllustrationUrl = urlsToImgSet({'68': explodedIllustration}, 68)
 const copyChildren = children =>
   React.Children.map(children, child => (child ? React.cloneElement(child) : child))
 
-const animationDuration = 1.5
+const animationDuration = 1
 
 const retainedHeights = {}
 
@@ -38,6 +38,7 @@ class ExplodingHeightRetainer extends React.Component<Props, State> {
   componentDidMount() {
     // remeasure if we are already exploded
     if (this.props.retainHeight && retainedHeights[this.props.messageKey] && this.props.measure) {
+      delete retainedHeights[this.props.messageKey]
       this.props.measure()
     }
   }
@@ -76,9 +77,9 @@ class ExplodingHeightRetainer extends React.Component<Props, State> {
           // to make sure we don't rewrap text when showing the animation
           this.props.retainHeight && {
             height: this.state.height,
+            overflow: 'hidden',
             paddingRight: 28,
             position: 'relative',
-            overflow: 'hidden',
           },
         ])}
       >
@@ -96,9 +97,9 @@ class ExplodingHeightRetainer extends React.Component<Props, State> {
 
 const AshBox = glamorous.div(props => ({
   '&.full-width': {
-    width: '100%',
     overflow: 'visible',
     transition: `width ${animationDuration}s ease-in-out`,
+    width: '100%',
   },
   backgroundColor: globalColors.white,
   backgroundImage: explodedIllustrationUrl,
@@ -139,7 +140,7 @@ const Ashes = (props: {doneExploding: boolean, exploded: boolean, explodedBy: ?s
 
 const maxFlameWidth = 20
 const FlameFront = (props: {height: number, stop: boolean}) => {
-  const numBoxes = Math.ceil(props.height / 17)
+  const numBoxes = Math.ceil(props.height / 15)
   const children = []
   for (let i = 0; i < numBoxes; i++) {
     children.push(<Flame key={i} stop={props.stop} />)
@@ -188,14 +189,13 @@ class Flame extends React.Component<{stop: boolean}, {color: string, width: numb
   render() {
     return (
       <Box
-        style={{
-          backgroundColor: this.state.color,
-          width: this.state.width,
-          height: 15,
-          marginTop: 1,
-          marginBottom: 1,
-          opacity: 0.9,
-        }}
+        style={collapseStyles([
+          {
+            backgroundColor: this.state.color,
+            width: this.state.width,
+          },
+          styles.flame,
+        ])}
       />
     )
   }
@@ -214,10 +214,16 @@ const styles = styleSheetCreate({
       whiteSpace: 'nowrap',
     },
   }),
+  flame: {
+    height: 17,
+    marginBottom: 1,
+    marginTop: 1,
+    opacity: 0.9,
+  },
   flameContainer: {
-    width: maxFlameWidth,
     position: 'absolute',
     right: -1 * maxFlameWidth,
+    width: maxFlameWidth,
   },
 })
 

--- a/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.js.flow
+++ b/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.js.flow
@@ -6,6 +6,7 @@ export type Props = {
   children?: React.Node,
   explodedBy: ?string,
   exploding: boolean,
+  measure: null | (() => void),
   messageKey: string,
   style?: StylesCrossPlatform,
   retainHeight: boolean,

--- a/shared/chat/conversation/messages/wrapper/index.js.flow
+++ b/shared/chat/conversation/messages/wrapper/index.js.flow
@@ -21,7 +21,7 @@ export type Props = {
   measure: null | (() => void),
   message: Types.MessageText | Types.MessageAttachment,
   messageFailed: boolean,
-  messageKey: string, // must always be unique and immutable for the message
+  messageKey: string,
   messagePending: boolean,
   messageSent: boolean,
   onRetry: null | (() => void),

--- a/shared/chat/conversation/messages/wrapper/shared.js
+++ b/shared/chat/conversation/messages/wrapper/shared.js
@@ -127,6 +127,7 @@ const RightSide = props => (
         <ExplodingHeightRetainer
           explodedBy={props.explodedBy}
           exploding={props.exploding}
+          measure={props.measure}
           messageKey={props.messageKey}
           style={styles.flexOneColumn}
           retainHeight={props.exploded || props.isExplodingUnreadable}


### PR DESCRIPTION
- Changes `ExplodingHeightRetainer` to throw away stored height on remount
  - Pipes `measure` through and uses `m.ordinal` instead of `m.id` to key the message

r? @keybase/react-hackers