### PR TITLE
Fix chat inbox reselection

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1469,13 +1469,16 @@ const _maybeAutoselectNewestConversation = (
     | TeamsGen.LeaveTeamPayload,
   state: TypedState
 ) => {
-  const selected = Constants.getSelectedConversation(state)
+  let selected = Constants.getSelectedConversation(state)
+  if (!state.chat2.metaMap.get(selected)) {
+    selected = Constants.noConversationIDKey
+  }
   if (action.type === Chat2Gen.metaDelete) {
     if (!action.payload.selectSomethingElse) {
       return
     }
     // only do this if we blocked the current conversation
-    if (selected !== action.payload.conversationIDKey) {
+    if (selected !== Constants.noConversationIDKey && selected !== action.payload.conversationIDKey) {
       return
     }
     // only select something if we're leaving a pending conversation
@@ -1499,11 +1502,7 @@ const _maybeAutoselectNewestConversation = (
     action.payload.conversationIDKey === selected
   ) {
     // Intentional fall-through -- force select a new one
-  } else if (
-    Constants.isValidConversationIDKey(selected) &&
-    !action.payload.findNewConversation &&
-    !action.payload.selectSomethingElse
-  ) {
+  } else if (Constants.isValidConversationIDKey(selected)) {
     // Stay with our existing convo if it was not empty or pending
     return
   }


### PR DESCRIPTION
### Problem
I introduced a regression with 775ac68cf944b511ceff72ee364bc414d82132f1 and @mmaxim reverted with 0696327994bfe0b8a762a8320bd3b8f8a46dbf6d.

The issue was that incoming chat messages on `metaReceived` would cause the currently selected conversation (maybe the 5th one down) to be changed to the conversation with the newest chat messages and then jump back.

### Test Cases
Since I messed up, these are the tests I've performed on this branch.

1. Pending Conversation
    - Start a new chat with a user
    - Pending chat added to the inbox
    - Click `X` on pending chat
    - Inbox should reselect the most recent non-pending converstaion
2. Pending Conversation w/ Incoming Messages
    - Start a new conversation with a user
    - Pending conversation added to the inbox
    - Incoming message arrives from existing conversation
    - Selection should **not change** from the pending conversation
3. Block Conversation - Most Recent (Inbox count >= 2)
    - Select the most recent conversation in the inbox
    - Block that conversation via the GUI
    - Selected conversation in the inbox should change to the next recent
    - Thread view should also change to the next recent
4. Block Conversation - Not Most Recent (Inbox count >= 2)
    - Select any conversation in the inbox except the most recent
    - Block that conversation via the GUI
    - Selected conversation in the inbox should change the most recent
    - Thread view should also change to the most recent
5. Block Conversation - Most Recent (Inbox count == 1)
    - Select the only conversation in the inbox
    - Block that conversation via the GUI
    - Inbox should clear and show no items, no selected conversation.
    - Thread view should show `EMPTY` state with text "All conversations are end to end encrypted"
6. Leave Big Team - (Inbox count >= 1)
    - Have 1 or more 1-1 or small team conversations in the inbox
    - Be part of exactly one big team
    - Select any channel in the big team
    - Leave team via the GUI
    - The most recent 1-1 or small team conversation should be selected
 7. Leave Team - (Inbox count == 0)
    - Have no 1-1 or small team conversations in the inbox
    - Be part of exactly one big team
    - Select any channel in the big team
    - 'Leave team'
    - Thread view should show `EMPTY` state with text "All conversations are end to end encrypted"

 ### Solution

Be less bad.