### PR TITLE
UnboxError for erasablekvstore

### DIFF
--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -32,8 +32,8 @@ type EKUnboxErr struct {
 	missingGeneration keybase1.EkGeneration
 }
 
-func newEKUnboxErr(boxType EKType, boxGeneration keybase1.EkGeneration, missingType EKType, missingGeneration keybase1.EkGeneration) *EKUnboxErr {
-	return &EKUnboxErr{
+func newEKUnboxErr(boxType EKType, boxGeneration keybase1.EkGeneration, missingType EKType, missingGeneration keybase1.EkGeneration) EKUnboxErr {
+	return EKUnboxErr{
 		missingType:       missingType,
 		boxType:           boxType,
 		missingGeneration: missingGeneration,
@@ -41,7 +41,7 @@ func newEKUnboxErr(boxType EKType, boxGeneration keybase1.EkGeneration, missingT
 	}
 }
 
-func (e *EKUnboxErr) Error() string {
+func (e EKUnboxErr) Error() string {
 	return fmt.Sprintf("Error unboxing %s@generation:%v missing %s@generation:%v", e.boxType, e.boxGeneration, e.missingType, e.missingGeneration)
 }
 
@@ -50,14 +50,14 @@ type EKMissingBoxErr struct {
 	boxGeneration keybase1.EkGeneration
 }
 
-func newEKMissingBoxErr(boxType EKType, boxGeneration keybase1.EkGeneration) *EKMissingBoxErr {
-	return &EKMissingBoxErr{
+func newEKMissingBoxErr(boxType EKType, boxGeneration keybase1.EkGeneration) EKMissingBoxErr {
+	return EKMissingBoxErr{
 		boxType:       boxType,
 		boxGeneration: boxGeneration,
 	}
 }
 
-func (e *EKMissingBoxErr) Error() string {
+func (e EKMissingBoxErr) Error() string {
 	return fmt.Sprintf("Missing box for %s@generation:%v", e.boxType, e.boxGeneration)
 }
 

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -210,7 +210,7 @@ func (s *DeviceEKStorage) getCache(ctx context.Context) (cache DeviceEKMap, err 
 			deviceEK, err := s.get(ctx, generation)
 			if err != nil {
 				switch err.(type) {
-				case *erasablekv.UnboxError:
+				case erasablekv.UnboxError:
 					s.G().Log.Debug("DeviceEKStorage#getCache failed to get item from storage: %v", err)
 					continue
 				default:

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -211,7 +211,7 @@ func (s *DeviceEKStorage) getCache(ctx context.Context) (cache DeviceEKMap, err 
 			if err != nil {
 				switch err.(type) {
 				case *erasablekv.UnboxError:
-					s.G().Log.Debug(err.Error())
+					s.G().Log.Debug("DeviceEKStorage#getCache failed to get item from storage: %v", err)
 					continue
 				default:
 					return nil, err

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -182,7 +182,7 @@ func (e *EKLib) newDeviceEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRo
 	if err != nil {
 		switch err.(type) {
 		case *erasablekv.UnboxError:
-			e.G().Log.Debug(err.Error())
+			e.G().Log.Debug("newDeviceEKNeeded: DeviceEKStorage.MaxGeneration failed %v", err)
 			return true, nil
 		default:
 			return false, err
@@ -196,7 +196,7 @@ func (e *EKLib) newDeviceEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRo
 	if err != nil {
 		switch err.(type) {
 		case *erasablekv.UnboxError:
-			e.G().Log.Debug(err.Error())
+			e.G().Log.Debug("newDeviceEKNeeded: DeviceEKStorage.Get failed %v", err)
 			return true, nil
 		default:
 			return false, err

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -181,7 +181,7 @@ func (e *EKLib) newDeviceEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRo
 	maxGeneration, err := s.MaxGeneration(ctx)
 	if err != nil {
 		switch err.(type) {
-		case *erasablekv.UnboxError:
+		case erasablekv.UnboxError:
 			e.G().Log.Debug("newDeviceEKNeeded: DeviceEKStorage.MaxGeneration failed %v", err)
 			return true, nil
 		default:
@@ -195,7 +195,7 @@ func (e *EKLib) newDeviceEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRo
 	ek, err := s.Get(ctx, maxGeneration)
 	if err != nil {
 		switch err.(type) {
-		case *erasablekv.UnboxError:
+		case erasablekv.UnboxError:
 			e.G().Log.Debug("newDeviceEKNeeded: DeviceEKStorage.Get failed %v", err)
 			return true, nil
 		default:
@@ -239,7 +239,7 @@ func (e *EKLib) newUserEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot
 	ek, err := s.Get(ctx, statement.CurrentUserEkMetadata.Generation)
 	if err != nil {
 		switch err.(type) {
-		case *EKUnboxErr, *EKMissingBoxErr:
+		case EKUnboxErr, EKMissingBoxErr:
 			e.G().Log.Debug(err.Error())
 			return true, nil
 		default:
@@ -286,7 +286,7 @@ func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, mer
 	ek, err := s.Get(ctx, teamID, statement.CurrentTeamEkMetadata.Generation)
 	if err != nil {
 		switch err.(type) {
-		case *EKUnboxErr, *EKMissingBoxErr:
+		case EKUnboxErr, EKMissingBoxErr:
 			e.G().Log.Debug(err.Error())
 			return true, latestGeneration, nil
 		default:
@@ -412,7 +412,7 @@ func (e *EKLib) GetTeamEK(ctx context.Context, teamID keybase1.TeamID, generatio
 	teamEK, err = e.G().GetTeamEKBoxStorage().Get(ctx, teamID, generation)
 	if err != nil {
 		switch err.(type) {
-		case *EKUnboxErr, *EKMissingBoxErr:
+		case EKUnboxErr, EKMissingBoxErr:
 			e.G().Log.Debug(err.Error())
 			if _, cerr := e.GetOrCreateLatestTeamEK(ctx, teamID); cerr != nil {
 				e.G().Log.CDebugf(ctx, "Unable to GetOrCreateLatestTeamEK: %v", cerr)

--- a/go/erasablekv/erasable_kv_store.go
+++ b/go/erasablekv/erasable_kv_store.go
@@ -21,8 +21,8 @@ type UnboxError struct {
 	inner error
 }
 
-func NewUnboxError(inner error) *UnboxError {
-	return &UnboxError{inner: inner}
+func NewUnboxError(inner error) UnboxError {
+	return UnboxError{inner: inner}
 }
 
 func (e UnboxError) Error() string {

--- a/go/erasablekv/erasable_kv_store_test.go
+++ b/go/erasablekv/erasable_kv_store_test.go
@@ -54,7 +54,7 @@ func TestErasableKVStore(t *testing.T) {
 	var corrupt string
 	err = s.Get(context.Background(), key, corrupt)
 	require.Error(t, err)
-	uerr, ok := err.(*UnboxError)
+	uerr, ok := err.(UnboxError)
 	require.True(t, ok)
 	require.Equal(t, fmt.Sprintf("ErasableKVStore UnboxError: secretbox.Open failure. Stored noise hash: %x, current noise hash: %x, equal: %v", s.noiseHash(noise), s.noiseHash(corruptedNoise), false), uerr.Error())
 	require.NotEqual(t, expected, corrupt)

--- a/go/erasablekv/erasable_kv_store_test.go
+++ b/go/erasablekv/erasable_kv_store_test.go
@@ -56,7 +56,7 @@ func TestErasableKVStore(t *testing.T) {
 	require.Error(t, err)
 	uerr, ok := err.(*UnboxError)
 	require.True(t, ok)
-	require.Equal(t, fmt.Sprintf("Unable to unbox item: secretbox.Open failure. Stored noise hash: %x, current noise hash: %x, equal: %v", s.noiseHash(noise), s.noiseHash(corruptedNoise), false), uerr.Error())
+	require.Equal(t, fmt.Sprintf("ErasableKVStore UnboxError: secretbox.Open failure. Stored noise hash: %x, current noise hash: %x, equal: %v", s.noiseHash(noise), s.noiseHash(corruptedNoise), false), uerr.Error())
 	require.NotEqual(t, expected, corrupt)
 
 	err = s.Erase(context.Background(), key)

--- a/go/erasablekv/erasable_kv_store_test.go
+++ b/go/erasablekv/erasable_kv_store_test.go
@@ -44,14 +44,19 @@ func TestErasableKVStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// flip one bit
-	noise[0] ^= 0x01
+	corruptedNoise := make([]byte, len(noise))
+	copy(corruptedNoise, noise)
+	corruptedNoise[0] ^= 0x01
 
-	err = ioutil.WriteFile(noiseFilePath, noise, libkb.PermFile)
+	err = ioutil.WriteFile(noiseFilePath, corruptedNoise, libkb.PermFile)
 	require.NoError(t, err)
 
 	var corrupt string
 	err = s.Get(context.Background(), key, corrupt)
 	require.Error(t, err)
+	uerr, ok := err.(*UnboxError)
+	require.True(t, ok)
+	require.Equal(t, fmt.Sprintf("Unable to unbox item: secretbox.Open failure. Stored noise hash: %x, current noise hash: %x, equal: %v", s.noiseHash(noise), s.noiseHash(corruptedNoise), false), uerr.Error())
 	require.NotEqual(t, expected, corrupt)
 
 	err = s.Erase(context.Background(), key)


### PR DESCRIPTION
It's possible that we can an error when trying to read deviceEKs from erasable storage. Rather than failing we want to 1. delete these keys  and 2. allow future key generation to proceed. Adds logging to try to determine if the noiseFile used for decryption is corrupted 
cc @oconnor663 