### PR TITLE
uint overflow fix

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -1066,7 +1066,7 @@ func (s *HybridConversationSource) mergeMaybeNotify(ctx context.Context,
 }
 
 // ClearFromDelete clears the current cache if there is a delete that we don't know about
-// and returns true to the caller if it schedule a background loader job
+// and returns true to the caller if it schedules a background loader job
 func (s *HybridConversationSource) ClearFromDelete(ctx context.Context, uid gregor1.UID,
 	convID chat1.ConversationID, deleteID chat1.MessageID) bool {
 	defer s.Trace(ctx, func() error { return nil }, "ClearFromDelete")()

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -758,6 +758,11 @@ func (s *Storage) ClearBefore(ctx context.Context, convID chat1.ConversationID, 
 	locks.Storage.Lock()
 	defer locks.Storage.Unlock()
 	s.Debug(ctx, "ClearBefore: convID: %s uid: %s msgID: %d", convID, uid, upto)
+
+	// Abort, we don't want to overflow uint (chat1.MessageID)
+	if upto == 0 {
+		return nil
+	}
 	return s.clearUpthrough(ctx, convID, uid, upto-1)
 }
 

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -432,8 +432,10 @@ func (be *blockEngine) ReadMessages(ctx context.Context, res ResultCollector,
 		res.Push(msg)
 	}
 
-	// Check if we read anything, otherwise move to another block and try again
-	if !res.Done() && b.BlockID > 0 {
+	// Check if we read anything, otherwise move to another block and try
+	// again. We check if lastAdded > 0 to avoid overflowing chat1.MessageID
+	// which is a uint type
+	if !res.Done() && b.BlockID > 0 && lastAdded > 0 {
 		return be.ReadMessages(ctx, res, convID, uid, lastAdded-1)
 	}
 	return nil


### PR DESCRIPTION
Was seeing a panic when we tried to `clearUpthrough` an overflowed uint so we abort early to fix. I tried grepping around to see if we had any similar bugs and there may have been one in the `storage_blockengine` I think there may still be a bug though, i'm not sure why we call `ClearBefore` (https://github.com/keybase/client/compare/joshblum/convload-panic-CORE-8082?expand=1#diff-cf8add58c26f1cbee6e6e1e5f4a20d6eR1091) on a `DELETE` message -- don't we only want to clear out the single message from the `DELETE` instead of everything `upto`? 