### PR TITLE
Stellar: support Federated addresses in UI

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -26,7 +26,9 @@ const buildPayment = (state: TypedState, action: any) =>
     publicMemo: state.wallets.buildingPayment.publicMemo.stringValue(),
     secretNote: state.wallets.buildingPayment.secretNote.stringValue(),
     to: state.wallets.buildingPayment.to,
-    toIsAccountID: state.wallets.buildingPayment.recipientType !== 'keybaseUser',
+    toIsAccountID:
+      state.wallets.buildingPayment.recipientType !== 'keybaseUser' &&
+      !Constants.isFederatedAddress(state.wallets.buildingPayment.to),
   }).then(build =>
     WalletsGen.createBuiltPaymentReceived({
       build: Constants.buildPaymentResultToBuiltPayment(build),

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -394,6 +394,8 @@ const shortenAccountID = (id: Types.AccountID) => id.substring(0, 8) + '...' + i
 const isAccountLoaded = (state: TypedState, accountID: Types.AccountID) =>
   state.wallets.accountMap.has(accountID)
 
+const isFederatedAddress = (address: ?string) => (address ? address.includes('*') : false)
+
 export {
   accountResultToAccount,
   assetsResultToAssets,
@@ -421,6 +423,7 @@ export {
   getSecretKey,
   getSelectedAccount,
   isAccountLoaded,
+  isFederatedAddress,
   linkExistingWaitingKey,
   loadAccountWaitingKey,
   loadEverythingWaitingKey,

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -7,6 +7,7 @@ import {SelectedEntry, DropdownEntry, DropdownText} from './dropdown'
 import Search from './search'
 import type {Account} from '.'
 import type {CounterpartyType} from '../../../constants/types/wallets'
+import {debounce} from 'lodash-es'
 
 type ToFieldProps = {|
   recipientType: CounterpartyType,
@@ -55,6 +56,10 @@ class ToField extends React.Component<ToFieldProps> {
       }
     }
   }
+
+  _onChangeStellarRecipient = debounce((to: string) => {
+    this.props.onChangeRecipient(to)
+  }, 1e3)
 
   render() {
     let component
@@ -137,7 +142,7 @@ class ToField extends React.Component<ToFieldProps> {
             />
             <Kb.NewInput
               type="text"
-              onChangeText={this.props.onChangeRecipient}
+              onChangeText={this._onChangeStellarRecipient}
               textType="BodySemibold"
               placeholder={'Stellar address'}
               placeholderColor={Styles.globalColors.black_20}

--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -43,9 +43,11 @@ const Header = (props: Props) => (
           <Kb.Text type="BodySmall">Default Keybase account</Kb.Text>
         </Kb.Box2>
       )}
-      <Kb.Box2 direction="horizontal" fullWidth={true} centerChildren={true}>
-        <SmallAccountID accountID={props.accountID} />
-      </Kb.Box2>
+      {props.walletName && (
+        <Kb.Box2 direction="horizontal" fullWidth={true} centerChildren={true}>
+          <SmallAccountID accountID={props.accountID} />
+        </Kb.Box2>
+      )}
     </Kb.Box2>
     <Kb.Box2 direction="horizontal" gap="tiny" centerChildren={true}>
       <SendButton


### PR DESCRIPTION
@keybase/react-hackers 

Core's going to work on intentional support for this in next sprint (so we won't have to care ourselves whether an address is federated, but in the meantime this'll work.

Also add a one second debounce to the to field for Stellar addresses only, since otherwise it's yelling at you about public key length and "invalid recipient" while you type a federated address, and we recently got a flickering "NOACCOUNTID" showing up during wallet load, add a spinner for that.