### PR TITLE
Chat can unbox messages from deleted users

### DIFF
--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -368,6 +368,9 @@ func (t *NameIdentifier) identifyUser(ctx context.Context, assertion string, pri
 		if _, ok := err.(libkb.ResolutionError); ok {
 			return keybase1.TLFIdentifyFailure{}, nil
 		}
+		if _, ok := err.(libkb.UserDeletedError); ok {
+			return keybase1.TLFIdentifyFailure{}, nil
+		}
 
 		// Special treatment is needed for GUI strict mode, since we need to
 		// simultaneously plumb identify breaks up to the UI, and make sure the


### PR DESCRIPTION
This brings chats with deleted users back to this level of functionality. It still appears as if they reset. This is worse.

![image](https://user-images.githubusercontent.com/705646/41627413-38329932-73ee-11e8-8a39-9e167edb294c.png)
