### PR TITLE
Avatar cache fixes

### DIFF
--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -182,7 +182,9 @@ func (c *FullCachingSource) commitAvatarToDisk(ctx context.Context, data io.Read
 		// started saving them to `avatars/` subdir. If user has just
 		// updated to client with new path, it's fine to have them
 		// start clean.
-		c.unlinkAllAvatars(ctx, c.G().GetCacheDir())
+		if len(c.tempDir) == 0 {
+			c.unlinkAllAvatars(ctx, c.G().GetCacheDir())
+		}
 
 		err := os.MkdirAll(c.getCacheDir(), os.ModePerm)
 		c.debug(ctx, "creating directory for avatars %q: %v", c.getCacheDir(), err)

--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -235,6 +235,7 @@ func (c *FullCachingSource) populateCacheWorker() {
 		found, ent, err := c.diskLRU.Get(ctx, c.G(), key)
 		if err != nil {
 			c.debug(ctx, "populateCacheWorker: failed to read previous entry in LRU: %s", err)
+			libkb.DiscardAndCloseBody(resp)
 			continue
 		}
 		if found {
@@ -243,6 +244,7 @@ func (c *FullCachingSource) populateCacheWorker() {
 
 		// Save to disk
 		path, err := c.commitAvatarToDisk(ctx, resp.Body, previousPath)
+		libkb.DiscardAndCloseBody(resp)
 		if err != nil {
 			c.debug(ctx, "populateCacheWorker: failed to write to disk: %s", err)
 			continue

--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -181,6 +181,9 @@ func (c *FullCachingSource) commitAvatarToDisk(ctx context.Context, data io.Read
 		// We already have the image, let's re-use the same file
 		c.debug(ctx, "commitAvatarToDisk: using previous path: %s", previousPath)
 		if file, err = os.OpenFile(previousPath, os.O_RDWR, os.ModeAppend); err != nil {
+			// NOTE: Even if we don't have this file anymore (e.g. user
+			// might have removed it manually), OpenFile will not error
+			// out, but create a new file on given path.
 			return path, err
 		}
 		path = file.Name()

--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -68,7 +68,7 @@ type FullCachingSource struct {
 
 	populateCacheCh chan populateArg
 
-	dirCreator sync.Once
+	prepareDirs sync.Once
 
 	// testing
 	populateSuccessCh chan struct{}
@@ -177,7 +177,7 @@ func (c *FullCachingSource) getFullFilename(fileName string) string {
 }
 
 func (c *FullCachingSource) commitAvatarToDisk(ctx context.Context, data io.ReadCloser, previousPath string) (path string, err error) {
-	c.dirCreator.Do(func() {
+	c.prepareDirs.Do(func() {
 		// Avatars used to be in main cache directory before we
 		// started saving them to `avatars/` subdir. If user has just
 		// updated to client with new path, it's fine to have them

--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -13,6 +13,7 @@ type Source interface {
 	LoadTeams(context.Context, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)
 
 	ClearCacheForName(context.Context, string, []keybase1.AvatarFormat) error
+	OnCacheCleared(context.Context) // Called after leveldb data goes away after db nuke
 
 	StartBackgroundTasks()
 	StopBackgroundTasks()

--- a/go/avatars/simple.go
+++ b/go/avatars/simple.go
@@ -109,3 +109,5 @@ func (s *SimpleSource) LoadTeams(ctx context.Context, teams []string, formats []
 func (s *SimpleSource) ClearCacheForName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
 	return nil
 }
+
+func (s *SimpleSource) OnCacheCleared(ctx context.Context) {}

--- a/go/avatars/urlcaching.go
+++ b/go/avatars/urlcaching.go
@@ -185,3 +185,5 @@ func (c *URLCachingSource) ClearCacheForName(ctx context.Context, name string, f
 	defer c.G().Trace(fmt.Sprintf("URLCachingSource.ClearCacheForUser(%s,%v)", name, formats), func() error { return err })()
 	return c.clearName(ctx, name, formats)
 }
+
+func (c *URLCachingSource) OnCacheCleared(ctx context.Context) {}

--- a/go/service/ctl.go
+++ b/go/service/ctl.go
@@ -63,6 +63,7 @@ func (c *CtlHandler) DbNuke(ctx context.Context, sessionID int) error {
 	}
 	// Now drop caches, since we had the DB's state in-memory too.
 	c.G().FlushCaches()
+	c.service.onDbNuke(ctx)
 	return nil
 }
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -1194,3 +1194,8 @@ func (d *Service) StartStandaloneChat(g *libkb.GlobalContext) error {
 
 	return nil
 }
+
+// Called by CtlHandler after DbNuke finishes and succeeds.
+func (d *Service) onDbNuke(ctx context.Context) {
+	d.avatarLoader.OnCacheCleared(ctx)
+}


### PR DESCRIPTION
This PR introduces the following changes:
1) Fixes a bug in `populateCacheWorker` where HTTP response was not properly disposed of. On some platforms it might have caused a resource leak.
2) Added a new method to `avatars.Source` interface: `OnCacheCleared`. It's called after DB nuke and gives a chance to avatar source to clean up after cache database has been cleared. `FullCachingSource` removes all avatar files from cache directory. Other sources don't have to do anything.
3) Moved avatar cache storage path to `avatars/` subdirectory (instead of main keybase cache dir). `FullCachingSource` will ensure this dir exists when it's initialized. Old cached avatars will continue to live on old path but new ones will be put in new path. Avatars from old directory will be slowly phased out with cache eviction.