### PR TITLE
Add forceReload argument to SecretSyncer to force key update

### DIFF
--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -75,7 +75,7 @@ func (e *Bootstrap) Run(m libkb.MetaContext) error {
 		}
 
 		m.CDebugf("connected, running full tracker2 syncer")
-		if err := libkb.RunSyncer(m, ts, e.status.Uid, false, nil); err != nil {
+		if err := libkb.RunSyncer(m, ts, e.status.Uid, false /* loggedIn */, nil /* sessionReader */, false /* forceReload */); err != nil {
 			m.CWarningf("error running Tracker2Syncer: %s", err)
 			return nil
 		}

--- a/go/engine/device_history.go
+++ b/go/engine/device_history.go
@@ -183,7 +183,7 @@ func (e *DeviceHistory) getLastUsedTimes(m libkb.MetaContext) (ret map[keybase1.
 	defer m.CTrace("DeviceHistory#getLastUsedTimes", func() error { return err })()
 	var devs libkb.DeviceKeyMap
 	var ss *libkb.SecretSyncer
-	ss, err = m.ActiveDevice().SyncSecrets(m)
+	ss, err = m.ActiveDevice().SyncSecretsForce(m)
 	if err != nil {
 		return nil, err
 	}

--- a/go/engine/devlist.go
+++ b/go/engine/devlist.go
@@ -47,7 +47,7 @@ func (d *DevList) Run(m libkb.MetaContext) (err error) {
 	var devs libkb.DeviceKeyMap
 	var ss *libkb.SecretSyncer
 
-	ss, err = m.ActiveDevice().SyncSecrets(m)
+	ss, err = m.ActiveDevice().SyncSecretsForce(m)
 	if err != nil {
 		return err
 	}

--- a/go/engine/list_trackers.go
+++ b/go/engine/list_trackers.go
@@ -65,7 +65,7 @@ func (e *ListTrackersEngine) Run(m libkb.MetaContext) error {
 		return err
 	}
 	ts := libkb.NewTrackerSyncer(e.uid, m.G())
-	if err := libkb.RunSyncer(m, ts, e.uid, false, nil); err != nil {
+	if err := libkb.RunSyncer(m, ts, e.uid, false /* loggedIn */, nil /* sessionReader */, false /* forceReload */); err != nil {
 		return err
 	}
 	e.trackers = ts.Trackers()

--- a/go/engine/list_trackers2.go
+++ b/go/engine/list_trackers2.go
@@ -68,7 +68,7 @@ func (e *ListTrackers2Engine) Run(m libkb.MetaContext) error {
 	}
 	callerUID := m.G().Env.GetUID()
 	ts := libkb.NewTracker2Syncer(m.G(), callerUID, e.arg.Reverse)
-	if err := libkb.RunSyncer(m, ts, e.uid, false, nil); err != nil {
+	if err := libkb.RunSyncer(m, ts, e.uid, false /* loggedIn */, nil /* sessionReader */, false /* forceReload */); err != nil {
 		return err
 	}
 	e.res = ts.Result()

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -373,7 +373,7 @@ func (a *ActiveDevice) NISTAndUID(ctx context.Context) (*NIST, keybase1.UID, err
 	return nist, a.uid, err
 }
 
-func (a *ActiveDevice) SyncSecretsForUID(m MetaContext, u keybase1.UID) (ret *SecretSyncer, err error) {
+func (a *ActiveDevice) SyncSecretsForUID(m MetaContext, u keybase1.UID, force bool) (ret *SecretSyncer, err error) {
 	defer m.CTrace("ActiveDevice#SyncSecretsForUID", func() error { return err })()
 
 	a.RLock()
@@ -390,6 +390,7 @@ func (a *ActiveDevice) SyncSecretsForUID(m MetaContext, u keybase1.UID) (ret *Se
 	if uid.IsNil() {
 		return nil, fmt.Errorf("can't run secret syncer without a UID")
 	}
+	s.forceNextSync = force
 	err = RunSyncer(m, s, uid, true, nil)
 	if err != nil {
 		return nil, err
@@ -400,7 +401,13 @@ func (a *ActiveDevice) SyncSecretsForUID(m MetaContext, u keybase1.UID) (ret *Se
 func (a *ActiveDevice) SyncSecrets(m MetaContext) (ret *SecretSyncer, err error) {
 	defer m.CTrace("ActiveDevice#SyncSecrets", func() error { return err })()
 	var zed keybase1.UID
-	return a.SyncSecretsForUID(m, zed)
+	return a.SyncSecretsForUID(m, zed, false /* force */)
+}
+
+func (a *ActiveDevice) SyncSecretsForce(m MetaContext) (ret *SecretSyncer, err error) {
+	defer m.CTrace("ActiveDevice#SyncSecretsForce", func() error { return err })()
+	var zed keybase1.UID
+	return a.SyncSecretsForUID(m, zed, true /* force */)
 }
 
 func (a *ActiveDevice) CheckForUsername(m MetaContext, n NormalizedUsername) (err error) {

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -390,8 +390,7 @@ func (a *ActiveDevice) SyncSecretsForUID(m MetaContext, u keybase1.UID, force bo
 	if uid.IsNil() {
 		return nil, fmt.Errorf("can't run secret syncer without a UID")
 	}
-	s.forceNextSync = force
-	err = RunSyncer(m, s, uid, true, nil)
+	err = RunSyncer(m, s, uid, true, nil, force)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -616,7 +616,7 @@ func (m MetaContext) SyncSecrets() (ss *SecretSyncer, err error) {
 
 func (m MetaContext) SyncSecretsForUID(u keybase1.UID) (ss *SecretSyncer, err error) {
 	defer m.CTrace("MetaContext#SyncSecrets", func() error { return err })()
-	return m.ActiveDevice().SyncSecretsForUID(m, u)
+	return m.ActiveDevice().SyncSecretsForUID(m, u, false /* force */)
 }
 
 func (m MetaContext) ProvisionalSessionArgs() (token string, csrf string) {

--- a/go/libkb/provisional_login_context.go
+++ b/go/libkb/provisional_login_context.go
@@ -175,7 +175,7 @@ func (p *ProvisionalLoginContext) RunSecretSyncer(m MetaContext, uid keybase1.UI
 	if uid.IsNil() {
 		uid = p.GetUID()
 	}
-	return RunSyncer(m, p.secretSyncer, uid, (p.localSession != nil), p.localSession)
+	return RunSyncer(m, p.secretSyncer, uid, (p.localSession != nil), p.localSession, false /* forceReload */)
 }
 func (p *ProvisionalLoginContext) GetUnlockedPaperEncKey() GenericKey {
 	return nil

--- a/go/libkb/sync_secret.go
+++ b/go/libkb/sync_secret.go
@@ -63,6 +63,9 @@ type SecretSyncer struct {
 	Contextified
 	dirty bool
 	keys  *ServerPrivateKeys
+	// forceNextSync makes it so next time syncFromServer is performed,
+	// version will be disregarded and latest keys will always be fetched.
+	forceNextSync bool
 }
 
 type DeviceTypeSet map[string]bool
@@ -122,7 +125,7 @@ func (ss *SecretSyncer) loadFromStorage(m MetaContext, uid keybase1.UID) (err er
 func (ss *SecretSyncer) syncFromServer(m MetaContext, uid keybase1.UID, sr SessionReader) (err error) {
 	hargs := HTTPArgs{}
 
-	if ss.keys != nil {
+	if ss.keys != nil && !ss.forceNextSync {
 		m.CDebugf("| adding version %d to fetch_private call", ss.keys.Version)
 		hargs.Add("version", I{ss.keys.Version})
 	}
@@ -146,10 +149,11 @@ func (ss *SecretSyncer) syncFromServer(m MetaContext, uid keybase1.UID, sr Sessi
 	}
 
 	m.CDebugf("| Returned object: {Status: %v, Version: %d, #pgpkeys: %d, #devices: %d}", obj.Status, obj.Version, len(obj.PrivateKeys), len(obj.Devices))
-	if ss.keys == nil || obj.Version > ss.keys.Version {
+	if ss.forceNextSync || ss.keys == nil || obj.Version > ss.keys.Version {
 		m.CDebugf("| upgrade to version -> %d", obj.Version)
 		ss.keys = &obj
 		ss.dirty = true
+		ss.forceNextSync = false
 	} else {
 		m.CDebugf("| not changing synced keys: synced version %d not newer than existing version %d", obj.Version, ss.keys.Version)
 	}

--- a/go/libkb/sync_trackers.go
+++ b/go/libkb/sync_trackers.go
@@ -109,7 +109,7 @@ func (t *TrackerSyncer) getLoadedVersion() int {
 
 func (t *TrackerSyncer) needsLogin(m MetaContext) bool { return false }
 
-func (t *TrackerSyncer) syncFromServer(m MetaContext, uid keybase1.UID, sr SessionReader) (err error) {
+func (t *TrackerSyncer) syncFromServer(m MetaContext, uid keybase1.UID, sr SessionReader, forceReload bool) (err error) {
 
 	lv := t.getLoadedVersion()
 
@@ -118,7 +118,7 @@ func (t *TrackerSyncer) syncFromServer(m MetaContext, uid keybase1.UID, sr Sessi
 		"limit": I{5000},
 	}
 
-	if lv >= 0 {
+	if lv >= 0 && !forceReload {
 		hargs.Add("version", I{lv})
 	}
 
@@ -137,7 +137,7 @@ func (t *TrackerSyncer) syncFromServer(m MetaContext, uid keybase1.UID, sr Sessi
 	if err = res.Body.UnmarshalAgain(&tmp); err != nil {
 		return
 	}
-	if lv < 0 || tmp.Version > lv {
+	if lv < 0 || tmp.Version > lv || forceReload {
 		m.CDebugf("| syncFromServer(): got update %d > %d (%d records)", tmp.Version, lv,
 			len(tmp.Trackers))
 		tmp = tmp.compact()

--- a/go/libkb/sync_trackers2.go
+++ b/go/libkb/sync_trackers2.go
@@ -60,7 +60,7 @@ func (t *Tracker2Syncer) getLoadedVersion() int {
 	return ret
 }
 
-func (t *Tracker2Syncer) syncFromServer(m MetaContext, uid keybase1.UID, sr SessionReader) (err error) {
+func (t *Tracker2Syncer) syncFromServer(m MetaContext, uid keybase1.UID, sr SessionReader, forceReload bool) (err error) {
 
 	defer m.CTrace(fmt.Sprintf("syncFromServer(%s)", uid), func() error { return err })()
 
@@ -71,7 +71,7 @@ func (t *Tracker2Syncer) syncFromServer(m MetaContext, uid keybase1.UID, sr Sess
 		"caller_uid": UIDArg(t.callerUID),
 	}
 	lv := t.getLoadedVersion()
-	if lv >= 0 {
+	if lv >= 0 && !forceReload {
 		hargs.Add("version", I{lv})
 	}
 	var res *APIRes
@@ -90,7 +90,7 @@ func (t *Tracker2Syncer) syncFromServer(m MetaContext, uid keybase1.UID, sr Sess
 		return
 	}
 	tmp.Time = keybase1.ToTime(time.Now())
-	if lv < 0 || tmp.Version > lv {
+	if lv < 0 || tmp.Version > lv || forceReload {
 		m.CDebugf("| syncFromServer(): got update %d > %d (%d records)", tmp.Version, lv,
 			len(tmp.Users))
 		t.res = &tmp

--- a/go/libkb/syncer.go
+++ b/go/libkb/syncer.go
@@ -14,12 +14,12 @@ type Syncer interface {
 	Contextifier
 	sync.Locker
 	loadFromStorage(m MetaContext, u keybase1.UID) error
-	syncFromServer(m MetaContext, u keybase1.UID, sr SessionReader) error
+	syncFromServer(m MetaContext, u keybase1.UID, sr SessionReader, forceReload bool) error
 	store(m MetaContext, u keybase1.UID) error
 	needsLogin(m MetaContext) bool
 }
 
-func RunSyncer(m MetaContext, s Syncer, uid keybase1.UID, loggedIn bool, sr SessionReader) (err error) {
+func RunSyncer(m MetaContext, s Syncer, uid keybase1.UID, loggedIn bool, sr SessionReader, forceReload bool) (err error) {
 	if uid.IsNil() {
 		return NotFoundError{"No UID given to syncer"}
 	}
@@ -43,7 +43,7 @@ func RunSyncer(m MetaContext, s Syncer, uid keybase1.UID, loggedIn bool, sr Sess
 		m.CDebugf("| Won't sync with server since we're not logged in")
 		return
 	}
-	if err = s.syncFromServer(m, uid, sr); err != nil {
+	if err = s.syncFromServer(m, uid, sr, forceReload); err != nil {
 		return
 	}
 	if err = s.store(m, uid); err != nil {


### PR DESCRIPTION
It is useful to update keys even if we have latest versions sometimes, especially when trying to get accurate LastUsedTime. This commit fixes device list screen/commmand problems where users would not see accurate "last used" times on their devices.

I tried to find the minimal patch to make it possible to force update in SecretSyncer. I did not want to change Syncer interface API because that would require changes all over the codebase. So this PR adds a new field to SecretSyncer struct.