### PR TITLE
 [KBFS-3173] Copy path: move option up

### DIFF
--- a/shared/fs/common/path-item-action.js
+++ b/shared/fs/common/path-item-action.js
@@ -85,24 +85,6 @@ const Save = DownloadTrackingHoc(
 
 const makeMenuItems = (props: Props, hideMenu: () => void) => {
   return [
-    ...(props.showInFileUI
-      ? [
-          {
-            title: 'Show in ' + fileUIName,
-            onClick: hideMenuOnClick(props.showInFileUI, hideMenu),
-          },
-        ]
-      : []),
-    ...(props.ignoreFolder
-      ? [
-          {
-            title: 'Ignore this folder',
-            onClick: hideMenuOnClick(props.ignoreFolder, hideMenu),
-            subTitle: 'The folder will no longer appear in your folders list.',
-            danger: true,
-          },
-        ]
-      : []),
     ...(props.saveMedia
       ? [
           {
@@ -130,11 +112,11 @@ const makeMenuItems = (props: Props, hideMenu: () => void) => {
           },
         ]
       : []),
-    ...(props.download
+    ...(props.showInFileUI
       ? [
           {
-            title: 'Download a copy',
-            onClick: hideMenuOnClick(props.download, hideMenu),
+            title: 'Show in ' + fileUIName,
+            onClick: hideMenuOnClick(props.showInFileUI, hideMenu),
           },
         ]
       : []),
@@ -143,6 +125,24 @@ const makeMenuItems = (props: Props, hideMenu: () => void) => {
           {
             title: 'Copy path',
             onClick: hideMenuOnClick(props.copyPath, hideMenu),
+          },
+        ]
+      : []),
+    ...(props.download
+      ? [
+          {
+            title: 'Download a copy',
+            onClick: hideMenuOnClick(props.download, hideMenu),
+          },
+        ]
+      : []),
+    ...(props.ignoreFolder
+      ? [
+          {
+            title: 'Ignore this folder',
+            onClick: hideMenuOnClick(props.ignoreFolder, hideMenu),
+            subTitle: 'The folder will no longer appear in your folders list.',
+            danger: true,
           },
         ]
       : []),


### PR DESCRIPTION
**Description:**

Reorder menu item options to have copy path in between show finder and download a copy

**Relevant Screenshots:**

![screen shot 2018-08-29 at 21 48 17](https://user-images.githubusercontent.com/10031957/44808631-68d56780-abd5-11e8-86df-87281e022f16.png)
