### PR TITLE
Electron depends on libasound2

### DIFF
--- a/packaging/linux/Dockerfile
+++ b/packaging/linux/Dockerfile
@@ -13,7 +13,7 @@ MAINTAINER Keybase <admin@keybase.io>
 #   - gnupg1 to avoid a password issue in key import
 RUN apt-get update
 RUN apt-get install -y fakeroot reprepro rpm createrepo git wget \
-  build-essential curl python python-pip libc6-dev-i386 gnupg1
+  build-essential curl python python-pip libc6-dev-i386 gnupg1 libasound2
 
 # Install s3cmd. See this issue for why we need a version newer than what's in
 # the Debian repos: https://github.com/s3tools/s3cmd/issues/437


### PR DESCRIPTION
Electron depends on libasound2.
As referenced here: https://electronjs.org/docs/development/build-instructions-linux
Here's an example of another project adding it: https://goo.gl/AYChLr

I don't know how to test this.