### PR TITLE
Fix lint

### DIFF
--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -557,9 +557,8 @@ func (f JSONConfigFile) GetGpgOptions() []string {
 	}
 	return ret
 }
-func (f JSONConfigFile) GetRunMode() (RunMode, error) {
-	var err error
-	var ret RunMode = NoRunMode
+func (f JSONConfigFile) GetRunMode() (ret RunMode, err error) {
+	ret = NoRunMode
 	if s, isSet := f.GetStringAtPath("run_mode"); isSet {
 		ret, err = StringToRunMode(s)
 	}


### PR DESCRIPTION
master ci was failing with:

`libkb/config.go:562:10: should omit type RunMode from declaration of var ret; it will be inferred from the right-hand side`
