### PR TITLE
Don't set exploding mode locks more than we need to

### DIFF
--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -34,6 +34,7 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
 
   return {
     _editOrdinal: editInfo ? editInfo.ordinal : null,
+    _isExplodingModeLocked: Constants.isExplodingModeLocked(state, conversationIDKey),
     _you,
     conversationIDKey,
     editText: editInfo ? editInfo.text : '',
@@ -110,7 +111,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
   },
   setUnsentText: (text: string) => {
     const unset = text.length <= 0
-    dispatchProps.onSetExplodingModeLock(stateProps.conversationIDKey, unset)
+    if (stateProps._isExplodingModeLocked ? unset : !unset) {
+      // if it's locked and we want to unset, unset it
+      // alternatively, if it's not locked and we want to set it, set it
+      dispatchProps.onSetExplodingModeLock(stateProps.conversationIDKey, unset)
+    }
     setUnsentText(stateProps.conversationIDKey, text)
   },
   typing: stateProps.typing,

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -147,6 +147,8 @@ export const getConversationExplodingMode = (state: TypedState, c: Types.Convers
   }
   return mode
 }
+export const isExplodingModeLocked = (state: TypedState, c: Types.ConversationIDKey) =>
+  state.chat2.getIn(['explodingModeLocks', c], null) !== null
 
 export const makeInboxQuery = (
   convIDKeys: Array<Types.ConversationIDKey>


### PR DESCRIPTION
DESKTOP-7225 was a dupe of the `undefined is not an object (evaluating 'n.offline')` bug, but also showed that the `chat2:setExplodingModeLock` action was flooding logs. Previously it was being called effectively `onKeyDown`, but was a noop unless the `keyDown` was either (1) the first character in the input or (2) clearing the characters in the input. This PR pipes through whether the exploding mode is already locked, so we can dispatch the action only if the lock needs to change. r? @keybase/react-hackers 