### PR TITLE
Turn paymentStatusNotification back on

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -341,6 +341,7 @@ const maybeNavigateAwayFromSendForm = (state: TypedState, action: WalletsGen.Aba
 const setupEngineListeners = () => {
   getEngine().setIncomingCallMap({
     'stellar.1.notify.paymentNotification': refreshPayments,
+    'stellar.1.notify.paymentStatusNotification': refreshPayments,
   })
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

We turned this off because it didn't come with the accountID that `refreshPayments` expects, but now it does.