### PR TITLE
Even better backwards compatibility with is exploding new

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2086,19 +2086,15 @@ function* handleSeeingExplodingMessages(action: Chat2Gen.HandleSeeingExplodingMe
     const contents = seenExplodingMessages.item.body.toString()
     if (isNaN(parseInt(contents, 10))) {
       logger.info('handleSeeingExplodingMessages: bad seenExploding item body, updating category')
-    }
-    if (contents === 'true') {
-      // user was on the old way. check if `newExploding` is there
-      // set `body` to 3 days back if not
-      if (!gregorState.items.find(i => i.item.category === Constants.newExplodingGregorKey)) {
-        logger.info(
-          'handleSeeingExplodingMessages: found that exploding is not new in old push state. Updating category with old timestamp.'
-        )
-        body = (Date.now() - Constants.newExplodingGregorOffset).toString()
-      }
     } else {
       // do nothing
       return
+    }
+  } else {
+    // haven't been here before. figure out the new body by seeing if newExploding is there
+    if (!gregorState.items.find(i => i.item.category === Constants.newExplodingGregorKey)) {
+      // not new!
+      body = (Date.now() - Constants.newExplodingGregorOffset).toString()
     }
   }
   yield Saga.call(RPCTypes.gregorUpdateCategoryRpcPromise, {

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -187,9 +187,10 @@ function handleIsExplodingNew(items: Array<Types.NonNullGregorItem>) {
     if (!isNaN(when)) {
       isNew = Date.now() - when < ChatConstants.newExplodingGregorOffset
     }
-    if (body === 'true') {
-      isNew = !!items.filter(i => i.item.category === ChatConstants.newExplodingGregorKey)
-    }
+  } else {
+    // never clicked on bomb icon with new setup
+    // check for old one
+    isNew = !!items.find(i => i.item.category === ChatConstants.newExplodingGregorKey)
   }
   return Saga.put(Chat2Gen.createSetExplodingMessagesNew({new: isNew}))
 }

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -123,11 +123,12 @@ export const creatingLoadingKey = 'creatingConvo'
 
 // unused for new stuff, kept for checks
 export const newExplodingGregorKey = 'explodingMessagesAreNew'
+export const oldSeenExplodingGregorKey = 'hasSeenExplodingMessages'
 
 // When we see that exploding messages are in the app, we set
 // seenExplodingGregorKey. Once newExplodingGregorOffset time
 // passes, we stop showing the 'NEW' tag.
-export const seenExplodingGregorKey = 'hasSeenExplodingMessages'
+export const seenExplodingGregorKey = 'seenExplodingMessages'
 export const newExplodingGregorOffset = 1000 * 3600 * 24 * 3 // 3 days in ms
 export const getIsExplodingNew = (state: TypedState) => state.chat2.get('isExplodingNew')
 export const explodingModeGregorKeyPrefix = 'exploding:'


### PR DESCRIPTION
Clients weren't getting the updated value with the old `seenExplodingGregorKey` because of the server blocking we added. This switches to use a new key and just checks for the existence of `newExplodingGregorKey` to decide how to transition to the new key. r? @keybase/react-hackers cc @mmaxim @chrisnojima 