### PR TITLE
Bail before setting reactions on exploded message

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2284,6 +2284,10 @@ const toggleMessageReaction = (action: Chat2Gen.ToggleMessageReactionPayload, st
     logger.warn(`toggleMessageReaction: no message found`)
     return
   }
+  if ((message.type === 'text' || message.type === 'attachment') && message.exploded) {
+    logger.warn(`toggleMessageReaction: message is exploded`)
+    return
+  }
   const messageID = message.id
   const clientPrev = Constants.getClientPrev(state, conversationIDKey)
   const meta = Constants.getMeta(state, conversationIDKey)


### PR DESCRIPTION
This is possible on mobile if you are on the emoji picker while the message explodes. r? @keybase/react-hackers 