### PR TITLE
Implement buildPayment RPC

### DIFF
--- a/go/stellar/bpc.go
+++ b/go/stellar/bpc.go
@@ -1,0 +1,89 @@
+package stellar
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/keybase/client/go/stellar/remote"
+	"github.com/keybase/client/go/stellar/stellarcommon"
+)
+
+// BuildPaymentCache has helpers for getting information quickly when building a payment.
+// Methods should err on the side of performance rather at the cost of serialization.
+// CORE-8119: But they don't yet.
+type BuildPaymentCache interface {
+	OwnsAccount(libkb.MetaContext, stellar1.AccountID) (bool, error)
+	// AccountSeqno should be cached _but_ it should also be busted asap.
+	// Because it is used to prevent users from sending payments twice in a row.
+	AccountSeqno(libkb.MetaContext, stellar1.AccountID) (string, error)
+	IsAccountFunded(libkb.MetaContext, stellar1.AccountID) (bool, error)
+	LookupRecipient(libkb.MetaContext, stellarcommon.RecipientInput) (stellarcommon.Recipient, error)
+	GetOutsideExchangeRate(libkb.MetaContext, stellar1.OutsideCurrencyCode) (stellar1.OutsideExchangeRate, error)
+	AvailableXLMToSend(libkb.MetaContext, stellar1.AccountID) (string, error)
+	GetOutsideCurrencyPreference(libkb.MetaContext, stellar1.AccountID) (stellar1.OutsideCurrencyCode, error)
+}
+
+func GetBuildPaymentCache(mctx libkb.MetaContext, remoter remote.Remoter) BuildPaymentCache {
+	// CORE-8119: attach an instance to G and use that.
+	// CORE-8119: delete it when a logout occurs.
+	return &buildPaymentCache{
+		remoter: remoter,
+	}
+}
+
+// Each instance is tied to a UV login. Must be discarded when switching users.
+// Threadsafe.
+// CORE-8119: Make all of these methods hit caches when called repeatedly.
+type buildPaymentCache struct {
+	sync.Mutex
+	remoter remote.Remoter
+}
+
+func (c *buildPaymentCache) OwnsAccount(mctx libkb.MetaContext,
+	accountID stellar1.AccountID) (bool, error) {
+	return OwnAccount(mctx.Ctx(), mctx.G(), accountID)
+}
+
+func (c *buildPaymentCache) AccountSeqno(mctx libkb.MetaContext,
+	accountID stellar1.AccountID) (string, error) {
+	seqno, err := c.remoter.AccountSeqno(mctx.Ctx(), accountID)
+	return fmt.Sprintf("%v", seqno), err
+}
+
+func (c *buildPaymentCache) IsAccountFunded(mctx libkb.MetaContext,
+	accountID stellar1.AccountID) (bool, error) {
+	return isAccountFunded(mctx.Ctx(), c.remoter, accountID)
+}
+
+func (c *buildPaymentCache) LookupRecipient(mctx libkb.MetaContext,
+	to stellarcommon.RecipientInput) (res stellarcommon.Recipient, err error) {
+	// CORE-8119: Will delegating to stellar.LookupRecipient be too slow?
+	// CORE-8119: Will it do identifies?
+	return LookupRecipient(mctx, to)
+}
+
+func (c *buildPaymentCache) GetOutsideExchangeRate(mctx libkb.MetaContext,
+	currency stellar1.OutsideCurrencyCode) (rate stellar1.OutsideExchangeRate, err error) {
+	return c.remoter.ExchangeRate(mctx.Ctx(), string(currency))
+}
+
+func (c *buildPaymentCache) AvailableXLMToSend(mctx libkb.MetaContext,
+	accountID stellar1.AccountID) (string, error) {
+	details, err := c.remoter.Details(mctx.Ctx(), accountID)
+	if err != nil {
+		return "", err
+	}
+	if details.Available == "" {
+		// This is what stellard does if the account is not funded.
+		return "0", nil
+	}
+	return details.Available, nil
+}
+
+func (c *buildPaymentCache) GetOutsideCurrencyPreference(mctx libkb.MetaContext,
+	accountID stellar1.AccountID) (stellar1.OutsideCurrencyCode, error) {
+	cr, err := GetCurrencySetting(mctx, c.remoter, accountID)
+	return cr.Code, err
+}

--- a/go/stellar/exchange_test.go
+++ b/go/stellar/exchange_test.go
@@ -173,7 +173,7 @@ func TestParseDecimalStrict(t *testing.T) {
 			if neg {
 				s = "-" + s
 			}
-			v, err := parseDecimalStrict(s)
+			v, err := ParseDecimalStrict(s)
 			t.Logf("-> (%v, %v)", v, err)
 			require.Equal(t, unit.ok, err == nil, "parsed without error")
 			if unit.ok {

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -850,6 +850,7 @@ func FormatPaymentAmountXLM(amount string, delta stellar1.BalanceDelta) (string,
 	return desc, nil
 }
 
+// Example: "157.5000000 XLM"
 func FormatAmountXLM(amount string) (string, error) {
 	return FormatAmountWithSuffix(amount, false, "XLM")
 }
@@ -866,7 +867,7 @@ func FormatAmount(amount string, precisionTwo bool) (string, error) {
 	if amount == "" {
 		return "", errors.New("empty amount")
 	}
-	x, err := parseDecimalStrict(amount)
+	x, err := ParseDecimalStrict(amount)
 	if err != nil {
 		return "", fmt.Errorf("unable to parse amount %s: %v", amount, err)
 	}
@@ -989,6 +990,22 @@ func DeleteAccount(m libkb.MetaContext, accountID stellar1.AccountID) error {
 		return fmt.Errorf("account not found: %v", accountID)
 	}
 	return remote.Post(m.Ctx(), m.G(), nextBundle)
+}
+
+func GetCurrencySetting(mctx libkb.MetaContext, remoter remote.Remoter, accountID stellar1.AccountID) (res stellar1.CurrencyLocal, err error) {
+	codeStr, err := remote.GetAccountDisplayCurrency(mctx.Ctx(), mctx.G(), accountID)
+	if err != nil {
+		return res, err
+	}
+	conf, err := mctx.G().GetStellar().GetServerDefinitions(mctx.Ctx())
+	if err != nil {
+		return res, err
+	}
+	currency, ok := conf.GetCurrencyLocal(stellar1.OutsideCurrencyCode(codeStr))
+	if !ok {
+		return res, fmt.Errorf("Got unrecognized currency code %q", codeStr)
+	}
+	return currency, nil
 }
 
 func accountIDFromSecretKey(skey stellar1.SecretKey) (stellar1.AccountID, error) {

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keybase/client/go/stellar/relays"
 	"github.com/keybase/client/go/stellar/remote"
 	"github.com/keybase/client/go/stellar/stellarcommon"
+	stellaramount "github.com/stellar/go/amount"
 )
 
 const WorthCurrencyErrorCode = "ERR"
@@ -601,20 +602,7 @@ func (s *Server) GetDisplayCurrencyLocal(ctx context.Context, arg stellar1.GetDi
 	if arg.AccountID.IsNil() {
 		return res, errors.New("passed empty AccountID")
 	}
-	codeStr, err := remote.GetAccountDisplayCurrency(ctx, s.G(), arg.AccountID)
-	if err != nil {
-		return res, err
-	}
-	conf, err := s.G().GetStellar().GetServerDefinitions(ctx)
-	if err != nil {
-		return res, err
-	}
-	currency, ok := conf.GetCurrencyLocal(stellar1.OutsideCurrencyCode(codeStr))
-	if !ok {
-		s.G().Log.CWarningf(ctx, "Got currency code %q for account %q that is not recognized.",
-			codeStr, arg.AccountID)
-	}
-	return currency, nil
+	return stellar.GetCurrencySetting(s.mctx(ctx), s.remoter, arg.AccountID)
 }
 
 func (s *Server) GetWalletAccountPublicKeyLocal(ctx context.Context, arg stellar1.GetWalletAccountPublicKeyLocalArg) (res string, err error) {
@@ -677,8 +665,350 @@ func (s *Server) BuildPaymentLocal(ctx context.Context, arg stellar1.BuildPaymen
 		return res, err
 	}
 
-	// Not implemented. CORE-7871
-	return res, fmt.Errorf("BuildPaymentLocal not implemented")
+	tracer := s.G().CTimeTracer(ctx, "BuildPaymentLocal", true)
+	defer tracer.Finish()
+
+	readyChecklist := struct {
+		from       bool
+		to         bool
+		amount     bool
+		secretNote bool
+		publicMemo bool
+	}{}
+	uis := libkb.UIs{
+		IdentifyUI: s.uiSource.IdentifyUI(s.G(), arg.SessionID),
+	}
+	log := func(format string, args ...interface{}) {
+		s.G().Log.CDebugf(ctx, "bpl: "+format, args...)
+	}
+
+	bpc := stellar.GetBuildPaymentCache(s.mctx(ctx), s.remoter)
+	if bpc == nil {
+		return res, fmt.Errorf("missing build payment cache")
+	}
+
+	// -------------------- from --------------------
+
+	tracer.Stage("from")
+	fromInfo := struct {
+		available bool
+		from      stellar1.AccountID
+	}{}
+	owns, err := bpc.OwnsAccount(s.mctx(ctx), arg.From)
+	if err != nil || !owns {
+		log("UserOwnsAccount -> owns:%v err:%v", owns, err)
+		res.Banners = append(res.Banners, stellar1.SendBannerLocal{
+			Level:   "error",
+			Message: "Could not find source account.",
+		})
+	} else {
+		fromInfo.from = arg.From
+		fromInfo.available = true
+		if arg.FromSeqno == "" {
+			readyChecklist.from = true
+		} else {
+			// Check that the seqno of the account matches the caller's expectation.
+			seqno, err := bpc.AccountSeqno(s.mctx(ctx), arg.From)
+			switch {
+			case err != nil:
+				log("AccountSeqno -> err:%v", err)
+				res.Banners = append(res.Banners, stellar1.SendBannerLocal{
+					Level:   "error",
+					Message: "Could not get seqno for source account.",
+				})
+			case seqno != arg.FromSeqno:
+				log("AccountSeqno -> got:%v != want:%v", seqno, arg.FromSeqno)
+				res.Banners = append(res.Banners, stellar1.SendBannerLocal{
+					Level:   "error",
+					Message: "Activity on account since initiating send. Take another look at account history.",
+				})
+			default:
+				readyChecklist.from = true
+				fromInfo.from = arg.From
+				fromInfo.available = true
+			}
+		}
+	}
+
+	// -------------------- to --------------------
+
+	tracer.Stage("to")
+	var skipRecipient bool
+	var minAmountXLM string
+	if arg.ToIsAccountID {
+		_, err := libkb.ParseStellarAccountID(arg.To)
+		if err != nil {
+			res.ToErrMsg = err.Error()
+			skipRecipient = true
+		} else {
+			readyChecklist.to = true
+		}
+	}
+	if !skipRecipient {
+		recipient, err := bpc.LookupRecipient(s.mctx(ctx).WithUIs(uis), stellarcommon.RecipientInput(arg.To))
+		if err != nil {
+			log("error with recipient field %v: %v", arg.To, err)
+			res.ToErrMsg = "recipient not found"
+			skipRecipient = true
+		} else {
+			readyChecklist.to = true
+			addMinBanner := func(them, amount string) {
+				res.Banners = append(res.Banners, stellar1.SendBannerLocal{
+					Level:   "info",
+					Message: fmt.Sprintf("Because it's %s first transaction, you must send at least %s XLM.", them, amount),
+				})
+			}
+			bannerThem := "their"
+			if recipient.User != nil {
+				bannerThem = fmt.Sprintf("%s's", recipient.User.GetNormalizedName())
+			}
+			if recipient.AccountID == nil {
+				// Sending a payment to a target with no account. (relay)
+				minAmountXLM = "2.01"
+				addMinBanner(bannerThem, minAmountXLM)
+			} else {
+				isFunded, err := bpc.IsAccountFunded(s.mctx(ctx), stellar1.AccountID(recipient.AccountID.String()))
+				if err != nil {
+					log("error checking recipient funding status %v: %v", *recipient.AccountID, err)
+				} else if !isFunded {
+					// Sending to a non-funded stellar account.
+					minAmountXLM = "1"
+					addMinBanner(bannerThem, minAmountXLM)
+				}
+			}
+		}
+	}
+
+	// -------------------- amount + asset --------------------
+
+	tracer.Stage("amount + asset")
+	bpaArg := buildPaymentAmountArg{
+		Amount:   arg.Amount,
+		Currency: arg.Currency,
+		Asset:    arg.Asset,
+	}
+	if fromInfo.available {
+		bpaArg.From = &fromInfo.from
+	}
+	amountX := s.buildPaymentAmountHelper(ctx, bpc, bpaArg)
+	res.AmountErrMsg = amountX.amountErrMsg
+	res.WorthDescription = amountX.worthDescription
+	res.WorthInfo = amountX.worthInfo
+
+	if amountX.haveAmount {
+		if !amountX.asset.IsNativeXLM() {
+			return res, fmt.Errorf("sending non-XLM assets is not supported")
+		}
+		readyChecklist.amount = true
+
+		if fromInfo.available {
+			// Check that the sender has enough asset available.
+			// Note: When adding support for sending non-XLM assets, check the asset instead of XLM here.
+			availableToSendXLM, err := bpc.AvailableXLMToSend(s.mctx(ctx), fromInfo.from)
+			if err != nil {
+				log("error getting available balance: %v", err)
+			} else {
+				cmp, err := stellar.CompareAmounts(availableToSendXLM, amountX.amountOfAsset)
+				switch {
+				case err != nil:
+					log("error comparing amounts", err)
+				case cmp == -1:
+					// Send amount is more than the available to send.
+					readyChecklist.amount = false // block sending
+					res.AmountErrMsg = fmt.Sprintf("Your available to send is *%s XLM*", availableToSendXLM)
+					if arg.Currency != nil && amountX.rate != nil {
+						// If the user entered an amount in outside currency and an exchange
+						// rate is available, attempt to show them available balance in that currency.
+						availableToSendOutside, err := stellar.ConvertXLMToOutside(availableToSendXLM, *amountX.rate)
+						if err != nil {
+							log("error converting available-to-send", err)
+						} else {
+							formattedATS, err := stellar.FormatCurrency(ctx, s.G(), availableToSendOutside, amountX.rate.Currency)
+							if err != nil {
+								log("error formatting available-to-send", err)
+							} else {
+								res.AmountErrMsg = fmt.Sprintf("Your available to send is *%s*", formattedATS)
+							}
+						}
+					}
+				default:
+					// Welcome back. How was your stay at the error handling hotel?
+				}
+			}
+		}
+
+		// Note: When adding support for sending non-XLM assets, check here that the recipient accepts the asset.
+	}
+
+	// -------------------- note + memo --------------------
+
+	tracer.Stage("note + memo")
+	if len(arg.SecretNote) <= 500 {
+		readyChecklist.secretNote = true
+	} else {
+		res.SecretNoteErrMsg = "Note is too long."
+	}
+
+	if len(arg.PublicMemo) <= 28 {
+		readyChecklist.publicMemo = true
+	} else {
+		res.PublicMemoErrMsg = "Memo is too long."
+	}
+
+	// -------------------- end --------------------
+
+	if readyChecklist.from && readyChecklist.to && readyChecklist.amount && readyChecklist.secretNote && readyChecklist.publicMemo {
+		res.ReadyToSend = true
+	}
+	return res, nil
+}
+
+type buildPaymentAmountArg struct {
+	// See buildPaymentLocal in avdl from which these args are copied.
+	Amount   string
+	Currency *stellar1.OutsideCurrencyCode
+	Asset    *stellar1.Asset
+	From     *stellar1.AccountID
+}
+
+type buildPaymentAmountResult struct {
+	haveAmount       bool // whether `amountOfAsset` and `asset` are valid
+	amountOfAsset    string
+	asset            stellar1.Asset
+	amountErrMsg     string
+	worthDescription string
+	worthInfo        string
+	// Rate may be nil if there was an error fetching it.
+	rate *stellar1.OutsideExchangeRate
+}
+
+func (s *Server) buildPaymentAmountHelper(ctx context.Context, bpc stellar.BuildPaymentCache, arg buildPaymentAmountArg) (res buildPaymentAmountResult) {
+	log := func(format string, args ...interface{}) {
+		s.G().Log.CDebugf(ctx, "bpl: "+format, args...)
+	}
+	res.asset = stellar1.AssetNative()
+	switch {
+	case arg.Currency != nil && arg.Asset == nil:
+		// Amount is of outside currency.
+		convertAmountOutside := "0"
+		if arg.Amount == "" {
+			// No amount given. Still convert for 0.
+		} else {
+			amount, err := stellar.ParseDecimalStrict(arg.Amount)
+			if err != nil || amount.Sign() < 0 {
+				// Invalid or negative amount.
+				res.amountErrMsg = "Invalid amount."
+				return res
+			}
+			if amount.Sign() > 0 {
+				// Only save the amount if it's non-zero. So that =="0" later works.
+				convertAmountOutside = arg.Amount
+			}
+		}
+		xrate, err := bpc.GetOutsideExchangeRate(s.mctx(ctx), *arg.Currency)
+		if err != nil {
+			log("error getting exchange rate for %v: %v", arg.Currency, err)
+			res.amountErrMsg = fmt.Sprintf("Could not get exchange rate for %v", arg.Currency.String())
+			return res
+		}
+		res.rate = &xrate
+		xlmAmount, err := stellar.ConvertOutsideToXLM(convertAmountOutside, xrate)
+		if err != nil {
+			log("error converting: %v", err)
+			res.amountErrMsg = fmt.Sprintf("Could not convert to XLM")
+			return res
+		}
+		res.amountOfAsset = xlmAmount
+		xlmAmountFormatted, err := stellar.FormatAmountXLM(xlmAmount)
+		if err != nil {
+			log("error formatting converted XLM amount: %v", err)
+			res.amountErrMsg = fmt.Sprintf("Could not convert to XLM")
+			return res
+		}
+		res.worthDescription = fmt.Sprintf("This is *%s*", xlmAmountFormatted)
+		if convertAmountOutside != "0" {
+			// haveAmount gates whether the send button is enabled.
+			// Only enable after `worthDescription` is set.
+			// Don't allow the user to send if they haven't seen `worthDescription`,
+			// since that's what they are really sending.
+			res.haveAmount = true
+		}
+		res.worthInfo, err = s.buildPaymentWorthInfo(ctx, xrate)
+		if err != nil {
+			log("error making worth info: %v", err)
+			res.worthInfo = ""
+		}
+		return res
+	case arg.Currency == nil:
+		// Amount is of asset.
+		useAmount := "0"
+		if arg.Amount != "" {
+			amountInt64, err := stellaramount.ParseInt64(arg.Amount)
+			if err != nil || amountInt64 <= 0 {
+				res.amountErrMsg = "Invalid amount."
+				return res
+			}
+			res.amountOfAsset = arg.Amount
+			res.haveAmount = true
+			useAmount = arg.Amount
+		}
+		// Attempt to show the converted amount in outside currency.
+		// Unlike when sending based on outside currency, conversion is not critical.
+		if arg.From == nil {
+			log("missing from address so can't convert XLM amount")
+			return res
+		}
+		currency, err := bpc.GetOutsideCurrencyPreference(s.mctx(ctx), *arg.From)
+		if err != nil {
+			log("error getting preferred currency for %v: %v", *arg.From, err)
+			return res
+		}
+		xrate, err := bpc.GetOutsideExchangeRate(s.mctx(ctx), currency)
+		if err != nil {
+			log("error getting exchange rate for %v: %v", currency, err)
+			return res
+		}
+		res.rate = &xrate
+		outsideAmount, err := stellar.ConvertXLMToOutside(useAmount, xrate)
+		if err != nil {
+			log("error converting: %v", err)
+			return res
+		}
+		outsideAmountFormatted, err := stellar.FormatCurrency(ctx, s.G(), outsideAmount, xrate.Currency)
+		if err != nil {
+			log("error formatting converted outside amount: %v", err)
+			return res
+		}
+		res.worthDescription = fmt.Sprintf("This is *%s*", outsideAmountFormatted)
+		res.worthInfo, err = s.buildPaymentWorthInfo(ctx, xrate)
+		if err != nil {
+			log("error making worth info: %v", err)
+			res.worthInfo = ""
+		}
+		return res
+	default:
+		// This is an API contract problem.
+		s.G().Log.CWarningf(ctx, "Only one of Asset and Currency parameters should be filled")
+		res.amountErrMsg = "Error in communication"
+		return res
+	}
+}
+
+func (s *Server) buildPaymentWorthInfo(ctx context.Context, rate stellar1.OutsideExchangeRate) (worthInfo string, err error) {
+	oneOutsideFormatted, err := stellar.FormatCurrency(ctx, s.G(), "1", rate.Currency)
+	if err != nil {
+		return "", err
+	}
+	amountXLM, err := stellar.ConvertOutsideToXLM("1", rate)
+	if err != nil {
+		return "", err
+	}
+	amountXLMFormatted, err := stellar.FormatAmountXLM(amountXLM)
+	if err != nil {
+		return "", err
+	}
+	worthInfo = fmt.Sprintf("%s = %s\nSource: coinmarketcap.com", oneOutsideFormatted, amountXLMFormatted)
+	return worthInfo, nil
 }
 
 func (s *Server) SendPaymentLocal(ctx context.Context, arg stellar1.SendPaymentLocalArg) (res stellar1.SendPaymentResLocal, err error) {

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -840,7 +840,7 @@ func requireBannerSet(t testing.TB, bres stellar1.BuildPaymentResLocal, expected
 	sort.Slice(expected, func(i, j int) bool {
 		return expected[i].Message < expected[j].Message
 	})
-	for i, _ := range expected {
+	for i := range expected {
 		require.Equal(t, expected[i], got[i])
 	}
 }

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -2,8 +2,11 @@ package stellarsvc
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/stellar"
 	"github.com/keybase/client/go/stellar/remote"
@@ -76,19 +79,11 @@ func TestGetAccountAssetsLocalEmptyBalance(t *testing.T) {
 	tcs, cleanup := setupNTests(t, 1)
 	defer cleanup()
 
-	_, err := stellar.CreateWallet(context.Background(), tcs[0].G)
-	require.NoError(t, err)
-
-	accountID := tcs[0].Backend.AddAccountEmpty(t)
-
-	argImport := stellar1.ImportSecretKeyLocalArg{
-		SecretKey:   tcs[0].Backend.SecretKey(accountID),
-		MakePrimary: true,
-	}
-	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), argImport)
-	require.NoError(t, err)
-
 	tcs[0].Backend.ImportAccountsForUser(tcs[0])
+
+	accounts, err := tcs[0].Srv.GetWalletAccountsLocal(context.Background(), 0)
+	require.NoError(t, err)
+	accountID := accounts[0].AccountID
 
 	assets, err := tcs[0].Srv.GetAccountAssetsLocal(context.Background(), stellar1.GetAccountAssetsLocalArg{AccountID: accountID})
 	require.NoError(t, err)
@@ -516,8 +511,6 @@ func TestGetPaymentsLocal(t *testing.T) {
 	err = srvRecip.ImportSecretKeyLocal(context.Background(), argImport)
 	require.NoError(t, err)
 
-	usd := stellar1.OutsideCurrencyCode("USD")
-
 	// Try some payments that should fail locally
 	{
 		_, err := srvSender.SendPaymentLocal(context.Background(), stellar1.SendPaymentLocalArg{
@@ -659,3 +652,197 @@ func TestGetPaymentsLocal(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestBuildPaymentLocal(t *testing.T) {
+	tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	senderAccountID, err := stellar.GetOwnPrimaryAccountID(context.Background(), tcs[0].G)
+	require.NoError(t, err)
+
+	worthInfo := "$1.00 = 3.1414139 XLM\nSource: coinmarketcap.com"
+
+	bres, err := tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From: senderAccountID,
+		To:   tcs[1].Fu.Username,
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, false, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, "", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "", bres.PublicMemoErrMsg)
+	require.Equal(t, "This is *$0.00*", bres.WorthDescription)
+	require.Equal(t, worthInfo, bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
+		Level:   "info",
+		Message: fmt.Sprintf("Because it's %v's first transaction, you must send at least 1 XLM.", tcs[1].Fu.Username),
+	}})
+
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:   senderAccountID,
+		To:     tcs[1].Fu.Username,
+		Amount: "-1",
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, false, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, "Invalid amount.", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "", bres.PublicMemoErrMsg)
+	require.Equal(t, "", bres.WorthDescription)
+	require.Equal(t, "", bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
+		Level:   "info",
+		Message: fmt.Sprintf("Because it's %v's first transaction, you must send at least 1 XLM.", tcs[1].Fu.Username),
+	}})
+
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:   senderAccountID,
+		To:     tcs[1].Fu.Username,
+		Amount: "30",
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, false, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, "Your available to send is *0 XLM*", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "", bres.PublicMemoErrMsg)
+	require.Equal(t, "This is *$9.55*", bres.WorthDescription)
+	require.Equal(t, worthInfo, bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
+		Level:   "info",
+		Message: fmt.Sprintf("Because it's %v's first transaction, you must send at least 1 XLM.", tcs[1].Fu.Username),
+	}})
+
+	tcs[0].Backend.ImportAccountsForUser(tcs[0])
+	tcs[0].Backend.Gift(senderAccountID, "20")
+
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:   senderAccountID,
+		To:     tcs[1].Fu.Username,
+		Amount: "30",
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, false, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, "Your available to send is *19.0000000 XLM*", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "", bres.PublicMemoErrMsg)
+	require.Equal(t, "This is *$9.55*", bres.WorthDescription)
+	require.Equal(t, worthInfo, bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
+		Level:   "info",
+		Message: fmt.Sprintf("Because it's %v's first transaction, you must send at least 1 XLM.", tcs[1].Fu.Username),
+	}})
+
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:   senderAccountID,
+		To:     tcs[1].Fu.Username,
+		Amount: "15",
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, true, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, "", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "", bres.PublicMemoErrMsg)
+	require.Equal(t, "This is *$4.77*", bres.WorthDescription)
+	require.Equal(t, worthInfo, bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
+		Level:   "info",
+		Message: fmt.Sprintf("Because it's %v's first transaction, you must send at least 1 XLM.", tcs[1].Fu.Username),
+	}})
+
+	_, err = tcs[0].Srv.SendPaymentLocal(context.Background(), stellar1.SendPaymentLocalArg{
+		From:   senderAccountID,
+		To:     tcs[1].Fu.Username,
+		Amount: "15",
+		Asset:  stellar1.AssetNative(),
+	})
+	require.NoError(t, err)
+
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:       senderAccountID,
+		To:         tcs[1].Fu.Username,
+		Amount:     "15",
+		PublicMemo: "🥔🥔🥔🥔🥔🥔🥔🥔",
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, false, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, "Your available to send is *3.9999900 XLM*", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "Memo is too long.", bres.PublicMemoErrMsg) // too many potatoes
+	require.Equal(t, "This is *$4.77*", bres.WorthDescription)
+	require.Equal(t, worthInfo, bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{}) // recipient is funded so banner's gone
+
+	t.Logf("using FromSeqno")
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:       senderAccountID,
+		FromSeqno:  "12",
+		To:         tcs[1].Fu.Username,
+		Amount:     "3",
+		PublicMemo: "🥔🥔🥔🥔🥔🥔🥔🥔",
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, false, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, "", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "Memo is too long.", bres.PublicMemoErrMsg)
+	require.Equal(t, "This is *$0.95*", bres.WorthDescription)
+	require.Equal(t, worthInfo, bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
+		Level:   "error",
+		Message: "Activity on account since initiating send. Take another look at account history.",
+	}})
+
+	tcs[0].Backend.Gift(senderAccountID, "30")
+
+	t.Logf("sending in amount composed in USD")
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:     senderAccountID,
+		To:       tcs[1].Fu.Username,
+		Amount:   "8.50",
+		Currency: &usd,
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, true, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, "", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "", bres.PublicMemoErrMsg)
+	require.Equal(t, "This is *26.7020180 XLM*", bres.WorthDescription)
+	require.Equal(t, worthInfo, bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{})
+}
+
+// modifies `expected`
+func requireBannerSet(t testing.TB, bres stellar1.BuildPaymentResLocal, expected []stellar1.SendBannerLocal) {
+	if len(bres.Banners) != len(expected) {
+		t.Logf(spew.Sdump(bres.Banners))
+		require.Len(t, bres.Banners, len(expected))
+	}
+	got := bres.DeepCopy().Banners
+	sort.Slice(got, func(i, j int) bool {
+		return got[i].Message < got[j].Message
+	})
+	sort.Slice(expected, func(i, j int) bool {
+		return expected[i].Message < expected[j].Message
+	})
+	for i, _ := range expected {
+		require.Equal(t, expected[i], got[i])
+	}
+}
+
+var usd = stellar1.OutsideCurrencyCode("USD")

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -394,7 +394,8 @@ func (r *BackendMock) Balances(ctx context.Context, accountID stellar1.AccountID
 	defer r.Unlock()
 	a, ok := r.accounts[accountID]
 	if !ok {
-		return nil, libkb.NotFoundError{}
+		// If an account does not exist on the network, return empty balance list.
+		return nil, nil
 	}
 	return []stellar1.Balance{a.balance}, nil
 }
@@ -434,14 +435,19 @@ func (r *BackendMock) SubmitPayment(ctx context.Context, tc *TestContext, post s
 		return stellar1.PaymentResult{}, errors.New("can only handle native")
 	}
 
+	toIsFunded := false
+	b, toExists := r.accounts[extract.To]
+
+	if !toIsFunded {
+		if extract.AmountXdr < 10000000 {
+			return stellar1.PaymentResult{}, errors.New("op minimum reserve get outta here")
+		}
+	}
+	if !toExists {
+		b = r.addAccountByID(extract.To, false)
+	}
 	a.SubtractBalance(extract.Amount)
 	a.AdjustBalance(-(int64(unpackedTx.Tx.Fee)))
-
-	b, ok := r.accounts[extract.To]
-	if !ok {
-		return res, fmt.Errorf("destination not funded: %v", extract.To)
-	}
-	// we know about destination as well
 	b.AddBalance(extract.Amount)
 
 	caller, err := tc.G.GetMeUV(ctx)
@@ -620,9 +626,16 @@ func (r *BackendMock) Details(ctx context.Context, tc *TestContext, accountID st
 	r.Lock()
 	defer r.Unlock()
 
+	_, err = stellarnet.NewAddressStr(string(accountID))
+	if err != nil {
+		return res, err
+	}
+
 	a, ok := r.accounts[accountID]
 	if !ok {
-		return stellar1.AccountDetails{}, libkb.NotFoundError{}
+		// If an account does not exist on the network, return empty details (WAT)
+		res.AccountID = accountID
+		return res, nil
 	}
 	var balances []stellar1.Balance
 	if a.balance.Amount != "" {

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -148,7 +148,6 @@ protocol local {
     string subtext; // Examples: "", "max doesn't accept HUGZ"
   }
 
-  // Not implemented. CORE-7871
   // Check but do not send a payment.
   // Opt  - Optional field.
   // Opt* - Optional for this RPC but required for res.readyToSend to be set.
@@ -166,6 +165,7 @@ protocol local {
     // Zero or one of `asset` and `currency` should be set.
     // If both are null or `asset` is native XLM then XLM are being sent.
     // If `currency` is set then XLM is being sent after converting `amount`.
+    // Note: Sending non-XLM assets is not yet supported.
     union { null, OutsideCurrencyCode } currency,
     union { null, Asset } asset,
     string secretNote,   // Opt. Encrypted for the sender, and recipient if possible.


### PR DESCRIPTION
Implement buildPayment. It hardly ever errors out, instead returning a value peppered with error fields. Expand `frontend.go`, that's where the good stuff is.

Can't handle sending non-XLM assets. But can handle sending USD and other outside currencies. The rpc signature is set up to be able to handle non-XLM assets.

The way it's done now there are a lot of operations that will roundtrip each call. But they are packaged up into `BuildPaymentCache` (CORE-8119) which is an interface with methods that could be sped up with caching.

There are some tests. There are a lot of branches, not nearly all of them are hit.