### PR TITLE
Release 2.1.0 on desktop; start 2.3.0 cycle

### DIFF
--- a/go/libkb/version.go
+++ b/go/libkb/version.go
@@ -4,4 +4,4 @@
 package libkb
 
 // Version is the current version (should be MAJOR.MINOR.PATCH)
-const Version = "2.1.0"
+const Version = "2.3.0"

--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -96,7 +96,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
         versionCode timestamp()
-        versionName "2.2.0"
+        versionName "2.3.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
@keybase/react-hackers CC @mmaxim 

Mobile snuck in a 2.2.0 bugfix release without bumping desktop -- let's sync up again at the start of 2.3.0 now that we've released?