### PR TITLE
don't load the team to get team IDs for use in finding conversations by name CORE-8271

### DIFF
--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -1639,6 +1639,18 @@ func NewKeyFinderMock(cryptKeys []keybase1.CryptKey) KeyFinder {
 
 func (k *KeyFinderMock) Reset() {}
 
+func (k *KeyFinderMock) FindUntrusted(ctx context.Context, tlfName string,
+	membersType chat1.ConversationMembersType, public bool) (*types.NameInfoUntrusted, error) {
+	ni, err := k.Find(ctx, tlfName, membersType, public)
+	if err != nil {
+		return nil, err
+	}
+	return &types.NameInfoUntrusted{
+		ID:            ni.ID,
+		CanonicalName: ni.CanonicalName,
+	}, nil
+}
+
 func (k *KeyFinderMock) Find(ctx context.Context, tlfName string,
 	membersType chat1.ConversationMembersType, tlfPublic bool) (res *types.NameInfo, err error) {
 	res = types.NewNameInfo()

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -705,6 +705,11 @@ func (f failingTlf) CompleteAndCanonicalizePrivateTlfName(context.Context, strin
 	return keybase1.CanonicalTLFNameAndIDWithBreaks{}, nil
 }
 
+func (f failingTlf) LookupUntrusted(context.Context, string, bool) (*types.NameInfoUntrusted, error) {
+	require.Fail(f.t, "LookupUnstrusted call")
+	return nil, nil
+}
+
 func (f failingTlf) Lookup(context.Context, string, bool) (*types.NameInfo, error) {
 	require.Fail(f.t, "Lookup call")
 	return nil, nil

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -723,7 +723,8 @@ func FindConversations(ctx context.Context, g *globals.Context, debugger utils.D
 							convLocal.GetConvID(), convLocal.Error.Message)
 						continue
 					}
-					if convLocal.Info.TopicName == topicName {
+					if convLocal.Info.TopicName == topicName &&
+						convLocal.Info.TLFNameExpanded() == nameInfo.CanonicalName {
 						debugger.Debug(ctx, "FindConversations: found matching public conv: id: %s topicName: %s",
 							convLocal.GetConvID(), topicName)
 						res = append(res, convLocal)

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -187,7 +187,7 @@ func (b *NonblockingLocalizer) Name() string {
 }
 
 func filterConvLocals(convLocals []chat1.ConversationLocal, rquery *chat1.GetInboxQuery,
-	query *chat1.GetInboxLocalQuery, nameInfo *types.NameInfo) (res []chat1.ConversationLocal, err error) {
+	query *chat1.GetInboxLocalQuery, nameInfo *types.NameInfoUntrusted) (res []chat1.ConversationLocal, err error) {
 
 	for _, convLocal := range convLocals {
 
@@ -265,7 +265,7 @@ func (b *baseInboxSource) SetRemoteInterface(ri func() chat1.RemoteInterface) {
 }
 
 func (b *baseInboxSource) GetInboxQueryLocalToRemote(ctx context.Context,
-	lquery *chat1.GetInboxLocalQuery) (rquery *chat1.GetInboxQuery, info *types.NameInfo, err error) {
+	lquery *chat1.GetInboxLocalQuery) (rquery *chat1.GetInboxQuery, info *types.NameInfoUntrusted, err error) {
 
 	if lquery == nil {
 		return nil, info, nil
@@ -276,7 +276,7 @@ func (b *baseInboxSource) GetInboxQueryLocalToRemote(ctx context.Context,
 		var err error
 		tlfName := utils.AddUserToTLFName(b.G(), lquery.Name.Name, lquery.Visibility(),
 			lquery.Name.MembersType)
-		info, err = CtxKeyFinder(ctx, b.G()).Find(ctx, tlfName, lquery.Name.MembersType,
+		info, err = CtxKeyFinder(ctx, b.G()).FindUntrusted(ctx, tlfName, lquery.Name.MembersType,
 			lquery.Visibility() == keybase1.TLFVisibility_PUBLIC)
 		if err != nil {
 			b.Debug(ctx, "GetInboxQueryLocalToRemote: failed: %s", err)
@@ -322,11 +322,11 @@ func (b *baseInboxSource) IsMember(ctx context.Context, uid gregor1.UID, convID 
 }
 
 func GetInboxQueryNameInfo(ctx context.Context, g *globals.Context,
-	lquery *chat1.GetInboxLocalQuery) (*types.NameInfo, error) {
+	lquery *chat1.GetInboxLocalQuery) (*types.NameInfoUntrusted, error) {
 	if lquery.Name == nil || len(lquery.Name.Name) == 0 {
 		return nil, nil
 	}
-	return CtxKeyFinder(ctx, g).Find(ctx, lquery.Name.Name, lquery.Name.MembersType,
+	return CtxKeyFinder(ctx, g).FindUntrusted(ctx, lquery.Name.Name, lquery.Name.MembersType,
 		lquery.Visibility() == keybase1.TLFVisibility_PUBLIC)
 }
 

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4291,7 +4291,6 @@ func TestChatSrvImplicitConversation(t *testing.T) {
 			})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(res.Conversations), "no convs found")
-		consumeIdentify(ctx, listener1) //impteam
 	})
 }
 

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -47,6 +47,17 @@ func (t *KBFSNameInfoSource) tlfKeysClient() (*keybase1.TlfKeysClient, error) {
 	}, nil
 }
 
+func (t *KBFSNameInfoSource) LookupUntrusted(ctx context.Context, name string, public bool) (res *types.NameInfoUntrusted, err error) {
+	ni, err := t.Lookup(ctx, name, public)
+	if err != nil {
+		return res, err
+	}
+	return &types.NameInfoUntrusted{
+		ID:            ni.ID,
+		CanonicalName: ni.CanonicalName,
+	}, nil
+}
+
 func (t *KBFSNameInfoSource) Lookup(ctx context.Context, tlfName string, public bool) (res *types.NameInfo, err error) {
 	defer t.Trace(ctx, func() error { return err }, fmt.Sprintf("Lookup(%s)", tlfName))()
 	var lastErr error

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -32,6 +32,7 @@ type CryptKey interface {
 type AllCryptKeys map[chat1.ConversationMembersType][]CryptKey
 
 type NameInfoSource interface {
+	LookupUntrusted(ctx context.Context, name string, public bool) (*NameInfoUntrusted, error)
 	Lookup(ctx context.Context, name string, public bool) (*NameInfo, error)
 	EncryptionKeys(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool) (*NameInfo, error)
@@ -152,7 +153,7 @@ type InboxSource interface {
 		info *chat1.ConversationMinWriterRoleInfo) (*chat1.ConversationLocal, error)
 
 	GetInboxQueryLocalToRemote(ctx context.Context,
-		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, *NameInfo, error)
+		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, *NameInfoUntrusted, error)
 
 	SetRemoteInterface(func() chat1.RemoteInterface)
 }

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -32,6 +32,11 @@ func NewAllCryptKeys() AllCryptKeys {
 	return make(AllCryptKeys)
 }
 
+type NameInfoUntrusted struct {
+	ID            chat1.TLFID
+	CanonicalName string
+}
+
 type NameInfo struct {
 	ID               chat1.TLFID
 	CanonicalName    string

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -210,6 +210,17 @@ func (m *TlfMock) getTlfID(cname keybase1.CanonicalTlfName) (keybase1.TLFID, err
 	return keybase1.TLFID(hex.EncodeToString([]byte(tlfID))), nil
 }
 
+func (m *TlfMock) LookupUntrusted(ctx context.Context, tlfName string, public bool) (*types.NameInfoUntrusted, error) {
+	ni, err := m.Lookup(ctx, tlfName, public)
+	if err != nil {
+		return nil, err
+	}
+	return &types.NameInfoUntrusted{
+		ID:            ni.ID,
+		CanonicalName: ni.CanonicalName,
+	}, nil
+}
+
 func (m *TlfMock) Lookup(ctx context.Context, tlfName string, public bool) (res *types.NameInfo, err error) {
 	var tlfID keybase1.TLFID
 	res = types.NewNameInfo()


### PR DESCRIPTION
Loading a team as a reset user is not possible, so we can't find conversations by name since we fail the initial step of getting a team ID to search for. Patch does the following to address this:

1.) Add a new function to `NameInfoSource` called `LookupUntrusted` which returns a `NameInfoUntrusted` that has an ID and canonical name. The name is fine, but the ID is server trust. We check the name against our query string when we query the inbox, so it is fine to use a random ID we get back from the server.
2.) Change `GetInboxQueryLocalToRemote` to use `LookupUntrusted` to fill in the `TLFID` of the conversations we are searching for. 
3.) Fix a bug where we didn't check the name of public conversations against the name we searched for. 