### PR TITLE
Add copy text on exploding messages

### DIFF
--- a/shared/chat/conversation/messages/message-popup/exploding/container.js
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.js
@@ -8,6 +8,8 @@ import * as KBFSGen from '../../../../../actions/kbfs-gen'
 import {navigateAppend} from '../../../../../actions/route-tree'
 import {compose, connect, isMobile, setDisplayName, type TypedState} from '../../../../../util/container'
 import {isIOS} from '../../../../../constants/platform'
+import {copyToClipboard} from '../../../../../util/clipboard'
+
 import type {Position} from '../../../../../common-adapters/relative-popup-hoc'
 import Exploding from '.'
 
@@ -41,6 +43,11 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
+  _onCopy: (message: Types.Message) => {
+    if (message.type === 'text') {
+      copyToClipboard(message.text.stringValue())
+    }
+  },
   _onDeleteHistory: () => {
     dispatch(Chat2Gen.createNavigateToThread())
     dispatch(navigateAppend([{props: {message: ownProps.message}, selected: 'deleteHistoryWarning'}]))
@@ -102,10 +109,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       title: 'Delete this + everything above',
     })
   }
-  const m = ownProps.message
-  if (m.type === 'attachment') {
+  const message = ownProps.message
+  if (message.type === 'attachment') {
     if (isMobile) {
-      if (m.attachmentType === 'image') {
+      if (message.attachmentType === 'image') {
         items.push({onClick: dispatchProps._onSaveAttachment, title: 'Save'})
       }
       if (isIOS) {
@@ -113,7 +120,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       }
     } else {
       items.push(
-        !m.downloadPath
+        !message.downloadPath
           ? {onClick: dispatchProps._onDownload, title: 'Download'}
           : {onClick: dispatchProps._onShowInFinder, title: 'Show in finder'}
       )
@@ -122,6 +129,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     if (stateProps._canEdit) {
       items.push({onClick: dispatchProps._onEdit, title: 'Edit'})
     }
+    items.push({onClick: dispatchProps._onCopy(message), title: 'Copy text'})
   }
   return {
     attachTo: ownProps.attachTo,

--- a/shared/chat/conversation/messages/message-popup/index.stories.js
+++ b/shared/chat/conversation/messages/message-popup/index.stories.js
@@ -74,7 +74,7 @@ const provider = PropProviders.compose(
         {danger: true, onClick: action('onDeleteHistory'), title: 'Delete this + everything above'},
         ...(props.message.type === 'attachment'
           ? [{onClick: action('onDownload'), title: 'Download'}]
-          : [{onClick: action('onEdit'), title: 'Edit'}]),
+          : [{onClick: action('onEdit'), title: 'Edit'}, {onClick: action('onCopy'), title: 'Copy text'}]),
       ],
       onHidden: props.onHidden,
       position: props.position,


### PR DESCRIPTION
## Description
Adds a "copy text" option to exploding messages, similar to the already implemented feature for regular messages.

## Solution
The solution was fairly straightforward and mostly involved _copying_ (hahaha get it?) the code from `TextPopupMenu` into `ExplodingPopupMenu`. One thing that I was kinda confused about was the responsibilities of `container.js` and `index.js` in each component: for `ExplodingPopupMenu`, the clickable actions/items for the popup are [assigned in its `container.js`](https://github.com/keybase/client/blob/6b0b8589d722be548c672e9292b5d95e8fb98081/shared/chat/conversation/messages/message-popup/exploding/container.js#L90) while both `TextPopupMenu` and `AttachmentPopupMenu` assign actions/items in [their](https://github.com/keybase/client/blob/6b0b8589d722be548c672e9292b5d95e8fb98081/shared/chat/conversation/messages/message-popup/text/index.js#L32) [respective](https://github.com/keybase/client/blob/6b0b8589d722be548c672e9292b5d95e8fb98081/shared/chat/conversation/messages/message-popup/attachment/index.js#L31) `index.js` files. I followed the convention of `ExplodingPopupMenu` for this change because I assumed that since it was written more recently, it follows a more up-to-date practice but I can refactor this if desired.

I also updated the `ExplodingPopupMenu` in our storybook.