### PR TITLE
Allow cancelling out of add members dialog on mobile

### DIFF
--- a/shared/common-adapters/header-hoc.native.js
+++ b/shared/common-adapters/header-hoc.native.js
@@ -21,7 +21,7 @@ export const HeaderHocHeader = ({
   <Box style={Styles.collapseStyles([_headerStyle, _headerStyleThemed[theme], headerStyle])}>
     {customComponent}
     {!!title && (
-      <Box pointerEvents="none" style={_titleStyle}>
+      <Box style={_titleStyle}>
         <Text type="BodyBig">{title}</Text>
       </Box>
     )}

--- a/shared/common-adapters/header-hoc.native.js
+++ b/shared/common-adapters/header-hoc.native.js
@@ -21,7 +21,7 @@ export const HeaderHocHeader = ({
   <Box style={Styles.collapseStyles([_headerStyle, _headerStyleThemed[theme], headerStyle])}>
     {customComponent}
     {!!title && (
-      <Box style={_titleStyle}>
+      <Box pointerEvents="none" style={_titleStyle}>
         <Text type="BodyBig">{title}</Text>
       </Box>
     )}
@@ -120,7 +120,6 @@ const _rightActionStyle = {
   bottom: 0,
   flex: 1,
   justifyContent: 'flex-end',
-  left: 0,
   position: 'absolute', // This is always right-aligned
   right: 0,
   top: 0,


### PR DESCRIPTION
Was a problem with how the right action button was styled in `HeaderHocHeader`. r? @keybase/react-hackers 