### PR TITLE
Fix a black bar on mobile when trying to join a channel and edit it at the same time

### DIFF
--- a/shared/chat/manage-channels/index.native.js
+++ b/shared/chat/manage-channels/index.native.js
@@ -56,16 +56,17 @@ const Row = (
         {props.description}
       </Text>
     </Box>
-    {props.canEditChannels && (
-      <Edit
-        style={{
-          ...globalStyles.flexBoxRow,
-          justifyContent: 'flex-end',
-          alignItems: 'center',
-        }}
-        onClick={props.onEdit}
-      />
-    )}
+    {props.showEdit &&
+      props.canEditChannels && (
+        <Edit
+          style={{
+            ...globalStyles.flexBoxRow,
+            justifyContent: 'flex-end',
+            alignItems: 'center',
+          }}
+          onClick={props.onEdit}
+        />
+      )}
   </Box>
 )
 


### PR DESCRIPTION
@keybase/react-hackers 

This just makes the mobile component match the desktop one, which is here:

https://github.com/keybase/client/blob/master/shared/chat/manage-channels/index.desktop.js#L74