### PR TITLE
Add `largerBadgeMinWidthFix` option to fix badge sizing

### DIFF
--- a/shared/common-adapters/badge.js.flow
+++ b/shared/common-adapters/badge.js.flow
@@ -5,7 +5,7 @@ export type Props = {
   badgeNumber: ?number,
   badgeStyle?: any,
   badgeNumberStyle?: Object,
-  largerBadgeMinWidthFix?: Boolean,
+  largerBadgeMinWidthFix?: boolean,
 }
 
 declare export default class Badge extends Component<Props> {}

--- a/shared/common-adapters/badge.js.flow
+++ b/shared/common-adapters/badge.js.flow
@@ -5,6 +5,7 @@ export type Props = {
   badgeNumber: ?number,
   badgeStyle?: any,
   badgeNumberStyle?: Object,
+  largerBadgeMinWidthFix?: Boolean,
 }
 
 declare export default class Badge extends Component<Props> {}

--- a/shared/common-adapters/badge.native.js
+++ b/shared/common-adapters/badge.native.js
@@ -6,9 +6,15 @@ import {globalStyles, globalColors, styleSheetCreate, collapseStyles} from '../s
 
 import type {Props} from './badge'
 
-function Badge({badgeStyle, badgeNumber, badgeNumberStyle}: Props) {
+function Badge({badgeStyle, badgeNumber, badgeNumberStyle, largerBadgeMinWidthFix}: Props) {
   return (
-    <Box style={collapseStyles([styles.badge, badgeStyle])}>
+    <Box
+      style={collapseStyles([
+        styles.badge,
+        largerBadgeMinWidthFix && styles.largerBadgeMinWidthFix,
+        badgeStyle,
+      ])}
+    >
       <Text style={collapseStyles([styles.text, badgeNumberStyle])} type="HeaderBig">
         {badgeNumber}
       </Text>
@@ -24,11 +30,15 @@ const styles = styleSheetCreate({
     borderRadius: 14,
     flex: 0,
     justifyContent: 'center',
-    minWidth: 24.5,
     paddingBottom: 2,
+    paddingLeft: 6,
+    paddingRight: 6,
+    paddingTop: 4,
+  },
+  largerBadgeMinWidthFix: {
+    minWidth: 24.5,
     paddingLeft: 4,
     paddingRight: 4,
-    paddingTop: 4,
   },
   text: {
     color: globalColors.white,

--- a/shared/settings/nav/index.native.js
+++ b/shared/settings/nav/index.native.js
@@ -28,7 +28,7 @@ function SettingsItem({
 }: {
   badgeNumber: number,
   icon?: any,
-  largerBadgeMinWidthFix?: true,
+  largerBadgeMinWidthFix?: boolean,
   onClick: () => void,
   text: string,
   textColor?: Color,

--- a/shared/settings/nav/index.native.js
+++ b/shared/settings/nav/index.native.js
@@ -21,12 +21,14 @@ import type {Props} from './index'
 function SettingsItem({
   badgeNumber,
   icon,
+  largerBadgeMinWidthFix,
   onClick,
   text,
   textColor,
 }: {
   badgeNumber: number,
   icon?: any,
+  largerBadgeMinWidthFix?: true,
   onClick: () => void,
   text: string,
   textColor?: Color,
@@ -72,18 +74,23 @@ function SettingsNav({badgeNotifications, badgeNumbers, selectedTab, onTabChange
             {
               badgeNumber: badgeNumbers[TabConstants.fsTab],
               icon: 'iconfont-nav-files',
+              largerBadgeMinWidthFix: true,
               onClick: () => onTabChange(Constants.fsTab),
               text: 'Files',
             },
             {
               badgeNumber: badgeNumbers[TabConstants.gitTab],
               icon: 'iconfont-nav-git',
+              largerBadgeMinWidthFix: true,
+
               onClick: () => onTabChange(Constants.gitTab),
               text: 'Git',
             },
             {
               badgeNumber: badgeNumbers[TabConstants.devicesTab],
               icon: 'iconfont-nav-devices',
+              largerBadgeMinWidthFix: true,
+
               onClick: () => onTabChange(Constants.devicesTab),
               text: 'Devices',
             },
@@ -92,6 +99,8 @@ function SettingsNav({badgeNotifications, badgeNumbers, selectedTab, onTabChange
                 ? {
                     badgeNumber: badgeNumbers[TabConstants.walletsTab],
                     icon: 'iconfont-nav-wallets',
+                    largerBadgeMinWidthFix: true,
+
                     onClick: () => onTabChange(Constants.walletsTab),
                     text: 'Wallet',
                   }
@@ -102,6 +111,7 @@ function SettingsNav({badgeNotifications, badgeNumbers, selectedTab, onTabChange
                 ? {
                     badgeNumber: 0,
                     icon: 'iconfont-nav-settings',
+                    largerBadgeMinWidthFix: true,
                     onClick: () => onTabChange(Constants.devMenuTab),
                     text: 'Dev menu',
                   }

--- a/shared/settings/nav/index.native.js
+++ b/shared/settings/nav/index.native.js
@@ -82,7 +82,6 @@ function SettingsNav({badgeNotifications, badgeNumbers, selectedTab, onTabChange
               badgeNumber: badgeNumbers[TabConstants.gitTab],
               icon: 'iconfont-nav-git',
               largerBadgeMinWidthFix: true,
-
               onClick: () => onTabChange(Constants.gitTab),
               text: 'Git',
             },
@@ -90,7 +89,6 @@ function SettingsNav({badgeNotifications, badgeNumbers, selectedTab, onTabChange
               badgeNumber: badgeNumbers[TabConstants.devicesTab],
               icon: 'iconfont-nav-devices',
               largerBadgeMinWidthFix: true,
-
               onClick: () => onTabChange(Constants.devicesTab),
               text: 'Devices',
             },
@@ -100,7 +98,6 @@ function SettingsNav({badgeNotifications, badgeNumbers, selectedTab, onTabChange
                     badgeNumber: badgeNumbers[TabConstants.walletsTab],
                     icon: 'iconfont-nav-wallets',
                     largerBadgeMinWidthFix: true,
-
                     onClick: () => onTabChange(Constants.walletsTab),
                     text: 'Wallet',
                   }


### PR DESCRIPTION
My previous badge sizing fix actually doesn't work on all badge sizes 😢

This is just a quick fix that adds an option (`largerBadgeMinWidthFix`) for the larger badge size on mobile that I was working with (it seems like all other badges are correctly sized, but please let me know if this is not the case!) I know there's probably a better and more elegant solution to the badge sizing problem, but this is just a quick fix. I'd love to come back later and make this better and welcome all suggestions you may have on how to do that!

Here's what the settings screen looks like with my change:
![simulator screen shot - iphone 8 plus - 2018-07-02 at 11 48 31](https://user-images.githubusercontent.com/5677971/42174212-7fc6ac1a-7def-11e8-9dd4-9fd545b438f3.png)
