### PR TITLE
run all chat notify through a single thread to guarantee ordering 

### DIFF
--- a/go/chat/activitynotifier.go
+++ b/go/chat/activitynotifier.go
@@ -46,8 +46,10 @@ func (n *NotifyRouterActivityRouter) Start(ctx context.Context, uid gregor1.UID)
 func (n *NotifyRouterActivityRouter) Stop(ctx context.Context) chan struct{} {
 	n.Lock()
 	defer n.Unlock()
+	if n.running {
+		close(n.notifyCh)
+	}
 	n.running = false
-	close(n.notifyCh)
 	ch := make(chan struct{})
 	close(ch)
 	return ch

--- a/go/chat/activitynotifier.go
+++ b/go/chat/activitynotifier.go
@@ -1,0 +1,170 @@
+package chat
+
+import (
+	"context"
+	"sync"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type NotifyRouterActivityRouter struct {
+	utils.DebugLabeler
+	globals.Contextified
+	sync.Mutex
+
+	running  bool
+	notifyCh chan func()
+}
+
+func NewNotifyRouterActivityRouter(g *globals.Context) *NotifyRouterActivityRouter {
+	return &NotifyRouterActivityRouter{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "NotifyRouterActivityRouter", false),
+	}
+}
+
+func (n *NotifyRouterActivityRouter) notifyLoop() {
+	for f := range n.notifyCh {
+		f()
+	}
+}
+
+func (n *NotifyRouterActivityRouter) Start(ctx context.Context, uid gregor1.UID) {
+	n.Lock()
+	defer n.Unlock()
+	if n.running {
+		return
+	}
+	n.notifyCh = make(chan func(), 5000)
+	go n.notifyLoop()
+}
+
+func (n *NotifyRouterActivityRouter) Stop(ctx context.Context) chan struct{} {
+	n.Lock()
+	defer n.Unlock()
+	n.running = false
+	close(n.notifyCh)
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func (n *NotifyRouterActivityRouter) kuid(uid gregor1.UID) keybase1.UID {
+	return keybase1.UID(uid.String())
+}
+
+func (n *NotifyRouterActivityRouter) Activity(ctx context.Context, uid gregor1.UID, topicType chat1.TopicType, activity *chat1.ChatActivity) {
+	defer n.Trace(ctx, func() error { return nil }, "Activity(%v)", topicType)()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleNewChatActivity(ctx, n.kuid(uid), topicType, activity)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) TypingUpdate(ctx context.Context, updates []chat1.ConvTypingUpdate) {
+	defer n.Trace(ctx, func() error { return nil }, "TypingUpdate")()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatTypingUpdate(ctx, updates)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) JoinedConversation(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType, conv *chat1.InboxUIItem) {
+	defer n.Trace(ctx, func() error { return nil }, "JoinedConversation(%s,%v)", convID, topicType)()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatJoinedConversation(ctx, n.kuid(uid), convID, topicType, conv)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) LeftConversation(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType) {
+	defer n.Trace(ctx, func() error { return nil }, "LeftConversation(%s,%v)", convID, topicType)()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatLeftConversation(ctx, n.kuid(uid), convID, topicType)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) ResetConversation(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType) {
+	defer n.Trace(ctx, func() error { return nil }, "ResetConversation(%s,%v)", convID, topicType)()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatResetConversation(ctx, n.kuid(uid), convID, topicType)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) KBFSToImpteamUpgrade(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType) {
+	defer n.Trace(ctx, func() error { return nil }, "KBFSToImpteamUpgrade(%s,%v)", convID, topicType)()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatKBFSToImpteamUpgrade(ctx, n.kuid(uid), convID, topicType)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) SetConvRetention(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType, conv *chat1.InboxUIItem) {
+	defer n.Trace(ctx, func() error { return nil }, "SetConvRetention(%s,%v)", convID, topicType)()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatSetConvRetention(ctx, n.kuid(uid), convID, topicType, conv)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) SetTeamRetention(ctx context.Context, uid gregor1.UID, teamID keybase1.TeamID, topicType chat1.TopicType, convs []chat1.InboxUIItem) {
+	defer n.Trace(ctx, func() error { return nil }, "SetTeamRetention(%s,%v)", teamID, topicType)()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatSetTeamRetention(ctx, n.kuid(uid), teamID, topicType, convs)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) InboxSyncStarted(ctx context.Context, uid gregor1.UID) {
+	defer n.Trace(ctx, func() error { return nil }, "InboxSyncStarted")()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatInboxSyncStarted(ctx, n.kuid(uid))
+	}
+}
+
+func (n *NotifyRouterActivityRouter) InboxSynced(ctx context.Context, uid gregor1.UID, topicType chat1.TopicType, syncRes chat1.ChatSyncResult) {
+	defer n.Trace(ctx, func() error { return nil }, "InboxSynced(%v)", topicType)()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatInboxSynced(ctx, n.kuid(uid), topicType, syncRes)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) InboxStale(ctx context.Context, uid gregor1.UID) {
+	defer n.Trace(ctx, func() error { return nil }, "InboxStale")()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatInboxStale(ctx, n.kuid(uid))
+	}
+}
+
+func (n *NotifyRouterActivityRouter) ThreadsStale(ctx context.Context, uid gregor1.UID, updates []chat1.ConversationStaleUpdate) {
+	defer n.Trace(ctx, func() error { return nil }, "ThreadsStale")()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatThreadsStale(ctx, n.kuid(uid), updates)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) TLFFinalize(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType, finalizeInfo chat1.ConversationFinalizeInfo, conv *chat1.InboxUIItem) {
+	defer n.Trace(ctx, func() error { return nil }, "TLFFinalize(%s,%v)", convID, topicType)()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatTLFFinalize(ctx, n.kuid(uid), convID, topicType, finalizeInfo, conv)
+	}
+}
+
+func (n *NotifyRouterActivityRouter) TLFResolve(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType, resolveInfo chat1.ConversationResolveInfo) {
+	defer n.Trace(ctx, func() error { return nil }, "TLFResolve(%s,%v)", convID, topicType)()
+	ctx = BackgroundContext(ctx, n.G())
+	n.notifyCh <- func() {
+		n.G().NotifyRouter.HandleChatTLFResolve(ctx, n.kuid(uid), convID, topicType, resolveInfo)
+	}
+}

--- a/go/chat/activitynotifier.go
+++ b/go/chat/activitynotifier.go
@@ -39,7 +39,7 @@ func (n *NotifyRouterActivityRouter) Start(ctx context.Context, uid gregor1.UID)
 	if n.running {
 		return
 	}
-	n.notifyCh = make(chan func(), 5000)
+	n.notifyCh = make(chan func(), 1000)
 	go n.notifyLoop()
 }
 

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -1050,7 +1050,7 @@ func (s *HybridConversationSource) expungeNotify(ctx context.Context, uid gregor
 			Expunge: *mergeRes.Expunged,
 			Conv:    inboxItem,
 		})
-		s.G().NotifyRouter.HandleNewChatActivity(ctx, keybase1.UID(uid.String()), topicType, &act)
+		s.G().ActivityNotifier.Activity(ctx, uid, topicType, &act)
 	}
 }
 
@@ -1076,7 +1076,7 @@ func (s *HybridConversationSource) notifyEphemeralPurge(ctx context.Context, uid
 			Msgs:   purgedMsgs,
 			Conv:   inboxItem,
 		})
-		s.G().NotifyRouter.HandleNewChatActivity(ctx, keybase1.UID(uid.String()), topicType, &act)
+		s.G().ActivityNotifier.Activity(ctx, uid, topicType, &act)
 	}
 }
 

--- a/go/chat/globals/globals.go
+++ b/go/chat/globals/globals.go
@@ -19,6 +19,7 @@ type ChatContext struct {
 	TeamChannelSource   types.TeamChannelSource   // source of all channels in a team
 	AttachmentURLSrv    types.AttachmentURLSrv    // source of URLs for loading attachments
 	EphemeralPurger     types.EphemeralPurger     // triggers background purges of ephemeral chats
+	ActivityNotifier    types.ActivityNotifier    // notify clients of chat of new activity
 }
 
 type Context struct {

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -249,7 +249,7 @@ func (g *PushHandler) TlfFinalize(ctx context.Context, m gregor.OutOfBandMessage
 			if conv != nil {
 				topicType = conv.GetTopicType()
 			}
-			g.G().NotifyRouter.HandleChatTLFFinalize(ctx, keybase1.UID(uid.String()),
+			g.G().ActivityNotifier.TLFFinalize(ctx, uid,
 				convID, topicType, update.FinalizeInfo, g.presentUIItem(ctx, conv, uid))
 		}
 	}(bctx)
@@ -303,7 +303,7 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 		}
 		g.Debug(ctx, "TlfResolve: convID: %s new TLF name: %s", updateConv.GetConvID(),
 			updateConv.Info.TlfName)
-		g.G().NotifyRouter.HandleChatTLFResolve(ctx, keybase1.UID(uid.String()),
+		g.G().ActivityNotifier.TLFResolve(ctx, uid,
 			update.ConvID, updateConv.GetTopicType(), resolveInfo)
 	}(bctx)
 
@@ -619,7 +619,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			g.badger.PushChatUpdate(ctx, *gm.UnreadUpdate, gm.InboxVers)
 		}
 		if activity != nil {
-			g.notifyNewChatActivity(ctx, m.UID(), gm.TopicType, activity)
+			g.notifyNewChatActivity(ctx, m.UID().(gregor1.UID), gm.TopicType, activity)
 		} else {
 			g.Debug(ctx, "chat activity: skipping notify, activity is nil")
 		}
@@ -627,36 +627,25 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 	return nil
 }
 
-func (g *PushHandler) notifyNewChatActivity(ctx context.Context, uid gregor.UID,
-	topicType chat1.TopicType, activity *chat1.ChatActivity) error {
-	kbUID, err := keybase1.UIDFromString(hex.EncodeToString(uid.Bytes()))
-	if err != nil {
-		return err
-	}
-	g.G().NotifyRouter.HandleNewChatActivity(ctx, kbUID, topicType, activity)
-	return nil
+func (g *PushHandler) notifyNewChatActivity(ctx context.Context, uid gregor1.UID,
+	topicType chat1.TopicType, activity *chat1.ChatActivity) {
+	g.G().ActivityNotifier.Activity(ctx, uid, topicType, activity)
 }
 
 func (g *PushHandler) notifyJoinChannel(ctx context.Context, uid gregor1.UID,
 	conv chat1.ConversationLocal) {
-	kuid := keybase1.UID(uid.String())
-	g.G().NotifyRouter.HandleChatJoinedConversation(ctx, kuid, conv.GetConvID(),
+	g.G().ActivityNotifier.JoinedConversation(ctx, uid, conv.GetConvID(),
 		conv.GetTopicType(), g.presentUIItem(ctx, &conv, uid))
 }
 
 func (g *PushHandler) notifyLeftChannel(ctx context.Context, uid gregor1.UID,
 	convID chat1.ConversationID, topicType chat1.TopicType) {
-	kuid := keybase1.UID(uid.String())
-	g.G().NotifyRouter.HandleChatLeftConversation(ctx, kuid, convID, topicType)
+	g.G().ActivityNotifier.LeftConversation(ctx, uid, convID, topicType)
 }
 
 func (g *PushHandler) notifyReset(ctx context.Context, uid gregor1.UID,
 	convID chat1.ConversationID, topicType chat1.TopicType) {
-	if topicType != chat1.TopicType_CHAT {
-		return
-	}
-	kuid := keybase1.UID(uid.String())
-	g.G().NotifyRouter.HandleChatResetConversation(ctx, kuid, convID, topicType)
+	g.G().ActivityNotifier.ResetConversation(ctx, uid, convID, topicType)
 }
 
 func (g *PushHandler) notifyMembersUpdate(ctx context.Context, uid gregor1.UID,
@@ -782,10 +771,7 @@ func (g *PushHandler) UpgradeKBFSToImpteam(ctx context.Context, m gregor.OutOfBa
 		if err = g.G().ConvSource.Clear(ctx, update.ConvID, uid); err != nil {
 			g.Debug(ctx, "UpgradeKBFSToImpteam: failed to clear convsource: %s", err)
 		}
-
-		g.G().NotifyRouter.HandleChatKBFSToImpteamUpgrade(ctx, keybase1.UID(uid.String()), update.ConvID,
-			update.TopicType)
-
+		g.G().ActivityNotifier.KBFSToImpteamUpgrade(ctx, uid, update.ConvID, update.TopicType)
 		return nil
 	}(bctx)
 
@@ -917,7 +903,7 @@ func (g *PushHandler) SetConvRetention(ctx context.Context, m gregor.OutOfBandMe
 			return
 		}
 		// Send notify for the conv
-		g.G().NotifyRouter.HandleChatSetConvRetention(ctx, keybase1.UID(uid.String()),
+		g.G().ActivityNotifier.SetConvRetention(ctx, uid,
 			conv.GetConvID(), conv.GetTopicType(), g.presentUIItem(ctx, conv, uid))
 	}(bctx)
 
@@ -972,8 +958,7 @@ func (g *PushHandler) SetTeamRetention(ctx context.Context, m gregor.OutOfBandMe
 			}
 		}
 		for topicType, items := range convUIItems {
-			g.G().NotifyRouter.HandleChatSetTeamRetention(ctx, keybase1.UID(uid.String()), update.TeamID,
-				topicType, items)
+			g.G().ActivityNotifier.SetTeamRetention(ctx, uid, update.TeamID, topicType, items)
 		}
 	}(bctx)
 

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -660,8 +660,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 			DisplayDesktopNotification: false,
 			Conv: s.presentUIItem(convLocal),
 		})
-		s.G().NotifyRouter.HandleNewChatActivity(ctx, keybase1.UID(boxed.ClientHeader.Sender.String()),
-			conv.GetTopicType(), &activity)
+		s.G().ActivityNotifier.Activity(ctx, boxed.ClientHeader.Sender, conv.GetTopicType(), &activity)
 	}
 	return []byte{}, boxed, nil
 }
@@ -879,10 +878,8 @@ func (s *Deliverer) failMessage(ctx context.Context, obr chat1.OutboxRecord,
 		act := chat1.NewChatActivityWithFailedMessage(chat1.FailedMessageInfo{
 			OutboxRecords: marked,
 		})
-		s.G().NotifyRouter.HandleNewChatActivity(context.Background(),
-			keybase1.UID(s.outbox.GetUID().String()), chat1.TopicType_NONE, &act)
+		s.G().ActivityNotifier.Activity(context.Background(), s.outbox.GetUID(), chat1.TopicType_NONE, &act)
 	}
-
 	return nil
 }
 

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -248,7 +248,6 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	g.ChatHelper = NewHelper(g, getRI)
 	g.TeamChannelSource = NewCachingTeamChannelSource(g, getRI)
 	g.ActivityNotifier = NewNotifyRouterActivityRouter(g)
-	g.ActivityNotifier.Start(context.TODO(), uid)
 
 	searcher := NewSearcher(g)
 	// Force small pages during tests to ensure we fetch context from new pages

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -344,7 +344,7 @@ func TestNonblockTimer(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Send a bunch of nonblocking messages
+	// Send a bunch of blocking messages
 	var sentRef []sentRecord
 	for i := 0; i < 5; i++ {
 		_, msgBoxed, err := baseSender.Send(ctx, res.ConvID, chat1.MessagePlaintext{
@@ -404,7 +404,7 @@ func TestNonblockTimer(t *testing.T) {
 	default:
 	}
 
-	// Send a bunch of nonblocking messages
+	// Send a bunch of blocking messages
 	for i := 0; i < 5; i++ {
 		_, msgBoxed, err := baseSender.Send(ctx, res.ConvID, chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
@@ -445,6 +445,7 @@ func TestNonblockTimer(t *testing.T) {
 			require.Fail(t, "event not received")
 		}
 
+		t.Logf("OUTBOXID: %s", obids[i/2])
 		require.Equal(t, i+1, olen, "wrong length")
 		require.Equal(t, listener.obids[i], obids[i/2], "wrong obid")
 	}

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -247,6 +247,8 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	g.PushHandler = pushHandler
 	g.ChatHelper = NewHelper(g, getRI)
 	g.TeamChannelSource = NewCachingTeamChannelSource(g, getRI)
+	g.ActivityNotifier = NewNotifyRouterActivityRouter(g)
+
 	searcher := NewSearcher(g)
 	// Force small pages during tests to ensure we fetch context from new pages
 	searcher.pageSize = 2

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -248,6 +248,7 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	g.ChatHelper = NewHelper(g, getRI)
 	g.TeamChannelSource = NewCachingTeamChannelSource(g, getRI)
 	g.ActivityNotifier = NewNotifyRouterActivityRouter(g)
+	g.ActivityNotifier.Start(context.TODO(), uid)
 
 	searcher := NewSearcher(g)
 	// Force small pages during tests to ensure we fetch context from new pages

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -355,7 +355,6 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	g.TeamChannelSource = NewCachingTeamChannelSource(g, func() chat1.RemoteInterface { return ri })
 	g.AttachmentURLSrv = DummyAttachmentHTTPSrv{}
 	g.ActivityNotifier = NewNotifyRouterActivityRouter(g)
-	g.ActivityNotifier.Start(context.TODO(), uid)
 
 	tc.G.ChatHelper = NewHelper(g, func() chat1.RemoteInterface { return ri })
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -354,6 +354,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	g.PushHandler = pushHandler
 	g.TeamChannelSource = NewCachingTeamChannelSource(g, func() chat1.RemoteInterface { return ri })
 	g.AttachmentURLSrv = DummyAttachmentHTTPSrv{}
+	g.ActivityNotifier = NewNotifyRouterActivityRouter(g)
 
 	tc.G.ChatHelper = NewHelper(g, func() chat1.RemoteInterface { return ri })
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -355,6 +355,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	g.TeamChannelSource = NewCachingTeamChannelSource(g, func() chat1.RemoteInterface { return ri })
 	g.AttachmentURLSrv = DummyAttachmentHTTPSrv{}
 	g.ActivityNotifier = NewNotifyRouterActivityRouter(g)
+	g.ActivityNotifier.Start(context.TODO(), uid)
 
 	tc.G.ChatHelper = NewHelper(g, func() chat1.RemoteInterface { return ri })
 

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -540,8 +540,7 @@ func (o *Outbox) OutboxPurge(ctx context.Context) (err error) {
 			OutboxRecords:    ephemeralPurged,
 			IsEphemeralPurge: true,
 		})
-		o.G().NotifyRouter.HandleNewChatActivity(context.Background(),
-			keybase1.UID(o.GetUID().String()), chat1.TopicType_NONE, &act)
+		o.G().ActivityNotifier.Activity(context.Background(), o.GetUID(), chat1.TopicType_NONE, &act)
 	}
 	return nil
 }

--- a/go/chat/storage/outbox_test.go
+++ b/go/chat/storage/outbox_test.go
@@ -178,7 +178,7 @@ func TestChatOutboxPurge(t *testing.T) {
 	require.Equal(t, obrs, res, "wrong obids")
 
 	// Nothing is in the error state & expired, so we should not have purged anything
-	err = ob.OutboxPurge(context.TODO())
+	_, err = ob.OutboxPurge(context.TODO())
 	require.NoError(t, err)
 
 	res, err = ob.PullAllConversations(context.TODO(), true, false)
@@ -196,7 +196,7 @@ func TestChatOutboxPurge(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	err = ob.OutboxPurge(context.TODO())
+	_, err = ob.OutboxPurge(context.TODO())
 	require.NoError(t, err)
 	res, err = ob.PullAllConversations(context.TODO(), true, false)
 	require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestChatOutboxPurge(t *testing.T) {
 	// move the clock forward the ephemeralPurgeCutoff duration and we'll
 	// remove the ephemeral records.
 	cl.Advance(ephemeralPurgeCutoff)
-	err = ob.OutboxPurge(context.TODO())
+	_, err = ob.OutboxPurge(context.TODO())
 	require.NoError(t, err)
 	res, err = ob.PullAllConversations(context.TODO(), true, false)
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestChatOutboxPurge(t *testing.T) {
 	// move the clock forward the errorPurgeCutoff duration and we'll remove
 	// the records that are marked as an error.
 	cl.Advance(errorPurgeCutoff)
-	err = ob.OutboxPurge(context.TODO())
+	_, err = ob.OutboxPurge(context.TODO())
 	require.NoError(t, err)
 	res, err = ob.PullAllConversations(context.TODO(), true, false)
 	require.NoError(t, err)

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"encoding/hex"
 	"sync"
 	"time"
 
@@ -108,19 +109,21 @@ func (s *Syncer) sendNotificationsOnce() {
 		// Broadcast full reloads
 		for uid := range s.fullReload {
 			s.Debug(context.Background(), "flushing full reload: uid: %s", uid)
-			s.G().NotifyRouter.HandleChatInboxStale(context.Background(), keybase1.UID(uid))
+			b, _ := hex.DecodeString(uid)
+			s.G().ActivityNotifier.InboxStale(context.Background(), gregor1.UID(b))
 		}
 		s.fullReload = make(map[string]bool)
 
 		// Broadcast conversation stales
 		for uid, updates := range s.notificationQueue {
 			updates = s.dedupUpdates(updates)
+			b, _ := hex.DecodeString(uid)
 			s.Debug(context.Background(), "flushing notifications: uid: %s len: %d", uid, len(updates))
 			for _, update := range updates {
 				s.Debug(context.Background(), "flushing: uid: %s convID: %s type: %v", uid,
 					update.ConvID, update.UpdateType)
 			}
-			s.G().NotifyRouter.HandleChatThreadsStale(context.Background(), keybase1.UID(uid), updates)
+			s.G().ActivityNotifier.ThreadsStale(context.Background(), gregor1.UID(b), updates)
 		}
 		s.notificationQueue = make(map[string][]chat1.ConversationStaleUpdate)
 	}
@@ -308,11 +311,11 @@ func (s *Syncer) filterNotifyConvs(ctx context.Context, convs []chat1.Conversati
 	return res
 }
 
-func (s *Syncer) notifyIncrementalSync(ctx context.Context, uid keybase1.UID,
+func (s *Syncer) notifyIncrementalSync(ctx context.Context, uid gregor1.UID,
 	allConvs []chat1.UnverifiedInboxUIItem) {
 	if len(allConvs) == 0 {
 		s.Debug(ctx, "notifyIncrementalSync: no conversations given, sending a current result")
-		s.G().NotifyRouter.HandleChatInboxSynced(ctx, uid, chat1.TopicType_NONE,
+		s.G().ActivityNotifier.InboxSynced(ctx, uid, chat1.TopicType_NONE,
 			chat1.NewChatSyncResultWithCurrent())
 		return
 	}
@@ -325,7 +328,7 @@ func (s *Syncer) notifyIncrementalSync(ctx context.Context, uid keybase1.UID,
 			continue
 		}
 		convs := m[topicType]
-		s.G().NotifyRouter.HandleChatInboxSynced(ctx, uid, topicType,
+		s.G().ActivityNotifier.InboxSynced(ctx, uid, topicType,
 			chat1.NewChatSyncResultWithIncremental(chat1.ChatSyncIncrementalInfo{
 				Items: convs,
 			}))
@@ -338,8 +341,6 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		s.Debug(ctx, "Sync: aborting because currently offline")
 		return OfflineError{}
 	}
-	kuid := keybase1.UID(uid.String())
-
 	// Grab current on disk version
 	ibox := storage.NewInbox(s.G(), uid)
 	vers, err := ibox.Version(ctx)
@@ -388,11 +389,11 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 			s.Debug(ctx, "Sync: failed to clear inbox: %s", err.Error())
 		}
 		// Send notifications for a full clear
-		s.G().NotifyRouter.HandleChatInboxSynced(ctx, kuid, chat1.TopicType_NONE,
+		s.G().ActivityNotifier.InboxSynced(ctx, uid, chat1.TopicType_NONE,
 			chat1.NewChatSyncResultWithClear())
 	case chat1.SyncInboxResType_CURRENT:
 		s.Debug(ctx, "Sync: version is current, standing pat: %v", vers)
-		s.G().NotifyRouter.HandleChatInboxSynced(ctx, kuid, chat1.TopicType_NONE,
+		s.G().ActivityNotifier.InboxSynced(ctx, uid, chat1.TopicType_NONE,
 			chat1.NewChatSyncResultWithCurrent())
 	case chat1.SyncInboxResType_INCREMENTAL:
 		incr := syncRes.InboxRes.Incremental()
@@ -405,7 +406,7 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 			s.Debug(ctx, "Sync: failed to sync conversations to inbox: %s", err.Error())
 
 			// Send notifications for a full clear
-			s.G().NotifyRouter.HandleChatInboxSynced(ctx, kuid, chat1.TopicType_NONE,
+			s.G().ActivityNotifier.InboxSynced(ctx, uid, chat1.TopicType_NONE,
 				chat1.NewChatSyncResultWithClear())
 		} else {
 			s.handleMembersTypeChanged(ctx, uid, iboxSyncRes.MembersTypeChanged)
@@ -416,13 +417,13 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 			if s.shouldDoFullReloadFromIncremental(ctx, iboxSyncRes, incr.Convs) {
 				// If we get word we should full clear the inbox (like if the user left a conversation),
 				// then just reload everything
-				s.G().NotifyRouter.HandleChatInboxSynced(ctx, kuid, chat1.TopicType_NONE,
+				s.G().ActivityNotifier.InboxSynced(ctx, uid, chat1.TopicType_NONE,
 					chat1.NewChatSyncResultWithClear())
 			} else {
 				// Send notifications for a successful partial sync
 				convs := utils.PresentRemoteConversations(
 					utils.RemoteConvs(s.filterNotifyConvs(ctx, incr.Convs, iboxSyncRes.TopicNameChanged)))
-				s.notifyIncrementalSync(ctx, kuid, convs)
+				s.notifyIncrementalSync(ctx, uid, convs)
 			}
 		}
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -224,6 +224,35 @@ type TeamChannelSource interface {
 	ChannelsChanged(context.Context, chat1.TLFID)
 }
 
+type ActivityNotifier interface {
+	Resumable
+
+	Activity(ctx context.Context, uid gregor1.UID, topicType chat1.TopicType, activity *chat1.ChatActivity)
+	TypingUpdate(ctx context.Context, updates []chat1.ConvTypingUpdate)
+	JoinedConversation(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
+		topicType chat1.TopicType, conv *chat1.InboxUIItem)
+	LeftConversation(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
+		topicType chat1.TopicType)
+	ResetConversation(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
+		topicType chat1.TopicType)
+	KBFSToImpteamUpgrade(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
+		topicType chat1.TopicType)
+	SetConvRetention(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
+		topicType chat1.TopicType, conv *chat1.InboxUIItem)
+	SetTeamRetention(ctx context.Context, uid gregor1.UID, teamID keybase1.TeamID, topicType chat1.TopicType,
+		convs []chat1.InboxUIItem)
+
+	InboxSyncStarted(ctx context.Context, uid gregor1.UID)
+	InboxSynced(ctx context.Context, uid gregor1.UID, topicType chat1.TopicType, syncRes chat1.ChatSyncResult)
+	InboxStale(ctx context.Context, uid gregor1.UID)
+	ThreadsStale(ctx context.Context, uid gregor1.UID, updates []chat1.ConversationStaleUpdate)
+
+	TLFFinalize(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType,
+		finalizeInfo chat1.ConversationFinalizeInfo, conv *chat1.InboxUIItem)
+	TLFResolve(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType,
+		resolveInfo chat1.ConversationResolveInfo)
+}
+
 type IdentifyNotifier interface {
 	Reset()
 	ResetOnGUIConnect()

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -225,8 +225,6 @@ type TeamChannelSource interface {
 }
 
 type ActivityNotifier interface {
-	Resumable
-
 	Activity(ctx context.Context, uid gregor1.UID, topicType chat1.TopicType, activity *chat1.ChatActivity)
 	TypingUpdate(ctx context.Context, updates []chat1.ConvTypingUpdate)
 	JoinedConversation(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,

--- a/go/chat/typingmonitor.go
+++ b/go/chat/typingmonitor.go
@@ -88,7 +88,7 @@ func (t *TypingMonitor) notifyConvUpdateLocked(ctx context.Context, convID chat1
 		ConvID: convID,
 		Typers: typers,
 	}
-	t.G().NotifyRouter.HandleChatTypingUpdate(ctx, []chat1.ConvTypingUpdate{update})
+	t.G().ActivityNotifier.TypingUpdate(ctx, []chat1.ConvTypingUpdate{update})
 }
 
 func (t *TypingMonitor) Update(ctx context.Context, typer chat1.TyperInfo, convID chat1.ConversationID,

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -604,7 +604,7 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 	res.RateLimit = &chat1.RateLimit{}
 
 	// hit notify router with new message
-	if m.world.TcsByID[uid.String()].G.NotifyRouter != nil {
+	if m.world.TcsByID[uid.String()].ChatG.ActivityNotifier != nil {
 		activity := chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
 			Message: utils.PresentMessageUnboxed(ctx, m.world.TcsByID[uid.String()].Context(),
 				chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
@@ -613,8 +613,8 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 					MessageBody:  m.createBogusBody(inserted.GetMessageType()),
 				}), uid, arg.ConversationID),
 		})
-		m.world.TcsByID[uid.String()].G.NotifyRouter.HandleNewChatActivity(context.Background(),
-			keybase1.UID(uid.String()), conv.GetTopicType(), &activity)
+		m.world.TcsByID[uid.String()].ChatG.ActivityNotifier.Activity(context.Background(),
+			uid, conv.GetTopicType(), &activity)
 	}
 
 	return

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -47,6 +47,9 @@ func (c ChatTestContext) Cleanup() {
 	if c.ChatG.FetchRetrier != nil {
 		<-c.ChatG.FetchRetrier.Stop(context.TODO())
 	}
+	if c.ChatG.ActivityNotifier != nil {
+		<-c.ChatG.ActivityNotifier.Stop(context.TODO())
+	}
 	c.TestContext.Cleanup()
 }
 

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -47,9 +47,6 @@ func (c ChatTestContext) Cleanup() {
 	if c.ChatG.FetchRetrier != nil {
 		<-c.ChatG.FetchRetrier.Stop(context.TODO())
 	}
-	if c.ChatG.ActivityNotifier != nil {
-		<-c.ChatG.ActivityNotifier.Stop(context.TODO())
-	}
 	c.TestContext.Cleanup()
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -100,6 +100,7 @@ func (h *gregorFirehoseHandler) IsAlive() bool {
 }
 
 func (h *gregorFirehoseHandler) PushState(s gregor1.State, r keybase1.PushReason) {
+	defer h.G().Trace("gregorFirehoseHandler#PushState", func() error { return nil })()
 	err := h.cli.PushState(context.Background(), keybase1.PushStateArg{State: s, Reason: r})
 	if err != nil {
 		h.G().Log.Error(fmt.Sprintf("Error in firehose push state: %s", err))
@@ -122,7 +123,7 @@ func (h *gregorFirehoseHandler) filterOOBMs(v []gregor1.OutOfBandMessage) []greg
 }
 
 func (h *gregorFirehoseHandler) PushOutOfBandMessages(v []gregor1.OutOfBandMessage) {
-
+	defer h.G().Trace("gregorFirehoseHandler#PushOutOfBandMessages", func() error { return nil })()
 	nOrig := len(v)
 
 	// Filter OOBMs down to wanted systems if we have a filter installed

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -356,6 +356,7 @@ func (d *Service) startChatModules() {
 		g.ConvLoader.Start(context.Background(), uid)
 		g.FetchRetrier.Start(context.Background(), uid)
 		g.EphemeralPurger.Start(context.Background(), uid)
+		g.ActivityNotifier.Start(context.Background(), uid)
 	}
 }
 
@@ -364,6 +365,7 @@ func (d *Service) stopChatModules() {
 	<-d.ChatG().ConvLoader.Stop(context.Background())
 	<-d.ChatG().FetchRetrier.Stop(context.Background())
 	<-d.ChatG().EphemeralPurger.Stop(context.Background())
+	<-d.ChatG().ActivityNotifier.Stop(context.Background())
 }
 
 func (d *Service) createChatModules() {
@@ -386,6 +388,7 @@ func (d *Service) createChatModules() {
 	g.FetchRetrier = chat.NewFetchRetrier(g)
 	g.ConvLoader = chat.NewBackgroundConvLoader(g)
 	g.EphemeralPurger = chat.NewBackgroundEphemeralPurger(g, chatStorage)
+	g.ActivityNotifier = chat.NewNotifyRouterActivityRouter(g)
 
 	// Set up push handler with the badger
 	d.badger.SetInboxVersionSource(storage.NewInboxVersionSource(g))

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -356,7 +356,6 @@ func (d *Service) startChatModules() {
 		g.ConvLoader.Start(context.Background(), uid)
 		g.FetchRetrier.Start(context.Background(), uid)
 		g.EphemeralPurger.Start(context.Background(), uid)
-		g.ActivityNotifier.Start(context.Background(), uid)
 	}
 }
 
@@ -365,7 +364,6 @@ func (d *Service) stopChatModules() {
 	<-d.ChatG().ConvLoader.Stop(context.Background())
 	<-d.ChatG().FetchRetrier.Stop(context.Background())
 	<-d.ChatG().EphemeralPurger.Stop(context.Background())
-	<-d.ChatG().ActivityNotifier.Stop(context.Background())
 }
 
 func (d *Service) createChatModules() {


### PR DESCRIPTION
If all these calls just go to `NotifyRouter` right away, they can all line up on the `ConnectionManager` lock in `ApplyAll`. If that happens, then all the threads waiting on the lock can get out of order. Patch does the following:

1.) Introduce `ActivityNotifier` a new interface in `globals`.
2.) Implement with `NotifyRouterActivityRouter` which just serializes calls into `NotifyRouter`. 
3.) Don't run any notifications from `OutboxPurge`, do it in a package outside. 