### PR TITLE
reset first connect bit on logout CORE-8178

### DIFF
--- a/go/service/main.go
+++ b/go/service/main.go
@@ -767,18 +767,17 @@ func (d *Service) OnLogin() error {
 
 func (d *Service) OnLogout() (err error) {
 	defer d.G().Trace("Service#OnLogout", func() error { return err })()
-
 	log := func(s string) {
 		d.G().Log.Debug("Service#OnLogout: %s", s)
 	}
 
-	log("shutting down gregor")
-	if d.gregor != nil {
-		d.gregor.Shutdown()
-	}
-
 	log("shutting down chat modules")
 	d.stopChatModules()
+
+	log("shutting down gregor")
+	if d.gregor != nil {
+		d.gregor.Reset()
+	}
 
 	log("shutting down rekeyMaster")
 	d.rekeyMaster.Logout()


### PR DESCRIPTION
The `firstConnect` bit is used to control the form of the badger result we get back for chat when connecting to Gregor. On logout, we need to make sure to reset this back to true so we get the full badge state.