### PR TITLE
Use engine controlled waitingkey in getTeamRetentionPolicy

### DIFF
--- a/shared/logger/action-transformer.js
+++ b/shared/logger/action-transformer.js
@@ -8,6 +8,7 @@ import * as Chat2Gen from '../actions/chat2-gen'
 import * as ConfigGen from '../actions/config-gen'
 import * as GregorGen from '../actions/gregor-gen'
 import * as EngineGen from '../actions/engine-gen'
+import * as WaitingGen from '../actions/waiting-gen'
 import {getPath} from '../route-tree'
 import type {TypedState} from '../constants/reducer'
 import * as Entity from '../constants/types/entities'
@@ -96,6 +97,9 @@ const actionTransformMap = {
     payload: {conversationIDKey: a.payload.conversationIDKey},
     type: a.type,
   }),
+
+  [WaitingGen.incrementWaiting]: fullOutput,
+  [WaitingGen.decrementWaiting]: fullOutput,
 }
 
 const transformActionForLog = (action: any, state: TypedState) =>

--- a/shared/teams/add-people/container.js
+++ b/shared/teams/add-people/container.js
@@ -46,8 +46,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
         teamname,
       })
     )
-    dispatch(SearchGen.createClearSearchResults({searchKey: 'addToTeamSearch'}))
-    dispatch(SearchGen.createSetUserInputItems({searchKey: 'addToTeamSearch', searchResults: []}))
   },
   onClose: () => {
     dispatch(navigateUp())


### PR DESCRIPTION
We weren't decrementing the waiting key before bailing out of `getTeamRetentionPolicy` which caused the team to be stuck in a waiting state for the rest of the session. Instead, let's switch to use the engine helper to set and unset the team waiting key so the team can recover. Also adds a bunch of logging to `addPeopleToTeam` and changes the search result dismissal to leave failed users / assertions in the input on failure. r? @keybase/react-hackers 