### PR TITLE
fix bug where FilePreviewLoaded overrides loaded into pending

### DIFF
--- a/shared/actions/fs/platform-specific.desktop.js
+++ b/shared/actions/fs/platform-specific.desktop.js
@@ -338,6 +338,9 @@ const loadUserFileEdits = (state: TypedState, action) =>
         )
         .toArray()
       yield Saga.sequentially([
+        // TODO (songgao): make a new action that accepts an array of updates,
+        // so that we only need to trigger one update through store/rpc/widget
+        // for all these each time.
         ...updateSet.map(path => Saga.put(FsGen.createFilePreviewLoad({path}))),
         Saga.put(FsGen.createUserFileEditsLoaded({tlfUpdates})),
       ])

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -28,9 +28,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
       return state.updateIn(['pathItems', action.payload.path], (original: Types.PathItem) => {
         const {meta} = action.payload
         if (original.type === 'folder' && meta.type === 'folder') {
-          const c = coalesceFolderUpdate(original, meta)
-          console.log({songgao: 'coalesce', original, meta, c})
-          return c
+          return coalesceFolderUpdate(original, meta)
         } else if (original.type !== 'file' || meta.type !== 'file') {
           return meta
         }


### PR DESCRIPTION
Otherwise opening widget would override some `FolderPathItem` into pending sometimes, and we'd show placeholders in the Files tab.