### PR TITLE
WIP: Inbox hover styles

### DIFF
--- a/shared/chat/inbox/row/small-team/index.js
+++ b/shared/chat/inbox/row/small-team/index.js
@@ -39,43 +39,25 @@ type Props = {
   youNeedToRekey: boolean,
 }
 
-type State = {
-  isHovered: boolean,
-}
-
 const SmallTeamBox = isMobile
   ? ClickableBox
   : glamorous(Box)({
       '& .small-team-gear': {display: 'none'},
       ':hover .small-team-gear': {display: 'unset'},
       ':hover .small-team-timestamp': {display: 'none'},
+      ':not(.selected):hover': {backgroundColor: globalColors.red},
     })
 
-class SmallTeam extends React.PureComponent<Props, State> {
-  state = {
-    isHovered: false,
-  }
-
-  _backgroundColor = () =>
-    // props.backgroundColor should always override hover styles, otherwise, there's a
-    // moment when the conversation is loading that the selected inbox row is styled
-    // with hover styles instead of props.backgroundColor.
-    this.props.isSelected
-      ? this.props.backgroundColor
-      : this.state.isHovered
-        ? globalColors.blue4
-        : this.props.backgroundColor
-
+class SmallTeam extends React.PureComponent<Props> {
   render() {
     const props = this.props
     return (
       <SmallTeamBox
+        className={props.isSelected ? 'selected' : ''}
         onClick={props.onSelectConversation}
-        onMouseLeave={() => this.setState({isHovered: false})}
-        onMouseOver={() => this.setState({isHovered: true})}
         style={collapseStyles([
-          {
-            backgroundColor: this._backgroundColor(),
+          props.isSelected && {
+            backgroundColor: props.backgroundColor,
           },
           styles.container,
         ])}
@@ -89,7 +71,7 @@ class SmallTeam extends React.PureComponent<Props, State> {
             />
           ) : (
             <Avatars
-              backgroundColor={this._backgroundColor()}
+              backgroundColor={props.backgroundColor}
               isMuted={props.isMuted}
               isLocked={props.youNeedToRekey || props.participantNeedToRekey || props.isFinalized}
               isSelected={props.isSelected}


### PR DESCRIPTION
@chrisnojima, this is how I _wanted_ to do the hover styles. The problem I ran into was the border color on multiavatars on hover because it's getting it from `props.backgroundColor`. I'm using red here to exaggerate the problem:
<img width="264" alt="screen shot 2018-07-24 at 1 14 06 pm" src="https://user-images.githubusercontent.com/30595/43154961-fd252e88-8f43-11e8-9194-ae9f846e6a88.png">

I'd rather not use state. It seems pretty flakey (as @buoyad pointed out). Do you have any suggestions?

(Also, it looks like the `div` making the border is a pixel or two too wide. I just noticed after taking the screenshot.)