### PR TITLE
Add stagger to background tasks

### DIFF
--- a/go/engine/puk_upgrade_background.go
+++ b/go/engine/puk_upgrade_background.go
@@ -16,15 +16,11 @@ import (
 )
 
 var PerUserKeyUpgradeBackgroundSettings = BackgroundTaskSettings{
-	// Wait after starting the app
-	Start: 30 * time.Second,
-	// When waking up on mobile lots of timers will go off at once. We wait an additional
-	// delay so as not to add to that herd and slow down the mobile experience when opening the app.
-	WakeUp: 10 * time.Second,
-	// Wait between checks
-	Interval: 1 * time.Hour,
-	// Time limit on each round
-	Limit: 5 * time.Minute,
+	Start:        30 * time.Second, // Wait after starting the app
+	StartStagger: 10 * time.Second, // Wait an additional random amount.
+	WakeUp:       10 * time.Second, // Additional delay after waking from sleep.
+	Interval:     1 * time.Hour,    // Wait between checks
+	Limit:        5 * time.Minute,  // Time limit on each round
 }
 
 // PerUserKeyUpgradeBackground is an engine.

--- a/go/engine/puk_upgrade_background_test.go
+++ b/go/engine/puk_upgrade_background_test.go
@@ -30,6 +30,7 @@ func TestPerUserKeyUpgradeBackgroundShutdownFirst(t *testing.T) {
 		testingMetaCh: metaCh,
 	}
 	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
+	eng.task.args.Settings.StartStagger = 0 // Disable stagger for deterministic testing
 	uis := libkb.UIs{
 		LogUI: tc.G.UI.GetLogUI(),
 	}
@@ -111,6 +112,7 @@ func TestPerUserKeyUpgradeBackgroundShutdownMiddle(t *testing.T) {
 		testingRoundResCh: roundResCh,
 	}
 	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
+	eng.task.args.Settings.StartStagger = 0 // Disable stagger for deterministic testing
 	m := NewMetaContextForTestWithLogUI(tc)
 	err := RunEngine2(m, eng)
 	require.NoError(t, err)
@@ -177,6 +179,7 @@ func TestPerUserKeyUpgradeBackgroundUnnecessary(t *testing.T) {
 		testingRoundResCh: roundResCh,
 	}
 	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
+	eng.task.args.Settings.StartStagger = 0 // Disable stagger for deterministic testing
 	m := NewMetaContextForTestWithLogUI(tc)
 	err := RunEngine2(m, eng)
 	require.NoError(t, err)
@@ -228,6 +231,7 @@ func TestPerUserKeyUpgradeBackgroundWork(t *testing.T) {
 		testingRoundResCh: roundResCh,
 	}
 	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
+	eng.task.args.Settings.StartStagger = 0 // Disable stagger for deterministic testing
 	m := NewMetaContextForTestWithLogUI(tc)
 	err := RunEngine2(m, eng)
 	require.NoError(t, err)
@@ -292,6 +296,7 @@ func TestPerUserKeyUpgradeBackgroundYield(t *testing.T) {
 		testingRoundResCh: roundResCh,
 	}
 	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
+	eng.task.args.Settings.StartStagger = 0 // Disable stagger for deterministic testing
 	m := NewMetaContextForTestWithLogUI(tc)
 	err := RunEngine2(m, eng)
 	require.NoError(t, err)
@@ -359,6 +364,7 @@ func TestPerUserKeyUpgradeBackgroundLoginLate(t *testing.T) {
 		testingRoundResCh: roundResCh,
 	}
 	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
+	eng.task.args.Settings.StartStagger = 0 // Disable stagger for deterministic testing
 	m := NewMetaContextForTestWithLogUI(tc)
 	err := RunEngine2(m, eng)
 	require.NoError(t, err)

--- a/go/engine/puk_upkeep_background.go
+++ b/go/engine/puk_upkeep_background.go
@@ -15,15 +15,11 @@ import (
 )
 
 var PerUserKeyUpkeepBackgroundSettings = BackgroundTaskSettings{
-	// Wait after starting the app
-	Start: 20 * time.Second,
-	// When waking up on mobile lots of timers will go off at once. We wait an additional
-	// delay so as not to add to that herd and slow down the mobile experience when opening the app.
-	WakeUp: 15 * time.Second,
-	// Wait between checks
-	Interval: 6 * time.Hour,
-	// Time limit on each round
-	Limit: 5 * time.Minute,
+	Start:        20 * time.Second, // Wait after starting the app
+	StartStagger: 20 * time.Second, // Wait an additional random amount.
+	WakeUp:       15 * time.Second, // Additional delay after waking from sleep.
+	Interval:     6 * time.Hour,    // Wait between checks
+	Limit:        5 * time.Minute,  // Time limit on each round
 }
 
 // PerUserKeyUpkeepBackground is an engine.

--- a/go/engine/puk_upkeep_background_test.go
+++ b/go/engine/puk_upkeep_background_test.go
@@ -37,6 +37,7 @@ func TestPerUserKeyUpkeepBackgroundUnnecessary(t *testing.T) {
 		testingRoundResCh: roundResCh,
 	}
 	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
+	eng.task.args.Settings.StartStagger = 0 // Disable stagger for deterministic testing
 	m := NewMetaContextForTestWithLogUI(tc)
 	err := RunEngine2(m, eng)
 	require.NoError(t, err)
@@ -114,6 +115,7 @@ func TestPerUserKeyUpkeepBackgroundWork(t *testing.T) {
 		testingRoundResCh: roundResCh,
 	}
 	eng := NewPerUserKeyUpkeepBackground(tc.G, arg)
+	eng.task.args.Settings.StartStagger = 0 // Disable stagger for deterministic testing
 	m := NewMetaContextForTestWithLogUI(tc)
 	err = RunEngine2(m, eng)
 	require.NoError(t, err)

--- a/go/engine/wallet_init_background.go
+++ b/go/engine/wallet_init_background.go
@@ -14,15 +14,11 @@ import (
 )
 
 var WalletInitBackgroundSettings = BackgroundTaskSettings{
-	// Wait after starting the app
-	Start: 15 * time.Second,
-	// When waking up on mobile lots of timers will go off at once. We wait an additional
-	// delay so as not to add to that herd and slow down the mobile experience when opening the app.
-	WakeUp: 12 * time.Second,
-	// Wait between checks
-	Interval: 6 * time.Hour,
-	// Time limit on each round
-	Limit: 5 * time.Minute,
+	Start:        15 * time.Second, // Wait after starting the app
+	StartStagger: 30 * time.Second, // Wait an additional random amount.
+	WakeUp:       12 * time.Second, // Additional delay after waking from sleep.
+	Interval:     6 * time.Hour,    // Wait between checks
+	Limit:        5 * time.Minute,  // Time limit on each round
 }
 
 // WalletInitBackground is an engine.

--- a/go/engine/wallet_upkeep_background.go
+++ b/go/engine/wallet_upkeep_background.go
@@ -13,15 +13,11 @@ import (
 )
 
 var WalletUpkeepBackgroundSettings = BackgroundTaskSettings{
-	// Wait after starting the app
-	Start: 40 * time.Second,
-	// When waking up on mobile lots of timers will go off at once. We wait an additional
-	// delay so as not to add to that herd and slow down the mobile experience when opening the app.
-	WakeUp: 20 * time.Second,
-	// Wait between checks
-	Interval: 24 * time.Hour,
-	// Time limit on each round
-	Limit: 10 * time.Minute,
+	Start:        40 * time.Second, // Wait after starting the app.
+	StartStagger: 20 * time.Second, // Wait an additional random amount.
+	WakeUp:       20 * time.Second, // Additional delay after waking from sleep.
+	Interval:     24 * time.Hour,   // Wait between checks
+	Limit:        10 * time.Minute, // Time limit on each round
 }
 
 // WalletUpkeepBackground is an engine.


### PR DESCRIPTION
Add random stagger to background tasks so that if all clients restart at the same time these tasks don't fire at exactly the same time. Is 20sec enough to make a difference?