### PR TITLE
Handle undefined in toStringForLog

### DIFF
--- a/shared/util/string.js
+++ b/shared/util/string.js
@@ -6,7 +6,9 @@ function pluralize(str: string): string {
 }
 
 function toStringForLog(a: any): string {
-  if (typeof a === 'string') {
+  if (typeof a === 'undefined') {
+    return 'undefined'
+  } else if (typeof a === 'string') {
     return a
   } else if (a instanceof Error) {
     return a.stack


### PR DESCRIPTION
Otherwise the logs are cluttered up with 'Failed to turn item to string in toStringForLog'.