### PR TITLE
wait for Init in BackgroundSync for Android bkg task startup

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -516,7 +516,7 @@ func AppWillExit(pusher PushNotifier) {
 // [iOS] returning true will request about ~3mins from iOS to continue execution
 func AppDidEnterBackground() bool {
 	if !isInited() {
-		return
+		return false
 	}
 	defer kbCtx.Trace("AppDidEnterBackground", func() error { return nil })()
 	ctx := context.Background()

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -354,18 +354,30 @@ func Version() string {
 }
 
 func SetAppStateForeground() {
+	if !isInited() {
+		return
+	}
 	defer kbCtx.Trace("SetAppStateForeground", func() error { return nil })()
 	kbCtx.AppState.Update(keybase1.AppState_FOREGROUND)
 }
 func SetAppStateBackground() {
+	if !isInited() {
+		return
+	}
 	defer kbCtx.Trace("SetAppStateBackground", func() error { return nil })()
 	kbCtx.AppState.Update(keybase1.AppState_BACKGROUND)
 }
 func SetAppStateInactive() {
+	if !isInited() {
+		return
+	}
 	defer kbCtx.Trace("SetAppStateInactive", func() error { return nil })()
 	kbCtx.AppState.Update(keybase1.AppState_INACTIVE)
 }
 func SetAppStateBackgroundActive() {
+	if !isInited() {
+		return
+	}
 	defer kbCtx.Trace("SetAppStateBackgroundActive", func() error { return nil })()
 	kbCtx.AppState.Update(keybase1.AppState_BACKGROUNDACTIVE)
 }
@@ -421,6 +433,9 @@ func BackgroundSync() {
 
 func HandleBackgroundNotification(strConvID, body string, intMembersType int, displayPlaintext bool, intMessageID int,
 	pushID string, badgeCount, unixTime int, soundName string, pusher PushNotifier) (err error) {
+	if err := waitForInit(5 * time.Second); err != nil {
+		return nil
+	}
 	gc := globals.NewContext(kbCtx, kbChatCtx)
 	ctx := chat.Context(context.Background(), gc,
 		keybase1.TLFIdentifyBehavior_CHAT_GUI, nil, chat.NewCachingIdentifyNotifier(gc))
@@ -483,6 +498,9 @@ func pushPendingMessageFailure(convID chat1.ConversationID, pusher PushNotifier)
 // AppWillExit is called reliably on iOS when the app is about to terminate
 // not as reliably on android
 func AppWillExit(pusher PushNotifier) {
+	if !isInited() {
+		return
+	}
 	defer kbCtx.Trace("AppWillExit", func() error { return nil })()
 	ctx := context.Background()
 	convs, err := kbChatCtx.MessageDeliverer.ActiveDeliveries(ctx)
@@ -497,6 +515,9 @@ func AppWillExit(pusher PushNotifier) {
 // AppDidEnterBackground notifies the service that the app is in the background
 // [iOS] returning true will request about ~3mins from iOS to continue execution
 func AppDidEnterBackground() bool {
+	if !isInited() {
+		return
+	}
 	defer kbCtx.Trace("AppDidEnterBackground", func() error { return nil })()
 	ctx := context.Background()
 	convs, err := kbChatCtx.MessageDeliverer.ActiveDeliveries(ctx)
@@ -514,6 +535,9 @@ func AppDidEnterBackground() bool {
 }
 
 func AppBeginBackgroundTaskNonblock(pusher PushNotifier) {
+	if !isInited() {
+		return
+	}
 	defer kbCtx.Trace("AppBeginBackgroundTaskNonblock", func() error { return nil })()
 	go AppBeginBackgroundTask(pusher)
 }
@@ -521,6 +545,9 @@ func AppBeginBackgroundTaskNonblock(pusher PushNotifier) {
 // AppBeginBackgroundTask notifies us that an app background task has been started on our behalf. This
 // function will return once we no longer need any time in the background.
 func AppBeginBackgroundTask(pusher PushNotifier) {
+	if !isInited() {
+		return
+	}
 	defer kbCtx.Trace("AppBeginBackgroundTask", func() error { return nil })()
 	ctx := context.Background()
 	// Poll active deliveries in case we can shutdown early

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -370,7 +370,7 @@ func SetAppStateBackgroundActive() {
 	kbCtx.AppState.Update(keybase1.AppState_BACKGROUNDACTIVE)
 }
 
-func waitForInit() error {
+func waitForInit(maxDur time.Duration) error {
 	if isInited() {
 		return nil
 	}
@@ -380,7 +380,7 @@ func waitForInit() error {
 			if isInited() {
 				return nil
 			}
-		case <-time.After(5 * time.Second):
+		case <-time.After(maxDur):
 			return errors.New("waitForInit timeout")
 		}
 	}
@@ -389,7 +389,7 @@ func waitForInit() error {
 func BackgroundSync() {
 	// On Android there is a race where this function can be called before Init when starting up in the
 	// background. Let's wait a little bit here for Init to get run, and bail out if it never does.
-	if err := waitForInit(); err != nil {
+	if err := waitForInit(5 * time.Second); err != nil {
 		return
 	}
 	defer kbCtx.Trace("BackgroundSync", func() error { return nil })()

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -374,13 +374,14 @@ func waitForInit(maxDur time.Duration) error {
 	if isInited() {
 		return nil
 	}
+	maxCh := time.After(maxDur)
 	for {
 		select {
 		case <-time.After(200 * time.Millisecond):
 			if isInited() {
 				return nil
 			}
-		case <-time.After(maxDur):
+		case <-maxCh:
 			return errors.New("waitForInit timeout")
 		}
 	}


### PR DESCRIPTION
For Android background task wakeup, there is a race between `BackgroundSync` and `Init` it seems. This could cause the app to crash if we tried to `Trace` using a `kbCtx` that hasn't been set to anything yet. Add a new function `waitForInit` that will poll the status of `Init` for `maxTime` duration before failing out or returning. I chose polling since I didn't want to have to mess with a lock or channel and risk a different kind of crash (closing a channel twice or something). 

cc @joshblum 