### PR TITLE
Fix misencoded RPCs after a disconnect

### DIFF
--- a/shared/engine/__tests__/transport-shared.test.js
+++ b/shared/engine/__tests__/transport-shared.test.js
@@ -11,6 +11,10 @@ describe('TransportShared', () => {
       this._messages = []
     }
 
+    is_connected = () => {
+      return true
+    }
+
     send = (msg: any) => {
       this._messages.push(msg)
     }

--- a/shared/engine/__tests__/transport-shared.test.js
+++ b/shared/engine/__tests__/transport-shared.test.js
@@ -40,27 +40,33 @@ describe('TransportShared', () => {
     }
   }
 
+  const args = {
+    arg1: 5,
+    arg2: 'value',
+  }
+  const invokeArg = {program: 'myProgram', method: 'myMethod', args: [args], notify: false}
+
+  const expectedMessage = [0, 1, 'myProgram.myMethod', [args]]
+
   it('invoke', () => {
     const t = new FakeTransportShared()
-    const msg = {program: 'foo', method: 'bar', args: [{}], notify: false}
 
     t.connected = true
-    t.invoke(msg, () => {})
-    expect(t.lastMessage).toEqual([0, 1, 'foo.bar', msg.args])
+    t.invoke(invokeArg, () => {})
+    expect(t.lastMessage).toEqual(expectedMessage)
   })
 
   it('invoke queued', () => {
     const t = new FakeTransportShared()
-    const msg = {program: 'foo', method: 'bar', args: [{}], notify: false}
 
     t.connected = false
-    t.invoke(msg, () => {})
-    expect(t.messages).toBe(null)
+    t.invoke(invokeArg, () => {})
+    expect(t.lastMessage).toBe(null)
 
     t.connected = true
 
     // $FlowIssue Flow doesn't see inherited methods.
     t._flush_queue()
-    expect(t.lastMessage).toEqual([0, 1, 'foo.bar', msg.args])
+    expect(t.lastMessage).toEqual(expectedMessage)
   })
 })

--- a/shared/engine/__tests__/transport-shared.test.js
+++ b/shared/engine/__tests__/transport-shared.test.js
@@ -1,0 +1,24 @@
+// @flow
+/* eslint-env jest */
+import {TransportShared} from '../transport-shared'
+
+describe('TransportShared', () => {
+  class FakeTransportShared extends TransportShared {
+    _messages: any[]
+
+    constructor() {
+      super({}, () => {}, () => {}, () => {})
+      this._messages = []
+    }
+
+    send = (msg: any) => {
+      this._messages.push(msg)
+    }
+  }
+  it('invoke', () => {
+    const t = new FakeTransportShared()
+    const msg = {foo: 'bar'}
+    t.invoke(msg, () => {})
+    expect(t._messages).toBe([msg])
+  })
+})

--- a/shared/engine/__tests__/transport-shared.test.js
+++ b/shared/engine/__tests__/transport-shared.test.js
@@ -5,20 +5,36 @@ import {TransportShared} from '../transport-shared'
 describe('TransportShared', () => {
   type MessageType = [number, number, string, Object]
 
+  // Extend TransportShared to fake out some methods.
   class FakeTransportShared extends TransportShared {
     connected: boolean
     lastMessage: ?MessageType
 
     constructor() {
-      super({}, () => {}, () => {}, () => {})
+      super(
+        {},
+        () => {
+          console.log('connectCallback')
+        },
+        () => {
+          console.log('disconnectCallback')
+        },
+        () => {
+          console.log('incomingRPCCallback')
+        }
+      )
       this.connected = false
       this.lastMessage = null
     }
 
+    // Override Transport.is_connected -- see transport.iced in
+    // framed-msgpack-rpc.
     is_connected = () => {
       return this.connected
     }
 
+    // Override Packetizer.send -- see packetizer.iced in
+    // framed-msgpack-rpc.
     send = (msg: MessageType) => {
       this.lastMessage = msg
     }

--- a/shared/engine/__tests__/transport-shared.test.js
+++ b/shared/engine/__tests__/transport-shared.test.js
@@ -21,8 +21,8 @@ describe('TransportShared', () => {
   }
   it('invoke', () => {
     const t = new FakeTransportShared()
-    const msg = {foo: 'bar'}
+    const msg = {program: 'foo', method: 'bar', args: {}, notify: null}
     t.invoke(msg, () => {})
-    expect(t._messages).toBe([msg])
+    expect(t._messages).toEqual([[0, 1, 'foo.bar', [msg.args]]])
   })
 })

--- a/shared/engine/__tests__/transport-shared.test.js
+++ b/shared/engine/__tests__/transport-shared.test.js
@@ -24,7 +24,7 @@ describe('TransportShared', () => {
 
   it('invoke', () => {
     const t = new FakeTransportShared()
-    const msg = {program: 'foo', method: 'bar', args: {}, notify: null}
+    const msg = {program: 'foo', method: 'bar', args: {}}
 
     t.connected = true
     t.invoke(msg, () => {})
@@ -33,7 +33,7 @@ describe('TransportShared', () => {
 
   it('invoke queued', () => {
     const t = new FakeTransportShared()
-    const msg = {program: 'foo', method: 'bar', args: {}, notify: null}
+    const msg = {program: 'foo', method: 'bar', args: {}}
 
     t.connected = false
     t.invoke(msg, () => {})

--- a/shared/engine/__tests__/transport-shared.test.js
+++ b/shared/engine/__tests__/transport-shared.test.js
@@ -3,22 +3,24 @@
 import {TransportShared} from '../transport-shared'
 
 describe('TransportShared', () => {
+  type MessageType = [number, number, string, Object]
+
   class FakeTransportShared extends TransportShared {
     connected: boolean
-    messages: any[]
+    lastMessage: ?MessageType
 
     constructor() {
       super({}, () => {}, () => {}, () => {})
       this.connected = false
-      this.messages = []
+      this.lastMessage = null
     }
 
     is_connected = () => {
       return this.connected
     }
 
-    send = (msg: any) => {
-      this.messages.push(msg)
+    send = (msg: MessageType) => {
+      this.lastMessage = msg
     }
   }
 
@@ -28,7 +30,7 @@ describe('TransportShared', () => {
 
     t.connected = true
     t.invoke(msg, () => {})
-    expect(t.messages).toEqual([[0, 1, 'foo.bar', msg.args]])
+    expect(t.lastMessage).toEqual([0, 1, 'foo.bar', msg.args])
   })
 
   it('invoke queued', () => {
@@ -37,12 +39,12 @@ describe('TransportShared', () => {
 
     t.connected = false
     t.invoke(msg, () => {})
-    expect(t.messages).toEqual([])
+    expect(t.messages).toBe(null)
 
     t.connected = true
 
     // $FlowIssue Flow doesn't see inherited methods.
     t._flush_queue()
-    expect(t.messages).toEqual([[0, 1, 'foo.bar', msg.args]])
+    expect(t.lastMessage).toEqual([0, 1, 'foo.bar', msg.args])
   })
 })

--- a/shared/engine/__tests__/transport-shared.test.js
+++ b/shared/engine/__tests__/transport-shared.test.js
@@ -11,18 +11,7 @@ describe('TransportShared', () => {
     lastMessage: ?MessageType
 
     constructor() {
-      super(
-        {},
-        () => {
-          console.log('connectCallback')
-        },
-        () => {
-          console.log('disconnectCallback')
-        },
-        () => {
-          console.log('incomingRPCCallback')
-        }
-      )
+      super({}, () => {}, () => {}, () => {})
       this.connected = false
       this.lastMessage = null
     }
@@ -52,6 +41,7 @@ describe('TransportShared', () => {
     const t = new FakeTransportShared()
 
     t.connected = true
+    // Since connected is true, this should call send.
     t.invoke(invokeArg, () => {})
     expect(t.lastMessage).toEqual(expectedMessage)
   })
@@ -60,11 +50,16 @@ describe('TransportShared', () => {
     const t = new FakeTransportShared()
 
     t.connected = false
+    // Since connected is false, this should queue up the message.
     t.invoke(invokeArg, () => {})
     expect(t.lastMessage).toBe(null)
 
     t.connected = true
-
+    // _flush_queue is defined in Transport in transport.iced in
+    // framed-msgpack-rpc.
+    //
+    // Since connected is true, this should call send.
+    //
     // $FlowIssue Flow doesn't see inherited methods.
     t._flush_queue()
     expect(t.lastMessage).toEqual(expectedMessage)

--- a/shared/engine/__tests__/transport-shared.test.js
+++ b/shared/engine/__tests__/transport-shared.test.js
@@ -4,25 +4,45 @@ import {TransportShared} from '../transport-shared'
 
 describe('TransportShared', () => {
   class FakeTransportShared extends TransportShared {
-    _messages: any[]
+    connected: boolean
+    messages: any[]
 
     constructor() {
       super({}, () => {}, () => {}, () => {})
-      this._messages = []
+      this.connected = false
+      this.messages = []
     }
 
     is_connected = () => {
-      return true
+      return this.connected
     }
 
     send = (msg: any) => {
-      this._messages.push(msg)
+      this.messages.push(msg)
     }
   }
+
   it('invoke', () => {
     const t = new FakeTransportShared()
     const msg = {program: 'foo', method: 'bar', args: {}, notify: null}
+
+    t.connected = true
     t.invoke(msg, () => {})
-    expect(t._messages).toEqual([[0, 1, 'foo.bar', [msg.args]]])
+    expect(t.messages).toEqual([[0, 1, 'foo.bar', [msg.args]]])
+  })
+
+  it('invoke queued', () => {
+    const t = new FakeTransportShared()
+    const msg = {program: 'foo', method: 'bar', args: {}, notify: null}
+
+    t.connected = false
+    t.invoke(msg, () => {})
+    expect(t.messages).toEqual([])
+
+    t.connected = true
+
+    // $FlowIssue Flow doesn't see inherited methods.
+    t._flush_queue()
+    expect(t.messages).toEqual([[0, 1, 'foo.bar', [msg.args]]])
   })
 })

--- a/shared/engine/__tests__/transport-shared.test.js
+++ b/shared/engine/__tests__/transport-shared.test.js
@@ -24,16 +24,16 @@ describe('TransportShared', () => {
 
   it('invoke', () => {
     const t = new FakeTransportShared()
-    const msg = {program: 'foo', method: 'bar', args: {}}
+    const msg = {program: 'foo', method: 'bar', args: [{}], notify: false}
 
     t.connected = true
     t.invoke(msg, () => {})
-    expect(t.messages).toEqual([[0, 1, 'foo.bar', [msg.args]]])
+    expect(t.messages).toEqual([[0, 1, 'foo.bar', msg.args]])
   })
 
   it('invoke queued', () => {
     const t = new FakeTransportShared()
-    const msg = {program: 'foo', method: 'bar', args: {}}
+    const msg = {program: 'foo', method: 'bar', args: [{}], notify: false}
 
     t.connected = false
     t.invoke(msg, () => {})
@@ -43,6 +43,6 @@ describe('TransportShared', () => {
 
     // $FlowIssue Flow doesn't see inherited methods.
     t._flush_queue()
-    expect(t.messages).toEqual([[0, 1, 'foo.bar', [msg.args]]])
+    expect(t.messages).toEqual([[0, 1, 'foo.bar', msg.args]])
   })
 })

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -271,7 +271,7 @@ class Engine {
     const session = this.createSession({incomingCallMap: p.incomingCallMap, waitingKey: p.waitingKey})
     // Don't make outgoing calls immediately since components can do this when they mount
     setImmediate(() => {
-      session.start(p.method, [p.params], p.callback)
+      session.start(p.method, p.params, p.callback)
     })
     return session.getId()
   }

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -272,7 +272,7 @@ class Engine {
     const session = this.createSession({incomingCallMap, waitingKey})
     // Don't make outgoing calls immediately since components can do this when they mount
     setImmediate(() => {
-      session.start(method, params, callback)
+      session.start(method, [params || {}], callback)
     })
     return session.getId()
   }

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -262,17 +262,16 @@ class Engine {
   // An outgoing call. ONLY called by the flow-type rpc helpers
   _rpcOutgoing(p: {
     method: string,
-    params: ?Object,
+    params: Object,
     callback: (...args: Array<any>) => void,
     incomingCallMap?: any, // IncomingCallMapType, actually a mix of all the incomingcallmap types, which we don't handle yet TODO we could mix them all
     waitingKey?: string,
   }) {
-    const {method, params = {}, callback, incomingCallMap, waitingKey} = p
     // Make a new session and start the request
-    const session = this.createSession({incomingCallMap, waitingKey})
+    const session = this.createSession({incomingCallMap: p.incomingCallMap, waitingKey: p.waitingKey})
     // Don't make outgoing calls immediately since components can do this when they mount
     setImmediate(() => {
-      session.start(method, [params || {}], callback)
+      session.start(p.method, [p.params], p.callback)
     })
     return session.getId()
   }

--- a/shared/engine/index.platform.js.flow
+++ b/shared/engine/index.platform.js.flow
@@ -5,8 +5,8 @@ type payloadType = {
   response: ?Object,
 }
 
-// Client in client.iced in framed-msgpack-rpc takes a list of
-// arguments, but we only ever pass in a single object with keyed
+// Client.invoke in client.iced in framed-msgpack-rpc ostensibly takes
+// a list of arguments, but it expects exactly one element with keyed
 // arguments.
 export type invokeType = (method: string, args: [Object], cb: (err: any, data: any) => void) => void
 export type createClientType = {

--- a/shared/engine/index.platform.js.flow
+++ b/shared/engine/index.platform.js.flow
@@ -5,11 +5,13 @@ type payloadType = {
   response: ?Object,
 }
 
-export type invokeType = (method: string, param: ?Object, cb: (err: any, data: any) => void) => void
+export type transportInvokeArgs = {|program: string, method: string, args: [Object], notify: boolean|}
+export type invokeType = (method: string, param: [Object], cb: (err: any, data: any) => void) => void
 export type createClientType = {
   transport: {
     needsConnect: boolean,
     reset: () => void,
+    invoke: (transportInvokeArgs) => void,
   },
   invoke: invokeType,
 }

--- a/shared/engine/index.platform.js.flow
+++ b/shared/engine/index.platform.js.flow
@@ -5,13 +5,11 @@ type payloadType = {
   response: ?Object,
 }
 
-export type transportInvokeArgs = {|program: string, method: string, args: [Object], notify: boolean|}
 export type invokeType = (method: string, param: [Object], cb: (err: any, data: any) => void) => void
 export type createClientType = {
   transport: {
     needsConnect: boolean,
     reset: () => void,
-    invoke: (transportInvokeArgs) => void,
   },
   invoke: invokeType,
 }

--- a/shared/engine/index.platform.js.flow
+++ b/shared/engine/index.platform.js.flow
@@ -5,7 +5,10 @@ type payloadType = {
   response: ?Object,
 }
 
-export type invokeType = (method: string, param: [Object], cb: (err: any, data: any) => void) => void
+// Client in client.iced in framed-msgpack-rpc takes a list of
+// arguments, but we only ever pass in a single object with keyed
+// arguments.
+export type invokeType = (method: string, args: [Object], cb: (err: any, data: any) => void) => void
 export type createClientType = {
   transport: {
     needsConnect: boolean,

--- a/shared/engine/request.js
+++ b/shared/engine/request.js
@@ -9,16 +9,13 @@ type SimpleWaiting = (waiting: boolean) => void
 class Request {
   // RPC call name
   method: MethodKey
-  // RPC parameters
-  param: Object
   // Let others know our waiting state
   _waitingHandler: (waiting: boolean) => void
   // If we're waiting for a response
   _waiting: boolean = false
 
-  constructor(method: MethodKey, param: ?Object, waitingHandler: SimpleWaiting) {
+  constructor(method: MethodKey, waitingHandler: SimpleWaiting) {
     this.method = method
-    this.param = param || {}
     this._waitingHandler = waitingHandler
   }
 
@@ -29,6 +26,8 @@ class Request {
 }
 
 class IncomingRequest extends Request {
+  // RPC parameters
+  param: Object
   // Callback in the incomingCallMap
   _handler: (param: ?Object, request: ResponseType) => void
   _response: ?ResponseType
@@ -40,8 +39,8 @@ class IncomingRequest extends Request {
     waitingHandler: SimpleWaiting,
     handler: Function
   ) {
-    super(method, param, waitingHandler)
-
+    super(method, waitingHandler)
+    this.param = param || {}
     this._handler = handler
     this._response = response
   }
@@ -69,6 +68,8 @@ class IncomingRequest extends Request {
 }
 
 class OutgoingRequest extends Request {
+  // RPC parameters
+  param: [Object]
   // Callback when we've gotten a response
   _callback: (err: any, data: any) => void
   // How we make calls
@@ -76,12 +77,13 @@ class OutgoingRequest extends Request {
 
   constructor(
     method: MethodKey,
-    param: ?Object,
+    param: [Object],
     callback: () => void,
     waitingHandler: SimpleWaiting,
     invoke: invokeType
   ) {
-    super(method, param, waitingHandler)
+    super(method, waitingHandler)
+    this.param = param
     this._invoke = invoke
     this._callback = callback
   }

--- a/shared/engine/request.js
+++ b/shared/engine/request.js
@@ -9,13 +9,16 @@ type SimpleWaiting = (waiting: boolean) => void
 class Request {
   // RPC call name
   method: MethodKey
+  // RPC parameters
+  param: Object
   // Let others know our waiting state
   _waitingHandler: (waiting: boolean) => void
   // If we're waiting for a response
   _waiting: boolean = false
 
-  constructor(method: MethodKey, waitingHandler: SimpleWaiting) {
+  constructor(method: MethodKey, param: Object, waitingHandler: SimpleWaiting) {
     this.method = method
+    this.param = param
     this._waitingHandler = waitingHandler
   }
 
@@ -26,21 +29,19 @@ class Request {
 }
 
 class IncomingRequest extends Request {
-  // RPC parameters
-  param: Object
   // Callback in the incomingCallMap
   _handler: (param: ?Object, request: ResponseType) => void
   _response: ?ResponseType
 
   constructor(
     method: MethodKey,
-    param: ?Object,
+    param: Object,
     response: ?ResponseType,
     waitingHandler: SimpleWaiting,
     handler: Function
   ) {
-    super(method, waitingHandler)
-    this.param = param || {}
+    super(method, param, waitingHandler)
+
     this._handler = handler
     this._response = response
   }
@@ -68,8 +69,6 @@ class IncomingRequest extends Request {
 }
 
 class OutgoingRequest extends Request {
-  // RPC parameters
-  param: Object
   // Callback when we've gotten a response
   _callback: (err: any, data: any) => void
   // How we make calls
@@ -82,8 +81,7 @@ class OutgoingRequest extends Request {
     waitingHandler: SimpleWaiting,
     invoke: invokeType
   ) {
-    super(method, waitingHandler)
-    this.param = param
+    super(method, param, waitingHandler)
     this._invoke = invoke
     this._callback = callback
   }

--- a/shared/engine/request.js
+++ b/shared/engine/request.js
@@ -72,7 +72,7 @@ class OutgoingRequest extends Request {
   // Callback when we've gotten a response
   _callback: (err: any, data: any) => void
   // How we make calls
-  _invoke: ?invokeType
+  _invoke: invokeType
 
   constructor(
     method: MethodKey,

--- a/shared/engine/request.js
+++ b/shared/engine/request.js
@@ -69,7 +69,7 @@ class IncomingRequest extends Request {
 
 class OutgoingRequest extends Request {
   // RPC parameters
-  param: [Object]
+  param: Object
   // Callback when we've gotten a response
   _callback: (err: any, data: any) => void
   // How we make calls
@@ -77,7 +77,7 @@ class OutgoingRequest extends Request {
 
   constructor(
     method: MethodKey,
-    param: [Object],
+    param: Object,
     callback: () => void,
     waitingHandler: SimpleWaiting,
     invoke: invokeType
@@ -91,7 +91,7 @@ class OutgoingRequest extends Request {
   send(): void {
     this.updateWaiting(true)
     if (this._invoke) {
-      this._invoke(this.method, this.param, (err, data) => this._sendCallback(err, data))
+      this._invoke(this.method, [this.param], (err, data) => this._sendCallback(err, data))
     }
   }
 

--- a/shared/engine/request.js
+++ b/shared/engine/request.js
@@ -88,9 +88,7 @@ class OutgoingRequest extends Request {
 
   send(): void {
     this.updateWaiting(true)
-    if (this._invoke) {
-      this._invoke(this.method, [this.param], (err, data) => this._sendCallback(err, data))
-    }
+    this._invoke(this.method, [this.param], (err, data) => this._sendCallback(err, data))
   }
 
   _sendCallback(err: any, data: any): void {

--- a/shared/engine/session.js
+++ b/shared/engine/session.js
@@ -119,7 +119,7 @@ class Session {
   }
 
   // Start the session normally. Tells engine we're done at the end
-  start(method: MethodKey, param: [Object], callback: ?() => void) {
+  start(method: MethodKey, param: Object, callback: ?() => void) {
     this._startMethod = method
     this._startCallback = callback
 
@@ -132,12 +132,10 @@ class Session {
     }
 
     // Add the sessionID
-    const wrappedParam = [
-      {
-        ...param[0],
-        sessionID: this.getId(),
-      },
-    ]
+    const wrappedParam = {
+      ...param,
+      sessionID: this.getId(),
+    }
 
     rpcLog({
       extra: {id: this.getId(), this: this},

--- a/shared/engine/session.js
+++ b/shared/engine/session.js
@@ -119,7 +119,7 @@ class Session {
   }
 
   // Start the session normally. Tells engine we're done at the end
-  start(method: MethodKey, param: ?Object, callback: ?() => void) {
+  start(method: MethodKey, param: [Object], callback: ?() => void) {
     this._startMethod = method
     this._startCallback = callback
 
@@ -132,10 +132,12 @@ class Session {
     }
 
     // Add the sessionID
-    const wrappedParam = {
-      ...param,
-      sessionID: this.getId(),
-    }
+    const wrappedParam = [
+      {
+        ...param[0],
+        sessionID: this.getId(),
+      },
+    ]
 
     rpcLog({
       extra: {id: this.getId(), this: this},

--- a/shared/engine/transport-shared.js
+++ b/shared/engine/transport-shared.js
@@ -15,7 +15,7 @@ function _wrap<A1, A2, A3, A4, A5, F: (A1, A2, A3, A4, A5) => void>(options: {|
   type: string,
   method: string | ((...Array<any>) => string),
   reason: string,
-  extra: [Object] | Object | ((...Array<any>) => Object),
+  extra: Object | ((...Array<any>) => Object),
   // we only want to enfoce a single callback on some wrapped things
   enforceOnlyOnce: boolean,
 |}): F {
@@ -47,7 +47,7 @@ function _wrap<A1, A2, A3, A4, A5, F: (A1, A2, A3, A4, A5) => void>(options: {|
 }
 
 // Logging for rpcs
-function rpcLog(info: {method: string, reason?: string, extra?: Object | [Object], type: string}): void {
+function rpcLog(info: {method: string, reason: string, extra?: Object, type: string}): void {
   if (!printRPC) {
     return
   }
@@ -164,7 +164,7 @@ class TransportShared extends RobustTransport {
   invoke(arg: InvokeArgs, cb: any) {
     const wrappedInvoke = _wrap({
       enforceOnlyOnce: true,
-      extra: arg.args,
+      extra: arg.args[0],
       handler: (args: InvokeArgs) => {
         super.invoke(
           args,

--- a/shared/engine/transport-shared.js
+++ b/shared/engine/transport-shared.js
@@ -13,9 +13,9 @@ const RpcClient = rpc.client.Client
 function _wrap<A1, A2, A3, A4, A5, F: (A1, A2, A3, A4, A5) => void>(options: {|
   handler: F,
   type: string,
-  method?: string | ((...Array<any>) => string),
-  reason?: string,
-  extra?: [Object] | Object | ((...Array<any>) => Object),
+  method: string | ((...Array<any>) => string),
+  reason: string,
+  extra: [Object] | Object | ((...Array<any>) => Object),
   // we only want to enfoce a single callback on some wrapped things
   enforceOnlyOnce: boolean,
 |}): F {

--- a/shared/engine/transport-shared.js
+++ b/shared/engine/transport-shared.js
@@ -5,7 +5,6 @@ import {printRPC, printRPCWaitingSession} from '../local-debug'
 import {requestIdleCallback} from '../util/idle-callback'
 import * as LocalConsole from '../util/local-console'
 import * as Stats from './stats'
-import {type transportInvokeArgs} from './index.platform'
 
 const RobustTransport = rpc.transport.RobustTransport
 const RpcClient = rpc.client.Client
@@ -71,6 +70,8 @@ function rpcLog(info: {method: string, reason?: string, extra?: Object | [Object
     {timeout: 1e3}
   )
 }
+
+type InvokeArgs = {|program: string, method: string, args: [Object], notify: boolean|}
 
 class TransportShared extends RobustTransport {
   constructor(
@@ -160,11 +161,11 @@ class TransportShared extends RobustTransport {
     }
   }
 
-  invoke(arg: transportInvokeArgs, cb: any) {
+  invoke(arg: InvokeArgs, cb: any) {
     const wrappedInvoke = _wrap({
       enforceOnlyOnce: true,
       extra: arg.args,
-      handler: (args: transportInvokeArgs) => {
+      handler: (args: InvokeArgs) => {
         super.invoke(
           args,
           _wrap({

--- a/shared/engine/transport-shared.js
+++ b/shared/engine/transport-shared.js
@@ -15,7 +15,7 @@ function _wrap<A1, A2, A3, A4, A5, F: (A1, A2, A3, A4, A5) => void>(options: {|
   type: string,
   method?: string | ((...Array<any>) => string),
   reason?: string,
-  extra?: Object | ((...Array<any>) => Object),
+  extra?: Array<any> | Object | ((...Array<any>) => Object),
   // we only want to enfoce a single callback on some wrapped things
   enforceOnlyOnce: boolean,
 |}): F {
@@ -47,7 +47,7 @@ function _wrap<A1, A2, A3, A4, A5, F: (A1, A2, A3, A4, A5) => void>(options: {|
 }
 
 // Logging for rpcs
-function rpcLog(info: {method: string, reason?: string, extra?: Object, type: string}): void {
+function rpcLog(info: {method: string, reason?: string, extra?: Object | Array<any>, type: string}): void {
   if (!printRPC) {
     return
   }
@@ -159,7 +159,7 @@ class TransportShared extends RobustTransport {
     }
   }
 
-  invoke(arg: Object, cb: any) {
+  invoke(arg: {program: string, method: string, args: Object}, cb: any) {
     // args needs to be wrapped as an array for some reason so let's just do that here
     const wrappedArgs = {
       ...arg,


### PR DESCRIPTION
Our RPC library takes a list of arguments, but our RPCs only ever use a single
element with keyed arguments. Therefore, we have to wrap the argument object
in an array, and we were doing this in TransportShared.invoke.

On disconnect, the arguments to invoke were being stored in a queue,
which is then flushed to call invoke again. Unfortunately, this results in array-wrapping
again, which the service doesn't expect.

Move the wrapping a few levels up, and add a regression test.

Fix types in a few places, and add more types.