### PR TITLE
Notification settings fixes for android API >= 26

### DIFF
--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -81,7 +81,6 @@ function* _toggleNotificationsSaga(): Saga.SagaGenerator<any, any> {
       if (groupName === Constants.securityGroup) {
         // Special case this since it will go to chat settings endpoint
         for (const key in group.settings) {
-          // TODO blacklist default setting if on android >= 26
           const setting = group.settings[key]
           chatGlobalArg[
             `${ChatTypes.commonGlobalAppNotificationSetting[setting.name]}`

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -12,7 +12,7 @@ import {mapValues, trim} from 'lodash-es'
 import {delay} from 'redux-saga'
 import {navigateAppend, navigateUp} from '../actions/route-tree'
 import {type TypedState} from '../constants/reducer'
-import {pprofDir} from '../constants/platform'
+import {isAndroid, mobileOsVersion, pprofDir} from '../constants/platform'
 
 function* _onUpdatePGPSettings(): Saga.SagaGenerator<any, any> {
   try {
@@ -81,6 +81,7 @@ function* _toggleNotificationsSaga(): Saga.SagaGenerator<any, any> {
       if (groupName === Constants.securityGroup) {
         // Special case this since it will go to chat settings endpoint
         for (const key in group.settings) {
+          // TODO blacklist default setting if on android >= 26
           const setting = group.settings[key]
           chatGlobalArg[`${ChatTypes.commonGlobalAppNotificationSetting[setting.name]}`] = setting.subscribed
         }
@@ -302,12 +303,18 @@ function* _refreshNotificationsSaga(): Saga.SagaGenerator<any, any> {
         subscribed:
           chatGlobalSettings.settings[`${ChatTypes.commonGlobalAppNotificationSetting.plaintextmobile}`],
       },
-      {
-        name: 'defaultsoundmobile',
-        description: 'Use mobile system default notification sound',
-        subscribed:
-          chatGlobalSettings.settings[`${ChatTypes.commonGlobalAppNotificationSetting.defaultsoundmobile}`],
-      },
+      ...(isAndroid && parseInt(mobileOsVersion, 10) >= 26
+        ? []
+        : [
+            {
+              name: 'defaultsoundmobile',
+              description: 'Use mobile system default notification sound',
+              subscribed:
+                chatGlobalSettings.settings[
+                  `${ChatTypes.commonGlobalAppNotificationSetting.defaultsoundmobile}`
+                ],
+            },
+          ]),
     ],
     unsub: false,
   }

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -12,7 +12,7 @@ import {mapValues, trim} from 'lodash-es'
 import {delay} from 'redux-saga'
 import {navigateAppend, navigateUp} from '../actions/route-tree'
 import {type TypedState} from '../constants/reducer'
-import {isAndroid, mobileOsVersion, pprofDir} from '../constants/platform'
+import {isAndroidNewerThanN, pprofDir} from '../constants/platform'
 
 function* _onUpdatePGPSettings(): Saga.SagaGenerator<any, any> {
   try {
@@ -83,7 +83,9 @@ function* _toggleNotificationsSaga(): Saga.SagaGenerator<any, any> {
         for (const key in group.settings) {
           // TODO blacklist default setting if on android >= 26
           const setting = group.settings[key]
-          chatGlobalArg[`${ChatTypes.commonGlobalAppNotificationSetting[setting.name]}`] = setting.subscribed
+          chatGlobalArg[
+            `${ChatTypes.commonGlobalAppNotificationSetting[setting.name]}`
+          ] = !!setting.subscribed
         }
       } else {
         for (const key in group.settings) {
@@ -300,19 +302,19 @@ function* _refreshNotificationsSaga(): Saga.SagaGenerator<any, any> {
       {
         name: 'plaintextmobile',
         description: 'Display mobile plaintext notifications',
-        subscribed:
-          chatGlobalSettings.settings[`${ChatTypes.commonGlobalAppNotificationSetting.plaintextmobile}`],
+        subscribed: !!chatGlobalSettings.settings[
+          `${ChatTypes.commonGlobalAppNotificationSetting.plaintextmobile}`
+        ],
       },
-      ...(isAndroid && parseInt(mobileOsVersion, 10) >= 26
+      ...(isAndroidNewerThanN
         ? []
         : [
             {
               name: 'defaultsoundmobile',
               description: 'Use mobile system default notification sound',
-              subscribed:
-                chatGlobalSettings.settings[
-                  `${ChatTypes.commonGlobalAppNotificationSetting.defaultsoundmobile}`
-                ],
+              subscribed: !!chatGlobalSettings.settings[
+                `${ChatTypes.commonGlobalAppNotificationSetting.defaultsoundmobile}`
+              ],
             },
           ]),
     ],

--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -10,6 +10,7 @@ const isSimulator = false
 const isIPhoneX = false
 const isDeviceSecureAndroid: boolean = false
 const isAndroidNewerThanM: boolean = false
+const isAndroidNewerThanN: boolean = false
 
 const isElectron = true
 const isDarwin = process.platform === 'darwin'
@@ -187,6 +188,7 @@ export {
   fileUIName,
   isAndroid,
   isAndroidNewerThanM,
+  isAndroidNewerThanN,
   isDarwin,
   isDeviceSecureAndroid,
   isElectron,

--- a/shared/constants/platform.js.flow
+++ b/shared/constants/platform.js.flow
@@ -14,6 +14,7 @@ export const isSimulator: boolean = false
 export const isIPhoneX: boolean = false
 export const isDeviceSecureAndroid: boolean = false
 export const isAndroidNewerThanM: boolean = false
+export const isAndroidNewerThanN: boolean = false
 declare export var fileUIName: string
 declare export var version: string
 declare export var appVersionName: string

--- a/shared/constants/platform.native.js
+++ b/shared/constants/platform.native.js
@@ -34,6 +34,7 @@ const isWindows = false
 const fileUIName = 'File Explorer'
 const mobileOsVersion = Platform.Version
 const isAndroidNewerThanM = parseInt(mobileOsVersion) > 22
+const isAndroidNewerThanN = isAndroid && parseInt(mobileOsVersion, 10) >= 26
 
 const isIPhoneX =
   Platform.OS === 'ios' && !Platform.isPad && !Platform.isTVOS && Dimensions.get('window').height === 812
@@ -62,6 +63,7 @@ export {
   fileUIName,
   isAndroid,
   isAndroidNewerThanM,
+  isAndroidNewerThanN,
   isDarwin,
   isDeviceSecureAndroid,
   isElectron,

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -11041,7 +11041,7 @@ react-native-mime-types@^2.2.1:
 
 "react-native-push-notification@git://github.com/keybase/react-native-push-notification#keybase-fixes-off-302":
   version "3.0.2"
-  resolved "git://github.com/keybase/react-native-push-notification#dafbaf7503feffcfab88288e38c28a578d2e2cf5"
+  resolved "git://github.com/keybase/react-native-push-notification#add2393eb774af85bdce71e8d5ffb83e89a3f19a"
 
 react-native-tab-view@^0.0.67:
   version "0.0.67"


### PR DESCRIPTION
- Hides `defaultsoundmobile` setting for android API >= 26 (Android O)
- Casts chat global settings to boolean (they can be undefined; flow has trouble checking computed property keys, [example](https://flow.org/try/#0C4TwDgpgBAwg9gWzAV2BAJgaQiAzlAXigG8BtAaxwC4pdgAnASwDsBzAXRoCM44AbCAENmAXwBQYgMZxmdKIMJQAFAhrwkqDNjwBKQgD4SYgJADgULt14DhiwaQDkACwh8+cB+zEigA))

This is half the fix, the other is to move to a new notification channel and attach our custom sound to it. That'll be on our `react-native-push-notification` fork.

r? @keybase/react-hackers 