### PR TITLE
remove AlreadyDeleted error from outbox

### DIFF
--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -242,7 +242,6 @@ func (d deleteOptionsV1) Check() error {
 
 	if d.MessageID == 0 {
 		return ErrInvalidOptions{version: 1, method: methodDelete, err: errors.New("invalid message id")}
-
 	}
 
 	return nil

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1929,7 +1929,7 @@ func (e ChatAlreadyDeletedError) Error() string {
 }
 
 func (e ChatAlreadyDeletedError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
-	return chat1.OutboxErrorType_MISC, true
+	return chat1.OutboxErrorType_ALREADY_DELETED, true
 }
 
 //=============================================================================

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1211,6 +1211,7 @@ const (
 	OutboxErrorType_DUPLICATE       OutboxErrorType = 4
 	OutboxErrorType_EXPIRED         OutboxErrorType = 5
 	OutboxErrorType_TOOMANYATTEMPTS OutboxErrorType = 6
+	OutboxErrorType_ALREADY_DELETED OutboxErrorType = 7
 )
 
 func (o OutboxErrorType) DeepCopy() OutboxErrorType { return o }
@@ -1223,6 +1224,7 @@ var OutboxErrorTypeMap = map[string]OutboxErrorType{
 	"DUPLICATE":       4,
 	"EXPIRED":         5,
 	"TOOMANYATTEMPTS": 6,
+	"ALREADY_DELETED": 7,
 }
 
 var OutboxErrorTypeRevMap = map[OutboxErrorType]string{
@@ -1233,6 +1235,7 @@ var OutboxErrorTypeRevMap = map[OutboxErrorType]string{
 	4: "DUPLICATE",
 	5: "EXPIRED",
 	6: "TOOMANYATTEMPTS",
+	7: "ALREADY_DELETED",
 }
 
 func (e OutboxErrorType) String() string {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -198,7 +198,8 @@ protocol local {
     TOOLONG_3,
     DUPLICATE_4,
     EXPIRED_5,
-    TOOMANYATTEMPTS_6
+    TOOMANYATTEMPTS_6,
+    ALREADY_DELETED_7
   }
 
   record OutboxStateError {

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -201,6 +201,7 @@ export const localOutboxErrorType = {
   duplicate: 4,
   expired: 5,
   toomanyattempts: 6,
+  alreadyDeleted: 7,
 }
 
 export const localOutboxStateType = {
@@ -670,6 +671,7 @@ export type OutboxErrorType =
   | 4 // DUPLICATE_4
   | 5 // EXPIRED_5
   | 6 // TOOMANYATTEMPTS_6
+  | 7 // ALREADY_DELETED_7
 
 export type OutboxID = Bytes
 export type OutboxInfo = $ReadOnly<{prev: MessageID, composeTime: Gregor1.Time}>

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -656,7 +656,8 @@
         "TOOLONG_3",
         "DUPLICATE_4",
         "EXPIRED_5",
-        "TOOMANYATTEMPTS_6"
+        "TOOMANYATTEMPTS_6",
+        "ALREADY_DELETED_7"
       ]
     },
     {

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -201,6 +201,7 @@ export const localOutboxErrorType = {
   duplicate: 4,
   expired: 5,
   toomanyattempts: 6,
+  alreadyDeleted: 7,
 }
 
 export const localOutboxStateType = {
@@ -670,6 +671,7 @@ export type OutboxErrorType =
   | 4 // DUPLICATE_4
   | 5 // EXPIRED_5
   | 6 // TOOMANYATTEMPTS_6
+  | 7 // ALREADY_DELETED_7
 
 export type OutboxID = Bytes
 export type OutboxInfo = $ReadOnly<{prev: MessageID, composeTime: Gregor1.Time}>


### PR DESCRIPTION
wrap the `AlreadyDeleted` error in a new `OutboxError` type so we can clear it from the user's outbox. if a user tried to delete a message that was wiped out from a background process (ephemeral purge, retention or maybe they were offline and another device deleted it) this error message would hang around in the outbox in definitely. https://github.com/keybase/client/pull/12352 would clear this out after some time but i don't think the error should ever be user facing 

cc @mmaxim 