### PR TITLE
Perform initial nav exactly once

### DIFF
--- a/shared/actions/config.js
+++ b/shared/actions/config.js
@@ -126,7 +126,7 @@ const bootstrap = (opts: $PropertyType<ConfigGen.BootstrapPayload, 'payload'>): 
     })
     dispatch(registerListeners())
   } else {
-    logger.info('[bootstrap] performing bootstrap...')
+    logger.info('[bootstrap] performing bootstrap...', opts)
     Promise.all([
       dispatch(getBootstrapStatus()),
       checkRPCOwnership(),

--- a/shared/actions/config.js
+++ b/shared/actions/config.js
@@ -96,6 +96,7 @@ const _retryBootstrap = () =>
 // TODO: It's unfortunate that we have these globals. Ideally,
 // bootstrap would be a method on an object.
 let bootstrapSetup = false
+let didInitialNav = false
 const routeStateStorage = new RouteStateStorage()
 
 // Until bootstrap is sagaized
@@ -126,7 +127,7 @@ const bootstrap = (opts: $PropertyType<ConfigGen.BootstrapPayload, 'payload'>): 
     })
     dispatch(registerListeners())
   } else {
-    logger.info('[bootstrap] performing bootstrap...', opts)
+    logger.info('[bootstrap] performing bootstrap...', opts, didInitialNav)
     Promise.all([
       dispatch(getBootstrapStatus()),
       checkRPCOwnership(),
@@ -142,7 +143,8 @@ const bootstrap = (opts: $PropertyType<ConfigGen.BootstrapPayload, 'payload'>): 
           logger.flush()
         })
         dispatch(NotificationsGen.createListenForKBFSNotifications())
-        if (!opts.isReconnect) {
+        if (!didInitialNav) {
+          didInitialNav = true
           dispatch(async () => {
             await dispatch(LoginGen.createNavBasedOnLoginAndInitialState())
             if (getState().config.loggedIn) {

--- a/shared/logger/action-transformer.js
+++ b/shared/logger/action-transformer.js
@@ -68,6 +68,7 @@ const actionTransformMap = {
   [Chat2Gen.metaNeedsUpdating]: fullOutput,
   [Chat2Gen.updateMoreToLoad]: fullOutput,
   [Chat2Gen.setConversationOffline]: fullOutput,
+  [ConfigGen.bootstrap]: fullOutput,
   [ConfigGen.globalError]: a => {
     let err = {}
     const ge = a.payload.globalError
@@ -82,6 +83,7 @@ const actionTransformMap = {
   },
   [Chat2Gen.setPendingMode]: fullOutput,
   [Chat2Gen.setPendingConversationUsers]: fullOutput,
+  [GregorGen.updateReachability]: fullOutput,
 
   [Chat2Gen.messageSend]: a => ({
     payload: {conversationIDKey: a.payload.conversationIDKey},


### PR DESCRIPTION
...instead of relying on isReconnect.

This fixes a bug where, in certain cases, the initial bootstrap
comes from reachability, and we fail to do the initial nav because
we think it's a reconnect.