### PR TITLE
Add a spinner on the team cancel invite button

### DIFF
--- a/shared/teams/team/invites-tab/invite-row/index.js
+++ b/shared/teams/team/invites-tab/invite-row/index.js
@@ -60,6 +60,7 @@ export const TeamInviteRow = (props: Props) => {
           label={isMobile ? 'Cancel' : 'Cancel invite'}
           onClick={onCancelInvite}
           type="Secondary"
+          waitingKey={null}
         />
       </Box>
     </ClickableBox>

--- a/shared/teams/team/invites-tab/invite-row/index.js
+++ b/shared/teams/team/invites-tab/invite-row/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {Avatar, Box, Button, ClickableBox, Text, ConnectedUsernames} from '../../../../common-adapters'
+import {Avatar, Box, ClickableBox, Text, ConnectedUsernames, WaitingButton} from '../../../../common-adapters'
 import {globalStyles, globalMargins, isMobile} from '../../../../styles'
 import {typeToLabel} from '../../../../constants/teams'
 import {type TeamRoleType} from '../../../../constants/types/teams'
@@ -55,7 +55,7 @@ export const TeamInviteRow = (props: Props) => {
         </Box>
       </Box>
       <Box style={{...globalStyles.flexBoxRow, marginLeft: globalMargins.xtiny}}>
-        <Button
+        <WaitingButton
           small={true}
           label={isMobile ? 'Cancel' : 'Cancel invite'}
           onClick={onCancelInvite}


### PR DESCRIPTION
@keybase/react-hackers 

Since the operation completing results in the row disappearing, went for the until-unmount version of the waiting button spinner.