### PR TITLE
Don't switch convo just because we received a new meta

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1453,7 +1453,6 @@ const changeSelectedConversation = (
 
 const _maybeAutoselectNewestConversation = (
   action:
-    | Chat2Gen.MetasReceivedPayload
     | Chat2Gen.LeaveConversationPayload
     | Chat2Gen.MetaDeletePayload
     | Chat2Gen.MessageSendPayload
@@ -2347,7 +2346,6 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
   // Sometimes change the selection
   yield Saga.safeTakeEveryPure(
     [
-      Chat2Gen.metasReceived,
       Chat2Gen.leaveConversation,
       Chat2Gen.metaDelete,
       Chat2Gen.setPendingMode,

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1453,6 +1453,7 @@ const changeSelectedConversation = (
 
 const _maybeAutoselectNewestConversation = (
   action:
+    | Chat2Gen.MetasReceivedPayload
     | Chat2Gen.LeaveConversationPayload
     | Chat2Gen.MetaDeletePayload
     | Chat2Gen.MessageSendPayload
@@ -1479,7 +1480,12 @@ const _maybeAutoselectNewestConversation = (
     }
   }
 
-  if (action.type === Chat2Gen.setPendingMode) {
+  if (action.type === Chat2Gen.metasReceived) {
+    // If we have new activity, don't switch to it unless no convo was selected
+    if (selected !== Constants.noConversationIDKey) {
+      return
+    }
+  } else if (action.type === Chat2Gen.setPendingMode) {
     if (Constants.isValidConversationIDKey(selected)) {
       return
     }
@@ -2346,6 +2352,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
   // Sometimes change the selection
   yield Saga.safeTakeEveryPure(
     [
+      Chat2Gen.metasReceived,
       Chat2Gen.leaveConversation,
       Chat2Gen.metaDelete,
       Chat2Gen.setPendingMode,


### PR DESCRIPTION
@keybase/react-hackers 

Coyne was hitting the following:

* start a new convo with someone you've already talked to

* you are now in a pendingMode convo

* receive a message from anyone

* the convo you just received a message in becomes selected instead of the pending one

This was because `metasReceived` leads to `changeSelectedConversation` in our sagas.  I can't think why this should be the case -- under which circumstance would you want a changed inbox row to select a new convo automatically?