### PR TITLE
fix problems with app state and attachment upload CORE-8551

### DIFF
--- a/go/chat/attachments/preprocess.go
+++ b/go/chat/attachments/preprocess.go
@@ -181,7 +181,11 @@ func PreprocessAsset(ctx context.Context, g *globals.Context, log utils.DebugLab
 	callerPreview *chat1.MakePreviewRes) (p Preprocess, err error) {
 	if callerPreview != nil && callerPreview.Location != nil {
 		log.Debug(ctx, "preprocessAsset: caller provided preview, using that")
-		return processCallerPreview(ctx, *callerPreview)
+		if p, err = processCallerPreview(ctx, *callerPreview); err != nil {
+			log.Debug(ctx, "preprocessAsset: failed to process caller preview, making fresh one: %s", err)
+		} else {
+			return p, nil
+		}
 	}
 	src, err := os.Open(filename)
 	if err != nil {

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -143,6 +143,7 @@ const BOOL isDebug = NO;
   [DDLog addLogger:self.fileLogger];
 
   [self setupGo];
+  [self notifyAppState:application];
 
   NSURL *jsCodeLocation;
 
@@ -320,11 +321,6 @@ const BOOL isDebug = NO;
 - (void)applicationWillEnterForeground:(UIApplication *)application {
   NSLog(@"applicationWillEnterForeground: hiding keyz screen.");
   [self hideCover];
-}
-
-- (void)applicationDidFinishLaunching:(UIApplication *)application {
-  NSLog(@"applicationDidFinishLaunching: notifying service.");
-  [self notifyAppState:application];
 }
 
 - (void)notifyAppState:(UIApplication *)application {


### PR DESCRIPTION
Patch does two distinct, but related things:

1.) Fixes how we plumb through the state of the app on iOS. Previously it was possible that if the app started in the background (from a refresh), then we would think we were in the foreground in the service, not the background like we truly are. This caused a problem with `BackgroundSync` not actually running, as well as the attachment HTTP server not properly tearing down/starting up.
2.) Change attachment preprocess step to not abort out if the caller provided preview fails to process (like if the HTTP server is dead). 