### PR TITLE
Log quantity of exploding messages on ephemeralPurge

### DIFF
--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -275,6 +275,7 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
       return messageMap
     case Chat2Gen.messagesExploded:
       const {conversationIDKey, messageIDs} = action.payload
+      logger.info(`messagesExploded: exploding ${messageIDs.length} messages`)
       const ordinals = messageIDs
         .map(mid => messageIDToOrdinal(messageMap, pendingOutboxToOrdinal, conversationIDKey, mid))
         .filter(Boolean)


### PR DESCRIPTION
This is to help debug an issue @malgorithms reported about messages exploding seemingly late all at once. It'll show whether the service is sending up the notification on loading the thread. r? @keybase/react-hackers 