### PR TITLE
fix logout push token delete

### DIFF
--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -591,10 +591,7 @@ const letResetUserBackIn = ({payload: {id, username}}: FsGen.LetResetUserBackInP
 
 const letResetUserBackInResult = () => undefined // Saga.put(FsGen.createLoadResets())
 
-const resetStore = () => Saga.put({type: FsGen.resetStore})
-
 function* fsSaga(): Saga.SagaGenerator<any, any> {
-  yield Saga.safeTakeEveryPureSimple(LoginGen.logout, resetStore)
   yield Saga.safeTakeEveryPure(
     FsGen.refreshLocalHTTPServerInfo,
     refreshLocalHTTPServerInfo,

--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -2,7 +2,6 @@
 import logger from '../../logger'
 import * as Constants from '../../constants/fs'
 import * as FsGen from '../fs-gen'
-import * as LoginGen from '../login-gen'
 import * as I from 'immutable'
 import * as RPCTypes from '../../constants/types/rpc-gen'
 import * as Saga from '../../util/saga'

--- a/shared/actions/login.js
+++ b/shared/actions/login.js
@@ -233,6 +233,8 @@ const loggedout = () =>
 const logout = () =>
   Saga.sequentially([
     Saga.put(ConfigGen.createClearRouteState()),
+    // Let push deregister work, TODO make this a real dependency or something, this is a short term fix
+    Saga.delay(1000),
     Saga.call(RPCTypes.loginLogoutRpcPromise, undefined, Constants.waitingKey),
     Saga.put(LoginGen.createLoggedout()),
   ])


### PR DESCRIPTION
@keybase/react-hackers 

This fixes the push token deregister on logout. Two issues
1. FS was hooking up logout to store reset. Store reset happens from one place (login) and it applies to everything. Also this happens on logged out, not log out (after, not while you're trying)
1. With the fix, if its slow the server can not have a session while you're trying to deregister so you can get logged out while trying to clean up. As part of a later cleanup on bootstrap we need a reverse bootstrap for logout. until then its just delaying a second

cc: @songgao 