### PR TITLE
retire SessionReader

### DIFF
--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -75,7 +75,7 @@ func (e *Bootstrap) Run(m libkb.MetaContext) error {
 		}
 
 		m.CDebugf("connected, running full tracker2 syncer")
-		if err := libkb.RunSyncer(m, ts, e.status.Uid, false /* loggedIn */, nil /* sessionReader */, false /* forceReload */); err != nil {
+		if err := libkb.RunSyncer(m, ts, e.status.Uid, false /* loggedIn */, false /* forceReload */); err != nil {
 			m.CWarningf("error running Tracker2Syncer: %s", err)
 			return nil
 		}

--- a/go/engine/common.go
+++ b/go/engine/common.go
@@ -150,9 +150,6 @@ func fetchLKS(m libkb.MetaContext, encKey libkb.GenericKey) (libkb.PassphraseGen
 		},
 		MetaContext: m,
 	}
-	if lctx := m.LoginContext(); lctx != nil {
-		arg.SessionR = lctx.LocalSession()
-	}
 	res, err := m.G().API.Get(arg)
 	var dummy libkb.LKSecClientHalf
 	if err != nil {

--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -333,12 +333,7 @@ func (e *DeviceKeygen) pushLKS(m libkb.MetaContext) {
 		return
 	}
 
-	// send it to api server
-	var sr libkb.SessionReader
-	if lctx := m.LoginContext(); lctx != nil {
-		sr = lctx.LocalSession()
-	}
-	e.pushErr = libkb.PostDeviceLKS(m, sr, e.args.DeviceID, e.args.DeviceType, serverHalf, e.args.Lks.Generation(), chr, chrk)
+	e.pushErr = libkb.PostDeviceLKS(m, e.args.DeviceID, e.args.DeviceType, serverHalf, e.args.Lks.Generation(), chr, chrk)
 	if e.pushErr != nil {
 		return
 	}

--- a/go/engine/list_trackers.go
+++ b/go/engine/list_trackers.go
@@ -65,7 +65,7 @@ func (e *ListTrackersEngine) Run(m libkb.MetaContext) error {
 		return err
 	}
 	ts := libkb.NewTrackerSyncer(e.uid, m.G())
-	if err := libkb.RunSyncer(m, ts, e.uid, false /* loggedIn */, nil /* sessionReader */, false /* forceReload */); err != nil {
+	if err := libkb.RunSyncer(m, ts, e.uid, false /* loggedIn */, false /* forceReload */); err != nil {
 		return err
 	}
 	e.trackers = ts.Trackers()

--- a/go/engine/list_trackers2.go
+++ b/go/engine/list_trackers2.go
@@ -68,7 +68,7 @@ func (e *ListTrackers2Engine) Run(m libkb.MetaContext) error {
 	}
 	callerUID := m.G().Env.GetUID()
 	ts := libkb.NewTracker2Syncer(m.G(), callerUID, e.arg.Reverse)
-	if err := libkb.RunSyncer(m, ts, e.uid, false /* loggedIn */, nil /* sessionReader */, false /* forceReload */); err != nil {
+	if err := libkb.RunSyncer(m, ts, e.uid, false /* loggedIn */, false /* forceReload */); err != nil {
 		return err
 	}
 	e.res = ts.Result()

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -269,12 +269,7 @@ func (e *PaperKeyGen) push(m libkb.MetaContext) (err error) {
 		return err
 	}
 
-	// post them to the server.
-	var sr libkb.SessionReader
-	if lctx := m.LoginContext(); lctx != nil {
-		sr = lctx.LocalSession()
-	}
-	if err := libkb.PostDeviceLKS(m, sr, backupDev.ID, libkb.DeviceTypePaper, backupLks.GetServerHalf(), backupLks.Generation(), ctext, e.encKey.GetKID()); err != nil {
+	if err := libkb.PostDeviceLKS(m, backupDev.ID, libkb.DeviceTypePaper, backupLks.GetServerHalf(), backupLks.Generation(), ctext, e.encKey.GetKID()); err != nil {
 		return err
 	}
 

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -390,7 +390,7 @@ func (a *ActiveDevice) SyncSecretsForUID(m MetaContext, u keybase1.UID, force bo
 	if uid.IsNil() {
 		return nil, fmt.Errorf("can't run secret syncer without a UID")
 	}
-	err = RunSyncer(m, s, uid, true, nil, force)
+	err = RunSyncer(m, s, uid, true, force)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -476,9 +476,9 @@ func (a *InternalAPIEngine) getURL(arg APIArg) url.URL {
 }
 
 func (a *InternalAPIEngine) sessionArgs(m MetaContext, arg APIArg) (tok, csrf string, err error) {
-	if arg.SessionR != nil {
-		m.CDebugf("using args from SessionR")
-		tok, csrf = arg.SessionR.APIArgs()
+	if m.apiTokener != nil {
+		m.CDebugf("Using apiTokener session and CSRF token")
+		tok, csrf = m.apiTokener.Tokens()
 		return tok, csrf, nil
 	}
 

--- a/go/libkb/apiarg.go
+++ b/go/libkb/apiarg.go
@@ -21,7 +21,6 @@ type APIArg struct {
 	Args            HTTPArgs
 	JSONPayload     JSONPayload
 	SessionType     APISessionType
-	SessionR        SessionReader
 	HTTPStatus      []int
 	AppStatusCodes  []int
 	InitialTimeout  time.Duration // optional

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -8,11 +8,16 @@ import (
 	context "golang.org/x/net/context"
 )
 
+type APITokener interface {
+	Tokens() (session, csrf string)
+}
+
 type MetaContext struct {
 	ctx          context.Context
 	g            *GlobalContext
 	loginContext LoginContext
 	activeDevice *ActiveDevice
+	apiTokener   APITokener
 	uis          UIs
 }
 
@@ -36,6 +41,11 @@ func NewMetaContext(ctx context.Context, g *GlobalContext) MetaContext {
 
 func (m MetaContext) WithLoginContext(l LoginContext) MetaContext {
 	m.loginContext = l
+	return m
+}
+
+func (m MetaContext) WithAPITokener(t APITokener) MetaContext {
+	m.apiTokener = t
 	return m
 }
 

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -263,10 +263,6 @@ func (d *Delegator) post(m MetaContext) (err error) {
 		Args:        hargs,
 		MetaContext: m,
 	}
-	if lctx := m.LoginContext(); lctx != nil {
-		arg.SessionR = lctx.LocalSession()
-	}
-
 	if d.Aggregated {
 		d.postArg = arg
 		return nil

--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -532,11 +532,6 @@ func (s *PerUserKeyring) fetchBoxesLocked(m MetaContext,
 
 	defer m.CTrace("PerUserKeyring#fetchBoxesLocked", func() error { return err })()
 
-	var sessionR SessionReader
-	if lctx := m.LoginContext(); lctx != nil {
-		sessionR = lctx.LocalSession()
-	}
-
 	var resp perUserKeySyncResp
 	err = m.G().API.GetDecode(APIArg{
 		Endpoint: "key/fetch_per_user_key_secrets",
@@ -545,7 +540,6 @@ func (s *PerUserKeyring) fetchBoxesLocked(m MetaContext,
 			"device_id":  S{deviceID.String()},
 		},
 		SessionType: APISessionTypeREQUIRED,
-		SessionR:    sessionR,
 		RetryCount:  5, // It's pretty bad to fail this, so retry.
 		MetaContext: m,
 	}, &resp)

--- a/go/libkb/post.go
+++ b/go/libkb/post.go
@@ -186,7 +186,7 @@ func CheckPostedViaSigID(m MetaContext, sigID keybase1.SigID) (found bool, statu
 	return rfound, keybase1.ProofStatus(rstatus), keybase1.ProofState(rstate), rerr
 }
 
-func PostDeviceLKS(m MetaContext, sr SessionReader, deviceID keybase1.DeviceID, deviceType string, serverHalf LKSecServerHalf,
+func PostDeviceLKS(m MetaContext, deviceID keybase1.DeviceID, deviceType string, serverHalf LKSecServerHalf,
 	ppGen PassphraseGeneration,
 	clientHalfRecovery string, clientHalfRecoveryKID keybase1.KID) error {
 	m.CDebugf("| PostDeviceLKS: %s", deviceID)
@@ -210,7 +210,6 @@ func PostDeviceLKS(m MetaContext, sr SessionReader, deviceID keybase1.DeviceID, 
 			"platform":        S{Val: GetPlatformString()},
 		},
 		RetryCount:  10,
-		SessionR:    sr,
 		MetaContext: m,
 	}
 	_, err := m.G().API.Post(arg)

--- a/go/libkb/provisional_login_context.go
+++ b/go/libkb/provisional_login_context.go
@@ -175,7 +175,8 @@ func (p *ProvisionalLoginContext) RunSecretSyncer(m MetaContext, uid keybase1.UI
 	if uid.IsNil() {
 		uid = p.GetUID()
 	}
-	return RunSyncer(m, p.secretSyncer, uid, (p.localSession != nil), p.localSession, false /* forceReload */)
+	m = m.WithLoginContext(p)
+	return RunSyncer(m, p.secretSyncer, uid, (p.localSession != nil), false /* forceReload */)
 }
 func (p *ProvisionalLoginContext) GetUnlockedPaperEncKey() GenericKey {
 	return nil

--- a/go/libkb/session.go
+++ b/go/libkb/session.go
@@ -8,12 +8,6 @@ import (
 	"time"
 )
 
-type SessionReader interface {
-	APIArgs() (token, csrf string)
-	IsLoggedIn() bool
-	Invalidate()
-}
-
 type Session struct {
 	Contextified
 	token    string

--- a/go/libkb/sync_secret.go
+++ b/go/libkb/sync_secret.go
@@ -119,8 +119,7 @@ func (ss *SecretSyncer) loadFromStorage(m MetaContext, uid keybase1.UID) (err er
 	return nil
 }
 
-func (ss *SecretSyncer) syncFromServer(m MetaContext, uid keybase1.UID, sr SessionReader,
-	forceReload bool) (err error) {
+func (ss *SecretSyncer) syncFromServer(m MetaContext, uid keybase1.UID, forceReload bool) (err error) {
 	hargs := HTTPArgs{}
 
 	if ss.keys != nil && !forceReload {
@@ -132,7 +131,6 @@ func (ss *SecretSyncer) syncFromServer(m MetaContext, uid keybase1.UID, sr Sessi
 		Endpoint:    "key/fetch_private",
 		Args:        hargs,
 		SessionType: APISessionTypeREQUIRED,
-		SessionR:    sr,
 		RetryCount:  5, // It's pretty bad to fail this, so retry.
 		MetaContext: m,
 	})

--- a/go/libkb/sync_trackers.go
+++ b/go/libkb/sync_trackers.go
@@ -109,7 +109,7 @@ func (t *TrackerSyncer) getLoadedVersion() int {
 
 func (t *TrackerSyncer) needsLogin(m MetaContext) bool { return false }
 
-func (t *TrackerSyncer) syncFromServer(m MetaContext, uid keybase1.UID, sr SessionReader, forceReload bool) (err error) {
+func (t *TrackerSyncer) syncFromServer(m MetaContext, uid keybase1.UID, forceReload bool) (err error) {
 
 	lv := t.getLoadedVersion()
 

--- a/go/libkb/sync_trackers2.go
+++ b/go/libkb/sync_trackers2.go
@@ -60,7 +60,7 @@ func (t *Tracker2Syncer) getLoadedVersion() int {
 	return ret
 }
 
-func (t *Tracker2Syncer) syncFromServer(m MetaContext, uid keybase1.UID, sr SessionReader, forceReload bool) (err error) {
+func (t *Tracker2Syncer) syncFromServer(m MetaContext, uid keybase1.UID, forceReload bool) (err error) {
 
 	defer m.CTrace(fmt.Sprintf("syncFromServer(%s)", uid), func() error { return err })()
 
@@ -78,7 +78,6 @@ func (t *Tracker2Syncer) syncFromServer(m MetaContext, uid keybase1.UID, sr Sess
 	res, err = t.G().API.Get(APIArg{
 		Endpoint:    "user/list_followers_for_display",
 		Args:        hargs,
-		SessionR:    sr,
 		MetaContext: m,
 	})
 	m.CDebugf("| syncFromServer() -> %s", ErrToOk(err))

--- a/go/libkb/syncer.go
+++ b/go/libkb/syncer.go
@@ -14,12 +14,12 @@ type Syncer interface {
 	Contextifier
 	sync.Locker
 	loadFromStorage(m MetaContext, u keybase1.UID) error
-	syncFromServer(m MetaContext, u keybase1.UID, sr SessionReader, forceReload bool) error
+	syncFromServer(m MetaContext, u keybase1.UID, forceReload bool) error
 	store(m MetaContext, u keybase1.UID) error
 	needsLogin(m MetaContext) bool
 }
 
-func RunSyncer(m MetaContext, s Syncer, uid keybase1.UID, loggedIn bool, sr SessionReader, forceReload bool) (err error) {
+func RunSyncer(m MetaContext, s Syncer, uid keybase1.UID, loggedIn bool, forceReload bool) (err error) {
 	if uid.IsNil() {
 		return NotFoundError{"No UID given to syncer"}
 	}
@@ -43,7 +43,7 @@ func RunSyncer(m MetaContext, s Syncer, uid keybase1.UID, loggedIn bool, sr Sess
 		m.CDebugf("| Won't sync with server since we're not logged in")
 		return
 	}
-	if err = s.syncFromServer(m, uid, sr, forceReload); err != nil {
+	if err = s.syncFromServer(m, uid, forceReload); err != nil {
 		return
 	}
 	if err = s.store(m, uid); err != nil {


### PR DESCRIPTION
- use MetaContext instead
- in most places, just drop-in, but in Kex2Provisionee, need to make a convenient stub --- APITokener