### PR TITLE
Expand Touch Targets

### DIFF
--- a/shared/chat/conversation/info-panel/channel-utils.js
+++ b/shared/chat/conversation/info-panel/channel-utils.js
@@ -38,6 +38,8 @@ const CaptionedDangerIcon = ({
       ...globalStyles.flexBoxRow,
       alignItems: 'center',
       justifyContent: 'center',
+      paddingBottom: globalMargins.tiny,
+      paddingTop: globalMargins.tiny,
     }}
     onClick={onClick}
   >

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -219,18 +219,22 @@ const Action = ({
           openExplodingPicker={openExplodingPicker}
         />
       )}
-      <Icon
-        onClick={insertMentionMarker}
-        type="iconfont-mention"
-        style={iconCastPlatformStyles(styles.actionButton)}
-        fontSize={22}
-      />
-      <Icon
-        onClick={openFilePicker}
-        type="iconfont-camera"
-        style={iconCastPlatformStyles(styles.actionButton)}
-        fontSize={22}
-      />
+      <Box style={styles.actionButtonWrapper}>
+        <Icon
+          onClick={insertMentionMarker}
+          type="iconfont-mention"
+          style={iconCastPlatformStyles(styles.actionButton)}
+          fontSize={22}
+        />
+      </Box>
+      <Box style={styles.actionButtonWrapper}>
+        <Icon
+          onClick={openFilePicker}
+          type="iconfont-camera"
+          style={iconCastPlatformStyles(styles.actionButton)}
+          fontSize={22}
+        />
+      </Box>
     </Box2>
   )
 
@@ -264,6 +268,13 @@ const styles = styleSheetCreate({
   actionButton: {
     alignSelf: isIOS ? 'flex-end' : 'center',
   },
+  actionButtonWrapper: platformStyles({
+    common: {
+      paddingLeft: containerPadding,
+      paddingRight: containerPadding,
+      paddingTop: containerPadding,
+    },
+  }),
   actionIconsContainer: {
     paddingRight: globalMargins.small - containerPadding,
   },
@@ -329,6 +340,9 @@ const explodingIconContainer = platformStyles({
   common: {
     ...globalStyles.flexBoxRow,
     marginRight: -3,
+    paddingLeft: containerPadding,
+    paddingRight: containerPadding,
+    paddingTop: containerPadding,
   },
 })
 

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -219,22 +219,18 @@ const Action = ({
           openExplodingPicker={openExplodingPicker}
         />
       )}
-      <Box style={styles.actionButtonWrapper}>
-        <Icon
-          onClick={insertMentionMarker}
-          type="iconfont-mention"
-          style={iconCastPlatformStyles(styles.actionButton)}
-          fontSize={22}
-        />
-      </Box>
-      <Box style={styles.actionButtonWrapper}>
-        <Icon
-          onClick={openFilePicker}
-          type="iconfont-camera"
-          style={iconCastPlatformStyles(styles.actionButton)}
-          fontSize={22}
-        />
-      </Box>
+      <Icon
+        onClick={insertMentionMarker}
+        type="iconfont-mention"
+        style={iconCastPlatformStyles(styles.actionButton)}
+        fontSize={22}
+      />
+      <Icon
+        onClick={openFilePicker}
+        type="iconfont-camera"
+        style={iconCastPlatformStyles(styles.actionButton)}
+        fontSize={22}
+      />
     </Box2>
   )
 
@@ -268,13 +264,6 @@ const styles = styleSheetCreate({
   actionButton: {
     alignSelf: isIOS ? 'flex-end' : 'center',
   },
-  actionButtonWrapper: platformStyles({
-    common: {
-      paddingLeft: containerPadding,
-      paddingRight: containerPadding,
-      paddingTop: containerPadding,
-    },
-  }),
   actionIconsContainer: {
     paddingRight: globalMargins.small - containerPadding,
   },
@@ -340,9 +329,6 @@ const explodingIconContainer = platformStyles({
   common: {
     ...globalStyles.flexBoxRow,
     marginRight: -3,
-    paddingLeft: containerPadding,
-    paddingRight: containerPadding,
-    paddingTop: containerPadding,
   },
 })
 

--- a/shared/chat/inbox/row/big-team-header/index.js
+++ b/shared/chat/inbox/row/big-team-header/index.js
@@ -67,6 +67,7 @@ const styles = styleSheetCreate({
   },
   showMenu: {
     ...globalStyles.flexBoxRow,
+    padding: globalMargins.xtiny,
     position: 'relative',
     right: globalMargins.xtiny,
   },

--- a/shared/chat/inbox/row/big-team-header/index.js
+++ b/shared/chat/inbox/row/big-team-header/index.js
@@ -67,7 +67,7 @@ const styles = styleSheetCreate({
   },
   showMenu: {
     ...globalStyles.flexBoxRow,
-    padding: globalMargins.xtiny,
+    padding: 6,
     position: 'relative',
     right: globalMargins.xtiny,
   },

--- a/shared/chat/inbox/row/divider/index.js
+++ b/shared/chat/inbox/row/divider/index.js
@@ -3,11 +3,11 @@ import * as React from 'react'
 import {ClickableBox, Box2, Text, Badge} from '../../../../common-adapters'
 import {
   styleSheetCreate,
+  platformStyles,
   collapseStyles,
   globalStyles,
   globalColors,
   globalMargins,
-  isMobile,
 } from '../../../../styles'
 import * as RowSizes from '../sizes'
 
@@ -33,14 +33,16 @@ class Divider extends React.PureComponent<Props> {
         gapEnd={true}
       >
         {this.props.showButton && (
-          <ClickableBox onClick={this.props.toggle} className="toggleButtonClass" style={styles.toggleButton}>
-            <Text type="BodySmallSemibold" style={styles.buttonText}>
-              {this.props.hiddenCount > 0 ? `+${this.props.hiddenCount} more` : 'Show less'}
-            </Text>
-            {this.props.hiddenCount > 0 &&
-              this.props.badgeCount > 0 && (
-                <Badge badgeStyle={styles.badgeToggle} badgeNumber={this.props.badgeCount} />
-              )}
+          <ClickableBox onClick={this.props.toggle} style={styles.containerToggleButton}>
+            <Box2 direction="horizontal" className="toggleButtonClass" style={styles.toggleButton}>
+              <Text type="BodySmallSemibold" style={styles.buttonText}>
+                {this.props.hiddenCount > 0 ? `+${this.props.hiddenCount} more` : 'Show less'}
+              </Text>
+              {this.props.hiddenCount > 0 &&
+                this.props.badgeCount > 0 && (
+                  <Badge badgeStyle={styles.badgeToggle} badgeNumber={this.props.badgeCount} />
+                )}
+            </Box2>
           </ClickableBox>
         )}
         <Box2 direction="vertical" style={styles.divider} />
@@ -70,6 +72,8 @@ const styles = styleSheetCreate({
     ...globalStyles.flexBoxColumn,
     height: RowSizes.dividerHeight(true),
     justifyContent: 'center',
+    paddingBottom: globalMargins.tiny,
+    paddingTop: globalMargins.tiny,
     width: '100%',
   },
   containerNoButton: {
@@ -77,6 +81,12 @@ const styles = styleSheetCreate({
     height: RowSizes.dividerHeight(false),
     justifyContent: 'center',
     width: '100%',
+  },
+  containerToggleButton: {
+    ...globalStyles.flexBoxRow,
+    alignItems: 'center',
+    alignSelf: 'center',
+    flexShrink: 0,
   },
   divider: {
     backgroundColor: globalColors.black_05,
@@ -88,18 +98,30 @@ const styles = styleSheetCreate({
     marginLeft: globalMargins.tiny,
     marginRight: globalMargins.tiny,
   },
-  toggleButton: {
-    ...globalStyles.flexBoxRow,
-    alignItems: 'center',
-    alignSelf: 'center',
-    backgroundColor: globalColors.black_05,
-    borderRadius: 19,
-    flexShrink: 0,
-    paddingBottom: globalMargins.xtiny,
-    paddingLeft: isMobile ? globalMargins.small : globalMargins.tiny,
-    paddingRight: isMobile ? globalMargins.small : globalMargins.tiny,
-    paddingTop: globalMargins.xtiny,
-  },
+  toggleButton: platformStyles({
+    common: {
+      backgroundColor: globalColors.black_05,
+      borderRadius: 19,
+      marginBottom: globalMargins.xtiny,
+      marginTop: globalMargins.xtiny,
+      paddingBottom: globalMargins.xtiny,
+      paddingTop: globalMargins.xtiny,
+    },
+    isElectron: {
+      marginLeft: globalMargins.tiny,
+      marginRight: globalMargins.tiny,
+
+      paddingLeft: globalMargins.tiny,
+      paddingRight: globalMargins.tiny,
+    },
+    isMobile: {
+      marginLeft: globalMargins.small,
+      marginRight: globalMargins.small,
+
+      paddingLeft: globalMargins.small,
+      paddingRight: globalMargins.small,
+    },
+  }),
 })
 
 export {Divider}

--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -196,6 +196,7 @@ const styleRow = {
 const styleService = {
   marginRight: globalMargins.xtiny,
   marginTop: 2,
+  padding: 5,
 }
 const styleServiceContainer = {
   color: globalColors.black_75,

--- a/shared/fs/header/add-new.js
+++ b/shared/fs/header/add-new.js
@@ -1,6 +1,14 @@
 // @flow
 import * as React from 'react'
-import {isMobile, globalStyles, globalColors, globalMargins, platformStyles} from '../../styles'
+import {
+  isMobile,
+  styleSheetCreate,
+  collapseStyles,
+  globalStyles,
+  globalColors,
+  globalMargins,
+  platformStyles,
+} from '../../styles'
 import {Box, ClickableBox, Icon, Text, type IconType} from '../../common-adapters'
 import StaticBreadcrumb from '../common/static-breadcrumb'
 import FloatingMenu, {
@@ -25,11 +33,15 @@ type AddNewProps = {
 const AddNew = (props: AddNewProps & FloatingMenuParentProps) => {
   return (
     !!props.menuItems.length && (
-      <Box style={props.style}>
-        <ClickableBox style={stylesBox} onClick={props.toggleShowingMenu} ref={props.setAttachmentRef}>
-          <Icon type="iconfont-new" color={globalColors.blue} style={stylesIconNew} />
+      <Box>
+        <ClickableBox style={props.style} onClick={props.toggleShowingMenu} ref={props.setAttachmentRef}>
+          <Icon
+            type="iconfont-new"
+            color={globalColors.blue}
+            style={collapseStyles([styles.stylesIconNew])}
+          />
           {!isMobile && (
-            <Text type="BodyBigLink" style={stylesText}>
+            <Text type="BodyBigLink" style={styles.stylesText}>
               New ...
             </Text>
           )}
@@ -63,9 +75,9 @@ const AddNew = (props: AddNewProps & FloatingMenuParentProps) => {
                       : {
                           title: item.title,
                           view: (
-                            <Box style={stylesBox}>
+                            <Box style={styles.stylesBox}>
                               <Icon type={item.icon} color={globalColors.blue} />
-                              <Text type="Body" style={stylesText}>
+                              <Text type="Body" style={styles.stylesText}>
                                 {item.title}
                               </Text>
                             </Box>
@@ -81,17 +93,17 @@ const AddNew = (props: AddNewProps & FloatingMenuParentProps) => {
   )
 }
 
-const stylesBox = {
-  ...globalStyles.flexBoxRow,
-  alignItems: 'center',
-}
-
-const stylesText = {
-  marginLeft: globalMargins.tiny,
-}
-
-const stylesIconNew = platformStyles({
-  isMobile: {fontSize: 22},
+const styles = styleSheetCreate({
+  stylesBox: {
+    ...globalStyles.flexBoxRow,
+    alignItems: 'center',
+  },
+  stylesText: {
+    marginLeft: globalMargins.tiny,
+  },
+  stylesIconNew: platformStyles({
+    isMobile: {fontSize: 22},
+  }),
 })
 
 export default FloatingMenuParentHOC(AddNew)

--- a/shared/fs/header/header.native.js
+++ b/shared/fs/header/header.native.js
@@ -1,30 +1,27 @@
 // @flow
 import * as React from 'react'
-import {globalColors, globalStyles, globalMargins} from '../../styles'
+import {styleSheetCreate, collapseStyles, globalColors, globalStyles, globalMargins} from '../../styles'
 import {BackButton, Box, Icon, Text} from '../../common-adapters'
 import AddNew from './add-new-container'
 import {type FolderHeaderProps} from './header'
 
 const Header = ({title, path, onBack, onChat}: FolderHeaderProps) => (
-  <Box style={stylesFolderHeaderContainer}>
-    <Box style={stylesFolderHeaderRow}>
+  <Box style={styles.stylesFolderHeaderContainer}>
+    <Box style={styles.stylesFolderHeaderRow}>
       <BackButton onClick={onBack} />
-      <Box style={stylesFolderHeaderRoot}>
-        <Text type="BodyBig" style={stylesTitle}>
+      <Box style={styles.stylesFolderHeaderRoot}>
+        <Text type="BodyBig" style={styles.stylesTitle}>
           {title}
         </Text>
       </Box>
-      <Box style={stylesAddNewBox}>
-        <AddNew path={path} style={stylesAddNew} />
+      <Box style={styles.stylesAddNewBox}>
+        <AddNew path={path} style={styles.stylesIcons} />
       </Box>
       {onChat && (
-        <Box style={stylesAddNewBox}>
+        <Box style={styles.stylesAddNewBox}>
           <Icon
             type="iconfont-chat"
-            style={{
-              marginLeft: globalMargins.tiny,
-              marginTop: globalMargins.tiny,
-            }}
+            style={collapseStyles([styles.stylesIcons])}
             color={globalColors.black_40}
             fontSize={22}
             onClick={onChat}
@@ -35,38 +32,36 @@ const Header = ({title, path, onBack, onChat}: FolderHeaderProps) => (
   </Box>
 )
 
-const stylesFolderHeaderRow = {
-  ...globalStyles.flexBoxRow,
-  alignItems: 'flex-start',
-  paddingTop: 12,
-  minHeight: 64,
-}
-
-const stylesFolderHeaderContainer = {
-  ...globalStyles.flexBoxColumn,
-  alignItems: 'flex-start',
-  minHeight: 64,
-}
-
-const stylesFolderHeaderRoot = {
-  paddingTop: 9,
-  paddingBottom: 21,
-  flexShrink: 1,
-  flexGrow: 1,
-}
-
-const stylesAddNew = {
-  padding: globalMargins.tiny,
-  paddingRight: globalMargins.small - 4,
-  paddingLeft: globalMargins.small,
-}
-
-const stylesTitle = {
-  textAlign: 'center',
-}
-
-const stylesAddNewBox = {
-  minWidth: 50,
-}
-
+const styles = styleSheetCreate({
+  stylesFolderHeaderRow: {
+    ...globalStyles.flexBoxRow,
+    alignItems: 'flex-start',
+    paddingTop: 12,
+    minHeight: 64,
+  },
+  stylesFolderHeaderContainer: {
+    ...globalStyles.flexBoxColumn,
+    alignItems: 'flex-start',
+    minHeight: 64,
+  },
+  stylesFolderHeaderRoot: {
+    paddingTop: 9,
+    paddingBottom: 21,
+    flexShrink: 1,
+    flexGrow: 1,
+  },
+  stylesIcons: {
+    ...globalStyles.flexBoxRow,
+    alignItems: 'center',
+    padding: globalMargins.tiny,
+    paddingRight: globalMargins.small - 4,
+    paddingLeft: globalMargins.small,
+  },
+  stylesTitle: {
+    textAlign: 'center',
+  },
+  stylesAddNewBox: {
+    minWidth: 50,
+  },
+})
 export default Header

--- a/shared/profile/index.native.js
+++ b/shared/profile/index.native.js
@@ -47,7 +47,11 @@ const EditControl = ({isYou, onClickShowcaseOffer}: {isYou: boolean, onClickShow
   <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', marginBottom: globalMargins.tiny}}>
     <Text type="BodySmallSemibold">Teams</Text>
     {!!isYou && (
-      <Icon style={{margin: 2, width: 22, height: 22}} type="iconfont-edit" onClick={onClickShowcaseOffer} />
+      <Icon
+        style={{margin: 2, width: 28, height: 28, padding: 6}}
+        type="iconfont-edit"
+        onClick={onClickShowcaseOffer}
+      />
     )}
   </Box>
 )

--- a/shared/teams/main/banner.js
+++ b/shared/teams/main/banner.js
@@ -1,7 +1,14 @@
 // @flow
 import * as React from 'react'
 import {Box, Icon, Text} from '../../common-adapters'
-import {globalColors, globalMargins, globalStyles, isMobile} from '../../styles'
+import {
+  styleSheetCreate,
+  platformStyles,
+  globalColors,
+  globalMargins,
+  globalStyles,
+  isMobile,
+} from '../../styles'
 
 export type Props = {
   onReadMore: () => void,
@@ -9,47 +16,13 @@ export type Props = {
 }
 
 const Banner = ({onReadMore, onHideChatBanner}: Props) => (
-  <Box
-    style={{
-      ...(isMobile
-        ? {
-            ...globalStyles.flexBoxColumn,
-            padding: 24,
-          }
-        : {
-            ...globalStyles.flexBoxRow,
-            height: 212,
-          }),
-      alignItems: 'center',
-      backgroundColor: globalColors.blue,
-      flexShrink: 0,
-      justifyContent: 'center',
-      position: 'relative',
-      width: '100%',
-    }}
-  >
+  <Box style={styles.containerBanner}>
     <Icon type={isMobile ? 'icon-illustration-teams-216' : 'icon-illustration-teams-180'} />
-    <Box
-      style={{
-        ...globalStyles.flexBoxColumn,
-        ...(isMobile ? {alignItems: 'center'} : {marginLeft: globalMargins.medium, maxWidth: 330}),
-      }}
-    >
-      <Text
-        backgroundMode="Terminal"
-        type="Header"
-        style={{
-          marginBottom: 15,
-          marginTop: 15,
-        }}
-      >
+    <Box style={styles.containerHeader}>
+      <Text backgroundMode="Terminal" type="Header" style={styles.header}>
         Now supporting teams!
       </Text>
-      <Text
-        backgroundMode="Terminal"
-        type="BodySmallSemibold"
-        style={{marginBottom: globalMargins.small, ...(isMobile ? {textAlign: 'center'} : {})}}
-      >
+      <Text backgroundMode="Terminal" type="BodySmallSemibold" style={styles.text}>
         Keybase team chats are encrypted - unlike Slack - and work for any size group, from casual friends to
         large communities.
       </Text>
@@ -62,25 +35,73 @@ const Banner = ({onReadMore, onHideChatBanner}: Props) => (
         Read our announcement
       </Text>
     </Box>
-    <Box style={closeIconStyle}>
-      <Icon type="iconfont-close" onClick={onHideChatBanner} />
+    <Box style={styles.closeIconContainer}>
+      <Icon type="iconfont-close" style={{padding: globalMargins.xtiny}} onClick={onHideChatBanner} />
     </Box>
   </Box>
 )
 
-let closeIconStyle = {
-  position: 'absolute',
-  ...(isMobile
-    ? {
-        right: globalMargins.small,
-        top: globalMargins.small,
-        height: 14,
-        width: 14,
-      }
-    : {
-        right: globalMargins.tiny,
-        top: globalMargins.tiny,
-      }),
-}
+const styles = styleSheetCreate({
+  containerBanner: platformStyles({
+    common: {
+      alignItems: 'center',
+      backgroundColor: globalColors.blue,
+      flexShrink: 0,
+      justifyContent: 'center',
+      position: 'relative',
+      width: '100%',
+    },
+    isElectron: {
+      ...globalStyles.flexBoxRow,
+      height: 212,
+    },
+    isMobile: {
+      ...globalStyles.flexBoxColumn,
+      padding: 24,
+    },
+  }),
+  containerHeader: platformStyles({
+    common: {
+      ...globalStyles.flexBoxColumn,
+    },
+    isElectron: {
+      marginLeft: globalMargins.medium,
+      maxWidth: 330,
+    },
+    isMobile: {
+      alignItems: 'center',
+    },
+  }),
+  header: {
+    marginBottom: 15,
+    marginTop: 15,
+  },
+  text: platformStyles({
+    common: {
+      marginBottom: globalMargins.small,
+    },
+    isMobile: {
+      textAlign: 'center',
+    },
+  }),
+  closeIconContainer: platformStyles({
+    common: {
+      position: 'absolute',
+    },
+    isElectron: {
+      right: globalMargins.tiny,
+      top: globalMargins.tiny,
+    },
+    isMobile: {
+      right: globalMargins.small,
+      top: globalMargins.small,
+      height: 26,
+      width: 26,
+    },
+  }),
+  closeIcon: {
+    padding: globalMargins.xtiny,
+  },
+})
 
 export default Banner

--- a/shared/teams/team/custom-title/index.js
+++ b/shared/teams/team/custom-title/index.js
@@ -61,6 +61,7 @@ const styles = styleSheetCreate({
   },
   icon: {
     marginRight: globalMargins.tiny,
+    padding: globalMargins.tiny,
   },
   progressIndicator: {
     height: 17,

--- a/shared/teams/team/members-tab/member-row/index.js
+++ b/shared/teams/team/members-tab/member-row/index.js
@@ -153,12 +153,13 @@ export const TeamMemberRow = (props: Props) => {
               </ButtonBar>
             </Box>
           )}
-        <Box style={{...globalStyles.flexBoxRow, flexShrink: 1}}>
+        <Box style={{...globalStyles.flexBoxRow, flexShrink: 1, height: '100%'}}>
           <Icon
             onClick={props.onChat}
             style={{
               marginLeft: globalMargins.small,
               marginRight: globalMargins.tiny,
+              padding: globalMargins.tiny,
             }}
             fontSize={isMobile ? 20 : 16}
             type="iconfont-chat"

--- a/shared/teams/team/subteams-tab/intro-row/index.js
+++ b/shared/teams/team/subteams-tab/intro-row/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import {Box, Icon, Text} from '../../../../common-adapters'
-import {globalColors, globalMargins, globalStyles, isMobile} from '../../../../styles'
+import {styleSheetCreate, platformStyles, globalColors, globalMargins, globalStyles} from '../../../../styles'
 import type {Teamname} from '../../../../constants/types/teams'
 
 export type Props = {
@@ -11,27 +11,13 @@ export type Props = {
 }
 
 const Banner = ({onReadMore, onHideSubteamsBanner, teamname}: Props) => (
-  <Box
-    style={{
-      ...(isMobile ? styleMobile : styleDesktop),
-      ...styleContainer,
-    }}
-  >
-    <Box style={{...globalStyles.flexBoxColumn, margin: globalMargins.small}}>
+  <Box style={styles.containerBanner}>
+    <Box style={styles.containerIllustration}>
       <Icon type="icon-illustration-subteams-380" />
     </Box>
 
-    <Box
-      style={{
-        ...globalStyles.flexBoxColumn,
-        ...(isMobile ? {alignItems: 'center'} : {marginLeft: globalMargins.medium, maxWidth: 330}),
-      }}
-    >
-      <Text
-        backgroundMode="Terminal"
-        type="BodySmallSemibold"
-        style={{marginBottom: globalMargins.small, ...(isMobile ? {textAlign: 'center'} : {})}}
-      >
+    <Box style={styles.containerText}>
+      <Text backgroundMode="Terminal" type="BodySmallSemibold" style={styles.text}>
         Subteams are cryptographically distinct, and can welcome people who aren't elsewhere in your team
         hierarchy. Some random ideas:
       </Text>
@@ -46,55 +32,88 @@ const Banner = ({onReadMore, onHideSubteamsBanner, teamname}: Props) => (
       </Text>
 
       <Text
-        style={{marginTop: globalMargins.small}}
         backgroundMode="Terminal"
         type="BodySmallSemiboldPrimaryLink"
         className="underline"
         onClick={onReadMore}
+        style={styles.readmore}
       >
         Read more about subteams
       </Text>
     </Box>
     {onHideSubteamsBanner && (
-      <Box style={closeIconStyle}>
-        <Icon type="iconfont-close" onClick={onHideSubteamsBanner} />
+      <Box style={styles.iconCloseContainer}>
+        <Icon type="iconfont-close" style={{padding: globalMargins.tiny}} onClick={onHideSubteamsBanner} />
       </Box>
     )}
   </Box>
 )
 
-let closeIconStyle = {
-  position: 'absolute',
-  ...(isMobile
-    ? {
-        height: 14,
-        right: globalMargins.small,
-        top: globalMargins.small,
-        width: 14,
-      }
-    : {
-        right: globalMargins.tiny,
-        top: globalMargins.tiny,
-      }),
-}
+const styles = styleSheetCreate({
+  containerBanner: platformStyles({
+    common: {
+      alignItems: 'center',
+      backgroundColor: globalColors.blue,
+      flexShrink: 0,
+      justifyContent: 'center',
+      position: 'relative',
+      width: '100%',
+    },
+    isElectron: {
+      ...globalStyles.flexBoxRow,
+      height: 256,
+    },
+    isMobile: {
+      ...globalStyles.flexBoxColumn,
+      padding: 24,
+    },
+  }),
+  containerIllustration: {
+    ...globalStyles.flexBoxColumn,
+    margin: globalMargins.small,
+  },
+  containerText: platformStyles({
+    common: {
+      ...globalStyles.flexBoxColumn,
+    },
+    isElectron: {
+      marginLeft: globalMargins.medium,
+      maxWidth: 330,
+    },
+    isMobile: {
+      alignItems: 'center',
+    },
+  }),
+  text: platformStyles({
+    common: {
+      marginBottom: globalMargins.small,
+    },
+    isMobile: {
+      textAlign: 'center',
+    },
+  }),
+  readmore: {
+    marginTop: globalMargins.small,
+  },
 
-const styleDesktop = {
-  ...globalStyles.flexBoxRow,
-  height: 256,
-}
-
-const styleMobile = {
-  ...globalStyles.flexBoxColumn,
-  padding: 24,
-}
-
-const styleContainer = {
-  alignItems: 'center',
-  backgroundColor: globalColors.blue,
-  flexShrink: 0,
-  justifyContent: 'center',
-  position: 'relative',
-  width: '100%',
-}
+  iconCloseContainer: platformStyles({
+    common: {
+      position: 'absolute',
+    },
+    isElectron: {
+      right: globalMargins.tiny,
+      top: globalMargins.tiny,
+    },
+    isMobile: {
+      height: 14,
+      right: globalMargins.small,
+      top: globalMargins.small,
+      width: 14,
+    },
+  }),
+  iconClose: {
+    padding: globalMargins.tiny,
+  },
+})
 
 export default Banner


### PR DESCRIPTION
Mainly focused on mobile, this bumps the padding and size of touch targets of icons and buttons throughout the app.

Chat input icons (exploding messages, emoji, and attachment icons) have not changed and will be done in a separate PR.

⚠️ If you notice buttons/icons with small touch targets that are not included in this PR, please tell me :) ⚠️ 