### PR TITLE
move PairwiseMacs from MessageBoxed to ClientHeader

### DIFF
--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -295,7 +295,7 @@ func TestChatMessageUnboxWithPairwiseMacsCorrupted(t *testing.T) {
 	}
 
 	// CORRUPT THE AUTHENTICATOR!!!
-	for _, mac := range boxed.PairwiseMacs {
+	for _, mac := range boxed.ClientHeader.PairwiseMacs {
 		mac[0] ^= 1
 	}
 

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -1164,6 +1164,7 @@ type MessageClientHeader struct {
 	OutboxID          *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	OutboxInfo        *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
 	EphemeralMetadata *MsgEphemeralMetadata    `codec:"em,omitempty" json:"em,omitempty"`
+	PairwiseMacs      map[keybase1.KID][]byte  `codec:"pm" json:"pm"`
 }
 
 func (o MessageClientHeader) DeepCopy() MessageClientHeader {
@@ -1239,6 +1240,23 @@ func (o MessageClientHeader) DeepCopy() MessageClientHeader {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.EphemeralMetadata),
+		PairwiseMacs: (func(x map[keybase1.KID][]byte) map[keybase1.KID][]byte {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[keybase1.KID][]byte)
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := (func(x []byte) []byte {
+					if x == nil {
+						return nil
+					}
+					return append([]byte{}, x...)
+				})(v)
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.PairwiseMacs),
 	}
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -12,14 +12,13 @@ import (
 )
 
 type MessageBoxed struct {
-	Version          MessageBoxedVersion     `codec:"version" json:"version"`
-	ServerHeader     *MessageServerHeader    `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
-	ClientHeader     MessageClientHeader     `codec:"clientHeader" json:"clientHeader"`
-	HeaderCiphertext SealedData              `codec:"headerCiphertext" json:"headerCiphertext"`
-	BodyCiphertext   EncryptedData           `codec:"bodyCiphertext" json:"bodyCiphertext"`
-	VerifyKey        []byte                  `codec:"verifyKey" json:"verifyKey"`
-	KeyGeneration    int                     `codec:"keyGeneration" json:"keyGeneration"`
-	PairwiseMacs     map[keybase1.KID][]byte `codec:"pairwiseMacs" json:"pairwiseMacs"`
+	Version          MessageBoxedVersion  `codec:"version" json:"version"`
+	ServerHeader     *MessageServerHeader `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
+	ClientHeader     MessageClientHeader  `codec:"clientHeader" json:"clientHeader"`
+	HeaderCiphertext SealedData           `codec:"headerCiphertext" json:"headerCiphertext"`
+	BodyCiphertext   EncryptedData        `codec:"bodyCiphertext" json:"bodyCiphertext"`
+	VerifyKey        []byte               `codec:"verifyKey" json:"verifyKey"`
+	KeyGeneration    int                  `codec:"keyGeneration" json:"keyGeneration"`
 }
 
 func (o MessageBoxed) DeepCopy() MessageBoxed {
@@ -42,23 +41,6 @@ func (o MessageBoxed) DeepCopy() MessageBoxed {
 			return append([]byte{}, x...)
 		})(o.VerifyKey),
 		KeyGeneration: o.KeyGeneration,
-		PairwiseMacs: (func(x map[keybase1.KID][]byte) map[keybase1.KID][]byte {
-			if x == nil {
-				return nil
-			}
-			ret := make(map[keybase1.KID][]byte)
-			for k, v := range x {
-				kCopy := k.DeepCopy()
-				vCopy := (func(x []byte) []byte {
-					if x == nil {
-						return nil
-					}
-					return append([]byte{}, x...)
-				})(v)
-				ret[kCopy] = vCopy
-			}
-			return ret
-		})(o.PairwiseMacs),
 	}
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -379,6 +379,12 @@
 
     @mpackkey("em") @jsonkey("em")
     union { null, MsgEphemeralMetadata } ephemeralMetadata;
+
+    // [V1, V2]: Missing
+    // [V3, V4]: Optional map of pairwise MACs, used for exploding messages on
+    //           small teams. In V4, if MACs are present, the verifyKey is a dummy.
+    @mpackkey("pm") @jsonkey("pm")
+    map<keybase1.KID, bytes> pairwiseMacs;
   }
 
   record MessageClientHeaderVerified {

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -32,12 +32,6 @@ protocol remote {
 
     // [V1, V2]: Key generation of the encryption key
     int keyGeneration;
-
-    // [V1, V2, V3]: Missing
-    // V4: Optional map of pairwise MACs, for repudiable messages. These cover
-    // both the headerCiphertext and the verifyKey, though in the repudiable
-    // case the verifyKey is usually a public constant.
-    map<keybase1.KID, bytes> pairwiseMacs;
   }
 
   enum MessageBoxedVersion {

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -561,7 +561,7 @@ export type MerkleRoot = $ReadOnly<{seqno: Long, hash: Bytes}>
 export type MessageAttachment = $ReadOnly<{object: Asset, preview?: ?Asset, previews?: ?Array<Asset>, metadata: Bytes, uploaded: Boolean}>
 export type MessageAttachmentUploaded = $ReadOnly<{messageID: MessageID, object: Asset, previews?: ?Array<Asset>, metadata: Bytes}>
 export type MessageBody = {messageType: 1, text: ?MessageText} | {messageType: 2, attachment: ?MessageAttachment} | {messageType: 3, edit: ?MessageEdit} | {messageType: 4, delete: ?MessageDelete} | {messageType: 5, metadata: ?MessageConversationMetadata} | {messageType: 7, headline: ?MessageHeadline} | {messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded} | {messageType: 9, join: ?MessageJoin} | {messageType: 10, leave: ?MessageLeave} | {messageType: 11, system: ?MessageSystem} | {messageType: 12, deletehistory: ?MessageDeleteHistory} | {messageType: 13, reaction: ?MessageReaction}
-export type MessageBoxed = $ReadOnly<{version: MessageBoxedVersion, serverHeader?: ?MessageServerHeader, clientHeader: MessageClientHeader, headerCiphertext: SealedData, bodyCiphertext: EncryptedData, verifyKey: Bytes, keyGeneration: Int, pairwiseMacs: {[key: string]: Bytes}}>
+export type MessageBoxed = $ReadOnly<{version: MessageBoxedVersion, serverHeader?: ?MessageServerHeader, clientHeader: MessageClientHeader, headerCiphertext: SealedData, bodyCiphertext: EncryptedData, verifyKey: Bytes, keyGeneration: Int}>
 export type MessageBoxedVersion =
   | 0 // VNONE_0
   | 1 // V1_1
@@ -569,7 +569,7 @@ export type MessageBoxedVersion =
   | 3 // V3_3
   | 4 // V4_4
 
-export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?MsgEphemeralMetadata}>
+export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?MsgEphemeralMetadata, pairwiseMacs: {[key: string]: Bytes}}>
 export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?MsgEphemeralMetadata, rtime: Gregor1.Time}>
 export type MessageConversationMetadata = $ReadOnly<{conversationTitle: String}>
 export type MessageDelete = $ReadOnly<{messageIDs?: ?Array<MessageID>}>

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -986,6 +986,16 @@
           "name": "ephemeralMetadata",
           "mpackkey": "em",
           "jsonkey": "em"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "bytes",
+            "keys": "keybase1.KID"
+          },
+          "name": "pairwiseMacs",
+          "mpackkey": "pm",
+          "jsonkey": "pm"
         }
       ]
     },

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -47,14 +47,6 @@
         {
           "type": "int",
           "name": "keyGeneration"
-        },
-        {
-          "type": {
-            "type": "map",
-            "values": "bytes",
-            "keys": "keybase1.KID"
-          },
-          "name": "pairwiseMacs"
         }
       ]
     },

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -561,7 +561,7 @@ export type MerkleRoot = $ReadOnly<{seqno: Long, hash: Bytes}>
 export type MessageAttachment = $ReadOnly<{object: Asset, preview?: ?Asset, previews?: ?Array<Asset>, metadata: Bytes, uploaded: Boolean}>
 export type MessageAttachmentUploaded = $ReadOnly<{messageID: MessageID, object: Asset, previews?: ?Array<Asset>, metadata: Bytes}>
 export type MessageBody = {messageType: 1, text: ?MessageText} | {messageType: 2, attachment: ?MessageAttachment} | {messageType: 3, edit: ?MessageEdit} | {messageType: 4, delete: ?MessageDelete} | {messageType: 5, metadata: ?MessageConversationMetadata} | {messageType: 7, headline: ?MessageHeadline} | {messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded} | {messageType: 9, join: ?MessageJoin} | {messageType: 10, leave: ?MessageLeave} | {messageType: 11, system: ?MessageSystem} | {messageType: 12, deletehistory: ?MessageDeleteHistory} | {messageType: 13, reaction: ?MessageReaction}
-export type MessageBoxed = $ReadOnly<{version: MessageBoxedVersion, serverHeader?: ?MessageServerHeader, clientHeader: MessageClientHeader, headerCiphertext: SealedData, bodyCiphertext: EncryptedData, verifyKey: Bytes, keyGeneration: Int, pairwiseMacs: {[key: string]: Bytes}}>
+export type MessageBoxed = $ReadOnly<{version: MessageBoxedVersion, serverHeader?: ?MessageServerHeader, clientHeader: MessageClientHeader, headerCiphertext: SealedData, bodyCiphertext: EncryptedData, verifyKey: Bytes, keyGeneration: Int}>
 export type MessageBoxedVersion =
   | 0 // VNONE_0
   | 1 // V1_1
@@ -569,7 +569,7 @@ export type MessageBoxedVersion =
   | 3 // V3_3
   | 4 // V4_4
 
-export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?MsgEphemeralMetadata}>
+export type MessageClientHeader = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, supersedes: MessageID, kbfsCryptKeysUsed?: ?Boolean, deletes?: ?Array<MessageID>, prev?: ?Array<MessagePreviousPointer>, deleteHistory?: ?MessageDeleteHistory, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?MsgEphemeralMetadata, pairwiseMacs: {[key: string]: Bytes}}>
 export type MessageClientHeaderVerified = $ReadOnly<{conv: ConversationIDTriple, tlfName: String, tlfPublic: Boolean, messageType: MessageType, prev?: ?Array<MessagePreviousPointer>, sender: Gregor1.UID, senderDevice: Gregor1.DeviceID, kbfsCryptKeysUsed?: ?Boolean, merkleRoot?: ?MerkleRoot, outboxID?: ?OutboxID, outboxInfo?: ?OutboxInfo, ephemeralMetadata?: ?MsgEphemeralMetadata, rtime: Gregor1.Time}>
 export type MessageConversationMetadata = $ReadOnly<{conversationTitle: String}>
 export type MessageDelete = $ReadOnly<{messageIDs?: ?Array<MessageID>}>


### PR DESCRIPTION
MessageBoxed gets pieced together by the server, and it was a mistake to
add the new field there. ClientHeader gets messagepack-deserialized from
the protocol, so putting the field there instead will have the behavior
we were originall hoping for.

r? @joshblum 

cc @mmaxim 