### PR TITLE
check devicename on signup for non-ascii characters 

### DIFF
--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -144,19 +144,7 @@ func CreateAndSignupFakeUserPaper(tc libkb.TestContext, prefix string) *FakeUser
 	return fu
 }
 
-func CreateAndSignupFakeUserSafe(g *libkb.GlobalContext, prefix string) (*FakeUser, error) {
-	noop := func(arg *SignupEngineRunArg) {}
-	return CreateAndSignupFakeUserSafeWithArg(g, prefix, noop)
-}
-
-func CreateAndSignupFakeUserSafeWithArg(g *libkb.GlobalContext, prefix string, fmod func(*SignupEngineRunArg)) (*FakeUser, error) {
-	fu, err := NewFakeUser(prefix)
-	if err != nil {
-		return nil, err
-	}
-
-	arg := MakeTestSignupEngineRunArg(fu)
-	fmod(&arg)
+func CreateAndSignupFakeUserSafeWithArg(g *libkb.GlobalContext, fu *FakeUser, arg SignupEngineRunArg) (*FakeUser, error) {
 	uis := libkb.UIs{
 		LogUI:    g.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},
@@ -164,11 +152,21 @@ func CreateAndSignupFakeUserSafeWithArg(g *libkb.GlobalContext, prefix string, f
 		LoginUI:  &libkb.TestLoginUI{Username: fu.Username},
 	}
 	s := NewSignupEngine(g, &arg)
-	err = RunEngine2(libkb.NewMetaContextTODO(g).WithUIs(uis), s)
+	err := RunEngine2(libkb.NewMetaContextTODO(g).WithUIs(uis), s)
 	if err != nil {
 		return nil, err
 	}
 	return fu, nil
+}
+
+func CreateAndSignupFakeUserSafe(g *libkb.GlobalContext, prefix string) (*FakeUser, error) {
+	fu, err := NewFakeUser(prefix)
+	if err != nil {
+		return nil, err
+	}
+	arg := MakeTestSignupEngineRunArg(fu)
+
+	return CreateAndSignupFakeUserSafeWithArg(g, fu, arg)
 }
 
 func CreateAndSignupFakeUserGPG(tc libkb.TestContext, prefix string) *FakeUser {

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -144,13 +144,14 @@ func CreateAndSignupFakeUserPaper(tc libkb.TestContext, prefix string) *FakeUser
 	return fu
 }
 
-func CreateAndSignupFakeUserSafe(g *libkb.GlobalContext, prefix string) (*FakeUser, error) {
+func CreateAndSignupFakeUserSafe(g *libkb.GlobalContext, prefix string, fmod func(*SignupEngineRunArg)) (*FakeUser, error) {
 	fu, err := NewFakeUser(prefix)
 	if err != nil {
 		return nil, err
 	}
 
 	arg := MakeTestSignupEngineRunArg(fu)
+	fmod(&arg)
 	uis := libkb.UIs{
 		LogUI:    g.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -144,7 +144,12 @@ func CreateAndSignupFakeUserPaper(tc libkb.TestContext, prefix string) *FakeUser
 	return fu
 }
 
-func CreateAndSignupFakeUserSafe(g *libkb.GlobalContext, prefix string, fmod func(*SignupEngineRunArg)) (*FakeUser, error) {
+func CreateAndSignupFakeUserSafe(g *libkb.GlobalContext, prefix string) (*FakeUser, error) {
+	noop := func(arg *SignupEngineRunArg) {}
+	return CreateAndSignupFakeUserSafeWithArg(g, prefix, noop)
+}
+
+func CreateAndSignupFakeUserSafeWithArg(g *libkb.GlobalContext, prefix string, fmod func(*SignupEngineRunArg)) (*FakeUser, error) {
 	fu, err := NewFakeUser(prefix)
 	if err != nil {
 		return nil, err

--- a/go/engine/concurrency_test.go
+++ b/go/engine/concurrency_test.go
@@ -143,7 +143,8 @@ func TestConcurrentSignup(t *testing.T) {
 		mwg.Add(1)
 		go func(index int) {
 			defer mwg.Done()
-			CreateAndSignupFakeUserSafe(tc.G, "login")
+			noop := func(arg *SignupEngineRunArg) {}
+			CreateAndSignupFakeUserSafe(tc.G, "login", noop)
 			Logout(tc)
 			fmt.Printf("func caller %d done\n", index)
 		}(i)

--- a/go/engine/concurrency_test.go
+++ b/go/engine/concurrency_test.go
@@ -143,8 +143,7 @@ func TestConcurrentSignup(t *testing.T) {
 		mwg.Add(1)
 		go func(index int) {
 			defer mwg.Done()
-			noop := func(arg *SignupEngineRunArg) {}
-			CreateAndSignupFakeUserSafe(tc.G, "login", noop)
+			CreateAndSignupFakeUserSafe(tc.G, "login")
 			Logout(tc)
 			fmt.Printf("func caller %d done\n", index)
 		}(i)

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -214,7 +214,7 @@ func (s *SignupEngine) registerDevice(m libkb.MetaContext, deviceName string) er
 
 	if !libkb.CheckDeviceName.F(s.arg.DeviceName) {
 		m.CDebugf("invalid device name supplied: %s", s.arg.DeviceName)
-		return fmt.Errorf("Bad device name: %v is not %s", s.arg.DeviceName, libkb.CheckDeviceName.Hint)
+		return libkb.DeviceBadNameError{}
 	}
 
 	switch s.arg.DeviceType {

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -212,6 +212,11 @@ func (s *SignupEngine) registerDevice(m libkb.MetaContext, deviceName string) er
 		IsEldest:   true,
 	}
 
+	if !libkb.CheckDeviceName.F(s.arg.DeviceName) {
+		m.CDebugf("invalid device name supplied: %s", s.arg.DeviceName)
+		return fmt.Errorf("Bad device name: %v is not %s", s.arg.DeviceName, libkb.CheckDeviceName.Hint)
+	}
+
 	switch s.arg.DeviceType {
 	case keybase1.DeviceType_DESKTOP:
 		args.DeviceType = libkb.DeviceTypeDesktop

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -317,7 +317,7 @@ func TestSignupNonAsciiDeviceName(t *testing.T) {
 		updateDeviceName := func(arg *SignupEngineRunArg) {
 			arg.DeviceName = testVal.deviceName
 		}
-		_, err := CreateAndSignupFakeUserSafe(tc.G, "sup", updateDeviceName)
+		_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, "sup", updateDeviceName)
 		if testVal.valid {
 			if err != nil {
 				t.Fatalf("did not expect an error with device name %s", testVal.deviceName)

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -5,7 +5,6 @@ package engine
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
@@ -308,24 +307,16 @@ func TestSignupNonAsciiDeviceName(t *testing.T) {
 
 	testValues := []struct {
 		deviceName string
-		valid      bool
+		err        error
 	}{
-		{"perfectly-reasonable", true},
-		{"definitely🙃not🐉ascii", false},
+		{"perfectly-reasonable", nil},
+		{"definitely🙃not🐉ascii", libkb.DeviceBadNameError{}},
 	}
 	for _, testVal := range testValues {
 		updateDeviceName := func(arg *SignupEngineRunArg) {
 			arg.DeviceName = testVal.deviceName
 		}
 		_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, "sup", updateDeviceName)
-		if testVal.valid {
-			if err != nil {
-				t.Fatalf("did not expect an error with device name %s", testVal.deviceName)
-			}
-		} else {
-			if !strings.Contains(err.Error(), libkb.CheckDeviceName.Hint) {
-				t.Fatalf("expected error message for %s to include %s", testVal.deviceName, libkb.CheckDeviceName.Hint)
-			}
-		}
+		require.IsType(t, err, testVal.err)
 	}
 }

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -312,11 +312,12 @@ func TestSignupNonAsciiDeviceName(t *testing.T) {
 		{"perfectly-reasonable", nil},
 		{"definitely🙃not🐉ascii", libkb.DeviceBadNameError{}},
 	}
+
 	for _, testVal := range testValues {
-		updateDeviceName := func(arg *SignupEngineRunArg) {
-			arg.DeviceName = testVal.deviceName
-		}
-		_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, "sup", updateDeviceName)
+		fu, _ := NewFakeUser("sup")
+		arg := MakeTestSignupEngineRunArg(fu)
+		arg.DeviceName = testVal.deviceName
+		_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, fu, arg)
 		require.IsType(t, err, testVal.err)
 	}
 }

--- a/go/libkb/checkers_test.go
+++ b/go/libkb/checkers_test.go
@@ -45,6 +45,7 @@ var deviceNameTests = []checkerTest{
 	{input: "home computer+", valid: false},
 	{input: "home computer'", valid: false},
 	{input: "home computer_", valid: false},
+	{input: "not😂ascii", valid: false},
 }
 
 func TestCheckDeviceName(t *testing.T) {


### PR DESCRIPTION
Per CORE-8221, non-ascii device names on signup can throw a misleading error when the server fails to parse. This PR catches those errors a little earlier with a more helpful message.

**Before**
"Non-canonical JSON error dump signing up"

**After**
the standard libkb.DeviceBadNameError message,  "device name is malformed"
