### PR TITLE
Improve logging and fix early deletion bug

### DIFF
--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -104,7 +104,6 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 	var hasExploding bool
 	for i, msg := range msgs {
 		if !msg.IsValid() {
-			s.Debug(ctx, "skipping invalid msg: %v", msg.GetMessageID())
 			continue
 		}
 		mvalid := msg.Valid()
@@ -120,7 +119,9 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 				if nextPurgeTime == 0 || mvalid.Etime() < nextPurgeTime {
 					nextPurgeTime = mvalid.Etime()
 				}
-				s.Debug(ctx, "skipping unexpired ephemeral msg: %v, etime: %v, now: %v", msg.GetMessageID(), mvalid.Etime().Time(), s.clock.Now())
+				s.Debug(ctx, "skipping unexpired ephemeral msg: %v, etime: %v, serverCtime: %v, serverNow: %v, rtime: %v now: %v, ephemeralMetadata: %v",
+					msg.GetMessageID(), mvalid.Etime().Time(), mvalid.ServerHeader.Ctime.Time(),
+					mvalid.ServerHeader.Now.Time(), mvalid.ClientHeader.Rtime.Time(), s.clock.Now(), mvalid.EphemeralMetadata())
 			} else if mvalid.MessageBody.IsNil() {
 				// do nothing
 			} else {

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -301,7 +301,7 @@ func (s *DeviceEKStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.Me
 	keyMap := make(keyExpiryMap)
 	for generation, deviceEK := range cache {
 		var ctime keybase1.Time
-		// If we have a nil root _and_ a valid DeviceCtime, use that.If we're
+		// If we have a nil root _and_ a valid DeviceCtime, use that. If we're
 		// missing a DeviceCtime it's better to use the slightly off
 		// merkleCtime than a 0
 		if merkleRoot.IsNil() && deviceEK.Metadata.DeviceCtime > 0 {
@@ -312,7 +312,7 @@ func (s *DeviceEKStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.Me
 		keyMap[generation] = ctime
 	}
 
-	expired = getExpiredGenerations(keyMap, now)
+	expired = getExpiredGenerations(context.Background(), s.G(), keyMap, now)
 	epick := libkb.FirstErrorPicker{}
 	for _, generation := range expired {
 		epick.Push(s.delete(ctx, generation))

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -328,7 +328,7 @@ type teamEKGenCacheEntry struct {
 func (e *EKLib) newCacheEntry(generation keybase1.EkGeneration) *teamEKGenCacheEntry {
 	return &teamEKGenCacheEntry{
 		Generation: generation,
-		Ctime:      keybase1.TimeFromSeconds(time.Now().Unix()),
+		Ctime:      keybase1.ToTime(time.Now()),
 	}
 }
 

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -292,7 +292,7 @@ func (s *UserEKBoxStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.M
 		keyMap[generation] = userEKBoxed.Metadata.Ctime
 	}
 
-	expired = getExpiredGenerations(keyMap, keybase1.TimeFromSeconds(merkleRoot.Ctime()))
+	expired = getExpiredGenerations(context.Background(), s.G(), keyMap, keybase1.TimeFromSeconds(merkleRoot.Ctime()))
 	err = s.deleteMany(ctx, expired)
 	return expired, err
 }


### PR DESCRIPTION
Improves logging for ephemeral messages and catches a bug in key deletion where we were comparing the wrong units and deleting keys early. Device keys that were supposed to have an extended lifetime because of a gap in generations were deleted early