### PR TITLE
don't make upload banner show up for folder creation

### DIFF
--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -188,6 +188,14 @@ function* folderList(
       ...entries.map(direntToPathAndPathItem),
     ]
     yield Saga.put(FsGen.createFolderListLoaded({pathItems: I.Map(pathItems), path: rootPath}))
+    if (action.type === FsGen.editSuccess) {
+      // Note that we discard the Edit metadat here rather than immediately
+      // after an FsGen.editSuccess event, so that if we hear about journal
+      // uploading the new folder before we hear from the folder list result,
+      // fs/footer/upload-container.js can determine this is a newly created
+      // folder instead of a file upload based on state.fs.edits.
+      yield Saga.put(FsGen.createDiscardEdit({editID: action.payload.editID}))
+    }
   } catch (error) {
     yield Saga.put(makeRetriableErrorHandler(action)(error))
   }

--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -189,7 +189,7 @@ function* folderList(
     ]
     yield Saga.put(FsGen.createFolderListLoaded({pathItems: I.Map(pathItems), path: rootPath}))
     if (action.type === FsGen.editSuccess) {
-      // Note that we discard the Edit metadat here rather than immediately
+      // Note that we discard the Edit metadata here rather than immediately
       // after an FsGen.editSuccess event, so that if we hear about journal
       // uploading the new folder before we hear from the folder list result,
       // fs/footer/upload-container.js can determine this is a newly created

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -194,7 +194,6 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
         ['edits', action.payload.editID],
         editItem => editItem && editItem.set('name', action.payload.name)
       )
-    case FsGen.editSuccess:
     case FsGen.discardEdit:
       // $FlowFixMe
       return state.removeIn(['edits', action.payload.editID])
@@ -252,6 +251,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     case FsGen.openPathInSystemFileManager:
     case FsGen.openLocalPathInSystemFileManager:
     case FsGen.commitEdit:
+    case FsGen.editSuccess:
     case FsGen.letResetUserBackIn:
     case FsGen.openAndUpload:
     case FsGen.pickAndUpload:


### PR DESCRIPTION
@brayoh 's work [here](https://github.com/keybase/client/pull/13619) for KBFS-3123 mostly took care of KBFS-3122 as well. There's just this race condition where when we hear from journal after a new folder is created, and before we get the result of the `folderList` RPC call triggered by `editSuccess`, we don't know yet from `pathItems` that it's a folder. Without this commit we might show user the upload banner since the type is `unknown`. This PR makes the upload container look at `state.fs.edits` as well to eliminate this race.