### PR TITLE
fix order of default merge

### DIFF
--- a/shared/app/global-errors/container.js
+++ b/shared/app/global-errors/container.js
@@ -35,5 +35,5 @@ const mapDispatchToProps = dispatch => ({
   },
 })
 
-const Connected = connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(GlobalError)
+const Connected = connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(GlobalError)
 export default Connected

--- a/shared/app/main.desktop.js
+++ b/shared/app/main.desktop.js
@@ -67,5 +67,5 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default hot(module)(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(Main)
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(Main)
 )

--- a/shared/app/main.native.js
+++ b/shared/app/main.native.js
@@ -66,5 +66,5 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   setRouteState: (path, partialState) => dispatch(setRouteState(path, partialState)),
 })
 
-const Connected = connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(Main)
+const Connected = connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(Main)
 export default Connected

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -360,14 +360,15 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
   hideNav: ownProps.routeSelected === loginTab,
 })
 
-const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
   navigateUp: () => dispatch(navigateUp()),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  // MUST spread ownProps as navigateUp overrides the passed in props!!
+  ...ownProps,
   hideNav: stateProps.hideNav,
   navigateUp: dispatchProps.navigateUp,
-  ...ownProps,
 })
 
 const styles = styleSheetCreate({

--- a/shared/app/push-prompt.native.js
+++ b/shared/app/push-prompt.native.js
@@ -78,7 +78,7 @@ const mapDispatchToProps = (dispatch: Container.Dispatch) => ({
 })
 
 export default Container.compose(
-  Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   Container.setDisplayName('PushPrompt'),
   Container.safeSubmitPerMount(['onRequestPermissions', 'onNoPermissions'])
 )(PushPrompt)

--- a/shared/app/rpc-stats.js
+++ b/shared/app/rpc-stats.js
@@ -216,4 +216,4 @@ const mapStateToProps = (state: TypedState) => ({
   username: state.config.username,
 })
 
-export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...s, ...d, ...o}))(RpcStats)
+export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...o, ...s, ...d}))(RpcStats)

--- a/shared/chat/conversation/header-area/container.js
+++ b/shared/chat/conversation/header-area/container.js
@@ -47,4 +47,4 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}: OwnProps) => {
   }
 }
 
-export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...s, ...d, ...o}))(HeaderArea)
+export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...o, ...s, ...d}))(HeaderArea)

--- a/shared/chat/conversation/info-panel/menu/container.js
+++ b/shared/chat/conversation/info-panel/menu/container.js
@@ -100,7 +100,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {teamname}: OwnProps) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('TeamDropdownMenu'),
   lifecycle({
     componentDidMount() {

--- a/shared/chat/conversation/input-area/container.js
+++ b/shared/chat/conversation/input-area/container.js
@@ -59,4 +59,4 @@ class InputArea extends React.PureComponent<Props> {
   }
 }
 
-export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...s, ...d, ...o}))(InputArea)
+export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...o, ...s, ...d}))(InputArea)

--- a/shared/chat/conversation/messages/set-channelname/container.js
+++ b/shared/chat/conversation/messages/set-channelname/container.js
@@ -18,4 +18,4 @@ const mapDispatchToProps = (dispatch: Dispatch, {message}) => ({
       : dispatch(createGetProfile({forceDisplay: true, ignoreCache: true, username: message.author})),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(SetChannelname)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(SetChannelname)

--- a/shared/chat/conversation/messages/set-description/container.js
+++ b/shared/chat/conversation/messages/set-description/container.js
@@ -18,4 +18,4 @@ const mapDispatchToProps = (dispatch: Dispatch, {message}) => ({
       : dispatch(createGetProfile({forceDisplay: true, ignoreCache: true, username: message.author})),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(SetDescription)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(SetDescription)

--- a/shared/chat/conversation/messages/system-git-push/container.js
+++ b/shared/chat/conversation/messages/system-git-push/container.js
@@ -15,4 +15,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
 })
 
-export default connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(Git)
+export default connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(Git)

--- a/shared/chat/conversation/messages/system-invite-accepted/container.js
+++ b/shared/chat/conversation/messages/system-invite-accepted/container.js
@@ -23,6 +23,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(
   SystemInviteAccepted
 )

--- a/shared/chat/conversation/rekey/enter-paper-key.js
+++ b/shared/chat/conversation/rekey/enter-paper-key.js
@@ -19,7 +19,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   withStateHandlers(
     {paperKey: null},
     {

--- a/shared/chat/create-channel/container.js
+++ b/shared/chat/create-channel/container.js
@@ -36,7 +36,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath}) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   withStateHandlers(
     {
       channelname: null,

--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -103,7 +103,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
 }
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   withPropsOnChange(['channels'], props => ({
     oldChannelState: props.channels.reduce((acc, c) => {
       acc[c.convID] = c.selected

--- a/shared/chat/new-team-dialog-container.js
+++ b/shared/chat/new-team-dialog-container.js
@@ -30,7 +30,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   withStateHandlers(
     {name: ''},
     {

--- a/shared/common-adapters/copy-text.js
+++ b/shared/common-adapters/copy-text.js
@@ -99,7 +99,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 const CopyText = compose(
-  connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('CopyText'),
   HOCTimers
 )(_CopyText)

--- a/shared/common-adapters/mention-container.js
+++ b/shared/common-adapters/mention-container.js
@@ -37,6 +37,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {username}: OwnProps) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('Mention')
 )(Mention)

--- a/shared/common-adapters/mention-container.js
+++ b/shared/common-adapters/mention-container.js
@@ -10,7 +10,7 @@ import {isSpecialMention} from '../constants/chat2'
 const mapStateToProps = (
   state: TypedState,
   {username}: OwnProps
-): {theme: $PropertyType<OwnProps, 'theme'>} => {
+): {|theme: $PropertyType<OwnProps, 'theme'>|} => {
   if (isSpecialMention(username)) {
     return {theme: 'highlight'}
   }

--- a/shared/common-adapters/relative-popup-hoc.desktop.js
+++ b/shared/common-adapters/relative-popup-hoc.desktop.js
@@ -305,7 +305,7 @@ const RelativePopupHoc: RelativePopupHocType<any> = PopupComponent => {
       targetRect: routeProps.get('targetRect'),
       position: routeProps.get('position'),
     }),
-    (s, d, o) => ({...s, ...d, ...o})
+    (s, d, o) => ({...o, ...s, ...d})
   )((props: Props<any> & {onClosePopup: () => void}) => {
     // $FlowIssue
     return <ModalPopupComponent {...(props: Props<any>)} onClosePopup={props.onClosePopup} />

--- a/shared/common-adapters/relative-popup-hoc.native.js
+++ b/shared/common-adapters/relative-popup-hoc.native.js
@@ -15,7 +15,7 @@ const RelativePopupHoc: RelativePopupHocType<any> = PopupComponent => {
       position: routeProps.get('position'),
       targetRect: routeProps.get('targetRect'),
     }),
-    (s, d, o) => ({...s, ...d, ...o})
+    (s, d, o) => ({...o, ...s, ...d})
   )((props: Props<any> & {onClosePopup: () => void}) => {
     // $FlowIssue
     return <PopupComponent {...(props: Props<any>)} onClosePopup={props.onClosePopup} />

--- a/shared/common-adapters/waiting-button.js
+++ b/shared/common-adapters/waiting-button.js
@@ -51,7 +51,7 @@ const mapStateToProps = (state: TypedState, ownProps) => {
   }
 }
 
-const ConnectedWaitingButton = connect(mapStateToProps, () => ({}), (s, d, o) => ({...s, ...d, ...o}))(
+const ConnectedWaitingButton = connect(mapStateToProps, () => ({}), (s, d, o) => ({...o, ...s, ...d}))(
   setDisplayName('WaitingButton')(WaitingButton)
 )
 export default ConnectedWaitingButton

--- a/shared/dev/dev-menu.desktop.js
+++ b/shared/dev/dev-menu.desktop.js
@@ -28,4 +28,4 @@ function DevMenu(props) {
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   onBack: () => dispatch(navigateUp()),
 })
-export default connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(DevMenu)
+export default connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(DevMenu)

--- a/shared/dev/dev-menu.native.js
+++ b/shared/dev/dev-menu.native.js
@@ -33,5 +33,5 @@ export default connect(
     onPushDebug: () => dispatch(navigateAppend(['push'])),
     onTestPopup: () => dispatch(navigateAppend(['testPopup'])),
   }),
-  (s, d, o) => ({...s, ...d, ...o})
+  (s, d, o) => ({...o, ...s, ...d})
 )(DevMenu)

--- a/shared/folders/container.desktop.js
+++ b/shared/folders/container.desktop.js
@@ -41,7 +41,7 @@ const mapDispatchToProps = (dispatch: any, {routePath, routeState, setRouteState
 })
 
 const ConnectedFolders = compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidMount() {
       this.props.favoriteList()

--- a/shared/fs/banner/container.js
+++ b/shared/fs/banner/container.js
@@ -13,6 +13,6 @@ const mapStateToProps = (state: TypedState, {path}) => {
 }
 
 export default compose(
-  connect(mapStateToProps, () => ({}), (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, () => ({}), (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('Banner')
 )(Banner)

--- a/shared/fs/common/open-hoc.js
+++ b/shared/fs/common/open-hoc.js
@@ -14,6 +14,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {path, routePath}: OwnProps) => 
 })
 
 export default compose(
-  connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('ConnectedOpenHOC')
 )

--- a/shared/fs/common/open-in-fileui-container.desktop.js
+++ b/shared/fs/common/open-in-fileui-container.desktop.js
@@ -16,6 +16,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {path}: OwnProps) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('ConnectedOpenInFileUI')
 )(OpenInFileUI)

--- a/shared/fs/common/security-prefs-container.desktop.js
+++ b/shared/fs/common/security-prefs-container.desktop.js
@@ -20,7 +20,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidUpdate(prevProps) {
       if (this.props.appFocusedCount !== prevProps.appFocusedCount) {

--- a/shared/fs/common/security-prefs-prompting-hoc.js
+++ b/shared/fs/common/security-prefs-prompting-hoc.js
@@ -44,7 +44,7 @@ const displayOnce = ({shouldPromptSecurityPrefs, showSecurityPrefsOnce}) => {
 }
 
 const DesktopSecurityPrefsPromptingHoc = compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   branch(displayOnce, renderNothing)
 )
 

--- a/shared/fs/sortbar/container.js
+++ b/shared/fs/sortbar/container.js
@@ -21,6 +21,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {path}) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('SortBar')
 )(SortBar)

--- a/shared/git/container.js
+++ b/shared/git/container.js
@@ -57,7 +57,7 @@ const mapDispatchToProps = (dispatch: any, {navigateAppend, setRouteState, route
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidMount() {
       this.props._loadGit()

--- a/shared/git/new-repo/container.js
+++ b/shared/git/new-repo/container.js
@@ -29,7 +29,7 @@ const mapDispatchToProps = (dispatch: any, {navigateAppend, navigateUp, routePro
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidMount() {
       this.props._loadTeams()

--- a/shared/login/routes.js
+++ b/shared/login/routes.js
@@ -26,7 +26,7 @@ const _RootLogin = ({showLoading, showRelogin, navigateAppend}) => {
   return <JoinOrLogin navigateAppend={navigateAppend} />
 }
 
-const RootLogin = connect(mapStateToProps, () => ({}), (s, d, o) => ({...s, ...d, ...o}))(_RootLogin)
+const RootLogin = connect(mapStateToProps, () => ({}), (s, d, o) => ({...o, ...s, ...d}))(_RootLogin)
 
 const addTags = component => ({component, tags: makeLeafTags({underStatusBar: true})})
 

--- a/shared/login/signup/device-name/container.js
+++ b/shared/login/signup/device-name/container.js
@@ -13,4 +13,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onSubmit: (devicename: string) => dispatch(SignupGen.createCheckDevicename({devicename})),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(DeviceName)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(DeviceName)

--- a/shared/login/signup/error/container.js
+++ b/shared/login/signup/error/container.js
@@ -12,4 +12,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onRestart: () => dispatch(SignupGen.createRestartSignup()),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(Error)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(Error)

--- a/shared/login/signup/invite-code/container.js
+++ b/shared/login/signup/invite-code/container.js
@@ -15,4 +15,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onSubmit: (inviteCode: string) => dispatch(SignupGen.createCheckInviteCode({inviteCode})),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(InviteCode)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(InviteCode)

--- a/shared/login/signup/passphrase/container.js
+++ b/shared/login/signup/passphrase/container.js
@@ -16,4 +16,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       SignupGen.createCheckPassphrase({pass1: new HiddenString(pass1), pass2: new HiddenString(pass2)})
     ),
 })
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(Passphrase)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(Passphrase)

--- a/shared/login/signup/request-invite-success/container.js
+++ b/shared/login/signup/request-invite-success/container.js
@@ -8,6 +8,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onBack: () => dispatch(SignupGen.createRestartSignup()),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(
   RequestInviteSuccess
 )

--- a/shared/login/signup/request-invite/container.js
+++ b/shared/login/signup/request-invite/container.js
@@ -12,4 +12,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onBack: () => dispatch(SignupGen.createGoBackAndClearErrors()),
   onSubmit: (email: string, name: string) => dispatch(SignupGen.createRequestInvite({email, name})),
 })
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(RequestInvite)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(RequestInvite)

--- a/shared/login/signup/username-email/container.js
+++ b/shared/login/signup/username-email/container.js
@@ -16,4 +16,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(SignupGen.createCheckUsernameEmail({email, username})),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(UsernameEmail)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(UsernameEmail)

--- a/shared/offline/container.js
+++ b/shared/offline/container.js
@@ -7,4 +7,4 @@ const mapStateToProps = (state: TypedState) => ({
   reachable: state.gregor.reachability.reachable,
 })
 
-export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...s, ...d, ...o}))(Offline)
+export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...o, ...s, ...d}))(Offline)

--- a/shared/people/task/container.js
+++ b/shared/people/task/container.js
@@ -91,7 +91,7 @@ const deviceConnector = connect(
     onConfirm: () => openURL(installLinkURL),
     onDismiss: onSkipTodo('device', dispatch),
   }),
-  (s, d, o) => ({...s, ...d, ...o})
+  (s, d, o) => ({...o, ...s, ...d})
 )
 
 // ----- FOLLOW ----- //
@@ -101,7 +101,7 @@ const followConnector = connect(
     onConfirm: () => dispatch(navigateAppend(['search'], [Tabs.peopleTab])),
     onDismiss: onSkipTodo('follow', dispatch),
   }),
-  (s, d, o) => ({...s, ...d, ...o})
+  (s, d, o) => ({...o, ...s, ...d})
 )
 
 // ----- CHAT ----- //
@@ -111,7 +111,7 @@ const chatConnector = connect(
     onConfirm: () => dispatch(switchTo([Tabs.chatTab])),
     onDismiss: onSkipTodo('chat', dispatch),
   }),
-  (s, d, o) => ({...s, ...d, ...o})
+  (s, d, o) => ({...o, ...s, ...d})
 )
 
 // ----- PAPERKEY ----- //
@@ -128,7 +128,7 @@ const paperKeyConnector = connect(
     },
     onDismiss: () => {},
   }),
-  (s, d, o) => ({...s, ...d, ...o})
+  (s, d, o) => ({...o, ...s, ...d})
 )
 
 // ----- TEAM ----- //
@@ -141,7 +141,7 @@ const teamConnector = connect(
     },
     onDismiss: onSkipTodo('team', dispatch),
   }),
-  (s, d, o) => ({...s, ...d, ...o})
+  (s, d, o) => ({...o, ...s, ...d})
 )
 
 // ----- FOLDER ----- //
@@ -159,7 +159,7 @@ const folderConnector = connect(
     },
     onDismiss: onSkipTodo('folder', dispatch),
   }),
-  (s, d, o) => ({...s, ...d, ...o})
+  (s, d, o) => ({...o, ...s, ...d})
 )
 
 // ----- GITREPO ----- //
@@ -172,7 +172,7 @@ const gitRepoConnector = connect(
     },
     onDismiss: onSkipTodo('gitRepo', dispatch),
   }),
-  (s, d, o) => ({...s, ...d, ...o})
+  (s, d, o) => ({...o, ...s, ...d})
 )
 
 // ----- TEAMSHOWCASE ----- //
@@ -186,7 +186,7 @@ const teamShowcaseConnector = connect(
     },
     onDismiss: onSkipTodo('teamShowcase', dispatch),
   }),
-  (s, d, o) => ({...s, ...d, ...o})
+  (s, d, o) => ({...o, ...s, ...d})
 )
 
 export default compose(

--- a/shared/pinentry/remote-proxy.desktop.js
+++ b/shared/pinentry/remote-proxy.desktop.js
@@ -48,4 +48,4 @@ const mapStateToProps = (state: TypedState) => ({
   sessionIDToPinentry: state.pinentry.sessionIDToPinentry,
 })
 
-export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...s, ...d, ...o}))(RemotePinentrys)
+export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...o, ...s, ...d}))(RemotePinentrys)

--- a/shared/profile/edit-avatar-placeholder/container.js
+++ b/shared/profile/edit-avatar-placeholder/container.js
@@ -22,4 +22,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onAck: () => dispatch(navigateUp()),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(EditAvatar)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(EditAvatar)

--- a/shared/profile/edit-profile/container.js
+++ b/shared/profile/edit-profile/container.js
@@ -34,7 +34,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   withStateHandlers(props => ({bio: props.bio, fullname: props.fullname, location: props.location}), {
     onBioChange: () => bio => ({bio}),
     onFullnameChange: () => fullname => ({fullname}),

--- a/shared/profile/post-proof/container.js
+++ b/shared/profile/post-proof/container.js
@@ -42,7 +42,7 @@ export default compose(
   withStateHandlers(({allowProofCheck: boolean}) => ({allowProofCheck: true}), {
     onAllowProofCheck: () => (allowProofCheck: boolean) => ({allowProofCheck}),
   }),
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidMount() {
       // Activate the proof check after they've completed the first step for these services.

--- a/shared/profile/prove-website-choice/container.js
+++ b/shared/profile/prove-website-choice/container.js
@@ -13,6 +13,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(ProfileGen.createAddProof({platform: choice === 'file' ? 'https' : 'dns'})),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(
   ProveWebsiteChoice
 )

--- a/shared/profile/revoke/container.js
+++ b/shared/profile/revoke/container.js
@@ -21,4 +21,4 @@ const mapDispatchToProps = (dispatch: Dispatch, {routeProps}) => ({
   },
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(Revoke)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(Revoke)

--- a/shared/profile/search/container.js
+++ b/shared/profile/search/container.js
@@ -14,4 +14,4 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}: RouteProps<{}, {}>
   },
 })
 
-export default connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(Search)
+export default connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(Search)

--- a/shared/profile/showcased-team-info/container.js
+++ b/shared/profile/showcased-team-info/container.js
@@ -65,7 +65,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {team}: OwnProps) => {
 }
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidMount() {
       this.props._onSetTeamJoinError('')

--- a/shared/provision/error/container.js
+++ b/shared/provision/error/container.js
@@ -17,4 +17,4 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
   onPasswordReset: () => openURL('https://keybase.io/#password-reset'),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(RenderError)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(RenderError)

--- a/shared/provision/gpg-sign/container.js
+++ b/shared/provision/gpg-sign/container.js
@@ -11,4 +11,4 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
   onSubmit: exportKey => dispatch(ProvisionGen.createSubmitGPGMethod({exportKey})),
 })
 
-export default connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(GPGSign)
+export default connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(GPGSign)

--- a/shared/provision/paper-key/container.js
+++ b/shared/provision/paper-key/container.js
@@ -20,5 +20,5 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
 
 export default compose(
   withStateHandlers({paperKey: ''}, {onChangePaperKey: () => (paperKey: string) => ({paperKey})}),
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))
 )(PaperKey)

--- a/shared/provision/passphrase/container.js
+++ b/shared/provision/passphrase/container.js
@@ -73,4 +73,4 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
     dispatch(ProvisionGen.createSubmitPassphrase({passphrase: new HiddenString(passphrase)})),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(_Passphrase)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(_Passphrase)

--- a/shared/provision/username-or-email/container.js
+++ b/shared/provision/username-or-email/container.js
@@ -19,6 +19,6 @@ const dispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, dispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, dispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   safeSubmit(['onBack', 'onSubmit'], ['error'])
 )(UsernameOrEmail)

--- a/shared/search/helpers.js
+++ b/shared/search/helpers.js
@@ -41,9 +41,7 @@ const clearSearchHoc = withHandlers({
 type OwnPropsWithSearchDebounced = OwnProps & {_searchDebounced: $PropertyType<OwnProps, 'search'>}
 
 const onChangeSelectedSearchResultHoc = compose(
-  // $FlowIssue TODO fix up thie type for real
   withHandlers({
-    // $FlowIssue TODO fix up thie type for real
     onMove: ({onUpdateSelectedSearchResult, selectedSearchId, searchResultIds}: OwnProps) => (
       direction: 'up' | 'down'
     ) => {

--- a/shared/search/results-list/container.js
+++ b/shared/search/results-list/container.js
@@ -57,6 +57,6 @@ const Chooser = (props: any) =>
 
 export default compose(
   // $FlowIssue
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('ResultsList')
 )(Chooser)

--- a/shared/search/user-input/container.js
+++ b/shared/search/user-input/container.js
@@ -148,7 +148,7 @@ export type Props = _Props & {
 }
 
 const ConnectedUserInput = compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('UserInput'),
   withStateHandlers(
     {searchText: '', selectedService: 'Keybase'},

--- a/shared/settings/about-container.js
+++ b/shared/settings/about-container.js
@@ -26,7 +26,7 @@ const mapDispatchToProps = (dispatch: Container.Dispatch, {navigateUp, navigateA
 })
 
 const connectedHeaderHoc = Container.compose(
-  Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   HeaderHoc
 )(About)
 

--- a/shared/settings/advanced/container.js
+++ b/shared/settings/advanced/container.js
@@ -31,7 +31,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidMount() {
       this.props._loadLockdownMode()

--- a/shared/settings/db-nuke-confirm/container.js
+++ b/shared/settings/db-nuke-confirm/container.js
@@ -15,4 +15,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(DBNukeConfirm)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(DBNukeConfirm)

--- a/shared/settings/delete-confirm/container.js
+++ b/shared/settings/delete-confirm/container.js
@@ -41,6 +41,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   HOCTimers
 )(DeleteConfirmContainer)

--- a/shared/settings/email/container.js
+++ b/shared/settings/email/container.js
@@ -29,4 +29,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(UpdateEmail)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(UpdateEmail)

--- a/shared/settings/feedback-container.native.js
+++ b/shared/settings/feedback-container.native.js
@@ -196,7 +196,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   HeaderHoc,
   HOCTimers
 )(FeedbackContainer)

--- a/shared/settings/files/container.js
+++ b/shared/settings/files/container.js
@@ -33,7 +33,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
 }
 
 const ConnectedFiles = compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidMount() {
       this.props.getFuseStatus()

--- a/shared/settings/invites/container.js
+++ b/shared/settings/invites/container.js
@@ -26,7 +26,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidMount() {
       this.props.onRefresh()

--- a/shared/settings/notifications/container.js
+++ b/shared/settings/notifications/container.js
@@ -24,7 +24,7 @@ const mapDispatchToProps = (dispatch: any, ownProps: {}) => ({
   onToggleSound: (sound: boolean) => dispatch(ConfigGen.createSetNotifySound({sound, writeFile: true})),
 })
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidMount() {
       this.props.onRefresh()

--- a/shared/settings/notifications/turn-on-notifications.native.js
+++ b/shared/settings/notifications/turn-on-notifications.native.js
@@ -54,6 +54,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onEnable: () => dispatch(PushGen.createRequestPermissions()),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(
   TurnOnNotifications
 )

--- a/shared/settings/passphrase/container.js
+++ b/shared/settings/passphrase/container.js
@@ -30,7 +30,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   lifecycle({
     componentDidMount() {
       this.props.onUpdatePGPSettings()

--- a/shared/settings/screenprotector-container.native.js
+++ b/shared/settings/screenprotector-container.native.js
@@ -9,6 +9,6 @@ const mapDispatchToProps = (dispatch: Container.Dispatch, {navigateUp}) => ({
   onBack: () => dispatch(navigateUp()),
 })
 
-export default Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(
+export default Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(
   Screenprotector
 )

--- a/shared/settings/web-links.native.js
+++ b/shared/settings/web-links.native.js
@@ -12,7 +12,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
 })
 
 const WebLinks = compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   defaultProps({
     dataDetectorTypes: 'none',
   }),

--- a/shared/teams/add-people/container.js
+++ b/shared/teams/add-people/container.js
@@ -90,7 +90,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routePath, routePro
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   compose(
     withStateHandlers(
       {role: 'writer', sendNotification: true},

--- a/shared/teams/invite-by-email/container.desktop.js
+++ b/shared/teams/invite-by-email/container.desktop.js
@@ -39,4 +39,4 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
   },
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(InviteByEmailDesktop)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(InviteByEmailDesktop)

--- a/shared/teams/invite-by-email/container.native.js
+++ b/shared/teams/invite-by-email/container.native.js
@@ -97,7 +97,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   compose(
     // basic state setters
     withStateHandlers(

--- a/shared/teams/join-team/container.js
+++ b/shared/teams/join-team/container.js
@@ -35,7 +35,7 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}: OwnProps) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   withStateHandlers(({name}) => ({name: name || ''}), {
     onNameChange: () => (name: string) => ({name: name.toLowerCase()}),
   }),

--- a/shared/teams/really-leave-team/container-chat.js
+++ b/shared/teams/really-leave-team/container-chat.js
@@ -54,4 +54,4 @@ class Switcher extends React.PureComponent<Props> {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(Switcher)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(Switcher)

--- a/shared/teams/really-leave-team/container.js
+++ b/shared/teams/really-leave-team/container.js
@@ -29,6 +29,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   branch(props => props._lastOwner, renderComponent(LastOwnerDialog))
 )(ReallyLeaveTeam)

--- a/shared/teams/team/header/add-people-how/container.js
+++ b/shared/teams/team/header/add-people-how/container.js
@@ -35,4 +35,4 @@ const mapDispatchToProps = (dispatch: Dispatch, {teamname}: OwnProps) => {
   }
 }
 
-export default connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(AddPeopleHow)
+export default connect(() => ({}), mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(AddPeopleHow)

--- a/shared/teams/team/really-remove-member/container.js
+++ b/shared/teams/team/really-remove-member/container.js
@@ -26,6 +26,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, routeProps}) => ({
   },
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(
   ReallyLeaveTeam
 )

--- a/shared/teams/team/settings-tab/retention/container.js
+++ b/shared/teams/team/settings-tab/retention/container.js
@@ -163,7 +163,7 @@ const mapDispatchToProps = (
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('RetentionPicker'),
   withStateHandlers({_parentPath: null}, {_setParentPath: () => _parentPath => ({_parentPath})}),
   lifecycle({

--- a/shared/teams/team/settings-tab/retention/warning/container.js
+++ b/shared/teams/team/settings-tab/retention/warning/container.js
@@ -25,6 +25,6 @@ const mapDispatchToProps = (dispatch: Dispatch, {routeProps, navigateUp}) => {
 }
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   withStateHandlers({enabled: false}, {setEnabled: () => (enabled: boolean) => ({enabled})})
 )(RetentionWarning)

--- a/shared/unlock-folders/remote-container.desktop.js
+++ b/shared/unlock-folders/remote-container.desktop.js
@@ -11,4 +11,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onFinish: () => dispatch(UnlockFoldersGen.createFinish()),
   toPaperKeyInput: () => dispatch(UnlockFoldersGen.createToPaperKeyInput()),
 })
-export default connect(state => state, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(UnlockFolders)
+export default connect(state => state, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(UnlockFolders)

--- a/shared/unlock-folders/remote-proxy.desktop.js
+++ b/shared/unlock-folders/remote-proxy.desktop.js
@@ -52,4 +52,4 @@ const mapStateToProps = (state: TypedState) => ({
   show: state.unlockFolders.popupOpen,
 })
 
-export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...s, ...d, ...o}))(UnlockFolders)
+export default connect(mapStateToProps, () => ({}), (s, d, o) => ({...o, ...s, ...d}))(UnlockFolders)

--- a/shared/wallets/confirm-form/container.js
+++ b/shared/wallets/confirm-form/container.js
@@ -26,4 +26,4 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
   onSendClick: () => dispatch(WalletsGen.createSendPayment()),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(ConfirmSend)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(ConfirmSend)

--- a/shared/wallets/participants/container.js
+++ b/shared/wallets/participants/container.js
@@ -30,6 +30,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('Participants')
 )(Participants)

--- a/shared/wallets/send-form/asset-input/container.js
+++ b/shared/wallets/send-form/asset-input/container.js
@@ -17,6 +17,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('AssetInput')
 )(AssetInput)

--- a/shared/wallets/send-form/available/container.js
+++ b/shared/wallets/send-form/available/container.js
@@ -9,6 +9,6 @@ const mapStateToProps = (state: TypedState) => ({
 const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('Available')
 )(Available)

--- a/shared/wallets/send-form/container.js
+++ b/shared/wallets/send-form/container.js
@@ -8,4 +8,4 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateUp}) => ({
   onClose: () => dispatch(navigateUp()),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o}))(SendForm)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(SendForm)

--- a/shared/wallets/send-form/footer/container.js
+++ b/shared/wallets/send-form/footer/container.js
@@ -22,6 +22,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('Footer')
 )(Footer)

--- a/shared/wallets/send-form/note-and-memo/container.js
+++ b/shared/wallets/send-form/note-and-memo/container.js
@@ -25,6 +25,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...s, ...d, ...o})),
+  connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   setDisplayName('NoteAndMemo')
 )(NoteAndMemo)


### PR DESCRIPTION
@keybase/react-hackers this actually fixes the nav issue. turns out navigateUp is overridden by the default merge. i mistakenly made the default mergePros which we have to pass do 
`(s,d,o) => ({...s, ...d, ...o})`
vs the actual default
`(s,d,o) => ({...o, ...s, ...d})`

added a comment to nav since thats way too subtle