### PR TITLE
Don't black-bar API network errors when offline

### DIFF
--- a/shared/app/global-errors/container.js
+++ b/shared/app/global-errors/container.js
@@ -4,12 +4,14 @@ import {connect, type TypedState, type Dispatch} from '../../util/container'
 import * as ConfigGen from '../../actions/config-gen'
 import {settingsTab} from '../../constants/tabs'
 import {feedbackTab} from '../../constants/settings'
+import {reachabilityReachable, constantsStatusCode} from '../../constants/types/rpc-gen'
 import {navigateTo, switchTo} from '../../actions/route-tree'
 
 const mapStateToProps = (state: TypedState) => ({
   daemonError: state.config.daemonError,
   debugDump: state.config.debugDump,
   error: state.config.globalError,
+  reachable: state.gregor.reachability.reachable,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -34,4 +36,24 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
 })
 
-export default connect(mapStateToProps, mapDispatchToProps)(GlobalError)
+const mergeProps = (stateProps, dispatchProps) => {
+  let error = stateProps.error
+  // If we're offline, ignore any API network errors.
+  if (
+    stateProps.reachable === reachabilityReachable.no &&
+    error &&
+    error.code === constantsStatusCode.scapinetworkerror
+  ) {
+    error = null
+  }
+
+  return {
+    error,
+    daemonError: stateProps.daemonError,
+    debugDump: stateProps.debugDump,
+    onDismiss: dispatchProps.onDismiss,
+    onFeedback: dispatchProps.onFeedback,
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(GlobalError)


### PR DESCRIPTION
This stops black bars when switching to a non-chat tab when offline.