### PR TITLE
Add `expectedUID` field to Kex2Provisionee, check it during handleHello

### DIFF
--- a/go/engine/device_add_test.go
+++ b/go/engine/device_add_test.go
@@ -25,7 +25,8 @@ func TestDeviceAddPUK(t *testing.T) {
 	testDeviceAdd(t, true)
 }
 
-func runDeviceAddTest(t *testing.T, wg *sync.WaitGroup, tcY *libkb.TestContext, secretY kex2.Secret) {
+func runDeviceAddTest(t *testing.T, wg *sync.WaitGroup, tcY *libkb.TestContext, secretY kex2.Secret,
+	uid keybase1.UID) {
 	defer wg.Done()
 	err := (func() error {
 		uis := libkb.UIs{
@@ -46,11 +47,8 @@ func runDeviceAddTest(t *testing.T, wg *sync.WaitGroup, tcY *libkb.TestContext, 
 			Description: &dname,
 			Type:        libkb.DeviceTypeDesktop,
 		}
-		provisionee := NewKex2Provisionee(tcY.G, device, secretY, fakeSalt())
-		if err := RunEngine2(m, provisionee); err != nil {
-			return err
-		}
-		return nil
+		provisionee := NewKex2Provisionee(tcY.G, device, secretY, uid, fakeSalt())
+		return RunEngine2(m, provisionee)
 	})()
 	require.NoError(t, err, "kex2 provisionee")
 }
@@ -78,7 +76,7 @@ func testDeviceAdd(t *testing.T, upgradePerUserKey bool) {
 
 	// start provisionee
 	wg.Add(1)
-	go runDeviceAddTest(t, &wg, &tcY, secretY)
+	go runDeviceAddTest(t, &wg, &tcY, secretY, userX.UID())
 
 	// run DeviceAdd engine on device X
 	uis := libkb.UIs{
@@ -115,7 +113,7 @@ func TestDeviceAddPhrase(t *testing.T) {
 
 	// start provisionee
 	wg.Add(1)
-	go runDeviceAddTest(t, &wg, &tcY, secretY.Secret())
+	go runDeviceAddTest(t, &wg, &tcY, secretY.Secret(), userX.UID())
 
 	// run DeviceAdd engine on device X
 	uis := libkb.UIs{
@@ -152,7 +150,7 @@ func TestDeviceAddStoredSecret(t *testing.T) {
 
 	// start provisionee
 	wg.Add(1)
-	go runDeviceAddTest(t, &wg, &tcY, secretY)
+	go runDeviceAddTest(t, &wg, &tcY, secretY, userX.UID())
 
 	testSecretUI := userX.NewSecretUI()
 

--- a/go/engine/kex2_test.go
+++ b/go/engine/kex2_test.go
@@ -73,11 +73,8 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 				Description: &dname,
 				Type:        libkb.DeviceTypeDesktop,
 			}
-			provisionee := NewKex2Provisionee(tcY.G, device, secretY, fakeSalt())
-			if err := RunEngine2(m, provisionee); err != nil {
-				return err
-			}
-			return nil
+			provisionee := NewKex2Provisionee(tcY.G, device, secretY, userX.UID(), fakeSalt())
+			return RunEngine2(m, provisionee)
 		})()
 		require.NoError(t, err, "no kex2 provisionee error")
 	}()
@@ -152,11 +149,8 @@ func provisionNewDeviceKex(tcX *libkb.TestContext, userX *FakeUser) (*libkb.Test
 				Description: &dname,
 				Type:        libkb.DeviceTypeDesktop,
 			}
-			provisionee := NewKex2Provisionee(tcY.G, device, secretY, fakeSalt())
-			if err := RunEngine2(m, provisionee); err != nil {
-				return err
-			}
-			return nil
+			provisionee := NewKex2Provisionee(tcY.G, device, secretY, userX.UID(), fakeSalt())
+			return RunEngine2(m, provisionee)
 		})()
 		require.NoError(t, err, "kex2 provisionee")
 	}()

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -200,7 +200,7 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 		m.CDebugf("Failed to get salt")
 		return err
 	}
-	provisionee := NewKex2Provisionee(m.G(), device, secret.Secret(), salt)
+	provisionee := NewKex2Provisionee(m.G(), device, secret.Secret(), e.arg.User.GetUID(), salt)
 
 	var canceler func()
 

--- a/go/ephemeral/kex2_test.go
+++ b/go/ephemeral/kex2_test.go
@@ -107,7 +107,7 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 				Description: &dname,
 				Type:        libkb.DeviceTypeDesktop,
 			}
-			provisionee := engine.NewKex2Provisionee(tcY.G, device, secretY, fakeSalt())
+			provisionee := engine.NewKex2Provisionee(tcY.G, device, secretY, userX.GetUID(), fakeSalt())
 			m := libkb.NewMetaContextForTest(tcY).WithUIs(uis).WithNewProvisionalLoginContext()
 			return engine.RunEngine2(m, provisionee)
 		})()

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -205,11 +205,8 @@ func ProvisionNewDeviceKex(tcX *libkb.TestContext, tcY *libkb.TestContext, userX
 				Description: &dname,
 				Type:        libkb.DeviceTypeDesktop,
 			}
-			provisionee := engine.NewKex2Provisionee(tcY.G, device, secretY, FakeSalt())
-			if err := engine.RunEngine2(m, provisionee); err != nil {
-				return err
-			}
-			return nil
+			provisionee := engine.NewKex2Provisionee(tcY.G, device, secretY, userX.GetUID(), FakeSalt())
+			return engine.RunEngine2(m, provisionee)
 		})()
 		require.NoError(t, err, "kex2 provisionee")
 	}()


### PR DESCRIPTION
When we are provisioning, we always know which user we want to provision as. Make use of that knowledge in Kex2Provisionee, by adding `expectedUID` field. If we get `Hello` message from UID we don't recognize, abort the process.