### PR TITLE
Factor out fetching display currency settings

### DIFF
--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -498,6 +498,9 @@ type accountCurrencyResult struct {
 }
 
 func GetAccountDisplayCurrency(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.AccountID) (string, error) {
+	// NOTE: If you are calling this, you might want to call
+	// stellar.GetAccountDisplayCurrency instead which checks for
+	// NULLs and returns a sane default ("USD").
 	apiArg := libkb.APIArg{
 		Endpoint:    "stellar/accountcurrency",
 		SessionType: libkb.APISessionTypeREQUIRED,

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -25,6 +25,7 @@ import (
 )
 
 const AccountNameMaxRunes = 24
+const DefaultCurrencySetting = "USD"
 
 // CreateWallet creates and posts an initial stellar bundle for a user.
 // Only succeeds if they do not already have one.
@@ -64,7 +65,7 @@ func CreateWallet(ctx context.Context, g *libkb.GlobalContext) (created bool, er
 		g.Log.CErrorf(ctx, "We've just posted a bundle that's missing PrimaryAccount: %s", err)
 		return false, err
 	}
-	if err := remote.SetAccountDefaultCurrency(ctx, g, primary.AccountID, "USD"); err != nil {
+	if err := remote.SetAccountDefaultCurrency(ctx, g, primary.AccountID, DefaultCurrencySetting); err != nil {
 		g.Log.CWarningf(ctx, "Error during setting display currency for %q: %s", primary.AccountID, err)
 	}
 	getGlobal(g).InformHasWallet(ctx, meUV)
@@ -1110,8 +1111,6 @@ func DeleteAccount(m libkb.MetaContext, accountID stellar1.AccountID) error {
 	return remote.Post(m.Ctx(), m.G(), nextBundle)
 }
 
-const defaultCurrencySetting = "USD"
-
 // GetAccountDisplayCurrency gets currency setting from the server, and it
 // returned currency is empty (NULL in database), then default "USD" is used.
 // When creating a wallet, client always sets default currency setting. Also
@@ -1125,7 +1124,7 @@ func GetAccountDisplayCurrency(mctx libkb.MetaContext, accountID stellar1.Accoun
 		return res, err
 	}
 	if codeStr == "" {
-		codeStr = defaultCurrencySetting
+		codeStr = DefaultCurrencySetting
 		mctx.CDebugf("Using default display currency %s for account %s", codeStr, accountID)
 	}
 	return codeStr, nil

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -25,7 +25,6 @@ import (
 )
 
 const AccountNameMaxRunes = 24
-const DefaultCurrencySetting = "USD"
 
 // CreateWallet creates and posts an initial stellar bundle for a user.
 // Only succeeds if they do not already have one.
@@ -59,14 +58,6 @@ func CreateWallet(ctx context.Context, g *libkb.GlobalContext) (created bool, er
 		return false, err
 	default:
 		return false, err
-	}
-	primary, err := clearBundle.PrimaryAccount()
-	if err != nil {
-		g.Log.CErrorf(ctx, "We've just posted a bundle that's missing PrimaryAccount: %s", err)
-		return false, err
-	}
-	if err := remote.SetAccountDefaultCurrency(ctx, g, primary.AccountID, DefaultCurrencySetting); err != nil {
-		g.Log.CWarningf(ctx, "Error during setting display currency for %q: %s", primary.AccountID, err)
 	}
 	getGlobal(g).InformHasWallet(ctx, meUV)
 	return true, nil
@@ -1110,6 +1101,8 @@ func DeleteAccount(m libkb.MetaContext, accountID stellar1.AccountID) error {
 	}
 	return remote.Post(m.Ctx(), m.G(), nextBundle)
 }
+
+const DefaultCurrencySetting = "USD"
 
 // GetAccountDisplayCurrency gets currency setting from the server, and it
 // returned currency is empty (NULL in database), then default "USD" is used.

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -121,6 +121,8 @@ func (s *Server) GetAccountAssetsLocal(ctx context.Context, arg stellar1.GetAcco
 		return nil, err
 	}
 
+	mctx := libkb.NewMetaContext(ctx, s.G())
+
 	details, err := s.remoter.Details(ctx, arg.AccountID)
 	if err != nil {
 		s.G().Log.CDebugf(ctx, "remote.Details failed for %q: %s", arg.AccountID, err)
@@ -138,15 +140,11 @@ func (s *Server) GetAccountAssetsLocal(ctx context.Context, arg stellar1.GetAcco
 		}
 	}
 
-	displayCurrency, err := remote.GetAccountDisplayCurrency(ctx, s.G(), arg.AccountID)
+	displayCurrency, err := stellar.GetAccountDisplayCurrency(mctx, arg.AccountID)
 	if err != nil {
 		return nil, err
 	}
 	s.G().Log.CDebugf(ctx, "Display currency for account %q is %q", arg.AccountID, displayCurrency)
-	if displayCurrency == "" {
-		displayCurrency = defaultOutsideCurrency
-		s.G().Log.CDebugf(ctx, "Using default display currency %s for account %s", displayCurrency, arg.AccountID)
-	}
 	rate, rateErr := s.remoter.ExchangeRate(ctx, displayCurrency)
 	if rateErr != nil {
 		s.G().Log.CDebugf(ctx, "exchange rate error: %s", rateErr)

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -300,26 +300,19 @@ func (s *Server) SetDisplayCurrency(ctx context.Context, arg stellar1.SetDisplay
 
 type exchangeRateMap map[string]stellar1.OutsideExchangeRate
 
-const defaultOutsideCurrency = "USD"
-
 // getLocalCurrencyAndExchangeRate gets display currency setting
 // for accountID and fetches exchange rate is set.
 //
 // Arguments `account` and `exchangeRates` may end up mutated.
-func getLocalCurrencyAndExchangeRate(ctx context.Context, g *libkb.GlobalContext, remoter remote.Remoter, account *stellar1.OwnAccountCLILocal, exchangeRates exchangeRateMap) error {
-	displayCurrency, err := remote.GetAccountDisplayCurrency(ctx, g, account.AccountID)
+func getLocalCurrencyAndExchangeRate(mctx libkb.MetaContext, remoter remote.Remoter, account *stellar1.OwnAccountCLILocal, exchangeRates exchangeRateMap) error {
+	displayCurrency, err := stellar.GetAccountDisplayCurrency(mctx, account.AccountID)
 	if err != nil {
 		return err
-	}
-	if displayCurrency == "" {
-		displayCurrency = defaultOutsideCurrency
-		g.Log.CDebugf(ctx, "Using default display currency %s for account %s",
-			displayCurrency, account.AccountID)
 	}
 	rate, ok := exchangeRates[displayCurrency]
 	if !ok {
 		var err error
-		rate, err = remoter.ExchangeRate(ctx, displayCurrency)
+		rate, err = remoter.ExchangeRate(mctx.Ctx(), displayCurrency)
 		if err != nil {
 			return err
 		}
@@ -339,6 +332,8 @@ func (s *Server) WalletGetAccountsCLILocal(ctx context.Context) (ret []stellar1.
 	if err != nil {
 		return ret, err
 	}
+
+	mctx := libkb.NewMetaContext(ctx, s.G())
 
 	currentBundle, _, err := remote.Fetch(ctx, s.G())
 	if err != nil {
@@ -364,7 +359,7 @@ func (s *Server) WalletGetAccountsCLILocal(ctx context.Context) (ret []stellar1.
 
 		acc.Balance = balances
 
-		if err := getLocalCurrencyAndExchangeRate(ctx, s.G(), s.remoter, &acc, exchangeRates); err != nil {
+		if err := getLocalCurrencyAndExchangeRate(mctx, s.remoter, &acc, exchangeRates); err != nil {
 			s.G().Log.Warning("Could not load local currency exchange rate for %q", accID)
 		}
 

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -653,10 +653,10 @@ func TestGetAvailableCurrencies(t *testing.T) {
 }
 
 func TestDefaultCurrency(t *testing.T) {
-	// Initial account should be created with display currency set
-	// according to system locale/region. Additional accounts display
-	// currencies should be set to primary account currency (and can
-	// later be changed by the user).
+	// Initial account are created without display currency. When an account
+	// has no currency selected, default "USD" is used. Additional accounts
+	// display currencies should be set to primary account currency or NULL as
+	// well (and can later be changed by the user).
 
 	tcs, cleanup := setupNTests(t, 1)
 	defer cleanup()
@@ -668,7 +668,13 @@ func TestDefaultCurrency(t *testing.T) {
 	primary := getPrimaryAccountID(tcs[0])
 	currency, err := remote.GetAccountDisplayCurrency(context.Background(), tcs[0].G, primary)
 	require.NoError(t, err)
-	require.EqualValues(t, "USD", currency)
+	require.EqualValues(t, "", currency)
+
+	// stellar.GetAccountDisplayCurrency also checks for NULLs and returns
+	// default currency code.
+	codeStr, err := stellar.GetAccountDisplayCurrency(tcs[0].MetaContext(), primary)
+	require.NoError(t, err)
+	require.Equal(t, "USD", codeStr)
 
 	err = tcs[0].Srv.SetDisplayCurrency(context.Background(), stellar1.SetDisplayCurrencyArg{
 		AccountID: primary,

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -298,7 +298,7 @@ func TestGetWalletAccountsCLILocal(t *testing.T) {
 	require.Equal(t, account.Balance[0].Amount, "0")
 	require.True(t, account.IsPrimary)
 	require.NotNil(t, account.ExchangeRate)
-	require.EqualValues(t, defaultOutsideCurrency, account.ExchangeRate.Currency)
+	require.EqualValues(t, stellar.DefaultCurrencySetting, account.ExchangeRate.Currency)
 }
 
 func TestSendLocalStellarAddress(t *testing.T) {


### PR DESCRIPTION
`stellar.GetAccountDisplayCurrency` will fetch current display currency for accountID, but return "USD" if fetched currency is NULL. This has been done manually in two places and forgotten to be done in one.