### PR TITLE
label deleted PUKless team members as deleted

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -752,19 +752,25 @@ type UIDMapper interface {
 	// hardcoded map.
 	CheckUIDAgainstUsername(uid keybase1.UID, un NormalizedUsername) bool
 
-	// MapUIDToUsernamePackages maps the given set of UIDs to the username packages, which include
-	// a username and a fullname, and when the mapping was loaded from the server. It blocks
-	// on the network until all usernames are known. If the `forceNetworkForFullNames` flag is specified,
-	// it will block on the network too. If the flag is not specified, then stale values (or unknown values)
-	// are OK, we won't go to network if we lack them. All network calls are limited by the given timeBudget,
-	// or if 0 is specified, there is indefinite budget. In the response, a nil FullNamePackage means that the
-	// lookup failed. A non-nil FullNamePackage means that some previous lookup worked, but
-	// might be arbitrarily out of date (depending on the cachedAt time). A non-nil FullNamePackage
-	// with an empty fullName field means that the user just hasn't supplied a fullName.
+	// MapUIDToUsernamePackages maps the given set of UIDs to the username
+	// packages, which include a username and a fullname, and when the mapping
+	// was loaded from the server. It blocks on the network until all usernames
+	// are known. If the `forceNetworkForFullNames` flag is specified, it will
+	// block on the network too. If the flag is not specified, then stale
+	// values (or unknown values) are OK, we won't go to network if we lack
+	// them. All network calls are limited by the given timeBudget, or if 0 is
+	// specified, there is indefinite budget. In the response, a nil
+	// FullNamePackage means that the lookup failed. A non-nil FullNamePackage
+	// means that some previous lookup worked, but might be arbitrarily out of
+	// date (depending on the cachedAt time). A non-nil FullNamePackage with an
+	// empty fullName field means that the user just hasn't supplied a
+	// fullName.
 	//
-	// *NOTE* that this function can return useful data and an error. In this regard, the error is more
-	// like a warning. But if, for instance, the mapper runs out of time budget, it will return the data
-	MapUIDsToUsernamePackages(ctx context.Context, g UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networktimeBudget time.Duration, forceNetworkForFullNames bool) ([]UsernamePackage, error)
+	// *NOTE* that this function can return useful data and an error. In this
+	// regard, the error is more like a warning. But if, for instance, the
+	// mapper runs out of time budget, it will return the data
+	MapUIDsToUsernamePackages(ctx context.Context, g UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration,
+		networktimeBudget time.Duration, forceNetworkForFullNames bool) ([]UsernamePackage, error)
 
 	// SetTestingNoCachingMode puts the UID mapper into a mode where it never serves cached results, *strictly
 	// for use in tests*

--- a/go/teams/constants.go
+++ b/go/teams/constants.go
@@ -1,0 +1,8 @@
+package teams
+
+import "time"
+
+// Default values for the UIDMapper. See comments in libkb/interfaces.go for
+// MapUIDsToUsernamePackages
+const defaultFullnameFreshness = 10 * time.Minute
+const defaultNetworkTimeBudget = 0

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -115,7 +115,8 @@ func userVersionsToDetails(ctx context.Context, g *libkb.GlobalContext, uvs []ke
 	for i, uv := range uvs {
 		uids[i] = uv.Uid
 	}
-	packages, err := g.UIDMapper.MapUIDsToUsernamePackages(ctx, g, uids, 10*time.Minute, 0, true)
+	packages, err := g.UIDMapper.MapUIDsToUsernamePackages(ctx, g, uids,
+		defaultFullnameFreshness, defaultNetworkTimeBudget, true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -339,23 +339,29 @@ func (u *UIDMap) InformOfEldestSeqno(ctx context.Context, g libkb.UIDMapperConte
 	return isCurrent, nil
 }
 
-// MapUIDsToUsernamePackages maps the given set of UIDs to the username packages, which include
-// a username and a fullname, and when the mapping was loaded from the server. It blocks
-// on the network until all usernames are known. If the `forceNetworkForFullNames` flag is specified,
-// it will block on the network too. If the flag is not specified, then stale values (or unknown values)
-// are OK, we won't go to network if we lack them. All network calls are limited by the given timeBudget,
-// or if 0 is specified, there is indefinite budget. In the response, a nil FullNamePackage means that the
-// lookup failed. A non-nil FullNamePackage means that some previous lookup worked, but
-// might be arbitrarily out of date (depending on the cachedAt time). A non-nil FullNamePackage
-// with an empty fullName field means that the user just hasn't supplied a fullName.
-// FullNames can be cached bt the UIDMap, but expire after networkTimeBudget duration. If that value
-// is 0, then infinitely stale names are allowed. If non-zero, and some names aren't stale, we'll
-// have to go to the network.
+// MapUIDsToUsernamePackages maps the given set of UIDs to the username
+// packages, which include a username and a fullname, and when the mapping was
+// loaded from the server. It blocks on the network until all usernames are
+// known. If the `forceNetworkForFullNames` flag is specified, it will block on
+// the network too. If the flag is not specified, then stale values (or unknown
+// values) are OK, we won't go to network if we lack them. All network calls
+// are limited by the given timeBudget, or if 0 is specified, there is
+// indefinite budget. In the response, a nil FullNamePackage means that the
+// lookup failed. A non-nil FullNamePackage means that some previous lookup
+// worked, but might be arbitrarily out of date (depending on the cachedAt
+// time). A non-nil FullNamePackage with an empty fullName field means that the
+// user just hasn't supplied a fullName.  FullNames can be cached bt the
+// UIDMap, but expire after networkTimeBudget duration. If that value is 0,
+// then infinitely stale names are allowed. If non-zero, and some names aren't
+// stale, we'll have to go to the network.
 //
-// *NOTE* that this function can return useful data and an error. In this regard, the error is more
-// like a warning. But if, for instance, the mapper runs out of time budget, it will return the data
-// it was able to get, and also the error.
-func (u *UIDMap) MapUIDsToUsernamePackages(ctx context.Context, g libkb.UIDMapperContext, uids []keybase1.UID, fullNameFreshness time.Duration, networkTimeBudget time.Duration, forceNetworkForFullNames bool) (res []libkb.UsernamePackage, err error) {
+// *NOTE* that this function can return useful data and an error. In this
+// regard, the error is more like a warning. But if, for instance, the mapper
+// runs out of time budget, it will return the data it was able to get, and
+// also the error.
+func (u *UIDMap) MapUIDsToUsernamePackages(ctx context.Context, g libkb.UIDMapperContext,
+	uids []keybase1.UID, fullNameFreshness, networkTimeBudget time.Duration,
+	forceNetworkForFullNames bool) (res []libkb.UsernamePackage, err error) {
 	defer libkb.CTrace(ctx, g.GetLog(), fmt.Sprintf("MapUIDsToUserPackages(%s)", uidsToStringForLog(uids)), func() error { return err })()
 
 	u.Lock()


### PR DESCRIPTION
if you had a deleted pukless member in a team it would not be correctly labeled as `deleted` since `fullNameFreshness=0`  was being passed in. this PR sets a default `fullNameFreshness` throughout the `teams` package and removes an old check for non showing inactive pukless members. verified manually through the UI and cli that the number of team members and status are consistent and accurate