### PR TITLE
fix updateAllSupersededBy

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1387,7 +1387,7 @@ func (h *Server) getMessage(ctx context.Context, uid gregor1.UID, convID chat1.C
 
 	}
 	if len(messages) != 1 || !messages[0].IsValid() {
-		return mvalid, fmt.Errorf("GetMessages returned multiple messages or an invalid result for msgID: %v", msgID)
+		return mvalid, fmt.Errorf("getMessage returned multiple messages or an invalid result for msgID: %v, numMsgs: %v", msgID, len(messages))
 	}
 	return messages[0].Valid(), nil
 }

--- a/go/chat/storage/storage_ephemeral_purge_tracker.go
+++ b/go/chat/storage/storage_ephemeral_purge_tracker.go
@@ -203,3 +203,7 @@ func (t *ephemeralTracker) inactivatePurgeInfo(ctx context.Context,
 	}
 	return err
 }
+
+func (t *ephemeralTracker) clear(uid gregor1.UID) error {
+	return t.G().LocalChatDb.Delete(t.makeDbKey(uid))
+}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -500,7 +500,8 @@ func GetSupersedes(msg chat1.MessageUnboxed) ([]chat1.MessageID, error) {
 		return nil, err
 	}
 
-	// We use the message ID in the body over the field in the client header to avoid server trust.
+	// We use the message ID in the body over the field in the client header to
+	// avoid server trust.
 	switch typ {
 	case chat1.MessageType_EDIT:
 		return []chat1.MessageID{msg.Valid().MessageBody.Edit().MessageID}, nil


### PR DESCRIPTION
@buoyad ran into a bug where he had set the target msg id for a reaction to `0` this caused a bug in `updateAllSupersededBy` throwing ` Storage: MergeHelper -> ERROR: internal chat storage error: getBlock: invalid block id: 0`. This PR just skips these messages since they aren't valid but also cleans up the storage code to make future debugging easier