### PR TITLE
make sure to always send a response from sync to notify clients

### DIFF
--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -60,11 +60,15 @@ func (n *chatListener) ChatThreadsStale(uid keybase1.UID, updates []chat1.Conver
 		panic("timeout on the threads stale channel")
 	}
 }
-func (n *chatListener) ChatInboxSynced(uid keybase1.UID, syncRes chat1.ChatSyncResult) {
-	select {
-	case n.inboxSynced <- syncRes:
-	case <-time.After(5 * time.Second):
-		panic("timeout on the threads stale channel")
+func (n *chatListener) ChatInboxSynced(uid keybase1.UID, topicType chat1.TopicType,
+	syncRes chat1.ChatSyncResult) {
+	switch topicType {
+	case chat1.TopicType_CHAT, chat1.TopicType_NONE:
+		select {
+		case n.inboxSynced <- syncRes:
+		case <-time.After(5 * time.Second):
+			panic("timeout on the threads stale channel")
+		}
 	}
 }
 func (n *chatListener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate) {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1888,8 +1888,12 @@ func (n *serverChatListener) ChatInboxStale(uid keybase1.UID) {
 func (n *serverChatListener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationStaleUpdate) {
 	n.threadsStale <- cids
 }
-func (n *serverChatListener) ChatInboxSynced(uid keybase1.UID, syncRes chat1.ChatSyncResult) {
-	n.inboxSynced <- syncRes
+func (n *serverChatListener) ChatInboxSynced(uid keybase1.UID, topicType chat1.TopicType,
+	syncRes chat1.ChatSyncResult) {
+	switch topicType {
+	case chat1.TopicType_CHAT, chat1.TopicType_NONE:
+		n.inboxSynced <- syncRes
+	}
 }
 func (n *serverChatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity) {
 	typ, _ := activity.ActivityType()

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -308,6 +308,12 @@ func (s *Syncer) filterNotifyConvs(ctx context.Context, convs []chat1.Conversati
 
 func (s *Syncer) notifyIncrementalSync(ctx context.Context, uid keybase1.UID,
 	allConvs []chat1.UnverifiedInboxUIItem) {
+	if len(allConvs) == 0 {
+		s.Debug(ctx, "notifyIncrementalSync: no conversations give, sending a current result")
+		s.G().NotifyRouter.HandleChatInboxSynced(ctx, uid, chat1.TopicType_NONE,
+			chat1.NewChatSyncResultWithCurrent())
+		return
+	}
 	m := make(map[chat1.TopicType][]chat1.UnverifiedInboxUIItem)
 	for _, c := range allConvs {
 		m[c.TopicType] = append(m[c.TopicType], c)

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -292,7 +292,9 @@ func (s *Syncer) filterNotifyConvs(ctx context.Context, convs []chat1.Conversati
 		switch conv.GetMembersType() {
 		case chat1.ConversationMembersType_TEAM:
 			// include if this is a simple team, or the topic name has changed
-			if conv.Metadata.TeamType != chat1.TeamType_COMPLEX || m[conv.GetConvID().String()] ||
+			if conv.GetTopicType() != chat1.TopicType_CHAT ||
+				conv.Metadata.TeamType != chat1.TeamType_COMPLEX ||
+				m[conv.GetConvID().String()] ||
 				conv.GetConvID().Eq(s.GetSelectedConversation()) {
 				include = true
 			}

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -321,6 +321,9 @@ func (s *Syncer) notifyIncrementalSync(ctx context.Context, uid keybase1.UID,
 		m[c.TopicType] = append(m[c.TopicType], c)
 	}
 	for _, topicType := range chat1.TopicTypeMap {
+		if topicType == chat1.TopicType_NONE {
+			continue
+		}
 		convs := m[topicType]
 		s.G().NotifyRouter.HandleChatInboxSynced(ctx, uid, topicType,
 			chat1.NewChatSyncResultWithIncremental(chat1.ChatSyncIncrementalInfo{

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -309,7 +309,7 @@ func (s *Syncer) filterNotifyConvs(ctx context.Context, convs []chat1.Conversati
 func (s *Syncer) notifyIncrementalSync(ctx context.Context, uid keybase1.UID,
 	allConvs []chat1.UnverifiedInboxUIItem) {
 	if len(allConvs) == 0 {
-		s.Debug(ctx, "notifyIncrementalSync: no conversations give, sending a current result")
+		s.Debug(ctx, "notifyIncrementalSync: no conversations given, sending a current result")
 		s.G().NotifyRouter.HandleChatInboxSynced(ctx, uid, chat1.TopicType_NONE,
 			chat1.NewChatSyncResultWithCurrent())
 		return
@@ -318,7 +318,8 @@ func (s *Syncer) notifyIncrementalSync(ctx context.Context, uid keybase1.UID,
 	for _, c := range allConvs {
 		m[c.TopicType] = append(m[c.TopicType], c)
 	}
-	for topicType, convs := range m {
+	for _, topicType := range chat1.TopicTypeMap {
+		convs := m[topicType]
 		s.G().NotifyRouter.HandleChatInboxSynced(ctx, uid, topicType,
 			chat1.NewChatSyncResultWithIncremental(chat1.ChatSyncIncrementalInfo{
 				Items: convs,


### PR DESCRIPTION
We run a variety of filters on the conversations the server sends down to sync, most notably we do not send up notifications for non-selected big team channels. If those were the only thing to have changed, then we would just send nothing and the frontend blue loading bar could get stuck. Patch does the following:

1.) If we have 0 conversations to sync, then just send up a `CURRENT` response, even if the server said it was incremental.
2.) If we have at least 1 conversation, then send a notification on each `TopicType` channel. This will make it so that it is possible to receive an `INCREMENTAL` response with nothing in it. cc @chrisnojima  hopefully the JS is cool with this.
3.) Only filter big team channels out of the sync that are of type `CHAT`, and let other topic types through. 