### PR TITLE
Improve logging on Android

### DIFF
--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -128,11 +128,16 @@ let _firstTimeConnecting = true
 const startHandshake = (state: TypedState) => {
   const firstTimeConnecting = _firstTimeConnecting
   _firstTimeConnecting = false
+  if (firstTimeConnecting) {
+    const now = new Date()
+    logger.info(`First bootstrap started on ${now.toString()}`)
+  }
   return Saga.put(
     ConfigGen.createDaemonHandshake({firstTimeConnecting, version: state.config.daemonHandshakeVersion + 1})
   )
 }
 
+let _firstTimeBootstrapDone = true
 const maybeDoneWithDaemonHandshake = (state: TypedState, action: ConfigGen.DaemonHandshakeWaitPayload) => {
   if (action.payload.version !== state.config.daemonHandshakeVersion) {
     // ignore out of date actions
@@ -146,6 +151,11 @@ const maybeDoneWithDaemonHandshake = (state: TypedState, action: ConfigGen.Daemo
         return Saga.put(ConfigGen.createRestartHandshake())
       }
     } else {
+      if (_firstTimeBootstrapDone) {
+        _firstTimeBootstrapDone = false
+        const now = new Date()
+        logger.info(`First bootstrap ended on ${now.toString()}`)
+      }
       return Saga.put(ConfigGen.createDaemonHandshakeDone())
     }
   }

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KBReactPackage.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KBReactPackage.java
@@ -19,12 +19,7 @@ import io.keybase.ossifrage.modules.ScreenProtector;
 import io.keybase.ossifrage.modules.ShareFiles;
 
 public class KBReactPackage implements com.facebook.react.ReactPackage {
-    private final String logFilePath;
     private List<KillableModule> killableModules = new ArrayList<>();
-
-    public KBReactPackage(String logFilePath) {
-        this.logFilePath = logFilePath;
-    }
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KeyStore.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KeyStore.java
@@ -6,7 +6,6 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
 import android.util.Base64;
-import android.util.Log;
 
 import org.msgpack.MessagePack;
 
@@ -70,7 +69,7 @@ public class KeyStore implements UnsafeExternalKeyStore {
         try {
             prefs.edit().remove(sharedPrefKeyPrefix(serviceName) + key).commit();
         } catch (Exception e) {
-            NativeLogger.error("KeyStore: error clearing secret for " + id + ": " + Log.getStackTraceString(e));
+            NativeLogger.error("KeyStore: error clearing secret for " + id, e);
             throw e;
         }
 
@@ -97,7 +96,7 @@ public class KeyStore implements UnsafeExternalKeyStore {
             MessagePack msgpack = new MessagePack();
             return msgpack.write(userNames);
         } catch (Exception e) {
-            NativeLogger.error("KeyStore: error getting users with stored secrets for " + serviceName + ": " + Log.getStackTraceString(e));
+            NativeLogger.error("KeyStore: error getting users with stored secrets for " + serviceName, e);
             throw e;
         }
     }
@@ -127,13 +126,13 @@ public class KeyStore implements UnsafeExternalKeyStore {
                 // Invalid key, this can happen when a user changes their lock screen from something to nothing
                 // or enrolls a new finger. See https://developer.android.com/reference/android/security/keystore/KeyPermanentlyInvalidatedException.html
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && e instanceof KeyPermanentlyInvalidatedException) {
-                    NativeLogger.info("KeyStore: key no longer valid; deleting entry: " + Log.getStackTraceString(e));
+                    NativeLogger.info("KeyStore: key no longer valid; deleting entry", e);
                     ks.deleteEntry((keyStoreAlias(serviceName)));
                 }
                 throw e;
             }
         } catch (Exception e) {
-            NativeLogger.error("KeyStore: error retrieving secret for " + id + ": " + Log.getStackTraceString(e));
+            NativeLogger.error("KeyStore: error retrieving secret for " + id, e);
             throw e;
         }
     }
@@ -166,7 +165,7 @@ public class KeyStore implements UnsafeExternalKeyStore {
                 ks.load(null);
             }
         } catch (Exception e) {
-            NativeLogger.error("KeyStore: error setting up key store for " + id + ": " + Log.getStackTraceString(e));
+            NativeLogger.error("KeyStore: error setting up key store for " + id, e);
             throw e;
         }
 
@@ -193,7 +192,7 @@ public class KeyStore implements UnsafeExternalKeyStore {
 
             saveWrappedSecret(prefs, sharedPrefKeyPrefix(serviceName) + key, wrappedSecret);
         } catch (Exception e) {
-            NativeLogger.error("KeyStore: error storing secret for " + id + ": " + Log.getStackTraceString(e));
+            NativeLogger.error("KeyStore: error storing secret for " + id, e);
             throw e;
         }
 

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -23,6 +23,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 
+import io.keybase.ossifrage.modules.NativeLogger;
 import io.keybase.ossifrage.util.ContactsPermissionsWrapper;
 import io.keybase.ossifrage.util.DNSNSFetcher;
 import io.keybase.ossifrage.util.VideoHelper;
@@ -49,7 +50,7 @@ public class MainActivity extends ReactActivity {
                 Log.d(TAG, "dummy.txt exists");
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            NativeLogger.error("Exception in createDummyFile", e);
         }
     }
 
@@ -59,7 +60,7 @@ public class MainActivity extends ReactActivity {
         try {
             Keybase.setGlobalExternalKeyStore(new KeyStore(this, getSharedPreferences("KeyStore", MODE_PRIVATE)));
         } catch (KeyStoreException | CertificateException | IOException | NoSuchAlgorithmException e) {
-            e.printStackTrace();
+            NativeLogger.error("Exception in MainActivity.onCreate", e);
         }
 
         createDummyFile();

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -30,9 +30,7 @@ import io.keybase.ossifrage.modules.NativeLogger;
 public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
-    long appStartMilli = System.currentTimeMillis();
-    Date d = new Date(appStateMilli);
-    NativeLogger.info("App started on " + d.toString());
+    NativeLogger.info("MainApplication created");
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     JobManager manager = JobManager.create(this);

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -28,7 +28,7 @@ import io.keybase.ossifrage.modules.BackgroundSyncJob;
 
 public class MainApplication extends Application implements ReactApplication {
   @Override
-  public void onCreate () {
+  public void onCreate() {
     long appStartMilli = System.currentTimeMillis();
     Date d = new Date(appStateMilli);
     NativeLogger.info("App started on " + d.toString());

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -25,6 +25,7 @@ import java.util.List;
 import io.keybase.ossifrage.modules.StorybookConstants;
 import io.keybase.ossifrage.modules.BackgroundJobCreator;
 import io.keybase.ossifrage.modules.BackgroundSyncJob;
+import io.keybase.ossifrage.modules.NativeLogger;
 
 public class MainApplication extends Application implements ReactApplication {
   @Override

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -60,7 +60,7 @@ public class MainApplication extends Application implements ReactApplication {
       if (BuildConfig.BUILD_TYPE == "storyBook") {
         return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-          new KBReactPackage("") {
+          new KBReactPackage() {
             @Override
             public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
               List<NativeModule> modules = new ArrayList<>();
@@ -78,7 +78,7 @@ public class MainApplication extends Application implements ReactApplication {
 
       return Arrays.<ReactPackage>asList(
               new MainReactPackage(),
-              new KBReactPackage(logFile.getAbsolutePath()),
+              new KBReactPackage(),
               new ReactNativePushNotificationPackage(),
               new RNCameraPackage(),
               new ImagePickerPackage(),

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -27,10 +27,11 @@ import io.keybase.ossifrage.modules.BackgroundJobCreator;
 import io.keybase.ossifrage.modules.BackgroundSyncJob;
 
 public class MainApplication extends Application implements ReactApplication {
-  private File logFile;
-
   @Override
   public void onCreate () {
+    long appStartMilli = System.currentTimeMillis();
+    Date d = new Date(appStateMilli);
+    NativeLogger.info("App started on " + d.toString());
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     JobManager manager = JobManager.create(this);
@@ -44,8 +45,6 @@ public class MainApplication extends Application implements ReactApplication {
         manager.cancelAllForTag(BackgroundSyncJob.TAG);
         BackgroundSyncJob.scheduleJob();
     }
-
-    logFile = this.getFileStreamPath("android.log");
   }
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -111,9 +111,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
             final KeyguardManager keyguardManager = (KeyguardManager) this.reactContext.getSystemService(Context.KEYGUARD_SERVICE);
             isDeviceSecure = keyguardManager.isKeyguardSecure();
         } catch (Exception e) {
-          NativeLogger.warn(NAME + ": Error reading keyguard secure state");
-          // TODO: Log exception.
-          //, e);
+          NativeLogger.warn(NAME + ": Error reading keyguard secure state", e);
         }
 
         final Map<String, Object> constants = new HashMap<>();

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -52,7 +52,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
                           .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                           .emit(KeybaseEngine.RPC_EVENT_NAME, data);
               } catch (Exception e) {
-                      e.printStackTrace();
+                  NativeLogger.error("Exception in ReadFromKBLib.run", e);
               }
           } while (!Thread.currentThread().isInterrupted() && reactContext.hasActiveCatalystInstance());
         }
@@ -93,7 +93,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
             }
             executor = null;
         } catch (Exception e) {
-            e.printStackTrace();
+            NativeLogger.error("Exception in KeybaseEngine.destroy", e);
         }
     }
 
@@ -130,7 +130,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
       try {
           writeB64(data);
       } catch (Exception e) {
-          e.printStackTrace();
+          NativeLogger.error("Exception in KeybaseEngine.runWithData", e);
       }
     }
 
@@ -139,7 +139,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
       try {
           Keybase.reset();
       } catch (Exception e) {
-          e.printStackTrace();
+          NativeLogger.error("Exception in KeybaseEngine.reset", e);
       }
     }
 
@@ -153,7 +153,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
                 executor.execute(new ReadFromKBLib(this.reactContext));
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            NativeLogger.error("Exception in KeybaseEngine.start", e);
         }
     }
 }

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -59,8 +59,8 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
     }
 
     public KeybaseEngine(final ReactApplicationContext reactContext) {
-        NativeLogger.info("KeybaseEngine constructed");
         super(reactContext);
+        NativeLogger.info("KeybaseEngine constructed");
         this.reactContext = reactContext;
 
         reactContext.addLifecycleEventListener(new LifecycleEventListener() {
@@ -111,7 +111,9 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
             final KeyguardManager keyguardManager = (KeyguardManager) this.reactContext.getSystemService(Context.KEYGUARD_SERVICE);
             isDeviceSecure = keyguardManager.isKeyguardSecure();
         } catch (Exception e) {
-            NativeLogger.warn(NAME + ": Error reading keyguard secure state", e);
+          NativeLogger.warn(NAME + ": Error reading keyguard secure state");
+          // TODO: Log exception.
+          //, e);
         }
 
         final Map<String, Object> constants = new HashMap<>();

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -2,7 +2,6 @@ package io.keybase.ossifrage.modules;
 
 import android.app.KeyguardManager;
 import android.content.Context;
-import android.util.Log;
 
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -18,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import keybase.Keybase;
 import io.keybase.ossifrage.BuildConfig;
+import io.keybase.ossifrage.modules.NativeLogger;
 
 import static keybase.Keybase.readB64;
 import static keybase.Keybase.writeB64;
@@ -45,7 +45,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
                   final String data = readB64();
 
                   if (!reactContext.hasActiveCatalystInstance()) {
-                      Log.e(NAME, "JS Bridge is dead, dropping engine message: " + data);
+                      NativeLogger.info(NAME + ": JS Bridge is dead, dropping engine message: " + data);
                   }
 
                   reactContext
@@ -89,7 +89,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
             // We often hit this timeout during app resume, e.g. hit the back
             // button to go to home screen and then tap Keybase app icon again.
             if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {
-                Log.w(NAME, "Executor pool didn't shut down cleanly");
+                NativeLogger.warn(NAME + ": Executor pool didn't shut down cleanly");
             }
             executor = null;
         } catch (Exception e) {
@@ -111,7 +111,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
             final KeyguardManager keyguardManager = (KeyguardManager) this.reactContext.getSystemService(Context.KEYGUARD_SERVICE);
             isDeviceSecure = keyguardManager.isKeyguardSecure();
         } catch (Exception e) {
-            Log.w(NAME, "Error reading keyguard secure state", e);
+            NativeLogger.warn(NAME + ": Error reading keyguard secure state", e);
         }
 
         final Map<String, Object> constants = new HashMap<>();

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -59,9 +59,9 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
     }
 
     public KeybaseEngine(final ReactApplicationContext reactContext) {
+        NativeLogger.info("KeybaseEngine constructed");
         super(reactContext);
         this.reactContext = reactContext;
-
 
         reactContext.addLifecycleEventListener(new LifecycleEventListener() {
             @Override
@@ -83,7 +83,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
         });
     }
 
-    public void destroy(){
+    public void destroy() {
         try {
             executor.shutdownNow();
             // We often hit this timeout during app resume, e.g. hit the back
@@ -143,6 +143,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
 
     @ReactMethod
     public void start() {
+        NativeLogger.info("KeybaseEngine started");
         try {
             started = true;
             if (executor == null) {

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
@@ -32,27 +32,32 @@ public class NativeLogger extends ReactContextBaseJavaModule {
 
     // This should do roughly the same thing as dumpLine from
     // native-logger.js.
-    private static String dumpLine(String toLog) throws IOException {
+    private static String dumpLine(String toLog) {
         long millis = System.currentTimeMillis();
         StringWriter sw = new StringWriter();
         JsonWriter js = new JsonWriter(sw);
-        js.beginArray()
+        try {
+            js.beginArray()
                 .value(millis)
                 .value(toLog)
                 .endArray()
                 .close();
-        return sw.toString();
+            return sw.toString();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return toLog;
+        }
     }
 
-    public static void error(String log) throws IOException {
+    public static void error(String log) {
         rawLog(ERROR_TAG, dumpLine(log));
     }
 
-    public static void info(String log) throws IOException {
+    public static void info(String log) {
         rawLog(INFO_TAG, dumpLine(log));
     }
 
-    public static void warn(String log) throws IOException {
+    public static void warn(String log) {
         rawLog(WARN_TAG, dumpLine(log));
     }
 

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
@@ -44,21 +44,37 @@ public class NativeLogger extends ReactContextBaseJavaModule {
                 .close();
             return sw.toString();
         } catch (IOException e) {
-            e.printStackTrace();
+            rawLog(ERROR_TAG, "Exception in dumpLine: " + Log.getStackTraceString(e));
             return toLog;
         }
+    }
+
+    private static String dumpLine(String toLog, Throwable tr) {
+      return dumpLine(toLog + ": " + Log.getStackTraceString(tr));
     }
 
     public static void error(String log) {
         rawLog(ERROR_TAG, dumpLine(log));
     }
 
+    public static void error(String log, Throwable tr) {
+        rawLog(ERROR_TAG, dumpLine(log, tr));
+    }
+
     public static void info(String log) {
         rawLog(INFO_TAG, dumpLine(log));
     }
 
+    public static void info(String log, Throwable tr) {
+        rawLog(INFO_TAG, dumpLine(log, tr));
+    }
+
     public static void warn(String log) {
         rawLog(WARN_TAG, dumpLine(log));
+    }
+
+    public static void warn(String log, Throwable tr) {
+      rawLog(WARN_TAG, dumpLine(log, tr));
     }
 
     public NativeLogger(final ReactApplicationContext reactContext) {

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
@@ -74,7 +74,7 @@ public class NativeLogger extends ReactContextBaseJavaModule {
     }
 
     public static void warn(String log, Throwable tr) {
-      rawLog(WARN_TAG, dumpLine(log, tr));
+        rawLog(WARN_TAG, dumpLine(log, tr));
     }
 
     public NativeLogger(final ReactApplicationContext reactContext) {

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
@@ -113,7 +113,7 @@ public class NativeLogger extends ReactContextBaseJavaModule {
             promise.resolve(totalArray);
         } catch (IOException e) {
             promise.reject(e);
-            e.printStackTrace();
+            rawLog(ERROR_TAG, "Exception in dump: " + Log.getStackTraceString(e));
         }
     }
 }

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/ScreenProtector.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/ScreenProtector.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Looper;
-import android.util.Log;
 import android.view.Window;
 import android.view.WindowManager;
 


### PR DESCRIPTION
Also log startup events on Android. This is to get a better idea of
bottlenecks on the native side.

Make NativeLogger methods not throw, and also take an optional exception. This
makes it a drop-in replacement for Log.i, etc. Port most things to use NativeLogger.

Log any thrown exceptions via NativeLogger.