### PR TITLE
Fix non user tracker render

### DIFF
--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -92,6 +92,7 @@ export default function(
           name: nonUser.assertion,
           reason: `You opened ${nonUser.folderName}`,
           serviceName: nonUser.socialAssertion.service,
+          type: 'nonUser',
         }
       })
     }

--- a/shared/tracker/remote-container.desktop.js
+++ b/shared/tracker/remote-container.desktop.js
@@ -66,7 +66,7 @@ export default compose(
     {onSetSelectedTeamRect: () => selectedTeamRect => ({selectedTeamRect})}
   ),
   connect(s => s, mapDispatchToProps, mergeProps),
-  branch(props => !props.username, renderNothing),
+  branch(props => !props.nonUser && !props.username, renderNothing),
   lifecycle({
     componentDidMount() {
       this.props._onSetTeamJoinError('')


### PR DESCRIPTION
This makes the rendering work again. The close button doesn't work - we dismiss with a token for user trackers but for non users we don't store a token, so I'm not sure what we should call to close it. I made a ticket for it. r? @keybase/react-hackers 