### PR TITLE
Don't show the boom icon when editing.

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -278,6 +278,7 @@ class PlatformInput extends Component<PlatformInputProps & FloatingMenuParentPro
             />
             {flags.explodingMessagesEnabled &&
               this.props.isExploding &&
+              !this.props.isEditing &&
               !this.state.hasText && (
                 <Icon
                   color={globalColors.black_20}


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review.