### PR TITLE
dont just not start the httpsrv if pinned port is taken, use a different port CORE-8729

### DIFF
--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -102,7 +102,7 @@ func (r *AttachmentHTTPSrv) startHTTPSrv() {
 				r.initHTTPSrv()
 				continue
 			}
-			r.Debug(context.TODO(), "startHTTPSrv: failed to start HTTP server: %", err)
+			r.Debug(context.TODO(), "startHTTPSrv: failed to start HTTP server: %s", err)
 			break
 		}
 		success = true

--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -52,13 +52,13 @@ func NewAttachmentHTTPSrv(g *globals.Context, fetcher types.AttachmentFetcher, r
 	r := &AttachmentHTTPSrv{
 		Contextified:    globals.NewContextified(g),
 		DebugLabeler:    utils.NewDebugLabeler(g.GetLog(), "AttachmentHTTPSrv", false),
-		httpSrv:         kbhttp.NewSrv(g.GetLog(), kbhttp.NewPortRangeListenerSource(16423, 18000)),
 		endpoint:        "at",
 		pendingEndpoint: "pe",
 		ri:              ri,
 		urlMap:          l,
 		fetcher:         fetcher,
 	}
+	r.initHTTPSrv()
 	r.startHTTPSrv()
 	g.PushShutdownHook(func() error {
 		r.httpSrv.Stop()
@@ -84,9 +84,32 @@ func (r *AttachmentHTTPSrv) monitorAppState() {
 	}
 }
 
+func (r *AttachmentHTTPSrv) initHTTPSrv() {
+	r.httpSrv = kbhttp.NewSrv(r.G().GetLog(), kbhttp.NewPortRangeListenerSource(16423, 18000))
+}
+
 func (r *AttachmentHTTPSrv) startHTTPSrv() {
-	if err := r.httpSrv.Start(); err != nil {
-		r.Debug(context.TODO(), "startHTTPSrv: failed to start HTTP server: %", err)
+	maxTries := 2
+	success := false
+	for i := 0; i < maxTries; i++ {
+		if err := r.httpSrv.Start(); err != nil {
+			if err == kbhttp.ErrPinnedPortInUse {
+				// If we hit this, just try again and get a different port.
+				// The advantage is that backing in and out of the thread will restore attachments,
+				// whereas if we do nothing you need to bkg/foreground.
+				r.Debug(context.TODO(),
+					"startHTTPSrv: pinned port taken error, re-initializing and trying again")
+				r.initHTTPSrv()
+				continue
+			}
+			r.Debug(context.TODO(), "startHTTPSrv: failed to start HTTP server: %", err)
+			break
+		}
+		success = true
+		break
+	}
+	if !success {
+		r.Debug(context.TODO(), "startHTTPSrv: exhausted attempts to start HTTP server, giving up")
 		return
 	}
 	r.httpSrv.HandleFunc("/"+r.endpoint, r.serve)


### PR DESCRIPTION
Not sure if KBFS uses `PortRangeListenerSource`, but this tries to improve how attachments work if a process somehow gets the "pinned" port from it on mobile app foreground. Previously, if that happened then the server would just be dead until we backgrounded/foregrounded again. However, with this solution it will shift to a new port. That might mean we render blank attachments on initial thread load, but backing in and out of thread would fix the problem. 