### PR TITLE
Fix multiple attachment upload

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -14,9 +14,9 @@ export const resetStore = 'common:resetStore' // not a part of chat2 but is hand
 export const attachmentDownload = 'chat2:attachmentDownload'
 export const attachmentDownloaded = 'chat2:attachmentDownloaded'
 export const attachmentLoading = 'chat2:attachmentLoading'
-export const attachmentUpload = 'chat2:attachmentUpload'
 export const attachmentUploaded = 'chat2:attachmentUploaded'
 export const attachmentUploading = 'chat2:attachmentUploading'
+export const attachmentsUpload = 'chat2:attachmentsUpload'
 export const badgesUpdated = 'chat2:badgesUpdated'
 export const blockConversation = 'chat2:blockConversation'
 export const clearLoading = 'chat2:clearLoading'
@@ -98,11 +98,6 @@ type _AttachmentLoadingPayload = $ReadOnly<{|
   ratio: number,
   isPreview: boolean,
 |}>
-type _AttachmentUploadPayload = $ReadOnly<{|
-  conversationIDKey: Types.ConversationIDKey,
-  path: string,
-  title: string,
-|}>
 type _AttachmentUploadedPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
   ordinal: Types.Ordinal,
@@ -111,6 +106,11 @@ type _AttachmentUploadingPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
   ordinal: Types.Ordinal,
   ratio: number,
+|}>
+type _AttachmentsUploadPayload = $ReadOnly<{|
+  conversationIDKey: Types.ConversationIDKey,
+  paths: Array<string>,
+  titles: Array<string>,
 |}>
 type _BadgesUpdatedPayload = $ReadOnly<{|conversations: Array<RPCTypes.BadgeConversationInfo>|}>
 type _BlockConversationPayload = $ReadOnly<{|
@@ -364,9 +364,9 @@ export const createSetPendingConversationExistingConversationIDKey = (payload: _
 export const createAttachmentDownload = (payload: _AttachmentDownloadPayload) => ({error: false, payload, type: attachmentDownload})
 export const createAttachmentDownloaded = (payload: _AttachmentDownloadedPayload) => ({error: false, payload, type: attachmentDownloaded})
 export const createAttachmentLoading = (payload: _AttachmentLoadingPayload) => ({error: false, payload, type: attachmentLoading})
-export const createAttachmentUpload = (payload: _AttachmentUploadPayload) => ({error: false, payload, type: attachmentUpload})
 export const createAttachmentUploaded = (payload: _AttachmentUploadedPayload) => ({error: false, payload, type: attachmentUploaded})
 export const createAttachmentUploading = (payload: _AttachmentUploadingPayload) => ({error: false, payload, type: attachmentUploading})
+export const createAttachmentsUpload = (payload: _AttachmentsUploadPayload) => ({error: false, payload, type: attachmentsUpload})
 export const createBadgesUpdated = (payload: _BadgesUpdatedPayload) => ({error: false, payload, type: badgesUpdated})
 export const createBlockConversation = (payload: _BlockConversationPayload) => ({error: false, payload, type: blockConversation})
 export const createClearLoading = (payload: _ClearLoadingPayload) => ({error: false, payload, type: clearLoading})
@@ -423,9 +423,9 @@ export const createUpdateTypers = (payload: _UpdateTypersPayload) => ({error: fa
 export type AttachmentDownloadPayload = $Call<typeof createAttachmentDownload, _AttachmentDownloadPayload>
 export type AttachmentDownloadedPayload = $Call<typeof createAttachmentDownloaded, _AttachmentDownloadedPayload>
 export type AttachmentLoadingPayload = $Call<typeof createAttachmentLoading, _AttachmentLoadingPayload>
-export type AttachmentUploadPayload = $Call<typeof createAttachmentUpload, _AttachmentUploadPayload>
 export type AttachmentUploadedPayload = $Call<typeof createAttachmentUploaded, _AttachmentUploadedPayload>
 export type AttachmentUploadingPayload = $Call<typeof createAttachmentUploading, _AttachmentUploadingPayload>
+export type AttachmentsUploadPayload = $Call<typeof createAttachmentsUpload, _AttachmentsUploadPayload>
 export type BadgesUpdatedPayload = $Call<typeof createBadgesUpdated, _BadgesUpdatedPayload>
 export type BlockConversationPayload = $Call<typeof createBlockConversation, _BlockConversationPayload>
 export type ClearLoadingPayload = $Call<typeof createClearLoading, _ClearLoadingPayload>
@@ -495,9 +495,9 @@ export type Actions =
   | AttachmentDownloadPayload
   | AttachmentDownloadedPayload
   | AttachmentLoadingPayload
-  | AttachmentUploadPayload
   | AttachmentUploadedPayload
   | AttachmentUploadingPayload
+  | AttachmentsUploadPayload
   | BadgesUpdatedPayload
   | BlockConversationPayload
   | ClearLoadingPayload

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1299,7 +1299,7 @@ const changeSelectedConversation = (
     | Chat2Gen.MetaDeletePayload
     | Chat2Gen.MessageSendPayload
     | Chat2Gen.SetPendingModePayload
-    | Chat2Gen.AttachmentUploadPayload
+    | Chat2Gen.AttachmentsUploadPayload
     | TeamsGen.LeaveTeamPayload,
   state: TypedState
 ) => {
@@ -1322,7 +1322,7 @@ const changeSelectedConversation = (
       break
     }
     case Chat2Gen.messageSend: // fallthrough
-    case Chat2Gen.attachmentUpload:
+    case Chat2Gen.attachmentsUpload:
       // Sent into a resolved pending conversation? Select the resolved one
       if (selected === Constants.pendingConversationIDKey) {
         const resolvedPendingConversationIDKey = Constants.getResolvedPendingConversationIDKey(state)
@@ -1349,7 +1349,7 @@ const _maybeAutoselectNewestConversation = (
     | Chat2Gen.MetaDeletePayload
     | Chat2Gen.MessageSendPayload
     | Chat2Gen.SetPendingModePayload
-    | Chat2Gen.AttachmentUploadPayload
+    | Chat2Gen.AttachmentsUploadPayload
     | TeamsGen.LeaveTeamPayload,
   state: TypedState
 ) => {
@@ -1517,20 +1517,25 @@ function* attachmentDownload(action: Chat2Gen.AttachmentDownloadPayload) {
 }
 
 // Upload an attachment
-function* attachmentUpload(action: Chat2Gen.AttachmentUploadPayload) {
-  const {conversationIDKey, path, title} = action.payload
+function* attachmentsUpload(action: Chat2Gen.AttachmentsUploadPayload) {
+  const {conversationIDKey, paths, titles} = action.payload
   const state: TypedState = yield Saga.select()
 
-  const outboxID = Constants.generateOutboxID()
+  const outboxIDs = paths.map(p => Constants.generateOutboxID())
 
-  // Make the preview
-  const preview: ?RPCChatTypes.MakePreviewRes = yield Saga.call(
-    RPCChatTypes.localMakePreviewRpcPromise,
-    ({
-      attachment: {filename: path},
-      outputDir: tmpDir(),
-    }: RPCChatTypes.LocalMakePreviewRpcParam)
+  // Make the previews
+  const previews: Array<?RPCChatTypes.MakePreviewRes> = yield Saga.sequentially(
+    paths.map(filename =>
+      Saga.call(
+        RPCChatTypes.localMakePreviewRpcPromise,
+        ({
+          attachment: {filename},
+          outputDir: tmpDir(),
+        }: RPCChatTypes.LocalMakePreviewRpcParam)
+      )
+    )
   )
+  const previewURLs = previews.map(preview => (preview && preview.filename) || '')
 
   const meta = state.chat2.metaMap.get(conversationIDKey)
   if (!meta) {
@@ -1544,25 +1549,63 @@ function* attachmentUpload(action: Chat2Gen.AttachmentUploadPayload) {
     : 0
   const ephemeralData = ephemeralLifetime !== 0 ? {ephemeralLifetime} : {}
 
-  const attachmentType = Constants.pathToAttachmentType(path)
-  const message = Constants.makePendingAttachmentMessage(
+  const attachmentTypes = paths.map(path => Constants.pathToAttachmentType(path))
+  const messages = Constants.makePendingAttachmentMessages(
     state,
     conversationIDKey,
-    attachmentType,
-    title,
-    (preview && preview.filename) || '',
-    Types.stringToOutboxID(outboxID.toString('hex') || ''), // never null but makes flow happy
+    attachmentTypes,
+    titles,
+    previewURLs,
+    outboxIDs.map(outboxID => Types.stringToOutboxID(outboxID.toString('hex') || '')), // never null but makes flow happy
     ephemeralLifetime
   )
-  const ordinal = message.ordinal
+  const ordinals = messages.map(m => m.ordinal)
   yield Saga.put(
+    // $FlowIssue getting confused about props on the message union
     Chat2Gen.createMessagesAdd({
       context: {type: 'sent'},
-      messages: [message],
+      messages,
     })
   )
-  yield Saga.put(Chat2Gen.createAttachmentUploading({conversationIDKey, ordinal, ratio: 0.01}))
+  yield Saga.sequentially(
+    ordinals.map(ordinal =>
+      Saga.put(Chat2Gen.createAttachmentUploading({conversationIDKey, ordinal, ratio: 0.01}))
+    )
+  )
 
+  yield Saga.sequentially(
+    paths.map((path, i) =>
+      Saga.call(attachmentUploadCall, {
+        conversationIDKey,
+        ephemeralData,
+        ordinal: ordinals[i],
+        outboxID: outboxIDs[i],
+        path,
+        title: titles[i],
+        tlfName: meta.tlfname,
+      })
+    )
+  )
+}
+
+function* attachmentUploadCall({
+  path,
+  conversationIDKey,
+  outboxID,
+  title,
+  tlfName,
+  ordinal,
+  ephemeralData,
+}: {
+  path: string,
+  conversationIDKey: Types.ConversationIDKey,
+  outboxID: Buffer,
+  title: string,
+  tlfName: string,
+  ordinal: Types.Ordinal,
+  ephemeralData: {ephemeralLifetime?: number},
+}) {
+  const state = yield Saga.select()
   try {
     let lastRatioSent = -1 // force the first update to show no matter what
     yield RPCChatTypes.localPostFileAttachmentLocalRpcSaga(
@@ -1574,7 +1617,7 @@ function* attachmentUpload(action: Chat2Gen.AttachmentUploadPayload) {
         metadata: Buffer.from([]),
         outboxID,
         title,
-        tlfName: meta.tlfname,
+        tlfName,
         visibility: RPCTypes.commonTLFVisibility.private,
       },
       {
@@ -2078,7 +2121,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
       Chat2Gen.metaDelete,
       Chat2Gen.setPendingMode,
       Chat2Gen.messageSend,
-      Chat2Gen.attachmentUpload,
+      Chat2Gen.attachmentsUpload,
       TeamsGen.leaveTeam,
     ],
     changeSelectedConversation
@@ -2143,7 +2186,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
   )
 
   yield Saga.safeTakeEvery(Chat2Gen.attachmentDownload, attachmentDownload)
-  yield Saga.safeTakeEvery(Chat2Gen.attachmentUpload, attachmentUpload)
+  yield Saga.safeTakeEvery(Chat2Gen.attachmentsUpload, attachmentsUpload)
 
   yield Saga.safeTakeEveryPure(Chat2Gen.sendTyping, sendTyping)
   yield Saga.safeTakeEveryPure(Chat2Gen.resetChatWithoutThem, resetChatWithoutThem)

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -290,11 +290,11 @@
       "path?": "string",
       "forShare?": "boolean"
     },
-    // We want to upload an attachment
-    "attachmentUpload": {
+    // We want to upload some attachments
+    "attachmentsUpload": {
       "conversationIDKey": "Types.ConversationIDKey",
-      "path": "string",
-      "title": "string"
+      "paths": "Array<string>",
+      "titles": "Array<string>"
     },
     // Update progress on an upload
     "attachmentUploading": {

--- a/shared/chat/conversation/attachment-get-titles/container.js
+++ b/shared/chat/conversation/attachment-get-titles/container.js
@@ -18,15 +18,15 @@ const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   _onSubmit: (conversationIDKey: Types.ConversationIDKey, pathToInfo: PathToInfo) => {
-    Object.keys(pathToInfo).forEach(path => {
-      dispatch(
-        Chat2Gen.createAttachmentUpload({
-          conversationIDKey,
-          path,
-          title: pathToInfo[path].title,
-        })
-      )
-    })
+    const paths = Object.keys(pathToInfo)
+    const titles = paths.map(p => pathToInfo[p].title)
+    dispatch(
+      Chat2Gen.createAttachmentsUpload({
+        conversationIDKey,
+        paths,
+        titles,
+      })
+    )
     dispatch(navigateUp())
   },
   onClose: () => dispatch(navigateUp()),

--- a/shared/chat/conversation/attachment-get-titles/index.js
+++ b/shared/chat/conversation/attachment-get-titles/index.js
@@ -61,6 +61,11 @@ class GetTitles extends React.Component<Props, State> {
     }
   }
 
+  _isLast = () => {
+    const numPaths = Object.keys(this.state.pathToInfo).length
+    return this.state.index + 1 === numPaths
+  }
+
   _updateTitle = (title: string) => {
     this.setState(state => {
       const paths = Object.keys(this.state.pathToInfo)
@@ -130,7 +135,11 @@ class GetTitles extends React.Component<Props, State> {
             />
             <ButtonBar style={{flexShrink: 0}}>
               <Button type="Secondary" onClick={this.props.onClose} label="Cancel" />
-              <WaitingButton type="Primary" waitingKey={null} onClick={this._onNext} label="Send" />
+              {this._isLast() ? (
+                <WaitingButton type="Primary" waitingKey={null} onClick={this._onNext} label="Send" />
+              ) : (
+                <Button type="Primary" onClick={this._onNext} label="Next" />
+              )}
             </ButtonBar>
           </Box>
         </ScrollView>

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -184,7 +184,7 @@ export {
   makeMessageAttachment,
   makeMessageDeleted,
   makeMessageText,
-  makePendingAttachmentMessage,
+  makePendingAttachmentMessages,
   makePendingTextMessage,
   messageExplodeDescriptions,
   pathToAttachmentType,

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -708,7 +708,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
         s.set('messageOrdinals', messageOrdinalsReducer(state.messageOrdinals, action))
       })
     // Saga only actions
-    case Chat2Gen.attachmentUpload:
+    case Chat2Gen.attachmentsUpload:
     case Chat2Gen.desktopNotification:
     case Chat2Gen.inboxRefresh:
     case Chat2Gen.joinConversation:


### PR DESCRIPTION
Fixes a bug with a `WaitingButton` implementation that hung on trying to attach multiple files. Once that was done, I noticed the attachment upload calls seemed to race and typically only the first would be rendered into the thread (they all used the same ordinal). I changed it so the action takes an array of paths and the saga delegates correctly so things show up. r? @keybase/react-hackers 