### PR TITLE
Pull loop for prev pointers

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -106,7 +106,7 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 	s.Debug(ctx, "postProcessThread: thread messages after type filter: %d", len(thread.Messages))
 	// If we have exploded any messages while fetching them from cache, remove
 	// them now.
-	thread.Messages = utils.FilterExploded(conv.GetExpunge(), thread.Messages)
+	thread.Messages = utils.FilterExploded(conv.GetExpunge(), thread.Messages, s.boxer.clock.Now())
 	s.Debug(ctx, "postProcessThread: thread messages after explode filter: %d", len(thread.Messages))
 
 	// Fetch outbox and tack onto the result

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -106,6 +106,8 @@ func (s *BlockingSender) addPrevPointersAndCheckConvID(ctx context.Context, msg 
 			pagination)
 		if err != nil {
 			return resMsg, err
+		} else if thread.Pagination == nil {
+			break
 		}
 		pagination.Next = thread.Pagination.Next
 

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -96,6 +96,8 @@ func (s *BlockingSender) addPrevPointersAndCheckConvID(ctx context.Context, msg 
 	pagination := &chat1.Pagination{
 		Num: s.prevPtrPagination.Num,
 	}
+	// If we fail to find anything to prev against after numRetries, we allow
+	// the message to be send with an empty prev list.
 	numRetries := 5
 	for i := 0; i < numRetries; i++ {
 		thread, err = s.G().ConvSource.Pull(ctx, conv.GetConvID(), msg.ClientHeader.Sender,
@@ -137,7 +139,7 @@ func (s *BlockingSender) addPrevPointersAndCheckConvID(ctx context.Context, msg 
 		} else if thread.Pagination.Last {
 			return resMsg, fmt.Errorf("Could not find previous messages for prev pointers (of %v)", len(thread.Messages))
 		} else {
-			s.Debug(ctx, "Could not find previous messages for prev pointers (of %v), attempt: %v, retrying", len(thread.Messages), i)
+			s.Debug(ctx, "Could not find previous messages for prev pointers (of %v), attempt: %v of %v, retrying", len(thread.Messages), i, numRetries)
 		}
 	}
 

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -966,9 +966,10 @@ func TestKBFSCryptKeysBit(t *testing.T) {
 func TestPrevPointerAddition(t *testing.T) {
 	mt := chat1.ConversationMembersType_TEAM
 	runWithEphemeral(t, mt, func(ephemeralLifetime *gregor1.DurationSec) {
-		ctx, world, ri, _, blockingSender, _ := setupTest(t, 1)
+		ctx, world, ri2, _, blockingSender, _ := setupTest(t, 1)
 		defer world.Cleanup()
 
+		ri := ri2.(*kbtest.ChatRemoteMock)
 		var ephemeralMetadata *chat1.MsgEphemeralMetadata
 		if ephemeralLifetime != nil {
 			ephemeralMetadata = &chat1.MsgEphemeralMetadata{
@@ -993,6 +994,40 @@ func TestPrevPointerAddition(t *testing.T) {
 				MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
 			}, 0, nil)
 			require.NoError(t, err)
+		}
+
+		// Hide all ephemeral messages by advancing the clock enough to hide
+		// the "ash" lines.  We also mock out the server call so we can
+		// simulate a chat with only long exploded ephemeral messages.
+		if ephemeralLifetime != nil {
+			t.Logf("expiry all ephemeral messages")
+			world.Fc.Advance(time.Second*time.Duration(*ephemeralLifetime) + chat1.ShowExplosionLifetime)
+			// Mock out server call for new messages
+			ri.GetThreadRemoteFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, arg chat1.GetThreadRemoteArg) (chat1.GetThreadRemoteRes, error) {
+				return chat1.GetThreadRemoteRes{
+					Thread: chat1.ThreadViewBoxed{
+						Pagination: &chat1.Pagination{},
+					},
+				}, nil
+			}
+			// Prepare a regular message and make sure it gets prev pointers
+			boxed, pendingAssetDeletes, _, _, _, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
+				ClientHeader: chat1.MessageClientHeader{
+					Conv:              conv.Metadata.IdTriple,
+					Sender:            uid,
+					TlfName:           u.Username,
+					MessageType:       chat1.MessageType_TEXT,
+					EphemeralMetadata: ephemeralMetadata,
+				},
+				MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
+			}, mt, &conv)
+			require.NoError(t, err)
+			require.Empty(t, pendingAssetDeletes)
+			// With all of the messages filtered because they exploded and the
+			// server not returning results, we give up and don't attach any
+			// prevs.
+			require.Empty(t, boxed.ClientHeader.Prev, "empty prev pointers")
+			ri.GetThreadRemoteFunc = nil
 		}
 
 		// Nuke the body cache

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -469,8 +469,7 @@ func FilterByType(msgs []chat1.MessageUnboxed, query *chat1.GetThreadQuery, incl
 
 // Filter messages that are both exploded that are no longer shown in the GUI
 // (as ash lines)
-func FilterExploded(expunge *chat1.Expunge, msgs []chat1.MessageUnboxed) (res []chat1.MessageUnboxed) {
-	now := time.Now()
+func FilterExploded(expunge *chat1.Expunge, msgs []chat1.MessageUnboxed, now time.Time) (res []chat1.MessageUnboxed) {
 	for _, msg := range msgs {
 		if msg.IsValid() {
 			mvalid := msg.Valid()

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -309,7 +309,8 @@ type ChatRemoteMock struct {
 	CacheBodiesVersion int
 	CacheInboxVersion  int
 
-	SyncInboxFunc func(m *ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error)
+	GetThreadRemoteFunc func(m *ChatRemoteMock, ctx context.Context, arg chat1.GetThreadRemoteArg) (chat1.GetThreadRemoteRes, error)
+	SyncInboxFunc       func(m *ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error)
 }
 
 var _ chat1.RemoteInterface = (*ChatRemoteMock)(nil)
@@ -441,6 +442,9 @@ func (m *ChatRemoteMock) GetInboxByTLFIDRemote(ctx context.Context, tlfID chat1.
 }
 
 func (m *ChatRemoteMock) GetThreadRemote(ctx context.Context, arg chat1.GetThreadRemoteArg) (res chat1.GetThreadRemoteRes, err error) {
+	if m.GetThreadRemoteFunc != nil {
+		return m.GetThreadRemoteFunc(m, ctx, arg)
+	}
 	var mts map[chat1.MessageType]bool
 	if arg.Query != nil && len(arg.Query.MessageTypes) > 0 {
 		mts = make(map[chat1.MessageType]bool)

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -17,7 +17,7 @@ import (
 )
 
 // we will show some representation of an exploded message in the UI for a week
-const showExplosionLifetime = time.Hour * 24 * 7
+const ShowExplosionLifetime = time.Hour * 24 * 7
 
 type ByUID []gregor1.UID
 type ConvIDShort = []byte
@@ -514,7 +514,7 @@ func (m MessageUnboxedValid) HideExplosion(expunge *Expunge, now time.Time) bool
 	}
 	etime := m.Etime()
 	// Don't show ash lines for messages that have been expunged.
-	return etime.Time().Add(showExplosionLifetime).Before(now) || m.ServerHeader.MessageID < upTo
+	return etime.Time().Add(ShowExplosionLifetime).Before(now) || m.ServerHeader.MessageID < upTo
 }
 
 func (b MessageBody) IsNil() bool {


### PR DESCRIPTION
In a chat with only exploded messages (and all of the ash lines have been hidden) it's possible for the prev pointer addition to fail. This adds a retry loop to fetch further pages before allowing the message to be sent without prev points (similar to https://github.com/keybase/client/compare/joshblum/prev-fix?expand=1#diff-a0fb8fa7e91c4b2c1548dc6363b637f9R124)

cc @oconnor663 