### PR TITLE
Move RunMode out of libkb

### DIFF
--- a/go/kbconst/constants.go
+++ b/go/kbconst/constants.go
@@ -1,0 +1,16 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+type RunMode string
+
+const (
+	DevelRunMode      RunMode = "devel"
+	StagingRunMode    RunMode = "staging"
+	ProductionRunMode RunMode = "prod"
+	RunModeError      RunMode = "error"
+	NoRunMode         RunMode = ""
+)
+
+const KBFSLogFileName = "keybase.kbfs.log"

--- a/go/kbconst/constants.go
+++ b/go/kbconst/constants.go
@@ -9,9 +9,10 @@ type RunMode string
 const (
 	// DevelRunMode means use devel servers.
 	DevelRunMode RunMode = "devel"
-	// DevelRunMode means use staging servers.
+	// StagingRunMode means use staging servers.
 	StagingRunMode RunMode = "staging"
-	// DevelRunMode means use prod servers (default for released apps).
+	// ProductionRunMode means use prod servers (default for
+	// released apps).
 	ProductionRunMode RunMode = "prod"
 	// RunModeError means an error was encountered.
 	RunModeError RunMode = "error"

--- a/go/kbconst/constants.go
+++ b/go/kbconst/constants.go
@@ -3,14 +3,21 @@
 
 package libkb
 
+// RunMode is an enum type for the mode the Keybase app runs in.
 type RunMode string
 
 const (
-	DevelRunMode      RunMode = "devel"
-	StagingRunMode    RunMode = "staging"
+	// DevelRunMode means use devel servers.
+	DevelRunMode RunMode = "devel"
+	// DevelRunMode means use staging servers.
+	StagingRunMode RunMode = "staging"
+	// DevelRunMode means use prod servers (default for released apps).
 	ProductionRunMode RunMode = "prod"
-	RunModeError      RunMode = "error"
-	NoRunMode         RunMode = ""
+	// RunModeError means an error was encountered.
+	RunModeError RunMode = "error"
+	// NoRunMode is the nil value for RunMode.
+	NoRunMode RunMode = ""
 )
 
+// KBFSLogFileName is the name of the log file for KBFS.
 const KBFSLogFileName = "keybase.kbfs.log"

--- a/go/kbconst/constants.go
+++ b/go/kbconst/constants.go
@@ -1,7 +1,7 @@
-// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-package libkb
+package kbconst
 
 // RunMode is an enum type for the mode the Keybase app runs in.
 type RunMode string

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -22,8 +22,8 @@ const (
 
 var TorProxy = "localhost:9050"
 
-// TODO: Remove these aliases once everything outside of this repo
-// points to kbconst.RunMode.
+// TODO (CORE-6576): Remove these aliases once everything outside of
+// this repo points to kbconst.RunMode.
 
 type RunMode = kbconst.RunMode
 

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/keybase/client/go/kbconst"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/saltpack"
 )

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -21,6 +21,9 @@ const (
 
 var TorProxy = "localhost:9050"
 
+// TODO: Remove these aliases once everything outside of this repo
+// points to kbconst.RunMode.
+
 type RunMode = kbconst.RunMode
 
 const (

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -21,17 +21,15 @@ const (
 
 var TorProxy = "localhost:9050"
 
-type RunMode string
+type RunMode = kbconst.RunMode
 
 const (
-	DevelRunMode      RunMode = "devel"
-	StagingRunMode    RunMode = "staging"
-	ProductionRunMode RunMode = "prod"
-	RunModeError      RunMode = "error"
-	NoRunMode         RunMode = ""
+	DevelRunMode      RunMode = kbconst.DevelRunMode
+	StagingRunMode    RunMode = kbconst.StagingRunMode
+	ProductionRunMode RunMode = kbconst.ProductionRunMode
+	RunModeError      RunMode = kbconst.RunModeError
+	NoRunMode         RunMode = kbconst.NoRunMode
 )
-
-var RunModes = []RunMode{DevelRunMode, StagingRunMode, ProductionRunMode}
 
 var ServerLookup = map[RunMode]string{
 	DevelRunMode:      DevelServerURI,

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -569,7 +569,7 @@ const (
 
 const (
 	ServiceLogFileName = "keybase.service.log"
-	KBFSLogFileName    = "keybase.kbfs.log"
+	KBFSLogFileName    = kbconst.KBFSLogFileName
 	GitLogFileName     = "keybase.git.log"
 	UpdaterLogFileName = "keybase.updater.log"
 	DesktopLogFileName = "Keybase.app.log"


### PR DESCRIPTION
This is so that kbfs can remove a dependency on libkb.

Leave aliases to not break existing code.

Also move out KBFSLogFileName.