### PR TITLE
Avoid UI flickers on send form

### DIFF
--- a/shared/chat/conversation/input-area/normal/wallets-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/container.js
@@ -19,7 +19,8 @@ const mapDispatchToProps = dispatch => ({
     if (wasNew) {
       dispatch(Chat2Gen.createHandleSeeingWallets())
     }
-    dispatch(WalletsGen.createAbandonPayment())
+    dispatch(WalletsGen.createClearBuildingPayment())
+    dispatch(WalletsGen.createClearBuiltPayment())
     dispatch(WalletsGen.createSetBuildingRecipientType({recipientType: 'keybaseUser'}))
     dispatch(WalletsGen.createSetBuildingTo({to}))
     dispatch(

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -76,7 +76,7 @@ export type _BuildingPayment = {
   currency: string,
   from: string,
   publicMemo: HiddenString,
-  recipientType: ?CounterpartyType,
+  recipientType: CounterpartyType,
   secretNote: HiddenString,
   to: string,
 }

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -380,6 +380,8 @@ const loadAccountWaitingKey = (id: Types.AccountID) => `wallets:loadAccount:${id
 
 const getAccountIDs = (state: TypedState) => state.wallets.accountMap.keySeq().toList()
 
+const getAccounts = (state: TypedState) => state.wallets.accountMap.valueSeq().toList()
+
 const getSelectedAccount = (state: TypedState) => state.wallets.selectedAccount
 
 const getDisplayCurrencies = (state: TypedState) => state.wallets.currencies
@@ -446,6 +448,7 @@ export {
   createNewAccountWaitingKey,
   deleteAccountWaitingKey,
   getAccountIDs,
+  getAccounts,
   getAccountName,
   getAccount,
   getAssets,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -26,7 +26,7 @@ const makeBuildingPayment: I.RecordFactory<Types._BuildingPayment> = I.Record({
   currency: 'XLM', // FIXME: Use default currency?
   from: Types.noAccountID,
   publicMemo: new HiddenString(''),
-  recipientType: null,
+  recipientType: 'keybaseUser',
   secretNote: new HiddenString(''),
   to: '',
 })

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -46,7 +46,7 @@ const mapStateToProps = (state: TypedState) => {
   const toFieldInput = build.to
   // Built section
   const incorrect = built.toErrMsg
-  const recipientUsername = built.toUsername
+  const recipientUsername = built.toUsername || (recipientType === 'keybaseUser' ? toFieldInput : '')
 
   return {
     allAccounts,

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -6,7 +6,7 @@ import * as SearchGen from '../../../actions/search-gen'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import * as TrackerGen from '../../../actions/tracker-gen'
 import {getAccount, getAccountIDs, searchKey} from '../../../constants/wallets'
-import {stringToAccountID} from '../../../constants/types/wallets'
+import {stringToAccountID, type Account as StateAccount} from '../../../constants/types/wallets'
 import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
 const mapStateToPropsKeybaseUser = (state: TypedState) => {
@@ -60,34 +60,20 @@ const ConnectedParticipantsStellarPublicKey = compose(
   setDisplayName('ParticipantsStellarPublicKey')
 )(ParticipantsStellarPublicKey)
 
+const makeAccount = (stateAccount: StateAccount) => ({
+  contents: stateAccount.balanceDescription,
+  id: stateAccount.accountID,
+  name: stateAccount.name || stateAccount.accountID,
+})
+
 const mapStateToPropsOtherAccount = (state: TypedState) => {
   const build = state.wallets.buildingPayment
 
-  const fromAccountFromState = getAccount(state, stringToAccountID(build.from))
-  const fromAccount = {
-    contents: fromAccountFromState.balanceDescription,
-    id: fromAccountFromState.accountID,
-    name: fromAccountFromState.name || fromAccountFromState.accountID,
-  }
-  let toAccount
-  if (build.to) {
-    const toAccountFromState = getAccount(state, stringToAccountID(build.to))
-    toAccount = {
-      contents: toAccountFromState.balanceDescription,
-      id: toAccountFromState.accountID,
-      name: toAccountFromState.name || toAccountFromState.accountID,
-    }
-  }
+  const fromAccount = makeAccount(getAccount(state, stringToAccountID(build.from)))
+  const toAccount = build.to ? makeAccount(getAccount(state, stringToAccountID(build.to))) : undefined
 
   const allAccounts = getAccountIDs(state)
-    .map(accountID => {
-      const account = getAccount(state, accountID)
-      return {
-        contents: account.balanceDescription,
-        id: account.accountID,
-        name: account.name || account.accountID,
-      }
-    })
+    .map(accountID => makeAccount(getAccount(state, accountID)))
     .toArray()
 
   return {

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -5,7 +5,7 @@ import * as RouteTree from '../../../actions/route-tree'
 import * as SearchGen from '../../../actions/search-gen'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import * as TrackerGen from '../../../actions/tracker-gen'
-import {getAccount, getAccountIDs, searchKey} from '../../../constants/wallets'
+import {getAccount, getAccounts, searchKey} from '../../../constants/wallets'
 import {stringToAccountID, type Account as StateAccount} from '../../../constants/types/wallets'
 import {compose, connect, setDisplayName, type TypedState, type Dispatch} from '../../../util/container'
 
@@ -72,8 +72,8 @@ const mapStateToPropsOtherAccount = (state: TypedState) => {
   const fromAccount = makeAccount(getAccount(state, stringToAccountID(build.from)))
   const toAccount = build.to ? makeAccount(getAccount(state, stringToAccountID(build.to))) : undefined
 
-  const allAccounts = getAccountIDs(state)
-    .map(accountID => makeAccount(getAccount(state, accountID)))
+  const allAccounts = getAccounts(state)
+    .map(makeAccount)
     .toArray()
 
   return {

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -42,7 +42,7 @@ const mapStateToProps = (state: TypedState) => {
   }
 
   // Building section
-  const recipientType = build.recipientType || 'keybaseUser'
+  const recipientType = build.recipientType
   const toFieldInput = build.to
   // Built section
   const incorrect = built.toErrMsg

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -14,7 +14,6 @@ const mapStateToPropsKeybaseUser = (state: TypedState) => {
   const built = state.wallets.builtPayment
 
   return {
-    recipientType: 'keybaseUser',
     recipientUsername: built.toUsername || build.to,
   }
 }
@@ -40,7 +39,6 @@ const mapStateToPropsStellarPublicKey = (state: TypedState) => {
   const built = state.wallets.builtPayment
 
   return {
-    recipientType: 'stellarPublicKey',
     incorrect: built.toErrMsg,
     toFieldInput: build.to,
   }
@@ -92,7 +90,6 @@ const mapStateToPropsOtherAccount = (state: TypedState) => {
     .toArray()
 
   return {
-    recipientType: 'otherAccount',
     user: state.config.username,
     fromAccount,
     toAccount,

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -44,8 +44,12 @@ const mapStateToProps = (state: TypedState) => {
   // Building section
   const recipientType = build.recipientType
   const toFieldInput = build.to
+
   // Built section
   const incorrect = built.toErrMsg
+
+  // If the recipientType is 'keybaseUser' and toFieldInput is
+  // non-empty, then assume that it's a valid Keybase username.
   const recipientUsername = built.toUsername || (recipientType === 'keybaseUser' ? toFieldInput : '')
 
   return {

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -13,20 +13,21 @@ const mapStateToPropsKeybaseUser = (state: TypedState) => {
   const build = state.wallets.buildingPayment
   const built = state.wallets.builtPayment
 
+  // If build.to is set, assume it's a valid username.
   return {
     recipientUsername: built.toUsername || build.to,
   }
 }
 
 const mapDispatchToPropsKeybaseUser = (dispatch: Dispatch) => ({
-  onChangeRecipient: (to: string) => {
-    dispatch(WalletsGen.createSetBuildingTo({to}))
-  },
   onShowProfile: (username: string) => {
     dispatch(TrackerGen.createGetProfile({forceDisplay: true, ignoreCache: true, username}))
   },
   onShowSuggestions: () => dispatch(SearchGen.createSearchSuggestions({searchKey})),
   onRemoveProfile: () => dispatch(WalletsGen.createSetBuildingTo({to: ''})),
+  onChangeRecipient: (to: string) => {
+    dispatch(WalletsGen.createSetBuildingTo({to}))
+  },
 })
 
 const ConnectedParticipantsKeybaseUser = compose(
@@ -39,8 +40,8 @@ const mapStateToPropsStellarPublicKey = (state: TypedState) => {
   const built = state.wallets.builtPayment
 
   return {
-    incorrect: built.toErrMsg,
-    toFieldInput: build.to,
+    recipientPublicKey: build.to,
+    errorMessage: built.toErrMsg,
   }
 }
 
@@ -98,11 +99,11 @@ const mapStateToPropsOtherAccount = (state: TypedState) => {
 }
 
 const mapDispatchToPropsOtherAccount = (dispatch: Dispatch) => ({
-  onChangeRecipient: (to: string) => {
-    dispatch(WalletsGen.createSetBuildingTo({to}))
-  },
   onChangeFromAccount: (from: string) => {
     dispatch(WalletsGen.createSetBuildingFrom({from}))
+  },
+  onChangeRecipient: (to: string) => {
+    dispatch(WalletsGen.createSetBuildingTo({to}))
   },
   onLinkAccount: () =>
     dispatch(

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -28,7 +28,7 @@ type ParticipantsProps = {|
   // Used to display a keybase profile
   recipientUsername?: string,
   recipientFullName?: string,
-  onShowProfile?: string => void,
+  onShowProfile: string => void,
   onShowSuggestions: () => void,
   onRemoveProfile?: () => void,
 |}

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -30,7 +30,7 @@ type ParticipantsProps = {|
   recipientFullName?: string,
   onShowProfile: string => void,
   onShowSuggestions: () => void,
-  onRemoveProfile?: () => void,
+  onRemoveProfile: () => void,
 |}
 
 const Participants = (props: ParticipantsProps) => (

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -5,38 +5,12 @@ import FromField from './from-field'
 import {ToKeybaseUser, ToStellarPublicKey, ToOtherAccount} from './to-field'
 import type {AccountID} from '../../../constants/types/wallets'
 
-export type Account = {|
-  contents: string,
-  name: string,
-  id: AccountID,
-|}
-
 type ParticipantsKeybaseUserProps = {|
-  recipientType: 'keybaseUser',
   recipientUsername: string,
   onChangeRecipient: string => void,
   onShowProfile: string => void,
   onShowSuggestions: () => void,
   onRemoveProfile: () => void,
-|}
-
-type ParticipantsStellarPublicKeyProps = {|
-  recipientType: 'stellarPublicKey',
-  incorrect?: string,
-  toFieldInput: string,
-  onChangeRecipient: string => void,
-|}
-
-type ParticipantsOtherAccountProps = {|
-  recipientType: 'otherAccount',
-  user: string,
-  fromAccount?: Account,
-  toAccount?: Account,
-  allAccounts: Account[],
-  onChangeRecipient: string => void,
-  onChangeFromAccount: string => void,
-  onLinkAccount: () => void,
-  onCreateNewAccount: () => void,
 |}
 
 const ParticipantsKeybaseUser = (props: ParticipantsKeybaseUserProps) => (
@@ -51,6 +25,12 @@ const ParticipantsKeybaseUser = (props: ParticipantsKeybaseUserProps) => (
   </Kb.Box2>
 )
 
+type ParticipantsStellarPublicKeyProps = {|
+  incorrect?: string,
+  toFieldInput: string,
+  onChangeRecipient: string => void,
+|}
+
 const ParticipantsStellarPublicKey = (props: ParticipantsStellarPublicKeyProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
     <ToStellarPublicKey
@@ -60,6 +40,23 @@ const ParticipantsStellarPublicKey = (props: ParticipantsStellarPublicKeyProps) 
     />
   </Kb.Box2>
 )
+
+export type Account = {|
+  contents: string,
+  name: string,
+  id: AccountID,
+|}
+
+type ParticipantsOtherAccountProps = {|
+  user: string,
+  fromAccount: Account,
+  toAccount?: Account,
+  allAccounts: Account[],
+  onChangeRecipient: string => void,
+  onChangeFromAccount: string => void,
+  onLinkAccount: () => void,
+  onCreateNewAccount: () => void,
+|}
 
 const ParticipantsOtherAccount = (props: ParticipantsOtherAccountProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -2,42 +2,24 @@
 import * as React from 'react'
 import * as Kb from '../../../common-adapters'
 import FromField from './from-field'
-import {ToKeybaseUser, ToStellarPublicKey, ToOtherAccount} from './to-field'
+import {
+  type ToKeybaseUserProps,
+  ToKeybaseUser,
+  type ToStellarPublicKeyProps,
+  ToStellarPublicKey,
+  ToOtherAccount,
+} from './to-field'
 import type {AccountID} from '../../../constants/types/wallets'
 
-type ParticipantsKeybaseUserProps = {|
-  recipientUsername: string,
-  onChangeRecipient: string => void,
-  onShowProfile: string => void,
-  onShowSuggestions: () => void,
-  onRemoveProfile: () => void,
-|}
-
-const ParticipantsKeybaseUser = (props: ParticipantsKeybaseUserProps) => (
+const ParticipantsKeybaseUser = (props: ToKeybaseUserProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
-    <ToKeybaseUser
-      recipientUsername={props.recipientUsername}
-      onChangeRecipient={props.onChangeRecipient}
-      onShowProfile={props.onShowProfile}
-      onShowSuggestions={props.onShowSuggestions}
-      onRemoveProfile={props.onRemoveProfile}
-    />
+    <ToKeybaseUser {...props} />
   </Kb.Box2>
 )
 
-type ParticipantsStellarPublicKeyProps = {|
-  incorrect?: string,
-  toFieldInput: string,
-  onChangeRecipient: string => void,
-|}
-
-const ParticipantsStellarPublicKey = (props: ParticipantsStellarPublicKeyProps) => (
+const ParticipantsStellarPublicKey = (props: ToStellarPublicKeyProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
-    <ToStellarPublicKey
-      recipientPublicKey={props.toFieldInput}
-      errorMessage={props.incorrect}
-      onChangeRecipient={props.onChangeRecipient}
-    />
+    <ToStellarPublicKey {...props} />
   </Kb.Box2>
 )
 
@@ -52,22 +34,20 @@ type ParticipantsOtherAccountProps = {|
   fromAccount: Account,
   toAccount?: Account,
   allAccounts: Account[],
-  onChangeRecipient: string => void,
   onChangeFromAccount: string => void,
+  onChangeRecipient: string => void,
   onLinkAccount: () => void,
   onCreateNewAccount: () => void,
 |}
 
 const ParticipantsOtherAccount = (props: ParticipantsOtherAccountProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
-    {props.fromAccount && (
-      <FromField
-        initialAccount={props.fromAccount}
-        accounts={props.allAccounts}
-        onChangeSelectedAccount={props.onChangeFromAccount}
-        user={props.user}
-      />
-    )}
+    <FromField
+      initialAccount={props.fromAccount}
+      accounts={props.allAccounts}
+      onChangeSelectedAccount={props.onChangeFromAccount}
+      user={props.user}
+    />
     <ToOtherAccount
       user={props.user}
       toAccount={props.toAccount}

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -11,78 +11,90 @@ export type Account = {|
   id: AccountID,
 |}
 
+type ParticipantsKeybaseUserProps = {|
+  recipientType: 'keybaseUser',
+  recipientUsername: string,
+  onChangeRecipient: string => void,
+  onShowProfile: string => void,
+  onShowSuggestions: () => void,
+  onRemoveProfile: () => void,
+|}
+
+type ParticipantsStellarPublicKeyProps = {|
+  recipientType: 'stellarPublicKey',
+  incorrect?: string,
+  toFieldInput: string,
+  onChangeRecipient: string => void,
+|}
+
+type ParticipantsOtherAccountProps = {|
+  recipientType: 'otherAccount',
+  user: string,
+  fromAccount?: Account,
+  toAccount?: Account,
+  allAccounts: Account[],
+  onChangeRecipient: string => void,
+  onChangeFromAccount: string => void,
+  onLinkAccount: () => void,
+  onCreateNewAccount: () => void,
+|}
+
 type ParticipantsProps =
-  | {|
-      recipientType: 'keybaseUser',
-      recipientUsername: string,
-      onChangeRecipient: string => void,
-      onShowProfile: string => void,
-      onShowSuggestions: () => void,
-      onRemoveProfile: () => void,
-    |}
-  | {|
-      recipientType: 'stellarPublicKey',
-      incorrect?: string,
-      toFieldInput: string,
-      onChangeRecipient: string => void,
-    |}
-  | {|
-      recipientType: 'otherAccount',
-      user: string,
-      fromAccount?: Account,
-      toAccount?: Account,
-      allAccounts: Account[],
-      onChangeFromAccount: string => void,
-      onChangeRecipient: string => void,
-      onLinkAccount: () => void,
-      onCreateNewAccount: () => void,
-    |}
+  | ParticipantsKeybaseUserProps
+  | ParticipantsStellarPublicKeyProps
+  | ParticipantsOtherAccountProps
+
+const ParticipantsKeybaseUser = (props: ParticipantsKeybaseUserProps) => (
+  <Kb.Box2 direction="vertical" fullWidth={true}>
+    <ToKeybaseUser
+      recipientUsername={props.recipientUsername}
+      onChangeRecipient={props.onChangeRecipient}
+      onShowProfile={props.onShowProfile}
+      onShowSuggestions={props.onShowSuggestions}
+      onRemoveProfile={props.onRemoveProfile}
+    />
+  </Kb.Box2>
+)
+
+const ParticipantsStellarPublicKey = (props: ParticipantsStellarPublicKeyProps) => (
+  <Kb.Box2 direction="vertical" fullWidth={true}>
+    <ToStellarPublicKey
+      recipientPublicKey={props.toFieldInput}
+      errorMessage={props.incorrect}
+      onChangeRecipient={props.onChangeRecipient}
+    />
+  </Kb.Box2>
+)
+
+const ParticipantsOtherAccount = (props: ParticipantsOtherAccountProps) => (
+  <Kb.Box2 direction="vertical" fullWidth={true}>
+    {props.fromAccount && (
+      <FromField
+        initialAccount={props.fromAccount}
+        accounts={props.allAccounts}
+        onChangeSelectedAccount={props.onChangeFromAccount}
+        user={props.user}
+      />
+    )}
+    <ToOtherAccount
+      user={props.user}
+      toAccount={props.toAccount}
+      allAccounts={props.allAccounts}
+      onChangeRecipient={props.onChangeRecipient}
+      onLinkAccount={props.onLinkAccount}
+      onCreateNewAccount={props.onCreateNewAccount}
+    />
+  </Kb.Box2>
+)
 
 const Participants = (props: ParticipantsProps) => {
   switch (props.recipientType) {
     case 'keybaseUser':
-      return (
-        <Kb.Box2 direction="vertical" fullWidth={true}>
-          <ToKeybaseUser
-            recipientUsername={props.recipientUsername}
-            onChangeRecipient={props.onChangeRecipient}
-            onShowProfile={props.onShowProfile}
-            onShowSuggestions={props.onShowSuggestions}
-            onRemoveProfile={props.onRemoveProfile}
-          />
-        </Kb.Box2>
-      )
+      return <ParticipantsKeybaseUser {...props} />
     case 'stellarPublicKey':
-      return (
-        <Kb.Box2 direction="vertical" fullWidth={true}>
-          <ToStellarPublicKey
-            recipientPublicKey={props.toFieldInput}
-            errorMessage={props.incorrect}
-            onChangeRecipient={props.onChangeRecipient}
-          />
-        </Kb.Box2>
-      )
+      return <ParticipantsStellarPublicKey {...props} />
     case 'otherAccount':
-      return (
-        <Kb.Box2 direction="vertical" fullWidth={true}>
-          {props.fromAccount && (
-            <FromField
-              initialAccount={props.fromAccount}
-              accounts={props.allAccounts}
-              onChangeSelectedAccount={props.onChangeFromAccount}
-              user={props.user}
-            />
-          )}
-          <ToOtherAccount
-            user={props.user}
-            toAccount={props.toAccount}
-            allAccounts={props.allAccounts}
-            onChangeRecipient={props.onChangeRecipient}
-            onLinkAccount={props.onLinkAccount}
-            onCreateNewAccount={props.onCreateNewAccount}
-          />
-        </Kb.Box2>
-      )
+      return <ParticipantsOtherAccount {...props} />
     default:
       /*::
     declare var ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove: (recipientType: empty) => any

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -56,8 +56,8 @@ const Participants = (props: ParticipantsProps) => {
       return (
         <Kb.Box2 direction="vertical" fullWidth={true}>
           <ToStellarPublicKey
-            incorrect={props.incorrect}
-            toFieldInput={props.toFieldInput}
+            recipientPublicKey={props.toFieldInput}
+            errorMessage={props.incorrect}
             onChangeRecipient={props.onChangeRecipient}
           />
         </Kb.Box2>

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -39,11 +39,6 @@ type ParticipantsOtherAccountProps = {|
   onCreateNewAccount: () => void,
 |}
 
-type ParticipantsProps =
-  | ParticipantsKeybaseUserProps
-  | ParticipantsStellarPublicKeyProps
-  | ParticipantsOtherAccountProps
-
 const ParticipantsKeybaseUser = (props: ParticipantsKeybaseUserProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
     <ToKeybaseUser
@@ -87,23 +82,4 @@ const ParticipantsOtherAccount = (props: ParticipantsOtherAccountProps) => (
   </Kb.Box2>
 )
 
-const Participants = (props: ParticipantsProps) => {
-  switch (props.recipientType) {
-    case 'keybaseUser':
-      return <ParticipantsKeybaseUser {...props} />
-    case 'stellarPublicKey':
-      return <ParticipantsStellarPublicKey {...props} />
-    case 'otherAccount':
-      return <ParticipantsOtherAccount {...props} />
-    default:
-      /*::
-    declare var ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove: (recipientType: empty) => any
-    ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove(props.recipientType);
-    */
-      return null
-  }
-}
-
 export {ParticipantsKeybaseUser, ParticipantsStellarPublicKey, ParticipantsOtherAccount}
-
-export default Participants

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -104,4 +104,6 @@ const Participants = (props: ParticipantsProps) => {
   }
 }
 
+export {ParticipantsKeybaseUser, ParticipantsStellarPublicKey, ParticipantsOtherAccount}
+
 export default Participants

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -2,8 +2,8 @@
 import * as React from 'react'
 import * as Kb from '../../../common-adapters'
 import FromField from './from-field'
-import ToField from './to-field'
-import type {CounterpartyType, AccountID} from '../../../constants/types/wallets'
+import {ToKeybaseUser, ToStellarPublicKey, ToOtherAccount} from './to-field'
+import type {AccountID} from '../../../constants/types/wallets'
 
 export type Account = {|
   contents: string,
@@ -11,56 +11,85 @@ export type Account = {|
   id: AccountID,
 |}
 
-type ParticipantsProps = {|
-  recipientType: CounterpartyType,
-  // Used for send to other account
-  user: string,
-  fromAccount?: Account,
-  toAccount?: Account,
-  allAccounts: Account[],
-  onChangeFromAccount: string => void,
-  onChangeRecipient: string => void,
-  onLinkAccount: () => void,
-  onCreateNewAccount: () => void,
-  // Used for send to stellar address
-  incorrect?: string,
-  toFieldInput: string,
-  // Used to display a keybase profile
-  recipientUsername?: string,
-  recipientFullName?: string,
-  onShowProfile: string => void,
-  onShowSuggestions: () => void,
-  onRemoveProfile: () => void,
-|}
+type ParticipantsProps =
+  | {|
+      recipientType: 'keybaseUser',
+      recipientUsername: string,
+      onChangeRecipient: string => void,
+      onShowProfile: string => void,
+      onShowSuggestions: () => void,
+      onRemoveProfile: () => void,
+    |}
+  | {|
+      recipientType: 'stellarPublicKey',
+      incorrect?: string,
+      toFieldInput: string,
+      onChangeRecipient: string => void,
+    |}
+  | {|
+      recipientType: 'otherAccount',
+      user: string,
+      fromAccount?: Account,
+      toAccount?: Account,
+      allAccounts: Account[],
+      onChangeFromAccount: string => void,
+      onChangeRecipient: string => void,
+      onLinkAccount: () => void,
+      onCreateNewAccount: () => void,
+    |}
 
-const Participants = (props: ParticipantsProps) => (
-  <Kb.Box2 direction="vertical" fullWidth={true}>
-    {props.recipientType === 'otherAccount' &&
-      props.fromAccount && (
-        <FromField
-          initialAccount={props.fromAccount}
-          accounts={props.allAccounts}
-          onChangeSelectedAccount={props.onChangeFromAccount}
-          user={props.user}
-        />
-      )}
-    <ToField
-      toAccount={props.toAccount}
-      accounts={props.allAccounts}
-      incorrect={props.incorrect}
-      onChangeRecipient={props.onChangeRecipient}
-      onCreateNewAccount={props.onCreateNewAccount}
-      onLinkAccount={props.onLinkAccount}
-      onRemoveProfile={props.onRemoveProfile}
-      onShowProfile={props.onShowProfile}
-      onShowSuggestions={props.onShowSuggestions}
-      recipientFullName={props.recipientFullName}
-      recipientType={props.recipientType}
-      recipientUsername={props.recipientUsername}
-      toFieldInput={props.toFieldInput}
-      user={props.user}
-    />
-  </Kb.Box2>
-)
+const Participants = (props: ParticipantsProps) => {
+  switch (props.recipientType) {
+    case 'keybaseUser':
+      return (
+        <Kb.Box2 direction="vertical" fullWidth={true}>
+          <ToKeybaseUser
+            recipientUsername={props.recipientUsername}
+            onChangeRecipient={props.onChangeRecipient}
+            onShowProfile={props.onShowProfile}
+            onShowSuggestions={props.onShowSuggestions}
+            onRemoveProfile={props.onRemoveProfile}
+          />
+        </Kb.Box2>
+      )
+    case 'stellarPublicKey':
+      return (
+        <Kb.Box2 direction="vertical" fullWidth={true}>
+          <ToStellarPublicKey
+            incorrect={props.incorrect}
+            toFieldInput={props.toFieldInput}
+            onChangeRecipient={props.onChangeRecipient}
+          />
+        </Kb.Box2>
+      )
+    case 'otherAccount':
+      return (
+        <Kb.Box2 direction="vertical" fullWidth={true}>
+          {props.fromAccount && (
+            <FromField
+              initialAccount={props.fromAccount}
+              accounts={props.allAccounts}
+              onChangeSelectedAccount={props.onChangeFromAccount}
+              user={props.user}
+            />
+          )}
+          <ToOtherAccount
+            user={props.user}
+            toAccount={props.toAccount}
+            allAccounts={props.allAccounts}
+            onChangeRecipient={props.onChangeRecipient}
+            onLinkAccount={props.onLinkAccount}
+            onCreateNewAccount={props.onCreateNewAccount}
+          />
+        </Kb.Box2>
+      )
+    default:
+      /*::
+    declare var ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove: (recipientType: empty) => any
+    ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove(props.recipientType);
+    */
+      return null
+  }
+}
 
 export default Participants

--- a/shared/wallets/send-form/participants/index.stories.js
+++ b/shared/wallets/send-form/participants/index.stories.js
@@ -99,10 +99,15 @@ const accounts = [
 
 const keybaseUserProps = {
   recipientUsername: '',
-  onChangeRecipient: Sb.action('onChangeRecipient'),
   onShowProfile: Sb.action('onShowProfile'),
   onShowSuggestions: Sb.action('onShowSuggestions'),
   onRemoveProfile: Sb.action('onRemoveProfile'),
+  onChangeRecipient: Sb.action('onChangeRecipient'),
+}
+
+const stellarPublicKeyProps = {
+  recipientPublicKey: '',
+  onChangeRecipient: Sb.action('onChangeRecipient'),
 }
 
 const otherAccountProps = {
@@ -115,12 +120,6 @@ const otherAccountProps = {
   onCreateNewAccount: Sb.action('onCreateNewAccount'),
 }
 
-const stellarPublicKeyProps = {
-  incorrect: '',
-  toFieldInput: '',
-  onChangeRecipient: Sb.action('onChangeRecipient'),
-}
-
 const load = () => {
   Sb.storiesOf('Wallets/SendForm/Participants', module)
     .addDecorator(provider)
@@ -128,7 +127,7 @@ const load = () => {
     .add('To Keybase user', () => <ParticipantsKeybaseUser {...keybaseUserProps} />)
     .add('To stellar address', () => <ParticipantsStellarPublicKey {...stellarPublicKeyProps} />)
     .add('Stellar address Error', () => (
-      <ParticipantsStellarPublicKey {...stellarPublicKeyProps} incorrect="Stellar address incorrect" />
+      <ParticipantsStellarPublicKey {...stellarPublicKeyProps} errorMessage="Stellar address incorrect" />
     ))
     .add('To other account (multiple accounts)', () => <ParticipantsOtherAccount {...otherAccountProps} />)
     .add('To other account (one account)', () => (

--- a/shared/wallets/send-form/participants/index.stories.js
+++ b/shared/wallets/send-form/participants/index.stories.js
@@ -101,6 +101,7 @@ const defaultProps = {
   onChangeRecipient: Sb.action('onChangeRecipient'),
   onLinkAccount: Sb.action('onLinkAccount'),
   onCreateNewAccount: Sb.action('onCreateNewAccount'),
+  onRemoveProfile: Sb.action('onRemoveProfile'),
   onShowProfile: Sb.action('onShowProfile'),
   onShowSuggestions: Sb.action('onShowSuggestions'),
   toFieldInput: '',

--- a/shared/wallets/send-form/participants/index.stories.js
+++ b/shared/wallets/send-form/participants/index.stories.js
@@ -3,7 +3,12 @@ import * as React from 'react'
 import * as Sb from '../../../stories/storybook'
 import {Box} from '../../../common-adapters'
 import {stringToAccountID} from '../../../constants/types/wallets'
-import Participants, {type Account} from '.'
+import {
+  type Account,
+  ParticipantsKeybaseUser,
+  ParticipantsStellarPublicKey,
+  ParticipantsOtherAccount,
+} from '.'
 import {makeSelectorMap as makeResultsListSelectorMap} from '../../../search/results-list/index.stories'
 import {type ConnectPropsMap as RowConnectPropsMap} from '../../../search/result-row/index.stories'
 import {makeSelectorMap as makeUserInputSelectorMap} from '../../../search/user-input/index.stories'
@@ -101,13 +106,6 @@ const keybaseUserProps = {
   onRemoveProfile: Sb.action('onRemoveProfile'),
 }
 
-const stellarPublicKeyProps = {
-  recipientType: 'stellarPublicKey',
-  incorrect: '',
-  toFieldInput: '',
-  onChangeRecipient: Sb.action('onChangeRecipient'),
-}
-
 const otherAccountProps = {
   recipientType: 'otherAccount',
   user: 'cjb',
@@ -119,18 +117,25 @@ const otherAccountProps = {
   onCreateNewAccount: Sb.action('onCreateNewAccount'),
 }
 
+const stellarPublicKeyProps = {
+  recipientType: 'stellarPublicKey',
+  incorrect: '',
+  toFieldInput: '',
+  onChangeRecipient: Sb.action('onChangeRecipient'),
+}
+
 const load = () => {
   Sb.storiesOf('Wallets/SendForm/Participants', module)
     .addDecorator(provider)
     .addDecorator(story => <Box style={{maxWidth: 360, marginTop: 60}}>{story()}</Box>)
-    .add('To Keybase user', () => <Participants {...keybaseUserProps} />)
-    .add('To other account (multiple accounts)', () => <Participants {...otherAccountProps} />)
-    .add('To other account (one account)', () => (
-      <Participants {...otherAccountProps} allAccounts={accounts.slice(0, 1)} />
-    ))
-    .add('To stellar address', () => <Participants {...stellarPublicKeyProps} />)
+    .add('To Keybase user', () => <ParticipantsKeybaseUser {...keybaseUserProps} />)
+    .add('To stellar address', () => <ParticipantsStellarPublicKey {...stellarPublicKeyProps} />)
     .add('Stellar address Error', () => (
-      <Participants {...stellarPublicKeyProps} incorrect="Stellar address incorrect" />
+      <ParticipantsStellarPublicKey {...stellarPublicKeyProps} incorrect="Stellar address incorrect" />
+    ))
+    .add('To other account (multiple accounts)', () => <ParticipantsOtherAccount {...otherAccountProps} />)
+    .add('To other account (one account)', () => (
+      <ParticipantsOtherAccount {...otherAccountProps} allAccounts={accounts.slice(0, 1)} />
     ))
 }
 

--- a/shared/wallets/send-form/participants/index.stories.js
+++ b/shared/wallets/send-form/participants/index.stories.js
@@ -98,7 +98,6 @@ const accounts = [
 ]
 
 const keybaseUserProps = {
-  recipientType: 'keybaseUser',
   recipientUsername: '',
   onChangeRecipient: Sb.action('onChangeRecipient'),
   onShowProfile: Sb.action('onShowProfile'),
@@ -107,7 +106,6 @@ const keybaseUserProps = {
 }
 
 const otherAccountProps = {
-  recipientType: 'otherAccount',
   user: 'cjb',
   fromAccount: primaryAccount,
   allAccounts: accounts,
@@ -118,7 +116,6 @@ const otherAccountProps = {
 }
 
 const stellarPublicKeyProps = {
-  recipientType: 'stellarPublicKey',
   incorrect: '',
   toFieldInput: '',
   onChangeRecipient: Sb.action('onChangeRecipient'),

--- a/shared/wallets/send-form/participants/index.stories.js
+++ b/shared/wallets/send-form/participants/index.stories.js
@@ -92,8 +92,24 @@ const accounts = [
   },
 ]
 
-const defaultProps = {
-  // Account -> Account transactions
+const keybaseUserProps = {
+  recipientType: 'keybaseUser',
+  recipientUsername: '',
+  onChangeRecipient: Sb.action('onChangeRecipient'),
+  onShowProfile: Sb.action('onShowProfile'),
+  onShowSuggestions: Sb.action('onShowSuggestions'),
+  onRemoveProfile: Sb.action('onRemoveProfile'),
+}
+
+const stellarPublicKeyProps = {
+  recipientType: 'stellarPublicKey',
+  incorrect: '',
+  toFieldInput: '',
+  onChangeRecipient: Sb.action('onChangeRecipient'),
+}
+
+const otherAccountProps = {
+  recipientType: 'otherAccount',
   user: 'cjb',
   fromAccount: primaryAccount,
   allAccounts: accounts,
@@ -101,30 +117,20 @@ const defaultProps = {
   onChangeRecipient: Sb.action('onChangeRecipient'),
   onLinkAccount: Sb.action('onLinkAccount'),
   onCreateNewAccount: Sb.action('onCreateNewAccount'),
-  onRemoveProfile: Sb.action('onRemoveProfile'),
-  onShowProfile: Sb.action('onShowProfile'),
-  onShowSuggestions: Sb.action('onShowSuggestions'),
-  toFieldInput: '',
 }
 
 const load = () => {
   Sb.storiesOf('Wallets/SendForm/Participants', module)
     .addDecorator(provider)
     .addDecorator(story => <Box style={{maxWidth: 360, marginTop: 60}}>{story()}</Box>)
-    .add('To Keybase user', () => <Participants {...defaultProps} recipientType="keybaseUser" />)
-    .add('To other account (multiple accounts)', () => (
-      <Participants recipientType="otherAccount" {...defaultProps} />
-    ))
+    .add('To Keybase user', () => <Participants {...keybaseUserProps} />)
+    .add('To other account (multiple accounts)', () => <Participants {...otherAccountProps} />)
     .add('To other account (one account)', () => (
-      <Participants recipientType="otherAccount" {...defaultProps} allAccounts={accounts.slice(0, 1)} />
+      <Participants {...otherAccountProps} allAccounts={accounts.slice(0, 1)} />
     ))
-    .add('To stellar address', () => <Participants {...defaultProps} recipientType="stellarPublicKey" />)
+    .add('To stellar address', () => <Participants {...stellarPublicKeyProps} />)
     .add('Stellar address Error', () => (
-      <Participants
-        {...defaultProps}
-        incorrect="Stellar address incorrect"
-        recipientType="stellarPublicKey"
-      />
+      <Participants {...stellarPublicKeyProps} incorrect="Stellar address incorrect" />
     ))
 }
 

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -30,19 +30,19 @@ type ToFieldProps = {|
 |}
 
 class ToField extends React.Component<ToFieldProps> {
-  onSelectRecipient = (recipient: Account | string) => {
-    if (typeof recipient === 'string') {
-      this.props.onChangeRecipient(recipient)
-    } else {
-      this.props.onChangeRecipient(recipient.id)
-    }
+  onSelectAccount = (recipient: Account) => {
+    this.props.onChangeRecipient(recipient.id)
+  }
+
+  onSelectKeybaseUser = (keybaseUser: string) => {
+    this.props.onChangeRecipient(keybaseUser)
   }
 
   onRemoveRecipient = () => {
     this.props.onChangeRecipient('')
   }
 
-  onDropdownChange = (node: React.Node) => {
+  onAccountDropdownChange = (node: React.Node) => {
     if (React.isValidElement(node)) {
       // $FlowIssue React.isValidElement refinement doesn't happen, see https://github.com/facebook/flow/issues/6392
       const element = (node: React.Element<any>)
@@ -51,7 +51,7 @@ class ToField extends React.Component<ToFieldProps> {
       } else if (element.key === 'link-existing') {
         this.props.onLinkAccount()
       } else {
-        this.onSelectRecipient(element.props.account)
+        this.onSelectAccount(element.props.account)
       }
     }
   }
@@ -90,7 +90,7 @@ class ToField extends React.Component<ToFieldProps> {
         // Case #1b: A user is sending to a keybase user but has not selected a keybase user yet. Show search input for keybase users.
         return (
           <Search
-            onClickResult={this.onSelectRecipient}
+            onClickResult={this.onSelectKeybaseUser}
             onClose={() => {}}
             onShowSuggestions={this.props.onShowSuggestions}
             onShowTracker={this.props.onShowProfile}
@@ -161,7 +161,7 @@ class ToField extends React.Component<ToFieldProps> {
 
         return (
           <Kb.Dropdown
-            onChanged={this.onDropdownChange}
+            onChanged={this.onAccountDropdownChange}
             items={items}
             selected={
               this.props.toAccount ? (

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -110,11 +110,7 @@ class ToOtherAccount extends React.Component<ToOtherAccountProps> {
     }
   }
 
-  _onChangeStellarRecipient = debounce((to: string) => {
-    this.props.onChangeRecipient(to)
-  }, 1e3)
-
-  render() {
+  render = () => {
     if (this.props.allAccounts.length <= 1) {
       // A user is sending to another account, but has no other
       // accounts. Show a "create new account" button.

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -49,8 +49,8 @@ const ToKeybaseUser = (props: ToKeybaseUserProps) => {
 }
 
 type ToStellarPublicKeyProps = {|
-  incorrect?: string,
-  toFieldInput: string,
+  recipientPublicKey: string,
+  errorMessage?: string,
   onChangeRecipient: string => void,
 |}
 
@@ -59,7 +59,7 @@ const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => (
     <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputInner}>
       <Kb.Icon
         type={
-          props.incorrect || props.toFieldInput.length === 0
+          props.recipientPublicKey.length === 0 || props.errorMessage
             ? 'icon-stellar-logo-grey-16'
             : 'icon-stellar-logo-16'
         }
@@ -78,9 +78,9 @@ const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => (
         rowsMax={3}
       />
     </Kb.Box2>
-    {!!props.incorrect && (
+    {!!props.errorMessage && (
       <Kb.Text type="BodySmall" style={styles.errorText}>
-        {props.incorrect}
+        {props.errorMessage}
       </Kb.Text>
     )}
   </Kb.Box2>

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -59,7 +59,7 @@ const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => (
   <ParticipantsRow
     heading="To"
     headingAlignment="Right"
-    headingStyle={{alignSelf: 'flex-start'}}
+    headingStyle={styles.heading}
     dividerColor={props.errorMessage ? Styles.globalColors.red : ''}
   >
     <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
@@ -179,6 +179,9 @@ const styles = Styles.styleSheetCreate({
   },
 
   // ToStellarPublicKey
+  heading: {
+    alignSelf: 'flex-start',
+  },
   inputBox: {flexGrow: 1},
   inputInner: {
     alignItems: 'flex-start',

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -14,25 +14,9 @@ type ToKeybaseUserProps = {|
   onRemoveProfile: () => void,
 |}
 
-type ToStellarPublicKeyProps = {|
-  incorrect?: string,
-  toFieldInput: string,
-  onChangeRecipient: string => void,
-|}
-
-type ToOtherAccountProps = {|
-  user: string,
-  toAccount?: Account,
-  allAccounts: Account[],
-  onChangeRecipient: string => void,
-  onLinkAccount: () => void,
-  onCreateNewAccount: () => void,
-|}
-
 const ToKeybaseUser = (props: ToKeybaseUserProps) => {
   if (props.recipientUsername) {
-    // Case #1a: A user has been set, so we display their name and avatar
-    // We can only get this case when the recipient is a searched user, not another account.
+    // A username has been set, so display their name and avatar.
     return (
       <React.Fragment>
         <Kb.ConnectedNameWithIcon
@@ -53,7 +37,7 @@ const ToKeybaseUser = (props: ToKeybaseUserProps) => {
     )
   }
 
-  // Case #1b: A user is sending to a keybase user but has not selected a keybase user yet. Show search input for keybase users.
+  // No username, so show search box.
   return (
     <Search
       onClickResult={props.onChangeRecipient}
@@ -63,6 +47,12 @@ const ToKeybaseUser = (props: ToKeybaseUserProps) => {
     />
   )
 }
+
+type ToStellarPublicKeyProps = {|
+  incorrect?: string,
+  toFieldInput: string,
+  onChangeRecipient: string => void,
+|}
 
 const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
@@ -95,6 +85,15 @@ const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => (
     )}
   </Kb.Box2>
 )
+
+type ToOtherAccountProps = {|
+  user: string,
+  toAccount?: Account,
+  allAccounts: Account[],
+  onChangeRecipient: string => void,
+  onLinkAccount: () => void,
+  onCreateNewAccount: () => void,
+|}
 
 class ToOtherAccount extends React.Component<ToOtherAccountProps> {
   onAccountDropdownChange = (node: React.Node) => {
@@ -160,14 +159,28 @@ class ToOtherAccount extends React.Component<ToOtherAccountProps> {
 }
 
 const styles = Styles.styleSheetCreate({
+  // ToKeybaseUser
   avatar: {
     marginRight: 8,
   },
-  createNewAccountButton: Styles.platformStyles({
-    isElectron: {
-      width: 194,
-    },
-  }),
+  keybaseUserRemoveButton: {
+    flex: 1,
+    textAlign: 'right',
+    marginRight: Styles.globalMargins.tiny, // consistent with UserInput
+  },
+
+  // ToStellarPublicKey
+  inputBox: {flexGrow: 1},
+  inputInner: {
+    alignItems: 'flex-start',
+  },
+  stellarIcon: {
+    alignSelf: 'flex-start',
+    marginRight: Styles.globalMargins.xxtiny,
+  },
+  input: {
+    padding: 0,
+  },
   errorText: Styles.platformStyles({
     common: {
       color: Styles.globalColors.red,
@@ -177,22 +190,13 @@ const styles = Styles.styleSheetCreate({
       wordWrap: 'break-word',
     },
   }),
-  input: {
-    padding: 0,
-  },
-  inputBox: {flexGrow: 1},
-  inputInner: {
-    alignItems: 'flex-start',
-  },
-  keybaseUserRemoveButton: {
-    flex: 1,
-    textAlign: 'right',
-    marginRight: Styles.globalMargins.tiny, // consistent with UserInput
-  },
-  stellarIcon: {
-    alignSelf: 'flex-start',
-    marginRight: Styles.globalMargins.xxtiny,
-  },
+
+  // ToOtherAccount
+  createNewAccountButton: Styles.platformStyles({
+    isElectron: {
+      width: 194,
+    },
+  }),
 })
 
 export {ToKeybaseUser, ToStellarPublicKey, ToOtherAccount}

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -8,10 +8,10 @@ import type {Account} from '.'
 
 type ToKeybaseUserProps = {|
   recipientUsername: string,
-  onChangeRecipient: string => void,
   onShowProfile: string => void,
   onShowSuggestions: () => void,
   onRemoveProfile: () => void,
+  onChangeRecipient: string => void,
 |}
 
 const ToKeybaseUser = (props: ToKeybaseUserProps) => {
@@ -31,7 +31,7 @@ const ToKeybaseUser = (props: ToKeybaseUserProps) => {
           boxStyle={Kb.iconCastPlatformStyles(styles.keybaseUserRemoveButton)}
           fontSize={16}
           color={Styles.globalColors.black_20}
-          onClick={() => props.onChangeRecipient('')}
+          onClick={props.onRemoveProfile}
         />
       </React.Fragment>
     )
@@ -201,5 +201,7 @@ const styles = Styles.styleSheetCreate({
     },
   }),
 })
+
+export type {ToKeybaseUserProps, ToStellarPublicKeyProps}
 
 export {ToKeybaseUser, ToStellarPublicKey, ToOtherAccount}

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -19,7 +19,7 @@ const ToKeybaseUser = (props: ToKeybaseUserProps) => {
   if (props.recipientUsername) {
     // A username has been set, so display their name and avatar.
     return (
-      <ParticipantsRow heading="To" headingAlignment="Right">
+      <ParticipantsRow heading="To" headingAlignment="Left">
         <Kb.ConnectedNameWithIcon
           colorFollowing={true}
           horizontal={true}
@@ -58,7 +58,7 @@ type ToStellarPublicKeyProps = {|
 const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => (
   <ParticipantsRow
     heading="To"
-    headingAlignment="Right"
+    headingAlignment="Left"
     headingStyle={styles.heading}
     dividerColor={props.errorMessage ? Styles.globalColors.red : ''}
   >
@@ -150,7 +150,7 @@ class ToOtherAccount extends React.Component<ToOtherAccountProps> {
     }
 
     return (
-      <ParticipantsRow heading="To" headingAlignment="Left">
+      <ParticipantsRow heading="To" headingAlignment="Right">
         <Kb.Dropdown
           onChanged={this.onAccountDropdownChange}
           items={items}

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -116,7 +116,8 @@ class ToOtherAccount extends React.Component<ToOtherAccountProps> {
 
   render() {
     if (this.props.allAccounts.length <= 1) {
-      // Case #3a: A user is sending to another account, but has no other accounts. Show a "create new account" button
+      // A user is sending to another account, but has no other
+      // accounts. Show a "create new account" button.
       return (
         <Kb.Box2 direction="horizontal" centerChildren={true} style={{width: 270}}>
           <Kb.Button
@@ -129,7 +130,9 @@ class ToOtherAccount extends React.Component<ToOtherAccountProps> {
       )
     }
 
-    // Case #3b: A user is sending from an account to another account with other accounts. Show a dropdown list of other accounts, in addition to the link existing and create new actions.
+    // A user is sending from an account to another account with other
+    // accounts. Show a dropdown list of other accounts, in addition
+    // to the link existing and create new actions.
     let items = [
       <DropdownText key="link-existing" text="Link an existing Stellar account" />,
       <DropdownText key="create-new" text="Create a new account" />,

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -5,43 +5,98 @@ import * as Styles from '../../../styles'
 import {SelectedEntry, DropdownEntry, DropdownText} from './dropdown'
 import Search from './search'
 import type {Account} from '.'
-import type {CounterpartyType} from '../../../constants/types/wallets'
-import {debounce} from 'lodash-es'
 
-type ToFieldProps = {|
-  recipientType: CounterpartyType,
+type ToKeybaseUserProps = {|
+  recipientUsername: string,
   onChangeRecipient: string => void,
-  // Used to display a keybase profile. We need the recipients' name and callbacks to show the tracker and remove profiles.
-  recipientUsername?: string,
-  recipientFullName?: string,
   onShowProfile: string => void,
   onShowSuggestions: () => void,
   onRemoveProfile: () => void,
-  // Used for sending to a stellar address.
+|}
+
+type ToStellarPublicKeyProps = {|
   incorrect?: string,
   toFieldInput: string,
-  // Used for sending from account to account
-  // We need the users' name, list of accounts, currently selected account, and callbacks to link and create new accounts.
+  onChangeRecipient: string => void,
+|}
+
+type ToOtherAccountProps = {|
   user: string,
-  accounts: Account[],
   toAccount?: Account,
+  allAccounts: Account[],
+  onChangeRecipient: string => void,
   onLinkAccount: () => void,
   onCreateNewAccount: () => void,
 |}
 
-class ToField extends React.Component<ToFieldProps> {
-  onSelectAccount = (recipient: Account) => {
-    this.props.onChangeRecipient(recipient.id)
+const ToKeybaseUser = (props: ToKeybaseUserProps) => {
+  if (props.recipientUsername) {
+    // Case #1a: A user has been set, so we display their name and avatar
+    // We can only get this case when the recipient is a searched user, not another account.
+    return (
+      <React.Fragment>
+        <Kb.ConnectedNameWithIcon
+          colorFollowing={true}
+          horizontal={true}
+          username={props.recipientUsername}
+          avatarStyle={styles.avatar}
+          onClick="tracker"
+        />
+        <Kb.Icon
+          type="iconfont-remove"
+          boxStyle={Kb.iconCastPlatformStyles(styles.keybaseUserRemoveButton)}
+          fontSize={16}
+          color={Styles.globalColors.black_20}
+          onClick={() => props.onChangeRecipient('')}
+        />
+      </React.Fragment>
+    )
   }
 
-  onSelectKeybaseUser = (keybaseUser: string) => {
-    this.props.onChangeRecipient(keybaseUser)
-  }
+  // Case #1b: A user is sending to a keybase user but has not selected a keybase user yet. Show search input for keybase users.
+  return (
+    <Search
+      onClickResult={props.onChangeRecipient}
+      onClose={() => {}}
+      onShowSuggestions={props.onShowSuggestions}
+      onShowTracker={props.onShowProfile}
+    />
+  )
+}
 
-  onRemoveRecipient = () => {
-    this.props.onChangeRecipient('')
-  }
+const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => (
+  <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
+    <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputInner}>
+      <Kb.Icon
+        type={
+          props.incorrect || props.toFieldInput.length === 0
+            ? 'icon-stellar-logo-grey-16'
+            : 'icon-stellar-logo-16'
+        }
+        style={Kb.iconCastPlatformStyles(styles.stellarIcon)}
+      />
+      <Kb.NewInput
+        type="text"
+        onChangeText={props.onChangeRecipient}
+        textType="BodySemibold"
+        placeholder={'Stellar address'}
+        placeholderColor={Styles.globalColors.black_20}
+        hideBorder={true}
+        containerStyle={styles.input}
+        multiline={true}
+        rowsMin={2}
+        rowsMax={3}
+      />
+    </Kb.Box2>
+    {!!props.incorrect && (
+      <Kb.Text type="BodySmall" style={styles.errorText}>
+        {props.incorrect}
+      </Kb.Text>
+    )}
+  </Kb.Box2>
+)
 
+class ToOtherAccount extends React.Component<ToOtherAccountProps> {
   onAccountDropdownChange = (node: React.Node) => {
     if (React.isValidElement(node)) {
       // $FlowIssue React.isValidElement refinement doesn't happen, see https://github.com/facebook/flow/issues/6392
@@ -51,7 +106,7 @@ class ToField extends React.Component<ToFieldProps> {
       } else if (element.key === 'link-existing') {
         this.props.onLinkAccount()
       } else {
-        this.onSelectAccount(element.props.account)
+        this.props.onChangeRecipient(element.props.account.id)
       }
     }
   }
@@ -61,125 +116,46 @@ class ToField extends React.Component<ToFieldProps> {
   }, 1e3)
 
   render() {
-    // There are a few different ways the participants form can look:
-    switch (this.props.recipientType) {
-      case 'keybaseUser':
-        if (this.props.recipientUsername) {
-          // Case #1a: A user has been set, so we display their name and avatar
-          // We can only get this case when the recipient is a searched user, not another account.
-          return (
-            <React.Fragment>
-              <Kb.ConnectedNameWithIcon
-                colorFollowing={true}
-                horizontal={true}
-                username={this.props.recipientUsername}
-                avatarStyle={styles.avatar}
-                onClick="tracker"
-              />
-              <Kb.Icon
-                type="iconfont-remove"
-                boxStyle={Kb.iconCastPlatformStyles(styles.keybaseUserRemoveButton)}
-                fontSize={16}
-                color={Styles.globalColors.black_20}
-                onClick={this.onRemoveRecipient}
-              />
-            </React.Fragment>
-          )
-        }
-
-        // Case #1b: A user is sending to a keybase user but has not selected a keybase user yet. Show search input for keybase users.
-        return (
-          <Search
-            onClickResult={this.onSelectKeybaseUser}
-            onClose={() => {}}
-            onShowSuggestions={this.props.onShowSuggestions}
-            onShowTracker={this.props.onShowProfile}
+    if (this.props.allAccounts.length <= 1) {
+      // Case #3a: A user is sending to another account, but has no other accounts. Show a "create new account" button
+      return (
+        <Kb.Box2 direction="horizontal" centerChildren={true} style={{width: 270}}>
+          <Kb.Button
+            type="Wallet"
+            style={styles.createNewAccountButton}
+            label="Create a new account"
+            onClick={this.props.onCreateNewAccount}
           />
-        )
-
-      case 'stellarPublicKey':
-        // Case #2: A user is sending to a stellar address that is either not associated to a keybase user or not complete. Show input for a stellar address.
-        return (
-          <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
-            <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputInner}>
-              <Kb.Icon
-                type={
-                  this.props.incorrect || this.props.toFieldInput.length === 0
-                    ? 'icon-stellar-logo-grey-16'
-                    : 'icon-stellar-logo-16'
-                }
-                style={Kb.iconCastPlatformStyles(styles.stellarIcon)}
-              />
-              <Kb.NewInput
-                type="text"
-                onChangeText={this.props.onChangeRecipient}
-                textType="BodySemibold"
-                placeholder={'Stellar address'}
-                placeholderColor={Styles.globalColors.black_20}
-                hideBorder={true}
-                containerStyle={styles.input}
-                multiline={true}
-                rowsMin={2}
-                rowsMax={3}
-              />
-            </Kb.Box2>
-            {!!this.props.incorrect && (
-              <Kb.Text type="BodySmall" style={styles.errorText}>
-                {this.props.incorrect}
-              </Kb.Text>
-            )}
-          </Kb.Box2>
-        )
-
-      case 'otherAccount':
-        if (this.props.accounts.length <= 1) {
-          // Case #3a: A user is sending to another account, but has no other accounts. Show a "create new account" button
-          return (
-            <Kb.Box2 direction="horizontal" centerChildren={true} style={{width: 270}}>
-              <Kb.Button
-                type="Wallet"
-                style={styles.createNewAccountButton}
-                label="Create a new account"
-                onClick={this.props.onCreateNewAccount}
-              />
-            </Kb.Box2>
-          )
-        }
-
-        // Case #3b: A user is sending from an account to another account with other accounts. Show a dropdown list of other accounts, in addition to the link existing and create new actions.
-        let items = [
-          <DropdownText key="link-existing" text="Link an existing Stellar account" />,
-          <DropdownText key="create-new" text="Create a new account" />,
-        ]
-
-        if (this.props.accounts.length > 0) {
-          const walletItems = this.props.accounts.map(account => (
-            <DropdownEntry key={account.id} account={account} user={this.props.user} />
-          ))
-          items = walletItems.concat(items)
-        }
-
-        return (
-          <Kb.Dropdown
-            onChanged={this.onAccountDropdownChange}
-            items={items}
-            selected={
-              this.props.toAccount ? (
-                <SelectedEntry account={this.props.toAccount} user={this.props.user} />
-              ) : (
-                <DropdownText key="placeholder-select" text="Pick another account" />
-              )
-            }
-          />
-        )
-
-      default:
-        /*::
-      declare var ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove: (recipientType: empty) => any
-      ifFlowErrorsHereItsCauseYouDidntHandleAllActionTypesAbove(this.props.recipientType);
-      */
-        return null
+        </Kb.Box2>
+      )
     }
+
+    // Case #3b: A user is sending from an account to another account with other accounts. Show a dropdown list of other accounts, in addition to the link existing and create new actions.
+    let items = [
+      <DropdownText key="link-existing" text="Link an existing Stellar account" />,
+      <DropdownText key="create-new" text="Create a new account" />,
+    ]
+
+    if (this.props.allAccounts.length > 0) {
+      const walletItems = this.props.allAccounts.map(account => (
+        <DropdownEntry key={account.id} account={account} user={this.props.user} />
+      ))
+      items = walletItems.concat(items)
+    }
+
+    return (
+      <Kb.Dropdown
+        onChanged={this.onAccountDropdownChange}
+        items={items}
+        selected={
+          this.props.toAccount ? (
+            <SelectedEntry account={this.props.toAccount} user={this.props.user} />
+          ) : (
+            <DropdownText key="placeholder-select" text="Pick another account" />
+          )
+        }
+      />
+    )
   }
 }
 
@@ -219,4 +195,4 @@ const styles = Styles.styleSheetCreate({
   },
 })
 
-export default ToField
+export {ToKeybaseUser, ToStellarPublicKey, ToOtherAccount}

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -6,6 +6,7 @@ import {ParticipantsRow} from '../../common'
 import {SelectedEntry, DropdownEntry, DropdownText} from './dropdown'
 import Search from './search'
 import type {Account} from '.'
+import {debounce} from 'lodash-es'
 
 type ToKeybaseUserProps = {|
   recipientUsername: string,
@@ -55,44 +56,48 @@ type ToStellarPublicKeyProps = {|
   onChangeRecipient: string => void,
 |}
 
-const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => (
-  <ParticipantsRow
-    heading="To"
-    headingAlignment="Left"
-    headingStyle={styles.heading}
-    dividerColor={props.errorMessage ? Styles.globalColors.red : ''}
-  >
-    <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
-      <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputInner}>
-        <Kb.Icon
-          type={
-            props.recipientPublicKey.length === 0 || props.errorMessage
-              ? 'icon-stellar-logo-grey-16'
-              : 'icon-stellar-logo-16'
-          }
-          style={Kb.iconCastPlatformStyles(styles.stellarIcon)}
-        />
-        <Kb.NewInput
-          type="text"
-          onChangeText={props.onChangeRecipient}
-          textType="BodySemibold"
-          placeholder={'Stellar address'}
-          placeholderColor={Styles.globalColors.black_20}
-          hideBorder={true}
-          containerStyle={styles.input}
-          multiline={true}
-          rowsMin={2}
-          rowsMax={3}
-        />
+class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps> {
+  _onChangeRecipient = debounce(this.props.onChangeRecipient, 1e3)
+
+  render = () => (
+    <ParticipantsRow
+      heading="To"
+      headingAlignment="Left"
+      headingStyle={styles.heading}
+      dividerColor={this.props.errorMessage ? Styles.globalColors.red : ''}
+    >
+      <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
+        <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputInner}>
+          <Kb.Icon
+            type={
+              this.props.recipientPublicKey.length === 0 || this.props.errorMessage
+                ? 'icon-stellar-logo-grey-16'
+                : 'icon-stellar-logo-16'
+            }
+            style={Kb.iconCastPlatformStyles(styles.stellarIcon)}
+          />
+          <Kb.NewInput
+            type="text"
+            onChangeText={this._onChangeRecipient}
+            textType="BodySemibold"
+            placeholder={'Stellar address'}
+            placeholderColor={Styles.globalColors.black_20}
+            hideBorder={true}
+            containerStyle={styles.input}
+            multiline={true}
+            rowsMin={2}
+            rowsMax={3}
+          />
+        </Kb.Box2>
+        {!!this.props.errorMessage && (
+          <Kb.Text type="BodySmall" style={styles.errorText}>
+            {this.props.errorMessage}
+          </Kb.Text>
+        )}
       </Kb.Box2>
-      {!!props.errorMessage && (
-        <Kb.Text type="BodySmall" style={styles.errorText}>
-          {props.errorMessage}
-        </Kb.Text>
-      )}
-    </Kb.Box2>
-  </ParticipantsRow>
-)
+    </ParticipantsRow>
+  )
+}
 
 type ToOtherAccountProps = {|
   user: string,

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
+import {ParticipantsRow} from '../../common'
 import {SelectedEntry, DropdownEntry, DropdownText} from './dropdown'
 import Search from './search'
 import type {Account} from '.'
@@ -18,7 +19,7 @@ const ToKeybaseUser = (props: ToKeybaseUserProps) => {
   if (props.recipientUsername) {
     // A username has been set, so display their name and avatar.
     return (
-      <React.Fragment>
+      <ParticipantsRow heading="To" headingAlignment="Right">
         <Kb.ConnectedNameWithIcon
           colorFollowing={true}
           horizontal={true}
@@ -33,7 +34,7 @@ const ToKeybaseUser = (props: ToKeybaseUserProps) => {
           color={Styles.globalColors.black_20}
           onClick={props.onRemoveProfile}
         />
-      </React.Fragment>
+      </ParticipantsRow>
     )
   }
 
@@ -55,35 +56,42 @@ type ToStellarPublicKeyProps = {|
 |}
 
 const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => (
-  <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
-    <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputInner}>
-      <Kb.Icon
-        type={
-          props.recipientPublicKey.length === 0 || props.errorMessage
-            ? 'icon-stellar-logo-grey-16'
-            : 'icon-stellar-logo-16'
-        }
-        style={Kb.iconCastPlatformStyles(styles.stellarIcon)}
-      />
-      <Kb.NewInput
-        type="text"
-        onChangeText={props.onChangeRecipient}
-        textType="BodySemibold"
-        placeholder={'Stellar address'}
-        placeholderColor={Styles.globalColors.black_20}
-        hideBorder={true}
-        containerStyle={styles.input}
-        multiline={true}
-        rowsMin={2}
-        rowsMax={3}
-      />
+  <ParticipantsRow
+    heading="To"
+    headingAlignment="Right"
+    headingStyle={{alignSelf: 'flex-start'}}
+    dividerColor={props.errorMessage ? Styles.globalColors.red : ''}
+  >
+    <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
+      <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputInner}>
+        <Kb.Icon
+          type={
+            props.recipientPublicKey.length === 0 || props.errorMessage
+              ? 'icon-stellar-logo-grey-16'
+              : 'icon-stellar-logo-16'
+          }
+          style={Kb.iconCastPlatformStyles(styles.stellarIcon)}
+        />
+        <Kb.NewInput
+          type="text"
+          onChangeText={props.onChangeRecipient}
+          textType="BodySemibold"
+          placeholder={'Stellar address'}
+          placeholderColor={Styles.globalColors.black_20}
+          hideBorder={true}
+          containerStyle={styles.input}
+          multiline={true}
+          rowsMin={2}
+          rowsMax={3}
+        />
+      </Kb.Box2>
+      {!!props.errorMessage && (
+        <Kb.Text type="BodySmall" style={styles.errorText}>
+          {props.errorMessage}
+        </Kb.Text>
+      )}
     </Kb.Box2>
-    {!!props.errorMessage && (
-      <Kb.Text type="BodySmall" style={styles.errorText}>
-        {props.errorMessage}
-      </Kb.Text>
-    )}
-  </Kb.Box2>
+  </ParticipantsRow>
 )
 
 type ToOtherAccountProps = {|
@@ -142,17 +150,19 @@ class ToOtherAccount extends React.Component<ToOtherAccountProps> {
     }
 
     return (
-      <Kb.Dropdown
-        onChanged={this.onAccountDropdownChange}
-        items={items}
-        selected={
-          this.props.toAccount ? (
-            <SelectedEntry account={this.props.toAccount} user={this.props.user} />
-          ) : (
-            <DropdownText key="placeholder-select" text="Pick another account" />
-          )
-        }
-      />
+      <ParticipantsRow heading="To" headingAlignment="Left">
+        <Kb.Dropdown
+          onChanged={this.onAccountDropdownChange}
+          items={items}
+          selected={
+            this.props.toAccount ? (
+              <SelectedEntry account={this.props.toAccount} user={this.props.user} />
+            ) : (
+              <DropdownText key="placeholder-select" text="Pick another account" />
+            )
+          }
+        />
+      </ParticipantsRow>
     )
   }
 }

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
-import {ParticipantsRow} from '../../common'
 import {SelectedEntry, DropdownEntry, DropdownText} from './dropdown'
 import Search from './search'
 import type {Account} from '.'
@@ -15,7 +14,7 @@ type ToFieldProps = {|
   // Used to display a keybase profile. We need the recipients' name and callbacks to show the tracker and remove profiles.
   recipientUsername?: string,
   recipientFullName?: string,
-  onShowProfile?: string => void,
+  onShowProfile: string => void,
   onShowSuggestions: () => void,
   onRemoveProfile?: () => void,
   // Used for sending to a stellar address.
@@ -62,13 +61,11 @@ class ToField extends React.Component<ToFieldProps> {
   }, 1e3)
 
   render() {
-    let component
-
     // There are a few different ways the participants form can look:
     // Case 1: A user has been set, so we display their name and avatar
     // We can only get this case when the recipient is a searched user, not another account.
     if (this.props.recipientUsername && this.props.recipientType === 'keybaseUser') {
-      component = (
+      return (
         <React.Fragment>
           <Kb.ConnectedNameWithIcon
             colorFollowing={true}
@@ -89,7 +86,7 @@ class ToField extends React.Component<ToFieldProps> {
     } else if (this.props.recipientType === 'otherAccount') {
       if (this.props.accounts.length <= 1 && this.props.onCreateNewAccount) {
         // Case #2: A user is sending to another account, but has no other accounts. Show a "create new account" button
-        component = (
+        return (
           <Kb.Box2 direction="horizontal" centerChildren={true} style={{width: 270}}>
             <Kb.Button
               type="Wallet"
@@ -99,37 +96,37 @@ class ToField extends React.Component<ToFieldProps> {
             />
           </Kb.Box2>
         )
-      } else {
-        // Case #3: A user is sending from an account to another account with other accounts. Show a dropdown list of other accounts, in addition to the link existing and create new actions.
-        let items = [
-          <DropdownText key="link-existing" text="Link an existing Stellar account" />,
-          <DropdownText key="create-new" text="Create a new account" />,
-        ]
-
-        if (this.props.accounts.length > 0) {
-          const walletItems = this.props.accounts.map(account => (
-            <DropdownEntry key={account.id} account={account} user={this.props.user} />
-          ))
-          items = walletItems.concat(items)
-        }
-
-        component = (
-          <Kb.Dropdown
-            onChanged={this.onDropdownChange}
-            items={items}
-            selected={
-              this.props.toAccount ? (
-                <SelectedEntry account={this.props.toAccount} user={this.props.user} />
-              ) : (
-                <DropdownText key="placeholder-select" text="Pick another account" />
-              )
-            }
-          />
-        )
       }
+
+      // Case #3: A user is sending from an account to another account with other accounts. Show a dropdown list of other accounts, in addition to the link existing and create new actions.
+      let items = [
+        <DropdownText key="link-existing" text="Link an existing Stellar account" />,
+        <DropdownText key="create-new" text="Create a new account" />,
+      ]
+
+      if (this.props.accounts.length > 0) {
+        const walletItems = this.props.accounts.map(account => (
+          <DropdownEntry key={account.id} account={account} user={this.props.user} />
+        ))
+        items = walletItems.concat(items)
+      }
+
+      return (
+        <Kb.Dropdown
+          onChanged={this.onDropdownChange}
+          items={items}
+          selected={
+            this.props.toAccount ? (
+              <SelectedEntry account={this.props.toAccount} user={this.props.user} />
+            ) : (
+              <DropdownText key="placeholder-select" text="Pick another account" />
+            )
+          }
+        />
+      )
     } else if (this.props.recipientType === 'stellarPublicKey') {
       // Case #4: A user is sending to a stellar address that is either not associated to a keybase user or not complete. Show input for a stellar address.
-      component = (
+      return (
         <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
           <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputInner}>
             <Kb.Icon
@@ -160,35 +157,16 @@ class ToField extends React.Component<ToFieldProps> {
           )}
         </Kb.Box2>
       )
-    } else if (this.props.onShowProfile) {
-      // Case #5: A user is sending to a keybase user but has not selected a keybase user yet. Show search input for keybase users.
-      return (
-        <Search
-          onClickResult={this.onSelectRecipient}
-          onClose={() => {}}
-          onShowSuggestions={this.props.onShowSuggestions}
-          onShowTracker={this.props.onShowProfile}
-        />
-      )
     }
 
+    // Case #5: A user is sending to a keybase user but has not selected a keybase user yet. Show search input for keybase users.
     return (
-      <ParticipantsRow
-        heading="To"
-        headingAlignment={this.props.recipientType === 'otherAccount' ? 'Right' : 'Left'}
-        headingStyle={
-          this.props.recipientType === 'stellarPublicKey' && !this.props.recipientUsername
-            ? {alignSelf: 'flex-start'}
-            : {}
-        }
-        dividerColor={
-          this.props.incorrect && this.props.recipientType === 'stellarPublicKey'
-            ? Styles.globalColors.red
-            : ''
-        }
-      >
-        {component}
-      </ParticipantsRow>
+      <Search
+        onClickResult={this.onSelectRecipient}
+        onClose={() => {}}
+        onShowSuggestions={this.props.onShowSuggestions}
+        onShowTracker={this.props.onShowProfile}
+      />
     )
   }
 }

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -16,7 +16,7 @@ type ToFieldProps = {|
   recipientFullName?: string,
   onShowProfile: string => void,
   onShowSuggestions: () => void,
-  onRemoveProfile?: () => void,
+  onRemoveProfile: () => void,
   // Used for sending to a stellar address.
   incorrect?: string,
   toFieldInput: string,
@@ -25,8 +25,8 @@ type ToFieldProps = {|
   user: string,
   accounts: Account[],
   toAccount?: Account,
-  onLinkAccount?: () => void,
-  onCreateNewAccount?: () => void,
+  onLinkAccount: () => void,
+  onCreateNewAccount: () => void,
 |}
 
 class ToField extends React.Component<ToFieldProps> {
@@ -46,9 +46,9 @@ class ToField extends React.Component<ToFieldProps> {
     if (React.isValidElement(node)) {
       // $FlowIssue React.isValidElement refinement doesn't happen, see https://github.com/facebook/flow/issues/6392
       const element = (node: React.Element<any>)
-      if (element.key === 'create-new' && this.props.onCreateNewAccount) {
+      if (element.key === 'create-new') {
         this.props.onCreateNewAccount()
-      } else if (element.key === 'link-existing' && this.props.onLinkAccount) {
+      } else if (element.key === 'link-existing') {
         this.props.onLinkAccount()
       } else {
         this.onSelectRecipient(element.props.account)
@@ -84,7 +84,7 @@ class ToField extends React.Component<ToFieldProps> {
         </React.Fragment>
       )
     } else if (this.props.recipientType === 'otherAccount') {
-      if (this.props.accounts.length <= 1 && this.props.onCreateNewAccount) {
+      if (this.props.accounts.length <= 1) {
         // Case #2: A user is sending to another account, but has no other accounts. Show a "create new account" button
         return (
           <Kb.Box2 direction="horizontal" centerChildren={true} style={{width: 270}}>


### PR DESCRIPTION
We were not trusting the passed-in user until the service replies, so we were
popping up the search component and removing it.

Also refactor the participants component to be three separate components instead of
one component with three different flows.