### PR TITLE
fs: implement upload

### DIFF
--- a/shared/actions/fs-gen.js
+++ b/shared/actions/fs-gen.js
@@ -13,8 +13,6 @@ export const commitEdit = 'fs:commitEdit'
 export const discardEdit = 'fs:discardEdit'
 export const dismissTransfer = 'fs:dismissTransfer'
 export const download = 'fs:download'
-export const downloadFinished = 'fs:downloadFinished'
-export const downloadStarted = 'fs:downloadStarted'
 export const editFailed = 'fs:editFailed'
 export const editSuccess = 'fs:editSuccess'
 export const favoriteIgnore = 'fs:favoriteIgnore'
@@ -42,36 +40,29 @@ export const openFinderPopup = 'fs:openFinderPopup'
 export const openInFileUI = 'fs:openInFileUI'
 export const openPathItem = 'fs:openPathItem'
 export const openSecurityPreferences = 'fs:openSecurityPreferences'
+export const pickAndUpload = 'fs:pickAndUpload'
 export const refreshLocalHTTPServerInfo = 'fs:refreshLocalHTTPServerInfo'
 export const save = 'fs:save'
 export const setFlags = 'fs:setFlags'
 export const setupFSHandlers = 'fs:setupFSHandlers'
 export const share = 'fs:share'
 export const sortSetting = 'fs:sortSetting'
+export const transferFinished = 'fs:transferFinished'
 export const transferProgress = 'fs:transferProgress'
+export const transferStarted = 'fs:transferStarted'
 export const uninstallKBFS = 'fs:uninstallKBFS'
 export const uninstallKBFSConfirm = 'fs:uninstallKBFSConfirm'
+export const upload = 'fs:upload'
 
 // Payload Types
 type _CancelTransferPayload = $ReadOnly<{|key: string|}>
 type _CommitEditPayload = $ReadOnly<{|editID: Types.EditID|}>
 type _DiscardEditPayload = $ReadOnly<{|editID: Types.EditID|}>
 type _DismissTransferPayload = $ReadOnly<{|key: string|}>
-type _DownloadFinishedPayload = $ReadOnly<{|
-  key: string,
-  error?: string,
-|}>
 type _DownloadPayload = $ReadOnly<{|
   intent: Types.TransferIntent,
   path: Types.Path,
   localPath?: string,
-|}>
-type _DownloadStartedPayload = $ReadOnly<{|
-  key: string,
-  path: Types.Path,
-  localPath: Types.LocalPath,
-  intent: Types.TransferIntent,
-  opID: RPCTypes.OpID,
 |}>
 type _EditFailedPayload = $ReadOnly<{|editID: Types.EditID|}>
 type _EditSuccessPayload = $ReadOnly<{|editID: Types.EditID|}>
@@ -135,6 +126,10 @@ type _OpenPathItemPayload = $ReadOnly<{|
   routePath: I.List<string>,
 |}>
 type _OpenSecurityPreferencesPayload = void
+type _PickAndUploadPayload = $ReadOnly<{|
+  type: Types.OpenDialogType,
+  parentPath: Types.Path,
+|}>
 type _RefreshLocalHTTPServerInfoPayload = void
 type _SavePayload = $ReadOnly<{|
   path: Types.Path,
@@ -158,13 +153,30 @@ type _SortSettingPayload = $ReadOnly<{|
   path: Types.Path,
   sortSetting: Types.SortSetting,
 |}>
+type _TransferFinishedPayload = $ReadOnly<{|
+  key: string,
+  error?: string,
+|}>
 type _TransferProgressPayload = $ReadOnly<{|
   key: string,
   completePortion: number,
   endEstimate?: number,
 |}>
+type _TransferStartedPayload = $ReadOnly<{|
+  type: Types.TransferType,
+  entryType?: Types.PathType,
+  key: string,
+  path: Types.Path,
+  localPath: Types.LocalPath,
+  intent: Types.TransferIntent,
+  opID: RPCTypes.OpID,
+|}>
 type _UninstallKBFSConfirmPayload = $ReadOnly<{|onSuccess: () => void|}>
 type _UninstallKBFSPayload = void
+type _UploadPayload = $ReadOnly<{|
+  parentPath: Types.Path,
+  localPath: string,
+|}>
 
 // Action Creators
 export const createCancelTransfer = (payload: _CancelTransferPayload) => ({error: false, payload, type: cancelTransfer})
@@ -172,8 +184,6 @@ export const createCommitEdit = (payload: _CommitEditPayload) => ({error: false,
 export const createDiscardEdit = (payload: _DiscardEditPayload) => ({error: false, payload, type: discardEdit})
 export const createDismissTransfer = (payload: _DismissTransferPayload) => ({error: false, payload, type: dismissTransfer})
 export const createDownload = (payload: _DownloadPayload) => ({error: false, payload, type: download})
-export const createDownloadFinished = (payload: _DownloadFinishedPayload) => ({error: false, payload, type: downloadFinished})
-export const createDownloadStarted = (payload: _DownloadStartedPayload) => ({error: false, payload, type: downloadStarted})
 export const createEditFailed = (payload: _EditFailedPayload) => ({error: false, payload, type: editFailed})
 export const createEditSuccess = (payload: _EditSuccessPayload) => ({error: false, payload, type: editSuccess})
 export const createFavoriteIgnore = (payload: _FavoriteIgnorePayload) => ({error: false, payload, type: favoriteIgnore})
@@ -201,24 +211,26 @@ export const createOpenFinderPopup = (payload: _OpenFinderPopupPayload) => ({err
 export const createOpenInFileUI = (payload: _OpenInFileUIPayload) => ({error: false, payload, type: openInFileUI})
 export const createOpenPathItem = (payload: _OpenPathItemPayload) => ({error: false, payload, type: openPathItem})
 export const createOpenSecurityPreferences = (payload: _OpenSecurityPreferencesPayload) => ({error: false, payload, type: openSecurityPreferences})
+export const createPickAndUpload = (payload: _PickAndUploadPayload) => ({error: false, payload, type: pickAndUpload})
 export const createRefreshLocalHTTPServerInfo = (payload: _RefreshLocalHTTPServerInfoPayload) => ({error: false, payload, type: refreshLocalHTTPServerInfo})
 export const createSave = (payload: _SavePayload) => ({error: false, payload, type: save})
 export const createSetFlags = (payload: _SetFlagsPayload) => ({error: false, payload, type: setFlags})
 export const createSetupFSHandlers = (payload: _SetupFSHandlersPayload) => ({error: false, payload, type: setupFSHandlers})
 export const createShare = (payload: _SharePayload) => ({error: false, payload, type: share})
 export const createSortSetting = (payload: _SortSettingPayload) => ({error: false, payload, type: sortSetting})
+export const createTransferFinished = (payload: _TransferFinishedPayload) => ({error: false, payload, type: transferFinished})
 export const createTransferProgress = (payload: _TransferProgressPayload) => ({error: false, payload, type: transferProgress})
+export const createTransferStarted = (payload: _TransferStartedPayload) => ({error: false, payload, type: transferStarted})
 export const createUninstallKBFS = (payload: _UninstallKBFSPayload) => ({error: false, payload, type: uninstallKBFS})
 export const createUninstallKBFSConfirm = (payload: _UninstallKBFSConfirmPayload) => ({error: false, payload, type: uninstallKBFSConfirm})
+export const createUpload = (payload: _UploadPayload) => ({error: false, payload, type: upload})
 
 // Action Payloads
 export type CancelTransferPayload = $Call<typeof createCancelTransfer, _CancelTransferPayload>
 export type CommitEditPayload = $Call<typeof createCommitEdit, _CommitEditPayload>
 export type DiscardEditPayload = $Call<typeof createDiscardEdit, _DiscardEditPayload>
 export type DismissTransferPayload = $Call<typeof createDismissTransfer, _DismissTransferPayload>
-export type DownloadFinishedPayload = $Call<typeof createDownloadFinished, _DownloadFinishedPayload>
 export type DownloadPayload = $Call<typeof createDownload, _DownloadPayload>
-export type DownloadStartedPayload = $Call<typeof createDownloadStarted, _DownloadStartedPayload>
 export type EditFailedPayload = $Call<typeof createEditFailed, _EditFailedPayload>
 export type EditSuccessPayload = $Call<typeof createEditSuccess, _EditSuccessPayload>
 export type FavoriteIgnoreErrorPayload = $Call<typeof createFavoriteIgnoreError, _FavoriteIgnoreErrorPayload>
@@ -246,15 +258,19 @@ export type OpenFinderPopupPayload = $Call<typeof createOpenFinderPopup, _OpenFi
 export type OpenInFileUIPayload = $Call<typeof createOpenInFileUI, _OpenInFileUIPayload>
 export type OpenPathItemPayload = $Call<typeof createOpenPathItem, _OpenPathItemPayload>
 export type OpenSecurityPreferencesPayload = $Call<typeof createOpenSecurityPreferences, _OpenSecurityPreferencesPayload>
+export type PickAndUploadPayload = $Call<typeof createPickAndUpload, _PickAndUploadPayload>
 export type RefreshLocalHTTPServerInfoPayload = $Call<typeof createRefreshLocalHTTPServerInfo, _RefreshLocalHTTPServerInfoPayload>
 export type SavePayload = $Call<typeof createSave, _SavePayload>
 export type SetFlagsPayload = $Call<typeof createSetFlags, _SetFlagsPayload>
 export type SetupFSHandlersPayload = $Call<typeof createSetupFSHandlers, _SetupFSHandlersPayload>
 export type SharePayload = $Call<typeof createShare, _SharePayload>
 export type SortSettingPayload = $Call<typeof createSortSetting, _SortSettingPayload>
+export type TransferFinishedPayload = $Call<typeof createTransferFinished, _TransferFinishedPayload>
 export type TransferProgressPayload = $Call<typeof createTransferProgress, _TransferProgressPayload>
+export type TransferStartedPayload = $Call<typeof createTransferStarted, _TransferStartedPayload>
 export type UninstallKBFSConfirmPayload = $Call<typeof createUninstallKBFSConfirm, _UninstallKBFSConfirmPayload>
 export type UninstallKBFSPayload = $Call<typeof createUninstallKBFS, _UninstallKBFSPayload>
+export type UploadPayload = $Call<typeof createUpload, _UploadPayload>
 
 // All Actions
 // prettier-ignore
@@ -263,9 +279,7 @@ export type Actions =
   | CommitEditPayload
   | DiscardEditPayload
   | DismissTransferPayload
-  | DownloadFinishedPayload
   | DownloadPayload
-  | DownloadStartedPayload
   | EditFailedPayload
   | EditSuccessPayload
   | FavoriteIgnoreErrorPayload
@@ -293,13 +307,17 @@ export type Actions =
   | OpenInFileUIPayload
   | OpenPathItemPayload
   | OpenSecurityPreferencesPayload
+  | PickAndUploadPayload
   | RefreshLocalHTTPServerInfoPayload
   | SavePayload
   | SetFlagsPayload
   | SetupFSHandlersPayload
   | SharePayload
   | SortSettingPayload
+  | TransferFinishedPayload
   | TransferProgressPayload
+  | TransferStartedPayload
   | UninstallKBFSConfirmPayload
   | UninstallKBFSPayload
+  | UploadPayload
   | {type: 'common:resetStore', payload: void}

--- a/shared/actions/fs-gen.js
+++ b/shared/actions/fs-gen.js
@@ -8,11 +8,14 @@ import * as Types from '../constants/types/fs'
 
 // Constants
 export const resetStore = 'common:resetStore' // not a part of fs but is handled by every reducer
-export const cancelTransfer = 'fs:cancelTransfer'
+export const cancelDownload = 'fs:cancelDownload'
 export const commitEdit = 'fs:commitEdit'
 export const discardEdit = 'fs:discardEdit'
-export const dismissTransfer = 'fs:dismissTransfer'
+export const dismissDownload = 'fs:dismissDownload'
 export const download = 'fs:download'
+export const downloadFinished = 'fs:downloadFinished'
+export const downloadProgress = 'fs:downloadProgress'
+export const downloadStarted = 'fs:downloadStarted'
 export const editFailed = 'fs:editFailed'
 export const editSuccess = 'fs:editSuccess'
 export const favoriteIgnore = 'fs:favoriteIgnore'
@@ -47,22 +50,38 @@ export const setFlags = 'fs:setFlags'
 export const setupFSHandlers = 'fs:setupFSHandlers'
 export const share = 'fs:share'
 export const sortSetting = 'fs:sortSetting'
-export const transferFinished = 'fs:transferFinished'
-export const transferProgress = 'fs:transferProgress'
-export const transferStarted = 'fs:transferStarted'
 export const uninstallKBFS = 'fs:uninstallKBFS'
 export const uninstallKBFSConfirm = 'fs:uninstallKBFSConfirm'
 export const upload = 'fs:upload'
+export const uploadStarted = 'fs:uploadStarted'
+export const uploadWritingFinished = 'fs:uploadWritingFinished'
 
 // Payload Types
-type _CancelTransferPayload = $ReadOnly<{|key: string|}>
+type _CancelDownloadPayload = $ReadOnly<{|key: string|}>
 type _CommitEditPayload = $ReadOnly<{|editID: Types.EditID|}>
 type _DiscardEditPayload = $ReadOnly<{|editID: Types.EditID|}>
-type _DismissTransferPayload = $ReadOnly<{|key: string|}>
+type _DismissDownloadPayload = $ReadOnly<{|key: string|}>
+type _DownloadFinishedPayload = $ReadOnly<{|
+  key: string,
+  error?: string,
+|}>
 type _DownloadPayload = $ReadOnly<{|
-  intent: Types.TransferIntent,
+  intent: Types.DownloadIntent,
   path: Types.Path,
   localPath?: string,
+|}>
+type _DownloadProgressPayload = $ReadOnly<{|
+  key: string,
+  completePortion: number,
+  endEstimate?: number,
+|}>
+type _DownloadStartedPayload = $ReadOnly<{|
+  entryType?: Types.PathType,
+  key: string,
+  path: Types.Path,
+  localPath: Types.LocalPath,
+  intent: Types.DownloadIntent,
+  opID: RPCTypes.OpID,
 |}>
 type _EditFailedPayload = $ReadOnly<{|editID: Types.EditID|}>
 type _EditSuccessPayload = $ReadOnly<{|editID: Types.EditID|}>
@@ -153,37 +172,27 @@ type _SortSettingPayload = $ReadOnly<{|
   path: Types.Path,
   sortSetting: Types.SortSetting,
 |}>
-type _TransferFinishedPayload = $ReadOnly<{|
-  key: string,
-  error?: string,
-|}>
-type _TransferProgressPayload = $ReadOnly<{|
-  key: string,
-  completePortion: number,
-  endEstimate?: number,
-|}>
-type _TransferStartedPayload = $ReadOnly<{|
-  type: Types.TransferType,
-  entryType?: Types.PathType,
-  key: string,
-  path: Types.Path,
-  localPath: Types.LocalPath,
-  intent: Types.TransferIntent,
-  opID: RPCTypes.OpID,
-|}>
 type _UninstallKBFSConfirmPayload = $ReadOnly<{|onSuccess: () => void|}>
 type _UninstallKBFSPayload = void
 type _UploadPayload = $ReadOnly<{|
   parentPath: Types.Path,
   localPath: string,
 |}>
+type _UploadStartedPayload = $ReadOnly<{|path: Types.Path|}>
+type _UploadWritingFinishedPayload = $ReadOnly<{|
+  path: Types.Path,
+  error?: string,
+|}>
 
 // Action Creators
-export const createCancelTransfer = (payload: _CancelTransferPayload) => ({error: false, payload, type: cancelTransfer})
+export const createCancelDownload = (payload: _CancelDownloadPayload) => ({error: false, payload, type: cancelDownload})
 export const createCommitEdit = (payload: _CommitEditPayload) => ({error: false, payload, type: commitEdit})
 export const createDiscardEdit = (payload: _DiscardEditPayload) => ({error: false, payload, type: discardEdit})
-export const createDismissTransfer = (payload: _DismissTransferPayload) => ({error: false, payload, type: dismissTransfer})
+export const createDismissDownload = (payload: _DismissDownloadPayload) => ({error: false, payload, type: dismissDownload})
 export const createDownload = (payload: _DownloadPayload) => ({error: false, payload, type: download})
+export const createDownloadFinished = (payload: _DownloadFinishedPayload) => ({error: false, payload, type: downloadFinished})
+export const createDownloadProgress = (payload: _DownloadProgressPayload) => ({error: false, payload, type: downloadProgress})
+export const createDownloadStarted = (payload: _DownloadStartedPayload) => ({error: false, payload, type: downloadStarted})
 export const createEditFailed = (payload: _EditFailedPayload) => ({error: false, payload, type: editFailed})
 export const createEditSuccess = (payload: _EditSuccessPayload) => ({error: false, payload, type: editSuccess})
 export const createFavoriteIgnore = (payload: _FavoriteIgnorePayload) => ({error: false, payload, type: favoriteIgnore})
@@ -218,19 +227,21 @@ export const createSetFlags = (payload: _SetFlagsPayload) => ({error: false, pay
 export const createSetupFSHandlers = (payload: _SetupFSHandlersPayload) => ({error: false, payload, type: setupFSHandlers})
 export const createShare = (payload: _SharePayload) => ({error: false, payload, type: share})
 export const createSortSetting = (payload: _SortSettingPayload) => ({error: false, payload, type: sortSetting})
-export const createTransferFinished = (payload: _TransferFinishedPayload) => ({error: false, payload, type: transferFinished})
-export const createTransferProgress = (payload: _TransferProgressPayload) => ({error: false, payload, type: transferProgress})
-export const createTransferStarted = (payload: _TransferStartedPayload) => ({error: false, payload, type: transferStarted})
 export const createUninstallKBFS = (payload: _UninstallKBFSPayload) => ({error: false, payload, type: uninstallKBFS})
 export const createUninstallKBFSConfirm = (payload: _UninstallKBFSConfirmPayload) => ({error: false, payload, type: uninstallKBFSConfirm})
 export const createUpload = (payload: _UploadPayload) => ({error: false, payload, type: upload})
+export const createUploadStarted = (payload: _UploadStartedPayload) => ({error: false, payload, type: uploadStarted})
+export const createUploadWritingFinished = (payload: _UploadWritingFinishedPayload) => ({error: false, payload, type: uploadWritingFinished})
 
 // Action Payloads
-export type CancelTransferPayload = $Call<typeof createCancelTransfer, _CancelTransferPayload>
+export type CancelDownloadPayload = $Call<typeof createCancelDownload, _CancelDownloadPayload>
 export type CommitEditPayload = $Call<typeof createCommitEdit, _CommitEditPayload>
 export type DiscardEditPayload = $Call<typeof createDiscardEdit, _DiscardEditPayload>
-export type DismissTransferPayload = $Call<typeof createDismissTransfer, _DismissTransferPayload>
+export type DismissDownloadPayload = $Call<typeof createDismissDownload, _DismissDownloadPayload>
+export type DownloadFinishedPayload = $Call<typeof createDownloadFinished, _DownloadFinishedPayload>
 export type DownloadPayload = $Call<typeof createDownload, _DownloadPayload>
+export type DownloadProgressPayload = $Call<typeof createDownloadProgress, _DownloadProgressPayload>
+export type DownloadStartedPayload = $Call<typeof createDownloadStarted, _DownloadStartedPayload>
 export type EditFailedPayload = $Call<typeof createEditFailed, _EditFailedPayload>
 export type EditSuccessPayload = $Call<typeof createEditSuccess, _EditSuccessPayload>
 export type FavoriteIgnoreErrorPayload = $Call<typeof createFavoriteIgnoreError, _FavoriteIgnoreErrorPayload>
@@ -265,21 +276,23 @@ export type SetFlagsPayload = $Call<typeof createSetFlags, _SetFlagsPayload>
 export type SetupFSHandlersPayload = $Call<typeof createSetupFSHandlers, _SetupFSHandlersPayload>
 export type SharePayload = $Call<typeof createShare, _SharePayload>
 export type SortSettingPayload = $Call<typeof createSortSetting, _SortSettingPayload>
-export type TransferFinishedPayload = $Call<typeof createTransferFinished, _TransferFinishedPayload>
-export type TransferProgressPayload = $Call<typeof createTransferProgress, _TransferProgressPayload>
-export type TransferStartedPayload = $Call<typeof createTransferStarted, _TransferStartedPayload>
 export type UninstallKBFSConfirmPayload = $Call<typeof createUninstallKBFSConfirm, _UninstallKBFSConfirmPayload>
 export type UninstallKBFSPayload = $Call<typeof createUninstallKBFS, _UninstallKBFSPayload>
 export type UploadPayload = $Call<typeof createUpload, _UploadPayload>
+export type UploadStartedPayload = $Call<typeof createUploadStarted, _UploadStartedPayload>
+export type UploadWritingFinishedPayload = $Call<typeof createUploadWritingFinished, _UploadWritingFinishedPayload>
 
 // All Actions
 // prettier-ignore
 export type Actions =
-  | CancelTransferPayload
+  | CancelDownloadPayload
   | CommitEditPayload
   | DiscardEditPayload
-  | DismissTransferPayload
+  | DismissDownloadPayload
+  | DownloadFinishedPayload
   | DownloadPayload
+  | DownloadProgressPayload
+  | DownloadStartedPayload
   | EditFailedPayload
   | EditSuccessPayload
   | FavoriteIgnoreErrorPayload
@@ -314,10 +327,9 @@ export type Actions =
   | SetupFSHandlersPayload
   | SharePayload
   | SortSettingPayload
-  | TransferFinishedPayload
-  | TransferProgressPayload
-  | TransferStartedPayload
   | UninstallKBFSConfirmPayload
   | UninstallKBFSPayload
   | UploadPayload
+  | UploadStartedPayload
+  | UploadWritingFinishedPayload
   | {type: 'common:resetStore', payload: void}

--- a/shared/actions/fs/common.native.js
+++ b/shared/actions/fs/common.native.js
@@ -2,6 +2,8 @@
 import * as Saga from '../../util/saga'
 import * as FsGen from '../fs-gen'
 import {putActionIfOnPath, navigateAppend} from '../route-tree'
+import {showImagePicker} from 'react-native-image-picker'
+import {isIOS} from '../../constants/platform'
 
 export const share = (action: FsGen.SharePayload) =>
   Saga.put(
@@ -31,3 +33,18 @@ export function* save(action: FsGen.SavePayload): Saga.SagaGenerator<any, any> {
     )
   )
 }
+
+export const pickAndUpload = ({payload: {type}}: FsGen.PickAndUploadPayload) =>
+  new Promise((resolve, reject) =>
+    showImagePicker(
+      {mediaType: 'photo'}, // TODO: support other types
+      response =>
+        !response.didCancel &&
+        (response.error
+          ? reject(response.error)
+          : resolve(isIOS ? response.uri.replace('file://', '') : response.path))
+    )
+  )
+
+export const pickAndUploadSuccess = (localPath: string, action: FsGen.PickAndUploadPayload) =>
+  localPath && Saga.put(FsGen.createUpload({localPath, parentPath: action.payload.parentPath}))

--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -119,7 +119,7 @@ function* folderList(action: FsGen.FolderListLoadPayload): Saga.SagaGenerator<an
   yield Saga.put(FsGen.createFolderListLoaded({pathItems, path: rootPath}))
 }
 
-function* monitorTransferProgress(key: string, opID: RPCTypes.OpID) {
+function* monitorDownloadProgress(key: string, opID: RPCTypes.OpID) {
   // This loop doesn't finish on its own, but it's in a Saga.race with
   // `SimpleFSWait`, so it's "canceled" when the other finishes.
   while (true) {
@@ -129,7 +129,7 @@ function* monitorTransferProgress(key: string, opID: RPCTypes.OpID) {
       continue
     }
     yield Saga.put(
-      FsGen.createTransferProgress({
+      FsGen.createDownloadProgress({
         key,
         endEstimate: progress.endEstimate,
         completePortion: progress.bytesWritten / progress.bytesTotal,
@@ -175,8 +175,7 @@ function* download(action: FsGen.DownloadPayload): Saga.SagaGenerator<any, any> 
   const key = Constants.makeDownloadKey(path, localPath)
 
   yield Saga.put(
-    FsGen.createTransferStarted({
-      type: 'download',
+    FsGen.createDownloadStarted({
       key,
       path,
       localPath,
@@ -200,13 +199,13 @@ function* download(action: FsGen.DownloadPayload): Saga.SagaGenerator<any, any> 
 
   try {
     yield Saga.race({
-      monitor: Saga.call(monitorTransferProgress, key, opID),
+      monitor: Saga.call(monitorDownloadProgress, key, opID),
       wait: Saga.call(RPCTypes.SimpleFSSimpleFSWaitRpcPromise, {opID}),
     })
 
     // No error, so the download has finished successfully. Set the
     // completePortion to 1.
-    yield Saga.put(FsGen.createTransferProgress({key, completePortion: 1}))
+    yield Saga.put(FsGen.createDownloadProgress({key, completePortion: 1}))
 
     const mimeType = yield Saga.call(_loadMimeType, path)
 
@@ -215,11 +214,11 @@ function* download(action: FsGen.DownloadPayload): Saga.SagaGenerator<any, any> 
     intentEffect && (yield intentEffect)
   } catch (error) {
     console.log(`Download for intent[${intent}] error: ${error}`)
-    yield Saga.put(FsGen.createTransferFinished({key, error}))
+    yield Saga.put(FsGen.createDownloadFinished({key, error}))
     return
   }
 
-  yield Saga.put(FsGen.createTransferFinished({key}))
+  yield Saga.put(FsGen.createDownloadFinished({key}))
 }
 
 function* upload(action: FsGen.UploadPayload) {
@@ -227,28 +226,8 @@ function* upload(action: FsGen.UploadPayload) {
   const opID = Constants.makeUUID()
   const name = Types.getLocalPathName(localPath)
   const path = Types.pathConcat(parentPath, name)
-  const key = Constants.makeUploadKey(localPath, path)
 
-  // Call stat to figure out path type.
-  const dirent = yield Saga.call(RPCTypes.SimpleFSSimpleFSStatRpcPromise, {
-    path: {
-      PathType: RPCTypes.simpleFSPathType.local,
-      local: localPath,
-    },
-  })
-  const entryType = Types.direntToPathType(dirent)
-
-  yield Saga.put(
-    FsGen.createTransferStarted({
-      type: 'upload',
-      entryType,
-      key,
-      path,
-      localPath,
-      intent: 'none',
-      opID,
-    })
-  )
+  yield Saga.put(FsGen.createUploadStarted({path}))
 
   // TODO: confirm overwrites?
   // TODO: what about directory merges?
@@ -264,37 +243,27 @@ function* upload(action: FsGen.UploadPayload) {
     },
   })
 
-  try {
-    yield Saga.race({
-      monitor: Saga.call(monitorTransferProgress, key, opID),
-      wait: Saga.call(RPCTypes.SimpleFSSimpleFSWaitRpcPromise, {opID}),
-    })
+  // TODO: Are we sure this happens after the file shows up in destination?
+  yield Saga.call(folderList, FsGen.createFolderListLoad({path: parentPath}))
 
-    // No error, so the upload has finished successfully. Set the
-    // completePortion to 1.
-    yield Saga.put(FsGen.createTransferProgress({key, completePortion: 1}))
+  try {
+    yield Saga.call(RPCTypes.SimpleFSSimpleFSWaitRpcPromise, {opID})
+    yield Saga.put(FsGen.createUploadWritingFinished({path}))
   } catch (error) {
     console.log(`Upload error: ${error}`)
-    yield Saga.put(FsGen.createTransferFinished({key, error}))
-    return
+    yield Saga.put(FsGen.createUploadWritingFinished({path, error}))
   }
-
-  // Reload folder list before marking the transfer as done so we don't go into
-  // a state where we think upload is finished but the item is not loaded
-  // (which causes UI to skip that row).
-  yield Saga.call(folderList, FsGen.createFolderListLoad({path: parentPath}))
-  yield Saga.put(FsGen.createTransferFinished({key}))
 }
 
-function cancelTransfer({payload: {key}}: FsGen.CancelTransferPayload, state: TypedState) {
-  const transfer = state.fs.transfers.get(key)
-  if (!transfer) {
-    console.log(`unknown transfer: ${key}`)
+function cancelDownload({payload: {key}}: FsGen.CancelDownloadPayload, state: TypedState) {
+  const download = state.fs.downloads.get(key)
+  if (!download) {
+    console.log(`unknown download: ${key}`)
     return
   }
   const {
     meta: {opID},
-  } = transfer
+  } = download
   return Saga.call(RPCTypes.SimpleFSSimpleFSCancelRpcPromise, {opID})
 }
 
@@ -546,7 +515,7 @@ function* fsSaga(): Saga.SagaGenerator<any, any> {
     refreshLocalHTTPServerInfo,
     refreshLocalHTTPServerInfoResult
   )
-  yield Saga.safeTakeEveryPure(FsGen.cancelTransfer, cancelTransfer)
+  yield Saga.safeTakeEveryPure(FsGen.cancelDownload, cancelDownload)
   yield Saga.safeTakeEvery(FsGen.download, download)
   yield Saga.safeTakeEvery(FsGen.upload, upload)
   yield Saga.safeTakeEvery(FsGen.folderListLoad, folderList)

--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -174,7 +174,17 @@ function* download(action: FsGen.DownloadPayload): Saga.SagaGenerator<any, any> 
 
   const key = Constants.makeDownloadKey(path, localPath)
 
-  yield Saga.put(FsGen.createDownloadStarted({key, path, localPath, intent, opID}))
+  yield Saga.put(
+    FsGen.createTransferStarted({
+      type: 'download',
+      key,
+      path,
+      localPath,
+      intent,
+      opID,
+      // Omit entryType to let reducer figure out.
+    })
+  )
 
   yield Saga.call(RPCTypes.SimpleFSSimpleFSCopyRecursiveRpcPromise, {
     opID,
@@ -205,11 +215,75 @@ function* download(action: FsGen.DownloadPayload): Saga.SagaGenerator<any, any> 
     intentEffect && (yield intentEffect)
   } catch (error) {
     console.log(`Download for intent[${intent}] error: ${error}`)
-    yield Saga.put(FsGen.createDownloadFinished({key, error}))
+    yield Saga.put(FsGen.createTransferFinished({key, error}))
     return
   }
 
-  yield Saga.put(FsGen.createDownloadFinished({key}))
+  yield Saga.put(FsGen.createTransferFinished({key}))
+}
+
+function* upload(action: FsGen.UploadPayload) {
+  const {parentPath, localPath} = action.payload
+  const opID = Constants.makeUUID()
+  const name = Types.getLocalPathName(localPath)
+  const path = Types.pathConcat(parentPath, name)
+  const key = Constants.makeUploadKey(localPath, path)
+
+  // Call stat to figure out path type.
+  const dirent = yield Saga.call(RPCTypes.SimpleFSSimpleFSStatRpcPromise, {
+    path: {
+      PathType: RPCTypes.simpleFSPathType.local,
+      local: localPath,
+    },
+  })
+  const entryType = Types.direntToPathType(dirent)
+
+  yield Saga.put(
+    FsGen.createTransferStarted({
+      type: 'upload',
+      entryType,
+      key,
+      path,
+      localPath,
+      intent: 'none',
+      opID,
+    })
+  )
+
+  // TODO: confirm overwrites?
+  // TODO: what about directory merges?
+  yield Saga.call(RPCTypes.SimpleFSSimpleFSCopyRecursiveRpcPromise, {
+    opID,
+    src: {
+      PathType: RPCTypes.simpleFSPathType.local,
+      local: localPath,
+    },
+    dest: {
+      PathType: RPCTypes.simpleFSPathType.kbfs,
+      kbfs: Constants.fsPathToRpcPathString(path),
+    },
+  })
+
+  try {
+    yield Saga.race({
+      monitor: Saga.call(monitorTransferProgress, key, opID),
+      wait: Saga.call(RPCTypes.SimpleFSSimpleFSWaitRpcPromise, {opID}),
+    })
+
+    // No error, so the upload has finished successfully. Set the
+    // completePortion to 1.
+    yield Saga.put(FsGen.createTransferProgress({key, completePortion: 1}))
+  } catch (error) {
+    console.log(`Upload error: ${error}`)
+    yield Saga.put(FsGen.createTransferFinished({key, error}))
+    return
+  }
+
+  // Reload folder list before marking the transfer as done so we don't go into
+  // a state where we think upload is finished but the item is not loaded
+  // (which causes UI to skip that row).
+  yield Saga.call(folderList, FsGen.createFolderListLoad({path: parentPath}))
+  yield Saga.put(FsGen.createTransferFinished({key}))
 }
 
 function cancelTransfer({payload: {key}}: FsGen.CancelTransferPayload, state: TypedState) {
@@ -474,6 +548,7 @@ function* fsSaga(): Saga.SagaGenerator<any, any> {
   )
   yield Saga.safeTakeEveryPure(FsGen.cancelTransfer, cancelTransfer)
   yield Saga.safeTakeEvery(FsGen.download, download)
+  yield Saga.safeTakeEvery(FsGen.upload, upload)
   yield Saga.safeTakeEvery(FsGen.folderListLoad, folderList)
   yield Saga.safeTakeEvery(FsGen.filePreviewLoad, filePreview)
   yield Saga.safeTakeEvery(FsGen.favoritesLoad, listFavoritesSaga)

--- a/shared/actions/fs/platform-specific.android.js
+++ b/shared/actions/fs/platform-specific.android.js
@@ -5,7 +5,7 @@ import * as FsGen from '../fs-gen'
 import RNFetchBlob from 'react-native-fetch-blob'
 import {copy, unlink} from '../../util/file'
 import {PermissionsAndroid} from 'react-native'
-import {share, save} from './common.native'
+import {share, save, pickAndUpload, pickAndUploadSuccess} from './common.native'
 import {saveAttachmentDialog, showShareActionSheet} from '../platform-specific'
 
 function copyToDownloadDir(path: string, mimeType: string) {
@@ -65,6 +65,7 @@ function platformSpecificIntentEffect(
 function* platformSpecificSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPure(FsGen.share, share)
   yield Saga.safeTakeEvery(FsGen.save, save)
+  yield Saga.safeTakeEveryPure(FsGen.pickAndUpload, pickAndUpload, pickAndUploadSuccess)
 }
 
 export {platformSpecificIntentEffect, platformSpecificSaga}

--- a/shared/actions/fs/platform-specific.android.js
+++ b/shared/actions/fs/platform-specific.android.js
@@ -39,7 +39,7 @@ function copyToDownloadDir(path: string, mimeType: string) {
 }
 
 function platformSpecificIntentEffect(
-  intent: Types.TransferIntent,
+  intent: Types.DownloadIntent,
   localPath: string,
   mimeType: string
 ): ?Saga.Effect {

--- a/shared/actions/fs/platform-specific.desktop.js
+++ b/shared/actions/fs/platform-specific.desktop.js
@@ -283,7 +283,7 @@ function openFinderPopup(action: FsGen.OpenFinderPopupPayload) {
 }
 
 function platformSpecificIntentEffect(
-  intent: Types.TransferIntent,
+  intent: Types.DownloadIntent,
   localPath: string,
   mimeType: string
 ): ?Saga.Effect {

--- a/shared/actions/fs/platform-specific.ios.js
+++ b/shared/actions/fs/platform-specific.ios.js
@@ -2,7 +2,7 @@
 import * as Saga from '../../util/saga'
 import * as Types from '../../constants/types/fs'
 import * as FsGen from '../fs-gen'
-import {share, save} from './common.native'
+import {share, save, pickAndUpload, pickAndUploadSuccess} from './common.native'
 import {saveAttachmentDialog, showShareActionSheet} from '../platform-specific'
 
 function platformSpecificIntentEffect(
@@ -31,6 +31,7 @@ function platformSpecificIntentEffect(
 function* platformSpecificSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPure(FsGen.share, share)
   yield Saga.safeTakeEvery(FsGen.save, save)
+  yield Saga.safeTakeEveryPure(FsGen.pickAndUpload, pickAndUpload, pickAndUploadSuccess)
 }
 
 export {platformSpecificIntentEffect, platformSpecificSaga}

--- a/shared/actions/fs/platform-specific.ios.js
+++ b/shared/actions/fs/platform-specific.ios.js
@@ -6,7 +6,7 @@ import {share, save, pickAndUpload, pickAndUploadSuccess} from './common.native'
 import {saveAttachmentDialog, showShareActionSheet} from '../platform-specific'
 
 function platformSpecificIntentEffect(
-  intent: Types.TransferIntent,
+  intent: Types.DownloadIntent,
   localPath: string,
   mimeType: string
 ): ?Saga.Effect {

--- a/shared/actions/fs/platform-specific.js.flow
+++ b/shared/actions/fs/platform-specific.js.flow
@@ -2,5 +2,5 @@
 import * as Saga from '../../util/saga'
 import * as Types from '../../constants/types/fs'
 
-declare export function platformSpecificIntentEffect(intent: Types.TransferIntent, localPath: string, mimeType: string): ?Saga.Effect
+declare export function platformSpecificIntentEffect(intent: Types.DownloadIntent, localPath: string, mimeType: string): ?Saga.Effect
 declare export function platformSpecificSaga(): Saga.SagaGenerator<any, any>

--- a/shared/actions/json/fs.json
+++ b/shared/actions/json/fs.json
@@ -35,16 +35,22 @@
       "path": "Types.Path",
       "localPath?": "string"
     },
-    "downloadStarted": {
+    "transferStarted": {
+      "type": "Types.TransferType",
+      "entryType?": "Types.PathType",
       "key": "string",
       "path": "Types.Path",
       "localPath": "Types.LocalPath",
       "intent": "Types.TransferIntent",
       "opID": "RPCTypes.OpID"
     },
-    "downloadFinished": {
+    "transferFinished": {
       "key": "string",
       "error?": "string"
+    },
+    "upload": {
+      "parentPath": "Types.Path",
+      "localPath": "string"
     },
     "transferProgress": {
       "key": "string",
@@ -142,6 +148,10 @@
     "letResetUserBackIn": {
       "id": "RPCTypes.TeamID",
       "username": "string"
+    },
+    "pickAndUpload": {
+      "type": "Types.OpenDialogType",
+      "parentPath": "Types.Path"
     },
 
     "setupFSHandlers": {}

--- a/shared/actions/json/fs.json
+++ b/shared/actions/json/fs.json
@@ -31,37 +31,43 @@
       "sortSetting": "Types.SortSetting"
     },
     "download": {
-      "intent": "Types.TransferIntent",
+      "intent": "Types.DownloadIntent",
       "path": "Types.Path",
       "localPath?": "string"
     },
-    "transferStarted": {
-      "type": "Types.TransferType",
+    "downloadStarted": {
       "entryType?": "Types.PathType",
       "key": "string",
       "path": "Types.Path",
       "localPath": "Types.LocalPath",
-      "intent": "Types.TransferIntent",
+      "intent": "Types.DownloadIntent",
       "opID": "RPCTypes.OpID"
     },
-    "transferFinished": {
+    "downloadFinished": {
       "key": "string",
       "error?": "string"
+    },
+    "downloadProgress": {
+      "key": "string",
+      "completePortion": "number",
+      "endEstimate?": "number"
+    },
+    "cancelDownload": {
+      "key": "string"
+    },
+    "dismissDownload": {
+      "key": "string"
     },
     "upload": {
       "parentPath": "Types.Path",
       "localPath": "string"
     },
-    "transferProgress": {
-      "key": "string",
-      "completePortion": "number",
-      "endEstimate?": "number"
+    "uploadStarted": {
+      "path": "Types.Path"
     },
-    "cancelTransfer": {
-      "key": "string"
-    },
-    "dismissTransfer": {
-      "key": "string"
+    "uploadWritingFinished": {
+      "path": "Types.Path",
+      "error?": "string"
     },
     "openInFileUI": {
       "path?": "string"

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -166,14 +166,6 @@ export const makeUUID = () => uuidv1({}, Buffer.alloc(16), 0)
 export const fsPathToRpcPathString = (p: Types.Path): string =>
   Types.pathToString(p).substring('/keybase'.length) || '/'
 
-export const sortPathItems = (
-  items: I.List<Types.PathItem>,
-  sortSetting: Types.SortSetting,
-  username?: string
-): I.List<Types.PathItem> => {
-  return items.sort(Types.sortSettingToCompareFunction(sortSetting, username))
-}
-
 const privateIconColor = globalColors.darkBlue2
 const privateTextColor = globalColors.darkBlue
 const publicIconColor = globalColors.yellowGreen
@@ -325,6 +317,8 @@ export const editTypeToPathType = (type: Types.EditType): Types.PathType => {
 
 export const makeDownloadKey = (path: Types.Path, localPath: string) =>
   `download:${Types.pathToString(path)}:${localPath}`
+export const makeUploadKey = (localPath: string, path: Types.Path) =>
+  `upload:${Types.pathToString(path)}:${localPath}`
 
 export const downloadFilePathFromPath = (p: Types.Path): Promise<Types.LocalPath> =>
   downloadFilePath(Types.getPathName(p))

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -93,7 +93,7 @@ export const makePathUserSetting: I.RecordFactory<Types._PathUserSetting> = I.Re
   sort: makeSortSetting(),
 })
 
-export const makeTransferMeta: I.RecordFactory<Types._TransferMeta> = I.Record({
+export const makeDownloadMeta: I.RecordFactory<Types._DownloadMeta> = I.Record({
   type: 'download',
   entryType: 'unknown',
   intent: 'none',
@@ -102,7 +102,7 @@ export const makeTransferMeta: I.RecordFactory<Types._TransferMeta> = I.Record({
   opID: null,
 })
 
-export const makeTransferState: I.RecordFactory<Types._TransferState> = I.Record({
+export const makeDownloadState: I.RecordFactory<Types._DownloadState> = I.Record({
   completePortion: 0,
   endEstimate: undefined,
   error: undefined,
@@ -110,9 +110,15 @@ export const makeTransferState: I.RecordFactory<Types._TransferState> = I.Record
   startedAt: 0,
 })
 
-export const makeTransfer: I.RecordFactory<Types._Transfer> = I.Record({
-  meta: makeTransferMeta(),
-  state: makeTransferState(),
+export const makeDownload: I.RecordFactory<Types._Download> = I.Record({
+  meta: makeDownloadMeta(),
+  state: makeDownloadState(),
+})
+
+export const makeUpload: I.RecordFactory<Types._Upload> = I.Record({
+  writingToJournal: false,
+  journalFlushing: false,
+  error: undefined,
 })
 
 export const makeFlags: I.RecordFactory<Types._Flags> = I.Record({
@@ -137,7 +143,8 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   edits: I.Map(),
   pathUserSettings: I.Map([[Types.stringToPath('/keybase'), makePathUserSetting()]]),
   loadingPaths: I.Set(),
-  transfers: I.Map(),
+  downloads: I.Map(),
+  uploads: I.Map(),
   localHTTPServerInfo: null,
 })
 

--- a/shared/constants/types/fs.js
+++ b/shared/constants/types/fs.js
@@ -114,35 +114,40 @@ export type PathUserSetting = I.RecordOf<_PathUserSetting>
 
 export type LocalPath = string
 
-export type TransferType = 'upload' | 'download'
-export type transferIntentMobile = 'camera-roll' | 'share'
-export type transferIntentWebview = 'web-view-text' | 'web-view'
-export type TransferIntent = 'none' | transferIntentMobile | transferIntentWebview
+export type DownloadIntentMobile = 'camera-roll' | 'share'
+export type DownloadIntentWebview = 'web-view-text' | 'web-view'
+export type DownloadIntent = 'none' | DownloadIntentMobile | DownloadIntentWebview
 
-export type _TransferMeta = {
-  type: TransferType,
+export type _DownloadMeta = {
   entryType: PathType,
-  intent: TransferIntent,
+  intent: DownloadIntent,
   path: Path,
   localPath: LocalPath,
   opID: RPCTypes.OpID,
 }
-export type TransferMeta = I.RecordOf<_TransferMeta>
+export type DownloadMeta = I.RecordOf<_DownloadMeta>
 
-export type _TransferState = {
+export type _DownloadState = {
   completePortion: number,
   endEstimate?: number,
   error?: string,
   isDone: boolean,
   startedAt: number,
 }
-export type TransferState = I.RecordOf<_TransferState>
+export type DownloadState = I.RecordOf<_DownloadState>
 
-export type _Transfer = {
-  meta: TransferMeta,
-  state: TransferState,
+export type _Download = {
+  meta: DownloadMeta,
+  state: DownloadState,
 }
-export type Transfer = I.RecordOf<_Transfer>
+export type Download = I.RecordOf<_Download>
+
+export type _Upload = {
+  writingToJournal: boolean,
+  journalFlushing: boolean,
+  error?: string,
+}
+export type Upload = I.RecordOf<_Upload>
 
 // 'both' is only supported on macOS
 export type OpenDialogType = 'file' | 'directory' | 'both'
@@ -178,7 +183,8 @@ export type _State = {
   edits: I.Map<EditID, Edit>,
   pathUserSettings: I.Map<Path, PathUserSetting>,
   loadingPaths: I.Set<Path>,
-  transfers: I.Map<string, Transfer>,
+  downloads: I.Map<string, Download>,
+  uploads: I.Map<Path, I.Map<string, Upload>>, // parent path -> name -> Upload
   fuseStatus: ?RPCTypes.FuseStatus,
   flags: Flags,
   localHTTPServerInfo: ?LocalHTTPServer,
@@ -384,8 +390,8 @@ export type EditingRowItem = {
 
 export type UploadingRowItem = {
   rowType: 'uploading',
-  transferID: string,
   name: string,
+  path: Path,
 }
 
 export type PlaceholderRowItem = {

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -111,7 +111,7 @@ const reconcileUploadingAndStillRows = (
   stills: Array<SortableStillRowItem>
 ): Array<SortableRowItem> => {
   const pendingUploads: Array<SortableUploadingRowItem> = uploadings.filter(uploading => !uploading.isDone)
-  const pendingUploadsNameSet = new Set(pendingUploads)
+  const pendingUploadsNameSet = new Set(pendingUploads.map(uploading => uploading.name))
   const doneStills: Array<SortableStillRowItem> = stills.filter(
     still => !pendingUploadsNameSet.has(still.name)
   )

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -34,7 +34,7 @@ const mapStateToProps = (state: TypedState, {path}) => {
       ? itemDetail.tlfMeta.resetParticipants.map(i => i.username)
       : []
   const isUserReset = resetParticipants.includes(_username)
-  const _transfers = state.fs.transfers
+  const _downloads = state.fs.downloads
   return {
     _itemChildren: itemChildren,
     _itemFavoriteChildren: itemFavoriteChildren,
@@ -44,7 +44,8 @@ const mapStateToProps = (state: TypedState, {path}) => {
     _username,
     isUserReset,
     resetParticipants,
-    _transfers,
+    _downloads,
+    _uploads: state.fs.uploads,
     path,
     progress: itemDetail ? itemDetail.progress : 'pending',
   }
@@ -84,39 +85,24 @@ const getStillRows = (
       lastModifiedTimestamp: item.lastModifiedTimestamp,
     }))
 
-const getUploadingRows = (
-  transfers: I.Map<string, Types.Transfer>,
-  parentPath: Types.Path
-): Array<SortableUploadingRowItem> =>
-  transfers
-    .filter(t => t.meta.type === 'upload' && Types.getPathParent(t.meta.path) === parentPath)
-    .toArray()
-    .map(([transferID, transfer]) => ({
-      rowType: 'uploading',
-      transferID,
-      name: Types.getPathName(transfer.meta.path),
-
-      type: transfer.meta.entryType,
-      isDone: transfer.state.isDone,
-    }))
-
-// Assumption: folder list gets reloaded (and correcponding state updates in
-// store) before a transfer is marked as done. In other words, a done upload
-// must appear in the `children` of its parent PathItem, unless the item has
-// been deleted.
-//
 // TODO: when we have renames, reconsile editing rows in here too.
-const reconcileUploadingAndStillRows = (
-  uploadings: Array<SortableUploadingRowItem>,
-  stills: Array<SortableStillRowItem>
-): Array<SortableRowItem> => {
-  const pendingUploads: Array<SortableUploadingRowItem> = uploadings.filter(uploading => !uploading.isDone)
-  const pendingUploadsNameSet = new Set(pendingUploads.map(uploading => uploading.name))
-  const doneStills: Array<SortableStillRowItem> = stills.filter(
-    still => !pendingUploadsNameSet.has(still.name)
-  )
-  return [...doneStills, ...pendingUploads]
-}
+const amendStillRows = (
+  stills: Array<SortableStillRowItem>,
+  uploads: I.Map<string, Types.Upload>
+): Array<SortableRowItem> =>
+  stills.map(still => {
+    const {name, type, path} = still
+    const upload = uploads.get(name)
+    if (upload && (upload.journalFlushing || upload.writingToJournal)) {
+      return ({
+        rowType: 'uploading',
+        name,
+        path,
+        type,
+      }: SortableUploadingRowItem)
+    }
+    return still
+  })
 
 const placeholderRows = [
   {rowType: 'placeholder', name: '1'},
@@ -134,15 +120,15 @@ const mergeProps = (stateProps, dispatchProps, {routePath}) => {
   }
 
   const editingRows = getEditingRows(stateProps._edits, stateProps.path)
-  const uploadingRows = getUploadingRows(stateProps._transfers, stateProps.path)
   const stillRows = getStillRows(
     stateProps._pathItems,
     stateProps.path,
     stateProps._itemChildren.union(stateProps._itemFavoriteChildren).toArray()
   )
+  const uploads = stateProps._uploads.get(stateProps.path, I.Map())
 
   const items = sortRowItems(
-    editingRows.concat(reconcileUploadingAndStillRows(uploadingRows, stillRows)),
+    editingRows.concat(amendStillRows(stillRows, uploads)),
     stateProps._sortSetting,
     Types.pathIsNonTeamTLFList(stateProps.path) ? stateProps._username : undefined
   )

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -13,6 +13,13 @@ import Files from '.'
 import * as FsGen from '../actions/fs-gen'
 import * as Types from '../constants/types/fs'
 import * as Constants from '../constants/fs'
+import {
+  sortRowItems,
+  type SortableStillRowItem,
+  type SortableEditingRowItem,
+  type SortableUploadingRowItem,
+  type SortableRowItem,
+} from './utils/sort'
 import SecurityPrefsPromptingHoc from './common/security-prefs-prompting-hoc'
 
 const mapStateToProps = (state: TypedState, {path}) => {
@@ -27,6 +34,7 @@ const mapStateToProps = (state: TypedState, {path}) => {
       ? itemDetail.tlfMeta.resetParticipants.map(i => i.username)
       : []
   const isUserReset = resetParticipants.includes(_username)
+  const _transfers = state.fs.transfers
   return {
     _itemChildren: itemChildren,
     _itemFavoriteChildren: itemFavoriteChildren,
@@ -36,34 +44,113 @@ const mapStateToProps = (state: TypedState, {path}) => {
     _username,
     isUserReset,
     resetParticipants,
+    _transfers,
     path,
     progress: itemDetail ? itemDetail.progress : 'pending',
   }
 }
 
+const getEditingRows = (
+  edits: I.Map<Types.EditID, Types.Edit>,
+  parentPath: Types.Path
+): Array<SortableEditingRowItem> =>
+  edits
+    .filter(edit => edit.parentPath === parentPath)
+    .toArray()
+    .map(([editID, edit]) => ({
+      rowType: 'editing',
+      editID,
+      name: edit.name,
+
+      editType: edit.type,
+      type: 'folder',
+    }))
+
+const getStillRows = (
+  pathItems: I.Map<Types.Path, Types.PathItem>,
+  parentPath: Types.Path,
+  names: Array<string>
+): Array<SortableStillRowItem> =>
+  names
+    .map(name => pathItems.get(Types.pathConcat(parentPath, name), Constants.makeUnknownPathItem({name})))
+    .filter(item => !(item.tlfMeta && item.tlfMeta.isIgnored))
+    .map(item => ({
+      rowType: 'still',
+      path: Types.pathConcat(parentPath, item.name),
+      name: item.name,
+
+      type: item.type,
+      tlfMeta: item.tlfMeta,
+      lastModifiedTimestamp: item.lastModifiedTimestamp,
+    }))
+
+const getUploadingRows = (
+  transfers: I.Map<string, Types.Transfer>,
+  parentPath: Types.Path
+): Array<SortableUploadingRowItem> =>
+  transfers
+    .filter(t => t.meta.type === 'upload' && Types.getPathParent(t.meta.path) === parentPath)
+    .toArray()
+    .map(([transferID, transfer]) => ({
+      rowType: 'uploading',
+      transferID,
+      name: Types.getPathName(transfer.meta.path),
+
+      type: transfer.meta.entryType,
+      isDone: transfer.state.isDone,
+    }))
+
+// Assumption: folder list gets reloaded (and correcponding state updates in
+// store) before a transfer is marked as done. In other words, a done upload
+// must appear in the `children` of its parent PathItem, unless the item has
+// been deleted.
+//
+// TODO: when we have renames, reconsile editing rows in here too.
+const reconcileUploadingAndStillRows = (
+  uploadings: Array<SortableUploadingRowItem>,
+  stills: Array<SortableStillRowItem>
+): Array<SortableRowItem> => {
+  const pendingUploads: Array<SortableUploadingRowItem> = uploadings.filter(uploading => !uploading.isDone)
+  const pendingUploadsNameSet = new Set(pendingUploads)
+  const doneStills: Array<SortableStillRowItem> = stills.filter(
+    still => !pendingUploadsNameSet.has(still.name)
+  )
+  return [...doneStills, ...pendingUploads]
+}
+
+const placeholderRows = [
+  {rowType: 'placeholder', name: '1'},
+  {rowType: 'placeholder', name: '2'},
+  {rowType: 'placeholder', name: '3'},
+]
+
 const mergeProps = (stateProps, dispatchProps, {routePath}) => {
-  const itemNames = stateProps._itemChildren.union(stateProps._itemFavoriteChildren)
-  const pathItems = itemNames.map(name => {
-    return (
-      stateProps._pathItems.get(Types.pathConcat(stateProps.path, name)) ||
-      Constants.makeUnknownPathItem({name})
-    )
-  })
-  const filteredPathItems = pathItems.filter(item => !(item.tlfMeta && item.tlfMeta.isIgnored)).toList()
-  const username = Types.pathIsNonTeamTLFList(stateProps.path) ? stateProps._username : undefined
-  const stillItems = Constants.sortPathItems(filteredPathItems, stateProps._sortSetting, username)
-    .map(({name}) => Types.pathConcat(stateProps.path, name))
-    .toArray()
-  const editingItems = stateProps._edits
-    .filter(edit => edit.parentPath === stateProps.path)
-    .keySeq()
-    .toArray()
-    .sort()
+  if (stateProps.progress === 'pending') {
+    return {
+      routePath,
+      items: placeholderRows,
+      path: stateProps.path,
+    }
+  }
+
+  const editingRows = getEditingRows(stateProps._edits, stateProps.path)
+  const uploadingRows = getUploadingRows(stateProps._transfers, stateProps.path)
+  const stillRows = getStillRows(
+    stateProps._pathItems,
+    stateProps.path,
+    stateProps._itemChildren.union(stateProps._itemFavoriteChildren).toArray()
+  )
+
+  const items = sortRowItems(
+    editingRows.concat(reconcileUploadingAndStillRows(uploadingRows, stillRows)),
+    stateProps._sortSetting,
+    Types.pathIsNonTeamTLFList(stateProps.path) ? stateProps._username : undefined
+  )
+
   return {
-    stillItems,
-    editingItems,
     isUserReset: stateProps.isUserReset,
     resetParticipants: stateProps.resetParticipants,
+    items,
     path: stateProps.path,
     progress: stateProps.progress,
     routePath,

--- a/shared/fs/footer/container.js
+++ b/shared/fs/footer/container.js
@@ -6,30 +6,26 @@ import * as FsGen from '../../actions/fs-gen'
 import {formatDurationFromNowTo} from '../../util/timestamp'
 
 const mapStateToProps = (state: TypedState) => ({
-  transfers: state.fs.transfers,
+  downloads: state.fs.downloads,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   opener: (p: Types.LocalPath) => dispatch(FsGen.createOpenInFileUI({path: p})),
-  dismisser: (key: string) => dispatch(FsGen.createDismissTransfer({key})),
-  canceler: (key: string) => dispatch(FsGen.createCancelTransfer({key})),
+  dismisser: (key: string) => dispatch(FsGen.createDismissDownload({key})),
+  canceler: (key: string) => dispatch(FsGen.createCancelDownload({key})),
 })
 
 const mergeProps = (stateProps, {opener, dismisser, canceler}, ownProps) =>
   ({
-    downloads: Array.from(
-      stateProps.transfers.filter(
-        transfer => transfer.meta.type === 'download' && transfer.meta.intent === 'none'
-      )
-    )
+    downloads: Array.from(stateProps.downloads.filter(download => download.meta.intent === 'none'))
       .sort(([_a, a], [_b, b]) => b.state.startedAt - a.state.startedAt) // newer first
-      .map(([key, transfer]) => ({
-        error: transfer.state.error,
-        filename: Types.getLocalPathName(transfer.meta.localPath),
-        completePortion: transfer.state.completePortion,
-        progressText: formatDurationFromNowTo(transfer.state.endEstimate),
-        isDone: transfer.state.isDone,
-        open: transfer.state.isDone ? () => opener(transfer.meta.localPath) : undefined,
+      .map(([key, download]) => ({
+        error: download.state.error,
+        filename: Types.getLocalPathName(download.meta.localPath),
+        completePortion: download.state.completePortion,
+        progressText: formatDurationFromNowTo(download.state.endEstimate),
+        isDone: download.state.isDone,
+        open: download.state.isDone ? () => opener(download.meta.localPath) : undefined,
         dismiss: () => dismisser(key),
         cancel: () => canceler(key),
         key,

--- a/shared/fs/header/add-new-container.js
+++ b/shared/fs/header/add-new-container.js
@@ -3,7 +3,7 @@ import * as Types from '../../constants/types/fs'
 import * as FsGen from '../../actions/fs-gen'
 import {compose, setDisplayName, connect, type Dispatch, type TypedState} from '../../util/container'
 import AddNew from './add-new'
-import {isDarwin} from '../../constants/platform'
+import {isDarwin, isMobile} from '../../constants/platform'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -12,6 +12,38 @@ const mapDispatchToProps = (dispatch: Dispatch, {routePath}) => ({
   _upload: (parentPath: Types.Path, type: Types.OpenDialogType) =>
     dispatch(FsGen.createPickAndUpload({parentPath, type})),
 })
+
+const desktopUploadItems = (path: Types.Path, _upload) =>
+  isDarwin
+    ? [
+        {
+          onClick: () => _upload(path, 'both'),
+          icon: 'iconfont-upload',
+          title: 'Upload a file or folder',
+        },
+      ]
+    : [
+        // Linux/Windows don't support accepting file and dir at the same time.
+        {
+          onClick: () => _upload(path, 'file'),
+          icon: 'iconfont-upload',
+          title: 'Upload a file',
+        },
+        {
+          onClick: () => _upload(path, 'directory'),
+          icon: 'iconfont-upload',
+          title: 'Upload a folder',
+        },
+        'Divider',
+      ]
+
+const mobileUploadItems = (path: Types.Path, _upload) => [
+  {
+    onClick: () => _upload(path, 'file'),
+    icon: 'iconfont-upload',
+    title: 'Upload an image',
+  },
+]
 
 const mergeProps = (stateProps, {_newFolderRow, _upload}, {path, style}) => {
   const pathElements = Types.getPathElements(path)
@@ -22,31 +54,9 @@ const mergeProps = (stateProps, {_newFolderRow, _upload}, {path, style}) => {
       pathElements.length <= 2
         ? []
         : [
-            ...(isDarwin // TODO
-              ? [
-                  {
-                    onClick: () => _upload(path, 'both'),
-                    icon: 'iconfont-upload',
-                    title: 'Upload a file or folder',
-                  },
-                ]
-              : [
-                  // Linux/Windows don't support accepting file and dir at the same time.
-                  {
-                    onClick: () => _upload(path, 'file'),
-                    icon: 'iconfont-upload',
-                    title: 'Upload a file',
-                  },
-                  {
-                    onClick: () => _upload(path, 'directory'),
-                    icon: 'iconfont-upload',
-                    title: 'Upload a folder',
-                  },
-                  'Divider',
-                ]),
+            ...(isMobile ? mobileUploadItems(path, _upload) : desktopUploadItems(path, _upload)),
             {
               // TODO: jump to top of list
-              // TODO: focus and select input somehow
               onClick: () => _newFolderRow(path),
               icon: 'iconfont-folder-new',
               title: 'New folder',

--- a/shared/fs/header/add-new-container.js
+++ b/shared/fs/header/add-new-container.js
@@ -3,14 +3,17 @@ import * as Types from '../../constants/types/fs'
 import * as FsGen from '../../actions/fs-gen'
 import {compose, setDisplayName, connect, type Dispatch, type TypedState} from '../../util/container'
 import AddNew from './add-new'
+import {isDarwin} from '../../constants/platform'
 
 const mapStateToProps = (state: TypedState) => ({})
 
 const mapDispatchToProps = (dispatch: Dispatch, {routePath}) => ({
   _newFolderRow: (parentPath: Types.Path) => dispatch(FsGen.createNewFolderRow({parentPath})),
+  _upload: (parentPath: Types.Path, type: Types.OpenDialogType) =>
+    dispatch(FsGen.createPickAndUpload({parentPath, type})),
 })
 
-const mergeProps = (stateProps, {_newFolderRow}, {path, style}) => {
+const mergeProps = (stateProps, {_newFolderRow, _upload}, {path, style}) => {
   const pathElements = Types.getPathElements(path)
   return {
     pathElements,
@@ -19,11 +22,28 @@ const mergeProps = (stateProps, {_newFolderRow}, {path, style}) => {
       pathElements.length <= 2
         ? []
         : [
-            {
-              onClick: () => {},
-              icon: 'iconfont-upload',
-              title: 'Upload file or folder',
-            },
+            ...(isDarwin // TODO
+              ? [
+                  {
+                    onClick: () => _upload(path, 'both'),
+                    icon: 'iconfont-upload',
+                    title: 'Upload a file or folder',
+                  },
+                ]
+              : [
+                  // Linux/Windows don't support accepting file and dir at the same time.
+                  {
+                    onClick: () => _upload(path, 'file'),
+                    icon: 'iconfont-upload',
+                    title: 'Upload a file',
+                  },
+                  {
+                    onClick: () => _upload(path, 'directory'),
+                    icon: 'iconfont-upload',
+                    title: 'Upload a folder',
+                  },
+                  'Divider',
+                ]),
             {
               // TODO: jump to top of list
               // TODO: focus and select input somehow

--- a/shared/fs/header/add-new.js
+++ b/shared/fs/header/add-new.js
@@ -10,11 +10,14 @@ import FloatingMenu, {
 type AddNewProps = {
   style?: Object,
   showText: boolean,
-  menuItems: Array<{
-    onClick: () => void,
-    icon: IconType,
-    title: string,
-  }>,
+  menuItems: Array<
+    | {
+        onClick: () => void,
+        icon: IconType,
+        title: string,
+      }
+    | 'Divider'
+  >,
   pathElements: Array<string>,
 }
 
@@ -83,22 +86,27 @@ const AddNew = (props: AddNewProps & FloatingMenuParentProps) => {
           visible={props.showingMenu}
           onHidden={props.toggleShowingMenu}
           header={header(props.pathElements) || undefined}
-          items={props.menuItems.map(({onClick, title, icon}) => ({
-            onClick,
-            ...(isMobile
-              ? {title}
-              : {
-                  title,
-                  view: (
-                    <Box style={stylesBox}>
-                      <Icon type={icon} color={globalColors.blue} />
-                      <Text type="Body" style={stylesText}>
-                        {title}
-                      </Text>
-                    </Box>
-                  ),
-                }),
-          }))}
+          items={props.menuItems.map(
+            item =>
+              item === 'Divider'
+                ? 'Divider'
+                : {
+                    onClick: item.onClick,
+                    ...(isMobile
+                      ? {title: item.title}
+                      : {
+                          title: item.title,
+                          view: (
+                            <Box style={stylesBox}>
+                              <Icon type={item.icon} color={globalColors.blue} />
+                              <Text type="Body" style={stylesText}>
+                                {item.title}
+                              </Text>
+                            </Box>
+                          ),
+                        }),
+                  }
+          )}
           position="bottom center"
           closeOnSelect={true}
         />

--- a/shared/fs/index.js
+++ b/shared/fs/index.js
@@ -6,80 +6,41 @@ import {globalStyles, globalMargins} from '../styles'
 import {Box, Icon, List, ScrollView, Text} from '../common-adapters'
 import FolderHeader from './header/container'
 import SortBar from './sortbar/container'
-import {Still, Editing, Placeholder, rowHeight} from './row'
+import {Still, Editing, Placeholder, Uploading, rowHeight} from './row'
 import Footer from './footer/container'
 import {isMobile} from '../constants/platform'
 import ConnectedBanner from './banner/container'
 
 type FolderProps = {
-  stillItems: Array<Types.Path>,
-  editingItems: Array<Types.EditID>,
+  items: Array<Types.RowItem>,
   isUserReset: boolean,
   resetParticipants: Array<string>,
   path: Types.Path,
   routePath: I.List<string>,
-  progress: 'pending' | 'loaded',
 }
-
-type StillRowItem = {
-  type: 'still',
-  path: Types.Path,
-}
-
-type EditingRowItem = {
-  type: 'editing',
-  editID: Types.EditID,
-}
-
-type PlaceholderRowItem = {
-  type: 'placeholder',
-  key: string,
-}
-
-type RowItem = StillRowItem | EditingRowItem | PlaceholderRowItem
 
 class Files extends React.PureComponent<FolderProps> {
-  _mapPropsToRowItems = (): Array<RowItem> =>
-    this.props.progress === 'pending'
-      ? [{type: 'placeholder', key: '1'}, {type: 'placeholder', key: '2'}, {type: 'placeholder', key: '3'}]
-      : this.props.editingItems
-          .map((editID: Types.EditID): EditingRowItem => ({
-            type: 'editing',
-            editID,
-          }))
-          .concat(
-            this.props.stillItems.map((path: Types.Path): StillRowItem => ({
-              type: 'still',
-              path,
-            }))
-          )
-
-  _rowRenderer = (index: number, item: RowItem) => {
-    switch (item.type) {
+  _rowRenderer = (index: number, item: Types.RowItem) => {
+    switch (item.rowType) {
       case 'placeholder':
-        return <Placeholder key={item.key} />
+        return <Placeholder key={`placeholder:${item.name}`} />
       case 'still':
-        return <Still key={Types.pathToString(item.path)} path={item.path} routePath={this.props.routePath} />
+        return <Still key={`still:${item.name}`} path={item.path} routePath={this.props.routePath} />
+      case 'uploading':
+        return <Uploading key={`uploading:${item.name}`} transferID={item.transferID} />
       case 'editing':
-        return (
-          <Editing
-            key={Types.editIDToString(item.editID)}
-            editID={item.editID}
-            routePath={this.props.routePath}
-          />
-        )
+        return <Editing key={`editing:${item.name}`} editID={item.editID} routePath={this.props.routePath} />
       default:
         /*::
-      let type = item.type
-      declare var ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove: (type: empty) => any
-      ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove(type);
+      let rowType = item.rowType
+      declare var ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove: (rowType: empty) => any
+      ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove(rowType);
       */
         return <Text type="BodyError">This should not happen.</Text>
     }
   }
 
   render() {
-    const rowItems = this._mapPropsToRowItems()
     const content = this.props.isUserReset ? (
       <Box style={globalStyles.flexBoxColumn}>
         <Box style={resetContainerStyle}>
@@ -87,8 +48,8 @@ class Files extends React.PureComponent<FolderProps> {
           <Icon type="icon-access-denied-266" />
         </Box>
       </Box>
-    ) : rowItems && rowItems.length ? (
-      <List fixedHeight={rowHeight} items={rowItems} renderItem={this._rowRenderer} />
+    ) : this.props.items && this.props.items.length ? (
+      <List fixedHeight={rowHeight} items={this.props.items} renderItem={this._rowRenderer} />
     ) : (
       <Box style={stylesEmptyContainer}>
         <Text type="BodySmall">This is an empty folder.</Text>

--- a/shared/fs/index.js
+++ b/shared/fs/index.js
@@ -27,9 +27,15 @@ class Files extends React.PureComponent<FolderProps> {
       case 'still':
         return <Still key={`still:${item.name}`} path={item.path} routePath={this.props.routePath} />
       case 'uploading':
-        return <Uploading key={`uploading:${item.name}`} transferID={item.transferID} />
+        return <Uploading key={`uploading:${item.name}`} path={item.path} />
       case 'editing':
-        return <Editing key={`editing:${item.name}`} editID={item.editID} routePath={this.props.routePath} />
+        return (
+          <Editing
+            key={`editing:${Types.editIDToString(item.editID)}`}
+            editID={item.editID}
+            routePath={this.props.routePath}
+          />
+        )
       default:
         /*::
       let rowType = item.rowType

--- a/shared/fs/index.stories.js
+++ b/shared/fs/index.stories.js
@@ -200,10 +200,10 @@ const load = () => {
         routePath={I.List([])}
         isUserReset={false}
         resetParticipants={[]}
-        stillItems={[
-          Types.stringToPath('/keybase/private'),
-          Types.stringToPath('/keybase/public'),
-          Types.stringToPath('/keybase/team'),
+        items={[
+          {rowType: 'still', path: Types.stringToPath('/keybase/private'), name: 'private'},
+          {rowType: 'still', path: Types.stringToPath('/keybase/public'), name: 'public'},
+          {rowType: 'still', path: Types.stringToPath('/keybase/team'), name: 'team'},
         ]}
         editingItems={[]}
       />

--- a/shared/fs/index.stories.js
+++ b/shared/fs/index.stories.js
@@ -255,8 +255,55 @@ const load = () => {
           isCreate={true}
           {...commonRowProps}
         />
-        <UploadingRow name="foo" itemStyles={fileItemStyles} />
-        <UploadingRow name="foo" itemStyles={folderItemStyles} />
+        <UploadingRow
+          name="foo"
+          itemStyles={folderItemStyles}
+          upload={Constants.makeUpload({
+            writingToJournal: true,
+            journalFlushing: false,
+          })}
+        />
+        <UploadingRow
+          name="foo"
+          itemStyles={fileItemStyles}
+          upload={Constants.makeUpload({
+            writingToJournal: true,
+            journalFlushing: false,
+          })}
+        />
+        <UploadingRow
+          name="foo"
+          itemStyles={fileItemStyles}
+          upload={Constants.makeUpload({
+            writingToJournal: true,
+            journalFlushing: true,
+          })}
+        />
+        <UploadingRow
+          name="foo"
+          itemStyles={fileItemStyles}
+          upload={Constants.makeUpload({
+            writingToJournal: false,
+            journalFlushing: true,
+          })}
+        />
+        <UploadingRow
+          name="foo"
+          itemStyles={fileItemStyles}
+          upload={Constants.makeUpload({
+            writingToJournal: false,
+            journalFlushing: false,
+          })}
+        />
+        <UploadingRow
+          name="foo"
+          itemStyles={fileItemStyles}
+          upload={Constants.makeUpload({
+            writingToJournal: false,
+            journalFlushing: false,
+            error: 'blah',
+          })}
+        />
         <StillRow
           name="bar"
           type="file"

--- a/shared/fs/popups/download-container.js
+++ b/shared/fs/popups/download-container.js
@@ -4,49 +4,49 @@ import * as Constants from '../../constants/fs'
 import * as FsGen from '../../actions/fs-gen'
 import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../util/container'
 import {navigateUp} from '../../actions/route-tree'
-import TransferPopup from './transfer'
+import DownloadPopup from './download'
 import {formatDurationFromNowTo} from '../../util/timestamp'
 
 const mapStateToProps = (state: TypedState, {routeProps}) => {
   const path = routeProps.get('path')
   const _pathItem = state.fs.pathItems.get(path) || Constants.makeUnknownPathItem()
   const _username = state.config.username || undefined
-  const _transfers = state.fs.transfers
+  const _downloads = state.fs.downloads
   return {
     path,
     _pathItem,
     _username,
-    _transfers,
+    _downloads,
   }
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   _onHidden: () => dispatch(navigateUp()),
-  _dismissTransfer: (key: string) => dispatch(FsGen.createDismissTransfer({key})),
-  _cancelTransfer: (key: string) => dispatch(FsGen.createCancelTransfer({key})),
+  _dismissDownload: (key: string) => dispatch(FsGen.createDismissDownload({key})),
+  _cancelDownload: (key: string) => dispatch(FsGen.createCancelDownload({key})),
 })
 
-const mergeProps = (stateProps, {_onHidden, _dismissTransfer, _cancelTransfer}) => {
+const mergeProps = (stateProps, {_onHidden, _dismissDownload, _cancelDownload}) => {
   const itemStyles = Constants.getItemStyles(
     Types.getPathElements(stateProps.path),
     stateProps._pathItem.type,
     stateProps._username
   )
-  const transferKV = stateProps._transfers
-    .filter(ts => ts.meta.type === 'download' && ['camera-roll', 'share'].includes(ts.meta.intent))
+  const downloadKV = stateProps._downloads
+    .filter(download => ['camera-roll', 'share'].includes(download.meta.intent))
     .entries()
-    .next().value || ['', Constants.makeTransfer()]
+    .next().value || ['', Constants.makeDownload()]
   const [
     key,
     {
       meta: {intent},
       state: {completePortion, endEstimate, isDone, error},
     },
-  ] = transferKV
+  ] = downloadKV
   const onHidden = () => {
-    isDone || _cancelTransfer(key)
+    isDone || _cancelDownload(key)
     _onHidden()
-    _dismissTransfer(key)
+    _dismissDownload(key)
   }
   isDone && !error && onHidden()
   return {
@@ -62,5 +62,5 @@ const mergeProps = (stateProps, {_onHidden, _dismissTransfer, _cancelTransfer}) 
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
-  setDisplayName('TransferPopup')
-)(TransferPopup)
+  setDisplayName('DownloadPopup')
+)(DownloadPopup)

--- a/shared/fs/popups/download.js
+++ b/shared/fs/popups/download.js
@@ -10,7 +10,7 @@ import {memoize} from 'lodash-es'
 
 type Props = {
   name: string,
-  intent: Types.TransferIntent,
+  intent: Types.DownloadIntent,
   itemStyles: Types.ItemStyles,
   completePortion: number,
   progressText: string,
@@ -18,7 +18,7 @@ type Props = {
   onHidden: () => void,
 }
 
-const getTitle = (intent: Types.TransferIntent): string => {
+const getTitle = (intent: Types.DownloadIntent): string => {
   switch (intent) {
     case 'camera-roll':
       return 'Saving to camera roll...'
@@ -39,7 +39,7 @@ const getTitle = (intent: Types.TransferIntent): string => {
   }
 }
 
-const TransferPopup = (props: Props) => {
+const DownloadPopup = (props: Props) => {
   const header = {
     title: 'unused',
     view: (
@@ -84,4 +84,4 @@ const stylesProgressContainer = memoize((errored: boolean) => ({
   paddingTop: globalMargins.small,
 }))
 
-export default TransferPopup
+export default DownloadPopup

--- a/shared/fs/popups/row-action-popup-container.js
+++ b/shared/fs/popups/row-action-popup-container.js
@@ -67,7 +67,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
             navigateAppend([
               {
                 props: {path, isShare: true},
-                selected: 'transferPopup',
+                selected: 'downloadPopup',
               },
             ])
           )
@@ -87,7 +87,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
             navigateAppend([
               {
                 props: {path, isShare: true},
-                selected: 'transferPopup',
+                selected: 'downloadPopup',
               },
             ])
           )

--- a/shared/fs/routes.js
+++ b/shared/fs/routes.js
@@ -9,7 +9,7 @@ import RelativePopupHoc from '../common-adapters/relative-popup-hoc'
 import RowPopupMenu from './popups/row-action-popup-container'
 import SecurityPrefs from './common/security-prefs-container'
 import SortBarPopupMenu from './sortbar/sort-setting-popup.js'
-import TransferPopup from './popups/transfer-container'
+import DownloadPopup from './popups/download-container'
 
 const _commonChildren = {
   finderAction: {
@@ -20,8 +20,8 @@ const _commonChildren = {
     component: RelativePopupHoc(RowPopupMenu),
     tags: makeLeafTags({layerOnTop: true}),
   },
-  transferPopup: {
-    component: RelativePopupHoc(TransferPopup),
+  downloadPopup: {
+    component: RelativePopupHoc(DownloadPopup),
     tags: makeLeafTags({layerOnTop: true}),
   },
   securityPrefs: {

--- a/shared/fs/row/index.js
+++ b/shared/fs/row/index.js
@@ -2,8 +2,9 @@
 import Placeholder from './placeholder'
 import Still from './still-container'
 import Editing from './editing-container'
+import Uploading from './uploading-container'
 import rowStyles from './styles'
 
 const rowHeight = rowStyles.height
 
-export {Still, Editing, Placeholder, rowHeight}
+export {Still, Editing, Placeholder, Uploading, rowHeight}

--- a/shared/fs/row/still-container.js
+++ b/shared/fs/row/still-container.js
@@ -10,10 +10,10 @@ import * as StateMappers from '../utils/state-mappers'
 const mapStateToProps = (state: TypedState, {path}) => {
   const pathItem = state.fs.pathItems.get(path, Constants.makeUnknownPathItem())
   const _username = state.config.username || undefined
-  const _transfers = state.fs.transfers
+  const _downloads = state.fs.downloads
   return {
     _username,
-    _transfers,
+    _downloads,
     path,
     kbfsEnabled: StateMappers.mapStateToKBFSEnabled(state),
     pathItem,
@@ -47,9 +47,7 @@ const mergeProps = (stateProps, dispatchProps) => {
     name: stateProps.pathItem.name,
     type: stateProps.pathItem.type,
     badgeCount: stateProps.pathItem.badgeCount,
-    isDownloading: !!stateProps._transfers.find(
-      t => t.meta.type === 'download' && t.meta.path === stateProps.path && !t.state.isDone
-    ),
+    isDownloading: !!stateProps._downloads.find(t => t.meta.path === stateProps.path && !t.state.isDone),
     tlfMeta: stateProps.pathItem.tlfMeta,
     isUserReset: resetParticipants.includes(stateProps._username),
     resetParticipants,

--- a/shared/fs/row/uploading-container.js
+++ b/shared/fs/row/uploading-container.js
@@ -1,0 +1,32 @@
+// @flow
+import * as Types from '../../constants/types/fs'
+import * as Constants from '../../constants/fs'
+import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import Uploading from './uploading'
+
+type OwnProps = {
+  transferID: string,
+}
+
+const mapStateToProps = (state: TypedState, {transferID}: OwnProps) => {
+  const _transfer = state.fs.transfers.get(transferID, Constants.makeTransfer())
+  const _username = state.config.username
+  return {
+    _transfer,
+    _username,
+  }
+}
+
+const mergeProps = ({_transfer, _name, _username}, {routePath}) => ({
+  name: Types.getPathName(_transfer.meta.path),
+  itemStyles: Constants.getItemStyles(
+    Types.getPathElements(_transfer.meta.path),
+    _transfer.meta.entryType,
+    _username
+  ),
+})
+
+export default compose(
+  connect(mapStateToProps, undefined, mergeProps),
+  setDisplayName('ConnectedUploadingRow')
+)(Uploading)

--- a/shared/fs/row/uploading-container.js
+++ b/shared/fs/row/uploading-container.js
@@ -1,30 +1,36 @@
 // @flow
+import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
 import Uploading from './uploading'
 
 type OwnProps = {
-  transferID: string,
+  path: Types.Path,
 }
 
-const mapStateToProps = (state: TypedState, {transferID}: OwnProps) => {
-  const _transfer = state.fs.transfers.get(transferID, Constants.makeTransfer())
+const mapStateToProps = (state: TypedState, {path}: OwnProps) => {
+  const _pathItem = state.fs.pathItems.get(path, Constants.makeUnknownPathItem())
+  const _uploads = state.fs.uploads
   const _username = state.config.username
   return {
-    _transfer,
+    _pathItem,
+    _uploads,
     _username,
   }
 }
 
-const mergeProps = ({_transfer, _name, _username}, {routePath}) => ({
-  name: Types.getPathName(_transfer.meta.path),
-  itemStyles: Constants.getItemStyles(
-    Types.getPathElements(_transfer.meta.path),
-    _transfer.meta.entryType,
-    _username
-  ),
-})
+const mergeProps = ({_pathItem, _uploads, _username}, dispatchProps, {path}: OwnProps) => {
+  const name = Types.getPathName(path)
+  const parentPath = Types.getPathParent(path)
+  const upload = _uploads.get(parentPath, I.Map()).get(name, Constants.makeUpload())
+
+  return {
+    name,
+    itemStyles: Constants.getItemStyles(Types.getPathElements(path), _pathItem.type, _username),
+    upload,
+  }
+}
 
 export default compose(
   connect(mapStateToProps, undefined, mergeProps),

--- a/shared/fs/row/uploading.js
+++ b/shared/fs/row/uploading.js
@@ -9,24 +9,44 @@ import PathItemIcon from '../common/path-item-icon'
 type UploadingProps = {
   name: string,
   itemStyles: Types.ItemStyles,
+  upload: Types.Upload,
 }
 
-const Uploading = (props: UploadingProps) => (
+const getStatusText = (upload: Types.Upload): string => {
+  if (upload.error) {
+    return 'Upload error'
+  }
+  if (upload.writingToJournal && upload.journalFlushing) {
+    return 'Encrypting & Uploading'
+  }
+  if (upload.writingToJournal) {
+    return 'Encrypting'
+  }
+  if (upload.journalFlushing) {
+    return 'Uploading'
+  }
+  return 'Done'
+}
+
+const Uploading = ({name, itemStyles, upload}: UploadingProps) => (
   <Box>
     <Box style={rowStyles.row}>
-      <PathItemIcon spec={props.itemStyles.iconSpec} style={rowStyles.pathItemIcon_30} />
+      <PathItemIcon spec={itemStyles.iconSpec} style={rowStyles.pathItemIcon_30} />
       <Box style={stylesIconBadge}>
         <Icon type="icon-addon-file-uploading" />
       </Box>
       <Box key="main" style={rowStyles.itemBox}>
         <Text
-          type={props.itemStyles.textType}
-          style={rowStyles.rowText_30(props.itemStyles.textColor)}
+          type={itemStyles.textType}
+          style={rowStyles.rowText_30(itemStyles.textColor)}
           lineClamp={isMobile ? 1 : undefined}
         >
-          {props.name}
+          {name}
         </Text>
-        <Meta title="Encrypting & Uploading" backgroundColor={globalColors.blue} />
+        <Meta
+          title={getStatusText(upload)}
+          backgroundColor={upload.error ? globalColors.red : globalColors.blue}
+        />
       </Box>
     </Box>
     <Divider style={rowStyles.divider} />

--- a/shared/fs/utils/sort.js
+++ b/shared/fs/utils/sort.js
@@ -1,0 +1,120 @@
+// @flow
+import * as Types from '../../constants/types/fs'
+import {memoize} from 'lodash'
+
+export type SortableStillRowItem = Types.StillRowItem & {
+  type: Types.PathType,
+  tlfMeta?: Types.FavoriteMetadata,
+  lastModifiedTimestamp: number,
+}
+export type SortableEditingRowItem = Types.EditingRowItem & {
+  rowType: 'editing',
+  editType: Types.EditType,
+  type: Types.PathType,
+}
+export type SortableUploadingRowItem = Types.UploadingRowItem & {
+  rowType: 'uploading',
+  type: Types.PathType,
+  isDone: boolean,
+}
+export type SortableRowItem = SortableStillRowItem | SortableEditingRowItem | SortableUploadingRowItem
+
+type PathItemComparer = (a: SortableRowItem, b: SortableRowItem) => number
+
+const getLastModifiedTimeStamp = (a: SortableRowItem) =>
+  a.rowType === 'still' ? a.lastModifiedTimestamp : Date.now()
+
+// This handles comparisons that aren't affected by asc/desc setting.
+const getCommonComparer = memoize(
+  (meUsername?: string) => (a: SortableRowItem, b: SortableRowItem): number => {
+    // See if any of them are newly created folders.
+    const aIsNewFolder = a.rowType === 'editing' && a.editType === 'new-folder'
+    const bIsNewFolder = b.rowType === 'editing' && b.editType === 'new-folder'
+    if (aIsNewFolder && !bIsNewFolder) {
+      return -1
+    }
+    if (!aIsNewFolder && bIsNewFolder) {
+      return 1
+    }
+
+    // If different type, folder goes first.
+    if (a.type === 'folder' && b.type !== 'folder') {
+      return -1
+    }
+    if (a.type !== 'folder' && b.type === 'folder') {
+      return 1
+    }
+
+    if (
+      a.rowType === 'still' &&
+      b.rowType === 'still' &&
+      a.type === 'folder' &&
+      b.type === 'folder' &&
+      a.tlfMeta &&
+      b.tlfMeta
+    ) {
+      // Both are folders that are in a TLF list.
+
+      // First, if meUsername is set (i.e. user logged in), try to put user's
+      // own TLF at first.
+      if (meUsername) {
+        const aIsMe = a.name === meUsername
+        const bIsMe = b.name === meUsername
+        if (aIsMe && !bIsMe) {
+          return -1
+        }
+        if (!aIsMe && bIsMe) {
+          return 1
+        }
+      }
+
+      // Then, inspect if any of them has isNew set. This only applies to TLF
+      // lists.
+      const aIsNew = a.tlfMeta.isNew
+      const bIsNew = b.tlfMeta.isNew
+      if (aIsNew && !bIsNew) {
+        return -1
+      }
+      if (!aIsNew && bIsNew) {
+        return 1
+      }
+    }
+
+    return 0
+  }
+)
+
+const getComparerBySortBy = (sortBy: Types.SortBy): PathItemComparer => {
+  switch (sortBy) {
+    case 'name':
+      return (a: SortableRowItem, b: SortableRowItem): number => a.name.localeCompare(b.name)
+    case 'time':
+      // asc === recent first, i.e. larger first
+      return (a: SortableRowItem, b: SortableRowItem): number =>
+        getLastModifiedTimeStamp(b) - getLastModifiedTimeStamp(a)
+    default:
+      throw new Error('invalid SortBy: ' + sortBy)
+  }
+}
+
+const getComparer = ({sortBy, sortOrder}: Types.SortSetting, meUsername?: string) => (
+  a: SortableRowItem,
+  b: SortableRowItem
+): number => {
+  const commonCompare = getCommonComparer(meUsername)(a, b)
+  if (commonCompare !== 0) {
+    return commonCompare
+  }
+
+  const multiplier = sortOrder === 'desc' ? -1 : 1
+  const sortByCompare = getComparerBySortBy(sortBy)(a, b)
+  return sortByCompare * multiplier
+}
+
+export const sortRowItems = (
+  items: Array<SortableRowItem>,
+  sortSetting: Types.SortSetting,
+  username?: string
+): Array<SortableRowItem> => {
+  return items.sort(getComparer(sortSetting, username))
+}

--- a/shared/fs/utils/sort.js
+++ b/shared/fs/utils/sort.js
@@ -15,7 +15,6 @@ export type SortableEditingRowItem = Types.EditingRowItem & {
 export type SortableUploadingRowItem = Types.UploadingRowItem & {
   rowType: 'uploading',
   type: Types.PathType,
-  isDone: boolean,
 }
 export type SortableRowItem = SortableStillRowItem | SortableEditingRowItem | SortableUploadingRowItem
 

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -51,7 +51,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
 
         toRemove = toRemove.concat(
           originalFolder.children
-            .filter(child => newItem.children.includes(child))
+            .filter(child => !newItem.children.includes(child))
             .toArray()
             .map(name => Types.pathConcat(path, name))
         )

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -31,31 +31,40 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
 
         if (item.type !== 'folder') return item
         if (!original || original.type !== 'folder') return item
-        if (original.progress === 'loaded' && item.progress === 'pending') {
-          // Don't override a loaded item into pending. This is specifically
-          // for the case where user goes back out of a folder where we could
-          // override the folder into an empty one. With this, next user
-          // navigates into the folder they would see the old list (instead of
-          // placeholder), which then gets updated when we hear back from RPC.
-          return original
+
+        // Make flow happy by referencing them with a new name that's
+        // explicitly typed.
+        const originalFolder: Types.FolderPathItem = original
+        let newItem: Types.FolderPathItem = item
+
+        if (originalFolder.progress === 'loaded' && newItem.progress === 'pending') {
+          // We don't want to override a loaded folder into pending, because
+          // otherwise next time user goes into that folder we'd show
+          // placeholders. We also don't want to simply use the original
+          // PathItem, since it's possible some metadata has updated. So use
+          // the new item, but reuse children, progress, and tlfMeta fields.
+          if (originalFolder.type === 'folder' && newItem.type === 'folder') {
+            // make flow happy
+            newItem = newItem.set('children', originalFolder.children).set('progress', 'loaded')
+          }
         }
 
         toRemove = toRemove.concat(
-          original.children
-            .filter(child => !item.children.includes(child))
+          originalFolder.children
+            .filter(child => newItem.children.includes(child))
             .toArray()
             .map(name => Types.pathConcat(path, name))
         )
-        console.log({msg: 'Removing entries in state.fs.pathItems', toRemove: toRemove})
 
         // Since `folderListLoaded`, `favoritesLoaded`, and `loadResetsResult`
         // can change `pathItems`, we need to make sure that neither one
         // clobbers the others' work.
-        return item
-          .set('badgeCount', original.badgeCount)
-          .set('tlfMeta', original.tlfMeta)
-          .set('favoriteChildren', original.favoriteChildren)
+        return newItem
+          .set('badgeCount', originalFolder.badgeCount)
+          .set('tlfMeta', originalFolder.tlfMeta)
+          .set('favoriteChildren', originalFolder.favoriteChildren)
       })
+      toRemove.length && console.log({msg: 'Removing entries in state.fs.pathItems', toRemove: toRemove})
       return state
         .set('pathItems', state.pathItems.filter((item, path) => !toRemove.includes(path)))
         .mergeIn(['pathItems'], toMerge)
@@ -87,15 +96,20 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     case FsGen.sortSetting:
       const {path, sortSetting} = action.payload
       return state.setIn(['pathUserSettings', path, 'sort'], sortSetting)
-    case FsGen.downloadStarted: {
-      const {key, path, localPath, intent, opID} = action.payload
-      const item = state.pathItems.get(path)
+    case FsGen.transferStarted: {
+      const {type, key, path, localPath, intent, opID} = action.payload
+      const entryType =
+        action.payload.entryType ||
+        (() => {
+          const item = state.pathItems.get(path)
+          return item ? item.type : 'unknown'
+        })()
       return state.setIn(
         ['transfers', key],
         Constants.makeTransfer({
           meta: Constants.makeTransferMeta({
-            type: 'download',
-            entryType: item ? item.type : 'unknown',
+            type,
+            entryType,
             intent,
             path,
             localPath,
@@ -115,7 +129,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
         original.set('completePortion', completePortion).set('endEstimate', endEstimate)
       )
     }
-    case FsGen.downloadFinished: {
+    case FsGen.transferFinished: {
       const {key, error} = action.payload
       return state.updateIn(['transfers', key, 'state'], (original: Types.TransferState) =>
         original.set('isDone', true).set('error', error)
@@ -208,6 +222,8 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     case FsGen.openPathItem:
     case FsGen.commitEdit:
     case FsGen.letResetUserBackIn:
+    case FsGen.pickAndUpload:
+    case FsGen.upload:
       return state
     default:
       /*::


### PR DESCRIPTION
This PR has upload implemented for both desktop and mobile, and prepare for overlaying KBFS journal status. It doesn't track journal status yet. That is, GUI for now doesn't know whether a file is in journal only, or has been done uploading. It also doesn't know whether the journal is still uploading anything or is idle. I will have a separate PR for it.