### PR TITLE
Add names of known device eks in log send

### DIFF
--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -100,6 +100,7 @@ type fstatus struct {
 	Clients              []keybase1.ClientDetails
 	PlatformInfo         keybase1.PlatformInfo
 	OSVersion            string
+	DeviceEKNames        []string
 }
 
 func (c *CmdStatus) Run() error {
@@ -208,6 +209,7 @@ func (c *CmdStatus) load() (*fstatus, error) {
 	status.ProvisionedUsernames = extStatus.ProvisionedUsernames
 	status.Clients = extStatus.Clients
 	status.PlatformInfo = extStatus.PlatformInfo
+	status.DeviceEKNames = extStatus.DeviceEKNames
 
 	// set anything os-specific:
 	if err := c.osSpecific(&status); err != nil {
@@ -301,6 +303,8 @@ func (c *CmdStatus) outputTerminal(status *fstatus) error {
 	dui.Printf("Config path:   %s\n", status.ConfigPath)
 	dui.Printf("Default user:  %s\n", status.DefaultUsername)
 	dui.Printf("Other users:   %s\n", strings.Join(status.ProvisionedUsernames, ", "))
+	dui.Printf("Known DeviceEKs:\n")
+	dui.Printf("    %s \n", strings.Join(status.DeviceEKNames, "\n    "))
 
 	c.outputClients(dui, status.Clients)
 	return nil

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -643,6 +643,8 @@ type DeviceEKStorage interface {
 	ClearCache()
 	// Dangerous! Only for deprovisioning.
 	ForceDeleteAll(ctx context.Context, username NormalizedUsername) error
+	// For keybase log send
+	ListAllForUser(ctx context.Context) ([]string, error)
 }
 
 type UserEKBoxStorage interface {

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -124,6 +124,7 @@ type ExtendedStatus struct {
 	DefaultUsername        string          `codec:"defaultUsername" json:"defaultUsername"`
 	ProvisionedUsernames   []string        `codec:"provisionedUsernames" json:"provisionedUsernames"`
 	Clients                []ClientDetails `codec:"Clients" json:"Clients"`
+	DeviceEKNames          []string        `codec:"DeviceEKNames" json:"DeviceEKNames"`
 	PlatformInfo           PlatformInfo    `codec:"platformInfo" json:"platformInfo"`
 	DefaultDeviceID        DeviceID        `codec:"defaultDeviceID" json:"defaultDeviceID"`
 }
@@ -185,6 +186,17 @@ func (o ExtendedStatus) DeepCopy() ExtendedStatus {
 			}
 			return ret
 		})(o.Clients),
+		DeviceEKNames: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.DeviceEKNames),
 		PlatformInfo:    o.PlatformInfo.DeepCopy(),
 		DefaultDeviceID: o.DefaultDeviceID.DeepCopy(),
 	}

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -192,6 +192,11 @@ func (h ConfigHandler) GetExtendedStatus(ctx context.Context, sessionID int) (re
 	res.PlatformInfo = getPlatformInfo()
 	res.DefaultDeviceID = h.G().Env.GetDeviceID()
 	res.RememberPassphrase = h.G().Env.RememberPassphrase()
+	dekNames, err := h.G().GetDeviceEKStorage().ListAllForUser(ctx)
+	if err != nil {
+		return res, err
+	}
+	res.DeviceEKNames = dekNames
 
 	return res, nil
 }

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -66,6 +66,7 @@ protocol config {
     array<string> provisionedUsernames;
     @lint("ignore")
     array<ClientDetails> Clients;
+    array<string> DeviceEKNames;
     PlatformInfo platformInfo;
     DeviceID defaultDeviceID;               /* this contains the device ID for defaultUsername
                                                in the config file. */

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -221,6 +221,13 @@
           "lint": "ignore"
         },
         {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "DeviceEKNames"
+        },
+        {
           "type": "PlatformInfo",
           "name": "platformInfo"
         },


### PR DESCRIPTION
Thought this would be good for debugging. You can see an example in this log send: 713136a26508bc36e78ee31c