### PR TITLE
fix fs header spacing

### DIFF
--- a/shared/fs/header/header.desktop.js
+++ b/shared/fs/header/header.desktop.js
@@ -70,16 +70,17 @@ const styleFolderHeaderEnd = {
 
 const styleFolderHeaderContainer = {
   ...stylesCommonRow,
+  width: '100%',
+  height: 48,
+  alignItems: 'center',
   position: 'relative',
-  marginTop: 15,
-  marginBottom: 15,
-  alignItems: 'flex-start',
 }
 
 const styleAddNew = {
   ...globalStyles.flexBoxRow,
   alignItems: 'center',
-  padding: globalMargins.tiny,
+  paddingTop: globalMargins.tiny,
+  paddingBottom: globalMargins.tiny,
   paddingRight: globalMargins.small - 4,
   paddingLeft: globalMargins.small,
 }


### PR DESCRIPTION
When "Add New" button is present, the whole header swells up:

<img width="711" alt="screen shot 2018-08-07 at 9 05 08 pm" src="https://user-images.githubusercontent.com/255797/43815655-9d618f26-9a85-11e8-8496-43ee7f46b931.png">

This PR makes it lean again:

<img width="608" alt="screen shot 2018-08-07 at 9 06 24 pm" src="https://user-images.githubusercontent.com/255797/43815683-c5e4ce40-9a85-11e8-898a-89f1c11247f2.png">
