### PR TITLE
Chat reactions: various cleanup

### DIFF
--- a/shared/chat/conversation/messages/react-button/container.js
+++ b/shared/chat/conversation/messages/react-button/container.js
@@ -4,6 +4,7 @@ import {compose, connect, setDisplayName, type TypedState} from '../../../../uti
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
+import type {StylesCrossPlatform} from '../../../../styles'
 import ReactButton, {NewReactionButton, type Props, type NewReactionButtonProps} from '.'
 
 export type WrapperProps = {...Props, ...NewReactionButtonProps}
@@ -18,9 +19,14 @@ const Wrapper = (props: WrapperProps) =>
       onMouseLeave={props.onMouseLeave}
       onMouseOver={props.onMouseOver}
       ordinal={props.ordinal}
+      style={props.style}
     />
   ) : (
-    <NewReactionButton onAddReaction={props.onAddReaction} showBorder={props.showBorder} />
+    <NewReactionButton
+      onAddReaction={props.onAddReaction}
+      showBorder={props.showBorder}
+      style={props.style}
+    />
   )
 
 export type OwnProps = {
@@ -30,6 +36,7 @@ export type OwnProps = {
   onMouseOver?: (evt: SyntheticEvent<Element>) => void,
   ordinal: Types.Ordinal,
   showBorder?: boolean,
+  style?: StylesCrossPlatform,
 }
 
 const noEmoji = {

--- a/shared/chat/conversation/messages/react-button/index.js
+++ b/shared/chat/conversation/messages/react-button/index.js
@@ -11,6 +11,7 @@ import {
   platformStyles,
   styleSheetCreate,
   transition,
+  type StylesCrossPlatform,
 } from '../../../../styles'
 import {Picker} from 'emoji-mart'
 import {backgroundImageFn} from '../../../../common-adapters/emoji'
@@ -24,6 +25,7 @@ export type Props = {|
   onMouseLeave?: (evt: SyntheticEvent<Element>) => void,
   onMouseOver?: (evt: SyntheticEvent<Element>) => void,
   ordinal: Types.Ordinal,
+  style?: StylesCrossPlatform,
 |}
 
 const ButtonBox = glamorous(ClickableBox)({
@@ -42,7 +44,7 @@ const ReactButton = (props: Props) => (
     onMouseLeave={props.onMouseLeave}
     onMouseOver={props.onMouseOver}
     onClick={props.onClick}
-    style={collapseStyles([styles.buttonBox, props.active && styles.active])}
+    style={collapseStyles([styles.buttonBox, props.active && styles.active, props.style])}
   >
     <Box2 centerChildren={true} direction="horizontal" gap="xtiny" style={styles.container}>
       <Emoji size={14} emojiName={props.emoji} />
@@ -60,6 +62,7 @@ const iconCycle = [
 export type NewReactionButtonProps = {|
   onAddReaction: (emoji: string) => void,
   showBorder: boolean,
+  style?: StylesCrossPlatform,
 |}
 type NewReactionButtonState = {|
   attachmentRef: ?React.Component<any, any>,
@@ -68,7 +71,7 @@ type NewReactionButtonState = {|
 |}
 export class NewReactionButton extends React.Component<NewReactionButtonProps, NewReactionButtonState> {
   state = {attachmentRef: null, iconIndex: 0, showingPicker: false}
-  _intervalID: IntervalID
+  _intervalID: ?IntervalID
 
   _setShowingPicker = (showingPicker: boolean) =>
     this.setState(s => (s.showingPicker === showingPicker ? null : {showingPicker}))
@@ -77,6 +80,7 @@ export class NewReactionButton extends React.Component<NewReactionButtonProps, N
     evt.stopPropagation()
     this.props.onAddReaction(colons)
     this._setShowingPicker(false)
+    this._stopCycle()
   }
 
   _onShowPicker = (evt: SyntheticEvent<Element>) => {
@@ -85,11 +89,14 @@ export class NewReactionButton extends React.Component<NewReactionButtonProps, N
   }
 
   _startCycle = () => {
-    this._intervalID = setInterval(this._nextIcon, 1000)
+    if (!this._intervalID) {
+      this._intervalID = setInterval(this._nextIcon, 1000)
+    }
   }
 
   _stopCycle = () => {
-    clearInterval(this._intervalID)
+    this._intervalID && clearInterval(this._intervalID)
+    this._intervalID = null
     this.setState(s => (s.iconIndex === 0 ? null : {iconIndex: 0}))
   }
 
@@ -106,7 +113,11 @@ export class NewReactionButton extends React.Component<NewReactionButtonProps, N
         onClick={this._onShowPicker}
         onMouseLeave={this._stopCycle}
         onMouseEnter={this._startCycle}
-        style={collapseStyles([styles.newReactionButtonBox, this.props.showBorder && styles.buttonBox])}
+        style={collapseStyles([
+          styles.newReactionButtonBox,
+          this.props.showBorder && styles.buttonBox,
+          this.props.style,
+        ])}
       >
         <Box2
           ref={attachmentRef => this.setState(s => (s.attachmentRef ? null : {attachmentRef}))}

--- a/shared/chat/conversation/messages/react-button/with-tooltip.js
+++ b/shared/chat/conversation/messages/react-button/with-tooltip.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
 import ReactButton from './container'
 import ReactionTooltip from '../reaction-tooltip/container'
+import type {StylesCrossPlatform} from '../../../../styles'
 
 /**
  * This file is split from index.js to avoid a circular dependency
@@ -18,6 +19,7 @@ export type Props = {|
   emoji?: string,
   ordinal: Types.Ordinal,
   showBorder?: boolean,
+  style?: StylesCrossPlatform,
 |}
 type State = {
   attachmentRef: ?React.Component<any, any>,

--- a/shared/chat/conversation/messages/reactions-row/index.js
+++ b/shared/chat/conversation/messages/reactions-row/index.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
 import {Box2} from '../../../../common-adapters'
 import ReactButton from '../react-button/with-tooltip'
-import {styleSheetCreate} from '../../../../styles'
+import {globalMargins, styleSheetCreate} from '../../../../styles'
 
 export type Props = {|
   conversationIDKey: Types.ConversationIDKey,
@@ -20,16 +20,25 @@ const ReactionsRow = (props: Props) =>
           conversationIDKey={props.conversationIDKey}
           emoji={emoji}
           ordinal={props.ordinal}
+          style={styles.button}
         />
       ))}
-      <ReactButton conversationIDKey={props.conversationIDKey} ordinal={props.ordinal} showBorder={true} />
+      <ReactButton
+        conversationIDKey={props.conversationIDKey}
+        ordinal={props.ordinal}
+        showBorder={true}
+        style={styles.button}
+      />
     </Box2>
   )
 
 const styles = styleSheetCreate({
+  button: {marginBottom: globalMargins.tiny},
   container: {
     alignItems: 'flex-start',
+    flexWrap: 'wrap',
     marginLeft: 56,
+    paddingRight: 50,
   },
 })
 

--- a/shared/common-adapters/emoji.native.js
+++ b/shared/common-adapters/emoji.native.js
@@ -7,14 +7,14 @@ import type {Props} from './emoji'
 
 const EmojiWrapper = (props: Props) => {
   const {emojiName, size} = props
-  const emojiVariantSuffx = '\ufe0f' // see http://mts.io/2015/04/21/unicode-symbol-render-text-emoji/
+  const emojiVariantSuffix = '\ufe0f' // see http://mts.io/2015/04/21/unicode-symbol-render-text-emoji/
   return (
     <Text
       type="Body"
       style={{fontSize: size, lineHeight: undefined}}
       allowFontScaling={props.allowFontScaling}
     >
-      {emojiIndexByName[emojiName] + emojiVariantSuffx}
+      {(!!emojiIndexByName[emojiName] && emojiIndexByName[emojiName] + emojiVariantSuffix) || emojiName}
     </Text>
   )
 }

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -281,6 +281,7 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
                 .set('explodedBy', action.payload.explodedBy || '')
                 .set('text', new HiddenString(''))
                 .set('mentionsAt', I.Set())
+                .set('reactions', I.Map())
             )
           )
         })


### PR DESCRIPTION
- Styling for `ReactionsRow` when there are a lot of reactions (> 1 line) (cc @adamjspooner this adds `marginBottom: 8` to react buttons beneath messages)
- Make sure we never start more than one interval in `NewReactionButton`
- Clear out reactions when messages explode (cc @joshblum)
- [Native] Show emoji name rather than `undefined` if we don't have it in the index

r? @keybase/react-hackers 