### PR TITLE
Time LoadKeyV2

### DIFF
--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -504,7 +504,8 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 // KID, as well as the Key data associated with that KID. It picks the latest such
 // incarnation if there are multiple.
 func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (ret *keybase1.UserPlusKeysV2, key *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
-	defer u.G().CVTrace(ctx, VLog0, fmt.Sprintf("LoadKeyV2 uid:%s,kid:%s", uid, kid), func() error { return err })()
+	ctx = WithLogTag(ctx, "LK") // Load key
+	defer u.G().CVTraceTimed(ctx, VLog0, fmt.Sprintf("LoadKeyV2 uid:%s,kid:%s", uid, kid), func() error { return err })()
 	ctx, tbs := u.G().CTimeBuckets(ctx)
 	defer tbs.Record("CachedUPAKLoader.LoadKeyV2")()
 	if uid.IsNil() {

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -517,13 +517,22 @@ func (g *GlobalContext) CTrace(ctx context.Context, msg string, f func() error) 
 	return CTrace(ctx, g.Log.CloneWithAddedDepth(1), msg, f)
 }
 
+func (g *GlobalContext) CTraceTimed(ctx context.Context, msg string, f func() error) func() {
+	return CTraceTimed(ctx, g.Log.CloneWithAddedDepth(1), msg, f, g.Clock())
+}
+
 func (g *GlobalContext) CVTrace(ctx context.Context, lev VDebugLevel, msg string, f func() error) func() {
 	g.VDL.CLogf(ctx, lev, "+ %s", msg)
 	return func() { g.VDL.CLogf(ctx, lev, "- %s -> %v", msg, ErrToOk(f())) }
 }
 
-func (g *GlobalContext) CTraceTimed(ctx context.Context, msg string, f func() error) func() {
-	return CTraceTimed(ctx, g.Log.CloneWithAddedDepth(1), msg, f, g.Clock())
+func (g *GlobalContext) CVTraceTimed(ctx context.Context, lev VDebugLevel, msg string, f func() error) func() {
+	cl := g.Clock()
+	g.VDL.CLogf(ctx, lev, "+ %s", msg)
+	start := cl.Now()
+	return func() {
+		g.VDL.CLogf(ctx, lev, "- %s -> %v [time=%s]", msg, f(), cl.Since(start))
+	}
 }
 
 func (g *GlobalContext) CTimeTracer(ctx context.Context, label string, enabled bool) profiling.TimeTracer {


### PR DESCRIPTION
Get `time=` on LoadKeyV2. Useful for analyzing team loads.
```
2018-07-09T16:24:41.437587-04:00 ▶ [DEBU keybase util.go:534] 180a {VDL:0} - LoadKeyV2 uid:23260c2ce19420f97b58d7d95b68ca00,kid:012000afe3dbbb6bb55e4386a61c110fe803a0b0d82cf9ad3ae63072e530f7a6c7190a -> <nil> [time=2.98469613s] [tags:LT=q9C8qP2Sf3wy,TM=vGCrE2LOysIb,LK=Sm1XM0nz1g-5]
```