### PR TITLE
Copy edits for keybase encrypt --help

### DIFF
--- a/go/client/cmd_encrypt.go
+++ b/go/client/cmd_encrypt.go
@@ -50,12 +50,15 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 			Usage: "Do not use per user/per team keys for encryption.",
 		},
 		cli.BoolFlag{
-			Name:  "no-device-keys",
-			Usage: "Do not use the device keys of all the user recipients (and memebers of recipient teams) for encryption. This does not affect paper keys.",
+			Name: "no-device-keys",
+			Usage: `Do not use the device keys of all the user recipients
+	(and members of recipient teams) for encryption.
+	This does not affect paper keys.`,
 		},
 		cli.BoolFlag{
-			Name:  "no-paper-keys",
-			Usage: "Do not use the paper keys of all the user recipients (and memebers of recipient teams) for encryption.",
+			Name: "no-paper-keys",
+			Usage: `Do not use the paper keys of all the user recipients
+	(and members of recipient teams) for encryption.`,
 		},
 		cli.BoolFlag{
 			Name:  "no-self-encrypt",
@@ -64,7 +67,9 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 		cli.StringFlag{
 			Name:  "auth-type",
 			Value: "signed",
-			Usage: "How to guarantee sender authenticity: signed|repudiable|anonymous. Uses this device's key for signing, pairwise MACs for repudiability, nothing if anonymous.",
+			Usage: `How to guarantee sender authenticity:
+	signed|repudiable|anonymous. Uses this device's key for signing, pairwise
+	MACs for repudiability, or nothing if anonymous.`,
 		},
 		cli.IntFlag{
 			Name:  "saltpack-version",
@@ -73,8 +78,10 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 	}
 	if develUsage {
 		flags = append(flags, cli.BoolFlag{
-			Name:  "use-kbfs-keys-only",
-			Usage: "[devel only] Encrypt using only kbfs keys (and post kbfs pseudonyms) to simulate messages encrypted with older versions of keybase. Used for tests. It ignores other no-*-keys options and team recipients.",
+			Name: "use-kbfs-keys-only",
+			Usage: `[devel only] Encrypt using only kbfs keys (and post kbfs
+	pseudonyms) to simulate messages encrypted with older versions of keybase.
+	Used for tests. It ignores other no-*-keys options and team recipients.`,
 		})
 	}
 
@@ -82,38 +89,42 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 		Name:         "encrypt",
 		ArgumentHelp: "<usernames...>",
 		Usage:        "Encrypt messages or files for keybase users and teams",
-		Description: `Encrypt messages and files for keybase users and teams using Saltpack 
-(https://saltpack.org), a modern encryption format.
-Saltpack is built on top of the well-established NaCl crypto library 
-(https://nacl.cr.yp.to/), to which it adds support for multiple recipients, a 
-new copy-paste friendly ASCII output format, and the ability to encrypt very 
-large files that don't fit int RAM. Messages are securely encrypted and cannot 
-be read by anyone but the intended recipient or altered in any way.
+		Description: `
+Encrypt messages and files for keybase users and teams using the Saltpack
+encryption format (https://saltpack.org). Saltpack is built on top of the
+well-established NaCl crypto library (https://nacl.cr.yp.to/), adding support
+for multiple recipients, a new copy-paste friendly ASCII output format, and the
+ability to encrypt very large files that don't fit into memory. Messages are
+securely encrypted and cannot be read by anyone but the intended recipient and
+cannot be altered in any way.
 
-"keybase encrypt" makes decryption as simple as possible: 
-  - When you encrypt for a keybase user, they will be able to decrypt your 
-message using any of their current devices, and even new devices which are 
-added after the message is generated (each user has an additional per user key 
-which is synced among all their devices).
-  - You can also encrypt for a team (through the "--team" flag), in which case 
-all devices of the current team members will be able to decrypt the message 
-*even after they leave the team!*, as well as devices of anyone who later joins 
-the team (through a shared team key).
-  - You can even encrypt for users that are not yet on keybase, such as 
-not_yet_on_keybase@twitter: the message will be encrypted with a key known only 
-to your devices, which will automatically rekey it for the recipient once they 
-join keybase and prove they own the recipient account.
-  - For advanced users, the set of keys used to encrypt the message can be 
-customized through flags.
+"keybase encrypt" makes decryption as simple as possible:
 
-"keybase encrypt" provides strong integrity guarantees: messages are signed by 
-default with the key of the device you use to generate them, but repudiable 
-authentication (the recipient of a message can be convinced that you sent it, 
-but cannot convince a third party of this fact)
-and private but anonymous messages are also supported. At the moment, 
-encrypting for teams (and users not yet on keybase or with missing keys) with 
-repudiable authentication is not possible. You can still use signed or 
-anonymous mode in such cases.
+  - When encrypting for a keybase user, decryption is possible with any of the
+  recipients current or future devices through their keybase per-user-key.
+
+  - Team encryption, available through the "--team" flag, encrypts the message
+  for all devices of the current team members as well as devices of people who
+  later join the team through a shared team key. Members will be able to
+  decrypt the message *even after they leave the team*.
+
+  - You can also encrypt for users who have not yet joined keybase, but are on
+  a social network such as foo@twitter: the message will be encrypted with a
+  key known only to your devices and will be automatically rekeyed for the
+  recipient once they join keybase and prove they own the account 'foo' on
+  twitter.
+
+  - For advanced users, the set of keys used to encrypt the message can be
+  customized through flags.
+
+"keybase encrypt" provides strong integrity guarantees. By default, messages are
+signed with the key of the encrypting device. Messages can also use repudiable
+authentication (the recipient of a message can be convinced that you sent it,
+but cannot convince a third party of this fact) or made completely anonymous.
+
+Encrypting for teams (and users not yet on keybase or with missing keys) with
+repudiable authentication is not possible. You can still use the signed or
+anonymous modes in such cases.
 `,
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&CmdEncrypt{


### PR DESCRIPTION
Some small wording changes/tweaks to the output format to help with readability for `keybase encrypt --help`

before:

```
NAME:
   keybase encrypt - Encrypt messages or files for keybase users and teams

USAGE:
   keybase encrypt [command options] <usernames...>

DESCRIPTION:
   Encrypt messages and files for keybase users and teams using Saltpack 
(https://saltpack.org), a modern encryption format.
Saltpack is built on top of the well-established NaCl crypto library 
(https://nacl.cr.yp.to/), to which it adds support for multiple recipients, a 
new copy-paste friendly ASCII output format, and the ability to encrypt very 
large files that don't fit int RAM. Messages are securely encrypted and cannot 
be read by anyone but the intended recipient or altered in any way.

"keybase encrypt" makes decryption as simple as possible: 
  - When you encrypt for a keybase user, they will be able to decrypt your 
message using any of their current devices, and even new devices which are 
added after the message is generated (each user has an additional per user key 
which is synced among all their devices).
  - You can also encrypt for a team (through the "--team" flag), in which case 
all devices of the current team members will be able to decrypt the message 
*even after they leave the team!*, as well as devices of anyone who later joins 
the team (through a shared team key).
  - You can even encrypt for users that are not yet on keybase, such as 
not_yet_on_keybase@twitter: the message will be encrypted with a key known only 
to your devices, which will automatically rekey it for the recipient once they 
join keybase and prove they own the recipient account.
  - For advanced users, the set of keys used to encrypt the message can be 
customized through flags.

"keybase encrypt" provides strong integrity guarantees: messages are signed by 
default with the key of the device you use to generate them, but repudiable 
authentication (the recipient of a message can be convinced that you sent it, 
but cannot convince a third party of this fact)
and private but anonymous messages are also supported. At the moment, 
encrypting for teams (and users not yet on keybase or with missing keys) with 
repudiable authentication is not possible. You can still use signed or 
anonymous mode in such cases.


OPTIONS:
   --team [--team option --team option]	Encrypt for a team. Can be specified multiple times.
   -b, --binary				Output in binary (rather than ASCII/armored).
   -i, --infile 			Specify an input file.
   -m, --message 			Provide the message on the command line.
   -o, --outfile 			Specify an outfile (stdout by default).
   --no-entity-keys			Do not use per user/per team keys for encryption.
   --no-device-keys			Do not use the device keys of all the user recipients (and memebers of recipient teams) for encryption. This does not affect paper keys.
   --no-paper-keys			Do not use the paper keys of all the user recipients (and memebers of recipient teams) for encryption.
   --no-self-encrypt			Don't encrypt for yourself.
   --auth-type "signed"			How to guarantee sender authenticity: signed|repudiable|anonymous. Uses this device's key for signing, pairwise MACs for repudiability, nothing if anonymous.
   --saltpack-version "0"		Force a specific saltpack version
   --use-kbfs-keys-only			[devel only] Encrypt using only kbfs keys (and post kbfs pseudonyms) to simulate messages encrypted with older versions of keybase. Used for tests. It ignores other no-*-keys options and team recipients.
```

after:
```
NAME:
   keybase encrypt - Encrypt messages or files for keybase users and teams

USAGE:
   keybase encrypt [command options] <usernames...>

DESCRIPTION:
   
Encrypt messages and files for keybase users and teams using the Saltpack
encryption format (https://saltpack.org). Saltpack is built on top of the
well-established NaCl crypto library (https://nacl.cr.yp.to/), adding support
for multiple recipients, a new copy-paste friendly ASCII output format, and the
ability to encrypt very large files that don't fit into memory. Messages are
securely encrypted and cannot be read by anyone but the intended recipient and
cannot be altered in any way.

"keybase encrypt" makes decryption as simple as possible:
  - When encrypting for a keybase user, decryption is possible with any of the
  recipients current or future devices through their keybase per-user-key.

  - Team encryption, available through the "--team" flag, encrypts the message
  for all devices of the current team members as well as devices of people who
  later join the team through a shared team key. Members will be able to
  decrypt the message *even after they leave the team*.

  - You can also encrypt for users who have not yet joined keybase, but are on
  a social network such as foo@twitter: the message will be encrypted with a
  key known only to your devices and will automatically rekey it for the
  recipient once they join keybase and prove they own the account 'foo' on
  twitter.

  - For advanced users, the set of keys used to encrypt the message can be
  customized through flags.

"keybase encrypt" provides strong integrity guarantees. By default, messages are
signed with the key of the encrypting device. Messages can also use repudiable
authentication (the recipient of a message can be convinced that you sent it,
but cannot convince a third party of this fact) or made completely anonymous.

Encrypting for teams (and users not yet on keybase or with missing keys) with
repudiable authentication is not possible. You can still use signed or
anonymous mode in such cases.


OPTIONS:
   --team [--team option --team option]	Encrypt for a team. Can be specified multiple times.
   -b, --binary				Output in binary (rather than ASCII/armored).
   -i, --infile 			Specify an input file.
   -m, --message 			Provide the message on the command line.
   -o, --outfile 			Specify an outfile (stdout by default).
   --no-entity-keys			Do not use per user/per team keys for encryption.
   --no-device-keys			Do not use the device keys of all the user recipients
					(and members of recipient teams) for encryption.
					This does not affect paper keys.
   --no-paper-keys			Do not use the paper keys of all the user recipients
					(and members of recipient teams) for encryption.
   --no-self-encrypt			Don't encrypt for yourself.
   --auth-type "signed"			How to guarantee sender authenticity:
					signed|repudiable|anonymous. Uses this device's key for signing, pairwise
					MACs for repudiability, or nothing if anonymous.
   --saltpack-version "0"		Force a specific saltpack version
   --use-kbfs-keys-only			[devel only] Encrypt using only kbfs keys (and post kbfs
					pseudonyms) to simulate messages encrypted with older versions of keybase.
					Used for tests. It ignores other no-*-keys options and team recipients.
```