### PR TITLE
Use global externalKeyStore always, simplify initialization

### DIFF
--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -134,7 +134,7 @@ func (s *secretStoreAndroid) RetrieveSecret(m MetaContext, username NormalizedUs
 
 	ks, err := getGlobalExternalKeyStore(m)
 	if err != nil {
-		return nil, err
+		return sec, err
 	}
 
 	return ks.RetrieveSecret(s.serviceName(m), string(username))

--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -91,18 +91,20 @@ func getGlobalExternalKeyStore(m MetaContext) (ExternalKeyStore, error) {
 		m.CDebugf("+ secret_store_external:setup (in getGlobalExternalKeyStore)")
 		defer m.CDebugf("- secret_store_external:setup (in getGlobalExternalKeyStore)")
 
+		serviceName := m.G().GetStoredSecretServiceName()
+
 		// username not required
-		err := externalKeyStore.SetupKeyStore(m.G().GetStoredSecretServiceName(), "")
+		err := externalKeyStore.SetupKeyStore(serviceName, "")
 		if err != nil {
-			m.CDebugf("externalKeyStore.SetupKeyStore(%s) error: %s (%T)", s.serviceName(m), err, err)
+			m.CDebugf("externalKeyStore.SetupKeyStore(%s) error: %s (%T)", serviceName, err, err)
 			return nil, err
 		}
 
-		m.CDebugf("externalKeyStore.SetupKeyStore(%s) success", s.serviceName(m))
+		m.CDebugf("externalKeyStore.SetupKeyStore(%s) success", serviceName)
 		externalKeyStoreInitialized = true
 	}
 
-	return externalKeyStore
+	return externalKeyStore, nil
 }
 
 type secretStoreAndroid struct{}
@@ -132,7 +134,7 @@ func (s *secretStoreAndroid) RetrieveSecret(m MetaContext, username NormalizedUs
 
 	ks, err := getGlobalExternalKeyStore(m)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	return ks.RetrieveSecret(s.serviceName(m), string(username))

--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -5,7 +5,10 @@
 
 package libkb
 
-import "sync"
+import (
+	"errors"
+	"sync"
+)
 
 // TODO: Make this implementation use GetStoredSecretServiceName(), as
 // otherwise tests will clobber each other's passwords. See
@@ -64,67 +67,102 @@ func (w TypeSafeExternalKeyStoreProxy) SetupKeyStore(serviceName string, key str
 
 // externalKeyStore is the reference to some external key store
 var externalKeyStore ExternalKeyStore
-
+var externalKeyStoreInitialized bool
 var externalKeyStoreMu sync.Mutex
-
-func (s *secretStoreAccountName) serviceName(m MetaContext) string {
-	return m.G().GetStoredSecretServiceName()
-}
 
 // SetGlobalExternalKeyStore is called by Android to register Android's KeyStore with Go
 func SetGlobalExternalKeyStore(s UnsafeExternalKeyStore) {
 	externalKeyStoreMu.Lock()
 	defer externalKeyStoreMu.Unlock()
 	externalKeyStore = TypeSafeExternalKeyStoreProxy{s}
+	externalKeyStoreInitialized = false
 }
 
-func getGlobalExternalKeyStore() ExternalKeyStore {
+var noExternalKeyStore = errors.New("no external key store available")
+
+func getGlobalExternalKeyStore(m MetaContext) (ExternalKeyStore, error) {
 	externalKeyStoreMu.Lock()
 	defer externalKeyStoreMu.Unlock()
+	if externalKeyStore == nil {
+		// perhaps SetGlobalExternalKeyStore has not been called by Android internals yet:
+		m.CDebugf("secret_store_external:getGlobalExternalKeyStore called, but externalKeyStore is nil")
+		return nil, noExternalKeyStore
+	}
+
+	// always check this since perhaps SetGlobalExternalKeyStore called more than once
+	if !externalKeyStoreInitialized {
+		m.CDebugf("+ secret_store_external:setup (in getGlobalExternalKeyStore)")
+		defer m.CDebugf("- secret_store_external:setup (in getGlobalExternalKeyStore)")
+
+		// username not required
+		err := externalKeyStore.SetupKeyStore(m.G().GetStoredSecretServiceName(), "")
+		if err != nil {
+			m.CDebugf("externalKeyStore.SetupKeyStore(%s) error: %s (%T)", s.serviceName(m), err, err)
+			return nil, err
+		}
+
+		m.CDebugf("externalKeyStore.SetupKeyStore(%s) success", s.serviceName(m))
+		externalKeyStoreInitialized = true
+	}
+
 	return externalKeyStore
 }
 
-type secretStoreAccountName struct {
-	externalKeyStore ExternalKeyStore
-	setupOnce        sync.Once
-}
+type secretStoreAndroid struct{}
 
-var _ SecretStoreAll = &secretStoreAccountName{}
+var _ SecretStoreAll = &secretStoreAndroid{}
 
 func NewSecretStoreAll(m MetaContext) SecretStoreAll {
-	externalKeyStore := getGlobalExternalKeyStore()
-	if externalKeyStore == nil {
-		return nil
-	}
-	s := &secretStoreAccountName{
-		externalKeyStore: externalKeyStore,
-	}
-	go s.setup(m)
-	return s
+	return &secretStoreAndroid{}
 }
 
-func (s *secretStoreAccountName) StoreSecret(m MetaContext, username NormalizedUsername, secret LKSecFullSecret) (err error) {
+func (s *secretStoreAndroid) serviceName(m MetaContext) string {
+	return m.G().GetStoredSecretServiceName()
+}
+
+func (s *secretStoreAndroid) StoreSecret(m MetaContext, username NormalizedUsername, secret LKSecFullSecret) (err error) {
 	defer m.CTraceTimed("secret_store_external StoreSecret", func() error { return err })()
-	s.setup(m)
-	return s.externalKeyStore.StoreSecret(s.serviceName(m), string(username), secret)
+	ks, err := getGlobalExternalKeyStore(m)
+	if err != nil {
+		return err
+	}
+
+	return ks.StoreSecret(s.serviceName(m), string(username), secret)
 }
 
-func (s *secretStoreAccountName) RetrieveSecret(m MetaContext, username NormalizedUsername) (sec LKSecFullSecret, err error) {
+func (s *secretStoreAndroid) RetrieveSecret(m MetaContext, username NormalizedUsername) (sec LKSecFullSecret, err error) {
 	defer m.CTraceTimed("secret_store_external RetrieveSecret", func() error { return err })()
-	s.setup(m)
-	return s.externalKeyStore.RetrieveSecret(s.serviceName(m), string(username))
+
+	ks, err := getGlobalExternalKeyStore(m)
+	if err != nil {
+		return err
+	}
+
+	return ks.RetrieveSecret(s.serviceName(m), string(username))
 }
 
-func (s *secretStoreAccountName) ClearSecret(m MetaContext, username NormalizedUsername) (err error) {
+func (s *secretStoreAndroid) ClearSecret(m MetaContext, username NormalizedUsername) (err error) {
 	defer m.CTraceTimed("secret_store_external ClearSecret", func() error { return err })()
-	return s.externalKeyStore.ClearSecret(s.serviceName(m), string(username))
+
+	ks, err := getGlobalExternalKeyStore(m)
+	if err != nil {
+		return err
+	}
+
+	return ks.ClearSecret(s.serviceName(m), string(username))
 }
 
 func (s *secretStoreAccountName) GetUsersWithStoredSecrets(m MetaContext) ([]string, error) {
-	if s.externalKeyStore == nil {
-		return nil, nil
+	ks, err := getGlobalExternalKeyStore(m)
+	if err != nil {
+		if err == noExternalKeyStore {
+			// this is to match previous behavior of this function,
+			// but perhaps it should return the error instead
+			return nil, nil
+		}
+		return err
 	}
-	usersMsgPack, err := s.externalKeyStore.GetUsersWithStoredSecretsMsgPack(s.serviceName(m))
+	usersMsgPack, err := ks.GetUsersWithStoredSecretsMsgPack(s.serviceName(m))
 	if err != nil {
 		return nil, err
 	}
@@ -132,20 +170,4 @@ func (s *secretStoreAccountName) GetUsersWithStoredSecrets(m MetaContext) ([]str
 	ch := codecHandle()
 	err = MsgpackDecodeAll(usersMsgPack, ch, &users)
 	return users, err
-}
-
-func (s *secretStoreAccountName) setup(m MetaContext) {
-	s.setupOnce.Do(func() {
-		m.CDebugf("+ secret_store_external:setup")
-
-		// username not required
-		err := s.externalKeyStore.SetupKeyStore(s.serviceName(m), "")
-		if err != nil {
-			m.CDebugf("externalKeyStore.SetupKeyStore(%s) error: %s (%T)", s.serviceName(m), err, err)
-		} else {
-			m.CDebugf("externalKeyStore.SetupKeyStore(%s) success", s.serviceName(m))
-		}
-
-		m.CDebugf("- secret_store_external:setup")
-	})
 }


### PR DESCRIPTION
I believe this patch could fix some races with android key store.

Before, there was a global reference to a key store that comes from Android.  When `NewSecretStoreAll` was called, it would copy whatever happened to be in that global reference and eventually initialize it and use it forever.

My theory is that on app startup it is possible `NewSecretStoreAll` is called before `SetGlobalExternalKeyStore` and then the user is screwed.  Or that it was possible to initialize it multiple times if `NewSecretStoreAll` happened to be called multiple times.  Or perhaps Android calls SetGlobalExternalKeyStore multiple times and the old reference held on to from NewSecretStoreAll is useless.

This patch changes it so that the SecretStore interface just uses the global reference all the time and makes sure it is only initialized once.

I never figured out a way to repro the situation people get in, but I did try this on an android device and it worked fine, so I think it's worth a shot.