### PR TITLE
If ReAddMemberAfterReset is no-op, return nil error

### DIFF
--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -358,3 +358,11 @@ func NewAttemptedInviteSocialOwnerError(assertion string) error {
 }
 
 func (e AttemptedInviteSocialOwnerError) Error() string { return e.Msg }
+
+type UserHasNotResetError struct{ Msg string }
+
+func NewUserHasNotResetError(format string, args ...interface{}) error {
+	return UserHasNotResetError{Msg: fmt.Sprintf(format, args...)}
+}
+
+func (e UserHasNotResetError) Error() string { return e.Msg }

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -491,14 +491,14 @@ func TestReAddMemberWithSameUV(t *testing.T) {
 
 	t.Logf("created team id: %s", teamObj.ID)
 
-	err = ReAddMemberAfterReset(context.Background(), tcs[0].G, teamObj.ID, bob.Username)
-	require.IsType(t, libkb.ExistsError{}, err)
+	err = reAddMemberAfterResetInner(context.Background(), tcs[0].G, teamObj.ID, bob.Username)
+	require.IsType(t, UserHasNotResetError{}, err)
 
 	err = ReAddMemberAfterReset(context.Background(), tcs[0].G, teamObj.ID, jun.Username)
-	require.IsType(t, libkb.ExistsError{}, err)
+	require.NoError(t, err)
 
-	err = ReAddMemberAfterReset(context.Background(), tcs[0].G, teamObj.ID, hal.Username)
-	require.IsType(t, libkb.ExistsError{}, err)
+	err = reAddMemberAfterResetInner(context.Background(), tcs[0].G, teamObj.ID, hal.Username)
+	require.IsType(t, UserHasNotResetError{}, err)
 
 	// Now, the fun part (bug CORE-8099):
 
@@ -512,8 +512,7 @@ func TestReAddMemberWithSameUV(t *testing.T) {
 	err = ReAddMemberAfterReset(context.Background(), tcs[0].G, teamObj.ID, bob.Username)
 	require.NoError(t, err)
 
-	// Subsequent calls should start failing with ExistsError again
-	// and cancel old invite and add new one for same UV.
-	err = ReAddMemberAfterReset(context.Background(), tcs[0].G, teamObj.ID, bob.Username)
-	require.IsType(t, libkb.ExistsError{}, err)
+	// Subsequent calls should start UserHasNotResetErrorin again
+	err = reAddMemberAfterResetInner(context.Background(), tcs[0].G, teamObj.ID, bob.Username)
+	require.IsType(t, UserHasNotResetError{}, err)
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -389,10 +389,9 @@ func ReAddMemberAfterReset(ctx context.Context, g *libkb.GlobalContext, teamID k
 		}
 
 		if existingUV.EldestSeqno == uv.EldestSeqno {
-			return libkb.ExistsError{
-				Msg: fmt.Sprintf("user %s has not reset, no need to re-add, existing: %v new: %v",
-					username, existingUV.EldestSeqno, uv.EldestSeqno),
-			}
+			g.Log.CDebugf(ctx, "user %s has not reset, no need to re-add, existing: %v new: %v",
+				username, existingUV.EldestSeqno, uv.EldestSeqno)
+			return nil
 		}
 
 		hasPUK := len(upak.Current.PerUserKeys) > 0


### PR DESCRIPTION
Some explanation in https://keybase.atlassian.net/browse/CORE-8272

This change makes it so that clicking let-them-in button repeatedly does not cause a global error.