### PR TITLE
Reduce black bar frequency on leaving a team

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1940,10 +1940,13 @@ const loadCanUserPerform = (action: Chat2Gen.SelectConversationPayload, state: T
 
 // Helpers to nav you to the right place
 const navigateToInbox = (
-  action: Chat2Gen.NavigateToInboxPayload | Chat2Gen.LeaveConversationPayload,
+  action: Chat2Gen.NavigateToInboxPayload | Chat2Gen.LeaveConversationPayload | TeamsGen.LeftTeamPayload,
   state: TypedState
 ) => {
   if (action.type === Chat2Gen.leaveConversation && action.payload.dontNavigateToInbox) {
+    return
+  }
+  if (action.type === TeamsGen.leftTeam && action.payload.context !== 'chat') {
     return
   }
   const actions = [
@@ -2541,7 +2544,10 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
     markThreadAsRead
   )
 
-  yield Saga.safeTakeEveryPure([Chat2Gen.navigateToInbox, Chat2Gen.leaveConversation], navigateToInbox)
+  yield Saga.safeTakeEveryPure(
+    [Chat2Gen.navigateToInbox, Chat2Gen.leaveConversation, TeamsGen.leftTeam],
+    navigateToInbox
+  )
   yield Saga.safeTakeEveryPure(Chat2Gen.navigateToThread, navigateToThread)
 
   yield Saga.safeTakeEveryPure(Chat2Gen.joinConversation, joinConversation)

--- a/shared/actions/json/route-tree.json
+++ b/shared/actions/json/route-tree.json
@@ -29,7 +29,7 @@
       "path": "RCConstants.PropsPath<any>",
       "parentPath?": "?RCConstants.Path"
     },
-    "navigateUp": { },
+    "navigateUp": {},
     "putActionIfOnPath": {
       "expectedPath": "RCConstants.Path",
       "otherAction": "any",

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -103,7 +103,8 @@
       "teamname": "string"
     },
     "leaveTeam": {
-      "teamname": "string"
+      "teamname": "string",
+      "goToTeamList?": "boolean"
     },
     "addToTeam": {
       "teamname": "string",

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -104,7 +104,12 @@
     },
     "leaveTeam": {
       "teamname": "string",
-      "goToTeamList?": "boolean"
+      "context": "'teams' | 'chat'"
+    },
+    "leftTeam": {
+      "_description": "We successfully left a team",
+      "teamname": "string",
+      "context": "'teams' | 'chat'"
     },
     "addToTeam": {
       "teamname": "string",

--- a/shared/actions/teams-gen.js
+++ b/shared/actions/teams-gen.js
@@ -39,6 +39,7 @@ export const inviteToTeamByEmail = 'teams:inviteToTeamByEmail'
 export const inviteToTeamByPhone = 'teams:inviteToTeamByPhone'
 export const joinTeam = 'teams:joinTeam'
 export const leaveTeam = 'teams:leaveTeam'
+export const leftTeam = 'teams:leftTeam'
 export const removeMemberOrPendingInvite = 'teams:removeMemberOrPendingInvite'
 export const removeParticipant = 'teams:removeParticipant'
 export const saveChannelMembership = 'teams:saveChannelMembership'
@@ -174,7 +175,11 @@ type _InviteToTeamByPhonePayload = $ReadOnly<{|
 type _JoinTeamPayload = $ReadOnly<{|teamname: string|}>
 type _LeaveTeamPayload = $ReadOnly<{|
   teamname: string,
-  goToTeamList?: boolean,
+  context: 'teams' | 'chat',
+|}>
+type _LeftTeamPayload = $ReadOnly<{|
+  teamname: string,
+  context: 'teams' | 'chat',
 |}>
 type _RemoveMemberOrPendingInvitePayload = $ReadOnly<{|
   email: string,
@@ -316,6 +321,10 @@ export const createGetTeamRetentionPolicy = (payload: _GetTeamRetentionPolicyPay
  * Sets the retention policy for a team. The store will be updated automatically.
  */
 export const createSaveTeamRetentionPolicy = (payload: _SaveTeamRetentionPolicyPayload) => ({error: false, payload, type: saveTeamRetentionPolicy})
+/**
+ * We successfully left a team
+ */
+export const createLeftTeam = (payload: _LeftTeamPayload) => ({error: false, payload, type: leftTeam})
 export const createAddParticipant = (payload: _AddParticipantPayload) => ({error: false, payload, type: addParticipant})
 export const createAddPeopleToTeam = (payload: _AddPeopleToTeamPayload) => ({error: false, payload, type: addPeopleToTeam})
 export const createAddTeamWithChosenChannels = (payload: _AddTeamWithChosenChannelsPayload) => ({error: false, payload, type: addTeamWithChosenChannels})
@@ -403,6 +412,7 @@ export type InviteToTeamByEmailPayload = $Call<typeof createInviteToTeamByEmail,
 export type InviteToTeamByPhonePayload = $Call<typeof createInviteToTeamByPhone, _InviteToTeamByPhonePayload>
 export type JoinTeamPayload = $Call<typeof createJoinTeam, _JoinTeamPayload>
 export type LeaveTeamPayload = $Call<typeof createLeaveTeam, _LeaveTeamPayload>
+export type LeftTeamPayload = $Call<typeof createLeftTeam, _LeftTeamPayload>
 export type RemoveMemberOrPendingInvitePayload = $Call<typeof createRemoveMemberOrPendingInvite, _RemoveMemberOrPendingInvitePayload>
 export type RemoveParticipantPayload = $Call<typeof createRemoveParticipant, _RemoveParticipantPayload>
 export type SaveChannelMembershipPayload = $Call<typeof createSaveChannelMembership, _SaveChannelMembershipPayload>
@@ -468,6 +478,7 @@ export type Actions =
   | InviteToTeamByPhonePayload
   | JoinTeamPayload
   | LeaveTeamPayload
+  | LeftTeamPayload
   | RemoveMemberOrPendingInvitePayload
   | RemoveParticipantPayload
   | SaveChannelMembershipPayload

--- a/shared/actions/teams-gen.js
+++ b/shared/actions/teams-gen.js
@@ -172,7 +172,10 @@ type _InviteToTeamByPhonePayload = $ReadOnly<{|
   fullName: string,
 |}>
 type _JoinTeamPayload = $ReadOnly<{|teamname: string|}>
-type _LeaveTeamPayload = $ReadOnly<{|teamname: string|}>
+type _LeaveTeamPayload = $ReadOnly<{|
+  teamname: string,
+  goToTeamList?: boolean,
+|}>
 type _RemoveMemberOrPendingInvitePayload = $ReadOnly<{|
   email: string,
   teamname: string,

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -100,11 +100,22 @@ const _joinTeam = function*(action: TeamsGen.JoinTeamPayload) {
 }
 
 const _leaveTeam = function(action: TeamsGen.LeaveTeamPayload) {
-  const {teamname} = action.payload
-  return Saga.call(RPCTypes.teamsTeamLeaveRpcPromise, {
-    name: teamname,
-    permanent: false,
-  })
+  const {goToTeamList, teamname} = action.payload
+  const steps = [
+    Saga.call(
+      RPCTypes.teamsTeamLeaveRpcPromise,
+      {
+        name: teamname,
+        permanent: false,
+      },
+      Constants.leaveTeamWaitingKey(teamname)
+    ),
+  ]
+  if (goToTeamList) {
+    steps.push(Saga.put(RouteTreeGen.createNavigateTo({path: [teamsTab]})))
+  }
+  steps.push(Saga.put(TeamsGen.createGetTeams()))
+  return Saga.sequentially(steps)
 }
 
 const _addPeopleToTeam = function*(action: TeamsGen.AddPeopleToTeamPayload) {
@@ -156,7 +167,8 @@ const _getTeamRetentionPolicy = function*(action: TeamsGen.GetTeamRetentionPolic
   }
   const policy: RPCChatTypes.RetentionPolicy = yield Saga.call(
     RPCChatTypes.localGetTeamRetentionLocalRpcPromise,
-    {teamID, waitingKey: Constants.teamWaitingKey(teamname)}
+    {teamID},
+    Constants.teamWaitingKey(teamname)
   )
   let retentionPolicy: RetentionPolicy = Constants.makeRetentionPolicy()
   try {

--- a/shared/common-adapters/waiting-button.js
+++ b/shared/common-adapters/waiting-button.js
@@ -5,10 +5,12 @@ import {connect, type TypedState, setDisplayName} from '../util/container'
 import * as WaitingConstants from '../constants/waiting'
 
 export type OwnProps = ButtonProps & {
+  onlyDisable?: boolean, // Must supply waiting key if this is true
   waitingKey: ?string,
 }
 
 export type Props = ButtonProps & {
+  onlyDisable?: boolean,
   storeWaiting: boolean,
   waitingKey: ?string,
 }
@@ -35,13 +37,20 @@ class WaitingButton extends React.Component<Props, {localWaiting: boolean}> {
     this.props.onClick && this.props.onClick(event)
   }
 
-  render = () => (
-    <Button
-      {...this.props}
-      onClick={this._onClick}
-      waiting={this.props.storeWaiting || this.state.localWaiting}
-    />
-  )
+  render = () => {
+    if (this.props.onlyDisable && !this.props.waitingKey) {
+      throw new Error('WaitingButton onlyDisable should only be used with a waiting key')
+    }
+    const waiting = this.props.storeWaiting || this.state.localWaiting
+    return (
+      <Button
+        {...this.props}
+        onClick={this._onClick}
+        disabled={this.props.onlyDisable ? waiting : false}
+        waiting={this.props.onlyDisable ? false : waiting}
+      />
+    )
+  }
 }
 
 const mapStateToProps = (state: TypedState, ownProps) => {

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -122,6 +122,10 @@ export const isUserActivelyLookingAtThisThread = (
     conversationIDKey === selectedConversationIDKey // looking at the selected thread?
   )
 }
+export const isTeamConversationSelected = (state: TypedState, teamname: string) => {
+  const meta = getMeta(state, getSelectedConversation(state))
+  return meta.teamname === teamname
+}
 export const isInfoPanelOpen = (state: TypedState) => {
   const routePath = getPath(state.routeTree.routeState, [chatTab])
   return routePath.size === 3 && routePath.get(2) === 'infoPanel'

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -28,6 +28,7 @@ export const addMemberWaitingKey = (teamname: Types.Teamname, username: string) 
 // also for pending invites, hence id rather than username
 export const removeMemberWaitingKey = (teamname: Types.Teamname, id: string) => `teamRemove:${teamname};${id}`
 export const addToTeamSearchKey = 'addToTeamSearch'
+export const leaveTeamWaitingKey = (teamname: Types.Teamname) => `teamLeave:${teamname}`
 
 export const makeChannelInfo: I.RecordFactory<Types._ChannelInfo> = I.Record({
   channelname: '',

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Chat2Gen from '../actions/chat2-gen'
+import * as TeamsGen from '../actions/teams-gen'
 import * as Constants from '../constants/chat2'
 import * as I from 'immutable'
 import * as RPCChatTypes from '../constants/types/rpc-chat-gen'
@@ -813,6 +814,18 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
         s.set('messageOrdinals', messageOrdinalsReducer(state.messageOrdinals, action))
       })
     }
+    case TeamsGen.leftTeam:
+      const {teamname} = action.payload
+      const selectedConvID = state.selectedConversation
+      const meta = state.metaMap.get(selectedConvID, Constants.makeConversationMeta())
+      if (meta.teamname === teamname) {
+        // Select a different conversation
+        const newConvo = state.metaMap.reduce((nextConv, conv, convID) => {
+          return conv.teamname !== teamname && conv.timestamp > nextConv.timestamp ? conv : nextConv
+        }, Constants.makeConversationMeta())
+        return state.set('selectedConversation', newConvo.conversationIDKey)
+      }
+      return state
     // metaMap/messageMap/messageOrdinalsList only actions
     case Chat2Gen.messageDelete:
     case Chat2Gen.messageEdit:

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -814,7 +814,7 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
         s.set('messageOrdinals', messageOrdinalsReducer(state.messageOrdinals, action))
       })
     }
-    case TeamsGen.leftTeam:
+    case TeamsGen.leaveTeam:
       const {teamname} = action.payload
       const selectedConvID = state.selectedConversation
       const meta = state.metaMap.get(selectedConvID, Constants.makeConversationMeta())

--- a/shared/reducers/teams.js
+++ b/shared/reducers/teams.js
@@ -182,6 +182,7 @@ const rootReducer = (state: Types.State = initialState, action: TeamsGen.Actions
     case TeamsGen.inviteToTeamByPhone:
     case TeamsGen.joinTeam:
     case TeamsGen.leaveTeam:
+    case TeamsGen.leftTeam:
     case TeamsGen.removeMemberOrPendingInvite:
     case TeamsGen.saveChannelMembership:
     case TeamsGen.setMemberPublicity:

--- a/shared/teams/really-leave-team/container-chat.js
+++ b/shared/teams/really-leave-team/container-chat.js
@@ -30,7 +30,7 @@ const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
   _loadOperations: teamname => dispatch(TeamsGen.createGetTeamOperations({teamname})),
   onBack: () => dispatch(navigateUp()),
   onLeave: () => {
-    dispatch(TeamsGen.createLeaveTeam({teamname: routeProps.get('teamname')}))
+    dispatch(TeamsGen.createLeaveTeam({context: 'chat', teamname: routeProps.get('teamname')}))
   },
 })
 

--- a/shared/teams/really-leave-team/container-chat.js
+++ b/shared/teams/really-leave-team/container-chat.js
@@ -1,25 +1,28 @@
 // @flow
 import * as React from 'react'
 import * as TeamsGen from '../../actions/teams-gen'
-import {connect, type TypedState} from '../../util/container'
+import * as Container from '../../util/container'
 import ReallyLeaveTeam, {Spinner, type Props as RenderProps} from '.'
 import LastOwnerDialog from './last-owner'
-import {getCanPerform, hasCanPerform} from '../../constants/teams'
+import {getCanPerform, hasCanPerform, leaveTeamWaitingKey} from '../../constants/teams'
 import {type Teamname} from '../../constants/types/teams'
+import {anyWaiting} from '../../constants/waiting'
 
 type Props = {|
   ...$Exact<RenderProps>,
   _canLeaveTeam: boolean,
+  _leaving: boolean,
   _loadOperations: (teamname: Teamname) => void,
   _loaded: boolean,
 |}
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state: Container.TypedState, {routeProps}) => {
   const name = routeProps.get('teamname')
   const canPerform = getCanPerform(state, name)
   const _canLeaveTeam = canPerform.leaveTeam
   return {
     _canLeaveTeam,
+    _leaving: anyWaiting(state, leaveTeamWaitingKey(name)),
     _loaded: hasCanPerform(state, name),
     name,
     title: 'Confirmation',
@@ -33,6 +36,19 @@ const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
     dispatch(TeamsGen.createLeaveTeam({context: 'chat', teamname: routeProps.get('teamname')}))
   },
 })
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  return {
+    _canLeaveTeam: stateProps._canLeaveTeam,
+    _leaving: stateProps._leaving,
+    _loadOperations: dispatchProps._loadOperations,
+    _loaded: stateProps._loaded,
+    name: stateProps.name,
+    onBack: stateProps._leaving ? () => {} : dispatchProps.onBack,
+    onLeave: dispatchProps.onLeave,
+    title: stateProps.title,
+  }
+}
 
 class Switcher extends React.PureComponent<Props> {
   componentDidMount() {
@@ -52,4 +68,7 @@ class Switcher extends React.PureComponent<Props> {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d}))(Switcher)
+export default Container.compose(
+  Container.connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  Container.safeSubmit(['onLeave'], ['_leaving'])
+)(Switcher)

--- a/shared/teams/really-leave-team/container-chat.js
+++ b/shared/teams/really-leave-team/container-chat.js
@@ -31,8 +31,6 @@ const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
   onBack: () => dispatch(navigateUp()),
   onLeave: () => {
     dispatch(TeamsGen.createLeaveTeam({teamname: routeProps.get('teamname')}))
-    dispatch(navigateUp())
-    dispatch(TeamsGen.createGetTeams())
   },
 })
 

--- a/shared/teams/really-leave-team/container.js
+++ b/shared/teams/really-leave-team/container.js
@@ -20,7 +20,7 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
 const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
   onBack: () => dispatch(navigateUp()),
   onLeave: () => {
-    dispatch(TeamsGen.createLeaveTeam({goToTeamList: true, teamname: routeProps.get('teamname')}))
+    dispatch(TeamsGen.createLeaveTeam({context: 'teams', teamname: routeProps.get('teamname')}))
   },
 })
 

--- a/shared/teams/really-leave-team/container.js
+++ b/shared/teams/really-leave-team/container.js
@@ -4,8 +4,6 @@ import {connect, type TypedState} from '../../util/container'
 import {compose, branch, renderComponent} from 'recompose'
 import ReallyLeaveTeam from '.'
 import LastOwnerDialog from './last-owner'
-import {navigateTo} from '../../actions/route-tree'
-import {teamsTab} from '../../constants/tabs'
 import {getTeamMemberCount, isSubteam} from '../../constants/teams'
 
 const mapStateToProps = (state: TypedState, {routeProps}) => {
@@ -22,9 +20,7 @@ const mapStateToProps = (state: TypedState, {routeProps}) => {
 const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
   onBack: () => dispatch(navigateUp()),
   onLeave: () => {
-    dispatch(TeamsGen.createLeaveTeam({teamname: routeProps.get('teamname')}))
-    dispatch(navigateTo([teamsTab]))
-    dispatch(TeamsGen.createGetTeams())
+    dispatch(TeamsGen.createLeaveTeam({goToTeamList: true, teamname: routeProps.get('teamname')}))
   },
 })
 

--- a/shared/teams/really-leave-team/index.js
+++ b/shared/teams/really-leave-team/index.js
@@ -4,7 +4,6 @@ import * as Constants from '../../constants/teams'
 import {
   Avatar,
   Box,
-  Button,
   ButtonBar,
   Icon,
   MaybePopup,
@@ -46,7 +45,13 @@ const _ReallyLeaveTeam = (props: Props) => (
         unless an admin invites you.
       </Text>
       <ButtonBar direction={isMobile ? 'column' : 'row'} fullWidth={isMobile}>
-        <Button type="Secondary" onClick={props.onBack} label="Cancel" />
+        <WaitingButton
+          type="Secondary"
+          onClick={props.onBack}
+          onlyDisable={true}
+          label="Cancel"
+          waitingKey={Constants.leaveTeamWaitingKey(props.name)}
+        />
         <WaitingButton
           type="Danger"
           onClick={props.onLeave}

--- a/shared/teams/really-leave-team/index.js
+++ b/shared/teams/really-leave-team/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import * as Constants from '../../constants/teams'
 import {
   Avatar,
   Box,
@@ -10,6 +11,7 @@ import {
   ProgressIndicator,
   HeaderOnMobile,
   Text,
+  WaitingButton,
 } from '../../common-adapters'
 import {globalStyles, globalMargins, isMobile} from '../../styles'
 
@@ -45,7 +47,12 @@ const _ReallyLeaveTeam = (props: Props) => (
       </Text>
       <ButtonBar direction={isMobile ? 'column' : 'row'} fullWidth={isMobile}>
         <Button type="Secondary" onClick={props.onBack} label="Cancel" />
-        <Button type="Danger" onClick={props.onLeave} label={`Yes, leave ${props.name}`} fullWidth={true} />
+        <WaitingButton
+          type="Danger"
+          onClick={props.onLeave}
+          label={`Yes, leave ${props.name}`}
+          waitingKey={Constants.leaveTeamWaitingKey(props.name)}
+        />
       </ButtonBar>
     </Box>
   </MaybePopup>


### PR DESCRIPTION
This PR became bigger than I expected. This adds some additional listeners to `TeamsGen.leaveTeam` as well as a new action `TeamsGen.leftTeam`. Also adds an additional param to both, `context: 'teams' | 'chat'`

On `leaveTeam` we:
- Make RPC call to leave the team
- Disable the cancel/confirm buttons on the dialog and disable navigating away from it
- On desktop: deselect any conversation for this team we may have had selected. We do this here instead of on `leftTeam` to avoid having a mark-as-read call slip through after we've left. On mobile this isn't as much of a problem.

On `leftTeam` we:
- If `context === 'chat'` we navigate to the inbox
- If the team we left is in the team tab's route stack, we navigate out to the root of that tab (but don't switch to it)
- Fetch the teams list

This doesn't pipe through an error message, so on `leaveTeam` failure everything on the dialog will re-enable and the user will see a black bar.

All of this is in an effort to make sure we don't drop the user on a page they wouldn't be allowed to see after leaving the team.

I spent most time testing the various states you can be in before leaving a team, so the other things that these actions affect deserve focus. r? @keybase/react-hackers 