### PR TITLE
improve the attachment save option on mobile CORE-9012

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1500,7 +1500,7 @@ func (h *Server) DownloadFileAttachmentLocal(ctx context.Context, arg chat1.Down
 		}
 		basepath := body.Attachment().Object.Filename
 		basename := path.Base(basepath)
-		f, err := os.OpenFile(filepath.Join(os.TempDir(), basename), os.O_RDWR, 0644)
+		f, err := os.OpenFile(filepath.Join(os.TempDir(), basename), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return res, err
 		}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1108,6 +1108,10 @@ func (r *DownloadAttachmentLocalRes) SetOffline() {
 	r.Offline = true
 }
 
+func (r *DownloadFileAttachmentLocalRes) SetOffline() {
+	r.Offline = true
+}
+
 func (r *FindConversationsLocalRes) SetOffline() {
 	r.Offline = true
 }
@@ -1331,6 +1335,14 @@ func (r *DownloadAttachmentLocalRes) GetRateLimit() []RateLimit {
 }
 
 func (r *DownloadAttachmentLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *DownloadFileAttachmentLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *DownloadFileAttachmentLocalRes) SetRateLimits(rl []RateLimit) {
 	r.RateLimits = rl
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3880,6 +3880,42 @@ func (o DownloadAttachmentLocalRes) DeepCopy() DownloadAttachmentLocalRes {
 	}
 }
 
+type DownloadFileAttachmentLocalRes struct {
+	Filename         string                        `codec:"filename" json:"filename"`
+	Offline          bool                          `codec:"offline" json:"offline"`
+	RateLimits       []RateLimit                   `codec:"rateLimits" json:"rateLimits"`
+	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identifyFailures"`
+}
+
+func (o DownloadFileAttachmentLocalRes) DeepCopy() DownloadFileAttachmentLocalRes {
+	return DownloadFileAttachmentLocalRes{
+		Filename: o.Filename,
+		Offline:  o.Offline,
+		RateLimits: (func(x []RateLimit) []RateLimit {
+			if x == nil {
+				return nil
+			}
+			ret := make([]RateLimit, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.RateLimits),
+		IdentifyFailures: (func(x []keybase1.TLFIdentifyFailure) []keybase1.TLFIdentifyFailure {
+			if x == nil {
+				return nil
+			}
+			ret := make([]keybase1.TLFIdentifyFailure, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.IdentifyFailures),
+	}
+}
+
 type PreviewLocationTyp int
 
 const (
@@ -4711,7 +4747,7 @@ type LocalInterface interface {
 	PostFileAttachmentMessageLocalNonblock(context.Context, PostFileAttachmentMessageLocalNonblockArg) (PostLocalNonblockRes, error)
 	PostFileAttachmentUploadLocalNonblock(context.Context, PostFileAttachmentUploadLocalNonblockArg) error
 	DownloadAttachmentLocal(context.Context, DownloadAttachmentLocalArg) (DownloadAttachmentLocalRes, error)
-	DownloadFileAttachmentLocal(context.Context, DownloadFileAttachmentLocalArg) (DownloadAttachmentLocalRes, error)
+	DownloadFileAttachmentLocal(context.Context, DownloadFileAttachmentLocalArg) (DownloadFileAttachmentLocalRes, error)
 	MakePreview(context.Context, MakePreviewArg) (MakePreviewRes, error)
 	CancelPost(context.Context, OutboxID) error
 	RetryPost(context.Context, RetryPostArg) error
@@ -5746,7 +5782,7 @@ func (c LocalClient) DownloadAttachmentLocal(ctx context.Context, __arg Download
 	return
 }
 
-func (c LocalClient) DownloadFileAttachmentLocal(ctx context.Context, __arg DownloadFileAttachmentLocalArg) (res DownloadAttachmentLocalRes, err error) {
+func (c LocalClient) DownloadFileAttachmentLocal(ctx context.Context, __arg DownloadFileAttachmentLocalArg) (res DownloadFileAttachmentLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.DownloadFileAttachmentLocal", []interface{}{__arg}, &res)
 	return
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -795,8 +795,14 @@ protocol local {
 
   // Download an attachment from a message into a local file.
   // Filename must be writable by the service.
+  record DownloadFileAttachmentLocalRes {
+    string filename;
+    boolean offline;
+    array<RateLimit> rateLimits;
+    array<keybase1.TLFIdentifyFailure> identifyFailures;
+  }
   @lint("ignore")
-  DownloadAttachmentLocalRes DownloadFileAttachmentLocal(int sessionID, ConversationID conversationID, MessageID messageID, string filename, boolean preview, keybase1.TLFIdentifyBehavior identifyBehavior);
+  DownloadFileAttachmentLocalRes DownloadFileAttachmentLocal(int sessionID, ConversationID conversationID, MessageID messageID, string filename, boolean preview, keybase1.TLFIdentifyBehavior identifyBehavior);
 
   enum PreviewLocationTyp {
     URL_0,

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2343,6 +2343,34 @@
       ]
     },
     {
+      "type": "record",
+      "name": "DownloadFileAttachmentLocalRes",
+      "fields": [
+        {
+          "type": "string",
+          "name": "filename"
+        },
+        {
+          "type": "boolean",
+          "name": "offline"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFIdentifyFailure"
+          },
+          "name": "identifyFailures"
+        }
+      ]
+    },
+    {
       "type": "enum",
       "name": "PreviewLocationTyp",
       "symbols": [
@@ -3444,7 +3472,7 @@
           "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": "DownloadAttachmentLocalRes",
+      "response": "DownloadFileAttachmentLocalRes",
       "lint": "ignore"
     },
     "makePreview": {

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -16,6 +16,8 @@ export const typePrefix = 'chat2:'
 export const attachmentDownload = 'chat2:attachmentDownload'
 export const attachmentDownloaded = 'chat2:attachmentDownloaded'
 export const attachmentLoading = 'chat2:attachmentLoading'
+export const attachmentMobileSave = 'chat2:attachmentMobileSave'
+export const attachmentMobileSaved = 'chat2:attachmentMobileSaved'
 export const attachmentPreviewSelect = 'chat2:attachmentPreviewSelect'
 export const attachmentUploaded = 'chat2:attachmentUploaded'
 export const attachmentUploading = 'chat2:attachmentUploading'
@@ -112,6 +114,14 @@ type _AttachmentLoadingPayload = $ReadOnly<{|
   ordinal: Types.Ordinal,
   ratio: number,
   isPreview: boolean,
+|}>
+type _AttachmentMobileSavePayload = $ReadOnly<{|
+  conversationIDKey: Types.ConversationIDKey,
+  ordinal: Types.Ordinal,
+|}>
+type _AttachmentMobileSavedPayload = $ReadOnly<{|
+  conversationIDKey: Types.ConversationIDKey,
+  ordinal: Types.Ordinal,
 |}>
 type _AttachmentPreviewSelectPayload = $ReadOnly<{|message: Types.MessageAttachment|}>
 type _AttachmentUploadedPayload = $ReadOnly<{|
@@ -468,6 +478,8 @@ export const createSetPendingConversationExistingConversationIDKey = (payload: _
 export const createAttachmentDownload = (payload: _AttachmentDownloadPayload) => ({error: false, payload, type: attachmentDownload})
 export const createAttachmentDownloaded = (payload: _AttachmentDownloadedPayload) => ({error: false, payload, type: attachmentDownloaded})
 export const createAttachmentLoading = (payload: _AttachmentLoadingPayload) => ({error: false, payload, type: attachmentLoading})
+export const createAttachmentMobileSave = (payload: _AttachmentMobileSavePayload) => ({error: false, payload, type: attachmentMobileSave})
+export const createAttachmentMobileSaved = (payload: _AttachmentMobileSavedPayload) => ({error: false, payload, type: attachmentMobileSaved})
 export const createAttachmentPreviewSelect = (payload: _AttachmentPreviewSelectPayload) => ({error: false, payload, type: attachmentPreviewSelect})
 export const createAttachmentUploaded = (payload: _AttachmentUploadedPayload) => ({error: false, payload, type: attachmentUploaded})
 export const createAttachmentUploading = (payload: _AttachmentUploadingPayload) => ({error: false, payload, type: attachmentUploading})
@@ -528,6 +540,8 @@ export const createUpdateTypers = (payload: _UpdateTypersPayload) => ({error: fa
 export type AttachmentDownloadPayload = $Call<typeof createAttachmentDownload, _AttachmentDownloadPayload>
 export type AttachmentDownloadedPayload = $Call<typeof createAttachmentDownloaded, _AttachmentDownloadedPayload>
 export type AttachmentLoadingPayload = $Call<typeof createAttachmentLoading, _AttachmentLoadingPayload>
+export type AttachmentMobileSavePayload = $Call<typeof createAttachmentMobileSave, _AttachmentMobileSavePayload>
+export type AttachmentMobileSavedPayload = $Call<typeof createAttachmentMobileSaved, _AttachmentMobileSavedPayload>
 export type AttachmentPreviewSelectPayload = $Call<typeof createAttachmentPreviewSelect, _AttachmentPreviewSelectPayload>
 export type AttachmentUploadedPayload = $Call<typeof createAttachmentUploaded, _AttachmentUploadedPayload>
 export type AttachmentUploadingPayload = $Call<typeof createAttachmentUploading, _AttachmentUploadingPayload>
@@ -613,6 +627,8 @@ export type Actions =
   | AttachmentDownloadPayload
   | AttachmentDownloadedPayload
   | AttachmentLoadingPayload
+  | AttachmentMobileSavePayload
+  | AttachmentMobileSavedPayload
   | AttachmentPreviewSelectPayload
   | AttachmentUploadedPayload
   | AttachmentUploadingPayload

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1670,22 +1670,26 @@ function* downloadAttachment(fileName: string, conversationIDKey: any, message: 
       }
     }
 
-    const rpcRes = yield RPCChatTypes.localDownloadFileAttachmentLocalRpcSaga({
-      incomingCallMap: {
-        'chat.1.chatUi.chatAttachmentDownloadDone': () => {},
-        'chat.1.chatUi.chatAttachmentDownloadProgress': onDownloadProgress,
-        'chat.1.chatUi.chatAttachmentDownloadStart': () => {},
-      },
-      params: {
-        conversationID: Types.keyToConversationID(conversationIDKey),
-        filename: fileName,
-        identifyBehavior: RPCTypes.tlfKeysTLFIdentifyBehavior.chatGui,
-        messageID: message.id,
-        preview: false,
-      },
-    })
+    const rpcRes: RPCChatTypes.DownloadFileAttachmentLocalRes = yield RPCChatTypes.localDownloadFileAttachmentLocalRpcSaga(
+      {
+        incomingCallMap: {
+          'chat.1.chatUi.chatAttachmentDownloadDone': () => {},
+          'chat.1.chatUi.chatAttachmentDownloadProgress': onDownloadProgress,
+          'chat.1.chatUi.chatAttachmentDownloadStart': () => {},
+        },
+        params: {
+          conversationID: Types.keyToConversationID(conversationIDKey),
+          filename: fileName,
+          identifyBehavior: RPCTypes.tlfKeysTLFIdentifyBehavior.chatGui,
+          messageID: message.id,
+          preview: false,
+        },
+      }
+    )
     yield Saga.put(Chat2Gen.createAttachmentDownloaded({conversationIDKey, ordinal, path: fileName}))
+    return rpcRes.filename
   } catch (e) {}
+  return fileName
 }
 
 // Download an attachment to your device
@@ -2076,10 +2080,10 @@ function* mobileMessageAttachmentSave(action: Chat2Gen.MessageAttachmentNativeSa
   if (!message || message.type !== 'attachment') {
     throw new Error('Invalid share message')
   }
-  yield Saga.call(downloadAttachment, '', conversationIDKey, message, message.ordinal)
+  const fileName = yield Saga.call(downloadAttachment, '', conversationIDKey, message, message.ordinal)
   try {
     logger.info('Trying to save chat attachment to camera roll')
-    yield Saga.call(saveAttachmentToCameraRoll, message.fileURL, message.fileType)
+    yield Saga.call(saveAttachmentToCameraRoll, 'file://' + fileName, message.fileType)
   } catch (err) {
     logger.error('Failed to save attachment: ' + err)
     throw new Error('Failed to save attachment: ' + err)

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1670,7 +1670,7 @@ function* downloadAttachment(fileName: string, conversationIDKey: any, message: 
       }
     }
 
-    yield RPCChatTypes.localDownloadFileAttachmentLocalRpcSaga({
+    const rpcRes = yield RPCChatTypes.localDownloadFileAttachmentLocalRpcSaga({
       incomingCallMap: {
         'chat.1.chatUi.chatAttachmentDownloadDone': () => {},
         'chat.1.chatUi.chatAttachmentDownloadProgress': onDownloadProgress,
@@ -2076,20 +2076,7 @@ function* mobileMessageAttachmentSave(action: Chat2Gen.MessageAttachmentNativeSa
   if (!message || message.type !== 'attachment') {
     throw new Error('Invalid share message')
   }
-  if (!message.fileURLCached) {
-    yield Saga.put(
-      Chat2Gen.createAttachmentDownload({
-        conversationIDKey: message.conversationIDKey,
-        ordinal: message.ordinal,
-      })
-    )
-  }
-  yield Saga.put(
-    Chat2Gen.createAttachmentMobileSave({
-      conversationIDKey: message.conversationIDKey,
-      ordinal: message.ordinal,
-    })
-  )
+  yield Saga.call(downloadAttachment, '', conversationIDKey, message, message.ordinal)
   try {
     logger.info('Trying to save chat attachment to camera roll')
     yield Saga.call(saveAttachmentToCameraRoll, message.fileURL, message.fileType)

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2084,6 +2084,12 @@ function* mobileMessageAttachmentSave(action: Chat2Gen.MessageAttachmentNativeSa
       })
     )
   }
+  yield Saga.put(
+    Chat2Gen.createAttachmentMobileSave({
+      conversationIDKey: message.conversationIDKey,
+      ordinal: message.ordinal,
+    })
+  )
   try {
     logger.info('Trying to save chat attachment to camera roll')
     yield Saga.call(saveAttachmentToCameraRoll, message.fileURL, message.fileType)
@@ -2091,6 +2097,12 @@ function* mobileMessageAttachmentSave(action: Chat2Gen.MessageAttachmentNativeSa
     logger.error('Failed to save attachment: ' + err)
     throw new Error('Failed to save attachment: ' + err)
   }
+  yield Saga.put(
+    Chat2Gen.createAttachmentMobileSaved({
+      conversationIDKey: message.conversationIDKey,
+      ordinal: message.ordinal,
+    })
+  )
 }
 
 const joinConversation = (action: Chat2Gen.JoinConversationPayload) =>

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2081,9 +2081,15 @@ function* mobileMessageAttachmentSave(action: Chat2Gen.MessageAttachmentNativeSa
     throw new Error('Invalid share message')
   }
   const fileName = yield Saga.call(downloadAttachment, '', conversationIDKey, message, message.ordinal)
+  yield Saga.put(
+    Chat2Gen.createAttachmentMobileSave({
+      conversationIDKey: message.conversationIDKey,
+      ordinal: message.ordinal,
+    })
+  )
   try {
     logger.info('Trying to save chat attachment to camera roll')
-    yield Saga.call(saveAttachmentToCameraRoll, 'file://' + fileName, message.fileType)
+    yield Saga.call(saveAttachmentToCameraRoll, fileName, message.fileType)
   } catch (err) {
     logger.error('Failed to save attachment: ' + err)
     throw new Error('Failed to save attachment: ' + err)

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -295,6 +295,16 @@
       "ordinal": "Types.Ordinal",
       "forShare?": "boolean"
     },
+    // Saving an attachment to mobile storage
+    "attachmentMobileSave": {
+      "conversationIDKey": "Types.ConversationIDKey",
+      "ordinal": "Types.Ordinal"
+    },
+    // Saving an attachment to mobile storage has finished
+    "attachmentMobileSaved": {
+      "conversationIDKey": "Types.ConversationIDKey",
+      "ordinal": "Types.Ordinal"
+    },
     // Update the loading bars
     "attachmentLoading": {
       "conversationIDKey": "Types.ConversationIDKey",

--- a/shared/actions/platform-specific/index.native.js
+++ b/shared/actions/platform-specific/index.native.js
@@ -50,15 +50,8 @@ function saveAttachmentDialog(filePath: string): Promise<NextURI> {
 }
 
 async function saveAttachmentToCameraRoll(fileURL: string, mimeType: string): Promise<void> {
-  const logPrefix = '[saveAttachmentToCameraRoll] '
   const saveType = mimeType.startsWith('video') ? 'video' : 'photo'
-  if (isIOS && saveType !== 'video') {
-    // iOS cannot save a video from a URL, so we can only do images here. Fallback to temp file
-    // method for videos.
-    logger.info(logPrefix + 'Saving iOS picture to camera roll')
-    await CameraRoll.saveToCameraRoll(fileURL)
-    return
-  }
+  const logPrefix = '[saveAttachmentToCameraRoll] '
   if (!isIOS) {
     const permissionStatus = await PermissionsAndroid.request(
       PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
@@ -72,26 +65,7 @@ async function saveAttachmentToCameraRoll(fileURL: string, mimeType: string): Pr
       throw new Error('Unable to acquire storage permissions')
     }
   }
-  const fetchURL = `${fileURL}&nostream=true`
-  logger.info(logPrefix + `Fetching from URL: ${fetchURL}`)
-  const download = await RNFetchBlob.config({
-    appendExt: mime.extension(mimeType),
-    fileCache: true,
-  }).fetch('GET', fetchURL)
-  logger.info(logPrefix + 'Fetching success, getting local file path')
-  const path = download.path()
-  logger.info(logPrefix + `Saving to ${path}`)
-  try {
-    logger.info(logPrefix + `Attempting to save as ${saveType}`)
-    await CameraRoll.saveToCameraRoll(`file://${path}`, saveType)
-    logger.info(logPrefix + 'Success')
-  } catch (err) {
-    logger.error(logPrefix + 'Failed:', err)
-    throw err
-  } finally {
-    logger.info(logPrefix + 'Deleting tmp file')
-    await RNFetchBlob.fs.unlink(path)
-  }
+  await CameraRoll.saveToCameraRoll(fileURL, saveType)
 }
 
 // Downloads a file, shows the shareactionsheet, and deletes the file afterwards

--- a/shared/actions/platform-specific/index.native.js
+++ b/shared/actions/platform-specific/index.native.js
@@ -68,7 +68,9 @@ async function saveAttachmentToCameraRoll(filePath: string, mimeType: string): P
     }
   }
   try {
+    logger.info(logPrefix + `Attempting to save as ${saveType}`)
     await CameraRoll.saveToCameraRoll(fileURL, saveType)
+    logger.info(logPrefix + 'Success')
   } catch (e) {
     // This can fail if the user backgrounds too quickly, so throw up a local notification
     // just in case to get their attention.

--- a/shared/chat/conversation/messages/attachment/file/container.js
+++ b/shared/chat/conversation/messages/attachment/file/container.js
@@ -38,9 +38,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
       ? 'Downloading'
       : message.transferState === 'uploading'
         ? 'Uploading'
-        : message.transferState === 'remoteUploading'
-          ? 'waiting...'
-          : ''
+        : message.transferState === 'mobileSaving'
+          ? 'Saving...'
+          : message.transferState === 'remoteUploading'
+            ? 'waiting...'
+            : ''
   const hasProgress = !!message.transferState && message.transferState !== 'remoteUploading'
   return {
     arrowColor,

--- a/shared/chat/conversation/messages/attachment/file/container.js
+++ b/shared/chat/conversation/messages/attachment/file/container.js
@@ -43,7 +43,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
           : message.transferState === 'remoteUploading'
             ? 'waiting...'
             : ''
-  const hasProgress = !!message.transferState && message.transferState !== 'remoteUploading'
+  const hasProgress =
+    !!message.transferState &&
+    message.transferState !== 'remoteUploading' &&
+    message.transferState !== 'mobileSaving'
   return {
     arrowColor,
     hasProgress,

--- a/shared/chat/conversation/messages/attachment/image/container.js
+++ b/shared/chat/conversation/messages/attachment/image/container.js
@@ -51,9 +51,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
       ? 'Downloading'
       : message.transferState === 'uploading'
         ? 'Uploading'
-        : message.transferState === 'remoteUploading'
-          ? 'waiting...'
-          : ''
+        : message.transferState === 'mobileSaving'
+          ? 'Saving...'
+          : message.transferState === 'remoteUploading'
+            ? 'waiting...'
+            : ''
   const buttonType = message.showPlayButton ? 'play' : null
   const hasProgress = !!message.transferState && message.transferState !== 'remoteUploading'
 

--- a/shared/chat/conversation/messages/attachment/image/container.js
+++ b/shared/chat/conversation/messages/attachment/image/container.js
@@ -57,7 +57,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
             ? 'waiting...'
             : ''
   const buttonType = message.showPlayButton ? 'play' : null
-  const hasProgress = !!message.transferState && message.transferState !== 'remoteUploading'
+  const hasProgress =
+    !!message.transferState &&
+    message.transferState !== 'remoteUploading' &&
+    message.transferState !== 'mobileSaving'
 
   return {
     arrowColor,

--- a/shared/constants/types/chat2/message.js
+++ b/shared/constants/types/chat2/message.js
@@ -148,7 +148,7 @@ export type _MessageAttachment = {
   timestamp: number,
   title: string,
   transferProgress: number, // 0-1 // only for the file
-  transferState: 'uploading' | 'downloading' | 'remoteUploading' | null,
+  transferState: 'uploading' | 'downloading' | 'remoteUploading' | 'mobileSaving' | null,
   type: 'attachment',
   videoDuration: ?string,
 }

--- a/shared/constants/types/rpc-chat-gen.js.flow
+++ b/shared/constants/types/rpc-chat-gen.js.flow
@@ -157,7 +157,7 @@ export type MessageTypes = {|
   |},
   'chat.1.local.DownloadFileAttachmentLocal': {|
     inParam: $ReadOnly<{|conversationID: ConversationID, messageID: MessageID, filename: String, preview: Boolean, identifyBehavior: Keybase1.TLFIdentifyBehavior|}>,
-    outParam: DownloadAttachmentLocalRes,
+    outParam: DownloadFileAttachmentLocalRes,
   |},
   'chat.1.local.RetryPost': {|
     inParam: $ReadOnly<{|outboxID: OutboxID, identifyBehavior?: ?Keybase1.TLFIdentifyBehavior|}>,
@@ -682,6 +682,7 @@ export type ConversationVers = Uint64
 export type DeleteConversationLocalRes = $ReadOnly<{offline: Boolean, rateLimits?: ?Array<RateLimit>}>
 export type DeleteConversationRemoteRes = $ReadOnly<{rateLimit?: ?RateLimit}>
 export type DownloadAttachmentLocalRes = $ReadOnly<{offline: Boolean, rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
+export type DownloadFileAttachmentLocalRes = $ReadOnly<{filename: String, offline: Boolean, rateLimits?: ?Array<RateLimit>, identifyFailures?: ?Array<Keybase1.TLFIdentifyFailure>}>
 export type EncryptedData = $ReadOnly<{v: Int, e: Bytes, n: Bytes}>
 export type EphemeralPurgeInfo = $ReadOnly<{c /* convID */: ConversationID, a /* isActive */: Boolean, n /* nextPurgeTime */: Gregor1.Time, e /* minUnexplodedID */: MessageID}>
 export type EphemeralPurgeNotifInfo = $ReadOnly<{convID: ConversationID, msgs?: ?Array<UIMessage>, conv?: ?InboxUIItem}>

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -240,6 +240,20 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
         }
         return message.set('transferProgress', 0).set('transferState', null)
       })
+    case Chat2Gen.attachmentMobileSave:
+      return messageMap.updateIn([action.payload.conversationIDKey, action.payload.ordinal], message => {
+        if (!message || message.type !== 'attachment') {
+          return message
+        }
+        return message.set('transferState', 'mobileSaving')
+      })
+    case Chat2Gen.attachmentMobileSaved:
+      return messageMap.updateIn([action.payload.conversationIDKey, action.payload.ordinal], message => {
+        if (!message || message.type !== 'attachment') {
+          return message
+        }
+        return message.set('transferState', null)
+      })
     case Chat2Gen.attachmentDownload:
       if (!action.payload.forShare) {
         return messageMap
@@ -799,6 +813,8 @@ const rootReducer = (state: Types.State = initialState, action: Chat2Gen.Actions
     case Chat2Gen.attachmentLoading:
     case Chat2Gen.attachmentUploading:
     case Chat2Gen.attachmentUploaded:
+    case Chat2Gen.attachmentMobileSave:
+    case Chat2Gen.attachmentMobileSaved:
     case Chat2Gen.attachmentDownload:
     case Chat2Gen.attachmentDownloaded:
     case Chat2Gen.markConversationsStale:


### PR DESCRIPTION
@keybase/react-hackers 

Saving big attachments is rough on mobile right now, there is a lag of about 5-10 seconds where if the app is backgrounded the process will fail. It is also features too much JS code to handle the actual saving of the attachment. Patch does the following:

**CORE** 
1.) Change `DownloadFileAttachmentLocal` to provide a new interface of taking a blank filename. If given a blank name, it will generate a new file in `os.TempDir()` with the same name as the attachment being saved. 
2.) Return the name of the file we saved in, which will be the argument if it has non-zero length, or the filename we generated.

**JS**
1.) Change `mobileMessageAttachmentSave` to download the attachment using a blank filename to instruct the service to put it wherever it wants.
2.) Change `saveAttachmentToCameraRoll` to not do anything with temp files, and just use the file path from the service to save. We delete the file out of the app container after we are done with it.
3.) Add additional actions to put a new `transferState` on attachment message rows called "Saving", so the user can be sure when the process is totally complete. 
4.) Throw up a local notification if the process fails. Note: this will only show if the app is in the background. 