### PR TITLE
auditor should work on a stale team

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -203,6 +203,10 @@ type TestParameters struct {
 	// might point off of the merkle sequence in the database. So it's just
 	// easiest to skip the audit in those cases.
 	TeamSkipAudit bool
+
+	// TeamAuditParams can be customized if we want to control the behavior
+	// of audits deep in a test
+	TeamAuditParams *TeamAuditParams
 }
 
 func (tp TestParameters) GetDebug() (bool, bool) {

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -891,7 +891,7 @@ func (mr MerkleRoot) ExportToAVDL(g *GlobalContext) keybase1.MerkleRootAndTime {
 // storeRoot stores the root in the db and mem.
 // Must be called from under a lock.
 func (mc *MerkleClient) storeRoot(m MetaContext, root *MerkleRoot) {
-	m.VLogf(VLog0, "storing merkling root: %d", *root.Seqno())
+	m.VLogf(VLog0, "storing merkle root: %d", *root.Seqno())
 	err := root.Store()
 	if err != nil {
 		m.CErrorf("Cannot commit Merkle root to local DB: %s", err)

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -2,6 +2,7 @@ package libkb
 
 import (
 	"fmt"
+	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
@@ -88,3 +89,13 @@ func (n nullTeamAuditor) AuditTeam(m MetaContext, id keybase1.TeamID, isPublic b
 func (n nullTeamAuditor) OnLogout(m MetaContext) {}
 
 func newNullTeamAuditor() nullTeamAuditor { return nullTeamAuditor{} }
+
+type TeamAuditParams struct {
+	RootFreshness time.Duration
+	// After this many new Merkle updates, another audit is triggered.
+	MerkleMovementTrigger keybase1.Seqno
+	NumPreProbes          int
+	NumPostProbes         int
+	Parallelism           int
+	LRUSize               int
+}

--- a/go/teams/audit.go
+++ b/go/teams/audit.go
@@ -13,17 +13,7 @@ import (
 	"time"
 )
 
-type AuditParams struct {
-	RootFreshness time.Duration
-	// After this many new Merkle updates, another audit is triggered.
-	MerkleMovementTrigger keybase1.Seqno
-	NumPreProbes          int
-	NumPostProbes         int
-	Parallelism           int
-	LRUSize               int
-}
-
-var desktopParams = AuditParams{
+var desktopParams = libkb.TeamAuditParams{
 	RootFreshness:         time.Minute,
 	MerkleMovementTrigger: keybase1.Seqno(1000),
 	NumPreProbes:          25,
@@ -32,7 +22,7 @@ var desktopParams = AuditParams{
 	LRUSize:               1000,
 }
 
-var mobileParams = AuditParams{
+var mobileParams = libkb.TeamAuditParams{
 	RootFreshness:         10 * time.Minute,
 	MerkleMovementTrigger: keybase1.Seqno(10000),
 	NumPreProbes:          10,
@@ -41,7 +31,7 @@ var mobileParams = AuditParams{
 	LRUSize:               500,
 }
 
-var devParams = AuditParams{
+var devParams = libkb.TeamAuditParams{
 	RootFreshness:         10 * time.Minute,
 	MerkleMovementTrigger: keybase1.Seqno(10000),
 	NumPreProbes:          3,
@@ -54,7 +44,10 @@ var devParams = AuditParams{
 // we're going to be performing a smaller audit, and therefore have a smaller
 // security margin (1-2^10). But it's worth it given the bandwidth and CPU
 // constraints.
-func getAuditParams(m libkb.MetaContext) AuditParams {
+func getAuditParams(m libkb.MetaContext) libkb.TeamAuditParams {
+	if m.G().Env.Test.TeamAuditParams != nil {
+		return *m.G().Env.Test.TeamAuditParams
+	}
 	if m.G().Env.GetRunMode() == libkb.DevelRunMode {
 		return devParams
 	}

--- a/go/teams/audit.go
+++ b/go/teams/audit.go
@@ -269,7 +269,6 @@ func (a *Auditor) doPostProbes(m libkb.MetaContext, history *keybase1.AuditHisto
 		}
 		prev = &tuple
 	}
-
 	return maxMerkleProbe, nil
 }
 

--- a/go/teams/audit_test.go
+++ b/go/teams/audit_test.go
@@ -1,0 +1,94 @@
+package teams
+
+import (
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+// See CORE-8860. We should be able to audit a stale team. That is, ever the merkle tree
+// is advertising a tail at 5, and we're only loaded through 3 (due to an unbusted cache),
+// the audit should still succeed.
+func TestAuditStaleTeam(t *testing.T) {
+
+	fus, tcs, cleanup := setupNTests(t, 3)
+	defer cleanup()
+
+	t.Logf("create team")
+	teamName, _ := createTeam2(*tcs[0])
+	m := make([]libkb.MetaContext, 3)
+	for i, tc := range tcs {
+		m[i] = libkb.NewMetaContextForTest(*tc)
+	}
+
+	// We set up codenames for 3 users, A, B and C
+	const (
+		A = 0
+		B = 1
+		C = 2
+	)
+
+	t.Logf("A adds B to the team as an admin")
+	_, err := AddMember(m[0].Ctx(), tcs[0].G, teamName.String(), fus[1].Username, keybase1.TeamRole_ADMIN)
+	require.NoError(t, err)
+
+	load := func(asUser int) {
+		_, err = Load(m[asUser].Ctx(), tcs[asUser].G, keybase1.LoadTeamArg{
+			Name:    teamName.String(),
+			Public:  false,
+			StaleOK: true,
+		})
+		require.NoError(t, err)
+	}
+
+	addC := func(asUser int) {
+		_, err = AddMember(m[asUser].Ctx(), tcs[asUser].G, teamName.String(), fus[2].Username, keybase1.TeamRole_READER)
+		require.NoError(t, err)
+	}
+
+	rmC := func(asUser int) {
+		err = RemoveMember(m[asUser].Ctx(), tcs[asUser].G, teamName.String(), fus[2].Username)
+		require.NoError(t, err)
+	}
+
+	setFastAudits := func() {
+		// do a lot of probes so we're likely to find issues
+		devParams.NumPostProbes = 10
+		devParams.MerkleMovementTrigger = keybase1.Seqno(1)
+		devParams.RootFreshness = time.Duration(1)
+	}
+
+	setSlowAudits := func() {
+		devParams.NumPostProbes = 1
+		devParams.MerkleMovementTrigger = keybase1.Seqno(1000000)
+		devParams.RootFreshness = time.Hour
+	}
+
+	// A adds C to the team and triggers an Audit
+	setFastAudits()
+	addC(A)
+
+	// A removes C from the team, and loads the team, but does *not* trigger an audit
+	setSlowAudits()
+	rmC(A)
+	load(A)
+
+	t.Logf("User B rotates the key a bunch of times")
+
+	// B rotates the key by adding and remove C a bunch of times.
+	for i := 0; i < 3; i++ {
+		addC(B)
+		rmC(B)
+	}
+
+	// A forces local idea of what the max merkle sequence number is.
+	_, err = tcs[A].G.MerkleClient.FetchRootFromServerBySeqno(m[0], keybase1.Seqno(100000000))
+	require.NoError(t, err)
+
+	// A forces an audit on a stale team.
+	setFastAudits()
+	t.Logf("User A loading the team, and auditing on an primed cached")
+	load(A)
+}

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -435,7 +435,7 @@ type AuditError struct {
 }
 
 func NewAuditError(format string, args ...interface{}) error {
-	return FastLoadError{Msg: fmt.Sprintf(format, args...)}
+	return AuditError{Msg: fmt.Sprintf(format, args...)}
 }
 
 func (e AuditError) Error() string {


### PR DESCRIPTION
- it could be that the team we have locally is stale, and the merkle roots will show links off the end of our
  chain. in this case, the audit is still legit, don't crash out