### PR TITLE
protect against a random duplicate membership update from the server CORE-8883

### DIFF
--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const inboxVersion = 20
+const inboxVersion = 21
 
 type queryHash []byte
 
@@ -1558,7 +1558,17 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat
 				cp.Conv.Metadata.ResetList = append(cp.Conv.Metadata.ResetList[:resetIndex],
 					cp.Conv.Metadata.ResetList[resetIndex+1:]...)
 			} else {
-				cp.Conv.Metadata.AllList = append(cp.Conv.Metadata.AllList, oj.Uid)
+				// Double check this user isn't already in here
+				exists := false
+				for _, u := range cp.Conv.Metadata.AllList {
+					if u.Eq(oj.Uid) {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					cp.Conv.Metadata.AllList = append(cp.Conv.Metadata.AllList, oj.Uid)
+				}
 			}
 			cp.Conv.Metadata.Version = vers.ToConvVers()
 		}


### PR DESCRIPTION
It seems like it is possible that we try to run the same `MembershipUpdate` twice on the inbox in some cases. This shouldn't be a problem, but the update handler was just blindly adding people into the `AllList` regardless of whether or not they were already in there. This patch adds a check to prevent the duplicates from happening. 

cc @malgorithms 