### PR TITLE
Do device clone check on service startup

### DIFF
--- a/go/service/main.go
+++ b/go/service/main.go
@@ -673,6 +673,10 @@ func (d *Service) slowChecks() {
 		ticker.Stop()
 		return nil
 	})
+	// Do this once fast
+	if err := d.deviceCloneSelfCheck(); err != nil {
+		d.G().Log.Debug("deviceCloneSelfCheck error: %s", err)
+	}
 	go func() {
 		for {
 			<-ticker.C


### PR DESCRIPTION
These periodic loops can run pretty infrequently on mobile/devices you don't use often, would probably be good to make sure we at least send on service restart.

cc @maxtaco 