### PR TITLE
Catch all exceptions on background job

### DIFF
--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/BackgroundSyncJob.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/BackgroundSyncJob.java
@@ -23,10 +23,14 @@ public class BackgroundSyncJob extends Job {
     }
 
     public static void scheduleJob() {
+        try {
         new JobRequest.Builder(TAG)
                 .setRequiredNetworkType(JobRequest.NetworkType.ANY)
                 .setPeriodic(TimeUnit.HOURS.toMillis(1))
                 .build()
                 .schedule();
+        } catch (Exception e) {
+            Log.d(TAG, "Background sync failed: " + e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Wrap background job in a try/catch. imo we should only do this since the root cause of crashers is undetermined, and we should dig in further after release