### PR TITLE
Tweak gobuild.sh to be runnable from anywhere

### DIFF
--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -83,11 +83,15 @@ gomobile_path="$vendor_path/golang.org/x/mobile/cmd/gomobile"
 rsync -pr --ignore-times "$vendor_path/" "$GOPATH/src/"
 package="github.com/keybase/client/go/bind"
 
-## TODO(mm) consolidate this with packaging/prerelease/
-current_date=`date -u +%Y%m%d%H%M%S` # UTC
-commit_short=`git log -1 --pretty=format:%h`
-build="$current_date+$commit_short"
-keybase_build=${KEYBASE_BUILD:-$build}
+if [[ -n ${KEYBASE_BUILD+x} && "$KEYBASE_BUILD" ]]; then
+    keybase_build="$KEYBASE_BUILD"
+else
+    ## TODO(mm) consolidate this with packaging/prerelease/
+    current_date=`date -u +%Y%m%d%H%M%S` # UTC
+    commit_short=`git log -1 --pretty=format:%h`
+    keybase_build="$current_date+$commit_short"
+fi
+
 tags=${TAGS:-"prerelease production"}
 ldflags="-X github.com/keybase/client/go/libkb.PrereleaseBuild=$keybase_build"
 

--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -14,7 +14,7 @@ fi
 
 # For CI, this is run like
 #
-#  env KEYBASE_BUILD=kbfsci DEST_DIR=/tmp /path/to/gobuild.sh android
+#  env KEYBASE_BUILD=ci DEST_DIR=/tmp /path/to/gobuild.sh android-or-ios
 #
 # so make sure doing so doesn't assume anything about where this file
 # is.

--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -7,6 +7,11 @@ cd $dir
 
 arg=${1:-}
 
+if [[ "$arg" != "ios" && "$arg" != "android" ]]; then
+  echo "Nothing to build, you need to specify 'ios' or 'android'"
+  exit 1
+fi
+
 local_client=${LOCAL_CLIENT:-"1"}
 local_kbfs=${LOCAL_KBFS:-}
 skip_gomobile_init=${SKIP_GOMOBILE_INIT:-}
@@ -137,5 +142,7 @@ elif [ "$arg" = "android" ]; then
     echo $OUTPUT
   fi
 else
+  # Shouldn't get here.
   echo "Nothing to build, you need to specify 'ios' or 'android'"
+  exit 1
 fi

--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -109,7 +109,8 @@ gomobileinit ()
 }
 
 if [ "$arg" = "ios" ]; then
-  ios_dest="$dir/ios/keybase.framework"
+  ios_dir=${DEST_DIR:-"$dir/ios"}
+  ios_dest="$ios_dir/keybase.framework"
   echo "Building for iOS ($ios_dest)..."
   set +e
   OUTPUT="$("$GOPATH/bin/gomobile" bind -target=ios -tags="ios" -ldflags "$ldflags" -o "$ios_dest" "$package" 2>&1)"
@@ -122,7 +123,8 @@ if [ "$arg" = "ios" ]; then
     echo $OUTPUT
   fi
 elif [ "$arg" = "android" ]; then
-  android_dest="$dir/android/keybaselib/keybaselib.aar"
+  android_dir=${DEST_DIR:-"$dir/android/keybaselib"}
+  android_dest="$android_dir/keybaselib.aar"
   echo "Building for Android ($android_dest)..."
   set +e
   OUTPUT="$("$GOPATH/bin/gomobile" bind -target=android -tags="android" -ldflags "$ldflags" -o "$android_dest" "$package" 2>&1)"

--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -14,10 +14,9 @@ fi
 
 # For CI, this is run like
 #
-#  env KEYBASE_BUILD=ci DEST_DIR=/tmp /path/to/gobuild.sh android-or-ios
+#  env KEYBASE_BUILD=ci DEST_DIR=/tmp ... /path/to/gobuild.sh android|ios
 #
-# so make sure doing so doesn't assume anything about where this file
-# is.
+# so make sure doing so doesn't assume anything about where this file is.
 
 # If KEYBASE_BUILD is set and non-empty (e.g., for CI), use it.
 if [[ -n ${KEYBASE_BUILD+x} && "$KEYBASE_BUILD" ]]; then

--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -12,6 +12,16 @@ if [[ "$arg" != "ios" && "$arg" != "android" ]]; then
   exit 1
 fi
 
+# If KEYBASE_BUILD is set and non-empty (e.g., for CI), use it.
+if [[ -n ${KEYBASE_BUILD+x} && "$KEYBASE_BUILD" ]]; then
+    keybase_build="$KEYBASE_BUILD"
+else
+    ## TODO(mm) consolidate this with packaging/prerelease/
+    current_date=`date -u +%Y%m%d%H%M%S` # UTC
+    commit_short=`git log -1 --pretty=format:%h`
+    keybase_build="$current_date+$commit_short"
+fi
+
 local_client=${LOCAL_CLIENT:-"1"}
 local_kbfs=${LOCAL_KBFS:-}
 skip_gomobile_init=${SKIP_GOMOBILE_INIT:-}
@@ -87,16 +97,6 @@ vendor_path="$GOPATH/src/github.com/keybase/vendor"
 gomobile_path="$vendor_path/golang.org/x/mobile/cmd/gomobile"
 rsync -pr --ignore-times "$vendor_path/" "$GOPATH/src/"
 package="github.com/keybase/client/go/bind"
-
-if [[ -n ${KEYBASE_BUILD+x} && "$KEYBASE_BUILD" ]]; then
-    keybase_build="$KEYBASE_BUILD"
-else
-    ## TODO(mm) consolidate this with packaging/prerelease/
-    current_date=`date -u +%Y%m%d%H%M%S` # UTC
-    commit_short=`git log -1 --pretty=format:%h`
-    keybase_build="$current_date+$commit_short"
-fi
-
 tags=${TAGS:-"prerelease production"}
 ldflags="-X github.com/keybase/client/go/libkb.PrereleaseBuild=$keybase_build"
 

--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -12,6 +12,13 @@ if [[ "$arg" != "ios" && "$arg" != "android" ]]; then
   exit 1
 fi
 
+# For CI, this is run like
+#
+#  env KEYBASE_BUILD=kbfsci DEST_DIR=/tmp /path/to/gobuild.sh android
+#
+# so make sure doing so doesn't assume anything about where this file
+# is.
+
 # If KEYBASE_BUILD is set and non-empty (e.g., for CI), use it.
 if [[ -n ${KEYBASE_BUILD+x} && "$KEYBASE_BUILD" ]]; then
     keybase_build="$KEYBASE_BUILD"


### PR DESCRIPTION
...for example, for KBFS CI, so that we don't have to do a clone
of the client repo just to get it.