### PR TITLE
fix upload banner height

### DIFF
--- a/shared/fs/footer/upload.desktop.js
+++ b/shared/fs/footer/upload.desktop.js
@@ -85,6 +85,7 @@ const stylesBox = {
   alignItems: 'center',
   justifyContent: 'center',
   maxHeight: height,
+  height,
 }
 
 export default Upload


### PR DESCRIPTION
Otherwise, it's entirely constrained by the content height unless it's hitting the `maxHeight`, making the upload banner very short and without margin.