### PR TITLE
inject in order so we don't go crazy

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2087,8 +2087,8 @@ function* handleSeeingExplodingMessages(action: Chat2Gen.HandleSeeingExplodingMe
   }
   // neither are set, inject both
   yield Saga.sequentially([
-    Saga.call(RPCTypes.gregorInjectItemRpcPromise, {
-      cat: Constants.seenExplodingGregorKey,
+    Saga.call(RPCTypes.gregorUpdateCategoryRpcPromise, {
+      category: Constants.seenExplodingGregorKey,
       body: 'true',
       dtime: {time: 0, offset: 0},
     }),

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2086,7 +2086,7 @@ function* handleSeeingExplodingMessages(action: Chat2Gen.HandleSeeingExplodingMe
     return
   }
   // neither are set, inject both
-  yield Saga.all([
+  yield Saga.sequentially([
     Saga.call(RPCTypes.gregorInjectItemRpcPromise, {
       cat: Constants.seenExplodingGregorKey,
       body: 'true',


### PR DESCRIPTION
If `Constants.newExplodingGregorKey` makes it into the state first, then it sets off a chain reaction later on in `handleIsExplodingNew`. It triggers this code:

```
else if (!seenExploding) {
    // newExploding && !seenExploding. this should never happen
    logger.warn('Got newExploding but not seenExploding! Setting seenExploding...')
    actions.push(
      Saga.call(RPCTypes.gregorInjectItemRpcPromise, {
        cat: ChatConstants.seenExplodingGregorKey,
        body: 'true',
        dtime: {time: 0, offset: 0},
      })
    )
  }
```

Can we just delete that code block too? 