### PR TITLE
move the ephemeral notify routine out of storage CORE-8188

### DIFF
--- a/go/chat/ephemeral_purger.go
+++ b/go/chat/ephemeral_purger.go
@@ -280,7 +280,7 @@ func (b *BackgroundEphemeralPurger) queuePurges(ctx context.Context) bool {
 		nextPurgeTime := purgeInfo.NextPurgeTime.Time()
 		if nextPurgeTime.Before(now) || nextPurgeTime.Equal(now) {
 			job := types.NewConvLoaderJob(purgeInfo.ConvID, &chat1.Pagination{},
-				types.ConvLoaderPriorityHigh, newConvLoaderEphemeralPurgeHook(b.G(), b.storage, b.uid, &purgeInfo))
+				types.ConvLoaderPriorityHigh, newConvLoaderEphemeralPurgeHook(b.G(), b.uid, &purgeInfo))
 			if err := b.G().ConvLoader.Queue(ctx, job); err != nil {
 				b.Debug(ctx, "convLoader Queue error %s", err)
 			}
@@ -316,9 +316,9 @@ func (b *BackgroundEphemeralPurger) resetTimer(purgeInfo chat1.EphemeralPurgeInf
 	b.purgeTimer.Reset(duration)
 }
 
-func newConvLoaderEphemeralPurgeHook(g *globals.Context, chatStorage *storage.Storage, uid gregor1.UID, purgeInfo *chat1.EphemeralPurgeInfo) func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
+func newConvLoaderEphemeralPurgeHook(g *globals.Context, uid gregor1.UID, purgeInfo *chat1.EphemeralPurgeInfo) func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
 	return func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
-		if _, _, err := chatStorage.EphemeralPurge(ctx, job.ConvID, uid, purgeInfo); err != nil {
+		if _, _, err := g.ConvSource.EphemeralPurge(ctx, job.ConvID, uid, purgeInfo); err != nil {
 			g.GetLog().CDebugf(ctx, "ephemeralPurge: %s", err)
 		}
 	}

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -328,6 +328,12 @@ func (s *Storage) GetMaxMsgID(ctx context.Context, convID chat1.ConversationID, 
 
 type MergeResult struct {
 	Expunged *chat1.Expunge
+	Exploded []chat1.MessageUnboxed
+}
+
+type FetchResult struct {
+	Thread   chat1.ThreadView
+	Exploded []chat1.MessageUnboxed
 }
 
 // Merge requires msgs to be sorted by descending message ID
@@ -389,9 +395,11 @@ func (s *Storage) MergeHelper(ctx context.Context,
 	}
 	res.Expunged = expunged
 
-	if err = s.explodeExpiredMessages(ctx, convID, uid, msgs); err != nil {
+	explodedMsgs, err := s.explodeExpiredMessages(ctx, convID, uid, msgs)
+	if err != nil {
 		return res, s.MaybeNuke(ctx, false, err, convID, uid)
 	}
+	res.Exploded = explodedMsgs
 
 	// Update max msg ID if needed
 	if len(msgs) > 0 {
@@ -797,23 +805,21 @@ func (s *Storage) ResultCollectorFromQuery(ctx context.Context, query *chat1.Get
 
 func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, rc ResultCollector,
 	convID chat1.ConversationID, uid gregor1.UID, msgID chat1.MessageID, query *chat1.GetThreadQuery,
-	pagination *chat1.Pagination) (chat1.ThreadView, Error) {
+	pagination *chat1.Pagination) (res FetchResult, err Error) {
 
-	var err Error
 	if err = isAbortedRequest(ctx); err != nil {
-		return chat1.ThreadView{}, err
+		return res, err
 	}
 	// Fetch secret key
 	key, ierr := getSecretBoxKey(ctx, s.G().ExternalG(), DefaultSecretUI)
 	if ierr != nil {
-		return chat1.ThreadView{},
-			MiscError{Msg: "unable to get secret key: " + ierr.Error()}
+		return res, MiscError{Msg: "unable to get secret key: " + ierr.Error()}
 	}
 
 	// Init storage engine first
 	ctx, err = s.engine.Init(ctx, key, convID, uid)
 	if err != nil {
-		return chat1.ThreadView{}, s.MaybeNuke(ctx, false, err, convID, uid)
+		return res, s.MaybeNuke(ctx, false, err, convID, uid)
 	}
 
 	// Calculate seek parameters
@@ -830,14 +836,14 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, rc ResultCollector,
 		} else if len(pagination.Next) > 0 {
 			if derr := decode(pagination.Next, &pid); derr != nil {
 				err = RemoteError{Msg: "Fetch: failed to decode pager: " + derr.Error()}
-				return chat1.ThreadView{}, s.MaybeNuke(ctx, false, err, convID, uid)
+				return res, s.MaybeNuke(ctx, false, err, convID, uid)
 			}
 			maxID = pid - 1
 			s.Debug(ctx, "Fetch: next pagination: pid: %d", pid)
 		} else {
 			if derr := decode(pagination.Previous, &pid); derr != nil {
 				err = RemoteError{Msg: "Fetch: failed to decode pager: " + derr.Error()}
-				return chat1.ThreadView{}, s.MaybeNuke(ctx, false, err, convID, uid)
+				return res, s.MaybeNuke(ctx, false, err, convID, uid)
 			}
 			maxID = chat1.MessageID(int(pid) + num)
 			s.Debug(ctx, "Fetch: prev pagination: pid: %d", pid)
@@ -853,15 +859,17 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, rc ResultCollector,
 
 	// Run seek looking for all the messages
 	if err = s.engine.ReadMessages(ctx, rc, convID, uid, maxID); err != nil {
-		return chat1.ThreadView{}, err
+		return res, err
 	}
 	msgs := rc.Result()
 
 	// Clear out any ephemeral messages that have exploded before we hand these
 	// messages out.
-	if err := s.explodeExpiredMessages(ctx, convID, uid, msgs); err != nil {
-		return chat1.ThreadView{}, err
+	explodedMsgs, err := s.explodeExpiredMessages(ctx, convID, uid, msgs)
+	if err != nil {
+		return res, err
 	}
+	res.Exploded = explodedMsgs
 
 	// Get the stored latest point upto which has been deleted.
 	// `maxDeletedUpto` can be behind the times, so the pager is patched later in ConvSource.
@@ -873,29 +881,28 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, rc ResultCollector,
 		maxDeletedUpto = delh.MaxDeleteHistoryUpto
 	case MissError:
 	default:
-		return chat1.ThreadView{}, err
+		return res, err
 	}
 	s.Debug(ctx, "Fetch: using max deleted upto: %v for pager", maxDeletedUpto)
 
 	// Form paged result
-	var tres chat1.ThreadView
 	var pmsgs []pager.Message
 	for _, m := range msgs {
 		pmsgs = append(pmsgs, m)
 	}
-	if tres.Pagination, ierr = pager.NewThreadPager().MakePage(pmsgs, num, maxDeletedUpto); ierr != nil {
-		return chat1.ThreadView{},
+	if res.Thread.Pagination, ierr = pager.NewThreadPager().MakePage(pmsgs, num, maxDeletedUpto); ierr != nil {
+		return res,
 			NewInternalError(ctx, s.DebugLabeler, "Fetch: failed to encode pager: %s", ierr.Error())
 	}
-	tres.Messages = msgs
+	res.Thread.Messages = msgs
 
 	s.Debug(ctx, "Fetch: cache hit: num: %d", len(msgs))
-	return tres, nil
+	return res, nil
 }
 
 func (s *Storage) FetchUpToLocalMaxMsgID(ctx context.Context,
 	convID chat1.ConversationID, uid gregor1.UID, rc ResultCollector, iboxMaxMsgID chat1.MessageID,
-	query *chat1.GetThreadQuery, pagination *chat1.Pagination) (res chat1.ThreadView, err Error) {
+	query *chat1.GetThreadQuery, pagination *chat1.Pagination) (res FetchResult, err Error) {
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functions.
 	locks.Storage.Lock()
@@ -904,7 +911,7 @@ func (s *Storage) FetchUpToLocalMaxMsgID(ctx context.Context,
 
 	maxMsgID, err := s.idtracker.getMaxMessageID(ctx, convID, uid)
 	if err != nil {
-		return chat1.ThreadView{}, err
+		return res, err
 	}
 	if iboxMaxMsgID > maxMsgID {
 		s.Debug(ctx, "FetchUpToLocalMaxMsgID: overriding locally stored max msgid with ibox: %d",
@@ -917,7 +924,7 @@ func (s *Storage) FetchUpToLocalMaxMsgID(ctx context.Context,
 }
 
 func (s *Storage) Fetch(ctx context.Context, conv chat1.Conversation,
-	uid gregor1.UID, rc ResultCollector, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (res chat1.ThreadView, err Error) {
+	uid gregor1.UID, rc ResultCollector, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (res FetchResult, err Error) {
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functions.
 	locks.Storage.Lock()

--- a/go/chat/storage/storage_ephemeral_purge_test.go
+++ b/go/chat/storage/storage_ephemeral_purge_test.go
@@ -57,7 +57,9 @@ func TestStorageEphemeralPurge(t *testing.T) {
 
 	assertState := func(maxMsgID chat1.MessageID) {
 		var rc ResultCollector
-		res, err := storage.Fetch(context.Background(), makeConversationAt(convID, maxMsgID), uid, rc, nil, nil)
+		fetchRes, err := storage.Fetch(context.Background(), makeConversationAt(convID, maxMsgID), uid, rc,
+			nil, nil)
+		res := fetchRes.Thread
 		require.NoError(t, err)
 		if len(res.Messages) != len(expectedState) {
 			t.Logf("wrong number of messages")

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -177,7 +177,7 @@ func TestSyncerConnected(t *testing.T) {
 	require.Equal(t, chat1.InboxVers(100), vers)
 	thread, cerr := store.Fetch(context.TODO(), mconv, uid, nil, nil, nil)
 	require.NoError(t, cerr)
-	require.Equal(t, 1, len(thread.Messages))
+	require.Equal(t, 1, len(thread.Thread.Messages))
 
 	t.Logf("test server version")
 	srvVers, err := ibox.ServerVersion(context.TODO())
@@ -518,8 +518,8 @@ func TestSyncerRetentionExpunge(t *testing.T) {
 	require.Equal(t, chat1.Expunge{Upto: 12}, iconvs[0].Conv.Expunge)
 	thread, cerr := store.Fetch(context.TODO(), mconv, uid, nil, nil, nil)
 	require.NoError(t, cerr)
-	require.True(t, len(thread.Messages) > 1)
-	for i, m := range thread.Messages {
+	require.True(t, len(thread.Thread.Messages) > 1)
+	for i, m := range thread.Thread.Messages {
 		t.Logf("message %v", i)
 		require.True(t, m.IsValid())
 		require.True(t, m.Valid().MessageBody.IsNil(), "remaining messages should have no body")

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -80,6 +80,8 @@ type ConversationSource interface {
 		uid gregor1.UID, expunge chat1.Expunge) error
 	ClearFromDelete(ctx context.Context, uid gregor1.UID,
 		convID chat1.ConversationID, deleteID chat1.MessageID) bool
+	EphemeralPurge(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+		purgeInfo *chat1.EphemeralPurgeInfo) (*chat1.EphemeralPurgeInfo, []chat1.MessageUnboxed, error)
 
 	SetRemoteInterface(func() chat1.RemoteInterface)
 	DeleteAssets(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, assets []chat1.Asset)


### PR DESCRIPTION
There is a problem with the current arrangement where if we try to notify from within `ephemeralPurgeHelper`, we will get deadlocked on the storage lock. Patch does the following:

1.) Move `notifyEphemeralPurge` into `HybridConversationSource`. This removes the dependency of `storage` on itself.
2.) Return information about which messages were exploded from both `Merge` and `Fetch`.
3.) Add `fetchMaybeNotify` to notify about ephemeral purges, and augment `mergeMaybeNotify` to act on exploding in addition to retention expunge. 
4.) Fixup tests.

cc @chrisnojima @maxtaco this needs to be in the hotfix before we release it.