### PR TITLE
More api tracing

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -679,6 +679,7 @@ func (a *InternalAPIEngine) Get(arg APIArg) (*APIRes, error) {
 // second arg should be called whenever we're done with the response (if it's non-nil).
 func (a *InternalAPIEngine) GetResp(arg APIArg) (*http.Response, func(), error) {
 	m := arg.GetMetaContext(a.G())
+	m = m.EnsureCtx().WithLogTag("API")
 
 	url1 := a.getURL(arg)
 	req, err := a.PrepareGet(url1, arg)
@@ -752,6 +753,7 @@ func (a *InternalAPIEngine) PostJSON(arg APIArg) (*APIRes, error) {
 // postResp performs a POST request and returns the http response.
 // The finisher() should be called after the response is no longer needed.
 func (a *InternalAPIEngine) postResp(m MetaContext, arg APIArg) (*http.Response, func(), error) {
+	m = m.EnsureCtx().WithLogTag("API")
 	url1 := a.getURL(arg)
 	req, err := a.PrepareMethodWithBody("POST", url1, arg)
 	if err != nil {
@@ -807,11 +809,13 @@ func (a *InternalAPIEngine) Delete(arg APIArg) (*APIRes, error) {
 
 func (a *InternalAPIEngine) DoRequest(arg APIArg, req *http.Request) (*APIRes, error) {
 	m := arg.GetMetaContext(a.G())
+	m = m.EnsureCtx().WithLogTag("API")
 	res, err := a.doRequest(m, arg, req)
 	return res, err
 }
 
 func (a *InternalAPIEngine) doRequest(m MetaContext, arg APIArg, req *http.Request) (res *APIRes, err error) {
+	m = m.EnsureCtx().WithLogTag("API")
 	defer a.G().CTraceTimed(m.Ctx(), "InternalAPIEngine#doRequest", func() error { return err })()
 	resp, finisher, jw, err := doRequestShared(m, a, arg, req, true)
 	if err != nil {
@@ -892,6 +896,7 @@ func (api *ExternalAPIEngine) DoRequest(
 	ar *ExternalAPIRes, hr *ExternalHTMLRes, tr *ExternalTextRes, err error) {
 
 	m := arg.GetMetaContext(api.G())
+	m = m.EnsureCtx().WithLogTag("API")
 
 	var resp *http.Response
 	var jw *jsonw.Wrapper


### PR DESCRIPTION
This makes the line with `time=` tagged with the API trace.
```
2018-07-03T10:52:45.572161-04:00 ▶ [DEBU keybase api.go:819] a82 + InternalAPIEngine#doRequest [tags:TM=iachMnXyjMYe,API=WUpJS4Mh4KIt]
2018-07-03T10:52:45.572201-04:00 ▶ [DEBU keybase context.go:96] a83 MetaContext#ActiveDevice: global [tags:TM=iachMnXyjMYe,API=WUpJS4Mh4KIt]
2018-07-03T10:52:45.572232-04:00 ▶ [DEBU keybase nist.go:98] a84 | NISTFactory#NIST: returning existing NIST (expires conservatively in 25h59m53.978222s, expiresAt: 2018-07-05 14:52:
39.550449 -0400 EDT) [tags:TM=iachMnXyjMYe,API=WUpJS4Mh4KIt]
2018-07-03T10:52:45.721906-04:00 ▶ [DEBU keybase api.go:277] ae0 - API POST http://localhost:3000/_/api/1.0/sig/multi.json: err=ok, status="200 OK", jsonwBytes=33 [tags:TM=iachMnXyjM
Ye,API=WUpJS4Mh4KIt]
2018-07-03T10:52:45.722045-04:00 ▶ [DEBU keybase api.go:841] ae1 - API call sig/multi success [tags:TM=iachMnXyjMYe,API=WUpJS4Mh4KIt]
2018-07-03T10:52:45.722091-04:00 ▶ [DEBU keybase api.go:813] ae2 - InternalAPIEngine#doRequest -> <nil> [time=149.900469ms] [tags:API=WUpJS4Mh4KIt,TM=iachMnXyjMYe]
```