### PR TITLE
Floating menu layout tweaks for native

### DIFF
--- a/shared/chat/conversation/info-panel/menu/index.js
+++ b/shared/chat/conversation/info-panel/menu/index.js
@@ -22,7 +22,13 @@ export type Props = {
 }
 
 const Header = ({teamname, memberCount}: {teamname: string, memberCount: number}) => (
-  <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', paddingTop: 16}}>
+  <Box
+    style={{
+      ...globalStyles.flexBoxColumn,
+      alignItems: 'center',
+      ...(isMobile ? {paddingBottom: 24, paddingTop: 40} : {paddingTop: 16}),
+    }}
+  >
     <Avatar size={isMobile ? 64 : 48} teamname={teamname} style={{marginBottom: isMobile ? 4 : 2}} />
     <Text type="BodySemibold">{teamname}</Text>
     <Text type="BodySmall">{`${memberCount} member${memberCount !== 1 ? 's' : ''}`}</Text>

--- a/shared/chat/conversation/info-panel/menu/index.js
+++ b/shared/chat/conversation/info-panel/menu/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
-import {Avatar, Box, FloatingMenu, Text} from '../../../../common-adapters'
-import {collapseStyles, globalColors, globalMargins, globalStyles, isMobile} from '../../../../styles'
+import * as Kb from '../../../../common-adapters'
+import * as Styles from '../../../../styles'
 
 export type Props = {
   attachTo: ?React.Component<any, any>,
@@ -21,18 +21,60 @@ export type Props = {
   onViewTeam: () => void,
 }
 
-const Header = ({teamname, memberCount}: {teamname: string, memberCount: number}) => (
-  <Box
-    style={{
-      ...globalStyles.flexBoxColumn,
+const styles = Styles.styleSheetCreate({
+  badge: Styles.platformStyles({
+    common: {
+      backgroundColor: Styles.globalColors.blue,
+      borderRadius: 6,
+      height: 8,
+      margin: 6,
+      width: 8,
+    },
+    isElectron: {
+      margin: 4,
+      marginTop: 5,
+      right: Styles.globalMargins.tiny,
+      position: 'absolute',
+    },
+  }),
+  headerAvatar: Styles.platformStyles({
+    isElectron: {
+      marginBottom: 2,
+    },
+    isMobile: {
+      marginBottom: 4,
+    },
+  }),
+  headerContainer: Styles.platformStyles({
+    common: {
+      ...Styles.globalStyles.flexBoxColumn,
       alignItems: 'center',
-      ...(isMobile ? {paddingBottom: 24, paddingTop: 40} : {paddingTop: 16}),
-    }}
-  >
-    <Avatar size={isMobile ? 64 : 48} teamname={teamname} style={{marginBottom: isMobile ? 4 : 2}} />
-    <Text type="BodySemibold">{teamname}</Text>
-    <Text type="BodySmall">{`${memberCount} member${memberCount !== 1 ? 's' : ''}`}</Text>
-  </Box>
+    },
+    isElectron: {
+      paddingTop: 16,
+    },
+    isMobile: {paddingBottom: 24, paddingTop: 40},
+  }),
+  noTopborder: {
+    borderTopWidth: 0,
+  },
+  text: Styles.platformStyles({
+    isMobile: {
+      color: Styles.globalColors.blue,
+    },
+  }),
+})
+
+const Header = ({teamname, memberCount}: {teamname: string, memberCount: number}) => (
+  <Kb.Box style={styles.headerContainer}>
+    <Kb.Avatar
+      size={Styles.isMobile ? 64 : 48}
+      teamname={teamname}
+      style={Kb.avatarCastPlatformStyles(styles.headerAvatar)}
+    />
+    <Kb.Text type="BodySemibold">{teamname}</Kb.Text>
+    <Kb.Text type="BodySmall">{`${memberCount} member${memberCount !== 1 ? 's' : ''}`}</Kb.Text>
+  </Kb.Box>
 )
 
 const InfoPanelMenu = (props: Props) => {
@@ -44,7 +86,7 @@ const InfoPanelMenu = (props: Props) => {
       style: {borderTopWidth: 0},
     },
     {
-      title: isMobile ? 'Add someone from address book' : 'Add someone by email',
+      title: Styles.isMobile ? 'Add someone from address book' : 'Add someone by email',
       onClick: props.onInvite,
     },
   ]
@@ -58,14 +100,12 @@ const InfoPanelMenu = (props: Props) => {
         onClick: props.onManageChannels,
         title: props.manageChannelsTitle,
         view: (
-          <Box style={globalStyles.flexBoxRow}>
-            <Text style={styleText} type={isMobile ? 'BodyBig' : 'Body'}>
+          <Kb.Box style={Styles.globalStyles.flexBoxRow}>
+            <Kb.Text style={styles.text} type={Styles.isMobile ? 'BodyBig' : 'Body'}>
               {props.manageChannelsTitle}
-            </Text>
-            {props.badgeSubscribe && (
-              <Box style={collapseStyles([styleBadge, !isMobile && styleBadgeDesktop])} />
-            )}
-          </Box>
+            </Kb.Text>
+            {props.badgeSubscribe && <Kb.Box style={styles.badge} />}
+          </Kb.Box>
         ),
       }
 
@@ -82,7 +122,7 @@ const InfoPanelMenu = (props: Props) => {
   }
 
   return (
-    <FloatingMenu
+    <Kb.FloatingMenu
       attachTo={props.attachTo}
       visible={props.visible}
       items={items}
@@ -92,25 +132,6 @@ const InfoPanelMenu = (props: Props) => {
       closeOnSelect={true}
     />
   )
-}
-
-const styleBadge = {
-  backgroundColor: globalColors.blue,
-  borderRadius: 6,
-  height: 8,
-  margin: 6,
-  width: 8,
-}
-
-const styleBadgeDesktop = {
-  margin: 4,
-  marginTop: 5,
-  right: globalMargins.tiny,
-  position: 'absolute',
-}
-
-const styleText = {
-  color: isMobile ? globalColors.blue : undefined,
 }
 
 export {InfoPanelMenu}

--- a/shared/chat/conversation/info-panel/menu/index.js
+++ b/shared/chat/conversation/info-panel/menu/index.js
@@ -21,50 +21,6 @@ export type Props = {
   onViewTeam: () => void,
 }
 
-const styles = Styles.styleSheetCreate({
-  badge: Styles.platformStyles({
-    common: {
-      backgroundColor: Styles.globalColors.blue,
-      borderRadius: 6,
-      height: 8,
-      margin: 6,
-      width: 8,
-    },
-    isElectron: {
-      margin: 4,
-      marginTop: 5,
-      right: Styles.globalMargins.tiny,
-      position: 'absolute',
-    },
-  }),
-  headerAvatar: Styles.platformStyles({
-    isElectron: {
-      marginBottom: 2,
-    },
-    isMobile: {
-      marginBottom: 4,
-    },
-  }),
-  headerContainer: Styles.platformStyles({
-    common: {
-      ...Styles.globalStyles.flexBoxColumn,
-      alignItems: 'center',
-    },
-    isElectron: {
-      paddingTop: 16,
-    },
-    isMobile: {paddingBottom: 24, paddingTop: 40},
-  }),
-  noTopborder: {
-    borderTopWidth: 0,
-  },
-  text: Styles.platformStyles({
-    isMobile: {
-      color: Styles.globalColors.blue,
-    },
-  }),
-})
-
 const Header = ({teamname, memberCount}: {teamname: string, memberCount: number}) => (
   <Kb.Box style={styles.headerContainer}>
     <Kb.Avatar
@@ -133,5 +89,49 @@ const InfoPanelMenu = (props: Props) => {
     />
   )
 }
+
+const styles = Styles.styleSheetCreate({
+  badge: Styles.platformStyles({
+    common: {
+      backgroundColor: Styles.globalColors.blue,
+      borderRadius: 6,
+      height: 8,
+      margin: 6,
+      width: 8,
+    },
+    isElectron: {
+      margin: 4,
+      marginTop: 5,
+      right: Styles.globalMargins.tiny,
+      position: 'absolute',
+    },
+  }),
+  headerAvatar: Styles.platformStyles({
+    isElectron: {
+      marginBottom: 2,
+    },
+    isMobile: {
+      marginBottom: 4,
+    },
+  }),
+  headerContainer: Styles.platformStyles({
+    common: {
+      ...Styles.globalStyles.flexBoxColumn,
+      alignItems: 'center',
+    },
+    isElectron: {
+      paddingTop: 16,
+    },
+    isMobile: {paddingBottom: 24, paddingTop: 40},
+  }),
+  noTopborder: {
+    borderTopWidth: 0,
+  },
+  text: Styles.platformStyles({
+    isMobile: {
+      color: Styles.globalColors.blue,
+    },
+  }),
+})
 
 export {InfoPanelMenu}

--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.js
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.js
@@ -14,6 +14,8 @@ const Prompt = () => (
 const promptContainerStyle = {
   alignItems: 'center',
   justifyContent: 'center',
+  paddingBottom: 24,
+  paddingTop: 24,
 }
 
 class FilePickerPopup extends React.Component<Props> {

--- a/shared/chat/conversation/messages/message-popup/exploding/index.js
+++ b/shared/chat/conversation/messages/message-popup/exploding/index.js
@@ -15,6 +15,7 @@ import {collapseStyles, globalColors, globalMargins, isMobile, platformStyles} f
 import {formatTimeForPopup, formatTimeForRevoked, msToDHMS} from '../../../../../util/timestamp'
 import {addTicker, removeTicker, type TickerID} from '../../../../../util/second-timer'
 import {PopupHeaderText, type MenuItem} from '../../../../../common-adapters/popup-menu'
+import {isAndroid} from '../../../../../constants/platform'
 import type {DeviceType} from '../../../../../constants/types/devices'
 import type {Position} from '../../../../../common-adapters/relative-popup-hoc'
 
@@ -70,7 +71,8 @@ class ExplodingPopupHeader extends React.Component<PropsWithTimer<Props>, State>
   render() {
     const {author, deviceName, deviceRevokedAt, hideTimer, timestamp, yourMessage} = this.props
     const whoRevoked = yourMessage ? 'You' : author
-    const bombVerticalOffset = isMobile ? 0 : -20
+    // Android overflow doesn't work
+    const bombVerticalOffset = isMobile ? (isAndroid ? 10 : -30) : -20
     return (
       <Box2
         direction="vertical"

--- a/shared/chat/conversation/messages/message-popup/header.js
+++ b/shared/chat/conversation/messages/message-popup/header.js
@@ -40,6 +40,12 @@ const MessagePopupHeader = (props: {
     <Box
       style={{
         ...globalStyles.flexBoxColumn,
+        ...(isMobile
+          ? {
+              paddingBottom: globalMargins.medium,
+              paddingTop: globalMargins.medium,
+            }
+          : {}),
         alignItems: 'center',
         maxWidth: isMobile ? '100%' : 240,
         width: '100%',

--- a/shared/chat/conversation/messages/message-popup/header.js
+++ b/shared/chat/conversation/messages/message-popup/header.js
@@ -1,14 +1,14 @@
 // @flow
 import * as React from 'react'
-import {Avatar, Box, Box2, ConnectedUsernames, Icon, Text, type IconType} from '../../../../common-adapters'
+import * as Kb from '../../../../common-adapters'
+import * as Styles from '../../../../styles'
 import {PopupHeaderText} from '../../../../common-adapters/popup-menu'
-import {globalStyles, globalMargins, globalColors, isMobile} from '../../../../styles'
 import {formatTimeForPopup, formatTimeForRevoked} from '../../../../util/timestamp'
 import {isAndroid} from '../../../../constants/platform'
 import type {DeviceType} from '../../../../constants/types/devices'
 
-const iconNameForDeviceType = isMobile
-  ? (deviceType: string, isRevoked: boolean): IconType => {
+const iconNameForDeviceType = Styles.isMobile
+  ? (deviceType: string, isRevoked: boolean): Kb.IconType => {
       switch (deviceType) {
         case 'mobile':
           return isRevoked ? 'icon-fancy-revoked-phone-183-x-96' : 'icon-fancy-encrypted-phone-183-x-96'
@@ -16,7 +16,7 @@ const iconNameForDeviceType = isMobile
           return isRevoked ? 'icon-fancy-revoked-computer-226-x-96' : 'icon-fancy-encrypted-computer-226-x-96'
       }
     }
-  : (deviceType: string, isRevoked: boolean): IconType => {
+  : (deviceType: string, isRevoked: boolean): Kb.IconType => {
       switch (deviceType) {
         case 'mobile':
           return isRevoked ? 'icon-fancy-revoked-phone-122-x-64' : 'icon-fancy-encrypted-phone-122-x-64'
@@ -37,51 +37,30 @@ const MessagePopupHeader = (props: {
   const {author, deviceName, deviceRevokedAt, deviceType, isLast, timestamp, yourMessage} = props
   const iconName = iconNameForDeviceType(deviceType, !!deviceRevokedAt)
   const whoRevoked = yourMessage ? 'You' : author
-  // The mobile special casing below is because RN doesn't support overflow on Android
-  const iconSpacing = isMobile ? 96 - (isAndroid ? 16 : 30) : 64
   return (
-    <Box
-      style={{
-        ...globalStyles.flexBoxColumn,
-        ...(isMobile
-          ? {
-              paddingBottom: globalMargins.medium,
-              paddingTop: globalMargins.medium + iconSpacing,
-            }
-          : {paddingTop: iconSpacing}),
-        alignItems: 'center',
-        maxWidth: isMobile ? '100%' : 240,
-        width: '100%',
-      }}
-    >
-      <Icon
-        type={iconName}
-        style={{
-          marginBottom: globalMargins.tiny,
-          marginTop: !isMobile ? globalMargins.small : 0,
-          position: 'absolute',
-          top: isMobile ? (isAndroid ? 0 : -15) : -25,
-        }}
-      />
-      <Box
-        style={{
-          ...globalStyles.flexBoxRow,
-        }}
-      >
-        <Text type="BodySmall" style={{color: deviceRevokedAt ? globalColors.black_40 : globalColors.green2}}>
+    <Kb.Box style={styles.headerContainer}>
+      <Kb.Icon type={iconName} style={Kb.iconCastPlatformStyles(styles.headerIcon)} />
+      <Kb.Box style={Styles.globalStyles.flexBoxRow}>
+        <Kb.Text
+          type="BodySmall"
+          style={{color: deviceRevokedAt ? Styles.globalColors.black_40 : Styles.globalColors.green2}}
+        >
           ENCRYPTED
-        </Text>
-        <Text type="BodySmall" style={{color: deviceRevokedAt ? globalColors.black_40 : globalColors.green2}}>
+        </Kb.Text>
+        <Kb.Text
+          type="BodySmall"
+          style={{color: deviceRevokedAt ? Styles.globalColors.black_40 : Styles.globalColors.green2}}
+        >
           &nbsp;& SIGNED
-        </Text>
-      </Box>
-      <Box2 direction="horizontal">
-        <Text type="BodySmall" style={{color: globalColors.black_40}}>
+        </Kb.Text>
+      </Kb.Box>
+      <Kb.Box2 direction="horizontal">
+        <Kb.Text type="BodySmall" style={styles.colorBlack40}>
           by
-        </Text>
-        <Box2 direction="horizontal" gap="xtiny" gapStart={true} style={{alignItems: 'center'}}>
-          <Avatar username={author} size={16} clickToProfile="tracker" />
-          <ConnectedUsernames
+        </Kb.Text>
+        <Kb.Box2 direction="horizontal" gap="xtiny" gapStart={true} style={styles.alignItemsCenter}>
+          <Kb.Avatar username={author} size={16} clickToProfile="tracker" />
+          <Kb.ConnectedUsernames
             clickable={true}
             colorFollowing={true}
             colorYou={true}
@@ -89,37 +68,75 @@ const MessagePopupHeader = (props: {
             underline={true}
             type="BodySmallSemibold"
           />
-        </Box2>
-      </Box2>
-      <Box
-        style={{
-          ...globalStyles.flexBoxRow,
-          paddingLeft: globalMargins.small,
-          paddingRight: globalMargins.small,
-        }}
-      >
-        <Text type="BodySmall">
-          from device&nbsp;<Text type="BodySmallSemibold">{deviceName}</Text>
-        </Text>
-      </Box>
-      <Text type="BodySmall">{formatTimeForPopup(timestamp)}</Text>
+        </Kb.Box2>
+      </Kb.Box2>
+      <Kb.Box style={styles.headerDetailsContainer}>
+        <Kb.Text type="BodySmall">
+          from device&nbsp;<Kb.Text type="BodySmallSemibold">{deviceName}</Kb.Text>
+        </Kb.Text>
+      </Kb.Box>
+      <Kb.Text type="BodySmall">{formatTimeForPopup(timestamp)}</Kb.Text>
       {deviceRevokedAt && (
         <PopupHeaderText
-          color={globalColors.white}
-          backgroundColor={globalColors.blue}
-          style={{
-            marginTop: globalMargins.small,
-            ...(isLast
-              ? {borderBottomLeftRadius: 3, borderBottomRightRadius: 3, marginBottom: -globalMargins.small}
-              : {}),
-            width: '100%',
-          }}
+          color={Styles.globalColors.white}
+          backgroundColor={Styles.globalColors.blue}
+          style={Styles.collapseStyles([styles.revokedAtContainer, isLast && styles.revokedAtContainerLast])}
         >
           {whoRevoked} revoked this device on {formatTimeForRevoked(deviceRevokedAt)}.
         </PopupHeaderText>
       )}
-    </Box>
+    </Kb.Box>
   )
 }
+
+// The mobile special casing below is because RN doesn't support overflow on Android
+const iconSpacing = Styles.isMobile ? 96 - (isAndroid ? 16 : 30) : 64
+const styles = Styles.styleSheetCreate({
+  alignItemsCenter: {alignItems: 'center'},
+  colorBlack40: {color: Styles.globalColors.black_40},
+  headerContainer: Styles.platformStyles({
+    common: {
+      ...Styles.globalStyles.flexBoxColumn,
+      alignItems: 'center',
+      maxWidth: Styles.isMobile ? '100%' : 240,
+      width: '100%',
+    },
+    isElectron: {
+      paddingTop: iconSpacing,
+    },
+    isMobile: {
+      paddingBottom: Styles.globalMargins.medium,
+      paddingTop: Styles.globalMargins.medium + iconSpacing,
+    },
+  }),
+  headerDetailsContainer: {
+    ...Styles.globalStyles.flexBoxRow,
+    paddingLeft: Styles.globalMargins.small,
+    paddingRight: Styles.globalMargins.small,
+  },
+  headerIcon: Styles.platformStyles({
+    common: {
+      marginBottom: Styles.globalMargins.tiny,
+      position: 'absolute',
+    },
+    isAndroid: {
+      top: 0,
+    },
+    isElectron: {marginTop: Styles.globalMargins.small, top: -25},
+    isIOS: {top: -15},
+    isMobile: {
+      marginTop: 0,
+    },
+  }),
+  revokedAtContainer: {
+    marginTop: Styles.globalMargins.small,
+    width: '100%',
+  },
+  revokedAtContainerLast: {
+    borderBottomLeftRadius: 3,
+    borderBottomRightRadius: 3,
+    marginBottom: -Styles.globalMargins.small,
+  },
+})
 
 export default MessagePopupHeader

--- a/shared/chat/conversation/messages/message-popup/header.js
+++ b/shared/chat/conversation/messages/message-popup/header.js
@@ -4,6 +4,7 @@ import {Avatar, Box, Box2, ConnectedUsernames, Icon, Text, type IconType} from '
 import {PopupHeaderText} from '../../../../common-adapters/popup-menu'
 import {globalStyles, globalMargins, globalColors, isMobile} from '../../../../styles'
 import {formatTimeForPopup, formatTimeForRevoked} from '../../../../util/timestamp'
+import {isAndroid} from '../../../../constants/platform'
 import type {DeviceType} from '../../../../constants/types/devices'
 
 const iconNameForDeviceType = isMobile
@@ -36,6 +37,8 @@ const MessagePopupHeader = (props: {
   const {author, deviceName, deviceRevokedAt, deviceType, isLast, timestamp, yourMessage} = props
   const iconName = iconNameForDeviceType(deviceType, !!deviceRevokedAt)
   const whoRevoked = yourMessage ? 'You' : author
+  // The mobile special casing below is because RN doesn't support overflow on Android
+  const iconSpacing = isMobile ? 96 - (isAndroid ? 16 : 30) : 64
   return (
     <Box
       style={{
@@ -43,9 +46,9 @@ const MessagePopupHeader = (props: {
         ...(isMobile
           ? {
               paddingBottom: globalMargins.medium,
-              paddingTop: globalMargins.medium,
+              paddingTop: globalMargins.medium + iconSpacing,
             }
-          : {}),
+          : {paddingTop: iconSpacing}),
         alignItems: 'center',
         maxWidth: isMobile ? '100%' : 240,
         width: '100%',
@@ -56,6 +59,8 @@ const MessagePopupHeader = (props: {
         style={{
           marginBottom: globalMargins.tiny,
           marginTop: !isMobile ? globalMargins.small : 0,
+          position: 'absolute',
+          top: isMobile ? (isAndroid ? 0 : -15) : -25,
         }}
       />
       <Box

--- a/shared/chat/conversation/messages/message-popup/payment/index.js
+++ b/shared/chat/conversation/messages/message-popup/payment/index.js
@@ -138,6 +138,9 @@ const styles = Styles.styleSheetCreate({
       marginBottom: 6,
       marginTop: -15,
     },
+    isAndroid: {
+      marginTop: Styles.globalMargins.tiny,
+    },
   }),
   textAlignCenter: {
     textAlign: 'center',

--- a/shared/chat/manage-channels/delete-channel.js
+++ b/shared/chat/manage-channels/delete-channel.js
@@ -1,17 +1,22 @@
 // @flow
 import * as React from 'react'
 import {Text, Box, Icon, FloatingMenu, type OverlayParentProps, OverlayParentHOC} from '../../common-adapters'
-import {globalStyles, globalColors, globalMargins, platformStyles} from '../../styles'
+import {globalStyles, globalColors, globalMargins, isMobile, platformStyles} from '../../styles'
 
 const PopupHeader = ({channelName}: {channelName: string}) => {
   return (
     <Box
       style={{
         ...globalStyles.flexBoxColumn,
+        ...(isMobile
+          ? {
+              paddingBottom: globalMargins.medium,
+              paddingTop: globalMargins.large,
+            }
+          : {paddingTop: globalMargins.small}),
         alignItems: 'center',
         paddingLeft: globalMargins.tiny,
         paddingRight: globalMargins.tiny,
-        paddingTop: globalMargins.small,
         width: '100%',
       }}
     >

--- a/shared/chat/manage-channels/delete-channel.js
+++ b/shared/chat/manage-channels/delete-channel.js
@@ -1,32 +1,18 @@
 // @flow
 import * as React from 'react'
-import {Text, Box, Icon, FloatingMenu, type OverlayParentProps, OverlayParentHOC} from '../../common-adapters'
-import {globalStyles, globalColors, globalMargins, isMobile, platformStyles} from '../../styles'
+import * as Kb from '../../common-adapters'
+import * as Styles from '../../styles'
 
 const PopupHeader = ({channelName}: {channelName: string}) => {
   return (
-    <Box
-      style={{
-        ...globalStyles.flexBoxColumn,
-        ...(isMobile
-          ? {
-              paddingBottom: globalMargins.medium,
-              paddingTop: globalMargins.large,
-            }
-          : {paddingTop: globalMargins.small}),
-        alignItems: 'center',
-        paddingLeft: globalMargins.tiny,
-        paddingRight: globalMargins.tiny,
-        width: '100%',
-      }}
-    >
-      <Text type="BodySemibold" style={{color: globalColors.black, textAlign: 'center'}}>
+    <Kb.Box style={styles.headerContainer}>
+      <Kb.Text type="BodySemibold" style={styles.headerTextTop}>
         Are you sure you want to delete #{channelName}?
-      </Text>
-      <Text type="BodySmall" style={{color: globalColors.black_40, textAlign: 'center'}}>
+      </Kb.Text>
+      <Kb.Text type="BodySmall" style={styles.headerTextBottom}>
         All messages will be lost. This cannot be undone.
-      </Text>
-    </Box>
+      </Kb.Text>
+    </Kb.Box>
   )
 }
 
@@ -34,30 +20,13 @@ type Props = {
   channelName: string,
   disabled: boolean,
   onConfirmedDelete: () => void,
-} & OverlayParentProps
+} & Kb.OverlayParentProps
 
 type State = {}
 
 class _DeleteChannel extends React.Component<Props, State> {
   render() {
     const {disabled} = this.props
-
-    const boxStyle = platformStyles({
-      common: {
-        ...globalStyles.flexBoxRow,
-        opacity: disabled ? 0.5 : undefined,
-      },
-      isElectron: {
-        position: 'absolute',
-        left: 0,
-      },
-      isMobile: {
-        paddingLeft: globalMargins.large,
-        paddingRight: globalMargins.large,
-        paddingTop: globalMargins.medium,
-        paddingBottom: globalMargins.medium,
-      },
-    })
 
     const header = {
       title: 'header',
@@ -71,32 +40,71 @@ class _DeleteChannel extends React.Component<Props, State> {
     ]
 
     return (
-      <Box style={boxStyle}>
-        <Icon
+      <Kb.Box style={Styles.collapseStyles([styles.container, disabled && {opacity: 0.5}])}>
+        <Kb.Icon
           type="iconfont-trash"
-          style={{height: 14, marginRight: globalMargins.tiny}}
-          color={globalColors.red}
+          style={Kb.iconCastPlatformStyles(styles.trashIcon)}
+          color={Styles.globalColors.red}
         />
-        <FloatingMenu
+        <Kb.FloatingMenu
           header={header}
           items={items}
           attachTo={this.props.attachmentRef}
           visible={this.props.showingMenu}
           onHidden={this.props.toggleShowingMenu}
-          containerStyle={{width: 196}}
+          containerStyle={styles.menuContainer}
         />
-        <Text
+        <Kb.Text
           type={disabled ? 'Body' : 'BodyPrimaryLink'}
-          style={{color: globalColors.red}}
+          style={styles.colorRed}
           onClick={this.props.toggleShowingMenu}
           ref={this.props.setAttachmentRef}
         >
           Delete Channel
-        </Text>
-      </Box>
+        </Kb.Text>
+      </Kb.Box>
     )
   }
 }
 
-const DeleteChannel = OverlayParentHOC(_DeleteChannel)
+const styles = Styles.styleSheetCreate({
+  colorRed: {color: Styles.globalColors.red},
+  container: Styles.platformStyles({
+    common: {
+      ...Styles.globalStyles.flexBoxRow,
+    },
+    isElectron: {
+      left: 0,
+      position: 'absolute',
+    },
+    isMobile: {
+      paddingBottom: Styles.globalMargins.medium,
+      paddingLeft: Styles.globalMargins.large,
+      paddingRight: Styles.globalMargins.large,
+      paddingTop: Styles.globalMargins.medium,
+    },
+  }),
+  headerContainer: Styles.platformStyles({
+    common: {
+      ...Styles.globalStyles.flexBoxColumn,
+      alignItems: 'center',
+      paddingLeft: Styles.globalMargins.tiny,
+      paddingRight: Styles.globalMargins.tiny,
+      width: '100%',
+    },
+    isElectron: {
+      paddingTop: Styles.globalMargins.small,
+    },
+    isMobile: {
+      paddingBottom: Styles.globalMargins.medium,
+      paddingTop: Styles.globalMargins.large,
+    },
+  }),
+  headerTextBottom: {color: Styles.globalColors.black_40, textAlign: 'center'},
+  headerTextTop: {color: Styles.globalColors.black, textAlign: 'center'},
+  menuContainer: {width: 196},
+  trashIcon: {height: 14, marginRight: Styles.globalMargins.tiny},
+})
+
+const DeleteChannel = Kb.OverlayParentHOC(_DeleteChannel)
 export default DeleteChannel

--- a/shared/common-adapters/floating-menu/menu-layout/index.js.flow
+++ b/shared/common-adapters/floating-menu/menu-layout/index.js.flow
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 export type MenuItem = {|
   title: string, // Only used as ID if view is provided for Header
-  view?: React.Node,
+  view?: React.Node, // Required for header
   subTitle?: string, // subTitle is not used on native
   danger?: boolean,
   disabled?: boolean,

--- a/shared/common-adapters/floating-menu/menu-layout/index.native.js
+++ b/shared/common-adapters/floating-menu/menu-layout/index.native.js
@@ -3,6 +3,7 @@ import React, {Component} from 'react'
 import {TouchableOpacity} from 'react-native'
 import {Box, Text} from '../..'
 import {globalColors, globalMargins, globalStyles, styleSheetCreate, collapseStyles} from '../../../styles'
+import {isIPhoneX} from '../../../constants/platform'
 import type {MenuItem, MenuLayoutProps} from '.'
 
 type MenuRowProps = {
@@ -94,6 +95,7 @@ const styles = styleSheetCreate({
     alignItems: 'stretch',
     borderColor: globalColors.black_05,
     borderTopWidth: 1,
+    paddingBottom: isIPhoneX ? globalMargins.medium : 0, // otherwise too close to the gesture bar
   },
   row: {
     ...globalStyles.flexBoxColumn,

--- a/shared/common-adapters/floating-menu/menu-layout/index.native.js
+++ b/shared/common-adapters/floating-menu/menu-layout/index.native.js
@@ -20,7 +20,7 @@ const MenuRow = (props: MenuRowProps) => (
       props.onHidden && props.onHidden() // auto hide after a selection
       props.onClick && props.onClick()
     }}
-    style={styleRow(props)}
+    style={styles.row}
   >
     {props.view || (
       <Text type={'BodyBig'} style={styleRowText(props)}>
@@ -38,21 +38,19 @@ class MenuLayout extends Component<MenuLayoutProps> {
       }
       return arr
     }, [])
-    const menuItemsWithHeader = [
-      ...(this.props.header ? [{...this.props.header, isHeader: true}] : []),
-      ...menuItemsNoDividers,
-    ]
 
     return (
       <Box style={styles.overlay}>
         <Box style={collapseStyles([styles.menuBox, this.props.style])}>
+          {/* Display header if there is one */}
+          {this.props.header && this.props.header.view}
           <Box style={styles.menuGroup}>
-            {menuItemsWithHeader.map((mi, idx) => (
+            {menuItemsNoDividers.map((mi, idx) => (
               <MenuRow
                 key={mi.title}
                 {...mi}
                 index={idx}
-                numItems={menuItemsWithHeader.length}
+                numItems={menuItemsNoDividers.length}
                 onHidden={this.props.closeOnClick ? this.props.onHidden : undefined}
               />
             ))}
@@ -72,29 +70,13 @@ class MenuLayout extends Component<MenuLayoutProps> {
   }
 }
 
-const styleRow = (props: {isHeader?: boolean, danger?: boolean, index: number, numItems: number}) => {
-  let rowStyle
-  if (props.isHeader) {
-    rowStyle = collapseStyles([
-      styles.rowHeader,
-      {backgroundColor: props.danger ? globalColors.red : globalColors.white},
-    ])
-  } else {
-    rowStyle = styles.row
-  }
-  return rowStyle
-}
-
 const styleRowText = (props: {isHeader?: boolean, danger?: boolean, disabled?: boolean}) => {
   const dangerColor = props.danger ? globalColors.red : globalColors.blue
   const color = props.isHeader ? globalColors.white : dangerColor
-  return {color, ...(props.disabled ? {opacity: 0.6} : {}), ...(props.isHeader ? {textAlign: 'center'} : {})}
+  return {color, ...(props.disabled ? {opacity: 0.6} : {}), textAlign: 'center'}
 }
 
 const styles = styleSheetCreate({
-  notMenuBox: {
-    flex: 1,
-  },
   menuBox: {
     ...globalStyles.flexBoxColumn,
     justifyContent: 'flex-end',
@@ -112,13 +94,6 @@ const styles = styleSheetCreate({
     alignItems: 'stretch',
     borderColor: globalColors.black_05,
     borderTopWidth: 1,
-  },
-  rowHeader: {
-    ...globalStyles.flexBoxColumn,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingBottom: globalMargins.medium,
-    paddingTop: globalMargins.medium,
   },
   row: {
     ...globalStyles.flexBoxColumn,

--- a/shared/fs/common/path-item-action.js
+++ b/shared/fs/common/path-item-action.js
@@ -241,12 +241,18 @@ const styles = Styles.styleSheetCreate({
       marginTop: undefined,
     },
   }),
-  header: {
-    ...Styles.globalStyles.flexBoxColumn,
-    width: '100%',
-    alignItems: 'center',
-    paddingTop: Styles.globalMargins.small,
-  },
+  header: Styles.platformStyles({
+    common: {
+      ...Styles.globalStyles.flexBoxColumn,
+      width: '100%',
+      alignItems: 'center',
+      paddingTop: Styles.globalMargins.small,
+    },
+    isMobile: {
+      paddingBottom: Styles.globalMargins.medium,
+      paddingTop: Styles.globalMargins.large,
+    },
+  }),
   actionIcon: {
     padding: Styles.globalMargins.tiny,
   },

--- a/shared/fs/header/add-new.js
+++ b/shared/fs/header/add-new.js
@@ -60,11 +60,13 @@ const AddNew = (props: AddNewProps & OverlayParentProps) => {
               ? {
                   title: 'header',
                   view: (
-                    <StaticBreadcrumb
-                      pathElements={props.pathElements}
-                      showTlfTypeIcon={true}
-                      includeLast={true}
-                    />
+                    <Box style={styles.stylesPadBreadcrumbHeader}>
+                      <StaticBreadcrumb
+                        pathElements={props.pathElements}
+                        showTlfTypeIcon={true}
+                        includeLast={true}
+                      />
+                    </Box>
                   ),
                 }
               : undefined
@@ -103,6 +105,7 @@ const styles = styleSheetCreate({
     ...globalStyles.flexBoxRow,
     alignItems: 'center',
   },
+  stylesPadBreadcrumbHeader: {paddingBottom: globalMargins.medium, paddingTop: globalMargins.medium},
   stylesText: platformStyles({
     common: {
       marginLeft: globalMargins.tiny,

--- a/shared/profile/showcased-team-info/index.js
+++ b/shared/profile/showcased-team-info/index.js
@@ -33,6 +33,10 @@ const TeamInfo = (props: Props) => (
       isElectron: {
         width: 220,
       },
+      isMobile: {
+        paddingBottom: globalMargins.medium,
+        paddingTop: globalMargins.medium,
+      },
     })}
   >
     <Box


### PR DESCRIPTION
- Remove header padding from floating menu layout and add to implementation locations where necessary
  - This involved some fs popup headers, cc @songgao if you'd like to take a look
- Add padding below the cancel button on iPhone X to give the gesture bar more room
- Allow all message menus icons to hang over the top on iOS
<img width="300" alt="image" src="https://user-images.githubusercontent.com/11968340/44164953-70552680-a095-11e8-81f3-f06992224101.png">

I think my grep caught everything but it's possible it didn't. If anyone sees a place I missed lmk! Also no storyshot changes 🎉  r? @keybase/react-hackers 
