### PR TITLE
Avoid buggy attachment functions on Android

### DIFF
--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.js
@@ -18,6 +18,9 @@ const promptContainerStyle = {
 
 class FilePickerPopup extends React.Component<Props> {
   render() {
+    // TODO: Have separate menu items for Take Photo, Take Video,
+    // Photo from Library, and Video from Library when launchCamera
+    // and launchImageLibrary Android bugs are fixed.
     const items = isIOS
       ? [
           {
@@ -36,27 +39,15 @@ class FilePickerPopup extends React.Component<Props> {
       : [
           {
             onClick: () => {
-              this.props.onSelect('photo', 'camera')
+              this.props.onSelect('photo', 'pick')
             },
-            title: 'Take Photo',
+            title: 'Photo',
           },
           {
             onClick: () => {
-              this.props.onSelect('video', 'camera')
+              this.props.onSelect('video', 'pick')
             },
-            title: 'Take Video',
-          },
-          {
-            onClick: () => {
-              this.props.onSelect('photo', 'library')
-            },
-            title: 'Photo from Library',
-          },
-          {
-            onClick: () => {
-              this.props.onSelect('video', 'library')
-            },
-            title: 'Video from Library',
+            title: 'Video',
           },
         ]
     const header = {

--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.js
@@ -19,8 +19,8 @@ const promptContainerStyle = {
 class FilePickerPopup extends React.Component<Props> {
   render() {
     // TODO: Have separate menu items for Take Photo, Take Video,
-    // Photo from Library, and Video from Library when launchCamera
-    // and launchImageLibrary Android bugs are fixed.
+    // Photo from Library, and Video from Library on Android when
+    // launchCamera and launchImageLibrary Android bugs are fixed.
     const items = isIOS
       ? [
           {

--- a/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.types.js.flow
@@ -5,5 +5,5 @@ export type Props = {
   attachTo: ?React.Component<any, any>,
   visible: boolean,
   onHidden: () => void,
-  onSelect: (mediaType: 'photo' | 'video' | 'mixed', location: 'camera' | 'library') => void,
+  onSelect: (mediaType: 'photo' | 'video' | 'mixed', location: 'pick' | 'camera' | 'library') => void,
 }

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -100,6 +100,8 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
       this.props.onAttach([filename])
     }
 
+    // TODO: Remove 'pick' case when launchCamera and
+    // launchImageLibrary Android bugs are fixed.
     const options = {mediaType, title, takePhotoButtonTitle, permissionDenied}
     switch (location) {
       case 'pick':

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -54,7 +54,7 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
 
   _launchNativeImagePicker = (
     mediaType: 'photo' | 'video' | 'mixed',
-    location: 'camera' | 'library' | 'pick'
+    location: 'pick' | 'camera' | 'library'
   ) => {
     let title = 'Select a Photo'
     let takePhotoButtonTitle = 'Take Photo...'

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -52,7 +52,7 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
     this._toggleShowingMenu('filepickerpopup')
   }
 
-  _launchNativeImagePicker = (mediaType: string, location: string) => {
+  _launchNativeImagePicker = (mediaType: 'photo' | 'video' | 'mixed', location: 'camera' | 'library') => {
     let title = 'Select a Photo'
     let takePhotoButtonTitle = 'Take Photo...'
     let permDeniedText = 'Allow Keybase to take photos and choose images from your library?'

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -75,6 +75,12 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
         takePhotoButtonTitle = 'Take Video...'
         permDeniedText = 'Allow Keybase to take video and choose videos from your library?'
         break
+      default:
+        /*::
+      declare var ifFlowErrorsHereItsCauseYouDidntHandleAllTypesAbove: (view: empty) => any
+        ifFlowErrorsHereItsCauseYouDidntHandleAllTypesAbove(mediaType);
+        */
+        throw new Error(`Impossible mediaType encountered: ${mediaType}`)
     }
     const permissionDenied = {
       title: 'Permissions needed',
@@ -105,6 +111,12 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
       case 'library':
         launchImageLibrary(options, handleSelection)
         break
+      default:
+        /*::
+      declare var ifFlowErrorsHereItsCauseYouDidntHandleAllTypesAbove: (view: empty) => any
+        ifFlowErrorsHereItsCauseYouDidntHandleAllTypesAbove(location);
+        */
+        throw new Error(`Impossible location encountered: ${location}`)
     }
   }
 

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -1,6 +1,6 @@
 // @flow
 /* eslint-env browser */
-import {launchCamera, launchImageLibrary} from 'react-native-image-picker'
+import {launchCamera, launchImageLibrary, showImagePicker} from 'react-native-image-picker'
 import React, {Component} from 'react'
 import {
   Box,
@@ -52,7 +52,10 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
     this._toggleShowingMenu('filepickerpopup')
   }
 
-  _launchNativeImagePicker = (mediaType: 'photo' | 'video' | 'mixed', location: 'camera' | 'library') => {
+  _launchNativeImagePicker = (
+    mediaType: 'photo' | 'video' | 'mixed',
+    location: 'camera' | 'library' | 'pick'
+  ) => {
     let title = 'Select a Photo'
     let takePhotoButtonTitle = 'Take Photo...'
     let permDeniedText = 'Allow Keybase to take photos and choose images from your library?'
@@ -91,12 +94,16 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
       this.props.onAttach([filename])
     }
 
+    const options = {mediaType, title, takePhotoButtonTitle, permissionDenied}
     switch (location) {
+      case 'pick':
+        showImagePicker(options, handleSelection)
+        break
       case 'camera':
-        launchCamera({mediaType, title, takePhotoButtonTitle, permissionDenied}, handleSelection)
+        launchCamera(options, handleSelection)
         break
       case 'library':
-        launchImageLibrary({mediaType, title, takePhotoButtonTitle, permissionDenied}, handleSelection)
+        launchImageLibrary(options, handleSelection)
         break
     }
   }


### PR DESCRIPTION
This fixes a crasher when hitting 'Deny' on the react-native-image-picker
dialog (when trying to take a photo where perms have been previously denied).

This also fixes a bug where nothing happens on the first run, if perms
are granted on the Android permission dialog.