### PR TITLE
Fix starting a new convo from a search with enter/tab

### DIFF
--- a/shared/chat/conversation/header-area/search.js
+++ b/shared/chat/conversation/header-area/search.js
@@ -26,8 +26,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   _onExitSearch: (conversationIDKey: Types.ConversationIDKey) => {
     if (conversationIDKey !== Constants.pendingConversationIDKey) {
       dispatch(Chat2Gen.createSelectConversation({conversationIDKey, reason: 'startFoundExisting'}))
-    } else {
-      Chat2Gen.createSetPendingMode({pendingMode: 'none'})
     }
   },
 })

--- a/shared/chat/conversation/header-area/search.js
+++ b/shared/chat/conversation/header-area/search.js
@@ -1,7 +1,6 @@
 // @flow
 import UserInput from '../../../search/user-input/container'
 import * as Constants from '../../../constants/chat2'
-import * as Types from '../../../constants/types/chat2'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import {
   connect,
@@ -13,21 +12,13 @@ import {
   type Dispatch,
 } from '../../../util/container'
 
-const mapStateToProps = (state: TypedState) => {
-  const meta = Constants.getMeta(state, Constants.pendingConversationIDKey)
-  return {
-    pendingConversationUsers: meta.participants,
-    resolvedConversationIDKey: meta.conversationIDKey,
-  }
-}
+const mapStateToProps = (state: TypedState) => ({
+  pendingConversationUsers: Constants.getMeta(state, Constants.pendingConversationIDKey).participants,
+})
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
+  _onExitSearch: (participants: Array<string>) => dispatch(Chat2Gen.createCreateConversation({participants})),
   onClearSearch: () => dispatch(Chat2Gen.createSetPendingMode({pendingMode: 'none'})),
-  _onExitSearch: (conversationIDKey: Types.ConversationIDKey) => {
-    if (conversationIDKey !== Constants.pendingConversationIDKey) {
-      dispatch(Chat2Gen.createSelectConversation({conversationIDKey, reason: 'startFoundExisting'}))
-    }
-  },
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
@@ -35,7 +26,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...stateProps,
     ...dispatchProps,
     ...ownProps,
-    onExitSearch: () => dispatchProps._onExitSearch(stateProps.resolvedConversationIDKey),
+    onExitSearch: () => dispatchProps._onExitSearch(stateProps.pendingConversationUsers.toArray()),
   }
 }
 export default compose(


### PR DESCRIPTION
@keybase/react-hackers 

exitSearch fires when you hit enter/tab on a searchv3 conversation result, and we want to go to that conversation you found.