### PR TITLE
BuildPayment and LookupRecipient resolve stellar -> keybase

### DIFF
--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -356,6 +356,7 @@ func (o SendAssetChoiceLocal) DeepCopy() SendAssetChoiceLocal {
 type BuildPaymentResLocal struct {
 	ReadyToSend      bool              `codec:"readyToSend" json:"readyToSend"`
 	ToErrMsg         string            `codec:"toErrMsg" json:"toErrMsg"`
+	ToUsername       string            `codec:"toUsername" json:"toUsername"`
 	AmountErrMsg     string            `codec:"amountErrMsg" json:"amountErrMsg"`
 	SecretNoteErrMsg string            `codec:"secretNoteErrMsg" json:"secretNoteErrMsg"`
 	PublicMemoErrMsg string            `codec:"publicMemoErrMsg" json:"publicMemoErrMsg"`
@@ -368,6 +369,7 @@ func (o BuildPaymentResLocal) DeepCopy() BuildPaymentResLocal {
 	return BuildPaymentResLocal{
 		ReadyToSend:      o.ReadyToSend,
 		ToErrMsg:         o.ToErrMsg,
+		ToUsername:       o.ToUsername,
 		AmountErrMsg:     o.AmountErrMsg,
 		SecretNoteErrMsg: o.SecretNoteErrMsg,
 		PublicMemoErrMsg: o.PublicMemoErrMsg,

--- a/go/stellar/relays/relays.go
+++ b/go/stellar/relays/relays.go
@@ -33,7 +33,7 @@ func GetKey(ctx context.Context, g *libkb.GlobalContext,
 	}
 	switch {
 	case recipient.User != nil:
-		impTeamNameStruct.Writers.KeybaseUsers = append(impTeamNameStruct.Writers.KeybaseUsers, recipient.User.GetNormalizedName().String())
+		impTeamNameStruct.Writers.KeybaseUsers = append(impTeamNameStruct.Writers.KeybaseUsers, recipient.User.Username.String())
 	case recipient.Assertion != nil:
 		impTeamNameStruct.Writers.UnresolvedUsers = append(impTeamNameStruct.Writers.UnresolvedUsers, *recipient.Assertion)
 	default:

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -255,6 +255,20 @@ func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput) (res 
 		if err != nil {
 			return res, err
 		}
+		uv, username, err := LookupUserByAccountID(m, stellar1.AccountID(to))
+		switch err.(type) {
+		case nil:
+			res.User = &stellarcommon.User{
+				UV:       uv,
+				Username: username,
+			}
+			return res, nil
+		case libkb.NotFoundError:
+			// common case
+		default:
+			m.CDebugf("identifyRecipient: lookup accountID->user accountID:%v err:%v", res.AccountID, err)
+			// log and ignore
+		}
 		return res, nil
 	}
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1159,7 +1159,7 @@ func MakeRequest(m libkb.MetaContext, remoter remote.Remoter, arg MakeRequestArg
 
 // Lookup a user who has the stellar account ID.
 // Verifies the result against the user's sigchain.
-// If there are multiple users, returns an arbitrary one.
+// If there are no users, or multiple users, returns NotFoundError.
 func LookupUserByAccountID(m libkb.MetaContext, accountID stellar1.AccountID) (uv keybase1.UserVersion, un libkb.NormalizedUsername, err error) {
 	defer m.CTraceTimed(fmt.Sprintf("Stellar.LookupUserByAccount(%v)", accountID), func() error { return err })()
 	usersUnverified, err := remote.LookupUnverified(m.Ctx(), m.G(), accountID)
@@ -1172,6 +1172,9 @@ func LookupUserByAccountID(m libkb.MetaContext, accountID stellar1.AccountID) (u
 	}
 	if len(usersUnverified) == 0 {
 		return uv, un, libkb.NotFoundError{Msg: fmt.Sprintf("No user found with account %v", accountID)}
+	}
+	if len(usersUnverified) > 1 {
+		return uv, un, libkb.NotFoundError{Msg: fmt.Sprintf("Multiple users found with account: %v", accountID)}
 	}
 	uv = usersUnverified[0]
 	// Verify that `uv` (from server) matches `accountID`.

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -237,6 +237,10 @@ func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput) (res 
 	}
 
 	storeAddress := func(address string) error {
+		_, err := libkb.ParseStellarAccountID(address)
+		if err != nil {
+			return err
+		}
 		accountID, err := stellarnet.NewAddressStr(address)
 		if err != nil {
 			return err

--- a/go/stellar/stellarcommon/common.go
+++ b/go/stellar/stellarcommon/common.go
@@ -11,8 +11,13 @@ type RecipientInput string
 type Recipient struct {
 	Input RecipientInput
 	// These 3 fields are nullable.
-	User      *libkb.User
+	User      *User
 	Assertion *keybase1.SocialAssertion
 	// Recipient may not have a stellar wallet ready to receive
 	AccountID *stellarnet.AddressStr // User entered G... OR target has receiving address
+}
+
+type User struct {
+	UV       keybase1.UserVersion
+	Username libkb.NormalizedUsername
 }

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -891,6 +891,7 @@ func (s *Server) BuildPaymentLocal(ctx context.Context, arg stellar1.BuildPaymen
 			}
 			bannerThem := "their"
 			if recipient.User != nil {
+				res.ToUsername = recipient.User.Username.String()
 				bannerThem = fmt.Sprintf("%s's", recipient.User.Username)
 			}
 			if recipient.AccountID == nil {

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -891,7 +891,7 @@ func (s *Server) BuildPaymentLocal(ctx context.Context, arg stellar1.BuildPaymen
 			}
 			bannerThem := "their"
 			if recipient.User != nil {
-				bannerThem = fmt.Sprintf("%s's", recipient.User.GetNormalizedName())
+				bannerThem = fmt.Sprintf("%s's", recipient.User.Username)
 			}
 			if recipient.AccountID == nil {
 				// Sending a payment to a target with no account. (relay)

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/stellar"
 	"github.com/keybase/client/go/stellar/remote"
@@ -960,12 +961,81 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "This is *26.7020180 XLM*", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{})
+
+	t.Logf("sending to account ID")
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:          senderAccountID,
+		To:            "GBJCIIIWEP2ZIKSNY3AP5GJ5OHNSN6Y4W5K4IVIY4VSQF5QLVE27GADK",
+		ToIsAccountID: true,
+		Amount:        "8.50",
+		Currency:      &usd,
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, true, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, "", bres.ToUsername) // account does not resolve to keybase user
+	require.Equal(t, "", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "", bres.PublicMemoErrMsg)
+	require.Equal(t, "This is *26.7020180 XLM*", bres.WorthDescription)
+	require.Equal(t, worthInfo, bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
+		Level:   "info",
+		Message: "Because it's their first transaction, you must send at least 1 XLM.",
+	}})
+
+	t.Logf("sending to account ID that resolves")
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:          senderAccountID,
+		To:            senderAccountID.String(),
+		ToIsAccountID: true,
+		Amount:        "8.50",
+		Currency:      &usd,
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, true, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, tcs[0].Fu.Username, bres.ToUsername) // account resolves to self
+	require.Equal(t, "", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "", bres.PublicMemoErrMsg)
+	require.Equal(t, "This is *26.7020180 XLM*", bres.WorthDescription)
+	require.Equal(t, worthInfo, bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{})
+
+	upak, _, err := tcs[0].G.GetUPAKLoader().LoadV2(
+		libkb.NewLoadUserArgWithMetaContext(tcs[0].MetaContext()).WithPublicKeyOptional().
+			WithUID(tcs[1].Fu.User.GetUID()).WithForcePoll(true))
+	require.NoError(t, err)
+	require.NotNil(t, upak.Current.StellarAccountID)
+
+	t.Logf("sending to account ID that resolves")
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:          senderAccountID,
+		To:            *upak.Current.StellarAccountID,
+		ToIsAccountID: true,
+		Amount:        "8.50",
+		Currency:      &usd,
+	})
+	require.NoError(t, err)
+	t.Logf(spew.Sdump(bres))
+	require.Equal(t, true, bres.ReadyToSend)
+	require.Equal(t, "", bres.ToErrMsg)
+	require.Equal(t, tcs[1].Fu.Username, bres.ToUsername) // account resolves to other
+	require.Equal(t, "", bres.AmountErrMsg)
+	require.Equal(t, "", bres.SecretNoteErrMsg)
+	require.Equal(t, "", bres.PublicMemoErrMsg)
+	require.Equal(t, "This is *26.7020180 XLM*", bres.WorthDescription)
+	require.Equal(t, worthInfo, bres.WorthInfo)
+	requireBannerSet(t, bres, []stellar1.SendBannerLocal{})
 }
 
 // modifies `expected`
 func requireBannerSet(t testing.TB, bres stellar1.BuildPaymentResLocal, expected []stellar1.SendBannerLocal) {
 	if len(bres.Banners) != len(expected) {
-		t.Logf(spew.Sdump(bres.Banners))
+		t.Logf("%s", spew.Sdump(bres.Banners))
 		require.Len(t, bres.Banners, len(expected))
 	}
 	got := bres.DeepCopy().Banners

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -46,7 +46,7 @@ func TestCreateWallet(t *testing.T) {
 	defer cleanup()
 
 	t.Logf("Lookup for a bogus address")
-	uv, err := stellar.LookupUserByAccountID(tcs[0].MetaContext(), "GCCJJFCRCQAWDWRAZ3R6235KCQ4PQYE5KEWHGE5ICVTZLTMRKVWAWP7N")
+	uv, _, err := stellar.LookupUserByAccountID(tcs[0].MetaContext(), "GCCJJFCRCQAWDWRAZ3R6235KCQ4PQYE5KEWHGE5ICVTZLTMRKVWAWP7N")
 	require.Error(t, err)
 	require.IsType(t, libkb.NotFoundError{}, err)
 
@@ -74,11 +74,12 @@ func TestCreateWallet(t *testing.T) {
 
 	t.Logf("Lookup the user by public address as another user")
 	a1 := bundle.Accounts[0].AccountID
-	uv, err = stellar.LookupUserByAccountID(tcs[1].MetaContext(), a1)
+	uv, username, err := stellar.LookupUserByAccountID(tcs[1].MetaContext(), a1)
 	require.NoError(t, err)
 	require.Equal(t, tcs[0].Fu.GetUserVersion(), uv)
+	require.Equal(t, tcs[0].Fu.Username, username.String())
 	t.Logf("and as self")
-	uv, err = stellar.LookupUserByAccountID(tcs[0].MetaContext(), a1)
+	uv, _, err = stellar.LookupUserByAccountID(tcs[0].MetaContext(), a1)
 	require.NoError(t, err)
 	require.Equal(t, tcs[0].Fu.GetUserVersion(), uv)
 
@@ -101,12 +102,12 @@ func TestCreateWallet(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Lookup by the new primary")
-	uv, err = stellar.LookupUserByAccountID(tcs[1].MetaContext(), a2)
+	uv, _, err = stellar.LookupUserByAccountID(tcs[1].MetaContext(), a2)
 	require.NoError(t, err)
 	require.Equal(t, tcs[0].Fu.GetUserVersion(), uv)
 
 	t.Logf("Looking up by the old address no longer works")
-	uv, err = stellar.LookupUserByAccountID(tcs[1].MetaContext(), a1)
+	uv, _, err = stellar.LookupUserByAccountID(tcs[1].MetaContext(), a1)
 	require.Error(t, err)
 	require.IsType(t, libkb.NotFoundError{}, err)
 }

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -219,6 +219,10 @@ protocol local {
     // Example: "This stellar address is incorrect"
     string toErrMsg;
 
+    // Optional. `arg.to` may be an account ID that resolves to a user.
+    // If this is returned, caller should switch to (to=res.toUsername,toIsAccountID=false).
+    string toUsername;
+
     // Optional. Error to show with the amount field.
     // Example: "russel doesn't accept *BTC/Stronghold.com*\nPlease pick another asset."
     // Example: "Your available to send is *128.4567890 XLM*."

--- a/protocol/js/rpc-stellar-gen.js
+++ b/protocol/js/rpc-stellar-gen.js
@@ -96,7 +96,7 @@ export type BalanceDelta =
   | 1 // INCREASE_1
   | 2 // DECREASE_2
 
-export type BuildPaymentResLocal = $ReadOnly<{readyToSend: Boolean, toErrMsg: String, amountErrMsg: String, secretNoteErrMsg: String, publicMemoErrMsg: String, worthDescription: String, worthInfo: String, banners?: ?Array<SendBannerLocal>}>
+export type BuildPaymentResLocal = $ReadOnly<{readyToSend: Boolean, toErrMsg: String, toUsername: String, amountErrMsg: String, secretNoteErrMsg: String, publicMemoErrMsg: String, worthDescription: String, worthInfo: String, banners?: ?Array<SendBannerLocal>}>
 export type Bundle = $ReadOnly<{revision: BundleRevision, prev: Hash, ownHash: Hash, accounts?: ?Array<BundleEntry>}>
 export type BundleEntry = $ReadOnly<{accountID: AccountID, mode: AccountMode, isPrimary: Boolean, signers?: ?Array<SecretKey>, name: String}>
 export type BundleRevision = Uint64

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -383,6 +383,10 @@
         },
         {
           "type": "string",
+          "name": "toUsername"
+        },
+        {
+          "type": "string",
           "name": "amountErrMsg"
         },
         {

--- a/shared/constants/types/rpc-stellar-gen.js
+++ b/shared/constants/types/rpc-stellar-gen.js
@@ -96,7 +96,7 @@ export type BalanceDelta =
   | 1 // INCREASE_1
   | 2 // DECREASE_2
 
-export type BuildPaymentResLocal = $ReadOnly<{readyToSend: Boolean, toErrMsg: String, amountErrMsg: String, secretNoteErrMsg: String, publicMemoErrMsg: String, worthDescription: String, worthInfo: String, banners?: ?Array<SendBannerLocal>}>
+export type BuildPaymentResLocal = $ReadOnly<{readyToSend: Boolean, toErrMsg: String, toUsername: String, amountErrMsg: String, secretNoteErrMsg: String, publicMemoErrMsg: String, worthDescription: String, worthInfo: String, banners?: ?Array<SendBannerLocal>}>
 export type Bundle = $ReadOnly<{revision: BundleRevision, prev: Hash, ownHash: Hash, accounts?: ?Array<BundleEntry>}>
 export type BundleEntry = $ReadOnly<{accountID: AccountID, mode: AccountMode, isPrimary: Boolean, signers?: ?Array<SecretKey>, name: String}>
 export type BundleRevision = Uint64


### PR DESCRIPTION
BuildPayment when given a stellar account can now return the corresponding keybase username if there is someone with that primary account. Needed so that the gui can flip the entry field.

As a consequence `LookupRecipient` and `wallet send` also resolve now. Like this:
```
$ kbu wallet send GAZLIYW4RT7EKX6LYVTFAAXPXHL2MCIFUGUCMSBRW537NER3MA5E7LXV 10 XLM
Send 10 XLM to GAZLIYW4RT7EKX6LYVTFAAXPXHL2MCIFUGUCMSBRW537NER3MA5E7LXV? (type 'YES' to confirm): YES
Sent!
Keybase Transaction ID: 1a9ab5a08b168dc84014a28248b94230
Stellar Transaction ID: 9e2042e5ea2a840e260c6ba9cc467672b4860a47a74d03ddc45b8821c75be84d

$ kbu wallet history
2018/07/20 17:23
10 XLM
alice -> bob
```