### PR TITLE
dump power save block

### DIFF
--- a/shared/desktop/app/index.desktop.js
+++ b/shared/desktop/app/index.desktop.js
@@ -72,9 +72,6 @@ function start() {
     }
   }
 
-  // Force the app to not get suspended
-  SafeElectron.getPowerSaveBlocker().start('prevent-app-suspension')
-
   // Windows needs this for notifications to show on certain versions
   // https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
   SafeElectron.getApp().setAppUserModelId('Keybase.Keybase.GUI')


### PR DESCRIPTION
Seems like this drops an idle lock on macOS, which doesn't seem great. I guess we will need a different solution to the problem I see where Electron goes idle. 

cc @chrisnojima 