### PR TITLE
switch avatars over to MetaContext

### DIFF
--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -231,7 +231,6 @@ func (c *FullCachingSource) removeFile(m libkb.MetaContext, ent *lru.DiskLRUEntr
 
 func (c *FullCachingSource) populateCacheWorker(m libkb.MetaContext) {
 	for arg := range c.populateCacheCh {
-		m := libkb.NewMetaContextBackground(m.G())
 		c.debug(m, "populateCacheWorker: fetching: name: %s format: %s url: %s", arg.name,
 			arg.format, arg.url)
 		// Grab image data first

--- a/go/avatars/fullcaching_test.go
+++ b/go/avatars/fullcaching_test.go
@@ -35,13 +35,12 @@ func TestAvatarsFullCaching(t *testing.T) {
 	a, _ := testSrv.Addr()
 	testSrvAddr := fmt.Sprintf("http://%s/p", a)
 	tc.G.API = newAvatarMockAPI(makeHandler(testSrvAddr, cb))
-	source := NewFullCachingSource(tc.G, time.Hour, 10)
+	m := libkb.NewMetaContextForTest(tc)
+	source := NewFullCachingSource(time.Hour, 10)
 	source.populateSuccessCh = make(chan struct{}, 5)
 	source.tempDir = os.TempDir()
-	source.StartBackgroundTasks()
-	defer source.StopBackgroundTasks()
-
-	m := libkb.NewMetaContextForTest(tc)
+	source.StartBackgroundTasks(m)
+	defer source.StopBackgroundTasks(m)
 
 	t.Logf("first blood")
 	res, err := source.LoadUsers(m, []string{"mike"}, []keybase1.AvatarFormat{"square"})

--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -1,7 +1,6 @@
 package avatars
 
 import (
-	"context"
 	"time"
 
 	"github.com/keybase/client/go/libkb"
@@ -9,11 +8,11 @@ import (
 )
 
 type Source interface {
-	LoadUsers(context.Context, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)
-	LoadTeams(context.Context, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)
+	LoadUsers(libkb.MetaContext, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)
+	LoadTeams(libkb.MetaContext, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)
 
-	ClearCacheForName(context.Context, string, []keybase1.AvatarFormat) error
-	OnCacheCleared(context.Context) // Called after leveldb data goes away after db nuke
+	ClearCacheForName(libkb.MetaContext, string, []keybase1.AvatarFormat) error
+	OnCacheCleared(libkb.MetaContext) // Called after leveldb data goes away after db nuke
 
 	StartBackgroundTasks()
 	StopBackgroundTasks()

--- a/go/avatars/simple.go
+++ b/go/avatars/simple.go
@@ -1,7 +1,6 @@
 package avatars
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -45,19 +44,19 @@ func (s *SimpleSource) api() libkb.API {
 	return s.G().API
 }
 
-func (s *SimpleSource) apiReq(ctx context.Context, endpoint, param string, names []string,
+func (s *SimpleSource) apiReq(m libkb.MetaContext, endpoint, param string, names []string,
 	formats []keybase1.AvatarFormat) (apiAvatarRes, error) {
-	arg := libkb.NewAPIArgWithNetContext(ctx, endpoint)
+	arg := libkb.NewAPIArgWithMetaContext(m, endpoint)
 	arg.Args = libkb.NewHTTPArgs()
 	arg.SessionType = libkb.APISessionTypeOPTIONAL
 	uarg := strings.Join(names, ",")
 	farg := s.formatArg(formats)
 	arg.Args.Add(param, libkb.S{Val: uarg})
 	arg.Args.Add("formats", libkb.S{Val: farg})
-	s.debug(ctx, "issuing %s avatar req: uarg: %s farg: %s", param, uarg, farg)
+	s.debug(m, "issuing %s avatar req: uarg: %s farg: %s", param, uarg, farg)
 	var apiRes apiAvatarRes
 	if err := s.api().GetDecode(arg, &apiRes); err != nil {
-		s.debug(ctx, "apiReq: API fail: %s", err)
+		s.debug(m, "apiReq: API fail: %s", err)
 		return apiRes, err
 	}
 	return apiRes, nil
@@ -78,13 +77,13 @@ func (s *SimpleSource) makeRes(res *keybase1.LoadAvatarsRes, apiRes apiAvatarRes
 	return nil
 }
 
-func (s *SimpleSource) debug(ctx context.Context, msg string, args ...interface{}) {
-	s.G().Log.CDebugf(ctx, "Avatars.SimpleSource: %s", fmt.Sprintf(msg, args...))
+func (s *SimpleSource) debug(m libkb.MetaContext, msg string, args ...interface{}) {
+	m.CDebugf("Avatars.SimpleSource: %s", fmt.Sprintf(msg, args...))
 }
 
-func (s *SimpleSource) LoadUsers(ctx context.Context, usernames []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
-	defer s.G().Trace("SimpleSource.LoadUsers", func() error { return err })()
-	apiRes, err := s.apiReq(ctx, "image/username_pic_lookups", "usernames", usernames, formats)
+func (s *SimpleSource) LoadUsers(m libkb.MetaContext, usernames []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
+	defer m.CTrace("SimpleSource.LoadUsers", func() error { return err })()
+	apiRes, err := s.apiReq(m, "image/username_pic_lookups", "usernames", usernames, formats)
 	if err != nil {
 		return res, err
 	}
@@ -94,9 +93,9 @@ func (s *SimpleSource) LoadUsers(ctx context.Context, usernames []string, format
 	return res, nil
 }
 
-func (s *SimpleSource) LoadTeams(ctx context.Context, teams []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
-	defer s.G().Trace("SimpleSource.LoadTeams", func() error { return err })()
-	apiRes, err := s.apiReq(ctx, "image/team_avatar_lookups", "team_names", teams, formats)
+func (s *SimpleSource) LoadTeams(m libkb.MetaContext, teams []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
+	defer m.CTrace("SimpleSource.LoadTeams", func() error { return err })()
+	apiRes, err := s.apiReq(m, "image/team_avatar_lookups", "team_names", teams, formats)
 	if err != nil {
 		return res, err
 	}
@@ -106,8 +105,8 @@ func (s *SimpleSource) LoadTeams(ctx context.Context, teams []string, formats []
 	return res, nil
 }
 
-func (s *SimpleSource) ClearCacheForName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
+func (s *SimpleSource) ClearCacheForName(m libkb.MetaContext, name string, formats []keybase1.AvatarFormat) (err error) {
 	return nil
 }
 
-func (s *SimpleSource) OnCacheCleared(ctx context.Context) {}
+func (s *SimpleSource) OnCacheCleared(m libkb.MetaContext) {}

--- a/go/avatars/simple.go
+++ b/go/avatars/simple.go
@@ -17,20 +17,16 @@ func (a apiAvatarRes) GetAppStatus() *libkb.AppStatus {
 	return &a.Status
 }
 
-type SimpleSource struct {
-	libkb.Contextified
-}
+type SimpleSource struct{}
 
-func NewSimpleSource(g *libkb.GlobalContext) *SimpleSource {
-	return &SimpleSource{
-		Contextified: libkb.NewContextified(g),
-	}
+func NewSimpleSource() *SimpleSource {
+	return &SimpleSource{}
 }
 
 var _ Source = (*SimpleSource)(nil)
 
-func (s *SimpleSource) StartBackgroundTasks() {}
-func (s *SimpleSource) StopBackgroundTasks()  {}
+func (s *SimpleSource) StartBackgroundTasks(_ libkb.MetaContext) {}
+func (s *SimpleSource) StopBackgroundTasks(_ libkb.MetaContext)  {}
 
 func (s *SimpleSource) formatArg(formats []keybase1.AvatarFormat) string {
 	var strs []string
@@ -38,10 +34,6 @@ func (s *SimpleSource) formatArg(formats []keybase1.AvatarFormat) string {
 		strs = append(strs, f.String())
 	}
 	return strings.Join(strs, ",")
-}
-
-func (s *SimpleSource) api() libkb.API {
-	return s.G().API
 }
 
 func (s *SimpleSource) apiReq(m libkb.MetaContext, endpoint, param string, names []string,
@@ -55,7 +47,7 @@ func (s *SimpleSource) apiReq(m libkb.MetaContext, endpoint, param string, names
 	arg.Args.Add("formats", libkb.S{Val: farg})
 	s.debug(m, "issuing %s avatar req: uarg: %s farg: %s", param, uarg, farg)
 	var apiRes apiAvatarRes
-	if err := s.api().GetDecode(arg, &apiRes); err != nil {
+	if err := m.G().API.GetDecode(arg, &apiRes); err != nil {
 		s.debug(m, "apiReq: API fail: %s", err)
 		return apiRes, err
 	}

--- a/go/avatars/urlcaching.go
+++ b/go/avatars/urlcaching.go
@@ -40,8 +40,8 @@ func (c *URLCachingSource) StopBackgroundTasks() {
 	c.diskLRU.Flush(context.Background(), c.G())
 }
 
-func (c *URLCachingSource) debug(ctx context.Context, msg string, args ...interface{}) {
-	c.G().Log.CDebugf(ctx, "Avatars.URLCachingSource: %s", fmt.Sprintf(msg, args...))
+func (c *URLCachingSource) debug(m libkb.MetaContext, msg string, args ...interface{}) {
+	m.CDebugf("Avatars.URLCachingSource: %s", fmt.Sprintf(msg, args...))
 }
 
 func (c *URLCachingSource) avatarKey(name string, format keybase1.AvatarFormat) string {
@@ -53,24 +53,24 @@ func (c *URLCachingSource) isStale(item lru.DiskLRUEntry) bool {
 }
 
 func (c *URLCachingSource) monitorAppState() {
-	c.debug(context.Background(), "monitorAppState: starting up")
+	m := libkb.NewMetaContextBackground(c.G())
+	c.debug(m, "monitorAppState: starting up")
 	state := keybase1.AppState_FOREGROUND
 	for {
 		state = <-c.G().AppState.NextUpdate(&state)
-		ctx := context.Background()
 		switch state {
 		case keybase1.AppState_BACKGROUND:
-			c.debug(ctx, "monitorAppState: backgrounded")
-			c.diskLRU.Flush(ctx, c.G())
+			c.debug(m, "monitorAppState: backgrounded")
+			c.diskLRU.Flush(m.Ctx(), m.G())
 		}
 	}
 }
 
-func (c *URLCachingSource) specLoad(ctx context.Context, names []string, formats []keybase1.AvatarFormat) (res avatarLoadSpec, err error) {
+func (c *URLCachingSource) specLoad(m libkb.MetaContext, names []string, formats []keybase1.AvatarFormat) (res avatarLoadSpec, err error) {
 	for _, name := range names {
 		for _, format := range formats {
 			key := c.avatarKey(name, format)
-			found, entry, err := c.diskLRU.Get(ctx, c.G(), key)
+			found, entry, err := c.diskLRU.Get(m.Ctx(), c.G(), key)
 			if err != nil {
 				return res, err
 			}
@@ -101,23 +101,23 @@ func (c *URLCachingSource) mergeRes(res *keybase1.LoadAvatarsRes, m keybase1.Loa
 	}
 }
 
-func (c *URLCachingSource) commitURLs(ctx context.Context, res keybase1.LoadAvatarsRes) {
+func (c *URLCachingSource) commitURLs(m libkb.MetaContext, res keybase1.LoadAvatarsRes) {
 	for name, rec := range res.Picmap {
 		for format, url := range rec {
-			if _, err := c.diskLRU.Put(ctx, c.G(), c.avatarKey(name, format), url); err != nil {
-				c.debug(ctx, "commitURLs: failed to save URL: url: %s err: %s", url, err)
+			if _, err := c.diskLRU.Put(m.Ctx(), c.G(), c.avatarKey(name, format), url); err != nil {
+				c.debug(m, "commitURLs: failed to save URL: url: %s err: %s", url, err)
 			}
 		}
 	}
 }
 
-func (c *URLCachingSource) loadNames(ctx context.Context, names []string, formats []keybase1.AvatarFormat,
-	remoteFetch func(context.Context, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)) (res keybase1.LoadAvatarsRes, err error) {
-	loadSpec, err := c.specLoad(ctx, names, formats)
+func (c *URLCachingSource) loadNames(m libkb.MetaContext, names []string, formats []keybase1.AvatarFormat,
+	remoteFetch func(libkb.MetaContext, []string, []keybase1.AvatarFormat) (keybase1.LoadAvatarsRes, error)) (res keybase1.LoadAvatarsRes, err error) {
+	loadSpec, err := c.specLoad(m, names, formats)
 	if err != nil {
 		return res, err
 	}
-	c.debug(ctx, "loadNames: hits: %d stales: %d misses: %d", len(loadSpec.hits), len(loadSpec.stales),
+	c.debug(m, "loadNames: hits: %d stales: %d misses: %d", len(loadSpec.hits), len(loadSpec.stales),
 		len(loadSpec.misses))
 
 	// Fill in the hits
@@ -133,25 +133,26 @@ func (c *URLCachingSource) loadNames(ctx context.Context, names []string, format
 	// Go get the misses
 	missNames, missFormats := loadSpec.missDetails()
 	if len(missNames) > 0 {
-		loadRes, err := remoteFetch(ctx, missNames, missFormats)
+		loadRes, err := remoteFetch(m, missNames, missFormats)
 		if err == nil {
-			c.commitURLs(ctx, loadRes)
+			c.commitURLs(m, loadRes)
 			c.mergeRes(&res, loadRes)
 		} else {
-			c.debug(ctx, "loadNames: failed to load server miss reqs: %s", err)
+			c.debug(m, "loadNames: failed to load server miss reqs: %s", err)
 		}
 	}
 	// Spawn off a goroutine to reload stales
 	staleNames, staleFormats := loadSpec.staleDetails()
 	if len(staleNames) > 0 {
 		go func() {
-			c.debug(context.Background(), "loadNames: spawning stale background load: names: %d",
+			m = m.BackgroundWithLogTags()
+			c.debug(m, "loadNames: spawning stale background load: names: %d",
 				len(staleNames))
-			loadRes, err := remoteFetch(context.Background(), staleNames, staleFormats)
+			loadRes, err := remoteFetch(m, staleNames, staleFormats)
 			if err != nil {
-				c.debug(ctx, "loadNames: failed to load server stale reqs: %s", err)
+				c.debug(m, "loadNames: failed to load server stale reqs: %s", err)
 			} else {
-				c.commitURLs(ctx, loadRes)
+				c.commitURLs(m, loadRes)
 			}
 			if c.staleFetchCh != nil {
 				c.staleFetchCh <- struct{}{}
@@ -161,29 +162,29 @@ func (c *URLCachingSource) loadNames(ctx context.Context, names []string, format
 	return res, nil
 }
 
-func (c *URLCachingSource) clearName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
+func (c *URLCachingSource) clearName(m libkb.MetaContext, name string, formats []keybase1.AvatarFormat) (err error) {
 	for _, format := range formats {
 		key := c.avatarKey(name, format)
-		if err := c.diskLRU.Remove(ctx, c.G(), key); err != nil {
+		if err := c.diskLRU.Remove(m.Ctx(), c.G(), key); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (c *URLCachingSource) LoadUsers(ctx context.Context, usernames []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
-	defer c.G().Trace("URLCachingSource.LoadUsers", func() error { return err })()
-	return c.loadNames(ctx, usernames, formats, c.simpleSource.LoadUsers)
+func (c *URLCachingSource) LoadUsers(m libkb.MetaContext, usernames []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
+	defer m.CTrace("URLCachingSource.LoadUsers", func() error { return err })()
+	return c.loadNames(m, usernames, formats, c.simpleSource.LoadUsers)
 }
 
-func (c *URLCachingSource) LoadTeams(ctx context.Context, teams []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
-	defer c.G().Trace("URLCachingSource.LoadTeams", func() error { return err })()
-	return c.loadNames(ctx, teams, formats, c.simpleSource.LoadTeams)
+func (c *URLCachingSource) LoadTeams(m libkb.MetaContext, teams []string, formats []keybase1.AvatarFormat) (res keybase1.LoadAvatarsRes, err error) {
+	defer m.CTrace("URLCachingSource.LoadTeams", func() error { return err })()
+	return c.loadNames(m, teams, formats, c.simpleSource.LoadTeams)
 }
 
-func (c *URLCachingSource) ClearCacheForName(ctx context.Context, name string, formats []keybase1.AvatarFormat) (err error) {
-	defer c.G().Trace(fmt.Sprintf("URLCachingSource.ClearCacheForUser(%s,%v)", name, formats), func() error { return err })()
-	return c.clearName(ctx, name, formats)
+func (c *URLCachingSource) ClearCacheForName(m libkb.MetaContext, name string, formats []keybase1.AvatarFormat) (err error) {
+	defer m.CTrace(fmt.Sprintf("URLCachingSource.ClearCacheForUser(%s,%v)", name, formats), func() error { return err })()
+	return c.clearName(m, name, formats)
 }
 
-func (c *URLCachingSource) OnCacheCleared(ctx context.Context) {}
+func (c *URLCachingSource) OnCacheCleared(m libkb.MetaContext) {}

--- a/go/avatars/urlcaching_test.go
+++ b/go/avatars/urlcaching_test.go
@@ -1,7 +1,6 @@
 package avatars
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -42,14 +41,14 @@ func TestAvatarsURLCaching(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	tc.G.SetClock(clock)
 
-	ctx := context.TODO()
 	cb := make(chan struct{}, 5)
 
 	tc.G.API = newAvatarMockAPI(makeHandler("url", cb))
 	source := NewURLCachingSource(tc.G, time.Hour, 10)
 
 	t.Logf("API server fetch")
-	res, err := source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	m := libkb.NewMetaContextForTest(tc)
+	res, err := source.LoadUsers(m, []string{"mike"}, []keybase1.AvatarFormat{"square"})
 	require.NoError(t, err)
 	require.Equal(t, "url", res.Picmap["mike"]["square"].String())
 	select {
@@ -58,7 +57,7 @@ func TestAvatarsURLCaching(t *testing.T) {
 		require.Fail(t, "no API call")
 	}
 	t.Logf("cache fetch")
-	res, err = source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	res, err = source.LoadUsers(m, []string{"mike"}, []keybase1.AvatarFormat{"square"})
 	require.NoError(t, err)
 	require.Equal(t, "url", res.Picmap["mike"]["square"].String())
 	select {
@@ -71,7 +70,7 @@ func TestAvatarsURLCaching(t *testing.T) {
 	source.staleFetchCh = make(chan struct{}, 5)
 	clock.Advance(2 * time.Hour)
 	tc.G.API = newAvatarMockAPI(makeHandler("url2", cb))
-	res, err = source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	res, err = source.LoadUsers(m, []string{"mike"}, []keybase1.AvatarFormat{"square"})
 	require.NoError(t, err)
 	require.Equal(t, "url", res.Picmap["mike"]["square"].String())
 	select {
@@ -84,7 +83,7 @@ func TestAvatarsURLCaching(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no stale fetch")
 	}
-	res, err = source.LoadUsers(ctx, []string{"mike"}, []keybase1.AvatarFormat{"square"})
+	res, err = source.LoadUsers(m, []string{"mike"}, []keybase1.AvatarFormat{"square"})
 	require.NoError(t, err)
 	require.Equal(t, "url2", res.Picmap["mike"]["square"].String())
 	select {

--- a/go/avatars/urlcaching_test.go
+++ b/go/avatars/urlcaching_test.go
@@ -44,7 +44,7 @@ func TestAvatarsURLCaching(t *testing.T) {
 	cb := make(chan struct{}, 5)
 
 	tc.G.API = newAvatarMockAPI(makeHandler("url", cb))
-	source := NewURLCachingSource(tc.G, time.Hour, 10)
+	source := NewURLCachingSource(time.Hour, 10)
 
 	t.Logf("API server fetch")
 	m := libkb.NewMetaContextForTest(tc)

--- a/go/libkb/apiarg.go
+++ b/go/libkb/apiarg.go
@@ -52,6 +52,13 @@ func NewAPIArgWithNetContext(ctx context.Context, endpoint string) APIArg {
 	}
 }
 
+func NewAPIArgWithMetaContext(m MetaContext, endpoint string) APIArg {
+	return APIArg{
+		MetaContext: m,
+		Endpoint:    endpoint,
+	}
+}
+
 // NewRetryAPIArg creates an APIArg that will cause the http client
 // to use a much smaller request timeout, but retry the request
 // several times, backing off on the timeout each time.

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -1208,5 +1208,5 @@ func (d *Service) StartStandaloneChat(g *libkb.GlobalContext) error {
 
 // Called by CtlHandler after DbNuke finishes and succeeds.
 func (d *Service) onDbNuke(ctx context.Context) {
-	d.avatarLoader.OnCacheCleared(ctx)
+	d.avatarLoader.OnCacheCleared(libkb.NewMetaContext(ctx, d.G()))
 }


### PR DESCRIPTION
We're going to be requiring `API#GetDecode` to take a `MetaContext` first argument.  In trying to make that change, I hit resistance here. So pull out the context -> MetaContext change into this PR.