### PR TITLE
Don't show a timestamp due to orange line above a message if we haven't loaded that message yet

### DIFF
--- a/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
@@ -13,7 +13,7 @@ type OwnProps = {
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   const lastReadMessageID = state.chat2.lastReadMessageMap.get(ownProps.message.conversationIDKey)
   // Show the orange line on the first message after the last read message
-  // Messages sent sent by you don't count
+  // Messages sent by you don't count
   const orangeLineAbove =
     !!ownProps.previous &&
     lastReadMessageID === ownProps.previous.id &&
@@ -34,7 +34,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const showTimestamp = Constants.enoughTimeBetweenMessages(_message, previous)
 
   const timestamp =
-    stateProps.orangeLineAbove || !previous || showTimestamp
+    (stateProps.orangeLineAbove && _message.timestamp) || !previous || showTimestamp
       ? formatTimeForMessages(_message.timestamp)
       : null
 


### PR DESCRIPTION
@keybase/react-hackers 

We were actually already testing whether a timestamp is non-zero when deciding whether to display it, in `Constants.enoughTimeBetweenMessages()`.  This bug appeared when we changed the logic to check for that function returning true *or* the orange line being above a message.  The bug appears when you're trying to load a new message but haven't got it yet, and so your orange line is above that message, and then we try to render a timestamp above that new message but haven't loaded its timestamp yet.

So this seems like the fix.  A bit difficult to test.