### PR TITLE
Signup tests

### DIFF
--- a/shared/actions/__tests__/signup.test.js
+++ b/shared/actions/__tests__/signup.test.js
@@ -79,7 +79,7 @@ describe('checkInviteCode', () => {
     const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
     // leaves state alone
     expect(nextState).toEqual(getState())
-    expect(_testing.showUserEmailOnNoErrors(action, nextState)).toEqual(
+    expect(_testing.showUserEmailOnNoErrors(nextState)).toEqual(
       Saga.put(navigateTo([loginTab, 'signup', 'usernameAndEmail']))
     )
   })
@@ -93,7 +93,7 @@ describe('checkInviteCode', () => {
 
     const nextState: TypedState = ({signup: reducer(preState.signup, action)}: any)
     expect(nextState.signup.inviteCodeError).toEqual(action.payload.error)
-    expect(_testing.showUserEmailOnNoErrors(action, nextState)).toEqual(false)
+    expect(_testing.showUserEmailOnNoErrors(nextState)).toEqual(false)
   })
   it("ignores error if invite doesn't match", () => {
     const preAction = SignupGen.createRequestedAutoInvite({inviteCode: 'a different invite code'})
@@ -110,8 +110,8 @@ describe('checkInviteCode', () => {
 
 describe('checkUsernameEmail', () => {
   it("ignores if there's an error", () => {
-    const getState = () => ({signup: Constants.makeState({inviteCodeError: 'invite error'})})
-    expect(_testing.checkUsernameEmail(undefined, getState())).toEqual(false)
+    const getState = (): TypedState => ({signup: Constants.makeState({inviteCodeError: 'invite error'})}: any)
+    expect(_testing.checkUsernameEmail(getState())).toEqual(false)
   })
 
   it('Updates store on success', () => {

--- a/shared/actions/__tests__/signup.test.js
+++ b/shared/actions/__tests__/signup.test.js
@@ -1,19 +1,18 @@
 // @flow
 /* eslint-env jest */
-// import * as I from 'immutable'
-// import * as Types from '../../constants/types/signup'
 import * as Constants from '../../constants/signup'
 import * as SignupGen from '../signup-gen'
 import * as Saga from '../../util/saga'
-// import * as WaitingGen from '../waiting-gen'
+import type {TypedState} from '../../constants/reducer'
+import {loginTab} from '../../constants/tabs'
 import HiddenString from '../../util/hidden-string'
-import {navigateUp} from '../route-tree'
+import {navigateUp, navigateTo} from '../route-tree'
 import {_testing} from '../signup'
 import reducer from '../../reducers/signup'
 
 jest.unmock('immutable')
 
-describe('cleanup', () => {
+describe('goBackAndClearErrors', () => {
   it('errors get cleaned and we go back a level', () => {
     const getState = () => ({
       signup: Constants.makeState({
@@ -28,8 +27,7 @@ describe('cleanup', () => {
     })
 
     const action = SignupGen.createGoBackAndClearErrors()
-    const nextSignupState = reducer(getState().signup, action)
-    const nextState = {signup: nextSignupState}
+    const nextState = {signup: reducer(getState().signup, action)}
     expect(nextState.signup.devicenameError).toEqual('')
     expect(nextState.signup.emailError).toEqual('')
     expect(nextState.signup.inviteCodeError).toEqual('')
@@ -37,6 +35,84 @@ describe('cleanup', () => {
     expect(nextState.signup.passphraseError.stringValue()).toEqual('')
     expect(nextState.signup.signupError.stringValue()).toEqual('')
     expect(nextState.signup.usernameError).toEqual('')
-    expect(_testing.goBackAndClearErrors(/* action, nextState */)).toEqual(Saga.put(navigateUp()))
+    expect(_testing.goBackAndClearErrors()).toEqual(Saga.put(navigateUp()))
+  })
+})
+
+describe('requestAutoInvite', () => {
+  const getState = () => ({signup: Constants.makeState({})})
+  it('makes a call to get an auto invite', () => {
+    const action = SignupGen.createRequestAutoInvite()
+    const nextState = {signup: reducer(getState().signup, action)}
+    expect(nextState).toEqual(getState())
+  })
+
+  it('fills inviteCode, shows invite screen', () => {
+    const action = SignupGen.createRequestedAutoInvite({inviteCode: 'hello world'})
+    const nextSignupState = reducer(getState().signup, action)
+    const nextState = {signup: nextSignupState}
+    expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
+    expect(_testing.showInviteScreen()).toEqual(navigateTo([loginTab, 'signup', 'inviteCode']))
+  })
+
+  it('goes to invite page on error', () => {
+    const action = SignupGen.createRequestedAutoInviteError()
+    const nextSignupState = reducer(getState().signup, action)
+    const nextState = {signup: nextSignupState}
+    expect(nextState).toEqual(getState())
+    expect(_testing.showInviteScreen()).toEqual(navigateTo([loginTab, 'signup', 'inviteCode']))
+  })
+})
+
+describe('checkInviteCode', () => {
+  const getState = () => ({signup: Constants.makeState({})})
+  it('checks requestedAutoInvite', () => {
+    const action = SignupGen.createRequestedAutoInvite({inviteCode: 'invite code'})
+    const nextSignupState = reducer(getState().signup, action)
+    const nextState = {signup: nextSignupState}
+    expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
+  })
+  it('checks checkInviteCode', () => {
+    const action = SignupGen.createCheckInviteCode({inviteCode: 'invite code'})
+    const nextSignupState = reducer(getState().signup, action)
+    const nextState = {signup: nextSignupState}
+    expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
+  })
+  it('shows user email page on success', () => {
+    const action = SignupGen.createCheckedInviteCode({inviteCode: 'working'})
+    const nextSignupState = reducer(getState().signup, action)
+    const nextState: TypedState = ({signup: nextSignupState}: any)
+    // leaves state alone
+    expect(nextState).toEqual(getState())
+    expect(_testing.showUserEmailOnNoErrors(action, nextState)).toEqual(
+      Saga.put(navigateTo([loginTab, 'signup', 'usernameAndEmail']))
+    )
+  })
+  it("shows error on fail: must match invite code. doesn't go to next screen", () => {
+    const preAction = SignupGen.createRequestedAutoInvite({inviteCode: 'invite code'})
+    const preNextSignupState = reducer(getState().signup, preAction)
+    const preState: TypedState = ({signup: preNextSignupState}: any)
+    const action = SignupGen.createCheckedInviteCodeError({
+      error: 'bad invitecode',
+      inviteCode: 'invite code',
+    })
+
+    const nextSignupState = reducer(preState.signup, action)
+    const nextState: TypedState = ({signup: nextSignupState}: any)
+    expect(nextState.signup.inviteCodeError).toEqual(action.payload.error)
+    expect(_testing.showUserEmailOnNoErrors(action, nextState)).toEqual(false)
+  })
+  it("ignores error if invite doesn't match", () => {
+    const preAction = SignupGen.createRequestedAutoInvite({inviteCode: 'a different invite code'})
+    const preNextSignupState = reducer(getState().signup, preAction)
+    const preState: TypedState = ({signup: preNextSignupState}: any)
+    const action = SignupGen.createCheckedInviteCodeError({
+      error: 'bad invitecode',
+      inviteCode: 'invite code',
+    })
+
+    const nextSignupState = reducer(preState.signup, action)
+    const nextState: TypedState = ({signup: nextSignupState}: any)
+    expect(nextState).toEqual(preState)
   })
 })

--- a/shared/actions/__tests__/signup.test.js
+++ b/shared/actions/__tests__/signup.test.js
@@ -1,5 +1,6 @@
 // @flow
 /* eslint-env jest */
+import * as Types from '../../constants/types/signup'
 import * as Constants from '../../constants/signup'
 import * as SignupGen from '../signup-gen'
 import * as LoginGen from '../login-gen'
@@ -13,28 +14,28 @@ import reducer from '../../reducers/signup'
 
 jest.unmock('immutable')
 
+const makeTypedState = (signupState: Types.State): TypedState => ({signup: signupState}: any)
+
 describe('resetNav works', () => {
-  it('nab based on login', () => {
+  it('nav based on login', () => {
     expect(_testing.resetNav()).toEqual(Saga.put(LoginGen.createNavBasedOnLoginAndInitialState()))
   })
 })
 
 describe('goBackAndClearErrors', () => {
   it('errors get cleaned and we go back a level', () => {
-    const getState = () => ({
-      signup: Constants.makeState({
-        devicenameError: 'bad name',
-        emailError: 'bad email',
-        inviteCodeError: 'bad invite',
-        nameError: 'bad name',
-        passphraseError: new HiddenString('bad pass'),
-        signupError: new HiddenString('bad signup'),
-        usernameError: 'bad username',
-      }),
+    const state = Constants.makeState({
+      devicenameError: 'bad name',
+      emailError: 'bad email',
+      inviteCodeError: 'bad invite',
+      nameError: 'bad name',
+      passphraseError: new HiddenString('bad pass'),
+      signupError: new HiddenString('bad signup'),
+      usernameError: 'bad username',
     })
 
     const action = SignupGen.createGoBackAndClearErrors()
-    const nextState = {signup: reducer(getState().signup, action)}
+    const nextState = {signup: reducer(state, action)}
     expect(nextState.signup.devicenameError).toEqual('')
     expect(nextState.signup.emailError).toEqual('')
     expect(nextState.signup.inviteCodeError).toEqual('')
@@ -47,40 +48,40 @@ describe('goBackAndClearErrors', () => {
 })
 
 describe('requestAutoInvite', () => {
-  const getState = () => ({signup: Constants.makeState({})})
+  const state = Constants.makeState()
   it('makes a call to get an auto invite', () => {
     const action = SignupGen.createRequestAutoInvite()
-    const nextState = {signup: reducer(getState().signup, action)}
-    expect(nextState).toEqual(getState())
+    const nextState = makeTypedState(reducer(state, action))
+    expect(nextState).toEqual(makeTypedState(state))
   })
 
   it('fills inviteCode, shows invite screen', () => {
     const action = SignupGen.createRequestedAutoInvite({inviteCode: 'hello world'})
-    const nextState = {signup: reducer(getState().signup, action)}
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
     expect(_testing.showInviteScreen()).toEqual(navigateTo([loginTab, 'signup', 'inviteCode']))
   })
 
   it('goes to invite page on error', () => {
     const action = SignupGen.createRequestedAutoInviteError()
-    const nextState = {signup: reducer(getState().signup, action)}
-    expect(nextState).toEqual(getState())
+    const nextState = makeTypedState(reducer(state, action))
+    expect(nextState).toEqual(makeTypedState(state))
     expect(_testing.showInviteScreen()).toEqual(navigateTo([loginTab, 'signup', 'inviteCode']))
   })
 })
 
 describe('requestInvite', () => {
   it('ignores if theres an error', () => {
-    const getState = () => ({signup: Constants.makeState({devicenameError: 'has an error'})})
+    const state = Constants.makeState({devicenameError: 'has an error'})
     const action = SignupGen.createRequestInvite({email: 'email@email.com', name: 'name'})
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(_testing.showInviteSuccessOnNoErrors(nextState)).toEqual(false)
   })
 
-  const getState = () => ({signup: Constants.makeState({})})
+  const state = Constants.makeState()
   it('saves email/name in store, shows invite success', () => {
     const action = SignupGen.createRequestInvite({email: 'email@email.com', name: 'name'})
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.email).toEqual(action.payload.email)
     expect(nextState.signup.name).toEqual(action.payload.name)
     expect(_testing.showInviteSuccessOnNoErrors(nextState)).toEqual(
@@ -90,96 +91,96 @@ describe('requestInvite', () => {
 
   it('shows error if it matches', () => {
     const preAction = SignupGen.createRequestInvite({email: 'email@email.com', name: 'name'})
-    const preNextState: TypedState = ({signup: reducer(getState().signup, preAction)}: any)
+    const preNextState = makeTypedState(reducer(state, preAction))
     const action = SignupGen.createRequestedInviteError({
       email: preNextState.signup.email,
       emailError: 'email error',
       name: preNextState.signup.name,
       nameError: 'name error',
     })
-    const nextState: TypedState = ({signup: reducer(preNextState.signup, action)}: any)
+    const nextState = makeTypedState(reducer(preNextState.signup, action))
     expect(nextState.signup.emailError).toEqual(action.payload.emailError)
     expect(nextState.signup.nameError).toEqual(action.payload.nameError)
   })
 
   it("ignore error if it doesn't match", () => {
     const preAction = SignupGen.createRequestInvite({email: 'email@email.com', name: 'name'})
-    const preNextState: TypedState = ({signup: reducer(getState().signup, preAction)}: any)
+    const preNextState = makeTypedState(reducer(state, preAction))
     const action = SignupGen.createRequestedInviteError({
       email: 'different email',
       emailError: 'email error',
       name: preNextState.signup.name,
       nameError: 'name error',
     })
-    const nextState: TypedState = ({signup: reducer(preNextState.signup, action)}: any)
+    const nextState = makeTypedState(reducer(preNextState.signup, action))
     expect(nextState).toEqual(preNextState)
   })
 })
 
 describe('checkInviteCode', () => {
-  const getState = () => ({signup: Constants.makeState({})})
+  const state = Constants.makeState()
   it('checks requestedAutoInvite', () => {
     const action = SignupGen.createRequestedAutoInvite({inviteCode: 'invite code'})
-    const nextState = {signup: reducer(getState().signup, action)}
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
   })
   it('checks checkInviteCode', () => {
     const action = SignupGen.createCheckInviteCode({inviteCode: 'invite code'})
-    const nextState = {signup: reducer(getState().signup, action)}
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
   })
   it('shows user email page on success', () => {
     const action = SignupGen.createCheckedInviteCode({inviteCode: 'working'})
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     // leaves state alone
-    expect(nextState).toEqual(getState())
+    expect(nextState).toEqual(makeTypedState(state))
     expect(_testing.showUserEmailOnNoErrors(nextState)).toEqual(
       Saga.put(navigateTo([loginTab, 'signup', 'usernameAndEmail']))
     )
   })
   it("shows error on fail: must match invite code. doesn't go to next screen", () => {
     const preAction = SignupGen.createRequestedAutoInvite({inviteCode: 'invite code'})
-    const preState: TypedState = ({signup: reducer(getState().signup, preAction)}: any)
+    const preState = makeTypedState(reducer(state, preAction))
     const action = SignupGen.createCheckedInviteCodeError({
       error: 'bad invitecode',
       inviteCode: 'invite code',
     })
 
-    const nextState: TypedState = ({signup: reducer(preState.signup, action)}: any)
+    const nextState = makeTypedState(reducer(preState.signup, action))
     expect(nextState.signup.inviteCodeError).toEqual(action.payload.error)
     expect(_testing.showUserEmailOnNoErrors(nextState)).toEqual(false)
   })
   it("ignores error if invite doesn't match", () => {
     const preAction = SignupGen.createRequestedAutoInvite({inviteCode: 'a different invite code'})
-    const preState: TypedState = ({signup: reducer(getState().signup, preAction)}: any)
+    const preState = makeTypedState(reducer(state, preAction))
     const action = SignupGen.createCheckedInviteCodeError({
       error: 'bad invitecode',
       inviteCode: 'invite code',
     })
 
-    const nextState: TypedState = ({signup: reducer(preState.signup, action)}: any)
+    const nextState = makeTypedState(reducer(preState.signup, action))
     expect(nextState).toEqual(preState)
   })
 })
 
 describe('checkUsernameEmail', () => {
   it("ignores if there's an error", () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({inviteCodeError: 'invite error'})}: any)
-    expect(_testing.checkUsernameEmail(getState())).toEqual(false)
+    const state = Constants.makeState({inviteCodeError: 'invite error'})
+    expect(_testing.checkUsernameEmail(makeTypedState(state))).toEqual(false)
   })
 
   it('Updates store on success', () => {
-    const getState = () => ({signup: Constants.makeState({})})
+    const state = Constants.makeState()
     const action = SignupGen.createCheckUsernameEmail({email: 'email@email.com', username: 'username'})
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.email).toEqual(action.payload.email)
     expect(nextState.signup.username).toEqual(action.payload.username)
   })
 
   it('Locally checks simple problems', () => {
-    const getState = () => ({signup: Constants.makeState({})})
+    const state = Constants.makeState()
     const action = SignupGen.createCheckUsernameEmail({email: 'notAValidEmail', username: 'a.bad.username'})
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.emailError).toBeTruthy()
     expect(nextState.signup.usernameError).toBeTruthy()
     expect(nextState.signup.email).toEqual(action.payload.email)
@@ -189,55 +190,51 @@ describe('checkUsernameEmail', () => {
 
 describe('checkedUsernameEmail', () => {
   it("ignores if email doesn't match", () => {
-    const getState = (): TypedState =>
-      ({signup: Constants.makeState({email: 'email@email.com', username: 'username'})}: any)
+    const state = Constants.makeState({email: 'email@email.com', username: 'username'})
     const action = SignupGen.createCheckedUsernameEmailError({
       email: 'different@email.com',
       emailError: 'a problem',
-      username: getState().signup.username,
+      username: state.username,
       usernameError: 'another problem',
     })
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     // doesn't update
-    expect(nextState).toEqual(getState())
+    expect(nextState).toEqual(makeTypedState(state))
   })
 
   it("ignores if username doesn't match", () => {
-    const getState = (): TypedState =>
-      ({signup: Constants.makeState({email: 'email@email.com', username: 'username'})}: any)
+    const state = Constants.makeState({email: 'email@email.com', username: 'username'})
     const action = SignupGen.createCheckedUsernameEmailError({
-      email: getState().signup.email,
+      email: state.email,
       emailError: 'a problem',
       username: 'different username',
       usernameError: 'another problem',
     })
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     // doesn't update
-    expect(nextState).toEqual(getState())
+    expect(nextState).toEqual(makeTypedState(state))
   })
 
   it('shows error', () => {
-    const getState = (): TypedState =>
-      ({signup: Constants.makeState({email: 'email@email.com', username: 'username'})}: any)
+    const state = Constants.makeState({email: 'email@email.com', username: 'username'})
     const action = SignupGen.createCheckedUsernameEmailError({
-      email: getState().signup.email,
+      email: state.email,
       emailError: 'a problem',
-      username: getState().signup.username,
+      username: state.username,
       usernameError: 'another problem',
     })
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.emailError).toEqual(action.payload.emailError)
     expect(nextState.signup.usernameError).toEqual(action.payload.usernameError)
   })
 
   it('shows passphrase page on success', () => {
-    const getState = (): TypedState =>
-      ({signup: Constants.makeState({email: 'email@email.com', username: 'username'})}: any)
+    const state = Constants.makeState({email: 'email@email.com', username: 'username'})
     const action = SignupGen.createCheckedUsernameEmail({
-      email: getState().signup.email,
-      username: getState().signup.username,
+      email: state.email,
+      username: state.username,
     })
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     // doesn't update
     expect(_testing.showPassphraseOnNoErrors(nextState)).toEqual(
       Saga.put(navigateAppend(['passphraseSignup'], [loginTab, 'signup']))
@@ -247,38 +244,38 @@ describe('checkedUsernameEmail', () => {
 
 describe('checkPassphrase', () => {
   it('passes must equal', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const state = Constants.makeState()
     const action = SignupGen.createCheckPassphrase({
       pass1: new HiddenString('aaaaaaaaaaa'),
       pass2: new HiddenString('bbbbbbbbbb'),
     })
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.passphraseError.stringValue()).toEqual('Passphrases must match')
   })
   it('passes must be long enough', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const state = Constants.makeState()
     const action = SignupGen.createCheckPassphrase({
       pass1: new HiddenString('12345'),
       pass2: new HiddenString('12345'),
     })
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.passphraseError.stringValue()).toEqual(
       'Passphrase must be at least 6 characters long'
     )
   })
   it('passes must have values', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const state = Constants.makeState()
     const action = SignupGen.createCheckPassphrase({pass1: new HiddenString(''), pass2: new HiddenString('')})
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.passphraseError.stringValue()).toEqual('Fields cannot be blank')
   })
   it('passes get updated', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const state = Constants.makeState()
     const action = SignupGen.createCheckPassphrase({
       pass1: new HiddenString('123456abcd'),
       pass2: new HiddenString('123456abcd'),
     })
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.passphraseError.stringValue()).toEqual('')
     expect(nextState.signup.passphrase.stringValue()).toEqual(action.payload.pass1.stringValue())
     expect(nextState.signup.passphrase.stringValue()).toEqual(action.payload.pass2.stringValue())
@@ -287,24 +284,24 @@ describe('checkPassphrase', () => {
 
 describe('deviceScreen', () => {
   it('trims name', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState()}: any)
+    const state = Constants.makeState()
     const action = SignupGen.createCheckDevicename({devicename: '   a name  \n'})
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.devicename).toEqual('a name')
   })
 
   it("ignores if devicename doesn't match", () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({devicename: 'a device'})}: any)
+    const state = Constants.makeState({devicename: 'a device'})
     const action = SignupGen.createCheckedDevicenameError({devicename: 'different name', error: 'an error'})
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     // doesn't update
-    expect(nextState).toEqual(getState())
+    expect(nextState).toEqual(makeTypedState(state))
   })
 
   it('shows error', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({devicename: 'devicename'})}: any)
+    const state = Constants.makeState({devicename: 'devicename'})
     const action = SignupGen.createCheckedDevicenameError({devicename: 'devicename', error: 'an error'})
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(makeTypedState(state).signup, action))
     expect(nextState.signup.devicename).toEqual(action.payload.devicename)
     expect(nextState.signup.devicenameError).toEqual(action.payload.error)
   })
@@ -312,34 +309,32 @@ describe('deviceScreen', () => {
 
 describe('actually sign up', () => {
   it('bails on devicenameError', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({devicenameError: 'error'})}: any)
-    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+    const state = Constants.makeState({devicenameError: 'error'})
+    expect(_testing.reallySignupOnNoErrors(makeTypedState(state))).toBeUndefined()
   })
   it('bails on emailError', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({emailError: 'error'})}: any)
-    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+    const state = Constants.makeState({emailError: 'error'})
+    expect(_testing.reallySignupOnNoErrors(makeTypedState(state))).toBeUndefined()
   })
   it('bails on inviteCodeError', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({inviteCodeError: 'error'})}: any)
-    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+    const state = Constants.makeState({inviteCodeError: 'error'})
+    expect(_testing.reallySignupOnNoErrors(makeTypedState(state))).toBeUndefined()
   })
   it('bails on nameError', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({nameError: 'error'})}: any)
-    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+    const state = Constants.makeState({nameError: 'error'})
+    expect(_testing.reallySignupOnNoErrors(makeTypedState(state))).toBeUndefined()
   })
   it('bails on usernameError', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({usernameError: 'error'})}: any)
-    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+    const state = Constants.makeState({usernameError: 'error'})
+    expect(_testing.reallySignupOnNoErrors(makeTypedState(state))).toBeUndefined()
   })
   it('bails on passphraseError', () => {
-    const getState = (): TypedState =>
-      ({signup: Constants.makeState({passphraseError: new HiddenString('error')})}: any)
-    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+    const state = Constants.makeState({passphraseError: new HiddenString('error')})
+    expect(_testing.reallySignupOnNoErrors(makeTypedState(state))).toBeUndefined()
   })
   it('bails on signupError', () => {
-    const getState = (): TypedState =>
-      ({signup: Constants.makeState({signupError: new HiddenString('error')})}: any)
-    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+    const state = Constants.makeState({signupError: new HiddenString('error')})
+    expect(_testing.reallySignupOnNoErrors(makeTypedState(state))).toBeUndefined()
   })
 
   const validSignup = Constants.makeState({
@@ -351,31 +346,27 @@ describe('actually sign up', () => {
   })
 
   it('bails on missing email', () => {
-    expect(() => _testing.reallySignupOnNoErrors(({signup: validSignup.set('email', '')}: any))).toThrow()
+    expect(() => _testing.reallySignupOnNoErrors(makeTypedState(validSignup.set('email', '')))).toThrow()
   })
   it('bails on missing devicename', () => {
-    expect(() =>
-      _testing.reallySignupOnNoErrors(({signup: validSignup.set('devicename', '')}: any))
-    ).toThrow()
+    expect(() => _testing.reallySignupOnNoErrors(makeTypedState(validSignup.set('devicename', '')))).toThrow()
   })
   it('bails on missing inviteCode', () => {
-    expect(() =>
-      _testing.reallySignupOnNoErrors(({signup: validSignup.set('inviteCode', '')}: any))
-    ).toThrow()
+    expect(() => _testing.reallySignupOnNoErrors(makeTypedState(validSignup.set('inviteCode', '')))).toThrow()
   })
   it('bails on missing passphrase', () => {
     expect(() =>
-      _testing.reallySignupOnNoErrors(({signup: validSignup.set('passphrase', new HiddenString(''))}: any))
+      _testing.reallySignupOnNoErrors(makeTypedState(validSignup.set('passphrase', new HiddenString(''))))
     ).toThrow()
   })
   it('bails on missing username', () => {
-    expect(() => _testing.reallySignupOnNoErrors(({signup: validSignup.set('username', '')}: any))).toThrow()
+    expect(() => _testing.reallySignupOnNoErrors(makeTypedState(validSignup.set('username', '')))).toThrow()
   })
 
   it('updates error', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const state = Constants.makeState()
     const action = SignupGen.createSignedupError({error: new HiddenString('an error')})
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.signupError.stringValue()).toEqual(action.payload.error.stringValue())
     expect(_testing.showErrorOrCleanupAfterSignup(nextState)).toEqual(
       Saga.put(navigateAppend(['signupError'], [loginTab, 'signup']))
@@ -383,9 +374,9 @@ describe('actually sign up', () => {
   })
 
   it('after signup cleanup', () => {
-    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const state = Constants.makeState()
     const action = SignupGen.createSignedup()
-    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    const nextState = makeTypedState(reducer(state, action))
     expect(_testing.showErrorOrCleanupAfterSignup(nextState)).toEqual(
       Saga.put(SignupGen.createRestartSignup())
     )

--- a/shared/actions/__tests__/signup.test.js
+++ b/shared/actions/__tests__/signup.test.js
@@ -6,7 +6,7 @@ import * as Saga from '../../util/saga'
 import type {TypedState} from '../../constants/reducer'
 import {loginTab} from '../../constants/tabs'
 import HiddenString from '../../util/hidden-string'
-import {navigateUp, navigateTo} from '../route-tree'
+import {navigateUp, navigateTo, navigateAppend} from '../route-tree'
 import {_testing} from '../signup'
 import reducer from '../../reducers/signup'
 
@@ -130,5 +130,63 @@ describe('checkUsernameEmail', () => {
     expect(nextState.signup.usernameError).toBeTruthy()
     expect(nextState.signup.email).toEqual(action.payload.email)
     expect(nextState.signup.username).toEqual(action.payload.username)
+  })
+})
+
+describe('checkedUsernameEmail', () => {
+  it("ignores if email doesn't match", () => {
+    const getState = (): TypedState =>
+      ({signup: Constants.makeState({email: 'email@email.com', username: 'username'})}: any)
+    const action = SignupGen.createCheckedUsernameEmailError({
+      email: 'different@email.com',
+      emailError: 'a problem',
+      username: getState().signup.username,
+      usernameError: 'another problem',
+    })
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    // doesn't update
+    expect(nextState).toEqual(getState())
+  })
+
+  it("ignores if username doesn't match", () => {
+    const getState = (): TypedState =>
+      ({signup: Constants.makeState({email: 'email@email.com', username: 'username'})}: any)
+    const action = SignupGen.createCheckedUsernameEmailError({
+      email: getState().signup.email,
+      emailError: 'a problem',
+      username: 'different username',
+      usernameError: 'another problem',
+    })
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    // doesn't update
+    expect(nextState).toEqual(getState())
+  })
+
+  it('shows error', () => {
+    const getState = (): TypedState =>
+      ({signup: Constants.makeState({email: 'email@email.com', username: 'username'})}: any)
+    const action = SignupGen.createCheckedUsernameEmailError({
+      email: getState().signup.email,
+      emailError: 'a problem',
+      username: getState().signup.username,
+      usernameError: 'another problem',
+    })
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.emailError).toEqual(action.payload.emailError)
+    expect(nextState.signup.usernameError).toEqual(action.payload.usernameError)
+  })
+
+  it('shows passphrase page on success', () => {
+    const getState = (): TypedState =>
+      ({signup: Constants.makeState({email: 'email@email.com', username: 'username'})}: any)
+    const action = SignupGen.createCheckedUsernameEmail({
+      email: getState().signup.email,
+      username: getState().signup.username,
+    })
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    // doesn't update
+    expect(_testing.showPassphraseOnNoErrors(nextState)).toEqual(
+      Saga.put(navigateAppend(['passphraseSignup'], [loginTab, 'signup']))
+    )
   })
 })

--- a/shared/actions/__tests__/signup.test.js
+++ b/shared/actions/__tests__/signup.test.js
@@ -2,6 +2,7 @@
 /* eslint-env jest */
 import * as Constants from '../../constants/signup'
 import * as SignupGen from '../signup-gen'
+import * as LoginGen from '../login-gen'
 import * as Saga from '../../util/saga'
 import type {TypedState} from '../../constants/reducer'
 import {loginTab} from '../../constants/tabs'
@@ -11,6 +12,12 @@ import {_testing} from '../signup'
 import reducer from '../../reducers/signup'
 
 jest.unmock('immutable')
+
+describe('resetNav works', () => {
+  it('nab based on login', () => {
+    expect(_testing.resetNav()).toEqual(Saga.put(LoginGen.createNavBasedOnLoginAndInitialState()))
+  })
+})
 
 describe('goBackAndClearErrors', () => {
   it('errors get cleaned and we go back a level', () => {
@@ -59,6 +66,53 @@ describe('requestAutoInvite', () => {
     const nextState = {signup: reducer(getState().signup, action)}
     expect(nextState).toEqual(getState())
     expect(_testing.showInviteScreen()).toEqual(navigateTo([loginTab, 'signup', 'inviteCode']))
+  })
+})
+
+describe('requestInvite', () => {
+  it('ignores if theres an error', () => {
+    const getState = () => ({signup: Constants.makeState({devicenameError: 'has an error'})})
+    const action = SignupGen.createRequestInvite({email: 'email@email.com', name: 'name'})
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(_testing.showInviteSuccessOnNoErrors(nextState)).toEqual(false)
+  })
+
+  const getState = () => ({signup: Constants.makeState({})})
+  it('saves email/name in store, shows invite success', () => {
+    const action = SignupGen.createRequestInvite({email: 'email@email.com', name: 'name'})
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.email).toEqual(action.payload.email)
+    expect(nextState.signup.name).toEqual(action.payload.name)
+    expect(_testing.showInviteSuccessOnNoErrors(nextState)).toEqual(
+      navigateAppend(['requestInviteSuccess'], [loginTab, 'signup'])
+    )
+  })
+
+  it('shows error if it matches', () => {
+    const preAction = SignupGen.createRequestInvite({email: 'email@email.com', name: 'name'})
+    const preNextState: TypedState = ({signup: reducer(getState().signup, preAction)}: any)
+    const action = SignupGen.createRequestedInviteError({
+      email: preNextState.signup.email,
+      emailError: 'email error',
+      name: preNextState.signup.name,
+      nameError: 'name error',
+    })
+    const nextState: TypedState = ({signup: reducer(preNextState.signup, action)}: any)
+    expect(nextState.signup.emailError).toEqual(action.payload.emailError)
+    expect(nextState.signup.nameError).toEqual(action.payload.nameError)
+  })
+
+  it("ignore error if it doesn't match", () => {
+    const preAction = SignupGen.createRequestInvite({email: 'email@email.com', name: 'name'})
+    const preNextState: TypedState = ({signup: reducer(getState().signup, preAction)}: any)
+    const action = SignupGen.createRequestedInviteError({
+      email: 'different email',
+      emailError: 'email error',
+      name: preNextState.signup.name,
+      nameError: 'name error',
+    })
+    const nextState: TypedState = ({signup: reducer(preNextState.signup, action)}: any)
+    expect(nextState).toEqual(preNextState)
   })
 })
 
@@ -187,6 +241,153 @@ describe('checkedUsernameEmail', () => {
     // doesn't update
     expect(_testing.showPassphraseOnNoErrors(nextState)).toEqual(
       Saga.put(navigateAppend(['passphraseSignup'], [loginTab, 'signup']))
+    )
+  })
+})
+
+describe('checkPassphrase', () => {
+  it('passes must equal', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const action = SignupGen.createCheckPassphrase({
+      pass1: new HiddenString('aaaaaaaaaaa'),
+      pass2: new HiddenString('bbbbbbbbbb'),
+    })
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.passphraseError.stringValue()).toEqual('Passphrases must match')
+  })
+  it('passes must be long enough', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const action = SignupGen.createCheckPassphrase({
+      pass1: new HiddenString('12345'),
+      pass2: new HiddenString('12345'),
+    })
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.passphraseError.stringValue()).toEqual(
+      'Passphrase must be at least 6 characters long'
+    )
+  })
+  it('passes must have values', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const action = SignupGen.createCheckPassphrase({pass1: new HiddenString(''), pass2: new HiddenString('')})
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.passphraseError.stringValue()).toEqual('Fields cannot be blank')
+  })
+  it('passes get updated', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const action = SignupGen.createCheckPassphrase({
+      pass1: new HiddenString('123456abcd'),
+      pass2: new HiddenString('123456abcd'),
+    })
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.passphraseError.stringValue()).toEqual('')
+    expect(nextState.signup.passphrase.stringValue()).toEqual(action.payload.pass1.stringValue())
+    expect(nextState.signup.passphrase.stringValue()).toEqual(action.payload.pass2.stringValue())
+  })
+})
+
+describe('deviceScreen', () => {
+  it('trims name', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState()}: any)
+    const action = SignupGen.createCheckDevicename({devicename: '   a name  \n'})
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.devicename).toEqual('a name')
+  })
+
+  it("ignores if devicename doesn't match", () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({devicename: 'a device'})}: any)
+    const action = SignupGen.createCheckedDevicenameError({devicename: 'different name', error: 'an error'})
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    // doesn't update
+    expect(nextState).toEqual(getState())
+  })
+
+  it('shows error', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({devicename: 'devicename'})}: any)
+    const action = SignupGen.createCheckedDevicenameError({devicename: 'devicename', error: 'an error'})
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.devicename).toEqual(action.payload.devicename)
+    expect(nextState.signup.devicenameError).toEqual(action.payload.error)
+  })
+})
+
+describe('actually sign up', () => {
+  it('bails on devicenameError', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({devicenameError: 'error'})}: any)
+    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+  })
+  it('bails on emailError', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({emailError: 'error'})}: any)
+    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+  })
+  it('bails on inviteCodeError', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({inviteCodeError: 'error'})}: any)
+    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+  })
+  it('bails on nameError', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({nameError: 'error'})}: any)
+    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+  })
+  it('bails on usernameError', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({usernameError: 'error'})}: any)
+    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+  })
+  it('bails on passphraseError', () => {
+    const getState = (): TypedState =>
+      ({signup: Constants.makeState({passphraseError: new HiddenString('error')})}: any)
+    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+  })
+  it('bails on signupError', () => {
+    const getState = (): TypedState =>
+      ({signup: Constants.makeState({signupError: new HiddenString('error')})}: any)
+    expect(_testing.reallySignupOnNoErrors(getState())).toBeUndefined()
+  })
+
+  const validSignup = Constants.makeState({
+    devicename: 'a valid devicename',
+    email: 'test@test.com',
+    inviteCode: '1234566',
+    passphrase: new HiddenString('a good passphrase'),
+    username: 'testuser',
+  })
+
+  it('bails on missing email', () => {
+    expect(() => _testing.reallySignupOnNoErrors(({signup: validSignup.set('email', '')}: any))).toThrow()
+  })
+  it('bails on missing devicename', () => {
+    expect(() =>
+      _testing.reallySignupOnNoErrors(({signup: validSignup.set('devicename', '')}: any))
+    ).toThrow()
+  })
+  it('bails on missing inviteCode', () => {
+    expect(() =>
+      _testing.reallySignupOnNoErrors(({signup: validSignup.set('inviteCode', '')}: any))
+    ).toThrow()
+  })
+  it('bails on missing passphrase', () => {
+    expect(() =>
+      _testing.reallySignupOnNoErrors(({signup: validSignup.set('passphrase', new HiddenString(''))}: any))
+    ).toThrow()
+  })
+  it('bails on missing username', () => {
+    expect(() => _testing.reallySignupOnNoErrors(({signup: validSignup.set('username', '')}: any))).toThrow()
+  })
+
+  it('updates error', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const action = SignupGen.createSignedupError({error: new HiddenString('an error')})
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.signupError.stringValue()).toEqual(action.payload.error.stringValue())
+    expect(_testing.showErrorOrCleanupAfterSignup(nextState)).toEqual(
+      Saga.put(navigateAppend(['signupError'], [loginTab, 'signup']))
+    )
+  })
+
+  it('after signup cleanup', () => {
+    const getState = (): TypedState => ({signup: Constants.makeState({})}: any)
+    const action = SignupGen.createSignedup()
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(_testing.showErrorOrCleanupAfterSignup(nextState)).toEqual(
+      Saga.put(SignupGen.createRestartSignup())
     )
   })
 })

--- a/shared/actions/__tests__/signup.test.js
+++ b/shared/actions/__tests__/signup.test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env jest */
+// import * as I from 'immutable'
+// import * as Types from '../../constants/types/signup'
+import * as Constants from '../../constants/signup'
+import * as SignupGen from '../signup-gen'
+import * as Saga from '../../util/saga'
+// import * as WaitingGen from '../waiting-gen'
+import HiddenString from '../../util/hidden-string'
+import {navigateUp} from '../route-tree'
+import {_testing} from '../signup'
+import reducer from '../../reducers/signup'
+
+jest.unmock('immutable')
+
+describe('cleanup', () => {
+  it('errors get cleaned and we go back a level', () => {
+    const getState = () => ({
+      signup: Constants.makeState({
+        devicenameError: 'bad name',
+        emailError: 'bad email',
+        inviteCodeError: 'bad invite',
+        nameError: 'bad name',
+        passphraseError: new HiddenString('bad pass'),
+        signupError: new HiddenString('bad signup'),
+        usernameError: 'bad username',
+      }),
+    })
+
+    const action = SignupGen.createGoBackAndClearErrors()
+    const nextSignupState = reducer(getState().signup, action)
+    const nextState = {signup: nextSignupState}
+    expect(nextState.signup.devicenameError).toEqual('')
+    expect(nextState.signup.emailError).toEqual('')
+    expect(nextState.signup.inviteCodeError).toEqual('')
+    expect(nextState.signup.nameError).toEqual('')
+    expect(nextState.signup.passphraseError.stringValue()).toEqual('')
+    expect(nextState.signup.signupError.stringValue()).toEqual('')
+    expect(nextState.signup.usernameError).toEqual('')
+    expect(_testing.goBackAndClearErrors(/* action, nextState */)).toEqual(Saga.put(navigateUp()))
+  })
+})

--- a/shared/actions/__tests__/signup.test.js
+++ b/shared/actions/__tests__/signup.test.js
@@ -49,16 +49,14 @@ describe('requestAutoInvite', () => {
 
   it('fills inviteCode, shows invite screen', () => {
     const action = SignupGen.createRequestedAutoInvite({inviteCode: 'hello world'})
-    const nextSignupState = reducer(getState().signup, action)
-    const nextState = {signup: nextSignupState}
+    const nextState = {signup: reducer(getState().signup, action)}
     expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
     expect(_testing.showInviteScreen()).toEqual(navigateTo([loginTab, 'signup', 'inviteCode']))
   })
 
   it('goes to invite page on error', () => {
     const action = SignupGen.createRequestedAutoInviteError()
-    const nextSignupState = reducer(getState().signup, action)
-    const nextState = {signup: nextSignupState}
+    const nextState = {signup: reducer(getState().signup, action)}
     expect(nextState).toEqual(getState())
     expect(_testing.showInviteScreen()).toEqual(navigateTo([loginTab, 'signup', 'inviteCode']))
   })
@@ -68,20 +66,17 @@ describe('checkInviteCode', () => {
   const getState = () => ({signup: Constants.makeState({})})
   it('checks requestedAutoInvite', () => {
     const action = SignupGen.createRequestedAutoInvite({inviteCode: 'invite code'})
-    const nextSignupState = reducer(getState().signup, action)
-    const nextState = {signup: nextSignupState}
+    const nextState = {signup: reducer(getState().signup, action)}
     expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
   })
   it('checks checkInviteCode', () => {
     const action = SignupGen.createCheckInviteCode({inviteCode: 'invite code'})
-    const nextSignupState = reducer(getState().signup, action)
-    const nextState = {signup: nextSignupState}
+    const nextState = {signup: reducer(getState().signup, action)}
     expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
   })
   it('shows user email page on success', () => {
     const action = SignupGen.createCheckedInviteCode({inviteCode: 'working'})
-    const nextSignupState = reducer(getState().signup, action)
-    const nextState: TypedState = ({signup: nextSignupState}: any)
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
     // leaves state alone
     expect(nextState).toEqual(getState())
     expect(_testing.showUserEmailOnNoErrors(action, nextState)).toEqual(
@@ -90,29 +85,50 @@ describe('checkInviteCode', () => {
   })
   it("shows error on fail: must match invite code. doesn't go to next screen", () => {
     const preAction = SignupGen.createRequestedAutoInvite({inviteCode: 'invite code'})
-    const preNextSignupState = reducer(getState().signup, preAction)
-    const preState: TypedState = ({signup: preNextSignupState}: any)
+    const preState: TypedState = ({signup: reducer(getState().signup, preAction)}: any)
     const action = SignupGen.createCheckedInviteCodeError({
       error: 'bad invitecode',
       inviteCode: 'invite code',
     })
 
-    const nextSignupState = reducer(preState.signup, action)
-    const nextState: TypedState = ({signup: nextSignupState}: any)
+    const nextState: TypedState = ({signup: reducer(preState.signup, action)}: any)
     expect(nextState.signup.inviteCodeError).toEqual(action.payload.error)
     expect(_testing.showUserEmailOnNoErrors(action, nextState)).toEqual(false)
   })
   it("ignores error if invite doesn't match", () => {
     const preAction = SignupGen.createRequestedAutoInvite({inviteCode: 'a different invite code'})
-    const preNextSignupState = reducer(getState().signup, preAction)
-    const preState: TypedState = ({signup: preNextSignupState}: any)
+    const preState: TypedState = ({signup: reducer(getState().signup, preAction)}: any)
     const action = SignupGen.createCheckedInviteCodeError({
       error: 'bad invitecode',
       inviteCode: 'invite code',
     })
 
-    const nextSignupState = reducer(preState.signup, action)
-    const nextState: TypedState = ({signup: nextSignupState}: any)
+    const nextState: TypedState = ({signup: reducer(preState.signup, action)}: any)
     expect(nextState).toEqual(preState)
+  })
+})
+
+describe('checkUsernameEmail', () => {
+  it("ignores if there's an error", () => {
+    const getState = () => ({signup: Constants.makeState({inviteCodeError: 'invite error'})})
+    expect(_testing.checkUsernameEmail(undefined, getState())).toEqual(false)
+  })
+
+  it('Updates store on success', () => {
+    const getState = () => ({signup: Constants.makeState({})})
+    const action = SignupGen.createCheckUsernameEmail({email: 'email@email.com', username: 'username'})
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.email).toEqual(action.payload.email)
+    expect(nextState.signup.username).toEqual(action.payload.username)
+  })
+
+  it('Locally checks simple problems', () => {
+    const getState = () => ({signup: Constants.makeState({})})
+    const action = SignupGen.createCheckUsernameEmail({email: 'notAValidEmail', username: 'a.bad.username'})
+    const nextState: TypedState = ({signup: reducer(getState().signup, action)}: any)
+    expect(nextState.signup.emailError).toBeTruthy()
+    expect(nextState.signup.usernameError).toBeTruthy()
+    expect(nextState.signup.email).toEqual(action.payload.email)
+    expect(nextState.signup.username).toEqual(action.payload.username)
   })
 })

--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -84,20 +84,20 @@ const requestInvite = (action: SignupGen.RequestInvitePayload, state: TypedState
       })
     )
 
-const checkUsernameEmail = (action: SignupGen.CheckUsernameEmailPayload, state: TypedState) =>
+const checkUsernameEmail = (_: any, state: TypedState) =>
   noErrors(state) &&
   RPCTypes.signupCheckUsernameAvailableRpcPromise({username: state.signup.username}, Constants.waitingKey)
     .then(r =>
       SignupGen.createCheckedUsernameEmail({
-        email: action.payload.email,
-        username: action.payload.username,
+        email: state.signup.email,
+        username: state.signup.username,
       })
     )
     .catch(err =>
       SignupGen.createCheckedUsernameEmailError({
-        email: action.payload.email,
+        email: state.signup.email,
         emailError: '',
-        username: action.payload.username,
+        username: state.signup.username,
         usernameError: `Sorry, there was a problem: ${err.desc}`,
       })
     )
@@ -114,7 +114,7 @@ const checkDevicename = (action: SignupGen.CheckDevicenamePayload, state: TypedS
     )
 
 // Actually sign up ///////////////////////////////////////////////////////////
-const reallySignupOnNoErrors = (_, state: TypedState) => {
+const reallySignupOnNoErrors = (_: any, state: TypedState) => {
   if (!noErrors(state)) {
     logger.warn('Still has errors, bailing on really signing up')
     return

--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -28,34 +28,34 @@ const resetNav = () => Saga.put(LoginGen.createNavBasedOnLoginAndInitialState())
 // When going back we clear all errors so we can fix things and move forward
 const goBackAndClearErrors = () => Saga.put(navigateUp())
 
-const showUserEmailOnNoErrors = (_, state: TypedState) =>
+const showUserEmailOnNoErrors = (state: TypedState) =>
   noErrors(state) && Saga.put(navigateTo([loginTab, 'signup', 'usernameAndEmail']))
 
 const showInviteScreen = () => navigateTo([loginTab, 'signup', 'inviteCode'])
 
-const showInviteSuccessOnNoErrors = (_, state: TypedState) =>
+const showInviteSuccessOnNoErrors = (state: TypedState) =>
   noErrors(state) && navigateAppend(['requestInviteSuccess'], [loginTab, 'signup'])
 
-const showPassphraseOnNoErrors = (_, state: TypedState) =>
+const showPassphraseOnNoErrors = (state: TypedState) =>
   noErrors(state) && Saga.put(navigateAppend(['passphraseSignup'], [loginTab, 'signup']))
 
-const showDeviceScreenOnNoErrors = (_: SignupGen.CheckPassphrasePayload, state: TypedState) =>
+const showDeviceScreenOnNoErrors = (state: TypedState) =>
   noErrors(state) && Saga.put(navigateAppend(['deviceName'], [loginTab, 'signup']))
 
-const showErrorOrCleanupAfterSignup = (_, state: TypedState) =>
+const showErrorOrCleanupAfterSignup = (state: TypedState) =>
   noErrors(state)
     ? Saga.put(SignupGen.createRestartSignup())
     : Saga.put(navigateAppend(['signupError'], [loginTab, 'signup']))
 
 // Validation side effects ///////////////////////////////////////////////////////////
-const checkInviteCode = (action: SignupGen.CheckInviteCodePayload) =>
+const checkInviteCode = (state: TypedState) =>
   RPCTypes.signupCheckInvitationCodeRpcPromise(
-    {invitationCode: action.payload.inviteCode},
+    {invitationCode: state.signup.inviteCode},
     Constants.waitingKey
   )
-    .then(() => SignupGen.createCheckedInviteCode({inviteCode: action.payload.inviteCode}))
+    .then(() => SignupGen.createCheckedInviteCode({inviteCode: state.signup.inviteCode}))
     .catch((err: RPCError) =>
-      SignupGen.createCheckedInviteCodeError({error: err.desc, inviteCode: action.payload.inviteCode})
+      SignupGen.createCheckedInviteCodeError({error: err.desc, inviteCode: state.signup.inviteCode})
     )
 
 const requestAutoInvite = () =>
@@ -63,7 +63,7 @@ const requestAutoInvite = () =>
     .then((inviteCode: string) => SignupGen.createRequestedAutoInvite({inviteCode}))
     .catch(() => SignupGen.createRequestedAutoInviteError())
 
-const requestInvite = (action: SignupGen.RequestInvitePayload, state: TypedState) =>
+const requestInvite = (state: TypedState) =>
   noErrors(state) &&
   RPCTypes.signupInviteRequestRpcPromise(
     {email: state.signup.email, fullname: state.signup.name, notes: 'Requested through GUI app'},
@@ -71,20 +71,20 @@ const requestInvite = (action: SignupGen.RequestInvitePayload, state: TypedState
   )
     .then(() =>
       SignupGen.createRequestedInvite({
-        email: action.payload.email,
-        name: action.payload.name,
+        email: state.signup.email,
+        name: state.signup.name,
       })
     )
     .catch(err =>
       SignupGen.createRequestedInviteError({
-        email: action.payload.email,
+        email: state.signup.email,
         emailError: `Sorry can't get an invite: ${err.desc}`,
-        name: action.payload.name,
+        name: state.signup.name,
         nameError: '',
       })
     )
 
-const checkUsernameEmail = (_: any, state: TypedState) =>
+const checkUsernameEmail = (state: TypedState) =>
   noErrors(state) &&
   RPCTypes.signupCheckUsernameAvailableRpcPromise({username: state.signup.username}, Constants.waitingKey)
     .then(r =>
@@ -102,19 +102,19 @@ const checkUsernameEmail = (_: any, state: TypedState) =>
       })
     )
 
-const checkDevicename = (action: SignupGen.CheckDevicenamePayload, state: TypedState) =>
+const checkDevicename = (state: TypedState) =>
   noErrors(state) &&
   RPCTypes.deviceCheckDeviceNameFormatRpcPromise({name: state.signup.devicename}, Constants.waitingKey)
-    .then(() => SignupGen.createCheckedDevicename({devicename: action.payload.devicename}))
+    .then(() => SignupGen.createCheckedDevicename({devicename: state.signup.devicename}))
     .catch(error =>
       SignupGen.createCheckedDevicenameError({
-        devicename: action.payload.devicename,
+        devicename: state.signup.devicename,
         error: `Device name is invalid: ${error.desc}.`,
       })
     )
 
 // Actually sign up ///////////////////////////////////////////////////////////
-const reallySignupOnNoErrors = (_: any, state: TypedState) => {
+const reallySignupOnNoErrors = (state: TypedState) => {
   if (!noErrors(state)) {
     logger.warn('Still has errors, bailing on really signing up')
     return
@@ -179,18 +179,18 @@ const signupSaga = function*(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPurePromise(SignupGen.checkDevicename, checkDevicename)
 
   // move to next screen actions
-  yield Saga.safeTakeEveryPure(SignupGen.restartSignup, resetNav)
-  yield Saga.safeTakeEveryPure(SignupGen.requestedInvite, showInviteSuccessOnNoErrors)
-  yield Saga.safeTakeEveryPure(SignupGen.checkedUsernameEmail, showPassphraseOnNoErrors)
-  yield Saga.safeTakeEveryPure(SignupGen.requestedAutoInvite, showInviteScreen)
-  yield Saga.safeTakeEveryPure(SignupGen.checkedInviteCode, showUserEmailOnNoErrors)
-  yield Saga.safeTakeEveryPure(SignupGen.checkPassphrase, showDeviceScreenOnNoErrors)
-  yield Saga.safeTakeEveryPure(SignupGen.signedup, showErrorOrCleanupAfterSignup)
+  yield Saga.safeTakeEveryPureSimple(SignupGen.restartSignup, resetNav)
+  yield Saga.safeTakeEveryPureSimple(SignupGen.requestedInvite, showInviteSuccessOnNoErrors)
+  yield Saga.safeTakeEveryPureSimple(SignupGen.checkedUsernameEmail, showPassphraseOnNoErrors)
+  yield Saga.safeTakeEveryPureSimple(SignupGen.requestedAutoInvite, showInviteScreen)
+  yield Saga.safeTakeEveryPureSimple(SignupGen.checkedInviteCode, showUserEmailOnNoErrors)
+  yield Saga.safeTakeEveryPureSimple(SignupGen.checkPassphrase, showDeviceScreenOnNoErrors)
+  yield Saga.safeTakeEveryPureSimple(SignupGen.signedup, showErrorOrCleanupAfterSignup)
 
   // actually make the signup call
-  yield Saga.safeTakeEveryPure(SignupGen.checkedDevicename, reallySignupOnNoErrors)
+  yield Saga.safeTakeEveryPureSimple(SignupGen.checkedDevicename, reallySignupOnNoErrors)
 
-  yield Saga.safeTakeEveryPure(SignupGen.goBackAndClearErrors, goBackAndClearErrors)
+  yield Saga.safeTakeEveryPureSimple(SignupGen.goBackAndClearErrors, goBackAndClearErrors)
 }
 
 export default signupSaga

--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -194,3 +194,20 @@ const signupSaga = function*(): Saga.SagaGenerator<any, any> {
 }
 
 export default signupSaga
+
+export const _testing = {
+  checkDevicename,
+  checkInviteCode,
+  checkUsernameEmail,
+  goBackAndClearErrors,
+  reallySignupOnNoErrors,
+  requestAutoInvite,
+  requestInvite,
+  resetNav,
+  showDeviceScreenOnNoErrors,
+  showErrorOrCleanupAfterSignup,
+  showInviteScreen,
+  showInviteSuccessOnNoErrors,
+  showPassphraseOnNoErrors,
+  showUserEmailOnNoErrors,
+}

--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -28,7 +28,7 @@ const resetNav = () => Saga.put(LoginGen.createNavBasedOnLoginAndInitialState())
 // When going back we clear all errors so we can fix things and move forward
 const goBackAndClearErrors = () => Saga.put(navigateUp())
 
-const showUserEmailOnNoErrors = (action: SignupGen.CheckedInviteCodePayload, state: TypedState) =>
+const showUserEmailOnNoErrors = (_, state: TypedState) =>
   noErrors(state) && Saga.put(navigateTo([loginTab, 'signup', 'usernameAndEmail']))
 
 const showInviteScreen = () => navigateTo([loginTab, 'signup', 'inviteCode'])

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -56,7 +56,7 @@ export default function(state: Types.State = initialState, action: SignupGen.Act
       })
     }
     case SignupGen.requestedInvite:
-      return action.payload.email === state.email && action.payload.name === state.username
+      return action.payload.email === state.email && action.payload.name === state.name
         ? state.merge({
             emailError: (action.error && action.payload.emailError) || '',
             nameError: (action.error && action.payload.nameError) || '',

--- a/shared/util/saga.js
+++ b/shared/util/saga.js
@@ -121,13 +121,27 @@ function* sequentially(effects: Array<any>): Generator<any, Array<any>, any> {
 // Helper that expects a function which returns a promise that resolves to a put
 function safeTakeEveryPurePromise<A, RA>(
   pattern: Pattern,
-  f: (action: A, state: TypedState) => null | false | Promise<RA>
+  f: (state: TypedState, action: A) => null | false | Promise<RA>
 ) {
   return safeTakeEveryPure(pattern, function*(action: A) {
     const state: TypedState = yield select()
-    const toPut = yield call(f, action, state)
+    const toPut = yield call(f, state, action)
     if (toPut) {
       yield put(toPut)
+    }
+  })
+}
+
+// like safeTakeEveryPure but simpler, only 2 params and gives you a state first
+function safeTakeEveryPureSimple<A, FinalAction>(
+  pattern: Pattern,
+  f: (state: TypedState, action: A) => null | false | FinalAction
+) {
+  return safeTakeEveryPure(pattern, function*(action: A) {
+    const state: TypedState = yield select()
+    const result = yield call(f, state, action)
+    if (result) {
+      yield result
     }
   })
 }
@@ -359,6 +373,7 @@ export {
   safeTakeEvery,
   safeTakeEveryPure,
   safeTakeEveryPurePromise,
+  safeTakeEveryPureSimple,
   safeTakeLatest,
   safeTakeLatestPure,
   safeTakeLatestWithCatch,


### PR DESCRIPTION
This adds signup tests for the new actions

Ideally we'd be able to just run the safeTakeEvery* and pump actions through but testing in redux saga seems to not really work this way so instead i'm assuming those connections work and instead test the actions which are the side effects and validating things that way. This'll help us catch any regressions.

This did find a bug! (https://github.com/keybase/client/pull/12647/files#diff-41a6064fd6e250f76ad0813d12789d5eR59)

Additionally I changed the new promise helper and added a 'simple' helper. 
The motivation is this. 
Before it used to be of the form
```
  const requestInvite = (action: SignupGen.RequestInvitePayload, state: TypedState) => ...
...
  yield Saga.safeTakeEveryPurePromise(SignupGen.requestInvite, requestInvite)
```

The problem with this approach is that 95% of the time when you're doing your side effect code we want to reach into the store and not into the action. This is especially apparent in the case where the reducer does real work ahead of the saga (like trimming a devicename). So usually the side effect should reach into the store (since the reducer runs first) to do its calculations. This also simplifies things, instead of having 2 pieces of data you can just go with one (the store, single source of truth). There are some cases where you might need something in the action so it is still passed, its just now been demoted to a second parameter

To mirror this in the non promise case there's a new version of safeTakeEveryPure which is

```
  yield Saga.safeTakeEveryPureSimple(SignupGen.requestedInvite, showInviteSuccessOnNoErrors)
```

This is like the old safeTakeEveryPure but
1. The callback gets (state, action) like the promise version above for the same reasons
1. This only takes 2 parameters, vs the 4 of safeTakeEveryPure. Just the pattern and the pure side effect creator.
