### PR TITLE
add anyRoleAllowed to nextMerkleRoot searches in team role permission downgrades

### DIFF
--- a/go/libkb/merkle_tools.go
+++ b/go/libkb/merkle_tools.go
@@ -2,8 +2,9 @@ package libkb
 
 import (
 	"fmt"
-	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"time"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
 // leafSlot is a simple accessor that takes the given leaf, and the private/public type,
@@ -49,7 +50,7 @@ func lookupMaxMerkleSeqno(m MetaContext) (ret keybase1.Seqno, err error) {
 // looking for the point of transition. Start this search from the given prevRootSeqno, not from merkle seqno 1.
 // The algorithm is to jump forward, in exponentially larger jumps, until we find a root that has a leaf
 // that makes comparer true. Then, to binary search to find the exact [a,b] pair in which a makes the
-// comparer false, and b makes it true. The leaf and root that correspond to be are returned.
+// comparer false, and b makes it true. The leaf and root that correspond to b are returned.
 func findFirstLeafWithComparer(m MetaContext, id keybase1.UserOrTeamID, comparator merkleSearchComparator, prevRootSeqno keybase1.Seqno) (leaf *MerkleGenericLeaf, root *MerkleRoot, err error) {
 	defer m.CTrace(fmt.Sprintf("findFirstLeafWithComparer(%s,%d)", id, prevRootSeqno), func() error { return err })()
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -5,7 +5,6 @@ package keybase1
 
 import (
 	"errors"
-
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )
@@ -2437,7 +2436,8 @@ type TeamsInterface interface {
 	FindNextMerkleRootAfterTeamRemoval(context.Context, FindNextMerkleRootAfterTeamRemovalArg) (NextMerkleRootRes, error)
 	// FindNextMerkleRootAfterTeamRemovalBySigningKey find the first Merkle root that contains the user
 	// with the given signing key being removed from the given team. If there are several such instances,
-	// we will return just the last one.
+	// we will return just the last one. When anyRoleAllowed is false, the team removal is any drop in
+	// permissions from Writer (or above) to Reader (or below).
 	FindNextMerkleRootAfterTeamRemovalBySigningKey(context.Context, FindNextMerkleRootAfterTeamRemovalBySigningKeyArg) (NextMerkleRootRes, error)
 	// ProfileTeamLoad loads a team and then throws it on the ground, for the purposes of profiling
 	// the team load machinery.
@@ -3406,7 +3406,8 @@ func (c TeamsClient) FindNextMerkleRootAfterTeamRemoval(ctx context.Context, __a
 
 // FindNextMerkleRootAfterTeamRemovalBySigningKey find the first Merkle root that contains the user
 // with the given signing key being removed from the given team. If there are several such instances,
-// we will return just the last one.
+// we will return just the last one. When anyRoleAllowed is false, the team removal is any drop in
+// permissions from Writer (or above) to Reader (or below).
 func (c TeamsClient) FindNextMerkleRootAfterTeamRemovalBySigningKey(ctx context.Context, __arg FindNextMerkleRootAfterTeamRemovalBySigningKeyArg) (res NextMerkleRootRes, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.findNextMerkleRootAfterTeamRemovalBySigningKey", []interface{}{__arg}, &res)
 	return

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -2377,6 +2377,7 @@ type FindNextMerkleRootAfterTeamRemovalBySigningKeyArg struct {
 	SigningKey KID    `codec:"signingKey" json:"signingKey"`
 	Team       TeamID `codec:"team" json:"team"`
 	IsPublic   bool   `codec:"isPublic" json:"isPublic"`
+	IsWriter   bool   `codec:"isWriter" json:"isWriter"`
 }
 
 type ProfileTeamLoadArg struct {

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -5,6 +5,7 @@ package keybase1
 
 import (
 	"errors"
+
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )
@@ -2377,7 +2378,7 @@ type FindNextMerkleRootAfterTeamRemovalBySigningKeyArg struct {
 	SigningKey KID    `codec:"signingKey" json:"signingKey"`
 	Team       TeamID `codec:"team" json:"team"`
 	IsPublic   bool   `codec:"isPublic" json:"isPublic"`
-	IsWriter   bool   `codec:"isWriter" json:"isWriter"`
+	WasReader  bool   `codec:"wasReader" json:"wasReader"`
 }
 
 type ProfileTeamLoadArg struct {

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -2374,11 +2374,11 @@ type FindNextMerkleRootAfterTeamRemovalArg struct {
 }
 
 type FindNextMerkleRootAfterTeamRemovalBySigningKeyArg struct {
-	Uid        UID    `codec:"uid" json:"uid"`
-	SigningKey KID    `codec:"signingKey" json:"signingKey"`
-	Team       TeamID `codec:"team" json:"team"`
-	IsPublic   bool   `codec:"isPublic" json:"isPublic"`
-	WasReader  bool   `codec:"wasReader" json:"wasReader"`
+	Uid            UID    `codec:"uid" json:"uid"`
+	SigningKey     KID    `codec:"signingKey" json:"signingKey"`
+	Team           TeamID `codec:"team" json:"team"`
+	IsPublic       bool   `codec:"isPublic" json:"isPublic"`
+	AnyRoleAllowed bool   `codec:"anyRoleAllowed" json:"anyRoleAllowed"`
 }
 
 type ProfileTeamLoadArg struct {

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -131,28 +131,6 @@ func (t TeamSigChainState) GetUserLogPoint(user keybase1.UserVersion) *keybase1.
 	return &tmp
 }
 
-// GetLastChangeLogPointWithPredicates gets the first user logpoint in the series at which
-// the second predicate is true AFTER the last user logpoint at which the first predicate is true.
-func (t TeamSigChainState) GetLastChangeLogPointWithPredicates(user keybase1.UserVersion,
-	f1 func(keybase1.UserLogPoint) bool, f2 func(keybase1.UserLogPoint) bool) *keybase1.UserLogPoint {
-
-	points := t.inner.UserLog[user]
-	if len(points) == 0 {
-		return nil
-	}
-	var closestCandidate int
-	for i := len(points) - 1; i >= 0; i-- {
-		if f2(points[i]) {
-			closestCandidate = i
-		}
-		if f1(points[i]) && closestCandidate != 0 {
-			tmp := points[closestCandidate].DeepCopy()
-			return &tmp
-		}
-	}
-	return nil
-}
-
 func (t TeamSigChainState) GetAdminUserLogPoint(user keybase1.UserVersion) *keybase1.UserLogPoint {
 	ret := t.GetUserLogPoint(user)
 	if ret == nil {

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -145,7 +145,7 @@ func (t TeamSigChainState) GetLastChangeLogPointWithPredicates(user keybase1.Use
 		if f2(points[i]) {
 			closestCandidate = i
 		}
-		if f1(points[i]) {
+		if f1(points[i]) && closestCandidate != 0 {
 			tmp := points[closestCandidate].DeepCopy()
 			return &tmp
 		}

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -131,16 +131,22 @@ func (t TeamSigChainState) GetUserLogPoint(user keybase1.UserVersion) *keybase1.
 	return &tmp
 }
 
-// GetLastUserLogPointWithPredicate gets the last user logpoint in the series for which the given
-// predicate is true.
-func (t TeamSigChainState) GetLastUserLogPointWithPredicate(user keybase1.UserVersion, f func(keybase1.UserLogPoint) bool) *keybase1.UserLogPoint {
+// GetLastChangeLogPointWithPredicates gets the first user logpoint in the series at which
+// the second predicate is true AFTER the last user logpoint at which the first predicate is true.
+func (t TeamSigChainState) GetLastChangeLogPointWithPredicates(user keybase1.UserVersion,
+	f1 func(keybase1.UserLogPoint) bool, f2 func(keybase1.UserLogPoint) bool) *keybase1.UserLogPoint {
+
 	points := t.inner.UserLog[user]
 	if len(points) == 0 {
 		return nil
 	}
+	var closestCandidate int
 	for i := len(points) - 1; i >= 0; i-- {
-		if f(points[i]) {
-			tmp := points[i].DeepCopy()
+		if f2(points[i]) {
+			closestCandidate = i
+		}
+		if f1(points[i]) {
+			tmp := points[closestCandidate].DeepCopy()
 			return &tmp
 		}
 	}

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -170,7 +170,7 @@ func TestMemberAddInvalidRole(t *testing.T) {
 // a thin wrapper around libkb.FindNextMerkleRootAfterTeamRemoval. Test that the plumbing works
 // properly. Pass in the values from the libkb inner function, to confirm that this function
 // returns the same.
-func testFindNextMerkleRootAfterRemoval(t *testing.T, tc libkb.TestContext, user *kbtest.FakeUser, id keybase1.TeamID, wasReader bool, seqno keybase1.Seqno) {
+func testFindNextMerkleRootAfterRemoval(t *testing.T, tc libkb.TestContext, user *kbtest.FakeUser, id keybase1.TeamID, anyRoleAllowed bool, seqno keybase1.Seqno) {
 	m := libkb.NewMetaContextForTest(tc)
 	upak, _, err := tc.G.GetUPAKLoader().LoadV2(libkb.NewLoadUserArgWithMetaContext(m).WithUID(user.GetUID()))
 	require.NoError(t, err)
@@ -184,11 +184,11 @@ func testFindNextMerkleRootAfterRemoval(t *testing.T, tc libkb.TestContext, user
 	}
 	require.False(t, signingKey.IsNil())
 	res, err := FindNextMerkleRootAfterRemoval(m, keybase1.FindNextMerkleRootAfterTeamRemovalBySigningKeyArg{
-		Uid:        user.GetUID(),
-		SigningKey: signingKey,
-		IsPublic:   false,
-		Team:       id,
-		WasReader:  wasReader,
+		Uid:            user.GetUID(),
+		SigningKey:     signingKey,
+		IsPublic:       false,
+		Team:           id,
+		AnyRoleAllowed: anyRoleAllowed,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, res.Res)
@@ -248,7 +248,7 @@ func TestMemberRemoveReader(t *testing.T) {
 	tc, owner, other, _, name := memberSetupMultiple(t)
 	defer tc.Cleanup()
 
-	wasReader := true
+	anyRoleAllowed := true
 	if err := SetRoleReader(context.TODO(), tc.G, name, other.Username); err != nil {
 		t.Fatal(err)
 	}
@@ -264,14 +264,14 @@ func TestMemberRemoveReader(t *testing.T) {
 	assertRole(tc, name, other.Username, keybase1.TeamRole_NONE)
 
 	teamID, seqno := pollForNextMerkleRootAfterRemovalViaLibkb(t, tc, other, name)
-	testFindNextMerkleRootAfterRemoval(t, tc, other, teamID, wasReader, seqno)
+	testFindNextMerkleRootAfterRemoval(t, tc, other, teamID, anyRoleAllowed, seqno)
 }
 
 func TestMemberRemoveWriter(t *testing.T) {
 	tc, owner, other, _, name := memberSetupMultiple(t)
 	defer tc.Cleanup()
 
-	wasReader := false
+	anyRoleAllowed := false
 	if err := SetRoleWriter(context.TODO(), tc.G, name, other.Username); err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +287,7 @@ func TestMemberRemoveWriter(t *testing.T) {
 	assertRole(tc, name, other.Username, keybase1.TeamRole_READER)
 
 	teamID, seqno := pollForNextMerkleRootAfterRemovalViaLibkb(t, tc, other, name)
-	testFindNextMerkleRootAfterRemoval(t, tc, other, teamID, wasReader, seqno)
+	testFindNextMerkleRootAfterRemoval(t, tc, other, teamID, anyRoleAllowed, seqno)
 }
 
 // make sure that adding a member creates new recipient boxes

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -267,6 +267,9 @@ func TestMemberRemoveReader(t *testing.T) {
 	testFindNextMerkleRootAfterRemoval(t, tc, other, teamID, anyRoleAllowed, seqno)
 }
 
+// Set up log points for a user in a team with roles of
+// Writer->Reader->Writer->Reader and verify that the first merkle root
+// after the last demotion from writer points to the last sequence number.
 func TestMemberRemoveWriter(t *testing.T) {
 	tc, owner, other, _, name := memberSetupMultiple(t)
 	defer tc.Cleanup()
@@ -275,14 +278,22 @@ func TestMemberRemoveWriter(t *testing.T) {
 	if err := SetRoleWriter(context.TODO(), tc.G, name, other.Username); err != nil {
 		t.Fatal(err)
 	}
-
 	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, name, other.Username, keybase1.TeamRole_WRITER)
 
 	if err := SetRoleReader(context.TODO(), tc.G, name, other.Username); err != nil {
 		t.Fatal(err)
 	}
+	assertRole(tc, name, other.Username, keybase1.TeamRole_READER)
 
+	if err := SetRoleWriter(context.TODO(), tc.G, name, other.Username); err != nil {
+		t.Fatal(err)
+	}
+	assertRole(tc, name, other.Username, keybase1.TeamRole_WRITER)
+
+	if err := SetRoleReader(context.TODO(), tc.G, name, other.Username); err != nil {
+		t.Fatal(err)
+	}
 	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, name, other.Username, keybase1.TeamRole_READER)
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -166,11 +166,9 @@ func TestMemberAddInvalidRole(t *testing.T) {
 	assertRole(tc, name, other.Username, keybase1.TeamRole_NONE)
 }
 
-// testFindNextMerkleRootAfterRemoval tests teams.FindNextMerkleRootAfterRemoval, which is
-// a thin wrapper around libkb.FindNextMerkleRootAfterTeamRemoval. Test that the plumbing works
-// properly. Pass in the values from the libkb inner function, to confirm that this function
-// returns the same.
-func testFindNextMerkleRootAfterRemoval(t *testing.T, tc libkb.TestContext, user *kbtest.FakeUser, id keybase1.TeamID, anyRoleAllowed bool, seqno keybase1.Seqno) {
+// getFindNextMerkleRootAfterRemoval calls out to teams.FindNextMerkleRootAfterRemoval, which is
+// a thin wrapper around libkb.FindNextMerkleRootAfterTeamRemoval.
+func getFindNextMerkleRootAfterRemoval(t *testing.T, tc libkb.TestContext, user *kbtest.FakeUser, id keybase1.TeamID, anyRoleAllowed bool) (res keybase1.NextMerkleRootRes, err error) {
 	m := libkb.NewMetaContextForTest(tc)
 	upak, _, err := tc.G.GetUPAKLoader().LoadV2(libkb.NewLoadUserArgWithMetaContext(m).WithUID(user.GetUID()))
 	require.NoError(t, err)
@@ -183,16 +181,13 @@ func testFindNextMerkleRootAfterRemoval(t *testing.T, tc libkb.TestContext, user
 		}
 	}
 	require.False(t, signingKey.IsNil())
-	res, err := FindNextMerkleRootAfterRemoval(m, keybase1.FindNextMerkleRootAfterTeamRemovalBySigningKeyArg{
+	return FindNextMerkleRootAfterRemoval(m, keybase1.FindNextMerkleRootAfterTeamRemovalBySigningKeyArg{
 		Uid:            user.GetUID(),
 		SigningKey:     signingKey,
 		IsPublic:       false,
 		Team:           id,
 		AnyRoleAllowed: anyRoleAllowed,
 	})
-	require.NoError(t, err)
-	require.NotNil(t, res.Res)
-	require.Equal(t, res.Res.Seqno, seqno)
 }
 
 // Check that `libkb.FindNextMerkleRootAfterTeamRemoval` works. To do so,
@@ -252,19 +247,21 @@ func TestMemberRemoveReader(t *testing.T) {
 	if err := SetRoleReader(context.TODO(), tc.G, name, other.Username); err != nil {
 		t.Fatal(err)
 	}
-
 	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, name, other.Username, keybase1.TeamRole_READER)
 
 	if err := RemoveMember(context.TODO(), tc.G, name, other.Username); err != nil {
 		t.Fatal(err)
 	}
-
 	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, name, other.Username, keybase1.TeamRole_NONE)
 
-	teamID, seqno := pollForNextMerkleRootAfterRemovalViaLibkb(t, tc, other, name)
-	testFindNextMerkleRootAfterRemoval(t, tc, other, teamID, anyRoleAllowed, seqno)
+	teamID, expectedSeqno := pollForNextMerkleRootAfterRemovalViaLibkb(t, tc, other, name)
+	res, err := getFindNextMerkleRootAfterRemoval(t, tc, other, teamID, anyRoleAllowed)
+
+	require.NoError(t, err)
+	require.NotNil(t, res.Res)
+	require.Equal(t, res.Res.Seqno, expectedSeqno)
 }
 
 // Set up log points for a user in a team with roles of
@@ -297,8 +294,32 @@ func TestMemberRemoveWriter(t *testing.T) {
 	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, name, other.Username, keybase1.TeamRole_READER)
 
-	teamID, seqno := pollForNextMerkleRootAfterRemovalViaLibkb(t, tc, other, name)
-	testFindNextMerkleRootAfterRemoval(t, tc, other, teamID, anyRoleAllowed, seqno)
+	teamID, expectedSeqno := pollForNextMerkleRootAfterRemovalViaLibkb(t, tc, other, name)
+	res, err := getFindNextMerkleRootAfterRemoval(t, tc, other, teamID, anyRoleAllowed)
+
+	require.NoError(t, err)
+	require.NotNil(t, res.Res)
+	require.Equal(t, res.Res.Seqno, expectedSeqno)
+}
+
+func TestMemberRemoveWithoutDemotion(t *testing.T) {
+	tc, owner, other, _, name := memberSetupMultiple(t)
+	defer tc.Cleanup()
+
+	anyRoleAllowed := true
+	if err := SetRoleWriter(context.TODO(), tc.G, name, other.Username); err != nil {
+		t.Fatal(err)
+	}
+	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
+	assertRole(tc, name, other.Username, keybase1.TeamRole_WRITER)
+
+	team, err := GetForTestByStringName(context.TODO(), tc.G, name)
+	require.NoError(t, err)
+	res, err := getFindNextMerkleRootAfterRemoval(t, tc, other, team.ID, anyRoleAllowed)
+
+	require.Nil(t, res.Res)
+	require.Error(t, err)
+	require.IsType(t, libkb.NotFoundError{}, err)
 }
 
 // make sure that adding a member creates new recipient boxes

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1584,7 +1584,7 @@ func FindNextMerkleRootAfterRemoval(mctx libkb.MetaContext, arg keybase1.FindNex
 	uv := vers.ToUserVersion()
 
 	var logPoint *keybase1.UserLogPoint
-	if arg.WasReader {
+	if arg.AnyRoleAllowed {
 		reader := func(p keybase1.UserLogPoint) bool {
 			return p.Role == keybase1.TeamRole_READER || p.Role == keybase1.TeamRole_WRITER || p.Role == keybase1.TeamRole_ADMIN || p.Role == keybase1.TeamRole_OWNER
 		}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1582,9 +1582,25 @@ func FindNextMerkleRootAfterRemoval(mctx libkb.MetaContext, arg keybase1.FindNex
 	}
 
 	uv := vers.ToUserVersion()
-	logPoint := team.chain().GetLastUserLogPointWithPredicate(uv, func(p keybase1.UserLogPoint) bool {
-		return p.Role == keybase1.TeamRole_NONE || p.Role == keybase1.TeamRole_READER
-	})
+
+	var logPoint *keybase1.UserLogPoint
+	if arg.IsWriter {
+		writer := func(p keybase1.UserLogPoint) bool {
+			return p.Role == keybase1.TeamRole_WRITER || p.Role == keybase1.TeamRole_ADMIN || p.Role == keybase1.TeamRole_OWNER
+		}
+		notWriter := func(p keybase1.UserLogPoint) bool {
+			return p.Role == keybase1.TeamRole_READER || p.Role == keybase1.TeamRole_NONE
+		}
+		logPoint = team.chain().GetLastChangeLogPointWithPredicates(uv, writer, notWriter)
+	} else {
+		reader := func(p keybase1.UserLogPoint) bool {
+			return p.Role == keybase1.TeamRole_READER || p.Role == keybase1.TeamRole_WRITER || p.Role == keybase1.TeamRole_ADMIN || p.Role == keybase1.TeamRole_OWNER
+		}
+		notReader := func(p keybase1.UserLogPoint) bool {
+			return p.Role == keybase1.TeamRole_NONE
+		}
+		logPoint = team.chain().GetLastChangeLogPointWithPredicates(uv, reader, notReader)
+	}
 	if logPoint == nil {
 		return res, libkb.NotFoundError{Msg: fmt.Sprintf("no downgraded log point for user found")}
 	}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1596,6 +1596,7 @@ func FindNextMerkleRootAfterRemoval(mctx libkb.MetaContext, arg keybase1.FindNex
 			earliestDemotion = i
 		} else if earliestDemotion != 0 {
 			logPoint = logPoints[earliestDemotion].DeepCopy()
+			break
 		}
 	}
 	if &logPoint == nil {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1590,16 +1590,17 @@ func FindNextMerkleRootAfterRemoval(mctx libkb.MetaContext, arg keybase1.FindNex
 		return !p.Role.IsWriterOrAbove()
 	}
 	var earliestDemotion int
-	var logPoint keybase1.UserLogPoint
+	var logPoint *keybase1.UserLogPoint
 	for i := len(logPoints) - 1; i >= 0; i-- {
 		if demotionPredicate(logPoints[i]) {
 			earliestDemotion = i
 		} else if earliestDemotion != 0 {
-			logPoint = logPoints[earliestDemotion].DeepCopy()
+			p := logPoints[earliestDemotion].DeepCopy()
+			logPoint = &p
 			break
 		}
 	}
-	if &logPoint == nil {
+	if logPoint == nil {
 		return res, libkb.NotFoundError{Msg: fmt.Sprintf("no downgraded log point for user found")}
 	}
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1584,15 +1584,7 @@ func FindNextMerkleRootAfterRemoval(mctx libkb.MetaContext, arg keybase1.FindNex
 	uv := vers.ToUserVersion()
 
 	var logPoint *keybase1.UserLogPoint
-	if arg.IsWriter {
-		writer := func(p keybase1.UserLogPoint) bool {
-			return p.Role == keybase1.TeamRole_WRITER || p.Role == keybase1.TeamRole_ADMIN || p.Role == keybase1.TeamRole_OWNER
-		}
-		notWriter := func(p keybase1.UserLogPoint) bool {
-			return p.Role == keybase1.TeamRole_READER || p.Role == keybase1.TeamRole_NONE
-		}
-		logPoint = team.chain().GetLastChangeLogPointWithPredicates(uv, writer, notWriter)
-	} else {
+	if arg.WasReader {
 		reader := func(p keybase1.UserLogPoint) bool {
 			return p.Role == keybase1.TeamRole_READER || p.Role == keybase1.TeamRole_WRITER || p.Role == keybase1.TeamRole_ADMIN || p.Role == keybase1.TeamRole_OWNER
 		}
@@ -1600,6 +1592,14 @@ func FindNextMerkleRootAfterRemoval(mctx libkb.MetaContext, arg keybase1.FindNex
 			return p.Role == keybase1.TeamRole_NONE
 		}
 		logPoint = team.chain().GetLastChangeLogPointWithPredicates(uv, reader, notReader)
+	} else {
+		writer := func(p keybase1.UserLogPoint) bool {
+			return p.Role == keybase1.TeamRole_WRITER || p.Role == keybase1.TeamRole_ADMIN || p.Role == keybase1.TeamRole_OWNER
+		}
+		notWriter := func(p keybase1.UserLogPoint) bool {
+			return p.Role == keybase1.TeamRole_READER || p.Role == keybase1.TeamRole_NONE
+		}
+		logPoint = team.chain().GetLastChangeLogPointWithPredicates(uv, writer, notWriter)
 	}
 	if logPoint == nil {
 		return res, libkb.NotFoundError{Msg: fmt.Sprintf("no downgraded log point for user found")}

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -868,7 +868,7 @@ protocol teams {
    with the given signing key being removed from the given team. If there are several such instances,
    we will return just the last one.
    */
-  NextMerkleRootRes findNextMerkleRootAfterTeamRemovalBySigningKey(UID uid, KID signingKey, TeamID team, boolean isPublic, boolean isWriter);
+  NextMerkleRootRes findNextMerkleRootAfterTeamRemovalBySigningKey(UID uid, KID signingKey, TeamID team, boolean isPublic, boolean wasReader);
 
   /**
    ProfileTeamLoad loads a team and then throws it on the ground, for the purposes of profiling

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -866,9 +866,10 @@ protocol teams {
   /**
    FindNextMerkleRootAfterTeamRemovalBySigningKey find the first Merkle root that contains the user
    with the given signing key being removed from the given team. If there are several such instances,
-   we will return just the last one.
+   we will return just the last one. When anyRoleAllowed is false, the team removal is any drop in
+   permissions from Writer (or above) to Reader (or below).
    */
-  NextMerkleRootRes findNextMerkleRootAfterTeamRemovalBySigningKey(UID uid, KID signingKey, TeamID team, boolean isPublic, boolean wasReader);
+  NextMerkleRootRes findNextMerkleRootAfterTeamRemovalBySigningKey(UID uid, KID signingKey, TeamID team, boolean isPublic, boolean anyRoleAllowed);
 
   /**
    ProfileTeamLoad loads a team and then throws it on the ground, for the purposes of profiling

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -868,7 +868,7 @@ protocol teams {
    with the given signing key being removed from the given team. If there are several such instances,
    we will return just the last one.
    */
-  NextMerkleRootRes findNextMerkleRootAfterTeamRemovalBySigningKey(UID uid, KID signingKey, TeamID team, boolean isPublic);
+  NextMerkleRootRes findNextMerkleRootAfterTeamRemovalBySigningKey(UID uid, KID signingKey, TeamID team, boolean isPublic, boolean isWriter);
 
   /**
    ProfileTeamLoad loads a team and then throws it on the ground, for the purposes of profiling

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2123,7 +2123,7 @@ export type TeamType =
   | 2 // MODERN_2
 
 export type TeamsCanUserPerformRpcParam = $ReadOnly<{name: String}>
-export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean, wasReader: Boolean}>
+export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean, anyRoleAllowed: Boolean}>
 export type TeamsFindNextMerkleRootAfterTeamRemovalRpcParam = $ReadOnly<{uid: UID, team: TeamID, isPublic: Boolean, teamSigchainSeqno: Seqno, prev: MerkleRootV2}>
 export type TeamsGetTarsDisabledRpcParam = $ReadOnly<{name: String}>
 export type TeamsGetTeamAndMemberShowcaseRpcParam = $ReadOnly<{name: String}>

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2123,7 +2123,7 @@ export type TeamType =
   | 2 // MODERN_2
 
 export type TeamsCanUserPerformRpcParam = $ReadOnly<{name: String}>
-export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean, isWriter: Boolean}>
+export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean, wasReader: Boolean}>
 export type TeamsFindNextMerkleRootAfterTeamRemovalRpcParam = $ReadOnly<{uid: UID, team: TeamID, isPublic: Boolean, teamSigchainSeqno: Seqno, prev: MerkleRootV2}>
 export type TeamsGetTarsDisabledRpcParam = $ReadOnly<{name: String}>
 export type TeamsGetTeamAndMemberShowcaseRpcParam = $ReadOnly<{name: String}>

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2123,7 +2123,7 @@ export type TeamType =
   | 2 // MODERN_2
 
 export type TeamsCanUserPerformRpcParam = $ReadOnly<{name: String}>
-export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean}>
+export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean, isWriter: Boolean}>
 export type TeamsFindNextMerkleRootAfterTeamRemovalRpcParam = $ReadOnly<{uid: UID, team: TeamID, isPublic: Boolean, teamSigchainSeqno: Seqno, prev: MerkleRootV2}>
 export type TeamsGetTarsDisabledRpcParam = $ReadOnly<{name: String}>
 export type TeamsGetTeamAndMemberShowcaseRpcParam = $ReadOnly<{name: String}>

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2642,6 +2642,10 @@
         {
           "name": "isPublic",
           "type": "boolean"
+        },
+        {
+          "name": "isWriter",
+          "type": "boolean"
         }
       ],
       "response": "NextMerkleRootRes",

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2649,7 +2649,7 @@
         }
       ],
       "response": "NextMerkleRootRes",
-      "doc": "FindNextMerkleRootAfterTeamRemovalBySigningKey find the first Merkle root that contains the user\n   with the given signing key being removed from the given team. If there are several such instances,\n   we will return just the last one."
+      "doc": "FindNextMerkleRootAfterTeamRemovalBySigningKey find the first Merkle root that contains the user\n   with the given signing key being removed from the given team. If there are several such instances,\n   we will return just the last one. When anyRoleAllowed is false, the team removal is any drop in\n   permissions from Writer (or above) to Reader (or below)."
     },
     "profileTeamLoad": {
       "request": [

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2644,7 +2644,7 @@
           "type": "boolean"
         },
         {
-          "name": "isWriter",
+          "name": "wasReader",
           "type": "boolean"
         }
       ],

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2644,7 +2644,7 @@
           "type": "boolean"
         },
         {
-          "name": "wasReader",
+          "name": "anyRoleAllowed",
           "type": "boolean"
         }
       ],

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2123,7 +2123,7 @@ export type TeamType =
   | 2 // MODERN_2
 
 export type TeamsCanUserPerformRpcParam = $ReadOnly<{name: String}>
-export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean, wasReader: Boolean}>
+export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean, anyRoleAllowed: Boolean}>
 export type TeamsFindNextMerkleRootAfterTeamRemovalRpcParam = $ReadOnly<{uid: UID, team: TeamID, isPublic: Boolean, teamSigchainSeqno: Seqno, prev: MerkleRootV2}>
 export type TeamsGetTarsDisabledRpcParam = $ReadOnly<{name: String}>
 export type TeamsGetTeamAndMemberShowcaseRpcParam = $ReadOnly<{name: String}>

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2123,7 +2123,7 @@ export type TeamType =
   | 2 // MODERN_2
 
 export type TeamsCanUserPerformRpcParam = $ReadOnly<{name: String}>
-export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean, isWriter: Boolean}>
+export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean, wasReader: Boolean}>
 export type TeamsFindNextMerkleRootAfterTeamRemovalRpcParam = $ReadOnly<{uid: UID, team: TeamID, isPublic: Boolean, teamSigchainSeqno: Seqno, prev: MerkleRootV2}>
 export type TeamsGetTarsDisabledRpcParam = $ReadOnly<{name: String}>
 export type TeamsGetTeamAndMemberShowcaseRpcParam = $ReadOnly<{name: String}>

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2123,7 +2123,7 @@ export type TeamType =
   | 2 // MODERN_2
 
 export type TeamsCanUserPerformRpcParam = $ReadOnly<{name: String}>
-export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean}>
+export type TeamsFindNextMerkleRootAfterTeamRemovalBySigningKeyRpcParam = $ReadOnly<{uid: UID, signingKey: KID, team: TeamID, isPublic: Boolean, isWriter: Boolean}>
 export type TeamsFindNextMerkleRootAfterTeamRemovalRpcParam = $ReadOnly<{uid: UID, team: TeamID, isPublic: Boolean, teamSigchainSeqno: Seqno, prev: MerkleRootV2}>
 export type TeamsGetTarsDisabledRpcParam = $ReadOnly<{name: String}>
 export type TeamsGetTeamAndMemberShowcaseRpcParam = $ReadOnly<{name: String}>


### PR DESCRIPTION
Currently, when a user gets kicked out of a team, and another client wants to know the first merkle root after that happened, we're using a bit of a broad stroke. We're finding the last update where they don't have permissions to write (or to read). 

The idea here is to allow a client to request whether this is someone being dropped from their status as a reader of the team (i.e. completely kicked out) or as a writer (e.g. Writer -> Reader) but not necessarily removed. More nuance. 

* add the anyRoleAllowed boolean field to FindNextMerkleRootAfterTeamRemovalBySigningKeyArg and related other places
* update the logic on logpoint searching to find the first value of the lower permission AFTER the last value of the higher permission. 