### PR TITLE
New Provision: switch qr back to using image, update qr code to generate blue

### DIFF
--- a/shared/common-adapters/image.desktop.js
+++ b/shared/common-adapters/image.desktop.js
@@ -3,9 +3,9 @@ import * as React from 'react'
 import type {Props, ReqProps} from './image'
 
 const RequireImage = ({src, style}: ReqProps) => <img src={src} style={style} />
-const FileImage = ({src, style, onDragStart, onLoad}: Props) => (
+const Image = ({src, style, onDragStart, onLoad}: Props) => (
   <img src={src} style={style} onDragStart={onDragStart} onLoad={onLoad} />
 )
 
-export default FileImage
+export default Image
 export {RequireImage}

--- a/shared/common-adapters/image.js.flow
+++ b/shared/common-adapters/image.js.flow
@@ -14,5 +14,6 @@ export type ReqProps = {|
   style?: ?StylesCrossPlatform,
 |}
 
-export default class FileImage extends React.Component<Props> {}
+export default class Image extends React.Component<Props> {}
+// Can accept require()
 export class RequireImage extends React.Component<ReqProps> {}

--- a/shared/common-adapters/image.native.js
+++ b/shared/common-adapters/image.native.js
@@ -3,14 +3,13 @@ import * as React from 'react'
 import {NativeImage} from './mobile.native'
 import type {Props, ReqProps} from './image'
 
-const FileImage = ({src, style}: Props) => {
-  const source = {uri: `file://${src}`}
-  return <NativeImage source={source} style={[{resizeMode: 'contain'}, style]} />
-}
+const Image = ({src, style}: Props) => (
+  <NativeImage source={{uri: src}} style={[{resizeMode: 'contain'}, style]} />
+)
 
 const RequireImage = ({src, style}: ReqProps) => (
   <NativeImage source={src} style={[{resizeMode: 'contain'}, style]} />
 )
 
-export default FileImage
+export default Image
 export {RequireImage}

--- a/shared/provision/code-page/qr-image.js
+++ b/shared/provision/code-page/qr-image.js
@@ -1,45 +1,32 @@
 // @flow
 import * as React from 'react'
-import {Box} from '../../common-adapters'
-import {globalColors} from '../../styles'
+import {Image} from '../../common-adapters'
 import QRCodeGen from 'qrcode-generator'
+import {styleSheetCreate} from '../../styles'
 
 type Props = {
   code: string,
   cellSize: number,
 }
 
-// Just rendering a bunch of divs. this is ok (maybe slow) . will have to see about native. if not go back to doing the image thing
 class QrImage extends React.PureComponent<Props> {
-  static defaultProps = {cellSize: 2}
+  static defaultProps = {cellSize: 4} // this creates a 132x132 (so we can use retina) image
   render() {
     const qr = QRCodeGen(4, 'L')
     qr.addData(this.props.code)
     qr.make()
-    const size = qr.getModuleCount()
-    const children = []
 
-    for (let x = 0; x < size; ++x) {
-      for (let y = 0; y < size; ++y) {
-        children.push(
-          <Box
-            key={`${x}:${y}`}
-            style={{
-              backgroundColor: qr.isDark(x, y) ? globalColors.blue : globalColors.transparent,
-              height: this.props.cellSize,
-              left: x * this.props.cellSize,
-              position: 'absolute',
-              top: y * this.props.cellSize,
-              width: this.props.cellSize,
-            }}
-          />
-        )
-      }
-    }
-
-    const dim = size * this.props.cellSize
-    return <Box style={{height: dim, position: 'relative', width: dim}}>{children}</Box>
+    const url = qr.createDataURL(this.props.cellSize, 0)
+    return <Image src={url} style={styles.image} />
   }
 }
+
+const styles = styleSheetCreate({
+  image: {
+    // actual qr size so it doesn't stretch
+    height: 66,
+    width: 66,
+  },
+})
 
 export default QrImage

--- a/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A9BB30DF1E6A274900E713E5 /* libRCTCameraRoll.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A9BB30C51E6A273A00E713E5 /* libRCTCameraRoll.a */; };
 		B62BF7E179804DC1BF27B544 /* libRCTWKWebView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B77D36F6B3B04107BB7524A1 /* libRCTWKWebView.a */; };
 		C3A47BFE1E8B148A00974A63 /* keybasemessage.wav in Resources */ = {isa = PBXBuildFile; fileRef = C3A47BFD1E8B148A00974A63 /* keybasemessage.wav */; };
+		C9F3BE08C6BB407385237F20 /* libRNCamera.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 45B8357E4AAA4F5F8AD11213 /* libRNCamera.a */; };
 		DB0846051BA75DC800F54960 /* keybase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB0846041BA75DC800F54960 /* keybase.framework */; };
 		DB27DE571D747A6C003DE8BC /* Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = DB27DE561D747A6C003DE8BC /* Utils.m */; };
 		DB2BD1E51DE7D9A600BB7989 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB2BD1961DE7D96200BB7989 /* libRCTActionSheet.a */; };
@@ -38,7 +39,6 @@
 		DB75391D1D776CC400AFA61B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DBDCF3081B8D03DD00BA95D8 /* Images.xcassets */; };
 		DB7539351D777E7100AFA61B /* Engine-Test.m in Sources */ = {isa = PBXBuildFile; fileRef = DB7539341D777E7100AFA61B /* Engine-Test.m */; };
 		DB7539371D777E8400AFA61B /* LogSend-Test.m in Sources */ = {isa = PBXBuildFile; fileRef = DB7539361D777E8400AFA61B /* LogSend-Test.m */; };
-		DBAEF29B20FD27D5001BCFF9 /* libRNCamera.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DBAEF29A20FD27C0001BCFF9 /* libRNCamera.a */; };
 		DBBCC6131D9C4A8100312652 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCC6121D9C4A8100312652 /* AppDelegate.m */; };
 		DBBCC6181D9C5C6A00312652 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCC6171D9C5C6A00312652 /* main.m */; };
 		DBCE36251B90F14800ECADDE /* Engine.m in Sources */ = {isa = PBXBuildFile; fileRef = DBCE36241B90F14800ECADDE /* Engine.m */; };
@@ -92,6 +92,13 @@
 			proxyType = 2;
 			remoteGlobalIDString = 3DBE0D0D1F3B181C0099AA32;
 			remoteInfo = "fishhook-tvOS";
+		};
+		374A785E2108C2000053E19E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C57EB246A82A498E96C1AD22 /* RNCamera.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 4107012F1ACB723B00C6AA39;
+			remoteInfo = RNCamera;
 		};
 		37D298091F9A48D600D43971 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -359,13 +366,6 @@
 			remoteGlobalIDString = 3D3CD9181DE5FBD800167DC4;
 			remoteInfo = "jschelpers-tvOS";
 		};
-		DBAEF29920FD27C0001BCFF9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DBAEF29520FD27C0001BCFF9 /* RNCamera.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4107012F1ACB723B00C6AA39;
-			remoteInfo = RNCamera;
-		};
 		DBEE30641FE84EF40020EBA5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DB2BD17E1DE7D81C00BB7989 /* React.xcodeproj */;
@@ -414,6 +414,7 @@
 		3791A8A020C71DC0001C2E86 /* PushPrompt.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PushPrompt.m; sourceTree = "<group>"; };
 		3791A8A220C71FE6001C2E86 /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		3FE4C3BB3E1F4B3482EDAED0 /* RCTWKWebView.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTWKWebView.xcodeproj; path = "../../node_modules/react-native-wkwebview-reborn/ios/RCTWKWebView.xcodeproj"; sourceTree = "<group>"; };
+		45B8357E4AAA4F5F8AD11213 /* libRNCamera.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNCamera.a; sourceTree = "<group>"; };
 		6266E16BBFF8461CAF2DDCB9 /* RCTContacts.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTContacts.xcodeproj; path = "../../node_modules/react-native-contacts/ios/RCTContacts.xcodeproj"; sourceTree = "<group>"; };
 		A90CD4A61FCE1D0A00F97901 /* NativeLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NativeLogger.m; sourceTree = "<group>"; };
 		A90CD4A71FCE1D0A00F97901 /* NativeLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeLogger.h; sourceTree = "<group>"; };
@@ -422,6 +423,7 @@
 		A9BB30BC1E6A273A00E713E5 /* RCTCameraRoll.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTCameraRoll.xcodeproj; path = "../../node_modules/react-native/Libraries/CameraRoll/RCTCameraRoll.xcodeproj"; sourceTree = "<group>"; };
 		B77D36F6B3B04107BB7524A1 /* libRCTWKWebView.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTWKWebView.a; sourceTree = "<group>"; };
 		C3A47BFD1E8B148A00974A63 /* keybasemessage.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = keybasemessage.wav; path = ../../../sounds/keybasemessage.wav; sourceTree = "<group>"; };
+		C57EB246A82A498E96C1AD22 /* RNCamera.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNCamera.xcodeproj; path = "../../node_modules/react-native-camera/ios/RNCamera.xcodeproj"; sourceTree = "<group>"; };
 		DB0500F31F10114D000B54AD /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		DB0846041BA75DC800F54960 /* keybase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = keybase.framework; sourceTree = "<group>"; };
 		DB27DE551D747A6B003DE8BC /* Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
@@ -442,7 +444,6 @@
 		DB7539311D77753600AFA61B /* Keybase_For_Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Keybase_For_Tests-Bridging-Header.h"; sourceTree = "<group>"; };
 		DB7539341D777E7100AFA61B /* Engine-Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Engine-Test.m"; sourceTree = "<group>"; };
 		DB7539361D777E8400AFA61B /* LogSend-Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "LogSend-Test.m"; sourceTree = "<group>"; };
-		DBAEF29520FD27C0001BCFF9 /* RNCamera.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNCamera.xcodeproj; path = "/Users/chrisnojima/go/src/github.com/keybase/client/shared/node_modules/react-native/Libraries/NativeAnimation/../../../react-native-camera/ios/RNCamera.xcodeproj"; sourceTree = "<absolute>"; };
 		DBBCC6111D9C4A8100312652 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		DBBCC6121D9C4A8100312652 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		DBBCC6171D9C5C6A00312652 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -487,7 +488,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DBAEF29B20FD27D5001BCFF9 /* libRNCamera.a in Frameworks */,
 				3791A8A320C71FE6001C2E86 /* UserNotifications.framework in Frameworks */,
 				DB61D78F201BA2BD0008C059 /* libRCTWebSocket.a in Frameworks */,
 				DBEE30D91FE8551E0020EBA5 /* libRCTContacts.a in Frameworks */,
@@ -506,6 +506,7 @@
 				DB0846051BA75DC800F54960 /* keybase.framework in Frameworks */,
 				A9BB30DF1E6A274900E713E5 /* libRCTCameraRoll.a in Frameworks */,
 				B62BF7E179804DC1BF27B544 /* libRCTWKWebView.a in Frameworks */,
+				C9F3BE08C6BB407385237F20 /* libRNCamera.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -552,6 +553,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		374A785B2108C2000053E19E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				374A785F2108C2000053E19E /* libRNCamera.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		37D298061F9A48D600D43971 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -563,7 +572,6 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
-				DBAEF29520FD27C0001BCFF9 /* RNCamera.xcodeproj */,
 				DB0500F31F10114D000B54AD /* RCTLinking.xcodeproj */,
 				A9BB30BC1E6A273A00E713E5 /* RCTCameraRoll.xcodeproj */,
 				DB6D0B731E5B9EB400410F3C /* RCTAnimation.xcodeproj */,
@@ -583,6 +591,7 @@
 				27DDEEF0AE72483E8BF08ED2 /* RNFetchBlob.xcodeproj */,
 				6266E16BBFF8461CAF2DDCB9 /* RCTContacts.xcodeproj */,
 				3FE4C3BB3E1F4B3482EDAED0 /* RCTWKWebView.xcodeproj */,
+				C57EB246A82A498E96C1AD22 /* RNCamera.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -649,6 +658,7 @@
 			isa = PBXGroup;
 			children = (
 				B77D36F6B3B04107BB7524A1 /* libRCTWKWebView.a */,
+				45B8357E4AAA4F5F8AD11213 /* libRNCamera.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -778,14 +788,6 @@
 			children = (
 				DB6D0B7A1E5B9EB400410F3C /* libRCTAnimation.a */,
 				DB6D0B7C1E5B9EB400410F3C /* libRCTAnimation.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		DBAEF29620FD27C0001BCFF9 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				DBAEF29A20FD27C0001BCFF9 /* libRNCamera.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1027,8 +1029,8 @@
 					ProjectRef = DB2BD17E1DE7D81C00BB7989 /* React.xcodeproj */;
 				},
 				{
-					ProductGroup = DBAEF29620FD27C0001BCFF9 /* Products */;
-					ProjectRef = DBAEF29520FD27C0001BCFF9 /* RNCamera.xcodeproj */;
+					ProductGroup = 374A785B2108C2000053E19E /* Products */;
+					ProjectRef = C57EB246A82A498E96C1AD22 /* RNCamera.xcodeproj */;
 				},
 				{
 					ProductGroup = DB311B521EA90680005513D2 /* Products */;
@@ -1074,6 +1076,13 @@
 			fileType = archive.ar;
 			path = "libfishhook-tvOS.a";
 			remoteRef = 27B80F5A1FB4C0F3008EF78B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		374A785F2108C2000053E19E /* libRNCamera.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNCamera.a;
+			remoteRef = 374A785E2108C2000053E19E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		37D2980A1F9A48D600D43971 /* libRCTContacts.a */ = {
@@ -1342,13 +1351,6 @@
 			remoteRef = DB7417C01E1FFF1000CEC6B7 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		DBAEF29A20FD27C0001BCFF9 /* libRNCamera.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNCamera.a;
-			remoteRef = DBAEF29920FD27C0001BCFF9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		DBEE30651FE84EF40020EBA5 /* libprivatedata.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1534,12 +1536,12 @@
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/KeybaseGo",
 					"$(SRCROOT)/../../node_modules/react-native/Libraries/PushNotificationIOS",
-					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
 					"$(SRCROOT)/../../node_modules/react-native-image-picker/ios",
 					"$(SRCROOT)/../../node_modules/react-native-fetch-blob/ios/**",
 					"$(SRCROOT)/../../node_modules/react-native/Libraries/LinkingIOS",
 					"$(SRCROOT)/../../node_modules/react-native-contacts/ios/RCTContacts",
 					"$(SRCROOT)/../../node_modules/react-native-wkwebview-reborn/ios/RCTWKWebView",
+					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
 				);
 				INFOPLIST_FILE = Keybase/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -1587,12 +1589,12 @@
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/KeybaseGo",
 					"$(SRCROOT)/../../node_modules/react-native/Libraries/PushNotificationIOS",
-					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
 					"$(SRCROOT)/../../node_modules/react-native-image-picker/ios",
 					"$(SRCROOT)/../../node_modules/react-native-fetch-blob/ios/**",
 					"$(SRCROOT)/../../node_modules/react-native/Libraries/LinkingIOS",
 					"$(SRCROOT)/../../node_modules/react-native-contacts/ios/RCTContacts",
 					"$(SRCROOT)/../../node_modules/react-native-wkwebview-reborn/ios/RCTWKWebView",
+					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
 				);
 				INFOPLIST_FILE = Keybase/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -1731,12 +1733,12 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/KeybaseGo",
-					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
 					"$(SRCROOT)/../../node_modules/react-native-image-picker/ios",
 					"$(SRCROOT)/../../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../../node_modules/react-native-fetch-blob/ios/**",
 					"$(SRCROOT)/../../node_modules/react-native-contacts/ios/RCTContacts",
 					"$(SRCROOT)/../../node_modules/react-native-wkwebview-reborn/ios/RCTWKWebView",
+					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
 				);
 				INFOPLIST_FILE = Keybase/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -1778,12 +1780,12 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/KeybaseGo",
-					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
 					"$(SRCROOT)/../../node_modules/react-native-image-picker/ios",
 					"$(SRCROOT)/../../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../../node_modules/react-native-fetch-blob/ios/**",
 					"$(SRCROOT)/../../node_modules/react-native-contacts/ios/RCTContacts",
 					"$(SRCROOT)/../../node_modules/react-native-wkwebview-reborn/ios/RCTWKWebView",
+					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
 				);
 				INFOPLIST_FILE = Keybase/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -10777,7 +10777,7 @@ q@~0.9.6:
 
 "qrcode-generator@git://github.com/keybase/qrcode-generator#keybase-changes-off-140":
   version "1.4.0"
-  resolved "git://github.com/keybase/qrcode-generator#3c4fa106586febdc5353bc82e6f6adce0221bf01"
+  resolved "git://github.com/keybase/qrcode-generator#9bd96b7cf7583a1df868982f274db1b80296c52d"
 
 qs@6.5.1, qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"


### PR DESCRIPTION
The original implementation use an image for the qr code. During development of new provision i switched to using divs so we had a lot more control of styling but android really chokes on this plus initializing the camera at the same time so i went back and used image and changed the lib to output blue also

@keybase/react-hackers @cjb 
cc: @thebearjew since this touches image which orientedimage uses. Looks fine to me on desktop and ios

This also kills the huge update to storyshots