### PR TITLE
Enforce 8 character minimum on *new* and *updated* passphrases.

### DIFF
--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -274,7 +274,7 @@ func TestSignupPassphrases(t *testing.T) {
 	tc := SetupEngineTest(t, "signup")
 	defer tc.Cleanup()
 	CreateAndSignupFakeUserWithPassphrase(tc, "pass", "123456789012")
-	CreateAndSignupFakeUserWithPassphrase(tc, "pass", "123456")
+	CreateAndSignupFakeUserWithPassphrase(tc, "pass", "12345678")
 }
 
 func TestSignupShortPassphrase(t *testing.T) {
@@ -282,7 +282,7 @@ func TestSignupShortPassphrase(t *testing.T) {
 	defer tc.Cleanup()
 
 	fu := NewFakeUserOrBust(t, "sup")
-	fu.Passphrase = "1234"
+	fu.Passphrase = "1234567"
 	uis := libkb.UIs{
 		LogUI:    tc.G.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -568,7 +568,7 @@ const (
 
 const UserSummaryLimit = 500 // max number of user summaries in one request
 
-const MinPassphraseLength = 6
+const MinPassphraseLength = 8
 
 const TrackingRateLimitSeconds = 50
 

--- a/shared/actions/__tests__/signup.test.js
+++ b/shared/actions/__tests__/signup.test.js
@@ -253,7 +253,7 @@ describe('checkPassphrase', () => {
     })
     const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.passphraseError.stringValue()).toEqual(
-      'Passphrase must be at least 6 characters long'
+      'Passphrase must be at least 8 characters long'
     )
   })
   it('passes must have values', () => {

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -71,8 +71,8 @@ export default function(state: Types.State = initialState, action: SignupGen.Act
         passphraseError = new HiddenString('Fields cannot be blank')
       } else if (p1 !== p2) {
         passphraseError = new HiddenString('Passphrases must match')
-      } else if (p1.length < 6) {
-        passphraseError = new HiddenString('Passphrase must be at least 6 characters long')
+      } else if (p1.length < 8) {
+        passphraseError = new HiddenString('Passphrase must be at least 8 characters long')
       }
       return state.merge({
         passphrase: action.payload.pass1,

--- a/shared/settings/passphrase/index.js
+++ b/shared/settings/passphrase/index.js
@@ -50,7 +50,7 @@ class UpdatePassphrase extends Component<Props, State> {
 
   _canSave(passphrase: string, passphraseConfirm: string): boolean {
     const downloadedPGPState = this.props.hasPGPKeyOnServer !== null
-    return downloadedPGPState && passphrase === passphraseConfirm && this.state.passphrase.length >= 6
+    return downloadedPGPState && passphrase === passphraseConfirm && this.state.passphrase.length >= 8
   }
 
   render() {
@@ -77,7 +77,7 @@ class UpdatePassphrase extends Component<Props, State> {
         />
         {!this.props.newPassphraseError && (
           <Text type="BodySmall" style={stylePasswordNote}>
-            (Minimum 6 characters)
+            (Minimum 8 characters)
           </Text>
         )}
         <Input


### PR DESCRIPTION
Not too much work...old 6-char passwords still work fine in both terminal and GUI.

Password strength meters are generally useless in my experience or at worst, mislead users into thinking weak passwords are strong: https://nakedsecurity.sophos.com/2015/03/02/why-you-cant-trust-password-strength-meters/.

Passphrase generation as Thomas suggested might be cool in the GUI. There is the risk of users mixing up paperkeys and passphrases, but if the new signup flow in the GUI doesn't include paperkeys then I think we should add it (in another ticket).