### PR TITLE
Store chainlink revocations

### DIFF
--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -4,6 +4,7 @@
 package libkb
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -401,6 +402,10 @@ func (c *ChainLink) GetRevocations() []keybase1.SigID {
 		return nil
 	}
 	var ret []keybase1.SigID
+	if !bytes.Contains(payload, []byte("revoke")) {
+		c.revocationsCache = &ret
+		return nil
+	}
 	if s, err := jsonparser.GetString(payload, "body", "revoke", "sig_id"); err == nil {
 		if sigID, err := keybase1.SigIDFromString(s, true); err == nil {
 			ret = append(ret, sigID)

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -198,16 +198,17 @@ var badWhitespaceChainLinks = map[keybase1.SigID]string{
 
 type ChainLink struct {
 	Contextified
-	parent          *SigChain
-	id              LinkID
-	hashVerified    bool
-	sigVerified     bool
-	payloadVerified bool
-	chainVerified   bool
-	storedLocally   bool
-	revoked         bool
-	unsigned        bool
-	dirty           bool
+	parent           *SigChain
+	id               LinkID
+	hashVerified     bool
+	sigVerified      bool
+	payloadVerified  bool
+	chainVerified    bool
+	storedLocally    bool
+	revoked          bool
+	unsigned         bool
+	dirty            bool
+	revocationsCache *[]keybase1.SigID
 
 	unpacked *ChainLinkUnpacked
 	cki      *ComputedKeyInfos
@@ -392,6 +393,9 @@ func (c *ChainLink) GetRevocations() []keybase1.SigID {
 	if c.IsStubbed() {
 		return nil
 	}
+	if c.revocationsCache != nil {
+		return *c.revocationsCache
+	}
 	payload, err := c.unpacked.Payload()
 	if err != nil {
 		return nil
@@ -409,6 +413,7 @@ func (c *ChainLink) GetRevocations() []keybase1.SigID {
 		}
 	}, "body", "revoke", "sig_ids")
 
+	c.revocationsCache = &ret
 	return ret
 }
 


### PR DESCRIPTION
This saves 5% of cpu time spent during a cold load of keybasefriends.

Is this safe? I'm not sure what the memory rules are around this code.