### PR TITLE
Order operations in AddMemberTx per UID

### DIFF
--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -161,8 +161,8 @@ func TestTeamTxDependency(t *testing.T) {
 	tx.AddMemberByUsername(context.Background(), bob.username, keybase1.TeamRole_WRITER)
 
 	// TODO: this has to pass once this feature is in. See ticket CORE-7147.
-	// payloads := tx.DebugPayloads()
-	// require.Equal(t, 3, len(payloads))
+	payloads := tx.DebugPayloads()
+	require.Equal(t, 3, len(payloads))
 
 	err = tx.Post(libkb.NewMetaContextForTest(*ann.tc))
 	require.NoError(t, err)

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -459,7 +459,7 @@ func HandleTeamSeitan(ctx context.Context, g *libkb.GlobalContext, msg keybase1.
 
 		if currentRole.IsOrAbove(invite.Role) {
 			g.Log.CDebugf(ctx, "User already has same or higher role, canceling invite.")
-			tx.CancelInvite(invite.Id)
+			tx.CancelInvite(invite.Id, uv.Uid)
 			continue
 		}
 

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -36,6 +36,8 @@ type AddMemberTx struct {
 type txTeamInvitesKeybase struct{ Val SCTeamInvites }
 type txTeamInvitesSocial struct{ Val SCTeamInvites }
 
+// getInviteSection returns SCTeamInvites field from either
+// *txTeamInvitesKeybase or *txTeamInvitesSocial without reflection.
 func getInviteSection(payload interface{}) (*SCTeamInvites, error) {
 	switch p := payload.(type) {
 	case *txTeamInvitesKeybase:
@@ -69,7 +71,7 @@ func (tx *AddMemberTx) IsEmpty() bool {
 func (tx *AddMemberTx) findPayload(typ interface{}) interface{} {
 	refType := reflect.TypeOf(typ)
 	for _, v := range tx.payloads {
-		if reflect.TypeOf(v) == refType {
+		if reflect.TypeOf(v).Elem() == refType {
 			return v
 		}
 	}
@@ -87,11 +89,13 @@ func (tx *AddMemberTx) findPayload(typ interface{}) interface{} {
 // satisfied.
 
 func (tx *AddMemberTx) invitePayload() *SCTeamInvites {
-	return &tx.findPayload(txTeamInvitesKeybase{}).(*txTeamInvitesKeybase).Val
+	p := tx.findPayload(txTeamInvitesKeybase{}).(*txTeamInvitesKeybase)
+	return &p.Val
 }
 
 func (tx *AddMemberTx) inviteSocialPayload() *SCTeamInvites {
-	return &tx.findPayload(txTeamInvitesSocial{}).(*txTeamInvitesSocial).Val
+	p := tx.findPayload(txTeamInvitesSocial{}).(*txTeamInvitesSocial)
+	return &p.Val
 }
 
 func (tx *AddMemberTx) changeMembershipPayload() *keybase1.TeamChangeReq {

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -72,21 +72,22 @@ func getInviteSection(payload interface{}) (*SCTeamInvites, error) {
 
 func (tx *AddMemberTx) findPayload(typ interface{}, forUID keybase1.UID) interface{} {
 	minSeqno := 0
-	if !forUID.IsNil() {
+	hasUID := !forUID.IsNil()
+	if hasUID {
 		minSeqno = tx.uidSeqno[forUID]
 	}
 
 	refType := reflect.TypeOf(typ)
 	for i, v := range tx.payloads {
-		if reflect.TypeOf(v).Elem() == refType && i >= minSeqno {
-			if !forUID.IsNil() && i > minSeqno {
+		if i >= minSeqno && reflect.TypeOf(v).Elem() == refType {
+			if hasUID && i > minSeqno {
 				tx.uidSeqno[forUID] = i
 			}
 			return v
 		}
 	}
 
-	if !forUID.IsNil() {
+	if hasUID {
 		tx.uidSeqno[forUID] = len(tx.payloads)
 	}
 	ret := reflect.New(refType).Interface()

--- a/go/teams/transactions_test.go
+++ b/go/teams/transactions_test.go
@@ -25,20 +25,25 @@ func TestTransactions1(t *testing.T) {
 	tx := CreateAddMemberTx(team)
 	tx.AddMemberByUsername(context.Background(), "t_alice", keybase1.TeamRole_WRITER)
 	require.Equal(t, 1, len(tx.payloads))
-	require.IsType(t, &txTeamInvitesKeybase{}, tx.payloads[0])
+	require.Equal(t, txPayloadTagInviteKeybase, tx.payloads[0].Tag)
+	require.IsType(t, &SCTeamInvites{}, tx.payloads[0].Val)
 
 	tx.AddMemberByUsername(context.Background(), other.Username, keybase1.TeamRole_WRITER)
 	require.Equal(t, 2, len(tx.payloads))
-	require.IsType(t, &txTeamInvitesKeybase{}, tx.payloads[0])
-	require.IsType(t, &keybase1.TeamChangeReq{}, tx.payloads[1])
+	require.Equal(t, txPayloadTagInviteKeybase, tx.payloads[0].Tag)
+	require.IsType(t, &SCTeamInvites{}, tx.payloads[0].Val)
+	require.Equal(t, txPayloadTagCryptomembers, tx.payloads[1].Tag)
+	require.IsType(t, &keybase1.TeamChangeReq{}, tx.payloads[1].Val)
 
 	tx.AddMemberByUsername(context.Background(), "t_tracy", keybase1.TeamRole_ADMIN)
 
 	// 3rd add (pukless member) should re-use first signature instead
 	// of creating new one.
 	require.Equal(t, 2, len(tx.payloads))
-	require.IsType(t, &txTeamInvitesKeybase{}, tx.payloads[0])
-	require.IsType(t, &keybase1.TeamChangeReq{}, tx.payloads[1])
+	require.Equal(t, txPayloadTagInviteKeybase, tx.payloads[0].Tag)
+	require.IsType(t, &SCTeamInvites{}, tx.payloads[0].Val)
+	require.Equal(t, txPayloadTagCryptomembers, tx.payloads[1].Tag)
+	require.IsType(t, &keybase1.TeamChangeReq{}, tx.payloads[1].Val)
 
 	err = tx.Post(libkb.NewMetaContextForTest(tc))
 	require.NoError(t, err)
@@ -89,12 +94,18 @@ func TestTransactionRotateKey(t *testing.T) {
 	tx := CreateAddMemberTx(team)
 	// Create payloads manually so user add and user del happen in
 	// separate links.
-	tx.payloads = []interface{}{
-		&keybase1.TeamChangeReq{
-			Writers: []keybase1.UserVersion{otherB.GetUserVersion()},
+	tx.payloads = []txPayload{
+		txPayload{
+			Tag: txPayloadTagCryptomembers,
+			Val: &keybase1.TeamChangeReq{
+				Writers: []keybase1.UserVersion{otherB.GetUserVersion()},
+			},
 		},
-		&keybase1.TeamChangeReq{
-			None: []keybase1.UserVersion{otherA.GetUserVersion()},
+		txPayload{
+			Tag: txPayloadTagCryptomembers,
+			Val: &keybase1.TeamChangeReq{
+				None: []keybase1.UserVersion{otherA.GetUserVersion()},
+			},
 		},
 	}
 	err = tx.Post(libkb.NewMetaContextForTest(tc))

--- a/go/teams/transactions_test.go
+++ b/go/teams/transactions_test.go
@@ -25,11 +25,11 @@ func TestTransactions1(t *testing.T) {
 	tx := CreateAddMemberTx(team)
 	tx.AddMemberByUsername(context.Background(), "t_alice", keybase1.TeamRole_WRITER)
 	require.Equal(t, 1, len(tx.payloads))
-	require.IsType(t, &SCTeamInvites{}, tx.payloads[0])
+	require.IsType(t, &txTeamInvitesKeybase{}, tx.payloads[0])
 
 	tx.AddMemberByUsername(context.Background(), other.Username, keybase1.TeamRole_WRITER)
 	require.Equal(t, 2, len(tx.payloads))
-	require.IsType(t, &SCTeamInvites{}, tx.payloads[0])
+	require.IsType(t, &txTeamInvitesKeybase{}, tx.payloads[0])
 	require.IsType(t, &keybase1.TeamChangeReq{}, tx.payloads[1])
 
 	tx.AddMemberByUsername(context.Background(), "t_tracy", keybase1.TeamRole_ADMIN)
@@ -37,7 +37,7 @@ func TestTransactions1(t *testing.T) {
 	// 3rd add (pukless member) should re-use first signature instead
 	// of creating new one.
 	require.Equal(t, 2, len(tx.payloads))
-	require.IsType(t, &SCTeamInvites{}, tx.payloads[0])
+	require.IsType(t, &txTeamInvitesKeybase{}, tx.payloads[0])
 	require.IsType(t, &keybase1.TeamChangeReq{}, tx.payloads[1])
 
 	err = tx.Post(libkb.NewMetaContextForTest(tc))


### PR DESCRIPTION
#### Enforce strict membership ordering by saving seqno per UID.

In AddMemberTx, remember in which payload given UID was affected last and do not queue operations affecting that UID in payloads prior.

~Adds `reflection` code in `transactions.go` so the `findPayload` func does not have to be repeated 3 times for 3 types of payload.~ Reflection code removed in favor of reflection-less "tagged union" pattern.

#### Example of what this is trying to solve:

Assume a transaction that tries to do the following, in this order:
1) Add alice as crypto member,
2) sweep old bob@keybase invite (pukless member),
3) add bob as crypto member.

Currently, this would post two signatures:
1) `change_membership { add: [ alice, bob ] }`
2) `invite { cancel: [ bob@keybase ] }`

With this PR, it's going to post:
1) `change_membership { add: [ alice ] }`
2) `invite { cancel: [ bob@keybase ] }`
3) `change_membership { add: [ bob ] }`

Ideally, we should be posting (assuming add of alice does not depend on anything else), but this would be a bigger rewrite.
1) `invite { cancel: [ bob@keybase ] }`
2) `change_membership { add: [ alice, bob ] }`