### PR TITLE
Correctly deselect blocked conversations

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1489,7 +1489,11 @@ const _maybeAutoselectNewestConversation = (
     action.payload.conversationIDKey === selected
   ) {
     // Intentional fall-through -- force select a new one
-  } else if (Constants.isValidConversationIDKey(selected)) {
+  } else if (
+    Constants.isValidConversationIDKey(selected) &&
+    !action.payload.findNewConversation &&
+    !action.payload.selectSomethingElse
+  ) {
     // Stay with our existing convo if it was not empty or pending
     return
   }


### PR DESCRIPTION
### Problem

Conversations: 

```
A: (most recent)
B: (2 minutes ago)
```

When attempting to block conversation `A` , `A` would be reselected and the conversation thread for `A` would remain fixed on the screen until clicking on another conversation.

```
A: (most recent)
```

If `A` is the only conversation, then after blocking the thread will remain stuck with no way to clear it.
The user will have to completely restart the Keybase GUI and service.

![screen shot 2018-08-27 at 9 53 53 am](https://user-images.githubusercontent.com/5200812/44664012-0e26ea80-a9e0-11e8-8dcd-81d2244495c5.png)

### Solution

When `metaDelete` action was coming in to the Saga, we would bail early and not auto-select the newest conversation after removal. This update prevents bailing if the action is `findNewestConversation` or `selectSomethingElse`.

