### PR TITLE
On desktop, use a spinner and nav-on-success for invite-by-email

### DIFF
--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -86,9 +86,12 @@
       "teamname": "string"
     },
     "inviteToTeamByEmail": {
-      "teamname": "string",
+      "destSubPath": "I.List<string>",
+      "invitees": "string",
       "role": "Types.TeamRoleType",
-      "invitees": "string"
+      "rootPath": "I.List<string>",
+      "sourceSubPath": "I.List<string>",
+      "teamname": "string"
     },
     "inviteToTeamByPhone": {
       "teamname": "string",

--- a/shared/actions/teams-gen.js
+++ b/shared/actions/teams-gen.js
@@ -158,9 +158,12 @@ type _IgnoreRequestPayload = $ReadOnly<{|
   username: string,
 |}>
 type _InviteToTeamByEmailPayload = $ReadOnly<{|
-  teamname: string,
-  role: Types.TeamRoleType,
+  destSubPath: I.List<string>,
   invitees: string,
+  role: Types.TeamRoleType,
+  rootPath: I.List<string>,
+  sourceSubPath: I.List<string>,
+  teamname: string,
 |}>
 type _InviteToTeamByPhonePayload = $ReadOnly<{|
   teamname: string,

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -19,6 +19,7 @@ export const rpcMemberStatusToStatus = invert(RPCTypes.teamsTeamMemberStatus)
 // Waiting keys
 // Add granularity as necessary
 export const teamWaitingKey = (teamname: Types.Teamname) => `team:${teamname}`
+export const addToTeamByEmailWaitingKey = (teamname: Types.Teamname) => `teamAddByEmail:${teamname}`
 export const getChannelsWaitingKey = (teamname: Types.Teamname) => `getChannels:${teamname}`
 export const settingsWaitingKey = (teamname: Types.Teamname) => `teamSettings:${teamname}`
 export const retentionWaitingKey = (teamname: Types.Teamname) => `teamRetention:${teamname}`

--- a/shared/teams/invite-by-email/container.desktop.js
+++ b/shared/teams/invite-by-email/container.desktop.js
@@ -13,14 +13,28 @@ const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => {
     errorMessage: inviteError.message,
     malformedEmails: inviteError.malformed,
     name: routeProps.get('teamname'),
+    waitingKey: Constants.addToTeamByEmailWaitingKey(routeProps.get('teamname') || ''),
   }
 }
 
-const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
+const mapDispatchToProps = (dispatch, {navigateUp, routePath, routeProps}) => ({
   onClearInviteError: () => dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''})), // should only be called on unmount
   onClose: () => dispatch(navigateUp()),
   onInvite: (invitees: string, role: Types.TeamRoleType) => {
-    dispatch(TeamsGen.createInviteToTeamByEmail({teamname: routeProps.get('teamname'), role, invitees}))
+    const teamname = routeProps.get('teamname')
+    const rootPath = routePath.take(1)
+    const sourceSubPath = routePath.rest()
+    const destSubPath = sourceSubPath.butLast()
+    dispatch(
+      TeamsGen.createInviteToTeamByEmail({
+        destSubPath,
+        invitees,
+        role,
+        rootPath,
+        sourceSubPath,
+        teamname,
+      })
+    )
     dispatch(TeamsGen.createGetTeams())
   },
   onOpenRolePicker: (role: Types.TeamRoleType, onComplete: Types.TeamRoleType => void) => {
@@ -39,4 +53,6 @@ const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
   },
 })
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(InviteByEmailDesktop)
+export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(
+  InviteByEmailDesktop
+)

--- a/shared/teams/invite-by-email/container.native.js
+++ b/shared/teams/invite-by-email/container.native.js
@@ -36,12 +36,12 @@ const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => {
   return {
     _pendingInvites: teamname ? Constants.getTeamInvites(state, teamname) : Set(),
     errorMessage: inviteError.message,
-    name: teamname,
     loadingInvites: teamname ? Constants.getTeamLoadingInvites(state, teamname) : Map(),
+    name: teamname,
   }
 }
 
-const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
+const mapDispatchToProps = (dispatch, {navigateUp, routePath, routeProps}) => ({
   openAppSettings: () => dispatch(ConfigGen.createOpenAppSettings()),
   onClearError: () => dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''})),
   onClose: () => {
@@ -49,9 +49,20 @@ const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
     dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''}))
   },
   onInviteEmail: ({invitee, role}) => {
+    const teamname = routeProps.get('teamname')
+    const rootPath = routePath.take(1)
+    const sourceSubPath = routePath.rest()
+    const destSubPath = sourceSubPath.butLast()
     dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''}))
     dispatch(
-      TeamsGen.createInviteToTeamByEmail({teamname: routeProps.get('teamname'), role, invitees: invitee})
+      TeamsGen.createInviteToTeamByEmail({
+        destSubPath,
+        invitees: invitee,
+        role,
+        rootPath,
+        sourceSubPath,
+        teamname,
+      })
     )
     dispatch(TeamsGen.createGetTeams())
   },

--- a/shared/teams/invite-by-email/index.desktop.js
+++ b/shared/teams/invite-by-email/index.desktop.js
@@ -4,13 +4,13 @@ import * as I from 'immutable'
 import {
   Box,
   Box2,
-  Button,
+  ButtonBar,
   ClickableBox,
   Dropdown,
   Input,
   PopupDialog,
   Text,
-  ButtonBar,
+  WaitingButton,
 } from '../../common-adapters'
 import {globalStyles, globalMargins, globalColors} from '../../styles'
 import {capitalize} from 'lodash-es'
@@ -141,7 +141,12 @@ class InviteByEmailDesktop extends React.Component<Props, State> {
             </Box2>
 
             <ButtonBar>
-              <Button label="Invite" onClick={this._onInvite} type="Primary" />
+              <WaitingButton
+                label="Invite"
+                onClick={this._onInvite}
+                type="Primary"
+                waitingKey={props.waitingKey}
+              />
             </ButtonBar>
           </Box>
         </Box>

--- a/shared/teams/invite-by-email/index.js.flow
+++ b/shared/teams/invite-by-email/index.js.flow
@@ -42,6 +42,7 @@ export type DesktopProps = {
   onClose: () => void,
   onInvite: (invitees: string, role: TeamRoleType) => void,
   onOpenRolePicker: (currentSelectedRole: TeamRoleType, selectedRoleCallback: (TeamRoleType) => void) => void,
+  waitingKey: string,
 }
 
 export type MobileProps = {


### PR DESCRIPTION
@keybase/react-hackers 

Invite by email is very different on desktop and mobile.  Mobile already uses per-contact spinners, but desktop had no spinner and no nav-on-success, leading you to believe the button hadn't done anything at all.  This PR adds a new waitingKey used by desktop only, and nav away on success on desktop only.