### PR TITLE
Only display plaintext when app is out of foreground

### DIFF
--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -119,7 +119,8 @@ function* pushNotificationSaga(notification: PushGen.NotificationPayload): Saga.
           pushIDs: typeof payload.p === 'string' ? JSON.parse(payload.p) : payload.p,
           shouldAck: displayPlaintext,
         })
-        if (unboxRes && displayPlaintext) {
+        const state: TypedState = yield Saga.select()
+        if (unboxRes && displayPlaintext && !state.config.appFocused) {
           yield Saga.call(displayNewMessageNotification, unboxRes, payload.c, payload.b, payload.d, payload.s)
         }
       } catch (err) {


### PR DESCRIPTION
Some versions of android have been displaying the plaintext notifications while the app is in the foreground, this should prevent this from happening.