### PR TITLE
Fix callbacks & styles for various member statuses

### DIFF
--- a/shared/teams/team/members-tab/member-row/container.js
+++ b/shared/teams/team/members-tab/member-row/container.js
@@ -3,12 +3,13 @@ import * as Constants from '../../../../constants/teams'
 import * as Types from '../../../../constants/types/teams'
 import * as TeamsGen from '../../../../actions/teams-gen'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
+import * as TrackerGen from '../../../../actions/tracker-gen'
+import * as ProfileGen from '../../../../actions/profile-gen'
 import {TeamMemberRow} from '.'
 import {amIFollowing} from '../../../../constants/selectors'
 import {navigateAppend} from '../../../../actions/route-tree'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect, isMobile, type TypedState} from '../../../../util/container'
 import {anyWaiting} from '../../../../constants/waiting'
-import * as TrackerGen from '../../../../actions/tracker-gen'
 
 type OwnProps = {
   teamname: string,
@@ -57,7 +58,9 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps): DispatchPro
     dispatch(TeamsGen.createRemoveMemberOrPendingInvite({email: '', inviteID: '', teamname, username}))
   },
   _onShowTracker: (username: string) => {
-    dispatch(TrackerGen.createGetProfile({forceDisplay: true, ignoreCache: false, username}))
+    isMobile
+      ? dispatch(ProfileGen.createShowUserProfile({username}))
+      : dispatch(TrackerGen.createGetProfile({forceDisplay: true, ignoreCache: false, username}))
   },
   onChat: () => {
     ownProps.username &&

--- a/shared/teams/team/members-tab/member-row/index.js
+++ b/shared/teams/team/members-tab/member-row/index.js
@@ -196,7 +196,7 @@ export const TeamMemberRow = (props: Props) => {
               />
             </ButtonBar>
             {!isLargeScreen && (
-              // Mobile small screens - for inactive user 
+              // Mobile small screens - for inactive user
               // display next to reset / deleted controls
               <Icon
                 onClick={props.onChat}

--- a/shared/teams/team/members-tab/member-row/index.js
+++ b/shared/teams/team/members-tab/member-row/index.js
@@ -13,6 +13,7 @@ import {
 import {globalMargins, globalStyles, globalColors, isMobile} from '../../../../styles'
 import {roleIconColorMap} from '../../../role-picker/index.meta'
 import {typeToLabel} from '../../../../constants/teams'
+import {isLargeScreen} from '../../../../constants/platform'
 import type {BoolTypeMap, MemberStatus, TeamRoleType} from '../../../../constants/types/teams'
 
 export type Props = {
@@ -38,6 +39,10 @@ const showCrown: BoolTypeMap = {
   reader: false,
   writer: false,
 }
+
+// NOTE the controls for reset and deleted users (and the chat button) are
+// duplicated here because the desktop & mobile layouts differ significantly. If
+// you're changing one remember to change the other.
 
 export const TeamMemberRow = (props: Props) => {
   let crown, fullNameLabel, resetLabel
@@ -89,7 +94,7 @@ export const TeamMemberRow = (props: Props) => {
             flexGrow: 1,
             alignItems: 'center',
           }}
-          onClick={active || isMobile ? props.onClick : props.onShowTracker}
+          onClick={active ? props.onClick : props.status === 'deleted' ? null : props.onShowTracker}
         >
           <Avatar username={props.username} size={isMobile ? 48 : 32} />
           <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.small}}>
@@ -153,17 +158,15 @@ export const TeamMemberRow = (props: Props) => {
               </ButtonBar>
             </Box>
           )}
-        <Box style={{...globalStyles.flexBoxRow, flexShrink: 1, height: '100%'}}>
-          <Icon
-            onClick={props.onChat}
-            style={{
-              marginLeft: globalMargins.small,
-              marginRight: globalMargins.tiny,
-              padding: globalMargins.tiny,
-            }}
-            fontSize={isMobile ? 20 : 16}
-            type="iconfont-chat"
-          />
+        <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', flexShrink: 1, height: '100%'}}>
+          {(active || isLargeScreen) && (
+            <Icon
+              onClick={props.onChat}
+              style={isMobile ? stylesChatButtonMobile(active) : stylesChatButtonDesktop}
+              fontSize={isMobile ? 20 : 16}
+              type="iconfont-chat"
+            />
+          )}
         </Box>
       </Box>
       {!active &&
@@ -171,14 +174,16 @@ export const TeamMemberRow = (props: Props) => {
         props.youCanManageMembers && (
           <Box style={{...globalStyles.flexBoxRow, flexShrink: 1}}>
             <ButtonBar direction="row">
-              <Button
-                small={true}
-                label="Re-Admit"
-                onClick={props.onReAddToTeam}
-                type="PrimaryGreen"
-                waiting={props.waitingForAdd}
-                disabled={props.waitingForRemove}
-              />
+              {props.status !== 'deleted' && (
+                <Button
+                  small={true}
+                  label="Re-Admit"
+                  onClick={props.onReAddToTeam}
+                  type="PrimaryGreen"
+                  waiting={props.waitingForAdd}
+                  disabled={props.waitingForRemove}
+                />
+              )}
               <Button
                 small={true}
                 label="Remove"
@@ -188,6 +193,16 @@ export const TeamMemberRow = (props: Props) => {
                 disabled={props.waitingForAdd}
               />
             </ButtonBar>
+            {!active &&
+              !isLargeScreen && (
+                // !isLargeScreen implies this is mobile
+                <Icon
+                  onClick={props.onChat}
+                  style={stylesChatButtonMobile(active)}
+                  fontSize={20}
+                  type="iconfont-chat"
+                />
+              )}
           </Box>
         )}
     </Box>
@@ -207,3 +222,15 @@ const stylesContainerReset = {
   ...stylesContainer,
   backgroundColor: globalColors.blue4,
 }
+
+const stylesChatButtonDesktop = {
+  marginLeft: globalMargins.small,
+  marginRight: globalMargins.tiny,
+  padding: globalMargins.tiny,
+}
+
+const stylesChatButtonMobile = (active: boolean) => ({
+  position: 'absolute',
+  right: 16,
+  top: isLargeScreen || active ? 12 : 24,
+})

--- a/shared/teams/team/members-tab/member-row/index.js
+++ b/shared/teams/team/members-tab/member-row/index.js
@@ -160,6 +160,8 @@ export const TeamMemberRow = (props: Props) => {
           )}
         <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', flexShrink: 1, height: '100%'}}>
           {(active || isLargeScreen) && (
+            // Desktop & mobile large screen - display on the far right of the first row
+            // Also when user is active
             <Icon
               onClick={props.onChat}
               style={isMobile ? stylesChatButtonMobile(active) : stylesChatButtonDesktop}
@@ -193,16 +195,16 @@ export const TeamMemberRow = (props: Props) => {
                 disabled={props.waitingForAdd}
               />
             </ButtonBar>
-            {!active &&
-              !isLargeScreen && (
-                // !isLargeScreen implies this is mobile
-                <Icon
-                  onClick={props.onChat}
-                  style={stylesChatButtonMobile(active)}
-                  fontSize={20}
-                  type="iconfont-chat"
-                />
-              )}
+            {!isLargeScreen && (
+              // Mobile small screens - for inactive user 
+              // display next to reset / deleted controls
+              <Icon
+                onClick={props.onChat}
+                style={stylesChatButtonMobile(active)}
+                fontSize={20}
+                type="iconfont-chat"
+              />
+            )}
           </Box>
         )}
     </Box>


### PR DESCRIPTION
Now clicking a deleted user does nothing, and clicking a reset user navigates to the profile. As for styling I just tried to put everything where it would fit. I'm going to ticket cleaning up this component, it's very messy.

small screen styles:
<img width="433" alt="image" src="https://user-images.githubusercontent.com/11968340/43742540-5acaeb66-99a0-11e8-9c65-ed8426e6200e.png">

large screen styles:
<img width="520" alt="image" src="https://user-images.githubusercontent.com/11968340/43742676-d1c21dde-99a0-11e8-9976-7b3a2138346a.png">


desktop styles:
<img width="526" alt="image" src="https://user-images.githubusercontent.com/11968340/43742571-7497d89c-99a0-11e8-97cc-1860b91a2bea.png">
