### PR TITLE
allow a 2x poll completion time for kex2 router

### DIFF
--- a/go/libkb/kex2_router.go
+++ b/go/libkb/kex2_router.go
@@ -89,7 +89,7 @@ func (k *KexRouter) Get(sessID kex2.SessionID, receiver kex2.DeviceID, low kex2.
 		},
 		MetaContext: mctx.BackgroundWithLogTags(),
 	}
-	kexAPITimeout(&arg, poll)
+	kexAPITimeout(&arg, 2*poll)
 	var j kexResp
 
 	if err = mctx.G().API.GetDecode(arg, &j); err != nil {


### PR DESCRIPTION
otherwise the context-based timeout might kill the API call