### PR TITLE
handle superseded messages properly for incremental mode in GetThreadNonblock CORE-8523

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -133,8 +133,9 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 
 	// Resolve supersedes
 	if q == nil || !q.DisableResolveSupersedes {
+		deletePlaceholders := q != nil && q.EnableDeletePlaceholders
 		if superXform == nil {
-			superXform = newBasicSupersedesTransform(s.G())
+			superXform = newBasicSupersedesTransform(s.G(), deletePlaceholders)
 		}
 		if thread.Messages, err = superXform.Run(ctx, conv, uid, thread.Messages); err != nil {
 			return err
@@ -165,7 +166,7 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 
 func (s *baseConversationSource) TransformSupersedes(ctx context.Context,
 	unboxInfo types.UnboxConversationInfo, uid gregor1.UID, msgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error) {
-	transform := newBasicSupersedesTransform(s.G())
+	transform := newBasicSupersedesTransform(s.G(), false)
 	return transform.Run(ctx, unboxInfo, uid, msgs)
 }
 
@@ -871,7 +872,7 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 	// Post process thread before returning
 	defer func() {
 		if err == nil {
-			superXform := newBasicSupersedesTransform(s.G())
+			superXform := newBasicSupersedesTransform(s.G(), false)
 			superXform.SetMessagesFunc(func(ctx context.Context, conv types.UnboxConversationInfo,
 				uid gregor1.UID, msgIDs []chat1.MessageID,
 				_ *chat1.GetThreadReason) (res []chat1.MessageUnboxed, err error) {

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -702,7 +702,8 @@ func (s *HybridConversationSource) resolveHoles(ctx context.Context, uid gregor1
 		if err != nil {
 			continue
 		}
-		if state == chat1.MessageUnboxedState_PLACEHOLDER {
+		switch state {
+		case chat1.MessageUnboxedState_PLACEHOLDER:
 			if msg, ok := msgLookup[threadMsg.GetMessageID()]; ok {
 				thread.Messages[i] = msg
 			} else {

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -135,7 +135,9 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 	if q == nil || !q.DisableResolveSupersedes {
 		deletePlaceholders := q != nil && q.EnableDeletePlaceholders
 		if superXform == nil {
-			superXform = newBasicSupersedesTransform(s.G(), deletePlaceholders)
+			superXform = newBasicSupersedesTransform(s.G(), basicSupersedesTransformOpts{
+				UseDeletePlaceholders: deletePlaceholders,
+			})
 		}
 		if thread.Messages, err = superXform.Run(ctx, conv, uid, thread.Messages); err != nil {
 			return err
@@ -166,7 +168,7 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 
 func (s *baseConversationSource) TransformSupersedes(ctx context.Context,
 	unboxInfo types.UnboxConversationInfo, uid gregor1.UID, msgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error) {
-	transform := newBasicSupersedesTransform(s.G(), false)
+	transform := newBasicSupersedesTransform(s.G(), basicSupersedesTransformOpts{})
 	return transform.Run(ctx, unboxInfo, uid, msgs)
 }
 
@@ -872,7 +874,7 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 	// Post process thread before returning
 	defer func() {
 		if err == nil {
-			superXform := newBasicSupersedesTransform(s.G(), false)
+			superXform := newBasicSupersedesTransform(s.G(), basicSupersedesTransformOpts{})
 			superXform.SetMessagesFunc(func(ctx context.Context, conv types.UnboxConversationInfo,
 				uid gregor1.UID, msgIDs []chat1.MessageID,
 				_ *chat1.GetThreadReason) (res []chat1.MessageUnboxed, err error) {

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -1232,7 +1232,6 @@ func (n *newConversationHelper) makeFirstMessage(ctx context.Context, triple cha
 }
 
 func CreateNameInfoSource(ctx context.Context, g *globals.Context, membersType chat1.ConversationMembersType) types.NameInfoSource {
-	g.GetLog().CDebugf(ctx, "createNameInfoSource: hi")
 	if override := ctx.Value(nameInfoOverrideKey); override != nil {
 		g.GetLog().CDebugf(ctx, "createNameInfoSource: using override: %T", override)
 		return override.(types.NameInfoSource)

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -78,7 +78,7 @@ func NewBlockingLocalizer(g *globals.Context) *BlockingLocalizer {
 	return &BlockingLocalizer{
 		Contextified:  globals.NewContextified(g),
 		baseLocalizer: newBaseLocalizer(g),
-		pipeline:      newLocalizerPipeline(g, newBasicSupersedesTransform(g)),
+		pipeline:      newLocalizerPipeline(g, newBasicSupersedesTransform(g, false)),
 	}
 }
 
@@ -124,7 +124,7 @@ func NewNonblockingLocalizer(g *globals.Context, localizeCb chan NonblockInboxRe
 		Contextified:  globals.NewContextified(g),
 		DebugLabeler:  utils.NewDebugLabeler(g.GetLog(), "NonblockingLocalizer", false),
 		baseLocalizer: newBaseLocalizer(g),
-		pipeline:      newLocalizerPipeline(g, newBasicSupersedesTransform(g)),
+		pipeline:      newLocalizerPipeline(g, newBasicSupersedesTransform(g, false)),
 		localizeCb:    localizeCb,
 		maxUnbox:      maxUnbox,
 	}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -78,7 +78,8 @@ func NewBlockingLocalizer(g *globals.Context) *BlockingLocalizer {
 	return &BlockingLocalizer{
 		Contextified:  globals.NewContextified(g),
 		baseLocalizer: newBaseLocalizer(g),
-		pipeline:      newLocalizerPipeline(g, newBasicSupersedesTransform(g, false)),
+		pipeline: newLocalizerPipeline(g,
+			newBasicSupersedesTransform(g, basicSupersedesTransformOpts{})),
 	}
 }
 
@@ -124,9 +125,10 @@ func NewNonblockingLocalizer(g *globals.Context, localizeCb chan NonblockInboxRe
 		Contextified:  globals.NewContextified(g),
 		DebugLabeler:  utils.NewDebugLabeler(g.GetLog(), "NonblockingLocalizer", false),
 		baseLocalizer: newBaseLocalizer(g),
-		pipeline:      newLocalizerPipeline(g, newBasicSupersedesTransform(g, false)),
-		localizeCb:    localizeCb,
-		maxUnbox:      maxUnbox,
+		pipeline: newLocalizerPipeline(g,
+			newBasicSupersedesTransform(g, basicSupersedesTransformOpts{})),
+		localizeCb: localizeCb,
+		maxUnbox:   maxUnbox,
 	}
 }
 

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -62,17 +62,15 @@ type Server struct {
 var _ chat1.LocalInterface = (*Server)(nil)
 
 func NewServer(g *globals.Context, serverConn ServerConnection, uiSource UISource) *Server {
-	delay := 5 * time.Second
 	return &Server{
-		Contextified:      globals.NewContextified(g),
-		DebugLabeler:      utils.NewDebugLabeler(g.GetLog(), "Server", false),
-		serverConn:        serverConn,
-		uiSource:          uiSource,
-		boxer:             NewBoxer(g),
-		identNotifier:     NewCachingIdentifyNotifier(g),
-		clock:             clockwork.NewRealClock(),
-		convPageStatus:    make(map[string]chat1.Pagination),
-		remoteThreadDelay: &delay,
+		Contextified:   globals.NewContextified(g),
+		DebugLabeler:   utils.NewDebugLabeler(g.GetLog(), "Server", false),
+		serverConn:     serverConn,
+		uiSource:       uiSource,
+		boxer:          NewBoxer(g),
+		identNotifier:  NewCachingIdentifyNotifier(g),
+		clock:          clockwork.NewRealClock(),
+		convPageStatus: make(map[string]chat1.Pagination),
 	}
 }
 

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -500,8 +500,6 @@ func (h *Server) mergeLocalRemoteThread(ctx context.Context, remoteThread, local
 			return true
 		}
 		// If newMsg is now superseded by something different than what we sent, then let's include it
-		h.Debug(ctx, "mergeLocalRemoteThread: new: %v old: %v newSupersededBy: %v oldSupersededy: %v",
-			newMsg.GetMessageID(), oldMsg.GetMessageID(), newMsg.Valid().ServerHeader.SupersededBy, oldMsg.Valid().ServerHeader.SupersededBy)
 		if newMsg.Valid().ServerHeader.SupersededBy != oldMsg.Valid().ServerHeader.SupersededBy {
 			h.Debug(ctx, "mergeLocalRemoteThread: including supersededBy change: msgID: %d",
 				newMsg.GetMessageID())

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -499,6 +499,8 @@ func (h *Server) mergeLocalRemoteThread(ctx context.Context, remoteThread, local
 		}
 		// If newMsg is now superseded by something different than what we sent, then let's include it
 		if newMsg.Valid().ServerHeader.SupersededBy != oldMsg.Valid().ServerHeader.SupersededBy {
+			h.Debug(ctx, "mergeLocalRemoteThread: including supersededBy change: msgID: %d",
+				newMsg.GetMessageID())
 			return true
 		}
 		return false

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -658,6 +658,12 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 		return res, err
 	}
 
+	// Enable delete placeholders for supersede transform
+	if arg.Query == nil {
+		arg.Query = new(chat1.GetThreadQuery)
+	}
+	arg.Query.EnableDeletePlaceholders = true
+
 	// Xlate pager control into pagination if given
 	if arg.Query != nil && arg.Query.MessageIDControl != nil {
 		pagination = utils.XlateMessageIDControlToPagination(arg.Query.MessageIDControl)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2667,31 +2667,11 @@ func confirmIsText(t *testing.T, msgID chat1.MessageID, msg chat1.UIMessage, tex
 	require.Equal(t, text, msg.Valid().MessageBody.Text().Body)
 }
 
-func TestChatSrvGetThreadNonblockPlaceholders(t *testing.T) {
+func TestChatSrvGetThreadNonblockSupersedes(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
-		ctc := makeChatTestContext(t, "GetThreadNonblockPlaceholders", 1)
+		ctc := makeChatTestContext(t, "GetThreadNonblockSupersedes", 1)
 		defer ctc.cleanup()
 		users := ctc.users()
-
-		editMsg := func(ctx context.Context, conv chat1.ConversationInfoLocal, msgID chat1.MessageID) chat1.MessageID {
-			postRes, err := ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, chat1.PostLocalArg{
-				ConversationID: conv.Id,
-				Msg: chat1.MessagePlaintext{
-					ClientHeader: chat1.MessageClientHeader{
-						Conv:        conv.Triple,
-						MessageType: chat1.MessageType_EDIT,
-						TlfName:     conv.TlfName,
-						Supersedes:  msgID,
-					},
-					MessageBody: chat1.NewMessageBodyWithEdit(chat1.MessageEdit{
-						MessageID: msgID,
-						Body:      "HI",
-					}),
-				},
-			})
-			require.NoError(t, err)
-			return postRes.MessageID
-		}
 
 		uid := gregor1.UID(users[0].GetUID().ToBytes())
 		inboxCb := make(chan kbtest.NonblockInboxResult, 100)
@@ -2708,11 +2688,185 @@ func TestChatSrvGetThreadNonblockPlaceholders(t *testing.T) {
 		msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
 		msgID1 := mustPostLocalForTest(t, ctc, users[0], conv, msg)
 		consumeNewMsgRemote(t, listener, chat1.MessageType_TEXT)
-		editMsgID1 := editMsg(ctx, conv, msgID1)
+		msgRes, err := ctc.as(t, users[0]).chatLocalHandler().GetMessagesLocal(ctx, chat1.GetMessagesLocalArg{
+			ConversationID:           conv.Id,
+			MessageIDs:               []chat1.MessageID{msgID1},
+			DisableResolveSupersedes: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(msgRes.Messages))
+		msg1 := msgRes.Messages[0]
+		editMsgID1 := mustEditMsg(ctx, t, ctc, users[0], conv, msgID1)
+		consumeNewMsgRemote(t, listener, chat1.MessageType_EDIT)
+
+		msgIDs := []chat1.MessageID{editMsgID1, msgID1, 1}
+		require.NoError(t, cs.Clear(context.TODO(), conv.Id, uid))
+		_, err = cs.PushUnboxed(ctx, conv.Id, uid, msg1)
+		require.NoError(t, err)
+
+		delay := 10 * time.Minute
+		clock := clockwork.NewFakeClock()
+		ctc.as(t, users[0]).h.clock = clock
+		ctc.as(t, users[0]).h.remoteThreadDelay = &delay
+		cb := make(chan struct{})
+		query := chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}
+		go func() {
+			_, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(ctx,
+				chat1.GetThreadNonblockArg{
+					ConversationID: conv.Id,
+					Query:          &query,
+					CbMode:         chat1.GetThreadNonblockCbMode_INCREMENTAL,
+				},
+			)
+			require.NoError(t, err)
+			close(cb)
+		}()
+		select {
+		case res := <-threadCb:
+			require.False(t, res.Full)
+			require.Equal(t, len(msgIDs), len(res.Thread.Messages))
+			require.Equal(t, msgIDs, utils.PluckUIMessageIDs(res.Thread.Messages))
+			confirmIsText(t, msgID1, res.Thread.Messages[1], "hi")
+			require.False(t, res.Thread.Messages[1].Valid().Superseded)
+			confirmIsPlaceholder(t, editMsgID1, res.Thread.Messages[0], false)
+			confirmIsPlaceholder(t, 1, res.Thread.Messages[2], false)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no thread cb")
+		}
+		clock.Advance(20 * time.Minute)
+		select {
+		case res := <-threadCb:
+			require.True(t, res.Full)
+			require.Equal(t, len(msgIDs), len(res.Thread.Messages))
+			confirmIsPlaceholder(t, editMsgID1, res.Thread.Messages[0], true)
+			confirmIsText(t, msgID1, res.Thread.Messages[1], "HI")
+			confirmIsPlaceholder(t, 1, res.Thread.Messages[2], true)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no thread cb")
+		}
+		select {
+		case <-cb:
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "GetThread never finished")
+		}
+
+		deleteMsgID := mustDeleteMsg(ctx, t, ctc, users[0], conv, msgID1)
+		consumeNewMsgRemote(t, listener, chat1.MessageType_DELETE)
+		msgIDs = []chat1.MessageID{deleteMsgID, editMsgID1, msgID1, 1}
+		require.NoError(t, cs.Clear(context.TODO(), conv.Id, uid))
+		_, err = cs.PushUnboxed(ctx, conv.Id, uid, msg1)
+		require.NoError(t, err)
+		cb = make(chan struct{})
+		go func() {
+			_, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(ctx,
+				chat1.GetThreadNonblockArg{
+					ConversationID: conv.Id,
+					Query:          &query,
+					CbMode:         chat1.GetThreadNonblockCbMode_INCREMENTAL,
+				},
+			)
+			require.NoError(t, err)
+			close(cb)
+		}()
+		select {
+		case res := <-threadCb:
+			require.False(t, res.Full)
+			require.Equal(t, len(msgIDs), len(res.Thread.Messages))
+			require.Equal(t, msgIDs, utils.PluckUIMessageIDs(res.Thread.Messages))
+			confirmIsPlaceholder(t, deleteMsgID, res.Thread.Messages[0], false)
+			confirmIsPlaceholder(t, editMsgID1, res.Thread.Messages[1], false)
+			confirmIsText(t, msgID1, res.Thread.Messages[2], "hi")
+			require.False(t, res.Thread.Messages[2].Valid().Superseded)
+			confirmIsPlaceholder(t, 1, res.Thread.Messages[3], false)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no thread cb")
+		}
+		clock.Advance(20 * time.Minute)
+		select {
+		case res := <-threadCb:
+			require.True(t, res.Full)
+			require.Equal(t, len(msgIDs), len(res.Thread.Messages))
+			confirmIsPlaceholder(t, deleteMsgID, res.Thread.Messages[0], true)
+			confirmIsPlaceholder(t, editMsgID1, res.Thread.Messages[1], true)
+			confirmIsPlaceholder(t, msgID1, res.Thread.Messages[2], true)
+			confirmIsPlaceholder(t, 1, res.Thread.Messages[3], true)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no thread cb")
+		}
+		select {
+		case <-cb:
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "GetThread never finished")
+		}
+	})
+}
+
+func mustDeleteMsg(ctx context.Context, t *testing.T, ctc *chatTestContext, user *kbtest.FakeUser,
+	conv chat1.ConversationInfoLocal, msgID chat1.MessageID) chat1.MessageID {
+	postRes, err := ctc.as(t, user).chatLocalHandler().PostLocal(ctx, chat1.PostLocalArg{
+		ConversationID: conv.Id,
+		Msg: chat1.MessagePlaintext{
+			ClientHeader: chat1.MessageClientHeader{
+				Conv:        conv.Triple,
+				MessageType: chat1.MessageType_DELETE,
+				TlfName:     conv.TlfName,
+				Supersedes:  msgID,
+			},
+		},
+	})
+	require.NoError(t, err)
+	return postRes.MessageID
+}
+
+func mustEditMsg(ctx context.Context, t *testing.T, ctc *chatTestContext, user *kbtest.FakeUser,
+	conv chat1.ConversationInfoLocal, msgID chat1.MessageID) chat1.MessageID {
+	postRes, err := ctc.as(t, user).chatLocalHandler().PostLocal(ctx, chat1.PostLocalArg{
+		ConversationID: conv.Id,
+		Msg: chat1.MessagePlaintext{
+			ClientHeader: chat1.MessageClientHeader{
+				Conv:        conv.Triple,
+				MessageType: chat1.MessageType_EDIT,
+				TlfName:     conv.TlfName,
+				Supersedes:  msgID,
+			},
+			MessageBody: chat1.NewMessageBodyWithEdit(chat1.MessageEdit{
+				MessageID: msgID,
+				Body:      "HI",
+			}),
+		},
+	})
+	require.NoError(t, err)
+	return postRes.MessageID
+}
+
+func TestChatSrvGetThreadNonblockPlaceholders(t *testing.T) {
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetThreadNonblockPlaceholders", 1)
+		defer ctc.cleanup()
+		users := ctc.users()
+
+		uid := gregor1.UID(users[0].GetUID().ToBytes())
+		inboxCb := make(chan kbtest.NonblockInboxResult, 100)
+		threadCb := make(chan kbtest.NonblockThreadResult, 100)
+		ui := kbtest.NewChatUI(inboxCb, threadCb, nil, nil)
+		ctc.as(t, users[0]).h.mockChatUI = ui
+		ctx := ctc.as(t, users[0]).startCtx
+		<-ctc.as(t, users[0]).h.G().ConvLoader.Stop(ctx)
+		listener := newServerChatListener()
+		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
+
+		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt)
+		cs := ctc.world.Tcs[users[0].Username].ChatG.ConvSource
+		msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
+		msgID1 := mustPostLocalForTest(t, ctc, users[0], conv, msg)
+		consumeNewMsgRemote(t, listener, chat1.MessageType_TEXT)
+		editMsgID1 := mustEditMsg(ctx, t, ctc, users[0], conv, msgID1)
 		consumeNewMsgRemote(t, listener, chat1.MessageType_EDIT)
 		msgID2 := mustPostLocalForTest(t, ctc, users[0], conv, msg)
 		consumeNewMsgRemote(t, listener, chat1.MessageType_TEXT)
-		editMsgID2 := editMsg(ctx, conv, msgID2)
+		editMsgID2 := mustEditMsg(ctx, t, ctc, users[0], conv, msgID2)
 		consumeNewMsgRemote(t, listener, chat1.MessageType_EDIT)
 		msgID3 := mustPostLocalForTest(t, ctc, users[0], conv, msg)
 		consumeNewMsgRemote(t, listener, chat1.MessageType_TEXT)

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -24,6 +24,7 @@ type ResultCollector interface {
 	Result() []chat1.MessageUnboxed
 	Error(err Error) Error
 	Name() string
+	SetTarget(num int)
 
 	String() string
 }
@@ -161,6 +162,10 @@ func (s *SimpleResultCollector) PushPlaceholder(chat1.MessageID) bool {
 	return false
 }
 
+func (s *SimpleResultCollector) SetTarget(num int) {
+	s.target = num
+}
+
 func NewSimpleResultCollector(num int) *SimpleResultCollector {
 	return &SimpleResultCollector{
 		target: num,
@@ -202,6 +207,8 @@ func (s *InsatiableResultCollector) String() string {
 func (s *InsatiableResultCollector) Error(err Error) Error {
 	return err
 }
+
+func (s *InsatiableResultCollector) SetTarget(num int) {}
 
 func (s *InsatiableResultCollector) PushPlaceholder(chat1.MessageID) bool {
 	// Missing messages are a-ok
@@ -266,6 +273,10 @@ func (t *TypedResultCollector) Error(err Error) Error {
 
 func (t *TypedResultCollector) PushPlaceholder(msgID chat1.MessageID) bool {
 	return false
+}
+
+func (t *TypedResultCollector) SetTarget(num int) {
+	t.target = num
 }
 
 type HoleyResultCollector struct {

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -20,22 +20,26 @@ type supersedesTransform interface {
 type getMessagesFunc func(context.Context, types.UnboxConversationInfo, gregor1.UID, []chat1.MessageID,
 	*chat1.GetThreadReason) ([]chat1.MessageUnboxed, error)
 
+type basicSupersedesTransformOpts struct {
+	UseDeletePlaceholders bool
+}
+
 type basicSupersedesTransform struct {
 	globals.Contextified
 	utils.DebugLabeler
 
-	messagesFunc          getMessagesFunc
-	useDeletePlaceholders bool
+	messagesFunc getMessagesFunc
+	opts         basicSupersedesTransformOpts
 }
 
 var _ supersedesTransform = (*basicSupersedesTransform)(nil)
 
-func newBasicSupersedesTransform(g *globals.Context, useDeletePlaceholders bool) *basicSupersedesTransform {
+func newBasicSupersedesTransform(g *globals.Context, opts basicSupersedesTransformOpts) *basicSupersedesTransform {
 	return &basicSupersedesTransform{
-		Contextified:          globals.NewContextified(g),
-		DebugLabeler:          utils.NewDebugLabeler(g.GetLog(), "supersedesTransform", false),
-		messagesFunc:          g.ConvSource.GetMessages,
-		useDeletePlaceholders: useDeletePlaceholders,
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "supersedesTransform", false),
+		messagesFunc: g.ConvSource.GetMessages,
+		opts:         opts,
 	}
 }
 
@@ -223,7 +227,7 @@ func (t *basicSupersedesTransform) Run(ctx context.Context,
 	// Run through all messages and transform superseded messages into final state
 	var newMsgs []chat1.MessageUnboxed
 	xformDelete := func(msgID chat1.MessageID) {
-		if t.useDeletePlaceholders {
+		if t.opts.UseDeletePlaceholders {
 			newMsgs = append(newMsgs, utils.CreateHiddenPlaceholder(msgID))
 		}
 	}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1395,3 +1395,11 @@ func ForceReloadUPAKsForUIDs(ctx context.Context, g *globals.Context, uids []key
 	}
 	return g.GetUPAKLoader().Batcher(ctx, getArg, nil, 0)
 }
+
+func CreateHiddenPlaceholder(msgID chat1.MessageID) chat1.MessageUnboxed {
+	return chat1.NewMessageUnboxedWithPlaceholder(
+		chat1.MessageUnboxedPlaceholder{
+			MessageID: msgID,
+			Hidden:    true,
+		})
+}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3074,6 +3074,7 @@ type GetThreadQuery struct {
 	MarkAsRead               bool              `codec:"markAsRead" json:"markAsRead"`
 	MessageTypes             []MessageType     `codec:"messageTypes" json:"messageTypes"`
 	DisableResolveSupersedes bool              `codec:"disableResolveSupersedes" json:"disableResolveSupersedes"`
+	EnableDeletePlaceholders bool              `codec:"enableDeletePlaceholders" json:"enableDeletePlaceholders"`
 	Before                   *gregor1.Time     `codec:"before,omitempty" json:"before,omitempty"`
 	After                    *gregor1.Time     `codec:"after,omitempty" json:"after,omitempty"`
 	MessageIDControl         *MessageIDControl `codec:"messageIDControl,omitempty" json:"messageIDControl,omitempty"`
@@ -3094,6 +3095,7 @@ func (o GetThreadQuery) DeepCopy() GetThreadQuery {
 			return ret
 		})(o.MessageTypes),
 		DisableResolveSupersedes: o.DisableResolveSupersedes,
+		EnableDeletePlaceholders: o.EnableDeletePlaceholders,
 		Before: (func(x *gregor1.Time) *gregor1.Time {
 			if x == nil {
 				return nil

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -574,6 +574,7 @@ protocol local {
     boolean markAsRead;
     array<MessageType> messageTypes;
     boolean disableResolveSupersedes;
+    boolean enableDeletePlaceholders;
 
     union { null, gregor1.Time } before;
     union { null, gregor1.Time } after;

--- a/protocol/js/rpc-chat-gen.js
+++ b/protocol/js/rpc-chat-gen.js
@@ -475,7 +475,7 @@ export type GetThreadNonblockPgMode =
   | 0 // DEFAULT_0
   | 1 // SERVER_1
 
-export type GetThreadQuery = $ReadOnly<{markAsRead: Boolean, messageTypes?: ?Array<MessageType>, disableResolveSupersedes: Boolean, before?: ?Gregor1.Time, after?: ?Gregor1.Time, messageIDControl?: ?MessageIDControl}>
+export type GetThreadQuery = $ReadOnly<{markAsRead: Boolean, messageTypes?: ?Array<MessageType>, disableResolveSupersedes: Boolean, enableDeletePlaceholders: Boolean, before?: ?Gregor1.Time, after?: ?Gregor1.Time, messageIDControl?: ?MessageIDControl}>
 export type GetThreadReason =
   | 0 // GENERAL_0
   | 1 // PUSH_1

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1728,6 +1728,10 @@
           "name": "disableResolveSupersedes"
         },
         {
+          "type": "boolean",
+          "name": "enableDeletePlaceholders"
+        },
+        {
           "type": [
             null,
             "gregor1.Time"

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -933,6 +933,7 @@ const loadMoreMessages = (
           },
           pgmode: RPCChatTypes.localGetThreadNonblockPgMode.server,
           query: {
+            enableDeletePlaceholders: true,
             disableResolveSupersedes: false,
             markAsRead: false,
             messageTypes: loadThreadMessageTypes,

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -475,7 +475,7 @@ export type GetThreadNonblockPgMode =
   | 0 // DEFAULT_0
   | 1 // SERVER_1
 
-export type GetThreadQuery = $ReadOnly<{markAsRead: Boolean, messageTypes?: ?Array<MessageType>, disableResolveSupersedes: Boolean, before?: ?Gregor1.Time, after?: ?Gregor1.Time, messageIDControl?: ?MessageIDControl}>
+export type GetThreadQuery = $ReadOnly<{markAsRead: Boolean, messageTypes?: ?Array<MessageType>, disableResolveSupersedes: Boolean, enableDeletePlaceholders: Boolean, before?: ?Gregor1.Time, after?: ?Gregor1.Time, messageIDControl?: ?MessageIDControl}>
 export type GetThreadReason =
   | 0 // GENERAL_0
   | 1 // PUSH_1


### PR DESCRIPTION
There is a problem in the `INCREMENTAL` mode of `GetThreadNonblock` where it does not include messages in the remote result that were modified (by a superseder) from the cached result. This affects edits and deletes of messages that we have cached. Patch does the following to fix the situation:

1.) Change `mergeLocalRemoteThread` to include messages from the remote result that have a `SupersededBy` value that is different than what we sent up for the cached result. 
2.) Fix how `resolveHoles` works in `HybridConversationSource`. Previously, it would try to modify the thread that we fetched from storage in-place. However, it didn't do anything for superseded messages, and so the results we got back from a "holey" cache hit were wrong. Now instead of modifying the thread in `resolveHoles`, we just re-fetch from `Storage` if we get a holey hit and resolve it.
3.) Add a new mode for `basicSupersedesTransform` to include a "hidden" `PLACEHOLDER` message instead of just dropping the message for deleted messages. This allows us to communicate to clients of `GetThreadNonblock` that cached messages have actually been deleted. 
4.) **Bonus Fix**: `PullLocalOnly` had previously been using a `SimpleResultCollector` regardless of the query passed in. This made it such that it returned a subset of what `Pull` would when given the same query. Change this to use a `ResultCollector` derived from the query. 

cc @buoyad 