### PR TITLE
client: add an "fs history" command

### DIFF
--- a/go/client/cmd_simplefs.go
+++ b/go/client/cmd_simplefs.go
@@ -41,6 +41,7 @@ func NewCmdSimpleFS(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 			NewCmdSimpleFSPs(cl, g),
 			NewCmdSimpleFSWrite(cl, g),
 			NewCmdSimpleFSDebug(cl, g),
+			NewCmdSimpleFSHistory(cl, g),
 		},
 	}
 }

--- a/go/client/cmd_simplefs_history.go
+++ b/go/client/cmd_simplefs_history.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
 package client

--- a/go/client/cmd_simplefs_history.go
+++ b/go/client/cmd_simplefs_history.go
@@ -1,0 +1,94 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"fmt"
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+// CmdSimpleFSHistory is the 'fs history' command.
+type CmdSimpleFSHistory struct {
+	libkb.Contextified
+	path keybase1.Path
+}
+
+// NewCmdSimpleFSHistory creates a new cli.Command.
+func NewCmdSimpleFSHistory(
+	cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "history",
+		ArgumentHelp: "[path-to-folder]",
+		Usage:        "output the edit history for a user or folder",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdSimpleFSHistory{
+				Contextified: libkb.NewContextified(g)}, "history", c)
+			cl.SetNoStandalone()
+		},
+	}
+}
+
+// Run runs the command in client/server mode.
+func (c *CmdSimpleFSHistory) Run() error {
+	cli, err := GetSimpleFSClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	if c.path == (keybase1.Path{}) {
+		history, err := cli.SimpleFSUserEditHistory(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, h := range history {
+			c.output(h)
+		}
+	} else {
+		history, err := cli.SimpleFSFolderEditHistory(context.TODO(), c.path)
+		if err != nil {
+			return err
+		}
+		c.output(history)
+	}
+
+	return err
+}
+
+func (c *CmdSimpleFSHistory) output(h keybase1.FSFolderEditHistory) {
+	ui := c.G().UI.GetTerminalUI()
+	for _, w := range h.History {
+		if len(w.Edits) == 0 {
+			continue
+		}
+
+		ui.Printf("\n%s (%s)\n", h.Folder.ToString(), w.WriterName)
+		for _, e := range w.Edits {
+			ui.Printf("\t%s (%s)\n", e.Filename, keybase1.FromTime(e.ServerTime))
+		}
+	}
+}
+
+// ParseArgv gets the optional path, if any.
+func (c *CmdSimpleFSHistory) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) > 1 {
+		return fmt.Errorf("wrong number of arguments")
+	} else if len(ctx.Args()) == 1 {
+		c.path = makeSimpleFSPath(c.G(), ctx.Args()[0])
+	}
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdSimpleFSHistory) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/cmd_simplefs_history.go
+++ b/go/client/cmd_simplefs_history.go
@@ -5,12 +5,13 @@ package client
 
 import (
 	"fmt"
-	"golang.org/x/net/context"
+	"time"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
 )
 
 // CmdSimpleFSHistory is the 'fs history' command.
@@ -69,7 +70,9 @@ func (c *CmdSimpleFSHistory) output(h keybase1.FSFolderEditHistory) {
 
 		ui.Printf("\n%s (%s)\n", h.Folder.ToString(), w.WriterName)
 		for _, e := range w.Edits {
-			ui.Printf("\t%s (%s)\n", e.Filename, keybase1.FromTime(e.ServerTime))
+			ui.Printf("\t%s: %s\n",
+				keybase1.FromTime(e.ServerTime).Format(time.UnixDate),
+				e.Filename)
 		}
 	}
 }


### PR DESCRIPTION
To show the edit history of either a whole user or a single TLF.

I literally put no thought into the output, and I'm happy to tweak it based on suggestions; this was just a first pass.  Here's a sample:

```sh
$ keybase fs history

private/strib (strib)
	/keybase/private/strib/tmp/z7 (2018-06-28 17:00:16.879 -0700 PDT)
	/keybase/private/strib/tmp/z6 (2018-06-28 16:08:00.167 -0700 PDT)
	/keybase/private/strib/tmp/z5 (2018-06-28 16:06:48.32 -0700 PDT)
	/keybase/private/strib/tmp/z4 (2018-06-28 15:30:51.385 -0700 PDT)
	/keybase/private/strib/tmp/z3 (2018-06-28 15:28:24.811 -0700 PDT)
	/keybase/private/strib/tmp/z2 (2018-06-28 15:12:26.712 -0700 PDT)
	/keybase/private/strib/tmp/z (2018-06-28 15:06:32.954 -0700 PDT)
	/keybase/private/strib/tmp/x (2018-06-28 15:00:49.817 -0700 PDT)

team/kbkbfstest (strib)
	/keybase/team/kbkbfstest/test (2018-06-28 16:38:30.249 -0700 PDT)
$
$ keybase fs history /keybase/private/strib

private/strib (strib)
	/keybase/private/strib/tmp/z7 (2018-06-28 17:00:16.879 -0700 PDT)
	/keybase/private/strib/tmp/z6 (2018-06-28 16:08:00.167 -0700 PDT)
	/keybase/private/strib/tmp/z5 (2018-06-28 16:06:48.32 -0700 PDT)
	/keybase/private/strib/tmp/z4 (2018-06-28 15:30:51.385 -0700 PDT)
	/keybase/private/strib/tmp/z3 (2018-06-28 15:28:24.811 -0700 PDT)
	/keybase/private/strib/tmp/z2 (2018-06-28 15:12:26.712 -0700 PDT)
	/keybase/private/strib/tmp/z (2018-06-28 15:06:32.954 -0700 PDT)
	/keybase/private/strib/tmp/x (2018-06-28 15:00:49.817 -0700 PDT)
$
```

Issue: KBFS-2998