### PR TITLE
fs tweaks

### DIFF
--- a/shared/actions/fs-gen.js
+++ b/shared/actions/fs-gen.js
@@ -43,10 +43,10 @@ export const openInFileUI = 'fs:openInFileUI'
 export const openPathItem = 'fs:openPathItem'
 export const openSecurityPreferences = 'fs:openSecurityPreferences'
 export const refreshLocalHTTPServerInfo = 'fs:refreshLocalHTTPServerInfo'
-export const save = 'fs:save'
+export const saveMedia = 'fs:saveMedia'
 export const setFlags = 'fs:setFlags'
 export const setupFSHandlers = 'fs:setupFSHandlers'
-export const share = 'fs:share'
+export const shareNative = 'fs:shareNative'
 export const sortSetting = 'fs:sortSetting'
 export const transferProgress = 'fs:transferProgress'
 export const uninstallKBFS = 'fs:uninstallKBFS'
@@ -136,9 +136,9 @@ type _OpenPathItemPayload = $ReadOnly<{|
 |}>
 type _OpenSecurityPreferencesPayload = void
 type _RefreshLocalHTTPServerInfoPayload = void
-type _SavePayload = $ReadOnly<{|
+type _SaveMediaPayload = $ReadOnly<{|
   path: Types.Path,
-  routePath: I.List<string>,
+  routePath?: I.List<string>,
 |}>
 type _SetFlagsPayload = $ReadOnly<{|
   kbfsOpening?: boolean,
@@ -150,9 +150,9 @@ type _SetFlagsPayload = $ReadOnly<{|
   syncing?: boolean,
 |}>
 type _SetupFSHandlersPayload = void
-type _SharePayload = $ReadOnly<{|
+type _ShareNativePayload = $ReadOnly<{|
   path: Types.Path,
-  routePath: I.List<string>,
+  routePath?: I.List<string>,
 |}>
 type _SortSettingPayload = $ReadOnly<{|
   path: Types.Path,
@@ -202,10 +202,10 @@ export const createOpenInFileUI = (payload: _OpenInFileUIPayload) => ({error: fa
 export const createOpenPathItem = (payload: _OpenPathItemPayload) => ({error: false, payload, type: openPathItem})
 export const createOpenSecurityPreferences = (payload: _OpenSecurityPreferencesPayload) => ({error: false, payload, type: openSecurityPreferences})
 export const createRefreshLocalHTTPServerInfo = (payload: _RefreshLocalHTTPServerInfoPayload) => ({error: false, payload, type: refreshLocalHTTPServerInfo})
-export const createSave = (payload: _SavePayload) => ({error: false, payload, type: save})
+export const createSaveMedia = (payload: _SaveMediaPayload) => ({error: false, payload, type: saveMedia})
 export const createSetFlags = (payload: _SetFlagsPayload) => ({error: false, payload, type: setFlags})
 export const createSetupFSHandlers = (payload: _SetupFSHandlersPayload) => ({error: false, payload, type: setupFSHandlers})
-export const createShare = (payload: _SharePayload) => ({error: false, payload, type: share})
+export const createShareNative = (payload: _ShareNativePayload) => ({error: false, payload, type: shareNative})
 export const createSortSetting = (payload: _SortSettingPayload) => ({error: false, payload, type: sortSetting})
 export const createTransferProgress = (payload: _TransferProgressPayload) => ({error: false, payload, type: transferProgress})
 export const createUninstallKBFS = (payload: _UninstallKBFSPayload) => ({error: false, payload, type: uninstallKBFS})
@@ -247,10 +247,10 @@ export type OpenInFileUIPayload = $Call<typeof createOpenInFileUI, _OpenInFileUI
 export type OpenPathItemPayload = $Call<typeof createOpenPathItem, _OpenPathItemPayload>
 export type OpenSecurityPreferencesPayload = $Call<typeof createOpenSecurityPreferences, _OpenSecurityPreferencesPayload>
 export type RefreshLocalHTTPServerInfoPayload = $Call<typeof createRefreshLocalHTTPServerInfo, _RefreshLocalHTTPServerInfoPayload>
-export type SavePayload = $Call<typeof createSave, _SavePayload>
+export type SaveMediaPayload = $Call<typeof createSaveMedia, _SaveMediaPayload>
 export type SetFlagsPayload = $Call<typeof createSetFlags, _SetFlagsPayload>
 export type SetupFSHandlersPayload = $Call<typeof createSetupFSHandlers, _SetupFSHandlersPayload>
-export type SharePayload = $Call<typeof createShare, _SharePayload>
+export type ShareNativePayload = $Call<typeof createShareNative, _ShareNativePayload>
 export type SortSettingPayload = $Call<typeof createSortSetting, _SortSettingPayload>
 export type TransferProgressPayload = $Call<typeof createTransferProgress, _TransferProgressPayload>
 export type UninstallKBFSConfirmPayload = $Call<typeof createUninstallKBFSConfirm, _UninstallKBFSConfirmPayload>
@@ -294,10 +294,10 @@ export type Actions =
   | OpenPathItemPayload
   | OpenSecurityPreferencesPayload
   | RefreshLocalHTTPServerInfoPayload
-  | SavePayload
+  | SaveMediaPayload
   | SetFlagsPayload
   | SetupFSHandlersPayload
-  | SharePayload
+  | ShareNativePayload
   | SortSettingPayload
   | TransferProgressPayload
   | UninstallKBFSConfirmPayload

--- a/shared/actions/fs/common.native.js
+++ b/shared/actions/fs/common.native.js
@@ -1,33 +1,25 @@
 // @flow
+import * as I from 'immutable'
+import * as Types from '../../constants/types/fs'
 import * as Saga from '../../util/saga'
 import * as FsGen from '../fs-gen'
 import {putActionIfOnPath, navigateAppend} from '../route-tree'
 
-export const share = (action: FsGen.SharePayload) =>
+const getTransferPopupAction = (path: Types.Path, routePath?: I.List<string>) =>
   Saga.put(
-    putActionIfOnPath(
-      action.payload.routePath,
-      navigateAppend([
-        {
-          props: {path: action.payload.path, isShare: true},
-          selected: 'pathItemAction',
-        },
-      ])
-    )
+    routePath
+      ? putActionIfOnPath(routePath, navigateAppend([{props: {path}, selected: 'transferPopup'}]))
+      : navigateAppend([{props: {path}, selected: 'transferPopup'}])
   )
 
-export function* save(action: FsGen.SavePayload): Saga.SagaGenerator<any, any> {
-  const {path, routePath} = action.payload
-  Saga.put(FsGen.createDownload({path, intent: 'camera-roll'}))
-  Saga.put(
-    putActionIfOnPath(
-      routePath,
-      navigateAppend([
-        {
-          props: {path, isShare: true},
-          selected: 'transferPopup',
-        },
-      ])
-    )
-  )
-}
+export const shareNative = ({payload: {path, routePath}}: FsGen.ShareNativePayload) =>
+  Saga.sequentially([
+    Saga.put(FsGen.createDownload({intent: 'share', path})),
+    getTransferPopupAction(path, routePath),
+  ])
+
+export const saveMedia = ({payload: {path, routePath}}: FsGen.SaveMediaPayload) =>
+  Saga.sequentially([
+    Saga.put(FsGen.createDownload({path, intent: 'camera-roll'})),
+    getTransferPopupAction(path, routePath),
+  ])

--- a/shared/actions/fs/common.native.js
+++ b/shared/actions/fs/common.native.js
@@ -20,6 +20,6 @@ export const shareNative = ({payload: {path, routePath}}: FsGen.ShareNativePaylo
 
 export const saveMedia = ({payload: {path, routePath}}: FsGen.SaveMediaPayload) =>
   Saga.sequentially([
-    Saga.put(FsGen.createDownload({path, intent: 'camera-roll'})),
+    Saga.put(FsGen.createDownload({intent: 'camera-roll', path})),
     getTransferPopupAction(path, routePath),
   ])

--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -411,7 +411,6 @@ function* fileActionPopup(action: FsGen.FileActionPopupPayload): Saga.SagaGenera
           props: {
             path,
             position: 'bottom right',
-            isShare: false,
             targetRect,
           },
           selected: 'pathItemAction',

--- a/shared/actions/fs/platform-specific.android.js
+++ b/shared/actions/fs/platform-specific.android.js
@@ -5,7 +5,7 @@ import * as FsGen from '../fs-gen'
 import RNFetchBlob from 'react-native-fetch-blob'
 import {copy, unlink} from '../../util/file'
 import {PermissionsAndroid} from 'react-native'
-import {share, save} from './common.native'
+import {shareNative, saveMedia} from './common.native'
 import {saveAttachmentDialog, showShareActionSheet} from '../platform-specific'
 
 function copyToDownloadDir(path: string, mimeType: string) {
@@ -63,8 +63,8 @@ function platformSpecificIntentEffect(
 }
 
 function* platformSpecificSaga(): Saga.SagaGenerator<any, any> {
-  yield Saga.safeTakeEveryPure(FsGen.share, share)
-  yield Saga.safeTakeEvery(FsGen.save, save)
+  yield Saga.safeTakeEveryPure(FsGen.shareNative, shareNative)
+  yield Saga.safeTakeEvery(FsGen.saveMedia, saveMedia)
 }
 
 export {platformSpecificIntentEffect, platformSpecificSaga}

--- a/shared/actions/fs/platform-specific.ios.js
+++ b/shared/actions/fs/platform-specific.ios.js
@@ -2,7 +2,7 @@
 import * as Saga from '../../util/saga'
 import * as Types from '../../constants/types/fs'
 import * as FsGen from '../fs-gen'
-import {share, save} from './common.native'
+import {shareNative, saveMedia} from './common.native'
 import {saveAttachmentDialog, showShareActionSheet} from '../platform-specific'
 
 function platformSpecificIntentEffect(
@@ -29,8 +29,8 @@ function platformSpecificIntentEffect(
 }
 
 function* platformSpecificSaga(): Saga.SagaGenerator<any, any> {
-  yield Saga.safeTakeEveryPure(FsGen.share, share)
-  yield Saga.safeTakeEvery(FsGen.save, save)
+  yield Saga.safeTakeEveryPure(FsGen.shareNative, shareNative)
+  yield Saga.safeTakeEvery(FsGen.saveMedia, saveMedia)
 }
 
 export {platformSpecificIntentEffect, platformSpecificSaga}

--- a/shared/actions/json/fs.json
+++ b/shared/actions/json/fs.json
@@ -117,13 +117,13 @@
       "editID": "Types.EditID"
     },
 
-    "share": {
+    "shareNative": {
       "path": "Types.Path",
-      "routePath": "I.List<string>"
+      "routePath?": "I.List<string>"
     },
-    "save": {
+    "saveMedia": {
       "path": "Types.Path",
-      "routePath": "I.List<string>"
+      "routePath?": "I.List<string>"
     },
     "fileActionPopup": {
       "path": "Types.Path",

--- a/shared/fs/common/path-item-info.js
+++ b/shared/fs/common/path-item-info.js
@@ -47,9 +47,12 @@ const PathItemInfo = (props: Props) => (
         )}
       </Box>
     ) : (
-      <Text type="BodySmall" lineClamp={isMobile ? 1 : undefined}>
-        {(props.startWithLastModified ? 'Last modified ' : '') + formatTimeForFS(props.lastModifiedTimestamp)}
-      </Text>
+      !!props.lastModifiedTimestamp && (
+        <Text type="BodySmall" lineClamp={isMobile ? 1 : undefined}>
+          {(props.startWithLastModified ? 'Last modified ' : '') +
+            formatTimeForFS(props.lastModifiedTimestamp)}
+        </Text>
+      )
     )}
     {props.lastWriter ? (
       <Text type="BodySmall" style={writerTextStyle} lineClamp={isMobile ? 1 : undefined}>

--- a/shared/fs/filepreview/bare-preview.native.js
+++ b/shared/fs/filepreview/bare-preview.native.js
@@ -51,7 +51,7 @@ type ConnectedBarePreviewProps = {
 const BarePreview = (props: ConnectedBarePreviewProps) => (
   <Box style={stylesContainer}>
     <Box style={stylesHeader}>
-      <ClickableBox onClick={props.onBack}>
+      <ClickableBox onClick={props.onBack} style={stylesCloseBox}>
         <Text type="Body" style={stylesText}>
           Close
         </Text>
@@ -84,12 +84,18 @@ const stylesContainer = platformStyles({
 
 const stylesText = {
   color: globalColors.white,
+  lineHeight: 48,
+}
+
+const stylesCloseBox = {
+  paddingLeft: globalMargins.tiny,
+  height: 48,
+  width: 64,
 }
 
 const stylesHeader = {
   ...globalStyles.flexBoxRow,
   alignItems: 'center',
-  height: 32,
   paddingLeft: globalMargins.tiny,
 }
 

--- a/shared/fs/filepreview/default-view-container.js
+++ b/shared/fs/filepreview/default-view-container.js
@@ -20,14 +20,14 @@ const mapDispatchToProps = (dispatch: Dispatch, {routePath}) => ({
   _download: (path: Types.Path) => dispatch(FsGen.createDownload({path, intent: 'none'})),
   _openFinderPopup: (evt?: SyntheticEvent<>) =>
     dispatch(FsGen.createOpenFinderPopup({targetRect: Constants.syntheticEventToTargetRect(evt), routePath})),
-  _save: (path: Types.Path) => dispatch(FsGen.createSave({path, routePath})),
-  _share: (path: Types.Path) => dispatch(FsGen.createShare({path, routePath})),
+  _saveMedia: (path: Types.Path) => dispatch(FsGen.createSaveMedia({path, routePath})),
+  _shareNative: (path: Types.Path) => dispatch(FsGen.createShareNative({path, routePath})),
   _showInFileUI: (path: Types.Path) => dispatch(FsGen.createOpenInFileUI({path: Types.pathToString(path)})),
 })
 
 const mergeProps = (stateProps, dispatchProps) => {
   const {fileUIEnabled, _path, pathItem, _username} = stateProps
-  const {_download, _openFinderPopup, _save, _share, _showInFileUI} = dispatchProps
+  const {_download, _openFinderPopup, _saveMedia, _shareNative, _showInFileUI} = dispatchProps
   const itemStyles = Constants.getItemStyles(Types.getPathElements(_path), pathItem.type, _username)
   return {
     fileUIEnabled,
@@ -35,8 +35,8 @@ const mergeProps = (stateProps, dispatchProps) => {
     pathItem,
 
     onDownload: () => _download(_path),
-    onSave: () => _save(_path),
-    onShare: () => _share(_path),
+    onSave: () => _saveMedia(_path),
+    onShare: () => _shareNative(_path),
     onShowInFileUI: fileUIEnabled ? () => _showInFileUI(_path) : _openFinderPopup,
   }
 }

--- a/shared/fs/popups/row-action-popup-container.js
+++ b/shared/fs/popups/row-action-popup-container.js
@@ -107,7 +107,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 
 const getRootMenuItems = (stateProps, dispatchProps) => {
   const {path, pathItem, fileUIEnabled, _username} = stateProps
-  const {showInFileUI, saveImage, share, download, _ignoreFolder} = dispatchProps
+  const {showInFileUI, saveImage, download, _ignoreFolder} = dispatchProps
   let menuItems = []
   !isMobile &&
     fileUIEnabled &&
@@ -123,11 +123,17 @@ const getRootMenuItems = (stateProps, dispatchProps) => {
       onClick: () => saveImage(path),
     })
   isMobile &&
+    pathItem.type === 'file' &&
+    // TODO: re-enable this (or refactor) when we have in-app share. This
+    // should probably be split up into separate components anyway.
+    /*
     pathItem.type !== 'folder' &&
     menuItems.push({
       title: 'Share...',
       onClick: () => share(path),
     })
+    */
+    menuItems.push(...getShareMenuItems(stateProps, dispatchProps))
   const shouldDownload = (isAndroid && pathItem.type !== 'folder') || !isMobile
   shouldDownload &&
     menuItems.push({

--- a/shared/fs/row/still-container.js
+++ b/shared/fs/row/still-container.js
@@ -3,7 +3,6 @@ import * as FsGen from '../../actions/fs-gen'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../util/container'
-import {isMobile} from '../../constants/platform'
 import Still from './still'
 import * as StateMappers from '../utils/state-mappers'
 
@@ -55,10 +54,6 @@ const mergeProps = (stateProps, dispatchProps) => {
     resetParticipants,
     lastModifiedTimestamp: stateProps.pathItem.lastModifiedTimestamp,
     lastWriter: stateProps.pathItem.lastWriter.username,
-    shouldShowMenu:
-      !isMobile ||
-      stateProps.pathItem.type !== 'folder' ||
-      Constants.showIgnoreFolder(stateProps.path, stateProps.pathItem, stateProps._username),
     onOpen: () => dispatchProps._onOpen(stateProps.path),
     openInFileUI: stateProps.kbfsEnabled
       ? () => dispatchProps._openInFileUI(stateProps.path)

--- a/shared/fs/row/still.js
+++ b/shared/fs/row/still.js
@@ -12,7 +12,6 @@ type StillProps = {
   type: Types.PathType,
   lastModifiedTimestamp: number,
   lastWriter: string,
-  shouldShowMenu: boolean,
   itemStyles: Types.ItemStyles,
   badgeCount: number,
   isDownloading?: boolean,
@@ -102,14 +101,12 @@ const Still = (props: StillProps) => (
             className="fs-path-item-hover-icon"
           />
         )}
-        {props.shouldShowMenu && (
-          <Icon
-            type="iconfont-ellipsis"
-            style={rowActionIconStyle}
-            onClick={props.onAction}
-            className="fs-path-item-hover-icon"
-          />
-        )}
+        <Icon
+          type="iconfont-ellipsis"
+          style={rowActionIconStyle}
+          onClick={props.onAction}
+          className="fs-path-item-hover-icon"
+        />
       </Box>
     </HoverBox>
     <Divider style={rowStyles.divider} />
@@ -117,7 +114,7 @@ const Still = (props: StillProps) => (
 )
 
 const rowActionIconStyle = {
-  marginLeft: globalMargins.small,
+  padding: globalMargins.small,
 }
 
 const rowActionIconFontSize = 16

--- a/shared/fs/row/still.js
+++ b/shared/fs/row/still.js
@@ -139,8 +139,8 @@ const styleBadgeContainerRekey = {
 
 const styleDownloadContainer = {
   ...styleBadgeContainer,
-  top: 22,
-  left: 20,
+  top: isMobile ? 2 : 22,
+  left: isMobile ? -28 : 20,
 }
 
 const badgeStyleCount = {

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -200,8 +200,8 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     case FsGen.setupFSHandlers:
     case FsGen.openSecurityPreferences:
     case FsGen.refreshLocalHTTPServerInfo:
-    case FsGen.share:
-    case FsGen.save:
+    case FsGen.shareNative:
+    case FsGen.saveMedia:
     case FsGen.fileActionPopup:
     case FsGen.openFinderPopup:
     case FsGen.mimeTypeLoad:

--- a/shared/util/timestamp.js
+++ b/shared/util/timestamp.js
@@ -57,7 +57,7 @@ export const formatTimeForFS = (time: number): string =>
 
 export const formatDurationFromNowTo = (timeInFuture?: number): string => {
   if (!timeInFuture) {
-    return '? s'
+    return ''
   }
   const d = moment.duration(-moment().diff(timeInFuture))
   if (d.hours()) {


### PR DESCRIPTION
1. Show ... menu for folders too, so we can see metadata;
2. Collapse 'Share to other apps' into main popup menu;
3. When time remaining for transfers is not known, just don't show any
thing, ratehr than show '? s';
4. When we don't know the modified timestamp (e.g. for
public/private/team folders in root, or for a TLF in a TLF list), just
don't show a time, rather than showing the epoch;
5. Make clickable area larger for row action ... button and close button in bare view;
6. Fix download badge position on mobile.