### PR TITLE
TeamWritePermDeniedError

### DIFF
--- a/go/git/settings.go
+++ b/go/git/settings.go
@@ -99,6 +99,13 @@ func SetTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, arg keybas
 	}
 
 	_, err = g.GetAPI().Post(*apiArg)
+	switch e := err.(type) {
+	case libkb.AppStatusError:
+		switch e.Code {
+		case libkb.SCTeamWritePermDenied:
+			return libkb.TeamWritePermDeniedError{}
+		}
+	}
 	return err
 }
 

--- a/go/git/settings.go
+++ b/go/git/settings.go
@@ -96,15 +96,13 @@ func SetTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, arg keybas
 		}
 		convID := convs[0].Info.Id
 		apiArg.Args["chat_conv_id"] = libkb.HexArg(convID)
+		apiArg.AppStatusCodes = []int{libkb.SCOk, libkb.SCTeamWritePermDenied}
 	}
 
-	_, err = g.GetAPI().Post(*apiArg)
-	switch e := err.(type) {
-	case libkb.AppStatusError:
-		switch e.Code {
-		case libkb.SCTeamWritePermDenied:
-			return libkb.TeamWritePermDeniedError{}
-		}
+	apiRes, err := g.GetAPI().Post(*apiArg)
+	switch apiRes.AppStatus.Code {
+	case libkb.SCTeamWritePermDenied:
+		return libkb.TeamWritePermDeniedError{}
 	}
 	return err
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -277,6 +277,7 @@ const (
 	SCAccountReset                     = int(keybase1.StatusCode_SCAccountReset)
 	SCIdentifiesFailed                 = int(keybase1.StatusCode_SCIdentifiesFailed)
 	SCTeamReadError                    = int(keybase1.StatusCode_SCTeamReadError)
+	SCTeamWritePermDenied              = int(keybase1.StatusCode_SCTeamWritePermDenied)
 	SCNoOp                             = int(keybase1.StatusCode_SCNoOp)
 	SCTeamNotFound                     = int(keybase1.StatusCode_SCTeamNotFound)
 	SCTeamTarDuplicate                 = int(keybase1.StatusCode_SCTeamTarDuplicate)

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2404,6 +2404,14 @@ func (e TeamInviteBadTokenError) Error() string {
 
 //=============================================================================
 
+type TeamWritePermDeniedError struct{}
+
+func (e TeamWritePermDeniedError) Error() string {
+	return "permission denied to modify team"
+}
+
+//=============================================================================
+
 type TeamInviteTokenReusedError struct{}
 
 func (e TeamInviteTokenReusedError) Error() string {
@@ -2464,6 +2472,12 @@ func (e HexWrongLengthError) Error() string { return e.msg }
 //=============================================================================
 
 type EphemeralPairwiseMACsMissingUIDsError struct{ UIDs []keybase1.UID }
+
+func NewEphemeralPairwiseMACsMissingUIDsError(uids []keybase1.UID) EphemeralPairwiseMACsMissingUIDsError {
+	return EphemeralPairwiseMACsMissingUIDsError{
+		UIDs: uids,
+	}
+}
 
 func (e EphemeralPairwiseMACsMissingUIDsError) Error() string {
 	return fmt.Sprintf("Missing %d uids from pairwise macs", len(e.UIDs))

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -702,13 +702,11 @@ func ImportStatusAsError(g *GlobalContext, s *keybase1.Status) error {
 		}
 		return e
 	case SCEphemeralPairwiseMACsMissingUIDs:
-		e := EphemeralPairwiseMACsMissingUIDsError{}
 		uids := []keybase1.UID{}
 		for _, field := range s.Fields {
 			uids = append(uids, keybase1.UID(field.Value))
 		}
-		e.UIDs = uids
-		return e
+		return NewEphemeralPairwiseMACsMissingUIDsError(uids)
 	case SCMerkleClientError:
 		e := MerkleClientError{m: s.Desc}
 		for _, field := range s.Fields {

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -127,6 +127,7 @@ const (
 	StatusCode_SCTeamNotFound                     StatusCode = 2614
 	StatusCode_SCTeamExists                       StatusCode = 2619
 	StatusCode_SCTeamReadError                    StatusCode = 2623
+	StatusCode_SCTeamWritePermDenied              StatusCode = 2625
 	StatusCode_SCNoOp                             StatusCode = 2638
 	StatusCode_SCTeamInviteBadToken               StatusCode = 2646
 	StatusCode_SCTeamTarDuplicate                 StatusCode = 2663
@@ -319,6 +320,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamNotFound":                     2614,
 	"SCTeamExists":                       2619,
 	"SCTeamReadError":                    2623,
+	"SCTeamWritePermDenied":              2625,
 	"SCNoOp":                             2638,
 	"SCTeamInviteBadToken":               2646,
 	"SCTeamTarDuplicate":                 2663,
@@ -509,6 +511,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2614: "SCTeamNotFound",
 	2619: "SCTeamExists",
 	2623: "SCTeamReadError",
+	2625: "SCTeamWritePermDenied",
 	2638: "SCNoOp",
 	2646: "SCTeamInviteBadToken",
 	2663: "SCTeamTarDuplicate",

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -119,6 +119,7 @@ protocol constants {
     SCTeamNotFound_2614,
     SCTeamExists_2619,
     SCTeamReadError_2623,
+    SCTeamWritePermDenied_2625,
     SCNoOp_2638,
     SCTeamInviteBadToken_2646,
     SCTeamTarDuplicate_2663,

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -123,6 +123,7 @@
         "SCTeamNotFound_2614",
         "SCTeamExists_2619",
         "SCTeamReadError_2623",
+        "SCTeamWritePermDenied_2625",
         "SCNoOp_2638",
         "SCTeamInviteBadToken_2646",
         "SCTeamTarDuplicate_2663",

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -205,6 +205,7 @@ export const constantsStatusCode = {
   scteamnotfound: 2614,
   scteamexists: 2619,
   scteamreaderror: 2623,
+  scteamwritepermdenied: 2625,
   scnoop: 2638,
   scteaminvitebadtoken: 2646,
   scteamtarduplicate: 2663,

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -215,6 +215,7 @@ export const constantsStatusCode = {
   scteamnotfound: 2614,
   scteamexists: 2619,
   scteamreaderror: 2623,
+  scteamwritepermdenied: 2625,
   scnoop: 2638,
   scteaminvitebadtoken: 2646,
   scteamtarduplicate: 2663,
@@ -1686,6 +1687,7 @@ export type StatusCode =
   | 2614 // SCTeamNotFound_2614
   | 2619 // SCTeamExists_2619
   | 2623 // SCTeamReadError_2623
+  | 2625 // SCTeamWritePermDenied_2625
   | 2638 // SCNoOp_2638
   | 2646 // SCTeamInviteBadToken_2646
   | 2663 // SCTeamTarDuplicate_2663


### PR DESCRIPTION
if you tried to modify git settings for a team where you were a writer or below you used to get:
`▶ ERROR DB error (code 2625)`
now it says:
`▶ ERROR permission denied to modify team`

is there an easier way to pipe the error message from the server directly?