### PR TITLE
teamEK background creation

### DIFF
--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -11,21 +11,23 @@ import (
 	"github.com/keybase/client/go/erasablekv"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
 )
 
 const SkipKeygenNilMerkleRoot = "Skipping key generation, unable to fetch merkle root"
 
-const cacheEntryLifetimeSecs = 60 * 5 // 5 minutes
+const cacheEntryLifetime = time.Minute * 5
 const lruSize = 200
 
 type EKLib struct {
 	libkb.Contextified
 	teamEKGenCache *lru.Cache
 	sync.Mutex
-}
 
-func (e *EKLib) metaContext(ctx context.Context) libkb.MetaContext {
-	return libkb.NewMetaContext(ctx, e.G())
+	// During testing we may want to stall background creation to assert cache
+	// state.
+	clock                    clockwork.Clock
+	backgroundCreationTestCh chan bool
 }
 
 func NewEKLib(g *libkb.GlobalContext) *EKLib {
@@ -37,7 +39,20 @@ func NewEKLib(g *libkb.GlobalContext) *EKLib {
 	return &EKLib{
 		Contextified:   libkb.NewContextified(g),
 		teamEKGenCache: nlru,
+		clock:          clockwork.NewRealClock(),
 	}
+}
+
+func (e *EKLib) metaContext(ctx context.Context) libkb.MetaContext {
+	return libkb.NewMetaContext(ctx, e.G())
+}
+
+func (e *EKLib) setClock(clock clockwork.Clock) {
+	e.clock = clock
+}
+
+func (e *EKLib) setBackgroundCreationTestCh(ch chan bool) {
+	e.backgroundCreationTestCh = ch
 }
 
 func (e *EKLib) NewMetaContext(ctx context.Context) libkb.MetaContext {
@@ -175,7 +190,7 @@ func (e *EKLib) NewDeviceEKNeeded(ctx context.Context) (needed bool, err error) 
 }
 
 func (e *EKLib) newDeviceEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
-	defer e.G().CTraceTimed(ctx, fmt.Sprintf("newDeviceEKNeeded: %v", needed), func() error { return err })()
+	defer e.G().CTraceTimed(ctx, "newDeviceEKNeeded", func() error { return err })()
 
 	s := e.G().GetDeviceEKStorage()
 	maxGeneration, err := s.MaxGeneration(ctx)
@@ -220,7 +235,7 @@ func (e *EKLib) NewUserEKNeeded(ctx context.Context) (needed bool, err error) {
 }
 
 func (e *EKLib) newUserEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
-	defer e.G().CTraceTimed(ctx, fmt.Sprintf("newUserEKNeeded: %v", needed), func() error { return err })()
+	defer e.G().CTraceTimed(ctx, "newUserEKNeeded", func() error { return err })()
 
 	// Let's see what the latest server statement is. This verifies that the
 	// latest statement was signed by the latest PUK and otherwise fails with
@@ -259,27 +274,27 @@ func (e *EKLib) NewTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID) (ne
 	if err != nil {
 		return false, err
 	}
-	needed, _, err = e.newTeamEKNeeded(ctx, teamID, *merkleRootPtr)
+	needed, _, _, err = e.newTeamEKNeeded(ctx, teamID, *merkleRootPtr)
 	return needed, err
 }
 
-func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (needed bool, latestGenerationk keybase1.EkGeneration, err error) {
-	defer e.G().CTraceTimed(ctx, fmt.Sprintf("newTeamEKNeeded: %v", needed), func() error { return err })()
+func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (needed, backgroundGenPossible bool, latestGeneration keybase1.EkGeneration, err error) {
+	defer e.G().CTraceTimed(ctx, "newTeamEKNeeded", func() error { return err })()
 
 	// Let's see what the latest server statement is. This verifies that the
 	// latest statement was signed by the latest PTK and otherwise fails with
 	// wrongKID set.
 	statement, latestGeneration, wrongKID, err := fetchTeamEKStatement(ctx, e.G(), teamID)
 	if wrongKID {
-		return true, latestGeneration, nil
+		return true, false, latestGeneration, nil
 	} else if err != nil {
-		return false, latestGeneration, err
+		return false, false, latestGeneration, err
 	}
 
 	// Let's see what the latest server statement is.
 	// No statement, so we need a teamEK
 	if statement == nil {
-		return true, latestGeneration, nil
+		return true, false, latestGeneration, nil
 	}
 	// Can we access this generation? If not, let's regenerate.
 	s := e.G().GetTeamEKBoxStorage()
@@ -288,25 +303,27 @@ func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, mer
 		switch err.(type) {
 		case EKUnboxErr, EKMissingBoxErr:
 			e.G().Log.Debug(err.Error())
-			return true, latestGeneration, nil
+			return true, false, latestGeneration, nil
 		default:
-			return false, latestGeneration, err
+			return false, false, latestGeneration, err
 		}
 	}
 	// Ok we can access the ek, check lifetime.
 	e.G().Log.CDebugf(ctx, "nextTeamEKNeeded at: %v", nextKeygenTime(ek.Metadata.Ctime))
-	return keygenNeeded(ek.Metadata.Ctime, merkleRoot), latestGeneration, nil
+	return keygenNeeded(ek.Metadata.Ctime, merkleRoot), true, latestGeneration, nil
 }
 
 type teamEKGenCacheEntry struct {
-	Generation keybase1.EkGeneration
-	Ctime      keybase1.Time
+	Generation         keybase1.EkGeneration
+	Ctime              keybase1.Time
+	CreationInProgress bool
 }
 
-func (e *EKLib) newCacheEntry(generation keybase1.EkGeneration) *teamEKGenCacheEntry {
+func (e *EKLib) newCacheEntry(generation keybase1.EkGeneration, creationInProgress bool) *teamEKGenCacheEntry {
 	return &teamEKGenCacheEntry{
-		Generation: generation,
-		Ctime:      keybase1.ToTime(time.Now()),
+		Generation:         generation,
+		Ctime:              keybase1.ToTime(e.clock.Now()),
+		CreationInProgress: creationInProgress,
 	}
 }
 
@@ -314,12 +331,12 @@ func (e *EKLib) cacheKey(teamID keybase1.TeamID) string {
 	return teamID.String()
 }
 
-func (e *EKLib) isEntryValid(val interface{}) (*teamEKGenCacheEntry, bool) {
+func (e *EKLib) isEntryExpired(val interface{}) (*teamEKGenCacheEntry, bool) {
 	cacheEntry, ok := val.(*teamEKGenCacheEntry)
 	if !ok || cacheEntry == nil {
 		return nil, false
 	}
-	return cacheEntry, time.Now().Sub(cacheEntry.Ctime.Time()) < time.Duration(cacheEntryLifetimeSecs*time.Second)
+	return cacheEntry, e.clock.Now().Sub(cacheEntry.Ctime.Time()) >= cacheEntryLifetime
 }
 
 func (e *EKLib) PurgeTeamEKGenCache(teamID keybase1.TeamID, generation keybase1.EkGeneration) {
@@ -327,7 +344,7 @@ func (e *EKLib) PurgeTeamEKGenCache(teamID keybase1.TeamID, generation keybase1.
 	cacheKey := e.cacheKey(teamID)
 	val, ok := e.teamEKGenCache.Get(cacheKey)
 	if ok {
-		if cacheEntry, valid := e.isEntryValid(val); valid && cacheEntry.Generation != generation {
+		if cacheEntry, _ := e.isEntryExpired(val); cacheEntry != nil && cacheEntry.Generation != generation {
 			e.teamEKGenCache.Remove(cacheKey)
 		}
 	}
@@ -357,7 +374,7 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 	cacheKey := e.cacheKey(teamID)
 	val, ok := e.teamEKGenCache.Get(cacheKey)
 	if ok {
-		if cacheEntry, valid := e.isEntryValid(val); valid {
+		if cacheEntry, expired := e.isEntryExpired(val); !expired || cacheEntry.CreationInProgress {
 			teamEK, err = teamEKBoxStorage.Get(ctx, teamID, cacheEntry.Generation)
 			if err == nil {
 				return teamEK, nil
@@ -384,23 +401,55 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 	// is not expired. It's crucial that this verifies that the latest PTK was
 	// used since we don't want to use a key signed by an old PTK for
 	// encryption.
-	teamEKNeeded, latestGeneration, err := e.newTeamEKNeeded(ctx, teamID, merkleRoot)
+	teamEKNeeded, backgroundGenPossible, latestGeneration, err := e.newTeamEKNeeded(ctx, teamID, merkleRoot)
 	if err != nil {
 		return teamEK, err
 	} else if teamEKNeeded {
-		publishedMetadata, err := publishNewTeamEK(ctx, e.G(), teamID, merkleRoot)
-		if err != nil {
-			return teamEK, err
+		// Our current teamEK is expired but otherwise valid, so let's create
+		// the new teamEK in the background.  For large teams and an empty UPAK
+		// cache it can be expensive to do this calculation and it's
+		// unfortunate to block message sending while we otherwise have access
+		// to a working teamEK.
+		if backgroundGenPossible {
+			go func() {
+				if e.backgroundCreationTestCh != nil {
+					select {
+					case <-e.backgroundCreationTestCh:
+					}
+				}
+
+				publishedMetadata, err := publishNewTeamEK(ctx, e.G(), teamID, merkleRoot)
+				// Grab the lock once we finish publishing so we do don't block
+				e.Lock()
+				defer e.Unlock()
+				if err != nil {
+					// Let's just clear the cache and try again later
+					e.G().Log.CDebugf(ctx, "Unable to GetOrCreateLatestTeamEK in the background: %v", err)
+					e.teamEKGenCache.Remove(cacheKey)
+				} else {
+					e.teamEKGenCache.Add(cacheKey, e.newCacheEntry(publishedMetadata.Generation, false))
+				}
+
+				if e.backgroundCreationTestCh != nil {
+					e.backgroundCreationTestCh <- true
+				}
+			}()
+		} else {
+			publishedMetadata, err := publishNewTeamEK(ctx, e.G(), teamID, merkleRoot)
+			if err != nil {
+				return teamEK, err
+			}
+			latestGeneration = publishedMetadata.Generation
 		}
-		latestGeneration = publishedMetadata.Generation
 	}
 
 	teamEK, err = teamEKBoxStorage.Get(ctx, teamID, latestGeneration)
 	if err != nil {
 		return teamEK, err
 	}
-	// Cache the latest generation
-	e.teamEKGenCache.Add(cacheKey, e.newCacheEntry(latestGeneration))
+	// Cache the latest generation and signal future callers if we are trying
+	// to create the new key in the background.
+	e.teamEKGenCache.Add(cacheKey, e.newCacheEntry(latestGeneration, backgroundGenPossible))
 	return teamEK, nil
 }
 

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
 )
 
@@ -113,6 +114,8 @@ func TestNewTeamEKNeeded(t *testing.T) {
 
 	teamID := createTeam(tc)
 	ekLib := NewEKLib(tc.G)
+	fc := clockwork.NewFakeClockAt(time.Now())
+	ekLib.setClock(fc)
 	deviceEKStorage := tc.G.GetDeviceEKStorage()
 	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
 	teamEKBoxStorage := tc.G.GetTeamEKBoxStorage()
@@ -140,7 +143,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 		expectedUserEKGen = 1
 	}
 
-	assertKeyGenerations := func(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen keybase1.EkGeneration) {
+	assertKeyGenerations := func(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen keybase1.EkGeneration, teamEKCreationInProgress bool) {
 		teamEK, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 		require.NoError(t, err)
 
@@ -148,8 +151,10 @@ func TestNewTeamEKNeeded(t *testing.T) {
 		cacheKey := ekLib.cacheKey(teamID)
 		val, ok := ekLib.teamEKGenCache.Get(cacheKey)
 		require.True(t, ok)
-		cacheEntry, valid := ekLib.isEntryValid(val)
-		require.True(t, valid)
+		cacheEntry, expired := ekLib.isEntryExpired(val)
+		require.False(t, expired)
+		require.NotNil(t, cacheEntry)
+		require.Equal(t, teamEKCreationInProgress, cacheEntry.CreationInProgress)
 		require.Equal(t, teamEK.Metadata.Generation, cacheEntry.Generation)
 
 		// verify deviceEK
@@ -178,12 +183,12 @@ func TestNewTeamEKNeeded(t *testing.T) {
 
 		teamEKNeeded, err := ekLib.NewTeamEKNeeded(context.Background(), teamID)
 		require.NoError(t, err)
-		require.False(t, teamEKNeeded)
+		require.Equal(t, teamEKCreationInProgress, teamEKNeeded)
 	}
 
 	// If we retry keygen, we don't regenerate keys
-	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
-	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /* teamEKCreationInProgress */)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /* teamEKCreationInProgress */)
 
 	rawDeviceEKStorage := NewDeviceEKStorage(tc.G)
 	rawUserEKBoxStorage := NewUserEKBoxStorage(tc.G)
@@ -194,14 +199,14 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	err = rawTeamEKBoxStorage.Delete(context.Background(), teamID, expectedTeamEKGen)
 	require.NoError(t, err)
 	teamEKBoxStorage.ClearCache()
-	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /* teamEKCreationInProgress */)
 
 	// Now let's kill our userEK, we should gracefully not regenerate
 	// since we can still fetch the userEK from the server.
 	err = rawUserEKBoxStorage.Delete(context.Background(), expectedUserEKGen)
 	require.NoError(t, err)
 	tc.G.GetDeviceEKStorage().ClearCache()
-	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /* teamEKCreationInProgress */)
 
 	// Now let's kill our deviceEK as well, and we should generate all new keys
 	err = rawDeviceEKStorage.Delete(context.Background(), expectedDeviceEKGen)
@@ -210,14 +215,14 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	expectedDeviceEKGen++
 	expectedUserEKGen++
 	expectedTeamEKGen++
-	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /* teamEKCreationInProgress */)
 
 	// If we try to access an older teamEK that we cannot access, we don't
 	// create a new teamEK
 	teamEK, err := ekLib.GetTeamEK(context.Background(), teamID, expectedTeamEKGen-1)
 	require.Error(t, err)
 	require.Equal(t, teamEK, keybase1.TeamEk{})
-	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /* teamEKCreationInProgress */)
 
 	// Now let's kill our deviceEK but corrupting a single bit in the
 	// noiseFile, so we can no longer access the latest teamEK and will
@@ -244,7 +249,38 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	expectedDeviceEKGen++
 	expectedUserEKGen++
 	expectedTeamEKGen++
-	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /* teamEKCreationInProgress */)
+
+	// Expire our cache entry so we can test background creation.
+	fc.Advance(cacheEntryLifetime)
+	ch := make(chan bool, 1)
+	ekLib.setBackgroundCreationTestCh(ch)
+
+	// Fake the teamEK creation time so we are forced to generate a new one.
+	rawTeamEKBoxStorage.Get(context.Background(), teamID, expectedTeamEKGen)
+	teamEKBoxes, found, err := rawTeamEKBoxStorage.getMap(context.Background(), teamID)
+	require.NoError(t, err)
+	require.True(t, found)
+	teamEKBoxed, ok := teamEKBoxes[expectedTeamEKGen]
+	require.True(t, ok)
+	teamEKBoxed.Metadata.Ctime = keybase1.ToTime(teamEKBoxed.Metadata.Ctime.Time().Add(-time.Second * time.Duration(2*KeyGenLifetimeSecs)))
+	err = teamEKBoxStorage.Put(context.Background(), teamID, expectedTeamEKGen, teamEKBoxed)
+	require.NoError(t, err)
+
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, true /* teamEKCreationInProgress */)
+	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, true /* teamEKCreationInProgress */)
+	// Signal background generation should start
+	ch <- true
+
+	// Wait until background generation completes
+	select {
+	case <-ch:
+		expectedTeamEKGen++
+		assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /* teamEKCreationInProgress */)
+	case <-time.After(time.Second * 20):
+		t.Fatalf("teamEK background creation failed")
+	}
+	close(ch)
 }
 
 func TestCleanupStaleUserAndDeviceEKs(t *testing.T) {

--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -36,7 +36,7 @@ type Client struct {
 	Sm      gregor.StateMachine
 	Storage LocalStorageEngine
 	Log     logger.Logger
-	Clock   clockwork.Clock
+	clock   clockwork.Clock
 
 	incomingClient func() gregor1.IncomingInterface
 	outboxSendCh   chan struct{}
@@ -48,14 +48,14 @@ type Client struct {
 }
 
 func NewClient(user gregor.UID, device gregor.DeviceID, createSm func() gregor.StateMachine,
-	storage LocalStorageEngine, incomingClient func() gregor1.IncomingInterface, log logger.Logger) *Client {
+	storage LocalStorageEngine, incomingClient func() gregor1.IncomingInterface, log logger.Logger, clock clockwork.Clock) *Client {
 	c := &Client{
 		User:           user,
 		Device:         device,
 		Sm:             createSm(),
 		Storage:        storage,
 		Log:            log,
-		Clock:          clockwork.NewRealClock(),
+		clock:          clockwork.NewRealClock(),
 		outboxSendCh:   make(chan struct{}, 100),
 		stopCh:         make(chan struct{}),
 		incomingClient: incomingClient,
@@ -503,11 +503,11 @@ func (c *Client) outboxSend() {
 }
 
 func (c *Client) outboxSendLoop() {
-	deadline := c.Clock.Now().Add(time.Minute)
+	deadline := c.clock.Now().Add(time.Minute)
 	for {
 		var now time.Time
 		select {
-		case now = <-c.Clock.AfterTime(deadline):
+		case now = <-c.clock.AfterTime(deadline):
 			c.outboxSend()
 		case <-c.outboxSendCh:
 			c.outboxSend()

--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -55,7 +55,7 @@ func NewClient(user gregor.UID, device gregor.DeviceID, createSm func() gregor.S
 		Sm:             createSm(),
 		Storage:        storage,
 		Log:            log,
-		clock:          clockwork.NewRealClock(),
+		clock:          clock,
 		outboxSendCh:   make(chan struct{}, 100),
 		stopCh:         make(chan struct{}),
 		incomingClient: incomingClient,

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -367,7 +367,7 @@ func (g *gregorHandler) resetGregorClient(ctx context.Context) (err error) {
 	// Create client object
 	gcli := grclient.NewClient(guid, gdid, func() gregor.StateMachine {
 		return storage.NewMemEngine(of, clockwork.NewRealClock(), g.G().Log)
-	}, storage.NewLocalDB(g.G().ExternalG()), g.GetIncomingClient, g.G().Log)
+	}, storage.NewLocalDB(g.G().ExternalG()), g.GetIncomingClient, g.G().Log, clockwork.NewRealClock())
 
 	// Bring up local state
 	g.Debug(ctx, "restoring state from leveldb")

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -971,13 +971,12 @@ func TestOfflineConsume(t *testing.T) {
 	defer h.Shutdown()
 
 	fclient := newFlakeyIncomingClient(func() gregor1.IncomingInterface { return server })
+	fc := clockwork.NewFakeClock()
 	client := grclient.NewClient(uid, nil, func() gregor.StateMachine {
-		return storage.NewMemEngine(gregor1.ObjFactory{}, clockwork.NewRealClock(), tc.G.GetLog())
+		return storage.NewMemEngine(gregor1.ObjFactory{}, clockwork.NewRealClock(), tc.G.GetLog(), fc)
 	}, storage.NewLocalDB(tc.G), func() gregor1.IncomingInterface { return fclient }, tc.G.GetLog())
 	tev := grclient.NewTestingEvents()
 	client.TestingEvents = tev
-	fc := clockwork.NewFakeClock()
-	client.Clock = fc
 	h.gregorCli = client
 
 	// Try to consume offline

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -973,8 +973,8 @@ func TestOfflineConsume(t *testing.T) {
 	fclient := newFlakeyIncomingClient(func() gregor1.IncomingInterface { return server })
 	fc := clockwork.NewFakeClock()
 	client := grclient.NewClient(uid, nil, func() gregor.StateMachine {
-		return storage.NewMemEngine(gregor1.ObjFactory{}, clockwork.NewRealClock(), tc.G.GetLog(), fc)
-	}, storage.NewLocalDB(tc.G), func() gregor1.IncomingInterface { return fclient }, tc.G.GetLog())
+		return storage.NewMemEngine(gregor1.ObjFactory{}, clockwork.NewRealClock(), tc.G.GetLog())
+	}, storage.NewLocalDB(tc.G), func() gregor1.IncomingInterface { return fclient }, tc.G.GetLog(), fc)
 	tev := grclient.NewTestingEvents()
 	client.TestingEvents = tev
 	h.gregorCli = client


### PR DESCRIPTION
If we have access to the current teamEK but it is expired (daily keygen needed) we can now do this generation in the background and temporarily use the old teamEK. Since we lazily create teamEKs for large teams, it can be a burn to get stuck with the daily generation and have you message hang (seemingly randomly) while this is happening. 

note this will conflict with https://github.com/keybase/client/pull/12546 because we reference `KeyGenLifetimeSecs` in tests