### PR TITLE
Add self check in orange line

### DIFF
--- a/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
@@ -7,25 +7,25 @@ import {formatTimeForMessages} from '../../../../../util/timestamp'
 
 const mapStateToProps = (
   state: TypedState,
-  props: {
+  ownProps: {
     message: Types.Message,
     previous: ?Types.Message,
   }
 ) => {
-  const lastReadMessageID = state.chat2.lastReadMessageMap.get(props.message.conversationIDKey)
+  const lastReadMessageID = state.chat2.lastReadMessageMap.get(ownProps.message.conversationIDKey)
   // Show the orange line on the first message after the last unread message
   // Messages sent sent by you don't count
   const orangeLineAbove =
-    !!props.previous &&
-    lastReadMessageID === props.previous.id &&
-    props.message.author !== state.config.username
+    !!ownProps.previous &&
+    lastReadMessageID === ownProps.previous.id &&
+    ownProps.message.author !== state.config.username
 
   return {
-    _message: props.message,
-    conversationIDKey: props.message.conversationIDKey,
+    _message: ownProps.message,
+    conversationIDKey: ownProps.message.conversationIDKey,
     orangeLineAbove,
-    ordinal: props.message.ordinal,
-    previous: props.previous,
+    ordinal: ownProps.message.ordinal,
+    previous: ownProps.previous,
   }
 }
 

--- a/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
@@ -12,7 +12,7 @@ type OwnProps = {
 
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   const lastReadMessageID = state.chat2.lastReadMessageMap.get(ownProps.message.conversationIDKey)
-  // Show the orange line on the first message after the last unread message
+  // Show the orange line on the first message after the last read message
   // Messages sent sent by you don't count
   const orangeLineAbove =
     !!ownProps.previous &&

--- a/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
@@ -1,19 +1,31 @@
 // @flow
 import {WrapperTimestamp} from '../'
 import * as Constants from '../../../../../constants/chat2/message'
+import * as Types from '../../../../../constants/types/chat2'
 import {setDisplayName, compose, connect, type TypedState} from '../../../../../util/container'
 import {formatTimeForMessages} from '../../../../../util/timestamp'
 
-const mapStateToProps = (state: TypedState, {message, previous}) => {
-  const lastReadMessageID = state.chat2.lastReadMessageMap.get(message.conversationIDKey)
-  // Show the orange line on the first message after the last unread message, if there is one
-  const orangeLineAbove = !!previous && lastReadMessageID === previous.id
+const mapStateToProps = (
+  state: TypedState,
+  props: {
+    message: Types.Message,
+    previous: ?Types.Message,
+  }
+) => {
+  const lastReadMessageID = state.chat2.lastReadMessageMap.get(props.message.conversationIDKey)
+  // Show the orange line on the first message after the last unread message
+  // Messages sent sent by you don't count
+  const orangeLineAbove =
+    !!props.previous &&
+    lastReadMessageID === props.previous.id &&
+    props.message.author !== state.config.username
+
   return {
-    _message: message,
-    conversationIDKey: message.conversationIDKey,
+    _message: props.message,
+    conversationIDKey: props.message.conversationIDKey,
     orangeLineAbove,
-    ordinal: message.ordinal,
-    previous,
+    ordinal: props.message.ordinal,
+    previous: props.previous,
   }
 }
 

--- a/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
@@ -5,13 +5,12 @@ import * as Types from '../../../../../constants/types/chat2'
 import {setDisplayName, compose, connect, type TypedState} from '../../../../../util/container'
 import {formatTimeForMessages} from '../../../../../util/timestamp'
 
-const mapStateToProps = (
-  state: TypedState,
-  ownProps: {
-    message: Types.Message,
-    previous: ?Types.Message,
-  }
-) => {
+type OwnProps = {
+  message: Types.Message,
+  previous: ?Types.Message,
+}
+
+const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   const lastReadMessageID = state.chat2.lastReadMessageMap.get(ownProps.message.conversationIDKey)
   // Show the orange line on the first message after the last unread message
   // Messages sent sent by you don't count


### PR DESCRIPTION
Adds a check in the orange line display logic to ensure that a message you send after the last read message doesn't trigger the orange line. (thanks to @buoyad for finding this!)

Also adds types to ownProps because it had a type of `empty` before.