### PR TITLE
Show close button for UnlockFolders

### DIFF
--- a/shared/unlock-folders/remote-container.desktop.js
+++ b/shared/unlock-folders/remote-container.desktop.js
@@ -5,8 +5,8 @@ import * as UnlockFoldersGen from '../actions/unlock-folders-gen'
 
 // Props are handled by remote-proxy.desktop.js
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  onClose: () => dispatch(UnlockFoldersGen.createClosePopup()),
   onBackFromPaperKey: () => dispatch(UnlockFoldersGen.createOnBackFromPaperKey()),
+  onClose: () => dispatch(UnlockFoldersGen.createClosePopup()),
   onContinueFromPaperKey: (paperKey: string) => dispatch(UnlockFoldersGen.createCheckPaperKey({paperKey})),
   onFinish: () => dispatch(UnlockFoldersGen.createFinish()),
   toPaperKeyInput: () => dispatch(UnlockFoldersGen.createToPaperKeyInput()),

--- a/shared/unlock-folders/remote-container.desktop.js
+++ b/shared/unlock-folders/remote-container.desktop.js
@@ -5,7 +5,7 @@ import * as UnlockFoldersGen from '../actions/unlock-folders-gen'
 
 // Props are handled by remote-proxy.desktop.js
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  close: () => dispatch(UnlockFoldersGen.createClosePopup()),
+  onClose: () => dispatch(UnlockFoldersGen.createClosePopup()),
   onBackFromPaperKey: () => dispatch(UnlockFoldersGen.createOnBackFromPaperKey()),
   onContinueFromPaperKey: (paperKey: string) => dispatch(UnlockFoldersGen.createCheckPaperKey({paperKey})),
   onFinish: () => dispatch(UnlockFoldersGen.createFinish()),


### PR DESCRIPTION
This was a simple prop name mismatch that caused the close button to remain hidden.