### PR TITLE
id2 now implemented in terms of UPK2

### DIFF
--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -384,11 +384,8 @@ func (t *NameIdentifier) identifyUser(ctx context.Context, assertion string, pri
 		return keybase1.TLFIdentifyFailure{}, err
 	}
 	var frep keybase1.TLFIdentifyFailure
-	if resp.TrackBreaks != nil {
-		frep.User = keybase1.User{
-			Uid:      resp.Upk.GetUID(),
-			Username: resp.Upk.GetName(),
-		}
+	if resp != nil && resp.TrackBreaks != nil {
+		frep.User = resp.Upk.ExportToSimpleUser()
 		frep.Breaks = resp.TrackBreaks
 	}
 

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -379,13 +379,15 @@ func (t *NameIdentifier) identifyUser(ctx context.Context, assertion string, pri
 			return keybase1.TLFIdentifyFailure{}, err
 		}
 	}
-	resp := eng.Result()
-
+	resp, err := eng.Result()
+	if err != nil {
+		return keybase1.TLFIdentifyFailure{}, err
+	}
 	var frep keybase1.TLFIdentifyFailure
-	if resp != nil && resp.TrackBreaks != nil {
+	if resp.TrackBreaks != nil {
 		frep.User = keybase1.User{
-			Uid:      resp.Upk.Uid,
-			Username: resp.Upk.Username,
+			Uid:      resp.Upk.GetUID(),
+			Username: resp.Upk.GetName(),
 		}
 		frep.Breaks = resp.TrackBreaks
 	}

--- a/go/engine/bg_identifier.go
+++ b/go/engine/bg_identifier.go
@@ -342,8 +342,13 @@ func (b *BackgroundIdentifier) runOne(m libkb.MetaContext, u keybase1.UID) (err 
 		eng.testArgs = b.testArgs.identify2TestArgs
 	}
 	err = RunEngine2(m, eng)
-	if err == nil {
-		err = trackBreaksToError(eng.Result().TrackBreaks)
+	if err != nil {
+		return err
 	}
+	res, err := eng.Result()
+	if err != nil {
+		return err
+	}
+	err = trackBreaksToError(res.TrackBreaks)
 	return err
 }

--- a/go/engine/device_keyfinder_test.go
+++ b/go/engine/device_keyfinder_test.go
@@ -33,7 +33,7 @@ func TestDeviceKeyfinder(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	up := eng.UsersPlusKeys()
+	up := eng.UsersPlusKeysV2()
 	if len(up) != 3 {
 		t.Errorf("number of users found: %d, expected 3", len(up))
 	}

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -13,7 +13,7 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-func runIdentify(tc *libkb.TestContext, username string) (idUI *FakeIdentifyUI, res *keybase1.Identify2Res, err error) {
+func runIdentify(tc *libkb.TestContext, username string) (idUI *FakeIdentifyUI, res *keybase1.Identify2ResUPK2, err error) {
 	idUI = &FakeIdentifyUI{}
 	arg := keybase1.Identify2Arg{
 		UserAssertion:    username,
@@ -32,42 +32,45 @@ func runIdentify(tc *libkb.TestContext, username string) (idUI *FakeIdentifyUI, 
 	if err != nil {
 		return idUI, nil, err
 	}
-	res = eng.Result()
+	res, err = eng.Result()
+	if err != nil {
+		return idUI, nil, err
+	}
 	return idUI, res, nil
 }
 
-func checkAliceProofs(tb libkb.TestingTB, idUI *FakeIdentifyUI, user *keybase1.UserPlusKeys) {
+func checkAliceProofs(tb libkb.TestingTB, idUI *FakeIdentifyUI, user *keybase1.UserPlusKeysV2) {
 	checkKeyedProfile(tb, idUI, user, "alice", true, map[string]string{
 		"github":  "kbtester2",
 		"twitter": "tacovontaco",
 	})
 }
 
-func checkBobProofs(tb libkb.TestingTB, idUI *FakeIdentifyUI, user *keybase1.UserPlusKeys) {
+func checkBobProofs(tb libkb.TestingTB, idUI *FakeIdentifyUI, user *keybase1.UserPlusKeysV2) {
 	checkKeyedProfile(tb, idUI, user, "bob", true, map[string]string{
 		"github":  "kbtester1",
 		"twitter": "kbtester1",
 	})
 }
 
-func checkCharlieProofs(tb libkb.TestingTB, idUI *FakeIdentifyUI, user *keybase1.UserPlusKeys) {
+func checkCharlieProofs(tb libkb.TestingTB, idUI *FakeIdentifyUI, user *keybase1.UserPlusKeysV2) {
 	checkKeyedProfile(tb, idUI, user, "charlie", true, map[string]string{
 		"github":  "tacoplusplus",
 		"twitter": "tacovontaco",
 	})
 }
 
-func checkDougProofs(tb libkb.TestingTB, idUI *FakeIdentifyUI, user *keybase1.UserPlusKeys) {
+func checkDougProofs(tb libkb.TestingTB, idUI *FakeIdentifyUI, user *keybase1.UserPlusKeysV2) {
 	checkKeyedProfile(tb, idUI, user, "doug", false, nil)
 }
 
-func checkKeyedProfile(tb libkb.TestingTB, idUI *FakeIdentifyUI, them *keybase1.UserPlusKeys, name string, hasImg bool, expectedProofs map[string]string) {
+func checkKeyedProfile(tb libkb.TestingTB, idUI *FakeIdentifyUI, them *keybase1.UserPlusKeysV2, name string, hasImg bool, expectedProofs map[string]string) {
 	if them == nil {
 		tb.Fatal("nil 'them' user")
 	}
 	exported := &keybase1.User{
-		Uid:      them.Uid,
-		Username: them.Username,
+		Uid:      them.GetUID(),
+		Username: them.GetName(),
 	}
 	if !reflect.DeepEqual(idUI.User, exported) {
 		tb.Fatal("LaunchNetworkChecks User not equal to result user.", idUI.User, exported)
@@ -98,7 +101,7 @@ func TestIdAlice(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkAliceProofs(t, idUI, &result.Upk)
+	checkAliceProofs(t, idUI, &result.Upk.Current)
 	checkDisplayKeys(t, idUI, 1, 1)
 }
 
@@ -109,7 +112,7 @@ func TestIdBob(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkBobProofs(t, idUI, &result.Upk)
+	checkBobProofs(t, idUI, &result.Upk.Current)
 	checkDisplayKeys(t, idUI, 1, 1)
 }
 
@@ -120,7 +123,7 @@ func TestIdCharlie(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkCharlieProofs(t, idUI, &result.Upk)
+	checkCharlieProofs(t, idUI, &result.Upk.Current)
 	checkDisplayKeys(t, idUI, 1, 1)
 }
 
@@ -131,7 +134,7 @@ func TestIdDoug(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkDougProofs(t, idUI, &result.Upk)
+	checkDougProofs(t, idUI, &result.Upk.Current)
 	checkDisplayKeys(t, idUI, 1, 1)
 }
 

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -1127,7 +1127,7 @@ func TestResolveAndCheck(t *testing.T) {
 		if test.r != nil {
 			tc.G.Resolver = test.r
 		}
-		upk, err := ResolveAndCheck(m, test.s)
+		upk, err := ResolveAndCheck(m, test.s, true)
 		require.IsType(t, test.e, err)
 		if err == nil {
 			require.True(t, upk.GetUID().Equal(tracyUID))

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -736,7 +736,7 @@ func (e *Identify2WithUID) displayUserCardAsync(m libkb.MetaContext) <-chan erro
 func (e *Identify2WithUID) setupIdentifyUI(m libkb.MetaContext) libkb.MetaContext {
 	if e.arg.IdentifyBehavior.ShouldSuppressTrackerPopups() {
 		m.CDebugf("| using the loopback identify UI")
-		iui := newLoopbackIdentifyUI(m.G(), &e.trackBreaks)
+		iui := NewLoopbackIdentifyUI(m.G(), &e.trackBreaks)
 		m = m.WithIdentifyUI(iui)
 	} else if e.useTracking && e.arg.CanSuppressUI && !e.arg.ForceDisplay {
 		iui := newBufferedIdentifyUI(m.G(), m.UIs().IdentifyUI, keybase1.ConfirmResult{

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -175,7 +175,7 @@ func (i *identifyUser) trackChainLinkFor(m libkb.MetaContext, name libkb.Normali
 
 	if i.full != nil {
 		m.CDebugf("| Using full user object")
-		return i.full.TrackChainLinkFor(name, uid)
+		return i.full.TrackChainLinkFor(m, name, uid)
 	}
 
 	if i.thin != nil {
@@ -209,7 +209,7 @@ func (i *identifyUser) trackChainLinkFor(m libkb.MetaContext, name libkb.Normali
 		if err != nil {
 			return nil, err
 		}
-		return i.full.TrackChainLinkFor(name, uid)
+		return i.full.TrackChainLinkFor(m, name, uid)
 	}
 
 	// No user loaded, so no track chain link.
@@ -868,7 +868,7 @@ func (e *Identify2WithUID) createIdentifyState(m libkb.MetaContext) (err error) 
 		m.CDebugf("| using track token %s", tcl.LinkID())
 		e.useTracking = true
 		e.state.SetTrackLookup(tcl)
-		if ttcl, _ := libkb.TmpTrackChainLinkFor(e.me.GetUID(), them.GetUID(), e.G()); ttcl != nil {
+		if ttcl, _ := libkb.TmpTrackChainLinkFor(m, e.me.GetUID(), them.GetUID()); ttcl != nil {
 			m.CDebugf("| also have temporary track")
 			e.state.SetTmpTrackLookup(ttcl)
 		}

--- a/go/engine/loopback_identify_ui.go
+++ b/go/engine/loopback_identify_ui.go
@@ -10,31 +10,31 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-type loopbackIdentifyUI struct {
+type LoopbackIdentifyUI struct {
 	libkb.Contextified
 	sync.Mutex
 	trackBreaksP **keybase1.IdentifyTrackBreaks
 }
 
-func newLoopbackIdentifyUI(g *libkb.GlobalContext, tb **keybase1.IdentifyTrackBreaks) *loopbackIdentifyUI {
-	return &loopbackIdentifyUI{
+func NewLoopbackIdentifyUI(g *libkb.GlobalContext, tb **keybase1.IdentifyTrackBreaks) *LoopbackIdentifyUI {
+	return &LoopbackIdentifyUI{
 		Contextified: libkb.NewContextified(g),
 		trackBreaksP: tb,
 	}
 }
 
-func (b *loopbackIdentifyUI) Start(s string, r keybase1.IdentifyReason, f bool) error {
+func (b *LoopbackIdentifyUI) Start(s string, r keybase1.IdentifyReason, f bool) error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) trackBreaks() *keybase1.IdentifyTrackBreaks {
+func (b *LoopbackIdentifyUI) trackBreaks() *keybase1.IdentifyTrackBreaks {
 	if *b.trackBreaksP == nil {
 		*b.trackBreaksP = &keybase1.IdentifyTrackBreaks{}
 	}
 	return *b.trackBreaksP
 }
 
-func (b *loopbackIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+func (b *LoopbackIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	b.Lock()
 	defer b.Unlock()
 	if l.BreaksTracking {
@@ -47,19 +47,19 @@ func (b *loopbackIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keyba
 	return nil
 }
 
-func (b *loopbackIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+func (b *LoopbackIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	return b.FinishWebProofCheck(p, l)
 }
 
-func (b *loopbackIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+func (b *LoopbackIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	return keybase1.ConfirmResult{}, nil
 }
 
-func (b *loopbackIdentifyUI) DisplayCryptocurrency(c keybase1.Cryptocurrency) error {
+func (b *LoopbackIdentifyUI) DisplayCryptocurrency(c keybase1.Cryptocurrency) error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) DisplayKey(k keybase1.IdentifyKey) error {
+func (b *LoopbackIdentifyUI) DisplayKey(k keybase1.IdentifyKey) error {
 	b.Lock()
 	defer b.Unlock()
 	if k.BreaksTracking {
@@ -69,38 +69,38 @@ func (b *loopbackIdentifyUI) DisplayKey(k keybase1.IdentifyKey) error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) ReportLastTrack(s *keybase1.TrackSummary) error {
+func (b *LoopbackIdentifyUI) ReportLastTrack(s *keybase1.TrackSummary) error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) LaunchNetworkChecks(i *keybase1.Identity, u *keybase1.User) error {
+func (b *LoopbackIdentifyUI) LaunchNetworkChecks(i *keybase1.Identity, u *keybase1.User) error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) DisplayTrackStatement(s string) error {
+func (b *LoopbackIdentifyUI) DisplayTrackStatement(s string) error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) DisplayUserCard(c keybase1.UserCard) error {
+func (b *LoopbackIdentifyUI) DisplayUserCard(c keybase1.UserCard) error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) ReportTrackToken(t keybase1.TrackToken) error {
+func (b *LoopbackIdentifyUI) ReportTrackToken(t keybase1.TrackToken) error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) Cancel() error {
+func (b *LoopbackIdentifyUI) Cancel() error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) Finish() error {
+func (b *LoopbackIdentifyUI) Finish() error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) DisplayTLFCreateWithInvite(d keybase1.DisplayTLFCreateWithInviteArg) error {
+func (b *LoopbackIdentifyUI) DisplayTLFCreateWithInvite(d keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil
 }
 
-func (b *loopbackIdentifyUI) Dismiss(s string, r keybase1.DismissReason) error {
+func (b *LoopbackIdentifyUI) Dismiss(s string, r keybase1.DismissReason) error {
 	return nil
 }

--- a/go/engine/pgp_decrypt.go
+++ b/go/engine/pgp_decrypt.go
@@ -116,9 +116,13 @@ func (e *PGPDecrypt) Run(m libkb.MetaContext) (err error) {
 		if err := RunEngine2(m, eng); err != nil {
 			return err
 		}
-		signByUser := eng.Result().Upk
+		res, err := eng.Result()
+		if err != nil {
+			return err
+		}
+		signByUser := res.Upk
 
-		if !signByUser.Uid.Equal(e.signer.GetUID()) {
+		if !signByUser.GetUID().Equal(e.signer.GetUID()) {
 			return libkb.BadSigError{
 				E: fmt.Sprintf("Signer %q did not match signed by assertion %q", e.signer.GetName(), e.arg.SignedBy),
 			}

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -201,8 +201,11 @@ func (e *PGPEncrypt) verifyUsers(m libkb.MetaContext, assertions []string, logge
 		if err := RunEngine2(m, eng); err != nil {
 			return nil, libkb.IdentifyFailedError{Assertion: userAssert, Reason: err.Error()}
 		}
-		res := eng.Result()
-		names = append(names, res.Upk.Username)
+		res, err := eng.Result()
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, res.Upk.GetName())
 	}
 	return names, nil
 }

--- a/go/engine/pgp_test.go
+++ b/go/engine/pgp_test.go
@@ -157,7 +157,8 @@ func (p *pgpPair) isTracking(meContext libkb.TestContext, username string) bool 
 	if err != nil {
 		p.t.Fatal(err)
 	}
-	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
+	m := NewMetaContextForTest(meContext)
+	s, err := me.TrackChainLinkFor(m, them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		p.t.Fatal(err)
 	}

--- a/go/engine/pgp_verify.go
+++ b/go/engine/pgp_verify.go
@@ -258,14 +258,17 @@ func (e *PGPVerify) checkSignedBy(m libkb.MetaContext) error {
 	if err := RunEngine2(m, eng); err != nil {
 		return err
 	}
-	signByUser := eng.Result().Upk
+	res, err := eng.Result()
+	if err != nil {
+		return err
+	}
+	signByUser := res.Upk
 
 	// check if it is equal to signature owner
-	if !e.signer.GetUID().Equal(signByUser.Uid) {
+	if !e.signer.GetUID().Equal(signByUser.GetUID()) {
 		return libkb.BadSigError{
 			E: fmt.Sprintf("Signer %q did not match signed by assertion %q", e.signer.GetName(), e.arg.SignedBy),
 		}
 	}
-
 	return nil
 }

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -180,7 +180,7 @@ func (e *ResolveThenIdentify2) GetProofSet() *libkb.ProofSet {
 // are *not* taken into account. No ID2-specific caching will be used, but the UPAK
 // cache will be used, and busted with ForceRepoll semantics. The output, on success,
 // is a populated UserPlusKeysV2.
-func ResolveAndCheck(m libkb.MetaContext, s string) (ret keybase1.UserPlusKeysV2, err error) {
+func ResolveAndCheck(m libkb.MetaContext, s string, useTracking bool) (ret keybase1.UserPlusKeysV2, err error) {
 
 	// Invokes the whole resolve/identify machinery. That is, it performs a server-trusted
 	// resolution of the name to a UID, then does an ID on the UID to make sure all
@@ -192,7 +192,7 @@ func ResolveAndCheck(m libkb.MetaContext, s string) (ret keybase1.UserPlusKeysV2
 	arg := keybase1.Identify2Arg{
 		UserAssertion:         s,
 		CanSuppressUI:         true,
-		ActLoggedOut:          true,
+		ActLoggedOut:          !useTracking,
 		NoErrorOnTrackFailure: true,
 		IdentifyBehavior:      keybase1.TLFIdentifyBehavior_RESOLVE_AND_CHECK,
 	}

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -193,7 +193,7 @@ func ResolveAndCheck(m libkb.MetaContext, s string, useTracking bool) (ret keyba
 		UserAssertion:         s,
 		CanSuppressUI:         true,
 		ActLoggedOut:          !useTracking,
-		NoErrorOnTrackFailure: true,
+		NoErrorOnTrackFailure: !useTracking,
 		IdentifyBehavior:      keybase1.TLFIdentifyBehavior_RESOLVE_AND_CHECK,
 	}
 	eng := NewResolveThenIdentify2(m.G(), &arg)

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -176,15 +176,11 @@ func (e *ResolveThenIdentify2) GetProofSet() *libkb.ProofSet {
 // ResolveAndCheck takes as input a name (joe), social assertion (joe@twitter)
 // or compound assertion (joe+joe@twitter+3883883773222@pgp) and resolves
 // it to a user, verifying the result. Pass into it a MetaContext without any UIs set,
-// since it is meant to run without any UI interaction. Also note that tracker statements
-// are *not* taken into account. No ID2-specific caching will be used, but the UPAK
-// cache will be used, and busted with ForceRepoll semantics. The output, on success,
+// since it is meant to run without any UI interaction. Tracking statements
+// are optionally taken into account (see flag). No ID2-specific caching will be used,
+// but the UPAK cache will be used, and busted with ForceRepoll semantics. The output, on success,
 // is a populated UserPlusKeysV2.
 func ResolveAndCheck(m libkb.MetaContext, s string, useTracking bool) (ret keybase1.UserPlusKeysV2, err error) {
-
-	// Invokes the whole resolve/identify machinery. That is, it performs a server-trusted
-	// resolution of the name to a UID, then does an ID on the UID to make sure all
-	// assertions are met. The identify is run as if the user is logged out.
 
 	m = m.WithLogTag("RAC")
 	defer m.CTraceTimed("ResolveAndCheck", func() error { return err })()

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -132,7 +132,7 @@ func (e *SaltpackEncrypt) Run(m libkb.MetaContext) (err error) {
 	}
 	uplus := kf.UsersPlusKeysV2()
 	for _, up := range uplus {
-		for kid, _ := range up.DeviceKeys {
+		for kid := range up.DeviceKeys {
 			gk, err := libkb.ImportKeypairFromKID(kid)
 			if err != nil {
 				return err

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -130,10 +130,10 @@ func (e *SaltpackEncrypt) Run(m libkb.MetaContext) (err error) {
 	if err := RunEngine2(m, kf); err != nil {
 		return err
 	}
-	uplus := kf.UsersPlusKeys()
+	uplus := kf.UsersPlusKeysV2()
 	for _, up := range uplus {
-		for _, k := range up.DeviceKeys {
-			gk, err := libkb.ImportKeypairFromKID(k.KID)
+		for kid, _ := range up.DeviceKeys {
+			gk, err := libkb.ImportKeypairFromKID(kid)
 			if err != nil {
 				return err
 			}

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -80,9 +80,12 @@ func (e *TrackEngine) Run(m libkb.MetaContext) error {
 		return err
 	}
 
-	upk := ieng.Result().Upk
-	var err error
-	loadarg := libkb.NewLoadUserArgWithMetaContext(m).WithUID(upk.Uid).WithPublicKeyOptional()
+	res, err := ieng.Result()
+	if err != nil {
+		return err
+	}
+	upk := res.Upk
+	loadarg := libkb.NewLoadUserArgWithMetaContext(m).WithUID(upk.GetUID()).WithPublicKeyOptional()
 	e.them, err = libkb.LoadUser(loadarg)
 	if err != nil {
 		return err

--- a/go/engine/track_proof_test.go
+++ b/go/engine/track_proof_test.go
@@ -43,7 +43,8 @@ func checkTrackCommon(tc libkb.TestContext, blocks []sb, outcome *keybase1.Ident
 	if them == nil {
 		tc.T.Fatal("checkTrackCommon called with nil 'them' user")
 	}
-	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
+	m := NewMetaContextForTest(tc)
+	s, err := me.TrackChainLinkFor(m, them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		return err
 	}

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -44,7 +44,8 @@ func assertTracking(tc libkb.TestContext, username string) {
 	if err != nil {
 		tc.T.Fatal(err)
 	}
-	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
+	m := NewMetaContextForTest(tc)
+	s, err := me.TrackChainLinkFor(m, them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		tc.T.Fatal(err)
 	}
@@ -62,7 +63,8 @@ func assertNotTracking(tc libkb.TestContext, username string) {
 	if err != nil {
 		tc.T.Fatal(err)
 	}
-	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
+	m := NewMetaContextForTest(tc)
+	s, err := me.TrackChainLinkFor(m, them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		tc.T.Fatal(err)
 	}
@@ -286,8 +288,8 @@ func TestTrackLocal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
+	m := NewMetaContextForTest(tc)
+	s, err := me.TrackChainLinkFor(m, them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -98,8 +98,11 @@ func trackAliceWithOptions(tc libkb.TestContext, fu *FakeUser, options keybase1.
 	if err != nil {
 		tc.T.Fatal(err)
 	}
-	upk := res.ExportToUserPlusKeys()
-	checkAliceProofs(tc.T, idUI, &upk)
+	upk, err := res.ExportToUPKV2AllIncarnations()
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	checkAliceProofs(tc.T, idUI, &upk.Current)
 	assertTracking(tc, "t_alice")
 	return
 }
@@ -118,8 +121,11 @@ func trackBobWithOptions(tc libkb.TestContext, fu *FakeUser, options keybase1.Tr
 	if err != nil {
 		tc.T.Fatal(err)
 	}
-	upk := res.ExportToUserPlusKeys()
-	checkBobProofs(tc.T, idUI, &upk)
+	upk, err := res.ExportToUPKV2AllIncarnations()
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	checkBobProofs(tc.T, idUI, &upk.Current)
 	assertTracking(tc, "t_bob")
 	return
 }

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -119,7 +119,7 @@ func (e *TrackToken) Run(m libkb.MetaContext) (err error) {
 
 	if e.arg.Options.LocalOnly || e.arg.Options.ExpiringLocal {
 		m.CDebugf("| Local")
-		err = e.storeLocalTrack()
+		err = e.storeLocalTrack(m)
 	} else {
 		err = e.storeRemoteTrack(m, signingKeyPub.GetKID())
 		if err == nil {
@@ -198,8 +198,8 @@ func (e *TrackToken) loadThem(m libkb.MetaContext, username libkb.NormalizedUser
 	return nil
 }
 
-func (e *TrackToken) storeLocalTrack() error {
-	return libkb.StoreLocalTrack(e.arg.Me.GetUID(), e.them.GetUID(), e.arg.Options.ExpiringLocal, e.trackStatement, e.G())
+func (e *TrackToken) storeLocalTrack(m libkb.MetaContext) error {
+	return libkb.StoreLocalTrack(m, e.arg.Me.GetUID(), e.them.GetUID(), e.arg.Options.ExpiringLocal, e.trackStatement)
 }
 
 func (e *TrackToken) storeRemoteTrack(m libkb.MetaContext, pubKID keybase1.KID) (err error) {
@@ -271,6 +271,6 @@ func (e *TrackToken) storeRemoteTrack(m libkb.MetaContext, pubKID keybase1.KID) 
 
 func (e *TrackToken) removeLocalTracks(m libkb.MetaContext) (err error) {
 	defer m.CTrace("removeLocalTracks", func() error { return err })()
-	err = libkb.RemoveLocalTracks(e.arg.Me.GetUID(), e.them.GetUID(), m.G())
+	err = libkb.RemoveLocalTracks(m, e.arg.Me.GetUID(), e.them.GetUID())
 	return err
 }

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -61,7 +61,7 @@ func (e *UntrackEngine) Run(m libkb.MetaContext) (err error) {
 		return
 	}
 
-	them, remoteLink, localLink, err := e.loadThem()
+	them, remoteLink, localLink, err := e.loadThem(m)
 	if err != nil {
 		return
 	}
@@ -86,7 +86,7 @@ func (e *UntrackEngine) Run(m libkb.MetaContext) (err error) {
 	didUntrack := false
 
 	if localLink != nil {
-		err = e.storeLocalUntrack(them)
+		err = e.storeLocalUntrack(m, them)
 		if err != nil {
 			return
 		}
@@ -119,7 +119,7 @@ func (e *UntrackEngine) loadMe() (me *libkb.User, err error) {
 	return libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
 }
 
-func (e *UntrackEngine) loadThem() (them *libkb.User, remoteLink, localLink *libkb.TrackChainLink, err error) {
+func (e *UntrackEngine) loadThem(m libkb.MetaContext) (them *libkb.User, remoteLink, localLink *libkb.TrackChainLink, err error) {
 	var rLink *libkb.TrackChainLink
 	trackMap := e.arg.Me.IDTable().GetTrackMap()
 	if links, ok := trackMap[e.arg.Username]; ok && (len(links) > 0) {
@@ -149,7 +149,7 @@ func (e *UntrackEngine) loadThem() (them *libkb.User, remoteLink, localLink *lib
 		}
 	}
 
-	lLink, err := libkb.LocalTrackChainLinkFor(e.arg.Me.GetUID(), uid, e.G())
+	lLink, err := libkb.LocalTrackChainLinkFor(m, e.arg.Me.GetUID(), uid)
 	if err != nil {
 		return
 	}
@@ -185,9 +185,9 @@ func (e *UntrackEngine) loadThem() (them *libkb.User, remoteLink, localLink *lib
 	return
 }
 
-func (e *UntrackEngine) storeLocalUntrack(them *libkb.User) error {
+func (e *UntrackEngine) storeLocalUntrack(m libkb.MetaContext, them *libkb.User) error {
 	// Also do a removal in case of expiring local tracks
-	return libkb.RemoveLocalTracks(e.arg.Me.GetUID(), them.GetUID(), e.G())
+	return libkb.RemoveLocalTracks(m, e.arg.Me.GetUID(), them.GetUID())
 }
 
 func (e *UntrackEngine) storeRemoteUntrack(m libkb.MetaContext, them *libkb.User) (err error) {

--- a/go/engine/untrack_test.go
+++ b/go/engine/untrack_test.go
@@ -34,7 +34,8 @@ func assertUntracked(tc libkb.TestContext, username string) {
 		tc.T.Fatal(err)
 	}
 
-	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
+	m := NewMetaContextForTest(tc)
+	s, err := me.TrackChainLinkFor(m, them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		tc.T.Fatal(err)
 	}
@@ -42,7 +43,7 @@ func assertUntracked(tc libkb.TestContext, username string) {
 		tc.T.Fatal("expected not to get a tracking statement; but got one")
 	}
 
-	s, err = libkb.LocalTrackChainLinkFor(me.GetUID(), them.GetUID(), tc.G)
+	s, err = libkb.LocalTrackChainLinkFor(m, me.GetUID(), them.GetUID())
 	if err != nil {
 		tc.T.Fatal(err)
 	}

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -1052,24 +1052,24 @@ func NewChainLink(g *GlobalContext, parent *SigChain, id LinkID) *ChainLink {
 	}
 }
 
-func ImportLinkFromStorage(id LinkID, selfUID keybase1.UID, g *GlobalContext) (*ChainLink, error) {
-	link, ok := g.LinkCache().Get(id)
+func ImportLinkFromStorage(m MetaContext, id LinkID, selfUID keybase1.UID) (*ChainLink, error) {
+	link, ok := m.G().LinkCache().Get(id)
 	if ok {
-		link.Contextified = NewContextified(g)
+		link.Contextified = NewContextified(m.G())
 		return &link, nil
 	}
 
 	var ret *ChainLink
-	data, _, err := g.LocalDb.GetRaw(DbKey{Typ: DBLink, Key: id.String()})
+	data, _, err := m.G().LocalDb.GetRaw(DbKey{Typ: DBLink, Key: id.String()})
 	if err == nil && data != nil {
 		// May as well recheck onload (maybe revisit this)
-		ret = NewChainLink(g, nil, id)
+		ret = NewChainLink(m.G(), nil, id)
 		if err = ret.Unpack(true, selfUID, data); err != nil {
 			return nil, err
 		}
 		ret.storedLocally = true
 
-		g.LinkCache().Put(id, ret.Copy())
+		m.G().LinkCache().Put(id, ret.Copy())
 	}
 	return ret, err
 }

--- a/go/libkb/identify2_cache.go
+++ b/go/libkb/identify2_cache.go
@@ -18,16 +18,16 @@ type Identify2Cache struct {
 }
 
 type Identify2Cacher interface {
-	Get(keybase1.UID, GetCheckTimeFunc, GetCacheDurationFunc, bool) (*keybase1.Identify2Res, error)
-	Insert(up *keybase1.Identify2Res) error
+	Get(keybase1.UID, GetCheckTimeFunc, GetCacheDurationFunc, bool) (*keybase1.Identify2ResUPK2, error)
+	Insert(up *keybase1.Identify2ResUPK2) error
 	DidFullUserLoad(keybase1.UID)
 	Shutdown()
 	Delete(uid keybase1.UID) error
 	UseDiskCache() bool
 }
 
-type GetCheckTimeFunc func(keybase1.Identify2Res) keybase1.Time
-type GetCacheDurationFunc func(keybase1.Identify2Res) time.Duration
+type GetCheckTimeFunc func(keybase1.Identify2ResUPK2) keybase1.Time
+type GetCacheDurationFunc func(keybase1.Identify2ResUPK2) time.Duration
 
 // NewIdentify2Cache creates a Identify2Cache and sets the object max age to
 // maxAge.  Once a user is inserted, after maxAge duration passes,
@@ -42,7 +42,7 @@ func NewIdentify2Cache(maxAge time.Duration) *Identify2Cache {
 }
 
 // Get returns a user object.  If none exists for uid, it will return nil.
-func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, gcdf GetCacheDurationFunc, breaksOK bool) (*keybase1.Identify2Res, error) {
+func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, gcdf GetCacheDurationFunc, breaksOK bool) (*keybase1.Identify2ResUPK2, error) {
 	v, err := c.cache.Get(string(uid))
 	if err != nil {
 		if err == ramcache.ErrNotFound {
@@ -50,7 +50,7 @@ func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, gcdf GetCa
 		}
 		return nil, err
 	}
-	up, ok := v.(*keybase1.Identify2Res)
+	up, ok := v.(*keybase1.Identify2ResUPK2)
 	if !ok {
 		return nil, fmt.Errorf("invalid type in cache: %T", v)
 	}
@@ -75,11 +75,11 @@ func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, gcdf GetCa
 }
 
 // Insert adds a user to the cache, keyed on UID.
-func (c *Identify2Cache) Insert(up *keybase1.Identify2Res) error {
+func (c *Identify2Cache) Insert(up *keybase1.Identify2ResUPK2) error {
 	tmp := *up
 	copy := &tmp
 	copy.Upk.Uvv.CachedAt = keybase1.ToTime(time.Now())
-	return c.cache.Set(string(up.Upk.Uid), copy)
+	return c.cache.Set(string(up.Upk.GetUID()), copy)
 }
 
 func (c *Identify2Cache) Delete(uid keybase1.UID) error {

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -966,7 +966,7 @@ func (l *SigChainLoader) LoadLinksFromStorage() (err error) {
 		return
 	}
 
-	currentLink, err := ImportLinkFromStorage(mt.LinkID, l.selfUID(), l.G())
+	currentLink, err := ImportLinkFromStorage(l.M(), mt.LinkID, l.selfUID())
 	if err != nil {
 		return err
 	}
@@ -987,7 +987,7 @@ func (l *SigChainLoader) LoadLinksFromStorage() (err error) {
 			}
 			break
 		}
-		prevLink, err := ImportLinkFromStorage(currentLink.GetPrev(), l.selfUID(), l.G())
+		prevLink, err := ImportLinkFromStorage(l.M(), currentLink.GetPrev(), l.selfUID())
 		if err != nil {
 			return err
 		}

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -402,33 +402,33 @@ func LocalTrackDBKey(tracker, trackee keybase1.UID, expireLocal bool) DbKey {
 
 //=====================================================================
 
-func localTrackChainLinkFor(tracker, trackee keybase1.UID, localExpires bool, g *GlobalContext) (ret *TrackChainLink, err error) {
-	data, _, err := g.LocalDb.GetRaw(LocalTrackDBKey(tracker, trackee, localExpires))
+func localTrackChainLinkFor(m MetaContext, tracker, trackee keybase1.UID, localExpires bool) (ret *TrackChainLink, err error) {
+	data, _, err := m.G().LocalDb.GetRaw(LocalTrackDBKey(tracker, trackee, localExpires))
 	if err != nil {
-		g.Log.Debug("| DB lookup failed")
+		m.CDebugf("| DB lookup failed")
 		return nil, err
 	}
 	if data == nil || len(data) == 0 {
-		g.Log.Debug("| No local track found")
+		m.CDebugf("| No local track found")
 		return nil, nil
 	}
 
-	cl := &ChainLink{Contextified: NewContextified(g), unsigned: true}
+	cl := &ChainLink{Contextified: NewContextified(m.G()), unsigned: true}
 	if err = cl.UnpackLocal(data); err != nil {
-		g.Log.Debug("| unpack local failed -> %s", err)
+		m.CDebugf("| unpack local failed -> %s", err)
 		return nil, err
 	}
 
 	var linkETime time.Time
 
 	if localExpires {
-		linkETime = cl.GetCTime().Add(g.Env.GetLocalTrackMaxAge())
+		linkETime = cl.GetCTime().Add(m.G().Env.GetLocalTrackMaxAge())
 
-		g.Log.Debug("| local track created %s, expires: %s, it is now %s", cl.GetCTime(), linkETime.String(), g.Clock().Now())
+		m.CDebugf("| local track created %s, expires: %s, it is now %s", cl.GetCTime(), linkETime.String(), m.G().Clock().Now())
 
-		if linkETime.Before(g.Clock().Now()) {
-			g.Log.Debug("| expired local track, deleting")
-			removeLocalTrack(tracker, trackee, true, g)
+		if linkETime.Before(m.G().Clock().Now()) {
+			m.CDebugf("| expired local track, deleting")
+			removeLocalTrack(m, tracker, trackee, true)
 			return nil, ErrTrackingExpired
 		}
 	}
@@ -443,26 +443,26 @@ func localTrackChainLinkFor(tracker, trackee keybase1.UID, localExpires bool, g 
 	return ret, err
 }
 
-func LocalTrackChainLinkFor(tracker, trackee keybase1.UID, g *GlobalContext) (ret *TrackChainLink, err error) {
-	return localTrackChainLinkFor(tracker, trackee, false, g)
+func LocalTrackChainLinkFor(m MetaContext, tracker, trackee keybase1.UID) (ret *TrackChainLink, err error) {
+	return localTrackChainLinkFor(m, tracker, trackee, false)
 }
 
-func LocalTmpTrackChainLinkFor(tracker, trackee keybase1.UID, g *GlobalContext) (ret *TrackChainLink, err error) {
-	return localTrackChainLinkFor(tracker, trackee, true, g)
+func LocalTmpTrackChainLinkFor(m MetaContext, tracker, trackee keybase1.UID) (ret *TrackChainLink, err error) {
+	return localTrackChainLinkFor(m, tracker, trackee, true)
 }
 
-func StoreLocalTrack(tracker keybase1.UID, trackee keybase1.UID, expiringLocal bool, statement *jsonw.Wrapper, g *GlobalContext) error {
-	g.Log.Debug("| StoreLocalTrack, expiring = %v", expiringLocal)
-	return g.LocalDb.Put(LocalTrackDBKey(tracker, trackee, expiringLocal), nil, statement)
+func StoreLocalTrack(m MetaContext, tracker keybase1.UID, trackee keybase1.UID, expiringLocal bool, statement *jsonw.Wrapper) error {
+	m.CDebugf("| StoreLocalTrack, expiring = %v", expiringLocal)
+	return m.G().LocalDb.Put(LocalTrackDBKey(tracker, trackee, expiringLocal), nil, statement)
 }
 
-func removeLocalTrack(tracker keybase1.UID, trackee keybase1.UID, expiringLocal bool, g *GlobalContext) error {
-	g.Log.Debug("| RemoveLocalTrack, expiring = %v", expiringLocal)
-	return g.LocalDb.Delete(LocalTrackDBKey(tracker, trackee, expiringLocal))
+func 	removeLocalTrack(m MetaContext, tracker keybase1.UID, trackee keybase1.UID, expiringLocal bool) error {
+	m.CDebugf("| RemoveLocalTrack, expiring = %v", expiringLocal)
+	return m.G().LocalDb.Delete(LocalTrackDBKey(tracker, trackee, expiringLocal))
 }
 
-func RemoveLocalTracks(tracker keybase1.UID, trackee keybase1.UID, g *GlobalContext) error {
-	e1 := removeLocalTrack(tracker, trackee, false, g)
-	e2 := removeLocalTrack(tracker, trackee, true, g)
+func RemoveLocalTracks(m MetaContext, tracker keybase1.UID, trackee keybase1.UID) error {
+	e1 := removeLocalTrack(m, tracker, trackee, false)
+	e2 := removeLocalTrack(m, tracker, trackee, true)
 	return PickFirstError(e1, e2)
 }

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -456,7 +456,7 @@ func StoreLocalTrack(m MetaContext, tracker keybase1.UID, trackee keybase1.UID, 
 	return m.G().LocalDb.Put(LocalTrackDBKey(tracker, trackee, expiringLocal), nil, statement)
 }
 
-func 	removeLocalTrack(m MetaContext, tracker keybase1.UID, trackee keybase1.UID, expiringLocal bool) error {
+func removeLocalTrack(m MetaContext, tracker keybase1.UID, trackee keybase1.UID, expiringLocal bool) error {
 	m.CDebugf("| RemoveLocalTrack, expiring = %v", expiringLocal)
 	return m.G().LocalDb.Delete(LocalTrackDBKey(tracker, trackee, expiringLocal))
 }

--- a/go/libkb/upak.go
+++ b/go/libkb/upak.go
@@ -69,48 +69,51 @@ func CheckKID(u *keybase1.UserPlusKeysV2AllIncarnations, kid keybase1.KID) (foun
 	return checkKIDKeybase(u, kid)
 }
 
-func GetRemoteChainLinkFor(u *keybase1.UserPlusKeysV2AllIncarnations, username NormalizedUsername, uid keybase1.UID, g *GlobalContext) (ret *TrackChainLink, err error) {
-	defer g.Trace(fmt.Sprintf("UPAK#GetRemoteChainLinkFor(%s,%s,%s)", u.Current.GetUID(), username, uid), func() error { return err })()
-	g.VDL.Log(VLog1, "| Full user: %+v\n", *u)
-	rtl := u.GetRemoteTrack(uid)
+func GetRemoteChainLinkFor(m MetaContext, follower *keybase1.UserPlusKeysV2AllIncarnations, followeeUsername NormalizedUsername, followeeUID keybase1.UID) (ret *TrackChainLink, err error) {
+	defer m.CTrace(fmt.Sprintf("UPAK#GetRemoteChainLinkFor(%s,%s,%s)", follower.Current.GetUID(), followeeUsername, followeeUID), func() error { return err })()
+	m.VLogf(VLog1, "| Full user: %+v\n", *follower)
+	rtl := follower.GetRemoteTrack(followeeUID)
 	if rtl == nil {
-		g.VDL.Log(VLog0, "| no remote track found")
+		m.VLogf(VLog0, "| no remote track found")
 		return nil, nil
 	}
-	if !NewNormalizedUsername(rtl.Username).Eq(username) {
-		return nil, UIDMismatchError{Msg: fmt.Sprintf("UIDs didn't match for (%s,%q); got %s", uid, username.String(), rtl.Uid)}
+	if !NewNormalizedUsername(rtl.Username).Eq(followeeUsername) {
+		return nil, UIDMismatchError{Msg: fmt.Sprintf("Usernames didn't match for (%s,%q); got %s", followeeUID, followeeUsername.String(), rtl.Uid)}
+	}
+	if !rtl.Uid.Equal(followeeUID) {
+		return nil, UIDMismatchError{Msg: fmt.Sprintf("UIDs didn't match for (%s,%q); got %s", followeeUID, followeeUsername.String(), rtl.Uid)}
 	}
 	var lid LinkID
-	g.VDL.Log(VLog0, "| remote track found with linkID=%s", rtl.LinkID)
+	m.VLogf(VLog0, "| remote track found with linkID=%s", rtl.LinkID)
 	lid, err = ImportLinkID(rtl.LinkID)
 	if err != nil {
-		g.Log.Debug("| Failed to import link ID")
+		m.CDebugf("| Failed to import link ID")
 		return nil, err
 	}
 	var link *ChainLink
-	link, err = ImportLinkFromStorage(lid, u.GetUID(), g)
+	link, err = ImportLinkFromStorage(lid, follower.GetUID(), m.G())
 	if err != nil {
-		g.Log.Debug("| failed to import link from storage")
+		m.CDebugf("| failed to import link from storage")
 		return nil, err
 	}
 	if link == nil {
-		g.Log.Debug("| no cached chainlink found")
+		m.CDebugf("| no cached chainlink found")
 		// Such a bug is only possible if the DB cache was reset after
 		// this user was originally loaded in; otherwise, all of this
 		// UPAK's chain links should be available on disk.
 		return nil, InconsistentCacheStateError{}
 	}
 	ret, err = ParseTrackChainLink(GenericChainLink{link})
-	g.VDL.Log(VLog0, "| ParseTrackChainLink -> found=%v", (ret != nil))
+	m.VLogf(VLog0, "| ParseTrackChainLink -> found=%v", (ret != nil))
 	return ret, err
 }
 
-func TrackChainLinkFromUPK2AI(u *keybase1.UserPlusKeysV2AllIncarnations, username NormalizedUsername, uid keybase1.UID, g *GlobalContext) (*TrackChainLink, error) {
-	tcl, err := GetRemoteChainLinkFor(u, username, uid, g)
+func TrackChainLinkFromUPK2AI(m MetaContext, follower *keybase1.UserPlusKeysV2AllIncarnations, followeeUsername NormalizedUsername, followeeUID keybase1.UID) (*TrackChainLink, error) {
+	tcl, err := GetRemoteChainLinkFor(m, follower, followeeUsername, followeeUID)
 	if _, ok := err.(InconsistentCacheStateError); ok {
 		return nil, err
 	}
-	tcl, err = TrackChainLinkFor(u.Current.Uid, uid, tcl, err, g)
+	tcl, err = TrackChainLinkFor(follower.Current.Uid, followeeUID, tcl, err, m.G())
 	return tcl, err
 }
 

--- a/go/libkb/upak.go
+++ b/go/libkb/upak.go
@@ -91,7 +91,7 @@ func GetRemoteChainLinkFor(m MetaContext, follower *keybase1.UserPlusKeysV2AllIn
 		return nil, err
 	}
 	var link *ChainLink
-	link, err = ImportLinkFromStorage(lid, follower.GetUID(), m.G())
+	link, err = ImportLinkFromStorage(m, lid, follower.GetUID())
 	if err != nil {
 		m.CDebugf("| failed to import link from storage")
 		return nil, err
@@ -113,7 +113,7 @@ func TrackChainLinkFromUPK2AI(m MetaContext, follower *keybase1.UserPlusKeysV2Al
 	if _, ok := err.(InconsistentCacheStateError); ok {
 		return nil, err
 	}
-	tcl, err = TrackChainLinkFor(follower.Current.Uid, followeeUID, tcl, err, m.G())
+	tcl, err = TrackChainLinkFor(m, follower.Current.Uid, followeeUID, tcl, err)
 	return tcl, err
 }
 

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -770,7 +770,7 @@ func (u *User) SigChainDump(w io.Writer) {
 	u.sigChain().Dump(w)
 }
 
-func (u *User) IsCachedIdentifyFresh(upk *keybase1.UserPlusKeys) bool {
+func (u *User) IsCachedIdentifyFresh(upk *keybase1.UserPlusKeysV2AllIncarnations) bool {
 	idv, _ := u.GetIDVersion()
 	if upk.Uvv.Id == 0 || idv != upk.Uvv.Id {
 		return false

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -532,30 +532,30 @@ func (u *User) Equal(other *User) bool {
 	return u.id == other.id
 }
 
-func (u *User) TmpTrackChainLinkFor(username string, uid keybase1.UID) (tcl *TrackChainLink, err error) {
-	return TmpTrackChainLinkFor(u.id, uid, u.G())
+func (u *User) TmpTrackChainLinkFor(m MetaContext, username string, uid keybase1.UID) (tcl *TrackChainLink, err error) {
+	return TmpTrackChainLinkFor(m, u.id, uid)
 }
 
-func TmpTrackChainLinkFor(me keybase1.UID, them keybase1.UID, g *GlobalContext) (tcl *TrackChainLink, err error) {
-	g.Log.Debug("+ TmpTrackChainLinkFor for %s", them)
-	tcl, err = LocalTmpTrackChainLinkFor(me, them, g)
-	g.Log.Debug("- TmpTrackChainLinkFor for %s -> %v, %v", them, (tcl != nil), err)
+func TmpTrackChainLinkFor(m MetaContext, me keybase1.UID, them keybase1.UID) (tcl *TrackChainLink, err error) {
+	m.CDebugf("+ TmpTrackChainLinkFor for %s", them)
+	tcl, err = LocalTmpTrackChainLinkFor(m, me, them)
+	m.CDebugf("- TmpTrackChainLinkFor for %s -> %v, %v", them, (tcl != nil), err)
 	return tcl, err
 }
 
-func (u *User) TrackChainLinkFor(username NormalizedUsername, uid keybase1.UID) (*TrackChainLink, error) {
+func (u *User) TrackChainLinkFor(m MetaContext, username NormalizedUsername, uid keybase1.UID) (*TrackChainLink, error) {
 	u.G().Log.Debug("+ TrackChainLinkFor for %s", uid)
 	defer u.G().Log.Debug("- TrackChainLinkFor for %s", uid)
 	remote, e1 := u.remoteTrackChainLinkFor(username, uid)
-	return TrackChainLinkFor(u.id, uid, remote, e1, u.G())
+	return TrackChainLinkFor(m, u.id, uid, remote, e1)
 }
 
-func TrackChainLinkFor(me keybase1.UID, them keybase1.UID, remote *TrackChainLink, remoteErr error, g *GlobalContext) (*TrackChainLink, error) {
+func TrackChainLinkFor(m MetaContext, me keybase1.UID, them keybase1.UID, remote *TrackChainLink, remoteErr error) (*TrackChainLink, error) {
 
-	local, e2 := LocalTrackChainLinkFor(me, them, g)
+	local, e2 := LocalTrackChainLinkFor(m, me, them)
 
-	g.Log.Debug("| Load remote -> %v", (remote != nil))
-	g.Log.Debug("| Load local -> %v", (local != nil))
+	m.CDebugf("| Load remote -> %v", (remote != nil))
+	m.CDebugf("| Load local -> %v", (local != nil))
 
 	if remoteErr != nil && e2 != nil {
 		return nil, remoteErr
@@ -570,12 +570,12 @@ func TrackChainLinkFor(me keybase1.UID, them keybase1.UID, remote *TrackChainLin
 	}
 
 	if remote == nil && local != nil {
-		g.Log.Debug("local expire %v: %s", local.tmpExpireTime.IsZero(), local.tmpExpireTime)
+		m.CDebugf("local expire %v: %s", local.tmpExpireTime.IsZero(), local.tmpExpireTime)
 		return local, nil
 	}
 
 	if remote.GetCTime().After(local.GetCTime()) {
-		g.Log.Debug("| Returning newer remote")
+		m.CDebugf("| Returning newer remote")
 		return remote, nil
 	}
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1223,9 +1223,6 @@ func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 		// track errors, because people need to be able to use it to ask each other
 		// about the fact that proofs are broken.
 		return true
-	case TLFIdentifyBehavior_RESOLVE_AND_CHECK:
-		// Tracks don't matter for ResolveAndCheck, since we act logged out.
-		return true
 	default:
 		return false
 	}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1335,17 +1335,12 @@ func (u UserPlusKeys) GetStatus() StatusCode {
 	return u.Status
 }
 
-func (u UserPlusAllKeys) GetRemoteTrack(s string) *RemoteTrack {
-	i := sort.Search(len(u.RemoteTracks), func(j int) bool {
-		return u.RemoteTracks[j].Username >= s
-	})
-	if i >= len(u.RemoteTracks) {
+func (u UserPlusKeysV2AllIncarnations) GetRemoteTrack(uid UID) *RemoteTrack {
+	ret, ok := u.Current.RemoteTracks[uid]
+	if !ok {
 		return nil
 	}
-	if u.RemoteTracks[i].Username != s {
-		return nil
-	}
-	return &u.RemoteTracks[i]
+	return &ret
 }
 
 func (u UserPlusAllKeys) GetUID() UID {
@@ -1407,6 +1402,14 @@ func (u UserPlusKeysV2) GetName() string {
 	return u.Username
 }
 
+func (u UserPlusKeysV2) GetStatus() StatusCode {
+	return u.Status
+}
+
+func (u UserPlusKeysV2AllIncarnations) ExportToSimpleUser() User {
+	return User{Uid: u.GetUID(), Username: u.GetName()}
+}
+
 func (u UserPlusKeysV2AllIncarnations) FindDevice(d DeviceID) *PublicKeyV2NaCl {
 	for _, k := range u.Current.DeviceKeys {
 		if k.DeviceID.Eq(d) {
@@ -1414,6 +1417,18 @@ func (u UserPlusKeysV2AllIncarnations) FindDevice(d DeviceID) *PublicKeyV2NaCl {
 		}
 	}
 	return nil
+}
+
+func (u UserPlusKeysV2AllIncarnations) GetUID() UID {
+	return u.Current.GetUID()
+}
+
+func (u UserPlusKeysV2AllIncarnations) GetName() string {
+	return u.Current.GetName()
+}
+
+func (u UserPlusKeysV2AllIncarnations) GetStatus() StatusCode {
+	return u.Current.GetStatus()
 }
 
 func (u UserPlusKeysV2AllIncarnations) AllIncarnations() (ret []UserPlusKeysV2) {
@@ -2117,6 +2132,10 @@ func (u UserPlusKeysV2) ToUserVersion() UserVersion {
 	}
 }
 
+func (u UserPlusKeysV2AllIncarnations) ToUserVersion() UserVersion {
+	return u.Current.ToUserVersion()
+}
+
 // Can return nil.
 func (u UserPlusKeysV2) GetLatestPerUserKey() *PerUserKey {
 	if len(u.PerUserKeys) > 0 {
@@ -2514,4 +2533,12 @@ func MakeAvatarURL(u string) AvatarUrl {
 func (b Bytes32) IsBlank() bool {
 	var blank Bytes32
 	return (subtle.ConstantTimeCompare(b[:], blank[:]) == 1)
+}
+
+func (i Identify2ResUPK2) ExportToV1() Identify2Res {
+	return Identify2Res{
+		Upk:          UPAKFromUPKV2AI(i.Upk).Base,
+		IdentifiedAt: i.IdentifiedAt,
+		TrackBreaks:  i.TrackBreaks,
+	}
 }

--- a/go/protocol/keybase1/identify.go
+++ b/go/protocol/keybase1/identify.go
@@ -72,6 +72,26 @@ func (o Identify2Res) DeepCopy() Identify2Res {
 	}
 }
 
+type Identify2ResUPK2 struct {
+	Upk          UserPlusKeysV2AllIncarnations `codec:"upk" json:"upk"`
+	IdentifiedAt Time                          `codec:"identifiedAt" json:"identifiedAt"`
+	TrackBreaks  *IdentifyTrackBreaks          `codec:"trackBreaks,omitempty" json:"trackBreaks,omitempty"`
+}
+
+func (o Identify2ResUPK2) DeepCopy() Identify2ResUPK2 {
+	return Identify2ResUPK2{
+		Upk:          o.Upk.DeepCopy(),
+		IdentifiedAt: o.IdentifiedAt.DeepCopy(),
+		TrackBreaks: (func(x *IdentifyTrackBreaks) *IdentifyTrackBreaks {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.TrackBreaks),
+	}
+}
+
 type IdentifyLiteRes struct {
 	Ul          UserOrTeamLite       `codec:"ul" json:"ul"`
 	TrackBreaks *IdentifyTrackBreaks `codec:"trackBreaks,omitempty" json:"trackBreaks,omitempty"`

--- a/go/service/debugging_devel.go
+++ b/go/service/debugging_devel.go
@@ -51,13 +51,16 @@ func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (
 		err := engine.RunEngine2(m, eng)
 		log("GetProofSet: %v", spew.Sdump(eng.GetProofSet()))
 		log("ConfirmResult: %v", spew.Sdump(eng.ConfirmResult()))
-		eres, _ := eng.Result()
+		eres, eerr := eng.Result()
 		if eres != nil {
 			log("Result.Upk.Username: %v", spew.Sdump(eres.Upk.GetName()))
 			log("Result.IdentifiedAt: %v", spew.Sdump(eres.IdentifiedAt))
 			log("Result.TrackBreaks: %v", spew.Sdump(eres.TrackBreaks))
 		} else {
 			log("Result: %v", spew.Sdump(eres))
+		}
+		if eerr != nil {
+			log("Result.error: %v", spew.Sdump(eerr))
 		}
 		return "", err
 	case "":

--- a/go/service/debugging_devel.go
+++ b/go/service/debugging_devel.go
@@ -51,9 +51,9 @@ func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (
 		err := engine.RunEngine2(m, eng)
 		log("GetProofSet: %v", spew.Sdump(eng.GetProofSet()))
 		log("ConfirmResult: %v", spew.Sdump(eng.ConfirmResult()))
-		eres := eng.Result()
+		eres, _ := eng.Result()
 		if eres != nil {
-			log("Result.Upk.Username: %v", spew.Sdump(eres.Upk.Username))
+			log("Result.Upk.Username: %v", spew.Sdump(eres.Upk.GetName()))
 			log("Result.IdentifiedAt: %v", spew.Sdump(eres.IdentifiedAt))
 			log("Result.TrackBreaks: %v", spew.Sdump(eres.TrackBreaks))
 		} else {

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -301,16 +301,19 @@ func (h *IdentifyHandler) resolveIdentifyImplicitTeamDoIdentifies(ctx context.Co
 			eng := engine.NewIdentify2WithUID(h.G(), &id2arg)
 			m := libkb.NewMetaContext(subctx, h.G()).WithUIs(uis)
 			err := engine.RunEngine2(m, eng)
-			idRes, _ := eng.Result()
+			idRes, idErr := eng.Result()
 			if err != nil {
 				h.G().Log.CDebugf(subctx, "identify failed (IDres %v, TrackBreaks %v): %v", idRes != nil, idRes != nil && idRes.TrackBreaks != nil, err)
-				if idRes != nil && idRes.TrackBreaks != nil {
+				if idRes != nil && idRes.TrackBreaks != nil && idErr == nil {
 					trackBreaksLock.Lock()
 					defer trackBreaksLock.Unlock()
 					if res.TrackBreaks == nil {
 						res.TrackBreaks = make(map[keybase1.UserVersion]keybase1.IdentifyTrackBreaks)
 					}
 					res.TrackBreaks[idRes.Upk.ToUserVersion()] = *idRes.TrackBreaks
+				}
+				if idErr != nil {
+					h.G().Log.CDebugf(subctx, "Failed to convert result from Identify2: %s", idErr)
 				}
 				return err
 			}

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -813,19 +813,21 @@ func identifyRecipient(m libkb.MetaContext, assertion string) (keybase1.TLFIdent
 			m.CDebugf("identifyRecipient: resolution error %s: %s", assertion, err)
 			return keybase1.TLFIdentifyFailure{}, nil
 		}
+		return keybase1.TLFIdentifyFailure{}, err
 	}
 
-	resp := eng.Result()
-	m.CDebugf("identifyRecipient: resp: %+v", resp)
+	resp, err := eng.Result()
+	if err != nil {
+		return keybase1.TLFIdentifyFailure{}, err
+	}
+	m.CDebugf("identifyRecipient: resp: %+v", *resp)
 
 	var frep keybase1.TLFIdentifyFailure
-	if resp != nil {
-		frep.User = keybase1.User{
-			Uid:      resp.Upk.Uid,
-			Username: resp.Upk.Username,
-		}
-		frep.Breaks = resp.TrackBreaks
+	frep.User = keybase1.User{
+		Uid:      resp.Upk.GetUID(),
+		Username: resp.Upk.GetName(),
 	}
+	frep.Breaks = resp.TrackBreaks
 
 	return frep, nil
 }

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -1364,3 +1364,31 @@ func TestMemberInviteChangeRoleOwner(t *testing.T) {
 	}
 	assertInvite(tc, name, fqUID, "keybase", keybase1.TeamRole_OWNER)
 }
+
+func TestFollowResetAdd(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+
+	alice, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+	require.NoError(t, err)
+	team := createTeam(tc)
+	t.Logf("Created team %q", team)
+	tc.G.Logout()
+
+	bob, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+	require.NoError(t, err)
+	tc.G.Logout()
+
+	alice.Login(tc.G)
+	_, err = kbtest.RunTrack(tc, alice, bob.Username)
+	require.NoError(t, err)
+
+	tc.G.Logout()
+	bob.Login(tc.G)
+	kbtest.ResetAccount(tc, bob)
+	tc.G.Logout()
+
+	alice.Login(tc.G)
+	_, err = AddMember(context.TODO(), tc.G, team, bob.Username, keybase1.TeamRole_ADMIN)
+	require.Error(t, err)
+	require.True(t, libkb.IsIdentifyProofError(err))
+}

--- a/go/teams/resolve.go
+++ b/go/teams/resolve.go
@@ -170,7 +170,7 @@ func verifyResolveResult(ctx context.Context, g *libkb.GlobalContext, resolvedAs
 	m := libkb.NewMetaContext(ctx, g).WithUIs(uis)
 	err = engine.RunEngine2(m, eng)
 	if err != nil {
-		idRes := eng.Result()
+		idRes, _ := eng.Result()
 		g.Log.CDebugf(ctx, "identify failed (IDres %v, TrackBreaks %v): %v", idRes != nil, idRes != nil && idRes.TrackBreaks != nil, err)
 	}
 	return err

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -847,7 +847,7 @@ func loadUserVersionPlusByUsername(ctx context.Context, g *libkb.GlobalContext, 
 	// need username here as `username` parameter might be social assertion, also username
 	// is used for chat notification recipient
 	m := libkb.NewMetaContext(ctx, g)
-	upk, err := engine.ResolveAndCheck(m, username)
+	upk, err := engine.ResolveAndCheck(m, username, true /* useTracking */)
 	if err != nil {
 		if e, ok := err.(libkb.ResolutionError); ok && e.Kind == libkb.ResolutionErrorNotFound {
 			// couldn't find a keybase user for username assertion
@@ -876,7 +876,7 @@ func loadUserVersionAndPUKedByUsername(ctx context.Context, g *libkb.GlobalConte
 
 func loadUserVersionByUsername(ctx context.Context, g *libkb.GlobalContext, username string) (keybase1.UserVersion, error) {
 	m := libkb.NewMetaContext(ctx, g)
-	upk, err := engine.ResolveAndCheck(m, username)
+	upk, err := engine.ResolveAndCheck(m, username, true /* resolveAndCheck */)
 	if err != nil {
 		if e, ok := err.(libkb.ResolutionError); ok && e.Kind == libkb.ResolutionErrorNotFound {
 			// couldn't find a keybase user for username assertion

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -146,7 +146,7 @@ func userVersionsToDetails(ctx context.Context, g *libkb.GlobalContext, uvs []ke
 }
 
 func SetRoleOwner(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	uv, err := loadUserVersionByUsername(ctx, g, username)
+	uv, err := loadUserVersionByUsername(ctx, g, username, true /* useTracking */)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func SetRoleOwner(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 }
 
 func SetRoleAdmin(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	uv, err := loadUserVersionByUsername(ctx, g, username)
+	uv, err := loadUserVersionByUsername(ctx, g, username, true /* useTracking */)
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func SetRoleAdmin(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 }
 
 func SetRoleWriter(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	uv, err := loadUserVersionByUsername(ctx, g, username)
+	uv, err := loadUserVersionByUsername(ctx, g, username, true /* useTracking */)
 	if err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ func SetRoleWriter(ctx context.Context, g *libkb.GlobalContext, teamname, userna
 }
 
 func SetRoleReader(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	uv, err := loadUserVersionByUsername(ctx, g, username)
+	uv, err := loadUserVersionByUsername(ctx, g, username, true /* useTracking */)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func getUserProofs(ctx context.Context, g *libkb.GlobalContext, username string)
 
 func AddMemberByID(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, username string, role keybase1.TeamRole) (res keybase1.TeamAddMemberResult, err error) {
 	var inviteRequired bool
-	resolvedUsername, uv, err := loadUserVersionPlusByUsername(ctx, g, username)
+	resolvedUsername, uv, err := loadUserVersionPlusByUsername(ctx, g, username, true /* useTracking */)
 	g.Log.CDebugf(ctx, "team.AddMember: loadUserVersionPlusByUsername(%s) -> (%s, %v, %v)", username, resolvedUsername, uv, err)
 	if err != nil {
 		if err == errInviteRequired {
@@ -511,7 +511,7 @@ func AddEmailsBulk(ctx context.Context, g *libkb.GlobalContext, teamname, emails
 }
 
 func EditMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string, role keybase1.TeamRole) error {
-	uv, err := loadUserVersionByUsername(ctx, g, username)
+	uv, err := loadUserVersionByUsername(ctx, g, username, true /* useTracking */)
 	if err == errInviteRequired {
 		g.Log.CDebugf(ctx, "team %s: edit member %s, member is an invite link", teamname, username)
 		return editMemberInvite(ctx, g, teamname, username, role, uv)
@@ -568,7 +568,7 @@ func editMemberInvite(ctx context.Context, g *libkb.GlobalContext, teamname, use
 }
 
 func MemberRole(ctx context.Context, g *libkb.GlobalContext, teamname, username string) (role keybase1.TeamRole, err error) {
-	uv, err := loadUserVersionByUsername(ctx, g, username)
+	uv, err := loadUserVersionByUsername(ctx, g, username, false /* useTracking */)
 	if err != nil {
 		return keybase1.TeamRole_NONE, err
 	}
@@ -588,7 +588,7 @@ func MemberRole(ctx context.Context, g *libkb.GlobalContext, teamname, username 
 func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
 
 	var inviteRequired bool
-	uv, err := loadUserVersionByUsername(ctx, g, username)
+	uv, err := loadUserVersionByUsername(ctx, g, username, false /* useTracking */)
 	if err != nil {
 		switch err {
 		case errInviteRequired:
@@ -843,11 +843,11 @@ func ChangeRoles(ctx context.Context, g *libkb.GlobalContext, teamname string, r
 var errInviteRequired = errors.New("invite required for username")
 var errUserDeleted = errors.New("user is deleted")
 
-func loadUserVersionPlusByUsername(ctx context.Context, g *libkb.GlobalContext, username string) (libkb.NormalizedUsername, keybase1.UserVersion, error) {
+func loadUserVersionPlusByUsername(ctx context.Context, g *libkb.GlobalContext, username string, useTracking bool) (libkb.NormalizedUsername, keybase1.UserVersion, error) {
 	// need username here as `username` parameter might be social assertion, also username
 	// is used for chat notification recipient
 	m := libkb.NewMetaContext(ctx, g)
-	upk, err := engine.ResolveAndCheck(m, username, true /* useTracking */)
+	upk, err := engine.ResolveAndCheck(m, username, useTracking)
 	if err != nil {
 		if e, ok := err.(libkb.ResolutionError); ok && e.Kind == libkb.ResolutionErrorNotFound {
 			// couldn't find a keybase user for username assertion
@@ -859,8 +859,8 @@ func loadUserVersionPlusByUsername(ctx context.Context, g *libkb.GlobalContext, 
 	return libkb.NormalizedUsernameFromUPK2(upk), uv, err
 }
 
-func loadUserVersionAndPUKedByUsername(ctx context.Context, g *libkb.GlobalContext, username string) (uname libkb.NormalizedUsername, uv keybase1.UserVersion, hasPUK bool, err error) {
-	uname, uv, err = loadUserVersionPlusByUsername(ctx, g, username)
+func loadUserVersionAndPUKedByUsername(ctx context.Context, g *libkb.GlobalContext, username string, useTracking bool) (uname libkb.NormalizedUsername, uv keybase1.UserVersion, hasPUK bool, err error) {
+	uname, uv, err = loadUserVersionPlusByUsername(ctx, g, username, useTracking)
 	if err == nil {
 		hasPUK = true
 	} else {
@@ -874,9 +874,9 @@ func loadUserVersionAndPUKedByUsername(ctx context.Context, g *libkb.GlobalConte
 	return uname, uv, hasPUK, nil
 }
 
-func loadUserVersionByUsername(ctx context.Context, g *libkb.GlobalContext, username string) (keybase1.UserVersion, error) {
+func loadUserVersionByUsername(ctx context.Context, g *libkb.GlobalContext, username string, useTracking bool) (keybase1.UserVersion, error) {
 	m := libkb.NewMetaContext(ctx, g)
-	upk, err := engine.ResolveAndCheck(m, username, true /* resolveAndCheck */)
+	upk, err := engine.ResolveAndCheck(m, username, useTracking)
 	if err != nil {
 		if e, ok := err.(libkb.ResolutionError); ok && e.Kind == libkb.ResolutionErrorNotFound {
 			// couldn't find a keybase user for username assertion
@@ -1148,7 +1148,7 @@ func ListMyAccessRequests(ctx context.Context, g *libkb.GlobalContext, teamName 
 }
 
 func IgnoreRequest(ctx context.Context, g *libkb.GlobalContext, teamName, username string) error {
-	uv, err := loadUserVersionByUsername(ctx, g, username)
+	uv, err := loadUserVersionByUsername(ctx, g, username, false /* useTracking */)
 	if err != nil {
 		if err == errInviteRequired {
 			return libkb.NotFoundError{

--- a/protocol/avdl/keybase1/identify.avdl
+++ b/protocol/avdl/keybase1/identify.avdl
@@ -27,6 +27,15 @@ protocol identify {
     union { null, IdentifyTrackBreaks } trackBreaks;
   }
 
+  // Identify2ResUPK2 is used internally, but we return Identify2Res for
+  // the purposes of KBFS.
+  @lint("ignore")
+  record Identify2ResUPK2 {
+    UserPlusKeysV2AllIncarnations upk;
+    Time identifiedAt;
+    union { null, IdentifyTrackBreaks } trackBreaks;
+  }
+
   /*
    * Note that UID can be empty, in which case a resolution is also forced.
    */

--- a/protocol/avdl/keybase1/upk.avdl
+++ b/protocol/avdl/keybase1/upk.avdl
@@ -111,6 +111,4 @@ protocol UPK {
       case V1: UserPlusAllKeys;
       case V2: UserPlusKeysV2AllIncarnations;
   }
-
-
 }

--- a/protocol/js/rpc-gen.js
+++ b/protocol/js/rpc-gen.js
@@ -1231,6 +1231,7 @@ export type HomeScreenTodoType =
 export type HomeUIHomeUIRefreshRpcParam = void
 export type HomeUserSummary = $ReadOnly<{uid: UID, username: String, bio: String, fullName: String, pics?: ?Pics}>
 export type Identify2Res = $ReadOnly<{upk: UserPlusKeys, identifiedAt: Time, trackBreaks?: ?IdentifyTrackBreaks}>
+export type Identify2ResUPK2 = $ReadOnly<{upk: UserPlusKeysV2AllIncarnations, identifiedAt: Time, trackBreaks?: ?IdentifyTrackBreaks}>
 export type IdentifyIdentify2RpcParam = $ReadOnly<{uid: UID, userAssertion: String, reason: IdentifyReason, useDelegateUI?: Boolean, alwaysBlock?: Boolean, noErrorOnTrackFailure?: Boolean, forceRemoteCheck?: Boolean, needProofSet?: Boolean, allowEmptySelfID?: Boolean, noSkipSelf?: Boolean, canSuppressUI?: Boolean, identifyBehavior?: TLFIdentifyBehavior, forceDisplay?: Boolean, actLoggedOut?: Boolean}>
 export type IdentifyIdentifyLiteRpcParam = $ReadOnly<{id: UserOrTeamID, assertion: String, reason: IdentifyReason, useDelegateUI?: Boolean, alwaysBlock?: Boolean, noErrorOnTrackFailure?: Boolean, forceRemoteCheck?: Boolean, needProofSet?: Boolean, allowEmptySelfID?: Boolean, noSkipSelf?: Boolean, canSuppressUI?: Boolean, identifyBehavior?: TLFIdentifyBehavior, forceDisplay?: Boolean}>
 export type IdentifyKey = $ReadOnly<{pgpFingerprint: Bytes, KID: KID, trackDiff?: ?TrackDiff, breaksTracking: Boolean}>

--- a/protocol/json/keybase1/identify.json
+++ b/protocol/json/keybase1/identify.json
@@ -68,6 +68,28 @@
     },
     {
       "type": "record",
+      "name": "Identify2ResUPK2",
+      "fields": [
+        {
+          "type": "UserPlusKeysV2AllIncarnations",
+          "name": "upk"
+        },
+        {
+          "type": "Time",
+          "name": "identifiedAt"
+        },
+        {
+          "type": [
+            null,
+            "IdentifyTrackBreaks"
+          ],
+          "name": "trackBreaks"
+        }
+      ],
+      "lint": "ignore"
+    },
+    {
+      "type": "record",
       "name": "IdentifyLiteRes",
       "fields": [
         {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -1231,6 +1231,7 @@ export type HomeScreenTodoType =
 export type HomeUIHomeUIRefreshRpcParam = void
 export type HomeUserSummary = $ReadOnly<{uid: UID, username: String, bio: String, fullName: String, pics?: ?Pics}>
 export type Identify2Res = $ReadOnly<{upk: UserPlusKeys, identifiedAt: Time, trackBreaks?: ?IdentifyTrackBreaks}>
+export type Identify2ResUPK2 = $ReadOnly<{upk: UserPlusKeysV2AllIncarnations, identifiedAt: Time, trackBreaks?: ?IdentifyTrackBreaks}>
 export type IdentifyIdentify2RpcParam = $ReadOnly<{uid: UID, userAssertion: String, reason: IdentifyReason, useDelegateUI?: Boolean, alwaysBlock?: Boolean, noErrorOnTrackFailure?: Boolean, forceRemoteCheck?: Boolean, needProofSet?: Boolean, allowEmptySelfID?: Boolean, noSkipSelf?: Boolean, canSuppressUI?: Boolean, identifyBehavior?: TLFIdentifyBehavior, forceDisplay?: Boolean, actLoggedOut?: Boolean}>
 export type IdentifyIdentifyLiteRpcParam = $ReadOnly<{id: UserOrTeamID, assertion: String, reason: IdentifyReason, useDelegateUI?: Boolean, alwaysBlock?: Boolean, noErrorOnTrackFailure?: Boolean, forceRemoteCheck?: Boolean, needProofSet?: Boolean, allowEmptySelfID?: Boolean, noSkipSelf?: Boolean, canSuppressUI?: Boolean, identifyBehavior?: TLFIdentifyBehavior, forceDisplay?: Boolean}>
 export type IdentifyKey = $ReadOnly<{pgpFingerprint: Bytes, KID: KID, trackDiff?: ?TrackDiff, breaksTracking: Boolean}>


### PR DESCRIPTION
- bubble changes up and down
- now .Result() can return an error, so handle that
- fix ResolveAndCheck to skip the UPAK load