### PR TITLE
Only show @here and @channel in team chats

### DIFF
--- a/shared/chat/conversation/input-area/user-mention-hud/index.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.js
@@ -14,22 +14,7 @@ import {
 } from '../../../../common-adapters/index'
 import {globalColors, globalMargins, globalStyles, isMobile, collapseStyles} from '../../../../styles'
 import {isSpecialMention} from '../../../../constants/chat2'
-
-type Props<D: {key: string, selected: boolean}> = {
-  rowRenderer: (i: number, d: D) => React$Element<any>,
-  data: Array<D>,
-  loading: boolean,
-  style: Object,
-  selectedIndex: number,
-}
-
-type MentionDatum = {
-  username: string,
-  fullName: string,
-  selected: boolean,
-  onClick: () => void,
-  onHover: () => void,
-}
+import type {MentionDatum, HudProps} from '.'
 
 const MentionRowRenderer = ({username, fullName, selected, onClick, onHover}: MentionDatum) => (
   <ClickableBox
@@ -69,7 +54,7 @@ const MentionRowRenderer = ({username, fullName, selected, onClick, onHover}: Me
 // We want to render Hud even if there's no data so we can still have lifecycle methods so we can still do things
 // This is important if you type a filter that gives you no results and you press enter for instance
 // $FlowIssue doens't like star now
-const Hud = ({style, data, loading, rowRenderer, selectedIndex}: Props<*>) =>
+const Hud = ({style, data, loading, rowRenderer, selectedIndex}: HudProps<*>) =>
   data.length ? (
     <Box style={collapseStyles([hudStyle, style])}>
       {loading ? (
@@ -91,18 +76,29 @@ const hudStyle = {
   backgroundColor: globalColors.white,
 }
 
-const _withProps = ({users, filter, selectedIndex}) => {
-  const fullList = users
+const _withProps = ({users, isTeam, selectedIndex, filter}) => {
+  let fullList = users
     .map((u, i) => ({
       fullName: u.fullName,
       key: u.username,
       username: u.username,
     }))
-    .concat({
-      fullName: 'Everyone in this channel',
-      key: 'channel',
-      username: 'channel',
-    })
+    .concat()
+
+  if (isTeam) {
+    fullList = fullList.concat([
+      {
+        fullName: 'Everyone in this channel',
+        key: 'channel',
+        username: 'channel',
+      },
+      {
+        fullName: 'Online users',
+        key: 'here',
+        username: 'here',
+      },
+    ])
+  }
   return {
     data: fullList
       .filter(u => {

--- a/shared/chat/conversation/input-area/user-mention-hud/index.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.js
@@ -77,27 +77,29 @@ const hudStyle = {
 }
 
 const _withProps = ({users, teamType, selectedIndex, filter}) => {
-  let fullList = users
-    .map((u, i) => ({
-      fullName: u.fullName,
-      key: u.username,
-      username: u.username,
-    }))
-    .concat()
+  const usersList = users.map((u, i) => ({
+    fullName: u.fullName,
+    key: u.username,
+    username: u.username,
+  }))
 
-  if (teamType === 'big') {
-    fullList = fullList.concat([
-      {fullName: 'Everyone in this channel', key: 'channel', username: 'channel'},
-      {fullName: 'Everyone in this channel', key: 'here', username: 'here'},
-    ])
-  }
+  const bigList =
+    teamType === 'big'
+      ? [
+          {fullName: 'Everyone in this channel', key: 'channel', username: 'channel'},
+          {fullName: 'Everyone in this channel', key: 'here', username: 'here'},
+        ]
+      : []
 
-  if (teamType === 'small') {
-    fullList = fullList.concat([
-      {fullName: 'Everyone in this team', key: 'channel', username: 'channel'},
-      {fullName: 'Everyone in this team', key: 'here', username: 'here'},
-    ])
-  }
+  const smallList =
+    teamType === 'small'
+      ? [
+          {fullName: 'Everyone in this team', key: 'channel', username: 'channel'},
+          {fullName: 'Everyone in this team', key: 'here', username: 'here'},
+        ]
+      : []
+
+  const fullList = [...usersList, ...bigList, ...smallList]
 
   return {
     data: fullList

--- a/shared/chat/conversation/input-area/user-mention-hud/index.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.js
@@ -76,7 +76,7 @@ const hudStyle = {
   backgroundColor: globalColors.white,
 }
 
-const _withProps = ({users, isTeam, selectedIndex, filter}) => {
+const _withProps = ({users, teamType, selectedIndex, filter}) => {
   let fullList = users
     .map((u, i) => ({
       fullName: u.fullName,
@@ -85,20 +85,20 @@ const _withProps = ({users, isTeam, selectedIndex, filter}) => {
     }))
     .concat()
 
-  if (isTeam) {
+  if (teamType === 'big') {
     fullList = fullList.concat([
-      {
-        fullName: 'Everyone in this channel',
-        key: 'channel',
-        username: 'channel',
-      },
-      {
-        fullName: 'Online users',
-        key: 'here',
-        username: 'here',
-      },
+      {fullName: 'Everyone in this channel', key: 'channel', username: 'channel'},
+      {fullName: 'Everyone in this channel', key: 'here', username: 'here'},
     ])
   }
+
+  if (teamType === 'small') {
+    fullList = fullList.concat([
+      {fullName: 'Everyone in this team', key: 'channel', username: 'channel'},
+      {fullName: 'Everyone in this team', key: 'here', username: 'here'},
+    ])
+  }
+
   return {
     data: fullList
       .filter(u => {

--- a/shared/chat/conversation/input-area/user-mention-hud/index.js.flow
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.js.flow
@@ -6,7 +6,7 @@ export type MentionContainer = {}
 export type MentionHudProps = {
   conversationIDKey: string,
   filter: string,
-  isTeam: boolean,
+  teamType: 'adhoc' | 'small' | 'big',
   loading: boolean,
   onPickUser: (string, options?: {notUser: boolean}) => void,
   onSelectUser: string => void,

--- a/shared/chat/conversation/input-area/user-mention-hud/index.js.flow
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.js.flow
@@ -1,0 +1,45 @@
+// @flow
+import React from 'react'
+
+export type MentionContainer = {}
+
+export type MentionHudProps = {
+  conversationIDKey: string,
+  filter: string,
+  isTeam: boolean,
+  loading: boolean,
+  onPickUser: (string, options?: {notUser: boolean}) => void,
+  onSelectUser: string => void,
+  pickSelectedUserCounter: number,
+  selectDownCounter: number,
+  selectUpCounter: number,
+  selectedIndex: number,
+  setSelectedIndex: number => void,
+  users: Array<{|fullName: string, username: string|}>,
+  _generalChannelConversationIDKey: string,
+  _loadParticipants: string => void,
+}
+
+export type MentionDatum = {
+  username: string,
+  fullName: string,
+  selected: boolean,
+  onClick: () => void,
+  onHover: () => void,
+}
+
+export type HudProps<D: {key: string, selected: boolean}> = {
+  rowRenderer: (i: number, d: D) => React$Element<any>,
+  data: Array<D>,
+  loading: boolean,
+  style: Object,
+  selectedIndex: number,
+}
+
+// $FlowIssue
+export default class Hud extends React.Component<HudProps<*>> {}
+
+class MentionHud extends React.Component<MentionHudProps> {}
+class MentionRowRenderer extends React.Component<MentionDatum> {}
+
+export {MentionHud, MentionRowRenderer}

--- a/shared/chat/conversation/input-area/user-mention-hud/index.js.flow
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.js.flow
@@ -1,6 +1,22 @@
 // @flow
 import React from 'react'
 
+/*
+ * This Flow type file exists because of a Flow error in
+ * `user-mention-hud/index.js` where Flow will get confused when attempting to
+ * type the incoming props to MentionHud.
+ *
+ * The issue is that recompose relies on Flow to correctly infer the types for
+ * the higher order component composition.
+ *
+ * compoose(hoc1, hoc2, hoc3)(component) becomes Hoc1(Hoc2(Hoc3(component))).
+ * Flow will lose typing on Hoc1.
+ *
+ * Adding this Flow file successfully adds types back to MentionHud via compose(...).
+ *
+ * TODO: Investigate if another typing stategy for Input > PlatformInput >
+ * MentionHudContainer > MentionHud that will not cause a Flow error
+ */
 export type MentionContainer = {}
 
 export type MentionHudProps = {

--- a/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
@@ -72,6 +72,13 @@ const load = () => {
       const Hud = UpDownFilterHoc(({upCounter, downCounter, filter}) => (
         <Box style={{...globalStyles.flexBoxColumn, height: 100, width: 240}}>
           <MentionHud
+            _loadParticipants={() => {}}
+            _generalChannelConversationIDKey="adfasdfsad"
+            conversationIDKey="adfasdfsad"
+            isTeam={false}
+            loading={false}
+            selectedIndex={0}
+            setSelectedIndex={action('setSelectedIndex')}
             users={[{username: 'marcopolo', fullName: 'Marco Munizaga'}, {username: 'trex', fullName: ''}]}
             onPickUser={Sb.action('onPickUser')}
             onSelectUser={Sb.action('onSelectUser')}

--- a/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
@@ -78,7 +78,7 @@ const load = () => {
             teamType="adhoc"
             loading={false}
             selectedIndex={0}
-            setSelectedIndex={action('setSelectedIndex')}
+            setSelectedIndex={Sb.action('setSelectedIndex')}
             users={[{username: 'marcopolo', fullName: 'Marco Munizaga'}, {username: 'trex', fullName: ''}]}
             onPickUser={Sb.action('onPickUser')}
             onSelectUser={Sb.action('onSelectUser')}

--- a/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
@@ -75,7 +75,7 @@ const load = () => {
             _loadParticipants={() => {}}
             _generalChannelConversationIDKey="adfasdfsad"
             conversationIDKey="adfasdfsad"
-            isTeam={false}
+            teamType="adhoc"
             loading={false}
             selectedIndex={0}
             setSelectedIndex={action('setSelectedIndex')}

--- a/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
@@ -1,17 +1,20 @@
 // @flow
-import * as React from 'react'
+import * as Constants from '../../../../constants/chat2'
 import {MentionHud} from '.'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
-import {compose, connect, type TypedState, setDisplayName} from '../../../../util/container'
+import {compose, connect, lifecycle, type TypedState, setDisplayName} from '../../../../util/container'
 import * as I from 'immutable'
 import logger from '../../../../logger'
 
 const mapStateToProps = (state: TypedState, {filter, conversationIDKey}) => {
+  const meta = Constants.getMeta(state, conversationIDKey)
+  const isTeam: boolean = meta.teamType === 'big' || meta.teamType === 'small'
   return {
     _filter: filter,
     _infoMap: state.users.infoMap,
     _metaMap: state.chat2.metaMap,
     conversationIDKey,
+    isTeam,
   }
 }
 
@@ -44,34 +47,30 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     _loadParticipants: dispatchProps._loadParticipants,
     conversationIDKey: stateProps.conversationIDKey,
     filter: stateProps._filter.toLowerCase(),
+    isTeam: stateProps.isTeam,
     loading: users.length === 0,
     users,
   }
 }
 
 // TODO fix up the typing of this component
-class AutoLoadMentionHud extends React.Component<any> {
-  componentDidMount() {
-    if (this.props.users.length === 0) {
-      // it can never be 0, we don't have a list of participants cached for the general channel or this channel
-      if (!this.props._generalChannelConversationIDKey) {
-        logger.warn(
-          'Mention HUD: no meta found for general channel, loading participants of current channel.'
-        )
-        this.props._loadParticipants(this.props.conversationIDKey)
-        return
-      }
-      logger.info('Mention HUD: no participants in general channel meta, requesting trusted inbox item.')
-      this.props._loadParticipants(this.props._generalChannelConversationIDKey)
-    }
-  }
-
-  render() {
-    return <MentionHud {...this.props} />
-  }
-}
-
 export default compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
-  setDisplayName('UserMentionHud')
-)(AutoLoadMentionHud)
+  setDisplayName('UserMentionHud'),
+  lifecycle({
+    componentDidMount() {
+      if (this.props.users.length === 0) {
+        // it can never be 0, we don't have a list of participants cached for the general channel or this channel
+        if (!this.props._generalChannelConversationIDKey) {
+          logger.warn(
+            'Mention HUD: no meta found for general channel, loading participants of current channel.'
+          )
+          this.props._loadParticipants(this.props.conversationIDKey)
+          return
+        }
+        logger.info('Mention HUD: no participants in general channel meta, requesting trusted inbox item.')
+        this.props._loadParticipants(this.props._generalChannelConversationIDKey)
+      }
+    },
+  })
+)(MentionHud)

--- a/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
@@ -8,13 +8,13 @@ import logger from '../../../../logger'
 
 const mapStateToProps = (state: TypedState, {filter, conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
-  const isTeam: boolean = meta.teamType === 'big' || meta.teamType === 'small'
+  const teamType = meta.teamType
   return {
     _filter: filter,
     _infoMap: state.users.infoMap,
     _metaMap: state.chat2.metaMap,
     conversationIDKey,
-    isTeam,
+    teamType,
   }
 }
 
@@ -47,7 +47,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     _loadParticipants: dispatchProps._loadParticipants,
     conversationIDKey: stateProps.conversationIDKey,
     filter: stateProps._filter.toLowerCase(),
-    isTeam: stateProps.isTeam,
+    teamType: stateProps.teamType,
     loading: users.length === 0,
     users,
   }

--- a/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
@@ -1,10 +1,12 @@
 // @flow
+import * as React from 'react'
 import * as Constants from '../../../../constants/chat2'
 import {MentionHud} from '.'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
-import {compose, connect, lifecycle, type TypedState, setDisplayName} from '../../../../util/container'
+import {compose, connect, type TypedState, setDisplayName} from '../../../../util/container'
 import * as I from 'immutable'
 import logger from '../../../../logger'
+import type {MentionHudProps} from '.'
 
 const mapStateToProps = (state: TypedState, {filter, conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
@@ -53,24 +55,27 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   }
 }
 
+class AutoLoadMentionHud extends React.Component<MentionHudProps> {
+  componentDidMount() {
+    if (this.props.users.length === 0) {
+      // it can never be 0, we don't have a list of participants cached for the general channel or this channel
+      if (!this.props._generalChannelConversationIDKey) {
+        logger.warn(
+          'Mention HUD: no meta found for general channel, loading participants of current channel.'
+        )
+        this.props._loadParticipants(this.props.conversationIDKey)
+        return
+      }
+      logger.info('Mention HUD: no participants in general channel meta, requesting trusted inbox item.')
+      this.props._loadParticipants(this.props._generalChannelConversationIDKey)
+    }
+  }
+  render() {
+    return <MentionHud {...this.props} />
+  }
+}
 // TODO fix up the typing of this component
 export default compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
-  setDisplayName('UserMentionHud'),
-  lifecycle({
-    componentDidMount() {
-      if (this.props.users.length === 0) {
-        // it can never be 0, we don't have a list of participants cached for the general channel or this channel
-        if (!this.props._generalChannelConversationIDKey) {
-          logger.warn(
-            'Mention HUD: no meta found for general channel, loading participants of current channel.'
-          )
-          this.props._loadParticipants(this.props.conversationIDKey)
-          return
-        }
-        logger.info('Mention HUD: no participants in general channel meta, requesting trusted inbox item.')
-        this.props._loadParticipants(this.props._generalChannelConversationIDKey)
-      }
-    },
-  })
-)(MentionHud)
+  setDisplayName('UserMentionHud')
+)(AutoLoadMentionHud)


### PR DESCRIPTION
This commit also handled a very annoying Flow issue. After adding the
prop `isTeam` to `mention-hud-container` Flow was endlessly erroring
that `isTeam` is missing in object literal `A`.

The solution was to add an `index.js.flow` file to the directory to
force flow to understand the module level props.

Cause of the original error is not totally known.

### 1-1 Chat 

![image](https://user-images.githubusercontent.com/5200812/43485415-2631e5c8-94df-11e8-965d-d40397e657e4.png)

### Group

![image](https://user-images.githubusercontent.com/5200812/43485439-3d52452c-94df-11e8-88b8-bf9b146b8c59.png)


### Small Team

![image](https://user-images.githubusercontent.com/5200812/43485480-596bb89c-94df-11e8-888f-8462695398d8.png)

### Big Team

![image](https://user-images.githubusercontent.com/5200812/43485501-64972fbc-94df-11e8-8ab5-bbf0c11ec1c6.png)
