### PR TITLE
More work on rename notification test

### DIFF
--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -52,9 +52,9 @@ func (r *teamHandler) Create(ctx context.Context, cli gregor1.IncomingInterface,
 	case "team.openreq":
 		return true, r.openTeamAccessRequest(ctx, cli, item)
 	case "team.change":
-		return true, r.changeTeam(ctx, cli, item, keybase1.TeamChangeSet{})
+		return true, r.changeTeam(ctx, cli, category, item, keybase1.TeamChangeSet{})
 	case "team.rename":
-		return true, r.changeTeam(ctx, cli, item, keybase1.TeamChangeSet{Renamed: true})
+		return true, r.changeTeam(ctx, cli, category, item, keybase1.TeamChangeSet{Renamed: true})
 	case "team.delete":
 		return true, r.deleteTeam(ctx, cli, item)
 	case "team.exit":
@@ -206,14 +206,15 @@ func (r *teamHandler) findAndDismissResetBadges(ctx context.Context, cli gregor1
 	return nil
 }
 
-func (r *teamHandler) changeTeam(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item, changes keybase1.TeamChangeSet) error {
+func (r *teamHandler) changeTeam(ctx context.Context, cli gregor1.IncomingInterface, category string,
+	item gregor.Item, changes keybase1.TeamChangeSet) error {
 	var rows []keybase1.TeamChangeRow
 	r.G().Log.CDebugf(ctx, "teamHandler: changeTeam received")
 	if err := json.Unmarshal(item.Body().Bytes(), &rows); err != nil {
-		r.G().Log.CDebugf(ctx, "error unmarshaling team.(change|rename) item: %s", err)
+		r.G().Log.CDebugf(ctx, "error unmarshaling %s item: %s", category, err)
 		return err
 	}
-	r.G().Log.CDebugf(ctx, "team.(change|rename) unmarshaled: %+v", rows)
+	r.G().Log.CDebugf(ctx, "%s unmarshaled: %+v", category, rows)
 	if err := teams.HandleChangeNotification(ctx, r.G(), rows, changes); err != nil {
 		return err
 	}

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1458,33 +1458,54 @@ func TestTeamBustResolverCacheOnSubteamRename(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
-	tt.addUser("onr")
-	user := tt.users[0]
-	tc := user.tc
-	_, teamName := user.createTeam2()
+	al := tt.addUser("al")
+	bob := tt.addUser("bob")
+	eve := tt.addUser("eve")
+
+	_, teamName := al.createTeam2()
 
 	// Verify subteams that have been renamed resolve correctly
 	subteamBasename := "bb1"
-	subteamID, err := teams.CreateSubteam(context.TODO(), tc.G, subteamBasename, teamName, keybase1.TeamRole_NONE /* addSelfAs */)
+	subteamID, err := teams.CreateSubteam(context.TODO(), al.tc.G, subteamBasename, teamName, keybase1.TeamRole_NONE /* addSelfAs */)
 	require.NoError(t, err)
 	subteamName, err := teamName.Append(subteamBasename)
 	require.NoError(t, err)
+
+	al.addTeamMember(subteamName.String(), bob.username, keybase1.TeamRole_READER)
+	al.addTeamMember(teamName.String(), eve.username, keybase1.TeamRole_ADMIN)
+
 	subteamRename, err := teamName.Append("bb2")
 	require.NoError(t, err)
 
-	subteamNameActual, err := teams.ResolveIDToName(context.TODO(), tc.G, *subteamID)
+	subteamNameActual, err := teams.ResolveIDToName(context.TODO(), al.tc.G, *subteamID)
 	require.NoError(t, err)
 	require.True(t, subteamName.Eq(subteamNameActual))
 
-	err = teams.RenameSubteam(context.TODO(), tc.G, subteamName, subteamRename)
+	err = teams.RenameSubteam(context.TODO(), al.tc.G, subteamName, subteamRename)
 	require.NoError(t, err)
-	user.waitForTeamChangeRenamed(*subteamID)
-	user.waitForTeamChangeRenamed(*subteamID)
 
-	subteamRenameActual, err := teams.ResolveIDToName(context.TODO(), tc.G, *subteamID)
-	require.NoError(t, err)
-	require.True(t, subteamRename.Eq(subteamRenameActual))
+	// While this may not be ideal, admin that posts the rename will
+	// get two notifications.
+	// - First notification comes from `RenameSubteam` func itself,
+	//   where `g.GetTeamLoader().NotifyTeamRename` is called.
+	// - Second one is the regular gregor team.rename notification.
+	t.Logf("Waiting for team notifications for %s", al.username)
+	al.waitForTeamChangeRenamed(*subteamID)
+	al.waitForTeamChangeRenamed(*subteamID)
 
-	_, err = teams.ResolveNameToID(context.TODO(), tc.G, subteamName)
-	require.Error(t, err)
+	// Members of subteam, and other admins from parent teams, will
+	// get just one.
+	for _, user := range []*userPlusDevice{bob, eve} {
+		t.Logf("Waiting for team notifications for %s", user.username)
+		user.waitForTeamChangeRenamed(*subteamID)
+	}
+
+	for _, user := range tt.users {
+		subteamRenameActual, err := teams.ResolveIDToName(context.TODO(), user.tc.G, *subteamID)
+		require.NoError(t, err)
+		require.True(t, subteamRename.Eq(subteamRenameActual))
+
+		_, err = teams.ResolveNameToID(context.TODO(), user.tc.G, subteamName)
+		require.Error(t, err)
+	}
 }


### PR DESCRIPTION
Please see the jira ticket for more information about what's going on.

I think we might as well leave the double-notification oddity. But this new test code is useful to lock in the behavior for other notification receivers - non-admin member of subteam, and admin member of parent team.