### PR TITLE
Change decimal convertors

### DIFF
--- a/go/client/cmd_wallet_send.go
+++ b/go/client/cmd_wallet_send.go
@@ -103,7 +103,7 @@ func (c *CmdWalletSend) Run() error {
 			return fmt.Errorf("Unable to get exchange rate for %q: %s", c.LocalCurrency, err)
 		}
 
-		amount, err = stellar.ConvertLocalToXLM(c.Amount, exchangeRate)
+		amount, err = stellar.ConvertOutsideToXLM(c.Amount, exchangeRate)
 		if err != nil {
 			return err
 		}

--- a/go/stellar/exchange.go
+++ b/go/stellar/exchange.go
@@ -1,47 +1,83 @@
 package stellar
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
+	"regexp"
 
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/stellar/go/amount"
 )
 
-func ConvertXLMToOutside(XLMAmount string, rate stellar1.OutsideExchangeRate) (localAmount string, err error) {
-	var zero big.Rat
-	rateRat := new(big.Rat)
-	_, ok := rateRat.SetString(rate.Rate)
-	if !ok {
-		return "", fmt.Errorf("error parsing exchange rate: %v", rate.Rate)
-	}
-	if rateRat.Cmp(&zero) == 0 {
-		return "", fmt.Errorf("zero-value exchange rate")
+// ConvertXLMToOutside converts an amount of lumens into an amount of outside currency.
+// The result is rounded to 7 digits past the decimal.
+// The rounding is arbitrary but expected to be sufficient precision.
+func ConvertXLMToOutside(XLMAmount string, rate stellar1.OutsideExchangeRate) (outsideAmount string, err error) {
+	rateRat, err := parseExchangeRate(rate.Rate)
+	if err != nil {
+		return "", err
 	}
 	amountInt64, err := amount.ParseInt64(XLMAmount)
 	if err != nil {
-		return "", fmt.Errorf("parsing amount to convert: %v", err)
+		return "", fmt.Errorf("parsing amount to convert: %q", err)
 	}
 	acc := big.NewRat(amountInt64, amount.One)
 	acc.Mul(acc, rateRat)
 	return acc.FloatString(7), nil
 }
 
-func ConvertLocalToXLM(localAmount string, rate stellar1.OutsideExchangeRate) (XLMAmount string, err error) {
-	var zero big.Rat
-	rateRat := new(big.Rat)
-	_, ok := rateRat.SetString(rate.Rate)
-	if !ok {
-		return "", fmt.Errorf("error parsing exchange rate: %v", rate.Rate)
-	}
-	if rateRat.Cmp(&zero) == 0 {
-		return "", fmt.Errorf("zero-value exchange rate")
-	}
-	amountInt64, err := amount.ParseInt64(localAmount)
+// ConvertOutsideToXLM converts an amount of outside currency into an amount of lumens.
+// The result is rounded to 7 digits past the decimal (which is what XLM supports).
+// The result returned can of a greater magnitude than XLM supports.
+func ConvertOutsideToXLM(outsideAmount string, rate stellar1.OutsideExchangeRate) (XLMAmount string, err error) {
+	rateRat, err := parseExchangeRate(rate.Rate)
 	if err != nil {
-		return "", fmt.Errorf("parsing amount to convert: %v", err)
+		return "", err
 	}
-	acc := big.NewRat(amountInt64, amount.One)
+	acc, err := parseDecimalStrict(outsideAmount)
+	if err != nil {
+		return "", fmt.Errorf("parsing amount to convert: %q", outsideAmount)
+	}
 	acc.Quo(acc, rateRat)
 	return acc.FloatString(7), nil
+}
+
+func parseExchangeRate(rate string) (*big.Rat, error) {
+	rateRat, err := parseDecimalStrict(rate)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing exchange rate: %q", rate)
+	}
+	sign := rateRat.Sign()
+	switch sign {
+	case 1:
+		return rateRat, nil
+	case 0:
+		return nil, errors.New("zero-value exchange rate")
+	case -1:
+		return nil, errors.New("negative exchange rate")
+	default:
+		return nil, fmt.Errorf("exchange rate of unknown sign (%v)", sign)
+	}
+}
+
+// Alow "-1", "1.", ".1", "1.1".
+// But not "." or "".
+var decimalStrictRE = regexp.MustCompile(`^-?((\d+\.?\d*)|(\d*\.?\d+))$`)
+
+// parseDecimalStrict parses a decimal number into a big rational.
+// Used instead of big.Rat.SetString because the latter accepts
+// additional formats like "1/2" and "1e10".
+func parseDecimalStrict(s string) (*big.Rat, error) {
+	if s == "" {
+		return nil, fmt.Errorf("expected decimal number but found empty string")
+	}
+	if !decimalStrictRE.MatchString(s) {
+		return nil, fmt.Errorf("expected decimal number: %s", s)
+	}
+	v, ok := new(big.Rat).SetString(s)
+	if !ok {
+		return nil, fmt.Errorf("expected decimal number: %s", s)
+	}
+	return v, nil
 }

--- a/go/stellar/exchange_test.go
+++ b/go/stellar/exchange_test.go
@@ -1,0 +1,190 @@
+package stellar
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/stretchr/testify/require"
+)
+
+var convertXLMToOutsideUnits = []struct {
+	ok   bool
+	rate string
+	xlm  string
+	out  string
+}{
+	{false, "", "1", ""},
+	{false, "1", "", ""},
+	{false, "0", "1", ""},
+	{false, "a", "1", ""},
+	{false, "1e10", "1", ""},
+	{false, "-1", "1", ""}, // negative exchange rate
+	// XLM amount too big
+	// skip negative variant because MIN_INT64 != -MAX_INT64
+	{false, "2", "922337203685.4775808", "skipneg"},
+	{false, "2", "0.47758071", ""}, // too many digits of precision for XLM
+
+	{true, "1", "0", "0.0000000"},
+	{true, "1", "1", "1.0000000"},
+	{true, "0.5", "1", "0.5000000"},
+	{true, "0.0000001", "1", "0.0000001"},
+	{true, ".75", "4294967290", "3221225467.5000000"},
+	{true, "2", "922337203685.4775807", "1844674407370.9551614"},
+}
+
+func TestConvertXLMToOutside(t *testing.T) {
+	for i, unit := range convertXLMToOutsideUnits {
+		for _, neg := range []bool{false, true} {
+			t.Logf("%v: %#v", i, unit)
+			s := unit.xlm
+			if neg {
+				s = "-" + s
+			}
+			y, err := ConvertXLMToOutside(s, stellar1.OutsideExchangeRate{
+				Currency: stellar1.OutsideCurrencyCode("PLN"),
+				Rate:     unit.rate,
+			})
+			if unit.out == "skipneg" {
+				continue
+			}
+			require.Equal(t, unit.ok, err == nil, "converted without error: (got err:%v)", err)
+			if unit.ok {
+				expect := unit.out
+				if neg && unit.xlm != "0" {
+					expect = "-" + expect
+				}
+				require.Equal(t, expect, y, "converted to outside amount")
+			}
+		}
+	}
+}
+
+var convertOutsideToXLMUnits = []struct {
+	ok      bool
+	rate    string
+	outside string
+	xlm     string
+}{
+	{false, "", "1", ""},
+	{false, "1", "", ""},
+	{false, "0", "1", ""},
+	{false, "a", "1", ""},
+	{false, "1e10", "1", ""},
+	{false, "-1", "1", ""}, // negative exchange rate
+
+	{true, "2", "0.47758071", "0.2387904"}, // many digits of precision are fine
+	{true, "1", "0", "0.0000000"},
+	{true, "1", "1", "1.0000000"},
+	{true, "0.5", "1", "2.0000000"},
+	{true, "0.0000001", "1", "10000000.0000000"},
+	{true, ".75", "4294967290", "5726623053.3333333"},
+	{true, "0.5", "922337203685.4775808", "1844674407370.9551616"}, // return can be greater than max XLM
+}
+
+func TestConvertOutsideToXLM(t *testing.T) {
+	for i, unit := range convertOutsideToXLMUnits {
+		for _, neg := range []bool{false, true} {
+			t.Logf("%v: %#v", i, unit)
+			s := unit.outside
+			if neg {
+				s = "-" + s
+			}
+			y, err := ConvertOutsideToXLM(s, stellar1.OutsideExchangeRate{
+				Currency: stellar1.OutsideCurrencyCode("PLN"),
+				Rate:     unit.rate,
+			})
+			require.Equal(t, unit.ok, err == nil, "converted without error: (got err:%v)", err)
+			if unit.ok {
+				expect := unit.xlm
+				if neg && unit.outside != "0" {
+					expect = "-" + expect
+				}
+				require.Equal(t, expect, y, "converted to xlm amount")
+			}
+		}
+	}
+}
+
+var decimalUnits = []struct {
+	ok  bool
+	s   string
+	val string
+}{
+	{false, "", ""},
+	{false, ".", ""},
+	{false, "-", ""},
+	{false, "1-", ""},
+	{false, ".1-", ""},
+	{false, ".-1", ""},
+	{false, "-1-", ""},
+	{false, "1a", ""},
+	{false, "a", ""},
+	{false, "a1", ""},
+	{false, "1.a", ""},
+	{false, "a.1", ""},
+	{false, ".1.", ""},
+	{false, "1e10", ""},
+	{false, "1,2", ""},
+	{false, "1,", ""},
+	{false, ",1", ""},
+	{false, "1/2", ""},
+	{false, "1b10", ""},
+	{false, " 10.95", ""},
+	{false, "10.95 ", ""},
+	{false, "10. 95 ", ""},
+	{false, "1 0.95 ", ""},
+	{false, "10.9 5", ""},
+	{false, "--10.95", ""},
+
+	{true, "1", "1/1"},
+	{true, "1.", ""},
+	{true, ".1", "1/10"},
+	{true, "1.1", ""},
+
+	{true, "3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333", ""},
+	{true, "3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333.", ""},
+	{true, ".3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333", ""},
+	{true, "3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333.3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333", "33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333/10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"},
+
+	{true, "10.95", "219/20"},
+	{true, "1234567", "1234567/1"},
+	{true, "1234567.8910", ""},
+	{true, "005.00500", ""},
+}
+
+func TestDecimalStrictRegex(t *testing.T) {
+	for i, unit := range decimalUnits {
+		for _, neg := range []bool{false, true} {
+			t.Logf("%v: %#v", i, unit)
+			s := unit.s
+			if neg {
+				s = "-" + s
+			}
+			require.Equal(t, unit.ok, decimalStrictRE.MatchString(s))
+		}
+	}
+}
+
+func TestParseDecimalStrict(t *testing.T) {
+	for i, unit := range decimalUnits {
+		for _, neg := range []bool{false, true} {
+			t.Logf("%v: %#v", i, unit)
+			s := unit.s
+			if neg {
+				s = "-" + s
+			}
+			v, err := parseDecimalStrict(s)
+			t.Logf("-> (%v, %v)", v, err)
+			require.Equal(t, unit.ok, err == nil, "parsed without error")
+			if unit.ok {
+				if unit.val != "" {
+					if neg {
+						require.Equal(t, "-"+unit.val, v.String())
+					} else {
+						require.Equal(t, unit.val, v.String())
+					}
+				}
+			}
+		}
+	}
+}

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -434,7 +434,7 @@ func (s *Server) checkDisplayAmount(ctx context.Context, arg stellar1.SendCLILoc
 		return err
 	}
 
-	xlmAmount, err := stellar.ConvertLocalToXLM(arg.DisplayAmount, exchangeRate)
+	xlmAmount, err := stellar.ConvertOutsideToXLM(arg.DisplayAmount, exchangeRate)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I noticed that the stellar amount parsing library was being used to parse amounts of outside currency. And then went on a rampage. The improvements made here are unlikely to strike in practice.

- remove support for non-decimal values like "1/2" and "1e10"  from non-XLM amounts and exchange rates
- disallow negative exchange rates
- support non-XLM amounts in the bazillions