### PR TITLE
Reorder keybases.framework for xcode to build

### DIFF
--- a/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -523,6 +523,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB0846051BA75DC800F54960 /* keybase.framework in Frameworks */,
 				DB788EF32152F47400699A23 /* libRNCamera.a in Frameworks */,
 				DB5E9BB2212A0CAC00F903B3 /* libRNFetchBlob.a in Frameworks */,
 				3791A8A320C71FE6001C2E86 /* UserNotifications.framework in Frameworks */,
@@ -539,7 +540,6 @@
 				DB2BD1EB1DE7D9A600BB7989 /* libRCTSettings.a in Frameworks */,
 				DB2BD1EC1DE7D9A600BB7989 /* libRCTText.a in Frameworks */,
 				DB2BD1EF1DE7D9A600BB7989 /* libReact.a in Frameworks */,
-				DB0846051BA75DC800F54960 /* keybase.framework in Frameworks */,
 				A9BB30DF1E6A274900E713E5 /* libRCTCameraRoll.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
@keybase/react-hackers this fixes my issue with the linker not finding symbols for x86_64