### PR TITLE
IncomingMessage local and remote

### DIFF
--- a/go/chat/push_test.go
+++ b/go/chat/push_test.go
@@ -87,14 +87,13 @@ func TestPushOrdering(t *testing.T) {
 	tc := world.Tcs[u.Username]
 	handler := NewPushHandler(tc.Context())
 	handler.SetClock(world.Fc)
-	list.remoteActivityOnly = true
 
 	conv := newBlankConv(ctx, t, tc, uid, ri, sender, u.Username)
 	sendSimple(ctx, t, tc, handler, sender, conv, u,
 		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 1 })
 
 	select {
-	case <-list.incoming:
+	case <-list.incomingRemote:
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no notification received")
 	}
@@ -102,7 +101,7 @@ func TestPushOrdering(t *testing.T) {
 	sendSimple(ctx, t, tc, handler, sender, conv, u,
 		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 2 })
 	select {
-	case <-list.incoming:
+	case <-list.incomingRemote:
 		require.Fail(t, "should not have gotten one of these")
 	default:
 	}
@@ -110,12 +109,12 @@ func TestPushOrdering(t *testing.T) {
 	sendSimple(ctx, t, tc, handler, sender, conv, u,
 		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 1 })
 	select {
-	case <-list.incoming:
+	case <-list.incomingRemote:
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no notification received")
 	}
 	select {
-	case <-list.incoming:
+	case <-list.incomingRemote:
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no notification received")
 	}
@@ -126,7 +125,7 @@ func TestPushOrdering(t *testing.T) {
 	sendSimple(ctx, t, tc, handler, sender, conv, u,
 		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 2 })
 	select {
-	case <-list.incoming:
+	case <-list.incomingRemote:
 		require.Fail(t, "should not have gotten one of these")
 	default:
 	}
@@ -134,7 +133,7 @@ func TestPushOrdering(t *testing.T) {
 	t.Logf("advancing clock")
 	world.Fc.Advance(time.Hour)
 	select {
-	case <-list.incoming:
+	case <-list.incomingRemote:
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no notification received")
 	}
@@ -159,7 +158,7 @@ func TestPushAppState(t *testing.T) {
 	sendSimple(ctx, t, tc, handler, sender, conv, u,
 		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 1 })
 	select {
-	case <-list.incoming:
+	case <-list.incomingRemote:
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no message received")
 	}
@@ -167,7 +166,7 @@ func TestPushAppState(t *testing.T) {
 	sendSimple(ctx, t, tc, handler, sender, conv, u,
 		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 1 })
 	select {
-	case <-list.incoming:
+	case <-list.incomingRemote:
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no message received")
 	}

--- a/go/chat/sbs_test.go
+++ b/go/chat/sbs_test.go
@@ -127,8 +127,7 @@ func TestChatSrvSBS(t *testing.T) {
 					Body: "HI",
 				}), ephemeralLifetime)
 			require.NoError(t, err)
-			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
-			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
+			consumeNewMsgRemote(t, listener0, chat1.MessageType_TEXT)
 
 			_, err = postLocalEphemeralForTest(t, ctc, users[1], ncres.Conv.Info,
 				chat1.NewMessageBodyWithText(chat1.MessageText{
@@ -163,17 +162,15 @@ func TestChatSrvSBS(t *testing.T) {
 				chat1.NewMessageBodyWithText(chat1.MessageText{
 					Body: "HI",
 				}), ephemeralLifetime)
-			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
-			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
-			consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
+			consumeNewMsgRemote(t, listener0, chat1.MessageType_TEXT)
+			consumeNewMsgRemote(t, listener1, chat1.MessageType_TEXT)
 
 			mustPostLocalEphemeralForTest(t, ctc, users[1], ncres.Conv.Info,
 				chat1.NewMessageBodyWithText(chat1.MessageText{
 					Body: "HI",
 				}), ephemeralLifetime)
-			consumeNewMsg(t, listener0, chat1.MessageType_TEXT)
-			consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
-			consumeNewMsg(t, listener1, chat1.MessageType_TEXT)
+			consumeNewMsgRemote(t, listener0, chat1.MessageType_TEXT)
+			consumeNewMsgRemote(t, listener1, chat1.MessageType_TEXT)
 			verifyThread := func(user *kbtest.FakeUser) {
 				tvres, err := ctc.as(t, user).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
 					ConversationID: ncres.Conv.GetConvID(),

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -110,7 +110,6 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 							panic("timeout on the incomingLocal channel")
 						}
 					}
-
 				}
 			}
 		case chat1.ChatActivityType_FAILED_MESSAGE:

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -29,11 +29,11 @@ type chatListener struct {
 	sync.Mutex
 	libkb.NoopNotifyListener
 
-	remoteActivityOnly bool
-
 	// ChatActivity channels
-	obids          []chat1.OutboxID
-	incoming       chan int
+	obidsLocal     []chat1.OutboxID
+	obidsRemote    []chat1.OutboxID
+	incomingLocal  chan int
+	incomingRemote chan int
 	failing        chan []chat1.OutboxRecord
 	identifyUpdate chan keybase1.CanonicalTLFNameAndIDWithBreaks
 	inboxStale     chan struct{}
@@ -90,17 +90,27 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 	if err == nil {
 		switch typ {
 		case chat1.ChatActivityType_INCOMING_MESSAGE:
-			if activity.IncomingMessage().Message.IsValid() &&
-				(!n.remoteActivityOnly || source == chat1.ChatActivitySource_REMOTE) {
+			if activity.IncomingMessage().Message.IsValid() {
 				strOutboxID := activity.IncomingMessage().Message.Valid().OutboxID
 				if strOutboxID != nil {
 					outboxID, _ := hex.DecodeString(*strOutboxID)
-					n.obids = append(n.obids, chat1.OutboxID(outboxID))
-					select {
-					case n.incoming <- len(n.obids):
-					case <-time.After(5 * time.Second):
-						panic("timeout on the incoming channel")
+					switch source {
+					case chat1.ChatActivitySource_REMOTE:
+						n.obidsRemote = append(n.obidsRemote, chat1.OutboxID(outboxID))
+						select {
+						case n.incomingRemote <- len(n.obidsRemote):
+						case <-time.After(5 * time.Second):
+							panic("timeout on the incomingRemote channel")
+						}
+					case chat1.ChatActivitySource_LOCAL:
+						n.obidsLocal = append(n.obidsLocal, chat1.OutboxID(outboxID))
+						select {
+						case n.incomingLocal <- len(n.obidsLocal):
+						case <-time.After(5 * time.Second):
+							panic("timeout on the incomingLocal channel")
+						}
 					}
+
 				}
 			}
 		case chat1.ChatActivityType_FAILED_MESSAGE:
@@ -201,7 +211,8 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	baseSender.SetClock(world.Fc)
 	sender := NewNonblockingSender(g, baseSender)
 	listener := chatListener{
-		incoming:       make(chan int, 100),
+		incomingLocal:  make(chan int, 100),
+		incomingRemote: make(chan int, 100),
 		failing:        make(chan []chat1.OutboxRecord, 100),
 		identifyUpdate: make(chan keybase1.CanonicalTLFNameAndIDWithBreaks, 10),
 		inboxStale:     make(chan struct{}, 1),
@@ -289,13 +300,13 @@ func TestNonblockChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	select {
-	case <-listener.incoming:
+	case <-listener.incomingRemote:
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "event not received")
 	}
 
-	require.Equal(t, 1, len(listener.obids), "wrong length")
-	require.Equal(t, obid, listener.obids[0], "wrong obid")
+	require.Equal(t, 1, len(listener.obidsRemote), "wrong length")
+	require.Equal(t, obid, listener.obidsRemote[0], "wrong obid")
 }
 
 type sentRecord struct {
@@ -400,7 +411,7 @@ func TestNonblockTimer(t *testing.T) {
 
 	// Make we get nothing until timer is up
 	select {
-	case <-listener.incoming:
+	case <-listener.incomingRemote:
 		require.Fail(t, "action event received too soon")
 	default:
 	}
@@ -444,22 +455,22 @@ func TestNonblockTimer(t *testing.T) {
 	// Should get a blast of all 5
 
 	var olen int
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		select {
-		case olen = <-listener.incoming:
+		case olen = <-listener.incomingRemote:
 		case <-time.After(20 * time.Second):
 			require.Fail(t, "event not received")
 		}
 
-		t.Logf("OUTBOXID: %s", obids[i/2])
+		t.Logf("OUTBOXID: %s", obids[i])
 		require.Equal(t, i+1, olen, "wrong length")
-		require.Equal(t, listener.obids[i], obids[i/2], "wrong obid")
+		require.Equal(t, listener.obidsRemote[i], obids[i], "wrong obid")
 	}
 
 	// Make sure it is really empty
 	clock.Advance(5 * time.Minute)
 	select {
-	case <-listener.incoming:
+	case <-listener.incomingRemote:
 		require.Fail(t, "action event received too soon")
 	default:
 	}
@@ -587,7 +598,7 @@ func TestOutboxItemExpiration(t *testing.T) {
 		require.Fail(t, "no failing message")
 	}
 	select {
-	case <-listener.incoming:
+	case <-listener.incomingRemote:
 		require.Fail(t, "no incoming message")
 	default:
 	}
@@ -598,7 +609,7 @@ func TestOutboxItemExpiration(t *testing.T) {
 	require.NoError(t, err)
 	tc.ChatG.MessageDeliverer.ForceDeliverLoop(ctx)
 	select {
-	case i := <-listener.incoming:
+	case i := <-listener.incomingRemote:
 		require.Equal(t, 1, i)
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no success")
@@ -648,16 +659,14 @@ func TestDisconnectedFailure(t *testing.T) {
 	default:
 	}
 	tc.ChatG.MessageDeliverer.Connected(ctx)
-	for i := 0; i < 2; i++ {
-		select {
-		case inc := <-listener.incoming:
-			require.Equal(t, i+1, inc)
-			require.Equal(t, obid, listener.obids[0])
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "no incoming message")
-		}
+	select {
+	case inc := <-listener.incomingRemote:
+		require.Equal(t, 1, inc)
+		require.Equal(t, obid, listener.obidsRemote[0])
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no incoming message")
 	}
-	listener.obids = nil
+	listener.obidsRemote = nil
 
 	tc.ChatG.MessageDeliverer.Disconnected(ctx)
 	tc.ChatG.MessageDeliverer.(*Deliverer).SetSender(FailingSender{})
@@ -719,8 +728,8 @@ func TestDisconnectedFailure(t *testing.T) {
 
 	for {
 		select {
-		case inc := <-listener.incoming:
-			if inc >= 2*len(obids) {
+		case inc := <-listener.incomingRemote:
+			if inc >= len(obids) {
 				break
 			}
 			continue
@@ -729,10 +738,8 @@ func TestDisconnectedFailure(t *testing.T) {
 		}
 		break
 	}
-	require.Equal(t, 2*len(obids), len(listener.obids), "wrong amount of successes")
-	for index, obid := range listener.obids {
-		require.Equal(t, obid, obids[index/2])
-	}
+	require.Equal(t, len(obids), len(listener.obidsRemote), "wrong amount of successes")
+	require.Equal(t, listener.obidsRemote, obids)
 }
 
 // The sender is responsible for making sure that a deletion of a single
@@ -1497,7 +1504,7 @@ func TestProcessDuplicateReactionMsgs(t *testing.T) {
 
 	// Make we get nothing until timer is up
 	select {
-	case <-listener.incoming:
+	case <-listener.incomingLocal:
 		require.Fail(t, "action event received too soon")
 	case <-listener.failing:
 		require.Fail(t, "failed message")
@@ -1508,21 +1515,19 @@ func TestProcessDuplicateReactionMsgs(t *testing.T) {
 	// Since we canceled all of the other outbox records we should should only
 	// get one hit here.
 	var olen int
-	for i := 0; i < 2; i++ {
-		select {
-		case olen = <-listener.incoming:
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "event not received")
-		}
-
-		require.Equal(t, i+1, olen, "wrong length")
-		require.Equal(t, listener.obids[i], obids[i/2], "wrong obid")
+	select {
+	case olen = <-listener.incomingLocal:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "event not received")
 	}
+
+	require.Equal(t, 1, olen, "wrong length")
+	require.Equal(t, listener.obidsLocal[0], obids[0], "wrong obid")
 
 	// Make sure it is really empty
 	clock.Advance(5 * time.Minute)
 	select {
-	case <-listener.incoming:
+	case <-listener.incomingLocal:
 		require.Fail(t, "action event received too soon")
 	default:
 	}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3935,7 +3935,6 @@ func TestChatSrvRetentionSweepTeam(t *testing.T) {
 }
 
 func TestChatSrvSetConvMinWriterRole(t *testing.T) {
-	t.Skip("not passing locally")
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		// Only run this test for teams
 		switch mt {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2218,7 +2218,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			case <-time.After(20 * time.Second):
 				require.Fail(t, "no event received")
 			}
-			consumeNewMsgRemote(t, listener, chat1.MessageType_DELETE)
+			consumeNewMsgLocal(t, listener, chat1.MessageType_DELETE)
 			switch mt {
 			case chat1.ConversationMembersType_KBFS:
 			default:


### PR DESCRIPTION
Separates incoming messages by ChatActivity source to clean up testing code and help prevent races and CI flakes.

This also re-enables the `TestChatSrvSetConvMinWriterRole`, @patrickxb lmk if this still fails locally for you after the patch