### PR TITLE
use latest summary for conv name, and store convlocal name in local metadata CORE-9037

### DIFF
--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const inboxVersion = 21
+const inboxVersion = 22
 
 type queryHash []byte
 
@@ -317,6 +317,7 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, uid gregor1.UID, convs [
 			topicName := utils.GetTopicName(convLocal)
 			snippet, snippetDecoration := utils.GetConvSnippet(convLocal, i.G().GetEnv().GetUsername().String())
 			rcm := &types.RemoteConversationMetadata{
+				Name:              convLocal.Info.TlfName,
 				TopicName:         topicName,
 				Headline:          utils.GetHeadline(convLocal),
 				Snippet:           snippet,

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -317,7 +317,7 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, uid gregor1.UID, convs [
 			topicName := utils.GetTopicName(convLocal)
 			snippet, snippetDecoration := utils.GetConvSnippet(convLocal, i.G().GetEnv().GetUsername().String())
 			rcm := &types.RemoteConversationMetadata{
-				Name:              convLocal.Info.TlfName,
+				Name:              convLocal.Info.TLFNameExpanded(),
 				TopicName:         topicName,
 				Headline:          utils.GetHeadline(convLocal),
 				Snippet:           snippet,

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -317,7 +317,7 @@ func (i *Inbox) MergeLocalMetadata(ctx context.Context, uid gregor1.UID, convs [
 			topicName := utils.GetTopicName(convLocal)
 			snippet, snippetDecoration := utils.GetConvSnippet(convLocal, i.G().GetEnv().GetUsername().String())
 			rcm := &types.RemoteConversationMetadata{
-				Name:              convLocal.Info.TLFNameExpanded(),
+				Name:              convLocal.Info.TlfName,
 				TopicName:         topicName,
 				Headline:          utils.GetHeadline(convLocal),
 				Snippet:           snippet,

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -70,6 +70,7 @@ func (m MembershipUpdateRes) AllOtherUsers() (res []gregor1.UID) {
 }
 
 type RemoteConversationMetadata struct {
+	Name              string   `codec:"n"`
 	TopicName         string   `codec:"t"`
 	Snippet           string   `codec:"s"`
 	SnippetDecoration string   `codec:"d"`

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -918,7 +918,7 @@ func PresentRemoteConversation(rc types.RemoteConversation) (res chat1.Unverifie
 	if err != nil {
 		tlfName = ""
 	} else {
-		tlfName = latest.TLFNameExpanded(rawConv.GetFinalizeInfo())
+		tlfName = latest.TlfName
 	}
 	res.ConvID = rawConv.GetConvID().String()
 	res.TopicType = rawConv.GetTopicType()

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -731,6 +731,25 @@ func GetConvMtime(conv chat1.Conversation) gregor1.Time {
 	return summaries[len(summaries)-1].Ctime
 }
 
+func PickLatestMessageSummary(conv chat1.Conversation, typs []chat1.MessageType) (res chat1.MessageSummary, err error) {
+	// nil means all
+	if typs == nil {
+		for typ := range chat1.MessageTypeRevMap {
+			typs = append(typs, typ)
+		}
+	}
+	for _, typ := range typs {
+		msg, err := conv.GetMaxMessage(typ)
+		if err == nil && msg.Ctime.After(res.Ctime) {
+			res = msg
+		}
+	}
+	if res.GetMessageID() == 0 {
+		return res, errors.New("no message summary found")
+	}
+	return res, nil
+}
+
 // PickLatestMessageUnboxed gets the latest message with one `typs`.
 // This method can return deleted messages which have a blank body.
 func PickLatestMessageUnboxed(conv chat1.ConversationLocal, typs []chat1.MessageType) (res chat1.MessageUnboxed, err error) {
@@ -893,10 +912,17 @@ func GetDesktopNotificationSnippet(conv *chat1.ConversationLocal, currentUsernam
 }
 
 func PresentRemoteConversation(rc types.RemoteConversation) (res chat1.UnverifiedInboxUIItem) {
+	var tlfName string
 	rawConv := rc.Conv
+	latest, err := PickLatestMessageSummary(rawConv, nil)
+	if err != nil {
+		tlfName = ""
+	} else {
+		tlfName = latest.TLFNameExpanded(rawConv.GetFinalizeInfo())
+	}
 	res.ConvID = rawConv.GetConvID().String()
 	res.TopicType = rawConv.GetTopicType()
-	res.Name = rawConv.MaxMsgSummaries[0].TlfName
+	res.Name = tlfName
 	res.Status = rawConv.Metadata.Status
 	res.Time = GetConvMtime(rawConv)
 	res.Visibility = rawConv.Metadata.Visibility

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -945,6 +945,7 @@ func PresentRemoteConversation(rc types.RemoteConversation) (res chat1.Unverifie
 			WriterNames:       rc.LocalMetadata.WriterNames,
 			ResetParticipants: rc.LocalMetadata.ResetParticipants,
 		}
+		res.Name = rc.LocalMetadata.Name
 	}
 	return res
 }


### PR DESCRIPTION
Patch does the following:

1.) Select the most recent max msg summary when presenting the name from max msgs.
2.) Store the name from unboxing in `Inbox` local metadata. 