### PR TITLE
OrientedImage: Use Canvas API for Better Results

### DIFF
--- a/shared/chat/conversation/attachment-get-titles/index.js
+++ b/shared/chat/conversation/attachment-get-titles/index.js
@@ -110,8 +110,7 @@ class GetTitles extends React.Component<Props, State> {
             <Box style={{...globalStyles.flexBoxCenter, height: 150, width: 150}}>
               {info.type === 'image' ? (
                 <OrientedImage
-                  preview={true}
-                  onLoad={() => {}}
+                  localFile={true}
                   src={path}
                   style={isMobile ? {height: 150, width: 150} : {maxHeight: '100%', maxWidth: '100%'}}
                 />

--- a/shared/chat/conversation/attachment-get-titles/index.js
+++ b/shared/chat/conversation/attachment-get-titles/index.js
@@ -4,7 +4,6 @@ import {
   Box,
   Button,
   Icon,
-  // Image,
   OrientedImage,
   Input,
   PopupDialog,

--- a/shared/chat/conversation/attachment-get-titles/index.js
+++ b/shared/chat/conversation/attachment-get-titles/index.js
@@ -4,7 +4,8 @@ import {
   Box,
   Button,
   Icon,
-  Image,
+  // Image,
+  OrientedImage,
   Input,
   PopupDialog,
   Text,
@@ -109,7 +110,9 @@ class GetTitles extends React.Component<Props, State> {
           <Box style={isMobile ? stylesMobile : stylesDesktop}>
             <Box style={{...globalStyles.flexBoxCenter, height: 150, width: 150}}>
               {info.type === 'image' ? (
-                <Image
+                <OrientedImage
+                  preview={true}
+                  onLoad={() => {}}
                   src={path}
                   style={isMobile ? {height: 150, width: 150} : {maxHeight: '100%', maxWidth: '100%'}}
                 />

--- a/shared/common-adapters/oriented-image.desktop.js
+++ b/shared/common-adapters/oriented-image.desktop.js
@@ -4,19 +4,25 @@ import fs from 'fs'
 import EXIF from 'exif-js'
 import {noop, isNumber} from 'lodash-es'
 import logger from '../logger'
-import {Image} from '../common-adapters'
+import {Image as ImageComponent} from '../common-adapters'
 import type {Props} from './oriented-image.types'
-import {collapseStyles} from '../styles'
 
 type State = {
-  styleTransform: string,
+  srcTransformed: string,
 }
+type TransformFn = (
+  canvas: HTMLCanvasElement,
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number
+) => void
 
 const uploadedSrc = /https?:\/\/127.0.0.1:.*$/i
 const NO_TRANSFORM = 'notransform'
+const _cacheNoTransforms: {[src: string]: string} = {}
 
-const _cacheStyleTransforms: {[src: string]: string} = {}
-// Orientations:
+// Define transformatin functions to operate on canvas elements
+//
 // 1: rotate 0 deg left
 // 2: flip horizontally
 // 3: rotate 180 deg left
@@ -25,27 +31,45 @@ const _cacheStyleTransforms: {[src: string]: string} = {}
 // 6: rotate 90 deg left
 // 7: flip vertically and rotate 90 degrees left
 // 8: rotate 270 deg left
-const exifOrientaionMap = {
-  '1': 'rotate(0deg)',
-  '2': 'scale(-1, 1)',
-  '3': 'rotate(180deg)',
-  '4': 'scale(1, -1)',
-  '5': 'scale(1, -1) rotate(270deg)',
-  '6': 'rotate(90deg)',
-  '7': 'scale(1, -1) rotate(90deg)',
-  '8': 'rotate(270deg)',
-}
-
-const makeStyleTransform = (orientation: ?number): string => {
-  // In the event that we get a missing orientation from EXIF library
-  if (!orientation) return ''
-
-  const transform = exifOrientaionMap[orientation]
-  if (!transform) {
-    logger.warn(`Invalid orientation value for desktop image attachment: orientation=${orientation}`)
-    return ''
-  }
-  return transform
+const transformMap: {[orientation: string]: TransformFn} = {
+  '1': noop,
+  '2': (canvas, ctx, width, height) => {
+    ctx.translate(width, 0)
+    ctx.scale(-1, 1)
+  },
+  '3': (canvas, ctx, width, height) => {
+    ctx.translate(width, height)
+    ctx.rotate(180 * Math.PI / 180)
+  },
+  '4': (canvas, ctx, width, height) => {
+    ctx.translate(0, height)
+    ctx.scale(1, -1)
+  },
+  '5': (canvas, ctx, width, height) => {
+    canvas.width = height
+    canvas.height = width
+    ctx.rotate(90 * Math.PI / 180)
+    ctx.scale(1, -1)
+  },
+  '6': (canvas, ctx, width, height) => {
+    canvas.width = height
+    canvas.height = width
+    ctx.rotate(90 * Math.PI / 180)
+    ctx.translate(0, -height)
+  },
+  '7': (canvas, ctx, width, height) => {
+    canvas.width = height
+    canvas.height = width
+    ctx.rotate(-90 * Math.PI / 180)
+    ctx.translate(-width, height)
+    ctx.scale(1, -1)
+  },
+  '8': (canvas, ctx, width, height) => {
+    canvas.width = height
+    canvas.height = width
+    ctx.translate(0, width)
+    ctx.rotate(-90 * Math.PI / 180)
+  },
 }
 
 /*
@@ -57,7 +81,7 @@ const makeStyleTransform = (orientation: ?number): string => {
  * orientation on images since 2012)
  *
  * When rendering a preview, the image location on the user's filesystem we
- * read the data directly using fs and have EXIF operate on the bytes.
+ * read the data using fs and have EXIF read directly from the bytes.
  */
 class OrientedImage extends React.Component<Props, State> {
   static defaultProps = {
@@ -65,32 +89,70 @@ class OrientedImage extends React.Component<Props, State> {
     preview: false,
   }
 
-  state = {
-    styleTransform: _cacheStyleTransforms[this.props.src] || '',
-  }
+  state = {srcTransformed: ''}
 
+  /*
+   * Instance Variables
+   */
   _hasComponentMounted = false
+  _canvasRef = null
+  _context = null
 
-  // Parse and update img exif data
-  _setOrientation = (src, orientation: ?number) => {
-    // If there is no Orientation data set for the image, then mark it as null
-    // in the cache to avoid subsequent calls to EXIF
-    if (!isNumber(orientation)) {
-      _cacheStyleTransforms[src] = NO_TRANSFORM
-      return
+  /*
+   * Apply Styles
+   */
+  // Source: Foliotek/Croppie = https://github.com/Foliotek/Croppie/
+  _drawCanvasOrientation = (img, orientation: number) => {
+    // Convice flow that these will not be null for the remainder of this function
+    if (!this._canvasRef || !this._context) return
+
+    const ctx = this._context
+    const canvas = this._canvasRef
+
+    // We have to set the width/height of the canvas to correctly export it
+    const width = img.naturalWidth
+    const height = img.naturalHeight
+    canvas.width = width
+    canvas.height = height
+
+    ctx.save()
+
+    const transformFn = transformMap[orientation.toString()]
+    if (!transformFn) {
+      logger.warn(`Invalid orientation value for desktop image attachment: orientation=${orientation}`)
+      return ''
     }
+    // Appy transformation to canvas
+    transformFn(canvas, ctx, width, height)
 
-    const newTransform: string = makeStyleTransform(orientation)
+    ctx.drawImage(img, 0, 0)
+    ctx.restore()
+
+    // Get an image dataURI from the canvas
+    // toDataURL(type, encoderOptions) is set to 1 to leave the image unencoded
+    const imageData = canvas.toDataURL('image/jpeg', 1)
     this.setState(p => {
-      if (p.styleTransform === newTransform) return undefined
-
-      _cacheStyleTransforms[this.props.src] = newTransform
-      return {styleTransform: newTransform}
+      if (p.srcTransformed === imageData) return undefined
+      return {srcTransformed: imageData}
     })
   }
 
+  _canvasImageTransform = (orientation: number) => {
+    const {src} = this.props
+
+    /* eslint-disable-next-line no-undef */
+    const img = new Image()
+    img.onload = () => this._drawCanvasOrientation(img, orientation)
+    img.src = src
+  }
+
+  /*
+   * Read/Fetch Image Data
+   */
+
   // EXIF will make a local HTTP request for images that have been uploaded to the Keybase service.
-  _fetchExifUploaded = src => {
+  _fetchExifUploaded = () => {
+    const {src} = this.props
     return new Promise((resolve, reject) => {
       const ret = EXIF.getData({src}, function() {
         const orientation = EXIF.getTag(this, 'Orientation')
@@ -102,79 +164,100 @@ class OrientedImage extends React.Component<Props, State> {
 
   // Read the file contents directly into a buffer and pass it to EXIF which
   // can extract the EXIF data
-  _readExifLocal = src => {
+  _readExifLocal = () => {
+    const {src} = this.props
     return new Promise((resolve, reject) => {
-      try {
-        // data is a Node Buffer which is backed by a JavaScript ArrayBuffer.
-        // EXIF.readFromBinaryFile takes an ArrayBuffer
-        const data = fs.readFileSync(src)
-        const tags = EXIF.readFromBinaryFile(data.buffer)
-        tags ? resolve(tags['Orientation']) : reject(new Error('EXIF failed to read exif data'))
-      } catch (err) {
-        reject(err)
-      }
+      // data is a Node Buffer which is backed by a JavaScript ArrayBuffer.
+      // EXIF.readFromBinaryFile takes an ArrayBuffer
+      const data = fs.readFileSync(src)
+      const tags = EXIF.readFromBinaryFile(data.buffer)
+      tags ? resolve(tags['Orientation']) : reject(new Error('EXIF failed to read exif data'))
     })
   }
 
-  _handleImageLoadSuccess = (src, orientation) => {
+  _handleOrientationSuccess = orientation => {
     if (!this._hasComponentMounted) return
-    this._setOrientation(src, orientation)
+
+    // If there is no Orientation data set for the image, then mark it as null
+    // in the cache to avoid subsequent calls to EXIF
+    if (!orientation || !isNumber(orientation)) {
+      return this._handleOrientationFailure()
+    }
+
+    this._canvasImageTransform(orientation)
   }
 
-  // Don't perform transforms if the image cannot be loaded or there is no EXIF data
-  _handleImgeLoadFailure = src => {
-    _cacheStyleTransforms[src] = NO_TRANSFORM
+  // Mark this image path as no transform and set the ImageComponent src to the original source
+  _handleOrientationFailure = () => {
+    _cacheNoTransforms[this.props.src] = NO_TRANSFORM
+    this.setState({srcTransformed: this.props.src})
   }
 
-  _setTranformForExifOrientation(src) {
+  _setTranformForExifOrientation = () => {
     if (!this._hasComponentMounted) return
 
     // This image either cannot be transofrmed or does not have an EXIF orientation flag
-    if (_cacheStyleTransforms[src] === NO_TRANSFORM) {
-      return
-    }
-
-    if (_cacheStyleTransforms[src]) {
-      return this.setState({styleTransform: _cacheStyleTransforms[src]})
+    if (_cacheNoTransforms[this.props.src] === NO_TRANSFORM) {
+      this._handleOrientationFailure()
     }
 
     // Uploaded file served from Keybase service
-    if (uploadedSrc.test(src)) {
-      this._fetchExifUploaded(src)
-        .then(orientation => this._handleImageLoadSuccess(src, orientation))
-        .catch(() => this._handleImgeLoadFailure(src))
+    if (uploadedSrc.test(this.props.src)) {
+      this._fetchExifUploaded()
+        .then(orientation => this._handleOrientationSuccess(orientation))
+        .catch(this._handleOrientationFailure)
     } else {
-      this._readExifLocal(src)
-        .then(orientation => this._handleImageLoadSuccess(src, orientation))
-        .catch(() => this._handleImgeLoadFailure(src))
+      this._readExifLocal()
+        .then(orientation => this._handleOrientationSuccess(orientation))
+        .catch(this._handleOrientationFailure)
     }
   }
 
+  /*
+   * Lifecyle Hooks
+   */
   componentDidMount() {
     this._hasComponentMounted = true
-    this._setTranformForExifOrientation(this.props.src)
+    if (this._canvasRef) {
+      this._context = this._canvasRef.getContext('2d')
+      this._setTranformForExifOrientation()
+    }
   }
 
   componentWillUnmount() {
     this._hasComponentMounted = false
+    this._canvasRef = null
+    this._context = null
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
     // New src requires changing EXIF transform
     if (prevProps && prevProps.src !== this.props.src) {
-      this._setTranformForExifOrientation(this.props.src)
+      this._setTranformForExifOrientation()
     }
   }
 
+  /*
+   * Render Methods
+   */
   render() {
     return (
-      <Image
-        src={this.props.src}
-        style={collapseStyles([this.props.style, {transform: this.state.styleTransform}])}
-        onLoad={this.props.onLoad}
-      />
+      <React.Fragment>
+        <canvas ref={el => (this._canvasRef = el)} style={styleCanvas} />
+        {this.state.srcTransformed && (
+          <ImageComponent
+            src={this.state.srcTransformed}
+            style={this.props.style}
+            onLoad={this.props.onLoad}
+          />
+        )}
+      </React.Fragment>
     )
   }
+}
+
+const styleCanvas = {
+  display: 'none',
 }
 
 export default OrientedImage

--- a/shared/common-adapters/oriented-image.js.flow
+++ b/shared/common-adapters/oriented-image.js.flow
@@ -2,4 +2,6 @@
 import * as React from 'react'
 import type {Props} from './oriented-image.types'
 
-export default class OrientedImage extends React.Component<Props> {}
+export default class OrientedImage extends React.Component<Props> {
+  _context: ?CanvasRenderingContext2D
+}

--- a/shared/common-adapters/oriented-image.types.js.flow
+++ b/shared/common-adapters/oriented-image.types.js.flow
@@ -5,4 +5,5 @@ export type Props = {
   src: string,
   style?: StylesDesktop,
   onLoad: () => void,
+  preview?: boolean,
 }

--- a/shared/common-adapters/oriented-image.types.js.flow
+++ b/shared/common-adapters/oriented-image.types.js.flow
@@ -5,5 +5,4 @@ export type Props = {
   src: string,
   style?: StylesDesktop,
   onLoad?: () => void,
-  localFile?: boolean,
 }

--- a/shared/common-adapters/oriented-image.types.js.flow
+++ b/shared/common-adapters/oriented-image.types.js.flow
@@ -4,6 +4,6 @@ import {type StylesDesktop} from '../styles'
 export type Props = {
   src: string,
   style?: StylesDesktop,
-  onLoad: () => void,
-  preview?: boolean,
+  onLoad?: () => void,
+  localFile?: boolean,
 }


### PR DESCRIPTION
### Problem

Correctly orienting images was done in #12797 using css `transform` styles. However images with orientations that involve a `90º` or `-90º` rotation can cause the final image to be rendered out of bounds of the parent.
This is because transformed DOM elements do not participate in flow and will not cause the parent to expand/contrast after transformation. This occurs when shrinking the window size to the minimum height. The rotated image will not scale down because css `width: 100%` and `height: auto` are applied to the un-transformed DOM element.

![oriented-images-exceeding-bounds](https://user-images.githubusercontent.com/5200812/42776671-b6b7a78a-8905-11e8-9cd6-5831fe7727c9.png)


### Solution

Use the canvas api to perform the following operations
1. Render a `<canvas />` element and get a backing 2D context from `getContext('2d')`
2. Draw the image into the context
3. Apply the appropriate transformation to the image using context `rotate()` `scale()` and `transform()`. Note: This approach was adapted from [croppie.js](https://github.com/Foliotek/Croppie/blob/master/croppie.js#L296-L352).
4. Encode the entire canvas as a dataURL using `canvas.toDataUrl()`
5. Use the canvas dataURL as the final source to the rendered `<Image />`

Final result works on pre-upload preview images (served from the user's filesystem) as well as the fullscreen attachment view for images.

![screen shot 2018-07-16 at 2 46 37 pm](https://user-images.githubusercontent.com/5200812/42777154-3253ce72-8907-11e8-939e-fb94f08f2590.png)
![screen shot 2018-07-16 at 2 47 00 pm](https://user-images.githubusercontent.com/5200812/42777156-337cf83c-8907-11e8-8356-69e8048b282a.png)


### Notes

- The final result from this process is a regular `<img />` component whose **content** has been rotated/flipped according to the EXIF orientation flag.
- There is some latency in the process from src → img → canvas → dataURL → img. However it is usually less that 700ms for jpeg images under 5Mb and approximately 1.5 seconds for images larger than 10Mb
- When the image is large, the largest source of latency is loading the image data from the service.
- Zooming works as expected.

