### PR TITLE
Don't allow isMobile styles to override isAndroid/isIOS

### DIFF
--- a/shared/chat/conversation/messages/wrapper/exploding-meta/index.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta/index.js
@@ -269,9 +269,6 @@ const styles = styleSheetCreate({
       height: 15,
       width: 32,
     },
-    isAndroid: {
-      height: 17,
-    },
   }),
 })
 

--- a/shared/styles/shared.js
+++ b/shared/styles/shared.js
@@ -55,8 +55,8 @@ export const platformStyles = (options: {|
   isElectron?: _StylesDesktop,
 |}) => ({
   ...(options.common ? unifyStyles(options.common) : {}),
+  ...(isMobile && options.isMobile ? options.isMobile : {}),
   ...(isIOS && options.isIOS ? options.isIOS : {}),
   ...(isAndroid && options.isAndroid ? options.isAndroid : {}),
-  ...(isMobile && options.isMobile ? options.isMobile : {}),
   ...(isElectron && options.isElectron ? unifyStyles(options.isElectron) : {}),
 })


### PR DESCRIPTION
I checked all the statically defined styles, only one needed changing.

- [x] Check `platformStyles` defined inline