### PR TITLE
6: More inbox optimizations for scrolling

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -15,7 +15,7 @@ type SwitchProps = {
   type: 'error' | 'noConvo' | 'rekey' | 'youAreReset' | 'normal' | 'rekey',
 }
 
-const DONT_RENDER_CONVERSATION = __DEV__ && true
+const DONT_RENDER_CONVERSATION = __DEV__ && false
 
 class Conversation extends React.PureComponent<SwitchProps> {
   render() {

--- a/shared/chat/conversation/info-panel/menu/container.js
+++ b/shared/chat/conversation/info-panel/menu/container.js
@@ -5,12 +5,11 @@ import {createGetTeamOperations, createAddTeamWithChosenChannels} from '../../..
 import {
   compose,
   connect,
-  lifecycle,
   setDisplayName,
   type TypedState,
   createCachedSelector,
 } from '../../../../util/container'
-import {type Props as _Props, InfoPanelMenu} from '.'
+import {InfoPanelMenu} from '.'
 import {navigateAppend, navigateTo, switchTo} from '../../../../actions/route-tree'
 import {teamsTab} from '../../../../constants/tabs'
 
@@ -20,10 +19,6 @@ export type OwnProps = {
   isSmallTeam: boolean,
   teamname: string,
   visible: boolean,
-}
-
-export type Props = _Props & {
-  _loadOperations: () => void,
 }
 
 const moreThanOneSubscribedChannel = createCachedSelector(
@@ -45,7 +40,7 @@ const moreThanOneSubscribedChannel = createCachedSelector(
 const mapStateToProps = (state: TypedState, {teamname, isSmallTeam}: OwnProps) => {
   const yourOperations = Constants.getCanPerform(state, teamname)
   // We can get here without loading canPerform
-  const _hasCanPerform = Constants.hasCanPerform(state, teamname)
+  const hasCanPerform = Constants.hasCanPerform(state, teamname)
   const badgeSubscribe = !Constants.isTeamWithChosenChannels(state, teamname)
 
   const manageChannelsTitle = isSmallTeam
@@ -55,7 +50,7 @@ const mapStateToProps = (state: TypedState, {teamname, isSmallTeam}: OwnProps) =
       : 'Subscribe to channels...'
   const manageChannelsSubtitle = isSmallTeam ? 'Turns this into a big team' : ''
   return {
-    _hasCanPerform,
+    hasCanPerform,
     badgeSubscribe,
     canAddPeople: yourOperations.manageMembers,
     isSmallTeam,
@@ -67,7 +62,7 @@ const mapStateToProps = (state: TypedState, {teamname, isSmallTeam}: OwnProps) =
 }
 
 const mapDispatchToProps = (dispatch, {teamname}: OwnProps) => ({
-  _loadOperations: () => dispatch(createGetTeamOperations({teamname})),
+  loadOperations: () => dispatch(createGetTeamOperations({teamname})),
   onAddPeople: () => {
     dispatch(
       navigateTo(
@@ -101,12 +96,5 @@ const mapDispatchToProps = (dispatch, {teamname}: OwnProps) => ({
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
-  setDisplayName('TeamDropdownMenu'),
-  lifecycle({
-    componentDidMount() {
-      if (!this.props._hasCanPerform) {
-        this.props._loadOperations()
-      }
-    },
-  })
+  setDisplayName('TeamDropdownMenu')
 )(InfoPanelMenu)

--- a/shared/chat/conversation/info-panel/menu/index.js
+++ b/shared/chat/conversation/info-panel/menu/index.js
@@ -13,6 +13,8 @@ export type Props = {
   memberCount: number,
   teamname: string,
   visible: boolean,
+  hasCanPerform: boolean,
+  loadOperations: () => void,
   onAddPeople: () => void,
   onHidden: () => void,
   onInvite: () => void,
@@ -33,61 +35,70 @@ const Header = ({teamname, memberCount}: {teamname: string, memberCount: number}
   </Kb.Box>
 )
 
-const InfoPanelMenu = (props: Props) => {
-  const addPeopleItems = [
-    {
-      title: 'Add someone by username',
-      subTitle: 'Keybase, Twitter, etc.',
-      onClick: props.onAddPeople,
-      style: {borderTopWidth: 0},
-    },
-    {
-      title: Styles.isMobile ? 'Add someone from address book' : 'Add someone by email',
-      onClick: props.onInvite,
-    },
-  ]
-  const channelItem = props.isSmallTeam
-    ? {
-        onClick: props.onManageChannels,
-        subTitle: props.manageChannelsSubtitle,
-        title: props.manageChannelsTitle,
-      }
-    : {
-        onClick: props.onManageChannels,
-        title: props.manageChannelsTitle,
-        view: (
-          <Kb.Box style={Styles.globalStyles.flexBoxRow}>
-            <Kb.Text style={styles.text} type={Styles.isMobile ? 'BodyBig' : 'Body'}>
-              {props.manageChannelsTitle}
-            </Kb.Text>
-            {props.badgeSubscribe && <Kb.Box style={styles.badge} />}
-          </Kb.Box>
-        ),
-      }
-
-  const items = [
-    ...(props.canAddPeople ? addPeopleItems : []),
-    {title: 'View team', onClick: props.onViewTeam, style: {borderTopWidth: 0}},
-    channelItem,
-    {title: 'Leave team', onClick: props.onLeaveTeam, danger: true},
-  ]
-
-  const header = {
-    title: 'header',
-    view: <Header teamname={props.teamname} memberCount={props.memberCount} />,
+class InfoPanelMenu extends React.Component<Props> {
+  componentDidDUpdate(prevProps: Props) {
+    if (this.props.hasCanPerform && this.props.visible !== prevProps.visible) {
+      this.props.loadOperations()
+    }
   }
 
-  return (
-    <Kb.FloatingMenu
-      attachTo={props.attachTo}
-      visible={props.visible}
-      items={items}
-      header={header}
-      onHidden={props.onHidden}
-      position="bottom left"
-      closeOnSelect={true}
-    />
-  )
+  render() {
+    const props = this.props
+    const addPeopleItems = [
+      {
+        title: 'Add someone by username',
+        subTitle: 'Keybase, Twitter, etc.',
+        onClick: props.onAddPeople,
+        style: {borderTopWidth: 0},
+      },
+      {
+        title: Styles.isMobile ? 'Add someone from address book' : 'Add someone by email',
+        onClick: props.onInvite,
+      },
+    ]
+    const channelItem = props.isSmallTeam
+      ? {
+          onClick: props.onManageChannels,
+          subTitle: props.manageChannelsSubtitle,
+          title: props.manageChannelsTitle,
+        }
+      : {
+          onClick: props.onManageChannels,
+          title: props.manageChannelsTitle,
+          view: (
+            <Kb.Box style={Styles.globalStyles.flexBoxRow}>
+              <Kb.Text style={styles.text} type={Styles.isMobile ? 'BodyBig' : 'Body'}>
+                {props.manageChannelsTitle}
+              </Kb.Text>
+              {props.badgeSubscribe && <Kb.Box style={styles.badge} />}
+            </Kb.Box>
+          ),
+        }
+
+    const items = [
+      ...(props.canAddPeople ? addPeopleItems : []),
+      {title: 'View team', onClick: props.onViewTeam, style: {borderTopWidth: 0}},
+      channelItem,
+      {title: 'Leave team', onClick: props.onLeaveTeam, danger: true},
+    ]
+
+    const header = {
+      title: 'header',
+      view: <Header teamname={props.teamname} memberCount={props.memberCount} />,
+    }
+
+    return (
+      <Kb.FloatingMenu
+        attachTo={props.attachTo}
+        visible={props.visible}
+        items={items}
+        header={header}
+        onHidden={props.onHidden}
+        position="bottom left"
+        closeOnSelect={true}
+      />
+    )
+  }
 }
 
 const styles = Styles.styleSheetCreate({

--- a/shared/chat/inbox/container/index.js
+++ b/shared/chat/inbox/container/index.js
@@ -1,5 +1,6 @@
 // @flow
 import {debounce} from 'lodash-es'
+import * as React from 'react'
 import * as Constants from '../../../constants/chat2'
 import * as Types from '../../../constants/types/chat2'
 import * as Chat2Gen from '../../../actions/chat2-gen'
@@ -14,14 +15,15 @@ import {
 } from '../../../util/container'
 import type {TypedState} from '../../../util/container'
 import type {RowItemSmall, RowItemBig} from '../index.types'
+import type {Props as _Props} from '../index.types'
 import normalRowData from './normal'
 import filteredRowData from './filtered'
 
 const mapStateToProps = (state: TypedState) => ({
-  _username: state.config.username,
   _metaMap: state.chat2.metaMap,
   _selectedConversationIDKey: Constants.getSelectedConversation(state),
   _smallTeamsExpanded: state.chat2.smallTeamsExpanded,
+  _username: state.config.username,
   filter: state.chat2.inboxFilter,
   isLoading: Constants.anyChatWaitingKeys(state),
   neverLoaded: !state.chat2.inboxHasLoaded,
@@ -43,6 +45,7 @@ const mapDispatchToProps = (dispatch, {navigateAppend}) => ({
       dispatch(Chat2Gen.createSelectConversation({conversationIDKey, reason: 'inboxFilterArrow'}))
     }
   },
+  _refreshInbox: () => dispatch(Chat2Gen.createInboxRefresh({reason: 'componentNeverLoaded'})),
   onNewChat: () => dispatch(Chat2Gen.createSetPendingMode({pendingMode: 'searchingForUsers'})),
   onUntrustedInboxVisible: (conversationIDKeys: Array<Types.ConversationIDKey>) =>
     dispatch(
@@ -51,7 +54,6 @@ const mapDispatchToProps = (dispatch, {navigateAppend}) => ({
         reason: 'untrusted inbox visible',
       })
     ),
-  refreshInbox: (force: boolean) => dispatch(Chat2Gen.createInboxRefresh({reason: 'componentNeverLoaded'})),
   toggleSmallTeamsExpanded: () => dispatch(Chat2Gen.createToggleSmallTeamsExpanded()),
 })
 
@@ -61,66 +63,86 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ? filteredRowData(stateProps._metaMap, stateProps.filter, stateProps._username)
     : normalRowData(stateProps._metaMap, stateProps._smallTeamsExpanded)
   return {
+    _isLoading: stateProps.isLoading,
+    _refreshInbox: dispatchProps._refreshInbox,
     allowShowFloatingButton,
     filter: stateProps.filter,
-    isLoading: stateProps.isLoading,
     neverLoaded: stateProps.neverLoaded,
     onNewChat: dispatchProps.onNewChat,
-    onSelect: (conversationIDKey: Types.ConversationIDKey) => dispatchProps._onSelect(conversationIDKey),
-    onSelectDebounced: debounce(
-      (conversationIDKey: Types.ConversationIDKey) => dispatchProps._onSelect(conversationIDKey),
-      400,
-      {maxWait: 600}
-    ),
     onSelectDown: () => dispatchProps._onSelectNext(rows, stateProps._selectedConversationIDKey, 1),
     onSelectUp: () => dispatchProps._onSelectNext(rows, stateProps._selectedConversationIDKey, -1),
     onUntrustedInboxVisible: dispatchProps.onUntrustedInboxVisible,
-    refreshInbox: dispatchProps.refreshInbox,
     rows,
     smallTeamsExpanded,
     toggleSmallTeamsExpanded: dispatchProps.toggleSmallTeamsExpanded,
   }
 }
 
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps, mergeProps),
-  setDisplayName('Inbox'),
-  withStateHandlers(
-    {filterFocusCount: 0},
-    {focusFilter: ({filterFocusCount}) => () => ({filterFocusCount: filterFocusCount + 1})}
-  ),
-  lifecycle({
-    componentDidMount() {
-      if (this.props.neverLoaded && !this.props.isLoading) {
-        this.props.refreshInbox()
-      }
-    },
-    componentDidUpdate(prevProps) {
-      const loadedForTheFirstTime = prevProps.rows.length === 0 && this.props.rows.length > 0
-      // See if the first 6 are small, this implies it's expanded
-      const smallRowsPlusOne = prevProps.rows.slice(0, 6).filter(r => r.type === 'small')
-      const expandedForTheFirstTime = smallRowsPlusOne.length === 5 && this.props.rows.length > 5
-      if (loadedForTheFirstTime || expandedForTheFirstTime) {
-        const toUnbox = this.props.rows.slice(0, 20).reduce((arr, row) => {
-          if (row.type === 'small' || row.type === 'big') {
-            arr.push(row.conversationIDKey)
-          }
-          return arr
-        }, [])
-        if (toUnbox.length) {
-          this.props.onUntrustedInboxVisible(toUnbox)
-        }
-      }
+type Props = $Diff<
+  {|
+    ..._Props,
+    _refreshInbox: () => void,
+    _isLoading: boolean,
+  |},
+  {
+    filterFocusCount: number,
+    focusFilter: () => void,
+  }
+>
 
-      // keep first item selected if filter changes
-      if (!isMobile) {
-        if (this.props.filter && prevProps.filter !== this.props.filter && this.props.rows.length > 0) {
-          const row = this.props.rows[0]
-          if (row.conversationIDKey) {
-            this.props.onSelectDebounced(row.conversationIDKey)
-          }
+type State = {
+  filterFocusCount: number,
+}
+class InboxWrapper extends React.PureComponent<Props, State> {
+  state = {
+    filterFocusCount: 0,
+  }
+  _focusFilter = () => {
+    this.setState(p => ({filterFocusCount: p.filterFocusCount + 1}))
+  }
+
+  _onSelectUp = () => this.props.onSelectUp()
+  _onSelectDown = () => this.props.onSelectDown()
+
+  componentDidMount() {
+    if (this.props.neverLoaded && !this.props._isLoading) {
+      this.props._refreshInbox()
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const loadedForTheFirstTime = prevProps.rows.length === 0 && this.props.rows.length > 0
+    // See if the first 6 are small, this implies it's expanded
+    const smallRowsPlusOne = prevProps.rows.slice(0, 6).filter(r => r.type === 'small')
+    const expandedForTheFirstTime = smallRowsPlusOne.length === 5 && this.props.rows.length > 5
+    if (loadedForTheFirstTime || expandedForTheFirstTime) {
+      const toUnbox = this.props.rows.slice(0, 20).reduce((arr, row) => {
+        if (row.type === 'small' || row.type === 'big') {
+          arr.push(row.conversationIDKey)
         }
+        return arr
+      }, [])
+      if (toUnbox.length) {
+        this.props.onUntrustedInboxVisible(toUnbox)
       }
-    },
-  })
-)(Inbox.default)
+    }
+  }
+
+  render() {
+    const Component = Inbox.default
+    const {_refreshInbox, _isLoading, ...rest} = this.props
+    return (
+      <Component
+        {...rest}
+        filterFocusCount={this.state.filterFocusCount}
+        focusFilter={this._focusFilter}
+        onSelectUp={this._onSelectUp}
+        onSelectDown={this._onSelectDown}
+      />
+    )
+  }
+}
+
+export default compose(connect(mapStateToProps, mapDispatchToProps, mergeProps), setDisplayName('Inbox'))(
+  InboxWrapper
+)

--- a/shared/chat/inbox/container/normal.js
+++ b/shared/chat/inbox/container/normal.js
@@ -26,6 +26,16 @@ const splitMetas = memoize((metaMap: Types.MetaMap) => {
   return {bigMetas, smallMetas}
 })
 
+const smallMetasEqual = (la, lb) => {
+  if (typeof la === 'boolean') return la === lb
+  return (
+    la.length === lb.length &&
+    la.every((a, idx) => {
+      const b = lb[idx]
+      return a.conversationIDKey === b.conversationIDKey && a.inboxVersion === b.inboxVersion
+    })
+  )
+}
 const sortByTimestsamp = (a, b) => b.timestamp - a.timestamp
 const getSmallRows = memoize((smallMetas, showAllSmallRows) => {
   let metas
@@ -37,7 +47,7 @@ const getSmallRows = memoize((smallMetas, showAllSmallRows) => {
       .toArray()
   }
   return metas.map(m => ({conversationIDKey: m.conversationIDKey, type: 'small'}))
-}, shallowEqual)
+}, smallMetasEqual)
 
 const sortByTeamChannel = (a, b) =>
   a.teamname === b.teamname

--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -181,7 +181,7 @@ class Inbox extends React.PureComponent<Props, State> {
       return false
     })
 
-    const noChats = !this.props.isLoading && !this.props.rows.length && !this.props.filter && <NoChats />
+    const noChats = !this.props.neverLoaded && !this.props.rows.length && !this.props.filter && <NoChats />
     const owl = !this.props.rows.length && !!this.props.filter && <Owl />
     const floatingDivider = this.state.showFloating &&
       this.props.allowShowFloatingButton && <BigTeamsDivider toggle={this.props.toggleSmallTeamsExpanded} />

--- a/shared/chat/inbox/index.stories.js
+++ b/shared/chat/inbox/index.stories.js
@@ -342,26 +342,19 @@ const propsInboxCommon = {
   focusFilter: () => {},
   filter: '',
   filterFocusCount: 0,
-  isLoading: false,
+  neverLoaded: false,
   nowOverride: 0, // just for dumb rendering
-  onBuildTeam: Sb.action('onBuildTeam'),
-  onHotkey: Sb.action('onHotkey'),
   onNewChat: Sb.action('onNewChat'),
   onUntrustedInboxVisible: Sb.action('onUntrustedInboxVisible'),
   onSelectUp: Sb.action('onSelectUp'),
   onSelectDown: Sb.action('onSelectDown'),
   rows: [],
-  showNewChat: false,
-  showNewConversation: false,
-  showSmallTeamsExpandDivider: false,
   smallTeamsExpanded: false,
   toggleSmallTeamsExpanded: Sb.action('toggleSmallTeamsExpanded'),
 }
 
 const propsInboxEmpty = {
   ...propsInboxCommon,
-  showNewChat: true,
-  showBuildATeam: true,
 }
 
 const propsInboxSimple = {
@@ -401,12 +394,6 @@ const propsInboxTeam = {
 const propsInboxDivider = {
   ...propsInboxCommon,
   smallTeamsExpanded: false,
-  smallIDsHidden: [
-    Constants.stringToConversationIDKey(mapPropProviderProps['smallTeamC'].conversationIDKey),
-    Constants.stringToConversationIDKey(mapPropProviderProps['smallTeamD'].conversationIDKey),
-    Constants.stringToConversationIDKey(mapPropProviderProps['smallTeamE'].conversationIDKey),
-    Constants.stringToConversationIDKey(mapPropProviderProps['smallTeamF'].conversationIDKey),
-  ],
   rows: [
     // Small
     makeRowItemSmall('smallTeamA'),
@@ -438,7 +425,6 @@ const propsInboxDivider = {
 const propsInboxExpanded = {
   ...propsInboxCommon,
   smallTeamsExpanded: false,
-  showSmallTeamsExpandDivider: true,
   rows: [
     // Small
     makeRowItemSmall('smallTeamA'),
@@ -514,7 +500,6 @@ const provider = Sb.createPropProviderWithCommon({
   }),
   BuildTeam: p => ({
     onBuildTeam: Sb.action('onBuildTeam'),
-    showBuildATeam: teamsEmpty,
     loaded: true,
   }),
   NewChooser: p => ({

--- a/shared/chat/inbox/index.types.js.flow
+++ b/shared/chat/inbox/index.types.js.flow
@@ -31,21 +31,19 @@ export type RouteState = I.RecordOf<{
   smallTeamsExpanded: boolean,
 }>
 
-export type Props = {
+export type Props = {|
   children?: React$Element<any>,
   focusFilter: () => void, // withStateHandler function
   filter: string,
   filterFocusCount: number,
-  isLoading: boolean,
+  neverLoaded: boolean,
   nowOverride?: number, // just for dumb rendering
   onNewChat: () => void,
   onUntrustedInboxVisible: (conversationIDKeys: Array<ConversationIDKey>) => void,
   rows: Array<RowItem>,
-  showNewChat: boolean,
-  showNewConversation: boolean,
   allowShowFloatingButton: boolean,
   smallTeamsExpanded: boolean,
   toggleSmallTeamsExpanded: () => void,
   onSelectUp: () => void,
   onSelectDown: () => void,
-}
+|}

--- a/shared/common-adapters/avatar.js
+++ b/shared/common-adapters/avatar.js
@@ -115,6 +115,7 @@ class SharedAskForUserData {
     }
     const now = Date.now()
     const oldEnough = now - this._cacheTime
+    // $FlowIssue flow thinks array doens't have filter for some reason??
     const usernames = Object.keys(this._userQueue).filter(k => {
       const lr = this._userLastReq[k]
       if (!lr || lr < oldEnough) {
@@ -123,6 +124,7 @@ class SharedAskForUserData {
       }
       return false
     })
+    // $FlowIssue flow thinks array doens't have filter for some reason??
     const teamnames = Object.keys(this._teamQueue).filter(k => {
       const lr = this._teamLastReq[k]
       if (!lr || lr < oldEnough) {
@@ -133,8 +135,12 @@ class SharedAskForUserData {
     })
     this._teamQueue = {}
     this._userQueue = {}
-    this._dispatch(ConfigGen.createLoadAvatars({usernames}))
-    this._dispatch(ConfigGen.createLoadTeamAvatars({teamnames}))
+    if (Object.keys(usernames).length) {
+      this._dispatch(ConfigGen.createLoadAvatars({usernames}))
+    }
+    if (Object.keys(teamnames).length) {
+      this._dispatch(ConfigGen.createLoadTeamAvatars({teamnames}))
+    }
   }, 200)
   getTeam = name => {
     this._teamQueue[name] = true

--- a/shared/common-adapters/avatar.js
+++ b/shared/common-adapters/avatar.js
@@ -102,15 +102,35 @@ const followIconHelper = (size: number, followsYou: boolean, following: boolean)
 
 // We keep one timer for all instances to reduce timer overhead
 class SharedAskForUserData {
+  _cacheTime = 1000 * 60 * 30 // cache for 30 mins
   _dispatch: any => void
   _teamQueue = {}
+  _teamLastReq = {}
   _userQueue = {}
+  _userLastReq = {}
+
   _makeCalls = throttle(() => {
     if (!this._dispatch) {
       return
     }
-    const usernames = Object.keys(this._userQueue)
-    const teamnames = Object.keys(this._teamQueue)
+    const now = Date.now()
+    const oldEnough = now - this._cacheTime
+    const usernames = Object.keys(this._userQueue).filter(k => {
+      const lr = this._userLastReq[k]
+      if (!lr || lr < oldEnough) {
+        this._userLastReq[k] = now
+        return true
+      }
+      return false
+    })
+    const teamnames = Object.keys(this._teamQueue).filter(k => {
+      const lr = this._teamLastReq[k]
+      if (!lr || lr < oldEnough) {
+        this._teamLastReq[k] = now
+        return true
+      }
+      return false
+    })
     this._teamQueue = {}
     this._userQueue = {}
     this._dispatch(ConfigGen.createLoadAvatars({usernames}))
@@ -265,9 +285,6 @@ const mockOwnToViewProps = (
   const url = iconTypeToImgSet(isTeam ? teamPlaceHolders : avatarPlaceHolders, ownProps.size)
 
   const name = isTeam ? ownProps.teamname : ownProps.username
-
-  const setInterval = action('setInterval')
-  const setTimeout = action('setTimeout')
 
   const iconInfo = followIconHelper(
     ownProps.size,

--- a/shared/stories/prop-providers.js
+++ b/shared/stories/prop-providers.js
@@ -3,7 +3,8 @@ import * as _Avatar from '../common-adapters/avatar'
 import * as _Usernames from '../common-adapters/usernames'
 import type {ConnectedProps as _UsernamesConnectedProps} from '../common-adapters/usernames/container'
 import * as _WaitingButton from '../common-adapters/waiting-button'
-import * as _TeamDropdownMenu from '../chat/conversation/info-panel/menu/container'
+import type {OwnProps as TeamDropdownMenuOwnProps} from '../chat/conversation/info-panel/menu/container'
+import type {Props as TeamDropdownMenuProps} from '../chat/conversation/info-panel/menu'
 import * as _CopyText from '../common-adapters/copy-text'
 import type {NameWithIconProps} from '../common-adapters/name-with-icon'
 import type {ConnectedNameWithIconProps} from '../common-adapters/name-with-icon/container'
@@ -59,8 +60,9 @@ export const Avatar = (following: string[] = defaultFollowing, followers: string
 })
 
 export const TeamDropdownMenu = (adminTeams?: string[], teamMemberCounts?: {[key: string]: number}) => ({
-  TeamDropdownMenu: (ownProps: _TeamDropdownMenu.OwnProps): _TeamDropdownMenu.Props => ({
-    _loadOperations: action('_loadOperations'),
+  TeamDropdownMenu: (ownProps: TeamDropdownMenuOwnProps): TeamDropdownMenuProps => ({
+    loadOperations: action('_loadOperations'),
+    hasCanPerform: true,
     attachTo: ownProps.attachTo,
     badgeSubscribe: false,
     canAddPeople: (adminTeams && adminTeams.includes(ownProps.teamname)) || true,


### PR DESCRIPTION
- [x] dont load team operations until info menu opens up
- [x] smarter memoize for inbox small rows
- [x] cache avatars for 30 minutes
- [x] tapping inbox items caused the entire list to rerender