### PR TITLE
High skips for all user chains on the client

### DIFF
--- a/go/engine/cryptocurrency.go
+++ b/go/engine/cryptocurrency.go
@@ -109,6 +109,7 @@ func (e *CryptocurrencyEngine) Run(m libkb.MetaContext) (err error) {
 	}
 
 	sig, _, _, err := libkb.MakeSig(
+		m,
 		sigKey,
 		libkb.LinkTypeCryptocurrency,
 		sigInner,

--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -196,6 +196,7 @@ func (p *Prove) generateProof(m libkb.MetaContext) (err error) {
 	}
 
 	p.sig, p.sigID, _, err = libkb.MakeSig(
+		m,
 		p.signingKey,
 		libkb.LinkTypeWebServiceBinding,
 		p.sigInner,

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -155,7 +155,7 @@ func testRevokePaperDevice(t *testing.T, upgradePerUserKey bool) {
 		nextSeqno = 5
 		postedSeqno = 3
 	}
-	nextExpected, err := user.GetExpectedNextHighSkip()
+	nextExpected, err := user.GetExpectedNextHighSkip(libkb.NewMetaContextForTest(tc))
 	require.NoError(t, err)
 	require.Equal(t, nextExpected.Seqno, keybase1.Seqno(nextSeqno))
 	assertPostedHighSkipSeqno(t, tc, user.GetName(), postedSeqno)

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -141,6 +141,24 @@ func testRevokePaperDevice(t *testing.T, upgradePerUserKey bool) {
 	} else {
 		checkPerUserKeyring(t, tc.G, 0)
 	}
+
+	arg := libkb.NewLoadUserByNameArg(tc.G, u.Username)
+	user, err := libkb.LoadUser(arg)
+	require.NoError(t, err)
+
+	var nextSeqno int
+	var postedSeqno int
+	if upgradePerUserKey {
+		nextSeqno = 7
+		postedSeqno = 4
+	} else {
+		nextSeqno = 5
+		postedSeqno = 3
+	}
+	nextExpected, err := user.GetExpectedNextHighSkip()
+	require.NoError(t, err)
+	require.Equal(t, nextExpected.Seqno, keybase1.Seqno(nextSeqno))
+	assertPostedHighSkipSeqno(t, tc, user.GetName(), postedSeqno)
 }
 
 func TestRevokerPaperDeviceTwice(t *testing.T) {

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -226,6 +226,7 @@ func (e *TrackToken) storeRemoteTrack(m libkb.MetaContext, pubKID keybase1.KID) 
 
 	sigVersion := libkb.SigVersion(*e.arg.Options.SigVersion)
 	sig, sigID, linkID, err := libkb.MakeSig(
+		m,
 		signingKey,
 		libkb.LinkTypeTrack,
 		e.trackStatementBytes,
@@ -264,7 +265,7 @@ func (e *TrackToken) storeRemoteTrack(m libkb.MetaContext, pubKID keybase1.KID) 
 		return err
 	}
 
-	me.SigChainBump(linkID, sigID)
+	me.SigChainBump(linkID, sigID, false)
 
 	return err
 }

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -205,6 +205,7 @@ func (e *UntrackEngine) storeRemoteUntrack(m libkb.MetaContext, them *libkb.User
 
 	sigVersion := libkb.SigVersion(e.arg.SigVersion)
 	sig, sigID, _, err := libkb.MakeSig(
+		m,
 		signingKey,
 		libkb.LinkTypeUntrack,
 		e.untrackStatementBytes,

--- a/go/engine/user_test.go
+++ b/go/engine/user_test.go
@@ -115,3 +115,46 @@ func TestMerkleHashMetaAndFirstAppearedInKeyFamily(t *testing.T) {
 		checkSubkey(subkey.GetKID())
 	}
 }
+
+func assertPostedHighSkipSeqno(t *testing.T, tc libkb.TestContext, name string, seqno int) {
+	u, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(tc.G, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	highSkip := u.GetLastLink().GetHighSkip()
+	require.Equal(t, highSkip.Seqno, keybase1.Seqno(seqno))
+}
+
+func TestBlankUserHighSkip(t *testing.T) {
+	tc := SetupEngineTest(t, "user")
+	defer tc.Cleanup()
+
+	i := CreateAndSignupFakeUser(tc, "login")
+
+	assertPostedHighSkipSeqno(t, tc, i.Username, 1)
+}
+
+func TestPaperUserHighSkip(t *testing.T) {
+	tc := SetupEngineTest(t, "user")
+	defer tc.Cleanup()
+	them, _ := createFakeUserWithNoKeys(tc)
+
+	i := CreateAndSignupFakeUserPaper(tc, "login")
+	assertPostedHighSkipSeqno(t, tc, i.Username, 4)
+
+	trackUser(tc, i, libkb.NewNormalizedUsername(them), libkb.GetDefaultSigVersion(tc.G))
+	assertPostedHighSkipSeqno(t, tc, i.Username, 4)
+
+	eng := NewPaperKey(tc.G)
+	uis := libkb.UIs{
+		LogUI:    tc.G.UI.GetLogUI(),
+		LoginUI:  &libkb.TestLoginUI{},
+		SecretUI: &libkb.TestSecretUI{},
+	}
+	m := NewMetaContextForTest(tc).WithUIs(uis)
+	if err := RunEngine2(m, eng); err != nil {
+		t.Fatal(err)
+	}
+	assertPostedHighSkipSeqno(t, tc, i.Username, 7)
+}

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -93,6 +93,7 @@ func (l LinkID) Eq(i2 LinkID) bool {
 type ChainLinkUnpacked struct {
 	prev                               LinkID
 	seqno                              keybase1.Seqno
+	highSkip                           *HighSkip
 	seqType                            keybase1.SeqType
 	ignoreIfUnsupported                SigIgnoreIfUnsupported
 	payloadLocal                       []byte // local track payloads
@@ -226,6 +227,7 @@ type ChainLink struct {
 	unsigned         bool
 	dirty            bool
 	revocationsCache *[]keybase1.SigID
+	computedHighSkip *HighSkip
 
 	unpacked *ChainLinkUnpacked
 	cki      *ComputedKeyInfos
@@ -280,6 +282,10 @@ func (c *ChainLink) getIgnoreIfUnsupportedFromPayload() SigIgnoreIfUnsupported {
 
 func (c *ChainLink) GetIgnoreIfSupported() SigIgnoreIfUnsupported {
 	return c.getIgnoreIfUnsupportedFromPayload()
+}
+
+func (c *ChainLink) getHighSkipFromPayload() *HighSkip {
+	return c.unpacked.highSkip
 }
 
 func (c *ChainLink) IsStubbed() bool {
@@ -490,6 +496,52 @@ func (c *ChainLink) checkAgainstMerkleTree(t *MerkleTriple) (found bool, err err
 	return
 }
 
+func (tmp *ChainLinkUnpacked) parseHighSkipFromPayload(payload []byte) (*HighSkip, error) {
+	hs, dataType, _, err := jsonparser.Get(payload, "high_skip")
+	// high_skip is optional, but must be an object if it exists
+	if err != nil {
+		if err == jsonparser.KeyPathNotFoundError {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if dataType != jsonparser.Object {
+		return nil, ChainLinkError{fmt.Sprintf("When provided, expected high_skip to be a JSON object, was %v.", dataType)}
+	}
+
+	highSkipSeqnoInt, err := jsonparser.GetInt(hs, "seqno")
+	if err != nil {
+		return nil, err
+	}
+
+	// highSkipHash can either be null (zero-value of a LinkID) or a hexstring.
+	// We call GetString first instead of Get so we only parse the value
+	// twice for the first link.
+	highSkipHashStr, err := jsonparser.GetString(hs, "hash")
+	var highSkipHash LinkID
+	if err != nil {
+		// If there was an error parsing as a string, make sure the value is null.
+		_, dataType, _, getErr := jsonparser.Get(hs, "hash")
+		if getErr != nil {
+			return nil, getErr
+		}
+		if dataType != jsonparser.Null {
+			return nil, ChainLinkError{
+				fmt.Sprintf("high_skip.hash was neither a valid string (%v) nor null.", err.Error()),
+			}
+		}
+	} else {
+		highSkipHash, err = LinkIDFromHex(highSkipHashStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	highSkip := NewHighSkip(keybase1.Seqno(highSkipSeqnoInt), highSkipHash)
+	return &highSkip, nil
+}
+
 func (tmp *ChainLinkUnpacked) unpackPayloadJSON(g *GlobalContext, payload []byte) error {
 	if s, err := jsonparser.GetString(payload, "body", "key", "fingerprint"); err == nil {
 		if tmp.pgpFingerprint, err = PGPFingerprintFromHex(s); err != nil {
@@ -523,6 +575,12 @@ func (tmp *ChainLinkUnpacked) unpackPayloadJSON(g *GlobalContext, payload []byte
 			return err
 		}
 	}
+
+	highSkip, err := tmp.parseHighSkipFromPayload(payload)
+	if err != nil {
+		return err
+	}
+	tmp.highSkip = highSkip
 
 	tmp.typ, err = jsonparser.GetString(payload, "body", "type")
 	if err != nil {
@@ -638,11 +696,22 @@ func (c *ChainLink) unpackStubbed(raw string) error {
 	}
 
 	c.id = ol.LinkID()
+
+	// Because the outer link does not have a highSkip parent object, we check
+	// for the nullity of highSkipSeqno to see if highSkip should be set, since
+	// a null highSkipHash is valid when specifying highSkip=0.
+	var highSkipPtr *HighSkip
+	if ol.HighSkipSeqno != nil {
+		highSkip := NewHighSkip(*ol.HighSkipSeqno, *ol.HighSkipHash)
+		highSkipPtr = &highSkip
+	}
+
 	c.unpacked = &ChainLinkUnpacked{
 		prev:                ol.Prev,
 		seqno:               ol.Seqno,
 		seqType:             ol.SeqType,
 		ignoreIfUnsupported: ol.IgnoreIfUnsupported,
+		highSkip:            highSkipPtr,
 		sigVersion:          ol.Version,
 		outerLinkV2:         ol,
 		stubbed:             true,
@@ -973,13 +1042,14 @@ func (c *ChainLink) verifyPayloadV2() error {
 	prev := c.getPrevFromPayload()
 	curr := c.getPayloadHash()
 	ignoreIfUnsupported := c.getIgnoreIfUnsupportedFromPayload()
-	linkType, err := c.GetSigchainV2Type(SigIgnoreIfUnsupported(ignoreIfUnsupported))
+	linkType, err := c.GetSigchainV2TypeFromInner(SigIgnoreIfUnsupported(ignoreIfUnsupported))
 	if err != nil {
 		return err
 	}
 	seqType := c.getSeqTypeFromPayload()
+	highSkip := c.getHighSkipFromPayload()
 
-	if err := ol.AssertFields(version, seqno, prev, curr, linkType, seqType, ignoreIfUnsupported); err != nil {
+	if err := ol.AssertFields(version, seqno, prev, curr, linkType, seqType, ignoreIfUnsupported, highSkip); err != nil {
 		return err
 	}
 
@@ -1016,6 +1086,10 @@ func (c *ChainLink) getSeqnoFromPayload() keybase1.Seqno {
 
 func (c *ChainLink) GetSeqno() keybase1.Seqno {
 	return c.unpacked.seqno
+}
+
+func (c *ChainLink) GetHighSkip() *HighSkip {
+	return c.unpacked.highSkip
 }
 
 func (c *ChainLink) GetSigID() keybase1.SigID {
@@ -1164,7 +1238,7 @@ func (c *ChainLink) verifyLinkV2() error {
 	return c.verifyPayloadV2()
 }
 
-func (c *ChainLink) GetSigchainV2Type(ignoreIfUnsupported SigIgnoreIfUnsupported) (SigchainV2Type, error) {
+func (c *ChainLink) GetSigchainV2TypeFromInner(ignoreIfUnsupported SigIgnoreIfUnsupported) (SigchainV2Type, error) {
 	if c.unpacked == nil || c.unpacked.typ == "" {
 		return SigchainV2TypeNone, errors.New("chain link not unpacked")
 	}
@@ -1179,6 +1253,22 @@ func (c *ChainLink) GetSigchainV2TypeFromV2Shell() (SigchainV2Type, error) {
 		return SigchainV2TypeNone, errors.New("GetSigchainV2TypeFromV2Shell: chain link has no v2 shell")
 	}
 	return c.unpacked.outerLinkV2.LinkType, nil
+}
+
+// GetSigchainV2Type is a helper function for getting a ChainLink's type. If it
+// is a v2 link (that may or may not be stubbed), return the type from the
+// outer link, otherwise from the inner link.
+func (c *ChainLink) GetSigchainV2Type() (SigchainV2Type, error) {
+	if c.unpacked == nil {
+		return SigchainV2TypeNone, errors.New("chain link is not unpacked")
+	}
+	if c.unpacked.outerLinkV2 == nil && c.unpacked.typ == "" {
+		return SigchainV2TypeNone, errors.New("chain inner link type is not unpacked, and has no v2 shell")
+	}
+	if c.unpacked.outerLinkV2 != nil {
+		return c.GetSigchainV2TypeFromV2Shell()
+	}
+	return c.GetSigchainV2TypeFromInner(c.GetIgnoreIfSupported())
 }
 
 func (c *ChainLink) checkServerSignatureMetadata(ckf ComputedKeyFamily) (ret keybase1.KID, err error) {
@@ -1350,4 +1440,50 @@ func (c ChainLink) AllowStubbing() bool {
 		return false
 	}
 	return c.unpacked.outerLinkV2.LinkType.AllowStubbing()
+}
+
+// IsHighUserLink determines whether a chainlink counts as "high" in a user's chain,
+// which is defined as an Eldest link, a link with seqno=1, a link that is Sibkey,
+// PGPUpdate, Revoke, or any link that is revoking.
+func (c ChainLink) IsHighUserLink() (bool, error) {
+	v2Type, err := c.GetSigchainV2Type()
+	if err != nil {
+		return false, err
+	}
+
+	hardcodedEldest := false
+	if c.GetSeqno() > 1 {
+		prevLink := c.parent.GetLinkFromSeqno(c.GetSeqno() - 1)
+		if prevLink == nil {
+			return false, ChainLinkWrongSeqnoError{}
+		}
+		hardcodedEldest = isSubchainStart(&c, prevLink)
+	}
+
+	isFirstLink := v2Type == SigchainV2TypeEldest || c.GetSeqno() == 1 || hardcodedEldest
+	isNewHighLink := isFirstLink ||
+		v2Type == SigchainV2TypeRevoke ||
+		v2Type == SigchainV2TypeWebServiceBindingWithRevoke ||
+		v2Type == SigchainV2TypeCryptocurrencyWithRevoke ||
+		v2Type == SigchainV2TypeSibkey ||
+		v2Type == SigchainV2TypePGPUpdate
+	return isNewHighLink, nil
+}
+
+// ExpectedNextHighSkip returns the expected highSkip of the immediately
+// subsequent link in the chain (which may not exist yet). This function can
+// only be called after VerifyChain has processed the chainLink, and set
+// c.computedHighSkip.
+func (c ChainLink) ExpectedNextHighSkip() (HighSkip, error) {
+	isHigh, err := c.IsHighUserLink()
+	if err != nil {
+		return HighSkip{}, err
+	}
+	if isHigh {
+		return NewHighSkip(c.GetSeqno(), c.id), nil
+	}
+	if c.computedHighSkip == nil {
+		return HighSkip{}, NewUserReverifyNeededError("Expected to have already computed this link's HighSkip, but it was not computed.")
+	}
+	return *c.computedHighSkip, nil
 }

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -216,8 +216,14 @@ func (d *Delegator) SignAndPost(m MetaContext, jw *jsonw.Wrapper) (err error) {
 	return nil
 }
 
+func (d *Delegator) isHighDelegator() bool {
+	return d.DelegationType == DelegationTypeEldest ||
+		d.DelegationType == DelegationTypeSibkey ||
+		d.DelegationType == DelegationTypePGPUpdate
+}
+
 func (d *Delegator) updateLocalState(linkid LinkID) (err error) {
-	d.Me.SigChainBump(linkid, d.sigID)
+	d.Me.SigChainBump(linkid, d.sigID, d.isHighDelegator())
 	d.merkleTriple = MerkleTriple{LinkID: linkid, SigID: d.sigID}
 	return d.Me.localDelegateKey(d.NewKey, d.sigID, d.getExistingKID(), d.IsSibkeyOrEldest(), d.IsEldest(), d.getMerkleHashMeta(), keybase1.Seqno(0))
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -180,6 +180,7 @@ type TestParameters struct {
 	RuntimeDir               string
 	DisableUpgradePerUserKey bool
 	DisableAutoWallet        bool
+	EnvironmentFeatureFlags  FeatureFlags
 
 	// set to true to use production run mode in tests
 	UseProductionRunMode bool
@@ -1048,6 +1049,9 @@ func (e *Env) GetFeatureFlags() FeatureFlags {
 		if ret.Empty() && err == nil {
 			ret = f
 		}
+	}
+	if e.Test.EnvironmentFeatureFlags != nil {
+		pick(e.Test.EnvironmentFeatureFlags, nil)
 	}
 	pick(e.cmd.GetFeatureFlags())
 	pick(StringToFeatureFlags(os.Getenv("KEYBASE_FEATURES")), nil)

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1385,6 +1385,26 @@ func NewChainLinkWrongSeqnoError(s string) error {
 
 //=============================================================================
 
+type ChainLinkHighSkipHashMismatchError struct {
+	Msg string
+}
+
+func (e ChainLinkHighSkipHashMismatchError) Error() string {
+	return fmt.Sprintf("Chain link HighSkipHash mismatch error: %s", e.Msg)
+}
+
+//=============================================================================
+
+type ChainLinkWrongHighSkipSeqnoError struct {
+	Msg string
+}
+
+func (e ChainLinkWrongHighSkipSeqnoError) Error() string {
+	return fmt.Sprintf("Chain link wrong HighSkipSeqno error: %s", e.Msg)
+}
+
+//=============================================================================
+
 type CtimeMismatchError struct {
 	Msg string
 }
@@ -2484,3 +2504,17 @@ func (f FeatureFlagError) Error() string {
 }
 
 var _ error = FeatureFlagError{}
+
+//=============================================================================
+
+type UserReverifyNeededError struct {
+	msg string
+}
+
+func NewUserReverifyNeededError(s string) error {
+	return UserReverifyNeededError{s}
+}
+
+func (e UserReverifyNeededError) Error() string {
+	return fmt.Sprintf("User green link error: %s", e.msg)
+}

--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -9,6 +9,10 @@ import (
 type Feature string
 type FeatureFlags []Feature
 
+const (
+	EnvironmentFeatureAllowHighSkips = Feature("env_allow_high_skips")
+)
+
 // StringToFeatureFlags returns a set of feature flags
 func StringToFeatureFlags(s string) (ret FeatureFlags) {
 	s = strings.TrimSpace(s)
@@ -26,6 +30,15 @@ func StringToFeatureFlags(s string) (ret FeatureFlags) {
 func (set FeatureFlags) Admin() bool {
 	for _, f := range set {
 		if f == Feature("admin") {
+			return true
+		}
+	}
+	return false
+}
+
+func (set FeatureFlags) HasFeature(feature Feature) bool {
+	for _, f := range set {
+		if f == feature {
 			return true
 		}
 	}

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -365,7 +365,7 @@ func (arg ProofMetadata) ToJSON(m MetaContext) (ret *jsonw.Wrapper, err error) {
 		if (arg.Me != nil) && (arg.HighSkipFallback != nil) {
 			return nil, fmt.Errorf("arg.Me and arg.HighSkipFallback can't both be non-nil.")
 		} else if arg.Me != nil {
-			highSkipPre, err := arg.Me.GetExpectedNextHighSkip()
+			highSkipPre, err := arg.Me.GetExpectedNextHighSkip(m)
 			if err != nil {
 				return nil, err
 			}
@@ -586,7 +586,7 @@ func MakeSig(
 	case KeybaseSignatureV2:
 		prevSeqno := me.GetSigChainLastKnownSeqno()
 		prevLinkID := me.GetSigChainLastKnownID()
-		highSkip, highSkipErr := me.GetExpectedNextHighSkip()
+		highSkip, highSkipErr := me.GetExpectedNextHighSkip(m)
 		if highSkipErr != nil {
 			return sig, sigID, linkID, highSkipErr
 		}

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -252,6 +252,32 @@ func remoteProofToTrackingStatement(s RemoteProofChainLink, base *jsonw.Wrapper)
 	return nil
 }
 
+type HighSkip struct {
+	Seqno keybase1.Seqno
+	Hash  LinkID
+}
+
+func NewHighSkip(highSkipSeqno keybase1.Seqno, highSkipHash LinkID) HighSkip {
+	return HighSkip{
+		Seqno: highSkipSeqno,
+		Hash:  highSkipHash,
+	}
+}
+
+func NewInitialHighSkip() HighSkip {
+	return NewHighSkip(keybase1.Seqno(0), nil)
+}
+
+func (h HighSkip) AssertEqualsExpected(expected HighSkip) error {
+	if expected.Seqno != h.Seqno {
+		return fmt.Errorf("Expected highSkip.Seqno %d, got %d.", expected.Seqno, h.Seqno)
+	}
+	if !expected.Hash.Eq(h.Hash) {
+		return fmt.Errorf("Expected highSkip.Hash %s, got %s.", expected.Hash.String(), h.Hash.String())
+	}
+	return nil
+}
+
 type ProofMetadata struct {
 	Me                  *User
 	SigningUser         UserBasic
@@ -267,6 +293,10 @@ type ProofMetadata struct {
 	SeqType             keybase1.SeqType
 	MerkleRoot          *MerkleRoot
 	IgnoreIfUnsupported SigIgnoreIfUnsupported
+	// HighSkipFallback is used for teams to provide team chain highSkips and
+	// for a KEX-provisisonee to provide the provisioner's information as the
+	// latest high link.
+	HighSkipFallback *HighSkip
 }
 
 func (arg ProofMetadata) merkleRootInfo(m MetaContext) (ret *jsonw.Wrapper) {
@@ -329,10 +359,36 @@ func (arg ProofMetadata) ToJSON(m MetaContext) (ret *jsonw.Wrapper, err error) {
 	ret.SetKey("seqno", jsonw.NewInt64(int64(seqno)))
 	ret.SetKey("prev", prev)
 
+	var highSkip *HighSkip
+	allowHighSkips := m.G().Env.GetFeatureFlags().HasFeature(EnvironmentFeatureAllowHighSkips)
+	if allowHighSkips {
+		if (arg.Me != nil) && (arg.HighSkipFallback != nil) {
+			return nil, fmt.Errorf("arg.Me and arg.HighSkipFallback can't both be non-nil.")
+		} else if arg.Me != nil {
+			highSkipPre, err := arg.Me.GetExpectedNextHighSkip()
+			if err != nil {
+				return nil, err
+			}
+			highSkip = &highSkipPre
+		} else if arg.HighSkipFallback != nil {
+			highSkip = arg.HighSkipFallback
+		}
+
+		if highSkip != nil {
+			highSkipObj := jsonw.NewDictionary()
+			highSkipObj.SetKey("seqno", jsonw.NewInt64(int64(highSkip.Seqno)))
+			if hash := highSkip.Hash; hash != nil {
+				highSkipObj.SetKey("hash", jsonw.NewString(hash.String()))
+			} else {
+				highSkipObj.SetKey("hash", jsonw.NewNil())
+			}
+			ret.SetKey("high_skip", highSkipObj)
+		}
+	}
+
 	if arg.IgnoreIfUnsupported {
 		ret.SetKey("ignore_if_unsupported", jsonw.NewBool(true))
 	}
-
 	eldest := arg.Eldest
 	if eldest == "" {
 		eldest = arg.Me.GetEldestKID()
@@ -430,18 +486,27 @@ func KeyProof(m MetaContext, arg Delegator) (ret *jsonw.Wrapper, err error) {
 		}
 	}
 
+	// Only set the fallback for subkeys during KEX where arg.Me == nil; it is
+	// otherwise updated using me.SigChainBump().
+	var highSkipFallback *HighSkip
+	if arg.Me == nil && arg.DelegationType == DelegationTypeSubkey {
+		highSkip := NewHighSkip(arg.Seqno-1, arg.PrevLinkID)
+		highSkipFallback = &highSkip
+	}
+
 	ret, err = ProofMetadata{
-		Me:             arg.Me,
-		SigningUser:    arg.SigningUser,
-		LinkType:       LinkType(arg.DelegationType),
-		ExpireIn:       arg.Expire,
-		SigningKey:     arg.GetSigningKey(),
-		Eldest:         arg.EldestKID,
-		CreationTime:   arg.Ctime,
-		IncludePGPHash: includePGPHash,
-		Seqno:          arg.Seqno,
-		PrevLinkID:     arg.PrevLinkID,
-		MerkleRoot:     arg.MerkleRoot,
+		Me:               arg.Me,
+		SigningUser:      arg.SigningUser,
+		LinkType:         LinkType(arg.DelegationType),
+		ExpireIn:         arg.Expire,
+		SigningKey:       arg.GetSigningKey(),
+		Eldest:           arg.EldestKID,
+		CreationTime:     arg.Ctime,
+		IncludePGPHash:   includePGPHash,
+		Seqno:            arg.Seqno,
+		HighSkipFallback: highSkipFallback,
+		PrevLinkID:       arg.PrevLinkID,
+		MerkleRoot:       arg.MerkleRoot,
 	}.ToJSON(m)
 
 	if err != nil {
@@ -505,6 +570,7 @@ func GetDefaultSigVersion(g *GlobalContext) SigVersion {
 }
 
 func MakeSig(
+	m MetaContext,
 	signingKey GenericKey,
 	v1LinkType LinkType,
 	innerLinkJSON []byte,
@@ -520,7 +586,12 @@ func MakeSig(
 	case KeybaseSignatureV2:
 		prevSeqno := me.GetSigChainLastKnownSeqno()
 		prevLinkID := me.GetSigChainLastKnownID()
+		highSkip, highSkipErr := me.GetExpectedNextHighSkip()
+		if highSkipErr != nil {
+			return sig, sigID, linkID, highSkipErr
+		}
 		sig, sigID, linkID, err = MakeSigchainV2OuterSig(
+			m,
 			signingKey,
 			v1LinkType,
 			prevSeqno+1,
@@ -529,6 +600,7 @@ func MakeSig(
 			hasRevokes,
 			seqType,
 			ignoreIfUnsupported,
+			&highSkip,
 		)
 	default:
 		err = errors.New("Invalid Signature Version")
@@ -734,7 +806,7 @@ func PerUserKeyProofReverseSigned(m MetaContext, me *User, perUserKeySeed PerUse
 	}
 
 	// Update the user locally
-	me.SigChainBump(linkID, sigID)
+	me.SigChainBump(linkID, sigID, false)
 	me.localDelegatePerUserKey(keybase1.PerUserKey{
 		Gen:         int(generation),
 		Seqno:       me.GetSigChainLastKnownSeqno(),
@@ -829,6 +901,7 @@ func StellarProofReverseSigned(m MetaContext, me *User, walletAddress stellar1.A
 		return nil, err
 	}
 	sig, sigID, linkID, err := MakeSig(
+		m,
 		signer,
 		LinkTypeWalletStellar,
 		innerJSON,
@@ -843,7 +916,7 @@ func StellarProofReverseSigned(m MetaContext, me *User, walletAddress stellar1.A
 	}
 
 	// Update the user locally
-	me.SigChainBump(linkID, sigID)
+	me.SigChainBump(linkID, sigID, false)
 	// TODO: do we need to locally do something like me.localDelegatePerUserKey?
 
 	res := make(JSONPayload)

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -56,9 +56,10 @@ type SigChain struct {
 	// If we've made local modifications to our chain, mark it here;
 	// there's a slight lag on the server and we might not get the
 	// new chain tail if we query the server right after an update.
-	localChainTail *MerkleTriple
+	localChainTail                 *MerkleTriple
+	localChainNextHighSkipOverride *HighSkip
 
-	// When the local chain was updated.
+	// When the local chains were updated.
 	localChainUpdateTime time.Time
 
 	// The sequence number of the first chain link in the current subchain. For
@@ -211,11 +212,18 @@ func (sc *SigChain) VerifiedChainLinks(fp PGPFingerprint) (ret ChainLinks) {
 	return ret
 }
 
-func (sc *SigChain) Bump(mt MerkleTriple) {
+// Bump updates the latest seqno and high skip pointers during
+// multisig posts. isHighDelegator is true iff the sig making
+// causing the bump is high (e.g., for a sibkey).
+func (sc *SigChain) Bump(mt MerkleTriple, isHighDelegator bool) {
 	mt.Seqno = sc.GetLastKnownSeqno() + 1
 	sc.G().Log.Debug("| Bumping SigChain LastKnownSeqno to %d", mt.Seqno)
 	sc.localChainTail = &mt
 	sc.localChainUpdateTime = sc.G().Clock().Now()
+	if isHighDelegator {
+		highSkip := NewHighSkip(mt.Seqno, mt.LinkID)
+		sc.localChainNextHighSkipOverride = &highSkip
+	}
 }
 
 func (sc *SigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID keybase1.UID) (dirtyTail *MerkleTriple, err error) {
@@ -322,6 +330,7 @@ func (sc *SigChain) LoadServerBody(m MetaContext, body []byte, low keybase1.Seqn
 		if sc.localChainTail != nil && sc.localChainTail.Less(*dirtyTail) {
 			m.CDebugf("| Clear cached last (%d < %d)", sc.localChainTail.Seqno, dirtyTail.Seqno)
 			sc.localChainTail = nil
+			sc.localChainNextHighSkipOverride = nil
 			sc.localCki = nil
 		}
 	}
@@ -344,12 +353,31 @@ func (sc *SigChain) getFirstSeqno() (ret keybase1.Seqno) {
 
 func (sc *SigChain) VerifyChain(m MetaContext) (err error) {
 	defer m.CTrace("SigChain#VerifyChain", func() error { return err })()
+	m.CDebugf("+ SigChain#VerifyChain()")
+	defer func() {
+		m.CDebugf("- SigChain#VerifyChain() -> %s", ErrToOk(err))
+	}()
+
+	expectedNextHighSkip := NewInitialHighSkip()
+	firstUnverifiedChainIdx := 0
+outer:
 	for i := len(sc.chainLinks) - 1; i >= 0; i-- {
 		curr := sc.chainLinks[i]
 		m.VLogf(VLog1, "| verify link %d (%s)", i, curr.id)
 		if curr.chainVerified {
-			m.CDebugf("| short-circuit at link %d", i)
-			break
+			expectedNextHighSkipPre, err := curr.ExpectedNextHighSkip()
+
+			switch err.(type) {
+			case UserReverifyNeededError:
+				m.CDebugf("Continuing verification at link %d due to uncomputed high skip.", i)
+			case nil:
+				m.CDebugf("| short-circuit at link %d", i)
+				expectedNextHighSkip = expectedNextHighSkipPre
+				firstUnverifiedChainIdx = i + 1
+				break outer
+			default:
+				return err
+			}
 		}
 		if err = curr.VerifyLink(); err != nil {
 			return err
@@ -369,6 +397,25 @@ func (sc *SigChain) VerifyChain(m MetaContext) (err error) {
 			return err
 		}
 		curr.markChainVerified()
+	}
+
+	for i := firstUnverifiedChainIdx; i < len(sc.chainLinks); i++ {
+		curr := sc.chainLinks[i]
+		curr.computedHighSkip = &expectedNextHighSkip
+
+		// If the sigchain claims an HighSkip, make sure it matches our
+		// computation.
+		if highSkip := curr.GetHighSkip(); highSkip != nil {
+			err = highSkip.AssertEqualsExpected(*curr.computedHighSkip)
+			if err != nil {
+				return err
+			}
+		}
+		expectedNextHighSkip, err = curr.ExpectedNextHighSkip()
+		if err != nil {
+			return err
+		}
+>>>>>>> add support for reading and writing user high links
 	}
 
 	return err
@@ -395,6 +442,18 @@ func (sc SigChain) GetLastKnownID() (ret LinkID) {
 		ret = sc.GetLastLoadedID()
 	}
 	return
+}
+
+// GetExpectedNextHighSkip returns the HighSkip expected for a new link to be
+// added to the chain.  It can only be called after VerifyChain is completed.
+func (sc SigChain) GetExpectedNextHighSkip() (HighSkip, error) {
+	if sc.localChainNextHighSkipOverride != nil {
+		return *sc.localChainNextHighSkipOverride, nil
+	}
+	if len(sc.chainLinks) == 0 {
+		return NewInitialHighSkip(), nil
+	}
+	return sc.GetLastLink().ExpectedNextHighSkip()
 }
 
 func (sc SigChain) GetFirstLink() *ChainLink {

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -351,11 +351,11 @@ func (sc *SigChain) getFirstSeqno() (ret keybase1.Seqno) {
 	return ret
 }
 
-func (sc *SigChain) VerifyChain(m MetaContext) (err error) {
-	defer m.CTrace("SigChain#VerifyChain", func() error { return err })()
-	m.CDebugf("+ SigChain#VerifyChain()")
+func (sc *SigChain) VerifyChain(mctx MetaContext, uid keybase1.UID) (err error) {
+	defer mctx.CTrace("SigChain#VerifyChain", func() error { return err })()
+	mctx.CDebugf("+ SigChain#VerifyChain()")
 	defer func() {
-		m.CDebugf("- SigChain#VerifyChain() -> %s", ErrToOk(err))
+		mctx.CDebugf("- SigChain#VerifyChain() -> %s", ErrToOk(err))
 	}()
 
 	expectedNextHighSkip := NewInitialHighSkip()
@@ -363,15 +363,15 @@ func (sc *SigChain) VerifyChain(m MetaContext) (err error) {
 outer:
 	for i := len(sc.chainLinks) - 1; i >= 0; i-- {
 		curr := sc.chainLinks[i]
-		m.VLogf(VLog1, "| verify link %d (%s)", i, curr.id)
+		mctx.VLogf(VLog1, "| verify link %d (%s)", i, curr.id)
 		if curr.chainVerified {
-			expectedNextHighSkipPre, err := curr.ExpectedNextHighSkip()
+			expectedNextHighSkipPre, err := curr.ExpectedNextHighSkip(mctx, uid)
 
 			switch err.(type) {
 			case UserReverifyNeededError:
-				m.CDebugf("Continuing verification at link %d due to uncomputed high skip.", i)
+				mctx.CDebugf("Continuing verification at link %d due to uncomputed high skip.", i)
 			case nil:
-				m.CDebugf("| short-circuit at link %d", i)
+				mctx.CDebugf("| short-circuit at link %d", i)
 				expectedNextHighSkip = expectedNextHighSkipPre
 				firstUnverifiedChainIdx = i + 1
 				break outer
@@ -411,11 +411,10 @@ outer:
 				return err
 			}
 		}
-		expectedNextHighSkip, err = curr.ExpectedNextHighSkip()
+		expectedNextHighSkip, err = curr.ExpectedNextHighSkip(mctx, uid)
 		if err != nil {
 			return err
 		}
->>>>>>> add support for reading and writing user high links
 	}
 
 	return err
@@ -446,14 +445,14 @@ func (sc SigChain) GetLastKnownID() (ret LinkID) {
 
 // GetExpectedNextHighSkip returns the HighSkip expected for a new link to be
 // added to the chain.  It can only be called after VerifyChain is completed.
-func (sc SigChain) GetExpectedNextHighSkip() (HighSkip, error) {
+func (sc SigChain) GetExpectedNextHighSkip(mctx MetaContext, uid keybase1.UID) (HighSkip, error) {
 	if sc.localChainNextHighSkipOverride != nil {
 		return *sc.localChainNextHighSkipOverride, nil
 	}
 	if len(sc.chainLinks) == 0 {
 		return NewInitialHighSkip(), nil
 	}
-	return sc.GetLastLink().ExpectedNextHighSkip()
+	return sc.GetLastLink().ExpectedNextHighSkip(mctx, uid)
 }
 
 func (sc SigChain) GetFirstLink() *ChainLink {
@@ -785,7 +784,7 @@ func (sc *SigChain) verifySubchain(m MetaContext, kf KeyFamily, links ChainLinks
 	return cached, cki, err
 }
 
-func (sc *SigChain) verifySigsAndComputeKeysCurrent(m MetaContext, eldest keybase1.KID, ckf *ComputedKeyFamily) (cached bool, linksConsumed int, err error) {
+func (sc *SigChain) verifySigsAndComputeKeysCurrent(m MetaContext, eldest keybase1.KID, ckf *ComputedKeyFamily, uid keybase1.UID) (cached bool, linksConsumed int, err error) {
 
 	cached = false
 	m.CDebugf("+ verifySigsAndComputeKeysCurrent for user %s (eldest = %s)", sc.uid, eldest)
@@ -793,7 +792,7 @@ func (sc *SigChain) verifySigsAndComputeKeysCurrent(m MetaContext, eldest keybas
 		m.CDebugf("- verifySigsAndComputeKeysCurrent for user %s -> %s", sc.uid, ErrToOk(err))
 	}()
 
-	if err = sc.VerifyChain(m); err != nil {
+	if err = sc.VerifyChain(m, uid); err != nil {
 		return cached, 0, err
 	}
 
@@ -868,9 +867,9 @@ func (c ChainLinks) omittingNRightmostLinks(n int) ChainLinks {
 
 // VerifySigsAndComputeKeys iterates over all potentially all incarnations of the user, trying to compute
 // multiple subchains. It returns (bool, error), where bool is true if the load hit the cache, and false otherwise.
-func (sc *SigChain) VerifySigsAndComputeKeys(m MetaContext, eldest keybase1.KID, ckf *ComputedKeyFamily) (bool, error) {
+func (sc *SigChain) VerifySigsAndComputeKeys(m MetaContext, eldest keybase1.KID, ckf *ComputedKeyFamily, uid keybase1.UID) (bool, error) {
 	// First consume the currently active sigchain.
-	cached, numLinksConsumed, err := sc.verifySigsAndComputeKeysCurrent(m, eldest, ckf)
+	cached, numLinksConsumed, err := sc.verifySigsAndComputeKeysCurrent(m, eldest, ckf, uid)
 	if err != nil || ckf.kf == nil {
 		return cached, err
 	}
@@ -1238,7 +1237,9 @@ func (l *SigChainLoader) VerifySigsAndComputeKeys() (err error) {
 	if l.ckf.kf == nil {
 		return nil
 	}
-	_, err = l.chain.VerifySigsAndComputeKeys(l.M(), l.leaf.eldest, &l.ckf)
+
+	uid := l.user.GetUID()
+	_, err = l.chain.VerifySigsAndComputeKeys(l.M(), l.leaf.eldest, &l.ckf, uid)
 	if err != nil {
 		return err
 	}
@@ -1321,7 +1322,7 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 	}
 	ret = l.chain
 	stage("VerifyChain")
-	if err = l.chain.VerifyChain(l.M()); err != nil {
+	if err = l.chain.VerifyChain(l.M(), uid); err != nil {
 		return nil, err
 	}
 	stage("CheckFreshness")
@@ -1361,7 +1362,7 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 	}
 
 	stage("VerifyChain")
-	if err = l.chain.VerifyChain(l.M()); err != nil {
+	if err = l.chain.VerifyChain(l.M(), uid); err != nil {
 		return nil, err
 	}
 

--- a/go/libkb/sig_chain_test.go
+++ b/go/libkb/sig_chain_test.go
@@ -225,7 +225,7 @@ func doChainTest(t *testing.T, tc TestContext, testCase TestCase) {
 		sigchain.chainLinks = append(sigchain.chainLinks, link)
 	}
 	if sigchainErr == nil {
-		_, sigchainErr = sigchain.VerifySigsAndComputeKeys(NewMetaContextForTest(tc), eldestKID, &ckf)
+		_, sigchainErr = sigchain.VerifySigsAndComputeKeys(NewMetaContextForTest(tc), eldestKID, &ckf, uid)
 	}
 
 	// Some tests expect an error. If we get one, make sure it's the right

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -306,6 +306,9 @@ func SetupTest(tb TestingTB, name string, depth int) (tc TestContext) {
 			break
 		}
 	}
+
+	AddEnvironmentFeatureForTest(tc, EnvironmentFeatureAllowHighSkips)
+
 	return tc
 }
 
@@ -534,4 +537,14 @@ func CreateClonedDevice(tc TestContext, m MetaContext) {
 
 	d := runAndGetDeviceCloneState()
 	require.True(tc.T, d.IsClone())
+}
+
+func ModifyFeatureForTest(m MetaContext, feature Feature, on bool, cacheSec int) {
+	slot := m.G().FeatureFlags.getOrMakeSlot(feature)
+	rawFeature := rawFeatureSlot{on, cacheSec}
+	slot.readFrom(m, rawFeature)
+}
+
+func AddEnvironmentFeatureForTest(tc TestContext, feature Feature) {
+	tc.Tp.EnvironmentFeatureFlags = append(tc.Tp.EnvironmentFeatureFlags, feature)
 }

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -148,11 +148,11 @@ func (u *User) GetCurrentEldestSeqno() keybase1.Seqno {
 	return u.sigChain().currentSubchainStart
 }
 
-func (u *User) GetExpectedNextHighSkip() (HighSkip, error) {
+func (u *User) GetExpectedNextHighSkip(mctx MetaContext) (HighSkip, error) {
 	if u.sigChain() == nil {
 		return NewInitialHighSkip(), nil
 	}
-	return u.sigChain().GetExpectedNextHighSkip()
+	return u.sigChain().GetExpectedNextHighSkip(mctx, u.GetUID())
 }
 
 func (u *User) GetLastLink() *ChainLink {

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -209,6 +209,7 @@ func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me libk
 	}
 	seqType := seqTypeForTeamPublicness(public)
 	v2Sig, _, _, err := libkb.MakeSigchainV2OuterSig(
+		libkb.NewMetaContext(ctx, g),
 		deviceSigningKey,
 		libkb.LinkTypeTeamRoot,
 		1, /* seqno */
@@ -217,6 +218,7 @@ func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me libk
 		libkb.SigHasRevokes(false),
 		seqType,
 		libkb.SigIgnoreIfUnsupported(false),
+		nil,
 	)
 	if err != nil {
 		return err
@@ -354,7 +356,7 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 	// starts a root team, and so making that link is very similar to what the
 	// CreateTeamEngine does.
 
-	newSubteamSig, err := generateNewSubteamSigForParentChain(g, me, deviceSigningKey, parentTeam.chain(), subteamName, subteamID, admin)
+	newSubteamSig, err := generateNewSubteamSigForParentChain(libkb.NewMetaContext(ctx, g), me, deviceSigningKey, parentTeam.chain(), subteamName, subteamID, admin)
 	if err != nil {
 		return nil, err
 	}
@@ -425,8 +427,8 @@ func makeRootTeamSection(teamName string, teamID keybase1.TeamID, members SCTeam
 	return teamSection, nil
 }
 
-func generateNewSubteamSigForParentChain(g *libkb.GlobalContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamName keybase1.TeamName, subteamID keybase1.TeamID, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
-	newSubteamSigBody, err := NewSubteamSig(g, me, signingKey, parentTeam, subteamName, subteamID, admin)
+func generateNewSubteamSigForParentChain(m libkb.MetaContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamName keybase1.TeamName, subteamID keybase1.TeamID, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
+	newSubteamSigBody, err := NewSubteamSig(m.G(), me, signingKey, parentTeam, subteamName, subteamID, admin)
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +442,9 @@ func generateNewSubteamSigForParentChain(g *libkb.GlobalContext, me libkb.UserFo
 		return nil, err
 	}
 	seqType := seqTypeForTeamPublicness(parentTeam.IsPublic())
+
 	v2Sig, _, _, err := libkb.MakeSigchainV2OuterSig(
+		m,
 		signingKey,
 		libkb.LinkTypeNewSubteam,
 		parentTeam.GetLatestSeqno()+1,
@@ -449,6 +453,7 @@ func generateNewSubteamSigForParentChain(g *libkb.GlobalContext, me libkb.UserFo
 		libkb.SigHasRevokes(false),
 		seqType,
 		libkb.SigIgnoreIfUnsupported(false),
+		nil,
 	)
 	if err != nil {
 		return nil, err
@@ -557,6 +562,7 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 
 	seqType := seqTypeForTeamPublicness(parentTeam.IsPublic())
 	v2Sig, _, _, err := libkb.MakeSigchainV2OuterSig(
+		libkb.NewMetaContext(ctx, g),
 		signingKey,
 		libkb.LinkTypeSubteamHead,
 		1, /* seqno */
@@ -565,6 +571,7 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 		libkb.SigHasRevokes(false),
 		seqType,
 		libkb.SigIgnoreIfUnsupported(false),
+		nil,
 	)
 	if err != nil {
 		return

--- a/go/teams/loader_types.go
+++ b/go/teams/loader_types.go
@@ -194,5 +194,6 @@ func (l *ChainLinkUnpacked) AssertInnerOuterMatch() (err error) {
 		l.innerLinkID,
 		linkType,
 		useSeqType,
-		l.inner.IgnoreIfUnsupported)
+		l.inner.IgnoreIfUnsupported,
+		nil)
 }

--- a/go/teams/rename.go
+++ b/go/teams/rename.go
@@ -75,13 +75,14 @@ func RenameSubteam(ctx context.Context, g *libkb.GlobalContext, prevName keybase
 
 		g.Log.CDebugf(ctx, "RenameSubteam make sigs")
 		renameSubteamSig, err := generateRenameSubteamSigForParentChain(
-			g, me, deviceSigningKey, parent.chain(), subteam.ID, newName, admin)
+			libkb.NewMetaContext(ctx, g), me, deviceSigningKey, parent.chain(), subteam.ID, newName, admin)
 		if err != nil {
 			return err
 		}
 
 		renameUpPointerSig, err := generateRenameUpPointerSigForSubteamChain(
-			g, me, deviceSigningKey, chainPair{parent: parent.chain(), subteam: subteam.chain()}, newName, admin)
+			libkb.NewMetaContext(ctx, g),
+			me, deviceSigningKey, chainPair{parent: parent.chain(), subteam: subteam.chain()}, newName, admin)
 		if err != nil {
 			return err
 		}
@@ -115,7 +116,7 @@ func RenameSubteam(ctx context.Context, g *libkb.GlobalContext, prevName keybase
 	})
 }
 
-func generateRenameSubteamSigForParentChain(g *libkb.GlobalContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamID keybase1.TeamID, newSubteamName keybase1.TeamName, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
+func generateRenameSubteamSigForParentChain(m libkb.MetaContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamID keybase1.TeamID, newSubteamName keybase1.TeamName, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
 
 	entropy, err := makeSCTeamEntropy()
 	if err != nil {
@@ -132,7 +133,7 @@ func generateRenameSubteamSigForParentChain(g *libkb.GlobalContext, me libkb.Use
 		Entropy: entropy,
 	}
 
-	sigBody, err := RenameSubteamSig(g, me, signingKey, parentTeam, teamSection)
+	sigBody, err := RenameSubteamSig(m.G(), me, signingKey, parentTeam, teamSection)
 	if err != nil {
 		return nil, err
 	}
@@ -147,6 +148,7 @@ func generateRenameSubteamSigForParentChain(g *libkb.GlobalContext, me libkb.Use
 	}
 	seqType := seqTypeForTeamPublicness(parentTeam.IsPublic())
 	v2Sig, _, _, err := libkb.MakeSigchainV2OuterSig(
+		m,
 		signingKey,
 		libkb.LinkTypeRenameSubteam,
 		parentTeam.GetLatestSeqno()+1,
@@ -155,6 +157,7 @@ func generateRenameSubteamSigForParentChain(g *libkb.GlobalContext, me libkb.Use
 		libkb.SigHasRevokes(false),
 		seqType,
 		libkb.SigIgnoreIfUnsupported(false),
+		nil,
 	)
 	if err != nil {
 		return nil, err
@@ -176,7 +179,7 @@ type chainPair struct {
 	subteam *TeamSigChainState
 }
 
-func generateRenameUpPointerSigForSubteamChain(g *libkb.GlobalContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, teams chainPair, newSubteamName keybase1.TeamName, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
+func generateRenameUpPointerSigForSubteamChain(m libkb.MetaContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, teams chainPair, newSubteamName keybase1.TeamName, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
 	newSubteamNameStr := newSubteamName.String()
 	teamSection := SCTeamSection{
 		Admin: admin,
@@ -189,7 +192,7 @@ func generateRenameUpPointerSigForSubteamChain(g *libkb.GlobalContext, me libkb.
 		},
 	}
 
-	sigBody, err := RenameUpPointerSig(g, me, signingKey, teams.subteam, teamSection)
+	sigBody, err := RenameUpPointerSig(m.G(), me, signingKey, teams.subteam, teamSection)
 	if err != nil {
 		return nil, err
 	}
@@ -204,6 +207,7 @@ func generateRenameUpPointerSigForSubteamChain(g *libkb.GlobalContext, me libkb.
 	}
 	seqType := seqTypeForTeamPublicness(teams.subteam.IsPublic())
 	v2Sig, _, _, err := libkb.MakeSigchainV2OuterSig(
+		m,
 		signingKey,
 		libkb.LinkTypeRenameUpPointer,
 		teams.subteam.GetLatestSeqno()+1,
@@ -212,6 +216,7 @@ func generateRenameUpPointerSigForSubteamChain(g *libkb.GlobalContext, me libkb.
 		libkb.SigHasRevokes(false),
 		seqType,
 		libkb.SigIgnoreIfUnsupported(false),
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1323,6 +1323,7 @@ func (t *Team) sigTeamItemRaw(ctx context.Context, section SCTeamSection, linkTy
 		return libkb.SigMultiItem{}, "", err
 	}
 	v2Sig, _, newLinkID, err := libkb.MakeSigchainV2OuterSig(
+		t.MetaContext(ctx),
 		deviceSigningKey,
 		linkType,
 		nextSeqno,
@@ -1331,6 +1332,7 @@ func (t *Team) sigTeamItemRaw(ctx context.Context, section SCTeamSection, linkTy
 		libkb.SigHasRevokes(false),
 		seqType,
 		libkb.SigIgnoreIfUnsupported(false),
+		nil,
 	)
 	if err != nil {
 		return libkb.SigMultiItem{}, "", err

--- a/go/tools/sigchain/main.go
+++ b/go/tools/sigchain/main.go
@@ -106,7 +106,7 @@ func main() {
 			errout(err.Error())
 		}
 
-		if err := sc.VerifyChain(m); err != nil {
+		if err := sc.VerifyChain(m, keybase1.UID(*uid)); err != nil {
 			errout(err.Error())
 		}
 


### PR DESCRIPTION
### All writing of new elements in any sigchain links in this PR is behind a feature flag

#### For team sigchains
* add a `high_skip` node to the inner section of new team chain links that get sent to the server en route to other members. this uses the high skip values that https://github.com/keybase/client/pull/13387 set on the TeamSigchainState
* also hoist those two values up into the outer section of those team chain links
* add some test assertions that, after posting team chain links to the server, those chain links have the expected high_skip seqnos.

#### For user sigchains
* the same stuff. add high_skip to the inner and outer links. 
* hide it all behind a feature flag