### PR TITLE
Allow opening the message menu while keyboard is up

### DIFF
--- a/shared/chat/conversation/list-area/normal/index.native.js
+++ b/shared/chat/conversation/list-area/normal/index.native.js
@@ -77,6 +77,7 @@ class ConversationList extends React.PureComponent<Props> {
             getItemCount={this._getItemCount}
             renderItem={this._renderItem}
             onViewableItemsChanged={this._onViewableItemsChanged}
+            keyboardShouldPersistTaps="handled"
             keyExtractor={this._keyExtractor}
             // Limit the number of pages rendered ahead of time (which also limits attachment previews loaded)
             windowSize={5}

--- a/shared/chat/conversation/messages/wrapper/wrapper-timestamp/index.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-timestamp/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import * as Types from '../../../../../constants/types/chat2'
 import {Box, Box2, Icon, OverlayParentHOC, type OverlayParentProps} from '../../../../../common-adapters'
+import {dismiss as dismissKeyboard} from '../../../../../util/keyboard'
 import Timestamp from '../timestamp'
 import * as Styles from '../../../../../styles'
 import WrapperAuthor from '../wrapper-author/container'
@@ -85,7 +86,11 @@ class _WrapperTimestamp extends React.Component<Props & OverlayParentProps, Stat
         <HoverBox
           className={props.showingMenu || this.state.showingPicker ? 'active' : ''}
           {...(Styles.isMobile && props.decorate
-            ? {onLongPress: props.toggleShowingMenu, underlayColor: Styles.globalColors.blue5}
+            ? {
+                onPress: () => dismissKeyboard(),
+                onLongPress: props.toggleShowingMenu,
+                underlayColor: Styles.globalColors.blue5,
+              }
             : {})}
           direction="column"
           decorate={props.decorate}

--- a/shared/common-adapters/overlay/index.native.js
+++ b/shared/common-adapters/overlay/index.native.js
@@ -5,10 +5,15 @@ import {Box, Box2} from '../box'
 import FloatingBox from '../floating-box'
 import type {Props} from '.'
 import {collapseStyles, globalColors, globalStyles, styleSheetCreate} from '../../styles'
+import {dismiss as dismissKeyboard, isOpen as isKeyboardOpen} from '../../util/keyboard'
 
 const Overlay = (props: Props) => {
   if (props.hasOwnProperty('visible') && !props.visible) {
     return null
+  }
+  if (isKeyboardOpen()) {
+    // Keyboard will cover up the overlay; need to hide
+    dismissKeyboard()
   }
   return (
     <FloatingBox onHidden={() => {}}>

--- a/shared/util/keyboard.desktop.js
+++ b/shared/util/keyboard.desktop.js
@@ -1,0 +1,4 @@
+// @flow
+const dismiss = () => {}
+const isOpen = () => false
+export {dismiss, isOpen}

--- a/shared/util/keyboard.js.flow
+++ b/shared/util/keyboard.js.flow
@@ -1,0 +1,5 @@
+// @flow
+
+declare var dismiss: () => void
+declare var isOpen: () => boolean
+export {dismiss, isOpen}

--- a/shared/util/keyboard.native.js
+++ b/shared/util/keyboard.native.js
@@ -1,0 +1,11 @@
+// @flow
+import {Keyboard} from 'react-native'
+import {isIOS} from '../constants/platform'
+
+let open = false
+Keyboard.addListener(isIOS ? 'keyboardWillShow' : 'keyboardDidShow', () => (open = true))
+Keyboard.addListener(isIOS ? 'keyboardWillHide' : 'keyboardDidHide', () => (open = false))
+
+const isOpen = () => open
+const dismiss = Keyboard.dismiss
+export {dismiss, isOpen}


### PR DESCRIPTION
1. Keyboard will stay up if a list area child handles the touch event
2. Overlay will dismiss the keyboard if it notices it's open when trying to render
3. Message will dismiss the keyboard when it's tapped (not long pressed) so it's still easy to get back to full screen view
4. Long pressing a message will open the message menu, triggering the keyboard dismissal

r? @keybase/react-hackers 