### PR TITLE
Don't copy exploded when copying multiple messages

### DIFF
--- a/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.desktop.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.desktop.js
@@ -142,7 +142,7 @@ const Ashes = (props: {doneExploding: boolean, exploded: boolean, explodedBy: ?s
   )
   return (
     <AshBox className={props.exploded ? 'full-width' : undefined}>
-      {explodedTag}
+      {props.exploded && explodedTag}
       <FlameFront height={props.height} stop={props.doneExploding} />
     </AshBox>
   )


### PR DESCRIPTION
It'll still copy boom emoji + timestamp when copying across an actual exploding message; I couldn't find a non-major way to fix it and it seems less bad since it's actually visible. r? @keybase/react-hackers 