### PR TITLE
Profile team loading on master

### DIFF
--- a/go/client/cmd_team.go
+++ b/go/client/cmd_team.go
@@ -30,6 +30,7 @@ func NewCmdTeam(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 			newCmdTeamDelete(cl, g),
 			newCmdTeamAPI(cl, g),
 			newCmdTeamSettings(cl, g),
+			newCmdTeamProfileLoad(cl, g),
 		},
 	}
 }

--- a/go/client/cmd_team_profile_load.go
+++ b/go/client/cmd_team_profile_load.go
@@ -1,0 +1,63 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+type cmdTeamProfileLoad struct {
+	libkb.Contextified
+	arg keybase1.LoadTeamArg
+}
+
+func newCmdTeamProfileLoad(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "profile-load",
+		Description:  "profile a team load operation",
+		ArgumentHelp: "name",
+		Flags:        []cli.Flag{},
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&cmdTeamProfileLoad{Contextified: libkb.NewContextified(g)}, "profile-load", c)
+		},
+	}
+}
+
+func (c *cmdTeamProfileLoad) Run() error {
+	cli, err := GetTeamsClient(c.G())
+	if err != nil {
+		return err
+	}
+	c.arg.ForceFullReload = true
+	res, err := cli.ProfileTeamLoad(context.TODO(), c.arg)
+	if err != nil {
+		return err
+	}
+	c.G().UI.GetTerminalUI().Printf("%+v\n", res)
+	c.G().UI.GetTerminalUI().Printf("%v\n", time.Duration(res.LoadTimeNsec)*time.Nanosecond)
+	return nil
+}
+
+func (c *cmdTeamProfileLoad) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		return errors.New("need a name argument")
+	}
+	c.arg.Name = ctx.Args()[0]
+	return nil
+}
+
+func (c *cmdTeamProfileLoad) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/profiling/timebuckets.go
+++ b/go/profiling/timebuckets.go
@@ -45,7 +45,7 @@ func (t *TimeBuckets) Get(bucketName string) time.Duration {
 }
 
 func (t *TimeBuckets) Log(ctx context.Context, bucketName string) {
-	t.log.CDebugf(ctx, "%s [time=%s]", bucketName, t.Get(bucketName))
+	t.log.CDebugf(ctx, "TimeBucket %s [time=%s]", bucketName, t.Get(bucketName))
 }
 
 type FinFn func()

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -556,3 +556,11 @@ func (h *TeamsHandler) FindNextMerkleRootAfterTeamRemovalBySigningKey(ctx contex
 	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
 	return teams.FindNextMerkleRootAfterRemoval(mctx, arg)
 }
+
+func (h *TeamsHandler) ProfileTeamLoad(ctx context.Context, arg keybase1.LoadTeamArg) (res keybase1.ProfileTeamLoadRes, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("ProfileTeamLoad(%+v)", arg), func() error { return err })()
+	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
+	return teams.ProfileTeamLoad(mctx, arg)
+
+}

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -381,7 +381,7 @@ func (l *TeamLoader) load2InnerLocked(ctx context.Context, arg load2ArgT) (res *
 
 func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (*load2ResT, error) {
 	ctx, tbs := l.G().CTimeBuckets(ctx)
-	tracer := l.G().CTimeTracer(ctx, "TeamLoader.load2ILR", false)
+	tracer := l.G().CTimeTracer(ctx, "TeamLoader.load2ILR", true)
 	defer tracer.Finish()
 
 	var err error
@@ -557,6 +557,8 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		prev = link.LinkID()
 	}
 	tbs.Log(ctx, "CachedUPAKLoader.LoadKeyV2")
+	tbs.Log(ctx, "TeamLoader.verifyLink")
+	tbs.Log(ctx, "TeamLoader.applyNewLink")
 
 	if ret == nil {
 		return nil, fmt.Errorf("team loader fault: got nil from load2")

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -155,6 +155,8 @@ func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID k
 func (l *TeamLoader) verifyLink(ctx context.Context,
 	teamID keybase1.TeamID, state *keybase1.TeamData, me keybase1.UserVersion, link *chainLinkUnpacked,
 	readSubteamID keybase1.TeamID, proofSet *proofSetT) (*signerX, error) {
+	ctx, tbs := l.G().CTimeBuckets(ctx)
+	defer tbs.Record("TeamLoader.verifyLink")()
 
 	if link.isStubbed() {
 		return nil, nil
@@ -398,6 +400,8 @@ func (l *TeamLoader) toParentChildOperation(ctx context.Context,
 func (l *TeamLoader) applyNewLink(ctx context.Context,
 	state *keybase1.TeamData, link *chainLinkUnpacked,
 	signer *signerX, me keybase1.UserVersion) (*keybase1.TeamData, error) {
+	ctx, tbs := l.G().CTimeBuckets(ctx)
+	defer tbs.Record("TeamLoader.applyNewLink")()
 
 	l.G().Log.CDebugf(ctx, "TeamLoader applying link seqno:%v", link.Seqno())
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1577,3 +1577,11 @@ func FindNextMerkleRootAfterRemoval(mctx libkb.MetaContext, arg keybase1.FindNex
 		Prev:              logPoint.SigMeta.PrevMerkleRootSigned,
 	})
 }
+
+func ProfileTeamLoad(mctx libkb.MetaContext, arg keybase1.LoadTeamArg) (res keybase1.ProfileTeamLoadRes, err error) {
+	pre := mctx.G().Clock().Now()
+	_, err = Load(mctx.Ctx(), mctx.G(), arg)
+	post := mctx.G().Clock().Now()
+	res.LoadTimeNsec = post.Sub(pre).Nanoseconds()
+	return res, err
+}


### PR DESCRIPTION
warm caches
```
2018-06-25T17:14:10.795603-04:00 ▶ [DEBU keybase util.go:531] 2c612 + TeamLoader.load2ILR [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:10.795628-04:00 ▶ [DEBU keybase timetracer.go:52] 2c613 | TeamLoader.load2ILR:init [time=25.769µs] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:10.795666-04:00 ▶ [DEBU keybase timetracer.go:52] 2c614 | TeamLoader.load2ILR:cache load [time=1.925µs] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:10.846534-04:00 ▶ [DEBU keybase timetracer.go:52] 2c634 | TeamLoader.load2ILR:merkle [time=50.836489ms] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:10.846562-04:00 ▶ [DEBU keybase timetracer.go:52] 2c635 | TeamLoader.load2ILR:backfill [time=1.401µs] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:10.846612-04:00 ▶ [DEBU keybase timetracer.go:52] 2c637 | TeamLoader.load2ILR:pre-fetch [time=29.311µs] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]




2018-06-25T17:14:11.640466-04:00 ▶ [DEBU keybase timetracer.go:52] 2c64a | TeamLoader.load2ILR:fetch [time=793.839657ms] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]


2018-06-25T17:14:11.944824-04:00 ▶ [DEBU keybase timetracer.go:52] 2c64b | TeamLoader.load2ILR:unpack [time=304.334995ms] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]




2018-06-25T17:14:32.573676-04:00 ▶ [DEBU keybase timebuckets.go:48] 3abc2 TimeBucket CachedUPAKLoader.LoadKeyV2 [time=2.070981928s] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:32.573770-04:00 ▶ [DEBU keybase timebuckets.go:48] 3abc3 TimeBucket TeamLoader.verifyLink [time=6.049868226s] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:32.573976-04:00 ▶ [DEBU keybase timebuckets.go:48] 3abc4 TimeBucket TeamLoader.applyNewLink [time=14.310856081s] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:32.574146-04:00 ▶ [DEBU keybase timetracer.go:52] 3abc5 | TeamLoader.load2ILR:linkloop (3393) [time=20.629272358s] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:32.574275-04:00 ▶ [DEBU keybase timetracer.go:52] 3abc6 | TeamLoader.load2ILR:pco [time=4.013µs] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]




2018-06-25T17:14:34.369891-04:00 ▶ [DEBU keybase timetracer.go:52] 3afee | TeamLoader.load2ILR:checkproofs [time=1.795480975s] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]


2018-06-25T17:14:34.675864-04:00 ▶ [DEBU keybase timetracer.go:52] 3aff3 | TeamLoader.load2ILR:secrets [time=305.904746ms] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:34.685704-04:00 ▶ [DEBU keybase timetracer.go:52] 3aff4 | TeamLoader.load2ILR:namecalc [time=9.769842ms] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:34.729953-04:00 ▶ [DEBU keybase timetracer.go:52] 3aff5 | TeamLoader.load2ILR:put [time=44.159287ms] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:34.730046-04:00 ▶ [DEBU keybase timetracer.go:52] 3aff6 | TeamLoader.load2ILR:notify [time=2.386µs] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:34.730123-04:00 ▶ [DEBU keybase timetracer.go:62] 3aff7 | TeamLoader.load2ILR:postcheck [time=3.606µs] [tags:TM=AtrVeTDIPSzV,LT=C1q57_oeAunb]
2018-06-25T17:14:34.730162-04:00 ▶ [DEBU keybase loader.go:674] 3aff8 - TeamLoader.load2ILR [time=23.934556493s] [tags:LT=C1q57_oeAunb,TM=AtrVeTDIPSzV]
```