### PR TITLE
enable pairwise macs, retry msg send if missing deviceKIDS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
             - "3000:3000"
             - "13009"
             - "13010"
+            - "13037"
         links:
             - mysql.local
             - gregor.local
@@ -44,6 +45,7 @@ services:
             - CHAT_MYSQL_DSN=root:secret@tcp(mysql.local:3306)/keybase
             - GREGOR_TLF_SERVER=fmprpc+tls://kbweb.local:13010
             - GREGOR_TEAM_SERVER=fmprpc+tls://kbweb.local:7890
+            - GREGOR_MACCHECKER_SERVER=fmprpc://kbweb.local:13037
             - INSECURE_TLS_MODE=1
             - GREGOR_TLFAUTH_PRIVATE_SIGNING_KEY=e20589b8cd66d447aaee44b587305bd521f34f3085709b32b4e3bd479b20253e59ea153c88a8ea524d39e0ae58fa195749214b38a28fdb4229ba3390b2d33e86
             - GREGOR_TLFAUTH_PUBLIC_SIGNING_KEY=012059ea153c88a8ea524d39e0ae58fa195749214b38a28fdb4229ba3390b2d33e860a

--- a/go/chat/sbs_test.go
+++ b/go/chat/sbs_test.go
@@ -190,13 +190,11 @@ func TestChatSrvSBS(t *testing.T) {
 					// turn depends on the size of the team, in a way that we
 					// might tune in the future. Allow that specific failure.
 
-					// TODO re-enable this check for tests to pass once
-					// pairwise macs are turned on
-					//if ephemeralLifetime != nil && msg.IsError() {
-					//	require.Equal(t, chat1.MessageUnboxedErrorType_PAIRWISE_MISSING, msg.Error().ErrType)
-					//} else {
-					require.True(t, msg.IsValid())
-					//}
+					if ephemeralLifetime != nil && msg.IsError() {
+						require.Equal(t, chat1.MessageUnboxedErrorType_PAIRWISE_MISSING, msg.Error().ErrType)
+					} else {
+						require.True(t, msg.IsValid())
+					}
 				}
 			}
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1994,6 +1994,9 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			listener := newServerChatListener()
 			ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
 			ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
+			if ephemeralLifetime != nil {
+				tc.m.G().GetUPAKLoader().ClearMemory()
+			}
 
 			assertEphemeral := func(ephemeralLifetime *gregor1.DurationSec, unboxed chat1.UIMessage) {
 				valid := unboxed.Valid()

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -294,12 +294,10 @@ func batchLoadEncryptionKIDs(ctx context.Context, g *libkb.GlobalContext, uvs []
 	return ret, err
 }
 
-const pairseMACDisabled = true
-
 func shouldPairwiseMAC(ctx context.Context, g *globals.Context, loader *TeamLoader, tlfName string,
 	tlfID chat1.TLFID, membersType chat1.ConversationMembersType, public bool) (should bool, kids []keybase1.KID, err error) {
 
-	if pairseMACDisabled || public {
+	if public {
 		return false, nil, nil
 	}
 

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1349,3 +1349,14 @@ func AddUserToTLFName(g *globals.Context, tlfName string, vis keybase1.TLFVisibi
 	}
 	return tlfName
 }
+
+func ForceReloadUPAKsForUIDs(ctx context.Context, g *globals.Context, uids []keybase1.UID) error {
+	getArg := func(i int) *libkb.LoadUserArg {
+		if i >= len(uids) {
+			return nil
+		}
+		tmp := libkb.NewLoadUserByUIDForceArg(g.GlobalContext, uids[i])
+		return &tmp
+	}
+	return g.GetUPAKLoader().Batcher(ctx, getArg, nil, 0)
+}

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -886,9 +886,11 @@ func (u *CachedUPAKLoader) Batcher(ctx context.Context, getArg func(int) *LoadUs
 			for awi := range args {
 				arg := awi.arg
 				_, _, err := u.loadWithInfo(arg, nil, func(u *keybase1.UserPlusKeysV2AllIncarnations) error {
-					mut.Lock()
-					processResult(awi.i, u)
-					mut.Unlock()
+					if processResult != nil {
+						mut.Lock()
+						processResult(awi.i, u)
+						mut.Unlock()
+					}
 					return nil
 				}, false)
 				if err != nil {


### PR DESCRIPTION
Enables pairwise MACs for ephemeral messages for small teams. Consumes the `libkb.EphemeralPairwiseMACsMissingUIDsError` and retries the message send after refreshing it's upak cache.

depends on https://github.com/keybase/keybase/pull/2660