### PR TITLE
use canonicalized team name

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -192,11 +192,9 @@ func filterConvLocals(convLocals []chat1.ConversationLocal, rquery *chat1.GetInb
 	query *chat1.GetInboxLocalQuery, nameInfo *types.NameInfoUntrusted) (res []chat1.ConversationLocal, err error) {
 
 	for _, convLocal := range convLocals {
-
 		if rquery != nil && rquery.TlfID != nil {
 			// inbox query contained a TLF name, so check to make sure that
 			// the conversation from the server matches tlfInfo from kbfs
-
 			if convLocal.Info.TLFNameExpanded() != nameInfo.CanonicalName {
 				if convLocal.Error == nil {
 					return nil, fmt.Errorf("server conversation TLF name mismatch: %s, expected %s",

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -163,14 +163,11 @@ func (t testUISource) GetStreamUICli() *keybase1.StreamUiClient {
 // Create a team with me as the owner
 func createTeam(tc libkb.TestContext) string {
 	b, err := libkb.RandBytes(4)
-	if err != nil {
-		tc.T.Fatal(err)
-	}
-	name := hex.EncodeToString(b)
+	require.NoError(tc.T, err)
+
+	name := fmt.Sprintf("TeAm%v", hex.EncodeToString(b))
 	_, err = teams.CreateRootTeam(context.TODO(), tc.G, name, keybase1.TeamSettings{})
-	if err != nil {
-		tc.T.Fatal(err)
-	}
+	require.NoError(tc.T, err)
 	return name
 }
 
@@ -649,7 +646,7 @@ func TestChatSrvNewConversationLocal(t *testing.T) {
 			require.Equal(t, refName, conv.MaxMsgSummaries[0].TlfName)
 		case chat1.ConversationMembersType_TEAM:
 			teamName := ctc.teamCache[teamKey(ctc.users())]
-			require.Equal(t, teamName, conv.MaxMsgSummaries[0].TlfName)
+			require.Equal(t, strings.ToLower(teamName), conv.MaxMsgSummaries[0].TlfName)
 		}
 	})
 }

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -182,7 +182,7 @@ func (t *TeamsNameInfoSource) LookupIDUntrusted(ctx context.Context, name string
 	}
 	return &types.NameInfoUntrusted{
 		ID:            chat1.TLFID(kid.ToBytes()),
-		CanonicalName: name,
+		CanonicalName: teamName.String(),
 	}, nil
 }
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2032,7 +2032,7 @@ func TeamNameFromString(s string) (TeamName, error) {
 func (t TeamName) String() string {
 	tmp := make([]string, len(t.Parts))
 	for i, p := range t.Parts {
-		tmp[i] = string(p)
+		tmp[i] = strings.ToLower(string(p))
 	}
 	return strings.Join(tmp, ".")
 }


### PR DESCRIPTION
ensures team names are always canonicalized to lowercase when working with them. previously an error of the form:
`▶ ERROR server conversation TLF name mismatch: blah, expected bLaH` could be thrown when performing this check: https://github.com/keybase/client/compare/joshblum/tlfname-CORE-8588?expand=1#diff-560008cd2bdd22d95d33f0194c0cf8e7R198