### PR TITLE
Partial pairwiseMAC reader support

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -416,7 +416,7 @@ func (b *Boxer) unbox(ctx context.Context, boxed chat1.MessageBoxed,
 	case chat1.MessageBoxedVersion_V2, chat1.MessageBoxedVersion_V3, chat1.MessageBoxedVersion_V4:
 		res, err := b.unboxV2orV3orV4(ctx, boxed, membersType, encryptionKey, ephemeralSeed)
 		if err != nil {
-			b.Debug(ctx, "error unboxing message version: %v, %v", boxed.Version, err)
+			b.Debug(ctx, "error unboxing message version: %v, %s", boxed.Version, err)
 		}
 		return res, err
 	// NOTE: When adding new versions here, you must also update

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -416,7 +416,7 @@ func (b *Boxer) unbox(ctx context.Context, boxed chat1.MessageBoxed,
 	case chat1.MessageBoxedVersion_V2, chat1.MessageBoxedVersion_V3, chat1.MessageBoxedVersion_V4:
 		res, err := b.unboxV2orV3orV4(ctx, boxed, membersType, encryptionKey, ephemeralSeed)
 		if err != nil {
-			b.Debug(ctx, "error unboxing message version: %v", boxed.Version)
+			b.Debug(ctx, "error unboxing message version: %v, %v", boxed.Version, err)
 		}
 		return res, err
 	// NOTE: When adding new versions here, you must also update
@@ -741,16 +741,7 @@ func (b *Boxer) unboxV2orV3orV4(ctx context.Context, boxed chat1.MessageBoxed,
 	// intended for our device, and error out if it's missing or invalid. If it
 	// is valid, then we *don't* validate the message signing key. That is,
 	// even though signEncryptOpen will check a signature in the end, we no
-	// longer care what signing key it's using. That means we're compatible
-	// with two different scenarios, to support gradual rollout:
-	// V3) Pairwise MACs are included, but also the signing key is still the
-	//     same as in regular messages. Clients with MAC support can check MACs,
-	//     but clients without MAC support ignore the MACs and keep working. We
-	//     don't have repudiability yet, but we can gradually roll out support.
-	// V4) Pairwise MACs are included, and the signing key is an all-zeros
-	//     dummy. Clients with MAC support won't notice this change. At this
-	//     point clients without MAC support will break (so we should pair this
-	//     with a version bump), and we will finally have repudiability.
+	// longer care what signing key it's using.
 	if len(boxed.ClientHeader.PairwiseMacs) > 0 {
 		if boxed.Version != chat1.MessageBoxedVersion_V3 && !bytes.Equal(boxed.VerifyKey, dummySigningKey().GetKID().ToBytes()) {
 			return nil, NewPermanentUnboxingError(fmt.Errorf("expected dummy signing key (%s), got %s", dummySigningKey().GetKID(), hex.EncodeToString(boxed.VerifyKey)))
@@ -1344,8 +1335,7 @@ func (b *Boxer) BoxMessage(ctx context.Context, msg chat1.MessagePlaintext,
 			ctx, tlfName, msg.ClientHeader.Conv.Tlfid, membersType, msg.ClientHeader.TlfPublic)
 		if err != nil {
 			return nil, err
-		}
-		if shouldPairwiseMAC {
+		} else if shouldPairwiseMAC {
 			if len(recipients) == 0 {
 				return nil, fmt.Errorf("unexpected empty pairwise recipients list")
 			}

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -29,9 +29,8 @@ import (
 
 func cryptKey(t *testing.T) *keybase1.CryptKey {
 	kp, err := libkb.GenerateNaclDHKeyPair()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	return &keybase1.CryptKey{
 		KeyGeneration: 1,
 		Key:           keybase1.Bytes32(*kp.Private),
@@ -210,15 +209,13 @@ func TestChatMessageUnbox(t *testing.T) {
 }
 
 func TestChatMessageUnboxWithPairwiseMacs(t *testing.T) {
-	key := cryptKey(t)
-	text := "hi"
 	tc, boxer := setupChatTest(t, "unbox")
 	defer tc.Cleanup()
 
 	u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
+	text := "hi"
 	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), chat1.MessageBoxedVersion_V3)
 	outboxID := chat1.OutboxID{0xdc, 0x74, 0x6, 0x5d, 0xf9, 0x5f, 0x1c, 0x48}
 	msg.ClientHeader.OutboxID = &outboxID
@@ -234,13 +231,11 @@ func TestChatMessageUnboxWithPairwiseMacs(t *testing.T) {
 	require.NoError(t, err)
 	pairwiseMACRecipients := []keybase1.KID{encryptionKeypair.GetKID()}
 
+	key := cryptKey(t)
 	boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, chat1.MessageBoxedVersion_V3, pairwiseMACRecipients)
 	require.NoError(t, err)
 	boxed = remarshalBoxed(t, *boxed)
-
-	if boxed.ClientHeader.OutboxID == msg.ClientHeader.OutboxID {
-		t.Fatalf("defective test: %+v   ==   %+v", boxed.ClientHeader.OutboxID, msg.ClientHeader.OutboxID)
-	}
+	require.NotEqual(t, outboxID, boxed.ClientHeader.OutboxID)
 
 	// need to give it a server header...
 	boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -248,28 +243,27 @@ func TestChatMessageUnboxWithPairwiseMacs(t *testing.T) {
 	}
 
 	unboxed, err := boxer.unbox(context.TODO(), *boxed, chat1.ConversationMembersType_TEAM, key, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	body := unboxed.MessageBody
 	typ, err := body.MessageType()
 	require.NoError(t, err)
+
 	require.Equal(t, typ, chat1.MessageType_TEXT)
 	require.Equal(t, body.Text().Body, text)
+
 	require.Nil(t, unboxed.SenderDeviceRevokedAt, "message should not be from revoked device")
 	require.NotNil(t, unboxed.BodyHash)
 }
 
 func TestChatMessageUnboxWithPairwiseMacsCorrupted(t *testing.T) {
-	key := cryptKey(t)
-	text := "hi"
 	tc, boxer := setupChatTest(t, "unbox")
 	defer tc.Cleanup()
 
 	u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
+	text := "hi"
 	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), chat1.MessageBoxedVersion_V3)
 	outboxID := chat1.OutboxID{0xdc, 0x74, 0x6, 0x5d, 0xf9, 0x5f, 0x1c, 0x48}
 	msg.ClientHeader.OutboxID = &outboxID
@@ -277,21 +271,20 @@ func TestChatMessageUnboxWithPairwiseMacsCorrupted(t *testing.T) {
 	deviceID := make([]byte, libkb.DeviceIDLen)
 	err = tc.G.ActiveDevice.DeviceID().ToBytes(deviceID)
 	require.NoError(t, err)
-	msg.ClientHeader.SenderDevice = gregor1.DeviceID(deviceID)
 
+	msg.ClientHeader.SenderDevice = gregor1.DeviceID(deviceID)
 	signKP := getSigningKeyPairForTest(t, tc, u)
 
 	encryptionKeypair, err := tc.G.ActiveDevice.NaclEncryptionKey()
 	require.NoError(t, err)
 	pairwiseMACRecipients := []keybase1.KID{encryptionKeypair.GetKID()}
 
+	key := cryptKey(t)
 	boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, chat1.MessageBoxedVersion_V3, pairwiseMACRecipients)
 	require.NoError(t, err)
-	boxed = remarshalBoxed(t, *boxed)
 
-	if boxed.ClientHeader.OutboxID == msg.ClientHeader.OutboxID {
-		t.Fatalf("defective test: %+v   ==   %+v", boxed.ClientHeader.OutboxID, msg.ClientHeader.OutboxID)
-	}
+	boxed = remarshalBoxed(t, *boxed)
+	require.NotEqual(t, outboxID, boxed.ClientHeader.OutboxID)
 
 	// need to give it a server header...
 	boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -304,54 +297,44 @@ func TestChatMessageUnboxWithPairwiseMacsCorrupted(t *testing.T) {
 	}
 
 	_, err = boxer.unbox(context.TODO(), *boxed, chat1.ConversationMembersType_TEAM, key, nil)
-	if err == nil {
-		t.Fatal("expected unboxing to fail")
-	}
+	require.Error(t, err)
 
 	// Check that we get the right failure type.
 	permErr, ok := err.(PermanentUnboxingError)
-	if !ok {
-		t.Fatalf("expected PermanentUnboxingError, got %T", err)
-	}
+	require.True(t, ok)
 	_, ok = permErr.Inner().(InvalidMACError)
-	if !ok {
-		t.Fatalf("expected InvalidMACError, got %T", permErr.Inner())
-	}
+	require.True(t, ok)
 }
 
 func TestChatMessageUnboxWithPairwiseMacsMissing(t *testing.T) {
-	key := cryptKey(t)
-	text := "hi"
 	tc, boxer := setupChatTest(t, "unbox")
 	defer tc.Cleanup()
 
 	u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
+	text := "hi"
 	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), chat1.MessageBoxedVersion_V3)
 	outboxID := chat1.OutboxID{0xdc, 0x74, 0x6, 0x5d, 0xf9, 0x5f, 0x1c, 0x48}
 	msg.ClientHeader.OutboxID = &outboxID
+
 	// Pairwise MACs rely on the sender's DeviceID in the header.
 	deviceID := make([]byte, libkb.DeviceIDLen)
 	err = tc.G.ActiveDevice.DeviceID().ToBytes(deviceID)
 	require.NoError(t, err)
 	msg.ClientHeader.SenderDevice = gregor1.DeviceID(deviceID)
 
-	signKP := getSigningKeyPairForTest(t, tc, u)
-
 	// Put a bogus key in the recipients list, instead of our own.
 	bogusKey, err := libkb.GenerateNaclDHKeyPair()
 	require.NoError(t, err)
 	pairwiseMACRecipients := []keybase1.KID{bogusKey.GetKID()}
 
+	key := cryptKey(t)
+	signKP := getSigningKeyPairForTest(t, tc, u)
 	boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, chat1.MessageBoxedVersion_V3, pairwiseMACRecipients)
 	require.NoError(t, err)
 	boxed = remarshalBoxed(t, *boxed)
-
-	if boxed.ClientHeader.OutboxID == msg.ClientHeader.OutboxID {
-		t.Fatalf("defective test: %+v   ==   %+v", boxed.ClientHeader.OutboxID, msg.ClientHeader.OutboxID)
-	}
+	require.NotEqual(t, outboxID, boxed.ClientHeader.OutboxID)
 
 	// need to give it a server header...
 	boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -359,34 +342,27 @@ func TestChatMessageUnboxWithPairwiseMacsMissing(t *testing.T) {
 	}
 
 	_, err = boxer.unbox(context.TODO(), *boxed, chat1.ConversationMembersType_TEAM, key, nil)
-	if err == nil {
-		t.Fatal("expected unboxing to fail")
-	}
+	require.Error(t, err)
 
 	// Check that we get the right failure type.
 	permErr, ok := err.(PermanentUnboxingError)
-	if !ok {
-		t.Fatalf("expected PermanentUnboxingError, got %T", err)
-	}
+	require.True(t, ok)
 	_, ok = permErr.Inner().(NotAuthenticatedForThisDeviceError)
-	if !ok {
-		t.Fatalf("expected InvalidMACError, got %T", permErr.Inner())
-	}
+	require.True(t, ok)
 }
 
 func TestChatMessageUnboxWithPairwiseMacsV4DummySigner(t *testing.T) {
-	key := cryptKey(t)
-	text := "hi"
 	tc, boxer := setupChatTest(t, "unbox")
 	defer tc.Cleanup()
 
 	u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
+	text := "hi"
 	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), chat1.MessageBoxedVersion_V4)
 	outboxID := chat1.OutboxID{0xdc, 0x74, 0x6, 0x5d, 0xf9, 0x5f, 0x1c, 0x48}
 	msg.ClientHeader.OutboxID = &outboxID
+
 	// Pairwise MACs rely on the sender's DeviceID in the header.
 	deviceID := make([]byte, libkb.DeviceIDLen)
 	err = tc.G.ActiveDevice.DeviceID().ToBytes(deviceID)
@@ -394,19 +370,16 @@ func TestChatMessageUnboxWithPairwiseMacsV4DummySigner(t *testing.T) {
 	msg.ClientHeader.SenderDevice = gregor1.DeviceID(deviceID)
 
 	// V4 messages require this keypair.
-	signKP := dummySigningKey()
-
 	encryptionKeypair, err := tc.G.ActiveDevice.NaclEncryptionKey()
 	require.NoError(t, err)
 	pairwiseMACRecipients := []keybase1.KID{encryptionKeypair.GetKID()}
 
+	key := cryptKey(t)
+	signKP := dummySigningKey()
 	boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, chat1.MessageBoxedVersion_V4, pairwiseMACRecipients)
 	require.NoError(t, err)
 	boxed = remarshalBoxed(t, *boxed)
-
-	if boxed.ClientHeader.OutboxID == msg.ClientHeader.OutboxID {
-		t.Fatalf("defective test: %+v   ==   %+v", boxed.ClientHeader.OutboxID, msg.ClientHeader.OutboxID)
-	}
+	require.NotEqual(t, outboxID, boxed.ClientHeader.OutboxID)
 
 	// need to give it a server header...
 	boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -414,9 +387,8 @@ func TestChatMessageUnboxWithPairwiseMacsV4DummySigner(t *testing.T) {
 	}
 
 	unboxed, err := boxer.unbox(context.TODO(), *boxed, chat1.ConversationMembersType_TEAM, key, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	body := unboxed.MessageBody
 	typ, err := body.MessageType()
 	require.NoError(t, err)

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -299,7 +299,7 @@ const pairseMACDisabled = true
 func shouldPairwiseMAC(ctx context.Context, g *globals.Context, loader *TeamLoader, tlfName string,
 	tlfID chat1.TLFID, membersType chat1.ConversationMembersType, public bool) (should bool, kids []keybase1.KID, err error) {
 
-	if pairseMACDisabled {
+	if pairseMACDisabled || public {
 		return false, nil, nil
 	}
 


### PR DESCRIPTION
cc @maxtaco  @mmaxim just as a sanity check that we don't need any changes to the upcoming release for pairwise mac support. Since reader support for `chat1.MessageBoxedVersion_V4` has had some time in the wild, once upak cache busting is supported we should be able to turn on pairwiseMAC sending and old clients will be able to decrypt these messages.

This pr just cleans up some comments about pairwiseMAC support. 
