### PR TITLE
Fix phone number style on desktop

### DIFF
--- a/shared/common-adapters/markdown.desktop.js
+++ b/shared/common-adapters/markdown.desktop.js
@@ -145,10 +145,15 @@ function messageCreateComponent(type, key, children, options) {
         </Text>
       )
     case 'text-block':
-    case 'phone':
       return (
         <Text type="Body" key={key} style={textBlockStyle}>
           {children && children.length ? children : '\u200b'}
+        </Text>
+      )
+    case 'phone':
+      return (
+        <Text type="Body" key={key} style={wrapStyle}>
+          {children}
         </Text>
       )
     case 'bold':


### PR DESCRIPTION
They were mistakenly using a block-display style.