### PR TITLE
Fix ReAddMemberAfterReset so it finds invite superseding membership

### DIFF
--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -402,6 +402,32 @@ func TestImplicitInvalidLinks(t *testing.T) {
 	}
 }
 
+func TestImpTeamAddInviteWithoutCanceling(t *testing.T) {
+	fus, tcs, cleanup := setupNTestsWithPukless(t, 2, 1)
+	defer cleanup()
+
+	impteamName := strings.Join([]string{fus[0].Username, fus[1].Username}, ",")
+	t.Logf("created implicit team: %s", impteamName)
+
+	teamObj, _, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, impteamName, false /*isPublic*/)
+	require.NoError(t, err)
+
+	t.Logf("created team id: %s", teamObj.ID)
+
+	kbtest.ResetAccount(*tcs[1], fus[1])
+	fus[1].EldestSeqno = 0
+
+	// Adding new version of user without canceling old invite should
+	// fail on the server side.
+	invite := SCTeamInvite{
+		Type: "keybase",
+		Name: fus[1].GetUserVersion().TeamInviteName(),
+		ID:   NewInviteID(),
+	}
+	err = teamObj.postInvite(context.Background(), invite, keybase1.TeamRole_OWNER)
+	require.IsType(t, libkb.AppStatusError{}, err)
+}
+
 func TestTeamListImplicit(t *testing.T) {
 	fus, tcs, cleanup := setupNTests(t, 2)
 	defer cleanup()
@@ -445,4 +471,49 @@ func TestTeamListImplicit(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, list.Teams, 4)
+}
+
+func TestReAddMemberWithSameUV(t *testing.T) {
+	fus, tcs, cleanup := setupNTestsWithPukless(t, 4, 2)
+	defer cleanup()
+
+	ann := fus[0] // crypto user
+	bob := fus[1] // crypto user
+	jun := fus[2] // pukless user
+	hal := fus[3] // pukless user (eldest=0)
+
+	kbtest.ResetAccount(*tcs[3], fus[3])
+
+	impteamName := strings.Join([]string{ann.Username, bob.Username, jun.Username, hal.Username}, ",")
+	t.Logf("ann creates an implicit team: %v", impteamName)
+	teamObj, _, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, impteamName, false /*isPublic*/)
+	require.NoError(t, err)
+
+	t.Logf("created team id: %s", teamObj.ID)
+
+	err = ReAddMemberAfterReset(context.Background(), tcs[0].G, teamObj.ID, bob.Username)
+	require.IsType(t, libkb.ExistsError{}, err)
+
+	err = ReAddMemberAfterReset(context.Background(), tcs[0].G, teamObj.ID, jun.Username)
+	require.IsType(t, libkb.ExistsError{}, err)
+
+	err = ReAddMemberAfterReset(context.Background(), tcs[0].G, teamObj.ID, hal.Username)
+	require.IsType(t, libkb.ExistsError{}, err)
+
+	// Now, the fun part (bug CORE-8099):
+
+	// Bob resets, ann re-adds bob by posting an "invite" link, so
+	// from chain point of view there are two active memberships for
+	// bob: cryptomember from before reset and invite from after reset
+	// (it's an implicit team weirdness - "invite" link has no way of
+	// removing old membership).
+
+	kbtest.ResetAccount(*tcs[1], fus[1])
+	err = ReAddMemberAfterReset(context.Background(), tcs[0].G, teamObj.ID, bob.Username)
+	require.NoError(t, err)
+
+	// Subsequent calls should start failing with ExistsError again
+	// and cancel old invite and add new one for same UV.
+	err = ReAddMemberAfterReset(context.Background(), tcs[0].G, teamObj.ID, bob.Username)
+	require.IsType(t, libkb.ExistsError{}, err)
 }


### PR DESCRIPTION
This PR fixes a bug in ReAddMemberAfterReset which makes the following possible:
1) Have an implicit team "alice,bob".
2) Bob resets (is now `bob%0`).
3) Alice re-adds bob (creates an invite link `bob%0%`. at this point his previous crypto membership is still not-removed).
4) Alice can call ReAddMemberAfterReset again and post pointless link like:
```
CanceledInvites: [bob%0]
NewInvites: { Owner: [bob%0] }
```

Changed `ReAddMemberAfterReset` to look for invites first, and for memberships second. It was the other way round before, and it was always finding the membership first, which resulted in condition `existingUV.EldestSeqno == uv.EldestSeqno` not being hit.
