### PR TITLE
check GetExtendedStatus for revokes and resets

### DIFF
--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -103,6 +103,7 @@ func runPrereqs(m libkb.MetaContext, e Engine2) error {
 
 func RunEngine2(m libkb.MetaContext, e Engine2) (err error) {
 	defer m.CTrace(fmt.Sprintf("RunEngine(%s)", e.Name()), func() error { return err })()
+	m = m.WithLogTag("ENG")
 
 	if m, err = delegateUIs(m, e); err != nil {
 		return err

--- a/go/libkb/all_provisioned_usernames.go
+++ b/go/libkb/all_provisioned_usernames.go
@@ -1,0 +1,59 @@
+package libkb
+
+func getUsernameIfProvisioned(m MetaContext, uc UserConfig) (ret NormalizedUsername, err error) {
+	m.CDebugf("getUsernameIfProvisioned(%+v)", uc)
+	did := uc.GetDeviceID()
+	if did.IsNil() {
+		m.CDebugf("- no valid username since nil deviceID")
+		return ret, nil
+	}
+	err = checkDeviceValidForUID(m.Ctx(), m.G().GetUPAKLoader(), uc.GetUID(), did)
+	switch err.(type) {
+	case nil:
+		m.CDebugf("- checks out")
+		return uc.GetUsername(), nil
+	case DeviceNotFoundError:
+		m.CDebugf("- user was likely reset (%s)", err)
+		return ret, err
+	case KeyRevokedError:
+		m.CDebugf("- device was revoked (s)", err)
+		return ret, err
+	default:
+		m.CDebugf("- unexpected error; propagating (%s)", err)
+		return ret, err
+	}
+}
+
+// GetAllProvisionedUsernames looks into the current config.json file, and finds all usernames
+// that are currently provisioned on this device. That is, it filters out those that are on revoked
+// devices or have reset their accounts. It uses UPAK loading for verifying the current user/device
+// statuses, so should be fast if everything is cached recently.
+func GetAllProvisionedUsernames(m MetaContext) (current NormalizedUsername, all []NormalizedUsername, err error) {
+
+	m = m.WithLogTag("GAPU")
+	defer m.CTrace("GetAllProvisionedUsernames", func() error { return err })()
+
+	currentUC, allUCs, err := m.G().Env.GetConfig().GetAllUserConfigs()
+	if err != nil {
+		return current, nil, err
+	}
+
+	if currentUC != nil {
+		current, err = getUsernameIfProvisioned(m, *currentUC)
+		if err != nil {
+			return current, nil, err
+		}
+	}
+
+	for _, u := range allUCs {
+		tmp, err := getUsernameIfProvisioned(m, u)
+		if err != nil {
+			return current, nil, err
+		}
+		if !tmp.IsNil() {
+			all = append(all, tmp)
+		}
+	}
+
+	return current, all, nil
+}

--- a/go/libkb/all_provisioned_usernames.go
+++ b/go/libkb/all_provisioned_usernames.go
@@ -14,10 +14,10 @@ func getUsernameIfProvisioned(m MetaContext, uc UserConfig) (ret NormalizedUsern
 		return uc.GetUsername(), nil
 	case DeviceNotFoundError:
 		m.CDebugf("- user was likely reset (%s)", err)
-		return ret, err
+		return ret, nil
 	case KeyRevokedError:
 		m.CDebugf("- device was revoked (s)", err)
-		return ret, err
+		return ret, nil
 	default:
 		m.CDebugf("- unexpected error; propagating (%s)", err)
 		return ret, err

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -367,6 +367,27 @@ func (f JSONConfigFile) GetUserConfigForUID(u keybase1.UID) (*UserConfig, error)
 	return nil, nil
 }
 
+func (f JSONConfigFile) GetAllUserConfigs() (current *UserConfig, all []UserConfig, err error) {
+
+	currentUsername, allUsernames, err := f.GetAllUsernames()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !currentUsername.IsNil() {
+		current, _ = f.GetUserConfigForUsername(currentUsername)
+	}
+
+	for _, u := range allUsernames {
+		tmp, err := f.GetUserConfigForUsername(u)
+		if err == nil && tmp != nil {
+			all = append(all, *tmp)
+		}
+	}
+
+	return current, all, nil
+}
+
 func (f JSONConfigFile) GetAllUsernames() (current NormalizedUsername, others []NormalizedUsername, err error) {
 	current = f.getCurrentUser()
 	uw := f.jw.AtKey("users")

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -115,6 +115,9 @@ func (n NullConfiguration) GetBool(string, bool) (bool, bool) { return false, fa
 func (n NullConfiguration) GetAllUsernames() (NormalizedUsername, []NormalizedUsername, error) {
 	return NormalizedUsername(""), nil, nil
 }
+func (n NullConfiguration) GetAllUserConfigs() (*UserConfig, []UserConfig, error) {
+	return nil, nil, nil
+}
 
 func (n NullConfiguration) GetDebug() (bool, bool) {
 	return false, false

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -164,6 +164,7 @@ type ConfigReader interface {
 	GetUIDForUsername(n NormalizedUsername) keybase1.UID
 	GetUsername() NormalizedUsername
 	GetAllUsernames() (current NormalizedUsername, others []NormalizedUsername, err error)
+	GetAllUserConfigs() (*UserConfig, []UserConfig, error)
 	GetUID() keybase1.UID
 	GetProxyCACerts() ([]string, error)
 	GetSecurityAccessGroupOverride() (bool, bool)

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -178,7 +178,7 @@ func (h ConfigHandler) GetExtendedStatus(ctx context.Context, sessionID int) (re
 	res.TsecCached = psc.ValidTsec()
 	res.SecretPromptSkip = m.ActiveDevice().SecretPromptCancelTimer().WasRecentlyCanceled(m)
 
-	current, all, err := h.G().GetAllUserNames()
+	current, all, err := libkb.GetAllProvisionedUsernames(m)
 	if err != nil {
 		h.G().Log.Debug("| died in GetAllUseranmes()")
 		return res, err


### PR DESCRIPTION
- we're now going to the API for each user section on the config file to check that the listed
users are still unrevoked/unreset. we'll filter that list down before sending it back up
to the UI
- this is now slower, since there's a merkle API path call for each such check. but we're not really
expecting users to have more than a small handful of sockpuppets
- tested by hand