### PR TITLE
For discussion: Users common adapter

### DIFF
--- a/shared/common-adapters/index.js
+++ b/shared/common-adapters/index.js
@@ -1,68 +1,4 @@
 // @flow
-import * as React from 'react'
-import Box from './box'
-import PopupDialog from './popup-dialog'
-import {connect, type Dispatch} from '../util/container'
-import {collapseStyles, globalColors, isMobile} from '../styles'
-
-const MaybePopup = isMobile
-  ? (props: {onClose: () => void, children: React.Node}) => (
-      <Box style={{height: '100%', width: '100%'}} children={props.children} />
-    )
-  : (props: {
-      onClose: () => void,
-      onMouseUp?: (e: SyntheticMouseEvent<>) => void,
-      onMouseDown?: (e: SyntheticMouseEvent<>) => void,
-      onMouseMove?: (e: SyntheticMouseEvent<>) => void,
-      children: React.Node,
-      cover?: boolean,
-      styleCover?: any,
-      styleContainer?: any,
-    }) => (
-      <PopupDialog
-        onClose={props.onClose}
-        onMouseUp={props.onMouseUp}
-        onMouseDown={props.onMouseDown}
-        onMouseMove={props.onMouseMove}
-        styleCover={collapseStyles([props.cover && _styleCover, props.styleCover])}
-        styleContainer={props.cover ? {..._styleContainer, ...props.styleContainer} : {}}
-        children={props.children}
-      />
-    )
-
-// TODO properly type this
-const DispatchNavUpHoc: any = connect(undefined, (dispatch: Dispatch, {navigateUp}) => ({
-  connectedNavigateUp: () => dispatch(navigateUp()),
-}))
-
-// TODO properly type this
-const _MaybePopupHoc: any = (cover: boolean) => {
-  return WrappedComponent => props => {
-    const onClose = props.onClose || props.connectedNavigateUp
-    return (
-      <MaybePopup onClose={onClose} cover={!!cover}>
-        <WrappedComponent onClose={onClose} {...props} />
-      </MaybePopup>
-    )
-  }
-}
-
-type MaybePopupHocType<P> = (
-  cover: boolean
-) => (WrappedComponent: React.ComponentType<P>) => React.ComponentType<P>
-const MaybePopupHoc: MaybePopupHocType<any> = (cover: boolean) => Component =>
-  DispatchNavUpHoc(_MaybePopupHoc(cover)(Component))
-
-const _styleCover = {
-  alignItems: 'stretch',
-  backgroundColor: globalColors.black_75,
-  justifyContent: 'stretch',
-}
-
-const _styleContainer = {
-  height: '100%',
-}
-
 export {default as Avatar, castPlatformStyles as avatarCastPlatformStyles} from './avatar'
 export {default as BackButton} from './back-button'
 export {default as Badge} from './badge'
@@ -99,7 +35,7 @@ export {default as LoadingLine} from './loading-line'
 export {default as ListItem} from './list-item'
 export {default as ListItem2} from './list-item2'
 export {default as Markdown} from './markdown'
-export {MaybePopup, MaybePopupHoc}
+export {MaybePopup, MaybePopupHoc} from './maybe-popup'
 export {default as MultiAvatar} from './multi-avatar.js'
 export {default as Meta} from './meta'
 export {default as NameWithIcon} from './name-with-icon'
@@ -124,6 +60,7 @@ export {default as TimelineMarker} from './timeline-marker'
 export {default as UserBio} from './user-bio'
 export {default as UserCard} from './user-card'
 export {default as UserProofs} from './user-proofs'
+export {default as Users} from './users'
 export {PlaintextUsernames, Usernames, ConnectedUsernames} from './usernames'
 export {default as WaitingButton} from './waiting-button'
 export {default as HOCTimers} from './hoc-timers'

--- a/shared/common-adapters/maybe-popup.js
+++ b/shared/common-adapters/maybe-popup.js
@@ -1,0 +1,66 @@
+// @flow
+import * as React from 'react'
+import Box from './box'
+import PopupDialog from './popup-dialog'
+import {connect, type Dispatch} from '../util/container'
+import {collapseStyles, globalColors, isMobile} from '../styles'
+
+const MaybePopup = isMobile
+  ? (props: {onClose: () => void, children: React.Node}) => (
+      <Box style={{height: '100%', width: '100%'}} children={props.children} />
+    )
+  : (props: {
+      onClose: () => void,
+      onMouseUp?: (e: SyntheticMouseEvent<>) => void,
+      onMouseDown?: (e: SyntheticMouseEvent<>) => void,
+      onMouseMove?: (e: SyntheticMouseEvent<>) => void,
+      children: React.Node,
+      cover?: boolean,
+      styleCover?: any,
+      styleContainer?: any,
+    }) => (
+      <PopupDialog
+        onClose={props.onClose}
+        onMouseUp={props.onMouseUp}
+        onMouseDown={props.onMouseDown}
+        onMouseMove={props.onMouseMove}
+        styleCover={collapseStyles([props.cover && _styleCover, props.styleCover])}
+        styleContainer={props.cover ? {..._styleContainer, ...props.styleContainer} : {}}
+        children={props.children}
+      />
+    )
+
+// TODO properly type this
+const DispatchNavUpHoc: any = connect(undefined, (dispatch: Dispatch, {navigateUp}) => ({
+  connectedNavigateUp: () => dispatch(navigateUp()),
+}))
+
+// TODO properly type this
+const _MaybePopupHoc: any = (cover: boolean) => {
+  return WrappedComponent => props => {
+    const onClose = props.onClose || props.connectedNavigateUp
+    return (
+      <MaybePopup onClose={onClose} cover={!!cover}>
+        <WrappedComponent onClose={onClose} {...props} />
+      </MaybePopup>
+    )
+  }
+}
+
+type MaybePopupHocType<P> = (
+  cover: boolean
+) => (WrappedComponent: React.ComponentType<P>) => React.ComponentType<P>
+const MaybePopupHoc: MaybePopupHocType<any> = (cover: boolean) => Component =>
+  DispatchNavUpHoc(_MaybePopupHoc(cover)(Component))
+
+const _styleCover = {
+  alignItems: 'stretch',
+  backgroundColor: globalColors.black_75,
+  justifyContent: 'stretch',
+}
+
+const _styleContainer = {
+  height: '100%',
+}
+
+export {MaybePopup, MaybePopupHoc}

--- a/shared/common-adapters/users.js
+++ b/shared/common-adapters/users.js
@@ -24,7 +24,7 @@ type OwnProps = {
 }
 
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
-  return {_following: state.config.following}
+  return {following: state.config.following}
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {tracker, usernames}: OwnProps) => ({
@@ -36,21 +36,8 @@ const mapDispatchToProps = (dispatch: Dispatch, {tracker, usernames}: OwnProps) 
 
 const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => ({
   children: ownProps.children,
-  colors: ownProps.usernames.map(
-    u => (stateProps._following.has(u) ? globalColors.green2 : globalColors.blue)
-  ),
-  followings: ownProps.usernames.map(u => stateProps._following.has(u)),
+  following: stateProps.following,
   onClick: dispatchProps.onClick,
-  texts: ownProps.usernames.map(username => (
-    <Text
-      type={ownProps.textType || 'BodySemibold'}
-      style={stateProps._following.has(username) ? styles.following : styles.everyoneElse}
-      key={username}
-      onClick={() => dispatchProps.onClick(username)}
-    >
-      {username}
-    </Text>
-  )),
   usernames: ownProps.usernames,
 })
 
@@ -65,25 +52,35 @@ const styles = styleSheetCreate({
 
 type Props = {
   children: Args => React.Node,
-  colors: string[],
-  followings: boolean[],
+  following: string[],
   onClick: (username: string) => void,
-  texts: React.Element<typeof Text>[],
+  textType?: TextType,
   usernames: string[],
 }
 const Users = (props: Props) => {
   return (
-    props.usernames.map((username, i, usernames) =>
-      props.children({
-        color: props.colors[i],
-        following: props.followings[i],
+    props.usernames.map((username, i, usernames) => {
+      const following = props.following.includes(username)
+      return props.children({
+        color: following ? globalColors.green2 : globalColors.blue,
+        following,
         index: i,
         last: i === usernames.length - 1,
         onClick: () => props.onClick(username),
-        text: props.texts[i],
+        text: (
+          <Text
+            className="hover-underline"
+            type={props.textType || 'BodySemibold'}
+            style={following ? styles.following : styles.everyoneElse}
+            key={username}
+            onClick={() => props.onClick(username)}
+          >
+            {username}
+          </Text>
+        ),
         username,
       })
-    ) || null
+    }) || null
   )
 }
 

--- a/shared/common-adapters/users.js
+++ b/shared/common-adapters/users.js
@@ -1,14 +1,24 @@
 // @flow
 import * as React from 'react'
+import * as I from 'immutable'
 import * as ProfileGen from '../actions/profile-gen'
 import * as TrackerGen from '../actions/tracker-gen'
+import * as UsersTypes from '../constants/types/users'
 import {connect, type TypedState} from '../util/container'
 import Text, {type TextType} from './text'
 import {globalColors, isMobile, styleSheetCreate} from '../styles'
 
+/**
+ * Users - get generic information about users to use in your view. Passes in
+ * various information (`Args`) to a function child. Renders arbitrary return
+ * value with no added markup. If children returns an array, it must be of
+ * either primitives or components with a `key` supplied.
+ */
+
 type Args = {
   color: string,
   following: boolean,
+  fullName: string,
   index: number,
   last: boolean,
   onClick: () => void,
@@ -24,7 +34,7 @@ type OwnProps = {
 }
 
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
-  return {following: state.config.following}
+  return {following: state.config.following, usersInfo: state.users.infoMap}
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {tracker, usernames}: OwnProps) => ({
@@ -40,6 +50,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => ({
   onClick: dispatchProps.onClick,
   textType: ownProps.textType,
   usernames: ownProps.usernames,
+  usersInfo: stateProps.usersInfo,
 })
 
 const styles = styleSheetCreate({
@@ -57,6 +68,7 @@ type Props = {
   onClick: (username: string) => void,
   textType?: TextType,
   usernames: string[],
+  usersInfo: I.Map<string, UsersTypes.UserInfo>,
 }
 const Users = (props: Props) => {
   return (
@@ -65,6 +77,7 @@ const Users = (props: Props) => {
       return props.children({
         color: following ? globalColors.green2 : globalColors.blue,
         following,
+        fullName: props.usersInfo.get(username, {fullname: ''}).fullname,
         index: i,
         last: i === usernames.length - 1,
         onClick: () => props.onClick(username),

--- a/shared/common-adapters/users.js
+++ b/shared/common-adapters/users.js
@@ -38,6 +38,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => ({
   children: ownProps.children,
   following: stateProps.following,
   onClick: dispatchProps.onClick,
+  textType: ownProps.textType,
   usernames: ownProps.usernames,
 })
 

--- a/shared/common-adapters/users.js
+++ b/shared/common-adapters/users.js
@@ -11,8 +11,7 @@ import {globalColors, isMobile, styleSheetCreate} from '../styles'
 /**
  * Users - get generic information about users to use in your view. Passes in
  * various information (`Args`) to a function child. Renders arbitrary return
- * value with no added markup. If children returns an array, it must be of
- * either primitives or components with a `key` supplied.
+ * value with no added markup.
  */
 
 type Args = {

--- a/shared/common-adapters/users.js
+++ b/shared/common-adapters/users.js
@@ -1,0 +1,98 @@
+// @flow
+import * as React from 'react'
+import * as ProfileGen from '../actions/profile-gen'
+import * as TrackerGen from '../actions/tracker-gen'
+import {connect, type TypedState} from '../util/container'
+import Text, {type TextType} from './text'
+import {globalColors, isMobile, styleSheetCreate} from '../styles'
+
+type Args = {
+  index: number,
+  username: string,
+  following: boolean,
+  color: string,
+  text: React.Element<typeof Text>,
+  last: boolean,
+}
+
+type OwnProps = {
+  children: Args => React.Node,
+  textType?: TextType,
+  tracker?: boolean,
+  usernames: string[],
+}
+
+const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+  return (
+    ownProps.usernames.reduce(
+      (res, username) => {
+        const following = state.config.following.includes(username)
+        res && res.usernames.push(username)
+        res && res.followings.push(following)
+        res && res.colors.push(following ? globalColors.green : globalColors.blue)
+        res &&
+          res.texts.push(
+            <Text
+              type={ownProps.textType || 'BodySemibold'}
+              style={following ? styles.following : styles.everyoneElse}
+            >
+              {username}
+            </Text>
+          )
+        return res
+      },
+      {
+        usernames: [],
+        followings: [],
+        colors: [],
+        texts: [],
+      }
+    ) || {
+      usernames: ownProps.usernames,
+      followings: [],
+      colors: [],
+      texts: [],
+    }
+  )
+}
+
+const mapDispatchToProps = (dispatch: Dispatch, {tracker, usernames}: OwnProps) => ({
+  onClick: (i: number) =>
+    tracker && !isMobile
+      ? dispatch(TrackerGen.createGetProfile({username: usernames[i]}))
+      : dispatch(ProfileGen.createShowUserProfile({username: usernames[i]})),
+})
+
+const styles = styleSheetCreate({
+  following: {
+    color: globalColors.green2,
+  },
+  everyoneElse: {
+    color: globalColors.blue,
+  },
+})
+
+type Props = {
+  children: Args => React.Node,
+  onClick: (i: number) => void,
+  usernames: string[],
+  followings: boolean[],
+  colors: string[],
+  texts: React.Element<typeof Text>[],
+}
+const Users = (props: Props) => {
+  return (
+    props.usernames.map((username, i, usernames) =>
+      props.children({
+        index: i,
+        username,
+        following: props.followings[i],
+        color: props.colors[i],
+        text: props.texts[i],
+        last: i === usernames.length - 1,
+      })
+    ) || null
+  )
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Users)

--- a/shared/constants/types/users.js
+++ b/shared/constants/types/users.js
@@ -6,7 +6,7 @@ export type _UserInfo = {
   broken: boolean,
   fullname: string,
 }
-type UserInfo = I.RecordOf<_UserInfo>
+export type UserInfo = I.RecordOf<_UserInfo>
 
 export type _State = {
   infoMap: I.Map<string, UserInfo>,

--- a/shared/people/follow-notification/index.js
+++ b/shared/people/follow-notification/index.js
@@ -11,8 +11,9 @@ import {
   Meta,
   ScrollView,
   Text,
+  Users,
 } from '../../common-adapters'
-import {globalStyles, globalColors, globalMargins, platformStyles} from '../../styles'
+import {globalStyles, globalColors, globalMargins} from '../../styles'
 import {isMobile} from '../../constants/platform'
 
 const connectedUsernamesProps = {
@@ -87,15 +88,14 @@ export const MultiFollowNotification = (props: Props) => {
       }
       when={props.notificationTime}
     >
-      <Text type="Body" style={platformStyles({common: {marginTop: 2, marginBottom: globalMargins.xtiny}, isElectron: {display: 'inline'}})}>
-        <ConnectedUsernames
-          containerStyle={platformStyles({isElectron: {whiteSpace: 'wrap'}})}
-          inlineGrammar={true}
-          showAnd={!props.numAdditional}
-          {...connectedUsernamesProps}
-          usernames={usernames}
-          onUsernameClicked={props.onClickUser}
-        />
+      <Text type="Body" style={{marginTop: 2, marginBottom: globalMargins.xtiny}}>
+        <Users usernames={usernames}>
+          {({index, username, following, color, text, last}) => [
+            text,
+            (!last && index !== usernames.length - 2 && ', ') || null,
+            (index === usernames.length - 2 && ' and ') || null,
+          ]}
+        </Users>
         {!!props.numAdditional && props.numAdditional > 0 && ` and ${props.numAdditional} others `} started
         following you.
       </Text>

--- a/shared/people/follow-notification/index.js
+++ b/shared/people/follow-notification/index.js
@@ -90,10 +90,10 @@ export const MultiFollowNotification = (props: Props) => {
     >
       <Text type="Body" style={{marginTop: 2, marginBottom: globalMargins.xtiny}}>
         <Users usernames={usernames}>
-          {({index, username, following, color, text, last}) => [
+          {({index, text, last}) => [
             text,
             (!last && index !== usernames.length - 2 && ', ') || null,
-            (index === usernames.length - 2 && ' and ') || null,
+            (index === usernames.length - 2 && !props.numAdditional && ' and ') || null,
           ]}
         </Users>
         {!!props.numAdditional && props.numAdditional > 0 && ` and ${props.numAdditional} others `} started

--- a/shared/people/follow-notification/index.js
+++ b/shared/people/follow-notification/index.js
@@ -2,30 +2,9 @@
 import React from 'react'
 import PeopleItem from '../item'
 import * as Types from '../../constants/types/people'
-import {
-  Avatar,
-  Box,
-  ClickableBox,
-  ConnectedUsernames,
-  Icon,
-  Meta,
-  ScrollView,
-  Text,
-  Users,
-} from '../../common-adapters'
+import {Avatar, Box, ClickableBox, Icon, Meta, ScrollView, Text, Users} from '../../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
 import {isMobile} from '../../constants/platform'
-
-const connectedUsernamesProps = {
-  clickable: true,
-  inline: true,
-  colorFollowing: true,
-  type: 'BodySemibold',
-  underline: true,
-  joinerStyle: {
-    fontWeight: 'normal',
-  },
-}
 
 export type NewFollow = Types.FollowedNotification
 
@@ -54,12 +33,7 @@ export const FollowNotification = (props: Props) => {
         contentStyle={{justifyContent: 'center'}}
       >
         <Text type="Body" style={{marginTop: 2}}>
-          <ConnectedUsernames
-            {...connectedUsernamesProps}
-            usernames={[username]}
-            onUsernameClicked={props.onClickUser}
-          />{' '}
-          followed you.
+          <Users usernames={[username]}>{({text}) => text}</Users> followed you.
         </Text>
       </PeopleItem>
     </ClickableBox>


### PR DESCRIPTION
Adds a new common adapter `Users`. It takes a function as a child, which it gives some generic information about a list of usernames such as their `fullName` and whether you follow them. It also gives a callback to navigate to the profile and a correctly colored / clickable `Text` instance that can be directly returned by `children`.

Also:  
- Replace instances of `ConnectedUsernames` in the people tab follow notifications, which have been particularly difficult to special case in the past (cc @jzila).
- Move `MaybePopup` out of `common-adapters/index` to it's own file.

I wrote this a couple weeks ago but it was giving a very strange flow error then. It works today hence the PR.

r? @keybase/react-hackers 