### PR TITLE
Restore chat avatar display logic

### DIFF
--- a/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
@@ -12,8 +12,8 @@ const mapStateToProps = (state: TypedState, {message, previous, innerClass, isEd
   const isYou = state.config.username === message.author
   const isFollowing = state.config.following.has(message.author)
   const isBroken = state.users.infoMap.getIn([message.author, 'broken'], false)
-  const {readMsgID, maxMsgID} = Constants.getMeta(state, message.conversationIDKey)
-  const lastPositionExists = maxMsgID > readMsgID
+  const orangeLineMessageID = state.chat2.orangeLineMap.get(message.conversationIDKey)
+  const lastPositionExists = orangeLineMessageID === message.id
   const messageSent = !message.submitState
   const messageFailed = message.submitState === 'failed'
   const messagePending = message.submitState === 'pending'


### PR DESCRIPTION
Fixes an issue introduced by #13122 where avatars were being displayed for all new messages.

The issue was that I changed the code here to rely on `readMsgID` and `maxMsgID` from `chat2.metaMap` for a conversation, not realizing that `readMsgID` would be updated on new message reads. The original code (and this solution) was to get the position of the orange line and base `lastPositionExists` off of that.