### PR TITLE
Use grey stellar icon when send form input is empty

### DIFF
--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -40,6 +40,7 @@ const mapStateToProps = (state: TypedState) => {
 
   // Building section
   const recipientType = build.recipientType || 'keybaseUser'
+  const toFieldInput = build.to
   // Built section
   const incorrect = built.toErrMsg
   const recipientUsername = built.toUsername
@@ -47,10 +48,11 @@ const mapStateToProps = (state: TypedState) => {
   return {
     allAccounts,
     fromAccount,
-    toAccount,
     incorrect,
     recipientType,
     recipientUsername,
+    toAccount,
+    toFieldInput,
     user: state.config.username,
   }
 }

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -24,6 +24,7 @@ type ParticipantsProps = {|
   onCreateNewAccount: () => void,
   // Used for send to stellar address
   incorrect?: string,
+  toFieldInput: string,
   // Used to display a keybase profile
   recipientUsername?: string,
   recipientFullName?: string,
@@ -53,6 +54,7 @@ const Participants = (props: ParticipantsProps) => (
       recipientFullName={props.recipientFullName}
       recipientType={props.recipientType}
       recipientUsername={props.recipientUsername}
+      toFieldInput={props.toFieldInput}
       user={props.user}
     />
   </Kb.Box2>

--- a/shared/wallets/send-form/participants/index.stories.js
+++ b/shared/wallets/send-form/participants/index.stories.js
@@ -102,6 +102,7 @@ const defaultProps = {
   onLinkAccount: Sb.action('onLinkAccount'),
   onCreateNewAccount: Sb.action('onCreateNewAccount'),
   onShowProfile: Sb.action('onShowProfile'),
+  toFieldInput: '',
 }
 
 const load = () => {

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -18,6 +18,7 @@ type ToFieldProps = {|
   onRemoveProfile?: () => void,
   // Used for sending to a stellar address.
   incorrect?: string,
+  toFieldInput: string,
   // Used for sending from account to account
   // We need the users' name, list of accounts, currently selected account, and callbacks to link and create new accounts.
   user: string,
@@ -125,7 +126,11 @@ class ToField extends React.Component<ToFieldProps> {
         <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
           <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputInner}>
             <Kb.Icon
-              type={this.props.incorrect ? 'icon-stellar-logo-grey-16' : 'icon-stellar-logo-16'}
+              type={
+                this.props.incorrect || this.props.toFieldInput.length === 0
+                  ? 'icon-stellar-logo-grey-16'
+                  : 'icon-stellar-logo-16'
+              }
               style={Kb.iconCastPlatformStyles(styles.stellarIcon)}
             />
             <Kb.NewInput


### PR DESCRIPTION
@mlsteele introduced a change into how payments were built a couple of weeks ago, silencing the error message when the to field was empty (#13478). I never got around to changing the logic of displaying the grey stellar icon, though, so this fixes that.

I check for if the to field input is empty or not with a new prop, `toFieldInput`. Note this means that while it works for the app, the send form's story's icon doesn't change since the prop remains the same. The only solution I could think of to that would be to have a controlled input on the to input. I think @buoyad is taking care of that, so this may be something to consider as you work on that ticket.

Here's what it looks like now:

No input:
![screen shot 2018-09-14 at 3 44 42 pm](https://user-images.githubusercontent.com/5677971/45571860-9fe28480-b835-11e8-8d80-555aa94319a6.png)

A good address:
![screen shot 2018-09-14 at 3 45 02 pm](https://user-images.githubusercontent.com/5677971/45571867-a8d35600-b835-11e8-96a6-d7174fee2a97.png)

A bad address: 
![screen shot 2018-09-14 at 3 48 57 pm](https://user-images.githubusercontent.com/5677971/45571878-b4bf1800-b835-11e8-94c2-d97a802b463d.png)
