### PR TITLE
Check if user was on buggy release before checking for newExploding item

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2092,7 +2092,10 @@ function* handleSeeingExplodingMessages(action: Chat2Gen.HandleSeeingExplodingMe
     }
   } else {
     // haven't been here before. figure out the new body by seeing if newExploding is there
-    if (!gregorState.items.find(i => i.item.category === Constants.newExplodingGregorKey)) {
+    const hasOldItems = !!gregorState.items.find(
+      i => i.item.category === Constants.legacySeenExplodingGregorKey
+    )
+    if (hasOldItems && !gregorState.items.find(i => i.item.category === Constants.newExplodingGregorKey)) {
       // not new!
       body = (Date.now() - Constants.newExplodingGregorOffset).toString()
     }

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -190,7 +190,10 @@ function handleIsExplodingNew(items: Array<Types.NonNullGregorItem>) {
   } else {
     // never clicked on bomb icon with new setup
     // check for old one
-    isNew = !!items.find(i => i.item.category === ChatConstants.newExplodingGregorKey)
+    const hasOldItems = !!items.find(i => i.item.category === ChatConstants.legacySeenExplodingGregorKey)
+    if (hasOldItems) {
+      isNew = !!items.find(i => i.item.category === ChatConstants.newExplodingGregorKey)
+    }
   }
   return Saga.put(Chat2Gen.createSetExplodingMessagesNew({new: isNew}))
 }

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -123,7 +123,7 @@ export const creatingLoadingKey = 'creatingConvo'
 
 // unused for new stuff, kept for checks
 export const newExplodingGregorKey = 'explodingMessagesAreNew'
-export const oldSeenExplodingGregorKey = 'hasSeenExplodingMessages'
+export const legacySeenExplodingGregorKey = 'hasSeenExplodingMessages'
 
 // When we see that exploding messages are in the app, we set
 // seenExplodingGregorKey. Once newExplodingGregorOffset time


### PR DESCRIPTION
Currently, we only check for `newExplodingGregorKey` to make decisions about whether to show the `NEW` tag or not. This is to be backwards compatible with the last release, which had a bug with the tag, and is intended to transition to the new gregor key without changing whether the `NEW` shows up. 

The problem is that the current code assumes users were on the buggy release. Since the absence of the gregor item means exploding isn't new, the `NEW` tag only shows for users who were on the bad version and happened to get into a good state, with the `NEW` tag visible. Anyone who wasn't on the bad version (most importantly new users) would never get the `NEW` tag. The fix is to check for the other item that was injected in the bad release. r? @keybase/react-hackers 