### PR TITLE
Make tapping on stuff in menus and pickers easier

### DIFF
--- a/shared/chat/conversation/messages/set-explode-popup/index.native.js
+++ b/shared/chat/conversation/messages/set-explode-popup/index.native.js
@@ -89,7 +89,7 @@ class SetExplodePopup extends React.Component<Props, State> {
         onCancel={this.props.onHidden}
         onDone={this.onDone}
         prompt={<Prompt />}
-        promptString="Explode message after"
+        promptString="Pick a timeout"
         visible={this.props.visible}
         selectedValue={this.state.selected}
       />

--- a/shared/common-adapters/floating-picker.native.js
+++ b/shared/common-adapters/floating-picker.native.js
@@ -3,14 +3,7 @@ import * as React from 'react'
 import {TouchableWithoutFeedback, Picker} from 'react-native'
 import Box, {Box2} from './box'
 import Text from './text'
-import {
-  globalColors,
-  globalMargins,
-  globalStyles,
-  platformStyles,
-  styleSheetCreate,
-  collapseStyles,
-} from '../styles'
+import {globalColors, globalMargins, globalStyles, platformStyles, styleSheetCreate} from '../styles'
 import FloatingBox from './floating-box.native'
 
 type PickerItem = {|label: string, value: string | number|}
@@ -35,46 +28,40 @@ const FloatingPicker = (props: Props) => {
   return (
     // onHidden required by the typing for desktop, not used on mobile
     <FloatingBox onHidden={() => {}}>
-      <TouchableWithoutFeedback style={styles.overlayContainer} onPress={props.onHidden}>
-        <Box style={[styles.overlayContainer, styles.overlay]}>
-          <Box2 direction="vertical" fullWidth={true} style={styles.menu}>
-            {props.header}
-            <Box2
-              direction="horizontal"
-              gap="small"
-              gapStart={true}
-              gapEnd={true}
-              fullWidth={true}
-              style={styles.actionButtons}
-            >
-              <Text
-                type="BodySemibold"
-                style={collapseStyles([styles.link, styles.cancelContainer])}
-                onClick={props.onCancel}
-              >
-                Cancel
-              </Text>
-              <Text type="BodySemibold" style={styles.link} onClick={props.onDone}>
-                Done
-              </Text>
-            </Box2>
-            {props.prompt}
-            <Picker
-              selectedValue={props.selectedValue}
-              onValueChange={(itemValue, itemIndex) => props.onSelect(itemValue)}
-              prompt={props.promptString}
-              style={styles.picker}
-            >
-              {props.items.map(item => <Picker.Item key={item.label} {...item} />)}
-            </Picker>
+      <Box style={[styles.overlayContainer, styles.overlay]}>
+        <TouchableWithoutFeedback onPress={props.onHidden}>
+          <Box style={styles.flexOne} />
+        </TouchableWithoutFeedback>
+        <Box2 direction="vertical" fullWidth={true} style={styles.menu}>
+          {props.header}
+          <Box2 direction="horizontal" fullWidth={true} style={styles.actionButtons}>
+            <Text type="BodySemibold" style={styles.link} onClick={props.onCancel}>
+              Cancel
+            </Text>
+            <Box style={styles.flexOne} />
+            <Text type="BodySemibold" style={styles.link} onClick={props.onDone}>
+              Done
+            </Text>
           </Box2>
-        </Box>
-      </TouchableWithoutFeedback>
+          {props.prompt}
+          <Picker
+            selectedValue={props.selectedValue}
+            onValueChange={(itemValue, itemIndex) => props.onSelect(itemValue)}
+            prompt={props.promptString}
+            style={styles.picker}
+          >
+            {props.items.map(item => <Picker.Item key={item.label} {...item} />)}
+          </Picker>
+        </Box2>
+      </Box>
     </FloatingBox>
   )
 }
 
 const styles = styleSheetCreate({
+  flexOne: {
+    flex: 1,
+  },
   overlayContainer: {
     position: 'absolute',
     top: 0,
@@ -93,16 +80,12 @@ const styles = styleSheetCreate({
     alignItems: 'stretch',
     backgroundColor: globalColors.white,
   },
-  cancelContainer: {
-    flex: 1,
-  },
   link: {
     color: globalColors.blue,
     fontSize: 17,
+    padding: globalMargins.small,
   },
   actionButtons: {
-    paddingBottom: globalMargins.small,
-    paddingTop: globalMargins.small,
     height: 56,
     justifyContent: 'flex-end',
     alignItems: 'stretch',

--- a/shared/common-adapters/popup-menu.native.js
+++ b/shared/common-adapters/popup-menu.native.js
@@ -98,26 +98,34 @@ class PopupMenu extends Component<Props> {
     ]
 
     return (
-      <TouchableWithoutFeedback style={styleOverlayContainer} onPress={this.props.onHidden}>
-        <Box style={styleOverlay}>
-          <Box style={{...styleMenu, ...this.props.style}}>
-            <Box style={styleMenuGroup}>
-              {menuItemsWithHeader.map((mi, idx) => (
-                <MenuRow
-                  key={mi.title}
-                  {...mi}
-                  index={idx}
-                  numItems={menuItemsWithHeader.length}
-                  onHidden={this.props.onHidden}
-                />
-              ))}
-            </Box>
-            <Box style={{...styleMenuGroup, borderColor: globalColors.black_05, borderTopWidth: 1}}>
-              <MenuRow title="Cancel" index={0} numItems={1} onHidden={this.props.onHidden} />
-            </Box>
+      <Box style={styleOverlay}>
+        <TouchableWithoutFeedback onPress={this.props.onHidden}>
+          <Box style={styleFlexOne} />
+        </TouchableWithoutFeedback>
+        <Box style={{...styleMenu, ...this.props.style}}>
+          <Box style={styleMenuGroup}>
+            {menuItemsWithHeader.map((mi, idx) => (
+              <MenuRow
+                key={mi.title}
+                {...mi}
+                index={idx}
+                numItems={menuItemsWithHeader.length}
+                onHidden={this.props.onHidden}
+              />
+            ))}
+          </Box>
+          <Box style={{...styleMenuGroup, borderColor: globalColors.black_05, borderTopWidth: 1}}>
+            <MenuRow
+              title="Cancel"
+              index={0}
+              numItems={1}
+              onClick={this.props.onHidden}
+              // pass in nothing to onHidden so it doesn't trigger it twice
+              onHidden={() => {}}
+            />
           </Box>
         </Box>
-      </TouchableWithoutFeedback>
+      </Box>
     )
   }
 }
@@ -154,6 +162,10 @@ const styleOverlay = {
   justifyContent: 'flex-end',
   alignItems: 'stretch',
   backgroundColor: globalColors.black_40,
+}
+
+const styleFlexOne = {
+  flex: 1,
 }
 
 const styleMenu = {


### PR DESCRIPTION
Makes the `TouchableWithoutFeedback` only cover the upper area of the screen rather than the whole thing. Also adds padding to `Done` and `Cancel` in `FloatingPicker` to make those easier to hit. r? @keybase/react-hackers 