### PR TITLE
errors were pre-empting the logging of pipeowner output

### DIFF
--- a/shared/engine/index.platform.desktop.js
+++ b/shared/engine/index.platform.desktop.js
@@ -52,17 +52,18 @@ function checkRPCOwnership(): Promise<void> {
     const args = ['pipeowner', socketPath]
     execFile(binPath, args, {windowsHide: true}, (error, stdout, stderr) => {
       if (error) {
-        logger.info(`pipeowner check returns: ${error.message}`)
+        logger.info(`pipeowner check result: ${stdout.toString()}`)
+        // error will be logged in bootstrap check
         reject(error)
         return
       }
       const result = JSON.parse(stdout.toString())
-      logger.info(`pipeowner check returns: ${stdout.toString()}`)
       if (result.isOwner) {
         resolve()
         return
       }
-      reject(new Error(`pipeowner check returns: ${stdout.toString()}`))
+      logger.info(`pipeowner check result: ${stdout.toString()}`)
+      reject(new Error(`pipeowner check failed`))
     })
   })
 }


### PR DESCRIPTION
No need to log stuff if the check is successful