### PR TITLE
Fix reddit redesign

### DIFF
--- a/browser/js/inject.js
+++ b/browser/js/inject.js
@@ -53,8 +53,8 @@ const profileInject = {
 
   "reddit": function redditInjectProfile(user) {
     const designV1 = document.querySelector("h1");
-    const designV2 = document.querySelector("h4");
-    const container = designV1 || designV2.nextSibling;
+    const designV2 = document.querySelector(".s1j2p31r-7.hBgquV");
+    const container = designV1 || designV2;
     if (!container) return;
 
     if (designV2) {


### PR DESCRIPTION
the reddit redesign broke the selector we were using to inject the chat button. The current state seems to have stripped all human readable selectors and only has anchor/div tags. Definitely not ideal, but not sure what else we can do to find the right place to inject.

@mlsteele is looking at the fb breakage since it's behind a login. once we have that and https://github.com/keybase/client/pull/12872 is merged we can release the changes