### PR TITLE
BuildPayment: Silence ToErrMsg when recipient is empty

### DIFF
--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -932,9 +932,9 @@ func (s *Server) BuildPaymentLocal(ctx context.Context, arg stellar1.BuildPaymen
 	// -------------------- to --------------------
 
 	tracer.Stage("to")
-	var skipRecipient bool
+	skipRecipient := len(arg.To) == 0
 	var minAmountXLM string
-	if arg.ToIsAccountID {
+	if !skipRecipient && arg.ToIsAccountID {
 		_, err := libkb.ParseStellarAccountID(arg.To)
 		if err != nil {
 			res.ToErrMsg = err.Error()

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -784,6 +784,24 @@ func TestBuildPaymentLocal(t *testing.T) {
 
 	worthInfo := "$1.00 = 3.1414139 XLM\nSource: coinmarketcap.com"
 
+	for _, toIsAccountID := range []bool{false, true} {
+		t.Logf("toIsAccountID: %v", toIsAccountID)
+		bres, err := tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+			From:          senderAccountID,
+			ToIsAccountID: toIsAccountID,
+		})
+		require.NoError(t, err)
+		t.Logf(spew.Sdump(bres))
+		require.Equal(t, false, bres.ReadyToSend)
+		require.Equal(t, "", bres.ToErrMsg)
+		require.Equal(t, "", bres.AmountErrMsg)
+		require.Equal(t, "", bres.SecretNoteErrMsg)
+		require.Equal(t, "", bres.PublicMemoErrMsg)
+		require.Equal(t, "$0.00", bres.WorthDescription)
+		require.Equal(t, worthInfo, bres.WorthInfo)
+		requireBannerSet(t, bres, nil)
+	}
+
 	bres, err := tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
 		From: senderAccountID,
 		To:   tcs[1].Fu.Username,


### PR DESCRIPTION
When arg.To is "", the return value used to have "recipient not found" under the to field. Now it shows no such error, but still isn't considered ready.

cc @nathunsmitty 