### PR TITLE
Use POST endpoint for batch UID calls

### DIFF
--- a/go/ephemeral/team_ek_test.go
+++ b/go/ephemeral/team_ek_test.go
@@ -35,7 +35,8 @@ func TestNewTeamEK(t *testing.T) {
 
 	teamID := createTeam(tc)
 
-	// Before we've published any teamEK's, fetchTeamEKStatement should return nil.
+	// Before we've published any teamEK's, fetchTeamEKStatement should return
+	// nil.
 	nilStatement, _, _, err := fetchTeamEKStatement(context.Background(), tc.G, teamID)
 	require.NoError(t, err)
 	require.Nil(t, nilStatement)

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -203,14 +203,14 @@ func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []k
 	defer g.CTraceTimed(ctx, fmt.Sprintf("fetchUserEKStatements: numUids: %v", len(uids)), func() error { return err })()
 
 	apiArg := libkb.APIArg{
-		Endpoint:    "user/user_ek",
+		Endpoint:    "user/get_user_ek_batch",
 		SessionType: libkb.APISessionTypeREQUIRED,
 		NetContext:  ctx,
 		Args: libkb.HTTPArgs{
 			"uids": libkb.S{Val: libkb.UidsToString(uids)},
 		},
 	}
-	res, err := g.GetAPI().Get(apiArg)
+	res, err := g.GetAPI().Post(apiArg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
uses a POST request to send up potentially large lists of uids, new endpoint is introduced in https://github.com/keybase/keybase/pull/2694 so CI will depend on that getting in first