### PR TITLE
Remove some options from messages sent by the current user

### DIFF
--- a/shared/chat/conversation/messages/message-popup/text/container.js
+++ b/shared/chat/conversation/messages/message-popup/text/container.js
@@ -99,9 +99,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
       : null,
     onEdit: yourMessage && message.type === 'text' ? () => dispatchProps._onEdit(message) : null,
     onHidden: () => ownProps.onHidden(),
-    onQuote: message.type === 'text' ? () => dispatchProps._onQuote(message) : null,
-    onReplyPrivately: message.type === 'text' ? () => dispatchProps._onReplyPrivately(message) : null,
-    onViewProfile: message.author ? () => dispatchProps._onViewProfile(message.author) : null,
+    onQuote: message.type === 'text' && !yourMessage ? () => dispatchProps._onQuote(message) : null,
+    onReplyPrivately:
+      message.type === 'text' && !yourMessage ? () => dispatchProps._onReplyPrivately(message) : null,
+    onViewProfile: message.author && !yourMessage ? () => dispatchProps._onViewProfile(message.author) : null,
     position: ownProps.position,
     showDivider: !message.deviceRevokedAt,
     timestamp: message.timestamp,

--- a/shared/chat/conversation/messages/message-popup/text/index.js
+++ b/shared/chat/conversation/messages/message-popup/text/index.js
@@ -19,7 +19,7 @@ type Props = {
   onHidden: () => void,
   onQuote: null | (() => void),
   onReplyPrivately: null | (() => void),
-  onViewProfile: () => void,
+  onViewProfile: null | (() => void),
   position: Position,
   showDivider: boolean,
   style?: Object,
@@ -52,9 +52,9 @@ const TextPopupMenu = (props: Props) => {
         ]
       : []),
     {onClick: props.onCopy, title: 'Copy text'},
-    {onClick: props.onQuote, title: 'Quote'},
-    {onClick: props.onReplyPrivately, title: 'Reply privately'},
-    {onClick: props.onViewProfile, title: 'View profile'},
+    ...(props.onQuote ? [{onClick: props.onQuote, title: 'Quote'}] : []),
+    ...(props.onReplyPrivately ? [{onClick: props.onReplyPrivately, title: 'Reply privately'}] : []),
+    ...(props.onViewProfile ? [{onClick: props.onViewProfile, title: 'View profile'}] : []),
   ]
 
   const header = {


### PR DESCRIPTION
`Add a reaction` causes the message menu for messages sent by the current user to overflow the top of the screen on small screens. This PR removes some of the less useful options on self-messages until we can figure out how to fit all these features into one menu. r? @keybase/react-hackers 