### PR TITLE
test no stub on subchains

### DIFF
--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -824,23 +824,26 @@ func (sc *SigChain) verifySigsAndComputeKeysHistorical(m MetaContext, allLinks C
 		}
 
 		i := len(allLinks) - 1
-		eldest := allLinks[i].ToEldestKID()
+		link := allLinks[i]
+		eldest := link.ToEldestKID()
+		seqno := link.GetSeqno()
+
 		if eldest.IsNil() {
-			m.CDebugf("Ending iteration through previous subchains; saw a nil eldest (@%d)", i)
+			m.CDebugf("Ending iteration through previous subchains; saw a nil eldest (@%d)", seqno)
 			break
 		}
-		m.CDebugf("Examining subchain that ends at %d with eldest %s", i, eldest)
+		m.CDebugf("Examining subchain that ends at %d with eldest %s", seqno, eldest)
 
 		var links ChainLinks
 		links, err = cropToRightmostSubchain(allLinks, eldest)
 		if err != nil {
-			m.CInfof("Error backtracking all links from %d: %s", i, err)
+			m.CInfof("Error backtracking all links from %d: %s", seqno, err)
 			break
 		}
 
 		cached, _, err = sc.verifySubchain(m, kf, links)
 		if err != nil {
-			m.CInfof("Error verifying subchain from %d: %s", i, err)
+			m.CInfof("Error verifying subchain from %d: %s", seqno, err)
 			break
 		}
 		if !cached {

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -177,9 +177,7 @@ func (tt *teamTester) addUserHelper(pre string, puk bool, paper bool, wallet boo
 	g.SetUI(&signupUI)
 	signup := client.NewCmdSignupRunner(g)
 	signup.SetTestWithPaper(paper)
-	if err := signup.Run(); err != nil {
-		tt.t.Fatal(err)
-	}
+	require.NoError(tt.t, signup.Run())
 	tt.t.Logf("signed up %s", userInfo.username)
 
 	u.tc = tc
@@ -189,9 +187,7 @@ func (tt *teamTester) addUserHelper(pre string, puk bool, paper bool, wallet boo
 	u.uid = libkb.UsernameToUID(u.username)
 
 	cli, xp, err := client.GetRPCClientWithContext(g)
-	if err != nil {
-		tt.t.Fatal(err)
-	}
+	require.NoError(tt.t, err)
 
 	u.deviceClient = keybase1.DeviceClient{Cli: cli}
 	u.device.userClient = keybase1.UserClient{Cli: cli}
@@ -200,23 +196,19 @@ func (tt *teamTester) addUserHelper(pre string, puk bool, paper bool, wallet boo
 	// register for notifications
 	u.notifications = newTeamNotifyHandler()
 	srv := rpc.NewServer(xp, nil)
-	if err = srv.Register(keybase1.NotifyTeamProtocol(u.notifications)); err != nil {
-		tt.t.Fatal(err)
-	}
-	if err = srv.Register(keybase1.NotifyBadgesProtocol(u.notifications)); err != nil {
-		tt.t.Fatal(err)
-	}
-	if err = srv.Register(keybase1.NotifyEphemeralProtocol(u.notifications)); err != nil {
-		tt.t.Fatal(err)
-	}
+	err = srv.Register(keybase1.NotifyTeamProtocol(u.notifications))
+	require.NoError(tt.t, err)
+	err = srv.Register(keybase1.NotifyBadgesProtocol(u.notifications))
+	require.NoError(tt.t, err)
+	err = srv.Register(keybase1.NotifyEphemeralProtocol(u.notifications))
+	require.NoError(tt.t, err)
 	ncli := keybase1.NotifyCtlClient{Cli: cli}
-	if err = ncli.SetNotifications(context.TODO(), keybase1.NotificationChannels{
+	err = ncli.SetNotifications(context.TODO(), keybase1.NotificationChannels{
 		Team:      true,
 		Badges:    true,
 		Ephemeral: true,
-	}); err != nil {
-		tt.t.Fatal(err)
-	}
+	})
+	require.NoError(tt.t, err)
 
 	u.teamsClient = keybase1.TeamsClient{Cli: cli}
 	u.stellarClient = newStellarRetryClient(cli)

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -220,12 +220,17 @@ func TestV2Compressed(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
+	ctx := context.TODO()
+
 	alice := tt.addUser("alice")
 	aliceG := alice.tc.G
 
 	tt.addUser("wong")
 	wong := tt.users[1]
 	wongG := wong.tc.G
+	upk, err := wongG.GetUPAKLoader().LoadUserPlusKeys(ctx, wong.uid, "")
+	require.NoError(t, err)
+
 	iuiW := newSimpleIdentifyUI()
 	attachIdentifyUI(t, wongG, iuiW)
 	iuiW.confirmRes = keybase1.ConfirmResult{IdentityConfirmed: true, RemoteConfirmed: true, AutoConfirmed: true}
@@ -233,7 +238,7 @@ func TestV2Compressed(t *testing.T) {
 	idAndListFollowers := func(username string) {
 		cli1, err := client.GetIdentifyClient(aliceG)
 		require.NoError(t, err)
-		_, err = cli1.Identify2(context.TODO(), keybase1.Identify2Arg{
+		_, err = cli1.Identify2(ctx, keybase1.Identify2Arg{
 			UserAssertion:    username,
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_GUI,
 		})
@@ -241,7 +246,7 @@ func TestV2Compressed(t *testing.T) {
 
 		cli2, err := client.GetUserClient(aliceG)
 		require.NoError(t, err)
-		_, err = cli2.ListTrackers2(context.TODO(), keybase1.ListTrackers2Arg{
+		_, err = cli2.ListTrackers2(ctx, keybase1.ListTrackers2Arg{
 			Assertion: username,
 			Reverse:   false,
 		})
@@ -260,4 +265,16 @@ func TestV2Compressed(t *testing.T) {
 	// ensure we don't stub tail since we need to check against the merkle tree
 	wong.untrack(alice.username)
 	idAndListFollowers(wong.username)
+
+	wong.reset()
+	wong.loginAfterReset()
+	tt.addUser("bob")
+	bob := tt.users[2]
+	bobG := bob.tc.G
+	for _, dk := range upk.DeviceKeys {
+		user, upak, _, err := bobG.GetUPAKLoader().LoadKeyV2(ctx, wong.uid, dk.KID)
+		require.NoError(t, err)
+		require.NotNil(t, user)
+		require.NotNil(t, upak)
+	}
 }


### PR DESCRIPTION
- adds a test for loading a previous incarnation of a user after a reset which will fail if the tail of the subchain is stubbed
- logs seqno correctly in `verifySigsAndComputeKeysHistorical`
cc @mlsteele 