### PR TITLE
use iOS app group shared directory for config dir, and migrate old devices CORE-8738

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -139,7 +139,7 @@ func Init(homeDir string, mobileSharedHome string, logFile string, runModeStr st
 		}
 	}()
 
-	fmt.Println("Go: Initializing")
+	fmt.Printf("Go: Initializing: home: %s mobileSharedHome: %s\n".homeDir, mobileSharedHome)
 	if logFile != "" {
 		fmt.Printf("Go: Using log: %s\n", logFile)
 	}

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -139,7 +139,7 @@ func Init(homeDir string, mobileSharedHome string, logFile string, runModeStr st
 		}
 	}()
 
-	fmt.Printf("Go: Initializing: home: %s mobileSharedHome: %s\n".homeDir, mobileSharedHome)
+	fmt.Printf("Go: Initializing: home: %s mobileSharedHome: %s\n", homeDir, mobileSharedHome)
 	if logFile != "" {
 		fmt.Printf("Go: Using log: %s\n", logFile)
 	}

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -120,18 +120,18 @@ func setInited() {
 }
 
 // InitOnce runs the Keybase services (only runs one time)
-func InitOnce(homeDir string, logFile string, runModeStr string, accessGroupOverride bool,
-	dnsNSFetcher ExternalDNSNSFetcher, nvh NativeVideoHelper) {
+func InitOnce(homeDir string, mobileSharedHome string, logFile string, runModeStr string,
+	accessGroupOverride bool, dnsNSFetcher ExternalDNSNSFetcher, nvh NativeVideoHelper) {
 	startOnce.Do(func() {
-		if err := Init(homeDir, logFile, runModeStr, accessGroupOverride, dnsNSFetcher, nvh); err != nil {
+		if err := Init(homeDir, mobileSharedHome, logFile, runModeStr, accessGroupOverride, dnsNSFetcher, nvh); err != nil {
 			kbCtx.Log.Errorf("Init error: %s", err)
 		}
 	})
 }
 
 // Init runs the Keybase services
-func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride bool,
-	externalDNSNSFetcher ExternalDNSNSFetcher, nvh NativeVideoHelper) (err error) {
+func Init(homeDir string, mobileSharedHome string, logFile string, runModeStr string,
+	accessGroupOverride bool, externalDNSNSFetcher ExternalDNSNSFetcher, nvh NativeVideoHelper) (err error) {
 	defer func() {
 		err = flattenError(err)
 		if err == nil {
@@ -175,6 +175,7 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 	}
 	config := libkb.AppConfig{
 		HomeDir:                        homeDir,
+		MobileSharedHomeDir:            mobileSharedHome,
 		LogFile:                        logFile,
 		RunMode:                        runMode,
 		Debug:                          true,

--- a/go/erasablekv/erasable_kv_store.go
+++ b/go/erasablekv/erasable_kv_store.go
@@ -44,7 +44,7 @@ const noiseSuffix = ".ns"
 const storageSubDir = "eraseablekvstore"
 
 func getStorageDir(g *libkb.GlobalContext, subDir string) string {
-	return filepath.Join(g.Env.GetDataDir(), storageSubDir, subDir)
+	return filepath.Join(g.Env.GetConfigDir(), storageSubDir, subDir)
 }
 
 type ErasableKVStore interface {

--- a/go/erasablekv/erasable_kv_store.go
+++ b/go/erasablekv/erasable_kv_store.go
@@ -44,7 +44,12 @@ const noiseSuffix = ".ns"
 const storageSubDir = "eraseablekvstore"
 
 func getStorageDir(g *libkb.GlobalContext, subDir string) string {
-	return filepath.Join(g.Env.GetConfigDir(), storageSubDir, subDir)
+	base := g.Env.GetDataDir()
+	// check for iOS
+	if runtime.GOOS == "darwin" && g.GetAppType() == libkb.MobileAppType {
+		base = g.Env.GetConfigDir()
+	}
+	return filepath.Join(base, storageSubDir, subDir)
 }
 
 type ErasableKVStore interface {

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -66,6 +66,9 @@ func (p CommandLine) GetAutoFork() (bool, bool) {
 func (p CommandLine) GetHome() string {
 	return p.GetGString("home")
 }
+func (p CommandLine) GetMobileSharedHome() string {
+	return p.GetGString("mobile-shared-home")
+}
 func (p CommandLine) GetServerURI() string {
 	return p.GetGString("server")
 }

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -400,6 +400,9 @@ func (f *JSONConfigFile) Reset() {
 func (f *JSONConfigFile) GetHome() string {
 	return f.GetTopLevelString("home")
 }
+func (f *JSONConfigFile) GetMobileSharedHome() string {
+	return f.GetTopLevelString("mobile_shared_home")
+}
 func (f *JSONConfigFile) GetServerURI() string {
 	return f.GetTopLevelString("server")
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -21,6 +21,7 @@ import (
 type NullConfiguration struct{}
 
 func (n NullConfiguration) GetHome() string                                                { return "" }
+func (n NullConfiguration) GetMobileSharedHome() string                                    { return "" }
 func (n NullConfiguration) GetServerURI() string                                           { return "" }
 func (n NullConfiguration) GetConfigFilename() string                                      { return "" }
 func (n NullConfiguration) GetUpdaterConfigFilename() string                               { return "" }
@@ -160,12 +161,13 @@ func (n NullConfiguration) GetSecurityAccessGroupOverride() (bool, bool) {
 }
 
 type TestParameters struct {
-	ConfigFilename string
-	Home           string
-	GPG            string
-	GPGHome        string
-	GPGOptions     []string
-	Debug          bool
+	ConfigFilename   string
+	Home             string
+	MobileSharedHome string
+	GPG              string
+	GPGHome          string
+	GPGOptions       []string
+	Debug            bool
 	// Whether we are in Devel Mode
 	Devel bool
 	// If we're in dev mode, the name for this test, with a random
@@ -303,6 +305,7 @@ func newEnv(cmd CommandLine, config ConfigReader, osname string, getLog LogGette
 
 	e.HomeFinder = NewHomeFinder("keybase",
 		func() string { return e.getHomeFromCmdOrConfig() },
+		func() string { return e.getMobileSharedHomeFromCmdOrConfig() },
 		osname,
 		func() RunMode { return e.GetRunMode() },
 		getLog)
@@ -314,6 +317,14 @@ func (e *Env) getHomeFromCmdOrConfig() string {
 		func() string { return e.Test.Home },
 		func() string { return e.cmd.GetHome() },
 		func() string { return e.GetConfig().GetHome() },
+	)
+}
+
+func (e *Env) getMobileSharedHomeFromCmdOrConfig() string {
+	return e.GetString(
+		func() string { return e.Test.MobileSharedHome },
+		func() string { return e.cmd.GetMobileSharedHome() },
+		func() string { return e.GetConfig().GetMobileSharedHome() },
 	)
 }
 
@@ -1245,6 +1256,7 @@ func (e *Env) GetStoredSecretServiceName() string {
 type AppConfig struct {
 	NullConfiguration
 	HomeDir                        string
+	MobileSharedHomeDir            string
 	LogFile                        string
 	RunMode                        RunMode
 	Debug                          bool
@@ -1275,6 +1287,10 @@ func (c AppConfig) GetRunMode() (RunMode, error) {
 
 func (c AppConfig) GetHome() string {
 	return c.HomeDir
+}
+
+func (c AppConfig) GetMobileSharedHome() string {
+	return c.MobileSharedHomeDir
 }
 
 func (c AppConfig) GetServerURI() string {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -328,12 +328,13 @@ func (e *Env) getMobileSharedHomeFromCmdOrConfig() string {
 	)
 }
 
-func (e *Env) GetHome() string            { return e.HomeFinder.Home(false) }
-func (e *Env) GetConfigDir() string       { return e.HomeFinder.ConfigDir() }
-func (e *Env) GetCacheDir() string        { return e.HomeFinder.CacheDir() }
-func (e *Env) GetSandboxCacheDir() string { return e.HomeFinder.SandboxCacheDir() }
-func (e *Env) GetDataDir() string         { return e.HomeFinder.DataDir() }
-func (e *Env) GetLogDir() string          { return e.HomeFinder.LogDir() }
+func (e *Env) GetHome() string             { return e.HomeFinder.Home(false) }
+func (e *Env) GetMobileSharedHome() string { return e.HomeFinder.MobileSharedHome(false) }
+func (e *Env) GetConfigDir() string        { return e.HomeFinder.ConfigDir() }
+func (e *Env) GetCacheDir() string         { return e.HomeFinder.CacheDir() }
+func (e *Env) GetSandboxCacheDir() string  { return e.HomeFinder.SandboxCacheDir() }
+func (e *Env) GetDataDir() string          { return e.HomeFinder.DataDir() }
+func (e *Env) GetLogDir() string           { return e.HomeFinder.LogDir() }
 
 func (e *Env) SendSystemChatMessages() bool {
 	return !e.Test.SkipSendingSystemChatMessages

--- a/go/libkb/home.go
+++ b/go/libkb/home.go
@@ -28,6 +28,7 @@ type HomeFinder interface {
 	CacheDir() string
 	ConfigDir() string
 	Home(emptyOk bool) string
+	MobileSharedHome(emptyOk bool) string
 	DataDir() string
 	RuntimeDir() string
 	Normalize(s string) string
@@ -54,6 +55,10 @@ func (x XdgPosix) Home(emptyOk bool) string {
 		ret = os.Getenv("HOME")
 	}
 	return ret
+}
+
+func (x XdgPosix) MobileSharedHome(emptyOk bool) string {
+	return x.Home(emptyOk)
 }
 
 func (x XdgPosix) dirHelper(env string, prefixDirs ...string) string {
@@ -174,6 +179,17 @@ func (d Darwin) Home(emptyOk bool) string {
 	return ret
 }
 
+func (d Darwin) MobileSharedHome(emptyOk bool) string {
+	var ret string
+	if d.getMobileSharedHome != nil {
+		ret = d.getMobileSharedHome()
+	}
+	if len(ret) == 0 && !emptyOk {
+		ret = os.Getenv("MOBILE_SHARED_HOME")
+	}
+	return ret
+}
+
 func (d Darwin) Normalize(s string) string { return s }
 
 type Win32 struct {
@@ -272,6 +288,10 @@ func (w Win32) Home(emptyOk bool) string {
 	ret = filepath.Join(ret, packageName)
 
 	return ret
+}
+
+func (w Win32) MobileSharedHome(emptyOk bool) string {
+	return w.Home(emptyOk)
 }
 
 func NewHomeFinder(appName string, getHome ConfigGetter, getMobileSharedHome ConfigGetter, osname string,

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -54,6 +54,7 @@ type configGetter interface {
 	GetGregorSaveInterval() (time.Duration, bool)
 	GetGregorURI() string
 	GetHome() string
+	GetMobileSharedHome() string
 	GetLinkCacheSize() (int, bool)
 	GetLocalRPCDebug() string
 	GetLocalTrackMaxAge() (time.Duration, bool)

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -63,7 +63,7 @@ public class MainActivity extends ReactActivity {
         }
 
         createDummyFile();
-        initOnce(this.getFilesDir().getPath(), this.getFileStreamPath("service.log").getAbsolutePath(), "prod", false,
+        initOnce(this.getFilesDir().getPath(), "", this.getFileStreamPath("service.log").getAbsolutePath(), "prod", false,
                 new DNSNSFetcher(), new VideoHelper());
 
         super.onCreate(savedInstanceState);

--- a/shared/react-native/ios/Keybase/Engine.m
+++ b/shared/react-native/ios/Keybase/Engine.m
@@ -52,7 +52,7 @@ static NSString *const eventName = @"objc-engine-event";
 }
 
 - (void)setupKeybaseWithSettings:(NSDictionary *)settings error:(NSError **)error {
-  KeybaseInit(settings[@"homedir"], settings[@"logFile"], settings[@"runmode"], settings[@"SecurityAccessGroupOverride"], NULL, NULL, error);
+  KeybaseInit(settings[@"homedir"], settings[@"sharedHome"], settings[@"logFile"], settings[@"runmode"], settings[@"SecurityAccessGroupOverride"], NULL, NULL, error);
 }
 
 - (void)setupQueues {


### PR DESCRIPTION
On iOS, app extensions run in their own processes, and cannot access the files from the container app.  Apple provides a "shared container" filesystem that is linked on the organization "app group". In order for the share extension to be logged in when used, our config files need to be in this shared location. Patch does the following:

1.) Add a new notion of "mobile shared home" to the whole env system and `HomeFinder`. If the `Config` specifies a mobile shared home, the `Darwin` `HomeFinder` will use it for `ConfigDir`. 
2.) Thread the mobile shared home directory down from native into Go during `Init`. If the device had previously been provisioned, we will copy the files from app storage to shared storage. Note: we also copy all the stored EK info as well. cc @joshblum 