### PR TITLE
Fix failure to rotate bug

### DIFF
--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -339,7 +339,7 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 		return nil, err
 	}
 
-	admin, err := parentTeam.getAdminPermission(ctx, true)
+	admin, err := parentTeam.getAdminPermission(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -273,6 +273,14 @@ func NewKeyMaskNotFoundErrorForApplicationAndGeneration(a keybase1.TeamApplicati
 	return libkb.KeyMaskNotFoundError{App: a, Gen: g}
 }
 
+type AdminPermissionRequiredError struct{}
+
+func NewAdminPermissionRequiredError() error { return &AdminPermissionRequiredError{} }
+
+func (e AdminPermissionRequiredError) Error() string {
+	return "Only admins can perform this operation."
+}
+
 type ImplicitAdminCannotLeaveError struct{}
 
 func NewImplicitAdminCannotLeaveError() error { return &ImplicitAdminCannotLeaveError{} }

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -240,14 +240,12 @@ func teamGet(t *testing.T) {
 
 func createTeam(tc libkb.TestContext) string {
 	b, err := libkb.RandBytes(4)
-	if err != nil {
-		tc.T.Fatal(err)
-	}
+	require.NoError(tc.T, err)
+
 	name := hex.EncodeToString(b)
 	_, err = CreateRootTeam(context.TODO(), tc.G, name, keybase1.TeamSettings{})
-	if err != nil {
-		tc.T.Fatal(err)
-	}
+	require.NoError(tc.T, err)
+
 	return name
 }
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -32,21 +32,15 @@ func memberSetupMultiple(t *testing.T) (tc libkb.TestContext, owner, otherA, oth
 	tc = SetupTest(t, "team", 1)
 
 	otherA, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	tc.G.Logout()
 
 	otherB, err = kbtest.CreateAndSignupFakeUser("team", tc.G)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	tc.G.Logout()
 
 	owner, err = kbtest.CreateAndSignupFakeUser("team", tc.G)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	name = createTeam(tc)
 	t.Logf("Created team %q", name)
@@ -65,23 +59,20 @@ func memberSetupSubteam(t *testing.T) (tc libkb.TestContext, owner, otherA, othe
 
 	// add otherA and otherB as admins to rootName
 	_, err := AddMember(context.TODO(), tc.G, root, otherA.Username, keybase1.TeamRole_ADMIN)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	assertRole(tc, root, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, root, otherA.Username, keybase1.TeamRole_ADMIN)
 	assertRole(tc, root, otherB.Username, keybase1.TeamRole_NONE)
 
 	// create a subteam
 	rootTeamName, err := keybase1.TeamNameFromString(root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	subPart := "sub"
 	_, err = CreateSubteam(context.TODO(), tc.G, subPart, rootTeamName, keybase1.TeamRole_NONE /* addSelfAs */)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	sub = root + "." + subPart
 
 	// make sure owner, otherA, otherB are not members

--- a/go/teams/rename.go
+++ b/go/teams/rename.go
@@ -60,7 +60,7 @@ func RenameSubteam(ctx context.Context, g *libkb.GlobalContext, prevName keybase
 			return err
 		}
 
-		admin, err := parent.getAdminPermission(ctx, true)
+		admin, err := parent.getAdminPermission(ctx)
 		if err != nil {
 			return err
 		}

--- a/go/teams/rotate_test.go
+++ b/go/teams/rotate_test.go
@@ -185,12 +185,8 @@ func TestImplicitAdminAfterRotateRequest(t *testing.T) {
 	defer tc.Cleanup()
 
 	team, err := GetForTestByStringName(context.TODO(), tc.G, sub)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if team.Generation() != 1 {
-		t.Fatalf("initial subteam generation: %d, expected 1", team.Generation())
-	}
+	require.NoError(t, err)
+	require.EqualValues(t, 1, team.Generation())
 	secretBefore := team.Data.PerTeamKeySeedsUnverified[team.Generation()].Seed.ToBytes()
 
 	params := keybase1.TeamCLKRMsg{
@@ -198,22 +194,14 @@ func TestImplicitAdminAfterRotateRequest(t *testing.T) {
 		Generation:          team.Generation(),
 		ResetUsersUntrusted: nil,
 	}
-	if err := HandleRotateRequest(context.TODO(), tc.G, params); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, HandleRotateRequest(context.TODO(), tc.G, params))
 
 	after, err := GetForTestByStringName(context.TODO(), tc.G, sub)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if after.Generation() != 2 {
-		t.Fatalf("rotated subteam generation: %d, expected 2", after.Generation())
-	}
+	require.EqualValues(t, 2, after.Generation())
 	secretAfter := after.Data.PerTeamKeySeedsUnverified[after.Generation()].Seed.ToBytes()
-	if libkb.SecureByteArrayEq(secretAfter, secretBefore) {
-		t.Fatal("team secret did not change when rotated")
-	}
+	require.False(t, libkb.SecureByteArrayEq(secretAfter, secretBefore))
 
 	// make sure the roles are ok after rotate
 	assertRole(tc, root, owner.Username, keybase1.TeamRole_OWNER)
@@ -228,18 +216,12 @@ func TestImplicitAdminAfterRotateRequest(t *testing.T) {
 
 	// switch to `otherA` user
 	tc.G.Logout()
-	if err := otherA.Login(tc.G); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, otherA.Login(tc.G))
 
 	// otherA has the power to add otherB to the subteam
 	res, err := AddMember(context.TODO(), tc.G, sub, otherB.Username, keybase1.TeamRole_WRITER)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res.User.Username != otherB.Username {
-		t.Errorf("AddMember result username %q does not match arg username %q", res.User.Username, otherB.Username)
-	}
+	require.NoError(t, err)
+	require.Equal(t, res.User.Username, otherB.Username)
 	// otherB should now be a writer
 	assertRole(tc, sub, otherB.Username, keybase1.TeamRole_WRITER)
 
@@ -605,4 +587,36 @@ func TestRemoveWithoutRotation(t *testing.T) {
 	// Generation should still be one, ChangeMembership should not
 	// have posted new key.
 	require.EqualValues(t, 1, team.Generation())
+}
+
+func TestRotateAsSubteamWriter(t *testing.T) {
+	// subteam has a single writer who is not part of the parent team.
+	// scenario manifested itself in CORE-8681
+	tc, _, _, otherB, _, sub := memberSetupSubteam(t)
+	defer tc.Cleanup()
+
+	team, err := GetForTestByStringName(context.TODO(), tc.G, sub)
+	require.NoError(t, err)
+	oldGeneration := team.Generation()
+
+	res, err := AddMember(context.TODO(), tc.G, sub, otherB.Username, keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+	require.Equal(t, res.User.Username, otherB.Username)
+	// otherB should now be a writer
+	assertRole(tc, sub, otherB.Username, keybase1.TeamRole_WRITER)
+
+	tc.G.Logout()
+	require.NoError(t, otherB.Login(tc.G))
+
+	params := keybase1.TeamCLKRMsg{
+		TeamID:              team.ID,
+		Generation:          oldGeneration,
+		ResetUsersUntrusted: nil,
+	}
+	err = HandleRotateRequest(context.Background(), tc.G, params)
+	require.NoError(t, err)
+
+	teamAfter, err := GetForTestByStringName(context.Background(), tc.G, sub)
+	require.NoError(t, err)
+	require.EqualValues(t, oldGeneration+1, teamAfter.Generation())
 }

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -387,7 +387,7 @@ func (t *Team) ApplicationKeyAtGeneration(ctx context.Context,
 	return ApplicationKeyAtGeneration(t.MetaContext(ctx), t.Data, application, generation)
 }
 
-func (t *Team) Rotate(ctx context.Context) error {
+func (t *Team) Rotate(ctx context.Context) (err error) {
 
 	// initialize key manager
 	if _, err := t.SharedSecret(ctx); err != nil {
@@ -397,9 +397,11 @@ func (t *Team) Rotate(ctx context.Context) error {
 	// load an empty member set (no membership changes)
 	memSet := newMemberSet()
 
-	admin, err := t.getAdminPermission(ctx, false)
+	// Try to get the admin perms if they are available, if not, proceed anyway
+	var admin *SCTeamAdmin
+	admin, err = t.getAdminPermission(ctx)
 	if err != nil {
-		return err
+		admin = nil
 	}
 
 	if err := t.ForceMerkleRootUpdate(ctx); err != nil {
@@ -607,8 +609,9 @@ func (t *Team) Leave(ctx context.Context, permanent bool) error {
 		role = keybase1.TeamRole_NONE
 	}
 	if role == keybase1.TeamRole_NONE {
-		_, err := t.getAdminPermission(ctx, false)
-		if err == nil {
+		_, err := t.getAdminPermission(ctx)
+		switch err.(type) {
+		case nil, AdminPermissionRequiredError:
 			return NewImplicitAdminCannotLeaveError()
 		}
 	}
@@ -695,7 +698,7 @@ func (t *Team) deleteSubteam(ctx context.Context, ui keybase1.TeamsUiInterface) 
 		return err
 	}
 
-	admin, err := parentTeam.getAdminPermission(ctx, true)
+	admin, err := parentTeam.getAdminPermission(ctx)
 	if err != nil {
 		return err
 	}
@@ -1021,7 +1024,7 @@ func (t *Team) postInvite(ctx context.Context, invite SCTeamInvite, role keybase
 }
 
 func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error {
-	admin, err := t.getAdminPermission(ctx, true)
+	admin, err := t.getAdminPermission(ctx)
 	if err != nil {
 		return err
 	}
@@ -1073,6 +1076,9 @@ func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error
 	return nil
 }
 
+// NOTE since this function uses `Load` and not `load2`, readSubteamID cannot
+// be passed through, this call will fail if a user is not a member of the
+// parent team (or child of the parent team) for which the validator validates
 func (t *Team) traverseUpUntil(ctx context.Context, validator func(t *Team) bool) (targetTeam *Team, err error) {
 	targetTeam = t
 	for {
@@ -1096,7 +1102,7 @@ func (t *Team) traverseUpUntil(ctx context.Context, validator func(t *Team) bool
 	}
 }
 
-func (t *Team) getAdminPermission(ctx context.Context, required bool) (admin *SCTeamAdmin, err error) {
+func (t *Team) getAdminPermission(ctx context.Context) (admin *SCTeamAdmin, err error) {
 	uv, err := t.currentUserUV(ctx)
 	if err != nil {
 		return nil, err
@@ -1109,10 +1115,7 @@ func (t *Team) getAdminPermission(ctx context.Context, required bool) (admin *SC
 		return nil, err
 	}
 	if targetTeam == nil {
-		if required {
-			err = errors.New("Only admins can perform this operation.")
-		}
-		return nil, err
+		return nil, NewAdminPermissionRequiredError()
 	}
 
 	logPoint := targetTeam.chain().GetAdminUserLogPoint(uv)
@@ -1130,7 +1133,7 @@ func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamCha
 		return SCTeamSection{}, nil, nil, nil, nil, err
 	}
 
-	admin, err := t.getAdminPermission(ctx, true)
+	admin, err := t.getAdminPermission(ctx)
 	if err != nil {
 		return SCTeamSection{}, nil, nil, nil, nil, err
 	}
@@ -1610,7 +1613,7 @@ func (t *Team) PostTeamSettings(ctx context.Context, settings keybase1.TeamSetti
 		return err
 	}
 
-	admin, err := t.getAdminPermission(ctx, true)
+	admin, err := t.getAdminPermission(ctx)
 	if err != nil {
 		return err
 	}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -401,6 +401,7 @@ func (t *Team) Rotate(ctx context.Context) (err error) {
 	var admin *SCTeamAdmin
 	admin, err = t.getAdminPermission(ctx)
 	if err != nil {
+		t.G().Log.CDebugf(ctx, "Rotate: unable to get admin permission: %v, attempting without admin section", err)
 		admin = nil
 	}
 

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -625,7 +625,7 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 	}
 
 	// Get admin permission, we will use the same one for all sigs.
-	admin, err := team.getAdminPermission(mctx.Ctx(), true)
+	admin, err := team.getAdminPermission(mctx.Ctx())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes a bug where a writer of a subteam was unable to perform a rotate when they were not a member of the parent team. We fix this by making the `Admin` section `nil` if we cannot get the permission. This section is required for implicit admin to rotate so it cannot be removed completely.