### PR TITLE
remove dependency on LookupOrCreateImplicitTeam everywhere except NewConversation CORE-8094

### DIFF
--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -407,7 +407,7 @@ func NewUnknownTLFNameError(name string) UnknownTLFNameError {
 }
 
 func (e UnknownTLFNameError) Error() string {
-	return fmt.Sprintf("unknown TLF name: %s", e.tlfName)
+	return fmt.Sprintf("unknown conversation name: %s", e.tlfName)
 }
 
 //=============================================================================

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -396,6 +396,22 @@ func (e ImpteamUpgradeBadteamError) Error() string {
 
 //=============================================================================
 
+type UnknownTLFNameError struct {
+	tlfName string
+}
+
+func NewUnknownTLFNameError(name string) UnknownTLFNameError {
+	return UnknownTLFNameError{
+		tlfName: name,
+	}
+}
+
+func (e UnknownTLFNameError) Error() string {
+	return fmt.Sprintf("unknown TLF name: %s", e.tlfName)
+}
+
+//=============================================================================
+
 type OfflineErrorKind int
 
 const (

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -384,11 +384,9 @@ type sendHelper struct {
 	sender      types.Sender
 	ri          func() chat1.RemoteInterface
 
-	canonicalName string
-	topicName     *string
-	tlfID         chat1.TLFID
-	convID        chat1.ConversationID
-	triple        chat1.ConversationIDTriple
+	topicName *string
+	convID    chat1.ConversationID
+	triple    chat1.ConversationIDTriple
 
 	globals.Contextified
 }
@@ -415,26 +413,10 @@ func (s *sendHelper) SendText(ctx context.Context, text string) error {
 
 func (s *sendHelper) SendBody(ctx context.Context, body chat1.MessageBody, mtype chat1.MessageType) error {
 	ctx = Context(ctx, s.G(), s.ident, nil, NewCachingIdentifyNotifier(s.G()))
-	if err := s.nameInfo(ctx); err != nil {
-		return err
-	}
-
 	if err := s.conversation(ctx); err != nil {
 		return err
 	}
-
 	return s.deliver(ctx, body, mtype)
-}
-
-func (s *sendHelper) nameInfo(ctx context.Context) error {
-	nameInfo, err := CtxKeyFinder(ctx, s.G()).Find(ctx, s.name, s.membersType, false)
-	if err != nil {
-		return err
-	}
-	s.tlfID = nameInfo.ID
-	s.canonicalName = nameInfo.CanonicalName
-
-	return nil
 }
 
 func (s *sendHelper) conversation(ctx context.Context) error {
@@ -443,57 +425,14 @@ func (s *sendHelper) conversation(ctx context.Context) error {
 		return err
 	}
 	uid := gregor1.UID(kuid.ToBytes())
-	conv, err := NewConversation(ctx, s.G(), uid, s.canonicalName, s.topicName,
+	conv, err := NewConversation(ctx, s.G(), uid, s.name, s.topicName,
 		chat1.TopicType_CHAT, s.membersType, keybase1.TLFVisibility_PRIVATE, s.remoteInterface)
 	if err != nil {
 		return err
 	}
 	s.convID = conv.GetConvID()
 	s.triple = conv.Info.Triple
-	return nil
-}
-
-func (s *sendHelper) newConversation(ctx context.Context) error {
-	s.triple = chat1.ConversationIDTriple{
-		Tlfid:     s.tlfID,
-		TopicType: chat1.TopicType_CHAT,
-	}
-	var err error
-	s.triple.TopicID, err = utils.NewChatTopicID()
-	if err != nil {
-		return err
-	}
-
-	first := chat1.MessagePlaintext{
-		ClientHeader: chat1.MessageClientHeader{
-			Conv:        s.triple,
-			TlfName:     s.canonicalName,
-			MessageType: chat1.MessageType_TLFNAME,
-		},
-	}
-
-	mbox, _, _, _, topicNameState, err := s.sender.Prepare(ctx, first, s.membersType, nil)
-	if err != nil {
-		return err
-	}
-
-	ncrres, reserr := s.ri().NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
-		IdTriple:       s.triple,
-		TLFMessage:     *mbox,
-		MembersType:    s.membersType,
-		TopicNameState: topicNameState,
-	})
-	convID := ncrres.ConvID
-	if reserr != nil {
-		switch cerr := reserr.(type) {
-		case libkb.ChatConvExistsError:
-			convID = cerr.ConvID
-		default:
-			return fmt.Errorf("error creating conversation: %s", reserr)
-		}
-	}
-	s.convID = convID
-
+	s.name = conv.Info.TlfName
 	return nil
 }
 
@@ -501,7 +440,7 @@ func (s *sendHelper) deliver(ctx context.Context, body chat1.MessageBody, mtype 
 	msg := chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        s.triple,
-			TlfName:     s.canonicalName,
+			TlfName:     s.name,
 			MessageType: mtype,
 		},
 		MessageBody: body,

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -277,6 +277,7 @@ func (b *baseInboxSource) GetInboxQueryLocalToRemote(ctx context.Context,
 		info, err = CtxKeyFinder(ctx, b.G()).Find(ctx, lquery.Name.Name, lquery.Name.MembersType,
 			lquery.Visibility() == keybase1.TLFVisibility_PUBLIC)
 		if err != nil {
+			b.Debug(ctx, "GetInboxQueryLocalToRemote: failed: %s", err)
 			return nil, info, err
 		}
 		rquery.TlfID = &info.ID

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4034,7 +4034,6 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Conversations), "conv found")
-		consumeIdentify(ctx, listener0) // impteam
 
 		// create a new conversation
 		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -23,34 +23,13 @@ func newBlankConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext,
 func newBlankConvWithMembersType(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext,
 	uid gregor1.UID, ri chat1.RemoteInterface, sender types.Sender, tlfName string,
 	membersType chat1.ConversationMembersType) chat1.Conversation {
-	trip := newConvTripleWithMembersType(ctx, t, tc, tlfName, membersType)
-	firstMessagePlaintext := chat1.MessagePlaintext{
-		ClientHeader: chat1.MessageClientHeader{
-			Conv:        trip,
-			TlfName:     tlfName,
-			TlfPublic:   false,
-			MessageType: chat1.MessageType_TLFNAME,
-		},
-		MessageBody: chat1.MessageBody{},
-	}
-	firstMessageBoxed, _, _, _, _, err := sender.Prepare(ctx, firstMessagePlaintext, membersType, nil)
+	res, err := NewConversation(ctx, tc.Context(), uid, tlfName, nil, chat1.TopicType_CHAT, membersType,
+		keybase1.TLFVisibility_PRIVATE, func() chat1.RemoteInterface { return ri })
 	require.NoError(t, err)
-	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
-		IdTriple:    trip,
-		TLFMessage:  *firstMessageBoxed,
-		MembersType: membersType,
-	})
-	require.NoError(t, err)
-
-	// Check that the initial message stored as a success.
-	tv, err := tc.ChatG.ConvSource.Pull(ctx, res.ConvID, uid, chat1.GetThreadReason_GENERAL, nil, nil)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(tv.Messages))
-	require.True(t, tv.Messages[0].IsValid(), "initial message invalid")
-
+	convID := res.GetConvID()
 	ires, err := ri.GetInboxRemote(ctx, chat1.GetInboxRemoteArg{
 		Query: &chat1.GetInboxQuery{
-			ConvID: &res.ConvID,
+			ConvID: &convID,
 		},
 	})
 	require.NoError(t, err)
@@ -104,12 +83,22 @@ func TestSyncerConnected(t *testing.T) {
 	store := storage.New(tc.Context(), tc.ChatG.ConvSource)
 
 	var convs []chat1.Conversation
-	convs = append(convs, newConv(ctx, t, tc, uid, ri, sender, u.Username+","+u1.Username))
-	convs = append(convs, newConv(ctx, t, tc, uid, ri, sender, u.Username+","+u2.Username))
-	convs = append(convs, newConv(ctx, t, tc, uid, ri, sender, u.Username+","+u2.Username+","+u1.Username))
+	convs = append(convs, newBlankConv(ctx, t, tc, uid, ri, sender, u.Username+","+u1.Username))
+	convs = append(convs, newBlankConv(ctx, t, tc, uid, ri, sender, u.Username+","+u2.Username))
+	convs = append(convs, newBlankConv(ctx, t, tc, uid, ri, sender, u.Username+","+u2.Username+","+u1.Username))
 	for index, conv := range convs {
 		t.Logf("index: %d conv: %s", index, conv.GetConvID())
 	}
+	// background loader will pick up all the convs from the creates above
+	for i := 0; i < len(convs); i++ {
+		select {
+		case convID := <-list.bgConvLoads:
+			require.Equal(t, convs[i].GetConvID(), convID)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no background conv loaded")
+		}
+	}
+
 	t.Logf("test current")
 	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
 		return chat1.NewSyncInboxResWithCurrent(), nil
@@ -150,15 +139,6 @@ func TestSyncerConnected(t *testing.T) {
 	_, iconvs, err := ibox.ReadAll(ctx)
 	require.NoError(t, err)
 	require.Equal(t, len(convs), len(iconvs))
-	// background loader will pick up all the convs from the read above
-	for i := 0; i < len(convs); i++ {
-		select {
-		case convID := <-list.bgConvLoads:
-			require.Equal(t, convs[i].GetConvID(), convID)
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "no background conv loaded")
-		}
-	}
 
 	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
 		mconv.Metadata.Status = chat1.ConversationStatus_MUTED
@@ -197,7 +177,7 @@ func TestSyncerConnected(t *testing.T) {
 	require.Equal(t, chat1.InboxVers(100), vers)
 	thread, cerr := store.Fetch(context.TODO(), mconv, uid, nil, nil, nil)
 	require.NoError(t, cerr)
-	require.Equal(t, 2, len(thread.Messages))
+	require.Equal(t, 1, len(thread.Messages))
 
 	t.Logf("test server version")
 	srvVers, err := ibox.ServerVersion(context.TODO())
@@ -462,26 +442,51 @@ func TestSyncerRetentionExpunge(t *testing.T) {
 	ibox := storage.NewInbox(tc.Context(), uid)
 	store := storage.New(tc.Context(), tc.ChatG.ConvSource)
 
-	mconv := newConv(ctx, t, tc, uid, ri, sender, u.Username+","+u1.Username)
+	tlfName := u.Username + "," + u1.Username
+	mconv := newBlankConv(ctx, t, tc, uid, ri, sender, tlfName)
+	select {
+	case cid := <-list.bgConvLoads:
+		require.Equal(t, mconv.GetConvID(), cid)
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no background conv loaded")
+	}
 
 	t.Logf("test incremental")
-	_, cerr := tc.ChatG.ConvSource.Pull(ctx, mconv.GetConvID(), uid, chat1.GetThreadReason_GENERAL, nil, nil)
+	_, _, err := sender.Send(ctx, mconv.GetConvID(), chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        mconv.Metadata.IdTriple,
+			Sender:      uid,
+			TlfName:     tlfName,
+			MessageType: chat1.MessageType_TEXT,
+		},
+		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+			Body: "hi",
+		}),
+	}, 0, nil)
+	require.NoError(t, err)
+	tv, cerr := tc.ChatG.ConvSource.Pull(ctx, mconv.GetConvID(), uid, chat1.GetThreadReason_GENERAL, nil, nil)
 	require.NoError(t, cerr)
+	require.Equal(t, 2, len(tv.Messages))
 	_, serr := tc.ChatG.InboxSource.Read(ctx, uid, nil, true, nil, nil)
 	require.NoError(t, serr)
+	select {
+	case cid := <-list.bgConvLoads:
+		require.Equal(t, mconv.GetConvID(), cid)
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no background conv loaded")
+	}
 	_, iconvs, err := ibox.ReadAll(ctx)
 	require.NoError(t, err)
 	require.Len(t, iconvs, 1)
-	// Field two of these here, since newConv reads and triggers a background load, as does the real read
-	for i := 0; i < 2; i++ {
-		select {
-		case cid := <-list.bgConvLoads:
-			require.Equal(t, mconv.GetConvID(), cid)
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "no background conv loaded")
-		}
-	}
+	require.Equal(t, chat1.MessageID(2), iconvs[0].Conv.ReaderInfo.MaxMsgid)
+	mconv = iconvs[0].Conv
 
+	time.Sleep(400 * time.Millisecond)
+	select {
+	case <-list.bgConvLoads:
+		require.Fail(t, "no loads here")
+	default:
+	}
 	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
 		mconv.Expunge = chat1.Expunge{Upto: 12}
 		return chat1.NewSyncInboxResWithIncremental(chat1.SyncIncrementalRes{
@@ -547,10 +552,11 @@ func TestSyncerTeamFilter(t *testing.T) {
 	tconv.Metadata.TeamType = chat1.TeamType_COMPLEX
 
 	t.Logf("dont sync shallow team change")
+	syncConvs := []chat1.Conversation{iconv, tconv}
 	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
 		return chat1.NewSyncInboxResWithIncremental(chat1.SyncIncrementalRes{
 			Vers:  100,
-			Convs: []chat1.Conversation{iconv, tconv},
+			Convs: syncConvs,
 		}), nil
 	}
 	doSync(t, syncer, ri, uid)
@@ -566,10 +572,15 @@ func TestSyncerTeamFilter(t *testing.T) {
 	}
 
 	t.Logf("sync it if metadata changed")
-	tconv.MaxMsgSummaries = append(tconv.MaxMsgSummaries, chat1.MessageSummary{
-		MsgID:       10,
-		MessageType: chat1.MessageType_METADATA,
-	})
+	for index, msg := range tconv.MaxMsgSummaries {
+		if msg.GetMessageType() == chat1.MessageType_METADATA {
+			tconv.MaxMsgSummaries[index] = chat1.MessageSummary{
+				MsgID:       10,
+				MessageType: chat1.MessageType_METADATA,
+			}
+		}
+	}
+	syncConvs = []chat1.Conversation{iconv, tconv}
 	doSync(t, syncer, ri, uid)
 	select {
 	case res := <-list.inboxSynced:
@@ -597,7 +608,7 @@ func TestSyncerBackgroundLoader(t *testing.T) {
 		t.Skip()
 	}
 
-	conv := newConv(ctx, t, tc, uid, ri, sender, u.Username)
+	conv := newBlankConv(ctx, t, tc, uid, ri, sender, u.Username)
 	select {
 	case <-list.bgConvLoads:
 	case <-time.After(20 * time.Second):
@@ -622,16 +633,28 @@ func TestSyncerBackgroundLoader(t *testing.T) {
 	default:
 	}
 
+	_, txtMsg, err := sender.Send(ctx, conv.GetConvID(), chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        conv.Metadata.IdTriple,
+			Sender:      u.User.GetUID().ToBytes(),
+			TlfName:     u.Username,
+			MessageType: chat1.MessageType_TEXT,
+		},
+		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+			Body: "MIKE!!!!",
+		}),
+	}, 0, nil)
+	require.NoError(t, err)
 	_, delMsg, err := sender.Send(ctx, conv.GetConvID(), chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        conv.Metadata.IdTriple,
 			Sender:      u.User.GetUID().ToBytes(),
 			TlfName:     u.Username,
 			MessageType: chat1.MessageType_DELETE,
-			Supersedes:  2,
+			Supersedes:  txtMsg.GetMessageID(),
 		},
 		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{
-			MessageIDs: []chat1.MessageID{2},
+			MessageIDs: []chat1.MessageID{txtMsg.GetMessageID()},
 		}),
 	}, 0, nil)
 	require.NoError(t, err)
@@ -670,7 +693,7 @@ func TestSyncerBackgroundLoaderRemoved(t *testing.T) {
 	syncer := NewSyncer(tc.Context())
 	syncer.isConnected = true
 
-	conv := newConv(ctx, t, tc, uid, ri, sender, u.Username)
+	conv := newBlankConv(ctx, t, tc, uid, ri, sender, u.Username)
 	select {
 	case <-list.bgConvLoads:
 	case <-time.After(20 * time.Second):
@@ -719,7 +742,7 @@ func TestSyncerStorageClear(t *testing.T) {
 	syncer := NewSyncer(tc.Context())
 	syncer.isConnected = true
 
-	conv := newConv(ctx, t, tc, uid, ri, sender, u.Username)
+	conv := newBlankConv(ctx, t, tc, uid, ri, sender, u.Username)
 	select {
 	case <-list.bgConvLoads:
 	case <-time.After(20 * time.Second):
@@ -727,7 +750,7 @@ func TestSyncerStorageClear(t *testing.T) {
 	}
 	tv, err := tc.Context().ConvSource.PullLocalOnly(ctx, conv.GetConvID(), uid, nil, nil, 0)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(tv.Messages))
+	require.Equal(t, 1, len(tv.Messages))
 
 	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
 		sconv := conv.DeepCopy()

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -417,6 +417,10 @@ func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, p
 
 	team, _, impTeamName, err := teams.LookupImplicitTeam(ctx, t.G().ExternalG(), name, public)
 	if err != nil {
+		// return the common type for a unknown TLF name
+		if _, ok := err.(teams.TeamDoesNotExistError); ok {
+			return res, NewUnknownTLFNameError(name)
+		}
 		return res, err
 	}
 	if !team.ID.IsRootTeam() {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -418,9 +418,11 @@ func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, p
 	team, _, impTeamName, err := teams.LookupImplicitTeam(ctx, t.G().ExternalG(), name, public)
 	if err != nil {
 		// return the common type for a unknown TLF name
-		if _, ok := err.(teams.TeamDoesNotExistError); ok {
+		switch err.(type) {
+		case teams.TeamDoesNotExistError:
 			return res, NewUnknownTLFNameError(name)
 		}
+		t.Debug(ctx, "Lookup: error looking up the team: %s", err)
 		return res, err
 	}
 	if !team.ID.IsRootTeam() {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -415,8 +415,7 @@ func (t *ImplicitTeamsNameInfoSource) Lookup(ctx context.Context, name string, p
 	}
 	res = types.NewNameInfo()
 
-	// Always create here to simulate behavior of GetTLFCryptKeys
-	team, _, impTeamName, err := teams.LookupOrCreateImplicitTeam(ctx, t.G().ExternalG(), name, public)
+	team, _, impTeamName, err := teams.LookupImplicitTeam(ctx, t.G().ExternalG(), name, public)
 	if err != nil {
 		return res, err
 	}

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -168,7 +168,7 @@ func annotateResolvingRequest(g *libkb.GlobalContext, req *chatConversationResol
 	if err != nil {
 		return err
 	}
-	switch *userOrTeamResult {
+	switch userOrTeamResult {
 	case keybase1.UserOrTeamResult_USER:
 		if g.Env.GetChatMemberType() == "impteam" {
 			req.MembersType = chat1.ConversationMembersType_IMPTEAMNATIVE

--- a/go/client/chat_common.go
+++ b/go/client/chat_common.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 
 	"golang.org/x/net/context"
@@ -14,34 +13,17 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func CheckUserOrTeamName(ctx context.Context, g *libkb.GlobalContext, name string) (*keybase1.UserOrTeamResult, error) {
+func CheckUserOrTeamName(ctx context.Context, g *libkb.GlobalContext, name string) (res keybase1.UserOrTeamResult, err error) {
 	var req chatConversationResolvingRequest
 	req.ctx = new(chatConversationResolvingRequestContext)
-	var tlfError, teamError error
-
 	cli, err := GetTeamsClient(g)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
-	if _, tlfError = cli.LookupOrCreateImplicitTeam(ctx, keybase1.LookupOrCreateImplicitTeamArg{
-		Name:   g.GetEnv().GetUsername().String() + "," + name,
-		Public: false,
-	}); tlfError == nil {
-		ret := keybase1.UserOrTeamResult_USER
-		return &ret, nil
+	if _, err = cli.TeamGet(ctx, keybase1.TeamGetArg{Name: name}); err == nil {
+		return keybase1.UserOrTeamResult_TEAM, nil
 	}
-	tlfError = errors.New("unable to find one or more users")
-
-	if _, teamError = cli.TeamGet(ctx, keybase1.TeamGetArg{Name: name}); teamError == nil {
-		ret := keybase1.UserOrTeamResult_TEAM
-		return &ret, nil
-	}
-
-	msg := `Unable to find conversation.
-When considering %s as a username or a list of usernames, received error: %v.
-When considering %s as a team name, received error: %v.`
-
-	return nil, libkb.NotFoundError{Msg: fmt.Sprintf(msg, name, tlfError, name, teamError)}
+	return keybase1.UserOrTeamResult_USER, nil
 }
 
 // Post a retention policy

--- a/go/teams/resolve.go
+++ b/go/teams/resolve.go
@@ -123,7 +123,8 @@ func ResolveImplicitTeamSetUntrusted(ctx context.Context, g *libkb.GlobalContext
 				// Could not convert to a social assertion.
 				// This could be because it is a compound assertion, which we do not support when SBS.
 				// Or it could be because it's a team assertion or something weird like that.
-				return err
+				return libkb.ResolutionError{Input: expr.String(), Msg: "unknown user assertion",
+					Kind: libkb.ResolutionErrorNotFound}
 			}
 			resSet.UnresolvedUsers = append(resSet.UnresolvedUsers, sa)
 		} else {


### PR DESCRIPTION
Patch does the following:

1.) Changes `ImplicitTeamsNameInfoSource#Lookup` to use `LookupImplicitTeam` instead of `LookupOrCreateImplicitTeam`. This stops us from generating bogus teams outside of a `NewConversation` flow.
2.) Change `FindConversation` to process a missed team lookup and not error out under that circumstance. Instead, it just treats the result like finding no conversations. 
3.) Change CLI to also not use `LookupOrCreateImplicitTeam`.