### PR TITLE
Show error for reusing device names and add logging to provisioning

### DIFF
--- a/shared/actions/provision.js
+++ b/shared/actions/provision.js
@@ -6,6 +6,7 @@ import * as ProvisionGen from './provision-gen'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import * as Saga from '../util/saga'
 import * as Tabs from '../constants/tabs'
+import logger from '../logger'
 import {isMobile} from '../constants/platform'
 import HiddenString from '../util/hidden-string'
 import {type TypedState} from '../constants/reducer'
@@ -377,6 +378,7 @@ const addNewDevice = (state: TypedState) =>
     } catch (e) {
       // If we're canceling then ignore the error
       if (e.desc !== Constants.cancelDesc) {
+        logger.error(`Provision -> Add device error: ${e.message}`)
         yield Saga.put(ProvisionGen.createProvisionError({error: new HiddenString(niceError(e))}))
       }
     }

--- a/shared/provision/set-public-name/container.js
+++ b/shared/provision/set-public-name/container.js
@@ -18,8 +18,7 @@ const mapDispatchToProps = (dispatch, ownProps: OwnProps) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const nameTaken = stateProps._existingDevices.indexOf(ownProps.deviceName) !== -1
-  const submitEnabled = !!(ownProps.deviceName.length >= 3 && ownProps.deviceName.length <= 64 && !nameTaken)
+  const submitEnabled = !!(ownProps.deviceName.length >= 3 && ownProps.deviceName.length <= 64)
   const onSubmit = submitEnabled ? () => dispatchProps._onSubmit(ownProps.deviceName) : null
   return {
     deviceName: ownProps.deviceName,
@@ -32,11 +31,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 
 export default compose(
   withStateHandlers(
-    {deviceName: '', submitEnabled: false},
+    {deviceName: ''},
     {
       onChange: () => (deviceName: string) => ({deviceName: Constants.cleanDeviceName(deviceName)}),
     }
   ),
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
-  safeSubmit(['onSubmit', 'onBack'], ['error'])
+  safeSubmit(['onSubmit', 'onBack'], ['deviceName', 'error'])
 )(SetPublicName)

--- a/shared/reducers/provision.js
+++ b/shared/reducers/provision.js
@@ -58,11 +58,11 @@ export default function(state: Types.State = initialState, action: ProvisionGen.
         error: initialState.error,
       })
     case ProvisionGen.submitDeviceName:
-      if (state.existingDevices.indexOf(action.payload.name) !== -1) {
+      if (state.existingDevices.find(ed => ed.toLowerCase() === action.payload.name.toLowerCase())) {
         return state.merge({
           deviceName: action.payload.name,
           error: new HiddenString(
-            `The device name: '${
+            `The device name '${
               action.payload.name
             }' is already taken. You can't reuse device names, even revoked ones, for security reasons. Otherwise, someone who stole one of your devices could cause a lot of confusion.`
           ),

--- a/shared/reducers/provision.js
+++ b/shared/reducers/provision.js
@@ -58,7 +58,8 @@ export default function(state: Types.State = initialState, action: ProvisionGen.
         error: initialState.error,
       })
     case ProvisionGen.submitDeviceName:
-      if (state.existingDevices.find(ed => ed.toLowerCase() === action.payload.name.toLowerCase())) {
+      const newNameLowerCase = action.payload.name.toLowerCase()
+      if (state.existingDevices.find(ed => ed.toLowerCase() === newNameLowerCase)) {
         return state.merge({
           deviceName: action.payload.name,
           error: new HiddenString(


### PR DESCRIPTION
We had split the error handling for reusing device names, some in the reducer and some in the view container. The reducer set the error, but since the container disallowed submitting the error was never shown. This consolidates the handling in the reducer so the user can hit 'Submit' and will see an error if the device name has been used. r? @keybase/react-hackers 