### PR TITLE
don't use --kill-kbfs on Windows

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -204,7 +204,7 @@
   <Fragment>
     <CustomAction Id="StopMainApp"
               Directory="INSTALLFOLDER"
-              ExeCommand="[INSTALLFOLDER]keybaserq.exe -wait &quot;[INSTALLFOLDER]keybase.exe&quot; ctl stop --kill-kbfs"
+              ExeCommand="[INSTALLFOLDER]keybaserq.exe -wait &quot;[INSTALLFOLDER]keybase.exe&quot; ctl stop"
               Execute="immediate"
               Return="ignore"/>
   </Fragment>

--- a/shared/desktop/app/ctl.desktop.js
+++ b/shared/desktop/app/ctl.desktop.js
@@ -9,7 +9,7 @@ export function ctlStop(callback: any) {
   var plat = 'darwin'
   var args = ['ctl', 'stop', '--exclude=app']
   if (isWindows) {
-    args = ['ctl', 'stop', '--kill-kbfs']
+    args = ['ctl', 'stop']
     plat = 'win32'
   }
   exec(binPath, args, plat, 'prod', false, callback)


### PR DESCRIPTION
just in case it holds up shutdown during upgrade. It's no longer necessary.