### PR TITLE
read from remote on duplicate topic name error before failing

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -1068,7 +1068,8 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 					n.Debug(ctx, "found previous conversation that matches, returning")
 					return convs[0], findErr
 				}
-				n.Debug(ctx, "failed to find previous conversation on second attempt: len(convs): %d err: %s", len(convs), findErr)
+				n.Debug(ctx, "failed to find previous conversation on second attempt: len(convs): %d err: %s",
+					len(convs), findErr)
 			}
 			return res, err
 		}

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -122,7 +122,8 @@ func (h *Helper) SendMsgByNameNonblock(ctx context.Context, name string, topicNa
 	return helper.SendBody(ctx, body, msgType)
 }
 
-func (h *Helper) FindConversations(ctx context.Context, name string, topicName *string, topicType chat1.TopicType, membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility) ([]chat1.ConversationLocal, error) {
+func (h *Helper) FindConversations(ctx context.Context, useLocalData bool, name string, topicName *string,
+	topicType chat1.TopicType, membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility) ([]chat1.ConversationLocal, error) {
 	kuid, err := CurrentUID(h.G())
 	if err != nil {
 		return nil, err
@@ -134,8 +135,8 @@ func (h *Helper) FindConversations(ctx context.Context, name string, topicName *
 	if topicName != nil {
 		tname = *topicName
 	}
-	convs, err := FindConversations(ctx, h.G(), h.DebugLabeler, h.ri, uid, name, topicType, membersType, vis,
-		tname, &oneChat)
+	convs, err := FindConversations(ctx, h.G(), h.DebugLabeler, useLocalData, h.ri, uid, name, topicType,
+		membersType, vis, tname, &oneChat)
 	return convs, err
 }
 
@@ -611,7 +612,8 @@ func GetTopicNameState(ctx context.Context, g *globals.Context, debugger utils.D
 }
 
 func FindConversations(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
-	ri func() chat1.RemoteInterface, uid gregor1.UID, tlfName string, topicType chat1.TopicType,
+	useLocalData bool, ri func() chat1.RemoteInterface, uid gregor1.UID, tlfName string,
+	topicType chat1.TopicType,
 	membersTypeIn chat1.ConversationMembersType, vis keybase1.TLFVisibility, topicName string,
 	oneChatPerTLF *bool) (res []chat1.ConversationLocal, err error) {
 
@@ -635,7 +637,7 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 			OneChatTypePerTLF: oneChatPerTLF,
 		}
 
-		inbox, err := g.InboxSource.Read(ctx, uid, nil, true, query, nil)
+		inbox, err := g.InboxSource.Read(ctx, uid, nil, useLocalData, query, nil)
 		if err != nil {
 			// don't error out if the TLF name is just unknown, treat it as a complete miss
 			if _, ok := err.(UnknownTLFNameError); !ok {
@@ -961,15 +963,15 @@ func newNewConversationHelper(g *globals.Context, uid gregor1.UID, tlfName strin
 }
 
 func (n *newConversationHelper) findConversations(ctx context.Context,
-	membersType chat1.ConversationMembersType, topicName string) ([]chat1.ConversationLocal, error) {
+	membersType chat1.ConversationMembersType, topicName string, useLocalData bool) ([]chat1.ConversationLocal, error) {
 	onechatpertlf := true
-	return FindConversations(ctx, n.G(), n.DebugLabeler, n.ri, n.uid, n.tlfName, n.topicType, membersType,
-		n.vis, topicName, &onechatpertlf)
+	return FindConversations(ctx, n.G(), n.DebugLabeler, useLocalData, n.ri, n.uid, n.tlfName, n.topicType,
+		membersType, n.vis, topicName, &onechatpertlf)
 }
 
-func (n *newConversationHelper) findExisting(ctx context.Context, topicName string) (res []chat1.ConversationLocal, err error) {
+func (n *newConversationHelper) findExisting(ctx context.Context, topicName string, useLocalData bool) (res []chat1.ConversationLocal, err error) {
 	// proceed to findConversations for requested member type
-	return n.findConversations(ctx, n.membersType, topicName)
+	return n.findConversations(ctx, n.membersType, topicName, useLocalData)
 }
 
 func (n *newConversationHelper) create(ctx context.Context) (res chat1.ConversationLocal, reserr error) {
@@ -996,7 +998,7 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 	// user and such. For the most part, the CLI just uses FindConversationsLocal though, so it
 	// should hopefully just result in a bunch of cache hits on the second invocation.
 
-	convs, err := n.findExisting(ctx, findConvsTopicName)
+	convs, err := n.findExisting(ctx, findConvsTopicName, true)
 
 	// If we find one conversation, then just return it as if we created it.
 	if len(convs) == 1 {
@@ -1061,11 +1063,12 @@ func (n *newConversationHelper) create(ctx context.Context) (res chat1.Conversat
 			case DuplicateTopicNameError:
 				n.Debug(ctx, "duplicate topic name encountered, attempting to findExisting again")
 				var findErr error
-				convs, findErr = n.findExisting(ctx, findConvsTopicName)
+				convs, findErr = n.findExisting(ctx, findConvsTopicName, false)
 				if len(convs) == 1 {
 					n.Debug(ctx, "found previous conversation that matches, returning")
 					return convs[0], findErr
 				}
+				n.Debug(ctx, "failed to find previous conversation on second attempt: len(convs): %d err: %s", len(convs), findErr)
 			}
 			return res, err
 		}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2316,7 +2316,7 @@ func (h *Server) FindConversationsLocal(ctx context.Context,
 	}
 	uid := gregor1.UID(h.G().Env.GetUID().ToBytes())
 
-	res.Conversations, err = FindConversations(ctx, h.G(), h.DebugLabeler, h.remoteClient,
+	res.Conversations, err = FindConversations(ctx, h.G(), h.DebugLabeler, true, h.remoteClient,
 		uid, arg.TlfName, arg.TopicType, arg.MembersType, arg.Visibility, arg.TopicName, arg.OneChatPerTLF)
 	if err != nil {
 		return res, err

--- a/go/git/common_test.go
+++ b/go/git/common_test.go
@@ -132,7 +132,8 @@ func (m *mockChatHelper) SendMsgByNameNonblock(ctx context.Context, name string,
 	return nil
 }
 
-func (m *mockChatHelper) FindConversations(ctx context.Context, name string, topicName *string, topicType chat1.TopicType,
+func (m *mockChatHelper) FindConversations(ctx context.Context, userLocalData bool, name string,
+	topicName *string, topicType chat1.TopicType,
 	membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility) ([]chat1.ConversationLocal, error) {
 
 	conv, ok := m.convs[m.convKey(name, topicName)]

--- a/go/git/settings.go
+++ b/go/git/settings.go
@@ -83,7 +83,8 @@ func SetTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, arg keybas
 		if !arg.Folder.Private {
 			vis = keybase1.TLFVisibility_PUBLIC
 		}
-		convs, err := g.ChatHelper.FindConversations(ctx, arg.Folder.Name, arg.ChannelName, chat1.TopicType_CHAT, chat1.ConversationMembersType_TEAM, vis)
+		convs, err := g.ChatHelper.FindConversations(ctx, true, arg.Folder.Name, arg.ChannelName,
+			chat1.TopicType_CHAT, chat1.ConversationMembersType_TEAM, vis)
 		if err != nil {
 			return err
 		}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -782,8 +782,8 @@ type ChatHelper interface {
 	SendMsgByNameNonblock(ctx context.Context, name string, topicName *string,
 		membersType chat1.ConversationMembersType, ident keybase1.TLFIdentifyBehavior, body chat1.MessageBody,
 		msgType chat1.MessageType) error
-	FindConversations(ctx context.Context, name string, topicName *string, topicType chat1.TopicType,
-		membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility) ([]chat1.ConversationLocal, error)
+	FindConversations(ctx context.Context, useLocalData bool, name string, topicName *string,
+		topicType chat1.TopicType, membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility) ([]chat1.ConversationLocal, error)
 	FindConversationsByID(ctx context.Context, convIDs []chat1.ConversationID) ([]chat1.ConversationLocal, error)
 	GetChannelTopicName(context.Context, keybase1.TeamID, chat1.TopicType, chat1.ConversationID) (string, error)
 	GetMessages(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,


### PR DESCRIPTION
It is possible that two threads can attempt to create the same conversation at the same time. Instead of returning an error for the loser, make a best effort to find the conversation after we know we have lost a race. Patch does the following:

1.) If we hit a `DuplicateTopicNameError` from `BlockingSender.Prepare` when creating a conversation, we issue another call to `FindConversations` against the server to try and return it from the original `NewConversation` call.
2.) Change `FindConversations` to be able to control if it uses local cache or not in its search. This is important in this case, since we may not have the actual conversation in our local cache yet when doing the second call. 

cc @strib 