### PR TITLE
Stellar cleanups: extrabold and bodysmall

### DIFF
--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -45,7 +45,7 @@ const AssetInput = (props: Props) => (
       !props.warningPayee && (
         <Text type="BodySmallError">
           Your available to send is{' '}
-          <Text type="BodySmallSemibold" style={{color: globalColors.red}}>
+          <Text type="BodySmallExtrabold" style={{color: globalColors.red}}>
             {props.warningAsset}
           </Text>
         </Text>

--- a/shared/wallets/transaction/index.js
+++ b/shared/wallets/transaction/index.js
@@ -53,7 +53,7 @@ type CounterpartyTextProps = {|
   counterparty: string,
   counterpartyType: Types.CounterpartyType,
   showFullKey: boolean,
-  textType?: 'Body' | 'BodySmall' | 'BodySemibold',
+  textType?: 'Body' | 'BodySmall' | 'BodyExtrabold',
   textTypeSemibold?: 'BodySemibold' | 'BodySmallSemibold',
 |}
 
@@ -109,6 +109,7 @@ type DetailProps = {|
 const Detail = (props: DetailProps) => {
   const textType = props.large ? 'Body' : 'BodySmall'
   const textTypeSemibold = props.large ? 'BodySemibold' : 'BodySmallSemibold'
+  const textTypeExtrabold = props.large ? 'BodyExtrabold' : 'BodySmallExtrabold'
 
   const counterparty = (
     <CounterpartyText
@@ -121,10 +122,10 @@ const Detail = (props: DetailProps) => {
     />
   )
   const amount = props.isXLM ? (
-    <Text type={textTypeSemibold}>{props.amountUser}</Text>
+    <Text type={textTypeExtrabold}>{props.amountUser}</Text>
   ) : (
     <React.Fragment>
-      Lumens worth <Text type={textTypeSemibold}>{props.amountUser}</Text>
+      Lumens worth <Text type={textTypeExtrabold}>{props.amountUser}</Text>
     </React.Fragment>
   )
 

--- a/shared/wallets/transaction/index.js
+++ b/shared/wallets/transaction/index.js
@@ -53,7 +53,7 @@ type CounterpartyTextProps = {|
   counterparty: string,
   counterpartyType: Types.CounterpartyType,
   showFullKey: boolean,
-  textType?: 'Body' | 'BodySmall' | 'BodyExtrabold',
+  textType?: 'Body' | 'BodySmall' | 'BodySemibold',
   textTypeSemibold?: 'BodySemibold' | 'BodySmallSemibold',
 |}
 

--- a/shared/wallets/wallet-list/wallet-row/index.js
+++ b/shared/wallets/wallet-list/wallet-row/index.js
@@ -66,14 +66,12 @@ const styles = styleSheetCreate({
     ...globalStyles.fontSemibold,
     ...rightColumnStyle,
     color: globalColors.darkBlue,
-    fontSize: 13,
   },
   titleSelected: {
     ...globalStyles.fontSemibold,
     ...rightColumnStyle,
     color: globalColors.white,
     backgroundColor: backgroundColorSelected,
-    fontSize: 13,
   },
 
   amount: {


### PR DESCRIPTION
@keybase/react-hackers 

Use extrabold for asset values, and don't override the fontSize of BodySmall on the wallet row.