### PR TITLE
add proper permission for taking video on iOS

### DIFF
--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.js
@@ -22,15 +22,15 @@ class FilePickerPopup extends React.Component<Props> {
       ? [
           {
             onClick: () => {
-              this.props.onSelect('photo', 'camera')
+              this.props.onSelect('mixed', 'camera')
             },
-            title: 'Take Photo',
+            title: 'Take Photo or Video',
           },
           {
             onClick: () => {
               this.props.onSelect('mixed', 'library')
             },
-            title: 'Photo or Video from Library',
+            title: 'Choose from Library',
           },
         ]
       : [

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -41,6 +41,8 @@
 	<string>Saving images from chat messages</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Attaching images to chat messages</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Recording audio when taking a video</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>OpenSans_bold.ttf</string>


### PR DESCRIPTION
@keybase/react-hackers 

Is turns out that `react-native-image-picker` can do video properly, I just didn't add the proper permissions to the app to make it happen.