### PR TITLE
Team invite-by-email dialog: exit on success case

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -239,6 +239,9 @@ const _inviteByEmail = function*(action: TeamsGen.InviteToTeamByEmailPayload) {
         })
       )
     }
+  } catch (err) {
+    // other error. display messages and leave all emails in input box
+    yield Saga.put(TeamsGen.createSetEmailInviteError({malformed: [], message: err.desc}))
   } finally {
     yield Saga.put(WaitingGen.createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))
     yield Saga.put(TeamsGen.createSetTeamLoadingInvites({teamname, invitees, loadingInvites: false}))

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -230,6 +230,14 @@ const _inviteByEmail = function*(action: TeamsGen.InviteToTeamByEmailPayload) {
             : `There was an error parsing ${malformed.length} address${malformed.length > 1 ? 'es' : ''}.`,
         })
       )
+    } else {
+      // no malformed emails, assume everything went swimmingly
+      yield Saga.put(
+        TeamsGen.createSetEmailInviteError({
+          malformed: [],
+          message: '',
+        })
+      )
     }
   } finally {
     yield Saga.put(WaitingGen.createDecrementWaiting({key: Constants.teamWaitingKey(teamname)}))

--- a/shared/teams/invite-by-email/container.desktop.js
+++ b/shared/teams/invite-by-email/container.desktop.js
@@ -17,11 +17,10 @@ const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
-  onClearInviteError: () => dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''})),
+  onClearInviteError: () => dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''})), // should only be called on unmount
   onClose: () => dispatch(navigateUp()),
   onInvite: (invitees: string, role: Types.TeamRoleType) => {
     dispatch(TeamsGen.createInviteToTeamByEmail({teamname: routeProps.get('teamname'), role, invitees}))
-    dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''}))
     dispatch(TeamsGen.createGetTeams())
   },
   onOpenRolePicker: (role: Types.TeamRoleType, onComplete: Types.TeamRoleType => void) => {

--- a/shared/teams/invite-by-email/index.desktop.js
+++ b/shared/teams/invite-by-email/index.desktop.js
@@ -48,7 +48,7 @@ class InviteByEmailDesktop extends React.Component<Props, State> {
     if (this.props.malformedEmails !== prevState.malformedEmails) {
       if (this.props.malformedEmails.size > 0) {
         this._setMalformedEmails(this.props.malformedEmails)
-      } else {
+      } else if (!this.props.errorMessage) {
         // we just invited successfully
         this.props.onClose()
       }

--- a/shared/teams/invite-by-email/index.desktop.js
+++ b/shared/teams/invite-by-email/index.desktop.js
@@ -45,8 +45,13 @@ class InviteByEmailDesktop extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Props, prevState: State) {
     // update contents of input box if we get a new list of malformed emails
-    if (this.props.malformedEmails !== prevState.malformedEmails && this.props.malformedEmails.size > 0) {
-      this._setMalformedEmails(this.props.malformedEmails)
+    if (this.props.malformedEmails !== prevState.malformedEmails) {
+      if (this.props.malformedEmails.size > 0) {
+        this._setMalformedEmails(this.props.malformedEmails)
+      } else {
+        // we just invited successfully
+        this.props.onClose()
+      }
     }
   }
 


### PR DESCRIPTION
I found an email format that causes the RPC to throw (rather than return it in `malformedEmails`); I made a core ticket for that and added handling for it on our end. r? @keybase/react-hackers 