### PR TITLE
return cached TeamsListUnverfied on network error

### DIFF
--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -257,8 +257,7 @@ func (s *TeamEKBoxStorage) put(ctx context.Context, teamID keybase1.TeamID, gene
 		return err
 	}
 	cache[generation] = newTeamEKBoxCacheItem(teamEKBoxed, ekErr)
-	err = s.G().GetKVStore().PutObj(key, nil, cache)
-	if err != nil {
+	if err = s.G().GetKVStore().PutObj(key, nil, cache); err != nil {
 		return err
 	}
 	s.cache.PutMap(teamID, cache)

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -202,6 +202,7 @@ const (
 	DBChatBodyHashIndex        = 0xfc
 	DBPvl                      = 0xfd
 	DBChatConvFailures         = 0xfe
+	DBTeamList                 = 0xff
 )
 
 const (


### PR DESCRIPTION
Verified manually that the `Build a team!` button doesn't show once we have the cached state