### PR TITLE
Disable the save button on bio page if we're showing a warning

### DIFF
--- a/shared/profile/edit-profile/container.js
+++ b/shared/profile/edit-profile/container.js
@@ -46,5 +46,5 @@ export default compose(
   withHandlers({
     ...(isMobile ? {} : {onCancel: ({onBack}) => () => onBack()}),
     onSubmit: ({bio, fullname, location, onEditProfile}) => () => onEditProfile(bio, fullname, location),
-  }),
+  })
 )(HeaderOnMobile(Render))

--- a/shared/profile/edit-profile/index.desktop.js
+++ b/shared/profile/edit-profile/index.desktop.js
@@ -33,7 +33,7 @@ const EditProfileRender = (props: Props) => (
       />
       <ButtonBar>
         <Button type="Secondary" onClick={props.onCancel} label="Cancel" />
-        <Button type="Primary" onClick={props.onSubmit} label="Save" />
+        <Button type="Primary" disabled={props.bioLengthLeft <= 0} onClick={props.onSubmit} label="Save" />
       </ButtonBar>
     </Box>
   </StandardScreen>

--- a/shared/profile/edit-profile/index.native.js
+++ b/shared/profile/edit-profile/index.native.js
@@ -1,12 +1,13 @@
 // @flow
 import * as React from 'react'
-import {Box, Button, ButtonBar, FormInput} from '../../common-adapters/mobile.native'
-import {globalMargins, globalStyles} from '../../styles'
+import * as Kb from '../../common-adapters/mobile.native'
+import * as Styles from '../../styles'
+
 import type {Props} from '.'
 
 const EditProfileRender = (props: Props) => (
-  <Box style={globalStyles.flexBoxColumn}>
-    <FormInput
+  <Kb.Box style={Styles.globalStyles.flexBoxColumn}>
+    <Kb.FormInput
       autoCorrect={true}
       autoFocus={true}
       label="Full name"
@@ -14,7 +15,7 @@ const EditProfileRender = (props: Props) => (
       onChangeText={fullname => props.onFullnameChange(fullname)}
       hideBottomBorder={true}
     />
-    <FormInput
+    <Kb.FormInput
       autoCorrect={true}
       label="Bio"
       value={props.bio}
@@ -23,21 +24,37 @@ const EditProfileRender = (props: Props) => (
       onChangeText={bio => props.onBioChange(bio)}
       hideBottomBorder={true}
     />
-    <FormInput
+    <Kb.FormInput
       autoCorrect={true}
       label="Location"
       value={props.location}
       onEnterKeyDown={props.onSubmit}
       onChangeText={location => props.onLocationChange(location)}
     />
-    <ButtonBar fullWidth={true}>
-      <Button style={styleButton} type="Primary" onClick={props.onSubmit} label="Save" />
-    </ButtonBar>
-  </Box>
+    {props.bioLengthLeft <= 5 && (
+      <Kb.Text style={styles.errorText} type="BodyError">
+        {props.bioLengthLeft} characters left.
+      </Kb.Text>
+    )}
+    <Kb.ButtonBar fullWidth={true}>
+      <Kb.Button
+        disabled={props.bioLengthLeft <= 0}
+        style={styles.button}
+        type="Primary"
+        onClick={props.onSubmit}
+        label="Save"
+      />
+    </Kb.ButtonBar>
+  </Kb.Box>
 )
 
-const styleButton = {
-  marginTop: globalMargins.medium,
-}
+const styles = Styles.styleSheetCreate({
+  button: {
+    marginTop: Styles.globalMargins.medium,
+  },
+  errorText: {
+    textAlign: 'center',
+  },
+})
 
 export default EditProfileRender


### PR DESCRIPTION
@keybase/react-hackers 

A user reported getting a black bar when trying to submit a bio that was > 256 chars long.

We already had a warning for this!  But it only displayed red text rather than disabling the Save button too, and it only did that warning on desktop.  Now both desktop and mobile disable the button if the bio's too long, and show the red warning.

This display component isn't unified across desktop and mobile.  I think that's because multiline wasn't doing the right thing at the time; it's using the raw native input component.  Could be worth another try at unifying using `<Kb.Input /`> instead.