### PR TITLE
fix a bug where we weren't respecting symmetric key context

### DIFF
--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -40,7 +40,7 @@ func (s *PerUserKeySeed) DeriveDHKey() (*NaclDHKeyPair, error) {
 }
 
 func (s *PerUserKeySeed) DeriveSymmetricKey(reason DeriveReason) (res NaclSecretBoxKey, err error) {
-	derived, err := DeriveFromSecret(*s, DeriveReasonPUKPrev)
+	derived, err := DeriveFromSecret(*s, reason)
 	if err != nil {
 		return res, err
 	}

--- a/go/stellar/bundle/boxer.go
+++ b/go/stellar/bundle/boxer.go
@@ -71,7 +71,8 @@ func Encrypt(bundle stellar1.BundleSecretVersioned, pukGen keybase1.PerUserKeyGe
 	}
 
 	// Derive key
-	symmetricKey, err := puk.DeriveSymmetricKey(libkb.DeriveReasonPUKStellarBundle)
+	// TODO: We're passing the wrong context in here. We need to migrate to libkb.DeriveReasonPUKStellarBundle. (CORE-8135)
+	symmetricKey, err := puk.DeriveSymmetricKey(libkb.DeriveReasonPUKPrev)
 	if err != nil {
 		return res, resB64, err
 	}
@@ -171,7 +172,8 @@ func Unbox(decodeRes DecodeResult, visibleBundleB64 string,
 func Decrypt(encBundle stellar1.EncryptedBundle,
 	puk libkb.PerUserKeySeed) (res stellar1.BundleSecretVersioned, err error) {
 	// Derive key
-	symmetricKey, err := puk.DeriveSymmetricKey(libkb.DeriveReasonPUKStellarBundle)
+	// TODO: We're passing the wrong context in here. We need to migrate to libkb.DeriveReasonPUKStellarBundle. (CORE-8135)
+	symmetricKey, err := puk.DeriveSymmetricKey(libkb.DeriveReasonPUKPrev)
 	if err != nil {
 		return res, err
 	}

--- a/go/stellar/note.go
+++ b/go/stellar/note.go
@@ -33,7 +33,8 @@ func noteSymmetricKey(ctx context.Context, g *libkb.GlobalContext, other *keybas
 	if err != nil {
 		return res, err
 	}
-	symmetricKey, err := puk1Seed.DeriveSymmetricKey(libkb.DeriveReasonPUKStellarNoteSelf)
+	// TODO: We're passing the wrong context in here. We need to migrate to libkb.DeriveReasonPUKStellarNoteSelf. (CORE-8135)
+	symmetricKey, err := puk1Seed.DeriveSymmetricKey(libkb.DeriveReasonPUKPrev)
 	if err != nil {
 		return res, err
 	}
@@ -95,7 +96,8 @@ func noteSymmetricKeyForDecryption(ctx context.Context, g *libkb.GlobalContext, 
 		return res, err
 	}
 	if them == nil {
-		return pukSeed.DeriveSymmetricKey(libkb.DeriveReasonPUKStellarNoteSelf)
+		// TODO: We're passing the wrong context in here. We need to migrate to libkb.DeriveReasonPUKStellarNoteSelf. (CORE-8135)
+		return pukSeed.DeriveSymmetricKey(libkb.DeriveReasonPUKPrev)
 	}
 	u2, err := loadUvUpk(ctx, g, them.User)
 	if err != nil {


### PR DESCRIPTION
This was causing different applications to derive the same symmetric
encryption key. Currently only the stellar code is affected, which isn't
yet publicly launched. We believe we can replace the bad boxes in the
employee accounts that have issued them, as part of switching this code
over to a proper context string.

r? @mlsteele 