### PR TITLE
Change LookupCLILocal errors to be less misleading

### DIFF
--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -512,7 +512,13 @@ func (s *Server) LookupCLILocal(ctx context.Context, arg string) (res stellar1.L
 		return res, err
 	}
 	if recipient.AccountID == nil {
-		return res, fmt.Errorf("Recipient does not have an account.")
+		if recipient.User != nil {
+			return res, fmt.Errorf("Assertion resolved to Keybase user %q, but they do not have a Stellar account", recipient.User.Username)
+		} else if recipient.Assertion != nil {
+			return res, fmt.Errorf("Could not resolve assertion %q", *recipient.Assertion)
+		} else {
+			return res, fmt.Errorf("Could not find a Stellar account for %q", recipient.Input)
+		}
 	}
 	res.AccountID = stellar1.AccountID(*recipient.AccountID)
 	if recipient.User != nil {


### PR DESCRIPTION
Previously it was unknown to the caller (the user of "keybase lookup" command, most likely) if the assertion was resolved to a user without Stellar account, of if the assertion did not resolve at all.