### PR TITLE
Support EXIF Orientation for Attachment Previews

### DIFF
--- a/shared/chat/conversation/attachment-get-titles/index.js
+++ b/shared/chat/conversation/attachment-get-titles/index.js
@@ -110,8 +110,7 @@ class GetTitles extends React.Component<Props, State> {
             <Box style={{...globalStyles.flexBoxCenter, height: 150, width: 150}}>
               {info.type === 'image' ? (
                 <OrientedImage
-                  preview={true}
-                  onLoad={() => {}}
+                  localFile={true}
                   src={path}
                   style={isMobile ? {height: 150, width: 150} : {maxHeight: '100%', maxWidth: '100%'}}
                 />

--- a/shared/chat/conversation/attachment-get-titles/index.js
+++ b/shared/chat/conversation/attachment-get-titles/index.js
@@ -4,7 +4,6 @@ import {
   Box,
   Button,
   Icon,
-  // Image,
   OrientedImage,
   Input,
   PopupDialog,

--- a/shared/chat/conversation/attachment-get-titles/index.js
+++ b/shared/chat/conversation/attachment-get-titles/index.js
@@ -4,7 +4,8 @@ import {
   Box,
   Button,
   Icon,
-  Image,
+  // Image,
+  OrientedImage,
   Input,
   PopupDialog,
   Text,
@@ -109,7 +110,9 @@ class GetTitles extends React.Component<Props, State> {
           <Box style={isMobile ? stylesMobile : stylesDesktop}>
             <Box style={{...globalStyles.flexBoxCenter, height: 150, width: 150}}>
               {info.type === 'image' ? (
-                <Image
+                <OrientedImage
+                  preview={true}
+                  onLoad={() => {}}
                   src={path}
                   style={isMobile ? {height: 150, width: 150} : {maxHeight: '100%', maxWidth: '100%'}}
                 />

--- a/shared/common-adapters/oriented-image.types.js.flow
+++ b/shared/common-adapters/oriented-image.types.js.flow
@@ -5,4 +5,5 @@ export type Props = {
   src: string,
   style?: StylesDesktop,
   onLoad: () => void,
+  preview?: boolean,
 }

--- a/shared/common-adapters/oriented-image.types.js.flow
+++ b/shared/common-adapters/oriented-image.types.js.flow
@@ -5,5 +5,4 @@ export type Props = {
   src: string,
   style?: StylesDesktop,
   onLoad?: () => void,
-  localFile?: boolean,
 }

--- a/shared/common-adapters/oriented-image.types.js.flow
+++ b/shared/common-adapters/oriented-image.types.js.flow
@@ -4,6 +4,6 @@ import {type StylesDesktop} from '../styles'
 export type Props = {
   src: string,
   style?: StylesDesktop,
-  onLoad: () => void,
-  preview?: boolean,
+  onLoad?: () => void,
+  localFile?: boolean,
 }


### PR DESCRIPTION
### Problem

In #12482, support for reading and rotating images according to EXIF Orientation metadata was added. However, during the upload preview stage, the preview image was being loaded from the user's local filesystem, preventing us from reading the image data via JavaScript.

This also became an issue for Avatar uploads via the desktop client #12306 whereby previews of avatars (during zoom/cropping stage) would not be oriented correctly.

### Solution

When `OrientedImage` has `preview={true}` Use `fs#readFile` to load the image file into an`ArrayBuffer` then pass the buffer to `EXIF#readFromBinaryFile` which can operate on the bytes directly which is highly performant.

### Notes

1. Performing `fs.readFile` followed by `EXIF#readFromBinaryFile` is very fast. For a 20mb image it took 8.3ms.
2. If the image is not `jpeg` then EXIF will return false and `NO_TRANSFORM` will be applied.