### PR TITLE
Stellar: Show assets in the GUI

### DIFF
--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -6,9 +6,6 @@
       "accountID": "Types.AccountID",
       "assets": "Array<Types.Assets>",
     },
-    "loadEverything": {
-      "_description": "Debugging only -- load accounts/assets/payments for every account at once",
-    },
     "loadAssets": {
       "_description": "Refresh our list of assets for a given account",
       "accountID": "Types.AccountID",

--- a/shared/actions/wallets-gen.js
+++ b/shared/actions/wallets-gen.js
@@ -12,7 +12,6 @@ export const accountsReceived = 'wallets:accountsReceived'
 export const assetsReceived = 'wallets:assetsReceived'
 export const loadAccounts = 'wallets:loadAccounts'
 export const loadAssets = 'wallets:loadAssets'
-export const loadEverything = 'wallets:loadEverything'
 export const loadPayments = 'wallets:loadPayments'
 export const paymentsReceived = 'wallets:paymentsReceived'
 export const selectAccount = 'wallets:selectAccount'
@@ -25,7 +24,6 @@ type _AssetsReceivedPayload = $ReadOnly<{|
 |}>
 type _LoadAccountsPayload = void
 type _LoadAssetsPayload = $ReadOnly<{|accountID: Types.AccountID|}>
-type _LoadEverythingPayload = void
 type _LoadPaymentsPayload = $ReadOnly<{|accountID: Types.AccountID|}>
 type _PaymentsReceivedPayload = $ReadOnly<{|
   accountID: Types.AccountID,
@@ -34,10 +32,6 @@ type _PaymentsReceivedPayload = $ReadOnly<{|
 type _SelectAccountPayload = $ReadOnly<{|accountID: Types.AccountID|}>
 
 // Action Creators
-/**
- * Debugging only -- load accounts/assets/payments for every account at once
- */
-export const createLoadEverything = (payload: _LoadEverythingPayload) => ({error: false, payload, type: loadEverything})
 /**
  * Refresh our list of accounts
  */
@@ -72,7 +66,6 @@ export type AccountsReceivedPayload = $Call<typeof createAccountsReceived, _Acco
 export type AssetsReceivedPayload = $Call<typeof createAssetsReceived, _AssetsReceivedPayload>
 export type LoadAccountsPayload = $Call<typeof createLoadAccounts, _LoadAccountsPayload>
 export type LoadAssetsPayload = $Call<typeof createLoadAssets, _LoadAssetsPayload>
-export type LoadEverythingPayload = $Call<typeof createLoadEverything, _LoadEverythingPayload>
 export type LoadPaymentsPayload = $Call<typeof createLoadPayments, _LoadPaymentsPayload>
 export type PaymentsReceivedPayload = $Call<typeof createPaymentsReceived, _PaymentsReceivedPayload>
 export type SelectAccountPayload = $Call<typeof createSelectAccount, _SelectAccountPayload>
@@ -84,7 +77,6 @@ export type Actions =
   | AssetsReceivedPayload
   | LoadAccountsPayload
   | LoadAssetsPayload
-  | LoadEverythingPayload
   | LoadPaymentsPayload
   | PaymentsReceivedPayload
   | SelectAccountPayload

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -3,9 +3,7 @@ import * as Constants from '../constants/wallets'
 import * as Types from '../constants/types/wallets'
 import * as RPCTypes from '../constants/types/rpc-stellar-gen'
 import * as Saga from '../util/saga'
-import * as WaitingGen from './waiting-gen'
 import * as WalletsGen from './wallets-gen'
-import type {TypedState} from '../util/container'
 
 const loadAccounts = (action: WalletsGen.LoadAccountsPayload) =>
   Saga.call(RPCTypes.localGetWalletAccountsLocalRpcPromise)

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -38,10 +38,16 @@ const loadPaymentsSuccess = (res: any, action: WalletsGen.LoadPaymentsPayload) =
   return Saga.put(
     WalletsGen.createPaymentsReceived({
       accountID,
-      payments: res.map(elem => Constants.paymentResultToPayment(elem)),
+      payments: res.payments.map(elem => Constants.paymentResultToPayment(elem)),
     })
   )
 }
+
+const loadAccount = (action: WalletsGen.SelectAccountPayload) =>
+  Saga.all([
+    Saga.put(WalletsGen.createLoadAssets({accountID: action.payload.accountID})),
+    Saga.put(WalletsGen.createLoadPayments({accountID: action.payload.accountID})),
+  ])
 
 function* loadEverything(action: WalletsGen.LoadEverythingPayload) {
   if (__DEV__) {
@@ -60,6 +66,7 @@ function* loadEverything(action: WalletsGen.LoadEverythingPayload) {
 
 function* walletsSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPure(WalletsGen.loadAccounts, loadAccounts, loadAccountsSuccess)
+  yield Saga.safeTakeEveryPure(WalletsGen.selectAccount, loadAccount)
   yield Saga.safeTakeEveryPure(WalletsGen.loadAssets, loadAssets, loadAssetsSuccess)
   yield Saga.safeTakeEveryPure(WalletsGen.loadPayments, loadPayments, loadPaymentsSuccess)
   // Debugging saga -- remove before launching.

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -43,36 +43,12 @@ const loadPaymentsSuccess = (res: any, action: WalletsGen.LoadPaymentsPayload) =
   )
 }
 
-const loadAccount = (action: WalletsGen.SelectAccountPayload) =>
-  Saga.all([
-    Saga.put(WalletsGen.createLoadAssets({accountID: action.payload.accountID})),
-    Saga.put(WalletsGen.createLoadPayments({accountID: action.payload.accountID})),
-  ])
-
-function* loadEverything(action: WalletsGen.LoadEverythingPayload) {
-  if (__DEV__) {
-    yield Saga.put(WaitingGen.createIncrementWaiting({key: Constants.loadEverythingWaitingKey}))
-    yield Saga.put(WalletsGen.createLoadAccounts())
-    yield Saga.take(WalletsGen.accountsReceived)
-    const state: TypedState = yield Saga.select()
-    const accounts = state.wallets.accountMap.keys()
-    for (const accountID of accounts) {
-      yield Saga.put(WalletsGen.createLoadAssets({accountID}))
-      yield Saga.put(WalletsGen.createLoadPayments({accountID}))
-    }
-    yield Saga.put(WaitingGen.createDecrementWaiting({key: Constants.loadEverythingWaitingKey}))
-  }
-}
-
 function* walletsSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPure(WalletsGen.loadAccounts, loadAccounts, loadAccountsSuccess)
-  yield Saga.safeTakeEveryPure(WalletsGen.selectAccount, loadAccount)
   yield Saga.safeTakeEveryPure(WalletsGen.loadAssets, loadAssets, loadAssetsSuccess)
   yield Saga.safeTakeEveryPure(WalletsGen.loadPayments, loadPayments, loadPaymentsSuccess)
-  // Debugging saga -- remove before launching.
-  if (__DEV__) {
-    yield Saga.safeTakeEvery(WalletsGen.loadEverything, loadEverything)
-  }
+  yield Saga.safeTakeEveryPure(WalletsGen.selectAccount, loadAssets, loadAssetsSuccess)
+  yield Saga.safeTakeEveryPure(WalletsGen.selectAccount, loadPayments, loadPaymentsSuccess)
 }
 
 export default walletsSaga

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -107,12 +107,13 @@ const loadEverythingWaitingKey = 'wallets:loadEverything'
 
 const getAccountIDs = (state: TypedState) => state.wallets.accountMap.keySeq().toList()
 
-const getAccount = (state: TypedState, accountID: Types.AccountID) =>
-  state.wallets.accountMap.get(accountID, makeAccount())
-
 const getSelectedAccount = (state: TypedState) => state.wallets.selectedAccount
 
-const getAssets = (state: TypedState, accountID: Types.AccountID) => state.wallets.assetsMap.get(accountID, I.List())
+const getAccount = (state: TypedState, accountID?: Types.AccountID) =>
+  state.wallets.accountMap.get(accountID || getSelectedAccount(state), makeAccount())
+
+const getAssets = (state: TypedState, accountID?: Types.AccountID) =>
+  state.wallets.assetsMap.get(accountID || getSelectedAccount(state), I.List())
 
 export {
   accountResultToAccount,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -112,6 +112,8 @@ const getAccount = (state: TypedState, accountID: Types.AccountID) =>
 
 const getSelectedAccount = (state: TypedState) => state.wallets.selectedAccount
 
+const getAssets = (state: TypedState, accountID: Types.AccountID) => state.wallets.assetsMap.get(accountID, I.List())
+
 export {
   accountResultToAccount,
   assetsResultToAssets,
@@ -124,5 +126,6 @@ export {
   paymentResultToPayment,
   getAccountIDs,
   getAccount,
+  getAssets,
   getSelectedAccount,
 }

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -20,7 +20,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.selectAccount:
       return state.set('selectedAccount', action.payload.accountID)
     // Saga only actions
-    case WalletsGen.loadEverything:
     case WalletsGen.loadAssets:
     case WalletsGen.loadPayments:
     case WalletsGen.loadAccounts:

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -84,9 +84,8 @@ const middlewares = [
   errorCatching,
   createSagaMiddleware(crashHandler),
   thunkMiddleware,
-  //...(enableStoreLogging && loggerMiddleware ? [loggerMiddleware] : []),
-  //...(enableActionLogging ? [actionLogger] : []),
-  createLogger(),
+  ...(enableStoreLogging && loggerMiddleware ? [loggerMiddleware] : []),
+  ...(enableActionLogging ? [actionLogger] : []),
 ]
 
 if (__DEV__ && typeof window !== 'undefined') {

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -84,8 +84,9 @@ const middlewares = [
   errorCatching,
   createSagaMiddleware(crashHandler),
   thunkMiddleware,
-  ...(enableStoreLogging && loggerMiddleware ? [loggerMiddleware] : []),
-  ...(enableActionLogging ? [actionLogger] : []),
+  //...(enableStoreLogging && loggerMiddleware ? [loggerMiddleware] : []),
+  //...(enableActionLogging ? [actionLogger] : []),
+  createLogger(),
 ]
 
 if (__DEV__ && typeof window !== 'undefined') {

--- a/shared/wallets/asset/container.js
+++ b/shared/wallets/asset/container.js
@@ -1,0 +1,32 @@
+// @flow
+import {Assets} from '.'
+import {connect, type TypedState, type Dispatch} from '../../util/container'
+import {getAssets, getSelectedAccount} from '../../constants/wallets'
+
+const mapStateToProps = (state: TypedState) => {
+  const selectedAccount = getSelectedAccount(state)
+  const assets = getAssets(state, selectedAccount)
+  return {
+    assets,
+  }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({})
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  assets: stateProps.assets
+    .map(asset => ({
+      availableToSend: asset.balanceAvailableToSend,
+      balance: asset.balanceTotal,
+      code: asset.assetCode,
+      equivAvailableToSend: '', // XXX: Need this from core.
+      equivBalance: `${asset.worth} ${asset.worthCurrency}`,
+      issuer: asset.issuer,
+      issuerAddress: '', // XXX: Need this from core.
+      name: asset.name,
+      reserves: [], // XXX: Need this from core.
+    }))
+    .toArray(),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Assets)

--- a/shared/wallets/asset/container.js
+++ b/shared/wallets/asset/container.js
@@ -9,20 +9,29 @@ const mapStateToProps = (state: TypedState) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
-const mergeProps = (stateProps, dispatchProps, ownProps) => ({
-  assets: stateProps.assets
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  const assets = stateProps.assets
     .map(asset => ({
-      availableToSend: asset.balanceAvailableToSend,
-      balance: asset.balanceTotal,
-      code: asset.assetCode,
-      equivAvailableToSend: '', // XXX: Need this from core.
-      equivBalance: `${asset.worth} ${asset.worthCurrency}`,
-      issuer: asset.issuer,
-      issuerAddress: '', // XXX: Need this from core.
-      name: asset.name,
-      reserves: [], // XXX: Need this from core.
+      asset: {
+        availableToSend: asset.balanceAvailableToSend,
+        balance: asset.balanceTotal,
+        code: asset.assetCode,
+        equivAvailableToSend: '', // XXX: Need this from core.
+        equivBalance: `${asset.worth} ${asset.worthCurrency}`,
+        issuer: asset.issuer,
+        issuerAddress: '', // XXX: Need this from core.
+        name: asset.name,
+        reserves: [], // XXX: Need this from core.
+      },
+      type: 'asset',
     }))
-    .toArray(),
-})
+    .toArray()
+  if (assets.length > 0) {
+    assets.unshift({type: 'header'})
+  }
+  return {
+    assets,
+  }
+}
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Assets)

--- a/shared/wallets/asset/container.js
+++ b/shared/wallets/asset/container.js
@@ -1,15 +1,11 @@
 // @flow
 import {Assets} from '.'
 import {connect, type TypedState, type Dispatch} from '../../util/container'
-import {getAssets, getSelectedAccount} from '../../constants/wallets'
+import {getAssets} from '../../constants/wallets'
 
-const mapStateToProps = (state: TypedState) => {
-  const selectedAccount = getSelectedAccount(state)
-  const assets = getAssets(state, selectedAccount)
-  return {
-    assets,
-  }
-}
+const mapStateToProps = (state: TypedState) => ({
+  assets: getAssets(state),
+})
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({})
 

--- a/shared/wallets/asset/index.js
+++ b/shared/wallets/asset/index.js
@@ -120,6 +120,10 @@ const IssuerAddress = (props: IssuerAddressProps) => (
 )
 
 const styles = styleSheetCreate({
+  assetHeader: {
+    backgroundColor: globalColors.blue5,
+    padding: globalMargins.xtiny,
+  },
   balanceContainer: {
     alignItems: 'flex-end',
     justifyContent: 'flex-start',
@@ -171,16 +175,14 @@ export class AssetWrapped extends React.Component<Props, AssetWrappedState> {
   )
 }
 
+type Row = {type: 'asset', asset: Props} | {type: 'header'}
+
 type AssetsProps = {
-  assets: Array<Props>,
+  assets: Array<Row>,
 }
 
 const AssetHeader = () => (
-  <Box2
-    direction="vertical"
-    fullWidth={true}
-    style={{backgroundColor: globalColors.blue5, padding: globalMargins.xtiny}}
-  >
+  <Box2 direction="vertical" fullWidth={true} style={styles.assetHeader}>
     <Text type="BodySmallSemibold">Your assets</Text>
   </Box2>
 )
@@ -201,16 +203,5 @@ export class Assets extends React.Component<AssetsProps> {
     }
   }
 
-  render = () => {
-    const rows = this.props.assets.map(asset => ({
-      asset,
-      type: 'asset',
-    }))
-    if (rows.length > 0) {
-      rows.unshift({type: 'header'})
-    }
-    return <List items={rows} renderItem={this._renderRow} keyProperty="key" />
-  }
+  render = () => <List items={this.props.assets} renderItem={this._renderRow} keyProperty="key" />
 }
-
-type Row = {type: 'asset', asset: Props} | {type: 'header'}

--- a/shared/wallets/asset/index.js
+++ b/shared/wallets/asset/index.js
@@ -175,19 +175,21 @@ type AssetsProps = {
   assets: Array<Props>,
 }
 
+const AssetHeader = () => (
+  <Box2
+    direction="vertical"
+    fullWidth={true}
+    style={{backgroundColor: globalColors.blue5, padding: globalMargins.xtiny}}
+  >
+    <Text type="BodySmallSemibold">Your assets</Text>
+  </Box2>
+)
+
 export class Assets extends React.Component<AssetsProps> {
   _renderRow = (i: number, row: Row): React.Node => {
     switch (row.type) {
       case 'header':
-        return (
-          <Box2
-            direction="vertical"
-            fullWidth={true}
-            style={{backgroundColor: globalColors.blue5, padding: globalMargins.xtiny}}
-          >
-            <Text type="BodySmallSemibold">Your assets</Text>
-          </Box2>
-        )
+        return <AssetHeader />
       case 'asset':
         return <AssetWrapped {...row.asset} />
       default:

--- a/shared/wallets/container.js
+++ b/shared/wallets/container.js
@@ -9,7 +9,7 @@ const mapStateToProps = (state: TypedState) => ({})
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
   onBack: () => dispatch(navigateUp()),
-  refresh: () => dispatch(WalletsGen.createLoadEverything()),
+  refresh: () => dispatch(WalletsGen.createLoadAccounts()),
 })
 
 const mergeProps = (stateProps, dispatchProps) => ({

--- a/shared/wallets/container.js
+++ b/shared/wallets/container.js
@@ -3,7 +3,6 @@ import Wallets from '.'
 import * as WalletsGen from '../actions/wallets-gen'
 import {compose, connect, lifecycle, type TypedState, type Dispatch} from '../util/container'
 import {HeaderOnMobile} from '../common-adapters'
-import {loadEverythingWaitingKey} from '../constants/wallets'
 
 const mapStateToProps = (state: TypedState) => ({})
 
@@ -16,7 +15,6 @@ const mergeProps = (stateProps, dispatchProps) => ({
   onBack: dispatchProps.onBack,
   refresh: dispatchProps.refresh,
   title: 'Wallets',
-  waitingKey: loadEverythingWaitingKey,
 })
 
 export default compose(

--- a/shared/wallets/index.js
+++ b/shared/wallets/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {Box2, WaitingButton} from '../common-adapters'
+import {Box2} from '../common-adapters'
 import WalletList from './wallet-list/container'
 import Assets from './asset/container'
 
@@ -10,10 +10,9 @@ type Props = {
 }
 
 const Wallets = ({refresh, waitingKey}: Props) => (
-  <Box2 direction="horizontal" fullHeight={true} fullWidth={true} gap="small">
+  <Box2 direction="horizontal" fullHeight={true} fullWidth={true} gap="xtiny">
     <WalletList style={{height: '100%', maxWidth: 240}} />
-    <Box2 direction="vertical" style={{flexGrow: 1}} fullHeight={true} gap="medium" gapStart={true} gapEnd={true}>
-      <WaitingButton type="Primary" label="Refresh wallets" onClick={refresh} waitingKey={waitingKey} />
+    <Box2 direction="vertical" style={{flexGrow: 1}} fullHeight={true} gap="small" gapStart={true} gapEnd={true}>
       <Assets />
     </Box2>
   </Box2>

--- a/shared/wallets/index.js
+++ b/shared/wallets/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {Box2, WaitingButton} from '../common-adapters'
 import WalletList from './wallet-list/container'
+import Assets from './asset/container'
 
 type Props = {
   refresh: () => void,
@@ -11,8 +12,9 @@ type Props = {
 const Wallets = ({refresh, waitingKey}: Props) => (
   <Box2 direction="horizontal" fullHeight={true} fullWidth={true} gap="small">
     <WalletList style={{height: '100%', maxWidth: 240}} />
-    <Box2 direction="vertical" fullHeight={true} gap="xlarge" gapStart={true} gapEnd={true}>
+    <Box2 direction="vertical" style={{flexGrow: 1}} fullHeight={true} gap="medium" gapStart={true} gapEnd={true}>
       <WaitingButton type="Primary" label="Refresh wallets" onClick={refresh} waitingKey={waitingKey} />
+      <Assets />
     </Box2>
   </Box2>
 )


### PR DESCRIPTION
@keybase/react-hackers 

This PR:

1. Hooks up showing assets in the GUI. They're loaded on-demand when you click on an account in the account list.  There are a few missing fields on the CORE side, nothing very important, I'm filing a CORE bug for those.
2. Fixes a black bar on master due to an RPC payload change -- `res.map` => `res.payments.map`
3. Fixes the account list on master. The account list was depending on the dev-only `loadEverything` RPC to perform its data load, but this code is live on admin builds (with `__DEV__` false) now, so this call wasn't doing anything.  Now we  `loadAccounts` when the main component loads, and `loadAssets` and `loadPayments` when you select an account.  So, `loadEverything` can be retired now.

There should soon be one scrollable List with sections for assets and payments, rather than a list of assets and a list of payments.  I haven't done that here, but we're using `<List />` for everything so combining them later should be straightforward.