### PR TITLE
Fix bugs surrounding deleted users and pairwise macs

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -694,7 +694,15 @@ func (b *Boxer) validatePairwiseMAC(ctx context.Context, boxed chat1.MessageBoxe
 	}
 	senderEncryptionKID := senderUPAK.Current.FindEncryptionKIDFromDeviceID(senderDeviceID)
 	if senderEncryptionKID.IsNil() {
-		return nil, fmt.Errorf("failed to find encryption key for device %s", senderDeviceID.String())
+		for _, upk := range senderUPAK.PastIncarnations {
+			senderEncryptionKID = upk.FindEncryptionKIDFromDeviceID(senderDeviceID)
+			if !senderEncryptionKID.IsNil() {
+				break
+			}
+		}
+		if senderEncryptionKID.IsNil() {
+			return nil, fmt.Errorf("failed to find encryption key for device %s", senderDeviceID.String())
+		}
 	}
 	senderDeviceDHKeyNacl, err := libkb.ImportDHKeypairFromKID(senderEncryptionKID)
 	if err != nil {

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -1381,6 +1381,11 @@ func TestPairwiseMACChecker(t *testing.T) {
 		msg.ClientHeader.EphemeralMetadata = ephemeralMetadata
 		_, _, err = blockingSender1.Send(ctx1, conv.Id, msg, 0, nil)
 		require.NoError(t, err)
+		select {
+		case <-listener1.newMessageRemote:
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no new message")
+		}
 
 		// send from user2
 		text2 := "hi2"

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -1295,9 +1295,14 @@ func TestPairwiseMACChecker(t *testing.T) {
 		defer ctc.cleanup()
 		users := ctc.users()
 
+		ephemeralMetadata := &chat1.MsgEphemeralMetadata{
+			Lifetime: 100000,
+		}
+
 		firstConv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt, users[1])
-		ctx := ctc.as(t, users[0]).startCtx
-		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
+		ctx1 := ctc.as(t, users[0]).startCtx
+		ctx2 := ctc.as(t, users[1]).startCtx
+		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx1,
 			chat1.NewConversationLocalArg{
 				TlfName:       firstConv.TlfName,
 				TopicType:     chat1.TopicType_CHAT,
@@ -1307,36 +1312,44 @@ func TestPairwiseMACChecker(t *testing.T) {
 		require.NoError(t, err)
 		conv := ncres.Conv.Info
 
-		tc := ctc.world.Tcs[users[0].Username]
+		tc1 := ctc.world.Tcs[users[0].Username]
+		tc2 := ctc.world.Tcs[users[1].Username]
+		require.NoError(t, tc1.G.GetEKLib().KeygenIfNeeded(ctx1))
+		require.NoError(t, tc2.G.GetEKLib().KeygenIfNeeded(ctx2))
 		uid1 := users[0].User.GetUID()
 		uid2 := users[1].User.GetUID()
-		ri := ctc.as(t, users[0]).ri
-		boxer := NewBoxer(tc.Context())
-		getRI := func() chat1.RemoteInterface { return ri }
-		g := globals.NewContext(tc.G, tc.ChatG)
-		blockingSender := NewBlockingSender(g, boxer, getRI)
+		ri1 := ctc.as(t, users[0]).ri
+		getRI1 := func() chat1.RemoteInterface { return ri1 }
+		ri2 := ctc.as(t, users[1]).ri
+		getRI2 := func() chat1.RemoteInterface { return ri2 }
+		boxer1 := NewBoxer(tc1.Context())
+		boxer2 := NewBoxer(tc2.Context())
+		g1 := globals.NewContext(tc1.G, tc1.ChatG)
+		g2 := globals.NewContext(tc2.G, tc2.ChatG)
+		blockingSender1 := NewBlockingSender(g1, boxer1, getRI1)
+		blockingSender2 := NewBlockingSender(g2, boxer2, getRI2)
 
 		text := "hi"
 		msg := textMsgWithSender(t, text, uid1.ToBytes(), chat1.MessageBoxedVersion_V3)
 		// Pairwise MACs rely on the sender's DeviceID in the header.
-		deviceID := make([]byte, libkb.DeviceIDLen)
-		err = tc.G.ActiveDevice.DeviceID().ToBytes(deviceID)
+		deviceID1 := make([]byte, libkb.DeviceIDLen)
+		err = tc1.G.ActiveDevice.DeviceID().ToBytes(deviceID1)
 		require.NoError(t, err)
 		msg.ClientHeader.TlfName = firstConv.TlfName
-		msg.ClientHeader.SenderDevice = gregor1.DeviceID(deviceID)
+		msg.ClientHeader.SenderDevice = gregor1.DeviceID(deviceID1)
 
 		key := cryptKey(t)
-		signKP := getSigningKeyPairForTest(t, tc, users[0])
-		encryptionKeypair, err := tc.G.ActiveDevice.NaclEncryptionKey()
+		signKP := getSigningKeyPairForTest(t, tc1, users[0])
+		encryptionKeypair, err := tc1.G.ActiveDevice.NaclEncryptionKey()
 		require.NoError(t, err)
 
 		// Missing recipients uid2
 		pairwiseMACRecipients := []keybase1.KID{encryptionKeypair.GetKID()}
 
-		boxed, err := boxer.box(context.TODO(), msg, key, nil, signKP, chat1.MessageBoxedVersion_V3, pairwiseMACRecipients)
+		boxed, err := boxer1.box(context.TODO(), msg, key, nil, signKP, chat1.MessageBoxedVersion_V3, pairwiseMACRecipients)
 		require.NoError(t, err)
 
-		_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
+		_, err = ri1.PostRemote(ctx1, chat1.PostRemoteArg{
 			ConversationID: conv.Id, MessageBoxed: *boxed,
 		})
 		require.Error(t, err)
@@ -1346,10 +1359,10 @@ func TestPairwiseMACChecker(t *testing.T) {
 
 		// Bogus recipients, both uids are missing
 		pairwiseMACRecipients = []keybase1.KID{"012141487209e42c6b39f7d9bcbda02a8e8045e4bcab10b571a5fa250ae72012bd3f0a"}
-		boxed, err = boxer.box(context.TODO(), msg, key, nil, signKP, chat1.MessageBoxedVersion_V3, pairwiseMACRecipients)
+		boxed, err = boxer1.box(context.TODO(), msg, key, nil, signKP, chat1.MessageBoxedVersion_V3, pairwiseMACRecipients)
 		require.NoError(t, err)
 
-		_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
+		_, err = ri1.PostRemote(ctx1, chat1.PostRemoteArg{
 			ConversationID: conv.Id,
 			MessageBoxed:   *boxed,
 		})
@@ -1363,15 +1376,55 @@ func TestPairwiseMACChecker(t *testing.T) {
 		require.Equal(t, expectedUIDs, merr.UIDs)
 
 		// Including all devices works
-		_, _, err = blockingSender.Send(ctx, conv.Id, msg, 0, nil)
+		msg.ClientHeader.EphemeralMetadata = ephemeralMetadata
+		_, _, err = blockingSender1.Send(ctx1, conv.Id, msg, 0, nil)
 		require.NoError(t, err)
 
-		tv, err := tc.Context().ConvSource.Pull(ctx, conv.Id, uid1.ToBytes(), chat1.GetThreadReason_GENERAL, nil, nil)
+		// send from user2
+		text2 := "hi2"
+		msg2 := textMsgWithSender(t, text2, uid2.ToBytes(), chat1.MessageBoxedVersion_V3)
+		deviceID2 := make([]byte, libkb.DeviceIDLen)
+		err = tc2.G.ActiveDevice.DeviceID().ToBytes(deviceID2)
 		require.NoError(t, err)
-		require.Len(t, tv.Messages, 2)
-		msgUnboxed := tv.Messages[0]
-		require.True(t, msgUnboxed.IsValid())
-		require.Equal(t, msgUnboxed.Valid().MessageBody.Text().Body, text)
+		msg2.ClientHeader.TlfName = firstConv.TlfName
+		msg2.ClientHeader.SenderDevice = gregor1.DeviceID(deviceID2)
+		msg2.ClientHeader.EphemeralMetadata = ephemeralMetadata
+		_, _, err = blockingSender2.Send(ctx2, conv.Id, msg2, 0, nil)
+		require.NoError(t, err)
+
+		tv, err := tc1.Context().ConvSource.Pull(ctx1, conv.Id, uid1.ToBytes(), chat1.GetThreadReason_GENERAL, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, tv.Messages, 3)
+		for _, msg := range tv.Messages {
+			require.True(t, msg.IsValid())
+		}
+
+		// Delete user2 and ensure user1 can still read/write to the channel
+		kbtest.DeleteAccount(tc2.TestContext, users[1])
+		kbtest.Logout(tc1.TestContext)
+		require.NoError(t, users[0].Login(tc1.G))
+
+		// Nuke caches so we're forced to reload the deleted user
+		tc1.G.LocalDb.Nuke()
+		tc1.G.LocalChatDb.Nuke()
+
+		text3 := "hi3"
+		msg3 := textMsgWithSender(t, text3, uid1.ToBytes(), chat1.MessageBoxedVersion_V3)
+		msg3.ClientHeader.TlfName = firstConv.TlfName
+		msg3.ClientHeader.SenderDevice = gregor1.DeviceID(deviceID1)
+		msg3.ClientHeader.EphemeralMetadata = ephemeralMetadata
+		_, _, err = blockingSender1.Send(ctx1, conv.Id, msg3, 0, nil)
+		require.NoError(t, err)
+
+		tc1.G.LocalDb.Nuke()
+		tc1.G.LocalChatDb.Nuke()
+
+		tv, err = tc1.Context().ConvSource.Pull(ctx1, conv.Id, uid1.ToBytes(), chat1.GetThreadReason_GENERAL, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, tv.Messages, 4)
+		for _, msg := range tv.Messages {
+			require.True(t, msg.IsValid())
+		}
 	})
 }
 

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -437,7 +437,7 @@ func batchLoadEncryptionKIDs(ctx context.Context, g *libkb.GlobalContext, uvs []
 		if i >= len(uvs) {
 			return nil
 		}
-		tmp := libkb.NewLoadUserByUIDArg(ctx, g, uvs[i].Uid)
+		tmp := libkb.NewLoadUserByUIDArg(ctx, g, uvs[i].Uid).WithPublicKeyOptional()
 		return &tmp
 	}
 

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -124,9 +124,7 @@ func createAndSignupFakeUser(prefix string, g *libkb.GlobalContext, skipPaper bo
 func ResetAccount(tc libkb.TestContext, u *FakeUser) {
 	m := libkb.NewMetaContextForTest(tc)
 	err := libkb.ResetAccount(m, u.NormalizedUsername(), u.Passphrase)
-	if err != nil {
-		tc.T.Fatalf("In account reset: %s", err)
-	}
+	require.NoError(tc.T, err)
 	tc.T.Logf("Account reset for user %s", u.Username)
 	Logout(tc)
 }
@@ -134,10 +132,8 @@ func ResetAccount(tc libkb.TestContext, u *FakeUser) {
 func DeleteAccount(tc libkb.TestContext, u *FakeUser) {
 	m := libkb.NewMetaContextForTest(tc)
 	err := libkb.DeleteAccount(m, u.NormalizedUsername(), u.Passphrase)
-	if err != nil {
-		tc.T.Fatalf("In account reset: %s", err)
-	}
-	tc.T.Logf("Account reset for user %s", u.Username)
+	require.NoError(tc.T, err)
+	tc.T.Logf("Account deleted for user %s", u.Username)
 	Logout(tc)
 }
 

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -607,7 +607,7 @@ func (u *CachedUPAKLoader) LoadDeviceKey(ctx context.Context, uid keybase1.UID, 
 // If the user exists but the device doesn't, will force a load in case the device is very new.
 func (u *CachedUPAKLoader) LoadUPAKWithDeviceID(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (*keybase1.UserPlusKeysV2AllIncarnations, error) {
 	var info CachedUserLoadInfo
-	larg := NewLoadUserByUIDArg(ctx, u.G(), uid)
+	larg := NewLoadUserByUIDArg(ctx, u.G(), uid).WithPublicKeyOptional()
 	upakV2, _, err := u.loadWithInfo(larg, &info, nil, false)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
if there was a deleted user in a team using ephemeral messages two bugs could pop up:

- sending would be blocked since we would get `No public key found` error when trying to load the deleted user. fixed by adding `WithPublicKeyOptional` to the load arg
- validating a pairwisemac from a deleted user would fail since the `Current` `UPAK` would be `nil`. fixed by checking previous incarnations for the given sender device id. this would also have failed for validating messages revoked devices 