### PR TITLE
Fix touch targets breaking UI layout

### DIFF
--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -162,17 +162,26 @@ class ProofsRender extends React.Component<Props> {
               onClickStatus={onClickProofMenu ? () => onClickProofMenu(idx) : p => this._onClickProof(p)}
               onClickProfile={p => this._onClickProfile(p)}
               hasMenu={!!onClickProofMenu}
-              style={{minHeight: 32}}
+              style={{left: -iconServicePadding, minHeight: 32}}
             />
           ))}
         {this.props.type === 'missingProofs' &&
           this.props.missingProofs.map((mp, idx) => (
-            <MissingProofRow key={mp.type} missingProof={mp} style={{minHeight: 32}} />
+            <MissingProofRow
+              key={mp.type}
+              missingProof={mp}
+              style={{left: -iconServicePadding, minHeight: 32}}
+            />
           ))}
       </Box>
     )
   }
 }
+
+// To increase the touch targets for proof icons, we define a common padding to
+// apply to all icons as well as to offset the proof row(s) to compensate for
+// the increased padding.
+const iconServicePadding = 5
 
 const iconContainer = {
   ...globalStyles.flexBoxRow,
@@ -196,7 +205,7 @@ const styleRow = {
 const styleService = {
   marginRight: globalMargins.xtiny,
   marginTop: 2,
-  padding: 5,
+  padding: iconServicePadding,
 }
 const styleServiceContainer = {
   color: globalColors.black_75,

--- a/shared/fs/header/add-new.js
+++ b/shared/fs/header/add-new.js
@@ -98,9 +98,15 @@ const styles = styleSheetCreate({
     ...globalStyles.flexBoxRow,
     alignItems: 'center',
   },
-  stylesText: {
-    marginLeft: globalMargins.tiny,
-  },
+  stylesText: platformStyles({
+    common: {
+      marginLeft: globalMargins.tiny,
+    },
+    isElectron: {
+      // Disable text-decoration: underline on hover for BodyBigLink
+      pointerEvents: 'none',
+    },
+  }),
   stylesIconNew: platformStyles({
     isMobile: {fontSize: 22},
   }),

--- a/shared/fs/header/header.desktop.js
+++ b/shared/fs/header/header.desktop.js
@@ -77,8 +77,11 @@ const styleFolderHeaderContainer = {
 }
 
 const styleAddNew = {
-  marginRight: globalMargins.small,
-  flexShrink: 0,
+  ...globalStyles.flexBoxRow,
+  alignItems: 'center',
+  padding: globalMargins.tiny,
+  paddingRight: globalMargins.small - 4,
+  paddingLeft: globalMargins.small,
 }
 
 export default FolderHeader


### PR DESCRIPTION
1. On desktop and mobile the "New..." button for files was broken (flex direction was wrong)
2. On desktop the dropdown after clicking "New..." had misaligned icons
3. On mobile the user proofs were misaligned by their paddingLeft amount.