### PR TITLE
Remove CircleCI cache

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -59,7 +59,6 @@ jobs:
     - run: sudo apt-get update -qq
     # - run: sudo apt-cache show yarn
     - run: sudo apt-get install -y -qq yarn=1.7.0-1
-    - run: sudo rm -rf /usr/local/go*
     - run: mkdir -p ~/downloads ~/go-path
     - run: ls "$HOME/downloads"
     - run: ls "$ANDROID_HOME"

--- a/circle.yml
+++ b/circle.yml
@@ -134,7 +134,8 @@ jobs:
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}
         paths:
-        - ~/.gradle
+        # We used to cache ~/.gradle, but that would cache every new
+        # Android build. Probably doesn't help that much anyway.
         - ~/downloads
         - ~/.cache/yarn
         - /tmp/go-android/bin

--- a/circle.yml
+++ b/circle.yml
@@ -58,6 +58,7 @@ jobs:
     - run: echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     - run: sudo apt-get update -qq
     # - run: sudo apt-cache show yarn
+    # TODO: Update yarn.
     - run: sudo apt-get install -y -qq yarn=1.7.0-1
     - run: mkdir -p ~/downloads ~/go-path
     - run: ls "$HOME/downloads"

--- a/circle.yml
+++ b/circle.yml
@@ -75,7 +75,7 @@ jobs:
 
     # Accept android licenses
     - run: mkdir -p /usr/local/android-sdk-linux/licenses
-    - run: if [[ ! -e "$ANDROID_HOME/ndk-bundle" ]]; then wget -nv http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip -O android-ndk-r11c-linux-x86_64.zip && unzip -o android-ndk-r11c-linux-x86_64.zip -d "$ANDROID_HOME" && mv "$ANDROID_HOME/android-ndk-r11c" "$ANDROID_HOME/ndk-bundle"; fi
+    - run: if [[ ! -e "$ANDROID_HOME/ndk-bundle" ]]; then wget -nv http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip -O $HOME/downloads/android-ndk-r11c-linux-x86_64.zip && unzip -o $HOME/downloads/android-ndk-r11c-linux-x86_64.zip -d "$ANDROID_HOME" && mv "$ANDROID_HOME/android-ndk-r11c" "$ANDROID_HOME/ndk-bundle"; fi
     - run: echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > /usr/local/android-sdk-linux/licenses/android-sdk-license
     - run: echo "d56f5187479451eabf01fb78af6dfcb131a6481e" >> /usr/local/android-sdk-linux/licenses/android-sdk-license
 

--- a/circle.yml
+++ b/circle.yml
@@ -134,16 +134,10 @@ jobs:
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}
         paths:
-        # We used to cache ~/.gradle, but that would cache every new
-        # Android build. Probably doesn't help that much anyway.
         - ~/downloads
         - ~/.cache/yarn
         - /tmp/go-android/bin
         - /tmp/go-android/pkg
-        - /usr/local/android-sdk-linux/tools
-        - /usr/local/android-sdk-linux/ndk-bundle
-        - /usr/local/android-sdk-linux/build-tools/23.0.2
-        - /usr/local/android-sdk-linux/extras/android/m2repository
 
     # TODO: Run device tests (see old versions of this file).
 

--- a/circle.yml
+++ b/circle.yml
@@ -53,16 +53,6 @@ jobs:
     - run: nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
     - run: sudo update-alternatives --set java /usr/lib/jvm/jdk1.8.0/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/jdk1.8.0/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/jdk1.8.0" >> $BASH_ENV
 
-    # Restore the dependency cache
-    - restore_cache:
-        keys:
-        # This branch if available
-        - v1-dep-{{ .Branch }}-
-        # Default branch if not
-        - v1-dep-master-
-        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1-dep-
-
     # - run: nvm ls-remote
     - run: sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
     - run: echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
@@ -129,15 +119,6 @@ jobs:
           _JAVA_OPTIONS: -Xms512m -Xmx2048m
           GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"
         command: ./gradlew assembleReleaseUnsigned -x bundleReleaseUnsignedJsAndAssets
-
-    # Save dependency cache
-    - save_cache:
-        key: v1-dep-{{ .Branch }}-{{ epoch }}
-        paths:
-        - ~/downloads
-        - ~/.cache/yarn
-        - /tmp/go-android/bin
-        - /tmp/go-android/pkg
 
     # TODO: Run device tests (see old versions of this file).
 


### PR DESCRIPTION
The main problem was that
~/.gradle/caches/transforms-1/files-1.1/keybaselib.aar is a
cached directory that stores every new keybaselib.aar build.

But we don't really need to be caching anyway. It seems that CircleCI already
does some sort of download caching. So just nuke caching entirely.

Also fix build breakage when there is no cache -- we'd previously run into
it periodically.