### PR TITLE
tweaks to ephemeral background purger

### DIFF
--- a/go/chat/ephemeral_purger.go
+++ b/go/chat/ephemeral_purger.go
@@ -207,6 +207,7 @@ func (b *BackgroundEphemeralPurger) Queue(ctx context.Context, purgeInfo chat1.E
 	// Sanity check to force our timer to fire if it hasn't for some reason.
 	head = b.pq.Peek()
 	if head.purgeInfo.NextPurgeTime.Time().Before(b.clock.Now()) {
+		b.Debug(ctx, "Queue resetting timer, head is in the past.")
 		b.resetTimer(ctx, head.purgeInfo)
 	}
 	return nil

--- a/go/chat/ephemeral_purger.go
+++ b/go/chat/ephemeral_purger.go
@@ -200,8 +200,15 @@ func (b *BackgroundEphemeralPurger) Queue(ctx context.Context, purgeInfo chat1.E
 	if head == nil || purgeInfo.NextPurgeTime < head.purgeInfo.NextPurgeTime {
 		b.resetTimer(ctx, purgeInfo)
 	}
-	b.Debug(ctx, "Queue purgeInfo: %v, head: %v, looping: %v, len(queue): %v", purgeInfo, head, b.looping, len(b.pq.queue))
 	b.updateQueue(purgeInfo)
+	b.Debug(ctx, "Queue purgeInfo: %v, head: %+v, looping: %v, len(queue): %v",
+		purgeInfo, head, b.looping, len(b.pq.queue))
+
+	// Sanity check to force our timer to fire if it hasn't for some reason.
+	head = b.pq.Peek()
+	if head.purgeInfo.NextPurgeTime.Time().Before(b.clock.Now()) {
+		b.resetTimer(ctx, head.purgeInfo)
+	}
 	return nil
 }
 
@@ -212,6 +219,8 @@ func (b *BackgroundEphemeralPurger) initQueue(ctx context.Context) {
 
 	// Create a new queue
 	b.pq = newPriorityQueue()
+	heap.Init(b.pq)
+
 	allPurgeInfo, err := b.storage.GetAllPurgeInfo(ctx, b.uid)
 	if err != nil {
 		b.Debug(ctx, "unable to get purgeInfo: %v", allPurgeInfo)


### PR DESCRIPTION
user reported UI did not update after an ephemeral message expired. from the logs it appears that the head of the queue had time set in the past so new additions would not trigger the timer to get reset (https://github.com/keybase/client/compare/joshblum/purge-fixes?expand=1#diff-e3fe9d345d5518b5e356d901f79c6851R201). i'm not able to reproduce the problem locally but am hoping that this fix can help get users unstuck if they get into this situation in the future