### PR TITLE
Reselect conversation when leaving a team

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1469,12 +1469,13 @@ const _maybeAutoselectNewestConversation = (
   state: TypedState
 ) => {
   const selected = Constants.getSelectedConversation(state)
+  const selectedExists = Constants.isExistingSelectedConversation(state)
   if (action.type === Chat2Gen.metaDelete) {
     if (!action.payload.selectSomethingElse) {
       return
     }
     // only do this if we blocked the current conversation
-    if (selected !== action.payload.conversationIDKey) {
+    if (selectedExists && selected !== action.payload.conversationIDKey) {
       return
     }
     // only select something if we're leaving a pending conversation
@@ -1486,26 +1487,13 @@ const _maybeAutoselectNewestConversation = (
 
   if (action.type === Chat2Gen.metasReceived) {
     // If we have new activity, don't switch to it unless no convo was selected
-    if (selected !== Constants.noConversationIDKey) {
+    if (selectedExists && selected !== Constants.noConversationIDKey) {
       return
     }
   } else if (action.type === Chat2Gen.setPendingMode) {
-    if (Constants.isValidConversationIDKey(selected)) {
+    if (selectedExists && Constants.isValidConversationIDKey(selected)) {
       return
     }
-  } else if (
-    action.type === TeamsGen.leaveTeam ||
-    (action.type === Chat2Gen.leaveConversation ||
-      (action.type === Chat2Gen.blockConversation && action.payload.conversationIDKey === selected))
-  ) {
-    // Intentional fall-through -- force select a new one
-  } else if (
-    Constants.isValidConversationIDKey(selected) &&
-    !action.payload.findNewConversation &&
-    !action.payload.selectSomethingElse
-  ) {
-    // Stay with our existing convo if it was not empty or pending
-    return
   }
 
   // If we got here we're auto selecting the newest convo

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1494,8 +1494,9 @@ const _maybeAutoselectNewestConversation = (
       return
     }
   } else if (
-    (action.type === Chat2Gen.leaveConversation || action.type === Chat2Gen.blockConversation) &&
-    action.payload.conversationIDKey === selected
+    action.type === TeamsGen.leaveTeam ||
+    (action.type === Chat2Gen.leaveConversation ||
+      (action.type === Chat2Gen.blockConversation && action.payload.conversationIDKey === selected))
   ) {
     // Intentional fall-through -- force select a new one
   } else if (

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1468,14 +1468,16 @@ const _maybeAutoselectNewestConversation = (
     | TeamsGen.LeaveTeamPayload,
   state: TypedState
 ) => {
-  const selected = Constants.getSelectedConversation(state)
-  const selectedExists = Constants.isExistingSelectedConversation(state)
+  let selected = Constants.getSelectedConversation(state)
+  if (!state.chat2.metaMap.get(selected)) {
+    selected = Constants.noConversationIDKey
+  }
   if (action.type === Chat2Gen.metaDelete) {
     if (!action.payload.selectSomethingElse) {
       return
     }
     // only do this if we blocked the current conversation
-    if (selectedExists && selected !== action.payload.conversationIDKey) {
+    if (selected !== action.payload.conversationIDKey) {
       return
     }
     // only select something if we're leaving a pending conversation
@@ -1487,11 +1489,11 @@ const _maybeAutoselectNewestConversation = (
 
   if (action.type === Chat2Gen.metasReceived) {
     // If we have new activity, don't switch to it unless no convo was selected
-    if (selectedExists && selected !== Constants.noConversationIDKey) {
+    if (selected !== Constants.noConversationIDKey) {
       return
     }
   } else if (action.type === Chat2Gen.setPendingMode) {
-    if (selectedExists && Constants.isValidConversationIDKey(selected)) {
+    if (Constants.isValidConversationIDKey(selected)) {
       return
     }
   }

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -68,9 +68,6 @@ export const getHasUnread = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.unreadMap.get(id, 0) > 0
 export const getSelectedConversation = (state: TypedState) => state.chat2.selectedConversation
 
-export const isExistingSelectedConversation = (state: TypedState) =>
-  !!state.chat2.metaMap.get(state.chat2.selectedConversation)
-
 export const getEditInfo = (state: TypedState, id: Types.ConversationIDKey) => {
   const ordinal = state.chat2.editingMap.get(id)
   if (!ordinal) {

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -68,6 +68,9 @@ export const getHasUnread = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.unreadMap.get(id, 0) > 0
 export const getSelectedConversation = (state: TypedState) => state.chat2.selectedConversation
 
+export const isExistingSelectedConversation = (state: TypedState) =>
+  !!state.chat2.metaMap.get(state.chat2.selectedConversation)
+
 export const getEditInfo = (state: TypedState, id: Types.ConversationIDKey) => {
   const ordinal = state.chat2.editingMap.get(id)
   if (!ordinal) {


### PR DESCRIPTION
This prevents the currently selected team conversation from being stuck in the thread view, much in the same way that #13458 handled reselecting after a blocked conversation.

The fix is to always reselect after leaving a team, which we did not do before because the fall-through logic was not true. Instead we bailed early because the currently selected conversation (now old as the user has left the team), was valid and we skipped re-selection.