### PR TITLE
Build with production tags in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,7 @@ helpers.rootLinuxNode(env, {
                                         "KEYBASE_SERVER_URI=http://${kbwebNodePrivateIP}:3000",
                                         "KEYBASE_PUSH_SERVER_URI=fmprpc://${kbwebNodePrivateIP}:9911",
                                     ]) {
-                                        if (hasGoChanges || true) {
+                                        if (hasGoChanges) {
                                             dir("go/keybase") {
                                                 sh "go build --tags=production"
                                             }
@@ -248,7 +248,7 @@ helpers.rootLinuxNode(env, {
                                         //    }
                                         //},
                                         test_macos_go: {
-                                            if (hasGoChanges || true) {
+                                            if (hasGoChanges) {
                                                 dir("go/keybase") {
                                                     sh "go build --tags=production"
                                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,7 @@ helpers.rootLinuxNode(env, {
                                         "KEYBASE_SERVER_URI=http://${kbwebNodePrivateIP}:3000",
                                         "KEYBASE_PUSH_SERVER_URI=fmprpc://${kbwebNodePrivateIP}:9911",
                                     ]) {
-                                        if (hasGoChanges) {
+                                        if (hasGoChanges || true) {
                                             dir("go/keybase") {
                                                 sh "go build --tags=production"
                                             }
@@ -248,7 +248,7 @@ helpers.rootLinuxNode(env, {
                                         //    }
                                         //},
                                         test_macos_go: {
-                                            if (hasGoChanges) {
+                                            if (hasGoChanges || true) {
                                                 dir("go/keybase") {
                                                     sh "go build --tags=production"
                                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,6 +127,9 @@ helpers.rootLinuxNode(env, {
                                         "KEYBASE_PUSH_SERVER_URI=fmprpc://${kbwebNodePrivateIP}:9911",
                                     ]) {
                                         if (hasGoChanges) {
+                                            dir("go/keybase") {
+                                                sh "go build --tags=production"
+                                            }
                                             testGo("test_linux_go_")
                                         }
                                     }},
@@ -195,6 +198,9 @@ helpers.rootLinuxNode(env, {
                                             // other than Go tests on Windows,
                                             // add a `hasGoChanges` check here.
                                             dir("go/keybase") {
+                                                bat "go build --tags=production"
+                                            }
+                                            dir("go/keybase") {
                                                 bat "go build"
                                             }
                                             testGo("test_windows_go_")
@@ -243,6 +249,9 @@ helpers.rootLinuxNode(env, {
                                         //},
                                         test_macos_go: {
                                             if (hasGoChanges) {
+                                                dir("go/keybase") {
+                                                    sh "go build --tags=production"
+                                                }
                                                 testGo("test_macos_go_")
                                             }
                                         }


### PR DESCRIPTION
will help prevent accidentally skipping a build specific definition. 