### PR TITLE
Show only one divider on attachments that aren't yours.

### DIFF
--- a/shared/chat/conversation/messages/message-popup/attachment/index.js
+++ b/shared/chat/conversation/messages/message-popup/attachment/index.js
@@ -29,9 +29,9 @@ type Props = {
 
 const AttachmentPopupMenu = (props: Props) => {
   const items = [
-    'Divider',
     ...(props.yourMessage
       ? [
+          'Divider',
           {
             danger: true,
             disabled: !props.onDelete,


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. It fixes this (someone else's attachment):

<img width="213" alt="screen shot 2018-07-12 at 09 24 30" src="https://user-images.githubusercontent.com/30595/42636110-e9d5ed8c-85b5-11e8-92be-d70f5a88f79c.png">