### PR TITLE
Force prompt in PGPPullEngine using NeedProofSet

### DIFF
--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -152,6 +152,7 @@ func (e *PGPPullEngine) processUserWithIdentify(m libkb.MetaContext, u string) e
 		UserAssertion:    u,
 		ForceRemoteCheck: true,
 		AlwaysBlock:      true,
+		NeedProofSet:     true, // forces prompt even if we declined before
 	}
 	topts := keybase1.TrackOptions{
 		LocalOnly:  true,


### PR DESCRIPTION
Identify2WithUID caches both ID failures and successes, and when failure is cached (even when not coming from the cli), user has no chance to try again.

NeedProofSet has a side-effect of blocking early-outs from Identify2WithUID, so by sacrificing caching, we force prompt to always appear in pgp pull command.