### PR TITLE
Always send NewChatActivityWithEphemeralPurge on ephemeral purge

### DIFF
--- a/go/chat/ephemeral_purger.go
+++ b/go/chat/ephemeral_purger.go
@@ -14,7 +14,6 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
-	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/clockwork"
 )
 
@@ -319,31 +318,8 @@ func (b *BackgroundEphemeralPurger) resetTimer(purgeInfo chat1.EphemeralPurgeInf
 
 func newConvLoaderEphemeralPurgeHook(g *globals.Context, chatStorage *storage.Storage, uid gregor1.UID, purgeInfo *chat1.EphemeralPurgeInfo) func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
 	return func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
-		_, explodedMsgs, err := chatStorage.EphemeralPurge(ctx, job.ConvID, uid, purgeInfo)
-		if err != nil {
+		if _, _, err := chatStorage.EphemeralPurge(ctx, job.ConvID, uid, purgeInfo); err != nil {
 			g.GetLog().CDebugf(ctx, "ephemeralPurge: %s", err)
-		} else {
-			if len(explodedMsgs) > 0 {
-				ib, err := g.InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
-					ConvIDs: []chat1.ConversationID{job.ConvID},
-				}, nil)
-				if err != nil || len(ib.Convs) != 1 {
-					g.GetLog().CDebugf(ctx, "FindConversationsByID: convs: %v err: %v", ib.Convs, err)
-					return
-				}
-				inboxUIItem := utils.PresentConversationLocal(ib.Convs[0], g.Env.GetUsername().String())
-
-				purgedMsgs := []chat1.UIMessage{}
-				for _, msg := range explodedMsgs {
-					purgedMsgs = append(purgedMsgs, utils.PresentMessageUnboxed(ctx, g, msg, uid, job.ConvID))
-				}
-				act := chat1.NewChatActivityWithEphemeralPurge(chat1.EphemeralPurgeNotifInfo{
-					ConvID: job.ConvID,
-					Msgs:   purgedMsgs,
-					Conv:   &inboxUIItem,
-				})
-				g.NotifyRouter.HandleNewChatActivity(ctx, keybase1.UID(uid.String()), &act)
-			}
 		}
 	}
 }

--- a/go/chat/ephemeral_purger_test.go
+++ b/go/chat/ephemeral_purger_test.go
@@ -94,6 +94,7 @@ func TestBackgroundPurge(t *testing.T) {
 	lifetimeDuration := time.Second
 	sendEphemeral(lifetime)
 	sendEphemeral(lifetime * 2)
+	sendEphemeral(lifetime * 3)
 
 	thread, err := tc.ChatG.ConvSource.Pull(ctx, res.ConvID, uid,
 		chat1.GetThreadReason_GENERAL,
@@ -102,9 +103,10 @@ func TestBackgroundPurge(t *testing.T) {
 		}, nil)
 	require.NoError(t, err)
 	msgs := thread.Messages
-	require.Len(t, msgs, 2)
-	msgUnboxed2 := msgs[0]
-	msgUnboxed1 := msgs[1]
+	require.Len(t, msgs, 3)
+	msgUnboxed3 := msgs[0]
+	msgUnboxed2 := msgs[1]
+	msgUnboxed1 := msgs[2]
 
 	t.Logf("assert listener 1")
 	world.Fc.Advance(lifetimeDuration)
@@ -129,9 +131,29 @@ func TestBackgroundPurge(t *testing.T) {
 	assertListener(res.ConvID)
 	assertTrackerState(res.ConvID, chat1.EphemeralPurgeInfo{
 		ConvID:          res.ConvID,
-		MinUnexplodedID: msgUnboxed2.GetMessageID(),
-		NextPurgeTime:   0,
-		IsActive:        false,
+		MinUnexplodedID: msgUnboxed3.GetMessageID(),
+		NextPurgeTime:   msgUnboxed3.Valid().Etime(),
+		IsActive:        true,
 	})
 	assertEphemeralPurgeNotifInfo(res.ConvID, []chat1.MessageID{msgUnboxed2.GetMessageID()})
+
+	// Stop the Purger, and ensure the final message gets purged when we Pull
+	// the conversation and the GUI get's a notification
+	<-g.EphemeralPurger.Stop(context.Background())
+	t.Logf("assert listener 3")
+	world.Fc.Advance(lifetimeDuration)
+	thread, err = tc.ChatG.ConvSource.Pull(ctx, res.ConvID, uid,
+		chat1.GetThreadReason_GENERAL,
+		&chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}, nil)
+	require.NoError(t, err)
+	require.Len(t, thread.Messages, 3)
+	assertTrackerState(res.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          res.ConvID,
+		MinUnexplodedID: msgUnboxed3.GetMessageID(),
+		NextPurgeTime:   msgUnboxed3.Valid().Etime(),
+		IsActive:        true,
+	})
+	assertEphemeralPurgeNotifInfo(res.ConvID, []chat1.MessageID{msgUnboxed3.GetMessageID()})
 }

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"time"
 
-	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
@@ -153,9 +152,7 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 		return nil, nil, err
 	}
 
-	if s.G().InboxSource != nil {
-		NotifyEphemeralPurge(ctx, s.G(), uid, convID, explodedMsgs)
-	}
+	s.notifyEphemeralPurge(ctx, uid, convID, explodedMsgs)
 
 	return &chat1.EphemeralPurgeInfo{
 		ConvID:          convID,
@@ -165,27 +162,27 @@ func (s *Storage) ephemeralPurgeHelper(ctx context.Context, convID chat1.Convers
 	}, explodedMsgs, nil
 }
 
-// NotifyEphemeralPurge notifies the GUI after messages are exploded.
-func NotifyEphemeralPurge(ctx context.Context, g *globals.Context, uid gregor1.UID, convID chat1.ConversationID, explodedMsgs []chat1.MessageUnboxed) {
-	if len(explodedMsgs) > 0 {
-		ib, err := g.InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
+// notifyEphemeralPurge notifies the GUI after messages are exploded.
+func (s *Storage) notifyEphemeralPurge(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, explodedMsgs []chat1.MessageUnboxed) {
+	if len(explodedMsgs) > 0 && s.G().InboxSource != nil {
+		ib, err := s.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
 			ConvIDs: []chat1.ConversationID{convID},
 		}, nil)
 		if err != nil || len(ib.Convs) != 1 {
-			g.GetLog().CDebugf(ctx, "FindConversationsByID: convs: %v err: %v", ib.Convs, err)
+			s.G().GetLog().CDebugf(ctx, "InboxSource.Read: convs: %v err: %v", ib.Convs, err)
 			return
 		}
-		inboxUIItem := utils.PresentConversationLocal(ib.Convs[0], g.Env.GetUsername().String())
+		inboxUIItem := utils.PresentConversationLocal(ib.Convs[0], s.G().Env.GetUsername().String())
 
 		purgedMsgs := []chat1.UIMessage{}
 		for _, msg := range explodedMsgs {
-			purgedMsgs = append(purgedMsgs, utils.PresentMessageUnboxed(ctx, g, msg, uid, convID))
+			purgedMsgs = append(purgedMsgs, utils.PresentMessageUnboxed(ctx, s.G(), msg, uid, convID))
 		}
 		act := chat1.NewChatActivityWithEphemeralPurge(chat1.EphemeralPurgeNotifInfo{
 			ConvID: convID,
 			Msgs:   purgedMsgs,
 			Conv:   &inboxUIItem,
 		})
-		g.NotifyRouter.HandleNewChatActivity(ctx, keybase1.UID(uid.String()), &act)
+		s.G().NotifyRouter.HandleNewChatActivity(ctx, keybase1.UID(uid.String()), &act)
 	}
 }


### PR DESCRIPTION
Previously there was a race where a message could be exploded in storage while we are sending a message (when we `Pull` in `addPrevPointersAndCheckConvID` in sender) and then the background purger would fire and find nothing to delete so it couldn't notify the UI to update.

I originally tried to fix this by adding to the `MergeResult` so we could handle it in `ConvSource` like we do for `Expunge`, but we also need this during `storage.Fetch` calls so it seemed best to fire them off at the source.