### PR TITLE
Remove operation ID field

### DIFF
--- a/go/protocol/stellar1/remote.go
+++ b/go/protocol/stellar1/remote.go
@@ -238,7 +238,6 @@ type PaymentSummaryStellar struct {
 	To          AccountID     `codec:"to" json:"to"`
 	Amount      string        `codec:"amount" json:"amount"`
 	Asset       Asset         `codec:"asset" json:"asset"`
-	OperationID uint64        `codec:"operationID" json:"operationID"`
 	Ctime       TimeMs        `codec:"ctime" json:"ctime"`
 	CursorToken string        `codec:"cursorToken" json:"cursorToken"`
 	Unread      bool          `codec:"unread" json:"unread"`
@@ -251,7 +250,6 @@ func (o PaymentSummaryStellar) DeepCopy() PaymentSummaryStellar {
 		To:          o.To.DeepCopy(),
 		Amount:      o.Amount,
 		Asset:       o.Asset.DeepCopy(),
-		OperationID: o.OperationID,
 		Ctime:       o.Ctime.DeepCopy(),
 		CursorToken: o.CursorToken,
 		Unread:      o.Unread,

--- a/protocol/avdl/stellar1/remote.avdl
+++ b/protocol/avdl/stellar1/remote.avdl
@@ -56,7 +56,6 @@ protocol remote {
     AccountID to;
     string amount; // amount of asset
     Asset asset;
-    uint64 operationID;
     TimeMs ctime; // time on the network
     string cursorToken;
     boolean unread;

--- a/protocol/json/stellar1/remote.json
+++ b/protocol/json/stellar1/remote.json
@@ -189,10 +189,6 @@
           "name": "asset"
         },
         {
-          "type": "uint64",
-          "name": "operationID"
-        },
-        {
           "type": "TimeMs",
           "name": "ctime"
         },

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -262,7 +262,7 @@ export type PaymentStrategy =
 export type PaymentSummary = {typ: 1, stellar: ?PaymentSummaryStellar} | {typ: 2, direct: ?PaymentSummaryDirect} | {typ: 3, relay: ?PaymentSummaryRelay}
 export type PaymentSummaryDirect = $ReadOnly<{kbTxID: KeybaseTransactionID, txID: TransactionID, txStatus: TransactionStatus, txErrMsg: String, fromStellar: AccountID, from: Keybase1.UserVersion, fromDeviceID: Keybase1.DeviceID, toStellar: AccountID, to?: ?Keybase1.UserVersion, amount: String, asset: Asset, displayAmount?: ?String, displayCurrency?: ?String, noteB64: String, ctime: TimeMs, rtime: TimeMs, cursorToken: String}>
 export type PaymentSummaryRelay = $ReadOnly<{kbTxID: KeybaseTransactionID, txID: TransactionID, txStatus: TransactionStatus, txErrMsg: String, fromStellar: AccountID, from: Keybase1.UserVersion, fromDeviceID: Keybase1.DeviceID, to?: ?Keybase1.UserVersion, toAssertion: String, relayAccount: AccountID, amount: String, displayAmount?: ?String, displayCurrency?: ?String, ctime: TimeMs, rtime: TimeMs, boxB64: String, teamID: Keybase1.TeamID, claim?: ?ClaimSummary, cursorToken: String}>
-export type PaymentSummaryStellar = $ReadOnly<{txID: TransactionID, from: AccountID, to: AccountID, amount: String, asset: Asset, operationID: Uint64, ctime: TimeMs, cursorToken: String, unread: Boolean}>
+export type PaymentSummaryStellar = $ReadOnly<{txID: TransactionID, from: AccountID, to: AccountID, amount: String, asset: Asset, ctime: TimeMs, cursorToken: String, unread: Boolean}>
 export type PaymentSummaryType =
   | 0 // NONE_0
   | 1 // STELLAR_1


### PR DESCRIPTION
This field is unused. Because of the server switching to `/accounts/💣/transactions` it's no longer easy to get the op ID.

It is now easy to get the op index within the tx, so we could use that in the future if it comes up.