### PR TITLE
set global limit on number of parts that can be simultaneously uploaded CORE-8604

### DIFF
--- a/go/chat/attachments/s3.go
+++ b/go/chat/attachments/s3.go
@@ -8,12 +8,60 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/keybase/client/go/chat/s3"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/protocol/chat1"
 	"golang.org/x/sync/errgroup"
 )
+
+const s3PipelineMaxWidth = 25
+
+type s3UploadPipeliner struct {
+	sync.Mutex
+	width   int
+	waiters []chan struct{}
+}
+
+func (s *s3UploadPipeliner) QueueForTakeoff(ctx context.Context) error {
+	s.Lock()
+	if s.width >= s3PipelineMaxWidth {
+		ch := make(chan struct{})
+		s.waiters = append(s.waiters, ch)
+		s.Unlock()
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		s.Lock()
+		s.width++
+		s.Unlock()
+		return nil
+	}
+	s.width++
+	s.Unlock()
+	return nil
+}
+
+func (s *s3UploadPipeliner) Complete() {
+	s.Lock()
+	defer s.Unlock()
+	if len(s.waiters) > 0 {
+		close(s.waiters[0])
+		if len(s.waiters) > 1 {
+			s.waiters = s.waiters[1:]
+		} else {
+			s.waiters = nil
+		}
+		if s.width > 0 {
+			s.width--
+		}
+	}
+}
+
+var s3UploadPipeline = &s3UploadPipeliner{}
 
 const minMultiSize = 5 * 1024 * 1024 // can't use Multi API with parts less than 5MB
 const blockSize = 5 * 1024 * 1024    // 5MB is the minimum Multi part size
@@ -138,17 +186,22 @@ func (a *S3Store) putMultiPipeline(ctx context.Context, r io.Reader, size int64,
 		defer close(blockCh)
 		return a.makeBlockJobs(ectx, r, blockCh, task.stashKey(), previous)
 	})
-	for i := 0; i < 10; i++ {
-		eg.Go(func() error {
-			for b := range blockCh {
+	eg.Go(func() error {
+		for lb := range blockCh {
+			if err := s3UploadPipeline.QueueForTakeoff(ectx); err != nil {
+				return err
+			}
+			b := lb
+			eg.Go(func() error {
+				defer s3UploadPipeline.Complete()
 				if err := a.uploadPart(ectx, task, b, previous, previousParts, multi, retCh); err != nil {
 					return err
 				}
-			}
-			return nil
-		})
-	}
-
+				return nil
+			})
+		}
+		return nil
+	})
 	go func() {
 		eg.Wait()
 		close(retCh)

--- a/go/chat/attachments/s3.go
+++ b/go/chat/attachments/s3.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const s3PipelineMaxWidth = 25
+const s3PipelineMaxWidth = 10
 
 type s3UploadPipeliner struct {
 	sync.Mutex
@@ -55,9 +55,9 @@ func (s *s3UploadPipeliner) Complete() {
 		} else {
 			s.waiters = nil
 		}
-		if s.width > 0 {
-			s.width--
-		}
+	}
+	if s.width > 0 {
+		s.width--
 	}
 }
 


### PR DESCRIPTION
If a user on a connection with some kind of bottleneck on it tries to upload a ton of data, Keybase can hose that connection by attempting too many part uploads at once. This is only in play if the user uploads a lot of files at once (which skirts around the 10 wide pipeline in `S3Stores). Patch does the following:

1.) Adds a new type `s3UploadPipeliner` which is global to the `attachments` package. It keeps track of how many part uploads are in flight, and will block requests that go over the limit.
2.) Change `putMultiPipeline` to start a goroutine per block, but be limited by the global `s3UploadPipeliner`.

cc @malgorithms @maxtaco