### PR TITLE
Optionally add extended status in log send

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -217,7 +217,7 @@ func LogSend(status string, feedback string, sendLogs bool, uiLogPath, traceDir 
 	logSendContext.Logs.Desktop = uiLogPath
 	logSendContext.Logs.Trace = traceDir
 	env := kbCtx.Env
-	return logSendContext.LogSend(status, feedback, sendLogs, 10*1024*1024, env.GetUID(), env.GetInstallID())
+	return logSendContext.LogSend(status, feedback, sendLogs, 10*1024*1024, env.GetUID(), env.GetInstallID(), true /* mergeExtendedStatus */)
 }
 
 // WriteB64 sends a base64 encoded msgpack rpc payload

--- a/go/client/cmd_log_send.go
+++ b/go/client/cmd_log_send.go
@@ -132,7 +132,7 @@ func (c *CmdLogSend) Run() error {
 		c.G().Log.Info("Not sending up a UID for logged in user; none found")
 	}
 
-	id, err := logSendContext.LogSend(statusJSON, c.feedback, true, c.numBytes, uid, installID)
+	id, err := logSendContext.LogSend(statusJSON, c.feedback, true, c.numBytes, uid, installID, false /* mergeExtendedStatus */)
 	if err != nil {
 		return err
 	}

--- a/go/libkb/status.go
+++ b/go/libkb/status.go
@@ -4,6 +4,8 @@
 package libkb
 
 import (
+	"runtime"
+
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
@@ -33,5 +35,96 @@ func GetCurrentStatus(ctx context.Context, g *GlobalContext) (res CurrentStatus,
 	}
 	res.SessionIsValid = g.ActiveDevice.Valid()
 	res.LoggedIn = res.SessionIsValid
+	return res, nil
+}
+
+func getPlatformInfo() keybase1.PlatformInfo {
+	return keybase1.PlatformInfo{
+		Os:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+		GoVersion: runtime.Version(),
+	}
+}
+
+func GetExtendedStatus(ctx context.Context, g *GlobalContext) (res keybase1.ExtendedStatus, err error) {
+	defer g.Trace("GetExtendedStatus", func() error { return err })()
+
+	res.Standalone = g.Env.GetStandalone()
+	res.LogDir = g.Env.GetLogDir()
+
+	// Should work in standalone mode too
+	if g.ConnectionManager != nil {
+		res.Clients = g.ConnectionManager.ListAllLabeledConnections()
+	}
+
+	err = g.GetFullSelfer().WithSelf(ctx, func(me *User) error {
+		device, err := me.GetComputedKeyFamily().GetCurrentDevice(g)
+		if err != nil {
+			g.Log.Debug("| GetCurrentDevice failed: %s", err)
+			res.DeviceErr = &keybase1.LoadDeviceErr{Where: "ckf.GetCurrentDevice", Desc: err.Error()}
+		} else {
+			res.Device = device.ProtExport()
+		}
+
+		ss := g.SecretStore()
+		if me != nil && ss != nil {
+			s, err := ss.RetrieveSecret(me.GetNormalizedName())
+			if err == nil && !s.IsNil() {
+				res.StoredSecret = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		g.Log.Debug("| could not load me user: %s", err)
+		res.DeviceErr = &keybase1.LoadDeviceErr{Where: "libkb.LoadMe", Desc: err.Error()}
+	}
+
+	// cached device key status
+	_, _, _, sk, ek := g.ActiveDevice.AllFields()
+	res.DeviceSigKeyCached = sk != nil
+	res.DeviceEncKeyCached = ek != nil
+
+	m := NewMetaContext(ctx, g)
+	ad := m.ActiveDevice()
+	// cached paper key status
+	if pk := ad.PaperKey(m); pk != nil {
+		if pk.EncryptionKey() != nil {
+			res.PaperEncKeyCached = true
+		}
+		if pk.SigningKey() != nil {
+			res.PaperSigKeyCached = true
+		}
+	}
+
+	psc := ad.PassphraseStreamCache()
+	res.PassphraseStreamCached = psc.ValidPassphraseStream()
+	res.TsecCached = psc.ValidTsec()
+	res.SecretPromptSkip = m.ActiveDevice().SecretPromptCancelTimer().WasRecentlyCanceled(m)
+
+	current, all, err := GetAllProvisionedUsernames(m)
+	if err != nil {
+		g.Log.Debug("| died in GetAllUseranmes()")
+		return res, err
+	}
+	res.DefaultUsername = current.String()
+	p := make([]string, len(all))
+	for i, u := range all {
+		p[i] = u.String()
+	}
+	res.ProvisionedUsernames = p
+	res.PlatformInfo = getPlatformInfo()
+	res.DefaultDeviceID = g.Env.GetDeviceID()
+	res.RememberPassphrase = g.Env.RememberPassphrase()
+	// DeviceEK status, can be nil if user is logged out
+	deviceEKStorage := g.GetDeviceEKStorage()
+	if deviceEKStorage != nil {
+		dekNames, err := deviceEKStorage.ListAllForUser(ctx)
+		if err != nil {
+			return res, err
+		}
+		res.DeviceEkNames = dekNames
+	}
+
 	return res, nil
 }

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -45,14 +44,6 @@ func (h ConfigHandler) GetCurrentStatus(ctx context.Context, sessionID int) (res
 		res = cs.Export()
 	}
 	return
-}
-
-func getPlatformInfo() keybase1.PlatformInfo {
-	return keybase1.PlatformInfo{
-		Os:        runtime.GOOS,
-		Arch:      runtime.GOARCH,
-		GoVersion: runtime.Version(),
-	}
 }
 
 func (h ConfigHandler) GetValue(_ context.Context, path string) (ret keybase1.ConfigValue, err error) {
@@ -123,82 +114,7 @@ func (h ConfigHandler) ClearValue(_ context.Context, path string) error {
 }
 
 func (h ConfigHandler) GetExtendedStatus(ctx context.Context, sessionID int) (res keybase1.ExtendedStatus, err error) {
-	defer h.G().Trace("ConfigHandler::GetExtendedStatus", func() error { return err })()
-
-	res.Standalone = h.G().Env.GetStandalone()
-	res.LogDir = h.G().Env.GetLogDir()
-
-	// Should work in standalone mode too
-	if h.G().ConnectionManager != nil {
-		res.Clients = h.G().ConnectionManager.ListAllLabeledConnections()
-	}
-
-	err = h.G().GetFullSelfer().WithSelf(ctx, func(me *libkb.User) error {
-		device, err := me.GetComputedKeyFamily().GetCurrentDevice(h.G())
-		if err != nil {
-			h.G().Log.Debug("| GetCurrentDevice failed: %s", err)
-			res.DeviceErr = &keybase1.LoadDeviceErr{Where: "ckf.GetCurrentDevice", Desc: err.Error()}
-		} else {
-			res.Device = device.ProtExport()
-		}
-
-		ss := h.G().SecretStore()
-		if me != nil && ss != nil {
-			s, err := ss.RetrieveSecret(me.GetNormalizedName())
-			if err == nil && !s.IsNil() {
-				res.StoredSecret = true
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		h.G().Log.Debug("| could not load me user: %s", err)
-		res.DeviceErr = &keybase1.LoadDeviceErr{Where: "libkb.LoadMe", Desc: err.Error()}
-	}
-
-	// cached device key status
-	_, _, _, sk, ek := h.G().ActiveDevice.AllFields()
-	res.DeviceSigKeyCached = sk != nil
-	res.DeviceEncKeyCached = ek != nil
-
-	m := libkb.NewMetaContext(ctx, h.G())
-	ad := m.ActiveDevice()
-	// cached paper key status
-	if pk := ad.PaperKey(m); pk != nil {
-		if pk.EncryptionKey() != nil {
-			res.PaperEncKeyCached = true
-		}
-		if pk.SigningKey() != nil {
-			res.PaperSigKeyCached = true
-		}
-	}
-
-	psc := ad.PassphraseStreamCache()
-	res.PassphraseStreamCached = psc.ValidPassphraseStream()
-	res.TsecCached = psc.ValidTsec()
-	res.SecretPromptSkip = m.ActiveDevice().SecretPromptCancelTimer().WasRecentlyCanceled(m)
-
-	current, all, err := libkb.GetAllProvisionedUsernames(m)
-	if err != nil {
-		h.G().Log.Debug("| died in GetAllUseranmes()")
-		return res, err
-	}
-	res.DefaultUsername = current.String()
-	p := make([]string, len(all))
-	for i, u := range all {
-		p[i] = u.String()
-	}
-	res.ProvisionedUsernames = p
-	res.PlatformInfo = getPlatformInfo()
-	res.DefaultDeviceID = h.G().Env.GetDeviceID()
-	res.RememberPassphrase = h.G().Env.RememberPassphrase()
-	dekNames, err := h.G().GetDeviceEKStorage().ListAllForUser(ctx)
-	if err != nil {
-		return res, err
-	}
-	res.DeviceEkNames = dekNames
-
-	return res, nil
+	return libkb.GetExtendedStatus(ctx, h.G())
 }
 
 func (h ConfigHandler) GetConfig(_ context.Context, sessionID int) (keybase1.Config, error) {


### PR DESCRIPTION
Right now the mobile status is pretty limited compared to desktop reports. The extended status is especially helpful for debugging deviceEK state since we log the filenames stored on disk.

- moves `GetExtendedStatus` to `libkb` and merges the result with the json string the frontend gives us
- adds library https://github.com/fatih/structs to simplify the json merging process (unless there is an easier way of doing this?)

an example log with these changes is here: https://keybase.io/_/admin/logdump_viewer?360376538#9d2deedf4facfd1e9391271c