### PR TITLE
new kex2 secret type, as recommended by NCC Audit

### DIFF
--- a/go/engine/device_add.go
+++ b/go/engine/device_add.go
@@ -112,9 +112,9 @@ func (e *DeviceAdd) Run(m libkb.MetaContext) (err error) {
 	uid := m.CurrentUID()
 
 	// make a new secret; continue to generate legacy Kex2 secrets for now.
-	kex2SecretTyp := libkb.Kex2SecretTypeLegacyDesktop
+	kex2SecretTyp := libkb.Kex2SecretTypeV1Desktop
 	if provisioneeType == keybase1.DeviceType_MOBILE || m.G().GetAppType() == libkb.DeviceTypeMobile {
-		kex2SecretTyp = libkb.Kex2SecretTypeLegacyMobile
+		kex2SecretTyp = libkb.Kex2SecretTypeV1Mobile
 	}
 	m.CDebugf("provisionee device type: %v; uid: %s; secret type: %d", provisioneeType, uid, kex2SecretTyp)
 	secret, err := libkb.NewKex2SecretFromTypeAndUID(kex2SecretTyp, uid)

--- a/go/engine/device_add_test.go
+++ b/go/engine/device_add_test.go
@@ -93,11 +93,11 @@ func testDeviceAdd(t *testing.T, upgradePerUserKey bool) {
 }
 
 func TestDeviceAddPhraseLegacyDesktop(t *testing.T) {
-	testDeviceAddPhrase(t, libkb.Kex2SecretTypeLegacyDesktop)
+	testDeviceAddPhrase(t, libkb.Kex2SecretTypeV1Desktop)
 }
 
 func TestDeviceAddPhraseLegacyMobile(t *testing.T) {
-	testDeviceAddPhrase(t, libkb.Kex2SecretTypeLegacyMobile)
+	testDeviceAddPhrase(t, libkb.Kex2SecretTypeV1Mobile)
 }
 
 func TestDeviceAddPhraseV2(t *testing.T) {

--- a/go/engine/device_add_test.go
+++ b/go/engine/device_add_test.go
@@ -92,7 +92,20 @@ func testDeviceAdd(t *testing.T, upgradePerUserKey bool) {
 	wg.Wait()
 }
 
-func TestDeviceAddPhrase(t *testing.T) {
+func TestDeviceAddPhraseLegacyDesktop(t *testing.T) {
+	testDeviceAddPhrase(t, libkb.Kex2SecretTypeLegacyDesktop)
+}
+
+func TestDeviceAddPhraseLegacyMobile(t *testing.T) {
+	testDeviceAddPhrase(t, libkb.Kex2SecretTypeLegacyMobile)
+}
+
+func TestDeviceAddPhraseV2(t *testing.T) {
+	testDeviceAddPhrase(t, libkb.Kex2SecretTypeV2)
+}
+
+func testDeviceAddPhrase(t *testing.T, typ libkb.Kex2SecretType) {
+
 	// device X (provisioner) context:
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
@@ -104,7 +117,7 @@ func TestDeviceAddPhrase(t *testing.T) {
 	// provisioner needs to be logged in
 	userX := CreateAndSignupFakeUser(tcX, "login")
 
-	secretY, err := libkb.NewKex2Secret(false)
+	secretY, err := libkb.NewKex2SecretFromTypeAndUID(typ, userX.UID())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -169,9 +169,9 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 	uid := m.CurrentUID()
 
 	// Continue to generate legacy Kex2 secret types
-	kex2SecretTyp := libkb.Kex2SecretTypeLegacyDesktop
+	kex2SecretTyp := libkb.Kex2SecretTypeV1Desktop
 	if e.arg.DeviceType == libkb.DeviceTypeMobile || provisionerType == keybase1.DeviceType_MOBILE {
-		kex2SecretTyp = libkb.Kex2SecretTypeLegacyMobile
+		kex2SecretTyp = libkb.Kex2SecretTypeV1Mobile
 	}
 	m.CDebugf("Generating Kex2 secret for uid=%s, typ=%d", uid, kex2SecretTyp)
 	secret, err := libkb.NewKex2SecretFromTypeAndUID(kex2SecretTyp, uid)

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -166,8 +166,15 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 	m.CDebugf("deviceWithType: got device name: %q", name)
 
 	// make a new secret:
-	secret, err := libkb.NewKex2Secret(e.arg.DeviceType == libkb.DeviceTypeMobile ||
-		provisionerType == keybase1.DeviceType_MOBILE)
+	uid := m.CurrentUID()
+
+	// Continue to generate legacy Kex2 secret types
+	kex2SecretTyp := libkb.Kex2SecretTypeLegacyDesktop
+	if e.arg.DeviceType == libkb.DeviceTypeMobile || provisionerType == keybase1.DeviceType_MOBILE {
+		kex2SecretTyp = libkb.Kex2SecretTypeLegacyMobile
+	}
+	m.CDebugf("Generating Kex2 secret for uid=%s, typ=%d", uid, kex2SecretTyp)
+	secret, err := libkb.NewKex2SecretFromTypeAndUID(kex2SecretTyp, uid)
 	if err != nil {
 		return err
 	}
@@ -214,7 +221,7 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 					continue
 				}
 				m.CDebugf("received secret phrase, adding to provisionee")
-				ks, err := libkb.NewKex2SecretFromPhrase(receivedSecret.Phrase)
+				ks, err := libkb.NewKex2SecretFromUIDAndPhrase(uid, receivedSecret.Phrase)
 				if err != nil {
 					m.CWarningf("DisplayAndPromptSecret error: %s", err)
 				} else {

--- a/go/libkb/checkers.go
+++ b/go/libkb/checkers.go
@@ -72,7 +72,7 @@ var CheckDeviceName = Checker{
 func MakeCheckKex2SecretPhrase(g *GlobalContext) Checker {
 	return Checker{
 		F: func(s string) bool {
-			if err := validPhrase(s, Kex2PhraseEntropy); err != nil {
+			if err := validPhrase(s, []int{Kex2PhraseEntropy, Kex2PhraseEntropy2}); err != nil {
 				g.Log.Debug("invalid kex2 phrase: %s", err)
 				return false
 			}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -539,6 +539,7 @@ const (
 
 const (
 	Kex2PhraseEntropy  = 88
+	Kex2PhraseEntropy2 = 99 // we've upped the entropy to 99 bits after the 2018 NCC Audit
 	Kex2ScryptCost     = 1 << 17
 	Kex2ScryptLiteCost = 1 << 10
 	Kex2ScryptR        = 8

--- a/go/libkb/kex2_secret.go
+++ b/go/libkb/kex2_secret.go
@@ -4,10 +4,12 @@
 package libkb
 
 import (
-	"strings"
-
+	"errors"
+	"fmt"
 	"github.com/keybase/client/go/kex2"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/crypto/scrypt"
+	"strings"
 )
 
 const kexPhraseVersion = "four"
@@ -15,10 +17,26 @@ const kexPhraseVersion = "four"
 type Kex2Secret struct {
 	phrase string
 	secret kex2.Secret
+	typ    Kex2SecretType
 }
 
-func NewKex2Secret(mobile bool) (*Kex2Secret, error) {
-	words, err := SecWordList(Kex2PhraseEntropy)
+type Kex2SecretType int
+
+const (
+	Kex2SecretTypeNone          Kex2SecretType = 0
+	Kex2SecretTypeLegacyDesktop Kex2SecretType = 1
+	Kex2SecretTypeLegacyMobile  Kex2SecretType = 2
+	Kex2SecretTypeV2            Kex2SecretType = 3
+)
+
+func NewKex2SecretFromTypeAndUID(typ Kex2SecretType, uid keybase1.UID) (*Kex2Secret, error) {
+
+	entropy := Kex2PhraseEntropy
+	if typ == Kex2SecretTypeV2 {
+		entropy = Kex2PhraseEntropy2
+	}
+
+	words, err := SecWordList(entropy)
 	if err != nil {
 		return nil, err
 	}
@@ -28,28 +46,58 @@ func NewKex2Secret(mobile bool) (*Kex2Secret, error) {
 	// communicate that to the two devices involved in kex without breaking the existing protocol,
 	// we have added an extra word that is not in the dictionary. Up to date clients can see this
 	// word and use the lighter version of scrypt.
-	if mobile {
+	if typ == Kex2SecretTypeLegacyMobile {
 		phrase += " " + kexPhraseVersion
 	}
-	return NewKex2SecretFromPhrase(phrase)
+	return newKex2SecretFromTypeUIDAndPhrase(typ, uid, phrase)
 }
 
-func NewKex2SecretFromPhrase(phrase string) (*Kex2Secret, error) {
+func NewKex2SecretFromUIDAndPhrase(uid keybase1.UID, phrase string) (*Kex2Secret, error) {
 
-	scryptCost := Kex2ScryptCost
-	// Detect if the phrase contains the magic word that indicates that we are provisioning a mobile
-	// device. If so, then we use the lighter cost version of scrypt.
-	words := strings.Split(phrase, " ")
-	if len(words) > 0 && words[len(words)-1] == kexPhraseVersion {
-		scryptCost = Kex2ScryptLiteCost
-	}
-
-	key, err := scrypt.Key([]byte(phrase), nil, scryptCost, Kex2ScryptR, Kex2ScryptP, Kex2ScryptKeylen)
+	typ, err := kex2TypeFromPhrase(phrase)
 	if err != nil {
 		return nil, err
 	}
 
-	res := &Kex2Secret{phrase: phrase}
+	return newKex2SecretFromTypeUIDAndPhrase(typ, uid, phrase)
+}
+
+func kex2TypeFromPhrase(phrase string) (typ Kex2SecretType, err error) {
+
+	words := strings.Split(phrase, " ")
+	if len(words) == 8 {
+		return Kex2SecretTypeLegacyDesktop, nil
+	}
+	if len(words) != 9 {
+		return Kex2SecretTypeNone, errors.New("wrong number of words in passphrase; wanted 8 or 9")
+	}
+	if words[len(words)-1] == kexPhraseVersion {
+		return Kex2SecretTypeLegacyMobile, nil
+	}
+	return Kex2SecretTypeV2, nil
+}
+
+func newKex2SecretFromTypeUIDAndPhrase(typ Kex2SecretType, uid keybase1.UID, phrase string) (*Kex2Secret, error) {
+
+	var cost int
+	var salt []byte
+	switch typ {
+	case Kex2SecretTypeLegacyMobile:
+		cost = Kex2ScryptLiteCost
+	case Kex2SecretTypeLegacyDesktop:
+		cost = Kex2ScryptCost
+	case Kex2SecretTypeV2:
+		cost = Kex2ScryptLiteCost
+		salt = uid.ToBytes()
+	default:
+		return nil, errors.New("unknown kex2 secret type")
+	}
+
+	key, err := scrypt.Key([]byte(phrase), salt, cost, Kex2ScryptR, Kex2ScryptP, Kex2ScryptKeylen)
+	if err != nil {
+		return nil, err
+	}
+	res := &Kex2Secret{phrase: phrase, typ: typ}
 	copy(res.secret[:], key)
 	return res, nil
 }

--- a/go/libkb/kex2_secret.go
+++ b/go/libkb/kex2_secret.go
@@ -5,7 +5,6 @@ package libkb
 
 import (
 	"errors"
-	"fmt"
 	"github.com/keybase/client/go/kex2"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/crypto/scrypt"

--- a/go/libkb/kex2_secret.go
+++ b/go/libkb/kex2_secret.go
@@ -22,10 +22,10 @@ type Kex2Secret struct {
 type Kex2SecretType int
 
 const (
-	Kex2SecretTypeNone          Kex2SecretType = 0
-	Kex2SecretTypeLegacyDesktop Kex2SecretType = 1
-	Kex2SecretTypeLegacyMobile  Kex2SecretType = 2
-	Kex2SecretTypeV2            Kex2SecretType = 3
+	Kex2SecretTypeNone      Kex2SecretType = 0
+	Kex2SecretTypeV1Desktop Kex2SecretType = 1
+	Kex2SecretTypeV1Mobile  Kex2SecretType = 2
+	Kex2SecretTypeV2        Kex2SecretType = 3
 )
 
 func NewKex2SecretFromTypeAndUID(typ Kex2SecretType, uid keybase1.UID) (*Kex2Secret, error) {
@@ -45,7 +45,7 @@ func NewKex2SecretFromTypeAndUID(typ Kex2SecretType, uid keybase1.UID) (*Kex2Sec
 	// communicate that to the two devices involved in kex without breaking the existing protocol,
 	// we have added an extra word that is not in the dictionary. Up to date clients can see this
 	// word and use the lighter version of scrypt.
-	if typ == Kex2SecretTypeLegacyMobile {
+	if typ == Kex2SecretTypeV1Mobile {
 		phrase += " " + kexPhraseVersion
 	}
 	return newKex2SecretFromTypeUIDAndPhrase(typ, uid, phrase)
@@ -65,13 +65,13 @@ func kex2TypeFromPhrase(phrase string) (typ Kex2SecretType, err error) {
 
 	words := strings.Split(phrase, " ")
 	if len(words) == 8 {
-		return Kex2SecretTypeLegacyDesktop, nil
+		return Kex2SecretTypeV1Desktop, nil
 	}
 	if len(words) != 9 {
 		return Kex2SecretTypeNone, errors.New("wrong number of words in passphrase; wanted 8 or 9")
 	}
 	if words[len(words)-1] == kexPhraseVersion {
-		return Kex2SecretTypeLegacyMobile, nil
+		return Kex2SecretTypeV1Mobile, nil
 	}
 	return Kex2SecretTypeV2, nil
 }
@@ -81,9 +81,9 @@ func newKex2SecretFromTypeUIDAndPhrase(typ Kex2SecretType, uid keybase1.UID, phr
 	var cost int
 	var salt []byte
 	switch typ {
-	case Kex2SecretTypeLegacyMobile:
+	case Kex2SecretTypeV1Mobile:
 		cost = Kex2ScryptLiteCost
-	case Kex2SecretTypeLegacyDesktop:
+	case Kex2SecretTypeV1Desktop:
 		cost = Kex2ScryptCost
 	case Kex2SecretTypeV2:
 		cost = Kex2ScryptLiteCost

--- a/go/libkb/secwords.go
+++ b/go/libkb/secwords.go
@@ -35,16 +35,21 @@ func secWordListN(n int) ([]string, error) {
 	return res, nil
 }
 
-func validPhrase(p string, entropy int) error {
-	numWords := secWordCount(entropy)
+func validPhrase(p string, entropies []int) error {
+
+	lens := make(map[int]bool)
+	for _, e := range entropies {
+		lens[secWordCount(e)] = true
+	}
+
 	words := strings.Split(p, " ")
 
 	if words[len(words)-1] == kexPhraseVersion {
 		words = words[:len(words)-1]
 	}
 
-	if len(words) != numWords {
-		return fmt.Errorf("phrase had %d words, expected %d", len(words), numWords)
+	if !lens[len(words)] {
+		return fmt.Errorf("phrase had %d words, expected %v", len(words), entropies)
 	}
 	for _, w := range words {
 		if !validWord(w) {


### PR DESCRIPTION
- 9 words, not 8
- use 2^10 scrypt cost always (on mobile or desktop)
- use UID as salt
- make a test and get it to work
- we'll still generate legacy phrases for a few releases, and then cut over