### PR TITLE
Open stellar send dialog via icon in input area

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -81,6 +81,7 @@ export const setPendingConversationExistingConversationIDKey = 'chat2:setPending
 export const setPendingConversationUsers = 'chat2:setPendingConversationUsers'
 export const setPendingMode = 'chat2:setPendingMode'
 export const setPendingStatus = 'chat2:setPendingStatus'
+export const setWalletsOld = 'chat2:setWalletsOld'
 export const staticConfigLoaded = 'chat2:staticConfigLoaded'
 export const toggleLocalReaction = 'chat2:toggleLocalReaction'
 export const toggleMessageReaction = 'chat2:toggleMessageReaction'
@@ -332,6 +333,7 @@ type _SetPendingModePayload = $ReadOnly<{|
   noneDestination?: 'inbox' | 'thread',
 |}>
 type _SetPendingStatusPayload = $ReadOnly<{|pendingStatus: Types.PendingStatus|}>
+type _SetWalletsOldPayload = void
 type _StaticConfigLoadedPayload = $ReadOnly<{|staticConfig: Types.StaticConfig|}>
 type _ToggleLocalReactionPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
@@ -393,9 +395,9 @@ export const createFilePickerError = (payload: _FilePickerErrorPayload) => ({err
  */
 export const createSetExplodingModeLock = (payload: _SetExplodingModeLockPayload) => ({error: false, payload, type: setExplodingModeLock})
 /**
- * Set that we've seen wallets integration in chat. This can come from the view or from gregor.
+ * Set that wallets in chat is not new.
  */
-export const createHandleSeeingWallets = (payload: _HandleSeeingWalletsPayload) => ({error: false, payload, type: handleSeeingWallets})
+export const createSetWalletsOld = (payload: _SetWalletsOldPayload) => ({error: false, payload, type: setWalletsOld})
 /**
  * Set the minimum role required to write into a conversation. Valid only for team conversations.
  */
@@ -428,6 +430,10 @@ export const createToggleMessageReaction = (payload: _ToggleMessageReactionPaylo
  * The service sent us an update for the reaction map of a message.
  */
 export const createUpdateReactions = (payload: _UpdateReactionsPayload) => ({error: false, payload, type: updateReactions})
+/**
+ * The user has interacted with wallets in chat.
+ */
+export const createHandleSeeingWallets = (payload: _HandleSeeingWalletsPayload) => ({error: false, payload, type: handleSeeingWallets})
 /**
  * Toggle a reaction in the store.
  */
@@ -575,6 +581,7 @@ export type SetPendingConversationExistingConversationIDKeyPayload = $Call<typeo
 export type SetPendingConversationUsersPayload = $Call<typeof createSetPendingConversationUsers, _SetPendingConversationUsersPayload>
 export type SetPendingModePayload = $Call<typeof createSetPendingMode, _SetPendingModePayload>
 export type SetPendingStatusPayload = $Call<typeof createSetPendingStatus, _SetPendingStatusPayload>
+export type SetWalletsOldPayload = $Call<typeof createSetWalletsOld, _SetWalletsOldPayload>
 export type StaticConfigLoadedPayload = $Call<typeof createStaticConfigLoaded, _StaticConfigLoadedPayload>
 export type ToggleLocalReactionPayload = $Call<typeof createToggleLocalReaction, _ToggleLocalReactionPayload>
 export type ToggleMessageReactionPayload = $Call<typeof createToggleMessageReaction, _ToggleMessageReactionPayload>
@@ -657,6 +664,7 @@ export type Actions =
   | SetPendingConversationUsersPayload
   | SetPendingModePayload
   | SetPendingStatusPayload
+  | SetWalletsOldPayload
   | StaticConfigLoadedPayload
   | ToggleLocalReactionPayload
   | ToggleMessageReactionPayload

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -26,6 +26,7 @@ export const createConversation = 'chat2:createConversation'
 export const desktopNotification = 'chat2:desktopNotification'
 export const filePickerError = 'chat2:filePickerError'
 export const handleSeeingExplodingMessages = 'chat2:handleSeeingExplodingMessages'
+export const handleSeeingWallets = 'chat2:handleSeeingWallets'
 export const inboxRefresh = 'chat2:inboxRefresh'
 export const joinConversation = 'chat2:joinConversation'
 export const leaveConversation = 'chat2:leaveConversation'
@@ -137,6 +138,7 @@ type _DesktopNotificationPayload = $ReadOnly<{|
 |}>
 type _FilePickerErrorPayload = $ReadOnly<{|error: Error|}>
 type _HandleSeeingExplodingMessagesPayload = void
+type _HandleSeeingWalletsPayload = void
 type _InboxRefreshPayload = $ReadOnly<{|reason: 'bootstrap' | 'componentNeverLoaded' | 'inboxStale' | 'inboxSyncedClear' | 'inboxSyncedUnknown' | 'joinedAConversation' | 'leftAConversation' | 'teamTypeChanged'|}>
 type _JoinConversationPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey|}>
 type _LeaveConversationPayload = $ReadOnly<{|
@@ -391,6 +393,10 @@ export const createFilePickerError = (payload: _FilePickerErrorPayload) => ({err
  */
 export const createSetExplodingModeLock = (payload: _SetExplodingModeLockPayload) => ({error: false, payload, type: setExplodingModeLock})
 /**
+ * Set that we've seen wallets integration in chat. This can come from the view or from gregor.
+ */
+export const createHandleSeeingWallets = (payload: _HandleSeeingWalletsPayload) => ({error: false, payload, type: handleSeeingWallets})
+/**
  * Set the minimum role required to write into a conversation. Valid only for team conversations.
  */
 export const createSetMinWriterRole = (payload: _SetMinWriterRolePayload) => ({error: false, payload, type: setMinWriterRole})
@@ -514,6 +520,7 @@ export type CreateConversationPayload = $Call<typeof createCreateConversation, _
 export type DesktopNotificationPayload = $Call<typeof createDesktopNotification, _DesktopNotificationPayload>
 export type FilePickerErrorPayload = $Call<typeof createFilePickerError, _FilePickerErrorPayload>
 export type HandleSeeingExplodingMessagesPayload = $Call<typeof createHandleSeeingExplodingMessages, _HandleSeeingExplodingMessagesPayload>
+export type HandleSeeingWalletsPayload = $Call<typeof createHandleSeeingWallets, _HandleSeeingWalletsPayload>
 export type InboxRefreshPayload = $Call<typeof createInboxRefresh, _InboxRefreshPayload>
 export type JoinConversationPayload = $Call<typeof createJoinConversation, _JoinConversationPayload>
 export type LeaveConversationPayload = $Call<typeof createLeaveConversation, _LeaveConversationPayload>
@@ -595,6 +602,7 @@ export type Actions =
   | DesktopNotificationPayload
   | FilePickerErrorPayload
   | HandleSeeingExplodingMessagesPayload
+  | HandleSeeingWalletsPayload
   | InboxRefreshPayload
   | JoinConversationPayload
   | LeaveConversationPayload

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -423,9 +423,11 @@
       "_description":
         "Some things need to happen when the user interacts with the exploding messages feature. Trigger the handler that takes care of those things."
     },
+    "setWalletsOld": {
+      "_description": "Set that wallets in chat is not new."
+    },
     "handleSeeingWallets": {
-      "_description":
-        "Set that we've seen wallets integration in chat. This can come from the view or from gregor."
+      "_description": "The user has interacted with wallets in chat."
     },
     "staticConfigLoaded": {
       "_description": "Static configuration info was loaded from the service.",

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -423,6 +423,10 @@
       "_description":
         "Some things need to happen when the user interacts with the exploding messages feature. Trigger the handler that takes care of those things."
     },
+    "handleSeeingWallets": {
+      "_description":
+        "Set that we've seen wallets integration in chat. This can come from the view or from gregor."
+    },
     "staticConfigLoaded": {
       "_description": "Static configuration info was loaded from the service.",
       "staticConfig": "Types.StaticConfig"

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -46,6 +46,13 @@ const provider = Sb.createPropProviderWithCommon({
       users,
     }
   },
+  WalletsIcon: ownProps => ({
+    isNew: true,
+    onClick: Sb.action('onOpenWalletsForm'),
+    shouldRender: true,
+    size: ownProps.size,
+    style: ownProps.style,
+  }),
 })
 
 type Props = {

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -20,6 +20,7 @@ import flags from '../../../../util/feature-flags'
 import SetExplodingMessagePopup from '../../messages/set-explode-popup/container'
 import type {PlatformInputProps} from './types'
 import {formatDurationShort} from '../../../../util/timestamp'
+import StellarIcon from './stellar-icon/container'
 
 const MentionCatcher = ({onClick}) => <Kb.Box onClick={onClick} style={styles.mentionCatcher} />
 
@@ -334,6 +335,7 @@ class PlatformInput extends Component<PlatformInputProps & Kb.OverlayParentProps
           {this.state.emojiPickerOpen && (
             <EmojiPicker emojiPickerToggle={this._emojiPickerToggle} onClick={this._pickerOnClick} />
           )}
+          {flags.walletsEnabled && <StellarIcon size={16} style={styles.marginRightTiny} />}
           <Kb.Icon
             color={this.state.emojiPickerOpen ? globalColors.black_75 : null}
             onClick={this._emojiPickerToggle}
@@ -542,6 +544,9 @@ const styles = styleSheetCreate({
     marginBottom: globalMargins.xtiny,
     marginLeft: 58,
     textAlign: 'left',
+  },
+  marginRightTiny: {
+    marginRight: globalMargins.tiny,
   },
   mentionCatcher: {
     ...globalStyles.fillAbsolute,

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -20,7 +20,7 @@ import flags from '../../../../util/feature-flags'
 import SetExplodingMessagePopup from '../../messages/set-explode-popup/container'
 import type {PlatformInputProps} from './types'
 import {formatDurationShort} from '../../../../util/timestamp'
-import StellarIcon from './stellar-icon/container'
+import WalletsIcon from './wallets-icon/container'
 
 const MentionCatcher = ({onClick}) => <Kb.Box onClick={onClick} style={styles.mentionCatcher} />
 
@@ -335,7 +335,7 @@ class PlatformInput extends Component<PlatformInputProps & Kb.OverlayParentProps
           {this.state.emojiPickerOpen && (
             <EmojiPicker emojiPickerToggle={this._emojiPickerToggle} onClick={this._pickerOnClick} />
           )}
-          {flags.walletsEnabled && <StellarIcon size={16} style={styles.marginRightTiny} />}
+          {flags.walletsEnabled && <WalletsIcon size={16} style={styles.marginRightTiny} />}
           <Kb.Icon
             color={this.state.emojiPickerOpen ? globalColors.black_75 : null}
             onClick={this._emojiPickerToggle}

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -25,7 +25,7 @@ import {ExplodingMeta} from './shared'
 import type {PlatformInputProps} from './types'
 import flags from '../../../../util/feature-flags'
 import FilePickerPopup from '../filepicker-popup'
-import StellarIcon from './stellar-icon/container'
+import WalletsIcon from './wallets-icon/container'
 
 type menuType = 'exploding' | 'filepickerpopup'
 
@@ -281,7 +281,7 @@ const Action = ({
           openExplodingPicker={openExplodingPicker}
         />
       )}
-      {flags.walletsEnabled && <StellarIcon size={22} style={styles.actionButton} />}
+      {flags.walletsEnabled && <WalletsIcon size={22} style={styles.actionButton} />}
       <Icon
         onClick={insertMentionMarker}
         type="iconfont-mention"

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -25,6 +25,7 @@ import {ExplodingMeta} from './shared'
 import type {PlatformInputProps} from './types'
 import flags from '../../../../util/feature-flags'
 import FilePickerPopup from '../filepicker-popup'
+import StellarIcon from './stellar-icon/container'
 
 type menuType = 'exploding' | 'filepickerpopup'
 
@@ -280,6 +281,7 @@ const Action = ({
           openExplodingPicker={openExplodingPicker}
         />
       )}
+      {flags.walletsEnabled && <StellarIcon size={22} style={styles.actionButton} />}
       <Icon
         onClick={insertMentionMarker}
         type="iconfont-mention"

--- a/shared/chat/conversation/input-area/normal/stellar-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/stellar-icon/container.js
@@ -1,0 +1,22 @@
+// @flow
+import * as Container from '../../../../../util/container'
+import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
+import * as WalletConstants from '../../../../../constants/wallets'
+import _StellarIcon from '.'
+
+const mapStateToProps = state => ({
+  isNew: true,
+})
+
+const mapDispatchToProps = dispatch => ({
+  onClick: () =>
+    dispatch(RouteTreeGen.createNavigateAppend({path: [WalletConstants.sendReceiveFormRouteKey]})),
+})
+
+const StellarIcon = Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({
+  ...o,
+  ...s,
+  ...d,
+}))(_StellarIcon)
+
+export default StellarIcon

--- a/shared/chat/conversation/input-area/normal/stellar-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/stellar-icon/container.js
@@ -1,16 +1,17 @@
 // @flow
 import * as Container from '../../../../../util/container'
+import * as Chat2Gen from '../../../../../actions/chat2-gen'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import * as WalletConstants from '../../../../../constants/wallets'
 import _StellarIcon from '.'
 
 const mapStateToProps = state => ({
-  isNew: true,
+  isNew: state.chat2.isWalletsNew,
 })
 
 const mapDispatchToProps = dispatch => ({
-  onClick: () =>
-    dispatch(RouteTreeGen.createNavigateAppend({path: [WalletConstants.sendReceiveFormRouteKey]})),
+  onClick: () => dispatch(Chat2Gen.createHandleSeeingWallets()),
+  // dispatch(RouteTreeGen.createNavigateAppend({path: [WalletConstants.sendReceiveFormRouteKey]})),
 })
 
 const StellarIcon = Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({

--- a/shared/chat/conversation/input-area/normal/stellar-icon/index.js
+++ b/shared/chat/conversation/input-area/normal/stellar-icon/index.js
@@ -1,0 +1,38 @@
+// @flow
+import * as React from 'react'
+import * as Kb from '../../../../../common-adapters'
+import * as Styles from '../../../../../styles'
+
+type StellarIconProps = {
+  isNew: boolean,
+  onClick: () => void,
+  size: number,
+  style?: Styles.StylesCrossPlatform,
+}
+const StellarIcon = ({isNew, onClick, size, style}: StellarIconProps) => (
+  <Kb.Box2 direction="horizontal" style={Styles.collapseStyles([styles.container, style])}>
+    <Kb.Icon type="iconfont-dollar-sign" fontSize={size} onClick={onClick} />
+    {isNew && <Kb.Box style={styles.newBadge} />}
+  </Kb.Box2>
+)
+
+const radius = 4
+const styles = Styles.styleSheetCreate({
+  container: {
+    position: 'relative',
+  },
+  newBadge: {
+    backgroundColor: Styles.globalColors.blue,
+    borderColor: Styles.globalColors.white,
+    borderRadius: radius,
+    borderStyle: 'solid',
+    borderWidth: 1,
+    height: radius * 2,
+    position: 'absolute',
+    right: -1,
+    top: -2,
+    width: radius * 2,
+  },
+})
+
+export default StellarIcon

--- a/shared/chat/conversation/input-area/normal/wallets-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/container.js
@@ -1,11 +1,14 @@
 // @flow
+import * as React from 'react'
 import * as Container from '../../../../../util/container'
 import * as Chat2Gen from '../../../../../actions/chat2-gen'
+import * as Constants from '../../../../../constants/chat2'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import * as WalletConstants from '../../../../../constants/wallets'
-import _WalletsIcon from '.'
+import WalletsIconRender, {type WalletsIconProps as ViewProps} from '.'
 
 const mapStateToProps = state => ({
+  _meta: Constants.getMeta(state, Constants.getSelectedConversation(state)),
   isNew: state.chat2.isWalletsNew,
 })
 
@@ -14,10 +17,29 @@ const mapDispatchToProps = dispatch => ({
   // dispatch(RouteTreeGen.createNavigateAppend({path: [WalletConstants.sendReceiveFormRouteKey]})),
 })
 
-const WalletsIcon = Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({
-  ...o,
-  ...s,
-  ...d,
-}))(_WalletsIcon)
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  if (stateProps._meta.teamType !== 'adhoc' || stateProps._meta.participants.size !== 2) {
+    // Only show this for one-on-one conversations
+    return {shouldRender: false}
+  }
+  return {
+    isNew: stateProps.isNew,
+    onClick: () => {}, // TODO
+    shouldRender: true,
+    size: ownProps.size,
+    style: ownProps.style,
+  }
+}
+
+type WrapperProps = {|...ViewProps, shouldRender: true|} | {|shouldRender: false|}
+const Wrapper = (props: WrapperProps) => {
+  if (props.shouldRender) {
+    const {shouldRender, ...passThroughProps} = props
+    return <WalletsIconRender {...passThroughProps} />
+  }
+  return null
+}
+
+const WalletsIcon = Container.connect(mapStateToProps, mapDispatchToProps, mergeProps)(Wrapper)
 
 export default WalletsIcon

--- a/shared/chat/conversation/input-area/normal/wallets-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/container.js
@@ -3,7 +3,7 @@ import * as Container from '../../../../../util/container'
 import * as Chat2Gen from '../../../../../actions/chat2-gen'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import * as WalletConstants from '../../../../../constants/wallets'
-import _StellarIcon from '.'
+import _WalletsIcon from '.'
 
 const mapStateToProps = state => ({
   isNew: state.chat2.isWalletsNew,
@@ -14,10 +14,10 @@ const mapDispatchToProps = dispatch => ({
   // dispatch(RouteTreeGen.createNavigateAppend({path: [WalletConstants.sendReceiveFormRouteKey]})),
 })
 
-const StellarIcon = Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({
+const WalletsIcon = Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({
   ...o,
   ...s,
   ...d,
-}))(_StellarIcon)
+}))(_WalletsIcon)
 
-export default StellarIcon
+export default WalletsIcon

--- a/shared/chat/conversation/input-area/normal/wallets-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/container.js
@@ -15,8 +15,10 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  _onClick: (to: string) => {
-    dispatch(Chat2Gen.createHandleSeeingWallets())
+  _onClick: (to: string, wasNew: boolean) => {
+    if (wasNew) {
+      dispatch(Chat2Gen.createHandleSeeingWallets())
+    }
     dispatch(WalletsGen.createAbandonPayment())
     dispatch(WalletsGen.createSetBuildingRecipientType({recipientType: 'keybaseUser'}))
     dispatch(WalletsGen.createSetBuildingTo({to}))
@@ -41,7 +43,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const to = stateProps._meta.participants.find(u => u !== stateProps._you)
   return {
     isNew: stateProps.isNew,
-    onClick: () => dispatchProps._onClick(to), // TODO
+    onClick: () => dispatchProps._onClick(to, stateProps.isNew),
     shouldRender: true,
     size: ownProps.size,
     style: ownProps.style,

--- a/shared/chat/conversation/input-area/normal/wallets-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/container.js
@@ -59,6 +59,9 @@ const Wrapper = (props: WrapperProps) => {
   return null
 }
 
-const WalletsIcon = Container.connect(mapStateToProps, mapDispatchToProps, mergeProps)(Wrapper)
+const WalletsIcon = Container.compose(
+  Container.connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  Container.setDisplayName('WalletsIcon')
+)(Wrapper)
 
 export default WalletsIcon

--- a/shared/chat/conversation/input-area/normal/wallets-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/container.js
@@ -2,19 +2,35 @@
 import * as React from 'react'
 import * as Container from '../../../../../util/container'
 import * as Chat2Gen from '../../../../../actions/chat2-gen'
-import * as Constants from '../../../../../constants/chat2'
+import * as WalletsGen from '../../../../../actions/wallets-gen'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
+import * as Constants from '../../../../../constants/chat2'
 import * as WalletConstants from '../../../../../constants/wallets'
 import WalletsIconRender, {type WalletsIconProps as ViewProps} from '.'
 
 const mapStateToProps = state => ({
   _meta: Constants.getMeta(state, Constants.getSelectedConversation(state)),
+  _you: state.config.username,
   isNew: state.chat2.isWalletsNew,
 })
 
 const mapDispatchToProps = dispatch => ({
-  onClick: () => dispatch(Chat2Gen.createHandleSeeingWallets()),
-  // dispatch(RouteTreeGen.createNavigateAppend({path: [WalletConstants.sendReceiveFormRouteKey]})),
+  _onClick: (to: string) => {
+    dispatch(Chat2Gen.createHandleSeeingWallets())
+    dispatch(WalletsGen.createAbandonPayment())
+    dispatch(WalletsGen.createSetBuildingRecipientType({recipientType: 'keybaseUser'}))
+    dispatch(WalletsGen.createSetBuildingTo({to}))
+    dispatch(
+      RouteTreeGen.createNavigateAppend({
+        path: [
+          {
+            props: {isRequest: true},
+            selected: WalletConstants.sendReceiveFormRouteKey,
+          },
+        ],
+      })
+    )
+  },
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
@@ -22,9 +38,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     // Only show this for one-on-one conversations
     return {shouldRender: false}
   }
+  const to = stateProps._meta.participants.find(u => u !== stateProps._you)
   return {
     isNew: stateProps.isNew,
-    onClick: () => {}, // TODO
+    onClick: () => dispatchProps._onClick(to), // TODO
     shouldRender: true,
     size: ownProps.size,
     style: ownProps.style,

--- a/shared/chat/conversation/input-area/normal/wallets-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/container.js
@@ -35,12 +35,17 @@ const mapDispatchToProps = dispatch => ({
   },
 })
 
+const renderNothingProps = {shouldRender: false}
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   if (stateProps._meta.teamType !== 'adhoc' || stateProps._meta.participants.size !== 2) {
     // Only show this for one-on-one conversations
-    return {shouldRender: false}
+    return renderNothingProps
   }
   const to = stateProps._meta.participants.find(u => u !== stateProps._you)
+  if (!to || to.indexOf('@') !== -1) {
+    // Send to SBS assertion not currently supported in the GUI
+    return renderNothingProps
+  }
   return {
     isNew: stateProps.isNew,
     onClick: () => dispatchProps._onClick(to, stateProps.isNew),

--- a/shared/chat/conversation/input-area/normal/wallets-icon/index.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/index.js
@@ -3,12 +3,12 @@ import * as React from 'react'
 import * as Kb from '../../../../../common-adapters'
 import * as Styles from '../../../../../styles'
 
-type WalletsIconProps = {
+export type WalletsIconProps = {|
   isNew: boolean,
   onClick: () => void,
   size: number,
   style?: Styles.StylesCrossPlatform,
-}
+|}
 const WalletsIcon = ({isNew, onClick, size, style}: WalletsIconProps) => (
   <Kb.Box2 direction="horizontal" style={Styles.collapseStyles([styles.container, style])}>
     <Kb.Icon type="iconfont-dollar-sign" fontSize={size} onClick={onClick} />

--- a/shared/chat/conversation/input-area/normal/wallets-icon/index.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/index.js
@@ -3,13 +3,13 @@ import * as React from 'react'
 import * as Kb from '../../../../../common-adapters'
 import * as Styles from '../../../../../styles'
 
-type StellarIconProps = {
+type WalletsIconProps = {
   isNew: boolean,
   onClick: () => void,
   size: number,
   style?: Styles.StylesCrossPlatform,
 }
-const StellarIcon = ({isNew, onClick, size, style}: StellarIconProps) => (
+const WalletsIcon = ({isNew, onClick, size, style}: WalletsIconProps) => (
   <Kb.Box2 direction="horizontal" style={Styles.collapseStyles([styles.container, style])}>
     <Kb.Icon type="iconfont-dollar-sign" fontSize={size} onClick={onClick} />
     {isNew && <Kb.Box style={styles.newBadge} />}
@@ -35,4 +35,4 @@ const styles = Styles.styleSheetCreate({
   },
 })
 
-export default StellarIcon
+export default WalletsIcon

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -26,6 +26,7 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   inboxHasLoaded: false,
   inboxFilter: '',
   isExplodingNew: true,
+  isWalletsNew: true,
   messageMap: I.Map(),
   messageOrdinals: I.Map(),
   metaMap: I.Map([
@@ -175,6 +176,10 @@ export const getConversationExplodingMode = (state: TypedState, c: Types.Convers
 }
 export const isExplodingModeLocked = (state: TypedState, c: Types.ConversationIDKey) =>
   state.chat2.getIn(['explodingModeLocks', c], null) !== null
+
+// When user clicks wallets icon in chat input, set seenWalletsGregorKey with
+// body of 'true'
+export const seenWalletsGregorKey = 'chat.seenWallets'
 
 export const makeInboxQuery = (
   convIDKeys: Array<Types.ConversationIDKey>

--- a/shared/constants/types/chat2/index.js
+++ b/shared/constants/types/chat2/index.js
@@ -44,6 +44,7 @@ export type _State = {
   inboxFilter: string, // filters 'jump to chat'
   inboxHasLoaded: boolean, // if we've ever loaded
   isExplodingNew: boolean, // controls the new-ness of exploding messages UI
+  isWalletsNew: boolean, // controls new-ness of wallets in chat UI
   messageMap: I.Map<Common.ConversationIDKey, I.Map<Message.Ordinal, Message.Message>>, // messages in a thread
   messageOrdinals: I.Map<Common.ConversationIDKey, I.SortedSet<Message.Ordinal>>, // ordered ordinals in a thread
   metaMap: MetaMap, // metadata about a thread, There is a special node for the pending conversation

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -785,6 +785,8 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
       const {conversationIDKey, messageID, requestInfo} = action.payload
       return state.update('accountsInfoMap', old => old.setIn([conversationIDKey, messageID], requestInfo))
     }
+    case Chat2Gen.handleSeeingWallets:
+      return state.isWalletsNew ? state.set('isWalletsNew', false) : state
     // metaMap/messageMap/messageOrdinalsList only actions
     case Chat2Gen.messageDelete:
     case Chat2Gen.messageEdit:

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -785,7 +785,8 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
       const {conversationIDKey, messageID, requestInfo} = action.payload
       return state.update('accountsInfoMap', old => old.setIn([conversationIDKey, messageID], requestInfo))
     }
-    case Chat2Gen.handleSeeingWallets:
+    case Chat2Gen.handleSeeingWallets: // fallthrough
+    case Chat2Gen.setWalletsOld:
       return state.isWalletsNew ? state.set('isWalletsNew', false) : state
     // metaMap/messageMap/messageOrdinalsList only actions
     case Chat2Gen.messageDelete:


### PR DESCRIPTION
Currently will only show up in `adhoc` conversations with exactly 2 participants. This uses gregor to keep track of the badge on the icon. It will show up for SBS but the participant won't be filled in on click, since the send form doesn't currently support SBS. r? @keybase/react-hackers 