### PR TITLE
Refactor actions/git

### DIFF
--- a/shared/actions/__tests__/devices.test.js
+++ b/shared/actions/__tests__/devices.test.js
@@ -267,7 +267,7 @@ describe('navs after revoking', () => {
   it('root of devices on revoke other', () => {
     const {dispatch, getState} = init
     const deviceID = Types.stringToDeviceID('456')
-    dispatch(DevicesGen.createRevoked({deviceID, deviceName: 'a phone', wasCurrentDevice: true}))
+    dispatch(DevicesGen.createRevoked({deviceID, deviceName: 'a phone', wasCurrentDevice: false}))
     expect(getRoute(getState)).toEqual(I.List([Tabs.devicesTab]))
   })
 

--- a/shared/actions/__tests__/git.test.js
+++ b/shared/actions/__tests__/git.test.js
@@ -1,0 +1,312 @@
+// @flow
+/* eslint-env jest */
+import * as I from 'immutable'
+import * as Tabs from '../../constants/tabs'
+import * as GitGen from '../git-gen'
+import * as RPCTypes from '../../constants/types/rpc-gen'
+import * as RouteTree from '../route-tree'
+import gitSaga from '../git'
+import appRouteTree from '../../app/routes-app'
+import * as Testing from '../../util/testing'
+import {getPath as getRoutePath, getPathState as getRoutePathState} from '../../route-tree'
+
+jest.mock('../../engine')
+
+// We want to be logged in usually
+const blankStore = Testing.getInitialStore()
+const initialStore = {
+  ...blankStore,
+  config: blankStore.config.merge({
+    deviceID: '999',
+    loggedIn: true,
+    username: 'username',
+  }),
+}
+
+const gitRepos = [
+  {
+    canDelete: true,
+    channelName: null,
+    chatDisabled: false,
+    devicename: 'My Mac Device',
+    id: '1b091b39c3c248a0b97d09a4c46c9224_b3749db074a859d991c71bc28d99d82c',
+    lastEditTime: 'a minute ago',
+    lastEditUser: 'eifjls092',
+    name: 'meta',
+    repoID: 'b3749db074a859d991c71bc28d99d82c',
+    teamname: null,
+    url: 'keybase://private/eifjls092/meta',
+  },
+  {
+    canDelete: true,
+    channelName: 'general',
+    chatDisabled: false,
+    devicename: 'My Mac Device',
+    id: '39ae3a19bf4215414d424677c37dce24_1a53ac017631bfbd59adfeb453c84c2c',
+    lastEditTime: 'a few seconds ago',
+    lastEditUser: 'eifjls092',
+    name: 'tea-shop',
+    repoID: '1a53ac017631bfbd59adfeb453c84c2c',
+    teamname: 'test_shop_932',
+    url: 'keybase://team/test_shop_932/tea-shop',
+  },
+]
+
+const gitReposRpc = [
+  {
+    ok: {
+      canDelete: true,
+      folder: {
+        created: false,
+        folderType: 3,
+        name: 'test_shop_932',
+        notificationsOn: false,
+        private: true,
+      },
+      globalUniqueID: '39ae3a19bf4215414d424677c37dce24_1a53ac017631bfbd59adfeb453c84c2c',
+      localMetadata: {
+        previousRepoName: '',
+        pushType: 0,
+        refs: null,
+        repoName: 'tea-shop',
+      },
+      repoID: '1a53ac017631bfbd59adfeb453c84c2c',
+      repoUrl: 'keybase://team/test_shop_932/tea-shop',
+      serverMetadata: {
+        ctime: 1534635051000,
+        lastModifyingDeviceID: '5fd8f74784674fa33f08724635497018',
+        lastModifyingDeviceName: 'My Mac Device',
+        lastModifyingUsername: 'eifjls092',
+        mtime: 1534635052000,
+      },
+      teamRepoSettings: {
+        channelName: 'general',
+        chatDisabled: false,
+      },
+    },
+    state: 1,
+  },
+  {
+    ok: {
+      canDelete: true,
+      folder: {
+        created: false,
+        folderType: 1,
+        name: 'eifjls092',
+        notificationsOn: false,
+        private: true,
+      },
+      globalUniqueID: '1b091b39c3c248a0b97d09a4c46c9224_b3749db074a859d991c71bc28d99d82c',
+      localMetadata: {
+        previousRepoName: '',
+        pushType: 0,
+        refs: null,
+        repoName: 'meta',
+      },
+      repoID: 'b3749db074a859d991c71bc28d99d82c',
+      repoUrl: 'keybase://private/eifjls092/meta',
+      serverMetadata: {
+        ctime: 1534634997000,
+        lastModifyingDeviceID: '5fd8f74784674fa33f08724635497018',
+        lastModifyingDeviceName: 'My Mac Device',
+        lastModifyingUsername: 'eifjls092',
+        mtime: 1534634998000,
+      },
+    },
+    state: 1,
+  },
+]
+
+const nowTimestamp = 1534635058000
+
+const loadedStore = {
+  ...initialStore,
+  git: initialStore.git.merge({
+    idToInfo: gitRepos.reduce((acc, r) => acc.set(r.id, I.Record(r)()), I.Map()),
+    lastLoad: nowTimestamp,
+  }),
+}
+
+const startOnGitTab = dispatch => {
+  dispatch(RouteTree.switchRouteDef(appRouteTree))
+  dispatch(RouteTree.navigateTo([Tabs.gitTab]))
+}
+
+const startReduxSaga = Testing.makeStartReduxSaga(gitSaga, initialStore, startOnGitTab)
+const startReduxSagaWithLoadedStore = Testing.makeStartReduxSaga(gitSaga, loadedStore, startOnGitTab)
+
+const getRoute = getState => getRoutePath(getState().routeTree.routeState, [Tabs.gitTab])
+const getRouteState = getState => getRoutePathState(getState().routeTree.routeState, [Tabs.gitTab])
+
+describe('reload side effects', () => {
+  let init
+  let rpc
+  beforeEach(() => {
+    init = startReduxSaga()
+    rpc = jest.spyOn(RPCTypes, 'gitGetAllGitMetadataRpcPromise')
+  })
+  afterEach(() => {
+    rpc && rpc.mockRestore()
+  })
+
+  it('loads on load', () => {
+    const {dispatch} = init
+    expect(rpc).not.toHaveBeenCalled()
+    dispatch(GitGen.createLoadGit())
+    expect(rpc).toHaveBeenCalled()
+  })
+
+  it("doesn't load on logged out", () => {
+    init = startReduxSaga(blankStore) // logged out store
+    const {dispatch} = init
+    dispatch(GitGen.createLoadGit())
+    expect(rpc).not.toHaveBeenCalled()
+  })
+})
+
+describe('load', () => {
+  let init
+  let rpc
+  let date
+  beforeEach(() => {
+    init = startReduxSaga()
+    date = jest.spyOn(Date, 'now')
+    date.mockImplementation(() => nowTimestamp)
+  })
+  afterEach(() => {
+    rpc && rpc.mockRestore()
+  })
+
+  it('load leads to loaded', () => {
+    const {dispatch, getState} = init
+    rpc = jest.spyOn(RPCTypes, 'gitGetAllGitMetadataRpcPromise')
+    rpc.mockImplementation(() => new Promise(resolve => resolve(gitReposRpc)))
+
+    dispatch(GitGen.createLoadGit())
+    return Testing.flushPromises().then(() => {
+      expect(
+        getState()
+          .git.idToInfo.sort()
+          .toJS()
+      ).toEqual(loadedStore.git.idToInfo.sort().toJS())
+      expect(rpc).toHaveBeenCalled()
+    })
+  })
+
+  it('loaded handles null', () => {
+    const {dispatch, getState} = init
+    rpc = jest.spyOn(RPCTypes, 'gitGetAllGitMetadataRpcPromise')
+    rpc.mockImplementation(() => new Promise(resolve => resolve()))
+    dispatch(GitGen.createLoadGit())
+    return Testing.flushPromises().then(() => {
+      expect(getState().devices.deviceMap).toEqual(I.Map())
+      expect(rpc).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('Team Repos', () => {
+  let init
+  let rpc
+  let date
+  beforeEach(() => {
+    init = startReduxSagaWithLoadedStore()
+    date = jest.spyOn(Date, 'now')
+    date.mockImplementation(() => nowTimestamp)
+  })
+  afterEach(() => {
+    rpc && rpc.mockRestore()
+  })
+
+  it('Expands the correct team repo on nav', () => {
+    const {dispatch, getState} = init
+    dispatch(
+      GitGen.createNavigateToTeamRepo({
+        repoID: '1a53ac017631bfbd59adfeb453c84c2c',
+        teamname: 'test_shop_932',
+      })
+    )
+    expect(getRoute(getState)).toEqual(I.List([Tabs.gitTab]))
+    expect(getRouteState(getState)).toEqual(
+      I.Map({
+        expandedSet: I.Set(['39ae3a19bf4215414d424677c37dce24_1a53ac017631bfbd59adfeb453c84c2c']),
+      })
+    )
+  })
+
+  it('Calls the correct rpc on setting team repo settings', () => {
+    rpc = jest.spyOn(RPCTypes, 'gitSetTeamRepoSettingsRpcPromise')
+    const {dispatch} = init
+    dispatch(
+      GitGen.createSetTeamRepoSettings({
+        channelName: null,
+        chatDisabled: true,
+        repoID: '1a53ac017631bfbd59adfeb453c84c2c',
+        teamname: 'test_shop_932',
+      })
+    )
+    expect(rpc).toHaveBeenCalled()
+  })
+})
+
+describe('Create / Delete', () => {
+  let init
+  let rpc
+  let date
+  beforeEach(() => {
+    init = startReduxSagaWithLoadedStore()
+    date = jest.spyOn(Date, 'now')
+    date.mockImplementation(() => nowTimestamp)
+  })
+  afterEach(() => {
+    rpc && rpc.mockRestore()
+  })
+
+  it('Calls Create Personal Repo RPC', () => {
+    rpc = jest.spyOn(RPCTypes, 'gitCreatePersonalRepoRpcPromise')
+    const {dispatch} = init
+    dispatch(
+      GitGen.createCreatePersonalRepo({
+        name: 'bestIdeaEver',
+      })
+    )
+    expect(rpc).toHaveBeenCalled()
+  })
+
+  it('Calls Create Team Repo RPC', () => {
+    rpc = jest.spyOn(RPCTypes, 'gitCreateTeamRepoRpcPromise')
+    const {dispatch} = init
+    dispatch(
+      GitGen.createCreateTeamRepo({
+        name: 'bestIdeaEver',
+        notifyTeam: true,
+        teamname: 'cowtober',
+      })
+    )
+    expect(rpc).toHaveBeenCalled()
+  })
+
+  it('Calls Delete Personal Repo RPC', () => {
+    rpc = jest.spyOn(RPCTypes, 'gitDeletePersonalRepoRpcPromise')
+    const {dispatch} = init
+    dispatch(
+      GitGen.createDeletePersonalRepo({
+        name: 'bestIdeaEver',
+      })
+    )
+    expect(rpc).toHaveBeenCalled()
+  })
+
+  it('Calls Delete Team Repo RPC', () => {
+    rpc = jest.spyOn(RPCTypes, 'gitDeleteTeamRepoRpcPromise')
+    const {dispatch} = init
+    dispatch(
+      GitGen.createDeleteTeamRepo({
+        name: 'bestIdeaEver',
+        notifyTeam: true,
+        teamname: 'cowtober',
+      })
+    )
+    expect(rpc).toHaveBeenCalled()
+  })
+})

--- a/shared/actions/git-gen.js
+++ b/shared/actions/git-gen.js
@@ -5,6 +5,7 @@
 import * as I from 'immutable'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import * as RPCTypesGregor from '../constants/types/rpc-gregor-gen'
+import * as Types from '../constants/types/git'
 
 // Constants
 export const resetStore = 'common:resetStore' // not a part of git but is handled by every reducer
@@ -16,6 +17,8 @@ export const deleteTeamRepo = 'git:deleteTeamRepo'
 export const handleIncomingGregor = 'git:handleIncomingGregor'
 export const loadGit = 'git:loadGit'
 export const loadGitRepo = 'git:loadGitRepo'
+export const loaded = 'git:loaded'
+export const navToGit = 'git:navToGit'
 export const navigateToTeamRepo = 'git:navigateToTeamRepo'
 export const setError = 'git:setError'
 export const setTeamRepoSettings = 'git:setTeamRepoSettings'
@@ -40,6 +43,11 @@ type _LoadGitRepoPayload = $ReadOnly<{|
   username: ?string,
   teamname: ?string,
 |}>
+type _LoadedPayload = $ReadOnly<{|
+  repos: {'[key: string]': Types.GitInfo},
+  errors: Array<Error>,
+|}>
+type _NavToGitPayload = $ReadOnly<{|routeState: ?{expandedSet: I.Set<string>}|}>
 type _NavigateToTeamRepoPayload = $ReadOnly<{|
   repoID: string,
   teamname: string,
@@ -61,6 +69,8 @@ export const createDeleteTeamRepo = (payload: _DeleteTeamRepoPayload) => ({error
 export const createHandleIncomingGregor = (payload: _HandleIncomingGregorPayload) => ({error: false, payload, type: handleIncomingGregor})
 export const createLoadGit = (payload: _LoadGitPayload) => ({error: false, payload, type: loadGit})
 export const createLoadGitRepo = (payload: _LoadGitRepoPayload) => ({error: false, payload, type: loadGitRepo})
+export const createLoaded = (payload: _LoadedPayload) => ({error: false, payload, type: loaded})
+export const createNavToGit = (payload: _NavToGitPayload) => ({error: false, payload, type: navToGit})
 export const createNavigateToTeamRepo = (payload: _NavigateToTeamRepoPayload) => ({error: false, payload, type: navigateToTeamRepo})
 export const createSetError = (payload: _SetErrorPayload) => ({error: false, payload, type: setError})
 export const createSetTeamRepoSettings = (payload: _SetTeamRepoSettingsPayload) => ({error: false, payload, type: setTeamRepoSettings})
@@ -74,6 +84,8 @@ export type DeleteTeamRepoPayload = $Call<typeof createDeleteTeamRepo, _DeleteTe
 export type HandleIncomingGregorPayload = $Call<typeof createHandleIncomingGregor, _HandleIncomingGregorPayload>
 export type LoadGitPayload = $Call<typeof createLoadGit, _LoadGitPayload>
 export type LoadGitRepoPayload = $Call<typeof createLoadGitRepo, _LoadGitRepoPayload>
+export type LoadedPayload = $Call<typeof createLoaded, _LoadedPayload>
+export type NavToGitPayload = $Call<typeof createNavToGit, _NavToGitPayload>
 export type NavigateToTeamRepoPayload = $Call<typeof createNavigateToTeamRepo, _NavigateToTeamRepoPayload>
 export type SetErrorPayload = $Call<typeof createSetError, _SetErrorPayload>
 export type SetTeamRepoSettingsPayload = $Call<typeof createSetTeamRepoSettings, _SetTeamRepoSettingsPayload>
@@ -89,6 +101,8 @@ export type Actions =
   | HandleIncomingGregorPayload
   | LoadGitPayload
   | LoadGitRepoPayload
+  | LoadedPayload
+  | NavToGitPayload
   | NavigateToTeamRepoPayload
   | SetErrorPayload
   | SetTeamRepoSettingsPayload

--- a/shared/actions/json/git.json
+++ b/shared/actions/json/git.json
@@ -1,7 +1,15 @@
 {
-  "prelude": ["import * as RPCTypesGregor from '../constants/types/rpc-gregor-gen'"],
+  "prelude": [
+    "import * as RPCTypesGregor from '../constants/types/rpc-gregor-gen'",
+    "import * as Types from '../constants/types/git'"
+  ],
   "actions": {
     "loadGit": {},
+    "loaded": {
+      "repos": "{\"[key: string]\": Types.GitInfo}",
+      "errors": "Array<Error>"
+    },
+    "navToGit": {routeState: "?{\"expandedSet\": I.Set<string>}"},
     "createTeamRepo": {
       "name": "string",
       "teamname": "string",

--- a/shared/constants/git.js
+++ b/shared/constants/git.js
@@ -1,10 +1,14 @@
 // @flow
 import * as I from 'immutable'
 import * as Types from './types/git'
+import * as RPCTypes from './types/rpc-gen'
+import moment from 'moment'
 import type {TypedState} from './reducer'
 
 export const makeGitInfo: I.RecordFactory<Types._GitInfo> = I.Record({
   canDelete: false,
+  channelName: null,
+  chatDisabled: false,
   devicename: '',
   id: '',
   lastEditTime: '',
@@ -13,18 +17,71 @@ export const makeGitInfo: I.RecordFactory<Types._GitInfo> = I.Record({
   repoID: '',
   teamname: null,
   url: '',
-  channelName: null,
-  chatDisabled: false,
 })
 
 export const makeState: I.RecordFactory<Types._State> = I.Record({
   error: null,
   idToInfo: I.Map(),
   isNew: I.Set(),
+  lastLoad: null,
 })
 
-const getIdToGit = (state: TypedState) => state.entities.getIn(['git', 'idToInfo'])
-const getError = (state: TypedState) => state.entities.getIn(['git', 'error'])
+const parseRepoResult = (result: RPCTypes.GitRepoResult): ?Types.GitInfo => {
+  if (result.state === RPCTypes.gitGitRepoResultState.ok && result.ok) {
+    const r: RPCTypes.GitRepoInfo = result.ok
+    if (!r.folder.private) {
+      // Skip public repos
+      return null
+    }
+    const teamname = r.folder.folderType === RPCTypes.favoriteFolderType.team ? r.folder.name : null
+    return makeGitInfo({
+      canDelete: r.canDelete,
+      channelName: (r.teamRepoSettings && r.teamRepoSettings.channelName) || null,
+      chatDisabled: !!r.teamRepoSettings && r.teamRepoSettings.chatDisabled,
+      devicename: r.serverMetadata.lastModifyingDeviceName,
+      id: r.globalUniqueID,
+      lastEditTime: moment(r.serverMetadata.mtime).fromNow(),
+      lastEditUser: r.serverMetadata.lastModifyingUsername,
+      name: r.localMetadata.repoName,
+      repoID: r.repoID,
+      teamname,
+      url: r.repoUrl,
+    })
+  }
+  return null
+}
+
+const parseRepoError = (result: RPCTypes.GitRepoResult): Error => {
+  let errStr: string = 'unknown'
+  if (result.state === RPCTypes.gitGitRepoResultState.err && result.err) {
+    errStr = result.err
+  }
+  return new Error(`Git repo error: ${errStr}`)
+}
+
+const parseRepos = (
+  results: Array<RPCTypes.GitRepoResult>
+): {|repos: {[key: string]: Types.GitInfo}, errors: Array<Error>|} => {
+  let errors = []
+  let repos = {}
+  results.forEach(result => {
+    if (result.state === RPCTypes.gitGitRepoResultState.ok && result.ok) {
+      const parsedRepo = parseRepoResult(result)
+      if (parsedRepo) {
+        repos[parsedRepo.id] = parsedRepo
+      }
+    } else {
+      errors.push(parseRepoError(result))
+    }
+  })
+  return {
+    repos,
+    errors,
+  }
+}
+
+const getIdToGit = (state: TypedState) => state.git.get('idToInfo')
+const getError = (state: TypedState) => state.git.get('error')
 const loadingWaitingKey = 'git:loading'
 
-export {getIdToGit, getError, loadingWaitingKey}
+export {getIdToGit, getError, loadingWaitingKey, parseRepos}

--- a/shared/constants/reducer.js
+++ b/shared/constants/reducer.js
@@ -6,6 +6,7 @@ import type {State as Dev} from '../constants/types/dev'
 import type {State as Devices} from '../constants/types/devices'
 import type {State as Entity} from '../constants/types/entities'
 import type {State as Favorite} from '../constants/types/favorite'
+import type {State as Git} from '../constants/types/git'
 import type {State as Gregor} from '../constants/types/gregor'
 import type {State as FS} from '../constants/types/fs'
 import type {State as Login} from '../constants/types/login'
@@ -33,6 +34,7 @@ export type TypedState = $ReadOnly<{|
   entities: Entity,
   favorite: Favorite,
   fs: FS,
+  git: Git,
   gregor: Gregor,
   login: Login,
   provision: Provision,

--- a/shared/constants/types/git.js
+++ b/shared/constants/types/git.js
@@ -17,6 +17,7 @@ export type _GitInfo = {
 export type GitInfo = I.RecordOf<_GitInfo>
 export type _State = {
   error: ?Error,
+  lastLoad: ?number,
   idToInfo: I.Map<string, GitInfo>,
   isNew: I.Set<string>,
 }

--- a/shared/git/row/container.js
+++ b/shared/git/row/container.js
@@ -12,11 +12,11 @@ import openURL from '../../util/open-url'
 import {isMobile} from '../../constants/platform'
 
 const mapStateToProps = (state: TypedState, {id, expanded}) => {
-  const git = state.entities.getIn(['git', 'idToInfo', id], Constants.makeGitInfo()).toObject()
+  const git = state.git.getIn(['idToInfo', id], Constants.makeGitInfo()).toObject()
   return {
     ...git,
     expanded,
-    isNew: state.entities.getIn(['git', 'isNew', id], false),
+    isNew: state.git.getIn(['isNew', id], false),
     lastEditUserFollowing: state.config.following.has(git.lastEditUser),
     you: state.config.username,
   }

--- a/shared/reducers/git.js
+++ b/shared/reducers/git.js
@@ -1,0 +1,39 @@
+// @flow
+import * as I from 'immutable'
+import * as Constants from '../constants/git'
+import * as Types from '../constants/types/git'
+import * as GitGen from '../actions/git-gen'
+
+const initialState: Types.State = Constants.makeState()
+
+export default function(state: Types.State = initialState, action: GitGen.Actions) {
+  switch (action.type) {
+    case GitGen.resetStore:
+      return initialState
+    case GitGen.loaded:
+      return state.set('idToInfo', I.Map(action.payload.repos)).set('lastLoad', Date.now())
+    case GitGen.setError:
+      return state.set('error', action.payload.error)
+    case GitGen.badgeAppForGit:
+      return state.set('isNew', I.Set(action.payload.ids))
+
+    // Saga only actions
+    case GitGen.createPersonalRepo:
+    case GitGen.createTeamRepo:
+    case GitGen.deletePersonalRepo:
+    case GitGen.deleteTeamRepo:
+    case GitGen.handleIncomingGregor:
+    case GitGen.loadGit:
+    case GitGen.loadGitRepo:
+    case GitGen.navToGit:
+    case GitGen.navigateToTeamRepo:
+    case GitGen.setTeamRepoSettings:
+      return state
+    default:
+      /*::
+      declare var ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove: (action: empty) => any
+      ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove(action);
+      */
+      return state
+  }
+}

--- a/shared/reducers/index.js
+++ b/shared/reducers/index.js
@@ -7,10 +7,11 @@ import devices from './devices'
 import entities from './entities'
 import favorite from './favorite'
 import fs from './fs'
+import git from './git'
 import gregor from './gregor'
 import login from './login'
-import provision from './provision'
 import notifications from './notifications'
+import provision from './provision'
 import people from './people'
 import pinentry from './pinentry'
 import planBilling from './plan-billing'
@@ -39,6 +40,7 @@ const reducers = {
   entities,
   favorite,
   fs,
+  git,
   gregor,
   login,
   notifications,


### PR DESCRIPTION
Moves actions/git to a the new coding style. Preferring `actionToAction` and `actionToPromise` over generators.

Adds a git sub reducer, and a couple more git actions to help move away from the generators.

Adds a couple tests for the actions. Just as a start, but happy to add more. (a lot of the additions come from this)

More notes inline.

(also it doesn't seem like I have write access to keybase/client. I can move this so it runs CI tests after I get access)