### PR TITLE
Fix floating box z-order issue

### DIFF
--- a/shared/common-adapters/overlay/index.desktop.js
+++ b/shared/common-adapters/overlay/index.desktop.js
@@ -15,8 +15,9 @@ const Overlay = (props: Props) => {
       position={props.position || 'top center'}
       positionFallbacks={props.positionFallbacks}
       propagateOutsideClicks={props.propagateOutsideClicks}
+      containerStyle={styles.outerContainer}
     >
-      <Box2 direction="vertical" style={collapseStyles([styles.container, props.style])}>
+      <Box2 direction="vertical" style={collapseStyles([styles.innerContainer, props.style])}>
         {props.children}
       </Box2>
     </FloatingBox>
@@ -24,13 +25,17 @@ const Overlay = (props: Props) => {
 }
 
 const styles = styleSheetCreate({
-  container: platformStyles({
+  outerContainer: platformStyles({
+    isElectron: {
+      zIndex: 1, // Put the floating box on top of any sticky section headers.
+    },
+  }),
+  innerContainer: platformStyles({
     isElectron: {
       borderRadius: 3,
       boxShadow: '0 0 15px 0 rgba(0, 0, 0, 0.2)',
       overflowX: 'hidden',
       overflowY: 'auto',
-      zIndex: 1, // Put the popup on top of any sticky section headers.
     },
   }),
 })

--- a/shared/common-adapters/overlay/index.desktop.js
+++ b/shared/common-adapters/overlay/index.desktop.js
@@ -30,6 +30,7 @@ const styles = styleSheetCreate({
       boxShadow: '0 0 15px 0 rgba(0, 0, 0, 0.2)',
       overflowX: 'hidden',
       overflowY: 'auto',
+      zIndex: 1, // Put the popup on top of any sticky section headers.
     },
   }),
 })

--- a/shared/common-adapters/popup-dialog.desktop.js
+++ b/shared/common-adapters/popup-dialog.desktop.js
@@ -64,7 +64,7 @@ const coverStyle = {
   paddingRight: globalMargins.large,
   paddingTop: globalMargins.small,
   paddingBottom: globalMargins.small,
-  zIndex: 1, // Put the popup on top of any siblings
+  zIndex: 1, // Put the popup on top of any sticky section headers.
 }
 
 const containerStyle = {

--- a/shared/common-adapters/popup-dialog.desktop.js
+++ b/shared/common-adapters/popup-dialog.desktop.js
@@ -64,6 +64,7 @@ const coverStyle = {
   paddingRight: globalMargins.large,
   paddingTop: globalMargins.small,
   paddingBottom: globalMargins.small,
+  zIndex: 1, // Put the popup on top of any siblings
 }
 
 const containerStyle = {

--- a/shared/common-adapters/section-list.desktop.js
+++ b/shared/common-adapters/section-list.desktop.js
@@ -64,7 +64,7 @@ class SectionList extends React.Component<Props, State> {
     }
     const indexWithinSection = section.data.indexOf(item.item)
     return item.type === 'header' ? (
-      <Box key={item.key || key} style={styles.sectionHeader}>
+      <Box key={item.key || key} style={this.props.stickySectionHeadersEnabled && styles.stickySectionHeader}>
         {this.props.renderSectionHeader({section})}
       </Box>
     ) : (
@@ -85,7 +85,7 @@ const styles = styleSheetCreate({
   fullHeight: {
     height: '100%',
   },
-  sectionHeader: platformStyles({
+  stickySectionHeader: platformStyles({
     isElectron: {
       position: 'sticky',
       top: 0,


### PR DESCRIPTION
We were mistakenly applying sticky styles to
non-sticky section headers.