### PR TITLE
disable background job scheduling

### DIFF
--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -38,11 +38,8 @@ public class MainApplication extends Application implements ReactApplication {
 
     // Make sure exactly one background job is scheduled.
     int numBackgroundJobs = manager.getAllJobRequestsForTag(BackgroundSyncJob.TAG).size();
-    if (numBackgroundJobs == 0) {
-        BackgroundSyncJob.scheduleJob();
-    } else if (numBackgroundJobs >1 ) {
+    if (numBackgroundJobs > 1 ) {
         manager.cancelAllForTag(BackgroundSyncJob.TAG);
-        BackgroundSyncJob.scheduleJob();
     }
 
     logFile = this.getFileStreamPath("android.log");


### PR DESCRIPTION
Removes all calls to `scheduleJob` until we can fix background sync crashes