### PR TITLE
Fix waitForBadgeStateWithReset, unskip test

### DIFF
--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -181,16 +181,23 @@ func (r *teamHandler) findAndDismissResetBadges(ctx context.Context, cli gregor1
 			}
 			if upak.Current.EldestSeqno == teamUV.EldestSeqno {
 				// We have the latest version of the user in the team.
+				r.G().Log.CDebugf(ctx, "Dismissing badge for %s - team has latest user version", badge.Uid)
 				dismiss = true
+			} else {
+				r.G().Log.CDebugf(ctx, "User %s is still reset: current seq: %d team seq: ",
+					badge.Uid, upak.Current.EldestSeqno, teamUV.EldestSeqno)
 			}
 		} else {
 			// User has been removed from the team.
+			r.G().Log.CDebugf(ctx, "Dismissing badge for %s - member was removed", badge.Uid)
 			dismiss = true
 		}
 
 		if dismiss {
 			err := r.G().GregorDismisser.DismissItem(ctx, cli, badge.Id)
-			if err != nil {
+			if err == nil {
+				r.G().Log.CDebugf(ctx, "dismissed badge %s for %s!", badge.Id, badge.Uid)
+			} else {
 				r.G().Log.CDebugf(ctx, "failed to dismiss TeamMemberOutFromReset badge: %s", err)
 			}
 		}

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -708,8 +708,6 @@ func TestTeamAfterDeleteUser(t *testing.T) {
 }
 
 func testTeamResetBadgesAndDismiss(t *testing.T, readd bool) {
-	t.Skip("issues related to reset badges")
-
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -509,19 +509,24 @@ func (u *userPlusDevice) waitForTeamChangedGregor(teamID keybase1.TeamID, toSeqn
 }
 
 func (u *userPlusDevice) waitForBadgeStateWithReset(numReset int) keybase1.BadgeState {
-	for i := 0; i < 10; i++ {
+	// Process any number of badge state updates, but bail out after
+	// 10 seconds.
+	timeout := time.After(10 * time.Second * libkb.CITimeMultiplier(u.tc.G))
+	i := 0
+	for {
 		select {
 		case arg := <-u.notifications.badgeCh:
-			u.tc.T.Logf("badge state received: %+v", arg.TeamsWithResetUsers)
+			u.tc.T.Logf("badge state received %d: %+v", i, arg.TeamsWithResetUsers)
+			i++
 			if len(arg.TeamsWithResetUsers) == numReset {
 				u.tc.T.Logf("badge state length match")
 				return arg
 			}
-		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
+		case <-timeout:
+			u.tc.T.Fatal("timed out waiting for badge state")
+			return keybase1.BadgeState{}
 		}
 	}
-	u.tc.T.Fatal("timed out waiting for badge state")
-	return keybase1.BadgeState{}
 }
 
 func (u *userPlusDevice) drainGregor() {


### PR DESCRIPTION
waitForBadgeStateWithReset was waiting for 10 badge state updates or timeouting after 1 second of not getting a state update. But it turned out that 10 updates is not enough, and adding one new notifications on the server side triggered an issue where relevant badge state was 11th.

Another issue with that waiting function was that if, say, 9 badge states were already queued up, and we expected the relevant update to happen on 10th badge state, there was only 1 second (or 3 on CI) for it to arrive. This triggered flakes with reset badge dismissal refactor because UPAK loading sometimes took longer than that.