### PR TITLE
engine.ResolveAndCheck calls into resolver and then checks proofs

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -1085,7 +1085,7 @@ type evilResolver struct {
 func (e *evilResolver) ResolveFullExpressionWithBody(ctx context.Context, s string) libkb.ResolveResult {
 	ret := e.ResolverImpl.ResolveFullExpressionWithBody(ctx, s)
 	if strings.HasPrefix(s, e.badPrefix) {
-		ret.SetUID(e.badUID)
+		ret.SetUIDForTesting(e.badUID)
 	}
 	return ret
 }

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -459,7 +459,12 @@ func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 			noMe:  true,
 			cache: tester,
 			tcl:   importTrackingLink(t, tc.G),
-			allowUntrackedFastPath: true,
+			// MK 2018-07-20 BUG BUG BUG! This test originally wanted to
+			// set allowUntrackedFastPath:true, but because noMe was
+			// set, that flag had no effect. So I think there's a bug of
+			// some sort here, that the intention of the test isn't captured
+			// in the test itself. To fix. See: CORE-8352
+			// allowUntrackedFastPath: true,  // THIS IS BuggY!
 		}
 
 		waiter := launchWaiter(t, tester.finishCh)
@@ -1088,11 +1093,11 @@ func TestResolveAndCheck(t *testing.T) {
 		{"foobunny+foobunny@github", libkb.NotFoundError{}},
 	}
 	for _, test := range tests {
-		uid, un, err := ResolveAndCheck(m, test.s)
+		upk, err := ResolveAndCheck(m, test.s)
 		require.IsType(t, test.e, err)
 		if err == nil {
-			require.True(t, uid.Equal(tracyUID))
-			require.True(t, un.Eq(libkb.NewNormalizedUsername("t_tracy")))
+			require.True(t, upk.GetUID().Equal(tracyUID))
+			require.Equal(t, upk.GetName(), "t_tracy")
 		}
 	}
 }

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -15,6 +15,7 @@ type ResolveThenIdentify2 struct {
 	i2eng                 *Identify2WithUID
 	testArgs              *Identify2WithUIDTestArgs
 	responsibleGregorItem gregor.Item
+	queriedName           libkb.NormalizedUsername
 
 	// When tracking is being performed, the identify engine is used with a tracking ui.
 	// These options are sent to the ui based on command line options.
@@ -87,6 +88,8 @@ func (e *ResolveThenIdentify2) resolveUID(m libkb.MetaContext) (err error) {
 		// the resolve assertion was a keybase username or UID, so remove it
 		// from identify2 arg to allow cache hits on UID.
 		e.arg.UserAssertion = ""
+		// But still check on that way out that the username matches the UID
+		e.queriedName = rres.GetNormalizedQueriedUsername()
 	}
 
 	// An optimization --- plumb through the resolve body for when we load the
@@ -113,7 +116,18 @@ func (e *ResolveThenIdentify2) Run(m libkb.MetaContext) (err error) {
 
 	// For testing
 	e.i2eng.testArgs = e.testArgs
-	return RunEngine2(m, e.i2eng)
+	err = RunEngine2(m, e.i2eng)
+	if err != nil {
+		return err
+	}
+
+	// Check the server for cheating on a Name->UID resolution. After we do a userload (by UID),
+	// we should have a merkle-verified idea of what the corresponding name is, so we check it
+	// as a post-assertion here.
+	if !e.queriedName.IsNil() && !libkb.NewNormalizedUsername(e.Result().Upk.GetName()).Eq(e.queriedName) {
+		return libkb.NewUIDMismatchError("bad user returned for " + e.queriedName.String())
+	}
+	return nil
 }
 
 func (e *ResolveThenIdentify2) Result() *keybase1.Identify2Res {
@@ -149,9 +163,11 @@ func (e *ResolveThenIdentify2) GetProofSet() *libkb.ProofSet {
 // assertions are met. Pass into it a MetaContext without any UIs set, since it
 // is meant to run without any UI interaction. Also note that tracker statements
 // are *not* taken into account. The identify is run as if the user is logged out.
-func ResolveAndCheck(m libkb.MetaContext, s string) (uid keybase1.UID, un libkb.NormalizedUsername, err error) {
+// The output, on success, is a populated UserPlusKeysV2.
+func ResolveAndCheck(m libkb.MetaContext, s string) (ret keybase1.UserPlusKeysV2, err error) {
 	m = m.WithLogTag("RAC")
 	defer m.CTraceTimed("ResolveAndCheck", func() error { return err })()
+
 	arg := keybase1.Identify2Arg{
 		UserAssertion:         s,
 		CanSuppressUI:         true,
@@ -161,9 +177,27 @@ func ResolveAndCheck(m libkb.MetaContext, s string) (uid keybase1.UID, un libkb.
 	}
 	eng := NewResolveThenIdentify2(m.G(), &arg)
 	err = RunEngine2(m, eng)
-	res := eng.Result()
 	if err != nil {
-		return uid, un, err
+		return ret, err
 	}
-	return res.Upk.GetUID(), libkb.NewNormalizedUsername(res.Upk.GetName()), nil
+	res := eng.Result()
+
+	// Note: this is slightly wasteful since we already loaded a UPAK V1 in Identify2WithUID,
+	// (downconverted from a V2), and now we're just reloading the V2. But the alternative was a big
+	// refactor, and we're punting on that for now. The good news is this load will almost always hit the
+	// cache (see identifyUser#load, which loads both the UPAK and the full user at the same time).
+	upk, _, err := m.G().GetUPAKLoader().LoadV2(libkb.NewLoadUserArgWithMetaContext(m).WithUID(res.Upk.GetUID()))
+	if err != nil {
+		return ret, err
+	}
+	curr := upk.Current
+
+	// There's a slight chance of a race, that the user reset, so just check we didn't race,
+	// and if so, error out.
+	if curr.EldestSeqno != res.Upk.EldestSeqno {
+		return ret, libkb.NewAccountResetError(curr.ToUserVersion(), res.Upk.EldestSeqno)
+	}
+
+	// Success path.
+	return curr, nil
 }

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -85,6 +85,7 @@ func (e *ResolveThenIdentify2) resolveUID(m libkb.MetaContext) (err error) {
 	}
 	e.arg.Uid = rres.GetUID()
 	if rres.WasKBAssertion() && !e.arg.NeedProofSet {
+		m.CDebugf("Assertion was 'KB' and we don't need proofset: %s", e.arg.UserAssertion)
 		// the resolve assertion was a keybase username or UID, so remove it
 		// from identify2 arg to allow cache hits on UID.
 		e.arg.UserAssertion = ""

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -158,14 +158,18 @@ func (e *ResolveThenIdentify2) GetProofSet() *libkb.ProofSet {
 }
 
 // ResolveAndCheck takes as input a name (joe), social assertion (joe@twitter)
-// or compound assertion (joe+joe@twitter+3883883773222@pgp) and invokes
-// the whole resolve/identify machinery. That is, it performs a server-trusted
-// resolution of the name to a UID, then does an ID on the UID to make sure all
-// assertions are met. Pass into it a MetaContext without any UIs set, since it
-// is meant to run without any UI interaction. Also note that tracker statements
-// are *not* taken into account. The identify is run as if the user is logged out.
-// The output, on success, is a populated UserPlusKeysV2.
+// or compound assertion (joe+joe@twitter+3883883773222@pgp) and resolves
+// it to a user, verifying the result. Pass into it a MetaContext without any UIs set,
+// since it is meant to run without any UI interaction. Also note that tracker statements
+// are *not* taken into account. No ID2-specific caching will be used, but the UPAK
+// cache will be used, and busted with ForceRepoll semantics. The output, on success,
+// is a populated UserPlusKeysV2.
 func ResolveAndCheck(m libkb.MetaContext, s string) (ret keybase1.UserPlusKeysV2, err error) {
+
+	// Invokes the whole resolve/identify machinery. That is, it performs a server-trusted
+	// resolution of the name to a UID, then does an ID on the UID to make sure all
+	// assertions are met. The identify is run as if the user is logged out.
+
 	m = m.WithLogTag("RAC")
 	defer m.CTraceTimed("ResolveAndCheck", func() error { return err })()
 

--- a/go/externals/resolve_test.go
+++ b/go/externals/resolve_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	clockwork "github.com/keybase/clockwork"
 	libkb "github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	clockwork "github.com/keybase/clockwork"
 	"golang.org/x/net/context"
 )
 
-func newTestResolverCache(g *libkb.GlobalContext) (*libkb.ResolverImpl, clockwork.FakeClock){
+func newTestResolverCache(g *libkb.GlobalContext) (*libkb.ResolverImpl, clockwork.FakeClock) {
 	clock := clockwork.NewFakeClockAt(time.Now())
 	g.SetClock(clock)
 	res := libkb.NewResolverImpl(g)

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -54,7 +54,7 @@ type GlobalContext struct {
 	perUserKeyringMu *sync.Mutex
 	perUserKeyring   *PerUserKeyring      // Keyring holding per user keys
 	API              API                  // How to make a REST call to the server
-	Resolver         *Resolver            // cache of resolve results
+	Resolver         Resolver             // cache of resolve results
 	LocalDb          *JSONLocalDb         // Local DB for cache
 	LocalChatDb      *JSONLocalDb         // Local DB for cache
 	MerkleClient     *MerkleClient        // client for querying server's merkle sig tree
@@ -213,7 +213,7 @@ func (g *GlobalContext) SetEKLib(ekLib EKLib) { g.ekLib = ekLib }
 func (g *GlobalContext) Init() *GlobalContext {
 	g.Env = NewEnv(nil, nil, g.GetLog)
 	g.Service = false
-	g.Resolver = NewResolver(g)
+	g.Resolver = NewResolverImpl(g)
 	g.RateLimits = NewRateLimits(g)
 	g.upakLoader = NewUncachedUPAKLoader(g)
 	g.teamLoader = newNullTeamLoader(g)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -787,6 +787,9 @@ type ChatHelper interface {
 	AckMobileNotificationSuccess(ctx context.Context, pushIDs []string)
 }
 
+// Resolver resolves human-readable usernames (joe) and user asssertions (joe+joe@github)
+// into UIDs. It is based on sever-trust. All results are unverified. So you should check
+// its answer if used in a security-sensitive setting. (See engine.ResolveAndCheck)
 type Resolver interface {
 	EnableCaching()
 	Shutdown()

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -786,3 +786,14 @@ type ChatHelper interface {
 		convID chat1.ConversationID, membersType chat1.ConversationMembersType, payload string) (string, error)
 	AckMobileNotificationSuccess(ctx context.Context, pushIDs []string)
 }
+
+type Resolver interface {
+	EnableCaching()
+	Shutdown()
+	ResolveFullExpression(ctx context.Context, input string) (res ResolveResult)
+	ResolveFullExpressionNeedUsername(ctx context.Context, input string) (res ResolveResult)
+	ResolveFullExpressionWithBody(ctx context.Context, input string) (res ResolveResult)
+	ResolveUser(ctx context.Context, assertion string) (u keybase1.User, res ResolveResult, err error)
+	ResolveWithBody(input string) ResolveResult
+	Resolve(input string) ResolveResult
+}

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -28,6 +28,7 @@ type ResolveResult struct {
 	cachedAt           time.Time
 	mutable            bool
 	deleted            bool
+	isCompound         bool
 }
 
 func (res ResolveResult) HasPrimaryKey() bool {
@@ -47,6 +48,11 @@ const (
 
 func (res *ResolveResult) GetUID() keybase1.UID {
 	return res.uid
+}
+
+// SetUID should only be used by testing
+func (res *ResolveResult) SetUID(u keybase1.UID) {
+	res.uid = u
 }
 
 func (res *ResolveResult) User() keybase1.User {
@@ -88,7 +94,7 @@ func (res *ResolveResult) GetTeamName() keybase1.TeamName {
 }
 
 func (res *ResolveResult) WasKBAssertion() bool {
-	return res.queriedKbUsername != "" || res.queriedByUID
+	return (res.queriedKbUsername != "" && !res.isCompound) || res.queriedByUID
 }
 
 func (res *ResolveResult) GetError() error {
@@ -110,15 +116,15 @@ func (res ResolveResult) FailOnDeleted() ResolveResult {
 	return res
 }
 
-func (r *Resolver) ResolveWithBody(input string) ResolveResult {
+func (r *ResolverImpl) ResolveWithBody(input string) ResolveResult {
 	return r.resolve(input, true)
 }
 
-func (r *Resolver) Resolve(input string) ResolveResult {
+func (r *ResolverImpl) Resolve(input string) ResolveResult {
 	return r.resolve(input, false)
 }
 
-func (r *Resolver) resolve(input string, withBody bool) (res ResolveResult) {
+func (r *ResolverImpl) resolve(input string, withBody bool) (res ResolveResult) {
 	defer r.G().Trace(fmt.Sprintf("Resolving username %q", input), func() error { return res.err })()
 
 	var au AssertionURL
@@ -129,19 +135,19 @@ func (r *Resolver) resolve(input string, withBody bool) (res ResolveResult) {
 	return res
 }
 
-func (r *Resolver) ResolveFullExpression(ctx context.Context, input string) (res ResolveResult) {
+func (r *ResolverImpl) ResolveFullExpression(ctx context.Context, input string) (res ResolveResult) {
 	return r.resolveFullExpression(ctx, input, false, false)
 }
 
-func (r *Resolver) ResolveFullExpressionNeedUsername(ctx context.Context, input string) (res ResolveResult) {
+func (r *ResolverImpl) ResolveFullExpressionNeedUsername(ctx context.Context, input string) (res ResolveResult) {
 	return r.resolveFullExpression(ctx, input, false, true)
 }
 
-func (r *Resolver) ResolveFullExpressionWithBody(ctx context.Context, input string) (res ResolveResult) {
+func (r *ResolverImpl) ResolveFullExpressionWithBody(ctx context.Context, input string) (res ResolveResult) {
 	return r.resolveFullExpression(ctx, input, true, false)
 }
 
-func (r *Resolver) ResolveUser(ctx context.Context, assertion string) (u keybase1.User, res ResolveResult, err error) {
+func (r *ResolverImpl) ResolveUser(ctx context.Context, assertion string) (u keybase1.User, res ResolveResult, err error) {
 	res = r.ResolveFullExpressionNeedUsername(ctx, assertion)
 	err = res.GetError()
 	if err != nil {
@@ -154,7 +160,7 @@ func (r *Resolver) ResolveUser(ctx context.Context, assertion string) (u keybase
 	return u, res, nil
 }
 
-func (r *Resolver) resolveFullExpression(ctx context.Context, input string, withBody bool, needUsername bool) (res ResolveResult) {
+func (r *ResolverImpl) resolveFullExpression(ctx context.Context, input string, withBody bool, needUsername bool) (res ResolveResult) {
 	defer r.G().CVTrace(ctx, VLog1, fmt.Sprintf("Resolver#resolveFullExpression(%q)", input), func() error { return res.err })()
 
 	var expr AssertionExpression
@@ -167,7 +173,9 @@ func (r *Resolver) resolveFullExpression(ctx context.Context, input string, with
 		res.err = ResolutionError{Input: input, Msg: "Cannot find a resolvable factor"}
 		return res
 	}
-	return r.resolveURL(ctx, u, input, withBody, needUsername)
+	ret := r.resolveURL(ctx, u, input, withBody, needUsername)
+	ret.isCompound = len(expr.CollectUrls(nil)) > 1
+	return ret
 }
 
 func (res *ResolveResult) addKeybaseNameIfKnown(au AssertionURL) {
@@ -176,7 +184,7 @@ func (res *ResolveResult) addKeybaseNameIfKnown(au AssertionURL) {
 	}
 }
 
-func (r *Resolver) getFromDiskCache(ctx context.Context, key string, au AssertionURL) (ret *ResolveResult) {
+func (r *ResolverImpl) getFromDiskCache(ctx context.Context, key string, au AssertionURL) (ret *ResolveResult) {
 	defer r.G().CVTraceOK(ctx, VLog1, fmt.Sprintf("Resolver#getFromDiskCache(%q)", key), func() bool { return ret != nil })()
 	var uid keybase1.UID
 	found, err := r.G().LocalDb.GetInto(&uid, resolveDbKey(key))
@@ -201,7 +209,7 @@ func isMutable(au AssertionURL) bool {
 	return !(au.IsUID() || au.IsKeybase())
 }
 
-func (r *Resolver) getFromUPAKLoader(ctx context.Context, uid keybase1.UID) (ret *ResolveResult) {
+func (r *ResolverImpl) getFromUPAKLoader(ctx context.Context, uid keybase1.UID) (ret *ResolveResult) {
 	nun, err := r.G().GetUPAKLoader().LookupUsername(ctx, uid)
 	if err != nil {
 		return nil
@@ -209,7 +217,7 @@ func (r *Resolver) getFromUPAKLoader(ctx context.Context, uid keybase1.UID) (ret
 	return &ResolveResult{uid: uid, queriedByUID: true, resolvedKbUsername: nun.String(), mutable: false}
 }
 
-func (r *Resolver) resolveURL(ctx context.Context, au AssertionURL, input string, withBody bool, needUsername bool) (res ResolveResult) {
+func (r *ResolverImpl) resolveURL(ctx context.Context, au AssertionURL, input string, withBody bool, needUsername bool) (res ResolveResult) {
 	ck := au.CacheKey()
 
 	lock := r.locktab.AcquireOnName(ctx, r.G(), ck)
@@ -268,7 +276,7 @@ func (r *Resolver) resolveURL(ctx context.Context, au AssertionURL, input string
 	return res
 }
 
-func (r *Resolver) resolveURLViaServerLookup(ctx context.Context, au AssertionURL, input string, withBody bool) (res ResolveResult) {
+func (r *ResolverImpl) resolveURLViaServerLookup(ctx context.Context, au AssertionURL, input string, withBody bool) (res ResolveResult) {
 	defer r.G().CVTrace(ctx, VLog1, fmt.Sprintf("Resolver#resolveURLViaServerLookup(input = %q)", input), func() error { return res.err })()
 
 	if au.IsTeamID() || au.IsTeamName() {
@@ -367,7 +375,7 @@ func (t *teamLookup) GetAppStatus() *AppStatus {
 	return &t.Status
 }
 
-func (r *Resolver) resolveTeamViaServerLookup(ctx context.Context, au AssertionURL) (res ResolveResult) {
+func (r *ResolverImpl) resolveTeamViaServerLookup(ctx context.Context, au AssertionURL) (res ResolveResult) {
 	r.G().Log.CDebugf(ctx, "resolveTeamViaServerLookup")
 
 	res.queriedByTeamID = au.IsTeamID()
@@ -410,11 +418,10 @@ type ResolveCacheStats struct {
 	diskPuts        int
 }
 
-type Resolver struct {
+type ResolverImpl struct {
 	Contextified
 	cache   *ramcache.Ramcache
 	Stats   ResolveCacheStats
-	NowFunc func() time.Time
 	locktab LockTable
 }
 
@@ -426,29 +433,28 @@ func (s ResolveCacheStats) EqWithDiskHits(m, t, mt, et, h, dh int) bool {
 	return (s.misses == m) && (s.timeouts == t) && (s.mutableTimeouts == mt) && (s.errorTimeouts == et) && (s.hits == h) && (s.diskGetHits == dh)
 }
 
-func NewResolver(g *GlobalContext) *Resolver {
-	return &Resolver{
+func NewResolverImpl(g *GlobalContext) *ResolverImpl {
+	return &ResolverImpl{
 		Contextified: NewContextified(g),
 		cache:        nil,
-		NowFunc:      func() time.Time { return time.Now() },
 	}
 }
 
-func (r *Resolver) EnableCaching() {
+func (r *ResolverImpl) EnableCaching() {
 	cache := ramcache.New()
 	cache.MaxAge = ResolveCacheMaxAge
 	cache.TTL = resolveCacheTTL
 	r.cache = cache
 }
 
-func (r *Resolver) Shutdown() {
+func (r *ResolverImpl) Shutdown() {
 	if r.cache == nil {
 		return
 	}
 	r.cache.Shutdown()
 }
 
-func (r *Resolver) getFromMemCache(ctx context.Context, key string, au AssertionURL) (ret *ResolveResult) {
+func (r *ResolverImpl) getFromMemCache(ctx context.Context, key string, au AssertionURL) (ret *ResolveResult) {
 	defer r.G().CVTraceOK(ctx, VLog1, fmt.Sprintf("Resolver#getFromMemCache(%q)", key), func() bool { return ret != nil })()
 	if r.cache == nil {
 		return nil
@@ -468,7 +474,7 @@ func (r *Resolver) getFromMemCache(ctx context.Context, key string, au Assertion
 		r.G().Log.CInfof(ctx, "Resolver#getFromMemCache: nil UID/teamID in cache")
 		return nil
 	}
-	now := r.NowFunc()
+	now := r.G().Clock().Now()
 	if now.Sub(rres.cachedAt) > ResolveCacheMaxAge {
 		r.Stats.timeouts++
 		return nil
@@ -493,7 +499,7 @@ func resolveDbKey(key string) DbKey {
 	}
 }
 
-func (r *Resolver) putToDiskCache(ctx context.Context, key string, res ResolveResult) {
+func (r *ResolverImpl) putToDiskCache(ctx context.Context, key string, res ResolveResult) {
 	r.G().VDL.CLogf(ctx, VLog1, "| Resolver#putToDiskCache (attempt) %+v", res)
 	// Only cache immutable resolutions to disk
 	if res.mutable {
@@ -521,7 +527,7 @@ func (r *Resolver) putToDiskCache(ctx context.Context, key string, res ResolveRe
 
 // Put receives a copy of a ResolveResult, clears out the body
 // to avoid caching data that can go stale, and stores the result.
-func (r *Resolver) putToMemCache(key string, res ResolveResult) {
+func (r *ResolverImpl) putToMemCache(key string, res ResolveResult) {
 	if r.cache == nil {
 		return
 	}
@@ -536,7 +542,9 @@ func (r *Resolver) putToMemCache(key string, res ResolveResult) {
 		}
 		return
 	}
-	res.cachedAt = r.NowFunc()
+	res.cachedAt = r.G().Clock().Now()
 	res.body = nil // Don't cache body
 	r.cache.Set(key, &res)
 }
+
+var _ Resolver = (*ResolverImpl)(nil)

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -50,8 +50,7 @@ func (res *ResolveResult) GetUID() keybase1.UID {
 	return res.uid
 }
 
-// SetUID should only be used by testing
-func (res *ResolveResult) SetUID(u keybase1.UID) {
+func (res *ResolveResult) SetUIDForTesting(u keybase1.UID) {
 	res.uid = u
 }
 

--- a/go/libkb/upak.go
+++ b/go/libkb/upak.go
@@ -113,3 +113,7 @@ func TrackChainLinkFromUserPlusAllKeys(u *keybase1.UserPlusAllKeys, username Nor
 	tcl, err = TrackChainLinkFor(u.Base.Uid, uid, tcl, err, g)
 	return tcl, err
 }
+
+func NormalizedUsernameFromUPK2(u keybase1.UserPlusKeysV2) NormalizedUsername {
+	return NewNormalizedUsername(u.Username)
+}

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -510,7 +510,7 @@ func (g *GlobalContext) Trace(msg string, f func() error) func() {
 }
 
 func (g *GlobalContext) ExitTrace(msg string, f func() error) func() {
-	return func() { g.Log.Debug("| %s -> %s", msg, ErrToOk(f())) }
+	return func() { g.Log.CloneWithAddedDepth(1).Debug("| %s -> %s", msg, ErrToOk(f())) }
 }
 
 func (g *GlobalContext) CTrace(ctx context.Context, msg string, f func() error) func() {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1206,7 +1206,8 @@ func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 	switch b {
 	case TLFIdentifyBehavior_CHAT_GUI,
 		TLFIdentifyBehavior_CHAT_GUI_STRICT,
-		TLFIdentifyBehavior_SALTPACK:
+		TLFIdentifyBehavior_SALTPACK,
+		TLFIdentifyBehavior_RESOLVE_AND_CHECK:
 		return true
 	default:
 		// TLFIdentifyBehavior_DEFAULT_KBFS, for filesystem activity that
@@ -1238,7 +1239,26 @@ func (b TLFIdentifyBehavior) SkipUserCard() bool {
 	default:
 		return false
 	}
+}
 
+func (b TLFIdentifyBehavior) AllowCaching() bool {
+	switch b {
+	case TLFIdentifyBehavior_RESOLVE_AND_CHECK:
+		// We Don't want to use any internal ID2 caching for ResolveAndCheck.
+		return false
+	default:
+		return true
+	}
+}
+
+func (b TLFIdentifyBehavior) AllowDeletedUsers() bool {
+	switch b {
+	case TLFIdentifyBehavior_RESOLVE_AND_CHECK:
+		// ResolveAndCheck is OK with deleted users
+		return true
+	default:
+		return false
+	}
 }
 
 // All of the chat modes want to prevent tracker popups.

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1222,9 +1222,23 @@ func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 		// track errors, because people need to be able to use it to ask each other
 		// about the fact that proofs are broken.
 		return true
+	case TLFIdentifyBehavior_RESOLVE_AND_CHECK:
+		// Tracks don't matter for ResolveAndCheck, since we act logged out.
+		return true
 	default:
 		return false
 	}
+}
+
+func (b TLFIdentifyBehavior) SkipUserCard() bool {
+	switch b {
+	case TLFIdentifyBehavior_CHAT_GUI, TLFIdentifyBehavior_RESOLVE_AND_CHECK:
+		// We don't need to bother loading a user card in these cases.
+		return true
+	default:
+		return false
+	}
+
 }
 
 // All of the chat modes want to prevent tracker popups.
@@ -1236,6 +1250,7 @@ func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
 		TLFIdentifyBehavior_KBFS_REKEY,
 		TLFIdentifyBehavior_KBFS_QR,
 		TLFIdentifyBehavior_SALTPACK,
+		TLFIdentifyBehavior_RESOLVE_AND_CHECK,
 		TLFIdentifyBehavior_KBFS_CHAT:
 		// These are identifies that either happen without user interaction at
 		// all, or happen while you're staring at some Keybase UI that can

--- a/go/protocol/keybase1/identify.go
+++ b/go/protocol/keybase1/identify.go
@@ -148,6 +148,7 @@ type Identify2Arg struct {
 	CanSuppressUI         bool                `codec:"canSuppressUI" json:"canSuppressUI"`
 	IdentifyBehavior      TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 	ForceDisplay          bool                `codec:"forceDisplay" json:"forceDisplay"`
+	ActLoggedOut          bool                `codec:"actLoggedOut" json:"actLoggedOut"`
 }
 
 type IdentifyLiteArg struct {

--- a/go/protocol/keybase1/tlf_keys.go
+++ b/go/protocol/keybase1/tlf_keys.go
@@ -11,35 +11,37 @@ import (
 type TLFIdentifyBehavior int
 
 const (
-	TLFIdentifyBehavior_UNSET           TLFIdentifyBehavior = 0
-	TLFIdentifyBehavior_CHAT_CLI        TLFIdentifyBehavior = 1
-	TLFIdentifyBehavior_CHAT_GUI        TLFIdentifyBehavior = 2
-	TLFIdentifyBehavior_CHAT_GUI_STRICT TLFIdentifyBehavior = 3
-	TLFIdentifyBehavior_KBFS_REKEY      TLFIdentifyBehavior = 4
-	TLFIdentifyBehavior_KBFS_QR         TLFIdentifyBehavior = 5
-	TLFIdentifyBehavior_CHAT_SKIP       TLFIdentifyBehavior = 6
-	TLFIdentifyBehavior_SALTPACK        TLFIdentifyBehavior = 7
-	TLFIdentifyBehavior_CLI             TLFIdentifyBehavior = 8
-	TLFIdentifyBehavior_GUI             TLFIdentifyBehavior = 9
-	TLFIdentifyBehavior_DEFAULT_KBFS    TLFIdentifyBehavior = 10
-	TLFIdentifyBehavior_KBFS_CHAT       TLFIdentifyBehavior = 11
+	TLFIdentifyBehavior_UNSET             TLFIdentifyBehavior = 0
+	TLFIdentifyBehavior_CHAT_CLI          TLFIdentifyBehavior = 1
+	TLFIdentifyBehavior_CHAT_GUI          TLFIdentifyBehavior = 2
+	TLFIdentifyBehavior_CHAT_GUI_STRICT   TLFIdentifyBehavior = 3
+	TLFIdentifyBehavior_KBFS_REKEY        TLFIdentifyBehavior = 4
+	TLFIdentifyBehavior_KBFS_QR           TLFIdentifyBehavior = 5
+	TLFIdentifyBehavior_CHAT_SKIP         TLFIdentifyBehavior = 6
+	TLFIdentifyBehavior_SALTPACK          TLFIdentifyBehavior = 7
+	TLFIdentifyBehavior_CLI               TLFIdentifyBehavior = 8
+	TLFIdentifyBehavior_GUI               TLFIdentifyBehavior = 9
+	TLFIdentifyBehavior_DEFAULT_KBFS      TLFIdentifyBehavior = 10
+	TLFIdentifyBehavior_KBFS_CHAT         TLFIdentifyBehavior = 11
+	TLFIdentifyBehavior_RESOLVE_AND_CHECK TLFIdentifyBehavior = 12
 )
 
 func (o TLFIdentifyBehavior) DeepCopy() TLFIdentifyBehavior { return o }
 
 var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
-	"UNSET":           0,
-	"CHAT_CLI":        1,
-	"CHAT_GUI":        2,
-	"CHAT_GUI_STRICT": 3,
-	"KBFS_REKEY":      4,
-	"KBFS_QR":         5,
-	"CHAT_SKIP":       6,
-	"SALTPACK":        7,
-	"CLI":             8,
-	"GUI":             9,
-	"DEFAULT_KBFS":    10,
-	"KBFS_CHAT":       11,
+	"UNSET":             0,
+	"CHAT_CLI":          1,
+	"CHAT_GUI":          2,
+	"CHAT_GUI_STRICT":   3,
+	"KBFS_REKEY":        4,
+	"KBFS_QR":           5,
+	"CHAT_SKIP":         6,
+	"SALTPACK":          7,
+	"CLI":               8,
+	"GUI":               9,
+	"DEFAULT_KBFS":      10,
+	"KBFS_CHAT":         11,
+	"RESOLVE_AND_CHECK": 12,
 }
 
 var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
@@ -55,6 +57,7 @@ var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
 	9:  "GUI",
 	10: "DEFAULT_KBFS",
 	11: "KBFS_CHAT",
+	12: "RESOLVE_AND_CHECK",
 }
 
 func (e TLFIdentifyBehavior) String() string {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -843,7 +843,7 @@ func loadUserVersionPlusByUsername(ctx context.Context, g *libkb.GlobalContext, 
 		}
 		return "", keybase1.UserVersion{}, err
 	}
-	uv, err := loadUserVersionByUPK2(ctx, g, upk)
+	uv, err := filterUserCornerCases(ctx, upk)
 	return libkb.NormalizedUsernameFromUPK2(upk), uv, err
 }
 
@@ -873,7 +873,7 @@ func loadUserVersionByUsername(ctx context.Context, g *libkb.GlobalContext, user
 		return keybase1.UserVersion{}, err
 	}
 
-	return loadUserVersionByUPK2(ctx, g, upk)
+	return filterUserCornerCases(ctx, upk)
 }
 
 func loadUserVersionByUID(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID) (keybase1.UserVersion, error) {
@@ -881,10 +881,10 @@ func loadUserVersionByUID(ctx context.Context, g *libkb.GlobalContext, uid keyba
 	if err != nil {
 		return keybase1.UserVersion{}, err
 	}
-	return loadUserVersionByUPK2(ctx, g, upak.Current)
+	return filterUserCornerCases(ctx, upak.Current)
 }
 
-func loadUserVersionByUPK2(ctx context.Context, g *libkb.GlobalContext, upak keybase1.UserPlusKeysV2) (keybase1.UserVersion, error) {
+func filterUserCornerCases(ctx context.Context, upak keybase1.UserPlusKeysV2) (keybase1.UserVersion, error) {
 	uv := upak.ToUserVersion()
 	if upak.Status == keybase1.StatusCode_SCDeleted {
 		return uv, errUserDeleted

--- a/protocol/avdl/keybase1/identify.avdl
+++ b/protocol/avdl/keybase1/identify.avdl
@@ -44,7 +44,8 @@ protocol identify {
     boolean noSkipSelf=true,
     boolean canSuppressUI=false,
     TLFIdentifyBehavior identifyBehavior=0,
-    boolean forceDisplay=false
+    boolean forceDisplay=false,
+    boolean actLoggedOut=false
   );
   record IdentifyLiteRes {
     UserOrTeamLite ul;

--- a/protocol/avdl/keybase1/tlf_keys.avdl
+++ b/protocol/avdl/keybase1/tlf_keys.avdl
@@ -18,7 +18,8 @@ protocol tlfKeys {
     CLI_8,
     GUI_9,
     DEFAULT_KBFS_10,
-    KBFS_CHAT_11
+    KBFS_CHAT_11,
+    RESOLVE_AND_CHECK_12
   }
 
   @typedef("string")

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -699,6 +699,7 @@ export const tlfKeysTLFIdentifyBehavior = {
   gui: 9,
   defaultKbfs: 10,
   kbfsChat: 11,
+  resolveAndCheck: 12,
 }
 
 export const uPKKeyType = {
@@ -1225,7 +1226,7 @@ export type HomeScreenTodoType =
 export type HomeUIHomeUIRefreshRpcParam = void
 export type HomeUserSummary = $ReadOnly<{uid: UID, username: String, bio: String, fullName: String, pics?: ?Pics}>
 export type Identify2Res = $ReadOnly<{upk: UserPlusKeys, identifiedAt: Time, trackBreaks?: ?IdentifyTrackBreaks}>
-export type IdentifyIdentify2RpcParam = $ReadOnly<{uid: UID, userAssertion: String, reason: IdentifyReason, useDelegateUI?: Boolean, alwaysBlock?: Boolean, noErrorOnTrackFailure?: Boolean, forceRemoteCheck?: Boolean, needProofSet?: Boolean, allowEmptySelfID?: Boolean, noSkipSelf?: Boolean, canSuppressUI?: Boolean, identifyBehavior?: TLFIdentifyBehavior, forceDisplay?: Boolean}>
+export type IdentifyIdentify2RpcParam = $ReadOnly<{uid: UID, userAssertion: String, reason: IdentifyReason, useDelegateUI?: Boolean, alwaysBlock?: Boolean, noErrorOnTrackFailure?: Boolean, forceRemoteCheck?: Boolean, needProofSet?: Boolean, allowEmptySelfID?: Boolean, noSkipSelf?: Boolean, canSuppressUI?: Boolean, identifyBehavior?: TLFIdentifyBehavior, forceDisplay?: Boolean, actLoggedOut?: Boolean}>
 export type IdentifyIdentifyLiteRpcParam = $ReadOnly<{id: UserOrTeamID, assertion: String, reason: IdentifyReason, useDelegateUI?: Boolean, alwaysBlock?: Boolean, noErrorOnTrackFailure?: Boolean, forceRemoteCheck?: Boolean, needProofSet?: Boolean, allowEmptySelfID?: Boolean, noSkipSelf?: Boolean, canSuppressUI?: Boolean, identifyBehavior?: TLFIdentifyBehavior, forceDisplay?: Boolean}>
 export type IdentifyKey = $ReadOnly<{pgpFingerprint: Bytes, KID: KID, trackDiff?: ?TrackDiff, breaksTracking: Boolean}>
 export type IdentifyLiteRes = $ReadOnly<{ul: UserOrTeamLite, trackBreaks?: ?IdentifyTrackBreaks}>
@@ -2031,6 +2032,7 @@ export type TLFIdentifyBehavior =
   | 9 // GUI_9
   | 10 // DEFAULT_KBFS_10
   | 11 // KBFS_CHAT_11
+  | 12 // RESOLVE_AND_CHECK_12
 
 export type TLFIdentifyFailure = $ReadOnly<{user: User, breaks?: ?IdentifyTrackBreaks}>
 export type TLFQuery = $ReadOnly<{tlfName: String, identifyBehavior: TLFIdentifyBehavior}>

--- a/protocol/json/keybase1/identify.json
+++ b/protocol/json/keybase1/identify.json
@@ -196,6 +196,11 @@
           "name": "forceDisplay",
           "type": "boolean",
           "default": false
+        },
+        {
+          "name": "actLoggedOut",
+          "type": "boolean",
+          "default": false
         }
       ],
       "response": "Identify2Res"

--- a/protocol/json/keybase1/tlf_keys.json
+++ b/protocol/json/keybase1/tlf_keys.json
@@ -26,7 +26,8 @@
         "CLI_8",
         "GUI_9",
         "DEFAULT_KBFS_10",
-        "KBFS_CHAT_11"
+        "KBFS_CHAT_11",
+        "RESOLVE_AND_CHECK_12"
       ]
     },
     {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -699,6 +699,7 @@ export const tlfKeysTLFIdentifyBehavior = {
   gui: 9,
   defaultKbfs: 10,
   kbfsChat: 11,
+  resolveAndCheck: 12,
 }
 
 export const uPKKeyType = {
@@ -1225,7 +1226,7 @@ export type HomeScreenTodoType =
 export type HomeUIHomeUIRefreshRpcParam = void
 export type HomeUserSummary = $ReadOnly<{uid: UID, username: String, bio: String, fullName: String, pics?: ?Pics}>
 export type Identify2Res = $ReadOnly<{upk: UserPlusKeys, identifiedAt: Time, trackBreaks?: ?IdentifyTrackBreaks}>
-export type IdentifyIdentify2RpcParam = $ReadOnly<{uid: UID, userAssertion: String, reason: IdentifyReason, useDelegateUI?: Boolean, alwaysBlock?: Boolean, noErrorOnTrackFailure?: Boolean, forceRemoteCheck?: Boolean, needProofSet?: Boolean, allowEmptySelfID?: Boolean, noSkipSelf?: Boolean, canSuppressUI?: Boolean, identifyBehavior?: TLFIdentifyBehavior, forceDisplay?: Boolean}>
+export type IdentifyIdentify2RpcParam = $ReadOnly<{uid: UID, userAssertion: String, reason: IdentifyReason, useDelegateUI?: Boolean, alwaysBlock?: Boolean, noErrorOnTrackFailure?: Boolean, forceRemoteCheck?: Boolean, needProofSet?: Boolean, allowEmptySelfID?: Boolean, noSkipSelf?: Boolean, canSuppressUI?: Boolean, identifyBehavior?: TLFIdentifyBehavior, forceDisplay?: Boolean, actLoggedOut?: Boolean}>
 export type IdentifyIdentifyLiteRpcParam = $ReadOnly<{id: UserOrTeamID, assertion: String, reason: IdentifyReason, useDelegateUI?: Boolean, alwaysBlock?: Boolean, noErrorOnTrackFailure?: Boolean, forceRemoteCheck?: Boolean, needProofSet?: Boolean, allowEmptySelfID?: Boolean, noSkipSelf?: Boolean, canSuppressUI?: Boolean, identifyBehavior?: TLFIdentifyBehavior, forceDisplay?: Boolean}>
 export type IdentifyKey = $ReadOnly<{pgpFingerprint: Bytes, KID: KID, trackDiff?: ?TrackDiff, breaksTracking: Boolean}>
 export type IdentifyLiteRes = $ReadOnly<{ul: UserOrTeamLite, trackBreaks?: ?IdentifyTrackBreaks}>
@@ -2031,6 +2032,7 @@ export type TLFIdentifyBehavior =
   | 9 // GUI_9
   | 10 // DEFAULT_KBFS_10
   | 11 // KBFS_CHAT_11
+  | 12 // RESOLVE_AND_CHECK_12
 
 export type TLFIdentifyFailure = $ReadOnly<{user: User, breaks?: ?IdentifyTrackBreaks}>
 export type TLFQuery = $ReadOnly<{tlfName: String, identifyBehavior: TLFIdentifyBehavior}>


### PR DESCRIPTION
- uses the identify2_with_uid machinery
- use it in teams where we were previously server-trusting