### PR TITLE
ephemeral retention policy CLI

### DIFF
--- a/go/client/chat_common.go
+++ b/go/client/chat_common.go
@@ -52,7 +52,8 @@ func postRetentionPolicy(ctx context.Context, lcli chat1.LocalClient, tui libkb.
 		}
 		return lcli.SetTeamRetentionLocal(ctx, chat1.SetTeamRetentionLocalArg{
 			TeamID: teamID,
-			Policy: policy})
+			Policy: policy,
+		})
 	}
 	return lcli.SetConvRetentionLocal(ctx, chat1.SetConvRetentionLocalArg{
 		ConvID: conv.Info.Id,


### PR DESCRIPTION
Adds CLI support for the ephemeral retention policy. Depends on the client changes here: https://github.com/keybase/client/pull/13037 and server changes here: https://github.com/keybase/keybase/pull/2716