### PR TITLE
client support for force-repoll mode

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -617,6 +617,7 @@ type TeamLoader interface {
 	// Untrusted hint of what a team's latest seqno is
 	HintLatestSeqno(ctx context.Context, id keybase1.TeamID, seqno keybase1.Seqno) error
 	ResolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName, public bool, allowCache bool) (id keybase1.TeamID, err error)
+	ForceRepollUntil(ctx context.Context, t gregor.TimeOrOffset) error
 	OnLogout()
 	// Clear the in-memory cache. Does not affect the disk cache.
 	ClearMem()

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	gregor "github.com/keybase/client/go/gregor"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
 )
@@ -56,6 +57,10 @@ func (n *nullTeamLoader) HintLatestSeqno(ctx context.Context, id keybase1.TeamID
 
 func (n *nullTeamLoader) ResolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName, public bool, allowCache bool) (id keybase1.TeamID, err error) {
 	return id, fmt.Errorf("null team loader")
+}
+
+func (n *nullTeamLoader) ForceRepollUntil(ctx context.Context, t gregor.TimeOrOffset) error {
+	return nil
 }
 
 func (n nullTeamLoader) OnLogout() {}

--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -53,6 +53,8 @@ func (r *teamHandler) Create(ctx context.Context, cli gregor1.IncomingInterface,
 		return true, r.openTeamAccessRequest(ctx, cli, item)
 	case "team.change":
 		return true, r.changeTeam(ctx, cli, category, item, keybase1.TeamChangeSet{})
+	case "team.force_repoll":
+		return true, r.gotForceRepoll(ctx, cli, item)
 	case "team.rename":
 		return true, r.changeTeam(ctx, cli, category, item, keybase1.TeamChangeSet{Renamed: true})
 	case "team.delete":
@@ -204,6 +206,11 @@ func (r *teamHandler) findAndDismissResetBadges(ctx context.Context, cli gregor1
 	}
 
 	return nil
+}
+
+func (r *teamHandler) gotForceRepoll(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
+	r.G().Log.CDebugf(ctx, "teamHandler: gotForceRepoll received")
+	return teams.HandleForceRepollNotification(ctx, r.G(), item.DTime())
 }
 
 func (r *teamHandler) changeTeam(ctx context.Context, cli gregor1.IncomingInterface, category string,

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -640,4 +641,8 @@ func handleSeitanSingleV2(key keybase1.SeitanPubKey, invite keybase1.TeamInvite,
 	}
 
 	return nil
+}
+
+func HandleForceRepollNotification(ctx context.Context, g *libkb.GlobalContext, dtime gregor.TimeOrOffset) error {
+	return g.GetTeamLoader().ForceRepollUntil(ctx, dtime)
 }

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -3,7 +3,6 @@ package teams
 import (
 	"encoding/hex"
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -3,6 +3,7 @@ package teams
 import (
 	"encoding/hex"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 


### PR DESCRIPTION
- when we get a gregor message of type team.force_repoll, then force a repoll on every team load since we no longer expect pushed cache invalidations
- a test in systests to make sure this bit is getting set properly