### PR TITLE
Use updateCategory rather than injectItem

### DIFF
--- a/shared/actions/gregor-gen.js
+++ b/shared/actions/gregor-gen.js
@@ -10,40 +10,40 @@ import * as RPCTypesGregor from '../constants/types/rpc-gregor-gen'
 // Constants
 export const resetStore = 'common:resetStore' // not a part of gregor but is handled by every reducer
 export const checkReachability = 'gregor:checkReachability'
-export const injectItem = 'gregor:injectItem'
 export const pushOOBM = 'gregor:pushOOBM'
 export const pushState = 'gregor:pushState'
+export const updateCategory = 'gregor:updateCategory'
 export const updateReachability = 'gregor:updateReachability'
 export const updateSeenMsgs = 'gregor:updateSeenMsgs'
 
 // Payload Types
 type _CheckReachabilityPayload = void
-type _InjectItemPayload = $ReadOnly<{|
-  category: string,
-  body: string,
-  dtime?: ?Date,
-|}>
 type _PushOOBMPayload = $ReadOnly<{|messages: Array<RPCTypesGregor.OutOfBandMessage>|}>
 type _PushStatePayload = $ReadOnly<{|
   state: RPCTypesGregor.State,
   reason: RPCTypes.PushReason,
+|}>
+type _UpdateCategoryPayload = $ReadOnly<{|
+  category: string,
+  body: string,
+  dtime?: {offset: number, time: number},
 |}>
 type _UpdateReachabilityPayload = $ReadOnly<{|reachability: RPCTypes.Reachability|}>
 type _UpdateSeenMsgsPayload = $ReadOnly<{|seenMsgs: Array<Types.NonNullGregorItem>|}>
 
 // Action Creators
 export const createCheckReachability = (payload: _CheckReachabilityPayload) => ({error: false, payload, type: checkReachability})
-export const createInjectItem = (payload: _InjectItemPayload) => ({error: false, payload, type: injectItem})
 export const createPushOOBM = (payload: _PushOOBMPayload) => ({error: false, payload, type: pushOOBM})
 export const createPushState = (payload: _PushStatePayload) => ({error: false, payload, type: pushState})
+export const createUpdateCategory = (payload: _UpdateCategoryPayload) => ({error: false, payload, type: updateCategory})
 export const createUpdateReachability = (payload: _UpdateReachabilityPayload) => ({error: false, payload, type: updateReachability})
 export const createUpdateSeenMsgs = (payload: _UpdateSeenMsgsPayload) => ({error: false, payload, type: updateSeenMsgs})
 
 // Action Payloads
 export type CheckReachabilityPayload = $Call<typeof createCheckReachability, _CheckReachabilityPayload>
-export type InjectItemPayload = $Call<typeof createInjectItem, _InjectItemPayload>
 export type PushOOBMPayload = $Call<typeof createPushOOBM, _PushOOBMPayload>
 export type PushStatePayload = $Call<typeof createPushState, _PushStatePayload>
+export type UpdateCategoryPayload = $Call<typeof createUpdateCategory, _UpdateCategoryPayload>
 export type UpdateReachabilityPayload = $Call<typeof createUpdateReachability, _UpdateReachabilityPayload>
 export type UpdateSeenMsgsPayload = $Call<typeof createUpdateSeenMsgs, _UpdateSeenMsgsPayload>
 
@@ -51,9 +51,9 @@ export type UpdateSeenMsgsPayload = $Call<typeof createUpdateSeenMsgs, _UpdateSe
 // prettier-ignore
 export type Actions =
   | CheckReachabilityPayload
-  | InjectItemPayload
   | PushOOBMPayload
   | PushStatePayload
+  | UpdateCategoryPayload
   | UpdateReachabilityPayload
   | UpdateSeenMsgsPayload
   | {type: 'common:resetStore', payload: void}

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -263,13 +263,13 @@ const _handleCheckReachability = (action: GregorGen.CheckReachabilityPayload) =>
 const _handleCheckReachabilitySuccess = reachability =>
   Saga.put(GregorGen.createUpdateReachability({reachability}))
 
-function _injectItem(action: GregorGen.InjectItemPayload) {
+function _updateCategory(action: GregorGen.UpdateCategoryPayload) {
   const {category, body, dtime} = action.payload
-  return Saga.call(RPCTypes.gregorInjectItemRpcPromise, {
+  return Saga.call(RPCTypes.gregorUpdateCategoryRpcPromise, {
     body,
-    cat: category,
-    dtime: {
-      time: dtime || 0,
+    category,
+    dtime: dtime || {
+      time: 0,
       offset: 0,
     },
   })
@@ -278,7 +278,7 @@ function _injectItem(action: GregorGen.InjectItemPayload) {
 function* gregorSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPure(GregorGen.pushState, _handlePushState)
   yield Saga.safeTakeEveryPure(GregorGen.pushOOBM, _handlePushOOBM)
-  yield Saga.safeTakeEveryPure(GregorGen.injectItem, _injectItem)
+  yield Saga.safeTakeEveryPure(GregorGen.updateCategory, _updateCategory)
   yield Saga.safeTakeLatestPure(
     GregorGen.checkReachability,
     _handleCheckReachability,

--- a/shared/actions/json/gregor.json
+++ b/shared/actions/json/gregor.json
@@ -18,10 +18,10 @@
     "updateSeenMsgs": {
       "seenMsgs": "Array<Types.NonNullGregorItem>"
     },
-    "injectItem": {
+    "updateCategory": {
       "category": "string",
       "body": "string",
-      "dtime?": "?Date"
+      "dtime?": "{offset: number, time: number}"
     }
   }
 }

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -1117,20 +1117,14 @@ function* _addTeamWithChosenChannels(action: TeamsGen.AddTeamWithChosenChannelsP
   // update if exists, else create
   if (msgID) {
     logger.info(`${logPrefix} Updating teamsWithChosenChannels`)
-    yield Saga.call(RPCTypes.gregorUpdateItemRpcPromise, {
-      body: JSON.stringify(teams),
-      cat: Constants.chosenChannelsGregorKey,
-      dtime,
-      msgID,
-    })
   } else {
     logger.info(`${logPrefix} Creating teamsWithChosenChannels`)
-    yield Saga.call(RPCTypes.gregorInjectItemRpcPromise, {
-      body: JSON.stringify(teams),
-      cat: Constants.chosenChannelsGregorKey,
-      dtime,
-    })
   }
+  yield Saga.call(RPCTypes.gregorUpdateCategoryRpcPromise, {
+    body: JSON.stringify(teams),
+    category: Constants.chosenChannelsGregorKey,
+    dtime,
+  })
 }
 
 function _updateChannelname(action: TeamsGen.UpdateChannelNamePayload, state: TypedState) {

--- a/shared/reducers/gregor.js
+++ b/shared/reducers/gregor.js
@@ -26,7 +26,7 @@ export default function(state: Types.State = Constants.initialState, action: Gre
       }
     // Saga only actions
     case GregorGen.checkReachability:
-    case GregorGen.injectItem:
+    case GregorGen.updateCategory:
     case GregorGen.pushOOBM:
     case GregorGen.pushState:
       return state

--- a/shared/teams/container.js
+++ b/shared/teams/container.js
@@ -33,7 +33,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       ])
     )
   },
-  onHideChatBanner: () => dispatch(GregorGen.createInjectItem({category: 'sawChatBanner', body: 'true'})),
+  onHideChatBanner: () => dispatch(GregorGen.createUpdateCategory({body: 'true', category: 'sawChatBanner'})),
   onJoinTeam: () => {
     dispatch(navigateAppend(['showJoinTeamDialog']))
   },

--- a/shared/teams/team/subteams-tab/intro-row/container.js
+++ b/shared/teams/team/subteams-tab/intro-row/container.js
@@ -10,7 +10,7 @@ const mapStateToProps = () => ({})
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   onHideSubteamsBanner: () =>
-    dispatch(GregorGen.createInjectItem({body: 'true', category: 'sawSubteamsBanner'})),
+    dispatch(GregorGen.createUpdateCategory({body: 'true', category: 'sawSubteamsBanner'})),
   onReadMore: () => openURL('https://keybase.io/docs/teams/design'),
 })
 


### PR DESCRIPTION
All the places we used `injectItem` could have used `updateCategory`, so I updated them and changed our gregor action to `updateCategory`. We only use `dismissItem` to dismiss team reset user badges, which seems fine. r? @keybase/react-hackers 