### PR TITLE
Fix 'You haven't chatted with yet' after canceling a pending conv

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -245,7 +245,7 @@ type _MuteConversationPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
   muted: boolean,
 |}>
-type _NavigateToInboxPayload = void
+type _NavigateToInboxPayload = $ReadOnly<{|findNewConversation: boolean|}>
 type _NavigateToThreadPayload = void
 type _NotificationSettingsUpdatedPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1316,7 +1316,10 @@ const changeSelectedConversation = (
           Saga.put(navigateToThreadRoute),
         ])
       } else if (action.payload.noneDestination === 'inbox') {
-        return Saga.put(Chat2Gen.createNavigateToInbox())
+        return Saga.sequentially([
+          Saga.put(Chat2Gen.createNavigateToInbox()),
+          !isMobile ? _maybeAutoselectNewestConversation(action, state) : undefined,
+        ])
       } else if (action.payload.noneDestination === 'thread') {
         // don't allow check of isValidConversationIDKey
         return Saga.put(navigateToThreadRoute)

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -334,7 +334,9 @@
       "updateType": "RPCChatTypes.StaleUpdateType"
     },
     // Navigation helpers. Nav is slightly different on mobile / desktop
-    "navigateToInbox": {},
+    "navigateToInbox": {
+      "findNewConversation": "boolean"
+    },
     "navigateToThread": {},
     // Share to external app on mobile
     "messageAttachmentNativeShare": {

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -48,7 +48,7 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {conversationIDKey, onBack}) => ({
-  _navToRootChat: () => dispatch(Chat2Gen.createNavigateToInbox()),
+  _navToRootChat: () => dispatch(Chat2Gen.createNavigateToInbox({findNewConversation: false})),
   onLeaveConversation: () => dispatch(Chat2Gen.createLeaveConversation({conversationIDKey})),
   onJoinChannel: () => dispatch(Chat2Gen.createJoinConversation({conversationIDKey})),
   onShowBlockConversationDialog: () => {

--- a/shared/chat/new-team-dialog-container.js
+++ b/shared/chat/new-team-dialog-container.js
@@ -22,7 +22,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
       })
     )
   },
-  onCancel: () => dispatch(Chat2Gen.createNavigateToInbox()),
+  onCancel: () => dispatch(Chat2Gen.createNavigateToInbox({findNewConversation: false})),
   onJoinSubteamChange: () => {},
   onSetTeamCreationError: (error: string) => {
     dispatch(TeamsGen.createSetTeamCreationError({error}))


### PR DESCRIPTION
@keybase/react-hackers 

Here's a fix for canceling a pending conversation not backing out of the "Start chatting" view on desktop.

But I think the fix suggests that `navigateToInbox()` itself should be doing this work -- it could perform the `isMobile` check and call `_maybeAutoselectNewestConversation()` itself instead of making callers do it.  I didn't do that here because I haven't looked at every caller to try to work out whether that would ever do the wrong thing.  Let's talk about it.