### PR TITLE
Hook up provision:switchToGPGSignOK

### DIFF
--- a/shared/actions/json/provision.json
+++ b/shared/actions/json/provision.json
@@ -14,6 +14,8 @@
     "submitDeviceSelect": { "name": "string" },
     "submitDeviceName": { "name": "string" },
     "submitGPGMethod": { "exportKey": "boolean" },
+    "switchToGPGSignOnly": { "importError": "string" },
+    "submitGPGSignOK": { "accepted": "boolean" },
     "showDeviceListPage": {
       "_description": "Show the list of devices the user can use to provision a device",
       "devices": "Array<Types.Device>"

--- a/shared/actions/provision-gen.js
+++ b/shared/actions/provision-gen.js
@@ -23,10 +23,12 @@ export const startProvision = 'provision:startProvision'
 export const submitDeviceName = 'provision:submitDeviceName'
 export const submitDeviceSelect = 'provision:submitDeviceSelect'
 export const submitGPGMethod = 'provision:submitGPGMethod'
+export const submitGPGSignOK = 'provision:submitGPGSignOK'
 export const submitPaperkey = 'provision:submitPaperkey'
 export const submitPassphrase = 'provision:submitPassphrase'
 export const submitTextCode = 'provision:submitTextCode'
 export const submitUsernameOrEmail = 'provision:submitUsernameOrEmail'
+export const switchToGPGSignOnly = 'provision:switchToGPGSignOnly'
 
 // Payload Types
 type _AddNewDevicePayload = $ReadOnly<{|otherDeviceType: 'desktop' | 'mobile'|}>
@@ -48,10 +50,12 @@ type _StartProvisionPayload = void
 type _SubmitDeviceNamePayload = $ReadOnly<{|name: string|}>
 type _SubmitDeviceSelectPayload = $ReadOnly<{|name: string|}>
 type _SubmitGPGMethodPayload = $ReadOnly<{|exportKey: boolean|}>
+type _SubmitGPGSignOKPayload = $ReadOnly<{|accepted: boolean|}>
 type _SubmitPaperkeyPayload = $ReadOnly<{|paperkey: HiddenString|}>
 type _SubmitPassphrasePayload = $ReadOnly<{|passphrase: HiddenString|}>
 type _SubmitTextCodePayload = $ReadOnly<{|phrase: HiddenString|}>
 type _SubmitUsernameOrEmailPayload = $ReadOnly<{|usernameOrEmail: string|}>
+type _SwitchToGPGSignOnlyPayload = $ReadOnly<{|importError: string|}>
 
 // Action Creators
 /**
@@ -73,10 +77,12 @@ export const createStartProvision = (payload: _StartProvisionPayload) => ({error
 export const createSubmitDeviceName = (payload: _SubmitDeviceNamePayload) => ({error: false, payload, type: submitDeviceName})
 export const createSubmitDeviceSelect = (payload: _SubmitDeviceSelectPayload) => ({error: false, payload, type: submitDeviceSelect})
 export const createSubmitGPGMethod = (payload: _SubmitGPGMethodPayload) => ({error: false, payload, type: submitGPGMethod})
+export const createSubmitGPGSignOK = (payload: _SubmitGPGSignOKPayload) => ({error: false, payload, type: submitGPGSignOK})
 export const createSubmitPaperkey = (payload: _SubmitPaperkeyPayload) => ({error: false, payload, type: submitPaperkey})
 export const createSubmitPassphrase = (payload: _SubmitPassphrasePayload) => ({error: false, payload, type: submitPassphrase})
 export const createSubmitTextCode = (payload: _SubmitTextCodePayload) => ({error: false, payload, type: submitTextCode})
 export const createSubmitUsernameOrEmail = (payload: _SubmitUsernameOrEmailPayload) => ({error: false, payload, type: submitUsernameOrEmail})
+export const createSwitchToGPGSignOnly = (payload: _SwitchToGPGSignOnlyPayload) => ({error: false, payload, type: switchToGPGSignOnly})
 
 // Action Payloads
 export type AddNewDevicePayload = $Call<typeof createAddNewDevice, _AddNewDevicePayload>
@@ -92,10 +98,12 @@ export type StartProvisionPayload = $Call<typeof createStartProvision, _StartPro
 export type SubmitDeviceNamePayload = $Call<typeof createSubmitDeviceName, _SubmitDeviceNamePayload>
 export type SubmitDeviceSelectPayload = $Call<typeof createSubmitDeviceSelect, _SubmitDeviceSelectPayload>
 export type SubmitGPGMethodPayload = $Call<typeof createSubmitGPGMethod, _SubmitGPGMethodPayload>
+export type SubmitGPGSignOKPayload = $Call<typeof createSubmitGPGSignOK, _SubmitGPGSignOKPayload>
 export type SubmitPaperkeyPayload = $Call<typeof createSubmitPaperkey, _SubmitPaperkeyPayload>
 export type SubmitPassphrasePayload = $Call<typeof createSubmitPassphrase, _SubmitPassphrasePayload>
 export type SubmitTextCodePayload = $Call<typeof createSubmitTextCode, _SubmitTextCodePayload>
 export type SubmitUsernameOrEmailPayload = $Call<typeof createSubmitUsernameOrEmail, _SubmitUsernameOrEmailPayload>
+export type SwitchToGPGSignOnlyPayload = $Call<typeof createSwitchToGPGSignOnly, _SwitchToGPGSignOnlyPayload>
 
 // All Actions
 // prettier-ignore
@@ -113,8 +121,10 @@ export type Actions =
   | SubmitDeviceNamePayload
   | SubmitDeviceSelectPayload
   | SubmitGPGMethodPayload
+  | SubmitGPGSignOKPayload
   | SubmitPaperkeyPayload
   | SubmitPassphrasePayload
   | SubmitTextCodePayload
   | SubmitUsernameOrEmailPayload
+  | SwitchToGPGSignOnlyPayload
   | {type: 'common:resetStore', payload: void}

--- a/shared/actions/provision.js
+++ b/shared/actions/provision.js
@@ -27,6 +27,7 @@ type ValidCallback =
   | 'keybase.1.provisionUi.ProvisionerSuccess'
   | 'keybase.1.provisionUi.chooseDevice'
   | 'keybase.1.provisionUi.chooseGPGMethod'
+  | 'keybase.1.provisionUi.switchToGPGSignOK'
   | 'keybase.1.secretUi.getPassphrase'
 
 const cancelOnCallback = (_: any, response: CommonResponseHandler, __: any) => {
@@ -195,6 +196,7 @@ class ProvisioningManager {
     this._stashResponse('keybase.1.provisionUi.chooseGPGMethod', response)
     return Saga.put(ProvisionGen.createShowGPGPage())
   }
+
   submitGPGMethod = (state: TypedState, action: ProvisionGen.SubmitGPGMethodPayload) => {
     // local error, ignore
     if (state.provision.error.stringValue()) {
@@ -211,6 +213,27 @@ class ProvisioningManager {
         ? RPCTypes.provisionUiGPGMethod.gpgImport
         : RPCTypes.provisionUiGPGMethod.gpgSign
     )
+  }
+
+  switchToGPGSignOKHandler = (
+    params: RPCTypes.ProvisionUiSwitchToGPGSignOKRpcParam,
+    response: CommonResponseHandler,
+    state: TypedState
+  ) => {
+    this._stashResponse('keybase.1.provisionUi.switchToGPGSignOK', response)
+    return Saga.all([
+      Saga.put(ProvisionGen.createSwitchToGPGSignOnly({importError: params.importError})),
+      Saga.put(ProvisionGen.createShowGPGPage()),
+    ])
+  }
+
+  submitGPGSignOK = (state: TypedState, action: ProvisionGen.SubmitGPGSignOKPayload) => {
+    const response = this._getAndClearResponse('keybase.1.provisionUi.switchToGPGSignOK')
+    if (!response || !response.result) {
+      throw new Error('Tried to respond to gpg sign ok but missing callback')
+    }
+
+    response.result(action.payload.accepted)
   }
 
   // User has an uploaded key so we can use a passphrase OR they selected a paperkey
@@ -280,6 +303,7 @@ class ProvisioningManager {
           'keybase.1.provisionUi.ProvisionerSuccess': ignoreCallback,
           'keybase.1.provisionUi.chooseDevice': this.chooseDeviceHandler,
           'keybase.1.provisionUi.chooseGPGMethod': this.chooseGPGMethodHandler,
+          'keybase.1.provisionUi.switchToGPGSignOK': this.switchToGPGSignOKHandler,
           'keybase.1.secretUi.getPassphrase': this.getPassphraseHandler,
         }
 
@@ -367,6 +391,8 @@ const submitDeviceName = (state: TypedState) => ProvisioningManager.getSingleton
 const submitTextCode = (state: TypedState) => ProvisioningManager.getSingleton().submitTextCode(state)
 const submitGPGMethod = (state: TypedState, action: ProvisionGen.SubmitGPGMethodPayload) =>
   ProvisioningManager.getSingleton().submitGPGMethod(state, action)
+const submitGPGSignOK = (state: TypedState, action: ProvisionGen.SubmitGPGSignOKPayload) =>
+  ProvisioningManager.getSingleton().submitGPGSignOK(state, action)
 const submitPassphraseOrPaperkey = (
   state: TypedState,
   action: ProvisionGen.SubmitPassphrasePayload | ProvisionGen.SubmitPaperkeyPayload
@@ -417,6 +443,7 @@ function* provisionSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.actionToAction(ProvisionGen.submitDeviceName, submitDeviceName)
   yield Saga.actionToAction(ProvisionGen.submitTextCode, submitTextCode)
   yield Saga.actionToAction(ProvisionGen.submitGPGMethod, submitGPGMethod)
+  yield Saga.actionToAction(ProvisionGen.submitGPGSignOK, submitGPGSignOK)
   yield Saga.actionToAction(
     [ProvisionGen.submitPassphrase, ProvisionGen.submitPaperkey],
     submitPassphraseOrPaperkey

--- a/shared/constants/provision.js
+++ b/shared/constants/provision.js
@@ -22,6 +22,7 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   error: new HiddenString(''),
   existingDevices: I.List(),
   finalError: null,
+  gpgImportError: null,
   selectedDevice: null,
   usernameOrEmail: '',
 })

--- a/shared/constants/types/provision.js
+++ b/shared/constants/types/provision.js
@@ -26,6 +26,7 @@ export type _State = {
   usernameOrEmail: string,
   deviceName: string,
   devices: I.List<Device>,
+  gpgImportError: ?string,
   existingDevices: I.List<string>,
 }
 

--- a/shared/provision/gpg-sign/container.js
+++ b/shared/provision/gpg-sign/container.js
@@ -2,13 +2,34 @@
 import * as ProvisionGen from '../../actions/provision-gen'
 import {connect, type Dispatch} from '../../util/container'
 import {type RouteProps} from '../../route-tree/render-route'
+import type {TypedState} from '../../constants/reducer'
 import GPGSign from '.'
 
 type OwnProps = RouteProps<{}, {}>
 
-const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
-  onBack: () => dispatch(ownProps.navigateUp()),
-  onSubmit: exportKey => dispatch(ProvisionGen.createSubmitGPGMethod({exportKey})),
+const mapStateToProps = (state: TypedState) => ({
+  importError: state.provision.gpgImportError,
 })
 
-export default connect(undefined, mapDispatchToProps)(GPGSign)
+const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
+  onBack: () => dispatch(ownProps.navigateUp()),
+  onSubmitGpgMethod: exportKey => dispatch(ProvisionGen.createSubmitGPGMethod({exportKey})),
+  onAcceptGpgSign: () => dispatch(ProvisionGen.createSubmitGPGSignOK({accepted: true})),
+  onRejectGpgSign: () => dispatch(ProvisionGen.createSubmitGPGSignOK({accepted: false})),
+})
+
+// If we are asked to switch to gpg sign, we either accept or reject.
+const mergeProps = ({importError}, dispatchProps) =>
+  importError
+    ? {
+        importError,
+        onBack: dispatchProps.onRejectGpgSign,
+        onSubmit: _ => dispatchProps.onAcceptGpgSign(),
+      }
+    : {
+        importError,
+        onBack: dispatchProps.onBack,
+        onSubmit: dispatchProps.onSubmitGpgMethod,
+      }
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(GPGSign)

--- a/shared/provision/gpg-sign/index.desktop.js
+++ b/shared/provision/gpg-sign/index.desktop.js
@@ -3,7 +3,7 @@
 import Container from '../../login/forms/container'
 import React, {Component} from 'react'
 import Row, {RowCSS} from './row.desktop'
-import {Text} from '../../common-adapters'
+import {Text, Box2} from '../../common-adapters'
 
 import type {Props} from '.'
 
@@ -12,34 +12,54 @@ class GPGSign extends Component<Props> {
     return (
       <Container style={styles.container} onBack={() => this.props.onBack()}>
         <RowCSS />
+        {this.props.importError && (
+          <Box2 direction="vertical" centerChildren={true}>
+            <Text type="Header" style={styles.header}>
+              There was an error importing your pgp key:
+              {'\n'}
+            </Text>
+            <Text type="BodyError">{this.props.importError}</Text>
+            <Text type="Body">You can try asking gpg to sign this install instead.</Text>
+          </Box2>
+        )}
         <Text type="Header" style={styles.header}>
           Let's sign your installation of keybase with GPG
         </Text>
         <Text type="Body" style={styles.subHeader}>
           Allow Keybase to run PGP commands?
         </Text>
-        <Row
-          onClick={() => this.props.onSubmit(true)}
-          icon="icon-GPG-export"
-          title="Export your secret key from GPG"
-        >
-          <p>
-            <Text type="BodySmall">
-              This copies your PGP pair into Keybase's local encrypted keyring. Later, you can{' '}
-            </Text>
-            <Text type="Terminal">keybase pgp sign</Text>
-            <Text type="BodySmall"> and </Text>
-            <Text type="Terminal">keybase pgp decrypt</Text>
-            <Text type="BodySmall"> messages and files.</Text>
-          </p>
-        </Row>
-        <Row onClick={() => this.props.onSubmit(false)} icon="icon-terminal-48" title="One-time shell to GPG">
-          <p>
-            <Text type="BodySmall">Keybase can ask GPG to sign this install. You won't be able to use </Text>
-            <Text type="Terminal">keybase pgp</Text>
-            <Text type="BodySmall"> commands on this computer.</Text>
-          </p>
-        </Row>
+        <Box2 direction="vertical" centerChildren={true} style={{maxWidth: 750}}>
+          {!this.props.importError && (
+            <Row
+              onClick={() => this.props.onSubmit(true)}
+              icon="icon-GPG-export"
+              title="Export your secret key from GPG"
+            >
+              <p>
+                <Text type="BodySmall">
+                  This copies your PGP pair into Keybase's local encrypted keyring. Later, you can{' '}
+                </Text>
+                <Text type="Terminal">keybase pgp sign</Text>
+                <Text type="BodySmall"> and </Text>
+                <Text type="Terminal">keybase pgp decrypt</Text>
+                <Text type="BodySmall"> messages and files.</Text>
+              </p>
+            </Row>
+          )}
+          <Row
+            onClick={() => this.props.onSubmit(false)}
+            icon="icon-terminal-48"
+            title="One-time shell to GPG"
+          >
+            <p>
+              <Text type="BodySmall">
+                Keybase can ask GPG to sign this install. You won't be able to use{' '}
+              </Text>
+              <Text type="Terminal">keybase pgp</Text>
+              <Text type="BodySmall"> commands on this computer.</Text>
+            </p>
+          </Row>
+        </Box2>
       </Container>
     )
   }
@@ -47,8 +67,8 @@ class GPGSign extends Component<Props> {
 
 const styles = {
   container: {
-    flex: 1,
     alignItems: 'center',
+    flex: 1,
   },
   header: {
     marginTop: 36,

--- a/shared/provision/gpg-sign/index.js.flow
+++ b/shared/provision/gpg-sign/index.js.flow
@@ -2,6 +2,7 @@
 import React, {Component} from 'react'
 
 export type Props = {
+  importError: ?string,
   onSubmit: (exportKey: boolean) => void,
   onBack: () => void,
 }

--- a/shared/provision/gpg-sign/index.stories.js
+++ b/shared/provision/gpg-sign/index.stories.js
@@ -1,10 +1,16 @@
 // @flow
 import * as React from 'react'
-import {Text} from '../../common-adapters'
-import {storiesOf} from '../../stories/storybook'
+import GPGSign from './index'
+import {storiesOf, action} from '../../stories/storybook'
 
 const load = () => {
-  storiesOf('Provision/GPGSign', module).add('GPGSign', () => <Text type="Body">TODO</Text>)
+  storiesOf('Provision/GPGSign', module)
+    .add('GPGSign', () => (
+      <GPGSign importError={null} onSubmit={action('onSubmit')} onBack={action('onBack')} />
+    ))
+    .add('GPGSign with import error', () => (
+      <GPGSign importError={'Too many failures'} onSubmit={action('onSubmit')} onBack={action('onBack')} />
+    ))
 }
 
 export default load

--- a/shared/reducers/provision.js
+++ b/shared/reducers/provision.js
@@ -83,6 +83,10 @@ export default function(state: Types.State = initialState, action: ProvisionGen.
         finalError: null,
         usernameOrEmail: action.payload.usernameOrEmail,
       })
+    case ProvisionGen.switchToGPGSignOnly:
+      return state.set('gpgImportError', action.payload.importError)
+    case ProvisionGen.submitGPGSignOK:
+      return state.set('gpgImportError', null)
     // Saga only actions
     case ProvisionGen.showGPGPage:
     case ProvisionGen.submitGPGMethod:


### PR DESCRIPTION
`provision.switchToGPGSignOK` is for this case:
```
// If there was an error importing a gpg key into the local
// keyring, tell the user and offer to switch to GPG signing
// with this key.  Return true to switch to GPG signing,
// false to abort provisioning.
```

I do this by reintroducing the gpg choose screen, but removing the import option and showing what the error was. It looks like this:
![screen shot 2018-08-19 at 3 42 12 pm](https://user-images.githubusercontent.com/594035/44313634-13c17680-a3c9-11e8-8492-27ab910eedc2.png)

While working on this I found these two issues:
[CORE-8616](https://keybase.atlassian.net/browse/CORE-8616)
[DESKTOP-7583](https://keybase.atlassian.net/browse/DESKTOP-7583)
