### PR TITLE
Fix native styling for edit msg input

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -196,7 +196,8 @@ const Action = ({
   hasText ? (
     <Box2 direction="horizontal" gap="small" style={styles.actionText}>
       {flags.explodingMessagesEnabled &&
-        isExploding && (
+        isExploding &&
+        !isEditing && (
           <ExplodingIcon
             explodingModeSeconds={explodingModeSeconds}
             isExploding={isExploding}
@@ -286,7 +287,7 @@ const styles = styleSheetCreate({
     alignItems: 'flex-start',
     backgroundColor: globalColors.yellow3,
     height: '100%',
-    maxWidth: 32,
+    minWidth: 32,
     padding: globalMargins.xtiny,
   },
   input: {


### PR DESCRIPTION
Also make sure bomb icon never shows while editing.
Before: 
<img width="386" alt="editing_before" src="https://user-images.githubusercontent.com/11968340/41438707-303a3498-6ff6-11e8-9a78-6f5f559747cd.png">
After:
<img width="386" alt="editing_after" src="https://user-images.githubusercontent.com/11968340/41438712-3376d90e-6ff6-11e8-980b-f61437ad2c64.png">
r? @keybase/react-hackers 