### PR TITLE
cancel uploads properly when user cancels attachment send CORE-8431

### DIFF
--- a/go/chat/attachments/uploader_test.go
+++ b/go/chat/attachments/uploader_test.go
@@ -142,7 +142,8 @@ func TestAttachmentUploader(t *testing.T) {
 			}
 		}
 	}
-	successCheck := func(ch chan types.AttachmentUploadResult) {
+	successCheck := func(cb types.AttachmentUploaderResultCb) {
+		ch := cb.Wait()
 		select {
 		case res := <-ch:
 			require.Nil(t, res.Error)
@@ -168,7 +169,7 @@ func TestAttachmentUploader(t *testing.T) {
 	require.NoError(t, err)
 	uploadStartCheck(true, outboxID)
 	select {
-	case res := <-resChan:
+	case res := <-resChan.Wait():
 		require.NotNil(t, res.Error)
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no upload")
@@ -198,7 +199,7 @@ func TestAttachmentUploader(t *testing.T) {
 	uploadStartCheck(true, outboxID)
 	deliverCheck(false)
 	select {
-	case <-resChan:
+	case <-resChan.Wait():
 		require.Fail(t, "no res")
 	default:
 	}
@@ -232,7 +233,7 @@ func TestAttachmentUploader(t *testing.T) {
 	uploadStartCheck(true, outboxID)
 	deliverCheck(false)
 	select {
-	case <-resChan:
+	case <-resChan.Wait():
 		require.Fail(t, "no res")
 	default:
 	}
@@ -240,7 +241,7 @@ func TestAttachmentUploader(t *testing.T) {
 	_, _, err = uploader.Status(context.TODO(), outboxID)
 	require.Error(t, err)
 	select {
-	case res := <-resChan:
+	case res := <-resChan.Wait():
 		require.NotNil(t, res.Error)
 	}
 }

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1606,7 +1606,6 @@ func (h *Server) CancelPost(ctx context.Context, outboxID chat1.OutboxID) (err e
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return err
 	}
-
 	uid := h.G().Env.GetUID()
 	outbox := storage.NewOutbox(h.G(), uid.ToBytes())
 	if err := outbox.RemoveMessage(ctx, outboxID); err != nil {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1447,13 +1447,13 @@ func (h *Server) PostFileAttachmentLocal(ctx context.Context, arg chat1.PostFile
 		return res, err
 	}
 	// Start upload
-	uresChan, err := h.G().AttachmentUploader.Register(ctx, uid, arg.Arg.ConversationID,
+	uresCb, err := h.G().AttachmentUploader.Register(ctx, uid, arg.Arg.ConversationID,
 		outboxID, arg.Arg.Title, arg.Arg.Filename, arg.Arg.Metadata, arg.Arg.CallerPreview)
 	if err != nil {
 		return res, err
 	}
 	// Wait for upload
-	ures := <-uresChan
+	ures := <-uresCb.Wait()
 	if ures.Error != nil {
 		h.Debug(ctx, "postAttachmentLocal: upload failed, bailing out: %s", *ures.Error)
 		return res, errors.New(*ures.Error)

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1609,7 +1609,11 @@ func (h *Server) CancelPost(ctx context.Context, outboxID chat1.OutboxID) (err e
 
 	uid := h.G().Env.GetUID()
 	outbox := storage.NewOutbox(h.G(), uid.ToBytes())
-	return outbox.RemoveMessage(ctx, outboxID)
+	if err := outbox.RemoveMessage(ctx, outboxID); err != nil {
+		return err
+	}
+	// Alert the attachment uploader as well, in case this outboxID corresponds to an attachment upload
+	return h.G().AttachmentUploader.Cancel(ctx, outboxID)
 }
 
 func (h *Server) RetryPost(ctx context.Context, arg chat1.RetryPostArg) (err error) {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -310,6 +310,7 @@ type AttachmentUploader interface {
 		callerPreview *chat1.MakePreviewRes) (chan AttachmentUploadResult, error)
 	Status(ctx context.Context, outboxID chat1.OutboxID) (AttachmentUploaderTaskStatus, AttachmentUploadResult, error)
 	Retry(ctx context.Context, outboxID chat1.OutboxID) (chan AttachmentUploadResult, error)
+	Cancel(ctx context.Context, outboxID chat1.OutboxID) error
 	Complete(ctx context.Context, outboxID chat1.OutboxID)
 }
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -304,12 +304,16 @@ type EphemeralPurger interface {
 	Queue(ctx context.Context, purgeInfo chat1.EphemeralPurgeInfo) error
 }
 
+type AttachmentUploaderResultCb interface {
+	Wait() chan AttachmentUploadResult
+}
+
 type AttachmentUploader interface {
 	Register(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
 		outboxID chat1.OutboxID, title, filename string, metadata []byte,
-		callerPreview *chat1.MakePreviewRes) (chan AttachmentUploadResult, error)
+		callerPreview *chat1.MakePreviewRes) (AttachmentUploaderResultCb, error)
 	Status(ctx context.Context, outboxID chat1.OutboxID) (AttachmentUploaderTaskStatus, AttachmentUploadResult, error)
-	Retry(ctx context.Context, outboxID chat1.OutboxID) (chan AttachmentUploadResult, error)
+	Retry(ctx context.Context, outboxID chat1.OutboxID) (AttachmentUploaderResultCb, error)
 	Cancel(ctx context.Context, outboxID chat1.OutboxID) error
 	Complete(ctx context.Context, outboxID chat1.OutboxID)
 }


### PR DESCRIPTION
Patch does the following:

1.) Adds a new method to `Uploader`, `Cancel`, which will stop uploading the attachment identified by `outboxID`.
2.) Store the upload context and cancel function in the uploads map.
3.) Adds `uploaderResult`, which generates a new result channel for each potentially different caller of `uploader`. This is relevant for `Retry` and `Cancel` which wait on the result channel, along with the original caller of `Register`. This way they all get the callback properly, not just one of them.
4.) Hook up the new `Cancel` to `CancelPost`.