### PR TITLE
dont center on adnroid due to keyboard avoiding crappiness

### DIFF
--- a/shared/provision/paper-key/index.js
+++ b/shared/provision/paper-key/index.js
@@ -8,6 +8,7 @@ import {
   globalStyles,
   styleSheetCreate,
   isMobile,
+  isIOS,
   platformStyles,
 } from '../../styles'
 
@@ -27,7 +28,7 @@ const PaperKey = (props: Props) => (
     <Box2
       direction="vertical"
       style={styles.contents}
-      centerChildren={true}
+      centerChildren={isIOS /* android keyboardAvoiding doesnt work well */}
       gap={isMobile ? 'tiny' : 'medium'}
     >
       <Box2 direction="vertical" gap="tiny" centerChildren={true} gapEnd={true}>
@@ -76,9 +77,9 @@ const styles = styleSheetCreate({
     },
   }),
   contents: {
+    flexGrow: 1,
     maxWidth: isMobile ? 300 : 460,
     width: '100%',
-    flexGrow: 1,
   },
   hint: {
     ...globalStyles.italic,

--- a/shared/provision/paper-key/index.js
+++ b/shared/provision/paper-key/index.js
@@ -8,7 +8,7 @@ import {
   globalStyles,
   styleSheetCreate,
   isMobile,
-  isIOS,
+  isAndroid,
   platformStyles,
 } from '../../styles'
 
@@ -28,7 +28,7 @@ const PaperKey = (props: Props) => (
     <Box2
       direction="vertical"
       style={styles.contents}
-      centerChildren={isIOS /* android keyboardAvoiding doesnt work well */}
+      centerChildren={!isAndroid /* android keyboardAvoiding doesnt work well */}
       gap={isMobile ? 'tiny' : 'medium'}
     >
       <Box2 direction="vertical" gap="tiny" centerChildren={true} gapEnd={true}>


### PR DESCRIPTION
@keybase/react-hackers this moves the paperkey input up on android. keyboard avoiding on android basically doens't work
https://github.com/facebook/react-native/issues/16826