### PR TITLE
Make currency conversion selectable

### DIFF
--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -62,7 +62,7 @@ const AssetInput = (props: Props) => (
       </Text>
     )}
     <Box2 direction="horizontal" fullWidth={true} gap="xtiny">
-      <Text type="BodySmall" style={styles.labelMargin}>
+      <Text type="BodySmall" style={styles.labelMargin} selectable={true}>
         {props.bottomLabel}
       </Text>
       <Icon


### PR DESCRIPTION
This conversion display isn't implemented in the GUI yet, you can see it in storybook [here](http://localhost:6006/?selectedKind=Wallets%2FSendForm%2FAsset%20input&selectedStory=XLM%20worth%20USD&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel). r? @keybase/react-hackers 