### PR TITLE
Remove margins on mobile quotes

### DIFF
--- a/shared/common-adapters/markdown.native.js
+++ b/shared/common-adapters/markdown.native.js
@@ -235,8 +235,6 @@ const styles = styleSheetCreate({
   quoteBlock: {
     borderLeftColor: globalColors.lightGrey2,
     borderLeftWidth: 3,
-    marginBottom: globalMargins.xtiny,
-    marginTop: globalMargins.xtiny,
     paddingLeft: 8,
   },
   strike: {color: undefined, fontWeight: undefined, textDecorationLine: 'line-through'},


### PR DESCRIPTION
r? @keybase/react-hackers 

after:
<img width="42" alt="image" src="https://user-images.githubusercontent.com/11968340/41551305-6ce25334-72f9-11e8-8dce-fdf5b14f9627.png">

before:
<img width="49" alt="image" src="https://user-images.githubusercontent.com/11968340/41551333-7b8680ea-72f9-11e8-8494-11a33ef38207.png">
