### PR TITLE
Do not verify team.leave links

### DIFF
--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -769,3 +769,30 @@ func TestTeamResetBadgesOnAdd(t *testing.T) {
 func TestTeamResetBadgesOnRemove(t *testing.T) {
 	testTeamResetBadgesAndDismiss(t, false)
 }
+
+// Test users leaving the team when their eldest seqno is not 1.
+func TestTeamResetAfterReset(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	alice := tt.addUser("alice")
+	bob := tt.addUser("bob")
+
+	bob.reset()
+	bob.loginAfterReset()
+	_, teamName := alice.createTeam2()
+	tn := teamName.String()
+	alice.addTeamMember(tn, bob.username, keybase1.TeamRole_OWNER)
+	bob.leave(tn)
+	bob.reset()
+	bob.loginAfterReset()
+	alice.addTeamMember(tn, bob.username, keybase1.TeamRole_WRITER)
+	bob.leave(tn)
+	bob.reset()
+	bob.loginAfterReset()
+	alice.addTeamMember(tn, bob.username, keybase1.TeamRole_OWNER)
+	bob.changeTeamMember(tn, alice.username, keybase1.TeamRole_READER)
+	alice.loadTeam(tn, false)
+	bob.leave(tn)
+	alice.loadTeam(tn, false)
+}

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -142,11 +142,12 @@ func (s *SCTeamMember) MarshalJSON() (b []byte, err error) {
 // -------------------------
 
 type SCChainLink struct {
-	Seqno   keybase1.Seqno `json:"seqno"`
-	Sig     string         `json:"sig"`
-	Payload string         `json:"payload_json"` // String containing json of a SCChainLinkPayload
-	UID     keybase1.UID   `json:"uid"`          // UID of the signer
-	Version int            `json:"version"`
+	Seqno       keybase1.Seqno `json:"seqno"`
+	Sig         string         `json:"sig"`
+	Payload     string         `json:"payload_json"` // String containing json of a SCChainLinkPayload
+	UID         keybase1.UID   `json:"uid"`          // UID of the signer
+	EldestSeqno keybase1.Seqno `json:"eldest_seqno"` // Eldest seqn of the signer
+	Version     int            `json:"version"`
 }
 
 func (link *SCChainLink) UnmarshalPayload() (res SCChainLinkPayload, err error) {


### PR DESCRIPTION
Don't verify team.leave links. Needs https://github.com/keybase/keybase/pull/2661. The thing that's not being verified is whether the signing KID has anything to do with the signing UV. So effectively the server could make leave anyone leave by signing a link with any KID.

If we plan to do this
- [ ] decide whether it's safe
- [ ] write more comments explaining `fullVerify`
- [ ] not sure whether omitting the link map part could stall order checking
- [ ] put an extra note in `chain.go` that it should never support key rotation on leave links