### PR TITLE
always use a memory SecretStore, sometimes a disk

### DIFF
--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -130,67 +130,112 @@ func ClearStoredSecret(g *GlobalContext, username NormalizedUsername) error {
 	return ss.ClearSecret(username)
 }
 
-// SecretStoreLocked protects a SecretStoreAll with a mutex.
+// SecretStoreLocked protects a SecretStoreAll with a mutex. It wraps two different
+// SecretStoreAlls: one in memory and one in disk. In all cases, we always have a memory
+// backing. If the OS and options provide one, we can additionally have a disk-backed
+// secret store. It's a write-through cache, so on RetrieveSecret, the memory store
+// will be checked first, and then the disk store.
 type SecretStoreLocked struct {
-	SecretStoreAll
+	Contextified
 	sync.Mutex
+	mem  SecretStoreAll
+	disk SecretStoreAll
 }
 
 func NewSecretStoreLocked(g *GlobalContext) *SecretStoreLocked {
-	var ss SecretStoreAll
+	var disk SecretStoreAll
+
+	mem := NewSecretStoreMem()
 
 	if g.Env.RememberPassphrase() {
 		// use os-specific secret store
 		g.Log.Debug("NewSecretStoreLocked: using os-specific SecretStore")
-		ss = NewSecretStoreAll(g)
+		disk = NewSecretStoreAll(g)
 	} else {
 		// config or command line flag said to use in-memory secret store
 		g.Log.Debug("NewSecretStoreLocked: using memory-only SecretStore")
-		ss = NewSecretStoreMem()
-	}
-
-	if ss == nil {
-		// right now, some stuff depends on g.SecretStoreAll being nil or not
-		return nil
 	}
 
 	return &SecretStoreLocked{
-		SecretStoreAll: ss,
+		Contextified: NewContextified(g),
+		mem:          mem,
+		disk:         disk,
 	}
 }
 
+func (s *SecretStoreLocked) isNil() bool {
+	return s.mem == nil && s.disk == nil
+}
+
 func (s *SecretStoreLocked) RetrieveSecret(username NormalizedUsername) (LKSecFullSecret, error) {
-	if s == nil || s.SecretStoreAll == nil {
+	if s == nil || s.isNil() {
 		return LKSecFullSecret{}, nil
 	}
 	s.Lock()
 	defer s.Unlock()
-	return s.SecretStoreAll.RetrieveSecret(username)
+
+	res, err := s.mem.RetrieveSecret(username)
+	if !res.IsNil() && err == nil {
+		return res, nil
+	}
+	if err != nil {
+		s.G().Log.Debug("SecretStoreLocked#RetrieveSecret: memory fetch error: %s", err.Error())
+	}
+	if s.disk == nil {
+		return res, err
+	}
+
+	res, err = s.disk.RetrieveSecret(username)
+	if err != nil {
+		return res, err
+	}
+	tmp := s.mem.StoreSecret(username, res)
+	if tmp != nil {
+		s.G().Log.Debug("SecretStoreLocked#RetrieveSecret: failed to store secret in memory: %s", err.Error())
+	}
+	return res, err
 }
 
 func (s *SecretStoreLocked) StoreSecret(username NormalizedUsername, secret LKSecFullSecret) error {
-	if s == nil || s.SecretStoreAll == nil {
+	if s == nil || s.isNil() {
 		return nil
 	}
 	s.Lock()
 	defer s.Unlock()
-	return s.SecretStoreAll.StoreSecret(username, secret)
+	err := s.mem.StoreSecret(username, secret)
+	if err != nil {
+		s.G().Log.Debug("SecretStoreLocked#StoreSecret: failed to store secret in memory: %s", err.Error())
+	}
+	if s.disk == nil {
+		return err
+	}
+	return s.disk.StoreSecret(username, secret)
 }
 
 func (s *SecretStoreLocked) ClearSecret(username NormalizedUsername) error {
-	if s == nil || s.SecretStoreAll == nil {
+	if s == nil || s.isNil() {
 		return nil
 	}
 	s.Lock()
 	defer s.Unlock()
-	return s.SecretStoreAll.ClearSecret(username)
+	err := s.mem.ClearSecret(username)
+	if err != nil {
+		s.G().Log.Debug("SecretStoreLocked#ClearSecret: failed to clear memory: %s", err.Error())
+	}
+	if s.disk == nil {
+		return err
+	}
+	return s.disk.ClearSecret(username)
 }
 
 func (s *SecretStoreLocked) GetUsersWithStoredSecrets() ([]string, error) {
-	if s == nil || s.SecretStoreAll == nil {
+	if s == nil || s.isNil() {
 		return nil, nil
 	}
 	s.Lock()
 	defer s.Unlock()
-	return s.SecretStoreAll.GetUsersWithStoredSecrets()
+	if s.disk == nil {
+		return s.mem.GetUsersWithStoredSecrets()
+	}
+	return s.disk.GetUsersWithStoredSecrets()
 }


### PR DESCRIPTION
- we've seen certain cases of the macOS keychain just not working; it's a bummer, but the least we can do is
  to only pester the user for a passphrase once every service restart. Previously, we were going to the secret
  store every time we needed the password.
- this PR introduces a SecretStoreMem as a write-through cache to a disk-backed SecretStore, which is optional