### PR TITLE
dont count dup conn error as a failed attempt CORE-8569

### DIFF
--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1108,6 +1108,16 @@ func (s *Deliverer) cancelPendingDuplicateReactions(ctx context.Context, obr cha
 	return false, nil
 }
 
+func (s *Deliverer) shouldRecordError(ctx context.Context, err error) bool {
+	switch err {
+	case ErrDuplicateConnection:
+		// This just happens when threads are racing to reconnect to Gregor, don't count it as
+		// an error to send.
+		return false
+	}
+	return true
+}
+
 func (s *Deliverer) deliverLoop() {
 	bgctx := context.Background()
 	s.Debug(bgctx, "deliverLoop: starting non blocking sender deliver loop: uid: %s duration: %v",
@@ -1193,8 +1203,8 @@ func (s *Deliverer) deliverLoop() {
 					}); err != nil {
 						s.Debug(bctx, "deliverLoop: unable to fail message: err: %s", err.Error())
 					}
-				} else {
-					if err = s.outbox.RecordFailedAttempt(bgctx, obr); err != nil {
+				} else if s.shouldRecordError(bctx, err) {
+					if err = s.outbox.RecordFailedAttempt(bctx, obr); err != nil {
 						s.Debug(bgctx, "deliverLoop: unable to record failed attempt on outbox: uid %s err: %s",
 							s.outbox.GetUID(), err.Error())
 					}


### PR DESCRIPTION
When Gregor is trying to reconnect, it can happen that two threads try and connect at the same time. If that happens, one gets an error, but don't count that error against a message trying to get sent. 