### PR TITLE
dont wait for a response from pushes into electron

### DIFF
--- a/go/protocol/keybase1/gregor_ui.go
+++ b/go/protocol/keybase1/gregor_ui.go
@@ -70,7 +70,7 @@ func GregorUIProtocol(i GregorUIInterface) rpc.Protocol {
 					err = i.PushState(ctx, (*typedArgs)[0])
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 			"pushOutOfBandMessages": {
 				MakeArg: func() interface{} {
@@ -86,7 +86,7 @@ func GregorUIProtocol(i GregorUIInterface) rpc.Protocol {
 					err = i.PushOutOfBandMessages(ctx, (*typedArgs)[0].Oobm)
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 		},
 	}
@@ -97,12 +97,12 @@ type GregorUIClient struct {
 }
 
 func (c GregorUIClient) PushState(ctx context.Context, __arg PushStateArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.gregorUI.pushState", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "keybase.1.gregorUI.pushState", []interface{}{__arg})
 	return
 }
 
 func (c GregorUIClient) PushOutOfBandMessages(ctx context.Context, oobm []gregor1.OutOfBandMessage) (err error) {
 	__arg := PushOutOfBandMessagesArg{Oobm: oobm}
-	err = c.Cli.Call(ctx, "keybase.1.gregorUI.pushOutOfBandMessages", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "keybase.1.gregorUI.pushOutOfBandMessages", []interface{}{__arg})
 	return
 }

--- a/protocol/avdl/keybase1/gregor_ui.avdl
+++ b/protocol/avdl/keybase1/gregor_ui.avdl
@@ -9,6 +9,6 @@ protocol gregorUI {
     NEW_DATA_2
   }
 
-  void pushState(gregor1.State state, PushReason reason);
-  void pushOutOfBandMessages(array<gregor1.OutOfBandMessage> oobm);
+  void pushState(gregor1.State state, PushReason reason) oneway;
+  void pushOutOfBandMessages(array<gregor1.OutOfBandMessage> oobm) oneway;
 }

--- a/protocol/json/keybase1/gregor_ui.json
+++ b/protocol/json/keybase1/gregor_ui.json
@@ -30,7 +30,8 @@
           "type": "PushReason"
         }
       ],
-      "response": null
+      "response": null,
+      "oneway": true
     },
     "pushOutOfBandMessages": {
       "request": [
@@ -42,7 +43,8 @@
           }
         }
       ],
-      "response": null
+      "response": null,
+      "oneway": true
     }
   },
   "namespace": "keybase.1"


### PR DESCRIPTION
cc @chrisnojima 

This is to fix a problem where Electron just stops responding to service RPC calls into it. Because `pushState` and `pushOutOfBandMessages` are on the main thread of processing Gregor messages, this can back up the whole system. 

```
2018-07-05T20:25:50.380639-04:00 ▶ [DEBU keybase gregor.go:931] 57fea ++Chat: - PushHandler: broadcastMessageOnce -> ok (5h49m45.56188765s)
```