### PR TITLE
use floating menu exclusively for selecting attachment type

### DIFF
--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import {FloatingMenu} from '../../../../common-adapters'
 import {Box2, Text} from '../../../../common-adapters/mobile.native'
 import type {Props} from './index.types'
+import {isIOS} from '../../../../constants/platform'
 
 const Prompt = () => (
   <Box2 direction="horizontal" fullWidth={true} gap="xtiny" style={promptContainerStyle}>
@@ -16,16 +17,61 @@ const promptContainerStyle = {
 }
 
 class FilePickerPopup extends React.Component<Props> {
-  onImage = () => {
-    this.props.onSelect('photo')
-  }
-
-  onVideo = () => {
-    this.props.onSelect('video')
-  }
-
   render() {
-    const items = [...[{onClick: this.onImage, title: 'Photo'}], ...[{onClick: this.onVideo, title: 'Video'}]]
+    const items = isIOS
+      ? [
+          ...[
+            {
+              onClick: () => {
+                this.props.onSelect('photo', 'camera')
+              },
+              title: 'Take Photo',
+            },
+          ],
+          ...[
+            {
+              onClick: () => {
+                this.props.onSelect('mixed', 'library')
+              },
+              title: 'Photo or Video from Library',
+            },
+          ],
+        ]
+      : [
+          ...[
+            {
+              onClick: () => {
+                this.props.onSelect('photo', 'camera')
+              },
+              title: 'Take Photo',
+            },
+          ],
+          ...[
+            {
+              onClick: () => {
+                this.props.onSelect('photo', 'library')
+              },
+              title: 'Photo from Library',
+            },
+          ],
+          'Divider',
+          ...[
+            {
+              onClick: () => {
+                this.props.onSelect('video', 'camera')
+              },
+              title: 'Take Video',
+            },
+          ],
+          ...[
+            {
+              onClick: () => {
+                this.props.onSelect('video', 'library')
+              },
+              title: 'Video from Library',
+            },
+          ],
+        ]
     const header = {
       title: 'header',
       view: <Prompt />,

--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.js
@@ -20,56 +20,44 @@ class FilePickerPopup extends React.Component<Props> {
   render() {
     const items = isIOS
       ? [
-          ...[
-            {
-              onClick: () => {
-                this.props.onSelect('photo', 'camera')
-              },
-              title: 'Take Photo',
+          {
+            onClick: () => {
+              this.props.onSelect('photo', 'camera')
             },
-          ],
-          ...[
-            {
-              onClick: () => {
-                this.props.onSelect('mixed', 'library')
-              },
-              title: 'Photo or Video from Library',
+            title: 'Take Photo',
+          },
+          {
+            onClick: () => {
+              this.props.onSelect('mixed', 'library')
             },
-          ],
+            title: 'Photo or Video from Library',
+          },
         ]
       : [
-          ...[
-            {
-              onClick: () => {
-                this.props.onSelect('photo', 'camera')
-              },
-              title: 'Take Photo',
+          {
+            onClick: () => {
+              this.props.onSelect('photo', 'camera')
             },
-          ],
-          ...[
-            {
-              onClick: () => {
-                this.props.onSelect('video', 'camera')
-              },
-              title: 'Take Video',
+            title: 'Take Photo',
+          },
+          {
+            onClick: () => {
+              this.props.onSelect('video', 'camera')
             },
-          ],
-          ...[
-            {
-              onClick: () => {
-                this.props.onSelect('photo', 'library')
-              },
-              title: 'Photo from Library',
+            title: 'Take Video',
+          },
+          {
+            onClick: () => {
+              this.props.onSelect('photo', 'library')
             },
-          ],
-          ...[
-            {
-              onClick: () => {
-                this.props.onSelect('video', 'library')
-              },
-              title: 'Video from Library',
+            title: 'Photo from Library',
+          },
+          {
+            onClick: () => {
+              this.props.onSelect('video', 'library')
             },
-          ],
+            title: 'Video from Library',
+          },
         ]
     const header = {
       title: 'header',

--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.js
@@ -49,18 +49,17 @@ class FilePickerPopup extends React.Component<Props> {
           ...[
             {
               onClick: () => {
-                this.props.onSelect('photo', 'library')
-              },
-              title: 'Photo from Library',
-            },
-          ],
-          'Divider',
-          ...[
-            {
-              onClick: () => {
                 this.props.onSelect('video', 'camera')
               },
               title: 'Take Video',
+            },
+          ],
+          ...[
+            {
+              onClick: () => {
+                this.props.onSelect('photo', 'library')
+              },
+              title: 'Photo from Library',
             },
           ],
           ...[

--- a/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
@@ -5,5 +5,5 @@ export type Props = {
   attachTo: ?React.Component<any, any>,
   visible: boolean,
   onHidden: () => void,
-  onSelect: (string, string) => void,
+  onSelect: (mediaType: string, location: string) => void,
 }

--- a/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
@@ -5,5 +5,5 @@ export type Props = {
   attachTo: ?React.Component<any, any>,
   visible: boolean,
   onHidden: () => void,
-  onSelect: (mediaType: string, location: string) => void,
+  onSelect: (mediaType: 'photo' | 'video' | 'mixed', location: 'camera' | 'library') => void,
 }

--- a/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
@@ -5,5 +5,5 @@ export type Props = {
   attachTo: ?React.Component<any, any>,
   visible: boolean,
   onHidden: () => void,
-  onSelect: string => void,
+  onSelect: (string, string) => void,
 }


### PR DESCRIPTION
@keybase/react-hackers 

Since taking video on iOS is broken in `react-native-image-picker` (it doesn't get the right set of perms), the easiest path forward is to just not allow it for now. This patch dumps invoking the native control from `showImagePicker` and just uses `FloatingMenu` for everything, taking advantage of `launchCamera` and `launchImageLibrary`. The Android experience is now improved, and I think the whole thing feels faster (the native popup on Android was pretty sluggish, this new deal just feels snappier). Here is what it looks like when you tap the camera icon on both platforms:

iOS:
![image](https://user-images.githubusercontent.com/1250314/43681728-71efb1fe-982a-11e8-9f01-ac39d3cc3132.png)

Android:
![image](https://user-images.githubusercontent.com/1250314/43681729-8aa79086-982a-11e8-9715-6f682751b747.png)
