### PR TITLE
Disable buttons in wallet header on loading wallets

### DIFF
--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -66,10 +66,6 @@ type SendProps = {|
 |}
 
 class _SendButton extends React.PureComponent<SendProps & Kb.OverlayParentProps> {
-  static defaultProps = {
-    disabled: false,
-  }
-
   _menuItems = [
     {
       onClick: () => this.props.onSendToKeybaseUser(),
@@ -115,10 +111,6 @@ type DropdownProps = {|
 |}
 
 class _DropdownButton extends React.PureComponent<DropdownProps & Kb.OverlayParentProps> {
-  static defaultProps = {
-    disabled: false,
-  }
-
   _menuItems = [
     {
       onClick: () => this.props.onDeposit(),

--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -45,24 +45,31 @@ const Header = (props: Props) => (
         onSendToKeybaseUser={props.onSendToKeybaseUser}
         onSendToStellarAddress={props.onSendToStellarAddress}
         onSendToAnotherAccount={props.onSendToAnotherAccount}
+        disabled={!props.walletName}
       />
-      <Kb.Button type="Secondary" onClick={props.onReceive} label="Receive" />
+      <Kb.Button type="Secondary" onClick={props.onReceive} label="Receive" disabled={!props.walletName} />
       <DropdownButton
         onDeposit={props.onDeposit}
         onSettings={props.onSettings}
         onShowSecretKey={props.onShowSecretKey}
+        disabled={!props.walletName}
       />
     </Kb.Box2>
   </Kb.Box2>
 )
 
-type SendProps = {
+type SendProps = {|
   onSendToKeybaseUser: () => void,
   onSendToStellarAddress: () => void,
   onSendToAnotherAccount: () => void,
-}
+  disabled: boolean,
+|}
 
 class _SendButton extends React.PureComponent<SendProps & Kb.OverlayParentProps> {
+  static defaultProps = {
+    disabled: false,
+  }
+
   _menuItems = [
     {
       onClick: () => this.props.onSendToKeybaseUser(),
@@ -80,9 +87,12 @@ class _SendButton extends React.PureComponent<SendProps & Kb.OverlayParentProps>
 
   render() {
     return (
-      <Kb.ClickableBox onClick={this.props.toggleShowingMenu} ref={this.props.setAttachmentRef}>
+      <Kb.ClickableBox
+        onClick={!this.props.disabled ? this.props.toggleShowingMenu : undefined}
+        ref={this.props.setAttachmentRef}
+      >
         <Kb.Box2 direction="horizontal" fullWidth={true} gap="xsmall">
-          <Kb.Button onClick={null} type="Wallet" label="Send" />
+          <Kb.Button onClick={null} type="Wallet" label="Send" disabled={this.props.disabled} />
         </Kb.Box2>
         <Kb.FloatingMenu
           attachTo={this.props.attachmentRef}
@@ -97,13 +107,18 @@ class _SendButton extends React.PureComponent<SendProps & Kb.OverlayParentProps>
   }
 }
 
-type DropdownProps = {
+type DropdownProps = {|
   onDeposit: () => void,
   onShowSecretKey: () => void,
   onSettings: () => void,
-}
+  disabled: boolean,
+|}
 
 class _DropdownButton extends React.PureComponent<DropdownProps & Kb.OverlayParentProps> {
+  static defaultProps = {
+    disabled: false,
+  }
+
   _menuItems = [
     {
       onClick: () => this.props.onDeposit(),
@@ -121,9 +136,17 @@ class _DropdownButton extends React.PureComponent<DropdownProps & Kb.OverlayPare
 
   render() {
     return (
-      <Kb.ClickableBox onClick={this.props.toggleShowingMenu} ref={this.props.setAttachmentRef}>
+      <Kb.ClickableBox
+        onClick={!this.props.disabled ? this.props.toggleShowingMenu : undefined}
+        ref={this.props.setAttachmentRef}
+      >
         <Kb.Box2 direction="horizontal" fullWidth={true} gap="xsmall">
-          <Kb.Button onClick={null} type="Secondary" style={styles.dropdownButton}>
+          <Kb.Button
+            onClick={null}
+            type="Secondary"
+            style={styles.dropdownButton}
+            disabled={this.props.disabled}
+          >
             <Kb.Icon
               fontSize={Styles.isMobile ? 22 : 16}
               type="iconfont-ellipsis"


### PR DESCRIPTION
If you go to the wallet tabs with a slow connection, then the buttons to access settings, send money, etc. are still clickable and result in a whole slew of errors if you click any of them. This simply disables those buttons so users can't get into that state. It uses the same logic that @cjb used in #13631 to determine whether or not to show a spinner when loading.


![screen shot 2018-09-12 at 2 10 27 pm](https://user-images.githubusercontent.com/5677971/45444550-c2d63280-b695-11e8-98d0-52af00990689.png)


If you want to test this, I recommend using network link conditioner or something similar.