### PR TITLE
Actions/Config cleanup part 1

### DIFF
--- a/shared/actions/app.js
+++ b/shared/actions/app.js
@@ -3,7 +3,6 @@ import logger from '../logger'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import * as Saga from '../util/saga'
 import * as AppGen from './app-gen'
-import {showMainWindow} from './platform-specific'
 import {quit} from '../util/quit-helper'
 import dumpLogs from '../logger/dump-log-fs'
 
@@ -27,10 +26,6 @@ function _onMobileAppStateChanged(action: AppGen.MobileAppStatePayload) {
   return Saga.put(AppGen.createChangedFocus({appFocused}))
 }
 
-function _onShowMain() {
-  showMainWindow()
-}
-
 function _dumpLogs(action: AppGen.DumpLogsPayload) {
   dumpLogs().then(() => {
     // quit as soon as possible
@@ -41,7 +36,6 @@ function _dumpLogs(action: AppGen.DumpLogsPayload) {
 }
 
 function* appStateSaga(): Saga.SagaGenerator<any, any> {
-  yield Saga.safeTakeLatestPure(AppGen.showMain, _onShowMain)
   yield Saga.safeTakeEveryPure(AppGen.mobileAppState, _onMobileAppStateChanged)
   yield Saga.safeTakeEveryPure(AppGen.dumpLogs, _dumpLogs)
 }

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -24,11 +24,7 @@ import {chatTab} from '../../constants/tabs'
 import {isMobile} from '../../constants/platform'
 import {getPath} from '../../route-tree'
 import {NotifyPopup} from '../../native/notifications'
-import {
-  showMainWindow,
-  saveAttachmentToCameraRoll,
-  downloadAndShowShareActionSheet,
-} from '../platform-specific'
+import {saveAttachmentToCameraRoll, downloadAndShowShareActionSheet} from '../platform-specific'
 import {tmpDir, downloadFilePath} from '../../util/file'
 import {privateFolderWithUsers, teamFolder} from '../../constants/config'
 import flags from '../../util/feature-flags'
@@ -940,7 +936,7 @@ const desktopNotify = (action: Chat2Gen.DesktopNotificationPayload, state: Typed
           })
         )
         dispatch(Route.switchTo([chatTab]))
-        showMainWindow()
+        dispatch(AppGen.createShowMain())
       })
     })
   }

--- a/shared/actions/platform-specific.js.flow
+++ b/shared/actions/platform-specific.js.flow
@@ -1,12 +1,10 @@
 // @flow
+import * as Saga from '../util/saga'
 declare export function checkPermissions(): Promise<boolean>
 declare export function getShownPushPrompt(): Promise<0 | 1>
 declare export function openAppSettings(): void
 declare export function requestPushPermissions(): Promise<void>
 declare export function configurePush(): void
-declare export function showMainWindow(): void
-declare export function getAppState(): Promise<Object>
-declare export function setAppState(toMerge: Object): void
 declare export function showShareActionSheet(options: {url?: ?any, message?: ?any}): Promise<{
   completed: boolean,
   method: string,
@@ -28,3 +26,5 @@ declare export function getContentTypeFromURL(
   url: string,
   cb: {error?: any, statusCode?: number, contentType?: string}
 ): Promise<string>
+
+declare export function platformConfigSaga(): Saga.SagaGenerator<any, any>

--- a/shared/actions/platform-specific.native.js
+++ b/shared/actions/platform-specific.native.js
@@ -5,6 +5,7 @@ import * as PushConstants from '../constants/push'
 import * as PushGen from './push-gen'
 import * as PushNotifications from 'react-native-push-notification'
 import * as mime from 'react-native-mime-types'
+import * as Saga from '../util/saga'
 import RNFetchBlob from 'react-native-fetch-blob'
 import {
   PushNotificationIOS,
@@ -41,20 +42,6 @@ function getShownPushPrompt(): Promise<boolean> {
 
 function checkPermissions() {
   return new Promise((resolve, reject) => PushNotifications.checkPermissions(resolve))
-}
-
-function showMainWindow() {
-  return () => {
-    // nothing
-  }
-}
-
-function getAppState() {
-  return Promise.resolve({})
-}
-
-function setAppState(toMerge: Object) {
-  throw new Error('setAppState not implemented in mobile')
 }
 
 function showShareActionSheet(options: {
@@ -309,15 +296,14 @@ const getContentTypeFromURL = (
           cb({error})
         })
 
+function* platformConfigSaga(): Saga.SagaGenerator<any, any> {}
+
 export {
   openAppSettings,
   checkPermissions,
   displayNewMessageNotification,
   downloadAndShowShareActionSheet,
-  getAppState,
-  setAppState,
   requestPushPermissions,
-  showMainWindow,
   configurePush,
   saveAttachmentDialog,
   saveAttachmentToCameraRoll,

--- a/shared/actions/platform-specific.native.js
+++ b/shared/actions/platform-specific.native.js
@@ -311,4 +311,5 @@ export {
   showShareActionSheet,
   clearAllNotifications,
   getContentTypeFromURL,
+  platformConfigSaga,
 }

--- a/shared/settings/advanced/container.js
+++ b/shared/settings/advanced/container.js
@@ -10,24 +10,16 @@ import {connect, type TypedState} from '../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({
   openAtLogin: state.config.openAtLogin,
-  traceInProgress: Constants.traceInProgress(state),
   processorProfileInProgress: Constants.processorProfileInProgress(state),
+  traceInProgress: Constants.traceInProgress(state),
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  onBack: () => {
-    dispatch(navigateUp())
-  },
-  onDBNuke: () => {
-    dispatch(navigateAppend(['dbNukeConfirm']))
-  },
-  onTrace: (durationSeconds: number) => {
-    dispatch(createTrace({durationSeconds}))
-  },
-  onProcessorProfile: (durationSeconds: number) => {
-    dispatch(createProcessorProfile({durationSeconds}))
-  },
+  onBack: () => dispatch(navigateUp()),
+  onDBNuke: () => dispatch(navigateAppend(['dbNukeConfirm'])),
+  onProcessorProfile: (durationSeconds: number) => dispatch(createProcessorProfile({durationSeconds})),
   onSetOpenAtLogin: (open: boolean) => dispatch(ConfigGen.createSetOpenAtLogin({open, writeFile: true})),
+  onTrace: (durationSeconds: number) => dispatch(createTrace({durationSeconds})),
 })
 
 const connectedAdvanced = compose(connect(mapStateToProps, mapDispatchToProps), HeaderHoc)(Advanced)


### PR DESCRIPTION
- [x] Move platform specific stuff into the platform specific files. before platform-specific exported calls that actions/config used but this means one half or the other has an empty handler. Instead lets just have a per platform saga it forks and does its own thing
- [x] Move showMain into platform specific

App.json / actions/app does very little and its not clear why its not just merged w/ config. doing that next

@keybase/react-hackers 