### PR TITLE
Retry on errors but without blackbar

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -322,6 +322,9 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv
 	}
 
 	unboxed, ierr := b.unbox(ctx, boxed, conv.GetMembersType(), encryptionKey, ephemeralSeed)
+	if ierr == nil {
+		ierr = b.checkInvariants(ctx, conv.GetConvID(), boxed, unboxed)
+	}
 	if ierr != nil {
 		b.Debug(ctx, "failed to unbox message: msgID: %d err: %s", boxed.ServerHeader.MessageID,
 			ierr.Error())
@@ -329,8 +332,6 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv
 			return b.makeErrorMessage(ctx, boxed, ierr), nil
 		}
 		return chat1.MessageUnboxed{}, ierr
-	} else {
-		ierr = b.checkInvariants(ctx, conv.GetConvID(), boxed, unboxed)
 	}
 	return chat1.NewMessageUnboxedWithValid(*unboxed), nil
 }

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -39,9 +39,7 @@ func cryptKey(t *testing.T) *keybase1.CryptKey {
 
 func textMsg(t *testing.T, text string, mbVersion chat1.MessageBoxedVersion) chat1.MessagePlaintext {
 	uid, err := libkb.RandBytes(16)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	uid[15] = keybase1.UID_SUFFIX_2
 	return textMsgWithSender(t, text, gregor1.UID(uid), mbVersion)
 }
@@ -95,18 +93,12 @@ func getSigningKeyPairForTest(t *testing.T, tc *kbtest.ChatTestContext, u *kbtes
 	var err error
 	if u == nil {
 		u, err = kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 	kp, err := tc.G.Keyrings.GetSecretKeyWithPassphrase(kbtest.NewMetaContextForTest(*tc), u.User, u.Passphrase, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	signKP, ok := kp.(libkb.NaclSigningKeyPair)
-	if !ok {
-		t.Fatal("signing key not nacl")
-	}
+	require.True(t, ok)
 	return signKP
 }
 
@@ -151,9 +143,8 @@ func TestChatMessageBox(t *testing.T) {
 		tc, boxer := setupChatTest(t, "box")
 		defer tc.Cleanup()
 		boxed, err := boxer.box(context.TODO(), msg, key, nil, getSigningKeyPairForTest(t, tc, nil), mbVersion, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		require.Equal(t, mbVersion, boxed.Version)
 		if len(boxed.BodyCiphertext.E) == 0 {
 			t.Error("after boxMessage, BodyCipherText.E is empty")
@@ -170,9 +161,8 @@ func TestChatMessageUnbox(t *testing.T) {
 
 		// need a real user
 		u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
 		outboxID := chat1.OutboxID{0xdc, 0x74, 0x6, 0x5d, 0xf9, 0x5f, 0x1c, 0x48}
 		msg.ClientHeader.OutboxID = &outboxID
@@ -193,16 +183,12 @@ func TestChatMessageUnbox(t *testing.T) {
 		}
 
 		unboxed, err := boxer.unbox(context.TODO(), *boxed, chat1.ConversationMembersType_KBFS, key, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		body := unboxed.MessageBody
-		if typ, _ := body.MessageType(); typ != chat1.MessageType_TEXT {
-			t.Errorf("body type: %d, expected %d", typ, chat1.MessageType_TEXT)
-		}
-		if body.Text().Body != text {
-			t.Errorf("body text: %q, expected %q", body.Text().Body, text)
-		}
+		typ, err := body.MessageType()
+		require.NoError(t, err)
+		require.Equal(t, typ, chat1.MessageType_TEXT)
+		require.Equal(t, body.Text().Body, text)
 		require.Nil(t, unboxed.SenderDeviceRevokedAt, "message should not be from revoked device")
 		require.NotNil(t, unboxed.BodyHash)
 	})
@@ -410,9 +396,8 @@ func TestChatMessageMissingOutboxID(t *testing.T) {
 
 	// need a real user
 	u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
 	outboxID := chat1.OutboxID{0xdc, 0x74, 0x6, 0x5d, 0xf9, 0x5f, 0x1c, 0x48}
 	msg.ClientHeader.OutboxID = &outboxID
@@ -426,7 +411,6 @@ func TestChatMessageMissingOutboxID(t *testing.T) {
 	if boxed.ClientHeader.OutboxID == msg.ClientHeader.OutboxID {
 		t.Fatalf("defective test: %+v   ==   %+v", boxed.ClientHeader.OutboxID, msg.ClientHeader.OutboxID)
 	}
-
 	// omit outbox id
 	boxed.ClientHeader.OutboxID = nil
 
@@ -451,9 +435,8 @@ func TestChatMessageInvalidBodyHash(t *testing.T) {
 
 		// need a real user
 		u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
 
 		signKP := getSigningKeyPairForTest(t, tc, u)
@@ -466,9 +449,7 @@ func TestChatMessageInvalidBodyHash(t *testing.T) {
 		}
 
 		boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, mbVersion, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// need to give it a server header...
 		boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -479,9 +460,8 @@ func TestChatMessageInvalidBodyHash(t *testing.T) {
 		boxer.hashV1 = origHashFn
 
 		_, ierr := boxer.unbox(context.TODO(), *boxed, chat1.ConversationMembersType_KBFS, key, nil)
-		if _, ok := ierr.Inner().(BodyHashInvalid); !ok {
-			t.Fatalf("unexpected error for invalid body hash: %s", ierr)
-		}
+		_, ok := ierr.Inner().(BodyHashInvalid)
+		require.True(t, ok)
 	})
 }
 
@@ -567,9 +547,7 @@ func TestChatMessageUnboxInvalidBodyHash(t *testing.T) {
 
 		boxer.boxVersionForTesting = &mbVersion
 		boxed, err := boxer.BoxMessage(ctx, msg, chat1.ConversationMembersType_KBFS, signKP)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// need to give it a server header...
 		boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -589,12 +567,8 @@ func TestChatMessageUnboxInvalidBodyHash(t *testing.T) {
 
 		// This should produce a permanent error. So err will be nil, but the decmsg will be state=error.
 		decmsg, err := boxer.UnboxMessage(ctx, *boxed, conv)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if decmsg.IsValid() {
-			t.Fatalf("message should not be unboxable")
-		}
+		require.NoError(t, err)
+		require.False(t, decmsg.IsValid())
 	})
 }
 
@@ -635,9 +609,7 @@ func TestChatMessageInvalidHeaderSig(t *testing.T) {
 
 		// need a real user
 		u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
 
 		signKP := getSigningKeyPairForTest(t, tc, u)
@@ -651,9 +623,7 @@ func TestChatMessageInvalidHeaderSig(t *testing.T) {
 		}
 
 		boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, mbVersion, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		require.True(t, called, "mangle must be called")
 
@@ -666,15 +636,13 @@ func TestChatMessageInvalidHeaderSig(t *testing.T) {
 		require.NotNil(t, ierr, "must have unbox error")
 		switch mbVersion {
 		case chat1.MessageBoxedVersion_V1:
-			if _, ok := ierr.Inner().(libkb.BadSigError); !ok {
-				t.Fatalf("unexpected error for invalid header signature: [%T] %s", ierr.Inner(), ierr)
-			}
+			_, ok := ierr.Inner().(libkb.BadSigError)
+			require.True(t, ok)
 		case chat1.MessageBoxedVersion_V2:
-			if _, ok := ierr.Inner().(signencrypt.Error); !ok {
-				t.Fatalf("unexpected error for invalid header signature: [%T] %s", ierr.Inner(), ierr)
-			}
+			_, ok := ierr.Inner().(signencrypt.Error)
+			require.True(t, ok)
 		default:
-			t.Fatalf("unexpected version: %v", mbVersion)
+			require.Fail(t, "unexpected version: %v", mbVersion)
 		}
 	})
 }
@@ -688,21 +656,15 @@ func TestChatMessageInvalidSenderKey(t *testing.T) {
 
 		// need a real user
 		u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
 
 		// use a random signing key, not one of u's keys
 		signKP, err := libkb.GenerateNaclSigningKeyPair()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, mbVersion, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		boxed.ServerHeader = &chat1.MessageServerHeader{
 			Ctime: gregor1.ToTime(time.Now()),
@@ -710,9 +672,8 @@ func TestChatMessageInvalidSenderKey(t *testing.T) {
 
 		_, ierr := boxer.unbox(context.TODO(), *boxed, chat1.ConversationMembersType_KBFS, key, nil)
 		if ierr != nil {
-			if _, ok := ierr.Inner().(libkb.NoKeyError); !ok {
-				t.Fatalf("unexpected error for invalid sender key: %v", ierr)
-			}
+			_, ok := ierr.Inner().(libkb.NoKeyError)
+			require.True(t, ok)
 		}
 	})
 }
@@ -876,9 +837,8 @@ func TestChatMessagePublic(t *testing.T) {
 
 		boxer.boxVersionForTesting = &mbVersion
 		boxed, err := boxer.BoxMessage(ctx, msg, chat1.ConversationMembersType_KBFS, signKP)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		_ = boxed
 
 		// need to give it a server header...
@@ -896,19 +856,14 @@ func TestChatMessagePublic(t *testing.T) {
 		}
 
 		decmsg, err := boxer.UnboxMessage(ctx, *boxed, conv)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !decmsg.IsValid() {
-			t.Fatalf("decmsg is not valid")
-		}
+		require.NoError(t, err)
+		require.True(t, decmsg.IsValid())
+
 		body := decmsg.Valid().MessageBody
-		if typ, _ := body.MessageType(); typ != chat1.MessageType_TEXT {
-			t.Errorf("body type: %d, expected %d", typ, chat1.MessageType_TEXT)
-		}
-		if body.Text().Body != text {
-			t.Errorf("body text: %q, expected %q", body.Text().Body, text)
-		}
+		typ, err := body.MessageType()
+		require.NoError(t, err)
+		require.Equal(t, typ, chat1.MessageType_TEXT)
+		require.Equal(t, body.Text().Body, text)
 	})
 }
 
@@ -938,9 +893,7 @@ func TestChatMessageSenderMismatch(t *testing.T) {
 		signKP := getSigningKeyPairForTest(t, tc, u)
 
 		boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, mbVersion, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// need to give it a server header...
 		boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -977,9 +930,8 @@ func TestChatMessageDeletes(t *testing.T) {
 
 		// need a real user
 		u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
 		deleteIDs := []chat1.MessageID{5, 6, 7}
 		msg.MessageBody = chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: deleteIDs})
@@ -989,9 +941,7 @@ func TestChatMessageDeletes(t *testing.T) {
 		signKP := getSigningKeyPairForTest(t, tc, u)
 
 		boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, mbVersion, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// need to give it a server header...
 		boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -1020,17 +970,14 @@ func TestChatMessageDeleted(t *testing.T) {
 
 			// need a real user
 			u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
 
 			signKP := getSigningKeyPairForTest(t, tc, u)
 
 			boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, mbVersion, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			// need to give it a server header...
 			boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -1062,17 +1009,14 @@ func TestChatMessageDeletedNotSuperseded(t *testing.T) {
 
 		// need a real user
 		u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
 
 		signKP := getSigningKeyPairForTest(t, tc, u)
 
 		boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, mbVersion, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// need to give it a server header...
 		boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -1101,9 +1045,8 @@ func TestChatMessageDeleteHistory(t *testing.T) {
 
 	// need a real user
 	u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
 	mdh := chat1.MessageDeleteHistory{Upto: chat1.MessageID(4)}
 	msg.MessageBody = chat1.NewMessageBodyWithDeletehistory(mdh)
@@ -1112,9 +1055,7 @@ func TestChatMessageDeleteHistory(t *testing.T) {
 	signKP := getSigningKeyPairForTest(t, tc, u)
 
 	boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, mbVersion, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// need to give it a server header...
 	boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -1460,9 +1401,7 @@ func TestChatMessageBodyHashReplay(t *testing.T) {
 
 		// need a real user
 		u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signKP := getSigningKeyPairForTest(t, tc, u)
 
@@ -1481,9 +1420,7 @@ func TestChatMessageBodyHashReplay(t *testing.T) {
 			},
 		}
 		boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, mbVersion, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Need to give it a server header...
 		boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -1778,7 +1715,9 @@ func TestExplodingMessageUnbox(t *testing.T) {
 	unboxed, err := boxer.unbox(context.TODO(), *boxed, chat1.ConversationMembersType_TEAM, key, &ephemeralKey)
 	require.NoError(t, err)
 	body := unboxed.MessageBody
-	require.Equal(t, body.MessageType(), chat1.MessageType_TEXT)
+	typ, err := body.MessageType()
+	require.NoError(t, err)
+	require.Equal(t, typ, chat1.MessageType_TEXT)
 	require.Equal(t, body.Text().Body, text)
 	require.Nil(t, unboxed.SenderDeviceRevokedAt, "message should not be from revoked device")
 	require.NotNil(t, unboxed.BodyHash)
@@ -1837,7 +1776,7 @@ func TestVersionError(t *testing.T) {
 		case chat1.MessageUnboxedErrorType_BADVERSION, chat1.MessageUnboxedErrorType_BADVERSION_CRITICAL:
 			// pass
 		default:
-			t.Fatalf("invalid error type (%s) for error: %s", typ, err.Error())
+			require.Fail(t, "invalid error type (%s) for error: %s", typ, err.Error())
 		}
 
 		e := chat1.MessageUnboxedError{

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -598,8 +598,8 @@ func GetTopicNameState(ctx context.Context, g *globals.Context, debugger utils.D
 			continue
 		}
 		if !msg.IsValid() {
-			debugger.Debug(ctx, "GetTopicNameState: skipping convID: %s, invalid metadata message",
-				conv.GetConvID())
+			debugger.Debug(ctx, "GetTopicNameState: skipping convID: %s, invalid metadata message: %v",
+				conv.GetConvID(), msg.DebugString())
 			continue
 		}
 		pairs.Pairs = append(pairs.Pairs, chat1.ConversationIDMessageIDPair{

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -176,11 +176,12 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 	chatUI := h.getChatUI(arg.SessionID)
 	localizeCb := make(chan NonblockInboxResult, 1)
 
-	// Invoke nonblocking inbox read and get remote inbox version to send back as our result
+	// Invoke nonblocking inbox read and get remote inbox version to send back
+	// as our result
 	localizer := NewNonblockingLocalizer(h.G(), localizeCb, arg.MaxUnbox)
-	_, err = h.G().InboxSource.Read(ctx, uid.ToBytes(), localizer, true, arg.Query, arg.Pagination)
-	if err != nil {
-		// If this is a convID based query, let's go ahead and drop those onto the retrier
+	if _, err = h.G().InboxSource.Read(ctx, uid.ToBytes(), localizer, true, arg.Query, arg.Pagination); err != nil {
+		// If this is a convID based query, let's go ahead and drop those onto
+		// the retrier
 		if arg.Query != nil && len(arg.Query.ConvIDs) > 0 {
 			h.Debug(ctx, "GetInboxNonblockLocal: failed to get unverified inbox, marking convIDs as failed")
 			for _, convID := range arg.Query.ConvIDs {

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -452,7 +452,7 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 	for _, msg := range msgs {
 		msgid := msg.GetMessageID()
 		if !msg.IsValid() {
-			s.Debug(ctx, "updateSupersededBy: skipping potential superseder marked as error: %d", msgid)
+			s.Debug(ctx, "updateSupersededBy: skipping potential superseder marked as not valid: %v", msg.DebugString())
 			continue
 		}
 
@@ -556,7 +556,7 @@ func (s *Storage) updateMinDeletableMessage(ctx context.Context, convID chat1.Co
 	for _, msg := range msgs {
 		msgid := msg.GetMessageID()
 		if !msg.IsValid() {
-			de("skipping message marked as error: %d", msgid)
+			de("skipping message marked as not valid: %v", msg.DebugString())
 			continue
 		}
 		if !chat1.IsDeletableByDeleteHistory(msg.GetMessageType()) {
@@ -611,7 +611,7 @@ func (s *Storage) handleDeleteHistory(ctx context.Context, convID chat1.Conversa
 	for _, msg := range msgs {
 		msgid := msg.GetMessageID()
 		if !msg.IsValid() {
-			de("skipping message marked as error: %d", msgid)
+			de("skipping message marked as not valid: %v", msg.DebugString())
 			continue
 		}
 		if msg.GetMessageType() != chat1.MessageType_DELETEHISTORY {
@@ -713,7 +713,7 @@ func (s *Storage) applyExpunge(ctx context.Context, convID chat1.ConversationID,
 			continue
 		}
 		if !msg.IsValid() {
-			de("skipping invalid msg: %v", msg.GetMessageID())
+			de("skipping invalid msg: %v", msg.DebugString())
 			continue
 		}
 		mvalid := msg.Valid()


### PR DESCRIPTION
changes the return signature for  `boxer.UnboxMessage` so we don't return errors but instead put the message in the thread with a `TRANSIENT` error type. `GetThreadNonblockLocal` and `ConversationRetry` then scan the thread for any transient errors so we know if we need to fetch/refetch the thread. this change gives us the benefit of no blackbars with retry for the broken messages.

Are there any other places we should attempt a retry? should we do the same for the `FullInboxRetry`? In particular `UnboxMessages` *wont* return an error for failed unboxing where it would before, not sure if there are any other relevant callers to attempt a retry.

cc @keybase/react-hackers i could use an assist here with formatting the error message. currently these failures look like: 
<img width="280" alt="screen shot 2018-08-29 at 5 55 48 pm" src="https://user-images.githubusercontent.com/1144020/44818099-c1950800-abb5-11e8-975e-eed6269dd538.png">
I'd like it just to say the error message without the `Failure to send:` or `Cancel`/`Retry` buttons but was having some trouble tracing how to thread this through correctly