### PR TITLE
User and Channel Mentions No Longer Send on <TAB> Press

### DIFF
--- a/shared/chat/conversation/input-area/normal/mention-input.js
+++ b/shared/chat/conversation/input-area/normal/mention-input.js
@@ -24,10 +24,10 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
   state: MentionState = {
     channelMentionFilter: '',
     channelMentionPopupOpen: false,
-    downArrowCounter: 0,
     mentionFilter: '',
     mentionPopupOpen: false,
     pickSelectedCounter: 0,
+    downArrowCounter: 0,
     upArrowCounter: 0,
   }
 
@@ -41,7 +41,7 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
   }
 
   _setLastSelectionKey = (lastSelectionKey: SelectionKey) => {
-    if (this._lastSelectionKey !== lastSelectionKey) this._lastSelectionKey = lastSelectionKey
+    this._lastSelectionKey = lastSelectionKey
   }
 
   _setMentionPopupOpen = (mentionPopupOpen: boolean) => {
@@ -175,10 +175,8 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
     this._replaceWordAtCursor(`@${u} `)
     this._setMentionPopupOpen(false)
 
-    // This happens if you type @notausername<enter>. We've essentially 'picked' nothing and really want to submit
-    // This is a little wonky cause this component doesn't directly know if the list is filtered all the way out
     if (options && options.notUser) {
-      this._submitAfterInsert()
+      this._maybeSubmitAfterInsert(options.notUser)
     }
   }
 
@@ -186,10 +184,8 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
     this._replaceWordAtCursor(`#${c} `)
     this._setChannelMentionPopupOpen(false)
 
-    // This happens if you type #notachannel<enter>. We've essentially 'picked' nothing and really want to submit
-    // This is a little wonky cause this component doesn't directly know if the list is filtered all the way out
     if (options && options.notChannel) {
-      this._submitAfterInsert()
+      this._maybeSubmitAfterInsert(options.notChannel)
     }
   }
 
@@ -213,7 +209,6 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
 
   _triggerPickSelectedCounter = (key: SelectionKey) => {
     this._setLastSelectionKey(key)
-    console.log('jry: pick selected counter', {key})
     this.setState(({pickSelectedCounter}) => ({pickSelectedCounter: pickSelectedCounter + 1}))
   }
 
@@ -248,12 +243,12 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
 
   // End desktop only.
 
-  _submitAfterInsert = () => {
+  // If you type @notausername<enter> or #notachannel<enter>, we've essentially 'picked' nothing and really want to submit ... all the way out.
+  //
+  // If you type e.g., @notausername<tab> we don't want to do anything.
+  _maybeSubmitAfterInsert = (notUserOrChannel: boolean) => {
     const text = this._getText()
-    // This avoids a bug where a use can begin to enter a user or channel
-    // mention that does not exist, press <TAB>, and the message will send. We
-    // only want to send here if the user previously pressed enter
-    if (text && this._lastSelectionKey === 'Enter') {
+    if (text && notUserOrChannel && this._lastSelectionKey === 'Enter') {
       this._setLastSelectionKey('')
       this.props.onSubmit(text)
     }

--- a/shared/chat/conversation/input-area/normal/mention-input.js
+++ b/shared/chat/conversation/input-area/normal/mention-input.js
@@ -242,7 +242,7 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
   // If you type @notausername<enter> or #notachannel<enter>, we've essentially
   // 'picked' nothing and really want to submit. This is a little wonky cause
   // this component doesn't directly know if the list is filtered all the way
-  // out If you type e.g., @notausername<tab> we don't want to do anything.
+  // out. If you type e.g., @notausername<tab> we don't want to do anything.
   _maybeSubmitAfterInsert = (notUserOrChannel: boolean) => {
     const text = this._getText()
     if (text && notUserOrChannel && this._lastSelectionKey === 'Enter') {

--- a/shared/chat/conversation/input-area/normal/mention-input.js
+++ b/shared/chat/conversation/input-area/normal/mention-input.js
@@ -175,18 +175,14 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
     this._replaceWordAtCursor(`@${u} `)
     this._setMentionPopupOpen(false)
 
-    if (options && options.notUser) {
-      this._maybeSubmitAfterInsert(options.notUser)
-    }
+    this._maybeSubmitAfterInsert(options ? options.notUser : false)
   }
 
   insertChannelMention = (c: string, options?: {notChannel: boolean}) => {
     this._replaceWordAtCursor(`#${c} `)
     this._setChannelMentionPopupOpen(false)
 
-    if (options && options.notChannel) {
-      this._maybeSubmitAfterInsert(options.notChannel)
-    }
+    this._maybeSubmitAfterInsert(options ? options.notChannel : false)
   }
 
   // Start desktop only.
@@ -243,15 +239,16 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
 
   // End desktop only.
 
-  // If you type @notausername<enter> or #notachannel<enter>, we've essentially 'picked' nothing and really want to submit ... all the way out.
-  //
-  // If you type e.g., @notausername<tab> we don't want to do anything.
+  // If you type @notausername<enter> or #notachannel<enter>, we've essentially
+  // 'picked' nothing and really want to submit. This is a little wonky cause
+  // this component doesn't directly know if the list is filtered all the way
+  // out If you type e.g., @notausername<tab> we don't want to do anything.
   _maybeSubmitAfterInsert = (notUserOrChannel: boolean) => {
     const text = this._getText()
     if (text && notUserOrChannel && this._lastSelectionKey === 'Enter') {
-      this._setLastSelectionKey('')
       this.props.onSubmit(text)
     }
+    this._setLastSelectionKey('')
   }
 
   _onSubmit = (text: string) => {


### PR DESCRIPTION
## Problem

When entering a user mention via `@text` in `MentionInput`, pressing `<TAB>` would incorrectly send the partially completed user name to the conversation.

**Steps to reproduce**
1. Enter any conversation
2. Type `@<character of user that does not exist in conversation or team>`
3. Press `<TAB>`
4. The `@<char>` message will send to the conversation

## Cause

The following execution flow will cause this bug inside of `MentionInput`

1. `@` symbol is pressed which will result in `mentionPopupOpen = true`
2. `MentionHud` inside of `PlatformInput` will be rendered
3. User types a character of a user or channel that does not exist in `MentionHud`
4. `mentionPopupOpen` is still `true` because of [this comment](https://github.com/keybase/client/blob/master/shared/chat/conversation/input-area/user-mention-hud/index.js#L69-L70)
5. User presses `<Tab>` which triggers [MentionInput#_onKeyDown(e)](https://github.com/keybase/client/blob/master/shared/chat/conversation/input-area/normal/mention-input.js#L192) which executes [MentionInput#_triggerPickSelectedCounter()](https://github.com/keybase/client/blob/master/shared/chat/conversation/input-area/normal/mention-input.js#L198)
6. As a result of [MentionInput#_triggerPickSelectedCounter()](https://github.com/keybase/client/blob/master/shared/chat/conversation/input-area/normal/mention-input.js#L198) being called, [MentionHud#onPickUser](https://github.com/keybase/client/blob/master/shared/chat/conversation/input-area/user-mention-hud/index.js#L147) is called which propagates up to [MentionInput#insertMention](https://github.com/keybase/client/blob/master/shared/chat/conversation/input-area/normal/mention-input.js#L155) which finally calls [MentionInput#_forceSubmit()](https://github.com/keybase/client/blob/master/shared/chat/conversation/input-area/normal/mention-input.js#L222)
6. [MentionInput#_forceSubmit()](https://github.com/keybase/client/blob/master/shared/chat/conversation/input-area/normal/mention-input.js#L222) has no way of knowing what key resulted in it being called, hence the bug

## Solution

In order to solve this the following state is added: `lastSelectionKey` which resolves to `Tab`, `ArrowUp` or `ArrowDown` - all keys that move the user/channel metions

In [MentionInput#_forceSubmit()](https://github.com/keybase/client/blob/master/shared/chat/conversation/input-area/normal/mention-input.js#L222), we can check if the last key was any of the selection keys, if so, then we should not force submit.

Force submits are still possible and still work, however tabbing is not possible.

Finally, in order to ensure that the component does not update unnecessarily and there are not lingering `lastSelectionKey` values between `@` mentions, we call `this._setLastSelectionKey('')` any time `messagePopupOpen` or `channelPopupOpen` is set to `false`.
