### PR TITLE
stricter checks for version numbers

### DIFF
--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -184,7 +184,7 @@ func (t SigchainV2Type) TeamAllowStub(role keybase1.TeamRole) bool {
 // OuterLinkV2 is the second version of Keybase sigchain signatures.
 type OuterLinkV2 struct {
 	_struct  bool           `codec:",toarray"`
-	Version  int            `codec:"version"`
+	Version  SigVersion     `codec:"version"`
 	Seqno    keybase1.Seqno `codec:"seqno"`
 	Prev     LinkID         `codec:"prev"`
 	Curr     LinkID         `codec:"curr"`
@@ -279,6 +279,9 @@ func DecodeStubbedOuterLinkV2(b64encoded string) (*OuterLinkV2WithMetadata, erro
 	if err != nil {
 		return nil, err
 	}
+	if !IsEncodedMsgpackArray(payload) {
+		return nil, ChainLinkError{"expected a msgpack array but got leading junk"}
+	}
 	var ol OuterLinkV2
 	if err = MsgpackDecode(&ol, payload); err != nil {
 		return nil, err
@@ -319,6 +322,10 @@ func DecodeOuterLinkV2(armored string) (*OuterLinkV2WithMetadata, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !IsEncodedMsgpackArray(payload) {
+		return nil, ChainLinkError{"expected a msgpack array but got leading junk"}
+	}
+
 	var ol OuterLinkV2
 	if err := MsgpackDecode(&ol, payload); err != nil {
 		return nil, err
@@ -427,7 +434,7 @@ func SigchainV2TypeFromV1TypeTeams(s string) (ret SigchainV2Type, err error) {
 }
 
 func (o OuterLinkV2) AssertFields(
-	version int,
+	version SigVersion,
 	seqno keybase1.Seqno,
 	prev LinkID,
 	curr LinkID,
@@ -463,7 +470,7 @@ func (o OuterLinkV2) AssertFields(
 }
 
 func (o OuterLinkV2) AssertSomeFields(
-	version int,
+	version SigVersion,
 	seqno keybase1.Seqno,
 ) (err error) {
 	mkErr := func(format string, arg ...interface{}) error {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -158,6 +158,9 @@ var CodeSigningProdKIDs = []string{
 var CodeSigningTestKIDs = []string{}
 var CodeSigningStagingKIDs = []string{}
 
+// SigVersion describes how the signature is computed. In signatures v1, the payload is a JSON
+// blob. In Signature V2, it's a Msgpack wrapper that points via SHA256 to the V1 blob.
+// V2 sigs allow for bandwidth-saving eliding of signature bodies that aren't relevant to clients.
 type SigVersion int
 
 const (

--- a/go/libkb/msgpack.go
+++ b/go/libkb/msgpack.go
@@ -35,3 +35,15 @@ func MsgpackDecodeAll(data []byte, handle *codec.MsgpackHandle, out interface{})
 	}
 	return nil
 }
+
+func IsEncodedMsgpackArray(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	b := data[0]
+	return (b >= 0x90 && b <= 0x9f) || b == 0xdc || b == 0xdd
+}
+
+func IsJSONObject(data []byte) bool {
+	return len(data) > 0 && data[0] == '{'
+}

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -545,7 +545,7 @@ func isSubchainStart(m MetaContext, currentLink *ChainLink, prevLink *ChainLink,
 	// v2 sigs were introduced. If either the current or previous sig is v2,
 	// short circuit here. This is important because stubbed links (introduced
 	// with v2) break the eldest_kid check for case 3.
-	if currentLink.unpacked.sigVersion > 1 || prevLink.unpacked.sigVersion > 1 {
+	if currentLink.unpacked.sigVersion > KeybaseSignatureV1 || prevLink.unpacked.sigVersion > KeybaseSignatureV1 {
 		return false, nil
 	}
 	// case 3
@@ -697,7 +697,7 @@ func (sc *SigChain) verifySubchain(m MetaContext, kf KeyFamily, links ChainLinks
 		if _, ok := tcl.(*WalletStellarChainLink); ok {
 			// Assert that wallet chain links are be >= v2.
 			// They must be v2 in order to be stubbable later for privacy.
-			if link.unpacked.sigVersion < 2 {
+			if link.unpacked.sigVersion < KeybaseSignatureV2 {
 				return cached, cki, SigchainV2Required{}
 			}
 			seenInflatedWalletStellarLink = true

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -142,13 +142,13 @@ func (s *SCTeamMember) MarshalJSON() (b []byte, err error) {
 // -------------------------
 
 type SCChainLink struct {
-	Seqno        keybase1.Seqno `json:"seqno"`
-	Sig          string         `json:"sig"`
-	SigV2Payload string         `json:"s2"`
-	Payload      string         `json:"payload_json"` // String containing json of a SCChainLinkPayload
-	UID          keybase1.UID   `json:"uid"`          // UID of the signer
-	EldestSeqno  keybase1.Seqno `json:"eldest_seqno"` // Eldest seqn of the signer
-	Version      int            `json:"version"`
+	Seqno        keybase1.Seqno   `json:"seqno"`
+	Sig          string           `json:"sig"`
+	SigV2Payload string           `json:"s2"`
+	Payload      string           `json:"payload_json"` // String containing json of a SCChainLinkPayload
+	UID          keybase1.UID     `json:"uid"`          // UID of the signer
+	EldestSeqno  keybase1.Seqno   `json:"eldest_seqno"` // Eldest seqn of the signer
+	Version      libkb.SigVersion `json:"version"`
 }
 
 func (link *SCChainLink) UnmarshalPayload() (res SCChainLinkPayload, err error) {
@@ -194,7 +194,7 @@ type SCPayloadBody struct {
 	Key        *SCKeySection       `json:"key,omitempty"`
 	Type       string              `json:"type,omitempty"`
 	MerkleRoot SCMerkleRootSection `json:"merkle_root"`
-	Version    int                 `json:"version"`
+	Version    libkb.SigVersion    `json:"version"`
 
 	Team *SCTeamSection `json:"team,omitempty"`
 }


### PR DESCRIPTION
- check that payload JSON version matches the outer link version for v=2
- check that what is actually signed matches JSON or Msgpack by looking at the first byte