### PR TITLE
Allow backspacing across lines in terminal

### DIFF
--- a/go/client/terminal.go
+++ b/go/client/terminal.go
@@ -55,12 +55,18 @@ func (t *Terminal) PromptPassword(s string) (string, error) {
 	if err := t.open(); err != nil {
 		return "", err
 	}
+	if t.escapeWrites {
+		s = terminalescaper.Clean(s)
+	}
 	return t.engine.PromptPassword(s)
 }
 
 func (t *Terminal) Prompt(s string) (string, error) {
 	if err := t.open(); err != nil {
 		return "", err
+	}
+	if t.escapeWrites {
+		s = terminalescaper.Clean(s)
 	}
 	s, err := t.engine.Prompt(s)
 	if err == minterm.ErrPromptInterrupted {

--- a/go/client/terminal.go
+++ b/go/client/terminal.go
@@ -10,7 +10,6 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/minterm"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/terminalescaper"
 )
 
 type Terminal struct {
@@ -57,23 +56,6 @@ func (t *Terminal) PromptPassword(s string) (string, error) {
 		return "", err
 	}
 	return t.engine.PromptPassword(s)
-}
-
-func (t *Terminal) Write(s string) error {
-	if err := t.open(); err != nil {
-		return err
-	}
-	if t.escapeWrites {
-		return t.engine.Write(terminalescaper.Clean(s))
-	}
-	return t.engine.Write(s)
-}
-
-func (t *Terminal) UnescapedWrite(s string) error {
-	if err := t.open(); err != nil {
-		return err
-	}
-	return t.engine.Write(s)
 }
 
 func (t *Terminal) Prompt(s string) (string, error) {
@@ -147,17 +129,11 @@ func (t *Terminal) GetSecret(arg *keybase1.SecretEntryArg) (res *keybase1.Secret
 		t.G().Log.Error(arg.Err)
 	}
 
-	if len(desc) > 0 {
-		if err = t.Write(desc + "\n"); err != nil {
-			return
-		}
-	}
-
 	var txt string
 	if arg.ShowTyping {
-		txt, err = t.Prompt(prompt)
+		txt, err = t.Prompt(desc + "\n" + prompt)
 	} else {
-		txt, err = t.PromptPassword(prompt)
+		txt, err = t.PromptPassword(desc + "\n" + prompt)
 	}
 
 	if err == io.EOF || err == minterm.ErrPromptInterrupted || len(txt) == 0 {

--- a/go/client/terminal.go
+++ b/go/client/terminal.go
@@ -134,7 +134,7 @@ func (t *Terminal) GetSecret(arg *keybase1.SecretEntryArg) (res *keybase1.Secret
 	if len(desc) > 0 {
 		d := desc + "\n"
 		if t.escapeWrites {
-			d = terminalescaper.Clean(s)
+			d = terminalescaper.Clean(d)
 		}
 		s += d
 	}

--- a/go/client/terminal.go
+++ b/go/client/terminal.go
@@ -130,9 +130,13 @@ func (t *Terminal) GetSecret(arg *keybase1.SecretEntryArg) (res *keybase1.Secret
 		t.G().Log.Error(arg.Err)
 	}
 
-	s := desc + "\n"
-	if t.escapeWrites {
-		s = terminalescaper.Clean(s)
+	s := ""
+	if len(desc) > 0 {
+		d := desc + "\n"
+		if t.escapeWrites {
+			d = terminalescaper.Clean(s)
+		}
+		s += d
 	}
 	s += prompt
 

--- a/go/minterm/minterm.go
+++ b/go/minterm/minterm.go
@@ -6,7 +6,6 @@ package minterm
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -59,42 +58,34 @@ func (m *MinTerm) Size() (int, int) {
 	return m.width, m.height
 }
 
-// Write writes a string to the terminal.
-func (m *MinTerm) Write(s string) error {
-	_, err := fmt.Fprint(m.getReadWriter(), s)
-	return err
-}
-
 // Prompt gets a line of input from the terminal.  It displays the text in
 // the prompt parameter first.
 func (m *MinTerm) Prompt(prompt string) (string, error) {
-	m.Write(prompt)
-	return m.readLine()
+	return m.readLine(prompt)
 }
 
 // PromptPassword gets a line of input from the terminal, but
 // nothing is echoed to the terminal to hide the text.
 func (m *MinTerm) PromptPassword(prompt string) (string, error) {
-	m.Write(prompt)
 	if !strings.HasSuffix(prompt, ": ") {
-		m.Write(": ")
+		prompt += ": "
 	}
-	return m.readSecret()
+	return m.readSecret(prompt)
 }
 
 func (m *MinTerm) fdIn() int { return int(m.termIn.Fd()) }
 
-func (m *MinTerm) readLine() (string, error) {
+func (m *MinTerm) readLine(prompt string) (string, error) {
 	m.makeRaw()
 	defer m.restore()
-	ret, err := terminal.NewTerminal(m.getReadWriter(), "").ReadLine()
+	ret, err := terminal.NewTerminal(m.getReadWriter(), prompt).ReadLine()
 	return ret, convertErr(err)
 }
 
-func (m *MinTerm) readSecret() (string, error) {
+func (m *MinTerm) readSecret(prompt string) (string, error) {
 	m.makeRaw()
 	defer m.restore()
-	ret, err := terminal.NewTerminal(m.getReadWriter(), "").ReadPassword("")
+	ret, err := terminal.NewTerminal(m.getReadWriter(), prompt).ReadPassword("")
 	return ret, convertErr(err)
 }
 


### PR DESCRIPTION
Linux Demo: https://asciinema.org/a/BfvzbZnYK4imPwKR0d4wVOzrg
Probably want to try on Mac and Windows too. I did some basic smoketesting and everything looks OK.

I don't think we can get support for Ctrl-U across lines, seems it only supports color codes.

We might be able to modify it to support an arbitrary width/height. By default its 80x24 with no option to set it anywhere, but width and height are internal variables. At that point it may be better to use another terminal library.

Also, if your terminal is smaller than 80 chars wide or you resize it, it's completely broken, but that was true before as well.