### PR TITLE
Purge resolver cache on subteam rename

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -799,6 +799,7 @@ type Resolver interface {
 	ResolveUser(ctx context.Context, assertion string) (u keybase1.User, res ResolveResult, err error)
 	ResolveWithBody(ctx context.Context, input string) ResolveResult
 	Resolve(ctx context.Context, input string) ResolveResult
+	PurgeResolveCache(ctx context.Context, input string) error
 }
 
 type EnginePrereqs struct {

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -187,12 +187,16 @@ func handleChangeSingle(ctx context.Context, g *libkb.GlobalContext, row keybase
 
 	defer g.CTrace(ctx, fmt.Sprintf("team.handleChangeSingle(%+v, %+v)", row, change), func() error { return err })()
 
-	err = g.GetTeamLoader().HintLatestSeqno(ctx, row.Id, row.LatestSeqno)
-	if err != nil {
+	if err = g.GetTeamLoader().HintLatestSeqno(ctx, row.Id, row.LatestSeqno); err != nil {
 		g.Log.CWarningf(ctx, "error in HintLatestSeqno: %v", err)
 		return nil
 	}
-	// Send teamID and teamName in two separate notifications. It is server-trust that they are the same team.
+	// If we're handling a rename we should also purge the resolver cache
+	if change.Renamed {
+		PurgeResolverTeamID(ctx, g, row.Id)
+	}
+	// Send teamID and teamName in two separate notifications. It is
+	// server-trust that they are the same team.
 	g.NotifyRouter.HandleTeamChangedByBothKeys(ctx, row.Id, row.Name, row.LatestSeqno, row.ImplicitTeam, change)
 
 	return nil

--- a/go/teams/resolve.go
+++ b/go/teams/resolve.go
@@ -21,8 +21,7 @@ func ResolveIDToName(ctx context.Context, g *libkb.GlobalContext, id keybase1.Te
 		return keybase1.TeamName{}, err
 	}
 	name = rres.GetTeamName()
-	err = g.GetTeamLoader().VerifyTeamName(ctx, id, name)
-	if err != nil {
+	if err = g.GetTeamLoader().VerifyTeamName(ctx, id, name); err != nil {
 		return keybase1.TeamName{}, err
 	}
 
@@ -37,13 +36,15 @@ func ResolveNameToID(ctx context.Context, g *libkb.GlobalContext, name keybase1.
 		return keybase1.TeamID(""), err
 	}
 	id = rres.GetTeamID()
-
-	err = g.GetTeamLoader().VerifyTeamName(ctx, id, name)
-	if err != nil {
+	if err = g.GetTeamLoader().VerifyTeamName(ctx, id, name); err != nil {
 		return keybase1.TeamID(""), err
 	}
 
 	return id, nil
+}
+
+func PurgeResolverTeamID(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) error {
+	return g.Resolver.PurgeResolveCache(ctx, fmt.Sprintf("tid:%s", teamID))
 }
 
 // Resolve assertions in an implicit team display name and verify the result.


### PR DESCRIPTION
When renaming a subteam we purge the resolver cache for the subteam id. Previously, when we would try to resolve a name, we would get an error because the cached name does not match the name in the team chain.