### PR TITLE
Log message on attachment failed

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1644,7 +1644,7 @@ function* attachmentUploadCall({
     }
   } catch (e) {
     // TODO better error
-    logger.warn(`Upload Attachment Failed: ${e}`)
+    logger.warn(`Upload Attachment Failed: ${e.message}`)
   }
 }
 


### PR DESCRIPTION
was `[object Object]` before. r? @keybase/react-hackers 