### PR TITLE
Clear outbox periodically

### DIFF
--- a/go/chat/ephemeral_purger.go
+++ b/go/chat/ephemeral_purger.go
@@ -256,7 +256,7 @@ func (b *BackgroundEphemeralPurger) loop() {
 			b.queueLock.Unlock()
 		case <-b.outboxTicker.C:
 			// Check the outbox for stuck ephemeral messages that need purging
-			storage.NewOutbox(b.G(), b.uid).EphemeralPurge(context.Background())
+			storage.NewOutbox(b.G(), b.uid).OutboxPurge(context.Background())
 		case ch := <-b.stopCh: // caller will reset looping=false
 			b.Debug(bgctx, "loop: shutting down for %s", b.uid)
 			close(ch)

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -26,7 +26,7 @@ type Outbox struct {
 }
 
 const outboxVersion = 4
-const ephemeralPurgeCutoff = time.Minute * 10
+const errorPurgeCutoff = time.Minute * 10
 
 type diskOutbox struct {
 	Version int                  `codec:"V"`
@@ -157,7 +157,7 @@ func (o *Outbox) PushMessage(ctx context.Context, convID chat1.ConversationID,
 	}
 	obox.Records = append(obox.Records, rec)
 
-	// Write out box
+	// Write outbox
 	obox.Version = outboxVersion
 	if err := o.writeDiskBox(ctx, o.dbKey(), obox); err != nil {
 		return rec, o.maybeNuke(NewInternalError(ctx, o.DebugLabeler,
@@ -197,7 +197,7 @@ func (o *Outbox) PullAllConversations(ctx context.Context, includeErrors bool, r
 		}
 	}
 	if remove {
-		// Write out box
+		// Write outbox
 		obox.Records = errors
 		obox.Version = outboxVersion
 		if err := o.writeDiskBox(ctx, o.dbKey(), obox); err != nil {
@@ -256,7 +256,7 @@ func (o *Outbox) RecordFailedAttempt(ctx context.Context, oldObr chat1.OutboxRec
 		sort.Sort(ByCtimeOrder(recs))
 	}
 
-	// Write out box
+	// Write outbox
 	obox.Records = recs
 	if err := o.writeDiskBox(ctx, o.dbKey(), obox); err != nil {
 		return o.maybeNuke(NewInternalError(ctx, o.DebugLabeler,
@@ -325,7 +325,7 @@ func (o *Outbox) MarkAsError(ctx context.Context, obr chat1.OutboxRecord, errRec
 		sort.Sort(ByCtimeOrder(recs))
 	}
 
-	// Write out box
+	// Write outbox
 	obox.Records = recs
 	if err := o.writeDiskBox(ctx, o.dbKey(), obox); err != nil {
 		return res, o.maybeNuke(NewInternalError(ctx, o.DebugLabeler,
@@ -360,7 +360,7 @@ func (o *Outbox) RetryMessage(ctx context.Context, obid chat1.OutboxID,
 		recs = append(recs, obr)
 	}
 
-	// Write out box
+	// Write outbox
 	obox.Records = recs
 	if err := o.writeDiskBox(ctx, o.dbKey(), obox); err != nil {
 		return o.maybeNuke(NewInternalError(ctx, o.DebugLabeler,
@@ -487,11 +487,11 @@ func (o *Outbox) SprinkleIntoThread(ctx context.Context, convID chat1.Conversati
 	return nil
 }
 
-// EphemeralPurge is called periodically to ensure exploding messages don't hang out too
+// OutboxPurge is called periodically to ensure messages don't hang out too
 // long in the outbox (since they are not encrypted with ephemeral keys until
 // they leave it). Currently we purge anything that is in the error state and
-// has been in the outbox for > ephemeralPurgeCutoff minutes.
-func (o *Outbox) EphemeralPurge(ctx context.Context) (err error) {
+// has been in the outbox for > purgeErrorCutoff minutes.
+func (o *Outbox) OutboxPurge(ctx context.Context) (err error) {
 	locks.Outbox.Lock()
 	defer locks.Outbox.Unlock()
 
@@ -501,33 +501,43 @@ func (o *Outbox) EphemeralPurge(ctx context.Context) (err error) {
 		return o.maybeNuke(rerr, o.dbKey())
 	}
 
-	var purged, recs []chat1.OutboxRecord
+	var purged, ephemeralPurged, recs []chat1.OutboxRecord
 	now := o.clock.Now()
 	for _, obr := range obox.Records {
-		if obr.Msg.IsEphemeral() {
-			st, err := obr.State.State()
-			if err != nil {
-				o.Debug(ctx, "purging ephemeral message from outbox with error getting state: %s", err)
+		st, err := obr.State.State()
+		if err != nil {
+			o.Debug(ctx, "purging ephemeral message from outbox with error getting state: %s", err)
+			purged = append(purged, obr)
+			continue
+		}
+		if st == chat1.OutboxStateType_ERROR && obr.Ctime.Time().Add(errorPurgeCutoff).Before(now) {
+			o.Debug(ctx, "purging message from outbox with error state that was older than %v: %s, isEphemeral", errorPurgeCutoff, obr, obr.Msg.IsEphemeral())
+			if obr.Msg.IsEphemeral() {
+				ephemeralPurged = append(ephemeralPurged, obr)
+			} else {
 				purged = append(purged, obr)
-				continue
 			}
-			if st == chat1.OutboxStateType_ERROR && obr.Ctime.Time().Add(ephemeralPurgeCutoff).Before(now) {
-				o.Debug(ctx, "purging ephemeral message from outbox with error state that was older than %v: %s", ephemeralPurgeCutoff, err)
-				purged = append(purged, obr)
-				continue
-			}
+			continue
 		}
 		recs = append(recs, obr)
 	}
 
 	obox.Records = recs
 
-	// Write out box
+	// Write outbox
 	if err := o.writeDiskBox(ctx, o.dbKey(), obox); err != nil {
 		return o.maybeNuke(NewInternalError(ctx, o.DebugLabeler,
 			"error writing outbox: err: %s", err.Error()), o.dbKey())
 	}
 
+	if len(ephemeralPurged) > 0 {
+		act := chat1.NewChatActivityWithFailedMessage(chat1.FailedMessageInfo{
+			OutboxRecords:    ephemeralPurged,
+			IsEphemeralPurge: true,
+		})
+		o.G().NotifyRouter.HandleNewChatActivity(context.Background(),
+			keybase1.UID(o.GetUID().String()), &act)
+	}
 	if len(purged) > 0 {
 		act := chat1.NewChatActivityWithFailedMessage(chat1.FailedMessageInfo{
 			OutboxRecords:    purged,


### PR DESCRIPTION
Bundles outbox cleaning into the existing `EphemeralPurge` method which is called periodically (rn every 5m by `BackgroundEphemeralPurger`).We could have different time cutoffs for ephemeral vs regular messages but wanted to see your opinion first @mmaxim 