### PR TITLE
Smarter key cache

### DIFF
--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -21,7 +21,7 @@ type UPAKLoader interface {
 	LoadV2(arg LoadUserArg) (ret *keybase1.UserPlusKeysV2AllIncarnations, user *User, err error)
 	CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error)
 	LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID) (keybase1.UserPlusKeys, error)
-	LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (*keybase1.UserPlusKeysV2, *keybase1.PublicKeyV2NaCl, map[keybase1.Seqno]keybase1.LinkID, error)
+	LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (*keybase1.UserPlusKeysV2, *keybase1.UserPlusKeysV2AllIncarnations, *keybase1.PublicKeyV2NaCl, error)
 	Invalidate(ctx context.Context, uid keybase1.UID)
 	LoadDeviceKey(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (upak *keybase1.UserPlusAllKeys, deviceKey *keybase1.PublicKey, revoked *keybase1.RevokedKey, err error)
 	LoadUPAKWithDeviceID(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (*keybase1.UserPlusKeysV2AllIncarnations, error)
@@ -509,7 +509,8 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 // LoadKeyV2 looks through all incarnations for the user and returns the incarnation with the given
 // KID, as well as the Key data associated with that KID. It picks the latest such
 // incarnation if there are multiple.
-func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (ret *keybase1.UserPlusKeysV2, key *keybase1.PublicKeyV2NaCl, linkMap map[keybase1.Seqno]keybase1.LinkID, err error) {
+func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (ret *keybase1.UserPlusKeysV2,
+	upak *keybase1.UserPlusKeysV2AllIncarnations, key *keybase1.PublicKeyV2NaCl, err error) {
 	ctx = WithLogTag(ctx, "LK") // Load key
 	defer u.G().CVTraceTimed(ctx, VLog0, fmt.Sprintf("LoadKeyV2 uid:%s,kid:%s", uid, kid), func() error { return err })()
 	ctx, tbs := u.G().CTimeBuckets(ctx)
@@ -544,16 +545,14 @@ func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid 
 			return nil, nil, nil, fmt.Errorf("Nil user, nil error from LoadUser")
 		}
 
-		linkMap = upak.SeqnoLinkIDs
-		ret, key = upak.FindKID(kid)
+		ret, key := upak.FindKID(kid)
 		if key != nil {
 			u.G().VDL.CLogf(ctx, VLog1, "- found kid in UPAK: %v", ret.Uid)
-			return ret, key, linkMap, nil
+			return ret, upak, key, nil
 		}
-		ret = nil
 	}
 
-	return nil, nil, nil, NotFoundError{Msg: "Not found: User"}
+	return nil, nil, nil, NotFoundError{Msg: "Not found: Key for user"}
 }
 
 func (u *CachedUPAKLoader) Invalidate(ctx context.Context, uid keybase1.UID) {

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -125,7 +125,7 @@ func (l *TeamLoader) loadUserAndKeyFromLinkInner(ctx context.Context,
 	}
 	uid := keySection.UID
 	kid := keySection.KID
-	signerUV, key, linkMap, err = lkc.loadKeyV2(l.MetaContext(ctx), l.world, uid, kid)
+	signerUV, key, linkMap, err = l.world.loadKeyV2(ctx, uid, kid, lkc)
 	if err != nil {
 		return signerUV, nil, nil, err
 	}

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -28,7 +28,7 @@ type LoaderContext interface {
 	merkleLookup(ctx context.Context, teamID keybase1.TeamID, public bool) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error)
 	merkleLookupTripleAtHashMeta(ctx context.Context, isPublic bool, leafID keybase1.UserOrTeamID, hm keybase1.HashMeta) (triple *libkb.MerkleTriple, err error)
 	forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap linkMapT, err error)
-	loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (keybase1.UserVersion, *keybase1.PublicKeyV2NaCl, linkMapT, error)
+	loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID, lkc *loadKeyCache) (keybase1.UserVersion, *keybase1.PublicKeyV2NaCl, linkMapT, error)
 }
 
 // The main LoaderContext is G.
@@ -188,17 +188,10 @@ func (l *LoaderContextG) forceLinkMapRefreshForUser(ctx context.Context, uid key
 	return upak.SeqnoLinkIDs, nil
 }
 
-func (l *LoaderContextG) loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (
+func (l *LoaderContextG) loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID, lkc *loadKeyCache) (
 	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap linkMapT, err error) {
 	ctx, tbs := l.G().CTimeBuckets(ctx)
 	defer tbs.Record("LoaderContextG.loadKeyV2")()
 
-	user, pubKey, linkMap, err := l.G().GetUPAKLoader().LoadKeyV2(ctx, uid, kid)
-	if err != nil {
-		return
-	}
-	if user == nil {
-		return uv, pubKey, linkMap, libkb.NotFoundError{}
-	}
-	return user.ToUserVersion(), pubKey, linkMap, nil
+	return lkc.loadKeyV2(l.MetaContext(ctx), uid, kid)
 }

--- a/go/teams/loader_ctx_test.go
+++ b/go/teams/loader_ctx_test.go
@@ -261,7 +261,7 @@ func (l *MockLoaderContext) forceLinkMapRefreshForUser(ctx context.Context, uid 
 	// return linkMap, nil
 }
 
-func (l *MockLoaderContext) loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (
+func (l *MockLoaderContext) loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID, _lkc *loadKeyCache) (
 	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap linkMapT,
 	err error) {
 

--- a/go/teams/loadkeycache.go
+++ b/go/teams/loadkeycache.go
@@ -26,11 +26,12 @@ func newLoadKeyCache() *loadKeyCache {
 	}
 }
 
-func (c *loadKeyCache) loadKeyV2(mctx libkb.MetaContext, world LoaderContext, uid keybase1.UID, kid keybase1.KID) (
+func (c *loadKeyCache) loadKeyV2(mctx libkb.MetaContext, uid keybase1.UID, kid keybase1.KID) (
 	uv keybase1.UserVersion, pubKey *keybase1.PublicKeyV2NaCl, linkMap linkMapT, err error) {
 	mctx, tbs := mctx.WithTimeBuckets()
 	defer tbs.Record("loadKeyCache.loadKeyV2")()
 
+	// Look in the cache first
 	m2, ok := c.userKeyCache[uid]
 	if ok {
 		v, ok := m2[kid]
@@ -40,18 +41,34 @@ func (c *loadKeyCache) loadKeyV2(mctx libkb.MetaContext, world LoaderContext, ui
 		}
 	}
 
-	uv, pubKey, linkMap, err = world.loadKeyV2(mctx.Ctx(), uid, kid)
+	// Load the user. LoadKeyV2 handles punching through the cache when needed.
+	user, upak, _, err := mctx.G().GetUPAKLoader().LoadKeyV2(mctx.Ctx(), uid, kid)
 	if err != nil {
-		return
+		return uv, pubKey, linkMap, err
+	}
+	if user == nil || upak == nil {
+		return uv, pubKey, linkMap, libkb.NotFoundError{}
 	}
 
+	// Put all the user's keys into the cache
+	c.userLinkMapCache[uid] = upak.SeqnoLinkIDs
 	if c.userKeyCache[uid] == nil {
 		c.userKeyCache[uid] = make(map[keybase1.KID]uvAndKey)
 	}
-	c.userKeyCache[uid][kid] = uvAndKey{
-		UV:  uv,
-		Key: *pubKey,
+	for _, user := range append(upak.PastIncarnations, upak.Current) {
+		pubKey, ok := user.DeviceKeys[kid]
+		if ok {
+			c.userKeyCache[uid][kid] = uvAndKey{
+				UV:  user.ToUserVersion(),
+				Key: pubKey,
+			}
+		}
 	}
-	c.userLinkMapCache[uid] = linkMap
-	return uv, pubKey, linkMap, nil
+
+	// Get from the just-updated cache
+	v, ok := c.userKeyCache[uid][kid]
+	if !ok {
+		return uv, nil, nil, libkb.NotFoundError{Msg: "Not found: Key for user"}
+	}
+	return v.UV, &v.Key, c.userLinkMapCache[uid], nil
 }


### PR DESCRIPTION
Used to be an attempt to load two different keys for the same user would miss the `loadKeyCache`. Now the cache preemptively caches all of the user's keys so future requests hit. This cut logging in half :D