### PR TITLE
fix fuzzy qr in non retina in some cases

### DIFF
--- a/shared/provision/code-page/index.js
+++ b/shared/provision/code-page/index.js
@@ -189,7 +189,7 @@ const SwitchTab = (props: {|...Props, selected: Tab, onSelect: Tab => void|}) =>
 const Qr = (props: Props) =>
   props.currentDeviceType === 'desktop' ? (
     <Box2 direction="vertical" style={styles.qrOnlyContainer}>
-      <QRImage code={props.textCode} cellSize={5} />
+      <QRImage code={props.textCode} cellSize={6} />
     </Box2>
   ) : (
     <Box2

--- a/shared/provision/code-page/index.stories.js
+++ b/shared/provision/code-page/index.stories.js
@@ -5,7 +5,8 @@ import CodePage2 from '.'
 import QRScanNotAuthorized from './qr-scan/not-authorized'
 import {Box2} from '../../common-adapters'
 
-const textCode = 'scrub disagree sheriff holiday cabin habit mushroom member four'
+const textCodeShort = 'scrub disagree sheriff holiday cabin habit mushroom member'
+const textCodeLong = textCodeShort + ' four'
 // Not using the container on purpose since i want every variant
 const derivedProps = (
   currentDeviceAlreadyProvisioned,
@@ -27,7 +28,7 @@ const derivedProps = (
     onSubmitTextCode: Sb.action('onSubmitTextCode'),
     otherDeviceName,
     otherDeviceType,
-    textCode,
+    textCode: otherDeviceType === 'mobile' || currentDeviceType === 'mobile' ? textCodeLong : textCodeShort,
   }
 }
 

--- a/shared/provision/code-page/qr-image.js
+++ b/shared/provision/code-page/qr-image.js
@@ -2,31 +2,22 @@
 import * as React from 'react'
 import {Image} from '../../common-adapters'
 import QRCodeGen from 'qrcode-generator'
-import {styleSheetCreate} from '../../styles'
 
 type Props = {
   code: string,
-  cellSize: number,
+  cellSize: 4 | 6, // we ONLY allow even numbers else you'll get fractional pixels and it looks blurry
 }
 
 class QrImage extends React.PureComponent<Props> {
-  static defaultProps = {cellSize: 4} // this creates a 132x132 (so we can use retina) image
+  static defaultProps = {cellSize: 4}
   render() {
     const qr = QRCodeGen(4, 'L')
     qr.addData(this.props.code)
     qr.make()
-
+    const size = qr.getModuleCount() * (this.props.cellSize / 2) // retina
     const url = qr.createDataURL(this.props.cellSize, 0)
-    return <Image src={url} style={styles.image} />
+    return <Image src={url} style={{height: size, width: size}} />
   }
 }
-
-const styles = styleSheetCreate({
-  image: {
-    // actual qr size so it doesn't stretch
-    height: 66,
-    width: 66,
-  },
-})
 
 export default QrImage


### PR DESCRIPTION
@keybase/react-hackers this fixes fuzzy qr code on non retina screens. also updates the mock to know about 8/9 length qr codes
@keybase/react-hackers 