### PR TITLE
[KBFS-3150] Mobile: copy should say "Create new folder", not "New folder"

### DIFF
--- a/shared/fs/header/add-new.js
+++ b/shared/fs/header/add-new.js
@@ -74,7 +74,7 @@ const propsToMenuItems = (props: AddNewProps) => {
       icon: 'iconfont-upload',
     })
   props.pickAndUploadPhoto && props.pickAndUploadVideo && items.push('Divider')
-  items.push({title: 'Create New folder', onClick: props.newFolderRow, icon: 'iconfont-folder-new'})
+  items.push({title: 'Create new folder', onClick: props.newFolderRow, icon: 'iconfont-folder-new'})
 
   return isMobile
     ? items.map(

--- a/shared/fs/header/add-new.js
+++ b/shared/fs/header/add-new.js
@@ -74,7 +74,7 @@ const propsToMenuItems = (props: AddNewProps) => {
       icon: 'iconfont-upload',
     })
   props.pickAndUploadPhoto && props.pickAndUploadVideo && items.push('Divider')
-  items.push({title: 'New folder', onClick: props.newFolderRow, icon: 'iconfont-folder-new'})
+  items.push({title: 'Create New folder', onClick: props.newFolderRow, icon: 'iconfont-folder-new'})
 
   return isMobile
     ? items.map(


### PR DESCRIPTION
#### Description of task:
In the mobile action sheet, when tapping on the "+ Add" button, it should say "Create new folder", not just "New folder".


#### Relevant Screenshots:
<img width="391" alt="screen shot 2018-09-12 at 22 35 20" src="https://user-images.githubusercontent.com/10031957/45448998-a7424a80-b6dc-11e8-9e37-cebf1628c788.png">
