### PR TITLE
update outbox prev pointers to correct values after sprinkling into a thread CORE-8067

### DIFF
--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -399,20 +399,10 @@ func (o *Outbox) RemoveMessage(ctx context.Context, obid chat1.OutboxID) error {
 }
 
 func (o *Outbox) getMsgOrdinal(msg chat1.MessageUnboxed) chat1.MessageID {
-	typ, err := msg.State()
-	if err != nil {
-		return 0
+	if msg.IsValid() && msg.Valid().ClientHeader.OutboxInfo != nil {
+		return msg.Valid().ClientHeader.OutboxInfo.Prev
 	}
-
-	switch typ {
-	case chat1.MessageUnboxedState_OUTBOX:
-		return msg.Outbox().Msg.ClientHeader.OutboxInfo.Prev
-	default:
-		if msg.IsValid() && msg.Valid().ClientHeader.OutboxInfo != nil {
-			return msg.Valid().ClientHeader.OutboxInfo.Prev
-		}
-		return msg.GetMessageID()
-	}
+	return msg.GetMessageID()
 }
 
 func (o *Outbox) insertMessage(ctx context.Context, thread *chat1.ThreadView, obr chat1.OutboxRecord) error {

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -408,6 +408,9 @@ func (o *Outbox) getMsgOrdinal(msg chat1.MessageUnboxed) chat1.MessageID {
 	case chat1.MessageUnboxedState_OUTBOX:
 		return msg.Outbox().Msg.ClientHeader.OutboxInfo.Prev
 	default:
+		if msg.IsValid() && msg.Valid().ClientHeader.OutboxInfo != nil {
+			return msg.Valid().ClientHeader.OutboxInfo.Prev
+		}
 		return msg.GetMessageID()
 	}
 }
@@ -439,8 +442,7 @@ func (o *Outbox) insertMessage(ctx context.Context, thread *chat1.ThreadView, ob
 
 	// If we didn't insert this guy, then put it at the front just so the user can see it
 	if !inserted {
-		o.Debug(ctx, "failed to insert instream, placing at front: obid: %s prev: %d", obr.OutboxID,
-			prev)
+		o.Debug(ctx, "failed to insert instream, placing at front: obid: %s prev: %d", obr.OutboxID, prev)
 		res = append([]chat1.MessageUnboxed{chat1.NewMessageUnboxedWithOutbox(obr)},
 			res...)
 	}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -203,14 +203,17 @@ func (hash Hash) Eq(other Hash) bool {
 
 func (m MessageUnboxed) GetMessageID() MessageID {
 	if state, err := m.State(); err == nil {
-		if state == MessageUnboxedState_VALID {
+		switch state {
+		case MessageUnboxedState_VALID:
 			return m.Valid().ServerHeader.MessageID
-		}
-		if state == MessageUnboxedState_ERROR {
+		case MessageUnboxedState_ERROR:
 			return m.Error().MessageID
-		}
-		if state == MessageUnboxedState_PLACEHOLDER {
+		case MessageUnboxedState_PLACEHOLDER:
 			return m.Placeholder().MessageID
+		case MessageUnboxedState_OUTBOX:
+			return m.Outbox().Msg.ClientHeader.OutboxInfo.Prev
+		default:
+			return 0
 		}
 	}
 	return 0


### PR DESCRIPTION
The point of the patch is to update the `Prev` value (used by the JS to order pending messages) to the correct value in case the original prev is now no longer correct. This can happen under the followig circumstance:

1.) Send 8 messages in a row that stay pending.
2.) Watch 4 get sent.
3.) Click in and out of the thread.

Before this patch, the 4 remaining messages will appear above the messages sent. After this patch, they will show up at the bottom. 