### PR TITLE
run badger resync before we sync other state

### DIFF
--- a/go/badges/badger.go
+++ b/go/badges/badger.go
@@ -49,20 +49,20 @@ func (b *Badger) SetInboxVersionSource(s InboxVersionSource) {
 }
 
 func (b *Badger) PushState(ctx context.Context, state gregor1.State) {
-	b.G().Log.Debug("Badger update with gregor state")
+	b.G().Log.CDebugf(ctx, "Badger update with gregor state")
 	b.badgeState.UpdateWithGregor(ctx, state)
-	err := b.Send()
+	err := b.Send(ctx)
 	if err != nil {
 		b.G().Log.Warning("Badger send (pushstate) failed: %v", err)
 	}
 }
 
 func (b *Badger) PushChatUpdate(ctx context.Context, update chat1.UnreadUpdate, inboxVers chat1.InboxVers) {
-	b.G().Log.Debug("Badger update with chat update")
+	b.G().Log.CDebugf(ctx, "Badger update with chat update")
 	b.badgeState.UpdateWithChat(ctx, update, inboxVers)
-	err := b.Send()
+	err := b.Send(ctx)
 	if err != nil {
-		b.G().Log.Warning("Badger send (pushchatupdate) failed: %v", err)
+		b.G().Log.CDebugf(ctx, "Badger send (pushchatupdate) failed: %v", err)
 	}
 }
 
@@ -70,17 +70,14 @@ func (b *Badger) inboxVersion(ctx context.Context) chat1.InboxVers {
 	uid := b.G().Env.GetUID()
 	vers, err := b.iboxVersSource.GetInboxVersion(ctx, uid.ToBytes())
 	if err != nil {
-		b.G().Log.Debug("Badger: inboxVersion error: %s", err.Error())
+		b.G().Log.CDebugf(ctx, "Badger: inboxVersion error: %s", err.Error())
 		return chat1.InboxVers(0)
 	}
 	return vers
 }
 
 func (b *Badger) Resync(ctx context.Context, chatRemote func() chat1.RemoteInterface,
-	gcli *grclient.Client, update *chat1.UnreadUpdateFull) error {
-	b.G().Log.Debug("Badger resync req")
-
-	var err error
+	gcli *grclient.Client, update *chat1.UnreadUpdateFull) (err error) {
 	if update == nil {
 		iboxVersion := b.inboxVersion(ctx)
 		b.G().Log.Debug("Badger: Resync(): using inbox version: %v", iboxVersion)
@@ -91,40 +88,40 @@ func (b *Badger) Resync(ctx context.Context, chatRemote func() chat1.RemoteInter
 			return err
 		}
 	} else {
-		b.G().Log.Debug("Badger: Resync(): skipping remote call, data previously obtained")
+		b.G().Log.CDebugf(ctx, "Badger: Resync(): skipping remote call, data previously obtained")
 	}
 
 	state, err := gcli.StateMachineState(ctx, nil, false)
 	if err != nil {
-		b.G().Log.Debug("Badger: Resync(): unable to get state: %s", err.Error())
+		b.G().Log.CDebugf(ctx, "Badger: Resync(): unable to get state: %s", err.Error())
 		state = gregor1.State{}
 	}
 	b.badgeState.UpdateWithChatFull(ctx, *update)
 	b.badgeState.UpdateWithGregor(ctx, state)
-	err = b.Send()
+	err = b.Send(ctx)
 	if err != nil {
-		b.G().Log.Warning("Badger send (resync) failed: %v", err)
+		b.G().Log.CDebugf(ctx, "Badger send (resync) failed: %v", err)
 	} else {
-		b.G().Log.Debug("Badger resync complete")
+		b.G().Log.CDebugf(ctx, "Badger resync complete")
 	}
 	return err
 }
 
 func (b *Badger) Clear(ctx context.Context) {
 	b.badgeState.Clear()
-	err := b.Send()
+	err := b.Send(ctx)
 	if err != nil {
-		b.G().Log.Warning("Badger send (clear) failed: %v", err)
+		b.G().Log.CDebugf(ctx, "Badger send (clear) failed: %v", err)
 	}
 }
 
 // Send the badgestate to electron
-func (b *Badger) Send() error {
+func (b *Badger) Send(ctx context.Context) error {
 	state, err := b.badgeState.Export()
 	if err != nil {
 		return err
 	}
-	b.log(state)
+	b.log(ctx, state)
 	b.G().NotifyRouter.HandleBadgeState(state)
 	return nil
 }
@@ -134,7 +131,7 @@ func (b *Badger) State() *BadgeState {
 }
 
 // Log a copy of the badgestate with some zeros stripped off for brevity.
-func (b *Badger) log(state1 keybase1.BadgeState) {
+func (b *Badger) log(ctx context.Context, state1 keybase1.BadgeState) {
 	var state2 keybase1.BadgeState
 	state2 = state1
 	state2.Conversations = nil
@@ -156,5 +153,5 @@ func (b *Badger) log(state1 keybase1.BadgeState) {
 		}
 		state2.Conversations = append(state2.Conversations, c2)
 	}
-	b.G().Log.Debug("Badger send: %+v", state2)
+	b.G().Log.CDebugf(ctx, "Badger send: %+v", state2)
 }

--- a/go/badges/badger.go
+++ b/go/badges/badger.go
@@ -48,18 +48,18 @@ func (b *Badger) SetInboxVersionSource(s InboxVersionSource) {
 	b.iboxVersSource = s
 }
 
-func (b *Badger) PushState(state gregor1.State) {
+func (b *Badger) PushState(ctx context.Context, state gregor1.State) {
 	b.G().Log.Debug("Badger update with gregor state")
-	b.badgeState.UpdateWithGregor(state)
+	b.badgeState.UpdateWithGregor(ctx, state)
 	err := b.Send()
 	if err != nil {
 		b.G().Log.Warning("Badger send (pushstate) failed: %v", err)
 	}
 }
 
-func (b *Badger) PushChatUpdate(update chat1.UnreadUpdate, inboxVers chat1.InboxVers) {
+func (b *Badger) PushChatUpdate(ctx context.Context, update chat1.UnreadUpdate, inboxVers chat1.InboxVers) {
 	b.G().Log.Debug("Badger update with chat update")
-	b.badgeState.UpdateWithChat(update, inboxVers)
+	b.badgeState.UpdateWithChat(ctx, update, inboxVers)
 	err := b.Send()
 	if err != nil {
 		b.G().Log.Warning("Badger send (pushchatupdate) failed: %v", err)
@@ -99,8 +99,8 @@ func (b *Badger) Resync(ctx context.Context, chatRemote func() chat1.RemoteInter
 		b.G().Log.Debug("Badger: Resync(): unable to get state: %s", err.Error())
 		state = gregor1.State{}
 	}
-	b.badgeState.UpdateWithChatFull(*update)
-	b.badgeState.UpdateWithGregor(state)
+	b.badgeState.UpdateWithChatFull(ctx, *update)
+	b.badgeState.UpdateWithGregor(ctx, state)
 	err = b.Send()
 	if err != nil {
 		b.G().Log.Warning("Badger send (resync) failed: %v", err)

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -616,7 +616,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			return
 		}
 		if g.badger != nil && gm.UnreadUpdate != nil {
-			g.badger.PushChatUpdate(*gm.UnreadUpdate, gm.InboxVers)
+			g.badger.PushChatUpdate(ctx, *gm.UnreadUpdate, gm.InboxVers)
 		}
 		if activity != nil {
 			g.notifyNewChatActivity(ctx, m.UID(), gm.TopicType, activity)
@@ -843,10 +843,10 @@ func (g *PushHandler) MembershipUpdate(ctx context.Context, m gregor.OutOfBandMe
 		// Fire off badger updates
 		if g.badger != nil {
 			if update.UnreadUpdate != nil {
-				g.badger.PushChatUpdate(*update.UnreadUpdate, update.InboxVers)
+				g.badger.PushChatUpdate(ctx, *update.UnreadUpdate, update.InboxVers)
 			}
 			for _, upd := range update.UnreadUpdates {
-				g.badger.PushChatUpdate(upd, update.InboxVers)
+				g.badger.PushChatUpdate(ctx, upd, update.InboxVers)
 			}
 		}
 

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1083,6 +1083,12 @@ func MakeEmptyUnreadUpdate(convID ConversationID) UnreadUpdate {
 	}
 }
 
+func (u UnreadUpdate) String() string {
+	return fmt.Sprintf("[d:%v c:%s u:%d nd:%d nm:%d]", u.Diff, u.ConvID, u.UnreadMessages,
+		u.UnreadNotifyingMessages[keybase1.DeviceType_DESKTOP],
+		u.UnreadNotifyingMessages[keybase1.DeviceType_MOBILE])
+}
+
 func (s TopicNameState) Bytes() []byte {
 	return []byte(s)
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -491,7 +491,7 @@ func (g *gregorHandler) PushHandler(handler libkb.GregorInBandMessageHandler) {
 				g.Warning(context.Background(), "Cannot get state in PushHandler: %s", err)
 				return
 			}
-			g.badger.PushState(s)
+			g.badger.PushState(context.Background(), s)
 		}
 	}
 }
@@ -543,7 +543,7 @@ func (g *gregorHandler) pushState(r keybase1.PushReason) {
 	// Only send this state update on reception of new data, not a reconnect since we will
 	// be sending that on a different code path altogether (see OnConnect).
 	if g.badger != nil && r != keybase1.PushReason_RECONNECTED {
-		g.badger.PushState(s)
+		g.badger.PushState(context.Background(), s)
 	}
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -780,6 +780,13 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 		return fmt.Errorf("error authenticating: %s", err)
 	}
 
+	// Sync badge state in the background
+	if g.badger != nil {
+		if err := g.badger.Resync(ctx, g.GetClient, gcli, &syncAllRes.Badge); err != nil {
+			g.chatLog.Debug(ctx, "badger failure: %s", err)
+		}
+	}
+
 	// Sync chat data using a Syncer object
 	if err := g.G().Syncer.Connected(ctx, chatCli, uid, &syncAllRes.Chat); err != nil {
 		return fmt.Errorf("error running chat sync: %s", err)
@@ -790,13 +797,6 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 		&syncAllRes.Notification); err != nil {
 		g.chatLog.Debug(ctx, "serverSync: failure: %s", err)
 		return fmt.Errorf("error running state sync: %s", err)
-	}
-
-	// Sync badge state in the background
-	if g.badger != nil {
-		if err := g.badger.Resync(ctx, g.GetClient, gcli, &syncAllRes.Badge); err != nil {
-			g.chatLog.Debug(ctx, "badger failure: %s", err)
-		}
 	}
 
 	// Call out to reachability module if we have one

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -738,14 +738,14 @@ func TestGregorBadgesOOBM(t *testing.T) {
 	t.Logf("client setup complete")
 
 	t.Logf("sending first chat update")
-	h.badger.PushChatUpdate(chat1.UnreadUpdate{
+	h.badger.PushChatUpdate(context.TODO(), chat1.UnreadUpdate{
 		ConvID:         chat1.ConversationID(`a`),
 		UnreadMessages: 2,
 	}, 0)
 	_ = listener.getBadgeState(t)
 
 	t.Logf("sending second chat update")
-	h.badger.PushChatUpdate(chat1.UnreadUpdate{
+	h.badger.PushChatUpdate(context.TODO(), chat1.UnreadUpdate{
 		ConvID:         chat1.ConversationID(`b`),
 		UnreadMessages: 2,
 	}, 1)
@@ -756,7 +756,7 @@ func TestGregorBadgesOOBM(t *testing.T) {
 
 	t.Logf("resyncing")
 	// Instead of calling badger.Resync, reach in and twiddle the knobs.
-	h.badger.State().UpdateWithChatFull(chat1.UnreadUpdateFull{
+	h.badger.State().UpdateWithChatFull(context.TODO(), chat1.UnreadUpdateFull{
 		InboxVers: chat1.InboxVers(4),
 		Updates: []chat1.UnreadUpdate{
 			{ConvID: chat1.ConversationID(`b`), UnreadMessages: 0},
@@ -764,7 +764,7 @@ func TestGregorBadgesOOBM(t *testing.T) {
 		},
 		InboxSyncStatus: chat1.SyncInboxResType_CLEAR,
 	})
-	h.badger.Send()
+	h.badger.Send(context.TODO())
 	bs = listener.getBadgeState(t)
 	require.Equal(t, 1, badgeStateStats(bs).UnreadChatConversations, "unread chat convs")
 	require.Equal(t, 3, badgeStateStats(bs).UnreadChatMessages, "unread chat messages")


### PR DESCRIPTION
I **think** that it is possible that when running `gregorHandler#OnConnect` that we can sync the inbox state, but then miss our chance to sync the badger state. If this happens, the badger will get stuck since any further `Resync` calls will be against the updated inbox version. Patch does the following:

1.) Run `Badger#ReSync` before we sync chat or notification state. This makes it so that the badger state can get out ahead of the inbox, but that is better than the current direction. 
2.) Add some more logging, and context aware logging to badger code. 