### PR TITLE
Fix KEYBASE_RUN_CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,6 +286,7 @@ def testGo(prefix) {
     dir('go') {
     withEnv([
         "KEYBASE_LOG_SETUPTEST_FUNCS=1",
+        "KEYBASE_RUN_CI=1",
     ]) {
         def dirs = getTestDirsNix()
         def goversion = sh(returnStdout: true, script: "go version").trim()

--- a/go/test/run_tests.sh
+++ b/go/test/run_tests.sh
@@ -10,7 +10,6 @@ echo "Running tests on commit $(git rev-parse --short HEAD) with $(go version)."
 DIRS=$(go list ./... | grep -v /vendor/ | sed -e 's/^github.com\/keybase\/client\/go\///')
 
 export KEYBASE_LOG_SETUPTEST_FUNCS=1
-export KEYBASE_RUN_CI=1
 
 # Add libraries used in testing
 go get "github.com/stretchr/testify/require"


### PR DESCRIPTION
`KEYBASE_RUN_CI` should be set when on CI. It hasn't been. It had been set if someone happened to run `run_tests.sh`. Maybe it should be set higher up in the Jenkinsfile? I only know of its use in Go tests.

This is used to extend test wait times so that slow tests don't time out on slow CI.

[Proof it wasn't set](https://github.com/keybase/client/pull/12877)
[Proof it's set now](https://github.com/keybase/client/pull/12879) (hasn't finished at the time of this writing)