### PR TITLE
dont count all placeholder results as hit from PullLocalOnly

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -783,9 +783,27 @@ func (p *pullLocalResultCollector) String() string {
 	return fmt.Sprintf("[ %s: t: %d ]", p.Name(), p.num)
 }
 
+func (p *pullLocalResultCollector) realHits() (total int) {
+	for _, m := range p.Result() {
+		st, err := m.State()
+		if err != nil {
+			// count these
+			total++
+			continue
+		}
+		switch st {
+		case chat1.MessageUnboxedState_PLACEHOLDER:
+			// don't count!
+		default:
+			total++
+		}
+	}
+	return total
+}
+
 func (p *pullLocalResultCollector) Error(err storage.Error) storage.Error {
 	// Swallow this error, we know we can miss if we get anything at all
-	if _, ok := err.(storage.MissError); ok && len(p.Result()) > 0 {
+	if _, ok := err.(storage.MissError); ok && p.realHits() > 0 {
 		return nil
 	}
 	return err

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -783,27 +783,26 @@ func (p *pullLocalResultCollector) String() string {
 	return fmt.Sprintf("[ %s: t: %d ]", p.Name(), p.num)
 }
 
-func (p *pullLocalResultCollector) realHits() (total int) {
+func (p *pullLocalResultCollector) haveRealResults() bool {
 	for _, m := range p.Result() {
 		st, err := m.State()
 		if err != nil {
 			// count these
-			total++
-			continue
+			return true
 		}
 		switch st {
 		case chat1.MessageUnboxedState_PLACEHOLDER:
 			// don't count!
 		default:
-			total++
+			return true
 		}
 	}
-	return total
+	return false
 }
 
 func (p *pullLocalResultCollector) Error(err storage.Error) storage.Error {
 	// Swallow this error, we know we can miss if we get anything at all
-	if _, ok := err.(storage.MissError); ok && p.realHits() > 0 {
+	if _, ok := err.(storage.MissError); ok && p.haveRealResults() {
 		return nil
 	}
 	return err

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -783,7 +783,7 @@ func (p *pullLocalResultCollector) String() string {
 	return fmt.Sprintf("[ %s: t: %d ]", p.Name(), p.num)
 }
 
-func (p *pullLocalResultCollector) haveRealResults() bool {
+func (p *pullLocalResultCollector) hasRealResults() bool {
 	for _, m := range p.Result() {
 		st, err := m.State()
 		if err != nil {
@@ -802,7 +802,7 @@ func (p *pullLocalResultCollector) haveRealResults() bool {
 
 func (p *pullLocalResultCollector) Error(err storage.Error) storage.Error {
 	// Swallow this error, we know we can miss if we get anything at all
-	if _, ok := err.(storage.MissError); ok && p.haveRealResults() {
+	if _, ok := err.(storage.MissError); ok && p.hasRealResults() {
 		return nil
 	}
 	return err


### PR DESCRIPTION
We don't get much value from returning 10 placeholder messages from `PullLocalOnly` to the UI, so just count those as cache misses. 

cc @chrisnojima 