### PR TITLE
try different gcm enabled

### DIFF
--- a/shared/react-native/android/app/src/main/AndroidManifest.xml
+++ b/shared/react-native/android/app/src/main/AndroidManifest.xml
@@ -62,9 +62,16 @@
               <action android:name="com.google.android.c2dm.intent.RECEIVE" />
           </intent-filter>
       </service>
-      <service android:name="com.evernote.android.job.gcm.PlatformGcmService"
-          android:enabled="true"
-          tools:replace="android:enabled"/>
+        <service
+            android:name="com.evernote.android.job.gcm.PlatformGcmService"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE"
+            tools:replace="android:enabled">
+            <intent-filter>
+                <action android:name="com.google.android.gms.gcm.ACTION_TASK_READY"/>
+            </intent-filter>
+        </service>
       <provider
           android:name="io.keybase.ossifrage.util.SharedFileProvider"
           android:authorities="${applicationId}.fileprovider"


### PR DESCRIPTION
Following a different suggestion in the issue https://github.com/evernote/android-job/issues/415 to fix the background crashes implemented here: https://github.com/nextcloud/android/pull/2650.

@AMarcedone says he hasn't noticed anything, might be best to merge this and monitor on more staff devices before potentially doing a hotfix release. I haven't been able to reproduce with the android simulator