### PR TITLE
Cancel outbox messages of dup reactions in Prepare

### DIFF
--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -441,6 +441,19 @@ func (e SenderTestImmediateFailError) IsImmediateFail() (chat1.OutboxErrorType, 
 
 //=============================================================================
 
+type DuplicateSendAbortedError struct {
+}
+
+func (e DuplicateSendAbortedError) Error() string {
+	return "send aborted, duplicate message"
+}
+
+func (e DuplicateSendAbortedError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
+	return chat1.OutboxErrorType_MISC, false
+}
+
+//=============================================================================
+
 type OfflineErrorKind int
 
 const (

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -441,19 +441,6 @@ func (e SenderTestImmediateFailError) IsImmediateFail() (chat1.OutboxErrorType, 
 
 //=============================================================================
 
-type DuplicateSendAbortedError struct {
-}
-
-func (e DuplicateSendAbortedError) Error() string {
-	return "send aborted, duplicate message"
-}
-
-func (e DuplicateSendAbortedError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
-	return chat1.OutboxErrorType_MISC, false
-}
-
-//=============================================================================
-
 type OfflineErrorKind int
 
 const (

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1145,11 +1145,13 @@ func (s *Deliverer) deliverLoop() {
 						obr.ConvID, obr.OutboxID)
 					continue
 				}
-				canceled, err := s.cancelPendingDuplicateReactions(bctx, obr)
-				if err == nil && canceled {
-					s.Debug(bctx, "deliverLoop: aborting send, duplicate send convID: %s, obid: %s",
-						obr.ConvID, obr.OutboxID)
-					continue
+				if err == nil {
+					canceled, err := s.cancelPendingDuplicateReactions(bctx, obr)
+					if err == nil && canceled {
+						s.Debug(bctx, "deliverLoop: aborting send, duplicate send convID: %s, obid: %s",
+							obr.ConvID, obr.OutboxID)
+						continue
+					}
 				}
 				if err == nil {
 					_, _, err = s.sender.Send(bctx, obr.ConvID, obr.Msg, 0, nil)

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1046,6 +1046,10 @@ func (s *Deliverer) processAttachment(ctx context.Context, obr chat1.OutboxRecor
 // If we cancel an odd number of items we cancel ourselves since the current
 // reaction state is correct.
 func (s *Deliverer) cancelPendingDuplicateReactions(ctx context.Context, obr chat1.OutboxRecord) (bool, error) {
+	if obr.Msg.ClientHeader.MessageType != chat1.MessageType_REACTION {
+		// nothing to do here
+		return false, nil
+	}
 	// While holding the outbox lock, let's remove any duplicate reaction
 	// messages and  make sure we are in the outbox, otherwise someone else
 	// canceled us.

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -1444,11 +1444,22 @@ func TestProcessDuplicateReactionMsgs(t *testing.T) {
 	require.Len(t, texts, 1)
 	txtMsg := texts[0]
 	expectedReactionMap := chat1.ReactionMap{
-		Reactions: map[string]map[string]chat1.MessageID{
-			":+1:": map[string]chat1.MessageID{
-				u.Username: *sentRef[len(sentRef)-1].msgID,
+		Reactions: map[string]map[string]chat1.Reaction{
+			":+1:": map[string]chat1.Reaction{
+				u.Username: chat1.Reaction{
+					ReactionMsgID: *sentRef[len(sentRef)-1].msgID,
+				},
 			},
 		},
+	}
+	// Verify the ctimes are not zero, but we don't care about the actual
+	// value for the test.
+	for _, reactions := range txtMsg.Valid().Reactions.Reactions {
+		for k, r := range reactions {
+			require.NotZero(t, r.Ctime)
+			r.Ctime = 0
+			reactions[k] = r
+		}
 	}
 	require.Equal(t, expectedReactionMap, txtMsg.Valid().Reactions)
 

--- a/go/chat/storage/outbox_test.go
+++ b/go/chat/storage/outbox_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"time"
@@ -266,7 +267,7 @@ func TestChatOutboxCancelMessagesWithPredicate(t *testing.T) {
 	var obrs []chat1.OutboxRecord
 	conv := makeConvo(gregor1.Time(5), 1, 1)
 	for i := 0; i < 5; i++ {
-		obr, err := ob.PushMessage(ctx, conv.GetConvID(), makeMsgPlaintext("hi"+string(i), uid),
+		obr, err := ob.PushMessage(ctx, conv.GetConvID(), makeMsgPlaintext(fmt.Sprintf("hi%d", i), uid),
 			nil, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 		require.NoError(t, err)
 		obrs = append(obrs, obr)
@@ -295,8 +296,8 @@ func TestChatOutboxCancelMessagesWithPredicate(t *testing.T) {
 	allTrue := func(obr chat1.OutboxRecord) bool { return true }
 	numCancelled, err = ob.CancelMessagesWithPredicate(ctx, allTrue)
 	require.NoError(t, err)
-	require.Zero(t, numCancelled)
+	require.Equal(t, 3, numCancelled)
 	res, err = ob.PullAllConversations(ctx, false, false)
 	require.NoError(t, err)
-	require.Len(t, res, 2)
+	require.Zero(t, len(res))
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1561,6 +1561,10 @@ func (r ReactionMap) HasReactionFromUser(reactionText, username string) (found b
 	return ok, reaction.ReactionMsgID
 }
 
+func (r MessageReaction) Eq(o MessageReaction) bool {
+	return r.Body == o.Body && r.MessageID == o.MessageID
+}
+
 func (i *ConversationMinWriterRoleInfoLocal) String() string {
 	if i == nil {
 		return "Minimum writer role for this conversation is not set."


### PR DESCRIPTION
-moves `getSupersederEphemeralMetadata` from the server call to `BlockingSender.Prepare` (removes duplication, nonblock send will be marginally faster)
-moves `processReactionMessage` as well, and now we scan the outbox and cancel any duplicate pending messages.

