### PR TITLE
hook up subteam rename to the UI CORE-8725

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -936,6 +936,22 @@ func (s *HybridInboxSource) SetConvSettings(ctx context.Context, uid gregor1.UID
 	})
 }
 
+func (s *HybridInboxSource) SubteamRename(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
+	convIDs []chat1.ConversationID) (convs []chat1.ConversationLocal, err error) {
+	defer s.Trace(ctx, func() error { return err }, "SubteamRename")()
+	ib := storage.NewInbox(s.G(), uid)
+	if cerr := ib.SubteamRename(ctx, vers, convIDs); cerr != nil {
+		err = s.handleInboxError(ctx, cerr, uid)
+		return nil, err
+	}
+	if convs, err = s.getConvsLocal(ctx, uid, convIDs); err != nil {
+		s.Debug(ctx, "SubteamRename: unable to load conversations: convIDs: %v err: %s",
+			convIDs, err.Error())
+		return nil, nil
+	}
+	return convs, nil
+}
+
 func (s *HybridInboxSource) modConversation(ctx context.Context, debugLabel string, uid gregor1.UID, convID chat1.ConversationID,
 	mod func(context.Context, *storage.Inbox) error) (
 	conv *chat1.ConversationLocal, err error) {

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -1033,21 +1033,19 @@ func (g *PushHandler) SubteamRename(ctx context.Context, m gregor.OutOfBandMessa
 		g.Lock()
 		defer g.Unlock()
 		defer g.orderer.CompleteTurn(ctx, uid, update.InboxVers)
-		// Get and localize the conversation to get the new tlfname.
-		inbox, err := g.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
-			ConvIDs: update.ConvIDs,
-		}, nil)
+		// Update inbox and get conversations
+		convs, err := g.G().InboxSource.SubteamRename(ctx, uid, update.InboxVers, update.ConvIDs)
 		if err != nil {
-			g.Debug(ctx, "resolve: unable to read conversation: %s", err.Error())
+			g.Debug(ctx, "SubteamRename: unable to read conversation: %s", err.Error())
 			return
 		}
-		if len(inbox.Convs) != len(update.ConvIDs) {
-			g.Debug(ctx, "resolve: unable to find all conversations")
+		if len(convs) != len(update.ConvIDs) {
+			g.Debug(ctx, "SubteamRename: unable to find all conversations")
 		}
 
 		convUIItems := make(map[chat1.TopicType][]chat1.InboxUIItem)
 		convIDs := make(map[chat1.TopicType][]chat1.ConversationID)
-		for _, conv := range inbox.Convs {
+		for _, conv := range convs {
 			uiItem := g.presentUIItem(ctx, &conv, uid)
 			if uiItem != nil {
 				convUIItems[uiItem.TopicType] = append(convUIItems[uiItem.TopicType], *uiItem)

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -1056,7 +1056,7 @@ func (i *Inbox) SubteamRename(ctx context.Context, vers chat1.InboxVers, convIDs
 	defer i.Trace(ctx, func() error { return err }, "SubteamRename")()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
-	i.Debug(ctx, "SubteamRename: vers: %d convIDs: %s", vers, len(convIDs))
+	i.Debug(ctx, "SubteamRename: vers: %d convIDs: %d", vers, len(convIDs))
 	ibox, err := i.readDiskInbox(ctx)
 	if err != nil {
 		if _, ok := err.(MissError); !ok {

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -1050,6 +1050,41 @@ func (i *Inbox) Expunge(ctx context.Context, vers chat1.InboxVers,
 	return i.writeDiskInbox(ctx, ibox)
 }
 
+func (i *Inbox) SubteamRename(ctx context.Context, vers chat1.InboxVers, convIDs []chat1.ConversationID) (err Error) {
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
+	defer i.Trace(ctx, func() error { return err }, "SubteamRename")()
+	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
+
+	i.Debug(ctx, "SubteamRename: vers: %d convIDs: %s", vers, len(convIDs))
+	ibox, err := i.readDiskInbox(ctx)
+	if err != nil {
+		if _, ok := err.(MissError); !ok {
+			return nil
+		}
+		return err
+	}
+	// Check inbox versions, make sure it makes sense (clear otherwise)
+	var cont bool
+	if vers, cont, err = i.handleVersion(ctx, ibox.InboxVersion, vers); !cont {
+		return err
+	}
+
+	// Update convs
+	for _, convID := range convIDs {
+		_, conv := i.getConv(convID, ibox.Conversations)
+		if conv == nil {
+			i.Debug(ctx, "SubteamRename: no conversation found: convID: %s", convID)
+			continue
+		}
+		conv.Conv.Metadata.Version = vers.ToConvVers()
+	}
+
+	// Write out to disk
+	ibox.InboxVersion = vers
+	return i.writeDiskInbox(ctx, ibox)
+}
+
 func (i *Inbox) SetConvRetention(ctx context.Context, vers chat1.InboxVers,
 	convID chat1.ConversationID, policy chat1.RetentionPolicy) (err Error) {
 	locks.Inbox.Lock()

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -154,6 +154,7 @@ type InboxSource interface {
 		policy chat1.RetentionPolicy) ([]chat1.ConversationLocal, error)
 	SetConvSettings(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
 		convSettings *chat1.ConversationSettings) (*chat1.ConversationLocal, error)
+	SubteamRename(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convIDs []chat1.ConversationID) ([]chat1.ConversationLocal, error)
 
 	GetInboxQueryLocalToRemote(ctx context.Context,
 		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, *NameInfoUntrusted, error)

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -493,6 +493,14 @@ const onChatThreadStale = updates => {
   return actions
 }
 
+const onChatSubteamRename = convs => {
+  const conversationIDKeys = (convs || []).map(c => Types.stringToConversationIDKey(c.convID))
+  return Chat2Gen.createMetaRequestTrusted({
+    conversationIDKeys,
+    force: true,
+  })
+}
+
 // Some participants are broken/fixed now
 const onChatIdentifyUpdate = update => {
   const usernames = update.CanonicalName.split(',')
@@ -653,6 +661,11 @@ const setupEngineListeners = () => {
   engine().setIncomingActionCreators(
     'chat.1.NotifyChat.ChatThreadsStale',
     ({updates}: RPCChatTypes.NotifyChatChatThreadsStaleRpcParam) => onChatThreadStale(updates)
+  )
+
+  engine().setIncomingActionCreators(
+    'chat.1.NotifyChat.ChatSubteamRename',
+    ({convs}: RPCChatTypes.NotifyChatChatSubteamRenameRpcParam) => onChatSubteamRename(convs)
   )
 
   engine().setIncomingActionCreators(


### PR DESCRIPTION
Patch does the following:

1.) Thread through the `SubteamRename` event to `Inbox` so we can update conversation version numbers.
2.) Get UI to refresh conv meta on receiving the rename notification. 