### PR TITLE
first implementation of the teamchain auditor

### DIFF
--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -168,6 +168,7 @@ const (
 	DBTeamChain         = 0x10
 	DBUserPlusAllKeysV1 = 0x19
 
+	DBTeamAuditor              = 0xce
 	DBAttachmentUploader       = 0xcf
 	DBDiskLRUEntries           = 0xda
 	DBDiskLRUIndex             = 0xdb

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -626,6 +626,11 @@ type FastTeamLoader interface {
 	OnLogout()
 }
 
+type TeamAuditor interface {
+	AuditTeam(m MetaContext, id keybase1.TeamID, isPublic bool, headMerkle keybase1.MerkleRootV2, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno) (err error)
+	OnLogout()
+}
+
 type Stellar interface {
 	OnLogout()
 	CreateWalletGated(context.Context) error

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -72,3 +72,15 @@ func (n nullFastTeamLoader) Load(MetaContext, keybase1.FastTeamLoadArg) (keybase
 func (n nullFastTeamLoader) OnLogout() {}
 
 func newNullFastTeamLoader() nullFastTeamLoader { return nullFastTeamLoader{} }
+
+type nullTeamAuditor struct{}
+
+var _ TeamAuditor = nullTeamAuditor{}
+
+func (n nullTeamAuditor) AuditTeam(m MetaContext, id keybase1.TeamID, isPublic bool, headMerkle keybase1.MerkleRootV2, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno) (err error) {
+	return fmt.Errorf("null team auditor")
+}
+
+func (n nullTeamAuditor) OnLogout() {}
+
+func newNullTeamAuditor() nullTeamAuditor { return nullTeamAuditor{} }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -737,6 +737,7 @@ type FastTeamSigChainState struct {
 	LastUpPointer           *UpPointer                              `codec:"lastUpPointer,omitempty" json:"lastUpPointer,omitempty"`
 	PerTeamKeyCTime         UnixTime                                `codec:"perTeamKeyCTime" json:"perTeamKeyCTime"`
 	LinkIDs                 map[Seqno]LinkID                        `codec:"linkIDs" json:"linkIDs"`
+	MerkleInfo              map[Seqno]MerkleRootV2                  `codec:"merkleInfo" json:"merkleInfo"`
 }
 
 func (o FastTeamSigChainState) DeepCopy() FastTeamSigChainState {
@@ -808,6 +809,98 @@ func (o FastTeamSigChainState) DeepCopy() FastTeamSigChainState {
 			}
 			return ret
 		})(o.LinkIDs),
+		MerkleInfo: (func(x map[Seqno]MerkleRootV2) map[Seqno]MerkleRootV2 {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[Seqno]MerkleRootV2, len(x))
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := v.DeepCopy()
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.MerkleInfo),
+	}
+}
+
+type Audit struct {
+	Time           Time  `codec:"time" json:"time"`
+	MaxMerkleSeqno Seqno `codec:"maxMerkleSeqno" json:"maxMerkleSeqno"`
+	MaxChainSeqno  Seqno `codec:"maxChainSeqno" json:"maxChainSeqno"`
+	MaxMerkleProbe Seqno `codec:"maxMerkleProbe" json:"maxMerkleProbe"`
+}
+
+func (o Audit) DeepCopy() Audit {
+	return Audit{
+		Time:           o.Time.DeepCopy(),
+		MaxMerkleSeqno: o.MaxMerkleSeqno.DeepCopy(),
+		MaxChainSeqno:  o.MaxChainSeqno.DeepCopy(),
+		MaxMerkleProbe: o.MaxMerkleProbe.DeepCopy(),
+	}
+}
+
+type Probe struct {
+	Index     int   `codec:"i" json:"index"`
+	TeamSeqno Seqno `codec:"s" json:"teamSeqno"`
+}
+
+func (o Probe) DeepCopy() Probe {
+	return Probe{
+		Index:     o.Index,
+		TeamSeqno: o.TeamSeqno.DeepCopy(),
+	}
+}
+
+type AuditHistory struct {
+	ID               TeamID          `codec:"ID" json:"ID"`
+	Public           bool            `codec:"public" json:"public"`
+	PriorMerkleSeqno Seqno           `codec:"priorMerkleSeqno" json:"priorMerkleSeqno"`
+	Audits           []Audit         `codec:"audits" json:"audits"`
+	PreProbes        map[Seqno]Probe `codec:"preProbes" json:"preProbes"`
+	PostProbes       map[Seqno]Probe `codec:"postProbes" json:"postProbes"`
+}
+
+func (o AuditHistory) DeepCopy() AuditHistory {
+	return AuditHistory{
+		ID:               o.ID.DeepCopy(),
+		Public:           o.Public,
+		PriorMerkleSeqno: o.PriorMerkleSeqno.DeepCopy(),
+		Audits: (func(x []Audit) []Audit {
+			if x == nil {
+				return nil
+			}
+			ret := make([]Audit, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.Audits),
+		PreProbes: (func(x map[Seqno]Probe) map[Seqno]Probe {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[Seqno]Probe, len(x))
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := v.DeepCopy()
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.PreProbes),
+		PostProbes: (func(x map[Seqno]Probe) map[Seqno]Probe {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[Seqno]Probe, len(x))
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := v.DeepCopy()
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.PostProbes),
 	}
 }
 

--- a/go/teams/audit.go
+++ b/go/teams/audit.go
@@ -1,15 +1,409 @@
 package teams
 
 import (
-	"errors"
+	"crypto/rand"
+	"fmt"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/pipeliner"
+	"math/big"
+	"sort"
+	"sync"
+	"time"
 )
+
+type AuditParams struct {
+	RootFreshness         time.Duration
+	MerkleMovementTrigger keybase1.Seqno
+	NumPreProbes          int
+	NumPostProbes         int
+	Parallelism           int
+}
+
+var params = AuditParams{
+	RootFreshness:         time.Minute,
+	MerkleMovementTrigger: keybase1.Seqno(1000),
+	NumPreProbes:          25,
+	NumPostProbes:         25,
+	Parallelism:           4,
+}
+
+type Auditor struct {
+
+	// single-flight lock on TeamID
+	locktab libkb.LockTable
+
+	// Map of TeamID -> AuditHistory
+	// The LRU is protected by a mutex, because it's swapped out on logout.
+	lruMutex sync.Mutex
+	lru      *lru.Cache
+}
+
+// NewAuditor makes a new auditor
+func NewAuditor() *Auditor {
+	ret := &Auditor{}
+	ret.newLRU()
+	return ret
+}
+
+// NewAuditorAndInstall makes a new Auditor and dangles it
+// off of the given GlobalContext.
+func NewAuditorAndInstall(g *libkb.GlobalContext) *Auditor {
+	a := NewAuditor()
+	g.SetTeamAuditor(a)
+	return a
+}
 
 // ProbabilisticMerkleTeamAudit runs an audit on the links of the given team chain (or subchain).
 // The security factor of the audit is a function of the platform type, and the amount of time
 // since the last audit. This method should use some sort of long-lived cache (via local DB) so that
 // previous audits can be combined with the current one.
-func ProbabilisticMerkleTeamAudit(m libkb.MetaContext, id keybase1.TeamID, startMerkleSeqno keybase1.Seqno, chain []SCChainLink) (err error) {
-	return errors.New("stubbed out")
+func (a *Auditor) AuditTeam(m libkb.MetaContext, id keybase1.TeamID, isPublic bool, headMerkle keybase1.MerkleRootV2, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno) (err error) {
+
+	m = m.WithLogTag("AUDIT")
+	defer m.CTrace(fmt.Sprintf("Auditor#AuditTeam(%+v)", id), func() error { return err })()
+
+	if id.IsPublic() != isPublic {
+		return NewBadPublicError(id, isPublic)
+	}
+
+	// Single-flight lock by team ID.
+	lock := a.locktab.AcquireOnName(m.Ctx(), m.G(), id.String())
+	defer lock.Release(m.Ctx())
+
+	return a.auditLocked(m, id, headMerkle, chain, maxSeqno)
+}
+
+func (a *Auditor) getLRU() *lru.Cache {
+	a.lruMutex.Lock()
+	defer a.lruMutex.Unlock()
+	return a.lru
+}
+
+func (a *Auditor) getFromLRU(m libkb.MetaContext, id keybase1.TeamID, lru *lru.Cache) *keybase1.AuditHistory {
+	tmp, found := lru.Get(id)
+	if !found {
+		return nil
+	}
+	ret, ok := tmp.(*keybase1.AuditHistory)
+	if !ok {
+		m.CErrorf("Bad type assertion in Auditor#getFromLRU")
+		return nil
+	}
+	return ret
+}
+
+func (a *Auditor) getFromDisk(m libkb.MetaContext, id keybase1.TeamID) (*keybase1.AuditHistory, error) {
+	var ret keybase1.AuditHistory
+	found, err := m.G().LocalDb.GetInto(&ret, libkb.DbKey{Typ: libkb.DBTeamAuditor, Key: string(id)})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	return &ret, nil
+}
+
+func (a *Auditor) getFromCache(m libkb.MetaContext, id keybase1.TeamID, lru *lru.Cache) (*keybase1.AuditHistory, error) {
+
+	ret := a.getFromLRU(m, id, lru)
+	if ret != nil {
+		return ret, nil
+	}
+	ret, err := a.getFromDisk(m, id)
+	return ret, err
+}
+
+func (a *Auditor) putToCache(m libkb.MetaContext, id keybase1.TeamID, lru *lru.Cache, h *keybase1.AuditHistory) (err error) {
+	lru.Add(id, h)
+	err = m.G().LocalDb.PutObj(libkb.DbKey{Typ: libkb.DBTeamAuditor, Key: string(id)}, nil, *h)
+	return err
+}
+
+func (a *Auditor) checkRecent(m libkb.MetaContext, history *keybase1.AuditHistory, root *libkb.MerkleRoot) bool {
+	if root == nil {
+		m.CDebugf("no recent known merkle root in checkRecent")
+		return false
+	}
+	last := lastAudit(history)
+	if last == nil {
+		m.CDebugf("no recent audits")
+		return false
+	}
+	diff := *root.Seqno() - last.MaxMerkleSeqno
+	if diff >= params.MerkleMovementTrigger {
+		m.CDebugf("previous merkle audit was %v ago", diff)
+		return false
+	}
+	return true
+}
+
+func lastAudit(h *keybase1.AuditHistory) *keybase1.Audit {
+	if h == nil {
+		return nil
+	}
+	if len(h.Audits) == 0 {
+		return nil
+	}
+	ret := h.Audits[len(h.Audits)-1]
+	return &ret
+}
+
+func makeHistory(history *keybase1.AuditHistory, id keybase1.TeamID) *keybase1.AuditHistory {
+	if history == nil {
+		return &keybase1.AuditHistory{
+			ID:         id,
+			Public:     id.IsPublic(),
+			PreProbes:  make(map[keybase1.Seqno]keybase1.Probe),
+			PostProbes: make(map[keybase1.Seqno]keybase1.Probe),
+		}
+	}
+	ret := history.DeepCopy()
+	return &ret
+}
+
+func (a *Auditor) doPostProbes(m libkb.MetaContext, history *keybase1.AuditHistory, probeId int, headMerkle keybase1.MerkleRootV2, latestMerkleSeqno keybase1.Seqno, chain map[keybase1.Seqno]keybase1.LinkID, maxChainSeqno keybase1.Seqno) (maxMerkleProbe keybase1.Seqno, err error) {
+	defer m.CTrace("Auditor#doPostProbes", func() error { return err })()
+
+	var low keybase1.Seqno
+	last := lastAudit(history)
+	var prev *probeTuple
+	if last == nil {
+		low = headMerkle.Seqno
+	} else {
+		low = last.MaxMerkleSeqno
+		probe, ok := history.PostProbes[last.MaxMerkleProbe]
+		if !ok {
+			return maxMerkleProbe, NewAuditError("previous audit pointed to a bogus probe (seqno=%d)", last.MaxMerkleProbe)
+		}
+		prev = &probeTuple{
+			merkle: last.MaxMerkleProbe,
+			team:   probe.TeamSeqno,
+			// leave linkID nil, it's not needed...
+		}
+	}
+
+	probeTuples, err := a.computeProbes(m, history.ID, history.PostProbes, probeId, low, latestMerkleSeqno, 0, params.NumPostProbes)
+	if err != nil {
+		return maxMerkleProbe, err
+	}
+	if len(probeTuples) == 0 {
+		m.CDebugf("No probe tuples, so bailing")
+		return maxMerkleProbe, nil
+	}
+
+	for _, tuple := range probeTuples {
+		m.CDebugf("postProbe: checking probe at %+v", tuple)
+		if tuple.team > keybase1.Seqno(0) {
+			expectedLinkID, ok := chain[tuple.team]
+			if !ok {
+				return maxMerkleProbe, NewAuditError("team chain doesn't have a link for seqno %d, but expected one", tuple.team)
+			}
+			if !expectedLinkID.Eq(tuple.linkID) {
+				return maxMerkleProbe, NewAuditError("team chain linkID mismatch at %d: wanted %s but got %s via merkle seqno %d", tuple.team, expectedLinkID, tuple.linkID, tuple.merkle)
+			}
+		}
+		history.PostProbes[tuple.merkle] = keybase1.Probe{Index: probeId, TeamSeqno: tuple.team}
+		if prev != nil && prev.team > tuple.team {
+			return maxMerkleProbe, NewAuditError("team chain unexpected jump: %d > %d via merkle seqno %d", prev.team, tuple.team, tuple.merkle)
+		}
+		if tuple.merkle > maxMerkleProbe {
+			maxMerkleProbe = tuple.merkle
+		}
+		prev = &tuple
+	}
+	return maxMerkleProbe, nil
+}
+
+func (a *Auditor) doPreProbes(m libkb.MetaContext, history *keybase1.AuditHistory, probeId int, headMerkle keybase1.MerkleRootV2) (err error) {
+	defer m.CTrace("Auditor#doPreProbes", func() error { return err })()
+
+	first := m.G().MerkleClient.FirstSeqnoWithSkips(m)
+	if first == nil {
+		return NewAuditError("cannot find a first modern merkle sequence")
+	}
+
+	probeTuples, err := a.computeProbes(m, history.ID, history.PreProbes, probeId, *first, headMerkle.Seqno, len(history.PreProbes), params.NumPreProbes)
+	if err != nil {
+		return err
+	}
+	if len(probeTuples) == 0 {
+		m.CDebugf("No probe pairs, so bailing")
+		return nil
+	}
+	for _, tuple := range probeTuples {
+		m.CDebugf("preProbe: checking probe at merkle %d", tuple.merkle)
+		if tuple.team != keybase1.Seqno(0) || !tuple.linkID.IsNil() {
+			return NewAuditError("merkle root at %v should have been nil for %v; got %s/%d",
+				tuple.merkle, history.ID, tuple.linkID, tuple.team)
+		}
+	}
+	return nil
+}
+
+func randSeqno(lo keybase1.Seqno, hi keybase1.Seqno) (keybase1.Seqno, error) {
+	rng := hi - lo + 1
+	rngBig := big.NewInt(int64(rng))
+	n, err := rand.Int(rand.Reader, rngBig)
+	if err != nil {
+		return keybase1.Seqno(0), err
+	}
+	return keybase1.Seqno(n.Int64()) + lo, nil
+}
+
+type probeTuple struct {
+	merkle keybase1.Seqno
+	team   keybase1.Seqno
+	linkID keybase1.LinkID
+}
+
+func (a *Auditor) computeProbes(m libkb.MetaContext, teamID keybase1.TeamID, probes map[keybase1.Seqno]keybase1.Probe, probeId int, left keybase1.Seqno, right keybase1.Seqno, probesInRange int, n int) (ret []probeTuple, err error) {
+	ret, err = a.scheduleProbes(m, probes, probeId, left, right, probesInRange, n)
+	if err != nil {
+		return nil, err
+	}
+	err = a.lookupProbes(m, teamID, ret)
+	if err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (a *Auditor) scheduleProbes(m libkb.MetaContext, probes map[keybase1.Seqno]keybase1.Probe, probeId int, left keybase1.Seqno, right keybase1.Seqno, probesInRange int, n int) (ret []probeTuple, err error) {
+	defer m.CTrace(fmt.Sprintf("Auditor#scheduleProbes(left=%d,right=%d)", left, right), func() error { return err })()
+	if probesInRange > n {
+		m.CDebugf("no more probes needed; did %d, wanted %d", probesInRange, n)
+		return nil, nil
+	}
+	rng := right - left + 1
+	if int(rng) <= probesInRange {
+		m.CDebugf("no more probes needed; range was only %d, and we did %d", rng, probesInRange)
+		return nil, nil
+	}
+	for i := 0; i < n; i++ {
+		x, err := randSeqno(left, right)
+		if err != nil {
+			return nil, err
+		}
+		if _, found := probes[x]; !found {
+			ret = append(ret, probeTuple{merkle: x})
+			probes[x] = keybase1.Probe{Index: probeId}
+		}
+	}
+	sort.SliceStable(ret, func(i, j int) bool {
+		return ret[i].merkle < ret[j].merkle
+	})
+	m.CDebugf("scheduled probes: %+v", ret)
+	return ret, nil
+}
+
+func (a *Auditor) lookupProbe(m libkb.MetaContext, teamID keybase1.TeamID, probe *probeTuple) (err error) {
+	defer m.CTrace(fmt.Sprintf("Auditor#lookupProbe(%v,%v)", teamID, *probe), func() error { return err })()
+	leaf, _, err := m.G().MerkleClient.LookupLeafAtSeqnoForAudit(m, teamID.AsUserOrTeam(), probe.merkle)
+	if err != nil {
+		return err
+	}
+	if leaf == nil || leaf.Private == nil {
+		m.CDebugf("nil leaf at %v/%v", teamID, probe.merkle)
+		return nil
+	}
+	probe.team = leaf.Private.Seqno
+	if leaf.Private.LinkID != nil {
+		probe.linkID = leaf.Private.LinkID.Export()
+	}
+	return nil
+}
+
+func (a *Auditor) lookupProbes(m libkb.MetaContext, teamID keybase1.TeamID, tuples []probeTuple) (err error) {
+	pipeliner := pipeliner.NewPipeliner(params.Parallelism)
+	for i := range tuples {
+		if err = pipeliner.WaitForRoom(m.Ctx()); err != nil {
+			return err
+		}
+		go func(probe *probeTuple) {
+			err := a.lookupProbe(m, teamID, probe)
+			pipeliner.CompleteOne(err)
+		}(&tuples[i])
+	}
+	err = pipeliner.Flush(m.Ctx())
+	return err
+}
+
+func (a *Auditor) auditLocked(m libkb.MetaContext, id keybase1.TeamID, headMerkle keybase1.MerkleRootV2, chain map[keybase1.Seqno]keybase1.LinkID, maxChainSeqno keybase1.Seqno) (err error) {
+
+	defer m.CTrace(fmt.Sprintf("Auditor#auditLocked(%v)", id), func() error { return err })()
+
+	lru := a.getLRU()
+
+	history, err := a.getFromCache(m, id, lru)
+	if err != nil {
+		return err
+	}
+
+	last := lastAudit(history)
+	if last != nil && last.MaxChainSeqno == maxChainSeqno {
+		m.CDebugf("Short-circuit audit, since there is no new data (@%v)", maxChainSeqno)
+		return nil
+	}
+
+	root, err := m.G().MerkleClient.FetchRootFromServerByFreshness(m, params.RootFreshness)
+	if err != nil {
+		return err
+	}
+
+	if history != nil && a.checkRecent(m, history, root) {
+		m.CDebugf("cached audit was recent; short-circuiting")
+		return nil
+	}
+
+	history = makeHistory(history, id)
+
+	newAuditIndex := len(history.Audits)
+
+	err = a.doPreProbes(m, history, newAuditIndex, headMerkle)
+	if err != nil {
+		return err
+	}
+
+	maxMerkleProbe, err := a.doPostProbes(m, history, newAuditIndex, headMerkle, *root.Seqno(), chain, maxChainSeqno)
+	if err != nil {
+		return err
+	}
+	audit := keybase1.Audit{
+		Time:           keybase1.ToTime(m.G().Clock().Now()),
+		MaxMerkleSeqno: *root.Seqno(),
+		MaxChainSeqno:  maxChainSeqno,
+		MaxMerkleProbe: maxMerkleProbe,
+	}
+	history.Audits = append(history.Audits, audit)
+	history.PriorMerkleSeqno = headMerkle.Seqno
+
+	err = a.putToCache(m, id, lru, history)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *Auditor) newLRU() {
+
+	a.lruMutex.Lock()
+	defer a.lruMutex.Unlock()
+
+	if a.lru != nil {
+		a.lru.Purge()
+	}
+
+	// TODO - make this configurable
+	lru, err := lru.New(10000)
+	if err != nil {
+		panic(err)
+	}
+	a.lru = lru
+}
+
+func (a *Auditor) OnLogout() {
+	a.newLRU()
 }

--- a/go/teams/audit.go
+++ b/go/teams/audit.go
@@ -55,7 +55,7 @@ func NewAuditorAndInstall(g *libkb.GlobalContext) *Auditor {
 	return a
 }
 
-// AuditTeam runs an audit on the links of the given team chain (or subchain).
+// AuditTeam runs an audit on the links of the given team chain (or team chain suffix).
 // The security factor of the audit is a function of the hardcoded parameters above,
 // and the amount of time since the last audit. This method should use some sort of
 // long-lived cache (via local DB) so that previous audits can be combined with the

--- a/go/teams/audit.go
+++ b/go/teams/audit.go
@@ -55,10 +55,13 @@ func NewAuditorAndInstall(g *libkb.GlobalContext) *Auditor {
 	return a
 }
 
-// ProbabilisticMerkleTeamAudit runs an audit on the links of the given team chain (or subchain).
-// The security factor of the audit is a function of the platform type, and the amount of time
-// since the last audit. This method should use some sort of long-lived cache (via local DB) so that
-// previous audits can be combined with the current one.
+// AuditTeam runs an audit on the links of the given team chain (or subchain).
+// The security factor of the audit is a function of the hardcoded parameters above,
+// and the amount of time since the last audit. This method should use some sort of
+// long-lived cache (via local DB) so that previous audits can be combined with the
+// current one. headMerkle is is the Merkle Root claimed in the head of the team.
+// maxSeqno is the maximum seqno of the chainLinks passed; that is, the highest
+// Seqno for which chain[s] is defined.
 func (a *Auditor) AuditTeam(m libkb.MetaContext, id keybase1.TeamID, isPublic bool, headMerkle keybase1.MerkleRootV2, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno) (err error) {
 
 	m = m.WithLogTag("AUDIT")

--- a/go/teams/audit.go
+++ b/go/teams/audit.go
@@ -19,6 +19,7 @@ type AuditParams struct {
 	NumPreProbes          int
 	NumPostProbes         int
 	Parallelism           int
+	LRUSize               int
 }
 
 var params = AuditParams{
@@ -27,6 +28,7 @@ var params = AuditParams{
 	NumPreProbes:          25,
 	NumPostProbes:         25,
 	Parallelism:           4,
+	LRUSize:               10000,
 }
 
 type Auditor struct {
@@ -399,8 +401,7 @@ func (a *Auditor) newLRU() {
 		a.lru.Purge()
 	}
 
-	// TODO - make this configurable
-	lru, err := lru.New(10000)
+	lru, err := lru.New(params.LRUSize)
 	if err != nil {
 		panic(err)
 	}

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -429,3 +429,15 @@ func NewBadPublicError(id keybase1.TeamID, isPublic bool) error {
 func (e BadPublicError) Error() string {
 	return fmt.Sprintf("Public bit for team %s is wrong (%v)", e.id, e.isPublic)
 }
+
+type AuditError struct {
+	Msg string
+}
+
+func NewAuditError(format string, args ...interface{}) error {
+	return FastLoadError{Msg: fmt.Sprintf(format, args...)}
+}
+
+func (e AuditError) Error() string {
+	return fmt.Sprintf("Audit error: %s", e.Msg)
+}

--- a/go/teams/ftl.go
+++ b/go/teams/ftl.go
@@ -731,7 +731,6 @@ func (f *FastTeamChainLoader) checkPrevs(m libkb.MetaContext, last *keybase1.Lin
 
 // audit runs probabilistic merkle tree audit on the new links, to make sure that the server isn't
 // running odd-even-style attacks against members in a group.
-// TODO, see CORE-8466
 func (f *FastTeamChainLoader) audit(m libkb.MetaContext, arg fastLoadArg, state *keybase1.FastTeamData) (err error) {
 	head, ok := state.Chain.MerkleInfo[1]
 	if !ok {

--- a/go/teams/ftl.go
+++ b/go/teams/ftl.go
@@ -732,8 +732,16 @@ func (f *FastTeamChainLoader) checkPrevs(m libkb.MetaContext, last *keybase1.Lin
 // audit runs probabilistic merkle tree audit on the new links, to make sure that the server isn't
 // running odd-even-style attacks against members in a group.
 // TODO, see CORE-8466
-func (f *FastTeamChainLoader) audit(m libkb.MetaContext, id keybase1.TeamID, isPublic bool, newLinks []*ChainLinkUnpacked) (err error) {
-	return nil
+func (f *FastTeamChainLoader) audit(m libkb.MetaContext, arg fastLoadArg, state *keybase1.FastTeamData) (err error) {
+	head, ok := state.Chain.MerkleInfo[1]
+	if !ok {
+		return NewAuditError("cannot run audit without merkle info for head")
+	}
+	last := state.Chain.Last
+	if last == nil {
+		return NewAuditError("cannot run audit, no last chain data")
+	}
+	return m.G().GetTeamAuditor().AuditTeam(m, arg.ID, arg.Public, head, state.Chain.LinkIDs, last.Seqno)
 }
 
 // readDownPointer reads a down pointer out of a given link, if it's unstubbed. Down pointers
@@ -765,6 +773,15 @@ func readDownPointer(m libkb.MetaContext, link *ChainLinkUnpacked) (*keybase1.Do
 		NameComponent: lastPart,
 		IsDeleted:     del,
 	}, nil
+}
+
+// readMerkleRoot reads the merkle root out of the link if this link is unstubbed.
+func readMerkleRoot(m libkb.MetaContext, link *ChainLinkUnpacked) (*keybase1.MerkleRootV2, error) {
+	if link.inner == nil {
+		return nil, nil
+	}
+	ret := link.inner.Body.MerkleRoot.ToMerkleRootV2()
+	return &ret, nil
 }
 
 // readUpPointer reads an up pointer out the given link, if it's unstubbed. Up pointers are
@@ -879,6 +896,13 @@ func (f *FastTeamChainLoader) putLinks(m libkb.MetaContext, arg fastLoadArg, sta
 		if ptk != nil {
 			state.Chain.PerTeamKeys[ptk.Gen] = *ptk
 		}
+		merkleRoot, err := readMerkleRoot(m, link)
+		if err != nil {
+			return err
+		}
+		if merkleRoot != nil {
+			state.Chain.MerkleInfo[link.Seqno()] = *merkleRoot
+		}
 	}
 	newLast := newLinks[len(newLinks)-1]
 	if state.Chain.Last == nil || state.Chain.Last.Seqno < newLast.Seqno() {
@@ -948,6 +972,7 @@ func makeState(arg fastLoadArg, s *keybase1.FastTeamData) *keybase1.FastTeamData
 			PerTeamKeySeedsVerified: make(map[keybase1.PerTeamKeyGeneration]keybase1.PerTeamKeySeed),
 			DownPointers:            make(map[keybase1.Seqno]keybase1.DownPointer),
 			LinkIDs:                 make(map[keybase1.Seqno]keybase1.LinkID),
+			MerkleInfo:              make(map[keybase1.Seqno]keybase1.MerkleRootV2),
 		},
 	}
 }
@@ -982,13 +1007,13 @@ func (f *FastTeamChainLoader) refresh(m libkb.MetaContext, arg fastLoadArg, stat
 		return nil, err
 	}
 
-	// peform a probabilistic audit on the new links
-	err = f.audit(m, arg.ID, arg.Public, groceries.newLinks)
+	err = f.mutateState(m, arg, state, groceries)
 	if err != nil {
 		return nil, err
 	}
 
-	err = f.mutateState(m, arg, state, groceries)
+	// peform a probabilistic audit on the new links
+	err = f.audit(m, arg, state)
 	if err != nil {
 		return nil, err
 	}

--- a/go/teams/init.go
+++ b/go/teams/init.go
@@ -7,5 +7,6 @@ import (
 func ServiceInit(g *libkb.GlobalContext) {
 	NewTeamLoaderAndInstall(g)
 	NewFastTeamLoaderAndInstall(g)
+	NewAuditorAndInstall(g)
 	NewImplicitTeamConflictInfoCacheAndInstall(g)
 }

--- a/go/vendor/github.com/keybase/pipeliner/LICENSE
+++ b/go/vendor/github.com/keybase/pipeliner/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2018, Keybase
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/go/vendor/github.com/keybase/pipeliner/README.md
+++ b/go/vendor/github.com/keybase/pipeliner/README.md
@@ -1,0 +1,74 @@
+# pipeliner
+
+[![Build Status](https://travis-ci.org/keybase/pipeliner.svg?branch=master)](https://travis-ci.org/keybase/pipeliner)
+[![GoDoc](https://godoc.org/github.com/keybase/pipeliner?status.svg)](https://godoc.org/github.com/keybase/pipeliner)
+
+A simplified pipline library, for parallel requests with bounded parallelism.
+
+## Getting
+
+```sh
+go get github.com/keybase/pipeliner
+```
+
+## Background
+
+Often you want do network requests with bounded parallelism. Let's say you have
+1,000 DNS queries to make, and don't want to wait for them to complete in serial,
+but don't want to blast your server with 1,000 simultaneous requests. In this case,
+*bounded parallelism* makes sense. Make 1,000 requests with only 10 outstanding
+at any one time.
+
+At this point, I usually Google for it, and come up with [this blog post](https://blog.golang.org/pipelines), and I become slightly sad, because that is a lot of code to digest and
+understand to do something that should be rather simple. It's not really the fault
+of the languge, but more so the library. Here is a library that makes it a lot
+easier:
+
+## Example
+
+```go
+import (
+	"context"
+	"github.com/keybase/pipeliner"
+	"sync"
+	"time"
+)
+
+// See example_request_test.go for a runnable example.
+
+type Request struct{ i int }
+type Result struct{ i int }
+
+func (r Request) Do() (Result, error) {
+	time.Sleep(time.Millisecond)
+	return Result{r.i}, nil
+}
+
+// makeRequests calls `Do` on all of the given requests, with only `window` outstanding
+// at any given time. It puts the results in `results`, and errors out on the first
+// failure.
+func makeRequests(ctx context.Context, requests []Request, window int) (results []Result, err error) {
+
+	var resultsLock sync.Mutex
+	results = make([]Result, len(requests))
+
+	pipeliner := pipeliner.NewPipeliner(window)
+
+	worker := func(ctx context.Context, i int) error {
+		res, err := requests[i].Do()
+		resultsLock.Lock()
+		results[i] = res
+		resultsLock.Unlock()
+		return err // the first error will kill the pipeline
+	}
+
+	for i := range requests {
+		err := pipeliner.WaitForRoom(ctx)
+		if err != nil {
+			return nil, err
+		}
+		go func(i int) { pipeliner.CompleteOne(worker(ctx, i)) }(i)
+	}
+	return results, pipeliner.Flush(ctx)
+}
+```

--- a/go/vendor/github.com/keybase/pipeliner/pipeliner.go
+++ b/go/vendor/github.com/keybase/pipeliner/pipeliner.go
@@ -1,0 +1,125 @@
+package pipeliner
+
+import (
+	"golang.org/x/net/context"
+	"sync"
+)
+
+// Pipeliner coordinates a flow of parallel requests, rate-limiting so that
+// only a fixed number are oustanding at any one given time.
+type Pipeliner struct {
+	sync.RWMutex
+	window int
+	numOut int
+	ch     chan struct{}
+	err    error
+}
+
+// NewPipeliner makes a pipeliner with window size `w`.
+func NewPipeliner(w int) *Pipeliner {
+	return &Pipeliner{
+		window: w,
+		ch:     make(chan struct{}),
+	}
+}
+
+func (p *Pipeliner) getError() error {
+	p.RLock()
+	defer p.RUnlock()
+	return p.err
+}
+
+func (p *Pipeliner) hasRoom() bool {
+	p.RLock()
+	defer p.RUnlock()
+	return p.numOut < p.window
+}
+
+func (p *Pipeliner) launchOne() {
+	p.Lock()
+	defer p.Unlock()
+	p.numOut++
+}
+
+// WaitForRoom will block until there is room in the window to fire
+// another request. It returns an error if any prior request failed,
+// instructing the caller to stop firing off new requests. The error
+// originates either from CompleteOne(), or from a context-based
+// cancelation
+func (p *Pipeliner) WaitForRoom(ctx context.Context) error {
+	for {
+		p.checkContextDone(ctx)
+		if err := p.getError(); err != nil {
+			return err
+		}
+		if p.hasRoom() {
+			break
+		}
+		p.wait(ctx)
+	}
+	p.launchOne()
+	return nil
+}
+
+// CompleteOne should be called when a request is completed, to make
+// room for subsequent requests. Call it with an error if you want the
+// rest of the pipeline to be short-circuited. This is the error that
+// is returned from WaitForRoom.
+func (p *Pipeliner) CompleteOne(e error) {
+	p.setError(e)
+	p.landOne()
+	p.ch <- struct{}{}
+}
+
+func (p *Pipeliner) landOne() {
+	p.Lock()
+	defer p.Unlock()
+	p.numOut--
+}
+
+func (p *Pipeliner) hasOutstanding() bool {
+	p.RLock()
+	defer p.RUnlock()
+	return p.numOut > 0
+}
+
+func (p *Pipeliner) setError(e error) {
+	p.Lock()
+	defer p.Unlock()
+	if e != nil && p.err == nil {
+		p.err = e
+	}
+}
+
+func (p *Pipeliner) checkContextDone(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		p.setError(ctx.Err())
+	default:
+	}
+}
+
+func (p *Pipeliner) wait(ctx context.Context) {
+	select {
+	case <-p.ch:
+	case <-ctx.Done():
+		p.setError(ctx.Err())
+	}
+}
+
+// Flush any oustanding requests, blocking until the last completes.
+// Returns an error set by CompleteOne, or a context-based error
+// if any request was canceled mid-flight.
+func (p *Pipeliner) Flush(ctx context.Context) error {
+	for {
+		p.checkContextDone(ctx)
+		if err := p.getError(); err != nil {
+			return err
+		}
+		if !p.hasOutstanding() {
+			break
+		}
+		p.wait(ctx)
+	}
+	return p.getError()
+}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -388,6 +388,12 @@
 			"revision": ""
 		},
 		{
+			"checksumSHA1": "o3BupHtJ9Txi4Cfns9vcvvLrQC8=",
+			"path": "github.com/keybase/pipeliner",
+			"revision": "d5de6f17e362642916083c2fb9c1c8b8606c0bf8",
+			"revisionTime": "2018-08-24T13:24:23Z"
+		},
+		{
 			"checksumSHA1": "AdTewzl8bd3Il/9CHP/+b4hkhyw=",
 			"path": "github.com/keybase/saltpack",
 			"revision": "4f6adfa39469a276a90a537ec95807901c72a0be",

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -55,10 +55,10 @@ protocol teams {
 
   @lint("ignore")
   record PerTeamKey {
-      PerTeamKeyGeneration gen;
-      Seqno seqno;
-      KID sigKID;
-      KID encKID;
+    PerTeamKeyGeneration gen;
+    Seqno seqno;
+    KID sigKID;
+    KID encKID;
   }
 
   fixed PerTeamKeySeed(32);
@@ -127,16 +127,16 @@ protocol teams {
   }
 
   record TeamPlusApplicationKeys {
-      TeamID id;
-      string name;
-      boolean implicit;
-      boolean public;
-      TeamApplication application;
+    TeamID id;
+    string name;
+    boolean implicit;
+    boolean public;
+    TeamApplication application;
 
-      array<UserVersion> writers;
-      array<UserVersion> onlyReaders;
+    array<UserVersion> writers;
+    array<UserVersion> onlyReaders;
 
-      array<TeamApplicationKey> applicationKeys;
+    array<TeamApplicationKey> applicationKeys;
   }
 
   // Snapshot of a loaded team.
@@ -266,6 +266,40 @@ protocol teams {
 
     // This is filled up to lastSeqno.
     map<Seqno, LinkID> linkIDs;
+
+    // For any link where we have it, fill in merkle sequence information.
+    map<Seqno, MerkleRootV2> merkleInfo;
+  }
+
+  record Audit {
+    Time time;
+    Seqno maxMerkleSeqno;
+    Seqno maxChainSeqno;
+    Seqno maxMerkleProbe;
+  }
+
+  record Probe {
+    @mpackkey("i")
+    int index;
+    @mpackkey("s")
+    Seqno teamSeqno;
+  }
+
+  record AuditHistory {
+    @lint("ignore")
+    TeamID ID;
+    // Whether this is a public team.
+    boolean public;
+    // The last known merkle seqno prior to team creation
+    Seqno priorMerkleSeqno;
+
+    // When the last audit(s) happened
+    array<Audit> audits;
+    // Probes of before the team was created. The value in the map is the index
+    // of the audit (each audit has a value in the audits array above).
+    map<Seqno,Probe> preProbes;
+    // Probes of after the team was created
+    map<Seqno,Probe> postProbes;
   }
 
   enum TeamInviteCategory {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -293,7 +293,7 @@ protocol teams {
     TeamID ID;
     // Whether this is a public team.
     boolean public;
-    // The last known merkle seqno prior to team creation
+    // The Merkle sequence number signed into the head link of the team chain.
     Seqno priorMerkleSeqno;
 
     // When the last audit(s) happened

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -273,8 +273,11 @@ protocol teams {
 
   record Audit {
     Time time;
+    // The Maximum Merkle Seqno known globally at the time of the audit.
     Seqno maxMerkleSeqno;
+    // The maximum Seqno in the chain at the time of the audit.
     Seqno maxChainSeqno;
+    // The maximum merkle Seqno probed in this audit.
     Seqno maxMerkleProbe;
   }
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -626,6 +626,94 @@
             "keys": "Seqno"
           },
           "name": "linkIDs"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "MerkleRootV2",
+            "keys": "Seqno"
+          },
+          "name": "merkleInfo"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "Audit",
+      "fields": [
+        {
+          "type": "Time",
+          "name": "time"
+        },
+        {
+          "type": "Seqno",
+          "name": "maxMerkleSeqno"
+        },
+        {
+          "type": "Seqno",
+          "name": "maxChainSeqno"
+        },
+        {
+          "type": "Seqno",
+          "name": "maxMerkleProbe"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "Probe",
+      "fields": [
+        {
+          "type": "int",
+          "name": "index",
+          "mpackkey": "i"
+        },
+        {
+          "type": "Seqno",
+          "name": "teamSeqno",
+          "mpackkey": "s"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "AuditHistory",
+      "fields": [
+        {
+          "type": "TeamID",
+          "name": "ID",
+          "lint": "ignore"
+        },
+        {
+          "type": "boolean",
+          "name": "public"
+        },
+        {
+          "type": "Seqno",
+          "name": "priorMerkleSeqno"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "Audit"
+          },
+          "name": "audits"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "Probe",
+            "keys": "Seqno"
+          },
+          "name": "preProbes"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "Probe",
+            "keys": "Seqno"
+          },
+          "name": "postProbes"
         }
       ]
     },

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -793,6 +793,8 @@ export type AsyncOps =
   | 7 // LIST_RECURSIVE_TO_DEPTH_7
   | 8 // GET_REVISIONS_8
 
+export type Audit = $ReadOnly<{time: Time, maxMerkleSeqno: Seqno, maxChainSeqno: Seqno, maxMerkleProbe: Seqno}>
+export type AuditHistory = $ReadOnly<{ID: TeamID, public: Boolean, priorMerkleSeqno: Seqno, audits?: ?Array<Audit>, preProbes: {[key: string]: Probe}, postProbes: {[key: string]: Probe}}>
 export type AuthenticityType =
   | 0 // SIGNED_0
   | 1 // REPUDIABLE_1
@@ -986,7 +988,7 @@ export type FSSyncStatusRequest = $ReadOnly<{requestID: Int}>
 export type FastTeamData = $ReadOnly<{name: TeamName, chain: FastTeamSigChainState, perTeamKeySeeds /* perTeamKeySeedsUnverified */: {[key: string]: PerTeamKeySeed}, latestKeyGeneration: PerTeamKeyGeneration, readerKeyMasks: {[key: string]: {[key: string]: MaskB64}}, latestSeqnoHint: Seqno, cachedAt: Time}>
 export type FastTeamLoadArg = $ReadOnly<{ID: TeamID, public: Boolean, applications?: ?Array<TeamApplication>, keyGenerationsNeeded?: ?Array<PerTeamKeyGeneration>, needLatestKey: Boolean}>
 export type FastTeamLoadRes = $ReadOnly<{name: TeamName, applicationKeys?: ?Array<TeamApplicationKey>}>
-export type FastTeamSigChainState = $ReadOnly<{ID: TeamID, public: Boolean, rootAncestor: TeamName, nameDepth: Int, last?: ?LinkTriple, perTeamKeys: {[key: string]: PerTeamKey}, perTeamKeySeedsVerified: {[key: string]: PerTeamKeySeed}, downPointers: {[key: string]: DownPointer}, lastUpPointer?: ?UpPointer, perTeamKeyCTime: UnixTime, linkIDs: {[key: string]: LinkID}}>
+export type FastTeamSigChainState = $ReadOnly<{ID: TeamID, public: Boolean, rootAncestor: TeamName, nameDepth: Int, last?: ?LinkTriple, perTeamKeys: {[key: string]: PerTeamKey}, perTeamKeySeedsVerified: {[key: string]: PerTeamKeySeed}, downPointers: {[key: string]: DownPointer}, lastUpPointer?: ?UpPointer, perTeamKeyCTime: UnixTime, linkIDs: {[key: string]: LinkID}, merkleInfo: {[key: string]: MerkleRootV2}}>
 export type FavoriteGetFavoritesResult = FavoritesResult
 export type FavoritesResult = $ReadOnly<{favoriteFolders?: ?Array<Folder>, ignoredFolders?: ?Array<Folder>, newFolders?: ?Array<Folder>}>
 export type Feature = $ReadOnly<{allow: Boolean, defaultValue: Boolean, readonly: Boolean, label: String}>
@@ -1322,6 +1324,7 @@ export type PgpUiShouldPushPrivateResult = Boolean
 export type Pics = $ReadOnly<{square40: String, square200: String, square360: String}>
 export type PingResponse = $ReadOnly<{timestamp: Time}>
 export type PlatformInfo = $ReadOnly<{os: String, osVersion: String, arch: String, goVersion: String}>
+export type Probe = $ReadOnly<{i /* index */: Int, s /* teamSeqno */: Seqno}>
 export type ProblemSet = $ReadOnly<{user: User, kid: KID, tlfs?: ?Array<ProblemTLF>}>
 export type ProblemSetDevices = $ReadOnly<{problemSet: ProblemSet, devices?: ?Array<Device>}>
 export type ProblemTLF = $ReadOnly<{tlf: TLF, score: Int, solution_kids?: ?Array<KID>}>


### PR DESCRIPTION
- the goal of the teamchain auditor is to prevent the server from pulling off an "odd/even" attack. That is, when showing team acme to
alice, the server sends even merkle roots, that show view A of the team. When showing team acme to bob, the server sends odd
merkle roots, that show view B of the team. Where A and B might not agree at all. The server can hide these patterns in the
merkle tree in arbitrary ways, with the goal to get alice and bob to see two different ideas of the same team, without forking
the merkle tree globally.
- our approach is for alice and bob to make random "probes".  probe the time before the team was created, the time after the
team was created, and ensure a consistent view.
- after 1000 new merkle roots, the audit repeats, with alice and bob idependently auditing the recent roots.
- for now, we've hardcoded parameters, but we'll likely want to tune them in the future.
- write all audit results to disk cache.
- also, while we're there, clean up the merkle client "first root with skip" logic