### PR TITLE
More safety in provisioning (and logging)

### DIFF
--- a/shared/actions/provision.js
+++ b/shared/actions/provision.js
@@ -49,10 +49,16 @@ class ProvisioningManager {
   _stashedResponse = null
   _stashedResponseKey: ?ValidCallback = null
   _addingANewDevice: boolean
+  _done: boolean = false
 
   constructor(addingANewDevice: boolean, onlyCallThisFromTheHelper: 'ONLY_CALL_THIS_FROM_HELPER') {
     this._addingANewDevice = addingANewDevice
     ProvisioningManager.singleton = this
+  }
+
+  done = (reason: string) => {
+    logger.info('ProvisioningManager.done', reason)
+    this._done = true
   }
 
   _stashResponse = (key: ValidCallback, response: any) => {
@@ -62,8 +68,10 @@ class ProvisioningManager {
 
   _getAndClearResponse = (key: ValidCallback) => {
     if (this._stashedResponseKey !== key) {
+      logger.info('ProvisioningManager._getAndClearResponse error', key, this._stashedResponseKey)
       throw new Error(`Invalid response key used wants: ${key} has: ${this._stashedResponseKey || ''}`)
     }
+    logger.info('ProvisioningManager._getAndClearResponse success', key)
     const response = this._stashedResponse
     this._stashedResponse = null
     return response
@@ -71,6 +79,10 @@ class ProvisioningManager {
 
   // Choosing a device to use to provision
   chooseDeviceHandler = (params, response) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet chooseDeviceHandler called')
+      return
+    }
     this._stashResponse('keybase.1.provisionUi.chooseDevice', response)
     return Saga.put(
       ProvisionGen.createShowDeviceListPage({
@@ -80,6 +92,10 @@ class ProvisioningManager {
   }
 
   submitDeviceSelect = (state: TypedState) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet submitDeviceSelect called')
+      return
+    }
     const response = this._getAndClearResponse('keybase.1.provisionUi.chooseDevice')
     if (!response || !response.result) {
       throw new Error('Tried to submit a device choice but missing callback')
@@ -95,6 +111,10 @@ class ProvisioningManager {
 
   // Telling the daemon the other device type when adding a new device
   chooseDeviceTypeHandler = (params, response) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet chooseDeviceTypeHandler called')
+      return
+    }
     return Saga.call(function*() {
       const state: TypedState = yield Saga.select()
       let type
@@ -118,6 +138,10 @@ class ProvisioningManager {
 
   // Choosing a name for this new device
   promptNewDeviceNameHandler = (params, response) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet promptNewDeviceNameHandler called')
+      return
+    }
     this._stashResponse('keybase.1.provisionUi.PromptNewDeviceName', response)
     return Saga.put(
       ProvisionGen.createShowNewDeviceNamePage({
@@ -128,6 +152,11 @@ class ProvisioningManager {
   }
 
   submitDeviceName = (state: TypedState) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet submitDeviceName called')
+      return
+    }
+
     // local error, ignore
     if (state.provision.error.stringValue()) {
       return
@@ -148,6 +177,10 @@ class ProvisioningManager {
 
   // We now need to exchange a secret sentence. Either side can move the process forward
   displayAndPromptSecretHandler = (params, response) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet displayAndPromptSecretHandler called')
+      return
+    }
     this._stashResponse('keybase.1.provisionUi.DisplayAndPromptSecret', response)
     return Saga.put(
       ProvisionGen.createShowCodePage({
@@ -158,6 +191,10 @@ class ProvisioningManager {
   }
 
   submitTextCode = (state: TypedState) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet submitTextCode called')
+      return
+    }
     // local error, ignore
     if (state.provision.error.stringValue()) {
       return
@@ -178,11 +215,19 @@ class ProvisioningManager {
 
   // Trying to use gpg flow
   chooseGPGMethodHandler = (params, response) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet chooseGPGMethodHandler called')
+      return
+    }
     this._stashResponse('keybase.1.provisionUi.chooseGPGMethod', response)
     return Saga.put(ProvisionGen.createShowGPGPage())
   }
 
   submitGPGMethod = (state: TypedState, action: ProvisionGen.SubmitGPGMethodPayload) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet submitGPGMethod called')
+      return
+    }
     // local error, ignore
     if (state.provision.error.stringValue()) {
       return
@@ -201,6 +246,10 @@ class ProvisioningManager {
   }
 
   switchToGPGSignOKHandler = (params, response) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet switchToGPGSignOKHandler called')
+      return
+    }
     this._stashResponse('keybase.1.provisionUi.switchToGPGSignOK', response)
     return Saga.all([
       Saga.put(ProvisionGen.createSwitchToGPGSignOnly({importError: params.importError})),
@@ -209,6 +258,10 @@ class ProvisioningManager {
   }
 
   submitGPGSignOK = (state: TypedState, action: ProvisionGen.SubmitGPGSignOKPayload) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet submitGPGSignOK called')
+      return
+    }
     const response = this._getAndClearResponse('keybase.1.provisionUi.switchToGPGSignOK')
     if (!response || !response.result) {
       throw new Error('Tried to respond to gpg sign ok but missing callback')
@@ -219,6 +272,10 @@ class ProvisioningManager {
 
   // User has an uploaded key so we can use a passphrase OR they selected a paperkey
   getPassphraseHandler = (params, response) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet getPassphraseHandler called')
+      return
+    }
     this._stashResponse('keybase.1.secretUi.getPassphrase', response)
 
     let error = ''
@@ -242,6 +299,10 @@ class ProvisioningManager {
     state: TypedState,
     action: ProvisionGen.SubmitPassphrasePayload | ProvisionGen.SubmitPaperkeyPayload
   ) => {
+    if (this._done) {
+      logger.info('ProvisioningManager done, yet submitPassphraseOrPaperkey called')
+      return
+    }
     // local error, ignore
     if (state.provision.error.stringValue()) {
       return
@@ -360,14 +421,18 @@ const addNewDevice = (state: TypedState) =>
         params: undefined,
         waitingKey: Constants.waitingKey,
       })
+      ProvisioningManager.getSingleton().done('success')
       // Now refresh and nav back
       yield Saga.put(DevicesGen.createLoad())
       yield Saga.put(RouteTreeGen.createNavigateTo({path: [], parentPath: devicesRoot}))
     } catch (e) {
+      ProvisioningManager.getSingleton().done(e.message)
       // If we're canceling then ignore the error
       if (e.desc !== Constants.cancelDesc) {
         logger.error(`Provision -> Add device error: ${e.message}`)
-        yield Saga.put(ProvisionGen.createProvisionError({error: new HiddenString(niceError(e))}))
+        yield Saga.put(RouteTreeGen.createNavigateTo({path: [], parentPath: devicesRoot}))
+        // show black bar
+        throw e
       }
     }
   })

--- a/shared/provision/code-page/qr-scan/index.native.js
+++ b/shared/provision/code-page/qr-scan/index.native.js
@@ -9,20 +9,22 @@ import type {Props} from '.'
 
 const QRScan = (props: Props) => (
   <Box2 direction="vertical" style={styles.container}>
-    <RNCamera
-      key={props.mountKey}
-      type={RNCamera.Constants.Type.back}
-      autoFocus={RNCamera.Constants.AutoFocus.on}
-      captureAudio={false}
-      flashMode={RNCamera.Constants.FlashMode.off}
-      permissionDialogTitle={'Permission to use camera'}
-      permissionDialogMessage={'We need access to your camera to scan in the secret code'}
-      notAuthorizedView={<QRScanNotAuthorized onOpenSettings={props.onOpenSettings} />}
-      onBarCodeRead={({data}) => props.onSubmitTextCode(data)}
-      barCodeTypes={[RNCamera.Constants.BarCodeType.qr]}
-      style={styles.camera}
-    />
-    <QRScanLines canScan={true} />
+    {!props.waiting && (
+      <RNCamera
+        key={props.mountKey}
+        type={RNCamera.Constants.Type.back}
+        autoFocus={RNCamera.Constants.AutoFocus.on}
+        captureAudio={false}
+        flashMode={RNCamera.Constants.FlashMode.off}
+        permissionDialogTitle={'Permission to use camera'}
+        permissionDialogMessage={'We need access to your camera to scan in the secret code'}
+        notAuthorizedView={<QRScanNotAuthorized onOpenSettings={props.onOpenSettings} />}
+        onBarCodeRead={({data}) => props.onSubmitTextCode(data)}
+        barCodeTypes={[RNCamera.Constants.BarCodeType.qr]}
+        style={styles.camera}
+      />
+    )}
+    {!props.waiting && <QRScanLines canScan={true} />}
     {props.waiting && <ProgressIndicator style={styles.waiting} type="Large" white={true} />}
   </Box2>
 )


### PR DESCRIPTION
I was investigating some racy stuff w/ the provisioning manager. What i was able to repro is if you get an error (like you provision and your phone username isn't the computer username) it'll complain yet leave you on the same screen so if you scan again it'll give you a bad error. Instead we do a couple of things

- [x] more logging
- [x] add a _done state. If the provisioning singleton is done lets mark it as done so nothing will happen after error
- [x] while waiting for scan results we remove the qr scanner. this'll stop it from continuing to call the callback
@keybase/react-hackers 
