### PR TITLE
simplefs: allow a specified revision for reading KBFS TLFs

### DIFF
--- a/go/client/cmd_simplefs_copy.go
+++ b/go/client/cmd_simplefs_copy.go
@@ -53,6 +53,10 @@ func NewCmdSimpleFSCopy(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 				Name:  "f, force",
 				Usage: "force overwrite",
 			},
+			cli.IntFlag{
+				Name:  "rev",
+				Usage: "specify a revision number for the KBFS folder of the source paths",
+			},
 		},
 	}
 }

--- a/go/client/cmd_simplefs_history.go
+++ b/go/client/cmd_simplefs_history.go
@@ -82,7 +82,11 @@ func (c *CmdSimpleFSHistory) ParseArgv(ctx *cli.Context) error {
 	if len(ctx.Args()) > 1 {
 		return fmt.Errorf("wrong number of arguments")
 	} else if len(ctx.Args()) == 1 {
-		c.path = makeSimpleFSPath(c.G(), ctx.Args()[0])
+		p, err := makeSimpleFSPath(c.G(), ctx.Args()[0], 0)
+		if err != nil {
+			return err
+		}
+		c.path = p
 	}
 	return nil
 }

--- a/go/client/cmd_simplefs_mkdir.go
+++ b/go/client/cmd_simplefs_mkdir.go
@@ -66,12 +66,16 @@ func (c *CmdSimpleFSMkdir) ParseArgv(ctx *cli.Context) error {
 	var err error
 
 	if nargs != 1 {
-		err = errors.New("mkdir requires a KBFS path argument")
-	} else {
-		c.path = makeSimpleFSPath(c.G(), ctx.Args()[0])
+		return errors.New("mkdir requires a KBFS path argument")
 	}
 
-	return err
+	p, err := makeSimpleFSPath(c.G(), ctx.Args()[0], 0)
+	if err != nil {
+		return err
+	}
+
+	c.path = p
+	return nil
 }
 
 // GetUsage says what this command needs to operate.

--- a/go/client/cmd_simplefs_read.go
+++ b/go/client/cmd_simplefs_read.go
@@ -39,6 +39,10 @@ func NewCmdSimpleFSRead(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 				Value: readBufSizeDefault,
 				Usage: "read buffer size",
 			},
+			cli.IntFlag{
+				Name:  "rev",
+				Usage: "specify a revision number for the KBFS folder",
+			},
 		},
 	}
 }
@@ -102,13 +106,19 @@ func (c *CmdSimpleFSRead) ParseArgv(ctx *cli.Context) error {
 
 	c.bufSize = ctx.Int("buffersize")
 
-	if nargs == 1 {
-		c.path = makeSimpleFSPath(c.G(), ctx.Args()[0])
-	} else {
-		err = fmt.Errorf("read requires a path argument")
+	if nargs != 1 {
+		return fmt.Errorf("read requires a path argument")
 	}
 
-	return err
+	// TODO: "rev" should be a real int64, need to update the
+	// `cli` library for that.
+	p, err := makeSimpleFSPath(c.G(), ctx.Args()[0], int64(ctx.Int("rev")))
+	if err != nil {
+		return err
+	}
+
+	c.path = p
+	return nil
 }
 
 // GetUsage says what this command needs to operate.

--- a/go/client/cmd_simplefs_remove.go
+++ b/go/client/cmd_simplefs_remove.go
@@ -79,7 +79,10 @@ func (c *CmdSimpleFSRemove) ParseArgv(ctx *cli.Context) error {
 	}
 
 	for _, src := range ctx.Args() {
-		argPath := makeSimpleFSPath(c.G(), src)
+		argPath, err := makeSimpleFSPath(c.G(), src, 0)
+		if err != nil {
+			return err
+		}
 		pathType, err := argPath.PathType()
 		if err != nil {
 			return err

--- a/go/client/cmd_simplefs_test.go
+++ b/go/client/cmd_simplefs_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeSimpleFSPath(t *testing.T) {
+	check := func(path string, rev int64, expectedPT keybase1.PathType) {
+		p, err := makeSimpleFSPath(nil, path, rev)
+		require.NoError(t, err)
+		pt, err := p.PathType()
+		require.NoError(t, err)
+		require.Equal(t, expectedPT, pt)
+		if rev != 0 {
+			archivedPath := p.KbfsArchived()
+			paramRev := archivedPath.ArchivedParam.Revision()
+			require.Equal(t, keybase1.KBFSRevision(rev), paramRev)
+		}
+	}
+
+	// Local path.
+	check("/tmp/", 0, keybase1.PathType_LOCAL)
+
+	// KBFS paths.
+	check("/keybase/private/jdoe", 0, keybase1.PathType_KBFS)
+
+	// KBFS archived path.
+	check("/keybase/private/jdoe", 10, keybase1.PathType_KBFS_ARCHIVED)
+}

--- a/go/client/cmd_simplefs_write.go
+++ b/go/client/cmd_simplefs_write.go
@@ -136,12 +136,16 @@ func (c *CmdSimpleFSWrite) ParseArgv(ctx *cli.Context) error {
 		c.flags = keybase1.OpenFlags_WRITE | keybase1.OpenFlags_REPLACE
 	}
 
-	if nargs == 1 {
-		c.path = makeSimpleFSPath(c.G(), ctx.Args()[0])
-	} else {
-		err = fmt.Errorf("write requires a path argument")
+	if nargs != 1 {
+		return fmt.Errorf("write requires a path argument")
 	}
 
+	p, err := makeSimpleFSPath(c.G(), ctx.Args()[0], 0)
+	if err != nil {
+		return err
+	}
+
+	c.path = p
 	return err
 }
 

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -217,13 +217,15 @@ func (s SimpleFSMock) SimpleFSGetUserQuotaUsage(ctx context.Context) (
 func TestSimpleFSPathRemote(t *testing.T) {
 	tc := libkb.SetupTest(t, "simplefs_path", 0)
 
-	testPath := makeSimpleFSPath(tc.G, "/keybase/private/foobar")
+	testPath, err := makeSimpleFSPath(tc.G, "/keybase/private/foobar", 0)
+	require.NoError(tc.T, err)
 	pathType, err := testPath.PathType()
 	require.NoError(tc.T, err, "bad path type")
 	assert.Equal(tc.T, keybase1.PathType_KBFS, pathType, "Expected remote path, got local %s", pathToString(testPath))
 	assert.Equal(tc.T, "/private/foobar", testPath.Kbfs())
 
-	testPath = makeSimpleFSPath(tc.G, "/keybase/private/")
+	testPath, err = makeSimpleFSPath(tc.G, "/keybase/private/", 0)
+	require.NoError(tc.T, err)
 	pathType, err = testPath.PathType()
 	require.NoError(tc.T, err, "bad path type")
 	assert.Equal(tc.T, keybase1.PathType_KBFS, pathType, "Expected remote path, got local")
@@ -234,7 +236,8 @@ func TestSimpleFSPathRemote(t *testing.T) {
 func TestSimpleFSPathLocal(t *testing.T) {
 	tc := libkb.SetupTest(t, "simplefs_path", 0)
 
-	testPath := makeSimpleFSPath(tc.G, "./foobar")
+	testPath, err := makeSimpleFSPath(tc.G, "./foobar", 0)
+	require.NoError(tc.T, err)
 	pathType, err := testPath.PathType()
 	require.NoError(tc.T, err, "bad path type")
 	assert.Equal(tc.T, keybase1.PathType_LOCAL, pathType, "Expected local path, got remote")
@@ -257,7 +260,8 @@ func TestSimpleFSLocalSrcFile(t *testing.T) {
 	require.Equal(tc.T, path1.Local(), srcPathString)
 
 	// Destination file not given
-	destPath := makeSimpleFSPath(tc.G, "/keybase/public/foobar")
+	destPath, err := makeSimpleFSPath(tc.G, "/keybase/public/foobar", 0)
+	require.NoError(tc.T, err)
 
 	isDestDir, destPathString, err := checkPathIsDir(context.TODO(), SimpleFSMock{remoteExists: true}, destPath)
 	require.NoError(tc.T, err, "bad path type")
@@ -311,8 +315,11 @@ func TestSimpleFSRemoteSrcFile(t *testing.T) {
 
 	tempdir = filepath.ToSlash(tempdir)
 
-	destPath := makeSimpleFSPath(tc.G, tempdir)
-	srcPath := makeSimpleFSPath(tc.G, "/keybase/public/foobar/test1.txt")
+	destPath, err := makeSimpleFSPath(tc.G, tempdir, 0)
+	require.NoError(tc.T, err)
+	srcPath, err := makeSimpleFSPath(
+		tc.G, "/keybase/public/foobar/test1.txt", 0)
+	require.NoError(tc.T, err)
 
 	// Destination file not included in path
 	destPath, err = makeDestPath(
@@ -376,7 +383,8 @@ func TestSimpleFSLocalSrcDir(t *testing.T) {
 	require.True(tc.T, isSrcDir)
 	require.Equal(tc.T, path1.Local(), srcPathString)
 
-	destPathInitial := makeSimpleFSPath(tc.G, "/keybase/public/foobar")
+	destPathInitial, err := makeSimpleFSPath(tc.G, "/keybase/public/foobar", 0)
+	require.NoError(tc.T, err)
 
 	// Test when dest. exists.
 	// We append the last element of the source in that case.
@@ -437,7 +445,8 @@ func TestSimpleFSRemoteSrcDir(t *testing.T) {
 	require.NoError(t, err)
 	testStatter := SimpleFSMock{remoteExists: true}
 
-	srcPathInitial := makeSimpleFSPath(tc.G, "/keybase/public/foobar")
+	srcPathInitial, err := makeSimpleFSPath(tc.G, "/keybase/public/foobar", 0)
+	require.NoError(tc.T, err)
 
 	isSrcDir, srcPathString, err := checkPathIsDir(context.TODO(), testStatter, srcPathInitial)
 	require.NoError(tc.T, err, "bad path type")
@@ -504,7 +513,8 @@ func TestSimpleFSLocalExists(t *testing.T) {
 	err = ioutil.WriteFile(tempFile, []byte("foo"), 0644)
 	require.NoError(t, err)
 
-	testPath := makeSimpleFSPath(tc.G, tempdir)
+	testPath, err := makeSimpleFSPath(tc.G, tempdir, 0)
+	require.NoError(tc.T, err)
 	pathType, err := testPath.PathType()
 	require.NoError(tc.T, err, "bad path type")
 	assert.Equal(tc.T, keybase1.PathType_LOCAL, pathType, "Expected local path, got remote")
@@ -514,7 +524,8 @@ func TestSimpleFSLocalExists(t *testing.T) {
 	require.Error(tc.T, err, "Should get an element exists error")
 
 	// check file
-	testPath = makeSimpleFSPath(tc.G, tempFile)
+	testPath, err = makeSimpleFSPath(tc.G, tempFile, 0)
+	require.NoError(tc.T, err)
 	err = checkElementExists(context.TODO(), SimpleFSMock{}, testPath)
 	require.Error(tc.T, err, "Should get an element exists error")
 }


### PR DESCRIPTION
This depends on #12957 and keybase/kbfs#1702 -- those should be reviewed and merged first.

This affects stat, ls, read, and the source paths of copy.

Issue: KBFS-3206