### PR TITLE
don't compute a plaintext hash anymore for uploads, use outboxID for stash CORE-8432

### DIFF
--- a/go/chat/attachments/s3.go
+++ b/go/chat/attachments/s3.go
@@ -119,6 +119,8 @@ func (a *S3Store) putMultiPipeline(ctx context.Context, r io.Reader, size int64,
 		list, err := multi.ListParts(ctx)
 		if err != nil {
 			a.Debug(ctx, "putMultiPipeline: ignoring multi.ListParts error: %s", err)
+			// dump previous since we can't check it anymore
+			previous = nil
 		} else {
 			for _, p := range list {
 				previousParts[p.N] = p

--- a/go/chat/attachments/stash.go
+++ b/go/chat/attachments/stash.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/keybase/client/go/chat/signencrypt"
 	"github.com/keybase/client/go/protocol/chat1"
-	"github.com/keybase/client/go/protocol/gregor1"
 )
 
 type AttachmentInfo struct {
@@ -24,21 +23,19 @@ type AttachmentInfo struct {
 }
 
 type StashKey struct {
-	PlaintextHash  []byte
-	ConversationID chat1.ConversationID
-	UserID         gregor1.UID
+	OutboxID chat1.OutboxID
+	Preview  bool
+}
+
+func NewStashKey(outboxID chat1.OutboxID, preview bool) StashKey {
+	return StashKey{
+		OutboxID: outboxID,
+		Preview:  preview,
+	}
 }
 
 func (s StashKey) String() string {
-	return fmt.Sprintf("%x:%x:%s", s.PlaintextHash, s.ConversationID, s.UserID)
-}
-
-func NewStashKey(plaintextHash []byte, cid chat1.ConversationID, uid gregor1.UID) StashKey {
-	return StashKey{
-		PlaintextHash:  plaintextHash,
-		ConversationID: cid,
-		UserID:         uid,
-	}
+	return fmt.Sprintf("%s:%v", s.OutboxID, s.Preview)
 }
 
 type AttachmentStash interface {

--- a/go/chat/attachments/store.go
+++ b/go/chat/attachments/store.go
@@ -1,6 +1,7 @@
 package attachments
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"errors"
@@ -31,29 +32,33 @@ type UploadTask struct {
 	Filename       string
 	FileSize       int
 	Plaintext      ReadResetter
-	plaintextHash  []byte
+	taskHash       []byte
 	S3Signer       s3.Signer
 	ConversationID chat1.ConversationID
 	UserID         gregor1.UID
+	OutboxID       chat1.OutboxID
+	Preview        bool
 	Progress       types.ProgressReporter
 }
 
-func (u *UploadTask) computePlaintextHash() error {
-	plaintextHasher := sha256.New()
-	io.Copy(plaintextHasher, u.Plaintext)
-	u.plaintextHash = plaintextHasher.Sum(nil)
+func (u *UploadTask) computeHash() {
+	hasher := sha256.New()
+	seed := fmt.Sprintf("%s:%v", u.OutboxID, u.Preview)
+	io.Copy(hasher, bytes.NewReader([]byte(seed)))
+	u.taskHash = hasher.Sum(nil)
+}
 
-	// reset the stream to the beginning of the file
-	return u.Plaintext.Reset()
+func (u *UploadTask) hash() []byte {
+	return u.taskHash
 }
 
 func (u *UploadTask) stashKey() StashKey {
-	return NewStashKey(u.plaintextHash, u.ConversationID, u.UserID)
+	return NewStashKey(u.OutboxID, u.Preview)
 }
 
 func (u *UploadTask) Nonce() signencrypt.Nonce {
 	var n [signencrypt.NonceSize]byte
-	copy(n[:], u.plaintextHash)
+	copy(n[:], u.taskHash)
 	return &n
 }
 
@@ -106,10 +111,8 @@ func NewStoreTesting(logger logger.Logger, kt func(enc, sig []byte)) *S3Store {
 func (a *S3Store) UploadAsset(ctx context.Context, task *UploadTask, encryptedOut io.Writer) (res chat1.Asset, err error) {
 	defer a.Trace(ctx, func() error { return err }, "UploadAsset")()
 	// compute plaintext hash
-	if task.plaintextHash == nil {
-		if err := task.computePlaintextHash(); err != nil {
-			return res, err
-		}
+	if task.hash() == nil {
+		task.computeHash()
 	} else {
 		if !a.testing {
 			return res, errors.New("task.plaintextHash not nil")
@@ -136,10 +139,7 @@ func (a *S3Store) UploadAsset(ctx context.Context, task *UploadTask, encryptedOu
 		a.aborts++
 		previous = nil
 		task.Plaintext.Reset()
-		// recompute plaintext hash:
-		if err := task.computePlaintextHash(); err != nil {
-			return res, err
-		}
+		task.computeHash()
 		return a.uploadAsset(ctx, task, enc, nil, resumable, encryptedOut)
 	}
 

--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -297,6 +297,8 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 			S3Signer:       u.s3signer,
 			ConversationID: convID,
 			UserID:         uid,
+			OutboxID:       outboxID,
+			Preview:        false,
 			Progress:       progress,
 		}
 		ures.Object, err = u.store.UploadAsset(bgctx, &task, nil)
@@ -341,6 +343,8 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 				S3Signer:       u.s3signer,
 				ConversationID: convID,
 				UserID:         uid,
+				OutboxID:       outboxID,
+				Preview:        true,
 			}
 			preview, err := u.store.UploadAsset(bgctx, &task, encryptedOut)
 			if err == nil {


### PR DESCRIPTION
Patch does the following:

1.) Drop computing the plaintext hash for uploads. It can be pretty slow for large enough files (big video files).
2.) Replace `plaintextHash` on `UploadTask` with a `taskHash` of the outboxID and whether or not the upload is a preview or full asset. We then SHA256 a string of those two values to get the hash of the upload. 