### PR TITLE
dont panic on perm denied error, just exit the app instead

### DIFF
--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -779,7 +779,7 @@ func MobilePermissionDeniedCheck(g *GlobalContext, err error, msg string) {
 		return
 	}
 	g.Log.Warning("file open permission denied on mobile (%s): %s", msg, err)
-	panic(fmt.Sprintf("panic due to file open permission denied on mobile (%s)", msg))
+	os.Exit(4)
 }
 
 // IsNoSpaceOnDeviceError will return true if err is an `os` error


### PR DESCRIPTION
cc @cjb @chrisnojima 

I think maybe this is the root cause of the new crash behavior on mobile. I think what is happening is that this change, https://github.com/golang/go/commit/5500c9ce27128ab26aa23bafddce7dd512ce72ea makes it so that signal handlers from native run when Go panics. On Android I think the effect is that the "app stopped working" dialog shows up, and on iOS the crash numbers on iTunes Connect look higher. Since this situation isn't totally unexpected, I think just exiting seems ok.

Also, a reminder for why we do this at all; if we don't die here, then if we let the app continue the user can possibly foreground the app and see themselves looking logged out and deprovisioned (since config.json failed to load). 