### PR TITLE
[KBFS-3172] Desktop: Show in Finder buttons - tooltip missing

### DIFF
--- a/shared/fs/common/open-in-fileui.desktop.js
+++ b/shared/fs/common/open-in-fileui.desktop.js
@@ -11,6 +11,7 @@ import {
   Overlay,
   OverlayParentHOC,
   type OverlayParentProps,
+  WithTooltip,
 } from '../../common-adapters'
 import {fileUIName} from '../../constants/platform'
 
@@ -28,13 +29,15 @@ type Props = {
   FinderPopupProps
 
 const OpenInFileUI = ({openInFileUI}: OpenInFileUIProps) => (
-  <Icon
-    type="iconfont-finder"
-    style={iconCastPlatformStyles(styles.pathItemActionIcon)}
-    fontSize={16}
-    onClick={openInFileUI}
-    className="fs-path-item-hover-icon"
-  />
+  <WithTooltip text="Show in Finder">
+    <Icon
+      type="iconfont-finder"
+      style={iconCastPlatformStyles(styles.pathItemActionIcon)}
+      fontSize={16}
+      onClick={openInFileUI}
+      className="fs-path-item-hover-icon"
+    />
+  </WithTooltip>
 )
 
 const FinderPopup = OverlayParentHOC((props: FinderPopupProps & OverlayParentProps) => (

--- a/shared/fs/header/header.desktop.js
+++ b/shared/fs/header/header.desktop.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
-import {Box, Icon, Text} from '../../common-adapters'
+import {Box, Icon, Text, WithTooltip} from '../../common-adapters'
 import AddNew from './add-new-container'
 import ConnectedFilesBanner from '../banner/fileui-banner/container'
 import Breadcrumb from './breadcrumb-container.desktop'
@@ -20,7 +20,9 @@ const FolderHeader = ({path, onChat}: FolderHeaderProps) => (
           <Breadcrumb path={path} />
           <Box style={styleFolderHeaderEnd}>
             <AddNew path={path} style={styleAddNew} />
-            <OpenInFileUI path={path} />
+            <WithTooltip text="Show in Finder">
+              <OpenInFileUI path={path} />
+            </WithTooltip>
             {onChat && (
               <Icon
                 type="iconfont-chat"


### PR DESCRIPTION
**Description of task:**
A tooltip should show up when hovering the Show in Finder button on desktop. This is for all instances: headers and list items.

**Relevant Screenshots:**
<img width="1678" alt="screen shot 2018-09-04 at 18 58 49" src="https://user-images.githubusercontent.com/10031957/45043071-e802e980-b074-11e8-8b8a-4527e38de95e.png">
<img width="841" alt="screen shot 2018-09-04 at 18 59 00" src="https://user-images.githubusercontent.com/10031957/45043072-e802e980-b074-11e8-861b-62ecbcff8b16.png">
