### PR TITLE
clean release output of prompter solution

### DIFF
--- a/packaging/windows/doinstaller_wix.cmd
+++ b/packaging/windows/doinstaller_wix.cmd
@@ -33,7 +33,7 @@ popd
 
 :: prompter
 pushd %GOPATH%\src\github.com\keybase\go-updater\windows\WpfPrompter
-msbuild WpfPrompter.sln /t:Clean
+msbuild WpfPrompter.sln /p:Configuration=Release /t:Clean
 msbuild WpfPrompter.sln /p:Configuration=Release /t:Build
 IF %ERRORLEVEL% NEQ 0 (
   EXIT /B 1


### PR DESCRIPTION
turns out the default was to clean only debug