### PR TITLE
Disable emoji mart control on native

### DIFF
--- a/shared/chat/conversation/messages/react-button/index.js
+++ b/shared/chat/conversation/messages/react-button/index.js
@@ -91,21 +91,22 @@ export class NewReactionButton extends React.Component<NewReactionButtonProps, N
         >
           <Icon type="iconfont-reacji" fontSize={isMobile ? 22 : 16} />
         </Box2>
-        {this.state.showingPicker && (
-          <FloatingBox
-            attachTo={this.state.attachmentRef}
-            position="bottom left"
-            onHidden={() => this._setShowingPicker(false)}
-          >
-            <Picker
-              autoFocus={true}
-              emoji="star-struck"
-              title="reacjibase"
-              onClick={this._onAddReaction}
-              backgroundImageFn={backgroundImageFn}
-            />
-          </FloatingBox>
-        )}
+        {this.state.showingPicker &&
+          !isMobile && (
+            <FloatingBox
+              attachTo={this.state.attachmentRef}
+              position="bottom left"
+              onHidden={() => this._setShowingPicker(false)}
+            >
+              <Picker
+                autoFocus={true}
+                emoji="star-struck"
+                title="reacjibase"
+                onClick={this._onAddReaction}
+                backgroundImageFn={backgroundImageFn}
+              />
+            </FloatingBox>
+          )}
       </ContainerComp>
     )
   }


### PR DESCRIPTION
Causes the app to crash when tapping `NewReactionButton`, since `emoji-mart` uses spans and such. r? @keybase/react-hackers 