### PR TITLE
Default initial wallet account name + require names

### DIFF
--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -65,6 +65,7 @@ const (
 	PromptDescriptorConfirmStellarImport
 	PromptDescriptorChatSetConvMinWriterRole
 	PromptDescriptorChangeLockdownMode
+	PromptDescriptorImportStellarAccountName
 )
 
 const (

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -868,6 +868,7 @@ type OwnAccountLocalArg struct {
 type ImportSecretKeyLocalArg struct {
 	SecretKey   SecretKey `codec:"secretKey" json:"secretKey"`
 	MakePrimary bool      `codec:"makePrimary" json:"makePrimary"`
+	Name        string    `codec:"name" json:"name"`
 }
 
 type ExportSecretKeyLocalArg struct {

--- a/go/stellar/bundle/main.go
+++ b/go/stellar/bundle/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stellar/go/keypair"
 )
 
-func NewInitialBundle() (res stellar1.Bundle, err error) {
+func NewInitialBundle(accountName string) (res stellar1.Bundle, err error) {
 	accountID, masterKey, err := randomStellarKeypair()
 	if err != nil {
 		return res, err
@@ -22,7 +22,7 @@ func NewInitialBundle() (res stellar1.Bundle, err error) {
 			Mode:      stellar1.AccountMode_USER,
 			IsPrimary: true,
 			Signers:   []stellar1.SecretKey{masterKey},
-			Name:      "",
+			Name:      accountName,
 		}},
 	}, nil
 }
@@ -44,6 +44,9 @@ func AddAccount(bundle *stellar1.Bundle, secretKey stellar1.SecretKey, name stri
 	secretKey, accountID, _, err := libkb.ParseStellarSecretKey(string(secretKey))
 	if err != nil {
 		return err
+	}
+	if name == "" {
+		return fmt.Errorf("Name required for new account")
 	}
 	if makePrimary {
 		for i := range bundle.Accounts {

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -208,6 +208,7 @@ func addWalletServerArg(serverArg libkb.JSONPayload, bundleEncB64 string, bundle
 	section["encrypted"] = bundleEncB64
 	section["visible"] = bundleVisB64
 	section["version"] = formatVersion
+	section["miniversion"] = 2
 	serverArg["stellar"] = section
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -31,9 +31,13 @@ const AccountNameMaxRunes = 24
 // Safe (but wasteful) to call even if the user has a bundle already.
 func CreateWallet(ctx context.Context, g *libkb.GlobalContext) (created bool, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.CreateWallet", func() error { return err })()
-	clearBundle, err := bundle.NewInitialBundle()
+	loggedInUsername := g.ActiveDevice.Username(libkb.NewMetaContext(ctx, g))
+	if !loggedInUsername.IsValid() {
+		return false, fmt.Errorf("could not get logged-in username")
+	}
+	clearBundle, err := bundle.NewInitialBundle(fmt.Sprintf("%v's account", loggedInUsername))
 	if err != nil {
-		return created, err
+		return false, err
 	}
 	meUV, err := g.GetMeUV(ctx)
 	if err != nil {
@@ -1014,10 +1018,13 @@ func reverse(s string) string {
 
 // ChangeAccountName changes the name of an account.
 // Make sure to keep this in sync with ValidateAccountNameLocal.
-// An empty name is always acceptable.
+// An empty name is not allowed.
 // Renaming an account to an already used name is blocked.
 // Maximum length of AccountNameMaxRunes runes.
 func ChangeAccountName(m libkb.MetaContext, accountID stellar1.AccountID, newName string) (err error) {
+	if newName == "" {
+		return fmt.Errorf("name required")
+	}
 	runes := utf8.RuneCountInString(newName)
 	if runes > AccountNameMaxRunes {
 		return fmt.Errorf("account name can be %v characters at the longest but was %v", AccountNameMaxRunes, runes)

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -500,7 +500,7 @@ func (s *Server) ValidateAccountNameLocal(ctx context.Context, arg stellar1.Vali
 	}
 	// Make sure to keep this validation in sync with ChangeAccountName.
 	if arg.Name == "" {
-		return nil
+		return fmt.Errorf("name required")
 	}
 	runes := utf8.RuneCountInString(arg.Name)
 	if runes > stellar.AccountNameMaxRunes {

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -223,7 +223,7 @@ func TestChangeWalletName(t *testing.T) {
 		}
 	}
 
-	chk("", "")
+	chk("", "name required")
 	chk("office lunch money", "")
 	chk("savings", "")
 	err = tcs[0].Srv.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -27,11 +27,11 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 
 	accountID := tcs[0].Backend.AddAccount()
 
-	argImport := stellar1.ImportSecretKeyLocalArg{
+	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   tcs[0].Backend.SecretKey(accountID),
 		MakePrimary: true,
-	}
-	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), argImport)
+		Name:        "qq",
+	})
 	require.NoError(t, err)
 
 	tcs[0].Backend.ImportAccountsForUser(tcs[0])
@@ -42,12 +42,12 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.Len(t, accts, 2)
 	require.Equal(t, accountID, accts[0].AccountID, accountID)
 	require.True(t, accts[0].IsDefault)
-	require.Equal(t, "", accts[0].Name) // TODO: once we can set the name on an account, check this
+	require.Equal(t, "qq", accts[0].Name)
 	require.Equal(t, "10,000.00 XLM", accts[0].BalanceDescription)
 	require.NotEmpty(t, accts[0].Seqno)
 
 	require.False(t, accts[1].IsDefault)
-	require.Equal(t, "", accts[1].Name)
+	require.Equal(t, firstAccountName(t, tcs[0]), accts[1].Name)
 	require.Equal(t, "0 XLM", accts[1].BalanceDescription)
 	require.NotEmpty(t, accts[1].Seqno)
 
@@ -55,6 +55,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	argDetails := stellar1.GetWalletAccountLocalArg{AccountID: accountID}
 	details, err := tcs[0].Srv.GetWalletAccountLocal(context.Background(), argDetails)
 	require.NoError(t, err)
+	require.Equal(t, "qq", accts[0].Name)
 	require.True(t, details.IsDefault)
 	require.Equal(t, "10,000.00 XLM", details.BalanceDescription)
 	require.NotEmpty(t, details.Seqno)
@@ -62,6 +63,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	argDetails.AccountID = accts[1].AccountID
 	details, err = tcs[0].Srv.GetWalletAccountLocal(context.Background(), argDetails)
 	require.NoError(t, err)
+	require.Equal(t, firstAccountName(t, tcs[0]), accts[1].Name)
 	require.False(t, details.IsDefault)
 	require.Equal(t, "0 XLM", details.BalanceDescription)
 	require.NotEmpty(t, details.Seqno)
@@ -76,11 +78,11 @@ func TestGetAccountAssetsLocalWithBalance(t *testing.T) {
 
 	accountID := tcs[0].Backend.AddAccount()
 
-	argImport := stellar1.ImportSecretKeyLocalArg{
+	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   tcs[0].Backend.SecretKey(accountID),
 		MakePrimary: true,
-	}
-	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), argImport)
+		Name:        "qq",
+	})
 	require.NoError(t, err)
 
 	tcs[0].Backend.ImportAccountsForUser(tcs[0])
@@ -209,7 +211,7 @@ func TestChangeWalletName(t *testing.T) {
 	accs, err := tcs[0].Srv.WalletGetAccountsCLILocal(context.Background())
 	require.NoError(t, err)
 	require.Len(t, accs, 1)
-	require.Equal(t, accs[0].Name, "")
+	require.Equal(t, accs[0].Name, firstAccountName(t, tcs[0]))
 
 	chk := func(name string, expected string) {
 		err = tcs[0].Srv.ValidateAccountNameLocal(context.Background(), stellar1.ValidateAccountNameLocalArg{Name: name})
@@ -294,11 +296,11 @@ func TestSetAccountAsDefault(t *testing.T) {
 	}
 
 	for _, v := range additionalAccs {
-		arg := stellar1.ImportSecretKeyLocalArg{
+		err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 			SecretKey:   tcs[0].Backend.SecretKey(v),
 			MakePrimary: false,
-		}
-		err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), arg)
+			Name:        "qq",
+		})
 		require.NoError(t, err)
 	}
 
@@ -360,7 +362,7 @@ func testCreateOrLinkNewAccount(t *testing.T, create bool) {
 
 	require.Len(t, accts, 2)
 	require.True(t, accts[0].IsDefault)
-	require.Equal(t, "", accts[0].Name)
+	require.Equal(t, firstAccountName(t, tcs[0]), accts[0].Name)
 	require.Equal(t, "0 XLM", accts[0].BalanceDescription)
 	require.False(t, accts[1].IsDefault)
 	require.Equal(t, accID, accts[1].AccountID)
@@ -405,6 +407,7 @@ func TestDeleteWallet(t *testing.T) {
 	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   tcs[0].Backend.SecretKey(accID2),
 		MakePrimary: true,
+		Name:        "qq",
 	})
 	require.NoError(t, err)
 
@@ -604,6 +607,7 @@ func TestGetPaymentsLocal(t *testing.T) {
 	err = srvSender.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   rm.SecretKey(accountIDSender),
 		MakePrimary: true,
+		Name:        "qq",
 	})
 	require.NoError(t, err)
 
@@ -616,12 +620,14 @@ func TestGetPaymentsLocal(t *testing.T) {
 	err = srvRecip.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   rm.SecretKey(accountIDRecip),
 		MakePrimary: true,
+		Name:        "uu",
 	})
 	require.NoError(t, err)
 
 	err = srvRecip.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   rm.SecretKey(accountIDRecip2),
 		MakePrimary: false,
+		Name:        "vv",
 	})
 	require.NoError(t, err)
 
@@ -705,7 +711,7 @@ func TestGetPaymentsLocal(t *testing.T) {
 		require.Equal(t, accountIDRecip, *p.ToAccountID)
 		var toAccountName string
 		if !sender {
-			toAccountName = accountIDRecip.String()
+			toAccountName = "uu"
 		}
 		require.Equal(t, toAccountName, p.ToAccountName, "ToAccountName")
 		require.Equal(t, tcs[1].Fu.Username, p.ToUsername)
@@ -807,7 +813,7 @@ func TestGetPaymentsLocal(t *testing.T) {
 		require.Equal(t, accountIDRecip, *p.ToAccountID)
 		var toAccountName string
 		if !sender {
-			toAccountName = accountIDRecip.String()
+			toAccountName = "uu"
 		}
 		require.Equal(t, toAccountName, p.ToAccountName)
 		require.Equal(t, tcs[1].Fu.Username, p.ToUsername)
@@ -897,7 +903,7 @@ func TestGetPaymentsLocal(t *testing.T) {
 	require.Equal(t, "", p.FromAccountName)
 	require.Equal(t, stellar1.ParticipantType_STELLAR, p.ToType)
 	require.Equal(t, accountIDRecip2, *p.ToAccountID)
-	require.Equal(t, accountIDRecip2.String(), p.ToAccountName)
+	require.Equal(t, "vv", p.ToAccountName)
 	require.Equal(t, "", p.ToUsername)
 	require.Equal(t, "", p.ToAssertion)
 	require.NotEmpty(t, p.NoteErr) // can't send encrypted note to stellar address
@@ -914,6 +920,7 @@ func TestSendToSelf(t *testing.T) {
 	err := tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   rm.SecretKey(accountID1),
 		MakePrimary: true,
+		Name:        "qq",
 	})
 	require.NoError(t, err)
 
@@ -925,6 +932,7 @@ func TestSendToSelf(t *testing.T) {
 
 	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey: rm.SecretKey(accountID2),
+		Name:      "uu",
 	})
 	require.NoError(t, err)
 
@@ -1701,4 +1709,10 @@ func (c *chatListener) ChatPaymentInfo(uid keybase1.UID, convID chat1.Conversati
 
 func (c *chatListener) ChatRequestInfo(uid keybase1.UID, convID chat1.ConversationID, msgID chat1.MessageID, info chat1.UIRequestInfo) {
 	c.requestInfos <- chat1.ChatRequestInfoArg{Uid: uid, ConvID: convID, MsgID: msgID, Info: info}
+}
+
+func firstAccountName(t testing.TB, tc *TestContext) string {
+	loggedInUsername := tc.G.ActiveDevice.Username(libkb.NewMetaContextForTest(tc.TestContext))
+	require.True(t, loggedInUsername.IsValid())
+	return fmt.Sprintf("%v's account", loggedInUsername)
 }

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -112,7 +112,7 @@ func (s *Server) ImportSecretKeyLocal(ctx context.Context, arg stellar1.ImportSe
 		return err
 	}
 
-	return stellar.ImportSecretKey(ctx, s.G(), arg.SecretKey, arg.MakePrimary, "")
+	return stellar.ImportSecretKey(ctx, s.G(), arg.SecretKey, arg.MakePrimary, arg.Name)
 }
 
 func (s *Server) ExportSecretKeyLocal(ctx context.Context, accountID stellar1.AccountID) (res stellar1.SecretKey, err error) {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -72,7 +72,7 @@ func TestCreateWallet(t *testing.T) {
 	require.Equal(t, stellar1.AccountMode_USER, bundle.Accounts[0].Mode)
 	require.True(t, bundle.Accounts[0].IsPrimary)
 	require.Len(t, bundle.Accounts[0].Signers, 1)
-	require.Equal(t, "", bundle.Accounts[0].Name)
+	require.Equal(t, firstAccountName(t, tcs[0]), bundle.Accounts[0].Name)
 
 	t.Logf("Lookup the user by public address as another user")
 	a1 := bundle.Accounts[0].AccountID
@@ -100,6 +100,7 @@ func TestCreateWallet(t *testing.T) {
 	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   s2,
 		MakePrimary: true,
+		Name:        "uu",
 	})
 	require.NoError(t, err)
 
@@ -187,6 +188,7 @@ func TestImportExport(t *testing.T) {
 	argS1 := stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   s1,
 		MakePrimary: false,
+		Name:        "qq",
 	}
 	err = srv.ImportSecretKeyLocal(context.Background(), argS1)
 	require.NoError(t, err)
@@ -236,6 +238,7 @@ func TestImportExport(t *testing.T) {
 	argS2 := stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   s2,
 		MakePrimary: true,
+		Name:        "uu",
 	}
 	err = srv.ImportSecretKeyLocal(context.Background(), argS2)
 	require.NoError(t, err)
@@ -310,11 +313,11 @@ func TestSendLocalStellarAddress(t *testing.T) {
 	accountIDSender := rm.AddAccount()
 	accountIDRecip := rm.AddAccount()
 
-	argImport := stellar1.ImportSecretKeyLocalArg{
+	err = srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   rm.SecretKey(accountIDSender),
 		MakePrimary: true,
-	}
-	err = srv.ImportSecretKeyLocal(context.Background(), argImport)
+		Name:        "uu",
+	})
 	require.NoError(t, err)
 
 	arg := stellar1.SendCLILocalArg{
@@ -360,6 +363,7 @@ func TestSendLocalKeybase(t *testing.T) {
 	argImport := stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   rm.SecretKey(accountIDSender),
 		MakePrimary: true,
+		Name:        "uu",
 	}
 	err = srvSender.ImportSecretKeyLocal(context.Background(), argImport)
 	require.NoError(t, err)
@@ -412,6 +416,7 @@ func TestRecentPaymentsLocal(t *testing.T) {
 	argImport := stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   rm.SecretKey(accountIDSender),
 		MakePrimary: true,
+		Name:        "uu",
 	}
 	err = srvSender.ImportSecretKeyLocal(context.Background(), argImport)
 	require.NoError(t, err)
@@ -679,6 +684,7 @@ func TestDefaultCurrency(t *testing.T) {
 	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
 		SecretKey:   s1,
 		MakePrimary: false,
+		Name:        "uu",
 	})
 	require.NoError(t, err)
 

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -414,7 +414,7 @@ protocol local {
   // Whether this account is one of this user's.
   boolean ownAccountLocal(AccountID accountID);
 
-  void importSecretKeyLocal(SecretKey secretKey, boolean makePrimary);
+  void importSecretKeyLocal(SecretKey secretKey, boolean makePrimary, string name);
 
   // prompts for passphrase
   SecretKey exportSecretKeyLocal(AccountID accountID);

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -1357,6 +1357,10 @@
         {
           "name": "makePrimary",
           "type": "boolean"
+        },
+        {
+          "name": "name",
+          "type": "string"
         }
       ],
       "response": null

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -327,8 +327,7 @@ const getAccount = (state: TypedState, accountID?: Types.AccountID) =>
   state.wallets.accountMap.get(accountID || getSelectedAccount(state), makeAccount())
 
 const getAccountName = (account: Types.Account) =>
-  account.name ||
-  (account.accountID !== Types.noAccountID ? Types.accountIDToString(account.accountID) : null)
+  account.name || (account.accountID !== Types.noAccountID ? 'unnamed account' : null)
 
 const getDefaultAccountID = (state: TypedState) => {
   const defaultAccount = state.wallets.accountMap.find(a => a.isDefault)

--- a/shared/wallets/wallet-list/wallet-row/container.js
+++ b/shared/wallets/wallet-list/wallet-row/container.js
@@ -7,7 +7,7 @@ import {type AccountID} from '../../../constants/types/wallets'
 
 const mapStateToProps = (state: TypedState, ownProps: {accountID: AccountID}) => {
   const account = getAccount(state, ownProps.accountID)
-  const name = account.name || ownProps.accountID
+  const name = account.name
   const me = state.config.username || ''
   const keybaseUser = account.isDefault ? me : ''
   return {


### PR DESCRIPTION
From this point on clients will not create accounts without names. The first account will be named "patrick's account" and future accounts imported or generated will need to be named by the user.

For example if bob signs up there will be "bob's account" and then if bob imports another account and names it "funds" and makes it primary there will be ["funds", "bob's account"].

Users with existing wallets will have an unsupported experience with blank names. Until we rename our accounts.

Together with https://github.com/keybase/keybase/pull/2893