### PR TITLE
Don't count currently selected conversation for back button badge

### DIFF
--- a/shared/chat/conversation/header-area/normal/container.js
+++ b/shared/chat/conversation/header-area/normal/container.js
@@ -13,7 +13,6 @@ import {
   type Dispatch,
 } from '../../../../util/container'
 import {createShowUserProfile} from '../../../../actions/profile-gen'
-import {chatTab} from '../../../../constants/tabs'
 
 const mapStateToProps = (state: TypedState, {infoPanelOpen, conversationIDKey}) => {
   const _isPending = conversationIDKey === Constants.pendingConversationIDKey
@@ -27,10 +26,10 @@ const mapStateToProps = (state: TypedState, {infoPanelOpen, conversationIDKey}) 
   const _participants = meta.teamname ? I.Set() : meta.participants
 
   return {
+    _badgeMap: state.chat2.badgeMap,
     _conversationIDKey: conversationIDKey,
     _isPending,
     _participants,
-    badgeNumber: state.notifications.getIn(['navBadges', chatTab]),
     channelName: meta.channelname,
     infoPanelOpen,
     muted: meta.isMuted,
@@ -48,7 +47,12 @@ const mapDispatchToProps = (dispatch: Dispatch, {onToggleInfoPanel, conversation
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
-  badgeNumber: stateProps.badgeNumber,
+  badgeNumber: stateProps._badgeMap.reduce(
+    (res, currentValue, currentConvID) =>
+      // only show sum of badges that aren't for the current conversation
+      currentConvID !== stateProps._conversationIDKey ? res + currentValue : res,
+    0
+  ),
   canOpenInfoPanel: !stateProps._isPending,
   channelName: stateProps.channelName,
   infoPanelOpen: stateProps.infoPanelOpen,


### PR DESCRIPTION
Adds a reduce on `state.chat2.badgeMap`. You can notice the difference in behavior if you receive some messages while in the inbox - currently on navigating into the chat the badge will flash in next to the back button. r? @keybase/react-hackers 