### PR TITLE
improve new folder naming hints when user creates multiple at same time

### DIFF
--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -173,9 +173,9 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
 
       const existingNewFolderNames = new Set(
         state.edits
-          .valueSeq()
           .filter(edit => edit.parentPath === parentPath)
           .map(edit => edit.name)
+          .toSet()
       )
 
       let newFolderName = 'New Folder'

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -170,8 +170,20 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
         console.warn(`bad parentPath: ${parentPathItem.type}`)
         return state
       }
+
+      const existingNewFolderNames = new Set(
+        state.edits
+          .valueSeq()
+          .filter(edit => edit.parentPath === parentPath)
+          .map(edit => edit.name)
+      )
+
       let newFolderName = 'New Folder'
-      for (let i = 2; parentPathItem.children.has(newFolderName); ++i) {
+      for (
+        let i = 2;
+        parentPathItem.children.has(newFolderName) || existingNewFolderNames.has(newFolderName);
+        ++i
+      ) {
         newFolderName = `New Folder ${i}`
       }
 


### PR DESCRIPTION
so that user gets following as default hint:

New Folder
New Folder 1
New Folder 2

instead of:

New Folder
New Folder
New Folder