### PR TITLE
Disable ephemeral during oneshot

### DIFF
--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/clockwork"
@@ -356,4 +357,62 @@ func TestCleanupStaleUserAndDeviceEKsOffline(t *testing.T) {
 	err = ekLib.keygenIfNeeded(context.Background(), libkb.MerkleRoot{})
 	require.Error(t, err)
 	require.Equal(t, SkipKeygenNilMerkleRoot, err.Error())
+}
+
+func TestLoginOneshotNoEphemeral(t *testing.T) {
+	tc, user := ephemeralKeyTestSetup(t)
+	defer tc.Cleanup()
+	uis := libkb.UIs{
+		LogUI:    tc.G.UI.GetLogUI(),
+		LoginUI:  &libkb.TestLoginUI{RevokeBackup: false},
+		SecretUI: &libkb.TestSecretUI{},
+	}
+	m := libkb.NewMetaContextForTest(tc).WithUIs(uis)
+	teamID := createTeam(tc)
+
+	ekLib := NewEKLib(tc.G)
+	defer ekLib.Shutdown()
+	teamEK, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	require.NoError(t, err)
+
+	eng := engine.NewPaperKey(tc.G)
+	err = engine.RunEngine2(m, eng)
+	require.NoError(t, err)
+	require.NotZero(t, len(eng.Passphrase()))
+	require.NoError(t, tc.G.Logout())
+
+	tc2 := libkb.SetupTest(t, "ephemeral", 2)
+	defer tc2.Cleanup()
+	m2 := libkb.NewMetaContextForTest(tc2)
+	NewEphemeralStorageAndInstall(tc2.G)
+
+	eng2 := engine.NewLoginOneshot(tc2.G, keybase1.LoginOneshotArg{
+		Username: user.NormalizedUsername().String(),
+		PaperKey: eng.Passphrase(),
+	})
+	err = engine.RunEngine2(m2, eng2)
+	require.NoError(t, err)
+
+	ekLib2 := NewEKLib(tc2.G)
+	defer ekLib2.Shutdown()
+
+	// Make sure we can't access or create any ephemeral keys
+	teamEK, err = ekLib2.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	require.Error(t, err)
+	require.Equal(t, keybase1.TeamEk{}, teamEK)
+
+	deks := tc2.G.GetDeviceEKStorage()
+	gen, err := deks.MaxGeneration(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, -1, gen)
+
+	ueks := tc2.G.GetUserEKBoxStorage()
+	gen, err = ueks.MaxGeneration(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, -1, gen)
+
+	teks := tc2.G.GetUserEKBoxStorage()
+	gen, err = teks.MaxGeneration(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, -1, gen)
 }


### PR DESCRIPTION
disable ephemeral key generation/fetching when logged in via oneshot. bug was that we didn't an return an error when detecting oneshot mode, patch fixes this and tests to verify

```
$ kb chat send --exploding-lifetime=30s test1 hi
▶ ERROR boxing error: unable to get crypt keys: Aborting ephemeral key generation, using oneshot session!
```