### PR TITLE
pass metaContext through to pvl and externals

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -85,7 +85,7 @@ func (i *Identify2WithUIDTester) DisplayName(n string) string { return n }
 func (i *Identify2WithUIDTester) GetPrompt() string           { return "" }
 func (i *Identify2WithUIDTester) GetProofType() string        { return "" }
 func (i *Identify2WithUIDTester) GetTypeName() string         { return "" }
-func (i *Identify2WithUIDTester) NormalizeRemoteName(_ libkb.ProofContext, name string) (string, error) {
+func (i *Identify2WithUIDTester) NormalizeRemoteName(_ libkb.MetaContext, name string) (string, error) {
 	return name, nil
 }
 func (i *Identify2WithUIDTester) NormalizeUsername(name string) (string, error)    { return name, nil }
@@ -100,11 +100,11 @@ func (i *Identify2WithUIDTester) MakeProofChecker(_ libkb.RemoteProofChainLink) 
 }
 func (i *Identify2WithUIDTester) GetServiceType(n string) libkb.ServiceType { return i }
 
-func (i *Identify2WithUIDTester) CheckStatus(_ libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode, _ libkb.PvlUnparsed) libkb.ProofError {
+func (i *Identify2WithUIDTester) CheckStatus(m libkb.MetaContext, h libkb.SigHint, pcm libkb.ProofCheckerMode, _ libkb.PvlUnparsed) libkb.ProofError {
 	if i.checkStatusHook != nil {
 		return i.checkStatusHook(h, pcm)
 	}
-	i.G().Log.Debug("Check status rubber stamp: %+v", h)
+	m.CDebugf("Check status rubber stamp: %+v", h)
 	return nil
 }
 

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -756,7 +756,7 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 	e.metaContext = m
 	if them.IDTable() == nil {
 		m.CDebugf("| No IDTable for user")
-	} else if err = them.IDTable().Identify(m.Ctx(), e.state, e.forceRemoteCheck(), iui, e, itm); err != nil {
+	} else if err = them.IDTable().Identify(m, e.state, e.forceRemoteCheck(), iui, e, itm); err != nil {
 		m.CDebugf("| Failure in running IDTable")
 		return err
 	}

--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -94,7 +94,7 @@ func (p *Prove) checkExists1(m libkb.MetaContext) (err error) {
 func (p *Prove) promptRemoteName(m libkb.MetaContext) error {
 	// If the name is already supplied, there's no need to prompt.
 	if len(p.arg.Username) > 0 {
-		remoteNameNormalized, err := p.st.NormalizeRemoteName(m.G(), p.arg.Username)
+		remoteNameNormalized, err := p.st.NormalizeRemoteName(m, p.arg.Username)
 		if err == nil {
 			p.remoteNameNormalized = remoteNameNormalized
 		}
@@ -113,7 +113,7 @@ func (p *Prove) promptRemoteName(m libkb.MetaContext) error {
 			return err
 		}
 		var remoteNameNormalized string
-		remoteNameNormalized, normalizationError = p.st.NormalizeRemoteName(m.G(), un)
+		remoteNameNormalized, normalizationError = p.st.NormalizeRemoteName(m, un)
 		if normalizationError == nil {
 			p.remoteNameNormalized = remoteNameNormalized
 			return nil
@@ -153,7 +153,7 @@ func (p *Prove) checkExists2(m libkb.MetaContext) (err error) {
 
 func (p *Prove) doPrechecks(m libkb.MetaContext) (err error) {
 	var w *libkb.Markup
-	w, err = p.st.PreProofCheck(m.G(), p.remoteNameNormalized)
+	w, err = p.st.PreProofCheck(m, p.remoteNameNormalized)
 	if w != nil {
 		if uierr := m.UIs().ProveUI.OutputPrechecks(m.Ctx(), keybase1.OutputPrechecksArg{Text: w.Export()}); uierr != nil {
 			m.CWarningf("prove ui OutputPrechecks call error: %s", uierr)
@@ -228,7 +228,7 @@ func (p *Prove) postProofToServer(m libkb.MetaContext) (err error) {
 func (p *Prove) instructAction(m libkb.MetaContext) (err error) {
 	mkp := p.st.PostInstructions(p.remoteNameNormalized)
 	var txt string
-	if txt, err = p.st.FormatProofText(m.G() /* as ProofContext */, p.postRes); err != nil {
+	if txt, err = p.st.FormatProofText(m, p.postRes); err != nil {
 		return
 	}
 	err = m.UIs().ProveUI.OutputInstructions(m.Ctx(), keybase1.OutputInstructionsArg{

--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -406,7 +406,7 @@ func (e *ScanProofsEngine) CheckOne(m libkb.MetaContext, rec map[string]string, 
 		return nil, foundhint, fmt.Errorf("error getting pvl: %s", err)
 	}
 
-	perr := pc.CheckStatus(m.G(), *hint, libkb.ProofCheckerModeActive, pvlU)
+	perr := pc.CheckStatus(m, *hint, libkb.ProofCheckerModeActive, pvlU)
 	if perr != nil {
 		return perr, foundhint, nil
 	}

--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -401,7 +401,7 @@ func (e *ScanProofsEngine) CheckOne(m libkb.MetaContext, rec map[string]string, 
 	if pvlSource == nil {
 		return nil, foundhint, fmt.Errorf("no pvl source for proof verification")
 	}
-	pvlU, err := pvlSource.GetPVL(m.Ctx())
+	pvlU, err := pvlSource.GetPVL(m)
 	if err != nil {
 		return nil, foundhint, fmt.Errorf("error getting pvl: %s", err)
 	}

--- a/go/externals/common.go
+++ b/go/externals/common.go
@@ -9,6 +9,6 @@ import (
 	"github.com/keybase/client/go/pvl"
 )
 
-func CheckProofPvl(ctx libkb.ProofContext, proofType keybase1.ProofType, proof libkb.RemoteProofChainLink, hint libkb.SigHint, pvlU libkb.PvlUnparsed) libkb.ProofError {
-	return pvl.CheckProof(ctx, string(pvlU.Pvl), proofType, pvl.NewProofInfo(proof, hint))
+func CheckProofPvl(m libkb.MetaContext, proofType keybase1.ProofType, proof libkb.RemoteProofChainLink, hint libkb.SigHint, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return pvl.CheckProof(m, string(pvlU.Pvl), proofType, pvl.NewProofInfo(proof, hint))
 }

--- a/go/externals/proof_support_dns.go
+++ b/go/externals/proof_support_dns.go
@@ -27,12 +27,12 @@ func NewDNSChecker(p libkb.RemoteProofChainLink) (*DNSChecker, libkb.ProofError)
 
 func (rc *DNSChecker) GetTorError() libkb.ProofError { return libkb.ProofErrorDNSOverTor }
 
-func (rc *DNSChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+func (rc *DNSChecker) CheckStatus(m libkb.MetaContext, h libkb.SigHint, pcm libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
 	if pcm != libkb.ProofCheckerModeActive {
-		ctx.GetLog().CDebugf(ctx.GetNetContext(), "DNS check skipped since proof checking was not in active mode (%s)", h.GetAPIURL())
+		m.CDebugf("DNS check skipped since proof checking was not in active mode (%s)", h.GetAPIURL())
 		return libkb.ProofErrorUnchecked
 	}
-	return CheckProofPvl(ctx, keybase1.ProofType_DNS, rc.proof, h, pvlU)
+	return CheckProofPvl(m, keybase1.ProofType_DNS, rc.proof, h, pvlU)
 }
 
 //
@@ -49,7 +49,7 @@ func (t DNSServiceType) NormalizeUsername(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-func (t DNSServiceType) NormalizeRemoteName(_ libkb.ProofContext, s string) (string, error) {
+func (t DNSServiceType) NormalizeRemoteName(_ libkb.MetaContext, s string) (string, error) {
 	// Allow a leading 'dns://' and preserve case.
 	s = strings.TrimPrefix(s, "dns://")
 	if !libkb.IsValidHostname(s) {
@@ -69,7 +69,7 @@ func (t DNSServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return ret
 }
 
-func (t DNSServiceType) FormatProofText(ctx libkb.ProofContext, ppr *libkb.PostProofRes) (string, error) {
+func (t DNSServiceType) FormatProofText(ctx libkb.MetaContext, ppr *libkb.PostProofRes) (string, error) {
 	return (ppr.Text + "\n"), nil
 }
 

--- a/go/externals/proof_support_facebook.go
+++ b/go/externals/proof_support_facebook.go
@@ -28,8 +28,8 @@ func NewFacebookChecker(p libkb.RemoteProofChainLink) (*FacebookChecker, libkb.P
 
 func (rc *FacebookChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *FacebookChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
-	return CheckProofPvl(ctx, keybase1.ProofType_FACEBOOK, rc.proof, h, pvlU)
+func (rc *FacebookChecker) CheckStatus(m libkb.MetaContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return CheckProofPvl(m, keybase1.ProofType_FACEBOOK, rc.proof, h, pvlU)
 }
 
 //
@@ -50,7 +50,7 @@ func (t FacebookServiceType) NormalizeUsername(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-func (t FacebookServiceType) NormalizeRemoteName(ctx libkb.ProofContext, s string) (string, error) {
+func (t FacebookServiceType) NormalizeRemoteName(m libkb.MetaContext, s string) (string, error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
 	if !facebookUsernameRegexp.MatchString(s) {

--- a/go/externals/proof_support_github.go
+++ b/go/externals/proof_support_github.go
@@ -28,8 +28,8 @@ func NewGithubChecker(p libkb.RemoteProofChainLink) (*GithubChecker, libkb.Proof
 
 func (rc *GithubChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *GithubChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
-	return CheckProofPvl(ctx, keybase1.ProofType_GITHUB, rc.proof, h, pvlU)
+func (rc *GithubChecker) CheckStatus(m libkb.MetaContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return CheckProofPvl(m, keybase1.ProofType_GITHUB, rc.proof, h, pvlU)
 }
 
 //
@@ -48,7 +48,7 @@ func (t GithubServiceType) NormalizeUsername(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-func (t GithubServiceType) NormalizeRemoteName(ctx libkb.ProofContext, s string) (ret string, err error) {
+func (t GithubServiceType) NormalizeRemoteName(m libkb.MetaContext, s string) (ret string, err error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
 	return t.NormalizeUsername(s)

--- a/go/externals/proof_support_reddit.go
+++ b/go/externals/proof_support_reddit.go
@@ -34,8 +34,8 @@ func NewRedditChecker(p libkb.RemoteProofChainLink) (*RedditChecker, libkb.Proof
 
 func (rc *RedditChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *RedditChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
-	return CheckProofPvl(ctx, keybase1.ProofType_REDDIT, rc.proof, h, pvlU)
+func (rc *RedditChecker) CheckStatus(m libkb.MetaContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return CheckProofPvl(m, keybase1.ProofType_REDDIT, rc.proof, h, pvlU)
 }
 
 //
@@ -93,7 +93,7 @@ func (t RedditServiceType) NormalizeUsername(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-func (t RedditServiceType) NormalizeRemoteName(ctx libkb.ProofContext, s string) (ret string, err error) {
+func (t RedditServiceType) NormalizeRemoteName(m libkb.MetaContext, s string) (ret string, err error) {
 	return t.NormalizeUsername(s)
 }
 
@@ -109,7 +109,7 @@ func (t RedditServiceType) PostInstructions(un string) *libkb.Markup {
 	return libkb.FmtMarkup(`Please click on the following link to post to Reddit:`)
 }
 
-func (t RedditServiceType) FormatProofText(ctx libkb.ProofContext, ppr *libkb.PostProofRes) (res string, err error) {
+func (t RedditServiceType) FormatProofText(m libkb.MetaContext, ppr *libkb.PostProofRes) (res string, err error) {
 	var title string
 	if title, err = ppr.Metadata.AtKey("title").GetString(); err != nil {
 		return
@@ -138,7 +138,7 @@ func (t RedditServiceType) FormatProofText(ctx libkb.ProofContext, ppr *libkb.Po
 		return trustedDefault
 	}
 	var host string
-	if ctx.GetAppType() == libkb.MobileAppType {
+	if m.G().GetAppType() == libkb.MobileAppType {
 		hostHint, err := ppr.Metadata.AtKey("mobile_host").GetString()
 		if err != nil {
 			hostHint = ""

--- a/go/externals/proof_support_rooter.go
+++ b/go/externals/proof_support_rooter.go
@@ -30,8 +30,8 @@ func NewRooterChecker(p libkb.RemoteProofChainLink) (*RooterChecker, libkb.Proof
 
 func (rc *RooterChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *RooterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) (perr libkb.ProofError) {
-	return CheckProofPvl(ctx, keybase1.ProofType_ROOTER, rc.proof, h, pvlU)
+func (rc *RooterChecker) CheckStatus(m libkb.MetaContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) (perr libkb.ProofError) {
+	return CheckProofPvl(m, keybase1.ProofType_ROOTER, rc.proof, h, pvlU)
 }
 
 //
@@ -50,7 +50,7 @@ func (t RooterServiceType) NormalizeUsername(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-func (t RooterServiceType) NormalizeRemoteName(_ libkb.ProofContext, s string) (string, error) {
+func (t RooterServiceType) NormalizeRemoteName(_ libkb.MetaContext, s string) (string, error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
 	return t.NormalizeUsername(s)

--- a/go/externals/proof_support_twitter.go
+++ b/go/externals/proof_support_twitter.go
@@ -28,8 +28,8 @@ func NewTwitterChecker(p libkb.RemoteProofChainLink) (*TwitterChecker, libkb.Pro
 
 func (rc *TwitterChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *TwitterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
-	return CheckProofPvl(ctx, keybase1.ProofType_TWITTER, rc.proof, h, pvlU)
+func (rc *TwitterChecker) CheckStatus(m libkb.MetaContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return CheckProofPvl(m, keybase1.ProofType_TWITTER, rc.proof, h, pvlU)
 }
 
 //
@@ -48,7 +48,7 @@ func (t TwitterServiceType) NormalizeUsername(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-func (t TwitterServiceType) NormalizeRemoteName(ctx libkb.ProofContext, s string) (string, error) {
+func (t TwitterServiceType) NormalizeRemoteName(m libkb.MetaContext, s string) (string, error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
 	return t.NormalizeUsername(s)

--- a/go/externals/proof_support_web.go
+++ b/go/externals/proof_support_web.go
@@ -41,12 +41,12 @@ func (rc *WebChecker) GetTorError() libkb.ProofError {
 	return nil
 }
 
-func (rc *WebChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+func (rc *WebChecker) CheckStatus(m libkb.MetaContext, h libkb.SigHint, pcm libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
 	if pcm != libkb.ProofCheckerModeActive {
-		ctx.GetLog().CDebugf(ctx.GetNetContext(), "Web check skipped since proof checking was not in active mode (%s)", h.GetAPIURL())
+		m.CDebugf("Web check skipped since proof checking was not in active mode (%s)", h.GetAPIURL())
 		return libkb.ProofErrorUnchecked
 	}
-	return CheckProofPvl(ctx, keybase1.ProofType_GENERIC_WEB_SITE, rc.proof, h, pvlU)
+	return CheckProofPvl(m, keybase1.ProofType_GENERIC_WEB_SITE, rc.proof, h, pvlU)
 }
 
 //
@@ -79,19 +79,20 @@ func ParseWeb(s string) (hostname string, prot string, err error) {
 	return
 }
 
-func (t WebServiceType) NormalizeRemoteName(ctx libkb.ProofContext, s string) (ret string, err error) {
+func (t WebServiceType) NormalizeRemoteName(m libkb.MetaContext, s string) (ret string, err error) {
 	// The remote name is a full (case-preserved) URL.
 	var prot, host string
 	if host, prot, err = ParseWeb(s); err != nil {
 		return
 	}
 	var res *libkb.APIRes
-	res, err = ctx.GetAPI().Get(libkb.APIArg{
+	res, err = m.G().GetAPI().Get(libkb.APIArg{
 		Endpoint:    "remotes/check",
 		SessionType: libkb.APISessionTypeREQUIRED,
 		Args: libkb.HTTPArgs{
 			"hostname": libkb.S{Val: host},
 		},
+		MetaContext: m,
 	})
 	if err != nil {
 		return

--- a/go/git/get.go
+++ b/go/git/get.go
@@ -92,7 +92,7 @@ func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keyba
 		SessionType: libkb.APISessionTypeREQUIRED,
 		NetContext:  ctx,
 		Args:        libkb.HTTPArgs{
-			// a limit parameter exists, default 100, and we don't currently set it
+		// a limit parameter exists, default 100, and we don't currently set it
 		},
 	}
 

--- a/go/git/get.go
+++ b/go/git/get.go
@@ -92,7 +92,7 @@ func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keyba
 		SessionType: libkb.APISessionTypeREQUIRED,
 		NetContext:  ctx,
 		Args:        libkb.HTTPArgs{
-		// a limit parameter exists, default 100, and we don't currently set it
+			// a limit parameter exists, default 100, and we don't currently set it
 		},
 	}
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -140,10 +140,6 @@ type GlobalContext struct {
 	NetContext context.Context
 }
 
-// There are many interfaces that slice and dice the GlobalContext to expose a
-// smaller API. TODO: Assert more of them here.
-var _ ProofContext = (*GlobalContext)(nil)
-
 type GlobalTestOptions struct {
 	NoBug3964Repair bool
 }

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1624,7 +1624,8 @@ func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack
 	if (hasPreviousTrack && res.trackedProofState != keybase1.ProofState_NONE && res.trackedProofState != keybase1.ProofState_UNCHECKED) || itm == IdentifyTableModeActive {
 		pcm = ProofCheckerModeActive
 	}
-	res.err = pc.CheckStatus(idt.G().CloneWithNetContext(ctx), *res.hint, pcm, pvlU)
+	m := NewMetaContext(ctx, idt.G())
+	res.err = pc.CheckStatus(m, *res.hint, pcm, pvlU)
 
 	// If no error than all good
 	if res.err == nil {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -11,7 +11,6 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	stellar1 "github.com/keybase/client/go/protocol/stellar1"
 	jsonw "github.com/keybase/go-jsonw"
-	"golang.org/x/net/context"
 )
 
 type TypedChainLink interface {
@@ -1459,11 +1458,11 @@ const (
 	IdentifyTableModeActive  IdentifyTableMode = iota
 )
 
-func (idt *IdentityTable) Identify(ctx context.Context, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
+func (idt *IdentityTable) Identify(m MetaContext, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
 	errs := make(chan error, len(is.res.ProofChecks))
 	for _, lcr := range is.res.ProofChecks {
 		go func(l *LinkCheckResult) {
-			errs <- idt.identifyActiveProof(ctx, l, is, forceRemoteCheck, ui, ccl, itm)
+			errs <- idt.identifyActiveProof(m, l, is, forceRemoteCheck, ui, ccl, itm)
 		}(lcr)
 	}
 
@@ -1486,8 +1485,8 @@ func (idt *IdentityTable) Identify(ctx context.Context, is IdentifyState, forceR
 
 //=========================================================================
 
-func (idt *IdentityTable) identifyActiveProof(ctx context.Context, lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
-	idt.proofRemoteCheck(ctx, is.HasPreviousTrack(), forceRemoteCheck, lcr, itm)
+func (idt *IdentityTable) identifyActiveProof(m MetaContext, lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
+	idt.proofRemoteCheck(m, is.HasPreviousTrack(), forceRemoteCheck, lcr, itm)
 	if ccl != nil {
 		ccl.CCLCheckCompleted(lcr)
 	}
@@ -1537,10 +1536,10 @@ func (idt *IdentityTable) ComputeRemoteDiff(tracked, trackedTmp, observed keybas
 	return ret
 }
 
-func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack, forceRemoteCheck bool, res *LinkCheckResult, itm IdentifyTableMode) {
+func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forceRemoteCheck bool, res *LinkCheckResult, itm IdentifyTableMode) {
 	p := res.link
 
-	idt.G().Log.CDebugf(ctx, "+ RemoteCheckProof %s", p.ToDebugString())
+	m.CDebugf("+ RemoteCheckProof %s", p.ToDebugString())
 	doCache := false
 	pvlHashUsed := PvlKitHash("")
 	sid := p.GetSigID()
@@ -1560,13 +1559,13 @@ func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack
 		}
 
 		if doCache {
-			idt.G().Log.CDebugf(ctx, "| Caching results under key=%s pvlHash=%s", sid, pvlHashUsed)
+			m.CDebugf("| Caching results under key=%s pvlHash=%s", sid, pvlHashUsed)
 			if cacheErr := idt.G().ProofCache.Put(sid, res.err, pvlHashUsed); cacheErr != nil {
-				idt.G().Log.CWarningf(ctx, "proof cache put error: %s", cacheErr)
+				m.CWarningf("proof cache put error: %s", cacheErr)
 			}
 		}
 
-		idt.G().Log.CDebugf(ctx, "- RemoteCheckProof %s", p.ToDebugString())
+		m.CDebugf("- RemoteCheckProof %s", p.ToDebugString())
 	}()
 
 	pvlSource := idt.G().GetPvlSource()
@@ -1574,7 +1573,7 @@ func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack
 		res.err = NewProofError(keybase1.ProofStatus_MISSING_PVL, "no pvl source for proof verification")
 		return
 	}
-	pvlU, err := pvlSource.GetPVL(ctx)
+	pvlU, err := pvlSource.GetPVL(m)
 	if err != nil {
 		res.err = NewProofError(keybase1.ProofStatus_MISSING_PVL, "error getting pvl: %s", err)
 		return
@@ -1591,24 +1590,24 @@ func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack
 
 	// Call the Global context's version of what a proof checker is. We might want to stub it out
 	// for the purposes of testing.
-	pc, res.err = MakeProofChecker(idt.G().Services, p)
+	pc, res.err = MakeProofChecker(m.G().Services, p)
 
 	if res.err != nil {
 		return
 	}
 
-	if idt.G().Env.GetTorMode().Enabled() {
+	if m.G().Env.GetTorMode().Enabled() {
 		if e := pc.GetTorError(); e != nil {
 			res.torWarning = true
 		}
 	}
 
 	if !forceRemoteCheck {
-		res.cached = idt.G().ProofCache.Get(sid, pvlU.Hash)
-		idt.G().Log.CDebugf(ctx, "| Proof cache lookup for %s: %+v", sid, res.cached)
+		res.cached = m.G().ProofCache.Get(sid, pvlU.Hash)
+		m.CDebugf("| Proof cache lookup for %s: %+v", sid, res.cached)
 		if res.cached != nil && res.cached.Freshness() == keybase1.CheckResultFreshness_FRESH {
 			res.err = res.cached.Status
-			idt.G().Log.CDebugf(ctx, "| Early exit after proofCache hit for %s", sid)
+			m.CDebugf("| Early exit after proofCache hit for %s", sid)
 			return
 		}
 	}
@@ -1624,7 +1623,6 @@ func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack
 	if (hasPreviousTrack && res.trackedProofState != keybase1.ProofState_NONE && res.trackedProofState != keybase1.ProofState_UNCHECKED) || itm == IdentifyTableModeActive {
 		pcm = ProofCheckerModeActive
 	}
-	m := NewMetaContext(ctx, idt.G())
 	res.err = pc.CheckStatus(m, *res.hint, pcm, pvlU)
 
 	// If no error than all good
@@ -1637,7 +1635,7 @@ func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack
 	// not to cache it.
 	if ProofErrorIsSoft(res.err) && res.cached != nil && res.cached.Status == nil &&
 		res.cached.Freshness() != keybase1.CheckResultFreshness_RANCID {
-		idt.G().Log.CDebugf(ctx, "| Got soft error (%s) but returning success (last seen at %s)",
+		m.CDebugf("| Got soft error (%s) but returning success (last seen at %s)",
 			res.err.Error(), res.cached.Time)
 		res.snoozedErr = res.err
 		res.err = nil
@@ -1645,7 +1643,7 @@ func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack
 		return
 	}
 
-	idt.G().Log.CDebugf(ctx, "| Check status (%s) failed with error: %s", p.ToDebugString(), res.err.Error())
+	m.CDebugf("| Check status (%s) failed with error: %s", p.ToDebugString(), res.err.Error())
 
 	return
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -514,16 +514,6 @@ type DNSContext interface {
 	GetDNSNameServerFetcher() DNSNameServerFetcher
 }
 
-// ProofContext defines features needed by the proof system
-type ProofContext interface {
-	LogContext
-	APIContext
-	NetContext
-	DNSContext
-	GetPvlSource() PvlSource
-	GetAppType() AppType
-}
-
 type AssertionContext interface {
 	NormalizeSocialName(service string, username string) (string, error)
 }
@@ -538,7 +528,7 @@ const (
 )
 
 type ProofChecker interface {
-	CheckStatus(ctx ProofContext, h SigHint, pcm ProofCheckerMode, pvlU PvlUnparsed) ProofError
+	CheckStatus(m MetaContext, h SigHint, pcm ProofCheckerMode, pvlU PvlUnparsed) ProofError
 	GetTorError() ProofError
 }
 
@@ -559,11 +549,11 @@ type ServiceType interface {
 	// leaves the dots in (that NormalizeUsername above would strip out). This
 	// lets us keep the dots in the proof text, and display them on your
 	// profile page, even though we ignore them for proof checking.
-	NormalizeRemoteName(ctx ProofContext, name string) (string, error)
+	NormalizeRemoteName(m MetaContext, name string) (string, error)
 
 	GetPrompt() string
 	LastWriterWins() bool
-	PreProofCheck(ctx ProofContext, remotename string) (*Markup, error)
+	PreProofCheck(m MetaContext, remotename string) (*Markup, error)
 	PreProofWarning(remotename string) *Markup
 	ToServiceJSON(remotename string) *jsonw.Wrapper
 	PostInstructions(remotename string) *Markup
@@ -572,7 +562,7 @@ type ServiceType interface {
 	GetProofType() string
 	GetTypeName() string
 	CheckProofText(text string, id keybase1.SigID, sig string) error
-	FormatProofText(ProofContext, *PostProofRes) (string, error)
+	FormatProofText(MetaContext, *PostProofRes) (string, error)
 	GetAPIArgKey() string
 	IsDevelOnly() bool
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -575,7 +575,7 @@ type ExternalServicesCollector interface {
 }
 
 type PvlSource interface {
-	GetPVL(ctx context.Context) (PvlUnparsed, error)
+	GetPVL(m MetaContext) (PvlUnparsed, error)
 }
 
 // UserChangedHandler is a generic interface for handling user changed events.

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -78,11 +78,11 @@ func (t BaseServiceType) BaseAllStringKeys(st ServiceType) []string {
 	return []string{st.GetTypeName()}
 }
 
-func (t BaseServiceType) LastWriterWins() bool                                { return true }
-func (t BaseServiceType) PreProofCheck(ProofContext, string) (*Markup, error) { return nil, nil }
-func (t BaseServiceType) PreProofWarning(remotename string) *Markup           { return nil }
+func (t BaseServiceType) LastWriterWins() bool                               { return true }
+func (t BaseServiceType) PreProofCheck(MetaContext, string) (*Markup, error) { return nil, nil }
+func (t BaseServiceType) PreProofWarning(remotename string) *Markup          { return nil }
 
-func (t BaseServiceType) FormatProofText(ctx ProofContext, ppr *PostProofRes) (string, error) {
+func (t BaseServiceType) FormatProofText(m MetaContext, ppr *PostProofRes) (string, error) {
 	return ppr.Text, nil
 }
 

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -249,12 +249,12 @@ func validateProtocol(s string, allowed []string) (string, bool) {
 	return canon, false
 }
 
-func rooterRewriteURL(ctx libkb.ProofContext, s string) (string, error) {
+func rooterRewriteURL(m metaContext, s string) (string, error) {
 	u1, err := url.Parse(s)
 	if err != nil {
 		return "", err
 	}
-	u2, err := url.Parse(ctx.GetServerURI())
+	u2, err := url.Parse(m.G().GetServerURI())
 	if err != nil {
 		return "", err
 	}

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -103,11 +103,11 @@ func NewProofInfo(link libkb.RemoteProofChainLink, h libkb.SigHint) ProofInfo {
 }
 
 // CheckProof verifies one proof by running the pvl on the provided proof information.
-func CheckProof(g1 libkb.ProofContext, pvlS string, service keybase1.ProofType, info ProofInfo) libkb.ProofError {
-	g := newProofContextExt(g1, info.stubDNS)
-	perr := checkProofInner(g, pvlS, service, info)
+func CheckProof(m libkb.MetaContext, pvlS string, service keybase1.ProofType, info ProofInfo) libkb.ProofError {
+	m1 := newMetaContext(m, info.stubDNS)
+	perr := checkProofInner(m1, pvlS, service, info)
 	if perr != nil {
-		debug(g, "CheckProof failed: %v", perr)
+		debug(m1, "CheckProof failed: %v", perr)
 	}
 	if perr != nil && perr.GetProofStatus() == keybase1.ProofStatus_INVALID_PVL {
 		return libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
@@ -116,14 +116,14 @@ func CheckProof(g1 libkb.ProofContext, pvlS string, service keybase1.ProofType, 
 	return perr
 }
 
-func checkProofInner(g proofContextExt, pvlS string, service keybase1.ProofType, info ProofInfo) libkb.ProofError {
+func checkProofInner(m metaContext, pvlS string, service keybase1.ProofType, info ProofInfo) libkb.ProofError {
 	pvl, err := parse(pvlS)
 	if err != nil {
 		return libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"Could not parse pvl: %v", err)
 	}
 
-	if perr := validateChunk(g, &pvl, service); perr != nil {
+	if perr := validateChunk(m, &pvl, service); perr != nil {
 		return perr
 	}
 
@@ -167,13 +167,13 @@ func checkProofInner(g proofContextExt, pvlS string, service keybase1.ProofType,
 			FetchResult: nil,
 		}
 
-		err := setupRegs(g, &state.Regs, info, sigBody, sigID, service)
+		err := setupRegs(m, &state.Regs, info, sigBody, sigID, service)
 		return state, err
 	}
 
 	var errs []libkb.ProofError
 	if service == keybase1.ProofType_DNS {
-		perr = runDNS(g, info.Hostname, scripts, mknewstate, sigID.ToMediumID())
+		perr = runDNS(m, info.Hostname, scripts, mknewstate, sigID.ToMediumID())
 		if perr != nil {
 			errs = append(errs, perr)
 		}
@@ -187,7 +187,7 @@ func checkProofInner(g proofContextExt, pvlS string, service keybase1.ProofType,
 			if perr != nil {
 				return perr
 			}
-			perr = runScript(g, &script, state)
+			perr = runScript(m, &script, state)
 			if perr == nil {
 				return nil
 			}
@@ -201,14 +201,14 @@ func checkProofInner(g proofContextExt, pvlS string, service keybase1.ProofType,
 		return errs[0]
 	} else {
 		for _, err := range errs {
-			debug(g, "multiple failures include: %v", err)
+			debug(m, "multiple failures include: %v", err)
 		}
 		// Arbitrarily use the error code of the first error
 		return libkb.NewProofError(errs[0].GetProofStatus(), "Multiple errors while verifying proof")
 	}
 }
 
-func setupRegs(g proofContextExt, regs *namedRegsStore, info ProofInfo, sigBody []byte, sigID keybase1.SigID, service keybase1.ProofType) libkb.ProofError {
+func setupRegs(m metaContext, regs *namedRegsStore, info ProofInfo, sigBody []byte, sigID keybase1.SigID, service keybase1.ProofType) libkb.ProofError {
 	webish := (service == keybase1.ProofType_DNS || service == keybase1.ProofType_GENERIC_WEB_SITE)
 
 	// hint_url
@@ -301,13 +301,13 @@ func chunkGetScripts(pvl *pvlT, service keybase1.ProofType) ([]scriptT, libkb.Pr
 
 // Check that a chunk of PVL is valid code.
 // Will always accept valid code, but may not always notice invalidities.
-func validateChunk(g proofContextExt, pvl *pvlT, service keybase1.ProofType) libkb.ProofError {
+func validateChunk(m metaContext, pvl *pvlT, service keybase1.ProofType) libkb.ProofError {
 	if pvl.PvlVersion != SupportedVersion {
 		return libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"PVL is for the wrong version %v != %v", pvl.PvlVersion, SupportedVersion)
 	}
 
-	debug(g, "valid version:%v revision:%v", pvl.PvlVersion, pvl.Revision)
+	debug(m, "valid version:%v revision:%v", pvl.PvlVersion, pvl.Revision)
 
 	scripts, perr := chunkGetScripts(pvl, service)
 	if perr != nil {
@@ -321,19 +321,19 @@ func validateChunk(g proofContextExt, pvl *pvlT, service keybase1.ProofType) lib
 	// Scan all the scripts (for this service) for errors. Report the first error.
 	var errs []libkb.ProofError
 	for whichscript, script := range scripts {
-		perr = validateScript(g, &script, service, whichscript)
+		perr = validateScript(m, &script, service, whichscript)
 		errs = append(errs, perr)
 	}
 	return errs[0]
 }
 
-func validateScript(g proofContextExt, script *scriptT, service keybase1.ProofType, whichscript int) libkb.ProofError {
+func validateScript(m metaContext, script *scriptT, service keybase1.ProofType, whichscript int) libkb.ProofError {
 	// Scan the script.
 	// Does not validate each instruction's format. (That is done when running it)
 	// Validate each instruction's "error" field.
 
-	logerr := func(g proofContextExt, service keybase1.ProofType, whichscript int, pc int, format string, arg ...interface{}) libkb.ProofError {
-		debugWithPosition(g, service, whichscript, pc, format, arg...)
+	logerr := func(m metaContext, service keybase1.ProofType, whichscript int, pc int, format string, arg ...interface{}) libkb.ProofError {
+		debugWithPosition(m, service, whichscript, pc, format, arg...)
 		return libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL, format, arg...)
 	}
 
@@ -344,12 +344,12 @@ func validateScript(g proofContextExt, script *scriptT, service keybase1.ProofTy
 		mode = fetchModeDNS
 	}
 	if len(script.Instructions) < 1 {
-		return logerr(g, service, whichscript, 0, "Empty script")
+		return logerr(m, service, whichscript, 0, "Empty script")
 	}
 
 	for i, ins := range script.Instructions {
 		if ins.variantsFilled() != 1 {
-			return logerr(g, service, whichscript, i, "exactly 1 variant must appear in instruction")
+			return logerr(m, service, whichscript, i, "exactly 1 variant must appear in instruction")
 		}
 
 		switch {
@@ -371,11 +371,11 @@ func validateScript(g proofContextExt, script *scriptT, service keybase1.ProofTy
 			fetchType := ins.Fetch.Kind
 
 			if service == keybase1.ProofType_DNS {
-				return logerr(g, service, whichscript, i,
+				return logerr(m, service, whichscript, i,
 					"DNS script cannot contain fetch instruction")
 			}
 			if modeknown {
-				return logerr(g, service, whichscript, i,
+				return logerr(m, service, whichscript, i,
 					"Script cannot contain multiple fetch instructions")
 			}
 			switch fetchMode(fetchType) {
@@ -389,7 +389,7 @@ func validateScript(g proofContextExt, script *scriptT, service keybase1.ProofTy
 				modeknown = true
 				mode = fetchModeJSON
 			default:
-				return logerr(g, service, whichscript, i,
+				return logerr(m, service, whichscript, i,
 					"Unsupported fetch type: %v", fetchType)
 			}
 		case ins.ParseHTML != nil:
@@ -397,23 +397,23 @@ func validateScript(g proofContextExt, script *scriptT, service keybase1.ProofTy
 			// Can only select after fetching.
 			switch {
 			case service == keybase1.ProofType_DNS:
-				return logerr(g, service, whichscript, i,
+				return logerr(m, service, whichscript, i,
 					"DNS script cannot use json selector")
 			case !modeknown:
-				return logerr(g, service, whichscript, i,
+				return logerr(m, service, whichscript, i,
 					"Script cannot select before fetch")
 			case mode != fetchModeJSON:
-				return logerr(g, service, whichscript, i,
+				return logerr(m, service, whichscript, i,
 					"Script contains json selector in non-html mode")
 			}
 		case ins.SelectorCSS != nil:
 			// Can only select one of text, attr, or data.
 			if ins.SelectorCSS.Attr != "" && ins.SelectorCSS.Data {
-				return logerr(g, service, whichscript, i,
+				return logerr(m, service, whichscript, i,
 					"Script contains css selector with both 'attr' and 'data' set")
 			}
 		default:
-			return logerr(g, service, whichscript, i,
+			return logerr(m, service, whichscript, i,
 				"Unsupported PVL instruction: %v", ins)
 		}
 	}
@@ -423,13 +423,13 @@ func validateScript(g proofContextExt, script *scriptT, service keybase1.ProofTy
 
 // Run each script on each TXT record of each domain.
 // Succeed if any succeed.
-func runDNS(g proofContextExt, userdomain string, scripts []scriptT, mknewstate stateMaker, sigIDMedium string) libkb.ProofError {
+func runDNS(m metaContext, userdomain string, scripts []scriptT, mknewstate stateMaker, sigIDMedium string) libkb.ProofError {
 	domains := []string{userdomain, "_keybase." + userdomain}
 	var errs []libkb.ProofError
 	for _, d := range domains {
-		debug(g, "Trying DNS for domain: %v", d)
+		debug(m, "Trying DNS for domain: %v", d)
 
-		err := runDNSOne(g, d, scripts, mknewstate, sigIDMedium)
+		err := runDNSOne(m, d, scripts, mknewstate, sigIDMedium)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
@@ -456,7 +456,7 @@ func formatDNSServer(srv string) string {
 	return srv + ":53"
 }
 
-func runDNSTXTQuery(g proofContextExt, domain string) (res []string, err error) {
+func runDNSTXTQuery(m metaContext, domain string) (res []string, err error) {
 
 	// Attempt to use the built-in resolver first, but this might fail on mobile.
 	// The reason for that is currently (as of Go 1.8), LookupTXT does not properly
@@ -464,7 +464,7 @@ func runDNSTXTQuery(g proofContextExt, domain string) (res []string, err error) 
 	// As for now, we can use a different library to specify our own name servers, since the
 	// Go resolver will attempt to use /etc/resolv.conf, which is not a thing on mobile.
 	if res, err = net.LookupTXT(domain); err != nil {
-		debug(g, "DNS LookupTXT failed: %s", err.Error())
+		debug(m, "DNS LookupTXT failed: %s", err.Error())
 	} else {
 		return res, nil
 	}
@@ -475,8 +475,8 @@ func runDNSTXTQuery(g proofContextExt, domain string) (res []string, err error) 
 		formatDNSServer("2001:4860:4860::8888"),
 	}
 	var fetchedSrvs []string
-	if g.GetDNSNameServerFetcher() != nil {
-		fetchedSrvs = g.GetDNSNameServerFetcher().GetServers()
+	if m.G().GetDNSNameServerFetcher() != nil {
+		fetchedSrvs = m.G().GetDNSNameServerFetcher().GetServers()
 		for i := 0; i < len(fetchedSrvs); i++ {
 			fetchedSrvs[i] = formatDNSServer(fetchedSrvs[i])
 		}
@@ -485,14 +485,14 @@ func runDNSTXTQuery(g proofContextExt, domain string) (res []string, err error) 
 
 	var r *dns.Msg
 	c := dns.Client{}
-	m := dns.Msg{}
+	msg := dns.Msg{}
 	found := false
 	for _, srv := range servers {
-		debug(g, "DNS trying backup server: %s", srv)
-		m.SetQuestion(domain+".", dns.TypeTXT)
-		r, _, err = c.Exchange(&m, srv)
+		debug(m, "DNS trying backup server: %s", srv)
+		msg.SetQuestion(domain+".", dns.TypeTXT)
+		r, _, err = c.Exchange(&msg, srv)
 		if err != nil {
-			debug(g, "DNS backup server failed; %s", err.Error())
+			debug(m, "DNS backup server failed; %s", err.Error())
 		} else {
 			found = true
 			break
@@ -513,14 +513,14 @@ func runDNSTXTQuery(g proofContextExt, domain string) (res []string, err error) 
 }
 
 // Run each script on each TXT record of the domain.
-func runDNSOne(g proofContextExt, domain string, scripts []scriptT, mknewstate stateMaker, sigIDMedium string) libkb.ProofError {
+func runDNSOne(m metaContext, domain string, scripts []scriptT, mknewstate stateMaker, sigIDMedium string) libkb.ProofError {
 	// Fetch TXT records
 	var txts []string
 	var err error
-	if g.getStubDNS() == nil {
-		txts, err = runDNSTXTQuery(g, domain)
+	if m.getStubDNS() == nil {
+		txts, err = runDNSTXTQuery(m, domain)
 	} else {
-		txts, err = g.getStubDNS().LookupTXT(domain)
+		txts, err = m.getStubDNS().LookupTXT(domain)
 	}
 
 	if err != nil {
@@ -529,7 +529,7 @@ func runDNSOne(g proofContextExt, domain string, scripts []scriptT, mknewstate s
 	}
 
 	for _, record := range txts {
-		debug(g, "For DNS domain '%s' got TXT record: '%s'", domain, record)
+		debug(m, "For DNS domain '%s' got TXT record: '%s'", domain, record)
 
 		// Try all scripts.
 		for i, script := range scripts {
@@ -543,7 +543,7 @@ func runDNSOne(g proofContextExt, domain string, scripts []scriptT, mknewstate s
 				return err
 			}
 
-			err = runScript(g, &script, state)
+			err = runScript(m, &script, state)
 			if err == nil {
 				return nil
 			}
@@ -557,12 +557,12 @@ func runDNSOne(g proofContextExt, domain string, scripts []scriptT, mknewstate s
 		len(txts), domain, sigIDMedium)
 }
 
-func runScript(g proofContextExt, script *scriptT, startstate scriptState) libkb.ProofError {
+func runScript(m metaContext, script *scriptT, startstate scriptState) libkb.ProofError {
 	var state = startstate
 	if len(script.Instructions) < 1 {
 		perr := libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"Empty scripts are not allowed.")
-		debugWithStateError(g, state, perr)
+		debugWithStateError(m, state, perr)
 		return perr
 	}
 	for i, ins := range script.Instructions {
@@ -570,11 +570,11 @@ func runScript(g proofContextExt, script *scriptT, startstate scriptState) libkb
 		if state.PC != i {
 			perr := libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 				"Execution failure, PC mismatch %v %v", state.PC, i)
-			debugWithStateError(g, state, perr)
+			debugWithStateError(m, state, perr)
 			return perr
 		}
 
-		newstate, perr := stepInstruction(g, ins, state)
+		newstate, perr := stepInstruction(m, ins, state)
 		if perr != nil {
 			return perr
 		}
@@ -587,48 +587,48 @@ func runScript(g proofContextExt, script *scriptT, startstate scriptState) libkb
 }
 
 // stepInstruction decides which instruction to run.
-func stepInstruction(g proofContextExt, ins instructionT, state scriptState) (scriptState, libkb.ProofError) {
-	debugWithState(g, state, "Running instruction %v: %v", ins.Name(), ins)
+func stepInstruction(m metaContext, ins instructionT, state scriptState) (scriptState, libkb.ProofError) {
+	debugWithState(m, state, "Running instruction %v: %v", ins.Name(), ins)
 
 	var newState scriptState
 	var stepErr libkb.ProofError
 	var customErrSpec *errorT
 	switch {
 	case ins.AssertRegexMatch != nil:
-		newState, stepErr = stepAssertRegexMatch(g, *ins.AssertRegexMatch, state)
+		newState, stepErr = stepAssertRegexMatch(m, *ins.AssertRegexMatch, state)
 		customErrSpec = ins.AssertRegexMatch.Error
 	case ins.AssertFindBase64 != nil:
-		newState, stepErr = stepAssertFindBase64(g, *ins.AssertFindBase64, state)
+		newState, stepErr = stepAssertFindBase64(m, *ins.AssertFindBase64, state)
 		customErrSpec = ins.AssertFindBase64.Error
 	case ins.AssertCompare != nil:
-		newState, stepErr = stepAssertCompare(g, *ins.AssertCompare, state)
+		newState, stepErr = stepAssertCompare(m, *ins.AssertCompare, state)
 		customErrSpec = ins.AssertCompare.Error
 	case ins.WhitespaceNormalize != nil:
-		newState, stepErr = stepWhitespaceNormalize(g, *ins.WhitespaceNormalize, state)
+		newState, stepErr = stepWhitespaceNormalize(m, *ins.WhitespaceNormalize, state)
 		customErrSpec = ins.WhitespaceNormalize.Error
 	case ins.RegexCapture != nil:
-		newState, stepErr = stepRegexCapture(g, *ins.RegexCapture, state)
+		newState, stepErr = stepRegexCapture(m, *ins.RegexCapture, state)
 		customErrSpec = ins.RegexCapture.Error
 	case ins.ReplaceAll != nil:
-		newState, stepErr = stepReplaceAll(g, *ins.ReplaceAll, state)
+		newState, stepErr = stepReplaceAll(m, *ins.ReplaceAll, state)
 		customErrSpec = ins.ReplaceAll.Error
 	case ins.ParseURL != nil:
-		newState, stepErr = stepParseURL(g, *ins.ParseURL, state)
+		newState, stepErr = stepParseURL(m, *ins.ParseURL, state)
 		customErrSpec = ins.ParseURL.Error
 	case ins.Fetch != nil:
-		newState, stepErr = stepFetch(g, *ins.Fetch, state)
+		newState, stepErr = stepFetch(m, *ins.Fetch, state)
 		customErrSpec = ins.Fetch.Error
 	case ins.ParseHTML != nil:
-		newState, stepErr = stepParseHTML(g, *ins.ParseHTML, state)
+		newState, stepErr = stepParseHTML(m, *ins.ParseHTML, state)
 		customErrSpec = ins.ParseHTML.Error
 	case ins.SelectorJSON != nil:
-		newState, stepErr = stepSelectorJSON(g, *ins.SelectorJSON, state)
+		newState, stepErr = stepSelectorJSON(m, *ins.SelectorJSON, state)
 		customErrSpec = ins.SelectorJSON.Error
 	case ins.SelectorCSS != nil:
-		newState, stepErr = stepSelectorCSS(g, *ins.SelectorCSS, state)
+		newState, stepErr = stepSelectorCSS(m, *ins.SelectorCSS, state)
 		customErrSpec = ins.SelectorCSS.Error
 	case ins.Fill != nil:
-		newState, stepErr = stepFill(g, *ins.Fill, state)
+		newState, stepErr = stepFill(m, *ins.Fill, state)
 		customErrSpec = ins.Fill.Error
 	default:
 		newState = state
@@ -637,14 +637,14 @@ func stepInstruction(g proofContextExt, ins instructionT, state scriptState) (sc
 	}
 
 	if stepErr != nil {
-		debugWithStateError(g, state, stepErr)
-		stepErr = replaceCustomError(g, state, customErrSpec, stepErr)
+		debugWithStateError(m, state, stepErr)
+		stepErr = replaceCustomError(m, state, customErrSpec, stepErr)
 	}
 	return newState, stepErr
 
 }
 
-func stepAssertRegexMatch(g proofContextExt, ins assertRegexMatchT, state scriptState) (scriptState, libkb.ProofError) {
+func stepAssertRegexMatch(m metaContext, ins assertRegexMatchT, state scriptState) (scriptState, libkb.ProofError) {
 	rdesc := regexDescriptor{
 		Template:        ins.Pattern,
 		CaseInsensitive: ins.CaseInsensitive,
@@ -654,7 +654,7 @@ func stepAssertRegexMatch(g proofContextExt, ins assertRegexMatchT, state script
 	if err != nil {
 		return state, err
 	}
-	re, err := interpretRegex(g, state, rdesc)
+	re, err := interpretRegex(m, state, rdesc)
 	if err != nil {
 		return state, err
 	}
@@ -663,7 +663,7 @@ func stepAssertRegexMatch(g proofContextExt, ins assertRegexMatchT, state script
 		if ins.Negate {
 			negate = ""
 		}
-		debugWithState(g, state, "Regex did %smatch:\n  %v\n  %v\n  %q",
+		debugWithState(m, state, "Regex did %smatch:\n  %v\n  %v\n  %q",
 			negate, rdesc.Template, re, from)
 		return state, libkb.NewProofError(keybase1.ProofStatus_CONTENT_FAILURE,
 			"Regex did %smatch (%v)", negate, rdesc.Template)
@@ -672,7 +672,7 @@ func stepAssertRegexMatch(g proofContextExt, ins assertRegexMatchT, state script
 	return state, nil
 }
 
-func stepAssertFindBase64(g proofContextExt, ins assertFindBase64T, state scriptState) (scriptState, libkb.ProofError) {
+func stepAssertFindBase64(m metaContext, ins assertFindBase64T, state scriptState) (scriptState, libkb.ProofError) {
 	if ins.Needle != "sig" {
 		return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"Can only assert_find_base64 for sig")
@@ -688,7 +688,7 @@ func stepAssertFindBase64(g proofContextExt, ins assertFindBase64T, state script
 		"Signature not found")
 }
 
-func stepAssertCompare(g proofContextExt, ins assertCompareT, state scriptState) (scriptState, libkb.ProofError) {
+func stepAssertCompare(m metaContext, ins assertCompareT, state scriptState) (scriptState, libkb.ProofError) {
 	a, err := state.Regs.Get(ins.A)
 	if err != nil {
 		return state, err
@@ -715,7 +715,7 @@ func stepAssertCompare(g proofContextExt, ins assertCompareT, state scriptState)
 	}
 
 	if !same {
-		debugWithState(g, state, "Comparison (%v) failed\n  %v != %v\n  '%v' != '%v'",
+		debugWithState(m, state, "Comparison (%v) failed\n  %v != %v\n  '%v' != '%v'",
 			ins.Cmp, ins.A, ins.B, a, b)
 		return state, libkb.NewProofError(keybase1.ProofStatus_CONTENT_FAILURE,
 			"Comparison (%v) failed '%v' != '%v'", ins.Cmp, a, b)
@@ -724,7 +724,7 @@ func stepAssertCompare(g proofContextExt, ins assertCompareT, state scriptState)
 	return state, nil
 }
 
-func stepWhitespaceNormalize(g proofContextExt, ins whitespaceNormalizeT, state scriptState) (scriptState, libkb.ProofError) {
+func stepWhitespaceNormalize(m metaContext, ins whitespaceNormalizeT, state scriptState) (scriptState, libkb.ProofError) {
 	from, err := state.Regs.Get(ins.From)
 	if err != nil {
 		return state, err
@@ -734,7 +734,7 @@ func stepWhitespaceNormalize(g proofContextExt, ins whitespaceNormalizeT, state 
 	return state, err
 }
 
-func stepRegexCapture(g proofContextExt, ins regexCaptureT, state scriptState) (scriptState, libkb.ProofError) {
+func stepRegexCapture(m metaContext, ins regexCaptureT, state scriptState) (scriptState, libkb.ProofError) {
 	rdesc := regexDescriptor{
 		Template:        ins.Pattern,
 		CaseInsensitive: ins.CaseInsensitive,
@@ -746,7 +746,7 @@ func stepRegexCapture(g proofContextExt, ins regexCaptureT, state scriptState) (
 		return state, err
 	}
 
-	re, err := interpretRegex(g, state, rdesc)
+	re, err := interpretRegex(m, state, rdesc)
 	if err != nil {
 		return state, err
 	}
@@ -761,7 +761,7 @@ func stepRegexCapture(g proofContextExt, ins regexCaptureT, state scriptState) (
 	// Assert that the match matched and has at least one capture group.
 	// -1 for the ignored first element of match
 	if len(match)-1 < len(ins.Into) {
-		debugWithState(g, state, "Regex capture did not match enough groups:\n  %v\n  %v\n  %q\n  %v",
+		debugWithState(m, state, "Regex capture did not match enough groups:\n  %v\n  %v\n  %q\n  %v",
 			rdesc.Template, re, from, match)
 		return state, libkb.NewProofError(keybase1.ProofStatus_CONTENT_FAILURE,
 			"Regex capture did not match enough groups (%v)", rdesc.Template)
@@ -775,7 +775,7 @@ func stepRegexCapture(g proofContextExt, ins regexCaptureT, state scriptState) (
 	return state, nil
 }
 
-func stepReplaceAll(g proofContextExt, ins replaceAllT, state scriptState) (scriptState, libkb.ProofError) {
+func stepReplaceAll(m metaContext, ins replaceAllT, state scriptState) (scriptState, libkb.ProofError) {
 	from, err := state.Regs.Get(ins.From)
 	if err != nil {
 		return state, err
@@ -790,7 +790,7 @@ func stepReplaceAll(g proofContextExt, ins replaceAllT, state scriptState) (scri
 	return state, nil
 }
 
-func stepParseURL(g proofContextExt, ins parseURLT, state scriptState) (scriptState, libkb.ProofError) {
+func stepParseURL(m metaContext, ins parseURLT, state scriptState) (scriptState, libkb.ProofError) {
 	s, err := state.Regs.Get(ins.From)
 	if err != nil {
 		return state, err
@@ -826,7 +826,7 @@ func stepParseURL(g proofContextExt, ins parseURLT, state scriptState) (scriptSt
 	return state, nil
 }
 
-func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, libkb.ProofError) {
+func stepFetch(m metaContext, ins fetchT, state scriptState) (scriptState, libkb.ProofError) {
 	if state.FetchResult != nil {
 		return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"Script cannot contain more than one fetch")
@@ -841,7 +841,7 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 		return state, err
 	}
 	if state.Service == keybase1.ProofType_ROOTER {
-		from2, err := rooterRewriteURL(g, from)
+		from2, err := rooterRewriteURL(m, from)
 		if err != nil {
 			return state, libkb.NewProofError(keybase1.ProofStatus_FAILED_PARSE,
 				"Could not rewrite rooter URL: %v", err)
@@ -851,8 +851,8 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 
 	switch fetchMode(ins.Kind) {
 	case fetchModeString:
-		debugWithState(g, state, "fetchurl: %v", from)
-		res, err1 := g.GetExternalAPI().GetText(libkb.NewAPIArgWithNetContext(g.GetNetContext(), from))
+		debugWithState(m, state, "fetchurl: %v", from)
+		res, err1 := m.G().GetExternalAPI().GetText(libkb.APIArg{Endpoint: from, MetaContext: m.MetaContext})
 		if err1 != nil {
 			return state, libkb.XapiError(err1, from)
 		}
@@ -870,7 +870,7 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 			return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 				"JSON fetch must not specify 'into' register")
 		}
-		res, err1 := g.GetExternalAPI().Get(libkb.NewAPIArgWithNetContext(g.GetNetContext(), from))
+		res, err1 := m.G().GetExternalAPI().Get(libkb.APIArg{Endpoint: from, MetaContext: m.MetaContext})
 		if err1 != nil {
 			return state, libkb.XapiError(err1, from)
 		}
@@ -884,7 +884,7 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 			return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 				"HTML fetch must not specify 'into' register")
 		}
-		res, err1 := g.GetExternalAPI().GetHTML(libkb.NewAPIArgWithNetContext(g.GetNetContext(), from))
+		res, err1 := m.G().GetExternalAPI().GetHTML(libkb.APIArg{Endpoint: from, MetaContext: m.MetaContext})
 		if err1 != nil {
 			return state, libkb.XapiError(err1, from)
 		}
@@ -899,7 +899,7 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 	}
 }
 
-func stepParseHTML(g proofContextExt, ins parseHTMLT, state scriptState) (scriptState, libkb.ProofError) {
+func stepParseHTML(m metaContext, ins parseHTMLT, state scriptState) (scriptState, libkb.ProofError) {
 	from, err := state.Regs.Get(ins.From)
 	if err != nil {
 		return state, err
@@ -917,7 +917,7 @@ func stepParseHTML(g proofContextExt, ins parseHTMLT, state scriptState) (script
 	return state, nil
 }
 
-func stepSelectorJSON(g proofContextExt, ins selectorJSONT, state scriptState) (scriptState, libkb.ProofError) {
+func stepSelectorJSON(m metaContext, ins selectorJSONT, state scriptState) (scriptState, libkb.ProofError) {
 	if state.FetchResult == nil || state.FetchResult.fetchMode != fetchModeJSON {
 		return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"Cannot use json selector with non-json fetch result")
@@ -928,7 +928,7 @@ func stepSelectorJSON(g proofContextExt, ins selectorJSONT, state scriptState) (
 			"Json selector list must contain at least 1 element")
 	}
 
-	results, perr := runSelectorJSONInner(g, state, state.FetchResult.JSON, ins.Selectors)
+	results, perr := runSelectorJSONInner(m, state, state.FetchResult.JSON, ins.Selectors)
 	if perr != nil {
 		return state, perr
 	}
@@ -942,13 +942,13 @@ func stepSelectorJSON(g proofContextExt, ins selectorJSONT, state scriptState) (
 	return state, err
 }
 
-func stepSelectorCSS(g proofContextExt, ins selectorCSST, state scriptState) (scriptState, libkb.ProofError) {
+func stepSelectorCSS(m metaContext, ins selectorCSST, state scriptState) (scriptState, libkb.ProofError) {
 	if state.FetchResult == nil || state.FetchResult.fetchMode != fetchModeHTML {
 		return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"Cannot use css selector with non-html fetch result")
 	}
 
-	selection, perr := runCSSSelectorInner(g, state.FetchResult.HTML.Selection, ins.Selectors)
+	selection, perr := runCSSSelectorInner(m, state.FetchResult.HTML.Selection, ins.Selectors)
 	if perr != nil {
 		return state, perr
 	}
@@ -977,10 +977,10 @@ func stepSelectorCSS(g proofContextExt, ins selectorCSST, state scriptState) (sc
 	return state, err
 }
 
-func stepFill(g proofContextExt, ins fillT, state scriptState) (scriptState, libkb.ProofError) {
+func stepFill(m metaContext, ins fillT, state scriptState) (scriptState, libkb.ProofError) {
 	s, err := substituteExact(ins.With, state)
 	if err != nil {
-		debugWithState(g, state, "Fill did not succeed:\n  %v\n  %v\n  %v",
+		debugWithState(m, state, "Fill did not succeed:\n  %v\n  %v\n  %v",
 			ins.With, err, ins.Into)
 		return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"Could not fill variable (%v): %v", ins.Into, err)
@@ -993,7 +993,7 @@ func stepFill(g proofContextExt, ins fillT, state scriptState) (scriptState, lib
 // Run a PVL CSS selector.
 // selectors is a list like [ "div .foo", 0, ".bar"] ].
 // Each string runs a selector, each integer runs a Eq.
-func runCSSSelectorInner(g proofContextExt, html *goquery.Selection, selectors []selectorEntryT) (*goquery.Selection, libkb.ProofError) {
+func runCSSSelectorInner(m metaContext, html *goquery.Selection, selectors []selectorEntryT) (*goquery.Selection, libkb.ProofError) {
 	if len(selectors) < 1 {
 		return nil, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"CSS selectors array must not be empty")
@@ -1021,12 +1021,12 @@ func runCSSSelectorInner(g proofContextExt, html *goquery.Selection, selectors [
 
 // Most failures here log instead of returning an error. If an error occurs, ([], nil) will be returned.
 // This is because a selector may descend into many subtrees and fail in all but one.
-func runSelectorJSONInner(g proofContextExt, state scriptState, selectedObject *jsonw.Wrapper, selectors []selectorEntryT) ([]string, libkb.ProofError) {
+func runSelectorJSONInner(m metaContext, state scriptState, selectedObject *jsonw.Wrapper, selectors []selectorEntryT) ([]string, libkb.ProofError) {
 	// The terminating condition is when we've consumed all the selectors.
 	if len(selectors) == 0 {
 		s, err := jsonStringSimple(selectedObject)
 		if err != nil {
-			debugWithState(g, state, "JSON could not read object: %v (%v)", err, selectedObject)
+			debugWithState(m, state, "JSON could not read object: %v (%v)", err, selectedObject)
 			return []string{}, nil
 		}
 		return []string{s}, nil
@@ -1039,7 +1039,7 @@ func runSelectorJSONInner(g proofContextExt, state scriptState, selectedObject *
 	case selector.IsIndex:
 		object, err := selectedObject.ToArray()
 		if err != nil {
-			debugWithState(g, state, "JSON select by index from non-array: %v (%v) (%v)", err, selector.Index, object)
+			debugWithState(m, state, "JSON select by index from non-array: %v (%v) (%v)", err, selector.Index, object)
 			return []string{}, nil
 		}
 		length, err := object.Len()
@@ -1052,25 +1052,25 @@ func runSelectorJSONInner(g proofContextExt, state scriptState, selectedObject *
 			return []string{}, nil
 		}
 		nextobject := object.AtIndex(index)
-		return runSelectorJSONInner(g, state, nextobject, nextselectors)
+		return runSelectorJSONInner(m, state, nextobject, nextselectors)
 	case selector.IsKey:
 		object, err := selectedObject.ToDictionary()
 		if err != nil {
-			debugWithState(g, state, "JSON select by key from non-map: %v (%v) (%v)", err, selector.Key, object)
+			debugWithState(m, state, "JSON select by key from non-map: %v (%v) (%v)", err, selector.Key, object)
 			return []string{}, nil
 		}
 
 		nextobject := object.AtKey(selector.Key)
-		return runSelectorJSONInner(g, state, nextobject, nextselectors)
+		return runSelectorJSONInner(m, state, nextobject, nextselectors)
 	case selector.IsAll:
 		children, err := jsonGetChildren(selectedObject)
 		if err != nil {
-			debugWithState(g, state, "JSON select could not get children: %v (%v)", err, selectedObject)
+			debugWithState(m, state, "JSON select could not get children: %v (%v)", err, selectedObject)
 			return []string{}, nil
 		}
 		var results []string
 		for _, child := range children {
-			innerresults, perr := runSelectorJSONInner(g, state, child, nextselectors)
+			innerresults, perr := runSelectorJSONInner(m, state, child, nextselectors)
 			if perr != nil {
 				return nil, perr
 			}
@@ -1084,7 +1084,7 @@ func runSelectorJSONInner(g proofContextExt, state scriptState, selectedObject *
 }
 
 // Take a regex descriptor, do variable substitution, and build a regex.
-func interpretRegex(g proofContextExt, state scriptState, rdesc regexDescriptor) (*regexp.Regexp, libkb.ProofError) {
+func interpretRegex(m metaContext, state scriptState, rdesc regexDescriptor) (*regexp.Regexp, libkb.ProofError) {
 	// Check that regex is bounded by "^" and "$".
 	if !strings.HasPrefix(rdesc.Template, "^") {
 		return nil, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
@@ -1118,7 +1118,7 @@ func interpretRegex(g proofContextExt, state scriptState, rdesc regexDescriptor)
 	// Build the regex.
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		debugWithState(g, state, "Could not compile regex: %v\n  %v\n  %v", err, rdesc.Template, pattern)
+		debugWithState(m, state, "Could not compile regex: %v\n  %v\n  %v", err, rdesc.Template, pattern)
 		return nil, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"Could not compile regex: %v (%v)", err, rdesc.Template)
 	}
@@ -1128,7 +1128,7 @@ func interpretRegex(g proofContextExt, state scriptState, rdesc regexDescriptor)
 // Use a custom error spec to derive an error.
 // spec can be none
 // Copies over the error code if none is specified.
-func replaceCustomError(g proofContextExt, state scriptState, spec *errorT, err1 libkb.ProofError) libkb.ProofError {
+func replaceCustomError(m metaContext, state scriptState, spec *errorT, err1 libkb.ProofError) libkb.ProofError {
 	if err1 == nil {
 		return err1
 	}
@@ -1149,8 +1149,8 @@ func replaceCustomError(g proofContextExt, state scriptState, spec *errorT, err1
 			newDesc = subbedDesc
 		}
 		err2 := libkb.NewProofError(spec.Status, newDesc)
-		debugWithState(g, state, "Replacing error with custom error")
-		debugWithStateError(g, state, err2)
+		debugWithState(m, state, "Replacing error with custom error")
+		debugWithStateError(m, state, err2)
 
 		return err2
 	}

--- a/go/pvl/interp_test.go
+++ b/go/pvl/interp_test.go
@@ -2087,7 +2087,8 @@ func runPvlTest(t *testing.T, unit *interpUnitTest) {
 		}
 	}
 
-	perr := CheckProof(g, pvl, unit.service, unit.proofinfo)
+	m := libkb.NewMetaContextForTest(tc)
+	perr := CheckProof(m, pvl, unit.service, unit.proofinfo)
 	if perr == nil {
 		if !unit.shouldwork {
 			fail("proof should have failed")


### PR DESCRIPTION
- retire libkb.ProofContext, since it's not compatible with the MetaContext approach