### PR TITLE
[KBFS-3331] Rows with uninteresting activity jumping to top of chat widget

### DIFF
--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -20,7 +20,7 @@ export type RemoteConvMeta = $Diff<
 // To cache the list
 const valuesCached = memoize((...vals) => vals.map(v => v))
 
-const metaMapToFirstValues = memoize(metaMap =>
+const metaMapToFirstValues = memoize((metaMap, _lastState) =>
   metaMap
     .filter((meta, id) => {
       if (Constants.isValidConversationIDKey(id)) {
@@ -58,7 +58,7 @@ const metaMapToFirstValues = memoize(metaMap =>
 let _lastState: TypedState
 export const conversationsToSend = (state: TypedState) => {
   _lastState = state
-  return valuesCached(...metaMapToFirstValues(state.chat2.metaMap))
+  return valuesCached(...metaMapToFirstValues(state.chat2.metaMap, _lastState))
 }
 
 export const serialize = (m: ChatTypes.ConversationMeta): RemoteConvMeta => {

--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -50,7 +50,7 @@ const metaMapToFirstValues = memoize((metaMap, _lastState) =>
         return false
       }
     })
-    .partialSort(maxShownConversations, (a, b) => b.timestamp - a.timestamp)
+    .partialSort(maxShownConversations * 10, (a, b) => b.timestamp - a.timestamp)
     .valueSeq()
     .toArray()
 )

--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -24,30 +24,31 @@ const metaMapToFirstValues = memoize((metaMap, _lastState) =>
   metaMap
     .filter((meta, id) => {
       if (Constants.isValidConversationIDKey(id)) {
-        if (meta.teamType === 'adhoc') {
-          // DM's
-          return !meta.isMuted
-        } else if (meta.teamType === 'big') {
-          // channels
-          if (!meta.notificationsGlobalIgnoreMentions) {
-            // @here and @mention not ignored
-            if (meta.notificationsDesktop === 'onAnyActivity') {
-              return true
-            } else if (meta.notificationsDesktop === 'onWhenAtMentioned') {
-              // check if user has been mentioned in the message
-              let snippet = meta.snippet.toLowerCase()
-              return (
-                (!!_lastState.config.username && snippet.indexOf(`@${_lastState.config.username}`) === 0) ||
-                snippet.indexOf('you') === 0
-              )
-            }
-            return false
-          }
-          return false
+        return false
+      }
+      if (meta.teamType === 'adhoc') {
+        // DM's
+        return !meta.isMuted
+      }
+      if (!meta.teamType === 'big') {
+        return false
+      }
+
+      // channels
+      if (!meta.notificationsGlobalIgnoreMentions) {
+        // @here and @mention not ignored
+        if (meta.notificationsDesktop === 'onAnyActivity') {
+          return true
+        } else if (meta.notificationsDesktop === 'onWhenAtMentioned') {
+          // check if user has been mentioned in the message
+          let snippet = meta.snippet.toLowerCase()
+          return (
+            (!!_lastState.config.username && snippet.indexOf(`@${_lastState.config.username}`) === 0) ||
+            snippet.indexOf('you') === 0
+          )
         }
         return false
       }
-      return false
     })
     .partialSort(maxShownConversations, (a, b) => b.timestamp - a.timestamp)
     .valueSeq()

--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -36,7 +36,10 @@ const metaMapToFirstValues = memoize(metaMap =>
             } else if (meta.notificationsDesktop === 'onWhenAtMentioned') {
               // check if user has been mentioned in the message
               let snippet = meta.snippet.toLowerCase()
-              return snippet.indexOf(`@${_username}`) === 0 || snippet.indexOf('you') === 0
+              return (
+                (!!_laststate.config.username && snippet.indexOf(`@${_laststate.config.username}`) === 0) ||
+                snippet.indexOf('you') === 0
+              )
             }
             return false
           }

--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -51,7 +51,7 @@ const metaMapToFirstValues = memoize((metaMap, _lastState) =>
         return false
       }
     })
-    .slice(maxShownConversations)
+    .slice(0, maxShownConversations)
     .valueSeq()
     .toArray()
 )

--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -37,7 +37,7 @@ const metaMapToFirstValues = memoize((metaMap, _lastState) =>
               // check if user has been mentioned in the message
               let snippet = meta.snippet.toLowerCase()
               return (
-                (!!_laststate.config.username && snippet.indexOf(`@${_laststate.config.username}`) === 0) ||
+                (!!_lastState.config.username && snippet.indexOf(`@${_lastState.config.username}`) === 0) ||
                 snippet.indexOf('you') === 0
               )
             }

--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -22,7 +22,6 @@ const valuesCached = memoize((...vals) => vals.map(v => v))
 
 const metaMapToFirstValues = memoize(metaMap =>
   metaMap
-    .partialSort(maxShownConversations, (a, b) => b.timestamp - a.timestamp)
     .filter((meta, id) => {
       if (Constants.isValidConversationIDKey(id)) {
         if (meta.teamType === 'adhoc') {
@@ -47,6 +46,7 @@ const metaMapToFirstValues = memoize(metaMap =>
       }
       return false
     })
+    .partialSort(maxShownConversations, (a, b) => b.timestamp - a.timestamp)
     .valueSeq()
     .toArray()
 )

--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -22,6 +22,7 @@ const valuesCached = memoize((...vals) => vals.map(v => v))
 
 const metaMapToFirstValues = memoize((metaMap, _lastState) =>
   metaMap
+    .partialSort(maxShownConversations * 10, (a, b) => b.timestamp - a.timestamp)
     .filter((meta, id) => {
       if (Constants.isValidConversationIDKey(id)) {
         return false
@@ -50,7 +51,7 @@ const metaMapToFirstValues = memoize((metaMap, _lastState) =>
         return false
       }
     })
-    .partialSort(maxShownConversations * 10, (a, b) => b.timestamp - a.timestamp)
+    .slice(maxShownConversations)
     .valueSeq()
     .toArray()
 )

--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -26,7 +26,7 @@ const metaMapToFirstValues = memoize((metaMap, _lastState) =>
       if (Constants.isValidConversationIDKey(id)) {
         if (meta.teamType === 'adhoc') {
           // DM's
-          return !meta.isMuted ? true : false
+          return !meta.isMuted
         } else if (meta.teamType === 'big') {
           // channels
           if (!meta.notificationsGlobalIgnoreMentions) {


### PR DESCRIPTION
#### Description of task:
The calculation of a row's position in the chat widget should be the max of:

   - when you last sent into that chat
   - when there was last activity in the chat you should've been notified of

for the second point, if you're in a big general channel, you don't want all activity, but if someone at-mentions you, odds are you'll have notifications on for that, so it should increase its score.

this means the things you want to get to will most likely be at the top - -chats with things you want to read and/or you just wrote in and want to get back to.



