### PR TITLE
Improving storybook typing and helper functions

### DIFF
--- a/shared/chat/conversation/info-panel/index.stories.js
+++ b/shared/chat/conversation/info-panel/index.stories.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {storiesOf, action, unexpected} from '../../../stories/storybook'
+import {action, storiesOf, createPropProvider, unexpected} from '../../../stories/storybook'
 import * as Constants from '../../../constants/chat2'
 import * as PropProviders from '../../../stories/prop-providers'
 import {retentionPolicies} from '../../../constants/teams'
@@ -42,7 +42,7 @@ const retentionPickerPropSelector = props => ({
   onSelect: action('onSelectRetentionPolicy'),
 })
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.TeamDropdownMenu(),

--- a/shared/chat/conversation/info-panel/index.stories.js
+++ b/shared/chat/conversation/info-panel/index.stories.js
@@ -42,7 +42,7 @@ const retentionPickerPropSelector = props => ({
   onSelect: action('onSelectRetentionPolicy'),
 })
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.TeamDropdownMenu(),

--- a/shared/chat/conversation/info-panel/index.stories.js
+++ b/shared/chat/conversation/info-panel/index.stories.js
@@ -42,17 +42,12 @@ const retentionPickerPropSelector = props => ({
   onSelect: action('onSelectRetentionPolicy'),
 })
 
-const provider = createPropProvider(
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
-  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  PropProviders.TeamDropdownMenu(),
-  {
-    InfoPanel: (props: InfoPanelProps) => props,
-    OnlyValidConversations: () => onlyValidConversationsProps,
-    LifecycleNotifications: () => notificationProps,
-    RetentionPicker: retentionPickerPropSelector,
-  }
-)
+const provider = createPropProvider(PropProviders.Common(), PropProviders.TeamDropdownMenu(), {
+  InfoPanel: (props: InfoPanelProps) => props,
+  OnlyValidConversations: () => onlyValidConversationsProps,
+  LifecycleNotifications: () => notificationProps,
+  RetentionPicker: retentionPickerPropSelector,
+})
 
 const commonProps = {
   selectedConversationIDKey: Constants.noConversationIDKey,

--- a/shared/chat/conversation/info-panel/menu/container.js
+++ b/shared/chat/conversation/info-panel/menu/container.js
@@ -10,17 +10,19 @@ import {
   type TypedState,
   createCachedSelector,
 } from '../../../../util/container'
-import {InfoPanelMenu} from '.'
+import {type Props, InfoPanelMenu} from '.'
 import {navigateAppend, navigateTo, switchTo} from '../../../../actions/route-tree'
 import {teamsTab} from '../../../../constants/tabs'
 
-type OwnProps = {
+export type OwnProps = {
   attachTo: ?Component<any, any>,
   onHidden: () => void,
   isSmallTeam: boolean,
   teamname: string,
   visible: boolean,
 }
+
+export type {Props}
 
 const moreThanOneSubscribedChannel = createCachedSelector(
   (state, _) => state.chat2.metaMap,

--- a/shared/chat/conversation/info-panel/menu/container.js
+++ b/shared/chat/conversation/info-panel/menu/container.js
@@ -10,7 +10,7 @@ import {
   type TypedState,
   createCachedSelector,
 } from '../../../../util/container'
-import {type Props, InfoPanelMenu} from '.'
+import {type Props as _Props, InfoPanelMenu} from '.'
 import {navigateAppend, navigateTo, switchTo} from '../../../../actions/route-tree'
 import {teamsTab} from '../../../../constants/tabs'
 
@@ -22,7 +22,9 @@ export type OwnProps = {
   visible: boolean,
 }
 
-export type {Props}
+export type Props = _Props & {
+  _loadOperations: () => void,
+}
 
 const moreThanOneSubscribedChannel = createCachedSelector(
   (state, _) => state.chat2.metaMap,

--- a/shared/chat/conversation/info-panel/menu/index.js
+++ b/shared/chat/conversation/info-panel/menu/index.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {Avatar, Box, FloatingMenu, Text} from '../../../../common-adapters'
 import {collapseStyles, globalColors, globalMargins, globalStyles, isMobile} from '../../../../styles'
 
-type Props = {
+export type Props = {
   attachTo: ?React.Component<any, any>,
   badgeSubscribe: boolean,
   canAddPeople: boolean,

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -9,26 +9,29 @@ import Input, {type Props as InputProps} from '.'
 import {isMobile} from '../../../../constants/platform'
 import {stringToConversationIDKey} from '../../../../constants/types/chat2'
 
-const provider = PropProviders.compose(PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'), {
-  ChannelMentionHud: ownProps => {
-    const channels = ['foo', 'bar']
-    return {
-      ...ownProps,
-      channels,
-    }
-  },
-  UserMentionHud: ownProps => {
-    const users = [
-      {username: 'marcopolo', fullName: 'Marco Munizaga'},
-      {username: 'trex', fullName: 'Thomas Rex'},
-      {username: 'chris', fullName: 'Chris Coyne'},
-    ]
-    return {
-      ...ownProps,
-      users,
-    }
-  },
-})
+const provider = PropProviders.composeAndCreate(
+  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
+  {
+    ChannelMentionHud: ownProps => {
+      const channels = ['foo', 'bar']
+      return {
+        ...ownProps,
+        channels,
+      }
+    },
+    UserMentionHud: ownProps => {
+      const users = [
+        {username: 'marcopolo', fullName: 'Marco Munizaga'},
+        {username: 'trex', fullName: 'Thomas Rex'},
+        {username: 'chris', fullName: 'Chris Coyne'},
+      ]
+      return {
+        ...ownProps,
+        users,
+      }
+    },
+  }
+)
 
 type Props = {
   isEditExploded: boolean,

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -9,7 +9,7 @@ import Input, {type Props as InputProps} from '.'
 import {isMobile} from '../../../../constants/platform'
 import {stringToConversationIDKey} from '../../../../constants/types/chat2'
 
-const provider = createPropProvider(PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'), {
+const provider = createPropProvider(PropProviders.Usernames(), {
   ChannelMentionHud: ownProps => {
     const channels = ['foo', 'bar']
     return {

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -4,34 +4,31 @@ import {Set} from 'immutable'
 import {Box2} from '../../../../common-adapters/box'
 import {platformStyles} from '../../../../styles'
 import * as PropProviders from '../../../../stories/prop-providers'
-import {action, storiesOf} from '../../../../stories/storybook'
+import {action, storiesOf, createPropProvider} from '../../../../stories/storybook'
 import Input, {type Props as InputProps} from '.'
 import {isMobile} from '../../../../constants/platform'
 import {stringToConversationIDKey} from '../../../../constants/types/chat2'
 
-const provider = PropProviders.composeAndCreate(
-  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  {
-    ChannelMentionHud: ownProps => {
-      const channels = ['foo', 'bar']
-      return {
-        ...ownProps,
-        channels,
-      }
-    },
-    UserMentionHud: ownProps => {
-      const users = [
-        {username: 'marcopolo', fullName: 'Marco Munizaga'},
-        {username: 'trex', fullName: 'Thomas Rex'},
-        {username: 'chris', fullName: 'Chris Coyne'},
-      ]
-      return {
-        ...ownProps,
-        users,
-      }
-    },
-  }
-)
+const provider = createPropProvider(PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'), {
+  ChannelMentionHud: ownProps => {
+    const channels = ['foo', 'bar']
+    return {
+      ...ownProps,
+      channels,
+    }
+  },
+  UserMentionHud: ownProps => {
+    const users = [
+      {username: 'marcopolo', fullName: 'Marco Munizaga'},
+      {username: 'trex', fullName: 'Thomas Rex'},
+      {username: 'chris', fullName: 'Chris Coyne'},
+    ]
+    return {
+      ...ownProps,
+      users,
+    }
+  },
+})
 
 type Props = {
   isEditExploded: boolean,

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -9,7 +9,7 @@ import Input, {type Props as InputProps} from '.'
 import {isMobile} from '../../../../constants/platform'
 import {stringToConversationIDKey} from '../../../../constants/types/chat2'
 
-const provider = createPropProvider(PropProviders.Usernames(), {
+const provider = createPropProvider(PropProviders.Common(), {
   ChannelMentionHud: ownProps => {
     const channels = ['foo', 'bar']
     return {

--- a/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
@@ -5,10 +5,10 @@ import * as PropProviders from '../../../../stories/prop-providers'
 import {MentionRowRenderer, MentionHud} from '.'
 import {compose, withStateHandlers} from '../../../../util/container'
 import {Box, Button, Input, ButtonBar} from '../../../../common-adapters'
-import {storiesOf, action, createPropProvider} from '../../../../stories/storybook'
+import {storiesOf, action} from '../../../../stories/storybook'
 import {globalStyles} from '../../../../styles'
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
+const provider = PropProviders.CommonProvider()
 
 const UpDownFilterHoc = compose(
   withStateHandlers(

--- a/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
@@ -8,10 +8,7 @@ import {Box, Button, Input, ButtonBar} from '../../../../common-adapters'
 import {storiesOf, action, createPropProvider} from '../../../../stories/storybook'
 import {globalStyles} from '../../../../styles'
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
-)
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
 
 const UpDownFilterHoc = compose(
   withStateHandlers(

--- a/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
@@ -5,10 +5,10 @@ import * as PropProviders from '../../../../stories/prop-providers'
 import {MentionRowRenderer, MentionHud} from '.'
 import {compose, withStateHandlers} from '../../../../util/container'
 import {Box, Button, Input, ButtonBar} from '../../../../common-adapters'
-import {storiesOf, action} from '../../../../stories/storybook'
+import {storiesOf, action, createPropProvider} from '../../../../stories/storybook'
 import {globalStyles} from '../../../../styles'
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
@@ -8,7 +8,7 @@ import {Box, Button, Input, ButtonBar} from '../../../../common-adapters'
 import {storiesOf, action} from '../../../../stories/storybook'
 import {globalStyles} from '../../../../styles'
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/chat/conversation/list-area/normal/index.stories.js
+++ b/shared/chat/conversation/list-area/normal/index.stories.js
@@ -5,7 +5,7 @@ import I from 'immutable'
 import moment from 'moment'
 import {Box2, Text} from '../../../../common-adapters'
 import * as Types from '../../../../constants/types/chat2'
-import {storiesOf, action} from '../../../../stories/storybook'
+import {storiesOf, action, createPropProvider} from '../../../../stories/storybook'
 import * as PropProviders from '../../../../stories/prop-providers'
 import Thread from '.'
 import * as Message from '../../../../constants/chat2/message'
@@ -128,7 +128,7 @@ const ordinalToMessage = o => {
   return message
 }
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
   {

--- a/shared/chat/conversation/list-area/normal/index.stories.js
+++ b/shared/chat/conversation/list-area/normal/index.stories.js
@@ -128,99 +128,95 @@ const ordinalToMessage = o => {
   return message
 }
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
-  {
-    Channel: p => ({name: p.name}),
-    Mention: p => ({username: p.username}),
-    BottomMessage: p => ({
-      showResetParticipants: null,
-      showSuperseded: null,
-      measure: null,
-    }),
-    TopMessage: p => ({
-      conversationIDKey,
-      hasOlderResetConversation: false,
-      showRetentionNotice: false,
-      loadMoreType: 'moreToLoad',
-      showTeamOffer: false,
-      measure: p.measure,
-    }),
-    MessageFactory: ({ordinal, previous, measure}) => ({
-      message: ordinalToMessage(ordinal),
-      previous: ordinalToMessage(previous),
-      isEditing: false,
-      measure,
-    }),
-    MessagePopupText: p => ({
-      attachTo: null,
-      author: 'a',
-      deviceName: 'a',
-      deviceRevokedAt: 0,
-      deviceType: 'mobile',
-      onCopy: action('oncopy'),
-      onDelete: null,
-      onDeleteMessageHistory: null,
-      onEdit: null,
-      onHidden: action('onhidden'),
-      onQuote: null,
-      onReplyPrivately: null,
-      onViewProfile: action('onviewprofile'),
-      position: 'top left',
-      showDivider: false,
-      timestamp: 0,
-      visible: false,
-      yourMessage: false,
-    }),
-    WrapperTimestamp: p => {
-      const {children, message, previous} = p
-      // Want to mimick the timestamp logic in WrapperTimestamp
-      const oldEnough = !!(
-        previous &&
-        previous.timestamp &&
-        message.timestamp &&
-        message.timestamp - previous.timestamp > Message.howLongBetweenTimestampsMs
-      )
-      return {
-        children,
-        message,
-        orangeLineAbove: false,
-        previous,
-        timestamp: !previous || oldEnough ? formatTimeForMessages(message.timestamp) : null,
-      }
-    },
-    WrapperAuthor: p => ({
-      author: 'a',
-      exploded: false,
-      explodedBy: '',
-      explodesAt: 0,
-      exploding: false,
-      failureDescription: '',
-      includeHeader: false,
-      innerClass: p.innerClass,
-      isBroken: false,
-      isEdited: false,
-      isEditing: false,
-      isExplodingUnreadable: false,
-      isFollowing: false,
-      isRevoked: false,
-      isYou: false,
-      measure: p.measure,
-      message: p.message,
-      messageFailed: false,
-      messageKey: p.message.ordinal,
-      messagePending: false,
-      messageSent: true,
-      onRetry: null,
-      onEdit: null,
-      onCancel: null,
-      onAuthorClick: action('onAuthorclick'),
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar(), {
+  Channel: p => ({name: p.name}),
+  Mention: p => ({username: p.username}),
+  BottomMessage: p => ({
+    showResetParticipants: null,
+    showSuperseded: null,
+    measure: null,
+  }),
+  TopMessage: p => ({
+    conversationIDKey,
+    hasOlderResetConversation: false,
+    showRetentionNotice: false,
+    loadMoreType: 'moreToLoad',
+    showTeamOffer: false,
+    measure: p.measure,
+  }),
+  MessageFactory: ({ordinal, previous, measure}) => ({
+    message: ordinalToMessage(ordinal),
+    previous: ordinalToMessage(previous),
+    isEditing: false,
+    measure,
+  }),
+  MessagePopupText: p => ({
+    attachTo: null,
+    author: 'a',
+    deviceName: 'a',
+    deviceRevokedAt: 0,
+    deviceType: 'mobile',
+    onCopy: action('oncopy'),
+    onDelete: null,
+    onDeleteMessageHistory: null,
+    onEdit: null,
+    onHidden: action('onhidden'),
+    onQuote: null,
+    onReplyPrivately: null,
+    onViewProfile: action('onviewprofile'),
+    position: 'top left',
+    showDivider: false,
+    timestamp: 0,
+    visible: false,
+    yourMessage: false,
+  }),
+  WrapperTimestamp: p => {
+    const {children, message, previous} = p
+    // Want to mimick the timestamp logic in WrapperTimestamp
+    const oldEnough = !!(
+      previous &&
+      previous.timestamp &&
+      message.timestamp &&
+      message.timestamp - previous.timestamp > Message.howLongBetweenTimestampsMs
+    )
+    return {
+      children,
+      message,
       orangeLineAbove: false,
-      timestamp: '',
-    }),
-  }
-)
+      previous,
+      timestamp: !previous || oldEnough ? formatTimeForMessages(message.timestamp) : null,
+    }
+  },
+  WrapperAuthor: p => ({
+    author: 'a',
+    exploded: false,
+    explodedBy: '',
+    explodesAt: 0,
+    exploding: false,
+    failureDescription: '',
+    includeHeader: false,
+    innerClass: p.innerClass,
+    isBroken: false,
+    isEdited: false,
+    isEditing: false,
+    isExplodingUnreadable: false,
+    isFollowing: false,
+    isRevoked: false,
+    isYou: false,
+    measure: p.measure,
+    message: p.message,
+    messageFailed: false,
+    messageKey: p.message.ordinal,
+    messagePending: false,
+    messageSent: true,
+    onRetry: null,
+    onEdit: null,
+    onCancel: null,
+    onAuthorClick: action('onAuthorclick'),
+    orangeLineAbove: false,
+    timestamp: '',
+  }),
+})
 
 type Props = {}
 type State = {|

--- a/shared/chat/conversation/list-area/normal/index.stories.js
+++ b/shared/chat/conversation/list-area/normal/index.stories.js
@@ -128,7 +128,7 @@ const ordinalToMessage = o => {
   return message
 }
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar(), {
+const provider = createPropProvider(PropProviders.Common(), {
   Channel: p => ({name: p.name}),
   Mention: p => ({username: p.username}),
   BottomMessage: p => ({

--- a/shared/chat/conversation/list-area/normal/index.stories.js
+++ b/shared/chat/conversation/list-area/normal/index.stories.js
@@ -128,7 +128,7 @@ const ordinalToMessage = o => {
   return message
 }
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
   {

--- a/shared/chat/conversation/messages/message-popup/index.stories.js
+++ b/shared/chat/conversation/messages/message-popup/index.stories.js
@@ -58,32 +58,28 @@ const commonExplodingProps = {
   visible: true,
 }
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
-  {
-    ExplodingPopup: (props: ExplodingOwnProps) => ({
-      attachTo: null,
-      author: props.message.author,
-      deviceName: props.message.deviceName,
-      deviceRevokedAt: props.message.deviceRevokedAt,
-      deviceType: props.message.deviceType,
-      explodesAt: props.message.explodingTime,
-      items: [
-        {danger: true, onClick: action('onExplodeNow'), title: 'Explode now'},
-        {danger: true, onClick: action('onDeleteHistory'), title: 'Delete this + everything above'},
-        ...(props.message.type === 'attachment'
-          ? [{onClick: action('onDownload'), title: 'Download'}]
-          : [{onClick: action('onEdit'), title: 'Edit'}, {onClick: action('onCopy'), title: 'Copy text'}]),
-      ],
-      onHidden: props.onHidden,
-      position: props.position,
-      timestamp: props.message.timestamp,
-      visible: props.visible,
-      yourMessage: props.message.author === 'cjb',
-    }),
-  }
-)
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar(), {
+  ExplodingPopup: (props: ExplodingOwnProps) => ({
+    attachTo: null,
+    author: props.message.author,
+    deviceName: props.message.deviceName,
+    deviceRevokedAt: props.message.deviceRevokedAt,
+    deviceType: props.message.deviceType,
+    explodesAt: props.message.explodingTime,
+    items: [
+      {danger: true, onClick: action('onExplodeNow'), title: 'Explode now'},
+      {danger: true, onClick: action('onDeleteHistory'), title: 'Delete this + everything above'},
+      ...(props.message.type === 'attachment'
+        ? [{onClick: action('onDownload'), title: 'Download'}]
+        : [{onClick: action('onEdit'), title: 'Edit'}, {onClick: action('onCopy'), title: 'Copy text'}]),
+    ],
+    onHidden: props.onHidden,
+    position: props.position,
+    timestamp: props.message.timestamp,
+    visible: props.visible,
+    yourMessage: props.message.author === 'cjb',
+  }),
+})
 
 const load = () => {
   storiesOf('Chat/Conversation/Message popup', module)

--- a/shared/chat/conversation/messages/message-popup/index.stories.js
+++ b/shared/chat/conversation/messages/message-popup/index.stories.js
@@ -58,7 +58,7 @@ const commonExplodingProps = {
   visible: true,
 }
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
   {

--- a/shared/chat/conversation/messages/message-popup/index.stories.js
+++ b/shared/chat/conversation/messages/message-popup/index.stories.js
@@ -58,7 +58,7 @@ const commonExplodingProps = {
   visible: true,
 }
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar(), {
+const provider = createPropProvider(PropProviders.Common(), {
   ExplodingPopup: (props: ExplodingOwnProps) => ({
     attachTo: null,
     author: props.message.author,

--- a/shared/chat/conversation/messages/message-popup/index.stories.js
+++ b/shared/chat/conversation/messages/message-popup/index.stories.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import * as PropProviders from '../../../../stories/prop-providers'
 import {makeMessageAttachment, makeMessageText} from '../../../../constants/chat2'
-import {storiesOf, action} from '../../../../stories/storybook'
+import {storiesOf, action, createPropProvider} from '../../../../stories/storybook'
 import TextPopupMenu from './text/index'
 import AttachmentPopupMenu from './attachment/index'
 import ExplodingPopupMenu, {type OwnProps as ExplodingOwnProps} from './exploding/container'
@@ -58,7 +58,7 @@ const commonExplodingProps = {
   visible: true,
 }
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
   {

--- a/shared/chat/create-channel/index.stories.js
+++ b/shared/chat/create-channel/index.stories.js
@@ -2,11 +2,11 @@
 import React from 'react'
 import * as PropProviders from '../../stories/prop-providers'
 import {Box} from '../../common-adapters'
-import {storiesOf, action, createPropProvider} from '../../stories/storybook'
+import {storiesOf, action} from '../../stories/storybook'
 import {isMobile} from '../../constants/platform'
 import CreateChannel from '.'
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Chat/Teams', module)

--- a/shared/chat/create-channel/index.stories.js
+++ b/shared/chat/create-channel/index.stories.js
@@ -2,11 +2,11 @@
 import React from 'react'
 import * as PropProviders from '../../stories/prop-providers'
 import {Box} from '../../common-adapters'
-import {storiesOf, action} from '../../stories/storybook'
+import {storiesOf, action, createPropProvider} from '../../stories/storybook'
 import {isMobile} from '../../constants/platform'
 import CreateChannel from '.'
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/chat/create-channel/index.stories.js
+++ b/shared/chat/create-channel/index.stories.js
@@ -6,7 +6,7 @@ import {storiesOf, action} from '../../stories/storybook'
 import {isMobile} from '../../constants/platform'
 import CreateChannel from '.'
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/chat/create-channel/index.stories.js
+++ b/shared/chat/create-channel/index.stories.js
@@ -6,10 +6,7 @@ import {storiesOf, action, createPropProvider} from '../../stories/storybook'
 import {isMobile} from '../../constants/platform'
 import CreateChannel from '.'
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
-)
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
 
 const load = () => {
   storiesOf('Chat/Teams', module)

--- a/shared/chat/inbox/row/index.stories.js
+++ b/shared/chat/inbox/row/index.stories.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import {Box} from '../../../common-adapters'
-import {storiesOf, action} from '../../../stories/storybook'
+import {storiesOf, action, createPropProvider} from '../../../stories/storybook'
 import * as PropProviders from '../../../stories/prop-providers'
 import {globalColors} from '../../../styles'
 import {SmallTeam} from './small-team'
@@ -102,7 +102,7 @@ const commonChannel = {
   isError: false,
 }
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.TeamDropdownMenu(),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/chat/inbox/row/index.stories.js
+++ b/shared/chat/inbox/row/index.stories.js
@@ -102,7 +102,7 @@ const commonChannel = {
   isError: false,
 }
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.TeamDropdownMenu(),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/chat/inbox/row/index.stories.js
+++ b/shared/chat/inbox/row/index.stories.js
@@ -102,10 +102,7 @@ const commonChannel = {
   isError: false,
 }
 
-const provider = createPropProvider(
-  PropProviders.TeamDropdownMenu(),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
-)
+const provider = createPropProvider(PropProviders.Common(), PropProviders.TeamDropdownMenu())
 
 const load = () => {
   storiesOf('Chat/Inbox', module)

--- a/shared/chat/manage-channels/index.stories.js
+++ b/shared/chat/manage-channels/index.stories.js
@@ -59,7 +59,7 @@ const channelState = channels.reduce((acc: Types.ChannelMembershipState, c) => {
   return acc
 }, {})
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Chat/Teams', module)

--- a/shared/common-adapters/avatar.js
+++ b/shared/common-adapters/avatar.js
@@ -40,7 +40,7 @@ export type OwnProps = {|
   showFollowingStatus?: boolean, // show the green dots or not
 |}
 
-type Props = PropsWithTimer<{
+type PropsWithoutTimer = {
   askForUserData?: () => void,
   borderColor?: string,
   children?: React.Node,
@@ -61,7 +61,9 @@ type Props = PropsWithTimer<{
   teamname?: ?string,
   url: URLType,
   username?: ?string,
-}>
+}
+
+type Props = PropsWithTimer<PropsWithoutTimer>
 
 const avatarPlaceHolders: {[key: string]: IconType} = {
   '192': 'icon-placeholder-avatar-192',
@@ -149,7 +151,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       : dispatch(createGetProfile({forceDisplay: true, ignoreCache: true, username})),
 })
 
-const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
+const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): PropsWithoutTimer => {
   const isTeam = ownProps.isTeam || !!ownProps.teamname
 
   let onClick = ownProps.onClick
@@ -170,8 +172,12 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
   }
 
   const askForUserData = isTeam
-    ? () => ownProps.teamname && dispatchProps._askForTeamUserData(ownProps.teamname)
-    : () => ownProps.username && dispatchProps._askForUserData(ownProps.username)
+    ? () => {
+        ownProps.teamname && dispatchProps._askForTeamUserData(ownProps.teamname)
+      }
+    : () => {
+        ownProps.username && dispatchProps._askForUserData(ownProps.username)
+      }
 
   const name = isTeam ? ownProps.teamname : ownProps.username
 
@@ -186,7 +192,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
     followsYou: stateProps.followsYou,
     isTeam,
     loadingColor: ownProps.loadingColor,
-    name,
+    name: name || '',
     onClick,
     opacity: ownProps.opacity,
     size: ownProps.size,
@@ -251,8 +257,8 @@ const mockOwnToViewProps = (
   ownProps: OwnProps,
   follows: string[],
   followers: string[],
-  action: string => () => void
-) => {
+  action: string => (...args: any[]) => void
+): Props => {
   const following = follows.includes(ownProps.username)
   const followsYou = followers.includes(ownProps.username)
   const isTeam = ownProps.isTeam || !!ownProps.teamname
@@ -268,14 +274,33 @@ const mockOwnToViewProps = (
   ])
   const url = iconTypeToImgSet(isTeam ? teamPlaceHolders : avatarPlaceHolders, ownProps.size)
 
+  const name = isTeam ? ownProps.teamname : ownProps.username
+
+  const setInterval = action('setInterval')
+  const setTimeout = action('setTimeout')
+
   return {
+    clearInterval: action('clearInterval'),
+    clearTimeout: action('clearTimeout'),
+    setInterval: (...args) => {
+      setInterval(...args)
+      return (0: any)
+    },
+    setTimeout: (...args) => {
+      setTimeout(...args)
+      return (0: any)
+    },
+
     borderColor: ownProps.borderColor,
     children: ownProps.children,
     followIconSize: _followIconSize(ownProps.size, followsYou, following),
     followIconStyle: followSizeToStyle[ownProps.size],
     followIconType: _followIconType(ownProps.size, followsYou, following),
+    following,
+    followsYou,
     isTeam,
     loadingColor: ownProps.loadingColor,
+    name: name || '',
     onClick,
     opacity: ownProps.opacity,
     size: ownProps.size,

--- a/shared/common-adapters/avatar.js
+++ b/shared/common-adapters/avatar.js
@@ -15,7 +15,6 @@ import {
 } from '../styles'
 import {createShowUserProfile} from '../actions/profile-gen'
 import {createGetProfile} from '../actions/tracker-gen'
-import {action} from '../stories/storybook'
 import * as ConfigGen from '../actions/config-gen'
 
 export type AvatarSize = 128 | 96 | 64 | 48 | 32 | 16
@@ -248,7 +247,14 @@ const Avatar = compose(
   HOCTimers
 )(AvatarConnector)
 
-const mockOwnToViewProps = (ownProps: OwnProps, following: boolean, followsYou: boolean) => {
+const mockOwnToViewProps = (
+  ownProps: OwnProps,
+  follows: string[],
+  followers: string[],
+  action: string => () => void
+) => {
+  const following = follows.includes(ownProps.username)
+  const followsYou = followers.includes(ownProps.username)
   const isTeam = ownProps.isTeam || !!ownProps.teamname
 
   let onClick = ownProps.onClick

--- a/shared/common-adapters/avatar.stories.js
+++ b/shared/common-adapters/avatar.stories.js
@@ -8,7 +8,7 @@ import {storiesOf, action} from '../stories/storybook'
 import * as PropProviders from '../stories/prop-providers'
 
 const sizes = [128, 96, 64, 48, 32, 16]
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Common', module)

--- a/shared/common-adapters/name-with-icon.stories.js
+++ b/shared/common-adapters/name-with-icon.stories.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import {action, storiesOf} from '../stories/storybook'
-import {Avatar, compose, Usernames} from '../stories/prop-providers'
+import {Avatar, composeAndCreate, Usernames} from '../stories/prop-providers'
 import ScrollView from './scroll-view'
 import Text from './text'
 import NameWithIcon from './name-with-icon'
@@ -22,7 +22,10 @@ const innerClick = evt => {
   action('Inner click')(evt)
 }
 
-const provider = compose(Avatar(['chrisnojima'], ['chrisnojima']), Usernames(['cecileb', 'chrisnojima']))
+const provider = composeAndCreate(
+  Avatar(['chrisnojima'], ['chrisnojima']),
+  Usernames(['cecileb', 'chrisnojima'])
+)
 
 const load = () => {
   storiesOf('Common/NameWithIcon', module)

--- a/shared/common-adapters/name-with-icon.stories.js
+++ b/shared/common-adapters/name-with-icon.stories.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
-import {action, storiesOf} from '../stories/storybook'
-import {Avatar, composeAndCreate, Usernames} from '../stories/prop-providers'
+import {action, storiesOf, createPropProvider} from '../stories/storybook'
+import {Avatar, Usernames} from '../stories/prop-providers'
 import ScrollView from './scroll-view'
 import Text from './text'
 import NameWithIcon from './name-with-icon'
@@ -22,7 +22,7 @@ const innerClick = evt => {
   action('Inner click')(evt)
 }
 
-const provider = composeAndCreate(
+const provider = createPropProvider(
   Avatar(['chrisnojima'], ['chrisnojima']),
   Usernames(['cecileb', 'chrisnojima'])
 )

--- a/shared/common-adapters/name-with-icon.stories.js
+++ b/shared/common-adapters/name-with-icon.stories.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
-import {action, storiesOf, createPropProvider} from '../stories/storybook'
-import {Avatar, Usernames} from '../stories/prop-providers'
+import {action, storiesOf} from '../stories/storybook'
+import * as PropProviders from '../stories/prop-providers'
 import ScrollView from './scroll-view'
 import Text from './text'
 import NameWithIcon from './name-with-icon'
@@ -22,10 +22,7 @@ const innerClick = evt => {
   action('Inner click')(evt)
 }
 
-const provider = createPropProvider(
-  Avatar(['chrisnojima'], ['chrisnojima']),
-  Usernames(['cecileb', 'chrisnojima'])
-)
+const provider = PropProviders.Common()
 
 const load = () => {
   storiesOf('Common/NameWithIcon', module)

--- a/shared/common-adapters/name-with-icon.stories.js
+++ b/shared/common-adapters/name-with-icon.stories.js
@@ -22,7 +22,7 @@ const innerClick = evt => {
   action('Inner click')(evt)
 }
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Common/NameWithIcon', module)

--- a/shared/common-adapters/waiting-button.js
+++ b/shared/common-adapters/waiting-button.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import Button, {type Props as ButtonProps} from './button'
 import {connect, type TypedState} from '../util/container'
 
-export type WaitingButtonProps = {
+export type Props = ButtonProps & {
   storeWaiting: boolean,
   waitingKey: ?string,
 }
@@ -20,7 +20,7 @@ export type WaitingButtonProps = {
  *  waiting store (store.waiting), which will be set by a saga somewhere.
  */
 
-class WaitingButton extends React.Component<ButtonProps & WaitingButtonProps, {localWaiting: boolean}> {
+class WaitingButton extends React.Component<Props, {localWaiting: boolean}> {
   state = {localWaiting: false}
 
   _onClick = (event: SyntheticEvent<>) => {

--- a/shared/common-adapters/waiting-button.js
+++ b/shared/common-adapters/waiting-button.js
@@ -20,7 +20,7 @@ export type WaitingButtonProps = {
  *  waiting store (store.waiting), which will be set by a saga somewhere.
  */
 
-class WaitingButton extends React.PureComponent<ButtonProps & WaitingButtonProps, {localWaiting: boolean}> {
+class WaitingButton extends React.Component<ButtonProps & WaitingButtonProps, {localWaiting: boolean}> {
   state = {localWaiting: false}
 
   _onClick = (event: SyntheticEvent<>) => {
@@ -46,6 +46,5 @@ const mapStateToProps = (state: TypedState, ownProps) => {
   }
 }
 
-export const ConnectedWaitingButton = connect(mapStateToProps)(WaitingButton)
-
+const ConnectedWaitingButton = connect(mapStateToProps)(WaitingButton)
 export default ConnectedWaitingButton

--- a/shared/common-adapters/waiting-button.js
+++ b/shared/common-adapters/waiting-button.js
@@ -1,11 +1,9 @@
 // @flow
 import * as React from 'react'
 import Button, {type Props as ButtonProps} from './button'
-import {compose, connect, setDisplayName, withStateHandlers, type TypedState} from '../util/container'
+import {connect, type TypedState} from '../util/container'
 
 export type WaitingButtonProps = {
-  localWaiting: boolean,
-  onSetWaiting: (waiting: boolean) => void,
   storeWaiting: boolean,
   waitingKey: ?string,
 }
@@ -22,23 +20,23 @@ export type WaitingButtonProps = {
  *  waiting store (store.waiting), which will be set by a saga somewhere.
  */
 
-class WaitingButton extends React.PureComponent<ButtonProps & WaitingButtonProps> {
+class WaitingButton extends React.PureComponent<ButtonProps & WaitingButtonProps, {localWaiting: boolean}> {
+  state = {localWaiting: false}
+
   _onClick = (event: SyntheticEvent<>) => {
     if (!this.props.waitingKey) {
-      this.props.onSetWaiting(true)
+      this.setState({localWaiting: true})
     }
     this.props.onClick && this.props.onClick(event)
   }
 
-  render() {
-    return (
-      <Button
-        {...this.props}
-        onClick={this._onClick}
-        waiting={this.props.storeWaiting || this.props.localWaiting}
-      />
-    )
-  }
+  render = () => (
+    <Button
+      {...this.props}
+      onClick={this._onClick}
+      waiting={this.props.storeWaiting || this.state.localWaiting}
+    />
+  )
 }
 
 const mapStateToProps = (state: TypedState, ownProps) => {
@@ -48,12 +46,6 @@ const mapStateToProps = (state: TypedState, ownProps) => {
   }
 }
 
-export const ConnectedWaitingButton = compose(
-  connect(mapStateToProps),
-  setDisplayName('WaitingButton'),
-  withStateHandlers(({localWaiting: boolean}) => ({localWaiting: false}), {
-    onSetWaiting: () => (localWaiting: boolean) => ({localWaiting}),
-  })
-)(WaitingButton)
+export const ConnectedWaitingButton = connect(mapStateToProps)(WaitingButton)
 
 export default ConnectedWaitingButton

--- a/shared/common-adapters/waiting-button.js
+++ b/shared/common-adapters/waiting-button.js
@@ -3,6 +3,10 @@ import * as React from 'react'
 import Button, {type Props as ButtonProps} from './button'
 import {connect, type TypedState} from '../util/container'
 
+export type OwnProps = ButtonProps & {
+  waitingKey: ?string,
+}
+
 export type Props = ButtonProps & {
   storeWaiting: boolean,
   waitingKey: ?string,

--- a/shared/git/delete-repo/index.stories.js
+++ b/shared/git/delete-repo/index.stories.js
@@ -5,7 +5,7 @@ import * as PropProviders from '../../stories/prop-providers'
 import {storiesOf, action} from '../../stories/storybook'
 import DeleteRepo from '.'
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Git/Delete', module)

--- a/shared/git/new-repo/index.stories.js
+++ b/shared/git/new-repo/index.stories.js
@@ -5,9 +5,7 @@ import * as PropProviders from '../../stories/prop-providers'
 import {storiesOf, action} from '../../stories/storybook'
 import NewRepo from '.'
 
-const provider = PropProviders.compose(
-  PropProviders.WaitingButton(),
-)
+const provider = PropProviders.composeAndCreate(PropProviders.WaitingButton())
 
 const load = () => {
   storiesOf('Git/New', module)

--- a/shared/git/new-repo/index.stories.js
+++ b/shared/git/new-repo/index.stories.js
@@ -2,10 +2,10 @@
 import React from 'react'
 import {Box} from '../../common-adapters'
 import * as PropProviders from '../../stories/prop-providers'
-import {storiesOf, action, createPropProvider} from '../../stories/storybook'
+import {storiesOf, action} from '../../stories/storybook'
 import NewRepo from '.'
 
-const provider = createPropProvider(PropProviders.WaitingButton())
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Git/New', module)

--- a/shared/git/new-repo/index.stories.js
+++ b/shared/git/new-repo/index.stories.js
@@ -2,10 +2,10 @@
 import React from 'react'
 import {Box} from '../../common-adapters'
 import * as PropProviders from '../../stories/prop-providers'
-import {storiesOf, action} from '../../stories/storybook'
+import {storiesOf, action, createPropProvider} from '../../stories/storybook'
 import NewRepo from '.'
 
-const provider = PropProviders.composeAndCreate(PropProviders.WaitingButton())
+const provider = createPropProvider(PropProviders.WaitingButton())
 
 const load = () => {
   storiesOf('Git/New', module)

--- a/shared/login/login/index.stories.js
+++ b/shared/login/login/index.stories.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as PropProviders from '../../stories/prop-providers'
 import Login, {type Props} from '.'
-import {action, storiesOf} from '../../stories/storybook'
+import {action, storiesOf, createPropProvider} from '../../stories/storybook'
 
 const commonProps: Props = {
   error: '',
@@ -25,7 +25,7 @@ const commonProps: Props = {
   waitingForResponse: false,
 }
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/login/login/index.stories.js
+++ b/shared/login/login/index.stories.js
@@ -25,7 +25,7 @@ const commonProps: Props = {
   waitingForResponse: false,
 }
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/login/login/index.stories.js
+++ b/shared/login/login/index.stories.js
@@ -25,10 +25,7 @@ const commonProps: Props = {
   waitingForResponse: false,
 }
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
-)
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
 
 const load = () => {
   storiesOf('Login/Login', module)

--- a/shared/login/login/index.stories.js
+++ b/shared/login/login/index.stories.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as PropProviders from '../../stories/prop-providers'
 import Login, {type Props} from '.'
-import {action, storiesOf, createPropProvider} from '../../stories/storybook'
+import {action, storiesOf} from '../../stories/storybook'
 
 const commonProps: Props = {
   error: '',
@@ -25,7 +25,7 @@ const commonProps: Props = {
   waitingForResponse: false,
 }
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Login/Login', module)

--- a/shared/login/register/passphrase/index.stories.js
+++ b/shared/login/register/passphrase/index.stories.js
@@ -20,7 +20,7 @@ const props = {
   waitingForResponse: false,
 }
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Register/Passphrase', module)

--- a/shared/login/signup/error/index.stories.js
+++ b/shared/login/signup/error/index.stories.js
@@ -6,7 +6,7 @@ import * as PropProviders from '../../../stories/prop-providers'
 
 const load = () => {
   storiesOf('Signup', module)
-    .addDecorator(PropProviders.Common())
+    .addDecorator(PropProviders.CommonProvider())
     .add('Error', () => (
       <Error error="This is an error" onBack={action('onBack')} onRestart={action('onRestart')} />
     ))

--- a/shared/login/signup/invite-code/index.stories.js
+++ b/shared/login/signup/invite-code/index.stories.js
@@ -13,7 +13,7 @@ const props = {
 
 const load = () => {
   storiesOf('Signup/Invite Code', module)
-    .addDecorator(PropProviders.Common())
+    .addDecorator(PropProviders.CommonProvider())
     .add('Start', () => <InviteCode {...props} />)
     .add('Code', () => <InviteCode {...props} />)
     .add('Error', () => <InviteCode {...props} error="This is an error" />)

--- a/shared/login/signup/passphrase/index.stories.js
+++ b/shared/login/signup/passphrase/index.stories.js
@@ -13,7 +13,7 @@ const props = {
 
 const load = () => {
   storiesOf('Signup/Passphrase', module)
-    .addDecorator(PropProviders.Common())
+    .addDecorator(PropProviders.CommonProvider())
     .add('Start', () => <Passphrase {...props} />)
     .add('Error', () => <Passphrase {...props} error="This is an error" />)
 }

--- a/shared/login/signup/request-invite-success/index.stories.js
+++ b/shared/login/signup/request-invite-success/index.stories.js
@@ -6,10 +6,8 @@ import * as PropProviders from '../../../stories/prop-providers'
 
 const load = () => {
   storiesOf('Signup', module)
-      .addDecorator(PropProviders.Common())
-    .add('Request Invite Success', () => (
-    <RequestInviteSuccess onBack={action('onBack')} />
-  ))
+    .addDecorator(PropProviders.CommonProvider())
+    .add('Request Invite Success', () => <RequestInviteSuccess onBack={action('onBack')} />)
 }
 
 export default load

--- a/shared/login/signup/request-invite/index.stories.js
+++ b/shared/login/signup/request-invite/index.stories.js
@@ -13,7 +13,7 @@ const props = {
 
 const load = () => {
   storiesOf('Signup/Request Invite', module)
-    .addDecorator(PropProviders.Common())
+    .addDecorator(PropProviders.CommonProvider())
     .add('Start', () => <RequestInvite {...props} />)
     .add('Name Error', () => <RequestInvite {...props} nameError="Name bad, smash!" />)
     .add('Email Error', () => <RequestInvite {...props} emailError="Email bad, booo" />)

--- a/shared/login/signup/username-email/index.stories.js
+++ b/shared/login/signup/username-email/index.stories.js
@@ -16,7 +16,7 @@ const props = {
 
 const load = () => {
   storiesOf('Signup/Username email', module)
-    .addDecorator(PropProviders.Common())
+    .addDecorator(PropProviders.CommonProvider())
     .addDecorator(story => (
       <Box2 direction="vertical" style={{height: '100%', width: '100%'}}>
         {story()}

--- a/shared/people/follow-notification/index.stories.js
+++ b/shared/people/follow-notification/index.stories.js
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react'
 import * as C from '../../constants/people'
-import {action, storiesOf, createPropProvider} from '../../stories/storybook'
+import {action, storiesOf} from '../../stories/storybook'
 import * as PropProviders from '../../stories/prop-providers'
 import FollowNotification, {type Props} from '.'
 import moment from 'moment'
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
+const provider = PropProviders.CommonProvider()
 
 const singleFollowProps1: Props = {
   type: 'notification',

--- a/shared/people/follow-notification/index.stories.js
+++ b/shared/people/follow-notification/index.stories.js
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react'
 import * as C from '../../constants/people'
-import {action, storiesOf} from '../../stories/storybook'
+import {action, storiesOf, createPropProvider} from '../../stories/storybook'
 import * as PropProviders from '../../stories/prop-providers'
 import FollowNotification, {type Props} from '.'
 import moment from 'moment'
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['max', 'chrisnojima'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/people/follow-notification/index.stories.js
+++ b/shared/people/follow-notification/index.stories.js
@@ -6,10 +6,7 @@ import * as PropProviders from '../../stories/prop-providers'
 import FollowNotification, {type Props} from '.'
 import moment from 'moment'
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['max', 'chrisnojima'], 'ayoubd'),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
-)
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
 
 const singleFollowProps1: Props = {
   type: 'notification',

--- a/shared/people/follow-notification/index.stories.js
+++ b/shared/people/follow-notification/index.stories.js
@@ -6,7 +6,7 @@ import * as PropProviders from '../../stories/prop-providers'
 import FollowNotification, {type Props} from '.'
 import moment from 'moment'
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['max', 'chrisnojima'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/people/follow-suggestions/index.stories.js
+++ b/shared/people/follow-suggestions/index.stories.js
@@ -4,7 +4,7 @@ import {storiesOf, action} from '../../stories/storybook'
 import * as PropProviders from '../../stories/prop-providers'
 import FollowSuggestions, {type Props} from '.'
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['max', 'cnojima', 'cdixon'], [])
 )

--- a/shared/people/follow-suggestions/index.stories.js
+++ b/shared/people/follow-suggestions/index.stories.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from 'react'
-import {storiesOf, action} from '../../stories/storybook'
+import {storiesOf, action, createPropProvider} from '../../stories/storybook'
 import * as PropProviders from '../../stories/prop-providers'
 import FollowSuggestions, {type Props} from '.'
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['max', 'cnojima', 'cdixon'], [])
 )

--- a/shared/people/follow-suggestions/index.stories.js
+++ b/shared/people/follow-suggestions/index.stories.js
@@ -4,10 +4,7 @@ import {storiesOf, action, createPropProvider} from '../../stories/storybook'
 import * as PropProviders from '../../stories/prop-providers'
 import FollowSuggestions, {type Props} from '.'
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  PropProviders.Avatar(['max', 'cnojima', 'cdixon'], [])
-)
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
 
 const props1: Props = {
   onClickUser: action('onClickUser'),

--- a/shared/people/follow-suggestions/index.stories.js
+++ b/shared/people/follow-suggestions/index.stories.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from 'react'
-import {storiesOf, action, createPropProvider} from '../../stories/storybook'
+import {storiesOf, action} from '../../stories/storybook'
 import * as PropProviders from '../../stories/prop-providers'
 import FollowSuggestions, {type Props} from '.'
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
+const provider = PropProviders.CommonProvider()
 
 const props1: Props = {
   onClickUser: action('onClickUser'),

--- a/shared/profile/edit-avatar/index.stories.js
+++ b/shared/profile/edit-avatar/index.stories.js
@@ -10,7 +10,7 @@ const props = {
   onAck: action('onAck'),
 }
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Profile/EditAvatar', module)

--- a/shared/profile/edit-profile/index.stories.js
+++ b/shared/profile/edit-profile/index.stories.js
@@ -23,7 +23,7 @@ const props = {
 
 const Wrapper = ({children}) => <Box style={{display: 'flex', height: 580, minWidth: 640}}>{children}</Box>
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Profile/EditProfile', module)

--- a/shared/profile/profile.stories.js
+++ b/shared/profile/profile.stories.js
@@ -230,7 +230,7 @@ const proofsPending = proofsDefault.map((proof, idx) => ({
   state: checking,
 }))
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Profile/Profile', module)

--- a/shared/search/result-row/index.stories.js
+++ b/shared/search/result-row/index.stories.js
@@ -38,10 +38,7 @@ const serviceRow = {
   rightUsername: null,
 }
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
-)
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
 
 const load = () => {
   storiesOf('Search', module)

--- a/shared/search/result-row/index.stories.js
+++ b/shared/search/result-row/index.stories.js
@@ -38,7 +38,7 @@ const serviceRow = {
   rightUsername: null,
 }
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/search/result-row/index.stories.js
+++ b/shared/search/result-row/index.stories.js
@@ -4,7 +4,7 @@ import * as PropProviders from '../../stories/prop-providers'
 import ResultRow from '.'
 import {Box} from '../../common-adapters'
 import {isMobile} from '../../constants/platform'
-import {storiesOf, action, createPropProvider} from '../../stories/storybook'
+import {storiesOf, action} from '../../stories/storybook'
 
 const commonRow = {
   id: 'result',
@@ -38,7 +38,7 @@ const serviceRow = {
   rightUsername: null,
 }
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Search', module)

--- a/shared/search/result-row/index.stories.js
+++ b/shared/search/result-row/index.stories.js
@@ -4,7 +4,7 @@ import * as PropProviders from '../../stories/prop-providers'
 import ResultRow from '.'
 import {Box} from '../../common-adapters'
 import {isMobile} from '../../constants/platform'
-import {storiesOf, action} from '../../stories/storybook'
+import {storiesOf, action, createPropProvider} from '../../stories/storybook'
 
 const commonRow = {
   id: 'result',
@@ -38,7 +38,7 @@ const serviceRow = {
   rightUsername: null,
 }
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/search/results-list/index.stories.js
+++ b/shared/search/results-list/index.stories.js
@@ -2,16 +2,11 @@
 import * as React from 'react'
 import ResultsList from '.'
 import {Box} from '../../common-adapters'
-import {mockOwnToViewProps} from '../../common-adapters/avatar'
 import {storiesOf, action, createPropProvider} from '../../stories/storybook'
+import * as PropProviders from '../../stories/prop-providers'
 
 const provider = createPropProvider({
-  Avatar: (props: any) =>
-    mockOwnToViewProps(
-      props,
-      ['following', 'both'].includes(props.username),
-      ['following', 'both'].includes(props.username)
-    ),
+  ...PropProviders.Avatar(['following', 'both'], ['following', 'both']),
   SearchResultRow: (props: {id: string}) => servicesResultsListMapCommonRows[props.id],
 })
 

--- a/shared/search/results-list/index.stories.js
+++ b/shared/search/results-list/index.stories.js
@@ -5,8 +5,7 @@ import {Box} from '../../common-adapters'
 import {storiesOf, action, createPropProvider} from '../../stories/storybook'
 import * as PropProviders from '../../stories/prop-providers'
 
-const provider = createPropProvider({
-  ...PropProviders.Avatar(['following', 'both'], ['following', 'both']),
+const provider = createPropProvider(PropProviders.Common(), {
   SearchResultRow: (props: {id: string}) => servicesResultsListMapCommonRows[props.id],
 })
 

--- a/shared/search/user-input/index.stories.js
+++ b/shared/search/user-input/index.stories.js
@@ -98,7 +98,7 @@ const chrisUsers = [
   },
 ]
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Search/UserInput', module)

--- a/shared/settings/delete-confirm/index.stories.js
+++ b/shared/settings/delete-confirm/index.stories.js
@@ -2,9 +2,9 @@
 import * as React from 'react'
 import DeleteConfirm from '.'
 import * as PropProviders from '../../stories/prop-providers'
-import {action, storiesOf} from '../../stories/storybook'
+import {action, storiesOf, createPropProvider} from '../../stories/storybook'
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/settings/delete-confirm/index.stories.js
+++ b/shared/settings/delete-confirm/index.stories.js
@@ -4,7 +4,7 @@ import DeleteConfirm from '.'
 import * as PropProviders from '../../stories/prop-providers'
 import {action, storiesOf} from '../../stories/storybook'
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/settings/delete-confirm/index.stories.js
+++ b/shared/settings/delete-confirm/index.stories.js
@@ -2,9 +2,9 @@
 import * as React from 'react'
 import DeleteConfirm from '.'
 import * as PropProviders from '../../stories/prop-providers'
-import {action, storiesOf, createPropProvider} from '../../stories/storybook'
+import {action, storiesOf} from '../../stories/storybook'
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Settings', module)

--- a/shared/settings/delete-confirm/index.stories.js
+++ b/shared/settings/delete-confirm/index.stories.js
@@ -4,10 +4,7 @@ import DeleteConfirm from '.'
 import * as PropProviders from '../../stories/prop-providers'
 import {action, storiesOf, createPropProvider} from '../../stories/storybook'
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
-)
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
 
 const load = () => {
   storiesOf('Settings', module)

--- a/shared/settings/invites/index.stories.js
+++ b/shared/settings/invites/index.stories.js
@@ -51,7 +51,7 @@ const props = {
   waitingForResponse: false,
 }
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Settings/Invites', module)

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -1,23 +1,7 @@
 // @flow
-import {action, unexpected, createPropProvider, type SelectorMap} from './storybook'
+import {action, unexpected, createPropProvider} from './storybook'
 import {mockOwnToViewProps} from '../common-adapters/avatar'
 import * as _Usernames from '../common-adapters/usernames'
-
-// Compose prop factories into a single provider.
-const compose = (...providers: SelectorMap[]): SelectorMap => {
-  return providers.reduce((obj, provider) => ({...obj, ...provider}), {})
-}
-
-/**
- * Compose prop factories into a single provider
- * @param {Array<SelectorMap>} providers An array of objects of the form { DisplayName: Function(ownProps) }
- *                      that are combined in the output
- * @returns a <Provider /> that can be used in a storybook `addDecorator` to provide viewProps
- *          for connected child components
- */
-const composeAndCreate = (...providers: SelectorMap[]) => {
-  return createPropProvider(compose(...providers))
-}
 
 /**
  * Some common prop factory creators.
@@ -74,10 +58,10 @@ const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: strin
 })
 
 const Common = () =>
-  composeAndCreate(
+  createPropProvider(
     Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
     Avatar(['following', 'both'], ['followers', 'both']),
     WaitingButton()
   )
 
-export {compose, composeAndCreate, Avatar, Common, TeamDropdownMenu, Usernames, WaitingButton}
+export {Avatar, Common, TeamDropdownMenu, Usernames, WaitingButton}

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -1,8 +1,9 @@
 // @flow
-import {action, unexpected, createPropProvider} from './storybook'
+import {action, createPropProvider} from './storybook'
 import {mockOwnToViewProps} from '../common-adapters/avatar'
 import * as _Usernames from '../common-adapters/usernames'
 import * as _WaitingButton from '../common-adapters/waiting-button'
+import * as _TeamDropdownMenu from '../chat/conversation/info-panel/menu/container'
 
 /**
  * Some common prop factory creators.
@@ -39,13 +40,13 @@ const Avatar = (following: string[], followers: string[]) => ({
 })
 
 const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: string]: number}) => ({
-  TeamDropdownMenu: (props: any) => ({
-    _hasCanPerform: true,
-    _loadOperations: unexpected('_loadOperations'),
+  TeamDropdownMenu: (props: _TeamDropdownMenu.OwnProps): _TeamDropdownMenu.Props => ({
     attachTo: props.attachTo,
     badgeSubscribe: false,
     canAddPeople: (adminTeams && adminTeams.includes(props.teamname)) || true,
     isSmallTeam: props.isSmallTeam,
+    manageChannelsSubtitle: props.isSmallTeam ? 'Turns this into a big team' : '',
+    manageChannelsTitle: props.isSmallTeam ? 'Create chat channels...' : 'Manage chat channels',
     memberCount: (teamMemberCounts && teamMemberCounts[props.teamname]) || 100,
     teamname: props.teamname,
     visible: props.visible,

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -14,7 +14,11 @@ import * as _TeamDropdownMenu from '../chat/conversation/info-panel/menu/contain
  *          view props the connected component is concerned with
  */
 
-const Usernames = (following: string[], you?: string) => ({
+const defaultYou = 'ayoubd'
+const defaultFollowing = ['max', 'cnojima', 'cdixon']
+const defaultFollowers = ['max', 'akalin']
+
+const Usernames = (following: string[] = defaultFollowing, you: string = defaultYou) => ({
   Usernames: (ownProps: _Usernames.ConnectedProps): _Usernames.Props => {
     const {usernames} = ownProps
     const users = (usernames || []).map(username => ({
@@ -37,7 +41,7 @@ const WaitingButton = () => ({
   }),
 })
 
-const Avatar = (following: string[], followers: string[]) => ({
+const Avatar = (following: string[] = defaultFollowing, followers: string[] = defaultFollowers) => ({
   Avatar: (ownProps: _Avatar.OwnProps) => _Avatar.mockOwnToViewProps(ownProps, following, followers, action),
 })
 
@@ -61,16 +65,12 @@ const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: strin
   }),
 })
 
-const you = 'ayoubd'
-const following = ['max', 'cnojima', 'cdixon']
-const followers = ['max', 'akalin']
-
 const Common = () => ({
-  ...Usernames(following, you),
-  ...Avatar(following, followers),
+  ...Usernames(),
+  ...Avatar(),
   ...WaitingButton(),
 })
 
 const CommonProvider = () => createPropProvider(Common())
 
-export {Avatar, CommonProvider, TeamDropdownMenu, Usernames, WaitingButton}
+export {Avatar, Common, CommonProvider, TeamDropdownMenu, Usernames, WaitingButton}

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -1,6 +1,7 @@
 // @flow
-import {action, unexpected, createPropProvider} from './storybook'
+import {action, unexpected, createPropProvider, type SelectorMap} from './storybook'
 import {mockOwnToViewProps} from '../common-adapters/avatar'
+import * as _Usernames from '../common-adapters/usernames'
 
 /**
  * Compose prop factories into a single provider
@@ -9,7 +10,7 @@ import {mockOwnToViewProps} from '../common-adapters/avatar'
  * @returns a <Provider /> that can be used in a storybook `addDecorator` to provide viewProps
  *          for connected child components
  */
-const compose = (...providers: any[]) => {
+const compose = (...providers: SelectorMap[]) => {
   return createPropProvider(providers.reduce((obj, provider) => ({...obj, ...provider}), {}))
 }
 
@@ -20,12 +21,10 @@ const compose = (...providers: any[]) => {
  *          that are needed to derive view props
  *  Output: a map of DisplayName: Function(...) that returns the
  *          view props the connected component is concerned with
- *
- *  TODO (DA) Type these props with respective OwnProps where possible
  */
 
 const Usernames = (following: string[], you?: string) => ({
-  Usernames: (props: any) => {
+  Usernames: (props: _Usernames.ConnectedProps): _Usernames.Props => {
     const {usernames} = props
     const users = (usernames || []).map(username => ({
       username,
@@ -69,11 +68,12 @@ const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: strin
   }),
 })
 
-const Common = () => compose(
-  Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  Avatar(['following', 'both'], ['followers', 'both']),
-  WaitingButton()
-)
+const Common = () =>
+  compose(
+    Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
+    Avatar(['following', 'both'], ['followers', 'both']),
+    WaitingButton()
+  )
 
 export {compose}
 export {Avatar, Common, TeamDropdownMenu, Usernames, WaitingButton}

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -3,6 +3,11 @@ import {action, unexpected, createPropProvider, type SelectorMap} from './storyb
 import {mockOwnToViewProps} from '../common-adapters/avatar'
 import * as _Usernames from '../common-adapters/usernames'
 
+// Compose prop factories into a single provider.
+const compose = (...providers: SelectorMap[]): SelectorMap => {
+  return providers.reduce((obj, provider) => ({...obj, ...provider}), {})
+}
+
 /**
  * Compose prop factories into a single provider
  * @param {Array<SelectorMap>} providers An array of objects of the form { DisplayName: Function(ownProps) }
@@ -11,7 +16,7 @@ import * as _Usernames from '../common-adapters/usernames'
  *          for connected child components
  */
 const composeAndCreate = (...providers: SelectorMap[]) => {
-  return createPropProvider(providers.reduce((obj, provider) => ({...obj, ...provider}), {}))
+  return createPropProvider(compose(...providers))
 }
 
 /**
@@ -75,4 +80,4 @@ const Common = () =>
     WaitingButton()
   )
 
-export {composeAndCreate, Avatar, Common, TeamDropdownMenu, Usernames, WaitingButton}
+export {compose, composeAndCreate, Avatar, Common, TeamDropdownMenu, Usernames, WaitingButton}

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -57,11 +57,12 @@ const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: strin
   }),
 })
 
-const Common = () =>
-  createPropProvider(
-    Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-    Avatar(['following', 'both'], ['followers', 'both']),
-    WaitingButton()
-  )
+const Common = () => ({
+  ...Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
+  ...Avatar(['following', 'both'], ['followers', 'both']),
+  ...WaitingButton(),
+})
 
-export {Avatar, Common, TeamDropdownMenu, Usernames, WaitingButton}
+const CommonProvider = () => createPropProvider(Common())
+
+export {Avatar, CommonProvider, TeamDropdownMenu, Usernames, WaitingButton}

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -15,15 +15,15 @@ import * as _TeamDropdownMenu from '../chat/conversation/info-panel/menu/contain
  */
 
 const Usernames = (following: string[], you?: string) => ({
-  Usernames: (props: _Usernames.ConnectedProps): _Usernames.Props => {
-    const {usernames} = props
+  Usernames: (ownProps: _Usernames.ConnectedProps): _Usernames.Props => {
+    const {usernames} = ownProps
     const users = (usernames || []).map(username => ({
       username,
       following: following.includes(username),
       you: you ? username === you : false,
     }))
     return {
-      ...props,
+      ...ownProps,
       users,
       onUsernameClicked: action('onUsernameClicked'),
     }
@@ -31,26 +31,29 @@ const Usernames = (following: string[], you?: string) => ({
 })
 
 const WaitingButton = () => ({
-  WaitingButton: (props: _WaitingButton.OwnProps): _WaitingButton.Props => ({...props, storeWaiting: false}),
+  WaitingButton: (ownProps: _WaitingButton.OwnProps): _WaitingButton.Props => ({
+    ...ownProps,
+    storeWaiting: false,
+  }),
 })
 
 const Avatar = (follows: string[], followers: string[]) => ({
-  Avatar: (props: _Avatar.OwnProps) => _Avatar.mockOwnToViewProps(props, follows, followers, action),
+  Avatar: (ownProps: _Avatar.OwnProps) => _Avatar.mockOwnToViewProps(ownProps, follows, followers, action),
 })
 
 const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: string]: number}) => ({
-  TeamDropdownMenu: (props: _TeamDropdownMenu.OwnProps): _TeamDropdownMenu.Props => ({
-    attachTo: props.attachTo,
+  TeamDropdownMenu: (ownProps: _TeamDropdownMenu.OwnProps): _TeamDropdownMenu.Props => ({
+    attachTo: ownProps.attachTo,
     badgeSubscribe: false,
-    canAddPeople: (adminTeams && adminTeams.includes(props.teamname)) || true,
-    isSmallTeam: props.isSmallTeam,
-    manageChannelsSubtitle: props.isSmallTeam ? 'Turns this into a big team' : '',
-    manageChannelsTitle: props.isSmallTeam ? 'Create chat channels...' : 'Manage chat channels',
-    memberCount: (teamMemberCounts && teamMemberCounts[props.teamname]) || 100,
-    teamname: props.teamname,
-    visible: props.visible,
+    canAddPeople: (adminTeams && adminTeams.includes(ownProps.teamname)) || true,
+    isSmallTeam: ownProps.isSmallTeam,
+    manageChannelsSubtitle: ownProps.isSmallTeam ? 'Turns this into a big team' : '',
+    manageChannelsTitle: ownProps.isSmallTeam ? 'Create chat channels...' : 'Manage chat channels',
+    memberCount: (teamMemberCounts && teamMemberCounts[ownProps.teamname]) || 100,
+    teamname: ownProps.teamname,
+    visible: ownProps.visible,
     onAddPeople: action('onAddPeople'),
-    onHidden: props.onHidden,
+    onHidden: ownProps.onHidden,
     onInvite: action('onInvite'),
     onLeaveTeam: action('onLeaveTeam'),
     onManageChannels: action('onManageChannels'),

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -2,6 +2,7 @@
 import {action, unexpected, createPropProvider} from './storybook'
 import {mockOwnToViewProps} from '../common-adapters/avatar'
 import * as _Usernames from '../common-adapters/usernames'
+import * as _WaitingButton from '../common-adapters/waiting-button'
 
 /**
  * Some common prop factory creators.
@@ -29,7 +30,7 @@ const Usernames = (following: string[], you?: string) => ({
 })
 
 const WaitingButton = () => ({
-  WaitingButton: (props: any) => props,
+  WaitingButton: (props: _WaitingButton.OwnProps): _WaitingButton.Props => ({...props, storeWaiting: false}),
 })
 
 const Avatar = (following: string[], followers: string[]) => ({

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -73,4 +73,4 @@ const Common = () => ({
 
 const CommonProvider = () => createPropProvider(Common())
 
-export {Avatar, Common, CommonProvider, TeamDropdownMenu, Usernames, WaitingButton}
+export {Common, CommonProvider, TeamDropdownMenu}

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -47,6 +47,7 @@ const Avatar = (following: string[] = defaultFollowing, followers: string[] = de
 
 const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: string]: number}) => ({
   TeamDropdownMenu: (ownProps: _TeamDropdownMenu.OwnProps): _TeamDropdownMenu.Props => ({
+    _loadOperations: action('_loadOperations'),
     attachTo: ownProps.attachTo,
     badgeSubscribe: false,
     canAddPeople: (adminTeams && adminTeams.includes(ownProps.teamname)) || true,

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -10,7 +10,7 @@ import * as _Usernames from '../common-adapters/usernames'
  * @returns a <Provider /> that can be used in a storybook `addDecorator` to provide viewProps
  *          for connected child components
  */
-const compose = (...providers: SelectorMap[]) => {
+const composeAndCreate = (...providers: SelectorMap[]) => {
   return createPropProvider(providers.reduce((obj, provider) => ({...obj, ...provider}), {}))
 }
 
@@ -69,11 +69,10 @@ const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: strin
 })
 
 const Common = () =>
-  compose(
+  composeAndCreate(
     Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
     Avatar(['following', 'both'], ['followers', 'both']),
     WaitingButton()
   )
 
-export {compose}
-export {Avatar, Common, TeamDropdownMenu, Usernames, WaitingButton}
+export {composeAndCreate, Avatar, Common, TeamDropdownMenu, Usernames, WaitingButton}

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -1,6 +1,6 @@
 // @flow
 import {action, createPropProvider} from './storybook'
-import {mockOwnToViewProps} from '../common-adapters/avatar'
+import * as _Avatar from '../common-adapters/avatar'
 import * as _Usernames from '../common-adapters/usernames'
 import * as _WaitingButton from '../common-adapters/waiting-button'
 import * as _TeamDropdownMenu from '../chat/conversation/info-panel/menu/container'
@@ -34,9 +34,8 @@ const WaitingButton = () => ({
   WaitingButton: (props: _WaitingButton.OwnProps): _WaitingButton.Props => ({...props, storeWaiting: false}),
 })
 
-const Avatar = (following: string[], followers: string[]) => ({
-  Avatar: (props: any) =>
-    mockOwnToViewProps(props, following.includes(props.username), followers.includes(props.username)),
+const Avatar = (follows: string[], followers: string[]) => ({
+  Avatar: (props: _Avatar.OwnProps) => _Avatar.mockOwnToViewProps(props, follows, followers, action),
 })
 
 const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: string]: number}) => ({

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -37,8 +37,8 @@ const WaitingButton = () => ({
   }),
 })
 
-const Avatar = (follows: string[], followers: string[]) => ({
-  Avatar: (ownProps: _Avatar.OwnProps) => _Avatar.mockOwnToViewProps(ownProps, follows, followers, action),
+const Avatar = (following: string[], followers: string[]) => ({
+  Avatar: (ownProps: _Avatar.OwnProps) => _Avatar.mockOwnToViewProps(ownProps, following, followers, action),
 })
 
 const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: string]: number}) => ({
@@ -61,9 +61,13 @@ const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: strin
   }),
 })
 
+const you = 'ayoubd'
+const following = ['max', 'cnojima', 'cdixon']
+const followers = ['max', 'akalin']
+
 const Common = () => ({
-  ...Usernames(['max', 'cnojima', 'cdixon'], 'ayoubd'),
-  ...Avatar(['following', 'both'], ['followers', 'both']),
+  ...Usernames(following, you),
+  ...Avatar(following, followers),
   ...WaitingButton(),
 })
 

--- a/shared/stories/storybook.js.flow
+++ b/shared/stories/storybook.js.flow
@@ -6,7 +6,7 @@ export type SelectorMap = {
 
 declare function storiesOf(name: string, module: any): any
 declare function action(name: string): any
-declare function createPropProvider(map: SelectorMap): (() => React.Node) => React.Node
+declare function createPropProvider(...maps: SelectorMap[]): (() => React.Node) => React.Node
 declare function unexpected(name: string): () => void
 
 export {action, storiesOf, createPropProvider, unexpected}

--- a/shared/stories/storybook.js.flow
+++ b/shared/stories/storybook.js.flow
@@ -6,7 +6,7 @@ export type SelectorMap = {
 
 declare function storiesOf(name: string, module: any): any
 declare function action(name: string): any
-declare function createPropProvider(map: SelectorMap): React.Node => React.Node
+declare function createPropProvider(map: SelectorMap): (() => React.Node) => React.Node
 declare function unexpected(name: string): () => void
 
 export {action, storiesOf, createPropProvider, unexpected}

--- a/shared/stories/storybook.shared.js
+++ b/shared/stories/storybook.shared.js
@@ -21,11 +21,15 @@ const unexpected = (name: string) => () => {
 // Redux doesn't allow swapping the store given a single provider so we use a new key to force a new provider to
 // work around this issue
 let uniqueProviderKey = 1
-const createPropProvider = (map: SelectorMap) => (story: () => React.Node) => (
-  <Provider key={`provider:${uniqueProviderKey++}`} store={createStore(state => state, map)}>
-    <StorybookErrorBoundary children={story()} />
-  </Provider>
-)
+const createPropProvider = (...maps: SelectorMap[]) => {
+  const merged = maps.reduce((obj, map) => ({...obj, ...merged}), {})
+
+  return (story: () => React.Node) => (
+    <Provider key={`provider:${uniqueProviderKey++}`} store={createStore(state => state, merged)}>
+      <StorybookErrorBoundary children={story()} />
+    </Provider>
+  )
+}
 
 class StorybookErrorBoundary extends React.Component<
   any,

--- a/shared/stories/storybook.shared.js
+++ b/shared/stories/storybook.shared.js
@@ -22,7 +22,7 @@ const unexpected = (name: string) => () => {
 // work around this issue
 let uniqueProviderKey = 1
 const createPropProvider = (...maps: SelectorMap[]) => {
-  const merged = maps.reduce((obj, map) => ({...obj, ...merged}), {})
+  const merged: SelectorMap = maps.reduce((obj, merged) => ({...obj, ...merged}), {})
 
   return (story: () => React.Node) => (
     <Provider key={`provider:${uniqueProviderKey++}`} store={createStore(state => state, merged)}>

--- a/shared/teams/edit-team-description/index.stories.js
+++ b/shared/teams/edit-team-description/index.stories.js
@@ -16,7 +16,7 @@ const sharedProps = {
   waitingKey: 'test',
 }
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Teams/Edit team description', module)

--- a/shared/teams/main/index.stories.js
+++ b/shared/teams/main/index.stories.js
@@ -19,7 +19,7 @@ const teamNameToIsOpen = {
   techtonica: true,
 }
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Teams/Main', module)

--- a/shared/teams/role-picker/index.stories.js
+++ b/shared/teams/role-picker/index.stories.js
@@ -28,7 +28,7 @@ const roleConfirmProps = {
   confirm: true,
 }
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Teams/Roles', module)

--- a/shared/tracker/index.stories.desktop.js
+++ b/shared/tracker/index.stories.desktop.js
@@ -287,7 +287,7 @@ const propsFiveProof = {
   },
 }
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Tracker', module)

--- a/shared/wallets/transaction-details/index.stories.js
+++ b/shared/wallets/transaction-details/index.stories.js
@@ -3,10 +3,10 @@ import * as React from 'react'
 import moment from 'moment'
 import * as PropProviders from '../../stories/prop-providers'
 import {Box2} from '../../common-adapters'
-import {action, storiesOf, createPropProvider} from '../../stories/storybook'
+import {action, storiesOf} from '../../stories/storybook'
 import TransactionDetails from '.'
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
+const provider = PropProviders.CommonProvider()
 
 const now = new Date()
 const yesterday = moment(now)

--- a/shared/wallets/transaction-details/index.stories.js
+++ b/shared/wallets/transaction-details/index.stories.js
@@ -6,7 +6,7 @@ import {Box2} from '../../common-adapters'
 import {action, storiesOf} from '../../stories/storybook'
 import TransactionDetails from '.'
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['paul'], 'john'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/wallets/transaction-details/index.stories.js
+++ b/shared/wallets/transaction-details/index.stories.js
@@ -6,10 +6,7 @@ import {Box2} from '../../common-adapters'
 import {action, storiesOf, createPropProvider} from '../../stories/storybook'
 import TransactionDetails from '.'
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['paul'], 'john'),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
-)
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
 
 const now = new Date()
 const yesterday = moment(now)

--- a/shared/wallets/transaction-details/index.stories.js
+++ b/shared/wallets/transaction-details/index.stories.js
@@ -3,10 +3,10 @@ import * as React from 'react'
 import moment from 'moment'
 import * as PropProviders from '../../stories/prop-providers'
 import {Box2} from '../../common-adapters'
-import {action, storiesOf} from '../../stories/storybook'
+import {action, storiesOf, createPropProvider} from '../../stories/storybook'
 import TransactionDetails from '.'
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['paul'], 'john'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/wallets/transaction/index.stories.js
+++ b/shared/wallets/transaction/index.stories.js
@@ -3,10 +3,10 @@ import * as React from 'react'
 import moment from 'moment'
 import * as PropProviders from '../../stories/prop-providers'
 import {Box2} from '../../common-adapters'
-import {storiesOf} from '../../stories/storybook'
+import {storiesOf, createPropProvider} from '../../stories/storybook'
 import Transaction from '.'
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Usernames(['paul'], 'john'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/wallets/transaction/index.stories.js
+++ b/shared/wallets/transaction/index.stories.js
@@ -3,10 +3,10 @@ import * as React from 'react'
 import moment from 'moment'
 import * as PropProviders from '../../stories/prop-providers'
 import {Box2} from '../../common-adapters'
-import {storiesOf, createPropProvider} from '../../stories/storybook'
+import {storiesOf} from '../../stories/storybook'
 import Transaction from '.'
 
-const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
+const provider = PropProviders.CommonProvider()
 
 const now = new Date()
 const yesterday = moment(now)

--- a/shared/wallets/transaction/index.stories.js
+++ b/shared/wallets/transaction/index.stories.js
@@ -6,10 +6,7 @@ import {Box2} from '../../common-adapters'
 import {storiesOf, createPropProvider} from '../../stories/storybook'
 import Transaction from '.'
 
-const provider = createPropProvider(
-  PropProviders.Usernames(['paul'], 'john'),
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
-)
+const provider = createPropProvider(PropProviders.Usernames(), PropProviders.Avatar())
 
 const now = new Date()
 const yesterday = moment(now)

--- a/shared/wallets/transaction/index.stories.js
+++ b/shared/wallets/transaction/index.stories.js
@@ -6,7 +6,7 @@ import {Box2} from '../../common-adapters'
 import {storiesOf} from '../../stories/storybook'
 import Transaction from '.'
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Usernames(['paul'], 'john'),
   PropProviders.Avatar(['following', 'both'], ['followers', 'both'])
 )

--- a/shared/wallets/wallet-list/index.stories.js
+++ b/shared/wallets/wallet-list/index.stories.js
@@ -47,7 +47,7 @@ const WalletRowProvider = mockWallets => ({
   },
 })
 
-const provider = PropProviders.compose(
+const provider = PropProviders.composeAndCreate(
   PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
   WalletRowProvider(mockWallets)
 )

--- a/shared/wallets/wallet-list/index.stories.js
+++ b/shared/wallets/wallet-list/index.stories.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import * as PropProviders from '../../stories/prop-providers'
-import {storiesOf, action} from '../../stories/storybook'
+import {storiesOf, action, createPropProvider} from '../../stories/storybook'
 import {WalletList} from '.'
 import walletRow from './wallet-row/index.stories'
 import {stringToAccountID} from '../../constants/types/wallets'
@@ -47,7 +47,7 @@ const WalletRowProvider = mockWallets => ({
   },
 })
 
-const provider = PropProviders.composeAndCreate(
+const provider = createPropProvider(
   PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
   WalletRowProvider(mockWallets)
 )

--- a/shared/wallets/wallet-list/index.stories.js
+++ b/shared/wallets/wallet-list/index.stories.js
@@ -47,10 +47,7 @@ const WalletRowProvider = mockWallets => ({
   },
 })
 
-const provider = createPropProvider(
-  PropProviders.Avatar(['following', 'both'], ['followers', 'both']),
-  WalletRowProvider(mockWallets)
-)
+const provider = createPropProvider(PropProviders.Common(), WalletRowProvider(mockWallets))
 
 const accountIDs = Object.keys(mockWallets).map(s => stringToAccountID(s))
 

--- a/shared/wallets/wallet-list/wallet-row/index.stories.js
+++ b/shared/wallets/wallet-list/wallet-row/index.stories.js
@@ -5,7 +5,7 @@ import {Box2} from '../../../common-adapters'
 import {storiesOf, action} from '../../../stories/storybook'
 import {WalletRow} from '.'
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const onSelect = action('onSelect')
 

--- a/shared/wallets/wallet/index.stories.js
+++ b/shared/wallets/wallet/index.stories.js
@@ -26,7 +26,7 @@ const commonActions = {
   onShowSecretKey: action('onShowSecretKey'),
 }
 
-const provider = PropProviders.Common()
+const provider = PropProviders.CommonProvider()
 
 const load = () => {
   storiesOf('Wallets/Wallet', module)


### PR DESCRIPTION
Type createPropProvider properly.

Get rid of PropProviders.compose, and just have createPropProvider
take in a list of SelectorMaps.

Rename PropProviders.Common() to CommonProvider, and have a new
Common variable that is a map (so that createPropProvider can be called
with Common and something else).

Make Avatar typing more strict.

Simplify WaitingButton.