### PR TITLE
(Possibly) Only Show Build Team Button with No Teams

### DIFF
--- a/shared/chat/inbox/index.stories.js
+++ b/shared/chat/inbox/index.stories.js
@@ -519,6 +519,7 @@ const provider = createPropProvider(
     BuildTeam: p => ({
       onBuildTeam: action('onBuildTeam'),
       showBuildATeam: teamsEmpty,
+      loaded: true,
     }),
     NewChooser: p => ({
       isSelected: false,

--- a/shared/chat/inbox/row/build-team/container.js
+++ b/shared/chat/inbox/row/build-team/container.js
@@ -6,6 +6,7 @@ import type {TypedState, Dispatch} from '../../../../util/container'
 import BuildTeam from '.'
 
 const mapStateToProps = (state: TypedState) => ({
+  loaded: state.teams.loaded,
   showBuildATeam: state.teams.teamnames.size === 0,
 })
 
@@ -15,6 +16,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  loaded: stateProps.loaded,
   onBuildTeam: dispatchProps._onBuildTeam,
   showBuildATeam: stateProps.showBuildATeam,
 })

--- a/shared/chat/inbox/row/build-team/index.js
+++ b/shared/chat/inbox/row/build-team/index.js
@@ -12,6 +12,7 @@ import {
 } from '../../../../styles'
 
 type Props = {
+  loaded: boolean,
   onBuildTeam: () => void,
   showBuildATeam: boolean,
 }
@@ -38,8 +39,8 @@ const DividerBox = glamorous(Box)({
   width: '100%',
 })
 
-const BuildTeam = ({showBuildATeam, onBuildTeam}: Props) =>
-  showBuildATeam ? (
+const BuildTeam = ({loaded, showBuildATeam, onBuildTeam}: Props) =>
+  loaded && showBuildATeam ? (
     <ClickableBox title="Make a new team" onClick={onBuildTeam} style={styles.container}>
       <DividerBox>
         <Box style={styles.text}>


### PR DESCRIPTION
I haven't been able to successfully reproduce the issue where the "Build a team" button will appear at the bottom of the inbox on desktop/mobile. However this check should have been included originally.