### PR TITLE
Android can't render strings in non <Text> exploding message fix

### DIFF
--- a/shared/chat/inbox/row/small-team/bottom-line.js
+++ b/shared/chat/inbox/row/small-team/bottom-line.js
@@ -117,7 +117,7 @@ class BottomLine extends PureComponent<Props> {
               {this.props.snippet}
             </Markdown>
           )}
-          {snippetDecoration && (
+          {!!snippetDecoration && (
             <Box2 direction="vertical" centerChildren={true}>
               {snippetDecoration}
             </Box2>


### PR DESCRIPTION
Last time I forget a `!!`.