### PR TITLE
fs: Remove favorites listing trigger from badge state notification

### DIFF
--- a/shared/actions/notifications.js
+++ b/shared/actions/notifications.js
@@ -75,7 +75,6 @@ function _onRecievedBadgeState(action: NotificationsGen.ReceivedBadgeStatePayloa
         teamsWithResetUsers: teamsWithResetUsers || [],
       })
     ),
-    Saga.put(FsGen.createFavoritesLoad()),
   ])
 }
 


### PR DESCRIPTION
Reset badging won't update without this, but that's probably fine for now because we don't display it at the root anyway yet.