### PR TITLE
if we don't know what decoration this is, dont crash

### DIFF
--- a/shared/chat/inbox/row/small-team/bottom-line.js
+++ b/shared/chat/inbox/row/small-team/bottom-line.js
@@ -94,7 +94,7 @@ class BottomLine extends PureComponent<Props> {
           )
           break
         default:
-          snippetDecoration = this.props.snippetDecoration
+          snippetDecoration = <Text type="BodySmall">this.props.snippetDecoration</Text>
       }
       content = (
         <Box2 direction="horizontal" gap="xtiny" style={styles.contentBox}>


### PR DESCRIPTION
@keybase/react-hackers 

I changed the service not to send up an unknown decoration last night, but it is probably also a good play to take care of the actual crasher, which is this `default` case injecting raw text.