### PR TITLE
Include full branch name in gitPush msg when it contains slashes

### DIFF
--- a/shared/chat/conversation/messages/system-git-push/index.js
+++ b/shared/chat/conversation/messages/system-git-push/index.js
@@ -8,6 +8,8 @@ import {globalStyles, globalColors, globalMargins, isMobile, platformStyles} fro
 import {formatTimeForMessages} from '../../../../util/timestamp'
 import {gitGitPushType} from '../../../../constants/types/rpc-gen'
 
+const branchRefPrefix = 'refs/heads/'
+
 type Props = {
   message: Types.MessageSystemGitPush,
   onClickUserAvatar: (username: string) => void,
@@ -127,7 +129,10 @@ class GitPush extends React.PureComponent<Props> {
     switch (gitType) {
       case 'default':
         return refs.map(ref => {
-          const branchName = ref.refName.split('/')[2]
+          let branchName = ref.refName
+          if (branchName.startsWith(branchRefPrefix)) {
+            branchName = branchName.substring(branchRefPrefix.length)
+          } // else show full ref
           return (
             <GitPushCommon
               key={branchName}


### PR DESCRIPTION
Makes the ref parsing a little smarter. Previously we split on `'/'` and only included the second entry. 

before: 
<img width="342" alt="image" src="https://user-images.githubusercontent.com/11968340/45243749-02320700-b2c3-11e8-90a0-fdba437faa85.png">


after:
<img width="343" alt="image" src="https://user-images.githubusercontent.com/11968340/45243711-e62e6580-b2c2-11e8-87d0-64ad8019c9f8.png">

r? @keybase/react-hackers 