### PR TITLE
fix saveToCameraRoll type arg

### DIFF
--- a/shared/actions/platform-specific.native.js
+++ b/shared/actions/platform-specific.native.js
@@ -76,7 +76,7 @@ function saveAttachmentDialog(filePath: string): Promise<NextURI> {
 
 async function saveAttachmentToCameraRoll(fileURL: string, mimeType: string): Promise<void> {
   const logPrefix = '[saveAttachmentToCameraRoll] '
-  const saveType = mimeType.startsWith('video') ? 'video' : 'image'
+  const saveType = mimeType.startsWith('video') ? 'video' : 'photo'
   if (isIOS && saveType !== 'video') {
     // iOS cannot save a video from a URL, so we can only do images here. Fallback to temp file
     // method for videos.

--- a/shared/chat/conversation/messages/message-popup/header.js
+++ b/shared/chat/conversation/messages/message-popup/header.js
@@ -42,7 +42,6 @@ const MessagePopupHeader = (props: {
         ...globalStyles.flexBoxColumn,
         alignItems: 'center',
         maxWidth: isMobile ? '100%' : 240,
-        textAlign: 'center',
         width: '100%',
       }}
     >


### PR DESCRIPTION
The `type` arg [is](https://facebook.github.io/react-native/docs/cameraroll) `enum('photo', 'video')`. See the [ticket](https://keybase.atlassian.net/browse/KBFS-3318) for an Android log. Perhaps it only breaks on Android?