### PR TITLE
Show a spinner when assets or payments are still loading in the account view

### DIFF
--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -281,10 +281,10 @@ const getDisplayCurrency = (state: TypedState, accountID?: Types.AccountID) =>
   state.wallets.currencyMap.get(accountID || getSelectedAccount(state), makeCurrency())
 
 const getPayments = (state: TypedState, accountID?: Types.AccountID) =>
-  state.wallets.paymentsMap.get(accountID || getSelectedAccount(state), I.List())
+  state.wallets.paymentsMap.get(accountID || getSelectedAccount(state))
 
 const getPendingPayments = (state: TypedState, accountID?: Types.AccountID) =>
-  state.wallets.pendingMap.get(accountID || getSelectedAccount(state), I.List())
+  state.wallets.pendingMap.get(accountID || getSelectedAccount(state))
 
 const getPayment = (state: TypedState, accountID: Types.AccountID, paymentID: RPCTypes.PaymentID) =>
   state.wallets.paymentsMap.get(accountID, I.List()).find(p => Types.paymentIDIsEqual(p.id, paymentID)) ||

--- a/shared/wallets/wallet/index.js
+++ b/shared/wallets/wallet/index.js
@@ -1,11 +1,11 @@
 // @flow
 import * as React from 'react'
+import * as Kb from '../../common-adapters'
+import * as Styles from '../../styles'
 import * as Types from '../../constants/types/wallets'
-import {Box2, Divider, SectionList, Text} from '../../common-adapters'
 import Header from './header/container'
 import Asset from '../asset/container'
 import Transaction from '../transaction/container'
-import {globalColors, globalMargins, styleSheetCreate} from '../../styles'
 
 type Props = {
   accountID: Types.AccountID,
@@ -14,19 +14,21 @@ type Props = {
 }
 
 const HistoryPlaceholder = () => (
-  <Box2 direction="horizontal" centerChildren={true} fullWidth={true} style={styles.historyPlaceholder}>
-    <Text type="BodySmall" style={styles.historyPlaceholderText}>
+  <Kb.Box2 direction="horizontal" centerChildren={true} fullWidth={true} style={styles.historyPlaceholder}>
+    <Kb.Text type="BodySmall" style={styles.historyPlaceholderText}>
       You don’t have any history with this account.
-    </Text>
-  </Box2>
+    </Kb.Text>
+  </Kb.Box2>
 )
 
 const Wallet = (props: Props) => {
   const renderItem = ({item, index, section}) => {
     const children = []
-    if (section.title === 'Your assets') {
+    if (item === 'notLoadedYet') {
+      children.push(<Kb.ProgressIndicator key="spinner" style={styles.spinner} type="Small" />)
+    } else if (section.title === 'Your assets') {
       children.push(<Asset accountID={props.accountID} index={item} key={`${props.accountID}:${item}`} />)
-    } else if (item === 'historyPlaceholder') {
+    } else if (item === 'noPayments') {
       children.push(<HistoryPlaceholder key="placeholder" />)
     } else if (section.title === 'History' || section.title === 'Pending') {
       children.push(
@@ -40,40 +42,45 @@ const Wallet = (props: Props) => {
     }
     if (index !== section.data.length - 1) {
       // don't put divider after last thing in section
-      children.push(<Divider key={`${props.accountID}:${item}:divider`} />)
+      children.push(<Kb.Divider key={`${props.accountID}:${item}:divider`} />)
     }
     // TODO
     return children
   }
 
   const renderSectionHeader = ({section}) => (
-    <Box2 direction="vertical" fullWidth={true} style={styles.assetHeader}>
-      <Text type="BodySmallSemibold">{section.title}</Text>
-    </Box2>
+    <Kb.Box2 direction="vertical" fullWidth={true} style={styles.assetHeader}>
+      <Kb.Text type="BodySmallSemibold">{section.title}</Kb.Text>
+    </Kb.Box2>
   )
 
   return (
-    <Box2 direction="vertical" style={{flexGrow: 1}} fullHeight={true} gap="small">
+    <Kb.Box2 direction="vertical" style={{flexGrow: 1}} fullHeight={true} gap="small">
       <Header navigateAppend={props.navigateAppend} />
-      <SectionList
+      <Kb.SectionList
         sections={props.sections}
         renderItem={renderItem}
         renderSectionHeader={renderSectionHeader}
       />
-    </Box2>
+    </Kb.Box2>
   )
 }
 
-const styles = styleSheetCreate({
+const styles = Styles.styleSheetCreate({
   assetHeader: {
-    backgroundColor: globalColors.blue5,
-    padding: globalMargins.xtiny,
+    backgroundColor: Styles.globalColors.blue5,
+    padding: Styles.globalMargins.xtiny,
   },
   historyPlaceholder: {
     marginTop: 36,
   },
   historyPlaceholderText: {
-    color: globalColors.black_40,
+    color: Styles.globalColors.black_40,
+  },
+  spinner: {
+    height: 46,
+    padding: Styles.globalMargins.tiny,
+    width: 46,
   },
 })
 

--- a/shared/wallets/wallet/index.stories.js
+++ b/shared/wallets/wallet/index.stories.js
@@ -25,7 +25,7 @@ const provider = Sb.createPropProviderWithCommon({
 const props = {
   accountID: stringToAccountID('fakeAccountID'),
   navigateAppend: Sb.action('navigateAppend'),
-  sections: [{title: 'Your assets', data: []}, {title: 'History', data: ['historyPlaceholder']}],
+  sections: [{title: 'Your assets', data: []}, {title: 'History', data: ['noPayments']}],
 }
 
 const load = () => {


### PR DESCRIPTION
@keybase/react-hackers 

This is part of the Stellar UX cleanup.  We weren't differentiating between "We haven't loaded assets or payments yet" and "We loaded the assets and payments and there were none".

This PR creates the distinction by allowing getPayments/getPendingPayments to return null instead of an empty list when the data hasn't been loaded yet.  The container creates a 'notLoadedYet' entry in the react list when it hits a null, and the display component puts up a spinner.