### PR TITLE
Handle navigating to a new convo after block on desktop

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1298,6 +1298,7 @@ const changeSelectedConversation = (
     | Chat2Gen.MessageSendPayload
     | Chat2Gen.SetPendingModePayload
     | Chat2Gen.AttachmentsUploadPayload
+    | Chat2Gen.BlockConversationPayload
     | TeamsGen.LeaveTeamPayload,
   state: TypedState
 ) => {
@@ -1351,6 +1352,7 @@ const _maybeAutoselectNewestConversation = (
     | Chat2Gen.MessageSendPayload
     | Chat2Gen.SetPendingModePayload
     | Chat2Gen.AttachmentsUploadPayload
+    | Chat2Gen.BlockConversationPayload
     | TeamsGen.LeaveTeamPayload,
   state: TypedState
 ) => {
@@ -1374,8 +1376,11 @@ const _maybeAutoselectNewestConversation = (
     if (Constants.isValidConversationIDKey(selected)) {
       return
     }
-  } else if (action.type === Chat2Gen.leaveConversation && action.payload.conversationIDKey === selected) {
-    // force select a new one
+  } else if (
+    (action.type === Chat2Gen.leaveConversation || action.type === Chat2Gen.blockConversation) &&
+    action.payload.conversationIDKey === selected
+  ) {
+    // Intentional fall-through -- force select a new one
   } else if (selected !== Constants.noConversationIDKey) {
     return
   }
@@ -2123,6 +2128,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
       Chat2Gen.setPendingMode,
       Chat2Gen.messageSend,
       Chat2Gen.attachmentsUpload,
+      Chat2Gen.blockConversation,
       TeamsGen.leaveTeam,
     ],
     changeSelectedConversation

--- a/shared/chat/conversation/block-conversation-warning/container.js
+++ b/shared/chat/conversation/block-conversation-warning/container.js
@@ -20,15 +20,13 @@ const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  _onBlock: (conversationIDKey: ConversationIDKey, reportUser: boolean) => {
+  _onBlock: (conversationIDKey: ConversationIDKey, reportUser: boolean) =>
     dispatch(
       Chat2Gen.createBlockConversation({
         conversationIDKey,
         reportUser,
       })
-    )
-    dispatch(Chat2Gen.createNavigateToInbox())
-  },
+    ),
   onBack: () => dispatch(navigateUp()),
 })
 


### PR DESCRIPTION
@keybase/react-hackers 

On mobile we call `navigateToInbox()` to leave, but on desktop there's a `_maybeAutoselectNewestConversation` saga that we need to hook the action into in order to nav away after blocking a chat.

(Tested on desktop and mobile.)