### PR TITLE
allow android video upload by adding an extra menu to specify image/video CORE-8489

### DIFF
--- a/go/chat/attachments/mime_types.go
+++ b/go/chat/attachments/mime_types.go
@@ -79,6 +79,7 @@ var mimeTypes = map[string]string{
 	".pptx":    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 	".prc":     "application/x-pilot",
 	".ps":      "application/postscript",
+	".qt":      "video/quicktime",
 	".ra":      "audio/x-realaudio",
 	".rar":     "application/x-rar-compressed",
 	".rpm":     "application/x-redhat-package-manager",

--- a/shared/chat/conversation/input-area/filepicker-popup/index.desktop.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.desktop.js
@@ -1,0 +1,5 @@
+// @flow
+
+const FilePickerPopup = () => null
+
+export default FilePickerPopup

--- a/shared/chat/conversation/input-area/filepicker-popup/index.js.flow
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.js.flow
@@ -1,0 +1,4 @@
+// @flow
+import * as React from 'react'
+import type {Props} from './index.types'
+declare export default class FilePickerPopup extends React.Component<Props> {}

--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.js
@@ -1,11 +1,12 @@
 // @flow
 import * as React from 'react'
-import {Box2, Text, FloatingPicker} from '../../../../common-adapters/mobile.native'
+import {FloatingMenu} from '../../../../common-adapters'
+import {Box2, Text} from '../../../../common-adapters/mobile.native'
 import type {Props} from './index.types'
 
 const Prompt = () => (
   <Box2 direction="horizontal" fullWidth={true} gap="xtiny" style={promptContainerStyle}>
-    <Text type="BodySmallSemibold">Select type of attachment:</Text>
+    <Text type="BodySmallSemibold">Select Attachment Type</Text>
   </Box2>
 )
 
@@ -14,37 +15,29 @@ const promptContainerStyle = {
   justifyContent: 'center',
 }
 
-type State = {selected: string}
-class FilePickerPopup extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props)
-    this.state = {selected: 'photo'}
+class FilePickerPopup extends React.Component<Props> {
+  onImage = () => {
+    this.props.onSelect('photo')
   }
 
-  setSelected = (value: number | string) => {
-    if (typeof value === 'number') {
-      return
-    }
-    this.setState({selected: value})
-  }
-
-  onDone = () => {
-    this.props.onSelect(this.state.selected)
-    this.props.onHidden()
+  onVideo = () => {
+    this.props.onSelect('video')
   }
 
   render() {
-    const items = [{label: 'Send an image', value: 'photo'}, {label: 'Send a video', value: 'video'}]
+    const items = [...[{onClick: this.onImage, title: 'Photo'}], ...[{onClick: this.onVideo, title: 'Video'}]]
+    const header = {
+      title: 'header',
+      view: <Prompt />,
+    }
     return (
-      <FloatingPicker
+      <FloatingMenu
+        header={header}
+        attachTo={this.props.attachTo}
         items={items}
-        onSelect={this.setSelected}
         onHidden={this.props.onHidden}
-        onCancel={this.props.onHidden}
-        onDone={this.onDone}
-        prompt={<Prompt />}
         visible={this.props.visible}
-        selectedValue={this.state.selected}
+        closeOnSelect={true}
       />
     )
   }

--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.js
@@ -1,0 +1,60 @@
+// @flow
+import * as React from 'react'
+import {Box2, Text, FloatingPicker} from '../../../../common-adapters/mobile.native'
+import type {Props} from './index.types'
+
+const Prompt = () => (
+  <Box2 direction="horizontal" fullWidth={true} gap="xtiny" style={promptContainerStyle}>
+    <Text type="BodySmallSemibold">Select type of attachment:</Text>
+  </Box2>
+)
+
+const promptContainerStyle = {
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+type State = {selected: string}
+class FilePickerPopup extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {selected: props.selected || 'photo'}
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.selected !== prevProps.selected) {
+      this.setState({selected: this.props.selected || 'photo'})
+    }
+  }
+
+  setSelected = (value: number | string) => {
+    if (typeof value === 'number') {
+      return
+    }
+    this.setState({selected: value})
+  }
+
+  onDone = () => {
+    this.props.onSelect(this.state.selected)
+    this.props.onHidden()
+  }
+
+  render() {
+    const items = [{label: 'Send an image', value: 'photo'}, {label: 'Send a video', value: 'video'}]
+    return (
+      <FloatingPicker
+        items={items}
+        onSelect={this.setSelected}
+        onHidden={this.props.onHidden}
+        onCancel={this.props.onHidden}
+        onDone={this.onDone}
+        prompt={<Prompt />}
+        promptString="Pick a timeout"
+        visible={this.props.visible}
+        selectedValue={this.state.selected}
+      />
+    )
+  }
+}
+
+export default FilePickerPopup

--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.js
@@ -18,13 +18,7 @@ type State = {selected: string}
 class FilePickerPopup extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = {selected: props.selected || 'photo'}
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (this.props.selected !== prevProps.selected) {
-      this.setState({selected: this.props.selected || 'photo'})
-    }
+    this.state = {selected: 'photo'}
   }
 
   setSelected = (value: number | string) => {
@@ -49,7 +43,6 @@ class FilePickerPopup extends React.Component<Props, State> {
         onCancel={this.props.onHidden}
         onDone={this.onDone}
         prompt={<Prompt />}
-        promptString="Pick a timeout"
         visible={this.props.visible}
         selectedValue={this.state.selected}
       />

--- a/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
@@ -5,6 +5,5 @@ export type Props = {
   attachTo: ?React.Component<any, any>,
   visible: boolean,
   onHidden: () => void,
-  selected: string,
   onSelect: string => void,
 }

--- a/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
@@ -1,0 +1,10 @@
+// @flow
+import * as React from 'react'
+
+export type Props = {
+  attachTo: ?React.Component<any, any>,
+  visible: boolean,
+  onHidden: () => void,
+  selected: string,
+  onSelect: string => void,
+}

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -136,7 +136,6 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
             visible={this.props.showingMenu}
             onHidden={this.props.toggleShowingMenu}
             onSelect={this._showNativeImagePicker}
-            selected="photo"
           />
         ) : (
           <SetExplodingMessagePicker

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -59,7 +59,18 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
   }
 
   _showNativeImagePicker = (mediaType: string) => {
-    showImagePicker({mediaType}, response => {
+    let title = 'Select a Photo'
+    switch (mediaType) {
+      case 'photo':
+        break
+      case 'mixed':
+        title = 'Select a Photo or Video'
+        break
+      case 'video':
+        title = 'Select a Video'
+        break
+    }
+    showImagePicker({mediaType, title}, response => {
       if (response.didCancel || !this.props.conversationIDKey) {
         return
       }

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -30,7 +30,6 @@ type menuType = 'exploding' | 'filepickerpopup'
 
 type State = {
   hasText: boolean,
-  showFilePickerPopup: boolean,
 }
 
 class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, State> {
@@ -41,7 +40,6 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
     super(props)
     this.state = {
       hasText: false,
-      showFilePickerPopup: false,
     }
   }
 

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -60,17 +60,20 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
 
   _showNativeImagePicker = (mediaType: string) => {
     let title = 'Select a Photo'
+    let takePhotoButtonTitle = 'Take Photo...'
     switch (mediaType) {
       case 'photo':
         break
       case 'mixed':
         title = 'Select a Photo or Video'
+        takePhotoButtonTitle = 'Take Photo or Video...'
         break
       case 'video':
         title = 'Select a Video'
+        takePhotoButtonTitle = 'Take Video...'
         break
     }
-    showImagePicker({mediaType, title}, response => {
+    showImagePicker({mediaType, title, takePhotoButtonTitle}, response => {
       if (response.didCancel || !this.props.conversationIDKey) {
         return
       }


### PR DESCRIPTION
`react-native-image-picker` doesn't allow `mixed` mode for Android like it does for iOS, so selecting video vs. photo is a little tricker. This patch adds an extra screen after clicking the photo attachment to allow the user to specify image vs. video, and puts the picker into the mode they select. 

@keybase/react-hackers 