### PR TITLE
Remove the descriptive text from payment.worthDescription

### DIFF
--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -1130,7 +1130,7 @@ func (s *Server) buildPaymentAmountHelper(ctx context.Context, bpc stellar.Build
 			res.amountErrMsg = fmt.Sprintf("Could not convert to XLM")
 			return res
 		}
-		res.worthDescription = fmt.Sprintf("This is *%s*", xlmAmountFormatted)
+		res.worthDescription = xlmAmountFormatted
 		if convertAmountOutside != "0" {
 			// haveAmount gates whether the send button is enabled.
 			// Only enable after `worthDescription` is set.
@@ -1184,7 +1184,7 @@ func (s *Server) buildPaymentAmountHelper(ctx context.Context, bpc stellar.Build
 			log("error formatting converted outside amount: %v", err)
 			return res
 		}
-		res.worthDescription = fmt.Sprintf("This is *%s*", outsideAmountFormatted)
+		res.worthDescription = outsideAmountFormatted
 		res.worthInfo, err = s.buildPaymentWorthInfo(ctx, xrate)
 		if err != nil {
 			log("error making worth info: %v", err)

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -795,7 +795,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "", bres.PublicMemoErrMsg)
-	require.Equal(t, "This is *$0.00*", bres.WorthDescription)
+	require.Equal(t, "$0.00", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
 		Level:   "info",
@@ -833,7 +833,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "Your available to send is *0 XLM*", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "", bres.PublicMemoErrMsg)
-	require.Equal(t, "This is *$9.55*", bres.WorthDescription)
+	require.Equal(t, "$9.55", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
 		Level:   "info",
@@ -855,7 +855,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "Your available to send is *18.9999900 XLM*", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "", bres.PublicMemoErrMsg)
-	require.Equal(t, "This is *$9.55*", bres.WorthDescription)
+	require.Equal(t, "$9.55", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
 		Level:   "info",
@@ -874,7 +874,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "", bres.PublicMemoErrMsg)
-	require.Equal(t, "This is *$4.77*", bres.WorthDescription)
+	require.Equal(t, "$4.77", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
 		Level:   "info",
@@ -902,7 +902,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "Your available to send is *3.9999800 XLM*", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "Memo is too long.", bres.PublicMemoErrMsg) // too many potatoes
-	require.Equal(t, "This is *$4.77*", bres.WorthDescription)
+	require.Equal(t, "$4.77", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{}) // recipient is funded so banner's gone
 
@@ -919,7 +919,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "Your available to send is *3.9999800 XLM*", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "", bres.PublicMemoErrMsg)
-	require.Equal(t, "This is *$1.27*", bres.WorthDescription)
+	require.Equal(t, "$1.27", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{})
 
@@ -938,7 +938,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "Memo is too long.", bres.PublicMemoErrMsg)
-	require.Equal(t, "This is *$0.95*", bres.WorthDescription)
+	require.Equal(t, "$0.95", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
 		Level:   "error",
@@ -961,7 +961,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "", bres.PublicMemoErrMsg)
-	require.Equal(t, "This is *26.7020180 XLM*", bres.WorthDescription)
+	require.Equal(t, "26.7020180 XLM", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{})
 
@@ -981,7 +981,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "", bres.PublicMemoErrMsg)
-	require.Equal(t, "This is *26.7020180 XLM*", bres.WorthDescription)
+	require.Equal(t, "26.7020180 XLM", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{{
 		Level:   "info",
@@ -1004,7 +1004,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "", bres.PublicMemoErrMsg)
-	require.Equal(t, "This is *26.7020180 XLM*", bres.WorthDescription)
+	require.Equal(t, "26.7020180 XLM", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{})
 
@@ -1030,7 +1030,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "", bres.AmountErrMsg)
 	require.Equal(t, "", bres.SecretNoteErrMsg)
 	require.Equal(t, "", bres.PublicMemoErrMsg)
-	require.Equal(t, "This is *26.7020180 XLM*", bres.WorthDescription)
+	require.Equal(t, "26.7020180 XLM", bres.WorthDescription)
 	require.Equal(t, worthInfo, bres.WorthInfo)
 	requireBannerSet(t, bres, []stellar1.SendBannerLocal{})
 }

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -234,8 +234,8 @@ protocol local {
     string publicMemoErrMsg;
 
     // Optional. Blank if non-native assets are being sent or if there is a global error.
-    // Example: "This is *96.5634762 XLM*."
-    // Example: "This is *$246.47*."
+    // Example: "96.5634762 XLM"
+    // Example: "$246.47"
     string worthDescription;
     // Set with `worthDescription`
     // Example: "$1 = 5.0992345 XLM\nSource: coinmarketcap.com"

--- a/shared/wallets/send-form/footer/index.js
+++ b/shared/wallets/send-form/footer/index.js
@@ -13,9 +13,11 @@ type Props = {
 
 const Footer = (props: Props) => (
   <Kb.Box2 direction="vertical" fullWidth={true} style={styles.background}>
-    <Kb.Text style={styles.worthDescription} type="BodySmall">
-      {props.worthDescription}
-    </Kb.Text>
+    {!!props.worthDescription && (
+      <Kb.Text style={styles.worthDescription} type="BodySmall">
+        This is <Kb.Text type="BodySmallExtrabold">{props.worthDescription}</Kb.Text>
+      </Kb.Text>
+    )}
     <Kb.Box2 direction="horizontal" style={styles.buttonBox} fullWidth={true}>
       {!!props.onClickRequest && (
         <Kb.Button


### PR DESCRIPTION
@keybase/react-hackers CC @patrickxb @mlsteele 

Service gives us a string like:

"This is **$0.23**"

for the conversion of XLM to USD, but we also use that string on the confirm screen, where it should just be the value itself rather than a description.  So, I think we should have the protocol field just send the value, and we'll put the description on it when we need it.