### PR TITLE
keybase chat api-listen

### DIFF
--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1000,7 +1000,7 @@ func computeOutboxOrdinal(obr chat1.OutboxRecord) float64 {
 	return float64(obr.Msg.ClientHeader.OutboxInfo.Prev) + float64(obr.Ordinal)/1000.0
 }
 
-func presentChannelNameMentions(ctx context.Context, crs []chat1.ChannelNameMention) (res []chat1.UIChannelNameMention) {
+func PresentChannelNameMentions(ctx context.Context, crs []chat1.ChannelNameMention) (res []chat1.UIChannelNameMention) {
 	for _, cr := range crs {
 		res = append(res, chat1.UIChannelNameMention{
 			Name:   cr.TopicName,
@@ -1186,7 +1186,7 @@ func PresentMessageUnboxed(ctx context.Context, g *globals.Context, rawMsg chat1
 			Superseded:            valid.ServerHeader.SupersededBy != 0,
 			AtMentions:            valid.AtMentionUsernames,
 			ChannelMention:        valid.ChannelMention,
-			ChannelNameMentions:   presentChannelNameMentions(ctx, valid.ChannelNameMentions),
+			ChannelNameMentions:   PresentChannelNameMentions(ctx, valid.ChannelNameMentions),
 			AssetUrlInfo:          presentAttachmentAssetInfo(ctx, g, rawMsg, convID),
 			IsEphemeral:           valid.IsEphemeral(),
 			IsEphemeralExpired:    valid.IsEphemeralExpired(time.Now()),

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -20,6 +20,7 @@ import (
 const (
 	methodList         = "list"
 	methodRead         = "read"
+	methodGet          = "get"
 	methodSend         = "send"
 	methodEdit         = "edit"
 	methodReaction     = "reaction"
@@ -46,6 +47,7 @@ type RateLimits struct {
 type ChatAPIHandler interface {
 	ListV1(context.Context, Call, io.Writer) error
 	ReadV1(context.Context, Call, io.Writer) error
+	GetV1(context.Context, Call, io.Writer) error
 	SendV1(context.Context, Call, io.Writer) error
 	EditV1(context.Context, Call, io.Writer) error
 	ReactionV1(context.Context, Call, io.Writer) error
@@ -185,6 +187,18 @@ type readOptionsV1 struct {
 
 func (r readOptionsV1) Check() error {
 	return checkChannelConv(methodRead, r.Channel, r.ConversationID)
+}
+
+type getOptionsV1 struct {
+	Channel        ChatChannel
+	ConversationID string            `json:"conversation_id"`
+	MessageIDs     []chat1.MessageID `json:"message_ids"`
+	Peek           bool
+	FailOffline    bool `json:"fail_offline"`
+}
+
+func (r getOptionsV1) Check() error {
+	return checkChannelConv(methodGet, r.Channel, r.ConversationID)
 }
 
 type editOptionsV1 struct {
@@ -384,6 +398,22 @@ func (a *ChatAPI) ReadV1(ctx context.Context, c Call, w io.Writer) error {
 	// opts are valid for read v1
 
 	return a.encodeReply(c, a.svcHandler.ReadV1(ctx, opts), w)
+}
+
+func (a *ChatAPI) GetV1(ctx context.Context, c Call, w io.Writer) error {
+	if len(c.Params.Options) == 0 {
+		return ErrInvalidOptions{version: 1, method: methodRead, err: errors.New("empty options")}
+	}
+	var opts getOptionsV1
+	if err := json.Unmarshal(c.Params.Options, &opts); err != nil {
+		return err
+	}
+	if err := opts.Check(); err != nil {
+		return err
+	}
+
+	// opts are valid for get v1
+	return a.encodeReply(c, a.svcHandler.GetV1(ctx, opts), w)
 }
 
 func (a *ChatAPI) SendV1(ctx context.Context, c Call, w io.Writer) error {

--- a/go/client/chat_api_test.go
+++ b/go/client/chat_api_test.go
@@ -17,6 +17,7 @@ import (
 type handlerTracker struct {
 	listV1         int
 	readV1         int
+	getV1          int
 	sendV1         int
 	editV1         int
 	reactionV1     int
@@ -35,6 +36,11 @@ func (h *handlerTracker) ListV1(context.Context, Call, io.Writer) error {
 
 func (h *handlerTracker) ReadV1(context.Context, Call, io.Writer) error {
 	h.readV1++
+	return nil
+}
+
+func (h *handlerTracker) GetV1(context.Context, Call, io.Writer) error {
+	h.getV1++
 	return nil
 }
 
@@ -96,6 +102,10 @@ func (c *chatEcho) ListV1(context.Context, listOptionsV1) Reply {
 }
 
 func (c *chatEcho) ReadV1(context.Context, readOptionsV1) Reply {
+	return Reply{Result: echoOK}
+}
+
+func (c *chatEcho) GetV1(context.Context, getOptionsV1) Reply {
 	return Reply{Result: echoOK}
 }
 

--- a/go/client/chat_api_version_handler.go
+++ b/go/client/chat_api_version_handler.go
@@ -36,6 +36,8 @@ func (d *ChatAPIVersionHandler) handleV1(ctx context.Context, c Call, w io.Write
 		return d.handler.ReadV1(ctx, c, w)
 	case methodSend:
 		return d.handler.SendV1(ctx, c, w)
+	case methodGet:
+		return d.handler.GetV1(ctx, c, w)
 	case methodEdit:
 		return d.handler.EditV1(ctx, c, w)
 	case methodReaction:

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/utils"
+	chatutils "github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
@@ -184,16 +185,19 @@ func (c *chatServiceHandler) formatMessages(ctx context.Context, messages []chat
 				UID:      mv.ClientHeader.Sender.String(),
 				DeviceID: mv.ClientHeader.SenderDevice.String(),
 			},
-			SentAt:             mv.ServerHeader.Ctime.UnixSeconds(),
-			SentAtMs:           mv.ServerHeader.Ctime.UnixMilliseconds(),
-			Prev:               prev,
-			Unread:             unread,
-			RevokedDevice:      mv.SenderDeviceRevokedAt != nil,
-			KBFSEncrypted:      mv.ClientHeader.KbfsCryptKeysUsed == nil || *mv.ClientHeader.KbfsCryptKeysUsed,
-			IsEphemeral:        mv.IsEphemeral(),
-			IsEphemeralExpired: mv.IsEphemeralExpired(time.Now()),
-			ETime:              mv.Etime(),
-			HasPairwiseMacs:    mv.HasPairwiseMacs(),
+			SentAt:              mv.ServerHeader.Ctime.UnixSeconds(),
+			SentAtMs:            mv.ServerHeader.Ctime.UnixMilliseconds(),
+			Prev:                prev,
+			Unread:              unread,
+			RevokedDevice:       mv.SenderDeviceRevokedAt != nil,
+			KBFSEncrypted:       mv.ClientHeader.KbfsCryptKeysUsed == nil || *mv.ClientHeader.KbfsCryptKeysUsed,
+			IsEphemeral:         mv.IsEphemeral(),
+			IsEphemeralExpired:  mv.IsEphemeralExpired(time.Now()),
+			ETime:               mv.Etime(),
+			HasPairwiseMacs:     mv.HasPairwiseMacs(),
+			AtMentionUsernames:  mv.AtMentionUsernames,
+			ChannelMention:      strings.ToLower(mv.ChannelMention.String()),
+			ChannelNameMentions: chatutils.PresentChannelNameMentions(ctx, mv.ChannelNameMentions),
 		}
 		if mv.Reactions.Reactions != nil {
 			msg.Reactions = &mv.Reactions
@@ -1052,22 +1056,25 @@ type MsgContent struct {
 
 // MsgSummary is used to display JSON details for a message.
 type MsgSummary struct {
-	ID                 chat1.MessageID                `json:"id"`
-	Channel            ChatChannel                    `json:"channel"`
-	Sender             MsgSender                      `json:"sender"`
-	SentAt             int64                          `json:"sent_at"`
-	SentAtMs           int64                          `json:"sent_at_ms"`
-	Content            MsgContent                     `json:"content"`
-	Prev               []chat1.MessagePreviousPointer `json:"prev"`
-	Unread             bool                           `json:"unread"`
-	RevokedDevice      bool                           `json:"revoked_device,omitempty"`
-	Offline            bool                           `json:"offline,omitempty"`
-	KBFSEncrypted      bool                           `json:"kbfs_encrypted,omitempty"`
-	IsEphemeral        bool                           `json:"is_ephemeral,omitempty"`
-	IsEphemeralExpired bool                           `json:"is_ephemeral_expired,omitempty"`
-	ETime              gregor1.Time                   `json:"etime,omitempty"`
-	Reactions          *chat1.ReactionMap             `json:"reactions,omitempty"`
-	HasPairwiseMacs    bool                           `json:"has_pairwise_macs,omitempty"`
+	ID                  chat1.MessageID                `json:"id"`
+	Channel             ChatChannel                    `json:"channel"`
+	Sender              MsgSender                      `json:"sender"`
+	SentAt              int64                          `json:"sent_at"`
+	SentAtMs            int64                          `json:"sent_at_ms"`
+	Content             MsgContent                     `json:"content"`
+	Prev                []chat1.MessagePreviousPointer `json:"prev"`
+	Unread              bool                           `json:"unread"`
+	RevokedDevice       bool                           `json:"revoked_device,omitempty"`
+	Offline             bool                           `json:"offline,omitempty"`
+	KBFSEncrypted       bool                           `json:"kbfs_encrypted,omitempty"`
+	IsEphemeral         bool                           `json:"is_ephemeral,omitempty"`
+	IsEphemeralExpired  bool                           `json:"is_ephemeral_expired,omitempty"`
+	ETime               gregor1.Time                   `json:"etime,omitempty"`
+	Reactions           *chat1.ReactionMap             `json:"reactions,omitempty"`
+	HasPairwiseMacs     bool                           `json:"has_pairwise_macs,omitempty"`
+	AtMentionUsernames  []string                       `json:"at_mention_usernames,omitempty"`
+	ChannelMention      string                         `json:"channel_mention,omitempty"`
+	ChannelNameMentions []chat1.UIChannelNameMention   `json:"channel_name_mentions,omitempty"`
 }
 
 // Message contains either a MsgSummary or an Error.  Used for JSON output.

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/utils"
-	chatutils "github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
@@ -197,7 +196,7 @@ func (c *chatServiceHandler) formatMessages(ctx context.Context, messages []chat
 			HasPairwiseMacs:     mv.HasPairwiseMacs(),
 			AtMentionUsernames:  mv.AtMentionUsernames,
 			ChannelMention:      strings.ToLower(mv.ChannelMention.String()),
-			ChannelNameMentions: chatutils.PresentChannelNameMentions(ctx, mv.ChannelNameMentions),
+			ChannelNameMentions: utils.PresentChannelNameMentions(ctx, mv.ChannelNameMentions),
 		}
 		if mv.Reactions.Reactions != nil {
 			msg.Reactions = &mv.Reactions

--- a/go/client/cmd_chat.go
+++ b/go/client/cmd_chat.go
@@ -33,6 +33,7 @@ func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 		newCmdChatSearch(cl, g),
 		newCmdChatSend(cl, g),
 		newCmdChatUpload(cl, g),
+		newCmdChatAPIListen(cl, g),
 	}
 	subcommands = append(subcommands, getBuildSpecificChatCommands(cl, g)...)
 	return cli.Command{

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -102,6 +102,10 @@ type incomingMessage struct {
 	Sender   string          `json:"sender,omitempty"`
 	Ctime    gregor1.Time    `json:"ctime"`
 
+	// Exploding messages
+	Etime      gregor1.Time `json:"explode_time"`
+	ExplodedBy *string      `json:"exploded_by,omitempty"`
+
 	// For messages that affect other messages (like edits, reactions)
 	TargetMsgID chat1.MessageID `json:"target_msg_id,omitempty"`
 
@@ -119,11 +123,13 @@ func (d *chatNotificationDisplay) NewChatActivity(ctx context.Context, arg chat1
 			if inMsg.Message.IsValid() {
 				mv := inMsg.Message.Valid()
 				msgJSON := incomingMessage{
-					ConvName: inMsg.Conv.Name,
-					Channel:  inMsg.Conv.Channel,
-					Sender:   mv.SenderUsername,
-					ID:       mv.MessageID,
-					Ctime:    mv.Ctime,
+					ConvName:   inMsg.Conv.Name,
+					Channel:    inMsg.Conv.Channel,
+					Sender:     mv.SenderUsername,
+					ID:         mv.MessageID,
+					Ctime:      mv.Ctime,
+					Etime:      mv.Etime,
+					ExplodedBy: mv.ExplodedBy,
 				}
 				bodyType, err := mv.MessageBody.MessageType()
 				if err == nil {

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -117,7 +117,8 @@ func (d *chatNotificationDisplay) errorf(format string, args ...interface{}) err
 
 type msgNotification struct {
 	Source     string              `json:"source,omitempty"`
-	Msg        *Message            `json:"msg,omitempty"`
+	Msg        *MsgSummary         `json:"msg,omitempty"`
+	Error      *string             `json:"error,omitempty"`
 	Pagination *chat1.UIPagination `json:"pagination,omitempty"`
 }
 
@@ -188,7 +189,8 @@ func (d *chatNotificationDisplay) NewChatActivity(ctx context.Context, arg chat1
 			}
 			notif := msgNotification{
 				Source:     strings.ToLower(arg.Source.String()),
-				Msg:        msg,
+				Msg:        msg.Msg,
+				Error:      msg.Error,
 				Pagination: inMsg.Pagination,
 			}
 			if jsonStr, err := json.Marshal(notif); err == nil {

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -116,6 +116,11 @@ type incomingMessage struct {
 
 	// Message deletions
 	DeletedMessageIDs []chat1.MessageID `json:"target_msg_ids,omitempty"`
+
+	// Attachment
+	Filename string `json:"filename,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+	Title    string `json:"title,omitempty"`
 }
 
 func (d *chatNotificationDisplay) NewChatActivity(ctx context.Context, arg chat1.NewChatActivityArg) error {
@@ -160,6 +165,11 @@ func (d *chatNotificationDisplay) NewChatActivity(ctx context.Context, arg chat1
 						msgJSON.TargetMsgID = e.MessageID
 					case chat1.MessageType_DELETE:
 						msgJSON.DeletedMessageIDs = mv.MessageBody.Delete().MessageIDs
+					case chat1.MessageType_ATTACHMENT:
+						a := mv.MessageBody.Attachment()
+						msgJSON.Filename = a.Object.Filename
+						msgJSON.MimeType = a.Object.MimeType
+						msgJSON.Title = a.Object.Title
 					}
 				}
 

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -138,15 +138,20 @@ func (d *chatNotificationDisplay) formatMessage(inMsg chat1.IncomingMessage) *Me
 				Username:   mv.SenderUsername,
 				DeviceName: mv.SenderDeviceName,
 			},
-			SentAt:             mv.Ctime.UnixSeconds(),
-			SentAtMs:           mv.Ctime.UnixMilliseconds(),
-			RevokedDevice:      mv.SenderDeviceRevokedAt != nil,
-			IsEphemeral:        mv.IsEphemeral,
-			IsEphemeralExpired: mv.IsEphemeralExpired,
-			ETime:              mv.Etime,
-			HasPairwiseMacs:    mv.HasPairwiseMacs,
-			Reactions:          mv.Reactions,
-			Content:            d.svc.convertMsgBody(mv.MessageBody),
+			SentAt:              mv.Ctime.UnixSeconds(),
+			SentAtMs:            mv.Ctime.UnixMilliseconds(),
+			RevokedDevice:       mv.SenderDeviceRevokedAt != nil,
+			IsEphemeral:         mv.IsEphemeral,
+			IsEphemeralExpired:  mv.IsEphemeralExpired,
+			ETime:               mv.Etime,
+			HasPairwiseMacs:     mv.HasPairwiseMacs,
+			Content:             d.svc.convertMsgBody(mv.MessageBody),
+			AtMentionUsernames:  mv.AtMentions,
+			ChannelMention:      strings.ToLower(mv.ChannelMention.String()),
+			ChannelNameMentions: mv.ChannelNameMentions,
+		}
+		if mv.Reactions.Reactions != nil {
+			summary.Reactions = &mv.Reactions
 		}
 		return &Message{Msg: summary}
 	}

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -1,0 +1,189 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"golang.org/x/net/context"
+)
+
+type CmdChatAPIListen struct {
+	libkb.Contextified
+}
+
+func (c *CmdChatAPIListen) ParseArgv(ctx *cli.Context) error {
+	return nil
+}
+
+func newCmdChatAPIListen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name: "api-listen",
+		// No "Usage" field makes it hidden in command list.
+		Description: "Listen and print incoming chat actions in JSON format",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdChatAPIListen{
+				Contextified: libkb.NewContextified(g),
+			}, "api-listen", c)
+			cl.SetNoStandalone()
+		},
+		Flags: []cli.Flag{},
+	}
+}
+
+func NewCmdChatAPIListenRunner(g *libkb.GlobalContext) *CmdChatAPIListen {
+	return &CmdChatAPIListen{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func (c *CmdChatAPIListen) Run() error {
+	display := &chatNotificationDisplay{
+		Contextified: libkb.NewContextified(c.G()),
+	}
+	protocols := []rpc.Protocol{
+		chat1.NotifyChatProtocol(display),
+	}
+	channels := keybase1.NotificationChannels{
+		Chat: true,
+	}
+
+	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
+	cli, err := GetNotifyCtlClient(c.G())
+	if err != nil {
+		return err
+	}
+	if err := cli.SetNotifications(context.TODO(), channels); err != nil {
+		return err
+	}
+
+	jsonStr, _ := json.Marshal(struct {
+		What string `json:"what"`
+	}{
+		What: "listening",
+	})
+	display.printf("%s\n", jsonStr)
+	for {
+		time.Sleep(time.Second)
+	}
+}
+
+func (c *CmdChatAPIListen) GetUsage() libkb.Usage {
+	return libkb.Usage{}
+}
+
+type chatNotificationDisplay struct {
+	libkb.Contextified
+}
+
+func (d *chatNotificationDisplay) printf(fmt string, args ...interface{}) error {
+	_, err := d.G().UI.GetTerminalUI().Printf(fmt, args...)
+	return err
+}
+
+type incomingMessage struct {
+	ConvName string `json:"conv_name"`
+	Channel  string `json:"channel,omitempty"`
+	Type     string `json:"type"`
+	Message  string `json:"message,omitempty"`
+	Sender   string `json:"sender,omitempty"`
+}
+
+func (d *chatNotificationDisplay) NewChatActivity(ctx context.Context, arg chat1.NewChatActivityArg) error {
+	activity := arg.Activity
+	typ, err := activity.ActivityType()
+	if err == nil {
+		switch typ {
+		case chat1.ChatActivityType_INCOMING_MESSAGE:
+			inMsg := activity.IncomingMessage()
+			if inMsg.Message.IsValid() {
+				mv := inMsg.Message.Valid()
+				msgJSON := incomingMessage{
+					ConvName: inMsg.Conv.Name,
+					Channel:  inMsg.Conv.Channel,
+					Sender:   mv.SenderUsername,
+				}
+				bodyType, err := mv.MessageBody.MessageType()
+				if err == nil {
+					msgJSON.Type = bodyType.String()
+					switch bodyType {
+					case chat1.MessageType_TEXT:
+						msgJSON.Message = mv.MessageBody.Text().Body
+					}
+				}
+				jsonStr, _ := json.Marshal(msgJSON)
+				d.printf("%s\n", string(jsonStr))
+			}
+		}
+	}
+	return nil
+}
+
+func (d *chatNotificationDisplay) ChatIdentifyUpdate(context.Context, keybase1.CanonicalTLFNameAndIDWithBreaks) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatTLFFinalize(context.Context, chat1.ChatTLFFinalizeArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatTLFResolve(context.Context, chat1.ChatTLFResolveArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatInboxStale(context.Context, keybase1.UID) error { return nil }
+func (d *chatNotificationDisplay) ChatThreadsStale(context.Context, chat1.ChatThreadsStaleArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatTypingUpdate(context.Context, []chat1.ConvTypingUpdate) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatJoinedConversation(context.Context, chat1.ChatJoinedConversationArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatLeftConversation(context.Context, chat1.ChatLeftConversationArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatResetConversation(context.Context, chat1.ChatResetConversationArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatInboxSyncStarted(context.Context, keybase1.UID) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatInboxSynced(context.Context, chat1.ChatInboxSyncedArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatSetConvRetention(context.Context, chat1.ChatSetConvRetentionArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatSetTeamRetention(context.Context, chat1.ChatSetTeamRetentionArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatSetConvSettings(context.Context, chat1.ChatSetConvSettingsArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatSubteamRename(context.Context, chat1.ChatSubteamRenameArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatKBFSToImpteamUpgrade(context.Context, chat1.ChatKBFSToImpteamUpgradeArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatAttachmentUploadStart(context.Context, chat1.ChatAttachmentUploadStartArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatAttachmentUploadProgress(context.Context, chat1.ChatAttachmentUploadProgressArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatPaymentInfo(context.Context, chat1.ChatPaymentInfoArg) error {
+	return nil
+}
+func (d *chatNotificationDisplay) ChatRequestInfo(context.Context, chat1.ChatRequestInfoArg) error {
+	return nil
+}

--- a/go/client/cmd_show_notifications.go
+++ b/go/client/cmd_show_notifications.go
@@ -72,6 +72,7 @@ func NewCmdShowNotifications(cl *libcmdline.CommandLine, g *libkb.GlobalContext)
 		Usage: "Display all notifications sent by daemon in real-time",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&CmdShowNotifications{Contextified: libkb.NewContextified(g)}, "show-notifications", c)
+			cl.SetNoStandalone()
 		},
 		Flags: []cli.Flag{},
 	}


### PR DESCRIPTION
This PR add some features to chat api, useful for bot and custom client makers.

- Add "get" method for `chat api` that fetches messages from conversation by `message_ids`.
   - Factor out thread formatting code from  `ReadV1` into `formatMessages`, call it from both `ReadV1` and `GetV1`.
- Add new `chat api-listen` command that registers `NotifyChatProtocol`. It will format incoming chat messages in `NewChatActivity` to JSON using `Message` struct - the same that's used in `chat api`.
   - Structures that are sent through notifications are missing some data that's defined in `Message` and `MsgSummary`. For now, keep these fields null/empty.
- Add `AtMentionUsernames`, `ChannelMention`, and `ChannelNameMentions` fields to `MsgSummary`. Add support both in chat api and chat listen api.