### PR TITLE
Stellar: show send form when clicking send button from chat

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -5,6 +5,7 @@ import * as RPCTypes from '../constants/types/rpc-stellar-gen'
 import * as Saga from '../util/saga'
 import * as WalletsGen from './wallets-gen'
 import * as Chat2Gen from './chat2-gen'
+import * as ConfigGen from './config-gen'
 import HiddenString from '../util/hidden-string'
 import * as Route from './route-tree'
 import logger from '../logger'
@@ -87,6 +88,7 @@ const loadAccounts = (
     | WalletsGen.LoadAccountsPayload
     | WalletsGen.LinkedExistingAccountPayload
     | WalletsGen.RefreshPaymentsPayload
+    | ConfigGen.LoggedInPayload
 ) =>
   !action.error &&
   RPCTypes.localGetWalletAccountsLocalRpcPromise().then(res =>
@@ -241,6 +243,7 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
       WalletsGen.createdNewAccount,
       WalletsGen.linkedExistingAccount,
       WalletsGen.refreshPayments,
+      ConfigGen.loggedIn,
     ],
     loadAccounts
   )

--- a/shared/chat/conversation/messages/account-payment/container.js
+++ b/shared/chat/conversation/messages/account-payment/container.js
@@ -1,14 +1,19 @@
 // @flow
 import * as React from 'react'
 import * as Container from '../../../../util/container'
-import * as Constants from '../../../../constants/wallets'
 import * as Types from '../../../../constants/types/chat2'
+import * as WalletConstants from '../../../../constants/wallets'
+import * as WalletTypes from '../../../../constants/types/wallets'
 import * as WalletsGen from '../../../../actions/wallets-gen'
+import * as Route from '../../../../actions/route-tree-gen'
 import * as Styles from '../../../../styles'
+import HiddenString from '../../../../util/hidden-string'
 import AccountPayment, {type Props as AccountPaymentProps} from '.'
 
 // Props for rendering the loading indicator
 const loadingProps = {
+  _defaultAccountID: WalletTypes.noAccountID,
+  _request: WalletConstants.makeRequest(),
   action: '',
   amount: '',
   balanceChange: '',
@@ -23,20 +28,25 @@ type OwnProps = {
   message: Types.MessageSendPayment | Types.MessageRequestPayment,
 }
 
-const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
+  const common = {
+    _defaultAccountID: WalletConstants.getDefaultAccountID(state),
+    _request: WalletConstants.makeRequest(),
+  }
   switch (ownProps.message.type) {
     case 'sendPayment': {
       const paymentID = ownProps.message.paymentID
-      const accountID = Constants.getDefaultAccountID(state)
+      const accountID = WalletConstants.getDefaultAccountID(state)
       if (!accountID) {
         return loadingProps
       }
-      const payment = Constants.getPayment(state, accountID, paymentID)
+      const payment = WalletConstants.getPayment(state, accountID, paymentID)
       if (payment.statusSimplified === 'none') {
         // no payment
         return loadingProps
       }
       return {
+        ...common,
         action: payment.worth ? 'sent lumens worth' : 'sent',
         amount: payment.worth ? payment.worth : payment.amountDescription,
         balanceChange: `${payment.delta === 'increase' ? '+' : '-'}${payment.amountDescription}`,
@@ -52,11 +62,11 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
     case 'requestPayment': {
       const message: Types.MessageRequestPayment = ownProps.message
       const requestID = ownProps.message.requestID
-      const request = Constants.getRequest(state, requestID)
+      const request = WalletConstants.getRequest(state, requestID)
       if (!request) {
         return loadingProps
       }
-
+      common._request = request
       const sendProps =
         ownProps.message.author === state.config.username
           ? {}
@@ -67,6 +77,7 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
             }
 
       return {
+        ...common,
         ...sendProps,
         action: request.asset === 'currency' ? 'requested lumens worth' : 'requested',
         amount: request.amountDescription,
@@ -83,16 +94,40 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
   }
 }
 
-const mapDispatchToProps = (dispatch: Container.Dispatch, ownProps: OwnProps) => ({
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  _onSend: (details: ?WalletTypes.Request, defaultAccountID: ?WalletTypes.AccountID) => {
+    if (details && defaultAccountID && ownProps.message.type === 'requestPayment') {
+      const message = ownProps.message
+      if (details.currencyCode) {
+        dispatch(WalletsGen.createSetBuildingCurrency({currency: details.currencyCode}))
+      }
+      dispatch(WalletsGen.createSetBuildingAmount({amount: details.amount}))
+      dispatch(WalletsGen.createSetBuildingFrom({from: defaultAccountID || ''}))
+      dispatch(WalletsGen.createSetBuildingRecipientType({recipientType: 'keybaseUser'}))
+      dispatch(WalletsGen.createSetBuildingTo({to: message.author}))
+      dispatch(WalletsGen.createSetBuildingSecretNote({secretNote: new HiddenString(message.note)}))
+      dispatch(Route.createNavigateAppend({path: ['sendReceiveForm']}))
+    }
+  },
   loadTxData: () => {
     if (ownProps.message.type === 'requestPayment') {
       dispatch(WalletsGen.createLoadRequestDetail({requestID: ownProps.message.requestID}))
     }
   },
-  onSend: () => {
-    // TODO navigate to dialog
-    console.log('TODO')
-  },
+})
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  action: stateProps.action,
+  amount: stateProps.amount,
+  balanceChange: stateProps.balanceChange,
+  balanceChangeColor: stateProps.balanceChangeColor,
+  icon: stateProps.icon,
+  loadTxData: dispatchProps.loadTxData,
+  loading: stateProps.loading,
+  memo: stateProps.memo,
+  onSend: () => dispatchProps._onSend(stateProps._request, stateProps._defaultAccountID),
+  pending: stateProps.pending,
+  sendButtonLabel: stateProps.sendButtonLabel || '',
 })
 
 type LoadCalls = {|
@@ -111,9 +146,7 @@ class LoadWrapper extends React.Component<{...AccountPaymentProps, ...LoadCalls}
   }
 }
 
-const ConnectedAccountPayment = Container.connect(mapStateToProps, mapDispatchToProps, (sp, dp, op) => ({
-  ...sp,
-  ...dp,
-  ...op,
-}))(LoadWrapper)
+const ConnectedAccountPayment = Container.connect(mapStateToProps, mapDispatchToProps, mergeProps)(
+  LoadWrapper
+)
 export default ConnectedAccountPayment

--- a/shared/chat/routes.js
+++ b/shared/chat/routes.js
@@ -19,6 +19,8 @@ import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import DeleteHistoryWarning from './delete-history-warning/container'
 import RetentionWarning from '../teams/team/settings-tab/retention/warning/container'
 import ChooseEmoji from './conversation/messages/react-button/emoji-picker/container'
+import ConfirmForm from '../wallets/confirm-form/container'
+import SendForm from '../wallets/send-form/container'
 
 // Arbitrarily stackable routes from the chat tab
 const chatChildren = {
@@ -91,6 +93,17 @@ const chatChildren = {
   },
   enterPaperkey: {
     component: EnterPaperkey,
+  },
+  sendReceiveForm: {
+    children: {
+      confirmForm: {
+        children: {},
+        component: ConfirmForm,
+        tags: makeLeafTags({layerOnTop: !isMobile}),
+      },
+    },
+    component: SendForm,
+    tags: makeLeafTags({layerOnTop: !isMobile}),
   },
 }
 

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -22,7 +22,7 @@ export opaque type AccountID: string = string
 export const stringToAccountID = __DEV__
   ? (s: string): AccountID => {
       if (!s) {
-        throw new Error('Invalid empty AccountID. Did you mean Constants.noAccountID?')
+        throw new Error('Invalid empty AccountID. Did you mean Types.noAccountID?')
       }
       return s
     }
@@ -110,10 +110,12 @@ export type _AssetDescription = {
 export type AssetDescription = I.RecordOf<_AssetDescription>
 
 export type _Request = {
-  amountDescription: string, // The amount the request was made in (XLM, asset, or equivalent fiat)
+  amount: string, // The number alone
+  amountDescription: string, // The amount the request was made in (XLM, asset, or equivalent fiat) (i.e. '<number> <code>')
   asset: 'native' | 'currency' | AssetDescription,
   completed: boolean,
   completedTransactionID: ?StellarRPCTypes.KeybaseTransactionID,
+  currencyCode: string, // set if asset === 'currency'
   id: StellarRPCTypes.KeybaseRequestID,
   requestee: string, // username or assertion
   requesteeType: string,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -172,10 +172,12 @@ const makeAssetDescription: I.RecordFactory<Types._AssetDescription> = I.Record(
 })
 
 const makeRequest: I.RecordFactory<Types._Request> = I.Record({
+  amount: '',
   amountDescription: '',
   asset: 'native',
   completed: false,
   completedTransactionID: null,
+  currencyCode: '',
   id: '',
   requestee: '',
   requesteeType: '',
@@ -185,6 +187,7 @@ const makeRequest: I.RecordFactory<Types._Request> = I.Record({
 
 const requestResultToRequest = (r: RPCTypes.RequestDetailsLocal) => {
   let asset = 'native'
+  let currencyCode = ''
   if (!(r.asset || r.currency)) {
     logger.error('Received requestDetails with no asset or currency code')
     return null
@@ -195,12 +198,15 @@ const requestResultToRequest = (r: RPCTypes.RequestDetailsLocal) => {
     })
   } else if (r.currency) {
     asset = 'currency'
+    currencyCode = r.currency
   }
   return makeRequest({
+    amount: r.amount,
     amountDescription: r.amountDescription,
     asset,
     completed: r.completed,
     completedTransactionID: r.fundingKbTxID,
+    currencyCode,
     id: r.id,
     requestee: r.toAssertion,
     requesteeType: partyTypeToString[r.toUserType],
@@ -298,6 +304,7 @@ export {
   makeBuildingPayment,
   makeBuiltPayment,
   makePayment,
+  makeRequest,
   makeReserve,
   makeState,
   paymentResultToPayment,

--- a/shared/wallets/send-form/container.js
+++ b/shared/wallets/send-form/container.js
@@ -1,11 +1,16 @@
 // @flow
 import SendForm from '.'
+import * as WalletsGen from '../../actions/wallets-gen'
 import {connect, type TypedState} from '../../util/container'
 
 const mapStateToProps = (state: TypedState) => ({})
 
 const mapDispatchToProps = (dispatch, {navigateUp}) => ({
-  onClose: () => dispatch(navigateUp()),
+  onClose: () => {
+    dispatch(navigateUp())
+    dispatch(WalletsGen.createClearBuildingPayment())
+    dispatch(WalletsGen.createClearBuiltPayment())
+  },
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({


### PR DESCRIPTION
Uses `setBuilding*` to set up the values in the form. Since our inputs aren't controlled, values won't be filled but corresponding errors will show when they should. Also adds a call to `loadAccounts` on login. r? @keybase/react-hackers 