### PR TITLE
Don't try to run the installer binary on Linux

### DIFF
--- a/shared/desktop/app/installer.desktop.js
+++ b/shared/desktop/app/installer.desktop.js
@@ -45,8 +45,8 @@ type CheckErrorsResult = {
 // Reminder: hot-server doesn't reload code in here (/desktop)
 export default (callback: (err: any) => void): void => {
   logger.info('Installer check starting now')
-  if (isWindows) {
-    logger.info('Skipping installer on win32')
+  if (isWindows || isLinux) {
+    logger.info('Skipping installer on this platform')
     callback(null)
     return
   }

--- a/shared/desktop/app/installer.desktop.js
+++ b/shared/desktop/app/installer.desktop.js
@@ -3,7 +3,7 @@ import * as SafeElectron from '../../util/safe-electron.desktop'
 import exec from './exec.desktop'
 import {keybaseBinPath} from './paths.desktop'
 import {quit} from './ctl.desktop'
-import {isWindows} from '../../constants/platform'
+import {isLinux, isWindows} from '../../constants/platform'
 import logger from '../../logger'
 import {
   ExitCodeFuseKextError,


### PR DESCRIPTION
@keybase/react-hackers 

We were worried that users were crashing because the installer binary isn't found on Linux.  I verified that this doesn't cause a crash -- it's not a throw, just an error being returned and printed.  But we were skipping this code entirely on Windows, so let's do that on Linux too.  Neither platform needs to run an installer at app startup.