### PR TITLE
write out any attachment preview to the fetcher cache on upload CORE-8361

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,10 @@ services:
             - INSECURE_TLS_MODE=1
             - GREGOR_TLFAUTH_PRIVATE_SIGNING_KEY=e20589b8cd66d447aaee44b587305bd521f34f3085709b32b4e3bd479b20253e59ea153c88a8ea524d39e0ae58fa195749214b38a28fdb4229ba3390b2d33e86
             - GREGOR_TLFAUTH_PUBLIC_SIGNING_KEY=012059ea153c88a8ea524d39e0ae58fa195749214b38a28fdb4229ba3390b2d33e860a
+            - CHAT_S3_BUCKET=test
+            - CHAT_S3_ACCESS_KEY=test
+            - CHAT_S3_SECRET_KEY=test
+
         logging:
             driver: json-file
             options:

--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -24,38 +24,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-type DummyAttachmentFetcher struct{}
-
-func (d DummyAttachmentFetcher) FetchAttachment(ctx context.Context, w io.Writer,
-	convID chat1.ConversationID, asset chat1.Asset, r func() chat1.RemoteInterface, signer s3.Signer,
-	progress types.ProgressReporter) error {
-	return nil
-}
-
-func (d DummyAttachmentFetcher) DeleteAssets(ctx context.Context,
-	convID chat1.ConversationID, assets []chat1.Asset, ri func() chat1.RemoteInterface, signer s3.Signer) (err error) {
-	return nil
-}
-
-func (d DummyAttachmentFetcher) PutUploadedAsset(ctx context.Context, filename string, asset chat1.Asset) error {
-	return nil
-}
-
-type DummyAttachmentHTTPSrv struct{}
-
-func (d DummyAttachmentHTTPSrv) GetURL(ctx context.Context, convID chat1.ConversationID, msgID chat1.MessageID,
-	preview bool) string {
-	return ""
-}
-
-func (d DummyAttachmentHTTPSrv) GetPendingPreviewURL(ctx context.Context, outboxID chat1.OutboxID) string {
-	return ""
-}
-
-func (d DummyAttachmentHTTPSrv) GetAttachmentFetcher() types.AttachmentFetcher {
-	return DummyAttachmentFetcher{}
-}
-
 var blankProgress = func(bytesComplete, bytesTotal int64) {}
 
 type AttachmentHTTPSrv struct {

--- a/go/chat/attachments/store.go
+++ b/go/chat/attachments/store.go
@@ -79,7 +79,7 @@ type S3Store struct {
 	blockLimit int                         // max number of blocks to upload
 }
 
-// NewStore creates a standard Store that uses a real
+// NewS3Store creates a standard Store that uses a real
 // S3 connection.
 func NewS3Store(logger logger.Logger, runtimeDir string) *S3Store {
 	return &S3Store{
@@ -89,11 +89,11 @@ func NewS3Store(logger logger.Logger, runtimeDir string) *S3Store {
 	}
 }
 
-// newStoreTesting creates an Store suitable for testing
+// NewStoreTesting creates an Store suitable for testing
 // purposes.  It is not exposed outside this package.
 // It uses an in-memory s3 interface, reports enc/sig keys, and allows limiting
 // the number of blocks uploaded.
-func newStoreTesting(logger logger.Logger, kt func(enc, sig []byte)) *S3Store {
+func NewStoreTesting(logger logger.Logger, kt func(enc, sig []byte)) *S3Store {
 	return &S3Store{
 		DebugLabeler: utils.NewDebugLabeler(logger, "Attachments.Store", false),
 		s3c:          &s3.Mem{},

--- a/go/chat/attachments/store.go
+++ b/go/chat/attachments/store.go
@@ -58,7 +58,7 @@ func (u *UploadTask) Nonce() signencrypt.Nonce {
 }
 
 type Store interface {
-	UploadAsset(ctx context.Context, task *UploadTask) (chat1.Asset, error)
+	UploadAsset(ctx context.Context, task *UploadTask, encryptedOut io.Writer) (chat1.Asset, error)
 	DownloadAsset(ctx context.Context, params chat1.S3Params, asset chat1.Asset, w io.Writer,
 		signer s3.Signer, progress types.ProgressReporter) error
 	DeleteAsset(ctx context.Context, params chat1.S3Params, signer s3.Signer, asset chat1.Asset) error
@@ -103,7 +103,7 @@ func newStoreTesting(logger logger.Logger, kt func(enc, sig []byte)) *S3Store {
 	}
 }
 
-func (a *S3Store) UploadAsset(ctx context.Context, task *UploadTask) (res chat1.Asset, err error) {
+func (a *S3Store) UploadAsset(ctx context.Context, task *UploadTask, encryptedOut io.Writer) (res chat1.Asset, err error) {
 	defer a.Trace(ctx, func() error { return err }, "UploadAsset")()
 	// compute plaintext hash
 	if task.plaintextHash == nil {
@@ -128,7 +128,7 @@ func (a *S3Store) UploadAsset(ctx context.Context, task *UploadTask) (res chat1.
 		previous = a.previousUpload(ctx, task)
 	}
 
-	res, err = a.uploadAsset(ctx, task, enc, previous, resumable)
+	res, err = a.uploadAsset(ctx, task, enc, previous, resumable, encryptedOut)
 
 	// if the upload is aborted, reset the stream and start over to get new keys
 	if err == ErrAbortOnPartMismatch && previous != nil {
@@ -140,13 +140,14 @@ func (a *S3Store) UploadAsset(ctx context.Context, task *UploadTask) (res chat1.
 		if err := task.computePlaintextHash(); err != nil {
 			return res, err
 		}
-		return a.uploadAsset(ctx, task, enc, nil, resumable)
+		return a.uploadAsset(ctx, task, enc, nil, resumable, encryptedOut)
 	}
 
 	return res, err
 }
 
-func (a *S3Store) uploadAsset(ctx context.Context, task *UploadTask, enc *SignEncrypter, previous *AttachmentInfo, resumable bool) (asset chat1.Asset, err error) {
+func (a *S3Store) uploadAsset(ctx context.Context, task *UploadTask, enc *SignEncrypter,
+	previous *AttachmentInfo, resumable bool, encryptedOut io.Writer) (asset chat1.Asset, err error) {
 	defer a.Trace(ctx, func() error { return err }, "uploadAsset")()
 	var encReader io.Reader
 	if previous != nil {
@@ -174,6 +175,9 @@ func (a *S3Store) uploadAsset(ctx context.Context, task *UploadTask, enc *SignEn
 	// compute ciphertext hash
 	hash := sha256.New()
 	tee := io.TeeReader(encReader, hash)
+	if encryptedOut != nil {
+		tee = io.TeeReader(tee, encryptedOut)
+	}
 
 	// post to s3
 	length := int64(enc.EncryptedLen(task.FileSize))

--- a/go/chat/attachments/store_test.go
+++ b/go/chat/attachments/store_test.go
@@ -92,7 +92,7 @@ func TestSignEncrypter(t *testing.T) {
 }
 
 func makeTestStore(t *testing.T, kt func(enc, sig []byte)) *S3Store {
-	return newStoreTesting(logger.NewTestLogger(t), kt)
+	return NewStoreTesting(logger.NewTestLogger(t), kt)
 }
 
 func testStoreMultis(t *testing.T, s *S3Store) []*s3.MemMulti {
@@ -197,7 +197,7 @@ func TestUploadAssetSmall(t *testing.T) {
 	s := makeTestStore(t, nil)
 	ctx := context.Background()
 	plaintext, task := makeUploadTask(t, 1*MB)
-	a, err := s.UploadAsset(ctx, task)
+	a, err := s.UploadAsset(ctx, task, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func TestUploadAssetLarge(t *testing.T) {
 	s := makeTestStore(t, nil)
 	ctx := context.Background()
 	plaintext, task := makeUploadTask(t, 12*MB)
-	a, err := s.UploadAsset(ctx, task)
+	a, err := s.UploadAsset(ctx, task, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func (u *uploader) keyTracker(e, s []byte) {
 
 func (u *uploader) UploadResume() chat1.Asset {
 	u.s.blockLimit = 0
-	a, err := u.s.UploadAsset(context.Background(), u.task)
+	a, err := u.s.UploadAsset(context.Background(), u.task, nil)
 	if err != nil {
 		u.t.Fatalf("expected second UploadAsset call to work, got: %s", err)
 	}
@@ -286,7 +286,7 @@ func (u *uploader) UploadResume() chat1.Asset {
 func (u *uploader) UploadPartial(blocks int) {
 	u.s.blockLimit = blocks
 
-	_, err := u.s.UploadAsset(context.Background(), u.task)
+	_, err := u.s.UploadAsset(context.Background(), u.task, nil)
 	if err == nil {
 		u.t.Fatal("expected incomplete upload to have error")
 	}

--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -2,7 +2,9 @@ package attachments
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/keybase/client/go/chat/globals"
@@ -198,6 +200,14 @@ func (u *Uploader) doneUploading(outboxID chat1.OutboxID) {
 	delete(u.uploads, outboxID.String())
 }
 
+func (u *Uploader) uploadPreviewFile(ctx context.Context) (f *os.File, err error) {
+	dir := filepath.Join(u.G().GetCacheDir(), "uploadedpreviews")
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return nil, err
+	}
+	return ioutil.TempFile(dir, "up")
+}
+
 func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
 	outboxID chat1.OutboxID, title, filename string, metadata []byte, callerPreview *chat1.MakePreviewRes) (res chan types.AttachmentUploadResult, err error) {
 	// Check to see if we are already uploading this message and set upload status if not
@@ -278,7 +288,7 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 			UserID:         uid,
 			Progress:       progress,
 		}
-		ures.Object, err = u.store.UploadAsset(bgctx, &task)
+		ures.Object, err = u.store.UploadAsset(bgctx, &task, nil)
 		if err != nil {
 			u.Debug(bgctx, "upload: error uploading primary asset to s3: %s", err)
 		} else {
@@ -300,6 +310,15 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 			// copy the params so as not to mess with the main params above
 			previewParams := s3params
 
+			// set up file to write out encrypted preview to
+			encryptedOut, err := u.uploadPreviewFile(ctx)
+			if err != nil {
+				u.Debug(bgctx, "upload: failed to create uploaded preview file: %s", err)
+				encryptedOut = nil
+			} else {
+				defer encryptedOut.Close()
+			}
+
 			// add preview suffix to object key (P in hex)
 			// the s3path in gregor is expecting hex here
 			previewParams.ObjectKey += "50"
@@ -312,12 +331,18 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 				ConversationID: convID,
 				UserID:         uid,
 			}
-			preview, err := u.store.UploadAsset(bgctx, &task)
+			preview, err := u.store.UploadAsset(bgctx, &task, encryptedOut)
 			if err == nil {
 				ures.Preview = &preview
 				ures.Preview.MimeType = pre.ContentType
 				ures.Preview.Metadata = pre.PreviewMetadata()
 				ures.Preview.Tag = chat1.AssetTag_PRIMARY
+				if encryptedOut != nil {
+					if err := u.G().AttachmentURLSrv.GetAttachmentFetcher().PutUploadedAsset(ctx,
+						encryptedOut.Name(), preview); err != nil {
+						u.Debug(bgctx, "upload: failed to put uploaded asset into fetcher: %s", err)
+					}
+				}
 			} else {
 				u.Debug(bgctx, "upload: error uploading preview asset to s3: %s", err)
 			}

--- a/go/chat/attachments/uploader_test.go
+++ b/go/chat/attachments/uploader_test.go
@@ -2,6 +2,7 @@ package attachments
 
 import (
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ type mockStore struct {
 	uploadFn func(context.Context, *UploadTask) (chat1.Asset, error)
 }
 
-func (m *mockStore) UploadAsset(ctx context.Context, task *UploadTask) (chat1.Asset, error) {
+func (m *mockStore) UploadAsset(ctx context.Context, task *UploadTask, encryptedOut io.Writer) (chat1.Asset, error) {
 	return m.uploadFn(ctx, task)
 }
 
@@ -92,6 +93,7 @@ func TestAttachmentUploader(t *testing.T) {
 	store := &mockStore{}
 	ri := mockRemote{}
 	deliverer := newMockDeliverer()
+	g.AttachmentURLSrv = types.DummyAttachmentHTTPSrv{}
 	g.ActivityNotifier = notifier
 	g.MessageDeliverer = deliverer
 	getRi := func() chat1.RemoteInterface { return ri }

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -258,7 +258,7 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	// Force small pages during tests to ensure we fetch context from new pages
 	searcher.pageSize = 2
 	g.Searcher = searcher
-	g.AttachmentURLSrv = DummyAttachmentHTTPSrv{}
+	g.AttachmentURLSrv = types.DummyAttachmentHTTPSrv{}
 
 	return ctx, world, ri, sender, baseSender, &listener
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -354,7 +354,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	pushHandler.SetClock(c.world.Fc)
 	g.PushHandler = pushHandler
 	g.TeamChannelSource = NewCachingTeamChannelSource(g, func() chat1.RemoteInterface { return ri })
-	g.AttachmentURLSrv = DummyAttachmentHTTPSrv{}
+	g.AttachmentURLSrv = types.DummyAttachmentHTTPSrv{}
 	g.ActivityNotifier = NewNotifyRouterActivityRouter(g)
 
 	tc.G.ChatHelper = NewHelper(g, func() chat1.RemoteInterface { return ri })
@@ -3146,7 +3146,7 @@ func TestChatSrvMakePreview(t *testing.T) {
 	}
 	ri := ctc.as(t, user).ri
 	tc := ctc.world.Tcs[user.Username]
-	tc.ChatG.AttachmentURLSrv = NewAttachmentHTTPSrv(tc.Context(), DummyAttachmentFetcher{},
+	tc.ChatG.AttachmentURLSrv = NewAttachmentHTTPSrv(tc.Context(), types.DummyAttachmentFetcher{},
 		func() chat1.RemoteInterface { return ri })
 	res, err := ctc.as(t, user).chatLocalHandler().MakePreview(context.TODO(), arg)
 	require.NoError(t, err)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -281,6 +281,7 @@ type AttachmentFetcher interface {
 		ri func() chat1.RemoteInterface, signer s3.Signer) error
 	FetchAttachment(ctx context.Context, w io.Writer, convID chat1.ConversationID, asset chat1.Asset,
 		ri func() chat1.RemoteInterface, signer s3.Signer, progress ProgressReporter) error
+	PutUploadedAsset(ctx context.Context, filename string, asset chat1.Asset) error
 }
 
 type AttachmentURLSrv interface {

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	"fmt"
+	"io"
 
+	"github.com/keybase/client/go/chat/s3"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -151,4 +153,36 @@ type AttachmentUploadResult struct {
 	Object   chat1.Asset
 	Preview  *chat1.Asset
 	Metadata []byte
+}
+
+type DummyAttachmentFetcher struct{}
+
+func (d DummyAttachmentFetcher) FetchAttachment(ctx context.Context, w io.Writer,
+	convID chat1.ConversationID, asset chat1.Asset, r func() chat1.RemoteInterface, signer s3.Signer,
+	progress ProgressReporter) error {
+	return nil
+}
+
+func (d DummyAttachmentFetcher) DeleteAssets(ctx context.Context,
+	convID chat1.ConversationID, assets []chat1.Asset, ri func() chat1.RemoteInterface, signer s3.Signer) (err error) {
+	return nil
+}
+
+func (d DummyAttachmentFetcher) PutUploadedAsset(ctx context.Context, filename string, asset chat1.Asset) error {
+	return nil
+}
+
+type DummyAttachmentHTTPSrv struct{}
+
+func (d DummyAttachmentHTTPSrv) GetURL(ctx context.Context, convID chat1.ConversationID, msgID chat1.MessageID,
+	preview bool) string {
+	return ""
+}
+
+func (d DummyAttachmentHTTPSrv) GetPendingPreviewURL(ctx context.Context, outboxID chat1.OutboxID) string {
+	return ""
+}
+
+func (d DummyAttachmentHTTPSrv) GetAttachmentFetcher() AttachmentFetcher {
+	return DummyAttachmentFetcher{}
 }


### PR DESCRIPTION
If we upload an image, and then reload a thread, we are forced to redownload that image from S3. This is kind of frustrating to see on a bad connection. This patch makes it such that the upload process writes out the encrypted bytes to a file in the cache directory. That file is then registered with the download cache.