### PR TITLE
Team tab badge fix

### DIFF
--- a/shared/teams/team/tabs/index.js
+++ b/shared/teams/team/tabs/index.js
@@ -11,7 +11,14 @@ import {
   Tabs,
   Text,
 } from '../../../common-adapters'
-import {globalColors, globalMargins, isMobile, platformStyles, styleSheetCreate} from '../../../styles'
+import {
+  globalColors,
+  globalMargins,
+  globalStyles,
+  isMobile,
+  platformStyles,
+  styleSheetCreate,
+} from '../../../styles'
 
 type TeamTabsProps = {
   admin: boolean,
@@ -136,8 +143,8 @@ const styles = styleSheetCreate({
     color: globalColors.black_75,
   },
   tabTextContainer: {
-    alignItems: 'center',
-    flex: 1,
+    ...globalStyles.flexBoxRow,
+    justifyContent: 'center',
   },
 })
 


### PR DESCRIPTION
Fixes an issue @buoyad caught when reviewing #12808 where team tab badges look like this:
<img width="124" alt="42908984-78280116-8ab0-11e8-9861-f79b7eba5545" src="https://user-images.githubusercontent.com/5677971/42950923-0ab262a0-8b43-11e8-98c4-20fde8e83895.png">
I figured it'd best to make this a separate PR than try to add it in to my storybook PR. 


Turns out it was a flexbox direction being a column instead of a row. Here's what badges look like now on desktop and mobile:

Desktop:
<img width="322" alt="screen shot 2018-07-19 at 10 57 50 am" src="https://user-images.githubusercontent.com/5677971/42950954-1cf8a618-8b43-11e8-9a3a-db617eaa53b0.png">

Mobile:
![he](https://user-images.githubusercontent.com/5677971/42951170-9b823436-8b43-11e8-9427-9c24063c6054.png)

