### PR TITLE
Show all channels in chat mention hud

### DIFF
--- a/shared/chat/conversation/input-area/channel-mention-hud/mention-hud-container.js
+++ b/shared/chat/conversation/input-area/channel-mention-hud/mention-hud-container.js
@@ -1,31 +1,38 @@
 // @flow
 import {MentionHud} from '.'
 import {compose, connect, type TypedState, setDisplayName} from '../../../../util/container'
+import * as TeamsGen from '../../../../actions/teams-gen'
 import * as Constants from '../../../../constants/chat2'
+import * as TeamConstants from '../../../../constants/teams'
+import {anyWaiting} from '../../../../constants/waiting'
 
 const mapStateToProps = (state: TypedState, {filter, conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
+  const _teamname = meta.teamname
+  const _channelInfos = TeamConstants.getTeamChannelInfos(state, _teamname)
   return {
-    _metaMap: state.chat2.metaMap,
-    _teamname: meta.teamname,
+    _channelInfos,
+    _teamname,
+    loading: anyWaiting(state, TeamConstants.getChannelsWaitingKey(_teamname)),
   }
 }
 
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  _loadChannels: (teamname: string) => dispatch(TeamsGen.createGetChannels({teamname})),
+})
+
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const channels = stateProps._metaMap.reduce((arr, meta) => {
-    // only if we're in a team
-    if (stateProps._teamname && meta.teamname === stateProps._teamname) {
-      arr.push(meta.channelname)
-    }
-    return arr
-  }, [])
+  const channels = Array.from(stateProps._channelInfos.map(ci => ci.channelname).values())
   return {
     ...ownProps,
     channels,
     filter: ownProps.filter.toLowerCase(),
+    loadChannels: stateProps._teamname ? () => dispatchProps._loadChannels(stateProps._teamname) : null,
+    loading: stateProps.loading,
   }
 }
 
-export default compose(connect(mapStateToProps, () => ({}), mergeProps), setDisplayName('ChannelMentionHud'))(
-  MentionHud
-)
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  setDisplayName('ChannelMentionHud')
+)(MentionHud)


### PR DESCRIPTION
Adds a loading state to the channel mention hud and a call to `TeamsGen.getChannels` on mount if we haven't loaded it before. The teams `teamNameToChannelInfos` doesn't have any cache busting, so this can get out of date if channels are removed/created. I'll make tickets for a notification for this and we can decide how to refresh the data / integrate with this PR. r? @keybase/react-hackers 
![channelhudload](https://user-images.githubusercontent.com/11968340/46298261-9ca50380-c56c-11e8-87a6-3bd1cd773829.gif)
