### PR TITLE
Use memory loadKeyCache when loading teams

### DIFF
--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -266,6 +266,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 
 	// Shorthands
 	m := arg.MetaContext()
+	m, tbs := arg.m.WithTimeBuckets()
 	g := m.G()
 	ctx := m.Ctx()
 
@@ -308,8 +309,10 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 			return nil, user, err
 		}
 		if needCopy {
+			fin := tbs.Record("CachedUPAKLoader.DeepCopy")
 			tmp := upak.DeepCopy()
 			upak = &tmp
+			fin()
 		}
 		return upak, user, nil
 	}

--- a/go/teams/keys.go
+++ b/go/teams/keys.go
@@ -338,7 +338,6 @@ func newSharedSecret() (ret keybase1.PerTeamKeySeed, err error) {
 }
 
 func derivedSecret(secret keybase1.PerTeamKeySeed, context string) []byte {
-	// xxx suspect
 	if secret.IsZero() {
 		panic("Should never be using a zero key in derivedSecret; something went terribly wrong")
 	}

--- a/go/teams/keys.go
+++ b/go/teams/keys.go
@@ -338,6 +338,7 @@ func newSharedSecret() (ret keybase1.PerTeamKeySeed, err error) {
 }
 
 func derivedSecret(secret keybase1.PerTeamKeySeed, context string) []byte {
+	// xxx suspect
 	if secret.IsZero() {
 		panic("Should never be using a zero key in derivedSecret; something went terribly wrong")
 	}

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -189,8 +189,9 @@ func (l *LoaderContextG) forceLinkMapRefreshForUser(ctx context.Context, uid key
 }
 
 func (l *LoaderContextG) loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (
-	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap linkMapT,
-	err error) {
+	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap linkMapT, err error) {
+	ctx, tbs := l.G().CTimeBuckets(ctx)
+	defer tbs.Record("LoaderContextG.loadKeyV2")()
 
 	user, pubKey, linkMap, err := l.G().GetUPAKLoader().LoadKeyV2(ctx, uid, kid)
 	if err != nil {
@@ -199,6 +200,5 @@ func (l *LoaderContextG) loadKeyV2(ctx context.Context, uid keybase1.UID, kid ke
 	if user == nil {
 		return uv, pubKey, linkMap, libkb.NotFoundError{}
 	}
-
 	return user.ToUserVersion(), pubKey, linkMap, nil
 }

--- a/go/teams/loadkeycache.go
+++ b/go/teams/loadkeycache.go
@@ -1,0 +1,57 @@
+package teams
+
+import (
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type uvAndKey struct {
+	UV  keybase1.UserVersion
+	Key keybase1.PublicKeyV2NaCl
+}
+
+// loadKeyCache is a short-lived cache for loading keys and linkmaps for TeamLoader.
+// It must be short-lived since it has no expiration or eviction.
+// Not threadsafe.
+type loadKeyCache struct {
+	userKeyCache     map[keybase1.UID]map[keybase1.KID]uvAndKey
+	userLinkMapCache map[keybase1.UID]map[keybase1.Seqno]keybase1.LinkID
+	cacheHits        int64
+}
+
+func newLoadKeyCache() *loadKeyCache {
+	return &loadKeyCache{
+		userKeyCache:     make(map[keybase1.UID]map[keybase1.KID]uvAndKey),
+		userLinkMapCache: make(map[keybase1.UID]map[keybase1.Seqno]keybase1.LinkID),
+	}
+}
+
+func (c *loadKeyCache) loadKeyV2(mctx libkb.MetaContext, world LoaderContext, uid keybase1.UID, kid keybase1.KID) (
+	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap linkMapT, err error) {
+	mctx, tbs := mctx.WithTimeBuckets()
+	defer tbs.Record("loadKeyCache.loadKeyV2")()
+
+	m2, ok := c.userKeyCache[uid]
+	if ok {
+		v, ok := m2[kid]
+		if ok {
+			c.cacheHits++
+			return v.UV, &v.Key, c.userLinkMapCache[uid], nil
+		}
+	}
+
+	uv, pubKey, linkMap, err = world.loadKeyV2(mctx.Ctx(), uid, kid)
+	if err != nil {
+		return
+	}
+
+	if c.userKeyCache[uid] == nil {
+		c.userKeyCache[uid] = make(map[keybase1.KID]uvAndKey)
+	}
+	c.userKeyCache[uid][kid] = uvAndKey{
+		UV:  uv,
+		Key: *pubKey,
+	}
+	c.userLinkMapCache[uid] = linkMap
+	return uv, pubKey, linkMap, nil
+}


### PR DESCRIPTION
Use an in-memory cache in front on UPAKLoader for a single team load. The fronting cache mostly doesn't do DeepCopy (which could also be accomplished by modifying UPAKLoader) but it additionally has no invalidation and freshness rules. Saves 2s on android.

This saves an additional 400ms compared to removing DeepCopy from UPAKLoader.
