### PR TITLE
Chat: Render Repo Create Message

### DIFF
--- a/shared/chat/conversation/messages/system-git-push/index.js
+++ b/shared/chat/conversation/messages/system-git-push/index.js
@@ -1,10 +1,12 @@
 // @flow
+import {invert} from 'lodash'
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
 import UserNotice from '../user-notice'
 import {Box, Text, ConnectedUsernames, TimelineMarker, Icon} from '../../../../common-adapters'
 import {globalStyles, globalColors, globalMargins, isMobile, platformStyles} from '../../../../styles'
 import {formatTimeForMessages} from '../../../../util/timestamp'
+import {gitGitPushType} from '../../../../constants/types/rpc-gen'
 
 type Props = {
   message: Types.MessageSystemGitPush,
@@ -12,9 +14,8 @@ type Props = {
   onViewGitRepo: (repoID: string, teamname: string) => void,
 }
 
-const PUSH_DEFAULT = 0
-const PUSH_CREATE = 1
-const PUSH_RENAME = 3
+// Map [int] -> 'push type string'
+const gitPushType = invert(gitGitPushType)
 
 const connectedUsernamesProps = {
   clickable: true,
@@ -121,8 +122,10 @@ class GitPush extends React.PureComponent<Props> {
   render() {
     const {timestamp, repo, repoID, refs, pushType, pusher, team} = this.props.message
 
-    switch (pushType) {
-      case PUSH_DEFAULT:
+    const gitType = gitPushType[pushType]
+
+    switch (gitType) {
+      case 'default':
         return refs.map(ref => {
           const branchName = ref.refName.split('/')[2]
           return (
@@ -145,7 +148,7 @@ class GitPush extends React.PureComponent<Props> {
             </GitPushCommon>
           )
         })
-      case PUSH_CREATE:
+      case 'createrepo':
         return (
           <GitPushCommon
             timestamp={timestamp}
@@ -162,9 +165,7 @@ class GitPush extends React.PureComponent<Props> {
             />
           </GitPushCommon>
         )
-      case PUSH_RENAME:
-        return null
-
+      // FIXME: @Jacob - The service has not implemented 'renamerepo' yet, so we don't render anything
       default:
         return null
     }

--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -211,6 +211,7 @@ const makeMessageSystemText: I.RecordFactory<MessageTypes._MessageSystemText> = 
 
 const makeMessageSystemGitPush: I.RecordFactory<MessageTypes._MessageSystemGitPush> = I.Record({
   ...makeMessageMinimum,
+  pushType: 0,
   pusher: '',
   reactions: I.Map(),
   refs: [],
@@ -367,9 +368,11 @@ const uiMessageToSystemMessage = (minimum, body): ?Types.Message => {
       })
     }
     case RPCChatTypes.localMessageSystemType.gitpush: {
-      const {team = '???', pusher = '???', repoName: repo = '???', repoID = '???', refs} = body.gitpush || {}
+      const {team = '???', pushType = 0, pusher = '???', repoName: repo = '???', repoID = '???', refs} =
+        body.gitpush || {}
       return makeMessageSystemGitPush({
         ...minimum,
+        pushType,
         pusher,
         refs: refs || [],
         repo,

--- a/shared/constants/types/chat2/message.js
+++ b/shared/constants/types/chat2/message.js
@@ -187,6 +187,7 @@ export type _MessageSystemGitPush = {
   id: MessageID,
   ordinal: Ordinal,
   pusher: string,
+  pushType: RPCTypes.GitPushType,
   reactions: Reactions,
   refs: Array<RPCTypes.GitRefMetadata>,
   repo: string,


### PR DESCRIPTION
### Problem

`MessageSystemGitPush` receives an integer flag from the service (`pushType`), however the UI did not read this flag and render accordingly. After #12590, we render timestamps above all message types for a better UX. However, when a repo creation event comes in, we render the timestamp wrapper but not an actual system message component.

![screen shot 2018-07-19 at 5 12 43 pm](https://user-images.githubusercontent.com/5200812/42970325-080f0d1c-8b77-11e8-9a3b-57936ce51121.png)

### Solution 

We pass the `pushType` along with the message creation for `MessageSystemGitPush` and read it in `chat/conversation/message/system-git-push/`.

![screen shot 2018-07-19 at 5 13 04 pm](https://user-images.githubusercontent.com/5200812/42970408-31a3c9a6-8b77-11e8-96d1-d2fc1286fece.png)
