### PR TITLE
remove all traces of "canonicalizing" TLF names in CLI code

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -951,7 +951,7 @@ func newNewConversationHelper(g *globals.Context, uid gregor1.UID, tlfName strin
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "newConversationHelper", false),
 		uid:          uid,
-		tlfName:      tlfName,
+		tlfName:      utils.AddUserToTLFName(g, tlfName, vis, membersType),
 		topicName:    topicName,
 		topicType:    topicType,
 		membersType:  membersType,

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -274,7 +274,19 @@ func (b *baseInboxSource) GetInboxQueryLocalToRemote(ctx context.Context,
 	rquery = &chat1.GetInboxQuery{}
 	if lquery.Name != nil && len(lquery.Name.Name) > 0 {
 		var err error
-		info, err = CtxKeyFinder(ctx, b.G()).Find(ctx, lquery.Name.Name, lquery.Name.MembersType,
+
+		// Normalize TLF name
+		tlfName := lquery.Name.Name
+		switch lquery.Name.MembersType {
+		case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE,
+			chat1.ConversationMembersType_KBFS:
+			username := b.G().Env.GetUsername().String()
+			if lquery.Visibility() != keybase1.TLFVisibility_PUBLIC && !strings.Contains(tlfName, username) {
+				tlfName += "," + username
+			}
+		}
+
+		info, err = CtxKeyFinder(ctx, b.G()).Find(ctx, tlfName, lquery.Name.MembersType,
 			lquery.Visibility() == keybase1.TLFVisibility_PUBLIC)
 		if err != nil {
 			b.Debug(ctx, "GetInboxQueryLocalToRemote: failed: %s", err)
@@ -282,8 +294,7 @@ func (b *baseInboxSource) GetInboxQueryLocalToRemote(ctx context.Context,
 		}
 		rquery.TlfID = &info.ID
 		rquery.MembersTypes = []chat1.ConversationMembersType{lquery.Name.MembersType}
-		b.Debug(ctx, "GetInboxQueryLocalToRemote: mapped name %q to TLFID %v",
-			lquery.Name.Name, info.ID)
+		b.Debug(ctx, "GetInboxQueryLocalToRemote: mapped name %q to TLFID %v", tlfName, info.ID)
 	}
 
 	rquery.After = lquery.After

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -274,18 +274,8 @@ func (b *baseInboxSource) GetInboxQueryLocalToRemote(ctx context.Context,
 	rquery = &chat1.GetInboxQuery{}
 	if lquery.Name != nil && len(lquery.Name.Name) > 0 {
 		var err error
-
-		// Normalize TLF name
-		tlfName := lquery.Name.Name
-		switch lquery.Name.MembersType {
-		case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE,
-			chat1.ConversationMembersType_KBFS:
-			username := b.G().Env.GetUsername().String()
-			if lquery.Visibility() != keybase1.TLFVisibility_PUBLIC && !strings.Contains(tlfName, username) {
-				tlfName += "," + username
-			}
-		}
-
+		tlfName := utils.AddUserToTLFName(b.G(), lquery.Name.Name, lquery.Visibility(),
+			lquery.Name.MembersType)
 		info, err = CtxKeyFinder(ctx, b.G()).Find(ctx, tlfName, lquery.Name.MembersType,
 			lquery.Visibility() == keybase1.TLFVisibility_PUBLIC)
 		if err != nil {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -624,25 +624,20 @@ func TestChatSrvNewConversationLocal(t *testing.T) {
 		ctc := makeChatTestContext(t, "NewConversationLocal", 2)
 		defer ctc.cleanup()
 		users := ctc.users()
-
 		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
 			ctc.as(t, users[1]).user())
-
 		tc := ctc.world.Tcs[users[0].Username]
 		ctx := ctc.as(t, users[0]).startCtx
 		uid := users[0].User.GetUID().ToBytes()
 		conv, err := GetUnverifiedConv(ctx, tc.Context(), uid, created.Id, false)
 		require.NoError(t, err)
-		if len(conv.MaxMsgSummaries) == 0 {
-			t.Fatalf("created conversation does not have a message")
-		}
-
+		require.NotZero(t, len(conv.MaxMsgSummaries))
 		switch mt {
-		case chat1.ConversationMembersType_KBFS:
-			if conv.MaxMsgSummaries[0].TlfName !=
-				string(kbtest.CanonicalTlfNameForTest(ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username)) {
-				t.Fatalf("unexpected TLF name in created conversation. expected %s, got %s", ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username, conv.MaxMsgs[0].ClientHeader.TlfName)
-			}
+		case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAMNATIVE:
+			refName := string(kbtest.CanonicalTlfNameForTest(
+				ctc.as(t, users[0]).user().Username + "," + ctc.as(t, users[1]).user().Username),
+			)
+			require.Equal(t, refName, conv.MaxMsgSummaries[0].TlfName)
 		case chat1.ConversationMembersType_TEAM:
 			teamName := ctc.teamCache[teamKey(ctc.users())]
 			require.Equal(t, teamName, conv.MaxMsgSummaries[0].TlfName)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1338,7 +1338,7 @@ func AddUserToTLFName(g *globals.Context, tlfName string, vis keybase1.TLFVisibi
 	case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE,
 		chat1.ConversationMembersType_KBFS:
 		username := g.Env.GetUsername().String()
-		if vis != keybase1.TLFVisibility_PUBLIC && !strings.Contains(tlfName, username) {
+		if vis != keybase1.TLFVisibility_PUBLIC {
 			if len(tlfName) == 0 {
 				tlfName = username
 			} else {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1331,3 +1331,16 @@ func AssetsForMessage(g *globals.Context, msgBody chat1.MessageBody) (assets []c
 	}
 	return assets
 }
+
+func AddUserToTLFName(g *globals.Context, tlfName string, vis keybase1.TLFVisibility,
+	membersType chat1.ConversationMembersType) string {
+	switch membersType {
+	case chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE,
+		chat1.ConversationMembersType_KBFS:
+		username := g.Env.GetUsername().String()
+		if vis != keybase1.TLFVisibility_PUBLIC && !strings.Contains(tlfName, username) {
+			tlfName += "," + username
+		}
+	}
+	return tlfName
+}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1339,7 +1339,11 @@ func AddUserToTLFName(g *globals.Context, tlfName string, vis keybase1.TLFVisibi
 		chat1.ConversationMembersType_KBFS:
 		username := g.Env.GetUsername().String()
 		if vis != keybase1.TLFVisibility_PUBLIC && !strings.Contains(tlfName, username) {
-			tlfName += "," + username
+			if len(tlfName) == 0 {
+				tlfName = username
+			} else {
+				tlfName += "," + username
+			}
 		}
 	}
 	return tlfName

--- a/go/client/chat_common.go
+++ b/go/client/chat_common.go
@@ -14,8 +14,6 @@ import (
 )
 
 func CheckUserOrTeamName(ctx context.Context, g *libkb.GlobalContext, name string) (res keybase1.UserOrTeamResult, err error) {
-	var req chatConversationResolvingRequest
-	req.ctx = new(chatConversationResolvingRequestContext)
 	cli, err := GetTeamsClient(g)
 	if err != nil {
 		return res, err

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -837,7 +837,7 @@ func (c *chatServiceHandler) makePostHeader(ctx context.Context, arg sendArgV1, 
 		if arg.channel.TopicName != "" {
 			topicName = &arg.channel.TopicName
 		}
-		channelName := c.normalizeChannelName(arg.channel)
+		channelName := arg.channel.Name
 		ncres, err := client.NewConversationLocal(ctx, chat1.NewConversationLocalArg{
 			TlfName:          channelName,
 			TlfVisibility:    visibility,
@@ -1038,10 +1038,7 @@ func (c *chatServiceHandler) findConversation(ctx context.Context, convIDStr str
 		if err != nil {
 			return conv, rlimits, fmt.Errorf("invalid conversation ID: %s", convIDStr)
 		}
-	} else {
-		channel.Name = c.normalizeChannelName(channel)
 	}
-
 	existing, existingRl, err := c.getExistingConvs(ctx, convID, channel)
 	if err != nil {
 		return conv, rlimits, err
@@ -1056,16 +1053,6 @@ func (c *chatServiceHandler) findConversation(ctx context.Context, convIDStr str
 	}
 
 	return existing[0], rlimits, nil
-}
-
-// If we have a channel name but the current username isn't present and the
-// channel is private, add it.
-func (c *chatServiceHandler) normalizeChannelName(channel ChatChannel) string {
-	channelName := channel.Name
-	if !channel.Public && channelName != "" && !strings.Contains(channelName, c.G().Env.GetUsername().String()) {
-		channelName = fmt.Sprintf("%s,%s", channelName, c.G().Env.GetUsername())
-	}
-	return channelName
 }
 
 func TopicTypeFromStrDefault(str string) (chat1.TopicType, error) {

--- a/go/client/cmd_chat_createchannel.go
+++ b/go/client/cmd_chat_createchannel.go
@@ -48,9 +48,6 @@ func (c *CmdChatCreateChannel) Run() error {
 		TopicType:   c.topicType,
 		MembersType: chat1.ConversationMembersType_TEAM,
 		Visibility:  keybase1.TLFVisibility_PRIVATE,
-		ctx: &chatConversationResolvingRequestContext{
-			canonicalizedTlfName: c.teamName,
-		},
 	}
 
 	_, err = resolver.create(context.Background(), req)

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -170,7 +170,16 @@ func NewTlfMock(world *ChatMockWorld) *TlfMock {
 func CanonicalTlfNameForTest(tlfName string) keybase1.CanonicalTlfName {
 	// very much simplified canonicalization.
 	// TODO: implement rest when we need it
-	names := strings.Split(tlfName, ",")
+	var names []string
+	nameMap := make(map[string]bool)
+	rawNames := strings.Split(tlfName, ",")
+	for _, rn := range rawNames {
+		if nameMap[rn] {
+			continue
+		}
+		names = append(names, rn)
+		nameMap[rn] = true
+	}
 	sort.Strings(names)
 	return keybase1.CanonicalTlfName(strings.Join(names, ","))
 }


### PR DESCRIPTION
I think this should make oneshot devices work for real this time.