### PR TITLE
fix toggle dev tools menu

### DIFF
--- a/shared/desktop/app/menu-helper.desktop.js
+++ b/shared/desktop/app/menu-helper.desktop.js
@@ -3,6 +3,8 @@ import * as SafeElectron from '../../util/safe-electron.desktop'
 import {executeActionsForContext} from '../../util/quit-helper.desktop'
 import {isDarwin} from '../../constants/platform'
 
+let devToolsState = false
+
 export default function makeMenu(window: any) {
   const editMenu = {
     label: 'Edit',
@@ -35,7 +37,15 @@ export default function makeMenu(window: any) {
             {
               label: 'Toggle Developer Tools',
               accelerator: (() => (isDarwin ? 'Alt+Command+I' : 'Ctrl+Shift+I'))(),
-              click: (item, focusedWindow) => focusedWindow && focusedWindow.toggleDevTools(),
+              click: (item, focusedWindow) => {
+                devToolsState = !devToolsState
+                SafeElectron.BrowserWindow.getAllWindows().map(
+                  bw =>
+                    devToolsState
+                      ? bw.webContents.openDevTools({mode: 'detach'})
+                      : bw.webContents.closeDevTools()
+                )
+              },
             },
           ]
         : []


### PR DESCRIPTION
@keybase/react-hackers makes the dev menu dev tools work (alt+command+k+b still works)