### PR TITLE
Fix inbox snippets and titles being cut off on mobile

### DIFF
--- a/shared/chat/inbox/row/small-team/bottom-line.js
+++ b/shared/chat/inbox/row/small-team/bottom-line.js
@@ -144,7 +144,7 @@ const styles = styleSheetCreate({
     ...globalStyles.flexBoxRow,
     alignItems: 'center',
     flexGrow: 1,
-    height: 17,
+    height: isMobile ? 21 : 17,
     position: 'relative',
   },
   rekeyNeededContainer: {

--- a/shared/chat/inbox/row/small-team/top-line.js
+++ b/shared/chat/inbox/row/small-team/top-line.js
@@ -61,7 +61,7 @@ class _SimpleTopLine extends React.Component<Props> {
           style={{
             ...globalStyles.flexBoxRow,
             flexGrow: 1,
-            height: 17,
+            height: isMobile ? 21 : 17,
             position: 'relative',
           }}
         >


### PR DESCRIPTION
Before:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/11968340/45572055-40d13f80-b836-11e8-8cbd-8e5d70e69246.png">


After:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/11968340/45572029-3020c980-b836-11e8-860e-44abed28ff38.png">

r? @keybase/react-hackers 