### PR TITLE
Stellar receive modal: Integration

### DIFF
--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -15,9 +15,9 @@ const makeReserve: I.RecordFactory<Types._Reserve> = I.Record({
 })
 
 const makeState: I.RecordFactory<Types._State> = I.Record({
+  accountMap: I.Map(),
   assetsMap: I.Map(),
   paymentsMap: I.Map(),
-  accountMap: I.Map(),
   selectedAccount: Types.noAccountID,
 })
 
@@ -148,12 +148,19 @@ const getAccount = (state: TypedState, accountID?: Types.AccountID) =>
 const getAssets = (state: TypedState, accountID?: Types.AccountID) =>
   state.wallets.assetsMap.get(accountID || getSelectedAccount(state), I.List())
 
+const getFederatedAddress = (state: TypedState, accountID?: Types.AccountID) => {
+  const account = state.wallets.accountMap.get(accountID || getSelectedAccount(state), makeAccount())
+  const {username} = state.config
+  return username && account.isDefault ? `${username}*keybase.io` : ''
+}
+
 export {
   accountResultToAccount,
   assetsResultToAssets,
   getAccountIDs,
   getAccount,
   getAssets,
+  getFederatedAddress,
   getPayment,
   getPayments,
   getSelectedAccount,

--- a/shared/wallets/container.js
+++ b/shared/wallets/container.js
@@ -6,14 +6,13 @@ import {HeaderOnMobile} from '../common-adapters'
 
 const mapStateToProps = (state: TypedState) => ({})
 
-const mapDispatchToProps = (dispatch: Dispatch, {navigateAppend, navigateUp}) => ({
-  navigateAppend,
+const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
   onBack: () => dispatch(navigateUp()),
   refresh: () => dispatch(WalletsGen.createLoadAccounts()),
 })
 
-const mergeProps = (stateProps, dispatchProps) => ({
-  navigateAppend: dispatchProps.navigateAppend,
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  navigateAppend: ownProps.navigateAppend,
   onBack: dispatchProps.onBack,
   refresh: dispatchProps.refresh,
   title: 'Wallets',

--- a/shared/wallets/container.js
+++ b/shared/wallets/container.js
@@ -6,12 +6,14 @@ import {HeaderOnMobile} from '../common-adapters'
 
 const mapStateToProps = (state: TypedState) => ({})
 
-const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
+const mapDispatchToProps = (dispatch: Dispatch, {navigateAppend, navigateUp}) => ({
+  navigateAppend,
   onBack: () => dispatch(navigateUp()),
   refresh: () => dispatch(WalletsGen.createLoadAccounts()),
 })
 
 const mergeProps = (stateProps, dispatchProps) => ({
+  navigateAppend: dispatchProps.navigateAppend,
   onBack: dispatchProps.onBack,
   refresh: dispatchProps.refresh,
   title: 'Wallets',

--- a/shared/wallets/index.js
+++ b/shared/wallets/index.js
@@ -6,16 +6,17 @@ import Wallet from './wallet/container'
 import {globalColors, styleSheetCreate} from '../styles'
 
 type Props = {
+  navigateAppend: () => void,
   refresh: () => void,
   waitingKey: string,
 }
 
-const Wallets = ({refresh, waitingKey}: Props) => (
+const Wallets = ({navigateAppend, refresh, waitingKey}: Props) => (
   <Box2 direction="horizontal" fullHeight={true} fullWidth={true}>
     <Box2 direction="vertical" fullHeight={true} style={styles.walletListContainer}>
       <WalletList style={{height: '100%'}} />
     </Box2>
-    <Wallet />
+    <Wallet navigateAppend={navigateAppend} />
   </Box2>
 )
 

--- a/shared/wallets/receive-modal/container.js
+++ b/shared/wallets/receive-modal/container.js
@@ -1,0 +1,29 @@
+// @flow
+import {connect, type TypedState} from '../../util/container'
+import * as Constants from '../../constants/wallets'
+import * as Types from '../../constants/types/wallets'
+import Receive from '.'
+
+export type OwnProps = {
+  accountID: Types.AccountID,
+}
+
+const mapStateToProps = (state: TypedState, {routeProps}) => {
+  const accountID = routeProps.get('accountID')
+  return {
+    federatedAddress: Constants.getFederatedAddress(state, accountID),
+    stellarAddress: accountID,
+    username: state.config.username,
+  }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
+  navigateUp: () => dispatch(navigateUp()),
+})
+
+const mergeProps = (stateProps, dispatchProps) => ({
+  ...stateProps,
+  onClose: dispatchProps.navigateUp,
+})
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Receive)

--- a/shared/wallets/receive-modal/index.js
+++ b/shared/wallets/receive-modal/index.js
@@ -19,45 +19,42 @@ type Props = {
   username: string,
 }
 
-const ReceiveModal = (props: Props) => {
-  console.warn('in receive', props)
-  return (
-    <MaybePopup onClose={props.onClose}>
-      <Box2 direction="vertical" style={containerStyle}>
-        <Icon
-          type={isMobile ? 'icon-wallet-receive-64' : 'icon-wallet-receive-48'}
-          style={iconCastPlatformStyles(styles.icon)}
-        />
-        <Text type="BodySmallSemibold">{props.username}’s wallet</Text>
-        <Text type="Header" style={styles.headerText}>
-          Receive
-        </Text>
-        <Text type="Body" style={styles.instructionText}>
-          To receive Lumens or assets from non-Keybase users, pass your Stellar addresses around:
-        </Text>
-        <Box2 direction="vertical" style={styles.stellarAddressContainer}>
-          <CopyText text={props.stellarAddress} />
-        </Box2>
-        {!!props.federatedAddress && (
-          <React.Fragment>
-            <Text type="Body" style={styles.orText}>
-              or
-            </Text>
-            <Box2 direction="vertical" style={styles.federatedAddressContainer}>
-              <CopyText text={props.federatedAddress} />
-            </Box2>
-          </React.Fragment>
-        )}
-        <InfoNote>
-          <Text type="BodySmall" style={styles.infoNoteText}>
-            Use the chat interface to request Lumens from a Keybase user.
-          </Text>
-        </InfoNote>
-        <Button label="Close" onClick={props.onClose} type="Secondary" />
+const ReceiveModal = (props: Props) => (
+  <MaybePopup onClose={props.onClose}>
+    <Box2 direction="vertical" style={containerStyle}>
+      <Icon
+        type={isMobile ? 'icon-wallet-receive-64' : 'icon-wallet-receive-48'}
+        style={iconCastPlatformStyles(styles.icon)}
+      />
+      <Text type="BodySmallSemibold">{props.username}’s wallet</Text>
+      <Text type="Header" style={styles.headerText}>
+        Receive
+      </Text>
+      <Text type="Body" style={styles.instructionText}>
+        To receive Lumens or assets from non-Keybase users, pass your Stellar addresses around:
+      </Text>
+      <Box2 direction="vertical" style={styles.stellarAddressContainer}>
+        <CopyText text={props.stellarAddress} />
       </Box2>
-    </MaybePopup>
-  )
-}
+      {!!props.federatedAddress && (
+        <React.Fragment>
+          <Text type="Body" style={styles.orText}>
+            or
+          </Text>
+          <Box2 direction="vertical" style={styles.federatedAddressContainer}>
+            <CopyText text={props.federatedAddress} />
+          </Box2>
+        </React.Fragment>
+      )}
+      <InfoNote>
+        <Text type="BodySmall" style={styles.infoNoteText}>
+          Use the chat interface to request Lumens from a Keybase user.
+        </Text>
+      </InfoNote>
+      <Button label="Close" onClick={props.onClose} type="Secondary" />
+    </Box2>
+  </MaybePopup>
+)
 
 const styles = styleSheetCreate({
   federatedAddressContainer: {

--- a/shared/wallets/receive-modal/index.js
+++ b/shared/wallets/receive-modal/index.js
@@ -13,7 +13,7 @@ import {
 import {globalMargins, isMobile, platformStyles, styleSheetCreate} from '../../styles'
 
 type Props = {
-  federatedAddress: string,
+  federatedAddress?: string,
   onClose: () => void,
   stellarAddress: string,
   username: string,
@@ -36,12 +36,16 @@ const ReceiveModal = (props: Props) => (
       <Box2 direction="vertical" style={styles.stellarAddressContainer}>
         <CopyText text={props.stellarAddress} />
       </Box2>
-      <Text type="Body" style={styles.orText}>
-        or
-      </Text>
-      <Box2 direction="vertical" style={styles.federatedAddressContainer}>
-        <CopyText text={props.federatedAddress} />
-      </Box2>
+      {!!props.federatedAddress && (
+        <React.Fragment>
+          <Text type="Body" style={styles.orText}>
+            or
+          </Text>
+          <Box2 direction="vertical" style={styles.federatedAddressContainer}>
+            <CopyText text={props.federatedAddress} />
+          </Box2>
+        </React.Fragment>
+      )}
       <InfoNote>
         <Text type="BodySmall" style={styles.infoNoteText}>
           Use the chat interface to request Lumens from a Keybase user.

--- a/shared/wallets/receive-modal/index.js
+++ b/shared/wallets/receive-modal/index.js
@@ -19,42 +19,45 @@ type Props = {
   username: string,
 }
 
-const ReceiveModal = (props: Props) => (
-  <MaybePopup onClose={props.onClose}>
-    <Box2 direction="vertical" style={containerStyle}>
-      <Icon
-        type={isMobile ? 'icon-wallet-receive-64' : 'icon-wallet-receive-48'}
-        style={iconCastPlatformStyles(styles.icon)}
-      />
-      <Text type="BodySmallSemibold">{props.username}’s wallet</Text>
-      <Text type="Header" style={styles.headerText}>
-        Receive
-      </Text>
-      <Text type="Body" style={styles.instructionText}>
-        To receive Lumens or assets from non-Keybase users, pass your Stellar addresses around:
-      </Text>
-      <Box2 direction="vertical" style={styles.stellarAddressContainer}>
-        <CopyText text={props.stellarAddress} />
-      </Box2>
-      {!!props.federatedAddress && (
-        <React.Fragment>
-          <Text type="Body" style={styles.orText}>
-            or
-          </Text>
-          <Box2 direction="vertical" style={styles.federatedAddressContainer}>
-            <CopyText text={props.federatedAddress} />
-          </Box2>
-        </React.Fragment>
-      )}
-      <InfoNote>
-        <Text type="BodySmall" style={styles.infoNoteText}>
-          Use the chat interface to request Lumens from a Keybase user.
+const ReceiveModal = (props: Props) => {
+  console.warn('in receive', props)
+  return (
+    <MaybePopup onClose={props.onClose}>
+      <Box2 direction="vertical" style={containerStyle}>
+        <Icon
+          type={isMobile ? 'icon-wallet-receive-64' : 'icon-wallet-receive-48'}
+          style={iconCastPlatformStyles(styles.icon)}
+        />
+        <Text type="BodySmallSemibold">{props.username}’s wallet</Text>
+        <Text type="Header" style={styles.headerText}>
+          Receive
         </Text>
-      </InfoNote>
-      <Button label="Close" onClick={props.onClose} type="Secondary" />
-    </Box2>
-  </MaybePopup>
-)
+        <Text type="Body" style={styles.instructionText}>
+          To receive Lumens or assets from non-Keybase users, pass your Stellar addresses around:
+        </Text>
+        <Box2 direction="vertical" style={styles.stellarAddressContainer}>
+          <CopyText text={props.stellarAddress} />
+        </Box2>
+        {!!props.federatedAddress && (
+          <React.Fragment>
+            <Text type="Body" style={styles.orText}>
+              or
+            </Text>
+            <Box2 direction="vertical" style={styles.federatedAddressContainer}>
+              <CopyText text={props.federatedAddress} />
+            </Box2>
+          </React.Fragment>
+        )}
+        <InfoNote>
+          <Text type="BodySmall" style={styles.infoNoteText}>
+            Use the chat interface to request Lumens from a Keybase user.
+          </Text>
+        </InfoNote>
+        <Button label="Close" onClick={props.onClose} type="Secondary" />
+      </Box2>
+    </MaybePopup>
+  )
+}
 
 const styles = styleSheetCreate({
   federatedAddressContainer: {

--- a/shared/wallets/receive-modal/index.stories.js
+++ b/shared/wallets/receive-modal/index.stories.js
@@ -4,14 +4,22 @@ import {action, storiesOf} from '../../stories/storybook'
 import ReceiveModal from '.'
 
 const load = () => {
-  storiesOf('Wallets', module).add('Receive', () => (
-    <ReceiveModal
-      federatedAddress="cecile*keybase.io"
-      onClose={action('onClose')}
-      stellarAddress="G23T5671ASCZZX09235678ASQ511U12O91AQ"
-      username="cecileb"
-    />
-  ))
+  storiesOf('Wallets', module)
+    .add('Receive to primary', () => (
+      <ReceiveModal
+        federatedAddress="cecile*keybase.io"
+        onClose={action('onClose')}
+        stellarAddress="G23T5671ASCZZX09235678ASQ511U12O91AQ"
+        username="cecileb"
+      />
+    ))
+    .add('Receive to secondary', () => (
+      <ReceiveModal
+        onClose={action('onClose')}
+        stellarAddress="G33T5671ASCZZX09235678ASQ511U12O91AQ"
+        username="cecileb"
+      />
+    ))
 }
 
 export default load

--- a/shared/wallets/routes.js
+++ b/shared/wallets/routes.js
@@ -1,9 +1,14 @@
 // @flow
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import Container from './container'
+import ReceiveModal from './receive-modal/container'
 
 const routeTree = makeRouteDefNode({
-  children: {},
+  children: {
+    receive: {
+      component: ReceiveModal,
+    },
+  },
   component: Container,
   defaultSelected: '',
   tags: makeLeafTags({}),

--- a/shared/wallets/wallet/container.js
+++ b/shared/wallets/wallet/container.js
@@ -20,8 +20,8 @@ const mergeProps = (stateProps, dispatchProps) => {
   // 2. assets header and list of assets
   // 3. transactions header and transactions (TODO)
   // Formatted in a SectionList
-  sections.push({title: 'Your assets', data: stateProps.assets.map((a, index) => index).toArray()})
-  sections.push({title: 'History', data: stateProps.payments.map(p => ({paymentID: p.id})).toArray()})
+  sections.push({data: stateProps.assets.map((a, index) => index).toArray(), title: 'Your assets'})
+  sections.push({data: stateProps.payments.map(p => ({paymentID: p.id})).toArray(), title: 'History'})
   return {
     accountID: stateProps.accountID,
     navigateAppend: dispatchProps.navigateAppend,

--- a/shared/wallets/wallet/container.js
+++ b/shared/wallets/wallet/container.js
@@ -9,7 +9,11 @@ const mapStateToProps = (state: TypedState) => ({
   payments: Constants.getPayments(state),
 })
 
-const mergeProps = stateProps => {
+const mapDispatchToProps = (dispatch: Dispatch, {navigateAppend}) => ({
+  navigateAppend,
+})
+
+const mergeProps = (stateProps, dispatchProps) => {
   const sections = []
   // layout is
   // 1. header (TODO: not included in list yet)
@@ -18,7 +22,11 @@ const mergeProps = stateProps => {
   // Formatted in a SectionList
   sections.push({title: 'Your assets', data: stateProps.assets.map((a, index) => index).toArray()})
   sections.push({title: 'History', data: stateProps.payments.map(p => ({paymentID: p.id})).toArray()})
-  return {accountID: stateProps.accountID, sections}
+  return {
+    accountID: stateProps.accountID,
+    navigateAppend: dispatchProps.navigateAppend,
+    sections,
+  }
 }
 
-export default connect(mapStateToProps, null, mergeProps)(Wallet)
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Wallet)

--- a/shared/wallets/wallet/header-container.js
+++ b/shared/wallets/wallet/header-container.js
@@ -7,6 +7,7 @@ import Header from './header'
 const mapStateToProps = (state: TypedState) => {
   const selectedAccount = Constants.getAccount(state)
   return {
+    accountID: selectedAccount.accountID,
     isDefaultWallet: selectedAccount.isDefault,
     keybaseUser: state.config.username,
     walletName: selectedAccount.name || Types.accountIDToString(selectedAccount.accountID),
@@ -14,9 +15,17 @@ const mapStateToProps = (state: TypedState) => {
 }
 
 const nyi = () => console.log('Not yet implemented')
-const mapDispatchToProps = (dispatch: Dispatch) => ({
+const mapDispatchToProps = (dispatch: Dispatch, ownProps) => ({
+  _onReceive: (accountID: Types.AccountID) =>
+    dispatch(
+      ownProps.navigateAppend([
+        {
+          props: {accountID},
+          selected: 'receive',
+        },
+      ])
+    ),
   onDeposit: nyi,
-  onReceive: nyi,
   onSendToAnotherWallet: nyi,
   onSendToKeybaseUser: nyi,
   onSendToStellarAddress: nyi,
@@ -24,4 +33,10 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onShowSecretKey: nyi,
 })
 
-export default connect(mapStateToProps, mapDispatchToProps)(Header)
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...stateProps,
+  ...dispatchProps,
+  onReceive: () => dispatchProps._onReceive(stateProps.accountID),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Header)

--- a/shared/wallets/wallet/header.js
+++ b/shared/wallets/wallet/header.js
@@ -6,6 +6,7 @@ import {FloatingMenuParentHOC, type FloatingMenuParentProps} from '../../common-
 
 type Props = {
   isDefaultWallet: boolean,
+  navigateAppend: (...Array<any>) => any,
   onDeposit: () => void,
   onReceive: () => void,
   onSendToAnotherWallet: () => void,

--- a/shared/wallets/wallet/index.js
+++ b/shared/wallets/wallet/index.js
@@ -9,6 +9,7 @@ import {globalColors, globalMargins, styleSheetCreate} from '../../styles'
 
 type Props = {
   accountID: Types.AccountID,
+  navigateAppend: (...Array<any>) => any,
   sections: any[],
 }
 
@@ -45,7 +46,7 @@ export default (props: Props) => {
 
   return (
     <Box2 direction="vertical" style={{flexGrow: 1}} fullHeight={true} gap="small">
-      <Header />
+      <Header navigateAppend={props.navigateAppend} />
       <ScrollView>
         <SectionList
           sections={props.sections}

--- a/shared/wallets/wallet/index.stories.js
+++ b/shared/wallets/wallet/index.stories.js
@@ -17,6 +17,7 @@ const secondWalletMock = {
 }
 
 const commonActions = {
+  navigateAppend: action('navigateAppend'),
   onDeposit: action('onDeposit'),
   onReceive: action('onReceive'),
   onSendToAnotherWallet: action('onSendToAnotherWallet'),


### PR DESCRIPTION
@keybase/react-hackers 

@buoyad, this PR has your tx-2 branch as a base, for reviewing, but it's totally fine for you to merge in first and I can just point the PR at master instead.

An unsatisfying thing about this PR was having to pass navigateAppend through from the main (routed) wallets container to the wallet/header/ component, so that it can be used for the Receive popup.  Let me know if you have other ideas!  I don't expect that making the header itself a route is the right thing.