### PR TITLE
cleartextTrafficPermitted=true on localhost

### DIFF
--- a/shared/react-native/android/app/src/main/AndroidManifest.xml
+++ b/shared/react-native/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
       android:name=".MainApplication"
       android:allowBackup="true"
       android:fullBackupContent="@xml/backup_rules"
+      android:networkSecurityConfig="@xml/network_security_config"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme">
@@ -81,8 +82,5 @@
               android:name="android.support.FILE_PROVIDER_PATHS"
               android:resource="@xml/fileprovider"/>
       </provider>
-
-
     </application>
-
 </manifest>

--- a/shared/react-native/android/app/src/main/res/xml/network_security_config.xml
+++ b/shared/react-native/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+      <domain includeSubdomains="false">127.0.0.1</domain>
+  </domain-config>
+</network-security-config>


### PR DESCRIPTION
Opt into cleartext traffic to allow attachment downloads from local attachment server.

https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted
https://koz.io/android-m-and-the-war-on-cleartext-traffic/