### PR TITLE
Check previous isUserMessage instead of current

### DIFF
--- a/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
@@ -71,7 +71,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
   const {message, previous} = stateProps
 
   const sequentialUserMessages =
-    previous && previous.author === message.author && Constants.isUserMessage(message)
+    previous && previous.author === message.author && Constants.isUserMessage(previous)
 
   const showAuthor = MessageConstants.enoughTimeBetweenMessages(message, previous)
 


### PR DESCRIPTION
This fixes the author wrapper not showing up correctly for user messages that follow system messages. Previously,
```
previous && previous.author === message.author && Constants.isUserMessage(message)
```
this could be true if `previous` was a system message written by the current user.

Example before:
<img width="175" alt="image" src="https://user-images.githubusercontent.com/11968340/44804772-6270cc80-ab90-11e8-8842-dc3c7c4bb885.png">

Example after:
<img width="174" alt="image" src="https://user-images.githubusercontent.com/11968340/44804828-8cc28a00-ab90-11e8-8399-14fccf8262d0.png">

r? @keybase/react-hackers 

