### PR TITLE
Team load optimization: don't copy team link maps when adding to proofSet

### DIFF
--- a/go/protocol/keybase1/upk.go
+++ b/go/protocol/keybase1/upk.go
@@ -5,7 +5,6 @@ package keybase1
 
 import (
 	"errors"
-
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 

--- a/go/protocol/keybase1/upk.go
+++ b/go/protocol/keybase1/upk.go
@@ -5,6 +5,7 @@ package keybase1
 
 import (
 	"errors"
+
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -286,12 +286,15 @@ func (l *TeamLoader) loadUserAndKeyFromLinkInnerAndVerify(ctx context.Context, t
 	if !signedByKID.Equal(key.Base.Kid) {
 		return keybase1.UserVersion{}, libkb.NewWrongKidError(signedByKID, key.Base.Kid)
 	}
-	teamLinkMap := make(linkMapT)
+	var teamLinkMap linkMapT
 	if state != nil {
+		teamLinkMap = make(linkMapT, len(state.Chain.LinkIDs))
 		// copy over the stored links
 		for k, v := range state.Chain.LinkIDs {
 			teamLinkMap[k] = v
 		}
+	} else {
+		teamLinkMap = make(linkMapT)
 	}
 	// add on the link that is being checked
 	teamLinkMap[link.Seqno()] = link.LinkID().Export()

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -161,8 +161,7 @@ var whitelistedTeamLinkSigs = []keybase1.SigID{
 	"e8279d7c73b8defab299094b73800262239e5a03812040ed381cc613a3db515622",
 }
 
-func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, teamLinkMap linkMapT, link *chainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap linkMapT, proofSet *proofSetT) {
-
+func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, link *chainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap linkMapT, proofSet *proofSetT) {
 	for _, okSigID := range whitelistedTeamLinkSigs {
 		if link.SigID().Equal(okSigID) {
 			// This proof is whitelisted, so don't check it.
@@ -170,7 +169,7 @@ func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID k
 		}
 	}
 
-	event1Link := newProofTerm(teamID.AsUserOrTeam(), link.SignatureMetadata(), teamLinkMap)
+	event1Link := newProofTerm(teamID.AsUserOrTeam(), link.SignatureMetadata(), nil)
 	event2Revoke := key.Base.Revocation
 	if event2Revoke != nil {
 		proofSet.AddNeededHappensBeforeProof(ctx, event1Link, newProofTerm(uid.AsUserOrTeam(), *event2Revoke, userLinkMap), "team link before user key revocation")
@@ -286,19 +285,7 @@ func (l *TeamLoader) loadUserAndKeyFromLinkInnerAndVerify(ctx context.Context, t
 	if !signedByKID.Equal(key.Base.Kid) {
 		return keybase1.UserVersion{}, libkb.NewWrongKidError(signedByKID, key.Base.Kid)
 	}
-	var teamLinkMap linkMapT
-	if state != nil {
-		teamLinkMap = make(linkMapT, len(state.Chain.LinkIDs))
-		// copy over the stored links
-		for k, v := range state.Chain.LinkIDs {
-			teamLinkMap[k] = v
-		}
-	} else {
-		teamLinkMap = make(linkMapT)
-	}
-	// add on the link that is being checked
-	teamLinkMap[link.Seqno()] = link.LinkID().Export()
-	l.addProofsForKeyInUserSigchain(ctx, teamID, teamLinkMap, link, signer.Uid, key, linkMap, proofSet)
+	l.addProofsForKeyInUserSigchain(ctx, teamID, link, signer.Uid, key, linkMap, proofSet)
 	return signer, nil
 }
 
@@ -346,9 +333,9 @@ func (l *TeamLoader) walkUpToAdmin(
 	return &TeamSigChainState{inner: team.Chain}, nil
 }
 
-func (l *TeamLoader) addProofsForAdminPermission(ctx context.Context, t keybase1.TeamSigChainState, link *chainLinkUnpacked, bookends proofTermBookends, proofSet *proofSetT) {
+func (l *TeamLoader) addProofsForAdminPermission(ctx context.Context, teamID keybase1.TeamID, link *chainLinkUnpacked, bookends proofTermBookends, proofSet *proofSetT) {
 	event1Promote := bookends.left
-	event2Link := newProofTerm(t.Id.AsUserOrTeam(), link.SignatureMetadata(), t.LinkIDs)
+	event2Link := newProofTerm(teamID.AsUserOrTeam(), link.SignatureMetadata(), nil)
 	event3Demote := bookends.right
 	proofSet.AddNeededHappensBeforeProof(ctx, event1Promote, event2Link, "became admin before team link")
 	if event3Demote != nil {
@@ -390,7 +377,7 @@ func (l *TeamLoader) verifyAdminPermissions(ctx context.Context,
 		signer.implicitAdmin = true
 	}
 
-	l.addProofsForAdminPermission(ctx, state.Chain, link, adminBookends, proofSet)
+	l.addProofsForAdminPermission(ctx, state.Chain.Id, link, adminBookends, proofSet)
 	return signer, nil
 }
 

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -288,8 +288,11 @@ func (l *TeamLoader) loadUserAndKeyFromLinkInnerAndVerify(ctx context.Context, t
 	}
 	var teamLinkMap linkMapT
 	if state != nil {
-		// xxx is it safe to take over the old state's link map?
-		teamLinkMap = state.Chain.LinkIDs
+		teamLinkMap = make(linkMapT, len(state.Chain.LinkIDs))
+		// copy over the stored links
+		for k, v := range state.Chain.LinkIDs {
+			teamLinkMap[k] = v
+		}
 	} else {
 		teamLinkMap = make(linkMapT)
 	}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -288,11 +288,8 @@ func (l *TeamLoader) loadUserAndKeyFromLinkInnerAndVerify(ctx context.Context, t
 	}
 	var teamLinkMap linkMapT
 	if state != nil {
-		teamLinkMap = make(linkMapT, len(state.Chain.LinkIDs))
-		// copy over the stored links
-		for k, v := range state.Chain.LinkIDs {
-			teamLinkMap[k] = v
-		}
+		// xxx is it safe to take over the old state's link map?
+		teamLinkMap = state.Chain.LinkIDs
 	} else {
 		teamLinkMap = make(linkMapT)
 	}

--- a/go/teams/proofs.go
+++ b/go/teams/proofs.go
@@ -12,6 +12,8 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
+// newProofTerm creates a new proof term.
+// `lm` can be nil (it is for teams since SetTeamLinkMap is used)
 func newProofTerm(i keybase1.UserOrTeamID, s keybase1.SignatureMetadata, lm linkMapT) proofTerm {
 	return proofTerm{leafID: i, sigMeta: s, linkMap: lm}
 }


### PR DESCRIPTION
Team link maps were being copied all over the place but in the end it would [just use](https://github.com/keybase/client/blob/master/go/teams/proofs.go#L244) the one from the [final chain](https://github.com/keybase/client/blob/master/go/teams/loader2.go#L594).

This was maybe 5% of cpu profile. For a load with warm upak but cold team.