### PR TITLE
When canceling out of a pending convo, find a new one to replace it with

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1376,7 +1376,8 @@ const _maybeAutoselectNewestConversation = (
     action.payload.conversationIDKey === selected
   ) {
     // Intentional fall-through -- force select a new one
-  } else if (selected !== Constants.noConversationIDKey) {
+  } else if (selected !== Constants.noConversationIDKey && selected !== Constants.pendingConversationIDKey) {
+    // Stay with our existing convo if it was not empty or pending
     return
   }
 

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1376,7 +1376,7 @@ const _maybeAutoselectNewestConversation = (
     action.payload.conversationIDKey === selected
   ) {
     // Intentional fall-through -- force select a new one
-  } else if (selected !== Constants.noConversationIDKey && selected !== Constants.pendingConversationIDKey) {
+  } else if (Constants.isValidConversationIDKey(selected)) {
     // Stay with our existing convo if it was not empty or pending
     return
   }


### PR DESCRIPTION
@keybase/react-hackers 

Fixes:

1) go to new conversation, choose someone you have no existing convo with

2) click the X next to the pending convo in the chat inbox

3) now you see "You haven't chatted with (blank) before" instead of a replacement convo.