### PR TITLE
Fix throwing of errors in engine saga helper

### DIFF
--- a/shared/engine/saga.js
+++ b/shared/engine/saga.js
@@ -99,11 +99,12 @@ function* call(p: {
       params,
     })
 
+    // Must return an unsubscribe function, we just ignore this
     return () => {}
   }, buffer) // allow the buffer to grow always
 
   let finalParams: any
-  let finalError: ?RPCError
+  let finalError: ?RPCError | ?Error
   try {
     while (true) {
       // Take things that we put into the eventChannel above
@@ -140,6 +141,9 @@ function* call(p: {
         finalError = res.error
       }
     }
+  } catch (e) {
+    // capture errors when we handle the callbacks and treat the whole process as an error
+    finalError = e
   } finally {
     // eventChannel will jump to finally when RS.END is emitted
     if (waitingKey) {


### PR DESCRIPTION
Before, if an incoming rpc handler threw an error it wasn't being captured as the final error of the flow. Before the only error the entire rpc would throw would be from the rpc itself but now it can be internal errors also.
This means that before an error would be thrown, but not stored as the finalError, the rpc would end and we'd end up with a null result and null error, which goes through the 'success' flow. This led to the result.offline where result is undefined.
So the good news is thats fixed. The bad news is whatever lead to that actually happening will now black bar, but we can debug it further from there

@keybase/react-hackers 
cc: @cjb @mmaxim 