### PR TITLE
[NOMERGE] Hotfixes from 2.1.0

### DIFF
--- a/go/libkb/version.go
+++ b/go/libkb/version.go
@@ -4,4 +4,4 @@
 package libkb
 
 // Version is the current version (should be MAJOR.MINOR.PATCH)
-const Version = "2.1.0"
+const Version = "2.1.1"

--- a/shared/actions/notifications.js
+++ b/shared/actions/notifications.js
@@ -75,7 +75,6 @@ function _onRecievedBadgeState(action: NotificationsGen.ReceivedBadgeStatePayloa
         teamsWithResetUsers: teamsWithResetUsers || [],
       })
     ),
-    Saga.put(FsGen.createFavoritesLoad()),
   ])
 }
 


### PR DESCRIPTION
[x] - Bump version to 2.1.1
[x] - Turn off favorites listing on receipt of a new badge state.