### PR TITLE
protocol: bserver changes for getting block size and status

### DIFF
--- a/go/protocol/keybase1/block.go
+++ b/go/protocol/keybase1/block.go
@@ -8,9 +8,40 @@ import (
 	context "golang.org/x/net/context"
 )
 
+type BlockStatus int
+
+const (
+	BlockStatus_UNKNOWN  BlockStatus = 0
+	BlockStatus_LIVE     BlockStatus = 1
+	BlockStatus_ARCHIVED BlockStatus = 2
+)
+
+func (o BlockStatus) DeepCopy() BlockStatus { return o }
+
+var BlockStatusMap = map[string]BlockStatus{
+	"UNKNOWN":  0,
+	"LIVE":     1,
+	"ARCHIVED": 2,
+}
+
+var BlockStatusRevMap = map[BlockStatus]string{
+	0: "UNKNOWN",
+	1: "LIVE",
+	2: "ARCHIVED",
+}
+
+func (e BlockStatus) String() string {
+	if v, ok := BlockStatusRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type GetBlockRes struct {
-	BlockKey string `codec:"blockKey" json:"blockKey"`
-	Buf      []byte `codec:"buf" json:"buf"`
+	BlockKey string      `codec:"blockKey" json:"blockKey"`
+	Buf      []byte      `codec:"buf" json:"buf"`
+	Size     int         `codec:"size" json:"size"`
+	Status   BlockStatus `codec:"status" json:"status"`
 }
 
 func (o GetBlockRes) DeepCopy() GetBlockRes {
@@ -22,6 +53,8 @@ func (o GetBlockRes) DeepCopy() GetBlockRes {
 			}
 			return append([]byte{}, x...)
 		})(o.Buf),
+		Size:   o.Size,
+		Status: o.Status.DeepCopy(),
 	}
 }
 
@@ -110,8 +143,9 @@ type PutBlockAgainArg struct {
 }
 
 type GetBlockArg struct {
-	Bid    BlockIdCombo `codec:"bid" json:"bid"`
-	Folder string       `codec:"folder" json:"folder"`
+	Bid      BlockIdCombo `codec:"bid" json:"bid"`
+	Folder   string       `codec:"folder" json:"folder"`
+	SizeOnly bool         `codec:"sizeOnly" json:"sizeOnly"`
 }
 
 type AddReferenceArg struct {

--- a/protocol/avdl/keybase1/block.avdl
+++ b/protocol/avdl/keybase1/block.avdl
@@ -3,9 +3,17 @@
 protocol block {
   import idl "backend_common.avdl";
 
+  enum BlockStatus {
+    UNKNOWN_0,
+    LIVE_1,
+    ARCHIVED_2
+  }
+
   record GetBlockRes {
     string blockKey;
     bytes buf;
+    int size;
+    BlockStatus status;
   }
 
   // Fixed-size nonce to identify a reference to a block
@@ -38,7 +46,7 @@ protocol block {
 
   void putBlock(BlockIdCombo bid, string folder, string blockKey, bytes buf);
   void putBlockAgain(string folder, BlockReference ref, string blockKey, bytes buf);
-  GetBlockRes getBlock(BlockIdCombo bid, string folder);
+  GetBlockRes getBlock(BlockIdCombo bid, string folder, boolean sizeOnly);
 
   void addReference(string folder, BlockReference ref);
   void delReference(string folder, BlockReference ref);

--- a/protocol/json/keybase1/block.json
+++ b/protocol/json/keybase1/block.json
@@ -8,6 +8,15 @@
   ],
   "types": [
     {
+      "type": "enum",
+      "name": "BlockStatus",
+      "symbols": [
+        "UNKNOWN_0",
+        "LIVE_1",
+        "ARCHIVED_2"
+      ]
+    },
+    {
       "type": "record",
       "name": "GetBlockRes",
       "fields": [
@@ -18,6 +27,14 @@
         {
           "type": "bytes",
           "name": "buf"
+        },
+        {
+          "type": "int",
+          "name": "size"
+        },
+        {
+          "type": "BlockStatus",
+          "name": "status"
         }
       ]
     },
@@ -146,6 +163,10 @@
         {
           "name": "folder",
           "type": "string"
+        },
+        {
+          "name": "sizeOnly",
+          "type": "boolean"
         }
       ],
       "response": "GetBlockRes"

--- a/protocol/yarn.lock
+++ b/protocol/yarn.lock
@@ -14,9 +14,9 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-avdl-compiler@1.3.22:
-  version "1.3.22"
-  resolved "https://registry.yarnpkg.com/avdl-compiler/-/avdl-compiler-1.3.22.tgz#2e238d2474087472b8be485707ec300eb38dde12"
+avdl-compiler@1.3.24:
+  version "1.3.24"
+  resolved "https://registry.yarnpkg.com/avdl-compiler/-/avdl-compiler-1.3.24.tgz#df803d3238c73a6bf64be7860285ac18226308ff"
   dependencies:
     avdl2json "^2.2.4"
     iced-error "0.0.9"
@@ -52,9 +52,13 @@ colors@0.5.x:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
-colors@>=0.6.2, colors@^1.1.2:
+colors@>=0.6.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+
+colors@^1.1.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.2.tgz#2df8ff573dfbf255af562f8ce7181d6b971a359b"
 
 colors@~0.6.2:
   version "0.6.2"

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -19,6 +19,12 @@ export const backendCommonBlockType = {
   git: 2,
 }
 
+export const blockBlockStatus = {
+  unknown: 0,
+  live: 1,
+  archived: 2,
+}
+
 export const commonClientType = {
   none: 0,
   cli: 1,

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -29,6 +29,12 @@ export const backendCommonBlockType = {
   git: 2,
 }
 
+export const blockBlockStatus = {
+  unknown: 0,
+  live: 1,
+  archived: 2,
+}
+
 export const commonClientType = {
   none: 0,
   cli: 1,
@@ -814,6 +820,11 @@ export type BlockPingResponse = $ReadOnly<{}>
 export type BlockRefNonce = ?string
 export type BlockReference = $ReadOnly<{bid: BlockIdCombo, nonce: BlockRefNonce, chargedTo: UserOrTeamID}>
 export type BlockReferenceCount = $ReadOnly<{ref: BlockReference, liveCount: Int}>
+export type BlockStatus =
+  | 0 // UNKNOWN_0
+  | 1 // LIVE_1
+  | 2 // ARCHIVED_2
+
 export type BlockType =
   | 0 // DATA_0
   | 1 // MD_1
@@ -1022,7 +1033,7 @@ export type GPGMethod =
 export type GUIEntryArg = $ReadOnly<{windowTitle: String, prompt: String, username: String, submitLabel: String, cancelLabel: String, retryLabel: String, type: PassphraseType, features: GUIEntryFeatures}>
 export type GUIEntryFeatures = $ReadOnly<{showTyping: Feature}>
 export type GcOptions = $ReadOnly<{maxLooseRefs: Int, pruneMinLooseObjects: Int, pruneExpireTime: Time}>
-export type GetBlockRes = $ReadOnly<{blockKey: String, buf: Bytes}>
+export type GetBlockRes = $ReadOnly<{blockKey: String, buf: Bytes, size: Int, status: BlockStatus}>
 export type GetCurrentStatusRes = $ReadOnly<{configured: Boolean, registered: Boolean, loggedIn: Boolean, sessionIsValid: Boolean, user?: ?User}>
 export type GetLockdownResponse = $ReadOnly<{history?: ?Array<LockdownHistory>, status: Boolean}>
 export type GetPassphraseRes = $ReadOnly<{passphrase: String, storeSecret: Boolean}>
@@ -2056,7 +2067,7 @@ export type BlockAuthenticateSessionRpcParam = $ReadOnly<{signature: String}>
 export type BlockBlockPingRpcParam = void
 export type BlockDelReferenceRpcParam = $ReadOnly<{folder: String, ref: BlockReference}>
 export type BlockDelReferenceWithCountRpcParam = $ReadOnly<{folder: String, refs?: ?Array<BlockReference>}>
-export type BlockGetBlockRpcParam = $ReadOnly<{bid: BlockIdCombo, folder: String}>
+export type BlockGetBlockRpcParam = $ReadOnly<{bid: BlockIdCombo, folder: String, sizeOnly: Boolean}>
 export type BlockGetSessionChallengeRpcParam = void
 export type BlockGetTeamQuotaInfoRpcParam = $ReadOnly<{tid: TeamID}>
 export type BlockGetUserQuotaInfoRpcParam = void


### PR DESCRIPTION
This makes it more efficient if a client just wants to look up the size of a block (and is willing to trust the server about it).

Also, in an upcoming kbfs PR, the client needs the server's help to know whether a given block is live or archived, so it can properly account for its size in the MD byte counts.

Issue: KBFS-3303