### PR TITLE
Stellar: improve amount formatting

### DIFF
--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -562,8 +562,7 @@ func formatRequestPaymentMessage(g *libkb.GlobalContext, body chat1.MessageReque
 	}
 
 	if details.Currency != nil {
-		view = fmt.Sprintf("requested Lumens worth %s (%s)", details.AmountDescription,
-			details.AmountStellarDescription)
+		view = fmt.Sprintf("requested Lumens worth %s", details.AmountDescription)
 	} else {
 		view = fmt.Sprintf("requested %s", details.AmountDescription)
 	}

--- a/go/libkb/stellar.go
+++ b/go/libkb/stellar.go
@@ -95,7 +95,15 @@ func StellarSimplifyAmount(amount string) string {
 		return amount
 	}
 	simpleRight := strings.TrimRight(sides[1], "0")
-	if len(simpleRight) == 0 {
+	if strings.Contains(sides[0], ",") {
+		// If integer part has the thousands separator (comma), always
+		// print the fractional part with at least two digits - this
+		// is to ensure that thousands separator is not confused with
+		// decimal point.
+		for len(simpleRight) < 2 {
+			simpleRight = simpleRight + "0"
+		}
+	} else if len(simpleRight) == 0 {
 		return sides[0]
 	}
 	return sides[0] + "." + simpleRight

--- a/go/libkb/stellar_test.go
+++ b/go/libkb/stellar_test.go
@@ -26,6 +26,10 @@ func TestStellarSimplifyAmount(t *testing.T) {
 		{"1.0010000", "1.001"},
 		{"1.0000000", "1"},
 		{"aaa", "aaa"},
+		{"1,231.0010000", "1,231.001"},
+		{"1,231.5000000", "1,231.50"},
+		{"1,231.0000000", "1,231.00"},
+		{"1,231", "1,231"},
 	}
 	for i, u := range units {
 		require.Equal(t, u.b, StellarSimplifyAmount(u.a), "units[%v]", i)

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -408,20 +408,16 @@ func (o SendPaymentResLocal) DeepCopy() SendPaymentResLocal {
 }
 
 type RequestDetailsLocal struct {
-	Id                       KeybaseRequestID     `codec:"id" json:"id"`
-	FromAssertion            string               `codec:"fromAssertion" json:"fromAssertion"`
-	FromCurrentUser          bool                 `codec:"fromCurrentUser" json:"fromCurrentUser"`
-	ToUserType               ParticipantType      `codec:"toUserType" json:"toUserType"`
-	ToAssertion              string               `codec:"toAssertion" json:"toAssertion"`
-	Amount                   string               `codec:"amount" json:"amount"`
-	Asset                    *Asset               `codec:"asset,omitempty" json:"asset,omitempty"`
-	Currency                 *OutsideCurrencyCode `codec:"currency,omitempty" json:"currency,omitempty"`
-	AmountDescription        string               `codec:"amountDescription" json:"amountDescription"`
-	AmountStellar            string               `codec:"amountStellar" json:"amountStellar"`
-	AmountStellarDescription string               `codec:"amountStellarDescription" json:"amountStellarDescription"`
-	Completed                bool                 `codec:"completed" json:"completed"`
-	FundingKbTxID            KeybaseTransactionID `codec:"fundingKbTxID" json:"fundingKbTxID"`
-	Status                   RequestStatus        `codec:"status" json:"status"`
+	Id                KeybaseRequestID     `codec:"id" json:"id"`
+	FromAssertion     string               `codec:"fromAssertion" json:"fromAssertion"`
+	FromCurrentUser   bool                 `codec:"fromCurrentUser" json:"fromCurrentUser"`
+	ToUserType        ParticipantType      `codec:"toUserType" json:"toUserType"`
+	ToAssertion       string               `codec:"toAssertion" json:"toAssertion"`
+	Amount            string               `codec:"amount" json:"amount"`
+	Asset             *Asset               `codec:"asset,omitempty" json:"asset,omitempty"`
+	Currency          *OutsideCurrencyCode `codec:"currency,omitempty" json:"currency,omitempty"`
+	AmountDescription string               `codec:"amountDescription" json:"amountDescription"`
+	Status            RequestStatus        `codec:"status" json:"status"`
 }
 
 func (o RequestDetailsLocal) DeepCopy() RequestDetailsLocal {
@@ -446,12 +442,8 @@ func (o RequestDetailsLocal) DeepCopy() RequestDetailsLocal {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Currency),
-		AmountDescription:        o.AmountDescription,
-		AmountStellar:            o.AmountStellar,
-		AmountStellarDescription: o.AmountStellarDescription,
-		Completed:                o.Completed,
-		FundingKbTxID:            o.FundingKbTxID.DeepCopy(),
-		Status:                   o.Status.DeepCopy(),
+		AmountDescription: o.AmountDescription,
+		Status:            o.Status.DeepCopy(),
 	}
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -944,6 +944,7 @@ func FormatAmountWithSuffix(amount string, precisionTwo bool, suffix string) (st
 	if err != nil {
 		return "", err
 	}
+	formatted = libkb.StellarSimplifyAmount(formatted)
 	return fmt.Sprintf("%s %s", formatted, suffix), nil
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -936,15 +936,20 @@ func FormatPaymentAmountXLM(amount string, delta stellar1.BalanceDelta) (string,
 
 // Example: "157.5000000 XLM"
 func FormatAmountXLM(amount string) (string, error) {
-	return FormatAmountWithSuffix(amount, false, "XLM")
+	// Do not simplify XLM amounts, all zeroes are important because
+	// that's the exact number of digits that Stellar protocol
+	// supports.
+	return FormatAmountWithSuffix(amount, false /* precisionTwo */, false /* simplify */, "XLM")
 }
 
-func FormatAmountWithSuffix(amount string, precisionTwo bool, suffix string) (string, error) {
+func FormatAmountWithSuffix(amount string, precisionTwo bool, simplify bool, suffix string) (string, error) {
 	formatted, err := FormatAmount(amount, precisionTwo)
 	if err != nil {
 		return "", err
 	}
-	formatted = libkb.StellarSimplifyAmount(formatted)
+	if simplify {
+		formatted = libkb.StellarSimplifyAmount(formatted)
+	}
 	return fmt.Sprintf("%s %s", formatted, suffix), nil
 }
 

--- a/go/stellar/stellar_test.go
+++ b/go/stellar/stellar_test.go
@@ -45,6 +45,7 @@ var fmtTests = []fmtTest{
 	{amount: "-9123123123.1234567", precTwo: false, out: "-9,123,123,123.1234567"},
 	{amount: "-89123123123.1234567", precTwo: false, out: "-89,123,123,123.1234567"},
 	{amount: "-456456456123123123.1234567", precTwo: false, out: "-456,456,456,123,123,123.1234567"},
+	{amount: "123123", precTwo: true, out: "123,123.00"},
 	{amount: "123123", precTwo: false, out: "123,123.00"},
 }
 

--- a/go/stellar/stellar_test.go
+++ b/go/stellar/stellar_test.go
@@ -1,6 +1,10 @@
 package stellar
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 type fmtTest struct {
 	amount  string
@@ -41,17 +45,13 @@ var fmtTests = []fmtTest{
 	{amount: "-9123123123.1234567", precTwo: false, out: "-9,123,123,123.1234567"},
 	{amount: "-89123123123.1234567", precTwo: false, out: "-89,123,123,123.1234567"},
 	{amount: "-456456456123123123.1234567", precTwo: false, out: "-456,456,456,123,123,123.1234567"},
+	{amount: "123123", precTwo: false, out: "123,123.00"},
 }
 
 func TestFormatAmount(t *testing.T) {
 	for _, test := range fmtTests {
 		x, err := FormatAmount(test.amount, test.precTwo)
-		if err != nil {
-			t.Errorf("%q (2pt prec %v) => error: %s", test.amount, test.precTwo, err)
-			continue
-		}
-		if x != test.out {
-			t.Errorf("%q (2pt prec %v) => %q, expected: %q", test.amount, test.precTwo, x, test.out)
-		}
+		require.NoError(t, err, "%q (2pt prec %v) => error: %s", test.amount, test.precTwo, err)
+		require.Equal(t, test.out, x, "%q (2pt prec %v) => %q, expected: %q", test.amount, test.precTwo, x, test.out)
 	}
 }

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -1363,8 +1363,6 @@ func (s *Server) GetRequestDetailsLocal(ctx context.Context, arg stellar1.GetReq
 		Amount:          details.Amount,
 		Asset:           details.Asset,
 		Currency:        details.Currency,
-		Completed:       !details.FundingKbTxID.IsNil(),
-		FundingKbTxID:   details.FundingKbTxID,
 		Status:          details.Status,
 	}
 
@@ -1375,60 +1373,27 @@ func (s *Server) GetRequestDetailsLocal(ctx context.Context, arg stellar1.GetReq
 	}
 
 	if details.Currency != nil {
-		converToXLM := func() error {
-			rate, err := s.remoter.ExchangeRate(ctx, details.Currency.String())
-			if err != nil {
-				return err
-			}
-			amountDesc, err := stellar.FormatAmountWithSuffix(details.Amount,
-				false /* precisionTwo */, true /* simplify */, rate.Currency.String())
-			if err != nil {
-				return err
-			}
-			xlms, err := stellarnet.ConvertOutsideToXLM(res.Amount, rate.Rate)
-			if err != nil {
-				return err
-			}
-			xlmDesc, err := stellar.FormatAmountXLM(xlms)
-			if err != nil {
-				return err
-			}
-			res.AmountDescription = amountDesc
-			res.AmountStellar = xlms
-			res.AmountStellarDescription = xlmDesc
-			return nil
+		amountDesc, err := stellar.FormatCurrency(ctx, s.G(), details.Amount, *details.Currency)
+		if err != nil {
+			amountDesc = details.Amount
+			s.G().Log.CDebugf(ctx, "Error formatting external currency: %v", err)
 		}
-
-		if err := converToXLM(); err != nil {
-			s.G().Log.CDebugf(ctx, "error converting outside currency to XLM: %v", err)
-		}
+		res.AmountDescription = fmt.Sprintf("%s %s", amountDesc, *details.Currency)
 	} else if details.Asset != nil {
-		// TODO: Pass info about issuer if Asset is not XLM.
 		var code string
 		if details.Asset.IsNativeXLM() {
 			code = "XLM"
 		} else {
 			code = details.Asset.Code
 		}
-		res.AmountStellar = details.Amount
 
-		// The "nice" amount description, with zeroes trimmed from fractional
-		// part.
-		amountDesc, err := stellar.FormatAmountWithSuffix(details.Amount, false, /* precisionTwo */
-			true /* simplify */, code)
+		amountDesc, err := stellar.FormatAmountWithSuffix(details.Amount,
+			false /* precisionTwo */, true /* simplify */, code)
 		if err != nil {
-			s.G().Log.CDebugf(ctx, "Error formatting amount for AmountDescription: %v", err)
-		} else {
-			res.AmountDescription = amountDesc
+			amountDesc = fmt.Sprintf("%s %s", details.Amount, code)
+			s.G().Log.CDebugf(ctx, "Error formatting amount for asset: %v", err)
 		}
-		// Full Stellar amount description with all digits present.
-		xlmDesc, err := stellar.FormatAmountWithSuffix(details.Amount, false, /* precisionTwo */
-			false /* simplify */, code)
-		if err != nil {
-			s.G().Log.CDebugf(ctx, "Error formatting amount for AmountStellarDescription: %v", err)
-		} else {
-			res.AmountStellarDescription = xlmDesc
-		}
+		res.AmountDescription = amountDesc
 	} else {
 		return stellar1.RequestDetailsLocal{}, fmt.Errorf("malformed request - currency/asset not defined")
 	}

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -39,7 +39,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.Equal(t, accountID, accts[0].AccountID, accountID)
 	require.True(t, accts[0].IsDefault)
 	require.Equal(t, "", accts[0].Name) // TODO: once we can set the name on an account, check this
-	require.Equal(t, "10,000 XLM", accts[0].BalanceDescription)
+	require.Equal(t, "10,000.00 XLM", accts[0].BalanceDescription)
 	require.NotEmpty(t, accts[0].Seqno)
 
 	require.False(t, accts[1].IsDefault)
@@ -74,7 +74,7 @@ func TestGetAccountAssetsLocalWithBalance(t *testing.T) {
 	require.Equal(t, "XLM", assets[0].AssetCode)
 	require.Equal(t, "Stellar network", assets[0].IssuerName)
 	require.Equal(t, "", assets[0].IssuerAccountID)
-	require.Equal(t, "10,000", assets[0].BalanceTotal)
+	require.Equal(t, "10,000.00", assets[0].BalanceTotal)
 	require.Equal(t, "9,998.9999900", assets[0].BalanceAvailableToSend)
 	require.Equal(t, "USD", assets[0].WorthCurrency)
 	require.Equal(t, "$3,183.28", assets[0].Worth)

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -698,7 +698,7 @@ func TestRequestPayment(t *testing.T) {
 	reqID, err := tcs[0].Srv.MakeRequestCLILocal(context.Background(), stellar1.MakeRequestCLILocalArg{
 		Recipient: tcs[1].Fu.Username,
 		Asset:     &xlm,
-		Amount:    "10",
+		Amount:    "5.23",
 		Note:      "hello world",
 	})
 	require.NoError(t, err)
@@ -717,6 +717,36 @@ func TestRequestPayment(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, stellar1.RequestStatus_CANCELED, details.Status)
+	require.Equal(t, "5.23 XLM", details.AmountDescription)
+	require.Equal(t, "5.23 XLM", details.AmountStellarDescription)
+	require.Equal(t, "5.23", details.Amount)
+	require.Equal(t, "5.23", details.AmountStellar)
+	require.Nil(t, details.Currency)
+	require.NotNil(t, details.Asset)
+	require.Equal(t, stellar1.AssetNative(), *details.Asset)
+}
+
+func TestRequestPaymentOutsideCurrency(t *testing.T) {
+	tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+	reqID, err := tcs[0].Srv.MakeRequestCLILocal(context.Background(), stellar1.MakeRequestCLILocalArg{
+		Recipient: tcs[1].Fu.Username,
+		Currency:  &usd,
+		Amount:    "8.196",
+		Note:      "got 10 bucks (minus tax)?",
+	})
+	require.NoError(t, err)
+	details, err := tcs[0].Srv.GetRequestDetailsLocal(context.Background(), stellar1.GetRequestDetailsLocalArg{
+		ReqID: reqID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "8.196", details.Amount)
+	require.Nil(t, details.Asset)
+	require.NotNil(t, details.Currency)
+	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), *details.Currency)
+	require.Equal(t, "8.196 USD", details.AmountDescription)
+	require.Equal(t, "25.7470282", details.AmountStellar) // derived from exchange rate during GetRequestDetails
+	require.Equal(t, "25.7470282 XLM", details.AmountStellarDescription)
 }
 
 type TestContext struct {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -718,7 +718,7 @@ func TestRequestPayment(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, stellar1.RequestStatus_CANCELED, details.Status)
 	require.Equal(t, "5.23 XLM", details.AmountDescription)
-	require.Equal(t, "5.23 XLM", details.AmountStellarDescription)
+	require.Equal(t, "5.2300000 XLM", details.AmountStellarDescription)
 	require.Equal(t, "5.23", details.Amount)
 	require.Equal(t, "5.23", details.AmountStellar)
 	require.Nil(t, details.Currency)

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -717,13 +717,11 @@ func TestRequestPayment(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, stellar1.RequestStatus_CANCELED, details.Status)
-	require.Equal(t, "5.23 XLM", details.AmountDescription)
-	require.Equal(t, "5.2300000 XLM", details.AmountStellarDescription)
 	require.Equal(t, "5.23", details.Amount)
-	require.Equal(t, "5.23", details.AmountStellar)
 	require.Nil(t, details.Currency)
 	require.NotNil(t, details.Asset)
 	require.Equal(t, stellar1.AssetNative(), *details.Asset)
+	require.Equal(t, "5.23 XLM", details.AmountDescription)
 }
 
 func TestRequestPaymentOutsideCurrency(t *testing.T) {
@@ -740,13 +738,12 @@ func TestRequestPaymentOutsideCurrency(t *testing.T) {
 		ReqID: reqID,
 	})
 	require.NoError(t, err)
+	require.Equal(t, stellar1.RequestStatus_OK, details.Status)
 	require.Equal(t, "8.196", details.Amount)
 	require.Nil(t, details.Asset)
 	require.NotNil(t, details.Currency)
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), *details.Currency)
-	require.Equal(t, "8.196 USD", details.AmountDescription)
-	require.Equal(t, "25.7470282", details.AmountStellar) // derived from exchange rate during GetRequestDetails
-	require.Equal(t, "25.7470282 XLM", details.AmountStellarDescription)
+	require.Equal(t, "$8.20 USD", details.AmountDescription)
 }
 
 type TestContext struct {

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -104,10 +104,10 @@ protocol local {
     string statusDescription;       // "pending", "completed", "error"
     string statusDetail;
     boolean showCancel;             // true if cancel is an option for this payment
-    string amountDescription;       // "1,323.1234567 XLM"
+    string amountDescription;       // "1,323.1234567 XLM" - always amount of XLM, even if converted from OutsideCurrency
     BalanceDelta delta;             // NONE/INCREASE/DECREASE (e.g. INCREASE for "+ 1,323.1234567 XLM" amount above)
-    string worth;                   // "$123.23"
-    string worthCurrency;           // "USD", "CAD", etc. (the symbols can be ambiguous)
+    string worth;                   // "$123.23", amount in local currency at the time of sending, or empty if no OutsideCurrency
+    string worthCurrency;           // "USD", "CAD", etc. (the symbols can be ambiguous), or empty
 
     string source;                  // keybase username or stellar public key
     ParticipantType sourceType;     // keybase or stellar
@@ -291,23 +291,16 @@ protocol local {
     ParticipantType toUserType; // keybase or SBS
     string toAssertion; // keybase username or sbs assertion.
 
-    // Exactly one of asset or currency below is filled
+    // Raw unformatted amount and asset/currency that come with the
+    // request. Can be used directly to build a payment.
     string amount;
+    // Exactly one of asset or currency below is filled
     union { null, Asset } asset;
     union { null, OutsideCurrencyCode } currency;
 
     // Formatted amount of either outside currency or stellar lumens.
-    string amountDescription; // "123.23 CAD"
+    string amountDescription; // "$123.23 CAD"
 
-    // Amount of Stellar lumens and formatted amount of Stellar
-    // lumens. It's either same as amountDescription, or amount of
-    // stellars after converting from outside currency.
-    string amountStellar; // "123.23"
-    string amountStellarDescription; // "123.23 XLM"
-
-    // Payment ID if funded, empty if not funded.
-    boolean completed;
-    KeybaseTransactionID fundingKbTxID;
     RequestStatus status;
   }
   RequestDetailsLocal getRequestDetailsLocal(int sessionID, KeybaseRequestID reqID);

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -487,22 +487,6 @@
           "name": "amountDescription"
         },
         {
-          "type": "string",
-          "name": "amountStellar"
-        },
-        {
-          "type": "string",
-          "name": "amountStellarDescription"
-        },
-        {
-          "type": "boolean",
-          "name": "completed"
-        },
-        {
-          "type": "KeybaseTransactionID",
-          "name": "fundingKbTxID"
-        },
-        {
           "type": "RequestStatus",
           "name": "status"
         }

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -218,7 +218,7 @@ export type RemoteSubmitRelayClaimResult = RelayClaimResult
 export type RemoteSubmitRelayPaymentResult = PaymentResult
 export type RemoteSubmitRequestResult = KeybaseRequestID
 export type RequestDetails = $ReadOnly<{id: KeybaseRequestID, fromUser: Keybase1.UserVersion, toUser?: ?Keybase1.UserVersion, toAssertion: String, amount: String, asset?: ?Asset, currency?: ?OutsideCurrencyCode, fundingKbTxID: KeybaseTransactionID, status: RequestStatus}>
-export type RequestDetailsLocal = $ReadOnly<{id: KeybaseRequestID, fromAssertion: String, fromCurrentUser: Boolean, toUserType: ParticipantType, toAssertion: String, amount: String, asset?: ?Asset, currency?: ?OutsideCurrencyCode, amountDescription: String, amountStellar: String, amountStellarDescription: String, completed: Boolean, fundingKbTxID: KeybaseTransactionID, status: RequestStatus}>
+export type RequestDetailsLocal = $ReadOnly<{id: KeybaseRequestID, fromAssertion: String, fromCurrentUser: Boolean, toUserType: ParticipantType, toAssertion: String, amount: String, asset?: ?Asset, currency?: ?OutsideCurrencyCode, amountDescription: String, status: RequestStatus}>
 export type RequestPost = $ReadOnly<{toUser?: ?Keybase1.UserVersion, toAssertion: String, amount: String, asset?: ?Asset, currency?: ?OutsideCurrencyCode}>
 export type RequestStatus =
   | 0 // OK_0

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -199,8 +199,6 @@ const requestResultToRequest = (r: RPCTypes.RequestDetailsLocal) => {
   return makeRequest({
     amountDescription: r.amountDescription,
     asset,
-    completed: r.completed,
-    completedTransactionID: r.fundingKbTxID,
     id: r.id,
     requestee: r.toAssertion,
     requesteeType: partyTypeToString[r.toUserType],


### PR DESCRIPTION
This pull request tries to improve monetary amount formatting in various places, as well as simplifies `RequestDetails` handling by removing obsolete or unused fields.

- Take extra care when formatting a number with thousands separator (`,`).
  - The reason is that number like `12,123` can look ambiguous for people from different regions with different locales. We should print this number as `12,123.00`.
  - In `StellarSimplifyAmount` never remove fractional part completely when `,` is present in integer part. Always leave at least two digits after decimal point even if they are zeroes.
  - In `FormatAmount` never remove fractional part completely even if in in `precision=7` mode and fractional part is `0000000`, when `,` is present in integer part. Change `0000000` to `00` in such situations which gives us nicely looking `.00`.
- Change `GetRequestDetailsLocal` to not do any currency conversions. Frontend never displays XLM amount if OutsideCurrency is requested, this is only done on sending step when sendPayment window is invoked.
   - Change cli rendering to not attempt to print converted XLM amount as well.
- `GetRequestDetailsLocal` now uses `stellar.FormatCurrency` to print outside currency amount with symbol. But it also adds currency code manually afterwards (for reason that `$` can be ambiguous).
   - This is kind of messy right now, because it has to do `FormatCurrency` to add symbol and `Sprintf` to add code.
   - There is also place in frontend where frontend does this manually: https://github.com/keybase/client/blob/master/shared/wallets/asset/container.js#L22 We should look into refactoring and unifying this.
- Refactor and simplify RequestDetails protocol:
    - Remove `completed` and `fundingKbTxID` fields from `RequestDetails` which were unused - we don't do any kind of request completion right now. `status` field stays because it holds `OK` or `CANCELED`.
    - Remove `amountStellar` and `amountStellarDescription`. `amountDescription` stays and will display either formatted Stellar asset amount or outside currency amount, depending what's in the payment request.