### PR TITLE
Make 'Please tell us' on black bar work when logged out

### DIFF
--- a/shared/app/global-errors/container.js
+++ b/shared/app/global-errors/container.js
@@ -7,6 +7,7 @@ import {feedbackTab} from '../../constants/settings'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 
 const mapStateToProps = state => ({
+  _loggedIn: state.config.loggedIn,
   daemonError: state.config.daemonError,
   debugDump: state.config.debugDump,
   error: state.config.globalError,
@@ -18,22 +19,38 @@ const mapDispatchToProps = dispatch => ({
     dispatch(ConfigGen.createGlobalError({globalError: null}))
     dispatch(ConfigGen.createDebugDump({items: []}))
   },
-  onFeedback: () => {
+  onFeedback: (loggedIn: boolean) => {
     dispatch(ConfigGen.createGlobalError({globalError: null}))
-    dispatch(RouteTreeGen.createSwitchTo({path: [settingsTab]}))
-    dispatch(
-      RouteTreeGen.createNavigateTo({
-        path: [
-          {
-            props: {heading: 'Oh no, a bug!'},
-            selected: feedbackTab,
-          },
-        ],
-        parentPath: [settingsTab],
-      })
-    )
+    if (loggedIn) {
+      dispatch(RouteTreeGen.createSwitchTo({path: [settingsTab]}))
+      dispatch(
+        RouteTreeGen.createNavigateTo({
+          path: [
+            {
+              props: {heading: 'Oh no, a bug!'},
+              selected: feedbackTab,
+            },
+          ],
+          parentPath: [settingsTab],
+        })
+      )
+    } else {
+      dispatch(RouteTreeGen.createNavigateAppend({path: ['feedback']}))
+    }
   },
 })
 
-const Connected = connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(GlobalError)
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  return {
+    ...ownProps,
+    copyToClipboard: dispatchProps.copyToClipboard,
+    daemonError: stateProps.daemonError,
+    debugDump: stateProps.debugDump,
+    error: stateProps.error,
+    onDismiss: dispatchProps.onDismiss,
+    onFeedback: () => dispatchProps.onFeedback(stateProps._loggedIn),
+  }
+}
+
+const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(GlobalError)
 export default Connected

--- a/shared/app/global-errors/container.js
+++ b/shared/app/global-errors/container.js
@@ -40,17 +40,15 @@ const mapDispatchToProps = dispatch => ({
   },
 })
 
-const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  return {
-    ...ownProps,
-    copyToClipboard: dispatchProps.copyToClipboard,
-    daemonError: stateProps.daemonError,
-    debugDump: stateProps.debugDump,
-    error: stateProps.error,
-    onDismiss: dispatchProps.onDismiss,
-    onFeedback: () => dispatchProps.onFeedback(stateProps._loggedIn),
-  }
-}
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...ownProps,
+  copyToClipboard: dispatchProps.copyToClipboard,
+  daemonError: stateProps.daemonError,
+  debugDump: stateProps.debugDump,
+  error: stateProps.error,
+  onDismiss: dispatchProps.onDismiss,
+  onFeedback: () => dispatchProps.onFeedback(stateProps._loggedIn),
+})
 
 const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(GlobalError)
 export default Connected


### PR DESCRIPTION
Adds a check on `state.config.loggedIn` and navigates with login routes rather than app routes. r? @keybase/react-hackers 