### PR TITLE
parent path handling isn't working

### DIFF
--- a/shared/actions/git.js
+++ b/shared/actions/git.js
@@ -130,12 +130,9 @@ function handleIncomingGregor(_, action: GregorGen.PushOOBMPayload) {
 }
 
 const navToGit = (_, action: GitGen.NavToGitPayload) => {
-  const {switchTab, routeState} = action.payload
+  const {routeState} = action.payload
   const path = isMobile ? [Tabs.settingsTab, SettingsConstants.gitTab] : [Tabs.gitTab]
   const parentPath = []
-  if (!switchTab) {
-    parentPath.push(path.pop())
-  }
   const actions = [Saga.put(RouteTreeGen.createNavigateTo({path, parentPath}))]
   if (routeState) {
     actions.push(Saga.put(RouteTreeGen.createSetRouteState({path, partialState: routeState})))


### PR DESCRIPTION
this fixes the git tab handling on mobile on new/delete. works on desktop also. also tested going from chat to a git repo and that seems fine too.
@keybase/react-hackers 