### PR TITLE
Stop listening to paymentStatusNotification for now

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -309,8 +309,6 @@ const maybeNavigateAwayFromSendForm = (state: TypedState, action: WalletsGen.Aba
 const setupEngineListeners = () => {
   getEngine().setIncomingCallMap({
     'stellar.1.notify.paymentNotification': refreshPayments,
-    // $FlowIssue @cjb this needs to be fixed
-    'stellar.1.notify.paymentStatusNotification': refreshPayments,
   })
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

`paymentStatusNotification` comes in without an `accountID`, just a `txID`.  This actually means we can't use it -- we don't know which account to reload payments for.  Core's going to rework the protocol to add an `accountID` there, in the meantime let's just disable that one.