### PR TITLE
Don't call getTeams inside components, and always reload teamList when it changes

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -1183,7 +1183,6 @@ function _badgeAppForTeams(action: TeamsGen.BadgeAppForTeamsPayload, state: Type
     // Call getTeams if new teams come in.
     // Covers the case when we're staring at the teams page so
     // we don't miss a notification we clear when we tab away
-    const existingNewTeams = state.teams.getIn(['newTeams'], I.Set())
     const existingNewTeamRequests = state.teams.getIn(['newTeamRequests'], I.List())
 
     // getDetails for teams that have new access requests

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -1185,10 +1185,6 @@ function _badgeAppForTeams(action: TeamsGen.BadgeAppForTeamsPayload, state: Type
     // we don't miss a notification we clear when we tab away
     const existingNewTeams = state.teams.getIn(['newTeams'], I.Set())
     const existingNewTeamRequests = state.teams.getIn(['newTeamRequests'], I.List())
-    if (!newTeams.equals(existingNewTeams) && newTeams.size > 0) {
-      // We have been added to a new team & we need to refresh the list
-      actions.push(Saga.put(TeamsGen.createGetTeams()))
-    }
 
     // getDetails for teams that have new access requests
     // Covers case where we have a badge appear on the requests

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -912,9 +912,6 @@ const _setMemberPublicity = function*(action: TeamsGen.SetMemberPublicityPayload
     // TODO handle error, but for now make sure loading is unset
     yield Saga.put(WaitingGen.createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
     yield Saga.put((dispatch: Dispatch) => dispatch(TeamsGen.createGetDetails({teamname})))
-
-    // The profile showcasing page gets this data from teamList rather than teamGet, so trigger one of those too.
-    yield Saga.put(TeamsGen.createGetTeams())
   }
 }
 
@@ -1045,13 +1042,7 @@ function _setupTeamHandlers() {
 }
 
 function getLoadCalls(teamname?: string) {
-  const actions = []
-  if (_wasOnTeamsTab) {
-    actions.push(TeamsGen.createGetTeams())
-    if (teamname) {
-      actions.push(TeamsGen.createGetDetails({teamname}))
-    }
-  }
+  const actions = [TeamsGen.createGetTeams(), teamname && TeamsGen.createGetDetails({teamname})]
   return actions
 }
 

--- a/shared/git/new-repo/container.js
+++ b/shared/git/new-repo/container.js
@@ -1,9 +1,8 @@
 // @flow
 import * as GitGen from '../../actions/git-gen'
 import * as Constants from '../../constants/git'
-import * as TeamsGen from '../../actions/teams-gen'
 import NewRepo from '.'
-import {compose, lifecycle, connect, type TypedState} from '../../util/container'
+import {connect, type TypedState} from '../../util/container'
 import {navigateTo} from '../../actions/route-tree'
 import {teamsTab} from '../../constants/tabs'
 import {getSortedTeamnames} from '../../constants/teams'
@@ -16,7 +15,6 @@ const mapStateToProps = (state: TypedState, {routeProps}) => ({
 })
 
 const mapDispatchToProps = (dispatch: any, {navigateAppend, navigateUp, routeProps}) => ({
-  _loadTeams: () => dispatch(TeamsGen.createGetTeams()),
   onClose: () => dispatch(navigateUp()),
   onCreate: (name: string, teamname: ?string, notifyTeam: boolean) => {
     const createAction =
@@ -28,11 +26,4 @@ const mapDispatchToProps = (dispatch: any, {navigateAppend, navigateUp, routePro
   onNewTeam: () => dispatch(navigateTo([teamsTab, 'showNewTeamDialog'])),
 })
 
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  lifecycle({
-    componentDidMount() {
-      this.props._loadTeams()
-    },
-  })
-)(NewRepo)
+export default connect(mapStateToProps, mapDispatchToProps)(NewRepo)

--- a/shared/profile/add-to-team/container.js
+++ b/shared/profile/add-to-team/container.js
@@ -28,7 +28,6 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
   loadAllTeams: () => dispatch(TeamsGen.createGetDetailsForAllTeams()),
-  loadTeamList: () => dispatch(TeamsGen.createGetTeams()),
   _onAddToTeams: (role: TeamRoleType, teams: Array<string>, user: string) => {
     dispatch(TeamsGen.createAddUserToTeams({role, teams, user}))
     dispatch(navigateUp())
@@ -91,7 +90,6 @@ export default compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
   lifecycle({
     componentDidMount() {
-      this.props.loadTeamList()
       this.props.loadAllTeams()
     },
   }),

--- a/shared/profile/showcase-team-offer/container.js
+++ b/shared/profile/showcase-team-offer/container.js
@@ -1,7 +1,7 @@
 // @flow
 import * as I from 'immutable'
 import Render from './index'
-import {compose, connect, lifecycle, type TypedState} from '../../util/container'
+import {connect, type TypedState} from '../../util/container'
 import * as TeamsGen from '../../actions/teams-gen'
 import {HeaderOnMobile} from '../../common-adapters'
 import {getSortedTeamnames} from '../../constants/teams'
@@ -21,7 +21,6 @@ const mapStateToProps = (state: TypedState) => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
-  loadTeams: teamname => dispatch(TeamsGen.createGetTeams()),
   onBack: () => dispatch(navigateUp()),
   onPromote: (teamname, showcase) => dispatch(TeamsGen.createSetMemberPublicity({showcase, teamname})),
 })
@@ -40,11 +39,4 @@ const mergeProps = (stateProps, dispatchProps) => {
   }
 }
 
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps, mergeProps),
-  lifecycle({
-    componentDidMount() {
-      this.props.loadTeams()
-    },
-  }),
-)(HeaderOnMobile(Render))
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(HeaderOnMobile(Render))

--- a/shared/profile/showcased-team-info/container.js
+++ b/shared/profile/showcased-team-info/container.js
@@ -53,7 +53,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {team}: OwnProps) => {
   const teamname = team.fqName
   return {
     _checkRequestedAccess: () => dispatch(TeamsGen.createCheckRequestedAccess({teamname})),
-    _loadTeams: () => dispatch(TeamsGen.createGetTeams()),
     _onSetTeamJoinError: (error: string) => dispatch(TeamsGen.createSetTeamJoinError({error})),
     _onSetTeamJoinSuccess: (success: boolean) =>
       dispatch(TeamsGen.createSetTeamJoinSuccess({success, teamname: ''})),
@@ -70,7 +69,6 @@ export default compose(
     componentDidMount() {
       this.props._onSetTeamJoinError('')
       this.props._onSetTeamJoinSuccess(false)
-      this.props._loadTeams()
       this.props._checkRequestedAccess()
     },
   })

--- a/shared/teams/container.js
+++ b/shared/teams/container.js
@@ -2,11 +2,10 @@
 import * as I from 'immutable'
 import * as KBFSGen from '../actions/kbfs-gen'
 import * as GregorGen from '../actions/gregor-gen'
-import * as TeamsGen from '../actions/teams-gen'
 import Teams from './main'
 import openURL from '../util/open-url'
 import {navigateAppend} from '../actions/route-tree'
-import {compose, lifecycle, type TypedState, connect} from '../util/container'
+import {connect, type TypedState} from '../util/container'
 import {getSortedTeamnames} from '../constants/teams'
 import {type Teamname} from '../constants/types/teams'
 
@@ -22,7 +21,6 @@ const mapStateToProps = (state: TypedState) => ({
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  _loadTeams: () => dispatch(TeamsGen.createGetTeams()),
   onCreateTeam: () => {
     dispatch(
       navigateAppend([
@@ -60,11 +58,4 @@ const mergeProps = (stateProps, dispatchProps) => {
   }
 }
 
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps, mergeProps),
-  lifecycle({
-    componentDidMount() {
-      this.props._loadTeams()
-    },
-  })
-)(Teams)
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Teams)

--- a/shared/teams/invite-by-email/container.desktop.js
+++ b/shared/teams/invite-by-email/container.desktop.js
@@ -22,7 +22,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
   onInvite: (invitees: string, role: Types.TeamRoleType) => {
     dispatch(TeamsGen.createInviteToTeamByEmail({teamname: routeProps.get('teamname'), role, invitees}))
     dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''}))
-    dispatch(TeamsGen.createGetTeams())
   },
   onOpenRolePicker: (role: Types.TeamRoleType, onComplete: Types.TeamRoleType => void) => {
     dispatch(

--- a/shared/teams/invite-by-email/container.native.js
+++ b/shared/teams/invite-by-email/container.native.js
@@ -51,7 +51,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
     dispatch(
       TeamsGen.createInviteToTeamByEmail({teamname: routeProps.get('teamname'), role, invitees: invitee})
     )
-    dispatch(TeamsGen.createGetTeams())
   },
   onInvitePhone: ({invitee, role, fullName = ''}) => {
     dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''}))
@@ -63,7 +62,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
         fullName,
       })
     )
-    dispatch(TeamsGen.createGetTeams())
   },
   onUninvite: (invitee: string, id?: string) => {
     dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''}))

--- a/shared/teams/really-leave-team/container-chat.js
+++ b/shared/teams/really-leave-team/container-chat.js
@@ -31,7 +31,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
   onLeave: () => {
     dispatch(TeamsGen.createLeaveTeam({teamname: routeProps.get('teamname')}))
     dispatch(navigateUp())
-    dispatch(TeamsGen.createGetTeams())
   },
 })
 

--- a/shared/teams/really-leave-team/container.js
+++ b/shared/teams/really-leave-team/container.js
@@ -24,7 +24,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
   onLeave: () => {
     dispatch(TeamsGen.createLeaveTeam({teamname: routeProps.get('teamname')}))
     dispatch(navigateTo([teamsTab]))
-    dispatch(TeamsGen.createGetTeams())
   },
 })
 

--- a/shared/tracker/remote-container.desktop.js
+++ b/shared/tracker/remote-container.desktop.js
@@ -20,7 +20,6 @@ import {
 // Props are handled by remote-proxy.desktop.js
 const mapDispatchToProps = (dispatch: Dispatch, {teamname}) => ({
   _checkRequestedAccess: (teamname: string) => dispatch(TeamsGen.createCheckRequestedAccess({teamname})),
-  _loadTeams: () => dispatch(TeamsGen.createGetTeams()),
   _onChat: (username: string) => {
     dispatch(ConfigGen.createShowMain())
     dispatch(Chat2Gen.createPreviewConversation({participants: [username], reason: 'tracker'}))
@@ -71,7 +70,6 @@ export default compose(
     componentDidMount() {
       this.props._onSetTeamJoinError('')
       this.props._onSetTeamJoinSuccess(false)
-      this.props._loadTeams()
     },
   })
 )(Tracker)


### PR DESCRIPTION
@keybase/react-hackers 

From the ticket:

1. We'll make a bootstrap call to the teamlist (already does this)

2. We'll listen to the notifications and recall teamlist (always, no matter what tab you're on), the goal being to always have this be correct

3. We'll remove any existing calls to teamlist. We should already have this data