### PR TITLE
Fix android background job

### DIFF
--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -181,5 +181,5 @@ dependencies {
     compile project(':react-native-image-picker')
     compile project(':react-native-fetch-blob')
     compile project(':react-native-contacts')
-    compile 'com.evernote:android-job:1.2.5'
+    compile 'com.evernote:android-job:1.2.6'
 }

--- a/shared/react-native/android/app/src/main/AndroidManifest.xml
+++ b/shared/react-native/android/app/src/main/AndroidManifest.xml
@@ -62,6 +62,9 @@
               <action android:name="com.google.android.c2dm.intent.RECEIVE" />
           </intent-filter>
       </service>
+      <service android:name="com.evernote.android.job.gcm.PlatformGcmService"
+          android:enabled="true"
+          tools:replace="android:enabled"/>
       <provider
           android:name="io.keybase.ossifrage.util.SharedFileProvider"
           android:authorities="${applicationId}.fileprovider"

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -1,6 +1,7 @@
 package io.keybase.ossifrage;
 
 import android.app.Application;
+
 import com.evernote.android.job.JobManager;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
@@ -34,8 +35,13 @@ public class MainApplication extends Application implements ReactApplication {
     SoLoader.init(this, /* native exopackage */ false);
     JobManager manager = JobManager.create(this);
     manager.addJobCreator(new BackgroundJobCreator());
-    if (manager.getAllJobRequestsForTag(BackgroundSyncJob.TAG).size() == 0) {
-        // Setup a background job
+
+    // Make sure exactly one background job is scheduled.
+    int numBackgroundJobs = manager.getAllJobRequestsForTag(BackgroundSyncJob.TAG).size();
+    if (numBackgroundJobs == 0) {
+        BackgroundSyncJob.scheduleJob();
+    } else if (numBackgroundJobs >1 ) {
+        manager.cancelAllForTag(BackgroundSyncJob.TAG);
         BackgroundSyncJob.scheduleJob();
     }
 


### PR DESCRIPTION
The library we use for scheduling background jobs published a new version that fixes a crash we were seeing when using GCM for background scheduling (https://github.com/evernote/android-job/commit/e9e03df03660b923790f57f1e7b9d13198f67e92). We also add the GCM service to the manifest manually: https://github.com/evernote/android-job#google-play-services, and ensure that we only have a single background job scheduled (which would have been possible before https://github.com/keybase/client/pull/12140).

The evernote library notes we should consider switching to [WorkManager](https://developer.android.com/reference/androidx/work/WorkManager) in the future as a replacement, which is an alpha library which offers the same functionality as the evernote one. We should keep an eye on this and consider upgrading once it's out of alpha and especially if the evernote library is deprecated.

cc @keybase/react-hackers 