### PR TITLE
use keybase pub for electron downloads

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -437,19 +437,6 @@ If you get this error message on trying to open the inspector:
 
 It might be because you're importing a library that attaches itself as a renderer, such as `react-dom`. If that's the case, you should make sure not to import any such module outside of a `.desktop.js` file, and if you have to, it should be predicated on `!isMobile` and use `require` to access the library.
 
-### Dependency forks
-
-We have some custom forks of dependencies. This is usually a temporary fix and is something we want to avoid long term.
-
-- react-navigation:
-  - Keep queued transitions, fixes races with dragging and touches
-  - Increase interactivity threshold so you can click while things are still animating
-- electron-download
-  - Add a force-use-cache option so we don't download all the time
-- react-native-push-notification
-  - 1 liner to add RN 0.47 support
-
-
 ### Updating `react-native`
 
 Take a look at [this repo](https://github.com/ncuillery/rn-diff), which contains branches for every version of react native. For example, this URL
@@ -457,3 +444,8 @@ Take a look at [this repo](https://github.com/ncuillery/rn-diff), which contains
  `https://github.com/ncuillery/rn-diff/compare/rn-0.51.0...rn-0.53.0`
 
  generates the diff between RN versions in a bare RN app. Use this to figure out if any configuration changes are needed. If the target version isn't in `rn-diff` yet, there'll usually be a fork that has it.
+
+
+### Updating `electron`
+
+We host the electron binaries in keybase.pub. If you update versions upload new binaries and SHASUM256.txt similar to https://keybase.pub/kbelectron/electron-download/v2.0.8/

--- a/shared/README.md
+++ b/shared/README.md
@@ -448,4 +448,4 @@ Take a look at [this repo](https://github.com/ncuillery/rn-diff), which contains
 
 ### Updating `electron`
 
-We host the electron binaries in keybase.pub. If you update versions copy files from https://github.com/electron/electron/releases/ to https://keybase.pub/kbelectron/electron-download/v{version}. Make sure to get the SHASUM256.txt file also
+We host the electron binaries used for our build process in keybase.pub. If you update versions copy files from https://github.com/electron/electron/releases/ to https://keybase.pub/kbelectron/electron-download/v{version}. Make sure to get the SHASUM256.txt file also. This only affects the build machines

--- a/shared/README.md
+++ b/shared/README.md
@@ -448,4 +448,4 @@ Take a look at [this repo](https://github.com/ncuillery/rn-diff), which contains
 
 ### Updating `electron`
 
-We host the electron binaries in keybase.pub. If you update versions upload new binaries and SHASUM256.txt similar to https://keybase.pub/kbelectron/electron-download/v2.0.8/
+We host the electron binaries in keybase.pub. If you update versions copy files from https://github.com/electron/electron/releases/ to https://keybase.pub/kbelectron/electron-download/v{version}. Make sure to get the SHASUM256.txt file also

--- a/shared/package.json
+++ b/shared/package.json
@@ -117,6 +117,9 @@
       "__STORYSHOT__": true
     }
   },
+  "config": {
+    "electron_mirror": "https://kbelectron.keybase.pub/electron-download/v"
+  },
   "keywords": [],
   "author": "",
   "license": "MIT",
@@ -205,7 +208,6 @@
     "del": "3.0.0",
     "devtron": "1.4.0",
     "electron": "2.0.8",
-    "electron-download": "git://github.com/keybase/electron-download#keybase-fixes-off-410",
     "electron-packager": "12.1.1",
     "eslint": "5.3.0",
     "eslint-config-standard": "12.0.0-alpha.0",

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -5087,20 +5087,6 @@ electron-download@^4.1.1:
     semver "^5.4.1"
     sumchecker "^2.0.2"
 
-"electron-download@git://github.com/keybase/electron-download#keybase-fixes-off-410":
-  version "4.1.0"
-  resolved "git://github.com/keybase/electron-download#a6e678202363d73214909b537ce5663bfdf0c175"
-  dependencies:
-    debug "^2.2.0"
-    env-paths "^1.0.0"
-    fs-extra "^2.0.0"
-    minimist "^1.2.0"
-    nugget "^2.0.0"
-    path-exists "^3.0.0"
-    rc "^1.1.2"
-    semver "^5.3.0"
-    sumchecker "^2.0.1"
-
 electron-osx-sign@^0.4.1:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.4.7.tgz#1d75647a82748eacd48bea70616ec83ffade3ee5"
@@ -6331,13 +6317,6 @@ fs-extra@^1.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
     klaw "^1.0.0"
-
-fs-extra@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
 
 fs-extra@^4.0.0:
   version "4.0.2"
@@ -13057,7 +13036,7 @@ sumchecker@^1.2.0:
     debug "^2.2.0"
     es6-promise "^4.0.5"
 
-sumchecker@^2.0.1, sumchecker@^2.0.2:
+sumchecker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-2.0.2.tgz#0f42c10e5d05da5d42eea3e56c3399a37d6c5b3e"
   dependencies:


### PR DESCRIPTION
@keybase/react-hackers this removes our electron-download fork and makes the packager use our own mirror for electron downloads