### PR TITLE
Add missing prop to badge

### DIFF
--- a/shared/settings/nav/index.native.js
+++ b/shared/settings/nav/index.native.js
@@ -45,7 +45,14 @@ function SettingsItem({
         >
           {text}
         </Text>
-        {!!badgeNumber && badgeNumber > 0 && <Badge badgeStyle={badgeStyle} badgeNumber={badgeNumber} />}
+        {!!badgeNumber &&
+          badgeNumber > 0 && (
+            <Badge
+              badgeStyle={badgeStyle}
+              badgeNumber={badgeNumber}
+              largerBadgeMinWidthFix={largerBadgeMinWidthFix}
+            />
+          )}
       </Box>
     </ClickableBox>
   ) : null


### PR DESCRIPTION
Realized in my [earlier badge fix PR](https://github.com/keybase/client/pull/12642) that everything was done except the Badge component itself was missing the prop that does the fix. 😞 

Anyways, this fixes that.
