### PR TITLE
acquire conversation lock while joining a conversation

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -846,6 +846,11 @@ func postJoinLeave(ctx context.Context, g *globals.Context, ri func() chat1.Remo
 
 func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.DebugLabeler,
 	ri func() chat1.RemoteInterface, uid gregor1.UID, convID chat1.ConversationID) (err error) {
+	if err := g.ConvSource.AcquireConversationLock(ctx, uid, convID); err != nil {
+		return err
+	}
+	defer g.ConvSource.ReleaseConversationLock(ctx, uid, convID)
+
 	alreadyIn, err := g.InboxSource.IsMember(ctx, uid, convID)
 	if err != nil {
 		debugger.Debug(ctx, "JoinConversation: IsMember err: %s", err.Error())


### PR DESCRIPTION
This doesn't _solve_ the problem, but I think it's an improvement. and maybe it's a solution for some definitions of solution.

#### Background
We have errors from repeated attempts to join the same conversation. It looks like this might be caused by the client allowing things to be run in a sub-optimal order in the middle of joining a large conversation on a slow connection. And the UI being a little misleading about what's going on. 

#### Before
In the situation where joining a conversation is incredibly slow for some reason (like if another thread acquires the lock and blocks this one from finishing what it's trying to do, then the UI appears like the request to join a conversation has been completely dropped even though it hasn't. This is why we've seen users make the same request multiple times (and get errors that they are already in the group). 

#### After
I'm not sure this is an ideal experience, but after this PR, a really slow join will still do the same thing as before (close the `Manage Chat Channels` window as if the join has succeeded, but the new channel will not appear in the chat list). BUT now if they go back (into the `Manage Chat Channels` window) to try to join again, they'll see this spinner and be unable to click on anything in there. At least it'll be obvious that it's still working on it if they make they effort to look again. Which at least some people have, because that's what results in these errors. 
<img width="786" alt="screen shot 2018-08-06 at 4 19 27 pm" src="https://user-images.githubusercontent.com/1275828/43742913-b0285958-99a1-11e8-9874-924a826b1ad6.png">
And, I couldn't really figure out how to test this, but adding the lock might actually prevent some of these super-slow-joins to begin with if it means some other process can't snag the lock. 

There's also a PR on the server to add some extra visibility around joining conversations. 