### PR TITLE
add current clone count to device clone request

### DIFF
--- a/go/libkb/device_clone_state.go
+++ b/go/libkb/device_clone_state.go
@@ -54,6 +54,7 @@ func UpdateDeviceCloneState(m MetaContext) (before int, after int, err error) {
 			"device_id": m.G().ActiveDevice.DeviceID(),
 			"prior":     S{Val: prior},
 			"stage":     S{Val: stage},
+			"clones":    I{Val: before},
 		},
 		MetaContext: m,
 	}


### PR DESCRIPTION
This enables access on the server to what the client thinks is the current clone count. It's useful (but not necessary) if we want to pause device clone detection behavior in the future.