### PR TITLE
Only use one item to figure out if exploding is new

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2089,9 +2089,9 @@ function* handleSeeingExplodingMessages(action: Chat2Gen.HandleSeeingExplodingMe
       return
     }
   }
-  yield Saga.call(RPCTypes.gregorInjectItemRpcPromise, {
-    cat: Constants.seenExplodingGregorKey,
+  yield Saga.call(RPCTypes.gregorUpdateCategoryRpcPromise, {
     body: Date.now().toString(),
+    category: Constants.seenExplodingGregorKey,
     dtime: {time: 0, offset: 0},
   })
 }

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2078,29 +2078,22 @@ const setConvExplodingModeFailure = (e, action: Chat2Gen.SetConvExplodingModePay
 
 function* handleSeeingExplodingMessages(action: Chat2Gen.HandleSeeingExplodingMessagesPayload) {
   const gregorState = yield Saga.call(RPCTypes.gregorGetStateRpcPromise)
-  const seenExplodingMessages = !!gregorState.items.filter(
+  const seenExplodingMessages = gregorState.items.find(
     i => i.item.category === Constants.seenExplodingGregorKey
-  ).length
+  )
   if (seenExplodingMessages) {
-    // do nothing
-    return
+    if (isNaN(parseInt(seenExplodingMessages.item.body.toString(), 10))) {
+      logger.info('handleSeeingExplodingMessages: bad seenExploding item body, updating category')
+    } else {
+      // do nothing
+      return
+    }
   }
-  // neither are set, inject both
-  yield Saga.all([
-    Saga.call(RPCTypes.gregorInjectItemRpcPromise, {
-      cat: Constants.seenExplodingGregorKey,
-      body: 'true',
-      dtime: {time: 0, offset: 0},
-    }),
-    // note that we don't get a push state when this item expires,
-    // it doesn't really affect things here - we can wait for the
-    // next push state to stop displaying 'new' mode
-    Saga.call(RPCTypes.gregorInjectItemRpcPromise, {
-      cat: Constants.newExplodingGregorKey,
-      body: 'true',
-      dtime: {time: 0, offset: Constants.newExplodingGregorOffset},
-    }),
-  ])
+  yield Saga.call(RPCTypes.gregorInjectItemRpcPromise, {
+    cat: Constants.seenExplodingGregorKey,
+    body: Date.now().toString(),
+    dtime: {time: 0, offset: 0},
+  })
 }
 
 function* chat2Saga(): Saga.SagaGenerator<any, any> {

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -178,67 +178,17 @@ function handleConvExplodingModes(items: Array<Types.NonNullGregorItem>) {
   return Saga.put(Chat2Gen.createUpdateConvExplodingModes({modes}))
 }
 
-function getIsExplodingNewDismissActions(items: Array<Types.NonNullGregorItem>) {
-  const seenExplodings = items.filter(i => i.item.category === ChatConstants.seenExplodingGregorKey)
-  const newExplodings = items.filter(i => i.item.category === ChatConstants.newExplodingGregorKey)
-
-  if (seenExplodings.length > 1) {
-    logger.warn('Found some extra seenExploding gregor items. Dismissing...')
-  }
-
-  const ret = []
-  let oldestSeenExploding
-  if (seenExplodings.length > 1) {
-    // keep the oldest one, dismiss the rest
-    oldestSeenExploding = seenExplodings.sort((a, b) => (a.md.ctime > b.md.ctime ? 0 : 1)).pop()
-    ret.push(...seenExplodings)
-  } else if (seenExplodings.length === 1) {
-    oldestSeenExploding = seenExplodings[0]
-  }
-
-  // keep the oldest one, or dismiss all if oldest one was created > offset between seenExploding and newExploding
-  const oldest = newExplodings.sort((a, b) => (a.md.ctime > b.md.ctime ? 0 : 1)).pop()
-  if (
-    oldestSeenExploding &&
-    oldest &&
-    oldest.md.ctime - oldestSeenExploding.md.ctime > ChatConstants.newExplodingGregorOffset
-  ) {
-    newExplodings.push(oldest)
-  }
-  ret.push(...newExplodings)
-
-  if (newExplodings.length) {
-    logger.warn('Found some extra newExploding gregor items. Dismissing...')
-  }
-
-  return ret.map(i => Saga.call(RPCTypes.gregorDismissItemRpcPromise, {id: i.md.msgID}))
-}
-
 function handleIsExplodingNew(items: Array<Types.NonNullGregorItem>) {
   const seenExploding = items.find(i => i.item.category === ChatConstants.seenExplodingGregorKey)
-  const newExploding = items.find(i => i.item.category === ChatConstants.newExplodingGregorKey)
-  const actions = getIsExplodingNewDismissActions(items)
-  if (!seenExploding && !newExploding) {
-    // neither exist. we haven't been here before - set flag in store to new.
-    actions.push(Saga.put(Chat2Gen.createSetExplodingMessagesNew({new: true})))
-  } else if (!seenExploding) {
-    // newExploding && !seenExploding. this should never happen
-    logger.warn('Got newExploding but not seenExploding! Setting seenExploding...')
-    actions.push(
-      Saga.call(RPCTypes.gregorInjectItemRpcPromise, {
-        cat: ChatConstants.seenExplodingGregorKey,
-        body: 'true',
-        dtime: {time: 0, offset: 0},
-      })
-    )
-  } else if (!newExploding) {
-    // seenExploding but not newExploding, set flag in store to old
-    actions.push(Saga.put(Chat2Gen.createSetExplodingMessagesNew({new: false})))
-  } else {
-    // both exist. exploding messages are new.
-    actions.push(Saga.put(Chat2Gen.createSetExplodingMessagesNew({new: true})))
+  let isNew = true
+  if (seenExploding) {
+    const body = seenExploding.item.body.toString()
+    const when = parseInt(body, 10)
+    if (!isNaN(when)) {
+      isNew = Date.now() - when < ChatConstants.newExplodingGregorOffset
+    }
   }
-  return Saga.all(actions)
+  return Saga.put(Chat2Gen.createSetExplodingMessagesNew({new: isNew}))
 }
 
 function _handlePushState(pushAction: GregorGen.PushStatePayload) {

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -186,6 +186,8 @@ function handleIsExplodingNew(items: Array<Types.NonNullGregorItem>) {
     const when = parseInt(body, 10)
     if (!isNaN(when)) {
       isNew = Date.now() - when < ChatConstants.newExplodingGregorOffset
+    } else if (body === 'true') {
+      isNew = !!items.filter(i => i.item.category === ChatConstants.newExplodingGregorKey)
     }
   }
   return Saga.put(Chat2Gen.createSetExplodingMessagesNew({new: isNew}))

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -121,6 +121,9 @@ export const isInfoPanelOpen = (state: TypedState) => {
 
 export const creatingLoadingKey = 'creatingConvo'
 
+// unused for new stuff, kept for checks
+export const newExplodingGregorKey = 'explodingMessagesAreNew'
+
 // When we see that exploding messages are in the app, we set
 // seenExplodingGregorKey. Once newExplodingGregorOffset time
 // passes, we stop showing the 'NEW' tag.

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -122,14 +122,9 @@ export const isInfoPanelOpen = (state: TypedState) => {
 export const creatingLoadingKey = 'creatingConvo'
 
 // When we see that exploding messages are in the app, we set
-// seenExplodingGregorKey as well as newExplodingGregorKey.
-// newExploding.. is set with a dtime of a couple days.
-// seenExploding.. never expires.
-// 1. Neither exist: new and user hasn't seen them
-// 2. Both exist: new and user has seen them
-// 3. One exists (seenExploding...): old; unset tag
+// seenExplodingGregorKey. Once newExplodingGregorOffset time
+// passes, we stop showing the 'NEW' tag.
 export const seenExplodingGregorKey = 'hasSeenExplodingMessages'
-export const newExplodingGregorKey = 'explodingMessagesAreNew'
 export const newExplodingGregorOffset = 1000 * 3600 * 24 * 3 // 3 days in ms
 export const getIsExplodingNew = (state: TypedState) => state.chat2.get('isExplodingNew')
 export const explodingModeGregorKeyPrefix = 'exploding:'


### PR DESCRIPTION
Fixes client thrashing that results from juggling two items to figure this out. @keybase/react-hackers @mmaxim 