### PR TITLE
Lookup user by stellar account ID

### DIFF
--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1429,7 +1429,7 @@ func (idt *IdentityTable) GetRevokedCryptocurrencyForTesting() []CryptocurrencyC
 
 // Return the active stellar public address for a user.
 // Returns nil if there is none or it has not been loaded.
-func (idt *IdentityTable) StellarWalletAddress() *stellar1.AccountID {
+func (idt *IdentityTable) StellarAccountID() *stellar1.AccountID {
 	// Return the account ID of the latest link with the network set to stellar.
 	if idt.stellar == nil {
 		return nil

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -1405,6 +1405,10 @@ func (u *User) ExportToUPKV2AllIncarnations() (*keybase1.UserPlusKeysV2AllIncarn
 			current.RemoteTracks[track.whomUID] = track.Export()
 		}
 	}
+	if accountID := u.StellarAccountID(); accountID != nil {
+		tmp := accountID.String()
+		current.StellarAccountID = &tmp
+	}
 
 	// Collect the link IDs (that is, the hashes of the signature inputs) from all subchains.
 	linkIDs := map[keybase1.Seqno]keybase1.LinkID{}

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -450,11 +450,11 @@ func (u *User) IDTable() *IdentityTable {
 
 // Return the active stellar public address for a user.
 // Returns nil if there is none or it has not been loaded.
-func (u *User) StellarWalletAddress() *stellar1.AccountID {
+func (u *User) StellarAccountID() *stellar1.AccountID {
 	if u.idTable == nil {
 		return nil
 	}
-	return u.idTable.StellarWalletAddress()
+	return u.idTable.StellarAccountID()
 }
 
 func (u *User) sigChain() *SigChain {

--- a/go/protocol/keybase1/upk.go
+++ b/go/protocol/keybase1/upk.go
@@ -299,15 +299,16 @@ func (o PublicKeyV2) DeepCopy() PublicKeyV2 {
 }
 
 type UserPlusKeysV2 struct {
-	Uid          UID                           `codec:"uid" json:"uid"`
-	Username     string                        `codec:"username" json:"username"`
-	EldestSeqno  Seqno                         `codec:"eldestSeqno" json:"eldestSeqno"`
-	Status       StatusCode                    `codec:"status" json:"status"`
-	PerUserKeys  []PerUserKey                  `codec:"perUserKeys" json:"perUserKeys"`
-	DeviceKeys   map[KID]PublicKeyV2NaCl       `codec:"deviceKeys" json:"deviceKeys"`
-	PGPKeys      map[KID]PublicKeyV2PGPSummary `codec:"pgpKeys" json:"pgpKeys"`
-	RemoteTracks map[UID]RemoteTrack           `codec:"remoteTracks" json:"remoteTracks"`
-	Reset        *ResetSummary                 `codec:"reset,omitempty" json:"reset,omitempty"`
+	Uid              UID                           `codec:"uid" json:"uid"`
+	Username         string                        `codec:"username" json:"username"`
+	EldestSeqno      Seqno                         `codec:"eldestSeqno" json:"eldestSeqno"`
+	Status           StatusCode                    `codec:"status" json:"status"`
+	PerUserKeys      []PerUserKey                  `codec:"perUserKeys" json:"perUserKeys"`
+	DeviceKeys       map[KID]PublicKeyV2NaCl       `codec:"deviceKeys" json:"deviceKeys"`
+	PGPKeys          map[KID]PublicKeyV2PGPSummary `codec:"pgpKeys" json:"pgpKeys"`
+	StellarAccountID *string                       `codec:"stellarAccountID,omitempty" json:"stellarAccountID,omitempty"`
+	RemoteTracks     map[UID]RemoteTrack           `codec:"remoteTracks" json:"remoteTracks"`
+	Reset            *ResetSummary                 `codec:"reset,omitempty" json:"reset,omitempty"`
 }
 
 func (o UserPlusKeysV2) DeepCopy() UserPlusKeysV2 {
@@ -351,6 +352,13 @@ func (o UserPlusKeysV2) DeepCopy() UserPlusKeysV2 {
 			}
 			return ret
 		})(o.PGPKeys),
+		StellarAccountID: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.StellarAccountID),
 		RemoteTracks: (func(x map[UID]RemoteTrack) map[UID]RemoteTrack {
 			if x == nil {
 				return nil

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -297,7 +297,7 @@ func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput) (res 
 		return res, err
 	}
 	res.User = user
-	accountID := user.StellarWalletAddress()
+	accountID := user.StellarAccountID()
 	if accountID == nil {
 		return res, nil
 	}
@@ -1139,4 +1139,63 @@ func MakeRequest(m libkb.MetaContext, remoter remote.Remoter, arg MakeRequestArg
 	err = m.G().ChatHelper.SendMsgByName(m.Ctx(), displayName, nil,
 		membersType, keybase1.TLFIdentifyBehavior_CHAT_SKIP, body, chat1.MessageType_REQUESTPAYMENT)
 	return requestID, err
+}
+
+// Lookup a user who has the stellar account ID.
+// Verifies the result against the user's sigchain.
+// If there are multiple users, returns an arbitrary one.
+func LookupUserByAccountID(m libkb.MetaContext, accountID stellar1.AccountID) (uv keybase1.UserVersion, err error) {
+	defer m.CTraceTimed(fmt.Sprintf("Stellar.LookupUserByAccount(%v)", accountID), func() error { return err })()
+	usersUnverified, err := remote.LookupUnverified(m.Ctx(), m.G(), accountID)
+	if err != nil {
+		return uv, err
+	}
+	m.CDebugf("got %v unverified results", len(usersUnverified))
+	for i, uv := range usersUnverified {
+		m.CDebugf("usersUnverified[%v] = %v", i, uv)
+	}
+	if len(usersUnverified) == 0 {
+		return uv, libkb.NotFoundError{Msg: fmt.Sprintf("No user found with account %v", accountID)}
+	}
+	uv = usersUnverified[0]
+	verify := func(forcePoll bool) (retry bool, err error) {
+		defer m.CTraceTimed(fmt.Sprintf("verify(forcePoll:%v, accountID:%v, uv:%v)", forcePoll, accountID, uv), func() error { return err })()
+		upak, _, err := m.G().GetUPAKLoader().LoadV2(
+			libkb.NewLoadUserArgWithMetaContext(m).WithPublicKeyOptional().WithUID(uv.Uid).WithForcePoll(forcePoll))
+		if err != nil {
+			return false, err
+		}
+		genericErr := errors.New("error verifying account lookup")
+		if !upak.Current.EldestSeqno.Eq(uv.EldestSeqno) {
+			m.CDebugf("user %v's eldest seqno did not match %v != %v", upak.Current.Username, upak.Current.EldestSeqno, uv.EldestSeqno)
+			return true, genericErr
+		}
+		if upak.Current.StellarAccountID == nil {
+			m.CDebugf("user %v has no stellar account", upak.Current.Username)
+			return true, genericErr
+		}
+		unverifiedAccountID, err := libkb.ParseStellarAccountID(*upak.Current.StellarAccountID)
+		if err != nil {
+			m.CDebugf("user has invalid account ID '%v': %v", *upak.Current.StellarAccountID, err)
+			return false, genericErr
+		}
+		if !unverifiedAccountID.Eq(accountID) {
+			m.CDebugf("user %v has different account %v != %v", upak.Current.Username, unverifiedAccountID, accountID)
+			return true, genericErr
+		}
+		return false, nil
+	}
+	retry, err := verify(false)
+	if err == nil {
+		return uv, err
+	}
+	if !retry {
+		return keybase1.UserVersion{}, err
+	}
+	// Try again with ForcePoll in case the previous attempt lost a race.
+	_, err = verify(true)
+	if err != nil {
+		return keybase1.UserVersion{}, err
+	}
+	return uv, err
 }

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -299,7 +299,7 @@ func TestSetAccountAsDefault(t *testing.T) {
 	// public Stellar address as another user.
 	u0, err := tcs[1].G.LoadUserByUID(tcs[0].Fu.User.GetUID())
 	require.NoError(t, err)
-	u0addr := u0.StellarWalletAddress()
+	u0addr := u0.StellarAccountID()
 	require.NotNil(t, u0addr)
 	require.Equal(t, additionalAccs[0], *u0addr)
 }

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -72,7 +72,7 @@ func (t *txlogger) Filter(ctx context.Context, tc *TestContext, accountID stella
 		WithNetContext(ctx)
 	user, err := libkb.LoadUser(loadMeArg)
 	require.NoError(t.T, err)
-	myAccountID := user.StellarWalletAddress()
+	myAccountID := user.StellarAccountID()
 	if myAccountID != nil {
 		callerAccountID = *myAccountID
 	}

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -45,6 +45,12 @@ func TestCreateWallet(t *testing.T) {
 	tcs, cleanup := setupTestsWithSettings(t, []usetting{usettingWalletless, usettingFull})
 	defer cleanup()
 
+	t.Logf("Lookup for a bogus address")
+	uv, err := stellar.LookupUserByAccountID(tcs[0].MetaContext(), "GCCJJFCRCQAWDWRAZ3R6235KCQ4PQYE5KEWHGE5ICVTZLTMRKVWAWP7N")
+	require.Error(t, err)
+	require.IsType(t, libkb.NotFoundError{}, err)
+
+	t.Logf("Create an initial wallet")
 	created, err := stellar.CreateWallet(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	require.True(t, created)
@@ -66,15 +72,43 @@ func TestCreateWallet(t *testing.T) {
 	require.Len(t, bundle.Accounts[0].Signers, 1)
 	require.Equal(t, "", bundle.Accounts[0].Name)
 
-	t.Logf("Lookup the public stellar address as another user")
+	t.Logf("Lookup the user by public address as another user")
+	a1 := bundle.Accounts[0].AccountID
+	uv, err = stellar.LookupUserByAccountID(tcs[1].MetaContext(), a1)
+	require.NoError(t, err)
+	require.Equal(t, tcs[0].Fu.GetUserVersion(), uv)
+	t.Logf("and as self")
+	uv, err = stellar.LookupUserByAccountID(tcs[0].MetaContext(), a1)
+	require.NoError(t, err)
+	require.Equal(t, tcs[0].Fu.GetUserVersion(), uv)
+
+	t.Logf("Lookup the address by user as another user")
 	u0, err := tcs[1].G.LoadUserByUID(tcs[0].G.ActiveDevice.UID())
 	require.NoError(t, err)
-	addr := u0.StellarWalletAddress()
+	addr := u0.StellarAccountID()
 	t.Logf("Found account: %v", addr)
 	require.NotNil(t, addr)
 	_, err = libkb.MakeNaclSigningKeyPairFromStellarAccountID(*addr)
 	require.NoError(t, err, "stellar key should be nacl pubable")
 	require.Equal(t, bundle.Accounts[0].AccountID.String(), addr.String(), "addr looked up should match secret bundle")
+
+	t.Logf("Change primary accounts")
+	a2, s2 := randomStellarKeypair()
+	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
+		SecretKey:   s2,
+		MakePrimary: true,
+	})
+	require.NoError(t, err)
+
+	t.Logf("Lookup by the new primary")
+	uv, err = stellar.LookupUserByAccountID(tcs[1].MetaContext(), a2)
+	require.NoError(t, err)
+	require.Equal(t, tcs[0].Fu.GetUserVersion(), uv)
+
+	t.Logf("Looking up by the old address no longer works")
+	uv, err = stellar.LookupUserByAccountID(tcs[1].MetaContext(), a1)
+	require.Error(t, err)
+	require.IsType(t, libkb.NotFoundError{}, err)
 }
 
 func TestUpkeep(t *testing.T) {
@@ -188,7 +222,7 @@ func TestImportExport(t *testing.T) {
 
 	u0, err := tcs[1].G.LoadUserByUID(tcs[0].G.ActiveDevice.UID())
 	require.NoError(t, err)
-	addr := u0.StellarWalletAddress()
+	addr := u0.StellarAccountID()
 	require.False(t, a1.Eq(*addr))
 
 	a2, s2 := randomStellarKeypair()
@@ -205,7 +239,7 @@ func TestImportExport(t *testing.T) {
 
 	u0, err = tcs[1].G.LoadUserByUID(tcs[0].G.ActiveDevice.UID())
 	require.NoError(t, err)
-	addr = u0.StellarWalletAddress()
+	addr = u0.StellarAccountID()
 	require.False(t, a1.Eq(*addr))
 
 	err = srv.ImportSecretKeyLocal(context.Background(), argS2)
@@ -689,6 +723,10 @@ type TestContext struct {
 	Fu      *kbtest.FakeUser
 	Srv     *Server
 	Backend *BackendMock
+}
+
+func (tc *TestContext) MetaContext() libkb.MetaContext {
+	return libkb.NewMetaContextForTest(tc.TestContext)
 }
 
 // Create n TestContexts with logged in users

--- a/protocol/avdl/keybase1/upk.avdl
+++ b/protocol/avdl/keybase1/upk.avdl
@@ -83,6 +83,7 @@ protocol UPK {
       array<PerUserKey> perUserKeys;
       map<KID, PublicKeyV2NaCl> deviceKeys;
       map<KID, PublicKeyV2PGPSummary> pgpKeys;
+      union { null, string } stellarAccountID;
       map<UID, RemoteTrack> remoteTracks;
       union { null, ResetSummary } reset;
   }

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -2282,7 +2282,7 @@ export type UserOrTeamResult =
 
 export type UserPlusAllKeys = $ReadOnly<{base: UserPlusKeys, pgpKeys?: ?Array<PublicKey>, remoteTracks?: ?Array<RemoteTrack>}>
 export type UserPlusKeys = $ReadOnly<{uid: UID, username: String, eldestSeqno: Seqno, status: StatusCode, deviceKeys?: ?Array<PublicKey>, revokedDeviceKeys?: ?Array<RevokedKey>, pgpKeyCount: Int, uvv: UserVersionVector, deletedDeviceKeys?: ?Array<PublicKey>, perUserKeys?: ?Array<PerUserKey>, resets?: ?Array<ResetSummary>}>
-export type UserPlusKeysV2 = $ReadOnly<{uid: UID, username: String, eldestSeqno: Seqno, status: StatusCode, perUserKeys?: ?Array<PerUserKey>, deviceKeys: {[key: string]: PublicKeyV2NaCl}, pgpKeys: {[key: string]: PublicKeyV2PGPSummary}, remoteTracks: {[key: string]: RemoteTrack}, reset?: ?ResetSummary}>
+export type UserPlusKeysV2 = $ReadOnly<{uid: UID, username: String, eldestSeqno: Seqno, status: StatusCode, perUserKeys?: ?Array<PerUserKey>, deviceKeys: {[key: string]: PublicKeyV2NaCl}, pgpKeys: {[key: string]: PublicKeyV2PGPSummary}, stellarAccountID?: ?String, remoteTracks: {[key: string]: RemoteTrack}, reset?: ?ResetSummary}>
 export type UserPlusKeysV2AllIncarnations = $ReadOnly<{current: UserPlusKeysV2, pastIncarnations?: ?Array<UserPlusKeysV2>, uvv: UserVersionVector, seqnoLinkIDs: {[key: string]: LinkID}, minorVersion: UPK2MinorVersion}>
 export type UserProfileEditRpcParam = $ReadOnly<{fullName: String, location: String, bio: String}>
 export type UserResolution = $ReadOnly<{assertion: SocialAssertion, userID: UID}>

--- a/protocol/json/keybase1/upk.json
+++ b/protocol/json/keybase1/upk.json
@@ -263,6 +263,13 @@
           "name": "pgpKeys"
         },
         {
+          "type": [
+            null,
+            "string"
+          ],
+          "name": "stellarAccountID"
+        },
+        {
           "type": {
             "type": "map",
             "values": "RemoteTrack",

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -2282,7 +2282,7 @@ export type UserOrTeamResult =
 
 export type UserPlusAllKeys = $ReadOnly<{base: UserPlusKeys, pgpKeys?: ?Array<PublicKey>, remoteTracks?: ?Array<RemoteTrack>}>
 export type UserPlusKeys = $ReadOnly<{uid: UID, username: String, eldestSeqno: Seqno, status: StatusCode, deviceKeys?: ?Array<PublicKey>, revokedDeviceKeys?: ?Array<RevokedKey>, pgpKeyCount: Int, uvv: UserVersionVector, deletedDeviceKeys?: ?Array<PublicKey>, perUserKeys?: ?Array<PerUserKey>, resets?: ?Array<ResetSummary>}>
-export type UserPlusKeysV2 = $ReadOnly<{uid: UID, username: String, eldestSeqno: Seqno, status: StatusCode, perUserKeys?: ?Array<PerUserKey>, deviceKeys: {[key: string]: PublicKeyV2NaCl}, pgpKeys: {[key: string]: PublicKeyV2PGPSummary}, remoteTracks: {[key: string]: RemoteTrack}, reset?: ?ResetSummary}>
+export type UserPlusKeysV2 = $ReadOnly<{uid: UID, username: String, eldestSeqno: Seqno, status: StatusCode, perUserKeys?: ?Array<PerUserKey>, deviceKeys: {[key: string]: PublicKeyV2NaCl}, pgpKeys: {[key: string]: PublicKeyV2PGPSummary}, stellarAccountID?: ?String, remoteTracks: {[key: string]: RemoteTrack}, reset?: ?ResetSummary}>
 export type UserPlusKeysV2AllIncarnations = $ReadOnly<{current: UserPlusKeysV2, pastIncarnations?: ?Array<UserPlusKeysV2>, uvv: UserVersionVector, seqnoLinkIDs: {[key: string]: LinkID}, minorVersion: UPK2MinorVersion}>
 export type UserProfileEditRpcParam = $ReadOnly<{fullName: String, location: String, bio: String}>
 export type UserResolution = $ReadOnly<{assertion: SocialAssertion, userID: UID}>


### PR DESCRIPTION
Store `union { null, string } stellarAccountID` on `UserPlusKeysV2`, which is from sigchain parsing. Use that to verify server lookups. This value may be wrong in the cache for clients that upgrade in the future, causing lookups to fail. I think experiencing that bug later might be better than busting the cache now.