### PR TITLE
To get current UV use UPAKLoader instead of FullSelfer

### DIFF
--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -1,7 +1,6 @@
 package ephemeral
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -106,14 +105,6 @@ func newEKSeedFromBytes(b []byte) (seed keybase1.Bytes32, err error) {
 	}
 	copy(seed[:], b)
 	return seed, nil
-}
-
-func getCurrentUserUV(ctx context.Context, g *libkb.GlobalContext) (ret keybase1.UserVersion, err error) {
-	err = g.GetFullSelfer().WithSelf(ctx, func(u *libkb.User) error {
-		ret = u.ToUserVersion()
-		return nil
-	})
-	return ret, err
 }
 
 // Map generations to their creation time

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -41,7 +41,7 @@ func (s *DeviceEKStorage) keyPrefixFromUsername(username libkb.NormalizedUsernam
 }
 
 func (s *DeviceEKStorage) keyPrefix(ctx context.Context) (prefix string, err error) {
-	uv, err := getCurrentUserUV(ctx, s.G())
+	uv, err := s.G().GetMeUV(ctx)
 	if err != nil {
 		return prefix, err
 	}
@@ -432,7 +432,7 @@ func (s *DeviceEKStorage) deletedWrongEldestSeqno(ctx context.Context) (err erro
 	if err != nil {
 		return err
 	}
-	uv, err := getCurrentUserUV(ctx, s.G())
+	uv, err := s.G().GetMeUV(ctx)
 	if err != nil {
 		return err
 	}

--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -114,7 +114,7 @@ func TestDeviceEKStorage(t *testing.T) {
 
 	// Test delete expired and check that we handle incorrect eldest seqno
 	// deletion correctly.
-	uv, err := getCurrentUserUV(context.Background(), tc.G)
+	uv, err := tc.G.GetMeUV(context.Background())
 	require.NoError(t, err)
 	erasableStorage := erasablekv.NewFileErasableKVStore(tc.G, deviceEKSubDir)
 
@@ -158,7 +158,7 @@ func TestDeviceEKStorageKeyFormat(t *testing.T) {
 
 	s := NewDeviceEKStorage(tc.G)
 	generation := keybase1.EkGeneration(1)
-	uv, err := getCurrentUserUV(context.Background(), tc.G)
+	uv, err := tc.G.GetMeUV(context.Background())
 	require.NoError(t, err)
 
 	key, err := s.key(context.Background(), generation)

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -34,7 +34,7 @@ func NewTeamEKBoxStorage(g *libkb.GlobalContext) *TeamEKBoxStorage {
 }
 
 func (s *TeamEKBoxStorage) dbKey(ctx context.Context, teamID keybase1.TeamID) (dbKey libkb.DbKey, err error) {
-	uv, err := getCurrentUserUV(ctx, s.G())
+	uv, err := s.G().GetMeUV(ctx)
 	if err != nil {
 		return dbKey, err
 	}

--- a/go/ephemeral/team_ek_box_storage_test.go
+++ b/go/ephemeral/team_ek_box_storage_test.go
@@ -139,7 +139,7 @@ func TestTeamEKStorageKeyFormat(t *testing.T) {
 	defer tc.Cleanup()
 
 	s := NewTeamEKBoxStorage(tc.G)
-	uv, err := getCurrentUserUV(context.Background(), tc.G)
+	uv, err := tc.G.GetMeUV(context.Background())
 	require.NoError(t, err)
 
 	teamID := createTeam(tc)

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -31,7 +31,7 @@ func NewUserEKBoxStorage(g *libkb.GlobalContext) *UserEKBoxStorage {
 }
 
 func (s *UserEKBoxStorage) dbKey(ctx context.Context) (dbKey libkb.DbKey, err error) {
-	uv, err := getCurrentUserUV(ctx, s.G())
+	uv, err := s.G().GetMeUV(ctx)
 	if err != nil {
 		return dbKey, err
 	}

--- a/go/ephemeral/user_ek_box_storage_test.go
+++ b/go/ephemeral/user_ek_box_storage_test.go
@@ -105,7 +105,7 @@ func TestUserEKStorageKeyFormat(t *testing.T) {
 	defer tc.Cleanup()
 
 	s := NewUserEKBoxStorage(tc.G)
-	uv, err := getCurrentUserUV(context.Background(), tc.G)
+	uv, err := tc.G.GetMeUV(context.Background())
 	require.NoError(t, err)
 
 	key, err := s.dbKey(context.Background())

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -119,7 +119,7 @@ func (l *LoaderContextG) getMe(ctx context.Context) (res keybase1.UserVersion, e
 	if uid.IsNil() {
 		return res, nil
 	}
-	return getCurrentUserUV(ctx, l.G())
+	return l.G().GetMeUV(ctx)
 }
 
 func (l *LoaderContextG) lookupEldestSeqno(ctx context.Context, uid keybase1.UID) (keybase1.Seqno, error) {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -664,7 +664,7 @@ func ParseAndAcceptSeitanToken(ctx context.Context, g *libkb.GlobalContext, tok 
 }
 
 func AcceptSeitan(ctx context.Context, g *libkb.GlobalContext, ikey SeitanIKey) error {
-	uv, err := getCurrentUserUV(ctx, g)
+	uv, err := g.GetMeUV(ctx)
 	if err != nil {
 		return err
 	}
@@ -717,7 +717,7 @@ func ProcessSeitanV2(ikey SeitanIKeyV2, uv keybase1.UserVersion, kbtime keybase1
 }
 
 func AcceptSeitanV2(ctx context.Context, g *libkb.GlobalContext, ikey SeitanIKeyV2) error {
-	uv, err := getCurrentUserUV(ctx, g)
+	uv, err := g.GetMeUV(ctx)
 	if err != nil {
 		return err
 	}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1191,16 +1191,8 @@ func (t *Team) postChangeItem(ctx context.Context, section SCTeamSection, linkTy
 	return t.postMulti(libkb.NewMetaContext(ctx, t.G()), payload)
 }
 
-func getCurrentUserUV(ctx context.Context, g *libkb.GlobalContext) (ret keybase1.UserVersion, err error) {
-	err = g.GetFullSelfer().WithSelf(ctx, func(u *libkb.User) error {
-		ret = u.ToUserVersion()
-		return nil
-	})
-	return ret, err
-}
-
 func (t *Team) currentUserUV(ctx context.Context) (keybase1.UserVersion, error) {
-	return getCurrentUserUV(ctx, t.G())
+	return t.G().GetMeUV(ctx)
 }
 
 func loadMeForSignatures(ctx context.Context, g *libkb.GlobalContext) (libkb.UserForSignatures, error) {


### PR DESCRIPTION
While analyzing `TeamAddMember`'s slowness it seems that it sometimes spends time LoadUsering the logged-in user. Hopefully `UPAKLoader` is faster, just a guess. This patch switches uses of `GetFullSelfer` to `UPAKLoader` (via `G.GetMeUV()`) in the `teams` and `ephemeral` packages.

Later on we could make `G.GetMeUV()` faster by storing UV on ActiveDevice.