### PR TITLE
only log error when an error happens

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -91,6 +91,9 @@ func (h *Server) getStreamUICli() *keybase1.StreamUiClient {
 
 func (h *Server) handleOfflineError(ctx context.Context, err error,
 	res chat1.OfflinableResult) error {
+	if err == nil {
+		return nil
+	}
 
 	errKind := IsOfflineError(err)
 	h.Debug(ctx, "handleOfflineError: errType: %T", err)

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -400,11 +400,14 @@ func (t *ImplicitTeamsNameInfoSource) identify(ctx context.Context, tlfID chat1.
 
 func (t *ImplicitTeamsNameInfoSource) transformTeamDoesNotExist(ctx context.Context, err error, name string) error {
 	switch err.(type) {
+	case nil:
+		return nil
 	case teams.TeamDoesNotExistError:
 		return NewUnknownTLFNameError(name)
+	default:
+		t.Debug(ctx, "Lookup: error looking up the team: %v", err)
+		return err
 	}
-	t.Debug(ctx, "Lookup: error looking up the team: %s", err)
-	return err
 }
 
 func (t *ImplicitTeamsNameInfoSource) LookupIDUntrusted(ctx context.Context, name string, public bool) (res *types.NameInfoUntrusted, err error) {


### PR DESCRIPTION
reduce log spam when `err = nil` since this is always called from `LookupIDUntrusted`


cc @mmaxim will merge after ci
