### PR TITLE
Mock feature flags for storybook

### DIFF
--- a/shared/.storybook/webpack.config.js
+++ b/shared/.storybook/webpack.config.js
@@ -28,7 +28,8 @@ module.exports = (storybookBaseConfig, configType) => {
     new webpack.NormalModuleReplacementPlugin(/^electron$/, __dirname + '/../__mocks__/electron.js'),
     new webpack.NormalModuleReplacementPlugin(/engine/, __dirname + '/../__mocks__/engine.js'),
     new webpack.NormalModuleReplacementPlugin(/util\/saga/, __dirname + '/../__mocks__/saga.js'),
-    new webpack.NormalModuleReplacementPlugin(/route-tree/, __dirname + '/../__mocks__/empty.js')
+    new webpack.NormalModuleReplacementPlugin(/route-tree/, __dirname + '/../__mocks__/empty.js'),
+    new webpack.NormalModuleReplacementPlugin(/feature-flags/, __dirname + '/../__mocks__/feature-flags.js')
   )
 
   // Override default ignoring node_modules

--- a/shared/__mocks__/feature-flags.js
+++ b/shared/__mocks__/feature-flags.js
@@ -1,5 +1,10 @@
 // @flow
+
 import type {FeatureFlags} from '../util/feature-flags.js.flow'
+
+if (!__STORYBOOK__) {
+  throw new Error('Invalid load of mock')
+}
 
 const ff: FeatureFlags = {
   admin: false,


### PR DESCRIPTION
Adds `__mocks__/feature-flags.js` as a module that will be mocked for storybook. Previously, we were only mocking feature flags for storyshots. 

The full list of storybooks mocks is in `shared/.storybook/webpack.config.js`, while storyshot mocks are in `shared/package.json`. There are a couple of other discrepancies; the storybook is missing mocks for:
- files
- react-list
- resolve-root
- hidden-string
- constants/platform
- local-debug

These are all things that I think we don't want to mock on storybook though to preserve interactivity, but lmk if anything on that list looks weird.

