### PR TITLE
Remove onclick handler from remove account if this is the default

### DIFF
--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -101,7 +101,7 @@ const AccountSettings = (props: SettingsProps) => {
         <Kb.Text type="BodySmall">- near your Lumens balance</Kb.Text>
         <Kb.Text type="BodySmall">- when sending or receiving Lumens</Kb.Text>
         <Kb.Box2 direction="vertical" fullWidth={true} style={styles.removeContainer}>
-          <Kb.ClickableBox style={styles.remove} onClick={props.onDelete}>
+          <Kb.ClickableBox style={styles.remove} onClick={props.isDefault ? null : props.onDelete}>
             <Kb.Icon
               type="iconfont-trash"
               style={Styles.collapseStyles([styles.rightMargin, props.isDefault && styles.deleteOpacity])}
@@ -110,7 +110,7 @@ const AccountSettings = (props: SettingsProps) => {
             <Kb.Text
               type="BodySemibold"
               style={Styles.collapseStyles([styles.red, props.isDefault && styles.deleteOpacity])}
-              className="hover-underline"
+              className={props.isDefault ? '' : 'hover-underline'}
             >
               Remove account
             </Kb.Text>


### PR DESCRIPTION
We reduced the opacity to indicate that it's disabled but not the click handler so you could still get to the dialog. This removes the click handler if we're on the settings for the default account. r? @keybase/react-hackers 