### PR TITLE
fix an issue with how we are passing around the mutex around config.json

### DIFF
--- a/go/engine/concurrency_test.go
+++ b/go/engine/concurrency_test.go
@@ -185,7 +185,7 @@ func genv(g *libkb.GlobalContext) {
 	g.Env.GetConfigWriter()
 	g.Env.GetCommandLine()
 	cf := libkb.NewJSONConfigFile(g, "")
-	g.Env.SetConfig(*cf, cf)
+	g.Env.SetConfig(cf, cf)
 }
 
 func gkeyring() {

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -28,17 +28,6 @@ func NewJSONConfigFile(g *GlobalContext, s string) *JSONConfigFile {
 	return &JSONConfigFile{NewJSONFile(g, s, "config"), &UserConfigWrapper{}}
 }
 
-type valueGetter func(*jsonw.Wrapper) (interface{}, error)
-
-func (f JSONConfigFile) getValueAtPath(p string, getter valueGetter) (ret interface{}, isSet bool) {
-	var err error
-	ret, err = getter(f.jw.AtPath(p))
-	if err == nil {
-		isSet = true
-	}
-	return
-}
-
 // Check looks inside the JSON file to see if any fields are poorly specified
 func (f JSONConfigFile) Check() error {
 	return PickFirstError(
@@ -48,56 +37,6 @@ func (f JSONConfigFile) Check() error {
 			return err
 		}(),
 	)
-}
-
-func getString(w *jsonw.Wrapper) (interface{}, error) {
-	return w.GetString()
-}
-
-func getBool(w *jsonw.Wrapper) (interface{}, error) {
-	return w.GetBool()
-}
-
-func getInt(w *jsonw.Wrapper) (interface{}, error) {
-	return w.GetInt()
-}
-
-func (f JSONConfigFile) GetFilename() string {
-	return f.filename
-}
-
-func (f JSONConfigFile) GetInterfaceAtPath(p string) (i interface{}, err error) {
-	return f.jw.AtPath(p).GetInterface()
-}
-
-func (f JSONConfigFile) GetStringAtPath(p string) (ret string, isSet bool) {
-	i, isSet := f.getValueAtPath(p, getString)
-	if isSet {
-		ret = i.(string)
-	}
-	return
-}
-
-func (f JSONConfigFile) GetBoolAtPath(p string) (ret bool, isSet bool) {
-	i, isSet := f.getValueAtPath(p, getBool)
-	if isSet {
-		ret = i.(bool)
-	}
-	return
-}
-
-func (f JSONConfigFile) GetIntAtPath(p string) (ret int, isSet bool) {
-	i, isSet := f.getValueAtPath(p, getInt)
-	if isSet {
-		ret = i.(int)
-	}
-	return
-}
-
-func (f JSONConfigFile) GetNullAtPath(p string) (isSet bool) {
-	w := f.jw.AtPath(p)
-	isSet = w.IsNil() && w.Error() == nil
-	return
 }
 
 func (f JSONConfigFile) GetDurationAtPath(p string) (time.Duration, bool) {
@@ -137,51 +76,12 @@ func (f JSONConfigFile) GetTopLevelBool(s string) (res, isSet bool) {
 	return
 }
 
-func (f *JSONConfigFile) setValueAtPath(p string, getter valueGetter, v interface{}) error {
-	existing, err := getter(f.jw.AtPath(p))
-
-	if err != nil || existing != v {
-		err = f.jw.SetValueAtPath(p, jsonw.NewWrapper(v))
-		if err == nil {
-			return f.Save()
-		}
-	}
-	return err
-}
-
 func (f *JSONConfigFile) SetWrapperAtPath(p string, w *jsonw.Wrapper) error {
 	err := f.jw.SetValueAtPath(p, w)
 	if err == nil {
 		err = f.Save()
 	}
 	return err
-}
-
-func (f *JSONConfigFile) SetStringAtPath(p string, v string) error {
-	return f.setValueAtPath(p, getString, v)
-}
-
-func (f *JSONConfigFile) SetBoolAtPath(p string, v bool) error {
-	return f.setValueAtPath(p, getBool, v)
-}
-
-func (f *JSONConfigFile) SetIntAtPath(p string, v int) error {
-	return f.setValueAtPath(p, getInt, v)
-}
-
-func (f *JSONConfigFile) SetInt64AtPath(p string, v int64) error {
-	return f.setValueAtPath(p, getInt, v)
-}
-
-func (f *JSONConfigFile) SetNullAtPath(p string) (err error) {
-	existing := f.jw.AtPath(p)
-	if !existing.IsNil() || existing.Error() != nil {
-		err = f.jw.SetValueAtPath(p, jsonw.NewNil())
-		if err == nil {
-			return f.Save()
-		}
-	}
-	return
 }
 
 func (f JSONConfigFile) GetUserConfig() (*UserConfig, error) {
@@ -193,7 +93,6 @@ func (f JSONConfigFile) GetUserConfig() (*UserConfig, error) {
 // GetUserConfig looks for the `current_user` field to see if there's
 // a corresponding user object in the `users` table. There really should be.
 func (f JSONConfigFile) getUserConfigWithLock() (ret *UserConfig, err error) {
-
 	var s string
 	if ret = f.userConfigWrapper.userConfig; ret != nil {
 		return

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -29,7 +29,7 @@ func NewJSONConfigFile(g *GlobalContext, s string) *JSONConfigFile {
 }
 
 // Check looks inside the JSON file to see if any fields are poorly specified
-func (f JSONConfigFile) Check() error {
+func (f *JSONConfigFile) Check() error {
 	return PickFirstError(
 		// Feel free to add others here..
 		func() error {
@@ -39,7 +39,7 @@ func (f JSONConfigFile) Check() error {
 	)
 }
 
-func (f JSONConfigFile) GetDurationAtPath(p string) (time.Duration, bool) {
+func (f *JSONConfigFile) GetDurationAtPath(p string) (time.Duration, bool) {
 	s, ok := f.GetStringAtPath(p)
 	if !ok {
 		return 0, false
@@ -52,22 +52,22 @@ func (f JSONConfigFile) GetDurationAtPath(p string) (time.Duration, bool) {
 	return d, true
 }
 
-func (f JSONConfigFile) GetUpgradePerUserKey() (bool, bool) {
+func (f *JSONConfigFile) GetUpgradePerUserKey() (bool, bool) {
 	return false, false
 }
 
-func (f JSONConfigFile) GetAutoWallet() (bool, bool) {
+func (f *JSONConfigFile) GetAutoWallet() (bool, bool) {
 	return false, false
 }
 
-func (f JSONConfigFile) GetTopLevelString(s string) (ret string) {
+func (f *JSONConfigFile) GetTopLevelString(s string) (ret string) {
 	var e error
 	f.jw.AtKey(s).GetStringVoid(&ret, &e)
 	f.G().VDL.Log(VLog1, "Config: mapping %q -> %q", s, ret)
 	return
 }
 
-func (f JSONConfigFile) GetTopLevelBool(s string) (res, isSet bool) {
+func (f *JSONConfigFile) GetTopLevelBool(s string) (res, isSet bool) {
 	if w := f.jw.AtKey(s); !w.IsNil() {
 		isSet = true
 		var e error
@@ -84,7 +84,7 @@ func (f *JSONConfigFile) SetWrapperAtPath(p string, w *jsonw.Wrapper) error {
 	return err
 }
 
-func (f JSONConfigFile) GetUserConfig() (*UserConfig, error) {
+func (f *JSONConfigFile) GetUserConfig() (*UserConfig, error) {
 	f.userConfigWrapper.Lock()
 	defer f.userConfigWrapper.Unlock()
 	return f.getUserConfigWithLock()
@@ -92,7 +92,7 @@ func (f JSONConfigFile) GetUserConfig() (*UserConfig, error) {
 
 // GetUserConfig looks for the `current_user` field to see if there's
 // a corresponding user object in the `users` table. There really should be.
-func (f JSONConfigFile) getUserConfigWithLock() (ret *UserConfig, err error) {
+func (f *JSONConfigFile) getUserConfigWithLock() (ret *UserConfig, err error) {
 	var s string
 	if ret = f.userConfigWrapper.userConfig; ret != nil {
 		return
@@ -112,7 +112,7 @@ func (f JSONConfigFile) getUserConfigWithLock() (ret *UserConfig, err error) {
 	return
 }
 
-func (f JSONConfigFile) GetDeviceIDForUsername(nu NormalizedUsername) keybase1.DeviceID {
+func (f *JSONConfigFile) GetDeviceIDForUsername(nu NormalizedUsername) keybase1.DeviceID {
 	f.userConfigWrapper.Lock()
 	defer f.userConfigWrapper.Unlock()
 	ret, err := f.GetUserConfigForUsername(nu)
@@ -123,7 +123,7 @@ func (f JSONConfigFile) GetDeviceIDForUsername(nu NormalizedUsername) keybase1.D
 	return ret.GetDeviceID()
 }
 
-func (f JSONConfigFile) GetDeviceIDForUID(u keybase1.UID) keybase1.DeviceID {
+func (f *JSONConfigFile) GetDeviceIDForUID(u keybase1.UID) keybase1.DeviceID {
 	f.userConfigWrapper.Lock()
 	defer f.userConfigWrapper.Unlock()
 	ret, err := f.GetUserConfigForUID(u)
@@ -134,7 +134,7 @@ func (f JSONConfigFile) GetDeviceIDForUID(u keybase1.UID) keybase1.DeviceID {
 	return ret.GetDeviceID()
 }
 
-func (f JSONConfigFile) GetUsernameForUID(u keybase1.UID) NormalizedUsername {
+func (f *JSONConfigFile) GetUsernameForUID(u keybase1.UID) NormalizedUsername {
 	f.userConfigWrapper.Lock()
 	defer f.userConfigWrapper.Unlock()
 	ret, err := f.GetUserConfigForUID(u)
@@ -145,7 +145,7 @@ func (f JSONConfigFile) GetUsernameForUID(u keybase1.UID) NormalizedUsername {
 	return ret.GetUsername()
 }
 
-func (f JSONConfigFile) GetUIDForUsername(n NormalizedUsername) keybase1.UID {
+func (f *JSONConfigFile) GetUIDForUsername(n NormalizedUsername) keybase1.UID {
 	f.userConfigWrapper.Lock()
 	defer f.userConfigWrapper.Unlock()
 	ret, err := f.GetUserConfigForUsername(n)
@@ -213,14 +213,14 @@ func (f *JSONConfigFile) NukeUser(nu NormalizedUsername) error {
 
 // GetUserConfigForUsername sees if there's a UserConfig object for the given
 // username previously stored.
-func (f JSONConfigFile) GetUserConfigForUsername(nu NormalizedUsername) (*UserConfig, error) {
+func (f *JSONConfigFile) GetUserConfigForUsername(nu NormalizedUsername) (*UserConfig, error) {
 	if uc := f.copyUserConfigIfForUsername(nu); uc != nil {
 		return uc, nil
 	}
 	return ImportUserConfigFromJSONWrapper(f.jw.AtKey("users").AtKey(nu.String()))
 }
 
-func (f JSONConfigFile) copyUserConfigIfForUsername(u NormalizedUsername) *UserConfig {
+func (f *JSONConfigFile) copyUserConfigIfForUsername(u NormalizedUsername) *UserConfig {
 	if f.userConfigWrapper == nil || f.userConfigWrapper.userConfig == nil {
 		return nil
 	}
@@ -234,7 +234,7 @@ func (f JSONConfigFile) copyUserConfigIfForUsername(u NormalizedUsername) *UserC
 	return nil
 }
 
-func (f JSONConfigFile) copyUserConfigIfForUID(u keybase1.UID) *UserConfig {
+func (f *JSONConfigFile) copyUserConfigIfForUID(u keybase1.UID) *UserConfig {
 	if f.userConfigWrapper == nil || f.userConfigWrapper.userConfig == nil {
 		return nil
 	}
@@ -249,7 +249,7 @@ func (f JSONConfigFile) copyUserConfigIfForUID(u keybase1.UID) *UserConfig {
 }
 
 // GetUserConfigForUID sees if there's a UserConfig object for the given UIDs previously stored.
-func (f JSONConfigFile) GetUserConfigForUID(u keybase1.UID) (*UserConfig, error) {
+func (f *JSONConfigFile) GetUserConfigForUID(u keybase1.UID) (*UserConfig, error) {
 
 	if uc := f.copyUserConfigIfForUID(u); uc != nil {
 		return uc, nil
@@ -266,7 +266,7 @@ func (f JSONConfigFile) GetUserConfigForUID(u keybase1.UID) (*UserConfig, error)
 	return nil, nil
 }
 
-func (f JSONConfigFile) GetAllUserConfigs() (current *UserConfig, all []UserConfig, err error) {
+func (f *JSONConfigFile) GetAllUserConfigs() (current *UserConfig, all []UserConfig, err error) {
 
 	currentUsername, allUsernames, err := f.GetAllUsernames()
 	if err != nil {
@@ -287,7 +287,7 @@ func (f JSONConfigFile) GetAllUserConfigs() (current *UserConfig, all []UserConf
 	return current, all, nil
 }
 
-func (f JSONConfigFile) GetAllUsernames() (current NormalizedUsername, others []NormalizedUsername, err error) {
+func (f *JSONConfigFile) GetAllUsernames() (current NormalizedUsername, others []NormalizedUsername, err error) {
 	current = f.getCurrentUser()
 	uw := f.jw.AtKey("users")
 	if uw.IsNil() {
@@ -397,51 +397,51 @@ func (f *JSONConfigFile) Reset() {
 	f.Save()
 }
 
-func (f JSONConfigFile) GetHome() string {
+func (f *JSONConfigFile) GetHome() string {
 	return f.GetTopLevelString("home")
 }
-func (f JSONConfigFile) GetServerURI() string {
+func (f *JSONConfigFile) GetServerURI() string {
 	return f.GetTopLevelString("server")
 }
-func (f JSONConfigFile) GetConfigFilename() string {
+func (f *JSONConfigFile) GetConfigFilename() string {
 	return f.GetTopLevelString("config_file")
 }
-func (f JSONConfigFile) GetUpdaterConfigFilename() string {
+func (f *JSONConfigFile) GetUpdaterConfigFilename() string {
 	return f.GetTopLevelString("updater_config_file")
 }
-func (f JSONConfigFile) GetDeviceCloneStateFilename() string {
+func (f *JSONConfigFile) GetDeviceCloneStateFilename() string {
 	return f.GetTopLevelString("device_clone_state_file")
 }
-func (f JSONConfigFile) GetSecretKeyringTemplate() string {
+func (f *JSONConfigFile) GetSecretKeyringTemplate() string {
 	return f.GetTopLevelString("secret_keyring")
 }
-func (f JSONConfigFile) GetSessionFilename() string {
+func (f *JSONConfigFile) GetSessionFilename() string {
 	return f.GetTopLevelString("session_file")
 }
-func (f JSONConfigFile) GetDbFilename() string {
+func (f *JSONConfigFile) GetDbFilename() string {
 	return f.GetTopLevelString("db")
 }
-func (f JSONConfigFile) GetChatDbFilename() string {
+func (f *JSONConfigFile) GetChatDbFilename() string {
 	return f.GetTopLevelString("chat_db")
 }
-func (f JSONConfigFile) GetPvlKitFilename() string {
+func (f *JSONConfigFile) GetPvlKitFilename() string {
 	return f.GetTopLevelString("pvl_kit")
 }
-func (f JSONConfigFile) GetPinentry() string {
+func (f *JSONConfigFile) GetPinentry() string {
 	res, _ := f.GetStringAtPath("pinentry.path")
 	return res
 }
-func (f JSONConfigFile) GetGpg() string {
+func (f *JSONConfigFile) GetGpg() string {
 	res, _ := f.GetStringAtPath("gpg.command")
 	return res
 }
-func (f JSONConfigFile) GetLocalRPCDebug() string {
+func (f *JSONConfigFile) GetLocalRPCDebug() string {
 	return f.GetTopLevelString("local_rpc_debug")
 }
-func (f JSONConfigFile) GetTimers() string {
+func (f *JSONConfigFile) GetTimers() string {
 	return f.GetTopLevelString("timers")
 }
-func (f JSONConfigFile) GetGpgOptions() []string {
+func (f *JSONConfigFile) GetGpgOptions() []string {
 	var ret []string
 	if f.jw == nil {
 		// noop
@@ -459,165 +459,165 @@ func (f JSONConfigFile) GetGpgOptions() []string {
 	}
 	return ret
 }
-func (f JSONConfigFile) GetRunMode() (ret RunMode, err error) {
+func (f *JSONConfigFile) GetRunMode() (ret RunMode, err error) {
 	ret = NoRunMode
 	if s, isSet := f.GetStringAtPath("run_mode"); isSet {
 		ret, err = StringToRunMode(s)
 	}
 	return ret, err
 }
-func (f JSONConfigFile) GetFeatureFlags() (ret FeatureFlags, err error) {
+func (f *JSONConfigFile) GetFeatureFlags() (ret FeatureFlags, err error) {
 	if s, isSet := f.GetStringAtPath("features"); isSet {
 		ret = StringToFeatureFlags(s)
 	}
 	return ret, err
 }
-func (f JSONConfigFile) GetNoPinentry() (bool, bool) {
+func (f *JSONConfigFile) GetNoPinentry() (bool, bool) {
 	return f.GetBoolAtPath("pinentry.disabled")
 }
-func (f JSONConfigFile) GetUsername() (ret NormalizedUsername) {
+func (f *JSONConfigFile) GetUsername() (ret NormalizedUsername) {
 	if uc, _ := f.GetUserConfig(); uc != nil {
 		ret = uc.GetUsername()
 	}
 	return ret
 }
-func (f JSONConfigFile) GetUID() (ret keybase1.UID) {
+func (f *JSONConfigFile) GetUID() (ret keybase1.UID) {
 	if uc, _ := f.GetUserConfig(); uc != nil {
 		ret = uc.GetUID()
 	}
 	return ret
 }
-func (f JSONConfigFile) GetDeviceID() (ret keybase1.DeviceID) {
+func (f *JSONConfigFile) GetDeviceID() (ret keybase1.DeviceID) {
 	if uc, _ := f.GetUserConfig(); uc != nil {
 		ret = uc.GetDeviceID()
 	}
 	return ret
 }
 
-func (f JSONConfigFile) GetTorMode() (ret TorMode, err error) {
+func (f *JSONConfigFile) GetTorMode() (ret TorMode, err error) {
 	if s, isSet := f.GetStringAtPath("tor.mode"); isSet {
 		ret, err = StringToTorMode(s)
 	}
 	return ret, err
 }
 
-func (f JSONConfigFile) GetTorHiddenAddress() string {
+func (f *JSONConfigFile) GetTorHiddenAddress() string {
 	s, _ := f.GetStringAtPath("tor.hidden_address")
 	return s
 }
-func (f JSONConfigFile) GetTorProxy() string {
+func (f *JSONConfigFile) GetTorProxy() string {
 	s, _ := f.GetStringAtPath("tor.proxy")
 	return s
 }
 
-func (f JSONConfigFile) GetProxy() string {
+func (f *JSONConfigFile) GetProxy() string {
 	return f.GetTopLevelString("proxy")
 }
-func (f JSONConfigFile) GetDebug() (bool, bool) {
+func (f *JSONConfigFile) GetDebug() (bool, bool) {
 	return f.GetTopLevelBool("debug")
 }
-func (f JSONConfigFile) GetDisplayRawUntrustedOutput() (bool, bool) {
+func (f *JSONConfigFile) GetDisplayRawUntrustedOutput() (bool, bool) {
 	return f.GetTopLevelBool("display_raw_untrusted_output")
 }
-func (f JSONConfigFile) GetVDebugSetting() string {
+func (f *JSONConfigFile) GetVDebugSetting() string {
 	return f.GetTopLevelString("vdebug")
 }
-func (f JSONConfigFile) GetAutoFork() (bool, bool) {
+func (f *JSONConfigFile) GetAutoFork() (bool, bool) {
 	return f.GetTopLevelBool("auto_fork")
 }
-func (f JSONConfigFile) GetRememberPassphrase() (bool, bool) {
+func (f *JSONConfigFile) GetRememberPassphrase() (bool, bool) {
 	return f.GetTopLevelBool("remember_passphrase")
 }
-func (f JSONConfigFile) GetLogFormat() string {
+func (f *JSONConfigFile) GetLogFormat() string {
 	return f.GetTopLevelString("log_format")
 }
-func (f JSONConfigFile) GetStandalone() (bool, bool) {
+func (f *JSONConfigFile) GetStandalone() (bool, bool) {
 	return f.GetTopLevelBool("standalone")
 }
-func (f JSONConfigFile) GetGregorURI() string {
+func (f *JSONConfigFile) GetGregorURI() string {
 	s, _ := f.GetStringAtPath("push.server_uri")
 	return s
 }
-func (f JSONConfigFile) GetGregorDisabled() (bool, bool) {
+func (f *JSONConfigFile) GetGregorDisabled() (bool, bool) {
 	return f.GetBoolAtPath("push.disabled")
 }
-func (f JSONConfigFile) GetBGIdentifierDisabled() (bool, bool) {
+func (f *JSONConfigFile) GetBGIdentifierDisabled() (bool, bool) {
 	return f.GetBoolAtPath("bg_identifier.disabled")
 }
-func (f JSONConfigFile) GetGregorSaveInterval() (time.Duration, bool) {
+func (f *JSONConfigFile) GetGregorSaveInterval() (time.Duration, bool) {
 	return f.GetDurationAtPath("push.save_interval")
 }
 
-func (f JSONConfigFile) GetGregorPingInterval() (time.Duration, bool) {
+func (f *JSONConfigFile) GetGregorPingInterval() (time.Duration, bool) {
 	return f.GetDurationAtPath("push.ping_interval")
 }
 
-func (f JSONConfigFile) GetGregorPingTimeout() (time.Duration, bool) {
+func (f *JSONConfigFile) GetGregorPingTimeout() (time.Duration, bool) {
 	return f.GetDurationAtPath("push.ping_timeout")
 }
 
-func (f JSONConfigFile) GetChatDelivererInterval() (time.Duration, bool) {
+func (f *JSONConfigFile) GetChatDelivererInterval() (time.Duration, bool) {
 	return f.GetDurationAtPath("chat.deliverer_interval")
 }
 
-func (f JSONConfigFile) getCacheSize(w string) (int, bool) {
+func (f *JSONConfigFile) getCacheSize(w string) (int, bool) {
 	return f.jw.AtPathGetInt(w)
 }
 
-func (f JSONConfigFile) GetUserCacheMaxAge() (time.Duration, bool) {
+func (f *JSONConfigFile) GetUserCacheMaxAge() (time.Duration, bool) {
 	return f.GetDurationAtPath("cache.maxage.users")
 }
-func (f JSONConfigFile) GetAPITimeout() (time.Duration, bool) {
+func (f *JSONConfigFile) GetAPITimeout() (time.Duration, bool) {
 	return f.GetDurationAtPath("timeouts.api")
 }
-func (f JSONConfigFile) GetScraperTimeout() (time.Duration, bool) {
+func (f *JSONConfigFile) GetScraperTimeout() (time.Duration, bool) {
 	return f.GetDurationAtPath("timeouts.scraper")
 }
-func (f JSONConfigFile) GetProofCacheSize() (int, bool) {
+func (f *JSONConfigFile) GetProofCacheSize() (int, bool) {
 	return f.getCacheSize("cache.limits.proofs")
 }
 
-func (f JSONConfigFile) GetProofCacheLongDur() (time.Duration, bool) {
+func (f *JSONConfigFile) GetProofCacheLongDur() (time.Duration, bool) {
 	return f.GetDurationAtPath("cache.long_duration.proofs")
 }
 
-func (f JSONConfigFile) GetProofCacheMediumDur() (time.Duration, bool) {
+func (f *JSONConfigFile) GetProofCacheMediumDur() (time.Duration, bool) {
 	return f.GetDurationAtPath("cache.medium_duration.proofs")
 }
 
-func (f JSONConfigFile) GetProofCacheShortDur() (time.Duration, bool) {
+func (f *JSONConfigFile) GetProofCacheShortDur() (time.Duration, bool) {
 	return f.GetDurationAtPath("cache.short_duration.proofs")
 }
 
-func (f JSONConfigFile) GetLinkCacheSize() (int, bool) {
+func (f *JSONConfigFile) GetLinkCacheSize() (int, bool) {
 	return f.getCacheSize("cache.limits.links")
 }
 
-func (f JSONConfigFile) GetLinkCacheCleanDur() (time.Duration, bool) {
+func (f *JSONConfigFile) GetLinkCacheCleanDur() (time.Duration, bool) {
 	return f.GetDurationAtPath("cache.clean_duration.links")
 }
 
-func (f JSONConfigFile) GetUPAKCacheSize() (int, bool) {
+func (f *JSONConfigFile) GetUPAKCacheSize() (int, bool) {
 	return f.getCacheSize("cache.limits.upak")
 }
 
-func (f JSONConfigFile) GetUIDMapFullNameCacheSize() (int, bool) {
+func (f *JSONConfigFile) GetUIDMapFullNameCacheSize() (int, bool) {
 	return f.getCacheSize("cache.limits.uid_map_full_name")
 }
 
-func (f JSONConfigFile) GetPayloadCacheSize() (int, bool) {
+func (f *JSONConfigFile) GetPayloadCacheSize() (int, bool) {
 	return f.getCacheSize("cache.limits.payloads")
 }
 
-func (f JSONConfigFile) GetLevelDBNumFiles() (int, bool) {
+func (f *JSONConfigFile) GetLevelDBNumFiles() (int, bool) {
 	return f.GetIntAtPath("leveldb.num_files")
 }
 
-func (f JSONConfigFile) GetChatInboxSourceLocalizeThreads() (int, bool) {
+func (f *JSONConfigFile) GetChatInboxSourceLocalizeThreads() (int, bool) {
 	return f.GetIntAtPath("chat.inboxsource.localizethreads")
 }
 
-func (f JSONConfigFile) getStringArray(v *jsonw.Wrapper) []string {
+func (f *JSONConfigFile) getStringArray(v *jsonw.Wrapper) []string {
 	n, err := v.Len()
 	if err != nil {
 		return nil
@@ -638,7 +638,7 @@ func (f JSONConfigFile) getStringArray(v *jsonw.Wrapper) []string {
 	return ret
 }
 
-func (f JSONConfigFile) GetMerkleKIDs() []string {
+func (f *JSONConfigFile) GetMerkleKIDs() []string {
 	if f.jw == nil {
 		return nil
 	}
@@ -651,7 +651,7 @@ func (f JSONConfigFile) GetMerkleKIDs() []string {
 	return f.getStringArray(v)
 }
 
-func (f JSONConfigFile) GetCodeSigningKIDs() []string {
+func (f *JSONConfigFile) GetCodeSigningKIDs() []string {
 	if f.jw == nil {
 		return nil
 	}
@@ -663,12 +663,12 @@ func (f JSONConfigFile) GetCodeSigningKIDs() []string {
 	return f.getStringArray(v)
 }
 
-func (f JSONConfigFile) GetGpgHome() (ret string) {
+func (f *JSONConfigFile) GetGpgHome() (ret string) {
 	ret, _ = f.GetStringAtPath("gpg.home")
 	return ret
 }
 
-func (f JSONConfigFile) GetBundledCA(host string) (ret string) {
+func (f *JSONConfigFile) GetBundledCA(host string) (ret string) {
 	var err error
 	f.jw.AtKey("bundled_ca").AtKey(host).GetStringVoid(&ret, &err)
 	if err == nil {
@@ -677,14 +677,14 @@ func (f JSONConfigFile) GetBundledCA(host string) (ret string) {
 	return ret
 }
 
-func (f JSONConfigFile) GetSocketFile() string {
+func (f *JSONConfigFile) GetSocketFile() string {
 	return f.GetTopLevelString("socket_file")
 }
-func (f JSONConfigFile) GetPidFile() string {
+func (f *JSONConfigFile) GetPidFile() string {
 	return f.GetTopLevelString("pid_file")
 }
 
-func (f JSONConfigFile) GetProxyCACerts() (ret []string, err error) {
+func (f *JSONConfigFile) GetProxyCACerts() (ret []string, err error) {
 	jw := f.jw.AtKey("proxy_ca_certs")
 	if l, e := jw.Len(); e == nil {
 		for i := 0; i < l; i++ {
@@ -705,31 +705,31 @@ func (f JSONConfigFile) GetProxyCACerts() (ret []string, err error) {
 	return
 }
 
-func (f JSONConfigFile) GetLogFile() string {
+func (f *JSONConfigFile) GetLogFile() string {
 	return f.GetTopLevelString("log_file")
 }
 
-func (f JSONConfigFile) GetLogPrefix() string {
+func (f *JSONConfigFile) GetLogPrefix() string {
 	return f.GetTopLevelString("log_prefix")
 }
 
-func (f JSONConfigFile) GetSecurityAccessGroupOverride() (bool, bool) {
+func (f *JSONConfigFile) GetSecurityAccessGroupOverride() (bool, bool) {
 	return false, false
 }
 
-func (f JSONConfigFile) GetUpdatePreferenceAuto() (bool, bool) {
+func (f *JSONConfigFile) GetUpdatePreferenceAuto() (bool, bool) {
 	return f.GetBoolAtPath("updates.auto")
 }
 
-func (f JSONConfigFile) GetUpdatePreferenceSnoozeUntil() keybase1.Time {
+func (f *JSONConfigFile) GetUpdatePreferenceSnoozeUntil() keybase1.Time {
 	return f.GetTimeAtPath("updates.snooze")
 }
 
-func (f JSONConfigFile) GetUpdateLastChecked() keybase1.Time {
+func (f *JSONConfigFile) GetUpdateLastChecked() keybase1.Time {
 	return f.GetTimeAtPath("updates.last_checked")
 }
 
-func (f JSONConfigFile) GetUpdatePreferenceSkip() string {
+func (f *JSONConfigFile) GetUpdatePreferenceSkip() string {
 	s, _ := f.GetStringAtPath("updates.skip")
 	return s
 }
@@ -750,16 +750,16 @@ func (f *JSONConfigFile) SetUpdateLastChecked(t keybase1.Time) error {
 	return f.SetTimeAtPath("updates.last_checked", t)
 }
 
-func (f JSONConfigFile) GetUpdateURL() string {
+func (f *JSONConfigFile) GetUpdateURL() string {
 	s, _ := f.GetStringAtPath("updates.url")
 	return s
 }
 
-func (f JSONConfigFile) GetUpdateDisabled() (bool, bool) {
+func (f *JSONConfigFile) GetUpdateDisabled() (bool, bool) {
 	return f.GetBoolAtPath("updates.disabled")
 }
 
-func (f JSONConfigFile) GetTimeAtPath(path string) keybase1.Time {
+func (f *JSONConfigFile) GetTimeAtPath(path string) keybase1.Time {
 	var ret keybase1.Time
 	s, _ := f.GetStringAtPath(path)
 	if len(s) == 0 {
@@ -780,11 +780,11 @@ func (f *JSONConfigFile) SetTimeAtPath(path string, t keybase1.Time) error {
 	return f.SetStringAtPath(path, fmt.Sprintf("%d", t))
 }
 
-func (f JSONConfigFile) GetLocalTrackMaxAge() (time.Duration, bool) {
+func (f *JSONConfigFile) GetLocalTrackMaxAge() (time.Duration, bool) {
 	return f.GetDurationAtPath("local_track_max_age")
 }
 
-func (f JSONConfigFile) GetMountDir() string {
+func (f *JSONConfigFile) GetMountDir() string {
 	return f.GetTopLevelString("mountdir")
 }
 
@@ -792,7 +792,7 @@ func bug3964path(un NormalizedUsername) string {
 	return fmt.Sprintf("maintenance.%s.bug_3964_repair_time", un)
 }
 
-func (f JSONConfigFile) GetBug3964RepairTime(un NormalizedUsername) (time.Time, error) {
+func (f *JSONConfigFile) GetBug3964RepairTime(un NormalizedUsername) (time.Time, error) {
 	if un == "" {
 		return time.Time{}, NoUserConfigError{}
 	}
@@ -807,15 +807,15 @@ func (f JSONConfigFile) GetBug3964RepairTime(un NormalizedUsername) (time.Time, 
 	return keybase1.FromTime(keybase1.Time(i)), nil
 }
 
-func (f JSONConfigFile) SetBug3964RepairTime(un NormalizedUsername, t time.Time) (err error) {
+func (f *JSONConfigFile) SetBug3964RepairTime(un NormalizedUsername, t time.Time) (err error) {
 	return f.SetStringAtPath(bug3964path(un), fmt.Sprintf("%d", int64(keybase1.ToTime(t))))
 }
 
-func (f JSONConfigFile) GetAppType() AppType {
+func (f *JSONConfigFile) GetAppType() AppType {
 	return AppType(f.GetTopLevelString("app_type"))
 }
 
-func (f JSONConfigFile) GetSlowGregorConn() (bool, bool) {
+func (f *JSONConfigFile) GetSlowGregorConn() (bool, bool) {
 	return f.GetBoolAtPath("slow_gregor_conn")
 }
 

--- a/go/libkb/device_clone_state.go
+++ b/go/libkb/device_clone_state.go
@@ -128,10 +128,10 @@ func SetDeviceCloneState(m MetaContext, d DeviceCloneState) error {
 	return nil
 }
 
-func newDeviceCloneStateReader(m MetaContext) (DeviceCloneStateJSONFile, error) {
+func newDeviceCloneStateReader(m MetaContext) (*DeviceCloneStateJSONFile, error) {
 	f := DeviceCloneStateJSONFile{NewJSONFile(m.G(), m.G().Env.GetDeviceCloneStateFilename(), "device clone state")}
 	err := f.Load(false)
-	return f, err
+	return &f, err
 }
 
 func newDeviceCloneStateWriter(m MetaContext) (*DeviceCloneStateJSONFile, error) {

--- a/go/libkb/device_clone_state.go
+++ b/go/libkb/device_clone_state.go
@@ -5,8 +5,6 @@ package libkb
 
 import (
 	"fmt"
-
-	jsonw "github.com/keybase/go-jsonw"
 )
 
 const (
@@ -140,49 +138,4 @@ func newDeviceCloneStateWriter(m MetaContext) (*DeviceCloneStateJSONFile, error)
 	f := DeviceCloneStateJSONFile{NewJSONFile(m.G(), m.G().Env.GetDeviceCloneStateFilename(), "device clone state")}
 	err := f.Load(false)
 	return &f, err
-}
-
-func (f DeviceCloneStateJSONFile) GetStringAtPath(p string) (ret string, isSet bool) {
-	i, isSet := f.getValueAtPath(p, getString)
-	if isSet {
-		ret = i.(string)
-	}
-	return ret, isSet
-}
-
-func (f DeviceCloneStateJSONFile) GetIntAtPath(p string) (ret int, isSet bool) {
-	i, isSet := f.getValueAtPath(p, getInt)
-	if isSet {
-		ret = i.(int)
-	}
-	return ret, isSet
-}
-
-func (f DeviceCloneStateJSONFile) getValueAtPath(p string, getter valueGetter) (ret interface{}, isSet bool) {
-	var err error
-	ret, err = getter(f.jw.AtPath(p))
-	if err == nil {
-		isSet = true
-	}
-	return ret, isSet
-}
-
-func (f *DeviceCloneStateJSONFile) SetStringAtPath(p string, v string) error {
-	return f.setValueAtPath(p, getString, v)
-}
-
-func (f *DeviceCloneStateJSONFile) SetIntAtPath(p string, v int) error {
-	return f.setValueAtPath(p, getInt, v)
-}
-
-func (f *DeviceCloneStateJSONFile) setValueAtPath(p string, getter valueGetter, v interface{}) error {
-	existing, err := getter(f.jw.AtPath(p))
-
-	if err != nil || existing != v {
-		err = f.jw.SetValueAtPath(p, jsonw.NewWrapper(v))
-		if err == nil {
-			return f.Save()
-		}
-	}
-	return err
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -346,7 +346,7 @@ func (g *GlobalContext) ConfigureConfig() error {
 	if err = c.Check(); err != nil {
 		return err
 	}
-	g.Env.SetConfig(*c, c)
+	g.Env.SetConfig(c, c)
 	return nil
 }
 
@@ -360,7 +360,7 @@ func (g *GlobalContext) ConfigureUpdaterConfig() error {
 	c := NewJSONUpdaterConfigFile(g)
 	err := c.Load(false)
 	if err == nil {
-		g.Env.SetUpdaterConfig(*c)
+		g.Env.SetUpdaterConfig(c)
 	} else {
 		g.Log.Debug("Failed to open update config: %s\n", err)
 	}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -142,17 +142,21 @@ type KVStorer interface {
 	Delete(id DbKey) error
 }
 
-type ConfigReader interface {
-	configGetter
-
-	GetUserConfig() (*UserConfig, error)
-	GetUserConfigForUsername(s NormalizedUsername) (*UserConfig, error)
-	GetBundledCA(host string) string
+type JSONReader interface {
 	GetStringAtPath(string) (string, bool)
 	GetInterfaceAtPath(string) (interface{}, error)
 	GetBoolAtPath(string) (bool, bool)
 	GetIntAtPath(string) (int, bool)
 	GetNullAtPath(string) bool
+}
+
+type ConfigReader interface {
+	JSONReader
+	configGetter
+
+	GetUserConfig() (*UserConfig, error)
+	GetUserConfigForUsername(s NormalizedUsername) (*UserConfig, error)
+	GetBundledCA(host string) string
 	GetProofCacheLongDur() (time.Duration, bool)
 	GetProofCacheMediumDur() (time.Duration, bool)
 	GetProofCacheShortDur() (time.Duration, bool)
@@ -188,16 +192,20 @@ type ConfigWriterTransacter interface {
 	Abort() error
 }
 
+type JSONWriter interface {
+	SetStringAtPath(string, string) error
+	SetBoolAtPath(string, bool) error
+	SetIntAtPath(string, int) error
+	SetNullAtPath(string) error
+}
+
 type ConfigWriter interface {
+	JSONWriter
 	SetUserConfig(cfg *UserConfig, overwrite bool) error
 	SwitchUser(un NormalizedUsername) error
 	NukeUser(un NormalizedUsername) error
 	SetDeviceID(keybase1.DeviceID) error
-	SetStringAtPath(string, string) error
-	SetBoolAtPath(string, bool) error
-	SetIntAtPath(string, int) error
 	SetWrapperAtPath(string, *jsonw.Wrapper) error
-	SetNullAtPath(string) error
 	DeleteAtPath(string)
 	SetUpdatePreferenceAuto(bool) error
 	SetUpdatePreferenceSkip(string) error

--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -337,7 +337,7 @@ func (f *jsonFileTransaction) Commit() (err error) {
 
 type valueGetter func(*jsonw.Wrapper) (interface{}, error)
 
-func (f JSONFile) getValueAtPath(p string, getter valueGetter) (ret interface{}, isSet bool) {
+func (f *JSONFile) getValueAtPath(p string, getter valueGetter) (ret interface{}, isSet bool) {
 	var err error
 	ret, err = getter(f.jw.AtPath(p))
 	if err == nil {
@@ -358,15 +358,15 @@ func getInt(w *jsonw.Wrapper) (interface{}, error) {
 	return w.GetInt()
 }
 
-func (f JSONFile) GetFilename() string {
+func (f *JSONFile) GetFilename() string {
 	return f.filename
 }
 
-func (f JSONFile) GetInterfaceAtPath(p string) (i interface{}, err error) {
+func (f *JSONFile) GetInterfaceAtPath(p string) (i interface{}, err error) {
 	return f.jw.AtPath(p).GetInterface()
 }
 
-func (f JSONFile) GetStringAtPath(p string) (ret string, isSet bool) {
+func (f *JSONFile) GetStringAtPath(p string) (ret string, isSet bool) {
 	i, isSet := f.getValueAtPath(p, getString)
 	if isSet {
 		ret = i.(string)
@@ -374,7 +374,7 @@ func (f JSONFile) GetStringAtPath(p string) (ret string, isSet bool) {
 	return ret, isSet
 }
 
-func (f JSONFile) GetBoolAtPath(p string) (ret bool, isSet bool) {
+func (f *JSONFile) GetBoolAtPath(p string) (ret bool, isSet bool) {
 	i, isSet := f.getValueAtPath(p, getBool)
 	if isSet {
 		ret = i.(bool)
@@ -382,7 +382,7 @@ func (f JSONFile) GetBoolAtPath(p string) (ret bool, isSet bool) {
 	return ret, isSet
 }
 
-func (f JSONFile) GetIntAtPath(p string) (ret int, isSet bool) {
+func (f *JSONFile) GetIntAtPath(p string) (ret int, isSet bool) {
 	i, isSet := f.getValueAtPath(p, getInt)
 	if isSet {
 		ret = i.(int)
@@ -390,7 +390,7 @@ func (f JSONFile) GetIntAtPath(p string) (ret int, isSet bool) {
 	return ret, isSet
 }
 
-func (f JSONFile) GetNullAtPath(p string) (isSet bool) {
+func (f *JSONFile) GetNullAtPath(p string) (isSet bool) {
 	w := f.jw.AtPath(p)
 	isSet = w.IsNil() && w.Error() == nil
 	return isSet

--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -334,3 +334,103 @@ func (f *jsonFileTransaction) Commit() (err error) {
 
 	return err
 }
+
+type valueGetter func(*jsonw.Wrapper) (interface{}, error)
+
+func (f JSONFile) getValueAtPath(p string, getter valueGetter) (ret interface{}, isSet bool) {
+	var err error
+	ret, err = getter(f.jw.AtPath(p))
+	if err == nil {
+		isSet = true
+	}
+	return ret, isSet
+}
+
+func getString(w *jsonw.Wrapper) (interface{}, error) {
+	return w.GetString()
+}
+
+func getBool(w *jsonw.Wrapper) (interface{}, error) {
+	return w.GetBool()
+}
+
+func getInt(w *jsonw.Wrapper) (interface{}, error) {
+	return w.GetInt()
+}
+
+func (f JSONFile) GetFilename() string {
+	return f.filename
+}
+
+func (f JSONFile) GetInterfaceAtPath(p string) (i interface{}, err error) {
+	return f.jw.AtPath(p).GetInterface()
+}
+
+func (f JSONFile) GetStringAtPath(p string) (ret string, isSet bool) {
+	i, isSet := f.getValueAtPath(p, getString)
+	if isSet {
+		ret = i.(string)
+	}
+	return ret, isSet
+}
+
+func (f JSONFile) GetBoolAtPath(p string) (ret bool, isSet bool) {
+	i, isSet := f.getValueAtPath(p, getBool)
+	if isSet {
+		ret = i.(bool)
+	}
+	return ret, isSet
+}
+
+func (f JSONFile) GetIntAtPath(p string) (ret int, isSet bool) {
+	i, isSet := f.getValueAtPath(p, getInt)
+	if isSet {
+		ret = i.(int)
+	}
+	return ret, isSet
+}
+
+func (f JSONFile) GetNullAtPath(p string) (isSet bool) {
+	w := f.jw.AtPath(p)
+	isSet = w.IsNil() && w.Error() == nil
+	return isSet
+}
+
+func (f *JSONFile) setValueAtPath(p string, getter valueGetter, v interface{}) error {
+	existing, err := getter(f.jw.AtPath(p))
+
+	if err != nil || existing != v {
+		err = f.jw.SetValueAtPath(p, jsonw.NewWrapper(v))
+		if err == nil {
+			return f.Save()
+		}
+	}
+	return err
+}
+
+func (f *JSONFile) SetStringAtPath(p string, v string) error {
+	return f.setValueAtPath(p, getString, v)
+}
+
+func (f *JSONFile) SetBoolAtPath(p string, v bool) error {
+	return f.setValueAtPath(p, getBool, v)
+}
+
+func (f *JSONFile) SetIntAtPath(p string, v int) error {
+	return f.setValueAtPath(p, getInt, v)
+}
+
+func (f *JSONFile) SetInt64AtPath(p string, v int64) error {
+	return f.setValueAtPath(p, getInt, v)
+}
+
+func (f *JSONFile) SetNullAtPath(p string) (err error) {
+	existing := f.jw.AtPath(p)
+	if !existing.IsNil() || existing.Error() != nil {
+		err = f.jw.SetValueAtPath(p, jsonw.NewNil())
+		if err == nil {
+			return f.Save()
+		}
+	}
+	return err
+}

--- a/go/libkb/json_test.go
+++ b/go/libkb/json_test.go
@@ -12,6 +12,13 @@ type JSONTestFile struct {
 	*JSONFile
 }
 
+type JSONTestReader interface {
+	JSONReader
+}
+type JSONTestWriter interface {
+	JSONWriter
+}
+
 func TestJsonTransaction(t *testing.T) {
 	tc := SetupTest(t, "json", 1)
 	defer tc.Cleanup()
@@ -40,30 +47,30 @@ func TestJsonTransaction(t *testing.T) {
 	wg.Wait()
 }
 
-func buildNewJSONFile(m *MetaContext) (reader JSONTestFile, writer *JSONTestFile) {
+func buildNewJSONFile(m MetaContext) (JSONTestReader, JSONTestWriter, *JSONTestFile) {
 	path := filepath.Join(m.G().Env.GetConfigDir(), "test-json-file")
 	jsonFile := JSONTestFile{NewJSONFile(m.G(), path, "device clone state")}
 	jsonFile.Load(false)
-	reader, writer = jsonFile, &jsonFile
-	return reader, writer
+	return &jsonFile, &jsonFile, &jsonFile
 }
 
 func TestJsonSetAndGetString(t *testing.T) {
 	tc := SetupTest(t, "json", 1)
 	defer tc.Cleanup()
 	m := NewMetaContextForTest(tc)
-	reader, writer := buildNewJSONFile(&m)
-	defer writer.Nuke()
+	reader, writer, rawFile := buildNewJSONFile(m)
+	defer rawFile.Nuke()
 
+	//verify that the path is empty first
 	path := "america.montana.bozeman"
 	value := "The American Computer Museum"
 	firstRead, isRet := reader.GetStringAtPath(path)
 	require.False(tc.T, isRet)
 	require.Equal(tc.T, firstRead, "")
 
+	//set, get, inspect
 	err := writer.SetStringAtPath(path, value)
 	require.NoError(tc.T, err)
-
 	secondRead, isRet := reader.GetStringAtPath(path)
 	require.True(tc.T, isRet)
 	require.Equal(tc.T, secondRead, value)
@@ -73,18 +80,19 @@ func TestJsonSetAndGetInt(t *testing.T) {
 	tc := SetupTest(t, "json", 1)
 	defer tc.Cleanup()
 	m := NewMetaContextForTest(tc)
-	reader, writer := buildNewJSONFile(&m)
-	defer writer.Nuke()
+	reader, writer, rawFile := buildNewJSONFile(m)
+	defer rawFile.Nuke()
 
+	//verify that the path is empty first
 	path := "candy.skittles.count"
 	value := 12
 	firstRead, isRet := reader.GetIntAtPath(path)
 	require.False(tc.T, isRet)
 	require.Equal(tc.T, firstRead, 0)
 
+	//set, get, inspect
 	err := writer.SetIntAtPath(path, value)
 	require.NoError(tc.T, err)
-
 	secondRead, isRet := reader.GetIntAtPath(path)
 	require.True(tc.T, isRet)
 	require.Equal(tc.T, secondRead, value)
@@ -94,18 +102,19 @@ func TestJsonSetAndGetBool(t *testing.T) {
 	tc := SetupTest(t, "json", 1)
 	defer tc.Cleanup()
 	m := NewMetaContextForTest(tc)
-	reader, writer := buildNewJSONFile(&m)
-	defer writer.Nuke()
+	reader, writer, rawFile := buildNewJSONFile(m)
+	defer rawFile.Nuke()
 
+	//verify that the path is empty first
 	path := "colors.orange.appetizing"
 	value := true
 	firstRead, isRet := reader.GetBoolAtPath(path)
 	require.False(tc.T, isRet)
 	require.Equal(tc.T, firstRead, false)
 
+	//set, get, inspect
 	err := writer.SetBoolAtPath(path, value)
 	require.NoError(tc.T, err)
-
 	secondRead, isRet := reader.GetBoolAtPath(path)
 	require.True(tc.T, isRet)
 	require.True(tc.T, secondRead)
@@ -115,19 +124,21 @@ func TestJsonSetAndGetNull(t *testing.T) {
 	tc := SetupTest(t, "json", 1)
 	defer tc.Cleanup()
 	m := NewMetaContextForTest(tc)
-	reader, writer := buildNewJSONFile(&m)
-	defer writer.Nuke()
+	reader, writer, rawFile := buildNewJSONFile(m)
+	defer rawFile.Nuke()
 
+	//verify that the path is empty first
+	//and that GetNull knows the path wasn't set
 	path := "worldcup.victories.croatia"
 	value := 2018
-
 	isRet := reader.GetNullAtPath(path)
 	require.False(tc.T, isRet)
 
+	//set, get, inspect
 	_ = writer.SetIntAtPath(path, value)
 	secondRead, _ := reader.GetIntAtPath(path)
 	require.Equal(tc.T, secondRead, value)
-
+	// null it out and verify
 	err := writer.SetNullAtPath(path)
 	require.NoError(tc.T, err)
 	isRet = reader.GetNullAtPath(path)

--- a/go/libkb/json_test.go
+++ b/go/libkb/json_test.go
@@ -1,9 +1,16 @@
 package libkb
 
 import (
+	"path/filepath"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+type JSONTestFile struct {
+	*JSONFile
+}
 
 func TestJsonTransaction(t *testing.T) {
 	tc := SetupTest(t, "json", 1)
@@ -31,4 +38,98 @@ func TestJsonTransaction(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func buildNewJSONFile(m *MetaContext) (reader JSONTestFile, writer *JSONTestFile) {
+	path := filepath.Join(m.G().Env.GetConfigDir(), "test-json-file")
+	jsonFile := JSONTestFile{NewJSONFile(m.G(), path, "device clone state")}
+	jsonFile.Load(false)
+	reader, writer = jsonFile, &jsonFile
+	return reader, writer
+}
+
+func TestJsonSetAndGetString(t *testing.T) {
+	tc := SetupTest(t, "json", 1)
+	defer tc.Cleanup()
+	m := NewMetaContextForTest(tc)
+	reader, writer := buildNewJSONFile(&m)
+	defer writer.Nuke()
+
+	path := "america.montana.bozeman"
+	value := "The American Computer Museum"
+	firstRead, isRet := reader.GetStringAtPath(path)
+	require.False(tc.T, isRet)
+	require.Equal(tc.T, firstRead, "")
+
+	err := writer.SetStringAtPath(path, value)
+	require.NoError(tc.T, err)
+
+	secondRead, isRet := reader.GetStringAtPath(path)
+	require.True(tc.T, isRet)
+	require.Equal(tc.T, secondRead, value)
+}
+
+func TestJsonSetAndGetInt(t *testing.T) {
+	tc := SetupTest(t, "json", 1)
+	defer tc.Cleanup()
+	m := NewMetaContextForTest(tc)
+	reader, writer := buildNewJSONFile(&m)
+	defer writer.Nuke()
+
+	path := "candy.skittles.count"
+	value := 12
+	firstRead, isRet := reader.GetIntAtPath(path)
+	require.False(tc.T, isRet)
+	require.Equal(tc.T, firstRead, 0)
+
+	err := writer.SetIntAtPath(path, value)
+	require.NoError(tc.T, err)
+
+	secondRead, isRet := reader.GetIntAtPath(path)
+	require.True(tc.T, isRet)
+	require.Equal(tc.T, secondRead, value)
+}
+
+func TestJsonSetAndGetBool(t *testing.T) {
+	tc := SetupTest(t, "json", 1)
+	defer tc.Cleanup()
+	m := NewMetaContextForTest(tc)
+	reader, writer := buildNewJSONFile(&m)
+	defer writer.Nuke()
+
+	path := "colors.orange.appetizing"
+	value := true
+	firstRead, isRet := reader.GetBoolAtPath(path)
+	require.False(tc.T, isRet)
+	require.Equal(tc.T, firstRead, false)
+
+	err := writer.SetBoolAtPath(path, value)
+	require.NoError(tc.T, err)
+
+	secondRead, isRet := reader.GetBoolAtPath(path)
+	require.True(tc.T, isRet)
+	require.True(tc.T, secondRead)
+}
+
+func TestJsonSetAndGetNull(t *testing.T) {
+	tc := SetupTest(t, "json", 1)
+	defer tc.Cleanup()
+	m := NewMetaContextForTest(tc)
+	reader, writer := buildNewJSONFile(&m)
+	defer writer.Nuke()
+
+	path := "worldcup.victories.croatia"
+	value := 2018
+
+	isRet := reader.GetNullAtPath(path)
+	require.False(tc.T, isRet)
+
+	_ = writer.SetIntAtPath(path, value)
+	secondRead, _ := reader.GetIntAtPath(path)
+	require.Equal(tc.T, secondRead, value)
+
+	err := writer.SetNullAtPath(path)
+	require.NoError(tc.T, err)
+	isRet = reader.GetNullAtPath(path)
+	require.True(tc.T, isRet)
 }

--- a/go/libkb/updater_config.go
+++ b/go/libkb/updater_config.go
@@ -14,7 +14,7 @@ type JSONUpdaterConfigFile struct {
 	*JSONFile
 }
 
-func (j JSONUpdaterConfigFile) GetInstallID() (ret InstallID) {
+func (j *JSONUpdaterConfigFile) GetInstallID() (ret InstallID) {
 	if !j.Exists() {
 		return ret
 	}
@@ -29,4 +29,4 @@ func NewJSONUpdaterConfigFile(g *GlobalContext) *JSONUpdaterConfigFile {
 	return &JSONUpdaterConfigFile{NewJSONFile(g, g.Env.GetUpdaterConfigFilename(), "updater config")}
 }
 
-var _ UpdaterConfigReader = JSONUpdaterConfigFile{}
+var _ UpdaterConfigReader = &JSONUpdaterConfigFile{}


### PR DESCRIPTION
* take the opportunity to dry out some shared json file manipulation functionality by pushing it down to `json.go`. and add some tests for it.
* doing ^ allowed `go vet` to identify the mutex issue. `ConfigReader` is an interface around a `JSONConfigFile`, which has a pointer to a `JSONFile` which has a mutex. The `ConfigWriter` (basically the same thing as a `ConfigReader` except with the `Set` methods instead of `Get`) was always passed around by reference 👍, but the `ConfigReader` was usually passed around by value. I don't think it's likely to have caused a problem (honestly, I don't know), but maybe it's safer to pass these by reference. And it'll hopefully be faster and leaner and stuff because pointers are smaller than `JSONConfigFile`s.