### PR TITLE
stash full image uploads on the disk and enter into the download cache CORE-8465

### DIFF
--- a/go/chat/attachment_httpsrv_test.go
+++ b/go/chat/attachment_httpsrv_test.go
@@ -185,7 +185,7 @@ func TestChatSrvAttachmentUploadPreviewCached(t *testing.T) {
 	useRemoteMock = false
 	tc := ctc.world.Tcs[users[0].Username]
 	store := attachments.NewStoreTesting(logger.NewTestLogger(t), nil)
-	fetcher := NewCachingAttachmentFetcher(tc.Context(), store, 1)
+	fetcher := NewCachingAttachmentFetcher(tc.Context(), store, 5)
 	ri := ctc.as(t, users[0]).ri
 	d, err := libkb.RandHexString("", 8)
 	require.NoError(t, err)
@@ -223,7 +223,14 @@ func TestChatSrvAttachmentUploadPreviewCached(t *testing.T) {
 	body := msgRes.Messages[0].Valid().MessageBody
 	require.NotNil(t, body.Attachment().Preview)
 
+	t.Logf("remote preview path: %s", body.Attachment().Preview.Path)
+	t.Logf("remote object path: %s", body.Attachment().Object.Path)
 	found, path, err := fetcher.localAssetPath(context.TODO(), *body.Attachment().Preview)
+	require.NoError(t, err)
+	require.True(t, found)
+	t.Logf("found path: %s", path)
+
+	found, path, err = fetcher.localAssetPath(context.TODO(), body.Attachment().Object)
 	require.NoError(t, err)
 	require.True(t, found)
 	t.Logf("found path: %s", path)

--- a/go/chat/attachments/store.go
+++ b/go/chat/attachments/store.go
@@ -174,10 +174,7 @@ func (a *S3Store) uploadAsset(ctx context.Context, task *UploadTask, enc *SignEn
 
 	// compute ciphertext hash
 	hash := sha256.New()
-	tee := io.TeeReader(encReader, hash)
-	if encryptedOut != nil {
-		tee = io.TeeReader(tee, encryptedOut)
-	}
+	tee := io.TeeReader(io.TeeReader(encReader, hash), encryptedOut)
 
 	// post to s3
 	length := int64(enc.EncryptedLen(task.FileSize))

--- a/go/chat/attachments/store_test.go
+++ b/go/chat/attachments/store_test.go
@@ -200,7 +200,7 @@ func TestUploadAssetSmall(t *testing.T) {
 	s := makeTestStore(t, nil)
 	ctx := context.Background()
 	plaintext, task := makeUploadTask(t, 1*MB)
-	a, err := s.UploadAsset(ctx, task, nil)
+	a, err := s.UploadAsset(ctx, task, ioutil.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestUploadAssetLarge(t *testing.T) {
 	s := makeTestStore(t, nil)
 	ctx := context.Background()
 	plaintext, task := makeUploadTask(t, 12*MB)
-	a, err := s.UploadAsset(ctx, task, nil)
+	a, err := s.UploadAsset(ctx, task, ioutil.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func (u *uploader) keyTracker(e, s []byte) {
 
 func (u *uploader) UploadResume() chat1.Asset {
 	u.s.blockLimit = 0
-	a, err := u.s.UploadAsset(context.Background(), u.task, nil)
+	a, err := u.s.UploadAsset(context.Background(), u.task, ioutil.Discard)
 	if err != nil {
 		u.t.Fatalf("expected second UploadAsset call to work, got: %s", err)
 	}
@@ -289,7 +289,7 @@ func (u *uploader) UploadResume() chat1.Asset {
 func (u *uploader) UploadPartial(blocks int) {
 	u.s.blockLimit = blocks
 
-	_, err := u.s.UploadAsset(context.Background(), u.task, nil)
+	_, err := u.s.UploadAsset(context.Background(), u.task, ioutil.Discard)
 	if err == nil {
 		u.t.Fatal("expected incomplete upload to have error")
 	}

--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -390,6 +390,7 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 		if err != nil {
 			u.Debug(bgctx, "upload: failed to create uploaded full file: %s", err)
 			encryptedOut = ioutil.Discard
+			uf = nil
 		} else {
 			defer uf.Close()
 			encryptedOut = uf
@@ -441,6 +442,7 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 			if err != nil {
 				u.Debug(bgctx, "upload: failed to create uploaded preview file: %s", err)
 				encryptedOut = ioutil.Discard
+				up = nil
 			} else {
 				defer up.Close()
 				encryptedOut = up

--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -389,6 +389,7 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 		uf, err := u.uploadFullFile(ctx, pre.BaseMetadata())
 		if err != nil {
 			u.Debug(bgctx, "upload: failed to create uploaded full file: %s", err)
+			encryptedOut = ioutil.Discard
 		} else {
 			defer uf.Close()
 			encryptedOut = uf
@@ -414,7 +415,7 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 			ures.Object.Title = title
 			ures.Object.MimeType = pre.ContentType
 			ures.Object.Metadata = pre.BaseMetadata()
-			if encryptedOut != nil {
+			if uf != nil {
 				if err := u.G().AttachmentURLSrv.GetAttachmentFetcher().PutUploadedAsset(ctx,
 					uf.Name(), ures.Object); err != nil {
 					u.Debug(bgctx, "upload: failed to put uploaded asset into fetcher: %s", err)
@@ -439,6 +440,7 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 			up, err := u.uploadPreviewFile(ctx)
 			if err != nil {
 				u.Debug(bgctx, "upload: failed to create uploaded preview file: %s", err)
+				encryptedOut = ioutil.Discard
 			} else {
 				defer up.Close()
 				encryptedOut = up
@@ -464,7 +466,7 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 				ures.Preview.MimeType = pre.PreviewContentType
 				ures.Preview.Metadata = pre.PreviewMetadata()
 				ures.Preview.Tag = chat1.AssetTag_PRIMARY
-				if encryptedOut != nil {
+				if up != nil {
 					if err := u.G().AttachmentURLSrv.GetAttachmentFetcher().PutUploadedAsset(ctx,
 						up.Name(), preview); err != nil {
 						u.Debug(bgctx, "upload: failed to put uploaded preview asset into fetcher: %s", err)


### PR DESCRIPTION
Stash the full version of an image upload in the download cache, in addition to the preview. 