### PR TITLE
Dedup reactions in supersedes

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -429,12 +429,9 @@ func TestReactions(t *testing.T) {
 	t.Logf("test +1 reaction")
 	reactionMsgID := sendReaction(":+1:", msgID)
 	expectedReactionMap := chat1.ReactionMap{
-		Reactions: map[string][]chat1.Reaction{
-			":+1:": []chat1.Reaction{
-				chat1.Reaction{
-					Username:      u.Username,
-					ReactionMsgID: reactionMsgID,
-				},
+		Reactions: map[string]map[string]chat1.MessageID{
+			":+1:": map[string]chat1.MessageID{
+				u.Username: reactionMsgID,
 			},
 		},
 	}
@@ -442,11 +439,8 @@ func TestReactions(t *testing.T) {
 
 	t.Logf("test -1 reaction")
 	reactionMsgID2 := sendReaction(":-1:", msgID)
-	expectedReactionMap.Reactions[":-1:"] = []chat1.Reaction{
-		chat1.Reaction{
-			Username:      u.Username,
-			ReactionMsgID: reactionMsgID2,
-		},
+	expectedReactionMap.Reactions[":-1:"] = map[string]chat1.MessageID{
+		u.Username: reactionMsgID2,
 	}
 	verifyThread(msgID, editMsgID, body, []chat1.MessageID{reactionMsgID, reactionMsgID2}, expectedReactionMap)
 
@@ -472,11 +466,8 @@ func TestReactions(t *testing.T) {
 	t.Logf("test reaction after delete")
 	reactionMsgID3 := sendReaction(":-1:", msgID)
 
-	expectedReactionMap.Reactions[":-1:"] = []chat1.Reaction{
-		chat1.Reaction{
-			Username:      u.Username,
-			ReactionMsgID: reactionMsgID3,
-		},
+	expectedReactionMap.Reactions[":-1:"] = map[string]chat1.MessageID{
+		u.Username: reactionMsgID3,
 	}
 	verifyThread(msgID, editMsgID3, body, []chat1.MessageID{reactionMsgID, reactionMsgID3}, expectedReactionMap)
 

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -107,18 +107,15 @@ func (t *basicSupersedesTransform) transformReaction(msg chat1.MessageUnboxed, s
 
 	reactionMap := msg.Valid().Reactions
 	if reactionMap.Reactions == nil {
-		reactionMap.Reactions = map[string][]chat1.Reaction{}
+		reactionMap.Reactions = map[string]map[string]chat1.MessageID{}
 	}
 
 	reactionText := superMsg.Valid().MessageBody.Reaction().Body
 	reactions, ok := reactionMap.Reactions[reactionText]
 	if !ok {
-		reactions = []chat1.Reaction{}
+		reactions = map[string]chat1.MessageID{}
 	}
-	reactions = append(reactions, chat1.Reaction{
-		Username:      superMsg.Valid().SenderUsername,
-		ReactionMsgID: superMsg.GetMessageID(),
-	})
+	reactions[superMsg.Valid().SenderUsername] = superMsg.GetMessageID()
 	reactionMap.Reactions[reactionText] = reactions
 
 	mvalid := msg.Valid()

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -1040,39 +1040,28 @@ func (o MessageSummary) DeepCopy() MessageSummary {
 	}
 }
 
-type Reaction struct {
-	Username      string    `codec:"username" json:"username"`
-	ReactionMsgID MessageID `codec:"reactionMsgID" json:"reactionMsgID"`
-}
-
-func (o Reaction) DeepCopy() Reaction {
-	return Reaction{
-		Username:      o.Username,
-		ReactionMsgID: o.ReactionMsgID.DeepCopy(),
-	}
-}
-
 type ReactionMap struct {
-	Reactions map[string][]Reaction `codec:"reactions" json:"reactions"`
+	Reactions map[string]map[string]MessageID `codec:"reactions" json:"reactions"`
 }
 
 func (o ReactionMap) DeepCopy() ReactionMap {
 	return ReactionMap{
-		Reactions: (func(x map[string][]Reaction) map[string][]Reaction {
+		Reactions: (func(x map[string]map[string]MessageID) map[string]map[string]MessageID {
 			if x == nil {
 				return nil
 			}
-			ret := make(map[string][]Reaction)
+			ret := make(map[string]map[string]MessageID)
 			for k, v := range x {
 				kCopy := k
-				vCopy := (func(x []Reaction) []Reaction {
+				vCopy := (func(x map[string]MessageID) map[string]MessageID {
 					if x == nil {
 						return nil
 					}
-					var ret []Reaction
-					for _, v := range x {
+					ret := make(map[string]MessageID)
+					for k, v := range x {
+						kCopy := k
 						vCopy := v.DeepCopy()
-						ret = append(ret, vCopy)
+						ret[kCopy] = vCopy
 					}
 					return ret
 				})(v)

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1557,12 +1557,8 @@ func (r ReactionMap) HasReactionFromUser(reactionText, username string) (found b
 	if !ok {
 		return false, 0
 	}
-	for _, reaction := range reactions {
-		if reaction.Username == username {
-			return true, reaction.ReactionMsgID
-		}
-	}
-	return false, 0
+	reactionMessageID, ok := reactions[username]
+	return ok, reactionMessageID
 }
 
 func (i *ConversationMinWriterRoleInfoLocal) String() string {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -299,13 +299,9 @@
     gregor1.Time ctime;
   }
 
-  record Reaction {
-    string username;
-    MessageID reactionMsgID;
-  }
-
   record ReactionMap {
-    map<string, array<Reaction>> reactions;
+    // { reactionText (:+1:) -> { username -> messageID } }
+    map<string, map<string, MessageID>> reactions;
   }
 
   record MessageServerHeader {

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -721,10 +721,9 @@ export type PreviewLocationTyp =
   | 1 // FILE_1
 
 export type RateLimit = $ReadOnly<{name: String, callsRemaining: Int, windowReset: Int, maxCalls: Int}>
-export type Reaction = $ReadOnly<{username: String, reactionMsgID: MessageID}>
 export type ReactionDelete = $ReadOnly<{reactionKey: String, reactionMsgID: MessageID, targetMsgID: MessageID}>
 export type ReactionDeleteNotif = $ReadOnly<{convID: ConversationID, reactionDeletes?: ?Array<ReactionDelete>}>
-export type ReactionMap = $ReadOnly<{reactions: {[key: string]: ?Array<Reaction>}}>
+export type ReactionMap = $ReadOnly<{reactions: {[key: string]: {[key: string]: MessageID}}}>
 export type ReadMessageInfo = $ReadOnly<{convID: ConversationID, msgID: MessageID, conv?: ?InboxUIItem}>
 export type ReadMessagePayload = $ReadOnly<{Action: String, convID: ConversationID, msgID: MessageID, inboxVers: InboxVers, topicType: TopicType, unreadUpdate?: ?UnreadUpdate}>
 export type RemoteDeleteConversationRpcParam = $ReadOnly<{convID: ConversationID}>

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -765,28 +765,15 @@
     },
     {
       "type": "record",
-      "name": "Reaction",
-      "fields": [
-        {
-          "type": "string",
-          "name": "username"
-        },
-        {
-          "type": "MessageID",
-          "name": "reactionMsgID"
-        }
-      ]
-    },
-    {
-      "type": "record",
       "name": "ReactionMap",
       "fields": [
         {
           "type": {
             "type": "map",
             "values": {
-              "type": "array",
-              "items": "Reaction"
+              "type": "map",
+              "values": "MessageID",
+              "keys": "string"
             },
             "keys": "string"
           },

--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -247,11 +247,8 @@ const reactionMapToReactions = (r: RPCChatTypes.ReactionMap): MessageTypes.React
     Object.keys(r.reactions).reduce((res, emoji) => {
       if (r.reactions[emoji]) {
         res[emoji] = I.Set(
-          r.reactions[emoji].map(reaction =>
-            makeReaction({
-              messageID: Types.numberToMessageID(reaction.reactionMsgID),
-              username: reaction.username,
-            })
+          Object.keys(r.reactions[emoji]).map(username =>
+            makeReaction({messageID: Types.numberToMessageID(r.reactions[emoji][username]), username})
           )
         )
       }

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -721,10 +721,9 @@ export type PreviewLocationTyp =
   | 1 // FILE_1
 
 export type RateLimit = $ReadOnly<{name: String, callsRemaining: Int, windowReset: Int, maxCalls: Int}>
-export type Reaction = $ReadOnly<{username: String, reactionMsgID: MessageID}>
 export type ReactionDelete = $ReadOnly<{reactionKey: String, reactionMsgID: MessageID, targetMsgID: MessageID}>
 export type ReactionDeleteNotif = $ReadOnly<{convID: ConversationID, reactionDeletes?: ?Array<ReactionDelete>}>
-export type ReactionMap = $ReadOnly<{reactions: {[key: string]: ?Array<Reaction>}}>
+export type ReactionMap = $ReadOnly<{reactions: {[key: string]: {[key: string]: MessageID}}}>
 export type ReadMessageInfo = $ReadOnly<{convID: ConversationID, msgID: MessageID, conv?: ?InboxUIItem}>
 export type ReadMessagePayload = $ReadOnly<{Action: String, convID: ConversationID, msgID: MessageID, inboxVers: InboxVers, topicType: TopicType, unreadUpdate?: ?UnreadUpdate}>
 export type RemoteDeleteConversationRpcParam = $ReadOnly<{convID: ConversationID}>


### PR DESCRIPTION
changes the `ReactionMap` struct to hold a map of `{username: reactionMessageID}` instead of an array so we can easily dedup multiple reactions from the same user.


cc @buoyad 