### PR TITLE
Attempt ephemeral keygen when going into background active state

### DIFF
--- a/go/ephemeral/init.go
+++ b/go/ephemeral/init.go
@@ -13,6 +13,11 @@ func NewEphemeralStorageAndInstall(g *libkb.GlobalContext) {
 	g.SetEKLib(ekLib)
 	g.AddLoginHook(ekLib)
 	g.AddLogoutHook(ekLib)
+	g.PushShutdownHook(func() error {
+		g.Log.Debug("stopping background eklib loop")
+		ekLib.Shutdown()
+		return nil
+	})
 }
 
 func ServiceInit(g *libkb.GlobalContext) {

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -80,6 +80,11 @@ func (e *EKLib) backgroundKeygen() {
 			runIfNeeded()
 		case state = <-e.G().AppState.NextUpdate(&state):
 			if state == keybase1.AppState_BACKGROUNDACTIVE {
+				// Before running  we pause briefly so we don't stampede for
+				// resources with other background tasks. libkb.BgTicker
+				// handles this internally, so we only need to throttle on
+				// AppState change.
+				time.Sleep(time.Second)
 				runIfNeeded()
 			}
 		case <-e.stopCh:

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -51,7 +51,7 @@ func (e *EKLib) Shutdown() {
 	e.Lock()
 	defer e.Unlock()
 	if e.stopCh != nil {
-		e.stopCh <- struct{}{}
+		close(e.stopCh)
 	}
 }
 
@@ -83,7 +83,6 @@ func (e *EKLib) backgroundKeygen() {
 				runIfNeeded()
 			}
 		case <-e.stopCh:
-			close(e.stopCh)
 			return
 		}
 	}

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -26,6 +26,7 @@ func TestKeygenIfNeeded(t *testing.T) {
 	defer tc.Cleanup()
 
 	ekLib := NewEKLib(tc.G)
+	defer ekLib.Shutdown()
 	deviceEKStorage := tc.G.GetDeviceEKStorage()
 	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
 
@@ -114,6 +115,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 
 	teamID := createTeam(tc)
 	ekLib := NewEKLib(tc.G)
+	defer ekLib.Shutdown()
 	fc := clockwork.NewFakeClockAt(time.Now())
 	ekLib.setClock(fc)
 	deviceEKStorage := tc.G.GetDeviceEKStorage()
@@ -308,6 +310,7 @@ func TestCleanupStaleUserAndDeviceEKs(t *testing.T) {
 	require.NoError(t, err)
 
 	ekLib := NewEKLib(tc.G)
+	defer ekLib.Shutdown()
 	err = ekLib.CleanupStaleUserAndDeviceEKs(context.Background())
 	require.NoError(t, err)
 
@@ -337,6 +340,7 @@ func TestCleanupStaleUserAndDeviceEKsOffline(t *testing.T) {
 	require.NoError(t, err)
 
 	ekLib := NewEKLib(tc.G)
+	defer ekLib.Shutdown()
 	err = ekLib.keygenIfNeeded(context.Background(), libkb.MerkleRoot{})
 	require.Error(t, err)
 	require.Equal(t, SkipKeygenNilMerkleRoot, err.Error())

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -141,6 +141,7 @@ func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 	ekLib := NewEKLib(tc.G)
+	defer ekLib.Shutdown()
 	needed, err := ekLib.NewUserEKNeeded(context.Background())
 	require.NoError(t, err)
 	if skipUserEKForTesting {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -615,17 +615,9 @@ func (d *Service) hourlyChecks() {
 		if err := m.LogoutAndDeprovisionIfRevoked(); err != nil {
 			m.CDebugf("LogoutAndDeprovisionIfRevoked error: %s", err)
 		}
-		ekLib := m.G().GetEKLib()
-		ekLib.KeygenIfNeeded(m.Ctx())
 		for {
 			<-ticker.C
 			m.CDebugf("+ hourly check loop")
-			ekLib := m.G().GetEKLib()
-			m.CDebugf("| checking if ephemeral keys need to be created or deleted")
-			if err := ekLib.KeygenIfNeeded(m.Ctx()); err != nil {
-				m.CDebugf("KeygenIfNeeded error: %s", err)
-			}
-
 			m.CDebugf("| checking if current device revoked")
 			if err := m.LogoutAndDeprovisionIfRevoked(); err != nil {
 				m.CDebugf("LogoutAndDeprovisionIfRevoked error: %s", err)


### PR DESCRIPTION
Although the mobile apps wake up during a `BackgroundSync`  periodically, the amount of active runtime often does not exceed the time for our routine checks to fire. Instead we monitor the app state to manually fire the check if necessary