### PR TITLE
Fix clicking on exploding meta

### DIFF
--- a/shared/chat/conversation/messages/wrapper/exploding-meta/container.js
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta/container.js
@@ -39,7 +39,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => ({
   explodesAt: stateProps.explodesAt,
   exploding: stateProps.exploding,
   messageKey: stateProps.messageKey,
-  onClick: dispatchProps.onClick,
+  onClick: ownProps.onClick,
   pending: stateProps.pending,
   style: ownProps.style,
 })


### PR DESCRIPTION
Re-allows clicking on the exploding meta to open the message menu. r? @keybase/react-hackers 