### PR TITLE
Team profiling and experiments

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -1183,6 +1183,7 @@ func (b *Boxer) UnboxMessages(ctx context.Context, boxed []chat1.MessageBoxed, c
 
 	boxCh := make(chan chat1.MessageBoxed)
 	eg, ctx := errgroup.WithContext(BackgroundContext(ctx, b.G()))
+
 	eg.Go(func() error {
 		defer close(boxCh)
 		for _, msg := range boxed {

--- a/go/engine/background_task.go
+++ b/go/engine/background_task.go
@@ -146,6 +146,7 @@ func (e *BackgroundTask) loop(m libkb.MetaContext) error {
 	var i int
 	for {
 		i++
+		m := m.WithLogTag("BGT") // Background Task
 		e.log(m, "round(%v) start", i)
 		err := e.round(m)
 		if err != nil {

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -136,7 +136,7 @@ func (e *UntrackEngine) loadThem(m libkb.MetaContext) (them *libkb.User, remoteL
 	}
 
 	if uid.IsNil() {
-		res := e.G().Resolver.Resolve(e.arg.Username.String())
+		res := e.G().Resolver.Resolve(m.Ctx(), e.arg.Username.String())
 		if err = res.GetError(); err != nil {
 			return
 		}

--- a/go/externals/resolve_test.go
+++ b/go/externals/resolve_test.go
@@ -27,7 +27,7 @@ func TestResolveSimple(t *testing.T) {
 	r, clock := newTestResolverCache(tc.G)
 
 	goodResolve := func(s string) {
-		res := r.Resolve(s)
+		res := r.Resolve(context.Background(), s)
 		if err := res.GetError(); err != nil {
 			t.Fatal(err)
 		}
@@ -66,7 +66,7 @@ func TestResolveSimple(t *testing.T) {
 	if !r.Stats.Eq(2, 1, 1, 0, 2) {
 		t.Fatalf("Got bad cache stats: %+v\n", r.Stats)
 	}
-	res := r.Resolve("tacovontaco@twitter")
+	res := r.Resolve(context.Background(), "tacovontaco@twitter")
 	if err := res.GetError(); err == nil {
 		t.Fatal("Expected an ambiguous error on taconvontaco")
 	} else if terr, ok := err.(libkb.ResolutionError); !ok {

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -254,19 +254,6 @@ func doRequestShared(m MetaContext, api Requester, arg APIArg, req *http.Request
 		return
 	}
 
-	/*
-		{ // Find API calls with no log tags.
-				tags, ok := LogTagsFromContext(m.Ctx())
-				if !ok {
-					panic("no tags")
-				}
-				if len(tags) <= 1 {
-					m.CDebugf("%v", spew.Sdump(tags))
-					panic("api call with no tags")
-				}
-		}
-	*/
-
 	finisher = noopFinisher
 
 	nist := getNIST(m, arg.SessionType)

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keybase/client/go/profiling"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
 )
@@ -146,6 +147,12 @@ func (m MetaContext) WithTimeout(timeout time.Duration) (MetaContext, func()) {
 func (m MetaContext) WithLogTag(k string) MetaContext {
 	m.ctx = WithLogTag(m.ctx, k)
 	return m
+}
+
+func (m MetaContext) WithTimeBuckets() (MetaContext, *profiling.TimeBuckets) {
+	ctx, tbs := m.G().CTimeBuckets(m.ctx)
+	m.ctx = ctx
+	return m, tbs
 }
 
 func (m MetaContext) EnsureCtx() MetaContext {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -797,6 +797,6 @@ type Resolver interface {
 	ResolveFullExpressionNeedUsername(ctx context.Context, input string) (res ResolveResult)
 	ResolveFullExpressionWithBody(ctx context.Context, input string) (res ResolveResult)
 	ResolveUser(ctx context.Context, assertion string) (u keybase1.User, res ResolveResult, err error)
-	ResolveWithBody(input string) ResolveResult
-	Resolve(input string) ResolveResult
+	ResolveWithBody(ctx context.Context, input string) ResolveResult
+	Resolve(ctx context.Context, input string) ResolveResult
 }

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -216,7 +216,7 @@ func (arg *LoadUserArg) checkUIDName() error {
 	return nil
 }
 
-func (arg *LoadUserArg) resolveUID() (ResolveResult, error) {
+func (arg *LoadUserArg) resolveUID(ctx context.Context) (ResolveResult, error) {
 	var rres ResolveResult
 	if arg.uid.Exists() {
 		return rres, nil
@@ -227,7 +227,7 @@ func (arg *LoadUserArg) resolveUID() (ResolveResult, error) {
 		return rres, fmt.Errorf("resolveUID: no uid or name")
 	}
 
-	if rres = arg.m.G().Resolver.ResolveWithBody(arg.name).FailOnDeleted(); rres.err != nil {
+	if rres = arg.m.G().Resolver.ResolveWithBody(ctx, arg.name).FailOnDeleted(); rres.err != nil {
 		return rres, rres.err
 	}
 
@@ -294,7 +294,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	m.CDebugf("LoadUser(uid=%v, name=%v)", arg.uid, arg.name)
 
 	// resolve the uid from the name, if necessary
-	rres, err := arg.resolveUID()
+	rres, err := arg.resolveUID(m.Ctx())
 	if err != nil {
 		return nil, err
 	}

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -115,22 +115,22 @@ func (res ResolveResult) FailOnDeleted() ResolveResult {
 	return res
 }
 
-func (r *ResolverImpl) ResolveWithBody(input string) ResolveResult {
-	return r.resolve(input, true)
+func (r *ResolverImpl) ResolveWithBody(ctx context.Context, input string) ResolveResult {
+	return r.resolve(ctx, input, true)
 }
 
-func (r *ResolverImpl) Resolve(input string) ResolveResult {
-	return r.resolve(input, false)
+func (r *ResolverImpl) Resolve(ctx context.Context, input string) ResolveResult {
+	return r.resolve(ctx, input, false)
 }
 
-func (r *ResolverImpl) resolve(input string, withBody bool) (res ResolveResult) {
-	defer r.G().Trace(fmt.Sprintf("Resolving username %q", input), func() error { return res.err })()
+func (r *ResolverImpl) resolve(ctx context.Context, input string, withBody bool) (res ResolveResult) {
+	defer r.G().CTraceTimed(ctx, fmt.Sprintf("Resolving username %q", input), func() error { return res.err })()
 
 	var au AssertionURL
 	if au, res.err = ParseAssertionURL(r.G().MakeAssertionContext(), input, false); res.err != nil {
 		return res
 	}
-	res = r.resolveURL(context.TODO(), au, input, withBody, false)
+	res = r.resolveURL(ctx, au, input, withBody, false)
 	return res
 }
 

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -659,7 +659,7 @@ func (u *CachedUPAKLoader) LookupUsernameUPAK(ctx context.Context, uid keybase1.
 // LookupUID is a verified map of username -> UID. IT calls into the resolver, which gives un untrusted
 // UID, but verifies with the UPAK loader that the mapping UID -> username is correct.
 func (u *CachedUPAKLoader) LookupUID(ctx context.Context, un NormalizedUsername) (keybase1.UID, error) {
-	rres := u.G().Resolver.Resolve(un.String())
+	rres := u.G().Resolver.Resolve(ctx, un.String())
 	if err := rres.GetError(); err != nil {
 		return keybase1.UID(""), err
 	}

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -28,7 +28,7 @@ func init() {
 	teamEnv.UserPreloadEnable = os.Getenv("KEYBASE_TEAM_PE") == "1"
 	teamEnv.UserPreloadParallel = os.Getenv("KEYBASE_TEAM_PP") == "1"
 	teamEnv.UserPreloadWait = os.Getenv("KEYBASE_TEAM_PW") == "1"
-	teamEnv.ProofSetParallel = os.Getenv("KEYBASE_TEAM_SP") == "1"
+	teamEnv.ProofSetParallel = os.Getenv("KEYBASE_TEAM_SP") == "0"
 }
 
 // How long until the tail of a team sigchain is considered non-fresh

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -592,7 +592,7 @@ func (l *TeamLoader) checkProofs(ctx context.Context,
 	// Without this it would fail in some cases when the team is on the left.
 	// Because the team linkmap in the proof objects is stale.
 	proofSet.SetTeamLinkMap(ctx, state.Chain.Id, state.Chain.LinkIDs)
-	return proofSet.check(ctx, l.world)
+	return proofSet.check(ctx, l.world, teamEnv.ProofSetParallel)
 }
 
 func (l *TeamLoader) unboxKBFSCryptKeys(ctx context.Context, key keybase1.TeamApplicationKey,

--- a/go/teams/proofs.go
+++ b/go/teams/proofs.go
@@ -290,9 +290,7 @@ func (p *proofSetT) check(ctx context.Context, world LoaderContext, parallel boo
 	var i int
 	for _, v := range p.proofs {
 		for _, proof := range v {
-			if i%100 == 0 {
-				p.G().Log.CDebugf(ctx, "TeamLoader proofSet check [%v / %v]", i, total)
-			}
+			p.G().Log.CDebugf(ctx, "TeamLoader proofSet check [%v / %v]", i, total)
 			err = proof.check(ctx, p.G(), world, p)
 			if err != nil {
 				return err

--- a/go/teams/proofs.go
+++ b/go/teams/proofs.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/client/go/libkb"
@@ -274,8 +275,12 @@ func (p proof) findLink(ctx context.Context, g *libkb.GlobalContext, world Loade
 }
 
 // check the entire proof set, failing if any one proof fails.
-func (p *proofSetT) check(ctx context.Context, world LoaderContext) (err error) {
+func (p *proofSetT) check(ctx context.Context, world LoaderContext, parallel bool) (err error) {
 	defer p.G().CTrace(ctx, "TeamLoader proofSet check", func() error { return err })()
+
+	if parallel {
+		return p.checkParallel(ctx, world)
+	}
 
 	var total int
 	for _, v := range p.proofs {
@@ -296,4 +301,47 @@ func (p *proofSetT) check(ctx context.Context, world LoaderContext) (err error) 
 		}
 	}
 	return nil
+}
+
+// check the entire proof set, failing if any one proof fails. (parallel version)
+func (p *proofSetT) checkParallel(ctx context.Context, world LoaderContext) (err error) {
+
+	var total int
+	for _, v := range p.proofs {
+		total += len(v)
+	}
+	p.G().Log.CDebugf(ctx, "TeamLoader proofSet check parallel [%v]", total)
+
+	queue := make(chan proof)
+	go func() {
+		for _, v := range p.proofs {
+			for _, proof := range v {
+				queue <- proof
+			}
+		}
+		close(queue)
+	}()
+
+	group, ctx := errgroup.WithContext(libkb.CopyTagsToBackground(ctx))
+	const pipeline = 20
+	for i := 0; i < pipeline; i++ {
+		group.Go(func() error {
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case proof, ok := <-queue:
+					if !ok {
+						return nil
+					}
+					err = proof.check(ctx, p.G(), world, p)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		})
+	}
+
+	return group.Wait()
 }


### PR DESCRIPTION
Check proofs in parallel x20. This brings the order checking (proofSet) stage down from 3s to 1s.

Add provisions for preloading users in parallel. These are disabled by default. They seem to maybe have some speedup on LTE but it's all very variable so it's hard to tell. Disabled by default.

Add some logging and instrumentation.