### PR TITLE
Fix service filter in search

### DIFF
--- a/shared/chat/conversation/header-area/search.js
+++ b/shared/chat/conversation/header-area/search.js
@@ -45,5 +45,6 @@ export default compose(
     autoFocus: true,
     searchKey: 'chatSearch',
     placeholder: 'Search someone',
+    showServiceFilter: true,
   })
 )(UserInput)

--- a/shared/profile/search/index.desktop.js
+++ b/shared/profile/search/index.desktop.js
@@ -18,6 +18,7 @@ const Search = (props: Props) => (
           onExitSearch={props.onClose}
           autoFocus={true}
           placeholder={placeholder}
+          showServiceFilter={true}
         />
       </Box>
       <Box style={{...styleSearchRow, ...desktopStyles.scrollable, justifyContent: 'center'}}>

--- a/shared/profile/search/index.native.js
+++ b/shared/profile/search/index.native.js
@@ -14,6 +14,7 @@ const Search = (props: Props) => (
       onExitSearch={props.onClose}
       autoFocus={true}
       placeholder={placeholder}
+      showServiceFilter={true}
     />
     <ResultsList searchKey={searchKey} onClick={props.onClick} disableListBuilding={true} />
   </StandardScreen>

--- a/shared/search/user-input/container.js
+++ b/shared/search/user-input/container.js
@@ -30,7 +30,7 @@ export type OwnProps = {|
   onSelectUser?: (id: string) => void,
   hideAddButton?: boolean,
   disableListBuilding?: boolean,
-  showServiceFilter?: boolean,
+  showServiceFilter: boolean,
   style?: StylesCrossPlatform,
   // Defaults to true. Desktop only, as clearSearch isn't used on mobile.
   // Note that the way that user input is super wonky with all these HOCs. If we ever refactor, we probably won't need this prop.

--- a/shared/search/user-input/index.stories.js
+++ b/shared/search/user-input/index.stories.js
@@ -16,6 +16,7 @@ const defaultOwnProps: OwnProps = {
   onExitSearch: Sb.action('onExitSearch'),
   onSelectUser: Sb.action('onSelectUser'),
   onFocus: Sb.action('onFocus'),
+  showServiceFilter: true,
 }
 
 const inputCommon = {

--- a/shared/teams/add-people/index.js
+++ b/shared/teams/add-people/index.js
@@ -75,6 +75,7 @@ const AddPeople = (props: Props) => (
           onExitSearch={props.onClearSearch}
           placeholder="Add people"
           searchKey={'addToTeamSearch'}
+          showServiceFilter={true}
         />
       </Kb.Box>
       <Kb.Box style={{...Styles.desktopStyles.scrollable, flex: 1}}>


### PR DESCRIPTION
@keybase/react-hackers 

Looks like #13491 added an optional ownProp `<UserInput showServiceFilter={bool} />`, but didn't go back and set it for the cases we need.  Make it required, and configure it as:

* team, profile always shows service filter
* stellar never shows service filter
* chat new conversation only shows service filter if you've entered search text