### PR TITLE
Add global tab shortcuts.

### DIFF
--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -33,7 +33,7 @@ type Props = {
   routePath: I.List<string>,
 }
 
-const hotKeyTabMap: {[string]: Tab} = {
+const hotkeyTabMap: {[string]: Tab} = {
   '1': peopleTab,
   '2': chatTab,
   '3': fsTab,
@@ -41,12 +41,10 @@ const hotKeyTabMap: {[string]: Tab} = {
   '5': devicesTab,
   '6': gitTab,
   '7': settingsTab,
-}
-if (flags.walletsEnabled) {
-  hotKeyTabMap['8'] = walletsTab
+  ...(flags.walletsEnabled ? {'8': walletsTab} : {}),
 }
 
-const hotkeys = Object.keys(hotKeyTabMap).map(key => `${isDarwin ? 'command' : 'control'}+${key}`)
+const hotkeys = Object.keys(hotkeyTabMap).map(key => `${isDarwin ? 'command' : 'control'}+${key}`)
 
 class Nav extends React.Component<Props> {
   render() {
@@ -92,8 +90,9 @@ const mapStateToProps = (state: TypedState) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   _onHotkey: (cmd: string) => {
-    if (hotkeys.includes(cmd)) {
-      dispatch(navigateTo([hotKeyTabMap[cmd.replace(/(command|control)\+/, '')]]))
+    const tab = hotkeyTabMap[cmd.replace(/(command|control)\+/, '')]
+    if (tab) {
+      dispatch(navigateTo([tab]))
     }
   },
 })

--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -31,7 +31,7 @@ type Props = {
   routePath: I.List<string>,
 }
 
-const hotKeyTabMap = {
+const hotKeyTabMap: {[string]: Tab} = {
   '1': peopleTab,
   '2': chatTab,
   '3': fsTab,

--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -46,6 +46,8 @@ if (flags.walletsEnabled) {
   hotKeyTabMap['8'] = walletsTab
 }
 
+const hotkeys = Object.keys(hotKeyTabMap).map(key => `${isDarwin ? 'command' : 'control'}+${key}`)
+
 class Nav extends React.Component<Props> {
   render() {
     const {routeSelected, routePath, visibleScreen, layerScreens} = this.props
@@ -54,7 +56,7 @@ class Nav extends React.Component<Props> {
         <Box style={stylesTabsContainer}>
           {routeSelected !== loginTab && (
             <TabBar
-              hotkeys={Object.keys(hotKeyTabMap).map(key => `${isDarwin ? 'command' : 'control'}+${key}`)}
+              hotkeys={hotkeys}
               onHotkey={this.props.onHotkey}
               routeSelected={routeSelected}
               routePath={routePath}

--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -25,7 +25,7 @@ import RpcStats from './rpc-stats'
 
 type Props = {
   layerScreens: I.Stack<RouteTree.RenderRouteResult>,
-  onHotKey: (cmd: string) => void,
+  onHotkey: (cmd: string) => void,
   visibleScreen: RouteTree.RenderRouteResult,
   routeSelected: Tab,
   routePath: I.List<string>,
@@ -50,7 +50,7 @@ class Nav extends React.Component<Props> {
           {routeSelected !== loginTab && (
             <TabBar
               hotkeys={Object.keys(hotKeyTabMap).map(key => `${isDarwin ? 'command' : 'control'}+${key}`)}
-              onHotKey={this.props.onHotKey}
+              onHotkey={this.props.onHotkey}
               routeSelected={routeSelected}
               routePath={routePath}
             />
@@ -84,7 +84,7 @@ const mapStateToProps = (state: TypedState) => ({
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  _onHotKey: (cmd: string) => dispatch(navigateTo([hotKeyTabMap[cmd.replace(/(command|control)\+/, '')]])),
+  _onHotkey: (cmd: string) => dispatch(navigateTo([hotKeyTabMap[cmd.replace(/(command|control)\+/, '')]])),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps): Props => {
@@ -96,7 +96,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps): Props => {
   const layerScreens = ownProps.routeStack.filter(r => r.tags.layerOnTop)
   return {
     layerScreens,
-    onHotKey: dispatchProps._onHotKey,
+    onHotkey: dispatchProps._onHotkey,
     routePath: ownProps.routePath,
     routeSelected: ownProps.routeSelected,
     visibleScreen,

--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -22,6 +22,7 @@ import {
 import {navigateTo} from '../actions/route-tree'
 import {connect, type TypedState, type Dispatch} from '../util/container'
 import {globalStyles} from '../styles'
+import flags from '../util/feature-flags'
 import RpcStats from './rpc-stats'
 
 type Props = {
@@ -40,7 +41,9 @@ const hotKeyTabMap: {[string]: Tab} = {
   '5': devicesTab,
   '6': gitTab,
   '7': settingsTab,
-  '8': walletsTab,
+}
+if (flags.walletsEnabled) {
+  hotKeyTabMap['8'] = walletsTab
 }
 
 class Nav extends React.Component<Props> {

--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -16,6 +16,7 @@ import {
   devicesTab,
   gitTab,
   settingsTab,
+  walletsTab,
   type Tab,
 } from '../constants/tabs'
 import {navigateTo} from '../actions/route-tree'
@@ -39,6 +40,7 @@ const hotKeyTabMap: {[string]: Tab} = {
   '5': devicesTab,
   '6': gitTab,
   '7': settingsTab,
+  '8': walletsTab,
 }
 
 class Nav extends React.Component<Props> {

--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -91,7 +91,11 @@ const mapStateToProps = (state: TypedState) => ({
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  _onHotkey: (cmd: string) => dispatch(navigateTo([hotKeyTabMap[cmd.replace(/(command|control)\+/, '')]])),
+  _onHotkey: (cmd: string) => {
+    if (hotkeys.includes(cmd)) {
+      dispatch(navigateTo([hotKeyTabMap[cmd.replace(/(command|control)\+/, '')]]))
+    }
+  },
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps): Props => {

--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -44,7 +44,7 @@ const hotkeyTabMap: {[string]: Tab} = {
   ...(flags.walletsEnabled ? {'8': walletsTab} : {}),
 }
 
-const hotkeys = Object.keys(hotkeyTabMap).map(key => `${isDarwin ? 'command' : 'control'}+${key}`)
+const hotkeys = Object.keys(hotkeyTabMap).map(key => `${isDarwin ? 'command' : 'ctrl'}+${key}`)
 
 class Nav extends React.Component<Props> {
   render() {
@@ -90,7 +90,7 @@ const mapStateToProps = (state: TypedState) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   _onHotkey: (cmd: string) => {
-    const tab = hotkeyTabMap[cmd.replace(/(command|control)\+/, '')]
+    const tab = hotkeyTabMap[cmd.replace(/(command|ctrl)\+/, '')]
     if (tab) {
       dispatch(navigateTo([tab]))
     }

--- a/shared/app/tab-bar/container.js
+++ b/shared/app/tab-bar/container.js
@@ -2,6 +2,7 @@
 import {connect, type TypedState, type Dispatch, isMobile} from '../../util/container'
 import {usernameSelector} from '../../constants/selectors'
 import TabBarRender from '.'
+import KeyHandler from '../../util/key-handler.desktop'
 import {chatTab, peopleTab, profileTab, type Tab} from '../../constants/tabs'
 import {navigateTo, switchTo} from '../../actions/route-tree'
 import {createShowUserProfile} from '../../actions/profile-gen'
@@ -70,4 +71,4 @@ const mergeProps = (stateProps, dispatchProps, {routeSelected}) => ({
   username: stateProps.username || '',
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(TabBarRender)
+export default KeyHandler(connect(mapStateToProps, mapDispatchToProps, mergeProps)(TabBarRender))

--- a/shared/app/tab-bar/index.desktop.js
+++ b/shared/app/tab-bar/index.desktop.js
@@ -4,7 +4,6 @@ import * as React from 'react'
 import flags from '../../util/feature-flags'
 import {Box} from '../../common-adapters'
 import {TabBarButton} from '../../common-adapters/tab-bar'
-import KeyHandler from '../../util/key-handler.desktop'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
 import type {Props} from './index.types'
 
@@ -92,4 +91,4 @@ const stylesSelectedTabButton = {
   color: globalColors.white,
 }
 
-export default KeyHandler(TabBarRender)
+export default TabBarRender

--- a/shared/app/tab-bar/index.desktop.js
+++ b/shared/app/tab-bar/index.desktop.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 import flags from '../../util/feature-flags'
 import {Box} from '../../common-adapters'
 import {TabBarButton} from '../../common-adapters/tab-bar'
+import KeyHandler from '../../util/key-handler.desktop'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
 import type {Props} from './index.types'
 
@@ -91,4 +92,4 @@ const stylesSelectedTabButton = {
   color: globalColors.white,
 }
 
-export default TabBarRender
+export default KeyHandler(TabBarRender)


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. It add global shortcuts for the desktop app's tabs. E.g., `cmd+1` on macOS will navigate you to the people tab.