### PR TITLE
Default to chat filter row while loading

### DIFF
--- a/shared/chat/inbox/row/chat-inbox-header/container.js
+++ b/shared/chat/inbox/row/chat-inbox-header/container.js
@@ -13,6 +13,7 @@ type OwnProps = {
 
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
   filter: state.chat2.inboxFilter,
+  isLoading: !state.chat2.loadingMap.isEmpty(),
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({})
@@ -20,6 +21,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   filterFocusCount: ownProps.filterFocusCount,
   focusFilter: ownProps.focusFilter,
+  isLoading: stateProps.isLoading,
   onNewChat: ownProps.onNewChat,
   rows: ownProps.rows,
   showNewChat: !(ownProps.rows.length || stateProps.filter),

--- a/shared/chat/inbox/row/chat-inbox-header/container.js
+++ b/shared/chat/inbox/row/chat-inbox-header/container.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Inbox from '../..'
+import * as Constants from '../../../../constants/chat2'
 import {connect, compose, setDisplayName} from '../../../../util/container'
 import type {TypedState, Dispatch} from '../../../../util/container'
 import ChatInboxHeader from '.'
@@ -13,7 +14,8 @@ type OwnProps = {
 
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
   filter: state.chat2.inboxFilter,
-  isLoading: !state.chat2.loadingMap.isEmpty(),
+  isLoading: Constants.anyChatWaitingKeys(state),
+  neverLoaded: state.chat2.metaMap.isEmpty(),
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({})
@@ -23,6 +25,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   focusFilter: ownProps.focusFilter,
   isLoading: stateProps.isLoading,
   onNewChat: ownProps.onNewChat,
+  neverLoaded: stateProps.neverLoaded,
   rows: ownProps.rows,
   showNewChat: !(ownProps.rows.length || stateProps.filter),
 })

--- a/shared/chat/inbox/row/chat-inbox-header/container.js
+++ b/shared/chat/inbox/row/chat-inbox-header/container.js
@@ -24,8 +24,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   filterFocusCount: ownProps.filterFocusCount,
   focusFilter: ownProps.focusFilter,
   isLoading: stateProps.isLoading,
-  onNewChat: ownProps.onNewChat,
   neverLoaded: stateProps.neverLoaded,
+  onNewChat: ownProps.onNewChat,
   rows: ownProps.rows,
   showNewChat: !(ownProps.rows.length || stateProps.filter),
 })

--- a/shared/chat/inbox/row/chat-inbox-header/container.js
+++ b/shared/chat/inbox/row/chat-inbox-header/container.js
@@ -1,6 +1,5 @@
 // @flow
 import * as Inbox from '../..'
-import * as Constants from '../../../../constants/chat2'
 import {connect, compose, setDisplayName} from '../../../../util/container'
 import type {TypedState, Dispatch} from '../../../../util/container'
 import ChatInboxHeader from '.'
@@ -14,7 +13,6 @@ type OwnProps = {
 
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
   filter: state.chat2.inboxFilter,
-  isLoading: Constants.anyChatWaitingKeys(state),
   neverLoaded: state.chat2.metaMap.isEmpty(),
 })
 
@@ -23,7 +21,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({})
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   filterFocusCount: ownProps.filterFocusCount,
   focusFilter: ownProps.focusFilter,
-  isLoading: stateProps.isLoading,
   neverLoaded: stateProps.neverLoaded,
   onNewChat: ownProps.onNewChat,
   rows: ownProps.rows,

--- a/shared/chat/inbox/row/chat-inbox-header/index.js
+++ b/shared/chat/inbox/row/chat-inbox-header/index.js
@@ -8,12 +8,13 @@ type Props = {
   onNewChat: () => void,
   filterFocusCount: number,
   focusFilter: () => void,
+  isLoading: boolean,
   rows: Array<Inbox.RowItem>,
   showNewChat: boolean,
 }
 
 const ChatInboxHeader = (props: Props) =>
-  props.showNewChat ? (
+  props.showNewChat && !props.isLoading ? (
     <StartNewChat onNewChat={props.onNewChat} />
   ) : (
     <ChatFilterRow

--- a/shared/chat/inbox/row/chat-inbox-header/index.js
+++ b/shared/chat/inbox/row/chat-inbox-header/index.js
@@ -5,16 +5,17 @@ import ChatFilterRow from '../chat-filter-row/container'
 import StartNewChat from '../start-new-chat'
 
 type Props = {
-  onNewChat: () => void,
   filterFocusCount: number,
   focusFilter: () => void,
+  onNewChat: () => void,
+  neverLoaded: boolean,
   isLoading: boolean,
   rows: Array<Inbox.RowItem>,
   showNewChat: boolean,
 }
 
 const ChatInboxHeader = (props: Props) =>
-  props.showNewChat && !props.isLoading ? (
+  props.showNewChat && !props.neverLoaded && !props.isLoading ? (
     <StartNewChat onNewChat={props.onNewChat} />
   ) : (
     <ChatFilterRow

--- a/shared/chat/inbox/row/chat-inbox-header/index.js
+++ b/shared/chat/inbox/row/chat-inbox-header/index.js
@@ -9,13 +9,12 @@ type Props = {
   focusFilter: () => void,
   onNewChat: () => void,
   neverLoaded: boolean,
-  isLoading: boolean,
   rows: Array<Inbox.RowItem>,
   showNewChat: boolean,
 }
 
 const ChatInboxHeader = (props: Props) =>
-  props.showNewChat && !props.neverLoaded && !props.isLoading ? (
+  props.showNewChat && !props.neverLoaded ? (
     <StartNewChat onNewChat={props.onNewChat} />
   ) : (
     <ChatFilterRow


### PR DESCRIPTION
Prevents "Start a new chat" from being rendered while conversations are loading

@keybase/react-hackers 